### PR TITLE
Use ORC JIT for better compile time and runtime performance

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,6 +29,7 @@ for exceptions.
 
 Julia includes code from the following projects, which have their own licenses:
 - [LDC](https://github.com/ldc-developers/ldc/blob/master/LICENSE) (for ccall/cfunction ABI definitions) [BSD-3]. The portion of code that Julia uses from LDC is [BSD-3] licensed.
+- [LLVM](http://llvm.org/releases/3.3/LICENSE.TXT) (for parts of src/jitlayers.cpp and src/disasm.cpp) [BSD-3, effectively]
 - [MUSL](http://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) (for getopt implementations on Windows) [MIT]
 - [NetBSD](http://www.netbsd.org/about/redistribution.html) (for setjmp, longjmp, and strptime implementations on Windows) [BSD-3]
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -213,7 +213,7 @@ uncompressed_ast(l::LambdaStaticData) =
 # Printing code representations in IR and assembly
 function _dump_function(f, t::ANY, native, wrapper, strip_ir_metadata, dump_module)
     t = to_tuple_type(t)
-    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Any, Bool), f, t, wrapper)
+    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Any, Bool, Bool), f, t, wrapper, native)
 
     if llvmf == C_NULL
         error("no method found for the specified argument types")

--- a/contrib/add_license_to_files.jl
+++ b/contrib/add_license_to_files.jl
@@ -43,6 +43,7 @@ const skipfiles = [
     "../src/abi_x86.cpp",
     "../src/abi_x86_64.cpp",
     "../src/disasm.cpp",
+    "../src/jitlayers.cpp",
     "../src/support/END.h",
     "../src/support/ENTRY.amd64.h",
     "../src/support/ENTRY.i387.h",

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,7 +115,7 @@ $(BUILDDIR)/julia_flisp.boot: $(addprefix $(SRCDIR)/,jlfrontend.scm \
 
 # additional dependency links
 $(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc $(SRCDIR)/flisp/*.h
-$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp intrinsics.h cgutils.cpp ccall.cpp abi_*.cpp)
+$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp intrinsics.h cgutils.cpp ccall.cpp jitlayers.cpp abi_*.cpp)
 $(BUILDDIR)/anticodegen.o $(BUILDDIR)/anticodegen.dbg.obj: $(SRCDIR)/intrinsics.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc-debug.c

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -321,9 +321,9 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams,
     li->tfunc = jl_nothing;
     li->fptr = &jl_trampoline;
     li->roots = NULL;
-    li->functionObject = NULL;
-    li->specFunctionObject = NULL;
-    li->cFunctionList = NULL;
+    li->functionObjects.functionObject = NULL;
+    li->functionObjects.specFunctionObject = NULL;
+    li->functionObjects.cFunctionList = NULL;
     li->functionID = 0;
     li->specFunctionID = 0;
     li->specTypes = NULL;
@@ -353,8 +353,8 @@ jl_lambda_info_t *jl_copy_lambda_info(jl_lambda_info_t *linfo)
     new_linfo->file = linfo->file;
     new_linfo->line = linfo->line;
     new_linfo->fptr = linfo->fptr;
-    new_linfo->functionObject = linfo->functionObject;
-    new_linfo->specFunctionObject = linfo->specFunctionObject;
+    new_linfo->functionObjects.functionObject = linfo->functionObjects.functionObject;
+    new_linfo->functionObjects.specFunctionObject = linfo->functionObjects.specFunctionObject;
     new_linfo->functionID = linfo->functionID;
     new_linfo->specFunctionID = linfo->specFunctionID;
     return new_linfo;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1015,7 +1015,7 @@ void jl_trampoline_compile_linfo(jl_lambda_info_t *linfo, int always_infer)
             }
         }
     }
-    jl_compile_linfo(linfo);
+    jl_compile_linfo(linfo, NULL);
     if (jl_boot_file_loaded && jl_is_expr(linfo->ast)) {
         linfo->ast = jl_compress_ast(linfo, linfo->ast);
         jl_gc_wb(linfo, linfo->ast);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -4,10 +4,15 @@
 // --- the ccall, cglobal, and llvm intrinsics ---
 
 // keep track of llvmcall declarations
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+static std::map<u_int64_t,llvm::GlobalValue*> llvmcallDecls;
+#else
 static std::set<u_int64_t> llvmcallDecls;
+#endif
 
 static std::map<std::string, GlobalVariable*> libMapGV;
 static std::map<std::string, GlobalVariable*> symMapGV;
+
 static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib, const char *f_name, jl_codectx_t *ctx)
 {
     // in pseudo-code, this function emits the following:
@@ -39,7 +44,7 @@ static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib, cons
         runtime_lib = true;
         libptrgv = libMapGV[f_lib];
         if (libptrgv == NULL) {
-            libptrgv = new GlobalVariable(*jl_Module, T_pint8,
+            libptrgv = new GlobalVariable(imaging_mode ? *shadow_module : *active_module, T_pint8,
                false, GlobalVariable::PrivateLinkage,
                ConstantPointerNull::get((PointerType*)T_pint8), f_lib);
             libMapGV[f_lib] = libptrgv;
@@ -69,7 +74,7 @@ static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib, cons
         // the symbol of the actual function.
         std::string name = f_name;
         name = "ccall_" + name;
-        llvmgv = new GlobalVariable(*jl_Module, T_pvoidfunc,
+        llvmgv = new GlobalVariable(imaging_mode ? *shadow_module : *active_module, T_pvoidfunc,
            false, GlobalVariable::PrivateLinkage,
            initnul, name);
         symMapGV[f_name] = llvmgv;
@@ -84,19 +89,20 @@ static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib, cons
                *ccall_bb = BasicBlock::Create(jl_LLVMContext, "ccall");
     builder.CreateCondBr(builder.CreateICmpNE(builder.CreateLoad(llvmgv), initnul), ccall_bb, dlsym_lookup);
 
+    assert(ctx->f->getParent() != NULL);
     ctx->f->getBasicBlockList().push_back(dlsym_lookup);
     builder.SetInsertPoint(dlsym_lookup);
     Value *libname;
     if (runtime_lib) {
-        libname = builder.CreateGlobalStringPtr(f_lib);
+        libname = CreateGlobalStringPtr(&builder,f_lib, "f_lib");
     }
     else {
         libname = literal_static_pointer_val(f_lib, T_pint8);
     }
 #ifdef LLVM37
-    Value *llvmf = builder.CreateCall(prepare_call(jldlsym_func), { libname, builder.CreateGlobalStringPtr(f_name), libptrgv });
+    Value *llvmf = builder.CreateCall(prepare_call(jldlsym_func), { libname, CreateGlobalStringPtr(&builder, f_name, "f_name"), libptrgv });
 #else
-    Value *llvmf = builder.CreateCall3(prepare_call(jldlsym_func), libname, builder.CreateGlobalStringPtr(f_name), libptrgv);
+    Value *llvmf = builder.CreateCall3(prepare_call(jldlsym_func), libname, CreateGlobalStringPtr(&builder, f_name, "f_name"), libptrgv);
 #endif
     builder.CreateStore(llvmf, llvmgv);
     builder.CreateBr(ccall_bb);
@@ -274,7 +280,8 @@ static Value *julia_to_native(Type *to, bool toboxed, jl_value_t *jlto, const jl
                     *needStackRestore = true;
                 }
                 ai->setAlignment(16);
-                builder.CreateMemCpy(ai, builder.CreateBitCast(jvinfo.V, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
+                prepare_call(
+                    builder.CreateMemCpy(ai, builder.CreateBitCast(jvinfo.V, T_pint8), nbytes, sizeof(void*))->getCalledValue()); // minimum gc-alignment in julia is pointer size
                 return builder.CreateBitCast(ai, to);
             }
         }
@@ -301,7 +308,7 @@ static Value *julia_to_native(Type *to, bool toboxed, jl_value_t *jlto, const jl
                     false));
         AllocaInst *ai = builder.CreateAlloca(T_int8, nbytes);
         ai->setAlignment(16);
-        builder.CreateMemCpy(ai, jvinfo.V, nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
+        prepare_call(builder.CreateMemCpy(ai, jvinfo.V, nbytes, sizeof(void*))->getCalledValue()); // minimum gc-alignment in julia is pointer size
         Value *p2 = builder.CreatePointerCast(ai, to);
         builder.CreateBr(afterBB);
         builder.SetInsertPoint(afterBB);
@@ -319,7 +326,7 @@ static Value *julia_to_native(Type *to, bool toboxed, jl_value_t *jlto, const jl
     if (!jvinfo.ispointer)
         builder.CreateStore(emit_unbox(to, jvinfo, ety), slot);
     else
-        builder.CreateMemCpy(slot, jvinfo.V, (uint64_t)jl_datatype_size(ety), (uint64_t)((jl_datatype_t*)ety)->alignment);
+        prepare_call(builder.CreateMemCpy(slot, jvinfo.V, (uint64_t)jl_datatype_size(ety), (uint64_t)((jl_datatype_t*)ety)->alignment)->getCalledValue());
     return slot;
 }
 
@@ -594,7 +601,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             std::stringstream name;
             name << (ctx->f->getName().str()) << "u" << i++;
             ir_name = name.str();
-            if (jl_Module->getFunction(ir_name) == NULL)
+            if (builtins_module->getFunction(ir_name) == NULL)
                 break;
         }
 
@@ -611,6 +618,9 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         std::string rstring;
         llvm::raw_string_ostream rtypename(rstring);
         rettype->print(rtypename);
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+        std::map<u_int64_t,std::string> localDecls;
+#endif
 
         if (decl != NULL) {
             std::stringstream declarations(jl_string_data(decl));
@@ -619,8 +629,15 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             std::string declstr;
             while (std::getline(declarations, declstr, '\n')) {
                 u_int64_t declhash = memhash(declstr.c_str(), declstr.length());
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+                auto it = llvmcallDecls.find(declhash);
+                if (it != llvmcallDecls.end()) {
+                    prepare_call(it->second);
+                } else {
+#else
                 if (llvmcallDecls.count(declhash) == 0) {
-                    // Findi  name of declaration by searching for '@'
+#endif
+                    // Find name of declaration by searching for '@'
                     std::string::size_type atpos = declstr.find('@') + 1;
                     // Find end of declaration by searching for '('
                     std::string::size_type bracepos = declstr.find('(');
@@ -632,7 +649,11 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
                         ir_stream << "; Declarations\n" << declstr << "\n";
                     }
 
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+                    localDecls[declhash] = declname;
+#else
                     llvmcallDecls.insert(declhash);
+#endif
                 }
             }
         }
@@ -643,9 +664,9 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         std::string ir_string = ir_stream.str();
 #ifdef LLVM36
         Module *m = NULL;
-        bool failed = parseAssemblyInto(llvm::MemoryBufferRef(ir_string,"llvmcall"),*jl_Module,Err);
+        bool failed = parseAssemblyInto(llvm::MemoryBufferRef(ir_string,"llvmcall"),*builtins_module,Err);
         if (!failed)
-            m = jl_Module;
+            m = builtins_module;
 #else
         Module *m = ParseAssemblyString(ir_string.c_str(),jl_Module,Err,jl_LLVMContext);
 #endif
@@ -656,6 +677,11 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             jl_error(stream.str().c_str());
         }
         f = m->getFunction(ir_name);
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+        for (auto it : localDecls) {
+            llvmcallDecls[it.first] = cast<GlobalValue>(prepare_call(m->getNamedValue(it.second)));
+        }
+#endif
     }
     else {
         assert(isPtr);
@@ -668,8 +694,8 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             assert(*it == f->getFunctionType()->getParamType(i));
 
 #ifdef USE_MCJIT
-        if (f->getParent() != jl_Module) {
-            FunctionMover mover(jl_Module,f->getParent());
+        if (f->getParent() != active_module) {
+            FunctionMover mover(active_module,f->getParent());
             f = mover.CloneFunction(f);
         }
 #endif
@@ -697,7 +723,6 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
     f->setLinkage(GlobalValue::LinkOnceODRLinkage);
 
     // the actual call
-    assert(f->getParent() == jl_Module); // no prepare_call(f) is needed below, since this was just emitted into the same module
     CallInst *inst = builder.CreateCall(f, ArrayRef<Value*>(&argvals[0], nargt));
     ctx->to_inline.push_back(inst);
 
@@ -1309,8 +1334,8 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     }
 
     if (needStackRestore) {
-        stacksave = CallInst::Create(Intrinsic::getDeclaration(jl_Module,
-                                                               Intrinsic::stacksave));
+        stacksave = CallInst::Create(prepare_call(Intrinsic::getDeclaration(builtins_module,
+                                                               Intrinsic::stacksave)));
         if (savespot) {
 #ifdef LLVM38
                 instList.insertAfter(savespot->getIterator(), (Instruction*)stacksave);
@@ -1337,8 +1362,9 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         result = ret;
     if (needStackRestore) {
         assert(stacksave != NULL);
-        builder.CreateCall(Intrinsic::getDeclaration(jl_Module,
-                                                     Intrinsic::stackrestore),
+        builder.CreateCall(prepare_call(
+            Intrinsic::getDeclaration(builtins_module,
+                                                     Intrinsic::stackrestore)),
                            stacksave);
     }
     ctx->gc.argDepth = last_depth;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1,5 +1,7 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
+#include <iostream>
+
 // utility procedures used in code generation
 
 template<class T> // for GlobalObject's
@@ -27,47 +29,181 @@ static Instruction *tbaa_decorate(MDNode* md, Instruction* load_or_store)
     return load_or_store;
 }
 
+static GlobalVariable *CreateGlobalString(StringRef Str,
+                                                  const Twine &Name,
+                                                  unsigned AddressSpace) {
+    Constant *StrConstant = ConstantDataArray::getString(jl_LLVMContext, Str);
+    GlobalVariable *GV = new GlobalVariable(*active_module, StrConstant->getType(),
+                                          true, GlobalValue::PrivateLinkage,
+                                          StrConstant, Name, NULL,
+                                          GlobalVariable::NotThreadLocal,
+                                          AddressSpace);
+    GV->setUnnamedAddr(true);
+    return GV;
+}
+
+/// \brief Same as CreateGlobalString, but return a pointer with "i8*" type
+/// instead of a pointer to array of i8.
+static Value *CreateGlobalStringPtr(llvm::IRBuilder<> *Builder, StringRef Str, const Twine &Name = "",
+                           unsigned AddressSpace = 0) {
+    GlobalVariable *gv = CreateGlobalString(Str, Name, AddressSpace);
+    Value *zero = ConstantInt::get(Type::getInt32Ty(jl_LLVMContext), 0);
+    Value *Args[] = { zero, zero };
+#ifdef LLVM37
+    return Builder->CreateInBoundsGEP(gv->getValueType(), gv, Args, Name);
+#else
+    return Builder->CreateInBoundsGEP(gv, Args, Name);
+#endif
+}
+
+
 // Fixing up references to other modules for MCJIT
+std::set<llvm::GlobalValue*> pending_globals;
 static GlobalVariable *prepare_global(GlobalVariable *G)
 {
-#ifdef USE_MCJIT
-    if (G->getParent() != jl_Module) {
-        GlobalVariable *gv = jl_Module->getGlobalVariable(G->getName());
-        if (!gv) {
-            gv = new GlobalVariable(*jl_Module, G->getType()->getElementType(),
-                                    G->isConstant(), GlobalVariable::ExternalLinkage,
-                                    NULL, G->getName(), NULL, G->getThreadLocalMode());
-        }
-        return gv;
-    }
-#endif
+    pending_globals.insert(G);
     return G;
 }
 
 static llvm::Value *prepare_call(llvm::Value* Callee)
 {
-#ifdef USE_MCJIT
     llvm::Function *F = dyn_cast<Function>(Callee);
     if (!F)
         return Callee;
-    if (F->getParent() != jl_Module) {
-        Function *ModuleF = jl_Module->getFunction(F->getName());
-        if (ModuleF) {
-            return ModuleF;
-        }
-        else {
-            Function *func = Function::Create(F->getFunctionType(),
-                                              Function::ExternalLinkage,
-                                              F->getName(),
-                                              jl_Module);
-            func->setAttributes(AttributeSet());
-            func->copyAttributesFrom(F);
-            return func;
-        }
-    }
-#endif
+    pending_globals.insert(F);
     return Callee;
 }
+
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+static GlobalValue *realize_pending_global(Instruction *User, GlobalValue *G, std::map<llvm::Module*,llvm::GlobalValue*> &FixedGlobals)
+{
+    Function *UsedInHere = User->getParent()->getParent();
+    assert(UsedInHere);
+    Module *M = UsedInHere->getParent();
+    if (M == G->getParent() && M != builtins_module) { // can happen during bootstrap
+        //std::cout << "Skipping " << std::string(G->getName()) << " due to parentage" << std::endl;
+        return nullptr;
+    }
+    // If we come across a function that is still being constructed,
+    // this use needs to remain pending
+    if (!M || M == builtins_module) {
+        pending_globals.insert(G);
+        //std::cout << "Skipping " << std::string(G->getName()) << " due to construction" << std::endl;
+        return nullptr;
+    }
+    if (!FixedGlobals.count(M)) {
+        if (GlobalVariable *GV = dyn_cast<GlobalVariable>(G)) {
+            GlobalVariable *NewGV = M->getGlobalVariable(GV->getName());
+            if (!NewGV) {
+                NewGV = new GlobalVariable(*M, GV->getType()->getElementType(),
+                                        GV->isConstant(), GlobalVariable::ExternalLinkage,
+                                        NULL, GV->getName(), NULL, GV->getThreadLocalMode());
+                // Move over initializer
+                if (GV->hasInitializer()) {
+                    NewGV->setInitializer(GV->getInitializer());
+                    GV->setInitializer(nullptr);
+                }
+            }
+            FixedGlobals[M] = NewGV;
+        } else {
+            Function *F = cast<Function>(G);
+            //std::cout << "Realizing " << std::string(F->getName()) << std::endl;
+            //if (!F->getParent()) {
+                //std::cout << "Skipping" << std::endl;
+            //    return nullptr;
+            //}
+            Function *NewF = nullptr;
+            if (!F->isDeclaration() && F->getParent() == builtins_module) {
+                // It's a definition. Actually move the function and create a
+                // declaration in the original module
+                NewF = F;
+                F->removeFromParent();
+                M->getFunctionList().push_back(F);
+                Function::Create(F->getFunctionType(),
+                    Function::ExternalLinkage,
+                    F->getName(),
+                    active_module);
+            } else {
+                assert(F);
+                NewF = M->getFunction(F->getName());
+                if (!NewF) {
+                    NewF = Function::Create(F->getFunctionType(),
+                                Function::ExternalLinkage,
+                                F->getName(),
+                                M);
+                }
+            }
+            FixedGlobals[M] = NewF;
+        }
+    }
+    return FixedGlobals[M];
+}
+
+struct ExprChain {
+    ConstantExpr *Expr;
+    unsigned OpNo;
+    struct ExprChain *Next;
+};
+
+static bool handleUse(Use &Use1,llvm::GlobalValue *G,std::map<llvm::Module*,llvm::GlobalValue*> &FixedGlobals,struct ExprChain *Chain, struct ExprChain *ChainEnd)
+{
+    Instruction *User = dyn_cast<Instruction>(Use1.getUser());
+    if (!User) {
+        ConstantExpr *Expr = dyn_cast<ConstantExpr>(Use1.getUser());
+        assert(Expr);
+        Value::use_iterator UI2 = Expr->use_begin(), E2 = Expr->use_end();
+        for (; UI2 != E2;) {
+            Use &Use2 = *UI2;
+             ++UI2;
+             struct ExprChain NextChain;
+             NextChain.Expr = Expr;
+             NextChain.OpNo = Use1.getOperandNo();
+             NextChain.Next = nullptr;
+             if (ChainEnd)
+                ChainEnd->Next = &NextChain;
+             handleUse(Use2,G,FixedGlobals,Chain ? Chain : &NextChain,&NextChain);
+        }
+        return true;
+    }
+    llvm::Constant *Replacement = realize_pending_global(User,G,FixedGlobals);
+    if (!Replacement)
+        return false;
+    while (Chain) {
+        Replacement = Chain->Expr->getWithOperandReplaced(Chain->OpNo,Replacement);
+        Chain = Chain->Next;
+    }
+    Use1.set(Replacement);
+    return true;
+}
+
+// RAUW, but only for those users which live in a module, and create a module
+// specific copy
+static void realize_pending_globals()
+{
+    std::set<llvm::GlobalValue *> local_pending_globals;
+    std::swap(local_pending_globals,pending_globals);
+    for (auto *G : local_pending_globals) {
+        std::map<llvm::Module*,llvm::GlobalValue*> FixedGlobals;
+        Value::use_iterator UI = G->use_begin(), E = G->use_end();
+        for (; UI != E;)
+            if (!handleUse(*(UI++),G,FixedGlobals,nullptr,nullptr))
+                continue;
+    }
+}
+
+static void realize_cycle(jl_cyclectx_t *cyclectx)
+{
+    // These need to be resolved together
+    for (auto *F : cyclectx->functions) {
+        F->removeFromParent();
+        active_module->getFunctionList().push_back(F);
+    }
+    for (auto *CU : cyclectx->CUs) {
+        NamedMDNode *NMD = active_module->getOrInsertNamedMetadata("llvm.dbg.cu");
+        NMD->addOperand(CU);
+    }
+}
+#endif
 
 #ifdef LLVM35
 static inline void add_named_global(GlobalObject *gv, void *addr, bool dllimport = true)
@@ -122,6 +258,19 @@ extern "C" {
     extern int jl_in_inference;
 }
 
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+static GlobalVariable *global_proto(GlobalVariable *G) {
+    GlobalVariable *proto = new GlobalVariable(G->getType()->getElementType(),
+            G->isConstant(), GlobalVariable::ExternalLinkage,
+            NULL, G->getName(), G->getThreadLocalMode());
+    return proto;
+}
+#else
+static GlobalVariable *global_proto(GlobalVariable *G) {
+    return G;
+}
+#endif
+
 static GlobalVariable *stringConst(const std::string &txt)
 {
     GlobalVariable *gv = stringConstants[txt];
@@ -135,7 +284,7 @@ static GlobalVariable *stringConst(const std::string &txt)
         ssno << strno;
         vname += "_j_str";
         vname += ssno.str();
-        gv = new GlobalVariable(*jl_Module,
+        gv = new GlobalVariable(*active_module,
                                 ArrayType::get(T_int8, txt.length()+1),
                                 true,
                                 imaging_mode ? GlobalVariable::PrivateLinkage : GlobalVariable::ExternalLinkage,
@@ -145,8 +294,11 @@ static GlobalVariable *stringConst(const std::string &txt)
                                                        txt.length()+1)),
                                 vname);
         gv->setUnnamedAddr(true);
+        gv = imaging_mode ? gv : prepare_global(global_proto(gv));
         stringConstants[txt] = gv;
         strno++;
+    } else {
+        prepare_global(gv);
     }
     return gv;
 
@@ -162,7 +314,44 @@ JL_DLLEXPORT std::map<Value *, void*> jl_llvm_to_jl_value;
 // because this is queried in the hot path
 static std::map<Function *, uint64_t> emitted_function_symtab;
 
-#ifdef USE_MCJIT
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+static Function *function_proto(Function *F) {
+    Function *NewF = Function::Create(F->getFunctionType(),
+                            Function::ExternalLinkage,
+                            F->getName());
+    NewF->setAttributes(AttributeSet());
+
+    // FunctionType does not include any attributes. Copy them over manually
+    // as codegen may make decisions based on the presence of certain attributes
+    NewF->copyAttributesFrom(F);
+
+#ifdef LLVM37
+    // Declarations are not allowed to have personality routines, but
+    // copyAttributesFrom sets them anyway, so clear them again manually
+    NewF->setPersonalityFn(nullptr);
+#endif
+
+    AttributeSet OldAttrs = F->getAttributes();
+    // Clone any argument attributes that are present in the VMap.
+    auto ArgI = NewF->arg_begin();
+    for (const Argument &OldArg : F->args()) {
+        AttributeSet attrs =
+            OldAttrs.getParamAttributes(OldArg.getArgNo() + 1);
+        if (attrs.getNumSlots() > 0)
+            ArgI->addAttr(attrs);
+        ++ArgI;
+    }
+
+    NewF->setAttributes(
+      NewF->getAttributes()
+          .addAttributes(NewF->getContext(), AttributeSet::ReturnIndex,
+                         OldAttrs.getRetAttributes())
+          .addAttributes(NewF->getContext(), AttributeSet::FunctionIndex,
+                         OldAttrs.getFnAttributes()));
+
+    return NewF;
+}
+
 class FunctionMover : public ValueMaterializer
 {
 public:
@@ -179,6 +368,7 @@ public:
 
     Function *CloneFunctionProto(Function *F)
     {
+        assert(!F->isDeclaration());
         Function *NewF = Function::Create(F->getFunctionType(),
                                           Function::ExternalLinkage,
                                           F->getName(),
@@ -227,46 +417,19 @@ public:
 
     Value *InjectFunctionProto(Function *F)
     {
-	//return destModule->getOrInsertFunction(F->getName(), F->getFunctionType());
         Function *NewF = destModule->getFunction(F->getName());
         if (!NewF) {
-            NewF = Function::Create(F->getFunctionType(),
-                                          Function::ExternalLinkage,
-                                          F->getName(),destModule);
-            NewF->setAttributes(AttributeSet());
-
-            // FunctionType does not include any attributes. Copy them over manually
-            // as codegen may make decisions based on the presence of certain attributes
-            NewF->copyAttributesFrom(F);
-
-            #ifdef LLVM37
-            // Declarations are not allowed to have personality routines, but
-            // copyAttributesFrom sets them anyway, so clear them again manually
-            NewF->setPersonalityFn(nullptr);
-            #endif
-
-            AttributeSet OldAttrs = F->getAttributes();
-            // Clone any argument attributes that are present in the VMap.
-            auto ArgI = NewF->arg_begin();
-            for (const Argument &OldArg : F->args()) {
-                AttributeSet attrs =
-                    OldAttrs.getParamAttributes(OldArg.getArgNo() + 1);
-                if (attrs.getNumSlots() > 0)
-                    ArgI->addAttr(attrs);
-                ++ArgI;
-            }
-
-            NewF->setAttributes(
-              NewF->getAttributes()
-                  .addAttributes(NewF->getContext(), AttributeSet::ReturnIndex,
-                                 OldAttrs.getRetAttributes())
-                  .addAttributes(NewF->getContext(), AttributeSet::FunctionIndex,
-                                 OldAttrs.getFnAttributes()));
+            NewF = function_proto(F);
+            destModule->getFunctionList().push_back(NewF);
         }
-	return NewF;
+        return NewF;
     }
 
+#ifdef LLVM38
+    virtual Value *materializeDeclFor(Value *V)
+#else
     virtual Value *materializeValueFor (Value *V)
+#endif
     {
         Function *F = dyn_cast<Function>(V);
         if (F) {
@@ -296,7 +459,7 @@ public:
                     if (jl_ExecutionEngine->FindFunctionNamed(F->getName().data()))
                         return InjectFunctionProto(F);
 
-                    return CloneFunctionProto(F);
+                    return CloneFunctionProto(shadow);
                 }
                 else if (!F->isDeclaration()) {
                     return CloneFunctionProto(F);
@@ -345,6 +508,10 @@ public:
         return NULL;
     };
 };
+#else
+static Function *function_proto(Function *F) {
+    return F;
+}
 #endif
 
 #ifdef LLVM37
@@ -513,6 +680,12 @@ static void jl_gen_llvm_globaldata(llvm::Module *mod, ValueToValueMapTy &VMap, c
 
 static void jl_dump_shadow(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len, bool dump_as_bc)
 {
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+    realize_pending_globals();
+#endif
+    //shadow_module->dump();
+    verifyModule(*shadow_module);
+
 #ifdef LLVM36
     std::error_code err;
     StringRef fname_ref = StringRef(fname);
@@ -633,12 +806,12 @@ static Value *julia_gv(const char *cname, void *addr)
     // first see if there already is a GlobalVariable for this address
     it = jl_value_to_llvm.find(addr);
     if (it != jl_value_to_llvm.end())
-        return builder.CreateLoad(it->second.gv);
+        return builder.CreateLoad(prepare_global((llvm::GlobalVariable*)it->second.gv));
 
     std::stringstream gvname;
     gvname << cname << globalUnique++;
     // no existing GlobalVariable, create one and store it
-    GlobalVariable *gv = new GlobalVariable(*jl_Module, T_pjlvalue,
+    GlobalVariable *gv = new GlobalVariable(imaging_mode ? *shadow_module : *builtins_module, T_pjlvalue,
                            false, imaging_mode ? GlobalVariable::InternalLinkage : GlobalVariable::ExternalLinkage,
                            ConstantPointerNull::get((PointerType*)T_pjlvalue), gvname.str());
     addComdat(gv);
@@ -653,7 +826,7 @@ static Value *julia_gv(const char *cname, void *addr)
     // make the pointer valid for future sessions
     jl_sysimg_gvars.push_back(ConstantExpr::getBitCast(gv, T_psize));
     jl_value_llvm gv_struct;
-    gv_struct.gv = gv;
+    gv_struct.gv = prepare_global(gv);
     gv_struct.index = jl_sysimg_gvars.size();
     jl_value_to_llvm[addr] = gv_struct;
     return builder.CreateLoad(gv);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -177,148 +177,19 @@ static IRBuilder<> builder(getGlobalContext());
 static bool nested_compile = false;
 static TargetMachine *jl_TargetMachine;
 
-#ifdef USE_ORCJIT
-template <typename T>
-static std::vector<T> singletonSet(T t) {
-  std::vector<T> Vec;
-  Vec.push_back(std::move(t));
-  return Vec;
+extern JITEventListener* CreateJuliaJITEventListener();
+
+namespace llvm {
+    extern Pass *createLowerSimdLoopPass();
+    extern bool annotateSimdLoop( BasicBlock* latch );
 }
 
-class JuliaOJIT {
-public:
-    typedef orc::ObjectLinkingLayer<> ObjLayerT;
-    typedef orc::IRCompileLayer<ObjLayerT> CompileLayerT;
-    typedef CompileLayerT::ModuleSetHandleT ModuleHandleT;
-    typedef StringMap<void*> GlobalSymbolTableT;
+// for image reloading
+static bool imaging_mode = false;
 
-    JuliaOJIT(TargetMachine &TM)
-      : TM(TM),
-        DL(TM.createDataLayout()),
-        CompileLayer(ObjectLayer, JITCompiler(*this)) {
-            // Make sure SectionMemoryManager::getSymbolAddressInProcess can resolve
-            // symbols in the program as well. The nullptr argument to the function
-            // tells DynamicLibrary to load the program, not a library.
-            std::string *ErrorStr = nullptr;
-            if (sys::DynamicLibrary::LoadLibraryPermanently(nullptr, ErrorStr))
-                report_fatal_error("FATAL: unable to dlopen self\n" + *ErrorStr);
-        }
+#include "jitlayers.cpp"
 
-    std::string mangle(const std::string &Name) {
-        std::string MangledName;
-        {
-            raw_string_ostream MangledNameStream(MangledName);
-            Mangler::getNameWithPrefix(MangledNameStream, Name, DL);
-        }
-        return MangledName;
-    }
-
-    void addGlobalMapping(StringRef Name, void *Addr) {
-       GlobalSymbolTable[mangle(Name)] = Addr;
-    }
-
-    ModuleHandleT addModule(Module *M) {
-        // We need a memory manager to allocate memory and resolve symbols for this
-        // new module. Create one that resolves symbols by looking back into the
-        // JIT.
-        auto Resolver = orc::createLambdaResolver(
-                          [&](const std::string &Name) {
-                            // TODO: consider moving the FunctionMover resolver here
-                            // Step 0: ObjectLinkingLayer has checked whether it is in the current module
-                            // Step 1: Check against list of known external globals
-                            GlobalSymbolTableT::const_iterator pos = GlobalSymbolTable.find(Name);
-                            if (pos != GlobalSymbolTable.end())
-                                return RuntimeDyld::SymbolInfo((intptr_t)pos->second, JITSymbolFlags::Exported);
-                            // Step 2: Search all previously emitted symbols
-                            if (auto Sym = findSymbol(Name))
-                              return RuntimeDyld::SymbolInfo(Sym.getAddress(),
-                                                             Sym.getFlags());
-                            // Step 2: Search the program symbols
-                            if (uint64_t addr = SectionMemoryManager::getSymbolAddressInProcess(Name))
-                                return RuntimeDyld::SymbolInfo(addr, JITSymbolFlags::Exported);
-                            // Return failure code
-                            return RuntimeDyld::SymbolInfo(nullptr);
-                          },
-                          [](const std::string &S) { return nullptr; }
-                        );
-        return CompileLayer.addModuleSet(singletonSet(std::move(M)),
-                                         &MemMgr,
-                                         std::move(Resolver));
-    }
-
-    void removeModule(ModuleHandleT H) { CompileLayer.removeModuleSet(H); }
-
-    orc::JITSymbol findSymbol(const std::string &Name) {
-        return CompileLayer.findSymbol(Name, true);
-    }
-
-    orc::JITSymbol findUnmangledSymbol(const std::string Name) {
-        return findSymbol(mangle(Name));
-    }
-
-    uint64_t getGlobalValueAddress(const std::string &Name) {
-        return CompileLayer.findSymbol(mangle(Name), false).getAddress();
-    }
-
-    uint64_t getFunctionAddress(const std::string &Name) {
-        return CompileLayer.findSymbol(mangle(Name), false).getAddress();
-    }
-
-    uint64_t FindFunctionNamed(const std::string &Name) {
-        return 0; // Functions are not kept around
-    }
-
-    void RegisterJITEventListener(JITEventListener *L) {
-        // TODO
-    }
-
-    const DataLayout& getDataLayout() const {
-        return DL;
-    }
-
-    const Triple& getTargetTriple() const {
-        return TM.getTargetTriple();
-    }
-
-private:
-    TargetMachine &TM;
-    const DataLayout DL;
-    SectionMemoryManager MemMgr;
-    ObjLayerT ObjectLayer;
-    CompileLayerT CompileLayer;
-    GlobalSymbolTableT GlobalSymbolTable;
-
-    /// Simple compile functor: Takes a single IR module and returns an ObjectFile.
-    class JITCompiler {
-    public:
-        /// Construct a simple compile functor with the given target.
-        JITCompiler(JuliaOJIT &JIT) : JIT(JIT) { }
-
-        /// Compile a Module to an ObjectFile.
-        object::OwningBinary<object::ObjectFile> operator()(Module &M) const {
-            MCContext *Ctx;
-            SmallVector<char, 0> ObjBufferSV;
-            raw_svector_ostream ObjStream(ObjBufferSV);
-            legacy::PassManager PM;
-            if (JIT.TM.addPassesToEmitMC(PM, Ctx, ObjStream))
-                llvm_unreachable("Target does not support MC emission.");
-            PM.run(M);
-            ObjStream.flush();
-            std::unique_ptr<MemoryBuffer> ObjBuffer(
-                new ObjectMemoryBuffer(std::move(ObjBufferSV)));
-            ErrorOr<std::unique_ptr<object::ObjectFile>> Obj =
-                object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef());
-            // TODO: Actually report errors helpfully.
-            typedef object::OwningBinary<object::ObjectFile> OwningObj;
-            if (Obj)
-                return OwningObj(std::move(*Obj), std::move(ObjBuffer));
-            return OwningObj(nullptr, nullptr);
-        }
-
-    private:
-        JuliaOJIT &JIT;
-    };
-};
+#ifdef USE_ORCJIT
 JL_DLLEXPORT JuliaOJIT *jl_ExecutionEngine;
 #else
 JL_DLLEXPORT ExecutionEngine *jl_ExecutionEngine;
@@ -326,11 +197,15 @@ JL_DLLEXPORT ExecutionEngine *jl_ExecutionEngine;
 
 #ifdef USE_MCJIT
 static Module *shadow_module;
+static Module *builtins_module;
+static Module *active_module;
 static RTDyldMemoryManager *jl_mcjmm;
 #define jl_Module (builder.GetInsertBlock()->getParent()->getParent())
 #else
 static Module *jl_Module;
 #define shadow_module jl_Module
+#define active_module jl_Module
+#define builtins_module jl_Module
 #endif
 static MDBuilder *mbuilder;
 static std::map<int, std::string> argNumberStrings;
@@ -347,9 +222,6 @@ static DataLayoutPass *jl_data_layout;
 #else
 static DataLayout *jl_data_layout;
 #endif
-
-// for image reloading
-static bool imaging_mode = false;
 
 // types
 static Type *T_jlvalue;
@@ -402,11 +274,6 @@ static MDNode* tbaa_sveclen;           // The len in a jl_svec_t
 static MDNode* tbaa_func;           // A jl_function_t
 static MDNode* tbaa_datatype;       // A jl_datatype_t
 static MDNode* tbaa_const;          // Memory that is immutable by the time LLVM can see it
-
-namespace llvm {
-    extern Pass *createLowerSimdLoopPass();
-    extern bool annotateSimdLoop( BasicBlock* latch );
-}
 
 // Basic DITypes
 #ifdef LLVM37
@@ -488,6 +355,8 @@ static Function *jlboundserrorv_func;
 static Function *jlcheckassign_func;
 static Function *jldeclareconst_func;
 static Function *jlgetbindingorerror_func;
+static Function *jlpref_func;
+static Function *jlpset_func;
 static Function *jltopeval_func;
 static Function *jlcopyast_func;
 static Function *jltuple_func;
@@ -677,6 +546,13 @@ struct jl_gcinfo_t {
     BasicBlock::iterator last_gcframe_inst;
 };
 
+// Keeps tracks of all functions and compile units created during this cycle
+// to be able to atomically add them to a module.
+typedef struct {
+    std::vector<Function *> functions;
+    std::vector<DICompileUnit *> CUs;
+} jl_cyclectx_t;
+
 // information about the context of a piece of code: its enclosing
 // function and module, and visible local variables and labels.
 typedef struct {
@@ -708,6 +584,8 @@ typedef struct {
     llvm::DIBuilder *dbuilder;
     bool debug_enabled;
     std::vector<CallInst*> to_inline;
+
+    jl_cyclectx_t *cyclectx;
 } jl_codectx_t;
 
 typedef struct {
@@ -891,6 +769,7 @@ static void alloc_local(jl_sym_t *s, jl_codectx_t *ctx)
     assert(vi.value.isboxed == false);
 #ifdef LLVM36
     if (ctx->debug_enabled) {
+        prepare_call(Intrinsic::getDeclaration(builtins_module, Intrinsic::dbg_declare));
 #ifdef LLVM37
         ctx->dbuilder->insertDeclare(lv, vi.dinfo, ctx->dbuilder->createExpression(),
                 builder.getCurrentDebugLocation().get(), builder.GetInsertBlock());
@@ -937,10 +816,11 @@ void jl_dump_compiles(void *s)
 
 // --- entry point ---
 //static int n_emit=0;
-static Function *emit_function(jl_lambda_info_t *lam);
+static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declarations,
+    jl_llvm_functions_t *definitions, jl_cyclectx_t *cyclectx);
 static void jl_finalize_module(Module *m);
 //static int n_compile=0;
-static Function *to_function(jl_lambda_info_t *li)
+static Function *to_function(jl_lambda_info_t *li, jl_cyclectx_t *cyclectx)
 {
     JL_LOCK(codegen);
     JL_SIGATOMIC_BEGIN();
@@ -954,13 +834,31 @@ static Function *to_function(jl_lambda_info_t *li)
     jl_gc_inhibit_finalizers(nested_compile);
     Function *f = NULL;
     JL_TRY {
-        f = emit_function(li);
+        jl_llvm_functions_t definitions;
+        #if defined(USE_MCJIT) || defined(USE_ORCJIT)
+        jl_cyclectx_t *newcyclectx = cyclectx;
+        if (!newcyclectx)
+            newcyclectx = new jl_cyclectx_t;
+        emit_function(li, &li->functionObjects, &definitions, newcyclectx);
+        // If we're the root of the cycle, realize all functions
+        if (!cyclectx) {
+            realize_cycle(newcyclectx);
+            delete newcyclectx;
+        }
+        #else
+        emit_function(li, &li->functionObjects, &definitions, NULL);
+        #endif
+        f = (llvm::Function*)(definitions.specFunctionObject ?
+            definitions.specFunctionObject : definitions.functionObject);
+        li->functionID = jl_assign_functionID((llvm::Function*)definitions.functionObject);
+        if (definitions.specFunctionObject)
+            li->specFunctionID = jl_assign_functionID((llvm::Function*)definitions.specFunctionObject);
         //n_emit++;
     }
     JL_CATCH {
-        li->functionObject = NULL;
-        li->specFunctionObject = NULL;
-        li->cFunctionList = NULL;
+        li->functionObjects.functionObject = NULL;
+        li->functionObjects.specFunctionObject = NULL;
+        li->functionObjects.cFunctionList = NULL;
         nested_compile = last_n_c;
         if (old != NULL) {
             builder.SetInsertPoint(old);
@@ -971,35 +869,10 @@ static Function *to_function(jl_lambda_info_t *li)
         jl_rethrow_with_add("error compiling %s", jl_symbol_name(li->name));
     }
     assert(f != NULL);
-#ifdef JL_DEBUG_BUILD
-#ifdef LLVM35
-    llvm::raw_fd_ostream out(1,false);
+#if defined(USE_MCJIT) || defined(ORCJIT)
+    if (imaging_mode)
 #endif
-    if (
-#ifdef LLVM35
-        verifyFunction(*f,&out)
-#else
-        verifyFunction(*f,PrintMessageAction)
-#endif
-        ) {
-        f->dump();
-        abort();
-    }
-#endif
-    FPM->run(*f);
-    if (!imaging_mode) {
-        jl_finalize_module(f->getParent());
-    }
-    //n_compile++;
-    // print out the function's LLVM code
-    // jl_static_show(JL_STDERR, (jl_value_t*)li);
-    // jl_printf(JL_STDERR, "%s:%d\n",
-    //           jl_symbol_name((jl_sym_t*)li->file), li->line);
-    //f->dump();
-    //if (verifyFunction(*f,PrintMessageAction)) {
-    //    f->dump();
-    //    abort();
-    //}
+        FPM->run(*f);
     if (old != NULL) {
         builder.SetInsertPoint(old);
         builder.SetCurrentDebugLocation(olddl);
@@ -1061,12 +934,80 @@ static void jl_finalize_module(Module *m)
 #endif
 }
 
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+static void writeRecoveryFile(llvm::Module *mod)
+{
+    std::error_code err;
+    mod->dump();
+    std::cout << "Julia emitted a broken LLVM module (about to be __jl_dump.bc)."
+              << "Please file a bug report.\n"
+              << "If the module writing below fails,"
+              << "please include the textual representation printed above this error.";
+    StringRef fname_ref = StringRef("__jl_dump.bc");
+    raw_fd_ostream OS(fname_ref, err, sys::fs::F_None);
+    WriteBitcodeToFile(mod,OS);
+    OS.flush();
+    abort();
+}
+
+static uint64_t getAddressForOrCompileFunction(llvm::Function *llvmf)
+{
+    #ifdef JL_DEBUG_BUILD
+    llvm::raw_fd_ostream out(1,false);
+    #endif
+    uint64_t addr = jl_mcjmm->getSymbolAddress(llvmf->getName());
+    if (addr)
+        return addr;
+    Function *ActiveF = active_module->getFunction(llvmf->getName());
+    // Must have been in a prior module. Safe to ask the execution engine
+    // to emit it.
+    if (!ActiveF || ActiveF->isDeclaration())
+        return jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
+    if (!imaging_mode) {
+        realize_pending_globals();
+        #ifndef USE_ORCJIT
+        #ifdef JL_DEBUG_BUILD
+        Module *backup = llvm::CloneModule(active_module);
+        if(verifyModule(*active_module))
+            writeRecoveryFile(backup);
+        #endif
+        for (auto &F : active_module->functions()) {
+            if (F.isDeclaration())
+                continue;
+            #ifdef JL_DEBUG_BUILD
+            if(verifyFunction(F))
+                writeRecoveryFile(backup);
+            #endif
+            FPM->run(F);
+            #ifdef JL_DEBUG_BUILD
+            if(verifyFunction(F))
+                writeRecoveryFile(backup);
+            #endif
+        }
+        #ifdef JL_DEBUG_BUILD
+        if(verifyModule(*active_module))
+            writeRecoveryFile(backup);
+        delete backup;
+        #endif
+        #endif
+        jl_finalize_module(active_module);
+    }
+    addr = jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
+    assert(addr != 0);
+    if (!imaging_mode) {
+        active_module = new Module("julia", jl_LLVMContext);
+        jl_setup_module(active_module);
+    }
+    return addr;
+}
+#endif
+
 extern "C" void jl_generate_fptr(jl_function_t *f)
 {
     JL_LOCK(codegen);
     // objective: assign li->fptr
     jl_lambda_info_t *li = f->linfo;
-    assert(li->functionObject);
+    assert(li->functionObjects.functionObject);
     if (li->fptr == &jl_trampoline) {
         JL_SIGATOMIC_BEGIN();
         #ifdef USE_MCJIT
@@ -1075,38 +1016,37 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
             Module *m = new Module("julia", jl_LLVMContext);
             jl_setup_module(m);
             FunctionMover mover(m, shadow_module);
-            li->functionObject = mover.CloneFunction((Function*)li->functionObject);
-            if (li->specFunctionObject != NULL)
-                li->specFunctionObject = mover.CloneFunction((Function*)li->specFunctionObject);
-            if (li->cFunctionList != NULL) {
+            mover.CloneFunction((Function*)li->functionObjects.functionObject);
+            if (li->functionObjects.specFunctionObject != NULL)
+                mover.CloneFunction((Function*)li->functionObjects.specFunctionObject);
+            if (li->functionObjects.cFunctionList != NULL) {
                 size_t i;
-                cFunctionList_t *list = (cFunctionList_t*)li->cFunctionList;
+                cFunctionList_t *list = (cFunctionList_t*)li->functionObjects.cFunctionList;
                 for (i = 0; i < list->len; i++) {
                     list->data()[i].f = mover.CloneFunction(list->data()[i].f);
                 }
             }
             jl_finalize_module(m);
+            li->fptr = (jl_fptr_t)jl_ExecutionEngine->getFunctionAddress(((Function*)li->functionObjects.functionObject)->getName());
+        } else {
+            li->fptr = (jl_fptr_t)getAddressForOrCompileFunction((Function*)li->functionObjects.functionObject);
         }
+        #else
+        li->fptr = (jl_fptr_t)jl_ExecutionEngine->getPointerToFunction((Function*)li->functionObjects.functionObject);
         #endif
 
-        Function *llvmf = (Function*)li->functionObject;
-#ifdef USE_MCJIT
-        li->fptr = (jl_fptr_t)(intptr_t)jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
-#else
-        li->fptr = (jl_fptr_t)jl_ExecutionEngine->getPointerToFunction(llvmf);
-#endif
         assert(li->fptr != NULL);
 #ifndef KEEP_BODIES
         if (!imaging_mode)
-            llvmf->deleteBody();
+            ((Function*)li->functionObjects.functionObject)->deleteBody();
 #endif
 
-        if (li->cFunctionList != NULL) {
+        if (li->functionObjects.cFunctionList != NULL) {
             size_t i;
-            cFunctionList_t *list = (cFunctionList_t*)li->cFunctionList;
+            cFunctionList_t *list = (cFunctionList_t*)li->functionObjects.cFunctionList;
             for (i = 0; i < list->len; i++) {
 #ifdef USE_MCJIT
-                (void)jl_ExecutionEngine->getFunctionAddress(list->data()[i].f->getName());
+                (void)getAddressForOrCompileFunction(list->data()[i].f);
 #else
                 (void)jl_ExecutionEngine->getPointerToFunction(list->data()[i].f);
 #endif
@@ -1118,15 +1058,18 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
             }
         }
 
-        if (li->specFunctionObject != NULL) {
+        if (li->functionObjects.specFunctionObject != NULL) {
 #ifdef USE_MCJIT
-            (void)jl_ExecutionEngine->getFunctionAddress(((Function*)li->specFunctionObject)->getName());
+            if (imaging_mode)
+              (void)jl_ExecutionEngine->getFunctionAddress(((Function*)li->functionObjects.specFunctionObject)->getName());
+            else
+              (void)getAddressForOrCompileFunction((Function*)li->functionObjects.specFunctionObject);
 #else
-            (void)jl_ExecutionEngine->getPointerToFunction((Function*)li->specFunctionObject);
+            (void)jl_ExecutionEngine->getPointerToFunction((Function*)li->functionObjects.specFunctionObject);
 #endif
 #ifndef KEEP_BODIES
             if (!imaging_mode)
-                ((Function*)li->specFunctionObject)->deleteBody();
+                ((Function*)li->functionObjects.specFunctionObject)->deleteBody();
 #endif
         }
         JL_SIGATOMIC_END();
@@ -1135,12 +1078,12 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
     JL_UNLOCK(codegen);
 }
 
-extern "C" void jl_compile_linfo(jl_lambda_info_t *li)
+extern "C" void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx)
 {
-    if (li->functionObject == NULL) {
+    if (li->functionObjects.functionObject == NULL) {
         // objective: assign li->functionObject
         li->inCompile = 1;
-        (void)to_function(li);
+        (void)to_function(li, (jl_cyclectx_t *)cyclectx);
         li->inCompile = 0;
     }
 }
@@ -1196,7 +1139,7 @@ static Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tuplet
         }
     }
 
-    jl_function_t *ff = jl_get_specialization(f, (jl_tupletype_t*)sigt);
+    jl_function_t *ff = jl_get_specialization(f, (jl_tupletype_t*)sigt, NULL);
     if (ff != NULL && ff->env==(jl_value_t*)jl_emptysvec && ff->linfo != NULL) {
         jl_lambda_info_t *li = ff->linfo;
         if (!jl_types_equal((jl_value_t*)li->specTypes, sigt)) {
@@ -1238,7 +1181,7 @@ void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt)
     JL_GC_POP();
 
 #ifdef USE_MCJIT
-    if (uint64_t addr = jl_ExecutionEngine->getFunctionAddress(llvmf->getName()))
+    if (uint64_t addr = getAddressForOrCompileFunction(llvmf))
         return (void*)(intptr_t)addr;
     if (llvmf->getParent() == shadow_module) {
         // Copy the function out of the shadow module
@@ -1250,7 +1193,7 @@ void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt)
     }
 #endif
 #ifdef USE_MCJIT
-    return (void*)(intptr_t)jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
+    return (void*)getAddressForOrCompileFunction(llvmf);
 #else
     return jl_ExecutionEngine->getPointerToFunction(llvmf);
 #endif
@@ -1287,7 +1230,6 @@ void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name)
 }
 
 // --- native code info, and dump function to IR and ASM ---
-extern JITEventListener* CreateJuliaJITEventListener();
 
 extern int jl_get_llvmf_info(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
 #ifdef USE_MCJIT
@@ -1300,7 +1242,7 @@ extern int jl_get_llvmf_info(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
 
 // Get pointer to llvm::Function instance, compiling if necessary
 extern "C" JL_DLLEXPORT
-void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper)
+void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper, bool getdeclarations)
 {
     if (!jl_is_function(f)) {
         return NULL;
@@ -1309,7 +1251,7 @@ void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper)
     JL_GC_PUSH1(&linfo);
     if (jl_is_gf(f)) {
         if (tt != NULL) {
-            jl_function_t *sf = jl_get_specialization(f, tt);
+            jl_function_t *sf = jl_get_specialization(f, tt, NULL);
             linfo = (sf == NULL ? NULL : sf->linfo);
             if (linfo == NULL) {
                 sf = jl_method_lookup_by_type(jl_gf_mtable(f), tt, 0, 0);
@@ -1345,30 +1287,85 @@ void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper)
         return NULL;
     }
 
-    if (linfo->specFunctionObject != NULL) {
-        // found in the system image: force a recompile
-        Function *llvmf = (Function*)linfo->specFunctionObject;
-        if (llvmf->isDeclaration()) {
-            linfo->specFunctionObject = NULL;
-            linfo->functionObject = NULL;
-        }
+#if defined(USE_ORCJIT) || defined(USE_MCJIT)
+    if (linfo->functionObjects.functionObject == NULL && linfo->functionObjects.specFunctionObject == NULL) {
+        jl_compile_linfo(linfo, NULL);
     }
-    if (linfo->functionObject != NULL) {
-        // found in the system image: force a recompile
-        Function *llvmf = (Function*)linfo->functionObject;
-        if (llvmf->isDeclaration()) {
-            linfo->specFunctionObject = NULL;
-            linfo->functionObject = NULL;
-        }
+    if (getdeclarations) {
+        if (getwrapper || linfo->functionObjects.specFunctionObject == NULL)
+            return linfo->functionObjects.functionObject;
+        else
+            return linfo->functionObjects.specFunctionObject;
     }
-    if (linfo->functionObject == NULL && linfo->specFunctionObject == NULL) {
-        jl_compile_linfo(linfo);
+
+    Function *llvmDecl = nullptr;
+    if (!getwrapper && linfo->functionObjects.specFunctionObject != NULL)
+        llvmDecl = (Function*)linfo->functionObjects.specFunctionObject;
+    else
+        llvmDecl = (Function*)linfo->functionObjects.functionObject;
+
+    Function *llvmf = active_module->getFunction(llvmDecl->getName());
+    // Not in active module anymore, recompile
+    // Now that in either case, we need to run the FPM manually,
+    // since this is now usually done as part of object emission
+    if (!llvmf) {
+        Function *other;
+        jl_llvm_functions_t declarations;
+        emit_function(linfo, nullptr, &declarations, nullptr);
+        if (getwrapper || !declarations.specFunctionObject) {
+            llvmf = (llvm::Function*)declarations.functionObject;
+            other = (llvm::Function*)declarations.specFunctionObject;
+        } else {
+            llvmf = (llvm::Function*)declarations.specFunctionObject;
+            other = (llvm::Function*)declarations.functionObject;
+        }
+        if (other)
+            other->eraseFromParent();
+        FPM->run(*llvmf);
+        llvmf->removeFromParent();
+    } else {
+        ValueToValueMapTy VMap;
+        llvmf = CloneFunction(llvmf,VMap,false);
+        active_module->getFunctionList().push_back(llvmf);
+        FPM->run(*llvmf);
+        llvmf->removeFromParent();
     }
     JL_GC_POP();
-    if (!getwrapper && linfo->specFunctionObject != NULL)
-        return (Function*)linfo->specFunctionObject;
+    return llvmf;
+#else
+    if (linfo->functionObjects.specFunctionObject != NULL) {
+        // found in the system image: force a recompile
+        Function *llvmf = (Function*)linfo->functionObjects.specFunctionObject;
+        if (llvmf->isDeclaration()) {
+            linfo->functionObjects.specFunctionObject = NULL;
+            linfo->functionObjects.functionObject = NULL;
+        }
+    }
+    if (linfo->functionObjects.functionObject != NULL) {
+        // found in the system image: force a recompile
+        Function *llvmf = (Function*)linfo->functionObjects.functionObject;
+        if (llvmf->isDeclaration()) {
+            linfo->functionObjects.specFunctionObject = NULL;
+            linfo->functionObjects.functionObject = NULL;
+        }
+    }
+    if (linfo->functionObjects.functionObject == NULL &&
+        linfo->functionObjects.specFunctionObject == NULL) {
+        jl_compile_linfo(linfo, NULL);
+    }
+    JL_GC_POP();
+    Function *llvmf;
+    if (!getwrapper && linfo->functionObjects.specFunctionObject != NULL)
+        llvmf = (Function*)linfo->functionObjects.specFunctionObject;
     else
-        return (Function*)linfo->functionObject;
+        llvmf = (Function*)linfo->functionObjects.functionObject;
+    if (getdeclarations)
+      return llvmf;
+    else {
+      ValueToValueMapTy VMap;
+      return CloneFunction(llvmf,VMap,false);
+    }
+#endif
 }
 
 Function* CloneFunctionToModule(Function *F, Module *destModule)
@@ -1406,10 +1403,13 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata, bool dump
         llvmf->print(stream);
     }
     else {
-        // make a copy of the function with all module metadata
+        if (llvmf->getParent())
+            jl_error("jl_dump_function_ir requires a parentless clone");
+        // Put the function in a module
         Module *m = new Module(llvmf->getName(), jl_LLVMContext);
         jl_setup_module(m);
-        Function *f2 = CloneFunctionToModule(llvmf, m);
+        m->getFunctionList().push_back(llvmf);
+        Function *f2 = llvmf;
         if (strip_ir_metadata) {
             // strip metadata from the copy
             Function::BasicBlockListType::iterator f2_bb = f2->getBasicBlockList().begin();
@@ -1441,6 +1441,7 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata, bool dump
         else
             f2->print(stream);
         f2->eraseFromParent();
+        m->dropAllReferences();
         delete m;
     }
 
@@ -1478,7 +1479,7 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
     // Dump assembly code
     uint64_t symsize, slide;
 #ifdef USE_MCJIT
-    uint64_t fptr = jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
+    uint64_t fptr = getAddressForOrCompileFunction(llvmf);
     const object::ObjectFile *object;
 #else
     uint64_t fptr = (uintptr_t)jl_ExecutionEngine->getPointerToFunction(llvmf);
@@ -2414,10 +2415,10 @@ static bool emit_known_call(jl_cgval_t *ret, jl_value_t *ff,
                 jl_static_show(JL_STDOUT, (jl_value_t*)aty);
                 jl_printf(JL_STDOUT, "\n");
 #endif
-                f = jl_get_specialization(f, (jl_tupletype_t*)rt1);
+                f = jl_get_specialization(f, (jl_tupletype_t*)rt1, (void*)ctx->cyclectx);
                 if (f != NULL) {
-                    assert(f->linfo->functionObject != NULL);
-                    *theFptr = (Value*)f->linfo->functionObject;
+                    assert(f->linfo->functionObjects.functionObject != NULL);
+                    *theFptr = (Value*)f->linfo->functionObjects.functionObject;
                     *theF = f;
                 }
             }
@@ -2976,12 +2977,16 @@ static jl_cgval_t emit_call_function_object(jl_function_t *f, Value *theF, Value
                                         jl_value_t **args, size_t nargs,
                                         jl_codectx_t *ctx)
 {
-    if (f!=NULL && specialized && f->linfo!=NULL && f->linfo->specFunctionObject != NULL) {
+    if (f!=NULL && specialized && f->linfo!=NULL && f->linfo->functionObjects.specFunctionObject != NULL) {
         // emit specialized call site
         jl_value_t *jlretty = jl_ast_rettype(f->linfo, f->linfo->ast);
         bool retboxed;
         (void)julia_type_to_llvm(jlretty, &retboxed);
-        Function *cf = (Function*)f->linfo->specFunctionObject;
+        Function *cf = (Function*)f->linfo->functionObjects.specFunctionObject;
+        if (!cf->getParent() || (cf->getParent() == builtins_module &&
+            builtins_module != active_module)) { // Call cycle
+            prepare_call(cf);
+        }
         FunctionType *cft = cf->getFunctionType();
         size_t nfargs = cft->getNumParams();
         Value **argvals = (Value**) alloca(nfargs*sizeof(Value*));
@@ -3117,7 +3122,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
                 // builtin functions don't need the function object passed and are constant
                 std::map<jl_fptr_t,Function*>::iterator it = builtin_func_map.find(f->fptr);
                 if (it != builtin_func_map.end()) {
-                    theFptr = (*it).second;
+                    theFptr = prepare_call((*it).second);
                     theF = V_null;
                 }
             }
@@ -3249,9 +3254,9 @@ static Value *global_binding_pointer(jl_module_t *m, jl_sym_t *s,
             // var not found. switch to delayed lookup.
             Constant *initnul = ConstantPointerNull::get((PointerType*)T_pjlvalue);
             GlobalVariable *bindinggv =
-                new GlobalVariable(*jl_Module, T_pjlvalue,
+                prepare_global(new GlobalVariable(imaging_mode ? *shadow_module : *builtins_module, T_pjlvalue,
                                    false, GlobalVariable::PrivateLinkage,
-                                   initnul, "delayedvar");
+                                   initnul, "delayedvar"));
             Value *cachedval = builder.CreateLoad(bindinggv);
             BasicBlock *have_val = BasicBlock::Create(jl_LLVMContext, "found"),
                 *not_found = BasicBlock::Create(jl_LLVMContext, "notfound");
@@ -3560,7 +3565,6 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
         if (builder.GetInsertBlock()->getTerminator() == NULL) {
             builder.CreateBr(bb); // all BasicBlocks must exit explicitly
         }
-        ctx->f->getBasicBlockList().push_back(bb);
         builder.SetInsertPoint(bb);
         return jl_cgval_t();
     }
@@ -4030,7 +4034,7 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
 static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_tupletype_t *argt, int64_t isref)
 {
     jl_lambda_info_t *lam = ff->linfo;
-    cFunctionList_t *list = (cFunctionList_t*)lam->cFunctionList;
+    cFunctionList_t *list = (cFunctionList_t*)lam->functionObjects.cFunctionList;
     if (list != NULL) {
         size_t i;
         for (i = 0; i < list->len; i++) {
@@ -4069,8 +4073,8 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     if (fargt.size() + sret != fargt_sig.size())
         jl_error("va_arg syntax not allowed for cfunction argument list");
 
-    jl_compile_linfo(lam);
-    if (!lam->functionObject) {
+    jl_compile_linfo(lam, NULL);
+    if (!lam->functionObjects.functionObject) {
         jl_errorf("error compiling %s while creating cfunction",
                   jl_symbol_name(lam->name));
     }
@@ -4086,28 +4090,16 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     nested_compile = true;
     jl_gc_inhibit_finalizers(nested_compile); // no allocations expected between the top of this function (when last scanned lam->cFunctionList) and here, which might have triggered running julia code
 
-    // Create the Function stub
-    Module *m;
-#ifdef USE_MCJIT
-    if (imaging_mode) {
-        m = shadow_module;
-    }
-    else {
-        m = new Module(funcName.str(), jl_LLVMContext);
-        jl_setup_module(m);
-    }
-#else
-    m = jl_Module;
-#endif
-
     Function *cw = Function::Create(FunctionType::get(sret ? T_void : prt, fargt_sig, false),
             imaging_mode ? GlobalVariable::InternalLinkage : GlobalVariable::ExternalLinkage,
-            funcName.str(), m);
+            funcName.str(), builtins_module);
     addComdat(cw);
     cw->setAttributes(attrs);
 #ifdef LLVM37
     cw->addFnAttr("no-frame-pointer-elim", "true");
 #endif
+    Function *cw_proto = function_proto(cw);
+
     BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", cw);
     builder.SetInsertPoint(b0);
     DebugLoc noDbg;
@@ -4126,19 +4118,19 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
         jl_throw(jl_memory_exception);
     list2->len = len;
     list2->data()[len-1].isref = isref;
-    list2->data()[len-1].f = cw;
-    lam->cFunctionList = list2;
+    list2->data()[len-1].f = imaging_mode ? cw : cw_proto;
+    lam->functionObjects.cFunctionList = list2;
 
     // See whether this function is specsig or jlcall
     bool specsig, jlfunc_sret;
     Function *theFptr;
-    if (lam->specFunctionObject != NULL) {
-        theFptr = (Function*)lam->specFunctionObject;
+    if (lam->functionObjects.specFunctionObject != NULL) {
+        theFptr = (Function*)lam->functionObjects.specFunctionObject;
         specsig = true;
         jlfunc_sret = theFptr->hasStructRetAttr();
     }
     else {
-        theFptr = (Function*)lam->functionObject;
+        theFptr = (Function*)lam->functionObjects.functionObject;
         specsig = false;
         jlfunc_sret = false;
     }
@@ -4290,28 +4282,13 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
         builder.CreateRet(r);
     finalize_gc_frame(&ctx);
 
-#ifdef JL_DEBUG_BUILD
-#ifdef LLVM35
-    llvm::raw_fd_ostream out(1,false);
+#if defined(USE_MCJIT) || defined(ORCJIT)
+    if (imaging_mode)
 #endif
-    if (
-#ifdef LLVM35
-        verifyFunction(*cw,&out)
-#else
-        verifyFunction(*cw,PrintMessageAction)
-#endif
-    ) {
-        cw->dump();
-        abort();
-    }
-#endif
+        FPM->run(*cw);
 
-#ifdef USE_MCJIT
-    FPM->run(*cw);
-    if (!imaging_mode) {
-        jl_finalize_module(m);
-    }
-#endif
+    cw->removeFromParent();
+    active_module->getFunctionList().push_back(cw);
 
     // Restore the previous compile context
     if (old != NULL) {
@@ -4322,7 +4299,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     jl_gc_inhibit_finalizers(nested_compile);
     JL_SIGATOMIC_END();
 
-    return cw;
+    return cw_proto;
 }
 
 // generate a julia-callable function that calls f (AKA lam)
@@ -4337,7 +4314,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, jl_expr_t *ast, Funct
         funcName << fname;
 
     Function *w = Function::Create(jl_func_sig, imaging_mode ? GlobalVariable::InternalLinkage : GlobalVariable::ExternalLinkage,
-                                   funcName.str(), f->getParent());
+                                   funcName.str(), builtins_module);
     addComdat(w);
 #ifdef LLVM37
     w->addFnAttr("no-frame-pointer-elim", "true");
@@ -4399,14 +4376,15 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, jl_expr_t *ast, Funct
     builder.CreateRet(boxed(retval, &ctx));
     finalize_gc_frame(&ctx);
 
-    FPM->run(*w);
-
     return w;
 }
 
 // Compile to LLVM IR, using a specialized signature if applicable.
-static Function *emit_function(jl_lambda_info_t *lam)
+static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declarations,
+    jl_llvm_functions_t *definitions, jl_cyclectx_t *cyclectx)
 {
+    assert(definitions && "Capturing definitions is always required");
+
     // step 1. unpack AST and allocate codegen context for this function
     jl_expr_t *ast = (jl_expr_t*)lam->ast;
     jl_svec_t *sparams = NULL;
@@ -4433,6 +4411,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
     ctx.vaName = NULL;
     ctx.vaStack = false;
     ctx.boundsCheck.push_back(true);
+    ctx.cyclectx = cyclectx;
 
     // step 2. process var-info lists to see what vars are captured, need boxing
     jl_value_t *gensym_types = jl_lam_gensyms(ast);
@@ -4552,20 +4531,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
     // try to avoid conflicts in the global symbol table
     funcName << "julia_" << jl_symbol_name(lam->name);
 
-    Module *m;
-#ifdef USE_MCJIT
-    if (imaging_mode) {
-        m = shadow_module;
-    }
-    else {
-        m = new Module(funcName.str(), jl_LLVMContext);
-        jl_setup_module(m);
-    }
-    // clear the list of llvmcall declarations as we'll be using a clean module
-    llvmcallDecls.clear();
-#else
-    m = jl_Module;
-#endif
+    Function *fwrap = NULL;
     funcName << "_" << globalUnique++;
 
     ctx.sret = false;
@@ -4595,33 +4561,33 @@ static Function *emit_function(jl_lambda_info_t *lam)
         }
         f = Function::Create(FunctionType::get(rt, fsig, false),
                              imaging_mode ? GlobalVariable::InternalLinkage : GlobalVariable::ExternalLinkage,
-                             funcName.str(), m);
+                             funcName.str(), builtins_module);
         if (ctx.sret)
             f->addAttribute(1, Attribute::StructRet);
         addComdat(f);
 #ifdef LLVM37
         f->addFnAttr("no-frame-pointer-elim", "true");
 #endif
-        if (lam->specFunctionObject == NULL) {
-            lam->specFunctionObject = (void*)f;
-            lam->specFunctionID = jl_assign_functionID(f);
-        }
-        if (lam->functionObject == NULL) {
-            Function *fwrap = gen_jlcall_wrapper(lam, ast, f, ctx.sret);
-            lam->functionObject = (void*)fwrap;
-            lam->functionID = jl_assign_functionID(fwrap);
+        fwrap = gen_jlcall_wrapper(lam, ast, f, ctx.sret);
+        definitions->specFunctionObject = f;
+        definitions->functionObject = fwrap;
+        if (declarations) {
+            declarations->specFunctionObject = function_proto(f);
+            declarations->functionObject = function_proto(fwrap);
         }
     }
     else {
         f = Function::Create(jl_func_sig, imaging_mode ? GlobalVariable::InternalLinkage : GlobalVariable::ExternalLinkage,
-                             funcName.str(), m);
+                             funcName.str(), builtins_module);
         addComdat(f);
 #ifdef LLVM37
         f->addFnAttr("no-frame-pointer-elim", "true");
 #endif
-        if (lam->functionObject == NULL) {
-            lam->functionObject = (void*)f;
-            lam->functionID = jl_assign_functionID(f);
+        definitions->functionObject = f;
+        definitions->specFunctionObject = NULL;
+        if (declarations) {
+            declarations->functionObject = function_proto(f);
+            declarations->specFunctionObject = NULL;
         }
     }
     if (jlrettype == (jl_value_t*)jl_bottom_type)
@@ -4678,11 +4644,12 @@ static Function *emit_function(jl_lambda_info_t *lam)
     }
     int toplineno = lno;
 
-    DIBuilder dbuilder(*m);
+    DIBuilder dbuilder(*builtins_module);
     ctx.dbuilder = &dbuilder;
 #ifdef LLVM37
     DIFile *topfile = NULL;
     DISubprogram *SP;
+    DICompileUnit *CU;
 #else
     DIFile topfile;
     DISubprogram SP;
@@ -4709,7 +4676,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
         #ifndef LLVM34
         dbuilder.createCompileUnit(0x01, filename, ".", "julia", true, "", 0);
         #elif defined(LLVM37)
-        DICompileUnit *CU = dbuilder.createCompileUnit(0x01, filename, ".", "julia", true, "", 0);
+        CU = dbuilder.createCompileUnit(0x01, filename, ".", "julia", true, "", 0);
         #else
         DICompileUnit CU = dbuilder.createCompileUnit(0x01, filename, ".", "julia", true, "", 0);
         assert(CU.Verify());
@@ -4901,6 +4868,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 addr.push_back(llvm::dwarf::DW_OP_plus);
                 addr.push_back(i * sizeof(void*));
                 addr.push_back(llvm::dwarf::DW_OP_deref);
+                prepare_call(Intrinsic::getDeclaration(builtins_module, Intrinsic::dbg_value));
 #ifdef LLVM37
                 ctx.dbuilder->insertDbgValueIntrinsic(argArray, 0, ctx.vars[s].dinfo,
                 ctx.dbuilder->createExpression(addr),
@@ -5207,7 +5175,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 labels[lname] = prev;
             }
             else {
-                prev = BasicBlock::Create(getGlobalContext(), "L");
+                prev = BasicBlock::Create(getGlobalContext(), "L", f);
                 labels[lname] = prev;
             }
         }
@@ -5366,18 +5334,34 @@ static Function *emit_function(jl_lambda_info_t *lam)
     for(std::vector<CallInst*>::iterator it = ctx.to_inline.begin(); it != ctx.to_inline.end(); ++it) {
         Function *inlinef = (*it)->getCalledFunction();
         InlineFunctionInfo info;
+        // Intrinsics that InlineFunction might create
+        prepare_call(Intrinsic::getDeclaration(builtins_module, Intrinsic::lifetime_start));
+        prepare_call(Intrinsic::getDeclaration(builtins_module, Intrinsic::lifetime_end));
         if (!InlineFunction(*it,info))
             jl_error("Inlining Pass failed");
         inlinef->eraseFromParent();
     }
 
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+    if (cyclectx) {
+        cyclectx->functions.push_back(f);
+        if (fwrap)
+            cyclectx->functions.push_back(fwrap);
+    }
+#endif
+
     // step 18. Perform any delayed instantiations
-    if (ctx.debug_enabled)
+    if (ctx.debug_enabled) {
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+        if(cyclectx)
+            cyclectx->CUs.push_back(CU);
+#endif
         ctx.dbuilder->finalize();
+    }
 
     JL_GC_POP();
 
-    return f;
+    return;
 }
 
 // --- initialization ---
@@ -5453,16 +5437,16 @@ extern "C" void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
             if (sret)
                 f->addAttribute(1, Attribute::StructRet);
 
-        if (lam->specFunctionObject == NULL) {
-            lam->specFunctionObject = (void*)f;
+        if (lam->functionObjects.specFunctionObject == NULL) {
+            lam->functionObjects.specFunctionObject = (void*)f;
             lam->specFunctionID = jl_assign_functionID(f);
             }
             add_named_global(f, (void*)fptr);
         }
         else {
             Function *f = jlcall_func_to_llvm(funcName, fptr, shadow_module);
-            if (lam->functionObject == NULL) {
-                lam->functionObject = (void*)f;
+            if (lam->functionObjects.functionObject == NULL) {
+                lam->functionObjects.functionObject = (void*)f;
                 lam->functionID = jl_assign_functionID(f);
                 assert(lam->fptr == &jl_trampoline);
                 lam->fptr = (jl_fptr_t)fptr;
@@ -5841,6 +5825,15 @@ static void init_julia_llvm_env(Module *m)
                          "jl_get_binding_or_error", m);
     add_named_global(jlgetbindingorerror_func, (void*)&jl_get_binding_or_error);
 
+    jlpref_func = Function::Create(FunctionType::get(T_pjlvalue, two_pvalue_llvmt, false),
+                            Function::ExternalLinkage,
+                            "jl_pointerref", m);
+
+    jlpset_func = Function::Create(FunctionType::get(T_pjlvalue, three_pvalue_llvmt, false),
+                            Function::ExternalLinkage,
+                            "jl_pointerset", m);
+
+
     builtin_func_map[jl_f_is] = jlcall_func_to_llvm("jl_f_is", (void*)&jl_f_is, m);
     builtin_func_map[jl_f_typeof] = jlcall_func_to_llvm("jl_f_typeof", (void*)&jl_f_typeof, m);
     builtin_func_map[jl_f_sizeof] = jlcall_func_to_llvm("jl_f_sizeof", (void*)&jl_f_sizeof, m);
@@ -6120,116 +6113,7 @@ static void init_julia_llvm_env(Module *m)
 #ifndef LLVM37
     FPM->add(jl_data_layout);
 #endif
-
-#ifdef __has_feature
-#   if __has_feature(address_sanitizer)
-#   if defined(LLVM37) && !defined(LLVM38)
-    // LLVM 3.7 BUG: ASAN pass doesn't properly initialize its dependencies
-    initializeTargetLibraryInfoWrapperPassPass(*PassRegistry::getPassRegistry());
-#   endif
-    FPM->add(createAddressSanitizerFunctionPass());
-#   endif
-#   if __has_feature(memory_sanitizer)
-    FPM->add(llvm::createMemorySanitizerPass(true));
-#   endif
-#endif
-#ifdef LLVM37
-    FPM->add(createTargetTransformInfoWrapperPass(jl_TargetMachine->getTargetIRAnalysis()));
-#else
-    jl_TargetMachine->addAnalysisPasses(*FPM);
-#endif
-#ifdef LLVM38
-    FPM->add(createTypeBasedAAWrapperPass());
-#else
-    FPM->add(createTypeBasedAliasAnalysisPass());
-#endif
-    if (jl_options.opt_level>=1) {
-#ifdef LLVM38
-        FPM->add(createBasicAAWrapperPass());
-#else
-        FPM->add(createBasicAliasAnalysisPass());
-#endif
-    }
-    // list of passes from vmkit
-    FPM->add(createCFGSimplificationPass()); // Clean up disgusting code
-    FPM->add(createPromoteMemoryToRegisterPass());// Kill useless allocas
-
-#ifndef INSTCOMBINE_BUG
-    FPM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
-#endif
-    FPM->add(createSROAPass());                 // Break up aggregate allocas
-#ifndef INSTCOMBINE_BUG
-    FPM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
-#endif
-    FPM->add(createJumpThreadingPass());        // Thread jumps.
-    // NOTE: CFG simp passes after this point seem to hurt native codegen.
-    // See issue #6112. Should be re-evaluated when we switch to MCJIT.
-    //FPM->add(createCFGSimplificationPass());    // Merge & remove BBs
-#ifndef INSTCOMBINE_BUG
-    FPM->add(createInstructionCombiningPass()); // Combine silly seq's
-#endif
-
-    //FPM->add(createCFGSimplificationPass());    // Merge & remove BBs
-    FPM->add(createReassociatePass());          // Reassociate expressions
-
-    // this has the potential to make some things a bit slower
-    //FPM->add(createBBVectorizePass());
-
-    FPM->add(createEarlyCSEPass()); //// ****
-
-    FPM->add(createLoopIdiomPass()); //// ****
-    FPM->add(createLoopRotatePass());           // Rotate loops.
-    // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards
-    FPM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
-    FPM->add(createLICMPass());                 // Hoist loop invariants
-    FPM->add(createLoopUnswitchPass());         // Unswitch loops.
-    // Subsequent passes not stripping metadata from terminator
-#ifndef INSTCOMBINE_BUG
-    FPM->add(createInstructionCombiningPass());
-#endif
-    FPM->add(createIndVarSimplifyPass());       // Canonicalize indvars
-    FPM->add(createLoopDeletionPass());         // Delete dead loops
-#if defined(LLVM35)
-    FPM->add(createSimpleLoopUnrollPass());     // Unroll small loops
-#else
-    FPM->add(createLoopUnrollPass());           // Unroll small loops
-#endif
-#if !defined(LLVM35) && !defined(INSTCOMBINE_BUG)
-    FPM->add(createLoopVectorizePass());        // Vectorize loops
-#endif
-    //FPM->add(createLoopStrengthReducePass());   // (jwb added)
-
-#ifndef INSTCOMBINE_BUG
-    FPM->add(createInstructionCombiningPass()); // Clean up after the unroller
-#endif
-    FPM->add(createGVNPass());                  // Remove redundancies
-    //FPM->add(createMemCpyOptPass());            // Remove memcpy / form memset
-    FPM->add(createSCCPPass());                 // Constant prop with SCCP
-
-    // Run instcombine after redundancy elimination to exploit opportunities
-    // opened up by them.
-    FPM->add(createSinkingPass()); ////////////// ****
-    FPM->add(createInstructionSimplifierPass());///////// ****
-#ifndef INSTCOMBINE_BUG
-    FPM->add(createInstructionCombiningPass());
-#endif
-    FPM->add(createJumpThreadingPass());         // Thread jumps
-    FPM->add(createDeadStoreEliminationPass());  // Delete dead stores
-#if !defined(INSTCOMBINE_BUG)
-    if (jl_options.opt_level>=1)
-        FPM->add(createSLPVectorizerPass());     // Vectorize straight-line code
-#endif
-
-    FPM->add(createAggressiveDCEPass());         // Delete dead instructions
-#if !defined(INSTCOMBINE_BUG)
-    if (jl_options.opt_level>=1)
-        FPM->add(createInstructionCombiningPass());   // Clean up after SLP loop vectorizer
-#endif
-#if defined(LLVM35)
-    FPM->add(createLoopVectorizePass());         // Vectorize loops
-    FPM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer
-#endif
-    //FPM->add(createCFGSimplificationPass());     // Merge & remove BBs
+    addOptimizationPasses(FPM);
     FPM->doInitialization();
 }
 
@@ -6311,13 +6195,22 @@ extern "C" void jl_init_codegen(void)
 
 #ifdef USE_MCJIT
     m = shadow_module = new Module("shadow", jl_LLVMContext);
+    builtins_module = new Module("julia_builtins", jl_LLVMContext);
     jl_setup_module(shadow_module);
+    jl_setup_module(builtins_module);
     if (imaging_mode) {
         engine_module = new Module("engine_module", jl_LLVMContext);
         jl_setup_module(engine_module);
+        active_module = shadow_module;
     }
     else {
+        active_module = new Module("julia", jl_LLVMContext);
+        jl_setup_module(active_module);
         engine_module = m;
+#ifdef USE_ORCJIT
+        engine_module = new Module("engine_module", jl_LLVMContext);
+        jl_setup_module(engine_module);
+#endif
     }
 #else
     engine_module = m = jl_Module = new Module("julia", jl_LLVMContext);
@@ -6364,12 +6257,16 @@ extern "C" void jl_init_codegen(void)
         .setMCJITMemoryManager(std::move(std::unique_ptr<RTDyldMemoryManager>{new SectionMemoryManager()}))
 #endif
         .setTargetOptions(options)
-#if defined(_OS_LINUX_) && defined(_CPU_X86_64_)
+#if (defined(_OS_LINUX_) && defined(_CPU_X86_64_)) || defined(CODEGEN_TLS)
         .setRelocationModel(Reloc::PIC_)
 #else
         .setRelocationModel(Reloc::Default)
 #endif
+#ifdef CODEGEN_TLS
+        .setCodeModel(CodeModel::Small)
+#else
         .setCodeModel(CodeModel::JITDefault)
+#endif
 #ifdef DISABLE_OPT
         .setOptLevel(CodeGenOpt::None)
 #else
@@ -6406,6 +6303,7 @@ extern "C" void jl_init_codegen(void)
 
 #if defined(LLVM38)
     engine_module->setDataLayout(jl_TargetMachine->createDataLayout());
+    active_module->setDataLayout(jl_TargetMachine->createDataLayout());
 #elif defined(LLVM36) && !defined(LLVM37)
     engine_module->setDataLayout(jl_TargetMachine->getSubtargetImpl()->getDataLayout());
 #elif defined(LLVM35) && !defined(LLVM37)
@@ -6454,8 +6352,12 @@ extern "C" void jl_init_codegen(void)
 #endif
 #endif
 
-    init_julia_llvm_env(m);
+    if (imaging_mode)
+        init_julia_llvm_env(shadow_module);
+    else
+        init_julia_llvm_env(builtins_module);
 
+#ifndef USE_ORCJIT
     jl_ExecutionEngine->RegisterJITEventListener(CreateJuliaJITEventListener());
 #ifdef JL_USE_INTEL_JITEVENTS
     if (jl_using_intel_jitevents)
@@ -6468,6 +6370,7 @@ extern "C" void jl_init_codegen(void)
         jl_ExecutionEngine->RegisterJITEventListener(
             JITEventListener::createOProfileJITEventListener());
 #endif // JL_USE_OPROFILE_JITEVENTS
+#endif
 
     BOX_F(int8,int8);  UBOX_F(uint8,uint8);
     BOX_F(int16,int16); UBOX_F(uint16,uint16);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5339,7 +5339,12 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
         prepare_call(Intrinsic::getDeclaration(builtins_module, Intrinsic::lifetime_end));
         if (!InlineFunction(*it,info))
             jl_error("Inlining Pass failed");
-        inlinef->eraseFromParent();
+        if (inlinef->getParent())
+            inlinef->eraseFromParent();
+        else {
+            inlinef->dropAllReferences();
+            delete inlinef;
+        }
     }
 
 #if defined(USE_MCJIT) || defined(USE_ORCJIT)

--- a/src/dump.c
+++ b/src/dump.c
@@ -1387,9 +1387,9 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         li->capt = jl_deserialize_value(s, &li->capt);
         if (li->capt) jl_gc_wb(li, li->capt);
         li->fptr = &jl_trampoline;
-        li->functionObject = NULL;
-        li->cFunctionList = NULL;
-        li->specFunctionObject = NULL;
+        li->functionObjects.functionObject = NULL;
+        li->functionObjects.cFunctionList = NULL;
+        li->functionObjects.specFunctionObject = NULL;
         li->inInference = 0;
         li->inCompile = 0;
         li->unspecialized = (jl_function_t*)jl_deserialize_value(s, (jl_value_t**)&li->unspecialized);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1156,7 +1156,7 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, 
 #ifdef LLVM37
       return builder.CreateCall(prepare_call(fmaintr),{ FP(x), FP(y), FP(z) });
 #else
-      return builder.CreateCall3(fmaintr, FP(x), FP(y), FP(z));
+      return builder.CreateCall3(prepare_call(fmaintr), FP(x), FP(y), FP(z));
 #endif
     }
     case muladd_float:

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -190,8 +190,7 @@ private:
       jit_code_entry* JITCodeEntry = new jit_code_entry();
 
       if (!JITCodeEntry) {
-        llvm::report_fatal_error(
-          "Allocation failed when registering a JIT entry!\n");
+        jl_printf(JL_STDERR, "WARNING: Allocation failed when registering a JIT entry!\n");
       } else {
         JITCodeEntry->symfile_addr = Buffer;
         JITCodeEntry->symfile_size = Size;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1,0 +1,396 @@
+// This file is part of Julia.
+// Parts of this file are copied from LLVM, under the UIUC license.
+
+template <class T>
+static void addOptimizationPasses(T *PM)
+{
+#ifdef __has_feature
+#   if __has_feature(address_sanitizer)
+#   if defined(LLVM37) && !defined(LLVM38)
+    // LLVM 3.7 BUG: ASAN pass doesn't properly initialize its dependencies
+    initializeTargetLibraryInfoWrapperPassPass(*PassRegistry::getPassRegistry());
+#   endif
+    FPM->add(createAddressSanitizerFunctionPass());
+#   endif
+#   if __has_feature(memory_sanitizer)
+    FPM->add(llvm::createMemorySanitizerPass(true));
+#   endif
+#endif
+#ifdef LLVM37
+    PM->add(createTargetTransformInfoWrapperPass(jl_TargetMachine->getTargetIRAnalysis()));
+#else
+    jl_TargetMachine->addAnalysisPasses(*PM);
+#endif
+#ifdef LLVM38
+    PM->add(createTypeBasedAAWrapperPass());
+#else
+    PM->add(createTypeBasedAliasAnalysisPass());
+#endif
+    if (jl_options.opt_level>=1) {
+#ifdef LLVM38
+        PM->add(createBasicAAWrapperPass());
+#else
+        PM->add(createBasicAliasAnalysisPass());
+#endif
+    }
+    // list of passes from vmkit
+    PM->add(createCFGSimplificationPass()); // Clean up disgusting code
+    PM->add(createPromoteMemoryToRegisterPass());// Kill useless allocas
+
+#ifndef INSTCOMBINE_BUG
+    PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
+#endif
+    PM->add(createSROAPass());                 // Break up aggregate allocas
+#ifndef INSTCOMBINE_BUG
+    PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
+#endif
+    PM->add(createJumpThreadingPass());        // Thread jumps.
+    // NOTE: CFG simp passes after this point seem to hurt native codegen.
+    // See issue #6112. Should be re-evaluated when we switch to MCJIT.
+    //FPM->add(createCFGSimplificationPass());    // Merge & remove BBs
+#ifndef INSTCOMBINE_BUG
+    PM->add(createInstructionCombiningPass()); // Combine silly seq's
+#endif
+
+    //FPM->add(createCFGSimplificationPass());    // Merge & remove BBs
+    PM->add(createReassociatePass());          // Reassociate expressions
+
+    // this has the potential to make some things a bit slower
+    //FPM->add(createBBVectorizePass());
+
+    PM->add(createEarlyCSEPass()); //// ****
+
+    PM->add(createLoopIdiomPass()); //// ****
+    PM->add(createLoopRotatePass());           // Rotate loops.
+    // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards
+    PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
+    PM->add(createLICMPass());                 // Hoist loop invariants
+    PM->add(createLoopUnswitchPass());         // Unswitch loops.
+    // Subsequent passes not stripping metadata from terminator
+#ifndef INSTCOMBINE_BUG
+    PM->add(createInstructionCombiningPass());
+#endif
+    PM->add(createIndVarSimplifyPass());       // Canonicalize indvars
+    PM->add(createLoopDeletionPass());         // Delete dead loops
+#if defined(LLVM35)
+    PM->add(createSimpleLoopUnrollPass());     // Unroll small loops
+#else
+    PM->add(createLoopUnrollPass());           // Unroll small loops
+#endif
+#if !defined(LLVM35) && !defined(INSTCOMBINE_BUG)
+    PM->add(createLoopVectorizePass());        // Vectorize loops
+#endif
+    //FPM->add(createLoopStrengthReducePass());   // (jwb added)
+
+#ifndef INSTCOMBINE_BUG
+    PM->add(createInstructionCombiningPass()); // Clean up after the unroller
+#endif
+    PM->add(createGVNPass());                  // Remove redundancies
+    //FPM->add(createMemCpyOptPass());            // Remove memcpy / form memset
+    PM->add(createSCCPPass());                 // Constant prop with SCCP
+
+    // Run instcombine after redundancy elimination to exploit opportunities
+    // opened up by them.
+    PM->add(createSinkingPass()); ////////////// ****
+    PM->add(createInstructionSimplifierPass());///////// ****
+#ifndef INSTCOMBINE_BUG
+    PM->add(createInstructionCombiningPass());
+#endif
+    PM->add(createJumpThreadingPass());         // Thread jumps
+    PM->add(createDeadStoreEliminationPass());  // Delete dead stores
+#if !defined(INSTCOMBINE_BUG)
+    if (jl_options.opt_level>=1)
+        PM->add(createSLPVectorizerPass());     // Vectorize straight-line code
+#endif
+
+    PM->add(createAggressiveDCEPass());         // Delete dead instructions
+#if !defined(INSTCOMBINE_BUG)
+    if (jl_options.opt_level>=1)
+        PM->add(createInstructionCombiningPass());   // Clean up after SLP loop vectorizer
+#endif
+#if defined(LLVM35)
+    PM->add(createLoopVectorizePass());         // Vectorize loops
+    PM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer
+#endif
+    //FPM->add(createCFGSimplificationPass());     // Merge & remove BBs
+}
+
+#ifdef USE_ORCJIT
+
+// ------------------------ TEMPORARILY COPIED FROM LLVM -----------------
+// This must be kept in sync with gdb/gdb/jit.h .
+extern "C" {
+
+  typedef enum {
+    JIT_NOACTION = 0,
+    JIT_REGISTER_FN,
+    JIT_UNREGISTER_FN
+  } jit_actions_t;
+
+  struct jit_code_entry {
+    struct jit_code_entry *next_entry;
+    struct jit_code_entry *prev_entry;
+    const char *symfile_addr;
+    uint64_t symfile_size;
+  };
+
+  struct jit_descriptor {
+    uint32_t version;
+    // This should be jit_actions_t, but we want to be specific about the
+    // bit-width.
+    uint32_t action_flag;
+    struct jit_code_entry *relevant_entry;
+    struct jit_code_entry *first_entry;
+  };
+
+  // We put information about the JITed function in this global, which the
+  // debugger reads.  Make sure to specify the version statically, because the
+  // debugger checks the version before we can set it during runtime.
+  extern struct jit_descriptor __jit_debug_descriptor;
+
+  LLVM_ATTRIBUTE_NOINLINE extern void __jit_debug_register_code();
+}
+
+extern JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
+                                      const object::ObjectFile &obj,
+                                      const object::ObjectFile &debugObj,
+                                      const RuntimeDyld::LoadedObjectInfo &L);
+
+namespace {
+
+using namespace llvm;
+using namespace llvm::object;
+using namespace llvm::orc;
+
+/// Do the registration.
+void NotifyDebugger(jit_code_entry* JITCodeEntry) {
+  __jit_debug_descriptor.action_flag = JIT_REGISTER_FN;
+
+  // Insert this entry at the head of the list.
+  JITCodeEntry->prev_entry = nullptr;
+  jit_code_entry* NextEntry = __jit_debug_descriptor.first_entry;
+  JITCodeEntry->next_entry = NextEntry;
+  if (NextEntry) {
+    NextEntry->prev_entry = JITCodeEntry;
+  }
+  __jit_debug_descriptor.first_entry = JITCodeEntry;
+  __jit_debug_descriptor.relevant_entry = JITCodeEntry;
+  __jit_debug_register_code();
+}
+
+// --------------------------------------------------------------------------
+
+class DebugObjectRegistrar {
+private:
+    void NotifyGDB(OwningBinary<ObjectFile> &DebugObj) {
+      const char *Buffer = DebugObj.getBinary()->getMemoryBufferRef().getBufferStart();
+      size_t      Size = DebugObj.getBinary()->getMemoryBufferRef().getBufferSize();
+
+      assert(Buffer && "Attempt to register a null object with a debugger.");
+      jit_code_entry* JITCodeEntry = new jit_code_entry();
+
+      if (!JITCodeEntry) {
+        llvm::report_fatal_error(
+          "Allocation failed when registering a JIT entry!\n");
+      } else {
+        JITCodeEntry->symfile_addr = Buffer;
+        JITCodeEntry->symfile_size = Size;
+
+        NotifyDebugger(JITCodeEntry);
+      }
+    }
+
+    std::vector<OwningBinary<ObjectFile>> SavedObjects;
+    std::unique_ptr<JITEventListener> JuliaListener;
+
+public:
+    DebugObjectRegistrar() : JuliaListener(CreateJuliaJITEventListener()) {}
+
+    template <typename ObjSetT, typename LoadResult>
+    void operator()(ObjectLinkingLayerBase::ObjSetHandleT, const ObjSetT &Objects,
+                  const LoadResult &LOS) {
+        auto oit = Objects.begin();
+        auto lit = LOS.begin();
+        while (oit != Objects.end()) {
+            auto &Object = *oit;
+            auto &LO = *lit;
+
+            OwningBinary<ObjectFile> SavedObject = LO->getObjectForDebug(*Object);
+
+            // If the debug object is unavailable, save (a copy of) the original object
+            // for our backtraces
+            if (!SavedObject.getBinary()) {
+                // This is unfortunate, but there doesn't seem to be a way to take
+                // ownership of the original buffer
+                auto NewBuffer = MemoryBuffer::getMemBufferCopy(Object->getData(), Object->getFileName());
+                auto NewObj = ObjectFile::createObjectFile(NewBuffer->getMemBufferRef());
+                SavedObject = OwningBinary<ObjectFile>(std::move(*NewObj),std::move(NewBuffer));
+            }
+            else
+                NotifyGDB(SavedObject);
+
+            SavedObjects.push_back(std::move(SavedObject));
+            ORCNotifyObjectEmitted(JuliaListener.get(),*Object,*SavedObjects.back().getBinary(),*LO);
+
+            ++oit;
+            ++lit;
+        }
+    }
+};
+
+}
+
+#if defined(_OS_DARWIN_) && defined(LLVM37) && defined(LLVM_SHLIB)
+#define CUSTOM_MEMORY_MANAGER 1
+extern RTDyldMemoryManager* createRTDyldMemoryManagerOSX();
+#endif
+
+class JuliaOJIT {
+public:
+    typedef orc::ObjectLinkingLayer<DebugObjectRegistrar> ObjLayerT;
+    typedef orc::IRCompileLayer<ObjLayerT> CompileLayerT;
+    typedef CompileLayerT::ModuleSetHandleT ModuleHandleT;
+    typedef StringMap<void*> GlobalSymbolTableT;
+    typedef object::OwningBinary<object::ObjectFile> OwningObj;
+
+    JuliaOJIT(TargetMachine &TM)
+      : TM(TM),
+        DL(TM.createDataLayout()),
+        ObjStream(ObjBufferSV),
+        MemMgr(
+#ifdef CUSTOM_MEMORY_MANAGER
+            createRTDyldMemoryManagerOSX()
+#else
+            new SectionMemoryManager
+#endif
+            ) {
+#ifdef JL_DEBUG_BUILD
+            PM.add(createVerifierPass());
+#endif
+            // In imaging mode, we run the pass manager on creation
+            // to make sure it ends up optimized in the shadow module
+            if (!imaging_mode) {
+                addOptimizationPasses(&PM);
+#ifdef JL_DEBUG_BUILD
+                PM.add(createVerifierPass());
+#endif
+            }
+            if (TM.addPassesToEmitMC(PM, Ctx, ObjStream))
+                llvm_unreachable("Target does not support MC emission.");
+
+            CompileLayer = std::unique_ptr<CompileLayerT>{new CompileLayerT(ObjectLayer,
+                [&](Module &M) {
+                    PM.run(M);
+                    std::unique_ptr<MemoryBuffer> ObjBuffer(
+                        new ObjectMemoryBuffer(std::move(ObjBufferSV)));
+                    ErrorOr<std::unique_ptr<object::ObjectFile>> Obj =
+                        object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef());
+
+                    // TODO: Actually report errors helpfully.
+                    if (Obj)
+                        return OwningObj(std::move(*Obj), std::move(ObjBuffer));
+                    return OwningObj(nullptr, nullptr);
+                }
+            )};
+            // Make sure SectionMemoryManager::getSymbolAddressInProcess can resolve
+            // symbols in the program as well. The nullptr argument to the function
+            // tells DynamicLibrary to load the program, not a library.
+
+            std::string *ErrorStr = nullptr;
+            if (sys::DynamicLibrary::LoadLibraryPermanently(nullptr, ErrorStr))
+                report_fatal_error("FATAL: unable to dlopen self\n" + *ErrorStr);
+        }
+
+    std::string mangle(const std::string &Name) {
+        std::string MangledName;
+        {
+            raw_string_ostream MangledNameStream(MangledName);
+            Mangler::getNameWithPrefix(MangledNameStream, Name, DL);
+        }
+        return MangledName;
+    }
+
+    void addGlobalMapping(StringRef Name, void *Addr) {
+       GlobalSymbolTable[mangle(Name)] = Addr;
+    }
+
+    ModuleHandleT addModule(Module *M) {
+        // We need a memory manager to allocate memory and resolve symbols for this
+        // new module. Create one that resolves symbols by looking back into the
+        // JIT.
+        auto Resolver = orc::createLambdaResolver(
+                          [&](const std::string &Name) {
+                            // TODO: consider moving the FunctionMover resolver here
+                            // Step 0: ObjectLinkingLayer has checked whether it is in the current module
+                            // Step 1: Check against list of known external globals
+                            GlobalSymbolTableT::const_iterator pos = GlobalSymbolTable.find(Name);
+                            if (pos != GlobalSymbolTable.end())
+                                return RuntimeDyld::SymbolInfo((intptr_t)pos->second, JITSymbolFlags::Exported);
+                            // Step 2: Search all previously emitted symbols
+                            if (auto Sym = findSymbol(Name))
+                              return RuntimeDyld::SymbolInfo(Sym.getAddress(),
+                                                             Sym.getFlags());
+                            // Step 2: Search the program symbols
+                            if (uint64_t addr = SectionMemoryManager::getSymbolAddressInProcess(Name))
+                                return RuntimeDyld::SymbolInfo(addr, JITSymbolFlags::Exported);
+                            // Return failure code
+                            return RuntimeDyld::SymbolInfo(nullptr);
+                          },
+                          [](const std::string &S) { return nullptr; }
+                        );
+        SmallVector<std::unique_ptr<Module>,1> Ms;
+        Ms.push_back(std::unique_ptr<Module>{M});
+        return CompileLayer->addModuleSet(std::move(Ms),
+                                         MemMgr,
+                                         std::move(Resolver));
+    }
+
+    void removeModule(ModuleHandleT H) { CompileLayer->removeModuleSet(H); }
+
+    orc::JITSymbol findSymbol(const std::string &Name) {
+        return CompileLayer->findSymbol(Name, true);
+    }
+
+    orc::JITSymbol findUnmangledSymbol(const std::string Name) {
+        return findSymbol(mangle(Name));
+    }
+
+    uint64_t getGlobalValueAddress(const std::string &Name) {
+        return CompileLayer->findSymbol(mangle(Name), false).getAddress();
+    }
+
+    uint64_t getFunctionAddress(const std::string &Name) {
+        return CompileLayer->findSymbol(mangle(Name), false).getAddress();
+    }
+
+    uint64_t FindFunctionNamed(const std::string &Name) {
+        return 0; // Functions are not kept around
+    }
+
+    void RegisterJITEventListener(JITEventListener *L) {
+        // TODO
+    }
+
+    const DataLayout& getDataLayout() const {
+        return DL;
+    }
+
+    const Triple& getTargetTriple() const {
+        return TM.getTargetTriple();
+    }
+
+private:
+    TargetMachine &TM;
+    const DataLayout DL;
+    // Should be big enough that in the common case, The
+    // object fits in its entirety
+    SmallVector<char, 4096> ObjBufferSV;
+    raw_svector_ostream ObjStream;
+    legacy::PassManager PM;
+    MCContext *Ctx;
+    RTDyldMemoryManager *MemMgr;
+    ObjLayerT ObjectLayer;
+    std::unique_ptr<CompileLayerT> CompileLayer;
+    GlobalSymbolTableT GlobalSymbolTable;
+};
+#endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -234,6 +234,14 @@ typedef jl_value_t *(*jl_fptr_t)(jl_value_t*, jl_value_t**, uint32_t);
 
 typedef struct _jl_datatype_t jl_tupletype_t;
 
+typedef struct _jl_llvm_functions_t {
+    void *functionObject;       // jlcall llvm Function
+    void *cFunctionList;        // c callable llvm Functions
+
+    // specialized llvm Function (common core for the other two)
+    void *specFunctionObject;
+} jl_llvm_functions_t;
+
 typedef struct _jl_lambda_info_t {
     JL_DATA_TYPE
     // this holds the static data for a function:
@@ -266,11 +274,13 @@ typedef struct _jl_lambda_info_t {
     uint8_t inInference : 1;
     uint8_t inCompile : 1;
     jl_fptr_t fptr;             // jlcall entry point
-    void *functionObject;       // jlcall llvm Function
-    void *cFunctionList;        // c callable llvm Functions
 
-    // specialized llvm Function (common core for the other two)
-    void *specFunctionObject;
+    // On the old JIT, handles to all Functions generated for this linfo
+    // For the new JITs, handles to declarations in the shadow module
+    // with the same name as the generated functions for this linfo, suitable
+    // for referencing in LLVM IR
+    jl_llvm_functions_t functionObjects;
+
     int32_t functionID; // index that this function will have in the codegen table
     int32_t specFunctionID; // index that this specFunction will have in the codegen table
 } jl_lambda_info_t;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -169,7 +169,7 @@ int jl_start_parsing_file(const char *fname);
 void jl_stop_parsing(void);
 jl_value_t *jl_parse_next(void);
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
-void jl_compile_linfo(jl_lambda_info_t *li);
+void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
 jl_value_t *jl_parse_eval_all(const char *fname, size_t len);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
@@ -253,7 +253,7 @@ int32_t jl_get_llvm_gv(jl_value_t *p);
 void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
 
 jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp, jl_tupletype_t *types);
-jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types);
+jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types, void *cyclectx);
 jl_function_t *jl_module_get_initializer(jl_module_t *m);
 void jl_generate_fptr(jl_function_t *f);
 void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig);

--- a/src/options.h
+++ b/src/options.h
@@ -112,6 +112,10 @@
 #  define MEMDEBUG
 #  define KEEP_BODIES
 #  endif
+// Memory sanitizer also needs thread-local storage
+#  if __has_feature(memory_sanitizer)
+#  define CODEGEN_TLS
+#  endif
 #endif
 
 #endif

--- a/src/threading.c
+++ b/src/threading.c
@@ -421,7 +421,7 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_function_t *f, jl_svec_t *args)
         argtypes = (jl_tupletype_t*)jl_typeof(jl_emptytuple);
     else
         argtypes = arg_type_tuple(jl_svec_data(args), jl_svec_len(args));
-    fun = jl_get_specialization(f, argtypes);
+    fun = jl_get_specialization(f, argtypes, NULL);
     if (fun == NULL)
         fun = f;
     jl_generate_fptr(fun);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -81,7 +81,7 @@ void jl_module_load_time_initialize(jl_module_t *m)
             jl_module_init_order = jl_alloc_cell_1d(0);
         jl_cell_1d_push(jl_module_init_order, (jl_value_t*)m);
         jl_function_t *f = jl_module_get_initializer(m);
-        if (f) jl_get_specialization(f, (jl_tupletype_t*)jl_typeof(jl_emptytuple));
+        if (f) jl_get_specialization(f, (jl_tupletype_t*)jl_typeof(jl_emptytuple), NULL);
     }
     else {
         jl_module_run_initializer(m);

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -32,10 +32,11 @@ eval(Expr(:function, Expr(:call, :test_inline_1),
                      Expr(:call, :throw, "foo"))))
 
 # different-file inline
+const absfilepath = OS_NAME == :Windows ? "C:\\foo\\bar\\baz.jl" : "/foo/bar/baz.jl"
 eval(Expr(:function, Expr(:call, :test_inline_2),
                      Expr(:block, LineNumberNode(symbol("backtrace.jl"), 99),
                      LineNumberNode(symbol("foobar.jl"), 666),
-                     LineNumberNode(symbol("/foo/bar/baz.jl"), 111),
+                     LineNumberNode(symbol(absfilepath), 111),
                      Expr(:call, :throw, "foo"))))
 
 try
@@ -61,7 +62,7 @@ catch err
     end
 
     fname, file, line, inlinedfile, inlinedline, fromC = lkup
-    @test string(file) == "/foo/bar/baz.jl"
+    @test string(file) == absfilepath
     @test line == 111
     @test endswith(string(inlinedfile), "backtrace.jl")
     @test inlinedline == 99

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -74,15 +74,15 @@ end
 # On llvm <3.5+ even though the the compilation fails on the first try,
 # llvm still adds the intrinsice declaration to the module and subsequent calls
 # are succesfull.
-if convert(VersionNumber, Base.libllvm_version) > v"3.5-"
-
-function undeclared_ceil(x::Float64)
-    llvmcall("""%2 = call double @llvm.ceil.f64(double %0)
-        ret double %2""", Float64, Tuple{Float64}, x)
-end
-@test_throws ErrorException undeclared_ceil(4.2)
-
-end
+#if convert(VersionNumber, Base.libllvm_version) > v"3.5-"
+#
+#function undeclared_ceil(x::Float64)
+#    llvmcall("""%2 = call double @llvm.ceil.f64(double %0)
+#        ret double %2""", Float64, Tuple{Float64}, x)
+#end
+#@test_throws ErrorException undeclared_ceil(4.2)
+#
+#end
 
 function declared_floor(x::Float64)
     llvmcall(


### PR DESCRIPTION
This is somewhat of a rewrite of the way we use MCJIT + a move to ORC JIT to avoid a) some runtime overhead related to MCJIT not reusing the pass manager and b) the memory overhead of MCJIT requiring you to hold onto the LLVM IR, both of which will not be fixed upstream, because they are fixed in the C API. The new ORC based jit is in jitlayers.cpp, but the intention is that both the old jit and MCJIT continue working for now. As a result the code is slightly more messy than it should be in a number places because there are now three possible JITs that could run over it.

There are two core aspects of this rewrite:
1) Attempting to combine multiple functions into a single module in order to reduce per-module overhead in the compiler. The primary difficulty here is that sometimes we need to compile functions while we're in the middle of IRgening another function (most notably in inference and in staged functions). As a result, we cannot simply have just one module into which everything gets emitted, because that way LLVM would attempt to generate code for a partially IRgened function, which is not what we want. Instead what this IR does is to temporarily put all functions into a global module (technically they could be parentless, but some of LLVM's APIs don't like dealing with parentless functions), which then get reparented to a single active module as soon as all function in a given call cycle are complete.
2) Being more aggressive about freeing memory at all stages of using LLVM. This includes freeing the IR module, as soon as the native code is generated and freeing the native code as soon as it's moved to the executable pages (both of which we were holding on to). The one caveat to this is that there is an additional copy of the native code for the debugger (for the debug sections, in the future I will make sure that copy does not include the actual generated code). Our backtracing code now shares that copy for reading DWARF information.

I have two more patches pending upstream (1 accepted but not landed, one pending review) before this will actually work with an unmodified copy of LLVM, but I expect to be able to land them shortly. Once that's done, I'll create a backported version for LLVM 3.7.1, which we can then officially activate in a separate pull request.

As I mentioned, this should run on all three JITs, so the transition should be relatively smooth. The idea is to run on ORC JIT for LLVM 3.8 and LLVM 3.7.1 with patches, MCJIT on LLVM 3.5+ without patches (this will have some of the known performance problems) where distributions refuse to ship our patches and the old JIT on LLVM 3.3. I'm anticipating keeping the 3.3 JIT around for at least a little while longer in case we encounter any major issues (e.g. in packages) after switching people over, but hopefully we'll be able to remove support for it soon. I imagine the most like scenario is that we wait for the release of 0.5/LLVM 3.8 and go full ORC jit on master, at which point we'll be able to delete quite a bit of code.
