### PR TITLE
Do not assume the GC is always running on the master thread.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2462,8 +2462,9 @@ void jl_print_gc_stats(JL_STREAM *s)
 jl_thread_heap_t *jl_mk_thread_heap(void)
 {
 #ifdef JULIA_ENABLE_THREADING
-    // FIXME - should be cache-aligned malloc
-    jl_thread_heap = (jl_thread_heap_t*)malloc(sizeof(jl_thread_heap_t));
+    // Cache-aligned malloc
+    jl_thread_heap =
+        (jl_thread_heap_t*)jl_malloc_aligned(sizeof(jl_thread_heap_t), 64);
 #endif
     FOR_CURRENT_HEAP () {
         const int* szc = sizeclasses;

--- a/src/threading.c
+++ b/src/threading.c
@@ -127,7 +127,6 @@ JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
 JL_DLLEXPORT int jl_n_threads;     // # threads we're actually using
 JL_DLLEXPORT int jl_max_threads;   // # threads possible
 jl_thread_task_state_t *jl_all_task_states;
-jl_gcframe_t ***jl_all_pgcstacks;
 
 // return calling thread's ID
 JL_DLLEXPORT int16_t jl_threadid(void) { return ti_tid; }
@@ -139,7 +138,6 @@ static void ti_initthread(int16_t tid)
 {
     ti_tid = tid;
     jl_pgcstack = NULL;
-    jl_all_pgcstacks[tid] = &jl_pgcstack;
 #ifdef JULIA_ENABLE_THREADING
     jl_all_heaps[tid] = jl_mk_thread_heap();
 #else
@@ -291,7 +289,6 @@ void jl_init_threading(void)
 
     // set up space for per-thread heaps
     jl_all_heaps = (struct _jl_thread_heap_t **)malloc(jl_n_threads * sizeof(void*));
-    jl_all_pgcstacks = (jl_gcframe_t ***)malloc(jl_n_threads * sizeof(void*));
     jl_all_task_states = (jl_thread_task_state_t *)malloc(jl_n_threads * sizeof(jl_thread_task_state_t));
 
 #if PROFILE_JL_THREADING
@@ -538,7 +535,6 @@ void jl_init_threading(void)
     jl_all_task_states = &_jl_all_task_states;
     jl_max_threads = 1;
     jl_n_threads = 1;
-    jl_all_pgcstacks = (jl_gcframe_t***) malloc(jl_n_threads * sizeof(jl_gcframe_t**));
 
 #if defined(__linux__) && defined(JL_USE_INTEL_JITEVENTS)
     if (jl_using_intel_jitevents)

--- a/src/threading.h
+++ b/src/threading.h
@@ -22,7 +22,6 @@ extern JL_DLLEXPORT int jl_n_threads;  // # threads we're actually using
 // GC
 extern struct _jl_thread_heap_t **jl_all_heaps;
 #endif
-extern jl_gcframe_t ***jl_all_pgcstacks;
 
 // thread state
 enum {


### PR DESCRIPTION
Plus clean up.

We can't wait for thread 0 or pause it to run GC because it might be waiting for a OS level lock or executing other non-reentrant libc functions (`malloc`, `printf` for example).
