### PR TITLE
hopefully fix assertion failure in random test

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -166,7 +166,7 @@ function read(s::IOStream, ::Type{UInt8})
     b % UInt8
 end
 
-function read{T<:Union{UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt128, Int128}}(s::IOStream, ::Type{T})
+function read{T<:Union{UInt16, Int16, UInt32, Int32, UInt64, Int64}}(s::IOStream, ::Type{T})
     ccall(:jl_ios_get_nbyte_int, UInt64, (Ptr{Void}, Csize_t), s.ios, sizeof(T)) % T
 end
 

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -197,6 +197,7 @@ else
   make VERBOSE=1 -C base version_git.jl.phony
   echo 'NO_GIT = 1' >> Make.user
 fi
+echo 'FORCE_ASSERTIONS = 1' >> Make.user
 
 cat Make.user
 make VERBOSE=1

--- a/test/random.jl
+++ b/test/random.jl
@@ -286,6 +286,11 @@ let mt = MersenneTwister()
     end
 end
 
+# make sure reading 128-bit ints from RandomDevice works
+let a = [rand(RandomDevice(), UInt128) for i=1:10]
+    @test reduce(|, a)>>>64 != 0
+end
+
 # test all rand APIs
 for rng in ([], [MersenneTwister()], [RandomDevice()])
     for f in [rand, randn, randexp]


### PR DESCRIPTION
introduced by https://github.com/JuliaLang/julia/commit/cb52f15feec9052e68c9102e7e12e93a49367def
jl_ios_get_nbyte_int does not support int128 right now
