### PR TITLE
add function `string.encode' to avoid flisp bootstrap failure

### DIFF
--- a/src/flisp/aliases.scm
+++ b/src/flisp/aliases.scm
@@ -12,7 +12,6 @@
 (define char>? >)
 (define char<=? <=)
 (define char>=? >=)
-(define (char-whitespace? c) (not (not (string.find *whitespace* c))))
 (define (char-numeric? c) (not (not (string.find "0123456789" c))))
 
 (define string-append string)

--- a/src/flisp/flisp.boot
+++ b/src/flisp/flisp.boot
@@ -59,9 +59,8 @@
   trycatch lambda if and pair? eq? car quote thrown-value cadr caddr raise])  let #fn(">000s1^|C6B0|m62}Mm02}Nm1530]2c0c1L1c2c3|32L1c4}3133c2c5|32g66C0c6g6g7L2L1g6L3540g7g8K;" [#fn(nconc)
   lambda #fn(map) #fn("5000r1|F650|M;|;" [])
   #fn(copy-list) #fn("5000r1|F650|\x84;e040;" [void]) letrec]))
-	  *whitespace* "\t\n\v\f\r \u0085  ᠎           \u2028\u2029  　" 1+
-	  #fn("6000r1|aw;" [] 1+) 1- #fn("6000r1|ax;" [] 1-) 1arg-lambda?
-	  #fn("7000r1|F16T02|Mc0<16J02|NF16B02|\x84F16:02e1|\x84a42;" [lambda
+	  1+ #fn("6000r1|aw;" [] 1+) 1-
+	  #fn("6000r1|ax;" [] 1-) 1arg-lambda? #fn("7000r1|F16T02|Mc0<16J02|NF16B02|\x84F16:02e1|\x84a42;" [lambda
   length=] 1arg-lambda?)
 	  <= #fn("6000r2|}X17602|}W;" [] <=) >
 	  #fn("6000r2}|X;" [] >) >= #fn("6000r2}|X17602|}W;" [] >=)

--- a/src/flisp/system.lsp
+++ b/src/flisp/system.lsp
@@ -640,11 +640,6 @@
 
 (define (string.tail s n) (string.sub s (string.inc s 0 n)))
 
-(define *whitespace*
-  (string.encode #array(wchar 9 10 11 12 13 32 133 160 5760 6158 8192
-			      8193 8194 8195 8196 8197 8198 8199 8200
-			      8201 8202 8232 8233 8239 8287 12288)))
-
 #;(define (string.trim s at-start at-end)
   (define (trim-start s chars i L)
     (if (and (< i L)


### PR DESCRIPTION
I notice that the c implementation of `string.encode` is removed, so the flisp can't boostrap now.

```
$ ./bootstrap.sh 
Creating stage 0 boot file...
Creating stage 1 boot file...
fatal error during bootstrap:
(unbound-error string.encode)
Testing...
./flisp unittest.lsp
fatal error during bootstrap:
(unbound-error string.encode)
Makefile:95: recipe for target 'test' failed
make: *** [test] Error 1
```

I just add a scheme version of `string.encode`.
