### PR TITLE
use BigInt version of powermod for [U]Int128

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -439,8 +439,8 @@ function powermod(x::BigInt, p::BigInt, m::BigInt)
           &r, &x, &p, &m)
     return m < 0 && r > 0 ? r + m : r # choose sign conistent with mod(x^p, m)
 end
-powermod(x::BigInt, p::Integer, m::BigInt) = powermod(x, BigInt(p), m)
-powermod(x::BigInt, p::Integer, m::Integer) = powermod(x, BigInt(p), BigInt(m))
+
+powermod(x::Integer, p::Integer, m::BigInt) = powermod(big(x), big(p), m)
 
 function gcdx(a::BigInt, b::BigInt)
     if b == 0 # shortcut this to ensure consistent results with gcdx(a,b)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -108,11 +108,11 @@ end
 ^(x, p::Integer)          = power_by_squaring(x,p)
 
 # b^p mod m
-function powermod{T}(b::Integer, p::Integer, m::T)
+function powermod{T<:Integer}(x::Integer, p::Integer, m::T)
     p < 0 && throw(DomainError())
-    b = oftype(m,mod(b,m))  # this also checks for divide by zero
-    p == 0 && return mod(one(b),m)
+    p == 0 && return mod(one(m),m)
     (m == 1 || m == -1) && return zero(m)
+    b = oftype(m,mod(x,m))  # this also checks for divide by zero
 
     t = prevpow2(p)
     local r::T
@@ -128,6 +128,9 @@ function powermod{T}(b::Integer, p::Integer, m::T)
     end
     return r
 end
+
+# optimization: promote the modulus m to BigInt only once (cf. widemul in generic powermod above)
+powermod(x::Integer, p::Integer, m::Union{Int128,UInt128}) = oftype(m, powermod(x, p, big(m)))
 
 # smallest power of 2 >= x
 nextpow2(x::Unsigned) = one(x)<<((sizeof(x)<<3)-leading_zeros(x-one(x)))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2316,25 +2316,32 @@ for T in (Int32,Int64), ii = -20:20, jj = -20:20
     end
 end
 
-# check powermod function against GMP
+# check powermod function against few types (in particular [U]Int128 and BigInt)
 for i = -10:10, p = 0:5, m = -10:10
-    if m != 0
-        @test powermod(i,p,m) == powermod(i,p,big(m)) == powermod(big(i),big(p),big(m))
-        @test mod(i^p,m) == powermod(i,p,m) == mod(big(i)^p,big(m))
+    m == 0 && continue
+    x = powermod(i, p, m)
+    for T in [Int32, Int64, Int128, UInt128, BigInt]
+        T <: Unsigned && m < 0 && continue
+        let xT = powermod(i, p, T(m))
+            @test x == xT
+            @test isa(xT, T)
+        end
+        T <: Unsigned && i < 0 && continue
+        @test x == mod(T(i)^p, T(m))
     end
 end
 
 # with m==1 should give 0
 @test powermod(1,0,1) == 0
-@test powermod(big(1),0,1) == 0
+@test powermod(1,0,big(1)) == 0
 @test powermod(1,0,-1) == 0
-@test powermod(big(1),0,-1) == 0
+@test powermod(1,0,big(-1)) == 0
 # divide by zero error
 @test_throws DivideError powermod(1,0,0)
-@test_throws DivideError powermod(big(1),0,0)
+@test_throws DivideError powermod(1,0,big(0))
 # negative power domain error
 @test_throws DomainError powermod(1,-2,1)
-@test_throws DomainError powermod(big(1),-2,1)
+@test_throws DomainError powermod(1,-2,big(1))
 
 # other divide-by-zero errors
 @test_throws DivideError div(1,0)


### PR DESCRIPTION
The changes are explained in the commit summary below, but I have one more general question (relevant to the 4th item in commit summary): it is not clear what should be the result type of `mod` and of `powermod`. I wish it was garanteed to be always of the same type as the modulus (or maybe I missed a reason why it's not possible/desirable?), in order to be able to reason more easily. It would be in line with the types versions of `mod`, the following illustrates what appears inconsistent to me:

```
julia> typeof(mod(UInt128(1), 10))
Int128
julia> typeof(mod(UInt128(1), typeof(10)))
Int64
```

Please suggest if I should move this question somewhere else, e.g. julia-devel.
- `widemul` is used in the non-`BigInt` version, which promotes
  repeatedly (in a loop) to `BigInt` if the arguments are `[U]Int128`, so
  better use the optimized BigInt version directly (to avoid needless
  heap allocations)
- this also removes a tiny type instability on the argument `b` (changed
  to `x` here)
- to resolve ambiguity (for `powermod(::BigInt, ::Integer, ::[U]Int128)`,
  one method in gmp.jl is made more general as: `powermod(x::Integer,
  p::Integer, m::BigInt)`. This seems more correct also, as that way a
  call like `powermod(2, 2, big(2))` will use the GMP implementation, as
  was probably intended.
- one the other hand, the method (in gmp.jl) `powermod(x::BigInt,
  p::Integer, m::Integer)`, which was using the GMP implementation, has
  been removed: falling back to the generic implementation, which uses
  the type of `m` for computations, seems more efficient (a special case
  could be made for `[U]Int128` because of the aforementioned
  `widemul`); but more importantly, this method was probably the only
  one which didn't return a value of the same type as the modulus.
