### PR TITLE
matmul: don't assume the existence of type-conversions

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -452,12 +452,15 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
         return matmul3x3!(C, tA, tB, A, B)
     end
 
+    tile_size = 0
+    if isbits(R) && isbits(T) && isbits(S)
+        tile_size = floor(Int,sqrt(tilebufsize/max(sizeof(R),sizeof(S),sizeof(T))))
+    end
     @inbounds begin
-    if isbits(R)
-        tile_size = floor(Int,sqrt(tilebufsize/sizeof(R)))
+    if tile_size > 0
         sz = (tile_size, tile_size)
-        Atile = pointer_to_array(convert(Ptr{R}, pointer(Abuf)), sz)
-        Btile = pointer_to_array(convert(Ptr{R}, pointer(Bbuf)), sz)
+        Atile = pointer_to_array(convert(Ptr{T}, pointer(Abuf)), sz)
+        Btile = pointer_to_array(convert(Ptr{S}, pointer(Bbuf)), sz)
 
         z = zero(R)
 

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -193,3 +193,20 @@ b = rand(3,3)
 @test_throws ArgumentError A_mul_B!(a, a, b)
 @test_throws ArgumentError A_mul_B!(a, b, a)
 @test_throws ArgumentError A_mul_B!(a, a, a)
+
+# Number types that lack conversion to the destination type (#14293)
+immutable RootInt
+    i::Int
+end
+import Base: *, promote_op
+(*)(x::RootInt, y::RootInt) = x.i*y.i
+promote_op(::Base.MulFun, ::Type{RootInt}, ::Type{RootInt}) = Int
+
+a = [RootInt(3)]
+C = [0]
+A_mul_Bt!(C, a, a)
+@test C[1] == 9
+a = [RootInt(2),RootInt(10)]
+@test a*a' == [4 20; 20 100]
+A = [RootInt(3) RootInt(5)]
+@test A*a == [56]


### PR DESCRIPTION
I've been playing around with number types whose product is a real number but for which I cannot define a conversion to Reals. This fixes a bug in our algorithm for matrix multiplication.

``` jl
julia> immutable RootInt
           i::Int
       end

julia> import Base: *

julia> (*)(x::RootInt, y::RootInt) = x.i*y.i
* (generic function with 143 methods)

julia> a = [RootInt(3)]
1-element Array{RootInt,1}:
 RootInt(3)

julia> C = [0]
1-element Array{Int64,1}:
 0

julia> A_mul_Bt!(C, a, a)
ERROR: MethodError: `convert` has no method matching convert(::Type{Int64}, ::RootInt)
This may have arisen from a call to the constructor Int64(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert(::Type{Int64}, ::Int8)
  convert(::Type{Int64}, ::UInt8)
  ...
 in copy_transpose! at abstractarray.jl:383
 in copy_transpose! at linalg/matmul.jl:355
 in generic_matmatmul! at linalg/matmul.jl:465
 in A_mul_Bt! at linalg/matmul.jl:168
 in eval at ./boot.jl:263
```
