### PR TITLE
Use SIGTRAP to raise debugger on unix

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -474,6 +474,9 @@ void jl_install_default_signal_handlers(void)
     if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
         jl_error("fatal error: Couldn't set SIGPIPE");
     }
+    if (signal(SIGTRAP, SIG_IGN) == SIG_ERR) {
+        jl_error("fatal error: Couldn't set SIGTRAP");
+    }
 
     allocate_segv_handler();
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -720,7 +720,7 @@ JL_DLLEXPORT void jl_raise_debugger(void)
     if (IsDebuggerPresent() == 1)
         DebugBreak();
 #else
-    kill(getpid(), SIGINT);
+    raise(SIGTRAP);
 #endif // _OS_WINDOWS_
 }
 


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/commit/fb48014b23273bc3f021d31aab3246d717d2bb5d#commitcomment-14810141

``` jl
julia> 
Program received signal SIGTRAP, Trace/breakpoint trap.
0x00007ffff653fc39 in raise () from /usr/lib/libpthread.so.0
(gdb) c
Continuing.
julia> ^C
```

We probably don't need the the `try ... end` in `REPL.jl` anymore but it doesn't hurt too much to keep them...
