### PR TITLE
Extend checked integer arithmetic

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -162,6 +162,7 @@ export
     #ccall, cglobal, llvmcall, abs_float, add_float, add_int, and_int, ashr_int,
     #box, bswap_int, checked_fptosi, checked_fptoui, checked_sadd,
     #checked_smul, checked_ssub, checked_uadd, checked_umul, checked_usub,
+    #checked_sdiv, checked_srem, checked_udiv, checked_urem,
     #checked_trunc_sint, checked_trunc_uint, check_top_bit,
     #nan_dom_err, copysign_float, ctlz_int, ctpop_int, cttz_int,
     #div_float, eq_float, eq_int, eqfsi64, eqfui64, flipsign_int, select_value,

--- a/base/int.jl
+++ b/base/int.jl
@@ -126,22 +126,37 @@ const Unsigned64Types = (UInt8,UInt16,UInt32,UInt64)
 typealias Integer64 Union{Signed64Types...,Unsigned64Types...}
 
 for T in Signed64Types
-    @eval div(x::$T, y::$T) = box($T,sdiv_int(unbox($T,x),unbox($T,y)))
-    @eval rem(x::$T, y::$T) = box($T,srem_int(unbox($T,x),unbox($T,y)))
-    @eval mod(x::$T, y::$T) = box($T,smod_int(unbox($T,x),unbox($T,y)))
+    @eval div(x::$T, y::$T) = box($T,checked_sdiv(unbox($T,x),unbox($T,y)))
+    @eval rem(x::$T, y::$T) = box($T,checked_srem(unbox($T,x),unbox($T,y)))
 end
 for T in Unsigned64Types
-    @eval div(x::$T, y::$T) = box($T,udiv_int(unbox($T,x),unbox($T,y)))
-    @eval rem(x::$T, y::$T) = box($T,urem_int(unbox($T,x),unbox($T,y)))
+    @eval div(x::$T, y::$T) = box($T,checked_udiv(unbox($T,x),unbox($T,y)))
+    @eval rem(x::$T, y::$T) = box($T,checked_urem(unbox($T,x),unbox($T,y)))
 end
 
+# x == fld(x,y)*y + mod(x,y)
 mod{T<:Unsigned}(x::T, y::T) = rem(x,y)
+function mod{T<:Integer}(x::T, y::T)
+    y == -1 && return T(0)   # avoid potential overflow in fld
+    x - fld(x,y)*y
+ end
 
+# fld(x,y) == div(x,y) - ((x>=0) != (y>=0) && rem(x,y) != 0 ? 1 : 0)
 fld{T<:Unsigned}(x::T, y::T) = div(x,y)
-fld{T<:Integer }(x::T, y::T) = div(x,y)-(signbit(x$y)&(rem(x,y)!=0))
+function fld{T<:Integer}(x::T, y::T)
+    d = div(x,y)
+    d - (signbit(x$y) & (d*y!=x))
+end
 
-cld{T<:Unsigned}(x::T, y::T) = div(x,y)+(rem(x,y)!=0)
-cld{T<:Integer }(x::T, y::T) = div(x,y)+(!signbit(x$y)&(rem(x,y)!=0))
+# cld(x,y) = div(x,y) + ((x>0) == (y>0) && rem(x,y) != 0 ? 1 : 0)
+function cld{T<:Unsigned}(x::T, y::T)
+    d = div(x,y)
+    d + (d*y!=x)
+end
+function cld{T<:Integer}(x::T, y::T)
+    d = div(x,y)
+    d + (((x>0) == (y>0)) & (d*y!=x))
+end
 
 ## integer bitwise operations ##
 
@@ -508,16 +523,14 @@ else
     *(x::Int128,  y::Int128)  = box(Int128,mul_int(unbox(Int128,x),unbox(Int128,y)))
     *(x::UInt128, y::UInt128) = box(UInt128,mul_int(unbox(UInt128,x),unbox(UInt128,y)))
 
-    div(x::Int128,  y::Int128)  = box(Int128,sdiv_int(unbox(Int128,x),unbox(Int128,y)))
-    div(x::UInt128, y::UInt128) = box(UInt128,udiv_int(unbox(UInt128,x),unbox(UInt128,y)))
+    div(x::Int128,  y::Int128)  = box(Int128,checked_sdiv(unbox(Int128,x),unbox(Int128,y)))
+    div(x::UInt128, y::UInt128) = box(UInt128,checked_udiv(unbox(UInt128,x),unbox(UInt128,y)))
 
-    rem(x::Int128,  y::Int128)  = box(Int128,srem_int(unbox(Int128,x),unbox(Int128,y)))
-    rem(x::UInt128, y::UInt128) = box(UInt128,urem_int(unbox(UInt128,x),unbox(UInt128,y)))
-
-    mod(x::Int128, y::Int128) = box(Int128,smod_int(unbox(Int128,x),unbox(Int128,y)))
+    rem(x::Int128,  y::Int128)  = box(Int128,checked_srem(unbox(Int128,x),unbox(Int128,y)))
+    rem(x::UInt128, y::UInt128) = box(UInt128,checked_urem(unbox(UInt128,x),unbox(UInt128,y)))
 end
 
-## checked +, - and *
+## checked +, -, *, div, rem, fld, mod
 
 """
     Base.checked_add(x, y)
@@ -545,6 +558,51 @@ Calculates `x*y`, checking for overflow errors where applicable.
 The overflow protection may impose a perceptible performance penalty.
 """
 function checked_mul end
+
+"""
+    Base.checked_div(x, y)
+
+Calculates `div(x,y)`, checking for overflow errors where applicable.
+
+The overflow protection may impose a perceptible performance penalty.
+"""
+function checked_div end
+
+"""
+    Base.checked_rem(x, y)
+
+Calculates `x%y`, checking for overflow errors where applicable.
+
+The overflow protection may impose a perceptible performance penalty.
+"""
+function checked_rem end
+
+"""
+    Base.checked_fld(x, y)
+
+Calculates `fld(x,y)`, checking for overflow errors where applicable.
+
+The overflow protection may impose a perceptible performance penalty.
+"""
+function checked_fld end
+
+"""
+    Base.checked_mod(x, y)
+
+Calculates `mod(x,y)`, checking for overflow errors where applicable.
+
+The overflow protection may impose a perceptible performance penalty.
+"""
+function checked_mod end
+
+"""
+    Base.checked_cld(x, y)
+
+Calculates `cld(x,y)`, checking for overflow errors where applicable.
+
+The overflow protection may impose a perceptible performance penalty.
+"""
+function checked_cld end
 
 # requires int arithmetic defined, for the loops to work
 
@@ -654,4 +712,31 @@ function checked_mul(x::UInt128, y::UInt128)
     # x * y > typemax(UInt128)
     y > 0 && x > fld(typemax(UInt128), y) && throw(OverflowError())
     x * y
+end
+
+# These implementations check by default
+checked_div{T<:Union{IntTypes...}}(x::T, y::T) = div(x,y)
+checked_rem{T<:Union{IntTypes...}}(x::T, y::T) = rem(x,y)
+checked_fld{T<:Union{IntTypes...}}(x::T, y::T) = fld(x,y)
+checked_mod{T<:Union{IntTypes...}}(x::T, y::T) = mod(x,y)
+checked_cld{T<:Union{IntTypes...}}(x::T, y::T) = cld(x,y)
+
+# Handle multiple arguments
+checked_add(x) = x
+checked_mul(x) = x
+for f in (:checked_add, :checked_mul)
+    @eval begin
+        ($f){T}(x1::T, x2::T, x3::T) =
+            ($f)(($f)(x1, x2), x3)
+        ($f){T}(x1::T, x2::T, x3::T, x4::T) =
+            ($f)(($f)(x1, x2), x3, x4)
+        ($f){T}(x1::T, x2::T, x3::T, x4::T, x5::T) =
+            ($f)(($f)(x1, x2), x3, x4, x5)
+        ($f){T}(x1::T, x2::T, x3::T, x4::T, x5::T, x6::T) =
+            ($f)(($f)(x1, x2), x3, x4, x5, x6)
+        ($f){T}(x1::T, x2::T, x3::T, x4::T, x5::T, x6::T, x7::T) =
+            ($f)(($f)(x1, x2), x3, x4, x5, x6, x7)
+        ($f){T}(x1::T, x2::T, x3::T, x4::T, x5::T, x6::T, x7::T, x8::T) =
+            ($f)(($f)(x1, x2), x3, x4, x5, x6, x7, x8)
+    end
 end

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1140,6 +1140,46 @@ Mathematical Functions
 
    The overflow protection may impose a perceptible performance penalty.
 
+.. function:: Base.checked_div(x, y)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``div(x,y)``\ , checking for overflow errors where applicable.
+
+   The overflow protection may impose a perceptible performance penalty.
+
+.. function:: Base.checked_rem(x, y)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``x%y``\ , checking for overflow errors where applicable.
+
+   The overflow protection may impose a perceptible performance penalty.
+
+.. function:: Base.checked_fld(x, y)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``fld(x,y)``\ , checking for overflow errors where applicable.
+
+   The overflow protection may impose a perceptible performance penalty.
+
+.. function:: Base.checked_mod(x, y)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``mod(x,y)``\ , checking for overflow errors where applicable.
+
+   The overflow protection may impose a perceptible performance penalty.
+
+.. function:: Base.checked_cld(x, y)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``cld(x,y)``\ , checking for overflow errors where applicable.
+
+   The overflow protection may impose a perceptible performance penalty.
+
 .. function:: abs2(x)
 
    .. Docstring generated from Julia source

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -262,6 +262,46 @@ int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart 
 }
 
 extern "C" JL_DLLEXPORT
+int LLVMDiv_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    bool Overflow;
+    a = a.sdiv_ov(b, Overflow);
+    ASSIGN(r, a)
+    return Overflow;
+}
+
+extern "C" JL_DLLEXPORT
+int LLVMDiv_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.udiv(b);
+    ASSIGN(r, a)
+    // unsigned division cannot overflow
+    return false;
+}
+
+extern "C" JL_DLLEXPORT
+int LLVMRem_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.srem(b);
+    ASSIGN(r, a)
+    // signed remainder cannot overflow
+    return false;
+}
+
+extern "C" JL_DLLEXPORT
+int LLVMRem_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.urem(b);
+    ASSIGN(r, a)
+    // unsigned remainder cannot overflow
+    return false;
+}
+
+extern "C" JL_DLLEXPORT
 void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr) {
     CREATE(a)
     a = a.byteSwap();

--- a/src/APInt-C.h
+++ b/src/APInt-C.h
@@ -46,6 +46,10 @@ JL_DLLEXPORT int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb,
 JL_DLLEXPORT int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 JL_DLLEXPORT int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 JL_DLLEXPORT int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMDiv_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMDiv_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMRem_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMRem_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
 JL_DLLEXPORT unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa);
 JL_DLLEXPORT unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa);

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -13,7 +13,6 @@
     ADD_I(udiv_int, 2) \
     ADD_I(srem_int, 2) \
     ADD_I(urem_int, 2) \
-    ADD_I(smod_int, 2) \
     ADD_I(neg_float, 1) \
     ADD_I(add_float, 2) \
     ADD_I(sub_float, 2) \
@@ -81,6 +80,10 @@
     ADD_I(checked_usub, 2) \
     ADD_I(checked_smul, 2) \
     ADD_I(checked_umul, 2) \
+    ADD_I(checked_sdiv, 2) \
+    ADD_I(checked_udiv, 2) \
+    ADD_I(checked_srem, 2) \
+    ADD_I(checked_urem, 2) \
     ADD_I(nan_dom_err, 2) \
     /*  functions */ \
     ADD_I(abs_float, 1) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -351,7 +351,6 @@ JL_DLLEXPORT jl_value_t *jl_sdiv_int(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_udiv_int(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_srem_int(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_urem_int(jl_value_t *a, jl_value_t *b);
-JL_DLLEXPORT jl_value_t *jl_smod_int(jl_value_t *a, jl_value_t *b);
 
 JL_DLLEXPORT jl_value_t *jl_neg_float(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_add_float(jl_value_t *a, jl_value_t *b);
@@ -413,6 +412,10 @@ JL_DLLEXPORT jl_value_t *jl_checked_ssub(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_checked_usub(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_checked_smul(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_checked_umul(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_sdiv(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_udiv(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_srem(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_urem(jl_value_t *a, jl_value_t *b);
 
 JL_DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_ceil_llvm(jl_value_t *a);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -855,6 +855,10 @@ checked_iintrinsic_fast(LLVMSub_sov, check_ssub, sub, checked_ssub,  )
 checked_iintrinsic_fast(LLVMSub_uov, check_usub, sub, checked_usub, u)
 checked_iintrinsic_slow(LLVMMul_sov, checked_smul,  )
 checked_iintrinsic_slow(LLVMMul_uov, checked_umul, u)
+checked_iintrinsic_slow(LLVMDiv_sov, checked_sdiv,  )
+checked_iintrinsic_slow(LLVMDiv_uov, checked_udiv, u)
+checked_iintrinsic_slow(LLVMRem_sov, checked_srem,  )
+checked_iintrinsic_slow(LLVMRem_uov, checked_urem, u)
 
 JL_DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b)
 {

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1593,6 +1593,38 @@ end
 @test signed(cld(typemax(UInt),typemin(Int)>>1))     == -3
 @test signed(cld(typemax(UInt),(typemin(Int)>>1)+1)) == -4
 
+# Test return types
+for T in (Int8,Int16,Int32,Int64,Int128, UInt8,UInt16,UInt32,UInt64,UInt128)
+    z, o = T(0), T(1)
+    @test typeof(+z) === T
+    @test typeof(-z) === T
+    @test typeof(abs(z)) === T
+    @test typeof(sign(z)) === T
+    @test typeof(copysign(z,z)) === T
+    @test typeof(flipsign(z,z)) === T
+    @test typeof(z+z) === T
+    @test typeof(z-z) === T
+    @test typeof(z*z) === T
+    @test typeof(z÷o) === T
+    @test typeof(z%o) === T
+    @test typeof(fld(z,o)) === T
+    @test typeof(mod(z,o)) === T
+    @test typeof(cld(z,o)) === T
+
+    @test typeof(Base.checked_add(z)) === T
+    @test typeof(Base.checked_neg(z)) === T
+    @test typeof(Base.checked_abs(z)) === T
+    @test typeof(Base.checked_mul(z)) === T
+    @test typeof(Base.checked_add(z,z)) === T
+    @test typeof(Base.checked_sub(z,z)) === T
+    @test typeof(Base.checked_mul(z,z)) === T
+    @test typeof(Base.checked_div(z,o)) === T
+    @test typeof(Base.checked_rem(z,o)) === T
+    @test typeof(Base.checked_fld(z,o)) === T
+    @test typeof(Base.checked_mod(z,o)) === T
+    @test typeof(Base.checked_cld(z,o)) === T
+end
+
 # issue #4156
 @test fld(1.4,0.35667494393873234) == 3.0
 @test div(1.4,0.35667494393873234) == 3.0


### PR DESCRIPTION
Provide checked_{div, rem, fld, mod, cld} to complete the set of checked_\* integer functions. Note that their regular counterparts also check for overflow, so that they currently have identical behaviour.

Rename the intrinsic sdiv, udiv, srem, urem to checked_*, since this is what they do.

Provide non-checking intrinsics (under the old, now unused names) for efficiency.

Implement mod in Julia instead of in C++ (significantly shorter). Use a more efficient algorithm based on a single div instead of on two rem.

Add tests ensuring that the new checked_\* functions throw when they need to.

Add tests checking the return types of all integer arithmetic operators (regular and checked), since I was bitten during development.

Update documentation.

Note: The tests include the flipsign function, assuming that PR #14299 is present.
