### PR TITLE
Root the function object in jlcall

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3105,6 +3105,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
         }
         else {
             theF = literal_pointer_val((jl_value_t*)f);
+            jl_add_linfo_root(ctx->linfo, (jl_value_t*)f);
             result = emit_call_function_object(f, theF, theFptr, true, args-1, nargs+1, ctx);
         }
     }
@@ -3132,6 +3133,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
         }
         else {
             theF = literal_pointer_val((jl_value_t*)f);
+            jl_add_linfo_root(ctx->linfo, (jl_value_t*)f);
         }
         result = emit_call_function_object(f, theF, theFptr, specialized, args, nargs, ctx);
     }


### PR DESCRIPTION
It took me a while to figure out but this is what causing a segfault for the following code with threading in #14190 .

`f` is a global function but has a closure specialization. It's address is inlined by the caller but is then replaced by a new method, causing a segfault when calling the old function when it's trying to access the closure variables. In some sense this is a consequence of https://github.com/JuliaLang/julia/issues/265 since the method is otherwise guaranteed to be rooted in the method table. This might make the gc root list bigger but until #265 is fixed, this is the only fix I can come up with.

``` jl
using Base.Threads

ex = quote
    for j in 1:10
        println(j)
        @threads all for i in 1:10
            global f() = i
            gc(false)
            f()
        end
    end
end

for k in 1:10000
    eval(ex)
end
```
