### PR TITLE
Fix show() error while calling UDPSocket() in REPL.

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -370,6 +370,8 @@ function UDPSocket()
     this
 end
 
+show(io::IO, stream::UDPSocket) = print(io, typeof(stream), "(", uv_status_string(stream), ")")
+
 function uvfinalize(uv::Union{TTY,PipeEndpoint,PipeServer,TCPServer,TCPSocket,UDPSocket})
     if (uv.status != StatusUninit && uv.status != StatusInit)
         close(uv)

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -64,6 +64,9 @@ end
 @test repr(ip"2001:db8:0:0:1:0:0:1") == "ip\"2001:db8::1:0:0:1\""
 @test repr(ip"2001:0:0:1:0:0:0:1") == "ip\"2001:0:0:1::1\""
 
+# test show() function for UDPSocket()
+@test repr(UDPSocket()) == "UDPSocket(init)"
+
 port = Channel(1)
 defaultport = rand(2000:4000)
 tsk = @async begin


### PR DESCRIPTION
Calling UDPSocket() displays this now.

``` julia
julia> UDPSocket()
UDPSocket(init)
```

Fixes [#13711](https://github.com/JuliaLang/julia/issues/13711)
