### PR TITLE
Correct @fastmath when accessing fields

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -93,7 +93,6 @@ function make_fastmath(expr::Expr)
     end
     op = get(rewrite_op, expr.head, :nothing)
     if op !== :nothing
-        info("FM: rewriting op $(expr.head) with $op")
         var = expr.args[1]
         rhs = expr.args[2]
         if isa(var, Symbol)

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -88,14 +88,18 @@ const rewrite_op =
          :^= => :^)
 
 function make_fastmath(expr::Expr)
+    if expr.head === :quote
+        return expr
+    end
     op = get(rewrite_op, expr.head, :nothing)
-    if op != :nothing
+    if op !== :nothing
+        info("FM: rewriting op $(expr.head) with $op")
         var = expr.args[1]
         rhs = expr.args[2]
         if isa(var, Symbol)
             # simple assignment
-            expr = :($var = $(op)($var, $rhs))
-        elseif isa(var, Expr) && var.head == :ref
+            expr = :($var = $op($var, $rhs))
+        elseif isa(var, Expr) && var.head === :ref
             # array reference
             arr = var.args[1]
             inds = tuple(var.args[2:end]...)
@@ -104,7 +108,7 @@ function make_fastmath(expr::Expr)
             expr = quote
                 $(Expr(:(=), arrvar, arr))
                 $(Expr(:(=), Expr(:tuple, indvars...), Expr(:tuple, inds...)))
-                $(arrvar)[$(indvars...)] = $(op)($(arrvar)[$(indvars...)], $rhs)
+                $arrvar[$(indvars...)] = $op($arrvar[$(indvars...)], $rhs)
             end
         end
     end
@@ -112,17 +116,16 @@ function make_fastmath(expr::Expr)
 end
 function make_fastmath(symb::Symbol)
     fast_symb = get(fast_op, symb, :nothing)
-    if fast_symb == :nothing
+    if fast_symb === :nothing
         return symb
     end
-    :(Base.FastMath.$(fast_symb))
+    :(Base.FastMath.$fast_symb)
 end
 make_fastmath(expr) = expr
 
 macro fastmath(expr)
     make_fastmath(esc(expr))
 end
-
 
 
 

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -2,6 +2,14 @@
 
 # fast math
 
+# check expansions
+
+@test macroexpand(:(@fastmath 1+2)) == :(Base.FastMath.add_fast(1,2))
+@test macroexpand(:(@fastmath +)) == :(Base.FastMath.add_fast)
+@test macroexpand(:(@fastmath min(1))) == :(Base.FastMath.min_fast(1))
+@test macroexpand(:(@fastmath min)) == :(Base.FastMath.min_fast)
+@test macroexpand(:(@fastmath x.min)) == :(x.min)
+
 # basic arithmetic
 
 const one32 = one(Float32)


### PR DESCRIPTION
Skip `quote` expresstion to handle e.g. `@fastmath x.min` without expanding `min` to `min_fast`.
Clean up code (remove parentheses, use `===` instead of `==`).
Closes #14318.
