### PR TITLE
fix copy and transpose on triangular views (#14317)

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -35,7 +35,7 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
             return $t(B)
         end
 
-        copy{T,S}(A::$t{T,S}) = $t{T,S}(copy(A.data))
+        copy(A::$t) = $t(copy(A.data))
 
         big(A::$t) = $t(big(A.data))
 
@@ -257,23 +257,23 @@ function tril!(A::UnitLowerTriangular,k::Integer=0)
     return tril!(LowerTriangular(A.data),k)
 end
 
-transpose{T,S}(A::LowerTriangular{T,S}) = UpperTriangular{T, S}(transpose(A.data))
-transpose{T,S}(A::UnitLowerTriangular{T,S}) = UnitUpperTriangular{T, S}(transpose(A.data))
-transpose{T,S}(A::UpperTriangular{T,S}) = LowerTriangular{T, S}(transpose(A.data))
-transpose{T,S}(A::UnitUpperTriangular{T,S}) = UnitLowerTriangular{T, S}(transpose(A.data))
-ctranspose{T,S}(A::LowerTriangular{T,S}) = UpperTriangular{T, S}(ctranspose(A.data))
-ctranspose{T,S}(A::UnitLowerTriangular{T,S}) = UnitUpperTriangular{T, S}(ctranspose(A.data))
-ctranspose{T,S}(A::UpperTriangular{T,S}) = LowerTriangular{T, S}(ctranspose(A.data))
-ctranspose{T,S}(A::UnitUpperTriangular{T,S}) = UnitLowerTriangular{T, S}(ctranspose(A.data))
+transpose(A::LowerTriangular) = UpperTriangular(transpose(A.data))
+transpose(A::UnitLowerTriangular) = UnitUpperTriangular(transpose(A.data))
+transpose(A::UpperTriangular) = LowerTriangular(transpose(A.data))
+transpose(A::UnitUpperTriangular) = UnitLowerTriangular(transpose(A.data))
+ctranspose(A::LowerTriangular) = UpperTriangular(ctranspose(A.data))
+ctranspose(A::UnitLowerTriangular) = UnitUpperTriangular(ctranspose(A.data))
+ctranspose(A::UpperTriangular) = LowerTriangular(ctranspose(A.data))
+ctranspose(A::UnitUpperTriangular) = UnitLowerTriangular(ctranspose(A.data))
 
-transpose!{T,S}(A::LowerTriangular{T,S}) = UpperTriangular{T, S}(copytri!(A.data, 'L'))
-transpose!{T,S}(A::UnitLowerTriangular{T,S}) = UnitUpperTriangular{T, S}(copytri!(A.data, 'L'))
-transpose!{T,S}(A::UpperTriangular{T,S}) = LowerTriangular{T, S}(copytri!(A.data, 'U'))
-transpose!{T,S}(A::UnitUpperTriangular{T,S}) = UnitLowerTriangular{T, S}(copytri!(A.data, 'U'))
-ctranspose!{T,S}(A::LowerTriangular{T,S}) = UpperTriangular{T, S}(copytri!(A.data, 'L' , true))
-ctranspose!{T,S}(A::UnitLowerTriangular{T,S}) = UnitUpperTriangular{T, S}(copytri!(A.data, 'L' , true))
-ctranspose!{T,S}(A::UpperTriangular{T,S}) = LowerTriangular{T, S}(copytri!(A.data, 'U' , true))
-ctranspose!{T,S}(A::UnitUpperTriangular{T,S}) = UnitLowerTriangular{T, S}(copytri!(A.data, 'U' , true))
+transpose!(A::LowerTriangular) = UpperTriangular(copytri!(A.data, 'L'))
+transpose!(A::UnitLowerTriangular) = UnitUpperTriangular(copytri!(A.data, 'L'))
+transpose!(A::UpperTriangular) = LowerTriangular(copytri!(A.data, 'U'))
+transpose!(A::UnitUpperTriangular) = UnitLowerTriangular(copytri!(A.data, 'U'))
+ctranspose!(A::LowerTriangular) = UpperTriangular(copytri!(A.data, 'L' , true))
+ctranspose!(A::UnitLowerTriangular) = UnitUpperTriangular(copytri!(A.data, 'L' , true))
+ctranspose!(A::UpperTriangular) = LowerTriangular(copytri!(A.data, 'U' , true))
+ctranspose!(A::UnitUpperTriangular) = UnitLowerTriangular(copytri!(A.data, 'U' , true))
 
 diag(A::LowerTriangular) = diag(A.data)
 diag(A::UnitLowerTriangular) = ones(eltype(A), size(A,1))


### PR DESCRIPTION
This pull request implements @andreasnoack's elegant solution to JuliaLang/LinearAlgebra.jl#290 (specifically https://github.com/JuliaLang/LinearAlgebra.jl/issues/290 .) The present version mimics the existing code's style; alternatively, in place of the repeated explicit `[c]transpose[!]` method definitions

``` julia
# Generate [c]transpose[!] methods for triangular types
for isunit in (true, false), islower in (true, false), conj in (true, false)
    origt = symbol(string((isunit ? "Unit" : ""), (islower ? "Lower" : "Upper"), "Triangular"))
    transt = symbol(string((isunit ? "Unit" : ""), (islower ? "Upper" : "Lower"), "Triangular"))
    opop = symbol(string((conj ? "c" : ""), "transpose")) # opop = out-of-place op
    ipop = symbol(string((conj ? "c" : ""), "transpose!")) # ipop = in-place op
    @eval ($opop)(A::$origt) = ($transt)(($opop)(A.data))
    @eval ($ipop)(A::$origt) = ($transt)(copytri!(A.data, $(islower ? :('L') : :('U')), $(conj ? :(true) : :(false))))
end
```

also works. The code reduction is minor though, and which form is simpler/clearer is arguable/a matter of taste, so I would be happy with either form; let me know which you prefer. (Any thoughts on a better name than `islower` in that snippet? Though the shadowing in the loop is harmless, I would prefer to avoid it given a better name. Or is that sort of shadowing acceptable in Julia?) Thanks, and best!
