### PR TITLE
Type-stability fixes for matmul

### DIFF
--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -59,6 +59,9 @@ A = rand(1:20, 5, 5) .- 10
 B = rand(1:20, 5, 5) .- 10
 @test At_mul_B(A, B) == A'*B
 @test A_mul_Bt(A, B) == A*B'
+v = [1,2]
+C = Array(Int, 2, 2)
+@test @inferred(A_mul_Bc!(C, v, v)) == [1 2; 2 4]
 
 # Preallocated
 C = Array(Int, size(A, 1), size(B, 2))


### PR DESCRIPTION
This one is quite funny: we have

``` jl
julia> v = [1,2]
2-element Array{Int64,1}:                                                                                                                                                          
 1                                                                                                                                                                                 
 2

julia> using Base.Test

julia> @inferred(v*v')
2x2 Array{Int64,2}:
 1  2
 2  4
```

but also

``` jl
julia> C = Array(Int, 2, 2)
2x2 Array{Int64,2}:
 140643182283632  140634494951504
 140634541475488                0

julia> @inferred(A_mul_Bc!(C, v, v))
ERROR: return type Array{Int64,2} does not match inferred return type Any
 in error at ./error.jl:21
```

The reason turned out to be a bit subtle:

``` jl
julia> Base.LinAlg.matmul2x2!(C, 'N', 'C', v, v)
ERROR: MethodError: `matmul2x2!` has no method matching matmul2x2!(::Array{Int64,2}, ::Char, ::Char, ::Array{Int64,1}, ::Array{Int64,1})
Closest candidates are:
  matmul2x2!{T,S,R}(::AbstractArray{R,2}, ::Any, ::Any, ::AbstractArray{T,2}, ::AbstractArray{S,2})
```

It seems that when no method exists, inference is returning `Any` rather than `Union{}` for the return type?

So the underlying cause is the branch for 2x2 or 3x3 matrices, the fact that the corresponding functions are defined only for `AbstractMatrix` inputs, and the fact that `generic_matmatmul!` can take inputs which are not `AbstractMatrix` objects.

Also fixes another type instability in `copy!` (it was returning `Union{Bool,typeof(B)}` which probably has no performance impact, but we might as well fix it.
