### PR TITLE
Make sure the argument to `cache_method` is always rooted

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1038,7 +1038,10 @@ static jl_function_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt,
                 JL_GC_POP();
                 return func;
             }
-            jl_function_t *res = cache_method(mt, tt, func, m->sig, jl_emptysvec, m->isstaged);
+            // make sure the argument is rooted in `cache_method`
+            // in case another thread changed it.
+            newsig = m->sig;
+            jl_function_t *res = cache_method(mt, tt, func, newsig, jl_emptysvec, m->isstaged);
             JL_GC_POP();
             return res;
         }


### PR DESCRIPTION
Even if another thread updated `m->sig`.

This causes a corruption with multi threading. Reproduced using [my collection of anti-patterns for threading](https://github.com/yuyichao/explore/blob/f42ccf5453cf2475362fa949be6c22f9c467bf1f/julia/gc_thread/gc-thread.jl)

The patch fixes the SegFault (or GC assertion) but I'm not sure if this is what I should do. The method list update doesn't have any lock and IIUC (from `jl_method_list_insert`), nothing worse happens only because the method I'm redefining doesn't have any type parameters. If it does, I can imagine the race condition where one thread reads `sig` and `tvar` from a method list while another thread overrides it to incompatible values.

@JeffBezanson 
