### PR TITLE
Fixing original issue #14331 by cleaning up print_fixed_point

### DIFF
--- a/test/printf.jl
+++ b/test/printf.jl
@@ -73,6 +73,11 @@ end
 @test( @sprintf( "%.6g", big"12340000.0" ) == "1.234e+07")
 @test( @sprintf( "%#.6g", big"12340000.0") == "1.23400e+07")
 
+# %g regression gh #14331
+@test( @sprintf( "%.5g", 42) == "42")
+@test( @sprintf( "%#.2g", 42) == "42.")
+@test( @sprintf( "%#.5g", 42) == "42.000")
+
 # hex float
 @test (@sprintf "%a" 1.5) == "0x1.8p+0"
 @test (@sprintf "%#.0a" 1.5) == "0x2.p+0"


### PR DESCRIPTION
Fixes the original issue found in #14331.

Also adding gen documentation `gen_d` and correcting `G` to correctly display `E` (as opposed to `e`).
