### PR TITLE
Don't locally and incorrectly declare jl_error

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -7,7 +7,7 @@
 
 extern "C" {
 #include "APInt-C.h"
-JL_DLLEXPORT void jl_error(const char *str);
+#include "julia.h"
 }
 
 using namespace llvm;


### PR DESCRIPTION
The local declaration misses the JL_NORETURN attribute.  Trying to add this attribute to the declaration results in requiring the actual definition of JL_NORETURN.

This then raises the question why the correct declaration from julia.h isn't used.  I found no reason.  The code compiles and tests OK as before after I added the #include and removed the local declaration.
