### PR TITLE
Framework for uninitialized variables

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -7,7 +7,7 @@
 
 extern "C" {
 #include "APInt-C.h"
-JL_DLLEXPORT void jl_error(const char *str);
+#include "julia.h"
 }
 
 using namespace llvm;

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -7,7 +7,7 @@
 
 extern "C" {
 #include "APInt-C.h"
-#include "julia.h"
+JL_DLLEXPORT void jl_error(const char *str);
 }
 
 using namespace llvm;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4701,6 +4701,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
         ctx.debug_enabled = false;
         do_coverage = false;
         do_malloc_log = false;
+	JL_MARK_INITIALIZED(SP);
     }
     else {
         // TODO: Fix when moving to new LLVM version

--- a/src/julia.h
+++ b/src/julia.h
@@ -43,13 +43,16 @@ extern "C" {
 #if defined(__GNUC__)
 #  define JL_NORETURN __attribute__ ((noreturn))
 #  define JL_CONST_FUNC __attribute__((const))
+#  define JL_MARK_INITIALIZED(var) asm("" : "=rm" (var))
 #elif defined(_COMPILER_MICROSOFT_)
 #  define JL_NORETURN __declspec(noreturn)
 // This is the closest I can find for __attribute__((const))
 #  define JL_CONST_FUNC __declspec(noalias)
+#  define JL_MARK_INITIALIZED(var) do {} while (0)
 #else
 #  define JL_NORETURN
 #  define JL_CONST_FUNC
+#  define JL_MARK_INITIALIZED(var) do {} while (0)
 #endif
 
 #define container_of(ptr, type, member) \


### PR DESCRIPTION
The compiler often cannot see through the tangle of code to make
100% correct deduction about whether a variable is initialized or
not.  It usually errs on the side of caution and emits a warning.

One example is in codegen.cpp:emit_function where the variable SP
is only ever used when at the same time ctx.debug_enabled is set
to true.  The compiler (at least gcc 5.x) doesn't keep track of
this relationship.

From my experience this kind of problem often appears in large
code bases which is why I'm kind of surprised I couldn't find a
framework to handle them.  This is why I'm proposing the following
change.

Instead of adding one kludgy workaround here a macro JL_MARK_INITIALIZED
is introduced.  When correctly defined (as I do it for gcc) this macro
creates no additional cost in the generated code while preventing the
warning.  Definitions for other compilers should be added appropriately.
