### PR TITLE
Initialize the `jl_array_t::pooled` field early

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -97,6 +97,10 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
         // temporarily initialize to make gc-safe
         a->data = NULL;
         a->how = 2;
+        // Make sure the GC can correctly identify if this is pool allocated
+        // and mark the page accordingly
+        a->pooled = tsz <= GC_MAX_SZCLASS;
+
         data = jl_gc_managed_malloc(tot);
         jl_gc_track_malloced_array(a);
         if (!isunboxed)


### PR DESCRIPTION
So that the GC can correctly mark the page if this is a pooled object.

Reproduced with the [following script](https://github.com/yuyichao/explore/blob/d62ec5717e6f2362bdefb26f1e184bcd0227ee29/julia/gc_thread/ary.jl) with threading. Without `jl_array_t::pooled` correctly set, if the GC happens to be triggered during `jl_gc_managed_malloc` when allocating the buffer for the array, it might not correctly mark the page and sweep the whole page.

This is way more likely to happen with threading since,
1. Without threading, there isn't any allocation between the array and the buffer so the allocation
   counter won't change and it is very unlikely to trigger a GC.
2. Even with the agressive GC I did before, it is still very unlikely that this is the only new object in the
   page given the objects we allocate during initialization and this is not an issue if the page has other
   live objects. With threading each thread has its own clean pool and we can easily trigger it if this is
   the first thing we do after initializing the thread....

``` jl
using Base.Threads

function gen_all_symbols()
    # ary = Vector{Any}(1000_000)
    ary = ccall(:jl_alloc_cell_1d, Ref{Vector{Any}}, (Csize_t,), 1000_000)
    gc(false)
    ary
end

@threads for i in 1:8
    gen_all_symbols()
end
```
