### PR TITLE
Simplify the launch script on os x.

### DIFF
--- a/contrib/mac/app/script
+++ b/contrib/mac/app/script
@@ -1,38 +1,9 @@
 #!/bin/sh
-# Copyright (C) 2007, Thomas Treichl and Paul Kienzle
-# Copyright (C) 2008-2009, Thomas Treichl
-# Copyright (C) 2013, Viral B. Shah (Adapted for Julia from Octave)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; If not, see <http://www.gnu.org/licenses/>.
 
 ROOT="${0%/script}"
-
-# This is the startup procedure written as AppleScript to open a
-# Terminal.app (if the Terminal.app is not already running) and start
-# the Julia program.
-# 20071007 removed: open -a /Applications/Utilities/Terminal.app
 osascript 2>&1>/dev/null <<EOF
-  tell application "System Events" to set ProcessList to get name of every process
   tell application "Terminal"
-    activate
-    if (ProcessList contains "Terminal") or ((count of every window) is less than 1) then
-      tell application "System Events" to tell process "Terminal" to keystroke "n" using command down
-    end if
     do script ("exec '${ROOT}/julia/bin/julia'")
+    activate
   end tell
 EOF
-
-# The app quits immediately after startup, as the app is completely 
-# separate from the actual Julia process. Something it would be neat to
-# change, once we're not just using the .app to tell Terminal what to do


### PR DESCRIPTION
Currently it always opens two terminals for me. This will always
reliably open only one new terminal for Julia in all the different
cases.
