### PR TITLE
always create new cache files in default path when recompiling 

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -540,13 +540,10 @@ end
 function recompile_stale(mod, cachefile)
     path = find_in_path(string(mod), nothing)
     if path === nothing
-        rm(cachefile)
-        error("module $mod not found in current path; removed orphaned cache file $cachefile")
+        error("module $mod not found in current path; you should rm(\"$(escape_string(cachefile))\") to remove the orphaned cache file")
     end
     if stale_cachefile(path, cachefile)
         info("Recompiling stale cache file $cachefile for module $mod.")
-        if !success(create_expr_cache(path, cachefile))
-            error("Failed to precompile $mod to $cachefile")
-        end
+        compilecache(mod)
     end
 end


### PR DESCRIPTION
Fixes #14368, by always calling `Base.compilecache` when creating new cache files (including when recompiling), so that new cache files are always put in the same place (`Base.LOAD_CACHE_PATH[1]`).

Should probably be backported because this is causing problems on JuliaBox.
