### PR TITLE
Use `rm(..., force=true)` instead of ignoring all errors

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -415,7 +415,7 @@ end
 evalfile(path::AbstractString, args::Vector) = evalfile(path, UTF8String[args...])
 
 function create_expr_cache(input::AbstractString, output::AbstractString)
-    try rm(output) end          # Remove file if it exists
+    rm(output, force=true)   # Remove file if it exists
     code_object = """
         while !eof(STDIN)
             eval(Main, deserialize(STDIN))


### PR DESCRIPTION
This only ignores errors due to non-existing files.

See #14248.
