### PR TITLE
Loosen signature on scale

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -38,8 +38,8 @@ function scale!(C::AbstractMatrix, b::AbstractVector, A::AbstractMatrix)
     end
     C
 end
-scale(A::Matrix, b::Vector) = scale!(similar(A, promote_op(MulFun(),eltype(A),eltype(b))), A, b)
-scale(b::Vector, A::Matrix) = scale!(similar(b, promote_op(MulFun(),eltype(b),eltype(A)), size(A)), b, A)
+scale(A::AbstractMatrix, b::AbstractVector) = scale!(similar(A, promote_op(MulFun(),eltype(A),eltype(b))), A, b)
+scale(b::AbstractVector, A::AbstractMatrix) = scale!(similar(b, promote_op(MulFun(),eltype(b),eltype(A)), size(A)), b, A)
 
 # Dot products
 

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -79,6 +79,8 @@ a = reshape([1.:6;], (2,3))
 @test scale(a, [1; 2; 3]) == a.*[1 2 3]
 @test scale([1; 2], a) == a.*[1; 2]
 @test scale(eye(Int, 2), 0.5) == 0.5*eye(2)
+@test scale([1; 2], sub(a, :, :)) == a.*[1; 2]
+@test scale(sub([1; 2], :), a) == a.*[1; 2]
 @test_throws DimensionMismatch scale(a, ones(2))
 @test_throws DimensionMismatch scale(ones(3), a)
 


### PR DESCRIPTION
Trivial, but making it a PR rather than a push so I can apply the backport tag. (The added tests fail on 0.4.)

I also noticed that `Diagonal` has some restrictive methods (e.g., for `*`), but I was a bit concerned that generalizing them would cause ambiguity warnings for every package-defined AbstractMatrix type out there.
