### PR TITLE
RFC: Modified writedlm() to write leading zeros when writing floats #14291

### DIFF
--- a/base/grisu.jl
+++ b/base/grisu.jl
@@ -127,7 +127,7 @@ Base.showcompact(io::IO, x::Float16) = _show(io, x, PRECISION, 5, false)
 
 # normal:
 #   0 < pt < len        ####.####           len+1
-#   pt <= 0             .000########        len-pt+1
+#   pt <= 0             0.000########       len-pt+1
 #   len <= pt (dot)     ########000.        pt+1
 #   len <= pt (no dot)  ########000         pt
 # exponential:
@@ -149,8 +149,8 @@ function _print_shortest(io::IO, x::AbstractFloat, dot::Bool, mode, n::Int)
         write(io, dec(e))
         return
     elseif pt <= 0
-        # => .000########
-        write(io, '.')
+        # => 0.000########
+        write(io, "0.")
         while pt < 0
             write(io, '0')
             pt += 1

--- a/test/datafmt.jl
+++ b/test/datafmt.jl
@@ -93,6 +93,18 @@ let x = [1,2,3], y = [4,5,6], io = IOBuffer()
     @test readcsv(io) == [x y]
 end
 
+let x = [0.1 0.3 0.5], io = IOBuffer()
+    writedlm(io, x, ", ")
+    seek(io, 0)
+    @test readall(io) == "0.1, 0.3, 0.5\n"
+end
+
+let x = [0.1 0.3 0.5], io = IOBuffer()
+    writedlm(io, x, ", ")
+    seek(io, 0)
+    @test readcsv(io) == [0.1 0.3 0.5]
+end
+
 let x = ["abc", "def\"ghi", "jk\nl"], y = [1, ",", "\"quoted\""], io = IOBuffer()
     writedlm(io, zip(x,y), ',')
     seek(io, 0)


### PR DESCRIPTION
writedlm() currently skips leading zeros when writing floats. For example, 0.5 is written as .5. This appears to confuse some programs, which interpret the column as strings by default. issue #14291 

Made changes to _print_shortest(), which is called by print_shortest() that in turn is called by writedlm(). 
PS: Its my first pull request.
