### PR TITLE
Remove unnecessary std::move calls

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6359,9 +6359,9 @@ extern "C" void jl_init_codegen(void)
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_) && !defined(USE_MCJIT)
         .setJITMemoryManager(createJITMemoryManagerWin())
 #elif defined(CUSTOM_MEMORY_MANAGER)
-        .setMCJITMemoryManager(std::move(std::unique_ptr<RTDyldMemoryManager>{createRTDyldMemoryManagerOSX()}))
+        .setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager>{createRTDyldMemoryManagerOSX()})
 #elif defined(USE_ORCMCJIT) // ORCJIT forgets to create one if one isn't created for it
-        .setMCJITMemoryManager(std::move(std::unique_ptr<RTDyldMemoryManager>{new SectionMemoryManager()}))
+        .setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager>{new SectionMemoryManager()})
 #endif
         .setTargetOptions(options)
 #if defined(_OS_LINUX_) && defined(_CPU_X86_64_)


### PR DESCRIPTION
C++11's `std::move` is somewhat dangerous, as it implies that its argument will not be used again by the caller. This can lead to performance improvements when true, and hard-to-find errors if this is not true. C++11 coding styles usually suggest to use `std::move` sparingly, or to use it in the implementation of a class instead of expecting the user of a class to use it.

`std::move` is an explicit cast from an lvalue to an rvalue (technically, from an lvalue reference to an rvalue reference). It is thus never necessary to apply it to an rvalue, since this is a no-op. It is also not beneficial when applied to a type that can be copied cheaply, such as e.g. `int` or regular pointers.

The two cases here apply `std::move` to rvalues. `std::move` does nothing in this case. (I called this "pessimizing" earlier, but I realize I was mistaken about this -- it's just a no-op.)

There is no error in the code, but code containing `std::move` necessarily raises a small warning flag in the reader's mind, so unnecessary calls to `std::move` should be avoided. This is arguably similar to manually calling the destructor of an object just before the closing brace that would implicitly call the destructor -- it's an unnecessary and potentially dangerous complication.
