### PR TITLE
Make flisp calls thread safe and task switch safe

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -37,42 +37,42 @@ static value_t fl_error_sym;
 static value_t fl_null_sym;
 static value_t fl_jlgensym_sym;
 
-static jl_value_t *scm_to_julia(value_t e, int expronly);
-static value_t julia_to_scm(jl_value_t *v);
+static jl_value_t *scm_to_julia(fl_context_t *fl_ctx, value_t e, int expronly);
+static value_t julia_to_scm(fl_context_t *fl_ctx, jl_value_t *v);
 
-value_t fl_defined_julia_global(value_t *args, uint32_t nargs)
+value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     // tells whether a var is defined in and *by* the current module
-    argcount("defined-julia-global", nargs, 1);
-    (void)tosymbol(args[0], "defined-julia-global");
+    argcount(fl_ctx, "defined-julia-global", nargs, 1);
+    (void)tosymbol(fl_ctx, args[0], "defined-julia-global");
     if (jl_current_module == NULL)
-        return FL_F;
-    jl_sym_t *var = jl_symbol(symbol_name(args[0]));
+        return fl_ctx->F;
+    jl_sym_t *var = jl_symbol(symbol_name(fl_ctx, args[0]));
     jl_binding_t *b =
         (jl_binding_t*)ptrhash_get(&jl_current_module->bindings, var);
-    return (b != HT_NOTFOUND && b->owner==jl_current_module) ? FL_T : FL_F;
+    return (b != HT_NOTFOUND && b->owner==jl_current_module) ? fl_ctx->T : fl_ctx->F;
 }
 
-value_t fl_current_julia_module(value_t *args, uint32_t nargs)
+value_t fl_current_julia_module(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    value_t opaque = cvalue(jvtype, sizeof(void*));
+    value_t opaque = cvalue(fl_ctx, jvtype, sizeof(void*));
     *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = (jl_value_t*)jl_current_module;
     return opaque;
 }
 
-value_t fl_invoke_julia_macro(value_t *args, uint32_t nargs)
+value_t fl_invoke_julia_macro(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 1)
-        argcount("invoke-julia-macro", nargs, 1);
+        argcount(fl_ctx, "invoke-julia-macro", nargs, 1);
     jl_function_t *f = NULL;
     jl_value_t **margs;
     JL_GC_PUSHARGS(margs, nargs);
     int i;
-    for(i=1; i < nargs; i++) margs[i] = scm_to_julia(args[i], 1);
+    for(i=1; i < nargs; i++) margs[i] = scm_to_julia(fl_ctx, args[i], 1);
     jl_value_t *result = NULL;
 
     JL_TRY {
-        margs[0] = scm_to_julia(args[0], 1);
+        margs[0] = scm_to_julia(fl_ctx, args[0], 1);
         margs[0] = jl_toplevel_eval(margs[0]);
         f = (jl_function_t*)margs[0];
         assert(jl_is_func(f));
@@ -80,9 +80,9 @@ value_t fl_invoke_julia_macro(value_t *args, uint32_t nargs)
     }
     JL_CATCH {
         JL_GC_POP();
-        value_t opaque = cvalue(jvtype, sizeof(void*));
+        value_t opaque = cvalue(fl_ctx, jvtype, sizeof(void*));
         *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = jl_exception_in_transit;
-        return fl_list2(fl_error_sym, opaque);
+        return fl_list2(fl_ctx, fl_error_sym, opaque);
     }
     // protect result from GC, otherwise it could be freed during future
     // macro expansions, since it will be referenced only from scheme and
@@ -91,25 +91,25 @@ value_t fl_invoke_julia_macro(value_t *args, uint32_t nargs)
     // so the preserved value stack is popped there.
     assert(result != NULL);
     jl_gc_preserve(result);
-    value_t scm = julia_to_scm(result);
-    fl_gc_handle(&scm);
+    value_t scm = julia_to_scm(fl_ctx, result);
+    fl_gc_handle(fl_ctx, &scm);
     value_t scmresult;
     jl_module_t *defmod = jl_gf_mtable(f)->module;
     if (defmod == NULL || defmod == jl_current_module) {
-        scmresult = fl_cons(scm, FL_F);
+        scmresult = fl_cons(fl_ctx, scm, fl_ctx->F);
     }
     else {
-        value_t opaque = cvalue(jvtype, sizeof(void*));
+        value_t opaque = cvalue(fl_ctx, jvtype, sizeof(void*));
         *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = (jl_value_t*)defmod;
-        scmresult = fl_cons(scm, opaque);
+        scmresult = fl_cons(fl_ctx, scm, opaque);
     }
-    fl_free_gc_handles(1);
+    fl_free_gc_handles(fl_ctx, 1);
 
     JL_GC_POP();
     return scmresult;
 }
 
-static builtinspec_t julia_flisp_ast_ext[] = {
+static const builtinspec_t julia_flisp_ast_ext[] = {
     { "defined-julia-global", fl_defined_julia_global },
     { "invoke-julia-macro", fl_invoke_julia_macro },
     { "current-julia-module", fl_current_julia_module },
@@ -118,26 +118,29 @@ static builtinspec_t julia_flisp_ast_ext[] = {
 
 extern int jl_parse_deperror(int err);
 
+static fl_context_t jl_fl_global_ctx;
+
 void jl_init_frontend(void)
 {
-    fl_init(4*1024*1024);
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
 
-    if (fl_load_system_image_str((char*)flisp_system_image,
+    fl_init(fl_ctx, 4*1024*1024);
+
+    if (fl_load_system_image_str(fl_ctx, (char*)flisp_system_image,
                                  sizeof(flisp_system_image))) {
         jl_error("fatal error loading system image");
     }
 
-    fl_applyn(0, symbol_value(symbol("__init_globals")));
+    fl_applyn(fl_ctx, 0, symbol_value(symbol(fl_ctx, "__init_globals")));
 
-    jvtype = define_opaque_type(symbol("julia_value"), sizeof(void*),
-                                NULL, NULL);
+    jvtype = define_opaque_type(fl_ctx->jl_sym, sizeof(void*), NULL, NULL);
 
-    assign_global_builtins(julia_flisp_ast_ext);
-    true_sym = symbol("true");
-    false_sym = symbol("false");
-    fl_error_sym = symbol("error");
-    fl_null_sym = symbol("null");
-    fl_jlgensym_sym = symbol("jlgensym");
+    assign_global_builtins(fl_ctx, julia_flisp_ast_ext);
+    true_sym = symbol(fl_ctx, "true");
+    false_sym = symbol(fl_ctx, "false");
+    fl_error_sym = symbol(fl_ctx, "error");
+    fl_null_sym = symbol(fl_ctx, "null");
+    fl_jlgensym_sym = symbol(fl_ctx, "jlgensym");
 
     // Enable / disable syntax deprecation warnings
     // Disable in imaging mode to avoid i/o errors (#10727)
@@ -151,47 +154,48 @@ void jl_init_frontend(void)
 
 JL_DLLEXPORT void jl_lisp_prompt(void)
 {
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
     if (jvtype==NULL) jl_init_frontend();
-    fl_applyn(1, symbol_value(symbol("__start")), fl_cons(FL_NIL,FL_NIL));
+    fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "__start")), fl_cons(fl_ctx, fl_ctx->NIL,fl_ctx->NIL));
 }
 
-static jl_sym_t *scmsym_to_julia(value_t s)
+static jl_sym_t *scmsym_to_julia(fl_context_t *fl_ctx, value_t s)
 {
     assert(issymbol(s));
-    if (fl_isgensym(s)) {
+    if (fl_isgensym(fl_ctx, s)) {
         static char gsname[16];
         char *n = uint2str(&gsname[1], sizeof(gsname)-1,
                            ((gensym_t*)ptr(s))->id, 10);
         *(--n) = '#';
         return jl_symbol(n);
     }
-    return jl_symbol(symbol_name(s));
+    return jl_symbol(symbol_name(fl_ctx, s));
 }
 
-static jl_value_t *scm_to_julia_(value_t e, int expronly);
+static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int expronly);
 
-static jl_value_t *full_list(value_t e, int expronly)
+static jl_value_t *full_list(fl_context_t *fl_ctx, value_t e, int expronly)
 {
     size_t ln = llength(e);
     if (ln == 0) return jl_an_empty_cell;
     jl_array_t *ar = jl_alloc_cell_1d(ln);
     size_t i=0;
     while (iscons(e)) {
-        jl_cellset(ar, i, scm_to_julia_(car_(e), expronly));
+        jl_cellset(ar, i, scm_to_julia_(fl_ctx, car_(e), expronly));
         e = cdr_(e);
         i++;
     }
     return (jl_value_t*)ar;
 }
 
-static jl_value_t *full_list_of_lists(value_t e, int expronly)
+static jl_value_t *full_list_of_lists(fl_context_t *fl_ctx, value_t e, int expronly)
 {
     size_t ln = llength(e);
     if (ln == 0) return jl_an_empty_cell;
     jl_array_t *ar = jl_alloc_cell_1d(ln);
     size_t i=0;
     while (iscons(e)) {
-        jl_cellset(ar, i, full_list(car_(e),expronly));
+        jl_cellset(ar, i, full_list(fl_ctx, car_(e),expronly));
         e = cdr_(e);
         i++;
     }
@@ -200,12 +204,12 @@ static jl_value_t *full_list_of_lists(value_t e, int expronly)
 
 static jl_value_t *resolve_globals(jl_value_t *expr, jl_lambda_info_t *lam);
 
-static jl_value_t *scm_to_julia(value_t e, int expronly)
+static jl_value_t *scm_to_julia(fl_context_t *fl_ctx, value_t e, int expronly)
 {
     int en = jl_gc_enable(0); // Might GC
     jl_value_t *v;
     JL_TRY {
-        v = scm_to_julia_(e, expronly);
+        v = scm_to_julia_(fl_ctx, e, expronly);
     }
     JL_CATCH {
         // if expression cannot be converted, replace with error expr
@@ -219,9 +223,9 @@ static jl_value_t *scm_to_julia(value_t e, int expronly)
 
 extern int64_t conv_to_int64(void *data, numerictype_t tag);
 
-static jl_value_t *scm_to_julia_(value_t e, int eo)
+static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
 {
-    if (fl_isnumber(e)) {
+    if (fl_isnumber(fl_ctx, e)) {
         int64_t i64;
         if (isfixnum(e)) {
             i64 = numval(e);
@@ -262,15 +266,15 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
             return jl_true;
         else if (e == false_sym)
             return jl_false;
-        return (jl_value_t*)scmsym_to_julia(e);
+        return (jl_value_t*)scmsym_to_julia(fl_ctx, e);
     }
-    if (fl_isstring(e))
+    if (fl_isstring(fl_ctx, e))
         return jl_pchar_to_string((char*)cvalue_data(e), cvalue_len(e));
-    if (e == FL_F)
+    if (e == fl_ctx->F)
         return jl_false;
-    if (e == FL_T)
+    if (e == fl_ctx->T)
         return jl_true;
-    if (e == FL_NIL) {
+    if (e == fl_ctx->NIL) {
         assert(0 && "Jeff doesn't think this is supposed to happen");
     }
     if (iscons(e)) {
@@ -282,7 +286,7 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
         if (hd == fl_null_sym && llength(e) == 1)
             return jl_nothing;
         if (issymbol(hd)) {
-            jl_sym_t *sym = scmsym_to_julia(hd);
+            jl_sym_t *sym = scmsym_to_julia(fl_ctx, hd);
             /* tree node types:
                goto  gotoifnot  label  return
                lambda  call  =  quote
@@ -296,27 +300,27 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                 jl_expr_t *ex = jl_exprn(lambda_sym, n);
                 e = cdr_(e);
                 value_t largs = car_(e);
-                jl_cellset(ex->args, 0, full_list(largs,eo));
+                jl_cellset(ex->args, 0, full_list(fl_ctx, largs,eo));
                 e = cdr_(e);
 
                 value_t ee = car_(e);
                 jl_array_t *vinf = jl_alloc_cell_1d(4);
-                jl_cellset(vinf, 0, full_list_of_lists(car_(ee),eo));
+                jl_cellset(vinf, 0, full_list_of_lists(fl_ctx, car_(ee),eo));
                 ee = cdr_(ee);
-                jl_cellset(vinf, 1, full_list_of_lists(car_(ee),eo));
+                jl_cellset(vinf, 1, full_list_of_lists(fl_ctx, car_(ee),eo));
                 ee = cdr_(ee);
                 jl_cellset(vinf, 2, isfixnum(car_(ee)) ?
                            jl_box_long(numval(car_(ee))) :
-                           full_list(car_(ee),eo));
+                           full_list(fl_ctx, car_(ee),eo));
                 ee = cdr_(ee);
-                jl_cellset(vinf, 3, full_list(car_(ee),eo));
+                jl_cellset(vinf, 3, full_list(fl_ctx, car_(ee),eo));
                 assert(!iscons(cdr_(ee)));
                 jl_cellset(ex->args, 1, vinf);
                 e = cdr_(e);
 
                 for(i=2; i < n; i++) {
                     assert(iscons(e));
-                    jl_cellset(ex->args, i, scm_to_julia_(car_(e), eo));
+                    jl_cellset(ex->args, i, scm_to_julia_(fl_ctx, car_(e), eo));
                     e = cdr_(e);
                 }
                 jl_lambda_info_t *nli = jl_new_lambda_info((jl_value_t*)ex, jl_emptysvec, jl_current_module);
@@ -332,8 +336,8 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                     //       See 'line handling in julia-syntax.scm:keywords-method-def-expr
                     jl_value_t *filename = NULL, *linenum = NULL;
                     JL_GC_PUSH2(&filename, &linenum);
-                    filename = scm_to_julia_(car_(cdr_(e)),0);
-                    linenum  = scm_to_julia_(car_(e),0);
+                    filename = scm_to_julia_(fl_ctx, car_(cdr_(e)),0);
+                    linenum  = scm_to_julia_(fl_ctx, car_(e),0);
                     jl_value_t *temp = jl_new_struct(jl_linenumbernode_type,
                                                      filename, linenum);
                     JL_GC_POP();
@@ -342,31 +346,31 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                 jl_value_t *scmv = NULL, *temp = NULL;
                 JL_GC_PUSH1(&scmv);
                 if (sym == label_sym) {
-                    scmv = scm_to_julia_(car_(e),0);
+                    scmv = scm_to_julia_(fl_ctx, car_(e),0);
                     temp = jl_new_struct(jl_labelnode_type, scmv);
                     JL_GC_POP();
                     return temp;
                 }
                 if (sym == goto_sym) {
-                    scmv = scm_to_julia_(car_(e),0);
+                    scmv = scm_to_julia_(fl_ctx, car_(e),0);
                     temp = jl_new_struct(jl_gotonode_type, scmv);
                     JL_GC_POP();
                     return temp;
                 }
                 if (sym == inert_sym || (sym == quote_sym && (!iscons(car_(e))))) {
-                    scmv = scm_to_julia_(car_(e),0);
+                    scmv = scm_to_julia_(fl_ctx, car_(e),0);
                     temp = jl_new_struct(jl_quotenode_type, scmv);
                     JL_GC_POP();
                     return temp;
                 }
                 if (sym == top_sym) {
-                    scmv = scm_to_julia_(car_(e),0);
+                    scmv = scm_to_julia_(fl_ctx, car_(e),0);
                     temp = jl_new_struct(jl_topnode_type, scmv);
                     JL_GC_POP();
                     return temp;
                 }
                 if (sym == newvar_sym) {
-                    scmv = scm_to_julia_(car_(e),0);
+                    scmv = scm_to_julia_(fl_ctx, car_(e),0);
                     temp = jl_new_struct(jl_newvarnode_type, scmv);
                     JL_GC_POP();
                     return temp;
@@ -382,7 +386,7 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                 ex->args = jl_alloc_cell_1d(0);
             for(i=0; i < n; i++) {
                 assert(iscons(e));
-                jl_cellset(ex->args, i, scm_to_julia_(car_(e),eo));
+                jl_cellset(ex->args, i, scm_to_julia_(fl_ctx, car_(e),eo));
                 e = cdr_(e);
             }
             return (jl_value_t*)ex;
@@ -391,7 +395,7 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
             jl_error("malformed tree");
         }
     }
-    if (iscprim(e) && cp_class((cprim_t*)ptr(e))==wchartype) {
+    if (iscprim(e) && cp_class((cprim_t*)ptr(e)) == fl_ctx->wchartype) {
         jl_value_t *wc =
             jl_box32(jl_char_type, *(int32_t*)cp_data((cprim_t*)ptr(e)));
         return wc;
@@ -404,10 +408,10 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
     return jl_nothing;
 }
 
-static value_t julia_to_scm_(jl_value_t *v);
+static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v);
 static arraylist_t jlgensym_to_flisp;
 
-static value_t julia_to_scm(jl_value_t *v)
+static value_t julia_to_scm(fl_context_t *fl_ctx, jl_value_t *v)
 {
     value_t temp;
     if (jlgensym_to_flisp.len)
@@ -415,98 +419,98 @@ static value_t julia_to_scm(jl_value_t *v)
     else
         arraylist_new(&jlgensym_to_flisp, 0);
     // need try/catch to reset GC handle stack in case of error
-    FL_TRY_EXTERN {
-        temp = julia_to_scm_(v);
+    FL_TRY_EXTERN(fl_ctx) {
+        temp = julia_to_scm_(fl_ctx, v);
     }
-    FL_CATCH_EXTERN {
-        temp = fl_list2(fl_error_sym, cvalue_static_cstring("expression too large"));
+    FL_CATCH_EXTERN(fl_ctx) {
+        temp = fl_list2(fl_ctx, fl_error_sym, cvalue_static_cstring(fl_ctx, "expression too large"));
     }
     arraylist_free(&jlgensym_to_flisp);
     return temp;
 }
 
-static void array_to_list(jl_array_t *a, value_t *pv)
+static void array_to_list(fl_context_t *fl_ctx, jl_array_t *a, value_t *pv)
 {
     if (jl_array_len(a) > 300000)
-        lerror(OutOfMemoryError, "expression too large");
+        lerror(fl_ctx, fl_ctx->OutOfMemoryError, "expression too large");
     value_t temp;
     for(long i=jl_array_len(a)-1; i >= 0; i--) {
-        *pv = fl_cons(FL_NIL, *pv);
-        temp = julia_to_scm_(jl_cellref(a,i));
+        *pv = fl_cons(fl_ctx, fl_ctx->NIL, *pv);
+        temp = julia_to_scm_(fl_ctx, jl_cellref(a,i));
         // note: must be separate statement
         car_(*pv) = temp;
     }
 }
 
-static value_t julia_to_list2(jl_value_t *a, jl_value_t *b)
+static value_t julia_to_list2(fl_context_t *fl_ctx, jl_value_t *a, jl_value_t *b)
 {
-    value_t sa = julia_to_scm_(a);
-    fl_gc_handle(&sa);
-    value_t sb = julia_to_scm_(b);
-    value_t l = fl_list2(sa, sb);
-    fl_free_gc_handles(1);
+    value_t sa = julia_to_scm_(fl_ctx, a);
+    fl_gc_handle(fl_ctx, &sa);
+    value_t sb = julia_to_scm_(fl_ctx, b);
+    value_t l = fl_list2(fl_ctx, sa, sb);
+    fl_free_gc_handles(fl_ctx, 1);
     return l;
 }
 
-static value_t julia_to_scm_(jl_value_t *v)
+static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v)
 {
     if (jl_is_symbol(v))
-        return symbol(jl_symbol_name((jl_sym_t*)v));
+        return symbol(fl_ctx, jl_symbol_name((jl_sym_t*)v));
     if (jl_is_gensym(v)) {
         size_t idx = ((jl_gensym_t*)v)->id;
         size_t i;
         for (i = 0; i < jlgensym_to_flisp.len; i+=2) {
             if ((ssize_t)jlgensym_to_flisp.items[i] == idx)
-                return fl_list2(fl_jlgensym_sym, fixnum((size_t)jlgensym_to_flisp.items[i+1]));
+                return fl_list2(fl_ctx, fl_jlgensym_sym, fixnum((size_t)jlgensym_to_flisp.items[i+1]));
         }
         arraylist_push(&jlgensym_to_flisp, (void*)idx);
-        value_t flv = fl_applyn(0, symbol_value(symbol("make-jlgensym")));
+        value_t flv = fl_applyn(fl_ctx, 0, symbol_value(symbol(fl_ctx, "make-jlgensym")));
         assert(iscons(flv) && car_(flv) == fl_jlgensym_sym);
         arraylist_push(&jlgensym_to_flisp, (void*)(size_t)numval(car_(cdr_(flv))));
         return flv;
     }
     if (v == jl_true)
-        return FL_T;
+        return fl_ctx->T;
     if (v == jl_false)
-        return FL_F;
+        return fl_ctx->F;
     if (v == jl_nothing)
-        return fl_cons(fl_null_sym, FL_NIL);
+        return fl_cons(fl_ctx, fl_null_sym, fl_ctx->NIL);
     if (jl_is_expr(v)) {
         jl_expr_t *ex = (jl_expr_t*)v;
-        value_t args = FL_NIL;
-        fl_gc_handle(&args);
-        array_to_list(ex->args, &args);
-        value_t hd = julia_to_scm_((jl_value_t*)ex->head);
-        value_t scmv = fl_cons(hd, args);
-        fl_free_gc_handles(1);
+        value_t args = fl_ctx->NIL;
+        fl_gc_handle(fl_ctx, &args);
+        array_to_list(fl_ctx, ex->args, &args);
+        value_t hd = julia_to_scm_(fl_ctx, (jl_value_t*)ex->head);
+        value_t scmv = fl_cons(fl_ctx, hd, args);
+        fl_free_gc_handles(fl_ctx, 1);
         return scmv;
     }
     if (jl_typeis(v, jl_linenumbernode_type)) {
         // GC Note: jl_fieldref(v, 1) allocates but neither jl_fieldref(v, 0)
         //          or julia_to_list2 should allocate here
-        value_t args = julia_to_list2(jl_fieldref(v,1), jl_fieldref(v,0));
-        fl_gc_handle(&args);
-        value_t hd = julia_to_scm_((jl_value_t*)line_sym);
-        value_t scmv = fl_cons(hd, args);
-        fl_free_gc_handles(1);
+        value_t args = julia_to_list2(fl_ctx, jl_fieldref(v,1), jl_fieldref(v,0));
+        fl_gc_handle(fl_ctx, &args);
+        value_t hd = julia_to_scm_(fl_ctx, (jl_value_t*)line_sym);
+        value_t scmv = fl_cons(fl_ctx, hd, args);
+        fl_free_gc_handles(fl_ctx, 1);
         return scmv;
     }
     // GC Note: jl_fieldref(v, 0) allocate for LabelNode, GotoNode
     //          but we don't need a GC root here because julia_to_list2
     //          shouldn't allocate in this case.
     if (jl_typeis(v, jl_labelnode_type))
-        return julia_to_list2((jl_value_t*)label_sym, jl_fieldref(v,0));
+        return julia_to_list2(fl_ctx, (jl_value_t*)label_sym, jl_fieldref(v,0));
     if (jl_typeis(v, jl_gotonode_type))
-        return julia_to_list2((jl_value_t*)goto_sym, jl_fieldref(v,0));
+        return julia_to_list2(fl_ctx, (jl_value_t*)goto_sym, jl_fieldref(v,0));
     if (jl_typeis(v, jl_quotenode_type))
-        return julia_to_list2((jl_value_t*)inert_sym, jl_fieldref(v,0));
+        return julia_to_list2(fl_ctx, (jl_value_t*)inert_sym, jl_fieldref(v,0));
     if (jl_typeis(v, jl_newvarnode_type))
-        return julia_to_list2((jl_value_t*)newvar_sym, jl_fieldref(v,0));
+        return julia_to_list2(fl_ctx, (jl_value_t*)newvar_sym, jl_fieldref(v,0));
     if (jl_typeis(v, jl_topnode_type))
-        return julia_to_list2((jl_value_t*)top_sym, jl_fieldref(v,0));
+        return julia_to_list2(fl_ctx, (jl_value_t*)top_sym, jl_fieldref(v,0));
     if (jl_is_long(v) && fits_fixnum(jl_unbox_long(v)))
         return fixnum(jl_unbox_long(v));
-    value_t opaque = cvalue(jvtype, sizeof(void*));
+    value_t opaque = cvalue(fl_ctx, jvtype, sizeof(void*));
     *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = v;
     return opaque;
 }
@@ -514,11 +518,12 @@ static value_t julia_to_scm_(jl_value_t *v)
 // this is used to parse a line of repl input
 JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len)
 {
-    value_t s = cvalue_static_cstrn(str, len);
-    value_t e = fl_applyn(1, symbol_value(symbol("jl-parse-string")), s);
-    if (e == FL_EOF)
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    value_t s = cvalue_static_cstrn(fl_ctx, str, len);
+    value_t e = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-parse-string")), s);
+    if (e == fl_ctx->FL_EOF)
         return jl_nothing;
-    return scm_to_julia(e,0);
+    return scm_to_julia(fl_ctx, e, 0);
 }
 
 // this is for parsing one expression out of a string, keeping track of
@@ -526,19 +531,20 @@ JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len)
 JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
                                          int pos0, int greedy)
 {
-    value_t s = cvalue_static_cstrn(str, len);
-    value_t p = fl_applyn(3, symbol_value(symbol("jl-parse-one-string")),
-                          s, fixnum(pos0), greedy?FL_T:FL_F);
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    value_t s = cvalue_static_cstrn(fl_ctx, str, len);
+    value_t p = fl_applyn(fl_ctx, 3, symbol_value(symbol(fl_ctx, "jl-parse-one-string")),
+                          s, fixnum(pos0), greedy?fl_ctx->T:fl_ctx->F);
     jl_value_t *expr=NULL, *pos1=NULL;
     JL_GC_PUSH2(&expr, &pos1);
 
     value_t e = car_(p);
-    if (e == FL_EOF)
+    if (e == fl_ctx->FL_EOF)
         expr = jl_nothing;
     else
-        expr = scm_to_julia(e,0);
+        expr = scm_to_julia(fl_ctx, e, 0);
 
-    pos1 = jl_box_long(tosize(cdr_(p),"parse"));
+    pos1 = jl_box_long(tosize(fl_ctx, cdr_(p),"parse"));
     jl_value_t *result = (jl_value_t*)jl_svec2(expr, pos1);
     JL_GC_POP();
     return result;
@@ -546,38 +552,43 @@ JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
 
 int jl_start_parsing_file(const char *fname)
 {
-    value_t s = cvalue_static_cstring(fname);
-    if (fl_applyn(1, symbol_value(symbol("jl-parse-file")), s) == FL_F)
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    value_t s = cvalue_static_cstring(fl_ctx, fname);
+    if (fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-parse-file")), s) == fl_ctx->F)
         return 1;
     return 0;
 }
 
 void jl_stop_parsing(void)
 {
-    fl_applyn(0, symbol_value(symbol("jl-parser-close-stream")));
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    fl_applyn(fl_ctx, 0, symbol_value(symbol(fl_ctx, "jl-parser-close-stream")));
 }
 
 JL_DLLEXPORT int jl_parse_depwarn(int warn)
 {
-    value_t prev = fl_applyn(1, symbol_value(symbol("jl-parser-depwarn")),
-                             warn ? FL_T : FL_F);
-    return prev == FL_T ? 1 : 0;
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    value_t prev = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-parser-depwarn")),
+                             warn ? fl_ctx->T : fl_ctx->F);
+    return prev == fl_ctx->T ? 1 : 0;
 }
 
 int jl_parse_deperror(int err)
 {
-    value_t prev = fl_applyn(1, symbol_value(symbol("jl-parser-deperror")),
-                             err ? FL_T : FL_F);
-    return prev == FL_T ? 1 : 0;
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    value_t prev = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-parser-deperror")),
+                             err ? fl_ctx->T : fl_ctx->F);
+    return prev == fl_ctx->T ? 1 : 0;
 }
 
 jl_value_t *jl_parse_next(void)
 {
-    value_t c = fl_applyn(0, symbol_value(symbol("jl-parser-next")));
-    if (c == FL_EOF)
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    value_t c = fl_applyn(fl_ctx, 0, symbol_value(symbol(fl_ctx, "jl-parser-next")));
+    if (c == fl_ctx->FL_EOF)
         return NULL;
     if (iscons(c)) {
-        if (cdr_(c) == FL_EOF)
+        if (cdr_(c) == fl_ctx->FL_EOF)
             return NULL;
         value_t a = car_(c);
         if (isfixnum(a)) {
@@ -588,29 +599,31 @@ jl_value_t *jl_parse_next(void)
     }
     // for error, get most recent line number
     if (iscons(c) && car_(c) == fl_error_sym)
-        jl_lineno = numval(fl_applyn(0, symbol_value(symbol("jl-parser-current-lineno"))));
-    return scm_to_julia(c,0);
+        jl_lineno = numval(fl_applyn(fl_ctx, 0, symbol_value(symbol(fl_ctx, "jl-parser-current-lineno"))));
+    return scm_to_julia(fl_ctx, c, 0);
 }
 
 JL_DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
                                              char *filename, size_t namelen)
 {
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
     value_t t, f;
-    t = cvalue_static_cstrn(text, len);
-    fl_gc_handle(&t);
-    f = cvalue_static_cstrn(filename, namelen);
-    fl_applyn(2, symbol_value(symbol("jl-parse-string-stream")), t, f);
-    fl_free_gc_handles(1);
+    t = cvalue_static_cstrn(fl_ctx, text, len);
+    fl_gc_handle(fl_ctx, &t);
+    f = cvalue_static_cstrn(fl_ctx, filename, namelen);
+    fl_applyn(fl_ctx, 2, symbol_value(symbol(fl_ctx, "jl-parse-string-stream")), t, f);
+    fl_free_gc_handles(fl_ctx, 1);
     return jl_parse_eval_all(filename, namelen);
 }
 
 // returns either an expression or a thunk
 JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr)
 {
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
     int np = jl_gc_n_preserved_values();
-    value_t arg = julia_to_scm(expr);
-    value_t e = fl_applyn(1, symbol_value(symbol("jl-expand-to-thunk")), arg);
-    jl_value_t *result = scm_to_julia(e,0);
+    value_t arg = julia_to_scm(fl_ctx, expr);
+    value_t e = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-expand-to-thunk")), arg);
+    jl_value_t *result = scm_to_julia(fl_ctx, e, 0);
     while (jl_gc_n_preserved_values() > np) {
         jl_gc_unpreserve();
     }
@@ -619,11 +632,12 @@ JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr)
 
 JL_DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr)
 {
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
     int np = jl_gc_n_preserved_values();
-    value_t arg = julia_to_scm(expr);
-    value_t e = fl_applyn(1, symbol_value(symbol("jl-macroexpand")), arg);
+    value_t arg = julia_to_scm(fl_ctx, expr);
+    value_t e = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-macroexpand")), arg);
     jl_value_t *result;
-    result = scm_to_julia(e,0);
+    result = scm_to_julia(fl_ctx, e, 0);
     while (jl_gc_n_preserved_values() > np) {
         jl_gc_unpreserve();
     }
@@ -999,12 +1013,14 @@ JL_DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams
 
 JL_DLLEXPORT int jl_is_operator(char *sym)
 {
-    return fl_applyn(1, symbol_value(symbol("operator?")), symbol(sym)) == FL_T;
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    return fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "operator?")), symbol(fl_ctx, sym)) == fl_ctx->T;
 }
 
 JL_DLLEXPORT int jl_operator_precedence(char *sym)
 {
-    return numval(fl_applyn(1, symbol_value(symbol("operator-precedence")), symbol(sym)));
+    fl_context_t *fl_ctx = &jl_fl_global_ctx;
+    return numval(fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "operator-precedence")), symbol(fl_ctx, sym)));
 }
 
 jl_value_t *skip_meta(jl_array_t *body)

--- a/src/flisp/builtins.c
+++ b/src/flisp/builtins.c
@@ -33,11 +33,11 @@ size_t llength(value_t v)
     return n;
 }
 
-static value_t fl_nconc(value_t *args, u_int32_t nargs)
+static value_t fl_nconc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs == 0)
-        return FL_NIL;
-    value_t lst, first=FL_NIL;
+        return fl_ctx->NIL;
+    value_t lst, first=fl_ctx->NIL;
     value_t *pcdr = &first;
     cons_t *c;
     uint32_t i=0;
@@ -51,17 +51,17 @@ static value_t fl_nconc(value_t *args, u_int32_t nargs)
                 c = (cons_t*)ptr(c->cdr);
             pcdr = &c->cdr;
         }
-        else if (lst != FL_NIL) {
-            type_error("nconc", "cons", lst);
+        else if (lst != fl_ctx->NIL) {
+            type_error(fl_ctx, "nconc", "cons", lst);
         }
     }
     *pcdr = lst;
     return first;
 }
 
-static value_t fl_assq(value_t *args, u_int32_t nargs)
+static value_t fl_assq(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("assq", nargs, 2);
+    argcount(fl_ctx, "assq", nargs, 2);
     value_t item = args[0];
     value_t v = args[1];
     value_t bind;
@@ -72,24 +72,24 @@ static value_t fl_assq(value_t *args, u_int32_t nargs)
             return bind;
         v = cdr_(v);
     }
-    return FL_F;
+    return fl_ctx->F;
 }
 
-static value_t fl_memq(value_t *args, u_int32_t nargs)
+static value_t fl_memq(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("memq", nargs, 2);
+    argcount(fl_ctx, "memq", nargs, 2);
     while (iscons(args[1])) {
         cons_t *c = (cons_t*)ptr(args[1]);
         if (c->car == args[0])
             return args[1];
         args[1] = c->cdr;
     }
-    return FL_F;
+    return fl_ctx->F;
 }
 
-static value_t fl_length(value_t *args, u_int32_t nargs)
+static value_t fl_length(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("length", nargs, 1);
+    argcount(fl_ctx, "length", nargs, 1);
     value_t a = args[0];
     cvalue_t *cv;
     if (isvector(a)) {
@@ -97,152 +97,148 @@ static value_t fl_length(value_t *args, u_int32_t nargs)
     }
     else if (iscprim(a)) {
         cv = (cvalue_t*)ptr(a);
-        if (cp_class(cv) == bytetype)
+        if (cp_class(cv) == fl_ctx->bytetype)
             return fixnum(1);
-        else if (cp_class(cv) == wchartype)
+        else if (cp_class(cv) == fl_ctx->wchartype)
             return fixnum(u8_charlen(*(uint32_t*)cp_data((cprim_t*)cv)));
     }
     else if (iscvalue(a)) {
         cv = (cvalue_t*)ptr(a);
         if (cv_class(cv)->eltype != NULL)
-            return size_wrap(cvalue_arraylen(a));
+            return size_wrap(fl_ctx, cvalue_arraylen(a));
     }
-    else if (a == FL_NIL) {
+    else if (a == fl_ctx->NIL) {
         return fixnum(0);
     }
     else if (iscons(a)) {
         return fixnum(llength(a));
     }
-    type_error("length", "sequence", a);
+    type_error(fl_ctx, "length", "sequence", a);
 }
 
-static value_t fl_f_raise(value_t *args, u_int32_t nargs)
+static value_t fl_f_raise(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("raise", nargs, 1);
-    fl_raise(args[0]);
+    argcount(fl_ctx, "raise", nargs, 1);
+    fl_raise(fl_ctx, args[0]);
 }
 
-static value_t fl_exit(value_t *args, u_int32_t nargs)
+static value_t fl_exit(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs > 0)
-        exit(tofixnum(args[0], "exit"));
+        exit(tofixnum(fl_ctx, args[0], "exit"));
     exit(0);
-    return FL_NIL;
+    return fl_ctx->NIL;
 }
 
-static value_t fl_symbol(value_t *args, u_int32_t nargs)
+static value_t fl_symbol(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("symbol", nargs, 1);
-    if (!fl_isstring(args[0]))
-        type_error("symbol", "string", args[0]);
-    return symbol((char*)cvalue_data(args[0]));
+    argcount(fl_ctx, "symbol", nargs, 1);
+    if (!fl_isstring(fl_ctx, args[0]))
+        type_error(fl_ctx, "symbol", "string", args[0]);
+    return symbol(fl_ctx, (char*)cvalue_data(args[0]));
 }
 
-static value_t fl_keywordp(value_t *args, u_int32_t nargs)
+static value_t fl_keywordp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("keyword?", nargs, 1);
+    argcount(fl_ctx, "keyword?", nargs, 1);
     return (issymbol(args[0]) &&
-            iskeyword((symbol_t*)ptr(args[0]))) ? FL_T : FL_F;
+            iskeyword((symbol_t*)ptr(args[0]))) ? fl_ctx->T : fl_ctx->F;
 }
 
-static value_t fl_top_level_value(value_t *args, u_int32_t nargs)
+static value_t fl_top_level_value(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("top-level-value", nargs, 1);
-    symbol_t *sym = tosymbol(args[0], "top-level-value");
+    argcount(fl_ctx, "top-level-value", nargs, 1);
+    symbol_t *sym = tosymbol(fl_ctx, args[0], "top-level-value");
     if (sym->binding == UNBOUND)
-        fl_raise(fl_list2(UnboundError, args[0]));
+        fl_raise(fl_ctx, fl_list2(fl_ctx, fl_ctx->UnboundError, args[0]));
     return sym->binding;
 }
 
-static value_t fl_set_top_level_value(value_t *args, u_int32_t nargs)
+static value_t fl_set_top_level_value(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("set-top-level-value!", nargs, 2);
-    symbol_t *sym = tosymbol(args[0], "set-top-level-value!");
+    argcount(fl_ctx, "set-top-level-value!", nargs, 2);
+    symbol_t *sym = tosymbol(fl_ctx, args[0], "set-top-level-value!");
     if (!isconstant(sym))
         sym->binding = args[1];
     return args[1];
 }
 
-static void global_env_list(symbol_t *root, value_t *pv)
+static void global_env_list(fl_context_t *fl_ctx, symbol_t *root, value_t *pv)
 {
     while (root != NULL) {
         if (root->name[0] != ':' && (root->binding != UNBOUND)) {
-            *pv = fl_cons(tagptr(root,TAG_SYM), *pv);
+            *pv = fl_cons(fl_ctx, tagptr(root,TAG_SYM), *pv);
         }
-        global_env_list(root->left, pv);
+        global_env_list(fl_ctx, root->left, pv);
         root = root->right;
     }
 }
 
-extern symbol_t *symtab;
-
-value_t fl_global_env(value_t *args, u_int32_t nargs)
+value_t fl_global_env(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     (void)args;
-    argcount("environment", nargs, 0);
-    value_t lst = FL_NIL;
-    fl_gc_handle(&lst);
-    global_env_list(symtab, &lst);
-    fl_free_gc_handles(1);
+    argcount(fl_ctx, "environment", nargs, 0);
+    value_t lst = fl_ctx->NIL;
+    fl_gc_handle(fl_ctx, &lst);
+    global_env_list(fl_ctx, fl_ctx->symtab, &lst);
+    fl_free_gc_handles(fl_ctx, 1);
     return lst;
 }
 
-extern value_t QUOTE;
-
-static value_t fl_constantp(value_t *args, u_int32_t nargs)
+static value_t fl_constantp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("constant?", nargs, 1);
+    argcount(fl_ctx, "constant?", nargs, 1);
     if (issymbol(args[0]))
-        return (isconstant((symbol_t*)ptr(args[0])) ? FL_T : FL_F);
+        return (isconstant((symbol_t*)ptr(args[0])) ? fl_ctx->T : fl_ctx->F);
     if (iscons(args[0])) {
-        if (car_(args[0]) == QUOTE)
-            return FL_T;
-        return FL_F;
+        if (car_(args[0]) == fl_ctx->QUOTE)
+            return fl_ctx->T;
+        return fl_ctx->F;
     }
-    return FL_T;
+    return fl_ctx->T;
 }
 
-static value_t fl_integer_valuedp(value_t *args, u_int32_t nargs)
+static value_t fl_integer_valuedp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("integer-valued?", nargs, 1);
+    argcount(fl_ctx, "integer-valued?", nargs, 1);
     value_t v = args[0];
     if (isfixnum(v)) {
-        return FL_T;
+        return fl_ctx->T;
     }
     else if (iscprim(v)) {
         numerictype_t nt = cp_numtype((cprim_t*)ptr(v));
         if (nt < T_FLOAT)
-            return FL_T;
+            return fl_ctx->T;
         void *data = cp_data((cprim_t*)ptr(v));
         if (nt == T_FLOAT) {
             float f = *(float*)data;
             if (f < 0) f = -f;
             if (f <= FLT_MAXINT && (float)(int32_t)f == f)
-                return FL_T;
+                return fl_ctx->T;
         }
         else {
             assert(nt == T_DOUBLE);
             double d = *(double*)data;
             if (d < 0) d = -d;
             if (d <= DBL_MAXINT && (double)(int64_t)d == d)
-                return FL_T;
+                return fl_ctx->T;
         }
     }
-    return FL_F;
+    return fl_ctx->F;
 }
 
-static value_t fl_integerp(value_t *args, u_int32_t nargs)
+static value_t fl_integerp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("integer?", nargs, 1);
+    argcount(fl_ctx, "integer?", nargs, 1);
     value_t v = args[0];
     return (isfixnum(v) ||
             (iscprim(v) && cp_numtype((cprim_t*)ptr(v)) < T_FLOAT)) ?
-        FL_T : FL_F;
+        fl_ctx->T : fl_ctx->F;
 }
 
-static value_t fl_fixnum(value_t *args, u_int32_t nargs)
+static value_t fl_fixnum(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("fixnum", nargs, 1);
+    argcount(fl_ctx, "fixnum", nargs, 1);
     if (isfixnum(args[0])) {
         return args[0];
     }
@@ -250,12 +246,12 @@ static value_t fl_fixnum(value_t *args, u_int32_t nargs)
         cprim_t *cp = (cprim_t*)ptr(args[0]);
         return fixnum(conv_to_ptrdiff(cp_data(cp), cp_numtype(cp)));
     }
-    type_error("fixnum", "number", args[0]);
+    type_error(fl_ctx, "fixnum", "number", args[0]);
 }
 
-static value_t fl_truncate(value_t *args, u_int32_t nargs)
+static value_t fl_truncate(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("truncate", nargs, 1);
+    argcount(fl_ctx, "truncate", nargs, 1);
     if (isfixnum(args[0]))
         return args[0];
     if (iscprim(args[0])) {
@@ -272,30 +268,30 @@ static value_t fl_truncate(value_t *args, u_int32_t nargs)
         if (d > 0) {
             if (d > (double)U64_MAX)
                 return args[0];
-            return return_from_uint64((uint64_t)d);
+            return return_from_uint64(fl_ctx, (uint64_t)d);
         }
         if (d > (double)S64_MAX || d < (double)S64_MIN)
             return args[0];
-        return return_from_int64((int64_t)d);
+        return return_from_int64(fl_ctx, (int64_t)d);
     }
-    type_error("truncate", "number", args[0]);
+    type_error(fl_ctx, "truncate", "number", args[0]);
 }
 
-static value_t fl_vector_alloc(value_t *args, u_int32_t nargs)
+static value_t fl_vector_alloc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     fixnum_t i;
     value_t f, v;
     if (nargs == 0)
-        lerror(ArgError, "vector.alloc: too few arguments");
-    i = (fixnum_t)tosize(args[0], "vector.alloc");
+        lerror(fl_ctx, fl_ctx->ArgError, "vector.alloc: too few arguments");
+    i = (fixnum_t)tosize(fl_ctx, args[0], "vector.alloc");
     if (i < 0)
-        lerror(ArgError, "vector.alloc: invalid size");
+        lerror(fl_ctx, fl_ctx->ArgError, "vector.alloc: invalid size");
     if (nargs == 2)
         f = args[1];
     else
-        f = FL_UNSPECIFIED;
-    v = alloc_vector((unsigned)i, f==FL_UNSPECIFIED);
-    if (f != FL_UNSPECIFIED) {
+        f = FL_UNSPECIFIED(fl_ctx);
+    v = alloc_vector(fl_ctx, (unsigned)i, f==FL_UNSPECIFIED(fl_ctx));
+    if (f != FL_UNSPECIFIED(fl_ctx)) {
         int k;
         for(k=0; k < i; k++)
             vector_elt(v,k) = f;
@@ -303,60 +299,60 @@ static value_t fl_vector_alloc(value_t *args, u_int32_t nargs)
     return v;
 }
 
-static value_t fl_time_now(value_t *args, u_int32_t nargs)
+static value_t fl_time_now(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("time.now", nargs, 0);
+    argcount(fl_ctx, "time.now", nargs, 0);
     (void)args;
-    return mk_double(jl_clock_now());
+    return mk_double(fl_ctx, jl_clock_now());
 }
 
-static value_t fl_path_cwd(value_t *args, uint32_t nargs)
+static value_t fl_path_cwd(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     int err;
     if (nargs > 1)
-        argcount("path.cwd", nargs, 1);
+        argcount(fl_ctx, "path.cwd", nargs, 1);
     if (nargs == 0) {
         char buf[1024];
         size_t len = sizeof(buf);
         err = uv_cwd(buf, &len);
         if (err != 0)
-            lerrorf(IOError, "path.cwd: could not get cwd: %s", uv_strerror(err));
-        return string_from_cstr(buf);
+            lerrorf(fl_ctx, fl_ctx->IOError, "path.cwd: could not get cwd: %s", uv_strerror(err));
+        return string_from_cstr(fl_ctx, buf);
     }
-    char *ptr = tostring(args[0], "path.cwd");
+    char *ptr = tostring(fl_ctx, args[0], "path.cwd");
     err = uv_chdir(ptr);
     if (err != 0)
-        lerrorf(IOError, "path.cwd: could not cd to %s: %s", ptr, uv_strerror(err));
-    return FL_T;
+        lerrorf(fl_ctx, fl_ctx->IOError, "path.cwd: could not cd to %s: %s", ptr, uv_strerror(err));
+    return fl_ctx->T;
 }
 
-static value_t fl_path_exists(value_t *args, uint32_t nargs)
+static value_t fl_path_exists(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("path.exists?", nargs, 1);
-    char *str = tostring(args[0], "path.exists?");
+    argcount(fl_ctx, "path.exists?", nargs, 1);
+    char *str = tostring(fl_ctx, args[0], "path.exists?");
     struct stat sbuf;
     if (stat(str, &sbuf) == -1)
-        return FL_F;
-    return FL_T;
+        return fl_ctx->F;
+    return fl_ctx->T;
 }
 
-static value_t fl_os_getenv(value_t *args, uint32_t nargs)
+static value_t fl_os_getenv(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("os.getenv", nargs, 1);
-    char *name = tostring(args[0], "os.getenv");
+    argcount(fl_ctx, "os.getenv", nargs, 1);
+    char *name = tostring(fl_ctx, args[0], "os.getenv");
     char *val = getenv(name);
-    if (val == NULL) return FL_F;
+    if (val == NULL) return fl_ctx->F;
     if (*val == 0)
-        return symbol_value(emptystringsym);
-    return cvalue_static_cstring(val);
+        return symbol_value(fl_ctx->emptystringsym);
+    return cvalue_static_cstring(fl_ctx, val);
 }
 
-static value_t fl_os_setenv(value_t *args, uint32_t nargs)
+static value_t fl_os_setenv(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("os.setenv", nargs, 2);
-    char *name = tostring(args[0], "os.setenv");
+    argcount(fl_ctx, "os.setenv", nargs, 2);
+    char *name = tostring(fl_ctx, args[0], "os.setenv");
     int result;
-    if (args[1] == FL_F) {
+    if (args[1] == fl_ctx->F) {
 #ifdef _OS_LINUX_
         result = unsetenv(name);
 #elif defined(_OS_WINDOWS_)
@@ -368,7 +364,7 @@ static value_t fl_os_setenv(value_t *args, uint32_t nargs)
 
     }
     else {
-        char *val = tostring(args[1], "os.setenv");
+        char *val = tostring(fl_ctx, args[1], "os.setenv");
 #if defined (_OS_WINDOWS_)
         result = SetEnvironmentVariable(name,val);
 #else
@@ -376,15 +372,15 @@ static value_t fl_os_setenv(value_t *args, uint32_t nargs)
 #endif
     }
     if (result != 0)
-        lerror(ArgError, "os.setenv: invalid environment variable");
-    return FL_T;
+        lerror(fl_ctx, fl_ctx->ArgError, "os.setenv: invalid environment variable");
+    return fl_ctx->T;
 }
 
-extern void stringfuncs_init(void);
-extern void table_init(void);
-extern void iostream_init(void);
+extern void stringfuncs_init(fl_context_t *fl_ctx);
+extern void table_init(fl_context_t *fl_ctx);
+extern void iostream_init(fl_context_t *fl_ctx);
 
-static builtinspec_t builtin_info[] = {
+static const builtinspec_t builtin_info[] = {
     { "environment", fl_global_env },
     { "constant?", fl_constantp },
     { "top-level-value", fl_top_level_value },
@@ -416,12 +412,12 @@ static builtinspec_t builtin_info[] = {
     { NULL, NULL }
 };
 
-void builtins_init(void)
+void builtins_init(fl_context_t *fl_ctx)
 {
-    assign_global_builtins(builtin_info);
-    stringfuncs_init();
-    table_init();
-    iostream_init();
+    assign_global_builtins(fl_ctx, builtin_info);
+    stringfuncs_init(fl_ctx);
+    table_init(fl_ctx);
+    iostream_init(fl_ctx);
 }
 
 #ifdef __cplusplus

--- a/src/flisp/cvalues.c
+++ b/src/flisp/cvalues.c
@@ -4,63 +4,45 @@
 #define NWORDS(sz) (((sz)+3)>>2)
 #endif
 
-static int ALIGN2, ALIGN4, ALIGN8, ALIGNPTR;
+struct prim_int16{ char a; int16_t i; };
+struct prim_int32{ char a; int32_t i; };
+struct prim_int64{ char a; int64_t i; };
+struct prim_ptr{ char a;  void   *i; };
 
-value_t int8sym, uint8sym, int16sym, uint16sym, int32sym, uint32sym;
-value_t int64sym, uint64sym;
-value_t ptrdiffsym, sizesym, bytesym, wcharsym;
-value_t floatsym, doublesym;
-value_t gftypesym, stringtypesym, wcstringtypesym;
-value_t emptystringsym;
+// compute struct field alignment required for primitives
+static const int ALIGN2   = sizeof(struct prim_int16) - 2;
+static const int ALIGN4   = sizeof(struct prim_int32) - 4;
+static const int ALIGN8   = sizeof(struct prim_int64) - 8;
+static const int ALIGNPTR = sizeof(struct prim_ptr) - sizeof(void*);
 
-value_t arraysym, cfunctionsym, voidsym, pointersym;
-
-static htable_t TypeTable;
-static htable_t reverse_dlsym_lookup_table;
-static fltype_t *int8type, *uint8type;
-static fltype_t *int16type, *uint16type;
-static fltype_t *int32type, *uint32type;
-static fltype_t *int64type, *uint64type;
-static fltype_t *ptrdifftype, *sizetype;
-static fltype_t *floattype, *doubletype;
-       fltype_t *bytetype, *wchartype;
-       fltype_t *stringtype, *wcstringtype;
-       fltype_t *builtintype;
-
-static void cvalue_init(fltype_t *type, value_t v, void *dest);
+static void cvalue_init(fl_context_t *fl_ctx, fltype_t *type, value_t v, void *dest);
 
 // cvalues-specific builtins
-value_t cvalue_new(value_t *args, u_int32_t nargs);
-value_t cvalue_sizeof(value_t *args, u_int32_t nargs);
-value_t cvalue_typeof(value_t *args, u_int32_t nargs);
+value_t cvalue_new(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+value_t cvalue_sizeof(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+value_t cvalue_typeof(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
 
 // trigger unconditional GC after this many bytes are allocated
 #define ALLOC_LIMIT_TRIGGER 67108864
 
-static size_t malloc_pressure = 0;
-
-static cvalue_t **Finalizers = NULL;
-static size_t nfinalizers=0;
-static size_t maxfinalizers=0;
-
-void add_finalizer(cvalue_t *cv)
+void add_finalizer(fl_context_t *fl_ctx, cvalue_t *cv)
 {
-    if (nfinalizers == maxfinalizers) {
-        size_t nn = (maxfinalizers==0 ? 256 : maxfinalizers*2);
-        cvalue_t **temp = (cvalue_t**)realloc(Finalizers, nn*sizeof(value_t));
+    if (fl_ctx->nfinalizers == fl_ctx->maxfinalizers) {
+        size_t nn = (fl_ctx->maxfinalizers==0 ? 256 : fl_ctx->maxfinalizers*2);
+        cvalue_t **temp = (cvalue_t**)realloc(fl_ctx->Finalizers, nn*sizeof(value_t));
         if (temp == NULL)
-            lerror(OutOfMemoryError, "out of memory");
-        Finalizers = temp;
-        maxfinalizers = nn;
+            lerror(fl_ctx, fl_ctx->OutOfMemoryError, "out of memory");
+        fl_ctx->Finalizers = temp;
+        fl_ctx->maxfinalizers = nn;
     }
-    Finalizers[nfinalizers++] = cv;
+    fl_ctx->Finalizers[fl_ctx->nfinalizers++] = cv;
 }
 
 // remove dead objects from finalization list in-place
-static void sweep_finalizers(void)
+static void sweep_finalizers(fl_context_t *fl_ctx)
 {
-    cvalue_t **lst = Finalizers;
-    size_t n=0, ndel=0, l=nfinalizers;
+    cvalue_t **lst = fl_ctx->Finalizers;
+    size_t n=0, ndel=0, l=fl_ctx->nfinalizers;
     cvalue_t *tmp;
 #define SWAP_sf(a,b) (tmp=a,a=b,b=tmp,1)
     if (l == 0)
@@ -75,7 +57,7 @@ static void sweep_finalizers(void)
         else {
             fltype_t *t = cv_class(tmp);
             if (t->vtable != NULL && t->vtable->finalize != NULL) {
-                t->vtable->finalize(tagptr(tmp, TAG_CVALUE));
+                t->vtable->finalize(fl_ctx, tagptr(tmp, TAG_CVALUE));
             }
             if (!isinlined(tmp) && owned(tmp)) {
 #ifdef DEBUG
@@ -87,75 +69,75 @@ static void sweep_finalizers(void)
         }
     } while ((n < l-ndel) && SWAP_sf(lst[n],lst[n+ndel]));
 
-    nfinalizers -= ndel;
+    fl_ctx->nfinalizers -= ndel;
 #ifdef VERBOSEGC
     if (ndel > 0)
         printf("GC: finalized %d objects\n", ndel);
 #endif
 
-    malloc_pressure = 0;
+    fl_ctx->malloc_pressure = 0;
 }
 
 // compute the size of the metadata object for a cvalue
-static size_t cv_nwords(cvalue_t *cv)
+static size_t cv_nwords(fl_context_t *fl_ctx, cvalue_t *cv)
 {
     if (isinlined(cv)) {
         size_t n = cv_len(cv);
-        if (n==0 || cv_isstr(cv))
+        if (n==0 || cv_isstr(fl_ctx, cv))
             n++;
         return CVALUE_NWORDS - 1 + NWORDS(n);
     }
     return CVALUE_NWORDS;
 }
 
-static void autorelease(cvalue_t *cv)
+static void autorelease(fl_context_t *fl_ctx, cvalue_t *cv)
 {
     cv->type = (fltype_t*)(((uptrint_t)cv->type) | CV_OWNED_BIT);
-    add_finalizer(cv);
+    add_finalizer(fl_ctx, cv);
 }
 
-void cv_autorelease(cvalue_t *cv)
+void cv_autorelease(fl_context_t *fl_ctx, cvalue_t *cv)
 {
-    autorelease(cv);
+    autorelease(fl_ctx, cv);
 }
 
-static value_t cprim(fltype_t *type, size_t sz)
+static value_t cprim(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
 {
-    cprim_t *pcp = (cprim_t*)alloc_words(CPRIM_NWORDS-1+NWORDS(sz));
+    cprim_t *pcp = (cprim_t*)alloc_words(fl_ctx, CPRIM_NWORDS-1+NWORDS(sz));
     pcp->type = type;
     return tagptr(pcp, TAG_CPRIM);
 }
 
-value_t cvalue(fltype_t *type, size_t sz)
+value_t cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
 {
     cvalue_t *pcv;
     int str=0;
 
     if (valid_numtype(type->numtype)) {
-        return cprim(type, sz);
+        return cprim(fl_ctx, type, sz);
     }
-    if (type->eltype == bytetype) {
+    if (type->eltype == fl_ctx->bytetype) {
         if (sz == 0)
-            return symbol_value(emptystringsym);
+            return symbol_value(fl_ctx->emptystringsym);
         sz++;
         str=1;
     }
     if (sz <= MAX_INL_SIZE) {
         size_t nw = CVALUE_NWORDS - 1 + NWORDS(sz) + (sz==0 ? 1 : 0);
-        pcv = (cvalue_t*)alloc_words(nw);
+        pcv = (cvalue_t*)alloc_words(fl_ctx, nw);
         pcv->type = type;
         pcv->data = &pcv->_space[0];
         if (type->vtable != NULL && type->vtable->finalize != NULL)
-            add_finalizer(pcv);
+            add_finalizer(fl_ctx, pcv);
     }
     else {
-        if (malloc_pressure > ALLOC_LIMIT_TRIGGER)
-            gc(0);
-        pcv = (cvalue_t*)alloc_words(CVALUE_NWORDS);
+        if (fl_ctx->malloc_pressure > ALLOC_LIMIT_TRIGGER)
+            gc(fl_ctx, 0);
+        pcv = (cvalue_t*)alloc_words(fl_ctx, CVALUE_NWORDS);
         pcv->type = type;
         pcv->data = malloc(sz);
-        autorelease(pcv);
-        malloc_pressure += sz;
+        autorelease(fl_ctx, pcv);
+        fl_ctx->malloc_pressure += sz;
     }
     if (str) {
         sz--;
@@ -165,10 +147,10 @@ value_t cvalue(fltype_t *type, size_t sz)
     return tagptr(pcv, TAG_CVALUE);
 }
 
-value_t cvalue_from_data(fltype_t *type, void *data, size_t sz)
+value_t cvalue_from_data(fl_context_t *fl_ctx, fltype_t *type, void *data, size_t sz)
 {
     value_t cv;
-    cv = cvalue(type, sz);
+    cv = cvalue(fl_ctx, type, sz);
     memcpy(cptr(cv), data, sz);
     return cv;
 }
@@ -180,17 +162,17 @@ value_t cvalue_from_data(fltype_t *type, void *data, size_t sz)
 // ptr is user-managed; we don't autorelease it unless the
 // user explicitly calls (autorelease ) on the result of this function.
 // 'parent' is an optional cvalue that this pointer is known to point
-// into; NIL if none.
-value_t cvalue_from_ref(fltype_t *type, void *ptr, size_t sz, value_t parent)
+// into; fl_ctx->NIL if none.
+value_t cvalue_from_ref(fl_context_t *fl_ctx, fltype_t *type, void *ptr, size_t sz, value_t parent)
 {
     cvalue_t *pcv;
     value_t cv;
 
-    pcv = (cvalue_t*)alloc_words(CVALUE_NWORDS);
+    pcv = (cvalue_t*)alloc_words(fl_ctx, CVALUE_NWORDS);
     pcv->data = ptr;
     pcv->len = sz;
     pcv->type = type;
-    if (parent != NIL) {
+    if (parent != fl_ctx->NIL) {
         pcv->type = (fltype_t*)(((uptrint_t)pcv->type) | CV_PARENT_BIT);
         pcv->parent = parent;
     }
@@ -198,70 +180,70 @@ value_t cvalue_from_ref(fltype_t *type, void *ptr, size_t sz, value_t parent)
     return cv;
 }
 
-value_t cvalue_string(size_t sz)
+value_t cvalue_string(fl_context_t *fl_ctx, size_t sz)
 {
-    return cvalue(stringtype, sz);
+    return cvalue(fl_ctx, fl_ctx->stringtype, sz);
 }
 
-value_t cvalue_static_cstrn(const char *str, size_t n)
+value_t cvalue_static_cstrn(fl_context_t *fl_ctx, const char *str, size_t n)
 {
-    return cvalue_from_ref(stringtype, (char*)str, n, NIL);
+    return cvalue_from_ref(fl_ctx, fl_ctx->stringtype, (char*)str, n, fl_ctx->NIL);
 }
 
-value_t cvalue_static_cstring(const char *str)
+value_t cvalue_static_cstring(fl_context_t *fl_ctx, const char *str)
 {
-    return cvalue_static_cstrn(str, strlen(str));
+    return cvalue_static_cstrn(fl_ctx, str, strlen(str));
 }
 
-value_t string_from_cstrn(char *str, size_t n)
+value_t string_from_cstrn(fl_context_t *fl_ctx, char *str, size_t n)
 {
-    value_t v = cvalue_string(n);
+    value_t v = cvalue_string(fl_ctx, n);
     memcpy(cvalue_data(v), str, n);
     return v;
 }
 
-value_t string_from_cstr(char *str)
+value_t string_from_cstr(fl_context_t *fl_ctx, char *str)
 {
-    return string_from_cstrn(str, strlen(str));
+    return string_from_cstrn(fl_ctx, str, strlen(str));
 }
 
-int fl_isstring(value_t v)
+int fl_isstring(fl_context_t *fl_ctx, value_t v)
 {
-    return (iscvalue(v) && cv_isstr((cvalue_t*)ptr(v)));
+    return (iscvalue(v) && cv_isstr(fl_ctx, (cvalue_t*)ptr(v)));
 }
 
 // convert to malloc representation (fixed address)
-void cv_pin(cvalue_t *cv)
+void cv_pin(fl_context_t *fl_ctx, cvalue_t *cv)
 {
     if (!isinlined(cv))
         return;
     size_t sz = cv_len(cv);
-    if (cv_isstr(cv)) sz++;
+    if (cv_isstr(fl_ctx, cv)) sz++;
     void *data = malloc(sz);
     memcpy(data, cv_data(cv), sz);
     cv->data = data;
-    autorelease(cv);
+    autorelease(fl_ctx, cv);
 }
 
-#define num_init(ctype, cnvt, tag)                              \
-static int cvalue_##ctype##_init(fltype_t *type, value_t arg,   \
-                                 void *dest)                    \
-{                                                               \
-    fl_##ctype##_t n=0;                                         \
-    (void)type;                                                 \
-    if (isfixnum(arg)) {                                        \
-        n = numval(arg);                                        \
-    }                                                           \
-    else if (iscprim(arg)) {                                    \
-        cprim_t *cp = (cprim_t*)ptr(arg);                       \
-        void *p = cp_data(cp);                                  \
-        n = (fl_##ctype##_t)conv_to_##cnvt(p, cp_numtype(cp));  \
-    }                                                           \
-    else {                                                      \
-        return 1;                                               \
-    }                                                           \
-    *((fl_##ctype##_t*)dest) = n;                               \
-    return 0;                                                   \
+#define num_init(ctype, cnvt, tag)                                     \
+static int cvalue_##ctype##_init(fl_context_t *fl_ctx, fltype_t *type, \
+                                 value_t arg, void *dest)              \
+{                                                                      \
+    fl_##ctype##_t n=0;                                                \
+    (void)type;                                                        \
+    if (isfixnum(arg)) {                                               \
+        n = numval(arg);                                               \
+    }                                                                  \
+    else if (iscprim(arg)) {                                           \
+        cprim_t *cp = (cprim_t*)ptr(arg);                              \
+        void *p = cp_data(cp);                                         \
+        n = (fl_##ctype##_t)conv_to_##cnvt(p, cp_numtype(cp));         \
+    }                                                                  \
+    else {                                                             \
+        return 1;                                                      \
+    }                                                                  \
+    *((fl_##ctype##_t*)dest) = n;                                      \
+    return 0;                                                          \
 }
 num_init(int8, int32, T_INT8)
 num_init(uint8, uint32, T_UINT8)
@@ -275,25 +257,25 @@ num_init(float, double, T_FLOAT)
 num_init(double, double, T_DOUBLE)
 
 #define num_ctor_init(typenam, ctype, tag)                              \
-value_t cvalue_##typenam(value_t *args, u_int32_t nargs)                \
+value_t cvalue_##typenam(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs) \
 {                                                                       \
-    if (nargs==0) { PUSH(fixnum(0)); args = &Stack[SP-1]; }             \
-    value_t cp = cprim(typenam##type, sizeof(fl_##ctype##_t));          \
-    if (cvalue_##ctype##_init(typenam##type,                            \
+    if (nargs==0) { PUSH(fl_ctx, fixnum(0)); args = &fl_ctx->Stack[fl_ctx->SP-1]; } \
+    value_t cp = cprim(fl_ctx, fl_ctx->typenam##type, sizeof(fl_##ctype##_t)); \
+    if (cvalue_##ctype##_init(fl_ctx, fl_ctx->typenam##type,            \
                               args[0], cp_data((cprim_t*)ptr(cp))))     \
-        type_error(#typenam, "number", args[0]);                        \
+        type_error(fl_ctx, #typenam, "number", args[0]);                \
     return cp;                                                          \
 }
 
 #define num_ctor_ctor(typenam, ctype, tag)                              \
-value_t mk_##typenam(fl_##ctype##_t n)                                  \
+value_t mk_##typenam(fl_context_t *fl_ctx, fl_##ctype##_t n)            \
 {                                                                       \
-    value_t cp = cprim(typenam##type, sizeof(fl_##ctype##_t));          \
+    value_t cp = cprim(fl_ctx, fl_ctx->typenam##type, sizeof(fl_##ctype##_t)); \
     *(fl_##ctype##_t*)cp_data((cprim_t*)ptr(cp)) = n;                   \
     return cp;                                                          \
 }
 
-#define num_ctor(typenam, ctype, tag) \
+#define num_ctor(typenam, ctype, tag)  \
     num_ctor_init(typenam, ctype, tag) \
     num_ctor_ctor(typenam, ctype, tag)
 
@@ -317,15 +299,15 @@ num_ctor(size, uint32, T_UINT32)
 num_ctor(float, float, T_FLOAT)
 num_ctor(double, double, T_DOUBLE)
 
-value_t size_wrap(size_t sz)
+value_t size_wrap(fl_context_t *fl_ctx, size_t sz)
 {
     if (fits_fixnum(sz))
         return fixnum(sz);
     assert(sizeof(void*) == sizeof(size_t));
-    return mk_size(sz);
+    return mk_size(fl_ctx, sz);
 }
 
-size_t tosize(value_t n, char *fname)
+size_t tosize(fl_context_t *fl_ctx, value_t n, char *fname)
 {
     if (isfixnum(n))
         return numval(n);
@@ -333,7 +315,7 @@ size_t tosize(value_t n, char *fname)
         cprim_t *cp = (cprim_t*)ptr(n);
         return conv_to_size(cp_data(cp), cp_numtype(cp));
     }
-    type_error(fname, "number", n);
+    type_error(fl_ctx, fname, "number", n);
     return 0;
 }
 
@@ -342,54 +324,54 @@ static int isarray(value_t v)
     return iscvalue(v) && cv_class((cvalue_t*)ptr(v))->eltype != NULL;
 }
 
-static size_t predict_arraylen(value_t arg)
+static size_t predict_arraylen(fl_context_t *fl_ctx, value_t arg)
 {
     if (isvector(arg))
         return vector_size(arg);
     else if (iscons(arg))
         return llength(arg);
-    else if (arg == NIL)
+    else if (arg == fl_ctx->NIL)
         return 0;
     if (isarray(arg))
         return cvalue_arraylen(arg);
     return 1;
 }
 
-static int cvalue_array_init(fltype_t *ft, value_t arg, void *dest)
+static int cvalue_array_init(fl_context_t *fl_ctx, fltype_t *ft, value_t arg, void *dest)
 {
     value_t type = ft->type;
     size_t elsize, i, cnt, sz;
     fltype_t *eltype = ft->eltype;
 
     elsize = ft->elsz;
-    cnt = predict_arraylen(arg);
+    cnt = predict_arraylen(fl_ctx, arg);
 
     if (iscons(cdr_(cdr_(type)))) {
-        size_t tc = tosize(car_(cdr_(cdr_(type))), "array");
+        size_t tc = tosize(fl_ctx, car_(cdr_(cdr_(type))), "array");
         if (tc != cnt)
-            lerror(ArgError, "array: size mismatch");
+            lerror(fl_ctx, fl_ctx->ArgError, "array: size mismatch");
     }
 
     sz = elsize * cnt;
 
     if (isvector(arg)) {
         for(i=0; i < cnt; i++) {
-            cvalue_init(eltype, vector_elt(arg,i), dest);
+            cvalue_init(fl_ctx, eltype, vector_elt(arg,i), dest);
             dest = (char *)dest + elsize;
         }
         return 0;
     }
-    else if (iscons(arg) || arg==NIL) {
+    else if (iscons(arg) || arg==fl_ctx->NIL) {
         i = 0;
         while (iscons(arg)) {
             if (i == cnt) { i++; break; } // trigger error
-            cvalue_init(eltype, car_(arg), dest);
+            cvalue_init(fl_ctx, eltype, car_(arg), dest);
             i++;
             dest = (char *)dest + elsize;
             arg = cdr_(arg);
         }
         if (i != cnt)
-            lerror(ArgError, "array: size mismatch");
+            lerror(fl_ctx, fl_ctx->ArgError, "array: size mismatch");
         return 0;
     }
     else if (iscvalue(arg)) {
@@ -400,39 +382,39 @@ static int cvalue_array_init(fltype_t *ft, value_t arg, void *dest)
                 if (cv_len(cv) == sz)
                     memcpy(dest, cv_data(cv), sz);
                 else
-                    lerror(ArgError, "array: size mismatch");
+                    lerror(fl_ctx, fl_ctx->ArgError, "array: size mismatch");
                 return 0;
             }
             else {
                 // TODO: initialize array from different type elements
-                lerror(ArgError, "array: element type mismatch");
+                lerror(fl_ctx, fl_ctx->ArgError, "array: element type mismatch");
             }
         }
     }
     if (cnt == 1)
-        cvalue_init(eltype, arg, dest);
+        cvalue_init(fl_ctx, eltype, arg, dest);
     else
-        type_error("array", "sequence", arg);
+        type_error(fl_ctx, "array", "sequence", arg);
     return 0;
 }
 
-value_t cvalue_array(value_t *args, u_int32_t nargs)
+value_t cvalue_array(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     size_t elsize, cnt, sz, i;
     value_t arg;
 
     if (nargs < 1)
-        argcount("array", nargs, 1);
+        argcount(fl_ctx, "array", nargs, 1);
 
     cnt = nargs - 1;
-    fltype_t *type = get_array_type(args[0]);
+    fltype_t *type = get_array_type(fl_ctx, args[0]);
     elsize = type->elsz;
     sz = elsize * cnt;
 
-    value_t cv = cvalue(type, sz);
+    value_t cv = cvalue(fl_ctx, type, sz);
     char *dest = (char*)cv_data((cvalue_t*)ptr(cv));
     FOR_ARGS(i,1,arg,args) {
-        cvalue_init(type->eltype, arg, dest);
+        cvalue_init(fl_ctx, type->eltype, arg, dest);
         dest += elsize;
     }
     return cv;
@@ -446,26 +428,26 @@ size_t cvalue_arraylen(value_t v)
 }
 
 // *palign is an output argument giving the alignment required by type
-size_t ctype_sizeof(value_t type, int *palign)
+size_t ctype_sizeof(fl_context_t *fl_ctx, value_t type, int *palign)
 {
-    if (type == int8sym || type == uint8sym || type == bytesym) {
+    if (type == fl_ctx->int8sym || type == fl_ctx->uint8sym || type == fl_ctx->bytesym) {
         *palign = 1;
         return 1;
     }
-    if (type == int16sym || type == uint16sym) {
+    if (type == fl_ctx->int16sym || type == fl_ctx->uint16sym) {
         *palign = ALIGN2;
         return 2;
     }
-    if (type == int32sym || type == uint32sym || type == wcharsym ||
-        type == floatsym) {
+    if (type == fl_ctx->int32sym || type == fl_ctx->uint32sym || type == fl_ctx->wcharsym ||
+        type == fl_ctx->floatsym) {
         *palign = ALIGN4;
         return 4;
     }
-    if (type == int64sym || type == uint64sym || type == doublesym) {
+    if (type == fl_ctx->int64sym || type == fl_ctx->uint64sym || type == fl_ctx->doublesym) {
         *palign = ALIGN8;
         return 8;
     }
-    if (type == ptrdiffsym || type == sizesym) {
+    if (type == fl_ctx->ptrdiffsym || type == fl_ctx->sizesym) {
 #ifdef _P64
         *palign = ALIGN8;
         return 8;
@@ -476,32 +458,30 @@ size_t ctype_sizeof(value_t type, int *palign)
     }
     if (iscons(type)) {
         value_t hed = car_(type);
-        if (hed == pointersym || hed == cfunctionsym) {
+        if (hed == fl_ctx->pointersym || hed == fl_ctx->cfunctionsym) {
             *palign = ALIGNPTR;
             return sizeof(void*);
         }
-        if (hed == arraysym) {
-            value_t t = car(cdr_(type));
+        if (hed == fl_ctx->arraysym) {
+            value_t t = car(fl_ctx, cdr_(type));
             if (!iscons(cdr_(cdr_(type))))
-                lerror(ArgError, "sizeof: incomplete type");
+                lerror(fl_ctx, fl_ctx->ArgError, "sizeof: incomplete type");
             value_t n = car_(cdr_(cdr_(type)));
-            size_t sz = tosize(n, "sizeof");
-            return sz * ctype_sizeof(t, palign);
+            size_t sz = tosize(fl_ctx, n, "sizeof");
+            return sz * ctype_sizeof(fl_ctx, t, palign);
         }
     }
-    lerror(ArgError, "sizeof: invalid c type");
+    lerror(fl_ctx, fl_ctx->ArgError, "sizeof: invalid c type");
     return 0;
 }
 
-extern fltype_t *iostreamtype;
-
 // get pointer and size for any plain-old-data value
-void to_sized_ptr(value_t v, char *fname, char **pdata, size_t *psz)
+void to_sized_ptr(fl_context_t *fl_ctx, value_t v, char *fname, char **pdata, size_t *psz)
 {
     if (iscvalue(v)) {
         cvalue_t *pcv = (cvalue_t*)ptr(v);
         ios_t *x = value2c(ios_t*,v);
-        if (cv_class(pcv) == iostreamtype && (x->bm == bm_mem)) {
+        if (cv_class(pcv) == fl_ctx->iostreamtype && (x->bm == bm_mem)) {
             *pdata = x->buf;
             *psz = x->size;
             return;
@@ -518,82 +498,82 @@ void to_sized_ptr(value_t v, char *fname, char **pdata, size_t *psz)
         *psz = cp_class(pcp)->size;
         return;
     }
-    type_error(fname, "plain-old-data", v);
+    type_error(fl_ctx, fname, "plain-old-data", v);
 }
 
-value_t cvalue_sizeof(value_t *args, u_int32_t nargs)
+value_t cvalue_sizeof(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("sizeof", nargs, 1);
+    argcount(fl_ctx, "sizeof", nargs, 1);
     if (issymbol(args[0]) || iscons(args[0])) {
         int a;
-        return size_wrap(ctype_sizeof(args[0], &a));
+        return size_wrap(fl_ctx, ctype_sizeof(fl_ctx, args[0], &a));
     }
     size_t n; char *data;
-    to_sized_ptr(args[0], "sizeof", &data, &n);
-    return size_wrap(n);
+    to_sized_ptr(fl_ctx, args[0], "sizeof", &data, &n);
+    return size_wrap(fl_ctx, n);
 }
 
-value_t cvalue_typeof(value_t *args, u_int32_t nargs)
+value_t cvalue_typeof(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("typeof", nargs, 1);
+    argcount(fl_ctx, "typeof", nargs, 1);
     switch(tag(args[0])) {
-    case TAG_CONS: return pairsym;
+    case TAG_CONS: return fl_ctx->pairsym;
     case TAG_NUM1:
-    case TAG_NUM:  return fixnumsym;
-    case TAG_SYM:  return symbolsym;
-    case TAG_VECTOR: return vectorsym;
+    case TAG_NUM:  return fl_ctx->fixnumsym;
+    case TAG_SYM:  return fl_ctx->symbolsym;
+    case TAG_VECTOR: return fl_ctx->vectorsym;
     case TAG_FUNCTION:
-        if (args[0] == FL_T || args[0] == FL_F)
-            return booleansym;
-        if (args[0] == NIL)
-            return nullsym;
-        if (args[0] == FL_EOF)
-            return symbol("eof-object");
+        if (args[0] == fl_ctx->T || args[0] == fl_ctx->F)
+            return fl_ctx->booleansym;
+        if (args[0] == fl_ctx->NIL)
+            return fl_ctx->nullsym;
+        if (args[0] == fl_ctx->FL_EOF)
+            return symbol(fl_ctx, "eof-object");
         if (isbuiltin(args[0]))
-            return builtinsym;
-        return FUNCTION;
+            return fl_ctx->builtinsym;
+        return fl_ctx->FUNCTION;
     }
     return cv_type((cvalue_t*)ptr(args[0]));
 }
 
-static value_t cvalue_relocate(value_t v)
+static value_t cvalue_relocate(fl_context_t *fl_ctx, value_t v)
 {
     size_t nw;
     cvalue_t *cv = (cvalue_t*)ptr(v);
     cvalue_t *nv;
     value_t ncv;
 
-    nw = cv_nwords(cv);
-    nv = (cvalue_t*)alloc_words(nw);
+    nw = cv_nwords(fl_ctx, cv);
+    nv = (cvalue_t*)alloc_words(fl_ctx, nw);
     memcpy(nv, cv, nw*sizeof(value_t));
     if (isinlined(cv))
         nv->data = &nv->_space[0];
     ncv = tagptr(nv, TAG_CVALUE);
     fltype_t *t = cv_class(cv);
     if (t->vtable != NULL && t->vtable->relocate != NULL)
-        t->vtable->relocate(v, ncv);
+        t->vtable->relocate(fl_ctx, v, ncv);
     forward(v, ncv);
     return ncv;
 }
 
-value_t cvalue_copy(value_t v)
+value_t cvalue_copy(fl_context_t *fl_ctx, value_t v)
 {
     assert(iscvalue(v));
-    PUSH(v);
+    PUSH(fl_ctx, v);
     cvalue_t *cv = (cvalue_t*)ptr(v);
-    size_t nw = cv_nwords(cv);
-    cvalue_t *ncv = (cvalue_t*)alloc_words(nw);
-    v = POP(); cv = (cvalue_t*)ptr(v);
+    size_t nw = cv_nwords(fl_ctx, cv);
+    cvalue_t *ncv = (cvalue_t*)alloc_words(fl_ctx, nw);
+    v = POP(fl_ctx); cv = (cvalue_t*)ptr(v);
     memcpy(ncv, cv, nw * sizeof(value_t));
     if (!isinlined(cv)) {
         size_t len = cv_len(cv);
-        if (cv_isstr(cv)) len++;
+        if (cv_isstr(fl_ctx, cv)) len++;
         ncv->data = malloc(len);
         memcpy(ncv->data, cv_data(cv), len);
-        autorelease(ncv);
+        autorelease(fl_ctx, ncv);
         if (hasparent(cv)) {
             ncv->type = (fltype_t*)(((uptrint_t)ncv->type) & ~CV_PARENT_BIT);
-            ncv->parent = NIL;
+            ncv->parent = fl_ctx->NIL;
         }
     }
     else {
@@ -603,73 +583,73 @@ value_t cvalue_copy(value_t v)
     return tagptr(ncv, TAG_CVALUE);
 }
 
-value_t fl_copy(value_t *args, u_int32_t nargs)
+value_t fl_copy(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("copy", nargs, 1);
+    argcount(fl_ctx, "copy", nargs, 1);
     if (iscons(args[0]) || isvector(args[0]))
-        lerror(ArgError, "copy: argument must be a leaf atom");
+        lerror(fl_ctx, fl_ctx->ArgError, "copy: argument must be a leaf atom");
     if (!iscvalue(args[0]))
         return args[0];
     if (!cv_isPOD((cvalue_t*)ptr(args[0])))
-        lerror(ArgError, "copy: argument must be a plain-old-data type");
-    return cvalue_copy(args[0]);
+        lerror(fl_ctx, fl_ctx->ArgError, "copy: argument must be a plain-old-data type");
+    return cvalue_copy(fl_ctx, args[0]);
 }
 
-value_t fl_podp(value_t *args, u_int32_t nargs)
+value_t fl_podp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("plain-old-data?", nargs, 1);
+    argcount(fl_ctx, "plain-old-data?", nargs, 1);
     return (iscprim(args[0]) ||
             (iscvalue(args[0]) && cv_isPOD((cvalue_t*)ptr(args[0])))) ?
-        FL_T : FL_F;
+        fl_ctx->T : fl_ctx->F;
 }
 
-static void cvalue_init(fltype_t *type, value_t v, void *dest)
+static void cvalue_init(fl_context_t *fl_ctx, fltype_t *type, value_t v, void *dest)
 {
     cvinitfunc_t f=type->init;
 
     if (f == NULL)
-        lerror(ArgError, "c-value: invalid c type");
+        lerror(fl_ctx, fl_ctx->ArgError, "c-value: invalid c type");
 
-    f(type, v, dest);
+    f(fl_ctx, type, v, dest);
 }
 
-static numerictype_t sym_to_numtype(value_t type)
+static numerictype_t sym_to_numtype(fl_context_t *fl_ctx, value_t type)
 {
-    if (type == int8sym)
+    if (type == fl_ctx->int8sym)
         return T_INT8;
-    else if (type == uint8sym || type == bytesym)
+    else if (type == fl_ctx->uint8sym || type == fl_ctx->bytesym)
         return T_UINT8;
-    else if (type == int16sym)
+    else if (type == fl_ctx->int16sym)
         return T_INT16;
-    else if (type == uint16sym)
+    else if (type == fl_ctx->uint16sym)
         return T_UINT16;
 #ifdef _P64
-    else if (type == int32sym || type == wcharsym)
+    else if (type == fl_ctx->int32sym || type == fl_ctx->wcharsym)
 #else
-    else if (type == int32sym || type == wcharsym || type == ptrdiffsym)
+    else if (type == fl_ctx->int32sym || type == fl_ctx->wcharsym || type == fl_ctx->ptrdiffsym)
 #endif
         return T_INT32;
 #ifdef _P64
-    else if (type == uint32sym)
+    else if (type == fl_ctx->uint32sym)
 #else
-    else if (type == uint32sym || type == sizesym)
+    else if (type == fl_ctx->uint32sym || type == fl_ctx->sizesym)
 #endif
         return T_UINT32;
 #ifdef _P64
-    else if (type == int64sym || type == ptrdiffsym)
+    else if (type == fl_ctx->int64sym || type == fl_ctx->ptrdiffsym)
 #else
-    else if (type == int64sym)
+    else if (type == fl_ctx->int64sym)
 #endif
         return T_INT64;
 #ifdef _P64
-    else if (type == uint64sym || type == sizesym)
+    else if (type == fl_ctx->uint64sym || type == fl_ctx->sizesym)
 #else
-    else if (type == uint64sym)
+    else if (type == fl_ctx->uint64sym)
 #endif
         return T_UINT64;
-    else if (type == floatsym)
+    else if (type == fl_ctx->floatsym)
         return T_FLOAT;
-    else if (type == doublesym)
+    else if (type == fl_ctx->doublesym)
         return T_DOUBLE;
     return (numerictype_t)N_NUMTYPES;
 }
@@ -678,12 +658,12 @@ static numerictype_t sym_to_numtype(value_t type)
 // this provides (1) a way to allocate values with a shared type for
 // efficiency, (2) a uniform interface for allocating cvalues of any
 // type, including user-defined.
-value_t cvalue_new(value_t *args, u_int32_t nargs)
+value_t cvalue_new(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 1 || nargs > 2)
-        argcount("c-value", nargs, 2);
+        argcount(fl_ctx, "c-value", nargs, 2);
     value_t type = args[0];
-    fltype_t *ft = get_type(type);
+    fltype_t *ft = get_type(fl_ctx, type);
     value_t cv;
     if (ft->eltype != NULL) {
         // special case to handle incomplete array types bla[]
@@ -691,19 +671,19 @@ value_t cvalue_new(value_t *args, u_int32_t nargs)
         size_t cnt;
 
         if (iscons(cdr_(cdr_(type))))
-            cnt = tosize(car_(cdr_(cdr_(type))), "array");
+            cnt = tosize(fl_ctx, car_(cdr_(cdr_(type))), "array");
         else if (nargs == 2)
-            cnt = predict_arraylen(args[1]);
+            cnt = predict_arraylen(fl_ctx, args[1]);
         else
             cnt = 0;
-        cv = cvalue(ft, elsz * cnt);
+        cv = cvalue(fl_ctx, ft, elsz * cnt);
         if (nargs == 2)
-            cvalue_array_init(ft, args[1], cv_data((cvalue_t*)ptr(cv)));
+            cvalue_array_init(fl_ctx, ft, args[1], cv_data((cvalue_t*)ptr(cv)));
     }
     else {
-        cv = cvalue(ft, ft->size);
+        cv = cvalue(fl_ctx, ft, ft->size);
         if (nargs == 2)
-            cvalue_init(ft, args[1], cptr(cv));
+            cvalue_init(fl_ctx, ft, args[1], cptr(cv));
     }
     return cv;
 }
@@ -728,27 +708,27 @@ value_t cvalue_compare(value_t a, value_t b)
     return fixnum(diff);
 }
 
-static void check_addr_args(char *fname, value_t arr, value_t ind,
-                            char **data, size_t *index)
+static void check_addr_args(fl_context_t *fl_ctx, char *fname, value_t arr,
+                            value_t ind, char **data, size_t *index)
 {
     size_t numel;
     cvalue_t *cv = (cvalue_t*)ptr(arr);
     *data = (char*)cv_data(cv);
     numel = cv_len(cv)/(cv_class(cv)->elsz);
-    *index = tosize(ind, fname);
+    *index = tosize(fl_ctx, ind, fname);
     if (*index >= numel)
-        bounds_error(fname, arr, ind);
+        bounds_error(fl_ctx, fname, arr, ind);
 }
 
-static value_t cvalue_array_aref(value_t *args)
+static value_t cvalue_array_aref(fl_context_t *fl_ctx, value_t *args)
 {
     char *data; size_t index;
     fltype_t *eltype = cv_class((cvalue_t*)ptr(args[0]))->eltype;
     value_t el = 0;
     numerictype_t nt = eltype->numtype;
     if (nt >= T_INT32)
-        el = cvalue(eltype, eltype->size);
-    check_addr_args("aref", args[0], args[1], &data, &index);
+        el = cvalue(fl_ctx, eltype, eltype->size);
+    check_addr_args(fl_ctx, "aref", args[0], args[1], &data, &index);
     if (nt < T_INT32) {
         if (nt == T_INT8)
             return fixnum((int8_t)data[index]);
@@ -773,49 +753,49 @@ static value_t cvalue_array_aref(value_t *args)
     return el;
 }
 
-static value_t cvalue_array_aset(value_t *args)
+static value_t cvalue_array_aset(fl_context_t *fl_ctx, value_t *args)
 {
     char *data; size_t index;
     fltype_t *eltype = cv_class((cvalue_t*)ptr(args[0]))->eltype;
-    check_addr_args("aset!", args[0], args[1], &data, &index);
+    check_addr_args(fl_ctx, "aset!", args[0], args[1], &data, &index);
     char *dest = data + index*eltype->size;
-    cvalue_init(eltype, args[2], dest);
+    cvalue_init(fl_ctx, eltype, args[2], dest);
     return args[2];
 }
 
-value_t fl_builtin(value_t *args, u_int32_t nargs)
+value_t fl_builtin(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("builtin", nargs, 1);
-    symbol_t *name = tosymbol(args[0], "builtin");
+    argcount(fl_ctx, "builtin", nargs, 1);
+    symbol_t *name = tosymbol(fl_ctx, args[0], "builtin");
     cvalue_t *cv;
-    if (ismanaged(args[0]) || (cv=(cvalue_t*)name->dlcache) == NULL) {
-        lerrorf(ArgError, "builtin: function %s not found", name->name);
+    if (ismanaged(fl_ctx, args[0]) || (cv=(cvalue_t*)name->dlcache) == NULL) {
+        lerrorf(fl_ctx, fl_ctx->ArgError, "builtin: function %s not found", name->name);
     }
     return tagptr(cv, TAG_CVALUE);
 }
 
-value_t cbuiltin(char *name, builtin_t f)
+value_t cbuiltin(fl_context_t *fl_ctx, char *name, builtin_t f)
 {
     cvalue_t *cv = (cvalue_t*)malloc(CVALUE_NWORDS * sizeof(value_t));
-    cv->type = builtintype;
+    cv->type = fl_ctx->builtintype;
     cv->data = &cv->_space[0];
     cv->len = sizeof(value_t);
     *(void**)cv->data = (void*)f;
 
-    value_t sym = symbol(name);
+    value_t sym = symbol(fl_ctx, name);
     ((symbol_t*)ptr(sym))->dlcache = cv;
-    ptrhash_put(&reverse_dlsym_lookup_table, cv, (void*)sym);
+    ptrhash_put(&fl_ctx->reverse_dlsym_lookup_table, cv, (void*)sym);
 
     return tagptr(cv, TAG_CVALUE);
 }
 
-static value_t fl_logand(value_t *args, u_int32_t nargs);
-static value_t fl_logior(value_t *args, u_int32_t nargs);
-static value_t fl_logxor(value_t *args, u_int32_t nargs);
-static value_t fl_lognot(value_t *args, u_int32_t nargs);
-static value_t fl_ash(value_t *args, u_int32_t nargs);
+static value_t fl_logand(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+static value_t fl_logior(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+static value_t fl_logxor(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+static value_t fl_lognot(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+static value_t fl_ash(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
 
-static builtinspec_t cvalues_builtin_info[] = {
+static const builtinspec_t cvalues_builtin_info[] = {
     { "c-value", cvalue_new },
     { "typeof", cvalue_typeof },
     { "sizeof", cvalue_sizeof },
@@ -832,123 +812,120 @@ static builtinspec_t cvalues_builtin_info[] = {
     { NULL, NULL }
 };
 
-#define cv_intern(tok) tok##sym = symbol(#tok)
-#define ctor_cv_intern(tok) \
-    cv_intern(tok);set(tok##sym, cbuiltin(#tok, cvalue_##tok))
+#define cv_intern(fl_ctx, tok) fl_ctx->tok##sym = symbol(fl_ctx, #tok)
+#define ctor_cv_intern(fl_ctx, tok)                             \
+    cv_intern(fl_ctx, tok);                                     \
+    set(fl_ctx->tok##sym, cbuiltin(fl_ctx, #tok, cvalue_##tok))
 
-#define mk_primtype(name) \
-  name##type=get_type(name##sym);name##type->init = &cvalue_##name##_init
+#define mk_primtype(fl_ctx, name)                               \
+    fl_ctx->name##type = get_type(fl_ctx, fl_ctx->name##sym);   \
+    fl_ctx->name##type->init = &cvalue_##name##_init
 
-#define mk_primtype_(name,ctype) \
-  name##type=get_type(name##sym);name##type->init = &cvalue_##ctype##_init
+#define mk_primtype_(fl_ctx, name, ctype)                       \
+    fl_ctx->name##type = get_type(fl_ctx, fl_ctx->name##sym);   \
+    fl_ctx->name##type->init = &cvalue_##ctype##_init
 
-struct prim_int16{ char a; int16_t i; };
-struct prim_int32{ char a; int32_t i; };
-struct prim_int64{ char a; int64_t i; };
-struct prim_ptr{ char a;  void   *i; };
-
-static void cvalues_init(void)
+static void cvalues_init(fl_context_t *fl_ctx)
 {
-    htable_new(&TypeTable, 256);
-    htable_new(&reverse_dlsym_lookup_table, 256);
+    fl_ctx->malloc_pressure = 0;
+    fl_ctx->Finalizers = NULL;
+    fl_ctx->nfinalizers = 0;
+    fl_ctx->maxfinalizers = 0;
 
-    // compute struct field alignment required for primitives
-    ALIGN2   = sizeof(struct prim_int16) - 2;
-    ALIGN4   = sizeof(struct prim_int32) - 4;
-    ALIGN8   = sizeof(struct prim_int64) - 8;
-    ALIGNPTR = sizeof(struct prim_ptr) - sizeof(void*);
+    htable_new(&fl_ctx->TypeTable, 256);
+    htable_new(&fl_ctx->reverse_dlsym_lookup_table, 256);
 
-    builtintype = define_opaque_type(builtinsym, sizeof(builtin_t), NULL, NULL);
+    fl_ctx->builtintype = define_opaque_type(fl_ctx->builtinsym, sizeof(builtin_t), NULL, NULL);
 
-    ctor_cv_intern(int8);
-    ctor_cv_intern(uint8);
-    ctor_cv_intern(int16);
-    ctor_cv_intern(uint16);
-    ctor_cv_intern(int32);
-    ctor_cv_intern(uint32);
-    ctor_cv_intern(int64);
-    ctor_cv_intern(uint64);
-    ctor_cv_intern(byte);
-    ctor_cv_intern(wchar);
-    ctor_cv_intern(ptrdiff);
-    ctor_cv_intern(size);
-    ctor_cv_intern(float);
-    ctor_cv_intern(double);
+    ctor_cv_intern(fl_ctx, int8);
+    ctor_cv_intern(fl_ctx, uint8);
+    ctor_cv_intern(fl_ctx, int16);
+    ctor_cv_intern(fl_ctx, uint16);
+    ctor_cv_intern(fl_ctx, int32);
+    ctor_cv_intern(fl_ctx, uint32);
+    ctor_cv_intern(fl_ctx, int64);
+    ctor_cv_intern(fl_ctx, uint64);
+    ctor_cv_intern(fl_ctx, byte);
+    ctor_cv_intern(fl_ctx, wchar);
+    ctor_cv_intern(fl_ctx, ptrdiff);
+    ctor_cv_intern(fl_ctx, size);
+    ctor_cv_intern(fl_ctx, float);
+    ctor_cv_intern(fl_ctx, double);
 
-    ctor_cv_intern(array);
-    cv_intern(pointer);
-    cv_intern(void);
-    cfunctionsym = symbol("c-function");
+    ctor_cv_intern(fl_ctx, array);
+    cv_intern(fl_ctx, pointer);
+    cv_intern(fl_ctx, void);
+    fl_ctx->cfunctionsym = symbol(fl_ctx, "c-function");
 
-    assign_global_builtins(cvalues_builtin_info);
+    assign_global_builtins(fl_ctx, cvalues_builtin_info);
 
-    stringtypesym = symbol("*string-type*");
-    setc(stringtypesym, fl_list2(arraysym, bytesym));
+    fl_ctx->stringtypesym = symbol(fl_ctx, "*string-type*");
+    setc(fl_ctx->stringtypesym, fl_list2(fl_ctx, fl_ctx->arraysym, fl_ctx->bytesym));
 
-    wcstringtypesym = symbol("*wcstring-type*");
-    setc(wcstringtypesym, fl_list2(arraysym, wcharsym));
+    fl_ctx->wcstringtypesym = symbol(fl_ctx, "*wcstring-type*");
+    setc(fl_ctx->wcstringtypesym, fl_list2(fl_ctx, fl_ctx->arraysym, fl_ctx->wcharsym));
 
-    mk_primtype(int8);
-    mk_primtype(uint8);
-    mk_primtype(int16);
-    mk_primtype(uint16);
-    mk_primtype(int32);
-    mk_primtype(uint32);
-    mk_primtype(int64);
-    mk_primtype(uint64);
+    mk_primtype(fl_ctx, int8);
+    mk_primtype(fl_ctx, uint8);
+    mk_primtype(fl_ctx, int16);
+    mk_primtype(fl_ctx, uint16);
+    mk_primtype(fl_ctx, int32);
+    mk_primtype(fl_ctx, uint32);
+    mk_primtype(fl_ctx, int64);
+    mk_primtype(fl_ctx, uint64);
 #ifdef _P64
-    mk_primtype_(ptrdiff,int64);
-    mk_primtype_(size,uint64);
+    mk_primtype_(fl_ctx, ptrdiff, int64);
+    mk_primtype_(fl_ctx, size, uint64);
 #else
-    mk_primtype_(ptrdiff,int32);
-    mk_primtype_(size,uint32);
+    mk_primtype_(fl_ctx, ptrdiff, int32);
+    mk_primtype_(fl_ctx, size, uint32);
 #endif
-    mk_primtype_(byte,uint8);
-    mk_primtype_(wchar,int32);
-    mk_primtype(float);
-    mk_primtype(double);
+    mk_primtype_(fl_ctx, byte, uint8);
+    mk_primtype_(fl_ctx, wchar, int32);
+    mk_primtype(fl_ctx, float);
+    mk_primtype(fl_ctx, double);
 
-    stringtype = get_type(symbol_value(stringtypesym));
-    wcstringtype = get_type(symbol_value(wcstringtypesym));
+    fl_ctx->stringtype = get_type(fl_ctx, symbol_value(fl_ctx->stringtypesym));
+    fl_ctx->wcstringtype = get_type(fl_ctx, symbol_value(fl_ctx->wcstringtypesym));
 
-    emptystringsym = symbol("*empty-string*");
-    setc(emptystringsym, cvalue_static_cstring(""));
+    fl_ctx->emptystringsym = symbol(fl_ctx, "*empty-string*");
+    setc(fl_ctx->emptystringsym, cvalue_static_cstring(fl_ctx, ""));
 }
 
-#define RETURN_NUM_AS(var, type) return(mk_##type((fl_##type##_t)var))
+#define RETURN_NUM_AS(fl_ctx, var, type) return(mk_##type(fl_ctx, (fl_##type##_t)var))
 
-value_t return_from_uint64(uint64_t Uaccum)
+value_t return_from_uint64(fl_context_t *fl_ctx, uint64_t Uaccum)
 {
     if (fits_fixnum(Uaccum)) {
         return fixnum((fixnum_t)Uaccum);
     }
     if (Uaccum > (uint64_t)S64_MAX) {
-        RETURN_NUM_AS(Uaccum, uint64);
+        RETURN_NUM_AS(fl_ctx, Uaccum, uint64);
     }
     else if (Uaccum > (uint64_t)INT_MAX) {
-        RETURN_NUM_AS(Uaccum, int64);
+        RETURN_NUM_AS(fl_ctx, Uaccum, int64);
     }
-    RETURN_NUM_AS(Uaccum, int32);
+    RETURN_NUM_AS(fl_ctx, Uaccum, int32);
 }
 
-value_t return_from_int64(int64_t Saccum)
+value_t return_from_int64(fl_context_t *fl_ctx, int64_t Saccum)
 {
     if (fits_fixnum(Saccum)) {
         return fixnum((fixnum_t)Saccum);
     }
     if (Saccum > (int64_t)INT_MAX || Saccum < (int64_t)INT_MIN) {
-        RETURN_NUM_AS(Saccum, int64);
+        RETURN_NUM_AS(fl_ctx, Saccum, int64);
     }
-    RETURN_NUM_AS(Saccum, int32);
+    RETURN_NUM_AS(fl_ctx, Saccum, int32);
 }
 
-static value_t fl_add_any(value_t *args, u_int32_t nargs, fixnum_t carryIn)
+static value_t fl_add_any(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs, fixnum_t carryIn)
 {
     uint64_t Uaccum=0;
     int64_t Saccum = carryIn;
     double Faccum=0;
     uint32_t i;
-    value_t arg=NIL;
+    value_t arg=fl_ctx->NIL;
 
     FOR_ARGS(i,0,arg,args) {
         if (isfixnum(arg)) {
@@ -982,12 +959,12 @@ static value_t fl_add_any(value_t *args, u_int32_t nargs, fixnum_t carryIn)
             continue;
         }
     add_type_error:
-        type_error("+", "number", arg);
+        type_error(fl_ctx, "+", "number", arg);
     }
     if (Faccum != 0) {
         Faccum += Uaccum;
         Faccum += Saccum;
-        return mk_double(Faccum);
+        return mk_double(fl_ctx, Faccum);
     }
     else if (Saccum < 0) {
         uint64_t negpart = (uint64_t)(-Saccum);
@@ -998,9 +975,9 @@ static value_t fl_add_any(value_t *args, u_int32_t nargs, fixnum_t carryIn)
                 if (fits_fixnum(Saccum)) {
                     return fixnum((fixnum_t)Saccum);
                 }
-                RETURN_NUM_AS(Saccum, int32);
+                RETURN_NUM_AS(fl_ctx, Saccum, int32);
             }
-            RETURN_NUM_AS(Saccum, int64);
+            RETURN_NUM_AS(fl_ctx, Saccum, int64);
         }
         Uaccum -= negpart;
     }
@@ -1008,10 +985,10 @@ static value_t fl_add_any(value_t *args, u_int32_t nargs, fixnum_t carryIn)
         Uaccum += (uint64_t)Saccum;
     }
     // return value in Uaccum
-    return return_from_uint64(Uaccum);
+    return return_from_uint64(fl_ctx, Uaccum);
 }
 
-static value_t fl_neg(value_t n)
+static value_t fl_neg(fl_context_t *fl_ctx, value_t n)
 {
     if (isfixnum(n)) {
         return fixnum(-numval(n));
@@ -1030,32 +1007,32 @@ static value_t fl_neg(value_t n)
         case T_INT32:
             i32 = *(int32_t*)a;
             if (i32 == (int32_t)BIT31)
-                return mk_uint32((uint32_t)BIT31);
-            return mk_int32(-i32);
+                return mk_uint32(fl_ctx, (uint32_t)BIT31);
+            return mk_int32(fl_ctx, -i32);
         case T_UINT32:
             ui32 = *(uint32_t*)a;
-            if (ui32 <= ((uint32_t)INT_MAX)+1) return mk_int32(-(int32_t)ui32);
-            return mk_int64(-(int64_t)ui32);
+            if (ui32 <= ((uint32_t)INT_MAX)+1) return mk_int32(fl_ctx, -(int32_t)ui32);
+            return mk_int64(fl_ctx, -(int64_t)ui32);
         case T_INT64:
             i64 = *(int64_t*)a;
             if (i64 == (int64_t)BIT63)
-                return mk_uint64((uint64_t)BIT63);
-            return mk_int64(-i64);
-        case T_UINT64: return mk_int64(-(int64_t)*(uint64_t*)a);
-        case T_FLOAT:  return mk_float(-*(float*)a);
-        case T_DOUBLE: return mk_double(-*(double*)a);
+                return mk_uint64(fl_ctx, (uint64_t)BIT63);
+            return mk_int64(fl_ctx, -i64);
+        case T_UINT64: return mk_int64(fl_ctx, -(int64_t)*(uint64_t*)a);
+        case T_FLOAT:  return mk_float(fl_ctx, -*(float*)a);
+        case T_DOUBLE: return mk_double(fl_ctx, -*(double*)a);
             break;
         }
     }
-    type_error("-", "number", n);
+    type_error(fl_ctx, "-", "number", n);
 }
 
-static value_t fl_mul_any(value_t *args, u_int32_t nargs, int64_t Saccum)
+static value_t fl_mul_any(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs, int64_t Saccum)
 {
     uint64_t Uaccum=1;
     double Faccum=1;
     uint32_t i;
-    value_t arg=NIL;
+    value_t arg=fl_ctx->NIL;
 
     FOR_ARGS(i,0,arg,args) {
         if (isfixnum(arg)) {
@@ -1089,12 +1066,12 @@ static value_t fl_mul_any(value_t *args, u_int32_t nargs, int64_t Saccum)
             continue;
         }
     mul_type_error:
-        type_error("*", "number", arg);
+        type_error(fl_ctx, "*", "number", arg);
     }
     if (Faccum != 1) {
         Faccum *= Uaccum;
         Faccum *= Saccum;
-        return mk_double(Faccum);
+        return mk_double(fl_ctx, Faccum);
     }
     else if (Saccum < 0) {
         Saccum *= (int64_t)Uaccum;
@@ -1102,14 +1079,14 @@ static value_t fl_mul_any(value_t *args, u_int32_t nargs, int64_t Saccum)
             if (fits_fixnum(Saccum)) {
                 return fixnum((fixnum_t)Saccum);
             }
-            RETURN_NUM_AS(Saccum, int32);
+            RETURN_NUM_AS(fl_ctx, Saccum, int32);
         }
-        RETURN_NUM_AS(Saccum, int64);
+        RETURN_NUM_AS(fl_ctx, Saccum, int64);
     }
     else {
         Uaccum *= (uint64_t)Saccum;
     }
-    return return_from_uint64(Uaccum);
+    return return_from_uint64(fl_ctx, Uaccum);
 }
 
 static int num_to_ptr(value_t a, fixnum_t *pi, numerictype_t *pt, void **pp)
@@ -1139,7 +1116,7 @@ static int num_to_ptr(value_t a, fixnum_t *pi, numerictype_t *pt, void **pp)
           inexact not considered equal to exact
   fname: if not NULL, throws type errors, else returns 2 for type errors
 */
-int numeric_compare(value_t a, value_t b, int eq, int eqnans, char *fname)
+int numeric_compare(fl_context_t *fl_ctx, value_t a, value_t b, int eq, int eqnans, char *fname)
 {
     int_t ai, bi;
     numerictype_t ta, tb;
@@ -1151,10 +1128,10 @@ int numeric_compare(value_t a, value_t b, int eq, int eqnans, char *fname)
         return 1;
     }
     if (!num_to_ptr(a, &ai, &ta, &aptr)) {
-        if (fname) type_error(fname, "number", a); else return 2;
+        if (fname) type_error(fl_ctx, fname, "number", a); else return 2;
     }
     if (!num_to_ptr(b, &bi, &tb, &bptr)) {
-        if (fname) type_error(fname, "number", b); else return 2;
+        if (fname) type_error(fl_ctx, fname, "number", b); else return 2;
     }
     if (eq && eqnans && ((ta >= T_FLOAT) != (tb >= T_FLOAT)))
         return 1;
@@ -1167,17 +1144,17 @@ int numeric_compare(value_t a, value_t b, int eq, int eqnans, char *fname)
 }
 
 #if defined(_OS_WINDOWS_)
-__declspec(noreturn) static void DivideByZeroError(void);
+__declspec(noreturn) static void DivideByZeroError(fl_context_t *fl_ctx);
 #else
-static void DivideByZeroError(void) __attribute__ ((__noreturn__));
+static void DivideByZeroError(fl_context_t *fl_ctx) __attribute__ ((__noreturn__));
 #endif
 
-static void DivideByZeroError(void)
+static void DivideByZeroError(fl_context_t *fl_ctx)
 {
-    lerror(DivideError, "/: division by zero");
+    lerror(fl_ctx, fl_ctx->DivideError, "/: division by zero");
 }
 
-static value_t fl_div2(value_t a, value_t b)
+static value_t fl_div2(fl_context_t *fl_ctx, value_t a, value_t b)
 {
     double da, db;
     int_t ai, bi;
@@ -1185,24 +1162,24 @@ static value_t fl_div2(value_t a, value_t b)
     void *aptr, *bptr;
 
     if (!num_to_ptr(a, &ai, &ta, &aptr))
-        type_error("/", "number", a);
+        type_error(fl_ctx, "/", "number", a);
     if (!num_to_ptr(b, &bi, &tb, &bptr))
-        type_error("/", "number", b);
+        type_error(fl_ctx, "/", "number", b);
 
     da = conv_to_double(aptr, ta);
     db = conv_to_double(bptr, tb);
 
     if (db == 0 && tb < T_FLOAT)  // exact 0
-        DivideByZeroError();
+        DivideByZeroError(fl_ctx);
 
     da = da/db;
 
     if (ta < T_FLOAT && tb < T_FLOAT && (double)(int64_t)da == da)
-        return return_from_int64((int64_t)da);
-    return mk_double(da);
+        return return_from_int64(fl_ctx, (int64_t)da);
+    return mk_double(fl_ctx, da);
 }
 
-static value_t fl_idiv2(value_t a, value_t b)
+static value_t fl_idiv2(fl_context_t *fl_ctx, value_t a, value_t b)
 {
     int_t ai, bi;
     numerictype_t ta, tb;
@@ -1210,43 +1187,43 @@ static value_t fl_idiv2(value_t a, value_t b)
     int64_t a64, b64;
 
     if (!num_to_ptr(a, &ai, &ta, &aptr))
-        type_error("div0", "number", a);
+        type_error(fl_ctx, "div0", "number", a);
     if (!num_to_ptr(b, &bi, &tb, &bptr))
-        type_error("div0", "number", b);
+        type_error(fl_ctx, "div0", "number", b);
 
     if (ta == T_UINT64) {
         if (tb == T_UINT64) {
             if (*(uint64_t*)bptr == 0) goto div_error;
-            return return_from_uint64(*(uint64_t*)aptr / *(uint64_t*)bptr);
+            return return_from_uint64(fl_ctx, *(uint64_t*)aptr / *(uint64_t*)bptr);
         }
         b64 = conv_to_int64(bptr, tb);
         if (b64 < 0) {
-            return return_from_int64(-(int64_t)(*(uint64_t*)aptr /
-                                                (uint64_t)(-b64)));
+            return return_from_int64(fl_ctx, -(int64_t)(*(uint64_t*)aptr /
+                                                        (uint64_t)(-b64)));
         }
         if (b64 == 0)
             goto div_error;
-        return return_from_uint64(*(uint64_t*)aptr / (uint64_t)b64);
+        return return_from_uint64(fl_ctx, *(uint64_t*)aptr / (uint64_t)b64);
     }
     if (tb == T_UINT64) {
         if (*(uint64_t*)bptr == 0) goto div_error;
         a64 = conv_to_int64(aptr, ta);
         if (a64 < 0) {
-            return return_from_int64(-((int64_t)((uint64_t)(-a64) /
-                                                 *(uint64_t*)bptr)));
+            return return_from_int64(fl_ctx, -((int64_t)((uint64_t)(-a64) /
+                                                         *(uint64_t*)bptr)));
         }
-        return return_from_uint64((uint64_t)a64 / *(uint64_t*)bptr);
+        return return_from_uint64(fl_ctx, (uint64_t)a64 / *(uint64_t*)bptr);
     }
 
     b64 = conv_to_int64(bptr, tb);
     if (b64 == 0) goto div_error;
 
-    return return_from_int64(conv_to_int64(aptr, ta) / b64);
+    return return_from_int64(fl_ctx, conv_to_int64(aptr, ta) / b64);
  div_error:
-    DivideByZeroError();
+    DivideByZeroError(fl_ctx);
 }
 
-static value_t fl_bitwise_op(value_t a, value_t b, int opcode, char *fname)
+static value_t fl_bitwise_op(fl_context_t *fl_ctx, value_t a, value_t b, int opcode, char *fname)
 {
     int_t ai, bi;
     numerictype_t ta, tb, itmp;
@@ -1254,9 +1231,9 @@ static value_t fl_bitwise_op(value_t a, value_t b, int opcode, char *fname)
     int64_t b64;
 
     if (!num_to_ptr(a, &ai, &ta, &aptr) || ta >= T_FLOAT)
-        type_error(fname, "integer", a);
+        type_error(fl_ctx, fname, "integer", a);
     if (!num_to_ptr(b, &bi, &tb, &bptr) || tb >= T_FLOAT)
-        type_error(fname, "integer", b);
+        type_error(fl_ctx, fname, "integer", b);
 
     if (ta < tb) {
         itmp = ta; ta = tb; tb = itmp;
@@ -1271,10 +1248,10 @@ static value_t fl_bitwise_op(value_t a, value_t b, int opcode, char *fname)
     case T_UINT8:  return fixnum(   *(uint8_t *)aptr & (uint8_t )b64);
     case T_INT16:  return fixnum(   *(int16_t*)aptr  & (int16_t )b64);
     case T_UINT16: return fixnum(   *(uint16_t*)aptr & (uint16_t)b64);
-    case T_INT32:  return mk_int32( *(int32_t*)aptr  & (int32_t )b64);
-    case T_UINT32: return mk_uint32(*(uint32_t*)aptr & (uint32_t)b64);
-    case T_INT64:  return mk_int64( *(int64_t*)aptr  & (int64_t )b64);
-    case T_UINT64: return mk_uint64(*(uint64_t*)aptr & (uint64_t)b64);
+    case T_INT32:  return mk_int32(fl_ctx,  *(int32_t*)aptr  & (int32_t )b64);
+    case T_UINT32: return mk_uint32(fl_ctx, *(uint32_t*)aptr & (uint32_t)b64);
+    case T_INT64:  return mk_int64(fl_ctx,  *(int64_t*)aptr  & (int64_t )b64);
+    case T_UINT64: return mk_uint64(fl_ctx, *(uint64_t*)aptr & (uint64_t)b64);
     case T_FLOAT:
     case T_DOUBLE: assert(0);
     }
@@ -1285,10 +1262,10 @@ static value_t fl_bitwise_op(value_t a, value_t b, int opcode, char *fname)
     case T_UINT8:  return fixnum(   *(uint8_t *)aptr | (uint8_t )b64);
     case T_INT16:  return fixnum(   *(int16_t*)aptr  | (int16_t )b64);
     case T_UINT16: return fixnum(   *(uint16_t*)aptr | (uint16_t)b64);
-    case T_INT32:  return mk_int32( *(int32_t*)aptr  | (int32_t )b64);
-    case T_UINT32: return mk_uint32(*(uint32_t*)aptr | (uint32_t)b64);
-    case T_INT64:  return mk_int64( *(int64_t*)aptr  | (int64_t )b64);
-    case T_UINT64: return mk_uint64(*(uint64_t*)aptr | (uint64_t)b64);
+    case T_INT32:  return mk_int32(fl_ctx,  *(int32_t*)aptr  | (int32_t )b64);
+    case T_UINT32: return mk_uint32(fl_ctx, *(uint32_t*)aptr | (uint32_t)b64);
+    case T_INT64:  return mk_int64(fl_ctx,  *(int64_t*)aptr  | (int64_t )b64);
+    case T_UINT64: return mk_uint64(fl_ctx, *(uint64_t*)aptr | (uint64_t)b64);
     case T_FLOAT:
     case T_DOUBLE: assert(0);
     }
@@ -1299,19 +1276,19 @@ static value_t fl_bitwise_op(value_t a, value_t b, int opcode, char *fname)
     case T_UINT8:  return fixnum(   *(uint8_t *)aptr ^ (uint8_t )b64);
     case T_INT16:  return fixnum(   *(int16_t*)aptr  ^ (int16_t )b64);
     case T_UINT16: return fixnum(   *(uint16_t*)aptr ^ (uint16_t)b64);
-    case T_INT32:  return mk_int32( *(int32_t*)aptr  ^ (int32_t )b64);
-    case T_UINT32: return mk_uint32(*(uint32_t*)aptr ^ (uint32_t)b64);
-    case T_INT64:  return mk_int64( *(int64_t*)aptr  ^ (int64_t )b64);
-    case T_UINT64: return mk_uint64(*(uint64_t*)aptr ^ (uint64_t)b64);
+    case T_INT32:  return mk_int32(fl_ctx,  *(int32_t*)aptr  ^ (int32_t )b64);
+    case T_UINT32: return mk_uint32(fl_ctx, *(uint32_t*)aptr ^ (uint32_t)b64);
+    case T_INT64:  return mk_int64(fl_ctx,  *(int64_t*)aptr  ^ (int64_t )b64);
+    case T_UINT64: return mk_uint64(fl_ctx, *(uint64_t*)aptr ^ (uint64_t)b64);
     case T_FLOAT:
     case T_DOUBLE: assert(0);
     }
     }
     assert(0);
-    return NIL;
+    return fl_ctx->NIL;
 }
 
-static value_t fl_logand(value_t *args, u_int32_t nargs)
+static value_t fl_logand(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     value_t v, e;
     int i;
@@ -1322,12 +1299,12 @@ static value_t fl_logand(value_t *args, u_int32_t nargs)
         if (bothfixnums(v, e))
             v = v & e;
         else
-            v = fl_bitwise_op(v, e, 0, "logand");
+            v = fl_bitwise_op(fl_ctx, v, e, 0, "logand");
     }
     return v;
 }
 
-static value_t fl_logior(value_t *args, u_int32_t nargs)
+static value_t fl_logior(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     value_t v, e;
     int i;
@@ -1338,12 +1315,12 @@ static value_t fl_logior(value_t *args, u_int32_t nargs)
         if (bothfixnums(v, e))
             v = v | e;
         else
-            v = fl_bitwise_op(v, e, 1, "logior");
+            v = fl_bitwise_op(fl_ctx, v, e, 1, "logior");
     }
     return v;
 }
 
-static value_t fl_logxor(value_t *args, u_int32_t nargs)
+static value_t fl_logxor(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     value_t v, e;
     int i;
@@ -1354,14 +1331,14 @@ static value_t fl_logxor(value_t *args, u_int32_t nargs)
         if (bothfixnums(v, e))
             v = fixnum(numval(v) ^ numval(e));
         else
-            v = fl_bitwise_op(v, e, 2, "logxor");
+            v = fl_bitwise_op(fl_ctx, v, e, 2, "logxor");
     }
     return v;
 }
 
-static value_t fl_lognot(value_t *args, u_int32_t nargs)
+static value_t fl_lognot(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("lognot", nargs, 1);
+    argcount(fl_ctx, "lognot", nargs, 1);
     value_t a = args[0];
     if (isfixnum(a))
         return fixnum(~numval(a));
@@ -1378,22 +1355,22 @@ static value_t fl_lognot(value_t *args, u_int32_t nargs)
         case T_UINT8:  return fixnum(~*(uint8_t *)aptr);
         case T_INT16:  return fixnum(~*(int16_t *)aptr);
         case T_UINT16: return fixnum(~*(uint16_t*)aptr);
-        case T_INT32:  return mk_int32(~*(int32_t *)aptr);
-        case T_UINT32: return mk_uint32(~*(uint32_t*)aptr);
-        case T_INT64:  return mk_int64(~*(int64_t *)aptr);
-        case T_UINT64: return mk_uint64(~*(uint64_t*)aptr);
+        case T_INT32:  return mk_int32(fl_ctx, ~*(int32_t *)aptr);
+        case T_UINT32: return mk_uint32(fl_ctx, ~*(uint32_t*)aptr);
+        case T_INT64:  return mk_int64(fl_ctx, ~*(int64_t *)aptr);
+        case T_UINT64: return mk_uint64(fl_ctx, ~*(uint64_t*)aptr);
         }
     }
-    type_error("lognot", "integer", a);
+    type_error(fl_ctx, "lognot", "integer", a);
 }
 
-static value_t fl_ash(value_t *args, u_int32_t nargs)
+static value_t fl_ash(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     fixnum_t n;
     int64_t accum;
-    argcount("ash", nargs, 2);
+    argcount(fl_ctx, "ash", nargs, 2);
     value_t a = args[0];
-    n = tofixnum(args[1], "ash");
+    n = tofixnum(fl_ctx, args[1], "ash");
     if (isfixnum(a)) {
         if (n <= 0)
             return fixnum(numval(a)>>(-n));
@@ -1401,7 +1378,7 @@ static value_t fl_ash(value_t *args, u_int32_t nargs)
         if (fits_fixnum(accum))
             return fixnum(accum);
         else
-            return return_from_int64(accum);
+            return return_from_int64(fl_ctx, accum);
     }
     cprim_t *cp;
     int ta;
@@ -1418,21 +1395,21 @@ static value_t fl_ash(value_t *args, u_int32_t nargs)
             case T_UINT8:  return fixnum((*(uint8_t *)aptr) >> n);
             case T_INT16:  return fixnum((*(int16_t *)aptr) >> n);
             case T_UINT16: return fixnum((*(uint16_t*)aptr) >> n);
-            case T_INT32:  return mk_int32((*(int32_t *)aptr) >> n);
-            case T_UINT32: return mk_uint32((*(uint32_t*)aptr) >> n);
-            case T_INT64:  return mk_int64((*(int64_t *)aptr) >> n);
-            case T_UINT64: return mk_uint64((*(uint64_t*)aptr) >> n);
+            case T_INT32:  return mk_int32(fl_ctx, (*(int32_t *)aptr) >> n);
+            case T_UINT32: return mk_uint32(fl_ctx, (*(uint32_t*)aptr) >> n);
+            case T_INT64:  return mk_int64(fl_ctx, (*(int64_t *)aptr) >> n);
+            case T_UINT64: return mk_uint64(fl_ctx, (*(uint64_t*)aptr) >> n);
             }
         }
         else {
             if (ta == T_UINT64)
-                return return_from_uint64((*(uint64_t*)aptr)<<n);
+                return return_from_uint64(fl_ctx, (*(uint64_t*)aptr)<<n);
             else if (ta < T_FLOAT) {
                 int64_t i64 = conv_to_int64(aptr, (numerictype_t)ta);
-                return return_from_int64(i64<<n);
+                return return_from_int64(fl_ctx, i64<<n);
             }
         }
     }
-    type_error("ash", "integer", a);
-    return NIL;
+    type_error(fl_ctx, "ash", "integer", a);
+    return fl_ctx->NIL;
 }

--- a/src/flisp/dirname.c
+++ b/src/flisp/dirname.c
@@ -42,7 +42,11 @@ extern "C" {
 JL_DLLEXPORT char *dirname( char *path )
 {
     size_t len;
-    static char *retfail = NULL;
+#  if !defined(_COMPILER_MICROSOFT_)
+    static __thread char *retfail = NULL;
+#  else
+    static __declspec(thread) char *retfail = NULL;
+#  endif
 
     /* to handle path names for files in multibyte character locales,
      * we need to set up LC_CTYPE to match the host file system locale.

--- a/src/flisp/equal.c
+++ b/src/flisp/equal.c
@@ -4,30 +4,30 @@
 // comparable tag
 #define cmptag(v) (isfixnum(v) ? TAG_NUM : tag(v))
 
-static value_t eq_class(htable_t *table, value_t key)
+static value_t eq_class(fl_context_t *fl_ctx, htable_t *table, value_t key)
 {
     value_t c = (value_t)ptrhash_get(table, (void*)key);
     if (c == (value_t)HT_NOTFOUND)
-        return NIL;
+        return fl_ctx->NIL;
     if (c == key)
         return c;
-    return eq_class(table, c);
+    return eq_class(fl_ctx, table, c);
 }
 
-static void eq_union(htable_t *table, value_t a, value_t b,
-                     value_t c, value_t cb)
+static void eq_union(fl_context_t *fl_ctx, htable_t *table, value_t a,
+                     value_t b, value_t c, value_t cb)
 {
-    value_t ca = (c==NIL ? a : c);
-    if (cb != NIL)
+    value_t ca = (c==fl_ctx->NIL ? a : c);
+    if (cb != fl_ctx->NIL)
         ptrhash_put(table, (void*)cb, (void*)ca);
     ptrhash_put(table, (void*)a, (void*)ca);
     ptrhash_put(table, (void*)b, (void*)ca);
 }
 
-static value_t bounded_compare(value_t a, value_t b, int bound, int eq);
-static value_t cyc_compare(value_t a, value_t b, htable_t *table, int eq);
+static value_t bounded_compare(fl_context_t *fl_ctx, value_t a, value_t b, int bound, int eq);
+static value_t cyc_compare(fl_context_t *fl_ctx, value_t a, value_t b, htable_t *table, int eq);
 
-static value_t bounded_vector_compare(value_t a, value_t b, int bound, int eq)
+static value_t bounded_vector_compare(fl_context_t *fl_ctx, value_t a, value_t b, int bound, int eq)
 {
     size_t la = vector_size(a);
     size_t lb = vector_size(b);
@@ -35,9 +35,9 @@ static value_t bounded_vector_compare(value_t a, value_t b, int bound, int eq)
     if (eq && (la!=lb)) return fixnum(1);
     m = la < lb ? la : lb;
     for (i = 0; i < m; i++) {
-        value_t d = bounded_compare(vector_elt(a,i), vector_elt(b,i),
+        value_t d = bounded_compare(fl_ctx, vector_elt(a,i), vector_elt(b,i),
                                     bound-1, eq);
-        if (d==NIL || numval(d)!=0) return d;
+        if (d==fl_ctx->NIL || numval(d)!=0) return d;
     }
     if (la < lb) return fixnum(-1);
     if (la > lb) return fixnum(1);
@@ -46,14 +46,14 @@ static value_t bounded_vector_compare(value_t a, value_t b, int bound, int eq)
 
 // strange comparisons are resolved arbitrarily but consistently.
 // ordering: number < cprim < function < vector < cvalue < symbol < cons
-static value_t bounded_compare(value_t a, value_t b, int bound, int eq)
+static value_t bounded_compare(fl_context_t *fl_ctx, value_t a, value_t b, int bound, int eq)
 {
     value_t d;
 
  compare_top:
     if (a == b) return fixnum(0);
     if (bound <= 0)
-        return NIL;
+        return fl_ctx->NIL;
     int taga = tag(a);
     int tagb = cmptag(b);
     int c;
@@ -64,29 +64,29 @@ static value_t bounded_compare(value_t a, value_t b, int bound, int eq)
             return (numval(a) < numval(b)) ? fixnum(-1) : fixnum(1);
         }
         if (iscprim(b)) {
-            if (cp_class((cprim_t*)ptr(b)) == wchartype)
+            if (cp_class((cprim_t*)ptr(b)) == fl_ctx->wchartype)
                 return fixnum(1);
-            return fixnum(numeric_compare(a, b, eq, 1, NULL));
+            return fixnum(numeric_compare(fl_ctx, a, b, eq, 1, NULL));
         }
         return fixnum(-1);
     case TAG_SYM:
         if (eq) return fixnum(1);
         if (tagb < TAG_SYM) return fixnum(1);
         if (tagb > TAG_SYM) return fixnum(-1);
-        return fixnum(strcmp(symbol_name(a), symbol_name(b)));
+        return fixnum(strcmp(symbol_name(fl_ctx, a), symbol_name(fl_ctx, b)));
     case TAG_VECTOR:
         if (isvector(b))
-            return bounded_vector_compare(a, b, bound, eq);
+            return bounded_vector_compare(fl_ctx, a, b, bound, eq);
         break;
     case TAG_CPRIM:
-        if (cp_class((cprim_t*)ptr(a)) == wchartype) {
-            if (!iscprim(b) || cp_class((cprim_t*)ptr(b)) != wchartype)
+        if (cp_class((cprim_t*)ptr(a)) == fl_ctx->wchartype) {
+            if (!iscprim(b) || cp_class((cprim_t*)ptr(b)) != fl_ctx->wchartype)
                 return fixnum(-1);
         }
-        else if (iscprim(b) && cp_class((cprim_t*)ptr(b)) == wchartype) {
+        else if (iscprim(b) && cp_class((cprim_t*)ptr(b)) == fl_ctx->wchartype) {
             return fixnum(1);
         }
-        c = numeric_compare(a, b, eq, 1, NULL);
+        c = numeric_compare(fl_ctx, a, b, eq, 1, NULL);
         if (c != 2)
             return fixnum(c);
         break;
@@ -102,12 +102,12 @@ static value_t bounded_compare(value_t a, value_t b, int bound, int eq)
             if (uintval(a) > N_BUILTINS && uintval(b) > N_BUILTINS) {
                 function_t *fa = (function_t*)ptr(a);
                 function_t *fb = (function_t*)ptr(b);
-                d = bounded_compare(fa->bcode, fb->bcode, bound-1, eq);
-                if (d==NIL || numval(d) != 0) return d;
-                d = bounded_compare(fa->vals, fb->vals, bound-1, eq);
-                if (d==NIL || numval(d) != 0) return d;
-                d = bounded_compare(fa->env, fb->env, bound-1, eq);
-                if (d==NIL || numval(d) != 0) return d;
+                d = bounded_compare(fl_ctx, fa->bcode, fb->bcode, bound-1, eq);
+                if (d==fl_ctx->NIL || numval(d) != 0) return d;
+                d = bounded_compare(fl_ctx, fa->vals, fb->vals, bound-1, eq);
+                if (d==fl_ctx->NIL || numval(d) != 0) return d;
+                d = bounded_compare(fl_ctx, fa->env, fb->env, bound-1, eq);
+                if (d==fl_ctx->NIL || numval(d) != 0) return d;
                 return fixnum(0);
             }
             return (uintval(a) < uintval(b)) ? fixnum(-1) : fixnum(1);
@@ -115,8 +115,8 @@ static value_t bounded_compare(value_t a, value_t b, int bound, int eq)
         break;
     case TAG_CONS:
         if (tagb < TAG_CONS) return fixnum(1);
-        d = bounded_compare(car_(a), car_(b), bound-1, eq);
-        if (d==NIL || numval(d) != 0) return d;
+        d = bounded_compare(fl_ctx, car_(a), car_(b), bound-1, eq);
+        if (d==fl_ctx->NIL || numval(d) != 0) return d;
         a = cdr_(a); b = cdr_(b);
         bound--;
         goto compare_top;
@@ -124,8 +124,8 @@ static value_t bounded_compare(value_t a, value_t b, int bound, int eq)
     return (taga < tagb) ? fixnum(-1) : fixnum(1);
 }
 
-static value_t cyc_vector_compare(value_t a, value_t b, htable_t *table,
-                                  int eq)
+static value_t cyc_vector_compare(fl_context_t *fl_ctx, value_t a,
+                                  value_t b, htable_t *table, int eq)
 {
     size_t la = vector_size(a);
     size_t lb = vector_size(b);
@@ -139,8 +139,8 @@ static value_t cyc_vector_compare(value_t a, value_t b, htable_t *table,
         xa = vector_elt(a,i);
         xb = vector_elt(b,i);
         if (leafp(xa) || leafp(xb)) {
-            d = bounded_compare(xa, xb, 1, eq);
-            if (d!=NIL && numval(d)!=0) return d;
+            d = bounded_compare(fl_ctx, xa, xb, 1, eq);
+            if (d!=fl_ctx->NIL && numval(d)!=0) return d;
         }
         else if (tag(xa) < tag(xb)) {
             return fixnum(-1);
@@ -150,18 +150,18 @@ static value_t cyc_vector_compare(value_t a, value_t b, htable_t *table,
         }
     }
 
-    ca = eq_class(table, a);
-    cb = eq_class(table, b);
-    if (ca!=NIL && ca==cb)
+    ca = eq_class(fl_ctx, table, a);
+    cb = eq_class(fl_ctx, table, b);
+    if (ca!=fl_ctx->NIL && ca==cb)
         return fixnum(0);
 
-    eq_union(table, a, b, ca, cb);
+    eq_union(fl_ctx, table, a, b, ca, cb);
 
     for (i = 0; i < m; i++) {
         xa = vector_elt(a,i);
         xb = vector_elt(b,i);
         if (!leafp(xa) || tag(xa)==TAG_FUNCTION) {
-            d = cyc_compare(xa, xb, table, eq);
+            d = cyc_compare(fl_ctx, xa, xb, table, eq);
             if (numval(d)!=0)
                 return d;
         }
@@ -172,7 +172,7 @@ static value_t cyc_vector_compare(value_t a, value_t b, htable_t *table,
     return fixnum(0);
 }
 
-static value_t cyc_compare(value_t a, value_t b, htable_t *table, int eq)
+static value_t cyc_compare(fl_context_t *fl_ctx, value_t a, value_t b, htable_t *table, int eq)
 {
     value_t d, ca, cb;
  cyc_compare_top:
@@ -185,29 +185,29 @@ static value_t cyc_compare(value_t a, value_t b, htable_t *table, int eq)
             int tagaa = tag(aa); int tagda = tag(da);
             int tagab = tag(ab); int tagdb = tag(db);
             if (leafp(aa) || leafp(ab)) {
-                d = bounded_compare(aa, ab, 1, eq);
-                if (d!=NIL && numval(d)!=0) return d;
+                d = bounded_compare(fl_ctx, aa, ab, 1, eq);
+                if (d!=fl_ctx->NIL && numval(d)!=0) return d;
             }
             else if (tagaa < tagab)
                 return fixnum(-1);
             else if (tagaa > tagab)
                 return fixnum(1);
             if (leafp(da) || leafp(db)) {
-                d = bounded_compare(da, db, 1, eq);
-                if (d!=NIL && numval(d)!=0) return d;
+                d = bounded_compare(fl_ctx, da, db, 1, eq);
+                if (d!=fl_ctx->NIL && numval(d)!=0) return d;
             }
             else if (tagda < tagdb)
                 return fixnum(-1);
             else if (tagda > tagdb)
                 return fixnum(1);
 
-            ca = eq_class(table, a);
-            cb = eq_class(table, b);
-            if (ca!=NIL && ca==cb)
+            ca = eq_class(fl_ctx, table, a);
+            cb = eq_class(fl_ctx, table, b);
+            if (ca!=fl_ctx->NIL && ca==cb)
                 return fixnum(0);
 
-            eq_union(table, a, b, ca, cb);
-            d = cyc_compare(aa, ab, table, eq);
+            eq_union(fl_ctx, table, a, b, ca, cb);
+            d = cyc_compare(fl_ctx, aa, ab, table, eq);
             if (numval(d)!=0) return d;
             a = da;
             b = db;
@@ -218,56 +218,55 @@ static value_t cyc_compare(value_t a, value_t b, htable_t *table, int eq)
         }
     }
     else if (isvector(a) && isvector(b)) {
-        return cyc_vector_compare(a, b, table, eq);
+        return cyc_vector_compare(fl_ctx, a, b, table, eq);
     }
     else if (isclosure(a) && isclosure(b)) {
         function_t *fa = (function_t*)ptr(a);
         function_t *fb = (function_t*)ptr(b);
-        d = bounded_compare(fa->bcode, fb->bcode, 1, eq);
+        d = bounded_compare(fl_ctx, fa->bcode, fb->bcode, 1, eq);
         if (numval(d) != 0) return d;
 
-        ca = eq_class(table, a);
-        cb = eq_class(table, b);
-        if (ca!=NIL && ca==cb)
+        ca = eq_class(fl_ctx, table, a);
+        cb = eq_class(fl_ctx, table, b);
+        if (ca!=fl_ctx->NIL && ca==cb)
             return fixnum(0);
 
-        eq_union(table, a, b, ca, cb);
-        d = cyc_compare(fa->vals, fb->vals, table, eq);
+        eq_union(fl_ctx, table, a, b, ca, cb);
+        d = cyc_compare(fl_ctx, fa->vals, fb->vals, table, eq);
         if (numval(d) != 0) return d;
         a = fa->env;
         b = fb->env;
         goto cyc_compare_top;
     }
-    return bounded_compare(a, b, 1, eq);
+    return bounded_compare(fl_ctx, a, b, 1, eq);
 }
 
-static htable_t equal_eq_hashtable;
-void comparehash_init(void)
+void comparehash_init(fl_context_t *fl_ctx)
 {
-    htable_new(&equal_eq_hashtable, 512);
+    htable_new(&fl_ctx->equal_eq_hashtable, 512);
 }
 
 // 'eq' means unordered comparison is sufficient
-static value_t compare_(value_t a, value_t b, int eq)
+static value_t compare_(fl_context_t *fl_ctx, value_t a, value_t b, int eq)
 {
-    value_t guess = bounded_compare(a, b, BOUNDED_COMPARE_BOUND, eq);
-    if (guess == NIL) {
-        guess = cyc_compare(a, b, &equal_eq_hashtable, eq);
-        htable_reset(&equal_eq_hashtable, 512);
+    value_t guess = bounded_compare(fl_ctx, a, b, BOUNDED_COMPARE_BOUND, eq);
+    if (guess == fl_ctx->NIL) {
+        guess = cyc_compare(fl_ctx, a, b, &fl_ctx->equal_eq_hashtable, eq);
+        htable_reset(&fl_ctx->equal_eq_hashtable, 512);
     }
     return guess;
 }
 
-value_t fl_compare(value_t a, value_t b)
+value_t fl_compare(fl_context_t *fl_ctx, value_t a, value_t b)
 {
-    return compare_(a, b, 0);
+    return compare_(fl_ctx, a, b, 0);
 }
 
-value_t fl_equal(value_t a, value_t b)
+value_t fl_equal(fl_context_t *fl_ctx, value_t a, value_t b)
 {
     if (eq_comparable(a, b))
-        return (a == b) ? FL_T : FL_F;
-    return (numval(compare_(a,b,1))==0 ? FL_T : FL_F);
+        return (a == b) ? fl_ctx->T : fl_ctx->F;
+    return (numval(compare_(fl_ctx, a,b,1))==0 ? fl_ctx->T : fl_ctx->F);
 }
 
 /*
@@ -287,7 +286,7 @@ value_t fl_equal(value_t a, value_t b)
 #endif
 
 // *oob: output argument, means we hit the limit specified by 'bound'
-static uptrint_t bounded_hash(value_t a, int bound, int *oob)
+static uptrint_t bounded_hash(fl_context_t *fl_ctx, value_t a, int bound, int *oob)
 {
     *oob = 0;
     union {
@@ -308,14 +307,14 @@ static uptrint_t bounded_hash(value_t a, int bound, int *oob)
         return doublehash(u.i64);
     case TAG_FUNCTION:
         if (uintval(a) > N_BUILTINS)
-            return bounded_hash(((function_t*)ptr(a))->bcode, bound, oob);
+            return bounded_hash(fl_ctx, ((function_t*)ptr(a))->bcode, bound, oob);
         return inthash(a);
     case TAG_SYM:
         return ((symbol_t*)ptr(a))->hash;
     case TAG_CPRIM:
         cp = (cprim_t*)ptr(a);
         data = cp_data(cp);
-        if (cp_class(cp) == wchartype)
+        if (cp_class(cp) == fl_ctx->wchartype)
             return inthash(*(int32_t*)data);
         nt = cp_numtype(cp);
         u.d = conv_to_double(data, nt);
@@ -332,7 +331,7 @@ static uptrint_t bounded_hash(value_t a, int bound, int *oob)
         }
         len = vector_size(a);
         for(i=0; i < len; i++) {
-            h = MIX(h, bounded_hash(vector_elt(a,i), bound/2, &oob2)^1);
+            h = MIX(h, bounded_hash(fl_ctx, vector_elt(a,i), bound/2, &oob2)^1);
             if (oob2)
                 bound/=2;
             *oob = *oob || oob2;
@@ -345,7 +344,7 @@ static uptrint_t bounded_hash(value_t a, int bound, int *oob)
                 *oob = 1;
                 return h;
             }
-            h = MIX(h, bounded_hash(car_(a), bound/2, &oob2));
+            h = MIX(h, bounded_hash(fl_ctx, car_(a), bound/2, &oob2));
             // bounds balancing: try to share the bounds efficiently
             // so we can hash better when a list is cdr-deep (a common case)
             if (oob2)
@@ -357,29 +356,29 @@ static uptrint_t bounded_hash(value_t a, int bound, int *oob)
             *oob = *oob || oob2;
             a = cdr_(a);
         } while (iscons(a));
-        h = MIX(h, bounded_hash(a, bound-1, &oob2)^2);
+        h = MIX(h, bounded_hash(fl_ctx, a, bound-1, &oob2)^2);
         *oob = *oob || oob2;
         return h;
     }
     return 0;
 }
 
-int equal_lispvalue(value_t a, value_t b)
+int equal_lispvalue(fl_context_t *fl_ctx, value_t a, value_t b)
 {
     if (eq_comparable(a, b))
         return (a==b);
-    return (numval(compare_(a,b,1))==0);
+    return (numval(compare_(fl_ctx, a, b, 1))==0);
 }
 
-uptrint_t hash_lispvalue(value_t a)
+uptrint_t hash_lispvalue(fl_context_t *fl_ctx, value_t a)
 {
-    int oob=0;
-    uptrint_t n = bounded_hash(a, BOUNDED_HASH_BOUND, &oob);
+    int oob = 0;
+    uptrint_t n = bounded_hash(fl_ctx, a, BOUNDED_HASH_BOUND, &oob);
     return n;
 }
 
-value_t fl_hash(value_t *args, u_int32_t nargs)
+value_t fl_hash(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("hash", nargs, 1);
-    return fixnum(hash_lispvalue(args[0]));
+    argcount(fl_ctx, "hash", nargs, 1);
+    return fixnum(hash_lispvalue(fl_ctx, args[0]));
 }

--- a/src/flisp/equalhash.c
+++ b/src/flisp/equalhash.c
@@ -10,13 +10,16 @@
 
 #include "htable.inc"
 
-#define _equal_lispvalue_(x,y) equal_lispvalue((value_t)(x),(value_t)(y))
+#define _equal_lispvalue_(x, y, ctx)                                    \
+    equal_lispvalue((fl_context_t*)ctx, (value_t)(x), (value_t)(y))
+#define _hash_lispvalue_(x, ctx)                        \
+    hash_lispvalue((fl_context_t*)ctx, (value_t)(x))
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-HTIMPL(equalhash, hash_lispvalue, _equal_lispvalue_)
+HTIMPL_R(equalhash, _hash_lispvalue_, _equal_lispvalue_)
 
 #ifdef __cplusplus
 }

--- a/src/flisp/equalhash.h
+++ b/src/flisp/equalhash.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-HTPROT(equalhash)
+HTPROT_R(equalhash)
 
 #ifdef __cplusplus
 }

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -59,7 +59,7 @@ JL_DLLEXPORT char * dirname(char *);
 #include <libgen.h>
 #endif
 
-static char *builtin_names[] =
+static char *const builtin_names[] =
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
       NULL, NULL, NULL, NULL,
       // predicates
@@ -82,7 +82,7 @@ static char *builtin_names[] =
 
 #define ANYARGS -10000
 
-static short builtin_arg_counts[] =
+static const short builtin_arg_counts[] =
     { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       2, ANYARGS, 1, 1, 2, 2,
@@ -90,37 +90,13 @@ static short builtin_arg_counts[] =
       ANYARGS, -1, ANYARGS, -1, 2,  2, 2, 2,
       ANYARGS, 2, 3 };
 
-static uint32_t N_STACK;
-static value_t *Stack;
-static uint32_t SP = 0;
-static uint32_t curr_frame = 0;
-#define PUSH(v) (Stack[SP++] = (v))
-#define POP()   (Stack[--SP])
-#define POPN(n) (SP-=(n))
+#define PUSH(fl_ctx, v) (fl_ctx->Stack[fl_ctx->SP++] = (v))
+#define POP(fl_ctx)   (fl_ctx->Stack[--fl_ctx->SP])
+#define POPN(fl_ctx, n) (fl_ctx->SP-=(n))
 
-#define N_GC_HANDLES 8192
-static value_t *GCHandleStack[N_GC_HANDLES];
-static uint32_t N_GCHND = 0;
-
-value_t FL_NIL, FL_T, FL_F, FL_EOF, QUOTE;
-value_t IOError, ParseError, TypeError, ArgError, UnboundError, OutOfMemoryError;
-value_t DivideError, BoundsError, Error, KeyError, EnumerationError;
-value_t printwidthsym, printreadablysym, printprettysym, printlengthsym;
-value_t printlevelsym, builtins_table_sym;
-
-static value_t NIL, LAMBDA, IF, TRYCATCH;
-static value_t BACKQUOTE, COMMA, COMMAAT, COMMADOT, FUNCTION;
-
-static value_t pairsym, symbolsym, fixnumsym, vectorsym, builtinsym, vu8sym;
-static value_t definesym, defmacrosym, forsym, setqsym;
-static value_t tsym, Tsym, fsym, Fsym, booleansym, nullsym, evalsym, fnsym;
-// for reading characters
-static value_t nulsym, alarmsym, backspacesym, tabsym, linefeedsym, newlinesym;
-static value_t vtabsym, pagesym, returnsym, escsym, spacesym, deletesym;
-
-static value_t apply_cl(uint32_t nargs);
-static value_t *alloc_words(int n);
-static value_t relocate(value_t v);
+static value_t apply_cl(fl_context_t *fl_ctx, uint32_t nargs);
+static value_t *alloc_words(fl_context_t *fl_ctx, int n);
+static value_t relocate(fl_context_t *fl_ctx, value_t v);
 
 typedef struct _fl_readstate_t {
     htable_t backrefs;
@@ -129,131 +105,114 @@ typedef struct _fl_readstate_t {
     struct _fl_readstate_t *prev;
 } fl_readstate_t;
 
-static fl_readstate_t *readstate = NULL;
-
 static void free_readstate(fl_readstate_t *rs)
 {
     htable_free(&rs->backrefs);
     htable_free(&rs->gensyms);
 }
 
-static unsigned char *fromspace;
-static unsigned char *tospace;
-static unsigned char *curheap;
-static unsigned char *lim;
-static uint32_t heapsize;//bytes
-static uint32_t *consflags;
-
 // error utilities ------------------------------------------------------------
 
-// saved execution state for an unwind target
-fl_exception_context_t *fl_ctx = NULL;
-uint32_t fl_throwing_frame=0;  // active frame when exception was thrown
-value_t fl_lasterror;
-
-#define FL_TRY \
+#define FL_TRY(fl_ctx)                           \
   fl_exception_context_t _ctx; int l__tr, l__ca; \
-  _ctx.sp=SP; _ctx.frame=curr_frame; _ctx.rdst=readstate; _ctx.prev=fl_ctx; \
-  _ctx.ngchnd = N_GCHND; fl_ctx = &_ctx;                                    \
+  _ctx.sp=fl_ctx->SP; _ctx.frame=fl_ctx->curr_frame; _ctx.rdst=fl_ctx->readstate; _ctx.prev=fl_ctx->exc_ctx; \
+  _ctx.ngchnd = fl_ctx->N_GCHND; fl_ctx->exc_ctx = &_ctx;                                    \
   if (!setjmp(_ctx.buf)) \
-    for (l__tr=1; l__tr; l__tr=0, (void)(fl_ctx=fl_ctx->prev))
+    for (l__tr=1; l__tr; l__tr=0, (void)(fl_ctx->exc_ctx=fl_ctx->exc_ctx->prev))
 
-#define FL_CATCH \
-  else \
-    for(l__ca=1; l__ca; l__ca=0, \
-      fl_lasterror=FL_NIL,fl_throwing_frame=0,SP=_ctx.sp,curr_frame=_ctx.frame)
+#define FL_CATCH(fl_ctx)                                                \
+    else                                                                \
+        for(l__ca=1; l__ca; l__ca=0,                                    \
+                fl_ctx->lasterror=fl_ctx->NIL,fl_ctx->throwing_frame=0,fl_ctx->SP=_ctx.sp,fl_ctx->curr_frame=_ctx.frame)
 
-void fl_savestate(fl_exception_context_t *_ctx)
+void fl_savestate(fl_context_t *fl_ctx, fl_exception_context_t *_ctx)
 {
-    _ctx->sp = SP;
-    _ctx->frame = curr_frame;
-    _ctx->rdst = readstate;
-    _ctx->prev = fl_ctx;
-    _ctx->ngchnd = N_GCHND;
+    _ctx->sp = fl_ctx->SP;
+    _ctx->frame = fl_ctx->curr_frame;
+    _ctx->rdst = fl_ctx->readstate;
+    _ctx->prev = fl_ctx->exc_ctx;
+    _ctx->ngchnd = fl_ctx->N_GCHND;
 }
 
-void fl_restorestate(fl_exception_context_t *_ctx)
+void fl_restorestate(fl_context_t *fl_ctx, fl_exception_context_t *_ctx)
 {
-    fl_lasterror = FL_NIL;
-    fl_throwing_frame = 0;
-    SP = _ctx->sp;
-    curr_frame = _ctx->frame;
+    fl_ctx->lasterror = fl_ctx->NIL;
+    fl_ctx->throwing_frame = 0;
+    fl_ctx->SP = _ctx->sp;
+    fl_ctx->curr_frame = _ctx->frame;
 }
 
-void fl_raise(value_t e)
+void fl_raise(fl_context_t *fl_ctx, value_t e)
 {
-    fl_lasterror = e;
+    fl_ctx->lasterror = e;
     // unwind read state
-    while (readstate != (fl_readstate_t*)fl_ctx->rdst) {
-        free_readstate(readstate);
-        readstate = readstate->prev;
+    while (fl_ctx->readstate != (fl_readstate_t*)fl_ctx->exc_ctx->rdst) {
+        free_readstate(fl_ctx->readstate);
+        fl_ctx->readstate = fl_ctx->readstate->prev;
     }
-    if (fl_throwing_frame == 0)
-        fl_throwing_frame = curr_frame;
-    N_GCHND = fl_ctx->ngchnd;
-    fl_exception_context_t *thisctx = fl_ctx;
-    if (fl_ctx->prev)   // don't throw past toplevel
-        fl_ctx = fl_ctx->prev;
+    if (fl_ctx->throwing_frame == 0)
+        fl_ctx->throwing_frame = fl_ctx->curr_frame;
+    fl_ctx->N_GCHND = fl_ctx->exc_ctx->ngchnd;
+    fl_exception_context_t *thisctx = fl_ctx->exc_ctx;
+    if (fl_ctx->exc_ctx->prev)   // don't throw past toplevel
+        fl_ctx->exc_ctx = fl_ctx->exc_ctx->prev;
     longjmp(thisctx->buf, 1);
 }
 
-static value_t make_error_msg(char *format, va_list args)
+static value_t make_error_msg(fl_context_t *fl_ctx, char *format, va_list args)
 {
     char msgbuf[512];
     vsnprintf(msgbuf, sizeof(msgbuf), format, args);
-    return string_from_cstr(msgbuf);
+    return string_from_cstr(fl_ctx, msgbuf);
 }
 
-void lerrorf(value_t e, char *format, ...)
+void lerrorf(fl_context_t *fl_ctx, value_t e, char *format, ...)
 {
     va_list args;
-    PUSH(e);
+    PUSH(fl_ctx, e);
     va_start(args, format);
-    value_t msg = make_error_msg(format, args);
+    value_t msg = make_error_msg(fl_ctx, format, args);
     va_end(args);
 
-    e = POP();
-    fl_raise(fl_list2(e, msg));
+    e = POP(fl_ctx);
+    fl_raise(fl_ctx, fl_list2(fl_ctx, e, msg));
 }
 
-void lerror(value_t e, const char *msg)
+void lerror(fl_context_t *fl_ctx, value_t e, const char *msg)
 {
-    PUSH(e);
-    value_t m = cvalue_static_cstring(msg);
-    e = POP();
-    fl_raise(fl_list2(e, m));
+    PUSH(fl_ctx, e);
+    value_t m = cvalue_static_cstring(fl_ctx, msg);
+    e = POP(fl_ctx);
+    fl_raise(fl_ctx, fl_list2(fl_ctx, e, m));
 }
 
-void type_error(char *fname, char *expected, value_t got)
+void type_error(fl_context_t *fl_ctx, char *fname, char *expected, value_t got)
 {
-    fl_raise(fl_listn(4, TypeError, symbol(fname), symbol(expected), got));
+    fl_raise(fl_ctx, fl_listn(fl_ctx, 4, fl_ctx->TypeError, symbol(fl_ctx, fname), symbol(fl_ctx, expected), got));
 }
 
-void bounds_error(char *fname, value_t arr, value_t ind)
+void bounds_error(fl_context_t *fl_ctx, char *fname, value_t arr, value_t ind)
 {
-    fl_raise(fl_listn(4, BoundsError, symbol(fname), arr, ind));
+    fl_raise(fl_ctx, fl_listn(fl_ctx, 4, fl_ctx->BoundsError, symbol(fl_ctx, fname), arr, ind));
 }
 
 // safe cast operators --------------------------------------------------------
 
-#define isstring fl_isstring
-#define SAFECAST_OP(type,ctype,cnvt)                                          \
-ctype to##type(value_t v, char *fname)                                        \
-{                                                                             \
-    if (is##type(v))                                                          \
-        return (ctype)cnvt(v);                                                \
-    type_error(fname, #type, v);                                              \
-}
+#define isstring(v) fl_isstring(fl_ctx, v)
+#define SAFECAST_OP(type,ctype,cnvt)                                    \
+    ctype to##type(fl_context_t *fl_ctx, value_t v, char *fname)        \
+    {                                                                   \
+        if (is##type(v))                                                \
+            return (ctype)cnvt(v);                                      \
+        type_error(fl_ctx, fname, #type, v);                            \
+    }
 SAFECAST_OP(cons,  cons_t*,  ptr)
 SAFECAST_OP(symbol,symbol_t*,ptr)
 SAFECAST_OP(fixnum,fixnum_t, numval)
-SAFECAST_OP(cvalue,cvalue_t*,ptr)
 SAFECAST_OP(string,char*,    cvalue_data)
 #undef isstring
 
 // symbol table ---------------------------------------------------------------
-
-symbol_t *symtab = NULL;
 
 int fl_is_keyword_name(const char *str, size_t len)
 {
@@ -302,31 +261,26 @@ static symbol_t **symtab_lookup(symbol_t **ptree, const char *str)
     return ptree;
 }
 
-value_t symbol(char *str)
+value_t symbol(fl_context_t *fl_ctx, char *str)
 {
-    symbol_t **pnode = symtab_lookup(&symtab, str);
+    symbol_t **pnode = symtab_lookup(&fl_ctx->symtab, str);
     if (*pnode == NULL)
         *pnode = mk_symbol(str);
     return tagptr(*pnode, TAG_SYM);
 }
 
-static uint32_t _gensym_ctr=0;
-// two static buffers for gensym printing so there can be two
-// gensym names available at a time, mostly for compare()
-static char gsname[2][16];
-static int gsnameno=0;
-value_t fl_gensym(value_t *args, uint32_t nargs)
+value_t fl_gensym(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
 #ifdef MEMDEBUG2
-    gsnameno = 1-gsnameno;
-    char *n = uint2str(gsname[gsnameno]+1, sizeof(gsname[0])-1, _gensym_ctr++, 10);
+    fl_ctx->gsnameno = 1-fl_ctx->gsnameno;
+    char *n = uint2str(fl_ctx->gsname[fl_ctx->gsnameno]+1, sizeof(fl_ctx->gsname[0])-1, fl_ctx->gensym_ctr++, 10);
     *(--n) = 'g';
     return tagptr(mk_symbol(n), TAG_SYM);
 #else
-    argcount("gensym", nargs, 0);
+    argcount(fl_ctx, "gensym", nargs, 0);
     (void)args;
-    gensym_t *gs = (gensym_t*)alloc_words(sizeof(gensym_t)/sizeof(void*));
-    gs->id = _gensym_ctr++;
+    gensym_t *gs = (gensym_t*)alloc_words(fl_ctx, sizeof(gensym_t)/sizeof(void*));
+    gs->id = fl_ctx->gensym_ctr++;
     gs->binding = UNBOUND;
     gs->isconst = 0;
     gs->type = NULL;
@@ -334,27 +288,29 @@ value_t fl_gensym(value_t *args, uint32_t nargs)
 #endif
 }
 
-int fl_isgensym(value_t v)
+int fl_isgensym(fl_context_t *fl_ctx, value_t v)
 {
-    return isgensym(v);
+    return isgensym(fl_ctx, v);
 }
 
-static value_t fl_gensymp(value_t *args, u_int32_t nargs)
+static value_t fl_gensymp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("gensym?", nargs, 1);
-    return isgensym(args[0]) ? FL_T : FL_F;
+    argcount(fl_ctx, "gensym?", nargs, 1);
+    return isgensym(fl_ctx, args[0]) ? fl_ctx->T : fl_ctx->F;
 }
 
-char *symbol_name(value_t v)
+char *symbol_name(fl_context_t *fl_ctx, value_t v)
 {
 #ifndef MEMDEBUG2
-    if (ismanaged(v)) {
+    if (ismanaged(fl_ctx, v)) {
         gensym_t *gs = (gensym_t*)ptr(v);
-        gsnameno = 1-gsnameno;
-        char *n = uint2str(gsname[gsnameno]+1, sizeof(gsname[0])-1, gs->id, 10);
+        fl_ctx->gsnameno = 1-fl_ctx->gsnameno;
+        char *n = uint2str(fl_ctx->gsname[fl_ctx->gsnameno]+1, sizeof(fl_ctx->gsname[0])-1, gs->id, 10);
         *(--n) = 'g';
         return n;
     }
+#else
+    (void)fl_ctx;
 #endif
     return ((symbol_t*)ptr(v))->name;
 }
@@ -362,92 +318,88 @@ char *symbol_name(value_t v)
 // conses ---------------------------------------------------------------------
 
 #ifdef MEMDEBUG2
-static void *tochain=NULL;
-static long long n_allocd=0;
 #define GC_INTERVAL 100000
 #endif
 
-void gc(int mustgrow);
+void gc(fl_context_t *fl_ctx, int mustgrow);
 
-static value_t mk_cons(void)
+static value_t mk_cons(fl_context_t *fl_ctx)
 {
     cons_t *c;
 
 #ifdef MEMDEBUG2
-    if (n_allocd > GC_INTERVAL)
-        gc(0);
+    if (fl_ctx->n_allocd > GC_INTERVAL)
+        gc(fl_ctx, 0);
     c = (cons_t*)((void**)malloc(3*sizeof(void*)) + 1);
     CHECK_ALIGN8(c);
-    ((void**)c)[-1] = tochain;
-    tochain = c;
-    n_allocd += sizeof(cons_t);
+    ((void**)c)[-1] = fl_ctx->tochain;
+    fl_ctx->tochain = c;
+    fl_ctx->n_allocd += sizeof(cons_t);
 #else
-    if (__unlikely(curheap > lim))
-        gc(0);
-    c = (cons_t*)curheap;
-    curheap += sizeof(cons_t);
+    if (__unlikely(fl_ctx->curheap > fl_ctx->lim))
+        gc(fl_ctx, 0);
+    c = (cons_t*)fl_ctx->curheap;
+    fl_ctx->curheap += sizeof(cons_t);
 #endif
     return tagptr(c, TAG_CONS);
 }
 
-static value_t *alloc_words(int n)
+static value_t *alloc_words(fl_context_t *fl_ctx, int n)
 {
     value_t *first;
 
     assert(n > 0);
     n = LLT_ALIGN(n, 2);   // only allocate multiples of 2 words
 #ifdef MEMDEBUG2
-    if (n_allocd > GC_INTERVAL)
-        gc(0);
+    if (fl_ctx->n_allocd > GC_INTERVAL)
+        gc(fl_ctx, 0);
     first = (value_t*)malloc((n+1)*sizeof(value_t)) + 1;
     CHECK_ALIGN8(first);
-    first[-1] = (value_t)tochain;
-    tochain = first;
-    n_allocd += (n*sizeof(value_t));
+    first[-1] = (value_t)fl_ctx->tochain;
+    fl_ctx->tochain = first;
+    fl_ctx->n_allocd += (n*sizeof(value_t));
 #else
-    if (__unlikely((value_t*)curheap > ((value_t*)lim)+2-n)) {
-        gc(0);
-        while ((value_t*)curheap > ((value_t*)lim)+2-n) {
-            gc(1);
+    if (__unlikely((value_t*)fl_ctx->curheap > ((value_t*)fl_ctx->lim)+2-n)) {
+        gc(fl_ctx, 0);
+        while ((value_t*)fl_ctx->curheap > ((value_t*)fl_ctx->lim)+2-n) {
+            gc(fl_ctx, 1);
         }
     }
-    first = (value_t*)curheap;
-    curheap += (n*sizeof(value_t));
+    first = (value_t*)fl_ctx->curheap;
+    fl_ctx->curheap += (n*sizeof(value_t));
 #endif
     return first;
 }
 
 // allocate n consecutive conses
 #ifndef MEMDEBUG2
-#define cons_reserve(n) tagptr(alloc_words((n)*2), TAG_CONS)
+#define cons_reserve(fl_ctx, n) tagptr(alloc_words(fl_ctx, (n)*2), TAG_CONS)
 #endif
 
 #ifndef MEMDEBUG2
-#define cons_index(c)  (((cons_t*)ptr(c))-((cons_t*)fromspace))
+#define cons_index(fl_ctx, c)  (((cons_t*)ptr(c))-((cons_t*)fl_ctx->fromspace))
 #endif
 
 #ifdef MEMDEBUG2
-#define ismarked(c)    ((((value_t*)ptr(c))[-1]&1) != 0)
-#define mark_cons(c)   ((((value_t*)ptr(c))[-1]) |= 1)
-#define unmark_cons(c) ((((value_t*)ptr(c))[-1]) &= (~(value_t)1))
+#define ismarked(fl_ctx, c)    ((((value_t*)ptr(c))[-1]&1) != 0)
+#define mark_cons(fl_ctx, c)   ((((value_t*)ptr(c))[-1]) |= 1)
+#define unmark_cons(fl_ctx, c) ((((value_t*)ptr(c))[-1]) &= (~(value_t)1))
 #else
-#define ismarked(c)    bitvector_get(consflags, cons_index(c))
-#define mark_cons(c)   bitvector_set(consflags, cons_index(c), 1)
-#define unmark_cons(c) bitvector_set(consflags, cons_index(c), 0)
+#define ismarked(fl_ctx, c)    bitvector_get(fl_ctx->consflags, cons_index(fl_ctx, c))
+#define mark_cons(fl_ctx, c)   bitvector_set(fl_ctx->consflags, cons_index(fl_ctx, c), 1)
+#define unmark_cons(fl_ctx, c) bitvector_set(fl_ctx->consflags, cons_index(fl_ctx, c), 0)
 #endif
 
-static value_t the_empty_vector;
-
-value_t alloc_vector(size_t n, int init)
+value_t alloc_vector(fl_context_t *fl_ctx, size_t n, int init)
 {
-    if (n == 0) return the_empty_vector;
-    value_t *c = alloc_words(n+1);
+    if (n == 0) return fl_ctx->the_empty_vector;
+    value_t *c = alloc_words(fl_ctx, n+1);
     value_t v = tagptr(c, TAG_VECTOR);
     vector_setsize(v, n);
     if (init) {
         unsigned int i;
         for(i=0; i < n; i++)
-            vector_elt(v, i) = FL_UNSPECIFIED;
+            vector_elt(v, i) = FL_UNSPECIFIED(fl_ctx);
     }
     return v;
 }
@@ -459,27 +411,42 @@ value_t alloc_vector(size_t n, int init)
 
 // print ----------------------------------------------------------------------
 
-static int isnumtok(char *tok, value_t *pval);
+static int isnumtok(fl_context_t *fl_ctx, char *tok, value_t *pval);
 static inline int symchar(char c);
 
 #include "print.c"
 
 // collector ------------------------------------------------------------------
 
-void fl_gc_handle(value_t *pv)
+void fl_gc_handle(fl_context_t *fl_ctx, value_t *pv)
 {
-    if (N_GCHND >= N_GC_HANDLES)
-        lerror(OutOfMemoryError, "out of gc handles");
-    GCHandleStack[N_GCHND++] = pv;
+    if (fl_ctx->N_GCHND >= FL_N_GC_HANDLES)
+        lerror(fl_ctx, fl_ctx->OutOfMemoryError, "out of gc handles");
+    fl_ctx->GCHandleStack[fl_ctx->N_GCHND++] = pv;
 }
 
-void fl_free_gc_handles(uint32_t n)
+void fl_free_gc_handles(fl_context_t *fl_ctx, uint32_t n)
 {
-    assert(N_GCHND >= n);
-    N_GCHND -= n;
+    assert(fl_ctx->N_GCHND >= n);
+    fl_ctx->N_GCHND -= n;
 }
 
-static value_t relocate(value_t v)
+value_t relocate_lispvalue(fl_context_t *fl_ctx, value_t v)
+{
+    return relocate(fl_ctx, v);
+}
+
+static void trace_globals(fl_context_t *fl_ctx, symbol_t *root)
+{
+    while (root != NULL) {
+        if (root->binding != UNBOUND)
+            root->binding = relocate(fl_ctx, root->binding);
+        trace_globals(fl_ctx, root->left);
+        root = root->right;
+    }
+}
+
+static value_t relocate(fl_context_t *fl_ctx, value_t v)
 {
     value_t a, d, nc, first, *pcdr;
     uptrint_t t = tag(v);
@@ -493,25 +460,25 @@ static value_t relocate(value_t v)
                 return first;
             }
 #ifdef MEMDEBUG2
-            *pcdr = nc = mk_cons();
+            *pcdr = nc = mk_cons(fl_ctx);
 #else
-            *pcdr = nc = tagptr((cons_t*)curheap, TAG_CONS);
-            curheap += sizeof(cons_t);
+            *pcdr = nc = tagptr((cons_t*)fl_ctx->curheap, TAG_CONS);
+            fl_ctx->curheap += sizeof(cons_t);
 #endif
             d = cdr_(v);
             car_(v) = TAG_FWD; cdr_(v) = nc;
-            if ((tag(a)&3) == 0 || !ismanaged(a))
+            if ((tag(a)&3) == 0 || !ismanaged(fl_ctx, a))
                 car_(nc) = a;
             else
-                car_(nc) = relocate(a);
+                car_(nc) = relocate(fl_ctx, a);
             pcdr = &cdr_(nc);
             v = d;
         } while (iscons(v));
-        *pcdr = (d==NIL) ? NIL : relocate(d);
+        *pcdr = (d==fl_ctx->NIL) ? fl_ctx->NIL : relocate(fl_ctx, d);
         return first;
     }
 
-    if ((t&3) == 0 || !ismanaged(v)) return v;
+    if ((t&3) == 0 || !ismanaged(fl_ctx, v)) return v;
     if (isforwarded(v)) return forwardloc(v);
 
     if (t == TAG_VECTOR) {
@@ -519,22 +486,22 @@ static value_t relocate(value_t v)
         size_t i, sz = vector_size(v);
         if (vector_elt(v,-1) & 0x1) {
             // grown vector
-            nc = relocate(vector_elt(v,0));
+            nc = relocate(fl_ctx, vector_elt(v,0));
             forward(v, nc);
         }
         else {
-            nc = tagptr(alloc_words(sz+1), TAG_VECTOR);
+            nc = tagptr(alloc_words(fl_ctx, sz+1), TAG_VECTOR);
             vector_setsize(nc, sz);
             a = vector_elt(v,0);
             forward(v, nc);
             if (sz > 0) {
-                vector_elt(nc,0) = relocate(a);
+                vector_elt(nc,0) = relocate(fl_ctx, a);
                 for(i=1; i < sz; i++) {
                     a = vector_elt(v,i);
-                    if ((tag(a)&3) == 0 || !ismanaged(a))
+                    if ((tag(a)&3) == 0 || !ismanaged(fl_ctx, a))
                         vector_elt(nc,i) = a;
                     else
-                        vector_elt(nc,i) = relocate(a);
+                        vector_elt(nc,i) = relocate(fl_ctx, a);
                 }
             }
         }
@@ -543,7 +510,7 @@ static value_t relocate(value_t v)
     else if (t == TAG_CPRIM) {
         cprim_t *pcp = (cprim_t*)ptr(v);
         size_t nw = CPRIM_NWORDS-1+NWORDS(cp_class(pcp)->size);
-        cprim_t *ncp = (cprim_t*)alloc_words(nw);
+        cprim_t *ncp = (cprim_t*)alloc_words(fl_ctx, nw);
         while (nw--)
             ((value_t*)ncp)[nw] = ((value_t*)pcp)[nw];
         nc = tagptr(ncp, TAG_CPRIM);
@@ -551,105 +518,87 @@ static value_t relocate(value_t v)
         return nc;
     }
     else if (t == TAG_CVALUE) {
-        return cvalue_relocate(v);
+        return cvalue_relocate(fl_ctx, v);
     }
     else if (t == TAG_FUNCTION) {
         function_t *fn = (function_t*)ptr(v);
-        function_t *nfn = (function_t*)alloc_words(4);
+        function_t *nfn = (function_t*)alloc_words(fl_ctx, 4);
         nfn->bcode = fn->bcode;
         nfn->vals = fn->vals;
         nc = tagptr(nfn, TAG_FUNCTION);
         forward(v, nc);
-        nfn->env = relocate(fn->env);
-        nfn->vals = relocate(nfn->vals);
-        nfn->bcode = relocate(nfn->bcode);
+        nfn->env = relocate(fl_ctx, fn->env);
+        nfn->vals = relocate(fl_ctx, nfn->vals);
+        nfn->bcode = relocate(fl_ctx, nfn->bcode);
         nfn->name = fn->name;
         return nc;
     }
     else if (t == TAG_SYM) {
         gensym_t *gs = (gensym_t*)ptr(v);
-        gensym_t *ng = (gensym_t*)alloc_words(sizeof(gensym_t)/sizeof(void*));
+        gensym_t *ng = (gensym_t*)alloc_words(fl_ctx, sizeof(gensym_t)/sizeof(void*));
         ng->id = gs->id;
         ng->binding = gs->binding;
         ng->isconst = 0;
         nc = tagptr(ng, TAG_SYM);
         forward(v, nc);
         if (ng->binding != UNBOUND)
-            ng->binding = relocate(ng->binding);
+            ng->binding = relocate(fl_ctx, ng->binding);
         return nc;
     }
     return v;
 }
 
-value_t relocate_lispvalue(value_t v)
-{
-    return relocate(v);
-}
-
-static void trace_globals(symbol_t *root)
-{
-    while (root != NULL) {
-        if (root->binding != UNBOUND)
-            root->binding = relocate(root->binding);
-        trace_globals(root->left);
-        root = root->right;
-    }
-}
-
-static value_t memory_exception_value;
-
-void gc(int mustgrow)
+void gc(fl_context_t *fl_ctx, int mustgrow)
 {
     void *temp;
     uint32_t i, f, top;
     fl_readstate_t *rs;
 #ifdef MEMDEBUG2
-    temp = tochain;
-    tochain = NULL;
-    n_allocd = -100000000000LL;
+    temp = fl_ctx->tochain;
+    fl_ctx->tochain = NULL;
+    fl_ctx->n_allocd = -100000000000LL;
 #else
-    static int grew = 0;
-    size_t hsz = grew ? heapsize*2 : heapsize;
+    size_t hsz = fl_ctx->gc_grew ? fl_ctx->heapsize*2 : fl_ctx->heapsize;
 #ifdef MEMDEBUG
-    tospace = LLT_ALLOC(hsz);
+    fl_ctx->tospace = LLT_ALLOC(hsz);
 #endif
-    curheap = tospace;
-    lim = curheap + hsz - sizeof(cons_t);
+    fl_ctx->curheap = fl_ctx->tospace;
+    fl_ctx->lim = fl_ctx->curheap + hsz - sizeof(cons_t);
 #endif
 
-    if (fl_throwing_frame > curr_frame) {
-        top = fl_throwing_frame - 3;
-        f = Stack[fl_throwing_frame-3];
+    if (fl_ctx->throwing_frame > fl_ctx->curr_frame) {
+        top = fl_ctx->throwing_frame - 3;
+        f = fl_ctx->Stack[fl_ctx->throwing_frame-3];
     }
     else {
-        top = SP;
-        f = curr_frame;
+        top = fl_ctx->SP;
+        f = fl_ctx->curr_frame;
     }
     while (1) {
         for (i=f; i < top; i++)
-            Stack[i] = relocate(Stack[i]);
+            fl_ctx->Stack[i] = relocate(fl_ctx, fl_ctx->Stack[i]);
         if (f == 0) break;
         top = f - 3;
-        f = Stack[f-3];
+        f = fl_ctx->Stack[f-3];
     }
-    for (i=0; i < N_GCHND; i++)
-        *GCHandleStack[i] = relocate(*GCHandleStack[i]);
-    trace_globals(symtab);
-    relocate_typetable();
-    rs = readstate;
+    for (i=0; i < fl_ctx->N_GCHND; i++)
+        *fl_ctx->GCHandleStack[i] = relocate(fl_ctx, *fl_ctx->GCHandleStack[i]);
+    trace_globals(fl_ctx, fl_ctx->symtab);
+    relocate_typetable(fl_ctx);
+    rs = fl_ctx->readstate;
     while (rs) {
         for(i=0; i < rs->backrefs.size; i++)
-            rs->backrefs.table[i] = (void*)relocate((value_t)rs->backrefs.table[i]);
+            rs->backrefs.table[i] = (void*)relocate(fl_ctx, (value_t)rs->backrefs.table[i]);
         for(i=0; i < rs->gensyms.size; i++)
-            rs->gensyms.table[i] = (void*)relocate((value_t)rs->gensyms.table[i]);
-        rs->source = relocate(rs->source);
+            rs->gensyms.table[i] = (void*)relocate(fl_ctx, (value_t)rs->gensyms.table[i]);
+        rs->source = relocate(fl_ctx, rs->source);
         rs = rs->prev;
     }
-    fl_lasterror = relocate(fl_lasterror);
-    memory_exception_value = relocate(memory_exception_value);
-    the_empty_vector = relocate(the_empty_vector);
+    fl_ctx->lasterror = relocate(fl_ctx, fl_ctx->lasterror);
+    fl_ctx->memory_exception_value = relocate(fl_ctx, fl_ctx->memory_exception_value);
+    fl_ctx->the_empty_vector = relocate(fl_ctx, fl_ctx->the_empty_vector);
 
-    sweep_finalizers();
+    sweep_finalizers(fl_ctx);
 
 #ifdef MEMDEBUG2
     while (temp != NULL) {
@@ -657,200 +606,200 @@ void gc(int mustgrow)
         free(&((void**)temp)[-1]);
         temp = next;
     }
-    n_allocd = 0;
+    fl_n_ctx->allocd = 0;
 #else
 #ifdef VERBOSEGC
     printf("GC: found %d/%d live conses\n",
-           (curheap-tospace)/sizeof(cons_t), heapsize/sizeof(cons_t));
+           (fl_ctx->curheap-fl_ctx->tospace)/sizeof(cons_t), fl_ctx->heapsize/sizeof(cons_t));
 #endif
 
-    temp = tospace;
-    tospace = fromspace;
-    fromspace = (unsigned char*)temp;
+    temp = fl_ctx->tospace;
+    fl_ctx->tospace = fl_ctx->fromspace;
+    fl_ctx->fromspace = (unsigned char*)temp;
 
     // if we're using > 80% of the space, resize tospace so we have
     // more space to fill next time. if we grew tospace last time,
     // grow the other half of the heap this time to catch up.
-    if (grew || mustgrow
+    if (fl_ctx->gc_grew || mustgrow
 #ifdef MEMDEBUG
         // GC more often
-        || ((lim-curheap) < (int)(heapsize/128))
+        || ((fl_ctx->lim-fl_ctx->curheap) < (int)(fl_ctx->heapsize/128))
 #else
-        || ((lim-curheap) < (int)(heapsize/5))
+        || ((fl_ctx->lim-fl_ctx->curheap) < (int)(fl_ctx->heapsize/5))
 #endif
         ) {
-        temp = LLT_REALLOC(tospace, heapsize*2);
+        temp = LLT_REALLOC(fl_ctx->tospace, fl_ctx->heapsize*2);
         if (temp == NULL)
-            fl_raise(memory_exception_value);
-        tospace = (unsigned char*)temp;
-        if (grew) {
-            heapsize*=2;
-            temp = bitvector_resize(consflags, 0, heapsize/sizeof(cons_t), 1);
+            fl_raise(fl_ctx, fl_ctx->memory_exception_value);
+        fl_ctx->tospace = (unsigned char*)temp;
+        if (fl_ctx->gc_grew) {
+            fl_ctx->heapsize*=2;
+            temp = bitvector_resize(fl_ctx->consflags, 0, fl_ctx->heapsize/sizeof(cons_t), 1);
             if (temp == NULL)
-                fl_raise(memory_exception_value);
-            consflags = (uint32_t*)temp;
+                fl_raise(fl_ctx, fl_ctx->memory_exception_value);
+            fl_ctx->consflags = (uint32_t*)temp;
         }
-        grew = !grew;
+        fl_ctx->gc_grew = !fl_ctx->gc_grew;
     }
 #ifdef MEMDEBUG
-    LLT_FREE(tospace);
+    LLT_FREE(fl_ctx->tospace);
 #endif
-    if ((value_t*)curheap > ((value_t*)lim)-2) {
+    if ((value_t*)fl_ctx->curheap > ((value_t*)fl_ctx->lim)-2) {
         // all data was live; gc again and grow heap.
         // but also always leave at least 4 words available, so a closure
         // can be allocated without an extra check.
-        gc(0);
+        gc(fl_ctx, 0);
     }
 #endif
 }
 
-static void grow_stack(void)
+static void grow_stack(fl_context_t *fl_ctx)
 {
-    size_t newsz = N_STACK + (N_STACK>>1);
-    value_t *ns = (value_t*)realloc(Stack, newsz*sizeof(value_t));
+    size_t newsz = fl_ctx->N_STACK + (fl_ctx->N_STACK>>1);
+    value_t *ns = (value_t*)realloc(fl_ctx->Stack, newsz*sizeof(value_t));
     if (ns == NULL)
-        lerror(OutOfMemoryError, "stack overflow");
-    Stack = ns;
-    N_STACK = newsz;
+        lerror(fl_ctx, fl_ctx->OutOfMemoryError, "stack overflow");
+    fl_ctx->Stack = ns;
+    fl_ctx->N_STACK = newsz;
 }
 
 // utils ----------------------------------------------------------------------
 
 // apply function with n args on the stack
-static value_t _applyn(uint32_t n)
+static value_t _applyn(fl_context_t *fl_ctx, uint32_t n)
 {
-    value_t f = Stack[SP-n-1];
-    uint32_t saveSP = SP;
+    value_t f = fl_ctx->Stack[fl_ctx->SP-n-1];
+    uint32_t saveSP = fl_ctx->SP;
     value_t v;
-    if (iscbuiltin(f)) {
-        v = ((builtin_t*)ptr(f))[3](&Stack[SP-n], n);
+    if (iscbuiltin(fl_ctx, f)) {
+        v = ((builtin_t*)ptr(f))[3](fl_ctx, &fl_ctx->Stack[fl_ctx->SP-n], n);
     }
     else if (isfunction(f)) {
-        v = apply_cl(n);
+        v = apply_cl(fl_ctx, n);
     }
     else if (isbuiltin(f)) {
-        value_t tab = symbol_value(builtins_table_sym);
-        Stack[SP-n-1] = vector_elt(tab, uintval(f));
-        v = apply_cl(n);
+        value_t tab = symbol_value(fl_ctx->builtins_table_sym);
+        fl_ctx->Stack[fl_ctx->SP-n-1] = vector_elt(tab, uintval(f));
+        v = apply_cl(fl_ctx, n);
     }
     else {
-        type_error("apply", "function", f);
+        type_error(fl_ctx, "apply", "function", f);
     }
-    SP = saveSP;
+    fl_ctx->SP = saveSP;
     return v;
 }
 
-value_t fl_apply(value_t f, value_t l)
+value_t fl_apply(fl_context_t *fl_ctx, value_t f, value_t l)
 {
     value_t v = l;
-    uint32_t n = SP;
+    uint32_t n = fl_ctx->SP;
 
-    PUSH(f);
+    PUSH(fl_ctx, f);
     while (iscons(v)) {
-        if (SP >= N_STACK)
-            grow_stack();
-        PUSH(car_(v));
+        if (fl_ctx->SP >= fl_ctx->N_STACK)
+            grow_stack(fl_ctx);
+        PUSH(fl_ctx, car_(v));
         v = cdr_(v);
     }
-    n = SP - n - 1;
-    v = _applyn(n);
-    POPN(n+1);
+    n = fl_ctx->SP - n - 1;
+    v = _applyn(fl_ctx, n);
+    POPN(fl_ctx, n+1);
     return v;
 }
 
-value_t fl_applyn(uint32_t n, value_t f, ...)
+value_t fl_applyn(fl_context_t *fl_ctx, uint32_t n, value_t f, ...)
 {
     va_list ap;
     va_start(ap, f);
     size_t i;
 
-    PUSH(f);
-    while (SP+n > N_STACK)
-        grow_stack();
+    PUSH(fl_ctx, f);
+    while (fl_ctx->SP+n > fl_ctx->N_STACK)
+        grow_stack(fl_ctx);
     for(i=0; i < n; i++) {
         value_t a = va_arg(ap, value_t);
-        PUSH(a);
+        PUSH(fl_ctx, a);
     }
-    value_t v = _applyn(n);
-    POPN(n+1);
+    value_t v = _applyn(fl_ctx, n);
+    POPN(fl_ctx, n+1);
     va_end(ap);
     return v;
 }
 
-value_t fl_listn(size_t n, ...)
+value_t fl_listn(fl_context_t *fl_ctx, size_t n, ...)
 {
     va_list ap;
     va_start(ap, n);
-    uint32_t si = SP;
+    uint32_t si = fl_ctx->SP;
     size_t i;
 
-    while (SP+n > N_STACK)
-        grow_stack();
+    while (fl_ctx->SP+n > fl_ctx->N_STACK)
+        grow_stack(fl_ctx);
     for(i=0; i < n; i++) {
         value_t a = va_arg(ap, value_t);
-        PUSH(a);
+        PUSH(fl_ctx, a);
     }
 #ifdef MEMDEBUG2
-    si = SP-1;
-    value_t l = NIL;
+    si = fl_ctx->SP-1;
+    value_t l = fl_ctx->NIL;
     for(i=0; i < n; i++) {
-        l = fl_cons(Stack[si--], l);
+        l = fl_cons(fl_ctx, fl_ctx->Stack[si--], l);
     }
-    POPN(n);
+    POPN(fl_ctx, n);
     va_end(ap);
     return l;
 #else
-    cons_t *c = (cons_t*)alloc_words(n*2);
+    cons_t *c = (cons_t*)alloc_words(fl_ctx, n*2);
     cons_t *l = c;
     for(i=0; i < n; i++) {
-        c->car = Stack[si++];
+        c->car = fl_ctx->Stack[si++];
         c->cdr = tagptr(c+1, TAG_CONS);
         c++;
     }
-    (c-1)->cdr = NIL;
-    POPN(n);
+    (c-1)->cdr = fl_ctx->NIL;
+    POPN(fl_ctx, n);
     va_end(ap);
     return tagptr(l, TAG_CONS);
 #endif
 }
 
-value_t fl_list2(value_t a, value_t b)
+value_t fl_list2(fl_context_t *fl_ctx, value_t a, value_t b)
 {
-    PUSH(a);
-    PUSH(b);
+    PUSH(fl_ctx, a);
+    PUSH(fl_ctx, b);
 #ifdef MEMDEBUG2
-    Stack[SP-1] = fl_cons(b, NIL);
-    a = fl_cons(Stack[SP-2], Stack[SP-1]);
-    POPN(2);
+    fl_ctx->Stack[fl_ctx->SP-1] = fl_cons(fl_ctx, b, fl_ctx->NIL);
+    a = fl_cons(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2], fl_ctx->Stack[fl_ctx->SP-1]);
+    POPN(fl_ctx, 2);
     return a;
 #else
-    cons_t *c = (cons_t*)alloc_words(4);
-    b = POP();
-    a = POP();
+    cons_t *c = (cons_t*)alloc_words(fl_ctx, 4);
+    b = POP(fl_ctx);
+    a = POP(fl_ctx);
     c[0].car = a;
     c[0].cdr = tagptr(c+1, TAG_CONS);
     c[1].car = b;
-    c[1].cdr = NIL;
+    c[1].cdr = fl_ctx->NIL;
     return tagptr(c, TAG_CONS);
 #endif
 }
 
-value_t fl_cons(value_t a, value_t b)
+value_t fl_cons(fl_context_t *fl_ctx, value_t a, value_t b)
 {
-    PUSH(a);
-    PUSH(b);
-    value_t c = mk_cons();
-    cdr_(c) = POP();
-    car_(c) = POP();
+    PUSH(fl_ctx, a);
+    PUSH(fl_ctx, b);
+    value_t c = mk_cons(fl_ctx);
+    cdr_(c) = POP(fl_ctx);
+    car_(c) = POP(fl_ctx);
     return c;
 }
 
-int fl_isnumber(value_t v)
+int fl_isnumber(fl_context_t *fl_ctx, value_t v)
 {
     if (isfixnum(v)) return 1;
     if (iscprim(v)) {
         cprim_t *c = (cprim_t*)ptr(v);
-        return c->type != wchartype;
+        return c->type != fl_ctx->wchartype;
     }
     return 0;
 }
@@ -865,9 +814,9 @@ int fl_isnumber(value_t v)
 
 // eval -----------------------------------------------------------------------
 
-#define list(a,n) _list((a),(n),0)
+#define list(fl_ctx, a,n) _list(fl_ctx, (a), (n), 0)
 
-static value_t _list(value_t *args, uint32_t nargs, int star)
+static value_t _list(fl_context_t *fl_ctx, value_t *args, uint32_t nargs, int star)
 {
     cons_t *c;
     int i;
@@ -876,7 +825,7 @@ static value_t _list(value_t *args, uint32_t nargs, int star)
     value_t n;
     i = nargs-1;
     if (star) {
-        n = mk_cons();
+        n = mk_cons(fl_ctx);
         c = (cons_t*)ptr(n);
         c->car = args[i-1];
         c->cdr = args[i];
@@ -884,19 +833,19 @@ static value_t _list(value_t *args, uint32_t nargs, int star)
         v = n;
     }
     else {
-        v = NIL;
+        v = fl_ctx->NIL;
     }
-    PUSH(v);
+    PUSH(fl_ctx, v);
     for(; i >= 0; i--) {
-        n = mk_cons();
+        n = mk_cons(fl_ctx);
         c = (cons_t*)ptr(n);
         c->car = args[i];
-        c->cdr = Stack[SP-1];
-        Stack[SP-1] = n;
+        c->cdr = fl_ctx->Stack[fl_ctx->SP-1];
+        fl_ctx->Stack[fl_ctx->SP-1] = n;
     }
-    v = POP();
+    v = POP(fl_ctx);
 #else
-    v = cons_reserve(nargs);
+    v = cons_reserve(fl_ctx, nargs);
     c = (cons_t*)ptr(v);
     for(i=0; i < nargs; i++) {
         c->car = args[i];
@@ -906,56 +855,56 @@ static value_t _list(value_t *args, uint32_t nargs, int star)
     if (star)
         (c-2)->cdr = (c-1)->car;
     else
-        (c-1)->cdr = NIL;
+        (c-1)->cdr = fl_ctx->NIL;
 #endif
     return v;
 }
 
-static value_t copy_list(value_t L)
+static value_t copy_list(fl_context_t *fl_ctx, value_t L)
 {
     if (!iscons(L))
-        return NIL;
-    PUSH(NIL);
-    PUSH(L);
-    value_t *plcons = &Stack[SP-2];
-    value_t *pL = &Stack[SP-1];
+        return fl_ctx->NIL;
+    PUSH(fl_ctx, fl_ctx->NIL);
+    PUSH(fl_ctx, L);
+    value_t *plcons = &fl_ctx->Stack[fl_ctx->SP-2];
+    value_t *pL = &fl_ctx->Stack[fl_ctx->SP-1];
     value_t c;
-    c = mk_cons(); PUSH(c);  // save first cons
+    c = mk_cons(fl_ctx); PUSH(fl_ctx, c);  // save first cons
     car_(c) = car_(*pL);
-    cdr_(c) = NIL;
+    cdr_(c) = fl_ctx->NIL;
     *plcons = c;
     *pL = cdr_(*pL);
     while (iscons(*pL)) {
-        c = mk_cons();
+        c = mk_cons(fl_ctx);
         car_(c) = car_(*pL);
-        cdr_(c) = NIL;
+        cdr_(c) = fl_ctx->NIL;
         cdr_(*plcons) = c;
         *plcons = c;
         *pL = cdr_(*pL);
     }
-    c = POP();  // first cons
-    POPN(2);
+    c = POP(fl_ctx);  // first cons
+    POPN(fl_ctx, 2);
     return c;
 }
 
-static value_t do_trycatch(void)
+static value_t do_trycatch(fl_context_t *fl_ctx)
 {
-    uint32_t saveSP = SP;
+    uint32_t saveSP = fl_ctx->SP;
     value_t v;
-    value_t thunk = Stack[SP-2];
-    Stack[SP-2] = Stack[SP-1];
-    Stack[SP-1] = thunk;
+    value_t thunk = fl_ctx->Stack[fl_ctx->SP-2];
+    fl_ctx->Stack[fl_ctx->SP-2] = fl_ctx->Stack[fl_ctx->SP-1];
+    fl_ctx->Stack[fl_ctx->SP-1] = thunk;
 
-    FL_TRY {
-        v = apply_cl(0);
+    FL_TRY(fl_ctx) {
+        v = apply_cl(fl_ctx, 0);
     }
-    FL_CATCH {
-        v = Stack[saveSP-2];
-        PUSH(v);
-        PUSH(fl_lasterror);
-        v = apply_cl(1);
+    FL_CATCH(fl_ctx) {
+        v = fl_ctx->Stack[saveSP-2];
+        PUSH(fl_ctx, v);
+        PUSH(fl_ctx, fl_ctx->lasterror);
+        v = apply_cl(fl_ctx, 1);
     }
-    SP = saveSP;
+    fl_ctx->SP = saveSP;
     return v;
 }
 
@@ -963,7 +912,7 @@ static value_t do_trycatch(void)
   argument layout on stack is
   |--required args--|--opt args--|--kw args--|--rest args...
 */
-static uint32_t process_keys(value_t kwtable,
+static uint32_t process_keys(fl_context_t *fl_ctx, value_t kwtable,
                              uint32_t nreq, uint32_t nkw, uint32_t nopt,
                              uint32_t bp, uint32_t nargs, int va)
 {
@@ -973,14 +922,14 @@ static uint32_t process_keys(value_t kwtable,
     value_t *args = (value_t*)alloca(extr*sizeof(value_t));
     value_t v;
     uint32_t i, a = 0, nrestargs;
-    value_t s1 = Stack[SP-1];
-    value_t s3 = Stack[SP-3];
-    value_t s4 = Stack[SP-4];
+    value_t s1 = fl_ctx->Stack[fl_ctx->SP-1];
+    value_t s3 = fl_ctx->Stack[fl_ctx->SP-3];
+    value_t s4 = fl_ctx->Stack[fl_ctx->SP-4];
     if (nargs < nreq)
-        lerror(ArgError, "apply: too few arguments");
+        lerror(fl_ctx, fl_ctx->ArgError, "apply: too few arguments");
     for (i=0; i < extr; i++) args[i] = UNBOUND;
     for (i=nreq; i < nargs; i++) {
-        v = Stack[bp+i];
+        v = fl_ctx->Stack[bp+i];
         if (issymbol(v) && iskeyword((symbol_t*)ptr(v)))
             break;
         if (a >= nopt)
@@ -993,8 +942,8 @@ static uint32_t process_keys(value_t kwtable,
     do {
         i++;
         if (i >= nargs)
-            lerrorf(ArgError, "keyword %s requires an argument",
-                    symbol_name(v));
+            lerrorf(fl_ctx, fl_ctx->ArgError, "keyword %s requires an argument",
+                    symbol_name(fl_ctx, v));
         value_t hv = fixnum(((symbol_t*)ptr(v))->hash);
         uptrint_t x = 2*(labs(numval(hv)) % n);
         if (vector_elt(kwtable, x) == v) {
@@ -1003,31 +952,31 @@ static uint32_t process_keys(value_t kwtable,
             idx += nopt;
             if (args[idx] == UNBOUND) {
                 // if duplicate key, keep first value
-                args[idx] = Stack[bp+i];
+                args[idx] = fl_ctx->Stack[bp+i];
             }
         }
         else {
-            lerrorf(ArgError, "unsupported keyword %s", symbol_name(v));
+            lerrorf(fl_ctx, fl_ctx->ArgError, "unsupported keyword %s", symbol_name(fl_ctx, v));
         }
         i++;
         if (i >= nargs) break;
-        v = Stack[bp+i];
+        v = fl_ctx->Stack[bp+i];
     } while (issymbol(v) && iskeyword((symbol_t*)ptr(v)));
  no_kw:
     nrestargs = nargs - i;
     if (!va && nrestargs > 0)
-        lerror(ArgError, "apply: too many arguments");
+        lerror(fl_ctx, fl_ctx->ArgError, "apply: too many arguments");
     nargs = ntot + nrestargs;
     if (nrestargs)
-        memmove(&Stack[bp+ntot], &Stack[bp+i], nrestargs*sizeof(value_t));
-    memcpy(&Stack[bp+nreq], args, extr*sizeof(value_t));
-    SP = bp + nargs;
-    assert(SP < N_STACK-4);
-    PUSH(s4);
-    PUSH(s3);
-    PUSH(nargs);
-    PUSH(s1);
-    curr_frame = SP;
+        memmove(&fl_ctx->Stack[bp+ntot], &fl_ctx->Stack[bp+i], nrestargs*sizeof(value_t));
+    memcpy(&fl_ctx->Stack[bp+nreq], args, extr*sizeof(value_t));
+    fl_ctx->SP = bp + nargs;
+    assert(fl_ctx->SP < fl_ctx->N_STACK-4);
+    PUSH(fl_ctx, s4);
+    PUSH(fl_ctx, s3);
+    PUSH(fl_ctx, nargs);
+    PUSH(fl_ctx, s1);
+    fl_ctx->curr_frame = fl_ctx->SP;
     return nargs;
 }
 
@@ -1065,18 +1014,18 @@ static uint32_t process_keys(value_t kwtable,
   - put the stack in this state
   - provide arg count
   - respect tail position
-  - restore SP
+  - restore fl_ctx->SP
 
   callee's responsibility:
   - check arg counts
   - allocate vararg array
   - push closed env, set up new environment
 */
-static value_t apply_cl(uint32_t nargs)
+static value_t apply_cl(fl_context_t *fl_ctx, uint32_t nargs)
 {
     VM_LABELS;
     VM_APPLY_LABELS;
-    uint32_t top_frame = curr_frame;
+    uint32_t top_frame = fl_ctx->curr_frame;
     // frame variables
     uint32_t n=0;
     uint32_t bp;
@@ -1089,28 +1038,30 @@ static value_t apply_cl(uint32_t nargs)
 #endif
     uint32_t i;
     symbol_t *sym;
-    static cons_t *c;
-    static value_t *pv;
-    static int64_t accum;
-    static value_t func, v, e;
+#define fl_apply_c fl_ctx->apply_c
+#define fl_apply_pv fl_ctx->apply_pv
+#define fl_apply_accum fl_ctx->apply_accum
+#define fl_apply_func fl_ctx->apply_func
+#define fl_apply_v fl_ctx->apply_v
+#define fl_apply_e fl_ctx->apply_e
 
  apply_cl_top:
-    func = Stack[SP-nargs-1];
-    ip = (uint8_t*)cv_data((cvalue_t*)ptr(fn_bcode(func)));
+    fl_apply_func = fl_ctx->Stack[fl_ctx->SP-nargs-1];
+    ip = (uint8_t*)cv_data((cvalue_t*)ptr(fn_bcode(fl_apply_func)));
 #ifndef MEMDEBUG2
-    assert(!ismanaged((uptrint_t)ip));
+    assert(!ismanaged(fl_ctx, (uptrint_t)ip));
 #endif
-    while (SP+GET_INT32(ip) > N_STACK) {
-        grow_stack();
+    while (fl_ctx->SP+GET_INT32(ip) > fl_ctx->N_STACK) {
+        grow_stack(fl_ctx);
     }
     ip += 4;
 
-    bp = SP-nargs;
-    PUSH(fn_env(func));
-    PUSH(curr_frame);
-    PUSH(nargs);
-    SP++;//PUSH(0); //ip
-    curr_frame = SP;
+    bp = fl_ctx->SP-nargs;
+    PUSH(fl_ctx, fn_env(fl_apply_func));
+    PUSH(fl_ctx, fl_ctx->curr_frame);
+    PUSH(fl_ctx, nargs);
+    fl_ctx->SP++;//PUSH(fl_ctx, 0); //ip
+    fl_ctx->curr_frame = fl_ctx->SP;
 
     {
 #ifdef USE_COMPUTED_GOTO
@@ -1127,9 +1078,9 @@ static value_t apply_cl(uint32_t nargs)
         do_argc:
             if (nargs != n) {
                 if (nargs > n)
-                    lerror(ArgError, "apply: too many arguments");
+                    lerror(fl_ctx, fl_ctx->ArgError, "apply: too many arguments");
                 else
-                    lerror(ArgError, "apply: too few arguments");
+                    lerror(fl_ctx, fl_ctx->ArgError, "apply: too few arguments");
             }
             NEXT_OP;
         OP(OP_VARGC)
@@ -1137,27 +1088,27 @@ static value_t apply_cl(uint32_t nargs)
         do_vargc:
             s = (fixnum_t)nargs - (fixnum_t)i;
             if (s > 0) {
-                v = list(&Stack[bp+i], s);
-                Stack[bp+i] = v;
+                fl_apply_v = list(fl_ctx, &fl_ctx->Stack[bp+i], s);
+                fl_ctx->Stack[bp+i] = fl_apply_v;
                 if (s > 1) {
-                    Stack[bp+i+1] = Stack[bp+nargs+0];
-                    Stack[bp+i+2] = Stack[bp+nargs+1];
-                    Stack[bp+i+3] = i+1;
-                    Stack[bp+i+4] = 0;
-                    SP =  bp+i+5;
-                    curr_frame = SP;
+                    fl_ctx->Stack[bp+i+1] = fl_ctx->Stack[bp+nargs+0];
+                    fl_ctx->Stack[bp+i+2] = fl_ctx->Stack[bp+nargs+1];
+                    fl_ctx->Stack[bp+i+3] = i+1;
+                    fl_ctx->Stack[bp+i+4] = 0;
+                    fl_ctx->SP =  bp+i+5;
+                    fl_ctx->curr_frame = fl_ctx->SP;
                 }
             }
             else if (s < 0) {
-                lerror(ArgError, "apply: too few arguments");
+                lerror(fl_ctx, fl_ctx->ArgError, "apply: too few arguments");
             }
             else {
-                SP++;
-                Stack[SP-2] = i+1;
-                Stack[SP-3] = Stack[SP-4];
-                Stack[SP-4] = Stack[SP-5];
-                Stack[SP-5] = NIL;
-                curr_frame = SP;
+                fl_ctx->SP++;
+                fl_ctx->Stack[fl_ctx->SP-2] = i+1;
+                fl_ctx->Stack[fl_ctx->SP-3] = fl_ctx->Stack[fl_ctx->SP-4];
+                fl_ctx->Stack[fl_ctx->SP-4] = fl_ctx->Stack[fl_ctx->SP-5];
+                fl_ctx->Stack[fl_ctx->SP-5] = fl_ctx->NIL;
+                fl_ctx->curr_frame = fl_ctx->SP;
             }
             nargs = i+1;
             NEXT_OP;
@@ -1169,37 +1120,37 @@ static value_t apply_cl(uint32_t nargs)
             goto do_vargc;
         OP(OP_BRBOUND)
             i = GET_INT32(ip); ip+=4;
-            v = Stack[bp+i];
-            if (v != UNBOUND) PUSH(FL_T);
-            else PUSH(FL_F);
+            fl_apply_v = fl_ctx->Stack[bp+i];
+            if (fl_apply_v != UNBOUND) PUSH(fl_ctx, fl_ctx->T);
+            else PUSH(fl_ctx, fl_ctx->F);
             NEXT_OP;
-        OP(OP_DUP) SP++; Stack[SP-1] = Stack[SP-2]; NEXT_OP;
-        OP(OP_POP) POPN(1); NEXT_OP;
+        OP(OP_DUP) fl_ctx->SP++; fl_ctx->Stack[fl_ctx->SP-1] = fl_ctx->Stack[fl_ctx->SP-2]; NEXT_OP;
+        OP(OP_POP) POPN(fl_ctx, 1); NEXT_OP;
         OP(OP_TCALL)
             n = *ip++;  // nargs
         do_tcall:
-            func = Stack[SP-n-1];
-            if (tag(func) == TAG_FUNCTION) {
-                if (func > (N_BUILTINS<<3)) {
-                    curr_frame = Stack[curr_frame-3];
+            fl_apply_func = fl_ctx->Stack[fl_ctx->SP-n-1];
+            if (tag(fl_apply_func) == TAG_FUNCTION) {
+                if (fl_apply_func > (N_BUILTINS<<3)) {
+                    fl_ctx->curr_frame = fl_ctx->Stack[fl_ctx->curr_frame-3];
                     for(s=-1; s < (fixnum_t)n; s++)
-                        Stack[bp+s] = Stack[SP-n+s];
-                    SP = bp+n;
+                        fl_ctx->Stack[bp+s] = fl_ctx->Stack[fl_ctx->SP-n+s];
+                    fl_ctx->SP = bp+n;
                     nargs = n;
                     goto apply_cl_top;
                 }
                 else {
-                    i = uintval(func);
+                    i = uintval(fl_apply_func);
                     if (i <= OP_ASET) {
                         s = builtin_arg_counts[i];
                         if (s >= 0)
-                            argcount(builtin_names[i], n, s);
+                            argcount(fl_ctx, builtin_names[i], n, s);
                         else if (s != ANYARGS && (signed)n < -s)
-                            argcount(builtin_names[i], n, -s);
+                            argcount(fl_ctx, builtin_names[i], n, -s);
                         // remove function arg
-                        for(s=SP-n-1; s < (int)SP-1; s++)
-                            Stack[s] = Stack[s+1];
-                        SP--;
+                        for(s=fl_ctx->SP-n-1; s < (int)fl_ctx->SP-1; s++)
+                            fl_ctx->Stack[s] = fl_ctx->Stack[s+1];
+                        fl_ctx->SP--;
 #ifdef USE_COMPUTED_GOTO
                         if (i == OP_APPLY)
                             goto apply_tapply;
@@ -1221,37 +1172,37 @@ static value_t apply_cl(uint32_t nargs)
                     }
                 }
             }
-            else if (iscbuiltin(func)) {
-                s = SP;
-                v = ((builtin_t)(((void**)ptr(func))[3]))(&Stack[SP-n], n);
-                SP = s-n;
-                Stack[SP-1] = v;
+            else if (iscbuiltin(fl_ctx, fl_apply_func)) {
+                s = fl_ctx->SP;
+                fl_apply_v = ((builtin_t)(((void**)ptr(fl_apply_func))[3]))(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-n], n);
+                fl_ctx->SP = s-n;
+                fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
                 NEXT_OP;
             }
-            type_error("apply", "function", func);
+            type_error(fl_ctx, "apply", "function", fl_apply_func);
         // WARNING: repeated code ahead
         OP(OP_CALL)
             n = *ip++;  // nargs
         do_call:
-            func = Stack[SP-n-1];
-            if (tag(func) == TAG_FUNCTION) {
-                if (func > (N_BUILTINS<<3)) {
-                    Stack[curr_frame-1] = (uptrint_t)ip;
+            fl_apply_func = fl_ctx->Stack[fl_ctx->SP-n-1];
+            if (tag(fl_apply_func) == TAG_FUNCTION) {
+                if (fl_apply_func > (N_BUILTINS<<3)) {
+                    fl_ctx->Stack[fl_ctx->curr_frame-1] = (uptrint_t)ip;
                     nargs = n;
                     goto apply_cl_top;
                 }
                 else {
-                    i = uintval(func);
+                    i = uintval(fl_apply_func);
                     if (i <= OP_ASET) {
                         s = builtin_arg_counts[i];
                         if (s >= 0)
-                            argcount(builtin_names[i], n, s);
+                            argcount(fl_ctx, builtin_names[i], n, s);
                         else if (s != ANYARGS && (signed)n < -s)
-                            argcount(builtin_names[i], n, -s);
+                            argcount(fl_ctx, builtin_names[i], n, -s);
                         // remove function arg
-                        for(s=SP-n-1; s < (int)SP-1; s++)
-                            Stack[s] = Stack[s+1];
-                        SP--;
+                        for(s=fl_ctx->SP-n-1; s < (int)fl_ctx->SP-1; s++)
+                            fl_ctx->Stack[s] = fl_ctx->Stack[s+1];
+                        fl_ctx->SP--;
 #ifdef USE_COMPUTED_GOTO
                         goto *vm_apply_labels[i];
 #else
@@ -1271,223 +1222,223 @@ static value_t apply_cl(uint32_t nargs)
                     }
                 }
             }
-            else if (iscbuiltin(func)) {
-                s = SP;
-                v = ((builtin_t)(((void**)ptr(func))[3]))(&Stack[SP-n], n);
-                SP = s-n;
-                Stack[SP-1] = v;
+            else if (iscbuiltin(fl_ctx, fl_apply_func)) {
+                s = fl_ctx->SP;
+                fl_apply_v = ((builtin_t)(((void**)ptr(fl_apply_func))[3]))(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-n], n);
+                fl_ctx->SP = s-n;
+                fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
                 NEXT_OP;
             }
-            type_error("apply", "function", func);
+            type_error(fl_ctx, "apply", "function", fl_apply_func);
         OP(OP_TCALLL) n = GET_INT32(ip); ip+=4; goto do_tcall;
         OP(OP_CALLL)  n = GET_INT32(ip); ip+=4; goto do_call;
         OP(OP_JMP) ip += (ptrint_t)GET_INT16(ip); NEXT_OP;
         OP(OP_BRF)
-            v = POP();
-            if (v == FL_F) ip += (ptrint_t)GET_INT16(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v == fl_ctx->F) ip += (ptrint_t)GET_INT16(ip);
             else ip += 2;
             NEXT_OP;
         OP(OP_BRT)
-            v = POP();
-            if (v != FL_F) ip += (ptrint_t)GET_INT16(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v != fl_ctx->F) ip += (ptrint_t)GET_INT16(ip);
             else ip += 2;
             NEXT_OP;
         OP(OP_JMPL) ip += (ptrint_t)GET_INT32(ip); NEXT_OP;
         OP(OP_BRFL)
-            v = POP();
-            if (v == FL_F) ip += (ptrint_t)GET_INT32(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v == fl_ctx->F) ip += (ptrint_t)GET_INT32(ip);
             else ip += 4;
             NEXT_OP;
         OP(OP_BRTL)
-            v = POP();
-            if (v != FL_F) ip += (ptrint_t)GET_INT32(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v != fl_ctx->F) ip += (ptrint_t)GET_INT32(ip);
             else ip += 4;
             NEXT_OP;
         OP(OP_BRNE)
-            if (Stack[SP-2] != Stack[SP-1]) ip += (ptrint_t)GET_INT16(ip);
+            if (fl_ctx->Stack[fl_ctx->SP-2] != fl_ctx->Stack[fl_ctx->SP-1]) ip += (ptrint_t)GET_INT16(ip);
             else ip += 2;
-            POPN(2);
+            POPN(fl_ctx, 2);
             NEXT_OP;
         OP(OP_BRNEL)
-            if (Stack[SP-2] != Stack[SP-1]) ip += (ptrint_t)GET_INT32(ip);
+            if (fl_ctx->Stack[fl_ctx->SP-2] != fl_ctx->Stack[fl_ctx->SP-1]) ip += (ptrint_t)GET_INT32(ip);
             else ip += 4;
-            POPN(2);
+            POPN(fl_ctx, 2);
             NEXT_OP;
         OP(OP_BRNN)
-            v = POP();
-            if (v != NIL) ip += (ptrint_t)GET_INT16(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v != fl_ctx->NIL) ip += (ptrint_t)GET_INT16(ip);
             else ip += 2;
             NEXT_OP;
         OP(OP_BRNNL)
-            v = POP();
-            if (v != NIL) ip += (ptrint_t)GET_INT32(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v != fl_ctx->NIL) ip += (ptrint_t)GET_INT32(ip);
             else ip += 4;
             NEXT_OP;
         OP(OP_BRN)
-            v = POP();
-            if (v == NIL) ip += (ptrint_t)GET_INT16(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v == fl_ctx->NIL) ip += (ptrint_t)GET_INT16(ip);
             else ip += 2;
             NEXT_OP;
         OP(OP_BRNL)
-            v = POP();
-            if (v == NIL) ip += (ptrint_t)GET_INT32(ip);
+            fl_apply_v = POP(fl_ctx);
+            if (fl_apply_v == fl_ctx->NIL) ip += (ptrint_t)GET_INT32(ip);
             else ip += 4;
             NEXT_OP;
         OP(OP_RET)
-            v = POP();
-            SP = curr_frame;
-            curr_frame = Stack[SP-3];
-            if (curr_frame == top_frame) return v;
-            SP -= (4+nargs);
-            ip = (uint8_t*)Stack[curr_frame-1];
-            nargs        = Stack[curr_frame-2];
-            bp           = curr_frame - 4 - nargs;
-            Stack[SP-1] = v;
+            fl_apply_v = POP(fl_ctx);
+            fl_ctx->SP = fl_ctx->curr_frame;
+            fl_ctx->curr_frame = fl_ctx->Stack[fl_ctx->SP-3];
+            if (fl_ctx->curr_frame == top_frame) return fl_apply_v;
+            fl_ctx->SP -= (4+nargs);
+            ip = (uint8_t*)fl_ctx->Stack[fl_ctx->curr_frame-1];
+            nargs        = fl_ctx->Stack[fl_ctx->curr_frame-2];
+            bp           = fl_ctx->curr_frame - 4 - nargs;
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
 
         OP(OP_EQ)
-            Stack[SP-2] = ((Stack[SP-2] == Stack[SP-1]) ? FL_T : FL_F);
-            POPN(1); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-2] = ((fl_ctx->Stack[fl_ctx->SP-2] == fl_ctx->Stack[fl_ctx->SP-1]) ? fl_ctx->T : fl_ctx->F);
+            POPN(fl_ctx, 1); NEXT_OP;
         OP(OP_EQV)
-            if (Stack[SP-2] == Stack[SP-1]) {
-                v = FL_T;
+            if (fl_ctx->Stack[fl_ctx->SP-2] == fl_ctx->Stack[fl_ctx->SP-1]) {
+                fl_apply_v = fl_ctx->T;
             }
-            else if (!leafp(Stack[SP-2]) || !leafp(Stack[SP-1])) {
-                v = FL_F;
+            else if (!leafp(fl_ctx->Stack[fl_ctx->SP-2]) || !leafp(fl_ctx->Stack[fl_ctx->SP-1])) {
+                fl_apply_v = fl_ctx->F;
             }
             else {
-                v = (compare_(Stack[SP-2], Stack[SP-1], 1)==0 ? FL_T : FL_F);
+                fl_apply_v = (compare_(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2], fl_ctx->Stack[fl_ctx->SP-1], 1)==0 ? fl_ctx->T : fl_ctx->F);
             }
-            Stack[SP-2] = v; POPN(1);
+            fl_ctx->Stack[fl_ctx->SP-2] = fl_apply_v; POPN(fl_ctx, 1);
             NEXT_OP;
         OP(OP_EQUAL)
-            if (Stack[SP-2] == Stack[SP-1]) {
-                v = FL_T;
+            if (fl_ctx->Stack[fl_ctx->SP-2] == fl_ctx->Stack[fl_ctx->SP-1]) {
+                fl_apply_v = fl_ctx->T;
             }
             else {
-                v = (compare_(Stack[SP-2], Stack[SP-1], 1)==0 ? FL_T : FL_F);
+                fl_apply_v = (compare_(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2], fl_ctx->Stack[fl_ctx->SP-1], 1)==0 ? fl_ctx->T : fl_ctx->F);
             }
-            Stack[SP-2] = v; POPN(1);
+            fl_ctx->Stack[fl_ctx->SP-2] = fl_apply_v; POPN(fl_ctx, 1);
             NEXT_OP;
         OP(OP_PAIRP)
-            Stack[SP-1] = (iscons(Stack[SP-1]) ? FL_T : FL_F); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-1] = (iscons(fl_ctx->Stack[fl_ctx->SP-1]) ? fl_ctx->T : fl_ctx->F); NEXT_OP;
         OP(OP_ATOMP)
-            Stack[SP-1] = (iscons(Stack[SP-1]) ? FL_F : FL_T); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-1] = (iscons(fl_ctx->Stack[fl_ctx->SP-1]) ? fl_ctx->F : fl_ctx->T); NEXT_OP;
         OP(OP_NOT)
-            Stack[SP-1] = ((Stack[SP-1]==FL_F) ? FL_T : FL_F); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-1] = ((fl_ctx->Stack[fl_ctx->SP-1]==fl_ctx->F) ? fl_ctx->T : fl_ctx->F); NEXT_OP;
         OP(OP_NULLP)
-            Stack[SP-1] = ((Stack[SP-1]==NIL) ? FL_T : FL_F); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-1] = ((fl_ctx->Stack[fl_ctx->SP-1]==fl_ctx->NIL) ? fl_ctx->T : fl_ctx->F); NEXT_OP;
         OP(OP_BOOLEANP)
-            v = Stack[SP-1];
-            Stack[SP-1] = ((v == FL_T || v == FL_F) ? FL_T:FL_F); NEXT_OP;
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
+            fl_ctx->Stack[fl_ctx->SP-1] = ((fl_apply_v == fl_ctx->T || fl_apply_v == fl_ctx->F) ? fl_ctx->T:fl_ctx->F); NEXT_OP;
         OP(OP_SYMBOLP)
-            Stack[SP-1] = (issymbol(Stack[SP-1]) ? FL_T : FL_F); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-1] = (issymbol(fl_ctx->Stack[fl_ctx->SP-1]) ? fl_ctx->T : fl_ctx->F); NEXT_OP;
         OP(OP_NUMBERP)
-            v = Stack[SP-1];
-            Stack[SP-1] = (fl_isnumber(v) ? FL_T:FL_F); NEXT_OP;
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
+            fl_ctx->Stack[fl_ctx->SP-1] = (fl_isnumber(fl_ctx, fl_apply_v) ? fl_ctx->T:fl_ctx->F); NEXT_OP;
         OP(OP_FIXNUMP)
-            Stack[SP-1] = (isfixnum(Stack[SP-1]) ? FL_T : FL_F); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-1] = (isfixnum(fl_ctx->Stack[fl_ctx->SP-1]) ? fl_ctx->T : fl_ctx->F); NEXT_OP;
         OP(OP_BOUNDP)
-            sym = tosymbol(Stack[SP-1], "bound?");
-            Stack[SP-1] = ((sym->binding == UNBOUND) ? FL_F : FL_T);
+            sym = tosymbol(fl_ctx, fl_ctx->Stack[fl_ctx->SP-1], "bound?");
+            fl_ctx->Stack[fl_ctx->SP-1] = ((sym->binding == UNBOUND) ? fl_ctx->F : fl_ctx->T);
             NEXT_OP;
         OP(OP_BUILTINP)
-            v = Stack[SP-1];
-            Stack[SP-1] = (isbuiltin(v) || iscbuiltin(v)) ? FL_T : FL_F;
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
+        fl_ctx->Stack[fl_ctx->SP-1] = (isbuiltin(fl_apply_v) || iscbuiltin(fl_ctx, fl_apply_v)) ? fl_ctx->T : fl_ctx->F;
             NEXT_OP;
         OP(OP_FUNCTIONP)
-            v = Stack[SP-1];
-            Stack[SP-1] = ((tag(v)==TAG_FUNCTION &&
-                            (uintval(v)<=OP_ASET || v>(N_BUILTINS<<3))) ||
-                           iscbuiltin(v)) ? FL_T : FL_F;
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
+            fl_ctx->Stack[fl_ctx->SP-1] = ((tag(fl_apply_v)==TAG_FUNCTION &&
+                            (uintval(fl_apply_v)<=OP_ASET || fl_apply_v>(N_BUILTINS<<3))) ||
+                                 iscbuiltin(fl_ctx, fl_apply_v)) ? fl_ctx->T : fl_ctx->F;
             NEXT_OP;
         OP(OP_VECTORP)
-            Stack[SP-1] = (isvector(Stack[SP-1]) ? FL_T : FL_F); NEXT_OP;
+            fl_ctx->Stack[fl_ctx->SP-1] = (isvector(fl_ctx->Stack[fl_ctx->SP-1]) ? fl_ctx->T : fl_ctx->F); NEXT_OP;
 
         OP(OP_CONS)
 #ifdef MEMDEBUG2
-            c = (cons_t*)ptr(mk_cons());
+            fl_apply_c = (cons_t*)ptr(mk_cons(fl_ctx));
 #else
-            if (curheap > lim)
-                gc(0);
-            c = (cons_t*)curheap;
-            curheap += sizeof(cons_t);
+            if (fl_ctx->curheap > fl_ctx->lim)
+                gc(fl_ctx, 0);
+            fl_apply_c = (cons_t*)fl_ctx->curheap;
+            fl_ctx->curheap += sizeof(cons_t);
 #endif
-            c->car = Stack[SP-2];
-            c->cdr = Stack[SP-1];
-            Stack[SP-2] = tagptr(c, TAG_CONS);
-            POPN(1); NEXT_OP;
+            fl_apply_c->car = fl_ctx->Stack[fl_ctx->SP-2];
+            fl_apply_c->cdr = fl_ctx->Stack[fl_ctx->SP-1];
+            fl_ctx->Stack[fl_ctx->SP-2] = tagptr(fl_apply_c, TAG_CONS);
+            POPN(fl_ctx, 1); NEXT_OP;
         OP(OP_CAR)
-            v = Stack[SP-1];
-            if (!iscons(v)) type_error("car", "cons", v);
-            Stack[SP-1] = car_(v);
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
+            if (!iscons(fl_apply_v)) type_error(fl_ctx, "car", "cons", fl_apply_v);
+            fl_ctx->Stack[fl_ctx->SP-1] = car_(fl_apply_v);
             NEXT_OP;
         OP(OP_CDR)
-            v = Stack[SP-1];
-            if (!iscons(v)) type_error("cdr", "cons", v);
-            Stack[SP-1] = cdr_(v);
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
+            if (!iscons(fl_apply_v)) type_error(fl_ctx, "cdr", "cons", fl_apply_v);
+            fl_ctx->Stack[fl_ctx->SP-1] = cdr_(fl_apply_v);
             NEXT_OP;
         OP(OP_CADR)
-            v = Stack[SP-1];
-            if (!iscons(v)) type_error("cdr", "cons", v);
-            v = cdr_(v);
-            if (!iscons(v)) type_error("car", "cons", v);
-            Stack[SP-1] = car_(v);
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
+            if (!iscons(fl_apply_v)) type_error(fl_ctx, "cdr", "cons", fl_apply_v);
+            fl_apply_v = cdr_(fl_apply_v);
+            if (!iscons(fl_apply_v)) type_error(fl_ctx, "car", "cons", fl_apply_v);
+            fl_ctx->Stack[fl_ctx->SP-1] = car_(fl_apply_v);
             NEXT_OP;
         OP(OP_SETCAR)
-            car(Stack[SP-2]) = Stack[SP-1];
-            POPN(1); NEXT_OP;
+            car(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2]) = fl_ctx->Stack[fl_ctx->SP-1];
+            POPN(fl_ctx, 1); NEXT_OP;
         OP(OP_SETCDR)
-            cdr(Stack[SP-2]) = Stack[SP-1];
-            POPN(1); NEXT_OP;
+            cdr(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2]) = fl_ctx->Stack[fl_ctx->SP-1];
+            POPN(fl_ctx, 1); NEXT_OP;
         OP(OP_LIST)
             n = *ip++;
         apply_list:
             if (n > 0) {
-                v = list(&Stack[SP-n], n);
-                POPN(n);
-                PUSH(v);
+                fl_apply_v = list(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-n], n);
+                POPN(fl_ctx, n);
+                PUSH(fl_ctx, fl_apply_v);
             }
             else {
-                PUSH(NIL);
+                PUSH(fl_ctx, fl_ctx->NIL);
             }
             NEXT_OP;
 
         OP(OP_TAPPLY)
             n = *ip++;
         apply_tapply:
-            v = POP();     // arglist
-            n = SP-(n-2);  // n-2 == # leading arguments not in the list
-            while (iscons(v)) {
-                if (SP >= N_STACK)
-                    grow_stack();
-                PUSH(car_(v));
-                v = cdr_(v);
+            fl_apply_v = POP(fl_ctx);     // arglist
+            n = fl_ctx->SP-(n-2);  // n-2 == # leading arguments not in the list
+            while (iscons(fl_apply_v)) {
+                if (fl_ctx->SP >= fl_ctx->N_STACK)
+                    grow_stack(fl_ctx);
+                PUSH(fl_ctx, car_(fl_apply_v));
+                fl_apply_v = cdr_(fl_apply_v);
             }
-            n = SP-n;
+            n = fl_ctx->SP-n;
             goto do_tcall;
         OP(OP_APPLY)
             n = *ip++;
         apply_apply:
-            v = POP();     // arglist
-            n = SP-(n-2);  // n-2 == # leading arguments not in the list
-            while (iscons(v)) {
-                if (SP >= N_STACK)
-                    grow_stack();
-                PUSH(car_(v));
-                v = cdr_(v);
+            fl_apply_v = POP(fl_ctx);     // arglist
+            n = fl_ctx->SP-(n-2);  // n-2 == # leading arguments not in the list
+            while (iscons(fl_apply_v)) {
+                if (fl_ctx->SP >= fl_ctx->N_STACK)
+                    grow_stack(fl_ctx);
+                PUSH(fl_ctx, car_(fl_apply_v));
+                fl_apply_v = cdr_(fl_apply_v);
             }
-            n = SP-n;
+            n = fl_ctx->SP-n;
             goto do_call;
 
         OP(OP_ADD)
             n = *ip++;
         apply_add:
             s = 0;
-            i = SP-n;
-            for (; i < SP; i++) {
-                if (isfixnum(Stack[i])) {
-                    s += numval(Stack[i]);
+            i = fl_ctx->SP-n;
+            for (; i < fl_ctx->SP; i++) {
+                if (isfixnum(fl_ctx->Stack[i])) {
+                    s += numval(fl_ctx->Stack[i]);
                     if (!fits_fixnum(s)) {
                         i++;
                         goto add_ovf;
@@ -1495,400 +1446,400 @@ static value_t apply_cl(uint32_t nargs)
                 }
                 else {
                 add_ovf:
-                    v = fl_add_any(&Stack[i], SP-i, s);
+                    fl_apply_v = fl_add_any(fl_ctx, &fl_ctx->Stack[i], fl_ctx->SP-i, s);
                     break;
                 }
             }
-            if (i==SP)
-                v = fixnum(s);
-            POPN(n);
-            PUSH(v);
+            if (i==fl_ctx->SP)
+                fl_apply_v = fixnum(s);
+            POPN(fl_ctx, n);
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_ADD2)
-            if (bothfixnums(Stack[SP-1], Stack[SP-2])) {
-                s = numval(Stack[SP-1]) + numval(Stack[SP-2]);
+            if (bothfixnums(fl_ctx->Stack[fl_ctx->SP-1], fl_ctx->Stack[fl_ctx->SP-2])) {
+                s = numval(fl_ctx->Stack[fl_ctx->SP-1]) + numval(fl_ctx->Stack[fl_ctx->SP-2]);
                 if (fits_fixnum(s))
-                    v = fixnum(s);
+                    fl_apply_v = fixnum(s);
                 else
-                    v = mk_ptrdiff(s);
+                    fl_apply_v = mk_ptrdiff(fl_ctx, s);
             }
             else {
-                v = fl_add_any(&Stack[SP-2], 2, 0);
+                fl_apply_v = fl_add_any(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-2], 2, 0);
             }
-            POPN(1);
-            Stack[SP-1] = v;
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
         OP(OP_SUB)
             n = *ip++;
         apply_sub:
             if (n == 2) goto do_sub2;
             if (n == 1) goto do_neg;
-            i = SP-n;
+            i = fl_ctx->SP-n;
             // we need to pass the full arglist on to fl_add_any
             // so it can handle rest args properly
-            PUSH(Stack[i]);
-            Stack[i] = fixnum(0);
-            Stack[i+1] = fl_neg(fl_add_any(&Stack[i], n, 0));
-            Stack[i] = POP();
-            v = fl_add_any(&Stack[i], 2, 0);
-            POPN(n);
-            PUSH(v);
+            PUSH(fl_ctx, fl_ctx->Stack[i]);
+            fl_ctx->Stack[i] = fixnum(0);
+            fl_ctx->Stack[i+1] = fl_neg(fl_ctx, fl_add_any(fl_ctx, &fl_ctx->Stack[i], n, 0));
+            fl_ctx->Stack[i] = POP(fl_ctx);
+            fl_apply_v = fl_add_any(fl_ctx, &fl_ctx->Stack[i], 2, 0);
+            POPN(fl_ctx, n);
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_NEG)
         do_neg:
-            if (isfixnum(Stack[SP-1]))
-                Stack[SP-1] = fixnum(-numval(Stack[SP-1]));
+            if (isfixnum(fl_ctx->Stack[fl_ctx->SP-1]))
+                fl_ctx->Stack[fl_ctx->SP-1] = fixnum(-numval(fl_ctx->Stack[fl_ctx->SP-1]));
             else
-                Stack[SP-1] = fl_neg(Stack[SP-1]);
+                fl_ctx->Stack[fl_ctx->SP-1] = fl_neg(fl_ctx, fl_ctx->Stack[fl_ctx->SP-1]);
             NEXT_OP;
         OP(OP_SUB2)
         do_sub2:
-            if (bothfixnums(Stack[SP-2], Stack[SP-1])) {
-                s = numval(Stack[SP-2]) - numval(Stack[SP-1]);
+            if (bothfixnums(fl_ctx->Stack[fl_ctx->SP-2], fl_ctx->Stack[fl_ctx->SP-1])) {
+                s = numval(fl_ctx->Stack[fl_ctx->SP-2]) - numval(fl_ctx->Stack[fl_ctx->SP-1]);
                 if (fits_fixnum(s))
-                    v = fixnum(s);
+                    fl_apply_v = fixnum(s);
                 else
-                    v = mk_ptrdiff(s);
+                    fl_apply_v = mk_ptrdiff(fl_ctx, s);
             }
             else {
-                Stack[SP-1] = fl_neg(Stack[SP-1]);
-                v = fl_add_any(&Stack[SP-2], 2, 0);
+                fl_ctx->Stack[fl_ctx->SP-1] = fl_neg(fl_ctx, fl_ctx->Stack[fl_ctx->SP-1]);
+                fl_apply_v = fl_add_any(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-2], 2, 0);
             }
-            POPN(1);
-            Stack[SP-1] = v;
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
         OP(OP_MUL)
             n = *ip++;
         apply_mul:
-            accum = 1;
-            i = SP-n;
-            for (; i < SP; i++) {
-                if (isfixnum(Stack[i])) {
-                    accum *= numval(Stack[i]);
+            fl_apply_accum = 1;
+            i = fl_ctx->SP-n;
+            for (; i < fl_ctx->SP; i++) {
+                if (isfixnum(fl_ctx->Stack[i])) {
+                    fl_apply_accum *= numval(fl_ctx->Stack[i]);
                 }
                 else {
-                    v = fl_mul_any(&Stack[i], SP-i, accum);
+                    fl_apply_v = fl_mul_any(fl_ctx, &fl_ctx->Stack[i], fl_ctx->SP-i, fl_apply_accum);
                     break;
                 }
             }
-            if (i == SP) {
-                if (fits_fixnum(accum))
-                    v = fixnum(accum);
+            if (i == fl_ctx->SP) {
+                if (fits_fixnum(fl_apply_accum))
+                    fl_apply_v = fixnum(fl_apply_accum);
                 else
-                    v = return_from_int64(accum);
+                    fl_apply_v = return_from_int64(fl_ctx, fl_apply_accum);
             }
-            POPN(n);
-            PUSH(v);
+            POPN(fl_ctx, n);
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_DIV)
             n = *ip++;
         apply_div:
-            i = SP-n;
+            i = fl_ctx->SP-n;
             if (n == 1) {
-                Stack[SP-1] = fl_div2(fixnum(1), Stack[i]);
+                fl_ctx->Stack[fl_ctx->SP-1] = fl_div2(fl_ctx, fixnum(1), fl_ctx->Stack[i]);
             }
             else {
                 if (n > 2) {
-                    PUSH(Stack[i]);
-                    Stack[i] = fixnum(1);
-                    Stack[i+1] = fl_mul_any(&Stack[i], n, 1);
-                    Stack[i] = POP();
+                    PUSH(fl_ctx, fl_ctx->Stack[i]);
+                    fl_ctx->Stack[i] = fixnum(1);
+                    fl_ctx->Stack[i+1] = fl_mul_any(fl_ctx, &fl_ctx->Stack[i], n, 1);
+                    fl_ctx->Stack[i] = POP(fl_ctx);
                 }
-                v = fl_div2(Stack[i], Stack[i+1]);
-                POPN(n);
-                PUSH(v);
+                fl_apply_v = fl_div2(fl_ctx, fl_ctx->Stack[i], fl_ctx->Stack[i+1]);
+                POPN(fl_ctx, n);
+                PUSH(fl_ctx, fl_apply_v);
             }
             NEXT_OP;
         OP(OP_IDIV)
-            v = Stack[SP-2]; e = Stack[SP-1];
-            if (bothfixnums(v, e)) {
-                if (e==0) DivideByZeroError();
-                v = fixnum(numval(v) / numval(e));
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-2]; fl_apply_e = fl_ctx->Stack[fl_ctx->SP-1];
+            if (bothfixnums(fl_apply_v, fl_apply_e)) {
+                if (fl_apply_e==0) DivideByZeroError(fl_ctx);
+                fl_apply_v = fixnum(numval(fl_apply_v) / numval(fl_apply_e));
             }
             else
-                v = fl_idiv2(v, e);
-            POPN(1);
-            Stack[SP-1] = v;
+                fl_apply_v = fl_idiv2(fl_ctx, fl_apply_v, fl_apply_e);
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
         OP(OP_NUMEQ)
-            v = Stack[SP-2]; e = Stack[SP-1];
-            if (bothfixnums(v, e))
-                v = (v == e) ? FL_T : FL_F;
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-2]; fl_apply_e = fl_ctx->Stack[fl_ctx->SP-1];
+            if (bothfixnums(fl_apply_v, fl_apply_e))
+                fl_apply_v = (fl_apply_v == fl_apply_e) ? fl_ctx->T : fl_ctx->F;
             else
-                v = (!numeric_compare(v,e,1,0,"=")) ? FL_T : FL_F;
-            POPN(1);
-            Stack[SP-1] = v;
+                fl_apply_v = (!numeric_compare(fl_ctx,fl_apply_v,fl_apply_e,1,0,"=")) ? fl_ctx->T : fl_ctx->F;
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
         OP(OP_LT)
-            if (bothfixnums(Stack[SP-2], Stack[SP-1])) {
-                v = (numval(Stack[SP-2]) < numval(Stack[SP-1])) ? FL_T : FL_F;
+            if (bothfixnums(fl_ctx->Stack[fl_ctx->SP-2], fl_ctx->Stack[fl_ctx->SP-1])) {
+                fl_apply_v = (numval(fl_ctx->Stack[fl_ctx->SP-2]) < numval(fl_ctx->Stack[fl_ctx->SP-1])) ? fl_ctx->T : fl_ctx->F;
             }
             else {
-                v = (numval(fl_compare(Stack[SP-2], Stack[SP-1])) < 0) ?
-                    FL_T : FL_F;
+                fl_apply_v = (numval(fl_compare(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2], fl_ctx->Stack[fl_ctx->SP-1])) < 0) ?
+                    fl_ctx->T : fl_ctx->F;
             }
-            POPN(1);
-            Stack[SP-1] = v;
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
         OP(OP_COMPARE)
-            Stack[SP-2] = compare_(Stack[SP-2], Stack[SP-1], 0);
-            POPN(1);
+            fl_ctx->Stack[fl_ctx->SP-2] = compare_(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2], fl_ctx->Stack[fl_ctx->SP-1], 0);
+            POPN(fl_ctx, 1);
             NEXT_OP;
 
         OP(OP_VECTOR)
             n = *ip++;
         apply_vector:
-            v = alloc_vector(n, 0);
+            fl_apply_v = alloc_vector(fl_ctx, n, 0);
             if (n) {
-                memcpy(&vector_elt(v,0), &Stack[SP-n], n*sizeof(value_t));
-                POPN(n);
+                memcpy(&vector_elt(fl_apply_v,0), &fl_ctx->Stack[fl_ctx->SP-n], n*sizeof(value_t));
+                POPN(fl_ctx, n);
             }
-            PUSH(v);
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
 
         OP(OP_AREF)
-            v = Stack[SP-2];
-            if (isvector(v)) {
-                e = Stack[SP-1];
-                if (isfixnum(e))
-                    i = numval(e);
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-2];
+            if (isvector(fl_apply_v)) {
+                fl_apply_e = fl_ctx->Stack[fl_ctx->SP-1];
+                if (isfixnum(fl_apply_e))
+                    i = numval(fl_apply_e);
                 else
-                    i = (uint32_t)tosize(e, "aref");
-                if ((unsigned)i >= vector_size(v))
-                    bounds_error("aref", v, e);
-                v = vector_elt(v, i);
+                    i = (uint32_t)tosize(fl_ctx, fl_apply_e, "aref");
+                if ((unsigned)i >= vector_size(fl_apply_v))
+                    bounds_error(fl_ctx, "aref", fl_apply_v, fl_apply_e);
+                fl_apply_v = vector_elt(fl_apply_v, i);
             }
-            else if (isarray(v)) {
-                v = cvalue_array_aref(&Stack[SP-2]);
+            else if (isarray(fl_apply_v)) {
+                fl_apply_v = cvalue_array_aref(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-2]);
             }
             else {
-                type_error("aref", "sequence", v);
+                type_error(fl_ctx, "aref", "sequence", fl_apply_v);
             }
-            POPN(1);
-            Stack[SP-1] = v;
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
         OP(OP_ASET)
-            e = Stack[SP-3];
-            if (isvector(e)) {
-                i = tofixnum(Stack[SP-2], "aset!");
-                if ((unsigned)i >= vector_size(e))
-                    bounds_error("aset!", v, Stack[SP-1]);
-                vector_elt(e, i) = (v=Stack[SP-1]);
+            fl_apply_e = fl_ctx->Stack[fl_ctx->SP-3];
+            if (isvector(fl_apply_e)) {
+                i = tofixnum(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2], "aset!");
+                if ((unsigned)i >= vector_size(fl_apply_e))
+                    bounds_error(fl_ctx, "aset!", fl_apply_v, fl_ctx->Stack[fl_ctx->SP-1]);
+                vector_elt(fl_apply_e, i) = (fl_apply_v=fl_ctx->Stack[fl_ctx->SP-1]);
             }
-            else if (isarray(e)) {
-                v = cvalue_array_aset(&Stack[SP-3]);
+            else if (isarray(fl_apply_e)) {
+                fl_apply_v = cvalue_array_aset(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-3]);
             }
             else {
-                type_error("aset!", "sequence", e);
+                type_error(fl_ctx, "aset!", "sequence", fl_apply_e);
             }
-            POPN(2);
-            Stack[SP-1] = v;
+            POPN(fl_ctx, 2);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
         OP(OP_FOR)
-            s  = tofixnum(Stack[SP-3], "for");
-            hi = tofixnum(Stack[SP-2], "for");
-            //f = Stack[SP-1];
-            v = FL_UNSPECIFIED;
-            SP += 2;
-            n = SP;
+            s  = tofixnum(fl_ctx, fl_ctx->Stack[fl_ctx->SP-3], "for");
+            hi = tofixnum(fl_ctx, fl_ctx->Stack[fl_ctx->SP-2], "for");
+            //f = fl_ctx->Stack[fl_ctx->SP-1];
+            fl_apply_v = FL_UNSPECIFIED(fl_ctx);
+            fl_ctx->SP += 2;
+            n = fl_ctx->SP;
             for(; s <= hi; s++) {
-                Stack[SP-2] = Stack[SP-3];
-                Stack[SP-1] = fixnum(s);
-                v = apply_cl(1);
-                SP = n;
+                fl_ctx->Stack[fl_ctx->SP-2] = fl_ctx->Stack[fl_ctx->SP-3];
+                fl_ctx->Stack[fl_ctx->SP-1] = fixnum(s);
+                fl_apply_v = apply_cl(fl_ctx, 1);
+                fl_ctx->SP = n;
             }
-            POPN(4);
-            Stack[SP-1] = v;
+            POPN(fl_ctx, 4);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
 
-        OP(OP_LOADT) PUSH(FL_T); NEXT_OP;
-        OP(OP_LOADF) PUSH(FL_F); NEXT_OP;
-        OP(OP_LOADNIL) PUSH(NIL); NEXT_OP;
-        OP(OP_LOAD0) PUSH(fixnum(0)); NEXT_OP;
-        OP(OP_LOAD1) PUSH(fixnum(1)); NEXT_OP;
-        OP(OP_LOADI8) s = (int8_t)*ip++; PUSH(fixnum(s)); NEXT_OP;
+        OP(OP_LOADT) PUSH(fl_ctx, fl_ctx->T); NEXT_OP;
+        OP(OP_LOADF) PUSH(fl_ctx, fl_ctx->F); NEXT_OP;
+        OP(OP_LOADNIL) PUSH(fl_ctx, fl_ctx->NIL); NEXT_OP;
+        OP(OP_LOAD0) PUSH(fl_ctx, fixnum(0)); NEXT_OP;
+        OP(OP_LOAD1) PUSH(fl_ctx, fixnum(1)); NEXT_OP;
+        OP(OP_LOADI8) s = (int8_t)*ip++; PUSH(fl_ctx, fixnum(s)); NEXT_OP;
         OP(OP_LOADV)
-            v = fn_vals(Stack[bp-1]);
-            assert(*ip < vector_size(v));
-            v = vector_elt(v, *ip); ip++;
-            PUSH(v);
+            fl_apply_v = fn_vals(fl_ctx->Stack[bp-1]);
+            assert(*ip < vector_size(fl_apply_v));
+            fl_apply_v = vector_elt(fl_apply_v, *ip); ip++;
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_LOADVL)
-            v = fn_vals(Stack[bp-1]);
-            v = vector_elt(v, GET_INT32(ip)); ip+=4;
-            PUSH(v);
+            fl_apply_v = fn_vals(fl_ctx->Stack[bp-1]);
+            fl_apply_v = vector_elt(fl_apply_v, GET_INT32(ip)); ip+=4;
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_LOADGL)
-            v = fn_vals(Stack[bp-1]);
-            v = vector_elt(v, GET_INT32(ip)); ip+=4;
+            fl_apply_v = fn_vals(fl_ctx->Stack[bp-1]);
+            fl_apply_v = vector_elt(fl_apply_v, GET_INT32(ip)); ip+=4;
             goto do_loadg;
         OP(OP_LOADG)
-            v = fn_vals(Stack[bp-1]);
-            assert(*ip < vector_size(v));
-            v = vector_elt(v, *ip); ip++;
+            fl_apply_v = fn_vals(fl_ctx->Stack[bp-1]);
+            assert(*ip < vector_size(fl_apply_v));
+            fl_apply_v = vector_elt(fl_apply_v, *ip); ip++;
         do_loadg:
-            assert(issymbol(v));
-            sym = (symbol_t*)ptr(v);
+            assert(issymbol(fl_apply_v));
+            sym = (symbol_t*)ptr(fl_apply_v);
             if (sym->binding == UNBOUND)
-                fl_raise(fl_list2(UnboundError, v));
-            PUSH(sym->binding);
+                fl_raise(fl_ctx, fl_list2(fl_ctx, fl_ctx->UnboundError, fl_apply_v));
+            PUSH(fl_ctx, sym->binding);
             NEXT_OP;
 
         OP(OP_SETGL)
-            v = fn_vals(Stack[bp-1]);
-            v = vector_elt(v, GET_INT32(ip)); ip+=4;
+            fl_apply_v = fn_vals(fl_ctx->Stack[bp-1]);
+            fl_apply_v = vector_elt(fl_apply_v, GET_INT32(ip)); ip+=4;
             goto do_setg;
         OP(OP_SETG)
-            v = fn_vals(Stack[bp-1]);
-            assert(*ip < vector_size(v));
-            v = vector_elt(v, *ip); ip++;
+            fl_apply_v = fn_vals(fl_ctx->Stack[bp-1]);
+            assert(*ip < vector_size(fl_apply_v));
+            fl_apply_v = vector_elt(fl_apply_v, *ip); ip++;
         do_setg:
-            assert(issymbol(v));
-            sym = (symbol_t*)ptr(v);
-            v = Stack[SP-1];
+            assert(issymbol(fl_apply_v));
+            sym = (symbol_t*)ptr(fl_apply_v);
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
             if (!isconstant(sym))
-                sym->binding = v;
+                sym->binding = fl_apply_v;
             NEXT_OP;
 
         OP(OP_LOADA)
             i = *ip++;
-            v = Stack[bp+i];
-            PUSH(v);
+            fl_apply_v = fl_ctx->Stack[bp+i];
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_LOADA0)
-            v = Stack[bp];
-            PUSH(v);
+            fl_apply_v = fl_ctx->Stack[bp];
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_LOADA1)
-            v = Stack[bp+1];
-            PUSH(v);
+            fl_apply_v = fl_ctx->Stack[bp+1];
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_LOADAL)
             i = GET_INT32(ip); ip+=4;
-            v = Stack[bp+i];
-            PUSH(v);
+            fl_apply_v = fl_ctx->Stack[bp+i];
+            PUSH(fl_ctx, fl_apply_v);
             NEXT_OP;
         OP(OP_SETA)
-            v = Stack[SP-1];
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
             i = *ip++;
-            Stack[bp+i] = v;
+            fl_ctx->Stack[bp+i] = fl_apply_v;
             NEXT_OP;
         OP(OP_SETAL)
-            v = Stack[SP-1];
+            fl_apply_v = fl_ctx->Stack[fl_ctx->SP-1];
             i = GET_INT32(ip); ip+=4;
-            Stack[bp+i] = v;
+            fl_ctx->Stack[bp+i] = fl_apply_v;
             NEXT_OP;
 
         OP(OP_BOX)
             i = *ip++;
-            v = mk_cons();
-            car_(v) = Stack[bp+i];
-            cdr_(v) = NIL;
-            Stack[bp+i] = v;
+            fl_apply_v = mk_cons(fl_ctx);
+            car_(fl_apply_v) = fl_ctx->Stack[bp+i];
+            cdr_(fl_apply_v) = fl_ctx->NIL;
+            fl_ctx->Stack[bp+i] = fl_apply_v;
             NEXT_OP;
         OP(OP_BOXL)
             i = GET_INT32(ip); ip+=4;
-            v = mk_cons();
-            car_(v) = Stack[bp+i];
-            cdr_(v) = NIL;
-            Stack[bp+i] = v;
+            fl_apply_v = mk_cons(fl_ctx);
+            car_(fl_apply_v) = fl_ctx->Stack[bp+i];
+            cdr_(fl_apply_v) = fl_ctx->NIL;
+            fl_ctx->Stack[bp+i] = fl_apply_v;
             NEXT_OP;
 
         OP(OP_SHIFT)
             i = *ip++;
-            Stack[SP-1-i] = Stack[SP-1];
-            SP -= i;
+            fl_ctx->Stack[fl_ctx->SP-1-i] = fl_ctx->Stack[fl_ctx->SP-1];
+            fl_ctx->SP -= i;
             NEXT_OP;
 
         OP(OP_LOADC)
             i = *ip++;
-            v = Stack[bp+nargs];
-            assert(isvector(v));
-            assert(i < vector_size(v));
-            PUSH(vector_elt(v, i));
+            fl_apply_v = fl_ctx->Stack[bp+nargs];
+            assert(isvector(fl_apply_v));
+            assert(i < vector_size(fl_apply_v));
+            PUSH(fl_ctx, vector_elt(fl_apply_v, i));
             NEXT_OP;
 
         OP(OP_LOADC0)
-            PUSH(vector_elt(Stack[bp+nargs], 0));
+            PUSH(fl_ctx, vector_elt(fl_ctx->Stack[bp+nargs], 0));
             NEXT_OP;
         OP(OP_LOADC1)
-            PUSH(vector_elt(Stack[bp+nargs], 1));
+            PUSH(fl_ctx, vector_elt(fl_ctx->Stack[bp+nargs], 1));
             NEXT_OP;
 
         OP(OP_LOADCL)
             i = GET_INT32(ip); ip+=4;
-            v = Stack[bp+nargs];
-            PUSH(vector_elt(v, i));
+            fl_apply_v = fl_ctx->Stack[bp+nargs];
+            PUSH(fl_ctx, vector_elt(fl_apply_v, i));
             NEXT_OP;
 
         OP(OP_CLOSURE)
             n = *ip++;
             assert(n > 0);
-            pv = alloc_words(n + 1);
-            v = tagptr(pv, TAG_VECTOR);
-            pv[0] = fixnum(n);
+            fl_apply_pv = alloc_words(fl_ctx, n + 1);
+            fl_apply_v = tagptr(fl_apply_pv, TAG_VECTOR);
+            fl_apply_pv[0] = fixnum(n);
             i = 1;
             do {
-                pv[i] = Stack[SP-n + i-1];
+                fl_apply_pv[i] = fl_ctx->Stack[fl_ctx->SP-n + i-1];
                 i++;
             } while (i<=n);
-            POPN(n);
-            PUSH(v);
+            POPN(fl_ctx, n);
+            PUSH(fl_ctx, fl_apply_v);
 #ifdef MEMDEBUG2
-            pv = alloc_words(4);
+            fl_apply_pv = alloc_words(fl_ctx, 4);
 #else
-            if ((value_t*)curheap > ((value_t*)lim)-2)
-                gc(0);
-            pv = (value_t*)curheap;
-            curheap += (4*sizeof(value_t));
+            if ((value_t*)fl_ctx->curheap > ((value_t*)fl_ctx->lim)-2)
+                gc(fl_ctx, 0);
+            fl_apply_pv = (value_t*)fl_ctx->curheap;
+            fl_ctx->curheap += (4*sizeof(value_t));
 #endif
-            e = Stack[SP-2];  // closure to copy
-            assert(isfunction(e));
-            pv[0] = ((value_t*)ptr(e))[0];
-            pv[1] = ((value_t*)ptr(e))[1];
-            pv[2] = Stack[SP-1];  // env
-            pv[3] = ((value_t*)ptr(e))[3];
-            POPN(1);
-            Stack[SP-1] = tagptr(pv, TAG_FUNCTION);
+            fl_apply_e = fl_ctx->Stack[fl_ctx->SP-2];  // closure to copy
+            assert(isfunction(fl_apply_e));
+            fl_apply_pv[0] = ((value_t*)ptr(fl_apply_e))[0];
+            fl_apply_pv[1] = ((value_t*)ptr(fl_apply_e))[1];
+            fl_apply_pv[2] = fl_ctx->Stack[fl_ctx->SP-1];  // env
+            fl_apply_pv[3] = ((value_t*)ptr(fl_apply_e))[3];
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = tagptr(fl_apply_pv, TAG_FUNCTION);
             NEXT_OP;
 
         OP(OP_TRYCATCH)
-            v = do_trycatch();
-            POPN(1);
-            Stack[SP-1] = v;
+            fl_apply_v = do_trycatch(fl_ctx);
+            POPN(fl_ctx, 1);
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_apply_v;
             NEXT_OP;
 
         OP(OP_OPTARGS)
             i = GET_INT32(ip); ip+=4;
             n = GET_INT32(ip); ip+=4;
             if (nargs < i)
-                lerror(ArgError, "apply: too few arguments");
+                lerror(fl_ctx, fl_ctx->ArgError, "apply: too few arguments");
             if ((int32_t)n > 0) {
                 if (nargs > n)
-                    lerror(ArgError, "apply: too many arguments");
+                    lerror(fl_ctx, fl_ctx->ArgError, "apply: too many arguments");
             }
             else n = -n;
             if (n > nargs) {
                 n -= nargs;
-                SP += n;
-                Stack[SP-1] = Stack[SP-n-1];
-                Stack[SP-2] = nargs+n;
-                Stack[SP-3] = Stack[SP-n-3];
-                Stack[SP-4] = Stack[SP-n-4];
-                curr_frame = SP;
+                fl_ctx->SP += n;
+                fl_ctx->Stack[fl_ctx->SP-1] = fl_ctx->Stack[fl_ctx->SP-n-1];
+                fl_ctx->Stack[fl_ctx->SP-2] = nargs+n;
+                fl_ctx->Stack[fl_ctx->SP-3] = fl_ctx->Stack[fl_ctx->SP-n-3];
+                fl_ctx->Stack[fl_ctx->SP-4] = fl_ctx->Stack[fl_ctx->SP-n-4];
+                fl_ctx->curr_frame = fl_ctx->SP;
                 for(i=0; i < n; i++) {
-                    Stack[bp+nargs+i] = UNBOUND;
+                    fl_ctx->Stack[bp+nargs+i] = UNBOUND;
                 }
                 nargs += n;
             }
             NEXT_OP;
         OP(OP_KEYARGS)
-            v = fn_vals(Stack[bp-1]);
-            v = vector_elt(v, 0);
+            fl_apply_v = fn_vals(fl_ctx->Stack[bp-1]);
+            fl_apply_v = vector_elt(fl_apply_v, 0);
             i = GET_INT32(ip); ip+=4;
             n = GET_INT32(ip); ip+=4;
             s = GET_INT32(ip); ip+=4;
-            nargs = process_keys(v, i, n, llabs(s)-(i+n), bp, nargs, s<0);
+            nargs = process_keys(fl_ctx, fl_apply_v, i, n, llabs(s)-(i+n), bp, nargs, s<0);
             NEXT_OP;
 
 #ifndef USE_COMPUTED_GOTO
@@ -2075,45 +2026,45 @@ static uint32_t compute_maxstack(uint8_t *code, size_t len, int bswap)
 }
 
 // top = top frame pointer to start at
-static value_t _stacktrace(uint32_t top)
+static value_t _stacktrace(fl_context_t *fl_ctx, uint32_t top)
 {
     uint32_t bp, sz;
-    value_t v, lst = NIL;
-    fl_gc_handle(&lst);
+    value_t v, lst = fl_ctx->NIL;
+    fl_gc_handle(fl_ctx, &lst);
     while (top > 0) {
-        sz = Stack[top-2]+1;
+        sz = fl_ctx->Stack[top-2]+1;
         bp = top-4-sz;
-        v = alloc_vector(sz, 0);
-        memcpy(&vector_elt(v,0), &Stack[bp], sz*sizeof(value_t));
-        lst = fl_cons(v, lst);
-        top = Stack[top-3];
+        v = alloc_vector(fl_ctx, sz, 0);
+        memcpy(&vector_elt(v,0), &fl_ctx->Stack[bp], sz*sizeof(value_t));
+        lst = fl_cons(fl_ctx, v, lst);
+        top = fl_ctx->Stack[top-3];
     }
-    fl_free_gc_handles(1);
+    fl_free_gc_handles(fl_ctx, 1);
     return lst;
 }
 
 // builtins -------------------------------------------------------------------
 
-void assign_global_builtins(builtinspec_t *b)
+void assign_global_builtins(fl_context_t *fl_ctx, const builtinspec_t *b)
 {
     while (b->name != NULL) {
-        setc(symbol(b->name), cbuiltin(b->name, b->fptr));
+        setc(symbol(fl_ctx, b->name), cbuiltin(fl_ctx, b->name, b->fptr));
         b++;
     }
 }
 
-static value_t fl_function(value_t *args, uint32_t nargs)
+static value_t fl_function(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs == 1 && issymbol(args[0]))
-        return fl_builtin(args, nargs);
+        return fl_builtin(fl_ctx, args, nargs);
     if (nargs < 2 || nargs > 4)
-        argcount("function", nargs, 2);
-    if (!fl_isstring(args[0]))
-        type_error("function", "string", args[0]);
+        argcount(fl_ctx, "function", nargs, 2);
+    if (!fl_isstring(fl_ctx, args[0]))
+        type_error(fl_ctx, "function", "string", args[0]);
     if (!isvector(args[1]))
-        type_error("function", "vector", args[1]);
+        type_error(fl_ctx, "function", "vector", args[1]);
     cvalue_t *arr = (cvalue_t*)ptr(args[0]);
-    cv_pin(arr);
+    cv_pin(fl_ctx, arr);
     char *data = (char*)cv_data(arr);
     int swap = 0;
     if ((uint8_t)data[4] >= N_OPCODES) {
@@ -2129,12 +2080,12 @@ static value_t fl_function(value_t *args, uint32_t nargs)
     }
     uint32_t ms = compute_maxstack((uint8_t*)data, cv_len(arr), swap);
     PUT_INT32(data, ms);
-    function_t *fn = (function_t*)alloc_words(4);
+    function_t *fn = (function_t*)alloc_words(fl_ctx, 4);
     value_t fv = tagptr(fn, TAG_FUNCTION);
     fn->bcode = args[0];
     fn->vals = args[1];
-    fn->env = NIL;
-    fn->name = LAMBDA;
+    fn->env = fl_ctx->NIL;
+    fn->name = fl_ctx->LAMBDA;
     if (nargs > 2) {
         if (issymbol(args[2])) {
             fn->name = args[2];
@@ -2145,175 +2096,175 @@ static value_t fl_function(value_t *args, uint32_t nargs)
             fn->env = args[2];
             if (nargs > 3) {
                 if (!issymbol(args[3]))
-                    type_error("function", "symbol", args[3]);
+                    type_error(fl_ctx, "function", "symbol", args[3]);
                 fn->name = args[3];
             }
         }
-        if (isgensym(fn->name))
-            lerror(ArgError, "function: name should not be a gensym");
+        if (isgensym(fl_ctx, fn->name))
+            lerror(fl_ctx, fl_ctx->ArgError, "function: name should not be a gensym");
     }
     return fv;
 }
 
-static value_t fl_function_code(value_t *args, uint32_t nargs)
+static value_t fl_function_code(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("function:code", nargs, 1);
+    argcount(fl_ctx, "function:code", nargs, 1);
     value_t v = args[0];
-    if (!isclosure(v)) type_error("function:code", "function", v);
+    if (!isclosure(v)) type_error(fl_ctx, "function:code", "function", v);
     return fn_bcode(v);
 }
-static value_t fl_function_vals(value_t *args, uint32_t nargs)
+static value_t fl_function_vals(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("function:vals", nargs, 1);
+    argcount(fl_ctx, "function:vals", nargs, 1);
     value_t v = args[0];
-    if (!isclosure(v)) type_error("function:vals", "function", v);
+    if (!isclosure(v)) type_error(fl_ctx, "function:vals", "function", v);
     return fn_vals(v);
 }
-static value_t fl_function_env(value_t *args, uint32_t nargs)
+static value_t fl_function_env(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("function:env", nargs, 1);
+    argcount(fl_ctx, "function:env", nargs, 1);
     value_t v = args[0];
-    if (!isclosure(v)) type_error("function:env", "function", v);
+    if (!isclosure(v)) type_error(fl_ctx, "function:env", "function", v);
     return fn_env(v);
 }
-static value_t fl_function_name(value_t *args, uint32_t nargs)
+static value_t fl_function_name(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("function:name", nargs, 1);
+    argcount(fl_ctx, "function:name", nargs, 1);
     value_t v = args[0];
-    if (!isclosure(v)) type_error("function:name", "function", v);
+    if (!isclosure(v)) type_error(fl_ctx, "function:name", "function", v);
     return fn_name(v);
 }
 
-value_t fl_copylist(value_t *args, u_int32_t nargs)
+value_t fl_copylist(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("copy-list", nargs, 1);
-    return copy_list(args[0]);
+    argcount(fl_ctx, "copy-list", nargs, 1);
+    return copy_list(fl_ctx, args[0]);
 }
 
-value_t fl_append(value_t *args, u_int32_t nargs)
+value_t fl_append(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs == 0)
-        return NIL;
-    value_t first=NIL, lst, lastcons=NIL;
-    fl_gc_handle(&first);
-    fl_gc_handle(&lastcons);
+        return fl_ctx->NIL;
+    value_t first=fl_ctx->NIL, lst, lastcons=fl_ctx->NIL;
+    fl_gc_handle(fl_ctx, &first);
+    fl_gc_handle(fl_ctx, &lastcons);
     uint32_t i=0;
     while (1) {
         lst = args[i++];
         if (i >= nargs) break;
         if (iscons(lst)) {
-            lst = copy_list(lst);
-            if (first == NIL)
+            lst = copy_list(fl_ctx, lst);
+            if (first == fl_ctx->NIL)
                 first = lst;
             else
                 cdr_(lastcons) = lst;
 #ifdef MEMDEBUG2
             lastcons = lst;
-            while (cdr_(lastcons) != NIL)
+            while (cdr_(lastcons) != fl_ctx->NIL)
                 lastcons = cdr_(lastcons);
 #else
-            lastcons = tagptr((((cons_t*)curheap)-1), TAG_CONS);
+            lastcons = tagptr((((cons_t*)fl_ctx->curheap)-1), TAG_CONS);
 #endif
         }
-        else if (lst != NIL) {
-            type_error("append", "cons", lst);
+        else if (lst != fl_ctx->NIL) {
+            type_error(fl_ctx, "append", "cons", lst);
         }
     }
-    if (first == NIL)
+    if (first == fl_ctx->NIL)
         first = lst;
     else
         cdr_(lastcons) = lst;
-    fl_free_gc_handles(2);
+    fl_free_gc_handles(fl_ctx, 2);
     return first;
 }
 
-value_t fl_liststar(value_t *args, u_int32_t nargs)
+value_t fl_liststar(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs == 1) return args[0];
-    else if (nargs == 0) argcount("list*", nargs, 1);
-    return _list(args, nargs, 1);
+    else if (nargs == 0) argcount(fl_ctx, "list*", nargs, 1);
+    return _list(fl_ctx, args, nargs, 1);
 }
 
-value_t fl_stacktrace(value_t *args, u_int32_t nargs)
+value_t fl_stacktrace(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     (void)args;
-    argcount("stacktrace", nargs, 0);
-    return _stacktrace(fl_throwing_frame ? fl_throwing_frame : curr_frame);
+    argcount(fl_ctx, "stacktrace", nargs, 0);
+    return _stacktrace(fl_ctx, fl_ctx->throwing_frame ? fl_ctx->throwing_frame : fl_ctx->curr_frame);
 }
 
-value_t fl_map1(value_t *args, u_int32_t nargs)
+value_t fl_map1(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 2)
-        lerror(ArgError, "map: too few arguments");
-    if (!iscons(args[1])) return NIL;
+        lerror(fl_ctx, fl_ctx->ArgError, "map: too few arguments");
+    if (!iscons(args[1])) return fl_ctx->NIL;
     value_t v;
-    uint32_t first, last, argSP = args-Stack;
-    assert(args >= Stack && argSP < N_STACK);
+    uint32_t first, last, argSP = args-fl_ctx->Stack;
+    assert(args >= fl_ctx->Stack && argSP < fl_ctx->N_STACK);
     if (nargs == 2) {
-        if (SP+4 > N_STACK) grow_stack();
-        PUSH(Stack[argSP]);
-        PUSH(car_(Stack[argSP+1]));
-        v = _applyn(1);
-        POPN(2);
-        PUSH(v);
-        v = mk_cons();
-        car_(v) = POP(); cdr_(v) = NIL;
-        PUSH(v);
-        PUSH(v);
-        first = SP-2;
-        last = SP-1;
-        Stack[argSP+1] = cdr_(Stack[argSP+1]);
-        while (iscons(Stack[argSP+1])) {
-            PUSH(Stack[argSP]);
-            PUSH(car_(Stack[argSP+1]));
-            v = _applyn(1);
-            POPN(2);
-            PUSH(v);
-            v = mk_cons();
-            car_(v) = POP(); cdr_(v) = NIL;
-            cdr_(Stack[last]) = v;
-            Stack[last] = v;
-            Stack[argSP+1] = cdr_(Stack[argSP+1]);
+        if (fl_ctx->SP+4 > fl_ctx->N_STACK) grow_stack(fl_ctx);
+        PUSH(fl_ctx, fl_ctx->Stack[argSP]);
+        PUSH(fl_ctx, car_(fl_ctx->Stack[argSP+1]));
+        v = _applyn(fl_ctx, 1);
+        POPN(fl_ctx, 2);
+        PUSH(fl_ctx, v);
+        v = mk_cons(fl_ctx);
+        car_(v) = POP(fl_ctx); cdr_(v) = fl_ctx->NIL;
+        PUSH(fl_ctx, v);
+        PUSH(fl_ctx, v);
+        first = fl_ctx->SP-2;
+        last = fl_ctx->SP-1;
+        fl_ctx->Stack[argSP+1] = cdr_(fl_ctx->Stack[argSP+1]);
+        while (iscons(fl_ctx->Stack[argSP+1])) {
+            PUSH(fl_ctx, fl_ctx->Stack[argSP]);
+            PUSH(fl_ctx, car_(fl_ctx->Stack[argSP+1]));
+            v = _applyn(fl_ctx, 1);
+            POPN(fl_ctx, 2);
+            PUSH(fl_ctx, v);
+            v = mk_cons(fl_ctx);
+            car_(v) = POP(fl_ctx); cdr_(v) = fl_ctx->NIL;
+            cdr_(fl_ctx->Stack[last]) = v;
+            fl_ctx->Stack[last] = v;
+            fl_ctx->Stack[argSP+1] = cdr_(fl_ctx->Stack[argSP+1]);
         }
-        POPN(2);
+        POPN(fl_ctx, 2);
     }
     else {
         size_t i;
-        while (SP+nargs+1 > N_STACK) grow_stack();
-        PUSH(Stack[argSP]);
+        while (fl_ctx->SP+nargs+1 > fl_ctx->N_STACK) grow_stack(fl_ctx);
+        PUSH(fl_ctx, fl_ctx->Stack[argSP]);
         for(i=1; i < nargs; i++) {
-            PUSH(car(Stack[argSP+i]));
-            Stack[argSP+i] = cdr_(Stack[argSP+i]);
+            PUSH(fl_ctx, car(fl_ctx, fl_ctx->Stack[argSP+i]));
+            fl_ctx->Stack[argSP+i] = cdr_(fl_ctx->Stack[argSP+i]);
         }
-        v = _applyn(nargs-1);
-        POPN(nargs);
-        PUSH(v);
-        v = mk_cons();
-        car_(v) = POP(); cdr_(v) = NIL;
-        PUSH(v);
-        PUSH(v);
-        first = SP-2;
-        last = SP-1;
-        while (iscons(Stack[argSP+1])) {
-            PUSH(Stack[argSP]);
+        v = _applyn(fl_ctx, nargs-1);
+        POPN(fl_ctx, nargs);
+        PUSH(fl_ctx, v);
+        v = mk_cons(fl_ctx);
+        car_(v) = POP(fl_ctx); cdr_(v) = fl_ctx->NIL;
+        PUSH(fl_ctx, v);
+        PUSH(fl_ctx, v);
+        first = fl_ctx->SP-2;
+        last = fl_ctx->SP-1;
+        while (iscons(fl_ctx->Stack[argSP+1])) {
+            PUSH(fl_ctx, fl_ctx->Stack[argSP]);
             for(i=1; i < nargs; i++) {
-                PUSH(car(Stack[argSP+i]));
-                Stack[argSP+i] = cdr_(Stack[argSP+i]);
+                PUSH(fl_ctx, car(fl_ctx, fl_ctx->Stack[argSP+i]));
+                fl_ctx->Stack[argSP+i] = cdr_(fl_ctx->Stack[argSP+i]);
             }
-            v = _applyn(nargs-1);
-            POPN(nargs);
-            PUSH(v);
-            v = mk_cons();
-            car_(v) = POP(); cdr_(v) = NIL;
-            cdr_(Stack[last]) = v;
-            Stack[last] = v;
+            v = _applyn(fl_ctx, nargs-1);
+            POPN(fl_ctx, nargs);
+            PUSH(fl_ctx, v);
+            v = mk_cons(fl_ctx);
+            car_(v) = POP(fl_ctx); cdr_(v) = fl_ctx->NIL;
+            cdr_(fl_ctx->Stack[last]) = v;
+            fl_ctx->Stack[last] = v;
         }
-        POPN(2);
+        POPN(fl_ctx, 2);
     }
-    return Stack[first];
+    return fl_ctx->Stack[first];
 }
 
-static builtinspec_t core_builtin_info[] = {
+static const builtinspec_t core_builtin_info[] = {
     { "function", fl_function },
     { "function:code", fl_function_code },
     { "function:vals", fl_function_vals },
@@ -2332,158 +2283,171 @@ static builtinspec_t core_builtin_info[] = {
 
 // initialization -------------------------------------------------------------
 
-extern void builtins_init(void);
-extern void comparehash_init(void);
+extern void builtins_init(fl_context_t *fl_ctx);
+extern void comparehash_init(fl_context_t *fl_ctx);
 
-static void lisp_init(size_t initial_heapsize)
+static void lisp_init(fl_context_t *fl_ctx, size_t initial_heapsize)
 {
     int i;
 
     libsupport_init();
 
-    heapsize = initial_heapsize;
+    fl_ctx->SP = 0;
+    fl_ctx->curr_frame = 0;
+    fl_ctx->N_GCHND = 0;
+    fl_ctx->readstate = NULL;
+    fl_ctx->gensym_ctr = 0;
+    fl_ctx->gsnameno = 0;
 
-    fromspace = (unsigned char*)LLT_ALLOC(heapsize);
-#ifdef MEMDEBUG
-    tospace   = NULL;
-#else
-    tospace   = (unsigned char*)LLT_ALLOC(heapsize);
+#ifdef MEMDEBUG2
+    fl_ctx->tochain = NULL;
+    fl_ctx->n_allocd = 0;
 #endif
-    curheap = fromspace;
-    lim = curheap+heapsize-sizeof(cons_t);
-    consflags = bitvector_new(heapsize/sizeof(cons_t), 1);
-    htable_new(&printconses, 32);
-    comparehash_init();
-    N_STACK = 262144;
-    Stack = (value_t*)malloc(N_STACK*sizeof(value_t));
-    CHECK_ALIGN8(Stack);
 
-    FL_NIL = NIL = builtin(OP_THE_EMPTY_LIST);
-    FL_T = builtin(OP_BOOL_CONST_T);
-    FL_F = builtin(OP_BOOL_CONST_F);
-    FL_EOF = builtin(OP_EOF_OBJECT);
-    LAMBDA = symbol("lambda");        FUNCTION = symbol("function");
-    QUOTE = symbol("quote");          TRYCATCH = symbol("trycatch");
-    BACKQUOTE = symbol("quasiquote");       COMMA = symbol("unquote");
-    COMMAAT = symbol("unquote-splicing");   COMMADOT = symbol("unquote-nsplicing");
-    IOError = symbol("io-error");     ParseError = symbol("parse-error");
-    TypeError = symbol("type-error"); ArgError = symbol("arg-error");
-    UnboundError = symbol("unbound-error");
-    KeyError = symbol("key-error");   OutOfMemoryError = symbol("memory-error");
-    BoundsError = symbol("bounds-error");
-    DivideError = symbol("divide-error");
-    EnumerationError = symbol("enumeration-error");
-    Error = symbol("error");          pairsym = symbol("pair");
-    symbolsym = symbol("symbol");     fixnumsym = symbol("fixnum");
-    vectorsym = symbol("vector");     builtinsym = symbol("builtin");
-    booleansym = symbol("boolean");   nullsym = symbol("null");
-    definesym = symbol("define");     defmacrosym = symbol("define-macro");
-    forsym = symbol("for");
-    setqsym = symbol("set!");         evalsym = symbol("eval");
-    vu8sym = symbol("vu8");           fnsym = symbol("fn");
-    nulsym = symbol("nul");           alarmsym = symbol("alarm");
-    backspacesym = symbol("backspace"); tabsym = symbol("tab");
-    linefeedsym = symbol("linefeed"); vtabsym = symbol("vtab");
-    pagesym = symbol("page");         returnsym = symbol("return");
-    escsym = symbol("esc");           spacesym = symbol("space");
-    deletesym = symbol("delete");     newlinesym = symbol("newline");
-    tsym = symbol("t"); Tsym = symbol("T");
-    fsym = symbol("f"); Fsym = symbol("F");
-    set(printprettysym=symbol("*print-pretty*"), FL_T);
-    set(printreadablysym=symbol("*print-readably*"), FL_T);
-    set(printwidthsym=symbol("*print-width*"), fixnum(SCR_WIDTH));
-    set(printlengthsym=symbol("*print-length*"), FL_F);
-    set(printlevelsym=symbol("*print-level*"), FL_F);
-    builtins_table_sym = symbol("*builtins*");
-    fl_lasterror = NIL;
+    fl_ctx->heapsize = initial_heapsize;
+
+    fl_ctx->fromspace = (unsigned char*)LLT_ALLOC(fl_ctx->heapsize);
+#ifdef MEMDEBUG
+    fl_ctx->tospace   = NULL;
+#else
+    fl_ctx->tospace   = (unsigned char*)LLT_ALLOC(fl_ctx->heapsize);
+#endif
+    fl_ctx->curheap = fl_ctx->fromspace;
+    fl_ctx->lim = fl_ctx->curheap+fl_ctx->heapsize-sizeof(cons_t);
+    fl_ctx->consflags = bitvector_new(fl_ctx->heapsize/sizeof(cons_t), 1);
+    fl_print_init(fl_ctx);
+    comparehash_init(fl_ctx);
+    fl_ctx->N_STACK = 262144;
+    fl_ctx->Stack = (value_t*)malloc(fl_ctx->N_STACK*sizeof(value_t));
+    CHECK_ALIGN8(fl_ctx->Stack);
+
+    fl_ctx->NIL = builtin(OP_THE_EMPTY_LIST);
+    fl_ctx->T = builtin(OP_BOOL_CONST_T);
+    fl_ctx->F = builtin(OP_BOOL_CONST_F);
+    fl_ctx->FL_EOF = builtin(OP_EOF_OBJECT);
+    fl_ctx->LAMBDA = symbol(fl_ctx, "lambda");        fl_ctx->FUNCTION = symbol(fl_ctx, "function");
+    fl_ctx->QUOTE = symbol(fl_ctx, "quote");          fl_ctx->TRYCATCH = symbol(fl_ctx, "trycatch");
+    fl_ctx->BACKQUOTE = symbol(fl_ctx, "quasiquote");       fl_ctx->COMMA = symbol(fl_ctx, "unquote");
+    fl_ctx->COMMAAT = symbol(fl_ctx, "unquote-splicing");   fl_ctx->COMMADOT = symbol(fl_ctx, "unquote-nsplicing");
+    fl_ctx->IOError = symbol(fl_ctx, "io-error");     fl_ctx->ParseError = symbol(fl_ctx, "parse-error");
+    fl_ctx->TypeError = symbol(fl_ctx, "type-error"); fl_ctx->ArgError = symbol(fl_ctx, "arg-error");
+    fl_ctx->UnboundError = symbol(fl_ctx, "unbound-error");
+    fl_ctx->KeyError = symbol(fl_ctx, "key-error");   fl_ctx->OutOfMemoryError = symbol(fl_ctx, "memory-error");
+    fl_ctx->BoundsError = symbol(fl_ctx, "bounds-error");
+    fl_ctx->DivideError = symbol(fl_ctx, "divide-error");
+    fl_ctx->EnumerationError = symbol(fl_ctx, "enumeration-error");
+    fl_ctx->pairsym = symbol(fl_ctx, "pair");
+    fl_ctx->symbolsym = symbol(fl_ctx, "symbol");     fl_ctx->fixnumsym = symbol(fl_ctx, "fixnum");
+    fl_ctx->vectorsym = symbol(fl_ctx, "vector");     fl_ctx->builtinsym = symbol(fl_ctx, "builtin");
+    fl_ctx->booleansym = symbol(fl_ctx, "boolean");   fl_ctx->nullsym = symbol(fl_ctx, "null");
+    fl_ctx->definesym = symbol(fl_ctx, "define");     fl_ctx->defmacrosym = symbol(fl_ctx, "define-macro");
+    fl_ctx->forsym = symbol(fl_ctx, "for");
+    fl_ctx->setqsym = symbol(fl_ctx, "set!");         fl_ctx->evalsym = symbol(fl_ctx, "eval");
+    fl_ctx->vu8sym = symbol(fl_ctx, "vu8");           fl_ctx->fnsym = symbol(fl_ctx, "fn");
+    fl_ctx->nulsym = symbol(fl_ctx, "nul");           fl_ctx->alarmsym = symbol(fl_ctx, "alarm");
+    fl_ctx->backspacesym = symbol(fl_ctx, "backspace"); fl_ctx->tabsym = symbol(fl_ctx, "tab");
+    fl_ctx->linefeedsym = symbol(fl_ctx, "linefeed"); fl_ctx->vtabsym = symbol(fl_ctx, "vtab");
+    fl_ctx->pagesym = symbol(fl_ctx, "page");         fl_ctx->returnsym = symbol(fl_ctx, "return");
+    fl_ctx->escsym = symbol(fl_ctx, "esc");           fl_ctx->spacesym = symbol(fl_ctx, "space");
+    fl_ctx->deletesym = symbol(fl_ctx, "delete");     fl_ctx->newlinesym = symbol(fl_ctx, "newline");
+    fl_ctx->tsym = symbol(fl_ctx, "t"); fl_ctx->Tsym = symbol(fl_ctx, "T");
+    fl_ctx->fsym = symbol(fl_ctx, "f"); fl_ctx->Fsym = symbol(fl_ctx, "F");
+    set(fl_ctx->printprettysym=symbol(fl_ctx, "*print-pretty*"), fl_ctx->T);
+    set(fl_ctx->printreadablysym=symbol(fl_ctx, "*print-readably*"), fl_ctx->T);
+    set(fl_ctx->printwidthsym=symbol(fl_ctx, "*print-width*"), fixnum(fl_ctx->SCR_WIDTH));
+    set(fl_ctx->printlengthsym=symbol(fl_ctx, "*print-length*"), fl_ctx->F);
+    set(fl_ctx->printlevelsym=symbol(fl_ctx, "*print-level*"), fl_ctx->F);
+    fl_ctx->builtins_table_sym = symbol(fl_ctx, "*builtins*");
+    fl_ctx->lasterror = fl_ctx->NIL;
     i = 0;
     for (i=OP_EQ; i <= OP_ASET; i++) {
-        setc(symbol(builtin_names[i]), builtin(i));
+        setc(symbol(fl_ctx, builtin_names[i]), builtin(i));
     }
-    setc(symbol("eq"), builtin(OP_EQ));
-    setc(symbol("procedure?"), builtin(OP_FUNCTIONP));
-    setc(symbol("top-level-bound?"), builtin(OP_BOUNDP));
+    setc(symbol(fl_ctx, "eq"), builtin(OP_EQ));
+    setc(symbol(fl_ctx, "procedure?"), builtin(OP_FUNCTIONP));
+    setc(symbol(fl_ctx, "top-level-bound?"), builtin(OP_BOUNDP));
 
 #if defined(_OS_LINUX_)
-    set(symbol("*os-name*"), symbol("linux"));
+    set(symbol(fl_ctx, "*os-name*"), symbol(fl_ctx, "linux"));
 #elif defined(_OS_WINDOWS_)
-    set(symbol("*os-name*"), symbol("win32"));
+    set(symbol(fl_ctx, "*os-name*"), symbol(fl_ctx, "win32"));
 #elif defined(_OS_DARWIN_)
-    set(symbol("*os-name*"), symbol("macos"));
+    set(symbol(fl_ctx, "*os-name*"), symbol(fl_ctx, "macos"));
 #else
-    set(symbol("*os-name*"), symbol("unknown"));
+    set(symbol(fl_ctx, "*os-name*"), symbol(fl_ctx, "unknown"));
 #endif
 
-    the_empty_vector = tagptr(alloc_words(1), TAG_VECTOR);
-    vector_setsize(the_empty_vector, 0);
+    fl_ctx->jl_sym = symbol(fl_ctx, "julia_value");
 
-    cvalues_init();
+    fl_ctx->the_empty_vector = tagptr(alloc_words(fl_ctx, 1), TAG_VECTOR);
+    vector_setsize(fl_ctx->the_empty_vector, 0);
+
+    cvalues_init(fl_ctx);
 
     char exename[1024];
     size_t exe_size = sizeof(exename) / sizeof(exename[0]);
     if ( uv_exepath(exename, &exe_size) == 0 ) {
-        setc(symbol("*install-dir*"), cvalue_static_cstring(strdup(dirname(exename))));
+        setc(symbol(fl_ctx, "*install-dir*"), cvalue_static_cstring(fl_ctx, strdup(dirname(exename))));
     }
 
-   memory_exception_value = fl_list2(OutOfMemoryError,
-                                      cvalue_static_cstring("out of memory"));
+    fl_ctx->memory_exception_value = fl_list2(fl_ctx, fl_ctx->OutOfMemoryError,
+                                              cvalue_static_cstring(fl_ctx, "out of memory"));
 
-    assign_global_builtins(core_builtin_info);
+    assign_global_builtins(fl_ctx, core_builtin_info);
 
-    builtins_init();
+    fl_read_init(fl_ctx);
+
+    builtins_init(fl_ctx);
 }
 
 // top level ------------------------------------------------------------------
 
-value_t fl_toplevel_eval(value_t expr)
+value_t fl_toplevel_eval(fl_context_t *fl_ctx, value_t expr)
 {
-    return fl_applyn(1, symbol_value(evalsym), expr);
+    return fl_applyn(fl_ctx, 1, symbol_value(fl_ctx->evalsym), expr);
 }
 
-extern void fl_init_julia_extensions(void);
+extern void fl_init_julia_extensions(fl_context_t *fl_ctx);
 
-void fl_init(size_t initial_heapsize)
+void fl_init(fl_context_t *fl_ctx, size_t initial_heapsize)
 {
-    lisp_init(initial_heapsize);
-    fl_init_julia_extensions();
+    lisp_init(fl_ctx, initial_heapsize);
+    fl_init_julia_extensions(fl_ctx);
 }
 
-extern fltype_t *iostreamtype;
-
-int fl_load_system_image_str(char *str, size_t len)
+int fl_load_system_image_str(fl_context_t *fl_ctx, char *str, size_t len)
 {
-    value_t img = cvalue(iostreamtype, sizeof(ios_t));
+    value_t img = cvalue(fl_ctx, fl_ctx->iostreamtype, sizeof(ios_t));
     ios_t *pi = value2c(ios_t*, img);
     ios_static_buffer(pi, str, len);
 
-    return fl_load_system_image(img);
+    return fl_load_system_image(fl_ctx, img);
 }
 
-
-int fl_load_system_image(value_t sys_image_iostream)
+int fl_load_system_image(fl_context_t *fl_ctx, value_t sys_image_iostream)
 {
     value_t e;
     int saveSP;
     symbol_t *sym;
 
-    PUSH(sys_image_iostream);
-    saveSP = SP;
-    FL_TRY {
+    PUSH(fl_ctx, sys_image_iostream);
+    saveSP = fl_ctx->SP;
+    FL_TRY(fl_ctx) {
         while (1) {
-            e = fl_read_sexpr(Stack[SP-1]);
-            if (ios_eof(value2c(ios_t*,Stack[SP-1]))) break;
+            e = fl_read_sexpr(fl_ctx, fl_ctx->Stack[fl_ctx->SP-1]);
+            if (ios_eof(value2c(ios_t*,fl_ctx->Stack[fl_ctx->SP-1]))) break;
             if (isfunction(e)) {
                 // stage 0 format: series of thunks
-                PUSH(e);
-                (void)_applyn(0);
-                SP = saveSP;
+                PUSH(fl_ctx, e);
+                (void)_applyn(fl_ctx, 0);
+                fl_ctx->SP = saveSP;
             }
             else {
                 // stage 1 format: list alternating symbol/value
                 while (iscons(e)) {
-                    sym = tosymbol(car_(e), "bootstrap");
+                    sym = tosymbol(fl_ctx, car_(e), "bootstrap");
                     e = cdr_(e);
-                    (void)tocons(e, "bootstrap");
+                    (void)tocons(fl_ctx, e, "bootstrap");
                     sym->binding = car_(e);
                     e = cdr_(e);
                 }
@@ -2491,14 +2455,14 @@ int fl_load_system_image(value_t sys_image_iostream)
             }
         }
     }
-    FL_CATCH {
+    FL_CATCH(fl_ctx) {
         ios_puts("fatal error during bootstrap:\n", ios_stderr);
-        fl_print(ios_stderr, fl_lasterror);
+        fl_print(fl_ctx, ios_stderr, fl_ctx->lasterror);
         ios_putc('\n', ios_stderr);
         return 1;
     }
-    ios_close(value2c(ios_t*,Stack[SP-1]));
-    POPN(1);
+    ios_close(value2c(ios_t*,fl_ctx->Stack[fl_ctx->SP-1]));
+    POPN(fl_ctx, 1);
     return 0;
 }
 

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -23,7 +23,7 @@ typedef int_t fixnum_t;
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+typedef struct _fl_context_t fl_context_t;
 typedef struct {
     value_t car;
     value_t cdr;
@@ -98,8 +98,8 @@ typedef struct {
 // functions ending in _ are unsafe, faster versions
 #define car_(v) (((cons_t*)ptr(v))->car)
 #define cdr_(v) (((cons_t*)ptr(v))->cdr)
-#define car(v)  (tocons((v),"car")->car)
-#define cdr(v)  (tocons((v),"cdr")->cdr)
+#define car(fl_ctx, v)  (tocons(fl_ctx, (v),"car")->car)
+#define cdr(fl_ctx, v)  (tocons(fl_ctx, (v),"cdr")->cdr)
 #define fn_bcode(f) (((value_t*)ptr(f))[0])
 #define fn_vals(f) (((value_t*)ptr(f))[1])
 #define fn_env(f) (((value_t*)ptr(f))[2])
@@ -112,19 +112,19 @@ typedef struct {
 #define iskeyword(s) ((s)->flags&0x2)
 #define symbol_value(s) (((symbol_t*)ptr(s))->binding)
 #ifdef MEMDEBUG2
-#define ismanaged(v) (!issymbol(v) && !isfixnum(v) && ((v)>(N_OPCODES<<3)) && !iscbuiltin(v))
+#define ismanaged(ctx, v) (!issymbol(v) && !isfixnum(v) && ((v)>(N_OPCODES<<3)) && !iscbuiltin(ctx, v))
 #else
-#define ismanaged(v) ((((unsigned char*)ptr(v)) >= fromspace) && \
-                      (((unsigned char*)ptr(v)) < fromspace+heapsize))
+#define ismanaged(ctx, v) ((((unsigned char*)ptr(v)) >= ctx->fromspace) && \
+                           (((unsigned char*)ptr(v)) < ctx->fromspace + ctx->heapsize))
 #endif
-#define isgensym(x)  (issymbol(x) && ismanaged(x))
+#define isgensym(ctx, x)  (issymbol(x) && ismanaged(ctx, x))
 
 #define isfunction(x) (tag(x) == TAG_FUNCTION && (x) > (N_BUILTINS<<3))
 #define isclosure(x) isfunction(x)
-#define iscbuiltin(x) (iscvalue(x) && (cv_class((cvalue_t*)ptr(x))==builtintype))
+#define iscbuiltin(ctx, x) (iscvalue(x) && (cv_class((cvalue_t*)ptr(x))==ctx->builtintype))
 
-void fl_gc_handle(value_t *pv);
-void fl_free_gc_handles(uint32_t n);
+void fl_gc_handle(fl_context_t *fl_ctx, value_t *pv);
+void fl_free_gc_handles(fl_context_t *fl_ctx, uint32_t n);
 
 #include "opcodes.h"
 
@@ -136,39 +136,35 @@ void fl_free_gc_handles(uint32_t n);
 
 #define N_BUILTINS ((int)N_OPCODES)
 
-extern value_t FL_NIL, FL_T, FL_F, FL_EOF;
-
-#define FL_UNSPECIFIED FL_T
+#define FL_UNSPECIFIED(fl_ctx) fl_ctx->T
 
 /* read, eval, print main entry points */
-value_t fl_read_sexpr(value_t f);
-void fl_print(ios_t *f, value_t v);
-value_t fl_toplevel_eval(value_t expr);
-value_t fl_apply(value_t f, value_t l);
-value_t fl_applyn(uint32_t n, value_t f, ...);
-
-extern value_t printprettysym, printreadablysym, printwidthsym;
+value_t fl_read_sexpr(fl_context_t *fl_ctx, value_t f);
+void fl_print(fl_context_t *fl_ctx, ios_t *f, value_t v);
+value_t fl_toplevel_eval(fl_context_t *fl_ctx, value_t expr);
+value_t fl_apply(fl_context_t *fl_ctx, value_t f, value_t l);
+value_t fl_applyn(fl_context_t *fl_ctx, uint32_t n, value_t f, ...);
 
 /* object model manipulation */
-value_t fl_cons(value_t a, value_t b);
-value_t fl_list2(value_t a, value_t b);
-value_t fl_listn(size_t n, ...);
-value_t symbol(char *str);
-char *symbol_name(value_t v);
+value_t fl_cons(fl_context_t *fl_ctx, value_t a, value_t b);
+value_t fl_list2(fl_context_t *fl_ctx, value_t a, value_t b);
+value_t fl_listn(fl_context_t *fl_ctx, size_t n, ...);
+value_t symbol(fl_context_t *fl_ctx, char *str);
+char *symbol_name(fl_context_t *fl_ctx, value_t v);
 int fl_is_keyword_name(const char *str, size_t len);
-value_t alloc_vector(size_t n, int init);
+value_t alloc_vector(fl_context_t *fl_ctx, size_t n, int init);
 size_t llength(value_t v);
-value_t fl_compare(value_t a, value_t b);  // -1, 0, or 1
-value_t fl_equal(value_t a, value_t b);    // T or nil
-int equal_lispvalue(value_t a, value_t b);
-uptrint_t hash_lispvalue(value_t a);
-int isnumtok_base(char *tok, value_t *pval, int base);
+value_t fl_compare(fl_context_t *fl_ctx, value_t a, value_t b);  // -1, 0, or 1
+value_t fl_equal(fl_context_t *fl_ctx, value_t a, value_t b);    // T or nil
+int equal_lispvalue(fl_context_t *fl_ctx, value_t a, value_t b);
+uptrint_t hash_lispvalue(fl_context_t *fl_ctx, value_t a);
+int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base);
 
 /* safe casts */
-cons_t *tocons(value_t v, char *fname);
-symbol_t *tosymbol(value_t v, char *fname);
-fixnum_t tofixnum(value_t v, char *fname);
-char *tostring(value_t v, char *fname);
+cons_t *tocons(fl_context_t *fl_ctx, value_t v, char *fname);
+symbol_t *tosymbol(fl_context_t *fl_ctx, value_t v, char *fname);
+fixnum_t tofixnum(fl_context_t *fl_ctx, value_t v, char *fname);
+char *tostring(fl_context_t *fl_ctx, value_t v, char *fname);
 
 /* error handling */
 typedef struct _ectx_t {
@@ -180,68 +176,55 @@ typedef struct _ectx_t {
     struct _ectx_t *prev;
 } fl_exception_context_t;
 
-extern fl_exception_context_t *fl_ctx;
-extern uint32_t fl_throwing_frame;
-extern value_t fl_lasterror;
-
-#define FL_TRY_EXTERN                                                   \
+#define FL_TRY_EXTERN(fl_ctx)                                           \
   fl_exception_context_t _ctx; int l__tr, l__ca;                        \
-  fl_savestate(&_ctx); fl_ctx = &_ctx;                                  \
+  fl_savestate(fl_ctx, &_ctx); fl_ctx->exc_ctx = &_ctx;                      \
   if (!setjmp(_ctx.buf))                                                \
-    for (l__tr=1; l__tr; l__tr=0, (void)(fl_ctx=fl_ctx->prev))
+      for (l__tr=1; l__tr; l__tr=0, (void)(fl_ctx->exc_ctx=fl_ctx->exc_ctx->prev))
 
-#define FL_CATCH_EXTERN \
-  else \
-    for(l__ca=1; l__ca; l__ca=0, fl_restorestate(&_ctx))
+#define FL_CATCH_EXTERN(fl_ctx)                                         \
+    else                                                                \
+        for(l__ca=1; l__ca; l__ca=0, fl_restorestate(fl_ctx, &_ctx))
 
 #if defined(_OS_WINDOWS_)
-__declspec(noreturn) void lerrorf(value_t e, char *format, ...);
-__declspec(noreturn) void lerror(value_t e, const char *msg);
-__declspec(noreturn) void fl_raise(value_t e);
-__declspec(noreturn) void type_error(char *fname, char *expected, value_t got);
-__declspec(noreturn) void bounds_error(char *fname, value_t arr, value_t ind);
+__declspec(noreturn) void lerrorf(fl_context_t *fl_ctx, value_t e, char *format, ...);
+__declspec(noreturn) void lerror(fl_context_t *fl_ctx, value_t e, const char *msg);
+__declspec(noreturn) void fl_raise(fl_context_t *fl_ctx, value_t e);
+__declspec(noreturn) void type_error(fl_context_t *fl_ctx, char *fname, char *expected, value_t got);
+__declspec(noreturn) void bounds_error(fl_context_t *fl_ctx, char *fname, value_t arr, value_t ind);
 #else
-void lerrorf(value_t e, char *format, ...) __attribute__ ((__noreturn__));
-void lerror(value_t e, const char *msg) __attribute__ ((__noreturn__));
-void fl_raise(value_t e) __attribute__ ((__noreturn__));
-void type_error(char *fname, char *expected, value_t got) __attribute__ ((__noreturn__));
-void bounds_error(char *fname, value_t arr, value_t ind) __attribute__ ((__noreturn__));
+void lerrorf(fl_context_t *fl_ctx, value_t e, char *format, ...) __attribute__ ((__noreturn__));
+void lerror(fl_context_t *fl_ctx, value_t e, const char *msg) __attribute__ ((__noreturn__));
+void fl_raise(fl_context_t *fl_ctx, value_t e) __attribute__ ((__noreturn__));
+void type_error(fl_context_t *fl_ctx, char *fname, char *expected, value_t got) __attribute__ ((__noreturn__));
+void bounds_error(fl_context_t *fl_ctx, char *fname, value_t arr, value_t ind) __attribute__ ((__noreturn__));
 #endif
 
-void fl_savestate(fl_exception_context_t *_ctx);
-void fl_restorestate(fl_exception_context_t *_ctx);
-
-extern value_t ArgError, IOError, KeyError, OutOfMemoryError, EnumerationError;
-extern value_t UnboundError;
-
-static inline void argcount(char *fname, uint32_t nargs, uint32_t c)
-{
-    if (__unlikely(nargs != c))
-        lerrorf(ArgError,"%s: too %s arguments", fname, nargs<c ? "few":"many");
-}
+void fl_savestate(fl_context_t *fl_ctx, fl_exception_context_t *_ctx);
+void fl_restorestate(fl_context_t *fl_ctx, fl_exception_context_t *_ctx);
 
 typedef struct {
-    void (*print)(value_t self, ios_t *f);
-    void (*relocate)(value_t oldv, value_t newv);
-    void (*finalize)(value_t self);
-    void (*print_traverse)(value_t self);
+    void (*print)(fl_context_t *fl_ctx, value_t self, ios_t *f);
+    void (*relocate)(fl_context_t *fl_ctx, value_t oldv, value_t newv);
+    void (*finalize)(fl_context_t *fl_ctx, value_t self);
+    void (*print_traverse)(fl_context_t *fl_ctx, value_t self);
 } cvtable_t;
 
 /* functions needed to implement the value interface (cvtable_t) */
-value_t relocate_lispvalue(value_t v);
-void print_traverse(value_t v);
-void fl_print_chr(char c, ios_t *f);
-void fl_print_str(char *s, ios_t *f);
-void fl_print_child(ios_t *f, value_t v);
+value_t relocate_lispvalue(fl_context_t *fl_ctx, value_t v);
+void print_traverse(fl_context_t *fl_ctx, value_t v);
+void fl_print_chr(fl_context_t *fl_ctx, char c, ios_t *f);
+void fl_print_str(fl_context_t *fl_ctx, char *s, ios_t *f);
+void fl_print_child(fl_context_t *fl_ctx, ios_t *f, value_t v);
 
-typedef int (*cvinitfunc_t)(struct _fltype_t*, value_t, void*);
+typedef int (*cvinitfunc_t)(fl_context_t *fl_ctx, struct _fltype_t*, value_t, void*);
 
 typedef struct _fltype_t {
     value_t type;
     numerictype_t numtype;
     size_t size;
     size_t elsz;
-    cvtable_t *vtable;
+    const cvtable_t *vtable;
     struct _fltype_t *eltype;  // for arrays
     struct _fltype_t *artype;  // (array this)
     int marked;
@@ -284,7 +267,7 @@ typedef struct {
 #define cv_len(cv)     ((cv)->len)
 #define cv_type(cv)    (cv_class(cv)->type)
 #define cv_data(cv)    ((cv)->data)
-#define cv_isstr(cv)   (cv_class(cv)->eltype == bytetype)
+#define cv_isstr(fl_ctx, cv)   (cv_class(cv)->eltype == fl_ctx->bytetype)
 #define cv_isPOD(cv)   (cv_class(cv)->init != NULL)
 
 #define cvalue_data(v) cv_data((cvalue_t*)ptr(v))
@@ -317,78 +300,193 @@ typedef size_t   fl_size_t;
 typedef double   fl_double_t;
 typedef float    fl_float_t;
 
-typedef value_t (*builtin_t)(value_t*, uint32_t);
+typedef value_t (*builtin_t)(fl_context_t*, value_t*, uint32_t);
 
-extern value_t QUOTE;
-extern value_t int8sym, uint8sym, int16sym, uint16sym, int32sym, uint32sym;
-extern value_t int64sym, uint64sym;
-extern value_t ptrdiffsym, sizesym, bytesym, wcharsym;
-extern value_t arraysym, cfunctionsym, voidsym, pointersym;
-extern value_t stringtypesym, wcstringtypesym, emptystringsym;
-extern value_t floatsym, doublesym;
-extern fltype_t *bytetype, *wchartype;
-extern fltype_t *stringtype, *wcstringtype;
-extern fltype_t *builtintype;
-
-value_t cvalue(fltype_t *type, size_t sz);
-void add_finalizer(cvalue_t *cv);
-void cv_autorelease(cvalue_t *cv);
-void cv_pin(cvalue_t *cv);
-size_t ctype_sizeof(value_t type, int *palign);
-value_t cvalue_copy(value_t v);
-value_t cvalue_from_data(fltype_t *type, void *data, size_t sz);
-value_t cvalue_from_ref(fltype_t *type, void *ptr, size_t sz, value_t parent);
-value_t cbuiltin(char *name, builtin_t f);
+value_t cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz);
+void add_finalizer(fl_context_t *fl_ctx, cvalue_t *cv);
+void cv_autorelease(fl_context_t *fl_ctx, cvalue_t *cv);
+void cv_pin(fl_context_t *fl_ctx, cvalue_t *cv);
+size_t ctype_sizeof(fl_context_t *fl_ctx, value_t type, int *palign);
+value_t cvalue_copy(fl_context_t *fl_ctx, value_t v);
+value_t cvalue_from_data(fl_context_t *fl_ctx, fltype_t *type, void *data, size_t sz);
+value_t cvalue_from_ref(fl_context_t *fl_ctx, fltype_t *type, void *ptr, size_t sz, value_t parent);
+value_t cbuiltin(fl_context_t *fl_ctx, char *name, builtin_t f);
 size_t cvalue_arraylen(value_t v);
-value_t size_wrap(size_t sz);
-size_t tosize(value_t n, char *fname);
-value_t cvalue_string(size_t sz);
-value_t cvalue_static_cstrn(const char *str, size_t n);
-value_t cvalue_static_cstring(const char *str);
-value_t string_from_cstr(char *str);
-value_t string_from_cstrn(char *str, size_t n);
-int fl_isstring(value_t v);
-int fl_isnumber(value_t v);
-int fl_isgensym(value_t v);
-int fl_isiostream(value_t v);
-ios_t *fl_toiostream(value_t v, char *fname);
+value_t size_wrap(fl_context_t *fl_ctx, size_t sz);
+size_t tosize(fl_context_t *fl_ctx, value_t n, char *fname);
+value_t cvalue_string(fl_context_t *fl_ctx, size_t sz);
+value_t cvalue_static_cstrn(fl_context_t *fl_ctx, const char *str, size_t n);
+value_t cvalue_static_cstring(fl_context_t *fl_ctx, const char *str);
+value_t string_from_cstr(fl_context_t *fl_ctx, char *str);
+value_t string_from_cstrn(fl_context_t *fl_ctx, char *str, size_t n);
+int fl_isstring(fl_context_t *fl_ctx, value_t v);
+int fl_isnumber(fl_context_t *fl_ctx, value_t v);
+int fl_isgensym(fl_context_t *fl_ctx, value_t v);
+int fl_isiostream(fl_context_t *fl_ctx, value_t v);
+ios_t *fl_toiostream(fl_context_t *fl_ctx, value_t v, char *fname);
 value_t cvalue_compare(value_t a, value_t b);
-int numeric_compare(value_t a, value_t b, int eq, int eqnans, char *fname);
+int numeric_compare(fl_context_t *fl_ctx, value_t a, value_t b, int eq, int eqnans, char *fname);
 
-void to_sized_ptr(value_t v, char *fname, char **pdata, size_t *psz);
+void to_sized_ptr(fl_context_t *fl_ctx, value_t v, char *fname, char **pdata, size_t *psz);
 
-fltype_t *get_type(value_t t);
-fltype_t *get_array_type(value_t eltype);
-fltype_t *define_opaque_type(value_t sym, size_t sz, cvtable_t *vtab,
+fltype_t *get_type(fl_context_t *fl_ctx, value_t t);
+fltype_t *get_array_type(fl_context_t *fl_ctx, value_t eltype);
+fltype_t *define_opaque_type(value_t sym, size_t sz, const cvtable_t *vtab,
                              cvinitfunc_t init);
 
-value_t mk_double(fl_double_t n);
-value_t mk_float(fl_float_t n);
-value_t mk_uint32(uint32_t n);
-value_t mk_uint64(uint64_t n);
-value_t mk_wchar(int32_t n);
-value_t return_from_uint64(uint64_t Uaccum);
-value_t return_from_int64(int64_t Saccum);
+value_t mk_double(fl_context_t *fl_ctx, fl_double_t n);
+value_t mk_float(fl_context_t *fl_ctx, fl_float_t n);
+value_t mk_uint32(fl_context_t *fl_ctx, uint32_t n);
+value_t mk_uint64(fl_context_t *fl_ctx, uint64_t n);
+value_t mk_wchar(fl_context_t *fl_ctx, int32_t n);
+value_t return_from_uint64(fl_context_t *fl_ctx, uint64_t Uaccum);
+value_t return_from_int64(fl_context_t *fl_ctx, int64_t Saccum);
 
 typedef struct {
     char *name;
     builtin_t fptr;
 } builtinspec_t;
 
-void assign_global_builtins(builtinspec_t *b);
+void assign_global_builtins(fl_context_t *fl_ctx, const builtinspec_t *b);
 
 /* builtins */
-value_t fl_hash(value_t *args, u_int32_t nargs);
-value_t cvalue_byte(value_t *args, uint32_t nargs);
-value_t cvalue_wchar(value_t *args, uint32_t nargs);
+value_t fl_hash(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+value_t cvalue_byte(fl_context_t *fl_ctx, value_t *args, uint32_t nargs);
+value_t cvalue_wchar(fl_context_t *fl_ctx, value_t *args, uint32_t nargs);
 
-void fl_init(size_t initial_heapsize);
-int fl_load_system_image(value_t ios);
-int fl_load_system_image_str(char* str, size_t len);
+void fl_init(fl_context_t *fl_ctx, size_t initial_heapsize);
+int fl_load_system_image(fl_context_t *fl_ctx, value_t ios);
+int fl_load_system_image_str(fl_context_t *fl_ctx, char* str, size_t len);
 
 /* julia extensions */
 JL_DLLEXPORT int jl_id_char(uint32_t wc);
 JL_DLLEXPORT int jl_id_start_char(uint32_t wc);
+
+struct _fl_context_t {
+    symbol_t *symtab;
+    value_t NIL, T, F, FL_EOF, QUOTE;
+    value_t int8sym, uint8sym, int16sym, uint16sym, int32sym, uint32sym;
+    value_t int64sym, uint64sym;
+
+    value_t ptrdiffsym, sizesym, bytesym, wcharsym;
+    value_t floatsym, doublesym;
+    value_t stringtypesym, wcstringtypesym;
+    value_t emptystringsym;
+
+    value_t arraysym, cfunctionsym, voidsym, pointersym;
+
+    htable_t TypeTable;
+    htable_t reverse_dlsym_lookup_table;
+
+    fltype_t *int8type, *uint8type;
+    fltype_t *int16type, *uint16type;
+    fltype_t *int32type, *uint32type;
+    fltype_t *int64type, *uint64type;
+    fltype_t *ptrdifftype, *sizetype;
+    fltype_t *floattype, *doubletype;
+    fltype_t *bytetype, *wchartype;
+    fltype_t *stringtype, *wcstringtype;
+    fltype_t *builtintype;
+
+    htable_t equal_eq_hashtable;
+
+    value_t tablesym;
+    fltype_t *tabletype;
+    cvtable_t table_vtable;
+
+    u_int32_t readtoktype;
+    value_t readtokval;
+    char readbuf[256];
+
+    htable_t printconses;
+    u_int32_t printlabel;
+    int print_pretty;
+    int print_princ;
+    fixnum_t print_length;
+    fixnum_t print_level;
+    fixnum_t P_LEVEL;
+    int SCR_WIDTH;
+    int HPOS, VPOS;
+
+    value_t iostreamsym, rdsym, wrsym, apsym, crsym, truncsym;
+    value_t instrsym, outstrsym;
+    fltype_t *iostreamtype;
+
+    size_t malloc_pressure;
+    cvalue_t **Finalizers;
+    size_t nfinalizers;
+    size_t maxfinalizers;
+
+    uint32_t N_STACK;
+    value_t *Stack;
+    uint32_t SP;
+    uint32_t curr_frame;
+
+#define FL_N_GC_HANDLES 8192
+    value_t *GCHandleStack[FL_N_GC_HANDLES];
+    uint32_t N_GCHND;
+
+    value_t IOError, ParseError, TypeError, ArgError, UnboundError, KeyError;
+    value_t OutOfMemoryError, DivideError, BoundsError, EnumerationError;
+    value_t printwidthsym, printreadablysym, printprettysym, printlengthsym;
+    value_t printlevelsym, builtins_table_sym;
+
+    value_t LAMBDA, IF, TRYCATCH;
+    value_t BACKQUOTE, COMMA, COMMAAT, COMMADOT, FUNCTION;
+
+    value_t pairsym, symbolsym, fixnumsym, vectorsym, builtinsym, vu8sym;
+    value_t definesym, defmacrosym, forsym, setqsym;
+    value_t tsym, Tsym, fsym, Fsym, booleansym, nullsym, evalsym, fnsym;
+    // for reading characters
+    value_t nulsym, alarmsym, backspacesym, tabsym, linefeedsym, newlinesym;
+    value_t vtabsym, pagesym, returnsym, escsym, spacesym, deletesym;
+
+    struct _fl_readstate_t *readstate;
+
+    unsigned char *fromspace;
+    unsigned char *tospace;
+    unsigned char *curheap;
+    unsigned char *lim;
+    uint32_t heapsize;//bytes
+    uint32_t *consflags;
+
+    // error utilities --------------------------------------------------
+
+    // saved execution state for an unwind target
+    fl_exception_context_t *exc_ctx;
+    uint32_t throwing_frame;  // active frame when exception was thrown
+    value_t lasterror;
+
+    uint32_t gensym_ctr;
+    // two static buffers for gensym printing so there can be two
+    // gensym names available at a time, mostly for compare()
+    char gsname[2][16];
+    int gsnameno;
+
+    void *tochain;
+    long long n_allocd;
+
+    value_t the_empty_vector;
+    value_t memory_exception_value;
+
+    int gc_grew;
+    cons_t *apply_c;
+    value_t *apply_pv;
+    int64_t apply_accum;
+    value_t apply_func, apply_v, apply_e;
+
+    value_t jl_sym;
+    // persistent buffer (avoid repeated malloc/free)
+    // for julia_extensions.c: normalize
+    size_t jlbuflen;
+    void *jlbuf;
+};
+
+static inline void argcount(fl_context_t *fl_ctx, char *fname, uint32_t nargs, uint32_t c)
+{
+    if (__unlikely(nargs != c))
+        lerrorf(fl_ctx, fl_ctx->ArgError,"%s: too %s arguments", fname, nargs<c ? "few":"many");
+}
 
 #ifdef __cplusplus
 }

--- a/src/flisp/flmain.c
+++ b/src/flisp/flmain.c
@@ -8,30 +8,33 @@
 extern "C" {
 #endif
 
-static value_t argv_list(int argc, char *argv[])
+static value_t argv_list(fl_context_t *fl_ctx, int argc, char *argv[])
 {
     int i;
-    value_t lst=FL_NIL, temp;
-    fl_gc_handle(&lst);
-    fl_gc_handle(&temp);
+    value_t lst=fl_ctx->NIL, temp;
+    fl_gc_handle(fl_ctx, &lst);
+    fl_gc_handle(fl_ctx, &temp);
     for(i=argc-1; i >= 0; i--) {
-        temp = cvalue_static_cstring(argv[i]);
-        lst = fl_cons(temp, lst);
+        temp = cvalue_static_cstring(fl_ctx, argv[i]);
+        lst = fl_cons(fl_ctx, temp, lst);
     }
-    fl_free_gc_handles(2);
+    fl_free_gc_handles(fl_ctx, 2);
     return lst;
 }
 
-extern value_t fl_file(value_t *args, uint32_t nargs);
+extern value_t fl_file(fl_context_t *fl_ctx, value_t *args, uint32_t nargs);
+
+static fl_context_t fl_global_ctx;
 
 int main(int argc, char *argv[])
 {
     char fname_buf[1024];
+    fl_context_t *fl_ctx = &fl_global_ctx;
 
-    fl_init(512*1024);
+    fl_init(fl_ctx, 512*1024);
 
     fname_buf[0] = '\0';
-    value_t str = symbol_value(symbol("*install-dir*"));
+    value_t str = symbol_value(symbol(fl_ctx, "*install-dir*"));
     char *exedir = (char*)(str == UNBOUND ? NULL : cvalue_data(str));
     if (exedir != NULL) {
         strcat(fname_buf, exedir);
@@ -40,23 +43,23 @@ int main(int argc, char *argv[])
     strcat(fname_buf, "flisp.boot");
 
     value_t args[2];
-    fl_gc_handle(&args[0]);
-    fl_gc_handle(&args[1]);
-    FL_TRY_EXTERN {
-        args[0] = cvalue_static_cstring(fname_buf);
-        args[1] = symbol(":read");
-        value_t f = fl_file(&args[0], 2);
-        fl_free_gc_handles(2);
+    fl_gc_handle(fl_ctx, &args[0]);
+    fl_gc_handle(fl_ctx, &args[1]);
+    FL_TRY_EXTERN(fl_ctx) {
+        args[0] = cvalue_static_cstring(fl_ctx, fname_buf);
+        args[1] = symbol(fl_ctx, ":read");
+        value_t f = fl_file(fl_ctx, &args[0], 2);
+        fl_free_gc_handles(fl_ctx, 2);
 
-        if (fl_load_system_image(f))
+        if (fl_load_system_image(fl_ctx, f))
             return 1;
 
-        (void)fl_applyn(1, symbol_value(symbol("__start")),
-                        argv_list(argc, argv));
+        (void)fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "__start")),
+                        argv_list(fl_ctx, argc, argv));
     }
-    FL_CATCH_EXTERN {
+    FL_CATCH_EXTERN(fl_ctx) {
         ios_puts("fatal error:\n", ios_stderr);
-        fl_print(ios_stderr, fl_lasterror);
+        fl_print(fl_ctx, ios_stderr, fl_ctx->lasterror);
         ios_putc('\n', ios_stderr);
         return 1;
     }

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -11,24 +11,22 @@
 extern "C" {
 #endif
 
-static value_t iostreamsym, rdsym, wrsym, apsym, crsym, truncsym;
-static value_t instrsym, outstrsym;
-fltype_t *iostreamtype;
-
-void print_iostream(value_t v, ios_t *f)
+void print_iostream(fl_context_t *fl_ctx, value_t v, ios_t *f)
 {
     (void)v;
-    fl_print_str("#<io stream>", f);
+    fl_print_str(fl_ctx, "#<io stream>", f);
 }
 
-void free_iostream(value_t self)
+void free_iostream(fl_context_t *fl_ctx, value_t self)
 {
+    (void)fl_ctx;
     ios_t *s = value2c(ios_t*, self);
     ios_close(s);
 }
 
-void relocate_iostream(value_t oldv, value_t newv)
+void relocate_iostream(fl_context_t *fl_ctx, value_t oldv, value_t newv)
 {
+    (void)fl_ctx;
     ios_t *olds = value2c(ios_t*, oldv);
     ios_t *news = value2c(ios_t*, newv);
     if (news->buf == &olds->local[0]) {
@@ -36,349 +34,349 @@ void relocate_iostream(value_t oldv, value_t newv)
     }
 }
 
-cvtable_t iostream_vtable = { print_iostream, relocate_iostream,
-                              free_iostream, NULL };
+const cvtable_t iostream_vtable = { print_iostream, relocate_iostream,
+                                    free_iostream, NULL };
 
-int fl_isiostream(value_t v)
+int fl_isiostream(fl_context_t *fl_ctx, value_t v)
 {
-    return iscvalue(v) && cv_class((cvalue_t*)ptr(v)) == iostreamtype;
+    return iscvalue(v) && cv_class((cvalue_t*)ptr(v)) == fl_ctx->iostreamtype;
 }
 
-value_t fl_iostreamp(value_t *args, uint32_t nargs)
+value_t fl_iostreamp(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("iostream?", nargs, 1);
-    return fl_isiostream(args[0]) ? FL_T : FL_F;
+    argcount(fl_ctx, "iostream?", nargs, 1);
+    return fl_isiostream(fl_ctx, args[0]) ? fl_ctx->T : fl_ctx->F;
 }
 
-value_t fl_eof_object(value_t *args, uint32_t nargs)
+value_t fl_eof_object(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     (void)args;
-    argcount("eof-object", nargs, 0);
-    return FL_EOF;
+    argcount(fl_ctx, "eof-object", nargs, 0);
+    return fl_ctx->FL_EOF;
 }
 
-value_t fl_eof_objectp(value_t *args, uint32_t nargs)
+value_t fl_eof_objectp(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("eof-object?", nargs, 1);
-    return (FL_EOF == args[0]) ? FL_T : FL_F;
+    argcount(fl_ctx, "eof-object?", nargs, 1);
+    return (fl_ctx->FL_EOF == args[0]) ? fl_ctx->T : fl_ctx->F;
 }
 
-static ios_t *toiostream(value_t v, char *fname)
+static ios_t *toiostream(fl_context_t *fl_ctx, value_t v, char *fname)
 {
-    if (!fl_isiostream(v))
-        type_error(fname, "iostream", v);
+    if (!fl_isiostream(fl_ctx, v))
+        type_error(fl_ctx, fname, "iostream", v);
     return value2c(ios_t*, v);
 }
 
-ios_t *fl_toiostream(value_t v, char *fname)
+ios_t *fl_toiostream(fl_context_t *fl_ctx, value_t v, char *fname)
 {
-    return toiostream(v, fname);
+    return toiostream(fl_ctx, v, fname);
 }
 
-value_t fl_file(value_t *args, uint32_t nargs)
+value_t fl_file(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 1)
-        argcount("file", nargs, 1);
+        argcount(fl_ctx, "file", nargs, 1);
     int i, r=0, w=0, c=0, t=0, a=0;
     for(i=1; i < (int)nargs; i++) {
-        if      (args[i] == wrsym)    w = 1;
-        else if (args[i] == apsym)    { a = 1; w = 1; }
-        else if (args[i] == crsym)    { c = 1; w = 1; }
-        else if (args[i] == truncsym) { t = 1; w = 1; }
-        else if (args[i] == rdsym)    r = 1;
+        if      (args[i] == fl_ctx->wrsym)    w = 1;
+        else if (args[i] == fl_ctx->apsym)    { a = 1; w = 1; }
+        else if (args[i] == fl_ctx->crsym)    { c = 1; w = 1; }
+        else if (args[i] == fl_ctx->truncsym) { t = 1; w = 1; }
+        else if (args[i] == fl_ctx->rdsym)    r = 1;
     }
     if ((r|w|c|t|a) == 0) r = 1;  // default to reading
-    value_t f = cvalue(iostreamtype, sizeof(ios_t));
-    char *fname = tostring(args[0], "file");
+    value_t f = cvalue(fl_ctx, fl_ctx->iostreamtype, sizeof(ios_t));
+    char *fname = tostring(fl_ctx, args[0], "file");
     ios_t *s = value2c(ios_t*, f);
     if (ios_file(s, fname, r, w, c, t) == NULL)
-        lerrorf(IOError, "file: could not open \"%s\"", fname);
+        lerrorf(fl_ctx, fl_ctx->IOError, "file: could not open \"%s\"", fname);
     if (a) ios_seek_end(s);
     return f;
 }
 
-value_t fl_buffer(value_t *args, u_int32_t nargs)
+value_t fl_buffer(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("buffer", nargs, 0);
+    argcount(fl_ctx, "buffer", nargs, 0);
     (void)args;
-    value_t f = cvalue(iostreamtype, sizeof(ios_t));
+    value_t f = cvalue(fl_ctx, fl_ctx->iostreamtype, sizeof(ios_t));
     ios_t *s = value2c(ios_t*, f);
     if (ios_mem(s, 0) == NULL)
-        lerror(OutOfMemoryError, "buffer: could not allocate stream");
+        lerror(fl_ctx, fl_ctx->OutOfMemoryError, "buffer: could not allocate stream");
     return f;
 }
 
-value_t fl_read(value_t *args, u_int32_t nargs)
+value_t fl_read(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     value_t arg = 0;
     if (nargs > 1) {
-        argcount("read", nargs, 1);
+        argcount(fl_ctx, "read", nargs, 1);
     }
     else if (nargs == 0) {
-        arg = symbol_value(instrsym);
+        arg = symbol_value(fl_ctx->instrsym);
     }
     else {
         arg = args[0];
     }
-    (void)toiostream(arg, "read");
-    fl_gc_handle(&arg);
-    value_t v = fl_read_sexpr(arg);
-    fl_free_gc_handles(1);
+    (void)toiostream(fl_ctx, arg, "read");
+    fl_gc_handle(fl_ctx, &arg);
+    value_t v = fl_read_sexpr(fl_ctx, arg);
+    fl_free_gc_handles(fl_ctx, 1);
     if (ios_eof(value2c(ios_t*,arg)))
-        return FL_EOF;
+        return fl_ctx->FL_EOF;
     return v;
 }
 
-value_t fl_iogetc(value_t *args, u_int32_t nargs)
+value_t fl_iogetc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.getc", nargs, 1);
-    ios_t *s = toiostream(args[0], "io.getc");
+    argcount(fl_ctx, "io.getc", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.getc");
     uint32_t wc;
     if (ios_getutf8(s, &wc) == IOS_EOF)
-        //lerror(IOError, "io.getc: end of file reached");
-        return FL_EOF;
-    return mk_wchar(wc);
+        //lerror(fl_ctx, IOError, "io.getc: end of file reached");
+        return fl_ctx->FL_EOF;
+    return mk_wchar(fl_ctx, wc);
 }
 
-value_t fl_iopeekc(value_t *args, u_int32_t nargs)
+value_t fl_iopeekc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.peekc", nargs, 1);
-    ios_t *s = toiostream(args[0], "io.peekc");
+    argcount(fl_ctx, "io.peekc", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.peekc");
     uint32_t wc;
     if (ios_peekutf8(s, &wc) == IOS_EOF)
-        return FL_EOF;
-    return mk_wchar(wc);
+        return fl_ctx->FL_EOF;
+    return mk_wchar(fl_ctx, wc);
 }
 
-value_t fl_ioputc(value_t *args, u_int32_t nargs)
+value_t fl_ioputc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.putc", nargs, 2);
-    ios_t *s = toiostream(args[0], "io.putc");
-    if (!iscprim(args[1]) || ((cprim_t*)ptr(args[1]))->type != wchartype)
-        type_error("io.putc", "wchar", args[1]);
+    argcount(fl_ctx, "io.putc", nargs, 2);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.putc");
+    if (!iscprim(args[1]) || ((cprim_t*)ptr(args[1]))->type != fl_ctx->wchartype)
+        type_error(fl_ctx, "io.putc", "wchar", args[1]);
     uint32_t wc = *(uint32_t*)cp_data((cprim_t*)ptr(args[1]));
     return fixnum(ios_pututf8(s, wc));
 }
 
-value_t fl_ioungetc(value_t *args, u_int32_t nargs)
+value_t fl_ioungetc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.ungetc", nargs, 2);
-    ios_t *s = toiostream(args[0], "io.ungetc");
-    if (!iscprim(args[1]) || ((cprim_t*)ptr(args[1]))->type != wchartype)
-        type_error("io.ungetc", "wchar", args[1]);
+    argcount(fl_ctx, "io.ungetc", nargs, 2);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.ungetc");
+    if (!iscprim(args[1]) || ((cprim_t*)ptr(args[1]))->type != fl_ctx->wchartype)
+        type_error(fl_ctx, "io.ungetc", "wchar", args[1]);
     uint32_t wc = *(uint32_t*)cp_data((cprim_t*)ptr(args[1]));
     if (wc >= 0x80) {
-        lerror(ArgError, "io_ungetc: unicode not yet supported");
+        lerror(fl_ctx, fl_ctx->ArgError, "io_ungetc: unicode not yet supported");
     }
     return fixnum(ios_ungetc((int)wc,s));
 }
 
-value_t fl_ioflush(value_t *args, u_int32_t nargs)
+value_t fl_ioflush(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.flush", nargs, 1);
-    ios_t *s = toiostream(args[0], "io.flush");
+    argcount(fl_ctx, "io.flush", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.flush");
     if (ios_flush(s) != 0)
-        return FL_F;
-    return FL_T;
+        return fl_ctx->F;
+    return fl_ctx->T;
 }
 
-value_t fl_ioclose(value_t *args, u_int32_t nargs)
+value_t fl_ioclose(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.close", nargs, 1);
-    ios_t *s = toiostream(args[0], "io.close");
+    argcount(fl_ctx, "io.close", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.close");
     ios_close(s);
-    return FL_T;
+    return fl_ctx->T;
 }
 
-value_t fl_iopurge(value_t *args, u_int32_t nargs)
+value_t fl_iopurge(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.discardbuffer", nargs, 1);
-    ios_t *s = toiostream(args[0], "io.discardbuffer");
+    argcount(fl_ctx, "io.discardbuffer", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.discardbuffer");
     ios_purge(s);
-    return FL_T;
+    return fl_ctx->T;
 }
 
-value_t fl_ioeof(value_t *args, u_int32_t nargs)
+value_t fl_ioeof(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.eof?", nargs, 1);
-    ios_t *s = toiostream(args[0], "io.eof?");
-    return (ios_eof(s) ? FL_T : FL_F);
+    argcount(fl_ctx, "io.eof?", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.eof?");
+    return (ios_eof(s) ? fl_ctx->T : fl_ctx->F);
 }
 
-value_t fl_iolineno(value_t *args, u_int32_t nargs)
+value_t fl_iolineno(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("input-port-line", nargs, 1);
-    ios_t *s = toiostream(args[0], "input-port-line");
-    return size_wrap(s->lineno);
+    argcount(fl_ctx, "input-port-line", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "input-port-line");
+    return size_wrap(fl_ctx, s->lineno);
 }
 
-value_t fl_ioseek(value_t *args, u_int32_t nargs)
+value_t fl_ioseek(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.seek", nargs, 2);
-    ios_t *s = toiostream(args[0], "io.seek");
-    size_t pos = tosize(args[1], "io.seek");
+    argcount(fl_ctx, "io.seek", nargs, 2);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.seek");
+    size_t pos = tosize(fl_ctx, args[1], "io.seek");
     off_t res = ios_seek(s, (off_t)pos);
     if (res < 0)
-        return FL_F;
-    return FL_T;
+        return fl_ctx->F;
+    return fl_ctx->T;
 }
 
-value_t fl_iopos(value_t *args, u_int32_t nargs)
+value_t fl_iopos(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.pos", nargs, 1);
-    ios_t *s = toiostream(args[0], "io.pos");
+    argcount(fl_ctx, "io.pos", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.pos");
     off_t res = ios_pos(s);
     if (res == -1)
-        return FL_F;
-    return size_wrap((size_t)res);
+        return fl_ctx->F;
+    return size_wrap(fl_ctx, (size_t)res);
 }
 
-value_t fl_write(value_t *args, u_int32_t nargs)
+value_t fl_write(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 1 || nargs > 2)
-        argcount("write", nargs, 1);
+        argcount(fl_ctx, "write", nargs, 1);
     ios_t *s;
     if (nargs == 2)
-        s = toiostream(args[1], "write");
+        s = toiostream(fl_ctx, args[1], "write");
     else
-        s = toiostream(symbol_value(outstrsym), "write");
-    fl_print(s, args[0]);
+        s = toiostream(fl_ctx, symbol_value(fl_ctx->outstrsym), "write");
+    fl_print(fl_ctx, s, args[0]);
     return args[0];
 }
 
-value_t fl_ioread(value_t *args, u_int32_t nargs)
+value_t fl_ioread(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs != 3)
-        argcount("io.read", nargs, 2);
-    (void)toiostream(args[0], "io.read");
+        argcount(fl_ctx, "io.read", nargs, 2);
+    (void)toiostream(fl_ctx, args[0], "io.read");
     size_t n;
     fltype_t *ft;
     if (nargs == 3) {
         // form (io.read s type count)
-        ft = get_array_type(args[1]);
-        n = tosize(args[2], "io.read") * ft->elsz;
+        ft = get_array_type(fl_ctx, args[1]);
+        n = tosize(fl_ctx, args[2], "io.read") * ft->elsz;
     }
     else {
-        ft = get_type(args[1]);
+        ft = get_type(fl_ctx, args[1]);
         if (ft->eltype != NULL && !iscons(cdr_(cdr_(args[1]))))
-            lerror(ArgError, "io.read: incomplete type");
+            lerror(fl_ctx, fl_ctx->ArgError, "io.read: incomplete type");
         n = ft->size;
     }
-    value_t cv = cvalue(ft, n);
+    value_t cv = cvalue(fl_ctx, ft, n);
     char *data;
     if (iscvalue(cv)) data = (char*)cv_data((cvalue_t*)ptr(cv));
     else data = cp_data((cprim_t*)ptr(cv));
     size_t got = ios_read(value2c(ios_t*,args[0]), data, n);
     if (got < n)
-        //lerror(IOError, "io.read: end of input reached");
-        return FL_EOF;
+        //lerror(fl_ctx, IOError, "io.read: end of input reached");
+        return fl_ctx->FL_EOF;
     return cv;
 }
 
 // args must contain data[, offset[, count]]
-static void get_start_count_args(value_t *args, uint32_t nargs, size_t sz,
+static void get_start_count_args(fl_context_t *fl_ctx, value_t *args, uint32_t nargs, size_t sz,
                                  size_t *offs, size_t *nb, char *fname)
 {
     if (nargs > 1) {
-        *offs = tosize(args[1], fname);
+        *offs = tosize(fl_ctx, args[1], fname);
         if (nargs > 2)
-            *nb = tosize(args[2], fname);
+            *nb = tosize(fl_ctx, args[2], fname);
         else
             *nb = sz - *offs;
         if (*offs >= sz || *offs + *nb > sz)
-            bounds_error(fname, args[0], args[1]);
+            bounds_error(fl_ctx, fname, args[0], args[1]);
     }
 }
 
-value_t fl_iowrite(value_t *args, u_int32_t nargs)
+value_t fl_iowrite(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 2 || nargs > 4)
-        argcount("io.write", nargs, 2);
-    ios_t *s = toiostream(args[0], "io.write");
-    if (iscprim(args[1]) && ((cprim_t*)ptr(args[1]))->type == wchartype) {
+        argcount(fl_ctx, "io.write", nargs, 2);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.write");
+    if (iscprim(args[1]) && ((cprim_t*)ptr(args[1]))->type == fl_ctx->wchartype) {
         if (nargs > 2)
-            lerror(ArgError,
+            lerror(fl_ctx, fl_ctx->ArgError,
                    "io.write: offset argument not supported for characters");
         uint32_t wc = *(uint32_t*)cp_data((cprim_t*)ptr(args[1]));
         return fixnum(ios_pututf8(s, wc));
     }
     char *data;
     size_t sz, offs=0;
-    to_sized_ptr(args[1], "io.write", &data, &sz);
+    to_sized_ptr(fl_ctx, args[1], "io.write", &data, &sz);
     size_t nb = sz;
     if (nargs > 2) {
-        get_start_count_args(&args[1], nargs-1, sz, &offs, &nb, "io.write");
+        get_start_count_args(fl_ctx, &args[1], nargs-1, sz, &offs, &nb, "io.write");
         data += offs;
     }
-    return size_wrap(ios_write(s, data, nb));
+    return size_wrap(fl_ctx, ios_write(s, data, nb));
 }
 
-static char get_delim_arg(value_t arg, char *fname)
+static char get_delim_arg(fl_context_t *fl_ctx, value_t arg, char *fname)
 {
-    size_t uldelim = tosize(arg, fname);
+    size_t uldelim = tosize(fl_ctx, arg, fname);
     if (uldelim > 0x7f) {
         // wchars > 0x7f, or anything else > 0xff, are out of range
-        if ((iscprim(arg) && cp_class((cprim_t*)ptr(arg))==wchartype) ||
+        if ((iscprim(arg) && cp_class((cprim_t*)ptr(arg))==fl_ctx->wchartype) ||
             uldelim > 0xff)
-            lerrorf(ArgError, "%s: delimiter out of range", fname);
+            lerrorf(fl_ctx, fl_ctx->ArgError, "%s: delimiter out of range", fname);
     }
     return (char)uldelim;
 }
 
-value_t fl_ioreaduntil(value_t *args, u_int32_t nargs)
+value_t fl_ioreaduntil(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.readuntil", nargs, 2);
-    value_t str = cvalue_string(80);
+    argcount(fl_ctx, "io.readuntil", nargs, 2);
+    value_t str = cvalue_string(fl_ctx, 80);
     cvalue_t *cv = (cvalue_t*)ptr(str);
     char *data = (char*)cv_data(cv);
     ios_t dest;
     ios_mem(&dest, 0);
     ios_setbuf(&dest, data, 80, 0);
-    char delim = get_delim_arg(args[1], "io.readuntil");
-    ios_t *src = toiostream(args[0], "io.readuntil");
+    char delim = get_delim_arg(fl_ctx, args[1], "io.readuntil");
+    ios_t *src = toiostream(fl_ctx, args[0], "io.readuntil");
     size_t n = ios_copyuntil(&dest, src, delim);
     cv->len = n;
     if (dest.buf != data) {
         // outgrew initial space
         cv->data = dest.buf;
-        cv_autorelease(cv);
+        cv_autorelease(fl_ctx, cv);
     }
     ((char*)cv->data)[n] = '\0';
     if (n == 0 && ios_eof(src))
-        return FL_EOF;
+        return fl_ctx->FL_EOF;
     return str;
 }
 
-value_t fl_iocopyuntil(value_t *args, u_int32_t nargs)
+value_t fl_iocopyuntil(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.copyuntil", nargs, 3);
-    ios_t *dest = toiostream(args[0], "io.copyuntil");
-    ios_t *src = toiostream(args[1], "io.copyuntil");
-    char delim = get_delim_arg(args[2], "io.copyuntil");
-    return size_wrap(ios_copyuntil(dest, src, delim));
+    argcount(fl_ctx, "io.copyuntil", nargs, 3);
+    ios_t *dest = toiostream(fl_ctx, args[0], "io.copyuntil");
+    ios_t *src = toiostream(fl_ctx, args[1], "io.copyuntil");
+    char delim = get_delim_arg(fl_ctx, args[2], "io.copyuntil");
+    return size_wrap(fl_ctx, ios_copyuntil(dest, src, delim));
 }
 
-value_t fl_iocopy(value_t *args, u_int32_t nargs)
+value_t fl_iocopy(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 2 || nargs > 3)
-        argcount("io.copy", nargs, 2);
-    ios_t *dest = toiostream(args[0], "io.copy");
-    ios_t *src = toiostream(args[1], "io.copy");
+        argcount(fl_ctx, "io.copy", nargs, 2);
+    ios_t *dest = toiostream(fl_ctx, args[0], "io.copy");
+    ios_t *src = toiostream(fl_ctx, args[1], "io.copy");
     if (nargs == 3) {
-        size_t n = tosize(args[2], "io.copy");
-        return size_wrap(ios_copy(dest, src, n));
+        size_t n = tosize(fl_ctx, args[2], "io.copy");
+        return size_wrap(fl_ctx, ios_copy(dest, src, n));
     }
-    return size_wrap(ios_copyall(dest, src));
+    return size_wrap(fl_ctx, ios_copyall(dest, src));
 }
 
-value_t stream_to_string(value_t *ps)
+value_t stream_to_string(fl_context_t *fl_ctx, value_t *ps)
 {
     value_t str;
     size_t n;
     ios_t *st = value2c(ios_t*,*ps);
     if (st->buf == &st->local[0]) {
         n = st->size;
-        str = cvalue_string(n);
+        str = cvalue_string(fl_ctx, n);
         st = value2c(ios_t*,*ps); // reload after allocating str
         memcpy(cvalue_data(str), st->buf, n);
         ios_trunc(st, 0);
@@ -386,22 +384,22 @@ value_t stream_to_string(value_t *ps)
     else {
         char *b = ios_takebuf(st, &n); n--;
         b[n] = '\0';
-        str = cvalue_from_ref(stringtype, b, n, FL_NIL);
-        cv_autorelease((cvalue_t*)ptr(str));
+        str = cvalue_from_ref(fl_ctx, fl_ctx->stringtype, b, n, fl_ctx->NIL);
+        cv_autorelease(fl_ctx, (cvalue_t*)ptr(str));
     }
     return str;
 }
 
-value_t fl_iotostring(value_t *args, u_int32_t nargs)
+value_t fl_iotostring(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("io.tostring!", nargs, 1);
-    ios_t *src = toiostream(args[0], "io.tostring!");
+    argcount(fl_ctx, "io.tostring!", nargs, 1);
+    ios_t *src = toiostream(fl_ctx, args[0], "io.tostring!");
     if (src->bm != bm_mem)
-        lerror(ArgError, "io.tostring!: requires memory stream");
-    return stream_to_string(&args[0]);
+        lerror(fl_ctx, fl_ctx->ArgError, "io.tostring!: requires memory stream");
+    return stream_to_string(fl_ctx, &args[0]);
 }
 
-static builtinspec_t iostreamfunc_info[] = {
+static const builtinspec_t iostreamfunc_info[] = {
     { "iostream?", fl_iostreamp },
     { "eof-object", fl_eof_object },
     { "eof-object?", fl_eof_objectp },
@@ -430,26 +428,26 @@ static builtinspec_t iostreamfunc_info[] = {
     { NULL, NULL }
 };
 
-void iostream_init(void)
+void iostream_init(fl_context_t *fl_ctx)
 {
-    iostreamsym = symbol("iostream");
-    rdsym = symbol(":read");
-    wrsym = symbol(":write");
-    apsym = symbol(":append");
-    crsym = symbol(":create");
-    truncsym = symbol(":truncate");
-    instrsym = symbol("*input-stream*");
-    outstrsym = symbol("*output-stream*");
-    iostreamtype = define_opaque_type(iostreamsym, sizeof(ios_t),
-                                      &iostream_vtable, NULL);
-    assign_global_builtins(iostreamfunc_info);
+    fl_ctx->iostreamsym = symbol(fl_ctx, "iostream");
+    fl_ctx->rdsym = symbol(fl_ctx, ":read");
+    fl_ctx->wrsym = symbol(fl_ctx, ":write");
+    fl_ctx->apsym = symbol(fl_ctx, ":append");
+    fl_ctx->crsym = symbol(fl_ctx, ":create");
+    fl_ctx->truncsym = symbol(fl_ctx, ":truncate");
+    fl_ctx->instrsym = symbol(fl_ctx, "*input-stream*");
+    fl_ctx->outstrsym = symbol(fl_ctx, "*output-stream*");
+    fl_ctx->iostreamtype = define_opaque_type(fl_ctx->iostreamsym, sizeof(ios_t),
+                                              &iostream_vtable, NULL);
+    assign_global_builtins(fl_ctx, iostreamfunc_info);
 
-    setc(symbol("*stdout*"), cvalue_from_ref(iostreamtype, ios_stdout,
-                                             sizeof(ios_t), FL_NIL));
-    setc(symbol("*stderr*"), cvalue_from_ref(iostreamtype, ios_stderr,
-                                             sizeof(ios_t), FL_NIL));
-    setc(symbol("*stdin*" ), cvalue_from_ref(iostreamtype, ios_stdin,
-                                             sizeof(ios_t), FL_NIL));
+    setc(symbol(fl_ctx, "*stdout*"), cvalue_from_ref(fl_ctx, fl_ctx->iostreamtype, ios_stdout,
+                                                     sizeof(ios_t), fl_ctx->NIL));
+    setc(symbol(fl_ctx, "*stderr*"), cvalue_from_ref(fl_ctx, fl_ctx->iostreamtype, ios_stderr,
+                                                     sizeof(ios_t), fl_ctx->NIL));
+    setc(symbol(fl_ctx, "*stdin*" ), cvalue_from_ref(fl_ctx, fl_ctx->iostreamtype, ios_stdin,
+                                                     sizeof(ios_t), fl_ctx->NIL));
 }
 
 #ifdef __cplusplus

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -26,22 +26,22 @@ static int is_bom(uint32_t wc)
     return wc == 0xFEFF;
 }
 
-value_t fl_skipws(value_t *args, u_int32_t nargs)
+value_t fl_skipws(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("skip-ws", nargs, 2);
-    ios_t *s = fl_toiostream(args[0], "skip-ws");
-    int newlines = (args[1]!=FL_F);
+    argcount(fl_ctx, "skip-ws", nargs, 2);
+    ios_t *s = fl_toiostream(fl_ctx, args[0], "skip-ws");
+    int newlines = (args[1]!=fl_ctx->F);
     uint32_t wc=0;
-    value_t skipped = FL_F;
+    value_t skipped = fl_ctx->F;
     while (1) {
         if (ios_peekutf8(s, &wc) == IOS_EOF) {
             ios_getutf8(s, &wc);  // to set EOF flag if this is a true EOF
             if (!ios_eof(s))
-                lerror(symbol("error"), "incomplete character");
-            return FL_EOF;
+                lerror(fl_ctx, symbol(fl_ctx, "error"), "incomplete character");
+            return fl_ctx->FL_EOF;
         }
         if (!ios_eof(s) && (is_uws(wc) || is_bom(wc)) && (newlines || wc!=10)) {
-            skipped = FL_T;
+            skipped = fl_ctx->T;
             ios_getutf8(s, &wc);
         }
         else {
@@ -136,29 +136,27 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
     return 0;
 }
 
-value_t fl_julia_identifier_char(value_t *args, u_int32_t nargs)
+value_t fl_julia_identifier_char(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("identifier-char?", nargs, 1);
-    if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != wchartype)
-        type_error("identifier-char?", "wchar", args[0]);
+    argcount(fl_ctx, "identifier-char?", nargs, 1);
+    if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != fl_ctx->wchartype)
+        type_error(fl_ctx, "identifier-char?", "wchar", args[0]);
     uint32_t wc = *(uint32_t*)cp_data((cprim_t*)ptr(args[0]));
-    return jl_id_char(wc) ? FL_T : FL_F;
+    return jl_id_char(wc) ? fl_ctx->T : fl_ctx->F;
 }
 
-value_t fl_julia_identifier_start_char(value_t *args, u_int32_t nargs)
+value_t fl_julia_identifier_start_char(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("identifier-start-char?", nargs, 1);
-    if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != wchartype)
-        type_error("identifier-start-char?", "wchar", args[0]);
+    argcount(fl_ctx, "identifier-start-char?", nargs, 1);
+    if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != fl_ctx->wchartype)
+        type_error(fl_ctx, "identifier-start-char?", "wchar", args[0]);
     uint32_t wc = *(uint32_t*)cp_data((cprim_t*)ptr(args[0]));
-    return jl_id_start_char(wc) ? FL_T : FL_F;
+    return jl_id_start_char(wc) ? fl_ctx->T : fl_ctx->F;
 }
 
 // return NFC-normalized UTF8-encoded version of s
-static char *normalize(char *s)
+static char *normalize(fl_context_t *fl_ctx, char *s)
 {
-    static size_t buflen = 0;
-    static void *buf = NULL; // persistent buffer (avoid repeated malloc/free)
     // options equivalent to utf8proc_NFC:
     const int options = UTF8PROC_NULLTERM|UTF8PROC_STABLE|UTF8PROC_COMPOSE;
     ssize_t result;
@@ -166,27 +164,27 @@ static char *normalize(char *s)
     result = utf8proc_decompose((uint8_t*) s, 0, NULL, 0, (utf8proc_option_t)options);
     if (result < 0) goto error;
     newlen = result * sizeof(int32_t) + 1;
-    if (newlen > buflen) {
-        buflen = newlen * 2;
-        buf = realloc(buf, buflen);
-        if (!buf) lerror(OutOfMemoryError, "error allocating UTF8 buffer");
+    if (newlen > fl_ctx->jlbuflen) {
+        fl_ctx->jlbuflen = newlen * 2;
+        fl_ctx->jlbuf = realloc(fl_ctx->jlbuf, fl_ctx->jlbuflen);
+        if (!fl_ctx->jlbuf) lerror(fl_ctx, fl_ctx->OutOfMemoryError, "error allocating UTF8 buffer");
     }
-    result = utf8proc_decompose((uint8_t*)s,0, (int32_t*)buf,result, (utf8proc_option_t)options);
+    result = utf8proc_decompose((uint8_t*)s,0, (int32_t*)fl_ctx->jlbuf,result, (utf8proc_option_t)options);
     if (result < 0) goto error;
-    result = utf8proc_reencode((int32_t*)buf,result, (utf8proc_option_t)options);
+    result = utf8proc_reencode((int32_t*)fl_ctx->jlbuf,result, (utf8proc_option_t)options);
     if (result < 0) goto error;
-    return (char*) buf;
+    return (char*) fl_ctx->jlbuf;
 error:
-    lerrorf(symbol("error"), "error normalizing identifier %s: %s", s,
+    lerrorf(fl_ctx, symbol(fl_ctx, "error"), "error normalizing identifier %s: %s", s,
             utf8proc_errmsg(result));
 }
 
-value_t fl_accum_julia_symbol(value_t *args, u_int32_t nargs)
+value_t fl_accum_julia_symbol(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("accum-julia-symbol", nargs, 2);
-    ios_t *s = fl_toiostream(args[1], "accum-julia-symbol");
-    if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != wchartype)
-        type_error("accum-julia-symbol", "wchar", args[0]);
+    argcount(fl_ctx, "accum-julia-symbol", nargs, 2);
+    ios_t *s = fl_toiostream(fl_ctx, args[1], "accum-julia-symbol");
+    if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != fl_ctx->wchartype)
+        type_error(fl_ctx, "accum-julia-symbol", "wchar", args[0]);
     uint32_t wc = *(uint32_t*)cp_data((cprim_t*)ptr(args[0]));
     ios_t str;
     ios_mem(&str, 0);
@@ -206,10 +204,10 @@ value_t fl_accum_julia_symbol(value_t *args, u_int32_t nargs)
             break;
     }
     ios_pututf8(&str, 0);
-    return symbol(normalize(str.buf));
+    return symbol(fl_ctx, normalize(fl_ctx, str.buf));
 }
 
-static builtinspec_t julia_flisp_func_info[] = {
+static const builtinspec_t julia_flisp_func_info[] = {
     { "skip-ws", fl_skipws },
     { "accum-julia-symbol", fl_accum_julia_symbol },
     { "identifier-char?", fl_julia_identifier_char },
@@ -217,9 +215,9 @@ static builtinspec_t julia_flisp_func_info[] = {
     { NULL, NULL }
 };
 
-void fl_init_julia_extensions(void)
+void fl_init_julia_extensions(fl_context_t *fl_ctx)
 {
-    assign_global_builtins(julia_flisp_func_info);
+    assign_global_builtins(fl_ctx, julia_flisp_func_info);
 }
 
 #ifdef __cplusplus

--- a/src/flisp/opcodes.h
+++ b/src/flisp/opcodes.h
@@ -36,8 +36,8 @@ enum {
 
 #ifdef USE_COMPUTED_GOTO
 #define VM_LABELS                                                       \
-    static void *vm_labels[] = {                                        \
-NULL, &&L_OP_DUP, &&L_OP_POP, &&L_OP_CALL, &&L_OP_TCALL, &&L_OP_JMP, \
+    static const void *vm_labels[] = {                                  \
+    NULL, &&L_OP_DUP, &&L_OP_POP, &&L_OP_CALL, &&L_OP_TCALL, &&L_OP_JMP,\
     &&L_OP_BRF, &&L_OP_BRT,                                             \
     &&L_OP_JMPL, &&L_OP_BRFL, &&L_OP_BRTL, &&L_OP_RET,                  \
                                                                         \

--- a/src/flisp/print.c
+++ b/src/flisp/print.c
@@ -1,42 +1,32 @@
 extern void *memrchr(const void *s, int c, size_t n);
 
-static htable_t printconses;
-static u_int32_t printlabel;
-static int print_pretty;
-static int print_princ;
-static fixnum_t print_length;
-static fixnum_t print_level;
-static fixnum_t P_LEVEL;
-static int SCR_WIDTH = 80;
-
-static int HPOS=0, VPOS;
-static void outc(char c, ios_t *f)
+static void outc(fl_context_t *fl_ctx, char c, ios_t *f)
 {
     ios_putc(c, f);
     if (c == '\n')
-        HPOS = 0;
+        fl_ctx->HPOS = 0;
     else
-        HPOS++;
+        fl_ctx->HPOS++;
 }
-static void outs(char *s, ios_t *f)
+static void outs(fl_context_t *fl_ctx, char *s, ios_t *f)
 {
     ios_puts(s, f);
-    HPOS += u8_strwidth(s);
+    fl_ctx->HPOS += u8_strwidth(s);
 }
-static void outsn(char *s, ios_t *f, size_t n)
+static void outsn(fl_context_t *fl_ctx, char *s, ios_t *f, size_t n)
 {
     ios_write(f, s, n);
-    HPOS += u8_strwidth(s);
+    fl_ctx->HPOS += u8_strwidth(s);
 }
-static int outindent(int n, ios_t *f)
+static int outindent(fl_context_t *fl_ctx, int n, ios_t *f)
 {
     // move back to left margin if we get too indented
-    if (n > SCR_WIDTH-12)
+    if (n > fl_ctx->SCR_WIDTH-12)
         n = 2;
     int n0 = n;
     ios_putc('\n', f);
-    VPOS++;
-    HPOS = n;
+    fl_ctx->VPOS++;
+    fl_ctx->HPOS = n;
     while (n >= 8) {
         ios_putc('\t', f);
         n -= 8;
@@ -48,75 +38,75 @@ static int outindent(int n, ios_t *f)
     return n0;
 }
 
-void fl_print_chr(char c, ios_t *f)
+void fl_print_chr(fl_context_t *fl_ctx, char c, ios_t *f)
 {
-    outc(c, f);
+    outc(fl_ctx, c, f);
 }
 
-void fl_print_str(char *s, ios_t *f)
+void fl_print_str(fl_context_t *fl_ctx, char *s, ios_t *f)
 {
-    outs(s, f);
+    outs(fl_ctx, s, f);
 }
 
-void print_traverse(value_t v)
+void print_traverse(fl_context_t *fl_ctx, value_t v)
 {
     value_t *bp;
     while (iscons(v)) {
-        if (ismarked(v)) {
-            bp = (value_t*)ptrhash_bp(&printconses, (void*)v);
+        if (ismarked(fl_ctx, v)) {
+            bp = (value_t*)ptrhash_bp(&fl_ctx->printconses, (void*)v);
             if (*bp == (value_t)HT_NOTFOUND)
-                *bp = fixnum(printlabel++);
+                *bp = fixnum(fl_ctx->printlabel++);
             return;
         }
-        mark_cons(v);
-        print_traverse(car_(v));
+        mark_cons(fl_ctx, v);
+        print_traverse(fl_ctx, car_(v));
         v = cdr_(v);
     }
-    if (!ismanaged(v) || issymbol(v))
+    if (!ismanaged(fl_ctx, v) || issymbol(v))
         return;
-    if (ismarked(v)) {
-        bp = (value_t*)ptrhash_bp(&printconses, (void*)v);
+    if (ismarked(fl_ctx, v)) {
+        bp = (value_t*)ptrhash_bp(&fl_ctx->printconses, (void*)v);
         if (*bp == (value_t)HT_NOTFOUND)
-            *bp = fixnum(printlabel++);
+            *bp = fixnum(fl_ctx->printlabel++);
         return;
     }
     if (isvector(v)) {
         if (vector_size(v) > 0)
-            mark_cons(v);
+            mark_cons(fl_ctx, v);
         unsigned int i;
         for(i=0; i < vector_size(v); i++)
-            print_traverse(vector_elt(v,i));
+            print_traverse(fl_ctx, vector_elt(v,i));
     }
     else if (iscprim(v)) {
-        mark_cons(v);
+        mark_cons(fl_ctx, v);
     }
     else if (isclosure(v)) {
-        mark_cons(v);
+        mark_cons(fl_ctx, v);
         function_t *f = (function_t*)ptr(v);
-        print_traverse(f->bcode);
-        print_traverse(f->vals);
-        print_traverse(f->env);
+        print_traverse(fl_ctx, f->bcode);
+        print_traverse(fl_ctx, f->vals);
+        print_traverse(fl_ctx, f->env);
     }
     else {
         assert(iscvalue(v));
         cvalue_t *cv = (cvalue_t*)ptr(v);
         // don't consider shared references to ""
-        if (!cv_isstr(cv) || cv_len(cv)!=0)
-            mark_cons(v);
+        if (!cv_isstr(fl_ctx, cv) || cv_len(cv)!=0)
+            mark_cons(fl_ctx, v);
         fltype_t *t = cv_class(cv);
         if (t->vtable != NULL && t->vtable->print_traverse != NULL)
-            t->vtable->print_traverse(v);
+            t->vtable->print_traverse(fl_ctx, v);
     }
 }
 
-static void print_symbol_name(ios_t *f, char *name)
+static void print_symbol_name(fl_context_t *fl_ctx, ios_t *f, char *name)
 {
     int i, escape=0, charescape=0;
 
     if ((name[0] == '\0') ||
         (name[0] == '.' && name[1] == '\0') ||
         (name[0] == '#') ||
-        isnumtok(name, NULL))
+        isnumtok(fl_ctx, name, NULL))
         escape = 1;
     i=0;
     while (name[i]) {
@@ -131,24 +121,24 @@ static void print_symbol_name(ios_t *f, char *name)
     }
     if (escape) {
         if (charescape) {
-            outc('|', f);
+            outc(fl_ctx, '|', f);
             i=0;
             while (name[i]) {
                 if (name[i]=='|' || name[i]=='\\')
-                    outc('\\', f);
-                outc(name[i], f);
+                    outc(fl_ctx, '\\', f);
+                outc(fl_ctx, name[i], f);
                 i++;
             }
-            outc('|', f);
+            outc(fl_ctx, '|', f);
         }
         else {
-            outc('|', f);
-            outs(name, f);
-            outc('|', f);
+            outc(fl_ctx, '|', f);
+            outs(fl_ctx, name, f);
+            outc(fl_ctx, '|', f);
         }
     }
     else {
-        outs(name, f);
+        outs(fl_ctx, name, f);
     }
 }
 
@@ -162,58 +152,58 @@ static void print_symbol_name(ios_t *f, char *name)
   to print anyway.
 */
 #define SMALL_STR_LEN 20
-static inline int tinyp(value_t v)
+static inline int tinyp(fl_context_t *fl_ctx, value_t v)
 {
     if (issymbol(v))
-        return (u8_strwidth(symbol_name(v)) < SMALL_STR_LEN);
-    if (fl_isstring(v))
+        return (u8_strwidth(symbol_name(fl_ctx, v)) < SMALL_STR_LEN);
+    if (fl_isstring(fl_ctx, v))
         return (cv_len((cvalue_t*)ptr(v)) < SMALL_STR_LEN);
-    return (isfixnum(v) || isbuiltin(v) || v==FL_F || v==FL_T || v==FL_NIL ||
-            v == FL_EOF);
+    return (isfixnum(v) || isbuiltin(v) || v==fl_ctx->F || v==fl_ctx->T || v==fl_ctx->NIL ||
+            v == fl_ctx->FL_EOF);
 }
 
-static int smallp(value_t v)
+static int smallp(fl_context_t *fl_ctx, value_t v)
 {
-    if (tinyp(v)) return 1;
-    if (fl_isnumber(v)) return 1;
+    if (tinyp(fl_ctx, v)) return 1;
+    if (fl_isnumber(fl_ctx, v)) return 1;
     if (iscons(v)) {
-        if (tinyp(car_(v)) && (tinyp(cdr_(v)) ||
-                               (iscons(cdr_(v)) && tinyp(car_(cdr_(v))) &&
-                                cdr_(cdr_(v))==NIL)))
+        if (tinyp(fl_ctx, car_(v)) && (tinyp(fl_ctx, cdr_(v)) ||
+                               (iscons(cdr_(v)) && tinyp(fl_ctx, car_(cdr_(v))) &&
+                                cdr_(cdr_(v))==fl_ctx->NIL)))
             return 1;
         return 0;
     }
     if (isvector(v)) {
         size_t s = vector_size(v);
-        return (s == 0 || (tinyp(vector_elt(v,0)) &&
+        return (s == 0 || (tinyp(fl_ctx, vector_elt(v,0)) &&
                            (s == 1 || (s == 2 &&
-                                       tinyp(vector_elt(v,1))))));
+                                       tinyp(fl_ctx, vector_elt(v,1))))));
     }
     return 0;
 }
 
-static int specialindent(value_t head)
+static int specialindent(fl_context_t *fl_ctx, value_t head)
 {
     // indent these forms 2 spaces, not lined up with the first argument
-    if (head == LAMBDA || head == TRYCATCH || head == definesym ||
-        head == defmacrosym || head == forsym)
+    if (head == fl_ctx->LAMBDA || head == fl_ctx->TRYCATCH || head == fl_ctx->definesym ||
+        head == fl_ctx->defmacrosym || head == fl_ctx->forsym)
         return 2;
     return -1;
 }
 
-static int lengthestimate(value_t v)
+static int lengthestimate(fl_context_t *fl_ctx, value_t v)
 {
     // get the width of an expression if we can do so cheaply
     if (issymbol(v))
-        return u8_strwidth(symbol_name(v));
+        return u8_strwidth(symbol_name(fl_ctx, v));
     return -1;
 }
 
-static int allsmallp(value_t v)
+static int allsmallp(fl_context_t *fl_ctx, value_t v)
 {
     int n = 1;
     while (iscons(v)) {
-        if (!smallp(car_(v)))
+        if (!smallp(fl_ctx, car_(v)))
             return 0;
         v = cdr_(v);
         n++;
@@ -223,102 +213,102 @@ static int allsmallp(value_t v)
     return n;
 }
 
-static int indentafter3(value_t head, value_t v)
+static int indentafter3(fl_context_t *fl_ctx, value_t head, value_t v)
 {
     // for certain X always indent (X a b c) after b
-    return ((head == forsym) && !allsmallp(cdr_(v)));
+    return ((head == fl_ctx->forsym) && !allsmallp(fl_ctx, cdr_(v)));
 }
 
-static int indentafter2(value_t head, value_t v)
+static int indentafter2(fl_context_t *fl_ctx, value_t head, value_t v)
 {
     // for certain X always indent (X a b) after a
-    return ((head == definesym || head == defmacrosym) &&
-            !allsmallp(cdr_(v)));
+    return ((head == fl_ctx->definesym || head == fl_ctx->defmacrosym) &&
+            !allsmallp(fl_ctx, cdr_(v)));
 }
 
-static int indentevery(value_t v)
+static int indentevery(fl_context_t *fl_ctx, value_t v)
 {
     // indent before every subform of a special form, unless every
     // subform is "small"
     value_t c = car_(v);
-    if (c == LAMBDA || c == setqsym)
+    if (c == fl_ctx->LAMBDA || c == fl_ctx->setqsym)
         return 0;
-    if (c == IF) // TODO: others
-        return !allsmallp(cdr_(v));
+    if (c == fl_ctx->IF) // TODO: others
+        return !allsmallp(fl_ctx, cdr_(v));
     return 0;
 }
 
-static int blockindent(value_t v)
+static int blockindent(fl_context_t *fl_ctx, value_t v)
 {
     // in this case we switch to block indent mode, where the head
     // is no longer considered special:
     // (a b c d e
     //  f g h i j)
-    return (allsmallp(v) > 9);
+    return (allsmallp(fl_ctx, v) > 9);
 }
 
-static void print_pair(ios_t *f, value_t v)
+static void print_pair(fl_context_t *fl_ctx, ios_t *f, value_t v)
 {
     value_t cd;
     char *op = NULL;
-    if (iscons(cdr_(v)) && cdr_(cdr_(v)) == NIL &&
-        !ptrhash_has(&printconses, (void*)cdr_(v)) &&
-        (((car_(v) == QUOTE)     && (op = "'"))  ||
-         ((car_(v) == BACKQUOTE) && (op = "`"))  ||
-         ((car_(v) == COMMA)     && (op = ","))  ||
-         ((car_(v) == COMMAAT)   && (op = ",@")) ||
-         ((car_(v) == COMMADOT)  && (op = ",.")))) {
+    if (iscons(cdr_(v)) && cdr_(cdr_(v)) == fl_ctx->NIL &&
+        !ptrhash_has(&fl_ctx->printconses, (void*)cdr_(v)) &&
+        (((car_(v) == fl_ctx->QUOTE)     && (op = "'"))  ||
+         ((car_(v) == fl_ctx->BACKQUOTE) && (op = "`"))  ||
+         ((car_(v) == fl_ctx->COMMA)     && (op = ","))  ||
+         ((car_(v) == fl_ctx->COMMAAT)   && (op = ",@")) ||
+         ((car_(v) == fl_ctx->COMMADOT)  && (op = ",.")))) {
         // special prefix syntax
-        unmark_cons(v);
-        unmark_cons(cdr_(v));
-        outs(op, f);
-        fl_print_child(f, car_(cdr_(v)));
+        unmark_cons(fl_ctx, v);
+        unmark_cons(fl_ctx, cdr_(v));
+        outs(fl_ctx, op, f);
+        fl_print_child(fl_ctx, f, car_(cdr_(v)));
         return;
     }
-    int startpos = HPOS;
-    outc('(', f);
-    int newindent=HPOS, blk=blockindent(v);
+    int startpos = fl_ctx->HPOS;
+    outc(fl_ctx, '(', f);
+    int newindent=fl_ctx->HPOS, blk=blockindent(fl_ctx, v);
     int lastv, n=0, si, ind=0, est, always=0, nextsmall, thistiny;
-    if (!blk) always = indentevery(v);
+    if (!blk) always = indentevery(fl_ctx, v);
     value_t head = car_(v);
-    int after3 = indentafter3(head, v);
-    int after2 = indentafter2(head, v);
+    int after3 = indentafter3(fl_ctx, head, v);
+    int after2 = indentafter2(fl_ctx, head, v);
     int n_unindented = 1;
     while (1) {
         cd = cdr_(v);
-        if (print_length >= 0 && n >= print_length && cd!=NIL) {
-            outsn("...)", f, 4);
+        if (fl_ctx->print_length >= 0 && n >= fl_ctx->print_length && cd!=fl_ctx->NIL) {
+            outsn(fl_ctx, "...)", f, 4);
             break;
         }
-        lastv = VPOS;
-        unmark_cons(v);
-        fl_print_child(f, car_(v));
-        if (!iscons(cd) || ptrhash_has(&printconses, (void*)cd)) {
-            if (cd != NIL) {
-                outsn(" . ", f, 3);
-                fl_print_child(f, cd);
+        lastv = fl_ctx->VPOS;
+        unmark_cons(fl_ctx, v);
+        fl_print_child(fl_ctx, f, car_(v));
+        if (!iscons(cd) || ptrhash_has(&fl_ctx->printconses, (void*)cd)) {
+            if (cd != fl_ctx->NIL) {
+                outsn(fl_ctx, " . ", f, 3);
+                fl_print_child(fl_ctx, f, cd);
             }
-            outc(')', f);
+            outc(fl_ctx, ')', f);
             break;
         }
 
-        if (!print_pretty ||
-            ((head == LAMBDA) && n == 0)) {
+        if (!fl_ctx->print_pretty ||
+            ((head == fl_ctx->LAMBDA) && n == 0)) {
             // never break line before lambda-list
             ind = 0;
         }
         else {
-            est = lengthestimate(car_(cd));
-            nextsmall = smallp(car_(cd));
-            thistiny = tinyp(car_(v));
-            ind = (((VPOS > lastv) ||
-                    (HPOS>SCR_WIDTH/2 && !nextsmall && !thistiny && n>0)) ||
+            est = lengthestimate(fl_ctx, car_(cd));
+            nextsmall = smallp(fl_ctx, car_(cd));
+            thistiny = tinyp(fl_ctx, car_(v));
+            ind = (((fl_ctx->VPOS > lastv) ||
+                    (fl_ctx->HPOS>fl_ctx->SCR_WIDTH/2 && !nextsmall && !thistiny && n>0)) ||
 
-                   (HPOS > SCR_WIDTH-4) ||
+                   (fl_ctx->HPOS > fl_ctx->SCR_WIDTH-4) ||
 
-                   (est!=-1 && (HPOS+est > SCR_WIDTH-2)) ||
+                   (est!=-1 && (fl_ctx->HPOS+est > fl_ctx->SCR_WIDTH-2)) ||
 
-                   ((head == LAMBDA) && !nextsmall) ||
+                   ((head == fl_ctx->LAMBDA) && !nextsmall) ||
 
                    (n > 0 && always) ||
 
@@ -327,23 +317,23 @@ static void print_pair(ios_t *f, value_t v)
 
                    (n_unindented >= 3 && !nextsmall) ||
 
-                   (n == 0 && !smallp(head)));
+                   (n == 0 && !smallp(fl_ctx, head)));
         }
 
         if (ind) {
-            newindent = outindent(newindent, f);
+            newindent = outindent(fl_ctx, newindent, f);
             n_unindented = 1;
         }
         else {
             n_unindented++;
-            outc(' ', f);
+            outc(fl_ctx, ' ', f);
             if (n==0) {
                 // set indent level after printing head
-                si = specialindent(head);
+                si = specialindent(fl_ctx, head);
                 if (si != -1)
                     newindent = startpos + si;
                 else if (!blk)
-                    newindent = HPOS;
+                    newindent = fl_ctx->HPOS;
             }
         }
         n++;
@@ -351,190 +341,190 @@ static void print_pair(ios_t *f, value_t v)
     }
 }
 
-static void cvalue_print(ios_t *f, value_t v);
+static void cvalue_print(fl_context_t *fl_ctx, ios_t *f, value_t v);
 
-static int print_circle_prefix(ios_t *f, value_t v)
+static int print_circle_prefix(fl_context_t *fl_ctx, ios_t *f, value_t v)
 {
     value_t label;
     char buf[64];
     char *str;
-    if ((label=(value_t)ptrhash_get(&printconses, (void*)v)) !=
+    if ((label=(value_t)ptrhash_get(&fl_ctx->printconses, (void*)v)) !=
         (value_t)HT_NOTFOUND) {
-        if (!ismarked(v)) {
-            //HPOS+=ios_printf(f, "#%ld#", numval(label));
-            outc('#', f);
+        if (!ismarked(fl_ctx, v)) {
+            //fl_ctx->HPOS+=ios_printf(f, "#%ld#", numval(label));
+            outc(fl_ctx, '#', f);
             str = uint2str(buf, sizeof(buf)-1, numval(label), 10);
-            outs(str, f);
-            outc('#', f);
+            outs(fl_ctx, str, f);
+            outc(fl_ctx, '#', f);
             return 1;
         }
-        //HPOS+=ios_printf(f, "#%ld=", numval(label));
-        outc('#', f);
+        //fl_ctx->HPOS+=ios_printf(f, "#%ld=", numval(label));
+        outc(fl_ctx, '#', f);
         str = uint2str(buf, sizeof(buf)-1, numval(label), 10);
-        outs(str, f);
-        outc('=', f);
+        outs(fl_ctx, str, f);
+        outc(fl_ctx, '=', f);
     }
-    if (ismanaged(v))
-        unmark_cons(v);
+    if (ismanaged(fl_ctx, v))
+        unmark_cons(fl_ctx, v);
     return 0;
 }
 
-void fl_print_child(ios_t *f, value_t v)
+void fl_print_child(fl_context_t *fl_ctx, ios_t *f, value_t v)
 {
     char *name, *str;
     char buf[64];
-    if (print_level >= 0 && P_LEVEL >= print_level &&
+    if (fl_ctx->print_level >= 0 && fl_ctx->P_LEVEL >= fl_ctx->print_level &&
         (iscons(v) || isvector(v) || isclosure(v))) {
-        outc('#', f);
+        outc(fl_ctx, '#', f);
         return;
     }
-    P_LEVEL++;
+    fl_ctx->P_LEVEL++;
 
     switch (tag(v)) {
     case TAG_NUM :
-    case TAG_NUM1: //HPOS+=ios_printf(f, "%ld", numval(v)); break;
+    case TAG_NUM1: //fl_ctx->HPOS+=ios_printf(f, "%ld", numval(v)); break;
         str = uint2str(&buf[1], sizeof(buf)-1, labs(numval(v)), 10);
         if (numval(v)<0)
             *(--str) = '-';
-        outs(str, f);
+        outs(fl_ctx, str, f);
         break;
     case TAG_SYM:
-        name = symbol_name(v);
-        if (print_princ)
-            outs(name, f);
-        else if (ismanaged(v)) {
-            outsn("#:", f, 2);
-            outs(name, f);
+        name = symbol_name(fl_ctx, v);
+        if (fl_ctx->print_princ)
+            outs(fl_ctx, name, f);
+        else if (ismanaged(fl_ctx, v)) {
+            outsn(fl_ctx, "#:", f, 2);
+            outs(fl_ctx, name, f);
         }
         else
-            print_symbol_name(f, name);
+            print_symbol_name(fl_ctx, f, name);
         break;
     case TAG_FUNCTION:
-        if (v == FL_T) {
-            outsn("#t", f, 2);
+        if (v == fl_ctx->T) {
+            outsn(fl_ctx, "#t", f, 2);
         }
-        else if (v == FL_F) {
-            outsn("#f", f, 2);
+        else if (v == fl_ctx->F) {
+            outsn(fl_ctx, "#f", f, 2);
         }
-        else if (v == FL_NIL) {
-            outsn("()", f, 2);
+        else if (v == fl_ctx->NIL) {
+            outsn(fl_ctx, "()", f, 2);
         }
-        else if (v == FL_EOF) {
-            outsn("#<eof>", f, 6);
+        else if (v == fl_ctx->FL_EOF) {
+            outsn(fl_ctx, "#<eof>", f, 6);
         }
         else if (isbuiltin(v)) {
-            if (!print_princ)
-                outsn("#.", f, 2);
-            outs(builtin_names[uintval(v)], f);
+            if (!fl_ctx->print_princ)
+                outsn(fl_ctx, "#.", f, 2);
+            outs(fl_ctx, builtin_names[uintval(v)], f);
         }
         else {
             assert(isclosure(v));
-            if (!print_princ) {
-                if (print_circle_prefix(f, v)) break;
+            if (!fl_ctx->print_princ) {
+                if (print_circle_prefix(fl_ctx, f, v)) break;
                 function_t *fn = (function_t*)ptr(v);
-                outs("#fn(", f);
+                outs(fl_ctx, "#fn(", f);
                 char *data = (char*)cvalue_data(fn->bcode);
                 size_t i, sz = cvalue_len(fn->bcode);
                 for(i=0; i < sz; i++) data[i] += 48;
-                fl_print_child(f, fn->bcode);
+                fl_print_child(fl_ctx, f, fn->bcode);
                 for(i=0; i < sz; i++) data[i] -= 48;
-                outc(' ', f);
-                fl_print_child(f, fn->vals);
-                if (fn->env != NIL) {
-                    outc(' ', f);
-                    fl_print_child(f, fn->env);
+                outc(fl_ctx, ' ', f);
+                fl_print_child(fl_ctx, f, fn->vals);
+                if (fn->env != fl_ctx->NIL) {
+                    outc(fl_ctx, ' ', f);
+                    fl_print_child(fl_ctx, f, fn->env);
                 }
-                if (fn->name != LAMBDA) {
-                    outc(' ', f);
-                    fl_print_child(f, fn->name);
+                if (fn->name != fl_ctx->LAMBDA) {
+                    outc(fl_ctx, ' ', f);
+                    fl_print_child(fl_ctx, f, fn->name);
                 }
-                outc(')', f);
+                outc(fl_ctx, ')', f);
             }
             else {
-                outs("#<function>", f);
+                outs(fl_ctx, "#<function>", f);
             }
         }
         break;
     case TAG_CVALUE:
     case TAG_CPRIM:
-        if (v == UNBOUND) { outs("#<undefined>", f); break; }
+        if (v == UNBOUND) { outs(fl_ctx, "#<undefined>", f); break; }
     case TAG_VECTOR:
     case TAG_CONS:
-        if (print_circle_prefix(f, v)) break;
+        if (print_circle_prefix(fl_ctx, f, v)) break;
         if (isvector(v)) {
-            outc('[', f);
-            int newindent = HPOS, est;
+            outc(fl_ctx, '[', f);
+            int newindent = fl_ctx->HPOS, est;
             int i, sz = vector_size(v);
             for(i=0; i < sz; i++) {
-                if (print_length >= 0 && i >= print_length && i < sz-1) {
-                    outsn("...", f, 3);
+                if (fl_ctx->print_length >= 0 && i >= fl_ctx->print_length && i < sz-1) {
+                    outsn(fl_ctx, "...", f, 3);
                     break;
                 }
-                fl_print_child(f, vector_elt(v,i));
+                fl_print_child(fl_ctx, f, vector_elt(v,i));
                 if (i < sz-1) {
-                    if (!print_pretty) {
-                        outc(' ', f);
+                    if (!fl_ctx->print_pretty) {
+                        outc(fl_ctx, ' ', f);
                     }
                     else {
-                        est = lengthestimate(vector_elt(v,i+1));
-                        if (HPOS > SCR_WIDTH-4 ||
-                            (est!=-1 && (HPOS+est > SCR_WIDTH-2)) ||
-                            (HPOS > SCR_WIDTH/2 &&
-                             !smallp(vector_elt(v,i+1)) &&
-                             !tinyp(vector_elt(v,i))))
-                            newindent = outindent(newindent, f);
+                        est = lengthestimate(fl_ctx, vector_elt(v,i+1));
+                        if (fl_ctx->HPOS > fl_ctx->SCR_WIDTH-4 ||
+                            (est!=-1 && (fl_ctx->HPOS+est > fl_ctx->SCR_WIDTH-2)) ||
+                            (fl_ctx->HPOS > fl_ctx->SCR_WIDTH/2 &&
+                             !smallp(fl_ctx, vector_elt(v,i+1)) &&
+                             !tinyp(fl_ctx, vector_elt(v,i))))
+                            newindent = outindent(fl_ctx, newindent, f);
                         else
-                            outc(' ', f);
+                            outc(fl_ctx, ' ', f);
                     }
                 }
             }
-            outc(']', f);
+            outc(fl_ctx, ']', f);
             break;
         }
         if (iscvalue(v) || iscprim(v))
-            cvalue_print(f, v);
+            cvalue_print(fl_ctx, f, v);
         else
-            print_pair(f, v);
+            print_pair(fl_ctx, f, v);
         break;
     }
-    P_LEVEL--;
+    fl_ctx->P_LEVEL--;
 }
 
-static void print_string(ios_t *f, char *str, size_t sz)
+static void print_string(fl_context_t *fl_ctx, ios_t *f, char *str, size_t sz)
 {
     char buf[512];
     size_t i = 0;
     uint8_t c;
-    static char hexdig[] = "0123456789abcdef";
+    static const char hexdig[] = "0123456789abcdef";
 
-    outc('"', f);
+    outc(fl_ctx, '"', f);
     if (!u8_isvalid(str, sz)) {
         // alternate print algorithm that preserves data if it's not UTF-8
         for(i=0; i < sz; i++) {
             c = str[i];
             if (c == '\\')
-                outsn("\\\\", f, 2);
+                outsn(fl_ctx, "\\\\", f, 2);
             else if (c == '"')
-                outsn("\\\"", f, 2);
+                outsn(fl_ctx, "\\\"", f, 2);
             else if (c >= 32 && c < 0x7f)
-                outc(c, f);
+                outc(fl_ctx, c, f);
             else {
-                outsn("\\x", f, 2);
-                outc(hexdig[c>>4], f);
-                outc(hexdig[c&0xf], f);
+                outsn(fl_ctx, "\\x", f, 2);
+                outc(fl_ctx, hexdig[c>>4], f);
+                outc(fl_ctx, hexdig[c&0xf], f);
             }
         }
     }
     else {
         while (i < sz) {
             size_t n = u8_escape(buf, sizeof(buf), str, &i, sz, 1, 0);
-            outsn(buf, f, n-1);
+            outsn(fl_ctx, buf, f, n-1);
         }
     }
-    outc('"', f);
+    outc(fl_ctx, '"', f);
 }
 
-static numerictype_t sym_to_numtype(value_t type);
+static numerictype_t sym_to_numtype(fl_context_t *fl_ctx, value_t type);
 #ifndef _OS_WINDOWS_
 #define __USE_GNU
 #include <dlfcn.h>
@@ -548,49 +538,49 @@ static numerictype_t sym_to_numtype(value_t type);
 // for example #int32(0) can be printed as just 0. this is used
 // printing in a context where a type is already implied, e.g. inside
 // an array.
-static void cvalue_printdata(ios_t *f, void *data, size_t len, value_t type,
-                             int weak)
+static void cvalue_printdata(fl_context_t *fl_ctx, ios_t *f, void *data,
+                             size_t len, value_t type, int weak)
 {
-    if (type == bytesym) {
+    if (type == fl_ctx->bytesym) {
         unsigned char ch = *(unsigned char*)data;
-        if (print_princ)
-            outc(ch, f);
+        if (fl_ctx->print_princ)
+            outc(fl_ctx, ch, f);
         else if (weak)
-            HPOS+=ios_printf(f, "0x%hhx", ch);
+            fl_ctx->HPOS+=ios_printf(f, "0x%hhx", ch);
         else
-            HPOS+=ios_printf(f, "#byte(0x%hhx)", ch);
+            fl_ctx->HPOS+=ios_printf(f, "#byte(0x%hhx)", ch);
     }
-    else if (type == wcharsym) {
+    else if (type == fl_ctx->wcharsym) {
         uint32_t wc = *(uint32_t*)data;
         char seq[8];
         size_t nb = u8_toutf8(seq, sizeof(seq), &wc, 1);
         seq[nb] = '\0';
-        if (print_princ) {
+        if (fl_ctx->print_princ) {
             // TODO: better multibyte handling
-            outs(seq, f);
+            outs(fl_ctx, seq, f);
         }
         else {
-            outsn("#\\", f, 2);
-            if      (wc == 0x00) outsn("nul", f, 3);
-            else if (wc == 0x07) outsn("alarm", f, 5);
-            else if (wc == 0x08) outsn("backspace", f, 9);
-            else if (wc == 0x09) outsn("tab", f, 3);
-            else if (wc == 0x0A) outsn("linefeed", f, 8);
-            //else if (wc == 0x0A) outsn("newline", f, 7);
-            else if (wc == 0x0B) outsn("vtab", f, 4);
-            else if (wc == 0x0C) outsn("page", f, 4);
-            else if (wc == 0x0D) outsn("return", f, 6);
-            else if (wc == 0x1B) outsn("esc", f, 3);
-            else if (wc == 0x20) outsn("space", f, 5);
-            else if (wc == 0x7F) outsn("delete", f, 6);
-            else if (iswprint(wc)) outs(seq, f);
-            else HPOS+=ios_printf(f, "x%04x", (int)wc);
+            outsn(fl_ctx, "#\\", f, 2);
+            if      (wc == 0x00) outsn(fl_ctx, "nul", f, 3);
+            else if (wc == 0x07) outsn(fl_ctx, "alarm", f, 5);
+            else if (wc == 0x08) outsn(fl_ctx, "backspace", f, 9);
+            else if (wc == 0x09) outsn(fl_ctx, "tab", f, 3);
+            else if (wc == 0x0A) outsn(fl_ctx, "linefeed", f, 8);
+            //else if (wc == 0x0A) outsn(fl_ctx, "newline", f, 7);
+            else if (wc == 0x0B) outsn(fl_ctx, "vtab", f, 4);
+            else if (wc == 0x0C) outsn(fl_ctx, "page", f, 4);
+            else if (wc == 0x0D) outsn(fl_ctx, "return", f, 6);
+            else if (wc == 0x1B) outsn(fl_ctx, "esc", f, 3);
+            else if (wc == 0x20) outsn(fl_ctx, "space", f, 5);
+            else if (wc == 0x7F) outsn(fl_ctx, "delete", f, 6);
+            else if (iswprint(wc)) outs(fl_ctx, seq, f);
+            else fl_ctx->HPOS+=ios_printf(f, "x%04x", (int)wc);
         }
     }
-    else if (type == floatsym || type == doublesym) {
+    else if (type == fl_ctx->floatsym || type == fl_ctx->doublesym) {
         char buf[64];
         double d;
-        if (type == floatsym) { d = (double)*(float*)data; }
+        if (type == fl_ctx->floatsym) { d = (double)*(float*)data; }
         else { d = *(double*)data; }
         if (!DFINITE(d)) {
             char *rep;
@@ -598,18 +588,18 @@ static void cvalue_printdata(ios_t *f, void *data, size_t len, value_t type,
                 rep = (char*)(sign_bit(d) ? "-nan.0" : "+nan.0");
             else
                 rep = (char*)(sign_bit(d) ? "-inf.0" : "+inf.0");
-            if (type == floatsym && !print_princ && !weak)
-                HPOS+=ios_printf(f, "#%s(%s)", symbol_name(type), rep);
+            if (type == fl_ctx->floatsym && !fl_ctx->print_princ && !weak)
+                fl_ctx->HPOS+=ios_printf(f, "#%s(%s)", symbol_name(fl_ctx, type), rep);
             else
-                outs(rep, f);
+                outs(fl_ctx, rep, f);
         }
         else if (d == 0) {
             if (sign_bit(d))
-                outsn("-0.0", f, 4);
+                outsn(fl_ctx, "-0.0", f, 4);
             else
-                outsn("0.0", f, 3);
-            if (type == floatsym && !print_princ && !weak)
-                outc('f', f);
+                outsn(fl_ctx, "0.0", f, 3);
+            if (type == fl_ctx->floatsym && !fl_ctx->print_princ && !weak)
+                outc(fl_ctx, 'f', f);
         }
         else {
             double ad = d < 0 ? -d : d;
@@ -617,195 +607,201 @@ static void cvalue_printdata(ios_t *f, void *data, size_t len, value_t type,
                 snprintf(buf, sizeof(buf), "%g", d);
             }
             else {
-                if (type == floatsym)
+                if (type == fl_ctx->floatsym)
                     snprintf(buf, sizeof(buf), "%.8g", d);
                 else
                     snprintf(buf, sizeof(buf), "%.16g", d);
             }
             int hasdec = (strpbrk(buf, ".eE") != NULL);
-            outs(buf, f);
-            if (!hasdec) outsn(".0", f, 2);
-            if (type == floatsym && !print_princ && !weak)
-                outc('f', f);
+            outs(fl_ctx, buf, f);
+            if (!hasdec) outsn(fl_ctx, ".0", f, 2);
+            if (type == fl_ctx->floatsym && !fl_ctx->print_princ && !weak)
+                outc(fl_ctx, 'f', f);
         }
     }
-    else if (type == uint64sym
+    else if (type == fl_ctx->uint64sym
 #ifdef _P64
-             || type == sizesym
+             || type == fl_ctx->sizesym
 #endif
              ) {
         uint64_t ui64 = *(uint64_t*)data;
-        if (weak || print_princ)
-            HPOS += ios_printf(f, "%llu", ui64);
+        if (weak || fl_ctx->print_princ)
+            fl_ctx->HPOS += ios_printf(f, "%llu", ui64);
         else
-            HPOS += ios_printf(f, "#%s(%llu)", symbol_name(type), ui64);
+            fl_ctx->HPOS += ios_printf(f, "#%s(%llu)", symbol_name(fl_ctx, type), ui64);
     }
     else if (issymbol(type)) {
         // handle other integer prims. we know it's smaller than uint64
         // at this point, so int64 is big enough to capture everything.
-        numerictype_t nt = sym_to_numtype(type);
+        numerictype_t nt = sym_to_numtype(fl_ctx, type);
         if (nt == N_NUMTYPES) {
-            static size_t (*jl_static_print)(ios_t*, void*) = 0;
-            static int init = 0;
-            static value_t jl_sym = 0;
+            // These states should be context independent.
+            static size_t (*volatile jl_static_print)(ios_t*, void*) = 0;
+            static volatile int init = 0;
             if (init == 0) {
-                init = 1;
 #if defined(RTLD_SELF)
                 jl_static_print = (size_t (*)(ios_t *, void *)) dlsym(RTLD_SELF, "jl_static_show");
 #elif defined(RTLD_DEFAULT)
                 jl_static_print = (size_t (*)(ios_t *, void *)) dlsym(RTLD_DEFAULT, "jl_static_show");
 #endif
-                jl_sym = symbol("julia_value");
+                init = 1;
             }
-            if (jl_static_print != 0 && jl_sym == type) {
-                HPOS += ios_printf(f, "#<julia: ");
-                HPOS += jl_static_print(f, *(void**)data);
-                HPOS += ios_printf(f, ">");
+            if (jl_static_print != 0 && fl_ctx->jl_sym == type) {
+                fl_ctx->HPOS += ios_printf(f, "#<julia: ");
+                fl_ctx->HPOS += jl_static_print(f, *(void**)data);
+                fl_ctx->HPOS += ios_printf(f, ">");
             }
             else
-                HPOS += ios_printf(f, "#<%s>", symbol_name(type));
+                fl_ctx->HPOS += ios_printf(f, "#<%s>", symbol_name(fl_ctx, type));
         }
         else {
             int64_t i64 = conv_to_int64(data, nt);
-            if (weak || print_princ)
-                HPOS += ios_printf(f, "%lld", i64);
+            if (weak || fl_ctx->print_princ)
+                fl_ctx->HPOS += ios_printf(f, "%lld", i64);
             else
-                HPOS += ios_printf(f, "#%s(%lld)", symbol_name(type), i64);
+                fl_ctx->HPOS += ios_printf(f, "#%s(%lld)", symbol_name(fl_ctx, type), i64);
         }
     }
     else if (iscons(type)) {
-        if (car_(type) == arraysym) {
-            value_t eltype = car(cdr_(type));
+        if (car_(type) == fl_ctx->arraysym) {
+            value_t eltype = car(fl_ctx, cdr_(type));
             size_t cnt, elsize;
             if (iscons(cdr_(cdr_(type)))) {
-                cnt = tosize(car_(cdr_(cdr_(type))), "length");
+                cnt = tosize(fl_ctx, car_(cdr_(cdr_(type))), "length");
                 elsize = cnt ? len/cnt : 0;
             }
             else {
                 // incomplete array type
                 int junk;
-                elsize = ctype_sizeof(eltype, &junk);
+                elsize = ctype_sizeof(fl_ctx, eltype, &junk);
                 cnt = elsize ? len/elsize : 0;
             }
-            if (eltype == bytesym) {
-                if (print_princ) {
+            if (eltype == fl_ctx->bytesym) {
+                if (fl_ctx->print_princ) {
                     ios_write(f, (char*)data, len);
                     /*
                     char *nl = memrchr(data, '\n', len);
                     if (nl)
-                        HPOS = u8_strwidth(nl+1);
+                        fl_ctx->HPOS = u8_strwidth(nl+1);
                     else
-                        HPOS += u8_strwidth(data);
+                        fl_ctx->HPOS += u8_strwidth(data);
                     */
                 }
                 else {
-                    print_string(f, (char*)data, len);
+                    print_string(fl_ctx, f, (char*)data, len);
                 }
                 return;
             }
-            else if (eltype == wcharsym) {
+            else if (eltype == fl_ctx->wcharsym) {
                 // TODO wchar
             }
             else {
             }
             size_t i;
             if (!weak) {
-                if (eltype == uint8sym) {
-                    outsn("#vu8(", f, 5);
+                if (eltype == fl_ctx->uint8sym) {
+                    outsn(fl_ctx, "#vu8(", f, 5);
                 }
                 else {
-                    outsn("#array(", f, 7);
-                    fl_print_child(f, eltype);
+                    outsn(fl_ctx, "#array(", f, 7);
+                    fl_print_child(fl_ctx, f, eltype);
                     if (cnt > 0)
-                        outc(' ', f);
+                        outc(fl_ctx, ' ', f);
                 }
             }
             else {
-                outc('[', f);
+                outc(fl_ctx, '[', f);
             }
             for(i=0; i < cnt; i++) {
                 if (i > 0)
-                    outc(' ', f);
-                cvalue_printdata(f, data, elsize, eltype, 1);
+                    outc(fl_ctx, ' ', f);
+                cvalue_printdata(fl_ctx, f, data, elsize, eltype, 1);
                 data = (char *)data + elsize;
             }
             if (!weak)
-                outc(')', f);
+                outc(fl_ctx, ')', f);
             else
-                outc(']', f);
+                outc(fl_ctx, ']', f);
         }
     }
 }
 
-static void cvalue_print(ios_t *f, value_t v)
+static void cvalue_print(fl_context_t *fl_ctx, ios_t *f, value_t v)
 {
     cvalue_t *cv = (cvalue_t*)ptr(v);
     void *data = cptr(v);
     value_t label;
 
-    if (cv_class(cv) == builtintype) {
+    if (cv_class(cv) == fl_ctx->builtintype) {
         void *fptr = *(void**)data;
-        label = (value_t)ptrhash_get(&reverse_dlsym_lookup_table, cv);
+        label = (value_t)ptrhash_get(&fl_ctx->reverse_dlsym_lookup_table, cv);
         if (label == (value_t)HT_NOTFOUND) {
-            HPOS += ios_printf(f, "#<builtin @0x%08zx>",
-                               (size_t)(builtin_t)fptr);
+            fl_ctx->HPOS += ios_printf(f, "#<builtin @0x%08zx>",
+                                  (size_t)(builtin_t)fptr);
         }
         else {
-            if (print_princ) {
-                outs(symbol_name(label), f);
+            if (fl_ctx->print_princ) {
+                outs(fl_ctx, symbol_name(fl_ctx, label), f);
             }
             else {
-                outsn("#fn(", f, 4);
-                outs(symbol_name(label), f);
-                outc(')', f);
+                outsn(fl_ctx, "#fn(", f, 4);
+                outs(fl_ctx, symbol_name(fl_ctx, label), f);
+                outc(fl_ctx, ')', f);
             }
         }
     }
     else if (cv_class(cv)->vtable != NULL &&
              cv_class(cv)->vtable->print != NULL) {
-        cv_class(cv)->vtable->print(v, f);
+        cv_class(cv)->vtable->print(fl_ctx, v, f);
     }
     else {
         value_t type = cv_type(cv);
         size_t len = iscprim(v) ? cv_class(cv)->size : cv_len(cv);
-        cvalue_printdata(f, data, len, type, 0);
+        cvalue_printdata(fl_ctx, f, data, len, type, 0);
     }
 }
 
-static void set_print_width(void)
+static void set_print_width(fl_context_t *fl_ctx)
 {
-    value_t pw = symbol_value(printwidthsym);
+    value_t pw = symbol_value(fl_ctx->printwidthsym);
     if (!isfixnum(pw)) return;
-    SCR_WIDTH = numval(pw);
+    fl_ctx->SCR_WIDTH = numval(pw);
 }
 
-void fl_print(ios_t *f, value_t v)
+void fl_print(fl_context_t *fl_ctx, ios_t *f, value_t v)
 {
-    print_pretty = (symbol_value(printprettysym) != FL_F);
-    if (print_pretty)
-        set_print_width();
-    print_princ = (symbol_value(printreadablysym) == FL_F);
+    fl_ctx->print_pretty = (symbol_value(fl_ctx->printprettysym) != fl_ctx->F);
+    if (fl_ctx->print_pretty)
+        set_print_width(fl_ctx);
+    fl_ctx->print_princ = (symbol_value(fl_ctx->printreadablysym) == fl_ctx->F);
 
-    value_t pl = symbol_value(printlengthsym);
-    if (isfixnum(pl)) print_length = numval(pl);
-    else print_length = -1;
-    pl = symbol_value(printlevelsym);
-    if (isfixnum(pl)) print_level = numval(pl);
-    else print_level = -1;
-    P_LEVEL = 0;
+    value_t pl = symbol_value(fl_ctx->printlengthsym);
+    if (isfixnum(pl)) fl_ctx->print_length = numval(pl);
+    else fl_ctx->print_length = -1;
+    pl = symbol_value(fl_ctx->printlevelsym);
+    if (isfixnum(pl)) fl_ctx->print_level = numval(pl);
+    else fl_ctx->print_level = -1;
+    fl_ctx->P_LEVEL = 0;
 
-    printlabel = 0;
-    print_traverse(v);
-    HPOS = VPOS = 0;
+    fl_ctx->printlabel = 0;
+    print_traverse(fl_ctx, v);
+    fl_ctx->HPOS = fl_ctx->VPOS = 0;
 
-    fl_print_child(f, v);
+    fl_print_child(fl_ctx, f, v);
 
-    if (print_level >= 0 || print_length >= 0) {
-        memset(consflags, 0, 4*bitvector_nwords(heapsize/sizeof(cons_t)));
+    if (fl_ctx->print_level >= 0 || fl_ctx->print_length >= 0) {
+        memset(fl_ctx->consflags, 0, 4*bitvector_nwords(fl_ctx->heapsize/sizeof(cons_t)));
     }
 
     if ((iscons(v) || isvector(v) || isfunction(v) || iscvalue(v)) &&
-        !fl_isstring(v) && v!=FL_T && v!=FL_F && v!=FL_NIL) {
-        htable_reset(&printconses, 32);
+        !fl_isstring(fl_ctx, v) && v!=fl_ctx->T && v!=fl_ctx->F && v!=fl_ctx->NIL) {
+        htable_reset(&fl_ctx->printconses, 32);
     }
+}
+
+void fl_print_init(fl_context_t *fl_ctx)
+{
+    htable_new(&fl_ctx->printconses, 32);
+    fl_ctx->SCR_WIDTH = 80;
+    fl_ctx->HPOS = 0;
 }

--- a/src/flisp/read.c
+++ b/src/flisp/read.c
@@ -5,7 +5,7 @@ enum {
     TOK_OPENB, TOK_CLOSEB, TOK_SHARPSYM, TOK_GENSYM, TOK_DOUBLEQUOTE
 };
 
-#define F value2c(ios_t*,readstate->source)
+#define readF(fl_ctx) value2c(ios_t*,fl_ctx->readstate->source)
 
 // defines which characters are ordinary symbol characters.
 // exceptions are '.', which is an ordinary symbol character
@@ -13,7 +13,7 @@ enum {
 // an ordinary symbol character unless it's the first character.
 static inline int symchar(char c)
 {
-    static char *special = "()[]'\";`,\\| \f\n\r\t\v";
+    static const char *special = "()[]'\";`,\\| \f\n\r\t\v";
     return !strchr(special, c);
 }
 
@@ -29,7 +29,7 @@ static unsigned long long strtoull_0b0o(const char *nptr, char **endptr, int bas
     return strtoull(nptr, endptr, base);
 }
 
-int isnumtok_base(char *tok, value_t *pval, int base)
+int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
 {
     char *end;
     int64_t i64;
@@ -41,14 +41,14 @@ int isnumtok_base(char *tok, value_t *pval, int base)
         strpbrk(tok, ".eEpP")) {
         d = jl_strtod_c(tok, &end);
         if (*end == '\0') {
-            if (pval) *pval = mk_double(d);
+            if (pval) *pval = mk_double(fl_ctx, d);
             return 1;
         }
         // floats can end in f or f0
         if (end > tok && end[0] == 'f' &&
             (end[1] == '\0' ||
              (end[1] == '0' && end[2] == '\0'))) {
-            if (pval) *pval = mk_float((float)d);
+            if (pval) *pval = mk_float(fl_ctx, (float)d);
             return 1;
         }
     }
@@ -57,35 +57,35 @@ int isnumtok_base(char *tok, value_t *pval, int base)
         strpbrk(tok, "pP")) {
         d = jl_strtod_c(tok, &end);
         if (*end == '\0') {
-            if (pval) *pval = mk_double(d);
+            if (pval) *pval = mk_double(fl_ctx, d);
             return 1;
         }
         // floats can end in f or f0
         if (end > tok && end[0] == 'f' &&
             (end[1] == '\0' ||
              (end[1] == '0' && end[2] == '\0'))) {
-            if (pval) *pval = mk_float((float)d);
+            if (pval) *pval = mk_float(fl_ctx, (float)d);
             return 1;
         }
     }
 
     if (tok[0] == '+') {
         if (!strcmp(tok,"+NaN") || !strcasecmp(tok,"+nan.0")) {
-            if (pval) *pval = mk_double(D_PNAN);
+            if (pval) *pval = mk_double(fl_ctx, D_PNAN);
             return 1;
         }
         if (!strcmp(tok,"+Inf") || !strcasecmp(tok,"+inf.0")) {
-            if (pval) *pval = mk_double(D_PINF);
+            if (pval) *pval = mk_double(fl_ctx, D_PINF);
             return 1;
         }
     }
     else if (tok[0] == '-') {
         if (!strcmp(tok,"-NaN") || !strcasecmp(tok,"-nan.0")) {
-            if (pval) *pval = mk_double(D_NNAN);
+            if (pval) *pval = mk_double(fl_ctx, D_NNAN);
             return 1;
         }
         if (!strcmp(tok,"-Inf") || !strcasecmp(tok,"-inf.0")) {
-            if (pval) *pval = mk_double(D_NINF);
+            if (pval) *pval = mk_double(fl_ctx, D_NINF);
             return 1;
         }
         errno = 0;
@@ -93,7 +93,7 @@ int isnumtok_base(char *tok, value_t *pval, int base)
         if (errno)
             return 0;
         int done = (*end == '\0');  // must access *end before alloc
-        if (pval) *pval = return_from_int64(i64);
+        if (pval) *pval = return_from_int64(fl_ctx, i64);
         return done;
     }
     errno = 0;
@@ -101,34 +101,30 @@ int isnumtok_base(char *tok, value_t *pval, int base)
     if (errno)
         return 0;
     int done = (*end == '\0');  // must access *end before alloc
-    if (pval) *pval = return_from_uint64(ui64);
+    if (pval) *pval = return_from_uint64(fl_ctx, ui64);
     return done;
 }
 
-static int isnumtok(char *tok, value_t *pval)
+static int isnumtok(fl_context_t *fl_ctx, char *tok, value_t *pval)
 {
-    return isnumtok_base(tok, pval, 0);
+    return isnumtok_base(fl_ctx, tok, pval, 0);
 }
 
-static int read_numtok(char *tok, value_t *pval, int base)
+static int read_numtok(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
 {
     int result;
     errno = 0;
-    result = isnumtok_base(tok, pval, base);
+    result = isnumtok_base(fl_ctx, tok, pval, base);
     if (errno == ERANGE)
-        lerrorf(ParseError, "read: overflow in numeric constant %s", tok);
+        lerrorf(fl_ctx, fl_ctx->ParseError, "read: overflow in numeric constant %s", tok);
     return result;
 }
 
-static u_int32_t toktype = TOK_NONE;
-static value_t tokval;
-static char buf[256];
-
-static char nextchar(void)
+static char nextchar(fl_context_t *fl_ctx)
 {
     int ch;
     char c;
-    ios_t *f = F;
+    ios_t *f = readF(fl_ctx);
 
     do {
         if (f->bpos < f->size) {
@@ -153,26 +149,26 @@ static char nextchar(void)
     return c;
 }
 
-static void take(void)
+static void take(fl_context_t *fl_ctx)
 {
-    toktype = TOK_NONE;
+    fl_ctx->readtoktype = TOK_NONE;
 }
 
-static void accumchar(char c, int *pi)
+static void accumchar(fl_context_t *fl_ctx, char c, int *pi)
 {
-    buf[(*pi)++] = c;
-    if (*pi >= (int)(sizeof(buf)-1))
-        lerror(ParseError, "read: token too long");
+    fl_ctx->readbuf[(*pi)++] = c;
+    if (*pi >= (int)(sizeof(fl_ctx->readbuf)-1))
+        lerror(fl_ctx, fl_ctx->ParseError, "read: token too long");
 }
 
 // return: 1 if escaped (forced to be symbol)
-static int read_token(char c, int digits)
+static int read_token(fl_context_t *fl_ctx, char c, int digits)
 {
     int i=0, ch, escaped=0, issym=0, first=1;
 
     while (1) {
         if (!first) {
-            ch = ios_getc(F);
+            ch = ios_getc(readF(fl_ctx));
             if (ch == IOS_EOF)
                 goto terminate;
             c = (char)ch;
@@ -184,141 +180,141 @@ static int read_token(char c, int digits)
         }
         else if (c == '\\') {
             issym = 1;
-            ch = ios_getc(F);
+            ch = ios_getc(readF(fl_ctx));
             if (ch == IOS_EOF)
                 goto terminate;
-            accumchar((char)ch, &i);
+            accumchar(fl_ctx, (char)ch, &i);
         }
         else if (!escaped && !(symchar(c) && (!digits || isdigit(c)))) {
             break;
         }
         else {
-            accumchar(c, &i);
+            accumchar(fl_ctx, c, &i);
         }
     }
-    ios_ungetc(c, F);
+    ios_ungetc(c, readF(fl_ctx));
  terminate:
-    buf[i++] = '\0';
+    fl_ctx->readbuf[i++] = '\0';
     return issym;
 }
 
-static value_t do_read_sexpr(value_t label);
+static value_t do_read_sexpr(fl_context_t *fl_ctx, value_t label);
 
-static u_int32_t peek(void)
+static u_int32_t peek(fl_context_t *fl_ctx)
 {
     char c, *end;
     fixnum_t x;
     int ch, base;
 
-    if (toktype != TOK_NONE)
-        return toktype;
-    c = nextchar();
-    if (ios_eof(F)) return TOK_NONE;
+    if (fl_ctx->readtoktype != TOK_NONE)
+        return fl_ctx->readtoktype;
+    c = nextchar(fl_ctx);
+    if (ios_eof(readF(fl_ctx))) return TOK_NONE;
     if (c == '(') {
-        toktype = TOK_OPEN;
+        fl_ctx->readtoktype = TOK_OPEN;
     }
     else if (c == ')') {
-        toktype = TOK_CLOSE;
+        fl_ctx->readtoktype = TOK_CLOSE;
     }
     else if (c == '[') {
-        toktype = TOK_OPENB;
+        fl_ctx->readtoktype = TOK_OPENB;
     }
     else if (c == ']') {
-        toktype = TOK_CLOSEB;
+        fl_ctx->readtoktype = TOK_CLOSEB;
     }
     else if (c == '\'') {
-        toktype = TOK_QUOTE;
+        fl_ctx->readtoktype = TOK_QUOTE;
     }
     else if (c == '`') {
-        toktype = TOK_BQ;
+        fl_ctx->readtoktype = TOK_BQ;
     }
     else if (c == '"') {
-        toktype = TOK_DOUBLEQUOTE;
+        fl_ctx->readtoktype = TOK_DOUBLEQUOTE;
     }
     else if (c == '#') {
-        ch = ios_getc(F); c = (char)ch;
+        ch = ios_getc(readF(fl_ctx)); c = (char)ch;
         if (ch == IOS_EOF)
-            lerror(ParseError, "read: invalid read macro");
+            lerror(fl_ctx, fl_ctx->ParseError, "read: invalid read macro");
         if (c == '.') {
-            toktype = TOK_SHARPDOT;
+            fl_ctx->readtoktype = TOK_SHARPDOT;
         }
         else if (c == '\'') {
-            toktype = TOK_SHARPQUOTE;
+            fl_ctx->readtoktype = TOK_SHARPQUOTE;
         }
         else if (c == '\\') {
             uint32_t cval;
-            if (ios_getutf8(F, &cval) == IOS_EOF)
-                lerror(ParseError, "read: end of input in character constant");
+            if (ios_getutf8(readF(fl_ctx), &cval) == IOS_EOF)
+                lerror(fl_ctx, fl_ctx->ParseError, "read: end of input in character constant");
             if (cval == (uint32_t)'u' || cval == (uint32_t)'U' ||
                 cval == (uint32_t)'x') {
-                read_token('u', 0);
-                if (buf[1] != '\0') {  // not a solitary 'u','U','x'
-                    if (!read_numtok(&buf[1], &tokval, 16))
-                        lerror(ParseError,
+                read_token(fl_ctx, 'u', 0);
+                if (fl_ctx->readbuf[1] != '\0') {  // not a solitary 'u','U','x'
+                    if (!read_numtok(fl_ctx, &fl_ctx->readbuf[1], &fl_ctx->readtokval, 16))
+                        lerror(fl_ctx, fl_ctx->ParseError,
                                "read: invalid hex character constant");
-                    cval = numval(tokval);
+                    cval = numval(fl_ctx->readtokval);
                 }
             }
             else if (cval >= 'a' && cval <= 'z') {
-                read_token((char)cval, 0);
-                tokval = symbol(buf);
-                if (buf[1] == '\0')       /* one character */;
-                else if (tokval == nulsym)        cval = 0x00;
-                else if (tokval == alarmsym)      cval = 0x07;
-                else if (tokval == backspacesym)  cval = 0x08;
-                else if (tokval == tabsym)        cval = 0x09;
-                else if (tokval == linefeedsym)   cval = 0x0A;
-                else if (tokval == newlinesym)    cval = 0x0A;
-                else if (tokval == vtabsym)       cval = 0x0B;
-                else if (tokval == pagesym)       cval = 0x0C;
-                else if (tokval == returnsym)     cval = 0x0D;
-                else if (tokval == escsym)        cval = 0x1B;
-                else if (tokval == spacesym)      cval = 0x20;
-                else if (tokval == deletesym)     cval = 0x7F;
+                read_token(fl_ctx, (char)cval, 0);
+                fl_ctx->readtokval = symbol(fl_ctx, fl_ctx->readbuf);
+                if (fl_ctx->readbuf[1] == '\0')       /* one character */;
+                else if (fl_ctx->readtokval == fl_ctx->nulsym)        cval = 0x00;
+                else if (fl_ctx->readtokval == fl_ctx->alarmsym)      cval = 0x07;
+                else if (fl_ctx->readtokval == fl_ctx->backspacesym)  cval = 0x08;
+                else if (fl_ctx->readtokval == fl_ctx->tabsym)        cval = 0x09;
+                else if (fl_ctx->readtokval == fl_ctx->linefeedsym)   cval = 0x0A;
+                else if (fl_ctx->readtokval == fl_ctx->newlinesym)    cval = 0x0A;
+                else if (fl_ctx->readtokval == fl_ctx->vtabsym)       cval = 0x0B;
+                else if (fl_ctx->readtokval == fl_ctx->pagesym)       cval = 0x0C;
+                else if (fl_ctx->readtokval == fl_ctx->returnsym)     cval = 0x0D;
+                else if (fl_ctx->readtokval == fl_ctx->escsym)        cval = 0x1B;
+                else if (fl_ctx->readtokval == fl_ctx->spacesym)      cval = 0x20;
+                else if (fl_ctx->readtokval == fl_ctx->deletesym)     cval = 0x7F;
                 else
-                    lerrorf(ParseError, "read: unknown character #\\%s", buf);
+                    lerrorf(fl_ctx, fl_ctx->ParseError, "read: unknown character #\\%s", fl_ctx->readbuf);
             }
-            toktype = TOK_NUM;
-            tokval = mk_wchar(cval);
+            fl_ctx->readtoktype = TOK_NUM;
+            fl_ctx->readtokval = mk_wchar(fl_ctx, cval);
         }
         else if (c == '(') {
-            toktype = TOK_SHARPOPEN;
+            fl_ctx->readtoktype = TOK_SHARPOPEN;
         }
         else if (c == '<') {
-            lerror(ParseError, "read: unreadable object");
+            lerror(fl_ctx, fl_ctx->ParseError, "read: unreadable object");
         }
         else if (isdigit(c)) {
-            read_token(c, 1);
-            c = (char)ios_getc(F);
+            read_token(fl_ctx, c, 1);
+            c = (char)ios_getc(readF(fl_ctx));
             if (c == '#')
-                toktype = TOK_BACKREF;
+                fl_ctx->readtoktype = TOK_BACKREF;
             else if (c == '=')
-                toktype = TOK_LABEL;
+                fl_ctx->readtoktype = TOK_LABEL;
             else
-                lerror(ParseError, "read: invalid label");
+                lerror(fl_ctx, fl_ctx->ParseError, "read: invalid label");
             errno = 0;
-            x = strtol(buf, &end, 10);
+            x = strtol(fl_ctx->readbuf, &end, 10);
             if (*end != '\0' || errno)
-                lerror(ParseError, "read: invalid label");
-            tokval = fixnum(x);
+                lerror(fl_ctx, fl_ctx->ParseError, "read: invalid label");
+            fl_ctx->readtokval = fixnum(x);
         }
         else if (c == '!') {
             // #! single line comment for shbang script support
             do {
-                ch = ios_getc(F);
+                ch = ios_getc(readF(fl_ctx));
             } while (ch != IOS_EOF && (char)ch != '\n');
-            return peek();
+            return peek(fl_ctx);
         }
         else if (c == '|') {
             // multiline comment
             int commentlevel=1;
             while (1) {
-                ch = ios_getc(F);
+                ch = ios_getc(readF(fl_ctx));
             hashpipe_gotc:
                 if (ch == IOS_EOF)
-                    lerror(ParseError, "read: eof within comment");
+                    lerror(fl_ctx, fl_ctx->ParseError, "read: eof within comment");
                 if ((char)ch == '|') {
-                    ch = ios_getc(F);
+                    ch = ios_getc(readF(fl_ctx));
                     if ((char)ch == '#') {
                         commentlevel--;
                         if (commentlevel == 0)
@@ -329,7 +325,7 @@ static u_int32_t peek(void)
                     goto hashpipe_gotc;
                 }
                 else if ((char)ch == '#') {
-                    ch = ios_getc(F);
+                    ch = ios_getc(readF(fl_ctx));
                     if ((char)ch == '|')
                         commentlevel++;
                     else
@@ -337,124 +333,124 @@ static u_int32_t peek(void)
                 }
             }
             // this was whitespace, so keep peeking
-            return peek();
+            return peek(fl_ctx);
         }
         else if (c == ';') {
             // datum comment
-            (void)do_read_sexpr(UNBOUND); // skip
-            return peek();
+            (void)do_read_sexpr(fl_ctx, UNBOUND); // skip
+            return peek(fl_ctx);
         }
         else if (c == ':') {
             // gensym
-            ch = ios_getc(F);
+            ch = ios_getc(readF(fl_ctx));
             if ((char)ch == 'g')
-                ch = ios_getc(F);
-            read_token((char)ch, 0);
+                ch = ios_getc(readF(fl_ctx));
+            read_token(fl_ctx, (char)ch, 0);
             errno = 0;
-            x = strtol(buf, &end, 10);
-            if (*end != '\0' || buf[0] == '\0' || errno)
-                lerror(ParseError, "read: invalid gensym label");
-            toktype = TOK_GENSYM;
-            tokval = fixnum(x);
+            x = strtol(fl_ctx->readbuf, &end, 10);
+            if (*end != '\0' || fl_ctx->readbuf[0] == '\0' || errno)
+                lerror(fl_ctx, fl_ctx->ParseError, "read: invalid gensym label");
+            fl_ctx->readtoktype = TOK_GENSYM;
+            fl_ctx->readtokval = fixnum(x);
         }
         else if (symchar(c)) {
-            read_token(ch, 0);
+            read_token(fl_ctx, ch, 0);
 
             if (((c == 'b' && (base= 2)) ||
                  (c == 'o' && (base= 8)) ||
                  (c == 'd' && (base=10)) ||
                  (c == 'x' && (base=16))) &&
-                (isdigit_base(buf[1],base) ||
-                 buf[1]=='-')) {
-                if (!read_numtok(&buf[1], &tokval, base))
-                    lerrorf(ParseError, "read: invalid base %d constant", base);
-                return (toktype=TOK_NUM);
+                (isdigit_base(fl_ctx->readbuf[1],base) ||
+                 fl_ctx->readbuf[1]=='-')) {
+                if (!read_numtok(fl_ctx, &fl_ctx->readbuf[1], &fl_ctx->readtokval, base))
+                    lerrorf(fl_ctx, fl_ctx->ParseError, "read: invalid base %d constant", base);
+                return (fl_ctx->readtoktype=TOK_NUM);
             }
 
-            toktype = TOK_SHARPSYM;
-            tokval = symbol(buf);
+            fl_ctx->readtoktype = TOK_SHARPSYM;
+            fl_ctx->readtokval = symbol(fl_ctx, fl_ctx->readbuf);
         }
         else {
-            lerror(ParseError, "read: unknown read macro");
+            lerror(fl_ctx, fl_ctx->ParseError, "read: unknown read macro");
         }
     }
     else if (c == ',') {
-        toktype = TOK_COMMA;
-        ch = ios_getc(F);
+        fl_ctx->readtoktype = TOK_COMMA;
+        ch = ios_getc(readF(fl_ctx));
         if (ch == IOS_EOF)
-            return toktype;
+            return fl_ctx->readtoktype;
         if ((char)ch == '@')
-            toktype = TOK_COMMAAT;
+            fl_ctx->readtoktype = TOK_COMMAAT;
         else if ((char)ch == '.')
-            toktype = TOK_COMMADOT;
+            fl_ctx->readtoktype = TOK_COMMADOT;
         else
-            ios_ungetc((char)ch, F);
+            ios_ungetc((char)ch, readF(fl_ctx));
     }
     else {
-        if (!read_token(c, 0)) {
-            if (buf[0]=='.' && buf[1]=='\0') {
-                return (toktype=TOK_DOT);
+        if (!read_token(fl_ctx, c, 0)) {
+            if (fl_ctx->readbuf[0]=='.' && fl_ctx->readbuf[1]=='\0') {
+                return (fl_ctx->readtoktype=TOK_DOT);
             }
             else {
-                if (read_numtok(buf, &tokval, 0))
-                    return (toktype=TOK_NUM);
+                if (read_numtok(fl_ctx, fl_ctx->readbuf, &fl_ctx->readtokval, 0))
+                    return (fl_ctx->readtoktype=TOK_NUM);
             }
         }
-        toktype = TOK_SYM;
-        tokval = symbol(buf);
+        fl_ctx->readtoktype = TOK_SYM;
+        fl_ctx->readtokval = symbol(fl_ctx, fl_ctx->readbuf);
     }
-    return toktype;
+    return fl_ctx->readtoktype;
 }
 
 // NOTE: this is NOT an efficient operation. it is only used by the
 // reader, and requires at least 1 and up to 3 garbage collections!
-static value_t vector_grow(value_t v, int rewrite_refs)
+static value_t vector_grow(fl_context_t *fl_ctx, value_t v, int rewrite_refs)
 {
     size_t i, s = vector_size(v);
     size_t d = vector_grow_amt(s);
-    PUSH(v);
-    value_t newv = alloc_vector(s+d, 1);
-    v = Stack[SP-1];
+    PUSH(fl_ctx, v);
+    value_t newv = alloc_vector(fl_ctx, s+d, 1);
+    v = fl_ctx->Stack[fl_ctx->SP-1];
     for(i=0; i < s; i++)
         vector_elt(newv, i) = vector_elt(v, i);
     // use gc to rewrite references from the old vector to the new
-    Stack[SP-1] = newv;
+    fl_ctx->Stack[fl_ctx->SP-1] = newv;
     if (s > 0 && rewrite_refs) {
         ((size_t*)ptr(v))[0] |= 0x1;
         vector_elt(v, 0) = newv;
-        gc(0);
+        gc(fl_ctx, 0);
     }
-    return POP();
+    return POP(fl_ctx);
 }
 
-static value_t read_vector(value_t label, u_int32_t closer)
+static value_t read_vector(fl_context_t *fl_ctx, value_t label, u_int32_t closer)
 {
-    value_t v=the_empty_vector, elt;
+    value_t v=fl_ctx->the_empty_vector, elt;
     u_int32_t i=0;
-    PUSH(v);
+    PUSH(fl_ctx, v);
     if (label != UNBOUND)
-        ptrhash_put(&readstate->backrefs, (void*)label, (void*)v);
-    while (peek() != closer) {
-        if (ios_eof(F))
-            lerror(ParseError, "read: unexpected end of input");
-        v = Stack[SP-1]; // reload after possible alloc in peek()
+        ptrhash_put(&fl_ctx->readstate->backrefs, (void*)label, (void*)v);
+    while (peek(fl_ctx) != closer) {
+        if (ios_eof(readF(fl_ctx)))
+            lerror(fl_ctx, fl_ctx->ParseError, "read: unexpected end of input");
+        v = fl_ctx->Stack[fl_ctx->SP-1]; // reload after possible alloc in peek()
         if (i >= vector_size(v)) {
-            v = Stack[SP-1] = vector_grow(v, label != UNBOUND);
+            v = fl_ctx->Stack[fl_ctx->SP-1] = vector_grow(fl_ctx, v, label != UNBOUND);
             if (label != UNBOUND)
-                ptrhash_put(&readstate->backrefs, (void*)label, (void*)v);
+                ptrhash_put(&fl_ctx->readstate->backrefs, (void*)label, (void*)v);
         }
-        elt = do_read_sexpr(UNBOUND);
-        v = Stack[SP-1];
+        elt = do_read_sexpr(fl_ctx, UNBOUND);
+        v = fl_ctx->Stack[fl_ctx->SP-1];
         vector_elt(v,i) = elt;
         i++;
     }
-    take();
+    take(fl_ctx);
     if (i > 0)
         vector_setsize(v, i);
-    return POP();
+    return POP(fl_ctx);
 }
 
-static value_t read_string(void)
+static value_t read_string(fl_context_t *fl_ctx)
 {
     char *buf, *temp;
     char eseq[10];
@@ -470,30 +466,30 @@ static value_t read_string(void)
             temp = (char*)realloc(buf, sz);
             if (temp == NULL) {
                 free(buf);
-                lerror(ParseError, "read: out of memory reading string");
+                lerror(fl_ctx, fl_ctx->ParseError, "read: out of memory reading string");
             }
             buf = temp;
         }
-        c = ios_getc(F);
+        c = ios_getc(readF(fl_ctx));
         if (c == IOS_EOF) {
             free(buf);
-            lerror(ParseError, "read: unexpected end of input in string");
+            lerror(fl_ctx, fl_ctx->ParseError, "read: unexpected end of input in string");
         }
         if (c == '"')
             break;
         else if (c == '\\') {
-            c = ios_getc(F);
+            c = ios_getc(readF(fl_ctx));
             if (c == IOS_EOF) {
                 free(buf);
-                lerror(ParseError, "read: end of input in escape sequence");
+                lerror(fl_ctx, fl_ctx->ParseError, "read: end of input in escape sequence");
             }
             j=0;
             if (octal_digit(c)) {
                 do {
                     eseq[j++] = c;
-                    c = ios_getc(F);
+                    c = ios_getc(readF(fl_ctx));
                 } while (octal_digit(c) && j<3 && (c!=IOS_EOF));
-                if (c!=IOS_EOF) ios_ungetc(c, F);
+                if (c!=IOS_EOF) ios_ungetc(c, readF(fl_ctx));
                 eseq[j] = '\0';
                 wc = strtol(eseq, NULL, 8);
                 // \DDD and \xXX read bytes, not characters
@@ -502,17 +498,17 @@ static value_t read_string(void)
             else if ((c=='x' && (ndig=2)) ||
                      (c=='u' && (ndig=4)) ||
                      (c=='U' && (ndig=8))) {
-                c = ios_getc(F);
+                c = ios_getc(readF(fl_ctx));
                 while (hex_digit(c) && j<ndig && (c!=IOS_EOF)) {
                     eseq[j++] = c;
-                    c = ios_getc(F);
+                    c = ios_getc(readF(fl_ctx));
                 }
-                if (c!=IOS_EOF) ios_ungetc(c, F);
+                if (c!=IOS_EOF) ios_ungetc(c, readF(fl_ctx));
                 eseq[j] = '\0';
                 if (j) wc = strtol(eseq, NULL, 16);
                 if (!j || wc > 0x10ffff) {
                     free(buf);
-                    lerror(ParseError, "read: invalid escape sequence");
+                    lerror(fl_ctx, fl_ctx->ParseError, "read: invalid escape sequence");
                 }
                 if (ndig == 2)
                     buf[i++] = ((char)wc);
@@ -527,7 +523,7 @@ static value_t read_string(void)
             buf[i++] = c;
         }
     }
-    s = cvalue_string(i);
+    s = cvalue_string(fl_ctx, i);
     memcpy(cvalue_data(s), buf, i);
     free(buf);
     return s;
@@ -536,183 +532,190 @@ static value_t read_string(void)
 // build a list of conses. this is complicated by the fact that all conses
 // can move whenever a new cons is allocated. we have to refer to every cons
 // through a handle to a relocatable pointer (i.e. a pointer on the stack).
-static void read_list(value_t *pval, value_t label)
+static void read_list(fl_context_t *fl_ctx, value_t *pval, value_t label)
 {
     value_t c, *pc;
     u_int32_t t;
 
-    PUSH(NIL);
-    pc = &Stack[SP-1];  // to keep track of current cons cell
-    t = peek();
+    PUSH(fl_ctx, fl_ctx->NIL);
+    pc = &fl_ctx->Stack[fl_ctx->SP-1];  // to keep track of current cons cell
+    t = peek(fl_ctx);
     while (t != TOK_CLOSE) {
-        if (ios_eof(F))
-            lerror(ParseError, "read: unexpected end of input");
-        c = mk_cons(); car_(c) = cdr_(c) = NIL;
+        if (ios_eof(readF(fl_ctx)))
+            lerror(fl_ctx, fl_ctx->ParseError, "read: unexpected end of input");
+        c = mk_cons(fl_ctx); car_(c) = cdr_(c) = fl_ctx->NIL;
         if (iscons(*pc)) {
             cdr_(*pc) = c;
         }
         else {
             *pval = c;
             if (label != UNBOUND)
-                ptrhash_put(&readstate->backrefs, (void*)label, (void*)c);
+                ptrhash_put(&fl_ctx->readstate->backrefs, (void*)label, (void*)c);
         }
         *pc = c;
-        c = do_read_sexpr(UNBOUND); // must be on separate lines due to
+        c = do_read_sexpr(fl_ctx, UNBOUND); // must be on separate lines due to
         car_(*pc) = c;              // undefined evaluation order
 
-        t = peek();
+        t = peek(fl_ctx);
         if (t == TOK_DOT) {
-            take();
-            c = do_read_sexpr(UNBOUND);
+            take(fl_ctx);
+            c = do_read_sexpr(fl_ctx, UNBOUND);
             cdr_(*pc) = c;
-            t = peek();
-            if (ios_eof(F))
-                lerror(ParseError, "read: unexpected end of input");
+            t = peek(fl_ctx);
+            if (ios_eof(readF(fl_ctx)))
+                lerror(fl_ctx, fl_ctx->ParseError, "read: unexpected end of input");
             if (t != TOK_CLOSE)
-                lerror(ParseError, "read: expected ')'");
+                lerror(fl_ctx, fl_ctx->ParseError, "read: expected ')'");
         }
     }
-    take();
-    (void)POP();
+    take(fl_ctx);
+    (void)POP(fl_ctx);
 }
 
 // label is the backreference we'd like to fix up with this read
-static value_t do_read_sexpr(value_t label)
+static value_t do_read_sexpr(fl_context_t *fl_ctx, value_t label)
 {
     value_t v, sym, oldtokval, *head;
     value_t *pv;
     u_int32_t t;
     char c;
 
-    t = peek();
-    take();
+    t = peek(fl_ctx);
+    take(fl_ctx);
     switch (t) {
     case TOK_CLOSE:
-        lerror(ParseError, "read: unexpected ')'");
+        lerror(fl_ctx, fl_ctx->ParseError, "read: unexpected ')'");
     case TOK_CLOSEB:
-        lerror(ParseError, "read: unexpected ']'");
+        lerror(fl_ctx, fl_ctx->ParseError, "read: unexpected ']'");
     case TOK_DOT:
-        lerror(ParseError, "read: unexpected '.'");
+        lerror(fl_ctx, fl_ctx->ParseError, "read: unexpected '.'");
     case TOK_SYM:
     case TOK_NUM:
-        return tokval;
+        return fl_ctx->readtokval;
     case TOK_COMMA:
-        head = &COMMA; goto listwith;
+        head = &fl_ctx->COMMA; goto listwith;
     case TOK_COMMAAT:
-        head = &COMMAAT; goto listwith;
+        head = &fl_ctx->COMMAAT; goto listwith;
     case TOK_COMMADOT:
-        head = &COMMADOT; goto listwith;
+        head = &fl_ctx->COMMADOT; goto listwith;
     case TOK_BQ:
-        head = &BACKQUOTE; goto listwith;
+        head = &fl_ctx->BACKQUOTE; goto listwith;
     case TOK_QUOTE:
-        head = &QUOTE;
+        head = &fl_ctx->QUOTE;
     listwith:
 #ifdef MEMDEBUG2
-        v = fl_list2(*head, NIL);
+        v = fl_list2(fl_ctx, *head, fl_ctx->NIL);
 #else
-        v = cons_reserve(2);
+        v = cons_reserve(fl_ctx, 2);
         car_(v) = *head;
         cdr_(v) = tagptr(((cons_t*)ptr(v))+1, TAG_CONS);
-        car_(cdr_(v)) = cdr_(cdr_(v)) = NIL;
+        car_(cdr_(v)) = cdr_(cdr_(v)) = fl_ctx->NIL;
 #endif
-        PUSH(v);
+        PUSH(fl_ctx, v);
         if (label != UNBOUND)
-            ptrhash_put(&readstate->backrefs, (void*)label, (void*)v);
-        v = do_read_sexpr(UNBOUND);
-        car_(cdr_(Stack[SP-1])) = v;
-        return POP();
+            ptrhash_put(&fl_ctx->readstate->backrefs, (void*)label, (void*)v);
+        v = do_read_sexpr(fl_ctx, UNBOUND);
+        car_(cdr_(fl_ctx->Stack[fl_ctx->SP-1])) = v;
+        return POP(fl_ctx);
     case TOK_SHARPQUOTE:
         // femtoLisp doesn't need symbol-function, so #' does nothing
-        return do_read_sexpr(label);
+        return do_read_sexpr(fl_ctx, label);
     case TOK_OPEN:
-        PUSH(NIL);
-        read_list(&Stack[SP-1], label);
-        return POP();
+        PUSH(fl_ctx, fl_ctx->NIL);
+        read_list(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-1], label);
+        return POP(fl_ctx);
     case TOK_SHARPSYM:
-        sym = tokval;
-        if (sym == tsym || sym == Tsym)
-            return FL_T;
-        else if (sym == fsym || sym == Fsym)
-            return FL_F;
+        sym = fl_ctx->readtokval;
+        if (sym == fl_ctx->tsym || sym == fl_ctx->Tsym)
+            return fl_ctx->T;
+        else if (sym == fl_ctx->fsym || sym == fl_ctx->Fsym)
+            return fl_ctx->F;
         // constructor notation
-        c = nextchar();
+        c = nextchar(fl_ctx);
         if (c != '(') {
-            take();
-            lerrorf(ParseError, "read: expected argument list for %s",
-                    symbol_name(tokval));
+            take(fl_ctx);
+            lerrorf(fl_ctx, fl_ctx->ParseError, "read: expected argument list for %s",
+                    symbol_name(fl_ctx, fl_ctx->readtokval));
         }
-        PUSH(NIL);
-        read_list(&Stack[SP-1], UNBOUND);
-        if (sym == vu8sym) {
-            sym = arraysym;
-            Stack[SP-1] = fl_cons(uint8sym, Stack[SP-1]);
+        PUSH(fl_ctx, fl_ctx->NIL);
+        read_list(fl_ctx, &fl_ctx->Stack[fl_ctx->SP-1], UNBOUND);
+        if (sym == fl_ctx->vu8sym) {
+            sym = fl_ctx->arraysym;
+            fl_ctx->Stack[fl_ctx->SP-1] = fl_cons(fl_ctx, fl_ctx->uint8sym, fl_ctx->Stack[fl_ctx->SP-1]);
         }
-        else if (sym == fnsym) {
-            sym = FUNCTION;
+        else if (sym == fl_ctx->fnsym) {
+            sym = fl_ctx->FUNCTION;
         }
         v = symbol_value(sym);
         if (v == UNBOUND)
-            fl_raise(fl_list2(UnboundError, sym));
-        return fl_apply(v, POP());
+            fl_raise(fl_ctx, fl_list2(fl_ctx, fl_ctx->UnboundError, sym));
+        return fl_apply(fl_ctx, v, POP(fl_ctx));
     case TOK_OPENB:
-        return read_vector(label, TOK_CLOSEB);
+        return read_vector(fl_ctx, label, TOK_CLOSEB);
     case TOK_SHARPOPEN:
-        return read_vector(label, TOK_CLOSE);
+        return read_vector(fl_ctx, label, TOK_CLOSE);
     case TOK_SHARPDOT:
         // eval-when-read
         // evaluated expressions can refer to existing backreferences, but they
         // cannot see pending labels. in other words:
         // (... #2=#.#0# ... )    OK
         // (... #2=#.(#2#) ... )  DO NOT WANT
-        sym = do_read_sexpr(UNBOUND);
+        sym = do_read_sexpr(fl_ctx, UNBOUND);
         if (issymbol(sym)) {
             v = symbol_value(sym);
             if (v == UNBOUND)
-                fl_raise(fl_list2(UnboundError, sym));
+                fl_raise(fl_ctx, fl_list2(fl_ctx, fl_ctx->UnboundError, sym));
             return v;
         }
-        return fl_toplevel_eval(sym);
+        return fl_toplevel_eval(fl_ctx, sym);
     case TOK_LABEL:
         // create backreference label
-        if (ptrhash_has(&readstate->backrefs, (void*)tokval))
-            lerrorf(ParseError, "read: label %ld redefined", numval(tokval));
-        oldtokval = tokval;
-        v = do_read_sexpr(tokval);
-        ptrhash_put(&readstate->backrefs, (void*)oldtokval, (void*)v);
+        if (ptrhash_has(&fl_ctx->readstate->backrefs, (void*)fl_ctx->readtokval))
+            lerrorf(fl_ctx, fl_ctx->ParseError, "read: label %ld redefined", numval(fl_ctx->readtokval));
+        oldtokval = fl_ctx->readtokval;
+        v = do_read_sexpr(fl_ctx, fl_ctx->readtokval);
+        ptrhash_put(&fl_ctx->readstate->backrefs, (void*)oldtokval, (void*)v);
         return v;
     case TOK_BACKREF:
         // look up backreference
-        v = (value_t)ptrhash_get(&readstate->backrefs, (void*)tokval);
+        v = (value_t)ptrhash_get(&fl_ctx->readstate->backrefs, (void*)fl_ctx->readtokval);
         if (v == (value_t)HT_NOTFOUND)
-            lerrorf(ParseError, "read: undefined label %ld", numval(tokval));
+            lerrorf(fl_ctx, fl_ctx->ParseError, "read: undefined label %ld", numval(fl_ctx->readtokval));
         return v;
     case TOK_GENSYM:
-        pv = (value_t*)ptrhash_bp(&readstate->gensyms, (void*)tokval);
+        pv = (value_t*)ptrhash_bp(&fl_ctx->readstate->gensyms, (void*)fl_ctx->readtokval);
         if (*pv == (value_t)HT_NOTFOUND)
-            *pv = fl_gensym(NULL, 0);
+            *pv = fl_gensym(fl_ctx, NULL, 0);
         return *pv;
     case TOK_DOUBLEQUOTE:
-        return read_string();
+        return read_string(fl_ctx);
     }
-    return FL_UNSPECIFIED;
+    return FL_UNSPECIFIED(fl_ctx);
 }
 
-value_t fl_read_sexpr(value_t f)
+value_t fl_read_sexpr(fl_context_t *fl_ctx, value_t f)
 {
     value_t v;
     fl_readstate_t state;
-    state.prev = readstate;
+    state.prev = fl_ctx->readstate;
     htable_new(&state.backrefs, 8);
     htable_new(&state.gensyms, 8);
     state.source = f;
-    readstate = &state;
-    assert(toktype == TOK_NONE);
-    fl_gc_handle(&tokval);
+    fl_ctx->readstate = &state;
+    assert(fl_ctx->readtoktype == TOK_NONE);
+    fl_gc_handle(fl_ctx, &fl_ctx->readtokval);
 
-    v = do_read_sexpr(UNBOUND);
+    v = do_read_sexpr(fl_ctx, UNBOUND);
 
-    fl_free_gc_handles(1);
-    readstate = state.prev;
+    fl_free_gc_handles(fl_ctx, 1);
+    fl_ctx->readstate = state.prev;
     free_readstate(&state);
     return v;
+}
+
+static void fl_read_init(fl_context_t *fl_ctx)
+{
+    fl_ctx->readtoktype = TOK_NONE;
+    fl_ctx->readtokval = 0;
+    memset(fl_ctx->readbuf, 0, sizeof(fl_ctx->readbuf));
 }

--- a/src/flisp/string.c
+++ b/src/flisp/string.c
@@ -26,255 +26,255 @@
 extern "C" {
 #endif
 
-value_t fl_stringp(value_t *args, u_int32_t nargs)
+value_t fl_stringp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("string?", nargs, 1);
-    return fl_isstring(args[0]) ? FL_T : FL_F;
+    argcount(fl_ctx, "string?", nargs, 1);
+    return fl_isstring(fl_ctx, args[0]) ? fl_ctx->T : fl_ctx->F;
 }
 
-value_t fl_string_count(value_t *args, u_int32_t nargs)
+value_t fl_string_count(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     size_t start = 0;
     if (nargs < 1 || nargs > 3)
-        argcount("string.count", nargs, 1);
-    if (!fl_isstring(args[0]))
-        type_error("string.count", "string", args[0]);
+        argcount(fl_ctx, "string.count", nargs, 1);
+    if (!fl_isstring(fl_ctx, args[0]))
+        type_error(fl_ctx, "string.count", "string", args[0]);
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
     size_t stop = len;
     if (nargs > 1) {
-        start = tosize(args[1], "string.count");
+        start = tosize(fl_ctx, args[1], "string.count");
         if (start > len)
-            bounds_error("string.count", args[0], args[1]);
+            bounds_error(fl_ctx, "string.count", args[0], args[1]);
         if (nargs > 2) {
-            stop = tosize(args[2], "string.count");
+            stop = tosize(fl_ctx, args[2], "string.count");
             if (stop > len)
-                bounds_error("string.count", args[0], args[2]);
+                bounds_error(fl_ctx, "string.count", args[0], args[2]);
             if (stop <= start)
                 return fixnum(0);
         }
     }
     char *str = (char*)cvalue_data(args[0]);
-    return size_wrap(u8_charnum(str+start, stop-start));
+    return size_wrap(fl_ctx, u8_charnum(str+start, stop-start));
 }
 
-extern value_t fl_buffer(value_t *args, u_int32_t nargs);
-extern value_t stream_to_string(value_t *ps);
+extern value_t fl_buffer(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+extern value_t stream_to_string(fl_context_t *fl_ctx, value_t *ps);
 
-value_t fl_string(value_t *args, u_int32_t nargs)
+value_t fl_string(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    if (nargs == 1 && fl_isstring(args[0]))
+    if (nargs == 1 && fl_isstring(fl_ctx, args[0]))
         return args[0];
-    value_t arg, buf = fl_buffer(NULL, 0);
-    fl_gc_handle(&buf);
+    value_t arg, buf = fl_buffer(fl_ctx, NULL, 0);
+    fl_gc_handle(fl_ctx, &buf);
     ios_t *s = value2c(ios_t*,buf);
     uint32_t i;
-    value_t oldpr = symbol_value(printreadablysym);
-    value_t oldpp = symbol_value(printprettysym);
-    set(printreadablysym, FL_F);
-    set(printprettysym, FL_F);
+    value_t oldpr = symbol_value(fl_ctx->printreadablysym);
+    value_t oldpp = symbol_value(fl_ctx->printprettysym);
+    set(fl_ctx->printreadablysym, fl_ctx->F);
+    set(fl_ctx->printprettysym, fl_ctx->F);
     FOR_ARGS(i,0,arg,args) {
-        fl_print(s, args[i]);
+        fl_print(fl_ctx, s, args[i]);
     }
-    set(printreadablysym, oldpr);
-    set(printprettysym, oldpp);
-    value_t outp = stream_to_string(&buf);
-    fl_free_gc_handles(1);
+    set(fl_ctx->printreadablysym, oldpr);
+    set(fl_ctx->printprettysym, oldpp);
+    value_t outp = stream_to_string(fl_ctx, &buf);
+    fl_free_gc_handles(fl_ctx, 1);
     return outp;
 }
 
-value_t fl_string_sub(value_t *args, u_int32_t nargs)
+value_t fl_string_sub(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs != 2)
-        argcount("string.sub", nargs, 3);
-    char *s = tostring(args[0], "string.sub");
+        argcount(fl_ctx, "string.sub", nargs, 3);
+    char *s = tostring(fl_ctx, args[0], "string.sub");
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
     size_t i1, i2;
-    i1 = tosize(args[1], "string.sub");
+    i1 = tosize(fl_ctx, args[1], "string.sub");
     if (i1 > len)
-        bounds_error("string.sub", args[0], args[1]);
+        bounds_error(fl_ctx, "string.sub", args[0], args[1]);
     if (nargs == 3) {
-        i2 = tosize(args[2], "string.sub");
+        i2 = tosize(fl_ctx, args[2], "string.sub");
         if (i2 > len)
-            bounds_error("string.sub", args[0], args[2]);
+            bounds_error(fl_ctx, "string.sub", args[0], args[2]);
     }
     else {
         i2 = len;
     }
     if (i2 <= i1)
-        return cvalue_string(0);
-    value_t ns = cvalue_string(i2-i1);
+        return cvalue_string(fl_ctx, 0);
+    value_t ns = cvalue_string(fl_ctx, i2-i1);
     s = (char*)cvalue_data(args[0]); // reload after alloc
     memcpy(cv_data((cvalue_t*)ptr(ns)), &s[i1], i2-i1);
     return ns;
 }
 
-value_t fl_string_char(value_t *args, u_int32_t nargs)
+value_t fl_string_char(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("string.char", nargs, 2);
-    char *s = tostring(args[0], "string.char");
+    argcount(fl_ctx, "string.char", nargs, 2);
+    char *s = tostring(fl_ctx, args[0], "string.char");
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
-    size_t i = tosize(args[1], "string.char");
+    size_t i = tosize(fl_ctx, args[1], "string.char");
     if (i >= len)
-        bounds_error("string.char", args[0], args[1]);
+        bounds_error(fl_ctx, "string.char", args[0], args[1]);
     size_t sl = u8_seqlen(&s[i]);
     if (sl > len || i > len-sl)
-        bounds_error("string.char", args[0], args[1]);
-    return mk_wchar(u8_nextchar(s, &i));
+        bounds_error(fl_ctx, "string.char", args[0], args[1]);
+    return mk_wchar(fl_ctx, u8_nextchar(s, &i));
 }
 
-static value_t mem_find_byte(char *s, char c, size_t start, size_t len)
+static value_t mem_find_byte(fl_context_t *fl_ctx, char *s, char c, size_t start, size_t len)
 {
     char *p = (char*)memchr(s+start, c, len-start);
     if (p == NULL)
-        return FL_F;
-    return size_wrap((size_t)(p - s));
+        return fl_ctx->F;
+    return size_wrap(fl_ctx, (size_t)(p - s));
 }
 
-value_t fl_string_find(value_t *args, u_int32_t nargs)
+value_t fl_string_find(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     char cbuf[8];
     size_t start = 0;
     if (nargs == 3)
-        start = tosize(args[2], "string.find");
+        start = tosize(fl_ctx, args[2], "string.find");
     else
-        argcount("string.find", nargs, 2);
-    char *s = tostring(args[0], "string.find");
+        argcount(fl_ctx, "string.find", nargs, 2);
+    char *s = tostring(fl_ctx, args[0], "string.find");
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
     if (start > len)
-        bounds_error("string.find", args[0], args[2]);
+        bounds_error(fl_ctx, "string.find", args[0], args[2]);
     char *needle; size_t needlesz;
 
     value_t v = args[1];
     cprim_t *cp = (cprim_t*)ptr(v);
-    if (iscprim(v) && cp_class(cp) == wchartype) {
+    if (iscprim(v) && cp_class(cp) == fl_ctx->wchartype) {
         uint32_t c = *(uint32_t*)cp_data(cp);
         if (c <= 0x7f)
-            return mem_find_byte(s, (char)c, start, len);
+            return mem_find_byte(fl_ctx, s, (char)c, start, len);
         needlesz = u8_toutf8(cbuf, sizeof(cbuf), &c, 1);
         needle = cbuf;
     }
-    else if (iscprim(v) && cp_class(cp) == bytetype) {
-        return mem_find_byte(s, *(char*)cp_data(cp), start, len);
+    else if (iscprim(v) && cp_class(cp) == fl_ctx->bytetype) {
+        return mem_find_byte(fl_ctx, s, *(char*)cp_data(cp), start, len);
     }
-    else if (fl_isstring(v)) {
+    else if (fl_isstring(fl_ctx, v)) {
         cvalue_t *cv = (cvalue_t*)ptr(v);
         needlesz = cv_len(cv);
         needle = (char*)cv_data(cv);
     }
     else {
-        type_error("string.find", "string", args[1]);
+        type_error(fl_ctx, "string.find", "string", args[1]);
     }
     if (needlesz > len-start)
-        return FL_F;
+        return fl_ctx->F;
     else if (needlesz == 1)
-        return mem_find_byte(s, needle[0], start, len);
+        return mem_find_byte(fl_ctx, s, needle[0], start, len);
     else if (needlesz == 0)
-        return size_wrap(start);
+        return size_wrap(fl_ctx, start);
     size_t i;
     for(i=start; i < len-needlesz+1; i++) {
         if (s[i] == needle[0]) {
             if (!memcmp(&s[i+1], needle+1, needlesz-1))
-                return size_wrap(i);
+                return size_wrap(fl_ctx, i);
         }
     }
-    return FL_F;
+    return fl_ctx->F;
 }
 
-value_t fl_string_inc(value_t *args, u_int32_t nargs)
+value_t fl_string_inc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 2 || nargs > 3)
-        argcount("string.inc", nargs, 2);
-    char *s = tostring(args[0], "string.inc");
+        argcount(fl_ctx, "string.inc", nargs, 2);
+    char *s = tostring(fl_ctx, args[0], "string.inc");
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
-    size_t i = tosize(args[1], "string.inc");
+    size_t i = tosize(fl_ctx, args[1], "string.inc");
     size_t cnt = 1;
     if (nargs == 3)
-        cnt = tosize(args[2], "string.inc");
+        cnt = tosize(fl_ctx, args[2], "string.inc");
     while (cnt--) {
         if (i >= len)
-            bounds_error("string.inc", args[0], args[1]);
+            bounds_error(fl_ctx, "string.inc", args[0], args[1]);
         (void)(isutf(s[++i]) || isutf(s[++i]) || isutf(s[++i]) || ++i);
     }
-    return size_wrap(i);
+    return size_wrap(fl_ctx, i);
 }
 
-value_t fl_string_dec(value_t *args, u_int32_t nargs)
+value_t fl_string_dec(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 2 || nargs > 3)
-        argcount("string.dec", nargs, 2);
-    char *s = tostring(args[0], "string.dec");
+        argcount(fl_ctx, "string.dec", nargs, 2);
+    char *s = tostring(fl_ctx, args[0], "string.dec");
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
-    size_t i = tosize(args[1], "string.dec");
+    size_t i = tosize(fl_ctx, args[1], "string.dec");
     size_t cnt = 1;
     if (nargs == 3)
-        cnt = tosize(args[2], "string.dec");
+        cnt = tosize(fl_ctx, args[2], "string.dec");
     // note: i is allowed to start at index len
     if (i > len)
-        bounds_error("string.dec", args[0], args[1]);
+        bounds_error(fl_ctx, "string.dec", args[0], args[1]);
     while (cnt--) {
         if (i == 0)
-            bounds_error("string.dec", args[0], args[1]);
+            bounds_error(fl_ctx, "string.dec", args[0], args[1]);
         (void)(isutf(s[--i]) || isutf(s[--i]) || isutf(s[--i]) || --i);
     }
-    return size_wrap(i);
+    return size_wrap(fl_ctx, i);
 }
 
-static unsigned long get_radix_arg(value_t arg, char *fname)
+static unsigned long get_radix_arg(fl_context_t *fl_ctx, value_t arg, char *fname)
 {
-    unsigned long radix = (unsigned long)tosize(arg, fname);
+    unsigned long radix = (unsigned long)tosize(fl_ctx, arg, fname);
     if (radix < 2 || radix > 36)
-        lerrorf(ArgError, "%s: invalid radix", fname);
+        lerrorf(fl_ctx, fl_ctx->ArgError, "%s: invalid radix", fname);
     return radix;
 }
 
-value_t fl_numbertostring(value_t *args, u_int32_t nargs)
+value_t fl_numbertostring(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
     if (nargs < 1 || nargs > 2)
-        argcount("number->string", nargs, 2);
+        argcount(fl_ctx, "number->string", nargs, 2);
     value_t n = args[0];
     int neg = 0;
     uint64_t num;
     if (isfixnum(n))      num = numval(n);
-    else if (!iscprim(n)) type_error("number->string", "integer", n);
+    else if (!iscprim(n)) type_error(fl_ctx, "number->string", "integer", n);
     else num = conv_to_uint64(cp_data((cprim_t*)ptr(n)),
                               cp_numtype((cprim_t*)ptr(n)));
-    if (numval(fl_compare(args[0],fixnum(0))) < 0) {
+    if (numval(fl_compare(fl_ctx, args[0],fixnum(0))) < 0) {
         num = -num;
         neg = 1;
     }
     unsigned long radix = 10;
     if (nargs == 2)
-        radix = get_radix_arg(args[1], "number->string");
+        radix = get_radix_arg(fl_ctx, args[1], "number->string");
     char buf[128];
     char *str = uint2str(buf, sizeof(buf), num, radix);
     if (neg && str > &buf[0])
         *(--str) = '-';
-    return string_from_cstr(str);
+    return string_from_cstr(fl_ctx, str);
 }
 
-value_t fl_stringtonumber(value_t *args, uint32_t nargs)
+value_t fl_stringtonumber(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 1 || nargs > 2)
-        argcount("string->number", nargs, 2);
-    char *str = tostring(args[0], "string->number");
+        argcount(fl_ctx, "string->number", nargs, 2);
+    char *str = tostring(fl_ctx, args[0], "string->number");
     value_t n;
     unsigned long radix = 0;
     if (nargs == 2)
-        radix = get_radix_arg(args[1], "string->number");
-    if (!isnumtok_base(str, &n, (int)radix))
-        return FL_F;
+        radix = get_radix_arg(fl_ctx, args[1], "string->number");
+    if (!isnumtok_base(fl_ctx, str, &n, (int)radix))
+        return fl_ctx->F;
     return n;
 }
 
-value_t fl_string_isutf8(value_t *args, u_int32_t nargs)
+value_t fl_string_isutf8(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
 {
-    argcount("string.isutf8", nargs, 1);
-    char *s = tostring(args[0], "string.isutf8");
+    argcount(fl_ctx, "string.isutf8", nargs, 1);
+    char *s = tostring(fl_ctx, args[0], "string.isutf8");
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
-    return u8_isvalid(s, len) ? FL_T : FL_F;
+    return u8_isvalid(s, len) ? fl_ctx->T : fl_ctx->F;
 }
 
-static builtinspec_t stringfunc_info[] = {
+static const builtinspec_t stringfunc_info[] = {
     { "string", fl_string },
     { "string?", fl_stringp },
     { "string.count", fl_string_count },
@@ -291,9 +291,9 @@ static builtinspec_t stringfunc_info[] = {
     { NULL, NULL }
 };
 
-void stringfuncs_init(void)
+void stringfuncs_init(fl_context_t *fl_ctx)
 {
-    assign_global_builtins(stringfunc_info);
+    assign_global_builtins(fl_ctx, stringfunc_info);
 }
 
 #ifdef __cplusplus

--- a/src/flisp/table.c
+++ b/src/flisp/table.c
@@ -12,46 +12,44 @@
 extern "C" {
 #endif
 
-static value_t tablesym;
-static fltype_t *tabletype;
-
-void print_htable(value_t v, ios_t *f)
+void print_htable(fl_context_t *fl_ctx, value_t v, ios_t *f)
 {
     htable_t *h = (htable_t*)cv_data((cvalue_t*)ptr(v));
     size_t i;
     int first=1;
-    fl_print_str("#table(", f);
+    fl_print_str(fl_ctx, "#table(", f);
     for(i=0; i < h->size; i+=2) {
         if (h->table[i+1] != HT_NOTFOUND) {
-            if (!first) fl_print_str("  ", f);
-            fl_print_child(f, (value_t)h->table[i]);
-            fl_print_chr(' ', f);
-            fl_print_child(f, (value_t)h->table[i+1]);
+            if (!first) fl_print_str(fl_ctx, "  ", f);
+            fl_print_child(fl_ctx, f, (value_t)h->table[i]);
+            fl_print_chr(fl_ctx, ' ', f);
+            fl_print_child(fl_ctx, f, (value_t)h->table[i+1]);
             first = 0;
         }
     }
-    fl_print_chr(')', f);
+    fl_print_chr(fl_ctx, ')', f);
 }
 
-void print_traverse_htable(value_t self)
+void print_traverse_htable(fl_context_t *fl_ctx, value_t self)
 {
     htable_t *h = (htable_t*)cv_data((cvalue_t*)ptr(self));
     size_t i;
     for(i=0; i < h->size; i+=2) {
         if (h->table[i+1] != HT_NOTFOUND) {
-            print_traverse((value_t)h->table[i]);
-            print_traverse((value_t)h->table[i+1]);
+            print_traverse(fl_ctx, (value_t)h->table[i]);
+            print_traverse(fl_ctx, (value_t)h->table[i+1]);
         }
     }
 }
 
-void free_htable(value_t self)
+void free_htable(fl_context_t *fl_ctx, value_t self)
 {
+    (void)fl_ctx;
     htable_t *h = (htable_t*)cv_data((cvalue_t*)ptr(self));
     htable_free(h);
 }
 
-void relocate_htable(value_t oldv, value_t newv)
+void relocate_htable(fl_context_t *fl_ctx, value_t oldv, value_t newv)
 {
     htable_t *oldh = (htable_t*)cv_data((cvalue_t*)ptr(oldv));
     htable_t *h = (htable_t*)cv_data((cvalue_t*)ptr(newv));
@@ -60,53 +58,50 @@ void relocate_htable(value_t oldv, value_t newv)
     size_t i;
     for(i=0; i < h->size; i++) {
         if (h->table[i] != HT_NOTFOUND)
-            h->table[i] = (void*)relocate_lispvalue((value_t)h->table[i]);
+            h->table[i] = (void*)relocate_lispvalue(fl_ctx, (value_t)h->table[i]);
     }
 }
 
-cvtable_t table_vtable = { print_htable, relocate_htable, free_htable,
-                           print_traverse_htable };
-
-int ishashtable(value_t v)
+static int ishashtable(fl_context_t *fl_ctx, value_t v)
 {
-    return iscvalue(v) && cv_class((cvalue_t*)ptr(v)) == tabletype;
+    return iscvalue(v) && cv_class((cvalue_t*)ptr(v)) == fl_ctx->tabletype;
 }
 
-value_t fl_tablep(value_t *args, uint32_t nargs)
+value_t fl_tablep(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("table?", nargs, 1);
-    return ishashtable(args[0]) ? FL_T : FL_F;
+    argcount(fl_ctx, "table?", nargs, 1);
+    return ishashtable(fl_ctx, args[0]) ? fl_ctx->T : fl_ctx->F;
 }
 
-static htable_t *totable(value_t v, char *fname)
+static htable_t *totable(fl_context_t *fl_ctx, value_t v, char *fname)
 {
-    if (!ishashtable(v))
-        type_error(fname, "table", v);
+    if (!ishashtable(fl_ctx, v))
+        type_error(fl_ctx, fname, "table", v);
     return (htable_t*)cv_data((cvalue_t*)ptr(v));
 }
 
-value_t fl_table(value_t *args, uint32_t nargs)
+value_t fl_table(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     size_t cnt = (size_t)nargs;
     if (cnt & 1)
-        lerror(ArgError, "table: arguments must come in pairs");
+        lerror(fl_ctx, fl_ctx->ArgError, "table: arguments must come in pairs");
     value_t nt;
     // prevent small tables from being added to finalizer list
     if (cnt <= HT_N_INLINE) {
-        tabletype->vtable->finalize = NULL;
-        nt = cvalue(tabletype, sizeof(htable_t));
-        tabletype->vtable->finalize = free_htable;
+        fl_ctx->table_vtable.finalize = NULL;
+        nt = cvalue(fl_ctx, fl_ctx->tabletype, sizeof(htable_t));
+        fl_ctx->table_vtable.finalize = free_htable;
     }
     else {
-        nt = cvalue(tabletype, 2*sizeof(void*));
+        nt = cvalue(fl_ctx, fl_ctx->tabletype, 2*sizeof(void*));
     }
     htable_t *h = (htable_t*)cv_data((cvalue_t*)ptr(nt));
     htable_new(h, cnt/2);
     uint32_t i;
-    value_t k=FL_NIL, arg=FL_NIL;
+    value_t k=fl_ctx->NIL, arg=fl_ctx->NIL;
     FOR_ARGS(i,0,arg,args) {
         if (i&1)
-            equalhash_put(h, (void*)k, (void*)arg);
+            equalhash_put_r(h, (void*)k, (void*)arg, (void*)fl_ctx);
         else
             k = arg;
     }
@@ -114,87 +109,87 @@ value_t fl_table(value_t *args, uint32_t nargs)
 }
 
 // (put! table key value)
-value_t fl_table_put(value_t *args, uint32_t nargs)
+value_t fl_table_put(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("put!", nargs, 3);
-    htable_t *h = totable(args[0], "put!");
+    argcount(fl_ctx, "put!", nargs, 3);
+    htable_t *h = totable(fl_ctx, args[0], "put!");
     void **table0 = h->table;
-    equalhash_put(h, (void*)args[1], (void*)args[2]);
+    equalhash_put_r(h, (void*)args[1], (void*)args[2], (void*)fl_ctx);
     // register finalizer if we outgrew inline space
     if (table0 == &h->_space[0] && h->table != &h->_space[0]) {
         cvalue_t *cv = (cvalue_t*)ptr(args[0]);
-        add_finalizer(cv);
+        add_finalizer(fl_ctx, cv);
         cv->len = 2*sizeof(void*);
     }
     return args[0];
 }
 
-static void key_error(char *fname, value_t key)
+static void key_error(fl_context_t *fl_ctx, char *fname, value_t key)
 {
-    lerrorf(fl_list2(KeyError, key), "%s: key not found", fname);
+    lerrorf(fl_ctx, fl_list2(fl_ctx, fl_ctx->KeyError, key), "%s: key not found", fname);
 }
 
 // (get table key [default])
-value_t fl_table_get(value_t *args, uint32_t nargs)
+value_t fl_table_get(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs != 3)
-        argcount("get", nargs, 2);
-    htable_t *h = totable(args[0], "get");
-    value_t v = (value_t)equalhash_get(h, (void*)args[1]);
+        argcount(fl_ctx, "get", nargs, 2);
+    htable_t *h = totable(fl_ctx, args[0], "get");
+    value_t v = (value_t)equalhash_get_r(h, (void*)args[1], (void*)fl_ctx);
     if (v == (value_t)HT_NOTFOUND) {
         if (nargs == 3)
             return args[2];
-        key_error("get", args[1]);
+        key_error(fl_ctx, "get", args[1]);
     }
     return v;
 }
 
 // (has? table key)
-value_t fl_table_has(value_t *args, uint32_t nargs)
+value_t fl_table_has(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("has", nargs, 2);
-    htable_t *h = totable(args[0], "has");
-    return equalhash_has(h, (void*)args[1]) ? FL_T : FL_F;
+    argcount(fl_ctx, "has", nargs, 2);
+    htable_t *h = totable(fl_ctx, args[0], "has");
+    return equalhash_has_r(h, (void*)args[1], (void*)fl_ctx) ? fl_ctx->T : fl_ctx->F;
 }
 
 // (del! table key)
-value_t fl_table_del(value_t *args, uint32_t nargs)
+value_t fl_table_del(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("del!", nargs, 2);
-    htable_t *h = totable(args[0], "del!");
-    if (!equalhash_remove(h, (void*)args[1]))
-        key_error("del!", args[1]);
+    argcount(fl_ctx, "del!", nargs, 2);
+    htable_t *h = totable(fl_ctx, args[0], "del!");
+    if (!equalhash_remove_r(h, (void*)args[1], (void*)fl_ctx))
+        key_error(fl_ctx, "del!", args[1]);
     return args[0];
 }
 
-value_t fl_table_foldl(value_t *args, uint32_t nargs)
+value_t fl_table_foldl(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
-    argcount("table.foldl", nargs, 3);
+    argcount(fl_ctx, "table.foldl", nargs, 3);
     value_t f=args[0], zero=args[1], t=args[2];
-    htable_t *h = totable(t, "table.foldl");
+    htable_t *h = totable(fl_ctx, t, "table.foldl");
     size_t i, n = h->size;
     void **table = h->table;
-    fl_gc_handle(&f);
-    fl_gc_handle(&zero);
-    fl_gc_handle(&t);
+    fl_gc_handle(fl_ctx, &f);
+    fl_gc_handle(fl_ctx, &zero);
+    fl_gc_handle(fl_ctx, &t);
     for(i=0; i < n; i+=2) {
         if (table[i+1] != HT_NOTFOUND) {
-            zero = fl_applyn(3, f,
+            zero = fl_applyn(fl_ctx, 3, f,
                              (value_t)table[i],
                              (value_t)table[i+1],
                              zero);
             // reload pointer
             h = (htable_t*)cv_data((cvalue_t*)ptr(t));
             if (h->size != n)
-                lerror(EnumerationError, "table.foldl: table modified");
+                lerror(fl_ctx, fl_ctx->EnumerationError, "table.foldl: table modified");
             table = h->table;
         }
     }
-    fl_free_gc_handles(3);
+    fl_free_gc_handles(fl_ctx, 3);
     return zero;
 }
 
-static builtinspec_t tablefunc_info[] = {
+static const builtinspec_t tablefunc_info[] = {
     { "table", fl_table },
     { "table?", fl_tablep },
     { "put!", fl_table_put },
@@ -205,12 +200,17 @@ static builtinspec_t tablefunc_info[] = {
     { NULL, NULL }
 };
 
-void table_init(void)
+void table_init(fl_context_t *fl_ctx)
 {
-    tablesym = symbol("table");
-    tabletype = define_opaque_type(tablesym, sizeof(htable_t),
-                                   &table_vtable, NULL);
-    assign_global_builtins(tablefunc_info);
+    fl_ctx->table_vtable.print = print_htable;
+    fl_ctx->table_vtable.relocate = relocate_htable;
+    fl_ctx->table_vtable.finalize = free_htable;
+    fl_ctx->table_vtable.print_traverse = print_traverse_htable;
+
+    fl_ctx->tablesym = symbol(fl_ctx, "table");
+    fl_ctx->tabletype = define_opaque_type(fl_ctx->tablesym, sizeof(htable_t),
+                                           &fl_ctx->table_vtable, NULL);
+    assign_global_builtins(fl_ctx, tablefunc_info);
 }
 
 #ifdef __cplusplus

--- a/src/flisp/types.c
+++ b/src/flisp/types.c
@@ -1,6 +1,6 @@
 #include "equalhash.h"
 
-fltype_t *get_type(value_t t)
+fltype_t *get_type(fl_context_t *fl_ctx, value_t t)
 {
     fltype_t *ft;
     if (issymbol(t)) {
@@ -8,24 +8,24 @@ fltype_t *get_type(value_t t)
         if (ft != NULL)
             return ft;
     }
-    void **bp = equalhash_bp(&TypeTable, (void*)t);
+    void **bp = equalhash_bp_r(&fl_ctx->TypeTable, (void*)t, (void*)fl_ctx);
     if (*bp != HT_NOTFOUND)
         return (fltype_t*)*bp;
 
-    int align, isarray=(iscons(t) && car_(t) == arraysym && iscons(cdr_(t)));
+    int align, isarray=(iscons(t) && car_(t) == fl_ctx->arraysym && iscons(cdr_(t)));
     size_t sz;
     if (isarray && !iscons(cdr_(cdr_(t)))) {
         // special case: incomplete array type
         sz = 0;
     }
     else {
-        sz = ctype_sizeof(t, &align);
+        sz = ctype_sizeof(fl_ctx, t, &align);
     }
 
     ft = (fltype_t*)malloc(sizeof(fltype_t));
     ft->type = t;
     if (issymbol(t)) {
-        ft->numtype = sym_to_numtype(t);
+        ft->numtype = sym_to_numtype(fl_ctx, t);
         ((symbol_t*)ptr(t))->type = ft;
     }
     else {
@@ -40,10 +40,10 @@ fltype_t *get_type(value_t t)
     ft->init = NULL;
     if (iscons(t)) {
         if (isarray) {
-            fltype_t *eltype = get_type(car_(cdr_(t)));
+            fltype_t *eltype = get_type(fl_ctx, car_(cdr_(t)));
             if (eltype->size == 0) {
                 free(ft);
-                lerror(ArgError, "invalid array element type");
+                lerror(fl_ctx, fl_ctx->ArgError, "invalid array element type");
             }
             ft->elsz = eltype->size;
             ft->eltype = eltype;
@@ -55,15 +55,15 @@ fltype_t *get_type(value_t t)
     return ft;
 }
 
-fltype_t *get_array_type(value_t eltype)
+fltype_t *get_array_type(fl_context_t *fl_ctx, value_t eltype)
 {
-    fltype_t *et = get_type(eltype);
+    fltype_t *et = get_type(fl_ctx, eltype);
     if (et->artype != NULL)
         return et->artype;
-    return get_type(fl_list2(arraysym, eltype));
+    return get_type(fl_ctx, fl_list2(fl_ctx, fl_ctx->arraysym, eltype));
 }
 
-fltype_t *define_opaque_type(value_t sym, size_t sz, cvtable_t *vtab,
+fltype_t *define_opaque_type(value_t sym, size_t sz, const cvtable_t *vtab,
                              cvinitfunc_t init)
 {
     fltype_t *ft = (fltype_t*)malloc(sizeof(fltype_t));
@@ -79,14 +79,14 @@ fltype_t *define_opaque_type(value_t sym, size_t sz, cvtable_t *vtab,
     return ft;
 }
 
-void relocate_typetable(void)
+void relocate_typetable(fl_context_t *fl_ctx)
 {
-    htable_t *h = &TypeTable;
+    htable_t *h = &fl_ctx->TypeTable;
     size_t i;
     void *nv;
     for(i=0; i < h->size; i+=2) {
         if (h->table[i] != HT_NOTFOUND) {
-            nv = (void*)relocate((value_t)h->table[i]);
+            nv = (void*)relocate(fl_ctx, (value_t)h->table[i]);
             h->table[i] = nv;
             if (h->table[i+1] != HT_NOTFOUND)
                 ((fltype_t*)h->table[i+1])->type = (value_t)nv;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -167,13 +167,13 @@ void jl_add_method(jl_function_t *gf, jl_tupletype_t *types, jl_function_t *meth
                    jl_svec_t *tvars, int8_t isstaged);
 jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
-int jl_start_parsing_file(const char *fname);
-void jl_stop_parsing(void);
-jl_value_t *jl_parse_next(void);
+void *jl_start_parsing_file(const char *fname);
+void jl_stop_parsing(void *ctx);
+jl_value_t *jl_parse_next(void *ctx);
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
 void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
-jl_value_t *jl_parse_eval_all(const char *fname, size_t len);
+jl_value_t *jl_parse_eval_all(const char *fname, size_t len, void *ctx);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
 jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
                                              jl_value_t **loc, size_t nl);

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -33,6 +33,14 @@ int HTNAME##_has(htable_t *h, void *key);                       \
 int HTNAME##_remove(htable_t *h, void *key);                    \
 void **HTNAME##_bp(htable_t *h, void *key);
 
+#define HTPROT_R(HTNAME)                                                \
+void *HTNAME##_get_r(htable_t *h, void *key, void *ctx);                \
+void HTNAME##_put_r(htable_t *h, void *key, void *val, void *ctx);      \
+void HTNAME##_adjoin_r(htable_t *h, void *key, void *val, void *ctx);   \
+int HTNAME##_has_r(htable_t *h, void *key, void *ctx);                  \
+int HTNAME##_remove_r(htable_t *h, void *key, void *ctx);               \
+void **HTNAME##_bp_r(htable_t *h, void *key, void *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/support/htable.inc
+++ b/src/support/htable.inc
@@ -9,8 +9,8 @@
 // compute empirical max-probe for a given size
 #define max_probe(size) ((size)<=(HT_N_INLINE*2) ? (HT_N_INLINE/2) : (size)>>3)
 
-#define HTIMPL(HTNAME, HFUNC, EQFUNC)                                   \
-static void **HTNAME##_lookup_bp(htable_t *h, void *key)                \
+#define _HTIMPL_EX(HTNAME, HFUNC, EQFUNC, _STATIC)                      \
+static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
 {                                                                       \
     uint_t hv;                                                          \
     size_t i, orig, index, iter;                                        \
@@ -19,7 +19,7 @@ static void **HTNAME##_lookup_bp(htable_t *h, void *key)                \
     void **tab = h->table;                                              \
     void **ol;                                                          \
                                                                         \
-    hv = HFUNC((uptrint_t)key);                                         \
+    hv = HFUNC((uptrint_t)key, ctx);                                    \
  retry_bp:                                                              \
     iter = 0;                                                           \
     index = (index_t)(hv & (sz-1)) * 2;                                 \
@@ -32,7 +32,7 @@ static void **HTNAME##_lookup_bp(htable_t *h, void *key)                \
             return &tab[index+1];                                       \
         }                                                               \
                                                                         \
-        if (EQFUNC(key, tab[index]))                                    \
+        if (EQFUNC(key, tab[index], ctx))                               \
             return &tab[index+1];                                       \
                                                                         \
         index = (index+2) & (sz-1);                                     \
@@ -63,7 +63,7 @@ static void **HTNAME##_lookup_bp(htable_t *h, void *key)                \
     h->size = newsz;                                                    \
     for(i=0; i < sz; i+=2) {                                            \
         if (ol[i+1] != HT_NOTFOUND) {                                   \
-            (*HTNAME##_lookup_bp(h, ol[i])) = ol[i+1];                  \
+            (*HTNAME##_lookup_bp_r(h, ol[i], ctx)) = ol[i+1];           \
         }                                                               \
     }                                                                   \
     if (ol != &h->_space[0])                                            \
@@ -78,26 +78,26 @@ static void **HTNAME##_lookup_bp(htable_t *h, void *key)                \
     return NULL;                                                        \
 }                                                                       \
                                                                         \
-void HTNAME##_put(htable_t *h, void *key, void *val)                    \
+_STATIC void HTNAME##_put_r(htable_t *h, void *key, void *val, void *ctx) \
 {                                                                       \
-    void **bp = HTNAME##_lookup_bp(h, key);                             \
+    void **bp = HTNAME##_lookup_bp_r(h, key, ctx);                      \
                                                                         \
     *bp = val;                                                          \
 }                                                                       \
                                                                         \
-void **HTNAME##_bp(htable_t *h, void *key)                              \
+_STATIC void **HTNAME##_bp_r(htable_t *h, void *key, void *ctx)         \
 {                                                                       \
-    return HTNAME##_lookup_bp(h, key);                                  \
+    return HTNAME##_lookup_bp_r(h, key, ctx);                           \
 }                                                                       \
                                                                         \
 /* returns bp if key is in hash, otherwise NULL */                      \
 /* if return is non-NULL and *bp == HT_NOTFOUND then key was deleted */ \
-static void **HTNAME##_peek_bp(htable_t *h, void *key)                  \
+static void **HTNAME##_peek_bp_r(htable_t *h, void *key, void *ctx)     \
 {                                                                       \
     size_t sz = hash_size(h);                                           \
     size_t maxprobe = max_probe(sz);                                    \
     void **tab = h->table;                                              \
-    size_t index = (index_t)(HFUNC((uptrint_t)key) & (sz-1)) * 2;       \
+    size_t index = (index_t)(HFUNC((uptrint_t)key, ctx) & (sz-1)) * 2;  \
     sz *= 2;                                                            \
     size_t orig = index;                                                \
     size_t iter = 0;                                                    \
@@ -105,7 +105,7 @@ static void **HTNAME##_peek_bp(htable_t *h, void *key)                  \
     do {                                                                \
         if (tab[index] == HT_NOTFOUND)                                  \
             return NULL;                                                \
-        if (EQFUNC(key, tab[index]))                                    \
+        if (EQFUNC(key, tab[index], ctx))                               \
             return &tab[index+1];                                       \
                                                                         \
         index = (index+2) & (sz-1);                                     \
@@ -117,22 +117,22 @@ static void **HTNAME##_peek_bp(htable_t *h, void *key)                  \
     return NULL;                                                        \
 }                                                                       \
                                                                         \
-void *HTNAME##_get(htable_t *h, void *key)                              \
+_STATIC void *HTNAME##_get_r(htable_t *h, void *key, void *ctx)         \
 {                                                                       \
-    void **bp = HTNAME##_peek_bp(h, key);                               \
+    void **bp = HTNAME##_peek_bp_r(h, key, ctx);                        \
     if (bp == NULL)                                                     \
         return HT_NOTFOUND;                                             \
     return *bp;                                                         \
 }                                                                       \
                                                                         \
-int HTNAME##_has(htable_t *h, void *key)                                \
+_STATIC int HTNAME##_has_r(htable_t *h, void *key, void *ctx)           \
 {                                                                       \
-    return (HTNAME##_get(h,key) != HT_NOTFOUND);                        \
+    return (HTNAME##_get_r(h, key, ctx) != HT_NOTFOUND);                \
 }                                                                       \
                                                                         \
-int HTNAME##_remove(htable_t *h, void *key)                             \
+_STATIC int HTNAME##_remove_r(htable_t *h, void *key, void *ctx)        \
 {                                                                       \
-    void **bp = HTNAME##_peek_bp(h, key);                               \
+    void **bp = HTNAME##_peek_bp_r(h, key, ctx);                        \
     if (bp != NULL) {                                                   \
         *bp = HT_NOTFOUND;                                              \
         return 1;                                                       \
@@ -140,9 +140,56 @@ int HTNAME##_remove(htable_t *h, void *key)                             \
     return 0;                                                           \
 }                                                                       \
                                                                         \
-void HTNAME##_adjoin(htable_t *h, void *key, void *val)                 \
+_STATIC void HTNAME##_adjoin_r(htable_t *h, void *key, void *val, void *ctx) \
 {                                                                       \
-    void **bp = HTNAME##_lookup_bp(h, key);                             \
+    void **bp = HTNAME##_lookup_bp_r(h, key, ctx);                      \
     if (*bp == HT_NOTFOUND)                                             \
         *bp = val;                                                      \
 }
+
+#define HTIMPL(HTNAME, HFUNC, EQFUNC)                                   \
+static uint_t HTNAME##_hfunc_wrapper(uptrint_t key, void *ctx)          \
+{                                                                       \
+    (void)ctx;                                                          \
+    return HFUNC(key);                                                  \
+}                                                                       \
+                                                                        \
+static uint_t HTNAME##_eqfunc_wrapper(void *key1, void *key2, void *ctx) \
+{                                                                       \
+    (void)ctx;                                                          \
+    return EQFUNC(key1, key2);                                          \
+}                                                                       \
+                                                                        \
+_HTIMPL_EX(HTNAME, HTNAME##_hfunc_wrapper, HTNAME##_eqfunc_wrapper, static) \
+                                                                        \
+void HTNAME##_put(htable_t *h, void *key, void *val)                    \
+{                                                                       \
+    HTNAME##_put_r(h, key, val, NULL);                                  \
+}                                                                       \
+                                                                        \
+void **HTNAME##_bp(htable_t *h, void *key)                              \
+{                                                                       \
+    return HTNAME##_bp_r(h, key, NULL);                                 \
+}                                                                       \
+                                                                        \
+void *HTNAME##_get(htable_t *h, void *key)                              \
+{                                                                       \
+    return HTNAME##_get_r(h, key, NULL);                                \
+}                                                                       \
+                                                                        \
+int HTNAME##_has(htable_t *h, void *key)                                \
+{                                                                       \
+    return HTNAME##_has_r(h, key, NULL);                                \
+}                                                                       \
+                                                                        \
+int HTNAME##_remove(htable_t *h, void *key)                             \
+{                                                                       \
+    return HTNAME##_remove_r(h, key, NULL);                             \
+}                                                                       \
+                                                                        \
+void HTNAME##_adjoin(htable_t *h, void *key, void *val)                 \
+{                                                                       \
+    return HTNAME##_adjoin_r(h, key, val, NULL);                        \
+}
+
+#define HTIMPL_R(HTNAME, HFUNC, EQFUNC) _HTIMPL_EX(HTNAME, HFUNC, EQFUNC, )


### PR DESCRIPTION
This wrap ~~most~~ all of the flisp states (~~there's a few static buffers that I didn't wrap so this dosn't make flisp completely thread safe~~ all wrapped now) in a struct and switch the context when different tasks/threads want to run the parser.

I've come to the conclusion that we have to do this since we have a few places that need to maintain the flisp states while executing arbitrary julia code. This not only include macro expansions (which we can kind of deal with in an ugly way by not allowing task switches or threads/locks) but also `jl_parse_eval_all` which is used by `jl_load` and not allowing task switches there basically means not allowing it anywhere. Moreover, this is also the only way I can think of to make the parser thread safe without dead lock.

The context manage for the parser/flisp currently create new context on demand and saves the used context in a free list so the only case we need to instantiate multiple instances of flisp is when the user code actually need them (i.e. in all the cases that currently segfault).

Things that can be improved.
1. The flisp contexts are never freed. Mainly because I didn't find a way to do that. (Ref https://github.com/JuliaLang/julia/issues/13540)
2. ~~We keep two static copy of the flisp context (since julia keeps a few more states) We could save one of them by moving that to the flisp main function instead.~~ Done

Fix #14354 
@JeffBezanson 
