### PR TITLE
Correct auto-detected CPU type for Raspberry Pi

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -296,6 +296,12 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
     Triple TheTriple(Triple::normalize(TripleName));
 
     std::string MCPU = sys::getHostCPUName();
+#ifdef _CPU_ARM_
+    // The Raspberry Pi CPU is misdetected by LLVM (at least of version
+    // 3.6); correct this.
+    if (MCPU == "arm1176jz-s")
+        MCPU = "arm1176jzf-s";
+#endif
     SubtargetFeatures Features;
     Features.getDefaultSubtargetFeatures(TheTriple);
 


### PR DESCRIPTION
The Raspberry Pi CPU is misdetected by LLVM, which means that hardware floating point instructions are not disassembled properly. `codegen.cpp` already has a work-around for this problem, explicitly enabling hardware floating point instructions on ARM systems. This patch is the counterpart for disassembling code.
