### PR TITLE
Support rook-pivoting in bkfact

### DIFF
--- a/test/linalg/bunchkaufman.jl
+++ b/test/linalg/bunchkaufman.jl
@@ -38,18 +38,22 @@ debug && println("(Automatic) Bunch-Kaufman factor of indefinite matrix")
         bc1 = factorize(asym)
         @test_approx_eq inv(bc1) * asym eye(n)
         @test_approx_eq_eps asym * (bc1\b) b 1000ε
-        @test_approx_eq inv(bkfact(a.' + a)) * (a.' + a) eye(n)
-        @test size(bc1) == size(bc1.LD)
-        @test size(bc1,1) == size(bc1.LD,1)
-        @test size(bc1,2) == size(bc1.LD,2)
-        if eltya <: BlasReal
-            @test_throws ArgumentError bkfact(a)
+        for rook in (false, true)
+            @test_approx_eq inv(bkfact(a.' + a, :U, true, rook)) * (a.' + a) eye(n)
+            @test size(bc1) == size(bc1.LD)
+            @test size(bc1,1) == size(bc1.LD,1)
+            @test size(bc1,2) == size(bc1.LD,2)
+            if eltya <: BlasReal
+                @test_throws ArgumentError bkfact(a)
+            end
         end
 debug && println("Bunch-Kaufman factors of a pos-def matrix")
-        bc2 = bkfact(apd)
-        @test_approx_eq inv(bc2) * apd eye(n)
-        @test_approx_eq_eps apd * (bc2\b) b 150000ε
-        @test ishermitian(bc2) == !issym(bc2)
+        for rook in (false, true)
+            bc2 = bkfact(apd, :U, issym(apd), rook)
+            @test_approx_eq inv(bc2) * apd eye(n)
+            @test_approx_eq_eps apd * (bc2\b) b 150000ε
+            @test ishermitian(bc2) == !issym(bc2)
+        end
 
     end
 end

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -322,6 +322,16 @@ for elty in (Float32, Float64, Complex64, Complex128)
     @test LAPACK.sytrf!('U',zeros(elty,0,0)) == (zeros(elty,0,0),zeros(BlasInt,0))
 end
 
+for elty in (Float32, Float64, Complex64, Complex128)
+    A = rand(elty,10,10)
+    A = A + A.' #symmetric!
+    B = copy(A)
+    B,ipiv = LAPACK.sytrf_rook!('U',B)
+    @test_approx_eq triu(inv(A)) triu(LAPACK.sytri_rook!('U',B,ipiv))
+    @test_throws DimensionMismatch LAPACK.sytrs_rook!('U',B,ipiv,rand(elty,11,5))
+    @test LAPACK.sytrf_rook!('U',zeros(elty,0,0)) == (zeros(elty,0,0),zeros(BlasInt,0))
+end
+
 # hetrs
 for elty in (Complex64, Complex128)
     A = rand(elty,10,10)


### PR DESCRIPTION
LAPACK 3.5 supports alternative [rook-pivoting algorithms](http://www.netlib.org/lapack/improvement.html) for Bunch-Kaufman. This PR wraps this functionality.

Best reviewed with `?w=1` appended to the URL.
