### PR TITLE
Limit the maximum memory on AppVeyor since we have 4 processes now.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
   matrix:
   - ARCH: "i686"
   - ARCH: "x86_64"
+    JULIA_TEST_MAXRSS_MB: 480
 
 # Only build on master and PR's for now, not personal branches
 # Whether or not PR's get built is determined in the webhook settings


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/14393#issuecomment-164306415

There are somehow 4 cores instead of 2 cores on AppVeyor now and that put us really close to the memory limit. Since the test time seems to be shorter by 30% (~30min to ~20min) when it doesn't segfault or hang, I think it's better if we keep the number of processes and limit their memory consumption. (Of course the even better solution would be getting more memory, increasing from 2.4G to 3.5-4G should be enough). It would also be nice if we could print the memory status and if the tests don't hang when a subprocess is killed due to OOM/segfault.
