### PR TITLE
allow A_ldiv_B! specialization in generic triangular solves

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -204,8 +204,8 @@ end
 
 #Linear solvers
 A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(A, b)
-At_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(transpose(A), b)
-Ac_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(ctranspose(A), b)
+At_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(transpose(A), b)
+Ac_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(ctranspose(A), b)
 function A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, B::AbstractMatrix)
     nA,mA = size(A)
     tmp = similar(B,size(B,1))


### PR DESCRIPTION
In 53978e7f4b5d216e51fd3a0ab82029ce54e1eef2/base/linalg/bidiag.jl#L206-L208, generic methods for `A(t|c)_ldiv_B!` directly call `naivesub!` for `A_ldiv_B!` functionality:

``` julia
A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(A, b)
At_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(transpose(A), b)
Ac_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(ctranspose(A), b)
```

This PR simply replaces the relevant `naivesub!` calls with `A_ldiv_B!`,

``` julia
A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(A, b)
At_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(transpose(A), b)
Ac_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(ctranspose(A), b)
```

which gives dispatch a chance to find better methods than `naivesub!`. Impact:

``` julia
# setup
ml, ms = 10000, 1000;
bo, Bo = rand(ml), rand(ms, ms);
As = eye(ms) + randn(ms, ms)/(2ms);
Al = eye(ml) + randn(ml, ml)/(2ml);
ltAs = LowerTriangular(As);
ltAl = LowerTriangular(Al);
```

Without PR:

``` julia
# warmup hidden
julia> B = copy(Bo);
julia> @time Base.LinAlg.At_ldiv_B!(ltAs, B);
    8.259813 seconds (6.00 k allocations: 7.451 GB, 10.34% gc time)
julia> b = copy(bo);
julia> @time Base.LinAlg.At_ldiv_B!(ltAl, b);
    1.412599 seconds (10 allocations: 762.940 MB, 4.28% gc time)
```

With PR:

``` julia
# warmup hidden
julia> B = copy(Bo);
julia> @time Base.LinAlg.At_ldiv_B!(ltAs, B);
    5.691988 seconds (7.00 k allocations: 7.451 GB, 14.62% gc time)
julia> b = copy(bo);
julia> @time Base.LinAlg.At_ldiv_B!(ltAl, b);
    0.691178 seconds (57 allocations: 762.942 MB, 0.53% gc time)
```

Best!
