### PR TITLE
Fix exception being thrown when a binding is not defined

### DIFF
--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -5,7 +5,15 @@ export @var
 immutable Binding
     mod::Module
     var::Symbol
-    Binding(m, v) = new(Base.which_module(m, v), v)
+    defined::Bool
+
+    function Binding(m, v)
+        if !isdefined(m, v)
+            new(m, v, false)
+        else
+            new(Base.binding_module(m, v), v, true)
+        end
+    end
 end
 
 function splitexpr(x::Expr)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -497,6 +497,12 @@ undocumented(x,y) = 3
 
 end
 
+@test docstrings_equal(@doc(Undocumented.bindingdoesnotexist), doc"""
+No documentation found.
+
+Binding `Undocumented.bindingdoesnotexist` does not exist.
+""")
+
 @test docstrings_equal(@doc(Undocumented.A), doc"""
 No documentation found.
 
@@ -577,12 +583,14 @@ end
 import Base.Docs: @var, Binding
 
 let x = Binding(Base, symbol("@time"))
+    @test x.defined == true
     @test @var(@time) == x
     @test @var(Base.@time) == x
     @test @var(Base.Pkg.@time) == x
 end
 
 let x = Binding(Base.LinAlg, :norm)
+    @test x.defined == true
     @test @var(norm) == x
     @test @var(Base.norm) == x
     @test @var(Base.LinAlg.norm) == x
@@ -590,6 +598,7 @@ let x = Binding(Base.LinAlg, :norm)
 end
 
 let x = Binding(Core, :Int)
+    @test x.defined == true
     @test @var(Int) == x
     @test @var(Base.Int) == x
     @test @var(Core.Int) == x
@@ -597,12 +606,24 @@ let x = Binding(Core, :Int)
 end
 
 let x = Binding(Base, :Pkg)
+    @test x.defined == true
     @test @var(Pkg) == x
     @test @var(Base.Pkg) == x
     @test @var(Main.Pkg) == x
 end
 
 let x = Binding(Base, :VERSION)
+    @test x.defined == true
     @test @var(VERSION) == x
     @test @var(Base.VERSION) == x
+end
+
+let x = Binding(Base, :bindingdoesnotexist)
+    @test x.defined == false
+    @test @var(Base.bindingdoesnotexist) == x
+end
+
+let x = Binding(Main, :bindingdoesnotexist)
+    @test x.defined == false
+    @test @var(bindingdoesnotexist) == x
 end


### PR DESCRIPTION
This fixes `help> iamnotdefined` error being propagated after
macroexpansion of the `@var` binding macro

I believe we do not explicitly store bindings that do not exist so this
should be safe.

Before:

```
help?> foo
search: floor ifloor pointer_from_objref OverflowError RoundFromZero FileMonitor functionloc functionlocs

Couldn't find foo
Perhaps you meant for, floor, fdio, fd, fft, fld, fma, eof, Bool, bool, cor, cos, cot, cov, dot, log, mod, now or rol
ERROR: "foo" is not defined in module Main
 in error at /usr/local/Cellar/julia/0.4.1/lib/julia/sys.dylib
 in which_module at /usr/local/Cellar/julia/0.4.1/lib/julia/sys.dylib
 in call at /usr/local/Cellar/julia/0.4.1/lib/julia/sys.dylib
```

After:

```
help?> foo
search: floor ifloor pointer_from_objref OverflowError RoundFromZero FileMonitor functionloc functionlocs

Couldn't find foo
Perhaps you meant for, floor, fdio, fd, fft, fld, fma, eof, Bool, bool, cor, cos, cot, cov, dot, log, mod, now or rol
  No documentation found.

  Binding foo does not exist.
```
