### PR TITLE
fix #14009; check for types growing due to recursion and widen them

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -3586,3 +3586,13 @@ function __f_isa_arg_1()
     length(a)
 end
 @test __f_isa_arg_1() == 1
+
+# non-terminating inference, issue #14009
+type A14009{T}; end
+A14009{T}(a::T) = A14009{T}()
+f14009(a) = rand(Bool) ? f14009(A14009(a)) : a
+code_typed(f14009, (Int,))
+
+type B14009{T}; end
+g14009(a) = g14009(B14009{a})
+code_typed(g14009, (Type{Int},))


### PR DESCRIPTION
This is an alternative to #14059 that should be a bit more optimistic.
