### PR TITLE
improve quantile: reduce allocations, use partial sort

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,10 @@ Library improvements
     (to alter Windows command-line generation) and `windows_hide` (to
     suppress creation of new console windows) ([#13780]).
 
+  * Statistics:
+
+    * Improve performance of `quantile` ([#14413]).
+
 Deprecated or removed
 ---------------------
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2451,13 +2451,6 @@ Like `mapreduce(f, op, v0, itr)`. In general, this cannot be used with empty col
 mapreduce(f, op, itr)
 
 """
-    quantile!(v, p)
-
-Like `quantile`, but overwrites the input vector.
-"""
-quantile!
-
-"""
     accept(server[,client])
 
 Accepts a connection on the given server and returns a connection to the client. An

--- a/base/float.jl
+++ b/base/float.jl
@@ -120,6 +120,10 @@ convert(::Type{AbstractFloat}, x::UInt128) = convert(Float64, x) # LOSSY
 
 float(x) = convert(AbstractFloat, x)
 
+# for constructing arrays
+float{T<:Number}(::Type{T}) = typeof(float(zero(T)))
+float{T}(::Type{T}) = Any
+
 for Ti in (Int8, Int16, Int32, Int64)
     @eval begin
         unsafe_trunc(::Type{$Ti}, x::Float32) = box($Ti,fptosi($Ti,unbox(Float32,x)))

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1753,23 +1753,29 @@ Statistics
 
    Compute the midpoints of the bins with edges ``e``\ . The result is a vector/range of length ``length(e) - 1``\ . Note: Julia does not ignore ``NaN`` values in the computation.
 
-.. function:: quantile(v, ps)
+.. function:: quantile(v, p; sorted=false)
 
    .. Docstring generated from Julia source
 
-   Compute the quantiles of a vector ``v`` at a specified set of probability values ``ps``\ . Note: Julia does not ignore ``NaN`` values in the computation.
+   Compute the quantile(s) of a vector ``v`` at a specified probability or vector ``p``\ . The keyword argument ``sorted`` indicates whether ``v`` can be assumed to be sorted.
 
-.. function:: quantile(v, p)
+   The ``p`` should be on the interval [0,1], and ``v`` should not have any ``NaN`` values.
+
+   Quantiles are computed via linear interpolation between the points ``((k-1)/(n-1), v[k])``\ , for ``k = 1:n`` where ``n = length(v)``\ . This corresponds to Definition 7 of Hyndman and Fan (1996), and is the same as the R default.
+
+   * Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",   *The American Statistician*, Vol. 50, No. 4, pp. 361-365
+
+.. function:: quantile!([q, ] v, p; sorted=false)
 
    .. Docstring generated from Julia source
 
-   Compute the quantile of a vector ``v`` at the probability ``p``\ . Note: Julia does not ignore ``NaN`` values in the computation.
+   Compute the quantile(s) of a vector ``v`` at the probabilities ``p``\ , with optional output into array ``q`` (if not provided, a new output array is created). The keyword argument ``sorted`` indicates whether ``v`` can be assumed to be sorted; if ``false`` (the default), then the elements of ``v`` may be partially sorted.
 
-.. function:: quantile!(v, p)
+   The elements of ``p`` should be on the interval [0,1], and ``v`` should not have any ``NaN`` values.
 
-   .. Docstring generated from Julia source
+   Quantiles are computed via linear interpolation between the points ``((k-1)/(n-1), v[k])``\ , for ``k = 1:n`` where ``n = length(v)``\ . This corresponds to Definition 7 of Hyndman and Fan (1996), and is the same as the R default.
 
-   Like ``quantile``\ , but overwrites the input vector.
+   * Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",   *The American Statistician*, Vol. 50, No. 4, pp. 361-365
 
 .. function:: cov(x[, corrected=true])
 

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -319,8 +319,12 @@ end
 @test midpoints(Float64[1.0:1.0:10.0;]) == Float64[1.5:1.0:9.5;]
 
 @test quantile([1,2,3,4],0.5) == 2.5
+@test quantile([1,2,3,4],[0.5]) == [2.5]
 @test quantile([1., 3],[.25,.5,.75])[2] == median([1., 3])
-@test quantile([0.:100.;],[.1,.2,.3,.4,.5,.6,.7,.8,.9])[1] == 10.0
+@test quantile(100.0:-1.0:0.0, 0.0:0.1:1.0) == collect(0.0:10.0:100.0)
+@test quantile(0.0:100.0, 0.0:0.1:1.0, sorted=true) == collect(0.0:10.0:100.0)
+@test quantile(100f0:-1f0:0.0, 0.0:0.1:1.0) == collect(0f0:10f0:100f0)
+
 
 # test invalid hist nbins argument (#9999)
 @test_throws ArgumentError hist(Int[], -1)


### PR DESCRIPTION
This improves the performance of `quantile` by reducing allocations and using a partial sort. I see a 3x improvement for large cases.

It should be mostly non-breaking, but it does slightly change the behaviour of values outside the interval `[0,1]` (the previous version was a bit more lax), but I don't think this should prevent backporting.
