### PR TITLE
Widen small integers only to Int32, not Int

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -339,10 +339,10 @@ typemax(::Type{UInt64}) = 0xffffffffffffffff
 @eval typemin(::Type{Int128} ) = $(convert(Int128,1)<<127)
 @eval typemax(::Type{Int128} ) = $(box(Int128,unbox(UInt128,typemax(UInt128)>>1)))
 
-widen{T<:Union{Int8, Int16}}(::Type{T}) = Int
+widen{T<:Union{Int8, Int16}}(::Type{T}) = Int32
 widen(::Type{Int32}) = Int64
 widen(::Type{Int64}) = Int128
-widen{T<:Union{UInt8, UInt16}}(::Type{T}) = UInt
+widen{T<:Union{UInt8, UInt16}}(::Type{T}) = UInt32
 widen(::Type{UInt32}) = UInt64
 widen(::Type{UInt64}) = UInt128
 

--- a/test/int.jl
+++ b/test/int.jl
@@ -125,19 +125,19 @@ for T in (UInt8, UInt16, UInt32, UInt64)
     @test_throws InexactError convert(T, -1)
 end
 
-for i in 1:length(UItypes)-1
-    T = UItypes[i]
-    S = UItypes[i+1]
-    R = sizeof(S) < sizeof(UInt) ? S : UInt
-    @test widen(T(3)) == R(3)
-end
+@test widen(UInt8(3)) === UInt32(3)
+@test widen(UInt16(3)) === UInt32(3)
+@test widen(UInt32(3)) === UInt64(3)
+@test widen(UInt64(3)) === UInt128(3)
+@test widen(UInt128(3)) == 3
+@test typeof(widen(UInt128(3))) == BigInt
 
-for i in 1:length(SItypes)-1
-    T = SItypes[i]
-    S = SItypes[i+1]
-    R = sizeof(S) < sizeof(Int) ? S : Int
-    @test widen(T(3)) == R(3)
-end
+@test widen(Int8(-3)) === Int32(-3)
+@test widen(Int16(-3)) === Int32(-3)
+@test widen(Int32(-3)) === Int64(-3)
+@test widen(Int64(-3)) === Int128(-3)
+@test widen(Int128(-3)) == -3
+@test typeof(widen(Int128(-3))) == BigInt
 
 @test widemul(false, false) == false
 @test widemul(false, 3) == 0

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2471,7 +2471,7 @@ end
 # widen
 @test widen(1.5f0) === 1.5
 @test widen(Int32(42)) === Int64(42)
-@test widen(Int8) === Int
+@test widen(Int8) === Int32
 @test widen(Float32) === Float64
 ## Note: this should change to e.g. Float128 at some point
 @test widen(Float64) === BigFloat

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -33,7 +33,7 @@
 
 # sum
 
-@test sum(Int8[]) === 0
+@test sum(Int8[]) === Int32(0)
 @test sum(Int[]) === Int(0)
 @test sum(Float64[]) === 0.0
 
@@ -41,7 +41,7 @@
 @test sum(3) === 3
 @test sum(3.0) === 3.0
 
-@test sum([Int8(3)]) === 3
+@test sum([Int8(3)]) === Int32(3)
 @test sum([3]) === 3
 @test sum([3.0]) === 3.0
 
@@ -62,14 +62,14 @@ fz = float(z)
 a = randn(32) # need >16 elements to trigger BLAS code path
 b = complex(randn(32), randn(32))
 @test sumabs(Float64[]) === 0.0
-@test sumabs([Int8(-2)]) === 2
+@test sumabs([Int8(-2)]) === Int32(2)
 @test sumabs(z) === 14
 @test sumabs(fz) === 14.0
 @test_approx_eq sumabs(a) sum(abs(a))
 @test_approx_eq sumabs(b) sum(abs(b))
 
 @test sumabs2(Float64[]) === 0.0
-@test sumabs2([Int8(-2)]) === 4
+@test sumabs2([Int8(-2)]) === Int32(4)
 @test sumabs2(z) === 54
 @test sumabs2(fz) === 54.0
 @test_approx_eq sumabs2(a) sum(abs2(a))
@@ -105,11 +105,11 @@ end
 # prod
 
 @test prod(Int[]) === 1
-@test prod(Int8[]) === 1
+@test prod(Int8[]) === Int32(1)
 @test prod(Float64[]) === 1.0
 
 @test prod([3]) === 3
-@test prod([Int8(3)]) === 3
+@test prod([Int8(3)]) === Int32(3)
 @test prod([3.0]) === 3.0
 
 @test prod(z) === 120
@@ -124,8 +124,8 @@ end
 prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test prod(Int[]) === prod2(Int[]) === 1
 @test prod(Int[7]) === prod2(Int[7]) === 7
-@test typeof(prod(Int8[])) == typeof(prod(Int8[1])) == typeof(prod(Int8[1, 7])) == Int
-@test typeof(prod2(Int8[])) == typeof(prod2(Int8[1])) == typeof(prod2(Int8[1 7])) == Int
+@test typeof(prod(Int8[])) == typeof(prod(Int8[1])) == typeof(prod(Int8[1, 7])) == Int32
+@test typeof(prod2(Int8[])) == typeof(prod2(Int8[1])) == typeof(prod2(Int8[1 7])) == Int32
 
 # maximum & minimum & extrema
 


### PR DESCRIPTION
Reasons, as described in #14407:
- 32-bit integer division is significantly faster than 64-bit integer division.
- Consistency across platforms (widen(Int(8)) will do the same thing on 32 & 64 bit)
- Smaller integers can have larger gains from vectorization

Changes:
- Widen small integers only to Int32, not Int
- Ensure that `widen` tests actually check the result type, not just the value.
- Update tests.
- No documentation update necessary since the actual return type is left unspecified.

Closes #14407.
