### PR TITLE
Rename CHOLMOD.update! -> CHOLMOD.cholfact!/CHOLMOD.ldltfact!

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -32,43 +32,6 @@ tab-delimited text to `f` by either `writedlm(f, [x y])` or by `writedlm(f, zip(
 writedlm
 
 """
-    cholfact(A, [LU=:U[,pivot=Val{false}]][;tol=-1.0]) -> Cholesky
-
-Compute the Cholesky factorization of a dense symmetric positive (semi)definite matrix `A`
-and return either a `Cholesky` if `pivot==Val{false}` or `CholeskyPivoted` if
-`pivot==Val{true}`. `LU` may be `:L` for using the lower part or `:U` for the upper part.
-The default is to use `:U`. The triangular matrix can be obtained from the factorization `F`
-with: `F[:L]` and `F[:U]`. The following functions are available for `Cholesky` objects:
-`size`, `\\`, `inv`, `det`. For `CholeskyPivoted` there is also defined a `rank`. If
-`pivot==Val{false}` a `PosDefException` exception is thrown in case the matrix is not
-positive definite. The argument `tol` determines the tolerance for determining the rank. For
-negative values, the tolerance is the machine precision.
-"""
-cholfact(A, LU=:U, pivot=Val{false})
-
-"""
-    cholfact(A; shift=0, perm=Int[]) -> CHOLMOD.Factor
-
-Compute the Cholesky factorization of a sparse positive definite matrix `A`. A fill-reducing
-permutation is used. `F = cholfact(A)` is most frequently used to solve systems of equations
-with `F\\b`, but also the methods `diag`, `det`, `logdet` are defined for `F`. You can also
-extract individual factors from `F`, using `F[:L]`. However, since pivoting is on by
-default, the factorization is internally represented as `A == P'*L*L'*P` with a permutation
-matrix `P`; using just `L` without accounting for `P` will give incorrect answers. To
-include the effects of permutation, it's typically preferable to extact "combined" factors
-like `PtL = F[:PtL]` (the equivalent of `P'*L`) and `LtP = F[:UP]` (the equivalent of
-`L'*P`).
-
-Setting optional `shift` keyword argument computes the factorization of `A+shift*I` instead
-of `A`. If the `perm` argument is nonempty, it should be a permutation of `1:size(A,1)`
-giving the ordering to use (instead of CHOLMOD's default AMD ordering).
-
-The function calls the C library CHOLMOD and many other functions from the library are
-wrapped but not exported.
-"""
-cholfact(A)
-
-"""
     digamma(x)
 
 Compute the digamma function of `x` (the logarithmic derivative of `gamma(x)`)
@@ -5881,16 +5844,6 @@ given indices instead of making a copy.  Calling [`getindex`](:func:`getindex`) 
 indices to the parent array on the fly without checking bounds.
 """
 sub
-
-"""
-    cholfact!(A [,LU=:U [,pivot=Val{false}]][;tol=-1.0]) -> Cholesky
-
-`cholfact!` is the same as [`cholfact`](:func:`cholfact`), but saves space by overwriting
-the input `A`, instead of creating a copy. `cholfact!` can also reuse the symbolic
-factorization from a different matrix `F` with the same structure when used as:
-`cholfact!(F::CholmodFactor, A)`.
-"""
-cholfact!
 
 """
     expanduser(path::AbstractString) -> AbstractString

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -137,27 +137,50 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the square root of a non-negative number ``x``\ .
 
-.. function:: cholfact(A, [LU=:U[,pivot=Val{false}]][;tol=-1.0]) -> Cholesky
+.. function:: cholfact(A::StridedMatrix, uplo::Symbol, Val{false}) -> Cholesky
 
    .. Docstring generated from Julia source
 
-   Compute the Cholesky factorization of a dense symmetric positive (semi)definite matrix ``A`` and return either a ``Cholesky`` if ``pivot==Val{false}`` or ``CholeskyPivoted`` if ``pivot==Val{true}``\ . ``LU`` may be ``:L`` for using the lower part or ``:U`` for the upper part. The default is to use ``:U``\ . The triangular matrix can be obtained from the factorization ``F`` with: ``F[:L]`` and ``F[:U]``\ . The following functions are available for ``Cholesky`` objects: ``size``\ , ``\``\ , ``inv``\ , ``det``\ . For ``CholeskyPivoted`` there is also defined a ``rank``\ . If ``pivot==Val{false}`` a ``PosDefException`` exception is thrown in case the matrix is not positive definite. The argument ``tol`` determines the tolerance for determining the rank. For negative values, the tolerance is the machine precision.
+   Compute the Cholesky factorization of a dense symmetric positive definite matrix ``A`` and return a ``Cholesky`` factorization. The ``uplo`` argument may be ``:L`` for using the lower part or ``:U`` for the upper part of ``A``\ . The default is to use ``:U``\ . The triangular Cholesky factor can be obtained from the factorization ``F`` with: ``F[:L]`` and ``F[:U]``\ . The following functions are available for ``Cholesky`` objects: ``size``\ , ``, ``inv``\ , ``det``\ . A ``PosDefException`` exception is thrown in case the matrix is not positive definite.
 
-.. function:: cholfact(A; shift=0, perm=Int[]) -> CHOLMOD.Factor
+.. function:: cholfact(A::StridedMatrix, uplo::Symbol, Val{true}; tol = 0.0) -> CholeskyPivoted
 
    .. Docstring generated from Julia source
 
-   Compute the Cholesky factorization of a sparse positive definite matrix ``A``\ . A fill-reducing permutation is used. ``F = cholfact(A)`` is most frequently used to solve systems of equations with ``F\b``\ , but also the methods ``diag``\ , ``det``\ , ``logdet`` are defined for ``F``\ . You can also extract individual factors from ``F``\ , using ``F[:L]``\ . However, since pivoting is on by default, the factorization is internally represented as ``A == P'*L*L'*P`` with a permutation matrix ``P``\ ; using just ``L`` without accounting for ``P`` will give incorrect answers. To include the effects of permutation, it's typically preferable to extact "combined" factors like ``PtL = F[:PtL]`` (the equivalent of ``P'*L``\ ) and ``LtP = F[:UP]`` (the equivalent of ``L'*P``\ ).
+   Compute the pivoted Cholesky factorization of a dense symmetric positive semi-definite matrix ``A`` and return a ``CholeskyPivoted`` factorization. The ``uplo`` argument may be ``:L`` for using the lower part or ``:U`` for the upper part of ``A``\ . The default is to use ``:U``\ . The triangular Cholesky factor can be obtained from the factorization ``F`` with: ``F[:L]`` and ``F[:U]``\ . The following functions are available for ``PivotedCholesky`` objects: ``size``\ , ``, ``inv``\ , ``det``\ , and ``rank``\ . The argument ``tol`` determines the tolerance for determining the rank. For negative values, the tolerance is the machine precision.
+
+.. function:: cholfact(::Union{SparseMatrixCSC,Symmetric{Float64,SparseMatrixCSC{Flaot64,
+                  SuiteSparse_long}},Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},
+                  SuiteSparse_long}}}; shift = 0.0, perm=Int[]) -> CHOLMOD.Factor
+
+   .. Docstring generated from Julia source
+
+   Compute the Cholesky factorization of a sparse positive definite matrix ``A``\ . A fill-reducing permutation is used. ``F = cholfact(A)`` is most frequently used to solve systems of equations with ``F``\ , but also the methods ``diag``\ , ``det``\ , ``logdet`` are defined for ``F``\ . You can also extract individual factors from ``F``\ , using ``F[:L]``\ . However, since pivoting is on by default, the factorization is internally represented as ``A == P'*L*L'*P`` with a permutation matrix ``P``\ ; using just ``L`` without accounting for ``P`` will give incorrect answers. To include the effects of permutation, it's typically preferable to extact "combined" factors like ``PtL = F[:PtL]`` (the equivalent of ``P'*L``\ ) and ``LtP = F[:UP]`` (the equivalent of ``L'*P``\ ).
 
    Setting optional ``shift`` keyword argument computes the factorization of ``A+shift*I`` instead of ``A``\ . If the ``perm`` argument is nonempty, it should be a permutation of ``1:size(A,1)`` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
    The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
 
-.. function:: cholfact!(A [,LU=:U [,pivot=Val{false}]][;tol=-1.0]) -> Cholesky
+.. function:: cholfact!(F::Factor, A::Union{SparseMatrixCSC,
+              Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}},
+              Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},SuiteSparse_long}}};
+              shift = 0.0) -> CHOLMOD.Factor
 
    .. Docstring generated from Julia source
 
-   ``cholfact!`` is the same as :func:`cholfact`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy. ``cholfact!`` can also reuse the symbolic factorization from a different matrix ``F`` with the same structure when used as: ``cholfact!(F::CholmodFactor, A)``\ .
+   Compute the LDLt factorization of ``A``\ , reusing the symbolic factorization ``F``\ .
+
+.. function:: cholfact!(A::StridedMatrix, uplo::Symbol, Val{false}) -> Cholesky
+
+   .. Docstring generated from Julia source
+
+   The same as ``cholfact``\ , but saves space by overwriting the input ``A``\ , instead of creating a copy.
+
+.. function:: cholfact!(A::StridedMatrix, uplo::Symbol, Val{true}) -> PivotedCholesky
+
+   .. Docstring generated from Julia source
+
+   The same as ``cholfact``\ , but saves space by overwriting the input ``A``\ , instead of creating a copy.
 
 .. currentmodule:: Base.LinAlg
 
@@ -193,15 +216,27 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute an ``LDLt`` factorization of a real symmetric tridiagonal matrix such that ``A = L*Diagonal(d)*L'`` where ``L`` is a unit lower triangular matrix and ``d`` is a vector. The main use of an ``LDLt`` factorization ``F = ldltfact(A)`` is to solve the linear system of equations ``Ax = b`` with ``F\b``\ .
 
-.. function:: ldltfact(::Union{SparseMatrixCSC,Symmetric{Float64,SparseMatrixCSC{Flaot64,SuiteSparse_long}},Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},SuiteSparse_long}}}; shift=0, perm=Int[]) -> CHOLMOD.Factor
+.. function:: ldltfact(::Union{SparseMatrixCSC,
+                  Symmetric{Float64,SparseMatrixCSC{Flaot64,SuiteSparse_long}},
+                  Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},SuiteSparse_long}}};
+                  shift = 0.0, perm=Int[]) -> CHOLMOD.Factor
 
    .. Docstring generated from Julia source
 
-   Compute the ``LDLt`` factorization of a sparse symmetric or Hermitian matrix. A fill-reducing permutation is used. ``F = ldltfact(A)`` is most frequently used to solve systems of equations ``A*x = b`` with ``F\b``\ . The returned factorization object ``F`` also supports the methods ``diag``\ , ``det``\ , and ``logdet``\ . You can extract individual factors from ``F`` using ``F[:L]``\ . However, since pivoting is on by default, the factorization is internally represented as ``A == P'*L*D*L'*P`` with a permutation matrix ``P``\ ; using just ``L`` without accounting for ``P`` will give incorrect answers. To include the effects of permutation, it's typically preferable to extact "combined" factors like ``PtL = F[:PtL]`` (the equivalent of ``P'*L``\ ) and ``LtP = F[:UP]`` (the equivalent of ``L'*P``\ ). The complete list of supported factors is ``:L, :PtL, :D, :UP, :U, :LD, :DU, :PtLD, :DUP``\ .
+   Compute the ``LDLt`` factorization of a sparse symmetric or Hermitian matrix. A fill-reducing permutation is used. ``F = ldltfact(A)`` is most frequently used to solve systems of equations ``A*x = b`` with ``F``\ . The returned factorization object ``F`` also supports the methods ``diag``\ , ``det``\ , and ``logdet``\ . You can extract individual factors from ``F`` using ``F[:L]``\ . However, since pivoting is on by default, the factorization is internally represented as ``A == P'*L*D*L'*P`` with a permutation matrix ``P``\ ; using just ``L`` without accounting for ``P`` will give incorrect answers. To include the effects of permutation, it's typically preferable to extact "combined" factors like ``PtL = F[:PtL]`` (the equivalent of ``P'*L``\ ) and ``LtP = F[:UP]`` (the equivalent of ``L'*P``\ ). The complete list of supported factors is ``:L, :PtL, :D, :UP, :U, :LD, :DU, :PtLD, :DUP``\ .
 
    Setting optional ``shift`` keyword argument computes the factorization of ``A+shift*I`` instead of ``A``\ . If the ``perm`` argument is nonempty, it should be a permutation of ``1:size(A,1)`` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
    The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
+
+.. function:: ldltfact!(F::Factor, A::Union{SparseMatrixCSC,
+                  Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}},
+                  Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},SuiteSparse_long}}};
+                  shift = 0.0) -> CHOLMOD.Factor
+
+   .. Docstring generated from Julia source
+
+   Compute the LDLt factorization of ``A``\ , reusing the symbolic factorization ``F``\ .
 
 .. function:: ldltfact!(::SymTridiagonal) -> LDLt
 

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -409,27 +409,27 @@ for elty in (Float64, Complex{Float64})
         @test F1 == F2
     end
 
-    ### update!
+    ### cholfact!/ldltfact!
     F = cholfact(A1pd)
     CHOLMOD.change_factor!(elty, false, false, true, true, F)
     @test unsafe_load(F.p).is_ll == 0
     CHOLMOD.change_factor!(elty, true, false, true, true, F)
-    @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
+    @test_approx_eq CHOLMOD.Sparse(cholfact!(copy(F), A1pd)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
     @test size(F, 2) == 5
     @test size(F, 3) == 1
     @test_throws ArgumentError size(F, 0)
 
     F = cholfact(A1pdSparse, shift=2)
     @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
-    @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
+    @test_approx_eq CHOLMOD.Sparse(cholfact!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     F = ldltfact(A1pd)
     @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
-    @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
+    @test_approx_eq CHOLMOD.Sparse(ldltfact!(copy(F), A1pd)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     F = ldltfact(A1pdSparse, shift=2)
     @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
-    @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
+    @test_approx_eq CHOLMOD.Sparse(ldltfact!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     @test isa(CHOLMOD.factor_to_sparse!(F), CHOLMOD.Sparse)
     @test_throws CHOLMOD.CHOLMODException CHOLMOD.factor_to_sparse!(F)


### PR DESCRIPTION
This can be considered a reversion of a renaming of `cholmod!` that I made in the spring. At that time I split `cholfact(SparseMatrixCSC)` into `chofact` and `ldltfact` and thought it would be a good idea to have a generic function for reusing the symbolic factorization.

In practice, I don't think it is important to have a generic function for this and we are now using `LinAlg.update!` for rank updates of matrices/factorizations so a renaming was necessary.

This also moves the cholfact documentation to the source.
