### PR TITLE
fix arguments to mklink when executing within msys2

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1995,7 +1995,7 @@ $(VIRTUALENV_SOURCE): $(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER).tar.gz
 $(VIRTUALENV_TARGET): $(VIRTUALENV_SOURCE)
 	"$(shell $(SRCDIR)/find_python2)" $< $@
 ifeq ($(BUILD_OS), WINNT)
-	-[ -e $@/Scripts ] && ! [ -e $@/bin ] && cmd //C mklink //J $@\\bin $@\\Scripts
+	-[ -e $@/Scripts ] && ! [ -e $@/bin ] && cmd //C mklink //J `echo $@/bin $@/Scripts | sed -e 's#/#\\\\#g'`
 endif
 	touch -c $@
 


### PR DESCRIPTION
Brute force converts all occurrences of `/` with `\` when calling mklink.  fixes #13206 
