### PR TITLE
Avoid expensive try-catch for Int128 division

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -376,46 +376,22 @@ if WORD_SIZE == 32
     end
 
     function div(x::Int128, y::Int128)
-        try
-            Int128(div(BigInt(x),BigInt(y)))
-        catch e
-            isa(e, InexactError) && throw(DivideError())
-            rethrow()
-        end
+        (x == typemin(Int128)) & (y == -1) && throw(DivideError())
+        Int128(div(BigInt(x),BigInt(y)))
     end
     function div(x::UInt128, y::UInt128)
-        try
-            UInt128(div(BigInt(x),BigInt(y)))
-        catch e
-            isa(e, InexactError) && throw(DivideError())
-            rethrow()
-        end
+        UInt128(div(BigInt(x),BigInt(y)))
     end
 
     function rem(x::Int128, y::Int128)
-        try
-            Int128(rem(BigInt(x),BigInt(y)))
-        catch e
-            isa(e, InexactError) && throw(DivideError())
-            rethrow()
-        end
+        Int128(rem(BigInt(x),BigInt(y)))
     end
     function rem(x::UInt128, y::UInt128)
-        try
-            UInt128(rem(BigInt(x),BigInt(y)))
-        catch e
-            isa(e, InexactError) && throw(DivideError())
-            rethrow()
-        end
+        UInt128(rem(BigInt(x),BigInt(y)))
     end
 
     function mod(x::Int128, y::Int128)
-        try
-            Int128(mod(BigInt(x),BigInt(y)))
-        catch e
-            isa(e, InexactError) && throw(DivideError())
-            rethrow()
-        end
+        Int128(mod(BigInt(x),BigInt(y)))
     end
 
     <<( x::Int128,  y::Int) = y == 0 ? x : box(Int128,shl_int(unbox(Int128,x),unbox(Int,y)))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1593,6 +1593,22 @@ end
 @test signed(cld(typemax(UInt),typemin(Int)>>1))     == -3
 @test signed(cld(typemax(UInt),(typemin(Int)>>1)+1)) == -4
 
+# Test exceptions and special cases
+for T in (Int8,Int16,Int32,Int64,Int128, UInt8,UInt16,UInt32,UInt64,UInt128)
+    @test_throws DivideError div(T(1), T(0))
+    @test_throws DivideError fld(T(1), T(0))
+    @test_throws DivideError cld(T(1), T(0))
+    @test_throws DivideError rem(T(1), T(0))
+    @test_throws DivideError mod(T(1), T(0))
+end
+for T in (Int8,Int16,Int32,Int64,Int128)
+    @test_throws DivideError div(typemin(T), T(-1))
+    @test_throws DivideError fld(typemin(T), T(-1))
+    @test_throws DivideError cld(typemin(T), T(-1))
+    @test rem(typemin(T), T(-1)) === T(0)
+    @test mod(typemin(T), T(-1)) === T(0)
+end
+
 # Test return types
 for T in (Int8,Int16,Int32,Int64,Int128, UInt8,UInt16,UInt32,UInt64,UInt128)
     z, o = T(0), T(1)


### PR DESCRIPTION
@JeffBezanson says that an explicit check is cheaper than a try-catch statement.

The other cases cannot overflow, so the try-catch construct was superfluous.
