### PR TITLE
Minor Array constructor tweaks

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -10,12 +10,10 @@ typealias DenseVector{T} DenseArray{T,1}
 typealias DenseMatrix{T} DenseArray{T,2}
 typealias DenseVecOrMat{T} Union{DenseVector{T}, DenseMatrix{T}}
 
-call{T}(::Type{Vector{T}}, m::Integer) = Array{T}(m)
 call{T}(::Type{Vector{T}}) = Array{T}(0)
 call(::Type{Vector}, m::Integer) = Array{Any}(m)
 call(::Type{Vector}) = Array{Any}(0)
 
-call{T}(::Type{Matrix{T}}, m::Integer, n::Integer) = Array{T}(m, n)
 call{T}(::Type{Matrix{T}}) = Array{T}(0, 0)
 call(::Type{Matrix}, m::Integer, n::Integer) = Array{Any}(m, n)
 call(::Type{Matrix}) = Array{Any}(0, 0)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -187,23 +187,21 @@ macro goto(name::Symbol)
     Expr(:symbolicgoto, name)
 end
 
+call{T}(::Type{Array{T}}, d::Tuple{Int}) =
+    ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, d[1])
+call{T}(::Type{Array{T}}, d::Tuple{Int, Int}) =
+    ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int), Array{T,2}, d[1], d[2])
+call{T}(::Type{Array{T}}, d::Tuple{Int, Int, Int}) =
+    ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, d[1], d[2], d[3])
 call{T,N}(::Type{Array{T}}, d::NTuple{N,Int}) =
     ccall(:jl_new_array, Array{T,N}, (Any,Any), Array{T,N}, d)
+
+call{T,N}(::Type{Array{T}}, d::NTuple{N,Integer}) = Array{T}(convert(Tuple{Vararg{Int}}, d))
 call{T}(::Type{Array{T}}, d::Integer...) = Array{T}(convert(Tuple{Vararg{Int}}, d))
 
-call{T}(::Type{Array{T}}, m::Integer) =
-    ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, m)
-call{T}(::Type{Array{T}}, m::Integer, n::Integer) =
-    ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int), Array{T,2}, m, n)
-call{T}(::Type{Array{T}}, m::Integer, n::Integer, o::Integer) =
-    ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, m, n, o)
-
 # TODO: possibly turn these into deprecations
-Array{T,N}(::Type{T}, d::NTuple{N,Int}) = Array{T}(d)
+Array{T,N}(::Type{T}, d::NTuple{N,Integer}) = Array{T}(convert(Tuple{Vararg{Int}}, d))
 Array{T}(::Type{T}, d::Integer...)      = Array{T}(convert(Tuple{Vararg{Int}}, d))
-Array{T}(::Type{T}, m::Integer)                       = Array{T}(m)
-Array{T}(::Type{T}, m::Integer,n::Integer)            = Array{T}(m,n)
-Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) = Array{T}(m,n,o)
 
 # SimpleVector
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -187,21 +187,23 @@ macro goto(name::Symbol)
     Expr(:symbolicgoto, name)
 end
 
-call{T}(::Type{Array{T}}, d::Tuple{Int}) =
+call{T}(::Type{Array{T,1}}, d::Tuple{Int}) =
     ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, d[1])
-call{T}(::Type{Array{T}}, d::Tuple{Int, Int}) =
+call{T}(::Type{Array{T,2}}, d::Tuple{Int, Int}) =
     ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int), Array{T,2}, d[1], d[2])
-call{T}(::Type{Array{T}}, d::Tuple{Int, Int, Int}) =
+call{T}(::Type{Array{T,3}}, d::Tuple{Int, Int, Int}) =
     ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, d[1], d[2], d[3])
-call{T,N}(::Type{Array{T}}, d::NTuple{N,Int}) =
+call{T,N}(::Type{Array{T,N}}, d::NTuple{N,Int}) =
     ccall(:jl_new_array, Array{T,N}, (Any,Any), Array{T,N}, d)
 
-call{T,N}(::Type{Array{T}}, d::NTuple{N,Integer}) = Array{T}(convert(Tuple{Vararg{Int}}, d))
-call{T}(::Type{Array{T}}, d::Integer...) = Array{T}(convert(Tuple{Vararg{Int}}, d))
+call{T,N}(::Type{Array{T,N}}, d::NTuple{N,Integer}) = Array{T,N}(convert(NTuple{N,Int}, d))
+call{T,N}(::Type{Array{T}}, d::NTuple{N,Integer}) = Array{T,N}(convert(NTuple{N,Int}, d))
+call{T,N}(::Type{Array{T,N}}, d::Integer...) = Array{T,N}(d)
+call{T}(::Type{Array{T}}, d::Integer...) = Array{T}(d)
 
 # TODO: possibly turn these into deprecations
-Array{T,N}(::Type{T}, d::NTuple{N,Integer}) = Array{T}(convert(Tuple{Vararg{Int}}, d))
-Array{T}(::Type{T}, d::Integer...)      = Array{T}(convert(Tuple{Vararg{Int}}, d))
+Array{T,N}(::Type{T}, d::NTuple{N,Integer}) = Array{T,N}(d)
+Array{T}(::Type{T}, d::Integer...)      = Array{T}(d)
 
 # SimpleVector
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -167,6 +167,43 @@ rt = Base.return_types(setindex!, Tuple{Array{Int32, 3}, UInt8, Vector{Int}, Int
 @test size(Matrix(2,3)) == (2,3)
 @test size(Matrix()) == (0,0)
 
+@test typeof(Array{Int}()) == Array{Int,0}
+@test typeof(Array{Int}(3)) == Array{Int,1}
+@test typeof(Array{Int}(2,3)) == Array{Int,2}
+@test typeof(Array{Int}(2,3,4)) == Array{Int,3}
+@test typeof(Array{Int}(2,3,4,5)) == Array{Int,4}
+@test size(Array{Int}()) == ()
+@test size(Array{Int}(3)) == (3,)
+@test size(Array{Int}(2,3)) == (2,3)
+@test size(Array{Int}(2,3,4)) == (2,3,4)
+@test size(Array{Int}(2,3,4,5)) == (2,3,4,5)
+
+@test typeof(Array{Int,0}()) == Array{Int,0}
+@test typeof(Array{Int,1}(3)) == Array{Int,1}
+@test typeof(Array{Int,2}(2,3)) == Array{Int,2}
+@test typeof(Array{Int,3}(2,3,4)) == Array{Int,3}
+@test typeof(Array{Int,4}(2,3,4,5)) == Array{Int,4}
+@test size(Array{Int,0}()) == ()
+@test size(Array{Int,1}(3)) == (3,)
+@test size(Array{Int,2}(2,3)) == (2,3)
+@test size(Array{Int,3}(2,3,4)) == (2,3,4)
+@test size(Array{Int,4}(2,3,4,5)) == (2,3,4,5)
+
+@test typeof(Array{Int,0}()) == Array{Int,0}
+@test typeof(Array{Int,1}(0x3)) == Array{Int,1}
+@test typeof(Array{Int,2}(Int8(2),Int16(3))) == Array{Int,2}
+@test typeof(Array{Int,3}((0x0002,3,Int128(4)))) == Array{Int,3}
+@test typeof(Array{Int,4}(2,Int32(3),Int64(4),5)) == Array{Int,4}
+@test size(Array{Int,0}()) == ()
+@test size(Array{Int,1}(0x3)) == (3,)
+@test size(Array{Int,2}((Int16(2),Int128(3)))) == (2,3)
+@test size(Array{Int,3}(0x0002,UInt32(3),4)) == (2,3,4)
+@test size(Array{Int,4}((2,3,4,5))) == (2,3,4,5)
+
+@test_throws MethodError Array{Int,1}(1,2)
+@test_throws MethodError Array{Int,2}(1)
+@test_throws MethodError Array{Int,3}((1,2,3,4))
+
 # get
 let
     A = reshape(1:24, 3, 8)


### PR DESCRIPTION
This removes an unnecessary tuple allocation when constructing 1-3 dimensional arrays with a single tuple argument.  Notably, this is the form that ends up getting called by `similar`.  Before:

``` jl
julia> @benchmark Array{Int}(1,1,1)
================ Benchmark Results ========================
     Time per evaluation: 67.50 ns [66.48 ns, 68.52 ns]
Proportion of time in GC: 2.00% [1.45%, 2.56%]
        Memory allocated: 80.00 bytes
   Number of allocations: 1 allocations

julia> @benchmark Array{Int}((1,1,1))
================ Benchmark Results ========================
     Time per evaluation: 132.95 ns [129.50 ns, 136.39 ns]
Proportion of time in GC: 1.96% [1.35%, 2.58%]
        Memory allocated: 112.00 bytes
   Number of allocations: 2 allocations
```

After:

``` jl
julia> @benchmark Array{Int}(1,1,1)
================ Benchmark Results ========================
     Time per evaluation: 62.19 ns [61.18 ns, 63.20 ns]
Proportion of time in GC: 2.20% [1.62%, 2.78%]
        Memory allocated: 80.00 bytes
   Number of allocations: 1 allocations

julia> @benchmark Array{Int}((1,1,1))
================ Benchmark Results ========================
     Time per evaluation: 62.44 ns [61.45 ns, 63.43 ns]
Proportion of time in GC: 2.23% [1.65%, 2.82%]
        Memory allocated: 80.00 bytes
   Number of allocations: 1 allocations
```

While I was there, I also cleaned up the constructor functions themselves a bit, such that the fully-parametrized Array{T,N} was the final endpoint.  It makes things simpler and a bit more consistent; before constructs like `Array{Int,3}(1,2,3)` and `Matrix{Int}((1,2))` were missing method errors… but you might expect them to work.
