### PR TITLE
add -fPIC to julia-config.jl

### DIFF
--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -51,6 +51,7 @@ end
 function cflags()
     arg1 = replace(initDir(),"\\","\\\\\\\\");
     arg2 = replace(includeDir(),"\\","\\\\");
+    @unix_only return """-fPIC -DJULIA_INIT_DIR=\\"$arg1\\" -I$arg2""";
     return """-DJULIA_INIT_DIR=\\"$arg1\\" -I$arg2""";
 end
 

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -35,7 +35,7 @@ We start with a simple C program that initializes Julia and calls some Julia cod
 
 In order to build this program you have to put the path to the Julia header into the include path and link against ``libjulia``. For instance, when Julia is installed to ``$JULIA_DIR``, one can compile the above test program ``test.c`` with ``gcc`` using::
 
-    gcc -o test -I$JULIA_DIR/include/julia -L$JULIA_DIR/usr/lib -ljulia test.c
+    gcc -o test -fPIC -I$JULIA_DIR/include/julia -L$JULIA_DIR/usr/lib test.c -ljulia
 
 Alternatively, look at the ``embedding.c`` program in the Julia source tree in the ``examples/`` folder. The file ``ui/repl.c`` program is another simple example of how to set ``jl_options`` options while linking against ``libjulia``.
 


### PR DESCRIPTION
@yuyichao found that `-fPIC` is needed so that the GC stack is properly initialized. I've tested on linux only.
