### PR TITLE
methods for left-division ops involving triangular matrices and sparse vectors

### DIFF
--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -7,7 +7,8 @@ using Base.Sort: Forward
 using Base.LinAlg: AbstractTriangular, PosDefException
 
 import Base: +, -, *, \, &, |, $, .+, .-, .*, ./, .\, .^, .<, .!=, ==
-import Base: A_mul_B!, Ac_mul_B, Ac_mul_B!, At_mul_B, At_mul_B!, A_ldiv_B!
+import Base: A_mul_B!, Ac_mul_B, Ac_mul_B!, At_mul_B, At_mul_B!, At_ldiv_B, Ac_ldiv_B, A_ldiv_B!
+import Base.LinAlg: At_ldiv_B!, Ac_ldiv_B!
 
 import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     atan, atand, atanh, broadcast!, chol, conj!, cos, cosc, cosd, cosh, cospi, cot,


### PR DESCRIPTION
This pull request addresses part of JuliaLang/LinearAlgebra.jl#283 by providing methods for left-division operations involving triangular matrices and `SparseVector`s. I believe these methods cover all valid operations; please correct me if I missed cases. The implementations are in keeping with the discussion in JuliaLang/LinearAlgebra.jl#283. A few points:

(1) I began implementing the corresponding right-division operations via the same approach. But I rapidly found that many relevant underlying methods (among A(t|c)_rdiv_B[t|c][!]) appear to be missing. So I nixed the effort. IIUC (#5332), supporting all such valid methods is not an objective. But should some of those be implemented? If so, which, and does that deserve an issue?

(2) In some cases the in-place operations introduce structural nonzeros that end up numerically zero. As those zeros should only appear in edge cases and stripping them can be expensive, the present implementation does not bother to strip them. Should it? (Edit: Given the discussion in JuliaLang/julia#12605, JuliaLang/julia#9906, and JuliaLang/julia#9928, I guess the answer is no.)

(3) Testing with more than one `SparseVector` might be wise given the `SparseVector`'s nonzero pattern impacts the execution path. Should I add that, or leave the tests as they are?

Thanks, and best!
