### PR TITLE
Clean up setting default number of bytes in readbytes()

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -274,8 +274,8 @@ function readbytes!(s::IO, b::AbstractArray{UInt8}, nb=length(b))
 end
 
 # read up to nb bytes from s, returning a Vector{UInt8} of bytes read.
-function readbytes(s::IO, nb=typemax(Int))
-    b = Array(UInt8, nb == typemax(Int) ? 1024 : nb)
+function readbytes(s::IO, nb=1024)
+    b = Array(UInt8, nb)
     nr = readbytes!(s, b, nb)
     resize!(b, nr)
 end


### PR DESCRIPTION
The old code added in c43ffb6 took min(nb, 65536) since it passed the value
to ios_read() as size_t. The default was typemax(Int).
8142e0d changed the code to replace typemax(Int) with 1024. Setting the
default argument is more natural, especially given that ios_read()
isn't called anymore.

Cc: @stevengj @JeffBezanson who wrote those two commits
