### PR TITLE
Two I/O related fixes

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -20,7 +20,7 @@ let err = nothing
     catch err
         io = IOBuffer()
         showerror(io, err)
-        @test takebuf_string(io) == "SystemError (with $file): mkdir: File exists"
+        @test startswith(takebuf_string(io), "SystemError (with $file): mkdir:")
     end
 end
 


### PR DESCRIPTION
The first commit seems so obvious to me that I suppose I'm missing something. I can't believe the tests would have passed if the existing code wasn't correct...

The second one is trivial. Unfortunately, without forcing LC_ALL=C on all julia processes, we cannot rely on the system error messages at all. Anyway, I suppose the messages could vary from one OS to another, so maybe better not test it. Cc @timholy who wrote these lines.
