### PR TITLE
[RFC] Automatically unlock on exceptions

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -196,6 +196,7 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     eh->gcstack = jl_pgcstack;
 #ifdef JULIA_ENABLE_THREADING
     eh->gc_state = jl_get_ptls_states()->gc_state;
+    eh->locks_len = jl_current_task->locks.len;
 #endif
     jl_current_task->eh = eh;
     // TODO: this should really go after setjmp(). see comment in


### PR DESCRIPTION
This is an attempt to teach the exception handler to unlock the runtime locks held by the thread/task when an exception happens. This is the reason that causes the CI to hang with threading enabled sometimes (e.g. https://travis-ci.org/JuliaLang/julia/jobs/97715911#L1228).

The traditional approach is of course add a `try-catch` block and rethrow the exception after catching the exception and unlock the lock. The reasons I'm trying a different approach are,
1. It messes up the code a lot. This is actually the most important motivation. We have some fairly long functions with multiple returns that are locked and I want to avoid adding `JL_TRY` to all of them because of the lock.
2. It is relatively expensive to set up the exception handler (see below). The difference is not very significant compare to the critical regions of the lock but it is still nice to write less code and run faster.

The approach in this PR also has the addition advantage that it can be generalized to other locks/resources as well (and can be used to avoid freeing a task when it is still holding a lock).

Benchmarks:

I used the following code for the benchmark,

``` c
JL_DEFINE_MUTEX(test_lock)

JL_DLLEXPORT void jl_testlock1(void)
{
    JL_LOCK_RAW(test_lock);
    JL_UNLOCK_RAW(test_lock);
}

JL_DLLEXPORT void jl_testlock2(void)
{
    JL_LOCK(test_lock);
    JL_UNLOCK(test_lock);
}

JL_DLLEXPORT void jl_testlock3(void)
{
    JL_LOCK_RAW(test_lock);
    JL_TRY {
    }
    JL_CATCH {
        JL_UNLOCK_RAW(test_lock);
        jl_rethrow();
    }
    JL_UNLOCK_RAW(test_lock);
}
```

The first function is the same with locking and unlocking on current master. The second version includes keeping track of the locks and the third version does it with a `try-catch` block. Both 1 and 2 takes ~26-29ns (with 2 slower by ~1ns on average) and 3 takes ~58-60ns. Also note that a significant amount of time (20-30%) for our current lock implementation is spent on calling `uv_thread_self()` at least 4 times and the ratio in the execution time is even bigger with that fixed.

Of course with the `RFC` in the title, I'm open to what other people think is the right way to solve this problem.

Also note that this might conflict with #14190. My current plan for this is to not allow exceptions for `JL_LOCK_NOGC` and bypass the locks list in that case. This is a minor optimization simply because this is currently true for all uses of `JL_LOCK_NOGC` and can easily be changed later.
