### PR TITLE
Add tests and comment for readbytes() and readbytes!()

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -275,6 +275,8 @@ end
 
 # read up to nb bytes from s, returning a Vector{UInt8} of bytes read.
 function readbytes(s::IO, nb=typemax(Int))
+    # Let readbytes! grow the array progressively by default
+    # instead of taking of risk of over-allocating
     b = Array(UInt8, nb == typemax(Int) ? 1024 : nb)
     nr = readbytes!(s, b, nb)
     resize!(b, nr)

--- a/test/file.jl
+++ b/test/file.jl
@@ -1107,6 +1107,18 @@ function test_read_nbyte()
 end
 test_read_nbyte()
 
+let s = "qwerty"
+    @test readbytes(IOBuffer(s)) == s.data
+    @test readbytes(IOBuffer(s), 10) == s.data
+    @test readbytes(IOBuffer(s), 1) == s.data[1:1]
+
+    # Test growing output array
+    x = UInt8[]
+    n = readbytes!(IOBuffer(s), x, 10)
+    @test x == s.data
+    @test n == length(x)
+end
+
 # DevNull
 @test !isreadable(DevNull)
 @test iswritable(DevNull)


### PR DESCRIPTION
The case when array needs to be resized wasn't tested. Also,
better make the trick about passing a small array from
readbytes() more explicit.

Cf. https://github.com/JuliaLang/julia/pull/14448 (for some reason I can't reopen it).
