### PR TITLE
Fix plain rendering of markdown horizontal rule

### DIFF
--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -47,7 +47,7 @@ function plain(io::IO, q::BlockQuote)
 end
 
 function plain(io::IO, md::HorizontalRule)
-    println(io, "–" ^ 3)
+    println(io, "-" ^ 3)
 end
 
 plain(io::IO, md) = writemime(io, "text/plain", md)


### PR DESCRIPTION
The "–" needs to be replaced by an ordinary dash "-" to produce properly formatted markdown.
