### PR TITLE
Fix markdown plain rendering of horizontal rule

### DIFF
--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -47,7 +47,7 @@ function plain(io::IO, q::BlockQuote)
 end
 
 function plain(io::IO, md::HorizontalRule)
-    println(io, "–" ^ 3)
+    println(io, "-" ^ 3)
 end
 
 plain(io::IO, md) = writemime(io, "text/plain", md)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -64,7 +64,7 @@ foo
 @test md"""Hello
 
 ---
-World""" |> plain == "Hello\n\n–––\n\nWorld\n"
+World""" |> plain == "Hello\n\n---\n\nWorld\n"
 @test md"[*a*](b)" |> plain == "[*a*](b)\n"
 @test md"""
 > foo


### PR DESCRIPTION
The "–" needs to be replaced by an ordinary dash "-" to produce properly formatted markdown.
