### PR TITLE
Modify .dmg installer

### DIFF
--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -10,11 +10,27 @@ ifeq ($(JULIA_PKGDIR),)
 	JULIA_PKGDIR:=$(shell echo ~)/.julia
 endif
 
-VERSION_SUFFIX:=$(shell [ $$(git describe --tags --exact-match 2>/dev/null) ] && echo $(JULIA_VERSION) || echo $(JULIA_VERSION)-$(JULIA_COMMIT))
+# X.Y.Z or X.Y.Z-hash
+DMG_VERSION_SUFFIX:=$(shell [ $$(git describe --tags --exact-match 2>/dev/null) ] && echo $(JULIA_VERSION) || echo $(JULIA_VERSION)-$(JULIA_COMMIT))
 
-all: clean dmg
+# X.Y
+APP_VERSION_SUFFIX:=$(shell echo $(JULIA_VERSION) | grep -o '^[0-9]\+.[0-9]\+')
 
-dmg:
+DMG_NAME:=Julia-$(DMG_VERSION_SUFFIX).dmg
+APP_NAME:=Julia-$(APP_VERSION_SUFFIX).app
+VOL_NAME:=Julia-$(DMG_VERSION_SUFFIX)
+
+all: clean $(DMG_NAME)
+
+$(DMG_NAME): dmg/$(APP_NAME)
+	-cp -f julia.icns dmg/.VolumeIcon.icns
+	-ln -fs /Applications ./dmg/Applications
+	-chmod 755 ./dmg/$(APP_NAME)/Contents/MacOS/Julia
+	@echo "We're going to chown the .app file to root:admin now, which requires sudo.  You may be asked for your password:"
+	sudo chown -R root:admin ./dmg/$(APP_NAME)
+	sudo hdiutil create $(DMG_NAME) -size 500m -ov -volname "$(VOL_NAME)" -imagekey zlib-level=9 -srcfolder dmg
+
+dmg/$(APP_NAME): julia.icns
 	make -C ../../../deps install-git
 	make -C ../../.. binary-dist
 	tar zxf ../../../julia-*.tar.gz
@@ -24,16 +40,11 @@ dmg:
 	-cp -a $(build_datarootdir)/git* ./julia/share
 	rm -f julia/lib/*.{a,la}
 	-mkdir dmg
-	platypus -a Julia -p /bin/bash -V $(JULIA_VERSION) -R -u "The Julia Project" -i julia.icns -Q julia.icns -o "None" -I org.julialang -x -f julia script ./dmg/Julia-$(VERSION_SUFFIX).app
-	-codesign -s "AFB379C0B4CBD9DB9A762797FC2AB5460A2B0DBE" --deep ./dmg/Julia-$(VERSION_SUFFIX).app
-	-cp -f Julia.icns dmg/.VolumeIcon.icns
-	-ln -fs /Applications ./dmg/Applications
-	-chmod 755 ./dmg/Julia-$(VERSION_SUFFIX).app/Contents/MacOS/Julia
-	@echo "We're going to chown the .app file to root:admin now, which requires sudo.  You may be asked for your password:"
-	sudo chown -R root:admin ./dmg/Julia-$(VERSION_SUFFIX).app
-	sudo hdiutil create Julia-$(VERSION_SUFFIX).dmg -size 500m -ov -volname "Julia" -imagekey zlib-level=9 -srcfolder dmg
-
+	platypus -a Julia -p /bin/bash -V $(JULIA_VERSION) -R -u "The Julia Project" -i julia.icns -Q julia.icns -o "None" -I org.julialang.julia -x -f julia script ./dmg/$(APP_NAME)
+	-codesign -s "AFB379C0B4CBD9DB9A762797FC2AB5460A2B0DBE" --deep ./dmg/$(APP_NAME)
 
 clean:
 	@echo "We have to use sudo here to clean out folders owned by root.  You may be asked for your password"
 	sudo rm -fr julia dmg *.dmg
+
+.PHONY: clean all


### PR DESCRIPTION
The first commit fixes #10697 by using only the major.minor version in the .app filename.

The second formats the background of the .dmg window:

<img width="325" alt="screen shot 2015-12-22 at 20 00 52" src="https://cloud.githubusercontent.com/assets/1692009/11964636/fb838b9c-a8e6-11e5-8ff5-e0cc9e9829f9.png">

Comments/suggestions welcome.
