### PR TITLE
elide code marked with `@boundscheck(...)`.

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -952,3 +952,11 @@ end
 #14555
 @deprecate_binding Coff_t Int64
 @deprecate_binding FileOffset Int64
+
+#14474
+macro boundscheck(yesno,blk)
+    depwarn("The meaning of `@boundscheck` has changed. It now indicates that the provided code block performs bounds checking, and may be elided when inbounds.", symbol("@boundscheck"))
+    if yesno === true
+        :(@inbounds $(esc(blk)))
+    end
+end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -168,15 +168,17 @@ end
 
 esc(e::ANY) = Expr(:escape, e)
 
-macro boundscheck(yesno,blk)
+macro boundscheck(blk)
     # hack: use this syntax since it avoids introducing line numbers
-    :($(Expr(:boundscheck,yesno));
+    :($(Expr(:boundscheck,true));
       $(esc(blk));
       $(Expr(:boundscheck,:pop)))
 end
 
 macro inbounds(blk)
-    :(@boundscheck false $(esc(blk)))
+    :($(Expr(:inbounds,true));
+      $(esc(blk));
+      $(Expr(:inbounds,:pop)))
 end
 
 macro label(name::Symbol)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -17,6 +17,10 @@ end
 macro _pure_meta()
     Expr(:meta, :pure)
 end
+# another version of inlining that propagates an inbounds context
+macro _propagate_inbounds_meta()
+    Expr(:meta, :inline, :propagate_inbounds)
+end
 
 
 # constructors for Core types in boot.jl

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -66,6 +66,21 @@ macro pure(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :pure) : ex)
 end
 
+"""
+    @propagate_inbounds(ex)
+
+Tells the compiler to inline a function while retaining the caller's inbounds context.
+"""
+macro propagate_inbounds(ex)
+    if isa(ex, Expr)
+        pushmeta!(ex, :inline)
+        pushmeta!(ex, :propagate_inbounds)
+        esc(ex)
+    else
+        esc(ex)
+    end
+end
+
 ## some macro utilities ##
 
 find_vars(e) = find_vars(e, [])

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2985,7 +2985,10 @@ function inlining_pass(e::Expr, sv, ast)
         end
         res = inlineable(f, e, atype, sv, ast)
         if isa(res,Tuple)
-            if isa(res[2],Array)
+            if isa(res[2],Array) && !isempty(res[2])
+                # inlined statements are out-of-bounds by default
+                unshift!(res[2], Expr(:inbounds, false))
+                push!(res[2], Expr(:inbounds, :pop))
                 append!(stmts,res[2])
             end
             res = res[1]

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1861,6 +1861,7 @@ function typeinf_uncached(linfo::LambdaStaticData, atypes::ANY, sparams::SimpleV
                 fulltree.args[3] = inlining_pass(fulltree.args[3], sv, fulltree)[1]
                 # inlining can add variables
                 sv.vars = append_any(f_argnames(fulltree), fulltree.args[2][1])
+                inbounds_meta_elim_pass(fulltree.args[3])
             end
             tuple_elim_pass(fulltree, sv)
             getfield_elim_pass(fulltree.args[3], sv)
@@ -3266,6 +3267,16 @@ function occurs_outside_getfield(e::ANY, sym::ANY, sv::StaticVarInfo, tuplen::In
         end
     end
     return false
+end
+
+# removes inbounds metadata if we never encounter an inbounds=true or
+# boundscheck context in the method body
+function inbounds_meta_elim_pass(e::Expr)
+    if findfirst(x -> isa(x, Expr) &&
+                      ((x.head === :inbounds && x.args[1] == true) || x.head === :boundscheck),
+                 e.args) == 0
+        filter!(x -> !(isa(x, Expr) && x.head === :inbounds), e.args)
+    end
 end
 
 # replace getfield(tuple(exprs...), i) with exprs[i]

--- a/doc/devdocs/ast.rst
+++ b/doc/devdocs/ast.rst
@@ -139,11 +139,16 @@ These symbols appear in the ``head`` field of ``Expr``\s in lowered form.
 ``leave``
     pop exception handlers. ``args[1]`` is the number of handlers to pop.
 
-``boundscheck``
+``inbounds``
     controls turning bounds checks on or off. A stack is maintained; if the
     first argument of this expression is true or false (``true`` means bounds
     checks are enabled), it is pushed onto the stack. If the first argument is
     ``:pop``, the stack is popped.
+
+``boundscheck``
+    indicates the beginning or end of a section of code that performs a bounds
+    check. Like ``inbounds``, a stack is maintained, and the second argument
+    can be one of: ``true``, ``false``, or ``:pop``.
 
 ``copyast``
     part of the implementation of quasi-quote. The argument is a surface syntax

--- a/doc/devdocs/boundscheck.rst
+++ b/doc/devdocs/boundscheck.rst
@@ -1,0 +1,61 @@
+.. _devdocs-subarrays:
+
+.. currentmodule:: Base
+
+**************************
+Bounds checking
+**************************
+
+Like many modern programming languages, Julia uses bounds checking to ensure
+program safety when accessing arrays. In tight inner loops or other performance
+critical situations, you may wish to skip these bounds checks to improve runtime
+performance. For instance, in order to emit vectorized (SIMD) instructions, your
+loop body cannot contain branches, and thus cannot contain bounds checks.
+Consequently, Julia includes an ``@inbounds(...)`` macro to tell the compiler to
+skip such bounds checks within the given block. For the built-in ``Array`` type,
+the magic happens inside the ``arrayref`` and ``arrayset`` intrinsics.
+User-defined array types instead use the ``@boundscheck(...)`` macro to achieve
+context-sensitive code selection.
+
+Eliding bounds checks
+---------------------
+
+The ``@boundscheck(...)`` macro marks blocks of code that perform bounds
+checking. When such blocks appear inside of an ``@inbounds(...)`` block, the
+compiler removes these blocks. When the ``@boundscheck(...)`` is nested inside
+of a calling function containing an ``@inbounds(...)``, the compiler will remove
+the ``@boundscheck`` block *only if it is inlined* into the calling function.
+For example, you might write the method ``sum`` as::
+
+    function sum(A::AbstractArray)
+        r = zero(eltype(A))
+        for i = 1:length(A)
+            @inbounds r += A[i]
+        end
+        return r
+    end
+
+With a custom array-like type ``MyArray`` having::
+
+    @inline getindex(A::MyArray, i::Real) = (@boundscheck checkbounds(A,i); A.data[to_index(i)])
+
+Then when ``getindex`` is inlined into ``sum``, the call to ``checkbounds(A,i)``
+will be elided. If your function contains multiple layers of inlining, only
+``@boundscheck`` blocks at most one level of inlining deeper are eliminated. The
+rule prevents unintended changes in program behavior from code further up the
+stack.
+
+
+Propagating inbounds
+--------------------
+
+There may be certain scenarios where for code-organization reasons you want more
+than one layer between the ``@inbounds`` and ``@boundscheck`` declarations. For
+instance, the default ``getindex`` methods have the chain
+``getindex(A::AbstractArray, i::Real)`` calls
+``getindex(linearindexing(A), A, i)`` calls
+``_getindex(::LinearFast, A, i)``.
+
+To override the "one layer of inlining" rule, a function may be marked with
+``@propagate_inbounds`` to propagate an inbounds context (or out of bounds
+context) through one additional layer of inlining.

--- a/doc/devdocs/julia.rst
+++ b/doc/devdocs/julia.rst
@@ -22,3 +22,4 @@
    llvm
    stdio
    promote-op
+   boundscheck

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -100,11 +100,11 @@ jl_sym_t *abstracttype_sym; jl_sym_t *bitstype_sym;
 jl_sym_t *compositetype_sym; jl_sym_t *type_goto_sym;
 jl_sym_t *global_sym; jl_sym_t *tuple_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
-jl_sym_t *boundscheck_sym; jl_sym_t *copyast_sym;
-jl_sym_t *fastmath_sym; jl_sym_t *pure_sym;
-jl_sym_t *simdloop_sym; jl_sym_t *meta_sym;
-jl_sym_t *arrow_sym;  jl_sym_t *inert_sym;
-jl_sym_t *vararg_sym;
+jl_sym_t *boundscheck_sym; jl_sym_t *inbounds_sym;
+jl_sym_t *copyast_sym; jl_sym_t *fastmath_sym;
+jl_sym_t *pure_sym; jl_sym_t *simdloop_sym;
+jl_sym_t *meta_sym; jl_sym_t *arrow_sym;
+jl_sym_t *inert_sym; jl_sym_t *vararg_sym;
 
 typedef struct {
     int64_t a;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1290,12 +1290,26 @@ static void emit_typecheck(const jl_cgval_t &x, jl_value_t *type, const std::str
     builder.SetInsertPoint(passBB);
 }
 
+static bool is_inbounds(jl_codectx_t *ctx)
+{
+    // inbounds rule is either of top two values on inbounds stack are true
+    bool inbounds = !ctx->inbounds.empty() && ctx->inbounds.back();
+    if (ctx->inbounds.size() > 1)
+        inbounds ^= ctx->inbounds[ctx->inbounds.size()-2];
+    return inbounds;
+}
+
+static bool is_bounds_check_block(jl_codectx_t *ctx)
+{
+    return !ctx->boundsCheck.empty() && ctx->boundsCheck.back();
+}
+
 #define CHECK_BOUNDS 1
 static Value *emit_bounds_check(const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len, jl_codectx_t *ctx)
 {
     Value *im1 = builder.CreateSub(i, ConstantInt::get(T_size, 1));
 #if CHECK_BOUNDS==1
-    if (((ctx->boundsCheck.empty() || ctx->boundsCheck.back()==true) &&
+    if ((!is_inbounds(ctx) &&
          jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_OFF) ||
          jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_ON) {
         Value *ok = builder.CreateICmpULT(im1, len);
@@ -1800,7 +1814,7 @@ static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, size_
     Value *i = ConstantInt::get(T_size, 0);
     Value *stride = ConstantInt::get(T_size, 1);
 #if CHECK_BOUNDS==1
-    bool bc = ((ctx->boundsCheck.empty() || ctx->boundsCheck.back()==true) &&
+    bool bc = (!is_inbounds(ctx) &&
                jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_OFF) ||
         jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_ON;
     BasicBlock *failBB=NULL, *endBB=NULL;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1295,7 +1295,7 @@ static bool is_inbounds(jl_codectx_t *ctx)
     // inbounds rule is either of top two values on inbounds stack are true
     bool inbounds = !ctx->inbounds.empty() && ctx->inbounds.back();
     if (ctx->inbounds.size() > 1)
-        inbounds ^= ctx->inbounds[ctx->inbounds.size()-2];
+        inbounds |= ctx->inbounds[ctx->inbounds.size()-2];
     return inbounds;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4037,6 +4037,7 @@ emit_gcpops(jl_codectx_t *ctx)
 {
     Function *F = ctx->f;
     for(Function::iterator I = F->begin(), E = F->end(); I != E; ++I) {
+        assert(I->getTerminator() != NULL);
         if (isa<ReturnInst>(I->getTerminator())) {
             builder.SetInsertPoint(I->getTerminator()); // set insert *before* Ret
             Instruction *gcpop =
@@ -4056,7 +4057,6 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
         clear_gc_frame(gc);
         return;
     }
-    BasicBlock::iterator bbi(gc->gcframe);
     AllocaInst *newgcframe = gc->gcframe;
     builder.SetInsertPoint(&*++gc->last_gcframe_inst); // set insert *before* point, e.g. after the gcframe
     // Allocate the real GC frame

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3877,8 +3877,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
         builder.SetInsertPoint(tryblk);
     }
     else if (head == inbounds_sym) {
-        if (jl_array_len(ex->args) > 0 &&
-            jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_DEFAULT) {
+        if (jl_array_len(ex->args) > 0) {
             jl_value_t *arg = args[0];
             if (arg == jl_true) {
                 ctx->inbounds.push_back(true);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4920,14 +4920,15 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
                 addr.push_back(i * sizeof(void*));
                 addr.push_back(llvm::dwarf::DW_OP_deref);
                 prepare_call(Intrinsic::getDeclaration(builtins_module, Intrinsic::dbg_value));
+                ctx.dbuilder->insertDbgValueIntrinsic(
+                    argArray,
+                    0,
+                    ctx.vars[s].dinfo,
+                    ctx.dbuilder->createExpression(addr),
 #ifdef LLVM37
-                ctx.dbuilder->insertDbgValueIntrinsic(argArray, 0, ctx.vars[s].dinfo,
-                ctx.dbuilder->createExpression(addr),
-                builder.getCurrentDebugLocation().get(), builder.GetInsertBlock());
-#else
-                ctx.dbuilder->insertDbgValueIntrinsic(argArray, 0, ctx.vars[s].dinfo,
-                ctx.dbuilder->createExpression(addr), builder.GetInsertBlock());
+                    builder.getCurrentDebugLocation().get(),
 #endif
+                    builder.GetInsertBlock());
             }
         }
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -580,6 +580,7 @@ typedef struct {
     bool sret;
     int nReqArgs;
     std::vector<bool> boundsCheck;
+    std::vector<bool> inbounds;
 
     jl_gcinfo_t gc;
 
@@ -3875,9 +3876,25 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
 #endif
         builder.SetInsertPoint(tryblk);
     }
-    else if (head == boundscheck_sym) {
+    else if (head == inbounds_sym) {
         if (jl_array_len(ex->args) > 0 &&
             jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_DEFAULT) {
+            jl_value_t *arg = args[0];
+            if (arg == jl_true) {
+                ctx->inbounds.push_back(true);
+            }
+            else if (arg == jl_false) {
+                ctx->inbounds.push_back(false);
+            }
+            else {
+                if (!ctx->inbounds.empty())
+                    ctx->inbounds.pop_back();
+            }
+        }
+        return ghostValue(jl_void_type);
+    }
+    else if (head == boundscheck_sym) {
+        if (jl_array_len(ex->args) > 0) {
             jl_value_t *arg = args[0];
             if (arg == jl_true) {
                 ctx->boundsCheck.push_back(true);
@@ -4436,7 +4453,8 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     ctx.funcName = jl_symbol_name(lam->name);
     ctx.vaName = NULL;
     ctx.vaStack = false;
-    ctx.boundsCheck.push_back(true);
+    ctx.inbounds.push_back(false);
+    ctx.boundsCheck.push_back(false);
     ctx.cyclectx = cyclectx;
 
     // step 2. process var-info lists to see what vars are captured, need boxing
@@ -5342,8 +5360,14 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
                 builder.SetInsertPoint(bb);
             }
         }
-        else {
-            (void)emit_expr(stmt, &ctx, false, false);
+        else if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == boundscheck_sym) {
+            // always emit expressions that update the boundscheck stack
+            emit_expr(stmt, &ctx, false, false);
+        }
+        else if (is_inbounds(&ctx) && is_bounds_check_block(&ctx)) {
+            // elide bounds check blocks
+        } else {
+            emit_expr(stmt, &ctx, false, false);
         }
     }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5384,6 +5384,14 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
         builder.CreateUnreachable();
     }
 
+    // patch up dangling BasicBlocks from skipped labels
+    for (std::map<int,BasicBlock*>::iterator it = labels.begin(); it != labels.end(); ++it) {
+        if (it->second->getTerminator() == NULL) {
+            builder.SetInsertPoint(it->second);
+            builder.CreateUnreachable();
+        }
+    }
+
     // step 16. fix up size of stack root list
     finalize_gc_frame(&ctx);
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3877,17 +3877,24 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
         builder.SetInsertPoint(tryblk);
     }
     else if (head == inbounds_sym) {
+        // manipulate inbounds stack
+        // note that when entering an inbounds context, we must also update
+        // the boundsCheck context to be false
         if (jl_array_len(ex->args) > 0) {
             jl_value_t *arg = args[0];
             if (arg == jl_true) {
                 ctx->inbounds.push_back(true);
+                ctx->boundsCheck.push_back(false);
             }
             else if (arg == jl_false) {
                 ctx->inbounds.push_back(false);
+                ctx->boundsCheck.push_back(false);
             }
             else {
                 if (!ctx->inbounds.empty())
                     ctx->inbounds.pop_back();
+                if (!ctx->boundsCheck.empty())
+                    ctx->boundsCheck.pop_back();
             }
         }
         return ghostValue(jl_void_type);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -471,6 +471,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
     else if (ex->head == boundscheck_sym) {
         return (jl_value_t*)jl_nothing;
     }
+    else if (ex->head == inbounds_sym) {
+        return (jl_value_t*)jl_nothing;
+    }
     else if (ex->head == fastmath_sym) {
         return (jl_value_t*)jl_nothing;
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3608,6 +3608,7 @@ void jl_init_types(void)
     kw_sym = jl_symbol("kw");
     dot_sym = jl_symbol(".");
     boundscheck_sym = jl_symbol("boundscheck");
+    inbounds_sym = jl_symbol("inbounds");
     fastmath_sym = jl_symbol("fastmath");
     newvar_sym = jl_symbol("newvar");
     copyast_sym = jl_symbol("copyast");

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1878,9 +1878,9 @@
       (if (null? ranges)
           `(block (= ,oneresult ,expr)
                   ,@(if atype '() `((type_goto ,initlabl ,oneresult)))
-                  (boundscheck false)
+                  (inbounds false)
                   (call (top setindex!) ,result ,oneresult ,ri)
-                  (boundscheck pop)
+                  (inbounds pop)
                   (= ,ri (call (top +) ,ri 1)))
           `(block
             (= ,(car states) (call (top start) ,(car rv)))

--- a/src/julia.h
+++ b/src/julia.h
@@ -607,10 +607,11 @@ extern jl_sym_t *anonymous_sym;  extern jl_sym_t *underscore_sym;
 extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
 extern jl_sym_t *compositetype_sym; extern jl_sym_t *type_goto_sym;
 extern jl_sym_t *global_sym;  extern jl_sym_t *tuple_sym;
-extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
-extern jl_sym_t *fastmath_sym; extern jl_sym_t *pure_sym;
-extern jl_sym_t *simdloop_sym; extern jl_sym_t *meta_sym;
-extern jl_sym_t *arrow_sym; extern jl_sym_t *inert_sym;
+extern jl_sym_t *boundscheck_sym; extern jl_sym_t *inbounds_sym;
+extern jl_sym_t *copyast_sym; extern jl_sym_t *fastmath_sym;
+extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
+extern jl_sym_t *meta_sym; extern jl_sym_t *arrow_sym;
+extern jl_sym_t *inert_sym;
 
 // gc -------------------------------------------------------------------------
 

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -83,4 +83,24 @@ end
 
 @test A1_nested() == 1
 
+# elide a throw
+cb(x) = x > 0 || throw("cb:error")
+
+function B1()
+    y = [1,2,3]
+    @inbounds begin
+        @boundscheck cb(0)
+    end
+    return 0
+end
+
+cond(x) = x > 0 ? x : -x
+function B2()
+    y = [1,2,3]
+    @inbounds begin
+        @boundscheck cond(0)
+    end
+    return 0
+end
+
 end

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -1,0 +1,61 @@
+
+module TestBoundsCheck
+
+using Base.Test
+
+# test for boundscheck block eliminated at same level
+function A1()
+    r = 0
+    @boundscheck r += 1
+    return r
+end
+
+function A1_inbounds()
+    r = 0
+    @inbounds begin
+        @boundscheck r += 1
+    end
+    return r
+end
+
+@test A1() == 1
+@test A1_inbounds() == 0
+
+# test for boundscheck block eliminated one layer deep
+function A2()
+    r = A1()+1
+    return r
+end
+
+function A2_inbounds()
+    @inbounds r = A1()+1
+    return r
+end
+
+@test A2() == 2
+@test A2_inbounds() == 1
+
+# test boundscheck NOT eliminated two layers deep
+
+function A3()
+    r = A2()+1
+    return r
+end
+
+function A3_inbounds()
+    @inbounds r = A2()+1
+    return r
+end
+
+@test A3() == 3
+@test A3_inbounds() == 3
+
+@inline B() = A1() + 1
+function A3_inbounds2()
+    @inbounds r = B()+1
+    return r
+end
+
+# @test A3_inbounds2() == 3
+
+end

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -58,4 +58,13 @@ end
 
 @test A3_inbounds2() == 3
 
+# swapped nesting order of @boundscheck and @inbounds
+function A1_nested()
+    r = 0
+    @boundscheck @inbounds r += 1
+    return r
+end
+
+@test A1_nested() == 1
+
 end

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -43,8 +43,7 @@ function A2_notinlined()
     return r
 end
 
-function A2_propagate_inbounds()
-    Base.@_propagate_inbounds_meta()
+Base.@propagate_inbounds function A2_propagate_inbounds()
     r = A1()+1
     return r
 end

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -10,6 +10,12 @@ using Base.Test
     return r
 end
 
+@noinline function A1_noinline()
+    r = 0
+    @boundscheck r += 1
+    return r
+end
+
 function A1_inbounds()
     r = 0
     @inbounds begin
@@ -21,8 +27,8 @@ end
 @test A1() == 1
 @test A1_inbounds() == 0
 
-# test for boundscheck block eliminated one layer deep
-function A2()
+# test for boundscheck block eliminated one layer deep, if the called method is inlined
+@inline function A2()
     r = A1()+1
     return r
 end
@@ -32,8 +38,14 @@ function A2_inbounds()
     return r
 end
 
+function A2_notinlined()
+    @inbounds r = A1_noinline()+1
+    return r
+end
+
 @test A2() == 2
 @test A2_inbounds() == 1
+@test A2_notinlined() == 2
 
 # test boundscheck NOT eliminated two layers deep
 
@@ -49,14 +61,6 @@ end
 
 @test A3() == 3
 @test A3_inbounds() == 3
-
-@inline B() = A1() + 1
-function A3_inbounds2()
-    @inbounds r = B()+1
-    return r
-end
-
-@test A3_inbounds2() == 3
 
 # swapped nesting order of @boundscheck and @inbounds
 function A1_nested()

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -4,7 +4,7 @@ module TestBoundsCheck
 using Base.Test
 
 # test for boundscheck block eliminated at same level
-function A1()
+@inline function A1()
     r = 0
     @boundscheck r += 1
     return r
@@ -56,6 +56,6 @@ function A3_inbounds2()
     return r
 end
 
-# @test A3_inbounds2() == 3
+@test A3_inbounds2() == 3
 
 end

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -43,11 +43,18 @@ function A2_notinlined()
     return r
 end
 
+function A2_propagate_inbounds()
+    Base.@_propagate_inbounds_meta()
+    r = A1()+1
+    return r
+end
+
 @test A2() == 2
 @test A2_inbounds() == 1
 @test A2_notinlined() == 2
+@test A2_propagate_inbounds() == 2
 
-# test boundscheck NOT eliminated two layers deep
+# test boundscheck NOT eliminated two layers deep, unless propagated
 
 function A3()
     r = A2()+1
@@ -59,8 +66,14 @@ function A3_inbounds()
     return r
 end
 
+function A3_inbounds2()
+    @inbounds r = A2_propagate_inbounds()+1
+    return r
+end
+
 @test A3() == 3
 @test A3_inbounds() == 3
+@test A3_inbounds2() == 2
 
 # swapped nesting order of @boundscheck and @inbounds
 function A1_nested()

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -32,7 +32,8 @@ function choosetests(choices = [])
         "nullable", "meta", "profile", "libgit2", "docs", "markdown",
         "base64", "serialize", "functors", "misc", "threads",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
-        "checked", "intset", "floatfuncs", "compile", "parallel", "inline"
+        "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
+        "boundscheck"
     ]
 
     if Base.USE_GPL_LIBS


### PR DESCRIPTION
This is my attempt to implement @JeffBezanson's suggestion in #7799, which is to say that this teaches the compiler how to elide blocks marked with the `@boundscheck` macro, with the simple heuristic of allowing an `inbounds` context to propagate through one layer of inlining.

I haven't yet marked code that does bounds checking with the `@boundscheck` macro. But, a quick demo:

```
function foo()
    x = 1
    @boundscheck(x += 1)
    return x
end

function bar()
    x = 1
    @inbounds begin
        @boundscheck(x += 1)
    end
    return x
end
```

Then,

```
julia> foo()
2

julia> bar()
1
```

Comments from Jeff or @vtjnash would be appreciated. I don't grok the details of how inlining works in the compiler yet, so I'm not sure I have properly implemented the inbounds heuristic.

Remaining TODOs:
- [x] Review of the overall approach
- [x] Clean up some AST "noise"
- [x] Mark bounds checking code in base with `@boundscheck`
- [x] Figure out a deprecation approach (if any) for the existing `@boundscheck` macro
- [x] Obey the `--check-bounds=yes` cmd line option, but still have a way to run the tests where we want to override it
