### PR TITLE
RFC: Extend the `|>` operator in order to chain tuples.

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -202,6 +202,7 @@ copy(x::Union{Symbol,Number,AbstractString,Function,Tuple,LambdaStaticData,
 
 # function pipelining
 |>(x, f) = f(x)
+|>(xs::Tuple, f) = f(xs...)
 
 # array shape rules
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -664,6 +664,17 @@ Generic Functions
        julia> [1:5;] |> x->x.^2 |> sum |> inv
        0.01818181818181818
 
+.. function:: |>(xs::Tuple, f)
+
+   .. Docstring generated from Julia source
+
+   Applies a function to the preceding tuple. This allows for easy function chaining.
+
+   .. doctest::
+
+       julia> (5, 2) |> divrem |> complex |> float
+       2.0 + 1.0im
+
 .. function:: call(x, args...)
 
    .. Docstring generated from Julia source

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -55,3 +55,10 @@ let xs = [[i:i+4;] for i in 1:10]
         @test max(xs[1:n]...) == [n:n+4;]
     end
 end
+
+# function chaining
+f_chain(x) = :x
+f_chain(xs...) = :xs
+@test 1 |> f_chain == :x
+@test (1, 2) |> f_chain == :xs
+@test ((1, 2),) |> f_chain == :x


### PR DESCRIPTION
I was trying to use an annonymous function in place, something like this:

``` julia
julia> (2, 3, 4) |> (x, y, z) -> 2x + 3y^2 * 4x/2
ERROR: wrong number of arguments
 in anonymous at none:1
```

This works but is less readable:

``` julia
julia> ((x, y, z) -> 2x + 3y^2 * 4x/2)(2, 3, 4)
112.0
```

Extending `|>` to map tuples of arguments:

``` julia
julia> Base.|>(xs::Tuple, f) = f(xs...)
|> (generic function with 7 methods)
```

This will let us make arbitrary chaining possible:

``` julia
julia> (2, 3, 4) |> (x, y, z) -> 2x + 3y^2 * 4x/2
112.0
```

Previous usage and semantics are left unchanged as far as I can tell, also see the tests and documentation.
