### PR TITLE
more efficient getindex methods for unit triangular types

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -114,9 +114,9 @@ function full!{T,S}(A::UnitUpperTriangular{T,S})
     B
 end
 
-getindex{T,S}(A::UnitLowerTriangular{T,S}, i::Integer, j::Integer) = i == j ? one(T) : (i > j ? A.data[i,j] : zero(A.data[j,i]))
+getindex{T,S}(A::UnitLowerTriangular{T,S}, i::Integer, j::Integer) = i > j ? A.data[i,j] : ifelse(i == j, one(T), zero(A.data[j,i]))
 getindex{T,S}(A::LowerTriangular{T,S}, i::Integer, j::Integer) = i >= j ? A.data[i,j] : zero(A.data[j,i])
-getindex{T,S}(A::UnitUpperTriangular{T,S}, i::Integer, j::Integer) = i == j ? one(T) : (i < j ? A.data[i,j] : zero(A.data[j,i]))
+getindex{T,S}(A::UnitUpperTriangular{T,S}, i::Integer, j::Integer) = i < j ? A.data[i,j] : ifelse(i == j, one(T), zero(A.data[j,i]))
 getindex{T,S}(A::UpperTriangular{T,S}, i::Integer, j::Integer) = i <= j ? A.data[i,j] : zero(A.data[j,i])
 
 function setindex!(A::UpperTriangular, x, i::Integer, j::Integer)


### PR DESCRIPTION
This pull request provides behaviorally-identical but more efficient `getindex` methods for `Unit(Lower|Upper)Triangular` types. See JuliaLang/LinearAlgebra.jl#294 for details. I've benchmarked these methods on Intel Ivy Bridge and AMD Piledriver machines; benchmarking on additional architectures might be wise. The benchmarks below, a subset of those in JuliaLang/LinearAlgebra.jl#294,

``` julia
import Base.LinAlg.UnitLowerTriangular
import Base.LinAlg.UnitUpperTriangular

# Define this PR's getindex methods
altgetindex{T,S}(A::UnitLowerTriangular{T,S}, i::Integer, j::Integer) = i > j ? A.data[i,j] : ifelse(i == j, one(T), zero(A.data[j,i]))
altgetindex{T,S}(A::UnitUpperTriangular{T,S}, i::Integer, j::Integer) = i < j ? A.data[i,j] : ifelse(i == j, one(T), zero(A.data[j,i]))

# Benchmark functions using master getindex
function master_sumlt(A::UnitLowerTriangular, n, s)
    @inbounds for j in 1:n, i in j:n
        s += getindex(A, i, j)
    end
    s
end
function master_sumall(A::UnitLowerTriangular, n, s)
    @inbounds for j in 1:n, i in 1:n
        s += getindex(A, i, j)
    end
    s
end
# Benchmark functions using this PR's getindex
function alt_sumlt(A::UnitLowerTriangular, n, s)
    @inbounds for j in 1:n, i in j:n
        s += altgetindex(A, i, j)
    end
    s
end
function alt_sumall(A::UnitLowerTriangular, n, s)
    @inbounds for j in 1:n, i in 1:n
        s += altgetindex(A, i, j)
    end
    s
end

# Benchmarks proper
using Benchmarks

function prettytimes(res)
    # based on Benchmarks.pretty_time_string
    stats = Benchmarks.SummaryStatistics(res)
    timecenter = stats.elapsed_time_center
    timelower = get(stats.elapsed_time_lower)
    timeupper = get(stats.elapsed_time_upper)
    timecenter < 1_000.0 ? (scalefactor = 1.0; units = "ns") :
        timecenter < 1_000_000.0 ? (scalefactor = 1_000.0; units = "μs") :
            timecenter < 1_000_000_000.0 ? (scalefactor = 1_000_000.0; units = "ms") :
                (scalefactor = 1_000_000_000.0; units = " s")
    @sprintf("%6.2f %s [%6.2f,%6.2f]", timecenter/scalefactor, units, timelower/scalefactor, timeupper/scalefactor)
end

matsize = 1000;
ultdensemat = UnitLowerTriangular(rand(matsize, matsize));
ultsparsemat = UnitLowerTriangular(sprand(matsize, matsize, 0.05));

wm, wt = 10, 25
println(" $(lpad("[branch]", wm)) $(lpad("sumlt/dense", wt)), $(lpad("sumall/dense", wt)) | $(lpad("sumlt/sparse", wt)), $(lpad("sumall/sparse", wt))")
@printf("%s: %s, %s | %s, %s\n",
    lpad("master", wm),
    prettytimes(@benchmark master_sumlt(ultdensemat, matsize, 0.0)),
    prettytimes(@benchmark master_sumall(ultdensemat, matsize, 0.0)),
    prettytimes(@benchmark master_sumlt(ultsparsemat, matsize, 0.0)),
    prettytimes(@benchmark master_sumall(ultsparsemat, matsize, 0.0)) )
@printf("%s: %s, %s | %s, %s\n",
    lpad("this PR", wm),
    prettytimes(@benchmark alt_sumlt(ultdensemat, matsize, 0.0)),
    prettytimes(@benchmark alt_sumall(ultdensemat, matsize, 0.0)),
    prettytimes(@benchmark alt_sumlt(ultsparsemat, matsize, 0.0)),
    prettytimes(@benchmark alt_sumall(ultsparsemat, matsize, 0.0)) )
```

yield

``` julia
[branch]               sumlt/dense,              sumall/dense |              sumlt/sparse,             sumall/sparse
 master:   2.58 ms [  2.33,  2.83],   5.24 ms [  4.86,  5.61] |  12.29 ms [ 11.55, 13.04],  31.49 ms [ 30.51, 32.47]
this PR: 739.79 μs [699.44,780.14],   1.39 ms [  1.30,  1.48] |  10.64 ms [  9.99, 11.28],  28.13 ms [ 26.94, 29.33]   
```

on the Ivy Bridge machine, and

``` julia
[branch]               sumlt/dense,              sumall/dense |              sumlt/sparse,             sumall/sparse
 master:   4.17 ms [  4.13,  4.22],   8.28 ms [  8.19,  8.36] |  15.84 ms [ 15.74, 15.93],  38.27 ms [ 38.03, 38.52]
this PR:   1.13 ms [  1.10,  1.16],   2.15 ms [  2.10,  2.20] |  13.00 ms [ 12.91, 13.08],  33.55 ms [ 33.41, 33.68]
```

on the Piledriver machine. Best! (Edit: xor -> sum)
