### PR TITLE
Don't use pthread_*_np functions to get stack master thread

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -228,7 +228,7 @@ void jl_init_primitives(void);
 void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
 void jl_init_tasks(void);
-void jl_init_stack_limits(void);
+void jl_init_stack_limits(int ismaster);
 void jl_init_root_task(void *stack, size_t ssize);
 void jl_init_serializer(void);
 void jl_gc_init(void);

--- a/src/threading.c
+++ b/src/threading.c
@@ -216,7 +216,7 @@ void ti_threadfun(void *arg)
 
     // initialize this thread (set tid, create heap, etc.)
     ti_initthread(ta->tid);
-    jl_init_stack_limits();
+    jl_init_stack_limits(0);
 
     // set up tasking
     jl_init_root_task(jl_stack_lo, jl_stack_hi - jl_stack_lo);


### PR DESCRIPTION
They seems to return bogus values for master thread on Linux.

For non-windows, this should be basically the same on master thread.

Buildbot runs:
http://buildbot.e.ip.saba.us:8010/builders/build_centos7.1-x64/builds/52
http://buildbot.e.ip.saba.us:8010/builders/build_osx10.9-x64/builds/51
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu12.04-x64/builds/49
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu12.04-x86/builds/50
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu14.04-x64/builds/50
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu14.04-x86/builds/49
Second commit:
http://buildbot.e.ip.saba.us:8010/builders/build_osx10.9-x64/builds/52

Ref https://github.com/JuliaLang/julia/pull/14473#issuecomment-167415471
c.c. @tkelman 

Also fix stack address detection on OSX since the signal (message?) handling thread cannot access the TLS value directly. The same logic is also used by #14190 and they should be combined when both are merged (to the version in this PR). c.c. @vtjnash 
