### PR TITLE
Make generic Ac_mul_B! and A_mul_Bc! work for complex triangular A and B respectively

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -571,7 +571,7 @@ function Ac_mul_B!(A::UpperTriangular, B::StridedVecOrMat)
     end
     for j = 1:n
         for i = m:-1:1
-            Bij = A.data[i,i]*B[i,j]
+            Bij = A.data[i,i]'B[i,j]
             for k = 1:i - 1
                 Bij += A.data[k,i]'B[k,j]
             end
@@ -604,7 +604,7 @@ function Ac_mul_B!(A::LowerTriangular, B::StridedVecOrMat)
     end
     for j = 1:n
         for i = 1:m
-            Bij = A.data[i,i]*B[i,j]
+            Bij = A.data[i,i]'B[i,j]
             for k = i + 1:m
                 Bij += A.data[k,i]'B[k,j]
             end
@@ -703,7 +703,7 @@ function A_mul_Bc!(A::StridedMatrix, B::UpperTriangular)
     end
     for i = 1:m
         for j = 1:n
-            Aij = A[i,j]*B[j,j]
+            Aij = A[i,j]*B.data[j,j]'
             for k = j + 1:n
                 Aij += A[i,k]*B.data[j,k]'
             end
@@ -736,7 +736,7 @@ function A_mul_Bc!(A::StridedMatrix, B::LowerTriangular)
     end
     for i = 1:m
         for j = n:-1:1
-            Aij = A[i,j]*B[j,j]
+            Aij = A[i,j]*B.data[j,j]'
             for k = 1:j - 1
                 Aij += A[i,k]*B.data[j,k]'
             end


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#295. Two questions:
1. I preserved the existing `A.data[i,i]'B[i,j]` style in this pull request. Is there a reason to prefer that style to more explicit expressions like `A.data[i,i]' * B[i,j]` or even `ctranspose(A.data[i,i]) * B[i,j]`?
2. Needs better tests as in JuliaLang/LinearAlgebra.jl#295. I wasn't certain how to go about adding them. Three possible approaches:
   1. Minimal modification. Add `Complex{BigFloat}` to the set of element types to test over in test/linalg/triangular.jl. That change should circumvent the BLAS-calling methods' suspected shadowing of the corresponding generic methods for complex arguments.
   2. Slightly more modification. Add explicit `invoke`s of the generic methods.

Given test/linalg/triangular.jl contains endearing lines like

``` julia
A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't) |> t -> uplo1 == :U ? t : ctranspose(t)))
```

I'm inclined to either touch that file as little as possible (and thus take approach i) or refactor the entire thing. That line is positively clever and concomitantly difficult to decipher. Thanks, and best!
