### PR TITLE
add generic A(t|c)_ldiv_B! for triangular A

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -204,8 +204,8 @@ end
 
 #Linear solvers
 A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(A, b)
-At_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(transpose(A), b)
-Ac_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(ctranspose(A), b)
+At_ldiv_B!(A::Bidiagonal, b::AbstractVector) = A_ldiv_B!(transpose(A), b)
+Ac_ldiv_B!(A::Bidiagonal, b::AbstractVector) = A_ldiv_B!(ctranspose(A), b)
 function A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, B::AbstractMatrix)
     nA,mA = size(A)
     tmp = similar(B,size(B,1))

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -829,6 +829,123 @@ function naivesub!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector=
     end
     x
 end
+# in the following transpose and conjugate transpose naive substitution variants, accumulating in z rather than b[j] significantly improves performance as of Dec 2015
+function At_ldiv_B!(A::LowerTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in n:-1:1
+        z = b[j]
+        for i in n:-1:j+1
+            z -= A.data[i,j] * x[i]
+        end
+        A.data[j,j] == zero(A.data[j,j]) && throw(SingularException(j))
+        x[j] = A.data[j,j] \ z
+    end
+    x
+end
+function At_ldiv_B!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in n:-1:1
+        z = b[j]
+        for i in n:-1:j+1
+            z -= A.data[i,j] * x[i]
+        end
+        x[j] = z
+    end
+    x
+end
+function At_ldiv_B!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in 1:n
+        z = b[j]
+        for i in 1:j-1
+            z -= A.data[i,j] * x[i]
+        end
+        A.data[j,j] == zero(A.data[j,j]) && throw(SingularException(j))
+        x[j] = A.data[j,j] \ z
+    end
+    x
+end
+function At_ldiv_B!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in 1:n
+        z = b[j]
+        for i in 1:j-1
+            z -= A.data[i,j] * x[i]
+        end
+        x[j] = z
+    end
+    x
+end
+function Ac_ldiv_B!(A::LowerTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in n:-1:1
+        z = b[j]
+        for i in n:-1:j+1
+            z -= A.data[i,j]' * x[i]
+        end
+        A.data[j,j] == zero(A.data[j,j]) && throw(SingularException(j))
+        x[j] = A.data[j,j]' \ z
+    end
+    x
+end
+function Ac_ldiv_B!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in n:-1:1
+        z = b[j] # accumulating in z rather than b[j] significantly improves performance as of Dec 2015
+        for i in n:-1:j+1
+            z -= A.data[i,j]' * x[i]
+        end
+        x[j] = z
+    end
+    x
+end
+function Ac_ldiv_B!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in 1:n
+        z = b[j]
+        for i in 1:j-1
+            z -= A.data[i,j]' * x[i]
+        end
+        A.data[j,j] == zero(A.data[j,j]) && throw(SingularException(j))
+        x[j] = A.data[j,j]' \ z
+    end
+    x
+end
+function Ac_ldiv_B!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector = b)
+    n = size(A, 1)
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("first dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
+    end
+    @inbounds for j in 1:n
+        z = b[j]
+        for i in 1:j-1
+            z -= A.data[i,j]' * x[i]
+        end
+        x[j] = z
+    end
+    x
+end
 
 function A_rdiv_B!(A::StridedMatrix, B::UpperTriangular)
     m, n = size(A)


### PR DESCRIPTION
Followup to https://github.com/JuliaLang/julia/pull/14396#issuecomment-164556049. This pull request provides generic `A(t|c)_ldiv_B!` for triangular `A`. Hypothetically test/linalg/triangular.jl already covers these methods but for the caveat mentioned in JuliaLang/LinearAlgebra.jl#295 / JuliaLang/julia#14504.

(edit by `@hayd`: cc @andreasnoack)
