### PR TITLE
fix promotion in bidiagonal backslash, At_ldiv_B, and Ac_ldiv_B. add missing bidiagonal matrix conversions.

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -67,6 +67,13 @@ function convert{T}(::Type{Tridiagonal{T}}, A::Bidiagonal)
 end
 promote_rule{T,S}(::Type{Tridiagonal{T}}, ::Type{Bidiagonal{S}})=Tridiagonal{promote_type(T,S)}
 
+# No-op for trivial conversion Bidiagonal{T} -> Bidiagonal{T}
+convert{T}(::Type{Bidiagonal{T}}, A::Bidiagonal{T}) = A
+# Convert Bidiagonal{Told} to Bidiagonal{Tnew} by constructing a new instance with converted elements
+convert{Tnew,Told}(::Type{Bidiagonal{Tnew}}, A::Bidiagonal{Told}) = Bidiagonal(convert(Vector{Tnew}, A.dv), convert(Vector{Tnew}, A.ev), A.isupper)
+# When asked to convert Bidiagonal{Told} to AbstractMatrix{Tnew}, preserve structure by converting to Bidiagonal{Tnew} <: AbstractMatrix{Tnew}
+convert{Tnew,Told}(::Type{AbstractMatrix{Tnew}}, A::Bidiagonal{Told}) = convert(Bidiagonal{Tnew}, A)
+
 big(B::Bidiagonal) = Bidiagonal(big(B.dv), big(B.ev), B.isupper)
 
 ###################
@@ -220,7 +227,6 @@ function A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, B::AbstractMatrix)
     end
     B
 end
-
 for func in (:Ac_ldiv_B!, :At_ldiv_B!)
     @eval function ($func)(A::Union{Bidiagonal, AbstractTriangular}, B::AbstractMatrix)
         nA,mA = size(A)
@@ -237,9 +243,6 @@ for func in (:Ac_ldiv_B!, :At_ldiv_B!)
         B
     end
 end
-Ac_ldiv_B(A::Union{Bidiagonal, AbstractTriangular}, B::AbstractMatrix) = Ac_ldiv_B!(A,copy(B))
-At_ldiv_B(A::Union{Bidiagonal, AbstractTriangular}, B::AbstractMatrix) = At_ldiv_B!(A,copy(B))
-
 #Generic solver using naive substitution
 function naivesub!{T}(A::Bidiagonal{T}, b::AbstractVector, x::AbstractVector = b)
     N = size(A, 2)
@@ -262,9 +265,15 @@ function naivesub!{T}(A::Bidiagonal{T}, b::AbstractVector, x::AbstractVector = b
     x
 end
 
-function \{T,S}(A::Bidiagonal{T}, B::AbstractVecOrMat{S})
-    TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
-    TS == S ? A_ldiv_B!(A, copy(B)) : A_ldiv_B!(A, convert(AbstractArray{TS}, B))
+### Generic promotion methods and fallbacks
+for (f,g) in ((:\, :A_ldiv_B!), (:At_ldiv_B, :At_ldiv_B!), (:Ac_ldiv_B, :Ac_ldiv_B!))
+    @eval begin
+        function ($f){TA<:Number,TB<:Number}(A::Bidiagonal{TA}, B::AbstractVecOrMat{TB})
+            TAB = typeof((zero(TA)*zero(TB) + zero(TA)*zero(TB))/one(TA))
+            ($g)(convert(AbstractArray{TAB}, A), copy_oftype(B, TAB))
+        end
+        ($f)(A::Bidiagonal, B::AbstractVecOrMat) = ($g)(A, copy(B))
+    end
 end
 
 factorize(A::Bidiagonal) = A

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1038,6 +1038,11 @@ for (f, g) in ((:/, :A_rdiv_B!), (:A_rdiv_Bc, :A_rdiv_Bc!), (:A_rdiv_Bt, :A_rdiv
         end
     end
 end
+### Fallbacks brought in from linalg/bidiag.jl while fixing #14506.
+# Eventually the above promotion methods should be generalized as
+# was done for bidiagonal matrices in #14506.
+At_ldiv_B(A::AbstractTriangular, B::AbstractVecOrMat) = At_ldiv_B!(A, copy(B))
+Ac_ldiv_B(A::AbstractTriangular, B::AbstractVecOrMat) = Ac_ldiv_B!(A, copy(B))
 
 # Complex matrix logarithm for the upper triangular factor, see:
 #   Al-Mohy and Higham, "Improved inverse  scaling and squaring algorithms for


### PR DESCRIPTION
This snippet

``` julia
m = 10
intvec = fill(1, m);
lbdintmat = Bidiagonal(fill(2, m), fill(1, m-1), false);
(\)(lbdintmat, intvec)
```

yields

``` julia
ERROR: InexactError()
 in naivesub! at linalg/bidiag.jl:253
 [inlined code] from linalg/bidiag.jl:206
 in \ at linalg/bidiag.jl:267
 in eval at ./boot.jl:265
```

due to promotion in the relevant backslash definition not accounting for usually-necessary divisions in forward/back substitution. This pull request fixes the promotion.

Needs tests. Question on that front. The linalg/bidiag tests don't catch this by nature of testing only floating-point types. Two potential approaches:
1. Minimal modification. Add targeted tests for this issue.
2. Significant modification. Expand the set and combinations of types tested.

? Thanks, and best!
