### PR TITLE
add missing mul, ldiv, and rdiv variants involving one triangular matrix. also fix #14502.

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -214,8 +214,8 @@ end
 
 #Linear solvers
 A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(A, b)
-At_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(transpose(A), b)
-Ac_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = A_ldiv_B!(ctranspose(A), b)
+At_ldiv_B!(A::Bidiagonal, b::AbstractVector) = A_ldiv_B!(transpose(A), b)
+Ac_ldiv_B!(A::Bidiagonal, b::AbstractVector) = A_ldiv_B!(ctranspose(A), b)
 function A_ldiv_B!(A::Union{Bidiagonal, AbstractTriangular}, B::AbstractMatrix)
     nA,mA = size(A)
     tmp = similar(B,size(B,1))

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -382,6 +382,7 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 
 A_mul_B!(A::Tridiagonal, B::AbstractTriangular) = A*full!(B)
 A_mul_B!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
+A_mul_Bt!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, transpose!(C, B))
 A_mul_Bc!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, ctranspose!(C, B))
 
 for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
@@ -391,14 +392,19 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
     @eval begin
         # Vector multiplication
         A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::$t{T,S}, b::StridedVector{T}) = BLAS.trmv!($uploc, 'N', $isunitc, A.data, b)
+        At_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::$t{T,S}, b::StridedVector{T}) = BLAS.trmv!($uploc, 'T', $isunitc, A.data, b)
+        Ac_mul_B!{T<:BlasReal,S<:StridedMatrix}(A::$t{T,S}, b::StridedVector{T}) = BLAS.trmv!($uploc, 'T', $isunitc, A.data, b)
+        Ac_mul_B!{T<:BlasComplex,S<:StridedMatrix}(A::$t{T,S}, b::StridedVector{T}) = BLAS.trmv!($uploc, 'C', $isunitc, A.data, b)
 
         # Matrix multiplication
         A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::$t{T,S}, B::StridedMatrix{T}) = BLAS.trmm!('L', $uploc, 'N', $isunitc, one(T), A.data, B)
         A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::StridedMatrix{T}, B::$t{T,S}) = BLAS.trmm!('R', $uploc, 'N', $isunitc, one(T), B.data, A)
 
+        At_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::$t{T,S}, B::StridedMatrix{T}) = BLAS.trmm!('L', $uploc, 'T', $isunitc, one(T), A.data, B)
         Ac_mul_B!{T<:BlasComplex,S<:StridedMatrix}(A::$t{T,S}, B::StridedMatrix{T}) = BLAS.trmm!('L', $uploc, 'C', $isunitc, one(T), A.data, B)
         Ac_mul_B!{T<:BlasReal,S<:StridedMatrix}(A::$t{T,S}, B::StridedMatrix{T}) = BLAS.trmm!('L', $uploc, 'T', $isunitc, one(T), A.data, B)
 
+        A_mul_Bt!{T<:BlasFloat,S<:StridedMatrix}(A::StridedMatrix{T}, B::$t{T,S}) = BLAS.trmm!('R', $uploc, 'T', $isunitc, one(T), B.data, A)
         A_mul_Bc!{T<:BlasComplex,S<:StridedMatrix}(A::StridedMatrix{T}, B::$t{T,S}) = BLAS.trmm!('R', $uploc, 'C', $isunitc, one(T), B.data, A)
         A_mul_Bc!{T<:BlasReal,S<:StridedMatrix}(A::StridedMatrix{T}, B::$t{T,S}) = BLAS.trmm!('R', $uploc, 'T', $isunitc, one(T), B.data, A)
 
@@ -581,7 +587,7 @@ function Ac_mul_B!(A::UpperTriangular, B::StridedVecOrMat)
     end
     for j = 1:n
         for i = m:-1:1
-            Bij = A.data[i,i]*B[i,j]
+            Bij = A.data[i,i]'B[i,j]
             for k = 1:i - 1
                 Bij += A.data[k,i]'B[k,j]
             end
@@ -614,7 +620,7 @@ function Ac_mul_B!(A::LowerTriangular, B::StridedVecOrMat)
     end
     for j = 1:n
         for i = 1:m
-            Bij = A.data[i,i]*B[i,j]
+            Bij = A.data[i,i]'B[i,j]
             for k = i + 1:m
                 Bij += A.data[k,i]'B[k,j]
             end
@@ -633,6 +639,72 @@ function Ac_mul_B!(A::UnitLowerTriangular, B::StridedVecOrMat)
             Bij = B[i,j]
             for k = i + 1:m
                 Bij += A.data[k,i]'B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+
+function At_mul_B!(A::UpperTriangular, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    if m != size(A, 1)
+        throw(DimensionMismatch("right hand side B needs first dimension of size $(size(A,1)), has size $m"))
+    end
+    for j = 1:n
+        for i = m:-1:1
+            Bij = A.data[i,i].'B[i,j]
+            for k = 1:i - 1
+                Bij += A.data[k,i].'B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+function At_mul_B!(A::UnitUpperTriangular, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    if m != size(A, 1)
+        throw(DimensionMismatch("right hand side B needs first dimension of size $(size(A,1)), has size $m"))
+    end
+    for j = 1:n
+        for i = m:-1:1
+            Bij = B[i,j]
+            for k = 1:i - 1
+                Bij += A.data[k,i].'B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+
+function At_mul_B!(A::LowerTriangular, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    if m != size(A, 1)
+        throw(DimensionMismatch("right hand side B needs first dimension of size $(size(A,1)), has size $m"))
+    end
+    for j = 1:n
+        for i = 1:m
+            Bij = A.data[i,i].'B[i,j]
+            for k = i + 1:m
+                Bij += A.data[k,i].'B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+function At_mul_B!(A::UnitLowerTriangular, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    if m != size(A, 1)
+        throw(DimensionMismatch("right hand side B needs first dimension of size $(size(A,1)), has size $m"))
+    end
+    for j = 1:n
+        for i = 1:m
+            Bij = B[i,j]
+            for k = i + 1:m
+                Bij += A.data[k,i].'B[k,j]
             end
             B[i,j] = Bij
         end
@@ -713,7 +785,7 @@ function A_mul_Bc!(A::StridedMatrix, B::UpperTriangular)
     end
     for i = 1:m
         for j = 1:n
-            Aij = A[i,j]*B[j,j]
+            Aij = A[i,j]*B.data[j,j]'
             for k = j + 1:n
                 Aij += A[i,k]*B.data[j,k]'
             end
@@ -746,7 +818,7 @@ function A_mul_Bc!(A::StridedMatrix, B::LowerTriangular)
     end
     for i = 1:m
         for j = n:-1:1
-            Aij = A[i,j]*B[j,j]
+            Aij = A[i,j]*B.data[j,j]'
             for k = 1:j - 1
                 Aij += A[i,k]*B.data[j,k]'
             end
@@ -765,6 +837,72 @@ function A_mul_Bc!(A::StridedMatrix, B::UnitLowerTriangular)
             Aij = A[i,j]
             for k = 1:j - 1
                 Aij += A[i,k]*B.data[j,k]'
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+
+function A_mul_Bt!(A::StridedMatrix, B::UpperTriangular)
+    m, n = size(A)
+    if size(B, 1) != n
+        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(size(B,1))"))
+    end
+    for i = 1:m
+        for j = 1:n
+            Aij = A[i,j]*B.data[j,j].'
+            for k = j + 1:n
+                Aij += A[i,k]*B.data[j,k].'
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+function A_mul_Bt!(A::StridedMatrix, B::UnitUpperTriangular)
+    m, n = size(A)
+    if size(B, 1) != n
+        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(size(B,1))"))
+    end
+    for i = 1:m
+        for j = 1:n
+            Aij = A[i,j]
+            for k = j + 1:n
+                Aij += A[i,k]*B.data[j,k].'
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+
+function A_mul_Bt!(A::StridedMatrix, B::LowerTriangular)
+    m, n = size(A)
+    if size(B, 1) != n
+        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(size(B,1))"))
+    end
+    for i = 1:m
+        for j = n:-1:1
+            Aij = A[i,j]*B.data[j,j].'
+            for k = 1:j - 1
+                Aij += A[i,k]*B.data[j,k].'
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+function A_mul_Bt!(A::StridedMatrix, B::UnitLowerTriangular)
+    m, n = size(A)
+    if size(B, 1) != n
+        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(size(B,1))"))
+    end
+    for i = 1:m
+        for j = n:-1:1
+            Aij = A[i,j]
+            for k = 1:j - 1
+                Aij += A[i,k]*B.data[j,k].'
             end
             A[i,j] = Aij
         end

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -341,9 +341,13 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
             # ... and division
             @test_approx_eq A1\B[:,1] full(A1)\B[:,1]
             @test_approx_eq A1\B full(A1)\B
+            @test_approx_eq A1.'\B[:,1] full(A1).'\B[:,1]
             @test_approx_eq A1'\B[:,1] full(A1)'\B[:,1]
+            @test_approx_eq A1.'\B full(A1).'\B
             @test_approx_eq A1'\B full(A1)'\B
+            @test_approx_eq A1\B.' full(A1)\B.'
             @test_approx_eq A1\B' full(A1)\B'
+            @test_approx_eq A1.'\B.' full(A1).'\B.'
             @test_approx_eq A1'\B' full(A1)'\B'
             if t1 == UpperTriangular || t1 == LowerTriangular
                 @test_throws Base.LinAlg.SingularException naivesub!(t1(zeros(elty1,n,n)),ones(eltyB,n))

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -307,25 +307,36 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
             # Triangular-dense Matrix/vector multiplication
             @test_approx_eq A1*B[:,1] full(A1)*B[:,1]
             @test_approx_eq A1*B full(A1)*B
+            @test_approx_eq A1.'B[:,1] full(A1).'B[:,1]
             @test_approx_eq A1'B[:,1] full(A1)'B[:,1]
+            @test_approx_eq A1.'B full(A1).'B
             @test_approx_eq A1'B full(A1)'B
+            @test_approx_eq A1*B.' full(A1)*B.'
             @test_approx_eq A1*B' full(A1)*B'
             @test_approx_eq B*A1 B*full(A1)
+            @test_approx_eq B[:,1].'A1 B[:,1].'full(A1)
             @test_approx_eq B[:,1]'A1 B[:,1]'full(A1)
+            @test_approx_eq B.'A1 B.'full(A1)
             @test_approx_eq B'A1 B'full(A1)
+            @test_approx_eq B*A1.' B*full(A1).'
             @test_approx_eq B*A1' B*full(A1)'
+            @test_approx_eq B[:,1].'A1.' B[:,1].'full(A1).'
             @test_approx_eq B[:,1]'A1' B[:,1]'full(A1)'
+            @test_approx_eq B.'A1.' B.'full(A1).'
             @test_approx_eq B'A1' B'full(A1)'
 
             if eltyB == elty1
                 @test_approx_eq A_mul_B!(zeros(B),A1,B) A1*B
                 @test_approx_eq A_mul_Bc!(zeros(B),A1,B) A1*B'
+                @test_approx_eq A_mul_Bt!(zeros(B),A1,B) A1*B.'
             end
             #error handling
             @test_throws DimensionMismatch Base.LinAlg.A_mul_B!(A1, ones(eltyB,n+1))
             @test_throws DimensionMismatch Base.LinAlg.A_mul_B!(ones(eltyB,n+1,n+1), A1)
+            @test_throws DimensionMismatch Base.LinAlg.At_mul_B!(A1, ones(eltyB,n+1))
             @test_throws DimensionMismatch Base.LinAlg.Ac_mul_B!(A1, ones(eltyB,n+1))
             @test_throws DimensionMismatch Base.LinAlg.A_mul_Bc!(ones(eltyB,n+1,n+1),A1)
+            @test_throws DimensionMismatch Base.LinAlg.A_mul_Bt!(ones(eltyB,n+1,n+1),A1)
 
             # ... and division
             @test_approx_eq A1\B[:,1] full(A1)\B[:,1]

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -2,7 +2,7 @@
 
 debug = false
 using Base.Test
-using Base.LinAlg: BlasFloat, errorbounds, full!, naivesub!, transpose!, UnitUpperTriangular, UnitLowerTriangular, A_rdiv_B!, A_rdiv_Bc!
+using Base.LinAlg: BlasFloat, errorbounds, full!, naivesub!, transpose!, UnitUpperTriangular, UnitLowerTriangular, A_rdiv_B!, A_rdiv_Bt!, A_rdiv_Bc!
 
 debug && println("Triangular matrices")
 
@@ -14,7 +14,7 @@ debug && println("Test basic type functionality")
 @test LowerTriangular(randn(3, 3)) |> t -> [size(t, i) for i = 1:3] == [size(full(t), i) for i = 1:3]
 
 # The following test block tries to call all methods in base/linalg/triangular.jl in order for a combination of input element types. Keep the ordering when adding code.
-for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat}, Int)
     # Begin loop for first Triangular matrix
     for (t1, uplo1) in ((UpperTriangular, :U),
                         (UnitUpperTriangular, :U),
@@ -234,7 +234,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         @test_throws DimensionMismatch naivesub!(A1,ones(elty1,n+1))
 
         # eigenproblems
-        if elty1 != BigFloat # Not handled yet
+        if !(elty1 in (BigFloat, Complex{BigFloat})) # Not handled yet
             vals, vecs = eig(A1)
             if (t1 == UpperTriangular || t1 == LowerTriangular) && elty1 != Int # Cannot really handle degenerate eigen space and Int matrices will probably have repeated eigenvalues.
                 @test_approx_eq_eps vecs*diagm(vals)/vecs full(A1) sqrt(eps(float(real(one(vals[1])))))*(norm(A1, Inf)*n)^2
@@ -249,7 +249,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
             @test cond(A1,2) == cond(full(A1),2)
         end
 
-        if elty1 != BigFloat # Not implemented yet
+        if !(elty1 in (BigFloat, Complex{BigFloat})) # Not implemented yet
             svd(A1)
             svdfact(A1)
             elty1 <: BlasFloat && svdfact!(copy(A1))
@@ -257,7 +257,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         end
 
         # Begin loop for second Triangular matrix
-        for elty2 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+        for elty2 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat}, Int)
             for (t2, uplo2) in ((UpperTriangular, :U),
                                 (UnitUpperTriangular, :U),
                                 (LowerTriangular, :L),
@@ -278,31 +278,37 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                 @test full(A1 + A2) == full(A1) + full(A2)
                 @test full(A1 - A2) == full(A1) - full(A2)
 
-                # Triangular-Triangular multiplication and division
-                elty1 != BigFloat && elty2 != BigFloat && @test_approx_eq full(A1*A2) full(A1)*full(A2)
+                # Triangular-Triangualar multiplication and division
+                @test_approx_eq full(A1*A2) full(A1)*full(A2)
+                @test_approx_eq full(A1.'A2) full(A1).'full(A2)
                 @test_approx_eq full(A1'A2) full(A1)'full(A2)
+                @test_approx_eq full(A1*A2.') full(A1)*full(A2).'
                 @test_approx_eq full(A1*A2') full(A1)*full(A2)'
+                @test_approx_eq full(A1.'A2.') full(A1).'full(A2).'
                 @test_approx_eq full(A1'A2') full(A1)'full(A2)'
                 @test_approx_eq full(A1/A2) full(A1)/full(A2)
-                if elty2 != BigFloat
-                    @test_throws DimensionMismatch eye(n+1)/A2
-                    @test_throws DimensionMismatch eye(n+1)/A2'
-                    @test_throws DimensionMismatch eye(n+1)*A2
-                    @test_throws DimensionMismatch eye(n+1)*A2'
-                    @test_throws DimensionMismatch A2'*eye(n+1)
-                    @test_throws DimensionMismatch A2*eye(n+1)
-                    @test_throws DimensionMismatch A2*ones(n+1)
-                end
+                @test_throws DimensionMismatch eye(n+1)/A2
+                @test_throws DimensionMismatch eye(n+1)/A2.'
+                @test_throws DimensionMismatch eye(n+1)/A2'
+                @test_throws DimensionMismatch eye(n+1)*A2
+                @test_throws DimensionMismatch eye(n+1)*A2.'
+                @test_throws DimensionMismatch eye(n+1)*A2'
+                @test_throws DimensionMismatch A2.'*eye(n+1)
+                @test_throws DimensionMismatch A2'*eye(n+1)
+                @test_throws DimensionMismatch A2*eye(n+1)
+                @test_throws DimensionMismatch A2*ones(n+1) # redundant with immediately preceding test?
             end
         end
 
-        for eltyB in (Float32, Float64, Complex64, Complex128)
+        for eltyB in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat})
             B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
 
             debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
 
-            Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
-            @test_approx_eq Base.LinAlg.A_mul_B!(Tri,copy(A1)) Tri*full(A1)
+            if !(eltyB in (BigFloat, Complex{BigFloat})) # rand does not support BigFloat and Complex{BigFloat} as of Dec 2015
+                Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
+                @test_approx_eq Base.LinAlg.A_mul_B!(Tri,copy(A1)) Tri*full(A1)
+            end
 
             # Triangular-dense Matrix/vector multiplication
             @test_approx_eq A1*B[:,1] full(A1)*B[:,1]
@@ -361,7 +367,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
             @test_approx_eq B'/A1' B'/full(A1)'
 
             # Error bounds
-            elty1 != BigFloat && errorbounds(A1, A1\B, B)
+            !(elty1 in (BigFloat, Complex{BigFloat})) && !(eltyB in (BigFloat, Complex{BigFloat})) && errorbounds(A1, A1\B, B)
 
         end
     end
@@ -472,4 +478,9 @@ let
     @test_throws DimensionMismatch A_rdiv_Bc!(A, UpperTriangular(B))
     @test_throws DimensionMismatch A_rdiv_Bc!(A, UnitLowerTriangular(B))
     @test_throws DimensionMismatch A_rdiv_Bc!(A, UnitUpperTriangular(B))
+
+    @test_throws DimensionMismatch A_rdiv_Bt!(A, LowerTriangular(B))
+    @test_throws DimensionMismatch A_rdiv_Bt!(A, UpperTriangular(B))
+    @test_throws DimensionMismatch A_rdiv_Bt!(A, UnitLowerTriangular(B))
+    @test_throws DimensionMismatch A_rdiv_Bt!(A, UnitUpperTriangular(B))
 end

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -349,8 +349,11 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                 @test_throws Base.LinAlg.SingularException naivesub!(t1(zeros(elty1,n,n)),ones(eltyB,n))
             end
             @test_approx_eq B/A1 B/full(A1)
+            @test_approx_eq B/A1.' B/full(A1).'
             @test_approx_eq B/A1' B/full(A1)'
+            @test_approx_eq B.'/A1 B.'/full(A1)
             @test_approx_eq B'/A1 B'/full(A1)
+            @test_approx_eq B.'/A1.' B.'/full(A1).'
             @test_approx_eq B'/A1' B'/full(A1)'
 
             # Error bounds


### PR DESCRIPTION
Followup to https://github.com/JuliaLang/julia/pull/14396#issuecomment-164556049. Subsumes JuliaLang/julia#14505. ~~Fixes the right-division part of JuliaLang/LinearAlgebra.jl#295 (https://github.com/JuliaLang/LinearAlgebra.jl/issues/295).~~ Update: Now subsumes JuliaLang/julia#14504 as well, fixing JuliaLang/LinearAlgebra.jl#295 altogether.

This pull request provides generic methods, BLAS hooks, and tests for missing matrix-matrix and matrix-vector multiplication, left-division, and right-division operations involving one triangular matrix.

Concerning tests, ~~the shadowing caveat mentioned in JuliaLang/LinearAlgebra.jl#295 / JuliaLang/julia#14504 still stands. Right now I lean towards the simple fix of adding `Complex{BigFloat}` to the set of types tested in test/linalg/triangular.jl.~~ Update: This pull request now expands the combinations of element types tested in linalg/triangular, fixing the shadowing issue and broadening the tests.

Question: Is the `StridedVecOrMat` part of the signature in https://github.com/JuliaLang/julia/blob/6bf6f35b1d522bb17da3feffcdffdf975cecccfa/base/linalg/triangular.jl#L401 correct? I would have thought the LHS could only be a `StridedMatrix`? Thanks!
