### PR TITLE
update linspace to n=50, from n=100 to match code.

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -537,7 +537,7 @@ Ac_rdiv_B
 
 
 """
-    linspace(start, stop, n=100)
+    linspace(start, stop, n=50)
 
 Construct a range of `n` linearly spaced elements from `start` to `stop`.
 """

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -269,7 +269,7 @@ Constructors
 
    Constructs an identity matrix of the same dimensions and type as ``A``\ .
 
-.. function:: linspace(start, stop, n=100)
+.. function:: linspace(start, stop, n=50)
 
    .. Docstring generated from Julia source
 


### PR DESCRIPTION
Fix to documentation for linspace

linspace is defined in
https://github.com/JuliaLang/julia/blob/master/base/range.jl#L235 to
have a default of n=50 points, not n=100.
