### PR TITLE
Fix stride1 computation for sub. Fixes #14509

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -383,6 +383,8 @@ function stride1expr(Atype::Type, Itypes, Aexpr, Isym, LD, Jsym=Isym, Iindex_lin
         I = Itypes[d]
         if I <: Real
             ex = :($ex * size($Aexpr, $d))
+        elseif I <: Range && d < LD && any(x->x<:Union{Range,Colon}, Itypes[d+1:LD])
+            ex = :($ex * ifelse(length($Isym[$d]) == 1, size($Aexpr, $d), step($Isym[$d])))
         else
             if d == Iindex_lin
                 ex = :($ex * step_sa($Jsym[$Jindex_lin]))


### PR DESCRIPTION
I _think_ this fixes #14509 in general, although the logic is complex, and the fact that we test only up to 3 dimensions could bite us. There's an alternative way of fixing this, described below, that would be more robust, but it risks breaking any package that dives into the internal representation of SubArrays.

Here's the logic of the problem and this fix:
- We use `Int` indexes to encode "dropped" dimensions, and `UnitRange{Int}` indexes to encode "retained" dimensions. `sub`, which does not drop anything other than trailing dimensions, therefore converts non-trailing `Int` indexes into `UnitRange{Int}`.
- `Int` indexes don't break uniformity of the stride, whereas `UnitRange` indexes might. Hence there is some conflict between marking dimensions as dropped/retained and having really good `LinearFast` "inference"---`sub` throws away useful information for the latter problem.
- `LD` of the parent SubArray will mark the last dimension at which your slicing did not break the uniformity of the stride. For example, for an `Array` `A`, `sub(A, 2:5, 3, 3, 1:4)` will have `LD = 3`, not `LD = 1`, because those intermediate `Int`s don't cause trouble on their own. However, the stride is 1, not `1 * size(A,2) * size(A,3)` or `size(A,1) * size(A,2) * size(A,3)`.
- When creating a view-of-a-view, if you encounter a `UnitRange` index, _and there is another one by the time you reach the `LD`th index_, you can infer that this is not the one that "broke" uniformity of the stride. In such cases, the stride _should_ be something like `size(A,1) * size(A,2) * size(A,3)`.

The more robust way to fix this would be to end the conflict between encoding dropped/retained dimensions and linear-indexing-inference: internally define

``` jl
immutable IntWrapper
    i::Int
end
```

and have `sub(A, 2, 1:3)` return a `SubArray{T, 2, typeof(A), Tuple{IntWrapper, UnitRange{Int}}, LD}`.

I wonder whether this PR is the way to fix 0.4, but to use IntWrapper for 0.5? Comments would be appreciated.
