### PR TITLE
Some documentation improvements for SharedArrays and Profile.print

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ from Julia's root directory. Sometimes errors only show up in one of them, so if
 Existing docstrings now live primarily in `base/docs/helpdb.jl`.
 It is a goal over time to move the docstrings inline to their respective method definitions.
 If you want to edit the body of a method docstring, run the `doc/genstdlib.jl` script to regenerate the restructured text files **after** you have already rebuilt Julia.
+(From the top-level source directory, you can do this with `make julia-genstdlib`.)
 If you want to edit an existing docstring signature, you **first** have to change the signature in the `doc/stdlib` `..function` or `..data` definition (not the auto-generated content) and *then*
 edit the helpdb.jl or inline method docstrings.  The existing signatures in the `doc/stdlib/*.rst` files are pattern matched to base docstrings and the new content overwrites the content in `doc/stdlib/`.
 The signature definitions **must** be in sync or else the pattern match will fail and documentation will be lost in the result.

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -8744,22 +8744,6 @@ Equivalent to `stat(file).mtime`.
 mtime
 
 """
-    SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
-
-Construct a `SharedArray` of a bitstype `T` and size `dims` across the processes specified
-by `pids` - all of which have to be on the same host.
-
-If `pids` is left unspecified, the shared array will be mapped across all processes on the
-current host, including the master. But, `localindexes` and `indexpids` will only refer to
-worker processes. This facilitates work distribution code to use workers for actual
-computation with the master process acting as a driver.
-
-If an `init` function of the type `initfn(S::SharedArray)` is specified, it is called on all
-the participating workers.
-"""
-SharedArray
-
-"""
     logspace(start, stop, n=50)
 
 Construct a vector of `n` logarithmically spaced numbers from `10^start` to `10^stop`.

--- a/base/docs/helpdb/Profile.jl
+++ b/base/docs/helpdb/Profile.jl
@@ -3,21 +3,28 @@
 # Base.Profile
 
 """
-    print([io::IO = STDOUT,] [data::Vector]; format = :tree, C = false, combine = true)
+    print([io::IO = STDOUT,] [data::Vector]; format = :tree, C = false, combine = true, maxdepth = typemax(Int), sortedby = :filefuncline)
 
-Prints profiling results to `io` (by default, `STDOUT`). If you do not supply a `data`
-vector, the internal buffer of accumulated backtraces will be used. `format` can be `:tree`
-or `:flat`. If `C==true`, backtraces from C and Fortran code are shown. `combine==true`
-merges instruction pointers that correspond to the same line of code.
+Prints profiling results to `io` (by default, `STDOUT`). If you do not
+supply a `data` vector, the internal buffer of accumulated backtraces
+will be used. `format` can be `:tree` or `:flat`. If `C==true`,
+backtraces from C and Fortran code are shown. `combine==true` merges
+instruction pointers that correspond to the same line of
+code. `maxdepth` can be used to limit the depth of printing in `:tree`
+format, while `sortedby` can be used to control the order in `:flat`
+format (`:filefuncline` sorts by the source line, whereas `:count`
+sorts in order of number of collected samples).
 """
 Profile.print(io::IO = STDOUT, data::Vector=?)
 
 """
-    print([io::IO = STDOUT,] data::Vector, lidict::Dict; format = :tree, combine = true)
+    print([io::IO = STDOUT,] data::Vector, lidict::Dict; kwargs)
 
 Prints profiling results to `io`. This variant is used to examine results exported by a
 previous call to [`retrieve`](:func:`retrieve`). Supply the vector `data` of backtraces and
 a dictionary `lidict` of line information.
+
+See `Profile.print([io], data)` for an explanation of the valid keyword arguments.
 """
 Profile.print(io::IO = STDOUT, data::Vector = ?, lidict::Dict = ?)
 

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -35,6 +35,20 @@ call{T}(::Type{SharedArray{T}}, m::Integer, n::Integer; kwargs...) =
 call{T}(::Type{SharedArray{T}}, m::Integer, n::Integer, o::Integer; kwargs...) =
     SharedArray(T, m, n, o; kwargs...)
 
+"""
+    SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
+
+Construct a `SharedArray` of a bitstype `T` and size `dims` across the processes specified
+by `pids` - all of which have to be on the same host.
+
+If `pids` is left unspecified, the shared array will be mapped across all processes on the
+current host, including the master. But, `localindexes` and `indexpids` will only refer to
+worker processes. This facilitates work distribution code to use workers for actual
+computation with the master process acting as a driver.
+
+If an `init` function of the type `initfn(S::SharedArray)` is specified, it is called on all
+the participating workers.
+"""
 function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
     N = length(dims)
 
@@ -96,7 +110,36 @@ end
 
 SharedArray(T, I::Int...; kwargs...) = SharedArray(T, I; kwargs...)
 
-# Create a SharedArray from a disk file
+"""
+    SharedArray(filename::AbstractString, T::Type, dims::NTuple, [offset=0]; mode=nothing, init=false, pids=Int[])
+
+Construct a `SharedArray` backed by the file `filename`, with element
+type `T` (must be a `bitstype`) and size `dims`, across the processes
+specified by `pids` - all of which have to be on the same host. This
+file is mmapped into the host memory, with the following consequences:
+
+- The array data must be represented in binary format (e.g., an ASCII
+  format like CSV cannot be supported)
+
+- Any changes you make to the array values (e.g., `A[3] = 0`) will
+  also change the values on disk
+
+If `pids` is left unspecified, the shared array will be mapped across
+all processes on the current host, including the master. But,
+`localindexes` and `indexpids` will only refer to worker
+processes. This facilitates work distribution code to use workers for
+actual computation with the master process acting as a driver.
+
+`mode` must be one of `"r"`, `"r+"`, `"w+"`, or `"a+"`, and defaults
+to `"r+"` if the file specified by `filename` already exists, or
+`"w+"` if not. If an `init` function of the type
+`initfn(S::SharedArray)` is specified, it is called on all the
+participating workers. You cannot specify an `init` function if the
+file is not writable.
+
+`offset` allows you to skip the specified number of bytes at the
+beginning of the file.
+"""
 function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,Int}, offset::Integer=0; mode=nothing, init=false, pids::Vector{Int}=Int[])
     isabspath(filename) || throw(ArgumentError("$filename is not an absolute path; try abspath(filename)?"))
     isbits(T) || throw(ArgumentError("type of SharedArray elements must be bits types, got $(T)"))
@@ -211,6 +254,20 @@ indexpids(S::SharedArray) = S.pidx
 sdata(S::SharedArray) = S.s
 sdata(A::AbstractArray) = A
 
+"""
+    localindexes(S::SharedArray)
+
+Returns a range describing the "default" indexes to be handled by the
+current process.  This range should be interpreted in the sense of
+linear indexing, i.e., as a sub-range of `1:length(S)`.  In
+multi-process contexts, returns an empty range in the parent process
+(or any process for which `indexpids` returns 0).
+
+It's worth emphasizing that `localindexes` exists purely as a
+convenience, and you can partition work on the array among workers any
+way you wish.  For a SharedArray, all indexes should be equally fast
+for each worker process.
+"""
 localindexes(S::SharedArray) = S.pidx > 0 ? range_1dim(S, S.pidx) : 1:0
 
 unsafe_convert{T}(::Type{Ptr{T}}, S::SharedArray) = unsafe_convert(Ptr{T}, sdata(S))

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -404,7 +404,7 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   Show a more compact representation of a value. This is used for printing array elements. If a new type has a different compact representation, it should test ``Base.limit_output(io)`` in its ``show`` method.
+   Show a more compact representation of a value. This is used for printing array elements. If a new type has a different compact representation, it should test ``Base.limit_output(io)`` in its normal ``show`` method.
 
 .. function:: showall(x)
 

--- a/doc/stdlib/profile.rst
+++ b/doc/stdlib/profile.rst
@@ -24,17 +24,19 @@ The methods in :mod:`Base.Profile` are not exported and need to be called e.g. a
 
    Clear any existing backtraces from the internal buffer.
 
-.. function:: print([io::IO = STDOUT,] [data::Vector]; format = :tree, C = false, combine = true, cols = tty_cols())
+.. function:: print([io::IO = STDOUT,] [data::Vector]; format = :tree, C = false, combine = true, maxdepth = typemax(Int), sortedby = :filefuncline)
 
    .. Docstring generated from Julia source
 
-   Prints profiling results to ``io`` (by default, ``STDOUT``\ ). If you do not supply a ``data`` vector, the internal buffer of accumulated backtraces will be used. ``format`` can be ``:tree`` or ``:flat``\ . If ``C==true``\ , backtraces from C and Fortran code are shown. ``combine==true`` merges instruction pointers that correspond to the same line of code. ``cols`` controls the width of the display.
+   Prints profiling results to ``io`` (by default, ``STDOUT``\ ). If you do not supply a ``data`` vector, the internal buffer of accumulated backtraces will be used. ``format`` can be ``:tree`` or ``:flat``\ . If ``C==true``\ , backtraces from C and Fortran code are shown. ``combine==true`` merges instruction pointers that correspond to the same line of code. ``maxdepth`` can be used to limit the depth of printing in ``:tree`` format, while ``sortedby`` can be used to control the order in ``:flat`` format (``:filefuncline`` sorts by the source line, whereas ``:count`` sorts in order of number of collected samples).
 
-.. function:: print([io::IO = STDOUT,] data::Vector, lidict::Dict; format = :tree, combine = true, cols = tty_cols())
+.. function:: print([io::IO = STDOUT,] data::Vector, lidict::Dict; kwargs)
 
    .. Docstring generated from Julia source
 
    Prints profiling results to ``io``\ . This variant is used to examine results exported by a previous call to :func:`retrieve`\ . Supply the vector ``data`` of backtraces and a dictionary ``lidict`` of line information.
+
+   See ``Profile.print([io], data)`` for an explanation of the valid keyword arguments.
 
 .. function:: init(; n::Integer, delay::Float64)
 


### PR DESCRIPTION
This addresses:
- `localindexes` was not documented (see #12423)
- creating a SharedArray from a file was not documented (see #13679)
- running `genstdlib.jl` reported two errors for `Profile.print`.
