### PR TITLE
Fix #14533

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1017,7 +1017,7 @@ xdump(fn::Function, io::IO, x, n::Int) = xdump(xdump, io, x, n, "")
 xdump(fn::Function, io::IO, args...) = throw(ArgumentError("invalid arguments to xdump"))
 xdump(fn::Function, args...) = xdump(fn, STDOUT::IO, args...)
 xdump(io::IO, args...) = xdump(xdump, io, args...)
-xdump(args...) = with_output_limit(()->xdump(xdump, STDOUT::IO, args...), true)
+xdump(args...) = xdump(xdump, IOContext(STDOUT::IO, :limit_output => true), args...)
 xdump(arg::IO) = xdump(xdump, STDOUT::IO, arg)
 
 # Here are methods specifically for dump:
@@ -1029,7 +1029,7 @@ dump(io::IO, x::AbstractString, n::Int, indent) =
 dump(io::IO, x, n::Int, indent) = xdump(dump, io, x, n, indent)
 dump(io::IO, args...) = throw(ArgumentError("invalid arguments to dump"))
 dump(arg::IO) = xdump(dump, STDOUT::IO, arg)
-dump(args...) = with_output_limit(()->dump(STDOUT::IO, args...), true)
+dump(args...) = dump(IOContext(STDOUT::IO, :limit_output => true), args...)
 
 function dump(io::IO, x::Dict, n::Int, indent)
     println(io, typeof(x), " len ", length(x))


### PR DESCRIPTION
I tried to add a test case for this issue, but this appears to be a REPL-only error, at least to the extent that the test case

```
# issue #14533
function f14533_1()
    buf = IOBuffer()
    dump(buf, "TEST")
    takebuf_string(buf)
end
function f14533_2()
    buf = IOBuffer()
    xdump(buf, "TEST")
    takebuf_string(buf)
end

@test f14533_1() == "ASCIIString \"TEST\"\n"
@test f14533_2() == "ASCIIString \n  data: Array(UInt8,(4,)) UInt8[84,69,83,84]\n"
```

does not reproduce the issue. Interestingly (perhaps for a reason obvious to better-versed individuals) the output from `xdump`-ing to an IOBuffer differs from that just written to STDOUT. In fact, the error in #14533 can be avoided if you call `dump(STDOUT, "TEST")` which does not seem expected...
