### PR TITLE
Rename internal `int.jl` type tuples and unions for clarity

### DIFF
--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -142,7 +142,7 @@ end
 
 ## streamlined hashing for smallish rational types ##
 
-function hash{T<:Integer64}(x::Rational{T}, h::UInt)
+function hash{T<:BitInteger64}(x::Rational{T}, h::UInt)
     num, den = Base.num(x), Base.den(x)
     den == 1 && return hash(num, h)
     den == 0 && return hash(ifelse(num > 0, Inf, -Inf), h)

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -6,7 +6,7 @@ export @printf, @sprintf
 
 ### printf formatter generation ###
 const SmallFloatingPoint = Union{Float64,Float32,Float16}
-const SmallNumber = Union{SmallFloatingPoint,Base.Integer64,UInt128,Int128}
+const SmallNumber = Union{SmallFloatingPoint,Base.BitInteger}
 
 function gen(s::AbstractString)
     args = []

--- a/base/random.jl
+++ b/base/random.jl
@@ -35,8 +35,8 @@ type Close1Open2 <: FloatInterval end
         RandomDevice(unlimited::Bool=true) = new(open(unlimited ? "/dev/urandom" : "/dev/random"))
     end
 
-    rand{ T<:Union{Bool, Base.IntTypes...}}(rd::RandomDevice,  ::Type{T})  = read( rd.file, T)
-    rand!{T<:Union{Bool, Base.IntTypes...}}(rd::RandomDevice, A::Array{T}) = read!(rd.file, A)
+    rand{ T<:Union{Bool, Base.BitInteger}}(rd::RandomDevice,  ::Type{T})  = read( rd.file, T)
+    rand!{T<:Union{Bool, Base.BitInteger}}(rd::RandomDevice, A::Array{T}) = read!(rd.file, A)
 end
 
 @windows_only begin
@@ -47,12 +47,12 @@ end
         RandomDevice() = new(Array(UInt128, 1))
     end
 
-    function rand{T<:Union{Bool, Base.IntTypes...}}(rd::RandomDevice, ::Type{T})
+    function rand{T<:Union{Bool, Base.BitInteger}}(rd::RandomDevice, ::Type{T})
         win32_SystemFunction036!(rd.buffer)
         @inbounds return rd.buffer[1] % T
     end
 
-    rand!{T<:Union{Bool, Base.IntTypes...}}(rd::RandomDevice, A::Array{T}) = (win32_SystemFunction036!(A); A)
+    rand!{T<:Union{Bool, Base.BitInteger}}(rd::RandomDevice, A::Array{T}) = (win32_SystemFunction036!(A); A)
 end
 
 rand(rng::RandomDevice, ::Type{Close1Open2}) =

--- a/test/int.jl
+++ b/test/int.jl
@@ -18,14 +18,12 @@ for y in (4, Float32(4), 4.0, big(4.0))
 end
 
 # Result type must be type of first argument
-for T in (Int8,Int16,Int32,Int64,Int128,BigInt,
-          UInt8,UInt16,UInt32,UInt64,UInt128,
-          Rational{Int},Rational{BigInt},
-          Float16,Float32,Float64)
-    for U in (Int8,Int16,Int32,Int64,Int128,BigInt,
-              Rational{Int},Rational{BigInt},
-              UInt8,UInt16,UInt32,UInt64,UInt128,
-              Float16,Float32,Float64)
+for T in (Base.BitInteger.types..., BigInt,
+          Rational{Int}, Rational{BigInt},
+          Float16, Float32, Float64)
+    for U in (Base.BitInteger.types..., BigInt,
+              Rational{Int}, Rational{BigInt},
+              Float16, Float32, Float64)
         @test typeof(copysign(T(3), U(4))) === T
         @test typeof(flipsign(T(3), U(4))) === T
     end
@@ -91,8 +89,8 @@ end
 bitstype 8 MyBitsType <: Integer
 @test_throws MethodError ~reinterpret(MyBitsType, 0x7b)
 
-UItypes = (UInt8, UInt16, UInt32, UInt64, UInt128)
-SItypes = (Int8, Int16, Int32, Int64, Int128)
+UItypes = Base.BitUnsigned.types
+SItypes = Base.BitSigned.types
 
 for T in UItypes, S in UItypes
     @test promote(S(3), T(3)) === (sizeof(T) < sizeof(S) ? (S(3), S(3)) : (T(3), T(3)))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1125,7 +1125,7 @@ end
 @test_approx_eq (Complex(1,2)/Complex(2.5,3.0))*Complex(2.5,3.0) Complex(1,2)
 @test 0.7 < real(sqrt(Complex(0,1))) < 0.707107
 
-for T in [Int8, Int16, Int32, Int64, Int128]
+for T in Base.BitSigned.types
     @test abs(typemin(T)) == -typemin(T)
     #for x in (typemin(T),convert(T,-1),zero(T),one(T),typemax(T))
     #    @test signed(unsigned(x)) == x
@@ -1137,8 +1137,8 @@ end
 #    @test unsigned(signed(x)) == x
 #end
 
-for S = [Int8,  Int16,  Int32,  Int64],
-    U = [UInt8, UInt16, UInt32, UInt64]
+for S = Base.BitSigned64.types,
+    U = Base.BitUnsigned64.types
     @test !(-one(S) == typemax(U))
     @test -one(S) != typemax(U)
     @test -one(S) < typemax(U)
@@ -1146,7 +1146,7 @@ for S = [Int8,  Int16,  Int32,  Int64],
 end
 
 # check type of constructed rationals
-int_types = [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64]
+int_types = Base.BitInteger64.types
 for N = int_types, D = int_types
     T = promote_type(N,D)
     @test typeof(convert(N,2)//convert(D,3)) <: Rational{T}
@@ -1156,9 +1156,9 @@ end
 @test typeof(convert(Rational{Integer},1)) === Rational{Integer}
 
 # check type of constructed complexes
-real_types = [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Float32, Float64,
-              Rational{Int8}, Rational{UInt8}, Rational{Int16}, Rational{UInt16},
-              Rational{Int32}, Rational{UInt32}, Rational{Int64}, Rational{UInt64}]
+real_types = [Base.BitInteger64.types...,
+              [Rational{T} for T in Base.BitInteger64.types]...,
+              Float32, Float64]
 for A = real_types, B = real_types
     T = promote_type(A,B)
     @test typeof(Complex(convert(A,2),convert(B,3))) <: Complex{T}

--- a/test/random.jl
+++ b/test/random.jl
@@ -315,7 +315,7 @@ for rng in ([], [MersenneTwister()], [RandomDevice()])
     rand!(rng..., BitArray(5))     ::BitArray{1}
     rand!(rng..., BitArray(2, 3))  ::BitArray{2}
 
-    for T in [Base.IntTypes..., Bool, Char, Float16, Float32, Float64]
+    for T in [Base.BitInteger.types..., Bool, Char, Float16, Float32, Float64]
         a0 = rand(rng..., T)       ::T
         a1 = rand(rng..., T, 5)    ::Vector{T}
         a2 = rand(rng..., T, 2, 3) ::Array{T, 2}


### PR DESCRIPTION
`Base/int.jl` uses internally certain tuples and unions of various `[U]Int{8,116,32,64,128}`. I found the current naming scheme somewhat confusing; e.g. `IntTypes` was a tuple whereas  `SignedIntTypes` was a union.

Rename these for consistency:
- Invent name `BitInteger` for all these types
- For tuples, use suffix `Types` (used only for iterating over types)
- For unions, use neither `Union` prefix nor `Types` suffix
- Add some missing cases
- When using these, prefer using unions over splatting tuples.
- Clean up some places where these can be used naturally, e.g. in respective test cases.
