### PR TITLE
Make methodswith() list methods with Union{} args

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -296,7 +296,8 @@ end
 function type_close_enough(x::ANY, t::ANY)
     x == t && return true
     return (isa(x,DataType) && isa(t,DataType) && x.name === t.name &&
-            !isleaftype(t) && x <: t)
+            !isleaftype(t) && x <: t) ||
+           (isa(x,Union) && isa(t,DataType) && any(u -> is(u,t), x.types))
 end
 
 function methodswith(t::Type, f::Function, showparents::Bool=false, meths = Method[])

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -121,6 +121,9 @@ end
 immutable NoMethodHasThisType end
 @test isempty(methodswith(NoMethodHasThisType))
 @test !isempty(methodswith(Int))
+immutable Type4Union end
+func4union(::Union{Type4Union,Int}) = ()
+@test !isempty(methodswith(Type4Union))
 
 # PR #10984
 # Disable on windows because of issue (missing flush) when redirecting STDERR.


### PR DESCRIPTION
methodswith() doesn't show all available methods for a given type. This patch makes it take into account Union{} argument types in the method signatures.
Example for before the patch:

```
julia> methodswith(TCPSocket)
3-element Array{Method,1}:
 connect(sock::TCPSocket, port::Integer) at socket.jl:664
 isreadable(io::TCPSocket) at socket.jl:326
 iswritable(io::TCPSocket) at socket.jl:327
```

After:

```
julia> methodswith(TCPSocket)
5-element Array{Method,1}:
 connect(sock::TCPSocket, port::Integer) at socket.jl:660
 getsockname(sock::Union{Base.TCPServer,TCPSocket}) at socket.jl:733
 isreadable(io::TCPSocket) at socket.jl:320
 iswritable(io::TCPSocket) at socket.jl:321
 listen(cb::Union{Bool,Function}, sock::Union{TCPSocket,UDPSocket}) at socket.jl:695
```
