### PR TITLE
Add GMP patch to fix abort in number test on non-x86

### DIFF
--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -18,6 +18,7 @@ $(SRCDIR)/srccache/gmp-$(GMP_VER)/configure: $(SRCDIR)/srccache/gmp-$(GMP_VER).t
 	cd $(dir $<) && $(TAR) jxf $<
 	touch -c $@
 $(SRCDIR)/srccache/gmp-$(GMP_VER)/patched: $(SRCDIR)/srccache/gmp-$(GMP_VER)/configure
+	cd $(dir $@) && patch < $(SRCDIR)/patches/gmp-exception.patch
 	echo 1 > $@
 $(BUILDDIR)/gmp-$(GMP_VER)/config.status: $(SRCDIR)/srccache/gmp-$(GMP_VER)/configure $(SRCDIR)/srccache/gmp-$(GMP_VER)/patched
 	mkdir -p $(dir $@)

--- a/deps/patches/gmp-exception.patch
+++ b/deps/patches/gmp-exception.patch
@@ -1,0 +1,35 @@
+diff -r 842c2ba359bf errno.c
+--- a/errno.c	Sun Jan 24 22:06:51 2016 +0100
++++ b/errno.c	Thu Jan 28 13:37:54 2016 -0500
+@@ -33,24 +33,24 @@
+ see https://www.gnu.org/licenses/.  */
+ 
+ #include <stdlib.h>
++
++#include <signal.h>
++
+ #include "gmp.h"
+ #include "gmp-impl.h"
+ 
+ int gmp_errno = 0;
+ 
+ 
+-/* The deliberate divide by zero triggers an exception on most systems.  On
+-   those where it doesn't, for example power and powerpc, use abort instead.
+-
+-   Enhancement: Perhaps raise(SIGFPE) (or the same with kill()) would be
+-   better than abort.  Perhaps it'd be possible to get the BSD style
+-   FPE_INTDIV_TRAP parameter in there too.  */
+-
++/* Use SIGFPE on systems which have it. Otherwise, deliberate divide
++   by zero, which triggers an exception on most systems. On those
++   where it doesn't, for example power and powerpc, use abort instead. */
+ void
+ __gmp_exception (int error_bit)
+ {
+   gmp_errno |= error_bit;
+   __gmp_junk = 10 / __gmp_0;
++  raise (SIGFPE);
+   abort ();
+ }
+ 


### PR DESCRIPTION
This affect AArch64 and according to the comment in the code, PPC and PPC64 as well. (Also very likely AArch32). This assertion was previously suppressed by an earlier test failure that is fixed recently (ref https://github.com/JuliaLang/julia/pull/14520#issuecomment-168353963). The numbers test fully pass on AArch64 with this patch.

Patch also submitted to the [gmp-devel list](https://gmplib.org/list-archives/gmp-devel/).
