### PR TITLE
Use correctly sized integer for sharedarray.

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -38,6 +38,16 @@ typealias Cfloat Float32
 typealias Cdouble Float64
 
 const sizeof_off_t = ccall(:jl_sizeof_off_t, Cint, ())
+if OS_NAME !== :Windows
+    const sizeof_mode_t = ccall(:jl_sizeof_mode_t, Cint, ())
+    if sizeof_mode_t == 2
+        typealias Cmode_t Int16
+    elseif sizeof_mode_t == 4
+        typealias Cmode_t Int32
+    elseif sizeof_mode_t == 8
+        typealias Cmode_t Int64
+    end
+end
 
 if sizeof_off_t === 4
     typealias FileOffset Int32

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -58,7 +58,7 @@ function grow!(io::IO, offset::Integer, len::Integer)
     pos = position(io)
     filelen = filesize(io)
     if filelen < offset + len
-        failure = ccall(:ftruncate, Cint, (Cint, Coff_t), fd(io), offset+len)
+        failure = ccall(:jl_ftruncate, Cint, (Cint, Coff_t), fd(io), offset+len)
         Base.systemerror(:ftruncate, failure != 0)
     end
     seek(io, pos)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -524,14 +524,14 @@ end
 
 function _shm_mmap_array(T, dims, shm_seg_name, mode)
     fd_mem = shm_open(shm_seg_name, mode, S_IRUSR | S_IWUSR)
-    systemerror("shm_open() failed for " * shm_seg_name, fd_mem <= 0)
+    systemerror("shm_open() failed for " * shm_seg_name, fd_mem < 0)
 
     s = fdio(fd_mem, true)
 
     # On OSX, ftruncate must to used to set size of segment, just lseek does not work.
     # and only at creation time
     if (mode & JL_O_CREAT) == JL_O_CREAT
-        rc = ccall(:ftruncate, Int, (Int, Int), fd_mem, prod(dims)*sizeof(T))
+        rc = ccall(:ftruncate, Cint, (Cint, Coff_t), fd_mem, prod(dims)*sizeof(T))
         systemerror("ftruncate() failed for shm segment " * shm_seg_name, rc != 0)
     end
 
@@ -539,7 +539,7 @@ function _shm_mmap_array(T, dims, shm_seg_name, mode)
 end
 
 shm_unlink(shm_seg_name) = ccall(:shm_unlink, Cint, (Cstring,), shm_seg_name)
-shm_open(shm_seg_name, oflags, permissions) = ccall(:shm_open, Int, (Cstring, Int, Int), shm_seg_name, oflags, permissions)
+shm_open(shm_seg_name, oflags, permissions) = ccall(:shm_open, Cint, (Cstring, Cint, Cmode_t), shm_seg_name, oflags, permissions)
 
 end # @unix_only
 

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -531,7 +531,7 @@ function _shm_mmap_array(T, dims, shm_seg_name, mode)
     # On OSX, ftruncate must to used to set size of segment, just lseek does not work.
     # and only at creation time
     if (mode & JL_O_CREAT) == JL_O_CREAT
-        rc = ccall(:ftruncate, Cint, (Cint, Coff_t), fd_mem, prod(dims)*sizeof(T))
+        rc = ccall(:jl_ftruncate, Cint, (Cint, Coff_t), fd_mem, prod(dims)*sizeof(T))
         systemerror("ftruncate() failed for shm segment " * shm_seg_name, rc != 0)
     end
 

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -235,7 +235,7 @@
 
 .. data:: Coff_t
 
-   Equivalent to the native ``off_t`` c-type
+   Equivalent to the native ``off_t`` c-type. Note that julia defines ``_FILE_OFFSET_BITS=64`` so this may not be the same as the default value on 32bits Linux.
 
 .. data:: Cwchar_t
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -74,6 +74,7 @@ JL_DLLEXPORT uint32_t jl_getutf8(ios_t *s)
 JL_DLLEXPORT int jl_sizeof_uv_mutex(void) { return sizeof(uv_mutex_t); }
 JL_DLLEXPORT int jl_sizeof_off_t(void) { return sizeof(off_t); }
 #ifndef _OS_WINDOWS_
+JL_DLLEXPORT int jl_sizeof_mode_t(void) { return sizeof(mode_t); }
 JL_DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence) { return lseek(fd, offset, whence); }
 JL_DLLEXPORT ssize_t jl_pwrite(int fd, const void *buf, size_t count, off_t offset)
 {

--- a/src/sys.c
+++ b/src/sys.c
@@ -75,7 +75,14 @@ JL_DLLEXPORT int jl_sizeof_uv_mutex(void) { return sizeof(uv_mutex_t); }
 JL_DLLEXPORT int jl_sizeof_off_t(void) { return sizeof(off_t); }
 #ifndef _OS_WINDOWS_
 JL_DLLEXPORT int jl_sizeof_mode_t(void) { return sizeof(mode_t); }
-JL_DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence) { return lseek(fd, offset, whence); }
+JL_DLLEXPORT int jl_ftruncate(int fd, off_t length)
+{
+    return ftruncate(fd, length);
+}
+JL_DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence)
+{
+    return lseek(fd, offset, whence);
+}
 JL_DLLEXPORT ssize_t jl_pwrite(int fd, const void *buf, size_t count, off_t offset)
 {
     return pwrite(fd, buf, count, offset);


### PR DESCRIPTION
This shouldn't really matter when the function succeed on most (all?) of the platforms we support but it can be confusing when the function returns an error on 64bits since the return value can appear to be positive.

Also change the fd check to allow 0 although I don't really believe this is too important... (one has to close the STDIN for that to happen...)
