### PR TITLE
codegen gcroot optimization

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -22,8 +22,6 @@ macro _propagate_inbounds_meta()
     Expr(:meta, :inline, :propagate_inbounds)
 end
 
-(::Type{T}){T}(arg) = convert(T, arg)::T
-
 convert{T}(::Type{T}, x::T) = x
 
 convert(::Type{Tuple{}}, ::Tuple{}) = ()

--- a/base/int.jl
+++ b/base/int.jl
@@ -260,7 +260,7 @@ end
 
 ## system word size ##
 
-const WORD_SIZE = Int(Int.size)*8
+const WORD_SIZE = convert(Int, Int.size)*8
 
 ## integer promotions ##
 
@@ -303,7 +303,7 @@ typemin(::Type{Int64 }) = -9223372036854775808
 typemax(::Type{Int64 }) = 9223372036854775807
 typemin(::Type{UInt64}) = UInt64(0)
 typemax(::Type{UInt64}) = 0xffffffffffffffff
-@eval typemin(::Type{UInt128}) = $(UInt128(0))
+@eval typemin(::Type{UInt128}) = $(convert(UInt128, 0))
 @eval typemax(::Type{UInt128}) = $(box(UInt128,unbox(Int128,convert(Int128,-1))))
 @eval typemin(::Type{Int128} ) = $(convert(Int128,1)<<127)
 @eval typemax(::Type{Int128} ) = $(box(Int128,unbox(UInt128,typemax(UInt128)>>1)))
@@ -415,3 +415,5 @@ else
     rem(x::Int128,  y::Int128)  = box(Int128,checked_srem_int(unbox(Int128,x),unbox(Int128,y)))
     rem(x::UInt128, y::UInt128) = box(UInt128,checked_urem_int(unbox(UInt128,x),unbox(UInt128,y)))
 end
+
+(::Type{T}){T}(arg) = convert(T, arg)::T

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ SRCS += gc
 endif
 
 ifeq ($(JULIACODEGEN),LLVM)
-SRCS += codegen disasm debuginfo llvm-simdloop
+SRCS += codegen disasm debuginfo llvm-simdloop llvm-gcroot
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
 else

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -492,7 +492,7 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
     }
 
     JL_GC_POP();
-    return mark_julia_type(res, false, rt);
+    return mark_julia_type(res, false, rt, ctx);
 }
 
 // llvmcall(ir, (rettypes...), (argtypes...), args...)
@@ -763,7 +763,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         jl_error("Return type of llvmcall'ed function does not match declared return type");
     }
 
-    return mark_julia_type(inst, retboxed, rtt);
+    return mark_julia_type(inst, retboxed, rtt, ctx);
 }
 
 // --- code generator for ccall itself ---
@@ -778,9 +778,9 @@ static jl_cgval_t mark_or_box_ccall_result(Value *result, bool isboxed, jl_value
         return mark_julia_type(
                 init_bits_value(emit_allocobj(nb), runtime_bt, result),
                 true,
-                (jl_value_t*)jl_pointer_type);
+                (jl_value_t*)jl_pointer_type, ctx);
     }
-    return mark_julia_type(result, isboxed, rt);
+    return mark_julia_type(result, isboxed, rt, ctx);
 }
 
 typedef AttributeSet attr_type;

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1140,7 +1140,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             largty = julia_struct_to_llvm(tti, &isboxed);
         }
         if (isboxed) {
-            ary = boxed(emit_expr(argi, ctx),ctx);
+            ary = boxed(emit_expr(argi, ctx), ctx);
         }
         else {
             assert(!addressOf);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1400,8 +1400,8 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
         }
     //}
     if (isbool)
-        return mark_julia_type(builder.CreateTrunc(elt, T_int1), false, jltype);
-    return mark_julia_type(elt, isboxed, jltype);
+        return mark_julia_type(builder.CreateTrunc(elt, T_int1), false, jltype, ctx);
+    return mark_julia_type(elt, isboxed, jltype, ctx);
 }
 
 static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
@@ -1555,7 +1555,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
                             idx)));
             if ((unsigned)stt->ninitialized != nfields)
                 null_pointer_check(fld, ctx);
-            *ret = mark_julia_type(fld, true, jl_any_type);
+            *ret = mark_julia_type(fld, true, jl_any_type, ctx);
             ret->needsgcroot = strct.needsgcroot || !strct.isimmutable;
             return true;
         }
@@ -1574,7 +1574,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
 #else
             Value *fld = builder.CreateCall2(prepare_call(jlgetnthfieldchecked_func), strct.V, idx);
 #endif
-            *ret = mark_julia_type(fld, true, jl_any_type);
+            *ret = mark_julia_type(fld, true, jl_any_type, ctx);
             return true;
         }
     }
@@ -1604,7 +1604,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
         if (jt == (jl_value_t*)jl_bool_type) {
             fld = builder.CreateTrunc(fld, T_int1);
         }
-        *ret = mark_julia_type(fld, false, jt);
+        *ret = mark_julia_type(fld, false, jt, ctx);
         return true;
     }
     return false;
@@ -1631,7 +1631,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
             Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(builder.CreateBitCast(addr, T_ppjlvalue)));
             if (idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
-            jl_cgval_t ret = mark_julia_type(fldv, true, jfty);
+            jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx);
             ret.needsgcroot = strct.needsgcroot || !strct.isimmutable;
             return ret;
         }
@@ -1659,7 +1659,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
             fldv = builder.CreateTrunc(fldv, T_int1);
         }
         assert(!jl_field_isptr(jt, idx));
-        return mark_julia_type(fldv, false, jfty);
+        return mark_julia_type(fldv, false, jfty, ctx);
     }
 }
 
@@ -2058,7 +2058,7 @@ static Value *boxed(const jl_cgval_t &vinfo, jl_codectx_t *ctx, jl_value_t *jt)
 static void emit_cpointercheck(const jl_cgval_t &x, const std::string &msg, jl_codectx_t *ctx)
 {
     Value *t = emit_typeof(x);
-    emit_typecheck(mark_julia_type(t, true, jl_any_type), (jl_value_t*)jl_datatype_type, msg, ctx);
+    emit_typecheck(mark_julia_type(t, true, jl_any_type, ctx), (jl_value_t*)jl_datatype_type, msg, ctx);
 
     Value *istype =
         builder.CreateICmpEQ(emit_nthptr(t, (ssize_t)(offsetof(jl_datatype_t,name)/sizeof(char*)), tbaa_datatype),
@@ -2203,7 +2203,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                 }
                 idx++;
             }
-            return mark_julia_type(strct, false, ty);
+            return mark_julia_type(strct, false, ty, ctx);
         }
         Value *f1 = NULL;
         size_t j = 0;
@@ -2219,11 +2219,11 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
         Value *strct = emit_allocobj(sty->size);
         if (nf > j)
             make_gcrooted(strct, ctx);
-        jl_cgval_t strctinfo = mark_julia_type(strct, true, ty);
+        jl_cgval_t strctinfo = mark_julia_type(strct, true, ty, ctx);
         builder.CreateStore(literal_pointer_val((jl_value_t*)ty),
                             emit_typeptr_addr(strct));
         if (f1) {
-            jl_cgval_t f1info = mark_julia_type(f1, true, jl_any_type);
+            jl_cgval_t f1info = mark_julia_type(f1, true, jl_any_type, ctx);
             if (!jl_subtype(expr_type(args[1],ctx), jl_field_type(sty,0), 0))
                 emit_typecheck(f1info, jl_field_type(sty,0), "new", ctx);
             emit_setfield(sty, strctinfo, 0, f1info, ctx, false, false);
@@ -2263,7 +2263,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             return emit_unboxed(args[1], ctx);  // do side effects
         Type *lt = julia_type_to_llvm(ty);
         assert(lt != T_pjlvalue);
-        return mark_julia_type(UndefValue::get(lt), false, ty);
+        return mark_julia_type(UndefValue::get(lt), false, ty, ctx);
     }
     else {
         // 0 fields, singleton

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2206,7 +2206,6 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             return mark_julia_type(strct, false, ty);
         }
         Value *f1 = NULL;
-        int fieldStart = ctx->gc.argDepth;
         bool needroots = false;
         for (size_t i = 1;i < nargs;i++) {
             if (might_need_root(args[i])) {
@@ -2224,7 +2223,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             f1 = boxed(fval_info, ctx);
             j++;
             if (might_need_root(args[1]) || !fval_info.isboxed)
-                make_gcroot(f1, ctx);
+                make_gcrooted(f1, ctx);
         }
         Value *strct = emit_allocobj(sty->size);
         jl_cgval_t strctinfo = mark_julia_type(strct, true, ty);
@@ -2235,12 +2234,11 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             if (!jl_subtype(expr_type(args[1],ctx), jl_field_type(sty,0), 0))
                 emit_typecheck(f1info, jl_field_type(sty,0), "new", ctx);
             emit_setfield(sty, strctinfo, 0, f1info, ctx, false, false);
-            ctx->gc.argDepth = fieldStart;
             if (nf > 1 && needroots)
-                make_gcroot(strct, ctx);
+                make_gcrooted(strct, ctx);
         }
         else if (nf > 0 && needroots) {
-            make_gcroot(strct, ctx);
+            make_gcrooted(strct, ctx);
         }
         for(size_t i=j; i < nf; i++) {
             if (jl_field_isptr(sty, i)) {
@@ -2259,7 +2257,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                 if (!needroots) {
                     // if this struct element needs boxing and we haven't rooted
                     // the struct, root it now.
-                    make_gcroot(strct, ctx);
+                    make_gcrooted(strct, ctx);
                     needroots = true;
                 }
                 need_wb = true;
@@ -2272,7 +2270,6 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                 need_wb = true;
             emit_setfield(sty, strctinfo, i-1, rhs, ctx, false, need_wb);
         }
-        ctx->gc.argDepth = fieldStart;
         return strctinfo;
     }
     else if (!sty->mutabl) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3700,19 +3700,21 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
     unsigned maxDepth, argSpaceSize;
     jl_codegen_finalize_temp_arg(newgcframe, last_gcframe_inst, maxDepth, argSpaceSize);
 
-    builder.SetInsertPoint(++BasicBlock::iterator(last_gcframe_inst)); // set insert *before* point, e.g. after the gcframe
-    DebugLoc noDbg;
-    builder.SetCurrentDebugLocation(noDbg);
+    if (last_gcframe_inst) {
+        builder.SetInsertPoint(++BasicBlock::iterator(last_gcframe_inst)); // set insert *before* point, e.g. after the gcframe
+        DebugLoc noDbg;
+        builder.SetCurrentDebugLocation(noDbg);
 
-    builder.CreateStore(ConstantInt::get(T_size, (argSpaceSize + maxDepth) << 1),
-                        builder.CreateBitCast(builder.CreateConstGEP1_32(newgcframe, 0), T_psize));
-    builder.CreateStore(builder.CreateLoad(emit_pgcstack(ctx)),
-                        builder.CreatePointerCast(builder.CreateConstGEP1_32(newgcframe, 1), PointerType::get(T_ppjlvalue,0)));
-    builder.CreateStore(newgcframe, emit_pgcstack(ctx));
+        builder.CreateStore(ConstantInt::get(T_size, (argSpaceSize + maxDepth) << 1),
+                            builder.CreateBitCast(builder.CreateConstGEP1_32(newgcframe, 0), T_psize));
+        builder.CreateStore(builder.CreateLoad(emit_pgcstack(ctx)),
+                            builder.CreatePointerCast(builder.CreateConstGEP1_32(newgcframe, 1), PointerType::get(T_ppjlvalue,0)));
+        builder.CreateStore(newgcframe, emit_pgcstack(ctx));
 
-    // Finish allocating the real GC frame
-    // n_frames++;
-    emit_gcpops(ctx);
+        // Finish allocating the real GC frame
+        // n_frames++;
+        emit_gcpops(ctx);
+    }
 }
 
 // here argt does not include the leading function type argument

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -419,10 +419,10 @@ static Function *resetstkoflw_func;
 static Function *diff_gc_total_bytes_func;
 
 // placeholder functions
-Function *gcroot_func;
-Function *gckill_func;
-Function *jlcall_frame_func;
-Function *jlcall_root_func;
+static Function *gcroot_func;
+static Function *gckill_func;
+static Function *jlcall_frame_func;
+static Function *jlcall_root_func;
 
 static std::vector<Type *> two_pvalue_llvmt;
 static std::vector<Type *> three_pvalue_llvmt;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -342,10 +342,10 @@ extern RTDyldMemoryManager *createRTDyldMemoryManagerOSX();
 extern RTDyldMemoryManager *createRTDyldMemoryManagerUnix();
 #endif
 
+static Function *jltls_states_func;
 #ifndef JULIA_ENABLE_THREADING
 static GlobalVariable *jltls_states_var;
 #else
-static Function *jltls_states_func;
 // Imaging mode only
 static GlobalVariable *jltls_states_func_ptr = NULL;
 static size_t jltls_states_func_idx = 0;
@@ -544,12 +544,6 @@ typedef struct {
     jl_value_t *ty;
 } jl_arrayvar_t;
 
-struct jl_gcinfo_t {
-    AllocaInst *gcframe;
-    Value *ptlsStates;
-    bool hasframe;
-};
-
 // Keeps tracks of all functions and compile units created during this cycle
 // to be able to atomically add them to a module.
 typedef struct {
@@ -584,7 +578,7 @@ typedef struct {
     std::vector<bool> boundsCheck;
     std::vector<bool> inbounds;
 
-    jl_gcinfo_t gc;
+    CallInst *ptlsStates;
 
     llvm::DIBuilder *dbuilder;
     bool debug_enabled;
@@ -621,13 +615,14 @@ static Value *global_binding_pointer(jl_module_t *m, jl_sym_t *s,
 static jl_cgval_t emit_checked_var(Value *bp, jl_sym_t *name, jl_codectx_t *ctx, bool isvol=false);
 static Value *emit_condition(jl_value_t *cond, const std::string &msg, jl_codectx_t *ctx);
 static void allocate_gc_frame(BasicBlock *b0, jl_codectx_t *ctx);
-static void finalize_gc_frame(jl_codectx_t *ctx);
+static void finalize_gc_frame(Function *F);
+static void finalize_gc_frame(Module *m);
 
 // --- convenience functions for tagging llvm values with julia types ---
 
 static AllocaInst *emit_static_alloca(Type *lty, int arraysize, jl_codectx_t *ctx)
 {
-    return new AllocaInst(lty, ConstantInt::get(T_int32, arraysize), "", /*InsertBefore=*/ctx->gc.gcframe);
+    return new AllocaInst(lty, ConstantInt::get(T_int32, arraysize), "", /*InsertBefore=*/ctx->ptlsStates);
 }
 static AllocaInst *emit_static_alloca(Type *lty, jl_codectx_t *ctx)
 {
@@ -899,6 +894,8 @@ static Function *to_function(jl_lambda_info_t *li, jl_cyclectx_t *cyclectx)
         jl_add_linfo_in_flight((specf ? specf : f)->getName(), li, DL);
     }
 #if !defined(USE_MCJIT) && !defined(USE_ORCJIT)
+    finalize_gc_frame(f);
+    if (specf) finalize_gc_frame(specf);
 #ifdef JL_DEBUG_BUILD
     if (verifyFunction(*f, PrintMessageAction) ||
         (specf && verifyFunction(*specf, PrintMessageAction))) {
@@ -980,6 +977,7 @@ static void jl_finalize_module(Module *m)
         false, GlobalVariable::InternalLinkage,
         ConstantAggregateZero::get(atype), "__catchjmp"))->setSection(".text");
 #endif
+    finalize_gc_frame(m);
     assert(jl_ExecutionEngine);
 #if defined(LLVM36) && !defined(USE_ORCJIT)
     jl_ExecutionEngine->addModule(std::unique_ptr<Module>(m));
@@ -1036,6 +1034,7 @@ static uint64_t getAddressForOrCompileFunction(llvm::Function *llvmf)
             if(verifyFunction(F))
                 writeRecoveryFile(backup);
             #endif
+            finalize_gc_frame(&F);
             FPM->run(F);
             #ifdef JL_DEBUG_BUILD
             if(verifyFunction(F))
@@ -1998,8 +1997,7 @@ static void simple_escape_analysis(jl_value_t *expr, bool esc, jl_codectx_t *ctx
 // Emit a gc-root slot indicator
 static Value* emit_local_slot(jl_codectx_t *ctx)
 {
-    CallInst *newroot = CallInst::Create(gcroot_func, "", /*InsertBefore*/ctx->gc.gcframe);
-    ctx->gc.hasframe = true;
+    CallInst *newroot = CallInst::Create(prepare_call(gcroot_func), "", /*InsertBefore*/ctx->ptlsStates);
     return newroot;
 }
 
@@ -2007,7 +2005,7 @@ static Value* emit_local_slot(jl_codectx_t *ctx)
 static void mark_gc_use(const jl_cgval_t &v)
 {
     if (v.gcroot)
-        builder.CreateCall(gckill_func, v.gcroot);
+        builder.CreateCall(prepare_call(gckill_func), v.gcroot);
 }
 
 static Value *get_gcrooted(const jl_cgval_t &v, jl_codectx_t *ctx) // TODO: this function should be removed
@@ -2023,7 +2021,7 @@ static Value *get_gcrooted(const jl_cgval_t &v, jl_codectx_t *ctx) // TODO: this
 static Value *make_jlcall(ArrayRef<const jl_cgval_t*> args, jl_codectx_t *ctx)
 {
     // the temporary variables are after all local variables in the GC frame.
-    CallInst *largs = builder.CreateCall(jlcall_frame_func, ConstantInt::get(T_int32, args.size()));
+    CallInst *largs = builder.CreateCall(prepare_call(jlcall_frame_func), ConstantInt::get(T_int32, args.size()));
     int slot = 0;
     assert(args.size() > 0);
     for (ArrayRef<const jl_cgval_t*>::iterator I = args.begin(), E = args.end(); I < E; ++I, ++slot) {
@@ -2031,7 +2029,6 @@ static Value *make_jlcall(ArrayRef<const jl_cgval_t*> args, jl_codectx_t *ctx)
         Value *newroot = builder.CreateGEP(largs, ConstantInt::get(T_int32, slot));
         builder.CreateStore(arg, newroot);
     }
-    ctx->gc.hasframe = true;
     return largs;
 }
 
@@ -3638,83 +3635,75 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
 // gc frame emission
 static void allocate_gc_frame(BasicBlock *b0, jl_codectx_t *ctx)
 {
-    // allocate a placeholder gc frame
-    jl_gcinfo_t *gc = &ctx->gc;
-    gc->hasframe = false;
-
-#ifdef JULIA_ENABLE_THREADING
-    CallInst *calltls;
-    if (imaging_mode) {
-        Value *getter = tbaa_decorate(tbaa_const,
-                                      builder.CreateLoad(jltls_states_func_ptr));
-        FunctionType *functype = jltls_states_func->getFunctionType();
-        Value *func = builder.CreateBitCast(getter,
-                                            PointerType::get(functype, 0));
-        calltls = builder.CreateCall(func);
-    }
-    else {
-        calltls = builder.CreateCall(prepare_call(jltls_states_func));
-    }
-    calltls->setAttributes(jltls_states_func->getAttributes());
-    gc->ptlsStates = calltls;
-#else
-    gc->ptlsStates = prepare_global(jltls_states_var);
-#endif
-
-    gc->gcframe = builder.CreateAlloca(T_pjlvalue, ConstantInt::get(T_int32, 0));
-#ifdef JL_DEBUG_BUILD
-    gc->gcframe->setName("gcrootframe");
-#endif
+    // allocate a placeholder gc instruction
+    ctx->ptlsStates = builder.CreateCall(prepare_call(jltls_states_func));
 }
 
-static void
-emit_gcpops(jl_codectx_t *ctx)
+void jl_codegen_finalize_temp_arg(CallInst *ptlsStates, Type *T_pjlvalue);
+static void finalize_gc_frame(Function *F)
 {
-    Function *F = ctx->f;
-    for(Function::iterator I = F->begin(), E = F->end(); I != E; ++I) {
-        assert(I->getTerminator() != NULL);
-        if (isa<ReturnInst>(I->getTerminator())) {
-            builder.SetInsertPoint(I->getTerminator()); // set insert *before* Ret
-            Instruction *gcpop =
-                (Instruction*)builder.CreateConstGEP1_32(ctx->gc.gcframe, 1);
-            builder.CreateStore(builder.CreatePointerCast(builder.CreateLoad(gcpop),
-                                                      T_ppjlvalue),
-                                emit_pgcstack(ctx));
+    Module *M = F->getParent();
+    M->getOrInsertFunction(gcroot_func->getName(), gcroot_func->getFunctionType());
+    M->getOrInsertFunction(gckill_func->getName(), gckill_func->getFunctionType());
+    M->getOrInsertFunction(jlcall_frame_func->getName(), jlcall_frame_func->getFunctionType());
+    M->getOrInsertFunction(jlcall_root_func->getName(), jlcall_root_func->getFunctionType());
+    Function *jl_get_ptls_states = M->getFunction("jl_get_ptls_states");
+
+    CallInst *ptlsStates = NULL;
+    for (BasicBlock::iterator i = F->getEntryBlock().begin(), e = F->getEntryBlock().end(); i != e; ++i) {
+        if (CallInst *callInst = dyn_cast<CallInst>(&*i)) {
+            if (callInst->getCalledFunction() == jl_get_ptls_states) {
+                ptlsStates = callInst;
+                break;
+            }
         }
     }
+    if (!ptlsStates)
+        return;
+
+    jl_codegen_finalize_temp_arg(ptlsStates, T_pjlvalue);
+
+#ifdef JULIA_ENABLE_THREADING
+    if (imaging_mode) {
+        Value *getter = tbaa_decorate(tbaa_const, new LoadInst(jltls_states_func_ptr, "", ptlsStates));
+        ptlsStates->setCalledFunction(getter);
+    }
+    ptlsStates->setAttributes(jltls_states_func->getAttributes());
+#else
+    Module *destModule = F->getParent();
+    GlobalVariable *GV = destModule->getGlobalVariable(jltls_states_var->getName());
+    if (GV == NULL) {
+        GV = new GlobalVariable(*destModule,
+            jltls_states_var->getType()->getElementType(),
+            jltls_states_var->isConstant(),
+            GlobalVariable::ExternalLinkage,
+            NULL,
+            jltls_states_var->getName());
+        GV->copyAttributesFrom(jltls_states_var);
+    }
+    ptlsStates->replaceAllUsesWith(GV);
+    ptlsStates->eraseFromParent();
+#endif
 }
 
-void jl_codegen_finalize_temp_arg(AllocaInst *gcframe, Instruction *&last_gcframe_inst, unsigned &argSpaceSize, unsigned &maxDepth);
-static void finalize_gc_frame(jl_codectx_t *ctx)
+static void finalize_gc_frame(Module *m)
 {
-    jl_gcinfo_t *gc = &ctx->gc;
-    AllocaInst *newgcframe = gc->gcframe;
-    if (!gc->hasframe) {
-        // 0 roots; remove gc frame entirely
-        newgcframe->eraseFromParent();
-        return;
+#if defined(USE_ORCJIT)
+    for (auto &F : m->functions()) {
+        if (F.isDeclaration())
+            continue;
+        finalize_gc_frame(&F);
     }
-    // Finalize the jlcall argument frames
-    // optimize the gcframe
-    Instruction *last_gcframe_inst;
-    unsigned maxDepth, argSpaceSize;
-    jl_codegen_finalize_temp_arg(newgcframe, last_gcframe_inst, maxDepth, argSpaceSize);
-
-    if (last_gcframe_inst) {
-        builder.SetInsertPoint(++BasicBlock::iterator(last_gcframe_inst)); // set insert *before* point, e.g. after the gcframe
-        DebugLoc noDbg;
-        builder.SetCurrentDebugLocation(noDbg);
-
-        builder.CreateStore(ConstantInt::get(T_size, (argSpaceSize + maxDepth) << 1),
-                            builder.CreateBitCast(builder.CreateConstGEP1_32(newgcframe, 0), T_psize));
-        builder.CreateStore(builder.CreateLoad(emit_pgcstack(ctx)),
-                            builder.CreatePointerCast(builder.CreateConstGEP1_32(newgcframe, 1), PointerType::get(T_ppjlvalue,0)));
-        builder.CreateStore(newgcframe, emit_pgcstack(ctx));
-
-        // Finish allocating the real GC frame
-        // n_frames++;
-        emit_gcpops(ctx);
-    }
+#endif
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+#ifndef JULIA_ENABLE_THREADING
+    m->getFunction("jl_get_ptls_states")->eraseFromParent();
+#endif
+    m->getFunction("julia.gc_root_decl")->eraseFromParent();
+    m->getFunction("julia.gc_root_kill")->eraseFromParent();
+    m->getFunction("julia.jlcall_frame_decl")->eraseFromParent();
+    m->getFunction("julia.jlcall_root_decl")->eraseFromParent();
+#endif
 }
 
 // here argt does not include the leading function type argument
@@ -3822,8 +3811,7 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
         theFptr = (Function*)lam->functionObjects.functionObject;
         specsig = false;
         jlfunc_sret = false;
-        myargs = builder.CreateCall(jlcall_frame_func, ConstantInt::get(T_int32, nargs));
-        ctx.gc.hasframe = true;
+        myargs = builder.CreateCall(prepare_call(jlcall_frame_func), ConstantInt::get(T_int32, nargs));
     }
     assert(theFptr);
 
@@ -3981,9 +3969,9 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
         builder.CreateRetVoid();
     else
         builder.CreateRet(r);
-    finalize_gc_frame(&ctx);
 
 #if !defined(USE_MCJIT) && !defined(USE_ORCJIT)
+    finalize_gc_frame(cw);
     FPM->run(*cw);
 #endif
 
@@ -4078,7 +4066,6 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, jl_expr_t *ast, Funct
     if (sret) { assert(!retboxed); }
     jl_cgval_t retval = sret ? mark_julia_slot(result, jlretty) : mark_julia_type(call, retboxed, jlretty, &ctx);
     builder.CreateRet(boxed(retval, &ctx));
-    finalize_gc_frame(&ctx);
 
     return w;
 }
@@ -4955,9 +4942,6 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
         }
     }
 
-    // step 16. fix up size of stack root list
-    finalize_gc_frame(&ctx);
-
     // step 17, Apply LLVM level inlining
     for(std::vector<CallInst*>::iterator it = ctx.to_inline.begin(); it != ctx.to_inline.end(); ++it) {
         Function *inlinef = (*it)->getCalledFunction();
@@ -5295,13 +5279,16 @@ static void init_julia_llvm_env(Module *m)
 
 #ifndef JULIA_ENABLE_THREADING
     // For non-threading, we use the address of the global variable directly
-    size_t tls_states_size = LLT_ALIGN(sizeof(jl_tls_states_t),
-                                       sizeof(void*)) / sizeof(void*);
     jltls_states_var =
-        new GlobalVariable(*m, ArrayType::get(T_pint8, tls_states_size),
+        new GlobalVariable(*m, T_ppjlvalue,
                            false, GlobalVariable::ExternalLinkage,
                            NULL, "jl_tls_states");
     add_named_global(jltls_states_var, &jl_tls_states);
+    // placeholder function for keeping track of the end of the gcframe
+    jltls_states_func = Function::Create(FunctionType::get(jltls_states_var->getType(), false),
+                                         Function::ExternalLinkage,
+                                         "jl_get_ptls_states", m);
+    add_named_global(jltls_states_func, (void*)NULL, /*dllimport*/false);
 #else
     // For threading, we emit a call to the getter function.
     // In non-imaging mode, (i.e. the code will not be saved to disk), we
@@ -5311,7 +5298,7 @@ static void init_julia_llvm_env(Module *m)
     // variable to be filled (in `dump.c`) at initialization time of the sysimg.
     // This way we can by pass the extra indirection in `jl_get_ptls_states`
     // since we don't know which getter function to use ahead of time.
-    jltls_states_func = Function::Create(FunctionType::get(T_ppint8, false),
+    jltls_states_func = Function::Create(FunctionType::get(PointerType::get(T_ppjlvalue, 0), false),
                                          Function::ExternalLinkage,
                                          "jl_get_ptls_states", m);
     jltls_states_func->setAttributes(
@@ -5322,10 +5309,11 @@ static void init_julia_llvm_env(Module *m)
                       AttributeSet::FunctionIndex, Attribute::NoUnwind));
     add_named_global(jltls_states_func, jl_get_ptls_states_getter());
     if (imaging_mode) {
+        PointerType *pfunctype = jltls_states_func->getFunctionType()->getPointerTo();
         jltls_states_func_ptr =
-            new GlobalVariable(*m, T_ppint8,
+            new GlobalVariable(*m, pfunctype,
                                false, GlobalVariable::InternalLinkage,
-                               ConstantPointerNull::get((PointerType*)T_ppint8),
+                               ConstantPointerNull::get(pfunctype),
                                "jl_get_ptls_states.ptr");
         addComdat(jltls_states_func_ptr);
 #ifdef USE_MCJIT
@@ -5726,26 +5714,26 @@ static void init_julia_llvm_env(Module *m)
         Function::Create(FunctionType::get(T_ppjlvalue, false),
                      Function::ExternalLinkage,
                      "julia.gc_root_decl", m);
-    add_named_global(gcroot_func, NULL, /*dllimport*/false);
+    add_named_global(gcroot_func, (void*)NULL, /*dllimport*/false);
 
     gckill_func =
         Function::Create(FunctionType::get(T_void, ArrayRef<Type*>(T_ppjlvalue), false),
                      Function::ExternalLinkage,
                      "julia.gc_root_kill", m);
-    add_named_global(gcroot_func, NULL, /*dllimport*/false);
+    add_named_global(gckill_func, (void*)NULL, /*dllimport*/false);
 
     jlcall_frame_func =
         Function::Create(FunctionType::get(T_ppjlvalue, ArrayRef<Type*>(T_int32), false),
                      Function::ExternalLinkage,
                      "julia.jlcall_frame_decl", m);
-    add_named_global(jlcall_frame_func, NULL, /*dllimport*/false);
+    add_named_global(jlcall_frame_func, (void*)NULL, /*dllimport*/false);
 
     Type* jlcall_root_args[2] = { T_ppjlvalue, T_int32 };
     jlcall_root_func =
         Function::Create(FunctionType::get(T_ppjlvalue, makeArrayRef(jlcall_root_args),  false),
                      Function::ExternalLinkage,
                      "julia.jlcall_root_decl", m);
-    add_named_global(jlcall_root_func, NULL, /*dllimport*/false);
+    add_named_global(jlcall_root_func, (void*)NULL, /*dllimport*/false);
 
     // set up optimization passes
 #ifdef LLVM38

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5724,26 +5724,26 @@ static void init_julia_llvm_env(Module *m)
         Function::Create(FunctionType::get(T_ppjlvalue, false),
                      Function::ExternalLinkage,
                      "julia.gc_root_decl", m);
-    add_named_global(gcroot_func, NULL);
+    add_named_global(gcroot_func, NULL, /*dllimport*/false);
 
     gckill_func =
         Function::Create(FunctionType::get(T_void, ArrayRef<Type*>(T_ppjlvalue), false),
                      Function::ExternalLinkage,
                      "julia.gc_root_kill", m);
-    add_named_global(gcroot_func, NULL);
+    add_named_global(gcroot_func, NULL, /*dllimport*/false);
 
     jlcall_frame_func =
         Function::Create(FunctionType::get(T_ppjlvalue, ArrayRef<Type*>(T_int32), false),
                      Function::ExternalLinkage,
                      "julia.jlcall_frame_decl", m);
-    add_named_global(jlcall_frame_func, NULL);
+    add_named_global(jlcall_frame_func, NULL, /*dllimport*/false);
 
     Type* jlcall_root_args[2] = { T_ppjlvalue, T_int32 };
     jlcall_root_func =
         Function::Create(FunctionType::get(T_ppjlvalue, makeArrayRef(jlcall_root_args),  false),
                      Function::ExternalLinkage,
                      "julia.jlcall_root_decl", m);
-    add_named_global(jlcall_root_func, NULL);
+    add_named_global(jlcall_root_func, NULL, /*dllimport*/false);
 
     // set up optimization passes
 #ifdef LLVM38

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2206,7 +2206,7 @@ static jl_cgval_t emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *
                                         ConstantInt::get(T_int32,2));
 #endif
     jl_cgval_t ret = mark_julia_type(result, true, jl_any_type); // (typ will be patched up by caller)
-    //ret.needsgcroot = arg1.needsgcroot || !arg1.isimmutable || !jl_is_leaf_type(arg1.typ) || !is_datatype_all_pointers((jl_datatype_t*)arg1.typ);
+    ret.needsgcroot = arg1.needsgcroot || !arg1.isimmutable || !jl_is_leaf_type(arg1.typ) || !is_datatype_all_pointers((jl_datatype_t*)arg1.typ);
     return ret;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2107,7 +2107,7 @@ static jl_cgval_t emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *
     Value *result = builder.CreateCall3(prepare_call(jlgetfield_func), V_null, myargs,
                                         ConstantInt::get(T_int32,2));
 #endif
-    bool needsgcroot = true; // !arg1.isimmutable || !jl_is_leaf_type(arg1.typ) || !is_datatype_all_pointers((jl_datatype_t*)arg1.typ); // jwn: probably want this as a llvm pass
+    bool needsgcroot = true; // !arg1.isimmutable || !jl_is_leaf_type(arg1.typ) || !is_datatype_all_pointers((jl_datatype_t*)arg1.typ); // TODO: probably want this as a llvm pass
     jl_cgval_t ret = mark_julia_type(result, true, jl_any_type, ctx, needsgcroot); // (typ will be patched up by caller)
     return ret;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -543,7 +543,6 @@ struct jl_gcinfo_t {
     Value *argSlot;
     Value *ptlsStates;
     GetElementPtrInst *tempSlot;
-    int argDepth;
     int maxDepth;
     int argSpaceSize;
     BasicBlock::iterator first_gcframe_inst;
@@ -612,7 +611,8 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool boxed=true
 static jl_cgval_t emit_unboxed(jl_value_t *e, jl_codectx_t *ctx);
 static int is_global(jl_sym_t *s, jl_codectx_t *ctx);
 
-static Value *make_gcroot(Value *v, jl_codectx_t *ctx);
+static void make_gcrooted(Value *v, jl_codectx_t *ctx);
+static Value *make_jlcall(ArrayRef<const jl_cgval_t*> args, jl_codectx_t *ctx);
 static jl_cgval_t emit_boxed_rooted(jl_value_t *e, jl_codectx_t *ctx);
 static Value *global_binding_pointer(jl_module_t *m, jl_sym_t *s,
                                      jl_binding_t **pbnd, bool assign, jl_codectx_t *ctx);
@@ -1993,24 +1993,52 @@ static void simple_escape_analysis(jl_value_t *expr, bool esc, jl_codectx_t *ctx
 // Emit GEP for the @slot-th slot in the GC frame
 static Value *emit_local_slot(int slot, jl_codectx_t *ctx)
 {
-    return builder.CreateGEP(ctx->gc.argSlot, ConstantInt::get(T_int32, slot));
+    Value *idx = ConstantInt::get(T_int32, slot);
+    GetElementPtrInst *newroot = GetElementPtrInst::Create(ctx->gc.argSlot, idx);
+    newroot->insertAfter(ctx->gc.last_gcframe_inst); // insert it into the gc frame basic block so it can be reused as needed
+    return newroot;
 }
 
-// Emit GEP for the @slot-th temporary variable in the GC frame.
-// The temporary variables are after all local variables in the GC frame.
-static Value *emit_temp_slot(int slot, jl_codectx_t *ctx)
+static void make_gcrooted(Value *v, jl_codectx_t *ctx) // TODO: this function should be removed
 {
-    return builder.CreateGEP(ctx->gc.tempSlot, ConstantInt::get(T_int32, slot));
+    Instruction *Inst = dyn_cast<Instruction>(v);
+    if (Inst) { // ignore make_gcrooted(Constant) -- TODO: make this an error
+        Value *froot = emit_local_slot(ctx->gc.argSpaceSize++, ctx);
+        StoreInst *store = new StoreInst(Inst, froot);
+        store->insertAfter(Inst);
+    }
 }
 
-static Value *make_gcroot(Value *v, jl_codectx_t *ctx)
+static Value *get_gcrooted(const jl_cgval_t &v, jl_codectx_t *ctx)
 {
-    Value *froot = emit_temp_slot(ctx->gc.argDepth, ctx);
-    builder.CreateStore(v, froot);
-    ctx->gc.argDepth++;
-    if (ctx->gc.argDepth > ctx->gc.maxDepth)
-        ctx->gc.maxDepth = ctx->gc.argDepth;
-    return froot;
+    Value *I = boxed(v, ctx);
+    if ((!v.isboxed || v.needsgcroot) && !v.isghost) {
+        Instruction *Inst = dyn_cast<Instruction>(I);
+        if (Inst) { // ignore make_gcrooted(Constant) -- TODO: make this an error
+            Value *froot = emit_local_slot(ctx->gc.argSpaceSize++, ctx);
+            StoreInst *store = new StoreInst(Inst, froot);
+            store->insertAfter(Inst);
+            return builder.CreateLoad(froot);
+        }
+    }
+    return I;
+}
+
+// turn an array of arguments into a single object suitable for passing to a jlcall
+static Value *make_jlcall(ArrayRef<const jl_cgval_t*> args, jl_codectx_t *ctx)
+{
+    // the temporary variables are after all local variables in the GC frame.
+    Value *largs = ctx->gc.tempSlot;
+    int slot = 0;
+    for (ArrayRef<const jl_cgval_t*>::iterator I = args.begin(), E = args.end(); I < E; ++I, ++slot) {
+        Value *arg = get_gcrooted(**I, ctx);
+        Value *idx = ConstantInt::get(T_int32, slot);
+        Value *newroot = builder.CreateGEP(largs, idx);
+        builder.CreateStore(arg, newroot);
+    }
+    if (slot > ctx->gc.maxDepth)
+        ctx->gc.maxDepth = slot;
+    return largs;
 }
 
 // test whether getting a field from the given type using the given
@@ -2086,11 +2114,11 @@ static jl_cgval_t emit_boxed_rooted(jl_value_t *e, jl_codectx_t *ctx) // TODO: m
     jl_cgval_t v = emit_expr(e, ctx);
     if (!v.isboxed) {
         Value *vbox = boxed(v, ctx);
-        make_gcroot(vbox, ctx);
+        make_gcrooted(vbox, ctx);
         v = jl_cgval_t(vbox, true, v.typ); // XXX: bypasses the normal auto-unbox behavior for isghost!
     }
     else if (might_need_root(e)) { // TODO: v.needsgcroot
-        make_gcroot(v.V, ctx);
+        make_gcrooted(v.V, ctx);
     }
     return v;
 }
@@ -2165,13 +2193,11 @@ static jl_cgval_t emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *
     // TODO: attempt better codegen for approximate types, if the types
     // and offsets of some fields are independent of parameters.
 
-    int argStart = ctx->gc.argDepth;
-    Value *arg1 = boxed(emit_expr(expr,ctx), ctx, expr_type(expr,ctx));
     // TODO: generic getfield func with more efficient calling convention
-    make_gcroot(arg1, ctx);
-    Value *arg2 = literal_pointer_val((jl_value_t*)name);
-    make_gcroot(arg2, ctx);
-    Value *myargs = emit_temp_slot(argStart, ctx);
+    jl_cgval_t arg1 = emit_expr(expr, ctx);
+    jl_cgval_t arg2 = mark_julia_const((jl_value_t*)name);
+    const jl_cgval_t* myargs_array[2] = {&arg1, &arg2};
+    Value *myargs = make_jlcall(makeArrayRef(myargs_array), ctx);
 #ifdef LLVM37
     Value *result = builder.CreateCall(prepare_call(jlgetfield_func), {V_null, myargs,
                                         ConstantInt::get(T_int32,2)});
@@ -2179,7 +2205,6 @@ static jl_cgval_t emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *
     Value *result = builder.CreateCall3(prepare_call(jlgetfield_func), V_null, myargs,
                                         ConstantInt::get(T_int32,2));
 #endif
-    ctx->gc.argDepth = argStart;
     jl_cgval_t ret = mark_julia_type(result, true, jl_any_type); // (typ will be patched up by caller)
     //ret.needsgcroot = arg1.needsgcroot || !arg1.isimmutable || !jl_is_leaf_type(arg1.typ) || !is_datatype_all_pointers((jl_datatype_t*)arg1.typ);
     return ret;
@@ -2301,10 +2326,10 @@ static Value *emit_f_is(const jl_cgval_t &arg1, const jl_cgval_t &arg2, jl_codec
     }
 
     if (arg2.isboxed && arg2.needsgcroot)
-        make_gcroot(arg2.V, ctx);
+        make_gcrooted(arg2.V, ctx);
     Value *varg1 = boxed(arg1, ctx);
     if (!arg1.isboxed)
-        make_gcroot(varg1, ctx);
+        make_gcrooted(varg1, ctx);
     Value *varg2 = boxed(arg2, ctx); // unrooted!
 #ifdef LLVM37
     return builder.CreateTrunc(builder.CreateCall(prepare_call(jlegal_func), {varg1, varg2}), T_int1);
@@ -2349,10 +2374,9 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             }
         }
         // emit values
-        int last_depth = ctx->gc.argDepth;
         jl_cgval_t v1 = emit_unboxed(args[1], ctx);
         if (v1.isboxed && v1.needsgcroot && might_need_root(args[1]))
-            make_gcroot(v1.V, ctx);
+            make_gcrooted(v1.V, ctx);
         jl_cgval_t v2 = emit_unboxed(args[2], ctx); // unrooted!
         // FIXME: v.typ is roughly equiv. to expr_type, but with typeof(T) == Type{T} instead of DataType in a few cases
         if (v1.typ == (jl_value_t*)jl_datatype_type)
@@ -2361,7 +2385,6 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             v2 = remark_julia_type(v2, expr_type(args[2], ctx)); // patch up typ if necessary
         // emit comparison test
         Value *ans = emit_f_is(v1, v2, ctx);
-        ctx->gc.argDepth = last_depth;
         *ret = mark_julia_type(ans, false, jl_bool_type);
         JL_GC_POP();
         return true;
@@ -2402,16 +2425,12 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             }
         }
         if (jl_subtype(ty, (jl_value_t*)jl_type_type, 0)) {
-            int ldepth = ctx->gc.argDepth;
             *ret = emit_expr(args[1], ctx);
-            Value *V = boxed(*ret, ctx);
-            make_gcroot(V, ctx);
 #ifdef LLVM37
-            builder.CreateCall(prepare_call(jltypeassert_func), {V, boxed(emit_expr(args[2], ctx),ctx)});
+            builder.CreateCall(prepare_call(jltypeassert_func), {get_gcrooted(*ret, ctx), boxed(emit_expr(args[2], ctx), ctx)});
 #else
-            builder.CreateCall2(prepare_call(jltypeassert_func), V, boxed(emit_expr(args[2], ctx),ctx));
+            builder.CreateCall2(prepare_call(jltypeassert_func), get_gcrooted(*ret, ctx), boxed(emit_expr(args[2], ctx), ctx));
 #endif
-            ctx->gc.argDepth = ldepth;
             JL_GC_POP();
             return true;
         }
@@ -2849,15 +2868,24 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
     return false;
 }
 
-static Value *emit_jlcall(Value *theFptr, Value *theF, int argStart,
+static Value *emit_jlcall(Value *theFptr, Value *theF, jl_value_t **args,
                           size_t nargs, jl_codectx_t *ctx)
 {
-    // call
+    // emit arguments
     Value *myargs;
-    if (nargs > 0)
-        myargs = emit_temp_slot(argStart, ctx);
-    else
+    if (nargs > 0) {
+        jl_cgval_t *anArg = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nargs);
+        const jl_cgval_t **largs = (const jl_cgval_t**)alloca(sizeof(jl_cgval_t*) * nargs);
+        for(size_t i=0; i < nargs; i++) {
+            anArg[i] = emit_expr(args[i], ctx, true, true);
+            largs[i] = &anArg[i];
+        }
+        // put into argument space
+        myargs = make_jlcall(makeArrayRef(largs, nargs), ctx);
+    }
+    else {
         myargs = Constant::getNullValue(T_ppjlvalue);
+    }
 #ifdef LLVM37
     Value *result = builder.CreateCall(prepare_call(theFptr), {theF, myargs,
                                        ConstantInt::get(T_int32,nargs)});
@@ -2865,21 +2893,7 @@ static Value *emit_jlcall(Value *theFptr, Value *theF, int argStart,
     Value *result = builder.CreateCall3(prepare_call(theFptr), theF, myargs,
                                         ConstantInt::get(T_int32,nargs));
 #endif
-    ctx->gc.argDepth = argStart; // clear the args from the gcstack
     return result;
-}
-
-static Value *emit_jlcall(Value *theFptr, Value *theF, jl_value_t **args,
-                          size_t nargs, jl_codectx_t *ctx)
-{
-    // emit arguments
-    int argStart = ctx->gc.argDepth;
-    for(size_t i=0; i < nargs; i++) {
-        jl_cgval_t anArg = emit_expr(args[i], ctx, true, true);
-        // put into argument space
-        make_gcroot(boxed(anArg, ctx, expr_type(args[i],ctx)), ctx);
-    }
-    return emit_jlcall(theFptr, theF, argStart, nargs, ctx);
 }
 
 static jl_cgval_t emit_call_function_object(jl_lambda_info_t *li, const jl_cgval_t &theF, Value *theFptr,
@@ -2925,7 +2939,7 @@ static jl_cgval_t emit_call_function_object(jl_lambda_info_t *li, const jl_cgval
                 // the value rooted if it was already, to avoid redundant stores.
                 if (!origval.isboxed ||
                     (might_need_root(args[i]) && !is_stable_expr(args[i], ctx))) {
-                    make_gcroot(argvals[idx], ctx);
+                    make_gcrooted(argvals[idx], ctx);
                 }
             }
             else if (et->isAggregateType()) {
@@ -2990,15 +3004,12 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
         }
     }
 
-    int argStart = ctx->gc.argDepth;
-
     // special case for known builtin not handled by emit_builtin_call
     if (f && jl_subtype(f, (jl_value_t*)jl_builtin_type, 1)) {
         std::map<jl_fptr_t,Function*>::iterator it = builtin_func_map.find(jl_get_builtin_fptr(f));
         if (it != builtin_func_map.end()) {
             theFptr = (*it).second;
             result = mark_julia_type(emit_jlcall(theFptr, V_null, &args[1], nargs, ctx), true, expr_type(expr,ctx));
-            ctx->gc.argDepth = argStart;
             JL_GC_POP();
             return result;
         }
@@ -3033,7 +3044,6 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
                 }
                 jl_add_linfo_root(ctx->linfo, (jl_value_t*)li);
                 result = emit_call_function_object(li, fval, theFptr, args, nargs, expr, ctx);
-                ctx->gc.argDepth = argStart;
                 JL_GC_POP();
                 return result;
             }
@@ -3041,25 +3051,24 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
     }
 
     // emit function and arguments
-    Value *theFunc = boxed(emit_expr(args[0], ctx), ctx);
-    make_gcroot(theFunc, ctx);
+    nargs++; // add function to nargs count
+    jl_cgval_t *anArg = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nargs);
+    const jl_cgval_t **largs = (const jl_cgval_t**)alloca(sizeof(jl_cgval_t*) * nargs);
     for(size_t i=0; i < nargs; i++) {
-        jl_cgval_t anArg = emit_expr(args[i+1], ctx);
-        // put into argument space
-        make_gcroot(boxed(anArg, ctx, expr_type(args[i+1],ctx)), ctx);
+        anArg[i] = emit_expr(args[i], ctx, true, true);
+        largs[i] = &anArg[i];
     }
-    Value *myargs, *callval;
-    myargs = emit_temp_slot(argStart, ctx);
+    // put into argument space
+    Value *myargs = make_jlcall(makeArrayRef(largs, nargs), ctx);
 #ifdef LLVM37
-    callval = builder.CreateCall(prepare_call(jlapplygeneric_func),
-                                 {myargs, ConstantInt::get(T_int32, nargs + 1)});
+    Value *callval = builder.CreateCall(prepare_call(jlapplygeneric_func),
+                                 {myargs, ConstantInt::get(T_int32, nargs)});
 #else
-    callval = builder.CreateCall2(prepare_call(jlapplygeneric_func),
-                                  myargs, ConstantInt::get(T_int32, nargs + 1));
+    Value *callval = builder.CreateCall2(prepare_call(jlapplygeneric_func),
+                                  myargs, ConstantInt::get(T_int32, nargs));
 #endif
     result = mark_julia_type(callval, true, expr_type(expr, ctx));
 
-    ctx->gc.argDepth = argStart; // remove the arguments from the gc stack
     JL_GC_POP();
     return result;
 }
@@ -3241,8 +3250,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
             Value *rval = boxed(emit_expr(r, ctx, true), ctx);
             if (!is_stable_expr(r, ctx)) {
                 // add a gc root for this GenSym node
-                Value *bp = emit_local_slot(ctx->gc.argSpaceSize++, ctx);
-                builder.CreateStore(rval, bp);
+                make_gcrooted(rval, ctx);
             }
             slot = mark_julia_type(rval, true, declType);
         }
@@ -3286,9 +3294,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
     jl_varinfo_t &vi = ctx->vars[s];
     if (!vi.memloc && !vi.hasGCRoot && vi.used
             && !vi.isArgument && !is_stable_expr(r, ctx)) {
-        Instruction *newroot = cast<Instruction>(emit_local_slot(ctx->gc.argSpaceSize++, ctx));
-        newroot->removeFromParent(); // move it to the gc frame basic block so it can be reused as needed
-        newroot->insertAfter(&*ctx->gc.last_gcframe_inst);
+        Value *newroot = emit_local_slot(ctx->gc.argSpaceSize++, ctx);
         vi.memloc = newroot;
         vi.hasGCRoot = true; // this has been discovered to need a gc root, add it now
         //TODO: move this logic after the emit_expr
@@ -3550,13 +3556,9 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
             if (jl_expr_nargs(ex) == 1)
                 return gf;
         }
-        int last_depth = ctx->gc.argDepth;
-        Value *a1 = boxed(emit_expr(args[1], ctx),ctx);
-        make_gcroot(a1, ctx);
-        Value *a2 = boxed(emit_expr(args[2], ctx),ctx);
-        make_gcroot(a2, ctx);
+        Value *a1 = get_gcrooted(emit_expr(args[1], ctx), ctx);
+        Value *a2 = get_gcrooted(emit_expr(args[2], ctx), ctx);
         Value *mdargs[3] = { a1, a2, literal_pointer_val(args[3]) };
-        ctx->gc.argDepth = last_depth;
         builder.CreateCall(prepare_call(jlmethod_func), ArrayRef<Value*>(&mdargs[0], 3));
         return ghostValue(jl_void_type);
     }
@@ -3749,7 +3751,6 @@ static void allocate_gc_frame(size_t n_roots, BasicBlock *b0, jl_codectx_t *ctx)
     // allocate a placeholder gc frame
     jl_gcinfo_t *gc = &ctx->gc;
     gc->argSpaceSize = n_roots;
-    gc->argDepth = 0;
     gc->maxDepth = 0;
 
 #ifdef JULIA_ENABLE_THREADING
@@ -3845,11 +3846,11 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
     builder.CreateStore(newgcframe, emit_pgcstack(ctx));
     // Initialize the slots for temporary variables to NULL
     for (int i = 0; i < gc->argSpaceSize; i++) {
-        Value *argTempi = emit_local_slot(i, ctx);
+        Value *argTempi = builder.CreateGEP(ctx->gc.argSlot, ConstantInt::get(T_int32, i));
         builder.CreateStore(V_null, argTempi);
     }
     for (int i = 0; i < gc->maxDepth; i++) {
-        Value *argTempi = emit_temp_slot(i, ctx);
+        Value *argTempi = builder.CreateGEP(ctx->gc.tempSlot, ConstantInt::get(T_int32, i));
         builder.CreateStore(V_null, argTempi);
     }
     emit_gcpops(ctx);
@@ -4033,14 +4034,15 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
         // figure out how to repack this type
         if (!specsig) {
             Value *arg = boxed(inputarg, &ctx);
-            make_gcroot(arg, &ctx);
+            Value *slot = builder.CreateGEP(ctx.gc.tempSlot, ConstantInt::get(T_int32, FParamIndex++));
+            builder.CreateStore(arg, slot);
         }
         else {
             Value *arg;
             FParamIndex++;
             if (isboxed) {
                 arg = boxed(inputarg, &ctx);
-                make_gcroot(arg, &ctx);
+                make_gcrooted(arg, &ctx);
             }
             else {
                 arg = emit_unbox(t, inputarg, jargty);
@@ -4073,8 +4075,18 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
     }
     else {
         assert(nargs > 0);
-        // for jlcall, we need to pass the function object even though it is a ghost
-        Value *ret = emit_jlcall(theFptr, literal_pointer_val((jl_value_t*)ff), 0, nargs, &ctx);
+        // for jlcall, we need to pass the function object even if it is a ghost.
+        // here we reconstruct the function instance from its type (first elt of argt)
+        ctx.gc.maxDepth = FParamIndex;
+        Value *myargs = ctx.gc.tempSlot;
+        Value *theF = literal_pointer_val((jl_value_t*)ff);
+#ifdef LLVM37
+        Value *ret = builder.CreateCall(prepare_call(theFptr), {theF, myargs,
+                                        ConstantInt::get(T_int32, nargs)});
+#else
+        Value *ret = builder.CreateCall3(prepare_call(theFptr), theF, myargs,
+                                         ConstantInt::get(T_int32, nargs));
+#endif
         retval = mark_julia_type(ret, true, jlrettype);
     }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -517,10 +517,13 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
 
         Value *newobj = emit_allocobj(nb);
         builder.CreateStore(runtime_bt, emit_typeptr_addr(newobj));
-        if (!v.ispointer)
+        if (!v.ispointer) {
             builder.CreateAlignedStore(emit_unbox(llvmt, v, v.typ), builder.CreatePointerCast(newobj, llvmt->getPointerTo()), alignment);
-        else
+        }
+        else {
             prepare_call(builder.CreateMemCpy(newobj, builder.CreateBitCast(v.V, T_pint8), nb, alignment)->getCalledValue());
+            mark_gc_use(v);
+        }
         return mark_julia_type(newobj, true, bt ? bt : (jl_value_t*)jl_any_type, ctx);
     }
 
@@ -1061,6 +1064,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
             if (y.ispointer) // TODO: elid this load if unnecessary
                 vy = builder.CreateLoad(builder.CreatePointerCast(vy, llt1->getPointerTo(0)));
             ifelse_result = builder.CreateSelect(isfalse, vy, vx);
+            mark_gc_use(x);
+            mark_gc_use(y);
             return mark_julia_type(ifelse_result, false, t2, ctx);
         }
         else {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -408,8 +408,8 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
     if (!bt || !jl_is_bitstype(bt)) {
         // it's easier to throw a good error from C than llvm
         if (bt) targ = bt;
-        Value *arg1 = get_gcrooted(emit_expr(targ, ctx), ctx);
-        Value *arg2 = get_gcrooted(emit_expr(x, ctx), ctx);
+        Value *arg1 = boxed(emit_expr(targ, ctx), ctx);
+        Value *arg2 = boxed(emit_expr(x, ctx), ctx);
         Value *func = prepare_call(runtime_func[reinterpret]);
 #ifdef LLVM37
         Value *r = builder.CreateCall(func, {arg1, arg2});
@@ -698,9 +698,9 @@ static jl_cgval_t emit_runtime_pointerref(jl_value_t *e, jl_value_t *i, jl_codec
     jl_cgval_t parg = emit_expr(e, ctx);
     Value *iarg = boxed(emit_expr(i, ctx), ctx);
 #ifdef LLVM37
-    Value *ret = builder.CreateCall(prepare_call(jlpref_func), { get_gcrooted(parg, ctx), iarg });
+    Value *ret = builder.CreateCall(prepare_call(jlpref_func), { boxed(parg, ctx), iarg });
 #else
-    Value *ret = builder.CreateCall2(prepare_call(jlpref_func), get_gcrooted(parg, ctx), iarg);
+    Value *ret = builder.CreateCall2(prepare_call(jlpref_func), boxed(parg, ctx), iarg);
 #endif
     jl_value_t *ety;
     if (jl_is_cpointer_type(parg.typ)) {
@@ -759,12 +759,12 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
 static jl_cgval_t emit_runtime_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, jl_codectx_t *ctx)
 {
     jl_cgval_t parg = emit_expr(e, ctx);
-    Value *iarg = get_gcrooted(emit_expr(i, ctx), ctx);
+    Value *iarg = boxed(emit_expr(i, ctx), ctx);
     Value *xarg = boxed(emit_expr(x, ctx), ctx);
 #ifdef LLVM37
-    builder.CreateCall(prepare_call(jlpset_func), { get_gcrooted(parg, ctx), xarg, iarg });
+    builder.CreateCall(prepare_call(jlpset_func), { boxed(parg, ctx), xarg, iarg });
 #else
-    builder.CreateCall3(prepare_call(jlpset_func), get_gcrooted(parg, ctx), xarg, iarg);
+    builder.CreateCall3(prepare_call(jlpset_func), boxed(parg, ctx), xarg, iarg);
 #endif
     return parg;
 }
@@ -901,7 +901,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Value *r;
         Value *func = prepare_call(runtime_func[f]);
         if (nargs == 1) {
-            Value *x = get_gcrooted(emit_expr(args[1], ctx), ctx);
+            Value *x = boxed(emit_expr(args[1], ctx), ctx);
 #ifdef LLVM37
             r = builder.CreateCall(func, {x});
 #else
@@ -909,8 +909,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 #endif
         }
         else if (nargs == 2) {
-            Value *x = get_gcrooted(emit_expr(args[1], ctx), ctx);
-            Value *y = get_gcrooted(emit_expr(args[2], ctx), ctx);
+            Value *x = boxed(emit_expr(args[1], ctx), ctx);
+            Value *y = boxed(emit_expr(args[2], ctx), ctx);
 #ifdef LLVM37
             r = builder.CreateCall(func, {x, y});
 #else
@@ -918,9 +918,9 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 #endif
         }
         else if (nargs == 3) {
-            Value *x = get_gcrooted(emit_expr(args[1], ctx), ctx);
-            Value *y = get_gcrooted(emit_expr(args[2], ctx), ctx);
-            Value *z = get_gcrooted(emit_expr(args[3], ctx), ctx);
+            Value *x = boxed(emit_expr(args[1], ctx), ctx);
+            Value *y = boxed(emit_expr(args[2], ctx), ctx);
+            Value *z = boxed(emit_expr(args[3], ctx), ctx);
 #ifdef LLVM37
             r = builder.CreateCall(func, {x, y, z});
 #else
@@ -1067,8 +1067,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
             jl_cgval_t arg1 = emit_expr(args[2],ctx);
             jl_cgval_t arg2 = emit_expr(args[3],ctx);
             ifelse_result = builder.CreateSelect(isfalse,
-                    get_gcrooted(arg2, ctx),
-                    get_gcrooted(arg1, ctx));
+                    boxed(arg2, ctx),
+                    boxed(arg1, ctx));
             jl_value_t *jt = (t1 == t2 ? t1 : (jl_value_t*)jl_any_type);
             mark_gc_use(arg1);
             mark_gc_use(arg2);

--- a/src/julia.h
+++ b/src/julia.h
@@ -428,7 +428,7 @@ typedef struct _jl_datatype_t {
     uint32_t haspadding : 1;  // has internal undefined bytes
     uint32_t fielddesc_type : 2; // 0 -> 8, 1 -> 16, 2 -> 32
     uint32_t uid;
-    void *struct_decl;  //llvm::Value*
+    void *struct_decl;  //llvm::Type*
     void *ditype; // llvm::MDNode* to be used as llvm::DIType(ditype)
     // Last field needs to be pointer size aligned
     // union {

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -22,7 +22,7 @@ public:
     };
 };
 
-#ifdef DEBUG // llvm debug build
+#ifdef DEBUG // llvm assertions build
 // gdb debugging code for inspecting the bb_uses map
 void jl_dump_bb_uses(std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses)
 {
@@ -429,4 +429,15 @@ void jl_codegen_finalize_temp_arg(AllocaInst *gcframe, Instruction *&last_gcfram
         GetElementPtrInst *gep = GetElementPtrInst::Create(tempSlot, makeArrayRef(offset));
         ReplaceInstWithInst(frame->first, gep);
     }
+
+#if 0
+    static struct {
+        unsigned count;
+        unsigned locals;
+        unsigned temp;
+    } gc_frame_stats = {0};
+    gc_frame_stats.count++;
+    gc_frame_stats.locals += argSpaceSize;
+    gc_frame_stats.temp += maxDepth;
+#endif
 }

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -1,0 +1,432 @@
+#include "llvm-version.h"
+#include <vector>
+#include <llvm/ADT/SmallBitVector.h>
+#include <llvm/IR/Value.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
+
+using namespace llvm;
+extern Function *gcroot_func;
+extern Function *jlcall_frame_func;
+extern Function *jlcall_root_func;
+
+typedef std::pair<CallInst*, unsigned> frame_register;
+class liveness {
+public:
+    typedef unsigned id;
+    enum {
+        assign = 1<<0,
+        kill   = 1<<1,
+        live   = 1<<2
+    };
+};
+
+#ifdef DEBUG // llvm debug build
+// gdb debugging code for inspecting the bb_uses map
+void jl_dump_bb_uses(std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses)
+{
+    for (std::map<BasicBlock*, std::map<frame_register, liveness::id> >::iterator
+            live_reg = bb_uses.begin(), e = bb_uses.end(); live_reg != e; ++live_reg) {
+        BasicBlock *bb = live_reg->first;
+        errs() << '\n' << bb << '\n';
+        for (std::map<frame_register, liveness::id>::iterator
+                regs = live_reg->second.begin(), regse = live_reg->second.end(); regs != regse; ++regs) {
+            errs() << regs->second << " #" << regs->first.second << ' ' << regs->first.first << '\n';
+        }
+    }
+}
+#endif
+
+static bool record_usage(CallInst *callInst,
+        std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses,
+        std::map<BasicBlock*, SmallBitVector> &regs_used,
+        unsigned offset, bool commit=true)
+{
+/* record-usage(inst, bb-uses, regs-used, offset, commit=true)
+ *     for (arg-offset, operand) in enumerate(arguments(inst))
+ *         reg = <inst, arg-offset>
+ *         for (bb, liveness) in bb-uses
+ *             if not reg in liveness
+ *                 continue
+ *             # TODO: optimize better if liveness[reg] doesn't contain live
+ *             conflict = regs-used[bb][offset + arg-offset]
+ *             if commit
+ *                 assert !conflict
+ *                 regs-used[bb][offset + arg-offset] = true
+ *             else if conflict
+ *                 return false
+ *     return true
+ */
+    unsigned arg_n = cast<ConstantInt>(callInst->getArgOperand(0))->getZExtValue();
+#if 0 // suboptimal allocator that ignores computed liveness data
+    SmallBitVector &regs = regs_used[&callInst->getParent()->getParent()->getEntryBlock()];
+    if (regs.size() < offset + arg_n)
+        regs.resize(offset + arg_n);
+    for (unsigned arg_offset = 0; arg_offset < arg_n; ++arg_offset) {
+        frame_register def(callInst, arg_offset);
+        unsigned index = offset + arg_offset;
+        bool conflict = regs.test(index);
+        if (commit) {
+            assert(!conflict);
+            regs.set(index);
+        } else if (conflict) {
+            return false;
+        }
+    }
+#else // better allocator that uses per-basicblock liveness
+    for (std::map<BasicBlock*, std::map<frame_register, liveness::id> >::iterator
+            live_reg = bb_uses.begin(), e = bb_uses.end(); live_reg != e; ++live_reg) {
+        BasicBlock *bb = live_reg->first;
+        SmallBitVector &regs = regs_used[bb];
+        if (regs.size() < offset + arg_n)
+            regs.resize(offset + arg_n);
+        for (unsigned arg_offset = 0; arg_offset < arg_n; ++arg_offset) {
+            frame_register def(callInst, arg_offset);
+            std::map<frame_register, liveness::id>::iterator inuse_reg = live_reg->second.find(def);
+            if (inuse_reg == live_reg->second.end())
+                continue;
+            // TODO: optimize here better when not live in inuse_reg->second, by ascertaining liveness at the instruction level for this bb
+            unsigned index = offset + arg_offset;
+            bool conflict = regs.test(index);
+            if (commit) {
+                assert(!conflict);
+                regs.set(index);
+            } else if (conflict) {
+                // TODO: updating offset to point to the next open register > index may help accelerate this loop and avoid unnecessary work
+                return false;
+            }
+        }
+    }
+#endif
+    return true;
+}
+
+static unsigned find_space_for(CallInst *callInst,
+        std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses,
+        std::map<BasicBlock*, SmallBitVector> &regs_used)
+{
+/* find-space-for(inst, bb-uses, regs-used)
+ *     n = 0
+ *     while !record-usage(inst, bb-uses, regs-used, n, false)
+ *         n++
+ *     return n
+ *
+ */
+    unsigned n = 0;
+    while (!record_usage(callInst, bb_uses, regs_used, n, false))
+        ++n;
+    return n;
+}
+
+void jl_codegen_finalize_temp_arg(AllocaInst *gcframe, Instruction *&last_gcframe_inst, unsigned &argSpaceSize, unsigned &maxDepth)
+{
+/* Algorithm sketch:
+ *  Compute liveness for each basic block
+ *    liveness computed at the basic-block level for <inst, arg-offset> pairs
+ *  Propagate liveness from each basic block to its predecessors
+ *  Allocate argument slot for each jlcall frame
+ */
+    Function &F = *gcframe->getParent()->getParent();
+    Type *T_int32 = Type::getInt32Ty(F.getContext());
+    Value *V_null = Constant::getNullValue(gcframe->getType()->getPointerElementType());
+    last_gcframe_inst = gcframe;
+
+/* bb-queue : queue<BB>
+ * bb-uses : map<BB, map< pair<inst, arg-offset>, assign|live|kill > >
+ * for bb in iterator(f)
+ *     inuse-list ; map< pair<inst, arg-offset>, assign|live|kill >
+ *     for inst in reverse-iterator(f)
+ *         if inst matches "a call to make-jlcall-frame"
+ *            # note that below this logic is rearranged slightly in the implementation so that failure to match an argument IR is "safe"
+ *            for (arg-offset, operand) in enumerate(arguments(inst))
+ *                if (not hasgcroot(operand)) or (users(GC-Root(operand)) is not only operand and store-instructions)
+ *                    inuse-list[<inst, arg-offset>] = (assign|kill)
+ *                else # e.g. this is the only use, replace gc-root with direct store to arg-slot
+ *                    ReplaceOperand(GC-Root(operand), "a call to jlcall-root", pair<inst, arg-offset>)
+ *                    inuse-list[<inst, arg-offset>] = kill
+ *         else if inst matches store-inst with op(1) matching "a call to jlcall-root"
+ *             def = <inst, arg-offset>
+ *             if inuse-list[def] is kill
+ *                 inuse-list[def] = assign|kill
+ *      bb-uses[bb] = inuse-list
+ *      if not has-live-out(bb)
+ *          continue
+ *      for pred in predecessors(bb)
+ *          if not pred in bb-queue
+ *              push-back(bb-queue, pred)
+ * GC-Root(load-gcroot-inst) = get-argument(load-gcroot-inst)
+ * hasgcroot(inst) = inst matches "CreateLoad(CallInst::Create(gcroot_func))"
+ */
+
+    std::vector<BasicBlock*> bb_queue;
+    std::map<BasicBlock*, std::map<frame_register, liveness::id> > bb_uses;
+    for (Function::iterator bb = F.begin(), be = F.end(); bb != be; ++bb) {
+        // TODO: this assumes that the kill bb (aka the jlcall) is the same as the store and the frame allocation (aka jlcall_frame_func)
+        // which is currently a safe assumption due to the specific behavior of `make_jlcall` and `emit_jlcall`, but may not be sufficiently general
+        std::map<frame_register, liveness::id> &inuse_list = bb_uses[bb];
+        unsigned live_out = 0;
+        for (BasicBlock::reverse_iterator ri = bb->rbegin(); ri != bb->rend(); ++ri) {
+            Instruction *i = &*ri;
+            if (CallInst* callInst = dyn_cast<CallInst>(i)) {
+                if (callInst->getCalledFunction() == jlcall_frame_func) {
+                    unsigned arg_n = cast<ConstantInt>(callInst->getArgOperand(0))->getZExtValue();
+                    for (unsigned arg_offset = 0; arg_offset < arg_n; ++arg_offset) {
+                        liveness::id &live = inuse_list[frame_register(callInst, arg_offset)];
+                        if (!live)
+                            live = liveness::kill | liveness::assign;
+                    }
+                }
+            }
+            else if (StoreInst *storeInst = dyn_cast<StoreInst>(i)) {
+                CallInst *callInst = dyn_cast<CallInst>(storeInst->getPointerOperand());
+                unsigned arg_offset = 0;
+                if (!callInst) {
+                    // also try to look through GEP
+                    if (GetElementPtrInst *gepInst = dyn_cast<GetElementPtrInst>(storeInst->getPointerOperand())) {
+                        if (gepInst->getNumIndices() == 1) {
+                            callInst = dyn_cast<CallInst>(gepInst->getPointerOperand());
+                            if (callInst && callInst->getCalledFunction() == jlcall_frame_func) {
+                                arg_offset = cast<ConstantInt>(gepInst->idx_begin()->get())->getZExtValue();
+                            }
+                        }
+                    }
+                }
+                if (callInst && callInst->getCalledFunction() == jlcall_frame_func) {
+                    LoadInst *loadInst = dyn_cast<LoadInst>(storeInst->getValueOperand());
+                    CallInst *gcroot = NULL;
+                    if (loadInst && loadInst->hasOneUse()) {
+                        gcroot = dyn_cast<CallInst>(loadInst->getPointerOperand());
+                        if (gcroot && gcroot->getCalledFunction() != gcroot_func)
+                            gcroot = NULL;
+                    }
+                    liveness::id live = liveness::kill;
+                    if (gcroot == NULL) {
+                        live |= liveness::assign;
+                    }
+                    else {
+                        for (User::use_iterator use = gcroot->use_begin(), usee = gcroot->use_end(); use != usee; ++use) {
+                            User *user = use.getUse().getUser();
+                            if (user != loadInst && !(isa<StoreInst>(user) && use.getOperandNo() == StoreInst::getPointerOperandIndex())) {
+                                gcroot = NULL;
+                                live |= liveness::assign;
+                                break;
+                            }
+                        }
+                    }
+                    inuse_list[frame_register(callInst, arg_offset)] = live;
+                    if (gcroot) {
+                        Value* args[2] = {callInst, ConstantInt::get(T_int32, arg_offset)};
+                        ReplaceInstWithInst(gcroot, CallInst::Create(jlcall_root_func, makeArrayRef(args)));
+                        storeInst->eraseFromParent();
+                        loadInst->eraseFromParent();
+                        ++live_out;
+                    }
+                }
+                else if (callInst && callInst->getCalledFunction() == jlcall_root_func) {
+                    assert(arg_offset == 0);
+                    frame_register def(
+                            cast<CallInst>(callInst->getArgOperand(0)),
+                            cast<ConstantInt>(callInst->getArgOperand(1))->getZExtValue());
+                    std::map<frame_register, liveness::id>::iterator inuse_reg = inuse_list.find(def);
+                    if (inuse_reg != inuse_list.end() && inuse_reg->second == liveness::kill) {
+                        inuse_reg->second |= liveness::assign;
+                        --live_out;
+                    }
+                }
+            }
+        }
+        if (!live_out)
+            continue;
+        assert(&*bb != &F.getEntryBlock()); // nothing should live-out from the entry bb
+        for (pred_iterator PI = pred_begin(bb), PE = pred_end(bb); PI != PE; ++PI) {
+            if (std::find(bb_queue.begin(), bb_queue.end(), *PI) == bb_queue.end())
+                bb_queue.push_back(*PI);
+        }
+    }
+
+/* while not empty(bb-queue)
+ *     bb = pop(bb-queue)
+ *     inuse-list = &bb-uses[bb]
+ *     changes = 0
+ *     for succ in successors(bb)
+ *         for <def, op> in bb-uses[succ]
+ *             if (not assign in op) and not (inuse-list[def] contains live or assign)
+ *                 # need to add live value from successor to current block, unless it was already marked
+ *                 inuse-list[def] |= live
+ *                 changes += 1
+ *     for inst in iterator(bb)
+ *         if inst matches store-inst with op(1) matching "a call to jlcall-root"
+ *             def = <inst, arg-offset>
+ *             if live in inuse-list[def]
+ *                 inuse-list[def] |= assign
+ *                 if not kill in inuse-list[def]
+ *                      # found the assignment, def is no longer live
+ *                      inuse-list[def] &= ~live
+ *                 else
+ *                      # not a true kill due to recursion -- the kill happened before this assign in this BB, so it is still live
+ *                 changes -= 1
+ *     # if the live list changed, make sure all predecessors are in the queue to be reanalyzed
+ *     if changes == 0
+ *         continue
+ *     for pred in predecessors(bb)
+ *         if not pred in bb-queue
+ *             push-back(bb-queue, pred)
+ */
+
+    while (!bb_queue.empty()) {
+        BasicBlock *bb = bb_queue.back();
+        bb_queue.pop_back();
+        std::map<frame_register, liveness::id> &inuse_list = bb_uses[bb];
+        unsigned changes = 0;
+        for (succ_iterator SI = succ_begin(bb), SE = succ_end(bb); SI != SE; ++SI) {
+            std::map<frame_register, liveness::id> &succ_uses = bb_uses[*SI];
+            for (std::map<frame_register, liveness::id>::iterator reg = succ_uses.begin(), rege = succ_uses.end(); reg != rege; ++reg) {
+                if (!(reg->second & liveness::assign)) {
+                    liveness::id &live = inuse_list[reg->first];
+                    if (!(live & (liveness::live | liveness::assign))) {
+                        live |= liveness::live;
+                        ++changes;
+                    }
+                }
+            }
+        }
+        if (!changes) // short-circuit
+            continue;
+        for (BasicBlock::iterator i = bb->begin(), ie = bb->end(); i != ie; ++i) {
+            if (StoreInst *storeInst = dyn_cast<StoreInst>(&*i)) {
+                if (CallInst *callInst = dyn_cast<CallInst>(storeInst->getPointerOperand())) {
+                    if (callInst->getCalledFunction() == jlcall_root_func) {
+                        frame_register def(
+                                cast<CallInst>(callInst->getArgOperand(0)),
+                                cast<ConstantInt>(callInst->getArgOperand(1))->getZExtValue());
+                        std::map<frame_register, liveness::id>::iterator inuse_reg = inuse_list.find(def);
+                        if (inuse_reg != inuse_list.end() && (inuse_reg->second & liveness::live)) {
+                            inuse_reg->second |= liveness::assign;
+                            if (!(inuse_reg->second & liveness::kill))
+                                inuse_reg->second &= ~liveness::live;
+                            --changes;
+                        }
+                    }
+                }
+            }
+        }
+        if (!changes)
+            continue;
+        assert(bb != &F.getEntryBlock()); // nothing should live-out from the entry bb
+        for (pred_iterator PI = pred_begin(bb), PE = pred_end(bb); PI != PE; ++PI) {
+            if (std::find(bb_queue.begin(), bb_queue.end(), *PI) == bb_queue.end())
+                bb_queue.push_back(*PI);
+        }
+    }
+
+    Instruction *tempSlot = GetElementPtrInst::Create(gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, 2)));
+#ifdef JL_DEBUG_BUILD
+    tempSlot->setName("temproots");
+#endif
+    tempSlot->insertAfter(gcframe);
+    if (last_gcframe_inst == gcframe)
+        last_gcframe_inst = tempSlot;
+
+/* # allocate space in temp-args for each jlcall frame
+ * regs-used = zip(get-basic-blocks(), falses)
+ * for bb in iterator(f)
+ *     for inst in iterator(bb)
+ *         if inst matches "a call to make-jlcall-frame"
+ *             frame-offset = find-space-for(inst, bb-uses, regs-used)
+ *             record-usage(inst, bb-uses, regs-used, frame-offset)
+ */
+    std::map<BasicBlock*, SmallBitVector> regs_used;
+    std::map<CallInst*, unsigned> frames;
+    maxDepth = 0;
+    // TODO: it is probably more optimal to allocate these from largest to smallest
+    for (Function::iterator bb = F.begin(), be = F.end(); bb != be; ++bb) {
+        for (BasicBlock::iterator i = bb->begin(), ie = bb->end(); i != ie; ++i) {
+            if (CallInst* callInst = dyn_cast<CallInst>(&*i)) {
+                if (callInst->getCalledFunction() == jlcall_frame_func) {
+                    unsigned arg_n = cast<ConstantInt>(callInst->getArgOperand(0))->getZExtValue();
+                    unsigned frame_offset = find_space_for(callInst, bb_uses, regs_used);
+                    record_usage(callInst, bb_uses, regs_used, frame_offset);
+                    frames[callInst] = frame_offset;
+                    if (frame_offset + arg_n > maxDepth)
+                        maxDepth = frame_offset + arg_n;
+                }
+            }
+        }
+    }
+
+/* replace all intermediate roots defs with the appropriate gep(gcroot) */
+    /* for inst in entry-basic-block(function)
+     *     if inst matches "jlcall_root_func" or "gc-root"
+     *         slot = get-argument(inst)
+     *         newslot = CreateGEP(gc-frame) -> at InsertPoint(gc-frame)
+     *         Replace(slot, newslot) -> at InsertPoint(gc-frame)
+     *         CreateStore(NULL, newslot) -> at InsertPoint(gc-frame)
+     */
+    argSpaceSize = 0;
+    Instruction *argSlot = NULL;
+    for(BasicBlock::iterator I = gcframe->getParent()->begin(), E = gcframe; I != E; ) {
+        CallInst* callInst = dyn_cast<CallInst>(&*I);
+        ++I;
+        if (callInst && callInst->getCalledFunction() == jlcall_root_func) {
+            frame_register def(
+                    cast<CallInst>(callInst->getArgOperand(0)),
+                    cast<ConstantInt>(callInst->getArgOperand(1))->getZExtValue());
+            unsigned frame_offset = frames.at(def.first);
+            Value* offset[1] = {ConstantInt::get(T_int32, frame_offset + def.second)};
+            GetElementPtrInst *frame = GetElementPtrInst::Create(tempSlot, makeArrayRef(offset));
+            frame->insertAfter(last_gcframe_inst);
+            callInst->replaceAllUsesWith(frame);
+            callInst->eraseFromParent();
+            last_gcframe_inst = frame;
+
+            // delete any associated StoreInst that aren't live
+            for (User::use_iterator use = callInst->use_begin(), usee = callInst->use_end(); use != usee; ++use) {
+                User *user = use.getUse().getUser();
+                if (StoreInst *storeInst = dyn_cast<StoreInst>(user)) {
+                    std::map<frame_register, liveness::id> &inuse_list = bb_uses[storeInst->getParent()];
+                    std::map<frame_register, liveness::id>::iterator inuse_reg = inuse_list.find(def);
+                    if (inuse_reg == inuse_list.end())
+                        storeInst->eraseFromParent();
+                }
+            }
+        }
+        if (callInst && callInst->getCalledFunction() == gcroot_func) {
+            if (!argSlot) {
+                argSlot = GetElementPtrInst::Create(gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, 2)));
+#ifdef JL_DEBUG_BUILD
+                argSlot->setName("locals");
+#endif
+                argSlot->insertAfter(gcframe);
+                if (last_gcframe_inst == gcframe)
+                    last_gcframe_inst = argSlot;
+            }
+            Instruction *argTempi = GetElementPtrInst::Create(argSlot, ArrayRef<Value*>(ConstantInt::get(T_int32, argSpaceSize++)));
+            argTempi->insertAfter(last_gcframe_inst);
+            callInst->replaceAllUsesWith(argTempi);
+            callInst->eraseFromParent();
+            // Initialize the slots for function variables to NULL
+            StoreInst *store = new StoreInst(V_null, argTempi);
+            store->insertAfter(argTempi);
+            last_gcframe_inst = store;
+        }
+    }
+
+    // Initialize the slots for temporary variables to NULL
+    for (int i = 0; i < maxDepth; i++) {
+        Instruction *argTempi = GetElementPtrInst::Create(tempSlot, ArrayRef<Value*>(ConstantInt::get(T_int32, i)));
+        argTempi->insertAfter(last_gcframe_inst);
+        StoreInst *store = new StoreInst(V_null, argTempi);
+        store->insertAfter(argTempi);
+        last_gcframe_inst = store;
+    }
+    gcframe->setOperand(0, ConstantInt::get(T_int32, 2 + argSpaceSize + maxDepth)); // fix up the size of the gc frame
+    tempSlot->setOperand(1, ConstantInt::get(T_int32, 2 + argSpaceSize)); // fix up the offset to the temp slot space
+
+/* finalize all of the frames by replacing them with the appropriate gep(tempslot) */
+    for (std::map<CallInst*, unsigned>::iterator frame = frames.begin(), framee = frames.end(); frame != framee; ++frame) {
+        Value* offset[1] = {ConstantInt::get(T_int32, frame->second)};
+        GetElementPtrInst *gep = GetElementPtrInst::Create(tempSlot, makeArrayRef(offset));
+        ReplaceInstWithInst(frame->first, gep);
+    }
+}

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -179,9 +179,7 @@ void jl_codegen_finalize_temp_arg(AllocaInst *gcframe, Instruction *&last_gcfram
                     }
                 }
                 if (callInst->getCalledFunction() == gckill_func) {
-                    // jwn: record this information instead of simply destroying it
-                    ++ri;
-                    callInst->eraseFromParent();
+                    // TODO: track variable liveness information starting from gckill, store-to-gcroot, and store-to-jlcall-frame
                 }
             }
             else if (StoreInst *storeInst = dyn_cast<StoreInst>(i)) {
@@ -335,6 +333,149 @@ void jl_codegen_finalize_temp_arg(AllocaInst *gcframe, Instruction *&last_gcfram
     if (last_gcframe_inst == gcframe)
         last_gcframe_inst = tempSlot;
 
+/* # allocate space in locals for the variables
+ * TBD
+ */
+    for (BasicBlock::iterator I = gcframe->getParent()->begin(), E = gcframe; I != E; ) {
+        CallInst* callInst = dyn_cast<CallInst>(&*I);
+        ++I;
+        if (callInst && callInst->getCalledFunction() == gcroot_func) {
+            // see if a root is only used briefly for `store -> load -> store other` pattern or `store, store other`
+            // such that the first store can be trivially replaced with just "other" and delete the chain
+            // or if is used for store, but the value is never needed
+            StoreInst *theStore = NULL;
+            LoadInst *theLoad = NULL;
+            for (User::use_iterator use = callInst->use_begin(), usee = callInst->use_end(); use != usee; ++use) {
+                // see if the gcroot uses consists of only the load and the store
+                User *user = use.getUse().getUser();
+                if (StoreInst *storeInst = dyn_cast<StoreInst>(user)) {
+                    if (theStore) {
+                        theStore = NULL;
+                        break;
+                    }
+                    theStore = storeInst;
+                }
+                else if (LoadInst *loadInst = dyn_cast<LoadInst>(user)) {
+                    if (theLoad) {
+                        theStore = NULL;
+                        break;
+                    }
+                    theLoad = loadInst;
+                }
+                else {
+                    theStore = NULL;
+                    break;
+                }
+            }
+            if (theStore) {
+                Value *theValue = theLoad ? theLoad : theStore->getValueOperand();
+                if (!theLoad && theValue->hasOneUse()) {
+                    // this gcroot is unused (the only Use of theValue is theStore)
+                    if (&*I == theStore) ++I;
+                    theStore->eraseFromParent();
+                    callInst->eraseFromParent();
+                }
+                else if (theValue->hasNUses(theLoad ? 1 : 2)) {
+                    StoreInst *theOther = NULL;
+                    bool patternMatchSuccess = false;
+                    // check if this value is only used for a store to another gcroot
+                    User::use_iterator value_use = theValue->use_begin();
+                    if (theLoad && *value_use == theStore)
+                        ++value_use;
+                    theOther = dyn_cast<StoreInst>(value_use.getUse().getUser());
+                    if (theOther && value_use.getOperandNo() != StoreInst::getPointerOperandIndex()) {
+                        // test whether this store is valid as a gc-root
+                        CallInst *gcroot_other = dyn_cast<CallInst>(theOther->getPointerOperand());
+                        unsigned arg_offset = 0;
+                        if (!gcroot_other) {
+                            // also try to look through GEP for jlcall_frame_func
+                            if (GetElementPtrInst *gepInst = dyn_cast<GetElementPtrInst>(theOther->getPointerOperand())) {
+                                if (gepInst->getNumIndices() == 1) {
+                                    gcroot_other = dyn_cast<CallInst>(gepInst->getPointerOperand());
+                                    if (gcroot_other && gcroot_other->getCalledFunction() == jlcall_frame_func)
+                                        arg_offset = cast<ConstantInt>(gepInst->idx_begin()->get())->getZExtValue();
+                                    else
+                                        gcroot_other = NULL;
+                                }
+                            }
+                        }
+                        // it could be a gcroot
+                        if (gcroot_other && gcroot_other->getCalledFunction() == gcroot_func) {
+                            // need to make sure there aren't any other uses of gcroot_other (including gckill)
+                            // between the initial store and the replacement store
+                            BasicBlock *current = theStore->getParent();
+                            BasicBlock::iterator bbi = theStore, bbi_end = current->end();
+                            patternMatchSuccess = true;
+                            ++bbi;
+                            while (patternMatchSuccess) {
+                                Instruction *inst = &*bbi;
+                                if (inst == theOther) {
+                                    break; // success
+                                }
+                                for (Instruction::op_iterator op = inst->op_begin(), op_e = inst->op_end(); op != op_e; ++op) {
+                                    if (op->get() == gcroot_other) {
+                                        patternMatchSuccess = false;
+                                        break; // fail: gcroot_other had another reference, can't make this replacement
+                                    }
+                                }
+                                if (++bbi == bbi_end) {
+                                    // iterate the basicblock forward, if it's a simple branch
+#ifdef LLVM35
+                                    BasicBlock *next = current->getUniqueSuccessor();
+#else
+                                    succ_iterator SI = succ_begin(current), E = succ_end(current);
+                                    BasicBlock *next = NULL;
+                                    if (SI != E) {
+                                        next = *SI;
+                                        for (++SI; SI != E; ++SI) {
+                                            if (*SI != next) {
+                                                next = NULL;
+                                                break;
+                                            }
+                                        }
+                                    }
+#endif
+                                    if (next) {
+                                        bbi = next->begin();
+                                        bbi_end = next->end();
+                                        current = next;
+                                    }
+                                    else {
+                                        patternMatchSuccess = false;
+                                    }
+                                }
+                            }
+                        }
+                        // or it could be a jlcall frame
+                        else if (gcroot_other && gcroot_other->getCalledFunction() == jlcall_frame_func) {
+                            // only one store to a jlcall_frame_func slot exists now,
+                            // until the allocate space in temp-args for each jlcall frame
+                            // but do need to update liveness information for this slot
+                            // TODO: do this better once we have liveness information for locals
+                            if (theOther->getParent() == theStore->getParent()) {
+                                //frame_register def(gcroot_other, arg_offset);
+                                //std::map<frame_register, liveness::id> &inuse_list = bb_uses[theOther->getParent()];
+                                //std::map<frame_register, liveness::id>::iterator inuse_reg = inuse_list.find(def);
+                                patternMatchSuccess = true;
+                            }
+                        }
+                    }
+                    if (patternMatchSuccess) {
+                        // do the gcroot merge
+                        theStore->setOperand(StoreInst::getPointerOperandIndex(), theOther->getPointerOperand());
+                        if (&*I == theOther) ++I;
+                        theOther->eraseFromParent();
+                        if (theLoad) {
+                            if (&*I == theLoad) ++I;
+                            theLoad->eraseFromParent();
+                        }
+                        callInst->eraseFromParent();
+                    }
+                }
+            }
+        }
+    }
+
 /* # allocate space in temp-args for each jlcall frame
  * regs-used = zip(get-basic-blocks(), falses)
  * for bb in iterator(f)
@@ -357,6 +498,19 @@ void jl_codegen_finalize_temp_arg(AllocaInst *gcframe, Instruction *&last_gcfram
                     frames[callInst] = frame_offset;
                     if (frame_offset + arg_n > maxDepth)
                         maxDepth = frame_offset + arg_n;
+                }
+            }
+        }
+    }
+
+    // delete the now unused gckill information
+    for (Function::iterator bb = F.begin(), be = F.end(); bb != be; ++bb) {
+        for (BasicBlock::iterator i = bb->begin(), ie = bb->end(); i != ie; ) {
+            Instruction *inst = &*i;
+            ++i;
+            if (CallInst* callInst = dyn_cast<CallInst>(inst)) {
+                if (callInst->getCalledFunction() == gckill_func) {
+                    callInst->eraseFromParent();
                 }
             }
         }
@@ -398,6 +552,7 @@ void jl_codegen_finalize_temp_arg(AllocaInst *gcframe, Instruction *&last_gcfram
                 }
             }
         }
+
         if (callInst && callInst->getCalledFunction() == gcroot_func) {
             if (!argSlot) {
                 argSlot = GetElementPtrInst::Create(gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, 2)));

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -19,9 +19,9 @@ ccall_echo_func{T,U}(x, ::Type{T}, ::Type{U}) = ccall((:test_echo_p, libccalltes
 # Make sure object x is still valid (rooted as argument)
 # when loading the pointer. This works as long as we still keep the argument
 # rooted but might fail if we are smarter about eliminating dead root.
-ccall_echo_load{T,U}(x, ::Type{T}, ::Type{U}) =
+@noinline ccall_echo_load{T,U}(x, ::Type{T}, ::Type{U}) =
     unsafe_load(ccall_echo_func(x, T, U))
-ccall_echo_objref{T,U}(x, ::Type{T}, ::Type{U}) =
+@noinline ccall_echo_objref{T,U}(x, ::Type{T}, ::Type{U}) =
     unsafe_pointer_to_objref(ccall_echo_func(x, Ptr{T}, U))
 type IntLike
     x::Int

--- a/test/core.jl
+++ b/test/core.jl
@@ -2272,7 +2272,7 @@ end
 
 # weak references
 type Obj; x; end
-function mk_wr(r, wr)
+@noinline function mk_wr(r, wr)
     x = Obj(1)
     push!(r, x)
     push!(wr, WeakRef(x))


### PR DESCRIPTION
this rewrites the codegen gcroot allocation algorithm to exist entirely as a llvm pass that can be run as a separate optimization pass (instead of updating `argDepth` along the way). it computes liveness intervals to perform register coloring at the basic-block level (fine-grained tracking for the instruction level has not been implemented yet).

at this stage, i believe this should yield results comparable to the current algorithm. however, the expected benefits are:
- the algorithm can handle an SSA-form Julia AST without degradation
- flexibility for writing new / more advanced algorithms is a possibility
- may make it easier to try new gc strategies (e.g. stack maps) and insert the correct gc-state transitions
- simpler codegen (gets us closer to merging emit_expr + emit_unboxed ~~\+ boxed + get_gcrooted~~)

TODO:
- [x] fix LLVM 3.7 compatibility
- [x] cleanup the `needsgcroot` computation in a few places
- [x] finish implementation and usage of `mark_gc_use`
