### PR TITLE
Check for invalid UTF8String in readall()

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -317,7 +317,8 @@ end
 
 function readall(s::IO)
     b = readbytes(s)
-    return isvalid(ASCIIString, b) ? ASCIIString(b) : UTF8String(b)
+    return isvalid(ASCIIString, b) ? ASCIIString(b) :
+           isvalid(UTF8String, b)  ? UTF8String(b)  : b
 end
 readall(filename::AbstractString) = open(readall, filename)
 


### PR DESCRIPTION
Without this UnicodeError occurs some time later when the string is accessed.
Perhaps it should be an immediate error...

``` julia
    isvalid(UTF8String, b) || throw(UnicodeError())
    return isvalid(ASCIIString, b) ? ASCIIString(b) : UTF8String(b)
```

But at least in my use case, it is more convenient to have readall() fall back to returning Array{UInt8} if the data isn't a string.
