### PR TITLE
write(filename::AbstractString, data)

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -125,8 +125,8 @@ function write(s::IO, a::AbstractArray)
     end
     return nb
 end
-"""Write directly to a named file. Equivalent to `open(io->write(io,x), filename, "w")`."""
-write(filename::AbstractString, data) = open(io->write(io, data), filename, "w")
+"""Write directly to a named file. Equivalent to `open(io->write(io,x...), filename, "w")`."""
+write(filename::AbstractString, x...) = open(io->write(io, x...), filename, "w")
 
 
 function write(s::IO, ch::Char)

--- a/base/io.jl
+++ b/base/io.jl
@@ -125,6 +125,7 @@ function write(s::IO, a::AbstractArray)
     end
     return nb
 end
+"""Write directly to a named file. Equivalent to `open(io->write(io,x), filename, "w")`."""
 write(filename::AbstractString, data) = open(io->write(io, data), filename, "w")
 
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -125,6 +125,8 @@ function write(s::IO, a::AbstractArray)
     end
     return nb
 end
+write(filename::AbstractString, data) = open(io->write(io, data), filename, "w")
+
 
 function write(s::IO, ch::Char)
     c = reinterpret(UInt32, ch)

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -134,6 +134,10 @@ General I/O
        write(stream, x, y...)
        write(stream, x) + write(stream, y...)
 
+.. function:: write(filename, x)
+
+   Write directly to a named file. Equivalent to ``open(io->write(io,x), filename, "w")``\ .
+
 .. function:: read(stream, type)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
Convenience function to write directly to a named file.

I'm doing a cleanup of my local stash of convenience functions and thought that this might be generally useful.
I seem to use this very often.

``` julia
write("/tmp/foo", "hello")
readall("/tmp/foo")
"hello"
```

See also JuliaLang/GZip.jl#45, gzreadall(filename) and gzwrite(filename, data).
