### PR TITLE
Make sure JL_DLLEXPORT debugging helper functions are actually exported

### DIFF
--- a/doc/devdocs/debuggingtips.rst
+++ b/doc/devdocs/debuggingtips.rst
@@ -43,7 +43,7 @@ there are a number of additional variables (see julia.h for a complete list) tha
 Useful Julia functions for Inspecting those variables
 -----------------------------------------------------
 
-- ``gdblookup($rip)`` :: For looking up the current function and line. (use ``$eip`` on i686 platforms)
+- ``jl_gdblookup($rip)`` :: For looking up the current function and line. (use ``$eip`` on i686 platforms)
 - ``jlbacktrace()`` :: For dumping the current julia backtrace stack to stderr. Only usable after ``record_backtrace()`` has been called.
 - ``jl_dump_llvm_value(Value*)`` :: For invoking ``Value->dump()`` in gdb, where it doesn't work natively. For example, ``f->linfo->functionObject``, ``f->linfo->specFunctionObject``, and ``to_function(f->linfo)``.
 - ``Type->dump()`` :: only works in lldb. Note: add something like ``;1`` to prevent lldb from printing its prompt over the output

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -14,6 +14,7 @@
     iswprint;
     jl_*;
     rec_backtrace;
+    rec_backtrace_ctx;
     julia_*;
     libsupport_init;
     localtime_r;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -289,7 +289,7 @@ JL_DLLEXPORT void attach_exception_port(void);
 void jl_getFunctionInfo(char **name, char **filename, size_t *line,
                         char **inlinedat_file, size_t *inlinedat_line,
                         uintptr_t pointer, int *fromC, int skipC, int skipInline);
-JL_DLLEXPORT void gdblookup(ptrint_t ip);
+JL_DLLEXPORT void jl_gdblookup(ptrint_t ip);
 
 // *to is NULL or malloc'd pointer, from is allowed to be NULL
 static inline char *jl_copy_str(char **to, const char *from)

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -56,7 +56,7 @@ static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, 
     if (context)
         *bt_size = n = rec_backtrace_ctx(bt_data, JL_MAX_BT_SIZE, context);
     for(size_t i=0; i < n; i++)
-        gdblookup(bt_data[i]);
+        jl_gdblookup(bt_data[i]);
     gc_debug_print_status();
 }
 

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -4,8 +4,6 @@
 #define sig_stack_size 131072 // 128k reserved for SEGV handling
 static BOOL (*pSetThreadStackGuarantee)(PULONG);
 
-JL_DLLEXPORT void gdblookup(ptrint_t ip);
-
 // Copied from MINGW_FLOAT_H which may not be found due to a collision with the builtin gcc float.h
 // eventually we can probably integrate this into OpenLibm.
 #if defined(_COMPILER_MINGW_)
@@ -220,7 +218,7 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
                 jl_safe_printf("UNKNOWN"); break;
         }
         jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-        gdblookup((ptrint_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+        jl_gdblookup((ptrint_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
         jl_critical_error(0, ExceptionInfo->ContextRecord, jl_bt_data, &jl_bt_size);
         static int recursion = 0;

--- a/src/task.c
+++ b/src/task.c
@@ -756,7 +756,7 @@ JL_DLLEXPORT jl_value_t *jl_get_backtrace(void)
 }
 
 //for looking up functions from gdb:
-JL_DLLEXPORT void gdblookup(ptrint_t ip)
+JL_DLLEXPORT void jl_gdblookup(ptrint_t ip)
 {
     char *func_name;
     size_t line_num;
@@ -794,11 +794,11 @@ JL_DLLEXPORT void gdblookup(ptrint_t ip)
 JL_DLLEXPORT void jlbacktrace(void)
 {
     size_t n = jl_bt_size; // jl_bt_size > 40 ? 40 : jl_bt_size;
-    for(size_t i=0; i < n; i++)
-        gdblookup(jl_bt_data[i]);
+    for (size_t i=0; i < n; i++)
+        jl_gdblookup(jl_bt_data[i]);
 }
 
-JL_DLLEXPORT void gdbbacktrace(void)
+JL_DLLEXPORT void jl_gdbbacktrace(void)
 {
     record_backtrace();
     jlbacktrace();


### PR DESCRIPTION
The particularly useful one is `gdbbacktrace` (`jl_gdbbacktrace` now) since it is otherwise not even used anywhere in the c code.
