### PR TITLE
Make sure pointerfree is initialized

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -552,6 +552,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
     t->fielddesc_type = fielddesc_type;
     t->nfields = nfields;
     t->haspadding = 0;
+    t->pointerfree = 0;
     return t;
 }
 


### PR DESCRIPTION
So that `jl_compute_field_offsets` can work correctly.

This is very likely what's causing the intermittent `UndefRefError` or similar `dict` and `show` related tests failures on CI recently. According to a very reliable repro on ARM, the cause is that the size of `ImmutableDict{Symbol,Any}` was computed to be `2 * sizeof(void*)` when the type appears to be `pointerfree && immutable` in `jl_compute_field_offsets`.

c.c. @vtjnash 
