### PR TITLE
reduce op count for isinteger, add tests

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -24,7 +24,7 @@ maxintfloat(::Type{Float16}) = Float16(2048f0)
 maxintfloat{T<:AbstractFloat}(x::T)  = maxintfloat(T)
 maxintfloat() = maxintfloat(Float64)
 
-isinteger(x::AbstractFloat) = (trunc(x)==x)&isfinite(x)
+isinteger(x::AbstractFloat) = x-trunc(x) == 0
 
 num2hex(x::Float16) = hex(reinterpret(UInt16,x), 4)
 num2hex(x::Float32) = hex(box(UInt32,unbox(Float32,x)),8)

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -20,6 +20,21 @@ for elty in (Float16,Float32,Float64)
 end
 @test maxintfloat() == maxintfloat(Float64)
 
+# isinteger
+for elty in (Float16,Float32,Float64)
+    @test !isinteger(elty(1.2))
+    @test isinteger(elty(12))
+    @test isinteger(zero(elty))
+    @test isinteger(-zero(elty))
+    @test !isinteger(nextfloat(zero(elty)))
+    @test !isinteger(prevfloat(zero(elty)))
+    @test isinteger(maxintfloat(elty))
+    @test isinteger(-maxintfloat(elty))
+    @test !isinteger(elty(Inf))
+    @test !isinteger(-elty(Inf))
+    @test !isinteger(elty(NaN))
+end
+
 #num2hex
 for elty in (Float16,Float32,Float64)
     x = rand(elty)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -206,8 +206,17 @@ x = BigFloat(12)
 @test_throws DomainError setprecision(1)
 
 # isinteger
+@test !isinteger(BigFloat(1.2))
 @test isinteger(BigFloat(12))
-@test !isinteger(BigFloat(12.12))
+@test isinteger(zero(BigFloat))
+@test isinteger(-zero(BigFloat))
+@test !isinteger(nextfloat(zero(BigFloat)))
+@test !isinteger(prevfloat(zero(BigFloat)))
+@test isinteger(maxintfloat(BigFloat))
+@test isinteger(-maxintfloat(BigFloat))
+@test !isinteger(BigFloat(Inf))
+@test !isinteger(-BigFloat(Inf))
+@test !isinteger(BigFloat(NaN))
 
 # nextfloat / prevfloat
 setprecision(53) do


### PR DESCRIPTION
Okay, not the biggest optimisation in the world, but we reduce

```
  %1 = call double @llvm.trunc.f64(double %0)
  %2 = fcmp oeq double %1, %0
  %3 = fsub double %0, %0
  %4 = fcmp oeq double %3, 0.000000e+00
  %5 = and i1 %2, %4
  ret i1 %5
```

to

```
  %1 = call double @llvm.trunc.f64(double %0)
  %2 = fsub double %1, %0
  %3 = fcmp oeq double %2, 0.000000e+00
  ret i1 %3
```
