### PR TITLE
Treat macros the same as functions in docsystem

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -711,14 +711,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
         keymap_func_data = repl,
         complete = replc,
         # When we're done transform the entered line into a call to help("$line")
-        on_done = respond(repl, julia_prompt) do line
-            line = strip(line)
-            haskey(Docs.keywords, symbol(line)) ? # Special-case keywords, which won't parse
-                :(Base.Docs.@repl $(symbol(line))) :
-                Base.syntax_deprecation_warnings(false) do
-                    parse("Base.Docs.@repl $line", raise=false)
-                end
-        end)
+        on_done = respond(Docs.helpmode, repl, julia_prompt))
 
     # Set up shell mode
     shell_mode = Prompt("shell> ";

--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -74,7 +74,13 @@ function find_docs(v)
     docs = []
     for mod in keys(mod_added)
         try
-            meta = Docs.meta(mod)[v]
+            m = Docs.meta(mod)
+            if haskey(m, v)
+                meta = m[v]
+            elseif isa(v, Docs.Binding)
+                obj = getfield(v.mod, v.var)
+                meta = m[obj]
+            end
             if isa(meta, Base.Docs.MultiDoc)
                 append!(docs, collect(values(meta.docs)))
             else

--- a/doc/manual/documentation.rst
+++ b/doc/manual/documentation.rst
@@ -206,6 +206,23 @@ Adds docstring ``"..."`` to ``Method`` ``f(::Any)``.
 
 Adds docstring ``"..."`` to two ``Method``\ s, namely ``f(::Any)`` and ``f(::Any, ::Any)``.
 
+Macros
+~~~~~~
+
+.. code-block:: julia
+
+    "..."
+    macro m(x) end
+
+Adds docstring ``"..."`` to the ``@m(::Any)`` macro definition.
+
+.. code-block:: julia
+
+    "..."
+    :(@m)
+
+Adds docstring ``"..."`` to the macro named ``@m``.
+
 Types
 ~~~~~
 
@@ -244,20 +261,6 @@ Adds docstring ``"..."`` to the ``Binding`` ``A``.
 
 ``Binding``\ s are used to store a reference to a particular ``Symbol`` in a ``Module``
 without storing the referenced value itself.
-
-Macros
-~~~~~~
-
-.. code-block:: julia
-
-    "..."
-    macro m() end
-
-    "..."
-    :(@m)
-
-Adds docstring ``"..."`` to the ``Binding`` ``@m``. Adding documentation at the definition
-is the preferred approach.
 
 Modules
 ~~~~~~~

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -670,3 +670,22 @@ let x = Binding(Main, :bindingdoesnotexist)
     @test x.defined == false
     @test @var(bindingdoesnotexist) == x
 end
+
+# Docs.helpmode tests: we test whether the correct expressions are being generated here,
+# rather than complete integration with Julia's REPL mode system.
+for (line, expr) in Pair[
+    "sin"          => :sin,
+    "Base.sin"     => :(Base.sin),
+    "@time(x)"     => :(@time(x)),
+    "@time"        => :(:@time),
+    ":@time"       => :(:@time),
+    "@time()"      => :(@time),
+    "Base.@time()" => :(Base.@time),
+    "ccall"        => :ccall, # keyword
+    "while       " => :while, # keyword, trailing spaces should be stripped.
+    "0"            => 0,
+    "\"...\""      => "...",
+    "r\"...\""     => :(r"..."),
+    ]
+    @test Docs.helpmode(line) == :(Base.Docs.@repl($expr))
+end


### PR DESCRIPTION
Since #14563 made macros into generic functions we should naturally handle them in the same way as functions in the docsystem.

Since the expression `@time` is no different to `@time()` this is slightly problematic for querying the docsystem for the docs associated with the `Function` rather than any one particular `Method` of the
macro. Hence I've added the syntax `help?> :@time` to get docs for the whole macro while `help?> @time`, `help?> @time(x)`, etc. will get docs for a particular signature. The quote (`:`) syntax mirrors that of

```
"..."
:@time
```

syntax which is already available for use to document `@time` so using it for retrieving as well as setting docs doesn't seem too much of a stretch. Any other suggestions on how to handle this better would be great.

I've also reorganised the `docm` method to be a bit less complex and added some comments describing the different syntax each case handles.
