### PR TITLE
Do not try to call uname on Windows during versioninfo(true)

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -185,7 +185,7 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
         if lsb != ""
             println(io,     "           ", lsb)
         end
-        println(io,         "  uname: ",readchomp(`uname -mprsv`))
+        @unix_only println(io,         "  uname: ",readchomp(`uname -mprsv`))
         println(io,         "Memory: $(Sys.total_memory()/2^30) GB ($(Sys.free_memory()/2^20) MB free)")
         try println(io,     "Uptime: $(Sys.uptime()) sec") end
         print(io,           "Load Avg: ")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -26,6 +26,14 @@ temp_pkg_dir() do
     @test sprint(io -> Pkg.status(io)) == "No packages installed\n"
     @test !isempty(Pkg.available())
 
+    # check that versioninfo(io, true) doesn't error and produces some output
+    # (done here since it calls Pkg.status which might error or clone metadata)
+    buf = PipeBuffer()
+    versioninfo(buf, true)
+    ver = readall(buf)
+    @test startswith(ver, "Julia Version $VERSION")
+    @test contains(ver, "Environment:")
+
     # Check that setprotocol! works.
     begin
         try


### PR DESCRIPTION
Add a test that `versioninfo(IOBuffer(), true)` works

Yay, posix assumptions. `mprsv` also brings up memories of a past life where I spent too many months dealing with a manifold pressure regulating shutoff valve...
