### PR TITLE
RFC: fixes IntSet copy!(a,a) for a === a; #14581

### DIFF
--- a/base/intset.jl
+++ b/base/intset.jl
@@ -159,8 +159,12 @@ function symdiff!(s::IntSet, ns)
 end
 
 function copy!(to::IntSet, from::IntSet)
-    empty!(to)
-    union!(to, from)
+    if is(to, from)
+        return to
+    else
+        empty!(to)
+        return union!(to, from)
+    end
 end
 
 in(n, s::IntSet) = n < 0 ? false : (n > typemax(Int) ? s.fill1s : in(convert(Int, n), s))

--- a/test/intset.jl
+++ b/test/intset.jl
@@ -86,6 +86,8 @@ k = IntSet([4, 5])
 copy!(k, i)
 @test k == i
 @test !(k === i)
+copy!(k, k)
+@test k == i
 
 # unions
 i = IntSet([1, 2, 3])


### PR DESCRIPTION
If an `IntSet` is copied into itself, it currently erases the data. Instead the function should do nothing. See #14581 
