### PR TITLE
RFC: Travis adjustments to use gcc 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,31 @@ matrix:
   include:
     - os: linux
       env: ARCH="i686"
-      compiler: "g++ -m32"
+      compiler: "g++-5 -m32"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
+            - bar
             - binutils:i386
-            - gcc:i386
-            - g++:i386
+            - gcc-5:i386
+            - g++-5:i386
             - make:i386
-            - cpp:i386
+            - cpp-5:i386
             - libssl-dev:i386
-            - gfortran:i386
+            - gfortran-5:i386
     - os: linux
       env: ARCH="x86_64"
-      compiler: "g++ -m64"
+      compiler: "g++-5 -m64"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
-            - gfortran
+            - bar
+            - g++-5
+            - gfortran-5
     - os: osx
       env: ARCH="x86_64"
 cache:
@@ -43,10 +50,15 @@ before_install:
     - make check-whitespace
     - if [ `uname` = "Linux" ]; then
         contrib/travis_fastfail.sh || exit 1;
+        mkdir -p $HOME/bin;
+        ln -s /usr/bin/gcc-5 $HOME/bin/gcc;
+        ln -s /usr/bin/g++-5 $HOME/bin/g++;
+        ln -s /usr/bin/gfortran-5 $HOME/bin/gfortran;
+        gcc --version;
         BUILDOPTS="-j3 VERBOSE=1 FORCE_ASSERTIONS=1";
       elif [ `uname` = "Darwin" ]; then
         brew update;
-        brew install -v jq;
+        brew install -v jq bar;
         contrib/travis_fastfail.sh || exit 1;
         brew tap staticfloat/julia;
         brew rm --force $(brew deps --HEAD julia);
@@ -62,8 +74,9 @@ before_install:
       fi
     - git clone -q git://git.kitenet.net/moreutils
 script:
+    - make -C moreutils mispipe
     - make $BUILDOPTS -C base version_git.jl.phony
-    - make $BUILDOPTS NO_GIT=1 -C deps > deps.log || cat deps.log
+    - moreutils/mispipe "make $BUILDOPTS NO_GIT=1 -C deps" bar > deps.log || cat deps.log
     - make $BUILDOPTS NO_GIT=1 JULIA_SYSIMG_BUILD_FLAGS="--output-ji ../usr/lib/julia/sys.ji" prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - if [ `uname` = "Darwin" ]; then
         for name in suitesparseconfig spqr umfpack colamd cholmod amd suitesparse_wrapper; do


### PR DESCRIPTION
This will be necessary for LLVM 3.7 (but can be merged on its own) since Travis Docker containers are still Ubuntu 12.04, where default gcc is 4.6
(could also use gcc 4.8 or 4.9 from the ubuntu-toolchain-r-test ppa, but i386
versions of gcc-5 and gfortran-5 are already on the travis apt whitelist)

pipe build output through bar (helps avoid timeouts when rebuilding deps)
brew install bar

use mispipe for piping through bar but propagating make's exit code
