### PR TITLE
Fix compilation under msvc

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -11,13 +11,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#ifdef _OS_WINDOWS_
-#include <malloc.h>
-#else
-#include <unistd.h>
-#endif
 #include "julia.h"
 #include "julia_internal.h"
+#ifndef _OS_WINDOWS_
+#include <unistd.h>
+#endif
 
 // ::ANY has no effect if the number of overlapping methods is greater than this
 #define MAX_UNSPECIALIZED_CONFLICTS 10

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -841,7 +841,7 @@ struct work_baton {
     void      *work_args;
     void      *work_retval;
     notify_cb_t notify_func;
-    pid_t     tid;
+    int       tid;
     int       notify_idx;
 };
 

--- a/src/support/strptime.c
+++ b/src/support/strptime.c
@@ -39,6 +39,7 @@ __RCSID("$NetBSD: strptime.c,v 1.58 2015/10/31 03:42:00 ginsbach Exp $");
 #include <time.h>
 #include <stdint.h>
 #include "tzfile.h"
+#include "dtypes.h" // for strncasecmp on msvc
 
 typedef unsigned int uint;
 typedef unsigned char u_char;
@@ -621,7 +622,7 @@ namedzone:
 				 * Our current timezone
 				 */
 				ep = find_string(bp, &i,
-					       	 (const char * const *)tzname,
+					       	 (const char * const *)_tzname,
 					       	  NULL, 2);
 				if (ep != NULL) {
 					tm->tm_isdst = i;
@@ -629,7 +630,7 @@ namedzone:
 					tm->TM_GMTOFF = -timezone;
 #endif
 #ifdef TM_ZONE
-					tm->TM_ZONE = tzname[i];
+					tm->TM_ZONE = _tzname[i];
 #endif
 					bp = ep;
 					continue;


### PR DESCRIPTION
strptime.c needs dtypes.h for strncasecmp, and _tzname instead of tzname

Use int instead of pid_t in work_baton struct for the sake of msvc

`_OS_WINDOWS_` in gf.c is not defined until after including julia.h
