### PR TITLE
add a test for #14174, eigfact of a not-tiny matrix

### DIFF
--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -70,3 +70,9 @@ debug && println("Non-symmetric generalized eigenproblem")
     @test d == f[:values]
     @test v == f[:vectors]
 end
+
+# test a matrix larger than 140-by-140 for #14174
+let a = rand(200, 200)
+    f = eigfact(a)
+    @test a ≈ f[:vectors] * Diagonal(f[:values]) / f[:vectors]
+end


### PR DESCRIPTION
I fixed this (well, borrowed Marco Atzeri's fix) in #14203 but couldn't add a test right away since we needed to get a patched openblas build into the nightlies.
