### PR TITLE
RFC: efficient product iterator

### DIFF
--- a/test/functional.jl
+++ b/test/functional.jl
@@ -155,6 +155,17 @@ let i = 0
     end
 end
 
+# product
+# -------
+
+@test isempty(Base.product(1:2,1:0))
+@test isempty(Base.product(1:2,1:0,1:10))
+@test isempty(Base.product(1:2,1:10,1:0))
+@test isempty(Base.product(1:0,1:2,1:10))
+@test collect(Base.product(1:2,3:4)) == [(1,3),(2,3),(1,4),(2,4)]
+@test isempty(collect(Base.product(1:0,1:2)))
+@test length(Base.product(1:2,1:10,4:6)) == 60
+
 # foreach
 let
     a = []


### PR DESCRIPTION
This uses the same general trick as the `zip` iterator to get performance without generated functions. I'm sure it could be better, but it's at least reasonably fast:

```
julia> function f()
         @time for k=1:10;[ i+j for i=1:1000, j=1:1000 ];end
         @time for k=1:10;[ i+j for (i,j) in product(1:1000,1:1000) ];end
       end
f (generic function with 1 method)

julia> f();
  0.011721 seconds (20 allocations: 76.295 MB, 18.53% gc time)
  0.022262 seconds (20 allocations: 76.295 MB, 4.50% gc time)

julia> function f()
         @time for k=1:10;[ i+j+l for i=1:1000, j=1:100, l=1:10 ];end
         @time for k=1:10;[ i+j+l for (i,j,l) in product(1:1000,1:100,1:10) ];end
       end
f (generic function with 1 method)

julia> f();
  0.013009 seconds (20 allocations: 76.295 MB, 11.70% gc time)
  0.046552 seconds (20 allocations: 76.295 MB, 4.16% gc time)

julia> f();
  0.020044 seconds (20 allocations: 76.295 MB, 11.20% gc time)
  0.029772 seconds (20 allocations: 76.295 MB, 6.82% gc time)
```

The times are pretty variable but this looks something like a factor of 2.

This implements the same iteration order as comprehensions (first iterator is the innermost loop). Would anybody want lexicographic order in addition or instead?
