### PR TITLE
Remove jl_gc_preserve

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -670,9 +670,6 @@ JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void);
 JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
 
 JL_DLLEXPORT void jl_gc_collect(int);
-JL_DLLEXPORT void jl_gc_preserve(jl_value_t *v);
-JL_DLLEXPORT void jl_gc_unpreserve(void);
-JL_DLLEXPORT int jl_gc_n_preserved_values(void);
 
 JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
 JL_DLLEXPORT void jl_finalize(jl_value_t *o);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -167,13 +167,16 @@ void jl_add_method(jl_function_t *gf, jl_tupletype_t *types, jl_function_t *meth
                    jl_svec_t *tvars, int8_t isstaged);
 jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
-void *jl_start_parsing_file(const char *fname);
-void jl_stop_parsing(void *ctx);
-jl_value_t *jl_parse_next(void *ctx);
+
+typedef struct _jl_ast_context_t jl_ast_context_t;
+jl_ast_context_t *jl_start_parsing_file(const char *fname);
+void jl_stop_parsing(jl_ast_context_t *ctx);
+jl_value_t *jl_parse_next(jl_ast_context_t *ctx);
+
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
 void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
-jl_value_t *jl_parse_eval_all(const char *fname, size_t len, void *ctx);
+jl_value_t *jl_parse_eval_all(const char *fname, size_t len, jl_ast_context_t *ctx);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
 jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
                                              jl_value_t **loc, size_t nl);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -555,7 +555,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v)
 }
 
 // repeatedly call jl_parse_next and eval everything
-jl_value_t *jl_parse_eval_all(const char *fname, size_t len, void *ctx)
+jl_value_t *jl_parse_eval_all(const char *fname, size_t len, jl_ast_context_t *ctx)
 {
     //jl_printf(JL_STDERR, "***** loading %s\n", fname);
     int last_lineno = jl_lineno;
@@ -615,7 +615,7 @@ JL_DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len)
     if (jl_stat(fpath, (char*)&stbuf) != 0 || (stbuf.st_mode & S_IFMT) != S_IFREG) {
         jl_errorf("could not open file %s", fpath);
     }
-    void *ctx = jl_start_parsing_file(fpath);
+    jl_ast_context_t *ctx = jl_start_parsing_file(fpath);
     if (!ctx) {
         jl_errorf("could not open file %s", fpath);
     }


### PR DESCRIPTION
This implements what I mentioned in https://github.com/JuliaLang/julia/pull/14384#issuecomment-169735803. (And fixes a small mem leak in the parser due to not resetting the preserved list after `jl-parse-next`).

The second commit removes the `gc_preserve*` api since there's no users of it in base anymore and a github search shows no one else using it either (and they shouldn't be using it). I'm fine with keeping it too if there's a good reason...

c.c. @vtjnash 
