### PR TITLE
cosmetic fixes for `LinAlg.chksquare`

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -179,14 +179,26 @@ function chkstride1(A...)
     end
 end
 
-# Check that matrix is square
-function chksquare(A)
+"""
+    LinAlg.checksquare(A)
+
+Check that a matrix is square, then return its common dimension.
+
+Input:
+
+- a matrix (or multiple matrices)
+
+Output:
+
+- the common dimension (a vector for multiple arguments)
+"""
+function checksquare(A)
     m,n = size(A)
     m == n || throw(DimensionMismatch("matrix is not square"))
     m
 end
 
-function chksquare(A...)
+function checksquare(A...)
     sizes = Int[]
     for a in A
         size(a,1)==size(a,2) || throw(DimensionMismatch("matrix is not square: dimensions are $(size(a))"))

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -182,15 +182,7 @@ end
 """
     LinAlg.checksquare(A)
 
-Check that a matrix is square, then return its common dimension.
-
-Input:
-
-- a matrix (or multiple matrices)
-
-Output:
-
-- the common dimension (a vector for multiple arguments)
+Check that a matrix is square, then return its common dimension. For multiple arguments, return a vector.
 """
 function checksquare(A)
     m,n = size(A)

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -122,7 +122,7 @@ function _eigs(A, B;
               tol=0.0, maxiter::Integer=300, sigma=nothing, v0::Vector=zeros(eltype(A),(0,)),
               ritzvec::Bool=true)
 
-    n = chksquare(A)
+    n = checksquare(A)
 
     T = eltype(A)
     iscmplx = T <: Complex

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -56,7 +56,7 @@ export
 
 const libblas = Base.libblas_name
 
-import ..LinAlg: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, chksquare, axpy!
+import ..LinAlg: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, axpy!
 
 """
     blas_set_num_threads(n)
@@ -682,7 +682,7 @@ for (fname, elty) in ((:dtrmv_,:Float64),
                 # *     .. Array Arguments ..
                 #       DOUBLE PRECISION A(LDA,*),X(*)
         function trmv!(uplo::Char, trans::Char, diag::Char, A::StridedMatrix{$elty}, x::StridedVector{$elty})
-            n = chksquare(A)
+            n = checksquare(A)
             if n != length(x)
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
             end
@@ -731,7 +731,7 @@ for (fname, elty) in ((:dtrsv_,:Float64),
                 #       .. Array Arguments ..
                 #       DOUBLE PRECISION A(LDA,*),X(*)
         function trsv!(uplo::Char, trans::Char, diag::Char, A::StridedMatrix{$elty}, x::StridedVector{$elty})
-            n = chksquare(A)
+            n = checksquare(A)
             if n != length(x)
                 throw(DimensionMismatch("size of A is $n != length(x) = $(length(x))"))
             end
@@ -795,7 +795,7 @@ for (fname, elty) in ((:dsyr_,:Float64),
                       (:csyr_,:Complex64))
     @eval begin
         function syr!(uplo::Char, α::$elty, x::StridedVector{$elty}, A::StridedMatrix{$elty})
-            n = chksquare(A)
+            n = checksquare(A)
             if length(x) != n
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
             end
@@ -824,7 +824,7 @@ for (fname, elty, relty) in ((:zher_,:Complex128, :Float64),
                              (:cher_,:Complex64, :Float32))
     @eval begin
         function her!(uplo::Char, α::$relty, x::StridedVector{$elty}, A::StridedMatrix{$elty})
-            n = chksquare(A)
+            n = checksquare(A)
             if length(x) != n
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
             end
@@ -922,7 +922,7 @@ for (mfname, elty) in ((:dsymm_,:Float64),
              #     DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
         function symm!(side::Char, uplo::Char, alpha::($elty), A::StridedMatrix{$elty}, B::StridedMatrix{$elty}, beta::($elty), C::StridedMatrix{$elty})
             m, n = size(C)
-            j = chksquare(A)
+            j = checksquare(A)
             if j != (side == 'L' ? m : n)
                 throw(DimensionMismatch("A has size $(size(A)), C has size ($m,$n)"))
             end
@@ -991,7 +991,7 @@ for (mfname, elty) in ((:zhemm_,:Complex128),
              #     DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
         function hemm!(side::Char, uplo::Char, alpha::($elty), A::StridedMatrix{$elty}, B::StridedMatrix{$elty}, beta::($elty), C::StridedMatrix{$elty})
             m, n = size(C)
-            j = chksquare(A)
+            j = checksquare(A)
             if j != (side == 'L' ? m : n)
                 throw(DimensionMismatch("A has size $(size(A)), C has size ($m,$n)"))
             end
@@ -1050,7 +1050,7 @@ for (fname, elty) in ((:dsyrk_,:Float64),
        function syrk!(uplo::Char, trans::Char,
                       alpha::($elty), A::StridedVecOrMat{$elty},
                       beta::($elty), C::StridedMatrix{$elty})
-           n = chksquare(C)
+           n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
            k  = size(A, trans == 'N' ? 2 : 1)
@@ -1103,7 +1103,7 @@ for (fname, elty, relty) in ((:zherk_, :Complex128, :Float64),
        #       COMPLEX A(LDA,*),C(LDC,*)
        function herk!(uplo::Char, trans::Char, α::$relty, A::StridedVecOrMat{$elty},
                       β::$relty, C::StridedMatrix{$elty})
-           n = chksquare(C)
+           n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n
                throw(DimensionMismatch("the matrix to update has dimension $n but the implied dimension of the update is $(size(A, trans == 'N' ? 1 : 2))"))
@@ -1144,7 +1144,7 @@ for (fname, elty) in ((:dsyr2k_,:Float64),
         function syr2k!(uplo::Char, trans::Char,
                         alpha::($elty), A::StridedVecOrMat{$elty}, B::StridedVecOrMat{$elty},
                         beta::($elty), C::StridedMatrix{$elty})
-            n = chksquare(C)
+            n = checksquare(C)
             nn = size(A, trans == 'N' ? 1 : 2)
             if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
             k  = size(A, trans == 'N' ? 2 : 1)
@@ -1181,7 +1181,7 @@ for (fname, elty1, elty2) in ((:zher2k_,:Complex128,:Float64), (:cher2k_,:Comple
        function her2k!(uplo::Char, trans::Char, alpha::($elty1),
                        A::StridedVecOrMat{$elty1}, B::StridedVecOrMat{$elty1},
                        beta::($elty2), C::StridedMatrix{$elty1})
-           n = chksquare(C)
+           n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
            k  = size(A, trans == 'N' ? 2 : 1)
@@ -1258,7 +1258,7 @@ for (mmname, smname, elty) in
         function trmm!(side::Char, uplo::Char, transa::Char, diag::Char, alpha::Number,
                        A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             m, n = size(B)
-            nA = chksquare(A)
+            nA = checksquare(A)
             if nA != (side == 'L' ? m : n)
                 throw(DimensionMismatch("size of A, $(size(A)), doesn't match $side size of B with dims, $(size(B))"))
             end
@@ -1283,7 +1283,7 @@ for (mmname, smname, elty) in
         function trsm!(side::Char, uplo::Char, transa::Char, diag::Char,
                        alpha::$elty, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             m, n = size(B)
-            k = chksquare(A)
+            k = checksquare(A)
             if k != (side == 'L' ? m : n)
                 throw(DimensionMismatch("size of A is $n, size(B)=($m,$n) and transa='$transa'"))
             end

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -34,7 +34,7 @@ end
 chol!(A::StridedMatrix) = chol!(A, UpperTriangular)
 
 function chol!{T}(A::AbstractMatrix{T}, ::Type{UpperTriangular})
-    n = chksquare(A)
+    n = checksquare(A)
     @inbounds begin
         for k = 1:n
             for i = 1:k - 1
@@ -54,7 +54,7 @@ function chol!{T}(A::AbstractMatrix{T}, ::Type{UpperTriangular})
     return UpperTriangular(A)
 end
 function chol!{T}(A::AbstractMatrix{T}, ::Type{LowerTriangular})
-    n = chksquare(A)
+    n = checksquare(A)
     @inbounds begin
         for k = 1:n
             for i = 1:k - 1

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -142,7 +142,7 @@ end
 diagm(x::Number) = (X = Array(typeof(x),1,1); X[1,1] = x; X)
 
 function trace{T}(A::Matrix{T})
-    n = chksquare(A)
+    n = checksquare(A)
     t = zero(T)
     for i=1:n
         t += A[i,i]
@@ -175,7 +175,7 @@ function ^(A::Matrix, p::Number)
     if isinteger(p)
         return A^Integer(real(p))
     end
-    chksquare(A)
+    checksquare(A)
     v, X = eig(A)
     any(v.<0) && (v = complex(v))
     Xinv = ishermitian(A) ? X' : inv(X)
@@ -190,7 +190,7 @@ expm(x::Number) = exp(x)
 ## Destructive matrix exponential using algorithm from Higham, 2008,
 ## "Functions of Matrices: Theory and Computation", SIAM
 function expm!{T<:BlasFloat}(A::StridedMatrix{T})
-    n = chksquare(A)
+    n = checksquare(A)
     if ishermitian(A)
         return full(expm(Hermitian(A)))
     end
@@ -308,7 +308,7 @@ function logm(A::StridedMatrix)
     end
 
     # Use Schur decomposition
-    n = chksquare(A)
+    n = checksquare(A)
     if istriu(A)
         retmat = full(logm(UpperTriangular(complex(A))))
         d = diag(A)
@@ -343,7 +343,7 @@ function sqrtm{T<:Real}(A::StridedMatrix{T})
     if issym(A)
         return full(sqrtm(Symmetric(A)))
     end
-    n = chksquare(A)
+    n = checksquare(A)
     if istriu(A)
         return full(sqrtm(UpperTriangular(A)))
     else
@@ -356,7 +356,7 @@ function sqrtm{T<:Complex}(A::StridedMatrix{T})
     if ishermitian(A)
         return full(sqrtm(Hermitian(A)))
     end
-    n = chksquare(A)
+    n = checksquare(A)
     if istriu(A)
         return full(sqrtm(UpperTriangular(A)))
     else
@@ -511,7 +511,7 @@ function cond(A::AbstractMatrix, p::Real=2)
         maxv = maximum(v)
         return maxv == 0.0 ? oftype(real(A[1,1]),Inf) : maxv / minimum(v)
     elseif p == 1 || p == Inf
-        chksquare(A)
+        checksquare(A)
         return cond(lufact(A), p)
     end
     throw(ArgumentError("p-norm must be 1, 2 or Inf, got $p"))

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -334,7 +334,7 @@ end
 rank(x::Number) = x==0 ? 0 : 1
 
 function trace(A::AbstractMatrix)
-    chksquare(A)
+    checksquare(A)
     sum(diag(A))
 end
 trace(x::Number) = x
@@ -347,7 +347,7 @@ trace(x::Number) = x
 inv(a::StridedMatrix) = throw(ArgumentError("argument must be a square matrix"))
 function inv{T}(A::AbstractMatrix{T})
     S = typeof(zero(T)/one(T))
-    A_ldiv_B!(factorize(convert(AbstractMatrix{S}, A)), eye(S, chksquare(A)))
+    A_ldiv_B!(factorize(convert(AbstractMatrix{S}, A)), eye(S, checksquare(A)))
 end
 
 function (\)(A::AbstractMatrix, B::AbstractVecOrMat)

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -8,7 +8,7 @@ const liblapack = Base.liblapack_name
 import Base.@blasfunc
 
 import ..LinAlg: BlasFloat, Char, BlasInt, LAPACKException,
-    DimensionMismatch, SingularException, PosDefException, chkstride1, chksquare
+    DimensionMismatch, SingularException, PosDefException, chkstride1, checksquare
 
 const VERSION = Ref{VersionNumber}()
 
@@ -198,7 +198,7 @@ for (gebal, gebak, elty, relty) in
         #      DOUBLE PRECISION   A( LDA, * ), SCALE( * )
         function gebal!(job::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkfinite(A) # balancing routines don't support NaNs and Infs
             ihi = Array(BlasInt, 1)
             ilo = Array(BlasInt, 1)
@@ -224,7 +224,7 @@ for (gebal, gebak, elty, relty) in
             chkstride1(V)
             chkside(side)
             chkfinite(V) # balancing routines don't support NaNs and Infs
-            n = chksquare(V)
+            n = checksquare(V)
             info = Ref{BlasInt}()
             ccall((@blasfunc($gebak), liblapack), Void,
                   (Ptr{UInt8}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
@@ -900,7 +900,7 @@ for (gels, gesv, getrs, getri, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function gesv!(A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A, B)
-            n = chksquare(A)
+            n = checksquare(A)
             if size(B,1) != n
                 throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
             end
@@ -924,7 +924,7 @@ for (gels, gesv, getrs, getri, elty) in
         function getrs!(trans::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
             chktrans(trans)
             chkstride1(A, B)
-            n = chksquare(A)
+            n = checksquare(A)
             if n != size(B, 1)
                 throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
             end
@@ -946,7 +946,7 @@ for (gels, gesv, getrs, getri, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function getri!(A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             if n != length(ipiv)
                 throw(DimensionMismatch("ipiv has length $(length(ipiv)), but needs $n"))
             end
@@ -1036,9 +1036,9 @@ for (gesvx, elty) in
                         AF::StridedMatrix{$elty}, ipiv::Vector{BlasInt}, equed::Char,
                         R::Vector{$elty}, C::Vector{$elty}, B::StridedVecOrMat{$elty})
             chktrans(trans)
-            n    = chksquare(A)
+            n    = checksquare(A)
             lda  = stride(A,2)
-            n    = chksquare(AF)
+            n    = checksquare(AF)
             ldaf = stride(AF,2)
             nrhs = size(B,2)
             ldb  = stride(B,2)
@@ -1104,9 +1104,9 @@ for (gesvx, elty, relty) in
                         AF::StridedMatrix{$elty}, ipiv::Vector{BlasInt}, equed::Char,
                         R::Vector{$relty}, C::Vector{$relty}, B::StridedVecOrMat{$elty})
             chktrans(trans)
-            n   = chksquare(A)
+            n   = checksquare(A)
             lda = stride(A,2)
-            n   = chksquare(AF)
+            n   = checksquare(AF)
             ldaf = stride(AF,2)
             nrhs = size(B,2)
             ldb = stride(B,2)
@@ -1471,7 +1471,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         #      $                   WI( * ), WORK( * ), WR( * )
         function geev!(jobvl::Char, jobvr::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkfinite(A) # balancing routines don't support NaNs and Infs
             lvecs = jobvl == 'V'
             rvecs = jobvr == 'V'
@@ -1935,7 +1935,7 @@ for (geevx, ggev, elty) in
         #      $                   SCALE( * ), VL( LDVL, * ), VR( LDVR, * ),
         #      $                   WI( * ), WORK( * ), WR( * )
         function geevx!(balanc::Char, jobvl::Char, jobvr::Char, sense::Char, A::StridedMatrix{$elty})
-            n = chksquare(A)
+            n = checksquare(A)
             chkfinite(A) # balancing routines don't support NaNs and Infs
             lda = max(1,stride(A,2))
             wr = similar(A, $elty, n)
@@ -2014,7 +2014,7 @@ for (geevx, ggev, elty) in
         #      $                   VR( LDVR, * ), WORK( * )
         function ggev!(jobvl::Char, jobvr::Char, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A,B)
-            n, m = chksquare(A,B)
+            n, m = checksquare(A,B)
             if n != m
                 throw(DimensionMismatch("A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
             end
@@ -2086,7 +2086,7 @@ for (geevx, ggev, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), VL( LDVL, * ), VR( LDVR, * ),
         #      $                   W( * ), WORK( * )
         function geevx!(balanc::Char, jobvl::Char, jobvr::Char, sense::Char, A::StridedMatrix{$elty})
-            n = chksquare(A)
+            n = checksquare(A)
             chkfinite(A) # balancing routines don't support NaNs and Infs
             lda = max(1,stride(A,2))
             w = similar(A, $elty, n)
@@ -2160,7 +2160,7 @@ for (geevx, ggev, elty, relty) in
         #      $                   WORK( * )
         function ggev!(jobvl::Char, jobvr::Char, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A, B)
-            n, m = chksquare(A, B)
+            n, m = checksquare(A, B)
             if n != m
                 throw(DimensionMismatch("A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
             end
@@ -2924,7 +2924,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function posv!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A, B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if size(B,1) != n
                 throw(DimensionMismatch("First dimension of B, $(size(B,1)), and size of A, ($n,$n), must match!"))
@@ -2947,7 +2947,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #       DOUBLE PRECISION   A( LDA, * )
         function potrf!(uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            chksquare(A)
+            checksquare(A)
             chkuplo(uplo)
             lda = max(1,stride(A,2))
             if lda == 0
@@ -2990,7 +2990,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function potrs!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A, B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             nrhs = size(B,2)
             if size(B,1) != n
@@ -3021,7 +3021,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #       INTEGER            PIV( N )
         function pstrf!(uplo::Char, A::StridedMatrix{$elty}, tol::Real)
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             piv  = similar(A, BlasInt, n)
             rank = Array(BlasInt, 1)
@@ -3247,7 +3247,7 @@ for (trtri, trtrs, elty) in
         #      DOUBLE PRECISION   A( LDA, * )
         function trtri!(uplo::Char, diag::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             chkdiag(diag)
             lda = max(1,stride(A, 2))
@@ -3271,7 +3271,7 @@ for (trtri, trtrs, elty) in
             chktrans(trans)
             chkdiag(diag)
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)) but needs $n"))
@@ -3326,7 +3326,7 @@ for (trcon, trevc, trrfs, elty) in
         function trcon!(norm::Char, uplo::Char, diag::Char, A::StridedMatrix{$elty})
             chkstride1(A)
             chkdiag(diag)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             rcond = Array($elty, 1)
             work  = Array($elty, 3n)
@@ -3359,7 +3359,7 @@ for (trcon, trevc, trrfs, elty) in
             if side ∉ ['L','R','B']
                 throw(ArgumentError("side argument must be 'L' (left eigenvectors), 'R' (right eigenvectors), or 'B' (both), got $side"))
             end
-            n, mm = chksquare(T), size(VL, 2)
+            n, mm = checksquare(T), size(VL, 2)
             ldt, ldvl, ldvr = stride(T, 2), stride(VL, 2), stride(VR, 2)
 
             # Check
@@ -3453,7 +3453,7 @@ for (trcon, trevc, trrfs, elty, relty) in
         # COMPLEX*16         A( LDA, * ), WORK( * )
         function trcon!(norm::Char, uplo::Char, diag::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             chkdiag(diag)
             rcond = Array($relty, 1)
@@ -3485,7 +3485,7 @@ for (trcon, trevc, trrfs, elty, relty) in
                         VL::StridedMatrix{$elty} = similar(T),
                         VR::StridedMatrix{$elty} = similar(T))
             # Extract
-            n, mm = chksquare(T), size(VL, 2)
+            n, mm = checksquare(T), size(VL, 2)
             ldt, ldvl, ldvr = stride(T, 2), stride(VL, 2), stride(VR, 2)
 
             # Check
@@ -3822,7 +3822,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function syconv!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -3844,7 +3844,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -3878,7 +3878,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function sytrf!(uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             ipiv  = similar(A, BlasInt, n)
             if n == 0
@@ -3911,7 +3911,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), WORK( * )
 #         function sytri!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
 #             chkstride1(A)
-#             n = chksquare(A)
+#             n = checksquare(A)
 #             chkuplo(uplo)
 #             work  = Array($elty, 1)
 #             lwork = BlasInt(-1)
@@ -3940,7 +3940,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function sytri!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -3964,7 +3964,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         function sytrs!(uplo::Char, A::StridedMatrix{$elty},
                        ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -3995,7 +3995,7 @@ for (sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv_rook!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4029,7 +4029,7 @@ for (sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function sytrf_rook!(uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             ipiv  = similar(A, BlasInt, n)
             if n == 0
@@ -4062,7 +4062,7 @@ for (sysv, sytrf, sytri, sytrs, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function sytri_rook!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -4086,7 +4086,7 @@ for (sysv, sytrf, sytri, sytrs, elty) in
         function sytrs_rook!(uplo::Char, A::StridedMatrix{$elty},
                        ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4119,7 +4119,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
        #        COMPLEX*16         A( LDA, * ), WORK( * )
         function syconv!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -4141,7 +4141,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function hesv!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4175,7 +4175,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function hetrf!(uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             ipiv  = similar(A, BlasInt, n)
             work  = Array($elty, 1)
@@ -4206,7 +4206,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
 #       COMPLEX*16         A( LDA, * ), WORK( * )
 #         function hetri!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
 #             chkstride1(A)
-#             n = chksquare(A)
+#             n = checksquare(A)
 #             chkuplo(uplo)
 #             work  = Array($elty, 1)
 #             lwork = BlasInt(-1)
@@ -4236,7 +4236,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function hetri!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -4259,7 +4259,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         function hetrs!(uplo::Char, A::StridedMatrix{$elty},
                        ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
             end
@@ -4288,7 +4288,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function hesv_rook!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4322,7 +4322,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function hetrf_rook!(uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             ipiv  = similar(A, BlasInt, n)
             work  = Array($elty, 1)
@@ -4353,7 +4353,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function hetri_rook!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -4376,7 +4376,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         function hetrs_rook!(uplo::Char, A::StridedMatrix{$elty},
                              ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
             end
@@ -4406,7 +4406,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4441,7 +4441,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function sytrf!(uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             ipiv = similar(A, BlasInt, n)
             if n == 0
@@ -4475,7 +4475,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
 #       COMPLEX*16         A( LDA, * ), WORK( * )
 #         function sytri!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
 #             chkstride1(A)
-#             n = chksquare(A)
+#             n = checksquare(A)
 #             chkuplo(uplo)
 #             work  = Array($elty, 1)
 #             lwork = BlasInt(-1)
@@ -4504,7 +4504,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function sytri!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -4527,7 +4527,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         function sytrs!(uplo::Char, A::StridedMatrix{$elty},
                        ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4558,7 +4558,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv_rook!(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4593,7 +4593,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function sytrf_rook!(uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             ipiv = similar(A, BlasInt, n)
             if n == 0
@@ -4627,7 +4627,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function sytri_rook!(uplo::Char, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             work = Array($elty, n)
             info = Ref{BlasInt}()
@@ -4650,7 +4650,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         function sytrs_rook!(uplo::Char, A::StridedMatrix{$elty},
                              ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
             chkstride1(A,B)
-            n = chksquare(A)
+            n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
                 throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
@@ -4773,7 +4773,7 @@ for (syev, syevr, sygvd, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), W( * ), WORK( * )
         function syev!(jobz::Char, uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             W     = similar(A, $elty, n)
             work  = Array($elty, 1)
             lwork = BlasInt(-1)
@@ -4806,7 +4806,7 @@ for (syev, syevr, sygvd, elty) in
         function syevr!(jobz::Char, range::Char, uplo::Char, A::StridedMatrix{$elty},
                         vl::AbstractFloat, vu::AbstractFloat, il::Integer, iu::Integer, abstol::AbstractFloat)
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             if range == 'I' && !(1 <= il <= iu <= n)
                 throw(ArgumentError("illegal choice of eigenvalue indices (il = $il, iu = $iu), which must be between 1 and n = $n"))
             end
@@ -4867,7 +4867,7 @@ for (syev, syevr, sygvd, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), W( * ), WORK( * )
         function sygvd!(itype::Integer, jobz::Char, uplo::Char, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A, B)
-            n, m = chksquare(A, B)
+            n, m = checksquare(A, B)
             if n != m
                 throw(DimensionMismatch("Dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
@@ -4917,7 +4917,7 @@ for (syev, syevr, sygvd, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function syev!(jobz::Char, uplo::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             W     = similar(A, $relty, n)
             work  = Array($elty, 1)
             lwork = BlasInt(-1)
@@ -4953,7 +4953,7 @@ for (syev, syevr, sygvd, elty, relty) in
         function syevr!(jobz::Char, range::Char, uplo::Char, A::StridedMatrix{$elty},
                         vl::AbstractFloat, vu::AbstractFloat, il::Integer, iu::Integer, abstol::AbstractFloat)
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             if range == 'I' && !(1 <= il <= iu <= n)
                 throw(ArgumentError("illegal choice of eigenvalue indices (il = $il, iu=$iu), which must be between 1 and n = $n"))
             end
@@ -5019,7 +5019,7 @@ for (syev, syevr, sygvd, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function sygvd!(itype::Integer, jobz::Char, uplo::Char, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A, B)
-            n, m = chksquare(A, B)
+            n, m = checksquare(A, B)
             if n != m
                 throw(DimensionMismatch("Dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
@@ -5245,7 +5245,7 @@ for (gecon, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function gecon!(normtype::Char, A::StridedMatrix{$elty}, anorm::$elty)
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             lda = max(1, stride(A, 2))
             rcond = Array($elty, 1)
             work = Array($elty, 4n)
@@ -5279,7 +5279,7 @@ for (gecon, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), WORK( * )
         function gecon!(normtype::Char, A::StridedMatrix{$elty}, anorm::$relty)
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             lda = max(1, stride(A, 2))
             rcond = Array($relty, 1)
             work = Array($elty, 2n)
@@ -5321,7 +5321,7 @@ for (gehrd, elty) in
         #       DOUBLE PRECISION  A( LDA, * ), TAU( * ), WORK( * )
         function gehrd!(ilo::Integer, ihi::Integer, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             chkfinite(A) # balancing routines don't support NaNs and Infs
             tau = similar(A, $elty, max(0,n - 1))
             work = Array($elty, 1)
@@ -5370,7 +5370,7 @@ for (orghr, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orghr!(ilo::Integer, ihi::Integer, A::StridedMatrix{$elty}, tau::StridedVector{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             if n - length(tau) != 1
                 throw(DimensionMismatch("tau has length $(length(tau)), needs $(n - 1)"))
             end
@@ -5418,7 +5418,7 @@ for (gees, gges, elty) in
         #    $                   WR( * )
         function gees!(jobvs::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             sdim = Array(BlasInt, 1)
             wr = similar(A, $elty, n)
             wi = similar(A, $elty, n)
@@ -5457,7 +5457,7 @@ for (gees, gges, elty) in
         #      $                   VSR( LDVSR, * ), WORK( * )
         function gges!(jobvsl::Char, jobvsr::Char, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A, B)
-            n, m = chksquare(A, B)
+            n, m = checksquare(A, B)
             if n != m
                 throw(DimensionMismatch("Dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
@@ -5511,7 +5511,7 @@ for (gees, gges, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), VS( LDVS, * ), W( * ), WORK( * )
         function gees!(jobvs::Char, A::StridedMatrix{$elty})
             chkstride1(A)
-            n = chksquare(A)
+            n = checksquare(A)
             sort = 'N'
             sdim = BlasInt(0)
             w = similar(A, $elty, n)
@@ -5552,7 +5552,7 @@ for (gees, gges, elty, relty) in
         #      $                   WORK( * )
         function gges!(jobvsl::Char, jobvsr::Char, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A, B)
-            n, m = chksquare(A, B)
+            n, m = checksquare(A, B)
             if n != m
                 throw(DimensionMismatch("Dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
@@ -5628,7 +5628,7 @@ for (trexc, trsen, tgsen, elty) in
         #       DOUBLE PRECISION   Q( LDQ, * ), T( LDT, * ), WORK( * )
         function trexc!(compq::Char, ifst::BlasInt, ilst::BlasInt, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
             chkstride1(T, Q)
-            n = chksquare(T)
+            n = checksquare(T)
             ldt = max(1, stride(T, 2))
             ldq = max(1, stride(Q, 2))
             work = Array($elty, n)
@@ -5660,7 +5660,7 @@ for (trexc, trsen, tgsen, elty) in
         function trsen!(compq::Char, job::Char, select::StridedVector{BlasInt},
                         T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
             chkstride1(T, Q)
-            n = chksquare(T)
+            n = checksquare(T)
             ldt = max(1, stride(T, 2))
             ldq = max(1, stride(Q, 2))
             wr = similar(T, $elty, n)
@@ -5713,7 +5713,7 @@ for (trexc, trsen, tgsen, elty) in
         function tgsen!(select::StridedVector{BlasInt}, S::StridedMatrix{$elty}, T::StridedMatrix{$elty},
                         Q::StridedMatrix{$elty}, Z::StridedMatrix{$elty})
             chkstride1(S, T, Q, Z)
-            n, nt, nq, nz = chksquare(S, T, Q, Z)
+            n, nt, nq, nz = checksquare(S, T, Q, Z)
             if n != nt
                 throw(DimensionMismatch("Dimensions of S, ($n,$n), and T, ($nt,$nt), must match"))
             end
@@ -5778,7 +5778,7 @@ for (trexc, trsen, tgsen, elty) in
         #      DOUBLE PRECISION   Q( LDQ, * ), T( LDT, * ), WORK( * )
         function trexc!(compq::Char, ifst::BlasInt, ilst::BlasInt, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
             chkstride1(T, Q)
-            n = chksquare(T)
+            n = checksquare(T)
             ldt = max(1, stride(T, 2))
             ldq = max(1, stride(Q, 2))
             info = Ref{BlasInt}()
@@ -5808,7 +5808,7 @@ for (trexc, trsen, tgsen, elty) in
         function trsen!(compq::Char, job::Char, select::StridedVector{BlasInt},
                         T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
             chkstride1(T, Q)
-            n = chksquare(T)
+            n = checksquare(T)
             ldt = max(1, stride(T, 2))
             ldq = max(1, stride(Q, 2))
             w = similar(T, $elty, n)
@@ -5856,7 +5856,7 @@ for (trexc, trsen, tgsen, elty) in
         function tgsen!(select::StridedVector{BlasInt}, S::StridedMatrix{$elty}, T::StridedMatrix{$elty},
                         Q::StridedMatrix{$elty}, Z::StridedMatrix{$elty})
             chkstride1(S, T, Q, Z)
-            n, nt, nq, nz = chksquare(S, T, Q, Z)
+            n, nt, nq, nz = checksquare(S, T, Q, Z)
             if n != nt
                 throw(DimensionMismatch("Dimensions of S, ($n,$n), and T, ($nt,$nt), must match"))
             end
@@ -5949,7 +5949,7 @@ for (fn, elty, relty) in ((:dtrsyl_, :Float64, :Float64),
         function trsyl!(transa::Char, transb::Char, A::StridedMatrix{$elty},
                         B::StridedMatrix{$elty}, C::StridedMatrix{$elty}, isgn::Int=1)
             chkstride1(A, B, C)
-            m, n = chksquare(A, B)
+            m, n = checksquare(A, B)
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
             m1, n1 = size(C)

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -152,7 +152,7 @@ Ac_ldiv_Bc{T<:BlasComplex,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) =
 Ac_ldiv_Bc(A::LU, B::StridedVecOrMat) = Ac_ldiv_B(A, ctranspose(B))
 
 function det{T,S}(A::LU{T,S})
-    n = chksquare(A)
+    n = checksquare(A)
     A.info > 0 && return zero(typeof(A.factors[1]))
     P = one(T)
     c = 0
@@ -167,7 +167,7 @@ function det{T,S}(A::LU{T,S})
 end
 
 function logabsdet{T,S}(A::LU{T,S})  # return log(abs(det)) and sign(det)
-    n = chksquare(A)
+    n = checksquare(A)
     c = 0
     P = one(real(T))
     abs_det = zero(real(T))
@@ -194,7 +194,7 @@ end
 _mod2pi(x::BigFloat) = mod(x, big(2)*π) # we don't want to export this, but we use it below
 _mod2pi(x) = mod2pi(x)
 function logdet{T<:Complex,S}(A::LU{T,S})
-    n = chksquare(A)
+    n = checksquare(A)
     s = zero(T)
     c = 0
     @inbounds for i = 1:n

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -201,7 +201,7 @@ Ac_mul_Bt!(C::StridedMatrix, A::StridedVecOrMat, B::StridedVecOrMat) = generic_m
 # Supporting functions for matrix multiplication
 
 function copytri!(A::StridedMatrix, uplo::Char, conjugate::Bool=false)
-    n = chksquare(A)
+    n = checksquare(A)
     if uplo == 'U'
         for i = 1:(n-1), j = (i+1):n
             A[j,i] = conjugate ? conj(A[i,j]) : A[i,j]
@@ -235,7 +235,7 @@ function gemv!{T<:BlasFloat}(y::StridedVector{T}, tA::Char, A::StridedVecOrMat{T
 end
 
 function syrk_wrapper!{T<:BlasFloat}(C::StridedMatrix{T}, tA::Char, A::StridedVecOrMat{T})
-    nC = chksquare(C)
+    nC = checksquare(C)
     if tA == 'T'
         (nA, mA) = size(A,1), size(A,2)
         tAt = 'N'
@@ -263,7 +263,7 @@ function syrk_wrapper!{T<:BlasFloat}(C::StridedMatrix{T}, tA::Char, A::StridedVe
 end
 
 function herk_wrapper!{T<:BlasReal}(C::Union{StridedMatrix{T}, StridedMatrix{Complex{T}}}, tA::Char, A::Union{StridedVecOrMat{T}, StridedVecOrMat{Complex{T}}})
-    nC = chksquare(C)
+    nC = checksquare(C)
     if tA == 'C'
         (nA, mA) = size(A,1), size(A,2)
         tAt = 'N'

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -5,13 +5,13 @@ immutable Symmetric{T,S<:AbstractMatrix} <: AbstractMatrix{T}
     data::S
     uplo::Char
 end
-Symmetric(A::AbstractMatrix, uplo::Symbol=:U) = (chksquare(A);Symmetric{eltype(A),typeof(A)}(A, char_uplo(uplo)))
+Symmetric(A::AbstractMatrix, uplo::Symbol=:U) = (checksquare(A);Symmetric{eltype(A),typeof(A)}(A, char_uplo(uplo)))
 immutable Hermitian{T,S<:AbstractMatrix} <: AbstractMatrix{T}
     data::S
     uplo::Char
 end
 function Hermitian(A::AbstractMatrix, uplo::Symbol=:U)
-    n = chksquare(A)
+    n = checksquare(A)
     for i=1:n
         isreal(A[i, i]) || throw(ArgumentError(
             "Cannot construct Hermitian from matrix with nonreal diagonals"))
@@ -190,7 +190,7 @@ function expm(A::Symmetric)
     return Symmetric((F.vectors * Diagonal(exp(F.values))) * F.vectors')
 end
 function expm{T}(A::Hermitian{T})
-    n = chksquare(A)
+    n = checksquare(A)
     F = eigfact(A)
     retmat = (F.vectors * Diagonal(exp(F.values))) * F.vectors'
     if T <: Real
@@ -218,7 +218,7 @@ for (funm, func) in ([:logm,:log], [:sqrtm,:sqrt])
         end
 
         function ($funm){T}(A::Hermitian{T})
-            n = chksquare(A)
+            n = checksquare(A)
             F = eigfact(A)
             if isposdef(F)
                 retmat = (F.vectors * Diagonal(($func)(F.values))) * F.vectors'

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -13,7 +13,7 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
         end
         $t(A::$t) = A
         function $t(A::AbstractMatrix)
-            Base.LinAlg.chksquare(A)
+            Base.LinAlg.checksquare(A)
             return $t{eltype(A), typeof(A)}(A)
         end
 
@@ -319,7 +319,7 @@ function copy!{T<:Union{LowerTriangular, UnitLowerTriangular}}(A::T, B::T)
 end
 
 function scale!{T<:Union{UpperTriangular, UnitUpperTriangular}}(A::UpperTriangular, B::T, c::Number)
-    n = chksquare(B)
+    n = checksquare(B)
     for j = 1:n
         if isa(B, UnitUpperTriangular)
             @inbounds A[j,j] = c
@@ -331,7 +331,7 @@ function scale!{T<:Union{UpperTriangular, UnitUpperTriangular}}(A::UpperTriangul
     return A
 end
 function scale!{T<:Union{LowerTriangular, UnitLowerTriangular}}(A::LowerTriangular, B::T, c::Number)
-    n = chksquare(B)
+    n = checksquare(B)
     for j = 1:n
         if isa(B, UnitLowerTriangular)
             @inbounds A[j,j] = c
@@ -410,7 +410,7 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
 
         # Condition numbers
         function cond{T<:BlasFloat,S}(A::$t{T,S}, p::Real=2)
-            chksquare(A)
+            checksquare(A)
             if p == 1
                 return inv(LAPACK.trcon!('O', $uploc, $isunitc, A.data))
             elseif p == Inf
@@ -1231,7 +1231,7 @@ end
 logm(A::LowerTriangular) = logm(A.').'
 
 function sqrtm{T}(A::UpperTriangular{T})
-    n = chksquare(A)
+    n = checksquare(A)
     realmatrix = false
     if isreal(A)
         realmatrix = true
@@ -1261,7 +1261,7 @@ function sqrtm{T}(A::UpperTriangular{T})
     return UpperTriangular(R)
 end
 function sqrtm{T}(A::UnitUpperTriangular{T})
-    n = chksquare(A)
+    n = checksquare(A)
     TT = typeof(sqrt(zero(T)))
     R = zeros(TT, n, n)
     for j = 1:n

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -89,7 +89,7 @@ function (-)(J::UniformScaling, UL::Union{LowerTriangular,UnitLowerTriangular})
 end
 
 function (+){TA,TJ}(A::AbstractMatrix{TA}, J::UniformScaling{TJ})
-    n = chksquare(A)
+    n = checksquare(A)
     B = similar(A, promote_type(TA,TJ))
     copy!(B,A)
     @inbounds for i = 1:n
@@ -99,7 +99,7 @@ function (+){TA,TJ}(A::AbstractMatrix{TA}, J::UniformScaling{TJ})
 end
 
 function (-){TA,TJ<:Number}(A::AbstractMatrix{TA}, J::UniformScaling{TJ})
-    n = chksquare(A)
+    n = checksquare(A)
     B = similar(A, promote_type(TA,TJ))
     copy!(B, A)
     @inbounds for i = 1:n
@@ -108,7 +108,7 @@ function (-){TA,TJ<:Number}(A::AbstractMatrix{TA}, J::UniformScaling{TJ})
     B
 end
 function (-){TA,TJ<:Number}(J::UniformScaling{TJ}, A::AbstractMatrix{TA})
-    n = chksquare(A)
+    n = checksquare(A)
     B = convert(AbstractMatrix{promote_type(TJ,TA)}, -A)
     @inbounds for j = 1:n
         B[j,j] += J.λ

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-import Base.LinAlg: chksquare
+import Base.LinAlg: checksquare
 
 ## Functions to switch to 0-based indexing to call external sparse solvers
 
@@ -171,7 +171,7 @@ end
 function fwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
 # forward substitution for CSC matrices
     nrowB, ncolB  = size(B, 1), size(B, 2)
-    ncol = LinAlg.chksquare(A)
+    ncol = LinAlg.checksquare(A)
     if nrowB != ncol
         throw(DimensionMismatch("A is $(ncol) columns and B has $(nrowB) rows"))
     end
@@ -216,7 +216,7 @@ end
 function bwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
 # backward substitution for CSC matrices
     nrowB, ncolB = size(B, 1), size(B, 2)
-    ncol = LinAlg.chksquare(A)
+    ncol = LinAlg.checksquare(A)
     if nrowB != ncol
         throw(DimensionMismatch("A is $(ncol) columns and B has $(nrowB) rows"))
     end
@@ -523,7 +523,7 @@ end
 function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A))))
     maxiter = 5
     # Check the input
-    n = chksquare(A)
+    n = checksquare(A)
     F = factorize(A)
     if t <= 0
         throw(ArgumentError("number of blocks must be a positive integer"))

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -134,6 +134,12 @@ Basic functions
 
    The inverse of ``ind2sub``\ , returns the linear index corresponding to the provided subscripts.
 
+.. function:: LinAlg.checksquare(A)
+
+   .. Docstring generated from Julia source
+
+   Check that a matrix is square, then return its common dimension. For multiple arguments, return a vector.
+
 Constructors
 ------------
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -469,6 +469,13 @@ function test_13315(::Type{TestAbstractArray})
     @test [U;[U;]] == [UInt(1), UInt(2), UInt(1), UInt(2)]
 end
 
+# checksquare
+function test_checksquare()
+    @test LinAlg.checksquare(zeros(2,2)) == 2
+    @test LinAlg.checksquare(zeros(2,2),zeros(3,3)) == [2,3]
+    @test_throws DimensionMismatch LinAlg.checksquare(zeros(2,3))
+end
+
 #----- run tests -------------------------------------------------------------#
 
 for T in (T24Linear, TSlow), shape in ((24,), (2, 12), (2,3,4), (1,2,3,4), (4,3,2,1))
@@ -489,6 +496,7 @@ test_map_promote(TestAbstractArray)
 test_UInt_indexing(TestAbstractArray)
 test_vcat_depwarn(TestAbstractArray)
 test_13315(TestAbstractArray)
+test_checksquare()
 
 A = TSlowNIndexes(rand(2,2))
 @test_throws ErrorException A[1]


### PR DESCRIPTION
Closes JuliaLang/LinearAlgebra.jl#292, by
- renaming `chksquare` to `checksquare`
- writing documentation for `checksquare` and putting it in the stdlib docs (without exportingit from `LinAlg`)
- adding some simple tests for `checksquare`
