### PR TITLE
Updating parallell computing text

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -134,13 +134,9 @@ type the following into the Julia prompt::
      0.153756  0.368514
      1.15119   0.918912
 
-    julia> @spawn rand2(2,2)
-    RemoteRef(1,1,1)
-
-    julia> @spawn rand2(2,2)
-    RemoteRef(2,1,2)
-
-    julia> exception on 2: in anonymous: rand2 not defined
+    julia> fetch(@spawn rand2(2,2))
+    ERROR: On worker 2:
+    function rand2 not defined on process 2
 
 Process 1 knew about the function ``rand2``, but process 2 did not.
 


### PR DESCRIPTION
The previous version didn't behave as documented on my machine.

If I copy paste the commands from the documentation, I never get the error that is quoted. It just happily continues doing nothing untill I try to actually fetch the answer.

If this is a version issue: here is my versioninfo:
Julia Version 0.4.2
Commit bb73f34 (2015-12-06 21:47 UTC)
Platform Info:
  System: Darwin (x86_64-apple-darwin13.4.0)
  CPU: Intel(R) Core(TM) i7-2675QM CPU @ 2.20GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.3
