### PR TITLE
Update Mac build directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ latest version.
    b. To delete existing binaries of `julia` and all its dependencies,
       delete the `./usr` directory _in the source tree_.
 
-3. If you've upgraded OS X recently and you get an error that looks like
-    ```ld: library not found for -lcrt1.10.6.o```, run `xcode-select --install`.
+3. If you've updated OS X recently, be sure to run `xcode-select --install` to update the command line tools.
+   Otherwise, you could run into errors for missing headers and libraries, such as
+   ```ld: library not found for -lcrt1.10.6.o```.
 
 4. If you've moved the source directory, you might get errors such as
     ```CMake Error: The current CMakeCache.txt directory ... is different than the directory ... where     CMakeCache.txt was created.```, in which case you may delete the offending dependency under `deps`
@@ -219,8 +220,12 @@ Illegal Instruction error | Check if your CPU supports AVX while your OS does no
 
 ### OS X
 
-It is essential to use a 64-bit gfortran to compile Julia dependencies. The gfortran-4.7 (and newer) compilers in Brew, Fink, and MacPorts work for building Julia.
-Clang is now used by default to build Julia on OS X (10.7 and above). It is recommended that you upgrade to the latest version of Xcode (at least 4.3.3.). You need to have the Xcode command line utilities installed (and updated): run `xcode-select --install` in the terminal (in Xcode prior to v5.0, you can alternatively go to Preferences -> Downloads and select the Command Line Utilities). This will ensure that clang v3.1 is installed, which is the minimum version of `clang` required to build Julia. On OS X 10.6, the Julia build will automatically use `gcc`.
+You need to have the current Xcode command line utilities installed: run `xcode-select --install` in the terminal.
+You will need to rerun this terminal command after each OS X update, otherwise you may run into errors involving missing libraries or headers.
+You will also need a 64-bit gfortran to compile Julia dependencies. The gfortran-4.7 (and newer) compilers in Brew, Fink, and MacPorts work for building Julia.
+
+Clang is now used by default to build Julia on OS X 10.7 and above. On OS X 10.6, the Julia build will automatically use `gcc`.
+On current systems, we recommend that you install the command line tools as described above. Older systems do not have a separate command line tools package from Apple, and will require a full Xcode install.  On these, you will need at least Xcode 4.3.3.  In Xcode prior to v5.0, you can alternatively go to Preferences -> Downloads and select the Command Line Utilities. These steps will ensure that clang v3.1 is installed, which is the minimum version of `clang` required to build Julia.
 
 If you have set `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` in your `.bashrc` or equivalent, Julia may be unable to find various libraries that come bundled with it. These environment variables need to be unset for Julia to work.
 


### PR DESCRIPTION
Clarifies that the correct (and only?) way to update the command line tools is with an `xcode-select --install`.  Wording changed so that this advice is not linked to a specific error, which made me look elsewhere.

I believe that the wording about "Older systems do not have a separate command line tools package..." is correct, but I'm basing this off of my somewhat fuzzy recollection.

ref: #14593
