### PR TITLE
Remove an unpaired " and a needless \n

### DIFF
--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -112,7 +112,7 @@ those available for the ``perl`` and ``ruby`` programs::
 
      -J, --sysimage <file>     Start up with the given system image file
      --precompiled={yes|no}    Use precompiled code from system image if available
-     --compilecache={yes|no}   Enable/disable incremental precompilation of modules\n"
+     --compilecache={yes|no}   Enable/disable incremental precompilation of modules
      -H, --home <dir>          Set location of julia executable
      --startup-file={yes|no}   Load ~/.juliarc.jl
      -f, --no-startup          Don't load ~/.juliarc (deprecated, use --startup-file=no)


### PR DESCRIPTION
The \n" makes the color of [document web page](http://docs.julialang.org/en/latest/manual/getting-started/) red. It will be better for reading after removing it.
