### PR TITLE
matmul: don't assume the existence of type-conversions

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -455,12 +455,15 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
         throw(DimensionMismatch("result C has dimensions $(size(C)), needs ($mA, $nB)"))
     end
 
+    tile_size = 0
+    if isbits(R) && isbits(T) && isbits(S)
+        tile_size = floor(Int,sqrt(tilebufsize/max(sizeof(R),sizeof(S),sizeof(T))))
+    end
     @inbounds begin
-    if isbits(R)
-        tile_size = floor(Int,sqrt(tilebufsize/sizeof(R)))
+    if tile_size > 0
         sz = (tile_size, tile_size)
-        Atile = pointer_to_array(convert(Ptr{R}, pointer(Abuf)), sz)
-        Btile = pointer_to_array(convert(Ptr{R}, pointer(Bbuf)), sz)
+        Atile = pointer_to_array(convert(Ptr{T}, pointer(Abuf)), sz)
+        Btile = pointer_to_array(convert(Ptr{S}, pointer(Bbuf)), sz)
 
         z = zero(R)
 

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -38,8 +38,9 @@ function scale!(C::AbstractMatrix, b::AbstractVector, A::AbstractMatrix)
     end
     C
 end
-scale(A::Matrix, b::Vector) = scale!(similar(A, promote_type(eltype(A),eltype(b))), A, b)
-scale(b::Vector, A::Matrix) = scale!(similar(b, promote_type(eltype(A),eltype(b)), size(A)), b, A)
+
+scale(A::AbstractMatrix, b::AbstractVector) = scale!(similar(A, promote_type(eltype(A),eltype(b))), A, b)
+scale(b::AbstractVector, A::AbstractMatrix) = scale!(similar(b, promote_type(eltype(b),eltype(A)), size(A)), b, A)
 
 # Dot products
 

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -77,6 +77,8 @@ a = reshape([1.:6;], (2,3))
 @test scale(a, [1; 2; 3]) == a.*[1 2 3]
 @test scale([1; 2], a) == a.*[1; 2]
 @test scale(eye(Int, 2), 0.5) == 0.5*eye(2)
+@test scale([1; 2], sub(a, :, :)) == a.*[1; 2]
+@test scale(sub([1; 2], :), a) == a.*[1; 2]
 @test_throws DimensionMismatch scale(a, ones(2))
 @test_throws DimensionMismatch scale(ones(3), a)
 

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -189,3 +189,23 @@ for elty in [Float32,Float64,Complex128,Complex64]
     A = rand(elty,3,3)
     @test Base.LinAlg.matmul3x3('T','N',A,eye(elty,3)) == A.'
 end
+
+# Number types that lack conversion to the destination type (#14293)
+immutable RootInt
+    i::Int
+end
+import Base: *
+(*)(x::RootInt, y::RootInt) = x.i*y.i
+
+a = [RootInt(3)]
+C = [0]
+A_mul_Bt!(C, a, a)
+@test C[1] == 9
+a = [RootInt(2),RootInt(10)]
+C = Array(Int, 2, 2)
+A_mul_Bt!(C, a, a)
+@test C == [4 20; 20 100]
+A = [RootInt(3) RootInt(5)]
+C = Array(Int, 1)
+A_mul_B!(C, A, a)
+@test C == [56]


### PR DESCRIPTION
(cherry picked from commit 709c867291ef0b4b6637cbad1c4ec9093bbed99d)

This is a backport of #14293 that doesn't rely on #13803. It loses the ability to do `A*B`, but it works with `A_mul_B!(C, A, B)`. CC @tkelman, note this is against your tk/backports-0.4.3 branch.

In retrospect, in the tests I realize I should have (for mathematical obviousness) named `RootInt` something like `PureImaginary`, as a more familiar example of a type of number where `!isa(::T * ::T, ::T)` and for which the conversion to `T` cannot be defined.
