### PR TITLE
fix MethodError for connect(addr::Base.InetAddr{T<:Base.IPAddr})

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -656,6 +656,8 @@ function connect!(sock::TCPSocket, host::IPv6, port::Integer)
     sock.status = StatusConnecting
 end
 
+connect!(sock::TCPSocket, addr::InetAddr) = connect!(sock, addr.host, addr.port)
+
 # Default Host to localhost
 connect(sock::TCPSocket, port::Integer) = connect(sock,IPv4(127,0,0,1),port)
 connect(port::Integer) = connect(IPv4(127,0,0,1),port)

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -268,3 +268,34 @@ let
     end
     [close(s) for s in [a, b, c]]
 end
+
+
+# test the method matching connect!(::TCPSocket, ::Base.InetAddr{T<:Base.IPAddr})
+let
+  addr = Base.InetAddr(ip"127.0.0.1", 4444)
+
+  function test_connect(addr::Base.InetAddr)
+    srv = listen(addr)
+
+    @async try c = accept(srv); close(c) catch end
+    yield()
+
+    t0 = TCPSocket()
+    t = t0
+    @assert is(t,t0)
+
+    try
+      t = connect(addr)
+    finally
+      close(srv)
+    end
+
+    test = !is(t,t0)
+    close(t)
+
+    return test
+  end
+
+  @test test_connect(addr)
+end
+


### PR DESCRIPTION
There is public method for the connect() function with the following signature:
`connect(addr::Base.InetAddr{T<:Base.IPAddr})`
It throws

```
MethodError: `connect!` has no method matching connect!(::TCPSocket, ::Base.InetAddr{...})
```

Here is the test example:

```
using Base.Test

# test method matching connect!(::TCPSocket, ::Base.InetAddr{T<:Base.IPAddr})
@test let
  addr = Base.InetAddr(ip"127.0.0.1", 4444)
  srv = listen(addr)
  @async try c = accept(srv); close(c) catch end
  local t = TCPSocket(), t0 = t
  try
    t = connect(addr)
  finally
    close(srv)
  end
  !is(t,t0)
end
```

PR fixes the issue. I've not included the above test since after the missing method has been added the test actually tests nothing but only the method existence.
