### PR TITLE
Safer serialization of ::SubArray{T,N,A<:Array}

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -3,6 +3,7 @@
 module Serializer
 
 import Base: GMP, Bottom, svec, unsafe_convert, uncompressed_ast
+using Base: ViewIndex, dimsize
 
 export serialize, deserialize
 
@@ -191,14 +192,26 @@ function serialize(s::SerializationState, a::Array)
 end
 
 function serialize{T,N,A<:Array}(s::SerializationState, a::SubArray{T,N,A})
-    if !isbits(T) || stride(a,1)!=1
-        return serialize(s, copy(a))
-    end
-    writetag(s.io, ARRAY_TAG)
-    serialize(s, T)
-    serialize(s, size(a))
-    serialize_array_data(s.io, a)
+    b = trimmedsubarray(a)
+    serialize_any(s, b)
 end
+
+function trimmedsubarray{T,N,A<:Array}(V::SubArray{T,N,A})
+    dest = Array(eltype(V), trimmedsize(V))
+    copy!(dest, V)
+    _trimmedsubarray(dest, V, (), V.indexes...)
+end
+
+trimmedsize(V) = _trimmedsize(V, (), V.indexes...)
+_trimmedsize(V, trimsz) = trimsz
+_trimmedsize(V, trimsz, index, indexes...) = _trimmedsize(V, (trimsz..., dimsize(V.parent, length(trimsz)+1, index)), indexes...)
+
+_trimmedsubarray{T,N,P,I,LD}(A, V::SubArray{T,N,P,I,LD}, newindexes) = SubArray{T,N,P,I,LD}(A, newindexes, size(V), 1, 1)
+_trimmedsubarray(A, V, newindexes, index::ViewIndex, indexes...) = _trimmedsubarray(A, V, (newindexes..., trimmedindex(V.parent, length(newindexes)+1, index)), indexes...)
+
+trimmedindex(P, d, i::Real) = oftype(i, 1)
+trimmedindex(P, d, i::Colon) = i
+trimmedindex(P, d, i::AbstractVector) = oftype(i, 1:length(i))
 
 function serialize{T<:AbstractString}(s::SerializationState, ss::SubString{T})
     # avoid saving a copy of the parent string, keeping the type of ss


### PR DESCRIPTION
When dealing with SubArrays-of-Arrays, we currently make serialization more efficient by "trimming" any unused data. However, we were not careful to reconstruct the exact type, and when the type was listed as a type-parameter in another type this can lead to problems.

Demo of failure on current master:

``` jl
module ArrayWrappers

immutable ArrayWrapper{T,N,A<:AbstractArray} <: AbstractArray{T,N}
    data::A
end
Base.size(A::ArrayWrapper) = size(A.data)
Base.size(A::ArrayWrapper, d) = size(A.data, d)
Base.getindex(A::ArrayWrapper, i::Real...) = getindex(A.data, i...)

end

let A = rand(3,4)
    for B in (sub(A, :, 2:4), slice(A, 2, 1:3))
        C = ArrayWrappers.ArrayWrapper{Float64,2,typeof(B)}(B)
        io = IOBuffer()
        serialize(io, C)
        seek(io, 0)
        Cd = deserialize(io)
        @show size(Cd) size(C)
    end
end
```

Results:

``` jl
julia> include("/tmp/sertest.jl")
size(Cd) = (561160,3)    # oh crap
size(C) = (3,3)
size(Cd) = (3,)
size(C) = (3,)
```

This PR reconstructs the type exactly, making the trimming strategy safe. (And look ma, no generated functions!)

Note this only affects SubArrays-of-Arrays; as before, we still serialize the entire parent array for any other kind of SubArray.
