### PR TITLE
fix MethodError for connect(addr::Base.InetAddr{T<:Base.IPAddr})

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -654,6 +654,8 @@ function connect!(sock::TCPSocket, host::IPv6, port::Integer)
     sock.status = StatusConnecting
 end
 
+connect!(sock::TCPSocket, addr::InetAddr) = connect!(sock, addr.host, addr.port)
+
 # Default Host to localhost
 connect(sock::TCPSocket, port::Integer) = connect(sock,IPv4(127,0,0,1),port)
 connect(port::Integer) = connect(IPv4(127,0,0,1),port)

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -289,3 +289,33 @@ let P = Pipe()
     @test !isopen(P)
     @test eof(P)
 end
+
+# test the method matching connect!(::TCPSocket, ::Base.InetAddr{T<:Base.IPAddr})
+let
+    addr = Base.InetAddr(ip"127.0.0.1", 4444)
+
+    function test_connect(addr::Base.InetAddr)
+        srv = listen(addr)
+
+        @async try c = accept(srv); close(c) catch end
+        yield()
+
+        t0 = TCPSocket()
+        t = t0
+        @assert is(t,t0)
+
+        try
+            t = connect(addr)
+        finally
+           close(srv)
+        end
+
+        test = !is(t,t0)
+        close(t)
+
+        return test
+    end
+
+    @test test_connect(addr)
+end
+


### PR DESCRIPTION
There is public method for the connect() function with the following signature:
`connect(addr::Base.InetAddr{T<:Base.IPAddr})`
It throws `MethodError:``connect!``has no method matching connect!(::TCPSocket, ::Base.InetAddr{...})`
Here is the test example:

```
using Base.Test

# test the method matching connect!(::TCPSocket, ::Base.InetAddr{T<:Base.IPAddr})
let
    addr = Base.InetAddr(ip"127.0.0.1", 4444)

    function test_connect(addr::Base.InetAddr)
        srv = listen(addr)

        @async try c = accept(srv); close(c) catch end
        yield()

        t0 = TCPSocket()
        t = t0
        @assert is(t,t0)

        try
            t = connect(addr)
        finally
           close(srv)
        end

        test = !is(t,t0)
        close(t)

        return test
    end

    @test test_connect(addr)
end
```

The PR fixes the issue.
