### PR TITLE
make 'read!(::Base.LibuvStream, ::Array{UInt8, 1})' indicate the number of bytes actually received on EOFError

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -931,7 +931,7 @@ function read!(s::LibuvStream, a::Array{UInt8, 1})
         finally
             s.buffer = sbuf
             if !isempty(s.readnotify.waitq)
-                start_reading(x) # resume reading iff there are currently other read clients of the stream
+                start_reading(s) # resume reading iff there are currently other read clients of the stream
             end
         end
     end


### PR DESCRIPTION
... and perhaps not lose data on UVError.
Before doing the changes I want to ask - what is the purpose of employing an additional reference to the LibuvStream internal buffer in the following excerpts?

```
function read(this::LibuvStream, ::Type{UInt8})
    wait_readnb(this, 1)
    buf = this.buffer
    @assert buf.seekable == false
    read(buf, UInt8)
end

function readavailable(this::LibuvStream)
    wait_readnb(this, 1)
    buf = this.buffer
    @assert buf.seekable == false
    takebuf_array(buf)
end

function readuntil(this::LibuvStream, c::UInt8)
    wait_readbyte(this, c)
    buf = this.buffer
    @assert buf.seekable == false
    readuntil(buf, c)
end
```

Why are the functions not like just:

```
function read(this::LibuvStream, ::Type{UInt8})
    wait_readnb(this, 1)
    read(this.buffer, UInt8)
end

function readavailable(this::LibuvStream)
    wait_readnb(this, 1)
    takebuf_array(this.buffer)
end

function readuntil(this::LibuvStream, c::UInt8)
    wait_readbyte(this, c)
    readuntil(this.buffer, c)
end
```

I want to change `read!(::Base.LibuvStream, ::Array{UInt8, 1})` so that on exceptions it resizes its array argument to be able somehow indicate the number of bytes actually received.
