### PR TITLE
fix --compile=all for jb/functions

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -631,8 +631,8 @@ let stagedcache=Dict{Any,Any}()
     function func_for_method(m::Method, tt, env)
         if !m.isstaged
             return m.func
-        elseif haskey(stagedcache,(m,tt,env))
-            return stagedcache[(m,tt,env)]
+        elseif haskey(stagedcache, (m, tt))
+            return stagedcache[(m, tt)]
         else
             if !isleaftype(tt)
                 # don't call staged functions on abstract types.
@@ -640,8 +640,8 @@ let stagedcache=Dict{Any,Any}()
                 # we can't guarantee that their type behavior is monotonic.
                 return NF
             end
-            f = ccall(:jl_instantiate_staged,Any,(Any,Any,Any),m,tt,env)
-            stagedcache[(m,tt,env)] = f
+            f = ccall(:jl_instantiate_staged, Any, (Any, Any, Any), m.func, tt, env)
+            stagedcache[(m, tt)] = f
             return f
         end
     end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -54,7 +54,7 @@ inference_stack = EmptyCallStack()
 function is_static_parameter(sv::StaticVarInfo, s::Symbol)
     sp = sv.sp
     for i=1:2:length(sp)
-        if is(sp[i].name,s)
+        if is(sp[i],s)
             return true
         end
     end
@@ -85,8 +85,8 @@ _iisconst(x::Expr) = false
 _iisconst(x::ANY) = true
 
 _ieval(x::ANY) =
-    ccall(:jl_interpret_toplevel_expr_in, Any, (Any, Any, Ptr{Void}, Csize_t),
-          (inference_stack::CallStack).mod, x, C_NULL, 0)
+    ccall(:jl_interpret_toplevel_expr_in, Any, (Any, Any, Any, Any),
+          (inference_stack::CallStack).mod, x, svec(), svec())
 _iisdefined(x::ANY) = isdefined((inference_stack::CallStack).mod, x)
 
 function _topmod()
@@ -428,7 +428,7 @@ const apply_type_tfunc = function (A::ANY, args...)
                     s = A[i]
                     found = false
                     for j=1:2:length(sp)
-                        if is(sp[j].name,s)
+                        if is(sp[j],s)
                             # static parameter
                             val = sp[j+1]
                             if valid_tparam(val)
@@ -1151,7 +1151,7 @@ function abstract_eval_symbol(s::Symbol, vtypes::ObjectIdDict, sv::StaticVarInfo
     if is(t,NF)
         sp = sv.sp
         for i=1:2:length(sp)
-            if is(sp[i].name,s)
+            if is(sp[i],s)
                 # static parameter
                 val = sp[i+1]
                 if isa(val,TypeVar)
@@ -1365,11 +1365,11 @@ f_argnames(ast) =
 
 is_rest_arg(arg::ANY) = (ccall(:jl_is_rest_arg,Int32,(Any,), arg) != 0)
 
-function typeinf_ext(linfo, atypes::ANY, sparams::ANY, def)
+function typeinf_ext(linfo, atypes::ANY, def)
     global inference_stack
     last = inference_stack
     inference_stack = EmptyCallStack()
-    result = typeinf(linfo, atypes, sparams, def, true, true)
+    result = typeinf(linfo, atypes, svec(), def, true, true)
     inference_stack = last
     return result
 end
@@ -1547,8 +1547,7 @@ function typeinf_uncached(linfo::LambdaStaticData, atypes::ANY, sparams::SimpleV
     #if dbg print("typeinf ", linfo.name, " ", atypes, "\n") end
 
     if cop
-        sparams = svec(sparams..., linfo.sparams...)
-        ast = ccall(:jl_prepare_ast, Any, (Any,Any), linfo, sparams)::Expr
+        ast = ccall(:jl_prepare_ast, Any, (Any,), linfo)::Expr
     else
         ast = linfo.ast
     end
@@ -1633,7 +1632,24 @@ function typeinf_uncached(linfo::LambdaStaticData, atypes::ANY, sparams::SimpleV
     gensym_init = Any[ NF for i = 1:length(gensym_uses) ]
     gensym_types = copy(gensym_init)
 
-    sv = StaticVarInfo(sparams, vars, gensym_types, vinflist, length(labels), ObjectIdDict())
+    sp = Any[]
+    if length(linfo.sparam_vals) > 0
+        for i = 1:length(linfo.sparam_syms)
+            push!(sp, linfo.sparam_syms[i])
+            push!(sp, linfo.sparam_vals[i])
+        end
+    else
+        for i = 1:2:length(sparams)
+            push!(sp, sparams[i].name)
+            push!(sp, sparams[i+1])
+        end
+        for i = 1:length(linfo.sparam_syms)
+            sym = linfo.sparam_syms[i]
+            push!(sp, sym)
+            push!(sp, TypeVar(sym, Any, true))
+        end
+    end
+    sv = StaticVarInfo(svec(sp...), vars, gensym_types, vinflist, length(labels), ObjectIdDict())
     frame.sv = sv
 
     recpts = IntSet()  # statements that depend recursively on our value
@@ -2218,7 +2234,6 @@ end
 function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enclosing_ast::Expr)
     local linfo,
         metharg::Type,
-        methsp::SimpleVector,
         atypes = atype.parameters,
         argexprs = copy(e.args),
         incompletematch = false
@@ -2259,15 +2274,15 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enc
     end
     meth = meth[1]::SimpleVector
     metharg = meth[1]
+    methsp = meth[2]
     linfo = try
-        func_for_method(meth[3],metharg,meth[2])
+        func_for_method(meth[3],metharg,methsp)
     catch
         NF
     end
     if linfo === NF
         return NF
     end
-    methsp = meth[2]
     methfunc = meth[3].func
     methsig = meth[3].sig
     if !(atype <: metharg)
@@ -2280,7 +2295,15 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enc
     end
     linfo = linfo::LambdaStaticData
 
-    sp = svec(methsp..., linfo.sparams...)
+    sp = Any[]
+    for i = 1:length(linfo.sparam_vals)
+        push!(sp, linfo.sparam_syms[i])
+        push!(sp, linfo.sparam_vals[i])
+    end
+    for i = 1:2:length(methsp)
+        push!(sp, methsp[i].name)
+        push!(sp, methsp[i+1])
+    end
 
     ## This code tries to limit the argument list length only when it is
     ## growing due to recursion.
@@ -2377,7 +2400,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enc
     body.args = filter(x->!(isa(x,Expr) && x.head === :meta && isempty(x.args)),
                        body.args)
 
-    spnames = Any[ sp[i].name for i=1:2:length(sp) ]
+    spnames = Any[ sp[i] for i=1:2:length(sp) ]
     enc_vinflist = enclosing_ast.args[2][1]::Array{Any,1}
     enc_locllist = ast_localvars(enclosing_ast)
     locllist = ast_localvars(ast)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2295,14 +2295,25 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enc
     end
     linfo = linfo::LambdaStaticData
 
-    sp = Any[]
-    for i = 1:length(linfo.sparam_vals)
-        push!(sp, linfo.sparam_syms[i])
-        push!(sp, linfo.sparam_vals[i])
+    spnames = Any[s for s in linfo.sparam_syms]
+    if length(linfo.sparam_vals) > 0
+        spvals = Any[x for x in linfo.sparam_vals]
+    else
+        spvals = Any[]
+        for i = 1:length(spnames)
+            methsp[2 * i - 1].name === spnames[i] || error("sp env in the wrong order")
+            si = methsp[2 * i]
+            if isa(si, TypeVar)
+                return NF
+            end
+            push!(spvals, si)
+        end
     end
-    for i = 1:2:length(methsp)
-        push!(sp, methsp[i].name)
-        push!(sp, methsp[i+1])
+    for i=1:length(spvals)
+        si = spvals[i]
+        if isa(si,Symbol) || isa(si,GenSym)
+            spvals[i] = QuoteNode(si)
+        end
     end
 
     ## This code tries to limit the argument list length only when it is
@@ -2330,17 +2341,6 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enc
     #         st = st.prev
     #     end
     # end
-
-    spvals = Any[ sp[i] for i in 2:2:length(sp) ]
-    for i=1:length(spvals)
-        si = spvals[i]
-        if isa(si, TypeVar)
-            return NF
-        end
-        if isa(si,Symbol) || isa(si,GenSym)
-            spvals[i] = QuoteNode(si)
-        end
-    end
 
     methargs = metharg.parameters
     nm = length(methargs)
@@ -2377,8 +2377,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enc
             # all the fiddly details
             numarg = length(argexprs)
             newnames = unique_names(ast,numarg)
-            methsp = sp
-            sp = svec()
+            spnames = []
             spvals = []
             locals = []
             newcall = Expr(:call, e.args[1])
@@ -2400,7 +2399,6 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enc
     body.args = filter(x->!(isa(x,Expr) && x.head === :meta && isempty(x.args)),
                        body.args)
 
-    spnames = Any[ sp[i] for i=1:2:length(sp) ]
     enc_vinflist = enclosing_ast.args[2][1]::Array{Any,1}
     enc_locllist = ast_localvars(enclosing_ast)
     locllist = ast_localvars(ast)

--- a/base/int.jl
+++ b/base/int.jl
@@ -204,12 +204,17 @@ rem{T<:Integer}(x::T, ::Type{T}) = x
 rem(x::Integer, ::Type{Bool}) = ((x&1)!=0)
 mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)
 
-convert{T<:UnionS64Types,Tf<:Union{Float32,Float64}}(::Type{T}, x::Tf) =
-    box(T,checked_fptosi(T,unbox(Tf,x)))
-convert{T<:UnionU64Types,Tf<:Union{Float32,Float64}}(::Type{T}, x::Tf) =
-    box(T,checked_fptoui(T,unbox(Tf,x)))
 
-convert{T<:Union{Int128,UInt128},Tf<:Union{Float32,Float64}}(::Type{T},x::Tf) =
+let STypes = Union{ntuple(i->Type{Signed64Types[i]}, length(Signed64Types))...},
+    UTypes = Union{ntuple(i->Type{Unsigned64Types[i]}, length(Unsigned64Types))...}
+global convert
+convert{Tf<:Union{Float32,Float64}}(T::STypes, x::Tf) =
+    box(T,checked_fptosi(T,unbox(Tf,x)))
+convert{Tf<:Union{Float32,Float64}}(T::UTypes, x::Tf) =
+    box(T,checked_fptoui(T,unbox(Tf,x)))
+end
+
+convert{Tf<:Union{Float32,Float64}}(T::Union{Type{Int128},Type{UInt128}}, x::Tf) =
     (isinteger(x) || throw(InexactError()) ; trunc(T,x))
 
 for (Ts, Tu) in ((Int8, UInt8), (Int16, UInt16), (Int32, UInt32), (Int64, UInt64), (Int128, UInt128))

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -57,6 +57,7 @@ immutable Zip{I, Z<:AbstractZipIterator} <: AbstractZipIterator
 end
 zip(a, b, c...) = Zip(a, zip(b, c...))
 length(z::Zip) = min(length(z.a), length(z.z))
+tuple_type_cons{S}(::Type{S}, ::Type{Union{}}) = Union{}
 function tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
     @_pure_meta
     Tuple{S, T.parameters...}

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -303,7 +303,8 @@ function serialize(s::SerializationState, linfo::LambdaStaticData)
     else
         serialize(s, Any[])
     end
-    serialize(s, linfo.sparams)
+    serialize(s, linfo.sparam_syms)
+    serialize(s, linfo.sparam_vals)
     serialize(s, linfo.inferred)
     serialize(s, linfo.module)
     serialize(s, linfo.name)
@@ -516,13 +517,14 @@ function deserialize(s::SerializationState, ::Type{LambdaStaticData})
         linfo = known_lambda_data[lnumber]::LambdaStaticData
         makenew = false
     else
-        linfo = ccall(:jl_new_lambda_info, Any, (Ptr{Void}, Ptr{Void}, Ptr{Void}), C_NULL, C_NULL, C_NULL)::LambdaStaticData
+        linfo = ccall(:jl_new_lambda_info, Any, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}), C_NULL, C_NULL, C_NULL, C_NULL)::LambdaStaticData
         makenew = true
     end
     deserialize_cycle(s, linfo)
     ast = deserialize(s)::Expr
     roots = deserialize(s)::Vector{Any}
-    sparams = deserialize(s)::SimpleVector
+    sparam_syms = deserialize(s)::SimpleVector
+    sparam_vals = deserialize(s)::SimpleVector
     infr = deserialize(s)::Bool
     mod = deserialize(s)::Module
     name = deserialize(s)
@@ -531,7 +533,8 @@ function deserialize(s::SerializationState, ::Type{LambdaStaticData})
     pure = deserialize(s)
     if makenew
         linfo.ast = ast
-        linfo.sparams = sparams
+        linfo.sparam_syms = sparam_syms
+        linfo.sparam_vals = sparam_vals
         linfo.inferred = infr
         linfo.module = mod
         linfo.roots = roots

--- a/doc/devdocs/ast.rst
+++ b/doc/devdocs/ast.rst
@@ -172,6 +172,10 @@ These symbols appear in the ``head`` field of ``Expr``\s in lowered form.
 LambdaStaticData
 ~~~~~~~~~~~~~~~~
 
+``sparam_syms`` - The names (symbols) of static parameters.
+
+``sparam_vals`` - The values of the static parameters (once known), indexed by ``sparam_syms``.
+
 Has an ``->ast`` field pointing to an ``Expr`` with head ``lambda``. This
 ``Expr`` has the following layout:
 
@@ -200,8 +204,6 @@ Has an ``->ast`` field pointing to an ``Expr`` with head ``lambda``. This
 
     ``args[2][3]`` - The types of variables represented by ``GenSym`` objects.
     Given ``GenSym`` ``g``, its type will be at ``args[2][3][g.id+1]``.
-
-    ``args[2][4]`` - The names (symbols) of static parameters.
 
 ``args[3]``
     an ``Expr`` with head ``body`` whose arguments are the statements

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -271,11 +271,6 @@ JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
     return jv;
 }
 
-JL_DLLEXPORT jl_fptr_t jl_linfo_fptr(jl_lambda_info_t *linfo)
-{
-    return linfo->fptr;
-}
-
 JL_DLLEXPORT
 jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast,
         jl_svec_t *tvars, jl_svec_t *sparams, jl_module_t *ctx)
@@ -316,6 +311,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast,
     li->sparam_vals = sparams;
     li->tfunc = jl_nothing;
     li->fptr = NULL;
+    li->jlcall_api = 0;
     li->roots = NULL;
     li->functionObjects.functionObject = NULL;
     li->functionObjects.specFunctionObject = NULL;
@@ -347,6 +343,7 @@ jl_lambda_info_t *jl_copy_lambda_info(jl_lambda_info_t *linfo)
     new_linfo->file = linfo->file;
     new_linfo->line = linfo->line;
     new_linfo->fptr = linfo->fptr;
+    new_linfo->jlcall_api = linfo->jlcall_api;
     new_linfo->functionObjects.functionObject = linfo->functionObjects.functionObject;
     new_linfo->functionObjects.specFunctionObject = linfo->functionObjects.specFunctionObject;
     new_linfo->functionID = linfo->functionID;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -277,8 +277,8 @@ JL_DLLEXPORT jl_fptr_t jl_linfo_fptr(jl_lambda_info_t *linfo)
 }
 
 JL_DLLEXPORT
-jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams,
-                                     jl_module_t *ctx)
+jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast,
+        jl_svec_t *tvars, jl_svec_t *sparams, jl_module_t *ctx)
 {
     jl_lambda_info_t *li =
         (jl_lambda_info_t*)newobj((jl_value_t*)jl_lambda_info_type,
@@ -312,7 +312,8 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams,
         li->called = called;
     }
     li->module = ctx;
-    li->sparams = sparams;
+    li->sparam_syms = tvars;
+    li->sparam_vals = sparams;
     li->tfunc = jl_nothing;
     li->fptr = NULL;
     li->roots = NULL;
@@ -335,7 +336,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams,
 jl_lambda_info_t *jl_copy_lambda_info(jl_lambda_info_t *linfo)
 {
     jl_lambda_info_t *new_linfo =
-        jl_new_lambda_info(linfo->ast, linfo->sparams, linfo->module);
+        jl_new_lambda_info(linfo->ast, linfo->sparam_syms, linfo->sparam_vals, linfo->module);
     new_linfo->tfunc = linfo->tfunc;
     new_linfo->name = linfo->name;
     new_linfo->roots = linfo->roots;

--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -12,11 +12,8 @@ void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t
 int32_t jl_get_llvm_gv(jl_value_t *p) UNAVAILABLE
 void jl_write_malloc_log(void) UNAVAILABLE
 void jl_write_coverage_data(void) UNAVAILABLE
-void jl_generate_fptr(jl_function_t *f) {
-    jl_lambda_info_t *li = f->linfo;
-    if (li->fptr == &jl_trampoline) UNAVAILABLE
-    f->fptr = li->fptr;
-}
+void jl_generate_fptr(jl_lambda_info_t *li) UNAVAILABLE
+void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx) UNAVAILABLE
 
 JL_DLLEXPORT void jl_clear_malloc_data(void) UNAVAILABLE
 JL_DLLEXPORT void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
@@ -25,7 +22,6 @@ JL_DLLEXPORT const jl_value_t *jl_dump_function_asm(void *f, int raw_mc) UNAVAIL
 JL_DLLEXPORT const jl_value_t *jl_dump_function_ir(void *f, uint8_t strip_ir_metadata, uint8_t dump_module) UNAVAILABLE
 
 void jl_init_codegen(void) { }
-void jl_compile_linfo(jl_lambda_info_t *li) { }
 void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
 {
     if (!specsig)
@@ -44,7 +40,7 @@ void jl_getFunctionInfo(char **name, char **filename, size_t *line,
 }
 
 jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
-                           jl_value_t *sp, jl_expr_t *ast, int sparams, int allow_alloc)
+                           jl_value_t *sp, jl_lambda_info_t *li, int sparams, int allow_alloc)
 {
     return NULL;
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -179,6 +179,20 @@ static jl_sym_t *scmsym_to_julia(value_t s)
 
 static jl_value_t *scm_to_julia_(value_t e, int expronly);
 
+static jl_svec_t *full_svec(value_t e, int expronly)
+{
+    size_t ln = llength(e);
+    if (ln == 0) return jl_emptysvec;
+    jl_svec_t *ar = jl_alloc_svec_uninit(ln);
+    size_t i=0;
+    while (iscons(e)) {
+        jl_svecset(ar, i, scm_to_julia_(car_(e), expronly));
+        e = cdr_(e);
+        i++;
+    }
+    return ar;
+}
+
 static jl_value_t *full_list(value_t e, int expronly)
 {
     size_t ln = llength(e);
@@ -300,13 +314,17 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
         size_t i;
         if (sym == lambda_sym) {
             jl_expr_t *ex = jl_exprn(lambda_sym, n);
+            jl_svec_t *tvars = NULL;
+            jl_array_t *vinf = NULL;
+            jl_lambda_info_t *nli = NULL;
+            JL_GC_PUSH4(&ex, &tvars, &vinf, &nli);
             e = cdr_(e);
             value_t largs = car_(e);
             jl_cellset(ex->args, 0, full_list(largs,eo));
             e = cdr_(e);
 
             value_t ee = car_(e);
-            jl_array_t *vinf = jl_alloc_cell_1d(4);
+            vinf = jl_alloc_cell_1d(3);
             jl_cellset(vinf, 0, full_list_of_lists(car_(ee),eo));
             ee = cdr_(ee);
             jl_cellset(vinf, 1, full_list_of_lists(car_(ee),eo));
@@ -315,7 +333,7 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                        jl_box_long(numval(car_(ee))) :
                        full_list(car_(ee),eo));
             ee = cdr_(ee);
-            jl_cellset(vinf, 3, full_list(car_(ee),eo));
+            tvars = full_svec(car_(ee),eo);
             assert(!iscons(cdr_(ee)));
             jl_cellset(ex->args, 1, vinf);
             e = cdr_(e);
@@ -325,8 +343,9 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                 jl_cellset(ex->args, i, scm_to_julia_(car_(e), eo));
                 e = cdr_(e);
             }
-            jl_lambda_info_t *nli = jl_new_lambda_info((jl_value_t*)ex, jl_emptysvec, jl_current_module);
+            nli = jl_new_lambda_info((jl_value_t*)ex, tvars, jl_emptysvec, jl_current_module);
             jl_preresolve_globals(nli->ast, nli);
+            JL_GC_POP();
             return (jl_value_t*)nli;
         }
 
@@ -671,11 +690,10 @@ jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr)
     JL_GC_PUSH3(&le, &vi, &bo);
     le = jl_exprn(lambda_sym, 3);
     jl_cellset(le->args, 0, mt);
-    vi = (jl_value_t*)jl_alloc_cell_1d(4);
+    vi = (jl_value_t*)jl_alloc_cell_1d(3);
     jl_cellset(vi, 0, mt);
     jl_cellset(vi, 1, mt);
     jl_cellset(vi, 2, jl_box_long(jl_max_jlgensym_in(expr)+1));
-    jl_cellset(vi, 3, mt);
     jl_cellset(le->args, 1, vi);
     if (!jl_is_expr(expr) || ((jl_expr_t*)expr)->head != body_sym) {
         bo = jl_exprn(body_sym, 1);
@@ -684,7 +702,7 @@ jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr)
         expr = (jl_value_t*)bo;
     }
     jl_cellset(le->args, 2, expr);
-    jl_lambda_info_t *li = jl_new_lambda_info((jl_value_t*)le, jl_emptysvec, jl_current_module);
+    jl_lambda_info_t *li = jl_new_lambda_info((jl_value_t*)le, jl_emptysvec, jl_emptysvec, jl_current_module);
     JL_GC_POP();
     return li;
 }
@@ -730,19 +748,8 @@ jl_value_t *jl_lam_gensyms(jl_expr_t *l)
     assert(jl_is_expr(l));
     jl_value_t *le = jl_exprarg(l, 1);
     assert(jl_is_array(le));
-    assert(jl_array_len(le) == 4);
+    assert(jl_array_len(le) == 3);
     return jl_cellref(le, 2);
-}
-
-// get array of static parameter symbols
-jl_array_t *jl_lam_staticparams(jl_expr_t *l)
-{
-    assert(jl_is_expr(l));
-    jl_value_t *le = jl_exprarg(l, 1);
-    assert(jl_is_array(le));
-    assert(jl_array_len(le) == 4);
-    assert(jl_is_array(jl_cellref(le, 3)));
-    return (jl_array_t*)jl_cellref(le, 3);
 }
 
 // get array of body forms
@@ -775,27 +782,15 @@ JL_DLLEXPORT int jl_is_rest_arg(jl_value_t *ex)
     return ((jl_sym_t*)jl_exprarg(atype,1)) == vararg_sym;
 }
 
-static jl_value_t *copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
+static jl_value_t *copy_ast(jl_value_t *expr)
 {
-    if (jl_is_symbol(expr)) {
-        if (!do_sp) return expr;
-        // pre-evaluate certain static parameters to help type inference
-        for(int i=0; i < jl_svec_len(sp); i+=2) {
-            assert(jl_is_typevar(jl_svecref(sp,i)));
-            if ((jl_sym_t*)expr == ((jl_tvar_t*)jl_svecref(sp,i))->name) {
-                jl_value_t *spval = jl_svecref(sp,i+1);
-                if (jl_is_long(spval))
-                    return spval;
-            }
-        }
-    }
-    else if (jl_typeis(expr,jl_array_any_type)) {
+    if (jl_typeis(expr,jl_array_any_type)) {
         jl_array_t *a = (jl_array_t*)expr;
         jl_array_t *na = jl_alloc_cell_1d(jl_array_len(a));
         JL_GC_PUSH1(&na);
         size_t i;
         for(i=0; i < jl_array_len(a); i++)
-            jl_cellset(na, i, copy_ast(jl_cellref(a,i), sp, do_sp));
+            jl_cellset(na, i, copy_ast(jl_cellref(a,i)));
         JL_GC_POP();
         return (jl_value_t*)na;
     }
@@ -804,17 +799,17 @@ static jl_value_t *copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
         jl_expr_t *ne = jl_exprn(e->head, jl_array_len(e->args));
         JL_GC_PUSH1(&ne);
         if (e->head == lambda_sym) {
-            jl_exprargset(ne, 0, copy_ast(jl_exprarg(e,0), sp, 0));
-            jl_exprargset(ne, 1, copy_ast(jl_exprarg(e,1), sp, 0));
-            jl_exprargset(ne, 2, copy_ast(jl_exprarg(e,2), sp, 1));
+            jl_exprargset(ne, 0, copy_ast(jl_exprarg(e,0)));
+            jl_exprargset(ne, 1, copy_ast(jl_exprarg(e,1)));
+            jl_exprargset(ne, 2, copy_ast(jl_exprarg(e,2)));
         }
         else if (e->head == assign_sym) {
-            jl_exprargset(ne, 0, copy_ast(jl_exprarg(e,0), sp, 0));
-            jl_exprargset(ne, 1, copy_ast(jl_exprarg(e,1), sp, 1));
+            jl_exprargset(ne, 0, copy_ast(jl_exprarg(e,0)));
+            jl_exprargset(ne, 1, copy_ast(jl_exprarg(e,1)));
         }
         else {
             for(size_t i=0; i < jl_array_len(e->args); i++) {
-                jl_exprargset(ne, i, copy_ast(jl_exprarg(e,i), sp, 1));
+                jl_exprargset(ne, i, copy_ast(jl_exprarg(e,i)));
             }
         }
         JL_GC_POP();
@@ -871,25 +866,25 @@ JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr)
     return expr;
 }
 
-static jl_value_t *dont_copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
+static jl_value_t *dont_copy_ast(jl_value_t *expr)
 {
     if (jl_is_symbol(expr) || jl_is_lambda_info(expr)) {
-        return copy_ast(expr, sp, do_sp);
+        return copy_ast(expr);
     }
     else if (jl_is_expr(expr)) {
         jl_expr_t *e = (jl_expr_t*)expr;
         if (e->head == lambda_sym) {
-            jl_exprargset(e, 0, dont_copy_ast(jl_exprarg(e,0), sp, 0));
-            jl_exprargset(e, 1, dont_copy_ast(jl_exprarg(e,1), sp, 0));
-            jl_exprargset(e, 2, dont_copy_ast(jl_exprarg(e,2), sp, 1));
+            jl_exprargset(e, 0, dont_copy_ast(jl_exprarg(e,0)));
+            jl_exprargset(e, 1, dont_copy_ast(jl_exprarg(e,1)));
+            jl_exprargset(e, 2, dont_copy_ast(jl_exprarg(e,2)));
         }
         else if (e->head == assign_sym) {
-            jl_exprargset(e, 0, dont_copy_ast(jl_exprarg(e,0), sp, 0));
-            jl_exprargset(e, 1, dont_copy_ast(jl_exprarg(e,1), sp, 1));
+            jl_exprargset(e, 0, dont_copy_ast(jl_exprarg(e,0)));
+            jl_exprargset(e, 1, dont_copy_ast(jl_exprarg(e,1)));
         }
         else {
             for(size_t i=0; i < jl_array_len(e->args); i++) {
-                jl_exprargset(e, i, dont_copy_ast(jl_exprarg(e,i), sp, 1));
+                jl_exprargset(e, i, dont_copy_ast(jl_exprarg(e,i)));
             }
         }
         return (jl_value_t*)e;
@@ -897,63 +892,22 @@ static jl_value_t *dont_copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
     return expr;
 }
 
-static void eval_decl_types(jl_array_t *vi, jl_value_t *ast, jl_svec_t *spenv)
-{
-    size_t i, l = jl_array_len(vi);
-    for(i=0; i < l; i++) {
-        jl_array_t *v = (jl_array_t*)jl_cellref(vi, i);
-        assert(jl_array_len(v) > 1);
-        jl_value_t *ty = jl_static_eval(jl_cellref(v,1), NULL, jl_current_module,
-                                        (jl_value_t*)spenv, (jl_expr_t*)ast, 1, 1);
-        if (ty != NULL && (jl_is_type(ty) || jl_is_typevar(ty))) {
-            jl_cellset(v, 1, ty);
-        }
-        else {
-            jl_cellset(v, 1, (jl_value_t*)jl_any_type);
-        }
-    }
-}
-
-jl_svec_t *jl_svec_tvars_to_symbols(jl_svec_t *t)
-{
-    jl_svec_t *s = jl_alloc_svec_uninit(jl_svec_len(t));
-    size_t i;
-    for(i=0; i < jl_svec_len(s); i+=2) {
-        assert(jl_is_typevar(jl_svecref(t,i)));
-        jl_svecset(s, i, (jl_value_t*)((jl_tvar_t*)jl_svecref(t,i))->name);
-        jl_svecset(s, i+1, jl_svecref(t,i+1));
-    }
-    return s;
-}
-
 // given a new lambda_info with static parameter values, make a copy
 // of the tree with declared types evaluated and static parameters passed
 // on to all enclosed functions.
 // this tree can then be further mutated by optimization passes.
-JL_DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams)
+JL_DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li)
 {
-    jl_svec_t *spenv = NULL;
     jl_value_t *ast = li->ast;
     if (ast == NULL) return NULL;
-    JL_GC_PUSH2(&spenv, &ast);
-    spenv = jl_svec_tvars_to_symbols(sparams);
+    JL_GC_PUSH1(&ast);
     if (!jl_is_expr(ast)) {
         ast = jl_uncompress_ast(li, ast);
-        ast = dont_copy_ast(ast, sparams, 1);
+        ast = dont_copy_ast(ast);
     }
     else {
-        ast = copy_ast(ast, sparams, 1);
+        ast = copy_ast(ast);
     }
-    jl_module_t *last_m = jl_current_module;
-    JL_TRY {
-        jl_current_module = li->module;
-        eval_decl_types(jl_lam_vinfo((jl_expr_t*)ast), ast, spenv);
-    }
-    JL_CATCH {
-        jl_current_module = last_m;
-        jl_rethrow();
-    }
-    jl_current_module = last_m;
     JL_GC_POP();
     return ast;
 }
@@ -992,8 +946,7 @@ int has_meta(jl_array_t *body, jl_sym_t *sym)
     return 0;
 }
 
-
-int jl_in_vinfo_array(jl_array_t *a, jl_sym_t *v)
+static int jl_in_vinfo_array(jl_array_t *a, jl_sym_t *v)
 {
     size_t i, l=jl_array_len(a);
     for(i=0; i<l; i++) {
@@ -1003,20 +956,20 @@ int jl_in_vinfo_array(jl_array_t *a, jl_sym_t *v)
     return 0;
 }
 
-int jl_in_sym_array(jl_array_t *a, jl_sym_t *v)
+static int jl_in_sym_svec(jl_svec_t *a, jl_sym_t *v)
 {
-    size_t i, l=jl_array_len(a);
+    size_t i, l = jl_svec_len(a);
     for(i=0; i<l; i++) {
-        if (jl_cellref(a,i) == (jl_value_t*)v)
+        if (jl_svecref(a,i) == (jl_value_t*)v)
             return 1;
     }
     return 0;
 }
 
-int jl_local_in_ast(jl_expr_t *ast, jl_sym_t *sym)
+int jl_local_in_linfo(jl_lambda_info_t *linfo, jl_sym_t *sym)
 {
-    return jl_in_vinfo_array(jl_lam_vinfo(ast), sym) ||
-        jl_in_sym_array(jl_lam_staticparams(ast), sym);
+    return jl_in_vinfo_array(jl_lam_vinfo((jl_expr_t*)linfo->ast), sym) ||
+        jl_in_sym_svec(linfo->sparam_syms, sym);
 }
 
 extern jl_value_t *jl_builtin_getfield;
@@ -1026,7 +979,7 @@ jl_value_t *jl_preresolve_globals(jl_value_t *expr, jl_lambda_info_t *lam)
     if (jl_is_symbol(expr)) {
         if (lam->module == NULL)
             return expr;
-        if (!jl_local_in_ast((jl_expr_t*)lam->ast, (jl_sym_t*)expr))
+        if (!jl_local_in_linfo(lam, (jl_sym_t*)expr))
             return jl_module_globalref(lam->module, (jl_sym_t*)expr);
     }
     else if (jl_is_lambda_info(expr)) {
@@ -1049,14 +1002,13 @@ jl_value_t *jl_preresolve_globals(jl_value_t *expr, jl_lambda_info_t *lam)
                 jl_value_t *s = jl_fieldref(jl_exprarg(e,2),0);
                 jl_value_t *fe = jl_exprarg(e,0);
                 if (jl_is_symbol(s) && jl_is_topnode(fe)) {
-                    jl_value_t *f = jl_static_eval(fe, NULL, lam->module,
-                                                   NULL, (jl_expr_t*)lam->ast, 0, 0);
+                    jl_value_t *f = jl_static_eval(fe, NULL, lam->module, lam, 0, 0);
                     if (f == jl_builtin_getfield) {
                         jl_value_t *me = jl_exprarg(e,1);
                         if (jl_is_topnode(me) ||
                             (jl_is_symbol(me) && jl_binding_resolved_p(lam->module,(jl_sym_t*)me))) {
                             jl_value_t *m = jl_static_eval(me, NULL, lam->module,
-                                                           NULL, (jl_expr_t*)lam->ast, 0, 0);
+                                                           lam, 0, 0);
                             if (m && jl_is_module(m))
                                 return jl_module_globalref((jl_module_t*)m, (jl_sym_t*)s);
                         }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1072,7 +1072,7 @@ jl_value_t *jl_mk_builtin_func(const char *name, jl_fptr_t fptr)
 {
     jl_sym_t *sname = jl_symbol(name);
     jl_value_t *f = jl_new_generic_function_with_supertype(sname, jl_core_module, jl_builtin_type, 0);
-    jl_lambda_info_t *li = jl_new_lambda_info(jl_nothing, jl_emptysvec, jl_core_module);
+    jl_lambda_info_t *li = jl_new_lambda_info(jl_nothing, jl_emptysvec, jl_emptysvec, jl_core_module);
     li->fptr = fptr;
     li->name = sname;
     // TODO jb/functions: what should li->ast be?

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -967,6 +967,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         }
         JL_CATCH {
             static_rt = false;
+            rt = NULL;
             if (jl_is_type_type(rtt_)) {
                 if (jl_subtype(jl_tparam0(rtt_), (jl_value_t*)jl_pointer_type, 0)) {
                     // substitute Ptr{Void} for statically-unknown pointer type
@@ -976,6 +977,24 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                     // `Array` used as return type just returns a julia object reference
                     rt = (jl_value_t*)jl_any_type;
                     static_rt = true;
+                }
+            }
+            if (rt == NULL) {
+                if (jl_is_expr(args[2])) {
+                    jl_expr_t *rtexpr = (jl_expr_t*)args[2];
+                    if (rtexpr->head == call_sym && jl_expr_nargs(rtexpr) == 4 &&
+                            static_eval(jl_exprarg(rtexpr, 0), ctx, true, false) == jl_builtin_apply_type &&
+                            static_eval(jl_exprarg(rtexpr, 1), ctx, true, false) == (jl_value_t*)jl_array_type) {
+                        // `Array` used as return type just returns a julia object reference
+                        rt = (jl_value_t*)jl_any_type;
+                        static_rt = true;
+                    }
+                    else if (rtexpr->head == call_sym && jl_expr_nargs(rtexpr) == 3 &&
+                            static_eval(jl_exprarg(rtexpr, 0), ctx, true, false) == jl_builtin_apply_type &&
+                            static_eval(jl_exprarg(rtexpr, 1), ctx, true, false) == (jl_value_t*)jl_pointer_type) {
+                        // substitute Ptr{Void} for statically-unknown pointer type
+                        rt = (jl_value_t*)jl_voidpointer_type;
+                    }
                 }
             }
             if (rt == NULL) {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -437,8 +437,8 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
     if (nargs == 2) {
         JL_TRY {
             rt = jl_interpret_toplevel_expr_in(ctx->module, args[2],
-                                               jl_svec_data(ctx->sp),
-                                               jl_svec_len(ctx->sp)/2);
+                                               ctx->linfo->sparam_syms,
+                                               ctx->linfo->sparam_vals);
         }
         JL_CATCH {
             jl_rethrow_with_add("error interpreting cglobal type");
@@ -502,8 +502,8 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
     {
     JL_TRY {
         at  = jl_interpret_toplevel_expr_in(ctx->module, args[3],
-                                            jl_svec_data(ctx->sp),
-                                            jl_svec_len(ctx->sp)/2);
+                                               ctx->linfo->sparam_syms,
+                                               ctx->linfo->sparam_vals);
     }
     JL_CATCH {
         jl_rethrow_with_add("error interpreting llvmcall argument tuple");
@@ -512,8 +512,8 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
     {
     JL_TRY {
         rt  = jl_interpret_toplevel_expr_in(ctx->module, args[2],
-                                            jl_svec_data(ctx->sp),
-                                            jl_svec_len(ctx->sp)/2);
+                                               ctx->linfo->sparam_syms,
+                                               ctx->linfo->sparam_vals);
     }
     JL_CATCH {
         jl_rethrow_with_add("error interpreting llvmcall return type");
@@ -522,8 +522,8 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
     {
     JL_TRY {
         ir  = jl_interpret_toplevel_expr_in(ctx->module, args[1],
-                                            jl_svec_data(ctx->sp),
-                                            jl_svec_len(ctx->sp)/2);
+                                               ctx->linfo->sparam_syms,
+                                               ctx->linfo->sparam_vals);
     }
     JL_CATCH {
         jl_rethrow_with_add("error interpreting IR argument");
@@ -962,8 +962,8 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     else {
         JL_TRY {
             rt  = jl_interpret_toplevel_expr_in(ctx->module, args[2],
-                                                jl_svec_data(ctx->sp),
-                                                jl_svec_len(ctx->sp)/2);
+                                               ctx->linfo->sparam_syms,
+                                               ctx->linfo->sparam_vals);
         }
         JL_CATCH {
             static_rt = false;
@@ -1025,9 +1025,9 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 
     {
         JL_TRY {
-            at  = jl_interpret_toplevel_expr_in(ctx->module, args[3],
-                                                jl_svec_data(ctx->sp),
-                                                jl_svec_len(ctx->sp)/2);
+            at = jl_interpret_toplevel_expr_in(ctx->module, args[3],
+                                               ctx->linfo->sparam_syms,
+                                               ctx->linfo->sparam_vals);
         }
         JL_CATCH {
             //jl_rethrow_with_add("error interpreting ccall argument tuple");

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -756,16 +756,7 @@ static int32_t jl_assign_functionID(Function *functionObject, int specsig)
     // give the function an index in the constant lookup table
     if (!imaging_mode)
         return 0;
-    Constant *c;
-    if (!specsig && functionObject->getFunctionType() != jl_func_sig)
-        c = ConstantExpr::getIntToPtr(
-                ConstantExpr::getAdd(
-                    ConstantExpr::getPtrToInt(functionObject, T_size),
-                    ConstantInt::get(T_size, 1)),
-                T_pvoidfunc);
-    else
-        c = ConstantExpr::getBitCast(functionObject, T_pvoidfunc);
-    jl_sysimg_fvars.push_back(c);
+    jl_sysimg_fvars.push_back(ConstantExpr::getBitCast(functionObject, T_pvoidfunc));
     return jl_sysimg_fvars.size();
 }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -751,12 +751,21 @@ static void jl_dump_shadow(char *fname, int jit_model, const char *sysimg_data, 
     delete clone;
 }
 
-static int32_t jl_assign_functionID(Function *functionObject)
+static int32_t jl_assign_functionID(Function *functionObject, int specsig)
 {
     // give the function an index in the constant lookup table
     if (!imaging_mode)
         return 0;
-    jl_sysimg_fvars.push_back(ConstantExpr::getBitCast(functionObject, T_pvoidfunc));
+    Constant *c;
+    if (!specsig && functionObject->getFunctionType() != jl_func_sig)
+        c = ConstantExpr::getIntToPtr(
+                ConstantExpr::getAdd(
+                    ConstantExpr::getPtrToInt(functionObject, T_size),
+                    ConstantInt::get(T_size, 1)),
+                T_pvoidfunc);
+    else
+        c = ConstantExpr::getBitCast(functionObject, T_pvoidfunc);
+    jl_sysimg_fvars.push_back(c);
     return jl_sysimg_fvars.size();
 }
 
@@ -1490,9 +1499,11 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
             if (is_global((jl_sym_t*)e, ctx)) {
                 // look for static parameter
                 jl_svec_t *sp = ctx->linfo->sparam_syms;
-                for(size_t i=0; i < jl_svec_len(sp); i++) {
+                for (size_t i=0; i < jl_svec_len(sp); i++) {
                     assert(jl_is_symbol(jl_svecref(sp, i)));
                     if (e == jl_svecref(sp, i)) {
+                        if (jl_svec_len(ctx->linfo->sparam_vals) == 0)
+                            return (jl_value_t*)jl_any_type;
                         e = jl_svecref(ctx->linfo->sparam_vals, i);
                         goto type_of_constant;
                     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1489,10 +1489,11 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
         if (jl_is_symbol(e)) {
             if (is_global((jl_sym_t*)e, ctx)) {
                 // look for static parameter
-                for(size_t i=0; i < jl_svec_len(ctx->sp); i+=2) {
-                    assert(jl_is_symbol(jl_svecref(ctx->sp, i)));
-                    if (e == jl_svecref(ctx->sp, i)) {
-                        e = jl_svecref(ctx->sp, i+1);
+                jl_svec_t *sp = ctx->linfo->sparam_syms;
+                for(size_t i=0; i < jl_svec_len(sp); i++) {
+                    assert(jl_is_symbol(jl_svecref(sp, i)));
+                    if (e == jl_svecref(sp, i)) {
+                        e = jl_svecref(ctx->linfo->sparam_vals, i);
                         goto type_of_constant;
                     }
                 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -565,7 +565,6 @@ typedef struct {
     std::map<int, Value*> *handlers;
     jl_module_t *module;
     jl_expr_t *ast;
-    jl_svec_t *sp;
     jl_lambda_info_t *linfo;
     Value *argArray;
     Value *argCount;
@@ -1702,7 +1701,7 @@ static void cg_bdw(jl_binding_t *b, jl_codectx_t *ctx)
 // try to statically evaluate, NULL if not possible
 extern "C"
 jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
-                           jl_value_t *sp, jl_expr_t *ast, int sparams, int allow_alloc)
+                           jl_lambda_info_t *linfo, int sparams, int allow_alloc)
 {
     jl_codectx_t *ctx = (jl_codectx_t*)ctx_;
     if (jl_is_symbolnode(ex))
@@ -1713,16 +1712,16 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
         if (ctx) {
             isglob = is_global(sym, ctx);
         }
-        else if (ast) {
-            isglob = !jl_local_in_ast(ast, sym);
+        else if (linfo) {
+            isglob = !jl_local_in_linfo(linfo, sym);
         }
         if (isglob) {
             size_t i;
             if (sparams) {
-                for(i=0; i < jl_svec_len(sp); i+=2) {
-                    if (sym == (jl_sym_t*)jl_svecref(sp, i)) {
+                for(i=0; i < jl_svec_len(linfo->sparam_syms); i++) {
+                    if (sym == (jl_sym_t*)jl_svecref(linfo->sparam_syms, i)) {
                         // static parameter
-                        return jl_svecref(sp, i+1);
+                        return jl_svecref(linfo->sparam_vals, i);
                     }
                 }
             }
@@ -1761,11 +1760,11 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
     if (jl_is_expr(ex)) {
         jl_expr_t *e = (jl_expr_t*)ex;
         if (e->head == call_sym) {
-            jl_value_t *f = jl_static_eval(jl_exprarg(e,0),ctx,mod,sp,ast,sparams,allow_alloc);
+            jl_value_t *f = jl_static_eval(jl_exprarg(e,0),ctx,mod,linfo,sparams,allow_alloc);
             if (f) {
                 if (jl_array_dim0(e->args) == 3 && f==jl_builtin_getfield) {
-                    m = (jl_module_t*)jl_static_eval(jl_exprarg(e,1),ctx,mod,sp,ast,sparams,allow_alloc);
-                    s = (jl_sym_t*)jl_static_eval(jl_exprarg(e,2),ctx,mod,sp,ast,sparams,allow_alloc);
+                    m = (jl_module_t*)jl_static_eval(jl_exprarg(e,1),ctx,mod,linfo,sparams,allow_alloc);
+                    s = (jl_sym_t*)jl_static_eval(jl_exprarg(e,2),ctx,mod,linfo,sparams,allow_alloc);
                     if (m && jl_is_module(m) && s && jl_is_symbol(s)) {
                         jl_binding_t *b = jl_get_binding(m, s);
                         if (b && b->constp) {
@@ -1783,7 +1782,7 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
                     jl_value_t **v;
                     JL_GC_PUSHARGS(v, n);
                     for (i = 0; i < n; i++) {
-                        v[i] = jl_static_eval(jl_exprarg(e,i+1),ctx,mod,sp,ast,sparams,allow_alloc);
+                        v[i] = jl_static_eval(jl_exprarg(e,i+1),ctx,mod,linfo,sparams,allow_alloc);
                         if (v[i] == NULL) {
                             JL_GC_POP();
                             return NULL;
@@ -1812,7 +1811,7 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
 static jl_value_t *static_eval(jl_value_t *ex, jl_codectx_t *ctx, bool sparams,
                                bool allow_alloc)
 {
-    return jl_static_eval(ex, ctx, ctx->module, (jl_value_t*)ctx->sp, ctx->ast,
+    return jl_static_eval(ex, ctx, ctx->module, ctx->linfo,
                           sparams, allow_alloc);
 }
 
@@ -1924,7 +1923,7 @@ static void simple_escape_analysis(jl_value_t *expr, bool esc, jl_codectx_t *ctx
             simple_escape_analysis(f, esc, ctx);
             if (expr_is_symbol(f)) {
                 if (is_constant(f, ctx, false)) {
-                    jl_value_t *fv = jl_interpret_toplevel_expr_in(ctx->module, f, NULL, 0);
+                    jl_value_t *fv = jl_interpret_toplevel_expr_in(ctx->module, f, jl_emptysvec, jl_emptysvec);
                     if (jl_typeis(fv, jl_intrinsic_type)) {
                         esc = false;
                         JL_I::intrinsic fi = (JL_I::intrinsic)jl_unbox_int32(fv);
@@ -3148,11 +3147,11 @@ static jl_cgval_t emit_var(jl_sym_t *sym, jl_codectx_t *ctx, bool isboxed)
     bool isglobal = is_global(sym, ctx);
     if (isglobal) {
         // look for static parameter
-        for(size_t i=0; i < jl_svec_len(ctx->sp); i+=2) {
-            assert(jl_is_symbol(jl_svecref(ctx->sp, i)));
-            if (sym == (jl_sym_t*)jl_svecref(ctx->sp, i)) {
-                jl_value_t *sp = jl_svecref(ctx->sp, i+1);
-                return mark_julia_const(sp);
+        jl_svec_t *sp = ctx->linfo->sparam_syms;
+        for(size_t i=0; i < jl_svec_len(sp); i++) {
+            assert(jl_is_symbol(jl_svecref(sp, i)));
+            if (sym == (jl_sym_t*)jl_svecref(sp, i)) {
+                return mark_julia_const(jl_svecref(ctx->linfo->sparam_vals, i));
             }
         }
         jl_binding_t *jbp=NULL;
@@ -3711,8 +3710,6 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
 
 // --- generate function bodies ---
 
-extern "C" jl_svec_t *jl_svec_tvars_to_symbols(jl_svec_t *t);
-
 // gc frame emission
 static void allocate_gc_frame(size_t n_roots, BasicBlock *b0, jl_codectx_t *ctx)
 {
@@ -4195,13 +4192,11 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
 
     // step 1. unpack AST and allocate codegen context for this function
     jl_expr_t *ast = (jl_expr_t*)lam->ast;
-    jl_svec_t *sparams = NULL;
-    JL_GC_PUSH2(&ast, &sparams);
+    JL_GC_PUSH1(&ast);
     if (!jl_is_expr(ast)) {
         ast = (jl_expr_t*)jl_uncompress_ast(lam, (jl_value_t*)ast);
     }
     assert(jl_is_expr(ast));
-    sparams = jl_svec_tvars_to_symbols(lam->sparams);
     //jl_static_show(JL_STDOUT, (jl_value_t*)ast);
     //jl_printf(JL_STDOUT, "\n");
     std::map<jl_sym_t*, jl_arrayvar_t> arrayvars;
@@ -4213,7 +4208,6 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     ctx.handlers = &handlers;
     ctx.module = lam->module;
     ctx.ast = ast;
-    ctx.sp = sparams;
     ctx.linfo = lam;
     ctx.funcName = jl_symbol_name(lam->name);
     ctx.vaName = NULL;
@@ -4230,9 +4224,6 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     size_t vinfoslen = jl_array_dim0(vinfos);
     size_t nreq = largslen;
     int va = 0;
-
-    if ((jl_array_len(jl_lam_staticparams(ast)) == 0) != (jl_svec_len(sparams) == 0)) // TODO: more accurate check
-        jl_error("wrong number of static parameters on LambdaStaticData");
 
     if (!lam->specTypes)  // TODO jb/functions
         lam->specTypes = jl_anytuple_type;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1054,7 +1054,7 @@ extern "C" void jl_generate_fptr(jl_lambda_info_t *li)
         #endif
         if (((Function*)li->functionObjects.functionObject)->getFunctionType() != jl_func_sig) {
             // mark the pointer as jl_fptr_sparam_t calling convention
-            li->fptr = (jl_fptr_t)(((uintptr_t)li->fptr) | 1);
+            li->jlcall_api = 1;
         }
 
         assert(li->fptr != NULL);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -229,7 +229,7 @@ static Type *T_pjlvalue;
 static Type *T_ppjlvalue;
 static Type* jl_parray_llvmt;
 static FunctionType *jl_func_sig;
-static Type *jl_pfptr_llvmt;
+static FunctionType *jl_func_sig_sparams;
 static Type *T_pvoidfunc;
 
 static IntegerType *T_int1;
@@ -566,6 +566,7 @@ typedef struct {
     jl_module_t *module;
     jl_expr_t *ast;
     jl_lambda_info_t *linfo;
+    Value *spvals_ptr;
     Value *argArray;
     Value *argCount;
     std::string funcName;
@@ -846,9 +847,9 @@ static Function *to_function(jl_lambda_info_t *li, jl_cyclectx_t *cyclectx)
         #endif
         f = (llvm::Function*)(definitions.specFunctionObject ?
             definitions.specFunctionObject : definitions.functionObject);
-        li->functionID = jl_assign_functionID((llvm::Function*)definitions.functionObject);
+        li->functionID = jl_assign_functionID((llvm::Function*)definitions.functionObject, false);
         if (definitions.specFunctionObject)
-            li->specFunctionID = jl_assign_functionID((llvm::Function*)definitions.specFunctionObject);
+            li->specFunctionID = jl_assign_functionID((llvm::Function*)definitions.specFunctionObject, true);
         //n_emit++;
     }
     JL_CATCH {
@@ -1051,6 +1052,10 @@ extern "C" void jl_generate_fptr(jl_lambda_info_t *li)
         #else
         li->fptr = (jl_fptr_t)jl_ExecutionEngine->getPointerToFunction((Function*)li->functionObjects.functionObject);
         #endif
+        if (((Function*)li->functionObjects.functionObject)->getFunctionType() != jl_func_sig) {
+            // mark the pointer as jl_fptr_sparam_t calling convention
+            li->fptr = (jl_fptr_t)(((uintptr_t)li->fptr) | 1);
+        }
 
         assert(li->fptr != NULL);
 #ifndef KEEP_BODIES
@@ -1718,10 +1723,13 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
         if (isglob) {
             size_t i;
             if (sparams) {
-                for(i=0; i < jl_svec_len(linfo->sparam_syms); i++) {
+                for (i=0; i < jl_svec_len(linfo->sparam_syms); i++) {
                     if (sym == (jl_sym_t*)jl_svecref(linfo->sparam_syms, i)) {
                         // static parameter
-                        return jl_svecref(linfo->sparam_vals, i);
+                        if (jl_svec_len(ctx->linfo->sparam_vals) > 0)
+                            return jl_svecref(linfo->sparam_vals, i);
+                        else
+                            return NULL;
                     }
                 }
             }
@@ -3151,7 +3159,16 @@ static jl_cgval_t emit_var(jl_sym_t *sym, jl_codectx_t *ctx, bool isboxed)
         for(size_t i=0; i < jl_svec_len(sp); i++) {
             assert(jl_is_symbol(jl_svecref(sp, i)));
             if (sym == (jl_sym_t*)jl_svecref(sp, i)) {
-                return mark_julia_const(jl_svecref(ctx->linfo->sparam_vals, i));
+                if (jl_svec_len(ctx->linfo->sparam_vals) > 0) {
+                    return mark_julia_const(jl_svecref(ctx->linfo->sparam_vals, i));
+                }
+                else {
+                    assert(ctx->spvals_ptr != NULL);
+                    Value *bp = builder.CreateConstInBoundsGEP1_32(LLVM37_param(T_pjlvalue)
+                            builder.CreateBitCast(ctx->spvals_ptr, T_ppjlvalue),
+                            i + sizeof(jl_svec_t) / sizeof(jl_value_t*));
+                    return mark_julia_type(tbaa_decorate(tbaa_const, builder.CreateLoad(bp)), true, jl_any_type);
+                }
             }
         }
         jl_binding_t *jbp=NULL;
@@ -3900,6 +3917,7 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_value_t *jlrettype, 
     ctx.f = cw;
     ctx.linfo = lam;
     ctx.sret = false;
+    ctx.spvals_ptr = NULL;
     allocate_gc_frame(0, b0, &ctx);
 
     // Save the Function object reference
@@ -4135,6 +4153,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, jl_expr_t *ast, Funct
     ctx.f = w;
     ctx.linfo = lam;
     ctx.sret = false;
+    ctx.spvals_ptr = NULL;
     allocate_gc_frame(0, b0, &ctx);
 
     size_t nargs = jl_array_dim0(jl_lam_args(ast));
@@ -4214,6 +4233,7 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     ctx.vaStack = false;
     ctx.boundsCheck.push_back(true);
     ctx.cyclectx = cyclectx;
+    ctx.spvals_ptr = NULL;
 
     // step 2. process var-info lists to see what vars need boxing
     jl_value_t *gensym_types = jl_lam_gensyms(ast);
@@ -4285,7 +4305,8 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     Function *f = NULL;
 
     bool specsig = false;
-    if (!va && lam->specTypes != jl_anytuple_type && lam->inferred) {
+    bool needsparams = jl_svec_len(lam->sparam_syms) != jl_svec_len(lam->sparam_vals);
+    if (!va && !needsparams && lam->specTypes != jl_anytuple_type && lam->inferred) {
         // not vararg, consider specialized signature
         for(size_t i=0; i < jl_nparams(lam->specTypes); i++) {
             if (isbits_spec(jl_tparam(lam->specTypes, i))) { // assumes !va
@@ -4309,7 +4330,7 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     funcName << "_" << globalUnique++;
 
     ctx.sret = false;
-    if (specsig) { // assumes !va
+    if (specsig) { // assumes !va and !needsparams
         std::vector<Type*> fsig(0);
         Type *rt;
         bool retboxed;
@@ -4352,7 +4373,8 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
             declarations->functionObject = function_proto(fwrap);
     }
     else {
-        f = Function::Create(jl_func_sig, imaging_mode ? GlobalVariable::InternalLinkage : GlobalVariable::ExternalLinkage,
+        f = Function::Create(needsparams ? jl_func_sig_sparams : jl_func_sig,
+                             imaging_mode ? GlobalVariable::InternalLinkage : GlobalVariable::ExternalLinkage,
                              funcName.str(), builtins_module);
         addComdat(f);
 #ifdef LLVM37
@@ -4604,6 +4626,9 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     Value *fArg=NULL, *argArray=NULL, *argCount=NULL;
     if (!specsig) {
         Function::arg_iterator AI = f->arg_begin();
+        if (needsparams) {
+            ctx.spvals_ptr = &*AI++;
+        }
         fArg = &*AI++;
         argArray = &*AI++;
         argCount = &*AI++;
@@ -5139,19 +5164,23 @@ extern "C" void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
             if (sret)
                 f->addAttribute(1, Attribute::StructRet);
 
-        if (lam->functionObjects.specFunctionObject == NULL) {
-            lam->functionObjects.specFunctionObject = (void*)f;
-            lam->specFunctionID = jl_assign_functionID(f);
+            if (lam->functionObjects.specFunctionObject == NULL) {
+                lam->functionObjects.specFunctionObject = (void*)f;
             }
             add_named_global(f, (void*)fptr);
         }
         else {
-            Function *f = jlcall_func_to_llvm(funcName, fptr, shadow_module);
-            if (lam->functionObjects.functionObject == NULL) {
-                lam->functionObjects.functionObject = (void*)f;
-                lam->functionID = jl_assign_functionID(f);
+            if (((uintptr_t)fptr) & 1) { // jl_func_sig_sparams -- don't bother emitting the FunctionObject (since it would never be used)
                 assert(lam->fptr == NULL);
                 lam->fptr = (jl_fptr_t)fptr;
+            }
+            else {
+                Function *f = jlcall_func_to_llvm(funcName, fptr, shadow_module);
+                if (lam->functionObjects.functionObject == NULL) {
+                    lam->functionObjects.functionObject = (void*)f;
+                    assert(lam->fptr == NULL);
+                    lam->fptr = (jl_fptr_t)fptr;
+                }
             }
         }
     }
@@ -5283,13 +5312,17 @@ static void init_julia_llvm_env(Module *m)
     three_pvalue_llvmt.push_back(T_pjlvalue);
     three_pvalue_llvmt.push_back(T_pjlvalue);
     V_null = Constant::getNullValue(T_pjlvalue);
+
     std::vector<Type*> ftargs(0);
-    ftargs.push_back(T_pjlvalue);
-    ftargs.push_back(T_ppjlvalue);
-    ftargs.push_back(T_int32);
+    ftargs.push_back(T_pjlvalue);  // linfo->sparam_vals
+    ftargs.push_back(T_pjlvalue);  // function
+    ftargs.push_back(T_ppjlvalue); // args[]
+    ftargs.push_back(T_int32);     // nargs
+    jl_func_sig_sparams = FunctionType::get(T_pjlvalue, ftargs, false);
+    assert(jl_func_sig_sparams != NULL);
+    ftargs.erase(ftargs.begin());  // drop linfo->sparams_vals argument
     jl_func_sig = FunctionType::get(T_pjlvalue, ftargs, false);
     assert(jl_func_sig != NULL);
-    jl_pfptr_llvmt = PointerType::get(PointerType::get(jl_func_sig, 0), 0);
 
     Type* vaelts[] = {T_pint8
 #ifdef STORE_ARRAY_LEN

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1291,24 +1291,13 @@ void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper, bool g
             }
         }
     }
-    if (linfo && !linfo->specTypes) {
-        jl_printf(JL_STDERR,
-                  "WARNING: Returned code may not match what actually runs.\n");
-        if (linfo->unspecialized) {
-            linfo = linfo->unspecialized;
-        }
-        else {
-            // linfo can't be compiled directly,
-            // but we can compile a throw-away copy
-            // by leaking a bit of memory
-            // (since the compiled code is not usable)
-            linfo = jl_copy_lambda_info(linfo);
-            linfo->specTypes = tt;
-        }
-    }
     if (linfo == NULL) {
         JL_GC_POP();
         return NULL;
+    }
+    if (!linfo->specTypes) {
+        jl_printf(JL_STDERR, "WARNING: Returned code may not match what actually runs.\n");
+        linfo = jl_get_unspecialized(linfo);
     }
 
 #if defined(USE_ORCJIT) || defined(USE_MCJIT)
@@ -4245,13 +4234,10 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     size_t nreq = largslen;
     int va = 0;
 
-    if (!lam->specTypes)  // TODO jb/functions
-        lam->specTypes = jl_anytuple_type;
-    //assert(lam->specTypes); // this could happen if the user tries to compile a generic-function
+    assert(lam->specTypes); // this could happen if the user tries to compile a generic-function
                             // without specializing (or unspecializing) it first
                             // compiling this would cause all specializations to inherit
                             // this code and could create an broken compile / function cache
-                            // if the method has static parameters
 
     if (nreq > 0 && jl_is_rest_arg(jl_cellref(largs,nreq-1))) {
         nreq--;

--- a/src/dump.c
+++ b/src/dump.c
@@ -824,6 +824,8 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         // save functionObject pointers
         write_int32(s, li->functionID);
         write_int32(s, li->specFunctionID);
+        if (li->functionID)
+            write_int8(s, li->jlcall_api);
     }
     else if (jl_typeis(v, jl_module_type)) {
         jl_serialize_module(s, (jl_module_t*)v);
@@ -1397,6 +1399,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         func_llvm = read_int32(s);
         cfunc_llvm = read_int32(s);
         jl_delayed_fptrs(li, func_llvm, cfunc_llvm);
+        li->jlcall_api = func_llvm ? read_int8(s) : 0;
         return (jl_value_t*)li;
     }
     else if (vtag == (jl_value_t*)jl_module_type) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -782,7 +782,8 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         writetag(s, jl_lambda_info_type);
         jl_lambda_info_t *li = (jl_lambda_info_t*)v;
         jl_serialize_value(s, li->ast);
-        jl_serialize_value(s, (jl_value_t*)li->sparams);
+        jl_serialize_value(s, (jl_value_t*)li->sparam_syms);
+        jl_serialize_value(s, (jl_value_t*)li->sparam_vals);
         // don't save cached type info for code in the Core module, because
         // it might reference types in the old Base module.
         if (li->module == jl_core_module) {
@@ -914,10 +915,7 @@ static void jl_serialize_methtable_from_mod(ios_t *s, jl_methtable_t *mt, int8_t
             write_int8(s, iskw);
             jl_serialize_value(s, ml->sig);
             jl_serialize_value(s, ml->func);
-            if (jl_is_svec(ml->tvars))
-                jl_serialize_value(s, ml->tvars);
-            else
-                jl_serialize_value(s, jl_svec1(ml->tvars));
+            jl_serialize_value(s, ml->tvars);
             write_int8(s, ml->isstaged);
         }
         ml = ml->next;
@@ -1358,8 +1356,10 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
             arraylist_push(&backref_list, li);
         li->ast = jl_deserialize_value(s, &li->ast);
         jl_gc_wb(li, li->ast);
-        li->sparams = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&li->sparams);
-        jl_gc_wb(li, li->sparams);
+        li->sparam_syms = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&li->sparam_syms);
+        jl_gc_wb(li, li->sparam_syms);
+        li->sparam_vals = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&li->sparam_vals);
+        jl_gc_wb(li, li->sparam_vals);
         li->tfunc = jl_deserialize_value(s, (jl_value_t**)&li->tfunc);
         jl_gc_wb(li, li->tfunc);
         li->name = (jl_sym_t*)jl_deserialize_value(s, NULL);

--- a/src/dump.c
+++ b/src/dump.c
@@ -652,7 +652,9 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         // compressing tree
         if (!is_ast_node(v)) {
             writetag(s, (jl_value_t*)LiteralVal_tag);
-            write_uint16(s, literal_val_id(v));
+            int id = literal_val_id(v);
+            assert(id >= 0 && id < UINT16_MAX);
+            write_uint16(s, id);
             return;
         }
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -298,6 +298,7 @@ static jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t
       method->unspecialized, not method */
     assert(!nli->ast ||
            (nli->fptr == NULL &&
+            nli->jlcall_api == 0 &&
             nli->functionObjects.functionObject == NULL &&
             nli->functionObjects.specFunctionObject == NULL &&
             nli->functionObjects.cFunctionList == NULL &&
@@ -308,6 +309,7 @@ static jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t
         jl_lambda_info_t *unspec = l->unspecialized;
         if (unspec != NULL) {
             nli->fptr = unspec->fptr;
+            nli->jlcall_api = unspec->jlcall_api;
             nli->functionObjects.functionObject = unspec->functionObjects.functionObject;
             nli->functionObjects.specFunctionObject = unspec->functionObjects.specFunctionObject;
             nli->functionID = unspec->functionID;
@@ -902,13 +904,10 @@ static jl_value_t *jl_call_unspecialized(jl_svec_t *sparam_vals, jl_lambda_info_
         jl_generate_fptr(meth);
     }
     assert(jl_svec_len(meth->sparam_syms) == jl_svec_len(sparam_vals));
-    jl_fptr_t fptr = meth->fptr;
-    uintptr_t fptr_int = (uintptr_t)fptr;
-    uintptr_t mask = 1;
-    if (__likely((fptr_int & mask) == 0))
-        return fptr(args[0], &args[1], nargs-1);
+    if (__likely(meth->jlcall_api == 0))
+        return meth->fptr(args[0], &args[1], nargs-1);
     else
-        return ((jl_fptr_sparam_t)(fptr_int & ~mask))(sparam_vals, args[0], &args[1], nargs-1);
+        return ((jl_fptr_sparam_t)meth->fptr)(sparam_vals, args[0], &args[1], nargs-1);
 }
 
 JL_DLLEXPORT jl_lambda_info_t *jl_instantiate_staged(jl_lambda_info_t *generator, jl_tupletype_t *tt, jl_svec_t *env)

--- a/src/gf.c
+++ b/src/gf.c
@@ -278,30 +278,41 @@ static jl_lambda_info_t *jl_method_table_assoc_exact(jl_methtable_t *mt, jl_valu
 }
 
 // return a new lambda-info that has some extra static parameters merged in.
-jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp, jl_tupletype_t *types)
+static jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp, jl_tupletype_t *types)
 {
     JL_GC_PUSH1(&sp);
-    assert(jl_svec_len(l->sparam_syms) == jl_svec_len(sp));
-    assert(jl_svec_len(l->sparam_vals) == 0 || l->sparam_vals == sp);
+    assert(jl_svec_len(l->sparam_syms) == jl_svec_len(sp) || sp == jl_emptysvec);
+    assert(l->sparam_vals == jl_emptysvec);
+    assert(l->specTypes == NULL);
     jl_lambda_info_t *nli = jl_copy_lambda_info(l);
+    nli->unspecialized = l;
     nli->sparam_vals = sp; // no gc_wb needed
     nli->tfunc = jl_nothing;
     nli->specializations = NULL;
-    nli->unspecialized = NULL;
     nli->specTypes = types;
     if (types) jl_gc_wb(nli, types);
-    if (jl_options.compile_enabled != JL_OPTIONS_COMPILE_OFF) {
-        // make sure this marked as needing to be (re)compiled
-        // since the sparams might be providing better type information
-        // this might happen if an inner lambda was compiled as part
-        // of running an unspecialized function
-        nli->fptr = NULL;
-        nli->functionObjects.functionObject = NULL;
-        nli->functionObjects.specFunctionObject = NULL;
-        nli->functionID = 0;
-        nli->specFunctionID = 0;
-    }
-    else {
+
+    /* "method" itself should never get compiled,
+      for example, if an unspecialized method is needed,
+      the slow compiled code should be associated with
+      method->unspecialized, not method */
+    assert(!nli->ast ||
+           (nli->fptr == NULL &&
+            nli->functionObjects.functionObject == NULL &&
+            nli->functionObjects.specFunctionObject == NULL &&
+            nli->functionObjects.cFunctionList == NULL &&
+            nli->functionID == 0 &&
+            nli->specFunctionID == 0));
+    if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF) {
+        // copy fptr from the unspecialized method definition
+        jl_lambda_info_t *unspec = l->unspecialized;
+        if (unspec != NULL) {
+            nli->fptr = unspec->fptr;
+            nli->functionObjects.functionObject = unspec->functionObjects.functionObject;
+            nli->functionObjects.specFunctionObject = unspec->functionObjects.specFunctionObject;
+            nli->functionID = unspec->functionID;
+            nli->specFunctionID = unspec->functionID;
+        }
         if (nli->fptr == NULL) {
             jl_printf(JL_STDERR,"code missing for ");
             jl_static_show(JL_STDERR, (jl_value_t*)nli);
@@ -310,6 +321,41 @@ jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp, j
     }
     JL_GC_POP();
     return nli;
+}
+
+jl_lambda_info_t *jl_get_unspecialized(jl_lambda_info_t *method)
+{
+    // one unspecialized version of a function can be shared among all cached specializations
+    jl_lambda_info_t *def = method;
+    if (def->specTypes) {
+        // a method is a specialization iff it has specTypes
+        // but method->unspecialized points to the definition in that case
+        // and definition->unspecialized points to the thing to call
+        def = def->unspecialized;
+    }
+    if (__unlikely(def->unspecialized == NULL)) {
+        int need_sparams = 0; // if there are intrinsics, probably require the sparams to compile successfully
+        if (method->sparam_vals != jl_emptysvec) {
+            jl_value_t *ast = def->ast;
+            JL_GC_PUSH1(&ast);
+            if (!jl_is_expr(ast))
+                ast = jl_uncompress_ast(def, ast);
+            if (jl_has_intrinsics(method, jl_lam_body((jl_expr_t*)ast), method->module))
+                need_sparams = 1;
+            JL_GC_POP();
+        }
+        if (need_sparams) {
+            method->unspecialized = jl_add_static_parameters(def, method->sparam_vals, method->specTypes);
+            jl_gc_wb(method, method->unspecialized);
+            method->unspecialized->unspecialized = method->unspecialized;
+            def = method;
+       }
+        else {
+            def->unspecialized = jl_add_static_parameters(def, jl_emptysvec, jl_anytuple_type);
+            jl_gc_wb(def, def->unspecialized);
+        }
+    }
+    return def->unspecialized;
 }
 
 static jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tupletype_t *type,
@@ -363,7 +409,7 @@ jl_lambda_info_t *jl_method_cache_insert(jl_methtable_t *mt, jl_tupletype_t *typ
   can be equal to "li" if not applicable.
 */
 int jl_in_inference = 0;
-void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes, jl_lambda_info_t *def)
+void jl_type_infer(jl_lambda_info_t *li, jl_lambda_info_t *def)
 {
     JL_LOCK(codegen); // Might GC
     int last_ii = jl_in_inference;
@@ -377,7 +423,7 @@ void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes, jl_lambda_inf
         jl_value_t *fargs[4];
         fargs[0] = (jl_value_t*)jl_typeinf_func;
         fargs[1] = (jl_value_t*)li;
-        fargs[2] = (jl_value_t*)argtypes;
+        fargs[2] = (jl_value_t*)li->specTypes;
         fargs[3] = (jl_value_t*)def;
 #ifdef TRACE_INFERENCE
         jl_printf(JL_STDERR,"inference on ");
@@ -762,33 +808,18 @@ static jl_lambda_info_t *cache_method(jl_methtable_t *mt, jl_tupletype_t *type,
         JL_UNLOCK(codegen);
         return newmeth;
     }
-    else {
-        jl_svec_t *sparam_vals = jl_svec_len(sparams) == 0 ? jl_emptysvec : jl_alloc_svec_uninit(jl_svec_len(sparams)/2);
-        for (int i = 0; i < jl_svec_len(sparam_vals); i++) {
-            jl_svecset(sparam_vals, i, jl_svecref(sparams, i * 2 + 1));
-        }
-        newmeth = jl_add_static_parameters(method, sparam_vals, type);
+    jl_svec_t *sparam_vals = jl_svec_len(sparams) == 0 ? jl_emptysvec : jl_alloc_svec_uninit(jl_svec_len(sparams)/2);
+    for (int i = 0; i < jl_svec_len(sparam_vals); i++) {
+        jl_svecset(sparam_vals, i, jl_svecref(sparams, i * 2 + 1));
     }
+    newmeth = jl_add_static_parameters(method, sparam_vals, type);
 
     if (cache_as_orig)
         (void)jl_method_cache_insert(mt, origtype, newmeth);
     else
         (void)jl_method_cache_insert(mt, type, newmeth);
 
-    if (newmeth->sparam_syms == jl_emptysvec) {
-        // when there are no static parameters, one unspecialized version
-        // of a function can be shared among all cached specializations.
-        if (method->unspecialized == NULL) {
-            method->unspecialized = jl_add_static_parameters(method, jl_emptysvec, decl);
-            jl_gc_wb(method, method->unspecialized);
-        }
-        newmeth->unspecialized = method->unspecialized;
-        jl_gc_wb(newmeth, newmeth->unspecialized);
-    }
-
     if (newmeth->ast != NULL) {
-        newmeth->specTypes = type;
-        jl_gc_wb(newmeth, type);
         jl_array_t *spe = method->specializations;
         if (spe == NULL) {
             spe = jl_alloc_cell_1d(1);
@@ -801,7 +832,7 @@ static jl_lambda_info_t *cache_method(jl_methtable_t *mt, jl_tupletype_t *type,
         jl_gc_wb(method, method->specializations);
         if (jl_options.compile_enabled != JL_OPTIONS_COMPILE_OFF) // don't bother with typeinf if compile is off
             if (jl_symbol_name(newmeth->name)[0] != '@')  // don't bother with typeinf on macros
-                jl_type_infer(newmeth, type, method);
+                jl_type_infer(newmeth, method);
     }
     JL_GC_POP();
     JL_UNLOCK(codegen);
@@ -863,94 +894,77 @@ static jl_value_t *lookup_match(jl_value_t *a, jl_value_t *b, jl_svec_t **penv,
     return ti;
 }
 
-JL_DLLEXPORT jl_lambda_info_t *jl_instantiate_staged(jl_methlist_t *m, jl_tupletype_t *tt, jl_svec_t *env)
+// invoke (compiling if necessary) the jlcall function pointer for an unspecialized method
+static jl_value_t *jl_call_unspecialized(jl_svec_t *sparam_vals, jl_lambda_info_t *meth, jl_value_t **args, uint32_t nargs)
+{
+    if (__unlikely(meth->fptr == NULL)) {
+        jl_compile_linfo(meth, NULL);
+        jl_generate_fptr(meth);
+    }
+    assert(jl_svec_len(meth->sparam_syms) == jl_svec_len(sparam_vals));
+    jl_fptr_t fptr = meth->fptr;
+    uintptr_t fptr_int = (uintptr_t)fptr;
+    uintptr_t mask = 1;
+    if (__likely((fptr_int & mask) == 0))
+        return fptr(args[0], &args[1], nargs-1);
+    else
+        return ((jl_fptr_sparam_t)(fptr_int & ~mask))(sparam_vals, args[0], &args[1], nargs-1);
+}
+
+JL_DLLEXPORT jl_lambda_info_t *jl_instantiate_staged(jl_lambda_info_t *generator, jl_tupletype_t *tt, jl_svec_t *env)
 {
     jl_expr_t *ex = NULL;
-    jl_expr_t *oldast = NULL;
-    jl_lambda_info_t *func = NULL;
     jl_value_t *linenum = NULL;
-    JL_GC_PUSH4(&ex, &oldast, &func, &linenum);
-    func = m->func;
-    if (jl_is_expr(func->ast)) {
-        oldast = (jl_expr_t*)func->ast;
-    }
-    else {
-        oldast = (jl_expr_t*)jl_uncompress_ast(func, func->ast);
-        func->ast = (jl_value_t*)oldast; jl_gc_wb(func, oldast);
-    }
-    assert(oldast->head == lambda_sym);
-    jl_array_t *oldargnames = jl_lam_args(oldast);
+    jl_svec_t *sparam_vals = NULL;
+    JL_GC_PUSH3(&ex, &linenum, &sparam_vals);
 
-    size_t nenv = jl_svec_len(env)/2;
-    size_t noa = jl_array_len(oldargnames);
-    if (nenv > 0 && (noa < 2 || jl_cellref(oldargnames,1) != (jl_value_t*)((jl_tvar_t*)jl_svecref(env,0))->name)) {
-        jl_array_t *vi = jl_lam_vinfo(oldast);
-        jl_array_grow_beg(oldargnames, nenv);
-        jl_array_grow_beg(vi, nenv);
-        jl_cellset(oldargnames, 0, jl_cellref(oldargnames, nenv));
-        // prepend static parameter names onto arg list and vinfo list
-        for (size_t i = 0; i < nenv; i++) {
-            jl_sym_t *s = ((jl_tvar_t*)jl_svecref(env, i*2))->name;
-            jl_cellset(oldargnames, i+1, s);
-            jl_array_t *v = jl_alloc_cell_1d(3);
-            jl_cellset(v, 0, s); jl_cellset(v, 1, jl_any_type), jl_cellset(v, 2, jl_box_long(0));
-            jl_cellset(vi, i, v);
-        }
-        // remove sparam list from ast
-        func->sparam_syms = jl_emptysvec;
-        func->sparam_vals = jl_emptysvec;
-        //jl_type_infer(func, jl_anytuple_type, func);  // this doesn't help all that much
-        jl_compile_linfo(func, NULL);
-        jl_generate_fptr(func);
+    sparam_vals = jl_svec_len(env) == 0 ? jl_emptysvec : jl_alloc_svec_uninit(jl_svec_len(env)/2);
+    for (int i = 0; i < jl_svec_len(sparam_vals); i++) {
+        jl_svecset(sparam_vals, i, jl_svecref(env, i * 2 + 1));
     }
+    assert(generator->sparam_vals == jl_emptysvec);
+    assert(jl_svec_len(generator->sparam_syms) == jl_svec_len(sparam_vals));
+    assert(generator->unspecialized == NULL && generator->specTypes == jl_anytuple_type);
+    //if (!generated->inferred)
+    //    jl_type_infer(generator, generator);  // this doesn't help all that much
 
     ex = jl_exprn(lambda_sym, 2);
-    jl_array_t *argnames = jl_alloc_cell_1d(jl_array_len(oldargnames)-nenv);
-    jl_cellset(argnames, 0, jl_cellref(oldargnames,0));
-    for (size_t i = 1; i < jl_array_len(argnames); ++i)
-        jl_cellset(argnames, i, jl_cellref(oldargnames,i+nenv));
+
+    jl_expr_t *generatorast = (jl_expr_t*)generator->ast;
+    if (!jl_is_expr(generatorast))
+        generatorast = (jl_expr_t*)jl_uncompress_ast(generator, (jl_value_t*)generatorast);
+    jl_array_t *argnames = jl_lam_args(generatorast);
     jl_cellset(ex->args, 0, argnames);
+
+    jl_expr_t *scopeblock = jl_exprn(jl_symbol("scope-block"), 1);
+    jl_cellset(ex->args, 1, scopeblock);
+
     jl_expr_t *body = jl_exprn(jl_symbol("block"), 2);
-    jl_cellset(ex->args, 1, body);
-    linenum = jl_box_long(func->line);
-    jl_value_t *linenode = jl_new_struct(jl_linenumbernode_type, m->func->file, linenum);
-    jl_cellset(body->args, 0, linenode);
-    assert(jl_nparams(tt) == jl_array_len(argnames) ||
-           (jl_is_rest_arg(jl_cellref(argnames,jl_array_len(argnames)-1)) &&
-            (jl_nparams(tt) >= jl_array_len(argnames)-1)));
-    {
-        // add static parameter values to beginning of arglist
-        size_t na = nenv + jl_nparams(tt);
-        jl_svec_t *argdata = jl_alloc_svec(na);
-        JL_GC_PUSH1(&argdata);
-        jl_svecset(argdata, 0, jl_tparam(tt, 0));
-        size_t i = 1;
-        for(; i < nenv+1; i++) jl_svecset(argdata, i, jl_svecref(env, (i-1)*2+1));
-        for(; i < na; i++)   jl_svecset(argdata, i, jl_tparam(tt, i-nenv));
-        // invoke code generator
-        jl_cellset(body->args, 1, jl_call_method_internal(func, jl_svec_data(argdata), na));
-        JL_GC_POP();
-    }
-    jl_cellset(ex->args, 1, jl_exprn(jl_symbol("scope-block"), 1));
     jl_cellset(((jl_expr_t*)jl_exprarg(ex,1))->args, 0, body);
-    if (m->tvars != jl_emptysvec) {
+
+    linenum = jl_box_long(generator->line);
+    jl_value_t *linenode = jl_new_struct(jl_linenumbernode_type, generator->file, linenum);
+    jl_cellset(body->args, 0, linenode);
+
+    // invoke code generator
+    assert(jl_nparams(tt) == jl_array_len(argnames) ||
+           (jl_is_rest_arg(jl_cellref(argnames, jl_array_len(argnames)-1)) &&
+            (jl_nparams(tt) >= jl_array_len(argnames) - 1)));
+    jl_cellset(body->args, 1, jl_call_unspecialized(sparam_vals, generator, jl_svec_data(tt->parameters), jl_nparams(tt)));
+
+    if (generator->sparam_syms != jl_emptysvec) {
         // mark this function as having the same static parameters as the generator
-        size_t nsp = jl_is_typevar(m->tvars) ? 1 : jl_svec_len(m->tvars);
-        oldast = jl_exprn(jl_symbol("with-static-parameters"), nsp+1);
-        jl_exprarg(oldast,0) = (jl_value_t*)ex;
+        size_t i, nsp = jl_svec_len(generator->sparam_syms);
+        jl_expr_t *newast = jl_exprn(jl_symbol("with-static-parameters"), nsp + 1);
+        jl_exprarg(newast, 0) = (jl_value_t*)ex;
         // (with-static-parameters func_expr sp_1 sp_2 ...)
-        if (jl_is_typevar(m->tvars)) {
-            jl_exprarg(oldast,1) = (jl_value_t*)((jl_tvar_t*)m->tvars)->name;
-        }
-        else {
-            for(size_t i=0; i < nsp; i++)
-                jl_exprarg(oldast,i+1) = (jl_value_t*)((jl_tvar_t*)jl_svecref(m->tvars,i))->name;
-        }
-        ex = oldast;
+        for (i = 0; i < nsp; i++)
+            jl_exprarg(newast, i+1) = jl_svecref(generator->sparam_syms, i);
+        ex = newast;
     }
     // need to eval macros in the right module, but not give a warning for the `eval` call unless that results in a call to `eval`
-    func = (jl_lambda_info_t*)jl_toplevel_eval_in_warn(m->func->module, (jl_value_t*)ex, 1);
-    func->name = m->func->name;
+    jl_lambda_info_t* func = (jl_lambda_info_t*)jl_toplevel_eval_in_warn(generator->module, (jl_value_t*)ex, 1);
+    func->name = generator->name;
     JL_GC_POP();
     return func;
 }
@@ -1000,7 +1014,7 @@ static jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *
         if (m != (void*)jl_nothing) {
             func = m->func;
             if (m->isstaged)
-                func = jl_instantiate_staged(m,tt,env);
+                func = jl_instantiate_staged(func, tt, env);
             if (!cache) {
                 JL_GC_POP();
                 return func;
@@ -1029,7 +1043,7 @@ static jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *
     }
 
     if (m->isstaged)
-        func = jl_instantiate_staged(m,tt,env);
+        func = jl_instantiate_staged(func, tt, env);
 
     // don't bother computing this if no arguments are tuples
     for(i=0; i < jl_nparams(tt); i++) {
@@ -1321,6 +1335,10 @@ jl_methlist_t *jl_method_table_insert(jl_methtable_t *mt, jl_tupletype_t *type,
 {
     if (jl_svec_len(tvars) == 1)
         tvars = (jl_svec_t*)jl_svecref(tvars,0);
+    if (isstaged) // staged function definitions will be compiled directly. mark them accordingly.
+        method->specTypes = jl_anytuple_type;
+    else // otherwise, the method will be compiled via unspecialized or the method cache, never directly
+        assert(!method->specTypes);
     JL_SIGATOMIC_BEGIN();
     jl_methlist_t *ml = jl_method_list_insert(&mt->defs,type,method,tvars,1,isstaged,(jl_value_t*)mt);
     // invalidate cached methods that overlap this definition
@@ -1533,13 +1551,11 @@ static int _compile_all_tvar_union(jl_methlist_t *meth, jl_tupletype_t *methsig)
                 // usually can create a specialized version of the function,
                 // if the signature is already a leaftype
                 jl_lambda_info_t *spec = jl_get_specialization1(methsig, NULL);
-                if (spec && !jl_has_typevars((jl_value_t*)methsig)) {
+                if (spec) {
                     if (methsig == meth->sig) {
-                        // replace unspecialized func with specialized version
-                        // but if there are no bound type vars (e.g. `call{K,V}(Dict{K,V})` vs `call(Dict)`)
-                        // that might cause a different method to match at runtime
-                        meth->func = spec;
-                        jl_gc_wb(meth, spec);
+                        // replace unspecialized func with newly specialized version
+                        meth->func->unspecialized = spec;
+                        jl_gc_wb(meth->func, spec);
                     }
                     return 1;
                 }
@@ -1682,19 +1698,33 @@ static void _compile_all_deq(jl_array_t *found)
     for (found_i = 0; found_i < found_l; found_i++) {
         jl_printf(JL_STDERR, " %zd / %zd\r", found_i + 1, found_l);
         jl_methlist_t *meth = (jl_methlist_t*)jl_cellref(found, found_i);
+        jl_lambda_info_t *linfo = meth->func;
+
+        if (!linfo)
+            return; // XXX: how does this happen
+        if (!linfo->specTypes)
+            linfo = jl_get_unspecialized(linfo);
+        if (!linfo->inferred) {
+            // force this function to be recompiled
+            jl_type_infer(linfo, linfo);
+            linfo->functionObjects.functionObject = NULL;
+            linfo->functionObjects.specFunctionObject = NULL;
+            linfo->functionObjects.cFunctionList = NULL;
+            linfo->functionID = 0;
+            linfo->specFunctionID = 0;
+        }
 
         // keep track of whether all possible signatures have been cached (and thus whether it can skip trying to compile the unspecialized function)
+        // this is necessary because many intrinsics try to call static_eval and thus are not compilable unspecialized
         int complete = _compile_all_union(meth);
-
         if (complete) {
-            if (!meth->func->functionID)
-                meth->func->functionID = -1; // indicate that this method doesn't need a functionID because it was fully covered above
+            if (!linfo->functionID)
+                // indicate that this method doesn't need a functionID because it was fully covered above
+                linfo->functionID = -1;
         }
         else {
-            if (!meth->func->inferred) // not necessarily valid to run type inference twice (due to inlining a non-gensym into a type_goto, for example), nor is it useful
-                jl_type_infer(meth->func, meth->sig, meth->func);
-            jl_compile_linfo(meth->func, NULL);
-            assert(meth->func->functionID > 0);
+            jl_compile_linfo(linfo, NULL);
+            assert(linfo->functionID > 0);
         }
     }
     jl_printf(JL_STDERR, "\n");
@@ -1703,14 +1733,25 @@ static void _compile_all_deq(jl_array_t *found)
 static void _compile_all_enq_mt(jl_methtable_t *mt, jl_array_t *found);
 static void _compile_all_enq_ml(jl_methlist_t *ml, jl_array_t *found)
 {
-    if (ml == NULL || (jl_value_t*)ml == jl_nothing) return;
-    if (ml->func != NULL && ml->func->fptr == NULL && !ml->func->functionID) {
-        // found a method (not a placeholder guard) that has not been compiled
-        if (!ml->isstaged)
-            jl_cell_1d_push(found, (jl_value_t*)ml);
+    while (ml != NULL && (jl_value_t*)ml != jl_nothing) {
+        if (ml->func != NULL) {
+            // found a method (not a placeholder guard)
+            jl_lambda_info_t *linfo = ml->func;
+            if (!linfo->specTypes) {
+                // method definition -- compile via unspecialized field
+                if (linfo->fptr != NULL)
+                    return; // builtin function
+                linfo = jl_get_unspecialized(linfo);
+            }
+            if (!linfo->functionID || !linfo->inferred) {
+                // and it still needs to be compiled
+                if (!ml->isstaged)
+                    jl_cell_1d_push(found, (jl_value_t*)ml);
+            }
+        }
+        _compile_all_enq_mt(ml->invokes, found);
+        ml = ml->next;
     }
-    _compile_all_enq_mt(ml->invokes, found);
-    _compile_all_enq_ml(ml->next, found);
 }
 
 static void _compile_all_enq_mt(jl_methtable_t *mt, jl_array_t *found)
@@ -1840,11 +1881,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
         if (mfunc->inInference || mfunc->inCompile) {
             // if inference is running on this function, return a copy
             // of the function to be compiled without inference and run.
-            if (mfunc->unspecialized == NULL) {
-                mfunc->unspecialized = jl_add_static_parameters(mfunc, mfunc->sparam_vals, jl_anytuple_type);
-                jl_gc_wb(mfunc, mfunc->unspecialized);
-            }
-            return verify_type(jl_call_method_internal(mfunc->unspecialized, args, nargs));
+            return verify_type(jl_call_unspecialized(mfunc->sparam_vals, jl_get_unspecialized(mfunc), args, nargs));
         }
         assert(!mfunc->inInference);
         return verify_type(jl_call_method_internal(mfunc, args, nargs));
@@ -1938,12 +1975,8 @@ jl_value_t *jl_gf_invoke(jl_tupletype_t *types0, jl_value_t **args, size_t nargs
         if (mfunc->inInference || mfunc->inCompile) {
             // if inference is running on this function, return a copy
             // of the function to be compiled without inference and run.
-            if (mfunc->unspecialized == NULL) {
-                mfunc->unspecialized = jl_add_static_parameters(mfunc, mfunc->sparam_vals, jl_anytuple_type);
-                jl_gc_wb(mfunc, mfunc->unspecialized);
-            }
             JL_GC_POP();
-            return jl_call_method_internal(mfunc->unspecialized, args, nargs);
+            return jl_call_unspecialized(mfunc->sparam_vals, jl_get_unspecialized(mfunc), args, nargs);
         }
     }
     else {
@@ -2043,7 +2076,9 @@ void jl_add_method_to_table(jl_methtable_t *mt, jl_tupletype_t *types, jl_lambda
     jl_sym_t *n = mt->name;
     if (meth->name != anonymous_sym && meth->name != n) {
         // already used by another GF; make a copy (issue #10373)
-        meth = jl_add_static_parameters(meth, meth->sparam_vals, NULL);
+        assert(meth->sparam_vals == jl_emptysvec);
+        meth = jl_add_static_parameters(meth, jl_emptysvec, NULL);
+        meth->unspecialized = NULL;
     }
     meth->name = n;
     (void)jl_method_table_insert(mt, types, meth, tvars, isstaged);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -37,7 +37,7 @@ JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
     jl_value_t **locals = (jl_value_t**)alloca(sizeof(jl_value_t*) * 2 * nl);
     for (i = 0; i < nl; i++) {
         locals[2 * i] = jl_svecref(local_syms, i);
-        locals[2 * i + 1] = jl_svecref(local_vals, i);
+        locals[2 * i + 1] = jl_svec_len(local_vals) > 0 ? jl_svecref(local_vals, i) : NULL;
     }
     JL_TRY {
         jl_current_task->current_module = jl_current_module = m;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -27,12 +27,18 @@ jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e)
 
 JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
                                                        jl_value_t *e,
-                                                       jl_value_t **locals,
-                                                       size_t nl)
+                                                       jl_svec_t *local_syms,
+                                                       jl_svec_t *local_vals)
 {
     jl_value_t *v=NULL;
     jl_module_t *last_m = jl_current_module;
     jl_module_t *task_last_m = jl_current_task->current_module;
+    size_t i, nl = jl_svec_len(local_syms);
+    jl_value_t **locals = (jl_value_t**)alloca(sizeof(jl_value_t*) * 2 * nl);
+    for (i = 0; i < nl; i++) {
+        locals[2 * i] = jl_svecref(local_syms, i);
+        locals[2 * i + 1] = jl_svecref(local_vals, i);
+    }
     JL_TRY {
         jl_current_task->current_module = jl_current_module = m;
         v = eval(e, locals, nl, 0);
@@ -68,8 +74,6 @@ jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
         jl_undefined_var_error(e);
     return v;
 }
-
-int jl_has_intrinsics(jl_expr_t *ast, jl_expr_t *e, jl_module_t *m);
 
 extern int jl_boot_file_loaded;
 extern int inside_typedef;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -360,8 +360,8 @@ static jl_value_t *staticeval_bitstype(jl_value_t *targ, const char *fname, jl_c
     else {
         JL_TRY { // TODO: change this to an actual call to staticeval rather than actually executing code
             bt = jl_interpret_toplevel_expr_in(ctx->module, targ,
-                                               jl_svec_data(ctx->sp),
-                                               jl_svec_len(ctx->sp)/2);
+                                               ctx->linfo->sparam_syms,
+                                               ctx->linfo->sparam_vals);
         }
         JL_CATCH {
             bt = NULL;

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -188,7 +188,10 @@ static void add_intrinsic(jl_module_t *inm, const char *name, enum intrinsic f)
     jl_module_export(inm, sym);
 }
 
-extern "C" jl_value_t *jl_mk_builtin_func(const char *name, jl_fptr_t fptr);
+#ifdef __cplusplus
+extern "C"
+#endif
+jl_value_t *jl_mk_builtin_func(const char *name, jl_fptr_t fptr);
 
 #ifdef __cplusplus
 extern "C"

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3478,7 +3478,8 @@ void jl_init_types(void)
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaStaticData"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(14, jl_symbol("ast"), jl_symbol("sparams"),
+                        jl_svec(15, jl_symbol("ast"),
+                                jl_symbol("sparam_syms"), jl_symbol("sparam_vals"),
                                 jl_symbol("tfunc"), jl_symbol("name"),
                                 jl_symbol("roots"),
                                 /* jl_symbol("specTypes"),
@@ -3489,14 +3490,15 @@ void jl_init_types(void)
                                 jl_symbol("file"), jl_symbol("line"),
                                 jl_symbol("inferred"),
                                 jl_symbol("pure")),
-                        jl_svec(14, jl_any_type, jl_simplevector_type,
+                        jl_svec(15, jl_any_type,
+                                jl_simplevector_type, jl_simplevector_type,
                                 jl_any_type, jl_sym_type,
                                 jl_any_type, jl_any_type,
                                 jl_any_type, jl_array_any_type,
                                 jl_module_type, jl_any_type,
                                 jl_sym_type, jl_int32_type,
                                 jl_bool_type, jl_bool_type),
-                        0, 1, 4);
+                        0, 1, 5);
 
     jl_typector_type =
         jl_new_datatype(jl_symbol("TypeConstructor"),

--- a/src/julia.h
+++ b/src/julia.h
@@ -300,9 +300,9 @@ typedef struct _jl_lambda_info_t {
     uint8_t called;  // bit flags: whether each of the first 8 arguments is called
 
     // hidden fields:
-    // flag telling if inference is running on this function
-    // used to avoid infinite recursion
-    uint8_t inInference : 1;
+    uint8_t jlcall_api : 1;     // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t
+    uint8_t inInference : 1;    // flags to tell if inference is running on this function
+                                // used to avoid infinite recursion
     uint8_t inCompile : 1;
     jl_fptr_t fptr;             // jlcall entry point
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -279,8 +279,9 @@ typedef struct _jl_lambda_info_t {
     // this is the stuff that's shared among different instantiations
     // (different environments) of a closure.
     jl_value_t *ast;
-    // sparams is a vector (symbol, value, symbol, value, ...)
-    jl_svec_t *sparams;
+    // sparams is a vector of values indexed by symbols
+    jl_svec_t *sparam_syms;
+    jl_svec_t *sparam_vals;
     jl_value_t *tfunc;
     jl_sym_t *name;  // for error reporting
     jl_array_t *roots;  // pointers in generated code
@@ -1028,6 +1029,7 @@ JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
 JL_DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t proc, jl_value_t *env,
                                            jl_lambda_info_t *li);
 JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast,
+                                                  jl_svec_t *tvars,
                                                   jl_svec_t *sparams,
                                                   jl_module_t *ctx);
 JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...);
@@ -1323,15 +1325,15 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex
 JL_DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len);
 JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
                                                        jl_value_t *e,
-                                                       jl_value_t **locals,
-                                                       size_t nl);
+                                                       jl_svec_t *local_syms,
+                                                       jl_svec_t *local_vals);
 JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m);
 
 // AST access
 JL_DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast);
 JL_DLLEXPORT int jl_is_rest_arg(jl_value_t *ex);
 
-JL_DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams);
+JL_DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li);
 JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr);
 
 JL_DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast);

--- a/src/julia.h
+++ b/src/julia.h
@@ -260,6 +260,7 @@ STATIC_INLINE int jl_array_ndimwords(uint32_t ndims)
 }
 
 typedef jl_value_t *(*jl_fptr_t)(jl_value_t*, jl_value_t**, uint32_t);
+typedef jl_value_t *(*jl_fptr_sparam_t)(jl_svec_t*, jl_value_t*, jl_value_t**, uint32_t);
 
 typedef struct _jl_datatype_t jl_tupletype_t;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -59,19 +59,10 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_val
         jl_compile_linfo(meth, NULL);
         jl_generate_fptr(meth);
     }
-    jl_fptr_t fptr = meth->fptr;
-    uintptr_t fptr_int = (uintptr_t)fptr;
-    uintptr_t mask = 1;
-    if (__likely((fptr_int & mask) == 0))
-        return fptr(args[0], &args[1], nargs-1);
+    if (meth->jlcall_api == 0)
+        return meth->fptr(args[0], &args[1], nargs-1);
     else
-        return ((jl_fptr_sparam_t)(fptr_int & ~mask))(meth->sparam_vals, args[0], &args[1], nargs-1);
-
-
-    if (__likely((((uintptr_t)fptr) & 1) == 0))
-        return fptr(args[0], &args[1], nargs-1);
-    else
-        return ((jl_fptr_sparam_t)fptr)(meth->sparam_vals, args[0], &args[1], nargs-1);
+        return ((jl_fptr_sparam_t)meth->fptr)(meth->sparam_vals, args[0], &args[1], nargs-1);
 }
 
 jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -55,11 +55,23 @@ void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx);
 // invoke (compiling if necessary) the jlcall function pointer for a method
 STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_value_t **args, uint32_t nargs)
 {
-    if (meth->fptr == NULL) {
+    if (__unlikely(meth->fptr == NULL)) {
         jl_compile_linfo(meth, NULL);
         jl_generate_fptr(meth);
     }
-    return meth->fptr(args[0], &args[1], nargs-1);
+    jl_fptr_t fptr = meth->fptr;
+    uintptr_t fptr_int = (uintptr_t)fptr;
+    uintptr_t mask = 1;
+    if (__likely((fptr_int & mask) == 0))
+        return fptr(args[0], &args[1], nargs-1);
+    else
+        return ((jl_fptr_sparam_t)(fptr_int & ~mask))(meth->sparam_vals, args[0], &args[1], nargs-1);
+
+
+    if (__likely((((uintptr_t)fptr) & 1) == 0))
+        return fptr(args[0], &args[1], nargs-1);
+    else
+        return ((jl_fptr_sparam_t)fptr)(meth->sparam_vals, args[0], &args[1], nargs-1);
 }
 
 jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -196,9 +196,9 @@ jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e);
 jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
                            jl_lambda_info_t *li, int sparams, int allow_alloc);
 int jl_is_toplevel_only_expr(jl_value_t *e);
-void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes,
-                   jl_lambda_info_t *def);
+void jl_type_infer(jl_lambda_info_t *li, jl_lambda_info_t *def);
 
+jl_lambda_info_t *jl_get_unspecialized(jl_lambda_info_t *method);
 jl_lambda_info_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *types,
                                            int cache, int inexact);
 jl_lambda_info_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache);
@@ -216,6 +216,7 @@ jl_expr_t *jl_lam_body(jl_expr_t *l);
 int jl_local_in_linfo(jl_lambda_info_t *linfo, jl_sym_t *sym);
 jl_value_t *jl_first_argument_datatype(jl_value_t *argtypes);
 jl_value_t *jl_preresolve_globals(jl_value_t *expr, jl_lambda_info_t *lam);
+int jl_has_intrinsics(jl_lambda_info_t *li, jl_expr_t *e, jl_module_t *m);
 
 void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super);
 void jl_add_constructors(jl_datatype_t *t);
@@ -270,7 +271,6 @@ int32_t jl_get_llvm_gv(jl_value_t *p);
 void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
 
 jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
-jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp, jl_tupletype_t *types);
 jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types, void *cyclectx);
 jl_function_t *jl_module_get_initializer(jl_module_t *m);
 uint32_t jl_module_next_counter(jl_module_t *m);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -182,8 +182,7 @@ jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
                                              jl_value_t **loc, size_t nl);
 jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e);
 jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
-                           jl_value_t *sp, jl_expr_t *ast, int sparams,
-                           int allow_alloc);
+                           jl_lambda_info_t *li, int sparams, int allow_alloc);
 int jl_is_toplevel_only_expr(jl_value_t *e);
 void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes,
                    jl_lambda_info_t *def);
@@ -202,8 +201,7 @@ jl_array_t *jl_lam_staticparams(jl_expr_t *l);
 jl_sym_t *jl_lam_argname(jl_lambda_info_t *li, int i);
 int jl_lam_vars_captured(jl_expr_t *ast);
 jl_expr_t *jl_lam_body(jl_expr_t *l);
-int jl_in_vinfo_array(jl_array_t *a, jl_sym_t *v);
-int jl_local_in_ast(jl_expr_t *ast, jl_sym_t *sym);
+int jl_local_in_linfo(jl_lambda_info_t *linfo, jl_sym_t *sym);
 jl_value_t *jl_first_argument_datatype(jl_value_t *argtypes);
 jl_value_t *jl_preresolve_globals(jl_value_t *expr, jl_lambda_info_t *lam);
 

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -57,24 +57,15 @@ JL_DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n)
     return jv;
 }
 
-JL_DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b)
+JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a)
 {
-    jl_svec_t *c = jl_alloc_svec_uninit(jl_svec_len(a) + jl_svec_len(b));
+    jl_svec_t *c = jl_alloc_svec_uninit(jl_svec_len(a));
     size_t i=0, j;
     for(j=0; j < jl_svec_len(a); j++) {
         jl_svecset(c, i, jl_svecref(a,j));
         i++;
     }
-    for(j=0; j < jl_svec_len(b); j++) {
-        jl_svecset(c, i, jl_svecref(b,j));
-        i++;
-    }
     return c;
-}
-
-JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a)
-{
-    return jl_svec_append(a, jl_emptysvec);
 }
 
 JL_DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x)

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -242,21 +242,21 @@ JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m)
     return jl_top_module;
 }
 
-int jl_has_intrinsics(jl_expr_t *ast, jl_expr_t *e, jl_module_t *m)
+static int jl_has_intrinsics(jl_lambda_info_t *li, jl_expr_t *e, jl_module_t *m)
 {
     if (jl_array_len(e->args) == 0)
         return 0;
     if (e->head == static_typeof_sym) return 1;
     jl_value_t *e0 = jl_exprarg(e,0);
     if (e->head == call_sym) {
-        jl_value_t *sv = jl_static_eval(e0, NULL, m, (jl_value_t*)jl_emptysvec, ast, 0, 0);
+        jl_value_t *sv = jl_static_eval(e0, NULL, m, li, 0, 0);
         if (sv && jl_typeis(sv, jl_intrinsic_type))
             return 1;
     }
     int i;
     for(i=0; i < jl_array_len(e->args); i++) {
         jl_value_t *a = jl_exprarg(e,i);
-        if (jl_is_expr(a) && jl_has_intrinsics(ast, (jl_expr_t*)a, m))
+        if (jl_is_expr(a) && jl_has_intrinsics(li, (jl_expr_t*)a, m))
             return 1;
     }
     return 0;
@@ -264,7 +264,7 @@ int jl_has_intrinsics(jl_expr_t *ast, jl_expr_t *e, jl_module_t *m)
 
 // heuristic for whether a top-level input should be evaluated with
 // the compiler or the interpreter.
-int jl_eval_with_compiler_p(jl_expr_t *ast, jl_expr_t *expr, int compileloops, jl_module_t *m)
+static int jl_eval_with_compiler_p(jl_lambda_info_t *li, jl_expr_t *expr, int compileloops, jl_module_t *m)
 {
     assert(jl_is_expr(expr));
     if (expr->head==body_sym && compileloops) {
@@ -308,7 +308,7 @@ int jl_eval_with_compiler_p(jl_expr_t *ast, jl_expr_t *expr, int compileloops, j
             }
         }
     }
-    if (jl_has_intrinsics(ast, expr, m)) return 1;
+    if (jl_has_intrinsics(li, expr, m)) return 1;
     return 0;
 }
 
@@ -520,7 +520,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
             thk->ast = jl_uncompress_ast(thk, thk->ast);
             jl_gc_wb(thk, thk->ast);
         }
-        ewc = jl_eval_with_compiler_p((jl_expr_t*)thk->ast, jl_lam_body((jl_expr_t*)thk->ast), fast, jl_current_module);
+        ewc = jl_eval_with_compiler_p(thk, jl_lam_body((jl_expr_t*)thk->ast), fast, jl_current_module);
     }
     else {
         if (head && jl_eval_with_compiler_p(NULL, (jl_expr_t*)ex, fast, jl_current_module)) {
@@ -781,6 +781,31 @@ jl_value_t *jl_first_argument_datatype(jl_value_t *argtypes)
     return (jl_value_t*)first_arg_datatype(argtypes, 0);
 }
 
+static jl_lambda_info_t* expr_to_lambda(jl_lambda_info_t *f)
+{
+    // this occurs when there is a closure being added to an out-of-scope function
+    // the user should only do this at the toplevel
+    // the result is that the closure variables get interpolated directly into the AST
+    jl_svec_t *tvar_syms = NULL;
+    JL_GC_PUSH2(&f, &tvar_syms);
+    assert(jl_is_expr(f) && ((jl_expr_t*)f)->head == lambda_sym);
+    // move tvar symbol array from args[1][4] to linfo
+    jl_array_t *le = (jl_array_t*)jl_exprarg(f, 1);
+    assert(jl_is_array(le) && jl_array_len(le) == 4);
+    jl_array_t *tvar_syms_arr = (jl_array_t*)jl_cellref(le, 3);
+    jl_array_del_end(le, 1);
+    size_t i, l = jl_array_len(tvar_syms_arr);
+    tvar_syms = jl_alloc_svec_uninit(l);
+    for (i = 0; i < l; i++) {
+        jl_svecset(tvar_syms, i, jl_arrayref(tvar_syms_arr, i));
+    }
+    // wrap in a LambdaInfo
+    f = jl_new_lambda_info((jl_value_t*)f, tvar_syms, jl_emptysvec, jl_current_module);
+    jl_preresolve_globals(f->ast, f);
+    JL_GC_POP();
+    return f;
+}
+
 JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_lambda_info_t *f, jl_value_t *isstaged)
 {
     // argdata is svec({types...}, svec(typevars...))
@@ -790,11 +815,8 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_lambda_info_t *f, jl_valu
     jl_sym_t *name;
     JL_GC_PUSH1(&f);
 
-    if (!jl_is_lambda_info(f)) {
-        assert(jl_is_expr(f) && ((jl_expr_t*)f)->head == lambda_sym);
-        f = jl_new_lambda_info((jl_value_t*)f, jl_emptysvec, jl_current_module);
-        jl_preresolve_globals(f->ast, f);
-    }
+    if (!jl_is_lambda_info(f))
+        f = expr_to_lambda(f);
 
     assert(jl_is_lambda_info(f));
     assert(jl_is_tuple_type(argtypes));

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -242,7 +242,7 @@ JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m)
     return jl_top_module;
 }
 
-static int jl_has_intrinsics(jl_lambda_info_t *li, jl_expr_t *e, jl_module_t *m)
+int jl_has_intrinsics(jl_lambda_info_t *li, jl_expr_t *e, jl_module_t *m)
 {
     if (jl_array_len(e->args) == 0)
         return 0;
@@ -542,9 +542,10 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
         }
     }
 
+    thk->specTypes = (jl_tupletype_t*)jl_typeof(jl_emptytuple); // no gc_wb needed
     if (ewc) {
         if (!jl_in_inference) {
-            jl_type_infer(thk, (jl_tupletype_t*)jl_typeof(jl_emptytuple), thk);
+            jl_type_infer(thk, thk);
         }
         jl_value_t *dummy_f_arg=NULL;
         result = jl_call_method_internal(thk, &dummy_f_arg, 1);


### PR DESCRIPTION
(note: this is against the jb/functions branch PR)

this simplifies the implementation of sparams (by always keeping them with the LambdaInfo and adding a calling convention such that they can be passed directly) and then unspecialized (since there's less need for it to be sparam-aware) and also instantiate_staged (since there's no need for it to edit the ast following the changes to sparams). From one measurement, this appeared to result in a net 0.5% reduction in sysimg size.

this also includes improvements to the `--compile=all` algorithm to be able to handle some changes to Base in the past month.
