### PR TITLE
added pmap method for arrays, with type/shape of result the same as map

### DIFF
--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -424,6 +424,22 @@ function test_map(::Type{TestAbstractArray})
     @test map(f, Int[], Int[], Complex{Int}[]) == Number[]
 end
 
+#test pmap array methods for compatibility with map array methods
+A = B = C = 1:8
+#single arg
+mA,mpA = map(string,A), pmap(string,A)
+@test mA == mpA
+@test typeof(mA) == typeof(mpA)
+#double arg
+mAB,mpAB = map(string,A,B), pmap(string,A,B)
+@test mAB == mpAB
+@test typeof(mAB) == typeof(mpAB)
+#n arg
+mABC,mpABC = map(string,A,B,C), pmap(string,A,B,C)
+@test mABC == mpABC
+@test typeof(mABC) == typeof(mpABC)
+
+
 function test_map_promote(::Type{TestAbstractArray})
     A = [1:10...]
     f(x) = iseven(x) ? 1.0 : 1


### PR DESCRIPTION
Implements array methods for `pmap` so that the shape and eltype of return type are the same as those from `map` (see issue #14265). 

Example:

``` julia
julia> a = rand(2,2)
2x2 Array{Float64,2}:
 0.745134  0.94089 
 0.382871  0.809724

julia> b = map(abs,a)
2x2 Array{Float64,2}:
 0.745134  0.94089 
 0.382871  0.809724

julia> c = pmap(abs,a)
2x2 Array{Float64,2}:
 0.745134  0.94089 
 0.382871  0.809724
```

Further tests for n-ary functions in PR body.
