### PR TITLE
Fix rendering bug of Markdown Code.

### DIFF
--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -20,9 +20,12 @@ function plain{l}(io::IO, header::Header{l})
 end
 
 function plain(io::IO, code::Code)
-    println(io, "```", code.language)
+    # If the code includes a fenced block this will break parsing,
+    # so it must be enclosed by a longer ````-sequence.
+    n = mapreduce(length, max, 2, matchall(r"^`+"m, code.code)) + 1
+    println(io, "`" ^ n, code.language)
     println(io, code.code)
-    println(io, "```")
+    println(io, "`" ^ n)
 end
 
 function plain(io::IO, p::Paragraph)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -47,6 +47,14 @@ foo
 ```
 """ == MD(LaTeX("..."))
 
+code_in_code = md"""
+````
+```
+````
+"""
+@test code_in_code == MD(Code("```"))
+@test plain(code_in_code) == "````\n```\n````\n"
+
 @test md"A footnote [^foo]." == MD(Paragraph(["A footnote ", Footnote("foo", nothing), "."]))
 
 @test md"[^foo]: footnote" == MD(Paragraph([Footnote("foo", Any[" footnote"])]))


### PR DESCRIPTION
When a code block included a ```, it would not be rendered correctly.

cc @MichaelHatherly
