### PR TITLE
Remove incorrect implementation of findin on range

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -863,19 +863,6 @@ function indexin(a::AbstractArray, b::AbstractArray)
     [get(bdict, i, 0) for i in a]
 end
 
-# findin (the index of intersection)
-function findin(a, b::UnitRange)
-    ind = Array(Int, 0)
-    f = first(b)
-    l = last(b)
-    for i = 1:length(a)
-        if f <= a[i] <= l
-            push!(ind, i)
-        end
-    end
-    ind
-end
-
 function findin(a, b)
     ind = Array(Int, 0)
     bset = Set(b)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -45,6 +45,8 @@ r = 5:-1:1
 @test isempty((1:4)[5:4])
 @test_throws BoundsError (1:10)[8:-1:-2]
 
+@test findin([5.2, 3.3], 3:20) == findin([5.2, 3.3], collect(3:20))
+
 let
     span = 5:20
     r = -7:3:42


### PR DESCRIPTION
Implements the correct behavior for findin when second argument is a UnitRange (see issue #14004). The strategy is to remove the current (incorrect) `findin(a, b::UnitRange)` method wand to modify the general `findin(a, b)` method through:

``` julia
-    bset = Set(b)
+    bset = unique(b)
```

Rationale:
For `a` of length `N` and `b` with `k` unique elements the total complexity in the worst case looping through the elements of `a` will be `O(Nk)` term. However, if elements in `b` can be looked up in less than `O(k)` the total cost can be decreased. In particular for ranges if one adds the methods

``` julia
Base.unique{T}(b::Range{T}) = b
```

then checking for inclusion in `b` will cost `O(1)`, so that the total cost of `findin` becomes `O(N)`, which is the lower bound. This is the justification for replace the call to `Set` with a call to `unique` above, as optimized uniques will improve the performance without the need for extra methods. 

Incidentally, there is quite a bit of low lying fruit with respect to optimizing `unique` methods, and I will open up a separate issue/PR for this (but I don't see that as holding up this PR, which is principally about correctness rather than performance). 
