### PR TITLE
use li->roots instead of module constant table

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1711,10 +1711,6 @@ NOINLINE static int gc_mark_module(jl_module_t *m, int d)
     for(i=0; i < m->usings.len; i++) {
         refyoung |= gc_push_root(m->usings.items[i], d);
     }
-    if (m->constant_table) {
-        verify_parent1("module", m, &m->constant_table, "constant_table");
-        refyoung |= gc_push_root(m->constant_table, d);
-    }
 
     if (m->parent) {
         refyoung |= gc_push_root(m->parent, d);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1812,12 +1812,6 @@ static void _compile_all_enq(jl_value_t *v, htable_t *h, jl_array_t *found, jl_f
                     }
                 }
             }
-            if (m->constant_table != NULL) {
-                for(i=0; i < jl_array_len(m->constant_table); i++) {
-                    jl_value_t *v = jl_cellref(m->constant_table, i);
-                    _compile_all_enq(v, h, found, 0);
-                }
-            }
         }
         jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(v);
         size_t i, nf = jl_datatype_nfields(dt);

--- a/src/julia.h
+++ b/src/julia.h
@@ -442,7 +442,6 @@ typedef struct _jl_module_t {
     struct _jl_module_t *parent;
     htable_t bindings;
     arraylist_t usings;  // modules with all bindings potentially imported
-    jl_array_t *constant_table;
     jl_function_t *call_func;  // cached lookup of `call` within this module
     uint8_t istopmod;
     uint8_t std_imports;  // only for temporarily deprecating `importall Base.Operators`

--- a/src/module.c
+++ b/src/module.c
@@ -25,7 +25,6 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     assert(jl_is_symbol(name));
     m->name = name;
     m->parent = NULL;
-    m->constant_table = NULL;
     m->call_func = NULL;
     m->istopmod = 0;
     m->std_imports = 0;


### PR DESCRIPTION
Looking at #14556, I experimented with (1) disabling AST compression, and (2) returning constant tables to per-function instead of per-module. Here is the data:

|  | sysimg | tests | peak mem |
| --- | --- | --- | --- |
| master | 29.49MB | 1788 s | 975MB |
| no compression | 30.07MB | 1787 s | 1669MB |
| li->roots | 29.83MB | 1547 s | 911MB |

With the new GC, AST compression is not as crucial as it used to be. Performance is on par (some things were faster and some were slower) but memory use is way higher. However using function-local constant tables wins hands-down by removing most of the O(n^2) constant lookup while retaining the benefits of compression. The only benefit of per-module constant tables is system image size, but not by much. Also I suspect if the common symbols lists were recomputed for the no-compression case its system image would improve a lot.

The subarray test accounts for almost all of the improvement; it got ~100s faster. In that test the constant tables are huge, and consist almost entirely of types. In the no-compression case the subarray test is also 100s faster than master.

So for now I recommend ripping out the per-module constant table since it's an easy win. Long term, we should get rid of AST compression by addressing memory use in that case. Ideas there:
- Replace all remaining Exprs in our IR with more compact specialized objects.
- Delete more ASTs. There can be heuristics for ASTs not likely to be needed. For example specialized ASTs too big to be inlined (and not declared inline).
- Or... switch to a bytecode representation. Most efficient but difficult to do.
