### PR TITLE
Fix compilation on llvm-svn due to function renaming

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -863,12 +863,20 @@ struct math_builder {
              jl_options.fast_math == JL_OPTIONS_FAST_MATH_ON)) {
             FastMathFlags fmf;
             fmf.setUnsafeAlgebra();
+#ifdef LLVM38
+            builder.setFastMathFlags(fmf);
+#else
             builder.SetFastMathFlags(fmf);
+#endif
         }
     }
     IRBuilder<>& operator()() const { return builder; }
     ~math_builder() {
+#ifdef LLVM38
+        builder.setFastMathFlags(old_fmf);
+#else
         builder.SetFastMathFlags(old_fmf);
+#endif
     }
 };
 


### PR DESCRIPTION
Ref https://github.com/llvm-mirror/llvm/commit/bd8623ae5cb0b73620e7bc5a15226feb722fd424 .

Happened to compile a llvm a few hours after that commit..... Tested on AArch64 (where I need llvm-svn).

c.c. @Keno 
