### PR TITLE
Don't fool the compiler about variable initialization

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -301,7 +301,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams,
         (jl_lambda_info_t*)newobj((jl_value_t*)jl_lambda_info_type,
                                   NWORDS(sizeof(jl_lambda_info_t)));
     li->ast = ast;
-    li->rettype = jl_any_type;
+    li->rettype = (jl_value_t*)jl_any_type;
     li->file = null_sym;
     li->line = 0;
     li->pure = 0;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4675,7 +4675,7 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
     ctx.dbuilder = &dbuilder;
 #ifdef LLVM37
     DIFile *topfile = NULL;
-    DISubprogram *SP;
+    DISubprogram *SP = NULL;
     DICompileUnit *CU;
 #else
     DIFile topfile;
@@ -4697,7 +4697,6 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
         ctx.debug_enabled = false;
         do_coverage = false;
         do_malloc_log = false;
-        JL_MARK_INITIALIZED(SP);
     }
     else {
         // TODO: Fix when moving to new LLVM version

--- a/src/julia.h
+++ b/src/julia.h
@@ -46,16 +46,13 @@ extern "C" {
 #if defined(__GNUC__)
 #  define JL_NORETURN __attribute__ ((noreturn))
 #  define JL_CONST_FUNC __attribute__((const))
-#  define JL_MARK_INITIALIZED(var) asm("" : "=rm" (var))
 #elif defined(_COMPILER_MICROSOFT_)
 #  define JL_NORETURN __declspec(noreturn)
 // This is the closest I can find for __attribute__((const))
 #  define JL_CONST_FUNC __declspec(noalias)
-#  define JL_MARK_INITIALIZED(var) do {} while (0)
 #else
 #  define JL_NORETURN
 #  define JL_CONST_FUNC
-#  define JL_MARK_INITIALIZED(var) do {} while (0)
 #endif
 
 #define container_of(ptr, type, member) \


### PR DESCRIPTION
It can easily break if any change is made to the code and incorrectly suppress the compiler warning.

Revert #14403. Close #14595

Also fixes a simple compiler warning introduced just now in https://github.com/JuliaLang/julia/commit/fb8c6e956898cf8acb76d0d5c4301c8773845e3b

c.c. @kshyatt 
