### PR TITLE
Make sure OSLIBS are always linked

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -800,7 +800,7 @@ else ifneq ($(USEMSVC), 1)
 endif
 
 ifeq ($(OS), Linux)
-OSLIBS += -ldl -lrt -lpthread -Wl,--export-dynamic -Wl,--no-whole-archive $(LIBUNWIND)
+OSLIBS += -Wl,--no-as-needed -ldl -lrt -lpthread -Wl,--export-dynamic,--as-needed,--no-whole-archive $(LIBUNWIND)
 ifneq ($(SANITIZE),1)
 ifneq ($(SANITIZE_MEMORY),1)
 ifneq ($(LLVM_SANITIZE),1)


### PR DESCRIPTION
Even when `-Wl,--as-needed` is in `LDFLAGS` on Linux. I believe this is the default on many Linux distributions now. Another way is to always specify the library in `ccall` or always use our own wrappers, but I think just adding the linker flag is less verbose and is less likely to fail when adding new functions to `Base`.

This causes the `parallel` test to fail on AArch64 with glibc 2.22 since apparently all the `librt` functions we use in `libjulia.so` are actually all defined in `libc` there. Therefore `librt` is not needed or linked and `dlopen` is not able to find `shm_link` (for `SharedArray` creation).

Tested locally on `x86_64` ArchLinux and `AArch64` ArchLinux:

Buildbots runs on the commit:
http://buildbot.e.ip.saba.us:8010/builders/build_centos7.1-x64/builds/134
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu12.04-x64/builds/130
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu12.04-x86/builds/132
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu14.04-x64/builds/131
http://buildbot.e.ip.saba.us:8010/builders/build_ubuntu14.04-x86/builds/129
