### PR TITLE
parse(IPAddr, str): use the generic parse function for IP parsing

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -960,3 +960,5 @@ macro boundscheck(yesno,blk)
         :(@inbounds $(esc(blk)))
     end
 end
+
+@deprecate parseip(str::AbstractString) parse(IPAddr, str)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4049,13 +4049,6 @@ itself). For matrices, returns an identity matrix of the appropriate size and ty
 one
 
 """
-    parseip(addr)
-
-Parse a string specifying an IPv4 or IPv6 ip address.
-"""
-parseip
-
-"""
     rationalize([Type=Int,] x; tol=eps(x))
 
 Approximate floating point number `x` as a Rational number with components of the given

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1121,9 +1121,9 @@ export
 
 # IP address stuff
     @ip_str,
+    IPAddr,
     IPv4,
     IPv6,
-    parseip,
 
 # I/O and events
     accept,

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -30,7 +30,7 @@ function init_bind_addr()
     opts = JLOptions()
     if opts.bindto != C_NULL
         bind_to = split(bytestring(opts.bindto), ":")
-        bind_addr = string(parseip(bind_to[1]))
+        bind_addr = string(parse(IPAddr, bind_to[1]))
         if length(bind_to) > 1
             bind_port = parse(Int,bind_to[2])
         else

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -389,7 +389,7 @@ function connect_to_worker(host::AbstractString, port::Integer)
         bind_addr = "127.0.0.1"
     else
         try
-            bind_addr = string(parseip(host))
+            bind_addr = string(parse(IPAddr,host))
         catch
             bind_addr = string(getaddrinfo(host))
         end

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -32,7 +32,7 @@ function IPv4(host::Integer)
 end
 
 # constructor: ("1.2.3.4")
-IPv4(ipstr::AbstractString) = parseipv4(ipstr)
+IPv4(str::AbstractString) = parse(IPv4, str)
 
 show(io::IO,ip::IPv4) = print(io,"ip\"",ip,"\"")
 print(io::IO,ip::IPv4) = print(io,dec((ip.host&(0xFF000000))>>24),".",
@@ -75,7 +75,7 @@ function IPv6(host::Integer)
     end
 end
 
-IPv6(ipstr::AbstractString) = parseipv6(ipstr)
+IPv6(str::AbstractString) = parse(IPv6, str)
 
 # Suppress leading '0's and "0x"
 print_ipv6_field(io,field::UInt16) = print(io,hex(field))
@@ -138,7 +138,7 @@ end
 
 # Parsing
 
-function parseipv4(str)
+function parse(::Type{IPv4}, str::AbstractString)
     fields = split(str,'.')
     i = 1
     ret = 0
@@ -199,7 +199,7 @@ function parseipv6fields(fields,num_fields)
 end
 parseipv6fields(fields) = parseipv6fields(fields,8)
 
-function parseipv6(str)
+function parse(::Type{IPv6}, str::AbstractString)
     fields = split(str,':')
     if length(fields) > 8
         throw(ArgumentError("too many fields in IPv6 address"))
@@ -207,7 +207,7 @@ function parseipv6(str)
         return IPv6(parseipv6fields(fields))
     elseif in('.',fields[end])
         return IPv6((parseipv6fields(fields[1:(end-1)],6))
-            | parseipv4(fields[end]).host )
+            | parse(IPv4, fields[end]).host )
     else
         return IPv6(parseipv6fields(fields))
     end
@@ -219,18 +219,16 @@ end
 # of the appropriate size and should use the appropriate constructor
 #
 
-function parseip(str)
-    if in(':',str)
-        # IPv6 Address
-        return parseipv6(str)
+function parse(::Type{IPAddr}, str::AbstractString)
+    if ':' in str
+        return parse(IPv6, str)
     else
-        # IPv4 Address
-        return parseipv4(str)
+        return parse(IPv4, str)
     end
 end
 
 macro ip_str(str)
-    return parseip(str)
+    return parse(IPAddr, str)
 end
 
 immutable InetAddr{T<:IPAddr}

--- a/contrib/BBEditTextWrangler-julia.plist
+++ b/contrib/BBEditTextWrangler-julia.plist
@@ -755,7 +755,6 @@
               <string>parse</string>
               <string>parsefloat</string>
               <string>parseint</string>
-              <string>parseip</string>
               <string>partitions</string>
               <string>peakflops</string>
               <string>permutations</string>

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -875,12 +875,6 @@ Network I/O
 
    Get the IP address and the port that the given TCP socket is connected to (or bound to, in the case of TCPServer).
 
-.. function:: parseip(addr)
-
-   .. Docstring generated from Julia source
-
-   Parse a string specifying an IPv4 or IPv6 ip address.
-
 .. function:: IPv4(host::Integer) -> IPv4
 
    .. Docstring generated from Julia source

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -14,17 +14,17 @@
 @test_throws InexactError Int16(IPv4("1.2.3.4"))
 @test_throws InexactError Int64(IPv6("2001:1::2"))
 
-let ipv = parseip("127.0.0.1")
+let ipv = parse(IPAddr, "127.0.0.1")
     @test isa(ipv, IPv4)
     @test ipv == ip"127.0.0.1"
 end
 
-@test_throws ArgumentError Base.parseipv4("192.0xFFFFFFF")
+@test_throws ArgumentError parse(IPv4, "192.0xFFFFFFF")
 @test_throws ArgumentError IPv4(192,255,255,-1)
 @test_throws ArgumentError IPv4(192,255,255,256)
 
-@test_throws ArgumentError Base.parseipv4("192.0xFFFFFFFFF")
-@test_throws ArgumentError Base.parseipv4("192.")
+@test_throws ArgumentError parse(IPv4, "192.0xFFFFFFFFF")
+@test_throws ArgumentError parse(IPv4, "192.")
 
 @test ip"::1" == IPv6(1)
 @test ip"2605:2700:0:3::4713:93e3" == IPv6(parse(UInt128,"260527000000000300000000471393e3",16))
@@ -33,7 +33,7 @@ end
 
 @test ip"0:0:0:0:0:ffff:127.0.0.1" == IPv6(0xffff7f000001)
 
-let ipv = parseip("0:0:0:0:0:ffff:127.0.0.1")
+let ipv = parse(IPAddr, "0:0:0:0:0:ffff:127.0.0.1")
     @test isa(ipv, IPv6)
     @test ipv == ip"0:0:0:0:0:ffff:127.0.0.1"
 end


### PR DESCRIPTION
Likewise `parse(IPv4, str)` and `parse(IPv6, str)`.
