### PR TITLE
RFC: serialize pointer- and padding-free objects in one write

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -237,6 +237,11 @@ JL_DLLEXPORT int jl_field_isdefined(jl_value_t *v, size_t i)
     return 1;
 }
 
+JL_DLLEXPORT int jl_datatype_haspadding(jl_datatype_t *dt)
+{
+    return dt->haspadding;
+}
+
 JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
 {
     if (type->instance != NULL) return type->instance;


### PR DESCRIPTION
This is a hack to try to address #14106. Any objects that contain no references and no padding can be sent as a single binary blob, instead of iterating over the fields which entails expensive boxing.

Before:

```
    From worker 2:  (300000,)
  2.356665 seconds (20.25 M allocations: 1.398 GB, 3.00% gc time)
    From worker 3:  (300000,)
  2.218371 seconds (20.10 M allocations: 1.391 GB, 2.71% gc time)
```

after:

```
    From worker 2:  (300000,)
  0.649856 seconds (2.25 M allocations: 165.977 MB, 3.34% gc time)
    From worker 3:  (300000,)
  0.501824 seconds (2.10 M allocations: 159.813 MB, 1.42% gc time)
```
