### PR TITLE
add generic sort method for sparse vectors

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -2,7 +2,7 @@
 
 ### Common definitions
 
-import Base: Func, AddFun, MulFun, MaxFun, MinFun, SubFun
+import Base: Func, AddFun, MulFun, MaxFun, MinFun, SubFun, sort
 
 immutable ComplexFun <: Func{2} end
 call(::ComplexFun, x::Real, y::Real) = complex(x, y)
@@ -1493,6 +1493,7 @@ function _At_or_Ac_mul_B{TvA,TiA,TvX,TiX}(tfun::BinaryOp, A::SparseMatrixCSC{TvA
     SparseVector(n, ynzind, ynzval)
 end
 
+
 # define matrix division operations involving triangular matrices and sparse vectors
 # the valid left-division operations are A[t|c]_ldiv_B[!] and \
 # the valid right-division operations are A(t|c)_rdiv_B[t|c][!]
@@ -1615,4 +1616,16 @@ function _densifystarttolastnz!(x::SparseVector)
     # finally update lengthened nzinds
     x.nzind[1:newnnz] = 1:newnnz
     x
+end
+
+#sorting
+function sort{Tv,Ti}(x::SparseVector{Tv,Ti}; kws...)
+    allvals = push!(copy(nonzeros(x)),zero(Tv))
+    sinds = sortperm(allvals;kws...)
+    n,k = length(x),length(allvals)
+    z = findfirst(sinds,k)
+    newnzind = collect(Ti,1:k-1)
+    newnzind[z:end]+= n-k+1
+    newnzvals = allvals[deleteat!(sinds[1:k],z)]
+    SparseVector(n,newnzind,newnzvals)
 end

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -810,6 +810,7 @@ let S = SparseMatrixCSC(10,1,[1,6],[1,3,5,6,7],[0,1,2,0,3]), x = SparseVector(10
     @test nnz(S[[1 3 5; 2 4 6]]) == nnz(x[[1 3 5; 2 4 6]])
 end
 
+
 # Issue 14013
 s14013 = sparse([10.0 0.0 30.0; 0.0 1.0 0.0])
 a14013 = [10.0 0.0 30.0; 0.0 1.0 0.0]
@@ -822,3 +823,18 @@ a14013 = [10.0 0.0 30.0; 0.0 1.0 0.0]
 s14046 = sprand(5, 1.0)
 @test spzeros(5) + s14046 == s14046
 @test 2*s14046 == s14046 + s14046
+
+# Issue 14589
+#test vectors with no zero elements
+x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 7)
+@test collect(sort(x)) == sort(collect(x))
+#test vectors with all zero elements
+x = sparsevec(Int64[], Float64[], 7)
+@test collect(sort(x)) == sort(collect(x))
+#test vector with sparsity approx 1/2
+x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 15)
+@test collect(sort(x)) == sort(collect(x))
+# apply three distinct tranformations where zeros sort into start/middle/end
+@test collect(sort(x, by=abs)) == sort(collect(x), by=abs)
+@test collect(sort(x, by=sign)) == sort(collect(x), by=sign)
+@test collect(sort(x, by=inv)) == sort(collect(x), by=inv)


### PR DESCRIPTION
Improves performance issue as pointed out in #14589 by adding a `sort` method that dispatches on `SparseVector` args. Supports keywords arguments to sort by transformed values in the same way as generic `sort` method (see tests). 

Performance characterization on vectors with increasing sparsity (1/10,1/100,1/1000):

``` julia
#run each call twice to let jit do its thing

#sparsity 1/10
julia> ss=sparsevec(1:10000,shuffle(collect(1:10000)),100000)
julia> @time sort(ss)
  0.002044 seconds (32 allocations: 704.141 KB)
julia> @time sort(full(ss))
  0.003275 seconds (10 allocations: 1.526 MB)

#sparsity 1/100
julia> ss=sparsevec(1:10000,shuffle(collect(1:10000)),1000000)
@time sort(ss)
  0.002080 seconds (32 allocations: 704.141 KB)
julia> @time sort(full(ss))
  0.036997 seconds (10 allocations: 15.259 MB, 12.47% gc time)

#sparsity 1/1000
julia> @time sort(ss)
  0.001848 seconds (32 allocations: 704.141 KB)
julia> @time sort(full(ss))
  0.371264 seconds (10 allocations: 152.588 MB, 7.65% gc time)
```

Performance at low sparsity is comparable to full. At high sparsity the optimized method is much faster.
