### PR TITLE
RFC: narrow uses of `@inbounds` to be more conservative

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -222,10 +222,10 @@ function copy!(dest::AbstractArray, doffs::Integer, src)
     doffs < 1 && throw(BoundsError(dest, doffs))
     st = start(src)
     i, dmax = doffs, length(dest)
-    @inbounds while !done(src, st)
+    while !done(src, st)
         i > dmax && throw(BoundsError(dest, i))
         val, st = next(src, st)
-        dest[i] = val
+        @inbounds dest[i] = val
         i += 1
     end
     return dest
@@ -251,10 +251,10 @@ function copy!(dest::AbstractArray, doffs::Integer, src, soffs::Integer)
                                       "expected at least ",soffs,", got ",soffs-1)))
     end
     i, dmax = doffs, length(dest)
-    @inbounds while !dn
+    while !dn
         i > dmax && throw(BoundsError(dest, i))
         val, st = next(src, st)
-        dest[i] = val
+        @inbounds dest[i] = val
         i += 1
         dn = done(src, st)
     end
@@ -280,9 +280,9 @@ function copy!(dest::AbstractArray, doffs::Integer, src, soffs::Integer, n::Inte
         _, st = next(src, st)
     end
     i = doffs
-    @inbounds while i <= dmax && !done(src, st)
+    while i <= dmax && !done(src, st)
         val, st = next(src, st)
-        dest[i] = val
+        @inbounds dest[i] = val
         i += 1
     end
     i <= dmax && throw(BoundsError(dest, i))
@@ -1250,11 +1250,12 @@ end
 function promote_to!{T,F}(f::F, offs, dest::AbstractArray{T}, A::AbstractArray)
     # map to dest array, checking the type of each result. if a result does not
     # match, do a type promotion and re-dispatch.
-    @inbounds for i = offs:length(A)
-        el = f(A[i])
+    for i = offs:length(A)
+        @inbounds Ai = A[i]
+        el = f(Ai)
         S = typeof(el)
         if S === T || S <: T
-            dest[i] = el::T
+            @inbounds dest[i] = el::T
         else
             R = promote_type(T, S)
             if R !== T
@@ -1263,7 +1264,7 @@ function promote_to!{T,F}(f::F, offs, dest::AbstractArray{T}, A::AbstractArray)
                 new[i] = el
                 return promote_to!(f, i+1, new, A)
             end
-            dest[i] = el
+            @inbounds dest[i] = el
         end
     end
     return dest
@@ -1298,16 +1299,17 @@ end
 function map_to!{T,F}(f::F, offs, dest::AbstractArray{T}, A::AbstractArray)
     # map to dest array, checking the type of each result. if a result does not
     # match, widen the result type and re-dispatch.
-    @inbounds for i = offs:length(A)
-        el = f(A[i])
+    for i = offs:length(A)
+        @inbounds Ai = A[i]
+        el = f(Ai)
         S = typeof(el)
         if S === T || S <: T
-            dest[i] = el::T
+            @inbounds dest[i] = el::T
         else
             R = typejoin(T, S)
             new = similar(dest, R)
             copy!(new,1, dest,1, i-1)
-            new[i] = el
+            @inbounds new[i] = el
             return map_to!(f, i+1, new, A)
         end
     end
@@ -1333,17 +1335,18 @@ function map!{F}(f::F, dest::AbstractArray, A::AbstractArray, B::AbstractArray)
 end
 
 function map_to!{T,F}(f::F, offs, dest::AbstractArray{T}, A::AbstractArray, B::AbstractArray)
-    @inbounds for i = offs:length(A)
-        el = f(A[i], B[i])
+    for i = offs:length(A)
+        @inbounds Ai, Bi = A[i], B[i]
+        el = f(Ai, Bi)
         S = typeof(el)
         if (S !== T) && !(S <: T)
             R = typejoin(T, S)
             new = similar(dest, R)
             copy!(new,1, dest,1, i-1)
-            new[i] = el
+            @inbounds new[i] = el
             return map_to!(f, i+1, new, A, B)
         end
-        dest[i] = el::T
+        @inbounds dest[i] = el::T
     end
     return dest
 end
@@ -1375,17 +1378,17 @@ end
 map!{F}(f::F, dest::AbstractArray, As::AbstractArray...) = map_n!(f, dest, As)
 
 function map_to_n!{T,F}(f::F, offs, dest::AbstractArray{T}, As)
-    @inbounds for i = offs:length(As[1])
+    for i = offs:length(As[1])
         el = f(ith_all(i, As)...)
         S = typeof(el)
         if (S !== T) && !(S <: T)
             R = typejoin(T, S)
             new = similar(dest, R)
             copy!(new,1, dest,1, i-1)
-            new[i] = el
+            @inbounds new[i] = el
             return map_to_n!(f, i+1, new, As)
         end
-        dest[i] = el::T
+        @inbounds dest[i] = el::T
     end
     return dest
 end

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -93,12 +93,12 @@ foldr(op, itr) = mapfoldr(IdFun(), op, itr)
 
 # mapreduce_***_impl require ifirst < ilast
 function mapreduce_seq_impl(f, op, A::AbstractArray, ifirst::Int, ilast::Int)
-    @inbounds fx1 = r_promote(op, f(A[ifirst]))
-    @inbounds fx2 = f(A[ifirst+=1])
-    @inbounds v = op(fx1, fx2)
+    fx1 = r_promote(op, f(A[ifirst]))
+    fx2 = f(A[ifirst+=1])
+    v = op(fx1, fx2)
     while ifirst < ilast
-        @inbounds fx = f(A[ifirst+=1])
-        v = op(v, fx)
+        @inbounds Ai = A[ifirst+=1]
+        v = op(v, f(Ai))
     end
     return v
 end
@@ -140,13 +140,13 @@ function _mapreduce{T}(f, op, ::LinearFast, A::AbstractArray{T})
     elseif n == 1
         return r_promote(op, f(A[1]))
     elseif n < 16
-        @inbounds fx1 = r_promote(op, f(A[1]))
-        @inbounds fx2 = r_promote(op, f(A[2]))
+        fx1 = r_promote(op, f(A[1]))
+        fx2 = r_promote(op, f(A[2]))
         s = op(fx1, fx2)
         i = 2
         while i < n
-            @inbounds fx = f(A[i+=1])
-            s = op(s, fx)
+            @inbounds Ai = A[i+=1]
+            s = op(s, f(Ai))
         end
         return s
     else
@@ -184,7 +184,7 @@ sc_finish(::OrFun)  = false
 ## short-circuiting (sc) mapreduce definitions
 
 function mapreduce_sc_impl(f, op, itr::AbstractArray)
-    @inbounds for x in itr
+    for x in itr
         shortcircuits(op, f(x)) && return shorted(op)
     end
     return sc_finish(op)
@@ -224,11 +224,10 @@ mapreduce(f, op::ShortCircuiting, itr::Any)           = mapreduce_sc(f,op,itr)
 ## sum
 
 function mapreduce_seq_impl(f, op::AddFun, a::AbstractArray, ifirst::Int, ilast::Int)
-    @inbounds begin
-        s = r_promote(op, f(a[ifirst])) + f(a[ifirst+1])
-        @simd for i = ifirst+2:ilast
-            s += f(a[i])
-        end
+    s = r_promote(op, f(a[ifirst])) + f(a[ifirst+1])
+    @simd for i = ifirst+2:ilast
+        @inbounds ai = a[i]
+        s += f(ai)
     end
     s
 end
@@ -284,11 +283,13 @@ function mapreduce_impl(f, op::MaxFun, A::AbstractArray, first::Int, last::Int)
     v = f(A[first])
     i = first + 1
     while v != v && i <= last
-        @inbounds v = f(A[i])
+        @inbounds Ai = A[i]
+        v = f(Ai)
         i += 1
     end
     while i <= last
-        @inbounds x = f(A[i])
+        @inbounds Ai = A[i]
+        x = f(Ai)
         if x > v
             v = x
         end
@@ -302,11 +303,13 @@ function mapreduce_impl(f, op::MinFun, A::AbstractArray, first::Int, last::Int)
     v = f(A[first])
     i = first + 1
     while v != v && i <= last
-        @inbounds v = f(A[i])
+        @inbounds Ai = A[i]
+        v = f(Ai)
         i += 1
     end
     while i <= last
-        @inbounds x = f(A[i])
+        @inbounds Ai = A[i]
+        x = f(Ai)
         if x < v
             v = x
         end
@@ -390,7 +393,7 @@ end
 
 function count(pred, itr)
     n = 0
-    @inbounds for x in itr
+    for x in itr
         n += pred(x)
     end
     return n

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1446,3 +1446,10 @@ end
 
 # issue #14482
 @inferred Base.map_to!(Int8, 1, Int8[0], Int[0])
+
+# make sure @inbounds isn't used too much
+type OOB_Functor{T}; a::T; end
+call(f::OOB_Functor, i::Int) = f.a[i]
+let f = OOB_Functor([1,2])
+    @test_throws BoundsError map(f, [1,2,3,4,5])
+end


### PR DESCRIPTION
I believe `@inbounds` has been over-applied in a few cases. This will become a bigger problem when function arguments start getting inlined more often. For example see the test case added to arrayops here.

Interestingly, this calls into question the practice of passing `--check-bounds=yes` when running tests, since it prevents us from detecting cases where we are incorrectly eliding bounds checks.
