### PR TITLE
RFC: Simplifed method display for constructors. Issue #13065

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -43,7 +43,10 @@ function arg_decl_parts(m::Method)
 end
 
 function show(io::IO, m::Method)
-    print(io, m.func.code.name)
+    sig = m.sig.parameters
+    use_constructor_syntax = !isempty(sig) && isa(sig[1], DataType) &&
+                             !isempty(sig[1].parameters) && isa(sig[1].parameters[1], DataType)
+    print(io, use_constructor_syntax ? sig[1].parameters[1].name : m.func.code.name)
     tv, decls, file, line = arg_decl_parts(m)
     if !isempty(tv)
         show_delim_array(io, tv, '{', ',', '}', false)


### PR DESCRIPTION
@mbauman I hope I am on the right line.

``` julia
methods(BigFloat)
6-element Array{Any,1}:
 BigFloat(::Type{BigFloat}) at mpfr.jl:51                                                    
 call{T<:AbstractFloat}(::Type{T}, x::Real, r::RoundingMode{T<:Any}) at rounding.jl:70       
 BigFloat(::Type{BigFloat}, prec::Int64, sign::Int32, exp::Int64, d::Ptr{Void}) at mpfr.jl:59
 BigFloat(::Type{BigFloat}, s::AbstractString) at deprecated.jl:49                           
 call{T}(::Type{T}, arg) at essentials.jl:58                                                 
 call{T}(::Type{T}, args...) at essentials.jl:59
```
