### PR TITLE
Use naïve algorithm for generic A[tc]_mul_B!

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -462,7 +462,7 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
     end
 
     tile_size = 0
-    if isbits(R) && isbits(T) && isbits(S)
+    if isbits(R) && isbits(T) && isbits(S) && (tA == 'N' || tB != 'N')
         tile_size = floor(Int,sqrt(tilebufsize/max(sizeof(R),sizeof(S),sizeof(T))))
     end
     @inbounds begin


### PR DESCRIPTION
All the memory accesses are contiguous, so there's no point in copying data around.

Before:

``` julia
julia> using Benchmarks

       A = rand(Int, 1000, 1000);
       B = rand(Int, 1000, 1000);
       C = Array(Int, 1000, 1000);

       @benchmark At_mul_B!(C, A, B)
================ Benchmark Results ========================
     Time per evaluation: 826.00 ms [767.24 ms, 884.75 ms]
Proportion of time in GC: 0.00% [0.00%, 0.00%]
        Memory allocated: 288.00 bytes
   Number of allocations: 6 allocations
       Number of samples: 9
   Number of evaluations: 9
 Time spent benchmarking: 9.01 s
```

After:

``` julia
julia> @benchmark At_mul_B!(C, A, B)
================ Benchmark Results ========================
     Time per evaluation: 618.04 ms [558.89 ms, 677.19 ms]
Proportion of time in GC: 0.00% [0.00%, 0.00%]
        Memory allocated: 0.00 bytes
   Number of allocations: 0 allocations
       Number of samples: 12
   Number of evaluations: 12
 Time spent benchmarking: 8.79 s
```
