### PR TITLE
Fix GCC warning about anonymous namespace

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -190,9 +190,9 @@ static bool imaging_mode = false;
 #include "jitlayers.cpp"
 
 #ifdef USE_ORCJIT
-JL_DLLEXPORT JuliaOJIT *jl_ExecutionEngine;
+JuliaOJIT *jl_ExecutionEngine;
 #else
-JL_DLLEXPORT ExecutionEngine *jl_ExecutionEngine;
+ExecutionEngine *jl_ExecutionEngine;
 #endif
 
 #ifdef USE_MCJIT

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -156,6 +156,11 @@ extern JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
                                       const object::ObjectFile &debugObj,
                                       const RuntimeDyld::LoadedObjectInfo &L);
 
+#if defined(_OS_DARWIN_) && defined(LLVM37) && defined(LLVM_SHLIB)
+#define CUSTOM_MEMORY_MANAGER 1
+extern RTDyldMemoryManager* createRTDyldMemoryManagerOSX();
+#endif
+
 namespace {
 
 using namespace llvm;
@@ -237,13 +242,6 @@ public:
         }
     }
 };
-
-}
-
-#if defined(_OS_DARWIN_) && defined(LLVM37) && defined(LLVM_SHLIB)
-#define CUSTOM_MEMORY_MANAGER 1
-extern RTDyldMemoryManager* createRTDyldMemoryManagerOSX();
-#endif
 
 class JuliaOJIT {
 public:
@@ -396,4 +394,6 @@ private:
     std::unique_ptr<CompileLayerT> CompileLayer;
     GlobalSymbolTableT GlobalSymbolTable;
 };
+
+}
 #endif


### PR DESCRIPTION
By moving `JuliaOJIT` into the anonymous namespace too. Ref [travis log](https://travis-ci.org/JuliaLang/julia/jobs/102823344#L1007)
Also un-`JL_DLLEXPORT` `jl_ExecutionEngine` since according to @Keno `Cxx.jl` doesn't need it anymore.
