### PR TITLE
remove the stateful `jl_parse_next` API

### DIFF
--- a/doc/devdocs/init.rst
+++ b/doc/devdocs/init.rst
@@ -126,7 +126,7 @@ creates the global "Main" module and sets
 
 Note: _julia_init() `then sets <https://github.com/JuliaLang/julia/blob/master/src/init.c>`_ :code:`jl_root_task->current_module = jl_core_module`. :code:`jl_root_task` is an alias of :code:`jl_current_task` at this point, so the current_module set by :c:func:`jl_new_main_module` above is overwritten.
 
-`jl_load("boot.jl", sizeof("boot.jl")) <https://github.com/JuliaLang/julia/blob/master/src/init.c>`_ calls `jl_parse_eval_all("boot.jl") <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ which repeatedly calls `jl_parse_next() <https://github.com/JuliaLang/julia/blob/master/src/ast.c>`_ and `jl_toplevel_eval_flex() <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ to parse and execute `boot.jl <https://github.com/JuliaLang/julia/blob/master/base/boot.jl>`_. TODO -- drill down into eval?
+`jl_load("boot.jl", sizeof("boot.jl")) <https://github.com/JuliaLang/julia/blob/master/src/init.c>`_ calls `jl_parse_eval_all <https://github.com/JuliaLang/julia/blob/master/src/ast.c>`_ which repeatedly calls `jl_toplevel_eval_flex() <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ to execute `boot.jl <https://github.com/JuliaLang/julia/blob/master/base/boot.jl>`_. TODO -- drill down into eval?
 
 `jl_get_builtin_hooks() <https://github.com/JuliaLang/julia/blob/master/src/init.c>`_ initialises global C pointers to Julia globals defined in ``boot.jl``.
 
@@ -168,7 +168,7 @@ true_main()
 
 `true_main() <https://github.com/JuliaLang/julia/blob/master/ui/repl.c>`_ loads the contents of :code:`argv[]` into :data:`Base.ARGS`.
 
-If a .jl "program" file was supplied on the command line, then `exec_program() <https://github.com/JuliaLang/julia/blob/master/ui/repl.c>`_ calls `jl_load(program,len) <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ which calls `jl_parse_eval_all() <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ which repeatedly calls `jl_parse_next() <https://github.com/JuliaLang/julia/blob/master/src/ast.c>`_ and `jl_toplevel_eval_flex() <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ to parse and execute the program.
+If a .jl "program" file was supplied on the command line, then `exec_program() <https://github.com/JuliaLang/julia/blob/master/ui/repl.c>`_ calls `jl_load(program,len) <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ which calls `jl_parse_eval_all <https://github.com/JuliaLang/julia/blob/master/src/ast.c>`_ which repeatedly calls `jl_toplevel_eval_flex() <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_ to execute the program.
 
 However, in our example (:code:`julia -e 'println("Hello World!")'`), `jl_get_global(jl_base_module, jl_symbol("_start")) <https://github.com/JuliaLang/julia/blob/master/src/module.c>`_ looks up `Base._start <https://github.com/JuliaLang/julia/blob/master/base/client.jl>`_ and `jl_apply() <https://github.com/JuliaLang/julia/blob/master/src/julia.h>`_ executes it.
 

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -134,11 +134,10 @@
 (define (jl-parse-one-string s pos0 greedy)
   (let ((inp (open-input-string s)))
     (io.seek inp pos0)
-    (let ((expr
-           (parser-wrap (lambda ()
-                          (if greedy
-                              (julia-parse inp)
-                              (julia-parse inp parse-atom))))))
+    (let ((expr (parser-wrap (lambda ()
+                               (if greedy
+                                   (julia-parse inp)
+                                   (julia-parse inp parse-atom))))))
       (cons expr (io.pos inp)))))
 
 (define (jl-parse-string s)
@@ -158,38 +157,36 @@
                                (loop (nreconc (cdr expr) exprs))
                                (loop (cons expr exprs))))))))))
 
+(define (jl-parse-all io filename)
+  (unwind-protect
+   (with-bindings ((current-filename (symbol filename)))
+    (let ((stream (make-token-stream io)))
+      (let loop ((exprs '()))
+        (let ((lineno (parser-wrap
+                       (lambda ()
+                         (skip-ws-and-comments (ts:port stream))
+                         (input-port-line (ts:port stream))))))
+          (if (pair? lineno)
+              (cons 'toplevel (reverse! (cons lineno exprs)))
+              (let ((expr (parser-wrap
+                           (lambda ()
+                             (julia-parse stream)))))
+                (if (eof-object? expr)
+                    (cons 'toplevel (reverse! exprs))
+                    (let ((next (list* expr `(line ,lineno) exprs)))
+                      (if (and (pair? expr) (eq? (car expr) 'error))
+                          (cons 'toplevel (reverse! next))
+                          (loop next))))))))))
+   (io.close io)))
+
 ;; parse file-in-a-string
 (define (jl-parse-string-stream str filename)
-  (jl-parser-set-stream filename (open-input-string str)))
+  (jl-parse-all (open-input-string str) filename))
 
-(define (jl-parse-file s)
+(define (jl-parse-file filename)
   (trycatch
-   (let ((b (buffer))
-	 (f (open-input-file s)))
-     ;; read whole file first to avoid problems with concurrent modification (issue #10497)
-     (io.copy b f)
-     (io.close f)
-     (io.seek b 0)
-     (begin (jl-parser-set-stream s b)
-	    #t))
+   (jl-parse-all (open-input-file filename) filename)
    (lambda (e) #f)))
-
-(define *filename-stack* '())
-(define *ts-stack* '())
-(define current-token-stream #())
-
-(define (jl-parser-set-stream name stream)
-  (set! *filename-stack* (cons current-filename *filename-stack*))
-  (set! *ts-stack* (cons current-token-stream *ts-stack*))
-  (set! current-filename (symbol name))
-  (set! current-token-stream (make-token-stream stream)))
-
-(define (jl-parser-close-stream)
-  (io.close (ts:port current-token-stream))
-  (set! current-filename (car *filename-stack*))
-  (set! current-token-stream (car *ts-stack*))
-  (set! *filename-stack* (cdr *filename-stack*))
-  (set! *ts-stack* (cdr *ts-stack*)))
 
 (define *depwarn* #t)
 (define (jl-parser-depwarn w)
@@ -202,27 +199,6 @@
   (let ((prev *deperror*))
     (set! *deperror* (eq? e #t))
     prev))
-
-(define (jl-parser-next)
-  (let* ((err (parser-wrap
-               (lambda ()
-                 (skip-ws-and-comments (ts:port current-token-stream)))))
-         (lineno (input-port-line (ts:port current-token-stream))))
-    (cons lineno
-          (if (pair? err)
-              err
-              (parser-wrap
-               (lambda ()
-                 (let ((e (julia-parse current-token-stream)))
-                   (if (eof-object? e)
-                       e
-                       (if (and (pair? e) (or (eq? (car e) 'error)
-                                              (eq? (car e) 'continue)))
-                           e
-                           (expand-toplevel-expr e))))))))))
-
-(define (jl-parser-current-lineno)
-  (input-port-line (ts:port current-token-stream)))
 
 ; expand a piece of raw surface syntax to an executable thunk
 (define (jl-expand-to-thunk expr)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -169,14 +169,13 @@ jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
 typedef struct _jl_ast_context_t jl_ast_context_t;
-jl_ast_context_t *jl_start_parsing_file(const char *fname);
-void jl_stop_parsing(jl_ast_context_t *ctx);
-jl_value_t *jl_parse_next(jl_ast_context_t *ctx);
+jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast);
 
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
 void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
-jl_value_t *jl_parse_eval_all(const char *fname, size_t len, jl_ast_context_t *ctx);
+jl_value_t *jl_parse_eval_all(const char *fname, size_t len,
+                              const char *content, size_t contentlen);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
 jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
                                              jl_value_t **loc, size_t nl);


### PR DESCRIPTION
With this change, we parse a whole file at once to a `toplevel` expression with interleaved `line` nodes. This is much simpler.

cc @yuyichao 
