### PR TITLE
`unspecialized` is now index 7 rather than 6

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3507,7 +3507,7 @@ void jl_init_types(void)
                         0, 1, 0);
 
     jl_svecset(jl_method_type->types, 4, jl_function_type);
-    jl_svecset(jl_lambda_info_type->types, 6, jl_function_type);
+    jl_svecset(jl_lambda_info_type->types, 7, jl_function_type);
 
     jl_bottom_func = jl_new_closure(jl_f_no_function, (jl_value_t*)jl_emptysvec, NULL);
 


### PR DESCRIPTION
An extra field was added in fb8c6e956898cf8acb76d0d5c4301c8773845e3b, but this number was not updated.

@JeffBezanson 
