### PR TITLE
Close file monitor in the test to free up kernel resources

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -160,6 +160,7 @@ function test_monitor_wait(tval)
         close(f)
     end
     fname, events = wait(fm)
+    close(fm)
     @test fname == basename(file)
     @test events.changed
 end
@@ -173,6 +174,7 @@ function test_monitor_wait_poll()
         close(f)
     end
     (old, new) = wait(pfw)
+    close(pfw)
     @test new.mtime - old.mtime > 2.5 - 1.5 # mtime may only have second-level accuracy (plus add some hysteresis)
 end
 


### PR DESCRIPTION
This could be related to the `ENOSPC` error during file test on travis (`inotify` returns `ENOSPC` if the user limit is reached). We aren't creating too many of them and the limit isn't too low ([128](https://travis-ci.org/JuliaLang/julia/jobs/103039259#L538)) so there might be other reasons why the test fails (e.g. if travis is using some by itself).... (We could also try to increase the limit by writing to the corresponding `/proc/sys` file with `sudo`).
