### PR TITLE
Reset history state in PrefixPromptSearch

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1100,6 +1100,7 @@ function reset_state(s::PrefixSearchState)
         s.response_buffer.size = 0
         s.response_buffer.ptr = 1
     end
+    reset_state(s.histprompt.hp)
 end
 
 function transition(f::Function, s::PrefixSearchState, mode)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -340,6 +340,46 @@ begin
     # Try entering search mode while in custom repl mode
     LineEdit.enter_search(s, custom_histp, true)
 end
+# Simple non-standard REPL tests
+if @unix? true : (Base.windows_version() >= Base.WINDOWS_VISTA_VER)
+    stdin_write, stdout_read, stdout_read, repl = fake_repl()
+    panel = LineEdit.Prompt("test";
+        prompt_prefix="\e[38;5;166m",
+        prompt_suffix=Base.text_colors[:white],
+        on_enter = s->true)
+
+    hp = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:parse => panel))
+    search_prompt, skeymap = LineEdit.setup_prefix_keymap(hp, panel)
+    REPL.history_reset_state(hp)
+
+    panel.hist = hp
+    panel.keymap_dict = LineEdit.keymap(Dict{Any,Any}[skeymap,
+        LineEdit.default_keymap, LineEdit.escape_defaults])
+
+    c = Condition()
+    panel.on_done = (s,buf,ok)->begin
+        if !ok
+            LineEdit.transition(s,:abort)
+        end
+        line = strip(takebuf_string(buf))
+        LineEdit.reset_state(s)
+        return notify(c,line)
+    end
+
+    repltask = @async Base.REPL.run_interface(repl.t, LineEdit.ModalInterface([panel,search_prompt]))
+
+    write(stdin_write,"a\n")
+    @test wait(c) == "a"
+    # Up arrow enter should recall history even at the start
+    write(stdin_write,"\e[A\n")
+    @test wait(c) == "a"
+    # And again
+    write(stdin_write,"\e[A\n")
+    @test wait(c) == "a"
+    # Close REPL ^D
+    write(stdin_write, '\x04')
+    wait(repltask)
+end
 
 ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
 


### PR DESCRIPTION
In REPLs without the SearchPrompt, the history was not being
reset properly when moving to the next input.
