### PR TITLE
Fix signature of git_signature_new

### DIFF
--- a/base/libgit2/signature.jl
+++ b/base/libgit2/signature.jl
@@ -30,7 +30,7 @@ end
 function Base.convert(::Type{GitSignature}, sig::Signature)
     sig_ptr_ptr = Ref{Ptr{SignatureStruct}}(C_NULL)
     @check ccall((:git_signature_new, :libgit2), Cint,
-                 (Ptr{Ptr{SignatureStruct}}, Cstring, Cstring, Cint, Cint),
+                 (Ptr{Ptr{SignatureStruct}}, Cstring, Cstring, Int64, Cint),
                  sig_ptr_ptr, sig.name, sig.email, sig.time, sig.time_offset)
     return GitSignature(sig_ptr_ptr[])
 end


### PR DESCRIPTION
[`git_time_t` is a `int64_t` instead of a `int`](https://github.com/libgit2/libgit2/blob/0f9d15493d5d8ad4353dd7beed52c9567334f6e5/include/git2/types.h#L39).

Fixes #14718 (Still running the tests locally to make sure).
