### PR TITLE
Fix type instability in generic matmul

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -457,6 +457,9 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
     if size(C,1) != mA || size(C,2) != nB
         throw(DimensionMismatch("result C has dimensions $(size(C)), needs ($mA,$nB)"))
     end
+    if isempty(A) || isempty(B)
+        return fill!(C, zero(R))
+    end
 
     tile_size = 0
     if isbits(R) && isbits(T) && isbits(S) && (tA == 'N' || tB != 'N')
@@ -468,7 +471,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
         Atile = unsafe_wrap(Array, convert(Ptr{T}, pointer(Abuf)), sz)
         Btile = unsafe_wrap(Array, convert(Ptr{S}, pointer(Bbuf)), sz)
 
-        z = zero(R)
+        z1 = zero(A[1, 1]*B[1, 1] + A[1, 1]*B[1, 1])
+        z = convert(promote_type(typeof(z1), R), z1)
 
         if mA < tile_size && nA < tile_size && nB < tile_size
             Base.copy_transpose!(Atile, 1:nA, 1:mA, tA, A, 1:mA, 1:nA)
@@ -520,11 +524,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
         if tA == 'N'
             if tB == 'N'
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[i, 1]*B[1, j] + A[i, 1]*B[1, j])
-                    end
+                    z2 = zero(A[i, 1]*B[1, j] + A[i, 1]*B[1, j])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[i, k]*B[k, j]
                     end
@@ -532,11 +533,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[i, 1]*B[j, 1] + A[i, 1]*B[j, 1])
-                    end
+                    z2 = zero(A[i, 1]*B[j, 1] + A[i, 1]*B[j, 1])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[i, k]*B[j, k].'
                     end
@@ -544,11 +542,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
                 end
             else
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[i, 1]*B[j, 1] + A[i, 1]*B[j, 1])
-                    end
+                    z2 = zero(A[i, 1]*B[j, 1] + A[i, 1]*B[j, 1])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[i, k]*B[j, k]'
                     end
@@ -558,11 +553,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
         elseif tA == 'T'
             if tB == 'N'
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[1, i]*B[1, j] + A[1, i]*B[1, j])
-                    end
+                    z2 = zero(A[1, i]*B[1, j] + A[1, i]*B[1, j])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[k, i].'B[k, j]
                     end
@@ -570,11 +562,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
-                    end
+                    z2 = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[k, i].'B[j, k].'
                     end
@@ -582,11 +571,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
                 end
             else
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
-                    end
+                    z2 = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[k, i].'B[j, k]'
                     end
@@ -596,11 +582,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
         else
             if tB == 'N'
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[1, i]*B[1, j] + A[1, i]*B[1, j])
-                    end
+                    z2 = zero(A[1, i]*B[1, j] + A[1, i]*B[1, j])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[k, i]'B[k, j]
                     end
@@ -608,11 +591,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
-                    end
+                    z2 = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[k, i]'B[j, k].'
                     end
@@ -620,11 +600,8 @@ function _generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractV
                 end
             else
                 for i = 1:mA, j = 1:nB
-                    if isempty(A) || isempty(B)
-                        Ctmp = zero(R)
-                    else
-                        Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
-                    end
+                    z2 = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
+                    Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
                         Ctmp += A[k, i]'B[j, k]'
                     end

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -388,3 +388,15 @@ let
         @test_throws DimensionMismatch A_mul_B!(full43, full43, tri44)
     end
 end
+
+# Ensure that matrix multiplication with a narrower output type than input type does not
+# produce allocation in the inner loop (#14722), by ensuring allocation does not change
+# with the size of the input.
+C1 = Array(Float32, 5, 5)
+A1 = rand(Float64, 5, 5)
+B1 = rand(Float64, 5, 5)
+C2 = Array(Float32, 6, 6)
+A2 = rand(Float64, 6, 6)
+B2 = rand(Float64, 6, 6)
+A_mul_B!(C1, A1, B1)
+@test @allocated(A_mul_B!(C1, A1, B1)) == @allocated(A_mul_B!(C2, A2, B2))


### PR DESCRIPTION
For `C::AbstractVecOrMat{R}`, `A::AbstractVecOrMat{T}`, `B::AbstractVecOrMat{S}`, we were sometimes initializing the intermediate sum as `zero(R)`, but it wouldn't stay that way if `R` was narrower than `T` and `S`.

This promotes the intermediate sums (`s` and `Ctmp` in the code) to the promotion of `R` and `zero(T)*zero(S) + zero(T)*zero(S)`. Thus, for `A_mul_B!(C::Matrix{Float32}, A::Matrix{Float64}, B::Matrix{Float64}`, the intermediate sums are Float64. The other possibility would be to enforce that the intermediate sums are the same type as `R` (i.e. Float32 in this example) but it seemed more conservative to potentially use higher precision than lower precision.

Before:

``` julia
julia> C = Array(Float32, 100, 100);
       A = rand(Float64, 100, 100);
       B = rand(Float64, 100, 100);

julia> @time A_mul_B!(C, A, B);
  0.031763 seconds (2.11 M allocations: 32.154 MB, 9.28% gc time)
```

After:

``` julia
julia> @time A_mul_B!(C, A, B);
  0.000870 seconds (10 allocations: 448 bytes)
```
