### PR TITLE
LLVM-SVN: RoundUpToAlignment renamed to alignTo.

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -12,7 +12,7 @@ extern "C" {
 
 using namespace llvm;
 
-#ifdef LLVM38
+#ifdef LLVM39
 inline uint64_t RoundUpToAlignment(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
   return alignTo(Value, Align, Skew);
 }

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -16,7 +16,7 @@ using namespace llvm;
 inline uint64_t RoundUpToAlignment(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
   return alignTo(Value, Align, Skew);
 }
-+#endif
+#endif
 
 /* create "APInt s" from "integerPart *ps" */
 #define CREATE(s) \

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -12,6 +12,12 @@ extern "C" {
 
 using namespace llvm;
 
+#ifdef LLVM38
+inline uint64_t RoundUpToAlignment(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
+  return alignTo(Value, Align, Skew);
+}
++#endif
+
 /* create "APInt s" from "integerPart *ps" */
 #define CREATE(s) \
     APInt s; \

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -2,6 +2,10 @@
 
 #include <llvm/Config/llvm-config.h>
 
+#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9
+#define LLVM39 1
+#endif
+
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 8
 #define LLVM38 1
 #define USE_ORCJIT


### PR DESCRIPTION
According to http://reviews.llvm.org/D16162 RoundUpToAlignment was first renamed to alignTo, with the alias creation, and the it was completely deleted https://github.com/llvm-mirror/llvm/commit/d8c74947878cf60bb69762700c262405d1296307

Couldn't find a better solution other than cherry-pick an aliasing for LLVM38.
