### PR TITLE
RFC: Perf JIT event listener

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -63,6 +63,9 @@ endif
 # Set to 1 to enable profiling with OProfile
 USE_OPROFILE_JITEVENTS ?= 0
 
+# Set to 1 to enable profiling with perf
+USE_PERF_JITEVENTS ?= 0
+
 # libc++ is standard on OS X 10.9, but not for earlier releases
 USE_LIBCPP := 0
 
@@ -863,6 +866,11 @@ endif
 # OProfile
 ifeq ($(USE_OPROFILE_JITEVENTS), 1)
 JCPPFLAGS += -DJL_USE_OPROFILE_JITEVENTS
+endif
+
+# perf
+ifeq ($(USE_PERF_JITEVENTS), 1)
+JCPPFLAGS += -DJL_USE_PERF_JITEVENTS
 endif
 
 # Intel libraries

--- a/src/Makefile
+++ b/src/Makefile
@@ -116,7 +116,7 @@ $(BUILDDIR)/julia_flisp.boot: $(addprefix $(SRCDIR)/,jlfrontend.scm \
 
 # additional dependency links
 $(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc $(SRCDIR)/flisp/*.h
-$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp intrinsics.h cgutils.cpp ccall.cpp jitlayers.cpp abi_*.cpp)
+$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp intrinsics.h cgutils.cpp ccall.cpp jitlayers.cpp abi_*.cpp PerfJITEventListener.cpp)
 $(BUILDDIR)/anticodegen.o $(BUILDDIR)/anticodegen.dbg.obj: $(SRCDIR)/intrinsics.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc-debug.c

--- a/src/PerfJITEventListener.cpp
+++ b/src/PerfJITEventListener.cpp
@@ -1,0 +1,103 @@
+#include <llvm/Object/SymbolSize.h>
+#include <unistd.h>
+
+#define DEBUG_TYPE "perf-jit-event-listener"
+
+namespace {
+
+using namespace llvm::object;
+
+class PerfJITEventListener : public JITEventListener {
+  raw_fd_ostream *OS;
+  bool enabled;
+
+  void initialize();
+  std::map<const char*, OwningBinary<ObjectFile>> DebugObjects;
+
+public:
+  PerfJITEventListener() {
+    initialize();
+  }
+
+  ~PerfJITEventListener();
+
+  void NotifyObjectEmitted(const ObjectFile &Obj,
+                           const RuntimeDyld::LoadedObjectInfo &L) override;
+
+  void NotifyFreeingObject(const ObjectFile &Obj) override;
+};
+
+void PerfJITEventListener::initialize() {
+  std::stringstream fname;
+  fname << "/tmp/perf-";
+  fname << getpid() << ".map";
+  std::error_code err;
+  OS = new raw_fd_ostream(fname.str(), err, sys::fs::F_Excl | sys::fs::F_Text);
+  if (err) {
+    jl_printf(JL_STDERR, "WARNING: could not open perf symbol mapping (%s)\n", err.message().c_str());
+  } else {
+    enabled = true;
+  }
+}
+
+PerfJITEventListener::~PerfJITEventListener() {
+  if (enabled) {
+    OS->close();
+  }
+}
+
+void PerfJITEventListener::NotifyObjectEmitted(
+                                       const ObjectFile &Obj,
+                                       const RuntimeDyld::LoadedObjectInfo &L) {
+  if (!enabled) {
+    return;
+  }
+
+  OwningBinary<ObjectFile> DebugObjOwner = L.getObjectForDebug(Obj);
+  const ObjectFile &DebugObj = *DebugObjOwner.getBinary();
+
+  // Use symbol info to iterate functions in the object.
+  for (const std::pair<SymbolRef, uint64_t> &P : object::computeSymbolSizes(DebugObj)) {
+    SymbolRef Sym = P.first;
+    if (Sym.getType() != SymbolRef::ST_Function)
+      continue;
+
+    ErrorOr<StringRef> NameOrErr = Sym.getName();
+    if (NameOrErr.getError())
+      continue;
+    StringRef Name = *NameOrErr;
+    ErrorOr<uint64_t> AddrOrErr = Sym.getAddress();
+    if (AddrOrErr.getError())
+      continue;
+    uint64_t Addr = *AddrOrErr;
+    uint64_t Size = P.second;
+
+    OS->write_hex(Addr);
+    *OS << " ";
+    OS->write_hex(Size);
+    *OS << " " << Name.data() << "\n";
+
+    // NOTE: perf doesn't currently support annotating JITted code.
+    //       When it does (https://lwn.net/Articles/638566/), we should
+    //       emit source location information (see IntelJITEventListener.cpp)
+
+    // FIXME: our destructor isn't called, so flush manually for each entry
+    OS->flush();
+  }
+
+  DebugObjects[Obj.getData().data()] = std::move(DebugObjOwner);
+}
+
+void PerfJITEventListener::NotifyFreeingObject(const ObjectFile &Obj) {
+  if (enabled) {
+    // FIXME: does this ever happen, apart from when destroying the runtime?
+  }
+
+  DebugObjects.erase(Obj.getData().data());
+}
+
+}  // anonymous namespace.
+
+JITEventListener *createPerfJITEventListener() {
+  return new PerfJITEventListener();
+}

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -115,6 +115,10 @@
 #include <cassert>
 using namespace llvm;
 
+#ifdef JL_USE_PERF_JITEVENTS
+#include "PerfJITEventListener.cpp"
+#endif
+
 // LLVM version compatibility macros
 #ifdef LLVM37
 using namespace llvm::legacy;
@@ -6415,6 +6419,12 @@ extern "C" void jl_init_codegen(void)
         jl_ExecutionEngine->RegisterJITEventListener(
             JITEventListener::createOProfileJITEventListener());
 #endif // JL_USE_OPROFILE_JITEVENTS
+
+#ifdef JL_USE_PERF_JITEVENTS
+    if (jl_using_perf_jitevents)
+        jl_ExecutionEngine->RegisterJITEventListener(
+            createPerfJITEventListener());
+#endif // JL_USE_PERF_JITEVENTS
 #endif
 
     BOX_F(int8,int8);  UBOX_F(uint8,uint8);

--- a/src/init.c
+++ b/src/init.c
@@ -407,6 +407,10 @@ char jl_using_intel_jitevents; // Non-zero if running under Intel VTune Amplifie
 char jl_using_oprofile_jitevents = 0; // Non-zero if running under OProfile
 #endif
 
+#ifdef JL_USE_PERF_JITEVENTS
+char jl_using_perf_jitevents = 0; // Non-zero if running under perf
+#endif
+
 int isabspath(const char *in)
 {
 #ifdef _OS_WINDOWS_
@@ -584,6 +588,13 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
     if (jit_profiling && atoi(jit_profiling)) {
         jl_using_oprofile_jitevents = 1;
+    }
+#endif
+
+#if defined(JL_USE_PERF_JITEVENTS)
+    const char *jit_profiling = getenv("ENABLE_JITPROFILING");
+    if (jit_profiling && atoi(jit_profiling)) {
+        jl_using_perf_jitevents = 1;
     }
 #endif
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -222,6 +222,9 @@ extern char jl_using_intel_jitevents;
 #ifdef JL_USE_OPROFILE_JITEVENTS
 extern char jl_using_oprofile_jitevents;
 #endif
+#ifdef JL_USE_PERF_JITEVENTS
+extern char jl_using_perf_jitevents;
+#endif
 extern size_t jl_arr_xtralloc_limit;
 
 void jl_init_types(void);


### PR DESCRIPTION
Any interest in this? It's a premature version, but if people are interested I could look into getting it in a shape to merge.

This PR adds a JIT listener which dumps symbol information to `/tmp/perf-$PID.map`, which is the file `perf` reads when reporting. It makes profiling really easy on any somewhat-recent Linux version.

```
$ make USE_PERF_JITEVENTS=1 USE_ORCJIT=0  # this is not a real build var
$ ENABLE_JITPROFILING=1 \
  perf record --call-graph fp ./julia perf/shootout/pidigits.jl
$ perf report --call-graph -G
```

This yields the following call graph, zooming in on the main `pidigits` function :

```
  Children      Self  Comma  Shared Object   Symbol

+   12,66%     0,00%  julia  perf-12888.map  [.] julia_pidigits_23309
-   12,66%     0,00%  julia  perf-12888.map  [.] jlcall_pidigits_23309
     jlcall_pidigits_23309
   - julia_pidigits_23309
      - 12,60% julia_pidigits_23310
         - 4,64% julia_divrem_23315
            + 3,88% __gmpz_tdiv_qr
            + 0,61% jl_gc_alloc_2w
            + 0,08% jl_apply_generic
         + 2,74% julia_*_23313
         + 1,72% julia_+_23314
         + 1,41% julia_*_23319
         + 1,25% julia_<<_23312
         + 0,34% jl_apply_generic
         + 0,18% julia_-_23318
         + 0,14% __gmpz_init
           0,02% jl_gc_alloc_2w
           0,01% __gmpz_add
           0,01% __gmpz_mul_si
         + 0,01% julia_+_23314
        0,04% __gmpz_cmp
        0,01% julia_-_23318
        0,01% __gmpz_cmp
+   12,60%     0,12%  julia  perf-12888.map  [.] julia_pidigits_23310
```

Once the follow-up of [this patchset](https://lwn.net/Articles/638566/) lands it should even be possible to annotate source code, making this a really powerful tool. Time to introduce `deps/linux`? :grin: 
