### PR TITLE
Make jl_current_module thread local

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2011,13 +2011,16 @@ static void pre_mark(void)
 {
     // modules
     gc_push_root(jl_main_module, 0);
-    gc_push_root(jl_current_module, 0);
     if (jl_old_base_module) gc_push_root(jl_old_base_module, 0);
     gc_push_root(jl_internal_main_module, 0);
 
     size_t i;
     for(i=0; i < jl_n_threads; i++) {
         jl_tls_states_t *ptls = jl_all_task_states[i].ptls;
+        // current_module might not have a value when the thread is not
+        // running.
+        if (ptls->current_module)
+            gc_push_root(ptls->current_module, 0);
         gc_push_root(ptls->current_task, 0);
         gc_push_root(ptls->root_task, 0);
         gc_push_root(ptls->exception_in_transit, 0);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1175,7 +1175,7 @@ extern JL_DLLEXPORT jl_module_t *jl_internal_main_module;
 extern JL_DLLEXPORT jl_module_t *jl_core_module;
 extern JL_DLLEXPORT jl_module_t *jl_base_module;
 extern JL_DLLEXPORT jl_module_t *jl_top_module;
-extern JL_DLLEXPORT jl_module_t *jl_current_module;
+#define jl_current_module (jl_get_ptls_states()->current_module)
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
 // get binding for reading
 JL_DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var);
@@ -1484,6 +1484,7 @@ typedef struct _jl_tls_states_t {
     volatile int8_t in_finalizer;
     int8_t disable_gc;
     struct _jl_thread_heap_t *heap;
+    jl_module_t *current_module;
     jl_task_t *volatile current_task;
     jl_task_t *root_task;
     jl_value_t *volatile task_arg_in_transit;

--- a/src/module.c
+++ b/src/module.c
@@ -15,7 +15,6 @@ jl_module_t *jl_main_module=NULL;
 jl_module_t *jl_core_module=NULL;
 jl_module_t *jl_base_module=NULL;
 jl_module_t *jl_top_module=NULL;
-jl_module_t *jl_current_module=NULL;
 
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 {

--- a/src/threadgroup.c
+++ b/src/threadgroup.c
@@ -186,17 +186,6 @@ int ti_threadgroup_join(ti_threadgroup_t *tg, int16_t ext_tid)
     return 0;
 }
 
-
-void ti_threadgroup_barrier(ti_threadgroup_t *tg, int16_t ext_tid)
-{
-    if (tg->tid_map[ext_tid] == 0  &&  !tg->forked)
-        return;
-
-    ti_threadgroup_join(tg, ext_tid);
-    ti_threadgroup_fork(tg, ext_tid, NULL);
-}
-
-
 int ti_threadgroup_destroy(ti_threadgroup_t *tg)
 {
     int i;

--- a/src/threadgroup.h
+++ b/src/threadgroup.h
@@ -43,7 +43,6 @@ int  ti_threadgroup_size(ti_threadgroup_t *tg, int16_t *tgsize);
 int  ti_threadgroup_fork(ti_threadgroup_t *tg, int16_t ext_tid,
                          void **bcast_val);
 int  ti_threadgroup_join(ti_threadgroup_t *tg, int16_t ext_tid);
-void ti_threadgroup_barrier(ti_threadgroup_t *tg, int16_t ext_tid);
 int  ti_threadgroup_destroy(ti_threadgroup_t *tg);
 
 extern ti_threadgroup_t *tgworld;

--- a/src/threading.h
+++ b/src/threading.h
@@ -52,7 +52,7 @@ typedef struct {
     jl_function_t       *fun;
     jl_svec_t           *args;
     jl_value_t          *ret;
-
+    jl_module_t         *current_module;
 } ti_threadwork_t;
 
 


### PR DESCRIPTION
So that `eval`ing on a thread won't interfere with other threads.

Add test for this and make sure that the current module on the thread is still the same with the one on the main thread with the work is created.

Also remove `ti_threadgroup_barrier` since it appears to be leaky and not used anymore.

Fix #14726
