### PR TITLE
Test UniformScaling methods with SubArrays.

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -7,9 +7,9 @@ import Base: A_mul_Bt, At_ldiv_Bt, A_rdiv_Bc, At_ldiv_B, Ac_mul_Bc, A_mul_Bc, Ac
     Ac_ldiv_B, Ac_ldiv_Bc, At_mul_Bt, A_rdiv_Bt, At_mul_B
 import Base: USE_BLAS64, abs, big, ceil, conj, convert, copy, copy!, copy_transpose!,
     ctranspose, ctranspose!, eltype, eye, findmax, findmin, fill!, floor, full, getindex,
-    imag, inv, isapprox, kron, ndims, power_by_squaring, print_matrix, promote_rule, real,
-    round, setindex!, show, similar, size, transpose, transpose!, trunc, unsafe_getindex,
-    unsafe_setindex!
+    imag, inv, isapprox, kron, ndims, parent, power_by_squaring, print_matrix,
+    promote_rule, real, round, setindex!, show, similar, size, transpose, transpose!,
+    trunc, unsafe_getindex, unsafe_setindex!
 using Base: promote_op, MulFun
 
 export

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -378,7 +378,7 @@ function inv{T}(A::StridedMatrix{T})
     else
         Ai = inv(lufact(AA))
     end
-    return convert(typeof(AA), Ai)
+    return convert(typeof(parent(Ai)), Ai)
 end
 
 function factorize{T}(A::Matrix{T})

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -29,6 +29,7 @@ unsafe_getindex(A::Symmetric, i::Integer, j::Integer) = (A.uplo == 'U') == (i < 
 unsafe_getindex(A::Hermitian, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? unsafe_getindex(A.data, i, j) : conj(unsafe_getindex(A.data, j, i))
 full(A::Symmetric) = copytri!(copy(A.data), A.uplo)
 full(A::Hermitian) = copytri!(copy(A.data), A.uplo, true)
+parent(A::HermOrSym) = A.data
 convert{T,S<:AbstractMatrix}(::Type{Symmetric{T,S}},A::Symmetric{T,S}) = A
 convert{T,S<:AbstractMatrix}(::Type{Symmetric{T,S}},A::Symmetric) = Symmetric{T,S}(convert(S,A.data),A.uplo)
 convert{T}(::Type{AbstractMatrix{T}}, A::Symmetric) = Symmetric(convert(AbstractMatrix{T}, A.data), symbol(A.uplo))

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -51,6 +51,7 @@ imag(A::UnitLowerTriangular) = LowerTriangular(tril!(imag(A.data),-1))
 imag(A::UnitUpperTriangular) = UpperTriangular(triu!(imag(A.data),1))
 
 full(A::AbstractTriangular) = convert(Matrix, A)
+parent(A::AbstractTriangular) = A.data
 
 fill!(A::AbstractTriangular, x) = (fill!(A.data, x); A)
 

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -128,15 +128,15 @@ inv(J::UniformScaling) = UniformScaling(inv(J.λ))
 *(J::UniformScaling, x::Number) = UniformScaling(J.λ*x)
 
 /(J1::UniformScaling, J2::UniformScaling) = J2.λ == 0 ? throw(SingularException(1)) : UniformScaling(J1.λ/J2.λ)
-/(J::UniformScaling, A::AbstractMatrix) = J.λ*inv(A)
+/(J::UniformScaling, A::AbstractMatrix) = scale!(J.λ, inv(A))
 /(A::AbstractMatrix, J::UniformScaling) = J.λ == 0 ? throw(SingularException(1)) : A/J.λ
 
 /(J::UniformScaling, x::Number) = UniformScaling(J.λ/x)
 
 \(J1::UniformScaling, J2::UniformScaling) = J1.λ == 0 ? throw(SingularException(1)) : UniformScaling(J1.λ\J2.λ)
-\{T<:Number}(A::Union{Bidiagonal{T},AbstractTriangular{T}}, J::UniformScaling) = inv(A)*J.λ
+\{T<:Number}(A::Union{Bidiagonal{T},AbstractTriangular{T}}, J::UniformScaling) = scale!(inv(A), J.λ)
 \(J::UniformScaling, A::AbstractVecOrMat) = J.λ == 0 ? throw(SingularException(1)) : J.λ\A
-\(A::AbstractMatrix, J::UniformScaling) = inv(A)*J.λ
+\(A::AbstractMatrix, J::UniformScaling) = scale!(inv(A), J.λ)
 
 \(x::Number, J::UniformScaling) = UniformScaling(x\J.λ)
 

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -36,57 +36,86 @@ B = bitrand(2,2)
 @test B + I == B + eye(B)
 @test I + B == B + eye(B)
 
-A = randn(2,2)
-@test A + I == A + eye(A)
-@test I + A == A + eye(A)
-@test I - I === UniformScaling(0)
-@test B - I == B - eye(B)
-@test I - B == eye(B) - B
-@test A - I == A - eye(A)
-@test I - A == eye(A) - A
-@test I*J === UniformScaling(λ)
-@test B*J == B*λ
-@test J*B == B*λ
+let AA = randn(2,2), SS = sprandn(3,3,0.5)
+    for atype in ("Array", "SubArray")
+        if atype == "Array"
+            A = AA
+            S = SS
+        else
+            A = sub(AA, 1:2, 1:2)
+            S = sub(SS, 1:3, 1:3)
+        end
 
-S = sprandn(3,3,0.5)
-@test S*J == S*λ
-@test J*S == S*λ
-@test A*J == A*λ
-@test J*A == A*λ
-@test J*ones(3) == ones(3)*λ
-@test λ*J === UniformScaling(λ*J.λ)
-@test J*λ === UniformScaling(λ*J.λ)
-@test J/I === J
-@test I/A == inv(A)
-@test A/I == A
-@test I/λ === UniformScaling(1/λ)
-@test I\J === J
+        @test A + I == A + eye(A)
+        @test I + A == A + eye(A)
+        @test I - I === UniformScaling(0)
+        @test B - I == B - eye(B)
+        @test I - B == eye(B) - B
+        @test A - I == A - eye(A)
+        @test I - A == eye(A) - A
+        @test I*J === UniformScaling(λ)
+        @test B*J == B*λ
+        @test J*B == B*λ
 
-T = LowerTriangular(randn(3,3))
-@test T + J == full(T) + J
-@test J + T == J + full(T)
-@test T - J == full(T) - J
-@test J - T == J - full(T)
-@test T\I == inv(T)
-T = LinAlg.UnitLowerTriangular(randn(3,3))
-@test T + J == full(T) + J
-@test J + T == J + full(T)
-@test T - J == full(T) - J
-@test J - T == J - full(T)
-@test T\I == inv(T)
-T = UpperTriangular(randn(3,3))
-@test T + J == full(T) + J
-@test J + T == J + full(T)
-@test T - J == full(T) - J
-@test J - T == J - full(T)
-@test T\I == inv(T)
-T = LinAlg.UnitUpperTriangular(randn(3,3))
-@test T + J == full(T) + J
-@test J + T == J + full(T)
-@test T - J == full(T) - J
-@test J - T == J - full(T)
-@test T\I == inv(T)
+        @test S*J == S*λ
+        @test J*S == S*λ
+        @test A*J == A*λ
+        @test J*A == A*λ
+        @test J*ones(3) == ones(3)*λ
+        @test λ*J === UniformScaling(λ*J.λ)
+        @test J*λ === UniformScaling(λ*J.λ)
+        @test J/I === J
+        @test I/A == inv(A)
+        @test A/I == A
+        @test I/λ === UniformScaling(1/λ)
+        @test I\J === J
 
-@test I\A == A
-@test A\I == inv(A)
-@test λ\I === UniformScaling(1/λ)
+        if atype == "Array"
+            T = LowerTriangular(randn(3,3))
+        else
+            T = LowerTriangular(sub(randn(3,3), 1:3, 1:3))
+        end
+        @test T + J == full(T) + J
+        @test J + T == J + full(T)
+        @test T - J == full(T) - J
+        @test J - T == J - full(T)
+        @test T\I == inv(T)
+
+        if atype == "Array"
+            T = LinAlg.UnitLowerTriangular(randn(3,3))
+        else
+            T = LinAlg.UnitLowerTriangular(sub(randn(3,3), 1:3, 1:3))
+        end
+        @test T + J == full(T) + J
+        @test J + T == J + full(T)
+        @test T - J == full(T) - J
+        @test J - T == J - full(T)
+        @test T\I == inv(T)
+
+        if atype == "Array"
+            T = UpperTriangular(randn(3,3))
+        else
+            T = UpperTriangular(sub(randn(3,3), 1:3, 1:3))
+        end
+        @test T + J == full(T) + J
+        @test J + T == J + full(T)
+        @test T - J == full(T) - J
+        @test J - T == J - full(T)
+        @test T\I == inv(T)
+
+        if atype == "Array"
+            T = LinAlg.UnitUpperTriangular(randn(3,3))
+        else
+            T = LinAlg.UnitUpperTriangular(sub(randn(3,3), 1:3, 1:3))
+        end
+        @test T + J == full(T) + J
+        @test J + T == J + full(T)
+        @test T - J == full(T) - J
+        @test J - T == J - full(T)
+        @test T\I == inv(T)
+
+        @test I\A == A
+        @test A\I == inv(A)
+        @test λ\I === UniformScaling(1/λ)
+    end
+end


### PR DESCRIPTION
I've started to extend the linear algebra tests to cover `SubArrays`. There is much work to be done. This one adds coverage for the `UniformScaling` tests.

The tests revealed a bug in `inv(SubArray)` so this PR also includes a fix for this by defining `parent` methods for special matrix types.
