### PR TITLE
idleworker() function.

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -332,11 +332,14 @@ function workers()
 end
 
 function idleworker()
+    if nprocs() == 1
+        return 1
+    end
     while true
         busy_workers = Int[rv.waitingfor for (id,rv) in PGRP.refs]
         for w in PGRP.workers
             if w.id != 1 && !(w.id in busy_workers)
-                return w
+                return w.id
             end
         end
         wait(PGRP.worker_is_idle)


### PR DESCRIPTION
`idleworker()` returns a worker that is not currently busy (not being waited for by `remotecall_fetch` or `remotecall_wait`).

If there are no idle workers, `idleworker()` blocks until a worker is available.

This is intended as a more general interface for the type of dynamic scheduling provided by `pmap`.
e.g. `pmap` might eventually be a simple combination of [`amap()`](https://github.com/samoconnor/AsyncMap.jl/blob/master/src/AsyncMap.jl#L22) and `idleworker()` as described in https://github.com/JuliaLang/julia/issues/14843...

``` julia
remote(f, args...) = (args...) -> remotecall_fetch(f, idleworker(), args...)
pmap(f, c...) = amap(remote(f), c...; max=nworkers())
```

Implementation notes:
- Uses the existing `RemoteValue.waitingfor` field to identify busy workers.
- Fixes `remotecall_fetch` and `remotecall_wait` to set `rv.waitingfor` back to 0 after waiting.
- Adds `ProcessGroup.worker_is_idle::Condition` to enable waiting for multiple busy workers. `idleworker()` waits on `worker_is_idle`. `remotecall_fetch` and `remotecall_wait` notify `worker_is_idle` just after setting `rv.waitingfor = 0`.
