### PR TITLE
Remove -fcolor-diagnostics when using Clang+ccache

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -394,8 +394,8 @@ CXX_BASE := ccache
 ifeq ($(USECLANG),1)
 # ccache and Clang don't do well together
 # http://petereisentraut.blogspot.be/2011/05/ccache-and-clang.html
-CC += -Qunused-arguments -fcolor-diagnostics
-CXX += -Qunused-arguments -fcolor-diagnostics
+CC += -Qunused-arguments
+CXX += -Qunused-arguments
 # http://petereisentraut.blogspot.be/2011/09/ccache-and-clang-part-2.html
 export CCACHE_CPP2 := yes
 endif


### PR DESCRIPTION
This has been fixed since [ccache 3.2.1](https://ccache.samba.org/releasenotes.html#_ccache_3_2_1).
