### PR TITLE
Fix LLVM 3.9 API breakage

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -216,7 +216,11 @@ public:
         auto oit = Objects.begin();
         auto lit = LOS.begin();
         while (oit != Objects.end()) {
+#ifdef LLVM39
+            const auto &Object = (*oit)->getBinary();
+#else
             auto &Object = *oit;
+#endif
             auto &LO = *lit;
 
             OwningBinary<ObjectFile> SavedObject = LO->getObjectForDebug(*Object);


### PR DESCRIPTION
Didn't check which commit is this but `ObjSetT` is `std::vector<std::unique_ptr<llvm::object::OwningBinary<llvm::object::ObjectFile>>>` on LLVM 3.9 now.

c.c. @Keno 
