### PR TITLE
llvmcall: fix declaration name extraction.

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -655,7 +655,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
                     // Find name of declaration by searching for '@'
                     std::string::size_type atpos = declstr.find('@') + 1;
                     // Find end of declaration by searching for '('
-                    std::string::size_type bracepos = declstr.find('(');
+                    std::string::size_type bracepos = declstr.find('(', atpos);
                     // Declaration name is the string between @ and (
                     std::string declname = declstr.substr(atpos, bracepos - atpos);
 

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -125,7 +125,6 @@ function declared_ceil(x::Float64)
             ret double %2"""),
     Float64, Tuple{Float64}, x)
 end
-
 @test_approx_eq declared_ceil(4.2) 5.0
 
 # Test for multiple lines
@@ -138,5 +137,13 @@ function ceilfloor(x::Float64)
             ret double %3"""),
     Float64, Tuple{Float64}, x)
 end
-
 @test_approx_eq ceilfloor(7.4) 8.0
+
+# Test for proper declaration extraction
+function confuse_declname_parsing()
+    llvmcall(
+        ("""declare i64 addrspace(0)* @foobar()""",
+         """ret void"""),
+    Void, Tuple{})
+end
+confuse_declname_parsing()


### PR DESCRIPTION
Finding the starting `(` when parsing the declaration name should start after the `@`.

@keno On a related note, I had an idea for making the whole `llvmcall` flow significantly cleaner: parse everything into a new module, call `prepare_` on all global values, and use the function mover to put everything in the builtins module. This would get rid of the fragile declaration parsing, as well as the global state. It would also unbreak LLVM<3.5 (where failure to parse IR leaves the module in a messy state, see the disabled test in `test/llvmcall.jl`). Disadvantage: creating and destroying a module for each `emit_llvmcall`, without caching. Thoughts?
