### PR TITLE
output build statistics during CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - bar
+            - time
             - binutils:i386
             - gcc-5:i386
             - g++-5:i386
@@ -27,6 +28,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - bar
+            - time
             - g++-5
             - gfortran-5
     - os: osx
@@ -64,7 +66,7 @@ before_install:
         brew tap staticfloat/julia;
         brew rm --force $(brew deps --HEAD julia);
         brew install -v --only-dependencies --HEAD julia;
-        BUILDOPTS="-j3 USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm37-julia)/bin/llvm-config-3.7.1 VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse-julia)/include FORCE_ASSERTIONS=1 STAGE2_DEPS=utf8proc";
+        BUILDOPTS="-j3 USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm37-julia)/bin/llvm-config-3.7.1 LLVM_SIZE=$(brew --prefix llvm37-julia)/bin/llvm-size-3.7.1 VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse-julia)/include FORCE_ASSERTIONS=1 STAGE2_DEPS=utf8proc";
         BUILDOPTS="$BUILDOPTS LIBBLAS=-lopenblas LIBBLASNAME=libopenblas LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas";
         for lib in LLVM SUITESPARSE ARPACK BLAS FFTW LAPACK GMP MPFR PCRE LIBUNWIND LIBGIT2; do
             export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1";
@@ -80,6 +82,8 @@ script:
     - make $BUILDOPTS -C base version_git.jl.phony
     - moreutils/mispipe "make $BUILDOPTS NO_GIT=1 -C deps" bar > deps.log || cat deps.log
     - make $BUILDOPTS NO_GIT=1 JULIA_SYSIMG_BUILD_FLAGS="--output-ji ../usr/lib/julia/sys.ji" prefix=/tmp/julia install | moreutils/ts -s "%.s"
+    - make $BUILDOPTS NO_GIT=1 build-stats
+    - du -sk /tmp/julia/*
     - if [ `uname` = "Darwin" ]; then
         for name in suitesparseconfig spqr umfpack colamd cholmod amd suitesparse_wrapper; do
             install -pm755 usr/lib/lib${name}*.dylib* /tmp/julia/lib/julia/;

--- a/Make.inc
+++ b/Make.inc
@@ -338,8 +338,8 @@ CXX := $(CROSS_COMPILE)g++
 JCFLAGS := -std=gnu99 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 JCPPFLAGS :=
 JCXXFLAGS := -pipe $(fPIC) -fno-rtti
-DEBUGFLAGS := -O0 -ggdb3 -DJL_DEBUG_BUILD -fstack-protector-all
-SHIPFLAGS := -O3 -ggdb3 -falign-functions
+DEBUGFLAGS := -O0 -ggdb2 -DJL_DEBUG_BUILD -fstack-protector-all
+SHIPFLAGS := -O3 -ggdb1 -falign-functions
 endif
 
 ifeq ($(USECLANG),1)

--- a/Makefile
+++ b/Makefile
@@ -621,3 +621,17 @@ endif
 	chmod a+x 7z.dll && \
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \
 	chmod a+x ./nsis/makensis.exe
+
+# various statistics about the build that may interest the user
+ifeq ($(USE_SYSTEM_LLVM), 1)
+LLVM_SIZE := llvm-size$(EXE)
+else
+LLVM_SIZE := $(build_bindir)/llvm-size$(EXE)
+endif
+build-stats:
+	@echo $(JULCOLOR)' ==> ./julia binary sizes'$(ENDCOLOR)
+	$(call spawn,$(LLVM_SIZE) -A $(build_private_libdir)/sys.$(SHLIB_EXT) $(build_shlibdir)/libjulia.$(SHLIB_EXT) $(build_bindir)/julia$(EXE))
+	@echo $(JULCOLOR)' ==> ./julia launch speedtest'$(ENDCOLOR)
+	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')
+	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')
+	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ build_script:
 # Unable to find Digest::SHA or Digest::SHA::PurePerl
   - set PATH=%PATH:C:\Perl\bin;=%
 #  - '"%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64'
-  - C:\MinGW\msys\1.0\bin\sh --login /c/projects/julia/contrib/windows/msys_build.sh
+  - C:\msys64\usr\bin\sh.exe --login /c/projects/julia/contrib/windows/msys_build.sh
 
 test_script:
   - usr\bin\julia -e "versioninfo()"

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -10,6 +10,8 @@
 cd `dirname "$0"`/../..
 # Stop on error
 set -e
+# Make sure stdin exists (not true on appveyor msys2)
+exec < /dev/null
 
 curlflags="curl --retry 10 -k -L -y 5"
 checksum_download() {
@@ -138,7 +140,7 @@ checksum_download \
     "$f" "https://bintray.com/artifact/download/tkelman/generic/$f"
 echo "Extracting $f"
 $SEVENZIP x -y $f >> get-deps.log
-echo 'override LLVM_CONFIG = $(JULIAHOME)/usr/bin/llvm-config' >> Make.user
+echo 'override LLVM_CONFIG = $(JULIAHOME)/usr/bin/llvm-config.exe' >> Make.user
 
 if [ -z "`which make 2>/dev/null`" ]; then
   if [ -n "`uname | grep CYGWIN`" ]; then
@@ -197,4 +199,5 @@ echo 'FORCE_ASSERTIONS = 1' >> Make.user
 
 cat Make.user
 make VERBOSE=1
+make build-stats
 #make debug


### PR DESCRIPTION
in order to make it easier to compare the effect of various CI runs and branches on code-size (and other metrics), this adds a `make build-stats` target to the toplevel makefile and the CI scripts.
