### PR TITLE
markdown: ensure line-break after displayed math

### DIFF
--- a/base/markdown/IPython/IPython.jl
+++ b/base/markdown/IPython/IPython.jl
@@ -26,7 +26,7 @@ writemime(io::IO, ::MIME"text/plain", tex::LaTeX) =
     print(io, '$', tex.formula, '$')
 
 latex(io::IO, tex::LaTeX) =
-    print(io, "\$\$", tex.formula, "\$\$")
+    println(io, "\$\$", tex.formula, "\$\$")
 
 latexinline(io::IO, tex::LaTeX) =
     print(io, '$', tex.formula, '$')

--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -53,7 +53,10 @@ function plain(io::IO, md::HorizontalRule)
     println(io, "-" ^ 3)
 end
 
-plain(io::IO, md) = writemime(io, "text/plain", md)
+function plain(io::IO, md)
+    writemime(io,  MIME"text/plain"(), md)
+    println(io)
+end
 
 # Inline elements
 

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -299,12 +299,15 @@ t = """a   |   b
 latex_doc = md"""
 We have $x^2 < x$ whenever:
 
-$|x| < 1$"""
+$|x| < 1$
+
+etc."""
 
 @test latex_doc == MD(Any[Paragraph(Any["We have ",
                                         LaTeX("x^2 < x"),
                                         " whenever:"]),
-                          LaTeX("|x| < 1")])
+                          LaTeX("|x| < 1"),
+                          Paragraph(Any["etc."])])
 
-
-@test latex(latex_doc) == "We have \$x^2 < x\$ whenever:\n\$\$|x| < 1\$\$"
+@test plain(latex_doc) == "We have \$x^2 < x\$ whenever:\n\n\$|x| < 1\$\n\netc.\n"
+@test latex(latex_doc) == "We have \$x^2 < x\$ whenever:\n\$\$|x| < 1\$\$\netc.\n"


### PR DESCRIPTION
fixes the display of help in IJulia notebooks (e.g. `ifft`)
