### PR TITLE
Error on undefined variable in statement position

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -520,8 +520,8 @@ more than one expression is marked then the same docstring is applied to each ex
 :(Base.@__doc__)
 
 function __doc__!(meta, def::Expr)
-    if isexpr(def, :block, 2) && def.args[1] == symbol("#doc#")
-        # Convert `Expr(:block, :#doc#, ...)` created by `@__doc__` to an `@doc`.
+    if isexpr(def, :block, 2) && isexpr(def.args[1], :meta, 1) && def.args[1].args[1] === :doc
+        # Convert `Expr(:block, Expr(:meta, :doc), ...)` created by `@__doc__` to an `@doc`.
         def.head = :macrocall
         def.args = [symbol("@doc"), meta, def.args[end]]
         true

--- a/base/docs/bootstrap.jl
+++ b/base/docs/bootstrap.jl
@@ -4,7 +4,7 @@ macro doc(args...)
     DocBootstrap._expand_(args...)
 end
 
-macro __doc__(ex) esc(Expr(:block, symbol("#doc#"), ex)) end
+macro __doc__(ex) esc(Expr(:block, Expr(:meta, :doc), ex)) end
 
 module DocBootstrap
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2807,7 +2807,7 @@ So far only the second case can actually occur.
     (define (compile e break-labels)
       (if (or (not (pair? e)) (equal? e '(null)))
           ;; atom has no effect, but keep symbols for undefined-var checking
-          #f #;(if (symbol? e) (emit e) #f)
+          (if (symbol? e) (emit e) #f)
           (case (car e)
             ((call)  (emit (goto-form e)))
             ((=)     (let ((vt (vinfo:type

--- a/test/core.jl
+++ b/test/core.jl
@@ -3666,3 +3666,7 @@ f14245() = (v = []; push!(v, length(v)); v)
 end
 foo9677(x::Array) = invoke(foo9677,(AbstractArray,),x)
 @test foo9677(1:5) == foo9677(randn(3))
+
+# issue #6846
+f6846() = (please6846; 2)
+@test_throws UndefVarError f6846()


### PR DESCRIPTION
easy way to fix #6846

Not quite sure about this yet since I don't know why this was removed (the lowering) in the first place. From a cursory test codegen seems to still eliminate useless globals lookups when we know that it is defined at compile time.
There may be cases where this induces a slowdown if we generate the dynamic lookup code and that the variable ends up being defined. I'm not sure how common are variables in value position anyway.
