### PR TITLE
RFC: always warn on overwritten methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@ Language changes
 
   * Relational symbols are now allowed as infix operators ([#8036]).
 
+  * A warning is always given when a method is overwritten (previously, this was done only when the new
+    and old definitions were in separate modules) ([#14759]).
+
 Command-line option changes
 ---------------------------
 
@@ -1764,3 +1767,4 @@ Too numerous to mention.
 [#14243]: https://github.com/JuliaLang/julia/issues/14243
 [#14413]: https://github.com/JuliaLang/julia/issues/14413
 [#14424]: https://github.com/JuliaLang/julia/issues/14424
+[#14759]: https://github.com/JuliaLang/julia/issues/14759

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -380,6 +380,7 @@ for (f, cachef, scalarf) in ((:.==, :bitcache_eq , :(==)),
                              (:.< , :bitcache_lt , :<   ),
                              (:.!=, :bitcache_neq, :!=  ),
                              (:.<=, :bitcache_le , :<=  ))
+    @eval ($cachef)(A::AbstractArray, B::AbstractArray, l::Int, ind::Int, C::Vector{Bool}) = 0
     for (sigA, sigB, expA, expB, shape) in ((:Any, :AbstractArray,
                                              :A, :(B[ind]),
                                              :(size(B))),
@@ -387,7 +388,6 @@ for (f, cachef, scalarf) in ((:.==, :bitcache_eq , :(==)),
                                              :(A[ind]), :B,
                                              :(size(A))))
         @eval begin
-            ($cachef)(A::AbstractArray, B::AbstractArray, l::Int, ind::Int, C::Vector{Bool}) = 0
             function ($cachef)(A::$sigA, B::$sigB, l::Int, ind::Int, C::Vector{Bool})
                 left = l - ind + 1
                 @inbounds begin

--- a/base/checked.jl
+++ b/base/checked.jl
@@ -81,14 +81,18 @@ end
 function checked_neg{T<:UnsignedInt}(x::T)
     checked_sub(T(0), x)
 end
+if BrokenSignedInt != Union{}
 function checked_neg{T<:BrokenSignedInt}(x::T)
     r = -x
     (x<0) & (r<0) && throw(OverflowError())
     r
 end
+end
+if BrokenUnsignedInt != Union{}
 function checked_neg{T<:BrokenUnsignedInt}(x::T)
     x != 0 && throw(OverflowError())
     T(0)
+end
 end
 
 """
@@ -124,17 +128,21 @@ end
 function checked_add{T<:UnsignedInt}(x::T, y::T)
     box(T, checked_uadd_int(unbox(T,x), unbox(T,y)))
 end
+if BrokenSignedInt != Union{}
 function checked_add{T<:BrokenSignedInt}(x::T, y::T)
     r = x + y
     # x and y have the same sign, and the result has a different sign
     (x<0) == (y<0) != (r<0) && throw(OverflowError())
     r
 end
+end
+if BrokenUnsignedInt != Union{}
 function checked_add{T<:BrokenUnsignedInt}(x::T, y::T)
     # x + y > typemax(T)
     # Note: ~y == -y-1
     x > ~y && throw(OverflowError())
     x + y
+end
 end
 
 # Handle multiple arguments
@@ -167,16 +175,20 @@ end
 function checked_sub{T<:UnsignedInt}(x::T, y::T)
     box(T, checked_usub_int(unbox(T,x), unbox(T,y)))
 end
+if BrokenSignedInt != Union{}
 function checked_sub{T<:BrokenSignedInt}(x::T, y::T)
     r = x - y
     # x and y have different signs, and the result has a different sign than x
     (x<0) != (y<0) == (r<0) && throw(OverflowError())
     r
 end
+end
+if BrokenUnsignedInt != Union{}
 function checked_sub{T<:BrokenUnsignedInt}(x::T, y::T)
     # x - y < 0
     x < y && throw(OverflowError())
     x - y
+end
 end
 
 """
@@ -194,15 +206,19 @@ end
 function checked_mul{T<:UnsignedInt}(x::T, y::T)
     box(T, checked_umul_int(unbox(T,x), unbox(T,y)))
 end
+if BrokenSignedIntMul != Union{} && BrokenSignedIntMul != Int128
 function checked_mul{T<:BrokenSignedIntMul}(x::T, y::T)
     r = widemul(x, y)
     r % T != r && throw(OverflowError())
     r % T
 end
+end
+if BrokenUnsignedIntMul != Union{} && BrokenUnsignedIntMul != UInt128
 function checked_mul{T<:BrokenUnsignedIntMul}(x::T, y::T)
     r = widemul(x, y)
     r % T != r && throw(OverflowError())
     r % T
+end
 end
 if Int128 <: BrokenSignedIntMul
     # Avoid BigInt

--- a/base/functors.jl
+++ b/base/functors.jl
@@ -119,7 +119,6 @@ call(pred::Predicate, x) = pred.f(x)::Bool
 immutable EqX{T} <: Func{1}
     x::T
 end
-EqX{T}(x::T) = EqX{T}(x)
 
 call(f::EqX, y) = f.x == y
 

--- a/base/libgit2/oid.jl
+++ b/base/libgit2/oid.jl
@@ -2,7 +2,6 @@
 
 Oid(id::Oid) = id
 Oid(ptr::Ptr{Oid}) = unsafe_load(ptr)::Oid
-Oid(arr::Vector{UInt8}) = Oid(tuple(arr...))
 
 function Oid(ptr::Ptr{UInt8})
     if ptr == C_NULL

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -183,7 +183,7 @@ function reset!(repo::GitRepo, obj::GitObject, mode::Cint;
 end
 
 function clone(repo_url::AbstractString, repo_path::AbstractString,
-               clone_opts::CloneOptions = CloneOptions())
+               clone_opts::CloneOptions)
     clone_opts_ref = Ref(clone_opts)
     repo_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
     @check ccall((:git_clone, :libgit2), Cint,

--- a/base/libgit2/tree.jl
+++ b/base/libgit2/tree.jl
@@ -26,10 +26,6 @@ function filemode(te::GitTreeEntry)
     return ccall((:git_tree_entry_filemode, :libgit2), Cint, (Ptr{Void},), te.ptr)
 end
 
-function filemode(te::GitTreeEntry)
-    return ccall((:git_tree_entry_filemode, :libgit2), Cint, (Ptr{Void},), te.ptr)
-end
-
 
 function object(repo::GitRepo, te::GitTreeEntry)
     obj_ptr_ptr = Ref{Ptr{Void}}(C_NULL)

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -390,7 +390,6 @@ function A_mul_Bc!{T}(A::AbstractMatrix{T},Q::QRPackedQ{T})
     end
     A
 end
-A_mul_Bc(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc(full(A), B)
 function A_mul_Bc{TA,TB}(A::AbstractArray{TA}, B::Union{QRCompactWYQ{TB},QRPackedQ{TB}})
     TAB = promote_type(TA,TB)
     BB = convert(AbstractMatrix{TAB}, B)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1300,7 +1300,7 @@ for t in (UpperTriangular, UnitUpperTriangular, LowerTriangular, UnitLowerTriang
     end
 end
 
-for f in (:*, :Ac_mul_B, :At_mul_B, :A_mul_Bc, :A_mul_Bt, :Ac_mul_Bc, :At_mul_Bt, :\, :Ac_ldiv_B, :At_ldiv_B)
+for f in (:*, :Ac_mul_B, :At_mul_B, :\, :Ac_ldiv_B, :At_ldiv_B)
     @eval begin
         ($f)(A::AbstractTriangular, B::AbstractTriangular) = ($f)(A, full(B))
     end

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -41,7 +41,6 @@ immutable Perm{O<:Ordering,V<:AbstractVector} <: Ordering
     order::O
     data::V
 end
-Perm{O<:Ordering,V<:AbstractVector}(o::O,v::V) = Perm{O,V}(o,v)
 
 lt(o::ForwardOrdering,       a, b) = isless(a,b)
 lt(o::ReverseOrdering,       a, b) = lt(o.fwd,b,a)

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -117,7 +117,7 @@ installed(pkg::AbstractString) = cd(Entry.installed,pkg)
 Prints out a summary of what packages are installed and what version and state they're in.
 """
 status(io::IO=STDOUT) = cd(Entry.status,io)
-status(pkg::AbstractString = "", io::IO=STDOUT) = cd(Entry.status,io,pkg)
+status(pkg::AbstractString, io::IO=STDOUT) = cd(Entry.status,io,pkg)
 
 """
     clone(pkg)

--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -11,7 +11,7 @@ immutable HierarchicalValue{T}
     rest::T
 end
 
-HierarchicalValue{T}(v::Vector{T}, rest::T = zero(T)) = HierarchicalValue{T}(v, rest)
+HierarchicalValue{T}(v::Vector{T}) = HierarchicalValue{T}(v, zero(T))
 HierarchicalValue(T::Type) = HierarchicalValue(T[])
 
 Base.zero{T}(::Type{HierarchicalValue{T}}) = HierarchicalValue(T)

--- a/base/process.jl
+++ b/base/process.jl
@@ -527,8 +527,6 @@ spawn_opts_inherit(in::Redirectable=RawFD(0), out::Redirectable=RawFD(1), err::R
 
 spawn(cmds::AbstractCmd, args...; chain::Nullable{ProcessChain}=Nullable{ProcessChain}()) =
     spawn(cmds, spawn_opts_swallow(args...)...; chain=chain)
-spawn(cmds::AbstractCmd, args...; chain::Nullable{ProcessChain}=Nullable{ProcessChain}()) =
-    spawn(cmds, spawn_opts_swallow(args...)...; chain=chain)
 
 function eachline(cmd::AbstractCmd, stdin)
     stdout = Pipe()

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -239,15 +239,8 @@ muladd{T<:Number}(x::T, y::T, z::T) = x*y+z
  <{T<:Real}(x::T, y::T) = no_op_err("<" , T)
 <={T<:Real}(x::T, y::T) = no_op_err("<=", T)
 
-div{T<:Real}(x::T, y::T) = no_op_err("div", T)
-fld{T<:Real}(x::T, y::T) = no_op_err("fld", T)
-cld{T<:Real}(x::T, y::T) = no_op_err("cld", T)
 rem{T<:Real}(x::T, y::T) = no_op_err("rem", T)
 mod{T<:Real}(x::T, y::T) = no_op_err("mod", T)
-
-mod1{T<:Real}(x::T, y::T) = no_op_err("mod1", T)
-rem1{T<:Real}(x::T, y::T) = no_op_err("rem1", T)
-fld1{T<:Real}(x::T, y::T) = no_op_err("fld1", T)
 
 min(x::Real) = x
 max(x::Real) = x

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -222,8 +222,6 @@ function _mapreducedim!{T,N}(f, op, R::AbstractArray, A::AbstractArray{T,N})
     return R
 end
 
-mapreducedim!(f, op, R::AbstractArray, A::AbstractArray) = (_mapreducedim!(f, op, R, A); R)
-
 to_op(op) = op
 function to_op(op::Function)
     is(op, +) ? AddFun() :

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -362,7 +362,7 @@ function next(itr::RegexMatchIterator, prev_match)
     (prev_match, nothing)
 end
 
-function eachmatch(re::Regex, str::AbstractString, ovr::Bool=false)
+function eachmatch(re::Regex, str::AbstractString, ovr::Bool)
     RegexMatchIterator(re,str,ovr)
 end
 

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -732,8 +732,6 @@ deserialize(s::SerializationState, ::Type{BigFloat}) = parse(BigFloat, deseriali
 
 deserialize(s::SerializationState, ::Type{BigInt}) = get(GMP.tryparse_internal(BigInt, deserialize(s), 62, true))
 
-deserialize(s::SerializationState, ::Type{BigInt}) = get(GMP.tryparse_internal(BigInt, deserialize(s), 62, true))
-
 function deserialize(s::SerializationState, t::Type{Regex})
     pattern = deserialize(s)
     compile_options = deserialize(s)

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -410,7 +410,6 @@ for Tv in (:Float64, :Complex128), Ti in UmfpackIndexTypes
         end
     end
 end
-show_umf_info() = show_umf_info(2.)
 
 function umfpack_report_symbolic(symb::Ptr{Void}, level::Real)
     old_prl::Float64 = umf_ctrl[UMFPACK_PRL]

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -120,7 +120,6 @@ for f in Symbol[
     :isdir
     :isblockdev
     :isfile
-    :islink
     :issocket
     :issetuid
     :issetgid

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -255,8 +255,6 @@ function iswritable(io::LibuvStream)
     return ccall(:uv_is_writable, Cint, (Ptr{Void},), io.handle) != 0
 end
 
-nb_available(stream::LibuvStream) = nb_available(stream.buffer)
-
 lock(s::LibuvStream) = lock(s.lock)
 unlock(s::LibuvStream) = unlock(s.lock)
 

--- a/examples/lru.jl
+++ b/examples/lru.jl
@@ -58,7 +58,6 @@ BoundedLRU() = BoundedLRU{Any, Any}()
 
 isempty(lru::LRU) = isempty(lru.q)
 length(lru::LRU) = length(lru.q)
-haskey(lru::LRU, key) = haskey(lru.ht, key)
 
 ## associative ##
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -1229,18 +1229,18 @@ jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tupletype_t *type,
         if (((l->tvars==jl_emptysvec) == (tvars==jl_emptysvec)) &&
             sigs_eq((jl_value_t*)type, (jl_value_t*)l->sig, 1)) {
             // method overwritten
-            if (check_amb && l->func->linfo && method->linfo &&
-                (l->func->linfo->module != method->linfo->module)) {
+            if (check_amb && l->func->linfo && method->linfo) {
                 jl_module_t *newmod = method->linfo->module;
+                jl_module_t *oldmod = l->func->linfo->module;
                 JL_STREAM *s = JL_STDERR;
                 jl_printf(s, "WARNING: Method definition %s",
                           jl_symbol_name(method->linfo->name));
                 jl_static_show_func_sig(s, (jl_value_t*)type);
-                jl_printf(s, " in module %s",
-                          jl_symbol_name(l->func->linfo->module->name));
+                jl_printf(s, " in module %s", jl_symbol_name(oldmod->name));
                 print_func_loc(s, l->func->linfo);
-                jl_printf(s, " overwritten in module %s",
-                          jl_symbol_name(newmod->name));
+                jl_printf(s, " overwritten");
+                if (oldmod != newmod)
+                    jl_printf(s, " in module %s", jl_symbol_name(newmod->name));
                 print_func_loc(s, method->linfo);
                 jl_printf(s, ".\n");
             }

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -89,12 +89,6 @@ b = ccall((:test_1, libccalltest), Struct1, (Struct1,), a)
 @test !(a === b)
 @test b.x == s1.x + 1 && b.y == s1.y - 2
 
-function foos1(s::Struct1)
-    @test !(s === a)
-    @test s == a
-    s
-end
-
 ci32 = Complex{Int32}(Int32(10),Int32(31))
 ba = ccall((:test_2a, libccalltest), Complex{Int32}, (Complex{Int32},), ci32)
 bb = ccall((:test_2b, libccalltest), Complex{Int32}, (Complex{Int32},), ci32)
@@ -134,7 +128,7 @@ verbose && Libc.flush_cstdio()
 verbose && println("Testing cfunction roundtrip: ")
 # cfunction roundtrip
 for (t,v) in ((Complex{Int32},:ci32),(Complex{Int64},:ci64),
-            (Complex64,:cf32),(Complex128,:cf64),(Struct1,:s1))
+              (Complex64,:cf32),(Complex128,:cf64),(Struct1,:s1))
     fname = symbol("foo"*string(v))
     fname1 = symbol("foo1"*string(v))
     @eval begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -319,15 +319,17 @@ function fooo_3()
     y
 end
 @test fooo_3() === 100
-function foo()
-    local x::Int8
-    function bar()
-        x = 100
-    end
+let
+    function foo()
+        local x::Int8
+        function bar()
+            x = 100
+        end
     bar()
-    x
+        x
+    end
+    @test foo() === convert(Int8,100)
 end
-@test foo() === convert(Int8,100)
 
 function bar{T}(x::T)
     local z::Complex{T}
@@ -421,14 +423,14 @@ glotest()
 # issue #7234
 begin
     glob_x2 = 24
-    f7234() = (glob_x2 += 1)
+    f7234_a() = (glob_x2 += 1)
 end
-@test_throws UndefVarError f7234()
+@test_throws UndefVarError f7234_a()
 begin
     global glob_x2 = 24
-    f7234() = (glob_x2 += 1)
+    f7234_b() = (glob_x2 += 1)
 end
-@test_throws UndefVarError f7234()
+@test_throws UndefVarError f7234_b()
 # existing globals can be inherited by non-function blocks
 for i = 1:2
     glob_x2 += 1
@@ -1233,14 +1235,15 @@ end
 @test isa(foo4075(Foo4075(Int64(1),2.0),:y), Float64)
 
 # issue #3167
-function foo(x)
-    ret=Array(typeof(x[1]), length(x))
-    for j = 1:length(x)
-        ret[j] = x[j]
+let
+    function foo(x)
+        ret=Array(typeof(x[1]), length(x))
+        for j = 1:length(x)
+            ret[j] = x[j]
+        end
+        return ret
     end
-    return ret
-end
-let x = Array(Union{Dict{Int64,AbstractString},Array{Int64,3},Number,AbstractString,Void}, 3)
+    x = Array(Union{Dict{Int64,AbstractString},Array{Int64,3},Number,AbstractString,Void}, 3)
     x[1] = 1.0
     x[2] = 2.0
     x[3] = 3.0
@@ -3089,10 +3092,12 @@ end
 # issue 11858
 type Foo11858
     x::Float64
+    Foo11858(x::Float64) = new(x)
 end
 
 type Bar11858
     x::Float64
+    Bar11858(x::Float64) = new(x)
 end
 
 g11858(x::Float64) = x

--- a/test/dates/accessors.jl
+++ b/test/dates/accessors.jl
@@ -40,7 +40,7 @@
 # test_dates(-10000,10000) takes about 15 seconds
 # test_dates(year(typemin(Date)),year(typemax(Date))) is full range
 # and would take.......a really long time
-function test_dates(from,to)
+function test_dates1(from,to)
     y = m = d = 0
     test_day = Dates.totaldays(from,1,1)
     for y in from:to
@@ -54,10 +54,10 @@ function test_dates(from,to)
         end
     end
 end
-test_dates(0,2100)
+test_dates1(0,2100)
 
 # Test year, month, day, hour, minute
-function test_dates()
+function test_dates1()
     y = m = d = h = mi = 0
     for m = 1:12
         for d = 1:Dates.daysinmonth(y,m)
@@ -77,10 +77,10 @@ function test_dates()
         end
     end
 end
-test_dates()
+test_dates1()
 
 # Test second, millisecond
-function test_dates()
+function test_dates2()
     y = m = d = h = mi = s = ms = 0
     for y in [-2013,-1,0,1,2013]
         for m in [1,6,12]
@@ -102,9 +102,9 @@ function test_dates()
         end
     end
 end
-test_dates()
+test_dates2()
 
-function test_dates(from,to)
+function test_dates2(from,to)
     y = m = d = 0
     for y in from:to
         for m = 1:12
@@ -117,7 +117,7 @@ function test_dates(from,to)
         end
     end
 end
-test_dates(0,2100)
+test_dates2(0,2100)
 
 # week function
 # Tests from https://en.wikipedia.org/wiki/ISO_week_date

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -51,7 +51,7 @@ test_inlined_symbols(test_outer, Tuple{Int64})
 # Make sure that an error is thrown for the undeclared
 # y in the else branch.
 # https://github.com/JuliaLang/julia/issues/12620
-@inline function foo(x)
+@inline function foo_inl(x)
     if x
         y = 2
     else
@@ -60,7 +60,7 @@ test_inlined_symbols(test_outer, Tuple{Int64})
 end
 function bar()
     for i = 1:3
-        foo(i==1)
+        foo_inl(i==1)
     end
 end
 @test_throws UndefVarError bar()

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -839,9 +839,10 @@ i3 = trunc(Integer,f)
 @test i3+1 > f
 @test i3+1 >= f
 
-err(z, x) = abs(z - x) / abs(x)
-@test 1e-60 > err(eta(parse(BigFloat,"1.005")), parse(BigFloat,"0.693945708117842473436705502427198307157819636785324430166786"))
-@test 1e-60 > err(exp(eta(big(1.0))), 2.0)
+let err(z, x) = abs(z - x) / abs(x)
+    @test 1e-60 > err(eta(parse(BigFloat,"1.005")), parse(BigFloat,"0.693945708117842473436705502427198307157819636785324430166786"))
+    @test 1e-60 > err(exp(eta(big(1.0))), 2.0)
+end
 
 # issue #8318
 @test convert(Int64,big(500_000_000_000_000.)) == 500_000_000_000_000

--- a/test/string.jl
+++ b/test/string.jl
@@ -1,5 +1,14 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+## generic string uses only endof and next; used for testing ##
+
+immutable GenericString <: AbstractString
+    string::AbstractString
+end
+
+Base.endof(s::GenericString) = endof(s.string)
+Base.next(s::GenericString, i::Int) = next(s.string, i)
+
 include("strings/basic.jl")
 include("strings/types.jl")
 include("strings/search.jl")

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -157,15 +157,6 @@ tstr = tstStringType("12");
 @test_throws ErrorException endof(tstr)
 @test_throws ErrorException next(tstr, Bool(1))
 
-## generic string uses only endof and next ##
-
-immutable GenericString <: AbstractString
-    string::AbstractString
-end
-
-Base.endof(s::GenericString) = endof(s.string)
-Base.next(s::GenericString, i::Int) = next(s.string, i)
-
 gstr = GenericString("12");
 @test typeof(string(gstr))==GenericString
 @test bytestring()==""

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -4,15 +4,6 @@
 astr = "Hello, world.\n"
 u8str = "∀ ε > 0, ∃ δ > 0: |x-y| < δ ⇒ |f(x)-f(y)| < ε"
 
-## generic string uses only endof and next ##
-
-immutable GenericString <: AbstractString
-    string::AbstractString
-end
-
-Base.endof(s::GenericString) = endof(s.string)
-Base.next(s::GenericString, i::Int) = next(s.string, i)
-
 # I think these should give error on 4 also, and "" is not treated
 # consistently with SubString("",1,1), nor with Char[]
 for ind in (0, 5)


### PR DESCRIPTION
Currently we only warn if a method is overwritten in a different module. I now believe we should always print this warning.

First, I was amazed to discover how often this happens in Base. Nearly all cases seem to be mistakes. Bizarrely, several definitions were literally copy & pasted one after the other. It's possible those were rebase artifacts of some kind. This also revealed that when doc strings are applied to `@enum`s, the entire definition (type and all methods) is repeated twice. I have not fixed this yet.

Second, jb/functions makes overwriting methods worse, since code can be specialized on function arguments. A few packages are failing because their tests repeatedly write `f(x) = ...`, intending to create a different function each time. These should be written as `f = x-> ...` instead. This warning will help find such cases. (This is an especially bad manifestation of #265.)

The first commit removes many overwritten definitions from Base. The second commit changes the warning to print in all cases.
