### PR TITLE
unsafe read/write

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1125,7 +1125,7 @@ end
 
 function refresh_multi_line(termbuf::TerminalBuffer, s::SearchState)
     buf = IOBuffer()
-    write(buf, pointer(s.query_buffer.data), s.query_buffer.ptr-1)
+    unsafe_write(buf, pointer(s.query_buffer.data), s.query_buffer.ptr-1)
     write(buf, "': ")
     offset = buf.ptr
     ptr = s.response_buffer.ptr

--- a/base/base64.jl
+++ b/base/base64.jl
@@ -85,16 +85,15 @@ end
 
 #############################################################################
 
-function write(b::Base64EncodePipe, x::AbstractVector{UInt8})
-    n = length(x)
+function unsafe_write(b::Base64EncodePipe, x::Ptr{UInt8}, n::UInt)
     s = 1 # starting index
     # finish any cached data to write:
     if b.nb == 1
         if n >= 2
-            write(b.io, b64(b.b0, x[1], x[2])...)
+            write(b.io, b64(b.b0, unsafe_load(x, 1), unsafe_load(x, 2))...)
             s = 3
         elseif n == 1
-            b.b1 = x[1]
+            b.b1 = unsafe_load(x, 1)
             b.nb = 2
             return
         else
@@ -102,7 +101,7 @@ function write(b::Base64EncodePipe, x::AbstractVector{UInt8})
         end
     elseif b.nb == 2
         if n >= 1
-            write(b.io, b64(b.b0, b.b1, x[1])...)
+            write(b.io, b64(b.b0, b.b1, unsafe_load(x, 1))...)
             s = 2
         else
             return
@@ -110,16 +109,16 @@ function write(b::Base64EncodePipe, x::AbstractVector{UInt8})
     end
     # write all groups of three bytes:
     while s + 2 <= n
-        write(b.io, b64(x[s], x[s+1], x[s+2])...)
+        write(b.io, b64(unsafe_load(x, s), unsafe_load(x, s + 1), unsafe_load(x, s + 2))...)
         s += 3
     end
     # cache any leftover bytes:
     if s + 1 == n
-        b.b0 = x[s]
-        b.b1 = x[s+1]
+        b.b0 = unsafe_load(x, s)
+        b.b1 = unsafe_load(x, s + 1)
         b.nb = 2
     elseif s == n
-        b.b0 = x[s]
+        b.b0 = unsafe_load(x, s)
         b.nb = 1
     else
         b.nb = 0

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -978,3 +978,6 @@ end
     end
     return offsets
 end
+
+# 14766
+@deprecate write(io::IO, p::Ptr, nb::Integer) unsafe_write(io, p, nb)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1333,7 +1333,9 @@ export
     unsafe_copy!,
     unsafe_load,
     unsafe_pointer_to_objref,
+    #unsafe_read,
     unsafe_store!,
+    unsafe_write,
 
 # nullable types
     isnull,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1333,7 +1333,7 @@ export
     unsafe_copy!,
     unsafe_load,
     unsafe_pointer_to_objref,
-    #unsafe_read,
+    unsafe_read,
     unsafe_store!,
     unsafe_write,
 

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -105,7 +105,7 @@ function sendfile(dst::File, src::File, src_offset::Int64, bytes::Int)
     nothing
 end
 
-function write(f::File, buf::Ptr{UInt8}, len::Integer, offset::Integer=-1)
+function unsafe_write(f::File, buf::Ptr{UInt8}, len::UInt, offset::Int64=Int64(-1))
     check_open(f)
     err = ccall(:jl_fs_write, Int32, (Int32, Ptr{UInt8}, Csize_t, Int64),
                 f.handle, buf, len, offset)
@@ -113,15 +113,7 @@ function write(f::File, buf::Ptr{UInt8}, len::Integer, offset::Integer=-1)
     return len
 end
 
-write(f::File, c::UInt8) = write(f, UInt8[c])
-
-function write{T}(f::File, a::Array{T})
-    if isbits(T)
-        write(f, pointer(a), sizeof(a))
-    else
-        invoke(write, Tuple{IO, Array}, f, a)
-    end
-end
+write(f::File, c::UInt8) = write(f, Ref{UInt8}(c))
 
 function truncate(f::File, n::Integer)
     check_open(f)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -144,18 +144,13 @@ function read(f::File, ::Type{UInt8})
     return ret % UInt8
 end
 
-function read!(f::File, a::Vector{UInt8}, nel=length(a))
+function unsafe_read(f::File, p::Ptr{UInt8}, nel::UInt)
     check_open(f)
-    if nel < 0 || nel > length(a)
-        throw(BoundsError())
-    end
     ret = ccall(:jl_fs_read, Int32, (Int32, Ptr{Void}, Csize_t),
-                f.handle, a, nel)
-    if ret < nel
-        throw(EOFError())
-    end
+                f.handle, p, nel)
     uv_error("read",ret)
-    return a
+    ret == nel || throw(EOFError())
+    nothing
 end
 
 nb_available(f::File) = filesize(f) - position(f)

--- a/base/grisu.jl
+++ b/base/grisu.jl
@@ -79,10 +79,10 @@ function _show(io::IO, x::AbstractFloat, mode, n::Int, typed, nanstr, infstr)
     exp_form = exp_form || (pt >= len && abs(mod(x + 0.05, 10^(pt - len)) - 0.05) > 0.05) # see issue #6608
     if exp_form # .00001 to 100000.
         # => #.#######e###
-        write(io, pdigits, 1)
+        unsafe_write(io, pdigits, 1)
         write(io, '.')
         if len > 1
-            write(io, pdigits+1, len-1)
+            unsafe_write(io, pdigits+1, len-1)
         else
             write(io, '0')
         end
@@ -97,19 +97,19 @@ function _show(io::IO, x::AbstractFloat, mode, n::Int, typed, nanstr, infstr)
             write(io, '0')
             pt += 1
         end
-        write(io, pdigits, len)
+        unsafe_write(io, pdigits, len)
     elseif pt >= len
         # => ########00.0
-        write(io, pdigits, len)
+        unsafe_write(io, pdigits, len)
         while pt > len
             write(io, '0')
             len += 1
         end
         write(io, ".0")
     else # => ####.####
-        write(io, pdigits, pt)
+        unsafe_write(io, pdigits, pt)
         write(io, '.')
-        write(io, pdigits+pt, len-pt)
+        unsafe_write(io, pdigits+pt, len-pt)
     end
     typed && isa(x,Float32) && write(io, "f0")
     typed && isa(x,Float16) && write(io, ")")
@@ -144,7 +144,7 @@ function _print_shortest(io::IO, x::AbstractFloat, dot::Bool, mode, n::Int)
     k = -9<=e<=9 ? 1 : 2
     if -pt > k+1 || e+dot > k+1
         # => ########e###
-        write(io, pdigits+0, len)
+        unsafe_write(io, pdigits+0, len)
         write(io, 'e')
         write(io, dec(e))
         return
@@ -155,10 +155,10 @@ function _print_shortest(io::IO, x::AbstractFloat, dot::Bool, mode, n::Int)
             write(io, '0')
             pt += 1
         end
-        write(io, pdigits+0, len)
+        unsafe_write(io, pdigits+0, len)
     elseif e >= dot
         # => ########000.
-        write(io, pdigits+0, len)
+        unsafe_write(io, pdigits+0, len)
         while e > 0
             write(io, '0')
             e -= 1
@@ -167,9 +167,9 @@ function _print_shortest(io::IO, x::AbstractFloat, dot::Bool, mode, n::Int)
             write(io, '.')
         end
     else # => ####.####
-        write(io, pdigits+0, pt)
+        unsafe_write(io, pdigits+0, pt)
         write(io, '.')
-        write(io, pdigits+pt, len-pt)
+        unsafe_write(io, pdigits+pt, len-pt)
     end
     nothing
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -171,7 +171,7 @@ function compact(io::AbstractIOBuffer)
     return io
 end
 
-function ensureroom(io::AbstractIOBuffer, nshort::Int)
+@inline function ensureroom(io::AbstractIOBuffer, nshort::Int)
     io.writable || throw(ArgumentError("ensureroom failed, IOBuffer is not writeable"))
     if !io.seekable
         nshort >= 0 || throw(ArgumentError("ensureroom failed, requested number of bytes must be ≥ 0, got $nshort"))
@@ -198,7 +198,7 @@ end
 
 eof(io::AbstractIOBuffer) = (io.ptr-1 == io.size)
 
-function close{T}(io::AbstractIOBuffer{T})
+@noinline function close{T}(io::AbstractIOBuffer{T})
     io.readable = false
     io.writable = false
     io.seekable = false
@@ -310,12 +310,12 @@ function write_sub{T}(to::AbstractIOBuffer, a::AbstractArray{T}, offs, nel)
             written += write(to, a[i])
         end
     end
-    written
+    return written
 end
 
 write(to::AbstractIOBuffer, a::Array) = write_sub(to, a, 1, length(a))
 
-function write(to::AbstractIOBuffer, a::UInt8)
+@inline function write(to::AbstractIOBuffer, a::UInt8)
     ensureroom(to, 1)
     ptr = (to.append ? to.size+1 : to.ptr)
     if ptr > to.maxsize
@@ -325,7 +325,7 @@ function write(to::AbstractIOBuffer, a::UInt8)
     end
     to.size = max(to.size, ptr)
     if !to.append to.ptr += 1 end
-    sizeof(UInt8)
+    return sizeof(UInt8)
 end
 
 function readbytes!(io::AbstractIOBuffer, b::Array{UInt8}, nb=length(b))

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -125,7 +125,7 @@ function unsafe_write(s::IOStream, p::Ptr{UInt8}, nb::UInt)
     if !iswritable(s)
         throw(ArgumentError("write failed, IOStream is not writeable"))
     end
-    Int(ccall(:ios_write, Csize_t, (Ptr{Void}, Ptr{Void}, Csize_t), s.ios, p, nb))
+    return Int(ccall(:ios_write, Csize_t, (Ptr{Void}, Ptr{Void}, Csize_t), s.ios, p, nb))
 end
 
 function write{T,N,A<:Array}(s::IOStream, a::SubArray{T,N,A})
@@ -153,19 +153,21 @@ function read(s::IOStream, ::Type{UInt8})
     if b == -1
         throw(EOFError())
     end
-    b % UInt8
+    return b % UInt8
 end
 
-function read{T<:Union{UInt16, Int16, UInt32, Int32, UInt64, Int64}}(s::IOStream, ::Type{T})
-    ccall(:jl_ios_get_nbyte_int, UInt64, (Ptr{Void}, Csize_t), s.ios, sizeof(T)) % T
+if ENDIAN_BOM == 0x04030201
+function read(s::IOStream, T::Union{Type{Int16},Type{UInt16},Type{Int32},Type{UInt32},Type{Int64},Type{UInt64}})
+    return ccall(:jl_ios_get_nbyte_int, UInt64, (Ptr{Void}, Csize_t), s.ios, sizeof(T)) % T
+end
 end
 
-function read!(s::IOStream, a::Vector{UInt8})
+function unsafe_read(s::IOStream, p::Ptr{UInt8}, nb::UInt)
     if ccall(:ios_readall, Csize_t,
-             (Ptr{Void}, Ptr{Void}, Csize_t), s.ios, a, sizeof(a)) < sizeof(a)
+             (Ptr{Void}, Ptr{Void}, Csize_t), s, p, nb) != nb
         throw(EOFError())
     end
-    a
+    nothing
 end
 
 ## text I/O ##

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -143,7 +143,7 @@ function serialize(s::SerializationState, x::Symbol)
         writetag(s.io, LONGSYMBOL_TAG)
         write(s.io, Int32(ln))
     end
-    write(s.io, pname, ln)
+    unsafe_write(s.io, pname, ln)
 end
 
 function serialize_array_data(s::IO, a)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -86,10 +86,14 @@ include(UTF8String(vcat(length(Core.ARGS)>=2?Core.ARGS[2].data:"".data, "version
 include("c.jl")
 include("osutils.jl")
 
+# Core I/O
+include("io.jl")
+include("iostream.jl")
+include("iobuffer.jl")
+
 # strings & printing
 include("char.jl")
 include("ascii.jl")
-include("iobuffer.jl")
 include("string.jl")
 include("unicode.jl")
 include("parse.jl")
@@ -97,10 +101,6 @@ include("shell.jl")
 include("regex.jl")
 include("base64.jl")
 importall .Base64
-
-# Core I/O
-include("io.jl")
-include("iostream.jl")
 
 # system & environment
 include("libc.jl")

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -168,6 +168,22 @@ General I/O
 
    If ``all`` is ``true`` (the default), this function will block repeatedly trying to read all requested bytes, until an error or end-of-file occurs. If ``all`` is ``false``\ , at most one ``read`` call is performed, and the amount of data returned is device-dependent. Note that not all stream types support the ``all`` option.
 
+.. function:: unsafe_read(io, ref, nbytes)
+
+   .. Docstring generated from Julia source
+
+   Copy nbytes from the IO stream object into ref (converted to a pointer).
+
+   It is recommended that IO subtypes override the exact method signature below to provide more efficient implementations: ``unsafe_read(s::IO, p::Ptr{UInt8}, n::UInt)``
+
+.. function:: unsafe_write(io, ref, nbytes)
+
+   .. Docstring generated from Julia source
+
+   Copy nbytes from ref (converted to a pointer) into the IO stream object.
+
+   It is recommended that IO subtypes override the exact method signature below to provide more efficient implementations: ``unsafe_write(s::IO, p::Ptr{UInt8}, n::UInt)``
+
 .. function:: position(s)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
as mentioned at https://github.com/JuliaLang/julia/pull/14678#discussion_r49818420, this renames `write(io, ptr, nb)` to `unsafe_write` (for consistency with `unsafe_load`, etc.) and ensures it exists for all IO subtypes. this makes the interface for creating an IO stream much simpler and a bit more efficient.

~~i'll add the corresponding change to `unsafe_read` later~~ done
