### PR TITLE
prevent inference from reading a global binding with no value

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1194,8 +1194,8 @@ function abstract_eval_constant(x::ANY)
 end
 
 function abstract_eval_global(M::Module, s::Symbol)
-    if isconst(M,s)
-        return abstract_eval_constant(eval(M,s))
+    if isdefined(M,s) && isconst(M,s)
+        return abstract_eval_constant(getfield(M,s))
     end
     return Any
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -3673,3 +3673,8 @@ f6846() = (please6846; 2)
 
 # issue #14758
 @test isa(eval(:(f14758(; $([]...)) = ())), Function)
+
+# issue #14767
+@inline f14767(x) = x ? A14767 : ()
+const A14767 = f14767(false)
+@test A14767 === ()


### PR DESCRIPTION
fixes #14767
