### PR TITLE
fix and test datatype field reflection

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -967,3 +967,14 @@ end
 #https://github.com/JuliaLang/julia/issues/14608
 @deprecate readall readstring
 @deprecate readbytes read
+
+@deprecate field_offset(x::DataType, idx) fieldoffset(x, idx+1)
+@noinline function fieldoffsets(x::DataType)
+    depwarn("fieldoffsets is deprecated. use `map(idx->fieldoffset(x, idx), 1:nfields(x))` instead", :fieldoffsets)
+    nf = nfields(x)
+    offsets = Array(Int, nf)
+    for i = 1:nf
+        offsets[i] = fieldoffset(x, i)
+    end
+    return offsets
+end

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -314,13 +314,6 @@ Compute a "2d histogram" with respect to the bins delimited by the edges given i
 hist2d!
 
 """
-    fieldtype(T, name::Symbol | index::Int)
-
-Determine the declared type of a field (specified by name or index) in a composite DataType `T`.
-"""
-fieldtype
-
-"""
     hypot(x, y)
 
 Compute the ``\\sqrt{x^2+y^2}`` avoiding overflow and underflow.
@@ -1969,13 +1962,6 @@ shift in each dimension.
 circshift
 
 """
-    fieldnames(x::DataType)
-
-Get an array of the fields of a `DataType`.
-"""
-fieldnames
-
-"""
     yield()
 
 Switch to the scheduler to allow another scheduled task to run. A task that calls this
@@ -2085,33 +2071,6 @@ kron
 Right bit shift operator, preserving the sign of `x`.
 """
 Base.(:(>>))
-
-"""
-    fieldoffsets(type)
-
-The byte offset of each field of a type relative to the data start. For example, we could
-use it in the following manner to summarize information about a struct type:
-
-```jldoctest
-julia> structinfo(T) = [zip(fieldoffsets(T),fieldnames(T),T.types)...];
-
-julia> structinfo(StatStruct)
-12-element Array{Tuple{Int64,Symbol,DataType},1}:
- (0,:device,UInt64)
- (8,:inode,UInt64)
- (16,:mode,UInt64)
- (24,:nlink,Int64)
- (32,:uid,UInt64)
- (40,:gid,UInt64)
- (48,:rdev,UInt64)
- (56,:size,Int64)
- (64,:blksize,Int64)
- (72,:blocks,Int64)
- (80,:mtime,Float64)
- (88,:ctime,Float64)
-```
-"""
-fieldoffsets
 
 """
     randn([rng], [dims...])

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1048,7 +1048,8 @@ export
 
 # types
     convert,
-    fieldoffsets,
+    fieldoffset,
+    fieldname,
     fieldnames,
     isleaftype,
     oftype,

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1035,11 +1035,9 @@ sparse{Tv}(FC::FactorComponent{Tv,:LD}) = sparse(Sparse(Factor(FC)))
 
 # Calculate the offset into the stype field of the cholmod_sparse_struct and
 # change the value
-let offidx=findfirst(fieldnames(C_Sparse) .== :stype)
-
+let offset = fieldoffset(C_Sparse{Float64}, findfirst(fieldnames(C_Sparse) .== :stype))
     global change_stype!
     function change_stype!(A::Sparse, i::Integer)
-        offset = fieldoffsets(C_Sparse)[offidx]
         unsafe_store!(convert(Ptr{Cint}, A.p), i, div(offset, 4) + 1)
         return A
     end

--- a/doc/devdocs/reflection.rst
+++ b/doc/devdocs/reflection.rst
@@ -74,8 +74,8 @@ The internal representation of a :obj:`DataType` is critically important when in
 C code and several functions are available to inspect these details.
 :func:`isbits(T::DataType) <isbits>` returns true if ``T`` is
 stored with C-compatible alignment.
-:func:`fieldoffsets(T::DataType) <fieldoffsets>` returns the (byte) offset for each
-field relative to the start of the type.
+:func:`fieldoffset(T::DataType, i::Integer) <fieldoffset>` returns the (byte) offset for
+field `i` relative to the start of the type.
 
 .. rubric:: Function methods
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -520,15 +520,15 @@ Types
 
    Assign ``x`` to a named field in ``value`` of composite type. The syntax ``a.b = c`` calls ``setfield!(a, :b, c)``\ , and the syntax ``a.(b) = c`` calls ``setfield!(a, b, c)``\ .
 
-.. function:: fieldoffsets(type)
+.. function:: fieldoffset(type, i)
 
    .. Docstring generated from Julia source
 
-   The byte offset of each field of a type relative to the data start. For example, we could use it in the following manner to summarize information about a struct type:
+   The byte offset of field ``i`` of a type relative to the data start. For example, we could use it in the following manner to summarize information about a struct type:
 
    .. doctest::
 
-       julia> structinfo(T) = [zip(fieldoffsets(T),fieldnames(T),T.types)...];
+       julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:nfields(T)];
 
        julia> structinfo(StatStruct)
        12-element Array{Tuple{Int64,Symbol,DataType},1}:
@@ -1251,6 +1251,12 @@ Reflection
    .. Docstring generated from Julia source
 
    Get an array of the fields of a ``DataType``\ .
+
+.. function:: fieldname(x::DataType, i)
+
+   .. Docstring generated from Julia source
+
+   Get the name of field ``i`` of a ``DataType``\ .
 
 .. function:: isconst([m::Module], s::Symbol) -> Bool
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -567,14 +567,6 @@ JL_DLLEXPORT jl_value_t *jl_is_char_signed(void)
     return ((char)255) < 0 ? jl_true : jl_false;
 }
 
-JL_DLLEXPORT void jl_field_offsets(jl_datatype_t *dt, ssize_t *offsets)
-{
-    size_t i;
-    for(i=0; i < jl_datatype_nfields(dt); i++) {
-        offsets[i] = jl_field_offset(dt, i);
-    }
-}
-
 // -- misc sysconf info --
 
 #ifdef _OS_WINDOWS_
@@ -624,9 +616,9 @@ JL_DLLEXPORT long jl_SC_CLK_TCK(void)
 
 JL_DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
 {
-    if (field > jl_datatype_nfields(ty))
-        jl_error("This type does not have that many fields");
-    return jl_field_offset(ty, field);
+    if (field > jl_datatype_nfields(ty) || field < 1)
+        jl_bounds_error_int((jl_value_t*)ty, field);
+    return jl_field_offset(ty, field - 1);
 }
 
 JL_DLLEXPORT size_t jl_get_alignment(jl_datatype_t *ty)


### PR DESCRIPTION
replaces field_offset with corrected, tested, an documented method `fieldoffset`

~~this function was untested, undocumented, unexported, and incorrect (off-by-one error in implementation)~~

see https://github.com/JuliaLang/julia/commit/30a44c9124e71c9835c71ed58e1cdea7962cee64#commitcomment-15624022
