### PR TITLE
Do not modify args array in jlcall

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -237,8 +237,8 @@ JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
     return jv;
 }
 
-JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
-                                        uint32_t na)
+JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type,
+                                        jl_value_t *const *args, uint32_t na)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (type->instance != NULL) return type->instance;

--- a/src/array.c
+++ b/src/array.c
@@ -449,8 +449,8 @@ JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
     return elt;
 }
 
-static size_t array_nd_index(jl_array_t *a, jl_value_t **args, size_t nidxs,
-                             const char *fname)
+static size_t array_nd_index(jl_array_t *a, jl_value_t *const *args,
+                             size_t nidxs, const char *fname)
 {
     size_t i=0;
     size_t k, stride=1;
@@ -488,7 +488,7 @@ JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
     return 1;
 }
 
-int jl_array_isdefined(jl_value_t **args0, int nargs)
+int jl_array_isdefined(jl_value_t *const *args0, int nargs)
 {
     assert(jl_is_array(args0[0]));
     jl_value_t **depwarn_args;
@@ -500,7 +500,7 @@ int jl_array_isdefined(jl_value_t **args0, int nargs)
     JL_GC_POP();
 
     jl_array_t *a = (jl_array_t*)args0[0];
-    jl_value_t **args = &args0[1];
+    jl_value_t *const *args = &args0[1];
     size_t nidxs = nargs-1;
     size_t i=0;
     size_t k, stride=1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT jl_value_t *jl_invoke(jl_method_instance_t *meth, jl_value_t **args, uint32_t nargs)
+JL_DLLEXPORT jl_value_t *jl_invoke(jl_method_instance_t *meth, jl_value_t *const *args, uint32_t nargs)
 {
     return jl_call_method_internal(meth, args, nargs);
 }
@@ -1102,7 +1102,7 @@ void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args)
     // not reached
 }
 
-void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t **args, size_t na)
+void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t *const *args, size_t na)
 {
     jl_value_t *argtup = jl_f_tuple(NULL, args+1, na-1);
     JL_GC_PUSH1(&argtup);
@@ -1112,7 +1112,7 @@ void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t **args, size_t na)
 
 jl_datatype_t *jl_wrap_Type(jl_value_t *t);
 
-jl_tupletype_t *arg_type_tuple(jl_value_t **args, size_t nargs)
+jl_tupletype_t *arg_type_tuple(jl_value_t *const *args, size_t nargs)
 {
     jl_tupletype_t *tt;
     size_t i;
@@ -1176,7 +1176,7 @@ JL_DLLEXPORT int jl_method_exists(jl_methtable_t *mt, jl_tupletype_t *types)
     return jl_method_lookup_by_type(mt, types, 0, 0, 1) != NULL;
 }
 
-jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache)
+jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t *const *args, size_t nargs, int cache)
 {
     jl_typemap_entry_t *entry = jl_typemap_assoc_exact(mt->cache, args, nargs, jl_cachearg_offset(mt));
     if (entry)
@@ -1711,7 +1711,7 @@ STATIC_INLINE uint32_t int32hash_fast(uint32_t a)
     return a;  // identity hashing seems to work well enough here
 }
 
-STATIC_INLINE int sig_match_fast(jl_value_t **args, jl_value_t **sig, size_t i, size_t n)
+STATIC_INLINE int sig_match_fast(jl_value_t *const *args, jl_value_t *const *sig, size_t i, size_t n)
 {
     // NOTE: This function is a huge performance hot spot!!
     for (; i < n; i++) {
@@ -1761,7 +1761,7 @@ static void flush_from_cache(jl_typemap_entry_t *entry)
 #define __builtin_return_address(n) _ReturnAddress()
 #endif
 
-JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
+JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *const *args, uint32_t nargs)
 {
 #ifdef JL_GF_PROFILE
     ncalls++;
@@ -1872,7 +1872,7 @@ JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_datatype_t *types)
 // every definition has its own private method table for this purpose.
 //
 // NOTE: assumes argument type is a subtype of the lookup type.
-jl_value_t *jl_gf_invoke(jl_tupletype_t *types0, jl_value_t **args, size_t nargs)
+jl_value_t *jl_gf_invoke(jl_tupletype_t *types0, jl_value_t *const *args, size_t nargs)
 {
     jl_svec_t *tpenv = jl_emptysvec;
     jl_tupletype_t *newsig = NULL;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -570,7 +570,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, int start,
     return NULL;
 }
 
-jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint32_t nargs)
+jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t *const *args, uint32_t nargs)
 {
     if (lam->jlcall_api == 2)
         return lam->inferred;

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -114,7 +114,7 @@ JL_DLLEXPORT const char *jl_string_ptr(jl_value_t *s)
     return jl_string_data(s);
 }
 
-JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs)
+JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t *const *args, int32_t nargs)
 {
     jl_value_t *v;
     JL_TRY {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -75,7 +75,7 @@ STATIC_INLINE int is_unspec(jl_datatype_t *dt)
     return (jl_datatype_t*)dt->name->primary == dt;
 }
 
-static int jl_has_typevars__(jl_value_t *v, int incl_wildcard, jl_value_t **p, size_t np)
+static int jl_has_typevars__(jl_value_t *v, int incl_wildcard, jl_value_t *const *p, size_t np)
 {
     size_t i;
     if (jl_typeis(v, jl_tvar_type)) {
@@ -147,7 +147,7 @@ static int jl_has_typevars_from(jl_value_t *v, jl_svec_t *p)
     return jl_has_typevars__(v, 0, jl_svec_data(p), jl_svec_len(p));
 }
 
-static int jl_has_typevars_from_v(jl_value_t *v, jl_value_t **p, size_t np)
+static int jl_has_typevars_from_v(jl_value_t *v, jl_value_t *const *p, size_t np)
 {
     if (np == 0) return 0;
     return jl_has_typevars__(v, 0, p, np);
@@ -217,7 +217,7 @@ JL_DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt)
 }
 // --- type union ---
 
-static int count_union_components(jl_value_t **types, size_t n)
+static int count_union_components(jl_value_t *const *types, size_t n)
 {
     size_t i, c=0;
     for(i=0; i < n; i++) {
@@ -233,7 +233,7 @@ static int count_union_components(jl_value_t **types, size_t n)
     return c;
 }
 
-static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, size_t *idx)
+static void flatten_type_union(jl_value_t *const *types, size_t n, jl_value_t **out, size_t *idx)
 {
     size_t i;
     for(i=0; i < n; i++) {
@@ -251,8 +251,8 @@ static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, s
 
 static int union_elt_morespecific(const void *a, const void *b)
 {
-    jl_value_t *va = *(jl_value_t**)a;
-    jl_value_t *vb = *(jl_value_t**)b;
+    jl_value_t *va = *(jl_value_t *const*)a;
+    jl_value_t *vb = *(jl_value_t *const*)b;
     if (jl_args_morespecific(va, vb))
         return -1;
     // impose a partially-arbitrary ordering on Union elements, to make it more
@@ -266,7 +266,7 @@ static int union_elt_morespecific(const void *a, const void *b)
 // type definitions. (issue #2365)
 int inside_typedef = 0;
 
-static jl_svec_t *jl_compute_type_union(jl_value_t **types, size_t ntypes)
+static jl_svec_t *jl_compute_type_union(jl_value_t *const *types, size_t ntypes)
 {
     size_t n = count_union_components(types, ntypes);
     jl_value_t **temp;
@@ -309,7 +309,7 @@ static jl_svec_t *jl_compute_type_union(jl_value_t **types, size_t ntypes)
     return result;
 }
 
-static jl_value_t *jl_type_union_v(jl_value_t **ts, size_t n)
+static jl_value_t *jl_type_union_v(jl_value_t *const *ts, size_t n)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (n == 0) return (jl_value_t*)jl_bottom_type;
@@ -461,7 +461,7 @@ typedef enum {
 
 // Set the parameters for a single tuple
 // returns lenf, sets kind and lenkind
-static size_t data_vararg_params(jl_value_t **data, size_t lenr, cenv_t *eqc, jl_vararg_kind_t *kind, jl_tuple_lenkind_t *lenkind)
+static size_t data_vararg_params(jl_value_t *const *data, size_t lenr, cenv_t *eqc, jl_vararg_kind_t *kind, jl_tuple_lenkind_t *lenkind)
 {
     size_t lenf = lenr;
     int i;
@@ -1772,7 +1772,7 @@ static int valid_type_param(jl_value_t *v)
     return jl_is_type(v) || jl_is_typevar(v) || jl_is_symbol(v) || jl_isbits(jl_typeof(v));
 }
 
-jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
+jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t *const *params, size_t n)
 {
     if (tc == (jl_value_t*)jl_anytuple_type)
         return (jl_value_t*)jl_apply_tuple_type_v(params, n);
@@ -1884,7 +1884,7 @@ static int contains_unions(jl_value_t *type)
 
 // this function determines whether a type is simple enough to form
 // a total order based on UIDs and object_id.
-static int is_typekey_ordered(jl_value_t **key, size_t n)
+static int is_typekey_ordered(jl_value_t *const *key, size_t n)
 {
     size_t i;
     for(i=0; i < n; i++) {
@@ -1902,7 +1902,7 @@ static int is_typekey_ordered(jl_value_t **key, size_t n)
 }
 
 // ordered comparison of types
-static int typekey_compare(jl_datatype_t *tt, jl_value_t **key, size_t n)
+static int typekey_compare(jl_datatype_t *tt, jl_value_t *const *key, size_t n)
 {
     size_t j;
     if (tt == NULL) return -1;  // place NULLs at end to allow padding for fast growing
@@ -1962,7 +1962,7 @@ void jl_resort_type_cache(jl_svec_t *c)
     qsort(jl_svec_data(c), jl_svec_len(c), sizeof(jl_value_t*), dt_compare);
 }
 
-static int typekey_eq(jl_datatype_t *tt, jl_value_t **key, size_t n)
+static int typekey_eq(jl_datatype_t *tt, jl_value_t *const *key, size_t n)
 {
     size_t j;
     size_t tnp = jl_nparams(tt);
@@ -1978,7 +1978,7 @@ static int typekey_eq(jl_datatype_t *tt, jl_value_t **key, size_t n)
 // look up a type in a cache by binary or linear search.
 // if found, returns the index of the found item. if not found, returns
 // ~n, where n is the index where the type should be inserted.
-static ssize_t lookup_type_idx(jl_typename_t *tn, jl_value_t **key, size_t n, int ordered)
+static ssize_t lookup_type_idx(jl_typename_t *tn, jl_value_t *const *key, size_t n, int ordered)
 {
     if (n==0) return -1;
     if (ordered) {
@@ -2014,7 +2014,7 @@ static ssize_t lookup_type_idx(jl_typename_t *tn, jl_value_t **key, size_t n, in
     }
 }
 
-static jl_value_t *lookup_type(jl_typename_t *tn, jl_value_t **key, size_t n)
+static jl_value_t *lookup_type(jl_typename_t *tn, jl_value_t *const *key, size_t n)
 {
     JL_TIMING(TYPE_CACHE_LOOKUP);
     int ord = is_typekey_ordered(key, n);
@@ -2105,13 +2105,13 @@ typedef struct _jl_typestack_t {
     struct _jl_typestack_t *prev;
 } jl_typestack_t;
 
-static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
+static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t *const *env, size_t n,
                                 jl_typestack_t *stack, int check);
-static jl_svec_t *inst_all(jl_svec_t *p, jl_value_t **env, size_t n,
+static jl_svec_t *inst_all(jl_svec_t *p, jl_value_t *const *env, size_t n,
                            jl_typestack_t *stack, int check);
 
 static jl_value_t *lookup_type_stack(jl_typestack_t *stack, jl_datatype_t *tt, size_t ntp,
-                                     jl_value_t **iparams)
+                                     jl_value_t *const *iparams)
 {
     // if an identical instantiation is already in process somewhere up the
     // stack, return it. this computes a fixed point for recursive types.
@@ -2169,9 +2169,9 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt)
 
 static arraylist_t partial_inst;
 
-static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **iparams, size_t ntp,
+static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t *const *iparams, size_t ntp,
                                  int cacheable, jl_typestack_t *stack,
-                                 jl_value_t **env, size_t n)
+                                 jl_value_t *const *env, size_t n)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_typestack_t top;
@@ -2348,7 +2348,7 @@ static void check_tuple_parameter(jl_value_t *pi, size_t i, size_t np)
         jl_type_error_rt("Tuple", "non-final parameter", (jl_value_t*)jl_type_type, pi);
 }
 
-static jl_tupletype_t *jl_apply_tuple_type_v_(jl_value_t **p, size_t np, jl_svec_t *params)
+static jl_tupletype_t *jl_apply_tuple_type_v_(jl_value_t *const *p, size_t np, jl_svec_t *params)
 {
     int cacheable = 1;
     for(size_t i=0; i < np; i++) {
@@ -2367,7 +2367,7 @@ JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params)
     return jl_apply_tuple_type_v_(jl_svec_data(params), jl_svec_len(params), params);
 }
 
-JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np)
+JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t *const *p, size_t np)
 {
     return jl_apply_tuple_type_v_(p, np, NULL);
 }
@@ -2377,12 +2377,12 @@ jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p)
     return (jl_datatype_t*)inst_datatype(jl_anytuple_type, p, jl_svec_data(p), jl_svec_len(p), 1, NULL, NULL, 0);
 }
 
-jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np)
+jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t *const *p, size_t np)
 {
     return (jl_datatype_t*)inst_datatype(jl_anytuple_type, NULL, p, np, 1, NULL, NULL, 0);
 }
 
-static jl_svec_t *inst_all(jl_svec_t *p, jl_value_t **env, size_t n,
+static jl_svec_t *inst_all(jl_svec_t *p, jl_value_t *const *env, size_t n,
                            jl_typestack_t *stack, int check)
 {
     size_t i;
@@ -2396,7 +2396,7 @@ static jl_svec_t *inst_all(jl_svec_t *p, jl_value_t **env, size_t n,
     return np;
 }
 
-static jl_value_t *inst_tuple_w_(jl_value_t *t, jl_value_t **env, size_t n,
+static jl_value_t *inst_tuple_w_(jl_value_t *t, jl_value_t *const *env, size_t n,
                                  jl_typestack_t *stack, int check)
 {
     jl_datatype_t *tt = (jl_datatype_t*)t;
@@ -2459,7 +2459,7 @@ static jl_value_t *inst_tuple_w_(jl_value_t *t, jl_value_t **env, size_t n,
     return result;
 }
 
-static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
+static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t *const *env, size_t n,
                                 jl_typestack_t *stack, int check)
 {
     size_t i, j;
@@ -2539,7 +2539,7 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
     return result;
 }
 
-jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n)
+jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t *const *env, size_t n)
 {
     return inst_type_w_((jl_value_t*)t, env, n, NULL, 1);
 }
@@ -2621,7 +2621,7 @@ void jl_reset_instantiate_inner_types(jl_datatype_t *t)
 
 static int jl_subtype_le(jl_value_t *a, jl_value_t *b, int ta, int invariant);
 
-static int jl_tuple_subtype_(jl_value_t **child, size_t clenr,
+static int jl_tuple_subtype_(jl_value_t *const *child, size_t clenr,
                              jl_datatype_t *pdt, int ta, int invariant)
 {
     size_t plenr = jl_nparams(pdt);
@@ -2683,7 +2683,7 @@ static int jl_tuple_subtype_(jl_value_t **child, size_t clenr,
     return result;
 }
 
-int jl_tuple_subtype(jl_value_t **child, size_t cl, jl_datatype_t *pdt, int ta)
+int jl_tuple_subtype(jl_value_t *const *child, size_t cl, jl_datatype_t *pdt, int ta)
 {
     return jl_tuple_subtype_(child, cl, pdt, ta, 0);
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -186,9 +186,9 @@ union jl_typemap_t {
 
 // "jlcall" calling convention signatures.
 // This defines the default ABI used by compiled julia functions.
-typedef jl_value_t *(*jl_fptr_t)(jl_value_t*, jl_value_t**, uint32_t);
-typedef jl_value_t *(*jl_fptr_sparam_t)(jl_svec_t*, jl_value_t*, jl_value_t**, uint32_t);
-typedef jl_value_t *(*jl_fptr_linfo_t)(struct _jl_method_instance_t*, jl_value_t**, uint32_t, jl_svec_t*);
+typedef jl_value_t *(*jl_fptr_t)(jl_value_t*, jl_value_t *const*, uint32_t);
+typedef jl_value_t *(*jl_fptr_sparam_t)(jl_svec_t*, jl_value_t*, jl_value_t *const*, uint32_t);
+typedef jl_value_t *(*jl_fptr_linfo_t)(struct _jl_method_instance_t*, jl_value_t *const*, uint32_t, jl_svec_t*);
 
 typedef struct {
     union {
@@ -987,7 +987,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name);
 JL_DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name,jl_value_t *lb,jl_value_t *ub);
 JL_DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params);
 JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params);
-JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np);
+JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t *const *p, size_t np);
 JL_DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
                                             jl_svec_t *parameters,
                                             jl_svec_t *fnames, jl_svec_t *ftypes,
@@ -1000,7 +1000,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name,
 // constructors
 JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data);
 JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...);
-JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
+JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t *const *args,
                                         uint32_t na);
 JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
 JL_DLLEXPORT jl_method_instance_t *jl_new_method_instance_uninit(void);
@@ -1242,9 +1242,9 @@ JL_DLLEXPORT void JL_NORETURN jl_type_error_rt(const char *fname,
 JL_DLLEXPORT void JL_NORETURN jl_undefined_var_error(jl_sym_t *var);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_v(jl_value_t *v,
-                                                jl_value_t **idxs, size_t nidxs);
+                                                jl_value_t *const *idxs, size_t nidxs);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_int(jl_value_t *v, size_t i);
-JL_DLLEXPORT void JL_NORETURN jl_bounds_error_tuple_int(jl_value_t **v,
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_tuple_int(jl_value_t *const *v,
                                                         size_t nv, size_t i);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_unboxed_int(void *v, jl_value_t *vt, size_t i);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v, size_t *idxs, size_t nidxs);
@@ -1367,16 +1367,16 @@ STATIC_INLINE int jl_vinfo_usedundef(uint8_t vi)
 
 // calling into julia ---------------------------------------------------------
 
-JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs);
-JL_DLLEXPORT jl_value_t *jl_invoke(jl_method_instance_t *meth, jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *const *args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_invoke(jl_method_instance_t *meth, jl_value_t *const *args, uint32_t nargs);
 
 STATIC_INLINE
-jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)
+jl_value_t *jl_apply(jl_value_t *const *args, uint32_t nargs)
 {
     return jl_apply_generic(args, nargs);
 }
 
-JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t *const *args, int32_t nargs);
 JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f);
 JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -180,7 +180,7 @@ jl_method_t *jl_new_method(jl_code_info_t *definition,
                            int isstaged);
 
 // invoke (compiling if necessary) the jlcall function pointer for a method
-STATIC_INLINE jl_value_t *jl_call_method_internal(jl_method_instance_t *meth, jl_value_t **args, uint32_t nargs)
+STATIC_INLINE jl_value_t *jl_call_method_internal(jl_method_instance_t *meth, jl_value_t *const *args, uint32_t nargs)
 {
     jl_generic_fptr_t fptr;
     fptr.fptr = meth->fptr;
@@ -226,7 +226,7 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_method_instance_t *meth, jl
 
 jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types);
 
-JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t *const *args, uint32_t nargs);
 
 void jl_gc_setmark(jl_ptls_t ptls, jl_value_t *v);
 void jl_gc_sync_total_bytes(void);
@@ -266,13 +266,13 @@ uint32_t jl_get_gs_ctr(void);
 void jl_set_gs_ctr(uint32_t ctr);
 
 void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args);
-void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t **args, size_t na);
+void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t *const *args, size_t na);
 jl_value_t *jl_get_exceptionf(jl_datatype_t *exception_type, const char *fmt, ...);
 
 JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t);
 
 #define JL_CALLABLE(name)                                               \
-    JL_DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)
+    JL_DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t *const *args, uint32_t nargs)
 
 JL_CALLABLE(jl_unprotect_stack);
 JL_CALLABLE(jl_f_tuple);
@@ -290,14 +290,14 @@ JL_DLLEXPORT void jl_uv_associate_julia_struct(uv_handle_t *handle,
                                                jl_value_t *data);
 JL_DLLEXPORT int jl_uv_fs_result(uv_fs_t *f);
 
-int jl_tuple_subtype(jl_value_t **child, size_t cl, jl_datatype_t *pdt, int ta);
+int jl_tuple_subtype(jl_value_t *const *child, size_t cl, jl_datatype_t *pdt, int ta);
 
 int jl_subtype_invariant(jl_value_t *a, jl_value_t *b, int ta);
 jl_value_t *jl_type_match(jl_value_t *a, jl_value_t *b);
 extern int type_match_invariance_mask;
 jl_value_t *jl_type_match_morespecific(jl_value_t *a, jl_value_t *b);
 int jl_types_equal_generic(jl_value_t *a, jl_value_t *b, int useenv);
-jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np);
+jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t *const *p, size_t np);
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p);
 void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
 void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr);
@@ -309,8 +309,8 @@ STATIC_INLINE int jl_is_type(jl_value_t *v)
 }
 jl_value_t *jl_type_intersection_matching(jl_value_t *a, jl_value_t *b,
                                           jl_svec_t **penv, jl_svec_t *tvars);
-jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n);
-jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
+jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t *const *params, size_t n);
+jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t *const *env, size_t n);
 jl_datatype_t *jl_new_uninitialized_datatype(void);
 jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
                                    jl_svec_t *parameters);
@@ -339,8 +339,8 @@ jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr);
 
 jl_method_instance_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *types,
                                            int cache, int inexact, int allow_exec);
-jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache);
-jl_value_t *jl_gf_invoke(jl_tupletype_t *types, jl_value_t **args, size_t nargs);
+jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t *const *args, size_t nargs, int cache);
+jl_value_t *jl_gf_invoke(jl_tupletype_t *types, jl_value_t *const *args, size_t nargs);
 
 jl_datatype_t *jl_first_argument_datatype(jl_value_t *argtypes);
 int jl_has_intrinsics(jl_method_instance_t *li, jl_value_t *v, jl_module_t *m);
@@ -460,7 +460,7 @@ jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_tupletype_t *types, 
 
 uint32_t jl_module_next_counter(jl_module_t *m);
 void jl_fptr_to_llvm(jl_fptr_t fptr, jl_method_instance_t *lam, int specsig);
-jl_tupletype_t *arg_type_tuple(jl_value_t **args, size_t nargs);
+jl_tupletype_t *arg_type_tuple(jl_value_t *const *args, size_t nargs);
 
 int jl_has_meta(jl_array_t *body, jl_sym_t *sym);
 
@@ -656,7 +656,7 @@ JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
 int jl_array_store_unboxed(jl_value_t *el_type);
-int jl_array_isdefined(jl_value_t **args, int nargs);
+int jl_array_isdefined(jl_value_t *const *args, int nargs);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 
 // -- synchronization utilities -- //
@@ -744,9 +744,9 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
 jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_tupletype_t *types, jl_svec_t **penv,
         int8_t subtype_inexact__sigseq_useenv, int8_t subtype, int8_t offs);
 static jl_typemap_entry_t *const INEXACT_ENTRY = (jl_typemap_entry_t*)(uintptr_t)-1;
-jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs);
-jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t **args, size_t n);
-STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(union jl_typemap_t ml_or_cache, jl_value_t **args, size_t n, int8_t offs)
+jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t *const *args, size_t n, int8_t offs);
+jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t *const *args, size_t n);
+STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(union jl_typemap_t ml_or_cache, jl_value_t *const *args, size_t n, int8_t offs)
 {
     // NOTE: This function is a huge performance hot spot!!
     if (jl_typeof(ml_or_cache.unknown) == (jl_value_t*)jl_typemap_entry_type) {

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -97,7 +97,7 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
     return 1;
 }
 
-static inline int sig_match_leaf(jl_value_t **args, jl_value_t **sig, size_t n)
+static inline int sig_match_leaf(jl_value_t *const *args, jl_value_t **sig, size_t n)
 {
     // NOTE: This function is a huge performance hot spot!!
     size_t i;
@@ -115,7 +115,7 @@ static inline int sig_match_leaf(jl_value_t **args, jl_value_t **sig, size_t n)
     return 1;
 }
 
-static inline int sig_match_simple(jl_value_t **args, size_t n, jl_value_t **sig,
+static inline int sig_match_simple(jl_value_t *const *args, size_t n, jl_value_t **sig,
                                    int va, size_t lensig)
 {
     // NOTE: This function is a performance hot spot!!
@@ -767,7 +767,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
     }
 }
 
-jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_value_t **args, size_t n)
+jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_value_t *const *args, size_t n)
 {
     // some manually-unrolled common special cases
     while (ml->simplesig == (void*)jl_nothing && ml->guardsigs == jl_emptysvec && ml->isleafsig) {
@@ -841,7 +841,7 @@ nomatch:
     return NULL;
 }
 
-jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs)
+jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t *const *args, size_t n, int8_t offs)
 {
     if (n > offs) {
         jl_value_t *a1 = args[offs];


### PR DESCRIPTION
And make `args` a const array.

Modifying the `args` in jlcall is technically unsafe since it might point to a heap allocated array in the old gen. We can probably also take advantage of this in codegen.
