### PR TITLE
Clean up gc_state macros

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -203,7 +203,7 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     eh->prev = jl_current_task->eh;
     eh->gcstack = jl_pgcstack;
 #ifdef JULIA_ENABLE_THREADING
-    eh->gc_state = jl_get_ptls_states()->gc_state;
+    eh->gc_state = jl_gc_state();
     eh->locks_len = jl_current_task->locks.len;
 #endif
     jl_current_task->eh = eh;

--- a/src/gc.c
+++ b/src/gc.c
@@ -358,7 +358,7 @@ static void jl_wait_for_gc(void)
 
 void jl_gc_signal_wait(void)
 {
-    int8_t state = jl_get_ptls_states()->gc_state;
+    int8_t state = jl_gc_state();
     jl_get_ptls_states()->gc_state = JL_GC_STATE_WAITING;
     jl_wait_for_gc();
     jl_get_ptls_states()->gc_state = state;
@@ -2413,7 +2413,7 @@ JL_DLLEXPORT void jl_gc_collect(int full)
     gc_debug_print();
     JL_SIGATOMIC_BEGIN();
 
-    int8_t old_state = jl_get_ptls_states()->gc_state;
+    int8_t old_state = jl_gc_state();
     jl_get_ptls_states()->gc_state = JL_GC_STATE_WAITING;
     // In case multiple threads enter the GC at the same time, only allow
     // one of them to actually run the collection. We can't just let the


### PR DESCRIPTION
Also add `jl_gc_state()` to make it easier to write `gc_state` checking code without any runtime overhead for non-threading version.

There were two definitions of some of the macros because `jl_ptls_get_states()->gc_state` is a volatile load for non-threading even though it's always `0`. (Not particularly expensive but a little bit unsatisfying).
