### PR TITLE
Fix type inference problem for eig(SymTridiagonal)

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -145,11 +145,6 @@ eigfact!{T<:BlasReal,S<:StridedMatrix}(A::RealHermSymComplexHerm{T,S}, vl::Real,
 # Because of #6721 it is necessary to specify the parameters explicitly here.
 eigfact{T1<:Real,T2}(A::RealHermSymComplexHerm{T1,T2}, vl::Real, vh::Real) = (T = eltype(A); S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), vl, vh))
 
-function eig{T<:Real,S}(A::Union{Hermitian{T,S}, Symmetric{T,S}, Hermitian{Complex{T},S}}, args...)
-    F = eigfact(A, args...)
-    return F.values, F.vectors
-end
-
 eigvals!{T<:BlasReal,S<:StridedMatrix}(A::RealHermSymComplexHerm{T,S}) = LAPACK.syevr!('N', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)[1]
 # Because of #6721 it is necessary to specify the parameters explicitly here.
 eigvals{T1<:Real,T2}(A::RealHermSymComplexHerm{T1,T2}) = (T = eltype(A); S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A)))

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -119,22 +119,44 @@ end
 (\)(T::SymTridiagonal, B::StridedVecOrMat) = ldltfact(T)\B
 
 eigfact!{T<:BlasReal}(A::SymTridiagonal{T}) = Eigen(LAPACK.stegr!('V', A.dv, A.ev)...)
-eigfact{T}(A::SymTridiagonal{T}) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(SymTridiagonal{S}, A) : copy(A)))
+function eigfact{T}(A::SymTridiagonal{T})
+    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    eigfact!(copy_oftype(A, S))
+end
 
-eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, irange::UnitRange) = Eigen(LAPACK.stegr!('V', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)...)
-eigfact{T}(A::SymTridiagonal{T}, irange::UnitRange) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(SymTridiagonal{S}, A) : copy(A), irange))
+eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, irange::UnitRange) =
+    Eigen(LAPACK.stegr!('V', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)...)
+function eigfact{T}(A::SymTridiagonal{T}, irange::UnitRange)
+    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    return eigfact!(copy_oftype(A, S), irange)
+end
 
-eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, vl::Real, vu::Real) = Eigen(LAPACK.stegr!('V', 'V', A.dv, A.ev, vl, vu, 0, 0)...)
-eigfact{T}(A::SymTridiagonal{T}, vl::Real, vu::Real) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(SymTridiagonal{S}, A) : copy(A), vl, vu))
+eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, vl::Real, vu::Real) =
+    Eigen(LAPACK.stegr!('V', 'V', A.dv, A.ev, vl, vu, 0, 0)...)
+function eigfact{T}(A::SymTridiagonal{T}, vl::Real, vu::Real)
+    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    return eigfact!(copy_oftype(A, S), vl, vu)
+end
 
 eigvals!{T<:BlasReal}(A::SymTridiagonal{T}) = LAPACK.stev!('N', A.dv, A.ev)[1]
-eigvals{T}(A::SymTridiagonal{T}) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigvals!(S != T ? convert(SymTridiagonal{S}, A) : copy(A)))
+function eigvals{T}(A::SymTridiagonal{T})
+    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    return eigvals!(copy_oftype(A, S))
+end
 
-eigvals!{T<:BlasReal}(A::SymTridiagonal{T}, irange::UnitRange) = LAPACK.stegr!('N', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)[1]
-eigvals{T}(A::SymTridiagonal{T}, irange::UnitRange) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigvals!(S != T ? convert(SymTridiagonal{S}, A) : copy(A), irange))
+eigvals!{T<:BlasReal}(A::SymTridiagonal{T}, irange::UnitRange) =
+    LAPACK.stegr!('N', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)[1]
+function eigvals{T}(A::SymTridiagonal{T}, irange::UnitRange)
+    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    return eigvals!(copy_oftype(A, S), irange)
+end
 
-eigvals!{T<:BlasReal}(A::SymTridiagonal{T}, vl::Real, vu::Real) = LAPACK.stegr!('N', 'V', A.dv, A.ev, vl, vu, 0, 0)[1]
-eigvals{T}(A::SymTridiagonal{T}, vl::Real, vu::Real) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigvals!(S != T ? convert(SymTridiagonal{S}, A) : copy(A), vl, vu))
+eigvals!{T<:BlasReal}(A::SymTridiagonal{T}, vl::Real, vu::Real) =
+    LAPACK.stegr!('N', 'V', A.dv, A.ev, vl, vu, 0, 0)[1]
+function eigvals{T}(A::SymTridiagonal{T}, vl::Real, vu::Real)
+    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    return eigvals!(copy_oftype(A, S), vl, vu)
+end
 
 #Computes largest and smallest eigenvalue
 eigmax(A::SymTridiagonal) = eigvals(A, size(A, 1):size(A, 1))[1]

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -98,7 +98,9 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
 
     # eigenvalues/eigenvectors of symmetric tridiagonal
     if elty === Float32 || elty === Float64
-        DT, VT = eig(Ts)
+        DT, VT = @inferred eig(Ts)
+        @inferred eig(Ts, 2:4)
+        @inferred eig(Ts, 1.0, 2.0)
         D, Vecs = eig(Fs)
         @test_approx_eq DT D
         @test_approx_eq abs(VT'Vecs) eye(elty, n)


### PR DESCRIPTION
by changing the catch all kwargs... argument in `eig(StridedMatrix)` to specific keywords and by adding
a fallback eig method without keywords.

Also changing the formatting of the `eig*` methods for `SymTridiagonal` to make
them easier to read.
