### PR TITLE
Allow negative bit-shift counts

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -346,23 +346,23 @@ for (fJ, fC) in ((:-, :neg), (:~, :com))
     end
 end
 
-function <<(x::BigInt, c::Int)
-    c < 0 && throw(DomainError())
+function <<(x::BigInt, c::UInt)
     c == 0 && return x
     z = BigInt()
     ccall((:__gmpz_mul_2exp, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, c)
     return z
 end
 
-function >>(x::BigInt, c::Int)
-    c < 0 && throw(DomainError())
+function >>(x::BigInt, c::UInt)
     c == 0 && return x
     z = BigInt()
     ccall((:__gmpz_fdiv_q_2exp, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, c)
     return z
 end
 
->>>(x::BigInt, c::Int) = x >> c
+>>>(x::BigInt, c::UInt) = x >> c
+
+
 
 trailing_zeros(x::BigInt) = Int(ccall((:__gmpz_scan1, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))
 trailing_ones(x::BigInt) = Int(ccall((:__gmpz_scan0, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -139,7 +139,7 @@ powermod(x::Integer, p::Integer, m::Union{Int128,UInt128}) = oftype(m, powermod(
 nextpow2(x::Unsigned) = one(x)<<((sizeof(x)<<3)-leading_zeros(x-one(x)))
 nextpow2(x::Integer) = reinterpret(typeof(x),x < 0 ? -nextpow2(unsigned(-x)) : nextpow2(unsigned(x)))
 
-prevpow2(x::Unsigned) = (one(x)>>(x==0)) << ((sizeof(x)<<3)-leading_zeros(x)-1)
+prevpow2(x::Unsigned) = one(x) << unsigned((sizeof(x)<<3)-leading_zeros(x)-1)
 prevpow2(x::Integer) = reinterpret(typeof(x),x < 0 ? -prevpow2(unsigned(-x)) : prevpow2(unsigned(x)))
 
 ispow2(x::Integer) = x > 0 && count_ones(x) == 1

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -230,7 +230,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Left bit shift operator, ``x << n``\ . The result is ``x`` shifted left by ``n`` bits, where ``n >= 0``\ , filling with ``0``\ s. This is equivalent to ``x * 2^n``\ .
+   Left bit shift operator, ``x << n``\ . For ``n >= 0``\ , the result is ``x`` shifted left by ``n`` bits, filling with ``0``\ s. This is equivalent to ``x * 2^n``\ . For ``n < 0``\ , this is equivalent to ``x >> -n``\ .
 
    .. doctest::
 
@@ -250,7 +250,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Right bit shift operator, ``x >> n``\ . The result is ``x`` shifted right by ``n`` bits, where ``n >= 0``\ , filling with ``0``\ s if ``x >= 0``\ , ``1``\ s if ``x < 0``\ , preserving the sign of ``x``\ . This is equivalent to ``fld(x, 2^n)``\ .
+   Right bit shift operator, ``x >> n``\ . For ``n >= 0``\ , the result is ``x`` shifted right by ``n`` bits, where ``n >= 0``\ , filling with ``0``\ s if ``x >= 0``\ , ``1``\ s if ``x < 0``\ , preserving the sign of ``x``\ . This is equivalent to ``fld(x, 2^n)``\ . For ``n < 0``\ , this is equivalent to ``x << -n``\ .
 
    .. doctest::
 
@@ -279,9 +279,9 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Unsigned right bit shift operator, ``x >>> n``\ . The result is ``x`` shifted right by ``n`` bits, where ``n >= 0``\ , filling with ``0``\ s.
+   Unsigned right bit shift operator, ``x >>> n``\ . For ``n >= 0``\ , the result is ``x`` shifted right by ``n`` bits, where ``n >= 0``\ , filling with ``0``\ s. For ``n < 0``\ , this is equivalent to ``x [<<](:func:``\ <<``) -n``\ ].
 
-   For ``Unsigned`` integer types, this is eqivalent to :func:`>>`\ . For ``Signed`` integer types, this is equivalent to ``(unsigned(x) >> n) % typeof(x)``\ .
+   For ``Unsigned`` integer types, this is eqivalent to :func:`>>`\ . For ``Signed`` integer types, this is equivalent to ``signed(unsigned(x) >> n)``\ .
 
    .. doctest::
 

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -156,6 +156,10 @@ end
 @test BigInt(5) >> 1 == 2
 @test BigInt(-5) << 3 == -40
 @test BigInt(-5) >> 1 == -3
+@test BigInt(5) >> -3 == 40
+@test BigInt(5) << -1 == 2
+@test BigInt(-5) >> -3 == -40
+@test BigInt(-5) << -1 == -3
 
 @test ~BigInt(123) == -124
 @test BigInt(123) & BigInt(234) == 106


### PR DESCRIPTION
This patch concerts the bit shift operators << >> >>>.
- Convert signed bit-shift counts explicitly to unsigned, reporting InexactErrors for negative counts.
- Introduce versions that take unsigned arguments, and which thus do not require any tests.
- Introduce new functions `bitshift` and `unsigned_bitshift` that (similar to Matlab) shift left or right for positive and negative counts, respectively.
- Add documentation.
- Add tests.

Closes #14516.
