### PR TITLE
Use tuples of types instead of accessing the .types field of Unions

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -7,12 +7,19 @@
 # they are also used elsewhere where Int128/UInt128 support is separated out,
 # such as in hashing2.jl
 
-typealias BitSigned64   Union{Int8,Int16,Int32,Int64}
-typealias BitUnsigned64 Union{UInt8,UInt16,UInt32,UInt64}
-typealias BitInteger64  Union{BitSigned64,BitUnsigned64}
-typealias BitSigned     Union{BitSigned64,Int128}
-typealias BitUnsigned   Union{BitUnsigned64,UInt128}
-typealias BitInteger    Union{BitSigned,BitUnsigned}
+const BitSigned64_types   = (Int8,Int16,Int32,Int64)
+const BitUnsigned64_types = (UInt8,UInt16,UInt32,UInt64)
+const BitInteger64_types  = (BitSigned64_types...,BitUnsigned64_types...)
+const BitSigned_types     = (BitSigned64_types...,Int128)
+const BitUnsigned_types   = (BitUnsigned64_types...,UInt128)
+const BitInteger_types    = (BitSigned_types...,BitUnsigned_types...)
+
+typealias BitSigned64   Union{BitSigned64_types...}
+typealias BitUnsigned64 Union{BitUnsigned64_types...}
+typealias BitInteger64  Union{BitInteger64_types...}
+typealias BitSigned     Union{BitSigned_types...}
+typealias BitUnsigned   Union{BitUnsigned_types...}
+typealias BitInteger    Union{BitInteger_types...}
 
 ## integer comparisons ##
 
@@ -155,7 +162,7 @@ trailing_ones(x::Integer) = trailing_zeros(~x)
 
 ## integer conversions ##
 
-for to in tuple(BitInteger.types...), from in tuple(BitInteger.types...,Bool)
+for to in BitInteger_types, from in (BitInteger_types...,Bool)
     if !(to === from)
         if to.size < from.size
             if issubtype(to, Signed)
@@ -263,7 +270,7 @@ promote_rule{T<:Union{Int8,Int16,Int32}}(::Type{Int64}, ::Type{T})     = Int64
 promote_rule{T<:Union{UInt8,UInt16,UInt32}}(::Type{UInt64}, ::Type{T}) = UInt64
 promote_rule{T<:BitSigned64}(::Type{Int128}, ::Type{T})    = Int128
 promote_rule{T<:BitUnsigned64}(::Type{UInt128}, ::Type{T}) = UInt128
-for T in tuple(BitSigned.types...)
+for T in BitSigned_types
     @eval promote_rule{S<:Union{UInt8,UInt16}}(::Type{S}, ::Type{$T}) =
         $(sizeof(T) < sizeof(Int) ? Int : T)
 end

--- a/test/int.jl
+++ b/test/int.jl
@@ -18,10 +18,10 @@ for y in (4, Float32(4), 4.0, big(4.0))
 end
 
 # Result type must be type of first argument
-for T in (Base.BitInteger.types..., BigInt,
+for T in (Base.BitInteger_types..., BigInt,
           Rational{Int}, Rational{BigInt},
           Float16, Float32, Float64)
-    for U in (Base.BitInteger.types..., BigInt,
+    for U in (Base.BitInteger_types..., BigInt,
               Rational{Int}, Rational{BigInt},
               Float16, Float32, Float64)
         @test typeof(copysign(T(3), U(4))) === T
@@ -89,8 +89,8 @@ end
 bitstype 8 MyBitsType <: Integer
 @test_throws MethodError ~reinterpret(MyBitsType, 0x7b)
 
-UItypes = Base.BitUnsigned.types
-SItypes = Base.BitSigned.types
+UItypes = Base.BitUnsigned_types
+SItypes = Base.BitSigned_types
 
 for T in UItypes, S in UItypes
     @test promote(S(3), T(3)) === (sizeof(T) < sizeof(S) ? (S(3), S(3)) : (T(3), T(3)))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1125,7 +1125,7 @@ end
 @test_approx_eq (Complex(1,2)/Complex(2.5,3.0))*Complex(2.5,3.0) Complex(1,2)
 @test 0.7 < real(sqrt(Complex(0,1))) < 0.707107
 
-for T in Base.BitSigned.types
+for T in Base.BitSigned_types
     @test abs(typemin(T)) == -typemin(T)
     #for x in (typemin(T),convert(T,-1),zero(T),one(T),typemax(T))
     #    @test signed(unsigned(x)) == x
@@ -1137,8 +1137,8 @@ end
 #    @test unsigned(signed(x)) == x
 #end
 
-for S = Base.BitSigned64.types,
-    U = Base.BitUnsigned64.types
+for S = Base.BitSigned64_types,
+    U = Base.BitUnsigned64_types
     @test !(-one(S) == typemax(U))
     @test -one(S) != typemax(U)
     @test -one(S) < typemax(U)
@@ -1146,7 +1146,7 @@ for S = Base.BitSigned64.types,
 end
 
 # check type of constructed rationals
-int_types = Base.BitInteger64.types
+int_types = Base.BitInteger64_types
 for N = int_types, D = int_types
     T = promote_type(N,D)
     @test typeof(convert(N,2)//convert(D,3)) <: Rational{T}
@@ -1156,8 +1156,8 @@ end
 @test typeof(convert(Rational{Integer},1)) === Rational{Integer}
 
 # check type of constructed complexes
-real_types = [Base.BitInteger64.types...,
-              [Rational{T} for T in Base.BitInteger64.types]...,
+real_types = [Base.BitInteger64_types...,
+              [Rational{T} for T in Base.BitInteger64_types]...,
               Float32, Float64]
 for A = real_types, B = real_types
     T = promote_type(A,B)

--- a/test/random.jl
+++ b/test/random.jl
@@ -315,7 +315,7 @@ for rng in ([], [MersenneTwister()], [RandomDevice()])
     rand!(rng..., BitArray(5))     ::BitArray{1}
     rand!(rng..., BitArray(2, 3))  ::BitArray{2}
 
-    for T in [Base.BitInteger.types..., Bool, Char, Float16, Float32, Float64]
+    for T in [Base.BitInteger_types..., Bool, Char, Float16, Float32, Float64]
         a0 = rand(rng..., T)       ::T
         a1 = rand(rng..., T, 5)    ::Vector{T}
         a2 = rand(rng..., T, 2, 3) ::Array{T, 2}


### PR DESCRIPTION
See #14535: "A type Union is not a good way to implement a container of types, because (1) a union is not a list of types but a union of them, and therefore brings in type-level semantics that you might not want, and (2) I plan to change the representation and remove the .types field."
