### PR TITLE
Make signed-unsigned integer comparisons more uniform

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -158,8 +158,8 @@ trailing_ones(x::Integer) = trailing_zeros(~x)
 ==(x::Signed,   y::Unsigned) = (x >= 0) & (unsigned(x) == y)
 ==(x::Unsigned, y::Signed  ) = (y >= 0) & (x == unsigned(y))
 <( x::Signed,   y::Unsigned) = (x <  0) | (unsigned(x) <  y)
-<( x::Unsigned, y::Signed  ) = (y >  0) & (x <  unsigned(y))
-<=(x::Signed,   y::Unsigned) = (x <= 0) | (unsigned(x) <= y)
+<( x::Unsigned, y::Signed  ) = (y >= 0) & (x <  unsigned(y))
+<=(x::Signed,   y::Unsigned) = (x <  0) | (unsigned(x) <= y)
 <=(x::Unsigned, y::Signed  ) = (y >= 0) & (x <= unsigned(y))
 
 ## integer conversions ##


### PR DESCRIPTION
This changes mixed signed unsigned integer comparisons to always compare the signed value either `>= 0` or `< 0`, and avoids comparisons `> 0` and `<= 0`. There is no change in behaviour.

This change might lead to additional optimization opportunities if the same signed value is compared multiple times, e.g. in chained comparisons.
