### PR TITLE
fix sparse matrix colon indexing

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1466,6 +1466,7 @@ end
 # Colon translation
 getindex(A::SparseMatrixCSC, ::Colon, ::Colon) = copy(A)
 getindex(A::SparseMatrixCSC, i, ::Colon)       = getindex(A, i, 1:size(A, 2))
+getindex(A::SparseMatrixCSC, ::Colon, i)       = getindex(A, 1:size(A, 1), i)
 
 function getindex_cols{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, J::AbstractVector)
     # for indexing whole columns


### PR DESCRIPTION
Added missing method `getindex(A::SparseMatrixCSC, ::Colon, i)`.
The `AbstractArray` fallback was much slower.
