### PR TITLE
Fix -Wpedantic and enable it in c++ code

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -338,6 +338,10 @@ CXX := $(CROSS_COMPILE)g++
 JCFLAGS := -std=gnu99 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 JCPPFLAGS :=
 JCXXFLAGS := -pipe $(fPIC) -fno-rtti
+ifneq ($(OS), WINNT)
+# Do no enable on windows to avoid warnings from libuv.
+JCXXFLAGS += -pedantic
+endif
 DEBUGFLAGS := -O0 -ggdb2 -DJL_DEBUG_BUILD -fstack-protector-all
 SHIPFLAGS := -O3 -ggdb1 -falign-functions
 endif
@@ -347,7 +351,7 @@ CC := $(CROSS_COMPILE)clang
 CXX := $(CROSS_COMPILE)clang++
 JCFLAGS := -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 JCPPFLAGS :=
-JCXXFLAGS := -pipe $(fPIC) -fno-rtti
+JCXXFLAGS := -pipe $(fPIC) -fno-rtti -pedantic
 DEBUGFLAGS := -O0 -g -DJL_DEBUG_BUILD -fstack-protector-all
 SHIPFLAGS := -O3 -g
 ifeq ($(OS), Darwin)

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -12,11 +12,11 @@ extern "C" {
 #ifdef DEFINE_BUILTIN_GLOBALS
 #define DECLARE_BUILTIN(name) \
     JL_CALLABLE(jl_f_##name); \
-    jl_value_t *jl_builtin_##name;
+    jl_value_t *jl_builtin_##name
 #else
 #define DECLARE_BUILTIN(name) \
     JL_CALLABLE(jl_f_##name); \
-    extern jl_value_t *jl_builtin_##name;
+    extern jl_value_t *jl_builtin_##name
 #endif
 
 DECLARE_BUILTIN(throw);      DECLARE_BUILTIN(is);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -494,7 +494,7 @@ JL_CALLABLE(jl_f__apply)
             assert(jl_is_array(ai));
             jl_array_t *aai = (jl_array_t*)ai;
             size_t al = jl_array_len(aai);
-            if (aai->ptrarray) {
+            if (aai->flags.ptrarray) {
                 for (j = 0; j < al; j++) {
                     jl_value_t *arg = jl_cellref(aai, j);
                     // apply with array splatting may have embedded NULL value
@@ -1426,7 +1426,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v,
         jl_array_t *av = (jl_array_t*)v;
         jl_datatype_t *el_type = (jl_datatype_t*)jl_tparam0(vt);
         for (j = 0; j < tlen; j++) {
-            if (av->ptrarray) {
+            if (av->flags.ptrarray) {
                 n += jl_static_show_x(out, jl_cellref(v, j), depth);
             } else {
                 char *ptr = ((char*)av->data) + j * av->elsize;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1772,11 +1772,17 @@ static Value *emit_arrayflags(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
 {
     assert(tinfo.isboxed);
     Value *t = tinfo.V;
+#ifdef STORE_ARRAY_LEN
+    int arrayflag_field = 2;
+#else
+    int arrayflag_field = 1;
+#endif
     Value *addr = builder.CreateStructGEP(
 #ifdef LLVM37
                             nullptr,
 #endif
-                            builder.CreateBitCast(t, jl_parray_llvmt), 2);
+                            builder.CreateBitCast(t, jl_parray_llvmt),
+                            arrayflag_field);
     return builder.CreateLoad(addr); // TODO: tbaa
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -127,6 +127,10 @@ using namespace llvm::legacy;
 #define AddrSpaceCastInst BitCastInst
 #endif
 
+#if !defined(_COMPILER_MICROSOFT_) && __cplusplus < 201103L
+#  define static_assert(...)
+#endif
+
 extern "C" {
 
 #include "builtin_proto.h"
@@ -5347,6 +5351,8 @@ static void init_julia_llvm_env(Module *m)
 #endif
                       , T_int16
     };
+    static_assert(sizeof(jl_array_flags_t) == sizeof(int16_t),
+                  "Size of jl_array_flags_t is not the same as int16_t");
     Type* jl_array_llvmt =
         StructType::create(jl_LLVMContext,
                            ArrayRef<Type*>(vaelts,sizeof(vaelts)/sizeof(vaelts[0])),

--- a/src/dump.c
+++ b/src/dump.c
@@ -730,19 +730,19 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
     }
     else if (jl_is_array(v)) {
         jl_array_t *ar = (jl_array_t*)v;
-        if (ar->ndims == 1 && ar->elsize < 128) {
+        if (ar->flags.ndims == 1 && ar->elsize < 128) {
             writetag(s, (jl_value_t*)Array1d_tag);
-            write_uint8(s, (ar->ptrarray<<7) | (ar->elsize & 0x7f));
+            write_uint8(s, (ar->flags.ptrarray<<7) | (ar->elsize & 0x7f));
         }
         else {
             writetag(s, (jl_value_t*)jl_array_type);
-            write_uint16(s, ar->ndims);
-            write_uint16(s, (ar->ptrarray<<15) | (ar->elsize & 0x7fff));
+            write_uint16(s, ar->flags.ndims);
+            write_uint16(s, (ar->flags.ptrarray<<15) | (ar->elsize & 0x7fff));
         }
-        for (i=0; i < ar->ndims; i++)
+        for (i=0; i < ar->flags.ndims; i++)
             jl_serialize_value(s, jl_box_long(jl_array_dim(ar,i)));
         jl_serialize_value(s, jl_typeof(ar));
-        if (!ar->ptrarray) {
+        if (!ar->flags.ptrarray) {
             size_t tot = jl_array_len(ar) * ar->elsize;
             ios_write(s, (char*)jl_array_data(ar), tot);
         }
@@ -1357,7 +1357,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
             backref_list.items[pos] = a;
         jl_value_t *aty = jl_deserialize_value(s, &jl_astaggedvalue(a)->type);
         jl_set_typeof(a, aty);
-        if (!a->ptrarray) {
+        if (!a->flags.ptrarray) {
             size_t tot = jl_array_len(a) * a->elsize;
             ios_read(s, (char*)jl_array_data(a), tot);
         }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -175,7 +175,6 @@ void jl_add_method_to_table(jl_methtable_t *mt, jl_tupletype_t *types, jl_lambda
 jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
-typedef struct _jl_ast_context_t jl_ast_context_t;
 jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast);
 
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);


### PR DESCRIPTION
This fixes the left over warning with `-pedantic` in c++ code after #13945. As mentioned in that pull request somehow this flag is added by llvm-config 3.7 on ArchLinux.
