### PR TITLE
fix UndefVarError problem

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -443,11 +443,13 @@ void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes, jl_lambda_inf
 #endif
 #ifdef ENABLE_INFERENCE
         jl_value_t *newast = jl_apply(jl_typeinf_func, fargs, 4);
+        jl_value_t *defast = def->ast;
         li->ast = jl_fieldref(newast, 0);
         jl_gc_wb(li, li->ast);
         li->rettype = jl_fieldref(newast, 1);
         jl_gc_wb(li, li->rettype);
-        li->inferred = 1;
+        // if type inference bails out it returns def->ast
+        li->inferred = li->ast != defast;
 #endif
         li->inInference = 0;
     }

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -105,6 +105,10 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
         @test eigvecs(Ts) == eigvecs(Fs)
         #call to LAPACK.stein here
         Test.test_approx_eq_modphase(eigvecs(Ts,eigvals(Ts)),eigvecs(Fs))
+    elseif elty != Int
+        # check that undef is determined accurately even if type inference
+        # bails out due to the number of try/catch blocks in this code.
+        @test_throws UndefVarError Fs
     end
 
     # Test det(A::Matrix)


### PR DESCRIPTION
caused by 25c3659d6cec2ebf6e6c7d16b03adac76a47b42a. Let's see if this fix works properly.
