### PR TITLE
[release-0.4, RFC]: Remove 0-size and variable size array members from public headers.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4938,7 +4938,7 @@ extern "C" DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
     jl_value_t *box = (jl_value_t*)jl_gc_alloc_1w();
     jl_set_typeof(box, jl_box_any_type);
     // if (v) jl_gc_wb(box, v); // write block not needed: box was just allocated
-    box->fieldptr[0] = v;
+    jl_data_ptr(box)[0] = v;
     return box;
 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -1686,7 +1686,7 @@ static void jl_reinit_item(ios_t *f, jl_value_t *v, int how) {
     JL_TRY {
         switch (how) {
             case 1: { // rehash ObjectIdDict
-                jl_array_t **a = (jl_array_t**)&v->fieldptr[0];
+                jl_array_t **a = (jl_array_t**)jl_data_ptr(v);
                 jl_idtable_rehash(a, jl_array_len(*a));
                 jl_gc_wb(v, *a);
                 break;


### PR DESCRIPTION
Backport of 63f3edf300e9fea39a1932ee2e8f1655c845361f to release-0.4. This allows building with GCC 6.0.

GCC 6.0 has just entered Fedora rawhide, and it seems smart enough to detect empty structs with variable-size arrays despite of the tricks used in the code. This is a manual backport, but I'm not actually sure this doesn't introduce any ABI breakage. At https://github.com/JuliaLang/julia/pull/13945#issuecomment-155913304, @yuyichao said it didn't, but I'd like him to confirm this.

There's still the API break, though, so that's not ideal for embedding. A simpler work-around would be a better solution, if at all possible.
