### PR TITLE
Use uv_hrtime instead of assembly to get current CPU time

### DIFF
--- a/src/ia_misc.h
+++ b/src/ia_misc.h
@@ -6,49 +6,12 @@
 #include <stdint.h>
 #if defined(_CPU_X86_64_) || defined(_CPU_X86_)
 #  include <immintrin.h>
-#elif defined(__linux__)
-#  include <linux/perf_event.h>
-#  include <linux/hw_breakpoint.h>
-#  include <asm/unistd.h>
 #endif
 #include "support/dtypes.h"
 
 #if defined(__i386__) && defined(__GNUC__) && !defined(__SSE2__)
 #error Julia can only be built for architectures above Pentium 4. Pass -march=pentium4, or set MARCH=pentium4 and ensure that -march is not passed separately with an older architecture.
 #endif
-
-#if defined(__i386__)
-
-STATIC_INLINE unsigned long long rdtsc(void)
-{
-    unsigned long long int x;
-    __asm__ volatile (".byte 0x0f, 0x31" : "=A" (x));
-    return x;
-}
-
-#elif defined(__x86_64__)
-
-STATIC_INLINE uint64_t rdtsc(void)
-{
-    unsigned hi, lo;
-    __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
-    return ((uint64_t)lo) | (((uint64_t)hi) << 32);
-}
-
-#elif defined(_COMPILER_MICROSOFT_)
-
-#include <intrin.h>
-
-STATIC_INLINE uint64_t rdtsc(void)
-{
-    return __rdtsc();
-}
-
-#elif defined(__linux__)
-
-long long rdtsc(void);
-
-#endif  /* __i386__ */
 
 #ifdef __MIC__
 

--- a/src/threadgroup.c
+++ b/src/threadgroup.c
@@ -141,20 +141,27 @@ int ti_threadgroup_fork(ti_threadgroup_t *tg, int16_t ext_tid,
         }
     }
     else {
-        // spin up to threshold cycles (count sheep), then sleep
-        uint64_t spin_cycles, spin_start = rdtsc();
+        // spin up to threshold ns (count sheep), then sleep
+        uint64_t spin_ns;
+        uint64_t spin_start = 0;
         while (tg->group_sense !=
                tg->thread_sense[tg->tid_map[ext_tid]]->sense) {
             if (tg->sleep_threshold) {
-                spin_cycles = rdtsc() - spin_start;
-                if (spin_cycles >= tg->sleep_threshold) {
+                if (!spin_start) {
+                    // Lazily initialize spin_start since uv_hrtime is expensive
+                    spin_start = uv_hrtime();
+                    continue;
+                }
+                spin_ns = uv_hrtime() - spin_start;
+                // In case uv_hrtime is not monotonic, we'll sleep earlier
+                if (spin_ns >= tg->sleep_threshold) {
                     uv_mutex_lock(&tg->alarm_lock);
                     if (tg->group_sense !=
                         tg->thread_sense[tg->tid_map[ext_tid]]->sense) {
                         uv_cond_wait(&tg->alarm, &tg->alarm_lock);
                     }
                     uv_mutex_unlock(&tg->alarm_lock);
-                    spin_start = rdtsc();
+                    spin_start = 0;
                     continue;
                 }
             }


### PR DESCRIPTION
- This is more portable (for obvious reason)
- This is also more reliable/predictable since it is independent of CPU frequency scaling.
- On the machines I've benchmarked this on, the clock resolution (minimum interval between two successive calls) is ~2-3x worse (20cycles vs ~13ns on 3/4.6GHz machine) and the performance is ~2-3x worse (8ns vs 20ns). (The libuv wrapper doesn't seem to add much overhead compare to `clock_gettime(CLOCK_MONOTONIC)` on linux). This shouldn't matter much since the only place it is used in non-benchmark code is `ti_threadgroup_fork` and I've re-organized the code such that it is only called in the waiting code path.
