### PR TITLE
Added working copytri! method for sparse matrices

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-import Base.LinAlg: checksquare
+import Base.LinAlg: checksquare, copytri!
 
 ## Functions to switch to 0-based indexing to call external sparse solvers
 
@@ -165,6 +165,20 @@ function spmatmul{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
     Cunsorted = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
     C = SparseArrays.sortSparseMatrixCSC!(Cunsorted, sortindices=sortindices)
     return C
+end
+
+# copytri! - for make symmetric sparse mats full
+function copytri!(A::SparseMatrixCSC, uplo::Char, conjugate::Bool=false)
+    n = checksquare(A)
+    B = conjugate ? ctranspose(A) : transpose(A)
+    if uplo == 'U'
+        A = triu!(A) + tril!(B,-1)
+    elseif uplo == 'L'
+        A = tril!(A) + triu!(B,1)
+    else
+        throw(ArgumentError("uplo argument must be 'U' (upper) or 'L' (lower), got $uplo"))
+    end
+    A
 end
 
 ## solvers

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -9,6 +9,11 @@ using Base.Test
 # check sparse matrix construction
 @test isequal(full(sparse(complex(ones(5,5),ones(5,5)))), complex(ones(5,5),ones(5,5)))
 
+# check symmetric full
+a = sparse(complex(ones(5,5),ones(5,5)))
+@test isequal(full(Symmetric(triu(a + a.'))),a + a.')
+@test isequal(full(Symmetric(a + a.')),a + a.')
+
 # check matrix operations
 se33 = speye(3)
 do33 = ones(3)


### PR DESCRIPTION
`full(::Symmetric{SparseMatrixCSC})` was failing because of a lack
of working `copytri!` method for sparse matrices. I added the
`copytri!` method, and added tests for full.
