### PR TITLE
Added escape support to DateFormat

### DIFF
--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -153,14 +153,19 @@ function parse(x::AbstractString,df::DateFormat)
         throw(ArgumentError("Delimiter mismatch. Couldn't find first delimiter, \"$(df.slots[1].transition)\", in date string"))
     end
     periods = Period[]
-    extra = []
+    extra = Any[]  # Supports custom slot types such as TimeZone
     cursor = 1
     for slot in df.slots
         cursor, pe = getslot(x,slot,df.locale,cursor)
         pe != nothing && (isa(pe,Period) ? push!(periods,pe) : push!(extra,pe))
         cursor > endof(x) && break
     end
-    return vcat(sort!(periods,rev=true,lt=periodisless), extra)
+    sort!(periods,rev=true,lt=periodisless)
+    if isempty(extra)
+        return periods
+    else
+        return vcat(periods, extra)
+    end
 end
 
 slotformat(slot,dt,locale) = lpad(string(value(slot.parser(dt))),slot.width,"0")

--- a/base/docs/helpdb/Dates.jl
+++ b/base/docs/helpdb/Dates.jl
@@ -46,8 +46,10 @@ string:
 | `E`        | Monday    | Matches full name days of the week                           |
 | `yyyymmdd` | 19960101  | Matches fixed-width year, month, and day                     |
 
-All characters not listed above are treated as delimiters between date and time slots. So a
-`dt` string of "1996-01-15T00:00:00.0" would have a `format` string like "y-m-dTH:M:S.s".
+Characters not listed above are normally treated as delimiters between date and time slots.
+For example a `dt` string of "1996-01-15T00:00:00.0" would have a `format` string like
+"y-m-dTH:M:S.s". If you need to use a code character as a delimiter you can escape it using
+backslash. The date "1995y01m" would have the format "y\\ym\\m".
 """
 Dates.DateTime(dt::AbstractString, format::AbstractString)
 
@@ -81,6 +83,8 @@ except that it does not truncate values longer than the width.
 
 When creating a `format` you can use any non-code characters as a separator. For example to
 generate the string "1996-01-15T00:00:00" you could use `format`: "yyyy-mm-ddTHH:MM:SS".
+Note that if you need to use a code character as a literal you can use the escape character
+backslash. The string "1996y01m" can be produced with the format "yyyy\\ymm\\m".
 """
 Dates.format(dt::Dates.TimeType, format::AbstractString)
 

--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -109,7 +109,7 @@ Alternatively, you can write ``using Base.Dates`` to bring all exported function
    | ``yyyymmdd`` | 19960101  | Matches fixed-width year, month, and day                       |
    +--------------+-----------+----------------------------------------------------------------+
 
-   All characters not listed above are treated as delimiters between date and time slots. So a ``dt`` string of "1996-01-15T00:00:00.0" would have a ``format`` string like "y-m-dTH:M:S.s".
+   Characters not listed above are normally treated as delimiters between date and time slots. For example a ``dt`` string of "1996-01-15T00:00:00.0" would have a ``format`` string like "y-m-dTH:M:S.s". If you need to use a code character as a delimiter you can escape it using backslash. The date "1995y01m" would have the format "y\\ym\\m".
 
 .. _man-date-formatting:
 
@@ -149,7 +149,7 @@ Alternatively, you can write ``using Base.Dates`` to bring all exported function
 
    The number of sequential code characters indicate the width of the code. A format of ``yyyy-mm`` specifies that the code ``y`` should have a width of four while ``m`` a width of two. Codes that yield numeric digits have an associated mode: fixed-width or minimum-width. The fixed-width mode left-pads the value with zeros when it is shorter than the specified width and truncates the value when longer. Minimum-width mode works the same as fixed-width except that it does not truncate values longer than the width.
 
-   When creating a ``format`` you can use any non-code characters as a separator. For example to generate the string "1996-01-15T00:00:00" you could use ``format``\ : "yyyy-mm-ddTHH:MM:SS".
+   When creating a ``format`` you can use any non-code characters as a separator. For example to generate the string "1996-01-15T00:00:00" you could use ``format``\ : "yyyy-mm-ddTHH:MM:SS". Note that if you need to use a code character as a literal you can use the escape character backslash. The string "1996y01m" can be produced with the format "yyyy\\ymm\\m".
 
 .. function:: DateFormat(format::AbstractString, locale::AbstractString="english") -> DateFormat
 

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -25,6 +25,9 @@ let str = "1996/02/15 24:00", format = "yyyy/mm/dd HH:MM"
     @test_throws ArgumentError Dates.DateTime(str, Dates.DateFormat(format))
 end
 
+# Issue #13644: Ensure that Dates.parse returns a Period array when no custom slots are used.
+@test eltype(Dates.parse("1942-12-25T01:23:45", Dates.DateFormat("yyyy-mm-ddTHH:MM:SS", "english"))) == Dates.Period
+
 # Common Parsing Patterns
 #'1996-January-15'
 dt = Dates.DateTime(1996,1,15)

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -328,3 +328,32 @@ let f = "YY"
     @test Dates.format(Dates.Date(9), f) == "09"
     @test Dates.format(typemax(Dates.Date), f) == "252522163911149"
 end
+
+# Issue: https://github.com/quinnj/TimeZones.jl/issues/19
+let
+    ds = "2015-07-24T05:38:19.591Z"
+    dt = Dates.DateTime(2015,7,24,5,38,19,591)
+
+    format = "yyyy-mm-ddTHH:MM:SS.sssZ"
+    escaped_format = "yyyy-mm-dd\\THH:MM:SS.sss\\Z"
+
+    # Typically 'Z' isn't treated as a slot so it doesn't have to be escaped
+    @test DateTime(ds, format) == dt
+    @test DateTime(ds, escaped_format) == dt
+
+    try
+        # Make 'Z' into a slot
+        Dates.SLOT_RULE['Z'] = Dates.TimeZone
+        slotparse(slot::Dates.Slot{Dates.TimeZone},x,locale) = throw(ArgumentError("Invalid slot"))
+
+        @test_throws ArgumentError DateTime(ds, format)
+        @test DateTime(ds, escaped_format) == dt
+    finally
+        # Ideally we would be able to set SLOT_RULE['Z'] back to being undefined
+        Dates.SLOT_RULE['Z'] = Void
+    end
+
+    # Ensure that the default behaviour has been restored
+    @test DateTime(ds, format) == dt
+    @test DateTime(ds, escaped_format) == dt
+end


### PR DESCRIPTION
Now that DateFormat can be extended with custom slots (see #12799) we need a way of escaping slot characters. For example:

The character 'Z' can be used to indicate Zulu:

``` julia
julia> DateTime("2015-07-24T05:38:19.591Z", "yyyy-mm-ddTHH:MM:SS.sssZ")
2015-07-24T05:38:19.591
```

Additionally 'Z' is used by the TimeZones.jl package to indicate a slot. After TimeZone.jl is imported the 'Z' is treated as a special slot character:

``` julia
julia> using TimeZones

julia> DateTime("2015-07-24T05:38:19.591Z", "yyyy-mm-ddTHH:MM:SS.sssZ")
ERROR: ArgumentError: Ambiguous timezone
```

This commit enables users to escape characters to ignore them from being processed as a slot:

``` julia
julia> using TimeZones

julia> DateTime("2015-07-24T05:38:19.591Z", "yyyy-mm-ddTHH:MM:SS.sss\\Z")
2015-07-24T05:38:19.591
```

Originally brought up by @slundberg in https://github.com/quinnj/TimeZones.jl/issues/19
