### PR TITLE
Consistently use stdint.h int types

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -369,9 +369,9 @@ JL_DEFINE_MUTEX(symbol_table)
 
 static jl_sym_t *volatile symtab = NULL;
 
-static uptrint_t hash_symbol(const char *str, size_t len)
+static uintptr_t hash_symbol(const char *str, size_t len)
 {
-    return memhash(str, len) ^ ~(uptrint_t)0/3*2;
+    return memhash(str, len) ^ ~(uintptr_t)0/3*2;
 }
 
 #define SYM_POOL_SIZE 524288
@@ -416,7 +416,7 @@ static jl_sym_t *symtab_lookup(jl_sym_t *volatile *ptree, const char *str,
                                size_t len, jl_sym_t *volatile **slot)
 {
     jl_sym_t *node = *ptree;
-    uptrint_t h = hash_symbol(str, len);
+    uintptr_t h = hash_symbol(str, len);
 
     // Tree nodes sorted by major key of (int(hash)) and minor key of (str).
     while (node != NULL) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -991,7 +991,7 @@ JL_CALLABLE(jl_f_invoke)
 #define hash64(a)   int64to32hash(a)
 #endif
 
-static uptrint_t bits_hash(void *b, size_t sz)
+static uintptr_t bits_hash(void *b, size_t sz)
 {
     switch (sz) {
     case 1:  return int32hash(*(int8_t*)b);
@@ -1007,19 +1007,19 @@ static uptrint_t bits_hash(void *b, size_t sz)
     }
 }
 
-static uptrint_t NOINLINE hash_svec(jl_svec_t *v)
+static uintptr_t NOINLINE hash_svec(jl_svec_t *v)
 {
-    uptrint_t h = 0;
+    uintptr_t h = 0;
     size_t l = jl_svec_len(v);
     for(size_t i = 0; i < l; i++) {
         jl_value_t *x = jl_svecref(v,i);
-        uptrint_t u = x==NULL ? 0 : jl_object_id(x);
+        uintptr_t u = x==NULL ? 0 : jl_object_id(x);
         h = bitmix(h, u);
     }
     return h;
 }
 
-static uptrint_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
+static uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
 {
     if (tv == (jl_value_t*)jl_sym_type)
         return ((jl_sym_t*)v)->hash;
@@ -1028,7 +1028,7 @@ static uptrint_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
     jl_datatype_t *dt = (jl_datatype_t*)tv;
     if (dt == jl_datatype_type) {
         jl_datatype_t *dtv = (jl_datatype_t*)v;
-        uptrint_t h = 0xda1ada1a;
+        uintptr_t h = 0xda1ada1a;
         // has_typevars always returns 0 on name->primary, so that type
         // can exist in the cache. however, interpreter.c mutates its
         // typevars' `bound` fields to 0, corrupting the cache. this is
@@ -1039,9 +1039,9 @@ static uptrint_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
     }
     if (dt == jl_typename_type)
         return bitmix(((jl_typename_t*)v)->uid, 0xa1ada1ad);
-    if (dt->mutabl) return inthash((uptrint_t)v);
+    if (dt->mutabl) return inthash((uintptr_t)v);
     size_t sz = jl_datatype_size(tv);
-    uptrint_t h = jl_object_id(tv);
+    uintptr_t h = jl_object_id(tv);
     if (sz == 0) return ~h;
     size_t nf = jl_datatype_nfields(dt);
     if (nf == 0) {
@@ -1050,7 +1050,7 @@ static uptrint_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
     for (size_t f=0; f < nf; f++) {
         size_t offs = jl_field_offset(dt, f);
         char *vo = (char*)jl_data_ptr(v) + offs;
-        uptrint_t u;
+        uintptr_t u;
         if (jl_field_isptr(dt, f)) {
             jl_value_t *f = *(jl_value_t**)vo;
             u = f==NULL ? 0 : jl_object_id(f);
@@ -1068,7 +1068,7 @@ static uptrint_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
     return h;
 }
 
-JL_DLLEXPORT uptrint_t jl_object_id(jl_value_t *v)
+JL_DLLEXPORT uintptr_t jl_object_id(jl_value_t *v)
 {
     return jl_object_id_(jl_typeof(v), v);
 }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -5,9 +5,9 @@
 
 // keep track of llvmcall declarations
 #if defined(USE_MCJIT) || defined(USE_ORCJIT)
-static std::map<u_int64_t,llvm::GlobalValue*> llvmcallDecls;
+static std::map<uint64_t,llvm::GlobalValue*> llvmcallDecls;
 #else
-static std::set<u_int64_t> llvmcallDecls;
+static std::set<uint64_t> llvmcallDecls;
 #endif
 
 static std::map<std::string, GlobalVariable*> libMapGV;
@@ -634,7 +634,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         llvm::raw_string_ostream rtypename(rstring);
         rettype->print(rtypename);
 #if defined(USE_MCJIT) || defined(USE_ORCJIT)
-        std::map<u_int64_t,std::string> localDecls;
+        std::map<uint64_t,std::string> localDecls;
 #endif
 
         if (decl != NULL) {
@@ -643,7 +643,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             // parse string line by line
             std::string declstr;
             while (std::getline(declarations, declstr, '\n')) {
-                u_int64_t declhash = memhash(declstr.c_str(), declstr.length());
+                uint64_t declhash = memhash(declstr.c_str(), declstr.length());
 #if defined(USE_MCJIT) || defined(USE_ORCJIT)
                 auto it = llvmcallDecls.find(declhash);
                 if (it != llvmcallDecls.end()) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -460,7 +460,7 @@ public:
             std::map<Value*, void *>::iterator it;
             it = jl_llvm_to_jl_value.find(GV);
             if (it != jl_llvm_to_jl_value.end()) {
-                newGV->setInitializer(Constant::getIntegerValue(GV->getType()->getElementType(),APInt(sizeof(void*)*8,(ptrint_t)it->second)));
+                newGV->setInitializer(Constant::getIntegerValue(GV->getType()->getElementType(),APInt(sizeof(void*)*8,(intptr_t)it->second)));
                 newGV->setConstant(true);
             }
             else if (GV->hasInitializer()) {
@@ -1082,7 +1082,7 @@ static Value *emit_typeof(Value *tt)
     tt = builder.CreateLoad(emit_typeptr_addr(tt), false);
     tt = builder.CreateIntToPtr(builder.CreateAnd(
                 builder.CreatePtrToInt(tt, T_size),
-                ConstantInt::get(T_size,~(uptrint_t)15)),
+                ConstantInt::get(T_size,~(uintptr_t)15)),
             T_pjlvalue);
     return tt;
 }

--- a/src/flisp/builtins.c
+++ b/src/flisp/builtins.c
@@ -33,7 +33,7 @@ size_t llength(value_t v)
     return n;
 }
 
-static value_t fl_nconc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_nconc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs == 0)
         return fl_ctx->NIL;
@@ -59,7 +59,7 @@ static value_t fl_nconc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return first;
 }
 
-static value_t fl_assq(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_assq(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "assq", nargs, 2);
     value_t item = args[0];
@@ -75,7 +75,7 @@ static value_t fl_assq(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->F;
 }
 
-static value_t fl_memq(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_memq(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "memq", nargs, 2);
     while (iscons(args[1])) {
@@ -87,7 +87,7 @@ static value_t fl_memq(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->F;
 }
 
-static value_t fl_length(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_length(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "length", nargs, 1);
     value_t a = args[0];
@@ -116,13 +116,13 @@ static value_t fl_length(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     type_error(fl_ctx, "length", "sequence", a);
 }
 
-static value_t fl_f_raise(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_f_raise(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "raise", nargs, 1);
     fl_raise(fl_ctx, args[0]);
 }
 
-static value_t fl_exit(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_exit(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs > 0)
         exit(tofixnum(fl_ctx, args[0], "exit"));
@@ -130,7 +130,7 @@ static value_t fl_exit(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->NIL;
 }
 
-static value_t fl_symbol(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_symbol(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "symbol", nargs, 1);
     if (!fl_isstring(fl_ctx, args[0]))
@@ -138,14 +138,14 @@ static value_t fl_symbol(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return symbol(fl_ctx, (char*)cvalue_data(args[0]));
 }
 
-static value_t fl_keywordp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_keywordp(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "keyword?", nargs, 1);
     return (issymbol(args[0]) &&
             iskeyword((symbol_t*)ptr(args[0]))) ? fl_ctx->T : fl_ctx->F;
 }
 
-static value_t fl_top_level_value(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_top_level_value(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "top-level-value", nargs, 1);
     symbol_t *sym = tosymbol(fl_ctx, args[0], "top-level-value");
@@ -154,7 +154,7 @@ static value_t fl_top_level_value(fl_context_t *fl_ctx, value_t *args, u_int32_t
     return sym->binding;
 }
 
-static value_t fl_set_top_level_value(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_set_top_level_value(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "set-top-level-value!", nargs, 2);
     symbol_t *sym = tosymbol(fl_ctx, args[0], "set-top-level-value!");
@@ -174,7 +174,7 @@ static void global_env_list(fl_context_t *fl_ctx, symbol_t *root, value_t *pv)
     }
 }
 
-value_t fl_global_env(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_global_env(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     (void)args;
     argcount(fl_ctx, "environment", nargs, 0);
@@ -185,7 +185,7 @@ value_t fl_global_env(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return lst;
 }
 
-static value_t fl_constantp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_constantp(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "constant?", nargs, 1);
     if (issymbol(args[0]))
@@ -198,7 +198,7 @@ static value_t fl_constantp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs
     return fl_ctx->T;
 }
 
-static value_t fl_integer_valuedp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_integer_valuedp(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "integer-valued?", nargs, 1);
     value_t v = args[0];
@@ -227,7 +227,7 @@ static value_t fl_integer_valuedp(fl_context_t *fl_ctx, value_t *args, u_int32_t
     return fl_ctx->F;
 }
 
-static value_t fl_integerp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_integerp(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "integer?", nargs, 1);
     value_t v = args[0];
@@ -236,7 +236,7 @@ static value_t fl_integerp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
         fl_ctx->T : fl_ctx->F;
 }
 
-static value_t fl_fixnum(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_fixnum(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "fixnum", nargs, 1);
     if (isfixnum(args[0])) {
@@ -249,7 +249,7 @@ static value_t fl_fixnum(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     type_error(fl_ctx, "fixnum", "number", args[0]);
 }
 
-static value_t fl_truncate(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_truncate(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "truncate", nargs, 1);
     if (isfixnum(args[0]))
@@ -277,7 +277,7 @@ static value_t fl_truncate(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     type_error(fl_ctx, "truncate", "number", args[0]);
 }
 
-static value_t fl_vector_alloc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_vector_alloc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     fixnum_t i;
     value_t f, v;
@@ -299,7 +299,7 @@ static value_t fl_vector_alloc(fl_context_t *fl_ctx, value_t *args, u_int32_t na
     return v;
 }
 
-static value_t fl_time_now(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+static value_t fl_time_now(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "time.now", nargs, 0);
     (void)args;

--- a/src/flisp/equal.c
+++ b/src/flisp/equal.c
@@ -286,7 +286,7 @@ value_t fl_equal(fl_context_t *fl_ctx, value_t a, value_t b)
 #endif
 
 // *oob: output argument, means we hit the limit specified by 'bound'
-static uptrint_t bounded_hash(fl_context_t *fl_ctx, value_t a, int bound, int *oob)
+static uintptr_t bounded_hash(fl_context_t *fl_ctx, value_t a, int bound, int *oob)
 {
     *oob = 0;
     union {
@@ -298,7 +298,7 @@ static uptrint_t bounded_hash(fl_context_t *fl_ctx, value_t a, int bound, int *o
     cvalue_t *cv;
     cprim_t *cp;
     void *data;
-    uptrint_t h = 0;
+    uintptr_t h = 0;
     int oob2, tg = tag(a);
     switch(tg) {
     case TAG_NUM :
@@ -370,14 +370,14 @@ int equal_lispvalue(fl_context_t *fl_ctx, value_t a, value_t b)
     return (numval(compare_(fl_ctx, a, b, 1))==0);
 }
 
-uptrint_t hash_lispvalue(fl_context_t *fl_ctx, value_t a)
+uintptr_t hash_lispvalue(fl_context_t *fl_ctx, value_t a)
 {
     int oob = 0;
-    uptrint_t n = bounded_hash(fl_ctx, a, BOUNDED_HASH_BOUND, &oob);
+    uintptr_t n = bounded_hash(fl_ctx, a, BOUNDED_HASH_BOUND, &oob);
     return n;
 }
 
-value_t fl_hash(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_hash(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "hash", nargs, 1);
     return fixnum(hash_lispvalue(fl_ctx, args[0]));

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -11,7 +11,7 @@
 //#define MEMDEBUG
 //#define MEMDEBUG2
 
-typedef uptrint_t value_t;
+typedef uintptr_t value_t;
 typedef int_t fixnum_t;
 #if NBITS==64
 #define T_FIXNUM T_INT64
@@ -30,7 +30,7 @@ typedef struct {
 } cons_t;
 
 typedef struct _symbol_t {
-    uptrint_t flags;
+    uintptr_t flags;
     value_t binding;   // global value binding
     struct _fltype_t *type;
     uint32_t hash;
@@ -61,7 +61,7 @@ typedef struct {
 #define tag(x) ((x)&0x7)
 #define ptr(x) ((void*)((x)&(~(value_t)0x7)))
 #define tagptr(p,t) (((value_t)(p)) | (t))
-#define fixnum(x) ((value_t)(((uptrint_t)(x))<<2))
+#define fixnum(x) ((value_t)(((uintptr_t)(x))<<2))
 #define numval(x)  (((fixnum_t)(x))>>2)
 #if NBITS==64
 #define fits_fixnum(x) (((x)>>61) == 0 || (~((x)>>61)) == 0)
@@ -157,7 +157,7 @@ size_t llength(value_t v);
 value_t fl_compare(fl_context_t *fl_ctx, value_t a, value_t b);  // -1, 0, or 1
 value_t fl_equal(fl_context_t *fl_ctx, value_t a, value_t b);    // T or nil
 int equal_lispvalue(fl_context_t *fl_ctx, value_t a, value_t b);
-uptrint_t hash_lispvalue(fl_context_t *fl_ctx, value_t a);
+uintptr_t hash_lispvalue(fl_context_t *fl_ctx, value_t a);
 int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base);
 
 /* safe casts */
@@ -260,10 +260,10 @@ typedef struct {
 
 #define CV_OWNED_BIT  0x1
 #define CV_PARENT_BIT 0x2
-#define owned(cv)      ((uptrint_t)(cv)->type & CV_OWNED_BIT)
-#define hasparent(cv)  ((uptrint_t)(cv)->type & CV_PARENT_BIT)
+#define owned(cv)      ((uintptr_t)(cv)->type & CV_OWNED_BIT)
+#define hasparent(cv)  ((uintptr_t)(cv)->type & CV_PARENT_BIT)
 #define isinlined(cv)  ((cv)->data == &(cv)->_space[0])
-#define cv_class(cv)   ((fltype_t*)(((uptrint_t)(cv)->type)&~3))
+#define cv_class(cv)   ((fltype_t*)(((uintptr_t)(cv)->type)&~3))
 #define cv_len(cv)     ((cv)->len)
 #define cv_type(cv)    (cv_class(cv)->type)
 #define cv_data(cv)    ((cv)->data)
@@ -350,7 +350,7 @@ typedef struct {
 void assign_global_builtins(fl_context_t *fl_ctx, const builtinspec_t *b);
 
 /* builtins */
-value_t fl_hash(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+value_t fl_hash(fl_context_t *fl_ctx, value_t *args, uint32_t nargs);
 value_t cvalue_byte(fl_context_t *fl_ctx, value_t *args, uint32_t nargs);
 value_t cvalue_wchar(fl_context_t *fl_ctx, value_t *args, uint32_t nargs);
 
@@ -394,12 +394,12 @@ struct _fl_context_t {
     fltype_t *tabletype;
     cvtable_t table_vtable;
 
-    u_int32_t readtoktype;
+    uint32_t readtoktype;
     value_t readtokval;
     char readbuf[256];
 
     htable_t printconses;
-    u_int32_t printlabel;
+    uint32_t printlabel;
     int print_pretty;
     int print_princ;
     fixnum_t print_length;

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -95,7 +95,7 @@ value_t fl_file(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     return f;
 }
 
-value_t fl_buffer(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_buffer(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "buffer", nargs, 0);
     (void)args;
@@ -106,7 +106,7 @@ value_t fl_buffer(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return f;
 }
 
-value_t fl_read(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_read(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     value_t arg = 0;
     if (nargs > 1) {
@@ -127,7 +127,7 @@ value_t fl_read(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return v;
 }
 
-value_t fl_iogetc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iogetc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.getc", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "io.getc");
@@ -138,7 +138,7 @@ value_t fl_iogetc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return mk_wchar(fl_ctx, wc);
 }
 
-value_t fl_iopeekc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iopeekc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.peekc", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "io.peekc");
@@ -148,7 +148,7 @@ value_t fl_iopeekc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return mk_wchar(fl_ctx, wc);
 }
 
-value_t fl_ioputc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioputc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.putc", nargs, 2);
     ios_t *s = toiostream(fl_ctx, args[0], "io.putc");
@@ -158,7 +158,7 @@ value_t fl_ioputc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fixnum(ios_pututf8(s, wc));
 }
 
-value_t fl_ioungetc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioungetc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.ungetc", nargs, 2);
     ios_t *s = toiostream(fl_ctx, args[0], "io.ungetc");
@@ -171,7 +171,7 @@ value_t fl_ioungetc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fixnum(ios_ungetc((int)wc,s));
 }
 
-value_t fl_ioflush(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioflush(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.flush", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "io.flush");
@@ -180,7 +180,7 @@ value_t fl_ioflush(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->T;
 }
 
-value_t fl_ioclose(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioclose(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.close", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "io.close");
@@ -188,7 +188,7 @@ value_t fl_ioclose(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->T;
 }
 
-value_t fl_iopurge(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iopurge(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.discardbuffer", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "io.discardbuffer");
@@ -196,21 +196,21 @@ value_t fl_iopurge(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->T;
 }
 
-value_t fl_ioeof(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioeof(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.eof?", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "io.eof?");
     return (ios_eof(s) ? fl_ctx->T : fl_ctx->F);
 }
 
-value_t fl_iolineno(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iolineno(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "input-port-line", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "input-port-line");
     return size_wrap(fl_ctx, s->lineno);
 }
 
-value_t fl_ioseek(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioseek(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.seek", nargs, 2);
     ios_t *s = toiostream(fl_ctx, args[0], "io.seek");
@@ -221,7 +221,7 @@ value_t fl_ioseek(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->T;
 }
 
-value_t fl_iopos(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iopos(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.pos", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "io.pos");
@@ -231,7 +231,7 @@ value_t fl_iopos(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return size_wrap(fl_ctx, (size_t)res);
 }
 
-value_t fl_write(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_write(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 1 || nargs > 2)
         argcount(fl_ctx, "write", nargs, 1);
@@ -244,7 +244,7 @@ value_t fl_write(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return args[0];
 }
 
-value_t fl_ioread(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioread(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs != 3)
         argcount(fl_ctx, "io.read", nargs, 2);
@@ -288,7 +288,7 @@ static void get_start_count_args(fl_context_t *fl_ctx, value_t *args, uint32_t n
     }
 }
 
-value_t fl_iowrite(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iowrite(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 2 || nargs > 4)
         argcount(fl_ctx, "io.write", nargs, 2);
@@ -323,7 +323,7 @@ static char get_delim_arg(fl_context_t *fl_ctx, value_t arg, char *fname)
     return (char)uldelim;
 }
 
-value_t fl_ioreaduntil(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_ioreaduntil(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.readuntil", nargs, 2);
     value_t str = cvalue_string(fl_ctx, 80);
@@ -347,7 +347,7 @@ value_t fl_ioreaduntil(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return str;
 }
 
-value_t fl_iocopyuntil(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iocopyuntil(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.copyuntil", nargs, 3);
     ios_t *dest = toiostream(fl_ctx, args[0], "io.copyuntil");
@@ -356,7 +356,7 @@ value_t fl_iocopyuntil(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return size_wrap(fl_ctx, ios_copyuntil(dest, src, delim));
 }
 
-value_t fl_iocopy(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iocopy(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 2 || nargs > 3)
         argcount(fl_ctx, "io.copy", nargs, 2);
@@ -390,7 +390,7 @@ value_t stream_to_string(fl_context_t *fl_ctx, value_t *ps)
     return str;
 }
 
-value_t fl_iotostring(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iotostring(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "io.tostring!", nargs, 1);
     ios_t *src = toiostream(fl_ctx, args[0], "io.tostring!");

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -26,7 +26,7 @@ static int is_bom(uint32_t wc)
     return wc == 0xFEFF;
 }
 
-value_t fl_skipws(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_skipws(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "skip-ws", nargs, 2);
     ios_t *s = fl_toiostream(fl_ctx, args[0], "skip-ws");
@@ -136,7 +136,7 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
     return 0;
 }
 
-value_t fl_julia_identifier_char(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_julia_identifier_char(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "identifier-char?", nargs, 1);
     if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != fl_ctx->wchartype)
@@ -145,7 +145,7 @@ value_t fl_julia_identifier_char(fl_context_t *fl_ctx, value_t *args, u_int32_t 
     return jl_id_char(wc) ? fl_ctx->T : fl_ctx->F;
 }
 
-value_t fl_julia_identifier_start_char(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_julia_identifier_start_char(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "identifier-start-char?", nargs, 1);
     if (!iscprim(args[0]) || ((cprim_t*)ptr(args[0]))->type != fl_ctx->wchartype)
@@ -179,7 +179,7 @@ error:
             utf8proc_errmsg(result));
 }
 
-value_t fl_accum_julia_symbol(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_accum_julia_symbol(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "accum-julia-symbol", nargs, 2);
     ios_t *s = fl_toiostream(fl_ctx, args[1], "accum-julia-symbol");

--- a/src/flisp/read.c
+++ b/src/flisp/read.c
@@ -200,7 +200,7 @@ static int read_token(fl_context_t *fl_ctx, char c, int digits)
 
 static value_t do_read_sexpr(fl_context_t *fl_ctx, value_t label);
 
-static u_int32_t peek(fl_context_t *fl_ctx)
+static uint32_t peek(fl_context_t *fl_ctx)
 {
     char c, *end;
     fixnum_t x;
@@ -423,10 +423,10 @@ static value_t vector_grow(fl_context_t *fl_ctx, value_t v, int rewrite_refs)
     return POP(fl_ctx);
 }
 
-static value_t read_vector(fl_context_t *fl_ctx, value_t label, u_int32_t closer)
+static value_t read_vector(fl_context_t *fl_ctx, value_t label, uint32_t closer)
 {
     value_t v=fl_ctx->the_empty_vector, elt;
-    u_int32_t i=0;
+    uint32_t i=0;
     PUSH(fl_ctx, v);
     if (label != UNBOUND)
         ptrhash_put(&fl_ctx->readstate->backrefs, (void*)label, (void*)v);
@@ -457,7 +457,7 @@ static value_t read_string(fl_context_t *fl_ctx)
     size_t i=0, j, sz = 64, ndig;
     int c;
     value_t s;
-    u_int32_t wc=0;
+    uint32_t wc=0;
 
     buf = (char*)malloc(sz);
     while (1) {
@@ -535,7 +535,7 @@ static value_t read_string(fl_context_t *fl_ctx)
 static void read_list(fl_context_t *fl_ctx, value_t *pval, value_t label)
 {
     value_t c, *pc;
-    u_int32_t t;
+    uint32_t t;
 
     PUSH(fl_ctx, fl_ctx->NIL);
     pc = &fl_ctx->Stack[fl_ctx->SP-1];  // to keep track of current cons cell
@@ -577,7 +577,7 @@ static value_t do_read_sexpr(fl_context_t *fl_ctx, value_t label)
 {
     value_t v, sym, oldtokval, *head;
     value_t *pv;
-    u_int32_t t;
+    uint32_t t;
     char c;
 
     t = peek(fl_ctx);

--- a/src/flisp/string.c
+++ b/src/flisp/string.c
@@ -26,13 +26,13 @@
 extern "C" {
 #endif
 
-value_t fl_stringp(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_stringp(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "string?", nargs, 1);
     return fl_isstring(fl_ctx, args[0]) ? fl_ctx->T : fl_ctx->F;
 }
 
-value_t fl_string_count(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string_count(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     size_t start = 0;
     if (nargs < 1 || nargs > 3)
@@ -57,10 +57,10 @@ value_t fl_string_count(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return size_wrap(fl_ctx, u8_charnum(str+start, stop-start));
 }
 
-extern value_t fl_buffer(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs);
+extern value_t fl_buffer(fl_context_t *fl_ctx, value_t *args, uint32_t nargs);
 extern value_t stream_to_string(fl_context_t *fl_ctx, value_t *ps);
 
-value_t fl_string(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs == 1 && fl_isstring(fl_ctx, args[0]))
         return args[0];
@@ -82,7 +82,7 @@ value_t fl_string(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return outp;
 }
 
-value_t fl_string_sub(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string_sub(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs != 2)
         argcount(fl_ctx, "string.sub", nargs, 3);
@@ -108,7 +108,7 @@ value_t fl_string_sub(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return ns;
 }
 
-value_t fl_string_char(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string_char(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "string.char", nargs, 2);
     char *s = tostring(fl_ctx, args[0], "string.char");
@@ -130,7 +130,7 @@ static value_t mem_find_byte(fl_context_t *fl_ctx, char *s, char c, size_t start
     return size_wrap(fl_ctx, (size_t)(p - s));
 }
 
-value_t fl_string_find(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string_find(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     char cbuf[8];
     size_t start = 0;
@@ -180,7 +180,7 @@ value_t fl_string_find(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return fl_ctx->F;
 }
 
-value_t fl_string_inc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string_inc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 2 || nargs > 3)
         argcount(fl_ctx, "string.inc", nargs, 2);
@@ -198,7 +198,7 @@ value_t fl_string_inc(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
     return size_wrap(fl_ctx, i);
 }
 
-value_t fl_string_dec(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string_dec(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 2 || nargs > 3)
         argcount(fl_ctx, "string.dec", nargs, 2);
@@ -227,7 +227,7 @@ static unsigned long get_radix_arg(fl_context_t *fl_ctx, value_t arg, char *fnam
     return radix;
 }
 
-value_t fl_numbertostring(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_numbertostring(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 1 || nargs > 2)
         argcount(fl_ctx, "number->string", nargs, 2);
@@ -266,7 +266,7 @@ value_t fl_stringtonumber(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     return n;
 }
 
-value_t fl_string_isutf8(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_string_isutf8(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "string.isutf8", nargs, 1);
     char *s = tostring(fl_ctx, args[0], "string.isutf8");

--- a/src/gc.c
+++ b/src/gc.c
@@ -109,7 +109,7 @@ typedef struct _buff_t {
     union {
         uintptr_t header;
         struct _buff_t *next;
-        uptrint_t flags;
+        uintptr_t flags;
         jl_value_t *type; // 16-bytes aligned
         struct {
             uintptr_t gc_bits:2;
@@ -133,13 +133,13 @@ typedef struct _bigval_t {
     struct _bigval_t **prev; // pointer to the next field of the prev entry
     union {
         size_t sz;
-        uptrint_t age : 2;
+        uintptr_t age : 2;
     };
     //struct buff_t <>;
     union {
-        uptrint_t header;
-        uptrint_t flags;
-        uptrint_t gc_bits:2;
+        uintptr_t header;
+        uintptr_t flags;
+        uintptr_t gc_bits:2;
     };
     // Work around a bug affecting gcc up to (at least) version 4.4.7
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36839
@@ -721,12 +721,12 @@ static inline void objprofile_count(void *ty, int old, int sz)
     if (*bp == HT_NOTFOUND)
         *bp = (void*)2;
     else
-        (*((ptrint_t*)bp))++;
+        (*((intptr_t*)bp))++;
     bp = ptrhash_bp(&obj_sizes[old], ty);
     if (*bp == HT_NOTFOUND)
         *bp = (void*)(1 + sz);
     else
-        *((ptrint_t*)bp) += sz;
+        *((intptr_t*)bp) += sz;
 #endif
 }
 
@@ -1718,7 +1718,7 @@ NOINLINE static int gc_mark_module(jl_module_t *m, int d)
     return refyoung;
 }
 
-static void gc_mark_stack(jl_value_t *ta, jl_gcframe_t *s, ptrint_t offset, int d)
+static void gc_mark_stack(jl_value_t *ta, jl_gcframe_t *s, intptr_t offset, int d)
 {
     while (s != NULL) {
         s = (jl_gcframe_t*)((char*)s + offset);
@@ -1758,7 +1758,7 @@ static void gc_mark_task_stack(jl_task_t *ta, int d)
         gc_mark_stack((jl_value_t*)ta, ptls->pgcstack, 0, d);
     }
     else if (stkbuf) {
-        ptrint_t offset;
+        intptr_t offset;
 #ifdef COPY_STACKS
         offset = (char *)ta->stkbuf - ((char *)ptls->stackbase - ta->ssize);
 #else

--- a/src/gf.c
+++ b/src/gf.c
@@ -115,7 +115,7 @@ static inline int cache_match(jl_value_t **args, size_t n, jl_value_t **sig,
 static inline
 jl_methlist_t *mtcache_hash_lookup(jl_array_t *a, jl_value_t *ty, int8_t tparam, int8_t offs)
 {
-    uptrint_t uid = ((jl_datatype_t*)ty)->uid;
+    uintptr_t uid = ((jl_datatype_t*)ty)->uid;
     jl_methlist_t *ml = (jl_methlist_t*)jl_cellref(a, uid & (a->nrows-1));
     if (ml && ml!=(void*)jl_nothing) {
         jl_value_t *t = jl_field_type(ml->sig, offs);
@@ -139,7 +139,7 @@ static void mtcache_rehash(jl_array_t **pa, jl_value_t *parent, int8_t offs)
             jl_value_t *t = jl_field_type(ml->sig, offs);
             if (jl_is_type_type(t))
                 t = jl_tparam0(t);
-            uptrint_t uid = ((jl_datatype_t*)t)->uid;
+            uintptr_t uid = ((jl_datatype_t*)t)->uid;
             nd[uid & (len*2-1)] = (jl_value_t*)ml;
         }
     }
@@ -150,7 +150,7 @@ static void mtcache_rehash(jl_array_t **pa, jl_value_t *parent, int8_t offs)
 static jl_methlist_t **mtcache_hash_bp(jl_array_t **pa, jl_value_t *ty,
                                        int8_t tparam, int8_t offs, jl_value_t *parent)
 {
-    uptrint_t uid;
+    uintptr_t uid;
     if (jl_is_datatype(ty) && (uid = ((jl_datatype_t*)ty)->uid)) {
         while (1) {
             jl_methlist_t **pml = &((jl_methlist_t**)jl_array_data(*pa))[uid & ((*pa)->nrows-1)];
@@ -370,7 +370,7 @@ jl_lambda_info_t *jl_method_cache_insert(jl_methtable_t *mt, jl_tupletype_t *typ
     jl_value_t *cache_array = NULL;
     if (jl_datatype_nfields(type) > offs) {
         jl_value_t *t1 = jl_tparam(type, offs);
-        uptrint_t uid=0;
+        uintptr_t uid=0;
         // if t1 != jl_typetype_type and the argument is Type{...}, this
         // method has specializations for singleton kinds and we use
         // the table indexed for that purpose.

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1864,8 +1864,8 @@ static int typekey_compare(jl_datatype_t *tt, jl_value_t **key, size_t n)
             int dtk = jl_is_datatype(kj);
             if (!dtt && !dtk && jl_egal(tj, kj))
                 continue;
-            uptrint_t tid = (dtt && ((jl_datatype_t*)tj)->uid ? ((jl_datatype_t*)tj)->uid : jl_object_id(tj));
-            uptrint_t kid = (dtk && ((jl_datatype_t*)kj)->uid ? ((jl_datatype_t*)kj)->uid : jl_object_id(kj));
+            uintptr_t tid = (dtt && ((jl_datatype_t*)tj)->uid ? ((jl_datatype_t*)tj)->uid : jl_object_id(tj));
+            uintptr_t kid = (dtk && ((jl_datatype_t*)kj)->uid ? ((jl_datatype_t*)kj)->uid : jl_object_id(kj));
             if (kid != tid)
                 return kid < tid ? -1 : 1;
         }

--- a/src/julia.h
+++ b/src/julia.h
@@ -215,7 +215,7 @@ typedef struct _jl_sym_t {
     JL_DATA_TYPE
     struct _jl_sym_t *left;
     struct _jl_sym_t *right;
-    uptrint_t hash;    // precomputed hash value
+    uintptr_t hash;    // precomputed hash value
     // JL_ATTRIBUTE_ALIGN_PTRSIZE(char name[]);
 } jl_sym_t;
 
@@ -351,7 +351,7 @@ typedef struct {
     jl_value_t *primary;
     jl_svec_t *cache;        // sorted array
     jl_svec_t *linearcache;  // unsorted array
-    ptrint_t uid;
+    intptr_t uid;
     struct _jl_methtable_t *mt;
 } jl_typename_t;
 
@@ -466,7 +466,7 @@ typedef struct _jl_methtable_t {
     jl_methlist_t *cache;
     jl_array_t *cache_arg1;
     jl_array_t *cache_targ;
-    ptrint_t max_args;  // max # of non-vararg arguments in a signature
+    intptr_t max_args;  // max # of non-vararg arguments in a signature
     jl_value_t *kwsorter;  // keyword argument sorter function
     jl_module_t *module; // used for incremental serialization to locate original binding
 #ifdef JL_GF_PROFILE
@@ -767,9 +767,9 @@ STATIC_INLINE jl_value_t *jl_cellset(void *a, size_t i, void *x)
 #define jl_symbolnode_sym(s) (*(jl_sym_t**)s)
 #define jl_symbolnode_type(s) (((jl_value_t**)s)[1])
 #define jl_linenode_file(x) (*(jl_sym_t**)x)
-#define jl_linenode_line(x) (((ptrint_t*)x)[1])
-#define jl_labelnode_label(x) (((ptrint_t*)x)[0])
-#define jl_gotonode_label(x) (((ptrint_t*)x)[0])
+#define jl_linenode_line(x) (((intptr_t*)x)[1])
+#define jl_labelnode_label(x) (((intptr_t*)x)[0])
+#define jl_gotonode_label(x) (((intptr_t*)x)[0])
 #define jl_globalref_mod(s) (*(jl_module_t**)s)
 #define jl_globalref_name(s) (((jl_sym_t**)s)[1])
 
@@ -1002,7 +1002,7 @@ STATIC_INLINE int jl_is_type_type(jl_value_t *v)
 
 // object identity
 JL_DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b);
-JL_DLLEXPORT uptrint_t jl_object_id(jl_value_t *v);
+JL_DLLEXPORT uintptr_t jl_object_id(jl_value_t *v);
 
 // type predicates and basic operations
 JL_DLLEXPORT int jl_is_leaf_type(jl_value_t *v);
@@ -1481,7 +1481,7 @@ typedef struct _jl_tls_states_t {
     int8_t in_jl_;
     int16_t tid;
     size_t bt_size;
-    ptrint_t bt_data[JL_MAX_BT_SIZE + 1];
+    intptr_t bt_data[JL_MAX_BT_SIZE + 1];
 } jl_tls_states_t;
 
 typedef struct {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -280,17 +280,17 @@ typedef unw_context_t *bt_context_t;
 #endif
 #define jl_bt_data (jl_get_ptls_states()->bt_data)
 #define jl_bt_size (jl_get_ptls_states()->bt_size)
-JL_DLLEXPORT size_t rec_backtrace(ptrint_t *data, size_t maxsize);
-JL_DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, bt_context_t ctx);
+JL_DLLEXPORT size_t rec_backtrace(intptr_t *data, size_t maxsize);
+JL_DLLEXPORT size_t rec_backtrace_ctx(intptr_t *data, size_t maxsize, bt_context_t ctx);
 #ifdef LIBOSXUNWIND
-size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, bt_context_t ctx);
+size_t rec_backtrace_ctx_dwarf(intptr_t *data, size_t maxsize, bt_context_t ctx);
 #endif
 JL_DLLEXPORT void jl_raise_debugger(void);
 // Set *name and *filename to either NULL or malloc'd string
 void jl_getFunctionInfo(char **name, char **filename, size_t *line,
                         char **inlinedat_file, size_t *inlinedat_line,
                         uintptr_t pointer, int *fromC, int skipC, int skipInline);
-JL_DLLEXPORT void jl_gdblookup(ptrint_t ip);
+JL_DLLEXPORT void jl_gdblookup(intptr_t ip);
 
 // *to is NULL or malloc'd pointer, from is allowed to be NULL
 static inline char *jl_copy_str(char **to, const char *from)

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -13,12 +13,12 @@ extern "C" {
 #include <threading.h>
 
 // Profiler control variables //
-static volatile ptrint_t *bt_data_prof = NULL;
+static volatile intptr_t *bt_data_prof = NULL;
 static volatile size_t bt_size_max = 0;
 static volatile size_t bt_size_cur = 0;
-static volatile u_int64_t nsecprof = 0;
+static volatile uint64_t nsecprof = 0;
 static volatile int running = 0;
-static const    u_int64_t GIGA = 1000000000ULL;
+static const    uint64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
@@ -36,7 +36,7 @@ JL_DLLEXPORT void jl_sigint_action(void)
     jl_throw(jl_interrupt_exception);
 }
 
-static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, size_t *bt_size);
+static void jl_critical_error(int sig, bt_context_t context, intptr_t *bt_data, size_t *bt_size);
 
 #if defined(_WIN32)
 #include "signals-win.c"
@@ -45,7 +45,7 @@ static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, 
 #endif
 
 // what to do on a critical error
-static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, size_t *bt_size)
+static void jl_critical_error(int sig, bt_context_t context, intptr_t *bt_data, size_t *bt_size)
 {
     // This function is not allowed to reference any TLS variables.
     // We need to explicitly pass in the TLS buffer pointer when
@@ -64,22 +64,22 @@ static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, 
 ///////////////////////
 // Utility functions //
 ///////////////////////
-JL_DLLEXPORT int jl_profile_init(size_t maxsize, u_int64_t delay_nsec)
+JL_DLLEXPORT int jl_profile_init(size_t maxsize, uint64_t delay_nsec)
 {
     bt_size_max = maxsize;
     nsecprof = delay_nsec;
     if (bt_data_prof != NULL)
         free((void*)bt_data_prof);
-    bt_data_prof = (ptrint_t*) calloc(maxsize, sizeof(ptrint_t));
+    bt_data_prof = (intptr_t*) calloc(maxsize, sizeof(intptr_t));
     if (bt_data_prof == NULL && maxsize > 0)
         return -1;
     bt_size_cur = 0;
     return 0;
 }
 
-JL_DLLEXPORT u_int8_t *jl_profile_get_data(void)
+JL_DLLEXPORT uint8_t *jl_profile_get_data(void)
 {
-    return (u_int8_t*) bt_data_prof;
+    return (uint8_t*) bt_data_prof;
 }
 
 JL_DLLEXPORT size_t jl_profile_len_data(void)
@@ -92,7 +92,7 @@ JL_DLLEXPORT size_t jl_profile_maxlen_data(void)
     return bt_size_max;
 }
 
-JL_DLLEXPORT u_int64_t jl_profile_delay_nsec(void)
+JL_DLLEXPORT uint64_t jl_profile_delay_nsec(void)
 {
     return nsecprof;
 }

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -372,10 +372,10 @@ void *mach_profile_listener(void *arg)
 
             if (forceDwarf == 0) {
                 // Save the backtrace
-                bt_size_cur += rec_backtrace_ctx((ptrint_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc);
+                bt_size_cur += rec_backtrace_ctx((intptr_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc);
             }
             else if (forceDwarf == 1) {
-                bt_size_cur += rec_backtrace_ctx_dwarf((ptrint_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc);
+                bt_size_cur += rec_backtrace_ctx_dwarf((intptr_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc);
             }
             else if (forceDwarf == -1) {
                 jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
@@ -383,7 +383,7 @@ void *mach_profile_listener(void *arg)
 
             forceDwarf = -2;
 #else
-            bt_size_cur += rec_backtrace_ctx((ptrint_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc);
+            bt_size_cur += rec_backtrace_ctx((intptr_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc);
 #endif
 
             // Mark the end of this block with 0

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -431,7 +431,7 @@ static void *signal_listener(void *arg)
             if (profile && running) {
                 if (bt_size_cur < bt_size_max - 1) {
                     // Get backtrace data
-                    bt_size_cur += rec_backtrace_ctx((ptrint_t*)bt_data_prof + bt_size_cur,
+                    bt_size_cur += rec_backtrace_ctx((intptr_t*)bt_data_prof + bt_size_cur,
                             bt_size_max - bt_size_cur - 1, signal_context);
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++] = 0;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -225,7 +225,7 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
                 jl_safe_printf("UNKNOWN"); break;
         }
         jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-        jl_gdblookup((ptrint_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+        jl_gdblookup((intptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
         jl_critical_error(0, ExceptionInfo->ContextRecord, jl_bt_data, &jl_bt_size);
         static int recursion = 0;
@@ -299,7 +299,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                 break;
             }
             // Get backtrace data
-            bt_size_cur += rec_backtrace_ctx((ptrint_t*)bt_data_prof+bt_size_cur, bt_size_max-bt_size_cur-1, &ctxThread);
+            bt_size_cur += rec_backtrace_ctx((intptr_t*)bt_data_prof+bt_size_cur, bt_size_max-bt_size_cur-1, &ctxThread);
             // Mark the end of this block with 0
             bt_data_prof[bt_size_cur] = 0;
             bt_size_cur++;

--- a/src/support/bitvector.c
+++ b/src/support/bitvector.c
@@ -19,12 +19,12 @@
 extern "C" {
 #endif
 
-u_int32_t *bitvector_resize(u_int32_t *b, uint64_t oldsz, uint64_t newsz,
+uint32_t *bitvector_resize(uint32_t *b, uint64_t oldsz, uint64_t newsz,
                             int initzero)
 {
-    u_int32_t *p;
+    uint32_t *p;
     size_t sz = ((newsz+31)>>5) * sizeof(uint32_t);
-    p = (u_int32_t*)LLT_REALLOC(b, sz);
+    p = (uint32_t*)LLT_REALLOC(b, sz);
     if (p == NULL) return NULL;
     if (initzero && newsz>oldsz) {
         size_t osz = ((oldsz+31)>>5) * sizeof(uint32_t);
@@ -33,17 +33,17 @@ u_int32_t *bitvector_resize(u_int32_t *b, uint64_t oldsz, uint64_t newsz,
     return p;
 }
 
-u_int32_t *bitvector_new(u_int64_t n, int initzero)
+uint32_t *bitvector_new(uint64_t n, int initzero)
 {
     return bitvector_resize(NULL, 0, n, initzero);
 }
 
-size_t bitvector_nwords(u_int64_t nbits)
+size_t bitvector_nwords(uint64_t nbits)
 {
     return ((nbits+31)>>5);
 }
 
-void bitvector_set(u_int32_t *b, u_int64_t n, u_int32_t c)
+void bitvector_set(uint32_t *b, uint64_t n, uint32_t c)
 {
     if (c)
         b[n>>5] |= (1<<(n&31));
@@ -51,19 +51,19 @@ void bitvector_set(u_int32_t *b, u_int64_t n, u_int32_t c)
         b[n>>5] &= ~(1<<(n&31));
 }
 
-u_int32_t bitvector_get(u_int32_t *b, u_int64_t n)
+uint32_t bitvector_get(uint32_t *b, uint64_t n)
 {
     return b[n>>5] & (1<<(n&31));
 }
 
 // a mask with n set lo or hi bits
-#define lomask(n) (u_int32_t)((((u_int32_t)1)<<(n))-1)
-#define ONES32 ((u_int32_t)0xffffffff)
+#define lomask(n) (uint32_t)((((uint32_t)1)<<(n))-1)
+#define ONES32 ((uint32_t)0xffffffff)
 
 #if defined(__INTEL_COMPILER) && !defined(__clang__)
 #define count_bits(b) _popcnt32(b)
 #else
-STATIC_INLINE u_int32_t count_bits(u_int32_t b)
+STATIC_INLINE uint32_t count_bits(uint32_t b)
 {
     b = b - ((b>>1)&0x55555555);
     b = ((b>>2)&0x33333333) + (b&0x33333333);
@@ -134,11 +134,11 @@ uint64_t bitvector_next(uint32_t *b, uint64_t n0, uint64_t n)
     return i + (n-nb);
 }
 
-u_int64_t bitvector_count(u_int32_t *b, u_int64_t offs, u_int64_t nbits)
+uint64_t bitvector_count(uint32_t *b, uint64_t offs, uint64_t nbits)
 {
     size_t i, nw;
-    u_int32_t ntail;
-    u_int64_t ans;
+    uint32_t ntail;
+    uint64_t ans;
 
     if (nbits == 0) return 0;
     nw = (offs+nbits+31)>>5;
@@ -161,11 +161,11 @@ u_int64_t bitvector_count(u_int32_t *b, u_int64_t offs, u_int64_t nbits)
     return ans;
 }
 
-u_int32_t bitvector_any1(u_int32_t *b, u_int64_t offs, u_int64_t nbits)
+uint32_t bitvector_any1(uint32_t *b, uint64_t offs, uint64_t nbits)
 {
-    index_t i;
-    u_int32_t nw, tail;
-    u_int32_t mask;
+    size_t i;
+    uint32_t nw, tail;
+    uint32_t mask;
 
     if (nbits == 0) return 0;
     nw = (offs+nbits+31)>>5;

--- a/src/support/bitvector.h
+++ b/src/support/bitvector.h
@@ -7,20 +7,20 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT u_int32_t *bitvector_new(u_int64_t n, int initzero);
+JL_DLLEXPORT uint32_t *bitvector_new(uint64_t n, int initzero);
 JL_DLLEXPORT
-u_int32_t *bitvector_resize(u_int32_t *b, uint64_t oldsz, uint64_t newsz,
-                            int initzero);
-size_t bitvector_nwords(u_int64_t nbits);
-JL_DLLEXPORT void bitvector_set(u_int32_t *b, u_int64_t n, u_int32_t c);
-JL_DLLEXPORT u_int32_t bitvector_get(u_int32_t *b, u_int64_t n);
+uint32_t *bitvector_resize(uint32_t *b, uint64_t oldsz, uint64_t newsz,
+                           int initzero);
+size_t bitvector_nwords(uint64_t nbits);
+JL_DLLEXPORT void bitvector_set(uint32_t *b, uint64_t n, uint32_t c);
+JL_DLLEXPORT uint32_t bitvector_get(uint32_t *b, uint64_t n);
 
 JL_DLLEXPORT uint64_t bitvector_next(uint32_t *b, uint64_t n0, uint64_t n);
 
 JL_DLLEXPORT
-u_int64_t bitvector_count(u_int32_t *b, u_int64_t offs, u_int64_t nbits);
+uint64_t bitvector_count(uint32_t *b, uint64_t offs, uint64_t nbits);
 JL_DLLEXPORT
-u_int32_t bitvector_any1(u_int32_t *b, u_int64_t offs, u_int64_t nbits);
+uint32_t bitvector_any1(uint32_t *b, uint64_t offs, uint64_t nbits);
 
 #ifdef __cplusplus
 }

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -146,16 +146,6 @@ typedef int64_t int_t;
 typedef uint32_t uint_t;
 typedef int32_t int_t;
 #endif
-typedef ptrdiff_t ptrint_t; // pointer-size int
-typedef size_t uptrint_t;
-typedef ptrdiff_t offset_t;
-typedef size_t index_t;
-
-typedef uint8_t  u_int8_t;
-typedef uint16_t u_int16_t;
-typedef uint32_t u_int32_t;
-typedef uint64_t u_int64_t;
-typedef uptrint_t u_ptrint_t;
 
 #define LLT_ALIGN(x, sz) (((x) + (sz-1)) & (-sz))
 

--- a/src/support/hashing.c
+++ b/src/support/hashing.c
@@ -27,7 +27,7 @@ uint_t nextipow2(uint_t i)
     return i<<1;
 }
 
-u_int32_t int32hash(u_int32_t a)
+uint32_t int32hash(uint32_t a)
 {
     a = (a+0x7ed55d16) + (a<<12);
     a = (a^0xc761c23c) ^ (a>>19);
@@ -38,7 +38,7 @@ u_int32_t int32hash(u_int32_t a)
     return a;
 }
 
-u_int64_t int64hash(u_int64_t key)
+uint64_t int64hash(uint64_t key)
 {
     key = (~key) + (key << 21);            // key = (key << 21) - key - 1;
     key =   key  ^ (key >> 24);
@@ -50,7 +50,7 @@ u_int64_t int64hash(u_int64_t key)
     return key;
 }
 
-u_int32_t int64to32hash(u_int64_t key)
+uint32_t int64to32hash(uint64_t key)
 {
     key = (~key) + (key << 18); // key = (key << 18) - key - 1;
     key =   key  ^ (key >> 31);
@@ -58,7 +58,7 @@ u_int32_t int64to32hash(u_int64_t key)
     key = key ^ (key >> 11);
     key = key + (key << 6);
     key = key ^ (key >> 22);
-    return (u_int32_t)key;
+    return (uint32_t)key;
 }
 
 #include "MurmurHash3.c"

--- a/src/support/hashing.h
+++ b/src/support/hashing.h
@@ -8,18 +8,18 @@ extern "C" {
 #endif
 
 uint_t nextipow2(uint_t i);
-JL_DLLEXPORT u_int32_t int32hash(u_int32_t a);
-JL_DLLEXPORT u_int64_t int64hash(u_int64_t key);
-JL_DLLEXPORT u_int32_t int64to32hash(u_int64_t key);
+JL_DLLEXPORT uint32_t int32hash(uint32_t a);
+JL_DLLEXPORT uint64_t int64hash(uint64_t key);
+JL_DLLEXPORT uint32_t int64to32hash(uint64_t key);
 #ifdef _P64
 #define inthash int64hash
 #else
 #define inthash int32hash
 #endif
-JL_DLLEXPORT u_int64_t memhash(const char *buf, size_t n);
-JL_DLLEXPORT u_int64_t memhash_seed(const char *buf, size_t n, u_int32_t seed);
-JL_DLLEXPORT u_int32_t memhash32(const char *buf, size_t n);
-JL_DLLEXPORT u_int32_t memhash32_seed(const char *buf, size_t n, u_int32_t seed);
+JL_DLLEXPORT uint64_t memhash(const char *buf, size_t n);
+JL_DLLEXPORT uint64_t memhash_seed(const char *buf, size_t n, uint32_t seed);
+JL_DLLEXPORT uint32_t memhash32(const char *buf, size_t n);
+JL_DLLEXPORT uint32_t memhash32_seed(const char *buf, size_t n, uint32_t seed);
 
 #ifdef __cplusplus
 }

--- a/src/support/htable.inc
+++ b/src/support/htable.inc
@@ -19,10 +19,10 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
     void **tab = h->table;                                              \
     void **ol;                                                          \
                                                                         \
-    hv = HFUNC((uptrint_t)key, ctx);                                    \
+    hv = HFUNC((uintptr_t)key, ctx);                                    \
  retry_bp:                                                              \
     iter = 0;                                                           \
-    index = (index_t)(hv & (sz-1)) * 2;                                 \
+    index = (size_t)(hv & (sz-1)) * 2;                                  \
     sz *= 2;                                                            \
     orig = index;                                                       \
                                                                         \
@@ -97,7 +97,7 @@ static void **HTNAME##_peek_bp_r(htable_t *h, void *key, void *ctx)     \
     size_t sz = hash_size(h);                                           \
     size_t maxprobe = max_probe(sz);                                    \
     void **tab = h->table;                                              \
-    size_t index = (index_t)(HFUNC((uptrint_t)key, ctx) & (sz-1)) * 2;  \
+    size_t index = (size_t)(HFUNC((uintptr_t)key, ctx) & (sz-1)) * 2;   \
     sz *= 2;                                                            \
     size_t orig = index;                                                \
     size_t iter = 0;                                                    \
@@ -148,7 +148,7 @@ _STATIC void HTNAME##_adjoin_r(htable_t *h, void *key, void *val, void *ctx) \
 }
 
 #define HTIMPL(HTNAME, HFUNC, EQFUNC)                                   \
-static uint_t HTNAME##_hfunc_wrapper(uptrint_t key, void *ctx)          \
+static uint_t HTNAME##_hfunc_wrapper(uintptr_t key, void *ctx)          \
 {                                                                       \
     (void)ctx;                                                          \
     return HFUNC(key);                                                  \

--- a/src/support/utils.h
+++ b/src/support/utils.h
@@ -36,7 +36,7 @@ int cmp_eq(void *a, numerictype_t atag, void *b, numerictype_t btag,
 #endif
 
 #if (!defined(__INTEL_COMPILER) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))
-STATIC_INLINE u_int16_t ByteSwap16(u_int16_t x)
+STATIC_INLINE uint16_t ByteSwap16(uint16_t x)
 {
   __asm("xchgb %b0,%h0" :
         LEGACY_REGS (x) :
@@ -45,7 +45,7 @@ STATIC_INLINE u_int16_t ByteSwap16(u_int16_t x)
 }
 #define bswap_16(x) ByteSwap16(x)
 
-STATIC_INLINE u_int32_t ByteSwap32(u_int32_t x)
+STATIC_INLINE uint32_t ByteSwap32(uint32_t x)
 {
  __asm("bswap   %0":
       "=r" (x)     :
@@ -55,7 +55,7 @@ STATIC_INLINE u_int32_t ByteSwap32(u_int32_t x)
 
 #define bswap_32(x) ByteSwap32(x)
 
-STATIC_INLINE u_int64_t ByteSwap64(u_int64_t x)
+STATIC_INLINE uint64_t ByteSwap64(uint64_t x)
 {
 #ifdef __x86_64__
   __asm("bswap  %0":
@@ -63,8 +63,8 @@ STATIC_INLINE u_int64_t ByteSwap64(u_int64_t x)
         "0" (x));
   return x;
 #else
-  register union { __extension__ u_int64_t __ll;
-          u_int32_t __l[2]; } __x;
+  register union { __extension__ uint64_t __ll;
+          uint32_t __l[2]; } __x;
   asm("xchgl    %0,%1":
       "=r"(__x.__l[0]),"=r"(__x.__l[1]):
       "0"(bswap_32((unsigned long)x)),"1"(bswap_32((unsigned long)(x>>32))));
@@ -85,11 +85,11 @@ STATIC_INLINE u_int64_t ByteSwap64(u_int64_t x)
       (((x) & 0x0000ff00) <<  8) | (((x) & 0x000000ff) << 24))
 #endif
 
-STATIC_INLINE u_int64_t ByteSwap64(u_int64_t x)
+STATIC_INLINE uint64_t ByteSwap64(uint64_t x)
 {
     union {
-        u_int64_t ll;
-        u_int32_t l[2];
+        uint64_t ll;
+        uint32_t l[2];
     } w, r;
     w.ll = x;
     r.l[0] = bswap_32 (w.l[1]);

--- a/src/table.c
+++ b/src/table.c
@@ -6,7 +6,7 @@
 #define max_probe(size) ((size)<=1024 ? 16 : (size)>>6)
 
 #define keyhash(k)     jl_object_id(k)
-#define h2index(hv,sz) (index_t)(((hv) & ((sz)-1))*2)
+#define h2index(hv,sz) (size_t)(((hv) & ((sz)-1))*2)
 
 static void **jl_table_lookup_bp(jl_array_t **pa, void *key);
 


### PR DESCRIPTION
We were basically using these interchangeably everywhere and I was also once confused why one of them is used instead of the other. This replaces these non-standard names with the `stdint.h` types and remove their definitions from `support/dtypes.h`

List of types removed:
- `ptrint_t` -> `intptr_t`
- `uptrint_t` -> `uintptr_t`
- `offset_t` not used anywhere, same with `intptr_t`
- `index_t` -> `size_t` (This is not a `stdint.h` type but we are already mixing the two in `htable.*` so it is not necessary to keep the distinction)
- `u_int8_t` -> `uint8_t`
- `u_int16_t` -> `uint16_t`
- `u_int32_t` -> `uint32_t`
- `u_int64_t` -> `uint64_t`
- `u_ptrint_t` -> `uintptr_t`

Ref https://github.com/JuliaLang/julia/issues/14866
