### PR TITLE
Added fallbacks for special matrix types

### DIFF
--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -164,3 +164,15 @@ end
 A_mul_Bc!(A::AbstractTriangular, B::QRCompactWYQ) = A_mul_Bc!(full!(A),B)
 A_mul_Bc!(A::AbstractTriangular, B::QRPackedQ) = A_mul_Bc!(full!(A),B)
 A_mul_Bc(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc(full(A), B)
+
+### Generic promotion methods and fallbacks
+for matrixtype in (:SymTridiagonal,:Tridiagonal,:Bidiagonal)
+    for (f,g) in ((:expm, :expm!), (:logm, :logm), (:sqrtm, :sqrtm))
+        @eval begin
+            function ($f)(A::($matrixtype))
+                ($g)(full(A))
+            end
+        end
+    end
+end
+

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -128,3 +128,26 @@ for typ in [UpperTriangular,LowerTriangular,Base.LinAlg.UnitUpperTriangular,Base
     @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
     @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
 end
+
+let a = rand(n), b = rand(n-1), c = rand(n-1)
+   A = Diagonal(a)
+   @test expm(A) == expm(full(A))
+   @test logm(A) == logm(full(A))
+   @test sqrtm(A) == sqrtm(full(A))
+   A = Bidiagonal(a,b,true)
+   @test expm(A) == expm(full(A))
+   @test logm(A) == logm(full(A))
+   @test sqrtm(A) == sqrtm(full(A))
+   A = Bidiagonal(a,b,false)
+   @test expm(A) == expm(full(A))
+   @test logm(A) == logm(full(A))
+   @test sqrtm(A) == sqrtm(full(A))
+   A = Tridiagonal(c,a,b)
+   @test expm(A) == expm(full(A))
+   @test logm(A) == logm(full(A))
+   @test sqrtm(A) == sqrtm(full(A))
+   A = SymTridiagonal(a,b)
+   @test expm(A) == expm(full(A))
+   @test logm(A) == logm(full(A))
+   @test sqrtm(A) == sqrtm(full(A))
+end


### PR DESCRIPTION
`expm`, `logm`, and `sqrtm` didn't work with the `Bidiagonal`,
`Tridiagonal`, and `SymTridiagonal` types. I've added a fallback
to `full` and tests.
