### PR TITLE
Generate more debug info for the release build

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -342,8 +342,8 @@ ifneq ($(OS), WINNT)
 # Do no enable on windows to avoid warnings from libuv.
 JCXXFLAGS += -pedantic
 endif
-DEBUGFLAGS := -O0 -ggdb2 -DJL_DEBUG_BUILD -fstack-protector-all
-SHIPFLAGS := -O3 -ggdb1 -falign-functions
+DEBUGFLAGS := -Og -ggdb2 -DJL_DEBUG_BUILD -fstack-protector-all
+SHIPFLAGS := -O3 -ggdb2 -falign-functions
 endif
 
 ifeq ($(USECLANG),1)

--- a/src/gc.c
+++ b/src/gc.c
@@ -1351,7 +1351,7 @@ static void sweep_pool_region(gcval_t ***pfl, int region_i, int sweep_mask)
                     gcpage_t *pg = &region->meta[pg_i*32 + j];
                     int p_n = pg->pool_n;
                     int t_n = pg->thread_n;
-                    pool_t *p;
+                    pool_t *p = NULL;
                     FOR_HEAP (t_n)
                         p = &pools[p_n];
                     int osize = pg->osize;
@@ -2457,7 +2457,7 @@ JL_DLLEXPORT void jl_gc_collect(int full)
 
 void *allocb(size_t sz)
 {
-    buff_t *b;
+    buff_t *b = NULL;
     size_t allocsz = sz + sizeof(buff_t);
     if (allocsz < sz)  // overflow in adding offs, size was "negative"
         jl_throw(jl_memory_exception);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -122,7 +122,7 @@ void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
 static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ngensym)
 {
     if (jl_is_symbol(e)) {
-        jl_value_t *v;
+        jl_value_t *v = NULL;
         size_t i;
         for(i=0; i < nl; i++) {
             if (locals[i*2] == e) {


### PR DESCRIPTION
Include information about local variable in the release build so that it is
debugable when necessary. Also use `-Og` to possibly improve the debug info
in the debug build.

This partially revert d705ce960d0bbf0a4d35f1aa2be9daf1055123d0.

Ref https://github.com/JuliaLang/julia/commit/d705ce960d0bbf0a4d35f1aa2be9daf1055123d0#commitcomment-15656098

c.c. @vtjnash 
