### PR TITLE
Improved svds documentation

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -6776,32 +6776,6 @@ Test whether a matrix is symmetric.
 issym
 
 """
-    svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000) -> (left_sv, s, right_sv, nconv, niter, nmult, resid)
-
-`svds` computes largest singular values `s` of `A` using Lanczos or Arnoldi iterations. Uses
-[`eigs`](:func:`eigs`) underneath.
-
-Inputs are:
-
-* `A`: Linear operator. It can either subtype of `AbstractArray` (e.g., sparse matrix) or
-  duck typed. For duck typing `A` has to support `size(A)`, `eltype(A)`, `A * vector` and
-  `A' * vector`.
-* `nsv`: Number of singular values.
-* `ritzvec`: Whether to return the left and right singular vectors `left_sv` and `right_sv`,
-  default is `true`. If `false` the singular vectors are omitted from the output.
-* `tol`: tolerance, see [`eigs`](:func:`eigs`).
-* `maxiter`: Maximum number of iterations, see [`eigs`](:func:`eigs`).
-
-**Example**
-
-```julia
-X = sprand(10, 5, 0.2)
-svds(X, nsv = 2)
-```
-"""
-svds
-
-"""
     acosh(x)
 
 Compute the inverse hyperbolic cosine of `x`.

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -278,6 +278,49 @@ function svds{T}(A::AbstractMatrix{T}; kwargs...)
     Tnew = typeof(zero(T)/sqrt(one(T)))
     svds(convert(AbstractMatrix{Tnew}, A); kwargs...)
 end
+
+"""
+    svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000) -> ([left_sv,] s, [right_sv,] nconv, niter, nmult, resid)
+
+Computes the largest singular values `s` of `A` using implicitly restarted Lanczos
+iterations derived from [`eigs`](:func:`eigs`).
+
+**Inputs**
+
+* `A`: Linear operator whose singular values are desired. `A` may be represented
+  as a subtype of `AbstractArray`, e.g., a sparse matrix, or any other type
+  supporting the four methods `size(A)`, `eltype(A)`, `A * vector`, and
+  `A' * vector`.
+* `nsv`: Number of singular values.
+* `ritzvec`: If `true`, return the left and right singular vectors `left_sv` and `right_sv`.
+   If `false`, omit the singular vectors. Default: `true`.
+* `tol`: tolerance, see [`eigs`](:func:`eigs`).
+* `maxiter`: Maximum number of iterations, see [`eigs`](:func:`eigs`).
+
+**Outputs**
+
+* `left_sv`: Left singular vectors (only if `ritzvec = true`).
+* `s`: A vector of length `nsv` containing the requested singular values.
+* `right_sv`: Right singular vectors (only if `ritzvec = true`).
+* `nconv`: Number of converged singular values.
+* `niter`: Number of iterations.
+* `nmult`: Number of matrix--vector products used.
+* `resid`: Final residual vector.
+
+**Example**
+
+```julia
+X = sprand(10, 5, 0.2)
+svds(X, nsv = 2)
+```
+
+**Implementation note**
+
+`svds(A)` is formally equivalent to calling `eigs` to perform implicitly restarted
+Lanczos tridiagonalization on the Hermitian matrix
+``\\begin{pmatrix} 0 & A^\\prime \\\\ A & 0 \\end{pmatrix}``, whose eigenvalues are
+plus and minus the singular values of ``A``.
+"""
 svds(A; kwargs...) = _svds(A; kwargs...)
 function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000)
     if nsv < 1

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1129,15 +1129,25 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   ``svds`` computes largest singular values ``s`` of ``A`` using Lanczos or Arnoldi iterations. Uses :func:`eigs` underneath.
+   Computes the largest singular values ``s`` of ``A`` using implicitly restarted Lanczos iterations derived from :func:`eigs`\ .
 
-   Inputs are:
+   **Inputs**
 
-   * ``A``\ : Linear operator. It can either subtype of ``AbstractArray`` (e.g., sparse matrix) or   duck typed. For duck typing ``A`` has to support ``size(A)``\ , ``eltype(A)``\ , ``A * vector`` and   ``A' * vector``\ .
+   * ``A``\ : Linear operator whose singular values are desired. ``A`` may be represented   as a subtype of ``AbstractArray``\ , e.g., a sparse matrix, or any other type   supporting the four methods ``size(A)``\ , ``eltype(A)``\ , ``A * vector``\ , and   ``A' * vector``\ .
    * ``nsv``\ : Number of singular values.
-   * ``ritzvec``\ : Whether to return the left and right singular vectors ``left_sv`` and ``right_sv``\ ,   default is ``true``\ . If ``false`` the singular vectors are omitted from the output.
+   * ``ritzvec``\ : If ``true``\ , return the left and right singular vectors ``left_sv`` and ``right_sv``\ .    If ``false``\ , omit the singular vectors. Default: ``true``\ .
    * ``tol``\ : tolerance, see :func:`eigs`\ .
    * ``maxiter``\ : Maximum number of iterations, see :func:`eigs`\ .
+
+   **Outputs**
+
+   * ``left_sv``\ : Left singular vectors (only if ``ritzvec = true``\ ).
+   * ``s``\ : A vector of length ``nsv`` containing the requested singular values.
+   * ``right_sv``\ : Right singular vectors (only if ``ritzvec = true``\ ).
+   * ``nconv``\ : Number of converged singular values.
+   * ``niter``\ : Number of iterations.
+   * ``nmult``\ : Number of matrix–vector products used.
+   * ``resid``\ : Final residual vector.
 
    **Example**
 
@@ -1145,6 +1155,10 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
        X = sprand(10, 5, 0.2)
        svds(X, nsv = 2)
+
+   **Implementation note**
+
+   ``svds(A)`` is formally equivalent to calling ``eigs`` to perform implicitly restarted Lanczos tridiagonalization on the Hermitian matrix :math:`\begin{pmatrix} 0 & A^\prime \\ A & 0 \end{pmatrix}`\ , whose eigenvalues are plus and minus the singular values of :math:`A`\ .
 
 .. function:: peakflops(n; parallel=false)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1125,7 +1125,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    | real or complex | inverse with level shift ``sigma`` | :math:`(A - \sigma B )^{-1}B = v\nu` |
    +-----------------+------------------------------------+--------------------------------------+
 
-.. function:: svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000) -> (left_sv, s, right_sv, nconv, niter, nmult, resid)
+.. function:: svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000) -> ([left_sv,] s, [right_sv,] nconv, niter, nmult, resid)
 
    .. Docstring generated from Julia source
 


### PR DESCRIPTION
- Moves `svds` docstring from `docs/helpdb/Base.jl` to
  `base/linalg/arnoldi.jl`.
- Corrects description of `svds` - it uses implicitly restart Lanczos
  only, never the implicitly restarted Arnoldi method.
- Describes each component of the output tuple, emphasizing that the
  singular vectors are not returned if `ritzvec=false`.
- Explains the formal relation between `svds` and `eigs`

Closes JuliaLang/LinearAlgebra.jl#305
