### PR TITLE
improve method name printing in edge cases

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -46,9 +46,9 @@ function show(io::IO, m::Method)
     tv, decls, file, line = arg_decl_parts(m)
     ft = m.sig.parameters[1]
     d1 = decls[1]
-    if isa(ft,DataType) && (isempty(ft.parameters) && nfields(ft)==0 &&
-                            isdefined(ft.name.module,ft.name.name) &&
-                            ft == getfield(ft.name.module,ft.name.name))
+    if ft <: Function &&
+            isdefined(ft.name.module, ft.name.name) &&
+            ft == getfield(ft.name.module, ft.name.name)
         print(io, ft.name.mt.name)
     else
         print(io, "(", d1[1], "::", d1[2], ")")
@@ -143,9 +143,9 @@ function writemime(io::IO, ::MIME"text/html", m::Method)
     tv, decls, file, line = arg_decl_parts(m)
     ft = m.sig.parameters[1]
     d1 = decls[1]
-    if isa(ft,DataType) && (isempty(ft.parameters) && nfields(ft)==0 &&
-                            isdefined(ft.name.module,ft.name.name) &&
-                            ft == getfield(ft.name.module,ft.name.name))
+    if ft <: Function &&
+            isdefined(ft.name.module, ft.name.name) &&
+            ft == getfield(ft.name.module, ft.name.name)
         print(io, ft.name.mt.name)
     else
         print(io, "(", d1[1], "::<b>", d1[2], "</b>)")

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -47,9 +47,16 @@ function show(io::IO, m::Method)
     ft = m.sig.parameters[1]
     d1 = decls[1]
     if ft <: Function &&
-            isdefined(ft.name.module, ft.name.name) &&
-            ft == getfield(ft.name.module, ft.name.name)
+            isdefined(ft.name.module, ft.name.mt.name) &&
+            ft == typeof(getfield(ft.name.module, ft.name.mt.name))
         print(io, ft.name.mt.name)
+    elseif isa(ft, DataType) && is(ft.name, Type.name) && isleaftype(ft)
+        f = ft.parameters[1]
+        if isa(f, DataType) && isempty(f.parameters)
+            print(io, f)
+        else
+            print(io, "(", d1[1], "::", d1[2], ")")
+        end
     else
         print(io, "(", d1[1], "::", d1[2], ")")
     end
@@ -67,10 +74,12 @@ end
 
 function show_method_table(io::IO, mt::MethodTable, max::Int=-1, header::Bool=true)
     name = mt.name
+    isself = isdefined(mt.module, name) &&
+             typeof(getfield(mt.module, name)) <: Function
     n = length(mt)
     if header
         m = n==1 ? "method" : "methods"
-        ns = string(name)
+        ns = isself ? string(name) : string("(::", name, ")")
         what = startswith(ns, '@') ? "macro" : "generic function"
         print(io, "# $n $m for ", what, " \"", ns, "\":")
     end
@@ -144,9 +153,16 @@ function writemime(io::IO, ::MIME"text/html", m::Method)
     ft = m.sig.parameters[1]
     d1 = decls[1]
     if ft <: Function &&
-            isdefined(ft.name.module, ft.name.name) &&
-            ft == getfield(ft.name.module, ft.name.name)
+            isdefined(ft.name.module, ft.name.mt.name) &&
+            ft == typeof(getfield(ft.name.module, ft.name.mt.name))
         print(io, ft.name.mt.name)
+    elseif isa(ft, DataType) && is(ft.name, Type.name) && isleaftype(ft)
+        f = ft.parameters[1]
+        if isa(f, DataType) && isempty(f.parameters)
+            print(io, f)
+        else
+            print(io, "(", d1[1], "::<b>", d1[2], "</b>)")
+        end
     else
         print(io, "(", d1[1], "::<b>", d1[2], "</b>)")
     end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -142,9 +142,13 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         if isdefined(linfo, 8)
             params = linfo.(#=specTypes=#8).parameters
             ft = params[1]
-            if ft <: Function && isdefined(ft.name.module, ft.name.name) &&
-                    ft == getfield(ft.name.module, ft.name.name)
+            if ft <: Function && isempty(ft.parameters) &&
+                    isdefined(ft.name.module, ft.name.mt.name) &&
+                    ft == typeof(getfield(ft.name.module, ft.name.mt.name))
                 print(io, ft.name.mt.name)
+            elseif isa(ft, DataType) && is(ft.name, Type.name) && isleaftype(ft)
+                f = ft.parameters[1]
+                print(io, f)
             else
                 print(io, "(::", ft, ")")
             end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -139,9 +139,25 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         print(io, frame.func !== empty_sym ? frame.func : "?")
     else
         linfo = get(frame.outer_linfo)
-        print(io, linfo.name)
         if isdefined(linfo, 8)
-            Base.show_delim_array(io, linfo.(#=specTypes=#8).parameters, "(", ", ", ")", false)
+            params = linfo.(#=specTypes=#8).parameters
+            ft = params[1]
+            if ft <: Function && isdefined(ft.name.module, ft.name.name) &&
+                    ft == getfield(ft.name.module, ft.name.name)
+                print(io, ft.name.mt.name)
+            else
+                print(io, "(::", ft, ")")
+            end
+            first = true
+            print(io, '(')
+            for i = 2:length(params)
+                first || print(io, ", ")
+                first = false
+                print(io, "::", params[i])
+            end
+            print(io, ')')
+        else
+            print(io, linfo.name)
         end
     end
 end

--- a/base/test.jl
+++ b/base/test.jl
@@ -240,7 +240,7 @@ end
 function do_test_throws(result::ExecutionResult, orig_expr, extype)
     if isa(result, Threw)
         # Check the right type of exception was thrown
-        if isa(result.exception, extype)
+        if is(typeof(result.exception), extype)
             testres = Pass(:test_throws, orig_expr, extype, result.exception)
         else
             testres = Fail(:test_throws_wrong, orig_expr, extype, result.exception)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -456,7 +456,7 @@ r = linspace(1/3,5/7,6)
 @test abs(r[end] - 5/7) <= eps(5/7)
 r = linspace(0.25,0.25,1)
 @test length(r) == 1
-@test_throws Exception linspace(0.25,0.5,1)
+@test_throws ErrorException linspace(0.25,0.5,1)
 
 # issue #7426
 @test [typemax(Int):1:typemax(Int);] == [typemax(Int)]

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -6,9 +6,6 @@
 
 module ReflectionTest
 using Base.Test
-# use versions of these functions that doesn't have static-parameters
-# so that code_llvm can handle them
-plus(a, b) = +(a, b)
 
 function test_ast_reflection(freflect, f, types)
     @test !isempty(freflect(f, types))
@@ -29,13 +26,11 @@ end
 function test_code_reflections(tester, freflect)
     test_code_reflection(freflect, ismatch,
                          Tuple{Regex, AbstractString}, tester) # abstract type
-    test_code_reflection(freflect, plus, Tuple{Int, Int}, tester) # leaftype signature
-    test_code_reflection(freflect, plus,
+    test_code_reflection(freflect, +, Tuple{Int, Int}, tester) # leaftype signature
+    test_code_reflection(freflect, +,
                          Tuple{Array{Float32}, Array{Float32}}, tester) # incomplete types
     test_code_reflection(freflect, Module, Tuple{}, tester) # Module() constructor (transforms to call)
-    if tester == test_ast_reflection
-        test_code_reflection(freflect, Array{Int64}, Tuple{Array{Int32}}, tester) # with incomplete types
-    end
+    test_code_reflection(freflect, Array{Int64}, Tuple{Array{Int32}}, tester) # with incomplete types
 end
 
 println(STDERR, "The following 'Returned code...' warnings indicate normal behavior:")
@@ -43,12 +38,6 @@ test_code_reflections(test_ast_reflection, code_lowered)
 test_code_reflections(test_ast_reflection, code_typed)
 test_code_reflections(test_bin_reflection, code_llvm)
 test_code_reflections(test_bin_reflection, code_native)
-
-@test_throws Exception code_native(+, Int, Int)
-@test_throws Exception code_native(+, Array{Float32}, Array{Float32})
-
-@test_throws Exception code_llvm(+, Int, Int)
-@test_throws Exception code_llvm(+, Array{Float32}, Array{Float32})
 end
 
 # code_warntype

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -69,16 +69,15 @@ for f in [getindex, setindex!]
     test_have_color(buf, "", "")
 end
 
-
-function _except_str(expr, err_type=Exception)
-    quote
+macro except_str(expr, err_type)
+    return quote
         let
             local err::$(esc(err_type))
             try
                 $(esc(expr))
             catch err
             end
-            err
+            @test typeof(err) === $err_type
             buff = IOBuffer()
             showerror(buff, err)
             takebuf_string(buff)
@@ -86,8 +85,19 @@ function _except_str(expr, err_type=Exception)
     end
 end
 
-macro except_str(args...)
-    _except_str(args...)
+macro except_stackframe(expr, err_type)
+    return quote
+       let
+           local st
+           try
+               $(esc(expr))
+           catch err
+               st = catch_stacktrace()
+               @test typeof(err) === $err_type
+           end
+           sprint(show, st[1])
+       end
+    end
 end
 
 # Pull Request 11007
@@ -114,14 +124,14 @@ end
 
 let
     g11007(::AbstractVector) = nothing
-    err_str = @except_str g11007([[1] [1]])
+    err_str = @except_str g11007([[1] [1]]) MethodError
     @test contains(err_str, "row vector")
     @test contains(err_str, "column vector")
 end
 
 abstract T11007
 let
-    err_str = @except_str T11007()
+    err_str = @except_str T11007() MethodError
     @test contains(err_str, "no method matching T11007()")
 end
 
@@ -133,6 +143,81 @@ let
     showerror(buff, MethodError(convert, Tuple{Type, Float64}))
     showerror(buff, MethodError(convert, Tuple{DataType, Float64}))
 end
+
+# Issue #14884
+bitstype 8 EightBitType
+bitstype 8 EightBitTypeT{T}
+immutable FunctionLike <: Function; end
+let err_str,
+    i = reinterpret(EightBitType, 0x54),
+    j = reinterpret(EightBitTypeT{Int32}, 0x54)
+
+    err_str = @except_str Symbol() MethodError
+    @test contains(err_str, "no method matching Symbol()")
+    err_str = @except_str :a() MethodError
+    @test contains(err_str, "no method matching (::Symbol)()")
+    err_str = @except_str EightBitType() MethodError
+    @test contains(err_str, "no method matching EightBitType()")
+    err_str = @except_str i() MethodError
+    @test contains(err_str, "no method matching (::EightBitType)()")
+    err_str = @except_str EightBitTypeT() MethodError
+    @test contains(err_str, "no method matching EightBitTypeT{T}()")
+    err_str = @except_str EightBitTypeT{Int32}() MethodError
+    @test contains(err_str, "no method matching EightBitTypeT{Int32}()")
+    err_str = @except_str j() MethodError
+    @test contains(err_str, "no method matching (::EightBitTypeT{Int32})()")
+    err_str = @except_str FunctionLike()() MethodError
+    @test contains(err_str, "no method matching (::FunctionLike)()")
+end
+@test stringmime("text/plain", FunctionLike()) == "(::FunctionLike) (generic function with 0 methods)"
+@test ismatch(r"@doc \(macro with \d+ method[s]?\)", stringmime("text/plain", Base.(symbol("@doc"))))
+
+method_defs_lineno = @__LINE__
+Base.Symbol() = error(1)
+(::Symbol)() = error(2)
+EightBitType() = error(3)
+(::EightBitType)() = error(4)
+EightBitTypeT() = error(5)
+(::Type{EightBitTypeT{T}}){T}() = error(6)
+(::EightBitTypeT)() = error(7)
+(::FunctionLike)() = error(8)
+
+
+let err_str,
+    i = reinterpret(EightBitType, 0x54),
+    j = reinterpret(EightBitTypeT{Int32}, 0x54),
+    sp = Base.source_path()
+    sn = basename(sp)
+
+    @test sprint(show, which(Symbol, Tuple{})) == "Symbol() at $sp:$(method_defs_lineno + 0)"
+    @test sprint(show, which(:a, Tuple{})) == "(::Symbol)() at $sp:$(method_defs_lineno + 1)"
+    @test sprint(show, which(EightBitType, Tuple{})) == "EightBitType() at $sp:$(method_defs_lineno + 2)"
+    @test sprint(show, which(reinterpret(EightBitType, 0x54), Tuple{})) == "(::EightBitType)() at $sp:$(method_defs_lineno + 3)"
+    @test sprint(show, which(EightBitTypeT, Tuple{})) == "(::Type{EightBitTypeT{T<:Any}})() at $sp:$(method_defs_lineno + 4)"
+    @test sprint(show, which(EightBitTypeT{Int32}, Tuple{})) == "(::Type{EightBitTypeT{T}}){T}() at $sp:$(method_defs_lineno + 5)"
+    @test sprint(show, which(reinterpret(EightBitTypeT{Int32}, 0x54), Tuple{})) == "(::EightBitTypeT{T<:Any})() at $sp:$(method_defs_lineno + 6)"
+    @test startswith(sprint(show, which(Base.(symbol("@doc")), Tuple{Vararg{Any}})), "@doc(args...) at docs/bootstrap.jl:")
+    @test startswith(sprint(show, which(FunctionLike(), Tuple{})), "(::FunctionLike)() at $sp:$(method_defs_lineno + 7)")
+    @test stringmime("text/plain", FunctionLike()) == "(::FunctionLike) (generic function with 1 method)"
+
+    err_str = @except_stackframe Symbol() ErrorException
+    @test err_str == " in Symbol() at $sn:$(method_defs_lineno + 0)"
+    err_str = @except_stackframe :a() ErrorException
+    @test err_str == " in (::Symbol)() at $sn:$(method_defs_lineno + 1)"
+    err_str = @except_stackframe EightBitType() ErrorException
+    @test err_str == " in EightBitType() at $sn:$(method_defs_lineno + 2)"
+    err_str = @except_stackframe i() ErrorException
+    @test err_str == " in (::EightBitType)() at $sn:$(method_defs_lineno + 3)"
+    err_str = @except_stackframe EightBitTypeT() ErrorException
+    @test err_str == " in EightBitTypeT{T}() at $sn:$(method_defs_lineno + 4)"
+    err_str = @except_stackframe EightBitTypeT{Int32}() ErrorException
+    @test err_str == " in EightBitTypeT{Int32}() at $sn:$(method_defs_lineno + 5)"
+    err_str = @except_stackframe j() ErrorException
+    @test err_str == " in (::EightBitTypeT{Int32})() at $sn:$(method_defs_lineno + 6)"
+    err_str = @except_stackframe FunctionLike()() ErrorException
+    @test err_str == " in (::FunctionLike)() at $sn:$(method_defs_lineno + 7)"
+end
+
 
 # Issue #13032
 withenv("JULIA_EDITOR" => nothing, "VISUAL" => nothing, "EDITOR" => nothing) do


### PR DESCRIPTION
this fixes method printing for errors and a few edge cases.
fixed printing includes:

``` julia
julia> Base.Symbol() = 1
julia> (::Symbol)() = 2
julia> Base.Int() = 3
julia> (::Int)() = 4

julia> which(Symbol, Tuple{})
Symbol() at none:1

julia> which(:a, Tuple{})
(::Symbol)() at none:1

julia> which(Int, Tuple{})
Int64() at none:1

julia> which(3, Tuple{})
(::Int64)() at none:1

julia> function f(x)
                g() = x
              end
f (generic function with 2 methods)

julia> which(f(1), Tuple{})
g() at none:2
```

these fixes are repeated for `stacktrace`, `MethodError`, and `writemime`
