### PR TITLE
Add `BlasReal` qualifier to `svdfact!` for `Bidiagonal`.

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -92,15 +92,11 @@ big(B::Bidiagonal) = Bidiagonal(big(B.dv), big(B.ev), B.isupper)
 
 #Singular values
 svdvals!{T<:BlasReal}(M::Bidiagonal{T}) = LAPACK.bdsdc!(M.isupper ? 'U' : 'L', 'N', M.dv, M.ev)[1]
-function svd{T<:BlasReal}(M::Bidiagonal{T})
-    d, e, U, Vt, Q, iQ = LAPACK.bdsdc!(M.isupper ? 'U' : 'L', 'I', copy(M.dv), copy(M.ev))
-    return U, d, Vt'
-end
-function svdfact!(M::Bidiagonal, thin::Bool=true)
+function svdfact!{T<:BlasReal}(M::Bidiagonal{T}; thin::Bool=true)
     d, e, U, Vt, Q, iQ = LAPACK.bdsdc!(M.isupper ? 'U' : 'L', 'I', M.dv, M.ev)
     SVD(U, d, Vt)
 end
-svdfact(M::Bidiagonal, thin::Bool=true) = svdfact!(copy(M),thin)
+svdfact(M::Bidiagonal; thin::Bool=true) = svdfact!(copy(M),thin=thin)
 
 ####################
 # Generic routines #

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -54,12 +54,9 @@ svdvals(x::Number) = abs(x)
 svdvals{T, Tr}(S::SVD{T, Tr}) = (S[:S])::Vector{Tr}
 
 # SVD least squares
-function A_ldiv_B!{T<:BlasFloat}(A::SVD{T}, B::StridedVecOrMat{T})
-    n = length(A.S)
-    Sinv = zeros(T, n)
-    k = length(find(A.S .> eps(real(float(one(T))))*maximum(A.S)))
-    Sinv[1:k] = one(T) ./ A.S[1:k]
-    A.Vt[1:k,:]' * (Sinv[1:k] .* (A.U[:,1:k]' * B))
+function A_ldiv_B!{Ta,Tb}(A::SVD{Ta}, B::StridedVecOrMat{Tb})
+    k = searchsortedlast(A.S, eps(real(Ta))*A.S[1], rev=true)
+    sub(A.Vt,1:k,:)' * (sub(A.S,1:k) .\ (sub(A.U,:,1:k)' * B))
 end
 
 # Generalized svd


### PR DESCRIPTION
Also removes unnecessary function definition (can be handled by generic methods).
