### PR TITLE
WIP interpreter

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -42,6 +42,14 @@ macro generated(f)
     end
 end
 
+@generated function generic_ccall{R,A}(fptr::Ptr{Void}, ::Type{R}, ::Type{A}, args::SimpleVector)
+    e = Expr(:call, TopNode(:ccall), :fptr, R, A.types)
+    for i in 1:2*length(A.types)
+        push!(e.args, :(args[$i]))
+    end
+    e
+end
+
 
 function tuple_type_head{T<:Tuple}(::Type{T})
     @_pure_meta

--- a/src/gf.c
+++ b/src/gf.c
@@ -178,7 +178,7 @@ static jl_methlist_t **mtcache_hash_bp(jl_array_t **pa, jl_value_t *ty,
   there tends to be lots of variation there. The type of the 0th argument
   (the function) is always the same for most functions.
 */
-static jl_lambda_info_t *jl_method_table_assoc_exact_by_type(jl_methtable_t *mt, jl_tupletype_t *types)
+jl_lambda_info_t *jl_method_table_assoc_exact_by_type(jl_methtable_t *mt, jl_tupletype_t *types)
 {
     // called object is the primary key for constructors, otherwise first argument
     int8_t offs = (mt == jl_type_type->name->mt) ? 0 : 1;
@@ -214,7 +214,7 @@ static jl_lambda_info_t *jl_method_table_assoc_exact_by_type(jl_methtable_t *mt,
     return NULL;
 }
 
-static jl_lambda_info_t *jl_method_table_assoc_exact(jl_methtable_t *mt, jl_value_t **args, size_t n)
+jl_lambda_info_t *jl_method_table_assoc_exact(jl_methtable_t *mt, jl_value_t **args, size_t n)
 {
     // NOTE: This function is a huge performance hot spot!!
     int8_t offs = (mt == jl_type_type->name->mt) ? 0 : 1;
@@ -971,7 +971,7 @@ JL_DLLEXPORT jl_lambda_info_t *jl_instantiate_staged(jl_lambda_info_t *generator
     return func;
 }
 
-static jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt, int cache, int inexact)
+jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt, int cache, int inexact)
 {
     jl_methlist_t *m = mt->defs;
     size_t nargs = jl_nparams(tt);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1852,9 +1852,15 @@ static jl_value_t *verify_type(jl_value_t *v)
     assert(jl_typeof(jl_typeof(v)));
     return v;
 }
-
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
 {
+    return jl_apply_generic_ex(args, nargs, 1);
+}
+JL_DLLEXPORT jl_value_t *jl_apply_generic_ex(jl_value_t **args, uint32_t nargs, int can_interpret)
+{
+    if (can_interpret && jl_interpreter_enabled) {
+        return jl_apply_interpreted(args, nargs);
+    }
     jl_value_t *F = args[0];
     jl_methtable_t *mt = jl_gf_mtable(F);
 #ifdef JL_GF_PROFILE

--- a/src/init.c
+++ b/src/init.c
@@ -648,6 +648,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     }
 
     if (jl_options.image_file) {
+        jl_restore_intrinsic_tables();
         JL_TRY {
             jl_restore_system_image(jl_options.image_file);
         }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -14,15 +14,22 @@
 extern "C" {
 #endif
 
-static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ngensym);
-static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl, size_t ngensym,
-                             int start, int toplevel);
+typedef struct {
+    jl_value_t **locals;
+    size_t nl;
+    size_t ngensym;
+    jl_module_t *mod;
+} interpreter_state;
+
+static jl_value_t *eval(jl_value_t *e, interpreter_state s);
+static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state s, int start, int toplevel);
 jl_value_t *jl_eval_module_expr(jl_expr_t *ex);
 int jl_is_toplevel_only_expr(jl_value_t *e);
 
 jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e)
 {
-    return eval(e, NULL, 0, 0);
+    interpreter_state s = { .locals = NULL, .nl = 0, .ngensym = 0, .mod = NULL };
+    return eval(e, s);
 }
 
 JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
@@ -41,7 +48,9 @@ JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
     }
     JL_TRY {
         jl_current_task->current_module = jl_current_module = m;
-        v = eval(e, locals, nl, 0);
+        interpreter_state s = { .locals = locals,
+                                .nl = nl, .ngensym = 0, .mod = NULL};
+        v = eval(e, s);
     }
     JL_CATCH {
         jl_current_module = last_m;
@@ -55,32 +64,130 @@ JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
 }
 
 static jl_value_t *do_call(jl_value_t **args, size_t nargs,
-                           jl_value_t **locals, size_t nl, size_t ngensym,
-                           int interpreted)
+                           interpreter_state s)
 {
     jl_value_t **argv;
     JL_GC_PUSHARGS(argv, nargs);
     size_t i;
-    for(i=0; i < nargs; i++)
-        argv[i] = eval(args[i], locals, nl, ngensym);
-    jl_value_t *result;
-    if (!interpreted) {
-        result = jl_apply_generic(argv, nargs);
-    } else {
-        jl_methtable_t *mt = jl_gf_mtable(argv[0]);
-        jl_lambda_info_t *mfunc = jl_method_table_assoc_exact(mt, argv, nargs);
-        if (!mfunc) {
-            jl_tupletype_t *tt = arg_type_tuple(args, nargs);
-            mfunc = jl_mt_assoc_by_type(mt, tt, 1, 0);
+    // hack, remove me
+    int *ref_index = alloca(sizeof(int)*nargs);
+    void **refs = alloca(sizeof(void*)*nargs);
+    for(i=0; i < nargs; i++) {
+        jl_value_t *arg = args[i];
+        /* ugly hack */
+        if (jl_is_expr(arg) && ((jl_expr_t*)arg)->head == amp_sym) {
+            jl_value_t *var = jl_cellref(((jl_expr_t*)arg)->args, 0);
+            jl_value_t *val = NULL;
+            if (jl_is_gensym(var)) {
+                size_t id = ((jl_gensym_t*)var)->id;
+                ref_index[i] = 1 + 2*s.nl + id;
+                val = s.locals[2*s.nl + id];
+            } else {
+                if (!jl_is_symbol(var)) {
+                    assert(jl_is_symbolnode(var));
+                    var = jl_symbolnode_sym(var);
+                }
+                assert(jl_is_symbol(var));
+                int k;
+                for (k = 0; k < s.nl; k++) {
+                    if (s.locals[2*k] == var) {
+                        ref_index[i] = 1 + 2*k + 1;
+                        val = s.locals[2*k + 1];
+                        break;
+                    }
+                }
+                assert(k < s.nl);
+            }
+            jl_value_t *param = NULL, *ty = NULL, *ref = NULL;
+            JL_GC_PUSH3(&param, &ty, &ref);
+            param = jl_alloc_svec(1);
+            jl_svecset(param, 0, jl_typeof(val));
+            int sz = jl_datatype_size(jl_typeof(val));
+            refs[i] = malloc(sz);
+            memcpy(refs[i], val, sz);
+            argv[i] = jl_new_struct_uninit(jl_apply_type(jl_pointer_type, param));
+            *(void**)argv[i] = refs[i];
+            JL_GC_POP();
+        } else { /* sane path */
+            argv[i] = eval(arg, s);
+            ref_index[i] = 0;
         }
-        if (!mfunc) {
-            jl_no_method_error((jl_function_t*)argv[0], args, nargs);
-            __builtin_unreachable();
+    }
+    /* nothing to see here */
+    jl_value_t *result = jl_apply_generic(argv, nargs);
+    for (int k = 0; k < nargs; k++) {
+        if (ref_index[k] != 0) {
+            int ri = ref_index[k] - 1;
+            jl_value_t *ty = jl_typeof(s.locals[ri]);
+            s.locals[ri] = jl_new_struct_uninit(ty);
+            memcpy(s.locals[ri], refs[k], jl_datatype_size(ty));
+            free(refs[k]);
         }
-        result = jl_interpret_toplevel_thunk_with(mfunc, args, nargs);
     }
     JL_GC_POP();
     return result;
+}
+
+jl_value_t *jl_apply_interpreted(jl_value_t **argv, uint32_t nargs)
+{
+    if (jl_typeof(argv[0]) == jl_intrinsic_type) {
+        int intr_id = *(int*)argv[0];
+        if (intr_id == 89) { // ccall implementation
+            jl_value_t *gen_ccall = jl_eval_string("Base.generic_ccall");
+            argv[0] = gen_ccall;
+            if (!jl_is_cpointer(argv[1])) {
+                argv[1] = jl_native_sym(argv[1], jl_voidpointer_type);
+            }
+            argv[3] = jl_inst_concrete_tupletype(argv[3]);
+            assert(nargs >= 4);
+            int was_enabled = jl_interpreter_enabled;
+            jl_interpreter_enabled = 0; // avoid recursing in there while generating generic_ccall's body
+            jl_value_t *result;
+            if (nargs == 4) {
+                jl_value_t **argv2 = alloca(sizeof(jl_value_t*)*(nargs+1));
+                memcpy(argv2, argv, nargs*sizeof(jl_value_t*));
+                argv2[4] = jl_emptysvec;
+                result = jl_apply_generic_ex(argv2, 5, 0);
+            } else {
+                jl_value_t *ccall_args = jl_alloc_svec(nargs - 4); // not rooted until next assignment
+                memcpy(jl_svec_data(ccall_args), &argv[4], (nargs - 4)*sizeof(jl_value_t*));
+                argv[4] = ccall_args;
+                result = jl_apply_generic_ex(argv, 5, 0);
+            }
+            jl_interpreter_enabled = was_enabled;
+            return result;
+        } else if (intr_id == 90) { // cglobal implementation
+            jl_value_t *ty = jl_voidpointer_type;
+            JL_GC_PUSH1(&ty);
+            if (nargs == 3) {
+                ty = jl_alloc_svec(1);
+                jl_svecset(ty, 0, argv[2]);
+                ty = jl_apply_type(jl_pointer_type, ty);
+            }
+            jl_value_t *result = jl_native_sym(argv[1], ty);
+            JL_GC_POP();
+            return result;
+        }
+        else {
+            return jl_f_intrinsic_call(NULL, argv, nargs);
+        }
+    }
+    else if (jl_subtype(argv[0], (jl_value_t*)jl_builtin_type, 1)) {
+        return ((jl_value_t*(*)(jl_value_t*,jl_value_t**,int))jl_get_builtin_fptr(argv[0]))(NULL, &argv[1], nargs-1);
+    }
+    else {
+        jl_methtable_t *mt = jl_gf_mtable(argv[0]);
+        jl_lambda_info_t *mfunc = jl_method_table_assoc_exact(mt, argv, nargs);
+        if (!mfunc) {
+            jl_tupletype_t *tt = arg_type_tuple(argv, nargs);
+            mfunc = jl_mt_assoc_by_type(mt, tt, 1, 0);
+        }
+        if (!mfunc) {
+            jl_no_method_error((jl_function_t*)argv[0], argv, nargs);
+            __builtin_unreachable();
+        }
+        return jl_interpret_call(/*jl_get_unspecialized(*/mfunc/*)*/, argv, nargs, mfunc->sparam_vals, 0);
+    }
 }
 
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
@@ -134,40 +241,41 @@ void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
     tt->super = (jl_datatype_t*)super;
     jl_gc_wb(tt, tt->super);
 }
-int jl_interpret_calls = 0;
-static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ngensym)
+int jl_interpreter_enabled = 1;
+static jl_value_t *eval(jl_value_t *e, interpreter_state s)
 {
+    jl_module_t *mod = s.mod ? s.mod : jl_current_module;
     if (jl_is_symbol(e)) {
         jl_value_t *v = NULL;
         size_t i;
-        for(i=0; i < nl; i++) {
-            if (locals[i*2] == e) {
-                v = locals[i*2+1];
+        for(i=0; i < s.nl; i++) {
+            if (s.locals[i*2] == e) {
+                v = s.locals[i*2+1];
                 break;
             }
         }
-        if (i >= nl)
-            v = jl_get_global(jl_current_module, (jl_sym_t*)e);
+        if (i >= s.nl)
+            v = jl_get_global(mod, (jl_sym_t*)e);
         if (v == NULL)
             jl_undefined_var_error((jl_sym_t*)e);
         return v;
     }
     if (jl_is_symbolnode(e)) {
-        return eval((jl_value_t*)jl_symbolnode_sym(e), locals, nl, ngensym);
+        return eval((jl_value_t*)jl_symbolnode_sym(e), s);
     }
     if (jl_is_gensym(e)) {
         ssize_t genid = ((jl_gensym_t*)e)->id;
-        if (genid >= ngensym || genid < 0)
+        if (genid >= s.ngensym || genid < 0)
             jl_error("access to invalid GenSym location");
         else
-            return locals[nl*2 + genid];
+            return s.locals[s.nl*2 + genid];
     }
     if (jl_is_quotenode(e)) {
         return jl_fieldref(e,0);
     }
     if (jl_is_topnode(e)) {
         jl_sym_t *s = (jl_sym_t*)jl_fieldref(e,0);
-        jl_value_t *v = jl_get_global(jl_base_relative_to(jl_current_module),s);
+        jl_value_t *v = jl_get_global(jl_base_relative_to(mod),s);
         if (v == NULL)
             jl_undefined_var_error(s);
         return v;
@@ -181,15 +289,16 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
             jl_lineno = jl_linenode_line(e);
         }
         if (jl_is_newvarnode(e)) {
-            jl_value_t *var = jl_fieldref(e,0);
+            // TODO enable again when frontend bug(?) fixed
+            /*jl_value_t *var = jl_fieldref(e,0);
             assert(!jl_is_gensym(var));
             assert(jl_is_symbol(var));
-            for(size_t i=0; i < nl; i++) {
-                if (locals[i*2] == var) {
-                    locals[i*2+1] = NULL;
+            for(size_t i=0; i < s.nl; i++) {
+                if (s.locals[i*2] == var) {
+                    s.locals[i*2+1] = NULL;
                     break;
                 }
-            }
+                }*/
             return (jl_value_t*)jl_nothing;
         }
         return e;
@@ -198,28 +307,28 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
     jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
     size_t nargs = jl_array_len(ex->args);
     if (ex->head == call_sym) {
-        return do_call(args, nargs, locals, nl, ngensym, jl_interpret_calls);
+        return do_call(args, nargs, s);
     }
     else if (ex->head == assign_sym) {
         jl_value_t *sym = args[0];
-        jl_value_t *rhs = eval(args[1], locals, nl, ngensym);
+        jl_value_t *rhs = eval(args[1], s);
         if (jl_is_gensym(sym)) {
             ssize_t genid = ((jl_gensym_t*)sym)->id;
-            if (genid >= ngensym || genid < 0)
+            if (genid >= s.ngensym || genid < 0)
                 jl_error("assignment to invalid GenSym location");
-            locals[nl*2 + genid] = rhs;
+            s.locals[s.nl*2 + genid] = rhs;
             return rhs;
         }
         if (jl_is_symbol(sym)) {
             size_t i;
-            for (i=0; i < nl; i++) {
-                if (locals[i*2] == sym) {
-                    locals[i*2+1] = rhs;
+            for (i=0; i < s.nl; i++) {
+                if (s.locals[i*2] == sym) {
+                    s.locals[i*2+1] = rhs;
                     return rhs;
                 }
             }
         }
-        jl_module_t *m = jl_current_module;
+        jl_module_t *m = mod;
         if (jl_is_globalref(sym)) {
             m = jl_globalref_mod(sym);
             sym = (jl_value_t*)jl_globalref_name(sym);
@@ -232,13 +341,13 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         return rhs;
     }
     else if (ex->head == new_sym) {
-        jl_value_t *thetype = eval(args[0], locals, nl, ngensym);
+        jl_value_t *thetype = eval(args[0], s);
         jl_value_t *v=NULL;
         JL_GC_PUSH2(&thetype, &v);
         assert(jl_is_structtype(thetype));
         v = jl_new_struct_uninit((jl_datatype_t*)thetype);
         for(size_t i=1; i < nargs; i++) {
-            jl_set_nth_field(v, i-1, eval(args[i], locals, nl, ngensym));
+            jl_set_nth_field(v, i-1, eval(args[i], s));
         }
         JL_GC_POP();
         return v;
@@ -247,7 +356,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         return (jl_value_t*)jl_nothing;
     }
     else if (ex->head == body_sym) {
-        return eval_body(ex->args, locals, nl, ngensym, 0, 0);
+        return eval_body(ex->args, s, 0, 0);
     }
     else if (ex->head == exc_sym) {
         return jl_exception_in_transit;
@@ -263,16 +372,16 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
             jl_value_t **bp=NULL;
             jl_value_t *bp_owner=NULL;
             jl_binding_t *b=NULL;
-            for (size_t i=0; i < nl; i++) {
-                if (locals[i*2] == (jl_value_t*)fname) {
-                    bp = &locals[i*2+1];
+            for (size_t i=0; i < s.nl; i++) {
+                if (s.locals[i*2] == (jl_value_t*)fname) {
+                    bp = &s.locals[i*2+1];
                     break;
                 }
             }
             if (bp == NULL) {
-                b = jl_get_binding_for_method_def(jl_current_module, fname);
+                b = jl_get_binding_for_method_def(mod, fname);
                 bp = &b->value;
-                bp_owner = (jl_value_t*)jl_current_module;
+                bp_owner = (jl_value_t*)mod;
             }
             jl_value_t *gf = jl_generic_function_def(fname, bp, bp_owner, b);
             if (jl_expr_nargs(ex) == 1)
@@ -281,24 +390,24 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
 
         jl_value_t *atypes=NULL, *meth=NULL;
         JL_GC_PUSH2(&atypes, &meth);
-        atypes = eval(args[1], locals, nl, ngensym);
-        meth = eval(args[2], locals, nl, ngensym);
+        atypes = eval(args[1], s);
+        meth = eval(args[2], s);
         jl_method_def((jl_svec_t*)atypes, (jl_lambda_info_t*)meth, args[3]);
         JL_GC_POP();
         return jl_nothing;
     }
     else if (ex->head == copyast_sym) {
-        return jl_copy_ast(eval(args[0], locals, nl, ngensym));
+        return jl_copy_ast(eval(args[0], s));
     }
     else if (ex->head == const_sym) {
         jl_value_t *sym = args[0];
         assert(jl_is_symbol(sym));
-        for (size_t i=0; i < nl; i++) {
-            if (locals[i*2] == sym) {
+        for (size_t i=0; i < s.nl; i++) {
+            if (s.locals[i*2] == sym) {
                 return (jl_value_t*)jl_nothing;
             }
         }
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)sym);
+        jl_binding_t *b = jl_get_binding_wr(mod, (jl_sym_t*)sym);
         jl_declare_constant(b);
         return (jl_value_t*)jl_nothing;
     }
@@ -307,13 +416,13 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         // TODO: handle type decls
         for (size_t i=0; i < jl_array_len(ex->args); i++) {
             assert(jl_is_symbol(args[i]));
-            jl_get_binding_wr(jl_current_module, (jl_sym_t*)args[i]);
+            jl_get_binding_wr(mod, (jl_sym_t*)args[i]);
         }
         return (jl_value_t*)jl_nothing;
     }
     else if (ex->head == abstracttype_sym) {
         jl_value_t *name = args[0];
-        jl_value_t *para = eval(args[1], locals, nl, ngensym);
+        jl_value_t *para = eval(args[1], s);
         jl_value_t *super = NULL;
         jl_value_t *temp = NULL;
         jl_datatype_t *dt = NULL;
@@ -321,12 +430,12 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         assert(jl_is_svec(para));
         assert(jl_is_symbol(name));
         dt = jl_new_abstracttype(name, jl_any_type, (jl_svec_t*)para);
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
+        jl_binding_t *b = jl_get_binding_wr(mod, (jl_sym_t*)name);
         temp = b->value;
         check_can_assign_type(b);
         b->value = (jl_value_t*)dt;
         jl_gc_wb_binding(b, dt);
-        super = eval(args[2], locals, nl, ngensym);
+        super = eval(args[2], s);
         jl_set_datatype_super(dt, super);
         jl_reinstantiate_inner_types(dt);
         b->value = temp;
@@ -342,9 +451,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         jl_datatype_t *dt = NULL;
         JL_GC_PUSH4(&para, &super, &temp, &dt);
         assert(jl_is_symbol(name));
-        para = eval(args[1], locals, nl, ngensym);
+        para = eval(args[1], s);
         assert(jl_is_svec(para));
-        vnb  = eval(args[2], locals, nl, ngensym);
+        vnb  = eval(args[2], s);
         if (!jl_is_long(vnb))
             jl_errorf("invalid declaration of bits type %s",
                       jl_symbol_name((jl_sym_t*)name));
@@ -353,12 +462,12 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
             jl_errorf("invalid number of bits in type %s",
                       jl_symbol_name((jl_sym_t*)name));
         dt = jl_new_bitstype(name, jl_any_type, (jl_svec_t*)para, nb);
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
+        jl_binding_t *b = jl_get_binding_wr(mod, (jl_sym_t*)name);
         temp = b->value;
         check_can_assign_type(b);
         b->value = (jl_value_t*)dt;
         jl_gc_wb_binding(b, dt);
-        super = eval(args[3], locals, nl, ngensym);
+        super = eval(args[3], s);
         jl_set_datatype_super(dt, super);
         jl_reinstantiate_inner_types(dt);
         b->value = temp;
@@ -371,18 +480,18 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
     else if (ex->head == compositetype_sym) {
         jl_value_t *name = args[0];
         assert(jl_is_symbol(name));
-        jl_value_t *para = eval(args[1], locals, nl, ngensym);
+        jl_value_t *para = eval(args[1], s);
         assert(jl_is_svec(para));
         jl_value_t *temp = NULL;
         jl_value_t *super = NULL;
         jl_datatype_t *dt = NULL;
         JL_GC_PUSH4(&para, &super, &temp, &dt);
-        temp = eval(args[2], locals, nl, ngensym);  // field names
+        temp = eval(args[2], s);  // field names
         dt = jl_new_datatype((jl_sym_t*)name, jl_any_type, (jl_svec_t*)para,
                              (jl_svec_t*)temp, NULL,
                              0, args[5]==jl_true ? 1 : 0, jl_unbox_long(args[6]));
 
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
+        jl_binding_t *b = jl_get_binding_wr(mod, (jl_sym_t*)name);
         temp = b->value;  // save old value
         // temporarily assign so binding is available for field types
         check_can_assign_type(b);
@@ -390,11 +499,11 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         jl_gc_wb_binding(b,dt);
 
         JL_TRY {
-            super = eval(args[3], locals, nl, ngensym);
+            super = eval(args[3], s);
             jl_set_datatype_super(dt, super);
             // operations that can fail
             inside_typedef = 1;
-            dt->types = (jl_svec_t*)eval(args[4], locals, nl, ngensym);
+            dt->types = (jl_svec_t*)eval(args[4], s);
             jl_gc_wb(dt, dt->types);
             inside_typedef = 0;
             for(size_t i=0; i < jl_svec_len(dt->types); i++) {
@@ -494,13 +603,14 @@ jl_value_t *jl_toplevel_eval_body(jl_array_t *stmts)
     if (ngensym > 0) {
         JL_GC_PUSHARGS(locals, ngensym);
     }
-    jl_value_t *ret = eval_body(stmts, locals, 0, ngensym, 0, 1);
+    interpreter_state s = {.locals = locals, .nl = 0, .ngensym = ngensym, .mod = NULL };
+    jl_value_t *ret = eval_body(stmts, s, 0, 1);
     if (ngensym > 0)
         JL_GC_POP();
     return ret;
 }
 
-static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl, size_t ngensym,
+static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state s,
                              int start, int toplevel)
 {
     jl_handler_t __eh;
@@ -517,7 +627,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl, 
         if (jl_is_expr(stmt)) {
             jl_sym_t *head = ((jl_expr_t*)stmt)->head;
             if (head == goto_ifnot_sym) {
-                jl_value_t *cond = eval(jl_exprarg(stmt,0), locals, nl, ngensym);
+                jl_value_t *cond = eval(jl_exprarg(stmt,0), s);
                 if (cond == jl_false) {
                     i = label_idx(jl_unbox_long(jl_exprarg(stmt, 1)), stmts);
                     continue;
@@ -532,12 +642,12 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl, 
                 if (toplevel && jl_is_toplevel_only_expr(ex))
                     return jl_toplevel_eval(ex);
                 else
-                    return eval(ex, locals, nl, ngensym);
+                    return eval(ex, s);
             }
             else if (head == enter_sym) {
                 jl_enter_handler(&__eh);
                 if (!jl_setjmp(__eh.eh_ctx,1)) {
-                    return eval_body(stmts, locals, nl, ngensym, i+1, toplevel);
+                    return eval_body(stmts, s, i+1, toplevel);
                 }
                 else {
 #ifdef _OS_WINDOWS_
@@ -556,14 +666,14 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl, 
                 if (toplevel && jl_is_toplevel_only_expr(stmt))
                     jl_toplevel_eval(stmt);
                 else
-                    eval(stmt, locals, nl, ngensym);
+                    eval(stmt, s);
             }
         }
         else {
             if (toplevel && jl_is_toplevel_only_expr(stmt))
                 jl_toplevel_eval(stmt);
             else
-                eval(stmt, locals, nl, ngensym);
+                eval(stmt, s);
         }
         i++;
     }
@@ -571,37 +681,68 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl, 
     return NULL;
 }
 
-jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
-                                             jl_value_t **loc, size_t nl)
+jl_value_t *jl_interpret_call(jl_lambda_info_t *lam,
+                              jl_value_t **args, size_t nargs,
+                              jl_value_t **sparam_vals,
+                              int toplevel)
 {
     jl_expr_t *ast = (jl_expr_t*)lam->ast;
+    JL_GC_PUSH1(&ast)
+    if (!jl_is_expr(ast))
+        ast = jl_uncompress_ast(lam, ast);
     jl_array_t *stmts = jl_lam_body(ast)->args;
-    size_t nargs = jl_array_len(jl_lam_args(ast));
+    jl_array_t *formals = jl_lam_args(ast);
+    size_t nformals = jl_array_len(formals);
     jl_array_t *l = jl_lam_vinfo(ast);
-    size_t llength = jl_array_len(l) - nargs;
-    nl += llength;
+    size_t nl = jl_array_len(l);
     jl_value_t **locals;
     jl_value_t *gensym_types = jl_lam_gensyms(ast);
     size_t ngensym = (jl_is_array(gensym_types) ? jl_array_len(gensym_types) : jl_unbox_gensym(gensym_types));
-    JL_GC_PUSHARGS(locals, nl*2+ngensym);
+    size_t n_sparam = jl_svec_len(lam->sparam_syms);
+    JL_GC_PUSHARGS(locals, 2*nl + 2*n_sparam + ngensym);
     jl_value_t *r = (jl_value_t*)jl_nothing;
     size_t i=0;
-    for(i=0; i < llength; i++) {
-        locals[i*2]   = jl_cellref(jl_cellref(l,i+nargs),0);
+    size_t used_l = 0;
+    // passed arguments
+    for(; i < nformals; i++) {
+        if (used_l >= nl)
+            break;
+        jl_value_t *local_name = jl_cellref(jl_cellref(l, used_l),0);
+        jl_value_t *formal = jl_cellref(formals, i);
+        jl_value_t *formal_name = jl_decl_var(formal);
+        assert(jl_is_symbol(local_name) && jl_is_symbol(formal_name));
+        if (formal_name != local_name) {
+            // parameter unused so has not slot in the frame
+            continue;
+        }
+        locals[used_l*2] = local_name;
+        if (jl_is_rest_arg(formal)) {
+            assert(i == nformals - 1);
+            locals[used_l*2+1] = jl_f_tuple(NULL, &args[i], nargs - i);
+        } else {
+            locals[used_l*2+1] = args[i];
+        }
+        used_l++;
+    }
+    // locals
+    for(i = used_l; i < nl; i++) {
+        locals[i*2]   = jl_cellref(jl_cellref(l,i),0);
         //locals[i*2+1] = NULL;   // init'd by JL_GC_PUSHARGS
     }
-    for(; i < nl; i++) {
-        locals[i*2]   = loc[(i-llength)*2];
-        locals[i*2+1] = loc[(i-llength)*2+1];
+    for(i = 0; i < n_sparam; i++) {
+        locals[(nl+i)*2] = jl_svecref(lam->sparam_syms, i);
+        locals[(nl+i)*2 + 1] = jl_svecref(sparam_vals, i);
     }
-    r = eval_body(stmts, locals, nl, ngensym, 0, 1);
+    interpreter_state s = { .locals = locals, .nl = nl + n_sparam, .ngensym = ngensym, .mod = lam->module };
+    r = eval_body(stmts, s, 0, toplevel);
+    JL_GC_POP();
     JL_GC_POP();
     return r;
 }
 
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam)
 {
-    return jl_interpret_toplevel_thunk_with(lam, NULL, 0);
+    return jl_interpret_call(lam, NULL, 0, NULL, 1);
 }
 
 #ifdef __cplusplus

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -196,7 +196,7 @@ jl_value_t *jl_mk_builtin_func(const char *name, jl_fptr_t fptr);
 #ifdef __cplusplus
 extern "C"
 #endif
-void jl_init_intrinsic_functions()
+void jl_init_intrinsic_functions(void)
 {
     jl_module_t *inm = jl_new_module(jl_symbol("Intrinsics"));
     inm->parent = jl_core_module;
@@ -213,4 +213,20 @@ void jl_init_intrinsic_functions()
 
     jl_set_const(inm, jl_symbol("intrinsic_call"),
                  jl_mk_builtin_func("intrinsic_call", jl_f_intrinsic_call));
+}
+
+#ifdef __cplusplus
+extern "C"
+#endif
+void jl_restore_intrinsic_tables(void)
+{
+#define ADD_I(name, nargs) add_intrinsic_properties(name, nargs, (void*)&jl_##name);
+#define ADD_HIDDEN(name, nargs) add_intrinsic_properties(name, nargs, (void*)&jl_##name);
+#define ALIAS(alias, base) add_intrinsic_properties(alias, intrinsic_nargs[base], runtime_fp[base]);
+    ADD_HIDDEN(reinterpret, 2);
+    INTRINSICS
+#undef ADD_I
+#undef ADD_HIDDEN
+#undef ALIAS
+
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1369,7 +1369,7 @@ STATIC_INLINE int jl_vinfo_usedundef(jl_array_t *vi)
 // calling into julia ---------------------------------------------------------
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs);
-
+JL_DLLEXPORT extern int jl_interpret_calls;
 STATIC_INLINE
 jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)
 {

--- a/src/julia.h
+++ b/src/julia.h
@@ -581,6 +581,8 @@ extern JL_DLLEXPORT jl_value_t *jl_true;
 extern JL_DLLEXPORT jl_value_t *jl_false;
 extern JL_DLLEXPORT jl_value_t *jl_nothing;
 
+extern JL_DLLEXPORT jl_value_t *jl_generic_ccall;
+
 // some important symbols
 extern jl_sym_t *call_sym;
 extern jl_sym_t *dots_sym;    extern jl_sym_t *vararg_sym;
@@ -1369,7 +1371,9 @@ STATIC_INLINE int jl_vinfo_usedundef(jl_array_t *vi)
 // calling into julia ---------------------------------------------------------
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs);
-JL_DLLEXPORT extern int jl_interpret_calls;
+JL_DLLEXPORT jl_value_t *jl_apply_interpreted(jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_apply_generic_ex(jl_value_t **args, uint32_t nargs, int can_interpret);
+JL_DLLEXPORT extern int jl_interpreter_enabled;
 STATIC_INLINE
 jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -182,8 +182,10 @@ jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
 jl_value_t *jl_parse_eval_all(const char *fname, size_t len,
                               const char *content, size_t contentlen);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
-jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
-                                             jl_value_t **loc, size_t nl);
+jl_value_t *jl_interpret_call(jl_lambda_info_t *lam,
+                              jl_value_t **args, size_t nargs,
+                              jl_value_t **sparam_vals,
+                              int toplevel);
 jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e);
 jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
                            jl_lambda_info_t *li, int sparams, int allow_alloc);
@@ -231,6 +233,7 @@ void jl_init_frontend(void);
 void jl_init_primitives(void);
 void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
+void jl_restore_intrinsic_tables(void);
 void jl_init_tasks(void);
 void jl_init_stack_limits(int ismaster);
 void jl_init_root_task(void *stack, size_t ssize);
@@ -327,6 +330,8 @@ void *jl_get_library(const char *f_lib);
 JL_DLLEXPORT void *jl_load_and_lookup(const char *f_lib, const char *f_name,
                                       void **hnd);
 const char *jl_dlfind_win32(const char *name);
+
+JL_DLLEXPORT jl_value_t *jl_native_sym(jl_value_t *ptr, jl_value_t *ty);
 
 // libuv wrappers:
 JL_DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -153,6 +153,8 @@ jl_lambda_info_t *jl_method_cache_insert(jl_methtable_t *mt, jl_tupletype_t *typ
 jl_methlist_t *jl_method_table_insert(jl_methtable_t *mt, jl_tupletype_t *type,
                                       jl_lambda_info_t *method, jl_svec_t *tvars,
                                       int8_t isstaged);
+jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt, int cache, int inexact);
+jl_lambda_info_t *jl_method_table_assoc_exact(jl_methtable_t *mt, jl_value_t **args, size_t n);
 int jl_is_type(jl_value_t *v);
 jl_value_t *jl_type_intersection_matching(jl_value_t *a, jl_value_t *b,
                                           jl_svec_t **penv, jl_svec_t *tvars);


### PR DESCRIPTION
Make the interpreter able to handle a lot more julia including function calls, ccalls and a couple more intrinsics. It still makes functions go through inference which is unnecessary but was easier for now.

The way I handle ccall (in particular &ref arguments) is either cute or gore depending on your particular fetishes.

There is a weird thing the frontend does where it emits undefvar nodes for arguments (see Dict's setindex!), it may be a bug.

That being said, it's close to getting a REPL in full interpreted mode, except of course that it cannot handle type_goto (I'm gonna wait for this to go away) and generates compiled little stubs for ccalls (one per signature).

Oh and it's super slow obviously.

@JeffBezanson 
