### PR TITLE
GC debugging tweaks

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -144,6 +144,7 @@ JL_DLLEXPORT void __stack_chk_fail()
 {
     /* put your panic function or similar in here */
     fprintf(stderr, "fatal error: stack corruption detected\n");
+    gc_debug_critical_error();
     abort(); // end with abort, since the compiler destroyed the stack upon entry to this function, there's no going back now
 }
 #endif
@@ -895,6 +896,7 @@ static Function *to_function(jl_lambda_info_t *li, jl_cyclectx_t *cyclectx)
         (specf && verifyFunction(*specf, PrintMessageAction))) {
         f->dump();
         if (specf) specf->dump();
+        gc_debug_critical_error();
         abort();
     }
 #endif
@@ -992,6 +994,7 @@ static void writeRecoveryFile(llvm::Module *mod)
     raw_fd_ostream OS(fname_ref, err, sys::fs::F_None);
     WriteBitcodeToFile(mod,OS);
     OS.flush();
+    gc_debug_critical_error();
     abort();
 }
 #endif

--- a/src/gc.c
+++ b/src/gc.c
@@ -389,6 +389,7 @@ void jl_gc_signal_init(void)
 #endif
     if (jl_gc_signal_page == NULL) {
         jl_printf(JL_STDERR, "could not allocate GC synchronization page\n");
+        gc_debug_critical_error();
         abort();
     }
 }
@@ -856,6 +857,7 @@ static NOINLINE void *malloc_page(void)
 #endif
             if (mem == NULL) {
                 jl_printf(JL_STDERR, "could not allocate pools\n");
+                gc_debug_critical_error();
                 abort();
             }
             if (GC_PAGE_SZ > jl_page_size) {
@@ -886,6 +888,7 @@ static NOINLINE void *malloc_page(void)
     }
     if (region_i >= REGION_COUNT) {
         jl_printf(JL_STDERR, "increase REGION_COUNT or allocate less memory\n");
+        gc_debug_critical_error();
         abort();
     }
     if (regions_lb[region_i] < i)
@@ -1951,6 +1954,7 @@ static int push_root(jl_value_t *v, int d, int bits)
         jl_printf(JL_STDOUT, "GC error (probable corruption) :\n");
         gc_debug_print_status();
         jl_(vt);
+        gc_debug_critical_error();
         abort();
     }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -1384,6 +1384,7 @@ void JL_NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args)
         jl_printf((JL_STREAM*)STDERR_FILENO, "A method error occurred before the base module was defined. Aborting...\n");
         jl_static_show((JL_STREAM*)STDERR_FILENO,(jl_value_t*)f); jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
         jl_static_show((JL_STREAM*)STDERR_FILENO,args); jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
+        gc_debug_critical_error();
         abort();
     }
     // not reached

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -171,6 +171,7 @@ JL_CALLABLE(jl_f_intrinsic_call)
         default:
             assert(0 && "unexpected number of arguments to an intrinsic function");
     }
+    gc_debug_critical_error();
     abort();
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -5,6 +5,12 @@
 
 #include <options.h>
 #include <uv.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#include <sched.h>
+#else
+#define sleep(x) Sleep(1000*x)
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,11 +103,8 @@ static inline void jl_gc_wb_buf(void *parent, void *bufptr) // parent isa jl_val
         gc_setmark_buf(bufptr, jl_astaggedvalue(parent)->gc_bits);
 }
 
-#ifdef GC_DEBUG_ENV
 void gc_debug_print_status(void);
-#else
-#define gc_debug_print_status()
-#endif
+void gc_debug_critical_error(void);
 #if defined(GC_FINAL_STATS)
 void jl_print_gc_stats(JL_STREAM *s);
 #else

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -59,6 +59,7 @@ static void jl_critical_error(int sig, bt_context_t context, intptr_t *bt_data, 
     for(size_t i=0; i < n; i++)
         jl_gdblookup(bt_data[i]);
     gc_debug_print_status();
+    gc_debug_critical_error();
 }
 
 ///////////////////////

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -306,6 +306,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
             bt_size_cur++;
             if ((DWORD)-1 == ResumeThread(hMainThread)) {
                 fputs("failed to resume main thread! aborting.",stderr);
+                gc_debug_critical_error();
                 abort();
             }
         }

--- a/src/task.c
+++ b/src/task.c
@@ -209,6 +209,7 @@ static void JL_NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
         // For now, only thread 0 runs the task scheduler.
         // The others return to the thread loop
         jl_switchto(jl_root_task, jl_nothing);
+        gc_debug_critical_error();
         abort();
     }
     if (task_done_hook_func == NULL) {
@@ -219,6 +220,7 @@ static void JL_NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
         jl_value_t *args[2] = {task_done_hook_func, (jl_value_t*)t};
         jl_apply(args, 2);
     }
+    gc_debug_critical_error();
     abort();
 }
 
@@ -253,6 +255,7 @@ static void NOINLINE JL_NORETURN start_task(void)
         }
     }
     finish_task(t, res);
+    gc_debug_critical_error();
     abort();
 }
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -18,12 +18,6 @@ TODO:
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#include <sched.h>
-#else
-#define sleep(x) Sleep(1000*x)
-#endif
 
 #include "julia.h"
 #include "julia_internal.h"


### PR DESCRIPTION
- Rename `JL_*` envs to `JULIA_*`
- Enable GC status printing for non-gc-debug build when there's a crash that is likely related to GC. (SegFault, type tag corruption)
- Add an env to put the process to sleep before aborting so that one can attach a debugger later. This doesn't cover all the abort and assertions but should handle most of them.
