### PR TITLE
define length(::Pair), fixes #14924

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -528,6 +528,7 @@ getindex(p::Pair,i::Real) = getfield(p, convert(Int, i))
 reverse{A,B}(p::Pair{A,B}) = Pair{B,A}(p.second, p.first)
 
 endof(p::Pair) = 2
+length(p::Pair) = 2
 
 # some operators not defined yet
 global //, >:, <|, hcat, hvcat, ⋅, ×, ∈, ∉, ∋, ∌, ⊆, ⊈, ⊊, ∩, ∪, √, ∛

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -10,6 +10,7 @@ p = Pair(1,2)
 @test !done(p,2)
 @test done(p,3)
 @test !done(p,0)
+@test endof(p) == length(p) == 2
 @test Base.indexed_next(p, 1, (1,2)) == (1,2)
 @test Base.indexed_next(p, 2, (1,2)) == (2,3)
 @test (1=>2) < (2=>3)


### PR DESCRIPTION
Just the trivial `length(::Pair) = 2` definition and a test, for #14924.
