### PR TITLE
improved Dict filtering

### DIFF
--- a/test/dict.jl
+++ b/test/dict.jl
@@ -439,3 +439,10 @@ let d = ImmutableDict{UTF8String, UTF8String}(),
     @test_throws KeyError d[k1]
     @test_throws KeyError d1["key2"]
 end
+
+# filtering
+let d = Dict(zip(1:1000,1:1000)), f = (k,v) -> iseven(k)
+    @test filter(f, d) == filter!(f, copy(d)) ==
+          invoke(filter!, (Function, Associative), f, copy(d)) ==
+          Dict(zip(2:2:1000, 2:2:1000))
+end


### PR DESCRIPTION
This patch contains two improvements to `filter` for `Associative` types:
- `filter(f, d)` no longer calls `filter!(f, copy(d))` — it makes only a single pass over `d` rather than making a compete copy first.
- `filter!(f, d::Associative)` no longer assumes that it is safe to mutate `d` during iteration.  This is unlikely to be true for generic user-defined associative types, e.g. it is not true for Python dictionaries as discussed in stevengj/PyCall.jl#227.  It appears to be safe for `Dict`, `ObjectIdDict`, and `WeakKeyDict`, however, so I still use the old mutating implementation for those types.
