### PR TITLE
support inv(::Diagonal) for integer elements

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -181,7 +181,7 @@ end
 (\)(Da::Diagonal, Db::Diagonal) = Diagonal(Db.diag ./ Da.diag)
 
 function inv{T}(D::Diagonal{T})
-    Di = similar(D.diag)
+    Di = similar(D.diag, typeof(inv(zero(T))))
     for i = 1:length(D.diag)
         if D.diag[i] == zero(T)
             throw(SingularException(i))
@@ -192,14 +192,14 @@ function inv{T}(D::Diagonal{T})
 end
 
 function pinv{T}(D::Diagonal{T})
-    Di = similar(D.diag)
+    Di = similar(D.diag, typeof(inv(zero(T))))
     for i = 1:length(D.diag)
         isfinite(inv(D.diag[i])) ? Di[i]=inv(D.diag[i]) : Di[i]=zero(T)
     end
     Diagonal(Di)
 end
 function pinv{T}(D::Diagonal{T}, tol::Real)
-    Di = similar(D.diag)
+    Di = similar(D.diag, typeof(inv(zero(T))))
     if( !isempty(D.diag) ) maxabsD = maximum(abs(D.diag)) end
     for i = 1:length(D.diag)
         if( abs(D.diag[i]) > tol*maxabsD && isfinite(inv(D.diag[i])) )

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -210,10 +210,13 @@ let d = randn(n), D = Diagonal(d)
 end
 
 # inv
-let d = randn(n), D = Diagonal(d)
+for d in (randn(n), [1, 2, 3], [1im, 2im, 3im])
+    D = Diagonal(d)
     @test inv(D) ≈ inv(full(D))
 end
 @test_throws SingularException inv(Diagonal(zeros(n)))
+@test_throws SingularException inv(Diagonal([0, 1, 2]))
+@test_throws SingularException inv(Diagonal([0im, 1im, 2im]))
 
 # allow construct from range
 @test Diagonal(linspace(1,3,3)) == Diagonal([1.,2.,3.])


### PR DESCRIPTION
This fixes a problem that `inv(Diagonal([1,2,3]))` throws an `InexactError` exception. Please see the example below and tests:

``` julia
julia> inv(Diagonal([1,2,3]))
3x3 Diagonal{Float64}:
 1.0   ⋅    ⋅
  ⋅   0.5   ⋅
  ⋅    ⋅   0.333333

julia> inv(Diagonal([1,2,3])) ≈ inv(diagm([1,2,3]))
true

# also supports Diagonal(::Complex{Int})
julia> inv(Diagonal([1im,2+im,3+3im])) ≈ inv(diagm([1im,2+im,3+3im]))
true

```

Inversion of diagonal arrays of integer elements is converted to arrays of `Float64` elements. This follows the behavior of `inv(::Matrix{Int})`.
