### PR TITLE
Allow combining pushmeta-based macros.

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -117,11 +117,17 @@ function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
     else
         tag = Expr(sym, args...)
     end
-    idx, exargs = findmeta(ex)
+
+    inner = ex
+    while inner.head == :macrocall
+        inner = inner.args[end]::Expr
+    end
+
+    idx, exargs = findmeta(inner)
     if idx != 0
         push!(exargs[idx].args, tag)
     else
-        body::Expr = ex.args[2]
+        body::Expr = inner.args[2]
         unshift!(body.args, Expr(:meta, tag))
     end
     ex

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -100,6 +100,23 @@ for m in [:foo1, :foo2, :foo3, :foo4, :foo5]
 end
 @test Base.findmeta(multi_meta.args)[1] == 0
 
+# Test that pushmeta! can push across other macros,
+# in the case multiple pushmeta!-based macros are combined
+
+@attach 40 @attach 41 @attach 42 dummy_multi() = return nothing
+
+asts = code_lowered(dummy_multi, Tuple{})
+@test length(asts) == 1
+ast = asts[1]
+
+body = Expr(:block)
+body.args = Base.uncompressed_ast(ast)
+
+@test popmeta!(body, :test) == (true, [40])
+@test popmeta!(body, :test) == (true, [41])
+@test popmeta!(body, :test) == (true, [42])
+@test popmeta!(body, :nonexistent) == (false, [])
+
 end
 
 


### PR DESCRIPTION
Combining pushmeta-based macros on a function currently fails in `pushmeta->findmeta` with the following error:

```
julia> Base.@pure @inline foo() = return nothing
ERROR: @inline foo() = begin 
            $(Expr(:line, 1, :none))
            return nothing
        end is not a function expression
 in eval(::Module, ::Any) at ./boot.jl:268
```

Expanding macros before calling `pushmeta` fixes this.
