### PR TITLE
Document import/using's effect on Main

### DIFF
--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -251,6 +251,19 @@ A variable can be "reserved" for the current module without assigning to
 it by declaring it as ``global x`` at the top level. This can be used to
 prevent name conflicts for globals initialized after load time.
 
+The ``using`` and ``import`` statements always bring their target modules
+into the ``Main`` namespace, in addition to their current context. For
+example, given the module definition ::
+
+    module A
+
+    import Lib
+    ...
+
+    end
+
+the statement ``using A`` brings ``Lib`` into the ``Main`` namespace.
+
 .. _man-modules-initialization-precompilation:
 
 Module initialization and precompilation


### PR DESCRIPTION
This adds a blurb to the manual under "Modules" > "Namespace miscellanea" explaining that `using` or `import` always make their target available in `Main`, regardless of where they are used.

I'm not sure this is exactly the best place for this, but it caught me off guard and wasn't obvious to me from reading the Module chapter as is.

Clarifications welcome!
