### PR TITLE
Replace unsafe_(get|set)index with inbounds macro

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -9,7 +9,7 @@ import Base: USE_BLAS64, abs, big, ceil, conj, convert, copy, copy!, copy_transp
     ctranspose, ctranspose!, eltype, eye, findmax, findmin, fill!, floor, full, getindex,
     imag, inv, isapprox, kron, ndims, parent, power_by_squaring, print_matrix,
     promote_rule, real, round, setindex!, show, similar, size, transpose, transpose!,
-    trunc, unsafe_getindex, unsafe_setindex!
+    trunc
 using Base: promote_op, MulFun
 
 export

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -23,10 +23,16 @@ typealias HermOrSym{T,S} Union{Hermitian{T,S}, Symmetric{T,S}}
 typealias RealHermSymComplexHerm{T<:Real,S} Union{Hermitian{T,S}, Symmetric{T,S}, Hermitian{Complex{T},S}}
 
 size(A::HermOrSym, args...) = size(A.data, args...)
-getindex(A::Symmetric, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.data, i, j) : getindex(A.data, j, i)
-getindex(A::Hermitian, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.data, i, j) : conj(getindex(A.data, j, i))
-unsafe_getindex(A::Symmetric, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? unsafe_getindex(A.data, i, j) : unsafe_getindex(A.data, j, i)
-unsafe_getindex(A::Hermitian, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? unsafe_getindex(A.data, i, j) : conj(unsafe_getindex(A.data, j, i))
+@inline function getindex(A::Symmetric, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
+    @inbounds r = (A.uplo == 'U') == (i < j) ? A.data[i, j] : A.data[j, i]
+    r
+end
+@inline function getindex(A::Hermitian, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
+    @inbounds r = (A.uplo == 'U') == (i < j) ? A.data[i, j] : conj(A.data[j, i])
+    r
+end
 full(A::Symmetric) = copytri!(copy(A.data), A.uplo)
 full(A::Hermitian) = copytri!(copy(A.data), A.uplo, true)
 parent(A::HermOrSym) = A.data

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -177,12 +177,12 @@ index_shape_dim(A, dim, ::Colon) = (trailingsize(A, dim),)
 @inline index_shape_dim(A, dim, i::AbstractVector, I...) = (length(i), index_shape_dim(A, dim+1, I...)...)
 
 ### From abstractarray.jl: Internal multidimensional indexing definitions ###
-# These are not defined on directly ongetindex and unsafe_getindex to avoid
+# These are not defined on directly on getindex to avoid
 # ambiguities for AbstractArray subtypes. See the note in abstractarray.jl
 
 # Note that it's most efficient to call checkbounds first, and then to_index
 @inline function _getindex(l::LinearIndexing, A::AbstractArray, I::Union{Real, AbstractArray, Colon}...)
-    checkbounds(A, I...)
+    @boundscheck checkbounds(A, I...)
     _unsafe_getindex(l, A, I...)
 end
 @generated function _unsafe_getindex(::LinearIndexing, A::AbstractArray, I::Union{Real, AbstractArray, Colon}...)
@@ -207,11 +207,11 @@ function _unsafe_getindex(::LinearIndexing, src::AbstractArray, I::AbstractArray
     D = eachindex(dest)
     Ds = start(D)
     s = 0
-    for b in eachindex(I)
+    @inbounds for b in eachindex(I)
         s+=1
-        if unsafe_getindex(I, b)
+        if I[b]
             d, Ds = next(D, Ds)
-            unsafe_setindex!(dest, unsafe_getindex(src, s), d)
+            dest[d] = src[s]
         end
     end
     dest
@@ -222,9 +222,9 @@ end
 @inline function _unsafe_getindex!(dest::AbstractArray, src::AbstractArray, I::AbstractArray)
     D = eachindex(dest)
     Ds = start(D)
-    for idx in I
+    @inbounds for idx in I
         d, Ds = next(D, Ds)
-        unsafe_setindex!(dest, unsafe_getindex(src, idx), d)
+        dest[d] = src[idx]
     end
     dest
 end
@@ -237,10 +237,10 @@ end
         D = eachindex(dest)
         Ds = start(D)
         idxlens = index_lengths(src, I...) # TODO: unsplat?
-        @nloops $N i d->(1:idxlens[d]) d->(j_d = unsafe_getindex(I[d], i_d)) begin
+        @inbounds @nloops $N i d->(1:idxlens[d]) d->(j_d = getindex(I[d], i_d)) begin
             d, Ds = next(D, Ds)
-            v = @ncall $N unsafe_getindex src j
-            unsafe_setindex!(dest, v, d)
+            v = @ncall $N getindex src j
+            dest[d] = v
         end
         dest
     end
@@ -267,9 +267,6 @@ end
     _checksize(A, dim+1, J...)
 end
 
-@inline unsafe_setindex!(v::BitArray, x::Bool, ind::Int) = (Base.unsafe_bitsetindex!(v.chunks, x, ind); v)
-@inline unsafe_setindex!(v::BitArray, x, ind::Real) = (Base.unsafe_bitsetindex!(v.chunks, convert(Bool, x), to_index(ind)); v)
-
 ## setindex! ##
 # For multi-element setindex!, we check bounds, convert the indices (to_index),
 # and ensure the value to set is either an AbstractArray or a Repeated scalar
@@ -277,7 +274,7 @@ end
 _iterable(v::AbstractArray) = v
 _iterable(v) = repeated(v)
 @inline function _setindex!(l::LinearIndexing, A::AbstractArray, x, J::Union{Real,AbstractArray,Colon}...)
-    checkbounds(A, J...)
+    @boundscheck checkbounds(A, J...)
     _unsafe_setindex!(l, A, x, J...)
 end
 @inline function _unsafe_setindex!(::LinearIndexing, A::AbstractArray, x, J::Union{Real,AbstractArray,Colon}...)
@@ -292,10 +289,10 @@ function _unsafe_setindex!(::LinearIndexing, A::AbstractArray, x, I::AbstractArr
     c = 0
     for b in eachindex(I)
         i+=1
-        if unsafe_getindex(I, b)
+        @inbounds if I[b]
             done(X, Xs) && throw_setindex_mismatch(x, c+1)
             (v, Xs) = next(X, Xs)
-            unsafe_setindex!(A, v, i)
+            A[i] = v
             c += 1
         end
     end
@@ -310,9 +307,9 @@ end
         idxlens = @ncall $N index_lengths A I
         @ncall $N setindex_shape_check X (d->idxlens[d])
         Xs = start(X)
-        @nloops $N i d->(1:idxlens[d]) d->(j_d = unsafe_getindex(I_d, i_d)) begin
+        @inbounds @nloops $N i d->(1:idxlens[d]) d->(@inbounds j_d = I_d[i_d]) begin
             v, Xs = next(X, Xs)
-            @ncall $N unsafe_setindex! A v j
+            @ncall $N setindex! A v j
         end
         A
     end
@@ -336,16 +333,10 @@ function cartindex_exprs(indexes, syms)
     exprs
 end
 @generated function _getindex{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
-    :($(Expr(:meta, :inline)); getindex(A, $(cartindex_exprs(I, :I)...)))
-end
-@generated function _unsafe_getindex{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
-    :($(Expr(:meta, :inline)); unsafe_getindex(A, $(cartindex_exprs(I, :I)...)))
+    :(@_propagate_inbounds_meta; getindex(A, $(cartindex_exprs(I, :I)...)))
 end
 @generated function _setindex!{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, v, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
-    :($(Expr(:meta, :inline)); setindex!(A, v, $(cartindex_exprs(I, :I)...)))
-end
-@generated function _unsafe_setindex!{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, v, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
-    :($(Expr(:meta, :inline)); unsafe_setindex!(A, v, $(cartindex_exprs(I, :I)...)))
+    :(@_propagate_inbounds_meta; setindex!(A, v, $(cartindex_exprs(I, :I)...)))
 end
 
 
@@ -473,9 +464,9 @@ end
             Base.Cartesian.@nexprs $N d->(d < $N ?
                 begin
                     c, k = divrem(k, Istride_{$N-d+1})
-                    j += (Base.unsafe_getindex(I_{$N-d+1}, c+1)-1)*Pstride_{$N-d+1}
+                    @inbounds j += (getindex(I_{$N-d+1}, c+1)-1)*Pstride_{$N-d+1}
                 end : begin
-                    j += Base.unsafe_getindex(I_1, k+1)
+                    @inbounds j += I_1[k+1]
                 end)
             index[i] = j
         end
@@ -616,7 +607,7 @@ end
         ind = 0
         Xc, Bc = X.chunks, B.chunks
         idxlens = index_lengths(B, I...) # TODO: unsplat?
-        @nloops $N i d->(1:idxlens[d]) d->(offset_{d-1} = offset_d + (unsafe_getindex(I[d], i_d)-1)*stride_d) begin
+        @inbounds @nloops $N i d->(1:idxlens[d]) d->(offset_{d-1} = offset_d + (getindex(I[d], i_d)-1)*stride_d) begin
             ind += 1
             unsafe_bitsetindex!(Xc, unsafe_bitgetindex(Bc, offset_0), ind)
         end
@@ -629,15 +620,18 @@ end
 # contiguous multidimensional indexing: if the first dimension is a range,
 # we can get some performance from using copy_chunks!
 
-function unsafe_setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int})
+@inline function setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int})
+    @boundscheck checkbounds(B, I0)
     l0 = length(I0)
+    setindex_shape_check(X, l0)
     l0 == 0 && return B
     f0 = first(I0)
     copy_chunks!(B.chunks, f0, X.chunks, 1, l0)
     return B
 end
 
-function unsafe_setindex!(B::BitArray, x::Bool, I0::UnitRange{Int})
+@inline function setindex!(B::BitArray, x::Bool, I0::UnitRange{Int})
+    @boundscheck checkbounds(B, I0)
     l0 = length(I0)
     l0 == 0 && return B
     f0 = first(I0)
@@ -645,9 +639,14 @@ function unsafe_setindex!(B::BitArray, x::Bool, I0::UnitRange{Int})
     return B
 end
 
-@generated function unsafe_setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@inline function setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+    @boundscheck checkbounds(B, I0, I...)
+    _unsafe_setindex!(B, X, I0, I...)
+end
+@generated function _unsafe_setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
     N = length(I)
     quote
+        # TODO: need to setindex_shape_check
         isempty(X) && return B
         f0 = first(I0)
         l0 = length(I0)
@@ -676,7 +675,11 @@ end
     end
 end
 
-@generated function unsafe_setindex!(B::BitArray, x::Bool, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@inline function setindex!(B::BitArray, x::Bool, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+    @boundscheck checkbounds(B, I0, I...)
+    _unsafe_setindex!(B, x, I0, I...)
+end
+@generated function _unsafe_setindex!(B::BitArray, x::Bool, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
     N = length(I)
     quote
         f0 = first(I0)

--- a/base/number.jl
+++ b/base/number.jl
@@ -12,10 +12,17 @@ ndims{T<:Number}(::Type{T}) = 0
 length(x::Number) = 1
 endof(x::Number) = 1
 getindex(x::Number) = x
-getindex(x::Number, i::Integer) = i == 1 ? x : throw(BoundsError())
-getindex(x::Number, I::Integer...) = all([i == 1 for i in I]) ? x : throw(BoundsError())
+function getindex(x::Number, i::Integer)
+    @_inline_meta
+    @boundscheck i == 1 || throw(BoundsError())
+    x
+end
+function getindex(x::Number, I::Integer...)
+    @_inline_meta
+    @boundscheck all([i == 1 for i in I]) || throw(BoundsError())
+    x
+end
 getindex(x::Number, I::Real...) = getindex(x, to_indexes(I...)...)
-unsafe_getindex(x::Real, i::Real) = x
 first(x::Number) = x
 last(x::Number) = x
 

--- a/base/primes.jl
+++ b/base/primes.jl
@@ -65,7 +65,7 @@ function primesmask(lo::Int, hi::Int)
     lsi = lo - 1
     lwi = wheel_index(lsi)
     @inbounds for i in eachindex(wheel_sieve)
-        Base.unsafe_setindex!(sieve, wheel_sieve[i], wheel_prime(i + lwi) - lsi)
+        sieve[wheel_prime(i + lwi) - lsi] = wheel_sieve[i]
     end
     return sieve
 end

--- a/base/range.jl
+++ b/base/range.jl
@@ -413,46 +413,61 @@ end
 
 ## indexing
 
-getindex(r::Range, i::Integer) = (checkbounds(r, i); unsafe_getindex(r, i))
-unsafe_getindex{T}(v::Range{T}, i::Integer) = convert(T, first(v) + (i-1)*step(v))
-unsafe_getindex{T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32}}(v::Range{T},
-                                                                i::Integer) =
+function getindex{T}(v::Range{T}, i::Integer)
+    @_inline_meta
+    @boundscheck checkbounds(v, i)
+    convert(T, first(v) + (i-1)*step(v))
+end
+function getindex{T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32}}(v::Range{T},i::Integer)
+    @_inline_meta
+    @boundscheck checkbounds(v, i)
     (first(v) + (i - 1) * step(v)) % T
+end
 
-getindex{T}(r::FloatRange{T}, i::Integer) = (checkbounds(r, i); unsafe_getindex(r, i))
-unsafe_getindex{T}(r::FloatRange{T}, i::Integer) = convert(T, (r.start + (i-1)*r.step)/r.divisor)
+function getindex{T}(r::FloatRange{T}, i::Integer)
+    @_inline_meta
+    @boundscheck checkbounds(r, i);
+    convert(T, (r.start + (i-1)*r.step)/r.divisor)
+end
 
-getindex{T}(r::LinSpace{T}, i::Integer) = (checkbounds(r, i); unsafe_getindex(r, i))
-unsafe_getindex{T}(r::LinSpace{T}, i::Integer) = convert(T, ((r.len-i)*r.start + (i-1)*r.stop)/r.divisor)
+function getindex{T}(r::LinSpace{T}, i::Integer)
+    @_inline_meta
+    @boundscheck checkbounds(r, i);
+    convert(T, ((r.len-i)*r.start + (i-1)*r.stop)/r.divisor)
+end
 
 getindex(r::Range, ::Colon) = copy(r)
-unsafe_getindex(r::Range, ::Colon) = copy(r)
 
-getindex{T<:Integer}(r::UnitRange, s::UnitRange{T}) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex{T<:Integer}(r::UnitRange, s::UnitRange{T})
+function getindex{T<:Integer}(r::UnitRange, s::UnitRange{T})
+    @_inline_meta
+    @boundscheck checkbounds(r, s)
     st = oftype(r.start, r.start + s.start-1)
     range(st, length(s))
 end
 
-getindex{T<:Integer}(r::UnitRange, s::StepRange{T}) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex{T<:Integer}(r::UnitRange, s::StepRange{T})
+function getindex{T<:Integer}(r::UnitRange, s::StepRange{T})
+    @_inline_meta
+    @boundscheck checkbounds(r, s)
     st = oftype(r.start, r.start + s.start-1)
     range(st, step(s), length(s))
 end
 
-getindex{T<:Integer}(r::StepRange, s::Range{T}) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex{T<:Integer}(r::StepRange, s::Range{T})
+function getindex{T<:Integer}(r::StepRange, s::Range{T})
+    @_inline_meta
+    @boundscheck checkbounds(r, s)
     st = oftype(r.start, r.start + (first(s)-1)*step(r))
     range(st, step(r)*step(s), length(s))
 end
 
-getindex(r::FloatRange, s::OrdinalRange) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex(r::FloatRange, s::OrdinalRange)
+function getindex(r::FloatRange, s::OrdinalRange)
+    @_inline_meta
+    @boundscheck checkbounds(r, s)
     FloatRange(r.start + (first(s)-1)*r.step, step(s)*r.step, length(s), r.divisor)
 end
 
-getindex(r::LinSpace, s::OrdinalRange) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex{T}(r::LinSpace{T}, s::OrdinalRange)
+function getindex{T}(r::LinSpace{T}, s::OrdinalRange)
+    @_inline_meta
+    @boundscheck checkbounds(r, s)
     sl::T = length(s)
     ifirst = first(s)
     ilast = last(s)

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -47,7 +47,7 @@ simd_outer_range(r) = 0:0
 simd_inner_length(r,j::Int) = length(r)
 
 # Construct user-level element from original range, outer loop index j, and inner loop index i.
-@inline simd_index(r,j::Int,i) = Base.unsafe_getindex(r,i+1)
+@inline simd_index(r,j::Int,i) = (@inbounds ret = r[i+1]; ret)
 
 # Compile Expr x in context of @simd.
 function compile(x)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -573,7 +573,11 @@ end
 
 # Indexing with non-scalars. For now, this returns a copy, but changing that
 # is just a matter of deleting the explicit call to copy.
-getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::ViewIndex...) = (@_propagate_inbounds_meta; copy(slice(V, I...)))
+function getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::ViewIndex...)
+    @_inline_meta
+    @boundscheck checkbounds(V, I...)
+    copy(slice_unsafe(V, to_indexes(I...)))
+end
 
 # Nonscalar setindex! falls back to the AbstractArray versions
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -222,10 +222,18 @@ function err_li(S::SubArray, ld::Int, szC)
     error("Linear indexing inference mismatch")
 end
 
+function dim_break_linindex(I)
+    i = 1
+    while i <= length(I) && !isa(I[i], Vector{Int})
+        i += 1
+    end
+    i - 1
+end
+
 function runtests(A::Array, I...)
     # Direct test of linear indexing inference
     C = Agen_nodrop(A, I...)
-    ld = single_stride_dim(C)
+    ld = min(single_stride_dim(C), dim_break_linindex(I))
     ldc = Base.subarray_linearindexing_dim(typeof(A), typeof(I))
     ld == ldc || err_li(I, ld, ldc)
     # sub
@@ -262,7 +270,7 @@ function runtests(A::SubArray, I...)
     AA = copy_to_array(A)
     # Direct test of linear indexing inference
     C = Agen_nodrop(AA, I...)
-    Cld = ld = single_stride_dim(C)
+    Cld = ld = min(single_stride_dim(C), dim_break_linindex(I))
     Cdim = AIindex = 0
     while Cdim <= Cld && AIindex < length(A.indexes)
         AIindex += 1

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -193,6 +193,21 @@ function _test_mixed(A, B)
     nothing
 end
 
+function test_bounds(A)
+    @test_throws BoundsError A[0]
+    @test_throws BoundsError A[end+1]
+    @test_throws BoundsError A[1, 0]
+    @test_throws BoundsError A[1, end+1]
+    @test_throws BoundsError A[1, 1, 0]
+    @test_throws BoundsError A[1, 1, end+1]
+    @test_throws BoundsError A[0, 1]
+    @test_throws BoundsError A[end+1, 1]
+    @test_throws BoundsError A[0, 1, 1]
+    @test_throws BoundsError A[end+1, 1, 1]
+    @test_throws BoundsError A[1, 0, 1]
+    @test_throws BoundsError A[1, end+1, 1]
+end
+
 function err_li(I::Tuple, ld::Int, ldc::Int)
     @show I
     @show ld, ldc
@@ -222,12 +237,14 @@ function runtests(A::Array, I...)
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
+    test_bounds(S)
     # slice
     S = slice(A, I...)
     getLD(S) == ldc || err_li(S, ldc)
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
+    test_bounds(S)
 end
 
 function runtests(A::SubArray, I...)
@@ -270,6 +287,7 @@ function runtests(A::SubArray, I...)
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
+    test_bounds(S)
     # slice
     try
         S = slice(A, I...)
@@ -284,6 +302,7 @@ function runtests(A::SubArray, I...)
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
+    test_bounds(S)
 end
 
 # indexN is a cartesian index, indexNN is a linear index for 2 dimensions, and indexNNN is a linear index for 3 dimensions


### PR DESCRIPTION
This patch does two things:
- It all but completely removes `unsafe_getindex` and `unsafe_setindex!` from the standard library. This merges their method definitions into the safe flavors with a `(at)boundscheck checkbounds(...)` clause, and it replaces call-sites with `(at)inbounds A[I...]`.  A few uses remain because the inbounds macro doesn't return its value, making the construct a little awkward in some cases.
- It changes _where_ bounds are checked in SubArrays. Previously, SubArrays would defer bounds checks to their parent arrays; they wouldn't check the indices directly, but rather they'd transform the indices into the proper references into the parent array, and then index into the parent array safely. E.g., previously:

``` jl
    julia> A = -.5:.1:.5
           S = sub(A, 7:11)
           S[-4], S[0], S[4]
    (-0.4,0.0,0.4)

    julia> S[-6]
    ERROR: BoundsError: attempt to access -0.5:0.1:0.5
      at index [0]
```

This behavior is neither tested nor depended upon in the Base library, but I believe some packages (cc @timholy?) have historically depended upon this.  With this patch, the behavior is much more sane; `S[0]` now immediately throws a bounds error from the SubArray itself.  I believe this is a strong requirement for making views more prominent (regardless of the syntax).

TODO:
- [x] `runbenchmarks("array", vs = "JuliaLang/julia:master")`
- [x] `JULIA_TESTFULL=1 make -C test subarray`
- [x] ~~If the change in semantics is at all controversial, I can split this into two PRs — one for the spelling change and one for the change in SubArray functionality.~~ No objections.
- [x] Restrict `@inbounds` annotations back to status quo.
