### PR TITLE
correct shape for vec*mat error #14679

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -85,7 +85,15 @@ function (*){T,S}(A::AbstractMatrix{T}, x::AbstractVector{S})
     TS = promote_op(MulFun(),arithtype(T),arithtype(S))
     A_mul_B!(similar(x,TS,size(A,1)),A,x)
 end
-(*)(A::AbstractVector, B::AbstractMatrix) = reshape(A,length(A),1)*B
+function (*)(A::AbstractVector, B::AbstractMatrix)
+    mB, nB = size(B)
+    if mB != 1
+        mA = size(A)
+        throw(DimensionMismatch("A has dimensions $mA but B has dimensions ($mB,$nB)"))
+    else
+        reshape(A,length(A),1)*B
+    end
+end
 
 A_mul_B!{T<:BlasFloat}(y::StridedVector{T}, A::StridedVecOrMat{T}, x::StridedVector{T}) = gemv!(y, 'N', A, x)
 for elty in (Float32,Float64)

--- a/base/test.jl
+++ b/base/test.jl
@@ -17,7 +17,7 @@ export @test, @test_throws
 export @testset
 # Legacy approximate testing functions, yet to be included
 export @test_approx_eq, @test_approx_eq_eps, @inferred
-
+export @except_str
 #-----------------------------------------------------------------------
 
 """
@@ -818,6 +818,22 @@ function test_approx_eq_modphase{S<:Real,T<:Real}(
     for i=1:n
         v1, v2 = a[:, i], b[:, i]
         @test_approx_eq_eps min(abs(norm(v1-v2)), abs(norm(v1+v2))) 0.0 err
+    end
+end
+
+macro except_str(expr, err_type)
+    return quote
+        let
+            local err
+            try
+                $(esc(expr))
+            catch err
+            end
+            @test typeof(err) === $(esc(err_type))
+            buff = IOBuffer()
+            showerror(buff, err)
+            takebuf_string(buff)
+        end
     end
 end
 

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -213,3 +213,10 @@ a = [RootInt(2),RootInt(10)]
 @test a*a' == [4 20; 20 100]
 A = [RootInt(3) RootInt(5)]
 @test A*a == [56]
+
+# 14679
+a = rand(4)
+b = rand(4,4)
+@test_throws DimensionMismatch (*)(a, b)
+err_str = @except_str (*)(a, b) DimensionMismatch
+@test contains(err_str, "A has dimensions (4,) but B has dimensions (4,4)")

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -69,22 +69,6 @@ for f in [getindex, setindex!]
     test_have_color(buf, "", "")
 end
 
-macro except_str(expr, err_type)
-    return quote
-        let
-            local err
-            try
-                $(esc(expr))
-            catch err
-            end
-            @test typeof(err) === $(esc(err_type))
-            buff = IOBuffer()
-            showerror(buff, err)
-            takebuf_string(buff)
-        end
-    end
-end
-
 macro except_strbt(expr, err_type)
     return quote
         let
@@ -116,6 +100,7 @@ macro except_stackframe(expr, err_type)
     end
 end
 
+using Base.Test
 # Pull Request 11007
 abstract InvokeType11007
 abstract MethodType11007 <: InvokeType11007
@@ -132,7 +117,6 @@ end
 module __tmp_replutil
 
 using Base.Test
-import Main.@except_str
 global +
 +() = nothing
 err_str = @except_str 1 + 2 MethodError
@@ -337,5 +321,3 @@ withenv("JULIA_EDITOR" => nothing, "VISUAL" => nothing, "EDITOR" => nothing) do
     ENV["JULIA_EDITOR"] = "\"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl\" -w"
     @test Base.editor() == ["/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl", "-w"]
 end
-
-


### PR DESCRIPTION
If the first dimension of a matrix is not 1, we should throw a dimension mismatch message for vec*mat.
