### PR TITLE
Fix #13401 (disable inbound checking for arrays generated on the fly)

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1930,7 +1930,7 @@
       (if (null? ranges)
           `(block (= ,oneresult ,expr)
                   ,@(if atype '() `((type_goto ,initlabl ,oneresult)))
-                  (inbounds false)
+                  (inbounds true)
                   (call (top setindex!) ,result ,oneresult ,ri)
                   (inbounds pop)
                   (= ,ri (call (top +) ,ri 1)))


### PR DESCRIPTION
Since the size of array is known in advance, one can disable bounds checking to allow vectorization
