### PR TITLE
Fix corner case in MethodError printing

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -167,7 +167,9 @@ function showerror(io::IO, ex::MethodError)
     f = ex.f
     ft = typeof(f)
     name = ft.name.mt.name
+    f_is_function = false
     if f == Base.convert && length(arg_types_param) == 2 && !is_arg_types
+        f_is_function = true
         # See #13033
         T = striptype(ex.args[1])
         if T == nothing
@@ -181,6 +183,7 @@ function showerror(io::IO, ex::MethodError)
         if ft <: Function && isempty(ft.parameters) &&
                 isdefined(ft.name.module, name) &&
                 ft == typeof(getfield(ft.name.module, name))
+            f_is_function = true
             print(io, "no method matching ", name)
         elseif isa(f, Type)
             print(io, "no method matching ", f)
@@ -195,8 +198,8 @@ function showerror(io::IO, ex::MethodError)
         print(io, ")")
     end
     # Check for local functions that shadow methods in Base
-    if isdefined(Base, name)
-        basef = eval(Base, name)
+    if f_is_function && isdefined(Base, name)
+        basef = getfield(Base, name)
         if basef !== ex.f && method_exists(basef, arg_types)
             println(io)
             print(io, "you may have intended to import Base.", name)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -72,12 +72,12 @@ end
 macro except_str(expr, err_type)
     return quote
         let
-            local err::$(esc(err_type))
+            local err
             try
                 $(esc(expr))
             catch err
             end
-            @test typeof(err) === $err_type
+            @test typeof(err) === $(esc(err_type))
             buff = IOBuffer()
             showerror(buff, err)
             takebuf_string(buff)
@@ -114,12 +114,21 @@ let
 end
 
 module __tmp_replutil
+
 using Base.Test
 import Main.@except_str
 global +
 +() = nothing
 err_str = @except_str 1 + 2 MethodError
-@test contains(err_str, "Base.+")
+@test contains(err_str, "import Base.+")
+
+err_str = @except_str Float64[](1) MethodError
+@test !contains(err_str, "import Base.Array")
+
+Array() = 1
+err_str = @except_str Array(1) MethodError
+@test contains(err_str, "import Base.Array")
+
 end
 
 let


### PR DESCRIPTION
Do not suggest import from base unless what's being called is actually
a function.
