### PR TITLE
Make sparse([1,1], [1,1], [true,true]) work

### DIFF
--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -19,8 +19,9 @@
 Create a sparse matrix `S` of dimensions `m x n` such that `S[I[k], J[k]] = V[k]`.
 The `combine` function is used to combine duplicates. If `m` and `n` are not
 specified, they are set to `maximum(I)` and `maximum(J)` respectively. If the
-`combine` function is not supplied, duplicates are added by default. All elements
-of `I` must satisfy `1 <= I[k] <= m`, and all elements of `J` must satisfy `1 <= J[k] <= n`.
+`combine` function is not supplied, `combine` defaults to `+` unless the elements
+of `V` are Booleans in which case `combine` defaults to `|`. All elements of `I` must
+satisfy `1 <= I[k] <= m`, and all elements of `J` must satisfy `1 <= J[k] <= n`.
 """
 function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti},
                                 J::AbstractVector{Ti},

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -322,11 +322,11 @@ end
 
 dimlub(I) = isempty(I) ? 0 : Int(maximum(I)) #least upper bound on required sparse matrix dimension
 
-sparse(I,J,v::Number) = sparse(I, J, fill(v,length(I)), dimlub(I), dimlub(J), AddFun())
+sparse(I,J,v::Number) = sparse(I, J, fill(v,length(I)))
 
-sparse(I,J,V::AbstractVector) = sparse(I, J, V, dimlub(I), dimlub(J), AddFun())
+sparse(I,J,V::AbstractVector) = sparse(I, J, V, dimlub(I), dimlub(J))
 
-sparse(I,J,v::Number,m,n) = sparse(I, J, fill(v,length(I)), Int(m), Int(n), AddFun())
+sparse(I,J,v::Number,m,n) = sparse(I, J, fill(v,length(I)), Int(m), Int(n))
 
 sparse(I,J,V::AbstractVector,m,n) = sparse(I, J, V, Int(m), Int(n), AddFun())
 

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -122,7 +122,8 @@ end
 
 Create a sparse vector `S` of length `m` such that `S[I[k]] = V[k]`.
 Duplicates are combined using the `combine` function, which defaults to
-`+` if it is not provided.
+`+` if no `combine` argument is provided, unless the elements of `V` are Booleans
+in which case `combine` defaults to `|`.
 """
 function sparsevec{Tv,Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector{Tv}, combine::BinaryOp)
     length(I) == length(V) ||
@@ -147,23 +148,25 @@ function sparsevec{Tv,Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector{Tv},
     _sparsevector!(collect(Ti, I), collect(Tv, V), len, combine)
 end
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector) =
+sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Number, AbstractVector}) =
     sparsevec(I, V, AddFun())
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector, len::Integer) =
+sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Number, AbstractVector},
+    len::Integer) =
     sparsevec(I, V, len, AddFun())
+
+sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Bool, AbstractVector{Bool}}) =
+    sparsevec(I, V, OrFun())
+
+sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Bool, AbstractVector{Bool}},
+    len::Integer) =
+    sparsevec(I, V, len, OrFun())
 
 sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, v::Number, combine::BinaryOp) =
     sparsevec(I, fill(v, length(I)), combine)
 
 sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, v::Number, len::Integer, combine::BinaryOp) =
     sparsevec(I, fill(v, length(I)), len, combine)
-
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, v::Number) =
-    sparsevec(I, v, AddFun())
-
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, v::Number, len::Integer) =
-    sparsevec(I, v, len, AddFun())
 
 
 ### Construction from dictionary

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -859,13 +859,13 @@ dense counterparts. The following functions are specific to sparse arrays.
 
    .. Docstring generated from Julia source
 
-   Create a sparse matrix ``S`` of dimensions ``m x n`` such that ``S[I[k], J[k]] = V[k]``\ . The ``combine`` function is used to combine duplicates. If ``m`` and ``n`` are not specified, they are set to ``maximum(I)`` and ``maximum(J)`` respectively. If the ``combine`` function is not supplied, duplicates are added by default. All elements of ``I`` must satisfy ``1 <= I[k] <= m``\ , and all elements of ``J`` must satisfy ``1 <= J[k] <= n``\ .
+   Create a sparse matrix ``S`` of dimensions ``m x n`` such that ``S[I[k], J[k]] = V[k]``\ . The ``combine`` function is used to combine duplicates. If ``m`` and ``n`` are not specified, they are set to ``maximum(I)`` and ``maximum(J)`` respectively. If the ``combine`` function is not supplied, ``combine`` defaults to ``+`` unless the elements of ``V`` are Boolean in which case ``combine`` defaults to ``|``\ . All elements of ``I`` must satisfy ``1 <= I[k] <= m``\ , and all elements of ``J`` must satisfy ``1 <= J[k] <= n``\ .
 
 .. function:: sparsevec(I, V, [m, combine])
 
    .. Docstring generated from Julia source
 
-   Create a sparse vector ``S`` of length ``m`` such that ``S[I[k]] = V[k]``\ . Duplicates are combined using the ``combine`` function, which defaults to ``+`` if it is not provided.
+   Create a sparse vector ``S`` of length ``m`` such that ``S[I[k]] = V[k]``\ . Duplicates are combined using the ``combine`` function, which defaults to ``+`` if no combine argument is provided, unless the elements of ``V`` are Boolean in which case ``combine`` defaults to |.
 
 .. function:: sparsevec(D::Dict, [m])
 

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1200,3 +1200,7 @@ let
     @test_throws LinAlg.SingularException LowerTriangular(A)\ones(n)
     @test_throws LinAlg.SingularException UpperTriangular(A)\ones(n)
 end
+
+# https://groups.google.com/forum/#!topic/julia-dev/QT7qpIpgOaA
+@test sparse([1,1], [1,1], [true, true]) == sparse([1,1], [1,1], [true, true], 1, 1) == fill(true, 1, 1)
+@test sparsevec([1,1], [true, true]) == sparsevec([1,1], [true, true], 1) == fill(true, 1)


### PR DESCRIPTION
...by making sure that the sparse method for Bool is always used.

As reported in https://groups.google.com/forum/#!topic/julia-dev/QT7qpIpgOaA
