### PR TITLE
Fix REPL parsing

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -791,7 +791,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
             edit_insert(buf, input)
             string = takebuf_string(buf)
             curspos = position(LineEdit.buffer(s))
-            pos = 0
+            pos = 1
             inputsz = sizeof(input)
             sz = sizeof(string)
             while pos <= sz

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -171,6 +171,7 @@ float{S<:AbstractString}(a::AbstractArray{S}) = map!(float, similar(a,typeof(flo
 ## interface to parser ##
 
 function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=true)
+    # pos is one based byte offset.
     # returns (expr, end_pos). expr is () in case of parse error.
     bstr = bytestring(str)
     ex, pos = ccall(:jl_parse_string, Any,
@@ -187,7 +188,7 @@ function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=tru
 end
 
 function parse(str::AbstractString; raise::Bool=true)
-    ex, pos = parse(str, start(str), greedy=true, raise=raise)
+    ex, pos = parse(str, 1, greedy=true, raise=raise)
     if isa(ex,Expr) && ex.head === :error
         return ex
     end

--- a/src/ast.c
+++ b/src/ast.c
@@ -704,6 +704,12 @@ JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len)
 JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
                                          int pos0, int greedy)
 {
+    if (pos0 < 0 || pos0 > len) {
+        jl_array_t *buf = jl_pchar_to_array(str, len);
+        JL_GC_PUSH1(&buf);
+        // jl_bounds_error roots the arguments.
+        jl_bounds_error((jl_value_t*)buf, jl_box_long(pos0));
+    }
     jl_ast_context_t *ctx = jl_ast_ctx_enter();
     fl_context_t *fl_ctx = &ctx->fl;
     value_t s = cvalue_static_cstrn(fl_ctx, str, len);

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -424,7 +424,7 @@ int64_t ios_seek(ios_t *s, int64_t pos)
 {
     s->_eof = 0;
     if (s->bm == bm_mem) {
-        if (pos > s->size)
+        if (pos < 0 || pos > s->size)
             return -2;
         s->bpos = pos;
     }

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -336,3 +336,10 @@ end
 let fname = :f
     @test :(function $fname end) == Expr(:function, :f)
 end
+
+# issue #14977
+@test parse("x = 1", 1) == (:(x = 1), 6)
+@test parse("x = 1", 6) == (nothing, 6)
+@test_throws BoundsError parse("x = 1", 0)
+@test_throws BoundsError parse("x = 1", -1)
+@test_throws BoundsError parse("x = 1", 7)


### PR DESCRIPTION
- Fix wrong offset to `parse(::AbstractString, ::Int)`
- Fix error checking in `ios_seek`
- Add bounds check in `jl_parse_string` to avoid surprising results or segfault

The error raised in `jl_parse_string` is a little twisted since the offset is in bytes. This is the simplest and the least confusing way I can come up with.

Closes #14977
