### PR TITLE
Docs: cholfact! double precision only for sparse

### DIFF
--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1248,7 +1248,14 @@ end
         Hermitian{Complex{<:Real},SparseMatrixCSC{Complex{<:Real},SuiteSparse_long}}};
         shift = 0.0) -> CHOLMOD.Factor
 
-Compute the LDLt factorization of `A`, reusing the symbolic factorization `F`.
+Compute the Cholesky (``LL'``) factorization of `A`, reusing the symbolic factorization `F`.
+
+** Note **
+
+This method uses the CHOLMOD library from SuiteSparse, which only supports
+doubles or complex doubles. Input matrices not of those element types will be
+converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
+appropriate.
 """
 cholfact!{T<:Real}(F::Factor, A::Union{SparseMatrixCSC{T},
         SparseMatrixCSC{Complex{T}},
@@ -1296,7 +1303,15 @@ Setting optional `shift` keyword argument computes the factorization of `A+shift
 If the `perm` argument is nonempty,
 it should be a permutation of `1:size(A,1)` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
-The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
+** Note **
+
+This method uses the CHOLMOD library from SuiteSparse, which only supports
+doubles or complex doubles. Input matrices not of those element types will be
+converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
+appropriate.
+
+Many other functions from CHOLMOD are wrapped but not exported from the
+`Base.SparseArrays.CHOLMOD` module.
 """
 cholfact{T<:Real}(A::Union{SparseMatrixCSC{T}, SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
@@ -1328,7 +1343,14 @@ end
         Hermitian{Complex{<:Real},SparseMatrixCSC{Complex{<:Real},SuiteSparse_long}}};
         shift = 0.0) -> CHOLMOD.Factor
 
-Compute the LDLt factorization of `A`, reusing the symbolic factorization `F`.
+Compute the ``LDL'`` factorization of `A`, reusing the symbolic factorization `F`.
+
+** Note **
+
+This method uses the CHOLMOD library from SuiteSparse, which only supports
+doubles or complex doubles. Input matrices not of those element types will be
+converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
+appropriate.
 """
 ldltfact!{T<:Real}(F::Factor, A::Union{SparseMatrixCSC{T},
     SparseMatrixCSC{Complex{T}},
@@ -1360,7 +1382,7 @@ end
         Hermitian{Complex{<:Real},SparseMatrixCSC{Complex{<:Real},SuiteSparse_long}}};
         shift = 0.0, perm=Int[]) -> CHOLMOD.Factor
 
-Compute the `LDLt` factorization of a sparse symmetric or Hermitian matrix.
+Compute the ``LDL'`` factorization of a sparse symmetric or Hermitian matrix.
 A fill-reducing permutation is used.
 `F = ldltfact(A)` is most frequently used to solve systems of equations `A*x = b` with `F\b`.
 The returned factorization object `F` also supports the methods `diag`,
@@ -1377,7 +1399,15 @@ Setting optional `shift` keyword argument computes the factorization of `A+shift
 If the `perm` argument is nonempty,
 it should be a permutation of `1:size(A,1)` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
-The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
+** Note **
+
+This method uses the CHOLMOD library from SuiteSparse, which only supports
+doubles or complex doubles. Input matrices not of those element types will be
+converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
+appropriate.
+
+Many other functions from CHOLMOD are wrapped but not exported from the
+`Base.SparseArrays.CHOLMOD` module.
 """
 ldltfact{T<:Real}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -160,7 +160,11 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Setting optional ``shift`` keyword argument computes the factorization of ``A+shift*I`` instead of ``A``\ . If the ``perm`` argument is nonempty, it should be a permutation of ``1:size(A,1)`` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
-   The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
+   ** Note **
+
+   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
+
+   Many other functions from CHOLMOD are wrapped but not exported from the ``Base.SparseArrays.CHOLMOD`` module.
 
 .. function:: cholfact!(F::Factor, A::Union{SparseMatrixCSC{<:Real},
                   SparseMatrixCSC{Complex{<:Real}},
@@ -170,7 +174,11 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Compute the LDLt factorization of ``A``\ , reusing the symbolic factorization ``F``\ .
+   Compute the Cholesky (:math:`LL'`\ ) factorization of ``A``\ , reusing the symbolic factorization ``F``\ .
+
+   ** Note **
+
+   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
 .. function:: cholfact!(A::StridedMatrix, uplo::Symbol, Val{false}) -> Cholesky
 
@@ -225,11 +233,15 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Compute the ``LDLt`` factorization of a sparse symmetric or Hermitian matrix. A fill-reducing permutation is used. ``F = ldltfact(A)`` is most frequently used to solve systems of equations ``A*x = b`` with ``F``\ . The returned factorization object ``F`` also supports the methods ``diag``\ , ``det``\ , and ``logdet``\ . You can extract individual factors from ``F`` using ``F[:L]``\ . However, since pivoting is on by default, the factorization is internally represented as ``A == P'*L*D*L'*P`` with a permutation matrix ``P``\ ; using just ``L`` without accounting for ``P`` will give incorrect answers. To include the effects of permutation, it's typically preferable to extact "combined" factors like ``PtL = F[:PtL]`` (the equivalent of ``P'*L``\ ) and ``LtP = F[:UP]`` (the equivalent of ``L'*P``\ ). The complete list of supported factors is ``:L, :PtL, :D, :UP, :U, :LD, :DU, :PtLD, :DUP``\ .
+   Compute the :math:`LDL'` factorization of a sparse symmetric or Hermitian matrix. A fill-reducing permutation is used. ``F = ldltfact(A)`` is most frequently used to solve systems of equations ``A*x = b`` with ``F``\ . The returned factorization object ``F`` also supports the methods ``diag``\ , ``det``\ , and ``logdet``\ . You can extract individual factors from ``F`` using ``F[:L]``\ . However, since pivoting is on by default, the factorization is internally represented as ``A == P'*L*D*L'*P`` with a permutation matrix ``P``\ ; using just ``L`` without accounting for ``P`` will give incorrect answers. To include the effects of permutation, it's typically preferable to extact "combined" factors like ``PtL = F[:PtL]`` (the equivalent of ``P'*L``\ ) and ``LtP = F[:UP]`` (the equivalent of ``L'*P``\ ). The complete list of supported factors is ``:L, :PtL, :D, :UP, :U, :LD, :DU, :PtLD, :DUP``\ .
 
    Setting optional ``shift`` keyword argument computes the factorization of ``A+shift*I`` instead of ``A``\ . If the ``perm`` argument is nonempty, it should be a permutation of ``1:size(A,1)`` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
-   The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
+   ** Note **
+
+   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
+
+   Many other functions from CHOLMOD are wrapped but not exported from the ``Base.SparseArrays.CHOLMOD`` module.
 
 .. function:: ldltfact!(F::Factor, A::Union{SparseMatrixCSC{<:Real},
                   SparseMatrixCSC{Complex{<:Real}},
@@ -239,7 +251,11 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Compute the LDLt factorization of ``A``\ , reusing the symbolic factorization ``F``\ .
+   Compute the :math:`LDL'` factorization of ``A``\ , reusing the symbolic factorization ``F``\ .
+
+   ** Note **
+
+   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
 .. function:: ldltfact!(::SymTridiagonal) -> LDLt
 


### PR DESCRIPTION
Closes #14810

Also changes description of `LDL^T` to `LDL'`. The former is wrong for
complex matrices.
