### PR TITLE
Optimized unique and union! methods

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -30,6 +30,8 @@ function in(p, a::Associative)
              function if you are looking for a key or value respectively.""")
 end
 
+unique(a::Associative) = collect(a)
+
 function summary(t::Associative)
     n = length(t)
     string(typeof(t), " with ", n, (n==1 ? " entry" : " entries"))

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -27,6 +27,7 @@ export
 # Types
     AbstractChannel,
     AbstractMatrix,
+    AbstractSet,
     AbstractVector,
     AbstractVecOrMat,
     Array,

--- a/base/intset.jl
+++ b/base/intset.jl
@@ -68,12 +68,11 @@ function push!(s::IntSet, n::Integer)
     return s
 end
 
-function union!(s::IntSet, ns)
-    for n in ns
-        push!(s, n)
-    end
-    return s
-end
+union!(s::AbstractSet, xs) = _union!(s, xs)
+
+_union!(s::AbstractSet, xs) = rawunion!(s, xs)
+
+rawunion!(s::AbstractSet, xs) = (for x=xs; push!(s,x); end; s)
 
 function pop!(s::IntSet, n::Integer, deflt)
     if n >= s.limit

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+import Base: union!, unique
+
 ## Diagonal matrices
 
 immutable Diagonal{T} <: AbstractMatrix{T}
@@ -240,4 +242,22 @@ end
 function svdfact(D::Diagonal)
     U, s, V = svd(D)
     SVD(U, s, V')
+end
+
+## Set related methods ##
+function union!{T}(s::AbstractSet, D::Diagonal{T})
+    d = diag(D)
+    if length(d) <= 1
+        return union!(s,d)
+    else
+        return union!(s, [zero(T); d])
+    end
+end
+function unique{T}(D::Diagonal{T})
+    d = diag(D)
+    if length(d) <= 1
+        return d
+    else
+        return unique([d[1]; zero(T); d[2:end]])
+    end
 end

--- a/base/range.jl
+++ b/base/range.jl
@@ -801,3 +801,5 @@ end
 
 in{T<:Integer}(x, r::Range{T}) = isinteger(x) && !isempty(r) && x>=minimum(r) && x<=maximum(r) && (mod(convert(T,x),step(r))-mod(first(r),step(r)) == 0)
 in(x::Char, r::Range{Char}) = !isempty(r) && x >= minimum(r) && x <= maximum(r) && (mod(Int(x) - Int(first(r)), step(r)) == 0)
+
+unique{T}(x::Range{T}) = step(x) == zero(T) ? x[1:1] : x

--- a/base/set.jl
+++ b/base/set.jl
@@ -131,6 +131,7 @@ function firstnunique(C, n::Integer)
                 end
             end
         end
+        return out
     end
     return out
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -103,6 +103,8 @@ const ⊆ = issubset
 ⊊(l::Set, r::Set) = <(l, r)
 ⊈(l::Set, r::Set) = !⊆(l, r)
 
+unique(x::AbstractSet) = collect(x)
+
 function unique(C)
     out = Vector{eltype(C)}()
     seen = Set{eltype(C)}()

--- a/base/sparse/abstractsparse.jl
+++ b/base/sparse/abstractsparse.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+import Base: union!, unique
+
 abstract AbstractSparseArray{Tv,Ti,N} <: AbstractArray{Tv,N}
 
 typealias AbstractSparseVector{Tv,Ti} AbstractSparseArray{Tv,Ti,1}
@@ -21,3 +23,22 @@ issparse{T, A<:AbstractSparseMatrix}(S::UpperTriangular{T, A}) = true
 issparse{T, A<:AbstractSparseMatrix}(S::LinAlg.UnitUpperTriangular{T, A}) = true
 
 indtype{Tv,Ti}(S::AbstractSparseArray{Tv,Ti}) = Ti
+
+function union!{Tv,Ti,N}(s::AbstractSet, x::AbstractSparseArray{Tv,Ti,N})
+    vals = nonzeros(x)
+    length(vals) == length(x) ? union!(s, vals) : union!(s, [zero(Tv); vals])
+end
+
+# assumes that AbstractSparseArray type stores nonzeros in column major order
+# this assumption is subject to change in the future
+function unique{Tv,Ti,N}(x::AbstractSparseArray{Tv,Ti,N})
+    vals = nonzeros(x)
+    if length(x) == length(vals)
+        return unique(vals)
+    else
+        # find the first zero valued element
+        i = findfirst(x, zero(Tv))
+        # insert first zero in sequence of potential uniques
+        return unique([vals[1:i-1]; zero(Tv); vals[i:end]])
+    end
+end

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -3,6 +3,7 @@
 ### Common definitions
 
 import Base: Func, AddFun, MulFun, MaxFun, MinFun, SubFun, sort
+import Base: union!, unique
 
 immutable ComplexFun <: Func{2} end
 (::ComplexFun)(x::Real, y::Real) = complex(x, y)
@@ -16,6 +17,8 @@ typealias BinaryOp Union{Function, Func{2}}
 ### The SparseVector
 
 ### Types
+
+# Assumes that indices in nzind are sorted (so that nzval is also ordered)
 
 immutable SparseVector{Tv,Ti<:Integer} <: AbstractSparseVector{Tv,Ti}
     n::Int              # the number of elements

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -371,6 +371,7 @@ d = Dict('a'=>1, 'b'=>1, 'c'=> 3)
 @test_throws ArgumentError Dict([1])
 @test_throws ArgumentError Dict([(1,2),0])
 
+
 # ImmutableDict
 import Base.ImmutableDict
 let d = ImmutableDict{UTF8String, UTF8String}(),
@@ -440,6 +441,7 @@ let d = ImmutableDict{UTF8String, UTF8String}(),
     @test_throws KeyError d1["key2"]
 end
 
+
 # filtering
 let d = Dict(zip(1:1000,1:1000)), f = (k,v) -> iseven(k)
     @test filter(f, d) == filter!(f, copy(d)) ==
@@ -467,3 +469,6 @@ let badKeys = ASCIIString["FINO_emv5.0","FINO_ema0.1","RATE_ema1.0","NIBPM_ema1.
     end
     @test d["NIBPD_emv5.0"] == 1
 end
+
+# Test set-like methods
+@test unique(Dict(zip("abc",1:3))) == unique(collect(Dict(zip("abc",1:3))))

--- a/test/intset.jl
+++ b/test/intset.jl
@@ -132,3 +132,5 @@ pop!(j, 257)
 @test IntSet([1, 2, 4]) <= IntSet(1:10)
 @test IntSet([1, 2, 4]) <= IntSet([1, 2, 4])
 @test IntSet([]) <= IntSet([])
+
+@test unique(IntSet([1, 2, 4])) == unique(collect(IntSet([1, 2, 4])))

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -233,3 +233,14 @@ C = Tridiagonal(rand(Float64,9),rand(Float64,10),rand(Float64,9))
 @test promote_rule(Matrix{Float64}, Bidiagonal{Float64}) == Matrix{Float64}
 @test promote(B,A) == (B,convert(Matrix{Float64},full(A)))
 @test promote(C,A) == (C,Tridiagonal(zeros(Float64,9),convert(Vector{Float64},A.dv),convert(Vector{Float64},A.ev)))
+
+# test set-like operations
+A = Bidiagonal([1,2],[3],true)
+@test unique(A) == [1,0,3,2]
+A = Bidiagonal([1,2],[3],false)
+@test unique(A) == [1,3,0,2]
+A = Bidiagonal([1,2,3],[4,5],true)
+@test unique(A) == [1,0,4,2,5,3]
+A = Bidiagonal([1,2,3],[4,5],false)
+@test unique(A) == [1,4,0,2,5,3]
+@test union!(Set([1]),A) == Set([1,4,0,2,5,3])

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -229,6 +229,7 @@ end
 @test_throws SingularException inv(Diagonal([0, 1, 2]))
 @test_throws SingularException inv(Diagonal([0im, 1im, 2im]))
 
+
 # allow construct from range
 @test Diagonal(linspace(1,3,3)) == Diagonal([1.,2.,3.])
 
@@ -236,3 +237,9 @@ end
 for t in (Float32, Float64, Int, Complex{Float64}, Rational{Int})
     @test Diagonal(Matrix{t}[ones(t, 2, 2), ones(t, 3, 3)])[2,1] == zeros(t, 3, 2)
 end
+
+#set-like operations
+@test union!(Set(Int[3]),Diagonal(Int[0,1,2])) == union!(Set(Int[3]),full(Diagonal(Int[0,1,2])))
+@test unique(Diagonal(Int[])) == unique(full(Diagonal(Int[])))
+@test unique(Diagonal([1,0,2])) == unique(full(Diagonal([1,0,2])))
+@test unique(Diagonal([0,1,2])) == unique(full(Diagonal([0,1,2])))

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -450,6 +450,7 @@ SymTridiagonal([1, 2], [0])^3 == [1 0; 0 8]
 @test convert(SymTridiagonal{Float64},SymTridiagonal(ones(Float32,5),ones(Float32,4))) == SymTridiagonal(ones(Float64,5),ones(Float64,4))
 @test convert(AbstractMatrix{Float64},SymTridiagonal(ones(Float32,5),ones(Float32,4))) == SymTridiagonal(ones(Float64,5),ones(Float64,4))
 
+
 # Test constructors from matrix
 @test SymTridiagonal([1 2 3; 2 5 6; 0 6 9]) == [1 2 0; 2 5 6; 0 6 9]
 @test Tridiagonal([1 2 3; 4 5 6; 7 8 9]) == [1 2 0; 4 5 6; 0 8 9]
@@ -457,3 +458,21 @@ SymTridiagonal([1, 2], [0])^3 == [1 0; 0 8]
 # Test constructors with range and other abstract vectors
 @test SymTridiagonal(1:3, 1:2) == [1 1 0; 1 2 2; 0 2 3]
 @test Tridiagonal(4:5, 1:3, 1:2) == [1 1 0; 4 2 2; 0 5 3]
+
+# Set-like methods
+A = Tridiagonal(collect(1:4),collect(1:5),collect(1:4))
+@test unique(A) == unique(full(A))
+A = Tridiagonal(collect(0:3),collect(1:5),collect(1:4))
+@test unique(A) == unique(full(A))
+@test union!(Set([1]),A) == Set([0,1,2,3,4,5])
+A = Tridiagonal([1],[2,3],[4])
+@test unique(A) == unique(full(A))
+@test union!(Set([1]),A) == Set([1,2,3,4])
+A = SymTridiagonal(collect(1:5),collect(6:9))
+@test unique(A) == unique(full(A))
+A = SymTridiagonal(collect(0:4),collect(1:4))
+@test unique(A) == unique(full(A))
+@test union!(Set([1]),A) == Set([0,1,2,3,4])
+A = SymTridiagonal([1,2],[3])
+@test unique(A) == unique(full(A))
+@test union!(Set([1]),A) == Set([1,2,3])

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -345,7 +345,7 @@ for T = (Float32, Float64)
     @test [linspace(u,-u,4);][3] === -z
     v = [linspace(-u,u,12);]
     @test length(v) == 12
-    @test issorted(v) && unique(v) == [-u,0,0,u]
+    @test issorted(v) && collect(unique(v)) == [-u,0,0,u]
     @test [-3u:u:3u;] == [linspace(-3u,3u,7);] == [-3:3;].*u
     @test [3u:-u:-3u;] == [linspace(3u,-3u,7);] == [3:-1:-3;].*u
 end
@@ -705,3 +705,7 @@ for r in (big(1):big(2), UInt128(1):UInt128(2), 0x1:0x2)
     # these calls to similar must not throw:
     @test size(similar(r, size(r))) == size(similar(r, length(r)))
 end
+
+# Issue #14649
+@test unique(1:3) == 1:3
+@test unique(range(1,.0,4)) == range(1,.0,1)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -203,6 +203,7 @@ u = unique([1,1,2])
 @test length(u) == 2
 @test unique(iseven, [5,1,8,9,3,4,10,7,2,6]) == [5,8]
 @test unique(n->n % 3, [5,1,8,9,3,4,10,7,2,6]) == [5,1,9]
+@test unique(Set(1:3)) == unique(collect(Set(1:3)))
 
 # filter
 s = Set([1,2,3,4])

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -135,6 +135,14 @@ s = union(Set([5,6,7,8]), Set([7,8,9]))
 s = Set([1,3,5,7])
 union!(s,(2,3,4,5))
 @test isequal(s,Set([1,2,3,4,5,7]))
+@test union!(Set([1]),[false,true,true]) == Set([true,false])
+@test union!(Set([1]),[collect(0x00:0xff); 0x00]) == Set(collect(Int,0x00:0xff))
+@test union!(Set([1]),[collect(range(Int8(-128),256)); Int8(0)]) == Set(collect(Int,range(Int8(-128),256)))
+@test union!(Set(Bool[]),[false,true,true]) == Set([true,false])
+@test union!(Set(UInt8[]),[collect(0x00:0xff); 0x00]) == Set(collect(0x00:0xff))
+@test union!(Set(Int8[]),[collect(range(Int8(-128),256)); Int8(0)]) == Set(collect(range(Int8(-128),256)))
+
+
 
 # intersect
 @test isequal(intersect(Set([1])),Set([1]))
@@ -201,9 +209,16 @@ u = unique([1,1,2])
 @test in(1,u)
 @test in(2,u)
 @test length(u) == 2
+@test unique([]) == []
 @test unique(iseven, [5,1,8,9,3,4,10,7,2,6]) == [5,8]
 @test unique(n->n % 3, [5,1,8,9,3,4,10,7,2,6]) == [5,1,9]
 @test unique(Set(1:3)) == unique(collect(Set(1:3)))
+@test unique([true,true]) == [true]
+@test unique(Int8[1,2,2,3]) == Int8[1,2,3]
+@test unique(UInt8[1,2,2,3]) == UInt8[1,2,3]
+# method used internally for optimization of other unique methods
+@test Base.firstnunique([1,1,2,3],2) == [1,2]
+@test Base.firstnunique([1,1,2,3],0) == Int[]
 
 # filter
 s = Set([1,2,3,4])

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -213,7 +213,7 @@ u = unique([1,1,2])
 @test unique(iseven, [5,1,8,9,3,4,10,7,2,6]) == [5,8]
 @test unique(n->n % 3, [5,1,8,9,3,4,10,7,2,6]) == [5,1,9]
 @test unique(Set(1:3)) == unique(collect(Set(1:3)))
-@test unique([true,true]) == [true]
+@test unique([true,true]) == Bool[true]
 @test unique(Int8[1,2,2,3]) == Int8[1,2,3]
 @test unique(UInt8[1,2,2,3]) == UInt8[1,2,3]
 # method used internally for optimization of other unique methods

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1188,6 +1188,7 @@ let A = 2. * speye(5,5)
     @test full(spones(A)) == eye(full(A))
 end
 
+
 let
     A = spdiagm(rand(5)) + sprandn(5,5,0.2) + im*sprandn(5,5,0.2)
     A = A + A'
@@ -1224,6 +1225,7 @@ let
     @test_throws LinAlg.SingularException UpperTriangular(A)\ones(n)
 end
 
+
 # https://groups.google.com/forum/#!topic/julia-dev/QT7qpIpgOaA
 @test sparse([1,1], [1,1], [true, true]) == sparse([1,1], [1,1], [true, true], 1, 1) == fill(true, 1, 1)
 @test sparsevec([1,1], [true, true]) == sparsevec([1,1], [true, true], 1) == fill(true, 1)
@@ -1244,3 +1246,16 @@ let
     @test issparse(UpperTriangular(full(m))) == false
     @test issparse(LinAlg.UnitUpperTriangular(full(m))) == false
 end
+
+# Set-like tests
+A = sparse([1,2,7,8],[1,1,2,3],[1,2,1,3],8,8)
+@test unique(A) == unique(full(A))
+A = sparse([1,1,2,2],[1,2,1,2],[1,2,1,3],2,2)
+@test unique(A) == unique(full(A))
+A = sparse([2,2,3,3],[2,3,3,3],[1,2,1,3],3,3)
+@test unique(A) == unique(full(A))
+
+A = sparse([1,1,2,2],[1,2,1,2],[1,2,1,3],2,2)
+@test union!(Set([]),A) == union!(Set([]),full(A))
+A = sparse([2,2,3,3],[2,3,3,3],[1,2,1,3],3,3)
+@test union!(Set([]),A) == union!(Set([]),full(A))

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -824,6 +824,7 @@ s14046 = sprand(5, 1.0)
 @test spzeros(5) + s14046 == s14046
 @test 2*s14046 == s14046 + s14046
 
+
 # Issue 14589
 #test vectors with no zero elements
 x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 7)
@@ -838,3 +839,13 @@ x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 15)
 @test collect(sort(x, by=abs)) == sort(collect(x), by=abs)
 @test collect(sort(x, by=sign)) == sort(collect(x), by=sign)
 @test collect(sort(x, by=inv)) == sort(collect(x), by=inv)
+
+#test set_like methods for compatibility with full
+x = SparseVector(15,collect(2:10), [3, 2, -1, 1, 1, -2, 2, -3, 3])
+@test unique(x) == unique(full(x))
+@test union!(Set([1]),x) == union!(Set([1]),full(x))
+x = SparseVector(15,collect(2:10), [3, 2, -1, 0, 1, -2, 2, -3, 3])
+@test unique(x) == unique(full(x))
+x = SparseVector(3, [1,2,3], [1,1,2])
+@test unique(x) == unique(full(x))
+@test union!(Set([1]),x) == union!(Set([1]),full(x))


### PR DESCRIPTION
This PR implements performance improvements for unique and union! and adds an additional method signature for unique. The basic outline of the different performance issues can be found in JuliaLang/julia#14649. There are four separates commits in the pull request which implement
1. optimized methods for associative collections
2. optimized methods for collections with "small" eltypes, as well as an additional method unique(c,k), which returns at most k unique elements from a collection c. This is used in the implementation of the aforementioned optimizations, but I think is a useful method in its own right and worth exposing to the user.
3. optimized unique method for range types
4. optimized unique and union methods for sparse-like arrays such as Diagonal,Bidiagonal,SparseVector etc.

Each of these optimizations have different regimes in which performance improvements become apparent. A benchmark that illustrates performance improvements for unique in action can be seen by looking at the diff in this gist: https://gist.github.com/gajomi/0c184160042ddfc329ab/revisions (results similar for union!). Generally speaking, one sees improvements in walltime performance, although there are some minor performance regressions in memory allocation for some methods. 
