### PR TITLE
\dots -> \ldots

### DIFF
--- a/base/latex_symbols.jl
+++ b/base/latex_symbols.jl
@@ -196,6 +196,7 @@ const latex_symbols = Dict(
     "\\_chi" => "ᵪ",
 
     # Misc. Math and Physics
+    "\\ldots" => "…",
     "\\hbar" => "ħ",
     "\\del" => "∇",
 


### PR DESCRIPTION
The latex command for an ellipsis is `\ldots`, not `\dots`.
