### PR TITLE
RFC: Add methods for `zero` and `one` to CartesianIndex

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -3,7 +3,7 @@
 ### Multidimensional iterators
 module IteratorsMD
 
-import Base: eltype, length, size, start, done, next, last, getindex, setindex!, linearindexing, min, max, isless, eachindex, ndims, iteratorsize
+import Base: eltype, length, size, start, done, next, last, getindex, setindex!, linearindexing, min, max, zero, one, isless, eachindex, ndims, iteratorsize
 importall ..Base.Operators
 import Base: simd_outer_range, simd_inner_length, simd_index, @generated
 import Base: @nref, @ncall, @nif, @nexprs, LinearFast, LinearSlow, to_index, AbstractCartesianIndex
@@ -49,6 +49,14 @@ length{N}(::Type{CartesianIndex{N}})=N
 
 # indexing
 getindex(index::CartesianIndex, i::Integer) = index.I[i]
+
+# zeros and ones
+for (felt, fname) in ((:zero, :zeros), (:one, :ones))
+    @eval begin
+        $felt{N}(ct::CartesianIndex{N}) = CartesianIndex(tuple($fname(eltype(ct.I), N)...))
+        $felt{N}(::Type{CartesianIndex{N}}) = CartesianIndex(tuple($fname(Integer, N)...))
+    end
+end
 
 # arithmetic, min/max
 for op in (:+, :-, :min, :max)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -51,12 +51,10 @@ length{N}(::Type{CartesianIndex{N}})=N
 getindex(index::CartesianIndex, i::Integer) = index.I[i]
 
 # zeros and ones
-for (felt, fname) in ((:zero, :zeros), (:one, :ones))
-    @eval begin
-        $felt{N}(ct::CartesianIndex{N}) = CartesianIndex(tuple($fname(eltype(ct.I), N)...))
-        $felt{N}(::Type{CartesianIndex{N}}) = CartesianIndex(tuple($fname(Integer, N)...))
-    end
-end
+zero{N}(::CartesianIndex{N}) = zero(CartesianIndex{N})
+zero{N}(::Type{CartesianIndex{N}}) = CartesianIndex(ntuple(x -> 0, Val{N}))
+one{N}(::CartesianIndex{N}) = one(CartesianIndex{N})
+one{N}(::Type{CartesianIndex{N}}) = CartesianIndex(ntuple(x -> 1, Val{N}))
 
 # arithmetic, min/max
 for op in (:+, :-, :min, :max)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1188,6 +1188,11 @@ I2 = CartesianIndex((-1,5,2))
 @test I1 + 1 == CartesianIndex((3,4,1))
 @test I1 - 2 == CartesianIndex((0,1,-2))
 
+@test zero(CartesianIndex{2}) == CartesianIndex((0,0))
+@test zero(CartesianIndex((2,3))) == CartesianIndex((0,0))
+@test one(CartesianIndex{2}) == CartesianIndex((1,1))
+@test one(CartesianIndex((2,3))) == CartesianIndex((1,1))
+
 @test min(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((2,2))
 @test max(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((5,3))
 


### PR DESCRIPTION
This provides a trivial implementation of `zero` and `one` for the `CartesianIndex` type. Both forms that accept a instance and the type (with `N` specified) have been implemented.

I have not yet implemented any tests, as I could not find any tests related to `CartesianIndex` (though I'd be happy to start a test file if needed).
