### PR TITLE
RFC/WIP: Conditional 1-D Generators

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -341,6 +341,7 @@ unsafe_convert{T}(::Type{T}, x::T) = x
 (::Type{Array{T}}){T}(m::Int, n::Int, o::Int) = Array{T,3}(m, n, o)
 
 # TODO: possibly turn these into deprecations
+Array{T,N}(::Type{T}, d::NTuple{N,Int}) = Array{T}(d)
 Array{T}(::Type{T}, d::Int...) = Array{T}(d)
 Array{T}(::Type{T}, m::Int)               = Array{T,1}(m)
 Array{T}(::Type{T}, m::Int,n::Int)        = Array{T,2}(m,n)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -193,3 +193,17 @@ const (:) = Colon()
 # For passing constants through type inference
 immutable Val{T}
 end
+
+immutable Generator{F,I}
+    f::F
+    iter::I
+end
+
+start(g::Generator) = start(g.iter)
+done(g::Generator, s) = done(g.iter, s)
+function next(g::Generator, s)
+    v, s2 = next(g.iter, s)
+    g.f(v), s2
+end
+
+collect(g::Generator) = map(g.f, g.iter)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1469,6 +1469,7 @@
                        (begin (take-token s) (loop (cons nxt lst))))
                       ((eqv? c #\;)          (loop (cons nxt lst)))
                       ((equal? c closer)     (loop (cons nxt lst)))
+                      ((eq? c 'for)          (take-token s) (parse-generator s t closer))
                       ;; newline character isn't detectable here
                       #;((eqv? c #\newline)
                        (error "unexpected line break in argument list"))
@@ -1522,6 +1523,13 @@
     (if (dict-literal? (cadr c))
         `(dict_comprehension ,@(cdr c))
         (error "invalid dict comprehension"))))
+
+(define (parse-generator s first closer)
+  (let ((r (parse-comma-separated-iters s)))
+    (if (not (eqv? (require-token s) closer))
+	(error (string "expected " closer))
+        (take-token s))
+    `(macrocall @generator ,first ,@r)))
 
 (define (parse-matrix s first closer gotnewline)
   (define (fix head v) (cons head (reverse v)))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1397,22 +1397,23 @@
 (define (parse-comma-separated-assignments s)
   (parse-comma-separated s parse-eq*))
 
+(define (parse-iteration-spec s)
+  (let ((r (parse-eq* s)))
+    (cond ((and (pair? r) (eq? (car r) '=))  r)
+          ((eq? r ':)  r)
+          ((and (length= r 4) (eq? (car r) 'comparison)
+                (or (eq? (caddr r) 'in) (eq? (caddr r) '∈)))
+           `(= ,(cadr r) ,(cadddr r)))
+          (else
+           (error "invalid iteration specification")))))
+
 ; as above, but allows both "i=r" and "i in r"
 (define (parse-comma-separated-iters s)
   (let loop ((ranges '()))
-    (let ((r (parse-eq* s)))
-      (let ((r (cond ((and (pair? r) (eq? (car r) '=))
-                      r)
-                     ((eq? r ':)
-                      r)
-                     ((and (length= r 4) (eq? (car r) 'comparison)
-                           (or (eq? (caddr r) 'in) (eq? (caddr r) '∈)))
-                      `(= ,(cadr r) ,(cadddr r)))
-                     (else
-                      (error "invalid iteration specification")))))
-        (case (peek-token s)
-          ((#\,)  (take-token s) (loop (cons r ranges)))
-          (else   (reverse! (cons r ranges))))))))
+    (let ((r (parse-iteration-spec s)))
+      (case (peek-token s)
+        ((#\,)  (take-token s) (loop (cons r ranges)))
+        (else   (reverse! (cons r ranges)))))))
 
 (define (parse-space-separated-exprs s)
   (with-space-sensitive
@@ -1469,6 +1470,12 @@
                        (begin (take-token s) (loop (cons nxt lst))))
                       ((eqv? c #\;)          (loop (cons nxt lst)))
                       ((equal? c closer)     (loop (cons nxt lst)))
+                      ((eq? c 'for)
+                       (take-token s)
+                       (let ((gen (parse-generator s nxt #f)))
+                         (if (eqv? (require-token s) #\,)
+                             (take-token s))
+                         (loop (cons gen lst))))
                       ((eq? c 'for)          (take-token s) (parse-generator s t closer))
                       ;; newline character isn't detectable here
                       #;((eqv? c #\newline)
@@ -1514,7 +1521,7 @@
 (define (parse-comprehension s first closer)
   (let ((r (parse-comma-separated-iters s)))
     (if (not (eqv? (require-token s) closer))
-        (error (string "expected " closer))
+        (error (string "expected \"" closer "\""))
         (take-token s))
     `(comprehension ,first ,@r)))
 
@@ -1524,12 +1531,11 @@
         `(dict_comprehension ,@(cdr c))
         (error "invalid dict comprehension"))))
 
-(define (parse-generator s first closer)
-  (let ((r (parse-comma-separated-iters s)))
-    (if (not (eqv? (require-token s) closer))
-	(error (string "expected " closer))
-        (take-token s))
-    `(macrocall @generator ,first ,@r)))
+(define (parse-generator s first allow-comma)
+  (let ((r (if allow-comma
+               (parse-comma-separated-iters s)
+               (list (parse-iteration-spec s)))))
+    `(generator ,first ,@r)))
 
 (define (parse-matrix s first closer gotnewline)
   (define (fix head v) (cons head (reverse v)))
@@ -1959,6 +1965,13 @@
                           `(tuple ,ex)
                           ;; value in parentheses (x)
                           ex))
+                     ((eq? t 'for)
+                      (take-token s)
+                      (let ((gen (parse-generator s ex #t)))
+                        (if (eqv? (require-token s) #\) )
+                            (take-token s)
+                            (error "expected \")\""))
+                        gen))
                      (else
                       ;; tuple (x,) (x,y) (x...) etc.
                       (if (eqv? t #\, )

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1846,6 +1846,23 @@
               (lower-ccall name RT (cdr argtypes) args))))
          e))
 
+   'generator
+   (lambda (e)
+     (let ((expr   (cadr e))
+           (vars   (map cadr  (cddr e)))
+           (ranges (map caddr (cddr e))))
+       (let* ((names (map (lambda (v) (if (symbol? v) v (gensy))) vars))
+              (stmts (apply append
+                            (map (lambda (v arg) (if (symbol? v)
+                                                     '()
+                                                     `((= ,v ,arg))))
+                                 vars names))))
+         (expand-forms
+          (expand-binding-forms
+           `(call (top ,(if (length> ranges 1) 'GeneratorND 'Generator))
+                  (-> (tuple ,@names) (block ,@stmts ,expr))
+                  ,@ranges))))))
+
    'comprehension
    (lambda (e)
      (expand-forms (lower-comprehension #f       (cadr e) (cddr e))))


### PR DESCRIPTION
This is based on the **currently open** PR #14848.

This adds the ability, in the 1-D case, to support conditional generators, otherwise known as "guards".

Ref #550.

Example

``` julia
julia> t = (i for i in 1:10)
Base.Generator{##1#2,UnitRange{Int64},Base.##1#2}(#1,1:10,Base.#1)

julia> collect(t)
10-element Array{Int64,1}:
  1
  2
  3
  4
  5
  6
  7
  8
  9
 10

# manually construct a Generator with a "guard" or condition
julia> t = Base.Generator(x->x, 1:10, x->x%2 == 0)
Base.Generator{##7#9,UnitRange{Int64},##8#10}(#7,1:10,#8)

julia> collect(t)
5-element Array{Int64,1}:
  2
  4
  6
  8
 10
```

This doesn't yet support the necessary syntax parsing of the form:

``` julia
t = (i for i in 1:10 if i % 2 == 0)
```

The `collect` implementation is probably too naive (not sure if we could get away with not having to evaluate every element), but I'm also not up to speed on the machinery `map` uses for determining the result element type.

This PR is more just to show a proof of concept and invite discussion of any other issues we'd need to consider with adding this feature.
