### PR TITLE
Fix inference for Union{Tuple, Tuple, ...}

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -815,7 +815,7 @@ function precise_container_types(args, types, vtypes, sv)
             if _any(isvarargtype, result[i])
                 return nothing
             end
-        elseif ti === Union{}
+        elseif isa(ti, Union)
             return nothing
         elseif ti<:Tuple
             if i == n


### PR DESCRIPTION
In a big complicated project (I haven't yet succeeded in developing a small test case :frowning: ), a small tweak to my code induced the following compile-time error (this is on 0.5, but a similar error also happens on 0.4):

``` jl
ERROR: LoadError: type Union has no field name
 in precise_container_types(::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:822
 in abstract_apply(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo, ::Expr) at ./inference.jl:843
 [inlined code] from ./range.jl:83
 in abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo, ::Expr) at ./inference.jl:970
 in abstract_eval_call(::Expr, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1044
 in abstract_eval(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1070
 in typeinf_uncached(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Type{T}, ::Bool, ::Bool) at ./inference.jl:1770
 in typeinf(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Bool, ::Bool) at ./inference.jl:1443
 in abstract_call_gf_by_type(::Any, ::Any, ::Expr) at ./inference.jl:1394
 in abstract_call_gf(::Any, ::Array{Any,1}, ::Any, ::Expr) at ./inference.jl:691
 in abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo, ::Expr) at ./inference.jl:1007
 in abstract_eval_call(::Expr, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1044
 in abstract_eval(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1070
 [inlined code] from ./boot.jl:331
 in abstract_eval_call(::Expr, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1011
 in abstract_eval(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1070
 in abstract_interpret(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1215
 in typeinf_uncached(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Type{T}, ::Bool, ::Bool) at ./inference.jl:1697
 in typeinf(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Bool, ::Bool) at ./inference.jl:1443
 in abstract_call_gf_by_type(::Any, ::Any, ::Expr) at ./inference.jl:1394
 in abstract_call_gf(::Any, ::Array{Any,1}, ::Any, ::Expr) at ./inference.jl:691
 in abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo, ::Expr) at ./inference.jl:1007
 in abstract_eval_call(::Expr, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1044
 in abstract_eval(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1070
 in typeinf_uncached(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Type{T}, ::Bool, ::Bool) at ./inference.jl:1770
 in typeinf(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Bool, ::Bool) at ./inference.jl:1443
 in abstract_call_gf_by_type(::Any, ::Any, ::Expr) at ./inference.jl:1394
 in abstract_call_gf(::Any, ::Array{Any,1}, ::Any, ::Expr) at ./inference.jl:691
 in abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo, ::Expr) at ./inference.jl:1007
 in abstract_eval_call(::Expr, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1044
 in abstract_eval(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1070
 in abstract_interpret(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1215
 in typeinf_uncached(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Type{T}, ::Bool, ::Bool) at ./inference.jl:1697
 in typeinf(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Bool, ::Bool) at ./inference.jl:1443
 in abstract_call_gf_by_type(::Any, ::Any, ::Expr) at ./inference.jl:1394
 in abstract_call_gf(::Any, ::Array{Any,1}, ::Any, ::Expr) at ./inference.jl:691
 in abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo, ::Expr) at ./inference.jl:1007
 in abstract_eval_call(::Expr, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1044
 in abstract_eval(::Any, ::Core.Inference.ObjectIdDict, ::Core.Inference.VarInfo) at ./inference.jl:1070
 in typeinf_uncached(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Type{T}, ::Bool, ::Bool) at ./inference.jl:1770
 in typeinf(::LambdaInfo, ::Any, ::SimpleVector, ::LambdaInfo, ::Bool, ::Bool) at ./inference.jl:1443
 in typeinf_ext(::LambdaInfo, ::Any, ::LambdaInfo) at ./inference.jl:1388
 in include(::ASCIIString) at ./boot.jl:264
 in include_from_node1(::ASCIIString) at ./loading.jl:417
 in eval(::Module, ::Any) at ./boot.jl:267
while loading /home/tim/.julia/v0.4/CellSegmentation/test/segment_2d_pairwise2.jl, in expression starting on line 52
```

By inserting `ccalls` to `jl_`, I discovered that the core problem seem to be [these lines](https://github.com/JuliaLang/julia/blob/086ac63a1badc6b1104c96a3e9b63c7937d9b1c1/base/inference.jl#L818-L822)
and the fact that we have

``` jl
julia> Union{Int, Float64} <: Tuple
false

julia> Union{Tuple{Int}, Tuple{Int,Int}} <: Tuple
true

julia> Union{Tuple{Int}, Tuple{Int,Int}}.name
ERROR: type Union has no field name
 in eval(::Module, ::Any) at ./boot.jl:267
```

This one-liner fixes the bug, and seems OK, but I have no confidence that this is the best fix. Nor do I have a test case I can supply. (When I've tried simple things, the bug doesn't get triggered.)
