### PR TITLE
WIP: Add text colors to print_with_color documentation (bug #15018)

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -18,9 +18,16 @@ const text_colors = AnyDict(
 
 # Create a docstring with an automatically generated list
 # of colors.
-const available_text_colors = collect(keys(text_colors))
+const possible_formatting_symbols = [:normal, :bold]
+available_text_colors = collect(keys(text_colors))
+available_text_colors =
+    cat(1, intersect(available_text_colors, possible_formatting_symbols),
+        sort(setdiff(  available_text_colors, possible_formatting_symbols)))
+
 const available_text_colors_docstring =
-    join([string("`:", key,"`") for key in available_text_colors], ",\n")
+    string(join([string("`:", key,"`")
+                 for key in available_text_colors[1:end-1]], ",\n"),
+           ", or ", string("`:", available_text_colors[end],"`"));
 """Dictionary of color codes for the terminal.
 
 Available colors are: $available_text_colors_docstring.

--- a/base/client.jl
+++ b/base/client.jl
@@ -16,6 +16,17 @@ const text_colors = AnyDict(
     :bold    => "\033[1m",
 )
 
+# Create a docstring with an automatically generated list
+# of colors.
+const available_text_colors = collect(keys(text_colors))
+const available_text_colors_docstring =
+    join([string("`:", key,"`") for key in available_text_colors], ",\n")
+"""Dictionary of color codes for the terminal.
+
+Available colors are: $available_text_colors_docstring.
+"""
+text_colors
+
 have_color = false
 default_color_warn = :red
 default_color_info = :blue

--- a/base/client.jl
+++ b/base/client.jl
@@ -26,8 +26,8 @@ available_text_colors =
 
 const available_text_colors_docstring =
     string(join([string("`:", key,"`")
-                 for key in available_text_colors[1:end-1]], ",\n"),
-           ", or ", string("`:", available_text_colors[end],"`"));
+                 for key in available_text_colors], ",\n", ", or \n"))
+
 """Dictionary of color codes for the terminal.
 
 Available colors are: $available_text_colors_docstring.

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -9667,7 +9667,9 @@ redirect_stdout(stream)
 """
     print_with_color(color::Symbol, [io], strings...)
 
-Print strings in a color specified as a symbol, for example `:red` or `:blue`.
+Print strings in a color specified as a symbol.
+
+`color` may take any of the values $(Base.available_text_colors_docstring).
 """
 print_with_color
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -452,7 +452,9 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   Print strings in a color specified as a symbol, for example ``:red`` or ``:blue``\ .
+   Print strings in a color specified as a symbol.
+
+   ``color`` may take any of the values ``:black``\ , ``:red``\ , ``:yellow``\ , ``:magenta``\ , ``:green``\ , ``:cyan``\ , ``:white``\ , ``:blue``\ , ``:normal``\ , ``:bold``\ .
 
 .. function:: info(msg)
 


### PR DESCRIPTION
Currently print_with_color has no substantial documentation for the color parameter (see #15018).  I have added an automatically-generated docstring section that includes a list of possible color values.

This should keep it from getting out of date, though it does feel mildly offensive and I suspect that I may be about to inspire a new coding rule.
