### PR TITLE
Additional tools for type-stable multidimensional coding

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -61,6 +61,11 @@ for op in (:+, :-, :min, :max)
     end
 end
 
+(+){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x+i, index.I))
+(+){N}(i::Integer, index::CartesianIndex{N}) = index+i
+(-){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x-i, index.I))
+(-){N}(i::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->i-x, index.I))
+
 @generated function *{N}(a::Integer, index::CartesianIndex{N})
     I = index
     args = [:(a*index[$d]) for d = 1:N]
@@ -78,7 +83,9 @@ end
     startargs = fill(1, N)
     :(CartesianRange($I($(startargs...)), I))
 end
+CartesianRange(::Tuple{}) = CartesianRange{CartesianIndex{0}}(CartesianIndex{0}(()),CartesianIndex{0}(()))
 CartesianRange{N}(sz::NTuple{N,Int}) = CartesianRange(CartesianIndex(sz))
+CartesianRange{N}(rngs::NTuple{N,Union{Int,UnitRange{Int}}}) = CartesianRange(CartesianIndex(map(r->first(r), rngs)), CartesianIndex(map(r->last(r), rngs)))
 
 ndims(R::CartesianRange) = length(R.start)
 ndims{I<:CartesianIndex}(::Type{CartesianRange{I}}) = length(I)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -85,6 +85,22 @@ tails(t::Tuple, ts::Tuple...) = (tail(t), tails(ts...)...)
 map(f, ::Tuple{}, ts::Tuple...) = ()
 map(f, ts::Tuple...) = (f(heads(ts...)...), map(f, tails(ts...)...)...)
 
+# type-stable padding
+fill_to_length{N}(t::Tuple, val, ::Type{Val{N}}) = _ftl((), val, Val{N}, t...)
+_ftl{N}(out::NTuple{N}, val, ::Type{Val{N}}) = out
+function _ftl{N}(out::NTuple{N}, val, ::Type{Val{N}}, t...)
+    @_inline_meta
+    error("input tuple of length $(N+length(t)), requested $N")
+end
+function _ftl{N}(out, val, ::Type{Val{N}}, t1, t...)
+    @_inline_meta
+    _ftl((out..., t1), val, Val{N}, t...)
+end
+function _ftl{N}(out, val, ::Type{Val{N}})
+    @_inline_meta
+    _ftl((out..., val), val, Val{N})
+end
+
 ## comparison ##
 
 function isequal(t1::Tuple, t2::Tuple)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1110,6 +1110,8 @@ I2 = CartesianIndex((-1,5,2))
 @test I2 + I1 == CartesianIndex((1,8,2))
 @test I1 - I2 == CartesianIndex((3,-2,-2))
 @test I2 - I1 == CartesianIndex((-3,2,2))
+@test I1 + 1 == CartesianIndex((3,4,1))
+@test I1 - 2 == CartesianIndex((0,1,-2))
 
 @test min(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((2,2))
 @test max(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((5,3))
@@ -1146,6 +1148,9 @@ indexes = collect(R)
 @test length(indexes) == 12
 @test length(R) == 12
 @test ndims(R) == 2
+
+@test CartesianRange((3:5,-7:7)) == CartesianRange(CartesianIndex{2}(3,-7),CartesianIndex{2}(5,7))
+@test CartesianRange((3,-7:7)) == CartesianRange(CartesianIndex{2}(3,-7),CartesianIndex{2}(3,7))
 
 r = 2:3
 itr = eachindex(r)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -37,6 +37,10 @@
 
 @test getindex((5,6,7,8), []) === ()
 
+## filling to specified length
+@test @inferred(Base.fill_to_length((1,2,3), -1, Val{5})) == (1,2,3,-1,-1)
+@test_throws ErrorException Base.fill_to_length((1,2,3), -1, Val{2})
+
 ## iterating ##
 @test start((1,2,3)) === 1
 


### PR DESCRIPTION
This has a couple of goals:
- [x] support a few more convenience methods for `CartesianIterator`/`CartesianRange`
- [ ] provide better support for writing code without resorting to generated functions

For the 2nd goal (which is the "WIP" part of this), a key step is providing more comprehensive tools for working with tuples. For this reason, I decided to export `tail` (which we've had in Base for ages), add a corresponding `head` (which I define locally and have found useful on quite a few occasions), and rewrite `ntuple` so it doesn't use generated functions. Everything else looks reasonable at the level of `@code_native`, e.g.,

``` jl
julia> @code_native head((1,2,3))
        .text
Filename: tuple.jl
Source line: 0
        pushq   %rbp
        movq    %rsp, %rbp
Source line: 21
        movq    (%rsi), %rax
        movq    8(%rsi), %rcx
        movq    %rcx, 8(%rdi)
        movq    %rax, (%rdi)
        movq    %rdi, %rax
        popq    %rbp
        retq

julia> @code_native tail((1,2,3))
        .text
Filename: essentials.jl
Source line: 0
        pushq   %rbp
        movq    %rsp, %rbp
Source line: 64
        movq    8(%rsi), %rax
        movq    16(%rsi), %rcx
        movq    %rcx, 8(%rdi)
        movq    %rax, (%rdi)
        movq    %rdi, %rax
        popq    %rbp
        retq
```

but my attempted rewrite of `ntuple` was Not Good:

``` jl
julia> @code_native ntuple(identity, Val{3})
        .text
Filename: tuple.jl
Source line: 0
        pushq   %rbp
        movq    %rsp, %rbp
        pushq   %r15
        pushq   %r14
        pushq   %r13
        pushq   %r12
        pushq   %rbx
        subq    $88, %rsp
        movq    %rdi, %r14
Source line: 66
        movq    %r14, -120(%rbp)
        leaq    -72(%rbp), %r13
Source line: 32
        movq    $14, -112(%rbp)
        movabsq $jl_tls_states, %rcx
        movq    (%rcx), %rax
        movq    %rax, -104(%rbp)
        leaq    -112(%rbp), %rax
        movq    %rax, (%rcx)
        vxorps  %xmm0, %xmm0, %xmm0
        vmovups %xmm0, -96(%rbp)
        movq    $0, -80(%rbp)
        movq    $0, -56(%rbp)
        movq    $0, -48(%rbp)
        movq    %r14, -72(%rbp)
        movabsq $139726505222272, %r12  # imm = 0x7F149CB5A080
        movq    %r12, -64(%rbp)
        movabsq $jl_apply_generic, %rax
        movl    $2, %esi
        movq    %r13, %rdi
        callq   *%rax
        movq    %rax, -72(%rbp)
        movabsq $jl_f_tuple, %rax
        xorl    %edi, %edi
        movl    $1, %edx
        movq    %r13, %rsi
        callq   *%rax
        movq    %rax, %rbx
        movq    %rbx, -96(%rbp)
Source line: 76
        movq    %rbx, -72(%rbp)
        movabsq $jl_f_nfields, %rax
        xorl    %edi, %edi
Source line: 32
        movl    $1, %edx
Source line: 76
        movq    %r13, %rsi
        callq   *%rax
        movq    (%rax), %r15
Source line: 32
        movq    %rbx, -72(%rbp)
        movq    %r12, -64(%rbp)
        movabsq $jl_f_getfield, %rax
        xorl    %edi, %edi
        movl    $2, %edx
        movq    %r13, %rsi
        callq   *%rax
        movq    %rax, -72(%rbp)
        movq    %r14, -64(%rbp)
        incq    %r15
        movabsq $jl_box_int64, %rax
        movq    %r15, %rdi
        callq   *%rax
        movq    %rax, -56(%rbp)
        movl    $2, %esi
        leaq    -64(%rbp), %r14
        movq    %r14, %rdi
        movabsq $jl_apply_generic, %rax
        callq   *%rax
        movq    %rax, -64(%rbp)
        xorl    %edi, %edi
        movl    $2, %edx
        movq    %r13, %rbx
        movq    %rbx, %rsi
        movabsq $jl_f_tuple, %rax
        callq   *%rax
        movq    %rax, %r13
        movq    %r13, -88(%rbp)
Source line: 76
        movq    %r13, -72(%rbp)
        xorl    %edi, %edi
Source line: 32
        movl    $1, %edx
Source line: 76
        movq    %rbx, %rsi
        movabsq $jl_f_nfields, %rax
        callq   *%rax
        movq    (%rax), %r15
Source line: 32
        movq    %r13, -72(%rbp)
        movq    %r12, -64(%rbp)
        xorl    %edi, %edi
        movl    $2, %edx
        movq    %rbx, %rsi
        movabsq $jl_f_getfield, %rbx
        callq   *%rbx
        movq    %rax, -72(%rbp)
        movq    %r13, -64(%rbp)
        orq     $48, %r12
        movq    %r12, -56(%rbp)
        xorl    %edi, %edi
        movl    $2, %edx
        movq    %r14, %rsi
        callq   *%rbx
        movq    %rax, -64(%rbp)
        movq    -120(%rbp), %rax
        movq    %rax, -56(%rbp)
        incq    %r15
        movq    %r15, %rdi
        movabsq $jl_box_int64, %rax
        callq   *%rax
        movq    %rax, -48(%rbp)
        movl    $2, %esi
        leaq    -56(%rbp), %rdi
        movabsq $jl_apply_generic, %rax
        callq   *%rax
        movq    %rax, -56(%rbp)
        xorl    %edi, %edi
        movl    $3, %edx
Source line: 66
        leaq    -72(%rbp), %rsi
Source line: 32
        movabsq $jl_f_tuple, %rax
        callq   *%rax
        movq    %rax, -80(%rbp)
Source line: 73
        movq    -104(%rbp), %rcx
Source line: 32
        movabsq $jl_tls_states, %rdx
Source line: 73
        movq    %rcx, (%rdx)
        addq    $88, %rsp
        popq    %rbx
        popq    %r12
        popq    %r13
        popq    %r14
        popq    %r15
        popq    %rbp
        retq
```

Compare `master` (which uses a generated function, though for N=3 we don't call it):

``` jl
julia> @code_native ntuple(identity, Val{3})
        .text
Filename: tuple.jl
Source line: 0
        pushq   %rbp
        movq    %rsp, %rbp
Source line: 56
        movq    $3, 16(%rdi)
        movq    $2, 8(%rdi)
        movq    $1, (%rdi)
        movq    %rdi, %rax
        popq    %rbp
        retq
```

I presume that #13359 strikes again?

If it's the best choice for now, I can drop the rewrite of `ntuple`, but I thought I'd throw it out there in case anyone has ideas.
