### PR TITLE
Add casts to fix compile on Clang 3.7

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -1131,7 +1131,7 @@ void RTDyldMemoryManagerOSX::registerEHFrames(uint8_t *Addr,
 {
   // On OS X OS X __register_frame takes a single FDE as an argument.
   // See http://lists.cs.uiuc.edu/pipermail/llvmdev/2013-April/061768.html
-  processFDEs(Addr, Size, [](const char *Entry) {
+  processFDEs((char*)Addr, Size, [](const char *Entry) {
         if (!libc_register_frame) {
           libc_register_frame = (void(*)(void*))dlsym(RTLD_NEXT,"__register_frame");
         }
@@ -1145,7 +1145,7 @@ void RTDyldMemoryManagerOSX::deregisterEHFrames(uint8_t *Addr,
                                                 uint64_t LoadAddr,
                                                 size_t Size)
 {
-   processFDEs(Addr, Size, [](const char *Entry) {
+   processFDEs((char*)Addr, Size, [](const char *Entry) {
         if (!libc_deregister_frame) {
           libc_deregister_frame = (void(*)(void*))dlsym(RTLD_NEXT,"__deregister_frame");
         }


### PR DESCRIPTION
The other call-sites have this cast. (AFAICT travis is on Clang 3.5, maybe Clang 3.7 is stricter?)
Fixes:

```
/Users/inorton/git/jldev/src/debuginfo.cpp:1134:3: error: no matching function for call to 'processFDEs'
  processFDEs(Addr, Size, [](const char *Entry) {
  ^~~~~~~~~~~
/Users/inorton/git/jldev/src/debuginfo.cpp:1089:13: note: candidate function [with callback = (lambda at
      /Users/inorton/git/jldev/src/debuginfo.cpp:1134:27)] not viable: no known conversion from 'uint8_t *' (aka 'unsigned char *') to 'const char *'
      for 1st argument
static void processFDEs(const char *EHFrameAddr, size_t EHFrameSize, callback f)
            ^
/Users/inorton/git/jldev/src/debuginfo.cpp:1148:4: error: no matching function for call to 'processFDEs'
   processFDEs(Addr, Size, [](const char *Entry) {
   ^~~~~~~~~~~
/Users/inorton/git/jldev/src/debuginfo.cpp:1089:13: note: candidate function [with callback = (lambda at
      /Users/inorton/git/jldev/src/debuginfo.cpp:1148:28)] not viable: no known conversion from 'uint8_t *' (aka 'unsigned char *') to 'const char *'
      for 1st argument
static void processFDEs(const char *EHFrameAddr, size_t EHFrameSize, callback f)
            ^
2 warnings and 2 errors generated.
make[1]: *** [debuginfo.o] Error 1
```

cc @yuyichao
