### PR TITLE
add tuple destructuring `(a,b,c) = d` to `let`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -960,6 +960,17 @@
                            (newvar ,name)
                            ,asgn
                            ,blk)))))
+               ;; (a, b, c, ...) = rhs
+               ((and (pair? (cadar binds))
+                     (eq? (caadar binds) 'tuple))
+                (let ((vars (lhs-vars (cadar binds))))
+                  (loop (cdr binds)
+                        `(scope-block
+                          (block
+                           ,@(map (lambda (v) `(local ,v)) vars)
+                           ,@(map (lambda (v) `(newvar ,(decl-var v))) vars)
+                           ,(car binds)
+                           ,blk)))))
                (else (error "invalid let syntax"))))
              (else (error "invalid let syntax")))))))))
 
@@ -2100,6 +2111,7 @@
 
 (define (lhs-vars e)
   (cond ((symbol? e) (list e))
+        ((decl? e)   (list (decl-var e)))
         ((and (pair? e) (eq? (car e) 'tuple))
          (apply append (map lhs-vars (cdr e))))
         (else '())))

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -108,6 +108,10 @@
                              (let ((asgn (cadr (julia-expand0 (car binds)))))
                                (loop (cdr binds)
                                      (cons (cadr asgn) vars))))
+                            ((and (pair? (cadar binds))
+                                  (eq? (caadar binds) 'tuple))
+                             (loop (cdr binds)
+                                   (append (map decl-var (lhs-vars (cadar binds))) vars)))
                             (else '())))
                           (else '())))))
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -3717,3 +3717,17 @@ end
           function generic end
           end,
           Function)
+
+# let syntax with multiple lhs
+let z = (3,9,42)
+    let (a,b,c) = z
+        @test a == 3 && b == 9 && c == 42
+    end
+    let (a,b::Float64,c::Int8) = z
+        @test a == 3 && b === 9.0 && c === Int8(42)
+    end
+    z = (1, z, 10)
+    let (a, (b,c,d), e) = z
+        @test (a,b,c,d,e) == (1,3,9,42,10)
+    end
+end


### PR DESCRIPTION
This was an oversight. Can't believe we didn't have this.
