### PR TITLE
use LLVM checked intrinsics instead of custom checked code

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -383,14 +383,84 @@ function binomial{T<:Integer}(n::T, k::T)
 end
 
 
+
+# safe functions
+
+if Checked.BrokenSignedInt != Union{}
+function safe_add{T<:Checked.BrokenSignedInt}(x::T, y::T)
+    r = x + y
+    # x and y have the same sign, and the result has a different sign
+    (x<0) == (y<0) != (r<0) && return Nullable{T}()
+    Nullable{T}(r)
+end
+end
+if Checked.BrokenUnsignedInt != Union{}
+function safe_add{T<:Checked.BrokenUnsignedInt}(x::T, y::T)
+    # x + y > typemax(T)
+    # Note: ~y == -y-1
+    x > ~y && return Nullable{T}()
+    Nullable{T}(x + y)
+end
+end
+
+if Checked.BrokenSignedIntMul != Union{} && Checked.BrokenSignedIntMul != Int128
+function safe_mul{T<:Checked.BrokenSignedIntMul}(x::T, y::T)
+    r = widemul(x, y)
+    r % T != r && return Nullable{T}()
+    Nullable{T}(r % T)
+end
+end
+if Checked.BrokenUnsignedIntMul != Union{} && Checked.BrokenUnsignedIntMul != UInt128
+function safe_mul{T<:Checked.BrokenUnsignedIntMul}(x::T, y::T)
+    r = widemul(x, y)
+    r % T != r && return Nullable{T}()
+    Nullable{T}(r % T)
+end
+end
+if Int128 <: Checked.BrokenSignedIntMul
+    # Avoid BigInt
+    function safe_mul{T<:Int128}(x::T, y::T)
+        if y > 0
+            # x * y > typemax(T)
+            # x * y < typemin(T)
+            x > fld(typemax(T), y) && return Nullable{T}()
+            x < cld(typemin(T), y) && return Nullable{T}()
+        elseif y < 0
+            # x * y > typemax(T)
+            # x * y < typemin(T)
+            x < cld(typemax(T), y) && return Nullable{T}()
+            # y == -1 can overflow fld
+            y != -1 && x > fld(typemin(T), y) && return Nullable{T}()
+        end
+        Nullable{T}(x * y)
+    end
+end
+if UInt128 <: Checked.BrokenUnsignedIntMul
+    # Avoid BigInt
+    function safe_mul{T<:UInt128}(x::T, y::T)
+        # x * y > typemax(T)
+        y > 0 && x > fld(typemax(T), y) && return Nullable{T}()
+        Nullable{T}(x * y)
+    end
+end
+
+
+
 for I in [Int8,Int16,Int32,Int64,Int128,
           UInt8,UInt16,UInt32,UInt64,UInt128]
 
     s = I <: Signed ? 's' : 'u'
     b = sizeof(I) << 3
     r = b == 8 ? "[2 x i8]" : "{ i$b, i8 }" # LLVM return type
+    ops = []
+    if !(I <: Checked.BrokenSignedInt || I <: Checked.BrokenUnsignedInt)
+        push!(ops,:add)
+    end
+    if !(I <: Checked.BrokenSignedIntMul || I <: Checked.BrokenUnsignedIntMul)
+        push!(ops,:mul)
+    end
 
-    for op in [:add,:sub,:mul]
+    for op in ops
         f = symbol(:safe_,op)
         @eval @inline function $f(x::$I, y::$I)
             x,n = Base.llvmcall((

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -63,10 +63,7 @@ function tryparse_internal{S<:ByteString}(::Type{Bool}, sbuff::S, startpos::Int,
     Nullable{Bool}()
 end
 
-safe_add{T<:Integer}(n1::T, n2::T) = ((n2 > 0) ? (n1 > (typemax(T) - n2)) : (n1 < (typemin(T) - n2))) ? Nullable{T}() : Nullable{T}(n1 + n2)
-safe_mul{T<:Integer}(n1::T, n2::T) = ((n2 >   0) ? ((n1 > div(typemax(T),n2)) || (n1 < div(typemin(T),n2))) :
-                                      (n2 <  -1) ? ((n1 > div(typemin(T),n2)) || (n1 < div(typemax(T),n2))) :
-                                      ((n2 == -1) && n1 == typemin(T))) ? Nullable{T}() : Nullable{T}(n1 * n2)
+
 
 function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base::Int, a::Int, raise::Bool)
     _n = Nullable{T}()


### PR DESCRIPTION
Unfortunately the generated code is still not that nice, e.g. the function

``` julia
function zadd(x,y)
    z = Base.safe_add(x,y)
    isnull(z) ? zero(x) : get(z)
end
```

gives the following assembly:

```
julia> @code_native zadd(1,2)
    .section    __TEXT,__text,regular,pure_instructions
    pushq   %rbp
    movq    %rsp, %rbp
    addq    %rsi, %rdi
    seto    %al
    testb   $1, %al
    jne L19
    movq    %rdi, %rax
    popq    %rbp
    retq
L19:
    xorl    %eax, %eax
    popq    %rbp
    retq
    nopw    (%rax,%rax)
```

Now I'm not really that familiar with assembly, but wouldn't a `jo` instruction would be more appropriate?

As a net result, there doesn't seem to be much change in `safe_add`, but `safe_mul` is about 10 times faster.
