### PR TITLE
Updated gcc command line and execution instruction

### DIFF
--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -35,7 +35,9 @@ We start with a simple C program that initializes Julia and calls some Julia cod
 
 In order to build this program you have to put the path to the Julia header into the include path and link against ``libjulia``. For instance, when Julia is installed to ``$JULIA_DIR``, one can compile the above test program ``test.c`` with ``gcc`` using::
 
-    gcc -o test -fPIC -I$JULIA_DIR/include/julia -L$JULIA_DIR/usr/lib test.c -ljulia
+    gcc -o test -fPIC -I$JULIA_DIR/include/julia -L$JULIA_DIR/lib/julia test.c -ljulia $JULIA_DIR/lib/julia/libstdc++.so.6
+
+Then if the environment variable ``JULIA_HOME`` is set to ``$JULIA_DIR/bin``, the output ``test`` program can be executed.
 
 Alternatively, look at the ``embedding.c`` program in the Julia source tree in the ``examples/`` folder. The file ``ui/repl.c`` program is another simple example of how to set ``jl_options`` options while linking against ``libjulia``.
 


### PR DESCRIPTION
This change updates the gcc command line to include linking to libstdc++.so.6 (on Linux, might need modification for other OS's), and also adds instructions for setting JULIA_HOME such that the compiled example executes successfully.
