### PR TITLE
parser handles stray quotes in char literals

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -343,3 +343,7 @@ end
 @test_throws BoundsError parse("x = 1", 0)
 @test_throws BoundsError parse("x = 1", -1)
 @test_throws BoundsError parse("x = 1", 7)
+
+# issue #14683
+@test_throws ParseError parse("'\\A\"'")
+@test parse("'\"'") == parse("'\\\"'") == '"' == "\""[1] == '\42'


### PR DESCRIPTION
also, parser doesn't special case empty string literal (already handled in unescape-string)

fixes https://github.com/JuliaLang/julia/issues/14683
