### PR TITLE
Fix #14489 (Throw ArgumentError for invalid indices on creating Spars…

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -26,6 +26,14 @@ immutable SparseVector{Tv,Ti<:Integer} <: AbstractSparseVector{Tv,Ti}
         n >= 0 || throw(ArgumentError("The number of elements must be non-negative."))
         length(nzind) == length(nzval) ||
             throw(ArgumentError("index and value vectors must be the same length"))
+        for i=1:length(nzind)
+            if nzind[i] <= 0
+                throw(ArgumentError("indices must be positive"))
+            end
+            if nzind[i] > n
+                throw(ArgumentError("indices exceeds size of vector"))
+            end
+        end
         new(convert(Int, n), nzind, nzval)
     end
 end

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -9,6 +9,9 @@ spv_x1 = SparseVector(8, [2, 5, 6], [1.25, -0.75, 3.5])
 x1_full = zeros(length(spv_x1))
 x1_full[SparseArrays.nonzeroinds(spv_x1)] = nonzeros(spv_x1)
 
+@test_throws ArgumentError SparseVector(2, [1, 2, 3], [1, 1, 2])
+@test_throws ArgumentError SparseVector(4, [1, 0], [0, 1])
+
 ### Basic Properties
 
 let x = spv_x1


### PR DESCRIPTION
…eVector)

For indices that are non positive or exceed the size of the vector, we should throw an error.
