### PR TITLE
building does not error in gcc 4.7

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -345,7 +345,7 @@ ifneq ($(OS), WINNT)
 # Do no enable on windows to avoid warnings from libuv.
 JCXXFLAGS += -pedantic
 endif
-DEBUGFLAGS := -Og -ggdb2 -DJL_DEBUG_BUILD -fstack-protector-all
+DEBUGFLAGS := -O0 -ggdb2 -DJL_DEBUG_BUILD -fstack-protector-all
 SHIPFLAGS := -O3 -ggdb2 -falign-functions
 endif
 


### PR DESCRIPTION
previously, DEBUGFLAGS used the -Og flag, which is new in gcc 4.8

fixes #15020 
