### PR TITLE
eliminate emit_expr alternatives

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -434,6 +434,7 @@ static std::map<jl_fptr_t, Function*> builtin_func_map;
 // metadata tracking for a llvm Value* during codegen
 struct jl_cgval_t {
     Value *V; // may be of type T* or T, or set to NULL if ghost (or if the value has not been initialized yet, for a variable definition)
+    jl_value_t *constant; // constant value (rooted in linfo.def.roots)
     Value *gcroot; // the gcroot associated with V (if it has one)
     jl_value_t *typ; // the original type of V, never NULL
     //Type *T; // cached result of julia_type_to_llvm(typ)
@@ -445,6 +446,7 @@ struct jl_cgval_t {
     //bool isarg; // derived from an argument
     jl_cgval_t(Value *V, Value *gcroot, bool isboxed, jl_value_t *typ) : // general constructor (with pointer type auto-detect)
         V(V), // V is allowed to be NULL in a jl_varinfo_t context, but not during codegen contexts
+        constant(NULL),
         gcroot(gcroot),
         typ(typ),
         //T(julia_type_to_llvm(typ)),
@@ -456,6 +458,7 @@ struct jl_cgval_t {
     }
     jl_cgval_t(jl_value_t *typ) : // ghost value constructor
         V(NULL),
+        constant(((jl_datatype_t*)typ)->instance),
         gcroot(NULL),
         typ(typ),
         //T(T_void),
@@ -464,9 +467,12 @@ struct jl_cgval_t {
         ispointer(false),
         isimmutable(true)
     {
+        assert(jl_is_datatype(typ));
+        assert(constant);
     }
     jl_cgval_t(const jl_cgval_t &v, jl_value_t *typ) : // copy constructor with new type
         V(v.V),
+        constant(v.constant),
         gcroot(v.gcroot),
         typ(typ),
         //T(V.T),
@@ -479,6 +485,7 @@ struct jl_cgval_t {
     }
     jl_cgval_t() : // undef / unreachable / default constructor
         V(UndefValue::get(T_void)),
+        constant(NULL),
         gcroot(NULL),
         typ(jl_bottom_type),
         isboxed(false),
@@ -601,9 +608,7 @@ typedef struct {
     }
 } cFunctionList_t;
 
-static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool boxed=true,
-                        bool valuepos=true);
-static jl_cgval_t emit_unboxed(jl_value_t *e, jl_codectx_t *ctx);
+static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx);
 static int is_global(jl_sym_t *s, jl_codectx_t *ctx);
 
 static Value* emit_local_slot(jl_codectx_t *ctx);
@@ -616,6 +621,7 @@ static Value *emit_condition(jl_value_t *cond, const std::string &msg, jl_codect
 static void allocate_gc_frame(BasicBlock *b0, jl_codectx_t *ctx);
 static void finalize_gc_frame(Function *F);
 static void finalize_gc_frame(Module *m);
+static GlobalVariable *prepare_global(GlobalVariable *G);
 
 // --- convenience functions for tagging llvm values with julia types ---
 
@@ -635,7 +641,8 @@ static AllocaInst *emit_static_alloca(Type *lty)
 
 static inline jl_cgval_t ghostValue(jl_value_t *typ)
 {
-    assert(typ == jl_bottom_type || (jl_is_datatype(typ) && jl_datatype_size(typ) == 0));
+    if (typ == jl_bottom_type)
+        return jl_cgval_t(); // Undef{}
     return jl_cgval_t(typ);
 }
 static inline jl_cgval_t ghostValue(jl_datatype_t *typ)
@@ -696,7 +703,8 @@ static inline jl_cgval_t mark_julia_const(jl_value_t *jv)
     if (type_is_ghost(julia_type_to_llvm(typ))) {
         return ghostValue(typ);
     }
-    jl_cgval_t constant(literal_pointer_val(jv), NULL, true, typ);
+    jl_cgval_t constant(NULL, NULL, true, typ);
+    constant.constant = jv;
     return constant;
 }
 
@@ -2066,10 +2074,7 @@ static jl_cgval_t emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *
         // TODO: refactor. this partially duplicates code in emit_var
         if (bnd && bnd->value != NULL) {
             if (bnd->constp) {
-                if (jl_isbits(jl_typeof(bnd->value)))
-                    return emit_unboxed(bnd->value, ctx);
-                else
-                    return mark_julia_const(bnd->value);
+                return mark_julia_const(bnd->value);
             }
             return mark_julia_type(builder.CreateLoad(bp), true, (jl_value_t*)jl_any_type, ctx);
         }
@@ -2085,7 +2090,7 @@ static jl_cgval_t emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *
         jl_is_leaf_type((jl_value_t*)sty)) {
         unsigned idx = jl_field_index(sty, name, 0);
         if (idx != (unsigned)-1) {
-            jl_cgval_t strct = emit_expr(expr, ctx, false);
+            jl_cgval_t strct = emit_expr(expr, ctx);
             jl_cgval_t fld = emit_getfield_knownidx(strct, idx, sty, ctx);
             JL_GC_POP();
             return fld;
@@ -2147,26 +2152,22 @@ static Value *emit_bits_compare(const jl_cgval_t &arg1, const jl_cgval_t &arg2, 
 #ifdef LLVM37
             Value *answer = builder.CreateCall(prepare_call(memcmp_func),
                             {
-                            builder.CreatePointerCast(arg1.V, T_pint8),
-                            builder.CreatePointerCast(arg2.V, T_pint8),
+                            data_pointer(arg1, ctx, T_pint8),
+                            data_pointer(arg2, ctx, T_pint8),
                             ConstantInt::get(T_size, sz)
                             });
 #else
             Value *answer = builder.CreateCall3(prepare_call(memcmp_func),
-                    builder.CreatePointerCast(arg1.V, T_pint8),
-                    builder.CreatePointerCast(arg2.V, T_pint8),
+                    data_pointer(arg1, ctx, T_pint8),
+                    data_pointer(arg2, ctx, T_pint8),
                     ConstantInt::get(T_size, sz));
 #endif
             return builder.CreateICmpEQ(answer, ConstantInt::get(T_int32, 0));
         }
         else {
             Type *atp = at->getPointerTo();
-            Value *varg1 = arg1.V;
-            if (varg1->getType() != atp)
-                varg1 = builder.CreatePointerCast(varg1, atp);
-            Value *varg2 = arg2.V;
-            if (varg2->getType() != atp)
-                varg2 = builder.CreatePointerCast(varg2, atp);
+            Value *varg1 = data_pointer(arg1, ctx, atp);
+            Value *varg2 = data_pointer(arg2, ctx, atp);
             jl_svec_t *types = ((jl_datatype_t*)arg1.typ)->types;
             Value *answer = ConstantInt::get(T_int1, 1);
             size_t l = jl_svec_len(types);
@@ -2224,7 +2225,7 @@ static Value *emit_f_is(const jl_cgval_t &arg1, const jl_cgval_t &arg2, jl_codec
         ptr_comparable = 1;
     if (ptr_comparable) {
         assert(arg1.isboxed && arg2.isboxed); // only boxed types are valid for pointer comparison
-        return builder.CreateICmpEQ(arg1.V, arg2.V);
+        return builder.CreateICmpEQ(boxed(arg1, ctx), boxed(arg2, ctx));
     }
 
     Value *varg1 = boxed(arg1, ctx);
@@ -2272,8 +2273,8 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             }
         }
         // emit values
-        jl_cgval_t v1 = emit_unboxed(args[1], ctx);
-        jl_cgval_t v2 = emit_unboxed(args[2], ctx);
+        jl_cgval_t v1 = emit_expr(args[1], ctx);
+        jl_cgval_t v2 = emit_expr(args[2], ctx);
         // FIXME: v.typ is roughly equiv. to expr_type, but with typeof(T) == Type{T} instead of DataType in a few cases
         if (v1.typ == (jl_value_t*)jl_datatype_type)
             v1 = remark_julia_type(v1, expr_type(args[1], ctx)); // patch up typ if necessary
@@ -2430,7 +2431,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
     }
 
     else if (f==jl_builtin_throw && nargs==1) {
-        Value *arg1 = boxed(emit_expr(args[1], ctx), ctx, false); // rooted by throw
+        Value *arg1 = boxed(emit_expr(args[1], ctx), ctx); // rooted by throw
         // emit a "conditional" throw so that codegen does't end up trying to emit code after an "unreachable" terminator
         raise_exception_unless(ConstantInt::get(T_int1,0), arg1, ctx);
         *ret = jl_cgval_t();
@@ -2460,8 +2461,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     }
                 }
                 else {
-                    Value *idx = emit_unbox(T_size,
-                                            emit_unboxed(args[2], ctx), ity);
+                    Value *idx = emit_unbox(T_size, emit_expr(args[2], ctx), ity);
                     error_unless(builder.CreateICmpSGT(idx,
                                                       ConstantInt::get(T_size,0)),
                                  "arraysize: dimension out of range", ctx);
@@ -2476,7 +2476,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     builder.CreateBr(ansBB);
                     ctx->f->getBasicBlockList().push_back(inBB);
                     builder.SetInsertPoint(inBB);
-                    Value *v_sz = emit_arraysize(ary, idx);
+                    Value *v_sz = emit_arraysize(ary, idx, ctx);
                     builder.CreateBr(ansBB);
                     ctx->f->getBasicBlockList().push_back(ansBB);
                     builder.SetInsertPoint(ansBB);
@@ -2548,13 +2548,14 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     if (!isboxed && ((jl_datatype_t*)ety)->size == 0) {
                         // no-op, but emit expr for possible effects
                         assert(jl_is_datatype(ety));
-                        emit_expr(args[2],ctx,false);
+                        emit_expr(args[2], ctx);
                     }
                     else {
-                        jl_cgval_t v = (ety == (jl_value_t*)jl_any_type ? emit_expr(args[2],ctx) : emit_unboxed(args[2],ctx));
+                        jl_cgval_t v = (ety == (jl_value_t*)jl_any_type ? emit_expr(args[2], ctx) : emit_expr(args[2], ctx));
                         PHINode *data_owner = NULL; // owner object against which the write barrier must check
                         if (isboxed) { // if not boxed we don't need a write barrier
                             assert(ary.isboxed);
+                            Value *aryv = boxed(ary, ctx);
                             Value *flags = emit_arrayflags(ary, ctx);
                             // the owner of the data is ary itself except if ary->how == 3
                             flags = builder.CreateAnd(flags, 3);
@@ -2567,12 +2568,12 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                             // load owner pointer
                             Value *own_ptr = builder.CreateLoad(
                                 builder.CreateBitCast(builder.CreateConstGEP1_32(
-                                    builder.CreateBitCast(ary.V,T_pint8), jl_array_data_owner_offset(nd)),
+                                    builder.CreateBitCast(aryv, T_pint8), jl_array_data_owner_offset(nd)),
                                     T_ppjlvalue));
                             builder.CreateBr(mergeBB);
                             builder.SetInsertPoint(mergeBB);
                             data_owner = builder.CreatePHI(T_pjlvalue, 2);
-                            data_owner->addIncoming(ary.V, curBB);
+                            data_owner->addIncoming(aryv, curBB);
                             data_owner->addIncoming(own_ptr, ownedBB);
                         }
                         typed_store(emit_arrayptr(ary,args[1],ctx), idx, v,
@@ -2601,8 +2602,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
         // VA tuple
         if (ctx->vaStack && symbol_eq(args[1], ctx->vaName)) {
             Value *valen = emit_n_varargs(ctx);
-            Value *idx = emit_unbox(T_size,
-                                    emit_unboxed(args[2], ctx), fldt);
+            Value *idx = emit_unbox(T_size, emit_expr(args[2], ctx), fldt);
             idx = emit_bounds_check(
                     jl_cgval_t(builder.CreateGEP(ctx->argArray, ConstantInt::get(T_size, ctx->nReqArgs)), NULL, false, NULL),
                     NULL, idx, valen, ctx);
@@ -2631,7 +2631,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                 }
                 else {
                     // unknown index
-                    Value *vidx = emit_unbox(T_size, emit_unboxed(args[2], ctx), (jl_value_t*)jl_long_type);
+                    Value *vidx = emit_unbox(T_size, emit_expr(args[2], ctx), (jl_value_t*)jl_long_type);
                     if (emit_getfield_unknownidx(ret, strct, vidx, stt, ctx)) {
                         if (ret->typ == (jl_value_t*)jl_any_type) // improve the type, if known from the expr
                             ret->typ = expr_type(expr, ctx);
@@ -2657,10 +2657,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                 if (jl_is_leaf_type((jl_value_t*)sty) && jl_subtype(rhst, ft, 0)) {
                     // TODO: attempt better codegen for approximate types
                     jl_cgval_t strct = emit_expr(args[1], ctx); // emit lhs
-                    if (jl_field_isptr(sty, idx)) // emit rhs
-                        *ret = emit_expr(args[3], ctx);
-                    else
-                        *ret = emit_unboxed(args[3], ctx);
+                    *ret = emit_expr(args[3], ctx);
                     emit_setfield(sty, strct, idx, *ret, ctx, true, true);
                     JL_GC_POP();
                     return true;
@@ -2690,9 +2687,12 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
         else if (jl_is_leaf_type(aty)) {
             jl_cgval_t arg1 = emit_expr(args[1], ctx);
             Value *sz;
-            if (aty == (jl_value_t*)jl_datatype_type) {
+            if (arg1.constant) {
+                sz = ConstantInt::get(T_size, jl_datatype_nfields(arg1.typ));
+            }
+            else if (aty == (jl_value_t*)jl_datatype_type) {
                 assert(arg1.isboxed);
-                sz = emit_datatype_nfields(arg1.V);
+                sz = emit_datatype_nfields(boxed(arg1, ctx));
             }
             else {
                 sz = ConstantInt::get(T_size, jl_datatype_nfields(aty));
@@ -2711,9 +2711,10 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             if (rt2 == (jl_value_t*)jl_long_type) {
                 jl_cgval_t ty = emit_expr(args[1], ctx);
                 assert(ty.isboxed);
-                Value *types_svec = emit_datatype_types(ty.V);
-                Value *types_len = emit_datatype_nfields(ty.V);
-                Value *idx = emit_unbox(T_size, emit_unboxed(args[2], ctx), (jl_value_t*)jl_long_type);
+                Value *tyv = boxed(ty, ctx);
+                Value *types_svec = emit_datatype_types(tyv);
+                Value *types_len = emit_datatype_nfields(tyv);
+                Value *idx = emit_unbox(T_size, emit_expr(args[2], ctx), (jl_value_t*)jl_long_type);
                 emit_bounds_check(ty, (jl_value_t*)jl_datatype_type, idx, types_len, ctx);
                 Value *fieldtyp = builder.CreateLoad(builder.CreateGEP(builder.CreateBitCast(types_svec, T_ppjlvalue), idx));
                 *ret = mark_julia_type(fieldtyp, true, expr_type(expr, ctx), ctx);
@@ -2776,7 +2777,7 @@ static Value *emit_jlcall(Value *theFptr, Value *theF, jl_value_t **args,
         jl_cgval_t *anArg = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nargs);
         const jl_cgval_t **largs = (const jl_cgval_t**)alloca(sizeof(jl_cgval_t*) * nargs);
         for(size_t i=0; i < nargs; i++) {
-            anArg[i] = emit_expr(args[i], ctx, true, true);
+            anArg[i] = emit_expr(args[i], ctx);
             largs[i] = &anArg[i];
         }
         // put into argument space
@@ -2837,13 +2838,10 @@ static jl_cgval_t emit_call_function_object(jl_lambda_info_t *li, const jl_cgval
             }
             else if (et->isAggregateType()) {
                 assert(at == PointerType::get(et, 0));
-                jl_cgval_t arg = i==0 ? theF : emit_unboxed(args[i], ctx);
+                jl_cgval_t arg = i==0 ? theF : emit_expr(args[i], ctx);
                 if (arg.isimmutable && arg.ispointer) {
                     // can lazy load on demand, no copy needed
-                    Value *argv = arg.V;
-                    if (argv->getType() != at)
-                        argv = builder.CreatePointerCast(argv, at);
-                    argvals[idx] = argv;
+                    argvals[idx] = data_pointer(arg, ctx, at);
                     mark_gc_use(arg); // jwn must be after the jlcall
                 }
                 else {
@@ -2858,7 +2856,7 @@ static jl_cgval_t emit_call_function_object(jl_lambda_info_t *li, const jl_cgval
                 if (i == 0)
                     argvals[idx] = emit_unbox(et, theF, jt);
                 else
-                    argvals[idx] = emit_unbox(et, emit_unboxed(args[i], ctx), jt);
+                    argvals[idx] = emit_unbox(et, emit_expr(args[i], ctx), jt);
             }
             idx++;
         }
@@ -2949,7 +2947,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
     jl_cgval_t *anArg = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nargs);
     const jl_cgval_t **largs = (const jl_cgval_t**)alloca(sizeof(jl_cgval_t*) * nargs);
     for(size_t i=0; i < nargs; i++) {
-        anArg[i] = emit_expr(args[i], ctx, true, true);
+        anArg[i] = emit_expr(args[i], ctx);
         largs[i] = &anArg[i];
     }
     // put into argument space
@@ -3047,7 +3045,7 @@ static jl_cgval_t emit_checked_var(Value *bp, jl_sym_t *name, jl_codectx_t *ctx,
     return mark_julia_type(v, true, jl_any_type, ctx);
 }
 
-static jl_cgval_t emit_var(jl_sym_t *sym, jl_codectx_t *ctx, bool isboxed)
+static jl_cgval_t emit_var(jl_sym_t *sym, jl_codectx_t *ctx)
 {
     bool isglobal = is_global(sym, ctx);
     if (isglobal) {
@@ -3073,10 +3071,7 @@ static jl_cgval_t emit_var(jl_sym_t *sym, jl_codectx_t *ctx, bool isboxed)
         assert(bp != NULL);
         if (jbp && jbp->value != NULL) {
             if (jbp->constp) {
-                if (!isboxed && jl_isbits(jl_typeof(jbp->value)))
-                    return emit_unboxed(jbp->value, ctx);
-                else
-                    return mark_julia_const(jbp->value);
+                return mark_julia_const(jbp->value);
             }
             // double-check that a global variable is actually defined. this
             // can be a problem in parallel when a definition is missing on
@@ -3105,9 +3100,7 @@ static jl_cgval_t emit_var(jl_sym_t *sym, jl_codectx_t *ctx, bool isboxed)
         // copy value to a non-volatile location
         assert(vi.value.ispointer);
         Type *T = julia_type_to_llvm(vi.value.typ)->getPointerTo();
-        Value *v = vi.value.V;
-        if (v->getType() != T)
-            v = builder.CreatePointerCast(v, T);
+        Value *v = data_pointer(vi.value, ctx, T);
         return mark_julia_type(builder.CreateLoad(v, true), false, vi.value.typ, ctx);
     }
     else {
@@ -3121,26 +3114,13 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
         ssize_t idx = ((jl_gensym_t*)l)->id;
         assert(idx >= 0);
         assert(!ctx->gensym_assigned.at(idx));
-        jl_value_t *gensym_types = jl_lam_gensyms(ctx->ast);
-        jl_value_t *declType = (jl_is_array(gensym_types) ? jl_cellref(gensym_types, idx) : (jl_value_t*)jl_any_type);
-        jl_cgval_t slot; // slot is a jl_value_t or jl_value_t*
-        if (store_unboxed_p(declType)) {
-            Type *vtype = julia_type_to_llvm(declType);
+        jl_cgval_t slot = emit_expr(r, ctx); // slot could be a jl_value_t (unboxed) or jl_value_t* (ispointer)
+        if (!slot.isboxed && !slot.isimmutable) { // emit a copy of values stored in mutable slots
+            Type *vtype = julia_type_to_llvm(slot.typ);
             assert(vtype != T_pjlvalue);
-            if (type_is_ghost(vtype)) {
-                slot = emit_expr(r, ctx);
-            }
-            else {
-                slot = emit_unboxed(r, ctx);
-                if (!slot.isimmutable) { // emit a copy of values stored in mutable slots
-                    slot = mark_julia_type(
-                            emit_unbox(vtype, slot, declType),
-                            false, declType, ctx);
-                }
-            }
-        }
-        else {
-            slot = emit_expr(r, ctx, true);
+            slot = mark_julia_type(
+                    emit_unbox(vtype, slot, slot.typ),
+                    false, slot.typ, ctx);
         }
         ctx->gensym_SAvalues.at(idx) = slot; // now gensym_SAvalues[idx] contains the SAvalue
         assert(ctx->gensym_assigned.at(idx) = true); // (assignment, not comparison test)
@@ -3163,7 +3143,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
     }
     if (bp != NULL) { // it's a global
         assert(bnd);
-        Value *rval = boxed(emit_expr(r, ctx, true), ctx, false); // no root needed since this is about to be assigned to a global
+        Value *rval = boxed(emit_expr(r, ctx), ctx, false); // no root needed since this is about to be assigned to a global
 #ifdef LLVM37
         builder.CreateCall(prepare_call(jlcheckassign_func),
                            {literal_pointer_val(bnd),
@@ -3183,7 +3163,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
 
     if (vi.memloc || !vi.hasGCRoot) {
         // boxed or unused variables
-        jl_cgval_t rval_info = emit_expr(r, ctx, true);
+        jl_cgval_t rval_info = emit_expr(r, ctx);
         if (!vi.used)
             return;
 
@@ -3222,7 +3202,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
             // so we don't try to assign it to the arrayvar info
             jl_arrayvar_t *av = arrayvar_for(l, ctx);
             if (av != NULL) {
-                assign_arrayvar(*av, rval_info);
+                assign_arrayvar(*av, rval_info, ctx);
             }
         }
     }
@@ -3235,7 +3215,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
         assert(vi.value.ispointer);
         builder.CreateStore(emit_unbox(
                     julia_type_to_llvm(vi.value.typ),
-                    emit_unboxed(r, ctx),
+                    emit_expr(r, ctx),
                     vi.value.typ),
                 vi.value.V, vi.isVolatile);
     }
@@ -3245,7 +3225,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
 
 static Value *emit_condition(jl_value_t *cond, const std::string &msg, jl_codectx_t *ctx)
 {
-    jl_cgval_t condV = emit_unboxed(cond, ctx);
+    jl_cgval_t condV = emit_expr(cond, ctx);
     if (condV.typ == (jl_value_t*)jl_bool_type) {
         Value *cond = emit_unbox(T_int1, condV, (jl_value_t*)jl_bool_type);
         assert(cond->getType() == T_int1);
@@ -3253,32 +3233,63 @@ static Value *emit_condition(jl_value_t *cond, const std::string &msg, jl_codect
     }
     emit_typecheck(condV, (jl_value_t*)jl_bool_type, msg, ctx);
     if (condV.isboxed) {
-        return builder.CreateICmpEQ(condV.V, tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlfalse_var))));
+        return builder.CreateICmpEQ(boxed(condV, ctx), tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlfalse_var))));
     }
     // not a boolean
     return ConstantInt::get(T_int1,0); // TODO: replace with Undef
 }
 
-static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, bool valuepos)
+static void emit_stmtpos(jl_value_t *expr, jl_codectx_t *ctx)
+{
+    if (jl_is_symbol(expr))
+        return; // value not used, no point in attempting codegen for it
+    if (jl_is_symbolnode(expr))
+        return; // value not used, no point in attempting codegen for it
+    if (jl_is_gensym(expr))
+        return; // value not used, no point in attempting codegen for it
+    if (jl_is_linenode(expr))
+        return;
+    if (jl_is_newvarnode(expr)) {
+        jl_sym_t *var = (jl_sym_t*)jl_fieldref(expr, 0);
+        assert(jl_is_symbol(var));
+        jl_varinfo_t &vi = ctx->vars[var];
+        Value *lv = vi.memloc;
+        if (lv != NULL) {
+            // create a new uninitialized variable
+            if (vi.usedUndef) {
+                builder.CreateStore(V_null, lv);
+            }
+        }
+        return;
+    }
+    if (jl_is_expr(expr)) {
+        jl_sym_t *head = ((jl_expr_t*)expr)->head;
+        // some expression types are metadata and can be ignored in statement position
+        if (head == line_sym || head == type_goto_sym || head == meta_sym) {
+            return;
+        }
+        // fall-through
+    }
+    (void)emit_expr(expr, ctx);
+}
+
+static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
 {
     if (jl_is_symbol(expr)) {
-        if (!valuepos) return jl_cgval_t(); // value not used, no point in doing codegen for it
         jl_sym_t *sym = (jl_sym_t*)expr;
-        return emit_var(sym, ctx, isboxed);
+        return emit_var(sym, ctx);
     }
     if (jl_is_symbolnode(expr)) {
-        if (!valuepos) return jl_cgval_t(); // value not used, no point in doing codegen for it
         jl_sym_t *sym = jl_symbolnode_sym(expr);
         jl_value_t *typ = jl_symbolnode_type(expr);
         if (jl_is_typevar(typ))
             typ = ((jl_tvar_t*)typ)->ub;
-        jl_cgval_t val = emit_var(sym, ctx, isboxed);
+        jl_cgval_t val = emit_var(sym, ctx);
         if (val.isboxed)
             val = remark_julia_type(val, typ); // patch up typ to match SymbolNode.type
         return val; // patch up typ to match SymbolNode.type
     }
     if (jl_is_gensym(expr)) {
-        if (!valuepos) return jl_cgval_t(); // value not used, no point in doing codegen for it
         ssize_t idx = ((jl_gensym_t*)expr)->id;
         assert(idx >= 0);
         //assert(ctx->gensym_assigned.at(idx));
@@ -3296,9 +3307,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
         return jl_cgval_t();
     }
     if (jl_is_linenode(expr)) {
-        if (valuepos)
-            jl_error("Linenode in value position");
-        return jl_cgval_t();
+        jl_error("Linenode in value position");
     }
     if (jl_is_gotonode(expr)) {
         if (builder.GetInsertBlock()->getTerminator() == NULL) {
@@ -3325,21 +3334,6 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
             return mark_julia_const(b->value);
         }
         return emit_checked_var(julia_binding_gv(b), var, ctx);
-    }
-    if (jl_is_newvarnode(expr)) {
-        assert(!valuepos);
-        jl_sym_t *var = (jl_sym_t*)jl_fieldref(expr,0);
-        assert(!jl_is_gensym(var));
-        assert(jl_is_symbol(var));
-        jl_varinfo_t &vi = ctx->vars[var];
-        Value *lv = vi.memloc;
-        if (lv != NULL) {
-            // create a new uninitialized variable
-            if (vi.usedUndef) {
-                builder.CreateStore(V_null, lv);
-            }
-        }
-        return jl_cgval_t();
     }
     if (!jl_is_expr(expr)) {
         int needroot = true;
@@ -3406,9 +3400,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
     }
     else if (head == assign_sym) {
         emit_assignment(args[0], args[1], ctx);
-        if (valuepos) {
-            return ghostValue(jl_void_type);
-        }
+        return ghostValue(jl_void_type);
     }
     else if (head == method_sym) {
         jl_value_t *mn = args[0];
@@ -3593,9 +3585,6 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
             jl_printf(JL_STDERR, "WARNING: could not attach metadata for @simd loop.\n");
         return jl_cgval_t();
     }
-    else if (head == meta_sym) {
-        return ghostValue(jl_void_type);  // will change as new metadata gets added
-    }
     else {
         if (!strcmp(jl_symbol_name(head), "$"))
             jl_error("syntax: prefix \"$\" in non-quoted expression");
@@ -3609,17 +3598,14 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
             jl_add_linfo_root(ctx->linfo, expr);
             return ghostValue(jl_void_type);
         }
-        // some expression types are metadata and can be ignored
-        if (valuepos || !(head == line_sym || head == type_goto_sym)) {
-            if (head == abstracttype_sym || head == compositetype_sym ||
-                head == bitstype_sym) {
-                jl_errorf("type definition not allowed inside a local scope");
-            }
-            else {
-                jl_errorf("unsupported or misplaced expression \"%s\" in function %s",
-                          jl_symbol_name(head),
-                          jl_symbol_name(ctx->linfo->name));
-            }
+        if (head == abstracttype_sym || head == compositetype_sym ||
+            head == bitstype_sym) {
+            jl_errorf("type definition not allowed inside a local scope");
+        }
+        else {
+            jl_errorf("unsupported or misplaced expression \"%s\" in function %s",
+                      jl_symbol_name(head),
+                      jl_symbol_name(ctx->linfo->name));
         }
     }
     return jl_cgval_t();
@@ -4159,10 +4145,12 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
         varinfo.escapes = false;
         varinfo.isSA = (jl_vinfo_sa(vi)!=0);
         varinfo.usedUndef = (jl_vinfo_usedundef(vi)!=0) || (!varinfo.isArgument && !lam->inferred);
-        jl_value_t *typ = jl_cellref(vi,1);
-        if (!jl_is_type(typ))
-            typ = (jl_value_t*)jl_any_type;
-        varinfo.value = mark_julia_type((Value*)NULL, false, typ, &ctx);
+        if (!varinfo.isArgument || varinfo.isAssigned) {
+            jl_value_t *typ = jl_cellref(vi,1);
+            if (!jl_is_type(typ))
+                typ = (jl_value_t*)jl_any_type;
+            varinfo.value = mark_julia_type((Value*)NULL, false, typ, &ctx);
+        }
     }
 
     // step 3. some variable analysis
@@ -4720,7 +4708,7 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
             // get arrayvar data if applicable
             if (arrayvars.find(s) != arrayvars.end()) {
                 jl_arrayvar_t av = arrayvars[s];
-                assign_arrayvar(av, theArg);
+                assign_arrayvar(av, theArg, &ctx);
             }
         }
         else {
@@ -4896,17 +4884,13 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
                 retty = T_pjlvalue;
                 retboxed = true;
             }
-            if (retboxed) {
-                retval = boxed(emit_expr(jl_exprarg(ex,0), &ctx, true), &ctx, false); // skip the gcroot on the return path
-            }
-            else if (!type_is_ghost(retty)) {
-                retval = emit_unbox(retty,
-                                    emit_unboxed(jl_exprarg(ex,0), &ctx), jlrettype);
-            }
-            else { // undef return type
-                emit_expr(jl_exprarg(ex,0), &ctx, false);
+            jl_cgval_t retvalinfo = emit_expr(jl_exprarg(ex,0), &ctx);
+            if (retboxed)
+                retval = boxed(retvalinfo, &ctx, false); // skip the gcroot on the return path
+            else if (!type_is_ghost(retty))
+                retval = emit_unbox(retty, retvalinfo, jlrettype);
+            else // undef return type
                 retval = NULL;
-            }
             if (do_malloc_log && lno != -1)
                 mallocVisitLine(filename, lno);
             if (ctx.sret)
@@ -4923,13 +4907,13 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
         }
         else if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == boundscheck_sym) {
             // always emit expressions that update the boundscheck stack
-            emit_expr(stmt, &ctx, false, false);
+            emit_stmtpos(stmt, &ctx);
         }
         else if (is_inbounds(&ctx) && is_bounds_check_block(&ctx)) {
             // elide bounds check blocks
         }
         else {
-            emit_expr(stmt, &ctx, false, false);
+            emit_stmtpos(stmt, &ctx);
         }
     }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -841,6 +841,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         write_int32(s, li->specFunctionID);
         if (li->functionID)
             write_int8(s, li->jlcall_api);
+        write_int8(s, li->needs_sparam_vals_ducttape);
     }
     else if (jl_typeis(v, jl_module_type)) {
         jl_serialize_module(s, (jl_module_t*)v);
@@ -1466,6 +1467,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         cfunc_llvm = read_int32(s);
         jl_delayed_fptrs(li, func_llvm, cfunc_llvm);
         li->jlcall_api = func_llvm ? read_int8(s) : 0;
+        li->needs_sparam_vals_ducttape = read_int8(s);
         return (jl_value_t*)li;
     }
     else if (vtag == (jl_value_t*)jl_module_type) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -334,22 +334,12 @@ jl_lambda_info_t *jl_get_unspecialized(jl_lambda_info_t *method)
         def = def->unspecialized;
     }
     if (__unlikely(def->unspecialized == NULL)) {
-        int need_sparams = 0; // if there are intrinsics, probably require the sparams to compile successfully
-        if (method->sparam_vals != jl_emptysvec) {
-            jl_value_t *ast = def->ast;
-            JL_GC_PUSH1(&ast);
-            if (!jl_is_expr(ast))
-                ast = jl_uncompress_ast(def, ast);
-            if (jl_has_intrinsics(method, jl_lam_body((jl_expr_t*)ast), method->module))
-                need_sparams = 1;
-            JL_GC_POP();
-        }
-        if (need_sparams) {
+        if (method->def->needs_sparam_vals_ducttape) {
             method->unspecialized = jl_add_static_parameters(def, method->sparam_vals, method->specTypes);
             jl_gc_wb(method, method->unspecialized);
             method->unspecialized->unspecialized = method->unspecialized;
             def = method;
-       }
+        }
         else {
             def->unspecialized = jl_add_static_parameters(def, jl_emptysvec, jl_anytuple_type);
             jl_gc_wb(def, def->unspecialized);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -350,16 +350,12 @@ static jl_value_t *staticeval_bitstype(jl_value_t *targ, const char *fname, jl_c
         bt = jl_tparam0(et);
     }
     else {
-        JL_TRY { // TODO: change this to an actual call to staticeval rather than actually executing code
-            bt = jl_interpret_toplevel_expr_in(ctx->module, targ,
-                                               ctx->linfo->sparam_syms,
-                                               ctx->linfo->sparam_vals);
-        }
-        JL_CATCH {
-            bt = NULL;
+        bt = try_eval(targ, ctx, NULL); // TODO: change this to an actual call to staticeval rather than actually executing code
+        if (bt && !jl_is_leaf_type(bt)) {
+            jl_add_linfo_root(ctx->linfo, bt);
         }
     }
-    if (fname && !jl_is_bitstype(bt)) {
+    if (fname && (!bt || !jl_is_bitstype(bt))) {
         jl_errorf("%s: expected bits type as first argument", fname);
         return NULL;
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -351,9 +351,7 @@ static jl_value_t *staticeval_bitstype(jl_value_t *targ, const char *fname, jl_c
     }
     else {
         bt = try_eval(targ, ctx, NULL); // TODO: change this to an actual call to staticeval rather than actually executing code
-        if (bt && !jl_is_leaf_type(bt)) {
-            jl_add_linfo_root(ctx->linfo, bt);
-        }
+        if (bt) jl_add_linfo_root(ctx->linfo, bt);
     }
     if (fname && (!bt || !jl_is_bitstype(bt))) {
         jl_errorf("%s: expected bits type as first argument", fname);
@@ -389,9 +387,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
 {
     // Examine the first argument //
     jl_value_t *bt = static_eval(targ, ctx, true, true);
-    if (bt && !jl_is_leaf_type(bt)) {
-        jl_add_linfo_root(ctx->linfo, bt);
-    }
+    if (bt) jl_add_linfo_root(ctx->linfo, bt);
 
     if (!bt || !jl_is_bitstype(bt)) {
         // it's easier to throw a good error from C than llvm

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -255,13 +255,6 @@ static Constant *julia_const_to_llvm(jl_value_t *e, bool nested=false)
     return NULL;
 }
 
-static jl_cgval_t emit_unboxed(jl_value_t *e, jl_codectx_t *ctx)
-{
-    Constant *c = julia_const_to_llvm(e);
-    if (c) return mark_julia_type(c, false, expr_type(e, ctx), ctx);
-    return emit_expr(e, ctx, false);
-}
-
 static jl_cgval_t ghostValue(jl_value_t *ty);
 
 // emit code to unpack a raw value from a box into registers
@@ -276,17 +269,10 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt)
         //emit_error("emit_unbox: a type mismatch error in occurred during codegen", ctx);
         return UndefValue::get(to); // type mismatch error
     }
-    if (!x.isboxed) { // already unboxed, but sometimes need conversion
-        Value *unboxed;
-        if (x.ispointer) {
-            if (jt == (jl_value_t*)jl_bool_type && to != T_int1)
-                return builder.CreateZExt(builder.CreateLoad(builder.CreatePointerCast(x.V, T_int1->getPointerTo())), to);
-            else
-                return builder.CreateLoad(builder.CreatePointerCast(x.V, to->getPointerTo()));
-        }
-        else {
-            unboxed = x.V;
-        }
+
+    Constant *c = x.constant ? julia_const_to_llvm(x.constant) : NULL;
+    if (!x.ispointer || c) { // already unboxed, but sometimes need conversion
+        Value *unboxed = c ? c : x.V;
         Type *ty = unboxed->getType();
         // bools are stored internally as int8 (for now)
         if (ty == T_int1 && to == T_int8)
@@ -308,14 +294,20 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt)
         }
         return unboxed;
     }
-    Value *p = x.V;
-    if (to == T_int1) {
-        // bools stored as int8, so an extra Trunc is needed to get an int1
-        return builder.CreateTrunc(
-                builder.CreateLoad(builder.CreateBitCast(p, T_pint8)),
-                T_int1);
-    }
-    return builder.CreateAlignedLoad(builder.CreateBitCast(p, to->getPointerTo()), 16); // julia's gc gives 16-byte aligned addresses
+
+    // bools stored as int8, so an extra Trunc is needed to get an int1
+    Value *p = x.constant ? literal_pointer_val(x.constant) : x.V;
+    Type *ptype = (to == T_int1 ? T_pint8 : to->getPointerTo());
+    if (p->getType() != ptype)
+        p = builder.CreateBitCast(p, ptype);
+    if (to == T_int1)
+        return builder.CreateTrunc(builder.CreateLoad(p), T_int1);
+    if (jt == (jl_value_t*)jl_bool_type)
+        return builder.CreateZExt(builder.CreateTrunc(builder.CreateLoad(p), T_int1), to);
+
+    if (!x.isboxed) // stack has default alignment
+        return builder.CreateLoad(p);
+    return builder.CreateAlignedLoad(p, 16); // julia's gc gives 16-byte aligned addresses
 }
 
 // unbox, trying to determine correct bitstype automatically
@@ -344,7 +336,7 @@ static Value *auto_unbox(const jl_cgval_t &v, jl_codectx_t *ctx)
 }
 static Value *auto_unbox(jl_value_t *x, jl_codectx_t *ctx)
 {
-    jl_cgval_t v = emit_unboxed(x, ctx);
+    jl_cgval_t v = emit_expr(x, ctx);
     return auto_unbox(v, ctx);
 }
 
@@ -424,7 +416,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
     int nb = jl_datatype_size(bt);
 
     // Examine the second argument //
-    jl_cgval_t v = emit_unboxed(x, ctx);
+    jl_cgval_t v = emit_expr(x, ctx);
     bool isboxed;
     Type *vxt = julia_type_to_llvm(v.typ, &isboxed);
 
@@ -455,14 +447,20 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
         }
     }
 
-    Value *vx = v.V;
-    if (v.ispointer) {
+    assert(!v.isghost);
+    Value *vx = NULL;
+    if (!v.ispointer)
         vx = v.V;
-        if (isboxed) // try to load as original Type, to preserve llvm optimizations
-            vxt = llvmt; // but if the v.typ is not well known, use T
-        if (vx->getType()->getPointerElementType() != vxt)
-            vx = builder.CreatePointerCast(vx, vxt->getPointerTo());
-        vx = builder.CreateLoad(vx);
+    else if (v.constant)
+        vx = julia_const_to_llvm(v.constant);
+
+    if (v.ispointer && vx == NULL) {
+        // try to load as original Type, to preserve llvm optimizations
+        // but if the v.typ is not well known, use llvmt
+        if (isboxed)
+            vxt = llvmt;
+        vx = builder.CreateLoad(data_pointer(v, ctx,
+                    vxt == T_int1 ? T_pint8 : vxt->getPointerTo()));
     }
 
     vxt = vx->getType();
@@ -489,7 +487,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
     jl_value_t *bt = staticeval_bitstype(targ, NULL, ctx);
 
     // Examine the second argument //
-    jl_cgval_t v = emit_unboxed(x, ctx);
+    jl_cgval_t v = emit_expr(x, ctx);
 
     if (bt == NULL || !jl_is_leaf_type(bt)) {
         // dynamically-determined type; evaluate.
@@ -521,7 +519,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
             builder.CreateAlignedStore(emit_unbox(llvmt, v, v.typ), builder.CreatePointerCast(newobj, llvmt->getPointerTo()), alignment);
         }
         else {
-            prepare_call(builder.CreateMemCpy(newobj, builder.CreateBitCast(v.V, T_pint8), nb, alignment)->getCalledValue());
+            prepare_call(builder.CreateMemCpy(newobj, data_pointer(v, ctx, T_pint8), nb, alignment)->getCalledValue());
             mark_gc_use(v);
         }
         return mark_julia_type(newobj, true, bt ? bt : (jl_value_t*)jl_any_type, ctx);
@@ -540,12 +538,12 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
     Value *vx;
     if (v.ispointer) {
         // TODO: validate the size and type of the pointer contents
-        if (v.isimmutable) { // wrong type, but can lazy load this later as needed
+        if (v.isimmutable && !v.constant) { // wrong type, but can lazy load this later as needed
             v.typ = bt;
             v.isboxed = false;
             return v;
         }
-        vx = builder.CreateLoad(builder.CreateBitCast(v.V, llvmt->getPointerTo()));
+        vx = builder.CreateLoad(data_pointer(v, ctx, llvmt->getPointerTo()));
     }
     else {
         vx = v.V;
@@ -729,7 +727,7 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
         return emit_runtime_pointerref(e, i, ctx);
         //jl_error("pointerref: invalid index type");
     Value *thePtr = auto_unbox(e,ctx);
-    Value *idx = emit_unbox(T_size, emit_unboxed(i, ctx), (jl_value_t*)jl_long_type);
+    Value *idx = emit_unbox(T_size, emit_expr(i, ctx), (jl_value_t*)jl_long_type);
     Value *im1 = builder.CreateSub(idx, ConstantInt::get(T_size, 1));
     if (!jl_isbits(ety)) {
         if (ety == (jl_value_t*)jl_any_type)
@@ -794,7 +792,7 @@ static jl_cgval_t emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, j
     if (expr_type(i, ctx) != (jl_value_t*)jl_long_type)
         return emit_runtime_pointerset(e, x, i, ctx);
         //jl_error("pointerset: invalid index type");
-    Value *idx = emit_unbox(T_size, emit_unboxed(i, ctx),(jl_value_t*)jl_long_type);
+    Value *idx = emit_unbox(T_size, emit_expr(i, ctx),(jl_value_t*)jl_long_type);
     Value *im1 = builder.CreateSub(idx, ConstantInt::get(T_size, 1));
     Value *thePtr = auto_unbox(e,ctx);
     if (!jl_isbits(ety) && ety != (jl_value_t*)jl_any_type) {
@@ -803,21 +801,18 @@ static jl_cgval_t emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, j
             return jl_cgval_t();
         }
         if (!emitted)
-            val = emit_expr(x,ctx,true,true);
+            val = emit_expr(x, ctx);
         assert(val.isboxed);
         assert(jl_is_datatype(ety));
         uint64_t size = ((jl_datatype_t*)ety)->size;
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, ((jl_datatype_t*)ety)->alignment)));
         prepare_call(builder.CreateMemCpy(builder.CreateGEP(builder.CreateBitCast(thePtr, T_pint8), im1),
-                             builder.CreateBitCast(val.V, T_pint8), size, 1)->getCalledValue());
+                             data_pointer(val, ctx, T_pint8), size, 1)->getCalledValue());
     }
     else {
         if (!emitted) {
-            if (ety == (jl_value_t*)jl_any_type)
-                val = emit_expr(x,ctx);
-            else
-                val = emit_unboxed(x,ctx);
+            val = emit_expr(x, ctx);
         }
         // TODO: alignment?
         typed_store(thePtr, im1, val, ety, ctx, tbaa_user, NULL, 1);
@@ -1046,23 +1041,27 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Value *ifelse_result;
         if (!isboxed && t1 == t2) {
             // emit X and Y arguments
-            jl_cgval_t x = emit_unboxed(args[2], ctx);
-            jl_cgval_t y = emit_unboxed(args[3], ctx);
+            jl_cgval_t x = emit_expr(args[2], ctx);
+            jl_cgval_t y = emit_expr(args[3], ctx);
             // check the return value was valid
             if (type_is_ghost(llt1))
                 return x;
-            if (x.V->getType() == T_void && y.V->getType() == T_void)
+            if (x.typ == jl_bottom_type && y.typ == jl_bottom_type)
                 return jl_cgval_t(); // undefined
-            if (x.V->getType() == T_void)
+            if (x.typ == jl_bottom_type)
                 return y;
-            if (y.V->getType() == T_void)
+            if (y.typ == jl_bottom_type)
                 return x;
             // ensure that X and Y have the same llvm Type
-            Value *vx = x.V, *vy = y.V;
+            Value *vx, *vy;
             if (x.ispointer) // TODO: elid this load if unnecessary
-                vx = builder.CreateLoad(builder.CreatePointerCast(vx, llt1->getPointerTo(0)));
+                vx = builder.CreateLoad(data_pointer(x, ctx, llt1->getPointerTo(0)));
+            else
+                vx = x.V;
             if (y.ispointer) // TODO: elid this load if unnecessary
-                vy = builder.CreateLoad(builder.CreatePointerCast(vy, llt1->getPointerTo(0)));
+                vy = builder.CreateLoad(data_pointer(y, ctx, llt1->getPointerTo(0)));
+            else
+                vy = y.V;
             ifelse_result = builder.CreateSelect(isfalse, vy, vx);
             mark_gc_use(x);
             mark_gc_use(y);
@@ -1083,7 +1082,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 
     default: {
         if (nargs < 1) jl_error("invalid intrinsic call");
-        jl_cgval_t xinfo = emit_unboxed(args[1], ctx);
+        jl_cgval_t xinfo = emit_expr(args[1], ctx);
         Value *x = auto_unbox(xinfo, ctx);
         if (!x || type_is_ghost(x->getType())) {
             emit_error("invalid intrinsic argument at 1", ctx);

--- a/src/julia.h
+++ b/src/julia.h
@@ -350,6 +350,9 @@ typedef struct _jl_lambda_info_t {
     uint8_t inInference : 1;    // flags to tell if inference is running on this function
                                 // used to avoid infinite recursion
     uint8_t inCompile : 1;
+    uint8_t needs_sparam_vals_ducttape : 1; // if there are intrinsic calls,
+                                            // probably require the sparams to compile successfully
+                                            // (and so unspecialized will be created for each linfo instead of linfo->def)
     jl_fptr_t fptr;             // jlcall entry point
 
     // On the old JIT, handles to all Functions generated for this linfo

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -244,15 +244,22 @@ int jl_has_intrinsics(jl_lambda_info_t *li, jl_expr_t *e, jl_module_t *m)
 {
     if (jl_array_len(e->args) == 0)
         return 0;
-    if (e->head == static_typeof_sym) return 1;
-    jl_value_t *e0 = jl_exprarg(e,0);
+    if (e->head == static_typeof_sym)
+        return 1;
+    jl_value_t *e0 = jl_exprarg(e, 0);
     if (e->head == call_sym) {
-        jl_value_t *sv = jl_static_eval(e0, NULL, m, li, 0, 0);
+        jl_value_t *sv = jl_static_eval(e0, NULL, m, li, li != NULL, 0);
+        if (sv && jl_typeis(sv, jl_intrinsic_type))
+            return 1;
+    }
+    if (0 && e->head == assign_sym && jl_is_gensym(e0)) { // code branch needed for *very-linear-mode*, but not desirable otherwise
+        jl_value_t *e1 = jl_exprarg(e, 1);
+        jl_value_t *sv = jl_static_eval(e1, NULL, m, li, li != NULL, 0);
         if (sv && jl_typeis(sv, jl_intrinsic_type))
             return 1;
     }
     int i;
-    for(i=0; i < jl_array_len(e->args); i++) {
+    for (i=0; i < jl_array_len(e->args); i++) {
         jl_value_t *a = jl_exprarg(e,i);
         if (jl_is_expr(a) && jl_has_intrinsics(li, (jl_expr_t*)a, m))
             return 1;


### PR DESCRIPTION
the different between the several emit_expr alternatives was mostly superficial following the codegen_rewrite PRs. this finishes the work of merging the potential optimizations paths from this set of functions (which was previously a question of whether to return constants as boxed or unboxed values).

`emit_expr` is now the only way to go from `jl_expr_t` -> `jl_cgval_t`.

to go from `jl_cgval_t` to `Value*`, there are a few options:
- `emit_unboxed` -> get the raw bits, unboxed. (occasionally instead use `.V` if `ispointer = false` and you don't want any llvm type conversion to happen)
- `boxed` -> get a `jl_value_t*` (plain and simple). if it needed to box the value, it makes the gcroot also, unless hinted not to by the caller
- `data_pointer` -> get the raw pointer for a pointer value (`ispointer = true`)
- `.V` -> accessing the value field directly is usually discouraged, but occasionally necessary

if you access `.V` or `data_pointer` directly, the code author is responsible for calling `mark_gc_use`, if the usage may not be "obvious" to the compiler (for example, a `CallExpr` usage can't be optimized away, whereas an PtrToInt or GEP may be hard for the root detection algorithm to track)
