### PR TITLE
increase Win64 stack space

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -856,13 +856,14 @@ ifneq ($(USEMSVC), 1)
 HAVE_SSP := 1
 OSLIBS += -Wl,--export-all-symbols -Wl,--version-script=$(JULIAHOME)/src/julia.expmap \
 	$(NO_WHOLE_ARCHIVE) -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp
-JLDFLAGS := -Wl,--stack,8388608
 ifeq ($(ARCH),i686)
-JLDFLAGS += -Wl,--large-address-aware
+JLDFLAGS := -Wl,--stack,8388608 -Wl,--large-address-aware
+else #x64
+JLDFLAGS := -Wl,--stack,16777216
 endif
 else #USEMSVC
 OSLIBS += kernel32.lib ws2_32.lib psapi.lib advapi32.lib iphlpapi.lib shell32.lib winmm.lib
-JLDFLAGS := -stack:8388608
+JLDFLAGS := -stack:16777216
 endif
 JCPPFLAGS += -D_WIN32_WINNT=0x0502
 UNTRUSTED_SYSTEM_LIBM := 1


### PR DESCRIPTION
this should help improve the buildbot passing rate, until type-inference is fixed to work non-recursively
