### PR TITLE
WorkerPool and remote()

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1223,6 +1223,7 @@ export
     pmap,
     procs,
     put!,
+    remote,
     remotecall,
     remotecall_fetch,
     remotecall_wait,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -226,6 +226,7 @@ include("serialize.jl")
 importall .Serializer
 include("channels.jl")
 include("multi.jl")
+include("workerpool.jl")
 include("managers.jl")
 
 # code loading

--- a/base/workerpool.jl
+++ b/base/workerpool.jl
@@ -1,0 +1,75 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+
+type WorkerPool
+    channel::RemoteChannel{Channel{Int}}
+end
+
+
+"""
+    WorkerPool([workers])
+
+Create a WorkerPool from a vector of worker ids.
+"""
+function WorkerPool(workers=Int[])
+
+    # Create a shared queue of available workers...
+    pool = WorkerPool(RemoteChannel(()->Channel{Int}(128)))
+
+    # Add workers to the pool...
+    for w in workers
+        put!(pool, w)
+    end
+
+    return pool
+end
+
+
+put!(pool::WorkerPool, w::Int) = put!(pool.channel, w)
+put!(pool::WorkerPool, w::Worker) = put!(pool.channel, w.id)
+
+isready(pool::WorkerPool) = isready(pool.channel)
+
+take!(pool::WorkerPool) = take!(pool.channel)
+
+
+"""
+    remotecall_fetch(f, pool::WorkerPool, args...)
+
+Call `f(args...)` on one of the workers in `pool`.
+"""
+function remotecall_fetch(f, pool::WorkerPool, args...)
+    worker = take!(pool)
+    try
+        remotecall_fetch(f, worker, args...)
+    finally
+        put!(pool, worker)
+    end
+end
+
+
+"""
+    default_worker_pool
+
+WorkerPool containing idle `workers()` (used by `remote(f)`).
+"""
+_default_worker_pool = Nullable{WorkerPool}()
+function default_worker_pool()
+    if isnull(_default_worker_pool) && myid() == 1
+        set_default_worker_pool(WorkerPool())
+    end
+    return get(_default_worker_pool)
+end
+
+function set_default_worker_pool(p::WorkerPool)
+    global _default_worker_pool = Nullable(p)
+end
+
+
+"""
+    remote(f)
+
+Returns a lambda that executes function `f` on an available worker
+using `remotecall_fetch`.
+"""
+remote(f) = (args...)->remotecall_fetch(f, default_worker_pool(), args...)

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -339,6 +339,12 @@ General Parallel Computing Support
 
    Perform ``fetch(remotecall(...))`` in one message. Any remote exceptions are captured in a ``RemoteException`` and thrown.
 
+.. function:: remote(f)
+
+   .. Docstring generated from Julia source
+
+   Returns a lambda that executes function ``f`` on an available worker using ``remotecall_fetch``.
+
 .. function:: put!(RemoteChannel, value)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
Second step in [Simplifying and generalising pmap (as per #14843)](https://github.com/JuliaLang/julia/issues/14843).

Please limit comments on this PR to technical / implementation detail relating to the code in the PR.

Please make comments relating the interface and the overall pmap refactoring in issue #14843.

See also [#15058 asyncmap](https://github.com/JuliaLang/julia/pull/15058)
