### PR TITLE
WIP: implemented task copying: #4085

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1399,6 +1399,7 @@ extern DLLEXPORT JL_THREAD jl_task_t *jl_root_task;
 extern DLLEXPORT JL_THREAD jl_value_t *jl_exception_in_transit;
 
 DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
+DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t, size_t ssize);
 DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);
 DLLEXPORT void NORETURN jl_throw(jl_value_t *e);
 DLLEXPORT void NORETURN jl_throw_with_superfluous_argument(jl_value_t *e, int);

--- a/src/task.c
+++ b/src/task.c
@@ -252,6 +252,7 @@ static void NOINLINE NORETURN start_task(void)
             jl_gc_wb(t, res);
         }
     }
+    t = jl_current_task; // copy_task may change jl_current_task.
     finish_task(t, res);
     abort();
 }
@@ -886,6 +887,40 @@ DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
 
     return t;
 }
+
+DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
+    {
+        jl_task_t *newt = (jl_task_t*)jl_gc_allocobj(sizeof(jl_task_t));
+        jl_set_typeof(newt, jl_task_type);
+        
+        newt->current_module = t->current_module;
+        newt->state = t->state;
+        newt->start = t->start;
+        newt->tls = jl_nothing; // does this point to newt.storate?
+        newt->exception = jl_nothing;
+        newt->backtrace = jl_nothing;
+        newt->eh = NULL;
+        newt->gcstack = t->gcstack;
+        
+        memcpy((void*)newt->ctx, (void*)t->ctx, sizeof(jl_jmp_buf));
+#ifdef COPY_STACKS
+        if (t->stkbuf){
+            newt->ssize = t->ssize;  // size of saved piece
+            newt->bufsz = t->bufsz;
+            newt->stkbuf = allocb(t->bufsz);
+            memcpy(newt->stkbuf, t->stkbuf, t->bufsz);
+        }else{
+            newt->ssize = 0;
+            newt->bufsz = 0;
+            newt->stkbuf = NULL;
+        }
+#else // task copying for other stack switching methanism not implemented yet.
+#error not supported yet.
+#endif
+        jl_gc_wb_back(newt); // gc write back for new task.
+        return newt;
+    }
+
 
 JL_CALLABLE(jl_unprotect_stack)
 {


### PR DESCRIPTION
This pull request contains a working implementation of task copying for release-0.4.*. More specifically:
- This implementation allows user to `fork` tasks (aka coroutines): `newt = copy(t::Task)`.
- The new task `newt` has an independent stack from the original task `t`, i.e. `newt` runs independently from the original task `t`.
- This implementation shallowly copies heap objects referenced from the stack.

Here is a simple test script for this feature:

``` julia
# test case 1: stack allocated objects are deep copied.
function f()
  t = 0;
  while true
    produce(t)
    t = 1 + t
  end
end

t = Task(f)

consume(t); # produce 0
a = copy(t);
consume(a); # produce 1
consume(t);  # produce 1 again



# test case 2: heap allocated objects are shallowly copied.
function f()
  t = [0];
  while true
    produce(t[1])
    t[1] = 1 + t[1]
  end
end

t = Task(f)

consume(t); # produce 0
a = copy(t);
consume(a); # produce 1
consume(t);  # produce 2, as expected.
```
