### PR TITLE
Task copying: #4085

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -56,18 +56,14 @@ end
 
 function copy(t::Task)
   t.state != :runnable && t.state != :done &&  error("Only runnable or finished tasks can be copied.")
-  newt = ccall(:jl_copy_task, Any, (Any), t)::Task
+  newt = ccall(:jl_copy_task, Any, (Any, ), t)::Task
   if t.storage != nothing
     newt.storage = copy(t.storage)
   else
     newt.storage = nothing
   end
   newt.code  = t.code
-  newt.result = t.result
-  newt.parent = t.parent
-  newt.last   = t.last
-  newt.consumers = jl_nothing;
-  newt.donenotify = jl_nothing;
+  newt.last  = t.last
   newt
 end
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1498,6 +1498,7 @@ typedef struct {
 #define jl_task_arg_in_transit (jl_get_ptls_states()->task_arg_in_transit)
 
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
+JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t);
 JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);

--- a/src/task.c
+++ b/src/task.c
@@ -251,6 +251,7 @@ static void NOINLINE JL_NORETURN start_task(void)
             jl_gc_wb(t, res);
         }
     }
+    t = jl_current_task; // copy_task may change jl_current_task.
     finish_task(t, res);
     gc_debug_critical_error();
     abort();
@@ -916,6 +917,40 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
 #endif
     return t;
 }
+
+DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
+{
+    jl_task_t *newt = (jl_task_t*)jl_gc_allocobj(sizeof(jl_task_t));
+    jl_set_typeof(newt, jl_task_type);
+
+    newt->current_module = t->current_module;
+    newt->state = t->state;
+    newt->start = t->start;
+    newt->tls = jl_nothing; // does this point to newt.storate?
+    newt->exception = jl_nothing;
+    newt->backtrace = jl_nothing;
+    newt->eh = NULL;
+    newt->gcstack = t->gcstack;
+
+    memcpy((void*)newt->ctx, (void*)t->ctx, sizeof(jl_jmp_buf));
+#ifdef COPY_STACKS
+    if (t->stkbuf){
+        newt->ssize = t->ssize;  // size of saved piece
+        newt->bufsz = t->bufsz;
+        newt->stkbuf = allocb(t->bufsz);
+        memcpy(newt->stkbuf, t->stkbuf, t->bufsz);
+    }else{
+        newt->ssize = 0;
+        newt->bufsz = 0;
+        newt->stkbuf = NULL;
+    }
+#else // task copying for other stack switching methanism not implemented yet.
+#error not supported yet.
+#endif
+    jl_gc_wb_back(newt); // gc write back for new task.
+    return newt;
+}
+
 
 JL_CALLABLE(jl_unprotect_stack)
 {

--- a/src/task.c
+++ b/src/task.c
@@ -935,6 +935,7 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
     newt->backtrace = jl_nothing;
     newt->eh = NULL;
     newt->gcstack = t->gcstack;
+    newt->tid = t->tid;
 
     memcpy((void*)newt->ctx, (void*)t->ctx, sizeof(jl_jmp_buf));
 #ifdef COPY_STACKS

--- a/src/task.c
+++ b/src/task.c
@@ -927,6 +927,10 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
     newt->state = t->state;
     newt->start = t->start;
     newt->tls = jl_nothing; // does this point to newt.storate?
+    newt->result = t->result;
+    newt->parent = t->parent;
+    newt->consumers = jl_nothing;
+    newt->donenotify = jl_nothing;
     newt->exception = jl_nothing;
     newt->backtrace = jl_nothing;
     newt->eh = NULL;
@@ -947,7 +951,12 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
 #else // task copying for other stack switching methanism not implemented yet.
 #error not supported yet.
 #endif
-    jl_gc_wb_back(newt); // gc write back for new task.
+
+#ifdef JULIA_ENABLE_THREADING
+    arraylist_new(&t->locks, 0);
+#endif
+
+    jl_gc_wb_back(newt); // gc write barrier for new task.
     return newt;
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -921,8 +921,9 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
 JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
 {
     jl_task_t *newt = (jl_task_t*)jl_gc_allocobj(sizeof(jl_task_t));
-    jl_set_typeof(newt, jl_task_type);
+    JL_GC_PUSH1(&newt);
 
+    jl_set_typeof(newt, jl_task_type);
     newt->current_module = t->current_module;
     newt->state = t->state;
     newt->start = t->start;
@@ -934,6 +935,7 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
     newt->exception = jl_nothing;
     newt->backtrace = jl_nothing;
     newt->eh = NULL;
+    newt->stkbuf = NULL;
     newt->gcstack = t->gcstack;
     newt->tid = t->tid;
 
@@ -958,6 +960,7 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
 #endif
 
     jl_gc_wb_back(newt); // gc write barrier for new task.
+    JL_GC_POP();
     return newt;
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -918,7 +918,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
     return t;
 }
 
-DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
+JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
 {
     jl_task_t *newt = (jl_task_t*)jl_gc_allocobj(sizeof(jl_task_t));
     jl_set_typeof(newt, jl_task_type);

--- a/src/task.c
+++ b/src/task.c
@@ -952,11 +952,8 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
         newt->bufsz = 0;
         newt->stkbuf = NULL;
     }
-#else // TODO: test task copying implementation for !COPY_STACKS.
-    newt->ssize = t->ssize;
-    newt->bufsz = t->bufsz;
-    newt->stkbuf = allocb(t->bufsz);
-    memcpy(newt->stkbuf, t->stkbuf, t->bufsz);
+#else // task copying for other stack switching methanism not supported yet.
+#error not supported yet.
 #endif
 
 #ifdef JULIA_ENABLE_THREADING

--- a/src/task.c
+++ b/src/task.c
@@ -938,6 +938,7 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
     newt->stkbuf = NULL;
     newt->gcstack = t->gcstack;
     newt->tid = t->tid;
+    newt->started = t->started;
 
     memcpy((void*)newt->ctx, (void*)t->ctx, sizeof(jl_jmp_buf));
 #ifdef COPY_STACKS
@@ -951,8 +952,11 @@ JL_DLLEXPORT jl_task_t *jl_copy_task(jl_task_t *t)
         newt->bufsz = 0;
         newt->stkbuf = NULL;
     }
-#else // task copying for other stack switching methanism not implemented yet.
-#error not supported yet.
+#else // TODO: test task copying implementation for !COPY_STACKS.
+    newt->ssize = t->ssize;
+    newt->bufsz = t->bufsz;
+    newt->stkbuf = allocb(t->bufsz);
+    memcpy(newt->stkbuf, t->stkbuf, t->bufsz);
 #endif
 
 #ifdef JULIA_ENABLE_THREADING


### PR DESCRIPTION
This PR contains a working implementation of task copying. More specifically:
- This implementation allows user to `fork` tasks (aka coroutines): `newt = copy(t::Task)`.
- The new task `newt` has an independent stack from the original task `t`, i.e. `newt` runs independently from the original task `t`.
- This implementation shallowly copies heap objects referenced from the stack.

Here is a simple test script for this feature:

``` julia
# test case 1: stack allocated objects are deep copied.
function f()
  t = 0;
  while true
    produce(t)
    t = 1 + t
  end
end

t = Task(f)

consume(t); # produce 0
a = copy(t);
consume(a); # produce 1
consume(t);  # produce 1 again



# test case 2: heap allocated objects are shallowly copied.
function f()
  t = [0];
  while true
    produce(t[1])
    t[1] = 1 + t[1]
  end
end

t = Task(f)

consume(t); # produce 0
a = copy(t);
consume(a); # produce 1
consume(t);  # produce 2, as expected.
```
