### PR TITLE
RFC: Life, the universe, and MAX_TUPLETYPE_LEN

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3,7 +3,7 @@
 # parameters limiting potentially-infinite types
 const MAX_TYPEUNION_LEN = 3
 const MAX_TYPE_DEPTH = 7
-const MAX_TUPLETYPE_LEN  = 8
+const MAX_TUPLETYPE_LEN  = 42
 const MAX_TUPLE_DEPTH = 4
 
 # avoid cycle due to over-specializing `any` when used by inference


### PR DESCRIPTION
Recent efforts to replace generated functions typically exploit tuples. These methods often work well when the number of arguments is modest, but can run into problems because many approaches involve "inlined splatting," which causes trouble if it creates tuples with more than 8 elements.

I decided to do an experiment bumping MAX_TUPLETYPE_LEN to a value that would not cause problems for algorithms involving AbstractArrays of any reasonable dimensionality. I didn't want to choose `typemax(Int)`, so I picked the obvious 2-digit integer.

My tests have not been thorough, but julia seems to build fine, and the time to run the test suite was no worse (34 minutes on `master`, 30 minutes on this PR). Thoughts from those who know the inference/compile toolchain best would be appreciated.
