### PR TITLE
Remove unnecessary options for accessing TLS from JIT code

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -387,8 +387,6 @@ DEBUGFLAGS := -O0 -g -DJL_DEBUG_BUILD -fstack-protector-all
 SHIPFLAGS := -O3 -g -falign-functions
 endif
 
-JCPPFLAGS += -ftls-model=global-dynamic
-
 ifeq ($(USECCACHE), 1)
 # expand CC and CXX at declaration time because we will redefine them
 CC_ARG   := $(CC)         # Expand CC and CXX here already because we want

--- a/src/julia.h
+++ b/src/julia.h
@@ -143,7 +143,6 @@ JL_DLLEXPORT void jl_threading_profile(void);
 #endif
 
 #ifdef JULIA_ENABLE_THREADING
-#define FORCE_ELF
 #define JL_DEFINE_MUTEX(m)                                                \
     uint64_t volatile m ## _mutex = 0;                                    \
     int32_t m ## _lock_count = 0;                                         \


### PR DESCRIPTION
We have our own access function and don't need these anymore.

These should be unnecessary since https://github.com/JuliaLang/julia/pull/14083
