### PR TITLE
Fix threading sysimg

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3656,7 +3656,7 @@ static void finalize_gc_frame(Function *F)
 #ifdef JULIA_ENABLE_THREADING
     if (imaging_mode) {
         Value *getter;
-        if (GlobalVariable *GV = M->getGlobalVariable(jltls_states_func_ptr->getName())) {
+        if (GlobalVariable *GV = M->getGlobalVariable(jltls_states_func_ptr->getName(), true /* AllowLocal */)) {
             getter = tbaa_decorate(tbaa_const, new LoadInst(GV, "", ptlsStates));
         }
         else {


### PR DESCRIPTION
The global variable is local and needs to be specified when looking it up. This seems to be target dependent since the previous version works on win32, win64, linux on x64, arm and aarch64 but it doesn't work on linux x86 or mac....
