### PR TITLE
Use File(RawFD(fd)) in preference to fdio(fd).

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -195,12 +195,12 @@ end
 # Obtain a temporary directory's path.
 tempdir() = dirname(tempname())
 
-# Create and return the name of a temporary file along with an IOStream
+# Create and return the name of a temporary file along with an IO
 function mktemp(parent=tempdir())
     b = joinpath(parent, "tmpXXXXXX")
     p = ccall(:mkstemp, Int32, (Cstring,), b) # modifies b
     systemerror(:mktemp, p == -1)
-    return (b, fdio(p, true))
+    return (b, File(RawFD(p)))
 end
 
 # Create and return the name of a temporary directory

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -49,6 +49,7 @@ function settings(s::Int, shared::Bool)
     end
     return prot, flags, (prot & PROT_WRITE) > 0
 end
+settings(fd::RawFD, shared::Bool) = settings(Int(fd.fd), shared)
 
 # Before mapping, grow the file to sufficient size
 # Note: a few mappable streams do not support lseek. When Julia

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -526,7 +526,7 @@ function _shm_mmap_array(T, dims, shm_seg_name, mode)
     fd_mem = shm_open(shm_seg_name, mode, S_IRUSR | S_IWUSR)
     systemerror("shm_open() failed for " * shm_seg_name, fd_mem < 0)
 
-    s = fdio(fd_mem, true)
+    s = File(RawFD(fd_mem))
 
     # On OSX, ftruncate must to used to set size of segment, just lseek does not work.
     # and only at creation time

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -271,9 +271,7 @@ disassociate_julia_struct(handle::Ptr{Void}) =
 function init_stdio(handle::Ptr{Void})
     t = ccall(:jl_uv_handle_type, Int32, (Ptr{Void},), handle)
     if t == UV_FILE
-        return fdio(ccall(:jl_uv_file_handle, Int32, (Ptr{Void},), handle))
-#       Replace ios.c file with libuv file?
-#       return File(RawFD(ccall(:jl_uv_file_handle,Int32,(Ptr{Void},),handle)))
+        return File(RawFD(ccall(:jl_uv_file_handle,Int32,(Ptr{Void},),handle)))
     else
         if t == UV_TTY
             ret = TTY(handle)


### PR DESCRIPTION
Use LibUV in preference to ios.c (following on from https://github.com/JuliaLang/julia/pull/9450/files#diff-ac5d350530574f3f82c860d1b963bc0aR240 ).

Includes @vtjnash's fix for #15088 taken from #15090.

Includes `cmdlineargs.jl` pipe deadlock fix per https://github.com/JuliaLang/julia/commit/31a0c5543e05095af26b0d4190d53a09c8efb7ed#commitcomment-16106258
