### PR TITLE
Remove ambiguity (warning) for *(Diagonal, SpecialMatrix)

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -207,7 +207,7 @@ end
 /(A::Bidiagonal, B::Number) = Bidiagonal(A.dv/B, A.ev/B, A.isupper)
 ==(A::Bidiagonal, B::Bidiagonal) = (A.dv==B.dv) && (A.ev==B.ev) && (A.isupper==B.isupper)
 
-SpecialMatrix = Union{Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, AbstractTriangular}
+SpecialMatrix = Union{Bidiagonal, SymTridiagonal, Tridiagonal, AbstractTriangular}
 *(A::SpecialMatrix, B::SpecialMatrix)=full(A)*full(B)
 
 #Generic multiplication


### PR DESCRIPTION
Simple fix of the warning introduced when the `*(Diagonal,Matrix)` method was widened to `AbstractMatrix` in https://github.com/JuliaLang/julia/commit/9ed79e68876313db1da8c178229b333c79644e9f
