### PR TITLE
update documentation of speye and spzeros

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -624,11 +624,12 @@ spones{T}(S::SparseMatrixCSC{T}) =
      SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), ones(T, S.colptr[end]-1))
 
 """
-    spzeros(m[,n])
+    spzeros([type,]m[,n])
 
 Create a sparse vector of length `m` or sparse matrix of size `m x n`. This
 sparse array will not contain any nonzero values. No storage will be allocated
-for nonzero values during construction.
+for nonzero values during construction. The type defaults to `Float64` if not
+specified.
 """
 spzeros(m::Integer, n::Integer) = spzeros(Float64, m, n)
 spzeros(Tv::Type, m::Integer, n::Integer) = spzeros(Tv, Int, m, n)
@@ -641,14 +642,21 @@ end
 speye(n::Integer) = speye(Float64, n)
 speye(T::Type, n::Integer) = speye(T, n, n)
 speye(m::Integer, n::Integer) = speye(Float64, m, n)
+
+"""
+    speye(S)
+
+Create a sparse identity matrix with the same structure as that of  `S`.
+"""
 speye{T}(S::SparseMatrixCSC{T}) = speye(T, size(S, 1), size(S, 2))
 eye(S::SparseMatrixCSC) = speye(S)
 
 """
-    speye(type,m[,n])
+    speye([type,]m[,n])
 
-Create a sparse identity matrix of specified type of size `m x m`. In case `n` is supplied,
-create a sparse identity matrix of size `m x n`.
+Create a sparse identity matrix of size `m x m`. When `n` is supplied,
+create a sparse identity matrix of size `m x n`. The type defaults to `Float64`
+if not specified.
 """
 function speye(T::Type, m::Integer, n::Integer)
     ((m < 0) || (n < 0)) && throw(ArgumentError("invalid Array dimensions"))

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -859,13 +859,13 @@ dense counterparts. The following functions are specific to sparse arrays.
 
    .. Docstring generated from Julia source
 
-   Create a sparse matrix ``S`` of dimensions ``m x n`` such that ``S[I[k], J[k]] = V[k]``\ . The ``combine`` function is used to combine duplicates. If ``m`` and ``n`` are not specified, they are set to ``maximum(I)`` and ``maximum(J)`` respectively. If the ``combine`` function is not supplied, ``combine`` defaults to ``+`` unless the elements of ``V`` are Boolean in which case ``combine`` defaults to ``|``\ . All elements of ``I`` must satisfy ``1 <= I[k] <= m``\ , and all elements of ``J`` must satisfy ``1 <= J[k] <= n``\ .
+   Create a sparse matrix ``S`` of dimensions ``m x n`` such that ``S[I[k], J[k]] = V[k]``\ . The ``combine`` function is used to combine duplicates. If ``m`` and ``n`` are not specified, they are set to ``maximum(I)`` and ``maximum(J)`` respectively. If the ``combine`` function is not supplied, ``combine`` defaults to ``+`` unless the elements of ``V`` are Booleans in which case ``combine`` defaults to ``|``\ . All elements of ``I`` must satisfy ``1 <= I[k] <= m``\ , and all elements of ``J`` must satisfy ``1 <= J[k] <= n``\ .
 
 .. function:: sparsevec(I, V, [m, combine])
 
    .. Docstring generated from Julia source
 
-   Create a sparse vector ``S`` of length ``m`` such that ``S[I[k]] = V[k]``\ . Duplicates are combined using the ``combine`` function, which defaults to ``+`` if no combine argument is provided, unless the elements of ``V`` are Boolean in which case ``combine`` defaults to |.
+   Create a sparse vector ``S`` of length ``m`` such that ``S[I[k]] = V[k]``\ . Duplicates are combined using the ``combine`` function, which defaults to ``+`` if no ``combine`` argument is provided, unless the elements of ``V`` are Booleans in which case ``combine`` defaults to ``|``\ .
 
 .. function:: sparsevec(D::Dict, [m])
 
@@ -903,11 +903,11 @@ dense counterparts. The following functions are specific to sparse arrays.
 
    Returns the number of stored (filled) elements in a sparse array.
 
-.. function:: spzeros(m[,n])
+.. function:: spzeros([type,]m[,n])
 
    .. Docstring generated from Julia source
 
-   Create a sparse vector of length ``m`` or sparse matrix of size ``m x n``\ . This sparse array will not contain any nonzero values. No storage will be allocated for nonzero values during construction.
+   Create a sparse vector of length ``m`` or sparse matrix of size ``m x n``\ . This sparse array will not contain any nonzero values. No storage will be allocated for nonzero values during construction. The type defaults to ``Float64`` if not specified.
 
 .. function:: spones(S)
 
@@ -915,11 +915,17 @@ dense counterparts. The following functions are specific to sparse arrays.
 
    Create a sparse array with the same structure as that of ``S``\ , but with every nonzero element having the value ``1.0``\ .
 
-.. function:: speye(type,m[,n])
+.. function:: speye([type,]m[,n])
 
    .. Docstring generated from Julia source
 
-   Create a sparse identity matrix of specified type of size ``m x m``\ . In case ``n`` is supplied, create a sparse identity matrix of size ``m x n``\ .
+   Create a sparse identity matrix of size ``m x m``\ . When ``n`` is supplied, create a sparse identity matrix of size ``m x n``\ . The type defaults to ``Float64`` if not specified.
+
+.. function:: speye(S)
+
+   .. Docstring generated from Julia source
+
+   Create a sparse identity matrix with the same structure as that of  ``S``\ .
 
 .. function:: spdiagm(B, d[, m, n])
 


### PR DESCRIPTION
State that the type defaults to `Float64` if not specified. 
