### PR TITLE
lufact overhaul

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3299,46 +3299,6 @@ Create all directories in the given `path`, with permissions `mode`. `mode` defa
 mkpath
 
 """
-    lufact(A [,pivot=Val{true}]) -> F
-
-Compute the LU factorization of `A`. The return type of `F` depends on the type of `A`. In
-most cases, if `A` is a subtype `S` of AbstractMatrix with an element type `T` supporting `+`, `-`, `*`
-and `/` the return type is `LU{T,S{T}}`. If pivoting is chosen (default) the element type
-should also support `abs` and `<`. When `A` is sparse and have element of type `Float32`,
-`Float64`, `Complex{Float32}`, or `Complex{Float64}` the return type is `UmfpackLU`. Some
-examples are shown in the table below.
-
-| Type of input `A`                              | Type of output `F`     | Relationship between `F` and `A`             |
-|:-----------------------------------------------|:-----------------------|:---------------------------------------------|
-| [`Matrix`](:func:`Matrix`)                     | `LU`                   | `F[:L]*F[:U] == A[F[:p], :]`                 |
-| [`Tridiagonal`](:func:`Tridiagonal`)           | `LU{T,Tridiagonal{T}}` | `F[:L]*F[:U] == A[F[:p], :]`                 |
-| [`SparseMatrixCSC`](:func:`SparseMatrixCSC`)   | `UmfpackLU`            | `F[:L]*F[:U] == (F[:Rs] .* A)[F[:p], F[:q]]` |
-
-The individual components of the factorization `F` can be accessed by indexing:
-
-| Component | Description                         | `LU` | `LU{T,Tridiagonal{T}}` | `UmfpackLU` |
-|:----------|:------------------------------------|:-----|:-----------------------|:------------|
-| `F[:L]`   | `L` (lower triangular) part of `LU` | ✓    | ✓                      | ✓           |
-| `F[:U]`   | `U` (upper triangular) part of `LU` | ✓    | ✓                      | ✓           |
-| `F[:p]`   | (right) permutation `Vector`        | ✓    | ✓                      | ✓           |
-| `F[:P]`   | (right) permutation `Matrix`        | ✓    | ✓                      |             |
-| `F[:q]`   | left permutation `Vector`           |      |                        | ✓           |
-| `F[:Rs]`  | `Vector` of scaling factors         |      |                        | ✓           |
-| `F[:(:)]` | `(L,U,p,q,Rs)` components           |      |                        | ✓           |
-
-| Supported function | `LU` | `LU{T,Tridiagonal{T}}` | `UmfpackLU` |
-|:-------------------|:-----|:-----------------------|:------------|
-| `/`                | ✓    |                        |             |
-| `\\`               | ✓    | ✓                      | ✓           |
-| `cond`             | ✓    |                        | ✓           |
-| `det`              | ✓    | ✓                      | ✓           |
-| `logdet`           | ✓    | ✓                      |             |
-| `logabsdet`        | ✓    | ✓                      |             |
-| `size`             | ✓    | ✓                      |             |
-"""
-lufact
-
-"""
     besselix(nu, x)
 
 Scaled modified Bessel function of the first kind of order `nu`, ``I_\\nu(x) e^{- | \\operatorname{Re}(x) |}``.

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -72,6 +72,41 @@ end
 lufact{T<:AbstractFloat}(A::Union{AbstractMatrix{T},AbstractMatrix{Complex{T}}}, pivot::Union{Type{Val{false}}, Type{Val{true}}} = Val{true}) = lufact!(copy(A), pivot)
 
 # for all other types we must promote to a type which is stable under division
+"""
+    lufact(A [,pivot=Val{true}]) -> F::LU
+
+Compute the LU factorization of `A`.
+
+In most cases, if `A` is a subtype `S` of `AbstractMatrix{T}` with an element
+type `T` supporting `+`, `-`, `*` and `/`, the return type is `LU{T,S{T}}`. If
+pivoting is chosen (default) the element type should also support `abs` and
+`<`.
+
+The individual components of the factorization `F` can be accessed by indexing:
+
+| Component | Description                         |
+|:----------|:------------------------------------|
+| `F[:L]`   | `L` (lower triangular) part of `LU` |
+| `F[:U]`   | `U` (upper triangular) part of `LU` |
+| `F[:p]`   | (right) permutation `Vector`        |
+| `F[:P]`   | (right) permutation `Matrix`        |
+
+The relationship between `F` and `A` is
+
+`F[:L]*F[:U] == A[F[:p], :]`
+
+`F` further supports the following functions:
+
+| Supported function               | `LU` | `LU{T,Tridiagonal{T}}` |
+|:---------------------------------|:-----|:-----------------------|
+| [`/`](:func:`/`)                 | ✓    |                        |
+| [`\\`](:func:`\\`)               | ✓    | ✓                      |
+| [`cond`](:func:`cond`)           | ✓    |                        |
+| [`det`](:func:`det`)             | ✓    | ✓                      |
+| [`logdet`](:func:`logdet`)       | ✓    | ✓                      |
+| [`logabsdet`](:func:`logabsdet`) | ✓    | ✓                      |
+| [`size`](:func:`size`)           | ✓    | ✓                      |
+"""
 function lufact{T}(A::AbstractMatrix{T}, pivot::Union{Type{Val{false}}, Type{Val{true}}})
     S = typeof(zero(T)/one(T))
     lufact!(copy_oftype(A, S), pivot)

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -148,9 +148,15 @@ function lufact{Tv<:UMFVTypes,Ti<:UMFITypes}(S::SparseMatrixCSC{Tv,Ti})
     finalizer(res, umfpack_free_symbolic)
     umfpack_numeric!(res)
 end
-lufact{Tv<:Union{Float16,Float32}, Ti<:UMFITypes}(A::SparseMatrixCSC{Tv,Ti}) = lufact(convert(SparseMatrixCSC{Float64,Ti}, A))
-lufact{Tv<:Union{Complex32,Complex64}, Ti<:UMFITypes}(A::SparseMatrixCSC{Tv,Ti}) = lufact(convert(SparseMatrixCSC{Complex128,Ti}, A))
-lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}}) = throw(ArgumentError("matrix type $(typeof(A)) not supported. Try lufact(convert(SparseMatrixCSC{Float64/Complex128,Int}, A)) for sparse floating point LU using UMFPACK or lufact(full(A)) for generic dense LU."))
+lufact{Tv<:Union{Float16,Float32}, Ti<:UMFITypes}(A::SparseMatrixCSC{Tv,Ti}) =
+    lufact(convert(SparseMatrixCSC{Float64,Ti}, A))
+lufact{Tv<:Union{Complex32,Complex64}, Ti<:UMFITypes}(A::SparseMatrixCSC{Tv,Ti}) =
+    lufact(convert(SparseMatrixCSC{Complex128,Ti}, A))
+lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}}) =
+    throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",
+    "Try lufact(convert(SparseMatrixCSC{Float64/Complex128,Int}, A)) for ",
+    "sparse floating point LU using UMFPACK or lufact(full(A)) for generic ",
+    "dense LU.")))
 lufact(A::SparseMatrixCSC) = lufact(float(A))
 lufact(A::SparseMatrixCSC, pivot::Type{Val{false}}) = lufact(A)
 

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -59,8 +59,8 @@ end
 
 # check the size of SuiteSparse_long
 if Int(ccall((:jl_cholmod_sizeof_long,:libsuitesparse_wrapper),Csize_t,())) == 4
-    const UmfpackIndexTypes = (:Int32, )
-    typealias UMFITypes Union{Int32}
+    const UmfpackIndexTypes = (:Int32,)
+    typealias UMFITypes Int32
 else
     const UmfpackIndexTypes = (:Int32, :Int64)
     typealias UMFITypes Union{Int32, Int64}
@@ -75,22 +75,20 @@ const umf_ctrl = Array(Float64, UMFPACK_CONTROL)
 ccall((:umfpack_dl_defaults,:libumfpack), Void, (Ptr{Float64},), umf_ctrl)
 const umf_info = Array(Float64, UMFPACK_INFO)
 
-function show_umf_ctrl(level::Real)
+function show_umf_ctrl(level::Real = 2.0)
     old_prt::Float64 = umf_ctrl[1]
     umf_ctrl[1] = Float64(level)
     ccall((:umfpack_dl_report_control, :libumfpack), Void, (Ptr{Float64},), umf_ctrl)
     umf_ctrl[1] = old_prt
 end
-show_umf_ctrl() = show_umf_ctrl(2.)
 
-function show_umf_info(level::Real)
+function show_umf_info(level::Real = 2.0)
     old_prt::Float64 = umf_ctrl[1]
     umf_ctrl[1] = Float64(level)
     ccall((:umfpack_dl_report_info, :libumfpack), Void,
           (Ptr{Float64}, Ptr{Float64}), umf_ctrl, umf_info)
     umf_ctrl[1] = old_prt
 end
-show_umf_info() = show_umf_info(2.)
 
 ## Should this type be immutable?
 type UmfpackLU{Tv<:UMFVTypes,Ti<:UMFITypes} <: Factorization{Tv}
@@ -103,6 +101,43 @@ type UmfpackLU{Tv<:UMFVTypes,Ti<:UMFITypes} <: Factorization{Tv}
     nzval::Vector{Tv}
 end
 
+"""
+    lufact(A::SparseMatrixCSC) -> F::UmfpackLU
+
+Compute the LU factorization of a sparse matrix `A`.
+
+For sparse `A` with real or complex element type, the return type of `F` is
+`UmfpackLU{Tv, Ti}`, with `Tv` = `Float64` or `Complex128` respectively and
+`Ti` is an integer type (`Int32` or `Int64`).
+
+The individual components of the factorization `F` can be accessed by indexing:
+
+| Component | Description                         |
+|:----------|:------------------------------------|
+| `F[:L]`   | `L` (lower triangular) part of `LU` |
+| `F[:U]`   | `U` (upper triangular) part of `LU` |
+| `F[:p]`   | right permutation `Vector`          |
+| `F[:q]`   | left permutation `Vector`           |
+| `F[:Rs]`  | `Vector` of scaling factors         |
+| `F[:(:)]` | `(L,U,p,q,Rs)` components           |
+
+The relation between `F` and `A` is
+
+`F[:L]*F[:U] == (F[:Rs] .* A)[F[:p], F[:q]]`
+
+`F` further supports the following functions:
+
+- [`\\`](:func:`\\`)
+- [`cond`](:func:`cond`)
+- [`det`](:func:`det`)
+
+** Implementation note **
+
+`lufact(A::SparseMatrixCSC)` uses the UMFPACK library that is part of
+SuiteSparse. As this library only supports sparse matrices with `Float64` or
+`Complex128` elements, `lufact` converts `A` into a copy that is of type
+`SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as appropriate.
+"""
 function lufact{Tv<:UMFVTypes,Ti<:UMFITypes}(S::SparseMatrixCSC{Tv,Ti})
 
     zerobased = S.colptr[1] == 0
@@ -113,12 +148,17 @@ function lufact{Tv<:UMFVTypes,Ti<:UMFITypes}(S::SparseMatrixCSC{Tv,Ti})
     finalizer(res, umfpack_free_symbolic)
     umfpack_numeric!(res)
 end
+lufact{Tv<:Union{Float16,Float32}, Ti<:UMFITypes}(A::SparseMatrixCSC{Tv,Ti}) = lufact(convert(SparseMatrixCSC{Float64,Ti}, A))
+lufact{Tv<:Union{Complex32,Complex64}, Ti<:UMFITypes}(A::SparseMatrixCSC{Tv,Ti}) = lufact(convert(SparseMatrixCSC{Complex128,Ti}, A))
+lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}}) = throw(ArgumentError("matrix type $(typeof(A)) not supported. Try lufact(convert(SparseMatrixCSC{Float64/Complex128,Int}, A)) for sparse floating point LU using UMFPACK or lufact(full(A)) for generic dense LU."))
 lufact(A::SparseMatrixCSC) = lufact(float(A))
+lufact(A::SparseMatrixCSC, pivot::Type{Val{false}}) = lufact(A)
+
 
 size(F::UmfpackLU) = (F.m, F.n)
 function size(F::UmfpackLU, dim::Integer)
     if dim < 1
-        error("arraysize: dimension out of range")
+        throw(ArgumentError("size: dimension $dim out of range"))
     elseif dim == 1
         return Int(F.m)
     elseif dim == 2

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -65,59 +65,91 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the LU factorization of ``A``\ , such that ``A[p,:] = L*U``\ .
 
-.. function:: lufact(A [,pivot=Val{true}]) -> F
+.. function:: lufact(A [,pivot=Val{true}]) -> F::LU
 
    .. Docstring generated from Julia source
 
-   Compute the LU factorization of ``A``\ . The return type of ``F`` depends on the type of ``A``\ . In most cases, if ``A`` is a subtype ``S`` of AbstractMatrix with an element type ``T`` supporting ``+``\ , ``-``\ , ``*`` and ``/`` the return type is ``LU{T,S{T}}``\ . If pivoting is chosen (default) the element type should also support ``abs`` and ``<``\ . When ``A`` is sparse and have element of type ``Float32``\ , ``Float64``\ , ``Complex{Float32}``\ , or ``Complex{Float64}`` the return type is ``UmfpackLU``\ . Some examples are shown in the table below.
+   Compute the LU factorization of ``A``\ .
 
-   +-------------------------+--------------------------+------------------------------------------------+
-   | Type of input ``A``     | Type of output ``F``     | Relationship between ``F`` and ``A``           |
-   +=========================+==========================+================================================+
-   | :func:`Matrix`          | ``LU``                   | ``F[:L]*F[:U] == A[F[:p], :]``                 |
-   +-------------------------+--------------------------+------------------------------------------------+
-   | :func:`Tridiagonal`     | ``LU{T,Tridiagonal{T}}`` | ``F[:L]*F[:U] == A[F[:p], :]``                 |
-   +-------------------------+--------------------------+------------------------------------------------+
-   | :func:`SparseMatrixCSC` | ``UmfpackLU``            | ``F[:L]*F[:U] == (F[:Rs] .* A)[F[:p], F[:q]]`` |
-   +-------------------------+--------------------------+------------------------------------------------+
+   In most cases, if ``A`` is a subtype ``S`` of ``AbstractMatrix{T}`` with an element type ``T`` supporting ``+``\ , ``-``\ , ``*`` and ``/``\ , the return type is ``LU{T,S{T}}``\ . If pivoting is chosen (default) the element type should also support ``abs`` and ``<``\ .
 
    The individual components of the factorization ``F`` can be accessed by indexing:
 
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
-   | Component   | Description                             | ``LU`` | ``LU{T,Tridiagonal{T}}`` | ``UmfpackLU`` |
-   +=============+=========================================+========+==========================+===============+
-   | ``F[:L]``   | ``L`` (lower triangular) part of ``LU`` | ✓      | ✓                        | ✓             |
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
-   | ``F[:U]``   | ``U`` (upper triangular) part of ``LU`` | ✓      | ✓                        | ✓             |
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
-   | ``F[:p]``   | (right) permutation ``Vector``          | ✓      | ✓                        | ✓             |
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
-   | ``F[:P]``   | (right) permutation ``Matrix``          | ✓      | ✓                        |               |
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
-   | ``F[:q]``   | left permutation ``Vector``             |        |                          | ✓             |
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
-   | ``F[:Rs]``  | ``Vector`` of scaling factors           |        |                          | ✓             |
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
-   | ``F[:(:)]`` | ``(L,U,p,q,Rs)`` components             |        |                          | ✓             |
-   +-------------+-----------------------------------------+--------+--------------------------+---------------+
+   +-----------+-----------------------------------------+
+   | Component | Description                             |
+   +===========+=========================================+
+   | ``F[:L]`` | ``L`` (lower triangular) part of ``LU`` |
+   +-----------+-----------------------------------------+
+   | ``F[:U]`` | ``U`` (upper triangular) part of ``LU`` |
+   +-----------+-----------------------------------------+
+   | ``F[:p]`` | (right) permutation ``Vector``          |
+   +-----------+-----------------------------------------+
+   | ``F[:P]`` | (right) permutation ``Matrix``          |
+   +-----------+-----------------------------------------+
 
-   +--------------------+--------+--------------------------+---------------+
-   | Supported function | ``LU`` | ``LU{T,Tridiagonal{T}}`` | ``UmfpackLU`` |
-   +====================+========+==========================+===============+
-   | ``/``              | ✓      |                          |               |
-   +--------------------+--------+--------------------------+---------------+
-   | ``\``              | ✓      | ✓                        | ✓             |
-   +--------------------+--------+--------------------------+---------------+
-   | ``cond``           | ✓      |                          | ✓             |
-   +--------------------+--------+--------------------------+---------------+
-   | ``det``            | ✓      | ✓                        | ✓             |
-   +--------------------+--------+--------------------------+---------------+
-   | ``logdet``         | ✓      | ✓                        |               |
-   +--------------------+--------+--------------------------+---------------+
-   | ``logabsdet``      | ✓      | ✓                        |               |
-   +--------------------+--------+--------------------------+---------------+
-   | ``size``           | ✓      | ✓                        |               |
-   +--------------------+--------+--------------------------+---------------+
+   The relationship between ``F`` and ``A`` is
+
+   ``F[:L]*F[:U] == A[F[:p], :]``
+
+   ``F`` further supports the following functions:
+
+   +--------------------+--------+--------------------------+
+   | Supported function | ``LU`` | ``LU{T,Tridiagonal{T}}`` |
+   +====================+========+==========================+
+   | :func:`/`          | ✓      |                          |
+   +--------------------+--------+--------------------------+
+   | :func:`\\`         | ✓      | ✓                        |
+   +--------------------+--------+--------------------------+
+   | :func:`cond`       | ✓      |                          |
+   +--------------------+--------+--------------------------+
+   | :func:`det`        | ✓      | ✓                        |
+   +--------------------+--------+--------------------------+
+   | :func:`logdet`     | ✓      | ✓                        |
+   +--------------------+--------+--------------------------+
+   | :func:`logabsdet`  | ✓      | ✓                        |
+   +--------------------+--------+--------------------------+
+   | :func:`size`       | ✓      | ✓                        |
+   +--------------------+--------+--------------------------+
+
+.. function:: lufact(A::SparseMatrixCSC) -> F::UmfpackLU
+
+   .. Docstring generated from Julia source
+
+   Compute the LU factorization of a sparse matrix ``A``\ .
+
+   For sparse ``A`` with real or complex element type, the return type of ``F`` is ``UmfpackLU{Tv, Ti}``\ , with ``Tv`` = ``Float64`` or ``Complex128`` respectively and ``Ti`` is an integer type (``Int32`` or ``Int64``\ ).
+
+   The individual components of the factorization ``F`` can be accessed by indexing:
+
+   +-------------+-----------------------------------------+
+   | Component   | Description                             |
+   +=============+=========================================+
+   | ``F[:L]``   | ``L`` (lower triangular) part of ``LU`` |
+   +-------------+-----------------------------------------+
+   | ``F[:U]``   | ``U`` (upper triangular) part of ``LU`` |
+   +-------------+-----------------------------------------+
+   | ``F[:p]``   | right permutation ``Vector``            |
+   +-------------+-----------------------------------------+
+   | ``F[:q]``   | left permutation ``Vector``             |
+   +-------------+-----------------------------------------+
+   | ``F[:Rs]``  | ``Vector`` of scaling factors           |
+   +-------------+-----------------------------------------+
+   | ``F[:(:)]`` | ``(L,U,p,q,Rs)`` components             |
+   +-------------+-----------------------------------------+
+
+   The relation between ``F`` and ``A`` is
+
+   ``F[:L]*F[:U] == (F[:Rs] .* A)[F[:p], F[:q]]``
+
+   ``F`` further supports the following functions:
+
+   * :func:`\\`
+   * :func:`cond`
+   * :func:`det`
+
+   ** Implementation note **
+
+   ``lufact(A::SparseMatrixCSC)`` uses the UMFPACK library that is part of SuiteSparse. As this library only supports sparse matrices with ``Float64`` or ``Complex128`` elements, ``lufact`` converts ``A`` into a copy that is of type ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
 .. function:: lufact!(A) -> LU
 

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -88,3 +88,13 @@ end
 for T in (BigFloat, Complex{BigFloat})
     @test_throws ArgumentError lufact(sparse(ones(T, 1, 1)))
 end
+
+#size(::UmfpackLU)
+let
+    m = n = 1
+    F = lufact(sparse(ones(m, n)))
+    @test size(F) == (m, n)
+    @test size(F, 1) == m
+    @test size(F, 2) == n
+    @test size(F, 3) == 1
+end

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
+using Base.Test
 
 se33 = speye(3)
 do33 = ones(3)
@@ -64,3 +65,26 @@ x = speye(2) + im * speye(2)
 
 # UMFPACK_ERROR_n_nonpositive
 @test_throws ArgumentError lufact(sparse(Int[], Int[], Float64[], 5, 0))
+
+#15099
+for (Tin, Tout) in (
+	(Complex32, Complex128),
+	(Complex64, Complex128),
+	(Complex128, Complex128),
+	(Float16, Float64),
+	(Float32, Float64),
+	(Float64, Float64),
+	(Int, Float64),
+    )
+
+    F = lufact(sparse(ones(Tin, 1, 1)))
+    L = sparse(ones(Tout, 1, 1))
+    @test F[:p] == F[:q] == [1]
+    @test F[:Rs] == [1.0]
+    @test F[:L] == F[:U] == L
+    @test F[:(:)] == (L, L, [1], [1], [1.0])
+end
+
+for T in (BigFloat, Complex{BigFloat})
+    @test_throws ArgumentError lufact(sparse(ones(T, 1, 1)))
+end


### PR DESCRIPTION
- Correct fallbacks for sparse `lufact`. Closes JuliaLang/LinearAlgebra.jl#308
- Also overhauls docstrings for `lufact`, separating out dense and sparse methods.
- Document that sparse `lufact` creates a copy of input if not of eltype `Complex128` or `Float64`.
- Create two separate entries for dense and sparse `lufact` in stdlib docs. It's now clear that sparse `lufact` does not support pivoting. 
- Add simple tests for `getindex(::UmfpackLU)`.

Includes minor changes in `sparse/umfpack.jl`:
- `Union{Int32}` -> `Int32`
- Use default value for `show_umf_ctrl` and `show_umf_info`
- `size` now throws `ArgumentError` instead of `ErrorException`
