### PR TITLE
RFC: added os_only documentation

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2095,8 +2095,7 @@ isdigit
 """
     @windows
 
-Given `@windows? a : b`, do `a` on Windows and `b` elsewhere. See documentation for Handling
-Platform Variations in the Calling C and Fortran Code section of the manual.
+Given `@windows? a : b`, do `a` on Windows and `b` elsewhere. See documentation in [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
 """
 :@windows
 
@@ -2104,10 +2103,24 @@ Platform Variations in the Calling C and Fortran Code section of the manual.
     @unix
 
 Given `@unix? a : b`, do `a` on Unix systems (including Linux and OS X) and `b` elsewhere.
-See documentation for Handling Platform Variations in the Calling C and Fortran Code section
-of the manual.
+See documentation in [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
 """
 :@unix
+
+"""
+    @windows_only
+
+A macro that evaluates the given expression only on Windows systems. See documentation in [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
+"""
+:@windows_only
+
+"""
+    @unix_only
+
+A macro that evaluates the given expression only on Unix systems (including Linux and OS X). See
+documentation in [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
+"""
+:@unix_only
 
 """
     num2hex(f)
@@ -6538,10 +6551,16 @@ ndims
 """
     @osx
 
-Given `@osx? a : b`, do `a` on OS X and `b` elsewhere. See documentation for Handling
-Platform Variations in the Calling C and Fortran Code section of the manual.
+Given `@osx? a : b`, do `a` on OS X and `b` elsewhere. See documentation in [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
 """
 :@osx
+
+"""
+    @osx_only
+
+A macro that evaluates the given expression only on OS X systems. See documentation in [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
+"""
+:@osx_only
 
 """
     ishermitian(A) -> Bool
@@ -8194,10 +8213,16 @@ cumprod!
 """
     @linux
 
-Given `@linux? a : b`, do `a` on Linux and `b` elsewhere. See documentation for Handling
-Platform Variations in the Calling C and Fortran Code section of the manual.
+Given `@linux? a : b`, do `a` on Linux and `b` elsewhere. See documentation [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
 """
 :@linux
+
+"""
+    @linux_only
+
+A macro that evaluates the given expression only on Linux systems. See documentation in [Handling Operating System Variation](:ref:`Handling Operating System Variation <man-handling-operating-system-variation>`).
+"""
+:@linux_only
 
 """
     complement(s)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,6 +41,7 @@
    manual/dates
    manual/running-external-programs
    manual/calling-c-and-fortran-code
+   manual/handling-operating-system-variation
    manual/interacting-with-julia
    manual/embedding
    manual/packages

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -1049,33 +1049,3 @@ C++
 
 Limited support for C++ is provided by the `Cpp <https://github.com/timholy/Cpp.jl>`_,
 `Clang <https://github.com/ihnorton/Clang.jl>`_, and `Cxx <https://github.com/Keno/Cxx.jl>`_ packages.
-
-Handling Operating System Variation
------------------------------------
-
-When dealing with platform libraries, it is often necessary to provide special cases
-for various platforms. The variable ``OS_NAME`` can be used to write these special
-cases. Additionally, there are several macros intended to make this easier:
-``@windows``, ``@unix``, ``@linux``, and ``@osx``. Note that ``@linux`` and ``@osx`` are mutually
-exclusive subsets of ``@unix``. Their usage takes the form of a ternary conditional
-operator, as demonstrated in the following examples.
-
-Simple blocks::
-
-    ccall( (@windows? :_fopen : :fopen), ...)
-
-Complex blocks::
-
-    @linux? (
-             begin
-                 some_complicated_thing(a)
-             end
-           : begin
-                 some_different_thing(a)
-             end
-           )
-
-Chaining (parentheses optional, but recommended for readability)::
-
-    @windows? :a : (@osx? :b : :c)
-

--- a/doc/manual/handling-operating-system-variation.rst
+++ b/doc/manual/handling-operating-system-variation.rst
@@ -1,0 +1,38 @@
+.. _man-handling-operating-system-variation:
+
+*************************************
+ Handling Operating System Variation
+*************************************
+
+When dealing with platform libraries, it is often necessary to provide special cases
+for various platforms. The variable ``OS_NAME`` can be used to write these special
+cases. There are several macros intended to make this easier: ``@windows_only``,
+``@unix_only``, ``@linux_only``, and ``@osx_only``. These may be used as follows::
+
+    @windows_only begin
+        some_complicated_thing(a)
+    end
+
+Note that ``@linux_only`` and ``@osx_only`` are mutually exclusive subsets of ``@unix_only``\ . (This
+similarly applies to ``@unix``\ .)
+Additionally, there are:``@windows``, ``@unix``, ``@linux``, and ``@osx``. Their usage takes
+the form of a ternary conditional operator, as demonstrated in the following examples.
+
+Simple blocks::
+
+    ccall( (@windows? :_fopen : :fopen), ...)
+
+Complex blocks::
+
+    @linux? (
+             begin
+                 some_complicated_thing(a)
+             end
+           : begin
+                 some_different_thing(a)
+             end
+           )
+
+Chaining (parentheses optional, but recommended for readability)::
+
+    @windows? :a : (@osx? :b : :c)

--- a/doc/manual/index.rst
+++ b/doc/manual/index.rst
@@ -32,6 +32,7 @@
    interacting-with-julia
    running-external-programs
    calling-c-and-fortran-code
+   handling-operating-system-variation
    embedding
    packages
    profile

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -977,25 +977,49 @@ System
 
    .. Docstring generated from Julia source
 
-   Given ``@unix? a : b``\ , do ``a`` on Unix systems (including Linux and OS X) and ``b`` elsewhere. See documentation for Handling Platform Variations in the Calling C and Fortran Code section of the manual.
+   Given ``@unix? a : b``\ , do ``a`` on Unix systems (including Linux and OS X) and ``b`` elsewhere. See documentation in :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
+
+.. function:: @unix_only
+
+   .. Docstring generated from Julia source
+
+   A macro that evaluates the given expression only on Unix systems (including Linux and OS X). See documentation in :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
 
 .. function:: @osx
 
    .. Docstring generated from Julia source
 
-   Given ``@osx? a : b``\ , do ``a`` on OS X and ``b`` elsewhere. See documentation for Handling Platform Variations in the Calling C and Fortran Code section of the manual.
+   Given ``@osx? a : b``\ , do ``a`` on OS X and ``b`` elsewhere. See documentation in :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
+
+.. function:: @osx_only
+
+   .. Docstring generated from Julia source
+
+   A macro that evaluates the given expression only on OS X systems. See documentation in :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
 
 .. function:: @linux
 
    .. Docstring generated from Julia source
 
-   Given ``@linux? a : b``\ , do ``a`` on Linux and ``b`` elsewhere. See documentation for Handling Platform Variations in the Calling C and Fortran Code section of the manual.
+   Given ``@linux? a : b``\ , do ``a`` on Linux and ``b`` elsewhere. See documentation :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
+
+.. function:: @linux_only
+
+   .. Docstring generated from Julia source
+
+   A macro that evaluates the given expression only on Linux systems. See documentation in :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
 
 .. function:: @windows
 
    .. Docstring generated from Julia source
 
-   Given ``@windows? a : b``\ , do ``a`` on Windows and ``b`` elsewhere. See documentation for Handling Platform Variations in the Calling C and Fortran Code section of the manual.
+   Given ``@windows? a : b``\ , do ``a`` on Windows and ``b`` elsewhere. See documentation in :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
+
+.. function:: @windows_only
+
+   .. Docstring generated from Julia source
+
+   A macro that evaluates the given expression only on Windows systems. See documentation in :ref:`Handling Operating System Variation <man-handling-operating-system-variation>`\ .
 
 Errors
 ------


### PR DESCRIPTION
The unix_only, linux_only, osx_only, and windows_only macros were missing documentation in the manual.
