### PR TITLE
re-fixes #13560

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -68,7 +68,7 @@ end # @unix_only
 
 @windows_only begin
 
-typealias DWORD Culong
+typealias DWORD Culonglong
 
 const PAGE_READONLY          = DWORD(0x02)
 const PAGE_READWRITE         = DWORD(0x04)


### PR DESCRIPTION
#13560  was not resolved for me.  On my machine (Windows 7 with julia compiled via cygwin64) Culong is equivalent to UInt32.  Simply changing to Culonglong solves the problem for me.
