### PR TITLE
Made octal examples easier to read on ReadTheDocs

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3354,7 +3354,7 @@ addprocs(manager::ClusterManager)
     mkpath(path, [mode])
 
 Create all directories in the given `path`, with permissions `mode`. `mode` defaults to
-0o777, modified by the current file creation mask.
+`0o777`, modified by the current file creation mask.
 """
 mkpath
 
@@ -5438,7 +5438,7 @@ include_string
 """
     chmod(path, mode)
 
-Change the permissions mode of `path` to `mode`. Only integer `mode`s (e.g. 0o777) are currently supported.
+Change the permissions mode of `path` to `mode`. Only integer `mode`s (e.g. `0o777`) are currently supported.
 """
 chmod
 
@@ -9977,7 +9977,7 @@ eigfact(A,B)
 """
     mkdir(path, [mode])
 
-Make a new directory with name `path` and permissions `mode`. `mode` defaults to 0o777,
+Make a new directory with name `path` and permissions `mode`. `mode` defaults to `0o777`,
 modified by the current file creation mask.
 """
 mkdir

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -51,13 +51,13 @@
 
    .. Docstring generated from Julia source
 
-   Make a new directory with name ``path`` and permissions ``mode``\ . ``mode`` defaults to 0o777, modified by the current file creation mask.
+   Make a new directory with name ``path`` and permissions ``mode``\ . ``mode`` defaults to ``0o777``\ , modified by the current file creation mask.
 
 .. function:: mkpath(path, [mode])
 
    .. Docstring generated from Julia source
 
-   Create all directories in the given ``path``\ , with permissions ``mode``\ . ``mode`` defaults to 0o777, modified by the current file creation mask.
+   Create all directories in the given ``path``\ , with permissions ``mode``\ . ``mode`` defaults to ``0o777``\ , modified by the current file creation mask.
 
 .. function:: symlink(target, link)
 
@@ -79,7 +79,7 @@
 
    .. Docstring generated from Julia source
 
-   Change the permissions mode of ``path`` to ``mode``\ . Only integer ``mode``\ s (e.g. 0o777) are currently supported.
+   Change the permissions mode of ``path`` to ``mode``\ . Only integer ``mode``\ s (e.g. ``0o777``\ ) are currently supported.
 
 .. function:: stat(file)
 


### PR DESCRIPTION
The font used on ReadTheDocs made the octal [examples](http://julia.readthedocs.org/en/latest/stdlib/file/?highlight=0o777#Base.chmod) appear to be `OO777` or `00777` rather than `0o777`.
