### PR TITLE
add `ini_HEX` method for ints

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -1071,6 +1071,11 @@ function ini_hex(x::Integer)
     pt = (len-1)<<2
     len,pt,neg
 end
+function ini_HEX(x::Integer)
+    len,pt,neg = decode_HEX(x)
+    pt = (len-1)<<2
+    len,pt,neg
+end
 
 # not implemented
 ini_hex(x::Integer,ndigits::Int) = throw(MethodError(ini_hex,(x,ndigits)))

--- a/test/printf.jl
+++ b/test/printf.jl
@@ -4,6 +4,7 @@
 # int
 @test (@sprintf "%d" typemax(Int64)) == "9223372036854775807"
 @test (@sprintf "%a" typemax(Int64)) == "0x7.fffffffffffffffp+60"
+@test (@sprintf "%A" typemax(Int64)) == "0X7.FFFFFFFFFFFFFFFP+60"
 
 for (fmt, val) in (("%i", "42"),
                    ("%u", "42"),


### PR DESCRIPTION
fixes `%A` formatting (#14409)
