### PR TITLE
mmap: remove unnecessary use of utf16

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -87,7 +87,7 @@ function gethandle(io::IO)
     return Int(handle)
 end
 
-settings(sh::Anonymous) = utf16(sh.name), sh.readonly, sh.create
+settings(sh::Anonymous) = sh.name, sh.readonly, sh.create
 settings(io::IO) = Ptr{Cwchar_t}(0), isreadonly(io), true
 end # @windows_only
 


### PR DESCRIPTION
This is a tiny change, but it's one less use of `utf16` that we don't need.
