### PR TITLE
Request 64-byte aligned memory instead of 16-byte aligned memory for large objects

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -18,7 +18,6 @@ extern "C" {
 
 #define JL_ARRAY_ALIGN(jl_value, nbytes) LLT_ALIGN(jl_value, nbytes)
 
-
 // array constructors ---------------------------------------------------------
 
 static inline int store_unboxed(jl_value_t *el_type)
@@ -74,13 +73,13 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
     }
 
     int ndimwords = jl_array_ndimwords(ndims);
-    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), 16);
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), JL_CACHE_BYTE_ALIGNMENT);
     if (tot <= ARRAY_INLINE_NBYTES) {
         if (isunboxed && elsz >= 4)
-            tsz = JL_ARRAY_ALIGN(tsz, 16); // align data area 16
+            tsz = JL_ARRAY_ALIGN(tsz, JL_SMALL_BYTE_ALIGNMENT); // align data area
         size_t doffs = tsz;
         tsz += tot;
-        tsz = JL_ARRAY_ALIGN(tsz, 16); // align whole object 16
+        tsz = JL_ARRAY_ALIGN(tsz, JL_SMALL_BYTE_ALIGNMENT); // align whole object
         a = (jl_array_t*)jl_gc_allocobj(tsz);
         jl_set_typeof(a, atype);
         a->flags.how = 0;
@@ -90,7 +89,7 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
         }
     }
     else {
-        tsz = JL_ARRAY_ALIGN(tsz, 16); // align whole object 16
+        tsz = JL_ARRAY_ALIGN(tsz, JL_CACHE_BYTE_ALIGNMENT); // align whole object
         a = (jl_array_t*)jl_gc_allocobj(tsz);
         JL_GC_PUSH1(&a);
         jl_set_typeof(a, atype);
@@ -157,7 +156,7 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
     size_t ndims = jl_nfields(dims);
 
     int ndimwords = jl_array_ndimwords(ndims);
-    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t) + sizeof(void*), 16);
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t) + sizeof(void*), JL_SMALL_BYTE_ALIGNMENT);
     a = (jl_array_t*)jl_gc_allocobj(tsz);
     jl_set_typeof(a, atype);
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
@@ -233,7 +232,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
         elsz = sizeof(void*);
 
     int ndimwords = jl_array_ndimwords(1);
-    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), 16);
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), JL_CACHE_BYTE_ALIGNMENT);
     a = (jl_array_t*)jl_gc_allocobj(tsz);
     jl_set_typeof(a, atype);
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
@@ -284,7 +283,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
         elsz = sizeof(void*);
 
     int ndimwords = jl_array_ndimwords(ndims);
-    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), 16);
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), JL_CACHE_BYTE_ALIGNMENT);
     a = (jl_array_t*)jl_gc_allocobj(tsz);
     jl_set_typeof(a, atype);
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -501,6 +501,9 @@ STATIC_INLINE void jl_free_aligned(void *p)
 }
 #endif
 
+#define JL_SMALL_BYTE_ALIGNMENT 16
+#define JL_CACHE_BYTE_ALIGNMENT 64
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/core.jl
+++ b/test/core.jl
@@ -3876,3 +3876,7 @@ module Test15264
     mod1{T}(x::T) = x < 1 ? x : mod1(x-1)
 end
 @test Test15264.mod1 !== Base.mod1
+
+
+# check that medium-sized array is 64-byte aligned (#15139)
+@test Int(pointer(Vector{Float64}(1024))) % 64 == 0


### PR DESCRIPTION
Prompted by discussion with @yuyichao and @carnaval, this is essentially a revival of [this older branch](https://github.com/JuliaLang/julia/commit/e60a64d75aa1c51e0bbb465fdf227f87f133e1a7).

This should align the requested memory with cache lines, thus improving register loads (and by extension, SIMD performance). We'll still request 16-byte aligned memory unless the object/array is "large enough" (determined by what the GC considers "big" or, in the case of arrays, a comparison with `ARRAY_INLINE_NBYTES`).

This change also replaces a bunch of magic alignment numbers with named constants (`SMALL_BYTE_ALIGNMENT` for 16-byte aligned memory and `CACHE_BYTE_ALIGNMENT` for 64-byte aligned memory).

This is my first time poking around C code in a real-world context, so apologies in advance for any silly mistakes.

`runbenchmarks(ALL, vs = "JuliaLang/julia:master")`
