### PR TITLE
Improve docs about read*() functions

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -48,9 +48,10 @@ the same object. `fill!(A, Foo())` will return `A` filled with the result of eva
 fill!
 
 """
-    read!(stream or filename, array::Array)
+    read!(stream::IO, array::Union{Array, BitArray})
+    read!(filename::AbstractString, array::Union{Array, BitArray})
 
-Read binary data from a stream or file, filling in the argument `array`.
+Read binary data from an I/O stream or file, filling in `array`.
 """
 read!
 
@@ -445,9 +446,11 @@ the mantissa.
 precision
 
 """
-    readlines(stream or filename)
+    readlines(stream::IO)
+    readlines(filename::AbstractString)
 
-Read all lines as an array.
+Read all lines of an I/O stream or a file as a vector of strings.
+The text is assumed to be encoded in UTF-8.
 """
 readlines
 
@@ -1011,9 +1014,11 @@ See `rounding` for available rounding modes.
 Float32
 
 """
-    readuntil(stream or filename, delim)
+    readuntil(stream::IO, delim)
+    readuntil(filename::AbstractString, delim)
 
-Read a string, up to and including the given delimiter byte.
+Read a string from an I/O stream or a file, up to and including the given delimiter byte.
+The text is assumed to be encoded in UTF-8.
 """
 readuntil
 
@@ -1968,15 +1973,15 @@ value returned by `f`.
 open(f::Function, command::Cmd, mod::AbstractString="r", stdio=DevNull)
 
 """
-    open(file_name, [read, write, create, truncate, append]) -> IOStream
+    open(filename, [read, write, create, truncate, append]) -> IOStream
 
 Open a file in a mode specified by five boolean arguments. The default is to open files for
 reading only. Returns a stream for accessing the file.
 """
-open(file_name, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool)
+open(filename, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool)
 
 """
-    open(file_name, [mode]) -> IOStream
+    open(filename, [mode]) -> IOStream
 
 Alternate syntax for open, where a string-based mode specifier is used instead of the five
 booleans. The values of `mode` correspond to those from `fopen(3)` or Perl `open`, and are
@@ -1991,7 +1996,7 @@ equivalent to setting the following boolean groups:
 | a    | write, create, append         |
 | a+   | read, write, create, append   |
 """
-open(file_name, mode="r")
+open(filename, mode="r")
 
 """
     open(f::Function, args...)
@@ -2349,9 +2354,11 @@ the process.
 triu!(M, k)
 
 """
-    readstring(stream or filename)
+    readstring(stream::IO)
+    readstring(filename::AbstractString)
 
 Read the entire contents of an I/O stream or a file as a string.
+The text is assumed to be encoded in UTF-8.
 """
 readstring
 
@@ -2371,9 +2378,11 @@ it is more reliable and efficient, although in some situations it may not be ava
 poll_file
 
 """
-    eachline(stream or filename)
+    eachline(stream::IO)
+    eachline(filename::AbstractString)
 
-Create an iterable object that will yield each line.
+Create an iterable object that will yield each line from an I/O stream or a file.
+The text is assumed to be encoded in UTF-8.
 """
 eachline
 
@@ -4143,10 +4152,11 @@ Squared absolute value of `x`.
 abs2
 
 """
-    write(stream or filename, x)
+    write(stream::IO, x)
+    write(filename::AbstractString, x)
 
-Write the canonical binary representation of a value to the given stream or file. Returns the number
-of bytes written into the stream.
+Write the canonical binary representation of a value to the given I/O stream or file.
+Returns the number of bytes written into the stream.
 
 You can write multiple values with the same :func:`write` call. i.e. the following are
 equivalent:
@@ -6028,20 +6038,28 @@ ERROR: ArgumentError: indices must be unique and sorted
 deleteat!(collection, itr)
 
 """
-    read(stream, type)
+    read(stream::IO, T)
 
-Read a value of the given type from a stream, in canonical binary representation.
+Read a single value of type `T` from `stream`, in canonical binary representation.
 """
 read(stream, t)
 
 """
-    read(stream, type, dims)
+    read(stream::IO, T, dims)
 
-Read a series of values of the given type from a stream, in canonical binary representation.
-`dims` is either a tuple or a series of integer arguments specifying the size of `Array` to
-return.
+Read a series of values of type `T` from `stream`, in canonical binary representation.
+`dims` is either a tuple or a series of integer arguments specifying the size of the `Array{T}`
+to return.
 """
 read(stream, t, dims)
+
+"""
+    read(filename::AbstractString, args...)
+
+Open a file and read its contents. `args` is passed to `read`: this is equivalent to
+`open(io->read(io, args...), filename)`.
+"""
+read(filename, args...)
 
 """
     @timev
@@ -6307,10 +6325,11 @@ Compute the inverse secant of `x`, where the output is in degrees.
 asecd
 
 """
-    readbytes!(stream, b::Vector{UInt8}, nb=length(b); all=true)
+    readbytes!(stream::IO, b::AbstractVector{UInt8}, nb=length(b); all=true)
 
-Read at most `nb` bytes from the stream into `b`, returning the number of bytes read
-(increasing the size of `b` as needed).
+Read at most `nb` bytes from `stream` into `b`, returning the number of bytes read.
+The size of `b` will be increased if needed (i.e. if `nb` is greater than `length(b)`
+and enough bytes could be read), but it will never be decreased.
 
 See `read` for a description of the `all` option.
 """
@@ -7266,10 +7285,12 @@ Return the supertype of DataType `T`.
 supertype
 
 """
-    readline(stream=STDIN or filename)
+    readline(stream::IO=STDIN)
+    readline(filename::AbstractString)
 
 Read a single line of text, including a trailing newline character (if one is reached before
-the end of the input), from the given stream or file (defaults to `STDIN`),
+the end of the input), from the given I/O stream or file (defaults to `STDIN`).
+When reading from a file, the text is assumed to be encoded in UTF-8.
 """
 readline
 
@@ -10084,9 +10105,9 @@ a series of integer arguments.
 cell
 
 """
-    read(stream, nb=typemax(Int); all=true)
+    read(stream::IO, nb=typemax(Int); all=true)
 
-Read at most `nb` bytes from the stream, returning a `Vector{UInt8}` of the bytes read.
+Read at most `nb` bytes from `stream`, returning a `Vector{UInt8}` of the bytes read.
 
 If `all` is `true` (the default), this function will block repeatedly trying to read all
 requested bytes, until an error or end-of-file occurs. If `all` is `false`, at most one

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1228,9 +1228,9 @@ An operation tried to write to memory that is read-only.
 ReadOnlyMemoryError
 
 """
-    startswith(string, prefix | chars)
+    startswith(string, prefix)
 
-Returns `true` if `string` starts with `prefix`. If the second argument is a vector or set
+Returns `true` if `string` starts with `prefix`. If `prefix` is a vector or set
 of characters, tests whether the first character of `string` belongs to that set.
 """
 startswith
@@ -6180,10 +6180,12 @@ Dirichlet eta function ``\\eta(s) = \\sum^\\infty_{n=1}(-)^{n-1}/n^{s}``.
 eta
 
 """
-    isdefined([object,] index | symbol)
+    isdefined([m::Module,] s::Symbol)
+    isdefined(object, s::Symbol)
+    isdefined(a::AbstractArray, index::Int)
 
-Tests whether an assignable location is defined. The arguments can be an array and index, a
-composite object and field name (as a symbol), or a module and a symbol. With a single
+Tests whether an assignable location is defined. The arguments can be a module and a symbol,
+a composite object and field name (as a symbol), or an array and index. With a single
 symbol argument, tests whether a global variable with that name is defined in
 `current_module()`.
 """
@@ -8373,9 +8375,9 @@ Returns `true` if `path` is a mount point, `false` otherwise.
 ismount
 
 """
-    endswith(string, suffix | chars)
+    endswith(string, suffix)
 
-Returns `true` if `string` ends with `suffix`. If the second argument is a vector or set of
+Returns `true` if `string` ends with `suffix`. If `suffix` is a vector or set of
 characters, tests whether the last character of `string` belongs to that set.
 """
 endswith
@@ -10309,11 +10311,11 @@ updated as appropriate before returning.
 deepcopy
 
 """
-    widen(type | x)
+    widen(x)
 
-If the argument is a type, return a "larger" type (for numeric types, this will be
+If `x` is a type, return a "larger" type (for numeric types, this will be
 a type with at least as much range and precision as the argument, and usually more).
-Otherwise the argument `x` is converted to `widen(typeof(x))`.
+Otherwise `x` is converted to `widen(typeof(x))`.
 
 ```jldoctest
 julia> widen(Int32)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -344,11 +344,13 @@ All Objects
 
    While it isn't normally necessary, user-defined types can override the default ``deepcopy`` behavior by defining a specialized version of the function ``deepcopy_internal(x::T, dict::ObjectIdDict)`` (which shouldn't otherwise be used), where ``T`` is the type to be specialized for, and ``dict`` keeps track of objects copied so far within the recursion. Within the definition, ``deepcopy_internal`` should be used in place of ``deepcopy``\ , and the ``dict`` variable should be updated as appropriate before returning.
 
-.. function:: isdefined([object,] index | symbol)
+.. function:: isdefined([m::Module,] s::Symbol)
+              isdefined(object, s::Symbol)
+              isdefined(a::AbstractArray, index::Int)
 
    .. Docstring generated from Julia source
 
-   Tests whether an assignable location is defined. The arguments can be an array and index, a composite object and field name (as a symbol), or a module and a symbol. With a single symbol argument, tests whether a global variable with that name is defined in ``current_module()``\ .
+   Tests whether an assignable location is defined. The arguments can be a module and a symbol, a composite object and field name (as a symbol), or an array and index. With a single symbol argument, tests whether a global variable with that name is defined in ``current_module()``\ .
 
 .. function:: convert(T, x)
 
@@ -395,11 +397,11 @@ All Objects
 
    Convert ``y`` to the type of ``x`` (``convert(typeof(x), y)``\ ).
 
-.. function:: widen(type | x)
+.. function:: widen(x)
 
    .. Docstring generated from Julia source
 
-   If the argument is a type, return a "larger" type (for numeric types, this will be a type with at least as much range and precision as the argument, and usually more). Otherwise the argument ``x`` is converted to ``widen(typeof(x))``\ .
+   If ``x`` is a type, return a "larger" type (for numeric types, this will be a type with at least as much range and precision as the argument, and usually more). Otherwise ``x`` is converted to ``widen(typeof(x))``\ .
 
    .. doctest::
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -19,13 +19,13 @@ General I/O
 
    Global variable referring to the standard input stream.
 
-.. function:: open(file_name, [read, write, create, truncate, append]) -> IOStream
+.. function:: open(filename, [read, write, create, truncate, append]) -> IOStream
 
    .. Docstring generated from Julia source
 
    Open a file in a mode specified by five boolean arguments. The default is to open files for reading only. Returns a stream for accessing the file.
 
-.. function:: open(file_name, [mode]) -> IOStream
+.. function:: open(filename, [mode]) -> IOStream
 
    .. Docstring generated from Julia source
 
@@ -121,11 +121,12 @@ General I/O
 
    Close an I/O stream. Performs a ``flush`` first.
 
-.. function:: write(stream or filename, x)
+.. function:: write(stream::IO, x)
+              write(filename::AbstractString, x)
 
    .. Docstring generated from Julia source
 
-   Write the canonical binary representation of a value to the given stream or file. Returns the number of bytes written into the stream.
+   Write the canonical binary representation of a value to the given I/O stream or file. Returns the number of bytes written into the stream.
 
    You can write multiple values with the same :func:``write`` call. i.e. the following are equivalent:
 
@@ -134,39 +135,46 @@ General I/O
        write(stream, x, y...)
        write(stream, x) + write(stream, y...)
 
-.. function:: read(stream, type)
+.. function:: read(stream::IO, T)
 
    .. Docstring generated from Julia source
 
-   Read a value of the given type from a stream, in canonical binary representation.
+   Read a single value of type ``T`` from ``stream``\ , in canonical binary representation.
 
-.. function:: read(stream, type, dims)
-
-   .. Docstring generated from Julia source
-
-   Read a series of values of the given type from a stream, in canonical binary representation. ``dims`` is either a tuple or a series of integer arguments specifying the size of ``Array`` to return.
-
-.. function:: read!(stream or filename, array::Array)
+.. function:: read(stream::IO, T, dims)
 
    .. Docstring generated from Julia source
 
-   Read binary data from a stream or file, filling in the argument ``array``\ .
+   Read a series of values of type ``T`` from ``stream``\ , in canonical binary representation. ``dims`` is either a tuple or a series of integer arguments specifying the size of the ``Array{T}`` to return.
 
-.. function:: readbytes!(stream, b::Vector{UInt8}, nb=length(b); all=true)
+.. function:: read!(stream::IO, array::Union{Array, BitArray})
+              read!(filename::AbstractString, array::Union{Array, BitArray})
 
    .. Docstring generated from Julia source
 
-   Read at most ``nb`` bytes from the stream into ``b``\ , returning the number of bytes read (increasing the size of ``b`` as needed).
+   Read binary data from an I/O stream or file, filling in ``array``\ .
+
+.. function:: readbytes!(stream::IO, b::AbstractVector{UInt8}, nb=length(b); all=true)
+
+   .. Docstring generated from Julia source
+
+   Read at most ``nb`` bytes from ``stream`` into ``b``\ , returning the number of bytes read. The size of ``b`` will be increased if needed (i.e. if ``nb`` is greater than ``length(b)`` and enough bytes could be read), but it will never be decreased.
 
    See ``read`` for a description of the ``all`` option.
 
-.. function:: read(stream, nb=typemax(Int); all=true)
+.. function:: read(stream::IO, nb=typemax(Int); all=true)
 
    .. Docstring generated from Julia source
 
-   Read at most ``nb`` bytes from the stream, returning a ``Vector{UInt8}`` of the bytes read.
+   Read at most ``nb`` bytes from ``stream``\ , returning a ``Vector{UInt8}`` of the bytes read.
 
    If ``all`` is ``true`` (the default), this function will block repeatedly trying to read all requested bytes, until an error or end-of-file occurs. If ``all`` is ``false``\ , at most one ``read`` call is performed, and the amount of data returned is device-dependent. Note that not all stream types support the ``all`` option.
+
+.. function:: read(filename::AbstractString, args...)
+
+   .. Docstring generated from Julia source
+
+   Open a file and read its contents. ``args`` is passed to ``read``\ : this is equivalent to ``open(io->read(io, args...), filename)``\ .
 
 .. function:: unsafe_read(io, ref, nbytes)
 
@@ -511,35 +519,40 @@ Text I/O
 
    Show all structure of a value, including all fields of objects.
 
-.. function:: readstring(stream or filename)
+.. function:: readstring(stream::IO)
+              readstring(filename::AbstractString)
 
    .. Docstring generated from Julia source
 
-   Read the entire contents of an I/O stream or a file as a string.
+   Read the entire contents of an I/O stream or a file as a string. The text is assumed to be encoded in UTF-8.
 
-.. function:: readline(stream=STDIN or filename)
-
-   .. Docstring generated from Julia source
-
-   Read a single line of text, including a trailing newline character (if one is reached before the end of the input), from the given stream or file (defaults to ``STDIN``\ ),
-
-.. function:: readuntil(stream or filename, delim)
+.. function:: readline(stream::IO=STDIN)
+              readline(filename::AbstractString)
 
    .. Docstring generated from Julia source
 
-   Read a string, up to and including the given delimiter byte.
+   Read a single line of text, including a trailing newline character (if one is reached before the end of the input), from the given I/O stream or file (defaults to ``STDIN``\ ). When reading from a file, the text is assumed to be encoded in UTF-8.
 
-.. function:: readlines(stream or filename)
-
-   .. Docstring generated from Julia source
-
-   Read all lines as an array.
-
-.. function:: eachline(stream or filename)
+.. function:: readuntil(stream::IO, delim)
+              readuntil(filename::AbstractString, delim)
 
    .. Docstring generated from Julia source
 
-   Create an iterable object that will yield each line.
+   Read a string from an I/O stream or a file, up to and including the given delimiter byte. The text is assumed to be encoded in UTF-8.
+
+.. function:: readlines(stream::IO)
+              readlines(filename::AbstractString)
+
+   .. Docstring generated from Julia source
+
+   Read all lines of an I/O stream or a file as a vector of strings. The text is assumed to be encoded in UTF-8.
+
+.. function:: eachline(stream::IO)
+              eachline(filename::AbstractString)
+
+   .. Docstring generated from Julia source
+
+   Create an iterable object that will yield each line from an I/O stream or a file. The text is assumed to be encoded in UTF-8.
 
 .. function:: readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, skipblanks=true, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
 

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -291,17 +291,17 @@
 
    Return ``string`` with any trailing whitespace removed. If ``chars`` (a character, or vector or set of characters) is provided, instead remove characters contained in it.
 
-.. function:: startswith(string, prefix | chars)
+.. function:: startswith(string, prefix)
 
    .. Docstring generated from Julia source
 
-   Returns ``true`` if ``string`` starts with ``prefix``\ . If the second argument is a vector or set of characters, tests whether the first character of ``string`` belongs to that set.
+   Returns ``true`` if ``string`` starts with ``prefix``\ . If ``prefix`` is a vector or set of characters, tests whether the first character of ``string`` belongs to that set.
 
-.. function:: endswith(string, suffix | chars)
+.. function:: endswith(string, suffix)
 
    .. Docstring generated from Julia source
 
-   Returns ``true`` if ``string`` ends with ``suffix``\ . If the second argument is a vector or set of characters, tests whether the last character of ``string`` belongs to that set.
+   Returns ``true`` if ``string`` ends with ``suffix``\ . If ``suffix`` is a vector or set of characters, tests whether the last character of ``string`` belongs to that set.
 
 .. function:: uppercase(string)
 


### PR DESCRIPTION
Fix array signatures for readbytes!() and read!().
Add docstring for read(filename::AbstractString, args...).
Mention that text should be UTF-8.
Separate "stream or filename" into two lines with types.
Various minor improvements.

[av skip]
