### PR TITLE
Only do Travis branch builds on master and release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ cache:
   directories:
     - $TRAVIS_BUILD_DIR/deps/srccache
     - $TRAVIS_BUILD_DIR/deps/build
+branches:
+  only:
+    - master
+    - /release-.*/
 notifications:
     email: false
     irc:
@@ -95,8 +99,8 @@ script:
         /tmp/julia/bin/julia-debug -J local.ji -e 'true' && rm local.ji
     - /tmp/julia/bin/julia -e 'versioninfo()'
     - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 && cd /tmp/julia/share/julia/test &&
-        /tmp/julia/bin/julia -O0 --check-bounds=yes runtests.jl $TESTSTORUN &&
-        /tmp/julia/bin/julia -O0 --check-bounds=yes runtests.jl libgit2-online pkg
+        /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
+        /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
     - cd `dirname $TRAVIS_BUILD_DIR` && mv julia2 julia && rm -rf julia/deps/build/julia-env
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg


### PR DESCRIPTION
you can manually add to this whitelist for temporary testing, or build on your fork

Also stop running tests at -O0 on Travis since it didn't help the runtime
significantly, and it's better to run in the more common configuration
