### PR TITLE
More customizable/repeating testsets (incl. tests for scope in testset use)

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -351,7 +351,7 @@ type DefaultTestSet <: AbstractTestSet
     repeats::Int # number of repeated runs of the tests, defaults to 1
     skip::Bool   # true iff we should not run tests in this testset, defaults to false
 end
-DefaultTestSet(desc; repeats=1, skip=false) = 
+DefaultTestSet(desc; repeats=1, skip=false) =
     DefaultTestSet(desc, [], false, repeats, skip)
 
 # For a passing result, simply store the result

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -248,9 +248,9 @@ Creating Custom ``AbstractTestSet`` Types
 -----------------------------------------
 
 Packages can create their own ``AbstractTestSet`` subtypes by implementing the
-``record``, ``should_run`` and ``finish`` methods. The subtype should have a one-argument
+``record`` and ``finish`` methods. The subtype should have a one-argument
 constructor taking a description string, with any options passed in as keyword
-arguments.
+arguments. Subtypes can also implement the ``should_run`` method to control the number of times the tests are executed but it has a sensible default to only run the tests once.
 
 .. function:: record(ts::AbstractTestSet, res::Result)
 
@@ -259,6 +259,10 @@ arguments.
    Record a result to a testset. This function is called by the ``@testset`` infrastructure each time a contained ``@test`` macro completes, and is given the test result (which could be an ``Error``\ ). This will also be called with an ``Error`` if an exception is thrown inside the test block but outside of a ``@test`` context.
 
 .. function:: should_run(ts::AbstractTestSet, nruns::Int)
+
+   .. Docstring generated from Julia source
+
+   Decide if the tests should be run; returns true if and only if they should. The tests are called in a loop and the ``nruns`` arg counts the number of times the test block has been executed. ``nruns`` is 0 when the tests have not yet executed.
 
 .. function:: finish(ts::AbstractTestSet)
 

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -248,7 +248,7 @@ Creating Custom ``AbstractTestSet`` Types
 -----------------------------------------
 
 Packages can create their own ``AbstractTestSet`` subtypes by implementing the
-``record`` and ``finish`` methods. The subtype should have a one-argument
+``record``, ``should_run`` and ``finish`` methods. The subtype should have a one-argument
 constructor taking a description string, with any options passed in as keyword
 arguments.
 
@@ -257,6 +257,8 @@ arguments.
    .. Docstring generated from Julia source
 
    Record a result to a testset. This function is called by the ``@testset`` infrastructure each time a contained ``@test`` macro completes, and is given the test result (which could be an ``Error``\ ). This will also be called with an ``Error`` if an exception is thrown inside the test block but outside of a ``@test`` context.
+
+.. function:: should_run(ts::AbstractTestSet, nruns::Int)
 
 .. function:: finish(ts::AbstractTestSet)
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -172,6 +172,28 @@ end
 @test typeof(tss[1]) == Base.Test.DefaultTestSet
 @test typeof(tss[1].results[1]) == Base.Test.Pass
 
+
+DTS = Base.Test.DefaultTestSet   # So we need not import it...
+global global_var = 0
+nonglobal_var = 0
+@testset "@testset should run in scope where macro called" begin
+    @testset "no testset type specified" begin
+        global global_var += 1
+        nonglobal_var += 1
+    end
+    global global_var
+    @test global_var == 1
+    @test nonglobal_var == 1
+
+    @testset DTS "default testset" begin
+        global global_var += 2
+        nonglobal_var += 3
+    end
+    @test global_var == 3
+    @test nonglobal_var == 4
+end
+
+
 # now we're done running tests with DefaultTestSet so we can go back to STDOUT
 redirect_stdout(OLD_STDOUT)
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -194,19 +194,50 @@ nonglobal_var = 0
 end
 
 
+@testset "default testset takes a skip argument" begin
+    skipped = true
+    @testset skip=true begin
+        skipped = false
+    end
+    @test skipped == true
+end
+
+counter = 0
+@testset "default testset can repeatedly run the tests" begin
+    @testset repeats=2 begin
+        counter += 1
+        @test true
+    end
+    @test counter == 2
+
+    @testset repeats=11 begin
+        counter += 1
+        @test counter < 100
+    end
+    @test counter == (2+11)
+
+    @testset skip=true repeats=33 "skip takes precedence over repeats" begin
+        counter += 1
+    end
+    @test counter == (2+11) # Still same value since we skipped
+end
+
+
 # now we're done running tests with DefaultTestSet so we can go back to STDOUT
 redirect_stdout(OLD_STDOUT)
 
+
 # import the methods needed for defining our own testset type
-import Base.Test: record, finish
+import Base.Test: record, finish, should_run
 using Base.Test: get_testset_depth, get_testset
 using Base.Test: AbstractTestSet, Result, Pass, Fail, Error
 immutable CustomTestSet <: Base.Test.AbstractTestSet
     description::AbstractString
     foo::Int
     results::Vector
+    reps::Int
     # constructor takes a description string and options keyword arguments
-    CustomTestSet(desc; foo=1) = new(desc, foo, [])
+    CustomTestSet(desc; foo=1, reps=1) = new(desc, foo, [], reps)
 end
 
 record(ts::CustomTestSet, child::AbstractTestSet) = push!(ts.results, child)
@@ -218,7 +249,13 @@ function finish(ts::CustomTestSet)
     end
     ts
 end
+function should_run(ts::CustomTestSet, nruns::Int)
+    (nruns < ts.reps) # Repeatedly run tests `reps` times
+end
 
+# These need to be global since the assignment to ts below affects scoping
+global counter_inner = 0
+global counter_outer = 0
 ts = @testset CustomTestSet "Testing custom testsets" begin
     # this testset should inherit the parent testset type
     @testset "custom testset inner 1" begin
@@ -240,6 +277,18 @@ ts = @testset CustomTestSet "Testing custom testsets" begin
         # specifying the testset type
         @testset foo=(1+2) "custom testset inner 2 inner 2" begin
             @test true
+        end
+    end
+    # this testset should inherit the parent testset type but change the reps arg
+    @testset reps=2 "custom testset inner 3" begin
+        global counter_outer += 1
+        @test true
+        @test false
+        @test error("this error will be reported as an error")
+        @test_throws ErrorException nothing
+        @test_throws ErrorException error("this error is a success")
+        @testset reps=3 "custom testset inner 3.1" begin
+            global counter_inner += 1
         end
     end
 end
@@ -265,6 +314,24 @@ end
 @test typeof(ts.results[2].results[2]) == CustomTestSet
 @test ts.results[2].results[2].foo == 3
 
+@test typeof(ts.results[3]) == CustomTestSet
+@test ts.results[3].description == "custom testset inner 3"
+@test counter_outer == 2
+@test counter_inner == 6
+@test length(ts.results[3].results) == 2*6 # 2 outer loops of 6 inner "tests" each
+for j in 1:2
+    i = (j-1)*6
+    @test typeof(ts.results[3].results[i+1]) == Pass
+    @test typeof(ts.results[3].results[i+2]) == Fail
+    @test typeof(ts.results[3].results[i+3]) == Error
+    @test typeof(ts.results[3].results[i+4]) == Fail
+    @test typeof(ts.results[3].results[i+5]) == Pass
+    @test typeof(ts.results[3].results[i+6]) == CustomTestSet
+    @test ts.results[3].results[i+6].description == "custom testset inner 3.1"
+    @test ts.results[3].results[i+6].reps == 3
+end
+
+
 # test custom testset types on testset/for
 tss = @testset CustomTestSet foo=3 "custom testset $i" for i in 1:6
     @testset "inner testset $i-$j" for j in 1:3
@@ -287,4 +354,28 @@ for i in 1:6
     end
     @test typeof(tss[i].results[4]) == CustomTestSet
     @test typeof(tss[i].results[4].results[1]) == (iseven(i) ? Pass : Fail)
+end
+
+
+# A more useful test case for repeatable testsets is for finding rare bugs
+# with random test data generation, aka property-based testing:
+my_buggy_reverse(v) = (length(v) == 4) ? Int64[1] : reverse(v) # Obvious, seeded, unrealistic bug here
+hit_one_of_length_4 = false
+ts = @testset CustomTestSet reps=500 begin
+    # Generate a random array of random length between 0-4.
+    a = Int64[rand(1:10000) for i in 1:rand(0:4)]
+    # A fundamental property of reverse is that if done twice we get orig ary
+    @test my_buggy_reverse(my_buggy_reverse(a)) == a
+
+    # Below code is only to handle the very unlikely case that our random testing
+    # did not "hit" an array of length 4.
+    # But we don't want to flag a failure below even if unlikely
+    global hit_one_of_length_4
+    hit_one_of_length_4 = hit_one_of_length_4 || (length(a) == 4)
+end
+
+@test length(ts.results) == 500
+if hit_one_of_length_4 # Chance that we didn't is extremely small, 0.8^500
+    numfails = find((r)->isa(r, Fail), ts.results)
+    @test length(numfails) > 0
 end


### PR DESCRIPTION
I'm not sure this is the right behavior for testset but since they currently execute and can update variables in the scope where they are called we need to have tests for this before we make changes. This is a very minor update to the test/test.jl file to add such tests. This is needed for later changes, such as proposed in https://github.com/JuliaLang/julia/pull/14971 etc.
