### PR TITLE
Remove superflous *one(T) in det for Unit...Triangular{T}

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1622,8 +1622,8 @@ function eigvecs{T}(A::AbstractTriangular{T})
         throw(ArgumentError("eigvecs type $(typeof(A)) not supported. Please submit a pull request."))
     end
 end
-det{T}(A::UnitUpperTriangular{T}) = one(T)*one(T)
-det{T}(A::UnitLowerTriangular{T}) = one(T)*one(T)
+det{T}(A::UnitUpperTriangular{T}) = one(T)
+det{T}(A::UnitLowerTriangular{T}) = one(T)
 det{T}(A::UpperTriangular{T}) = prod(diag(A.data))
 det{T}(A::LowerTriangular{T}) = prod(diag(A.data))
 


### PR DESCRIPTION
There might be a trick I am missing here, but the documentation says that `one(T)` is the multiplicative identity for `T`. If that is the case, then `one(T)*x == x` for all `x` such that `typeof(x)==T==true`. However, if that is the case, then surely `x = one(T)` implies `one(T)*one(T)==one(T)`, or am I reading the documentation too literately? Is there some "computer sciency" reason for this?
