### PR TITLE
Catch segfault in unwinder

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1549,15 +1549,17 @@ JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type)
 
 JL_DLLEXPORT void jl_(void *jl_value)
 {
-    jl_in_jl_++;
-    JL_TRY {
+    jl_jmp_buf *old_buf = jl_safe_restore;
+    jl_jmp_buf buf;
+    jl_safe_restore = &buf;
+    if (!jl_setjmp(buf, 0)) {
         (void)jl_static_show((JL_STREAM*)STDERR_FILENO, (jl_value_t*)jl_value);
         jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
     }
-    JL_CATCH {
+    else {
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n!!! ERROR in jl_ -- ABORTING !!!\n");
     }
-    jl_in_jl_--;
+    jl_safe_restore = old_buf;
 }
 
 JL_DLLEXPORT void jl_breakpoint(jl_value_t *v)

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -309,7 +309,7 @@ JL_DLLEXPORT int jl_fs_chmod(char *path, int mode)
 JL_DLLEXPORT int jl_fs_write(int handle, const char *data, size_t len,
                              int64_t offset)
 {
-    if (jl_in_jl_)
+    if (jl_safe_restore)
         return write(handle, data, len);
     uv_fs_t req;
     uv_buf_t buf[1];

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -23,7 +23,7 @@ extern jl_function_t *jl_typeinf_func;
 #if defined(JL_USE_INTEL_JITEVENTS)
 extern unsigned sig_stack_size;
 #endif
-#define jl_in_jl_ jl_get_ptls_states()->in_jl_
+#define jl_safe_restore jl_get_ptls_states()->safe_restore
 
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -49,7 +49,7 @@ typedef struct _jl_tls_states_t {
     char *stack_hi;
     jl_jmp_buf *volatile jmp_target;
     jl_jmp_buf base_ctx; // base context of stack
-    int8_t in_jl_;
+    jl_jmp_buf *safe_restore;
     int16_t tid;
     size_t bt_size;
     intptr_t bt_data[JL_MAX_BT_SIZE + 1];

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -96,7 +96,7 @@ static void segv_handler(int sig, siginfo_t *info, void *context)
         return;
     }
 #endif
-    if (jl_in_jl_ || is_addr_on_stack(jl_get_ptls_states(), info->si_addr)) { // stack overflow, or restarting jl_
+    if (jl_safe_restore || is_addr_on_stack(jl_get_ptls_states(), info->si_addr)) { // stack overflow, or restarting jl_
         jl_unblock_signal(sig);
         jl_throw(jl_stackovf_exception);
     }


### PR DESCRIPTION
This seems to happen ~ `0.001%` of time on x64 ArchLinux when benchmarking codegen (once every ~2s with ~20k-50kHz sampling rate or once ~1-2min with the default sampling rate). Everytime this happens it seems to be unwinding a c++ frame in libstdc++.

This should also help enabling unwinding on ARM and PPC64 although last time I tried something similar on ARM it seems to trigger an error similar to https://github.com/JuliaLang/julia/issues/14550 which I now suspect is a compiler issue....
