### PR TITLE
Fix #13130 - concatenation of dense and sparse should be sparse.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -160,6 +160,8 @@ Library improvements
 
   * There is now a default no-op `flush(io)` function for all `IO` types ([#16403]).
 
+  * Concatenating dense and sparse matrices now returns a sparse matrix ([#15172]).
+
 Deprecated or removed
 ---------------------
 
@@ -231,3 +233,4 @@ Deprecated or removed
 [#15609]: https://github.com/JuliaLang/julia/issues/15609
 [#15763]: https://github.com/JuliaLang/julia/issues/15763
 [#16403]: https://github.com/JuliaLang/julia/issues/16403
+[#15172]: https://github.com/JuliaLang/julia/issues/15172

--- a/base/array.jl
+++ b/base/array.jl
@@ -717,6 +717,14 @@ function hcat{T}(V::Vector{T}...)
     [ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]
 end
 
+hcat(A::Matrix...) = typed_hcat(promote_eltype(A...), A...)
+hcat{T}(A::Matrix{T}...) = typed_hcat(T, A...)
+
+vcat(A::Matrix...) = typed_vcat(promote_eltype(A...), A...)
+vcat{T}(A::Matrix{T}...) = typed_vcat(T, A...)
+
+hvcat(rows::Tuple{Vararg{Int}}, xs::Matrix...) = typed_hvcat(promote_eltype(xs...), rows, xs...)
+hvcat{T}(rows::Tuple{Vararg{Int}}, xs::Matrix{T}...) = typed_hvcat(T, rows, xs...)
 
 ## find ##
 

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -29,7 +29,7 @@ const CHOLMOD_MIN_VERSION = v"2.1.1"
 ### These offsets are defined in SuiteSparse_wrapper.c
 const common_size = ccall((:jl_cholmod_common_size,:libsuitesparse_wrapper),Int,())
 
-const cholmod_com_offsets = Array(Csize_t, 19)
+const cholmod_com_offsets = Array{Csize_t}(19)
 ccall((:jl_cholmod_common_offsets, :libsuitesparse_wrapper),
     Void, (Ptr{Csize_t},), cholmod_com_offsets)
 
@@ -56,7 +56,7 @@ end
 
 common() = commonStruct
 
-const build_version_array = Array(Cint, 3)
+const build_version_array = Array{Cint}(3)
 ccall((:jl_cholmod_version, :libsuitesparse_wrapper), Cint, (Ptr{Cint},), build_version_array)
 const build_version = VersionNumber(build_version_array...)
 
@@ -64,7 +64,7 @@ function __init__()
     try
         ### Check if the linked library is compatible with the Julia code
         if Libdl.dlsym_e(Libdl.dlopen("libcholmod"), :cholmod_version) != C_NULL
-            current_version_array = Array(Cint, 3)
+            current_version_array = Array{Cint}(3)
             ccall((:cholmod_version, :libcholmod), Cint, (Ptr{Cint},), current_version_array)
             current_version = VersionNumber(current_version_array...)
         else # CHOLMOD < 2.1.1 does not include cholmod_version()
@@ -704,10 +704,10 @@ function vertcat{Tv<:VRealTypes}(A::Sparse{Tv}, B::Sparse{Tv}, values::Bool)
 end
 
 function symmetry{Tv<:VTypes}(A::Sparse{Tv}, option::Integer)
-    xmatched = Array(SuiteSparse_long, 1)
-    pmatched = Array(SuiteSparse_long, 1)
-    nzoffdiag = Array(SuiteSparse_long, 1)
-    nzdiag = Array(SuiteSparse_long, 1)
+    xmatched = Array{SuiteSparse_long}(1)
+    pmatched = Array{SuiteSparse_long}(1)
+    nzoffdiag = Array{SuiteSparse_long}(1)
+    nzdiag = Array{SuiteSparse_long}(1)
     rv = ccall((@cholmod_name("symmetry", SuiteSparse_long), :libcholmod), Cint,
             (Ptr{C_Sparse{Tv}}, Cint, Ptr{SuiteSparse_long}, Ptr{SuiteSparse_long},
                 Ptr{SuiteSparse_long}, Ptr{SuiteSparse_long}, Ptr{UInt8}),
@@ -956,7 +956,7 @@ end
 ## convertion back to base Julia types
 function convert{T}(::Type{Matrix{T}}, D::Dense{T})
     s = unsafe_load(D.p)
-    a = Array(T, s.nrow, s.ncol)
+    a = Array{T}(s.nrow, s.ncol)
     copy!(a, D)
 end
 function Base.copy!(dest::AbstractArray, D::Dense)
@@ -980,7 +980,7 @@ function convert{T}(::Type{Vector{T}}, D::Dense{T})
     if size(D, 2) > 1
         throw(DimensionMismatch("input must be a vector but had $(size(D, 2)) columns"))
     end
-    copy!(Array(T, size(D, 1)), D)
+    copy!(Array{T}(size(D, 1)), D)
 end
 convert{T}(::Type{Vector}, D::Dense{T}) = convert(Vector{T}, D)
 
@@ -1032,7 +1032,7 @@ function sparse(F::Factor)
     SparseArrays.sortSparseMatrixCSC!(A)
     p = get_perm(F)
     if p != [1:s.n;]
-        pinv = Array(Int, length(p))
+        pinv = Array{Int}(length(p))
         for k = 1:length(p)
             pinv[p[k]] = k
         end
@@ -1154,7 +1154,7 @@ function getindex(F::Factor, sym::Symbol)
 end
 
 function getLd!(S::SparseMatrixCSC)
-    d = Array(eltype(S), size(S, 1))
+    d = Array{eltype(S)}(size(S, 1))
     fill!(d, 0)
     col = 1
     for k = 1:length(S.nzval)

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -151,9 +151,9 @@ function spmatmul{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
     colptrB = B.colptr; rowvalB = B.rowval; nzvalB = B.nzval
     # TODO: Need better estimation of result space
     nnzC = min(mA*nB, length(nzvalA) + length(nzvalB))
-    colptrC = Array(Ti, nB+1)
-    rowvalC = Array(Ti, nnzC)
-    nzvalC = Array(Tv, nnzC)
+    colptrC = Array{Ti}(nB+1)
+    rowvalC = Array{Ti}(nnzC)
+    nzvalC = Array{Tv}(nnzC)
 
     @inbounds begin
         ip = 1
@@ -302,7 +302,7 @@ function triu{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0)
     if (k > 0 && k > n) || (k < 0 && -k > m)
         throw(BoundsError())
     end
-    colptr = Array(Ti, n+1)
+    colptr = Array{Ti}(n+1)
     nnz = 0
     for col = 1 : min(max(k+1,1), n+1)
         colptr[col] = 1
@@ -314,8 +314,8 @@ function triu{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0)
         end
         colptr[col+1] = nnz+1
     end
-    rowval = Array(Ti, nnz)
-    nzval = Array(Tv, nnz)
+    rowval = Array{Ti}(nnz)
+    nzval = Array{Tv}(nnz)
     A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
     for col = max(k+1,1) : n
         c1 = S.colptr[col]
@@ -333,7 +333,7 @@ function tril{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0)
     if (k > 0 && k > n) || (k < 0 && -k > m)
         throw(BoundsError())
     end
-    colptr = Array(Ti, n+1)
+    colptr = Array{Ti}(n+1)
     nnz = 0
     colptr[1] = 1
     for col = 1 : min(n, m+k)
@@ -347,8 +347,8 @@ function tril{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0)
     for col = max(min(n, m+k)+2,1) : n+1
         colptr[col] = nnz+1
     end
-    rowval = Array(Ti, nnz)
-    nzval = Array(Tv, nnz)
+    rowval = Array{Ti}(nnz)
+    nzval = Array{Tv}(nnz)
     A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
     for col = 1 : min(n, m+k)
         c1 = S.colptr[col+1]-1
@@ -367,10 +367,10 @@ end
 function sparse_diff1{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
     m,n = size(S)
     m > 1 || return SparseMatrixCSC(0, n, ones(Ti,n+1), Ti[], Tv[])
-    colptr = Array(Ti, n+1)
+    colptr = Array{Ti}(n+1)
     numnz = 2 * nnz(S) # upper bound; will shrink later
-    rowval = Array(Ti, numnz)
-    nzval = Array(Tv, numnz)
+    rowval = Array{Ti}(numnz)
+    nzval = Array{Tv}(numnz)
     numnz = 0
     colptr[1] = 1
     for col = 1 : n
@@ -406,10 +406,10 @@ end
 
 function sparse_diff2{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti})
     m,n = size(a)
-    colptr = Array(Ti, max(n,1))
+    colptr = Array{Ti}(max(n,1))
     numnz = 2 * nnz(a) # upper bound; will shrink later
-    rowval = Array(Ti, numnz)
-    nzval = Array(Tv, numnz)
+    rowval = Array{Ti}(numnz)
+    nzval = Array{Tv}(numnz)
 
     z = zero(Tv)
 
@@ -561,8 +561,8 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)
     if t > n
         throw(ArgumentError("number of blocks must not be greater than $n"))
     end
-    ind = Array(Int64, n)
-    ind_hist = Array(Int64, maxiter * t)
+    ind = Array{Int64}(n)
+    ind_hist = Array{Int64}(maxiter * t)
 
     Ti = typeof(float(zero(T)))
 
@@ -584,7 +584,7 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)
     end
 
     # Generate the block matrix
-    X = Array(Ti, n, t)
+    X = Array{Ti}(n, t)
     X[1:n,1] = 1
     for j = 2:t
         while true
@@ -734,9 +734,9 @@ function kron{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti}, b::SparseMatrixCSC{Tv,Ti})
 
     m,n = mA*mB, nA*nB
 
-    colptr = Array(Ti, n+1)
-    rowval = Array(Ti, numnz)
-    nzval = Array(Tv, numnz)
+    colptr = Array{Ti}(n+1)
+    rowval = Array{Ti}(numnz)
+    nzval = Array{Tv}(numnz)
 
     colptr[1] = 1
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -275,7 +275,7 @@ function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, M::AbstractMatrix)
 end
 convert{T}(::Type{AbstractMatrix{T}}, A::SparseMatrixCSC) = convert(SparseMatrixCSC{T}, A)
 convert(::Type{Matrix}, S::SparseMatrixCSC) = full(S)
-
+convert(::Type{SparseMatrixCSC}, M::Matrix) = sparse(M)
 
 """
     full(S)
@@ -2896,7 +2896,20 @@ function hcat(X::SparseMatrixCSC...)
     SparseMatrixCSC(m, n, colptr, rowval, nzval)
 end
 
-function hvcat(rows::Tuple{Vararg{Int}}, X::SparseMatrixCSC...)
+
+# Sparse/dense concatenation
+
+function hcat(Xin::Union{Matrix, SparseMatrixCSC}...)
+    X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
+    hcat(X...)
+end
+
+function vcat(Xin::Union{Matrix, SparseMatrixCSC}...)
+    X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
+    vcat(X...)
+end
+
+function hvcat(rows::Tuple{Vararg{Int}}, X::Union{Matrix, SparseMatrixCSC}...)
     nbr = length(rows)  # number of block rows
 
     tmp_rows = Array(SparseMatrixCSC, nbr)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -163,7 +163,7 @@ function reinterpret{T,Tv,Ti,N}(::Type{T}, a::SparseMatrixCSC{Tv,Ti}, dims::NTup
     mS,nS = dims
     mA,nA = size(a)
     numnz = nnz(a)
-    colptr = Array(Ti, nS+1)
+    colptr = Array{Ti}(nS+1)
     rowval = similar(a.rowval)
     nzval = reinterpret(T, a.nzval)
 
@@ -239,8 +239,8 @@ function copy!(A::SparseMatrixCSC, B::SparseMatrixCSC)
     return A
 end
 
-similar(S::SparseMatrixCSC, Tv::Type=eltype(S))   = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), Array(Tv, length(S.nzval)))
-similar{Tv,Ti,TvNew,TiNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{TiNew}) = SparseMatrixCSC(S.m, S.n, convert(Array{TiNew},S.colptr), convert(Array{TiNew}, S.rowval), Array(TvNew, length(S.nzval)))
+similar(S::SparseMatrixCSC, Tv::Type=eltype(S)) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), Array{Tv}(length(S.nzval)))
+similar{Tv,Ti,TvNew,TiNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{TiNew}) = SparseMatrixCSC(S.m, S.n, convert(Array{TiNew},S.colptr), convert(Array{TiNew}, S.rowval), Array{TvNew}(length(S.nzval)))
 similar{Tv}(S::SparseMatrixCSC, ::Type{Tv}, d::Dims) = spzeros(Tv, d...)
 
 function convert{Tv,Ti,TvS,TiS}(::Type{SparseMatrixCSC{Tv,Ti}}, S::SparseMatrixCSC{TvS,TiS})
@@ -287,7 +287,7 @@ full
 function full{Tv}(S::SparseMatrixCSC{Tv})
     # Handle cases where zero(Tv) is not defined but the array is dense.
     # (Should we really worry about this?)
-    A = length(S) == nnz(S) ? Array(Tv, S.m, S.n) : zeros(Tv, S.m, S.n)
+    A = length(S) == nnz(S) ? Array{Tv}(S.m, S.n) : zeros(Tv, S.m, S.n)
     for col = 1 : S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
         A[S.rowval[k], col] = S.nzval[k]
     end
@@ -807,8 +807,8 @@ end
 
 function findn{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
     numnz = nnz(S)
-    I = Array(Ti, numnz)
-    J = Array(Ti, numnz)
+    I = Array{Ti}(numnz)
+    J = Array{Ti}(numnz)
 
     count = 1
     @inbounds for col = 1 : S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
@@ -830,9 +830,9 @@ end
 
 function findnz{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
     numnz = nnz(S)
-    I = Array(Ti, numnz)
-    J = Array(Ti, numnz)
-    V = Array(Tv, numnz)
+    I = Array{Ti}(numnz)
+    J = Array{Ti}(numnz)
+    V = Array{Tv}(numnz)
 
     count = 1
     @inbounds for col = 1 : S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
@@ -861,7 +861,7 @@ function sprand_IJ(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloa
     0 <= density <= 1 || throw(ArgumentError("$density not in [0,1]"))
     N = n*m
 
-    I, J = Array(Int, 0), Array(Int, 0) # indices of nonzero elements
+    I, J = Array{Int}(0), Array{Int}(0) # indices of nonzero elements
     sizehint!(I, round(Int,N*density))
     sizehint!(J, round(Int,N*density))
 
@@ -871,7 +871,7 @@ function sprand_IJ(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloa
     colsparsity = exp(m*L) # = 1 - coldensity
     iL = 1/L
 
-    rows = Array(Int, 0)
+    rows = Array{Int}(0)
     for j in randsubseq(r, 1:n, coldensity)
         # To get the right statistics, we *must* have a nonempty column j
         # even if p*m << 1.   To do this, we use an approach similar to
@@ -966,7 +966,7 @@ spzeros(m::Integer, n::Integer) = spzeros(Float64, m, n)
 spzeros(Tv::Type, m::Integer, n::Integer) = spzeros(Tv, Int, m, n)
 function spzeros(Tv::Type, Ti::Type, m::Integer, n::Integer)
     ((m < 0) || (n < 0)) && throw(ArgumentError("invalid Array dimensions"))
-    SparseMatrixCSC(m, n, ones(Ti, n+1), Array(Ti, 0), Array(Tv, 0))
+    SparseMatrixCSC(m, n, ones(Ti, n+1), Array{Ti}(0), Array{Tv}(0))
 end
 
 
@@ -1009,9 +1009,9 @@ end
 macro _unary_op_nz2z_z2z(op,A,Tv,Ti)
     esc(quote
         nfilledA = nnz($A)
-        colptrB = Array($Ti, $A.n+1)
-        rowvalB = Array($Ti, nfilledA)
-        nzvalB = Array($Tv, nfilledA)
+        colptrB = Array{$Ti}($A.n+1)
+        rowvalB = Array{$Ti}(nfilledA)
+        nzvalB = Array{$Tv}(nfilledA)
 
         nzvalA = $A.nzval
         colptrA = $A.colptr
@@ -1500,9 +1500,9 @@ end
 # and computing reductions along columns into SparseMatrixCSC is
 # non-trivial, so use Arrays for output
 Base.reducedim_initarray{R}(A::SparseMatrixCSC, region, v0, ::Type{R}) =
-    fill!(Array(R,Base.reduced_dims(A,region)), v0)
+    fill!(Array{R}(Base.reduced_dims(A,region)), v0)
 Base.reducedim_initarray0{R}(A::SparseMatrixCSC, region, v0, ::Type{R}) =
-    fill!(Array(R,Base.reduced_dims0(A,region)), v0)
+    fill!(Array{R}(Base.reduced_dims0(A,region)), v0)
 
 # General mapreduce
 function _mapreducezeros(f, op, T::Type, nzeros::Int, v0)
@@ -1718,7 +1718,7 @@ macro _findr(op, A, region, Tv, Ti)
 
     if $region == 1 || $region == (1,)
         (N == 0) && (return (fill(zval,1,n), fill(convert($Ti,1),1,n)))
-        S = Array($Tv, n); I = Array($Ti, n)
+        S = Array{$Tv}(n); I = Array{$Ti}(n)
         @inbounds for i = 1 : n
             Sc = zval; Ic = _findz($A, 1:m, i:i)
             if Ic == 0
@@ -1737,7 +1737,7 @@ macro _findr(op, A, region, Tv, Ti)
         return(reshape(S,1,n), reshape(I,1,n))
     elseif $region == 2 || $region == (2,)
         (N == 0) && (return (fill(zval,m,1), fill(convert($Ti,1),m,1)))
-        S = Array($Tv, m); I = Array($Ti, m)
+        S = Array{$Tv}(m); I = Array{$Ti}(m)
         @inbounds for row in 1:m
             S[row] = zval; I[row] = _findz($A, row:row, 1:n)
             if I[row] == 0
@@ -1813,7 +1813,7 @@ function getindex_cols{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, J::AbstractVector)
 
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
 
-    colptrS = Array(Ti, nJ+1)
+    colptrS = Array{Ti}(nJ+1)
     colptrS[1] = 1
     nnzS = 0
 
@@ -1824,8 +1824,8 @@ function getindex_cols{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, J::AbstractVector)
         colptrS[j+1] = nnzS + 1
     end
 
-    rowvalS = Array(Ti, nnzS)
-    nzvalS  = Array(Tv, nnzS)
+    rowvalS = Array{Ti}(nnzS)
+    nzvalS  = Array{Tv}(nnzS)
     ptrS = 0
 
     @inbounds for j = 1:nJ
@@ -1851,7 +1851,7 @@ function getindex{Tv,Ti<:Integer}(A::SparseMatrixCSC{Tv,Ti}, I::Range, J::Abstra
     nI == 0 || (minimum(I) >= 1 && maximum(I) <= m) || throw(BoundsError())
     nJ = length(J)
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
-    colptrS = Array(Ti, nJ+1)
+    colptrS = Array{Ti}(nJ+1)
     colptrS[1] = 1
     nnzS = 0
 
@@ -1866,8 +1866,8 @@ function getindex{Tv,Ti<:Integer}(A::SparseMatrixCSC{Tv,Ti}, I::Range, J::Abstra
     end
 
     # Populate the values in the result
-    rowvalS = Array(Ti, nnzS)
-    nzvalS  = Array(Tv, nnzS)
+    rowvalS = Array{Ti}(nnzS)
+    nzvalS  = Array{Tv}(nnzS)
     ptrS    = 1
 
     @inbounds for j = 1:nJ
@@ -1911,7 +1911,7 @@ function getindex_I_sorted_bsearch_A{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::Abstra
     const nJ = length(J)
 
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
-    colptrS = Array(Ti, nJ+1)
+    colptrS = Array{Ti}(nJ+1)
     colptrS[1] = 1
 
     ptrS = 1
@@ -1936,8 +1936,8 @@ function getindex_I_sorted_bsearch_A{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::Abstra
         colptrS[j+1] = ptrS
     end
 
-    rowvalS = Array(Ti, ptrS-1)
-    nzvalS  = Array(Tv, ptrS-1)
+    rowvalS = Array{Ti}(ptrS-1)
+    nzvalS  = Array{Tv}(ptrS-1)
 
     # fill the values
     ptrS = 1
@@ -1970,7 +1970,7 @@ function getindex_I_sorted_linear{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::AbstractV
     const nJ = length(J)
 
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
-    colptrS = Array(Ti, nJ+1)
+    colptrS = Array{Ti}(nJ+1)
     colptrS[1] = 1
     cacheI = zeros(Int, A.m)
 
@@ -1998,8 +1998,8 @@ function getindex_I_sorted_linear{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::AbstractV
         colptrS[j+1] = ptrS
     end
 
-    rowvalS = Array(Ti, ptrS-1)
-    nzvalS  = Array(Tv, ptrS-1)
+    rowvalS = Array{Ti}(ptrS-1)
+    nzvalS  = Array{Tv}(ptrS-1)
 
     # fill the values
     ptrS = 1
@@ -2029,7 +2029,7 @@ function getindex_I_sorted_bsearch_I{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::Abstra
     const nJ = length(J)
 
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
-    colptrS = Array(Ti, nJ+1)
+    colptrS = Array{Ti}(nJ+1)
     colptrS[1] = 1
 
     m = A.m
@@ -2063,8 +2063,8 @@ function getindex_I_sorted_bsearch_I{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::Abstra
             break
         end
     end
-    rowvalS = Array(Ti, ptrS)
-    nzvalS  = Array(Tv, ptrS)
+    rowvalS = Array{Ti}(ptrS)
+    nzvalS  = Array{Tv}(ptrS)
     colptrS[nJ+1] = ptrS+1
 
     # fill the values
@@ -2098,9 +2098,9 @@ function permute_rows!{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti}, pI::Vector{Int})
     colptrS = S.colptr; rowvalS = S.rowval; nzvalS = S.nzval
     # preallocate temporary sort space
     nr = min(nnz(S), m)
-    rowperm = Array(Int, nr)
-    rowvalTemp = Array(Ti, nr)
-    nzvalTemp = Array(Tv, nr)
+    rowperm = Array{Int}(nr)
+    rowvalTemp = Array{Ti}(nr)
+    nzvalTemp = Array{Tv}(nr)
 
     @inbounds for j in 1:n
         rowrange = colptrS[j]:(colptrS[j+1]-1)
@@ -2168,8 +2168,8 @@ function getindex{Tv}(A::SparseMatrixCSC{Tv}, I::AbstractArray)
     outn = size(I,2)
     szB = (outm, outn)
     colptrB = zeros(Int, outn+1)
-    rowvalB = Array(Int, n)
-    nzvalB = Array(Tv, n)
+    rowvalB = Array{Int}(n)
+    nzvalB = Array{Tv}(n)
 
     colB = 1
     rowB = 1
@@ -2820,9 +2820,9 @@ function vcat(X::SparseMatrixCSC...)
 
     nnzX = [ nnz(x) for x in X ]
     nnz_res = sum(nnzX)
-    colptr = Array(Ti, n + 1)
-    rowval = Array(Ti, nnz_res)
-    nzval  = Array(Tv, nnz_res)
+    colptr = Array{Ti}(n + 1)
+    rowval = Array{Ti}(nnz_res)
+    nzval  = Array{Tv}(nnz_res)
 
     colptr[1] = 1
     for c = 1:n
@@ -2871,11 +2871,11 @@ function hcat(X::SparseMatrixCSC...)
     Tv = promote_type(map(x->eltype(x.nzval), X)...)
     Ti = promote_type(map(x->eltype(x.rowval), X)...)
 
-    colptr = Array(Ti, n + 1)
+    colptr = Array{Ti}(n + 1)
     nnzX = [ nnz(x) for x in X ]
     nnz_res = sum(nnzX)
-    rowval = Array(Ti, nnz_res)
-    nzval = Array(Tv, nnz_res)
+    rowval = Array{Ti}(nnz_res)
+    nzval = Array{Tv}(nnz_res)
 
     nnz_sofar = 0
     nX_sofar = 0
@@ -2912,7 +2912,7 @@ end
 function hvcat(rows::Tuple{Vararg{Int}}, X::Union{Matrix, SparseMatrixCSC}...)
     nbr = length(rows)  # number of block rows
 
-    tmp_rows = Array(SparseMatrixCSC, nbr)
+    tmp_rows = Array{SparseMatrixCSC}(nbr)
     k = 0
     @inbounds for i = 1 : nbr
         tmp_rows[i] = hcat(X[(1 : rows[i]) + k]...)
@@ -2936,11 +2936,11 @@ function blkdiag(X::SparseMatrixCSC...)
     Tv = promote_type(map(x->eltype(x.nzval), X)...)
     Ti = promote_type(map(x->eltype(x.rowval), X)...)
 
-    colptr = Array(Ti, n + 1)
+    colptr = Array{Ti}(n + 1)
     nnzX = [ nnz(x) for x in X ]
     nnz_res = sum(nnzX)
-    rowval = Array(Ti, nnz_res)
-    nzval = Array(Tv, nnz_res)
+    rowval = Array{Ti}(nnz_res)
+    nzval = Array{Tv}(nnz_res)
 
     nnz_sofar = 0
     nX_sofar = 0
@@ -3079,9 +3079,9 @@ function spdiagm_internal(B, d)
     for vec in B
         ncoeffs += length(vec)
     end
-    I = Array(Int, ncoeffs)
-    J = Array(Int, ncoeffs)
-    V = Array(promote_type(map(eltype, B)...), ncoeffs)
+    I = Array{Int}(ncoeffs)
+    J = Array{Int}(ncoeffs)
+    V = Array{promote_type(map(eltype, B)...)}(ncoeffs)
     id = 0
     i = 0
     for vec in B
@@ -3180,9 +3180,9 @@ function diagm{Tv,Ti}(v::SparseMatrixCSC{Tv,Ti})
 
     n = length(v)
     numnz = nnz(v)
-    colptr = Array(Ti, n+1)
-    rowval = Array(Ti, numnz)
-    nzval = Array(Tv, numnz)
+    colptr = Array{Ti}(n+1)
+    rowval = Array{Ti}(numnz)
+    nzval = Array{Tv}(numnz)
 
     if size(v,1) == 1
         copy!(colptr, 1, v.colptr, 1, n+1)
@@ -3223,7 +3223,7 @@ end
 function sortSparseMatrixCSC!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}; sortindices::Symbol = :sortcols)
     if sortindices == :doubletranspose
         nB, mB = size(A)
-        B = SparseMatrixCSC(mB, nB, Array(Ti, nB+1), similar(A.rowval), similar(A.nzval))
+        B = SparseMatrixCSC(mB, nB, Array{Ti}(nB+1), similar(A.rowval), similar(A.nzval))
         transpose!(B, A)
         transpose!(A, B)
         return A

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -149,8 +149,8 @@ the dictionary, and the nonzero values are the values from the dictionary.
 """
 function sparsevec{Tv,Ti<:Integer}(dict::Associative{Ti,Tv})
     m = length(dict)
-    nzind = Array(Ti, m)
-    nzval = Array(Tv, m)
+    nzind = Array{Ti}(m)
+    nzval = Array{Tv}(m)
 
     cnt = 0
     len = zero(Ti)
@@ -170,8 +170,8 @@ end
 
 function sparsevec{Tv,Ti<:Integer}(dict::Associative{Ti,Tv}, len::Integer)
     m = length(dict)
-    nzind = Array(Ti, m)
-    nzval = Array(Tv, m)
+    nzind = Array{Ti}(m)
+    nzval = Array{Tv}(m)
 
     cnt = 0
     maxk = convert(Ti, len)
@@ -246,8 +246,8 @@ function _dense2sparsevec{Tv,Ti}(s::AbstractArray{Tv}, initcap::Ti)
     # pre-condition: initcap > 0; the initcap determines the index type
     n = length(s)
     cap = initcap
-    nzind = Array(Ti, cap)
-    nzval = Array(Tv, cap)
+    nzind = Array{Ti}(cap)
+    nzval = Array{Tv}(cap)
     c = 0
     @inbounds for i = 1:n
         v = s[i]
@@ -401,8 +401,8 @@ function Base.getindex{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, i::Integer, J::Abstract
     nJ = length(J)
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
 
-    nzinds = Array(Ti, 0)
-    nzvals = Array(Tv, 0)
+    nzinds = Array{Ti}(0)
+    nzvals = Array{Tv}(0)
 
     # adapted from SparseMatrixCSC's sorted_bsearch_A
     ptrI = 1
@@ -435,8 +435,8 @@ function _logical_index{Tv}(A::SparseMatrixCSC{Tv}, I::AbstractArray{Bool})
     nnzB = min(n, nnz(A))
 
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
-    rowvalB = Array(Int, nnzB)
-    nzvalB = Array(Tv, nnzB)
+    rowvalB = Array{Int}(nnzB)
+    nzvalB = Array{Tv}(nnzB)
     c = 1
     rowB = 1
 
@@ -480,8 +480,8 @@ function getindex{Tv}(A::SparseMatrixCSC{Tv}, I::UnitRange)
 
     n = length(I)
     nnzB = min(n, nnz(A))
-    rowvalB = Array(Int, nnzB)
-    nzvalB = Array(Tv, nnzB)
+    rowvalB = Array{Int}(nnzB)
+    nzvalB = Array{Tv}(nnzB)
 
     rowstart,colstart = ind2sub(szA, first(I))
     rowend,colend = ind2sub(szA, last(I))
@@ -515,8 +515,8 @@ function getindex{Tv}(A::SparseMatrixCSC{Tv}, I::AbstractVector)
 
     n = length(I)
     nnzB = min(n, nnz(A))
-    rowvalB = Array(Int, nnzB)
-    nzvalB = Array(Tv, nnzB)
+    rowvalB = Array{Int}(nnzB)
+    nzvalB = Array{Tv}(nnzB)
 
     idxB = 1
     for i in 1:n
@@ -576,8 +576,8 @@ function getindex{Tv,Ti}(x::AbstractSparseVector{Tv,Ti}, I::UnitRange)
     # compute the number of non-zeros
     jrgn = j0:j1
     mr = length(jrgn)
-    rind = Array(Ti, mr)
-    rval = Array(Tv, mr)
+    rind = Array{Ti}(mr)
+    rval = Array{Tv}(mr)
     if mr > 0
         c = 0
         for j in jrgn
@@ -668,7 +668,7 @@ convert{Tv,Ti}(::Type{SparseMatrixCSC}, x::AbstractSparseVector{Tv,Ti}) =
 
 function full{Tv}(x::AbstractSparseVector{Tv})
     n = length(x)
-    n == 0 && return Array(Tv, 0)
+    n == 0 && return Array{Tv}(0)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
     r = zeros(Tv, n)
@@ -711,9 +711,9 @@ function hcat{Tv,Ti}(X::AbstractSparseVector{Tv,Ti}...)
     end
 
     # construction
-    colptr = Array(Ti, n+1)
-    nzrow = Array(Ti, tnnz)
-    nzval = Array(Tv, tnnz)
+    colptr = Array{Ti}(n+1)
+    nzrow = Array{Ti}(tnnz)
+    nzval = Array{Tv}(tnnz)
     roff = 1
     @inbounds for j = 1:n
         xj = X[j]
@@ -737,8 +737,8 @@ function vcat{Tv,Ti}(X::AbstractSparseVector{Tv,Ti}...)
     end
 
     # construction
-    rnzind = Array(Ti, tnnz)
-    rnzval = Array(Tv, tnnz)
+    rnzind = Array{Ti}(tnnz)
+    rnzval = Array{Tv}(tnnz)
     ir = 0
     len = 0
     @inbounds for j = 1:n
@@ -780,8 +780,8 @@ macro unarymap_nz2z_z2z(op, TF)
             xnzval = nonzeros(x)
             m = length(xnzind)
 
-            ynzind = Array(Ti, m)
-            ynzval = Array(R, m)
+            ynzind = Array{Ti}(m)
+            ynzval = Array{R}(m)
             ir = 0
             @inbounds for j = 1:m
                 i = xnzind[j]
@@ -871,8 +871,8 @@ function _binarymap{Tx,Ty}(f::Function,
     my = length(ynzind)
     cap = (mode == 0 ? min(mx, my) : mx + my)::Int
 
-    rind = Array(Int, cap)
-    rval = Array(R, cap)
+    rind = Array{Int}(cap)
+    rval = Array{R}(cap)
     ir = 0
     ix = 1
     iy = 1
@@ -1009,7 +1009,7 @@ function _binarymap{Tx,Ty}(f::Function,
     ynzval = nonzeros(y)
     m = length(ynzind)
 
-    dst = Array(R, n)
+    dst = Array{R}(n)
     if mode == 0
         ii = 1
         @inbounds for i = 1:m
@@ -1052,7 +1052,7 @@ function _binarymap{Tx,Ty}(f::Function,
     xnzval = nonzeros(x)
     m = length(xnzind)
 
-    dst = Array(R, n)
+    dst = Array{R}(n)
     if mode == 0
         ii = 1
         @inbounds for i = 1:m
@@ -1161,7 +1161,7 @@ vecnorm(x::AbstractSparseVector, p::Real=2) = vecnorm(nonzeros(x), p)
 transpose(x::SparseVector) = _ct(identity, x)
 ctranspose(x::SparseVector) = _ct(conj, x)
 function _ct{T}(f, x::SparseVector{T})
-    isempty(x) && return Array(T, 1, 0)
+    isempty(x) && return Array{T}(1, 0)
     A = zeros(T, 1, length(x))
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
@@ -1288,7 +1288,7 @@ function *{Ta,Tx}(A::StridedMatrix{Ta}, x::AbstractSparseVector{Tx})
     m, n = size(A)
     length(x) == n || throw(DimensionMismatch())
     Ty = promote_type(Ta, Tx)
-    y = Array(Ty, m)
+    y = Array{Ty}(m)
     A_mul_B!(y, A, x)
 end
 
@@ -1325,7 +1325,7 @@ function At_mul_B{Ta,Tx}(A::StridedMatrix{Ta}, x::AbstractSparseVector{Tx})
     m, n = size(A)
     length(x) == m || throw(DimensionMismatch())
     Ty = promote_type(Ta, Tx)
-    y = Array(Ty, n)
+    y = Array{Ty}(n)
     At_mul_B!(y, A, x)
 end
 
@@ -1373,7 +1373,7 @@ function densemv(A::SparseMatrixCSC, x::AbstractSparseVector; trans::Char='N')
     end
     xlen == length(x) || throw(DimensionMismatch())
     T = promote_type(eltype(A), eltype(x))
-    y = Array(T, ylen)
+    y = Array{T}(ylen)
     if trans == 'N' || trans == 'N'
         A_mul_B!(y, A, x)
     elseif trans == 'T' || trans == 't'
@@ -1488,8 +1488,8 @@ function _At_or_Ac_mul_B{TvA,TiA,TvX,TiX}(tfun::Function, A::SparseMatrixCSC{TvA
     Anzval = A.nzval
     mx = length(xnzind)
 
-    ynzind = Array(Ti, n)
-    ynzval = Array(Tv, n)
+    ynzind = Array{Ti}(n)
+    ynzval = Array{Tv}(n)
 
     jr = 0
     for j = 1:n

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -71,9 +71,9 @@ typealias UMFVTypes Union{Float64,Complex128}
 ## UMFPACK
 
 # the control and info arrays
-const umf_ctrl = Array(Float64, UMFPACK_CONTROL)
+const umf_ctrl = Array{Float64}(UMFPACK_CONTROL)
 ccall((:umfpack_dl_defaults,:libumfpack), Void, (Ptr{Float64},), umf_ctrl)
-const umf_info = Array(Float64, UMFPACK_INFO)
+const umf_info = Array{Float64}(UMFPACK_INFO)
 
 function show_umf_ctrl(level::Real = 2.0)
     old_prt::Float64 = umf_ctrl[1]
@@ -199,7 +199,7 @@ for itype in UmfpackIndexTypes
     @eval begin
         function umfpack_symbolic!(U::UmfpackLU{Float64,$itype})
             if U.symbolic != C_NULL return U end
-            tmp = Array(Ptr{Void},1)
+            tmp = Array{Ptr{Void}}(1)
             @isok ccall(($sym_r, :libumfpack), $itype,
                         ($itype, $itype, Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Void},
                          Ptr{Float64}, Ptr{Float64}),
@@ -210,7 +210,7 @@ for itype in UmfpackIndexTypes
         end
         function umfpack_symbolic!(U::UmfpackLU{Complex128,$itype})
             if U.symbolic != C_NULL return U end
-            tmp = Array(Ptr{Void},1)
+            tmp = Array{Ptr{Void}}(1)
             @isok ccall(($sym_c, :libumfpack), $itype,
                         ($itype, $itype, Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Float64}, Ptr{Void},
                          Ptr{Float64}, Ptr{Float64}),
@@ -222,7 +222,7 @@ for itype in UmfpackIndexTypes
         function umfpack_numeric!(U::UmfpackLU{Float64,$itype})
             if U.numeric != C_NULL return U end
             if U.symbolic == C_NULL umfpack_symbolic!(U) end
-            tmp = Array(Ptr{Void}, 1)
+            tmp = Array{Ptr{Void}}(1)
             status = ccall(($num_r, :libumfpack), $itype,
                            (Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Void}, Ptr{Void},
                             Ptr{Float64}, Ptr{Float64}),
@@ -237,7 +237,7 @@ for itype in UmfpackIndexTypes
         function umfpack_numeric!(U::UmfpackLU{Complex128,$itype})
             if U.numeric != C_NULL return U end
             if U.symbolic == C_NULL umfpack_symbolic!(U) end
-            tmp = Array(Ptr{Void}, 1)
+            tmp = Array{Ptr{Void}}(1)
             status = ccall(($num_c, :libumfpack), $itype,
                            (Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Float64}, Ptr{Void}, Ptr{Void},
                             Ptr{Float64}, Ptr{Float64}),
@@ -268,10 +268,10 @@ for itype in UmfpackIndexTypes
             size(b,1)==lu.m || throw(DimensionMismatch())
             x = similar(b)
             n = size(b,1)
-            br = Array(Float64, n)
-            bi = Array(Float64, n)
-            xr = Array(Float64, n)
-            xi = Array(Float64, n)
+            br = Array{Float64}(n)
+            bi = Array{Float64}(n)
+            xr = Array{Float64}(n)
+            xi = Array{Float64}(n)
             joff = 0
             for k = 1:size(b,2)
                 for j = 1:n
@@ -294,37 +294,37 @@ for itype in UmfpackIndexTypes
             x
         end
         function det(lu::UmfpackLU{Float64,$itype})
-            mx = Array(Float64,1)
+            mx = Array{Float64}(1)
             @isok ccall(($det_r,:libumfpack), $itype,
                            (Ptr{Float64},Ptr{Float64},Ptr{Void},Ptr{Float64}),
                            mx, C_NULL, lu.numeric, umf_info)
             mx[1]
         end
         function det(lu::UmfpackLU{Complex128,$itype})
-            mx = Array(Float64,1)
-            mz = Array(Float64,1)
+            mx = Array{Float64}(1)
+            mz = Array{Float64}(1)
             @isok ccall(($det_z,:libumfpack), $itype,
                         (Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Void},Ptr{Float64}),
                         mx, mz, C_NULL, lu.numeric, umf_info)
             complex(mx[1], mz[1])
         end
         function umf_lunz(lu::UmfpackLU{Float64,$itype})
-            lnz = Array($itype, 1)
-            unz = Array($itype, 1)
-            n_row = Array($itype, 1)
-            n_col = Array($itype, 1)
-            nz_diag = Array($itype, 1)
+            lnz = Array{$itype}(1)
+            unz = Array{$itype}(1)
+            n_row = Array{$itype}(1)
+            n_col = Array{$itype}(1)
+            nz_diag = Array{$itype}(1)
             @isok ccall(($lunz_r,:libumfpack), $itype,
                            (Ptr{$itype},Ptr{$itype},Ptr{$itype},Ptr{$itype},Ptr{$itype},Ptr{Void}),
                            lnz, unz, n_row, n_col, nz_diag, lu.numeric)
             (lnz[1], unz[1], n_row[1], n_col[1], nz_diag[1])
         end
         function umf_lunz(lu::UmfpackLU{Complex128,$itype})
-            lnz = Array($itype, 1)
-            unz = Array($itype, 1)
-            n_row = Array($itype, 1)
-            n_col = Array($itype, 1)
-            nz_diag = Array($itype, 1)
+            lnz = Array{$itype}(1)
+            unz = Array{$itype}(1)
+            n_row = Array{$itype}(1)
+            n_col = Array{$itype}(1)
+            nz_diag = Array{$itype}(1)
             @isok ccall(($lunz_z,:libumfpack), $itype,
                            (Ptr{$itype},Ptr{$itype},Ptr{$itype},Ptr{$itype},Ptr{$itype},Ptr{Void}),
                            lnz, unz, n_row, n_col, nz_diag, lu.numeric)
@@ -333,15 +333,15 @@ for itype in UmfpackIndexTypes
         function umf_extract(lu::UmfpackLU{Float64,$itype})
             umfpack_numeric!(lu)        # ensure the numeric decomposition exists
             (lnz, unz, n_row, n_col, nz_diag) = umf_lunz(lu)
-            Lp = Array($itype, n_row + 1)
-            Lj = Array($itype, lnz) # L is returned in CSR (compressed sparse row) format
-            Lx = Array(Float64, lnz)
-            Up = Array($itype, n_col + 1)
-            Ui = Array($itype, unz)
-            Ux = Array(Float64, unz)
-            P  = Array($itype, n_row)
-            Q  = Array($itype, n_col)
-            Rs = Array(Float64, n_row)
+            Lp = Array{$itype}(n_row + 1)
+            Lj = Array{$itype}(lnz) # L is returned in CSR (compressed sparse row) format
+            Lx = Array{Float64}(lnz)
+            Up = Array{$itype}(n_col + 1)
+            Ui = Array{$itype}(unz)
+            Ux = Array{Float64}(unz)
+            P  = Array{$itype}(n_row)
+            Q  = Array{$itype}(n_col)
+            Rs = Array{Float64}(n_row)
             @isok ccall(($get_num_r,:libumfpack), $itype,
                         (Ptr{$itype},Ptr{$itype},Ptr{Float64},
                          Ptr{$itype},Ptr{$itype},Ptr{Float64},
@@ -358,17 +358,17 @@ for itype in UmfpackIndexTypes
         function umf_extract(lu::UmfpackLU{Complex128,$itype})
             umfpack_numeric!(lu)        # ensure the numeric decomposition exists
             (lnz, unz, n_row, n_col, nz_diag) = umf_lunz(lu)
-            Lp = Array($itype, n_row + 1)
-            Lj = Array($itype, lnz) # L is returned in CSR (compressed sparse row) format
-            Lx = Array(Float64, lnz)
-            Lz = Array(Float64, lnz)
-            Up = Array($itype, n_col + 1)
-            Ui = Array($itype, unz)
-            Ux = Array(Float64, unz)
-            Uz = Array(Float64, unz)
-            P  = Array($itype, n_row)
-            Q  = Array($itype, n_col)
-            Rs = Array(Float64, n_row)
+            Lp = Array{$itype}(n_row + 1)
+            Lj = Array{$itype}(lnz) # L is returned in CSR (compressed sparse row) format
+            Lx = Array{Float64}(lnz)
+            Lz = Array{Float64}(lnz)
+            Up = Array{$itype}(n_col + 1)
+            Ui = Array{$itype}(unz)
+            Ux = Array{Float64}(unz)
+            Uz = Array{Float64}(unz)
+            P  = Array{$itype}(n_row)
+            Q  = Array{$itype}(n_col)
+            Rs = Array{Float64}(n_row)
             @isok ccall(($get_num_z,:libumfpack), $itype,
                         (Ptr{$itype},Ptr{$itype},Ptr{Float64},Ptr{Float64},
                          Ptr{$itype},Ptr{$itype},Ptr{Float64},Ptr{Float64},

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1367,3 +1367,16 @@ end
 @inferred sprand(1, 1, 1.0)
 @inferred sprand(1, 1, 1.0, rand, Float64)
 @inferred sprand(1, 1, 1.0, x->round(Int,rand(x)*100))
+
+# dense sparse concatenation -> sparse return type
+@test issparse([sprand(10,10,.1) rand(10,10)])
+@test issparse([sprand(10,10,.1); rand(10,10)])
+@test issparse([sprand(10,10,.1) rand(10,10); rand(10,10) rand(10,10)])
+#---
+# Matrix vector cat not supported for sparse #13130
+#@test issparse([sprand(10,10,.1) rand(10)])
+#@test issparse([sprand(10,10,.1) sprand(10,.1)])
+# ---
+@test !issparse([rand(10,10)  rand(10,10)])
+@test !issparse([rand(10,10); rand(10,10)])
+@test !issparse([rand(10,10)  rand(10,10); rand(10,10) rand(10,10)])


### PR DESCRIPTION
Fixes #13130 .

I had to add `hcat`, `vcat`, and `hvcat` for `Matrix`. If I didn't, it would fall back to the `Union{Matrix, SparseMatrixCSC` method for `[rand(10,10) rand(10, 10)]`. There may be cleaner ways to do all of this.

Also, currently `[sprand(10, 0.1) sprand(10, 10, 0.1)]` returns a dense matrix. Surely, that should be sparse. I havn't implemented `[rand(10) sprand(10, 10, 0.1)]` yet either.

I guess it is still to be decided if this is the wanted behaviour, but I just wanted to make a PR to mirror my issue.

By the way, I am unsure what happened with the first two commits mentioned at the issue. They were supposed to be to my fork, but it doesn't say "to pkofod/julia". Is that because I've deleted that fork since?
