### PR TITLE
Make doc collection 600x faster in genstdlib.jl

### DIFF
--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -15,13 +15,18 @@ function add_all_docs(it)
     end
 end
 
-function add_all_docs(it, k)
+function add_all_docs(it, k::ANY)
     for (_, v) in it
         all_docs[v] = k
     end
 end
 
 function sym_exported(obj::ANY, m, exports)
+    if isa(obj, Function)
+        try
+            return typeof(obj).name.mt.name in exports
+        end
+    end
     if isa(obj, Union{Function,DataType,Module})
         return symbol(string(obj)) in exports
     elseif isa(obj, IntrinsicFunction)


### PR DESCRIPTION
[This line](https://github.com/JuliaLang/julia/blob/dbae7b995fc83f376d9d76d14d1d5c2eee311604/doc/genstdlib.jl#L67) takes ~0.12s on 0.4 and ~70s on master. It spends all it's time doing type inference on `string(::Function)` and `add_all_docs(_, ::Function)` (where `Function` is a concrete gf type). This patch bring the time down to ~0.12s.

@JeffBezanson Seems that some specialization heuristic is messed up here?
