### PR TITLE
Export StatStruct from FileSystem instead of Base.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -104,7 +104,6 @@ export
     SharedArray,
     SharedMatrix,
     SharedVector,
-    StatStruct,
     StepRange,
     StridedArray,
     StridedMatrix,

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -18,6 +18,7 @@ const S_IXOTH = 0o001
 const S_IRWXO = 0o007
 
 export File,
+       StatStruct,
        # open,
        futime,
        unlink,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -101,20 +101,20 @@ use it in the following manner to summarize information about a struct type:
 ```jldoctest
 julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:nfields(T)];
 
-julia> structinfo(StatStruct)
-12-element Array{Tuple{Int64,Symbol,DataType},1}:
- (0,:device,UInt64)
- (8,:inode,UInt64)
- (16,:mode,UInt64)
- (24,:nlink,Int64)
- (32,:uid,UInt64)
- (40,:gid,UInt64)
- (48,:rdev,UInt64)
- (56,:size,Int64)
- (64,:blksize,Int64)
- (72,:blocks,Int64)
- (80,:mtime,Float64)
- (88,:ctime,Float64)
+julia> structinfo(Base.Filesystem.StatStruct)
+12-element Array{Tuple{UInt64,Symbol,Type{_}},1}:
+ (0x0000000000000000,:device,UInt64)
+ (0x0000000000000008,:inode,UInt64)
+ (0x0000000000000010,:mode,UInt64)
+ (0x0000000000000018,:nlink,Int64)
+ (0x0000000000000020,:uid,UInt64)
+ (0x0000000000000028,:gid,UInt64)
+ (0x0000000000000030,:rdev,UInt64)
+ (0x0000000000000038,:size,Int64)
+ (0x0000000000000040,:blksize,Int64)
+ (0x0000000000000048,:blocks,Int64)
+ (0x0000000000000050,:mtime,Float64)
+ (0x0000000000000058,:ctime,Float64)
 ```
 """
 fieldoffset(x::DataType, idx::Integer) = (@_pure_meta; ccall(:jl_get_field_offset, Csize_t, (Any, Cint), x, idx))

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -532,20 +532,20 @@ Types
 
        julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:nfields(T)];
 
-       julia> structinfo(StatStruct)
-       12-element Array{Tuple{Int64,Symbol,DataType},1}:
-        (0,:device,UInt64)
-        (8,:inode,UInt64)
-        (16,:mode,UInt64)
-        (24,:nlink,Int64)
-        (32,:uid,UInt64)
-        (40,:gid,UInt64)
-        (48,:rdev,UInt64)
-        (56,:size,Int64)
-        (64,:blksize,Int64)
-        (72,:blocks,Int64)
-        (80,:mtime,Float64)
-        (88,:ctime,Float64)
+       julia> structinfo(Base.Filesystem.StatStruct)
+       12-element Array{Tuple{UInt64,Symbol,Type{_}},1}:
+        (0x0000000000000000,:device,UInt64)
+        (0x0000000000000008,:inode,UInt64)
+        (0x0000000000000010,:mode,UInt64)
+        (0x0000000000000018,:nlink,Int64)
+        (0x0000000000000020,:uid,UInt64)
+        (0x0000000000000028,:gid,UInt64)
+        (0x0000000000000030,:rdev,UInt64)
+        (0x0000000000000038,:size,Int64)
+        (0x0000000000000040,:blksize,Int64)
+        (0x0000000000000048,:blocks,Int64)
+        (0x0000000000000050,:mtime,Float64)
+        (0x0000000000000058,:ctime,Float64)
 
 .. function:: fieldtype(T, name::Symbol | index::Int)
 


### PR DESCRIPTION
Noticed in https://github.com/JuliaLang/julia/pull/15177#issuecomment-186896376 ....

Fix doc.

Many doc tests are still failing, a lot of them are caused by https://github.com/JuliaLang/JuliaDoc/pull/19 and others due to recent changes in printing.
