### PR TITLE
Address issparse for specialized matrix types part of #13096

### DIFF
--- a/base/sparse/abstractsparse.jl
+++ b/base/sparse/abstractsparse.jl
@@ -13,4 +13,11 @@ Returns `true` if `S` is sparse, and `false` otherwise.
 issparse(A::AbstractArray) = false
 issparse(S::AbstractSparseArray) = true
 
+issparse{T, A<:AbstractSparseMatrix}(S::Symmetric{T, A}) = true
+issparse{T, A<:AbstractSparseMatrix}(S::Hermitian{T, A}) = true
+issparse{T, A<:AbstractSparseMatrix}(S::LowerTriangular{T, A}) = true
+issparse{T, A<:AbstractSparseMatrix}(S::LinAlg.UnitLowerTriangular{T, A}) = true
+issparse{T, A<:AbstractSparseMatrix}(S::UpperTriangular{T, A}) = true
+issparse{T, A<:AbstractSparseMatrix}(S::LinAlg.UnitUpperTriangular{T, A}) = true
+
 indtype{Tv,Ti}(S::AbstractSparseArray{Tv,Ti}) = Ti

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1227,3 +1227,20 @@ end
 # https://groups.google.com/forum/#!topic/julia-dev/QT7qpIpgOaA
 @test sparse([1,1], [1,1], [true, true]) == sparse([1,1], [1,1], [true, true], 1, 1) == fill(true, 1, 1)
 @test sparsevec([1,1], [true, true]) == sparsevec([1,1], [true, true], 1) == fill(true, 1)
+
+# issparse for specialized matrix types
+let
+    m = sprand(10, 10, 0.1)
+    @test issparse(Symmetric(m))
+    @test issparse(Hermitian(m))
+    @test issparse(LowerTriangular(m))
+    @test issparse(LinAlg.UnitLowerTriangular(m))
+    @test issparse(UpperTriangular(m))
+    @test issparse(LinAlg.UnitUpperTriangular(m))
+    @test issparse(Symmetric(full(m))) == false
+    @test issparse(Hermitian(full(m))) == false
+    @test issparse(LowerTriangular(full(m))) == false
+    @test issparse(LinAlg.UnitLowerTriangular(full(m))) == false
+    @test issparse(UpperTriangular(full(m))) == false
+    @test issparse(LinAlg.UnitUpperTriangular(full(m))) == false
+end


### PR DESCRIPTION
Adds `issparse` methods for specialized matrix types, such that it returns `true` if the matrix they are based on are sparse.

cc @kshyatt 
