### PR TITLE
julia-mode: Indent manually inside multi-line strings

### DIFF
--- a/contrib/julia-mode-tests.el
+++ b/contrib/julia-mode-tests.el
@@ -252,6 +252,24 @@ y2 = g(x)"
        z)
 y2 = g(x)"))
 
+(ert-deftest julia--test-indentation-of-multi-line-strings ()
+  "Indentation should only affect the first line of a multi-line string."
+    (julia--should-indent
+     "   a = \"\"\"
+    description
+begin
+    foo
+bar
+end
+\"\"\""
+     "a = \"\"\"
+    description
+begin
+    foo
+bar
+end
+\"\"\""))
+
 (defun julia--run-tests ()
   (interactive)
   (if (featurep 'ert)


### PR DESCRIPTION
Don't try to automatically indent when inside strings with newline
characters. We don't want to add indentation where it is not intended,
so any automatic formatting should not assume that we want to indent
inside a string. This also fixes #12419, because we won't get confused
by keywords in multi-line strings.

Because it is still useful, make TAB and <backtab> increase and decrease
indentation when called inside a string.
