### PR TITLE
julia-mode: Indentation performance improvements

### DIFF
--- a/contrib/julia-mode-tests.el
+++ b/contrib/julia-mode-tests.el
@@ -270,6 +270,20 @@ bar
 end
 \"\"\""))
 
+(ert-deftest julia--test-indent-of-end-in-brackets ()
+  "Ignore end keyword in brackets for the purposes of indenting blocks."
+  (julia--should-indent
+   "begin
+    begin
+        arr[1: end - 1]
+        end
+end"
+   "begin
+    begin
+        arr[1: end - 1]
+    end
+end"))
+
 (defun julia--run-tests ()
   (interactive)
   (if (featurep 'ert)


### PR DESCRIPTION
These focus on the block indentation algorithm, and basically remove
unnecessary checks.
1. If we jump out of any comments at the beginning of the block
    indentation routine we don't need to check later if we are in a
    comment because backward-sexp jumps over comment blocks.
2. We also don't need to check if an end keyword is inside of
    brackets, because any time we are in brackets indentation is
    handled by julia-paren-indent.

For an example of performance improvements, the time to indent lapack.jl
fall from 18s to 5s on my machine
