### PR TITLE
Fix captured static param lowering

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2453,12 +2453,12 @@ f(x) = yt(x)
 (define (clear-capture-bits vinfos)
   (map vinfo:not-capt vinfos))
 
-(define (convert-lambda lam fname interp)
+(define (convert-lambda lam fname interp capt-sp)
   `(lambda ,(lam:args lam)
      (,(clear-capture-bits (car (lam:vinfo lam)))
       ()
       ,(caddr (lam:vinfo lam))
-      ,(cadddr (lam:vinfo lam)))
+      ,(delete-duplicates (append (lam:sp lam) capt-sp)))
      ,(add-box-inits-to-body
        lam
        (cl-convert (cadddr lam) fname lam (table) #f interp))))
@@ -2701,7 +2701,7 @@ f(x) = yt(x)
                                       (cl-convert (cadddr lam2) 'anon lam2 (table) #f interp)))
                                   ,(last e))))
                        (else
-                        (let* ((exprs     (lift-toplevel (convert-lambda lam2 '|#anon| #t)))
+                        (let* ((exprs     (lift-toplevel (convert-lambda lam2 '|#anon| #t '())))
                                (top-stmts (cdr exprs))
                                (newlam    (renumber-jlgensym (linearize (car exprs))))
                                (vi        (lam:vinfo newlam))
@@ -2796,7 +2796,7 @@ f(x) = yt(x)
                                                       (if iskw
                                                           (caddr (lam:args lam2))
                                                           (car (lam:args lam2)))
-                                                      #f)
+                                                      #f capt-sp)
                                      ,(last e))))
                      ,(if exists
                           '(null)

--- a/test/core.jl
+++ b/test/core.jl
@@ -3777,3 +3777,13 @@ let ex = quote
          end
     @test ex.args[2] == :test
 end
+
+# issue #15180
+function f15180{T}(x::T)
+    X = Array(T, 1)
+    X[1] = x
+    @noinline ef{J}(::J) = (J,X[1]) # Use T
+    ef{J}(::J, ::Int) = (T,J)
+    return ef
+end
+@test map(f15180(1), [1,2]) == [(Int,1),(Int,1)]


### PR DESCRIPTION
Captured static parameters by other methods of the same generic
closure were only added to the '(method ...) expr but not in the vinfo
of the '(lambda ...) if said parameter was not used in the definition.
Fixes #15180.

@JeffBezanson 
