### PR TITLE
Require the `cx16` feature on Intel CPUs when threading is enabled

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5794,7 +5794,7 @@ static void init_julia_llvm_env(Module *m)
 }
 
 // Helper to figure out what features to set for the LLVM target
-// If the user specifies native ( or does not specify ) we default
+// If the user specifies native (or does not specify) we default
 // using the API provided by LLVM
 static inline SmallVector<std::string,10> getTargetFeatures() {
   StringMap<bool> HostFeatures;
@@ -5807,13 +5807,19 @@ static inline SmallVector<std::string,10> getTargetFeatures() {
   // Platform specific overides follow
 #if defined(_CPU_X86_64_) || defined(_CPU_X86_)
 #ifndef USE_MCJIT
-    // Temporarily disable Haswell BMI2 features due to LLVM bug.
+  // Temporarily disable Haswell BMI2 features due to LLVM bug.
   HostFeatures["bmi2"] = false;
   HostFeatures["avx2"] = false;
 #endif
 #ifdef V128_BUG
   HostFeatures["avx"] = false;
 #endif
+  // Require cx16 (cmpxchg16b)
+  // We need this for 128-bit atomic operations. We only need this
+  // when threading is enabled; however, to test whether this excludes
+  // important systems, we require this even when threading is
+  // disabled.
+  HostFeatures["cx16"] = true;
 #endif
 
   // Figure out if we know the cpu_target


### PR DESCRIPTION
This makes 128-bit atomics work on Intel. Without this feature, LLVM does not always know how to generate the respective code.

The CPU feature `cx16` describes whether the CPU supports the `cmpxchg16b` instruction. All modern Intel CPUs support this feature; see the discussion in #14818.

When Julia generates code for a `native` 64-bit CPU, this flag is already set correctly. However, when Julia generates code for either a 32-bit or a `generic` Intel CPU, then LLVM assumes pessimistically that this feature is not present. According to Wikipedia https://en.wikipedia.org/wiki/X86-64, this is only relevant for "early AMD64 processors", and "the 64-bit version of Windows 8.1 requires the instruction". I thus suggest to require this instruction as well when threading is enabled.

The alternative is to disable support for 128-bit atomics. The generic CPU target is apparently specified at many occasions, including for 32-bit Intel CPUs and in Travis.

Closes #14818.
