### PR TITLE
Add new Dates slot character 'Y'

### DIFF
--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -69,6 +69,7 @@ setindex!(collection::SlotRule, value::Type, key::Char) = collection.rules[Int(k
 keys(c::SlotRule) = map(Char, filter(el -> isdefined(c.rules, el), eachindex(c.rules)))
 
 SLOT_RULE['y'] = Year
+SLOT_RULE['Y'] = Year
 SLOT_RULE['m'] = Month
 SLOT_RULE['u'] = Month
 SLOT_RULE['U'] = Month
@@ -169,8 +170,15 @@ function parse(x::AbstractString,df::DateFormat)
     return vcat(sort!(periods,rev=true,lt=periodisless), extra)
 end
 
-slotformat(slot::Slot{Year},dt,locale) = lpad(string(value(slot.parser(dt))),slot.width,"0")[(end-slot.width+1):end]
 slotformat(slot,dt,locale) = lpad(string(value(slot.parser(dt))),slot.width,"0")
+function slotformat(slot::Slot{Year},dt,locale)
+    s = lpad(string(value(slot.parser(dt))),slot.width,"0")
+    if slot.letter == 'y'
+        return s[(end-slot.width+1):end]  # Truncate the year
+    else # == 'Y'
+        return s
+    end
+end
 function slotformat(slot::Slot{Month},dt,locale)
     if slot.letter == 'm'
         return lpad(month(dt),slot.width,"0")

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -311,3 +311,10 @@ dt = Dates.DateTime(2014,8,23,17,22,15)
 @test Dates.format(Dates.DateTime(2014,10,31,0,0,0,9),Dates.RFC1123Format) == "Fri, 31 Oct 2014 00:00:00"
 @test Dates.format(Dates.DateTime(2014,11,2,0,0,0,9),Dates.RFC1123Format) == "Sun, 02 Nov 2014 00:00:00"
 @test Dates.format(Dates.DateTime(2014,12,5,0,0,0,9),Dates.RFC1123Format) == "Fri, 05 Dec 2014 00:00:00"
+
+# Issue 15195
+let f = "YY"
+    @test Dates.format(Dates.Date(1999), f) == "1999"
+    @test Dates.format(Dates.Date(9), f) == "09"
+    @test Dates.format(typemax(Dates.Date), f) == "252522163911149"
+end


### PR DESCRIPTION
Adds a new date formating slot 'Y' which allows a non-truncated format for year:

``` julia
julia> Dates.format(Date(1999), "yy")
"99"

julia> Dates.format(Date(9), "yy")
"09"

julia> Dates.format(typemax(Date), "yy")
"49"

julia> Dates.format(Date(1999), "YY")
"1999"

julia> Dates.format(Date(9), "YY")
"09"

julia> Dates.format(typemax(Date), "YY")
"252522163911149"
```

Fixes issue #15195
