### PR TITLE
Fix edge cases in rounding of Rational(num, den)

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -289,19 +289,19 @@ floor{T}(::Type{T}, x::Rational) = convert(T,fld(x.num,x.den))
 ceil{ T}(::Type{T}, x::Rational) = convert(T,cld(x.num,x.den))
 
 function round{T}(::Type{T}, x::Rational, ::RoundingMode{:Nearest})
-    q,r = divrem(x.num,x.den)
-    s = abs(r) < abs((x.den-copysign(typeof(x.den)(4), x.num)+one(x.den)+iseven(q))>>1 + copysign(typeof(x.den)(2), x.num)) ? q : q+copysign(one(q),x.num)
+    q,r = divrem(num(x), den(x))
+    s = abs(r) < abs((den(x)-copysign(typeof(den(x))(4), num(x))+one(den(x))+iseven(q))>>1 + copysign(typeof(den(x))(2), num(x))) ? q : q+copysign(one(q),num(x))
     convert(T,s)
 end
 round{T}(::Type{T}, x::Rational) = round(T,x,RoundNearest)
 function round{T}(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesAway})
-    q,r = divrem(x.num,x.den)
-    s = abs(r) < abs((x.den-copysign(typeof(x.den)(4), x.num)+one(x.den))>>1 + copysign(typeof(x.den)(2), x.num)) ? q : q+copysign(one(q),x.num)
+    q,r = divrem(num(x), den(x))
+    s = abs(r) < abs((den(x)-copysign(typeof(den(x))(4), num(x))+one(den(x)))>>1 + copysign(typeof(den(x))(2), num(x))) ? q : q+copysign(one(q),num(x))
     convert(T,s)
 end
 function round{T}(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesUp})
-    q,r = divrem(x.num,x.den)
-    s = abs(r) < abs((x.den-copysign(typeof(x.den)(4), x.num)+one(x.den)+(x.num<0))>>1 + copysign(typeof(x.den)(2), x.num)) ? q : q+copysign(one(q),x.num)
+    q,r = divrem(num(x), den(x))
+    s = abs(r) < abs((den(x)-copysign(typeof(den(x))(4), num(x))+one(den(x))+(num(x)<0))>>1 + copysign(typeof(den(x))(2), num(x))) ? q : q+copysign(one(q),num(x))
     convert(T,s)
 end
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -290,18 +290,18 @@ ceil{ T}(::Type{T}, x::Rational) = convert(T,cld(x.num,x.den))
 
 function round{T}(::Type{T}, x::Rational, ::RoundingMode{:Nearest})
     q,r = divrem(x.num,x.den)
-    s = abs(r) < (x.den+one(x.den)+iseven(q))>>1 ? q : q+copysign(one(q),x.num)
+    s = abs(r) < abs((x.den-copysign(typeof(x.den)(4), x.num)+one(x.den)+iseven(q))>>1 + copysign(typeof(x.den)(2), x.num)) ? q : q+copysign(one(q),x.num)
     convert(T,s)
 end
 round{T}(::Type{T}, x::Rational) = round(T,x,RoundNearest)
 function round{T}(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesAway})
     q,r = divrem(x.num,x.den)
-    s = abs(r) < (x.den+one(x.den))>>1 ? q : q+copysign(one(q),x.num)
+    s = abs(r) < abs((x.den-copysign(typeof(x.den)(4), x.num)+one(x.den))>>1 + copysign(typeof(x.den)(2), x.num)) ? q : q+copysign(one(q),x.num)
     convert(T,s)
 end
 function round{T}(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesUp})
     q,r = divrem(x.num,x.den)
-    s = abs(r) < (x.den+one(x.den)+(x.num<0))>>1 ? q : q+copysign(one(q),x.num)
+    s = abs(r) < abs((x.den-copysign(typeof(x.den)(4), x.num)+one(x.den)+(x.num<0))>>1 + copysign(typeof(x.den)(2), x.num)) ? q : q+copysign(one(q),x.num)
     convert(T,s)
 end
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -289,34 +289,58 @@ floor{T}(::Type{T}, x::Rational) = convert(T,fld(x.num,x.den))
 ceil{ T}(::Type{T}, x::Rational) = convert(T,cld(x.num,x.den))
 
 
-function round{Tf, Tr}(::Type{Tf}, x::Rational{Tr}, ::RoundingMode{:Nearest})
+function round{T, Tr}(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest})
+    if den(x) == zero(Tr) && T <: Integer
+        throw(DivideError())
+    elseif den(x) == zero(Tr)
+        return convert(T, copysign(one(Tr)//zero(Tr), num(x)))
+    end
     q,r = divrem(num(x), den(x))
     s = q
     if abs(r) >= abs((den(x)-copysign(Tr(4), num(x))+one(Tr)+iseven(q))>>1 + copysign(Tr(2), num(x)))
         s += copysign(one(Tr),num(x))
     end
-    convert(Tf, s)
+    convert(T, s)
 end
 
 round{T}(::Type{T}, x::Rational) = round(T, x, RoundNearest)
 
-function round{Tf, Tr}(::Type{Tf}, x::Rational{Tr}, ::RoundingMode{:NearestTiesAway})
+function round{T, Tr}(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesAway})
+    if den(x) == zero(Tr) && T <: Integer
+        throw(DivideError())
+    elseif den(x) == zero(Tr)
+        return convert(T, copysign(one(Tr)//zero(Tr), num(x)))
+    end
     q,r = divrem(num(x), den(x))
     s = q
     if abs(r) >= abs((den(x)-copysign(Tr(4), num(x))+one(Tr))>>1 + copysign(Tr(2), num(x)))
         s += copysign(one(Tr),num(x))
     end
-    convert(Tf, s)
+    convert(T, s)
 end
 
-function round{Tf, Tr}(::Type{Tf}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp})
+function round{T, Tr}(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp})
+    if den(x) == zero(Tr) && T <: Integer
+        throw(DivideError())
+    elseif den(x) == zero(Tr)
+        return convert(T, copysign(one(Tr)//zero(Tr), num(x)))
+    end
     q,r = divrem(num(x), den(x))
     s = q
     if abs(r) >= abs((den(x)-copysign(Tr(4), num(x))+one(Tr)+(num(x)<0))>>1 + copysign(Tr(2), num(x)))
         s += copysign(one(Tr),num(x))
     end
-    convert(Tf, s)
+    convert(T, s)
 end
+
+function round{T}(::Type{T}, x::Rational{Bool})
+    if den(x) == false && issubtype(T, Union{Integer, Bool})
+        throw(DivideError())
+    end
+    convert(T, x)
+end
+
+round{T}(::Type{T}, x::Rational{Bool}, ::RoundingMode) = round(T, x)
 
 trunc{T}(x::Rational{T}) = Rational(trunc(T,x))
 floor{T}(x::Rational{T}) = Rational(floor(T,x))

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -288,21 +288,34 @@ trunc{T}(::Type{T}, x::Rational) = convert(T,div(x.num,x.den))
 floor{T}(::Type{T}, x::Rational) = convert(T,fld(x.num,x.den))
 ceil{ T}(::Type{T}, x::Rational) = convert(T,cld(x.num,x.den))
 
-function round{T}(::Type{T}, x::Rational, ::RoundingMode{:Nearest})
+
+function round{Tf, Tr}(::Type{Tf}, x::Rational{Tr}, ::RoundingMode{:Nearest})
     q,r = divrem(num(x), den(x))
-    s = abs(r) < abs((den(x)-copysign(typeof(den(x))(4), num(x))+one(den(x))+iseven(q))>>1 + copysign(typeof(den(x))(2), num(x))) ? q : q+copysign(one(q),num(x))
-    convert(T,s)
+    s = q
+    if abs(r) >= abs((den(x)-copysign(Tr(4), num(x))+one(Tr)+iseven(q))>>1 + copysign(Tr(2), num(x)))
+        s += copysign(one(Tr),num(x))
+    end
+    convert(Tf, s)
 end
-round{T}(::Type{T}, x::Rational) = round(T,x,RoundNearest)
-function round{T}(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesAway})
+
+round{T}(::Type{T}, x::Rational) = round(T, x, RoundNearest)
+
+function round{Tf, Tr}(::Type{Tf}, x::Rational{Tr}, ::RoundingMode{:NearestTiesAway})
     q,r = divrem(num(x), den(x))
-    s = abs(r) < abs((den(x)-copysign(typeof(den(x))(4), num(x))+one(den(x)))>>1 + copysign(typeof(den(x))(2), num(x))) ? q : q+copysign(one(q),num(x))
-    convert(T,s)
+    s = q
+    if abs(r) >= abs((den(x)-copysign(Tr(4), num(x))+one(Tr))>>1 + copysign(Tr(2), num(x)))
+        s += copysign(one(Tr),num(x))
+    end
+    convert(Tf, s)
 end
-function round{T}(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesUp})
+
+function round{Tf, Tr}(::Type{Tf}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp})
     q,r = divrem(num(x), den(x))
-    s = abs(r) < abs((den(x)-copysign(typeof(den(x))(4), num(x))+one(den(x))+(num(x)<0))>>1 + copysign(typeof(den(x))(2), num(x))) ? q : q+copysign(one(q),num(x))
-    convert(T,s)
+    s = q
+    if abs(r) >= abs((den(x)-copysign(Tr(4), num(x))+one(Tr)+(num(x)<0))>>1 + copysign(Tr(2), num(x)))
+        s += copysign(one(Tr),num(x))
+    end
+    convert(Tf, s)
 end
 
 trunc{T}(x::Rational{T}) = Rational(trunc(T,x))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2785,12 +2785,12 @@ for Tf = (Float16, Float32, Float64), Ti = (Int16, Int32, Int64)
     @test round(Tf, Rational(1,2), RoundNearestTiesUp) == 1.0
     @test round(Tf, Rational(1,2), RoundNearestTiesAway) == 1.0
 
-   # @test round( almost_half) == 0//1
-   # @test round(-almost_half) == 0//1
-   # @test round(Tf,  almost_half, RoundNearestTiesUp) == 0.0
-   # @test round(Tf, -almost_half, RoundNearestTiesUp) == 0.0
-   # @test round(Tf,  almost_half, RoundNearestTiesAway) == 0.0
-   # @test round(Tf, -almost_half, RoundNearestTiesAway) == 0.0
+    @test round( almost_half) == 0//1
+    @test round(-almost_half) == 0//1
+    @test round(Tf,  almost_half, RoundNearestTiesUp) == 0.0
+    @test round(Tf, -almost_half, RoundNearestTiesUp) == 0.0
+    @test round(Tf,  almost_half, RoundNearestTiesAway) == 0.0
+    @test round(Tf, -almost_half, RoundNearestTiesAway) == 0.0
 
     @test round( exactly_half) == 0//1 # rounds to closest _even_ integer
     @test round(-exactly_half) == 0//1 # rounds to closest _even_ integer
@@ -2806,6 +2806,11 @@ for Tf = (Float16, Float32, Float64), Ti = (Int16, Int32, Int64)
     @test round(Tf,  over_half, RoundNearestTiesAway) == 1.0
     @test round(Tf, -over_half, RoundNearestTiesUp) == -1.0
     @test round(Tf, -over_half, RoundNearestTiesAway) == -1.0
+
+    @test round(Tf, 11//2, RoundNearestTiesUp) == 6.0
+    @test round(Tf, -11//2, RoundNearestTiesUp) == -5.0
+    @test round(Tf, 11//2, RoundNearestTiesAway) == 6.0
+    @test round(Tf, -11//2, RoundNearestTiesAway) == -6.0
 end
 
 let
@@ -2826,3 +2831,8 @@ let
         @test read(io2, typeof(rational2)) == rational2
     end
 end
+
+@test round(11//2) == 6 # rounds to closest _even_ integer
+@test round(-11//2) == -6 # rounds to closest _even_ integer
+@test round(11//3) == 4 # rounds to closest _even_ integer
+@test round(-11//3) == -4 # rounds to closest _even_ integer

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2782,9 +2782,6 @@ for Tf = (Float16, Float32, Float64), Ti = (Int16, Int32, Int64)
     over_half    = Rational(div(typemax(Ti),Ti(2))+one(Ti), typemax(Ti))
     exactly_half = Rational(one(Ti)  , Ti(2))
 
-    @test round(Tf, Rational(1,2), RoundNearestTiesUp) == 1.0
-    @test round(Tf, Rational(1,2), RoundNearestTiesAway) == 1.0
-
     @test round( almost_half) == 0//1
     @test round(-almost_half) == 0//1
     @test round(Tf,  almost_half, RoundNearestTiesUp) == 0.0
@@ -2811,6 +2808,17 @@ for Tf = (Float16, Float32, Float64), Ti = (Int16, Int32, Int64)
     @test round(Tf, -11//2, RoundNearestTiesUp) == -5.0
     @test round(Tf, 11//2, RoundNearestTiesAway) == 6.0
     @test round(Tf, -11//2, RoundNearestTiesAway) == -6.0
+
+    @test round(Tf, Ti(-1)//zero(Ti)) == -Inf
+    @test round(Tf, one(1)//zero(Ti)) == Inf
+    @test round(Tf, Ti(-1)//zero(Ti), RoundNearestTiesUp) == -Inf
+    @test round(Tf, one(1)//zero(Ti), RoundNearestTiesUp) == Inf
+    @test round(Tf, Ti(-1)//zero(Ti), RoundNearestTiesAway) == -Inf
+    @test round(Tf, one(1)//zero(Ti), RoundNearestTiesAway) == Inf
+
+    @test round(Tf, zero(Ti)//one(Ti)) == 0
+    @test round(Tf, zero(Ti)//one(Ti), RoundNearestTiesUp) == 0
+    @test round(Tf, zero(Ti)//one(Ti), RoundNearestTiesAway) == 0
 end
 
 let
@@ -2832,7 +2840,19 @@ let
     end
 end
 
-@test round(11//2) == 6 # rounds to closest _even_ integer
-@test round(-11//2) == -6 # rounds to closest _even_ integer
-@test round(11//3) == 4 # rounds to closest _even_ integer
-@test round(-11//3) == -4 # rounds to closest _even_ integer
+@test round(11//2) == 6//1 # rounds to closest _even_ integer
+@test round(-11//2) == -6//1 # rounds to closest _even_ integer
+@test round(11//3) == 4//1 # rounds to closest _even_ integer
+@test round(-11//3) == -4//1 # rounds to closest _even_ integer
+
+for T in (Float16, Float32, Float64)
+    @test round(T, true//false) === convert(T, Inf)
+    @test round(T, true//true) === one(T)
+    @test round(T, false//true) === zero(T)
+end
+
+for T in (Int8, Int16, Int32, Int64, Bool)
+    @test_throws DivideError round(T, true//false)
+    @test round(T, true//true) === one(T)
+    @test round(T, false//true) === zero(T)
+end


### PR DESCRIPTION
Fixes #15215 .
I would love someone to look this through, and give feedback. The first commit is the actual change, the second commit simply changes `x.num` and `x.den` to `num(x)` and `den(x)`.

Basically the idea is to remove the number being bit shifted towards zero, do the bit shift, and add half the correction outside. The idea is very much like `log(exp(a-K)+exp(b-K))+K = log(exp(a)+exp(b))` for stability. The reason why it's 4 and not 2 is because two of the `RoundingMode`s can add `2` to `typemax`, so...

**Update**
The implementation seems to pass all tests, also the new tests which did not pass with the old method. Performance and style suggestions are still welcome. Can be merged if no one objects.

**Update 2** What has happened so far
To fix  #15215 I fixed the edge case if `x.den` was `typemax`. This was done by subtracting a number before doing the bit shift, and the adding half that number afterwards. Added tests.

Changed the use of dots to functions: `x.num -> num(x)` and `x.den -> den(x)`.

Changed from ternary control flow to explicit `if` statements.

Found a different edge case thanks to a comment by Simon Byrne (won't ping) on `Rational{Bool}` (see below). This edge case is when `den(x) == 0`. In this case we throw a `DivideError()` if the return type is chosen to be an `Integer`, and returns the appropriate `±Inf` for floating point types.

Made a `round` for `Rational{Bool}`. Uses the fact that `one(Bool) == true` and `zero(Bool) == false` to return `Inf` for `true//false`, `true` or `1` for `true//true` and `false` or `0` for `false//true`. There should be tests for this depending on the wanted return type.
- [x] Add these tests

This also reminds me that I should take care of the `true//false` case if the return type is `Integer` or `Bool`, as they don't have an `Inf` value.
- [x] Fix these edge cases
- [x] Change the `Tf` back to `T`, as I didn't think of the fact that they can be `Integer` (`f` was for `float`)
  Came to fix an edge case, left dizzy :)
