### PR TITLE
Remove no longer accurate documentation about Base.call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink ju
 debug release : % : julia-%
 
 julia-genstdlib: julia-sysimg-$(JULIA_BUILD_MODE)
-	@$(call PRINT_JULIA, $(JULIA_EXECUTABLE) $(JULIAHOME)/doc/genstdlib.jl)
+	@$(call PRINT_JULIA, $(JULIA_EXECUTABLE) $(call cygpath_w, $(JULIAHOME)/doc/genstdlib.jl))
 
 docs: julia-genstdlib
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/doc

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -483,7 +483,7 @@ function moddoc(meta, def, def′)
         block = def.args[3].args
         if !def.args[1]
             isempty(block) && error("empty baremodules are not documentable.")
-            insert!(block, 2, :(import Base: call, @doc))
+            insert!(block, 2, :(import Base: @doc))
         end
         push!(block, docex)
         esc(Expr(:toplevel, def))

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -130,7 +130,7 @@ end
 
 @keyword(
     """
-    `baremodule` declares a module that does not contain `using Base`, `import Base.call`,
+    `baremodule` declares a module that does not contain `using Base`
     or a definition of `eval`.  It does still import `Core`.
     """,
     :baremodule

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -221,7 +221,7 @@ Generator Expressions
 Comprehensions can also be written without the enclosing square brackets, producing
 an object known as a generator. This object can be iterated to produce values on
 demand, instead of allocating an array and storing them in advance
-(see :ref:`_man-interfaces-iteration`).
+(see <man-interfaces-iteration>).
 For example, the following expression sums a series without allocating memory::
 
 .. doctest::
@@ -242,10 +242,10 @@ parentheses lets us add a third argument to ``map``::
 
     julia> map(tuple, (1/(i+j) for i=1:2, j=1:2), [1:4;])
     4-element Array{Any,1}:
-     (0.5,1)
-     (0.333333,2)
-     (0.333333,3)
-     (0.25,4)
+    (0.5,1)
+    (0.333333,2)
+    (0.333333,3)
+    (0.25,4)
 
 .. _man-array-indexing:
 

--- a/doc/manual/documentation.rst
+++ b/doc/manual/documentation.rst
@@ -289,7 +289,7 @@ is the preferred syntax, however both are equivalent.
 
     baremodule M
 
-    import Base: call, @doc
+    import Base: @doc
 
     "..."
     f(x) = x
@@ -297,7 +297,7 @@ is the preferred syntax, however both are equivalent.
     end
 
 Documenting a ``baremodule`` by placing a docstring above the expression automatically
-imports ``call`` and ``@doc`` into the module. These imports must be done manually when the
+imports ``@doc`` into the module. These imports must be done manually when the
 module expression is not documented. Empty ``baremodule``\ s cannot be documented.
 
 Global Variables

--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -162,10 +162,8 @@ contain ``using Base``, since this is needed in the vast majority of cases.
 Default top-level definitions and bare modules
 ----------------------------------------------
 
-In addition to ``using Base``, modules also perform ``import Base.call`` by
-default, to facilitate adding constructors to new types.
-A new module also automatically contains a definition of the ``eval`` function,
-which evaluates expressions within the context of that module.
+In addition to ``using Base``, modules also automatically contain a definition
+of the ``eval`` function, which evaluates expressions within the context of that module.
 
 If these default definitions are not wanted, modules can be defined using the
 keyword ``baremodule`` instead (note: ``Core`` is still imported, as per above).
@@ -174,8 +172,6 @@ In terms of ``baremodule``, a standard ``module`` looks like this::
     baremodule Mod
 
     using Base
-
-    import Base.call
 
     eval(x) = Core.eval(Mod, x)
     eval(m,x) = Core.eval(m, x)


### PR DESCRIPTION
I think this is no longer the case after #13412?
