### PR TITLE
Remove `at-init` from docsystem.

### DIFF
--- a/base/docs/bootstrap.jl
+++ b/base/docs/bootstrap.jl
@@ -48,7 +48,7 @@ DocBootstrap
 """
     loaddocs()
 
-Move all docstrings from `DocBootstrap.docs` to their module's `__META__` dict.
+Move all docstrings from `DocBootstrap.docs` to their module's metadata dict.
 """
 function loaddocs()
     node = docs

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -171,7 +171,7 @@ function _require_from_serialized(node::Int, mod::Symbol, path_to_try::ByteStrin
 
     if restored !== nothing
         for M in restored
-            if isdefined(M, :__META__)
+            if isdefined(M, Base.Docs.META)
                 push!(Base.Docs.modules, M)
             end
         end


### PR DESCRIPTION
Replaces macro `@init` with a function instead. Appears to reduce the amount of code generated by `@doc` which should help shorten bootstrapping time slightly.

Also changes the name of the `ObjectIdDict` used to store docstrings to a gensym'd one to avoid naming clashes. `Docs.meta` has always been available to access this const without needing to know it's name so this shouldn't be a major breaking change.
