### PR TITLE
Inverted marking of vector tuple type

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -125,7 +125,7 @@ export
     SimpleVector, AbstractArray, DenseArray,
     # special objects
     Function, LambdaInfo, Method, MethodTable, TypeMapEntry, TypeMapLevel,
-    Module, Symbol, Task, Array, WeakRef,
+    Module, Symbol, Task, Array, WeakRef, VecElement,
     # numeric types
     Number, Real, Integer, Bool, Ref, Ptr,
     AbstractFloat, Float16, Float32, Float64,
@@ -270,6 +270,10 @@ TypeConstructor(p::ANY, t::ANY) =
     ccall(:jl_new_type_constructor, Ref{TypeConstructor}, (Any, Any), p::SimpleVector, t::Type)
 
 Void() = nothing
+
+immutable VecElement{T}
+    value::T
+end
 
 Expr(args::ANY...) = _expr(args...)
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -365,30 +365,37 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, bool *isboxed)
             }
             std::vector<Type*> latypes(0);
             size_t i;
+            bool isarray = true;
             bool isvector = true;
+            jl_value_t* jlasttype = NULL;
             Type *lasttype = NULL;
             for(i = 0; i < ntypes; i++) {
                 jl_value_t *ty = jl_svecref(jst->types, i);
+                if (jlasttype!=NULL && ty!=jlasttype)
+                    isvector = false;
+                jlasttype = ty;
                 Type *lty;
                 if (jl_field_isptr(jst, i))
                     lty = T_pjlvalue;
                 else
                     lty = ty==(jl_value_t*)jl_bool_type ? T_int8 : julia_type_to_llvm(ty);
                 if (lasttype != NULL && lasttype != lty)
-                    isvector = false;
+                    isarray = false;
                 lasttype = lty;
                 if (type_is_ghost(lty))
                     lty = NoopType;
                 latypes.push_back(lty);
             }
             if (!isTuple) {
-                structdecl->setBody(latypes);
+                if (is_vecelement_type(jt))
+                    // VecElement type is unwrapped in LLVM
+                    jst->struct_decl = latypes[0];
+                else
+                    structdecl->setBody(latypes);
             }
             else {
-                if (isvector && lasttype != T_int1 && !type_is_ghost(lasttype)) {
-                    // TODO: currently we get LLVM assertion failures for other vector sizes
-                    bool validVectorSize = (ntypes == 2 || ntypes == 4 || ntypes == 6);
-                    if (0 && lasttype->isSingleValueType() && !lasttype->isVectorTy() && validVectorSize) // currently disabled due to load/store alignment issues
+                if (isarray && lasttype != T_int1 && !type_is_ghost(lasttype)) {
+                    if (isvector && jl_special_vector_alignment(ntypes, jlasttype)!=0)
                         jst->struct_decl = VectorType::get(lasttype, ntypes);
                     else
                         jst->struct_decl = ArrayType::get(lasttype, ntypes);
@@ -397,6 +404,12 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, bool *isboxed)
                     jst->struct_decl = StructType::get(jl_LLVMContext,ArrayRef<Type*>(&latypes[0],ntypes));
                 }
             }
+#ifndef NDEBUG
+            // If LLVM and Julia disagree about alignment, much trouble ensues, so check it!
+            unsigned llvm_alignment = jl_ExecutionEngine->getDataLayout().getABITypeAlignment((Type*)jst->struct_decl);
+            unsigned julia_alignment = jst->alignment;
+            assert(llvm_alignment==julia_alignment);
+#endif
         }
         return (Type*)jst->struct_decl;
     }
@@ -432,7 +445,7 @@ static bool is_tupletype_homogeneous(jl_svec_t *t)
 static bool deserves_sret(jl_value_t *dt, Type *T)
 {
     assert(jl_is_datatype(dt));
-    return (size_t)jl_datatype_size(dt) > sizeof(void*) && !T->isFloatingPointTy();
+    return (size_t)jl_datatype_size(dt) > sizeof(void*) && !T->isFloatingPointTy() && !T->isVectorTy();
 }
 
 // --- generating various field accessors ---
@@ -750,10 +763,28 @@ static Value *emit_bounds_check(const jl_cgval_t &ainfo, jl_value_t *ty, Value *
 
 // --- loading and storing ---
 
+// If given alignment is 0 and LLVM's assumed alignment for a load/store via ptr
+// might be stricter than the Julia alignment for jltype, return the alignment of jltype.
+// Otherwise return the given alignment.
+//
+// Parameter ptr should be the pointer argument for the LoadInst or StoreInst.
+// It is currently unused, but might be used in the future for a more precise answer.
+static unsigned julia_alignment(Value* /*ptr*/, jl_value_t *jltype, unsigned alignment) {
+    if (!alignment && ((jl_datatype_t*)jltype)->alignment > MAX_ALIGN) {
+        // Type's natural alignment exceeds strictest alignment promised in heap, so return the heap alignment.
+        return MAX_ALIGN;
+    }
+    return alignment;
+}
+
+static LoadInst *build_load (Value *ptr, jl_value_t *jltype) {
+    return builder.CreateAlignedLoad(ptr, julia_alignment(ptr, jltype, 0));
+}
+
 static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt);
 
 static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
-                             jl_codectx_t *ctx, MDNode *tbaa, size_t alignment = 0)
+                             jl_codectx_t *ctx, MDNode *tbaa, unsigned alignment = 0)
 {
     bool isboxed;
     Type *elty = julia_type_to_llvm(jltype, &isboxed);
@@ -778,9 +809,7 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
     //    elt = data;
     //}
     //else {
-        if (data->getType()->getContainedType(0)->isVectorTy() && !alignment)
-            alignment = ((jl_datatype_t*)jltype)->alignment; // prevent llvm from assuming 32 byte alignment of vectors
-        Instruction *load = builder.CreateAlignedLoad(data, alignment, false);
+        Instruction *load = builder.CreateAlignedLoad(data, julia_alignment(data, jltype, alignment), false);
         if (tbaa) {
             elt = tbaa_decorate(tbaa, load);
         }
@@ -799,7 +828,7 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
 static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
                         jl_value_t *jltype, jl_codectx_t *ctx, MDNode *tbaa,
                         Value *parent,  // for the write barrier, NULL if no barrier needed
-                        size_t alignment = 0, bool root_box = true) // if the value to store needs a box, should we root it ?
+                        unsigned alignment = 0, bool root_box = true) // if the value to store needs a box, should we root it ?
 {
     Type *elty = julia_type_to_llvm(jltype);
     assert(elty != NULL);
@@ -821,9 +850,7 @@ static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
         data = builder.CreateBitCast(ptr, PointerType::get(elty, 0));
     else
         data = ptr;
-    if (data->getType()->getContainedType(0)->isVectorTy() && !alignment)
-        alignment = ((jl_datatype_t*)jltype)->alignment; // prevent llvm from assuming 32 byte alignment of vectors
-    Instruction *store = builder.CreateAlignedStore(r, builder.CreateGEP(data, idx_0based), alignment);
+    Instruction *store = builder.CreateAlignedStore(r, builder.CreateGEP(data, idx_0based), julia_alignment(r, jltype, alignment));
     if (tbaa)
         tbaa_decorate(tbaa, store);
 }
@@ -1026,18 +1053,20 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         }
         else {
             int align = jl_field_offset(jt,idx);
-            if (align & 1) align = 1;
-            else if (align & 2) align = 2;
-            else if (align & 4) align = 4;
-            else if (align & 8) align = 8;
-            else align = 16;
+            align |= 16;
+            align &= -align;
             return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, tbaa, align);
         }
     }
     else if (strct.ispointer) { // something stack allocated
-        Value *addr = builder.CreateConstInBoundsGEP2_32(
-            LLVM37_param(julia_type_to_llvm(strct.typ))
-            strct.V, 0, idx);
+        Value *addr;
+        if (is_vecelement_type((jl_value_t*)jt))
+            // VecElement types are unwrapped in LLVM.
+            addr = strct.V;
+        else
+            addr = builder.CreateConstInBoundsGEP2_32(
+                LLVM37_param(julia_type_to_llvm(strct.typ))
+                strct.V, 0, idx);
         assert(!jt->mutabl);
         jl_cgval_t fieldval = mark_julia_slot(addr, jfty);
         fieldval.isimmutable = strct.isimmutable;
@@ -1045,8 +1074,13 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         return fieldval;
     }
     else {
-        assert(strct.V->getType()->isVectorTy());
-        fldv = builder.CreateExtractElement(strct.V, ConstantInt::get(T_int32, idx));
+        if (strct.V->getType()->isVectorTy()) {
+            fldv = builder.CreateExtractElement(strct.V, ConstantInt::get(T_int32, idx));
+        } else {
+            // VecElement types are unwrapped in LLVM.
+            assert( strct.V->getType()->isSingleValueType() );
+            fldv = strct.V;
+        }
         if (jfty == (jl_value_t*)jl_bool_type) {
             fldv = builder.CreateTrunc(fldv, T_int1);
         }
@@ -1376,7 +1410,7 @@ static Value *boxed(const jl_cgval_t &vinfo, jl_codectx_t *ctx, bool gcrooted)
     assert(!type_is_ghost(t)); // should have been handled by isghost above!
 
     if (vinfo.ispointer)
-        v = builder.CreateLoad(builder.CreatePointerCast(v, t->getPointerTo()));
+        v = build_load( builder.CreatePointerCast(v, t->getPointerTo()), vinfo.typ );
 
     if (t == T_int1)
         return julia_bool(v);
@@ -1548,11 +1582,8 @@ static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t id
         }
         else {
             int align = jl_field_offset(sty, idx0);
-            if (align & 1) align = 1;
-            else if (align & 2) align = 2;
-            else if (align & 4) align = 4;
-            else if (align & 8) align = 8;
-            else align = 16;
+            align |= 16;
+            align &= -align;
             typed_store(addr, ConstantInt::get(T_size, 0), rhs, jfty, ctx, sty->mutabl ? tbaa_user : tbaa_immut, data_pointer(strct, ctx, T_pjlvalue), align);
         }
     }
@@ -1594,8 +1625,13 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                         fval = builder.CreateZExt(fval, T_int8);
                     if (lt->isVectorTy())
                         strct = builder.CreateInsertElement(strct, fval, ConstantInt::get(T_int32,idx));
-                    else
+                    else if (lt->isAggregateType())
                         strct = builder.CreateInsertValue(strct, fval, ArrayRef<unsigned>(&idx,1));
+                    else {
+                        // Must be a VecElement type, which comes unwrapped in LLVM.
+                        assert(is_vecelement_type(ty));
+                        strct = fval;
+                    }
                 }
                 idx++;
             }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3936,7 +3936,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, Function *f, bool sre
         if (lty != NULL && !isboxed) {
             theArg = builder.CreatePointerCast(theArg, PointerType::get(lty,0));
             if (!lty->isAggregateType()) // keep "aggregate" type values in place as pointers
-                theArg = builder.CreateLoad(theArg);
+                theArg = build_load(theArg, ty);
         }
         assert(dyn_cast<UndefValue>(theArg) == NULL);
         args[idx] = theArg;

--- a/src/init.c
+++ b/src/init.c
@@ -833,6 +833,7 @@ void jl_get_builtin_hooks(void)
     jl_ascii_string_type = (jl_datatype_t*)core("ASCIIString");
     jl_utf8_string_type = (jl_datatype_t*)core("UTF8String");
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
+    jl_vecelement_typename = ((jl_datatype_t*)core("VecElement"))->name;
 }
 
 JL_DLLEXPORT void jl_get_system_hooks(void)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -305,9 +305,13 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt)
     if (jt == (jl_value_t*)jl_bool_type)
         return builder.CreateZExt(builder.CreateTrunc(builder.CreateLoad(p), T_int1), to);
 
-    if (!x.isboxed) // stack has default alignment
+    if (x.isboxed)
+        return builder.CreateAlignedLoad(p, 16); // julia's gc gives 16-byte aligned addresses
+    else if (jt)
+        return build_load(p, jt);
+    else
+        // stack has default alignment
         return builder.CreateLoad(p);
-    return builder.CreateAlignedLoad(p, 16); // julia's gc gives 16-byte aligned addresses
 }
 
 // unbox, trying to determine correct bitstype automatically

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -35,6 +35,7 @@ jl_tupletype_t *jl_anytuple_type;
 jl_datatype_t *jl_anytuple_type_type;
 jl_datatype_t *jl_ntuple_type;
 jl_typename_t *jl_ntuple_typename;
+jl_typename_t *jl_vecelement_typename;
 jl_datatype_t *jl_vararg_type;
 jl_datatype_t *jl_tvar_type;
 jl_datatype_t *jl_uniontype_type;

--- a/src/julia.h
+++ b/src/julia.h
@@ -441,6 +441,7 @@ extern JL_DLLEXPORT jl_datatype_t *jl_slotnumber_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_typedslot_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_simplevector_type;
 extern JL_DLLEXPORT jl_typename_t *jl_tuple_typename;
+extern JL_DLLEXPORT jl_typename_t *jl_vecelement_typename;
 extern JL_DLLEXPORT jl_datatype_t *jl_anytuple_type;
 #define jl_tuple_type jl_anytuple_type
 extern JL_DLLEXPORT jl_datatype_t *jl_anytuple_type_type;
@@ -938,6 +939,12 @@ STATIC_INLINE int jl_is_tuple_type(void *t)
 {
     return (jl_is_datatype(t) &&
             ((jl_datatype_t*)(t))->name == jl_tuple_typename);
+}
+
+STATIC_INLINE int is_vecelement_type(jl_value_t* t)
+{
+    return (jl_is_datatype(t) &&
+            ((jl_datatype_t*)(t))->name == jl_vecelement_typename);
 }
 
 STATIC_INLINE int jl_is_vararg_type(jl_value_t *v)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -585,6 +585,7 @@ int sigs_eq(jl_value_t *a, jl_value_t *b, int useenv);
 
 jl_value_t *jl_lookup_match(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, jl_svec_t *tvars);
 
+unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *field_type);
 
 #ifdef __cplusplus
 }

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -19,7 +19,7 @@ function choosetests(choices = [])
         "char", "string", "triplequote", "unicode",
         "dates", "dict", "hashing", "remote", "iobuffer", "staged",
         "arrayops", "tuple", "subarray", "reduce", "reducedim", "random",
-        "abstractarray", "intfuncs", "simdloop", "blas", "sparse",
+        "abstractarray", "intfuncs", "simdloop", "vecelement", "blas", "sparse",
         "bitarray", "copy", "math", "fastmath", "functional",
         "operators", "path", "ccall", "parse", "loading", "bigint",
         "bigfloat", "sorting", "statistics", "spawn", "backtrace",

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -1,0 +1,65 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+make_value{T<:Integer}(::Type{T}, i::Integer) = 3*i%T
+make_value{T<:AbstractFloat}(::Type{T},i::Integer) = T(3*i)
+
+typealias Vec{N,T} NTuple{N,Base.VecElement{T}}
+
+# Crash report for #15244 motivated this test.
+@generated function thrice_iota{N,T}(::Type{Vec{N,T}})
+    :(tuple($([:(Base.VecElement(make_value($T,$i))) for i in 1:N]...)))
+end
+
+function call_iota(n::Integer,t::DataType)
+    x = thrice_iota(Vec{n,t})
+    @test x[1].value === make_value(t,1)
+    @test x[n].value === make_value(t,n)
+end
+
+# Try various tuple lengths and element types
+for i=1:20
+    for t in [Bool, Int8, Int16, Int32, Int64, Float32, Float64]
+        call_iota(i,t)
+    end
+end
+
+# Another crash report for #15244 motivated this test.
+immutable Bunch{N,T}
+    elts::NTuple{N,Base.VecElement{T}}
+end
+
+unpeel(x) = x.elts[1].value
+
+@test unpeel(Bunch{2,Float64}((Base.VecElement(5.0),
+                               Base.VecElement(4.0)))) === 5.0
+
+rewrap(x) = VecElement(x.elts[1].value+0)
+b = Bunch((VecElement(1.0), VecElement(2.0)))
+
+@test rewrap(b)===VecElement(1.0)
+
+immutable Herd{N,T}
+    elts::NTuple{N,Base.VecElement{T}}
+    Herd(elts::NTuple{N,T}) = new(ntuple(i->Base.VecElement{T}(elts[i]), N))
+end
+
+function check{N,T}(x::Herd{N,T})
+    for i=1:N
+        @test x.elts[i].value === N*N+i-1
+    end
+end
+
+check(Herd{1,Int}((1,)))
+check(Herd{2,Int}((4,5)))
+check(Herd{4,Int}((16,17,18,19)))
+
+immutable Gr{N, T}
+    u::T
+    v::Bunch{N,T}
+    w::T
+end
+
+a = Vector{Gr{2,Float64}}(2)
+a[2] = Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
+a[1] = Gr(5.0, Bunch((VecElement(6.0), VecElement(7.0))), 8.0)
+@test a[2] == Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)


### PR DESCRIPTION
This is PR is intended to generate a discussion about a solution to a problem that @eschnett and I were discussing.  See [here](https://github.com/eschnett/SIMD.jl/issues/1#issuecomment-182132687) for start of discussion chain. The problem is how to get access to LLVM vector types from Julia.  The intent of the PR is to get feedback on whether the inverted approach (5 below) is something we should take forward.

Some approaches to the general problem are:
1.  Map homogeneous tuples to LLVM vector types automatically.  This introduces layout problems, which though I've been able to surmount though type punning, but can cause performance problems since sometimes the vector type causes  _worse_ performance, as when operations on a tuple do not map to vector operations and require excessive extract/insert code.
2.  Modify LLVM SLP to work on arrays as if they were vectors.  This approach works up to a point, but requires type punning on loads/stores that starts to break down for vectors that are members of structs, such as in the [GradientNumber](https://github.com/eschnett/SIMD.jl/issues/1#issuecomment-182093320) example.  If we could talk the LLVM community into adding cast operations or intrinsics to case between arrays and vectors, this approach would be my preference since it keeps use of SIMD instructions hidden.  Though some users want explicit SIMD.
3.  Introduce a special Julia type that maps to an LLVM vector.  This requires teaching the Julia type system and users about the type (yuck!)
4.  Use an immutable Julia type with a single tuple field.  Mark the type in some way to indicate that the tuple should map to an LLVM vector.  [Experience](https://github.com/eschnett/SIMD.jl/issues/1#issuecomment-186357742) so far indicates that this is awkward.  In retrospect, the approach is troublesome because the interpretation of a tuple type depends on surrounding context.
5.  Use a homogeneous Julia tuple where the _elements_ have a marked type.  Marking the element types eliminates the context-sensitivity problems of approach 4.

Approach 5, which sounds upside-down, seems to be the simplest solution.  This PR implements it.  [Updated 2016-3-1 to reflect update in PR.  Original PR called the marked type `Banana` and used "pre-peeled" metaphor.  Now marked type is `VecElement`.  Updated example uses `typealias` to retain discussion context.]   Example:

```
#from Base
#immutable VecElement{T}  # Marked type
#    value :: T
#end
#export VecElt

typealias Banana VecElement
typealias V NTuple{4,Banana{Float32}}
```

The PR causes two special mappings for the example:
- A `Banana{T}` maps to the LLVM type for a T, not an LLVM struct containing the LLVM representation of T.  In other words,  bananas are pre-peeled in LLVM.  
- A homogeneous tuple of `Banana{T}` maps to an LLVM vector of T.  I.e., an LLVM vector is used instead of an array.  

The pre-peeling rule ensures that a `Banana{T}` is mapped consistently regardless of surrounding context.

Below is an example that uses the definitions above:

```
add(u,v) = (Banana(u[1].value+v[1].value),
            Banana(u[2].value+v[2].value),
            Banana(u[3].value+v[3].value),
            Banana(u[4].value+v[4].value))

code_llvm(add,(V,V))
```

At -O3, the code is:

```
define void @julia_add_22173(<4 x float>* sret, <4 x float>, <4 x float>) #0 {
top:
  %3 = fadd <4 x float> %1, %2
  store <4 x float> %3, <4 x float>* %0, align 16
  ret void
}
```

A library such as SIMD.jl could presumably obtain similar effect without -O via `llvmcall`.
