### PR TITLE
linspace with 1 or 0 elements is sorted

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -883,7 +883,7 @@ reverse(r::LinSpace)     = LinSpace(r.stop, r.start, r.len, r.divisor)
 ## sorting ##
 
 issorted(r::AbstractUnitRange) = true
-issorted(r::Range) = step(r) >= zero(step(r))
+issorted(r::Range) = length(r) <= 1 || step(r) >= zero(step(r))
 
 sort(r::AbstractUnitRange) = r
 sort!(r::AbstractUnitRange) = r

--- a/test/dates/ranges.jl
+++ b/test/dates/ranges.jl
@@ -77,8 +77,8 @@ function test_all_combos()
                 @test length(reverse(dr)) == 0
                 @test first(reverse(dr)) > l1
                 @test last(reverse(dr)) <= l1
-                @test !issorted(dr)
-                @test sortperm(dr) == 0:-1:1
+                @test issorted(dr)
+                @test sortperm(dr) == 1:1:0
                 @test !(l1 in dr)
                 @test !(l1 in dr)
                 @test !(l1-neg_step in dr)
@@ -106,7 +106,7 @@ function test_all_combos()
                     end
                     @test !isempty(reverse(dr))
                     @test length(reverse(dr)) == len
-                    @test !issorted(dr)
+                    @test issorted(dr) == (len <= 1)
                     @test l in dr
                 end
             end
@@ -182,8 +182,8 @@ function test_all_combos()
                     @test length(reverse(dr)) == 0
                     @test first(reverse(dr)) > l1
                     @test last(reverse(dr)) <= l1
-                    @test !issorted(dr)
-                    @test sortperm(dr) == 0:-1:1
+                    @test issorted(dr)
+                    @test sortperm(dr) == 1:1:0
                     @test !(l1 in dr)
                     @test !(l1 in dr)
                     @test !(l1-neg_step in dr)
@@ -212,7 +212,7 @@ function test_all_combos()
                         @test !isempty(reverse(dr))
                         @test length(reverse(dr)) == len
                         @test last(reverse(dr)) >= l
-                        @test !issorted(dr)
+                        @test issorted(dr) == (len <= 1)
                         @test l in dr
 
                     end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -391,6 +391,10 @@ for T = (Float32, Float64)
     end
 end
 
+# linspace with 1 or 0 elements (whose step length is NaN)
+@test issorted(linspace(1,1,0))
+@test issorted(linspace(1,1,1))
+
 # near-equal ranges
 @test 0.0:0.1:1.0 != 0.0f0:0.1f0:1.0f0
 


### PR DESCRIPTION
linspace of length 1 or 0 causes a step length of NaN which makes "issorted" return false.

I expected the same return value as the flattened data (collect of such a linspace) which has a true "issorted".
