### PR TITLE
squeeze for sparse matrices

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2692,8 +2692,6 @@ function blkdiag(X::SparseMatrixCSC...)
     SparseMatrixCSC(m, n, colptr, rowval, nzval)
 end
 
-squeeze(S::SparseMatrixCSC, dims::Dims) = throw(ArgumentError("squeeze is not available for sparse matrices"))
-
 ## Structure query functions
 issym(A::SparseMatrixCSC) = is_hermsym(A, IdFun())
 

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -74,6 +74,18 @@ a116[p, p] = reshape(1:9, 3, 3)
 s116[p, p] = reshape(1:9, 3, 3)
 @test a116 == s116
 
+# squeeze
+for i = 1:5
+    am = sprand(20, 1, 0.2)
+    av = squeeze(am, 2)
+    @test ndims(av) == 1
+    @test all(av.==am)
+    am = sprand(1, 20, 0.2)
+    av = squeeze(am, 1)
+    @test ndims(av) == 1
+    @test all(av.'.==am)
+end
+
 # matrix-vector multiplication (non-square)
 for i = 1:5
     a = sprand(10, 5, 0.5)


### PR DESCRIPTION
Before having `SparseVector`s, the default `squeeze` from `abstractarray.jl` returned wrong results (see #10813). Hence a dedicated `squeeze` implementation for sparse matrices throwing an error was added in f8e343eb80bb2936ffc81064d4bdc197ba26598f. Thanks to `SparseVector`, things look different now and that change can be reverted. (Adding functionality by removing code - fantastic!)

The only thing that doesn't work is squeezing down to 0 dimensions (e.g. `squeeze(speye(1),(1,2))`), if anyone needs that. It still errors, but with a less helpful message.
