### PR TITLE
Ellide immutable allocation in some simple cases

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3498,6 +3498,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
         if (jl_is_type_type(ty) &&
             jl_is_datatype(jl_tparam0(ty)) &&
             jl_is_leaf_type(jl_tparam0(ty))) {
+            assert(nargs <= jl_datatype_nfields(jl_tparam0(ty))+1);
             return emit_new_struct(jl_tparam0(ty),nargs,args,ctx);
         }
         Value *typ = boxed(emit_expr(args[0], ctx), ctx);

--- a/src/julia.h
+++ b/src/julia.h
@@ -692,6 +692,7 @@ STATIC_INLINE char *jl_symbol_name_(jl_sym_t *s)
 #define DEFINE_FIELD_ACCESSORS(f)                                       \
     static inline uint32_t jl_field_##f(jl_datatype_t *st, int i)       \
     {                                                                   \
+        assert(i >= 0 && (size_t)i < jl_datatype_nfields(st));          \
         if (st->fielddesc_type == 0) {                                  \
             return ((jl_fielddesc8_t*)jl_datatype_fields(st))[i].f;     \
         }                                                               \
@@ -705,6 +706,7 @@ STATIC_INLINE char *jl_symbol_name_(jl_sym_t *s)
     static inline void jl_field_set##f(jl_datatype_t *st, int i,        \
                                        uint32_t val)                    \
     {                                                                   \
+        assert(i >= 0 && (size_t)i < jl_datatype_nfields(st));          \
         if (st->fielddesc_type == 0) {                                  \
             ((jl_fielddesc8_t*)jl_datatype_fields(st))[i].f = val;      \
         }                                                               \


### PR DESCRIPTION
Extend tuple_elim_pass and getfield_elim_pass to handle immutable object allocations.

@andreasnoack 

``` julia
julia> immutable Diag; A :: Vector{Float64}; end
julia> *(d::Diag,M) = scale(d.A,M)
* (generic function with 142 methods)
julia> f(x,M) = Diag(x)*M
f (generic function with 1 method)
julia> code_typed(f,(Vector{Float64},Matrix{Float64}))
1-element Array{Any,1}:
 :($(Expr(:lambda, Any[symbol("#self#"),:x,:M], Any[Any[Any[symbol("#self#"),#f,0],Any[:x,Array{Float64,1},0],Any[:M,Array{Float64,2},0]],Any[],Any[Tuple{Int64,Int64}]], :(begin  # none, line 1: # none, line 1: # linalg/matmul.jl, line 42:
        GenSym(0) = (top(tuple))((Base.arraysize)(M::Array{Float64,2},1)::Int64,(Base.arraysize)(M::Array{Float64,2},2)::Int64)::Tuple{Int64,Int64} # array.jl, line 120:
        return (Base.LinAlg.scale!)((top(ccall))(:jl_new_array,(top(apply_type))(Core.Array,Float64,2)::Type{Array{Float64,2}},(top(svec))(Core.Any,Core.Any)::SimpleVector,Array{Float64,2},0,GenSym(0),0)::Array{Float64,2},x::Array{Float64,1},M::Array{Float64,2})::Array{Float64,2}
    end::Array{Float64,2}))))
```

no allocations
