### PR TITLE
Clean up some tests that are a bit noisier than they should be

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -3750,7 +3750,7 @@ end
 module I13229
     using Base.Test
     global z = 0
-    @time @profile for i = 1:5
+    @timed @profile for i = 1:5
         function f(x)
             return x + i
         end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -45,7 +45,7 @@ include(joinpath(dir, "queens.jl"))
 end
 
 dc_path = joinpath(dir, "dictchannel.jl")
-include(dc_path)
+myid() == 1 || include(dc_path)
 
 # Run the remote on pid 1, since runtests may terminate workers
 # at any time depending on memory usage

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -1,33 +1,17 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-@testset "libgit2-online" begin
-
-#########
-# Setup #
-#########
-
-function temp_dir(fn::Function, remove_tmp_dir::Bool=true)
-    tmpdir = joinpath(tempdir(),randstring())
-    @test !isdir(tmpdir)
-    try
-        mkdir(tmpdir)
-        @test isdir(tmpdir)
-        fn(tmpdir)
-    finally
-        remove_tmp_dir && rm(tmpdir, recursive=true)
-    end
-end
+#@testset "libgit2-online" begin
 
 #########
 # TESTS #
 #########
 # init & clone
-temp_dir() do dir
+mktempdir() do dir
     repo_url = "github.com/JuliaLang/Example.jl"
     https_prefix = "https://"
     ssh_prefix = "git@"
-    @testset "Cloning repository" begin
-        @testset "with 'https' protocol" begin
+    #@testset "Cloning repository" begin
+        #@testset "with 'https' protocol" begin
             repo_path = joinpath(dir, "Example1")
             repo = LibGit2.clone(https_prefix*repo_url, repo_path)
             try
@@ -36,24 +20,24 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
-        @testset "with incorrect url" begin
+        #end
+        #@testset "with incorrect url" begin
             repo_path = joinpath(dir, "Example2")
             # credential are required because github try authenticate on uknown repo
             x = Nullable(LibGit2.UserPasswordCredentials("X","X"))
             @test_throws LibGit2.Error.GitError LibGit2.clone(https_prefix*repo_url*randstring(10), repo_path, payload=x)
-        end
+        #end
 
         try
-            @testset "with 'ssh' protocol (by default is not supported)" begin
+            #@testset "with 'ssh' protocol (by default is not supported)" begin
                 repo_path = joinpath(dir, "Example3")
                 @test_throws LibGit2.Error.GitError LibGit2.clone(ssh_prefix*repo_url, repo_path)
-            end
+            #end
         catch ex
             # but we cloned succesfully, so check that repo was created
             ex.fail == 1 && @test isdir(joinpath(path, ".git"))
         end
-    end
+    #end
 end
 
-end
+#end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1,36 +1,19 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-@testset "libgit2" begin
+#@testset "libgit2" begin
 
 const LIBGIT2_VER = v"0.23.0"
-
-#########
-# Setup #
-#########
-
-function temp_dir(fn::Function, remove_tmp_dir::Bool=true)
-    tmpdir = joinpath(tempdir(),randstring())
-    @test !isdir(tmpdir)
-    try
-        mkdir(tmpdir)
-        @test isdir(tmpdir)
-        fn(tmpdir)
-    finally
-        remove_tmp_dir && rm(tmpdir, recursive=true)
-    end
-end
-
 
 #########
 # TESTS #
 #########
 
-@testset "Check library verison" begin
+#@testset "Check library verison" begin
     v = LibGit2.version()
     @test  v.major == LIBGIT2_VER.major && v.minor >= LIBGIT2_VER.minor
-end
+#end
 
-@testset "OID" begin
+#@testset "OID" begin
     z = LibGit2.Oid()
     @test LibGit2.iszero(z)
     @test z == zero(LibGit2.Oid)
@@ -41,9 +24,9 @@ end
     @test z == LibGit2.Oid(pointer(rr))
     for i in 11:length(rr); rr[i] = 0; end
     @test LibGit2.Oid(rr) == LibGit2.Oid(rs[1:20])
-end
+#end
 
-@testset "StrArrayStruct" begin
+#@testset "StrArrayStruct" begin
     p1 = "XXX"
     p2 = "YYY"
     sa1 = LibGit2.StrArrayStruct(p1)
@@ -67,9 +50,9 @@ end
     finally
         finalize(sa2)
     end
-end
+#end
 
-@testset "Signature" begin
+#@testset "Signature" begin
     sig = LibGit2.Signature("AAA", "AAA@BBB.COM", round(time(), 0), 0)
     git_sig = convert(LibGit2.GitSignature, sig)
     sig2 = LibGit2.Signature(git_sig)
@@ -77,9 +60,9 @@ end
     @test sig.name == sig2.name
     @test sig.email == sig2.email
     @test sig.time == sig2.time
-end
+#end
 
-temp_dir() do dir
+mktempdir() do dir
 
     # test parameters
     repo_url = "https://github.com/JuliaLang/Example.jl"
@@ -97,7 +80,7 @@ temp_dir() do dir
     tag1 = "tag1"
     tag2 = "tag2"
 
-    @testset "Configuration" begin
+    #@testset "Configuration" begin
         cfg = LibGit2.GitConfig(joinpath(dir, config_file), LibGit2.Consts.CONFIG_LEVEL_APP)
         try
             @test_throws LibGit2.Error.GitError LibGit2.get(AbstractString, cfg, "tmp.str")
@@ -115,10 +98,10 @@ temp_dir() do dir
         finally
             finalize(cfg)
         end
-    end
+    #end
 
-    @testset "Initializing repository" begin
-        @testset "with remote branch" begin
+    #@testset "Initializing repository" begin
+        #@testset "with remote branch" begin
             repo = LibGit2.init(cache_repo)
             try
                 @test isdir(cache_repo)
@@ -138,9 +121,9 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
+        #end
 
-        @testset "bare" begin
+        #@testset "bare" begin
             path = joinpath(dir, "Example.Bare")
             repo = LibGit2.init(path, true)
             try
@@ -149,12 +132,12 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
-    end
+        #end
+    #end
 
-    @testset "Cloning repository" begin
+    #@testset "Cloning repository" begin
 
-        @testset "bare" begin
+        #@testset "bare" begin
             repo_path = joinpath(dir, "Example.Bare1")
             repo = LibGit2.clone(cache_repo, repo_path, isbare = true)
             try
@@ -163,8 +146,8 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
-        @testset "bare with remote callback" begin
+        #end
+        #@testset "bare with remote callback" begin
             repo_path = joinpath(dir, "Example.Bare2")
             repo = LibGit2.clone(cache_repo, repo_path, isbare = true, remote_cb = LibGit2.mirror_cb())
             try
@@ -179,8 +162,8 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
-        @testset "normal" begin
+        #end
+        #@testset "normal" begin
             repo = LibGit2.clone(cache_repo, test_repo, remote_cb = LibGit2.mirror_cb())
             try
                 @test isdir(test_repo)
@@ -188,12 +171,12 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
-    end
+        #end
+    #end
 
-    @testset "Update cache repository" begin
+    #@testset "Update cache repository" begin
 
-        @testset "with commits" begin
+        #@testset "with commits" begin
             repo = LibGit2.GitRepo(cache_repo)
             repo_file = open(joinpath(cache_repo,test_file), "a")
             try
@@ -239,9 +222,9 @@ temp_dir() do dir
                 finalize(repo)
                 close(repo_file)
             end
-        end
+        #end
 
-        @testset "with branch" begin
+        #@testset "with branch" begin
             repo = LibGit2.GitRepo(cache_repo)
             try
                 brnch = LibGit2.branch(repo)
@@ -255,9 +238,9 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
+        #end
 
-        @testset "with default configuration" begin
+        #@testset "with default configuration" begin
             repo = LibGit2.GitRepo(cache_repo)
             try
                 try
@@ -277,10 +260,10 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
+        #end
 
 
-        @testset "with tags" begin
+        #@testset "with tags" begin
             repo = LibGit2.GitRepo(cache_repo)
             try
                 tags = LibGit2.tag_list(repo)
@@ -306,10 +289,10 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
-    end
+        #end
+    #end
 
-    @testset "Fetch from cache repository" begin
+    #@testset "Fetch from cache repository" begin
         repo = LibGit2.GitRepo(test_repo)
         try
             # fetch changes
@@ -326,14 +309,14 @@ temp_dir() do dir
         finally
             finalize(repo)
         end
-    end
+    #end
 
-    @testset "Examine test repository" begin
-        @testset "files" begin
+    #@testset "Examine test repository" begin
+        #@testset "files" begin
             @test readstring(joinpath(test_repo, test_file)) == readstring(joinpath(cache_repo, test_file))
-        end
+        #end
 
-        @testset "tags & branches" begin
+        #@testset "tags & branches" begin
             repo = LibGit2.GitRepo(test_repo)
             try
                 # all tag in place
@@ -348,9 +331,9 @@ temp_dir() do dir
             finally
                 finalize(repo)
             end
-        end
+        #end
 
-        @testset "commits with revwalk" begin
+        #@testset "commits with revwalk" begin
             repo = LibGit2.GitRepo(test_repo)
             cache = LibGit2.GitRepo(cache_repo)
             try
@@ -365,17 +348,17 @@ temp_dir() do dir
                 cache_oids = LibGit2.with(LibGit2.GitRevWalker(cache)) do walker
                     LibGit2.map((oid,repo)->string(oid), walker, by = LibGit2.Consts.SORT_TIME)
                 end
-                @testset for i in eachindex(oids)
+                for i in eachindex(oids)
                     @test cache_oids[i] == test_oids[i]
                 end
             finally
                 finalize(repo)
                 finalize(cache)
             end
-        end
-    end
+        #end
+    #end
 
-    @testset "Transact test repository" begin
+    #@testset "Transact test repository" begin
         repo = LibGit2.GitRepo(test_repo)
         try
             cp(joinpath(test_repo, test_file), joinpath(test_repo, "CCC"))
@@ -394,8 +377,8 @@ temp_dir() do dir
         finally
             finalize(repo)
         end
-    end
+    #end
 
 end
 
-end
+#end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -563,14 +563,14 @@ end
 
 # stringmime/writemime should display the range or linspace nicely
 # to test print_range in range.jl
-replstr(x) = stringmime("text/plain", x)
-@test replstr(1:4) == "4-element UnitRange{$Int}:\n 1,2,3,4"
-@test replstr(linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
-@test replstr(0:100.) == "101-element FloatRange{Float64}:\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
+replstrmime(x) = stringmime("text/plain", x)
+@test replstrmime(1:4) == "4-element UnitRange{$Int}:\n 1,2,3,4"
+@test replstrmime(linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
+@test replstrmime(0:100.) == "101-element FloatRange{Float64}:\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
 # next is to test a very large range, which should be fast because print_range
 # only examines spacing of the left and right edges of the range, sufficient
 # to cover the designated screen size.
-@test replstr(0:10^9) == "1000000001-element UnitRange{$Int}:\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
+@test replstrmime(0:10^9) == "1000000001-element UnitRange{$Int}:\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
 
 @test sprint(io -> show(io,UnitRange(1,2))) == "1:2"
 @test sprint(io -> show(io,StepRange(1,2,5))) == "1:2:5"

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -333,7 +333,7 @@ end
 @test Base.shell_split("\"\\\\\"") == ["\\"]
 
 # issue #13616
-@test_throws ErrorException collect(eachline(`cat _doesnt_exist__111_`))
+@test_throws ErrorException collect(eachline(pipeline(`cat _doesnt_exist__111_`, stderr=DevNull)))
 
 # make sure windows_verbatim strips quotes
 @windows_only readstring(`cmd.exe /c dir /b spawn.jl`) == readstring(Cmd(`cmd.exe /c dir /b "\"spawn.jl\""`, windows_verbatim=true))


### PR DESCRIPTION
unnecessary output from `@time` or `cat`'s stderr, default testsets,
and double definition warnings when tests are run on a single worker
