### PR TITLE
Added tests for rook methods

### DIFF
--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -330,6 +330,13 @@ for elty in (Float32, Float64, Complex64, Complex128)
     @test_approx_eq triu(inv(A)) triu(LAPACK.sytri_rook!('U',B,ipiv))
     @test_throws DimensionMismatch LAPACK.sytrs_rook!('U',B,ipiv,rand(elty,11,5))
     @test LAPACK.sytrf_rook!('U',zeros(elty,0,0)) == (zeros(elty,0,0),zeros(BlasInt,0))
+    A = rand(elty,10,10)
+    A = A + A.' #symmetric!
+    b = rand(elty,10)
+    c = A \ b
+    b,A = LAPACK.sysv_rook!('U',A,b)
+    @test_approx_eq b c
+    @test_throws DimensionMismatch LAPACK.sysv_rook!('U',A,rand(elty,11))
 end
 
 # hetrs
@@ -391,6 +398,13 @@ for elty in (Complex64, Complex128)
     b,A = LAPACK.hesv!('U',A,b)
     @test_approx_eq b c
     @test_throws DimensionMismatch LAPACK.hesv!('U',A,rand(elty,11))
+    A = rand(elty,10,10)
+    A = A + A' #hermitian!
+    b = rand(elty,10)
+    c = A \ b
+    b,A = LAPACK.hesv_rook!('U',A,b)
+    @test_approx_eq b c
+    @test_throws DimensionMismatch LAPACK.hesv_rook!('U',A,rand(elty,11))
 end
 
 #ptsv


### PR DESCRIPTION
The `hesv_rook` and `sysv_rook` methods didn't have any tests.
