### PR TITLE
Enable `@edit @time 1+1`, fix #3377

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -219,14 +219,6 @@ Bessel function of the first kind of order `nu`, ``J_\\nu(x)``.
 besselj
 
 """
-    @code_lowered
-
-Evaluates the arguments to the function call, determines their types, and calls
-[`code_lowered`](:func:`code_lowered`) on the resulting expression.
-"""
-:@code_lowered
-
-"""
     //(num, den)
 
 Divide two integers or rational numbers, giving a `Rational` result.
@@ -715,14 +707,6 @@ once all workers, requested by `manager` have been launched. `params` is a dicti
 keyword arguments `addprocs` was called with.
 """
 launch
-
-"""
-    @code_typed
-
-Evaluates the arguments to the function call, determines their types, and calls
-[`code_typed`](:func:`code_typed`) on the resulting expression.
-"""
-:@code_typed
 
 """
     invdigamma(x)
@@ -3493,13 +3477,6 @@ Returns the lower triangle of `M` starting from the `k`th superdiagonal.
 """
 tril(M,k)
 
-"""
-    @edit
-
-Evaluates the arguments to the function call, determines their types, and calls the `edit`
-function on the resulting expression.
-"""
-:@edit
 
 """
     subtypes(T::DataType)
@@ -3613,14 +3590,6 @@ not representable.
 `digits` and `base` work as for [`round`](:func:`round`).
 """
 trunc
-
-"""
-    @less
-
-Evaluates the arguments to the function call, determines their types, and calls the `less`
-function on the resulting expression.
-"""
-:@less
 
 """
     broadcast_function(f)
@@ -5550,14 +5519,6 @@ Returns `string` with the first character converted to lowercase.
 lcfirst
 
 """
-    @code_native
-
-Evaluates the arguments to the function call, determines their types, and calls
-[`code_native`](:func:`code_native`) on the resulting expression.
-"""
-:@code_native
-
-"""
     flipbits!(B::BitArray{N}) -> BitArray{N}
 
 Performs a bitwise not operation on `B`. See [`~`](:ref:`~ operator <~>`).
@@ -5570,14 +5531,6 @@ flipbits!
 Returns the value of a symbolic link `path`.
 """
 readlink
-
-"""
-    @code_warntype
-
-Evaluates the arguments to the function call, determines their types, and calls
-[`code_warntype`](:func:`code_warntype`) on the resulting expression.
-"""
-:@code_warntype
 
 """
     deg2rad(x)
@@ -8258,16 +8211,6 @@ Converts a packed boolean array to an array of booleans.
 bitunpack
 
 """
-    @which
-
-Applied to a function call, it evaluates the arguments to the specified function call, and
-returns the `Method` object for the method that would be called for those arguments. Applied
-to a variable, it returns the module in which the variable was bound. It calls out to the
-`which` function.
-"""
-:@which
-
-"""
     size(A, [dim...])
 
 Returns a tuple containing the dimensions of `A`. Optionally you can specify the
@@ -8453,14 +8396,6 @@ Read a UDP packet from the specified socket, returning a tuple of (address, data
 address will be either IPv4 or IPv6 as appropriate.
 """
 recvfrom
-
-"""
-    @code_llvm
-
-Evaluates the arguments to the function call, determines their types, and calls
-[`code_llvm`](:func:`code_llvm`) on the resulting expression.
-"""
-:@code_llvm
 
 """
     nextfloat(f)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1387,6 +1387,7 @@ export
     # reflection
     @which,
     @edit,
+    @functionloc,
     @less,
     @code_typed,
     @code_warntype,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -80,7 +80,7 @@ Getting Around
 
    .. Docstring generated from Julia source
 
-   Evaluates the arguments to the function call, determines their types, and calls the ``edit`` function on the resulting expression.
+   Evaluates the arguments to the function or macro call, determines their types, and calls the ``edit`` function on the resulting expression.
 
 .. function:: less(file::AbstractString, [line])
 
@@ -98,7 +98,7 @@ Getting Around
 
    .. Docstring generated from Julia source
 
-   Evaluates the arguments to the function call, determines their types, and calls the ``less`` function on the resulting expression.
+   Evaluates the arguments to the function or macro call, determines their types, and calls the ``less`` function on the resulting expression.
 
 .. function:: clipboard(x)
 
@@ -188,7 +188,7 @@ Getting Around
 
    .. Docstring generated from Julia source
 
-   Applied to a function call, it evaluates the arguments to the specified function call, and returns the ``Method`` object for the method that would be called for those arguments. Applied to a variable, it returns the module in which the variable was bound. It calls out to the ``which`` function.
+   Applied to a function or macro call, it evaluates the arguments to the specified call, and returns the ``Method`` object for the method that would be called for those arguments. Applied to a variable, it returns the module in which the variable was bound. It calls out to the ``which`` function.
 
 .. function:: methods(f, [types])
 
@@ -1326,6 +1326,12 @@ Reflection
 
    Returns a tuple ``(filename,line)`` giving the location of a ``Method`` definition.
 
+.. function:: @functionloc
+
+   .. Docstring generated from Julia source
+
+   Applied to a function or macro call, it evaluates the arguments to the specified call, and returns a tuple ``(filename,line)`` giving the location for the method that would be called for those arguments. It calls out to the ``functionloc`` function.
+
 Internals
 ---------
 
@@ -1363,7 +1369,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Evaluates the arguments to the function call, determines their types, and calls :func:`code_lowered` on the resulting expression.
+   Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_lowered` on the resulting expression.
 
 .. function:: code_typed(f, types; optimize=true)
 
@@ -1375,7 +1381,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Evaluates the arguments to the function call, determines their types, and calls :func:`code_typed` on the resulting expression.
+   Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_typed` on the resulting expression.
 
 .. function:: code_warntype(f, types)
 
@@ -1387,7 +1393,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Evaluates the arguments to the function call, determines their types, and calls :func:`code_warntype` on the resulting expression.
+   Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_warntype` on the resulting expression.
 
 .. function:: code_llvm(f, types)
 
@@ -1401,7 +1407,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Evaluates the arguments to the function call, determines their types, and calls :func:`code_llvm` on the resulting expression.
+   Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_llvm` on the resulting expression.
 
 .. function:: code_native(f, types)
 
@@ -1413,7 +1419,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Evaluates the arguments to the function call, determines their types, and calls :func:`code_native` on the resulting expression.
+   Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_native` on the resulting expression.
 
 .. function:: precompile(f,args::Tuple{Vararg{Any}})
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -259,3 +259,22 @@ for (f,t) in ((definitely_not_in_sysimg,Tuple{}),
     @test llvmf != C_NULL
     @test ccall(:jl_get_llvm_fptr, Ptr{Void}, (Ptr{Void},), llvmf) != C_NULL
 end
+
+module MacroTest
+export @macrotest
+macro macrotest(x::Int, y::Symbol) end
+macro macrotest(x::Int, y::Int)
+    nothing #This is here because of #15280
+end
+end
+
+let
+    using MacroTest
+    a = 1
+    m = getfield(current_module(), Symbol("@macrotest"))
+    @test which(m, Tuple{Int,Symbol})==@which @macrotest 1 a
+    @test which(m, Tuple{Int,Int})==@which @macrotest 1 1
+
+    @test methods(m,Tuple{Int, Int})[1]==@which MacroTest.@macrotest 1 1
+    @test functionloc(@which @macrotest 1 1) == @functionloc @macrotest 1 1
+end


### PR DESCRIPTION
This allows for writing ~~`methods(:@time)`, `edit(:@time)`  and~~ `@edit @time 1+1` plus the equivalent for `which` and `less`. ~~`methods` can also check for macro methods as  `methods(:@time, Tuple{Any})`~~. The `@edit`, `@less` and `@which` do also check for method specialization of the macro.
