### PR TITLE
Set `isapprox` default relative error to be the larger of the default relative errors of each type.

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -176,7 +176,7 @@ const ≈ = isapprox
 # default tolerance arguments
 rtoldefault{T<:AbstractFloat}(::Type{T}) = sqrt(eps(T))
 rtoldefault{T<:Real}(::Type{T}) = 0
-rtoldefault{T<:Number,S<:Number}(x::Union{T,Type{T}}, y::Union{S,Type{S}}) = rtoldefault(promote_type(real(T),real(S)))
+rtoldefault{T<:Number,S<:Number}(x::Union{T,Type{T}}, y::Union{S,Type{S}}) = max(rtoldefault(real(T)),rtoldefault(real(S)))
 
 # fused multiply-add
 fma_libm(x::Float32, y::Float32, z::Float32) =

--- a/test/math.jl
+++ b/test/math.jl
@@ -387,9 +387,9 @@ j33 = besselj(3,3.)
 @test besselj(-3,-3) == j33
 @test besselj(-3,3) == -j33
 @test besselj(3,-3) == -j33
-@test besselj(3,3f0) ≈ Float32(j33)
+@test besselj(3,3f0) ≈ j33
 @test besselj(3,complex(3.)) ≈ j33
-@test besselj(3,complex(3f0)) ≈ Float32(j33)
+@test besselj(3,complex(3f0)) ≈ j33
 @test besselj(3,complex(3)) ≈ j33
 
 j43 = besselj(4,3.)
@@ -397,9 +397,9 @@ j43 = besselj(4,3.)
 @test besselj(-4,-3) == j43
 @test besselj(-4,3) == j43
 @test besselj(4,-3) == j43
-@test besselj(4,3f0) ≈ Float32(j43)
+@test besselj(4,3f0) ≈ j43
 @test besselj(4,complex(3.)) ≈ j43
-@test besselj(4,complex(3f0)) ≈ Float32(j43)
+@test besselj(4,complex(3f0)) ≈ j43
 @test besselj(4,complex(3)) ≈ j43
 
 @test_approx_eq j33 0.30906272225525164362

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1663,10 +1663,10 @@ end
 @test isnan(eps(-Inf))
 
 @test .1+.1+.1 != .3
-# TODO: uncomment when isapprox() becomes part of base.
-# @test isapprox(.1+.1+.1, .3)
-# @test !isapprox(.1+.1+.1-.3, 0)
-# @test isapprox(.1+.1+.1-.3, 0, eps(.3))
+@test isapprox(.1+.1+.1, .3)
+@test !isapprox(.1+.1+.1-.3, 0)
+@test isapprox(.1+.1+.1-.3, 0, atol=eps(.3))
+@test isapprox(1.1,1.1f0)
 
 @test div(1e50,1) == 1e50
 @test fld(1e50,1) == 1e50


### PR DESCRIPTION
See #15272.
