### PR TITLE
Avoid boundchecking iteration

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -232,6 +232,11 @@ collect(itr) = collect(eltype(itr), itr)
 ## Iteration ##
 start(A::Array) = 1
 next(a::Array,i) = (a[i],i+1)
+function unsafe_next(a::Array,i)
+    @inbounds begin
+        return next(a,i)
+    end
+end
 done(a::Array,i) = i == length(a)+1
 
 ## Indexing: getindex ##

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -148,6 +148,8 @@ macro goto(name::Symbol)
     Expr(:symbolicgoto, name)
 end
 
+unsafe_next(x,i) = next(x,i)
+
 # SimpleVector
 
 function getindex(v::SimpleVector, i::Int)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2386,7 +2386,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::VarInfo, 
     if incompletematch
         cost *= 4
     end
-    if (istopfunction(topmod, f, :next) || istopfunction(topmod, f, :done) ||
+    if (istopfunction(topmod, f, :next) || istopfunction(topmod, f, :unsafe_next) || istopfunction(topmod, f, :done) ||
        istopfunction(topmod, f, :unsafe_convert) || istopfunction(topmod, f, :cconvert))
         cost ÷= 4
     end

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -11,10 +11,10 @@ enumerate(itr) = Enumerate(itr)
 
 length(e::Enumerate) = length(e.itr)
 start(e::Enumerate) = (1, start(e.itr))
-function next(e::Enumerate, state)
-    n = next(e.itr,state[2])
-    (state[1],n[1]), (state[1]+1,n[2])
-end
+next(e::Enumerate, state) = next(e, state, next(e.itr, state[2]))
+unsafe_next(e::Enumerate, state) = next(e, state, unsafe_next(e.itr, state[2]))
+next(e::Enumerate, state, itr_state) = (state[1],itr_state[1]), (state[1]+1,itr_state[2])
+
 done(e::Enumerate, state) = done(e.itr, state[2])
 
 eltype{I}(::Type{Enumerate{I}}) = Tuple{Int, eltype(I)}

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1477,7 +1477,7 @@
                    ;; NOTE: enable this to force loop-local var
                    #;,@(map (lambda (v) `(local ,v)) (lhs-vars lhs))
                    ,(lower-tuple-assignment (list lhs state)
-                                            `(call (top next) ,coll ,state))
+                                            `(call (top unsafe_next) ,coll ,state))
                    ,body))))))))
 
 ;; table mapping expression head to a function expanding that form
@@ -2055,7 +2055,7 @@
                    (block
                     (= ,(car is) (call (top +) ,(car is) 1))
                     (= (tuple ,(cadr (car ranges)) ,(car states))
-                       (call (top next) ,(car rv) ,(car states)))
+                       (call (top unsafe_next) ,(car rv) ,(car states)))
                     ;; *** either this or force all for loop vars local
                     ,.(map (lambda (r) `(local ,r))
                            (lhs-vars (cadr (car ranges))))


### PR DESCRIPTION
Add an unsafe_next method which contract is that the iteration protocol was followed correctly. It has a generic fallback to next.
Lowering uses this instead of next. Wrapper iterators can also forward it.
This is demonstrated for Enumerate in this commit.

With this we can proudly say we compile a dead loop to nothing, yay...
