### PR TITLE
Fix check of inner dimension in matmul for 2x2 and 3x3 outer dimension

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -437,11 +437,12 @@ const Cbuf = Array(UInt8, tilebufsize)
 function generic_matmatmul!{T,S,R}(C::AbstractMatrix{R}, tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S})
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
+    mC, nC = size(C)
 
-    if mA == nA == nB == 2
+    if mA == nA == mB == nB == mC == nC == 2
         return matmul2x2!(C, tA, tB, A, B)
     end
-    if mA == nA == nB == 3
+    if mA == nA == mB == nB == mC == nC == 3
         return matmul3x3!(C, tA, tB, A, B)
     end
     _generic_matmatmul!(C, tA, tB, A, B)

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -32,6 +32,7 @@ Bi = B+(2.5*im).*A[[2,1],[2,1]]
 @test Ac_mul_B(Ai, Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
 @test A_mul_Bc(Ai, Bi) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
 @test Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
+@test_throws DimensionMismatch [1 2; 0 0; 0 0] * [1 2]
 
 # 3x3
 A = [1 2 3; 4 5 6; 7 8 9].-5
@@ -46,6 +47,7 @@ Bi = B+(2.5*im).*A[[2,1,3],[2,3,1]]
 @test Ac_mul_B(Ai, Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
 @test A_mul_Bc(Ai, Bi) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
 @test Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
+@test_throws DimensionMismatch [1 2 3; 0 0 0; 0 0 0] * [1 2 3]
 
 # Generic integer matrix multiplication
 A = [1 2 3; 4 5 6] .- 3


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#311 by adding extra dimension checks.
