### PR TITLE
Clean up objprofile and unused GC states

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -444,3 +444,114 @@ static void gc_scrub(char *stack_hi)
 }
 
 #endif
+
+#ifdef OBJPROFILE
+static htable_t obj_counts[3];
+static htable_t obj_sizes[3];
+static inline void objprofile_count(void *ty, int old, int sz)
+{
+#ifdef GC_VERIFY
+    if (verifying) return;
+#endif
+    if ((intptr_t)ty <= 0x10) {
+        ty = (void*)jl_buff_tag;
+    }
+    else if (ty != (void*)jl_buff_tag && ty != jl_malloc_tag &&
+             jl_typeof(ty) == (jl_value_t*)jl_datatype_type &&
+             ((jl_datatype_t*)ty)->instance) {
+        ty = jl_singleton_tag;
+    }
+    void **bp = ptrhash_bp(&obj_counts[old], ty);
+    if (*bp == HT_NOTFOUND)
+        *bp = (void*)2;
+    else
+        (*((intptr_t*)bp))++;
+    bp = ptrhash_bp(&obj_sizes[old], ty);
+    if (*bp == HT_NOTFOUND)
+        *bp = (void*)(intptr_t)(1 + sz);
+    else
+        *((intptr_t*)bp) += sz;
+}
+
+static void objprofile_reset(void)
+{
+    for(int g=0; g < 3; g++) {
+        htable_reset(&obj_counts[g], 0);
+        htable_reset(&obj_sizes[g], 0);
+    }
+}
+
+static void objprofile_print(htable_t nums, htable_t sizes)
+{
+    for(int i=0; i < nums.size; i+=2) {
+        if (nums.table[i+1] != HT_NOTFOUND) {
+            void *ty = nums.table[i];
+            int num = (intptr_t)nums.table[i + 1] - 1;
+            size_t sz = (uintptr_t)ptrhash_get(&sizes, ty) - 1;
+            static const int ptr_hex_width = 2 * sizeof(void*);
+            if (sz > 2e9) {
+                jl_printf(JL_STDERR, " %6d : %*.1f GB of (%*p) ",
+                          num, 6, ((double)sz) / 1024 / 1024 / 1024,
+                          ptr_hex_width, ty);
+            }
+            else if (sz > 2e6) {
+                jl_printf(JL_STDERR, " %6d : %*.1f MB of (%*p) ",
+                          num, 6, ((double)sz) / 1024 / 1024,
+                          ptr_hex_width, ty);
+            }
+            else if (sz > 2e3) {
+                jl_printf(JL_STDERR, " %6d : %*.1f kB of (%*p) ",
+                          num, 6, ((double)sz) / 1024,
+                          ptr_hex_width, ty);
+            }
+            else {
+                jl_printf(JL_STDERR, " %6d : %*d  B of (%*p) ",
+                          num, 6, (int)sz, ptr_hex_width, ty);
+            }
+            if (ty == (void*)jl_buff_tag)
+                jl_printf(JL_STDERR, "#<buffer>");
+            else if (ty == jl_malloc_tag)
+                jl_printf(JL_STDERR, "#<malloc>");
+            else if (ty == jl_singleton_tag)
+                jl_printf(JL_STDERR, "#<singletons>");
+            else
+                jl_static_show(JL_STDERR, (jl_value_t*)ty);
+            jl_printf(JL_STDERR, "\n");
+        }
+    }
+}
+
+static void objprofile_printall(void)
+{
+    jl_printf(JL_STDERR, "Transient mark :\n");
+    objprofile_print(obj_counts[0], obj_sizes[0]);
+    jl_printf(JL_STDERR, "Perm mark :\n");
+    objprofile_print(obj_counts[1], obj_sizes[1]);
+    jl_printf(JL_STDERR, "Remset :\n");
+    objprofile_print(obj_counts[2], obj_sizes[2]);
+}
+
+static void objprofile_init(void)
+{
+    for (int g = 0;g < 3;g++) {
+        htable_new(&obj_counts[g], 0);
+        htable_new(&obj_sizes[g], 0);
+    }
+}
+#else
+static inline void objprofile_count(void *ty, int old, int sz)
+{
+}
+
+static inline void objprofile_printall(void)
+{
+}
+
+static inline void objprofile_reset(void)
+{
+}
+
+static void objprofile_init(void)
+{
+}
+#endif

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -237,7 +237,6 @@ static void gc_verify(void)
     lostval = NULL;
     lostval_parents.len = 0;
     lostval_parents_done.len = 0;
-    check_timeout = 0;
     clear_mark(GC_CLEAN);
     verifying = 1;
     pre_mark();


### PR DESCRIPTION
- Remove unused GC global variables.
- Improve printing in objprofile and move it to `gc-debug.c`.
