### PR TITLE
RFC: define UnitStridedVecOrMat to restrict BLAS methods

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -4,6 +4,7 @@ module BLAS
 
 import Base: copy!, @blasfunc
 import Base.LinAlg: axpy!, dot
+using Base: UnitStridedVector, UnitStridedMatrix, UnitStridedVecOrMat
 
 export
 # Level 1
@@ -863,7 +864,7 @@ for (gemm, elty) in
              #       CHARACTER TRANSA,TRANSB
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
-        function gemm!(transA::Char, transB::Char, alpha::($elty), A::StridedVecOrMat{$elty}, B::StridedVecOrMat{$elty}, beta::($elty), C::StridedVecOrMat{$elty})
+        function gemm!(transA::Char, transB::Char, alpha::($elty), A::UnitStridedVecOrMat{$elty}, B::UnitStridedVecOrMat{$elty}, beta::($elty), C::UnitStridedVecOrMat{$elty})
 #           if any([stride(A,1), stride(B,1), stride(C,1)] .!= 1)
 #               error("gemm!: BLAS module requires contiguous matrix columns")
 #           end  # should this be checked on every call?

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -53,6 +53,11 @@ typealias StridedVector{T,A<:DenseArray,I<:Tuple{Vararg{Union{RangeIndex, NoSlic
 typealias StridedMatrix{T,A<:DenseArray,I<:Tuple{Vararg{Union{RangeIndex, NoSlice, AbstractCartesianIndex}}}}  Union{DenseArray{T,2}, SubArray{T,2,A,I}}
 typealias StridedVecOrMat{T} Union{StridedVector{T}, StridedMatrix{T}}
 
+# typealiases ensuring that the first dimension has unit stride (used by BLAS)
+typealias UnitStridedVector{T,A<:DenseArray,I<:Tuple{Union{Colon,UnitRange{Int}},Vararg{Int}}}  Union{DenseArray{T,1}, SubArray{T,1,A,I}}
+typealias UnitStridedMatrix{T,A<:DenseArray,I<:Tuple{Union{Colon,UnitRange{Int}},Vararg{Union{RangeIndex, NoSlice, AbstractCartesianIndex}}}}  Union{DenseArray{T,2}, SubArray{T,2,A,I}}
+typealias UnitStridedVecOrMat{T} Union{UnitStridedVector{T}, UnitStridedMatrix{T}}
+
 # This computes the linear indexing compatability for a given tuple of indices
 viewindexing() = LinearFast()
 # Leading scalar indexes simply increase the stride

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -110,9 +110,12 @@ Asub = sub(Ai, 1:2:5, 1:2:4)
 @test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
 @test A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
 # issue #15286
-let C = zeros(8, 8), sC = sub(C, 1:2:8, 1:2:8), B = reshape(map(Float64,-9:10),5,4)
-    @test At_mul_B!(sC, A, A) == A'*A
-    @test At_mul_B!(sC, A, B) == A'*B
+let C = zeros(8, 8), sC1 = sub(C, 1:4, 1:2:8),
+    sC2 = sub(C, 1:2:8, 1:2:8), B = reshape(map(Float64,-9:10),5,4)
+    @test At_mul_B!(sC2, A, A) == A'*A
+    @test At_mul_B!(sC2, A, B) == A'*B
+    @test_throws MethodError BLAS.gemm!('T', 'N', 1.0, A, B, 0.0 ,sC2)
+    @test BLAS.gemm!('T', 'N', 1.0, A, B, 0.0 ,sC1) == A'*B
 end
 let Aim = A .- im, C = zeros(Complex128,8,8), sC = sub(C, 1:2:8, 1:2:8), B = reshape(map(Float64,-9:10),5,4) .+ im
     @test Ac_mul_B!(sC, Aim, Aim) == Aim'*Aim


### PR DESCRIPTION
This is a prototype of a further solution to the problem reported in #15286. Its aim is to prevent BLAS methods from being called with SubArrays that don't have unit stride along dimension 1.

Is this desirable?
