### PR TITLE
Reinstate printing of :line Exprs

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -372,6 +372,7 @@ is_expr(ex, head::Symbol)         = (isa(ex, Expr) && (ex.head == head))
 is_expr(ex, head::Symbol, n::Int) = is_expr(ex, head) && length(ex.args) == n
 
 is_linenumber(ex::LineNumberNode) = true
+is_linenumber(ex::Expr)           = (ex.head == :line)
 is_linenumber(ex)                 = false
 
 is_quoted(ex)            = false
@@ -417,7 +418,8 @@ end
 
 emphasize(io, str::AbstractString) = have_color ? print_with_color(:red, io, str) : print(io, uppercase(str))
 
-show_linenumber(io::IO, file, line) = print(io," # ", file,", line ",line,':')
+show_linenumber(io::IO, line)       = print(io," # line ",line,':')
+show_linenumber(io::IO, line, file) = print(io," # ", file,", line ",line,':')
 
 # show a block, e g if/for/etc
 function show_block(io::IO, head, args::Vector, body, indent::Int)
@@ -486,7 +488,7 @@ end
 ## AST printing ##
 
 show_unquoted(io::IO, sym::Symbol, ::Int, ::Int)        = print(io, sym)
-show_unquoted(io::IO, ex::LineNumberNode, ::Int, ::Int) = show_linenumber(io, ex.file, ex.line)
+show_unquoted(io::IO, ex::LineNumberNode, ::Int, ::Int) = show_linenumber(io, ex.line, ex.file)
 show_unquoted(io::IO, ex::LabelNode, ::Int, ::Int)      = print(io, ex.label, ": ")
 show_unquoted(io::IO, ex::GotoNode, ::Int, ::Int)       = print(io, "goto ", ex.label)
 show_unquoted(io::IO, ex::TopNode, ::Int, ::Int)        = print(io,"top(",ex.name,')')
@@ -736,6 +738,9 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     elseif is(head, :typealias) && nargs == 2
         print(io, "typealias ")
         show_list(io, args, ' ', indent)
+
+    elseif is(head, :line) && 1 <= nargs <= 2
+        show_linenumber(io, args...)
 
     elseif is(head, :if) && nargs == 3     # if/else
         show_block(io, "if",   args[1], args[2], indent)

--- a/test/show.jl
+++ b/test/show.jl
@@ -347,6 +347,29 @@ end
 @test_repr "-(1,2,3)"
 @test_repr "*(1,2,3)"
 
+
+# issue #15309
+l1, l2, l2n = Expr(:line,42), Expr(:line,42,:myfile), LineNumberNode(:myfile,42)
+@test string(l2n) == " # myfile, line 42:"
+@test string(l2)  == string(l2n)
+@test string(l1)  == replace(string(l2n),"myfile, ","",1)
+ex = Expr(:block, l1, :x, l2, :y, l2n, :z)
+@test replace(string(ex)," ","") == replace("""
+begin  # line 42:
+    x # myfile, line 42:
+    y # myfile, line 42:
+    z
+end""", " ", "")
+# Test the printing of whatever form of line number representation
+# that is used in the arguments to a macro looks the same as for
+# regular quoting
+macro strquote(ex)
+    QuoteNode(string(ex))
+end
+str_ex2a, str_ex2b = @strquote(begin x end), string(quote x end)
+@test str_ex2a == str_ex2b
+
+
 # test structured zero matrix printing for select structured types
 A = reshape(1:16,4,4)
 @test replstr(Diagonal(A)) == "4x4 Diagonal{$Int}:\n 1  ⋅   ⋅   ⋅\n ⋅  6   ⋅   ⋅\n ⋅  ⋅  11   ⋅\n ⋅  ⋅   ⋅  16"


### PR DESCRIPTION
Line numbers in ASTs are nowadays often represented with `LineNumberNode`s, but this at least doesn't hold for macro arguments, which caused trouble in #15299, and is demonstrated by the example

```
macro q(ex)
    QuoteNode([ex])
end
@q begin x end
```

which prints

```
1-element Array{Expr,1}:
 quote 
    $(Expr(:line, 1, :none))
    x
end
```

This patch reinstates printing of `:line` expressions as it existed in Julia 0.3.
An alternative (and maybe preferable?) fix would be to consistently present `LineNumberNode`s to the user instead.
