### PR TITLE
Couple ispointer fixes

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4712,8 +4712,10 @@ static void emit_function(jl_lambda_info_t *lam, jl_llvm_functions_t *declaratio
             else if (specsig) {
                 if (type_is_ghost(llvmArgType)) // this argument is not actually passed
                     theArg = ghostValue(argType);
-                else if (llvmArgType->isAggregateType())
+                else if (llvmArgType->isAggregateType()) {
                     theArg = mark_julia_slot(&*AI++, argType); // this argument is by-pointer
+                    theArg.isimmutable = true;
+                }
                 else
                     theArg = mark_julia_type(&*AI++, isboxed, argType, &ctx, /*needsgcroot*/false);
             }


### PR DESCRIPTION
- Do not copy a getfield argument if it is already a pointer.
- Mark struct-as-pointer arguments immutable

Should: fix #15274, fix #13305, fix #15277 

@KristofferC @simonster can you please check that it is all better ?

Also thanks to @vtjnash for the much nicer codegen.cpp now
