### PR TITLE
use `mark_julia_const` in codegen of `typeof` when type is known

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -289,7 +289,7 @@ static Value *julia_to_native(Type *to, bool toboxed, jl_value_t *jlto, const jl
                 }
                 else {
                     nbytes = tbaa_decorate(tbaa_datatype, builder.CreateLoad(
-                                    builder.CreateGEP(builder.CreatePointerCast(emit_typeof(jvinfo), T_pint32),
+                                    builder.CreateGEP(builder.CreatePointerCast(emit_typeof_boxed(jvinfo,ctx), T_pint32),
                                         ConstantInt::get(T_size, offsetof(jl_datatype_t,size)/sizeof(int32_t))),
                                     false));
                     ai = builder.CreateAlloca(T_int8, nbytes);
@@ -303,7 +303,7 @@ static Value *julia_to_native(Type *to, bool toboxed, jl_value_t *jlto, const jl
         }
         // emit maybe copy
         *needStackRestore = true;
-        Value *jvt = emit_typeof(jvinfo);
+        Value *jvt = emit_typeof_boxed(jvinfo, ctx);
         BasicBlock *mutableBB = BasicBlock::Create(getGlobalContext(),"is-mutable",ctx->f);
         BasicBlock *immutableBB = BasicBlock::Create(getGlobalContext(),"is-immutable",ctx->f);
         BasicBlock *afterBB = BasicBlock::Create(getGlobalContext(),"after",ctx->f);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1075,6 +1075,9 @@ static Value *emit_typeptr_addr(Value *p)
     return emit_nthptr_addr(p, -offset);
 }
 
+static Value *boxed(const jl_cgval_t &v, jl_codectx_t *ctx, bool gcooted=true);
+static Value *boxed(const jl_cgval_t &v, jl_codectx_t *ctx, jl_value_t* type) = delete; // C++11 (temporary to prevent rebase error)
+
 static Value *emit_typeof(Value *tt)
 {
     // given p, a jl_value_t*, compute its type tag
@@ -1086,17 +1089,21 @@ static Value *emit_typeof(Value *tt)
             T_pjlvalue);
     return tt;
 }
-static Value *emit_typeof(const jl_cgval_t &p)
+static jl_cgval_t emit_typeof(const jl_cgval_t &p, jl_codectx_t *ctx)
 {
     // given p, compute its type
     if (!p.constant && p.isboxed && !jl_is_leaf_type(p.typ)) {
-        return emit_typeof(p.V);
+        return mark_julia_type(emit_typeof(p.V), true, jl_datatype_type, ctx);
     }
     jl_value_t *aty = p.typ;
     if (jl_is_type_type(aty)) // convert Int::Type{Int} ==> typeof(Int) ==> DataType
                               // but convert 1::Type{1} ==> typeof(1) ==> Int
         aty = (jl_value_t*)jl_typeof(jl_tparam0(aty));
-    return literal_pointer_val(aty);
+    return mark_julia_const(aty);
+}
+static Value *emit_typeof_boxed(const jl_cgval_t &p, jl_codectx_t *ctx)
+{
+    return boxed(emit_typeof(p, ctx), ctx);
 }
 
 static Value *emit_datatype_types(Value *dt)
@@ -1231,9 +1238,6 @@ static void null_pointer_check(Value *v, jl_codectx_t *ctx)
                            prepare_global(jlundeferr_var), ctx);
 }
 
-static Value *boxed(const jl_cgval_t &v, jl_codectx_t *ctx, bool gcooted=true);
-static Value *boxed(const jl_cgval_t &v, jl_codectx_t *ctx, jl_value_t* type) = delete; // C++11 (temporary to prevent rebase error)
-
 static void emit_type_error(const jl_cgval_t &x, jl_value_t *type, const std::string &msg,
                             jl_codectx_t *ctx)
 {
@@ -1272,7 +1276,7 @@ static void emit_typecheck(const jl_cgval_t &x, jl_value_t *type, const std::str
                          ConstantInt::get(T_int32,0));
     }
     else {
-        istype = builder.CreateICmpEQ(emit_typeof(x), literal_pointer_val(type));
+        istype = builder.CreateICmpEQ(emit_typeof_boxed(x,ctx), literal_pointer_val(type));
     }
     BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
     BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
@@ -2055,7 +2059,7 @@ static Value *boxed(const jl_cgval_t &vinfo, jl_codectx_t *ctx, bool gcrooted)
 
 static void emit_cpointercheck(const jl_cgval_t &x, const std::string &msg, jl_codectx_t *ctx)
 {
-    Value *t = emit_typeof(x);
+    Value *t = emit_typeof_boxed(x,ctx);
     emit_typecheck(mark_julia_type(t, true, jl_any_type, ctx), (jl_value_t*)jl_datatype_type, msg, ctx);
 
     Value *istype =

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2309,8 +2309,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
 
     else if (f==jl_builtin_typeof && nargs==1) {
         jl_cgval_t arg1 = emit_expr(args[1], ctx);
-        Value *lty = emit_typeof(arg1);
-        *ret = mark_julia_type(lty, true, jl_datatype_type, ctx);
+        *ret = emit_typeof(arg1,ctx);
         JL_GC_POP();
         return true;
     }
@@ -2380,7 +2379,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                 if (jl_is_leaf_type(tp0)) {
                     jl_cgval_t arg1 = emit_expr(args[1], ctx);
                     *ret = mark_julia_type(
-                            builder.CreateICmpEQ(emit_typeof(arg1),
+                            builder.CreateICmpEQ(emit_typeof_boxed(arg1,ctx),
                                                  literal_pointer_val(tp0)),
                             false,
                             jl_bool_type, ctx);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -415,7 +415,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
     if (!jl_is_datatype(v.typ)
         || !jl_is_bitstype(v.typ)
         || jl_datatype_size(v.typ) != nb) {
-        Value *typ = emit_typeof(v);
+        Value *typ = emit_typeof_boxed(v, ctx);
         if (!jl_is_bitstype(v.typ)) {
             if (isboxed) {
                 Value *isbits = emit_datatype_isbitstype(typ);


### PR DESCRIPTION
This improves performance of #15146. In `collect_to!` there is a call to `typeof` in the inner loop, which was generating a store to the gc frame instead of a no-op. @vtjnash is this the right way to do this?
