### PR TITLE
Fix missing GC root in table.c

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1763,6 +1763,7 @@ static void jl_reinit_item(ios_t *f, jl_value_t *v, int how) {
         switch (how) {
             case 1: { // rehash ObjectIdDict
                 jl_array_t **a = (jl_array_t**)v;
+                // Assume *a don't need a write barrier
                 jl_idtable_rehash(a, jl_array_len(*a));
                 jl_gc_wb(v, *a);
                 break;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -258,6 +258,8 @@ void jl_gc_signal_wait(void);
 void jl_dump_bitcode(char *fname, const char *sysimg_data, size_t sysimg_len);
 void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len);
 int32_t jl_get_llvm_gv(jl_value_t *p);
+// the first argument to jl_idtable_rehash is used to return a value
+// make sure it is rooted if it is used after the function returns
 void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
 
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);


### PR DESCRIPTION
This is the second GC (usage) bug discovered while investigating https://github.com/JuliaLang/julia/issues/15271. This has a higher chance to be the real cause since I can see how some recent change can put a higher pressure on the ObjectIdDict rehashing... (OTOH, it seems to be as old as 2011/2010 and I'm surprised that no one have hit it before.....)

@tkelman ~~backport 0.4 might need to remove the `dump.c` part.~~ (the change in `dump.c` is only a comment now so it should be easy to backport.) Let me know if it is not straight foward when doing the backport.

@colbec If you can try to see if this fixes the issue.
