### PR TITLE
Two fixes for LLVM SVN

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -8,6 +8,7 @@ BUILDDIR := .
 endif
 include $(SRCDIR)/Versions.make
 include $(JULIAHOME)/Make.inc
+include $(SRCDIR)/llvm-ver.make
 
 # Special comments:
 #
@@ -343,25 +344,6 @@ LLVM_BUILDTYPE := $(LLVM_BUILDTYPE)+MSAN
 else
 LLVM_BUILDTYPE := $(LLVM_BUILDTYPE)+ASAN
 endif
-endif
-
-LLVM_VER_MAJ:=$(word 1, $(subst ., ,$(LLVM_VER)))
-LLVM_VER_MIN:=$(word 2, $(subst ., ,$(LLVM_VER)))
-# define a "short" LLVM version for easy comparisons
-ifeq ($(LLVM_VER),svn)
-LLVM_VER_SHORT:=svn
-else
-LLVM_VER_SHORT:=$(LLVM_VER_MAJ).$(LLVM_VER_MIN)
-endif
-LLVM_VER_PATCH:=$(word 3, $(subst ., ,$(LLVM_VER)))
-ifeq ($(LLVM_VER_PATCH),)
-LLVM_VER_PATCH := 0
-endif
-
-ifeq ($(LLVM_VER_SHORT),$(filter $(LLVM_VER_SHORT),3.3 3.4 3.5 3.6 3.7 3.8))
-LLVM_USE_CMAKE := 0
-else
-LLVM_USE_CMAKE := 1
 endif
 
 LLVM_SRC_DIR:=$(SRCDIR)/srccache/llvm-$(LLVM_VER)

--- a/deps/llvm-ver.make
+++ b/deps/llvm-ver.make
@@ -1,0 +1,18 @@
+LLVM_VER_MAJ:=$(word 1, $(subst ., ,$(LLVM_VER)))
+LLVM_VER_MIN:=$(word 2, $(subst ., ,$(LLVM_VER)))
+# define a "short" LLVM version for easy comparisons
+ifeq ($(LLVM_VER),svn)
+LLVM_VER_SHORT:=svn
+else
+LLVM_VER_SHORT:=$(LLVM_VER_MAJ).$(LLVM_VER_MIN)
+endif
+LLVM_VER_PATCH:=$(word 3, $(subst ., ,$(LLVM_VER)))
+ifeq ($(LLVM_VER_PATCH),)
+LLVM_VER_PATCH := 0
+endif
+
+ifeq ($(LLVM_VER_SHORT),$(filter $(LLVM_VER_SHORT),3.3 3.4 3.5 3.6 3.7 3.8))
+LLVM_USE_CMAKE := 0
+else
+LLVM_USE_CMAKE := 1
+endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,7 @@ JULIAHOME := $(abspath $(SRCDIR)/..)
 BUILDDIR := .
 include $(JULIAHOME)/deps/Versions.make
 include $(JULIAHOME)/Make.inc
+include $(JULIAHOME)/deps/llvm-ver.make
 
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -3,6 +3,7 @@ JULIAHOME := $(abspath $(SRCDIR)/..)
 BUILDDIR ?= .
 include $(JULIAHOME)/deps/Versions.make
 include $(JULIAHOME)/Make.inc
+include $(JULIAHOME)/deps/llvm-ver.make
 
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)


### PR DESCRIPTION
- Factor the detection of `LLVM_USE_CMAKE` out of `deps/Makefile`, since `{src,ui}/Makefile` need to use that variable as well.
- Eagerly construct the DIContext to fix #15319 while a proper solution is being worked out upstream.
