### PR TITLE
Fix deps compilation with system suitesparse

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1752,6 +1752,7 @@ $(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT):  $(SUITESPARSE_OBJ_TARGET
 endif
 
 $(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT): $(SRCDIR)/SuiteSparse_wrapper.c
+	mkdir -p $(build_shlibdir)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) $< -o $@ $(SUITESPARSE_LIB)
 	$(INSTALL_NAME_CMD)libsuitesparse_wrapper.$(SHLIB_EXT) $@
 	touch -c $@


### PR DESCRIPTION
Build rule for `suitesparse-wrapper` didn't make sure that the dest dir exists.
