### PR TITLE
Delay the error in Bunch-Kaufman for singular matrices.

### DIFF
--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -10,37 +10,66 @@ immutable BunchKaufman{T,S<:AbstractMatrix} <: Factorization{T}
     uplo::Char
     symmetric::Bool
     rook::Bool
-    BunchKaufman(LD::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::Char, symmetric::Bool, rook::Bool) = new(LD, ipiv, uplo, symmetric, rook)
+    info::BlasInt
 end
-BunchKaufman{T}(LD::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::Char, symmetric::Bool, rook::Bool) = BunchKaufman{T,typeof(LD)}(LD, ipiv, uplo, symmetric, rook)
+BunchKaufman{T}(A::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::Char, symmetric::Bool,
+    rook::Bool, info::BlasInt) =
+        BunchKaufman{T,typeof(A)}(A, ipiv, uplo, symmetric, rook, info)
 
-function bkfact!{T<:BlasReal}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false)
+function bkfact!{T<:BlasReal}(A::StridedMatrix{T}, uplo::Symbol = :U,
+    symmetric::Bool = issymmetric(A), rook::Bool = false)
+
     if !symmetric
         throw(ArgumentError("Bunch-Kaufman decomposition is only valid for symmetric matrices"))
     end
-    LD, ipiv = rook ? LAPACK.sytrf_rook!(char_uplo(uplo) , A) : LAPACK.sytrf!(char_uplo(uplo) , A)
-    BunchKaufman(LD, ipiv, char_uplo(uplo), symmetric, rook)
-end
-function bkfact!{T<:BlasComplex}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false)
     if rook
-        LD, ipiv = (symmetric ? LAPACK.sytrf_rook! : LAPACK.hetrf_rook!)(char_uplo(uplo) , A)
+        LD, ipiv, info = LAPACK.sytrf_rook!(char_uplo(uplo), A)
     else
-        LD, ipiv = (symmetric ? LAPACK.sytrf! : LAPACK.hetrf!)(char_uplo(uplo) , A)
+        LD, ipiv, info = LAPACK.sytrf!(char_uplo(uplo), A)
     end
-    BunchKaufman(LD, ipiv, char_uplo(uplo), symmetric, rook)
+    BunchKaufman(LD, ipiv, char_uplo(uplo), symmetric, rook, info)
 end
-bkfact{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false) = bkfact!(copy(A), uplo, symmetric, rook)
-bkfact{T}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false) = bkfact!(convert(Matrix{promote_type(Float32,typeof(sqrt(one(T))))},A),uplo,symmetric,rook)
+function bkfact!{T<:BlasComplex}(A::StridedMatrix{T}, uplo::Symbol=:U,
+    symmetric::Bool=issymmetric(A), rook::Bool=false)
 
-convert{T}(::Type{BunchKaufman{T}},B::BunchKaufman) = BunchKaufman(convert(Matrix{T},B.LD),B.ipiv,B.uplo,B.symmetric,B.rook)
+    if rook
+        if symmetric
+            LD, ipiv, info = LAPACK.sytrf_rook!(char_uplo(uplo), A)
+        else
+            LD, ipiv, info = LAPACK.hetrf_rook!(char_uplo(uplo), A)
+        end
+    else
+        if symmetric
+            LD, ipiv, info = LAPACK.sytrf!(char_uplo(uplo),  A)
+        else
+            LD, ipiv, info = LAPACK.hetrf!(char_uplo(uplo), A)
+        end
+    end
+    BunchKaufman(LD, ipiv, char_uplo(uplo), symmetric, rook, info)
+end
+bkfact{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issymmetric(A),
+    rook::Bool=false) =
+        bkfact!(copy(A), uplo, symmetric, rook)
+bkfact{T}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issymmetric(A),
+    rook::Bool=false) =
+        bkfact!(convert(Matrix{promote_type(Float32, typeof(sqrt(one(T))))}, A),
+                uplo, symmetric, rook)
+
+convert{T}(::Type{BunchKaufman{T}}, B::BunchKaufman{T}) = B
+convert{T}(::Type{BunchKaufman{T}}, B::BunchKaufman) =
+    BunchKaufman(convert(Matrix{T}, B.LD), B.ipiv, B.uplo, B.symmetric, B.rook, B.info)
 convert{T}(::Type{Factorization{T}}, B::BunchKaufman) = convert(BunchKaufman{T}, B)
 
 size(B::BunchKaufman) = size(B.LD)
-size(B::BunchKaufman,d::Integer) = size(B.LD,d)
+size(B::BunchKaufman, d::Integer) = size(B.LD, d)
 issymmetric(B::BunchKaufman) = B.symmetric
 ishermitian(B::BunchKaufman) = !B.symmetric
 
 function inv{T<:BlasReal}(B::BunchKaufman{T})
+    if B.info > 0
+        throw(SingularException(B.info))
+    end
+
     if B.rook
         copytri!(LAPACK.sytri_rook!(B.uplo, copy(B.LD), B.ipiv), B.uplo, true)
     else
@@ -49,6 +78,10 @@ function inv{T<:BlasReal}(B::BunchKaufman{T})
 end
 
 function inv{T<:BlasComplex}(B::BunchKaufman{T})
+    if B.info > 0
+        throw(SingularException(B.info))
+    end
+
     if issymmetric(B)
         if B.rook
             copytri!(LAPACK.sytri_rook!(B.uplo, copy(B.LD), B.ipiv), B.uplo)
@@ -65,6 +98,10 @@ function inv{T<:BlasComplex}(B::BunchKaufman{T})
 end
 
 function A_ldiv_B!{T<:BlasReal}(B::BunchKaufman{T}, R::StridedVecOrMat{T})
+    if B.info > 0
+        throw(SingularException(B.info))
+    end
+
     if B.rook
         LAPACK.sytrs_rook!(B.uplo, B.LD, B.ipiv, R)
     else
@@ -72,14 +109,31 @@ function A_ldiv_B!{T<:BlasReal}(B::BunchKaufman{T}, R::StridedVecOrMat{T})
     end
 end
 function A_ldiv_B!{T<:BlasComplex}(B::BunchKaufman{T}, R::StridedVecOrMat{T})
+    if B.info > 0
+        throw(SingularException(B.info))
+    end
+
     if B.rook
-        (issymmetric(B) ? LAPACK.sytrs_rook! : LAPACK.hetrs_rook!)(B.uplo, B.LD, B.ipiv, R)
+        if issymmetric(B)
+            LAPACK.sytrs_rook!(B.uplo, B.LD, B.ipiv, R)
+        else
+            LAPACK.hetrs_rook!(B.uplo, B.LD, B.ipiv, R)
+        end
     else
-        (issymmetric(B) ? LAPACK.sytrs! : LAPACK.hetrs!)(B.uplo, B.LD, B.ipiv, R)
+        if issymmetric(B)
+            LAPACK.sytrs!(B.uplo, B.LD, B.ipiv, R)
+        else
+            LAPACK.hetrs!(B.uplo, B.LD, B.ipiv, R)
+        end
     end
 end
 
 function det(F::BunchKaufman)
+
+    if F.info > 0
+        return zero(eltype(F))
+    end
+
     M = F.LD
     p = F.ipiv
     n = size(F.LD, 1)
@@ -92,11 +146,15 @@ function det(F::BunchKaufman)
             d *= M[i,i]
             i += 1
         else
-            # 2x2 pivot case. Make sure not to square before the subtraction by scaling with the off-diagonal element. This is safe because the off diagonal is always large for 2x2 pivots.
+            # 2x2 pivot case. Make sure not to square before the subtraction by scaling
+            # with the off-diagonal element. This is safe because the off diagonal is
+            # always large for 2x2 pivots.
             if F.uplo == 'U'
-                d *= M[i, i + 1]*(M[i,i]/M[i, i + 1]*M[i + 1, i + 1] - (issymmetric(F) ? M[i, i + 1] : conj(M[i, i + 1])))
+                d *= M[i, i + 1]*(M[i,i]/M[i, i + 1]*M[i + 1, i + 1] -
+                    (issymmetric(F) ? M[i, i + 1] : conj(M[i, i + 1])))
             else
-                d *= M[i + 1,i]*(M[i, i]/M[i + 1, i]*M[i + 1, i + 1] - (issymmetric(F) ? M[i + 1, i] : conj(M[i + 1, i])))
+                d *= M[i + 1,i]*(M[i, i]/M[i + 1, i]*M[i + 1, i + 1] -
+                    (issymmetric(F) ? M[i + 1, i] : conj(M[i + 1, i])))
             end
             i += 2
         end

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -3893,13 +3893,12 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
                 chkargsok(info[])
-                chknonsingular(info[])
                 if i == 1
                     lwork = BlasInt(real(work[1]))
                     work = Array($elty, lwork)
                 end
             end
-            return A, ipiv
+            return A, ipiv, info[]
         end
 
         #       SUBROUTINE DSYTRI2( UPLO, N, A, LDA, IPIV, WORK, LWORK, INFO )
@@ -4044,13 +4043,12 @@ for (sysv, sytrf, sytri, sytrs, elty) in
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
                 chkargsok(info[])
-                chknonsingular(info[])
                 if i == 1
                     lwork = BlasInt(real(work[1]))
                     work = Array($elty, lwork)
                 end
             end
-            return A, ipiv
+            return A, ipiv, info[]
         end
 
         #      SUBROUTINE DSYTRI_ROOK( UPLO, N, A, LDA, IPIV, WORK, INFO )
@@ -4187,13 +4185,12 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, A, &max(1,stride(A,2)), ipiv, work, &lwork, info)
                 chkargsok(info[])
-                chknonsingular(info[])
                 if i == 1
                     lwork = BlasInt(real(work[1]))
                     work = Array($elty, lwork)
                 end
             end
-            A, ipiv
+            A, ipiv, info[]
         end
 
 #       SUBROUTINE ZHETRI2( UPLO, N, A, LDA, IPIV, WORK, LWORK, INFO )
@@ -4334,13 +4331,12 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, A, &max(1,stride(A,2)), ipiv, work, &lwork, info)
                 chkargsok(info[])
-                chknonsingular(info[])
                 if i == 1
                     lwork = BlasInt(real(work[1]))
                     work = Array($elty, lwork)
                 end
             end
-            A, ipiv
+            A, ipiv, info[]
         end
 
         #       SUBROUTINE ZHETRI_ROOK( UPLO, N, A, LDA, IPIV, WORK, INFO )
@@ -4456,13 +4452,12 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, A, &max(1,stride(A,2)), ipiv, work, &lwork, info)
                 chkargsok(info[])
-                chknonsingular(info[])
                 if i == 1
                     lwork = BlasInt(real(work[1]))
                     work = Array($elty, lwork)
                 end
             end
-            A, ipiv
+            A, ipiv, info[]
         end
 
 #       SUBROUTINE ZSYTRI2( UPLO, N, A, LDA, IPIV, WORK, LWORK, INFO )
@@ -4608,13 +4603,12 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, A, &max(1,stride(A,2)), ipiv, work, &lwork, info)
                 chkargsok(info[])
-                chknonsingular(info[])
                 if i == 1
                     lwork = BlasInt(real(work[1]))
                     work = Array($elty, lwork)
                 end
             end
-            A, ipiv
+            A, ipiv, info[]
         end
 
         #       SUBROUTINE ZSYTRI_ROOK( UPLO, N, A, LDA, IPIV, WORK, INFO )

--- a/test/linalg/bunchkaufman.jl
+++ b/test/linalg/bunchkaufman.jl
@@ -47,6 +47,7 @@ debug && println("(Automatic) Bunch-Kaufman factor of indefinite matrix")
                 @test_throws ArgumentError bkfact(a)
             end
         end
+
 debug && println("Bunch-Kaufman factors of a pos-def matrix")
         for rook in (false, true)
             bc2 = bkfact(apd, :U, issymmetric(apd), rook)
@@ -54,6 +55,23 @@ debug && println("Bunch-Kaufman factors of a pos-def matrix")
             @test_approx_eq_eps apd * (bc2\b) b 150000ε
             @test ishermitian(bc2) == !issymmetric(bc2)
         end
+    end
+end
 
+debug && println("Bunch-Kaufman factors of a singular matrix")
+let
+    As1 = ones(n, n)
+    As2 = complex(ones(n, n))
+    As3 = complex(ones(n, n))
+    As3[end, 1] += im
+    As3[1, end] -= im
+
+    for As = (As1, As2, As3)
+        for rook in (false, true)
+            F = bkfact(As, :U, issymmetric(As), rook)
+            @test det(F) == 0
+            @test_throws LinAlg.SingularException inv(F)
+            @test_throws LinAlg.SingularException F \ ones(size(As, 1))
+        end
     end
 end


### PR DESCRIPTION
Instead of erroring in the LAPACK wrapper the info code is returned provided
it is positive which is the error code for singularity. Add field
to the BunchKaufman type to store the error code and error on inv
and A_ldiv_B!.
