### PR TITLE
fix #15264, spurious `must be explicitly imported` error

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -336,9 +336,6 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *tvars, jl_svec_
                 called |= (1<<(i-1));
         }
         li->called = called;
-        if (tvars != jl_emptysvec)
-            if (jl_has_intrinsics(li, (jl_expr_t*)ast, ctx))
-                li->needs_sparam_vals_ducttape = 1;
     }
     return li;
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -1111,10 +1111,6 @@ jl_value_t *jl_preresolve_globals(jl_value_t *expr, jl_lambda_info_t *lam)
         if (!jl_local_in_linfo(lam, (jl_sym_t*)expr))
             return jl_module_globalref(lam->module, (jl_sym_t*)expr);
     }
-    else if (jl_is_lambda_info(expr)) {
-        jl_lambda_info_t *l = (jl_lambda_info_t*)expr;
-        (void)jl_preresolve_globals(l->ast, l);
-    }
     else if (jl_is_expr(expr)) {
         jl_expr_t *e = (jl_expr_t*)expr;
         if (e->head == lambda_sym) {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -746,6 +746,9 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_lambda_info_t *f, jl_valu
 
     if (!jl_is_lambda_info(f))
         f = expr_to_lambda((jl_expr_t*)f);
+    if (tvars != jl_emptysvec && !f->needs_sparam_vals_ducttape &&
+        jl_has_intrinsics(f, (jl_expr_t*)f->ast, f->module))
+        f->needs_sparam_vals_ducttape = 1;
 
     assert(jl_is_lambda_info(f));
     assert(jl_is_tuple_type(argtypes));

--- a/test/core.jl
+++ b/test/core.jl
@@ -3870,3 +3870,9 @@ let
 end
 @test j15283 == 1
 @test !isdefined(:k15283)
+
+# issue #15264
+module Test15264
+    mod1{T}(x::T) = x < 1 ? x : mod1(x-1)
+end
+@test Test15264.mod1 !== Base.mod1


### PR DESCRIPTION
This was caused by the call to jl_has_intrinsics in the LambdaInfo constructor, which looked up symbols inside the function too soon.
