### PR TITLE
Make `Pkg.Read.url` use absolute path to METADATA

### DIFF
--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -2,13 +2,13 @@
 
 module Read
 
-import ...LibGit2, ..Cache, ..Reqs, ...Pkg.PkgError
+import ...LibGit2, ..Cache, ..Reqs, ...Pkg.PkgError, ..Dir
 using ..Types
 
 readstrip(path...) = strip(readstring(joinpath(path...)))
 
-url(pkg::AbstractString) = readstrip("METADATA", pkg, "url")
-sha1(pkg::AbstractString, ver::VersionNumber) = readstrip("METADATA", pkg, "versions", string(ver), "sha1")
+url(pkg::AbstractString) = readstrip(Dir.path("METADATA"), pkg, "url")
+sha1(pkg::AbstractString, ver::VersionNumber) = readstrip(Dir.path("METADATA"), pkg, "versions", string(ver), "sha1")
 
 function available(names=readdir("METADATA"))
     pkgs = Dict{ByteString,Dict{VersionNumber,Available}}()

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -245,4 +245,7 @@ temp_pkg_dir() do
             @test ex.msg == "Pkg.submit(pkg[, commit]) has been moved to the package PkgDev.jl.\nRun Pkg.add(\"PkgDev\") to install PkgDev on Julia v0.5-"
         end
     end
+
+    # Test Pkg.Read.url works
+    @test Pkg.Read.url("Example") == "git://github.com/JuliaLang/Example.jl.git"
 end


### PR DESCRIPTION
Functions in `Pkg.Read` had been using relative paths to `METADATA` directory. Changed it so they would use an absolute path and added a test to make sure they worked.
