### PR TITLE
Allow abstract exception type in at-test_throws

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -240,7 +240,7 @@ end
 function do_test_throws(result::ExecutionResult, orig_expr, extype)
     if isa(result, Threw)
         # Check the right type of exception was thrown
-        if is(typeof(result.exception), extype)
+        if isa(result.exception, extype)
             testres = Pass(:test_throws, orig_expr, extype, result.exception)
         else
             testres = Fail(:test_throws_wrong, orig_expr, extype, result.exception)

--- a/test/test.jl
+++ b/test/test.jl
@@ -266,3 +266,7 @@ for i in 1:6
     @test typeof(tss[i].results[4]) == CustomTestSet
     @test typeof(tss[i].results[4].results[1]) == (iseven(i) ? Pass : Fail)
 end
+
+# Issue #14928
+# Make sure abstract error type works.
+@test_throws Exception error("")


### PR DESCRIPTION
Fix #14928 

c.c. @vtjnash 
