### PR TITLE
WIP: Slightly refactor object file lookup

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -37,6 +37,7 @@
 #ifdef LLVM37
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
+#include <llvm/Object/SymbolSize.h>
 #else
 #include <llvm/Target/TargetLibraryInfo.h>
 #endif
@@ -99,12 +100,15 @@
 #include <llvm/ExecutionEngine/Interpreter.h>
 #endif
 
+using namespace llvm;
+
 #if defined(_OS_WINDOWS_) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 
 #include "julia.h"
 #include "julia_internal.h"
+#include "codegen_internal.h"
 
 #include <setjmp.h>
 
@@ -116,7 +120,6 @@
 #include <set>
 #include <cstdio>
 #include <cassert>
-using namespace llvm;
 
 // LLVM version compatibility macros
 #ifdef LLVM37
@@ -1311,18 +1314,6 @@ void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name)
 }
 
 // --- native code info, and dump function to IR and ASM ---
-
-extern int jl_get_llvmf_info(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
-#if defined(USE_MCJIT) || defined(USE_ORCJIT)
-    const object::ObjectFile **object
-#else
-    std::vector<JITEvent_EmittedFunctionDetails::LineStart> *lines
-#endif
-    );
-
-extern "C"
-uint64_t jl_getUnwindInfo(uint64_t dwAddr);
-
 // Get pointer to llvm::Function instance, compiling if necessary
 extern "C" JL_DLLEXPORT
 void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper, bool getdeclarations)
@@ -1402,14 +1393,6 @@ void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper, bool g
         JL_GC_POP();
         return llvmf;
     }
-
-    if (linfo->fptr && !jl_getUnwindInfo((uintptr_t)linfo->fptr)) {
-        // Not in in the current ExecutionEngine
-        // found in the system image: force a recompile
-        linfo->functionObjects.specFunctionObject = NULL;
-        linfo->functionObjects.functionObject = NULL;
-        linfo->fptr = NULL;
-    }
     if (linfo->functionObjects.functionObject == NULL) {
         jl_compile_linfo(linfo, NULL);
     }
@@ -1420,12 +1403,6 @@ void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper, bool g
     else {
         llvmf = (Function*)linfo->functionObjects.functionObject;
     }
-#if !defined(USE_ORCJIT) && !defined(USE_MCJIT)
-    if (!getdeclarations) {
-        ValueToValueMapTy VMap;
-        llvmf = CloneFunction(llvmf, VMap, false);
-    }
-#endif
     JL_GC_POP();
     return llvmf;
 }
@@ -1504,20 +1481,15 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata, bool dump
     return jl_cstr_to_string(const_cast<char*>(stream.str().c_str()));
 }
 
-// Pre-declaration. Definition in disasm.cpp
-extern "C"
-void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
-#ifdef USE_MCJIT
-                          const object::ObjectFile *objectfile,
-#else
-                          std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
-#endif
-#ifdef LLVM37
-                          raw_ostream &rstream
-#else
-                          formatted_raw_ostream &stream
-#endif
-                          );
+// This is expensive, but it's only used for interactive mode
+static uint64_t compute_obj_symsize(const object::ObjectFile *obj, uint64_t offset)
+{
+    for (const auto &sym_size : object::computeSymbolSizes(*obj))
+        if (offset == sym_size.first.getValue() && sym_size.first.getType() == object::SymbolRef::ST_Function
+		&& sym_size.second != 0)
+            return sym_size.second;
+    return 0;
+}
 
 extern "C" JL_DLLEXPORT
 const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
@@ -1533,27 +1505,55 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
         jl_error("jl_dump_function_asm: Expected Function*");
 
     // Dump assembly code
-    uint64_t symsize, slide;
+    uint64_t symsize = 0;
+    int64_t slide = 0, SectionSlide = 0;
 #ifdef USE_MCJIT
     uint64_t fptr = getAddressForOrCompileFunction(llvmf);
-    const object::ObjectFile *object;
+#ifdef USE_ORCJIT
+    // Look in the system image as well
+    if (fptr == 0)
+        fptr = jl_ExecutionEngine->findSymbol(
+            jl_ExecutionEngine->mangle(llvmf->getName()), true).getAddress();
+#endif
+    llvm::DIContext *context;
 #else
     uint64_t fptr = (uintptr_t)jl_ExecutionEngine->getPointerToFunction(llvmf);
-    std::vector<JITEvent_EmittedFunctionDetails::LineStart> object;
+    std::vector<JITEvent_EmittedFunctionDetails::LineStart> context;
 #endif
+    const ObjectFile *object = NULL;
     assert(fptr != 0);
-    if (jl_get_llvmf_info(fptr, &symsize, &slide, &object)) {
-        if (raw_mc)
-            return (jl_value_t*)jl_pchar_to_array((char*)fptr, symsize);
+    bool isJIT = true;
+    if (!jl_DI_for_fptr(fptr, &symsize, &slide, &SectionSlide, &object, &context)) {
+        isJIT = false;
+        if (!jl_dylib_DI_for_fptr(fptr, &object, &context, &slide, false,
+            NULL, NULL, NULL, NULL)) {
+                jl_printf(JL_STDERR, "WARNING: Unable to find function pointer\n");
+                return jl_cstr_to_string("");
+        }
+    }
 #ifdef LLVM37
-        jl_dump_asm_internal(fptr, symsize, slide, object, stream);
-#else
-        jl_dump_asm_internal(fptr, symsize, slide, object, fstream);
+    if (symsize == 0)
+        symsize = compute_obj_symsize(object, fptr + slide + SectionSlide);
 #endif
+    if (symsize == 0) {
+        jl_printf(JL_STDERR, "WARNING: Could not determine size of symbol\n");
+        return jl_cstr_to_string("");
     }
-    else {
-        jl_printf(JL_STDERR, "WARNING: Unable to find function pointer\n");
+
+    if (raw_mc) {
+#ifdef LLVM37
+        jl_cleanup_DI(context);
+#endif
+        return (jl_value_t*)jl_pchar_to_array((char*)fptr, symsize);
     }
+#ifdef LLVM37
+    jl_dump_asm_internal(fptr, symsize, slide, context, stream);
+    if (isJIT)
+        jl_cleanup_DI(context);
+#else
+    jl_dump_asm_internal(fptr, symsize, slide, context, fstream);
+#endif
+
 #ifndef LLVM37
     fstream.flush();
 #endif

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -1,0 +1,28 @@
+// Pre-declaration. Definition in disasm.cpp
+extern "C"
+void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
+#ifdef USE_MCJIT
+                          llvm::DIContext *context,
+#else
+                          std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
+#endif
+#ifdef LLVM37
+                          raw_ostream &rstream
+#else
+                          formatted_raw_ostream &stream
+#endif
+                          );
+
+extern int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide, int64_t *SectionSlide,
+                      const object::ObjectFile **object,
+#ifdef USE_MCJIT
+                      llvm::DIContext **context
+#else
+                      std::vector<JITEvent_EmittedFunctionDetails::LineStart> *lines
+#endif
+                      );
+extern bool jl_dylib_DI_for_fptr(size_t pointer, const object::ObjectFile **object, llvm::DIContext **context, int64_t *slide, bool onlySysImg,
+    bool *isSysImg, void **saddr, char **name, char **filename);
+#ifdef USE_MCJIT
+extern void jl_cleanup_DI(llvm::DIContext *context);
+#endif

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -272,11 +272,11 @@ static void print_source_line(raw_ostream &stream, DebugLoc Loc)
 #endif
 
 extern "C"
-void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
+void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #ifndef USE_MCJIT
                           std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
 #else
-                          const object::ObjectFile *objectfile,
+                          DIContext *di_ctx,
 #endif
 #ifdef LLVM37
                           raw_ostream &rstream
@@ -431,16 +431,8 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
     SymbolTable DisInfo(Ctx, memoryObject);
 
 #ifdef USE_MCJIT
-    if (!objectfile) return;
-#ifdef LLVM37
-    DIContext *di_ctx = new DWARFContextInMemory(*objectfile);
-#elif LLVM36
-    DIContext *di_ctx = DIContext::getDWARFContext(*objectfile);
-#else
-    DIContext *di_ctx = DIContext::getDWARFContext(const_cast<object::ObjectFile*>(objectfile));
-#endif
     if (di_ctx == NULL) return;
-    DILineInfoTable lineinfo = di_ctx->getLineInfoForAddressRange(Fptr-slide, Fsize);
+    DILineInfoTable lineinfo = di_ctx->getLineInfoForAddressRange(Fptr+slide, Fsize);
 #else
     typedef std::vector<JITEvent_EmittedFunctionDetails::LineStart> LInfoVec;
 #endif

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -31,6 +31,7 @@ function test_code_reflections(tester, freflect)
                          Tuple{Array{Float32}, Array{Float32}}, tester) # incomplete types
     test_code_reflection(freflect, Module, Tuple{}, tester) # Module() constructor (transforms to call)
     test_code_reflection(freflect, Array{Int64}, Tuple{Array{Int32}}, tester) # with incomplete types
+    test_code_reflection(freflect, muladd, Tuple{Float64, Float64, Float64}, tester)
 end
 
 println(STDERR, "The following 'Returned code...' warnings indicate normal behavior:")


### PR DESCRIPTION
This doesn't change any functionality, but does address a few pain points:
- Don't recompile functions in the system image if all we want to do is look at their disassembly
- Only save one object map entry per object rather than one per function. This means we don't cache the symbol size any more, but since that information is only ever used when looking at the native code, saving it for every symbol is not efficient (even if computing it is expensive). This does require splitting out the linfo map, but I think this is still cleaner than saving redundant information for every object.
- There were several places that constructed DWARF contexts, now there is only one. Fixes `code_native` on LLVM 3.9.

Of course this code is still the ugliest in the entire system, which probably won't change until we get rid of the legacy versions of LLVM.
