### PR TITLE
fix mem leak in remote references under certain conditions

### DIFF
--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -640,6 +640,11 @@ if DoFullTest
     end
     sleep(0.5)  # Give some time for the above error to be printed
 
+    # github PR #14456
+    for n = 1:10^6
+        fetch(@spawnat myid() myid())
+    end
+
 @unix_only begin
     function test_n_remove_pids(new_pids)
         for p in new_pids


### PR DESCRIPTION
fix mem leak in remote references with the following pattern:
- worker 1 sends a local RemoteChannel to worker 2
- finalizer on worker 1 is manually called
- worker 2 immediately sends it back to worker 1
- object is garbage collected on worker 2
- the deserialized reference is not collected on 1 since it is
  found in the WeakDict client_refs (new finalizer is not
  installed)

Added a test for #14456 to ensure that this PR does not cause breakage of that fix.

NOTE: issue identified by @shashi 
