### PR TITLE
Add tests for SubArrays in test/linalg/bunchkaufman.jl

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -381,7 +381,7 @@ function inv{T}(A::StridedMatrix{T})
     return convert(typeof(parent(Ai)), Ai)
 end
 
-function factorize{T}(A::Matrix{T})
+function factorize{T}(A::StridedMatrix{T})
     m, n = size(A)
     if m == n
         if m == 1 return A[1] end

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -24,12 +24,12 @@ inv{T}(F::Factorization{T}) = A_ldiv_B!(F, eye(T, size(F,1)))
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
 function (\){T<:BlasReal}(F::Factorization{T}, B::AbstractVector{Complex{T}})
-    c2r = reshape(transpose(reinterpret(T, B, (2, length(B)))), size(B, 1), 2*size(B, 2))
+    c2r = reshape(transpose(reinterpret(T, parent(B), (2, length(B)))), size(B, 1), 2*size(B, 2))
     x = A_ldiv_B!(F, c2r)
     return reinterpret(Complex{T}, transpose(reshape(x, div(length(x), 2), 2)), (size(F,2),))
 end
 function (\){T<:BlasReal}(F::Factorization{T}, B::AbstractMatrix{Complex{T}})
-    c2r = reshape(transpose(reinterpret(T, B, (2, length(B)))), size(B, 1), 2*size(B, 2))
+    c2r = reshape(transpose(reinterpret(T, parent(B), (2, length(B)))), size(B, 1), 2*size(B, 2))
     x = A_ldiv_B!(F, c2r)
     return reinterpret(Complex{T}, transpose(reshape(x, div(length(x), 2), 2)), (size(F,2), size(B,2)))
 end

--- a/test/linalg/givens.jl
+++ b/test/linalg/givens.jl
@@ -15,50 +15,60 @@ for elty in (Float32, Float64, Complex64, Complex128)
     else
         A = convert(Matrix{elty}, complex(randn(10,10),randn(10,10)))
     end
-    Ac = copy(A)
-    R = Base.LinAlg.Rotation(Base.LinAlg.Givens{elty}[])
-    for j = 1:8
-        for i = j+2:10
-            G, _ = givens(A, j+1, i, j)
-            A_mul_B!(G, A)
-            A_mul_Bc!(A, G)
-            A_mul_B!(G, R)
-
-            @test A_mul_B!(G,eye(elty,10,10)) == [G[i,j] for i=1:10,j=1:10]
-
-            # test transposes
-            @test_approx_eq ctranspose(G)*G*eye(10) eye(elty, 10)
-            @test_approx_eq ctranspose(R)*(R*eye(10)) eye(elty, 10)
-            @test_throws ErrorException transpose(G)
-            @test_throws ErrorException transpose(R)
+    for Atype in ("Array", "SubArray")
+        if Atype == "Array"
+            A = A
+        else
+            A = sub(A, 1:10, 1:10)
         end
+        Ac = copy(A)
+        R = Base.LinAlg.Rotation(Base.LinAlg.Givens{elty}[])
+        for j = 1:8
+            for i = j+2:10
+                G, _ = givens(A, j+1, i, j)
+                A_mul_B!(G, A)
+                A_mul_Bc!(A, G)
+                A_mul_B!(G, R)
+
+                @test A_mul_B!(G,eye(elty,10,10)) == [G[i,j] for i=1:10,j=1:10]
+
+                # test transposes
+                @test_approx_eq ctranspose(G)*G*eye(10) eye(elty, 10)
+                @test_approx_eq ctranspose(R)*(R*eye(10)) eye(elty, 10)
+                @test_throws ErrorException transpose(G)
+                @test_throws ErrorException transpose(R)
+            end
+        end
+        @test_throws ArgumentError givens(A, 3, 3, 2)
+        @test_throws ArgumentError givens(one(elty),zero(elty),2,2)
+        G, _ = givens(one(elty),zero(elty),11,12)
+        @test_throws DimensionMismatch A_mul_B!(G, A)
+        @test_throws DimensionMismatch A_mul_Bc!(A,G)
+        @test_approx_eq abs(A) abs(hessfact(Ac)[:H])
+        @test_approx_eq norm(R*eye(elty, 10)) one(elty)
+
+        G, _ = givens(one(elty),zero(elty),9,10)
+        @test_approx_eq ctranspose(G*eye(elty,10))*(G*eye(elty,10)) eye(elty, 10)
+        K, _ = givens(zero(elty),one(elty),9,10)
+        @test_approx_eq ctranspose(K*eye(elty,10))*(K*eye(elty,10)) eye(elty, 10)
+
+        # test that Givens * work for vectors
+        if Atype == "Array"
+            x = A[:, 1]
+        else
+            x = sub(A, 1:10, 1)
+        end
+        G, r = givens(x[2], x[4], 2, 4)
+        @test (G*x)[2] ≈ r
+        @test abs((G*x)[4]) < eps(real(elty))
+
+        G, r = givens(x, 2, 4)
+        @test (G*x)[2] ≈ r
+        @test abs((G*x)[4]) < eps(real(elty))
+
+        G, r = givens(x, 4, 2)
+        @test (G*x)[4] ≈ r
+        @test abs((G*x)[2]) < eps(real(elty))
     end
-    @test_throws ArgumentError givens(A, 3, 3, 2)
-    @test_throws ArgumentError givens(one(elty),zero(elty),2,2)
-    G, _ = givens(one(elty),zero(elty),11,12)
-    @test_throws DimensionMismatch A_mul_B!(G, A)
-    @test_throws DimensionMismatch A_mul_Bc!(A,G)
-    @test_approx_eq abs(A) abs(hessfact(Ac)[:H])
-    @test_approx_eq norm(R*eye(elty, 10)) one(elty)
-
-    G, _ = givens(one(elty),zero(elty),9,10)
-    @test_approx_eq ctranspose(G*eye(elty,10))*(G*eye(elty,10)) eye(elty, 10)
-    K, _ = givens(zero(elty),one(elty),9,10)
-    @test_approx_eq ctranspose(K*eye(elty,10))*(K*eye(elty,10)) eye(elty, 10)
-
-    # test that Givens * work for vectors
-    x = A[:,1]
-    G, r = givens(x[2], x[4], 2, 4)
-    @test (G*x)[2] ≈ r
-    @test abs((G*x)[4]) < eps(real(elty))
-
-    x = A[:,1]
-    G, r = givens(x, 2, 4)
-    @test (G*x)[2] ≈ r
-    @test abs((G*x)[4]) < eps(real(elty))
-
-    G, r = givens(x, 4, 2)
-    @test (G*x)[4] ≈ r
-    @test abs((G*x)[2]) < eps(real(elty))
 end
 end #let

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -21,6 +21,8 @@ a2img  = randn(n,n)/2
 for eltya in (Float32, Float64, Complex64, Complex128, Int)
     aa = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
     aa2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(a2real, a2img) : a2real)
+    asym = aa'+aa                  # symmetric indefinite
+    apd  = aa'*aa                 # symmetric positive-definite
     for atype in ("Array", "SubArray")
         if atype == "Array"
             a = aa
@@ -29,8 +31,6 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
             a = sub(aa, 1:n, 1:n)
             a2 = sub(aa2, 1:n, 1:n)
         end
-        asym = a'+a                  # symmetric indefinite
-        apd  = a'*a                 # symmetric positive-definite
         ε = εa = eps(abs(float(one(eltya))))
 
     debug && println("\ntype of a: ", eltya, "\n")


### PR DESCRIPTION
- Added tests for `linalg/bunchkaufman.jl`. Found tiny dispatch bug, as `factorize` didn't dispatch properly for `SubArray`s (changed `Matrix` -> `StridedMatrix`).
- Moved two matrix calculations in `svd.jl`.
- Added tests for `givens.jl`. Again, at loop over `Array` and `SubArray`, here for the matrix `A`, and vector `x`. `SubArray`s seem to pass just fine.
