### PR TITLE
Add shareindexes macro for (sometimes) faster iteration

### DIFF
--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -55,6 +55,30 @@ type.
 
    Note that :func:`zip` is its own inverse: ``collect(zip(zip(a...)...)) == collect(a)``\ .
 
+.. function:: @shareiterators
+
+   .. Docstring generated from Julia source
+
+   This macro may improve the efficiency of loops that have multiple iterators. For example,
+
+   .. code-block:: julia
+
+       @shareiterators for (IA, IB) in zip(eachindex(A), eachindex(B))
+           # body
+       end
+
+   generates, by default, a loop with two indexes that need to be incremented and tested on each iteration. However, if it happens that the two iterators in the ``zip`` call have the same value, then it runs a variant of the loop that uses a single index.
+
+   Note this is only recommended for cases where the iterators can be compared efficiently. The example above demonstrates good usage of this macro; in contrast,
+
+   .. code-block:: julia
+
+       @shareiterators for (a, b) in zip(A, B)
+           # body
+       end
+
+   would be much worse than the version without ``@shareiterators``\ , because it would check each element of ``A`` and ``B`` before deciding which variant of the loop to run (and hence pass through ``A`` and ``B`` twice).
+
 .. function:: enumerate(iter)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
I'm preparing another couple of PRs that will expand the range of array iterators (and I'm planning even further expansion later on). I'm thinking ahead about loops that involve multiple arrays. 
### The problem

Currently we have two options:

``` jl
for I in eachindex(A, B)
    # body
end
```

and

``` jl
for (IA, IB) in zip(eachindex(A), eachindex(B))
    # body
end
```

My sense is that our `eachindex(A, B)` mechanism is too limited for the coming brave new world, and should gradually be retired. That means we should use `zip`. However, `zip` sometimes still has performance issues, some of which are unavoidable: when you have to increment two iterators rather than one, it's going to be slower, especially if incrementing is more expensive than the body. See benchmarks below.
### This PR's solution

This PR introduces a new macro, `@shareindexes`, which takes a block like this:

``` jl
@shareindexes for (IA,IB) in zip(eachindex(A), eachindex(B))
    @inbounds s += A[IA]*B[IB]
end
```

and turns it into

``` jl
RA, RB = eachindex(A), eachindex(B)
if RA == RB
    for I in RA
        @inbounds s += A[I]*B[I]
    end
else
    for (IA,IB) in zip(RA, RB)
        @inbounds s += A[IA]*B[IB]
    end
end
```
### An alternative that didn't work

I tried an alternative implementation based on

``` jl
immutable Zip2Each{I1, I2} <: AbstractZipIterator
    same::Bool
    a::I1
    b::I2
end
```

and then defining `start`, `done`, and `next` functions that test `same` at runtime. Unfortunately, this was slower than just plain `zip`. If we could hoist that `same` check out of the entire block, then this solution would be just like the macro-based solution (but prettier).
### Benchmarks

Using the functions `mydot1`, `mydot2`, and `mydotshared` in the new tests (with a `@simd` added in front of the loop in `mydot1` for good measure), with arrays of size (10001,10000), here are timings.

``` jl
mydot1
  0.093147 seconds (5 allocations: 176 bytes)
  0.094556 seconds (5 allocations: 176 bytes)
  0.094084 seconds (5 allocations: 176 bytes)
mydot2
  0.115129 seconds (5 allocations: 176 bytes)
  0.796566 seconds (5 allocations: 176 bytes)
  0.161923 seconds (5 allocations: 176 bytes)
mydotshared
  0.114697 seconds (5 allocations: 176 bytes)
  0.180229 seconds (5 allocations: 176 bytes)
  0.161990 seconds (5 allocations: 176 bytes)
```

Like in the tests, the first in each block is for a pair of `LinearFast` arrays, the second for `LinearSlow` arrays, and third with one of each.

I'm not quite sure why `mydotshared` isn't as fast as `mydot1`, but I've verified that this also holds when I write out that function manually rather than using the macro. The noteworthy case is when there are two `CartesianRange` iterators, which yields a ~4x speedup.

CC @JeffBezanson, @mbauman.
