### PR TITLE
Fix incorrect `->` handling in docs bootstrapping.

### DIFF
--- a/base/docs/bootstrap.jl
+++ b/base/docs/bootstrap.jl
@@ -27,13 +27,22 @@ function __bootexpand(str, obj)
 end
 
 function __bootexpand(expr::Expr)
-    if expr.head !== :->
-        throw(ArgumentError("Wrong argument to @doc"))
-    end
-    __bootexpand(expr.args...)
+    expr.head === :-> || throw(ArgumentError("Wrong argument to @doc"))
+    str = Core.arrayref(expr.args, 1)
+    obj = Core.arrayref(Core.arrayref(expr.args, 2).args, 2)
+    __bootexpand(str, obj)
 end
 
 setexpand!(__bootexpand)
+
+# The following docstrings are basic sanity checks for `__bootexpand`.
+
+@doc """
+Captures and stores docstrings in `DocBootstrap.docs` before the real docsystem is defined.
+
+Note: this expander is later replaced by the more feature-complete `Docs.docm`.
+""" ->
+__bootexpand(str, obj)
 
 """
     DocBootstrap :: Module

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -21,6 +21,18 @@ function docstring_startswith(d1, d2)
 end
 docstring_startswith(d1::DocStr, d2) = docstring_startswith(parsedoc(d1), d2)
 
+# Check that some very early docs have been found.
+let d1 = @doc(Base.DocBootstrap.__bootexpand),
+    d3 = @doc(Base.DocBootstrap.loaddocs),
+    d2 = @doc(Base.DocBootstrap)
+    @test length(d1.meta[:results]) === 1
+    @test contains(stringmime("text/markdown", d1), "Captures and stores")
+    @test length(d2.meta[:results]) === 1
+    @test contains(stringmime("text/markdown", d2), "DocBootstrap :: Module")
+    @test length(d3.meta[:results]) === 1
+    @test contains(stringmime("text/markdown", d2), "loaddocs()")
+end
+
 @doc "Doc abstract type" ->
 abstract C74685 <: AbstractArray
 @test stringmime("text/plain", Docs.doc(C74685))=="Doc abstract type\n"


### PR DESCRIPTION
`:call` expressions on the RHS of `->` were being masked by a `:block` expression, so were not replaced with `nothing` during doc bootstrapping.

This PR avoids that by unwrapping the `:block` expression and passing the inner expression instead of the entire block.

@omus, if you could confirm whether this does fix your issue that would be great, thanks.
