### PR TITLE
Add example of doc generation with metaprogramming

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -284,6 +284,23 @@ end
 will add documentation to `f(x)` when `condition()` is `true`. Note that even if `f(x)` goes
 out of scope at the end of the block, its documentation will remain.
 
+It is possible to make use of metaprogramming to assist in the creation of documentation.
+When using string-interpolation within the docstring you will need to use an extra `$` as
+shown with `$($name)`:
+
+```julia
+for func in (:day, :dayofmonth)
+    name = string(func)
+    @eval begin
+        @doc """
+            $($name)(dt::TimeType) -> Int64
+
+        The day of month of a `Date` or `DateTime` as an `Int64`.
+        """ $func(dt::Dates.TimeType)
+    end
+end
+```
+
 ### Dynamic documentation
 
 Sometimes the appropriate documentation for an instance of a type depends on the field values of that


### PR DESCRIPTION
When writing some documentation using metaprogramming for #15334 I was confused with how string interpolation worked within `eval`. Thanks to @MichaelHatherly who introduced me to the double-$ string interpolation.
