### PR TITLE
Added SubArray tests for linalg/eigen.jl and linalg/schur.jl

### DIFF
--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -207,3 +207,6 @@ function schur(A::StridedMatrix, B::StridedMatrix)
 end
 
 full(F::Schur) = (F.Z * F.T) * F.Z'
+
+copy(F::Schur) = Schur(copy(F.T), copy(F.Z), copy(F.values))
+copy(F::GeneralizedSchur) = GeneralizedSchur(copy(F.S), copy(F.T), copy(F.alpha), copy(F.beta), copy(F.Q), copy(F.Z))

--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -17,68 +17,93 @@ areal = randn(n,n)/2
 aimg  = randn(n,n)/2
 
 for eltya in (Float32, Float64, Complex64, Complex128, Int)
-    a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
-    asym = a'+a                 # symmetric indefinite
-    apd  = a'*a                 # symmetric positive-definite
-    ε = εa = eps(abs(float(one(eltya))))
+    aa = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
+    asym = aa'+aa                  # symmetric indefinite
+    apd  = aa'*aa                 # symmetric positive-definite
+    for atype in ("Array", "SubArray")
+        if atype == "Array"
+            a = aa
+        else
+            a = sub(aa, 1:n, 1:n)
+            asym = sub(asym, 1:n, 1:n)
+            apd = sub(apd, 1:n, 1:n)
+        end
+        ε = εa = eps(abs(float(one(eltya))))
 
-    α = rand(eltya)
-    β = rand(eltya)
-    eab = eig(α,β)
-    @test eab[1] == eigvals(fill(α,1,1),fill(β,1,1))
-    @test eab[2] == eigvecs(fill(α,1,1),fill(β,1,1))
+        α = rand(eltya)
+        β = rand(eltya)
+        eab = eig(α,β)
+        @test eab[1] == eigvals(fill(α,1,1),fill(β,1,1))
+        @test eab[2] == eigvecs(fill(α,1,1),fill(β,1,1))
 
-debug && println("\ntype of a: ", eltya,"\n")
-debug && println("non-symmetric eigen decomposition")
-    d,v   = eig(a)
-    for i in 1:size(a,2) @test_approx_eq a*v[:,i] d[i]*v[:,i] end
-    f = eigfact(a)
-    @test_approx_eq det(a) det(f)
-    @test_approx_eq inv(a) inv(f)
-    @test eigvals(f) === f[:values]
-    @test eigvecs(f) === f[:vectors]
+    debug && println("\ntype of a: ", eltya,"\n")
+    debug && println("non-symmetric eigen decomposition")
+        d,v   = eig(a)
+        for i in 1:size(a,2) @test_approx_eq a*v[:,i] d[i]*v[:,i] end
+        f = eigfact(a)
+        @test_approx_eq det(a) det(f)
+        @test_approx_eq inv(a) inv(f)
+        @test eigvals(f) === f[:values]
+        @test eigvecs(f) === f[:vectors]
 
-    num_fact = eigfact(one(eltya))
-    @test num_fact.values[1] == one(eltya)
-    h = a + a'
-    @test_approx_eq minimum(eigvals(h)) eigmin(h)
-    @test_approx_eq maximum(eigvals(h)) eigmax(h)
-    @test_throws DomainError eigmin(a - a')
-    @test_throws DomainError eigmax(a - a')
+        num_fact = eigfact(one(eltya))
+        @test num_fact.values[1] == one(eltya)
+        h = asym
+        @test_approx_eq minimum(eigvals(h)) eigmin(h)
+        @test_approx_eq maximum(eigvals(h)) eigmax(h)
+        @test_throws DomainError eigmin(a - a')
+        @test_throws DomainError eigmax(a - a')
 
-debug && println("symmetric generalized eigenproblem")
-    asym_sg = asym[1:n1, 1:n1]
-    a_sg = a[:,n1+1:n2]
-    f = eigfact(asym_sg, a_sg'a_sg)
-    @test_approx_eq asym_sg*f[:vectors] (a_sg'a_sg*f[:vectors]) * Diagonal(f[:values])
-    @test_approx_eq f[:values] eigvals(asym_sg, a_sg'a_sg)
-    @test_approx_eq_eps prod(f[:values]) prod(eigvals(asym_sg/(a_sg'a_sg))) 200ε
-    @test eigvecs(asym_sg, a_sg'a_sg) == f[:vectors]
-    @test eigvals(f) === f[:values]
-    @test eigvecs(f) === f[:vectors]
-    @test_throws KeyError f[:Z]
+    debug && println("symmetric generalized eigenproblem")
+        if atype == "Array"
+            asym_sg = asym[1:n1, 1:n1]
+            a_sg = a[:,n1+1:n2]
+        else
+            asym_sg = sub(asym, 1:n1, 1:n1)
+            a_sg = sub(a, 1:n, n1+1:n2)
+        end
+        f = eigfact(asym_sg, a_sg'a_sg)
+        @test_approx_eq asym_sg*f[:vectors] (a_sg'a_sg*f[:vectors]) * Diagonal(f[:values])
+        @test_approx_eq f[:values] eigvals(asym_sg, a_sg'a_sg)
+        @test_approx_eq_eps prod(f[:values]) prod(eigvals(asym_sg/(a_sg'a_sg))) 200ε
+        @test eigvecs(asym_sg, a_sg'a_sg) == f[:vectors]
+        @test eigvals(f) === f[:values]
+        @test eigvecs(f) === f[:vectors]
+        @test_throws KeyError f[:Z]
 
-    d,v = eig(asym_sg, a_sg'a_sg)
-    @test d == f[:values]
-    @test v == f[:vectors]
+        d,v = eig(asym_sg, a_sg'a_sg)
+        @test d == f[:values]
+        @test v == f[:vectors]
 
-debug && println("Non-symmetric generalized eigenproblem")
-    a1_nsg = a[1:n1, 1:n1]
-    a2_nsg = a[n1+1:n2, n1+1:n2]
-    f = eigfact(a1_nsg, a2_nsg)
-    @test_approx_eq a1_nsg*f[:vectors] (a2_nsg*f[:vectors]) * Diagonal(f[:values])
-    @test_approx_eq f[:values] eigvals(a1_nsg, a2_nsg)
-    @test_approx_eq_eps prod(f[:values]) prod(eigvals(a1_nsg/a2_nsg)) 50000ε
-    @test eigvecs(a1_nsg, a2_nsg) == f[:vectors]
-    @test_throws KeyError f[:Z]
+    debug && println("Non-symmetric generalized eigenproblem")
+        if atype == "Array"
+            a1_nsg = a[1:n1, 1:n1]
+            a2_nsg = a[n1+1:n2, n1+1:n2]
+        else
+            a1_nsg = sub(a, 1:n1, 1:n1)
+            a2_nsg = sub(a, n1+1:n2, n1+1:n2)
+        end
+        f = eigfact(a1_nsg, a2_nsg)
+        @test_approx_eq a1_nsg*f[:vectors] (a2_nsg*f[:vectors]) * Diagonal(f[:values])
+        @test_approx_eq f[:values] eigvals(a1_nsg, a2_nsg)
+        @test_approx_eq_eps prod(f[:values]) prod(eigvals(a1_nsg/a2_nsg)) 50000ε
+        @test eigvecs(a1_nsg, a2_nsg) == f[:vectors]
+        @test_throws KeyError f[:Z]
 
-    d,v = eig(a1_nsg, a2_nsg)
-    @test d == f[:values]
-    @test v == f[:vectors]
+        d,v = eig(a1_nsg, a2_nsg)
+        @test d == f[:values]
+        @test v == f[:vectors]
+    end
 end
-
 # test a matrix larger than 140-by-140 for #14174
-let a = rand(200, 200)
-    f = eigfact(a)
-    @test a ≈ f[:vectors] * Diagonal(f[:values]) / f[:vectors]
+let aa = rand(200, 200)
+    for atype in ("Array", "SubArray")
+        if atype == "Array"
+            a = aa
+        else
+            a = sub(aa, 1:n, 1:n)
+        end
+        f = eigfact(a)
+        @test a ≈ f[:vectors] * Diagonal(f[:values]) / f[:vectors]
+    end
 end

--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -20,69 +20,80 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
     a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
     asym = a'+a                  # symmetric indefinite
     apd  = a'*a                 # symmetric positive-definite
-    ε = εa = eps(abs(float(one(eltya))))
+    for atype in ("Array", "SubArray")
+        if atype == "Array"
+            a = a
+        else
+            a = sub(a, 1:n, 1:n)
+            asym = sub(asym, 1:n, 1:n)
+            apd = sub(apd, 1:n, 1:n)
+        end
+        ε = εa = eps(abs(float(one(eltya))))
 
-debug && println("\ntype of a: ", eltya, "\n")
-debug && println("Schur")
-    d,v = eig(a)
-    f   = schurfact(a)
-    @test_approx_eq f[:vectors]*f[:Schur]*f[:vectors]' a
-    @test_approx_eq sort(real(f[:values])) sort(real(d))
-    @test_approx_eq sort(imag(f[:values])) sort(imag(d))
-    @test istriu(f[:Schur]) || eltype(a)<:Real
-    @test_approx_eq full(f) a
-    @test_throws KeyError f[:A]
+    debug && println("\ntype of a: ", eltya, "\n")
+    debug && println("Schur")
+        d,v = eig(a)
+        f   = schurfact(a)
+        @test_approx_eq f[:vectors]*f[:Schur]*f[:vectors]' a
+        @test_approx_eq sort(real(f[:values])) sort(real(d))
+        @test_approx_eq sort(imag(f[:values])) sort(imag(d))
+        @test istriu(f[:Schur]) || eltype(a)<:Real
+        @test_approx_eq full(f) a
+        @test_throws KeyError f[:A]
 
-debug && println("Reorder Schur")
-    # use asym for real schur to enforce tridiag structure
-    # avoiding partly selection of conj. eigenvalues
-    ordschura = eltya <: Complex ? a : asym
-    S = schurfact(ordschura)
-    select = bitrand(n)
-    O = ordschur(S, select)
-    sum(select) != 0 && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
-    @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
-    @test_throws KeyError f[:A]
-    Snew = Base.LinAlg.Schur(copy(S.T), copy(S.Z), copy(S.values))
-    SchurNew = ordschur!(Snew, select)
-    @test O[:vectors] ≈ SchurNew[:vectors]
-    @test O[:Schur] ≈ SchurNew[:Schur]
+    debug && println("Reorder Schur")
+        # use asym for real schur to enforce tridiag structure
+        # avoiding partly selection of conj. eigenvalues
+        ordschura = eltya <: Complex ? a : asym
+        S = schurfact(ordschura)
+        select = bitrand(n)
+        O = ordschur(S, select)
+        sum(select) != 0 && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
+        @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
+        @test_throws KeyError f[:A]
+        Snew = Base.LinAlg.Schur(S.T, S.Z, S.values)
+        SchurNew = ordschur!(copy(Snew), select)
+        @test O[:vectors] ≈ SchurNew[:vectors]
+        @test O[:Schur] ≈ SchurNew[:Schur]
 
-debug && println("Generalized Schur")
-    a1_sf = a[1:n1, 1:n1]
-    a2_sf = a[n1+1:n2, n1+1:n2]
-    f = schurfact(a1_sf, a2_sf)
-    @test_approx_eq f[:Q]*f[:S]*f[:Z]' a1_sf
-    @test_approx_eq f[:Q]*f[:T]*f[:Z]' a2_sf
-    @test istriu(f[:S]) || eltype(a)<:Real
-    @test istriu(f[:T]) || eltype(a)<:Real
-    @test_throws KeyError f[:A]
+    debug && println("Generalized Schur")
+        if atype == "Array"
+            a1_sf = a[1:n1, 1:n1]
+            a2_sf = a[n1+1:n2, n1+1:n2]
+        else
+            a1_sf = sub(a, 1:n1, 1:n1)
+            a2_sf = sub(a, n1+1:n2, n1+1:n2)
+        end
+        f = schurfact(a1_sf, a2_sf)
+        @test_approx_eq f[:Q]*f[:S]*f[:Z]' a1_sf
+        @test_approx_eq f[:Q]*f[:T]*f[:Z]' a2_sf
+        @test istriu(f[:S]) || eltype(a)<:Real
+        @test istriu(f[:T]) || eltype(a)<:Real
+        @test_throws KeyError f[:A]
+    debug && println("Reorder Generalized Schur")
+        NS = schurfact(a1_sf, a2_sf)
+        # Currently just testing with selecting gen eig values < 1
+        select = abs2(NS[:values]) .< 1
+        m = sum(select)
+        S = ordschur(NS, select)
+        # Make sure that the new factorization stil factors matrix
+        @test_approx_eq S[:Q]*S[:S]*S[:Z]' a1_sf
+        @test_approx_eq S[:Q]*S[:T]*S[:Z]' a2_sf
+        # Make sure that we have sorted it correctly
+        @test_approx_eq NS[:values][find(select)] S[:values][1:m]
 
-debug && println("Reorder Generalized Schur")
-    a1_sf = a[1:n1, 1:n1]
-    a2_sf = a[n1+1:n2, n1+1:n2]
-    NS = schurfact(a1_sf, a2_sf)
-    # Currently just testing with selecting gen eig values < 1
-    select = abs2(NS[:values]) .< 1
-    m = sum(select)
-    S = ordschur(NS, select)
-    # Make sure that the new factorization stil factors matrix
-    @test_approx_eq S[:Q]*S[:S]*S[:Z]' a1_sf
-    @test_approx_eq S[:Q]*S[:T]*S[:Z]' a2_sf
-    # Make sure that we have sorted it correctly
-    @test_approx_eq NS[:values][find(select)] S[:values][1:m]
-
-    Snew = Base.LinAlg.GeneralizedSchur(copy(NS.S), copy(NS.T), copy(NS.alpha), copy(NS.beta), copy(NS.Q), copy(NS.Z))
-    SchurNew = ordschur!(Snew, select)
-    @test S[:Q] ≈ SchurNew[:Q]
-    @test S[:S] ≈ SchurNew[:S]
-    @test S[:T] ≈ SchurNew[:T]
-    @test S[:Z] ≈ SchurNew[:Z]
-    @test S[:alpha] ≈ SchurNew[:alpha]
-    @test S[:beta] ≈ SchurNew[:beta]
-    sS,sT,sQ,sZ = schur(a1_sf,a2_sf)
-    @test NS[:Q] ≈ sQ
-    @test NS[:T] ≈ sT
-    @test NS[:S] ≈ sS
-    @test NS[:Z] ≈ sZ
+        Snew = Base.LinAlg.GeneralizedSchur(NS.S, NS.T, NS.alpha, NS.beta, NS.Q, NS.Z)
+        SchurNew = ordschur!(copy(Snew), select)
+        @test S[:Q] ≈ SchurNew[:Q]
+        @test S[:S] ≈ SchurNew[:S]
+        @test S[:T] ≈ SchurNew[:T]
+        @test S[:Z] ≈ SchurNew[:Z]
+        @test S[:alpha] ≈ SchurNew[:alpha]
+        @test S[:beta] ≈ SchurNew[:beta]
+        sS,sT,sQ,sZ = schur(a1_sf,a2_sf)
+        @test NS[:Q] ≈ sQ
+        @test NS[:T] ≈ sT
+        @test NS[:S] ≈ sS
+        @test NS[:Z] ≈ sZ
+    end
 end


### PR DESCRIPTION
These tests are added to make sure that the linear algebra functions work with `SubArray`s, as proposed in JuliaLang/LinearAlgebra.jl#299.
- Added loop over `Array` and `SubArray` in `eigen.jl`, and appropriately define `a`, `asym`, `apd`, `asym_sg`, `a_sg`, `a1_nsg`, and `a2_nsg` (and `a` again at the bottom`).
- Added loop over `Array` and `SubArray` in `schur.jl` and appropriately define `a`, `asym`, `apd`, `a1_sf`, and `a2_sf`.

Everything seems to work fine with `SubArray`s.
Edit: I've seen the whitespace errors, will fix when at a computer.
