### PR TITLE
Remove a spurious backtick in control flow manual

### DIFF
--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -195,7 +195,7 @@ conditional expression is anything but ``true`` or ``false``:
     ERROR: TypeError: non-boolean (Int64) used in boolean context
 
 This error indicates that the conditional was of the wrong type:
-:obj:`Int64`` rather than the required :obj:`Bool`.
+:obj:`Int64` rather than the required :obj:`Bool`.
 
 The so-called "ternary operator", ``?:``, is closely related to the
 ``if``-``elseif``-``else`` syntax, but is used where a conditional


### PR DESCRIPTION
Followup of #15371 against master, should merge cleanly this time
