### PR TITLE
Improve performance of zip

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -29,12 +29,12 @@ end
 zip(a) = Zip1(a)
 length(z::Zip1) = length(z.a)
 eltype{I}(::Type{Zip1{I}}) = Tuple{eltype(I)}
-start(z::Zip1) = (start(z.a),)
-function next(z::Zip1, st)
+@inline start(z::Zip1) = (start(z.a),)
+@inline function next(z::Zip1, st)
     n = next(z.a,st[1])
     return ((n[1],), (n[2],))
 end
-done(z::Zip1, st) = done(z.a,st[1])
+@inline done(z::Zip1, st) = done(z.a,st[1])
 
 immutable Zip2{I1, I2} <: AbstractZipIterator
     a::I1
@@ -43,13 +43,13 @@ end
 zip(a, b) = Zip2(a, b)
 length(z::Zip2) = min(length(z.a), length(z.b))
 eltype{I1,I2}(::Type{Zip2{I1,I2}}) = Tuple{eltype(I1), eltype(I2)}
-start(z::Zip2) = (start(z.a), start(z.b))
-function next(z::Zip2, st)
+@inline start(z::Zip2) = (start(z.a), start(z.b))
+@inline function next(z::Zip2, st)
     n1 = next(z.a,st[1])
     n2 = next(z.b,st[2])
     return ((n1[1], n2[1]), (n1[2], n2[2]))
 end
-done(z::Zip2, st) = done(z.a,st[1]) | done(z.b,st[2])
+@inline done(z::Zip2, st) = done(z.a,st[1]) | done(z.b,st[2])
 
 immutable Zip{I, Z<:AbstractZipIterator} <: AbstractZipIterator
     a::I
@@ -63,13 +63,13 @@ function tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
     Tuple{S, T.parameters...}
 end
 eltype{I,Z}(::Type{Zip{I,Z}}) = tuple_type_cons(eltype(I), eltype(Z))
-start(z::Zip) = tuple(start(z.a), start(z.z))
-function next(z::Zip, st)
+@inline start(z::Zip) = tuple(start(z.a), start(z.z))
+@inline function next(z::Zip, st)
     n1 = next(z.a, st[1])
     n2 = next(z.z, st[2])
     (tuple(n1[1], n2[1]...), (n1[2], n2[2]))
 end
-done(z::Zip, st) = done(z.a,st[1]) | done(z.z,st[2])
+@inline done(z::Zip, st) = done(z.a,st[1]) | done(z.z,st[2])
 
 # filter
 


### PR DESCRIPTION
Late in the process of #15356, I discovered that forcing inlining can greatly improve the performance of `zip`. The `zipsame` approach developed in that PR remains attractive, but I need a 3-iterator version, and this should be good enough for me to proceed with ReshapedArrays (which is my real goal here).

Benchmarks:

``` jl
function iter1!(A, B, C)
    @assert size(A) == size(B) == size(C)
    for I in eachindex(A, B, C)
        @inbounds A[I] = B[I]*C[I]
    end
    A
end

function iter3!(A, B, C)
    @assert length(A) == length(B) == length(C)
    for (IA, IB, IC) in zip(eachindex(A), eachindex(B), eachindex(C))
        @inbounds A[IA] = B[IB]*C[IC]
    end
    A
end

sz = (100,100,100,100);
rng = map(n->1:n, sz)
B = sub(rand(sz...), rng...)
C = sub(rand(sz...), rng...)
A = similar(B)
iter1!(A, B, C)
iter3!(A, B, C)
@time iter1!(A, B, C)
@time iter3!(A, B, C)
nothing
```

Results:

master:

```
  0.631552 seconds (197 allocations: 11.855 KB)
  2.735151 seconds (4 allocations: 160 bytes)
```

This PR:

```
  0.630054 seconds (159 allocations: 11.137 KB)
  0.796275 seconds (4 allocations: 160 bytes)
```

So a 3-4 fold improvement.
