### PR TITLE
Expand `Docs.doc!` support.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -177,23 +177,42 @@ end
 # =======================
 
 """
-    Docs.doc!(binding, str, sig)
+    Docs.doc!(str, binding, typesig)
 
-Adds a new docstring `str` to the docsystem for `binding` and signature `sig`.
+Adds a new docstring `str` to the docsystem for `binding` and signature `typesig`.
 """
-function doc!(b::Binding, str::DocStr, sig::ANY = Union{})
-    m = get!(meta(), b, MultiDoc())
-    if haskey(m.docs, sig)
+function doc!(str::DocStr, binding::Binding, typesig::ANY = Union{})
+    initmeta() # Initialise the current module's `#meta` dict.
+    multidoc = get!(meta(), binding, MultiDoc())
+    if haskey(multidoc.docs, typesig)
         # We allow for docstrings to be updated, but print a warning since it is possible
         # that over-writing a docstring *may* have been accidental.
-        warn("replacing docs for '$b :: $sig'.")
+        warn("replacing docs for '$binding :: $typesig'.")
     else
         # The ordering of docstrings for each Binding is defined by the order in which they
         # are initially added. Replacing a specific docstring does not change it's ordering.
-        push!(m.order, sig)
+        push!(multidoc.order, typesig)
     end
-    m.docs[sig] = str
-    return b
+    multidoc.docs[typesig] = str
+    return binding
+end
+
+# When the `object` is not already a `Binding` then try to convert it to one.
+function doc!(str::DocStr, object, typesig::ANY = Union{})
+    binding = aliasof(object, object)
+    binding ≡ object && error("cannot find binding for '$object'. Use '@doc' instead.")
+    doc!(str, binding, typesig)
+end
+
+# When the docstring is not already a `DocStr` object then convert it to one.
+function doc!(str, object, typesig::ANY = Union{})
+    data = Dict(
+        :source     => :(),
+        :path       => Base.source_path(),
+        :linenumber => unsafe_load(cglobal(:jl_lineno, Int)),
+        :module     => current_module(),
+    )
+    doc!(DocStr(str, data), object, typesig)
 end
 
 # Docstring lookup.
@@ -432,7 +451,7 @@ function objectdoc(str, def, expr, sig = :(Union{}))
     docstr  = esc(docexpr(str, metadata(expr)))
     quote
         $(esc(def))
-        $(doc!)($binding, $docstr, $(esc(sig)))
+        $(doc!)($docstr, $binding, $(esc(sig)))
     end
 end
 
@@ -538,9 +557,6 @@ function docm(meta, ex, define = true)
     # Don't try to redefine expressions. This is only needed for `Base` img gen since
     # otherwise calling `loaddocs` would redefine all documented functions and types.
     def = define ? x : nothing
-
-    # Initalise the module's docstring storage.
-    initmeta()
 
     # Method / macro definitions and "call" syntax.
     #

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -287,6 +287,42 @@ let a = @doc(DocsTest.multidoc),
     @test docstrings_equal(a, b)
 end
 
+
+module DynamicDocs
+
+function f end
+g(x) = x
+type T end
+abstract AT
+
+for each in (f, g, T, AT)
+    Docs.doc!("$each", each)
+end
+Docs.doc!("DynamicDocs.g(x)", g, Tuple{Any})
+
+end
+
+let d1 = @doc(DynamicDocs.f),
+    d2 = @doc(DynamicDocs.g),
+    d3 = @doc(DynamicDocs.T),
+    d4 = @doc(DynamicDocs.AT)
+
+    @test length(d1.meta[:results]) === 1
+    @test d1.meta[:results][1].text == "DynamicDocs.f"
+
+    @test length(d2.meta[:results]) === 2
+    @test meta(DynamicDocs)[@var(DynamicDocs.g)].order == [Union{}, Tuple{Any}]
+    @test d2.meta[:results][1].text == "DynamicDocs.g"
+    @test d2.meta[:results][2].text == "DynamicDocs.g(x)"
+
+    @test length(d3.meta[:results]) === 1
+    @test d3.meta[:results][1].text == "DynamicDocs.T"
+
+    @test length(d4.meta[:results]) === 1
+    @test d4.meta[:results][1].text == "DynamicDocs.AT"
+end
+
+
 "BareModule"
 baremodule BareModule
 


### PR DESCRIPTION
This allows `doc!` to handle objects such as functions and types in addition to the current `Binding` support. Also automatically converts normal strings into `DocStr` objects and adds expected metadata before registering the docstring with the docsystem.

Todos:
- Should `doc!` be able to add docs to non-`current_module` modules? I'd think not, but I'm open to arguments in favour.
- Add some documentation for `doc!`.
- Export the function.
- Handle `:path` and `:linenumber` data correctly. `@__LINE__` doesn't work in either `doc!` or `@doc` since it gets transformed (during parsing?) to an actual number. `Base.source_path`, and by extension `@__FILE__`, return `""` during bootstrap. This all makes file and line info currently quite worthless for `Base`, though non-`Base` modules do get the right file info at least. Any suggestions for getting accurate data here would be much appreciated :)
