### PR TITLE
RFC: Modifying base to play nicely with physical units

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -62,29 +62,21 @@ complex(z::Complex) = z
 flipsign(x::Complex, y::Real) = ifelse(signbit(y), -x, x)
 
 function show(io::IO, z::Complex)
-    if unitless(z) != z
-        print(io, "(")
-    end
-    r, i = reim(unitless(z))
+    r, i = reim(z)
     compact = limit_output(io)
-    Base.showcompact_lim(io, r)
+    showcompact_lim(io, r)
     if signbit(i) && !isnan(i)
         i = -i
         print(io, compact ? "-" : " - ")
     else
         print(io, compact ? "+" : " + ")
     end
-    Base.showcompact_lim(io, i)
+    showcompact_lim(io, i)
     if !(isa(i,Integer) && !isa(i,Bool) || isa(i,AbstractFloat) && isfinite(i))
         print(io, "*")
     end
     print(io, "im")
-    if unitless(z) != z
-        print(io, ") ")
-        print(io, unit(z))
-    end
 end
-
 show(io::IO, z::Complex{Bool}) =
     print(io, z == im ? "im" : "Complex($(z.re),$(z.im))")
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -62,21 +62,29 @@ complex(z::Complex) = z
 flipsign(x::Complex, y::Real) = ifelse(signbit(y), -x, x)
 
 function show(io::IO, z::Complex)
-    r, i = reim(z)
+    if unitless(z) != z
+        print(io, "(")
+    end
+    r, i = reim(unitless(z))
     compact = limit_output(io)
-    showcompact_lim(io, r)
+    Base.showcompact_lim(io, r)
     if signbit(i) && !isnan(i)
         i = -i
         print(io, compact ? "-" : " - ")
     else
         print(io, compact ? "+" : " + ")
     end
-    showcompact_lim(io, i)
+    Base.showcompact_lim(io, i)
     if !(isa(i,Integer) && !isa(i,Bool) || isa(i,AbstractFloat) && isfinite(i))
         print(io, "*")
     end
     print(io, "im")
+    if unitless(z) != z
+        print(io, ") ")
+        print(io, unit(z))
+    end
 end
+
 show(io::IO, z::Complex{Bool}) =
     print(io, z == im ? "im" : "Complex($(z.re),$(z.im))")
 

--- a/base/number.jl
+++ b/base/number.jl
@@ -59,3 +59,15 @@ one(x::Number)  = oftype(x,1)
 one{T<:Number}(::Type{T}) = convert(T,1)
 
 factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
+
+# Fallback methods for unit support
+# For numbers without units, nothing to be done in stripping units
+function unitless(x::Number)
+    @_inline_meta
+    x
+end
+# For numbers without units, the "unit" is multiplicative identity
+function unit(x::Number)
+    @_inline_meta
+    one(x)
+end


### PR DESCRIPTION
I'm interested and personally invested in getting Julia to support physical units. There are some places in base that could be modified to suppress the numerous override warnings that appear when using my physical unit package for Julia 0.5.0-dev, [Unitful.jl](https://github.com/ajkeller34/Unitful.jl). Advertisements aside, I believe some changes to base are going to be necessary for any units package that fully supports Ranges (`UnitRange`, `FloatRange`, etc.) to have a chance of integrating with Julia without emitting warnings. Here's a TL;DR version: `one(x)` is not logically the same as `oftype(x,1)` when working with quantities that have units (`one(x)` is defined as the multiplicative identity, which should not have units!), and sometimes we need to strip units for certain numerical operations and comparisons. This is especially obvious in `range.jl`.

Encouraged by @StefanKarpinski in this [julia-users thread](https://groups.google.com/d/msg/julia-users/BT4bP5VyaRY/e3xdTRgsAgAJ), here are some changes to base I'd appreciate having comments on. The change to `complex.jl` is not as important as the changes to `number.jl` and `range.jl`. I built Julia using a few-day-old version of master and find no test regressions with my modifications. I could use some help with benchmarking, however. This is my first PR for Julia and while I have read the guidelines for contributions, please advise if I should be doing something differently.

Thanks!
