### PR TITLE
Array TBAA clean up

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1090,7 +1090,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!(jl_is_expr(argi) && ((jl_expr_t*)argi)->head == amp_sym));
         jl_cgval_t ary = emit_expr(argi, ctx);
         JL_GC_POP();
-        return mark_or_box_ccall_result(builder.CreateBitCast(emit_arrayptr(boxed(ary, ctx)), lrt),
+        return mark_or_box_ccall_result(builder.CreateBitCast(emit_arrayptr(ary, ctx), lrt),
                                         retboxed, args[2], rt, static_rt, ctx);
     }
     if (fptr == (void(*)(void))&jl_value_ptr ||

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -276,9 +276,10 @@ static MDNode *tbaa_array;              // Julia array
 static MDNode *tbaa_arrayptr;               // The pointer inside a jl_array_t
 static MDNode *tbaa_arraysize;              // A size in a jl_array_t
 static MDNode *tbaa_arraylen;               // The len in a jl_array_t
-static MDNode *tbaa_sveclen;           // The len in a jl_svec_t
-static MDNode *tbaa_func;           // A jl_function_t
-static MDNode *tbaa_datatype;       // A jl_datatype_t
+static MDNode *tbaa_arrayflags;             // The flags in a jl_array_t
+static MDNode *tbaa_sveclen;            // The len in a jl_svec_t
+static MDNode *tbaa_func;               // A jl_function_t
+static MDNode *tbaa_datatype;           // A jl_datatype_t
 static MDNode *tbaa_const;          // Memory that is immutable by the time LLVM can see it
 
 // Basic DITypes
@@ -796,8 +797,7 @@ static void alloc_local(jl_sym_t *s, jl_codectx_t *ctx)
 static void maybe_alloc_arrayvar(jl_sym_t *s, jl_codectx_t *ctx)
 {
     jl_value_t *jt = ctx->vars[s].value.typ;
-    if (jl_is_array_type(jt) && jl_is_leaf_type(jt) && jl_is_long(jl_tparam1(jt)) &&
-        jl_unbox_long(jl_tparam1(jt)) != 1) {
+    if (arraytype_constshape(jt)) {
         // TODO: this optimization does not yet work with 1-d arrays, since the
         // length and data pointer can change at any time via push!
         // we could make it work by reloading the metadata when the array is
@@ -5125,6 +5125,7 @@ static void init_julia_llvm_env(Module *m)
     tbaa_arrayptr = tbaa_make_child("jtbaa_arrayptr",tbaa_array);
     tbaa_arraysize = tbaa_make_child("jtbaa_arraysize",tbaa_array);
     tbaa_arraylen = tbaa_make_child("jtbaa_arraylen",tbaa_array);
+    tbaa_arrayflags = tbaa_make_child("jtbaa_arrayflags",tbaa_array);
     tbaa_sveclen = tbaa_make_child("jtbaa_sveclen",tbaa_value);
     tbaa_func = tbaa_make_child("jtbaa_func",tbaa_value);
     tbaa_datatype = tbaa_make_child("jtbaa_datatype",tbaa_value);


### PR DESCRIPTION
- More consistently use `const jl_cgval_t&`
- TBAA node for arrayflags
- use `tbaa_const` for array size/len/ptr of high dimensional arrays.

I doubt there will be any performance improvement and this is mainly a clean up for other GC/array related stuff.
