### PR TITLE
Fix axpy! and add tests.

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -482,20 +482,19 @@ function axpy!(α, x::AbstractArray, y::AbstractArray)
 end
 
 function axpy!{Ti<:Integer,Tj<:Integer}(α, x::AbstractArray, rx::AbstractArray{Ti}, y::AbstractArray, ry::AbstractArray{Tj})
-    if length(x) != length(y)
-        throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
+    if length(rx) != length(ry)
+        throw(DimensionMismatch("rx has length $(length(rx)), but ry has length $(length(ry))"))
     elseif minimum(rx) < 1 || maximum(rx) > length(x)
         throw(BoundsError(x, rx))
     elseif minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError(y, ry))
-    elseif length(rx) != length(ry)
-        throw(ArgumentError("rx has length $(length(rx)), but ry has length $(length(ry))"))
     end
     for i = 1:length(rx)
         @inbounds y[ry[i]] += x[rx[i]]*α
     end
     y
 end
+
 
 # Elementary reflection similar to LAPACK. The reflector is not Hermitian but ensures that tridiagonalization of Hermitian matrices become real. See lawn72
 @inline function reflector!(x::AbstractVector)

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -84,9 +84,8 @@ y = ['a','b','c','d','e']
 @test_throws DimensionMismatch Base.LinAlg.axpy!(α,x,['g'])
 @test_throws BoundsError Base.LinAlg.axpy!(α,x,collect(-1:5),y,collect(1:7))
 @test_throws BoundsError Base.LinAlg.axpy!(α,x,collect(1:7),y,collect(-1:5))
-@test_throws ArgumentError Base.LinAlg.axpy!(α,x,collect(1:3),y,collect(1:5))
 @test_throws BoundsError Base.LinAlg.axpy!(α,x,collect(1:7),y,collect(1:7))
-@test_throws DimensionMismatch Base.LinAlg.axpy!(α,x,collect(1:2),['a','b'],collect(1:2))
+@test_throws DimensionMismatch Base.LinAlg.axpy!(α,x,collect(1:3),y,collect(1:5))
 
 @test_throws ArgumentError diag(rand(10))
 @test !issymmetric(ones(5,3))
@@ -198,6 +197,16 @@ let
     y = fill(zeros(Int, 2, 2), 3)
     @test LinAlg.axpy!(α, x, deepcopy(y)) == x .* Matrix{Int}[α]
     @test LinAlg.axpy!(α, x, deepcopy(y)) != Matrix{Int}[α] .* x
+end
+
+# test that LinAlg.axpy! works for x and y of different dimensions
+let
+    α = 5
+    x = 2:5
+    y = ones(Int, 2, 4)
+    rx = [1 4]
+    ry = [2 8]
+    @test LinAlg.axpy!(α, x, rx, y, ry) == [1 1 1 1; 11 1 1 26]
 end
 
 let


### PR DESCRIPTION
Fixed bug in LinAlg.axpy! and added test. Fixes JuliaLang/LinearAlgebra.jl#315. 

Is it convention for tests to explicit say `Base.LinAlg.axpy!`  vs `LinAlg.axpy!`  ?
