### PR TITLE
Added SubArray tests for linalg/matmul.jl and fixed Vector -> StridedVector in dot

### DIFF
--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -5,66 +5,65 @@ using Base.Test
 ## Test Julia fallbacks to BLAS routines
 
 # matrices with zero dimensions
-for i = 1:10
-    @test ones(0,5)*ones(5,3) == zeros(0,3)
-    @test ones(3,5)*ones(5,0) == zeros(3,0)
-    @test ones(3,0)*ones(0,4) == zeros(3,4)
-    @test ones(0,5)*ones(5,0) == zeros(0,0)
-    @test ones(0,0)*ones(0,4) == zeros(0,4)
-    @test ones(3,0)*ones(0,0) == zeros(3,0)
-    @test ones(0,0)*ones(0,0) == zeros(0,0)
-    @test Array(Float64, 5, 0) |> t -> t't == zeros(0,0)
-    @test Array(Float64, 5, 0) |> t -> t*t' == zeros(5,5)
-    @test Array(Complex128, 5, 0) |> t -> t't == zeros(0,0)
-    @test Array(Complex128, 5, 0) |> t -> t*t' == zeros(5,5)
-end
+@test ones(0,5)*ones(5,3) == zeros(0,3)
+@test ones(3,5)*ones(5,0) == zeros(3,0)
+@test ones(3,0)*ones(0,4) == zeros(3,4)
+@test ones(0,5)*ones(5,0) == zeros(0,0)
+@test ones(0,0)*ones(0,4) == zeros(0,4)
+@test ones(3,0)*ones(0,0) == zeros(3,0)
+@test ones(0,0)*ones(0,0) == zeros(0,0)
+@test Array(Float64, 5, 0) |> t -> t't == zeros(0,0)
+@test Array(Float64, 5, 0) |> t -> t*t' == zeros(5,5)
+@test Array(Complex128, 5, 0) |> t -> t't == zeros(0,0)
+@test Array(Complex128, 5, 0) |> t -> t*t' == zeros(5,5)
 
 # 2x2
-A = [1 2; 3 4]
-B = [5 6; 7 8]
-@test A*B == [19 22; 43 50]
-@test At_mul_B(A, B) == [26 30; 38 44]
-@test A_mul_Bt(A, B) == [17 23; 39 53]
-@test At_mul_Bt(A, B) == [23 31; 34 46]
-Ai = A+(0.5*im).*B
-Bi = B+(2.5*im).*A[[2,1],[2,1]]
-@test Ai*Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
-@test Ac_mul_B(Ai, Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
-@test A_mul_Bc(Ai, Bi) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
-@test Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
-@test_throws DimensionMismatch [1 2; 0 0; 0 0] * [1 2]
+let
+    AA = [1 2; 3 4]
+    BB = [5 6; 7 8]
+    AAi = AA+(0.5*im).*BB
+    BBi = BB+(2.5*im).*AA[[2,1],[2,1]]
+    for Atype = ["Array", "SubArray"], Btype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:2, 1:2)
+        B = Btype == "Array" ? BB : sub(BB, 1:2, 1:2)
+        @test A*B == [19 22; 43 50]
+        @test At_mul_B(A, B) == [26 30; 38 44]
+        @test A_mul_Bt(A, B) == [17 23; 39 53]
+        @test At_mul_Bt(A, B) == [23 31; 34 46]
 
+        Ai = Atype == "Array" ? AAi : sub(AAi, 1:2, 1:2)
+        Bi = Btype == "Array" ? BBi : sub(BBi, 1:2, 1:2)
+        @test Ai*Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
+        @test Ac_mul_B(Ai, Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
+        @test A_mul_Bc(Ai, Bi) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
+        @test Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
+        @test_throws DimensionMismatch [1 2; 0 0; 0 0] * [1 2]
+    end
+end
 # 3x3
-A = [1 2 3; 4 5 6; 7 8 9].-5
-B = [1 0 5; 6 -10 3; 2 -4 -1]
-@test A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
-@test Ac_mul_B(A, B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
-@test A_mul_Bc(A, B) == [-14 0 6; 4 -3 -3; 22 -6 -12]
-@test Ac_mul_Bc(A, B) == [6 -8 -6; 12 -9 -9; 18 -10 -12]
-Ai = A+(0.5*im).*B
-Bi = B+(2.5*im).*A[[2,1,3],[2,3,1]]
-@test Ai*Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
-@test Ac_mul_B(Ai, Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
-@test A_mul_Bc(Ai, Bi) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
-@test Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
-@test_throws DimensionMismatch [1 2 3; 0 0 0; 0 0 0] * [1 2 3]
+let
+    AA = [1 2 3; 4 5 6; 7 8 9].-5
+    BB = [1 0 5; 6 -10 3; 2 -4 -1]
+    AAi = AA+(0.5*im).*BB
+    BBi = BB+(2.5*im).*AA[[2,1,3],[2,3,1]]
+    for Atype = ["Array", "SubArray"], Btype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:3, 1:3)
+        B = Btype == "Array" ? BB : sub(BB, 1:3, 1:3)
+        @test A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
+        @test Ac_mul_B(A, B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
+        @test A_mul_Bc(A, B) == [-14 0 6; 4 -3 -3; 22 -6 -12]
+        @test Ac_mul_Bc(A, B) == [6 -8 -6; 12 -9 -9; 18 -10 -12]
 
+        Ai = Atype == "Array" ? AAi : sub(AAi, 1:3, 1:3)
+        Bi = Btype == "Array" ? BBi : sub(BBi, 1:3, 1:3)
+        @test Ai*Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
+        @test Ac_mul_B(Ai, Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
+        @test A_mul_Bc(Ai, Bi) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
+        @test Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
+        @test_throws DimensionMismatch [1 2 3; 0 0 0; 0 0 0] * [1 2 3]
+    end
+end
 # Generic integer matrix multiplication
-A = [1 2 3; 4 5 6] .- 3
-B = [2 -2; 3 -5; -4 7]
-@test A*B == [-7 9; -4 9]
-@test At_mul_Bt(A, B) == [-6 -11 15; -6 -13 18; -6 -15 21]
-A = ones(Int, 2, 100)
-B = ones(Int, 100, 3)
-@test A*B == [100 100 100; 100 100 100]
-A = rand(1:20, 5, 5) .- 10
-B = rand(1:20, 5, 5) .- 10
-@test At_mul_B(A, B) == A'*B
-@test A_mul_Bt(A, B) == A*B'
-v = [1,2]
-C = Array(Int, 2, 2)
-@test @inferred(A_mul_Bc!(C, v, v)) == [1 2; 2 4]
-
 # Generic AbstractArrays
 module MyArray15367
     using Base.Test
@@ -80,88 +79,168 @@ module MyArray15367
     @test_approx_eq A*b A.data*b
 end
 
-# Preallocated
-C = Array(Int, size(A, 1), size(B, 2))
-@test A_mul_B!(C, A, B) == A*B
-@test At_mul_B!(C, A, B) == A'*B
-@test A_mul_Bt!(C, A, B) == A*B'
-@test At_mul_Bt!(C, A, B) == A'*B'
-@test Base.LinAlg.Ac_mul_Bt!(C, A, B) == A'*B.'
+let
+    AA = [1 2 3; 4 5 6] .- 3
+    BB = [2 -2; 3 -5; -4 7]
+    for Atype = ["Array", "SubArray"], Btype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:2, 1:3)
+        B = Btype == "Array" ? BB : sub(BB, 1:3, 1:2)
+        @test A*B == [-7 9; -4 9]
+        @test At_mul_Bt(A, B) == [-6 -11 15; -6 -13 18; -6 -15 21]
+    end
+    AA = ones(Int, 2, 100)
+    BB = ones(Int, 100, 3)
+    for Atype = ["Array", "SubArray"], Btype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:2, 1:100)
+        B = Btype == "Array" ? BB : sub(BB, 1:100, 1:3)
+        @test A*B == [100 100 100; 100 100 100]
+    end
+    AA = rand(1:20, 5, 5) .- 10
+    BB = rand(1:20, 5, 5) .- 10
+    CC = Array(Int, size(AA, 1), size(BB, 2))
+    for Atype = ["Array", "SubArray"], Btype = ["Array", "SubArray"], Ctype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:5, 1:5)
+        B = Btype == "Array" ? BB : sub(BB, 1:5, 1:5)
+        C = Btype == "Array" ? CC : sub(CC, 1:5, 1:5)
+        @test At_mul_B(A, B) == A'*B
+        @test A_mul_Bt(A, B) == A*B'
+        # Preallocated
+        @test A_mul_B!(C, A, B) == A*B
+        @test At_mul_B!(C, A, B) == A'*B
+        @test A_mul_Bt!(C, A, B) == A*B'
+        @test At_mul_Bt!(C, A, B) == A'*B'
+        @test Base.LinAlg.Ac_mul_Bt!(C, A, B) == A'*B.'
 
-#test DimensionMismatch for generic_matmatmul
-@test_throws DimensionMismatch Base.LinAlg.Ac_mul_Bt!(C,A,ones(Int,4,4))
-@test_throws DimensionMismatch Base.LinAlg.Ac_mul_Bt!(C,ones(Int,4,4),B)
+        #test DimensionMismatch for generic_matmatmul
+        @test_throws DimensionMismatch Base.LinAlg.Ac_mul_Bt!(C,A,ones(Int,4,4))
+        @test_throws DimensionMismatch Base.LinAlg.Ac_mul_Bt!(C,ones(Int,4,4),B)
+    end
+    vv = [1,2]
+    CC = Array(Int, 2, 2)
+    for vtype = ["Array", "SubArray"], Ctype = ["Array", "SubArray"]
+        v = vtype == "Array" ? vv : sub(vv, 1:2)
+        C = Ctype == "Array" ? CC : sub(CC, 1:2, 1:2)
+        @test @inferred(A_mul_Bc!(C, v, v)) == [1 2; 2 4]
+    end
+end
 
 #and for generic_matvecmul
-A = rand(5,5)
-B = rand(5)
-@test_throws DimensionMismatch Base.LinAlg.generic_matvecmul!(zeros(6),'N',A,B)
-@test_throws DimensionMismatch Base.LinAlg.generic_matvecmul!(B,'N',A,zeros(6))
-
-v = [1,2,3]
-C = Array(Int, 3, 3)
-@test A_mul_Bt!(C, v, v) == v*v'
-vf = map(Float64,v)
-C = Array(Float64, 3, 3)
-@test A_mul_Bt!(C, v, v) == v*v'
+let
+    AA = rand(5,5)
+    BB = rand(5)
+    for Atype = ["Array", "SubArray"], Btype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:5, 1:5)
+        B = Btype == "Array" ? BB : sub(BB, 1:5)
+        @test_throws DimensionMismatch Base.LinAlg.generic_matvecmul!(zeros(6),'N',A,B)
+        @test_throws DimensionMismatch Base.LinAlg.generic_matvecmul!(B,'N',A,zeros(6))
+    end
+    vv = [1,2,3]
+    CC = Array(Int, 3, 3)
+    for vtype = ["Array", "SubArray"], Ctype = ["Array", "SubArray"]
+        v = vtype == "Array" ? vv : sub(vv, 1:3)
+        C = Ctype == "Array" ? CC : sub(CC, 1:3, 1:3)
+        @test A_mul_Bt!(C, v, v) == v*v'
+    end
+    vvf = map(Float64,vv)
+    CC = Array(Float64, 3, 3)
+    for vtype = ["Array", "SubArray"], Ctype = ["Array", "SubArray"]
+        vf = vtype == "Array" ? vvf : sub(vvf, 1:3)
+        C = Ctype == "Array" ? CC : sub(CC, 1:3, 1:3)
+        @test A_mul_Bt!(C, vf, vf) == vf*vf'
+    end
+end
 
 # fallbacks & such for BlasFloats
-A = rand(Float64,6,6)
-B = rand(Float64,6,6)
-C = zeros(Float64,6,6)
-@test Base.LinAlg.At_mul_Bt!(C,A,B) == A.'*B.'
-@test Base.LinAlg.A_mul_Bc!(C,A,B) == A*B.'
-@test Base.LinAlg.Ac_mul_B!(C,A,B) == A.'*B
+let
+    AA = rand(Float64,6,6)
+    BB = rand(Float64,6,6)
+    CC = zeros(Float64,6,6)
+    for Atype = ["Array", "SubArray"], Btype = ["Array", "SubArray"], Ctype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:6, 1:6)
+        B = Btype == "Array" ? BB : sub(BB, 1:6, 1:6)
+        C = Ctype == "Array" ? CC : sub(CC, 1:6, 1:6)
+        @test Base.LinAlg.At_mul_Bt!(C,A,B) == A.'*B.'
+        @test Base.LinAlg.A_mul_Bc!(C,A,B) == A*B.'
+        @test Base.LinAlg.Ac_mul_B!(C,A,B) == A.'*B
+    end
+end
 
 # matrix algebra with subarrays of floats (stride != 1)
-A = reshape(map(Float64,1:20),5,4)
-Aref = A[1:2:end,1:2:end]
-Asub = sub(A, 1:2:5, 1:2:4)
-b = [1.2,-2.5]
-@test (Aref*b) == (Asub*b)
-@test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
-@test A_mul_Bt(Asub, Asub) == A_mul_Bt(Aref, Aref)
-Ai = A .+ im
-Aref = Ai[1:2:end,1:2:end]
-Asub = sub(Ai, 1:2:5, 1:2:4)
-@test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
-@test A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
+let
+    A = reshape(map(Float64,1:20),5,4)
+    Aref = A[1:2:end,1:2:end]
+    Asub = sub(A, 1:2:5, 1:2:4)
+    b = [1.2,-2.5]
+    @test (Aref*b) == (Asub*b)
+    @test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
+    @test A_mul_Bt(Asub, Asub) == A_mul_Bt(Aref, Aref)
+    Ai = A .+ im
+    Aref = Ai[1:2:end,1:2:end]
+    Asub = sub(Ai, 1:2:5, 1:2:4)
+    @test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
+    @test A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
+end
+
 # issue #15286
-let C = zeros(8, 8), sC = sub(C, 1:2:8, 1:2:8), B = reshape(map(Float64,-9:10),5,4)
+let A = reshape(map(Float64, 1:20), 5, 4), C = zeros(8, 8), sC = sub(C, 1:2:8, 1:2:8), B = reshape(map(Float64,-9:10),5,4)
     @test At_mul_B!(sC, A, A) == A'*A
     @test At_mul_B!(sC, A, B) == A'*B
-end
-let Aim = A .- im, C = zeros(Complex128,8,8), sC = sub(C, 1:2:8, 1:2:8), B = reshape(map(Float64,-9:10),5,4) .+ im
+
+    Aim = A .- im
+    C = zeros(Complex128,8,8)
+    sC = sub(C, 1:2:8, 1:2:8)
+    B = reshape(map(Float64,-9:10),5,4) .+ im
     @test Ac_mul_B!(sC, Aim, Aim) == Aim'*Aim
     @test Ac_mul_B!(sC, Aim, B) == Aim'*B
 end
 
-
 # syrk & herk
-A = reshape(1:1503, 501, 3).-750.0
-res = Float64[135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759]
-@test At_mul_B(A, A) == res
-@test A_mul_Bt(A',A') == res
-cutoff = 501
-A = reshape(1:6*cutoff,2*cutoff,3).-(6*cutoff)/2
-Asub = sub(A, 1:2:2*cutoff, 1:3)
-Aref = A[1:2:2*cutoff, 1:3]
-@test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
-Ai = A .- im
-Asub = sub(Ai, 1:2:2*cutoff, 1:3)
-Aref = Ai[1:2:2*cutoff, 1:3]
-@test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
+let
+    AA = reshape(1:1503, 501, 3).-750.0
+    res = Float64[135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759]
+    for Atype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:501, 1:3)
+        @test At_mul_B(A, A) == res
+        @test A_mul_Bt(A',A') == res
+    end
+    cutoff = 501
+    A = reshape(1:6*cutoff,2*cutoff,3).-(6*cutoff)/2
+    Asub = sub(A, 1:2:2*cutoff, 1:3)
+    Aref = A[1:2:2*cutoff, 1:3]
+    @test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
+    Ai = A .- im
+    Asub = sub(Ai, 1:2:2*cutoff, 1:3)
+    Aref = Ai[1:2:2*cutoff, 1:3]
+    @test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
 
-@test_throws DimensionMismatch Base.LinAlg.syrk_wrapper!(zeros(5,5),'N',ones(6,5))
-@test_throws DimensionMismatch Base.LinAlg.herk_wrapper!(zeros(5,5),'N',ones(6,5))
+    @test_throws DimensionMismatch Base.LinAlg.syrk_wrapper!(zeros(5,5),'N',ones(6,5))
+    @test_throws DimensionMismatch Base.LinAlg.herk_wrapper!(zeros(5,5),'N',ones(6,5))
+end
 
 # matmul for types w/o sizeof (issue #1282)
-A = Array(Complex{Int},10,10)
-A[:] = complex(1,1)
-A2 = A^2
-@test A2[1,1] == 20im
+let
+    AA = fill(complex(1,1), 10, 10)
+    for Atype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:10, 1:10)
+        A2 = A^2
+        @test A2[1,1] == 20im
+    end
+end
 
-@test_throws DimensionMismatch scale!(zeros(5,5),ones(5),rand(5,6))
+let
+    AA = zeros(5, 5)
+    BB = ones(5)
+    CC = rand(5, 6)
+    for Atype = ["Array", "SubArray"],  Btype = ["Array", "SubArray"]
+        for  Ctype = ["Array", "SubArray"]
+            A = Atype == "Array" ? AA : sub(AA, 1:5, 1:5)
+            B = Btype == "Array" ? BB : sub(BB, 1:5)
+            C = Ctype == "Array" ? CC : sub(CC, 1:5, 1:6)
+
+            @test_throws DimensionMismatch scale!(A, B, C)
+        end
+    end
+end
 
 # issue #6450
 @test dot(Any[1.0,2.0], Any[3.5,4.5]) === 12.5
@@ -177,32 +256,39 @@ for elty in (Float32,Float64,Complex64,Complex128)
 end
 
 vecdot_(x,y) = invoke(vecdot, (Any,Any), x,y) # generic vecdot
-let A = [1+2im 3+4im; 5+6im 7+8im], B = [2+7im 4+1im; 3+8im 6+5im]
-    @test vecdot(A,B) == dot(vec(A),vec(B)) == vecdot_(A,B) == vecdot(float(A),float(B))
-    @test vecdot(Int[], Int[]) == 0 == vecdot_(Int[], Int[])
-    @test_throws MethodError vecdot(Any[], Any[])
-    @test_throws MethodError vecdot_(Any[], Any[])
-    for n1 = 0:2, n2 = 0:2, d in (vecdot, vecdot_)
-        if n1 != n2
-            @test_throws DimensionMismatch d(1:n1, 1:n2)
-        else
-            @test_approx_eq d(1:n1, 1:n2) vecnorm(1:n1)^2
+let AA = [1+2im 3+4im; 5+6im 7+8im], BB = [2+7im 4+1im; 3+8im 6+5im]
+    for Atype = ["Array", "SubArray"],  Btype = ["Array", "SubArray"]
+        A = Atype == "Array" ? AA : sub(AA, 1:2, 1:2)
+        B = Btype == "Array" ? BB : sub(BB, 1:2, 1:2)
+        @test vecdot(A,B) == dot(vec(A),vec(B)) == vecdot_(A,B) == vecdot(float(A),float(B))
+        @test vecdot(Int[], Int[]) == 0 == vecdot_(Int[], Int[])
+        @test_throws MethodError vecdot(Any[], Any[])
+        @test_throws MethodError vecdot_(Any[], Any[])
+        for n1 = 0:2, n2 = 0:2, d in (vecdot, vecdot_)
+            if n1 != n2
+                @test_throws DimensionMismatch d(1:n1, 1:n2)
+            else
+                @test_approx_eq d(1:n1, 1:n2) vecnorm(1:n1)^2
+            end
         end
     end
 end
 
 # Issue 11978
-A = Array(Matrix{Float64}, 2, 2)
-A[1,1] = eye(3)
-A[1,2] = eye(3,2)
-A[2,1] = eye(2,3)
-A[2,2] = eye(2)
-b = Array(Vector{Float64}, 2)
-b[1] = ones(3)
-b[2] = ones(2)
-@test A*b == Vector{Float64}[[2,2,1], [2,2]]
+let
+    A = Array(Matrix{Float64}, 2, 2)
+    A[1,1] = eye(3)
+    A[1,2] = eye(3,2)
+    A[2,1] = eye(2,3)
+    A[2,2] = eye(2)
+    b = Array(Vector{Float64}, 2)
+    b[1] = ones(3)
+    b[2] = ones(2)
+    @test A*b == Vector{Float64}[[2,2,1], [2,2]]
+end
 
 @test_throws ArgumentError Base.LinAlg.copytri!(ones(10,10),'Z')
+
 for elty in [Float32,Float64,Complex128,Complex64]
     @test_throws DimensionMismatch Base.LinAlg.gemv!(ones(elty,10),'N',rand(elty,10,10),ones(elty,11))
     @test_throws DimensionMismatch Base.LinAlg.gemv!(ones(elty,11),'N',rand(elty,10,10),ones(elty,10))
@@ -218,11 +304,17 @@ for elty in [Float32,Float64,Complex128,Complex64]
 end
 
 # 13593, #13488
-a = rand(3,3)
-b = rand(3,3)
-@test_throws ArgumentError A_mul_B!(a, a, b)
-@test_throws ArgumentError A_mul_B!(a, b, a)
-@test_throws ArgumentError A_mul_B!(a, a, a)
+let
+    aa = rand(3,3)
+    bb = rand(3,3)
+    for atype = ["Array", "SubArray"],  btype = ["Array", "SubArray"]
+        a = atype == "Array" ? aa : sub(aa, 1:3, 1:3)
+        b = btype == "Array" ? bb : sub(bb, 1:3, 1:3)
+        @test_throws ArgumentError A_mul_B!(a, a, b)
+        @test_throws ArgumentError A_mul_B!(a, b, a)
+        @test_throws ArgumentError A_mul_B!(a, a, a)
+    end
+end
 
 # Number types that lack conversion to the destination type (#14293)
 immutable RootInt


### PR DESCRIPTION
<s>First of all: I know there are many commits. They are to be squashed, but they are there for my own sake until this is (hopefully) ready to be merged.</s>

I've generally tried to do what I did in #15364, #15354, #15314, but I tried not to close my eyes and add `for Atype in ["Array", "SubArray"]` everywhere without thinking. Some cases I ignored were the ones already testing `SubArray` related problems, and also the `gemv!` tests. The latter was mostly due to the fact that `gemv!` is defined for `Strided*`, and the number of combinations of matrices of `Array` and `SubArray` is large. My concern was that these tests would take much longer to run, but for no real reason. I would love comments on this.

I also added `let` blocks around groups of tests with named matrices and vectors (`A`, `B`, ..., `b`, ...). This is because running all the tests in `julia/test/` defines a lot of variables that can potentially be used by mistake if all contributors are not equally careful or lucky. At some point I had removed a `A =` definition somewhere, and another `A` was used by mistake (and didn't cause a test fail by chance). This is not ideal, as there's a chance such a mistake is not caught. If people don't like them, I can remove them again.

Other points to be made
- The very first commit removes a 10 times loop, bit `i` is never used, so I removed it. Was there a reason simply couldn't infer from the test?
- In commit 4, `vf` was constructed, but an old `v` was used
- <s>fixed `dot` such that it is defined for `StridedVector` instead of `Vector`</s> This was not a good idea, and has been reverted.
