### PR TITLE
Fix arrayset codegen

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -772,6 +772,11 @@ JL_DLLEXPORT void jl_cell_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c)
     jl_cellset(a, jl_array_dim(a,0)-1, c);
 }
 
+JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a)
+{
+    return jl_array_data_owner(a);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -446,6 +446,7 @@ JL_DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_
 JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
 int jl_array_store_unboxed(jl_value_t *el_type);
 int jl_array_isdefined(jl_value_t **args, int nargs);
+JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 
 JL_DEFINE_MUTEX_EXT(codegen)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -3877,6 +3877,20 @@ module Test15264
 end
 @test Test15264.mod1 !== Base.mod1
 
-
 # check that medium-sized array is 64-byte aligned (#15139)
 @test Int(pointer(Vector{Float64}(1024))) % 64 == 0
+
+# PR #15413
+# Make sure arrayset can handle `Array{T}` (where `T` is a type and not a
+# `TypeVar`) without crashing
+let
+    function arrayset_unknown_dim{T}(::Type{T}, n)
+        Base.arrayset(reshape(Vector{T}(1), ones(Int, n)...), 2, 1)
+    end
+    arrayset_unknown_dim(Any, 1)
+    arrayset_unknown_dim(Any, 2)
+    arrayset_unknown_dim(Any, 3)
+    arrayset_unknown_dim(Int, 1)
+    arrayset_unknown_dim(Int, 2)
+    arrayset_unknown_dim(Int, 3)
+end


### PR DESCRIPTION
When inference failed to infer the array dimensions.

I don't know if this path can actually be triggered in real code (that doesn't call `Base.arrayset` directly) but since we have the logic there to handle this case, this should be handled correctly....

I'd also like to kill this branch in the fast path soon....

Add backport label although the backported version might need to be tweaked due to the codegen changes.
