### PR TITLE
Re-enable custom docstring types.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -127,7 +127,7 @@ linenumber, source code, and fielddocs.
 """
 type DocStr
     text   :: UTF8String
-    object :: Nullable{Markdown.MD}
+    object :: Nullable
     data   :: Dict{Symbol, Any}
 
     DocStr(text::AbstractString, data = Dict()) = new(text, Nullable(), data)
@@ -233,11 +233,13 @@ function doc(binding::Binding, sig::Type = Union)
             end
         end
         # Get parsed docs and concatenate them.
-        md = Markdown.MD(map(parsedoc, results))
+        md = catdoc(map(parsedoc, results)...)
         # Save metadata in the generated markdown.
-        md.meta[:results] = results
-        md.meta[:binding] = binding
-        md.meta[:typesig] = sig
+        if isa(md, Markdown.MD)
+            md.meta[:results] = results
+            md.meta[:binding] = binding
+            md.meta[:typesig] = sig
+        end
         return md
     end
 end

--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -32,7 +32,7 @@ function HTML(xs...)
 end
 
 writemime(io::IO, ::MIME"text/html", h::HTML) = print(io, h.content)
-writemime(io::IO, ::MIME"text/html", h::HTML{Function}) = h.content(io)
+writemime{F <: Function}(io::IO, ::MIME"text/html", h::HTML{F}) = h.content(io)
 
 """
     @html_str -> Docs.HTML
@@ -69,7 +69,7 @@ type Text{T}
 end
 
 print(io::IO, t::Text) = print(io, t.content)
-print(io::IO, t::Text{Function}) = t.content(io)
+print{F <: Function}(io::IO, t::Text{F}) = t.content(io)
 writemime(io::IO, ::MIME"text/plain", t::Text) = print(io, t)
 
 """
@@ -335,7 +335,7 @@ function docsearch(haystack::Array, needle)
     false
 end
 function docsearch(haystack, needle)
-    warn_once("unable to search documentation of type $(typeof(haystack))")
+    Base.warn_once("unable to search documentation of type $(typeof(haystack))")
     false
 end
 


### PR DESCRIPTION
Custom docstring support was lost in #15266. This remedies the regressions introduced there as well as fixing `Text` and `HTML` display signatures that were also broken, likely when `Function`
became an abstract type, and had gone unnoticed.

Also adds a test case based on PyPlot to hopefully avoid future regressions.

Fixes #15424.

@stevengj, I've been having trouble loading PyPlot and encountered the following error

```
LLVM ERROR: Program used external function 'julia_getindex_23100' which could not be resolved!
```

during pre-compilation, which doesn't seem to be related to the docsystem issue as far as I can see. Would you be able to confirm locally whether this pr fixes PyPlot? Thanks.
