### PR TITLE
WIP: Disentangle arrays in iteration

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -964,8 +964,8 @@ function isequal(A::AbstractArray, B::AbstractArray)
     if isa(A,Range) != isa(B,Range)
         return false
     end
-    for i in eachindex(A,B)
-        if !isequal(A[i], B[i])
+    for (a, b) in zip(A, B)
+        if !isequal(a, b)
             return false
         end
     end
@@ -973,12 +973,11 @@ function isequal(A::AbstractArray, B::AbstractArray)
 end
 
 function lexcmp(A::AbstractArray, B::AbstractArray)
-    nA, nB = length(A), length(B)
-    for i = 1:min(nA, nB)
-        res = lexcmp(A[i], B[i])
+    for (a, b) in zip(A, B)
+        res = lexcmp(a, b)
         res == 0 || return res
     end
-    return cmp(nA, nB)
+    return cmp(length(A), length(B))
 end
 
 function (==)(A::AbstractArray, B::AbstractArray)
@@ -988,8 +987,8 @@ function (==)(A::AbstractArray, B::AbstractArray)
     if isa(A,Range) != isa(B,Range)
         return false
     end
-    for i in eachindex(A,B)
-        if !(A[i]==B[i])
+    for (a, b) in zip(A, B)
+        if !(a == b)
             return false
         end
     end

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -13,8 +13,8 @@ for f in (:-, :~, :conj, :sign)
     @eval begin
         function ($f)(A::AbstractArray)
             F = similar(A)
-            for i in eachindex(A)
-                F[i] = ($f)(A[i])
+            for (iF, iA) in zip(eachindex(F), eachindex(A))
+                F[iF] = ($f)(A[iA])
             end
             return F
         end
@@ -28,8 +28,8 @@ imag(A::AbstractArray) = reshape([ imag(x) for x in A ], size(A))
 
 function !(A::AbstractArray{Bool})
     F = similar(A)
-    for i in eachindex(A)
-        F[i] = !A[i]
+    for (iF, iA) in zip(eachindex(F), eachindex(A))
+        F[iF] = !A[iA]
     end
     return F
 end
@@ -66,35 +66,29 @@ for (f,F) in ((:+,   AddFun()),
     @eval begin
         function ($f){S,T}(A::Range{S}, B::Range{T})
             F = similar(A, promote_op($F,S,T), promote_shape(size(A),size(B)))
-            i = 1
-            for (a,b) in zip(A,B)
-                @inbounds F[i] = ($f)(a, b)
-                i += 1
+            for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
+                @inbounds F[iF] = ($f)(A[iA], B[iB])
             end
             return F
         end
         function ($f){S,T}(A::AbstractArray{S}, B::Range{T})
             F = similar(A, promote_op($F,S,T), promote_shape(size(A),size(B)))
-            i = 1
-            for b in B
-                @inbounds F[i] = ($f)(A[i], b)
-                i += 1
+            for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
+                @inbounds F[iF] = ($f)(A[iA], B[iB])
             end
             return F
         end
         function ($f){S,T}(A::Range{S}, B::AbstractArray{T})
             F = similar(B, promote_op($F,S,T), promote_shape(size(A),size(B)))
-            i = 1
-            for a in A
-                @inbounds F[i] = ($f)(a, B[i])
-                i += 1
+            for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
+                @inbounds F[iF] = ($f)(A[iA], B[iB])
             end
             return F
         end
         function ($f){S,T}(A::AbstractArray{S}, B::AbstractArray{T})
             F = similar(A, promote_op($F,S,T), promote_shape(size(A),size(B)))
-            for i in eachindex(A,B)
-                @inbounds F[i] = ($f)(A[i], B[i])
+            for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
+                @inbounds F[iF] = ($f)(A[iA], B[iB])
             end
             return F
         end
@@ -116,15 +110,15 @@ for (f,F) in ((:.+,  DotAddFun()),
     @eval begin
         function ($f){T}(A::Number, B::AbstractArray{T})
             F = similar(B, promote_array_type($F,typeof(A),T))
-            for i in eachindex(B)
-                @inbounds F[i] = ($f)(A, B[i])
+            for (iF, iB) in zip(eachindex(F), eachindex(B))
+                @inbounds F[iF] = ($f)(A, B[iB])
             end
             return F
         end
         function ($f){T}(A::AbstractArray{T}, B::Number)
             F = similar(A, promote_array_type($F,typeof(B),T))
-            for i in eachindex(A)
-                @inbounds F[i] = ($f)(A[i], B)
+            for (iF, iA) in zip(eachindex(F), eachindex(A))
+                @inbounds F[iF] = ($f)(A[iA], B)
             end
             return F
         end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -140,8 +140,7 @@ Return the inverse permutation of `v`
 function invperm(a::AbstractVector)
     b = zero(a) # similar vector of zeros
     n = length(a)
-    @inbounds for i in eachindex(a)
-        j = a[i]
+    @inbounds for (i, j) in enumerate(a)
         ((1 <= j <= n) && b[j] == 0) ||
             throw(ArgumentError("argument is not a permutation"))
         b[j] = i

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -795,24 +795,24 @@ promote_array_type{S<:Union{Complex, Real}, AT<:AbstractFloat}(F, ::Type{S}, ::T
 function complex{S<:Real,T<:Real}(A::Array{S}, B::Array{T})
     if size(A) != size(B); throw(DimensionMismatch()); end
     F = similar(A, typeof(complex(zero(S),zero(T))))
-    for i in eachindex(A)
-        @inbounds F[i] = complex(A[i], B[i])
+    for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
+        @inbounds F[iF] = complex(A[iA], B[iB])
     end
     return F
 end
 
 function complex{T<:Real}(A::Real, B::Array{T})
     F = similar(B, typeof(complex(A,zero(T))))
-    for i in eachindex(B)
-        @inbounds F[i] = complex(A, B[i])
+    for (iF, iB) in zip(eachindex(F), eachindex(B))
+        @inbounds F[iF] = complex(A, B[iB])
     end
     return F
 end
 
 function complex{T<:Real}(A::Array{T}, B::Real)
     F = similar(A, typeof(complex(zero(T),B)))
-    for i in eachindex(A)
-        @inbounds F[i] = complex(A[i], B)
+    for (iF, iA) in zip(eachindex(F), eachindex(A))
+        @inbounds F[iF] = complex(A[iA], B)
     end
     return F
 end

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -223,7 +223,7 @@ for op in (:.+, :.-)
         ($op_){P<:GeneralPeriod}(x::GeneralPeriod,Y::StridedArray{P}) = ($op)(Y,x) |> ($op_)
         ($op_){P<:GeneralPeriod}(Y::StridedArray{P},x::GeneralPeriod) = ($op)(Y,x)
         ($op_){P<:GeneralPeriod, Q<:GeneralPeriod}(X::StridedArray{P}, Y::StridedArray{Q}) =
-            reshape(CompoundPeriod[($op_)(X[i],Y[i]) for i in eachindex(X, Y)], promote_shape(size(X),size(Y)))
+            reshape(CompoundPeriod[($op_)(x,y) for (x,y) in zip(X, Y)], promote_shape(size(X),size(Y)))
     end
 end
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -69,44 +69,44 @@ round{T<:Integer}(::Type{T}, x::AbstractFloat, r::RoundingMode) = trunc(T,round(
 for f in (:trunc,:floor,:ceil,:round)
     @eval begin
         function ($f){T,R}(::Type{T}, x::AbstractArray{R,1})
-            [ ($f)(T, x[i])::T for i = 1:length(x) ]
+            [ ($f)(T, y)::T for y in x ]
         end
         function ($f){T,R}(::Type{T}, x::AbstractArray{R,2})
             [ ($f)(T, x[i,j])::T for i = 1:size(x,1), j = 1:size(x,2) ]
         end
         function ($f){T}(::Type{T}, x::AbstractArray)
-            reshape([ ($f)(T, x[i])::T for i in eachindex(x) ], size(x))
+            reshape([ ($f)(T, y)::T for y in x ], size(x))
         end
         function ($f){R}(x::AbstractArray{R,1}, digits::Integer, base::Integer=10)
-            [ ($f)(x[i], digits, base) for i = 1:length(x) ]
+            [ ($f)(y, digits, base) for y in x ]
         end
         function ($f){R}(x::AbstractArray{R,2}, digits::Integer, base::Integer=10)
             [ ($f)(x[i,j], digits, base) for i = 1:size(x,1), j = 1:size(x,2) ]
         end
         function ($f)(x::AbstractArray, digits::Integer, base::Integer=10)
-            reshape([ ($f)(x[i], digits, base) for i in eachindex(x) ], size(x))
+            reshape([ ($f)(y, digits, base) for y in x ], size(x))
         end
     end
 end
 
 function round{R}(x::AbstractArray{R,1}, r::RoundingMode)
-    [ round(x[i], r) for i = 1:length(x) ]
+    [ round(y, r) for y in x ]
 end
 function round{R}(x::AbstractArray{R,2}, r::RoundingMode)
     [ round(x[i,j], r) for i = 1:size(x,1), j = 1:size(x,2) ]
 end
 function round(x::AbstractArray, r::RoundingMode)
-    reshape([ round(x[i], r) for i in eachindex(x) ], size(x))
+    reshape([ round(y, r) for y in x ], size(x))
 end
 
 function round{T,R}(::Type{T}, x::AbstractArray{R,1}, r::RoundingMode)
-    [ round(T, x[i], r)::T for i = 1:length(x) ]
+    [ round(T, y, r)::T for y in x ]
 end
 function round{T,R}(::Type{T}, x::AbstractArray{R,2}, r::RoundingMode)
     [ round(T, x[i,j], r)::T for i = 1:size(x,1), j = 1:size(x,2) ]
 end
 function round{T}(::Type{T}, x::AbstractArray, r::RoundingMode)
-    reshape([ round(T, x[i], r)::T for i in eachindex(x) ], size(x))
+    reshape([ round(T, y, r)::T for y in x ], size(x))
 end
 
 # adapted from Matlab File Exchange roundsd: http://www.mathworks.com/matlabcentral/fileexchange/26212

--- a/base/io.jl
+++ b/base/io.jl
@@ -142,10 +142,10 @@ end
 write(s::IO, x::Bool)    = write(s, UInt8(x))
 write(to::IO, p::Ptr) = write(to, convert(UInt, p))
 
-function write(s::IO, a::AbstractArray)
+function write(s::IO, A::AbstractArray)
     nb = 0
-    for i in eachindex(a)
-        nb += write(s, a[i])
+    for a in A
+        nb += write(s, a)
     end
     return nb
 end
@@ -159,8 +159,8 @@ end
         return unsafe_write(s, pointer(a), sizeof(a))
     else
         nb = 0
-        for i in eachindex(a)
-            nb += write(s, a[i])
+        for b in a
+            nb += write(s, b)
         end
         return nb
     end

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -22,14 +22,8 @@ function generic_scale!(C::AbstractArray, X::AbstractArray, s::Number)
     if length(C) != length(X)
         throw(DimensionMismatch("first array has length $(length(C)) which does not match the length of the second, $(length(X))."))
     end
-    if size(C) == size(X)
-        for I in eachindex(C, X)
-            @inbounds C[I] = X[I]*s
-        end
-    else
-        for (IC, IX) in zip(eachindex(C), eachindex(X))
-            @inbounds C[IC] = X[IX]*s
-        end
+    for (IC, IX) in zip(eachindex(C), eachindex(X))
+        @inbounds C[IC] = X[IX]*s
     end
     C
 end
@@ -39,14 +33,8 @@ function generic_scale!(C::AbstractArray, s::Number, X::AbstractArray)
         throw(DimensionMismatch("first array has length $(length(C)) which does not
 match the length of the second, $(length(X))."))
     end
-    if size(C) == size(X)
-        for I in eachindex(C, X)
-            @inbounds C[I] = s*X[I]
-        end
-    else
-        for (IC, IX) in zip(eachindex(C), eachindex(X))
-            @inbounds C[IC] = s*X[IX]
-        end
+    for (IC, IX) in zip(eachindex(C), eachindex(X))
+        @inbounds C[IC] = s*X[IX]
     end
     C
 end
@@ -273,14 +261,8 @@ function vecdot(x::AbstractArray, y::AbstractArray)
         return dot(zero(eltype(x)), zero(eltype(y)))
     end
     s = zero(dot(x[1], y[1]))
-    if size(x) == size(y)
-        for I in eachindex(x, y)
-            @inbounds s += dot(x[I], y[I])
-        end
-    else
-        for (Ix, Iy) in zip(eachindex(x), eachindex(y))
-            @inbounds  s += dot(x[Ix], y[Iy])
-        end
+    for (Ix, Iy) in zip(eachindex(x), eachindex(y))
+        @inbounds  s += dot(x[Ix], y[Iy])
     end
     s
 end

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -87,9 +87,9 @@ subsetrows(X::AbstractVector, Y::AbstractArray, k) = Y[1:k]
 subsetrows(X::AbstractMatrix, Y::AbstractArray, k) = Y[1:k, :]
 
 function chkfinite(A::StridedMatrix)
-    for i = eachindex(A)
-        if !isfinite(A[i])
-            throw(ArgumentError("matrix contains NaNs"))
+    for a in A
+        if !isfinite(a)
+            throw(ArgumentError("matrix contains Infs or NaNs"))
         end
     end
     return true

--- a/base/math.jl
+++ b/base/math.jl
@@ -250,12 +250,12 @@ function frexp{T<:AbstractFloat}(x::T)
 end
 
 function frexp{T<:AbstractFloat}(A::Array{T})
-    f = similar(A)
-    e = Array(Int, size(A))
-    for i in eachindex(A)
-        f[i], e[i] = frexp(A[i])
+    F = similar(A)
+    E = Array(Int, size(A))
+    for (iF, iE, iA) in zip(eachindex(F), eachindex(E), eachindex(A))
+        F[iF], E[iE] = frexp(A[iA])
     end
-    return (f, e)
+    return (F, E)
 end
 
 modf(x) = rem(x,one(x)), trunc(x)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -477,7 +477,7 @@ macro vectorize_1arg(S,f)
         ($f){$T<:$S}(x::AbstractArray{$T,2}) =
             [ ($f)(x[i,j]) for i=1:size(x,1), j=1:size(x,2) ]
         ($f){$T<:$S}(x::AbstractArray{$T}) =
-            reshape([ ($f)(x[i]) for i in eachindex(x) ], size(x))
+            reshape([ ($f)(y) for y in x ], size(x))
     end
 end
 
@@ -485,13 +485,13 @@ macro vectorize_2arg(S,f)
     S = esc(S); f = esc(f); T1 = esc(:T1); T2 = esc(:T2)
     quote
         ($f){$T1<:$S, $T2<:$S}(x::($T1), y::AbstractArray{$T2}) =
-            reshape([ ($f)(x, y[i]) for i in eachindex(y) ], size(y))
+            reshape([ ($f)(x, z) for z in y ], size(y))
         ($f){$T1<:$S, $T2<:$S}(x::AbstractArray{$T1}, y::($T2)) =
-            reshape([ ($f)(x[i], y) for i in eachindex(x) ], size(x))
+            reshape([ ($f)(z, y) for z in x ], size(x))
 
         function ($f){$T1<:$S, $T2<:$S}(x::AbstractArray{$T1}, y::AbstractArray{$T2})
             shp = promote_shape(size(x),size(y))
-            reshape([ ($f)(x[i], y[i]) for i in eachindex(x,y) ], shp)
+            reshape([ ($f)(xx, yy) for (xx, yy) in zip(x, y) ], shp)
         end
     end
 end

--- a/base/primes.jl
+++ b/base/primes.jl
@@ -39,7 +39,7 @@ function _primesmask(lo::Int, hi::Int)
     sieve = ones(Bool, whi - wlo)
     hi < 49 && return sieve
     small_sieve = _primesmask(isqrt(hi))
-    @inbounds for i in eachindex(small_sieve)
+    @inbounds for i = 1:length(small_sieve)  # don't use eachindex here
         if small_sieve[i]; p = wheel_prime(i)
             j = wheel_index(2 * div(lo - p - 1, 2p) + 1)
             q = p * wheel_prime(j + 1); j = j & 7 + 1
@@ -64,7 +64,7 @@ function primesmask(lo::Int, hi::Int)
     wheel_sieve = _primesmask(max(7, lo), hi)
     lsi = lo - 1
     lwi = wheel_index(lsi)
-    @inbounds for i in eachindex(wheel_sieve)
+    @inbounds for i = 1:length(wheel_sieve)   # don't use eachindex here
         sieve[wheel_prime(i + lwi) - lsi] = wheel_sieve[i]
     end
     return sieve
@@ -86,7 +86,7 @@ function primes(lo::Int, hi::Int)
     sizehint!(list, floor(Int, hi / log(hi)))
     sieve = _primesmask(max(7, lo), hi)
     lwi = wheel_index(lo - 1)
-    @inbounds for i in eachindex(sieve)
+    @inbounds for i = 1:length(sieve)   # don't use eachindex here
         sieve[i] && push!(list, wheel_prime(i + lwi))
     end
     return list

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -576,8 +576,8 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)
     end
 
     function _any_abs_eq(v,n::Int)
-        for i in eachindex(v)
-            if abs(v[i])==n
+        for vv in v
+            if abs(vv)==n
                 return true
             end
         end


### PR DESCRIPTION
This PR is designed to allow us to expand our collection of array iterators (most proximally, to solve serious performance problems with `ReshapedArrays`). 
As a motivating example, suppose `copy!` is implemented like this:

``` jl
function copy!(dest, src)
    for I in eachindex(dest, src)
        dest[I] = src[I]
    end
    dest
end
```

Let's suppose that `src` and `dest` don't have an efficient iterator in common; in that case, the loop will be slow. This PR replaces such implementations with

``` jl
function copy!(dest, src)
    for (Idest, Isrc) in zip(eachindex(dest), eachindex(src))
        dest[Idest] = src[Isrc]
    end
    dest
end
```

leveraging recent improvements (and planned additional improvements) in the performance of `zip`.

This first commit addresses every use of `eachindex` in Base. I still have the classic `for i = 1:n` cases to go. (Where's that :janitor: emoticon when you need it?) I'm putting this out now in case there are reservations. It's also an almost guarantee that some workloads will see performance regressions. I'd rather find out now how bad they are, so: `runbenchmarks(ALL, vs = "JuliaLang/julia:master")`.
