### PR TITLE
Fix #14591, Add CPU Architecture and JIT type to versioninfo()

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -206,7 +206,7 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
     end
     println(io,             "  LAPACK: ",liblapack_name)
     println(io,             "  LIBM: ",libm_name)
-    println(io,             "  LLVM: libLLVM-",libllvm_version)
+    println(io,             "  LLVM: libLLVM-",libllvm_version," (", Sys.JIT, ", ", Sys.cpu_name, ")")
     if verbose
         println(io,         "Environment:")
         for (k,v) in ENV

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -7,6 +7,7 @@ export  CPU_CORES,
         WORD_SIZE,
         ARCH,
         MACHINE,
+        JIT,
         cpu_info,
         cpu_name,
         cpu_summary,
@@ -27,6 +28,7 @@ function __init__()
                                         Int(ccall(:jl_cpu_cores, Int32, ()))
     global const SC_CLK_TCK = ccall(:jl_SC_CLK_TCK, Clong, ())
     global const cpu_name = ccall(:jl_get_cpu_name, Any, ())::ByteString
+    global const JIT = ccall(:jl_get_JIT, Any, ())::ByteString
 end
 
 type UV_cpu_info_t

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -6,6 +6,7 @@
 #include <llvm/Support/Host.h>
 #include "julia.h"
 #include "julia_internal.h"
+#include "llvm-version.h"
 using namespace llvm;
 
 // --- library symbol lookup ---
@@ -137,4 +138,17 @@ jl_value_t *jl_get_cpu_name(void)
     const std::string& HostCPUName = llvm::sys::getHostCPUName();
 #endif
     return jl_pchar_to_string(HostCPUName.data(), HostCPUName.size());
+}
+
+extern "C" JL_DLLEXPORT
+jl_value_t *jl_get_JIT(void)
+{
+#if defined(USE_ORCJIT)
+    const std::string& HostJITName = "ORCJIT";
+#elif defined(USE_MCJIT)
+    const std::string& HostJITName = "MCJIT";
+#else
+    const std::string& HostJITName = "Unknown";
+#endif
+    return jl_pchar_to_string(HostJITName.data(), HostJITName.size());
 }


### PR DESCRIPTION
This should add CPU Architecture and JIT type to `versioninfo()`, as required in (fixes #14591)
