### PR TITLE
use of finalizers to release remote references/shared arrays early.

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -476,7 +476,17 @@ type Future <: AbstractRemoteRef
     Future(w, wh, id) = Future(w, wh, id, Nullable{Any}())
     Future(w, wh, id, v) = (r = new(w,wh,id,v); test_existing_ref(r))
 end
-finalize_future(f::Future) = (isnull(f.v) && send_del_client(f))
+
+function finalize_future(f::Future)
+    if f.where > 0
+        isnull(f.v) && send_del_client(f)
+        f.where = 0
+        f.whence = 0
+        f.id = 0
+        f.v = Nullable{Any}()
+    end
+    f
+end
 
 type RemoteChannel{T<:AbstractChannel} <: AbstractRemoteRef
     where::Int
@@ -505,9 +515,20 @@ function test_existing_ref(r::RemoteChannel)
     found = getkey(client_refs, r, false)
     !is(found,false) && (client_refs[r] == true) && return found
     client_refs[r] = true
-    finalizer(r, send_del_client)
+    finalizer(r, finalize_remote_channel)
     r
 end
+
+function finalize_remote_channel(r::RemoteChannel)
+    if r.where > 0
+        send_del_client(r)
+        r.where = 0
+        r.whence = 0
+        r.id = 0
+    end
+    r
+end
+
 
 let REF_ID::Int = 1
     global next_ref_id

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -216,13 +216,16 @@ function initialize_shared_array(S, s, onlocalhost, init, pids)
 end
 
 function finalize_refs{T,N}(S::SharedArray{T,N})
-    for r in S.refs
-        finalize(r)
+    if length(S.pids) > 0
+        for r in S.refs
+            finalize(r)
+        end
+        empty!(S.pids)
+        empty!(S.refs)
+        init_loc_flds(S)
+        finalize(S.s)
+        S.s = Array(T, ntuple(d->0,N))
     end
-    empty!(S.pids)
-    empty!(S.refs)
-    init_loc_flds(S)
-    S.s = Array(T, ntuple(d->0,N))
     S
 end
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -529,6 +529,7 @@ a good practice to explicitly call ``finalize`` on local instances of a ``Remote
 is not required on fetched ``Future``\ s. Explicitly calling ``finalize`` results in an immediate message sent to
 the remote node to go ahead and remove its reference to the value.
 
+Once finalized, a reference becomes invalid and cannot be used in any further calls.
 
 Shared Arrays
 -------------
@@ -712,6 +713,16 @@ If we create SharedArrays and time these functions, we get the following results
 The biggest advantage of ``advection_shared!`` is that it minimizes traffic
 among the workers, allowing each to compute for an extended time on the
 assigned piece.
+
+Shared Arrays and Distributed Garbage Collection
+------------------------------------------------
+
+Like remote references, shared arrays are also dependent on garbage collection
+on the creating node to release references from all participating workers. Code which
+creates many short lived shared array objects would benefit from explicitly
+finalizing these objects as soon as possible. This results in both memory and file
+handles mapping the shared segment being released sooner.
+
 
 .. _man-clustermanagers:
 


### PR DESCRIPTION
Enhance documentation and make the finalizers robust to multiple invocations.

The limitations of distributed gc keeps coming up. Having folks call `gc()` or a `@everywhere gc()` is not a good option.

Explicitly calling finalizers help a lot (not fully as effective as a `@everywhere gc()` which releases resources even sooner).

I suspect that both https://github.com/JuliaLang/julia/issues/15155 and https://github.com/JuliaLang/Distributed.jl/issues/35 are due to distributed gc not releasing resources quickly enough. 
