### PR TITLE
Pkg.submit has been moved to PkgDev in latest

### DIFF
--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -394,7 +394,8 @@ in the Images package::
   <edit code>                      # be sure to add a test for your bug
   Pkg.test("Images")               # make sure everything works now
   ;git commit -a -m "Fix foo by calling bar"   # write a descriptive message
-  Pkg.submit("Images")
+  using PkgDev
+  PkgDev.submit("Images")
 
 The last line will present you with a link to submit a pull request
 to incorporate your changes.


### PR DESCRIPTION
I get the following error

```
julia> Pkg.submit("Images")
ERROR: Pkg.submit(pkg[, commit]) has been moved to the package PkgDev.jl.
Run Pkg.add("PkgDev") to install PkgDev on Julia v0.5-
 in submit(::ASCIIString) at ./pkg.jl:262
 in eval(::Module, ::Any) at ./boot.jl:267
```
