### PR TITLE
dwarf info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,13 +226,13 @@ COMMA:=,
 define sysimg_builder
 $$(build_private_libdir)/sys$1.o: $$(build_private_libdir)/inference.ji $$(JULIAHOME)/VERSION $$(BASE_SRCS)
 	@$$(call PRINT_JULIA, cd $$(JULIAHOME)/base && \
-	$$(call spawn,$2) -C $$(JULIA_CPU_TARGET) --output-o $$(call cygpath_w,$$@) $$(JULIA_SYSIMG_BUILD_FLAGS) -f \
+	$$(call spawn,$3) $2 -C $$(JULIA_CPU_TARGET) --output-o $$(call cygpath_w,$$@) $$(JULIA_SYSIMG_BUILD_FLAGS) -f \
 		-J $$(call cygpath_w,$$<) sysimg.jl $$(RELBUILDROOT) \
 		|| { echo '*** This error is usually fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***' && false; } )
 .SECONDARY: $(build_private_libdir)/sys$1.o
 endef
-$(eval $(call sysimg_builder,,$(JULIA_EXECUTABLE_release)))
-$(eval $(call sysimg_builder,-debug,$(JULIA_EXECUTABLE_debug)))
+$(eval $(call sysimg_builder,,-O3,$(JULIA_EXECUTABLE_release)))
+$(eval $(call sysimg_builder,-debug,-O0,$(JULIA_EXECUTABLE_debug)))
 
 $(build_bindir)/stringreplace: $(JULIAHOME)/contrib/stringreplace.c | $(build_bindir)
 	@$(call PRINT_CC, $(HOSTCC) -o $(build_bindir)/stringreplace $(JULIAHOME)/contrib/stringreplace.c)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -489,7 +489,11 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
 {
     if (isboxed)
         return jl_pvalue_dillvmt;
-    if (jl_is_abstracttype(jt) || jl_is_uniontype(jt) || jl_is_array_type(jt) || jt == (jl_value_t*)jl_sym_type)
+    // always return the boxed representation for types with hidden content
+    if (jl_is_abstracttype(jt) || !jl_is_datatype(jt) || jl_is_array_type(jt) ||
+            jt == (jl_value_t*)jl_sym_type || jt == (jl_value_t*)jl_module_type ||
+            jt == (jl_value_t*)jl_simplevector_type || jt == (jl_value_t*)jl_datatype_type ||
+            jt == (jl_value_t*)jl_lambda_info_type)
         return jl_pvalue_dillvmt;
     if (jl_is_typector(jt) || jl_is_typevar(jt))
         return jl_pvalue_dillvmt;
@@ -516,7 +520,11 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
     #endif
     }
     #ifdef LLVM37
-    else if (jl_is_tuple_type(jt) || jl_is_structtype(jt)) {
+    else if (!jl_is_leaf_type(jt)) {
+        jdt->ditype = jl_pvalue_dillvmt;
+        return jl_pvalue_dillvmt;
+    }
+    else if (jl_is_structtype(jt)) {
         jl_datatype_t *jst = (jl_datatype_t*)jt;
         size_t ntypes = jl_datatype_nfields(jst);
         llvm::DICompositeType *ct = dbuilder->createStructType(

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -489,7 +489,7 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
 {
     if (isboxed)
         return jl_pvalue_dillvmt;
-    if (jl_is_abstracttype(jt) || jl_is_uniontype(jt) || jl_is_array_type(jt))
+    if (jl_is_abstracttype(jt) || jl_is_uniontype(jt) || jl_is_array_type(jt) || jt == (jl_value_t*)jl_sym_type)
         return jl_pvalue_dillvmt;
     if (jl_is_typector(jt) || jl_is_typevar(jt))
         return jl_pvalue_dillvmt;
@@ -2075,7 +2075,7 @@ static Value *boxed(const jl_cgval_t &vinfo, jl_codectx_t *ctx, bool gcrooted)
     if (gcrooted) {
         // make a gcroot for the new box
         // (unless the caller explicitly said this was unnecessary)
-        Value *froot = emit_local_slot(ctx);
+        Value *froot = emit_local_root(ctx);
         builder.CreateStore(box, froot);
     }
 

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -1,16 +1,21 @@
+#include "llvm-version.h"
 #include <llvm/ADT/SmallBitVector.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Intrinsics.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
+#ifdef LLVM36
+#include <llvm/IR/DIBuilder.h>
+#include <llvm/IR/DebugInfoMetadata.h>
+#endif
 
 #include <vector>
 #include <queue>
 
-#include "llvm-version.h"
 #include "julia.h"
 
 #ifdef LLVM37
@@ -668,24 +673,47 @@ void allocate_frame()
  *         Replace(slot, newslot) -> at InsertPoint(gc-frame)
  *         CreateStore(NULL, newslot) -> at InsertPoint(gc-frame)
  */
+#ifdef LLVM36
+    DIBuilder dbuilder(M, false);
+#endif
     unsigned argSpaceSize = 0;
-    Instruction *argSlot = NULL;
     for(BasicBlock::iterator I = gcframe->getParent()->begin(), E(gcframe); I != E; ) {
         Instruction* inst = &*I;
         ++I;
         if (CallInst* callInst = dyn_cast<CallInst>(inst)) {
             if (callInst->getCalledFunction() == gcroot_func) {
-                if (!argSlot) {
-                    argSlot = GetElementPtrInst::Create(LLVM37_param(NULL) gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, 2)));
-#ifdef JL_DEBUG_BUILD
-                    argSlot->setName("locals");
-#endif
-                    argSlot->insertAfter(gcframe);
-                    if (last_gcframe_inst == gcframe)
-                        last_gcframe_inst = argSlot;
-                }
-                Instruction *argTempi = GetElementPtrInst::Create(LLVM37_param(NULL) argSlot, ArrayRef<Value*>(ConstantInt::get(T_int32, argSpaceSize++)));
+                unsigned offset = 2 + argSpaceSize++;
+                Instruction *argTempi = GetElementPtrInst::Create(LLVM37_param(NULL) gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, offset)));
                 argTempi->insertAfter(last_gcframe_inst);
+#ifdef LLVM36
+                Metadata *md = ValueAsMetadata::getIfExists(callInst);
+                if (md) {
+                    Value *mdValue = MetadataAsValue::get(M.getContext(), md);
+                    for (User::use_iterator use = mdValue->use_begin(), usee = mdValue->use_end(); use != usee; ) {
+                        // need to recreate the dbg_declare accordingly -- sadly llvm can't handle this in RAUW
+                        User *user = use->getUser();
+                        ++use;
+                        if (CallInst* dbg = dyn_cast<CallInst>(user)) {
+                            Function *called = dbg->getCalledFunction();
+                            if (called && called->getIntrinsicID() == Intrinsic::dbg_declare) {
+                                DILocalVariable *dinfo = cast<DILocalVariable>(cast<MetadataAsValue>(dbg->getOperand(1))->getMetadata());
+                                DIExpression *expr = cast<DIExpression>(cast<MetadataAsValue>(dbg->getOperand(2))->getMetadata());
+                                SmallVector<uint64_t, 8> addr;
+                                addr.push_back(llvm::dwarf::DW_OP_plus);
+                                addr.push_back(offset * sizeof(void*));
+                                addr.append(expr->elements_begin(), expr->elements_end());
+                                expr = dbuilder.createExpression(addr);
+                                dbuilder.insertDeclare(gcframe, dinfo, expr,
+#ifdef LLVM37
+                                                dbg->getDebugLoc(),
+#endif
+                                                dbg->getParent());
+                                dbg->eraseFromParent();
+                            }
+                        }
+                    }
+                }
+#endif
                 callInst->replaceAllUsesWith(argTempi);
                 argTempi->takeName(callInst);
                 callInst->eraseFromParent();
@@ -702,6 +730,9 @@ void allocate_frame()
             }
         }
     }
+#ifdef LLVM36
+    dbuilder.finalize();
+#endif
 
     if (argSpaceSize + maxDepth == 0) {
         // 0 roots; remove gc frame entirely


### PR DESCRIPTION
this change ensures dwarf debug emission happens for every variable (in `-O0` mode). this is a bit simpler (since every variable and argument can be found in an alloca slot during codegen), but should perform the same (due to mem2reg, when not optimizations are enabled)
