### PR TITLE
WIP: Support iteration along an array dimension

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -422,6 +422,21 @@ function _maxlength(A, B, C...)
     max(length(A), _maxlength(B, C...))
 end
 
+# eachindex(A, d) and eachindex(A, (:, j))
+eachindex(A::AbstractArray, d::Integer) = 1:size(A, d)
+eachindex{d}(A::AbstractArray, ::Type{Val{d}}) = 1:size(A, d)
+eachindex{T,N}(A::AbstractArray{T,N}, indexes::NTuple{N,Union{Colon,Integer,UnitRange}}) = (@_inline_meta; _eachindex((), (), A, indexes...))
+_eachindex{N}(dims::Tuple{Int}, processed::NTuple{N}, A::AbstractArray) = eachindex(A, dims[1])
+_eachindex{N}(dims, processed::NTuple{N}, A::AbstractArray) = throw(DimensionMismatch("selection of $(length(dims)) dimensions not supported"))
+function _eachindex{M}(dims, processed::NTuple{M}, A::AbstractArray, c::Union{Colon,UnitRange}, indexes...)
+    @_inline_meta
+    _eachindex((dims..., M+1), (processed..., c), A, indexes...)
+end
+function _eachindex{M}(dims, processed::NTuple{M}, A::AbstractArray, i::Integer, indexes...)
+    @_inline_meta
+    _eachindex(dims, (processed..., i), A, indexes...)
+end
+
 isempty(a::AbstractArray) = (length(a) == 0)
 
 ## Conversions ##


### PR DESCRIPTION
This should allow us to support a much wider set of `AbstractArray`s with generic code. First, as demonstrated by the test script below, I think it will unify dense and sparse matrices, allowing us to write efficient algorithms for both (though it won't be maximally efficient without some help from @carnaval on stack-allocating immutables that contain references). Second, it should support Fortran-style arrays that don't start at 1.

This is WIP because we should add support for `Diagonal`, `Tridiagonal`, etc. `Tridiagonal` could be a bit tricky; we might want to consider changing its internal representation to an `Array{T}(3,n)` so that we can index without branching.

``` jl
# Test generic iteration for dense and sparse matrices
function matvecmul!(out::AbstractVector, A::AbstractMatrix, v::AbstractVector)
    size(A, 1) == length(out) && size(A, 2) == length(v) || throw(DimensionMismatch("oops"))
    fill!(out, 0)
    for j in eachindex(A, 2)
        vj = v[j]
        for i in eachindex(A, (:, j))
            out[i] += A[i,j]*vj
        end
    end
    out
end
matvecmul(A::AbstractMatrix, v::AbstractVector) = matvecmul!(Array(typeof(first(A)*first(v)), size(A, 1)), A, v)
```

This algorithm performs only as many multiplications as `A` has nonzeros.
