### PR TITLE
Disentangled arrays in iteration: repl, serialization and shared arrays

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -48,7 +48,7 @@ function complete_symbol(sym, ffunc)
             # We're now looking for a type
             fields = fieldnames(t)
             found = false
-            for i in 1:length(fields)
+            for i in eachindex(fields)
                 s == fields[i] || continue
                 t = t.types[i]
                 (Base.isstructtype(t) && !(t <: Tuple)) || return UTF8String[]

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -433,7 +433,7 @@ function process_backtrace(process_func::Function, top_function::Symbol, t::Vect
     n = 0
     last_frame = StackTraces.UNKNOWN
     count = 0
-    for i = 1:length(t)
+    for i = eachindex(t)
         lkup = StackTraces.lookup(t[i])
         if lkup === StackTraces.UNKNOWN
             continue

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -83,8 +83,8 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
         end
 
         # Wait till all the workers have mapped the segment
-        for i in 1:length(refs)
-            wait(refs[i])
+        for ref in refs
+            wait(ref)
         end
 
         # All good, immediately unlink the segment.
@@ -183,8 +183,8 @@ function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,In
     end
 
     # Wait till all the workers have mapped the segment
-    for i in 1:length(refs)
-        wait(refs[i])
+    for ref in refs
+        wait(ref)
     end
 
     S = SharedArray{T,N}(dims, pids, refs, filename)


### PR DESCRIPTION
As suggested in #15434, replaced occurrences of `for i=1:length(A)` by either `for a in A` or `for i in eachindex(A)` for flexibility and speed. 

I omitted 2 kinds of cases: 
- `for i=1:n` where `n` comes from outside (e.g. length of array being deserialized) or is used in function logic anyway (see `deserialize(s::SerializationState, t::DataType)` for example); 
- loops over custom indexes (e.g. `for i=2:length(A)`).

Let me know if there's a way to improve these 2 cases as well. 

cc: @timholy 
