### PR TITLE
Fixed no-inline getindex for UnitTriangular types

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -109,9 +109,9 @@ function full!{T,S}(A::UnitUpperTriangular{T,S})
     B
 end
 
-getindex{T,S}(A::UnitLowerTriangular{T,S}, i::Integer, j::Integer) = i > j ? A.data[i,j] : ifelse(i == j, one(T), zero(A.data[j,i]))
+getindex{T,S}(A::UnitLowerTriangular{T,S}, i::Integer, j::Integer) = i > j ? A.data[i,j] : ifelse(i == j, one(T), zero(T))
 getindex{T,S}(A::LowerTriangular{T,S}, i::Integer, j::Integer) = i >= j ? A.data[i,j] : zero(A.data[j,i])
-getindex{T,S}(A::UnitUpperTriangular{T,S}, i::Integer, j::Integer) = i < j ? A.data[i,j] : ifelse(i == j, one(T), zero(A.data[j,i]))
+getindex{T,S}(A::UnitUpperTriangular{T,S}, i::Integer, j::Integer) = i < j ? A.data[i,j] : ifelse(i == j, one(T), zero(T))
 getindex{T,S}(A::UpperTriangular{T,S}, i::Integer, j::Integer) = i <= j ? A.data[i,j] : zero(A.data[j,i])
 
 function setindex!(A::UpperTriangular, x, i::Integer, j::Integer)


### PR DESCRIPTION
The old method would fail the tests with

``` julia
Error During Test
  Test threw an exception of type UndefRefError
  Expression: B == A1
  UndefRefError: access to undefined reference
   in getindex(::Array{BigFloat,2}, ::Int64, ::Int64) at ./array.jl:241
   in getindex(::Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}}, ::Int64, ::Int64) at ./linalg/triangular.jl:114
   in _getindex(::Base.LinearSlow, ::Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}}, ::CartesianIndex{2}) at ./multidimensional.jl:359
   in getindex(::Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}}, ::CartesianIndex{2}) at ./abstractarray.jl:476
   in next(::Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}}, ::Tuple{CartesianRange{CartesianIndex{2}},CartesianIndex{2}}) at ./abstractarray.jl:400
   in next(::Base.Zip2{Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}},Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}}}, ::Tuple{Tuple{CartesianRange{CartesianIndex{2}},CartesianIndex{2}},Tuple{CartesianRange{CartesianIndex{2}},CartesianIndex{2}}}) at ./iterator.jl:48
   in ==(::Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}}, ::Base.LinAlg.UnitUpperTriangular{BigFloat,Array{BigFloat,2}}) at ./abstractarray.jl:990
   [inlined code] from /Users/kshyatt/Projects/julia/test/linalg/triangular.jl:159
   in anonymous at ./no file:4294967295
   in include(::ASCIIString) at ./boot.jl:264
   in include_from_node1(::UTF8String) at ./loading.jl:417
   in process_options(::Base.JLOptions) at ./client.jl:262
   in _start() at ./client.jl:318
ERROR: LoadError: There was an error during testing
 in error(::ASCIIString) at ./error.jl:21
 in record(::Base.Test.FallbackTestSet, ::Base.Test.Error) at ./test.jl:317
 in do_test(::Base.Test.Threw, ::Expr) at ./test.jl:215
 [inlined code] from /Users/kshyatt/Projects/julia/test/linalg/triangular.jl:159
 in anonymous at ./no file:4294967295
 in include(::ASCIIString) at ./boot.jl:264
 in include_from_node1(::UTF8String) at ./loading.jl:417
 in process_options(::Base.JLOptions) at ./client.jl:262
 in _start() at ./client.jl:318
while loading /Users/kshyatt/Projects/julia/test/linalg/triangular.jl, in expression starting on line 17
```

if run with `--inline=no`. This passes both with and without inlining.
