### PR TITLE
Minor cleanup of 'for' loops in test.jl

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -160,8 +160,8 @@ macro test(ex)
         # comparison indivudally
         comp_block = Expr(:block)
         comp_block.args = [:(
-                            $(terms[i]) = $(esc(ex.args[i]))
-                            ) for i in 1:n]
+                            $(t) = $(esc(x))
+                            ) for (t,x) in zip(terms, ex.args)]
         # The block should then evaluate whether the comparison
         # evaluates to true by splicing in the new terms into the
         # original comparsion. The block returns
@@ -651,7 +651,7 @@ function parse_testset_args(args)
     desc = nothing
     testsettype = nothing
     options = :(Dict{Symbol, Any}())
-    for arg in args[1:end]
+    for arg in args
         # a standalone symbol is assumed to be the test set we should use
         if isa(arg, Symbol)
             testsettype = esc(arg)
@@ -735,8 +735,7 @@ function test_approx_eq(va, vb, Eps, astr, bstr)
               "\n  ", bstr, " (length $(length(vb))) = ", vb)
     end
     diff = real(zero(eltype(va)))
-    for i = 1:length(va)
-        xa = va[i]; xb = vb[i]
+    for (xa, xb) = zip(va, vb)
         if isfinite(xa) && isfinite(xb)
             diff = max(diff, abs(xa-xb))
         elseif !isequal(xa,xb)


### PR DESCRIPTION
My first code contribution. A very minor clean up three 'for' loops in `test.jl`.
