### PR TITLE
Don't error under wine if VirtualAlloc fails

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -5,7 +5,7 @@
 
 #include <options.h>
 #include <uv.h>
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
 #include <unistd.h>
 #include <sched.h>
 #else

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -595,8 +595,21 @@ int main(int argc, char *argv[])
 {
     uv_setup_args(argc, argv); // no-op on Windows
 #else
+
+#if defined(_P64) && defined(JL_DEBUG_BUILD)
+static int is_running_under_wine()
+{
+    static const char * (CDECL *pwine_get_version)(void);
+    HMODULE hntdll = GetModuleHandle("ntdll.dll");
+    assert(hntdll);
+    pwine_get_version = (void *)GetProcAddress(hntdll, "wine_get_version");
+    return pwine_get_version != 0;
+}
+#endif
+
 static void lock_low32() {
 #if defined(_P64) && defined(JL_DEBUG_BUILD)
+    int under_wine = is_running_under_wine();
     // block usage of the 32-bit address space on win64, to catch pointer cast errors
     char *const max32addr = (char*)0xffffffffL;
     SYSTEM_INFO info;
@@ -605,7 +618,8 @@ static void lock_low32() {
     memset(&meminfo, 0, sizeof(meminfo));
     meminfo.BaseAddress = info.lpMinimumApplicationAddress;
     while ((char*)meminfo.BaseAddress < max32addr) {
-        VirtualQuery(meminfo.BaseAddress, &meminfo, sizeof(meminfo));
+        size_t nbytes = VirtualQuery(meminfo.BaseAddress, &meminfo, sizeof(meminfo));
+        assert(nbytes == sizeof(meminfo));
         if (meminfo.State == MEM_FREE) { // reserve all free pages in the first 4GB of memory
             char *first = (char*)meminfo.BaseAddress;
             char *last = first + meminfo.RegionSize;
@@ -618,7 +632,7 @@ static void lock_low32() {
             last = (char*)((long long)last & ~(info.dwAllocationGranularity - 1));
             if (last != first) {
                 p = VirtualAlloc(first, last - first, MEM_RESERVE, PAGE_NOACCESS); // reserve all memory in between
-                assert(p == first);
+                assert(under_wine || p == first);
             }
         }
         meminfo.BaseAddress += meminfo.RegionSize;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -609,6 +609,8 @@ static int is_running_under_wine()
 
 static void lock_low32() {
 #if defined(_P64) && defined(JL_DEBUG_BUILD)
+    // Wine currently has a that causes it to answer VirtualQuery incorrectly.
+    // See https://www.winehq.org/pipermail/wine-devel/2016-March/112188.html for details
     int under_wine = is_running_under_wine();
     // block usage of the 32-bit address space on win64, to catch pointer cast errors
     char *const max32addr = (char*)0xffffffffL;


### PR DESCRIPTION
Wine has a bug that makes VirtualQuery return the wrong answer in
some situations. Technical details can be found in my post to the
Wine mailing list at [1].

[1] https://www.winehq.org/pipermail/wine-devel/2016-March/112188.html
