### PR TITLE
Make linalg/symmetric test robust against rounding errors

### DIFF
--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -131,6 +131,9 @@ let n=10
 
         # rank
         let A = a[:,1:5]*a[:,1:5]'
+            # Make sure A is Hermitian even in the present of rounding error
+            # xianyi/OpenBLAS#729
+            A = (A' + A) / 2
             @test rank(A) == rank(Hermitian(A))
         end
 


### PR DESCRIPTION
See https://github.com/xianyi/OpenBLAS/issues/729 for more detail.

In short, when the BLAS routine uses `fma` for matrix multiplication, it is not guaranteed that the `a * a'` is exactly Hermitian (it might be off on eps level). IIUC, trying to fix this in BLAS will degrade performance by a lot and may not guarantee better precision in all cases either so this patch simply ignore the non-Hermitian part (not sure if this is the best way to do it though...).

This is the last aarch64 specific test failure (and it has been the only one for the past two months...).

c.c. @xianyi
