### PR TITLE
Support SSL_CERT_FILE and SSL_CERT_DIR env vars

### DIFF
--- a/base/libgit2/consts.jl
+++ b/base/libgit2/consts.jl
@@ -291,4 +291,24 @@ These priority levels correspond to the natural escalation logic (from higher to
                       CONFIG_LEVEL_LOCAL   = 4,
                       CONFIG_LEVEL_APP     = 5,
                       CONFIG_HIGHEST_LEVEL =-1)
+
+    """
+Global library options.
+
+These are used to select which global option to set or get and are used in `git_libgit2_opts()`.
+    """
+    @enum(GIT_OPT,  GET_MWINDOW_SIZE         = 0,
+                    SET_MWINDOW_SIZE         = 1,
+                    GET_MWINDOW_MAPPED_LIMIT = 2,
+                    SET_MWINDOW_MAPPED_LIMIT = 3,
+                    GET_SEARCH_PATH          = 4,
+                    SET_SEARCH_PATH          = 5,
+                    SET_CACHE_OBJECT_LIMIT   = 6,
+                    SET_CACHE_MAX_SIZE       = 7,
+                    ENABLE_CACHING           = 8,
+                    GET_CACHED_MEMORY        = 9,
+                    GET_TEMPLATE_PATH        = 10,
+                    SET_TEMPLATE_PATH        = 11,
+                    SET_SSL_CERT_LOCATIONS   = 12)
+
 end


### PR DESCRIPTION
Use OpenSSL environment variables `SSL_CERT_FILE` and `SSL_CERT_DIR` to point libgit2 to specific bundle of trusted CA certificates.

Relates to: #13399, #15128.
