### PR TITLE
Adds documentation for mod1 in mathematical operations. Fixes #15486

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2161,17 +2161,6 @@ See also [`sortperm!`](:func:`sortperm!`).
 sortperm
 
 """
-    mod2pi(x)
-
-Modulus after division by 2pi, returning in the range \[0,2pi).
-
-This function computes a floating point representation of the modulus after division by
-numerically exact 2pi, and is therefore not exactly the same as mod(x,2pi), which would
-compute the modulus of `x` relative to division by the floating-point number 2pi.
-"""
-mod2pi
-
-"""
     cumsum!(B, A, [dim])
 
 Cumulative sum of `A` along a dimension, storing the result in `B`. The dimension defaults
@@ -7584,18 +7573,6 @@ Get the vector of processes that have mapped the shared array.
 procs(::SharedArray)
 
 """
-    mod(x, y)
-
-Modulus after flooring division, returning in the range \[0,`y`), if `y` is positive, or
-(`y`,0\] if `y` is negative.
-
-```julia
-x == fld(x,y)*y + mod(x,y)
-```
-"""
-mod
-
-"""
     qr(A [,pivot=Val{false}][;thin=true]) -> Q, R, [p]
 
 Compute the (pivoted) QR factorization of `A` such that either `A = Q*R` or `A[:,p] = Q*R`.
@@ -7730,32 +7707,6 @@ get!(f::Function,collection,key)
 Matrix inverse.
 """
 inv
-
-"""
-    fld1(x, y)
-
-Flooring division, returning a value consistent with `mod1(x,y)`
-
-```julia
-x == fld(x,y)*y + mod(x,y)
-x == (fld1(x,y)-1)*y + mod1(x,y)
-```
-"""
-fld1
-
-"""
-    mod1(x, y)
-
-Modulus after flooring division, returning a value in the range `(0, y]`.
-"""
-mod1
-
-"""
-    fldmod1(x, y)
-
-Return `(fld1(x,y), mod1(x,y))`.
-"""
-fldmod1
 
 """
     @assert cond [text]

--- a/base/int.jl
+++ b/base/int.jl
@@ -88,8 +88,24 @@ rem(x::Unsigned, y::Signed) = rem(x,unsigned(abs(y)))
 fld(x::Signed, y::Unsigned) = div(x,y)-(signbit(x)&(rem(x,y)!=0))
 fld(x::Unsigned, y::Signed) = div(x,y)-(signbit(y)&(rem(x,y)!=0))
 
+
+"""
+    mod(x, y)
+
+Modulus after flooring division, returning in the range ``[0,y)``, if `y` is positive, or
+``(y,0]`` if `y` is negative.
+
+```julia
+x == fld(x,y)*y + mod(x,y)
+```
+"""
+function mod{T<:Integer}(x::T, y::T)
+    y == -1 && return T(0)   # avoid potential overflow in fld
+    x - fld(x,y)*y
+end
 mod(x::Signed, y::Unsigned) = rem(y+unsigned(rem(x,y)),y)
 mod(x::Unsigned, y::Signed) = rem(y+signed(rem(x,y)),y)
+mod{T<:Unsigned}(x::T, y::T) = rem(x,y)
 
 cld(x::Signed, y::Unsigned) = div(x,y)+(!signbit(x)&(rem(x,y)!=0))
 cld(x::Unsigned, y::Signed) = div(x,y)+(!signbit(y)&(rem(x,y)!=0))
@@ -101,12 +117,6 @@ rem{T<:BitSigned64}(x::T, y::T) = box(T,checked_srem_int(unbox(T,x),unbox(T,y)))
 div{T<:BitUnsigned64}(x::T, y::T) = box(T,checked_udiv_int(unbox(T,x),unbox(T,y)))
 rem{T<:BitUnsigned64}(x::T, y::T) = box(T,checked_urem_int(unbox(T,x),unbox(T,y)))
 
-# x == fld(x,y)*y + mod(x,y)
-mod{T<:Unsigned}(x::T, y::T) = rem(x,y)
-function mod{T<:Integer}(x::T, y::T)
-    y == -1 && return T(0)   # avoid potential overflow in fld
-    x - fld(x,y)*y
- end
 
 # fld(x,y) == div(x,y) - ((x>=0) != (y>=0) && rem(x,y) != 0 ? 1 : 0)
 fld{T<:Unsigned}(x::T, y::T) = div(x,y)

--- a/base/math.jl
+++ b/base/math.jl
@@ -353,6 +353,15 @@ const pi3o2_l  = 1.8369701987210297e-16 # convert(Float64, pi * BigFloat(3/2) - 
 const pi4o2_h  = 6.283185307179586      # convert(Float64, pi * BigFloat(2))
 const pi4o2_l  = 2.4492935982947064e-16 # convert(Float64, pi * BigFloat(2) - pi4o2_h)
 
+"""
+    mod2pi(x)
+
+Modulus after division by `2π`, returning in the range ``[0,2π)``.
+
+This function computes a floating point representation of the modulus after division by
+numerically exact `2π`, and is therefore not exactly the same as `mod(x,2π)`, which would
+compute the modulus of `x` relative to division by the floating-point number `2π`.
+"""
 function mod2pi(x::Float64) # or modtau(x)
 # with r = mod2pi(x)
 # a) 0 <= r < 2π  (note: boundary open or closed - a bit fuzzy, due to rem_pio2 implementation)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -241,14 +241,39 @@ const % = rem
 const ÷ = div
 .÷(x::Real, y::Real) = x÷y
 
-# mod returns in [0,y) or (y,0] (for negative y),
-# whereas mod1 returns in (0,y] or [y,0)
+
+"""
+    mod1(x, y)
+
+Modulus after flooring division, returning a value `r` such that `mod(r, y) == mod(x, y)`
+ in the range ``(0, y]`` for positive `y` and in the range ``[y,0)`` for negative `y`.
+"""
 mod1{T<:Real}(x::T, y::T) = (m=mod(x,y); ifelse(m==0, y, m))
-fld1{T<:Real}(x::T, y::T) = (m=mod(x,y); fld(x-m,y))
-fldmod1{T<:Real}(x::T, y::T) = (fld1(x,y), mod1(x,y))
 # efficient version for integers
 mod1{T<:Integer}(x::T, y::T) = mod(x+y-T(1),y)+T(1)
+
+
+"""
+    fld1(x, y)
+
+Flooring division, returning a value consistent with `mod1(x,y)`
+
+```julia
+x == fld(x,y)*y + mod(x,y)
+x == (fld1(x,y)-1)*y + mod1(x,y)
+```
+"""
+fld1{T<:Real}(x::T, y::T) = (m=mod(x,y); fld(x-m,y))
+# efficient version for integers
 fld1{T<:Integer}(x::T, y::T) = fld(x+y-T(1),y)
+
+"""
+    fldmod1(x, y)
+
+Return `(fld1(x,y), mod1(x,y))`.
+"""
+fldmod1{T<:Real}(x::T, y::T) = (fld1(x,y), mod1(x,y))
+# efficient version for integers
 fldmod1{T<:Integer}(x::T, y::T) = (fld1(x,y), mod1(x,y))
 
 # transpose

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -463,6 +463,7 @@ Function                     Description
 :func:`cld(x,y) <cld>`       ceiling division; quotient rounded towards ``+Inf``
 :func:`rem(x,y) <rem>`       remainder; satisfies ``x == div(x,y)*y + rem(x,y)``; sign matches ``x``
 :func:`mod(x,y) <mod>`       modulus; satisfies ``x == fld(x,y)*y + mod(x,y)``; sign matches ``y``
+:func:`mod1(x,y) <mod1>`     ``mod()`` with offset 1; returns ``r∈(0,y]`` for ``y>0`` or ``r∈[y,0)`` for ``y<0``, where ``mod(r, y) == mod(x, y)``
 :func:`mod2pi(x) <mod2pi>`   modulus with respect to 2pi;  ``0 <= mod2pi(x)  < 2pi``
 :func:`divrem(x,y) <divrem>` returns ``(div(x,y),rem(x,y))``
 :func:`fldmod(x,y) <fldmod>` returns ``(fld(x,y),mod(x,y))``

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -134,7 +134,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Modulus after flooring division, returning in the range [0,``y``\ ), if ``y`` is positive, or (``y``\ ,0] if ``y`` is negative.
+   Modulus after flooring division, returning in the range :math:`[0,y)`\ , if ``y`` is positive, or :math:`(y,0]` if ``y`` is negative.
 
    .. code-block:: julia
 
@@ -144,9 +144,9 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Modulus after division by 2pi, returning in the range [0,2pi).
+   Modulus after division by ``2π``\ , returning in the range :math:`[0,2π)`\ .
 
-   This function computes a floating point representation of the modulus after division by numerically exact 2pi, and is therefore not exactly the same as mod(x,2pi), which would compute the modulus of ``x`` relative to division by the floating-point number 2pi.
+   This function computes a floating point representation of the modulus after division by numerically exact ``2π``\ , and is therefore not exactly the same as ``mod(x,2π)``\ , which would compute the modulus of ``x`` relative to division by the floating-point number ``2π``\ .
 
 .. function:: rem(x, y)
               %(x, y)
@@ -186,7 +186,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Modulus after flooring division, returning a value in the range ``(0, y]``\ .
+   Modulus after flooring division, returning a value ``r`` such that ``mod(r, y) == mod(x, y)``  in the range :math:`(0, y]` for positive ``y`` and in the range :math:`[y,0)` for negative ``y``\ .
 
 .. function:: fldmod1(x, y)
 


### PR DESCRIPTION
Also there is a formatting issue for mod http://docs.julialang.org/en/release-0.4/stdlib/math/#Base.mod where the '``' are visible. Corrected that.
