### PR TITLE
Work around GMP misdetermining the dll prefix

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1872,6 +1872,9 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(GMP_OBJ_TARGET): $(GMP_SRC_TARGET) | $(build_shlibdir) $(build_includedir)
+ifeq ($(BUILD_OS),WINNT)
+	-mv $(BUILDDIR)/gmp-$(GMP_VER)/.libs/gmp.dll $(BUILDDIR)/gmp-$(GMP_VER)/.libs/libgmp.dll
+endif
 	$(INSTALL_M) $(BUILDDIR)/gmp-$(GMP_VER)/.libs/libgmp.*$(SHLIB_EXT)* $(build_shlibdir)
 	$(INSTALL_F) $(BUILDDIR)/gmp-$(GMP_VER)/gmp.h $(build_includedir)
 	$(INSTALL_NAME_CMD)libgmp.$(SHLIB_EXT) $@


### PR DESCRIPTION
When building julia with Clang, GMP mistakingly creates gmp.dll rather than libgmp.dll.
To fix this, add an extra move command, which will fail in the usual case, but doesn't
to any extra harm otherwise.
