### PR TITLE
Fix compilation on LLVM svn

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -68,6 +68,9 @@
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/Transforms/Instrumentation.h>
 #include <llvm/Transforms/Vectorize.h>
+#ifdef LLVM39
+#include <llvm/Transforms/Scalar/GVN.h>
+#endif
 #include <llvm/Support/Host.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -102,8 +102,12 @@ static void addOptimizationPasses(T *PM)
     PM->add(createJumpThreadingPass());         // Thread jumps
     PM->add(createDeadStoreEliminationPass());  // Delete dead stores
 #if !defined(INSTCOMBINE_BUG)
-    if (jl_options.opt_level >= 3)
+    if (jl_options.opt_level >= 3) {
+#ifdef LLVM39
+        initializeDemandedBitsPass(*PassRegistry::getPassRegistry());
+#endif
         PM->add(createSLPVectorizerPass());     // Vectorize straight-line code
+    }
 #endif
 
     PM->add(createAggressiveDCEPass());         // Delete dead instructions


### PR DESCRIPTION
Closes #14998

According to @vtjnash , the SLP Vectorizer initialization issue is a llvm bug. Is fixing it upstream a matter of adding the missing pass to https://github.com/llvm-mirror/llvm/blob/a3a17e4d45bbb44c6d8967b83e8569680a90553b/lib/Transforms/Vectorize/SLPVectorizer.cpp#L4578 and/or syncing the list from https://github.com/llvm-mirror/llvm/blob/a3a17e4d45bbb44c6d8967b83e8569680a90553b/lib/Transforms/Vectorize/SLPVectorizer.cpp#L3468 ?
