### PR TITLE
fix for loop for array indexing

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -113,7 +113,7 @@ function cumsum_kbn{T<:AbstractFloat}(v::AbstractVector{T})
 
     s = r[1] = v[1]
     c = zero(T)
-    for i=2:n
+    for i=2:n #Fixme iter
         vi = v[i]
         t = s + vi
         if abs(s) >= abs(vi)
@@ -128,6 +128,7 @@ function cumsum_kbn{T<:AbstractFloat}(v::AbstractVector{T})
 end
 
 # Uses K-B-N summation
+# TODO: Needs a separate LinearSlow method, this is only fast for LinearIndexing
 function cumsum_kbn{T<:AbstractFloat}(A::AbstractArray{T}, axis::Integer=1)
     dimsA = size(A)
     ndimsA = ndims(A)
@@ -179,8 +180,8 @@ end
 
 function ipermutedims(A::AbstractArray,perm)
     iperm = Array(Int,length(perm))
-    for i = 1:length(perm)
-        iperm[perm[i]] = i
+    for (i,p) = enumerate(perm)
+        iperm[p] = i
     end
     return permutedims(A,iperm)
 end

--- a/base/array.jl
+++ b/base/array.jl
@@ -681,7 +681,7 @@ end
 findfirst(testf::Function, A) = findnext(testf, A, 1)
 
 # returns the index of the previous non-zero element, or 0 if all zeros
-function findprev(A, start)
+function findprev(A, start::Integer)
     for i = start:-1:1
         A[i] != 0 && return i
     end
@@ -690,7 +690,7 @@ end
 findlast(A) = findprev(A, length(A))
 
 # returns the index of the matching element, or 0 if no matching
-function findprev(A, v, start)
+function findprev(A, v, start::Integer)
     for i = start:-1:1
         A[i] == v && return i
     end
@@ -699,7 +699,7 @@ end
 findlast(A, v) = findprev(A, v, length(A))
 
 # returns the index of the previous element for which the function returns true, or zero if it never does
-function findprev(testf::Function, A, start)
+function findprev(testf::Function, A, start::Integer)
     for i = start:-1:1
         testf(A[i]) && return i
     end
@@ -711,8 +711,8 @@ function find(testf::Function, A::AbstractArray)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return
     tmpI = Array(Int, 0)
-    for i = 1:length(A)
-        if testf(A[i])
+    for (i,a) = enumerate(A)
+        if testf(a)
             push!(tmpI, i)
         end
     end
@@ -725,8 +725,8 @@ function find(A::AbstractArray)
     nnzA = countnz(A)
     I = similar(A, Int, nnzA)
     count = 1
-    for i=1:length(A)
-        if A[i] != 0
+    for (i,a) in enumerate(A)
+        if a != 0
             I[count] = i
             count += 1
         end
@@ -823,8 +823,8 @@ end
 function findin(a, b)
     ind = Array(Int, 0)
     bset = Set(b)
-    @inbounds for i = 1:length(a)
-        a[i] in bset && push!(ind, i)
+    @inbounds for (i,ai) in enumerate(a)
+        ai in bset && push!(ind, i)
     end
     ind
 end
@@ -859,9 +859,9 @@ filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
 function filter!(f, a::Vector)
     insrt = 1
-    for curr = 1:length(a)
-        if f(a[curr])
-            a[insrt] = a[curr]
+    for acurr in a
+        if f(acurr)
+            a[insrt] = acurr
             insrt += 1
         end
     end
@@ -871,9 +871,9 @@ end
 
 function filter(f, a::Vector)
     r = Array(eltype(a), 0)
-    for i = 1:length(a)
-        if f(a[i])
-            push!(r, a[i])
+    for ai in a
+        if f(ai)
+            push!(r, ai)
         end
     end
     return r
@@ -886,8 +886,8 @@ function intersect(v1, vs...)
     ret = Array(eltype(v1),0)
     for v_elem in v1
         inall = true
-        for i = 1:length(vs)
-            if !in(v_elem, vs[i])
+        for vsi in vs
+            if !in(v_elem, vsi)
                 inall=false; break
             end
         end

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -238,7 +238,7 @@ end
 function rotl90(A::AbstractMatrix)
     m,n = size(A)
     B = similar(A,(n,m))
-    for i=1:m, j=1:n
+    for i=1:m, j=1:n #Fixme iter
         B[n-j+1,i] = A[i,j]
     end
     return B
@@ -246,7 +246,7 @@ end
 function rotr90(A::AbstractMatrix)
     m,n = size(A)
     B = similar(A,(n,m))
-    for i=1:m, j=1:n
+    for i=1:m, j=1:n #Fixme iter
         B[j,m-i+1] = A[i,j]
     end
     return B
@@ -254,7 +254,7 @@ end
 function rot180(A::AbstractMatrix)
     m,n = size(A)
     B = similar(A)
-    for i=1:m, j=1:n
+    for i=1:m, j=1:n #Fixme iter
         B[m-i+1,n-j+1] = A[i,j]
     end
     return B
@@ -277,8 +277,8 @@ function transpose!(B::AbstractMatrix,A::AbstractMatrix)
 
     if m*n<=4*transposebaselength
         @inbounds begin
-            for j = 1:n
-                for i = 1:m
+            for j = 1:n #Fixme iter
+                for i = 1:m #Fixme iter
                     B[j,i] = transpose(A[i,j])
                 end
             end
@@ -299,8 +299,8 @@ end
 function transposeblock!(B::AbstractMatrix,A::AbstractMatrix,m::Int,n::Int,offseti::Int,offsetj::Int)
     if m*n<=transposebaselength
         @inbounds begin
-            for j = offsetj+(1:n)
-                for i = offseti+(1:m)
+            for j = offsetj+(1:n) #Fixme iter
+                for i = offseti+(1:m) #Fixme iter
                     B[j,i] = transpose(A[i,j])
                 end
             end
@@ -322,8 +322,8 @@ function ctranspose!(B::AbstractMatrix,A::AbstractMatrix)
 
     if m*n<=4*transposebaselength
         @inbounds begin
-            for j = 1:n
-                for i = 1:m
+            for j = 1:n #Fixme iter
+                for i = 1:m #Fixme iter
                     B[j,i] = ctranspose(A[i,j])
                 end
             end
@@ -344,8 +344,8 @@ end
 function ctransposeblock!(B::AbstractMatrix,A::AbstractMatrix,m::Int,n::Int,offseti::Int,offsetj::Int)
     if m*n<=transposebaselength
         @inbounds begin
-            for j = offsetj+(1:n)
-                for i = offseti+(1:m)
+            for j = offsetj+(1:n) #Fixme iter
+                for i = offseti+(1:m) #Fixme iter
                     B[j,i] = ctranspose(A[i,j])
                 end
             end
@@ -362,8 +362,8 @@ function ctransposeblock!(B::AbstractMatrix,A::AbstractMatrix,m::Int,n::Int,offs
     return B
 end
 function ccopy!(B, A)
-    for i = 1:length(A)
-        B[i] = ctranspose(A[i])
+    for (i,j) = zip(eachindex(B),eachindex(A))
+        B[i] = ctranspose(A[j])
     end
 end
 
@@ -377,8 +377,8 @@ function ctranspose(A::AbstractMatrix)
 end
 ctranspose{T<:Real}(A::AbstractVecOrMat{T}) = transpose(A)
 
-transpose(x::AbstractVector) = [ transpose(x[j]) for i=1, j=1:size(x,1) ]
-ctranspose{T}(x::AbstractVector{T}) = T[ ctranspose(x[j]) for i=1, j=1:size(x,1) ]
+transpose(x::AbstractVector) = [ transpose(v) for i=1, v in x ]
+ctranspose{T}(x::AbstractVector{T}) = T[ ctranspose(v) for i=1, v in x ] #Fixme comprehension
 
 _cumsum_type{T<:Number}(v::AbstractArray{T}) = typeof(+zero(T))
 _cumsum_type(v) = typeof(v[1]+v[1])
@@ -391,7 +391,7 @@ for (f, f!, fp, op) = ((:cumsum, :cumsum!, :cumsum_pairwise!, :+),
         if n < 128
             @inbounds s_ = v[i1]
             @inbounds c[i1] = ($op)(s, s_)
-            for i = i1+1:i1+n-1
+            for i = i1+1:i1+n-1 #Fixme iter
                 @inbounds s_ = $(op)(s_, v[i])
                 @inbounds c[i] = $(op)(s, s_)
             end


### PR DESCRIPTION
This is the iteration fixes for the files abstractarray.jl ... arraymath.jl, see issue #15434 

There were quite a few cases where the fix was not obviuos because of one of these reasons:
- there was an offset in the iteration e.g. (`for i=2:length(A)`)
- iteration was done over certain dimensions of a matrix
- changes were too non-trivial for this PR,  I did not want to touch (and possibly mess up) `map_n!` and `map_to_n!`

However, `#Fixme iter` and `#Fixme comp` comments were added in these cases.
