### PR TITLE
Fix eachindex use in sertag()

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -43,10 +43,12 @@ const TAGS = Any[
 
 const ser_version = 3 # do not make changes without bumping the version #!
 
+const NTAGS = length(TAGS)
+
 function sertag(v::ANY)
     ptr = pointer_from_objref(v)
     ptags = convert(Ptr{Ptr{Void}}, pointer(TAGS))
-    @inbounds for i in eachindex(TAGS)
+    @inbounds for i in 1:NTAGS
         ptr == unsafe_load(ptags,i) && return (i+1)%Int32
     end
     return Int32(-1)


### PR DESCRIPTION
Only integer indices can work here.
Introduced by 9491dea349475af3f3cb86e7c5c1607fa04a62fb.
