### PR TITLE
faster A_mul_B! and * involving bidiagonal and tridiagonal matrices

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -29,8 +29,6 @@ function size(D::Diagonal,d::Integer)
     return d<=2 ? length(D.diag) : 1
 end
 
-fill!(D::Diagonal, x) = (fill!(D.diag, x); D)
-
 full(D::Diagonal) = diagm(D.diag)
 
 @inline function getindex(D::Diagonal, i::Int, j::Int)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -47,8 +47,6 @@ imag(A::UnitUpperTriangular) = UpperTriangular(triu!(imag(A.data),1))
 full(A::AbstractTriangular) = convert(Matrix, A)
 parent(A::AbstractTriangular) = A.data
 
-fill!(A::AbstractTriangular, x) = (fill!(A.data, x); A)
-
 # then handle all methods that requires specific handling of upper/lower and unit diagonal
 
 function convert{Tret,T,S}(::Type{Matrix{Tret}}, A::LowerTriangular{T,S})
@@ -376,6 +374,8 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 ######################
 
 A_mul_B!(A::Tridiagonal, B::AbstractTriangular) = A*full!(B)
+A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::Tridiagonal) = A_mul_B!(C, full(A), B)
+A_mul_B!(C::AbstractMatrix, A::Tridiagonal, B::AbstractTriangular) = A_mul_B!(C, A, full(B))
 A_mul_B!(C::AbstractVector, A::AbstractTriangular, B::AbstractVector) = A_mul_B!(A, copy!(C, B))
 A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
 A_mul_B!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -497,33 +497,3 @@ function convert{T}(::Type{SymTridiagonal{T}}, M::Tridiagonal)
         throw(ArgumentError("Tridiagonal is not symmetric, cannot convert to SymTridiagonal"))
     end
 end
-
-A_mul_B!(C::AbstractVector, A::Tridiagonal, B::AbstractVector) = A_mul_B_td!(C, A, B)
-A_mul_B!(C::AbstractMatrix, A::Tridiagonal, B::AbstractVecOrMat) = A_mul_B_td!(C, A, B)
-A_mul_B!(C::AbstractVecOrMat, A::Tridiagonal, B::AbstractVecOrMat) = A_mul_B_td!(C, A, B)
-
-function A_mul_B_td!(C::AbstractVecOrMat, A::Tridiagonal, B::AbstractVecOrMat)
-    nA = size(A,1)
-    nB = size(B,2)
-    if !(size(C,1) == size(B,1) == nA)
-        throw(DimensionMismatch("A has first dimension $nA, B has $(size(B,1)), C has $(size(C,1)) but all must match"))
-    end
-    if size(C,2) != nB
-        throw(DimensionMismatch("A has second dimension $nA, B has $(size(B,2)), C has $(size(C,2)) but all must match"))
-    end
-    l = A.dl
-    d = A.d
-    u = A.du
-    @inbounds begin
-        for j = 1:nB
-            b₀, b₊ = B[1, j], B[2, j]
-            C[1, j] = d[1]*b₀ + u[1]*b₊
-            for i = 2:nA - 1
-                b₋, b₀, b₊ = b₀, b₊, B[i + 1, j]
-                C[i, j] = l[i - 1]*b₋ + d[i]*b₀ + u[i]*b₊
-            end
-            C[nA, j] = l[nA - 1]*b₀ + d[nA]*b₊
-        end
-    end
-    C
-end

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -1681,3 +1681,43 @@ droptol!(x::SparseVector, tol, trim::Bool = true) = fkeep!(x, (i, x, tol) -> abs
 
 dropzeros!(x::SparseVector, trim::Bool = true) = fkeep!(x, (i, x, other) -> x != 0, nothing, trim)
 dropzeros(x::SparseVector, trim::Bool = true) = dropzeros!(copy(x), trim)
+
+function _fillnonzero!{Tv,Ti}(arr::SparseMatrixCSC{Tv, Ti}, val)
+    m, n = size(arr)
+    resize!(arr.colptr, n+1)
+    resize!(arr.rowval, m*n)
+    resize!(arr.nzval, m*n)
+    copy!(arr.colptr, 1:m:n*m+1)
+    fill!(arr.nzval, val)
+    index = 1
+    @inbounds for _ in 1:n
+        for i in 1:m
+            arr.rowval[index] = Ti(i)
+            index += 1
+        end
+    end
+    arr
+end
+
+function _fillnonzero!{Tv,Ti}(arr::SparseVector{Tv,Ti}, val)
+    n = arr.n
+    resize!(arr.nzind, n)
+    resize!(arr.nzval, n)
+    @inbounds for i in 1:n
+        arr.nzind[i] = Ti(i)
+    end
+    fill!(arr.nzval, val)
+    arr
+end
+
+import Base.fill!
+function fill!(A::Union{SparseVector, SparseMatrixCSC}, x)
+    T = eltype(A)
+    xT = convert(T, x)
+    if xT == zero(T)
+        fill!(A.nzval, xT)
+    else
+        _fillnonzero!(A, xT)
+    end
+    return A
+end

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -950,3 +950,20 @@ x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 15)
 @test collect(sort(x, by=abs)) == sort(collect(x), by=abs)
 @test collect(sort(x, by=sign)) == sort(collect(x), by=sign)
 @test collect(sort(x, by=inv)) == sort(collect(x), by=inv)
+
+#fill!
+for Tv in [Float32, Float64, Int64, Int32, Complex128]
+    for Ti in [Int16, Int32, Int64, BigInt]
+        sptypes = (SparseMatrixCSC{Tv, Ti}, SparseVector{Tv, Ti})
+        sizes = [(3, 4), (3,)]
+        for (siz, Sp) in zip(sizes, sptypes)
+            arr = rand(Tv, siz...)
+            sparr = Sp(arr)
+            fillval = rand(Tv)
+            fill!(sparr, fillval)
+            @test full(sparr) == fillval * ones(arr)
+            fill!(sparr, 0)
+            @test full(sparr) == zeros(arr)
+        end
+    end
+end


### PR DESCRIPTION
Two `A_mul_B!(C, A, B)` methods where `B` or `A, B` are tridiagonal are implemented. This gives faster matrix multiplication methods for some bi and tridiagonal argument combinations, which would fall back to full matrix multiplication before. See JuliaLang/LinearAlgebra.jl#263 and timings below.

```
begin
           import Base.LinAlg.A_mul_B!
           k = 1000;
           A = Tridiagonal(randn(k-1), randn(k), randn(k-1));
           B = Tridiagonal(randn(k-1), randn(k), randn(k-1));
           C = randn(k, k);

           Ai = Bidiagonal(randn(k), randn(k-1), rand(Bool));
           Bi = Bidiagonal(randn(k), randn(k-1), rand(Bool));
           fullAi = full(Ai);
           fullBi = full(Bi);
           Atri = Tridiagonal(randn(k-1), randn(k), randn(k-1));
           Btri = Tridiagonal(randn(k-1), randn(k), randn(k-1));
           C = randn(k, k);
       end
```

```
julia> @time A_mul_B!(C, fullAi, fullBi);
  0.035776 seconds (4 allocations: 160 bytes)

julia> @time A_mul_B!(C, fullAi, Btri);
  0.002102 seconds (4 allocations: 160 bytes)

julia> @time A_mul_B!(C, Atri, fullBi);
  0.004037 seconds (4 allocations: 160 bytes)

julia> @time A_mul_B!(C, Atri, Btri);
  0.000815 seconds (4 allocations: 160 bytes)
```

```
julia> @time A_mul_B!(C, fullAi, Bi);
  0.001518 seconds (11 allocations: 16.141 KB)

julia> @time A_mul_B!(C, Ai, fullBi);
  0.004141 seconds (11 allocations: 16.141 KB)

julia> @time A_mul_B!(C, Ai, Bi);
  0.001324 seconds (18 allocations: 32.125 KB)
```

```
julia> @time fullAi * fullBi;
  0.035390 seconds (9 allocations: 7.630 MB)

julia> @time fullAi * Btri;
  0.001393 seconds (9 allocations: 7.630 MB)

julia> @time Atri * fullBi;
  0.004084 seconds (9 allocations: 7.630 MB)

julia> @time Atri * Btri;
  0.001264 seconds (9 allocations: 7.630 MB)
```

```
julia> @time fullAi * Bi;
  0.002728 seconds (16 allocations: 7.645 MB)

julia> @time Ai * fullBi;
  0.005010 seconds (16 allocations: 7.645 MB)

julia> @time Ai * Bi;
  0.001789 seconds (23 allocations: 7.661 MB)

```
