### PR TITLE
RFC: making tuples easy and fun

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -265,6 +265,8 @@ UnionAll(v::TypeVar, t::ANY) = ccall(:jl_type_unionall, Any, (Any, Any), v, t)
 
 Void() = nothing
 
+(::Type{Tuple{}})() = ()
+
 immutable VecElement{T}
     value::T
     VecElement(value::T) = new(value) # disable converting constructor in Core

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -51,7 +51,7 @@ tuple_type_head(T::UnionAll) = tuple_type_head(T.body)
 function tuple_type_head(T::DataType)
     @_pure_meta
     T.name === Tuple.name || throw(MethodError(tuple_type_head, (T,)))
-    return T.parameters[1]
+    return unwrapva(T.parameters[1])
 end
 tuple_type_tail(T::UnionAll) = tuple_type_tail(T.body)
 function tuple_type_tail(T::DataType)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -44,7 +44,7 @@ test_have_color(buf, "", "")
 # matches the implicit constructor -> convert method
 Base.show_method_candidates(buf, Base.MethodError(Tuple{}, (1, 1, 1)))
 let mc = String(take!(buf))
-    @test contains(mc, "\nClosest candidates are:\n  Tuple{}{T}(")
+    @test contains(mc, "\nClosest candidates are:\n  Tuple{}")
     @test !contains(mc, cfile)
 end
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -203,3 +203,17 @@ let
 
     test_15703()
 end
+
+# PR #15516
+@test Tuple{Char,Char}("za") === ('z','a')
+@test_throws ArgumentError Tuple{Char,Char}("z")
+
+@test NTuple{20,Int}(Iterators.countfrom(2)) === (2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)
+@test NTuple{20,Float64}(Iterators.countfrom(2)) === (2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.)
+@test_throws ArgumentError NTuple{20,Int}([1,2])
+
+@test Tuple{Vararg{Float32}}(Float64[1,2,3]) === (1.0f0, 2.0f0, 3.0f0)
+@test Tuple{Int,Vararg{Float32}}(Float64[1,2,3]) === (1, 2.0f0, 3.0f0)
+@test Tuple{Int,Vararg{Any}}(Float64[1,2,3]) === (1, 2.0, 3.0)
+@test Tuple(ones(5)) === (1.0,1.0,1.0,1.0,1.0)
+@test_throws MethodError convert(Tuple, ones(5))


### PR DESCRIPTION
This allows constructing a tuple by type, from an iterator. Suddenly they seem a lot friendlier:

```
julia> NTuple{5,UInt8}("Hello")
(0x48,0x65,0x6c,0x6c,0x6f)

julia> Tuple{Int,Float32,Int,Float32}(repeated(0))
(0,0.0,0,0.0)

julia> NTuple{100,Int8}(countfrom(2))
(2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101)
```

For better or for worse, the code is fully unrolled, so when using `NTuple` the size of the generated code is exponential in the length of your input.

I kind of like the permissiveness of taking a prefix of the iterator, instead of requiring the whole thing to be consumed (there is an error for that commented out in this patch). Otherwise you have to write e.g. `NTuple{5,T}(repeated(0, 5))`, and unfortunately adding in the `Take` iterator leads to much worse code generation.

This technique could also be used to implement a very efficient `Partition` iterator.
