### PR TITLE
RFC: Fix #12973, ui sources not rebuilding when src headers change

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -14,6 +14,9 @@ ifeq ($(USEMSVC), 1)
 SRCS += getopt
 endif
 
+HEADERS := $(addprefix $(JULIAHOME)/src/,julia.h julia_threads.h julia_internal.h options.h) \
+	$(BUILDDIR)/../src/julia_version.h $(wildcard $(JULIAHOME)/src/support/*.h) $(LIBUV_INC)/uv.h
+
 FLAGS := -I$(BUILDROOT)/src -I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir)
 ifneq ($(USEMSVC), 1)
 FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer -Wc++-compat
@@ -48,9 +51,9 @@ default: release
 all: release debug
 release debug :  % : julia-%
 
-$(BUILDDIR)/%.o: $(SRCDIR)/%.c
+$(BUILDDIR)/%.o: $(SRCDIR)/%.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@)
-$(BUILDDIR)/%.dbg.obj: $(SRCDIR)/%.c
+$(BUILDDIR)/%.dbg.obj: $(SRCDIR)/%.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
 ifeq ($(OS),WINNT)


### PR DESCRIPTION
(0.4-backported version is at e5e774b6201e7296a2388e07baa469d38ca2ea74, I anticipate seeing a dupe of this issue soon if we don't fix it first)
