### PR TITLE
Reduce dimensionality of tests in linalg/triangular.jl

### DIFF
--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -6,7 +6,7 @@ using Base.LinAlg: BlasFloat, errorbounds, full!, naivesub!, transpose!, UnitUpp
 
 debug && println("Triangular matrices")
 
-n = 9
+n = 5
 srand(123)
 
 debug && println("Test basic type functionality")


### PR DESCRIPTION
This test file takes a very long time to run. It has a for loop on the outside with 7 eltypes, and two loops on the inside (run sequentially) with 7 eltypes. This results in _a lot_ of tests..

Now, if it is because we have to be sure that everything works, 7 minutes less doesn't really matter. However, if we could just as well use `n=5` and save 50% of the time (normally around 900 secs on appveyor, let's see how long this runs for), then it might be worth it. Especially when we're so close to the 60 minute mark for `ARCH=x86_64`.

It can be another number if it is wanted, and if this change is not wanted at all, feel free to close. There might be reasons for such a high `n` that I am not aware of (hardcoded solutions somewhere?).
