### PR TITLE
Use "sidebars" for markdown tables.

### DIFF
--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -97,20 +97,22 @@ function padcells!(rows, align; len = length, min = 0)
 end
 
 _dash(width, align) =
-    align == :l ? ":" * "-"^(width-1) :
-    align == :r ? "-"^(width-1) * ":" :
-    align == :c ? ":" * "-"^(width-2) * ":" :
+    align == :l ? ":" * "-"^width * " " :
+    align == :r ? " " * "-"^width * ":" :
+    align == :c ? ":" * "-"^width * ":" :
     throw(ArgumentError("Invalid alignment $align"))
 
 function plain(io::IO, md::Table)
     cells = mapmap(plaininline, md.rows)
     padcells!(cells, md.align, len = length, min = 3)
     for i = 1:length(cells)
+        print(io, "| ")
         print_joined(io, cells[i], " | ")
-        println(io)
+        println(io, " |")
         if i == 1
-            print_joined(io, [_dash(length(cells[i][j]), md.align[j]) for j = 1:length(cells[1])], " | ")
-            println(io)
+            print(io, "|")
+            print_joined(io, [_dash(length(cells[i][j]), md.align[j]) for j = 1:length(cells[1])], "|")
+            println(io, "|")
         end
     end
 end

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -316,12 +316,32 @@ no|table
 no error
 """ == MD([Paragraph(Any["no|table no error"])])
 
-t = """a   |   b
-:-- | --:
-1   |   2
-"""
-@test plain(Markdown.parse(t)) == t
+let t = """a   |   b
+    :-- | --:
+    1   |   2
+    """
+    @test Markdown.parse(t) == MD(Table(Any[Any["a", "b"], Any["1", "2"]], [:l, :r]))
+end
 
+let text =
+    """
+    | a   |   b |
+    |:--- | ---:|
+    | 1   |   2 |
+    """,
+    table = Markdown.parse(text)
+    @test text == Markdown.plain(table)
+end
+let text =
+    """
+    | Markdown | Table |  Test |
+    |:-------- |:-----:| -----:|
+    | foo      | `bar` | *baz* |
+    | `bar`    |  baz  | *foo* |
+    """,
+    table = Markdown.parse(text)
+    @test text == Markdown.plain(table)
+end
 
 # LaTeX extension
 latex_doc = md"""


### PR DESCRIPTION
Adds `|` columns on each side of markdown tables to avoid trailing whitespace problems in rendered documents. This is still valid markdown.

This does not change the parsing of markdown tables, which can still be written without the `|` columns on each side.
