### PR TITLE
Correctly render display equations in markdown.

### DIFF
--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -53,6 +53,12 @@ function plain(io::IO, md::HorizontalRule)
     println(io, "-" ^ 3)
 end
 
+function plain(io::IO, l::LaTeX)
+    println(io, '$', '$')
+    println(io, l.formula)
+    println(io, '$', '$')
+end
+
 function plain(io::IO, md)
     writemime(io,  MIME"text/plain"(), md)
     println(io)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -344,18 +344,68 @@ let text =
 end
 
 # LaTeX extension
-latex_doc = md"""
-We have $x^2 < x$ whenever:
 
-$|x| < 1$
+let in_dollars =
+    """
+    We have \$x^2 < x\$ whenever:
 
-etc."""
+    \$|x| < 1\$
 
-@test latex_doc == MD(Any[Paragraph(Any["We have ",
-                                        LaTeX("x^2 < x"),
-                                        " whenever:"]),
-                          LaTeX("|x| < 1"),
-                          Paragraph(Any["etc."])])
+    etc.
+    """,
+    in_backticks =
+    """
+    We have ``x^2 < x`` whenever:
 
-@test plain(latex_doc) == "We have \$x^2 < x\$ whenever:\n\n\$|x| < 1\$\n\netc.\n"
-@test latex(latex_doc) == "We have \$x^2 < x\$ whenever:\n\$\$|x| < 1\$\$\netc.\n"
+    ```math
+    |x| < 1
+    ```
+
+    etc.
+    """,
+    out_plain =
+    """
+    We have \$x^2 < x\$ whenever:
+
+    \$\$
+    |x| < 1
+    \$\$
+
+    etc.
+    """,
+    out_rst =
+    """
+    We have :math:`x^2 < x` whenever:
+
+    .. math::
+
+        |x| < 1
+
+    etc.
+    """,
+    out_latex =
+    """
+    We have \$x^2 < x\$ whenever:
+    \$\$|x| < 1\$\$
+    etc.
+    """,
+    dollars   = Markdown.parse(in_dollars),
+    backticks = Markdown.parse(in_backticks),
+    latex_doc = MD(
+        Any[Paragraph(Any["We have ", LaTeX("x^2 < x"), " whenever:"]),
+            LaTeX("|x| < 1"),
+            Paragraph(Any["etc."])
+    ])
+
+    @test out_plain == Markdown.plain(dollars)
+    @test out_plain == Markdown.plain(backticks)
+
+    @test out_rst   == Markdown.rst(dollars)
+    @test out_rst   == Markdown.rst(backticks)
+
+    @test out_latex == Markdown.latex(dollars)
+    @test out_latex == Markdown.latex(backticks)
+
+    @test latex_doc == dollars
+    @test latex_doc == backticks
+end


### PR DESCRIPTION
Rendering of display equations in markdown was falling back to using single `$`s, which doesn't render well. Both MathJax and KaTeX support double `$`s for display equations.
