### PR TITLE
implement copy(::Void) = nothing

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+copy(::Void) = nothing
+
 # timing
 
 # time() in libc.jl


### PR DESCRIPTION
See https://github.com/Keno/Gallium.jl/issues/52. This seems like the only reasonable definition for copying nothing. I couldn't figure out a good place to put this and I wonder if we shouldn't make copying singletons (i.e. instances of types with no fields) work automatically like this, although I'm not sure how.
