### PR TITLE
Test `return` as expression

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -371,3 +371,8 @@ end
 @test parse("x>:y") == Expr(:(>:), :x, :y)
 @test parse("x<:y<:z").head === :comparison
 @test parse("x>:y<:z").head === :comparison
+
+# issue #11169
+uncalled(x) = @test false
+fret() = uncalled(return true)
+@test fret()


### PR DESCRIPTION
Closes #11169.
