### PR TITLE
simplify interaction between new JITs and codegen

### DIFF
--- a/contrib/add_license_to_files.jl
+++ b/contrib/add_license_to_files.jl
@@ -43,7 +43,6 @@ const skipfiles = [
     "../src/abi_x86.cpp",
     "../src/abi_x86_64.cpp",
     "../src/disasm.cpp",
-    "../src/jitlayers.cpp",
     "../src/support/END.h",
     "../src/support/ENTRY.amd64.h",
     "../src/support/ENTRY.i387.h",

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,8 +117,10 @@ $(BUILDDIR)/julia_flisp.boot: $(addprefix $(SRCDIR)/,jlfrontend.scm \
 
 # additional dependency links
 $(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc $(SRCDIR)/flisp/*.h
-$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp intrinsics.h cgutils.cpp ccall.cpp jitlayers.cpp abi_*.cpp)
+$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp jitlayers.cpp intrinsics.h codegen_internal.h cgutils.cpp ccall.cpp abi_*.cpp)
 $(BUILDDIR)/anticodegen.o $(BUILDDIR)/anticodegen.dbg.obj: $(SRCDIR)/intrinsics.h
+$(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: $(SRCDIR)/codegen_internal.h
+$(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/codegen_internal.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc-debug.c
 $(BUILDDIR)/signal-handling.o $(BUILDDIR)/signal-handling.dbg.obj: $(addprefix $(SRCDIR)/,signals-*.c)

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -1,4 +1,6 @@
-// Pre-declaration. Definition in disasm.cpp
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+// Declarations for disasm.cpp
 extern "C"
 void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #ifndef USE_MCJIT
@@ -12,6 +14,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #endif
                           );
 
+// Declarations for debuginfo.cpp
 extern int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide, int64_t *section_slide,
                       const object::ObjectFile **object,
 #ifdef USE_MCJIT
@@ -20,8 +23,17 @@ extern int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide, int6
                       std::vector<JITEvent_EmittedFunctionDetails::LineStart> *lines
 #endif
                       );
+
 extern bool jl_dylib_DI_for_fptr(size_t pointer, const object::ObjectFile **object, llvm::DIContext **context, int64_t *slide, int64_t *section_slide,
         bool onlySysImg, bool *isSysImg, void **saddr, char **name, char **filename);
+
 #ifdef USE_MCJIT
 extern void jl_cleanup_DI(llvm::DIContext *context);
+#endif
+
+#ifdef USE_ORCJIT
+extern JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
+                                      const object::ObjectFile &obj,
+                                      const object::ObjectFile &debugObj,
+                                      const RuntimeDyld::LoadedObjectInfo &L);
 #endif

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -238,6 +238,10 @@ public:
 #endif
         FuncInfo tmp = {&F, Size, Details.LineStarts, linfo};
         info[(size_t)(Code)] = tmp;
+#ifndef KEEP_BODIES
+        if (!jl_generating_output())
+            const_cast<Function*>(&F)->deleteBody();
+#endif
         uv_rwlock_wrunlock(&threadsafe);
     }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -1921,7 +1921,7 @@ JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname)
     }
 
     // Get handle to sys.so
-    jl_sysimg_handle = jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
+    jl_sysimg_handle = jl_load_dynamic_library_e(fname_shlib, JL_RTLD_LOCAL | JL_RTLD_NOW);
 
     // set cpu target if unspecified by user and available from sysimg
     // otherwise default to native.

--- a/src/gf.c
+++ b/src/gf.c
@@ -870,7 +870,7 @@ static jl_value_t *jl_call_unspecialized(jl_svec_t *sparam_vals, jl_lambda_info_
                                          jl_value_t **args, uint32_t nargs)
 {
     if (__unlikely(meth->fptr == NULL)) {
-        jl_compile_linfo(meth, NULL);
+        jl_compile_linfo(meth);
         jl_generate_fptr(meth);
     }
     assert(jl_svec_len(meth->sparam_syms) == jl_svec_len(sparam_vals));
@@ -1414,7 +1414,7 @@ jl_lambda_info_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t
 JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_value_t *types, int lim);
 
 // compile-time method lookup
-jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types, void *cyclectx)
+jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types)
 {
     assert(jl_nparams(types) > 0);
     if (!jl_is_leaf_type((jl_value_t*)types))
@@ -1451,7 +1451,7 @@ jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types, void *cyclectx)
     if (sf->functionObjects.functionObject == NULL) {
         if (sf->fptr != NULL)
             goto not_found;
-        jl_compile_linfo(sf, cyclectx);
+        jl_compile_linfo(sf);
     }
     JL_GC_POP();
     return sf;
@@ -1506,7 +1506,7 @@ static int _compile_all_tvar_union(jl_methlist_t *meth, jl_tupletype_t *methsig)
             if (jl_is_leaf_type((jl_value_t*)methsig)) {
                 // usually can create a specialized version of the function,
                 // if the signature is already a leaftype
-                jl_lambda_info_t *spec = jl_get_specialization1(methsig, NULL);
+                jl_lambda_info_t *spec = jl_get_specialization1(methsig);
                 if (spec) {
                     if (methsig == meth->sig) {
                         // replace unspecialized func with newly specialized version
@@ -1545,7 +1545,7 @@ static int _compile_all_tvar_union(jl_methlist_t *meth, jl_tupletype_t *methsig)
             goto getnext; // signature wouldn't be callable / is invalid -- skip it
         }
         if (jl_is_leaf_type(sig)) {
-            if (jl_get_specialization1((jl_tupletype_t*)sig, NULL)) {
+            if (jl_get_specialization1((jl_tupletype_t*)sig)) {
                 if (!jl_has_typevars((jl_value_t*)sig)) goto getnext; // success
             }
         }
@@ -1680,7 +1680,7 @@ static void _compile_all_deq(jl_array_t *found)
                 linfo->functionID = -1;
         }
         else {
-            jl_compile_linfo(linfo, NULL);
+            jl_compile_linfo(linfo);
             assert(linfo->functionID > 0);
         }
     }
@@ -1783,7 +1783,7 @@ void jl_compile_all(void)
 
 JL_DLLEXPORT void jl_compile_hint(jl_tupletype_t *types)
 {
-    (void)jl_get_specialization1(types, NULL);
+    (void)jl_get_specialization1(types);
 }
 
 #ifdef JL_TRACE

--- a/src/init.c
+++ b/src/init.c
@@ -615,6 +615,11 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     init_stdio();
     // libuv stdio cleanup depends on jl_init_tasks() because JL_TRY is used in jl_atexit_hook()
 
+    if ((jl_options.outputo || jl_options.outputbc) &&
+        (jl_options.code_coverage || jl_options.malloc_log)) {
+        jl_error("cannot generate code-coverage or track allocation information while generating a .o or .bc output file");
+    }
+
     jl_init_codegen();
 
     jl_start_threads();

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1,6 +1,8 @@
-// This file is part of Julia.
-// Parts of this file are copied from LLVM, under the UIUC license.
+// This file is a part of Julia. License is MIT: http://julialang.org/license
 
+// Except for parts of this file which were copied from LLVM, under the UIUC license (marked below).
+
+// this defines the set of optimization passes defined for Julia at various optimization levels
 template <class T>
 static void addOptimizationPasses(T *PM)
 {
@@ -158,11 +160,6 @@ extern "C" {
   LLVM_ATTRIBUTE_NOINLINE extern void __jit_debug_register_code();
 }
 
-extern JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
-                                      const object::ObjectFile &obj,
-                                      const object::ObjectFile &debugObj,
-                                      const RuntimeDyld::LoadedObjectInfo &L);
-
 #if defined(_OS_DARWIN_) && defined(LLVM37) && defined(LLVM_SHLIB)
 #define CUSTOM_MEMORY_MANAGER createRTDyldMemoryManagerOSX
 extern RTDyldMemoryManager *createRTDyldMemoryManagerOSX();
@@ -193,9 +190,10 @@ void NotifyDebugger(jit_code_entry *JITCodeEntry)
     __jit_debug_descriptor.relevant_entry = JITCodeEntry;
     __jit_debug_register_code();
 }
+// ------------------------ END OF TEMPORARY COPY FROM LLVM -----------------
 
-// --------------------------------------------------------------------------
-
+// Custom object emission notification handler for the JuliaOJIT
+// TODO: hook up RegisterJITEventListener, instead of hard-coding the GDB and JuliaListener targets
 class DebugObjectRegistrar {
 private:
     void NotifyGDB(OwningBinary<ObjectFile> &DebugObj)
@@ -253,7 +251,11 @@ public:
             }
 
             SavedObjects.push_back(std::move(SavedObject));
-            ORCNotifyObjectEmitted(JuliaListener.get(),*Object,*SavedObjects.back().getBinary(),*LO);
+
+            ORCNotifyObjectEmitted(JuliaListener.get(),
+                    *Object,
+                    *SavedObjects.back().getBinary(),
+                    *LO);
 
             ++oit;
             ++lit;
@@ -261,6 +263,8 @@ public:
     }
 };
 
+// A simplified model of the LLVM ExecutionEngine that implements only the methods that Julia needs
+// but tries to roughly match the API anyways so that compatibility is easier
 class JuliaOJIT {
 public:
     typedef orc::ObjectLinkingLayer<DebugObjectRegistrar> ObjLayerT;
@@ -313,26 +317,49 @@ public:
                 report_fatal_error("FATAL: unable to dlopen self\n" + *ErrorStr);
         }
 
-    std::string mangle(const std::string &Name)
+    std::string getMangledName(const std::string &Name)
     {
-        std::string MangledName;
-        {
-            raw_string_ostream MangledNameStream(MangledName);
-            Mangler::getNameWithPrefix(MangledNameStream, Name, DL);
+        SmallString<128> FullName;
+        Mangler::getNameWithPrefix(FullName, Name, DL);
+        return FullName.str();
+    }
+
+    std::string getMangledName(const GlobalValue *GV)
+    {
+        return getMangledName(GV->getName());
+    }
+
+    void addGlobalMapping(StringRef Name, uint64_t Addr)
+    {
+       bool successful = GlobalSymbolTable.insert(make_pair(getMangledName(Name), (void*)Addr)).second;
+       assert(successful);
+    }
+
+    void *getPointerToGlobalIfAvailable(StringRef S) {
+        GlobalSymbolTableT::const_iterator pos = GlobalSymbolTable.find(S);
+        if (pos != GlobalSymbolTable.end())
+            return pos->second;
+        return nullptr;
+    }
+
+    ModuleHandleT addModule(std::unique_ptr<Module> M)
+    {
+#ifndef NDEBUG
+        // validate the relocations for M
+        for (Module::iterator I = M->begin(), E = M->end(); I != E; ) {
+            Function *F = &*I;
+            ++I;
+            if (F->isDeclaration()) {
+                if (F->use_empty())
+                    F->eraseFromParent();
+                else
+                    assert(F->isIntrinsic() || findUnmangledSymbol(F->getName()) ||
+                            SectionMemoryManager::getSymbolAddressInProcess(F->getName()));
+            }
         }
-        return MangledName;
-    }
-
-    void addGlobalMapping(StringRef Name, void *Addr)
-    {
-       GlobalSymbolTable[mangle(Name)] = Addr;
-    }
-
-    ModuleHandleT addModule(Module *M)
-    {
+#endif
         // We need a memory manager to allocate memory and resolve symbols for this
-        // new module. Create one that resolves symbols by looking back into the
-        // JIT.
+        // new module. Create one that resolves symbols by looking back into the JIT.
         auto Resolver = orc::createLambdaResolver(
                           [&](const std::string &Name) {
                             // TODO: consider moving the FunctionMover resolver here
@@ -350,7 +377,7 @@ public:
                           [](const std::string &S) { return nullptr; }
                         );
         SmallVector<std::unique_ptr<Module>,1> Ms;
-        Ms.push_back(std::unique_ptr<Module>{M});
+        Ms.push_back(std::move(M));
         return CompileLayer->addModuleSet(std::move(Ms),
                                           MemMgr,
                                           std::move(Resolver));
@@ -362,9 +389,9 @@ public:
     {
         if (ExportedSymbolsOnly) {
             // Step 1: Check against list of known external globals
-            GlobalSymbolTableT::const_iterator pos = GlobalSymbolTable.find(Name);
-            if (pos != GlobalSymbolTable.end())
-                return orc::JITSymbol((uintptr_t)pos->second, JITSymbolFlags::Exported);
+            void *Addr = getPointerToGlobalIfAvailable(Name);
+            if (Addr != nullptr)
+                return orc::JITSymbol((uintptr_t)Addr, JITSymbolFlags::Exported);
         }
         // Step 2: Search all previously emitted symbols
         return CompileLayer->findSymbol(Name, ExportedSymbolsOnly);
@@ -372,17 +399,17 @@ public:
 
     orc::JITSymbol findUnmangledSymbol(const std::string Name)
     {
-        return findSymbol(mangle(Name), true);
+        return findSymbol(getMangledName(Name), true);
     }
 
     uint64_t getGlobalValueAddress(const std::string &Name)
     {
-        return findSymbol(mangle(Name), false).getAddress();
+        return findSymbol(getMangledName(Name), false).getAddress();
     }
 
     uint64_t getFunctionAddress(const std::string &Name)
     {
-        return findSymbol(mangle(Name), false).getAddress();
+        return findSymbol(getMangledName(Name), false).getAddress();
     }
 
     Function *FindFunctionNamed(const std::string &Name)
@@ -422,3 +449,555 @@ private:
 
 }
 #endif
+
+#ifdef USE_ORCJIT
+JuliaOJIT *jl_ExecutionEngine;
+#else
+ExecutionEngine *jl_ExecutionEngine;
+#endif
+
+// destructively move the contents of src into dest
+// this assumes that the targets of the two modules are the same
+// including the DataLayout and ModuleFlags (for example)
+// and that there is no module-level assembly
+static void jl_merge_module(Module *dest, std::unique_ptr<Module> src)
+{
+    assert(dest != src.get());
+    for (Module::global_iterator I = src->global_begin(), E = src->global_end(); I != E;) {
+        GlobalVariable *sG = &*I;
+        GlobalValue *dG = dest->getNamedValue(sG->getName());
+        ++I;
+        if (dG) {
+            if (sG->isDeclaration()) {
+                sG->replaceAllUsesWith(dG);
+                sG->eraseFromParent();
+                continue;
+            }
+            else {
+                dG->replaceAllUsesWith(sG);
+                dG->eraseFromParent();
+            }
+        }
+        sG->removeFromParent();
+        dest->getGlobalList().push_back(sG);
+    }
+
+    for (Module::iterator I = src->begin(), E = src->end(); I != E;) {
+        Function *sG = &*I;
+        GlobalValue *dG = dest->getNamedValue(sG->getName());
+        ++I;
+        if (dG) {
+            if (sG->isDeclaration()) {
+                sG->replaceAllUsesWith(dG);
+                sG->eraseFromParent();
+                continue;
+            }
+            else {
+                dG->replaceAllUsesWith(sG);
+                dG->eraseFromParent();
+            }
+        }
+        sG->removeFromParent();
+        dest->getFunctionList().push_back(sG);
+    }
+
+    for (Module::alias_iterator I = src->alias_begin(), E = src->alias_end(); I != E;) {
+        GlobalAlias *sG = &*I;
+        GlobalValue *dG = dest->getNamedValue(sG->getName());
+        ++I;
+        if (dG) {
+            if (!dG->isDeclaration()) { // aliases are always definitions, so this test is reversed from the above two
+                sG->replaceAllUsesWith(dG);
+                sG->eraseFromParent();
+                continue;
+            }
+            else {
+                dG->replaceAllUsesWith(sG);
+                dG->eraseFromParent();
+            }
+        }
+        sG->removeFromParent();
+        dest->getAliasList().push_back(sG);
+    }
+
+    // metadata nodes need to be explicitly merged not just copied
+    // so there are special passes here for each known type of metadata
+    NamedMDNode *sNMD = src->getNamedMetadata("llvm.dbg.cu");
+    if (sNMD) {
+        NamedMDNode *dNMD = dest->getOrInsertNamedMetadata("llvm.dbg.cu");
+#ifdef LLVM35
+        for (NamedMDNode::op_iterator I = sNMD->op_begin(), E = sNMD->op_end(); I != E; ++I) {
+            dNMD->addOperand(*I);
+        }
+#else
+        for (unsigned i = 0, l = sNMD->getNumOperands(); i < l; i++) {
+            dNMD->addOperand(sNMD->getOperand(i));
+        }
+#endif
+    }
+}
+
+// to finalizing a function, look up its name in the `module_for_fname` map of unfinalized functions
+// and merge it, plus any other modules it depends upon, into `collector`
+// then add `collector` to the execution engine
+//
+// in the old JIT, functions are finalized by adding them to the shadow module
+// (which aliases the engine module), so this is unneeded
+#ifdef USE_MCJIT
+static StringMap<Module*> module_for_fname;
+static void jl_finalize_function(StringRef F, Module *collector = NULL)
+{
+    std::unique_ptr<Module> m(module_for_fname.lookup(F));
+    if (m) {
+        // probably not many unresolved declarations, but be sure iterate over their Names,
+        // since the declarations may get destroyed by the jl_merge_module call
+        SmallVector<StringRef, 8> to_finalize;
+        for (Module::iterator I = m->begin(), E = m->end(); I != E; ++I) {
+            Function *F = &*I;
+            if (!F->isDeclaration()) {
+                module_for_fname.erase(F->getName());
+            }
+            else if (!F->isIntrinsic()) {
+                to_finalize.push_back(F->getName());
+            }
+        }
+
+        for (auto F : to_finalize) {
+            jl_finalize_function(F, collector ? collector : m.get());
+        }
+
+        if (collector) {
+            jl_merge_module(collector, std::move(m));
+        }
+        else {
+#if defined(_CPU_X86_64_) && defined(_OS_WINDOWS_) && defined(LLVM35)
+            // Add special values used by debuginfo to build the UnwindData table registration for Win64
+            ArrayType *atype = ArrayType::get(T_uint32, 3); // want 4-byte alignment of 12-bytes of data
+            (new GlobalVariable(*m, atype,
+                false, GlobalVariable::InternalLinkage,
+                ConstantAggregateZero::get(atype), "__UnwindData"))->setSection(".text");
+            (new GlobalVariable(*m, atype,
+                false, GlobalVariable::InternalLinkage,
+                ConstantAggregateZero::get(atype), "__catchjmp"))->setSection(".text");
+#endif
+            assert(jl_ExecutionEngine);
+#if defined(LLVM36)
+            jl_ExecutionEngine->addModule(std::move(m));
+#else
+            jl_ExecutionEngine->addModule(m.release());
+#endif
+        }
+    }
+}
+static void jl_finalize_function(Function *F, Module *collector = NULL)
+{
+    jl_finalize_function(F->getName(), collector);
+}
+#endif
+
+// MSVC's link.exe requires each function declaration to have a Comdat section
+// rather than litter the code with conditionals,
+// all global values that get emitted call this function
+// and it decides whether the definition needs a Comdat section and adds the appropriate declation
+// TODO: consider moving this into jl_add_to_shadow or jl_dump_shadow? the JIT doesn't care, so most calls are now no-ops
+template<class T> // for GlobalObject's
+static T *addComdat(T *G)
+{
+#if defined(_OS_WINDOWS_)
+    if (imaging_mode && !G->isDeclaration()) {
+#ifdef LLVM35
+        // Add comdat information to make MSVC link.exe happy
+        Comdat *jl_Comdat = G->getParent()->getOrInsertComdat(G->getName());
+        jl_Comdat->setSelectionKind(Comdat::NoDuplicates);
+        G->setComdat(jl_Comdat);
+        // add __declspec(dllexport) to everything marked for export
+        if (G->getLinkage() == GlobalValue::ExternalLinkage)
+            G->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
+#endif
+    }
+#endif
+    return G;
+}
+
+// Connect Modules via prototypes, each owned by module `M`
+static GlobalVariable *global_proto(GlobalVariable *G, Module *M = NULL)
+{
+    // Copy the GlobalVariable, but without the initializer, so it becomes a declaration
+    GlobalVariable *proto = new GlobalVariable(G->getType()->getElementType(),
+            G->isConstant(), GlobalVariable::ExternalLinkage,
+            NULL, G->getName(),  G->getThreadLocalMode());
+    if (M)
+        M->getGlobalList().push_back(proto);
+    return proto;
+}
+
+static Function *function_proto(Function *F, Module *M = NULL)
+{
+    // Copy the declaration characteristics of the Function (not the body)
+    Function *NewF = Function::Create(F->getFunctionType(),
+                                      Function::ExternalLinkage,
+                                      F->getName(), M);
+    NewF->setAttributes(AttributeSet());
+
+    // FunctionType does not include any attributes. Copy them over manually
+    // as codegen may make decisions based on the presence of certain attributes
+    NewF->copyAttributesFrom(F);
+
+#ifdef LLVM37
+    // Declarations are not allowed to have personality routines, but
+    // copyAttributesFrom sets them anyway, so clear them again manually
+    NewF->setPersonalityFn(nullptr);
+#endif
+
+    return NewF;
+}
+
+// helper function for adding a DLLImport (dlsym) address to the execution engine
+// (for values created locally or in the sysimage, jl_emit_and_add_to_shadow is generally preferable)
+template<typename T>
+#ifdef LLVM35
+static inline void add_named_global(GlobalObject *gv, T *_addr, bool dllimport = true)
+#else
+static inline void add_named_global(GlobalValue *gv, T *_addr, bool dllimport = true)
+#endif
+{
+    // cast through integer to avoid c++ pedantic warning about casting between
+    // data and code pointers
+    void *addr = (void*)(uintptr_t)_addr;
+#ifdef LLVM34
+    StringRef name = gv->getName();
+#ifdef _OS_WINDOWS_
+    std::string imp_name;
+#endif
+#endif
+
+#ifdef _OS_WINDOWS_
+    // setting JL_DLLEXPORT correctly only matters when building a binary
+    if (dllimport && imaging_mode) {
+        assert(gv->getLinkage() == GlobalValue::ExternalLinkage);
+#ifdef LLVM35
+        // add the __declspec(dllimport) attribute
+        gv->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
+        // this will cause llvm to rename it, so we do the same
+        imp_name = Twine("__imp_", name).str();
+        name = StringRef(imp_name);
+#else
+        gv->setLinkage(GlobalValue::DLLImportLinkage);
+#endif
+#if defined(_P64) || defined(LLVM35)
+        // __imp_ variables are indirection pointers, so use malloc to simulate that
+        void **imp_addr = (void**)malloc(sizeof(void**));
+        *imp_addr = addr;
+        addr = (void*)imp_addr;
+#endif
+    }
+#endif // _OS_WINDOWS_
+
+#ifdef USE_ORCJIT
+    addComdat(gv);
+    jl_ExecutionEngine->addGlobalMapping(name, (uintptr_t)addr);
+#elif defined(USE_MCJIT)
+    addComdat(gv);
+    sys::DynamicLibrary::AddSymbol(name, addr);
+#else // USE_MCJIT
+    jl_ExecutionEngine->addGlobalMapping(gv, addr);
+#endif // USE_MCJIT
+}
+
+static std::vector<Constant*> jl_sysimg_gvars;
+static std::vector<Constant*> jl_sysimg_fvars;
+typedef struct {Value *gv; int32_t index;} jl_value_llvm; // uses 1-based indexing
+static std::map<void*, jl_value_llvm> jl_value_to_llvm;
+
+// global variables to pointers are pretty common,
+// so this method is available as a convenience for emitting them.
+// for other types, the formula for implementation is straightforward:
+// (see stringConstPtr, for an alternative example to the code below)
+//
+// if in imaging_mode, emit a GlobalVariable with the same name and an initializer to the shadow_module
+// making it valid for emission and reloading in the sysimage
+//
+// then add a global mapping to the current value (usually from calloc'd space)
+// to the execution engine to make it valid for the current session (with the current value)
+static void* jl_emit_and_add_to_shadow(GlobalVariable *gv, void *gvarinit = NULL)
+{
+    PointerType *T = cast<PointerType>(gv->getType()->getElementType()); // pointer is the only supported type here
+
+    GlobalVariable *shadowvar = NULL;
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+    if (imaging_mode)
+#endif
+        shadowvar = global_proto(gv, shadow_output);
+
+    if (shadowvar) {
+        shadowvar->setInitializer(ConstantPointerNull::get(T));
+        shadowvar->setLinkage(GlobalVariable::InternalLinkage);
+        addComdat(shadowvar);
+        if (imaging_mode && gvarinit) {
+            // make the pointer valid for future sessions
+            jl_sysimg_gvars.push_back(ConstantExpr::getBitCast(shadowvar, T_psize));
+            jl_value_llvm gv_struct;
+            gv_struct.gv = global_proto(gv);
+            gv_struct.index = jl_sysimg_gvars.size();
+            jl_value_to_llvm[gvarinit] = gv_struct;
+        }
+    }
+
+    // make the pointer valid for this session
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+    void *slot = calloc(1, sizeof(void*));
+    jl_ExecutionEngine->addGlobalMapping(gv->getName(), (uintptr_t)slot);
+    return slot;
+#else
+    return jl_ExecutionEngine->getPointerToGlobal(shadowvar);
+#endif
+}
+
+static void* jl_get_global(GlobalVariable *gv)
+{
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+    void *p = (void*)(intptr_t)jl_ExecutionEngine->getPointerToGlobalIfAvailable(
+            jl_ExecutionEngine->getMangledName(gv));
+#else
+    void *p = jl_ExecutionEngine->getPointerToGlobal(
+            shadow_output->getNamedValue(gv->getName()));
+#endif
+    assert(p);
+    return p;
+}
+
+// clones the contents of the module `m` to the shadow_output collector
+// in the old JIT, this is equivalent to also adding it to the execution engine
+static void jl_add_to_shadow(Module *m)
+{
+#if defined(USE_MCJIT) || defined(USE_ORCJIT)
+    if (!imaging_mode)
+        return;
+    ValueToValueMapTy VMap;
+    std::unique_ptr<Module> clone(CloneModule(m, VMap));
+    for (Module::iterator I = clone->begin(), E = clone->end(); I != E; ++I) {
+        Function *F = &*I;
+        if (!F->isDeclaration()) {
+            F->setLinkage(Function::InternalLinkage);
+            addComdat(F);
+        }
+    }
+#else
+    // on the old jit, the shadow_module is the same as the execution engine_module
+    std::unique_ptr<Module> clone(m);
+#endif
+    jl_merge_module(shadow_output, std::move(clone));
+}
+
+#ifdef HAVE_CPUID
+extern "C" {
+    extern void jl_cpuid(int32_t CPUInfo[4], int32_t InfoType);
+}
+#endif
+
+static void jl_gen_llvm_globaldata(llvm::Module *mod, ValueToValueMapTy &VMap,
+                                   const char *sysimg_data, size_t sysimg_len)
+{
+    ArrayType *gvars_type = ArrayType::get(T_psize, jl_sysimg_gvars.size());
+    addComdat(new GlobalVariable(*mod,
+                                 gvars_type,
+                                 true,
+                                 GlobalVariable::ExternalLinkage,
+                                 MapValue(ConstantArray::get(gvars_type, ArrayRef<Constant*>(jl_sysimg_gvars)), VMap),
+                                 "jl_sysimg_gvars"));
+    ArrayType *fvars_type = ArrayType::get(T_pvoidfunc, jl_sysimg_fvars.size());
+    addComdat(new GlobalVariable(*mod,
+                                 fvars_type,
+                                 true,
+                                 GlobalVariable::ExternalLinkage,
+                                 MapValue(ConstantArray::get(fvars_type, ArrayRef<Constant*>(jl_sysimg_fvars)), VMap),
+                                 "jl_sysimg_fvars"));
+    addComdat(new GlobalVariable(*mod,
+                                 T_size,
+                                 true,
+                                 GlobalVariable::ExternalLinkage,
+                                 ConstantInt::get(T_size, globalUnique+1),
+                                 "jl_globalUnique"));
+#ifdef JULIA_ENABLE_THREADING
+    addComdat(new GlobalVariable(*mod,
+                                 T_size,
+                                 true,
+                                 GlobalVariable::ExternalLinkage,
+                                 ConstantInt::get(T_size, jltls_states_func_idx),
+                                 "jl_ptls_states_getter_idx"));
+#endif
+
+    Constant *feature_string = ConstantDataArray::getString(jl_LLVMContext, jl_options.cpu_target);
+    addComdat(new GlobalVariable(*mod,
+                                 feature_string->getType(),
+                                 true,
+                                 GlobalVariable::ExternalLinkage,
+                                 feature_string,
+                                 "jl_sysimg_cpu_target"));
+
+#ifdef HAVE_CPUID
+    // For native also store the cpuid
+    if (strcmp(jl_options.cpu_target,"native") == 0) {
+        uint32_t info[4];
+
+        jl_cpuid((int32_t*)info, 1);
+        addComdat(new GlobalVariable(*mod,
+                                     T_int64,
+                                     true,
+                                     GlobalVariable::ExternalLinkage,
+                                     ConstantInt::get(T_int64,((uint64_t)info[2])|(((uint64_t)info[3])<<32)),
+                                     "jl_sysimg_cpu_cpuid"));
+    }
+#endif
+
+    if (sysimg_data) {
+        Constant *data = ConstantDataArray::get(jl_LLVMContext, ArrayRef<uint8_t>((const unsigned char*)sysimg_data, sysimg_len));
+        addComdat(new GlobalVariable(*mod, data->getType(), true,
+                                     GlobalVariable::ExternalLinkage,
+                                     data, "jl_system_image_data"));
+        Constant *len = ConstantInt::get(T_size, sysimg_len);
+        addComdat(new GlobalVariable(*mod, len->getType(), true,
+                                     GlobalVariable::ExternalLinkage,
+                                     len, "jl_system_image_size"));
+    }
+}
+
+// takes the running content that has collected in the shadow module and dump it to disk
+// this builds the object file portion of the sysimage files for fast startup
+static void jl_dump_shadow(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len,
+                           bool dump_as_bc)
+{
+#ifdef JL_DEBUG_BUILD
+    verifyModule(*shadow_output);
+#endif
+
+#ifdef LLVM36
+    std::error_code err;
+    StringRef fname_ref = StringRef(fname);
+    raw_fd_ostream OS(fname_ref, err, sys::fs::F_None);
+#elif defined(LLVM35)
+    std::string err;
+    raw_fd_ostream OS(fname, err, sys::fs::F_None);
+#else
+    std::string err;
+    raw_fd_ostream OS(fname, err);
+#endif
+#ifdef LLVM37 // 3.7 simplified formatted output; just use the raw stream alone
+    raw_fd_ostream& FOS(OS);
+#else
+    formatted_raw_ostream FOS(OS);
+#endif
+
+    // We don't want to use MCJIT's target machine because
+    // it uses the large code model and we may potentially
+    // want less optimizations there.
+    Triple TheTriple = Triple(jl_TargetMachine->getTargetTriple());
+#if defined(_OS_WINDOWS_) && defined(FORCE_ELF)
+#ifdef LLVM35
+    TheTriple.setObjectFormat(Triple::COFF);
+#else
+    TheTriple.setEnvironment(Triple::UnknownEnvironment);
+#endif
+#elif defined(_OS_DARWIN_) && defined(FORCE_ELF)
+#ifdef LLVM35
+    TheTriple.setObjectFormat(Triple::MachO);
+#else
+    TheTriple.setEnvironment(Triple::MachO);
+#endif
+#endif
+#ifdef LLVM35
+    std::unique_ptr<TargetMachine>
+#else
+    OwningPtr<TargetMachine>
+#endif
+    TM(jl_TargetMachine->getTarget().createTargetMachine(
+        TheTriple.getTriple(),
+        jl_TargetMachine->getTargetCPU(),
+        jl_TargetMachine->getTargetFeatureString(),
+        jl_TargetMachine->Options,
+#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
+        Reloc::PIC_,
+#else
+        jit_model ? Reloc::PIC_ : Reloc::Default,
+#endif
+        jit_model ? CodeModel::JITDefault : CodeModel::Default,
+        CodeGenOpt::Aggressive // -O3 TODO: respect command -O0 flag?
+        ));
+
+#ifdef LLVM38
+    legacy::PassManager PM;
+#else
+    PassManager PM;
+#endif
+#ifndef LLVM37
+    PM.add(new TargetLibraryInfo(Triple(TM->getTargetTriple())));
+#else
+    PM.add(new TargetLibraryInfoWrapperPass(Triple(TM->getTargetTriple())));
+#endif
+
+
+    // set up optimization passes
+#ifdef LLVM37
+    // No DataLayout pass needed anymore.
+#elif defined(LLVM36)
+    PM.add(new DataLayoutPass());
+#elif defined(LLVM35)
+    PM.add(new DataLayoutPass(*jl_ExecutionEngine->getDataLayout()));
+#else
+    PM.add(new DataLayout(*jl_ExecutionEngine->getDataLayout()));
+#endif
+
+    addOptimizationPasses(&PM);
+    if (!dump_as_bc) {
+        if (TM->addPassesToEmitFile(PM, FOS, TargetMachine::CGFT_ObjectFile, false)) {
+            jl_error("Could not generate obj file for this target");
+        }
+    }
+
+    // now copy the module, since PM.run may modify it
+    ValueToValueMapTy VMap;
+#ifdef LLVM38
+    Module *clone = CloneModule(shadow_output, VMap).release();
+#else
+    Module *clone = CloneModule(shadow_output, VMap);
+#endif
+#ifdef LLVM37
+    // Reset the target triple to make sure it matches the new target machine
+    clone->setTargetTriple(TM->getTargetTriple().str());
+#ifdef LLVM38
+    clone->setDataLayout(TM->createDataLayout());
+#else
+    clone->setDataLayout(TM->getDataLayout()->getStringRepresentation());
+#endif
+#endif
+
+    // add metadata information
+    jl_gen_llvm_globaldata(clone, VMap, sysimg_data, sysimg_len);
+
+    // do the actual work
+    PM.run(*clone);
+    if (dump_as_bc)
+        WriteBitcodeToFile(clone, FOS);
+    delete clone;
+}
+
+static int32_t jl_assign_functionID(Function *functionObject, int specsig)
+{
+    // give the function an index in the constant lookup table
+    if (!imaging_mode)
+        return 0;
+    jl_sysimg_fvars.push_back(ConstantExpr::getBitCast(
+                shadow_output->getNamedValue(functionObject->getName()),
+                T_pvoidfunc));
+    return jl_sysimg_fvars.size();
+}
+
+extern "C" int32_t jl_get_llvm_gv(jl_value_t *p)
+{
+    // map a jl_value_t memory location to a GlobalVariable
+    std::map<void*, jl_value_llvm>::iterator it;
+    it = jl_value_to_llvm.find(p);
+    if (it == jl_value_to_llvm.end())
+        return 0;
+    return it->second.index;
+}

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -56,13 +56,13 @@ STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 }
 
 void jl_generate_fptr(jl_lambda_info_t *li);
-void jl_compile_linfo(jl_lambda_info_t *li, void *cyclectx);
+void jl_compile_linfo(jl_lambda_info_t *li);
 
 // invoke (compiling if necessary) the jlcall function pointer for a method
 STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_value_t **args, uint32_t nargs)
 {
     if (__unlikely(meth->fptr == NULL)) {
-        jl_compile_linfo(meth, NULL);
+        jl_compile_linfo(meth);
         jl_generate_fptr(meth);
     }
     if (meth->jlcall_api == 0)
@@ -263,7 +263,7 @@ int32_t jl_get_llvm_gv(jl_value_t *p);
 void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
 
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
-jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types, void *cyclectx);
+jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types);
 jl_function_t *jl_module_get_initializer(jl_module_t *m);
 uint32_t jl_module_next_counter(jl_module_t *m);
 void jl_fptr_to_llvm(jl_fptr_t fptr, jl_lambda_info_t *lam, int specsig);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -81,7 +81,7 @@ static void jl_module_load_time_initialize(jl_module_t *m)
             jl_value_t *tt = jl_is_type(f) ? (jl_value_t*)jl_wrap_Type(f) : jl_typeof(f);
             JL_GC_PUSH1(&tt);
             tt = (jl_value_t*)jl_apply_tuple_type_v(&tt, 1);
-            jl_get_specialization1((jl_tupletype_t*)tt, NULL);
+            jl_get_specialization1((jl_tupletype_t*)tt);
             JL_GC_POP();
         }
     }

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -70,19 +70,12 @@ end
         Int32(1), Int32(2))) == 3
 
 # Test whether declarations work properly
-# This test only work properly for llvm 3.5+
-# On llvm <3.5+ even though the the compilation fails on the first try,
-# llvm still adds the intrinsice declaration to the module and subsequent calls
-# are succesfull.
-#if convert(VersionNumber, Base.libllvm_version) > v"3.5-"
-#
-#function undeclared_ceil(x::Float64)
-#    llvmcall("""%2 = call double @llvm.ceil.f64(double %0)
-#        ret double %2""", Float64, Tuple{Float64}, x)
-#end
-#@test_throws ErrorException undeclared_ceil(4.2)
-#
-#end
+function undeclared_ceil(x::Float64)
+    llvmcall("""%2 = call double @llvm.ceil.f64(double %0)
+        ret double %2""", Float64, Tuple{Float64}, x)
+end
+@test_throws ErrorException undeclared_ceil(4.2)
+@test_throws ErrorException undeclared_ceil(4.2)
 
 function declared_floor(x::Float64)
     llvmcall(


### PR DESCRIPTION
this treats the new JITs (MCJIT, ORCJIT) much like the old JIT, but using Module as the atomic unit instead of Function

reviewer note: much of the code motion is moving the logic to interact with the JIT into jitlayers.cpp. this is not yet separable from codegen.cpp, but I expect they should be able to divide into separate compilation units in the future.

TODO:
- [x] reimplement memory optimization of strings in the JIT
- [x] reimplement code-coverage and memory-usage counters

fix #15533
