### PR TITLE
RFC: Make inbounds macros expression-like more often

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -484,8 +484,9 @@ end
 macro inbounds(blk)
     return Expr(:block,
         Expr(:inbounds, true),
-        esc(blk),
-        Expr(:inbounds, :pop))
+        Expr(:local, Expr(:(=), :val, esc(blk))),
+        Expr(:inbounds, :pop),
+        :val)
 end
 
 """

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2024,6 +2024,18 @@ end
     @test typeof(.~A) == Vector{Int}
 end
 
+# @inbounds is expression-like, returning its value; #15558
+@testset "expression-like inbounds" begin
+    local A = [1,2,3]
+    @test (@inbounds A[1]) == 1
+    f(A, i) = @inbounds i == 0 ? (return 0) : A[i]
+    @test f(A, 0) == 0
+    @test f(A, 1) == 1
+    g(A, i) = (i == 0 ? (@inbounds return 0) : (@inbounds A[i]))
+    @test g(A, 0) == 0
+    @test g(A, 1) == 1
+end
+
 @testset "issue #16247" begin
     local A = zeros(3,3)
     @test size(A[:,0x1:0x2]) == (3, 2)


### PR DESCRIPTION
With #11169 fixed, we can now make `@inbounds` return its value ~~*edit: in common cases*.~~
