### PR TITLE
RFC: emphasize Box in code_warntype

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -408,7 +408,7 @@ function show_expr_type(io::IO, ty, emph)
     elseif is(ty, IntrinsicFunction)
         print(io, "::I")
     else
-        if emph && !isleaftype(ty)
+        if emph && (!isleaftype(ty) || ty == Box)
             emphasize(io, "::$ty")
         else
             print(io, "::$ty")


### PR DESCRIPTION
AFAIU: Even though `Box` is a leaftype it still wrecks performance and should thus probably be given the same emphasize treatment as `Any`
