### PR TITLE
More general indexes [2]

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -116,16 +116,16 @@ function serialize(s::SerializationState, t::Tuple)
         writetag(s.io, LONGTUPLE_TAG)
         write(s.io, Int32(l))
     end
-    for e in t
-        serialize(s, e)
+    for x in t
+        serialize(s, x)
     end
 end
 
 function serialize(s::SerializationState, v::SimpleVector)
     writetag(s.io, SIMPLEVECTOR_TAG)
     write(s.io, Int32(length(v)))
-    for e in v
-        serialize(s, e)
+    for x in v
+        serialize(s, x)
     end
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -151,8 +151,8 @@ function show(io::IO, x::DataType)
     if (!isempty(x.parameters) || x.name === Tuple.name) && x !== Tuple
         print(io, '{')
         n = length(x.parameters)
-        for i = 1:n
-            show_type_parameter(io, x.parameters[i])
+        for (i, p) in enumerate(x.parameters)
+            show_type_parameter(io, p)
             i < n && print(io, ',')
         end
         print(io, '}')

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -426,7 +426,7 @@ function selectperm!{I<:Integer}(ix::AbstractVector{I}, v::AbstractVector,
                                  order::Ordering=Forward,
                                  initialized::Bool=false)
     if !initialized
-        @inbounds for i = 1:length(ix)
+        @inbounds for i in eachindex(ix)
             ix[i] = i
         end
     end
@@ -460,7 +460,7 @@ function sortperm!{I<:Integer}(x::AbstractVector{I}, v::AbstractVector;
         throw(ArgumentError("index vector must be the same length as the source vector, $lx != $lv"))
     end
     if !initialized
-        @inbounds for i = 1:lv
+        @inbounds for i in eachindex(v)
             x[i] = i
         end
     end
@@ -500,14 +500,14 @@ end
 
 function sortrows(A::AbstractMatrix; kws...)
     c = 1:size(A,2)
-    rows = [ sub(A,i,c) for i=1:size(A,1) ]
+    rows = [ sub(A,i,c) for i=1:size(A,1) ]  # fixme (iter): update when #15459 is done
     p = sortperm(rows; kws..., order=Lexicographic)
     A[p,:]
 end
 
 function sortcols(A::AbstractMatrix; kws...)
     r = 1:size(A,1)
-    cols = [ sub(A,r,i) for i=1:size(A,2) ]
+    cols = [ sub(A,r,i) for i=1:size(A,2) ]  # fixme (iter): update when #15459 is done
     p = sortperm(cols; kws..., order=Lexicographic)
     A[:,p]
 end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -180,7 +180,7 @@ function show_spec_linfo(io::IO, frame::StackFrame)
             end
             first = true
             print(io, '(')
-            for i = 2:length(params)
+            for i = 2:length(params)  # fixme (iter): `eachindex` with offset?
                 first || print(io, ", ")
                 first = false
                 print(io, "::", params[i])

--- a/base/unicode/utf32.jl
+++ b/base/unicode/utf32.jl
@@ -169,8 +169,8 @@ function convert(T::Type{UTF32String}, bytes::AbstractArray{UInt8})
 end
 
 function isvalid(::Type{UTF32String}, str::Union{Vector{UInt32}, Vector{Char}})
-    for i=1:length(str)
-        @inbounds if !isvalid(Char, UInt32(str[i])) ; return false ; end
+    for c in str
+        @inbounds if !isvalid(Char, UInt32(c)) ; return false ; end
     end
     return true
 end


### PR DESCRIPTION
Here's a second PR to cover [this list](https://github.com/JuliaLang/julia/pull/15434#issuecomment-194991739) of subtasks (from `show.jl` and to the end of the list). 

General idea is to move from a linear integer-based indexing (i.e. `for i=1:length(A)`) to more general approaches (e.g. `for a in A` or `for a in eachindex(A)`) to support wider range of arrays and possibly better optimize code for them. 
