### PR TITLE
Fix compilation on LLVM 3.8

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1510,10 +1510,7 @@ static uint64_t compute_obj_symsize(const object::ObjectFile *obj, uint64_t offs
         object::SectionRef Section = *I;
 #endif
         uint64_t SAddr, SSize;
-#ifdef LLVM38
-        SAddr = Section.getAddress().get();
-        SSize = Section.getSize().get();
-#elif defined(LLVM36)
+#ifdef LLVM36
         SAddr = Section.getAddress();
         SSize = Section.getSize();
 #else

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -377,13 +377,12 @@ public:
 #endif
             if (Section == EndSection) continue;
             if (!Section->isText()) continue;
+            uint64_t SectionAddr = Section->getAddress();
 #ifdef LLVM38
-            uint64_t SectionAddr = Section->getAddress().get();
             uint64_t SectionLoadAddr = L.getSectionLoadAddress(*Section);
 #else
             StringRef secName;
             Section->getName(secName);
-            uint64_t SectionAddr = Section->getAddress();
             uint64_t SectionLoadAddr = L.getSectionLoadAddress(secName);
 #endif
             Addr -= SectionAddr - SectionLoadAddr;


### PR DESCRIPTION
According to [git blame](https://github.com/llvm-mirror/llvm/blame/2e8d041188e1eb4042a407d2af3fbb2ebecd3215/include/llvm/Object/ObjectFile.h#L86), the return type of `llvm::object::SectionRef::getAddress` and `llvm::object::SectionRef::getSize` has always been `uint64_t` since late 2014 so I'm wondering if the `#ifdef`'s for LLVM 38 are correct.

The code was added in https://github.com/JuliaLang/julia/commit/70c6e3473808d06fae02de69947a517a80476479 so @vtjnash 
