### PR TITLE
make sparsevec preserve zeros

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -70,24 +70,9 @@ function _sparsevector!{Tv,Ti<:Integer}(I::Vector{Ti}, V::Vector{Tv}, len::Integ
         permute!(I, p)
         permute!(V, p)
         m = length(I)
-
-        # advances to the first non-zero element
-        r = 1     # index of last processed entry
-        while r <= m
-            if V[r] == 0
-                r += 1
-            else
-                break
-            end
-        end
-        r > m && return SparseVector(len, Ti[], Tv[])
-
-        # move r-th to l-th
+        r = 1
         l = 1       # length of processed part
         i = I[r]    # row-index of current element
-        if r > 1
-            I[l] = i; V[l] = V[r]
-        end
 
         # main loop
         while r < m
@@ -97,17 +82,12 @@ function _sparsevector!{Tv,Ti<:Integer}(I::Vector{Ti}, V::Vector{Tv}, len::Integ
                 V[l] = combine(V[l], V[r])
             else  # advance l, and move r-th to l-th
                 pv = V[l]
-                if pv != 0
-                    l += 1
-                end
+                l += 1
                 i = i2
                 if l < r
                     I[l] = i; V[l] = V[r]
                 end
             end
-        end
-        if V[l] == 0
-            l -= 1
         end
         if l < m
             resize!(I, l)
@@ -188,11 +168,9 @@ function sparsevec{Tv,Ti<:Integer}(dict::Associative{Ti,Tv})
         if k > len
             len = k
         end
-        if v != 0
-            cnt += 1
-            @inbounds nzind[cnt] = k
-            @inbounds nzval[cnt] = v
-        end
+        cnt += 1
+        @inbounds nzind[cnt] = k
+        @inbounds nzval[cnt] = v
     end
     resize!(nzind, cnt)
     resize!(nzval, cnt)
@@ -208,11 +186,9 @@ function sparsevec{Tv,Ti<:Integer}(dict::Associative{Ti,Tv}, len::Integer)
     maxk = convert(Ti, len)
     for (k, v) in dict
         1 <= k <= maxk || throw(ArgumentError("an index (key) is out of bound."))
-        if v != 0
-            cnt += 1
-            @inbounds nzind[cnt] = k
-            @inbounds nzval[cnt] = v
-        end
+        cnt += 1
+        @inbounds nzind[cnt] = k
+        @inbounds nzval[cnt] = v
     end
     resize!(nzind, cnt)
     resize!(nzval, cnt)

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -66,7 +66,7 @@ end
 
 @test exact_equal(
     sparsevec([3, 3], [5.0, -5.0], 8),
-    spzeros(Float64, 8))
+    SparseVector(8, [3], [0.0]))
 
 @test exact_equal(
     sparsevec([2, 3, 6], [12.0, 18.0, 25.0]),
@@ -81,14 +81,15 @@ let x0 = SparseVector(8, [2, 3, 6], [12.0, 18.0, 25.0])
 
     @test exact_equal(
         sparsevec([2, 3, 4, 4, 6], [12.0, 18.0, 5.0, -5.0, 25.0], 8),
-        x0)
+        SparseVector(8, [2, 3, 4, 6], [12.0, 18.0, 0.0, 25.0]))
 
     @test exact_equal(
         sparsevec([1, 1, 1, 2, 3, 3, 6], [2.0, 3.0, -5.0, 12.0, 10.0, 8.0, 25.0], 8),
-        x0)
+        SparseVector(8, [1, 2, 3, 6], [0.0, 12.0, 18.0, 25.0]))
 
     @test exact_equal(
-        sparsevec([2, 3, 6, 7, 7], [12.0, 18.0, 25.0, 5.0, -5.0], 8), x0)
+        sparsevec([2, 3, 6, 7, 7], [12.0, 18.0, 25.0, 5.0, -5.0], 8),
+        SparseVector(8, [2, 3, 6, 7], [12.0, 18.0, 25.0, 0.0]))
 end
 
 # from dictionary
@@ -108,6 +109,9 @@ let x = spv_x1
 
     xc = sparsevec(a)
     @test exact_equal(xc, SparseVector(6, [2, 5, 6], [1.25, -0.75, 3.5]))
+
+    d = Dict{Int, Float64}((1 => 0.0, 2 => 1.0, 3 => 2.0))
+    @test exact_equal(sparsevec(d), SparseVector(3, [1, 2, 3], [0.0, 1.0, 2.0]))
 end
 
 # spones - copies structure, but replaces nzvals with ones


### PR DESCRIPTION
After https://github.com/JuliaLang/julia/pull/15242 there is a mismatch between the constructors of sparse matrices / sparse vectors whether they preserve values in the sparse structure that happened to accumulate to zero.

Currently, matrices keeps them while vectors remove them:

``` jl
julia> sparsevec([1,2,3], [0.0, 1.0, 2.0])
Sparse vector of length 3, with 2 Float64 nonzero entries:
  [2]  =  1.0
  [3]  =  2.0


julia> sparse([1, 2, 3], [1, 1, 1], [0.0, 1.0, 2.0])
3x1 sparse matrix with 3 Float64 entries:
    [1, 1]  =  0.0
    [2, 1]  =  1.0
    [3, 1]  =  2.0
```

This makes sparse vectors behave the same as matrices:

``` jl
julia> sparsevec([1,2,3], [0.0, 1.0, 2.0])
Sparse vector of length 3, with 3 Float64 nonzero entries:
  [1]  =  0.0
  [2]  =  1.0
  [3]  =  2.0
```
