### PR TITLE
RFC: Improve consistency of Date formatting

### DIFF
--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -243,23 +243,35 @@ string:
 | Code       | Matches   | Comment                                                      |
 |:-----------|:----------|:-------------------------------------------------------------|
 | `y`        | 1996, 96  | Returns year of 1996, 0096                                   |
-| `Y`        | 1996, 96  | Returns year of 1996, 0096. Equivalent to `y`                |
-| `m`        | 1, 01     | Matches 1 or 2-digit months                                  |
+| `m`        | 1, 01     | Matches numeric month                                        |
 | `u`        | Jan       | Matches abbreviated months according to the `locale` keyword |
 | `U`        | January   | Matches full month names according to the `locale` keyword   |
-| `d`        | 1, 01     | Matches 1 or 2-digit days                                    |
+| `d`        | 1, 01     | Matches the day of the month                                 |
 | `H`        | 00        | Matches hours                                                |
 | `M`        | 00        | Matches minutes                                              |
 | `S`        | 00        | Matches seconds                                              |
-| `s`        | .500      | Matches milliseconds                                         |
+| `s`        | 500       | Matches milliseconds                                         |
 | `e`        | Mon, Tues | Matches abbreviated days of the week                         |
 | `E`        | Monday    | Matches full name days of the week                           |
-| `yyyymmdd` | 19960101  | Matches fixed-width year, month, and day                     |
 
-Characters not listed above are normally treated as delimiters between date and time slots.
-For example a `dt` string of "1996-01-15T00:00:00.0" would have a `format` string like
-"y-m-dTH:M:S.s". If you need to use a code character as a delimiter you can escape it using
-backslash. The date "1995y01m" would have the format "y\\ym\\m".
+Any non-code characters are treated as delimiters between date and time slots. For example:
+```jldoctest
+julia> DateTime("1996-01-15T00:00:00.0", "y-m-dTH:M:S.s")
+1996-01-15T00:00:00
+```
+
+When delimiters do not exist then the width of the code character controls how the string is
+parsed.
+```jldoctest
+julia> DateTime("19960115", "yyyymmdd")
+1996-01-15T00:00:00
+```
+
+If you need to use a code character as a delimiter you can escape it using backslash.
+```jldoctest
+julia> DateTime("1995y01m", "y\\ym\\m")
+1995-01-01T00:00:00
+```
 """
 DateTime(dt::AbstractString,format::AbstractString;locale::AbstractString="english") = DateTime(dt,DateFormat(format,locale))
 
@@ -298,30 +310,56 @@ following character codes can be used to construct the `format` string:
 
 | Code       | Examples  | Comment                                                      |
 |:-----------|:----------|:-------------------------------------------------------------|
-| `y`        | 6         | Numeric year with a fixed width                              |
-| `Y`        | 1996      | Numeric year with a minimum width                            |
-| `m`        | 1, 12     | Numeric month with a minimum width                           |
-| `u`        | Jan       | Month name shortened to 3-chars according to the `locale`    |
+| `y`        | 1996      | Numeric year                                                 |
+| `m`        | 1, 12     | Numeric month                                                |
+| `u`        | Jan       | Month name abbreviation according to the `locale` keyword    |
 | `U`        | January   | Full month name according to the `locale` keyword            |
-| `d`        | 1, 31     | Day of the month with a minimum width                        |
-| `H`        | 0, 23     | Hour (24-hour clock) with a minimum width                    |
-| `M`        | 0, 59     | Minute with a minimum width                                  |
-| `S`        | 0, 59     | Second with a minimum width                                  |
-| `s`        | 000, 500  | Millisecond with a minimum width of 3                        |
-| `e`        | Mon, Tue  | Abbreviated days of the week                                 |
-| `E`        | Monday    | Full day of week name                                        |
+| `d`        | 1, 31     | Day of the month                                             |
+| `H`        | 0, 23     | Hour (24-hour clock)                                         |
+| `M`        | 0, 59     | Minute                                                       |
+| `S`        | 0, 59     | Second                                                       |
+| `s`        | 0, 999    | Millisecond                                                  |
+| `e`        | Mon, Tue  | Abbreviated day of the week                                  |
+| `E`        | Monday    | Named day of the week                                        |
 
 The number of sequential code characters indicate the width of the code. A format of
 `yyyy-mm` specifies that the code `y` should have a width of four while `m` a width of two.
-Codes that yield numeric digits have an associated mode: fixed-width or minimum-width.
-The fixed-width mode left-pads the value with zeros when it is shorter than the specified
-width and truncates the value when longer. Minimum-width mode works the same as fixed-width
-except that it does not truncate values longer than the width.
+Codes that yield numeric digits and have a width greater than one will be truncated or
+left-padded with zeros to match the specified width. Codes with a width of one are not
+truncated.
 
-When creating a `format` you can use any non-code characters as a separator. For example to
-generate the string "1996-01-15T00:00:00" you could use `format`: "yyyy-mm-ddTHH:MM:SS".
-Note that if you need to use a code character as a literal you can use the escape character
-backslash. The string "1996y01m" can be produced with the format "yyyy\\ymm\\m".
+Any non-code characters are treated as separator between date and time slots. For example:
+```jldoctest
+julia> Dates.format(DateTime(1996,1,15), "y-mm-ddTHH:MM:SS")
+"1996-01-15T00:00:00"
+```
+
+The millisecond code `s` has a special behaviour when it is directly preceeded by a period:
+```jldoctest
+julia> dt = DateTime(1,1,1,0,0,0,25)
+0001-01-01T00:00:00.025
+
+julia> Dates.format(dt, "s")
+"25"
+
+julia> Dates.format(dt, ".s")
+".025"
+
+julia> dt = DateTime(1,1,1,0,0,0,250)
+0001-01-01T00:00:00.25
+
+julia> Dates.format(dt, "s")
+"250"
+
+julia> Dates.format(dt, ".s")
+".25"
+```
+
+If you need to use a code character as a separator you can escape it using backslash.
+```jldoctest
+julia> Dates.format(DateTime(1995), "yyyy\\ymm\\m")
+"1995y01m"
+```
 """
 format(dt::TimeType,f::AbstractString;locale::AbstractString="english") = format(dt,DateFormat(f,locale))
 

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -143,7 +143,10 @@ function slotparse(slot::Slot{Month},x,locale)
         return Month(MONTHTOVALUE[locale][lowercase(x)])
     end
 end
-slotparse(slot::Slot{Millisecond},x,locale) = !ismatch(r"[^0-9\s]",x) ? slot.parser(Base.parse(Float64,"."*x)*1000.0) : throw(SLOTERROR)
+function slotparse(slot::Slot{Millisecond},str,locale)
+    ismatch(r"[^0-9\s]", str) && throw(SLOTERROR)
+    return slot.parser(endswith(slot.prefix, '.') ? rpad(str, 3, '0') : str)
+end
 slotparse(slot::Slot{DayOfWeekSlot},x,locale) = nothing
 
 function getslot(x,slot::DelimitedSlot,locale,cursor)

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -210,7 +210,7 @@ end
 function slotformat(slot::Slot{Millisecond},dt,locale)
     if endswith(slot.prefix, '.')
         s = string(millisecond(dt) / 1000)[3:end]
-        return slot.width > 1 ? rpad(s, slot.width, '0') : s
+        return slot.width > 1 ? rpad(s, slot.width, '0')[1:slot.width] : s
     else
         s = string(millisecond(dt))
         return slot.width > 1 ? lpad(s, slot.width, '0')[(end - slot.width + 1):end] : s

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -151,15 +151,15 @@ end
 slotparse(slot::Slot{DayOfWeekSlot},str,locale) = nothing
 
 function getslot(str,slot::DelimitedSlot,locale,cursor)
-    endind = first(search(str, slot.suffix, nextind(str, cursor)))
-    if endind == 0 # we didn't find the next delimiter
+    index = search(str, slot.suffix, nextind(str, cursor))
+    if first(index) == 0  # we didn't find the next delimiter
         s = str[cursor:end]
-        index = endof(str) + 1
+        cursor = endof(str) + 1
     else
-        s = str[cursor:(endind - 1)]
-        index = nextind(str, endind)
+        s = str[cursor:(first(index) - 1)]
+        cursor = nextind(str, last(index))
     end
-    return index, slotparse(slot, strip(s),locale)
+    return cursor, slotparse(slot, strip(s),locale)
 end
 function getslot(str,slot,locale,cursor)
     cursor + slot.width, slotparse(slot, strip(str[cursor:(cursor + slot.width - 1)]), locale)

--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -85,37 +85,52 @@ Alternatively, you can write ``using Base.Dates`` to bring all exported function
 
    Construct a ``DateTime`` by parsing the ``dt`` date string following the pattern given in the ``format`` string. The following character codes can be used to construct the ``format`` string:
 
-   +--------------+-----------+----------------------------------------------------------------+
-   | Code         | Matches   | Comment                                                        |
-   +==============+===========+================================================================+
-   | ``y``        | 1996, 96  | Returns year of 1996, 0096                                     |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``Y``        | 1996, 96  | Returns year of 1996, 0096. Equivalent to ``y``                |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``m``        | 1, 01     | Matches 1 or 2-digit months                                    |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``u``        | Jan       | Matches abbreviated months according to the ``locale`` keyword |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``U``        | January   | Matches full month names according to the ``locale`` keyword   |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``d``        | 1, 01     | Matches 1 or 2-digit days                                      |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``H``        | 00        | Matches hours                                                  |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``M``        | 00        | Matches minutes                                                |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``S``        | 00        | Matches seconds                                                |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``s``        | .500      | Matches milliseconds                                           |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``e``        | Mon, Tues | Matches abbreviated days of the week                           |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``E``        | Monday    | Matches full name days of the week                             |
-   +--------------+-----------+----------------------------------------------------------------+
-   | ``yyyymmdd`` | 19960101  | Matches fixed-width year, month, and day                       |
-   +--------------+-----------+----------------------------------------------------------------+
+   +-------+-----------+----------------------------------------------------------------+
+   | Code  | Matches   | Comment                                                        |
+   +=======+===========+================================================================+
+   | ``y`` | 1996, 96  | Returns year of 1996, 0096                                     |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``m`` | 1, 01     | Matches numeric month                                          |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``u`` | Jan       | Matches abbreviated months according to the ``locale`` keyword |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``U`` | January   | Matches full month names according to the ``locale`` keyword   |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``d`` | 1, 01     | Matches the day of the month                                   |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``H`` | 00        | Matches hours                                                  |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``M`` | 00        | Matches minutes                                                |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``S`` | 00        | Matches seconds                                                |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``s`` | 500       | Matches milliseconds                                           |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``e`` | Mon, Tues | Matches abbreviated days of the week                           |
+   +-------+-----------+----------------------------------------------------------------+
+   | ``E`` | Monday    | Matches full name days of the week                             |
+   +-------+-----------+----------------------------------------------------------------+
 
-   Characters not listed above are normally treated as delimiters between date and time slots. For example a ``dt`` string of "1996-01-15T00:00:00.0" would have a ``format`` string like "y-m-dTH:M:S.s". If you need to use a code character as a delimiter you can escape it using backslash. The date "1995y01m" would have the format "y\\ym\\m".
+   Any non-code characters are treated as delimiters between date and time slots. For example:
+
+   .. doctest::
+
+       julia> DateTime("1996-01-15T00:00:00.0", "y-m-dTH:M:S.s")
+       1996-01-15T00:00:00
+
+   When delimiters do not exist then the width of the code character controls how the string is parsed.
+
+   .. doctest::
+
+       julia> DateTime("19960115", "yyyymmdd")
+       1996-01-15T00:00:00
+
+   If you need to use a code character as a delimiter you can escape it using backslash.
+
+   .. doctest::
+
+       julia> DateTime("1995y01m", "y\ym\m")
+       1995-01-01T00:00:00
 
 .. _man-date-formatting:
 
@@ -128,34 +143,66 @@ Alternatively, you can write ``using Base.Dates`` to bring all exported function
    +-------+----------+-------------------------------------------------------------+
    | Code  | Examples | Comment                                                     |
    +=======+==========+=============================================================+
-   | ``y`` | 6        | Numeric year with a fixed width                             |
+   | ``y`` | 1996     | Numeric year                                                |
    +-------+----------+-------------------------------------------------------------+
-   | ``Y`` | 1996     | Numeric year with a minimum width                           |
+   | ``m`` | 1, 12    | Numeric month                                               |
    +-------+----------+-------------------------------------------------------------+
-   | ``m`` | 1, 12    | Numeric month with a minimum width                          |
-   +-------+----------+-------------------------------------------------------------+
-   | ``u`` | Jan      | Month name shortened to 3-chars according to the ``locale`` |
+   | ``u`` | Jan      | Month name abbreviation according to the ``locale`` keyword |
    +-------+----------+-------------------------------------------------------------+
    | ``U`` | January  | Full month name according to the ``locale`` keyword         |
    +-------+----------+-------------------------------------------------------------+
-   | ``d`` | 1, 31    | Day of the month with a minimum width                       |
+   | ``d`` | 1, 31    | Day of the month                                            |
    +-------+----------+-------------------------------------------------------------+
-   | ``H`` | 0, 23    | Hour (24-hour clock) with a minimum width                   |
+   | ``H`` | 0, 23    | Hour (24-hour clock)                                        |
    +-------+----------+-------------------------------------------------------------+
-   | ``M`` | 0, 59    | Minute with a minimum width                                 |
+   | ``M`` | 0, 59    | Minute                                                      |
    +-------+----------+-------------------------------------------------------------+
-   | ``S`` | 0, 59    | Second with a minimum width                                 |
+   | ``S`` | 0, 59    | Second                                                      |
    +-------+----------+-------------------------------------------------------------+
-   | ``s`` | 000, 500 | Millisecond with a minimum width of 3                       |
+   | ``s`` | 0, 999   | Millisecond                                                 |
    +-------+----------+-------------------------------------------------------------+
-   | ``e`` | Mon, Tue | Abbreviated days of the week                                |
+   | ``e`` | Mon, Tue | Abbreviated day of the week                                 |
    +-------+----------+-------------------------------------------------------------+
-   | ``E`` | Monday   | Full day of week name                                       |
+   | ``E`` | Monday   | Named day of the week                                       |
    +-------+----------+-------------------------------------------------------------+
 
-   The number of sequential code characters indicate the width of the code. A format of ``yyyy-mm`` specifies that the code ``y`` should have a width of four while ``m`` a width of two. Codes that yield numeric digits have an associated mode: fixed-width or minimum-width. The fixed-width mode left-pads the value with zeros when it is shorter than the specified width and truncates the value when longer. Minimum-width mode works the same as fixed-width except that it does not truncate values longer than the width.
+   The number of sequential code characters indicate the width of the code. A format of ``yyyy-mm`` specifies that the code ``y`` should have a width of four while ``m`` a width of two. Codes that yield numeric digits and have a width greater than one will be truncated or left-padded with zeros to match the specified width. Codes with a width of one are not truncated.
 
-   When creating a ``format`` you can use any non-code characters as a separator. For example to generate the string "1996-01-15T00:00:00" you could use ``format``\ : "yyyy-mm-ddTHH:MM:SS". Note that if you need to use a code character as a literal you can use the escape character backslash. The string "1996y01m" can be produced with the format "yyyy\\ymm\\m".
+   Any non-code characters are treated as separator between date and time slots. For example:
+
+   .. doctest::
+
+       julia> Dates.format(DateTime(1996,1,15), "y-mm-ddTHH:MM:SS")
+       "1996-01-15T00:00:00"
+
+   The millisecond code ``s`` has a special behaviour when it is directly preceeded by a period:
+
+   .. doctest::
+
+       julia> dt = DateTime(1,1,1,0,0,0,25)
+       0001-01-01T00:00:00.025
+
+       julia> Dates.format(dt, "s")
+       "25"
+
+       julia> Dates.format(dt, ".s")
+       ".025"
+
+       julia> dt = DateTime(1,1,1,0,0,0,250)
+       0001-01-01T00:00:00.25
+
+       julia> Dates.format(dt, "s")
+       "250"
+
+       julia> Dates.format(dt, ".s")
+       ".25"
+
+   If you need to use a code character as a separator you can escape it using backslash.
+
+   .. doctest::
+
+       julia> Dates.format(DateTime(1995), "yyyy\ymm\m")
+       "1995y01m"
 
 .. function:: DateFormat(format::AbstractString, locale::AbstractString="english") -> DateFormat
 

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -387,3 +387,6 @@ let dt = Dates.DateTime(54321, 12, 13, 14, 55, 56, 997)
     @test Dates.format(dt, ".s") == ".997"
     @test Dates.format(dt, ".ssss") == ".9970"
 end
+
+@test Dates.DateTime("25", "s") == Dates.DateTime(1,1,1,0,0,0,25)
+@test Dates.DateTime(".25", ".s") == Dates.DateTime(1,1,1,0,0,0,250)

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -262,6 +262,8 @@ f = "/yyyy/m/d"
 # from Jiahao
 @test Dates.Date("2009年12月01日","yyyy年mm月dd日") == Dates.Date(2009,12,1)
 @test Dates.format(Dates.Date(2009,12,1),"yyyy年mm月dd日") == "2009年12月01日"
+@test Dates.Date("2009(年)12(月)01(日)","yyyy(年)mm(月)dd(日)") == Dates.Date(2009,12,1)
+@test Dates.format(Dates.Date(2009,12,1),"yyyy(年)mm(月)dd(日)") == "2009(年)12(月)01(日)"
 @test Dates.Date("2009-12-01","yyyy-mm-dd") == Dates.Date(2009,12,1)
 
 # French: from Milan

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -17,7 +17,7 @@
 @test string(Dates.DateTime(2000,1,1,0,0,0,998)) == "2000-01-01T00:00:00.998"
 @test string(Dates.DateTime(2000,1,1,0,0,0,999)) == "2000-01-01T00:00:00.999"
 
-# DateTime parsing
+# DateTime parsing and formatting
 # Useful reference for different locales: http://library.princeton.edu/departments/tsd/katmandu/reference/months.html
 
 # Using parse directly allows for more flexibility.
@@ -29,6 +29,65 @@ end
 
 # Issue #13644: Ensure that Dates.parse returns a Period array when no custom slots are used.
 @test eltype(Dates.parse("1942-12-25T01:23:45", Dates.DateFormat("yyyy-mm-ddTHH:MM:SS", "english"))) == Dates.Period
+
+let d = Dates.Date(1996, 1, 15)
+    @test Dates.format(d, "y") == "1996"
+    @test Dates.format(d, "yy") == "96"
+    @test Dates.format(d, "yyyy") == "1996"
+    @test Dates.format(d, "yyyyyy") == "001996"
+    @test Dates.format(d, "m") == "1"
+    @test Dates.format(d, "mm") == "01"
+    @test Dates.format(d, "d") == "15"
+    @test Dates.format(d, "dd") == "15"
+end
+
+# Issue 15195
+let d = Dates.Date(typemax(Dates.Date))
+    @test Dates.format(d, "y") == "252522163911149"
+    @test Dates.format(d, "yy") == "49"
+    @test Dates.format(d, "yyyy") == "1149"
+end
+
+# Milliseconds formatting works differently when preceeded by a period
+let dt = Dates.DateTime(1,1,1,0,0,0,250)
+    @test Dates.format(dt, "s") == "250"
+    @test Dates.format(dt, "ss") == "50"
+    @test Dates.format(dt, "sss") == "250"
+    @test Dates.format(dt, "ssss") == "0250"
+    @test Dates.format(dt, ".s") == ".25"
+    @test Dates.format(dt, ".ss") == ".25"
+    @test Dates.format(dt, ".sss") == ".250"
+    @test Dates.format(dt, ".ssss") == ".2500"
+
+    @test Dates.DateTime("250", "s") == dt
+    @test Dates.DateTime("250", "ss") == dt
+    @test Dates.DateTime("250", "sss") == dt
+    @test Dates.DateTime("250", "ssss") == dt
+    @test Dates.DateTime(".25", ".s") == dt
+    @test Dates.DateTime(".25", ".ss") == dt
+    @test Dates.DateTime(".25", ".sss") == dt
+    @test Dates.DateTime(".25", ".ssss") == dt
+end
+
+let dt = Dates.DateTime(1,1,1,0,0,0,25)
+    @test Dates.format(dt, "s") == "25"
+    @test Dates.format(dt, "ss") == "25"
+    @test Dates.format(dt, "sss") == "025"
+    @test Dates.format(dt, "ssss") == "0025"
+    @test Dates.format(dt, ".s") == ".025"
+    @test Dates.format(dt, ".ss") == ".02"
+    @test Dates.format(dt, ".sss") == ".025"
+    @test Dates.format(dt, ".ssss") == ".0250"
+
+    @test Dates.DateTime("25", "s") == dt
+    @test Dates.DateTime("25", "ss") == dt
+    @test Dates.DateTime("25", "sss") == dt
+    @test Dates.DateTime("25", "ssss") == dt
+    @test Dates.DateTime(".025", ".s") == dt
+    @test Dates.DateTime(".025", ".ss") == dt
+    @test Dates.DateTime(".025", ".sss") == dt
+    @test Dates.DateTime(".025", ".ssss") == dt
+end
 
 # Common Parsing Patterns
 #'1996-January-15'
@@ -353,13 +412,7 @@ let
     @test DateTime(ds, escaped_format) == dt
 end
 
-# PR: https://github.com/JuliaLang/julia/pull/15588
-let d = typemax(Dates.Date)
-    @test Dates.format(d, "y") == "252522163911149"
-    @test Dates.format(d, "yy") == "49"
-    @test Dates.format(d, "yyyy") == "1149"
-end
-
+# PR: 15588
 let dt = Dates.DateTime(1991, 2, 3, 4, 5, 6, 7)
     @test Dates.format(dt, "y") == "1991"
     @test Dates.format(dt, "yy") == "91"

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -368,6 +368,10 @@ let dt = Dates.DateTime(1991, 2, 3, 4, 5, 6, 7)
     @test Dates.format(dt, "m") == "2"
     @test Dates.format(dt, "mm") == "02"
     @test Dates.format(dt, "mmm") == "002"
+    @test Dates.format(dt, "s") == "7"
+    @test Dates.format(dt, "ssss") == "0007"
+    @test Dates.format(dt, ".s") == ".007"
+    @test Dates.format(dt, ".ssss") == ".0070"
 end
 
 let dt = Dates.DateTime(54321, 12, 13, 14, 55, 56, 997)
@@ -378,4 +382,8 @@ let dt = Dates.DateTime(54321, 12, 13, 14, 55, 56, 997)
     @test Dates.format(dt, "m") == "12"
     @test Dates.format(dt, "mm") == "12"
     @test Dates.format(dt, "mmm") == "012"
+    @test Dates.format(dt, "s") == "997"
+    @test Dates.format(dt, "ssss") == "0997"
+    @test Dates.format(dt, ".s") == ".997"
+    @test Dates.format(dt, ".ssss") == ".9970"
 end

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -385,6 +385,10 @@ dt = Dates.DateTime(2014,8,23,17,22,15)
 
 # Issue: https://github.com/quinnj/TimeZones.jl/issues/19
 let
+    @test Dates.DateTime("1995y01m", "y\\ym\\m") == Dates.DateTime(1995)
+    @test Dates.DateTime("1995yy01", "y\\y\\ym") == Dates.DateTime(1995)
+end
+let
     ds = "2015-07-24T05:38:19.591Z"
     dt = Dates.DateTime(2015,7,24,5,38,19,591)
 

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -215,7 +215,7 @@ const french = Dict("janv"=>1,"févr"=>2,"mars"=>3,"avril"=>4,"mai"=>5,"juin"=>6
 Dates.MONTHTOVALUEABBR["french"] = french
 Dates.VALUETOMONTHABBR["french"] = Dict(v=>k for (k,v) in french)
 
-f = "dd uuuuu yyyy"
+f = "dd uuu yyyy"
 @test Dates.Date("28 mai 2014",f;locale="french") == Dates.Date(2014,5,28)
 @test Dates.format(Dates.Date(2014,5,28),f;locale="french") == "28 mai 2014"
 @test Dates.Date("28 févr 2014",f;locale="french") == Dates.Date(2014,2,28)
@@ -238,13 +238,13 @@ f = "dduuuyy"
 f = "dduuuyyyy"
 @test Dates.Date("01Dec2009",f) == Dates.Date(2009,12,1)
 @test Dates.format(Dates.Date(2009,12,1),f) == "01Dec2009"
-f = "duy"
+f = "duyy"
 const globex = Dict("f"=>Dates.Jan,"g"=>Dates.Feb,"h"=>Dates.Mar,"j"=>Dates.Apr,"k"=>Dates.May,"m"=>Dates.Jun,
                     "n"=>Dates.Jul,"q"=>Dates.Aug,"u"=>Dates.Sep,"v"=>Dates.Oct,"x"=>Dates.Nov,"z"=>Dates.Dec)
 Dates.MONTHTOVALUEABBR["globex"] = globex
 Dates.VALUETOMONTHABBR["globex"] = Dict(v=>uppercase(k) for (k,v) in globex)
-@test Dates.Date("1F4",f;locale="globex") + Dates.Year(2010) == Dates.Date(2014,1,1)
-@test Dates.format(Dates.Date(2014,1,1),f;locale="globex") == "1F4"
+@test Dates.Date("1F14",f;locale="globex") + Dates.Year(2000) == Dates.Date(2014,1,1)
+@test Dates.format(Dates.Date(2014,1,1),f;locale="globex") == "1F14"
 
 # From Matt Bauman
 f = "yyyy-mm-ddTHH:MM:SS"
@@ -324,13 +324,6 @@ dt = Dates.DateTime(2014,8,23,17,22,15)
 @test Dates.format(Dates.DateTime(2014,11,2,0,0,0,9),Dates.RFC1123Format) == "Sun, 02 Nov 2014 00:00:00"
 @test Dates.format(Dates.DateTime(2014,12,5,0,0,0,9),Dates.RFC1123Format) == "Fri, 05 Dec 2014 00:00:00"
 
-# Issue 15195
-let f = "YY"
-    @test Dates.format(Dates.Date(1999), f) == "1999"
-    @test Dates.format(Dates.Date(9), f) == "09"
-    @test Dates.format(typemax(Dates.Date), f) == "252522163911149"
-end
-
 # Issue: https://github.com/quinnj/TimeZones.jl/issues/19
 let
     ds = "2015-07-24T05:38:19.591Z"
@@ -358,4 +351,31 @@ let
     # Ensure that the default behaviour has been restored
     @test DateTime(ds, format) == dt
     @test DateTime(ds, escaped_format) == dt
+end
+
+# PR: https://github.com/JuliaLang/julia/pull/15588
+let d = typemax(Dates.Date)
+    @test Dates.format(d, "y") == "252522163911149"
+    @test Dates.format(d, "yy") == "49"
+    @test Dates.format(d, "yyyy") == "1149"
+end
+
+let dt = Dates.DateTime(1991, 2, 3, 4, 5, 6, 7)
+    @test Dates.format(dt, "y") == "1991"
+    @test Dates.format(dt, "yy") == "91"
+    @test Dates.format(dt, "yyyy") == "1991"
+    @test Dates.format(dt, "yyyyyy") == "001991"
+    @test Dates.format(dt, "m") == "2"
+    @test Dates.format(dt, "mm") == "02"
+    @test Dates.format(dt, "mmm") == "002"
+end
+
+let dt = Dates.DateTime(54321, 12, 13, 14, 55, 56, 997)
+    @test Dates.format(dt, "y") == "54321"
+    @test Dates.format(dt, "yy") == "21"
+    @test Dates.format(dt, "yyyy") == "4321"
+    @test Dates.format(dt, "yyyyyy") == "054321"
+    @test Dates.format(dt, "m") == "12"
+    @test Dates.format(dt, "mm") == "12"
+    @test Dates.format(dt, "mmm") == "012"
 end


### PR DESCRIPTION
After the work on #15224 had completed I came up with an alternative that eliminates the need for the 'Y' slot and makes the slots work in a more consistent manner. Take the example of formatting a month as a string:

``` julia
julia> Dates.format(DateTime(1996, 4), "m")
"4"

julia> Dates.format(DateTime(1996, 4), "mm")
"04"

julia> Dates.format(DateTime(1996, 12), "m")
"12"

julia> Dates.format(DateTime(1996, 12), "mm")
"12"
```

When the number of digits in the month exceeds the width of the slot then all of the digits of the month are returned. Contrast this with year:

``` julia
julia> Dates.format(DateTime(1996, 4), "y")
"6"

julia> Dates.format(DateTime(1996, 4), "yy")
"96"
```

This PR attempts to unify these behaviours by only truncating a slot when the width is two or greater:

``` julia
julia> Dates.format(DateTime(1996, 4), "y m")  # New breaking behaviour
"1996 4"

julia> Dates.format(DateTime(1996, 4), "yy mm")
"96 04"
```

Another issue which this PR addresses is how milliseconds where always assumed to be preceded by a period:

``` julia
julia> Dates.format(DateTime(1,1,1,0,0,0,250), "s")
"25"

julia> Dates.format(DateTime(1,1,1,0,0,0,250), "ss")
"25"

julia> Dates.format(DateTime(1,1,1,0,0,0,250), ".s")
".25"
```

The code now looks at the preceeding delimiter and adjusts the behaviour accordingly:

``` julia
julia> Dates.format(DateTime(1,1,1,0,0,0,250), "s")  # New behaviour
"250"

julia> Dates.format(DateTime(1,1,1,0,0,0,250), "ss")  # New behaviour
"50"

julia> Dates.format(DateTime(1,1,1,0,0,0,250), ".s")
".25"
```

To summarize:
- Changes now make working with formatting more consistent
- `y` slot with a width of one returns the entire year rather than just the last digit
- `Y` slot removed
- `s` (millisecond) slot behaviour changes when preceded by a period
