### PR TITLE
Two more tweaks for the debugger

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -978,6 +978,12 @@ static uint64_t getAddressForFunction(llvm::Function *llvmf)
 #endif
 }
 
+extern "C" JL_DLLEXPORT
+uint64_t jl_get_llvm_fptr(llvm::Function *llvmf)
+{
+    return getAddressForFunction(llvmf);
+}
+
 // this assumes that jl_compile_linfo has already been called
 // and forces compilation of the lambda info
 extern "C" void jl_generate_fptr(jl_lambda_info_t *li)


### PR DESCRIPTION
- Put back jl_get_llvmf_fptr, which got lost in a recent commit
- Have jl_get_section_start, return the fbase if asked for an ip
  in a shared library. The name might be slightly inaccurate now,
  but good enough. We can rename this function later, once we know
  what exactly we want the semantics to be.

cc @StefanKarpinski who really wants his debugger to work again ;). Will merge once CI is green.
