### PR TITLE
Do not raise BoundsError when indexing SubString with empty range

### DIFF
--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -79,9 +79,7 @@ convert{T<:AbstractString}(::Type{SubString{T}}, s::T) = SubString(s, 1, endof(s
 bytestring{T <: ByteString}(p::SubString{T}) = bytestring(p.string.data[1+p.offset:p.offset+nextind(p, p.endof)-1])
 
 function getindex(s::AbstractString, r::UnitRange{Int})
-    if first(r) < 1 || endof(s) < last(r)
-        throw(BoundsError(s, r))
-    end
+    checkbounds(s, r) || throw(BoundsError(s, r))
     SubString(s, first(r), last(r))
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -86,6 +86,19 @@ end
 @test checkbounds("hello", 1:5)
 @test checkbounds("hello", [1:5;])
 
+# issue #15624 (indexing with out of bounds empty range)
+@test "hello"[10:9] == ""
+@test "hellø"[10:9] == ""
+@test SubString("hello", 1, 6)[10:9] == ""
+@test SubString("hello", 1, 0)[10:9] == ""
+@test SubString("hellø", 1, 6)[10:9] == ""
+@test SubString("hellø", 1, 0)[10:9] == ""
+@test ASCIIString("")[10:9] == ""
+@test UTF8String("")[10:9] == ""
+@test SubString("", 1, 6)[10:9] == ""
+@test SubString("", 1, 0)[10:9] == ""
+
+
 #=
 # issue #7764
 let


### PR DESCRIPTION
Even if the range is out of bounds. Fixes #15624.
