### PR TITLE
Minor docs fixes.

### DIFF
--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -139,7 +139,7 @@ function getdoc(state::State, file::AbstractString, input::Vector)
     # Capture the lines containing the docstring signature.
     output = []
     while !isempty(input)
-        line = shift!(input)
+        line = rstrip(shift!(input))
         push!(output, line)
         ismatch(r"^$", line) && break
     end

--- a/doc/manual/documentation.rst
+++ b/doc/manual/documentation.rst
@@ -335,15 +335,19 @@ Types
 .. code-block:: julia
 
     "..."
-    abstract T
+    abstract T1
 
     "..."
-    type T end
+    type T2
+        ...
+    end
 
     "..."
-    immutable T end
+    immutable T3
+        ...
+    end
 
-Adds the docstring ``"..."`` to type ``T``.
+Adds the docstring ``"..."`` to types ``T1``, ``T2``, and ``T3``.
 
 .. code-block:: julia
 


### PR DESCRIPTION
Rename types in docstring docs. Having the same name, `T`, for each docstring example may give the impression that it is valid to redeclare types like that. Instead use different names for each example. Fixes #15623.

Also, strip trailing whitespace for signature parsing in `genstdlib.jl`. This fixes #15628 where trailing whitespace caused the signature before it to be ignored.

cc @eschnett
