### PR TITLE
Use inference in dot completion FIX #10091.

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -19,48 +19,38 @@ end
 
 # REPL Symbol Completions
 function complete_symbol(sym, ffunc)
-    # Find module
-    strs = split(sym, '.')
     # Maybe be smarter in the future
     context_module = Main
-
     mod = context_module
+    name = sym
+
     lookup_module = true
     t = Union{}
-    for name in strs[1:(end-1)]
-        s = symbol(name)
-        if lookup_module
-            # If we're considering A.B.C where B doesn't exist in A, give up
-            isdefined(mod, s) || return UTF8String[]
-            b = mod.(s)
+    if rsearch(sym, non_identifier_chars) < rsearch(sym, '.')
+        # Find module
+        lookup_name, name = rsplit(sym, ".", limit=2)
+
+        ex = Base.syntax_deprecation_warnings(false) do
+            parse(lookup_name, raise=false)
+        end
+
+        b, found = get_value(ex, context_module)
+        if found
             if isa(b, Module)
                 mod = b
-            elseif Base.isstructtype(typeof(b)) && !isa(b, Tuple)
+                lookup_module = true
+            elseif Base.isstructtype(typeof(b))
                 lookup_module = false
                 t = typeof(b)
-            else
-                # A.B.C where B is neither a type nor a
-                # module. Will have to be revisited if
-                # overloading is allowed
-                return UTF8String[]
             end
-        else
-            # We're now looking for a type
-            fields = fieldnames(t)
-            found = false
-            for i in eachindex(fields)
-                s == fields[i] || continue
-                t = t.types[i]
-                (Base.isstructtype(t) && !(t <: Tuple)) || return UTF8String[]
-                found = true
-                break
-            end
-            #Same issue as above, but with types instead of modules
-            found || return UTF8String[]
+        else # If the value is not found using get_value, the expression contain an advanced expression
+            lookup_module = false
+            t, found = get_type(ex, context_module)
         end
+        found || return UTF8String[]
+        # Ensure REPLCompletion do not crash when asked to complete a tuple, #15329
+        !lookup_module && t <: Tuple && return UTF8String[]
     end
-
-    name = strs[end]
 
     suggestions = UTF8String[]
     if lookup_module
@@ -210,7 +200,7 @@ end
 
 # Returns a range that includes the method name in front of the first non
 # closed start brace from the end of the string.
-function find_start_brace(s::AbstractString)
+function find_start_brace(s::AbstractString; c_start='(', c_end=')')
     braces = 0
     r = RevString(s)
     i = start(r)
@@ -220,9 +210,9 @@ function find_start_brace(s::AbstractString)
     while !done(r, i)
         c, i = next(r, i)
         if !in_single_quotes && !in_double_quotes && !in_back_ticks
-            if c == '('
+            if c == c_start
                 braces += 1
-            elseif c == ')'
+            elseif c == c_end
                 braces -= 1
             elseif c == '\''
                 in_single_quotes = true
@@ -464,9 +454,33 @@ function completions(string, pos)
         comp_keywords = false
     end
     startpos == 0 && (pos = -1)
-    dotpos <= startpos && (dotpos = startpos - 1)
+    dotpos < startpos && (dotpos = startpos - 1)
     s = string[startpos:pos]
     comp_keywords && append!(suggestions, complete_keyword(s))
+    # The case where dot and start pos is equal could look like: "(""*"").d","". or  CompletionFoo.test_y_array[1].y
+    # This case can be handled by finding the begining of the expresion. This is done bellow.
+    if dotpos == startpos
+        i = prevind(string, startpos)
+        while 0 < i
+            c = string[i]
+            if c in [')', ']']
+                if c==')'
+                    c_start='('; c_end=')'
+                elseif c==']'
+                    c_start='['; c_end=']'
+                end
+                frange, end_off_indentifier = find_start_brace(string[1:prevind(string, i)], c_start=c_start, c_end=c_end)
+                startpos = start(frange)
+                i = prevind(string, startpos)
+            elseif c in ["\'\"\`"...]
+                s = "$c$c"*string[startpos:pos]
+                break
+            else
+                break
+            end
+            s = string[startpos:pos]
+        end
+    end
     append!(suggestions, complete_symbol(s, ffunc))
     return sort(unique(suggestions)), (dotpos+1):pos, true
 end

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -10,6 +10,7 @@ module CompletionFoo
         xx :: Test_y
     end
     type_test = Test_x(Test_y(1))
+    (::Test_y)() = "", ""
     module CompletionFoo2
 
     end
@@ -39,6 +40,8 @@ module CompletionFoo
     test5(x::Array{Bool,1}) = pass
     test5(x::BitArray{1}) = pass
     test5(x::Float64) = pass
+    const a=x->x
+    test6()=[a, a]
 
     array = [1, 1]
     varfloat = 0.1
@@ -288,6 +291,12 @@ c, r, res = test_complete(s)
 @test length(c) == 1
 @test c[1] == string(methods(CompletionFoo.test5, Tuple{BitArray{1}})[1])
 
+s = "CompletionFoo.test4(CompletionFoo.test_y_array[1]()[1], CompletionFoo.test_y_array[1]()[2], "
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 1
+@test c[1] == string(methods(CompletionFoo.test4, Tuple{ASCIIString, ASCIIString})[1])
+
 ########## Test where the current inference logic fails ########
 # Fails due to inferrence fails to determine a concrete type for arg 1
 # But it returns AbstractArray{T,N} and hence is able to remove test5(x::Float64) from the suggestions
@@ -323,6 +332,12 @@ c,r = test_complete(s)
 @test c[1] == "yy"
 
 s = "CompletionFoo.Test_y(rand()).y"
+c,r = test_complete(s)
+@test length(c)==1
+@test r == endof(s):endof(s)
+@test c[1] == "yy"
+
+s = "CompletionFoo.test6()[1](CompletionFoo.Test_y(rand())).y"
 c,r = test_complete(s)
 @test length(c)==1
 @test r == endof(s):endof(s)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -44,6 +44,8 @@ module CompletionFoo
     varfloat = 0.1
 
     const tuple = (1, 2)
+
+    test_y_array=[CompletionFoo.Test_y(rand()) for i in 1:10]
 end
 
 function temp_pkg_dir(fn::Function)
@@ -109,6 +111,10 @@ c,r = test_complete(s)
 @test s[r] == "x"
 
 s = "Main.CompletionFoo.bar.no_val_available"
+c,r = test_complete(s)
+@test length(c)==0
+#cannot do dot completion on infix operator
+s = "+."
 c,r = test_complete(s)
 @test length(c)==0
 
@@ -296,6 +302,31 @@ c, r, res = test_complete(s)
 @test !res
 @test length(c) == 2
 #################################################################
+
+# Test of inference based getfield completion
+s = "\"\"."
+c,r = test_complete(s)
+@test length(c)==1
+@test r == (endof(s)+1):endof(s)
+@test c[1] == "data"
+
+s = "(\"\"*\"\")."
+c,r = test_complete(s)
+@test length(c)==1
+@test r == (endof(s)+1):endof(s)
+@test c[1] == "data"
+
+s = "CompletionFoo.test_y_array[1]."
+c,r = test_complete(s)
+@test length(c)==1
+@test r == (endof(s)+1):endof(s)
+@test c[1] == "yy"
+
+s = "CompletionFoo.Test_y(rand()).y"
+c,r = test_complete(s)
+@test length(c)==1
+@test r == endof(s):endof(s)
+@test c[1] == "yy"
 
 # Test completion in multi-line comments
 s = "#=\n\\alpha"


### PR DESCRIPTION
This adds inference in to dot completion. Examples of this use

```
julia> split("","")[1].<tab>
endof  offset  string
julia> IOBuffer().<tab>
append   data      mark      maxsize   ptr       readable  seekable  size      writable
```

More elaborate examples can be seen in the test/replcompletions.jl.

cc @blakejohnson could you review this as you reviewed similar changes in #11679. 
note: This uses the same framework for dot completion as I added in #11679 for method completion. The second commit improves `get_type_call` logic, so it is more general and hence can figure the return types from more elaborate expressions.
