### PR TITLE
remove some unncessary and/or misleading methods of `copy`

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -1000,7 +1000,6 @@ next{K,V}(::ImmutableDict{K,V}, t) = (Pair{K,V}(t.key, t.value), t.parent)
 done(::ImmutableDict, t) = !isdefined(t, :parent)
 length(t::ImmutableDict) = count(x->1, t)
 isempty(t::ImmutableDict) = done(t, start(t))
-copy(t::ImmutableDict) = t
 function similar(t::ImmutableDict)
     while isdefined(t, :parent)
         t = t.parent

--- a/base/number.jl
+++ b/base/number.jl
@@ -25,6 +25,7 @@ end
 getindex(x::Number, I::Real...) = getindex(x, to_indexes(I...)...)
 first(x::Number) = x
 last(x::Number) = x
+copy(x::Number) = x  # some code treats numbers as collection-like
 
 divrem(x,y) = (div(x,y),rem(x,y))
 fldmod(x,y) = (fld(x,y),mod(x,y))

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -286,10 +286,6 @@ eltype(::Type{Any}) = Any
 eltype(t::DataType) = eltype(supertype(t))
 eltype(x) = eltype(typeof(x))
 
-# copying immutable things
-copy(x::Union{Symbol,Number,AbstractString,Function,Tuple,LambdaInfo,
-              TopNode,QuoteNode,DataType,Union}) = x
-
 # function pipelining
 |>(x, f) = f(x)
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -153,7 +153,6 @@ read(::DevNullStream, ::Type{UInt8}) = throw(EOFError())
 write(::DevNullStream, ::UInt8) = 1
 close(::DevNullStream) = nothing
 flush(::DevNullStream) = nothing
-copy(::DevNullStream) = DevNull
 wait_connected(::DevNullStream) = nothing
 wait_readnb(::DevNullStream) = wait()
 wait_readbyte(::DevNullStream) = wait()

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -82,8 +82,6 @@ RegexMatch("angry,\\nBad world")
 """
 macro r_str(pattern, flags...) Regex(pattern, flags...) end
 
-copy(r::Regex) = r
-
 function show(io::IO, re::Regex)
     imsx = PCRE.CASELESS|PCRE.MULTILINE|PCRE.DOTALL|PCRE.EXTENDED
     opts = re.compile_options

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -441,8 +441,6 @@ let d = ImmutableDict{UTF8String, UTF8String}(),
     @test get(d, k1, :default) === :default
     @test d1["key1"] === v1
     @test d4["key1"] === v2
-    @test copy(d4) === d4
-    @test copy(d) === d
     @test similar(d3) === d
     @test similar(d) === d
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -299,7 +299,7 @@ for (name, f) in l
     @test readstring("$filename.to") == text
 
     verbose && println("$name write(::IOBuffer, ...)")
-    to = IOBuffer(Vector{UInt8}(copy(text)), false, true)
+    to = IOBuffer(copy(text.data), false, true)
     write(to, io())
     @test takebuf_string(to) == text
 
@@ -363,7 +363,6 @@ test_read_nbyte()
 @test_throws EOFError read(DevNull, UInt8)
 @test close(DevNull) === nothing
 @test flush(DevNull) === nothing
-@test copy(DevNull) === DevNull
 @test eof(DevNull)
 @test print(DevNull, "go to /dev/null") === nothing
 


### PR DESCRIPTION
I think it's better not to define `copy` on objects where it doesn't make sense and doesn't do anything. IIRC, most of these definitions were introduced a long time ago when they might have been needed for copying ASTs. That was silly, and has been replaced by the internal `astcopy` function that knows how to copy only what's needed.

These can cause problems, such as writing `copy(str).data` and thinking you'll get a new copy of the string's data.

To minimize breakage, I'm leaving the definitions for `Range` and `Number` for now, since there is some code that assumes all array-like things are copyable.
