### PR TITLE
Minor fixes of some deprecated functions

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -346,7 +346,7 @@ end
 
 @deprecate integer(x) Integer(x)
 
-for (f,t) in ((:uint8,:UInt8), (:uint16,:UInt16), (:uint32,:UInt32), (:uint64,:Uint64),
+for (f,t) in ((:uint8,:UInt8), (:uint16,:UInt16), (:uint32,:UInt32), (:uint64,:UInt64),
               (:int8,:Int8),   (:int16,:Int16),   (:int32,:Int32),   (:int64,:Int64),
               (:int128,:Int128), (:uint128,:UInt128), (:signed,:Int), (:unsigned,:UInt),
               (:integer,:Int), (:int,:Int), (:uint,:UInt))
@@ -403,7 +403,7 @@ end
 end
 
 @noinline function unsafe_convert{P}(::Type{P}, x)
-    P<:Ptr || throw(MethodError(unsafe_convert, (Type{P}, x)))
+    P<:Ptr || throw(MethodError(unsafe_convert, (P, x)))
     ret = convert(P, x) # attempt the call first, so we only print the depwarn if it can even succeed
     depwarn("convert(::Type{Ptr}, ::$(typeof(x))) methods should be converted to be methods of unsafe_convert", :unsafe_convert)
     return ret


### PR DESCRIPTION
- Use `UInt64` instead of `Uint64` in `uint64`.
  
  Noticed in the Mac compile all test...
- Correct the type in `unsafe_convert` method error.
