### PR TITLE
[WIP] More generalindexing [3]

### DIFF
--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -88,7 +88,7 @@ padding(width, twidth, a) =
 
 function padcells!(rows, align; len = length, min = 0)
     widths = colwidths(rows, len = len, min = min)
-    for i = 1:length(rows), j = 1:length(rows[1])
+    for i = 1:length(rows), j = 1:length(rows[1])  # fixme (iter): can we make indexing more general here?
         cell = rows[i][j]
         lpad, rpad = padding(len(cell), widths[j], align[j])
         rows[i][j] = " "^lpad * cell * " "^rpad
@@ -105,7 +105,7 @@ _dash(width, align) =
 function plain(io::IO, md::Table)
     cells = mapmap(plaininline, md.rows)
     padcells!(cells, md.align, len = length, min = 3)
-    for i = 1:length(cells)
+    for i = 1:length(cells) # fixme (iter): can we make indexing more general here?
         print(io, "| ")
         print_joined(io, cells[i], " | ")
         println(io, " |")

--- a/base/math.jl
+++ b/base/math.jl
@@ -42,7 +42,7 @@ clamp{X,L,H}(x::X, lo::L, hi::H) =
 
 clamp{T}(x::AbstractArray{T,1}, lo, hi) = [clamp(xx, lo, hi) for xx in x]
 clamp{T}(x::AbstractArray{T,2}, lo, hi) =
-    [clamp(x[i,j], lo, hi) for i in 1:size(x,1), j in 1:size(x,2)]
+    [clamp(x[i,j], lo, hi) for i in 1:size(x,1), j in 1:size(x,2)]  # fixme (iter): change to `eachindex` when #15459 is ready
 clamp{T}(x::AbstractArray{T}, lo, hi) =
     reshape([clamp(xx, lo, hi) for xx in x], size(x))
 

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1544,13 +1544,13 @@ function pmap(f, lsts...; err_retry=true, err_stop=false, pids = workers())
     nextidx = 0
     getnextidx() = (nextidx += 1)
 
-    states = [start(lst) for lst in lsts]
+    states = map(start, lsts)
     function getnext_tasklet()
         if is_task_in_error() && err_stop
             return nothing
-        elseif !any(idx->done(lsts[idx],states[idx]), eachindex(lsts))  # fixme (iter): here `eachindex` may give speedup for unusually indexed arrays, but still won't work for OffsetArray's or non-integer indexed collections. Does it worth changing then?
-            nxts = [next(lsts[idx],states[idx]) for idx in eachindex(lsts)]
-            for idx in eachindex(lsts); states[idx] = nxts[idx][2]; end
+        elseif !any(idx->done(lsts[idx],states[idx]), 1:len)
+            nxts = [next(lsts[idx],states[idx]) for idx in 1:len]
+            for idx in 1:len; states[idx] = nxts[idx][2]; end
             nxtvals = [x[1] for x in nxts]
             return (getnextidx(), nxtvals)
         elseif !isempty(retryqueue)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1526,7 +1526,7 @@ pmap(f) = f()
 # as it finishes.
 # example unbalanced workload:
 # rsym(n) = (a=rand(n,n);a*a')
-# L = {rsym(200),rsym(1000),rsym(200),rsym(1000),rsym(200),rsym(1000),rsym(200),rsym(1000)};
+# L = Any[rsym(200),rsym(1000),rsym(200),rsym(1000),rsym(200),rsym(1000),rsym(200),rsym(1000)];
 # pmap(eig, L);
 function pmap(f, lsts...; err_retry=true, err_stop=false, pids = workers())
     len = length(lsts)
@@ -1544,13 +1544,13 @@ function pmap(f, lsts...; err_retry=true, err_stop=false, pids = workers())
     nextidx = 0
     getnextidx() = (nextidx += 1)
 
-    states = [start(lsts[idx]) for idx in 1:len]
+    states = [start(lst) for lst in lsts]
     function getnext_tasklet()
         if is_task_in_error() && err_stop
             return nothing
-        elseif !any(idx->done(lsts[idx],states[idx]), 1:len)
-            nxts = [next(lsts[idx],states[idx]) for idx in 1:len]
-            for idx in 1:len; states[idx] = nxts[idx][2]; end
+        elseif !any(idx->done(lsts[idx],states[idx]), eachindex(lsts))  # fixme (iter): here `eachindex` may give speedup for unusually indexed arrays, but still won't work for OffsetArray's or non-integer indexed collections. Does it worth changing then?
+            nxts = [next(lsts[idx],states[idx]) for idx in eachindex(lsts)]
+            for idx in eachindex(lsts); states[idx] = nxts[idx][2]; end
             nxtvals = [x[1] for x in nxts]
             return (getnextidx(), nxtvals)
         elseif !isempty(retryqueue)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1544,7 +1544,7 @@ function pmap(f, lsts...; err_retry=true, err_stop=false, pids = workers())
     nextidx = 0
     getnextidx() = (nextidx += 1)
 
-    states = map(start, lsts)
+    states = [start(lsts[idx]) for idx in 1:len]
     function getnext_tasklet()
         if is_task_in_error() && err_stop
             return nothing

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -102,7 +102,7 @@ end
     startargs = fill(1, K)
     stopargs = Array(Expr, K)
     for i = 1:K
-        Bargs = [:(size(B[$j],$i)) for j = 1:length(B)]
+        Bargs = [:(size(B[$j],$i)) for j = 1:length(B)]  # fixme (iter): it might be faster to use `eachindex(B)`, but is it safe to use it here?
         stopargs[i] = :(max(size(A,$i),$(Bargs...)))
     end
     meta = Expr(:meta, :inline)
@@ -804,7 +804,7 @@ If `dim` is specified, returns unique regions of the array `itr` along `dim`.
         # Collect index of first row for each hash
         uniquerow = Array(Int, size(A, dim))
         firstrow = Dict{Prehashed,Int}()
-        for k = 1:size(A, dim)
+        for k = 1:size(A, dim)   # fixme (iter): use `eachindex(A, dim)` after #15459 is implemented
             uniquerow[k] = get!(firstrow, Prehashed(hashes[k]), k)
         end
         uniquerows = collect(values(firstrow))
@@ -829,7 +829,7 @@ If `dim` is specified, returns unique regions of the array `itr` along `dim`.
             while any(collided)
                 # Collect index of first row for each collided hash
                 empty!(firstrow)
-                for j = 1:size(A, dim)
+                for j = 1:size(A, dim)  # fixme (iter): use `eachindex(A, dim)` after #15459 is implemented
                     collided[j] || continue
                     uniquerow[j] = get!(firstrow, Prehashed(hashes[j]), j)
                 end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -102,7 +102,7 @@ end
     startargs = fill(1, K)
     stopargs = Array(Expr, K)
     for i = 1:K
-        Bargs = [:(size(B[$j],$i)) for j = 1:length(B)]  # fixme (iter): it might be faster to use `eachindex(B)`, but is it safe to use it here?
+        Bargs = [:(size(B[$j],$i)) for j = 1:length(B)]
         stopargs[i] = :(max(size(A,$i),$(Bargs...)))
     end
     meta = Expr(:meta, :inline)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -473,7 +473,7 @@ end
 macro vectorize_1arg(S,f)
     S = esc(S); f = esc(f); T = esc(:T)
     quote
-        ($f){$T<:$S}(x::AbstractArray{$T,1}) = [ ($f)(x[i]) for i=1:length(x) ]
+        ($f){$T<:$S}(x::AbstractArray{$T,1}) = [ ($f)(elem) for elem in x ]
         ($f){$T<:$S}(x::AbstractArray{$T,2}) =
             [ ($f)(x[i,j]) for i=1:size(x,1), j=1:size(x,2) ]
         ($f){$T<:$S}(x::AbstractArray{$T}) =
@@ -504,17 +504,17 @@ end
 
 function ifelse(c::AbstractArray{Bool}, x::AbstractArray, y::AbstractArray)
     shp = promote_shape(size(c), promote_shape(size(x), size(y)))
-    reshape([ifelse(c[i], x[i], y[i]) for i = 1 : length(c)], shp)
+    reshape([ifelse(c_elem, x_elem, y_elem) for (c_elem, x_elem, y_elem) in zip(c, x, y)], shp)
 end
 
 function ifelse(c::AbstractArray{Bool}, x::AbstractArray, y)
     shp = promote_shape(size(c), size(c))
-    reshape([ifelse(c[i], x[i], y) for i = 1 : length(c)], shp)
+    reshape([ifelse(c_elem, x_elem, y) for (c_elem, x_elem) in zip(c, x)], shp)
 end
 
 function ifelse(c::AbstractArray{Bool}, x, y::AbstractArray)
     shp = promote_shape(size(c), size(y))
-    reshape([ifelse(c[i], x, y[i]) for i = 1 : length(c)], shp)
+    reshape([ifelse(c_elem, x, y_elem) for (c_elem, y_elem) in zip(c, y)], shp)
 end
 
 # Pair

--- a/base/quadgk.jl
+++ b/base/quadgk.jl
@@ -169,10 +169,10 @@ end
 # all the integration-segment endpoints
 function quadgk(f, a, b, c...; kws...)
     T = promote_type(typeof(float(a)), typeof(b))
-    for i in 1:length(c)
-        T = promote_type(T, typeof(c[i]))
+    for x in c
+        T = promote_type(T, typeof(x))
     end
-    cT = T[ c[i] for i in 1:length(c) ]
+    cT = map(T, c)
     quadgk(f, convert(T, a), convert(T, b), cT...; kws...)
 end
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -570,7 +570,7 @@ rand{T<:Union{Signed,Unsigned,BigInt,Bool}}(rng::AbstractRNG, r::UnitRange{T}) =
 rand(rng::AbstractRNG, r::AbstractArray) = @inbounds return r[rand(rng, 1:length(r))]
 
 function rand!(rng::AbstractRNG, A::AbstractArray, g::RangeGenerator)
-    for i = 1 : length(A)
+    for i in eachindex(A)
         @inbounds A[i] = rand(rng, g)
     end
     return A
@@ -580,7 +580,7 @@ rand!{T<:Union{Signed,Unsigned,BigInt,Bool,Char}}(rng::AbstractRNG, A::AbstractA
 
 function rand!(rng::AbstractRNG, A::AbstractArray, r::AbstractArray)
     g = RangeGenerator(1:(length(r)))
-    for i = 1 : length(A)
+    for i in eachindex(A)
         @inbounds A[i] = r[rand(rng, g)]
     end
     return A

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -204,7 +204,7 @@ function _mapreducedim!{T,N}(f, op, R::AbstractArray, A::AbstractArray{T,N})
         @inbounds for IA in CartesianRange(sizeA1)
             IR = min(sizeR1, IA)
             r = R[1,IR]
-            @simd for i = 1:size(A, 1)
+            @simd for i = 1:size(A, 1)  # fixme (iter): update when #15459 is implemented (and if it does't affect @simd)
                 r = op(r, f(A[i, IA]))
             end
             R[1,IR] = r
@@ -214,7 +214,7 @@ function _mapreducedim!{T,N}(f, op, R::AbstractArray, A::AbstractArray{T,N})
         sizeA1 = Base.size_skip1(size(A), A)
         @inbounds for IA in CartesianRange(sizeA1)
             IR = min(IA, sizeR1)
-            @simd for i = 1:size(A, 1)
+            @simd for i = 1:size(A, 1)  # fixme (iter): update when #15459 is implemented (and if it does't affect @simd)
                 R[i,IR] = op(R[i,IR], f(A[i,IA]))
             end
         end
@@ -296,7 +296,7 @@ function findminmax!{T,N}(f, Rval, Rind, A::AbstractArray{T,N})
             IR = min(sizeR1, IA)
             tmpRv = Rval[1,IR]
             tmpRi = Rind[1,IR]
-            for i = 1:size(A,1)
+            for i = 1:size(A,1)  # fixme (iter): update when #15459 is implemented (and if it does't affect @simd)
                 k += 1
                 tmpAv = A[i,IA]
                 if f(tmpAv, tmpRv)
@@ -310,7 +310,7 @@ function findminmax!{T,N}(f, Rval, Rind, A::AbstractArray{T,N})
     else
         @inbounds for IA in CartesianRange(sizeA1)
             IR = min(sizeR1, IA)
-            for i = 1:size(A, 1)
+            for i = 1:size(A, 1)  # fixme (iter): update when #15459 is implemented (and if it does't affect @simd)
                 k += 1
                 tmpAv = A[i,IA]
                 if f(tmpAv, Rval[i,IR])

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -120,7 +120,7 @@ function show(io::IO, m::RegexMatch)
     idx_to_capture_name = PCRE.capture_names(m.regex.regex)
     if !isempty(m.captures)
         print(io, ", ")
-        for i = 1:length(m.captures)
+        for i in eachindex(m.captures)
             # If the capture group is named, show the name.
             # Otherwise show its index.
             capture_name = get(idx_to_capture_name, i, i)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -120,7 +120,7 @@ function show(io::IO, m::RegexMatch)
     idx_to_capture_name = PCRE.capture_names(m.regex.regex)
     if !isempty(m.captures)
         print(io, ", ")
-        for i in eachindex(m.captures)
+        for i = 1:length(m.captures)
             # If the capture group is named, show the name.
             # Otherwise show its index.
             capture_name = get(idx_to_capture_name, i, i)


### PR DESCRIPTION
One more step towards filling up [this list](https://github.com/JuliaLang/julia/pull/15434#issuecomment-194991739), this time from `markdown/*` to `regex.jl`. 

This is marked as WIP since there's a number of discussable changes (see `fixme (iter)` comments with question mark) for which I'd be happy to get comments. Given previous PRs, I also suggest not to merge these changes until at least 2 pairs of eyes don't check it out. 

Also I couldn't find any "standard" performance tests, but it would be very nice to make sure the PR doesn't introduce any performance regression. I hope folks here can run such tests or point me to a proper way to do it. 

---

I skipped several files for particular reasons described below. Please, take another look at them if you believe we can improve them further. The files are:
- markdown/GitHub/table.jl

Works on `cells` with unspecified type. Seems to expect array of arrays, but no guarantee of consistency. Anyway, looks like internal stuff so unlikely to change default array format.
- pkg/resolve/maxsum.jl
- pkg/resolve/maxsum.jl  

All loops over internal data structures (e.g. `Messages`, `Field`, etc), considered unlikely to change.
- primes.jl

Direct comment not to use `eachindex` there :)
- profile.jl

`for i=1:length(V)` where `V` is a `Vector`, so equivalent to `eachindex` anyway.

cc: @timholy @nalimilan @KristofferC
