### PR TITLE
fixup a typo in codegen undef var handling

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2967,9 +2967,7 @@ static jl_cgval_t emit_local(int sl, jl_codectx_t *ctx)
     }
     if (vi.memloc) {
         Value *bp = vi.memloc;
-        if (vi.isArgument ||  // arguments are always defined
-            (!vi.isAssigned && !vi.usedUndef)) {
-            // if no undef usage was found by inference, and it's either not assigned or not in env: it must be always defined
+        if (vi.isArgument || !vi.usedUndef) { // arguments are always defined
             Instruction *v = builder.CreateLoad(bp, vi.isVolatile);
             return mark_julia_type(v, true, vi.value.typ, ctx);
         }


### PR DESCRIPTION
introduced in a1ee8676, instead of eliding the check for every proven-non-undef variables (since the captured variable are handled earlier) we were now checking in a lot of unnecessary cases. (almost all actually ?)

@JeffBezanson
