### PR TITLE
BigFloat: test various BigFloat^Integer methods, not BigInt^Integer

### DIFF
--- a/test/bigfloat.jl
+++ b/test/bigfloat.jl
@@ -1,8 +1,8 @@
-@test big(2)^big(3) == 8
+@test big(2.0)^big(3) == 8
 
 for T in [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128, BigInt]
-	@test T(2)^big(3) == 8
-	@test big(2)^T(3) == 8
+    @test T(2)^big(3.0) == 8
+    @test big(2.0)^T(3) == 8
 end
 
 # issue 15659


### PR DESCRIPTION
I was accidentally testing the wrong thing in 50e1eb3d537ecfc4d65f0.
