### PR TITLE
Don't pass an :incomplete expressions back into flisp

### DIFF
--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -427,7 +427,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
         return jl_interpret_toplevel_expr(e);
 
     jl_expr_t *ex = (jl_expr_t*)e;
-    if (ex->head == null_sym || ex->head == error_sym) {
+    if (ex->head == null_sym || ex->head == error_sym || ex->head == jl_incomplete_sym) {
         // expression types simple enough not to need expansion
         return jl_interpret_toplevel_expr(e);
     }


### PR DESCRIPTION
Changes:

```
ERROR: syntax: unhandled expr (incomplete #<julia: "incomplete: premature end of input">)
 in eval(::Module, ::Any) at ./docs/bootstrap.jl:69
```

into

```
ERROR: syntax: incomplete: premature end of input
 in eval(::Module, ::Any) at ./docs/bootstrap.jl:69
```

as for other syntax errors.
