### PR TITLE
Document `unique(itr)`

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -104,6 +104,12 @@ const ⊆ = issubset
 ⊊(l::Set, r::Set) = <(l, r)
 ⊈(l::Set, r::Set) = !⊆(l, r)
 
+"""
+    unique(itr)
+
+Returns an array containing one value from `itr` for each unique value,
+as determined by `isequal`.
+"""
 function unique(C)
     out = Vector{eltype(C)}()
     seen = Set{eltype(C)}()

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -215,6 +215,12 @@ Iterable Collections
 
    Returns an array containing only the unique elements of the iterable ``itr``\ , in the order that the first of each set of equivalent elements originally appears. If ``dim`` is specified, returns unique regions of the array ``itr`` along ``dim``\ .
 
+.. function:: unique(itr)
+
+   .. Docstring generated from Julia source
+
+   Returns an array containing one value from ``itr`` for each unique value, as determined by ``isequal``\ .
+
 .. function:: unique(f, itr)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
`unique(f, itr)` was already documented, it's strange not to document the simpler `unique(itr)` as well.
