### PR TITLE
Make rec_backtrace() always return 0 on ARM and PPC64

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -654,9 +654,13 @@ DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, CONTEXT *Cont
 // stacktrace using libunwind
 DLLEXPORT size_t rec_backtrace(ptrint_t *data, size_t maxsize)
 {
+#if !defined(_CPU_ARM_) && !defined(_CPU_PPC64_)
     unw_context_t uc;
     unw_getcontext(&uc);
     return rec_backtrace_ctx(data, maxsize, &uc);
+#else
+    return 0;
+#endif
 }
 DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, unw_context_t *uc)
 {


### PR DESCRIPTION
The same was done for rec_backtrace_ctx() in commit fb00eac468510c26f71c007904ef94dff6b5d020
Not needed in master since refactoring done here a14b32b490bad4c440ad1e716b39e70d14d58cd1
