### PR TITLE
Skip certain tests when running as root, fix #15683

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -157,7 +157,7 @@ rm(c_tmpdir, recursive=true)
 @test rm(c_tmpdir, force=true, recursive=true) === nothing
 
 # chown will give an error if the user does not have permissions to change files
-@unix_only if get(ENV, "USER", "") == "root"
+@unix_only if get(ENV, "USER", "") == "root" || get(ENV, "HOME", "") == "/root"
     chown(file, -2, -1)  # Change the file owner to nobody
     @test stat(file).uid !=0
     chown(file, 0, -2)  # Change the file group to nogroup (and owner back to root)

--- a/test/read.jl
+++ b/test/read.jl
@@ -417,6 +417,8 @@ close(io)
     # so we don't test that it correctly set the umask on windows
     @test_throws SystemError open(f)
     @test_throws Base.UVError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDONLY)
+else
+    warn("file permissions tests skipped due to running tests as root (not recommended)")
 end
 chmod(f, 0o400)
 f1 = open(f)
@@ -462,6 +464,8 @@ close(f2)
 if get(ENV, "USER", "") != "root" && get(ENV, "HOME", "") != "/root"
     @test_throws SystemError open(f, "r+")
     @test_throws Base.UVError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
+else
+    warn("file permissions tests skipped due to running tests as root (not recommended)")
 end
 chmod(f, 0o600)
 f1 = open(f, "r+")

--- a/test/read.jl
+++ b/test/read.jl
@@ -138,7 +138,6 @@ verbose = false
 
 
 for (name, f) in l
-
     io = ()->(s=f(text); push!(open_streams, s); s)
 
     write(filename, text)
@@ -184,7 +183,6 @@ for (name, f) in l
         UTF8String(Char['A' + i % 52 for i in 1:(    Base.SZ_UNBUFFERED_IO   )]),
         UTF8String(Char['A' + i % 52 for i in 1:(    Base.SZ_UNBUFFERED_IO +1)])
     ]
-
         write(filename, text)
 
         verbose && println("$name readstring...")
@@ -268,7 +266,6 @@ for (name, f) in l
     write(filename, text)
 
     if !(typeof(io()) in [Base.PipeEndpoint, Pipe, TCPSocket])
-
         verbose && println("$name position...")
         @test (s = io(); read!(s, Vector{UInt8}(4)); position(s))  == 4
 
@@ -415,7 +412,7 @@ rm(f)
 io = Base.Filesystem.open(f, Base.Filesystem.JL_O_WRONLY | Base.Filesystem.JL_O_CREAT | Base.Filesystem.JL_O_EXCL, 0o000)
 @test write(io, "abc") == 3
 close(io)
-@unix_only begin
+@unix_only if get(ENV, "USER", "") != "root" && get(ENV, "HOME", "") != "/root"
     # msvcrt _wchmod documentation states that all files are readable,
     # so we don't test that it correctly set the umask on windows
     @test_throws SystemError open(f)
@@ -462,9 +459,10 @@ close(f1)
 close(f2)
 @test eof(f1)
 @test_throws Base.UVError eof(f2)
-
-@test_throws SystemError open(f, "r+")
-@test_throws Base.UVError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
+if get(ENV, "USER", "") != "root" && get(ENV, "HOME", "") != "/root"
+    @test_throws SystemError open(f, "r+")
+    @test_throws Base.UVError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
+end
 chmod(f, 0o600)
 f1 = open(f, "r+")
 f2 = Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
@@ -484,4 +482,4 @@ close(f1)
 close(f2)
 rm(f)
 
-end
+end # mktempdir() do dir


### PR DESCRIPTION
docker containers are probably the only place you should ever be doing this

edit: or for testing `chown`
