### PR TITLE
Fix LLVM 3.9 build

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -397,9 +397,12 @@ public:
                         );
         SmallVector<std::unique_ptr<Module>,1> Ms;
         Ms.push_back(std::move(M));
-        return CompileLayer.addModuleSet(std::move(Ms),
-                                          MemMgr,
-                                          std::move(Resolver));
+        auto modset = CompileLayer.addModuleSet(std::move(Ms), MemMgr,
+                                                std::move(Resolver));
+        // Force LLVM to emit the module so that we can register the symbols
+        // in our lookup table.
+        CompileLayer.emitAndFinalize(modset);
+        return modset;
     }
 
     void removeModule(ModuleHandleT H)


### PR DESCRIPTION
Force LLVM to emit the code before we look for function addresses.

We call `findSymbol` right after we call `addModule` so this shouldn't make the JIT more eager than what it is now.

Fixes https://github.com/JuliaLang/julia/issues/15712
