### PR TITLE
RFC: use first/last as endpoints for Range indexing

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -130,6 +130,10 @@ end
 checkbounds(::Type{Bool}, sz::Integer, i) = throw(ArgumentError("unable to check bounds for indices of type $(typeof(i))"))
 checkbounds(::Type{Bool}, sz::Integer, i::Real) = 1 <= i <= sz
 checkbounds(::Type{Bool}, sz::Integer, ::Colon) = true
+checkbounds(::Type{Bool}, sz::Integer, i::EndpointRange{typeof(first),typeof(last)}) = true
+checkbounds(::Type{Bool}, sz::Integer, i::EndpointRange{typeof(first),Int}) = 1 <= i.stop <= sz
+checkbounds(::Type{Bool}, sz::Integer, i::EndpointRange{Int,typeof(last)}) = 1 <= i.start <= sz
+
 function checkbounds(::Type{Bool}, sz::Integer, r::Range)
     @_propagate_inbounds_meta
     isempty(r) || (checkbounds(Bool, sz, minimum(r)) && checkbounds(Bool, sz, maximum(r)))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -210,15 +210,15 @@ index_shape_dim(A, dim, ::Colon) = (trailingsize(A, dim),)
 # ambiguities for AbstractArray subtypes. See the note in abstractarray.jl
 
 # Note that it's most efficient to call checkbounds first, and then to_index
-@inline function _getindex(l::LinearIndexing, A::AbstractArray, I::Union{Real, AbstractArray, Colon}...)
+@inline function _getindex(l::LinearIndexing, A::AbstractArray, I::Union{Real, AbstractArray, Colon, EndpointRange}...)
     @boundscheck checkbounds(A, I...)
     _unsafe_getindex(l, A, I...)
 end
-@generated function _unsafe_getindex(::LinearIndexing, A::AbstractArray, I::Union{Real, AbstractArray, Colon}...)
+@generated function _unsafe_getindex(::LinearIndexing, A::AbstractArray, I::Union{Real, AbstractArray, Colon, EndpointRange}...)
     N = length(I)
     quote
         # This is specifically *not* inlined.
-        @nexprs $N d->(I_d = to_index(I[d]))
+        @nexprs $N d->(I_d = to_index(A, d, I[d]))
         dest = similar(A, @ncall $N index_shape A I)
         @ncall $N checksize dest I
         @ncall $N _unsafe_getindex! dest A I
@@ -305,7 +305,7 @@ _iterable(v) = repeated(v)
     _unsafe_setindex!(l, A, x, J...)
 end
 @inline function _unsafe_setindex!(::LinearIndexing, A::AbstractArray, x, J::Union{Real,AbstractArray,Colon}...)
-    _unsafe_batchsetindex!(A, _iterable(x), to_indexes(J...)...)
+    _unsafe_batchsetindex!(A, _iterable(x), to_array_indexes(A, J...)...)
 end
 
 # 1-d logical indexing: override the above to avoid calling find (in to_index)


### PR DESCRIPTION
This is basically a trial balloon to see what folks think of some thoughts I've had on handling syntax challenges for certain parts of #15648.

Demo:

``` jl
julia> a = rand(5)
5-element Array{Float64,1}:
 0.963267 
 0.651218 
 0.149261 
 0.0209307
 0.323606 

julia> a[first:3]
3-element Array{Float64,1}:
 0.963267
 0.651218
 0.149261

julia> a[2:last]
4-element Array{Float64,1}:
 0.651218 
 0.149261 
 0.0209307
 0.323606 
```

Compared to `a[2:end]`, `a[2:last]` does not require special parser tricks, and `2:last` has independent existence and can be passed as an argument to a function. 
