### PR TITLE
findfirst and findnext for general iterables

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1009,6 +1009,8 @@ sub2ind(dims::Tuple{Vararg{Integer}}, I::Integer...) = _sub2ind(dims,I)
     end
     Expr(:block, meta,:($ex + 1))
 end
+sub2ind(A::AbstractArray, I::Integer...) = _sub2ind(size(A), I)
+_sub2ind(A::AbstractArray, I) = _sub2ind(size(A), I)
 
 @generated function ind2sub{N}(dims::NTuple{N,Integer}, ind::Integer)
     meta = Expr(:meta,:inline)

--- a/base/array.jl
+++ b/base/array.jl
@@ -727,15 +727,19 @@ end
 findfirst(A) = findnext(A, 1)
 
 # returns the index of the next matching element
-function findnext(A, v, start::Integer)
-    for i = start:length(A)
-        if A[i] == v
-            return i
+function findnext{T}(iter, v, state::T, failed::T)
+    while !done(iter, state)
+        oldstate = state
+        item, state = next(iter, state)
+        if item == v
+            return oldstate
         end
     end
-    return 0
+    return failed
 end
-findfirst(A, v) = findnext(A, v, 1)
+findnext(iter, v, state::Integer) = findnext(iter, v, state, oftype(state, 0))
+
+findfirst(iter, v) = findnext(iter, v, start(iter))
 
 # returns the index of the next element for which the function returns true
 function findnext(testf::Function, A, start::Integer)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1295,7 +1295,7 @@ function findnext(B::BitArray, start::Integer)
     end
     return 0
 end
-#findfirst(B::BitArray) = findnext(B, 1)  ## defined in array.jl
+findfirst(B::BitArray) = findnext(B, 1)
 
 # aux function: same as findnext(~B, start), but performed without temporaries
 function findnextnot(B::BitArray, start::Integer)
@@ -1335,7 +1335,7 @@ function findnext(B::BitArray, v, start::Integer)
     v == true && return findnext(B, start)
     return 0
 end
-#findfirst(B::BitArray, v) = findnext(B, 1, v)  ## defined in array.jl
+findfirst(B::BitArray, v) = findnext(B, v, 1)
 
 # returns the index of the first element for which the function returns true
 function findnext(testf::Function, B::BitArray, start::Integer)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -368,7 +368,6 @@ end
 @deprecate flipud(A::AbstractArray) flipdim(A, 1)
 @deprecate fliplr(A::AbstractArray) flipdim(A, 2)
 
-@deprecate sub2ind{T<:Integer}(dims::Array{T}, sub::Array{T}) sub2ind(tuple(dims...), sub...)
 @deprecate ind2sub!{T<:Integer}(sub::Array{T}, dims::Array{T}, ind::T) ind2sub!(sub, tuple(dims...), ind)
 
 @deprecate strftime     Libc.strftime

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -3,7 +3,7 @@
 ### Multidimensional iterators
 module IteratorsMD
 
-import Base: eltype, length, size, start, done, next, last, getindex, setindex!, linearindexing, min, max, eachindex, ndims, iteratorsize
+import Base: eltype, length, size, start, done, next, last, getindex, setindex!, linearindexing, min, max, eachindex, ndims, iteratorsize, sub2ind, _sub2ind
 importall ..Base.Operators
 import Base: simd_outer_range, simd_inner_length, simd_index, @generated
 import Base: @nref, @ncall, @nif, @nexprs, LinearFast, LinearSlow, to_index, AbstractCartesianIndex
@@ -49,6 +49,10 @@ length{N}(::Type{CartesianIndex{N}})=N
 
 # indexing
 getindex(index::CartesianIndex, i::Integer) = index.I[i]
+
+# conversion to linear index
+sub2ind(A::AbstractArray, I::CartesianIndex) = _sub2ind(A, I.I)
+_sub2ind(A::AbstractArray, I::CartesianIndex) = _sub2ind(A, I.I)
 
 # arithmetic, min/max
 for op in (:+, :-, :min, :max)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -285,6 +285,7 @@ a = [0,1,2,3,0,1,2,3]
 @test findnext(a,1) == 2
 @test findnext(a,1,4) == 6
 @test findnext(a,5,4) == 0
+@test findnext(a,5,0x04) === 0x00
 @test findlast(a) == 8
 @test findlast(a.==0) == 5
 @test findlast(a.==5) == 0
@@ -298,6 +299,13 @@ a = [0,1,2,3,0,1,2,3]
 @test findprev(a,1,8) == 6
 @test findprev(isodd, [2,4,5,3,9,2,0], 7) == 5
 @test findprev(isodd, [2,4,5,3,9,2,0], 2) == 0
+let A = reshape(1:20, 5, 4)
+    B = sub(A, 1:4, 1:3)
+    @test findfirst(B,8) == 7
+    @test findfirst(B,5) == 0
+    @test get(findnext(B,8,start(B)))[2] == CartesianIndex((3,2))
+    @test isnull(findnext(B,5,start(B)))
+end
 
 ## findn ##
 

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -373,3 +373,7 @@ end
 # string searchindex with a two-char UTF-8 (4 byte) string literal
 @test rsearchindex("\U1f596\U1f596", "\U1f596\U1f596") == 1
 @test rsearchindex("\U1f596\U1f596", "\U1f596\U1f596", endof("\U1f596\U1f596\U1f596")) == 1
+
+# using findfirst (#15723)
+@test findfirst("⨳(",'(') == 4
+@test findfirst("⨳(",'x') == 0


### PR DESCRIPTION
This fixes #15723. While on balance I think it's an improvement, there are a few negatives:
- The simplest call to `findnext` returns an `Int` for `AbstractArray`s, and a `Nullable{T}` for any other iterable. This is a consequence of our choice to use 0 to indicate failure-to-find for arrays; for a general iterable, there is no type-stable construct that can safely return an `Int`. It's regrettable whenever the general iterable API disagrees with the one for arrays.
- In light of recent discussions that would allow us to support arrays that index starting at something besides 1, the use of 0 to indicate failure is unfortunate. A safer choice would be to return `start - 1` and then test whether `findnext(A, start) < start`. But presumably everyone who uses `findnext` tests whether `findnext(A, start) == 0`, so changing the sentinel value would break a lot of code. Of course, if we change to returning a `Nullable` even for arrays, this issue goes away, too.

The only solution I can think of for these problems is to introduce `findnext(FromFuture, A, start)`, deprecate `findnext(A, start)`, and make a julia release. Then deprecate `findnext(FromFuture, A, start)` in favor of the new version of `findnext(A, start)` in the following cycle.
