### PR TITLE
Fix jl_get_llvm_fptr if llvmf is in sysimg

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -979,7 +979,12 @@ static uint64_t getAddressForFunction(llvm::Function *llvmf)
 extern "C" JL_DLLEXPORT
 uint64_t jl_get_llvm_fptr(llvm::Function *llvmf)
 {
-    return getAddressForFunction(llvmf);
+    uint64_t addr = getAddressForFunction(llvmf);
+#ifdef USE_ORCJIT
+    if (!addr)
+        addr = jl_ExecutionEngine->findUnmangledSymbol(llvmf->getName()).getAddress();
+#endif
+    return addr;
 }
 
 // this assumes that jl_compile_linfo has already been called

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -249,3 +249,13 @@ end
     end
 end
 @test functionloc(f15447)[2] > 0
+
+# test jl_get_llvm_fptr. We test functions both in and definitely not in the system image
+definitely_not_in_sysimg() = nothing
+for (f,t) in ((definitely_not_in_sysimg,Tuple{}),
+        (Base.throw_boundserror,Tuple{UnitRange{Int64},Int64}))
+    t = Base.tt_cons(Core.Typeof(f), Base.to_tuple_type(t))
+    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Any, Bool, Bool), f, t, false, true)
+    @test llvmf != C_NULL
+    @test ccall(:jl_get_llvm_fptr, Ptr{Void}, (Ptr{Void},), llvmf) != C_NULL
+end


### PR DESCRIPTION
@vtjnash I'm surprised getFunctionAddress doesn't look in the global symbol table. Is that intended?

Fixes https://github.com/Keno/Gallium.jl/issues/69
