### PR TITLE
clipboard: update parameters of `xclip`

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -109,7 +109,7 @@ end
     function clipboard(x)
         c = clipboardcmd()
         cmd = c == :xsel  ? `xsel --nodetach --input --clipboard` :
-              c == :xclip ? `xclip -quiet -in -selection clipboard` :
+              c == :xclip ? `xclip -silent -in -selection clipboard` :
             error("unexpected clipboard command: $c")
         open(pipeline(cmd, stderr=STDERR), "w") do io
             print(io, x)


### PR DESCRIPTION
According to the [man page](http://linux.die.net/man/1/xclip) the
former used option `-quiet` does "show informational messages on the
terminal and run in the foreground"

In contrast `-silent` does more what we want when using from within
Julia: "forks into the background to wait for requests, no
informational output, errors only (default)"
