### PR TITLE
Move release-0.3 to use a versioned Homebrew tap branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
         brew tap staticfloat/julia;
         brew rm --force $(brew deps julia);
         brew update;
+        (cd $(brew --prefix)/Library/Taps/staticfloat/homebrew-julia; git checkout origin/release-0.3);
         brew install -v --only-dependencies julia;
         brew install -v suite-sparse42-julia pcre;
         BUILDOPTS="USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm33-julia)/bin/llvm-config-3.3 VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse42-julia)/include";


### PR DESCRIPTION
This makes it so the current tap directory can be clean of old cruft, while allowing us to continue travis testing of 0.3, if we ever need to.
