### PR TITLE
WIP. Fix thread build on OS X with newest XCode by reducing JL_MAX_BT_SIZE.

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -24,8 +24,18 @@
 #  include <immintrin.h>
 #endif
 
+// JL_MAX_BT_SIZE has to be restricted on Clang 7.3.0
+// See https://llvm.org/bugs/show_bug.cgi?id=27059
+#ifdef __clang__
+#   if __clang_major__==7 & __clang_minor__==3 & __clang_patchlevel__==0
+#       define JL_MAX_BT_SIZE 4312
+#   else
+#       define JL_MAX_BT_SIZE 80000
+#   endif
+#else
+#   define JL_MAX_BT_SIZE 80000
+#endif
 // This includes all the thread local states we care about for a thread.
-#define JL_MAX_BT_SIZE 80000
 typedef struct _jl_tls_states_t {
     struct _jl_gcframe_t *pgcstack;
     struct _jl_value_t *exception_in_transit;


### PR DESCRIPTION
Fixes #15647 (when done).

I'm pretty sure the version restrictions here are wrong/insufficient so I'd like some advice from someone with more knowledge about Xcode. I think the issue might be the linker in latest Xcode so the best thing might be if we could just detect the Xcode version but I couldn't find macros for that.

The fix was inspired by https://github.com/Homebrew/homebrew-science/commit/62088d6ec6b6d7aa03a3534877053196650fe1e0 and the value was found by bisection.

Update: I saw that the value used to be smaller on OS X, https://github.com/JuliaLang/julia/commit/0bbacf84fbc4d5c27d46f120b2a9fe898fcb5004
