### PR TITLE
gcd and lcm manual was not updated after issue #4810

### DIFF
--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -457,8 +457,8 @@ Function                     Description
 :func:`mod2pi(x) <mod2pi>`   modulus with respect to 2pi;  ``0 <= mod2pi(x)  < 2pi``
 :func:`divrem(x,y) <divrem>` returns ``(div(x,y),rem(x,y))``
 :func:`fldmod(x,y) <fldmod>` returns ``(fld(x,y),mod(x,y))``
-:func:`gcd(x,y...) <gcd>`    greatest common divisor of ``x``, ``y``,...; sign matches ``x``
-:func:`lcm(x,y...) <lcm>`    least common multiple of ``x``, ``y``,...; sign matches ``x``
+:func:`gcd(x,y...) <gcd>`    greatest positive common divisor of ``x``, ``y``,...
+:func:`lcm(x,y...) <lcm>`    least positive common multiple of ``x``, ``y``,...
 ============================ =======================================================================
 
 Sign and absolute value functions


### PR DESCRIPTION
After issue #4810 it was decided that gcd and lcm return a >= 0 value.
The file doc/stdlib/math.rst was updated, but the file
manual/mathematical-operations.rst needs an update.
