### PR TITLE
Fix `ascii` and `utf8` and some ccall usage

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -251,23 +251,24 @@ end
 type WeakRef
     value
     WeakRef() = WeakRef(nothing)
-    WeakRef(v::ANY) = ccall(:jl_gc_new_weakref, Any, (Any,), v)::WeakRef
+    WeakRef(v::ANY) = ccall(:jl_gc_new_weakref, Ref{WeakRef}, (Any,), v)
 end
 
 TypeVar(n::Symbol) =
-    ccall(:jl_new_typevar, Any, (Any, Any, Any), n, Union{}, Any)::TypeVar
+    ccall(:jl_new_typevar, Ref{TypeVar}, (Any, Any, Any), n, Union{}, Any)
 TypeVar(n::Symbol, ub::ANY) =
     (isa(ub,Bool) ?
-     ccall(:jl_new_typevar_, Any, (Any, Any, Any, Any), n, Union{}, Any, ub)::TypeVar :
-     ccall(:jl_new_typevar, Any, (Any, Any, Any), n, Union{}, ub::Type)::TypeVar)
+     ccall(:jl_new_typevar_, Ref{TypeVar}, (Any, Any, Any, Any), n, Union{}, Any, ub) :
+     ccall(:jl_new_typevar, Ref{TypeVar}, (Any, Any, Any), n, Union{}, ub::Type))
 TypeVar(n::Symbol, lb::ANY, ub::ANY) =
     (isa(ub,Bool) ?
-     ccall(:jl_new_typevar_, Any, (Any, Any, Any, Any), n, Union{}, lb::Type, ub)::TypeVar :
-     ccall(:jl_new_typevar, Any, (Any, Any, Any), n, lb::Type, ub::Type)::TypeVar)
+     ccall(:jl_new_typevar_, Ref{TypeVar}, (Any, Any, Any, Any), n, Union{}, lb::Type, ub) :
+     ccall(:jl_new_typevar, Ref{TypeVar}, (Any, Any, Any), n, lb::Type, ub::Type))
 TypeVar(n::Symbol, lb::ANY, ub::ANY, b::Bool) =
-    ccall(:jl_new_typevar_, Any, (Any, Any, Any, Any), n, lb::Type, ub::Type, b)::TypeVar
+    ccall(:jl_new_typevar_, Ref{TypeVar}, (Any, Any, Any, Any), n, lb::Type, ub::Type, b)
 
-TypeConstructor(p::ANY, t::ANY) = ccall(:jl_new_type_constructor, Any, (Any, Any), p::SimpleVector, t::Type)
+TypeConstructor(p::ANY, t::ANY) =
+    ccall(:jl_new_type_constructor, Ref{TypeConstructor}, (Any, Any), p::SimpleVector, t::Type)
 
 Void() = nothing
 
@@ -285,9 +286,9 @@ eval(:((::Type{GlobalRef})(m::Module, s::Symbol) = $(Expr(:new, :GlobalRef, :m, 
 eval(:((::Type{Slot})(n::Int) = $(Expr(:new, :Slot, :n, Any))))
 eval(:((::Type{Slot})(n::Int, t::ANY) = $(Expr(:new, :Slot, :n, :t))))
 
-Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Any, (Any, Bool), name, std_imports)::Module
+Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool), name, std_imports)
 
-Task(f::ANY) = ccall(:jl_new_task, Any, (Any, Int), f, 0)::Task
+Task(f::ANY) = ccall(:jl_new_task, Ref{Task}, (Any, Int), f, 0)
 
 # simple convert for use by constructors of types in Core
 # note that there is no actual conversion defined here,

--- a/base/c.jl
+++ b/base/c.jl
@@ -6,7 +6,7 @@ import Core.Intrinsics: cglobal, box
 
 cfunction(f::Function, r, a) = ccall(:jl_function_ptr, Ptr{Void}, (Any, Any, Any), f, r, a)
 
-if ccall(:jl_is_char_signed, Any, ())
+if ccall(:jl_is_char_signed, Ref{Bool}, ())
     typealias Cchar Int8
 else
     typealias Cchar UInt8

--- a/base/error.jl
+++ b/base/error.jl
@@ -21,8 +21,8 @@
 error(s::AbstractString) = throw(Main.Base.ErrorException(s))
 error(s...) = throw(Main.Base.ErrorException(Main.Base.string(s...)))
 
-rethrow() = ccall(:jl_rethrow, Void, ())::Bottom
-rethrow(e) = ccall(:jl_rethrow_other, Void, (Any,), e)::Bottom
+rethrow() = ccall(:jl_rethrow, Bottom, ())
+rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
 backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32,), false)
 catch_backtrace() = ccall(:jl_get_backtrace, Array{Ptr{Void},1}, ())
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -6,18 +6,18 @@ symbol(s::Symbol) = s
 symbol(s::ASCIIString) = symbol(s.data)
 symbol(s::UTF8String) = symbol(s.data)
 symbol(a::Array{UInt8,1}) =
-    ccall(:jl_symbol_n, Any, (Ptr{UInt8}, Int32), a, length(a))::Symbol
+    ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int32), a, length(a))
 symbol(x...) = symbol(string(x...))
 
-gensym() = ccall(:jl_gensym, Any, ())::Symbol
+gensym() = ccall(:jl_gensym, Ref{Symbol}, ())
 
 gensym(s::ASCIIString) = gensym(s.data)
 gensym(s::UTF8String) = gensym(s.data)
 gensym(a::Array{UInt8,1}) =
-    ccall(:jl_tagged_gensym, Any, (Ptr{UInt8}, Int32), a, length(a))::Symbol
+    ccall(:jl_tagged_gensym, Ref{Symbol}, (Ptr{UInt8}, Int32), a, length(a))
 gensym(ss::Union{ASCIIString, UTF8String}...) = map(gensym, ss)
 gensym(s::Symbol) =
-    ccall(:jl_tagged_gensym, Any, (Ptr{UInt8}, Int32), s, ccall(:strlen, Csize_t, (Ptr{UInt8},), s))::Symbol
+    ccall(:jl_tagged_gensym, Ref{Symbol}, (Ptr{UInt8}, Int32), s, ccall(:strlen, Csize_t, (Ptr{UInt8},), s))
 
 macro gensym(names...)
     blk = Expr(:block)
@@ -46,8 +46,8 @@ astcopy(x) = x
 ==(x::QuoteNode, y::QuoteNode) = x.value == y.value
 ==(x::Slot, y::Slot) = x.id === y.id && x.typ === y.typ
 
-expand(x) = ccall(:jl_expand, Any, (Any,), x)
-macroexpand(x) = ccall(:jl_macroexpand, Any, (Any,), x)
+expand(x::ANY) = ccall(:jl_expand, Any, (Any,), x)
+macroexpand(x::ANY) = ccall(:jl_macroexpand, Any, (Any,), x)
 
 ## misc syntax ##
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -181,7 +181,7 @@ end
 read(s::IOStream, ::Type{Char}) = Char(ccall(:jl_getutf8, UInt32, (Ptr{Void},), s.ios))
 
 takebuf_string(s::IOStream) =
-    ccall(:jl_takebuf_string, Any, (Ptr{Void},), s.ios)::ByteString
+    ccall(:jl_takebuf_string, Ref{ByteString}, (Ptr{Void},), s.ios)
 
 takebuf_array(s::IOStream) =
     ccall(:jl_takebuf_array, Vector{UInt8}, (Ptr{Void},), s.ios)

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -54,7 +54,7 @@ unsafe_store!{T}(p::Ptr{T}, x) = pointerset(p, convert(T,x), 1)
 function pointer_to_string(p::Ptr{UInt8}, len::Integer, own::Bool=false)
     a = ccall(:jl_ptr_to_array_1d, Vector{UInt8},
               (Any, Ptr{UInt8}, Csize_t, Cint), Vector{UInt8}, p, len, own)
-    ccall(:jl_array_to_string, Any, (Any,), a)::ByteString
+    ccall(:jl_array_to_string, Ref{ByteString}, (Any,), a)
 end
 pointer_to_string(p::Ptr{UInt8}, own::Bool=false) =
     pointer_to_string(p, ccall(:strlen, Csize_t, (Cstring,), p), own)

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -29,7 +29,10 @@ unsafe_convert{T}(::Type{Ptr{T}}, a::Array{T}) = ccall(:jl_array_ptr, Ptr{T}, (A
 unsafe_convert(::Type{Ptr{Void}}, a::Array) = ccall(:jl_array_ptr, Ptr{Void}, (Any,), a)
 
 # unsafe pointer to array conversions
-pointer_to_array(p, d::Integer, own=false) = pointer_to_array(p, (d,), own)
+function pointer_to_array{T}(p::Ptr{T}, d::Integer, own::Bool=false)
+    ccall(:jl_ptr_to_array_1d, Vector{T},
+          (Any, Ptr{Void}, Csize_t, Cint), Array{T,1}, p, d, own)
+end
 function pointer_to_array{T,N}(p::Ptr{T}, dims::NTuple{N,Int}, own::Bool=false)
     ccall(:jl_ptr_to_array, Array{T,N}, (Any, Ptr{Void}, Any, Int32),
           Array{T,N}, p, dims, own)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # name and module reflection
-module_name(m::Module) = ccall(:jl_module_name, Any, (Any,), m)::Symbol
-module_parent(m::Module) = ccall(:jl_module_parent, Any, (Any,), m)::Module
-current_module() = ccall(:jl_get_current_module, Any, ())::Module
+module_name(m::Module) = ccall(:jl_module_name, Ref{Symbol}, (Any,), m)
+module_parent(m::Module) = ccall(:jl_module_parent, Ref{Module}, (Any,), m)
+current_module() = ccall(:jl_get_current_module, Ref{Module}, ())
 
 function fullname(m::Module)
     m === Main && return ()
@@ -249,7 +249,7 @@ done(mt::MethodTable, m::Method) = false
 done(mt::MethodTable, i::Void) = true
 
 uncompressed_ast(l::LambdaInfo) =
-    isa(l.code,Array{Any,1}) ? l.code : ccall(:jl_uncompress_ast, Any, (Any,Any), l, l.code)
+    isa(l.code,Array{Any,1}) ? l.code::Array{Any,1} : ccall(:jl_uncompress_ast, Array{Any,1}, (Any,Any), l, l.code)
 
 # Printing code representations in IR and assembly
 function _dump_function(f, t::ANY, native, wrapper, strip_ir_metadata, dump_module)
@@ -260,11 +260,11 @@ function _dump_function(f, t::ANY, native, wrapper, strip_ir_metadata, dump_modu
         error("no method found for the specified argument types")
     end
 
-    if (native)
-        str = ccall(:jl_dump_function_asm, Any, (Ptr{Void},Cint), llvmf, 0)::ByteString
+    if native
+        str = ccall(:jl_dump_function_asm, Ref{ByteString}, (Ptr{Void},Cint), llvmf, 0)
     else
-        str = ccall(:jl_dump_function_ir, Any,
-                    (Ptr{Void}, Bool, Bool), llvmf, strip_ir_metadata, dump_module)::ByteString
+        str = ccall(:jl_dump_function_ir, Ref{ByteString},
+                    (Ptr{Void}, Bool, Bool), llvmf, strip_ir_metadata, dump_module)
     end
 
     return str

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -554,7 +554,7 @@ function deserialize(s::SerializationState, ::Type{LambdaInfo})
         linfo = known_object_data[lnumber]::LambdaInfo
         makenew = false
     else
-        linfo = ccall(:jl_new_lambda_info, Any, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}), C_NULL, C_NULL, C_NULL, C_NULL)::LambdaInfo
+        linfo = ccall(:jl_new_lambda_info, Ref{LambdaInfo}, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}), C_NULL, C_NULL, C_NULL, C_NULL)
         makenew = true
     end
     deserialize_cycle(s, linfo)
@@ -679,7 +679,7 @@ function deserialize(s::SerializationState, ::Type{TypeName})
     else
         name = gensym()
         mod = __deserialized_types__
-        tn = ccall(:jl_new_typename_in, Any, (Any, Any), name, mod)
+        tn = ccall(:jl_new_typename_in, Ref{TypeName}, (Any, Any), name, mod)
         makenew = true
     end
     deserialize_cycle(s, tn)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -11,16 +11,17 @@ string() = ""
 string(s::AbstractString) = s
 
 bytestring() = ""
-bytestring(s::Vector{UInt8}) = bytestring(pointer(s),length(s))
+bytestring(s::Vector{UInt8}) =
+    ccall(:jl_pchar_to_string, Ref{ByteString}, (Ptr{UInt8},Int), s, length(s))
 
 function bytestring(p::Union{Ptr{UInt8},Ptr{Int8}})
-    p == C_NULL ? throw(ArgumentError("cannot convert NULL to string")) :
+    p == C_NULL && throw(ArgumentError("cannot convert NULL to string"))
     ccall(:jl_cstr_to_string, Ref{ByteString}, (Cstring,), p)
 end
 bytestring(s::Cstring) = bytestring(convert(Ptr{UInt8}, s))
 
 function bytestring(p::Union{Ptr{UInt8},Ptr{Int8}},len::Integer)
-    p == C_NULL ? throw(ArgumentError("cannot convert NULL to string")) :
+    p == C_NULL && throw(ArgumentError("cannot convert NULL to string"))
     ccall(:jl_pchar_to_string, Ref{ByteString}, (Ptr{UInt8},Int), p, len)
 end
 
@@ -269,4 +270,3 @@ function filter(f, s::AbstractString)
     end
     takebuf_string(out)
 end
-

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -15,13 +15,13 @@ bytestring(s::Vector{UInt8}) = bytestring(pointer(s),length(s))
 
 function bytestring(p::Union{Ptr{UInt8},Ptr{Int8}})
     p == C_NULL ? throw(ArgumentError("cannot convert NULL to string")) :
-    ccall(:jl_cstr_to_string, Any, (Cstring,), p)::ByteString
+    ccall(:jl_cstr_to_string, Ref{ByteString}, (Cstring,), p)
 end
 bytestring(s::Cstring) = bytestring(convert(Ptr{UInt8}, s))
 
 function bytestring(p::Union{Ptr{UInt8},Ptr{Int8}},len::Integer)
     p == C_NULL ? throw(ArgumentError("cannot convert NULL to string")) :
-    ccall(:jl_pchar_to_string, Any, (Ptr{UInt8},Int), p, len)::ByteString
+    ccall(:jl_pchar_to_string, Ref{ByteString}, (Ptr{UInt8},Int), p, len)
 end
 
 convert(::Type{Vector{UInt8}}, s::AbstractString) = bytestring(s).data

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -27,8 +27,8 @@ function __init__()
         haskey(ENV,"JULIA_CPU_CORES") ? parse(Int,ENV["JULIA_CPU_CORES"]) :
                                         Int(ccall(:jl_cpu_cores, Int32, ()))
     global const SC_CLK_TCK = ccall(:jl_SC_CLK_TCK, Clong, ())
-    global const cpu_name = ccall(:jl_get_cpu_name, Any, ())::ByteString
-    global const JIT = ccall(:jl_get_JIT, Any, ())::ByteString
+    global const cpu_name = ccall(:jl_get_cpu_name, Ref{ByteString}, ())
+    global const JIT = ccall(:jl_get_JIT, Ref{ByteString}, ())
 end
 
 type UV_cpu_info_t

--- a/base/task.jl
+++ b/base/task.jl
@@ -53,7 +53,7 @@ macro task(ex)
     :(Task(()->$(esc(ex))))
 end
 
-current_task() = ccall(:jl_get_current_task, Any, ())::Task
+current_task() = ccall(:jl_get_current_task, Ref{Task}, ())
 istaskdone(t::Task) = ((t.state == :done) | (t.state == :failed))
 
 """

--- a/base/unicode/utf8.jl
+++ b/base/unicode/utf8.jl
@@ -355,5 +355,10 @@ function encode_to_utf8{T<:Union{UInt16, UInt32}}(::Type{T}, dat, len)
     UTF8String(buf)
 end
 
-utf8(p::Ptr{UInt8}) = UTF8String(bytestring(p))
-utf8(p::Ptr{UInt8}, len::Integer) = utf8(pointer_to_array(p, len))
+utf8(p::Ptr{UInt8}) =
+    utf8(p, p == C_NULL ? Csize_t(0) : ccall(:strlen, Csize_t, (Ptr{UInt8},), p))
+function utf8(p::Ptr{UInt8}, len::Integer)
+    p == C_NULL && throw(ArgumentError("cannot convert NULL to string"))
+    UTF8String(ccall(:jl_pchar_to_array, Vector{UInt8},
+                     (Ptr{UInt8}, Csize_t), p, len))
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -911,7 +911,7 @@ let
     @test aa == a
     aa = pointer_to_array(pointer(a), UInt16(length(a)))
     @test aa == a
-    @test_throws ErrorException pointer_to_array(pointer(a), -3)
+    @test_throws InexactError pointer_to_array(pointer(a), -3)
 end
 
 immutable FooBar

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -227,6 +227,9 @@ s = "abcde\uff\u2000\U1f596"
 sp = pointer(s)
 @test utf8(sp) == s
 @test utf8(sp,5) == "abcde"
+@test_throws ArgumentError ascii(sp)
+@test ascii(sp, 5) == "abcde"
+@test_throws ArgumentError ascii(sp, 6)
 @test typeof(utf8(sp)) == UTF8String
 
 @test get(tryparse(BigInt, "1234567890")) == BigInt(1234567890)
@@ -496,3 +499,12 @@ foobaz(ch) = reinterpret(Char, typemax(UInt32))
 @test utf8("a").*["b","c"] == ["ab","ac"]
 @test "a".*map(utf8,["b","c"]) == ["ab","ac"]
 @test ["a","b"].*["c","d"]' == ["ac" "ad"; "bc" "bd"]
+
+# Make sure NULL pointer are handled consistently by
+# `bytestring`, `ascii` and `utf8`
+@test_throws ArgumentError bytestring(Ptr{UInt8}(0))
+@test_throws ArgumentError bytestring(Ptr{UInt8}(0), 10)
+@test_throws ArgumentError ascii(Ptr{UInt8}(0))
+@test_throws ArgumentError ascii(Ptr{UInt8}(0), 10)
+@test_throws ArgumentError utf8(Ptr{UInt8}(0))
+@test_throws ArgumentError utf8(Ptr{UInt8}(0), 10)


### PR DESCRIPTION
1. Make sure `utf8`, `ascii` and `bytestring` always check if the pointer is `NULL`.
2. Avoid useless copy and dynamic dispatch in `ascii` and `utf8`.
3. Fix some out-of-date `ccall` usage to reduce avoid a few type assertions.
