### PR TITLE
Better doc and codegen for noreturn ccall

### DIFF
--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -400,6 +400,9 @@ Julia type with the same name, prefixed by C. This can help for writing portable
 +-----------------------------------+-----------------+----------------------+-----------------------------------+
 | ``void``                          |                 |                      | ``Void``                          |
 +-----------------------------------+-----------------+----------------------+-----------------------------------+
+| ``void`` and                      |                 |                      | ``Union{}``                       |
+| ``[[noreturn]]`` or ``_Noreturn`` |                 |                      |                                   |
++-----------------------------------+-----------------+----------------------+-----------------------------------+
 | ``void*``                         |                 |                      | ``Ptr{Void}``                     |
 +-----------------------------------+-----------------+----------------------+-----------------------------------+
 | ``T*`` (where T represents an     |                 |                      | ``Ref{T}``                        |
@@ -472,6 +475,13 @@ C name                  Standard Julia Alias    Julia Base Type
 
     Julia's ``Char`` type is 32 bits, which is not the same as the wide character
     type (``wchar_t`` or ``wint_t``) on all platforms.
+
+.. warning::
+
+    A return type of ``Union{}`` means the function will not return
+    i.e. C++11 ``[[noreturn]]`` or C11 ``_Noreturn`` (e.g. ``jl_throw`` or
+    ``longjmp``). Do not use this for function that returns
+    no value (``void``) but does return.
 
 .. note::
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1013,6 +1013,10 @@ static std::string generate_func_sig(
                                                   AttributeSet::get(jl_LLVMContext, i + 1, paramattrs[i]));
         }
     }
+    if (rt == jl_bottom_type)
+        attributes = attributes.addAttribute(jl_LLVMContext,
+                                             AttributeSet::FunctionIndex,
+                                             Attribute::NoReturn);
     return "";
 }
 


### PR DESCRIPTION
Noticed in https://github.com/JuliaLang/julia/pull/15773 that we treat `ccall` with `Bottom` return type as `Void` in codegen (not in typeinf). Add llvm function attribute to save a few return instructions...

One potential future issue I can see is that we have to handle the gc roots lifetime before dead code elimination.

Closes #14685
