### PR TITLE
Document recursive (c)transpose

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2629,7 +2629,9 @@ find(f, A)
 """
     ctranspose(A)
 
-The conjugate transposition operator (`'`).
+
+The conjugate transposition operator (`'`). Operates recursively on arrays with vector or
+matrix element type (e.g., block matrices).
 """
 ctranspose
 
@@ -4726,7 +4728,9 @@ lock
 """
     transpose(A)
 
-The transposition operator (`.'`).
+The transposition operator (`.'`). Operates recursively on arrays with vector or matrix
+element type (e.g., block matrices). Non-recursive behavior may be obtained in such cases
+by calling `permutedims(A, [2,1])`.
 """
 transpose
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1275,7 +1275,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   The transposition operator (``.'``\ ).
+   The transposition operator (``.'``\ ). Operates recursively on arrays with vector or matrix element type (e.g., block matrices). Non-recursive behavior may be obtained in such cases by calling ``permutedims(A, [2,1])``\ .
 
 .. function:: transpose!(dest,src)
 
@@ -1287,7 +1287,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   The conjugate transposition operator (``'``\ ).
+   The conjugate transposition operator (``'``\ ). Operates recursively on arrays with vector or matrix element type (e.g., block matrices).
 
 .. function:: ctranspose!(dest,src)
 


### PR DESCRIPTION
Notes:
- `ctranspose{T<:AbstractVector}(::Type{T})` is defined indirectly through the methods here: https://github.com/JuliaLang/julia/blob/master/base/operators.jl#L261
- As far as I can tell, `transpose{T<:AbstractVector}(::Type{T}) = Matrix{eltype(T)}` is the correct definition for all `subtypes` of AbstractVector.
- According to a brief search, the jury's out on whether the julia community prefers American (behavior) or British (behaviour) spellings, so I went with the good old USofA.
