### PR TITLE
Work around issue with truncated Float32 representation of lwork in sgesdd by using nextfloat.

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1572,7 +1572,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
                 end
                 chklapackerror(info[])
                 if i == 1
-                    lwork = BlasInt(real(work[1]))
+                    lwork = round(BlasInt, nextfloat(real(work[1])))
                     work = Array($elty, lwork)
                 end
             end


### PR DESCRIPTION
I've not added a test since it would take quite long to finish because of the size of the matrix required.

See

http://icl.cs.utk.edu/lapack-forum/viewtopic.php?f=13&t=4587&p=11036&hilit=sgesdd#p11036

and

https://github.com/scipy/scipy/issues/5401

Fixes JuliaLang/LinearAlgebra.jl#325
