### PR TITLE
Revert printing of ranges to v0.4

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -21,17 +21,21 @@ function writemime(io::IO, ::MIME"text/plain", f::Builtin)
     print(io, typeof(f).name.mt.name, " (built-in function)")
 end
 
-# writemime for ranges, e.g.
-#  3-element UnitRange{Int64,Int}
-#   1,2,3
-# or for more elements than fit on screen:
-#   1.0,2.0,3.0,…,6.0,7.0,8.0
-function writemime(io::IO, ::MIME"text/plain", r::Range)
+# writemime for linspace, e.g.
+# linspace(1,3,7)
+# 7-element LinSpace{Float64}:
+#   1.0,1.33333,1.66667,2.0,2.33333,2.66667,3.0
+function writemime(io::IO, ::MIME"text/plain", r::LinSpace)
     print(io, summary(r))
     if !isempty(r)
         println(io, ":")
         print_range(IOContext(io, :limit_output => true), r)
     end
+end
+
+# writemime for ranges
+function writemime(io::IO, ::MIME"text/plain", r::Range)
+  show(io, r)
 end
 
 function writemime(io::IO, ::MIME"text/plain", v::AbstractVector)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -564,13 +564,13 @@ end
 # stringmime/writemime should display the range or linspace nicely
 # to test print_range in range.jl
 replstrmime(x) = stringmime("text/plain", x)
-@test replstrmime(1:4) == "4-element UnitRange{$Int}:\n 1,2,3,4"
+@test replstrmime(1:4) == "1:4"
 @test replstrmime(linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
-@test replstrmime(0:100.) == "101-element FloatRange{Float64}:\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
+@test replstrmime(0:100.) == "0.0:1.0:100.0"
 # next is to test a very large range, which should be fast because print_range
 # only examines spacing of the left and right edges of the range, sufficient
 # to cover the designated screen size.
-@test replstrmime(0:10^9) == "1000000001-element UnitRange{$Int}:\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
+@test replstrmime(linspace(0,100, 10000)) == "10000-element LinSpace{Float64}:\n 0.0,0.010001,0.020002,0.030003,0.040004,…,99.95,99.96,99.97,99.98,99.99,100.0"
 
 @test sprint(io -> show(io,UnitRange(1,2))) == "1:2"
 @test sprint(io -> show(io,StepRange(1,2,5))) == "1:2:5"


### PR DESCRIPTION
This came up during #15753 and I followed  @StefanKarpinski comment here: https://github.com/JuliaLang/julia/issues/13966#issuecomment-156541581

This reverts printing of ranges to the status quo of v0.4. But keeps the
improvement for linspace.

The rational is that the information given for ranges is sufficient to
imagine the values contained in it, but for linspace the mapping to
values contained is non-trivial.
