### PR TITLE
Fixes to convert

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -292,7 +292,8 @@ end
 ## Conversions ##
 
 convert{T,N}(::Type{Array{T}}, B::BitArray{N}) = convert(Array{T,N},B)
-function convert{T,N}(::Type{Array{T,N}}, B::BitArray{N})
+convert{T,N}(::Type{Array{T,N}}, B::BitArray{N}) = _convert(Array{T,N}, B) # see #15801
+function _convert{T,N}(::Type{Array{T,N}}, B::BitArray{N})
     A = Array(T, size(B))
     Bc = B.chunks
     @inbounds for i = 1:length(A)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -282,10 +282,6 @@ function pointer{T,N,P<:Array,I<:Tuple{Vararg{Union{RangeIndex, NoSlice}}}}(V::S
     return pointer(V.parent, index)
 end
 
-## Convert
-convert{T,S,N}(::Type{Array{T,N}}, V::SubArray{S,N}) = copy!(Array(T, size(V)), V)
-
-
 ## Compatability
 # deprecate?
 function parentdims(s::SubArray)


### PR DESCRIPTION
These arose in the context of trying to get Images passing its tests on julia-0.5. The changes to `convert` arose largely in the context of eliminating ambiguity warnings. The method in `subarray` is unnecessary (it is redundant with [this method](https://github.com/JuliaLang/julia/blob/c60c9c8754cd4af0d46b2e67225355e9f1546d15/base/array.jl#L198), and therefore only generates additional ambiguities that must be resolved), and the `bitarray` one is a workaround for #15801.
