### PR TITLE
Fix LLVM 3.9 build

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -310,8 +310,7 @@ public:
                     PM.run(M);
                     std::unique_ptr<MemoryBuffer> ObjBuffer(
                         new ObjectMemoryBuffer(std::move(ObjBufferSV)));
-                    ErrorOr<std::unique_ptr<object::ObjectFile>> Obj =
-                        object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef());
+                    auto Obj = object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef());
 
                     if (!Obj) {
                         M.dump();


### PR DESCRIPTION
`ErrorOr` related again... There's another use of this function below that is already using `auto`...
