### PR TITLE
fix #15763, disallow newline immediately after `if`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,8 @@ Language changes
   * Simple 2-argument comparisons like `A < B` are parsed as calls intead of using the
     `:comparison` expression type.
 
+  * The `if` keyword cannot be followed immediately by a line break ([#15763]).
+
 Command-line option changes
 ---------------------------
 
@@ -181,3 +183,4 @@ Deprecated or removed
 [#15258]: https://github.com/JuliaLang/julia/issues/15258
 [#15550]: https://github.com/JuliaLang/julia/issues/15550
 [#15609]: https://github.com/JuliaLang/julia/issues/15609
+[#15763]: https://github.com/JuliaLang/julia/issues/15763

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1094,6 +1094,10 @@
                 ,body)))
 
        ((if)
+        (if (newline? (peek-token s))
+            (syntax-deprecation s "if with line break before condition" "")
+            #;(error (string "missing condition in \"if\" at " current-filename
+                           ":" (- (input-port-line (ts:port s)) 1))))
         (let* ((test (parse-cond s))
                (then (if (memq (require-token s) '(else elseif))
                          '(block)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -401,3 +401,8 @@ test_parseerror("0x1.0p", "invalid numeric constant \"0x1.0\"")
 @test expand(Base.parse_input_line("""
               try = "No"
            """)) == Expr(:error, "unexpected \"=\"")
+
+# issue #15763
+# TODO enable post-0.5
+#test_parseerror("if\nfalse\nend", "missing condition in \"if\" at none:1")
+test_parseerror("if false\nelseif\nend", "missing condition in \"elseif\" at none:2")


### PR DESCRIPTION
This was probably an oversight, and never should have been allowed to begin with.
