### PR TITLE
Implement permutedims for general AbstractArrays

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -164,18 +164,6 @@ function cumsum_kbn{T<:AbstractFloat}(A::AbstractArray{T}, axis::Integer=1)
     return B + C
 end
 
-## Permute array dims ##
-
-function permutedims(B::AbstractArray, perm)
-    dimsB = size(B)
-    ndimsB = length(dimsB)
-    (ndimsB == length(perm) && isperm(perm)) || throw(ArgumentError("no valid permutation of dimensions"))
-    dimsP = ntuple(i->dimsB[perm[i]], ndimsB)::typeof(dimsB)
-    P = similar(B, dimsP)
-    permutedims!(P, B, perm)
-end
-
-
 ## ipermutedims in terms of permutedims ##
 
 function ipermutedims(A::AbstractArray,perm)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -755,16 +755,21 @@ function permutedims(B::StridedArray, perm)
     permutedims!(P, B, perm)
 end
 
+function checkdims_perm{TP,TB,N}(P::AbstractArray{TP,N}, B::AbstractArray{TB,N}, perm)
+    dimsB = size(B)
+    length(perm) == N || throw(ArgumentError("expected permutation of size $N, but length(perm)=$(length(perm))"))
+    isperm(perm) || throw(ArgumentError("input is not a permutation"))
+    dimsP = size(P)
+    for i = 1:length(perm)
+        dimsP[i] == dimsB[perm[i]] || throw(DimensionMismatch("destination tensor of incorrect size"))
+    end
+    nothing
+end
+
 for (V, PT, BT) in [((:N,), BitArray, BitArray), ((:T,:N), Array, StridedArray)]
     @eval @generated function permutedims!{$(V...)}(P::$PT{$(V...)}, B::$BT{$(V...)}, perm)
         quote
-            dimsB = size(B)
-            length(perm) == N || throw(ArgumentError("expected permutation of size $N, but length(perm)=$(length(perm))"))
-            isperm(perm) || throw(ArgumentError("input is not a permutation"))
-            dimsP = size(P)
-            for i = 1:length(perm)
-                dimsP[i] == dimsB[perm[i]] || throw(DimensionMismatch("destination tensor of incorrect size"))
-            end
+            checkdims_perm(P, B, perm)
 
             #calculates all the strides
             strides_1 = 0

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -744,6 +744,17 @@ end
 
 ## permutedims
 
+## Permute array dims ##
+
+function permutedims(B::StridedArray, perm)
+    dimsB = size(B)
+    ndimsB = length(dimsB)
+    (ndimsB == length(perm) && isperm(perm)) || throw(ArgumentError("no valid permutation of dimensions"))
+    dimsP = ntuple(i->dimsB[perm[i]], ndimsB)::typeof(dimsB)
+    P = similar(B, dimsP)
+    permutedims!(P, B, perm)
+end
+
 for (V, PT, BT) in [((:N,), BitArray, BitArray), ((:T,:N), Array, StridedArray)]
     @eval @generated function permutedims!{$(V...)}(P::$PT{$(V...)}, B::$BT{$(V...)}, perm)
         quote

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -1,0 +1,40 @@
+module PermutedDimsArrays
+
+export permutedims
+
+immutable PermutedDimsArray{T,N,AA<:AbstractArray,perm} <: AbstractArray{T,N}
+    parent::AA
+    dims::NTuple{N,Int}
+
+    function PermutedDimsArray(data::AA, p::AbstractVector)
+        isa(perm, NTuple{N,Int}) || error("perm must be an NTuple{$N,Int}")
+        (length(perm) == N && isperm(perm)) || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
+        for i = 1:N
+            perm[p[i]] == i || throw(ArgumentError("size permutation must be the inverse of perm"))
+        end
+        new(data, ([size(data)...][p]...,))
+    end
+end
+
+function PermutedDimsArray{T,N}(data::AbstractArray{T,N}, p::AbstractVector)
+    length(p) == N || throw(ArgumentError(string(p, " is not a valid permutation of dimensions 1:", N)))
+    PermutedDimsArray{T,N,typeof(data),(invperm(p)...,)}(data, p)
+end
+
+Base.size(A::PermutedDimsArray) = A.dims
+
+@inline Base.getindex{T,N,AA,perm}(A::PermutedDimsArray{T,N,AA,perm}, I::Int...) = getindex(A.parent, _pda_reindex(perm, (), I)...)
+@inline Base.setindex!{T,N,AA,perm}(A::PermutedDimsArray{T,N,AA,perm}, val, I::Int...) = setindex!(A.parent, val, _pda_reindex(perm, (), I)...)
+
+@inline _pda_reindex(::Tuple{}, out, I) = out
+@inline _pda_reindex(perm, out, I) = _pda_reindex(Base.tail(perm), (out..., I[perm[1]]), I)
+
+function Base.permutedims{T,N}(A::AbstractArray{T,N}, perm)
+    sz::NTuple{N,Int} = size(A)[perm]
+    dest = similar(A, sz)
+    P = PermutedDimsArray(dest, invperm(perm))
+    copy!(P, A)
+    dest
+end
+
+end

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -23,8 +23,16 @@ end
 
 Base.size(A::PermutedDimsArray) = A.dims
 
-@inline Base.getindex{T,N,AA,perm}(A::PermutedDimsArray{T,N,AA,perm}, I::Int...) = getindex(A.parent, _pda_reindex(perm, (), I)...)
-@inline Base.setindex!{T,N,AA,perm}(A::PermutedDimsArray{T,N,AA,perm}, val, I::Int...) = setindex!(A.parent, val, _pda_reindex(perm, (), I)...)
+@inline function Base.getindex{T,N,AA,perm}(A::PermutedDimsArray{T,N,AA,perm}, I::Int...)
+    @boundscheck checkbounds(A, I...)
+    @inbounds val = getindex(A.parent, _pda_reindex(perm, (), I)...)
+    val
+end
+@inline function Base.setindex!{T,N,AA,perm}(A::PermutedDimsArray{T,N,AA,perm}, val, I::Int...)
+    @boundscheck checkbounds(A, I...)
+    @inbounds setindex!(A.parent, val, _pda_reindex(perm, (), I)...)
+    val
+end
 
 @inline _pda_reindex(::Tuple{}, out, I) = out
 @inline _pda_reindex(perm, out, I) = _pda_reindex(Base.tail(perm), (out..., I[perm[1]]), I)
@@ -32,9 +40,57 @@ Base.size(A::PermutedDimsArray) = A.dims
 function Base.permutedims{T,N}(A::AbstractArray{T,N}, perm)
     sz::NTuple{N,Int} = size(A)[perm]
     dest = similar(A, sz)
+    permutedims!(dest, A, perm)
+end
+
+function Base.permutedims!(dest, src::AbstractArray, perm)
+    Base.checkdims_perm(dest, src, perm)
     P = PermutedDimsArray(dest, invperm(perm))
-    copy!(P, A)
+    # If dest/src are "close to dense," then it pays to be cache-friendly.
+    # Determine the first permuted dimension
+    d = 0  # d+1 will hold the first permuted dimension of src
+    while d < ndims(src) && perm[d+1] == d+1
+        d += 1
+    end
+    sz1 = size(src)[1:d]
+    if prod(sz1) > 1
+        copy!(P, src)
+    else
+        R1 = CartesianRange(sz1)
+        d1 = findfirst(perm, d+1)  # first permuted dim of dest
+        R2 = CartesianRange(size(src)[d+2:d1-1])
+        R3 = CartesianRange(size(src)[d1+1:end])
+        _permutedims!(P, src, R1, R2, R3, d+1, d1)
+    end
     dest
+end
+
+@noinline function _permutedims!(P::PermutedDimsArray, src, R1::CartesianRange{CartesianIndex{0}}, R2, R3, ds, dp)
+    for jo in 1:8:size(src, dp), io in 1:8:size(src, ds)
+        for I3 in R3, I2 in R2
+            for j in jo:min(jo+7, size(src, dp))
+                for i in io:min(io+7, size(src, ds))
+                    @inbounds P[i, I2, j, I3] = src[i, I2, j, I3]
+                end
+            end
+        end
+    end
+    P
+end
+
+@noinline function _permutedims!(P::PermutedDimsArray, src, R1, R2, R3, ds, dp)
+    for jo in 1:8:size(src, dp), io in 1:8:size(src, ds)
+        for I3 in R3, I2 in R2
+            for j in jo:min(jo+7, size(src, dp))
+                for i in io:min(io+7, size(src, ds))
+                    for I1 in R1
+                        @inbounds P[I1, i, I2, j, I3] = src[I1, i, I2, j, I3]
+                    end
+                end
+            end
+        end
+    end
+    P
 end
 
 end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -172,6 +172,8 @@ include("float16.jl")
 include("cartesian.jl")
 using .Cartesian
 include("multidimensional.jl")
+include("permuteddimsarray.jl")
+using .PermutedDimsArrays
 
 include("primes.jl")
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -367,6 +367,14 @@ p = permutedims(s, [2,1])
 @test p[1,1]==a[2,2] && p[1,2]==a[3,2]
 @test p[2,1]==a[2,3] && p[2,2]==a[3,3]
 
+# of a non-strided subarray
+a = reshape(1:60, 3, 4, 5)
+s = sub(a,:,[1,2,4],[1,5])
+c = convert(Array, s)
+for p in ([1,2,3], [1,3,2], [2,1,3], [2,3,1], [3,1,2], [3,2,1])
+    @test permutedims(s, p) == permutedims(c, p)
+end
+
 ## ipermutedims ##
 
 tensors = Any[rand(1,2,3,4),rand(2,2,2,2),rand(5,6,5,6),rand(1,1,1,1)]


### PR DESCRIPTION
In #15810, there was some concern expressed about converting to `Array` before calling `permutedims`. This PR is an alternative, implementing a ~~naive (non-cache-friendly)~~ general `permutedims` that allocates the output using `similar`, potentially preserving the type information.

Performance is not dreadful, but is about two-fold worse than the other implementation (after warmup):

``` jl
julia> A = rand(100,101,102);

julia> B = sub(A, collect(1:size(A,1)), :, :);

julia> isa(B, StridedArray)
false

julia> @time (Bc = copy(B); permutedims(Bc, [3,1,2]));
  0.018679 seconds (21 allocations: 15.720 MB, 37.47% gc time)

julia> @time permutedims(B, [3,1,2]);
  0.035161 seconds (23 allocations: 7.861 MB)
```

It is half the memory allocation, however.
