### PR TITLE
RFC: Add `x as <type>` syntax for conversion.

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -33,6 +33,9 @@ convert{T}(::Type{Tuple{Vararg{T}}}, x::Tuple) = cnvt_all(T, x...)
 cnvt_all(T) = ()
 cnvt_all(T, x, rest...) = tuple(convert(T,x), cnvt_all(T, rest...)...)
 
+# provides syntax for convert
+as(x, t) = convert(t, x)
+
 macro generated(f)
     isa(f, Expr) || error("invalid syntax; @generated must be used with a function definition")
     if is(f.head, :function) || (isdefined(:length) && is(f.head, :(=)) && length(f.args) == 2 && f.args[1].head == :call)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1057,6 +1057,7 @@ export
     catch_stacktrace,
 
 # types
+    as,
     convert,
     fieldoffset,
     fieldname,

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -90,6 +90,16 @@ action:
     julia> typeof(ans)
     Float64
 
+The ``as`` operator provides a shorthand syntax for conversion:
+
+.. doctest::
+
+    julia> x = 12
+    12
+
+    julia> x as UInt8
+    0x0c
+
 Conversion isn't always possible, in which case a no method error is
 thrown indicating that ``convert`` doesn't know how to perform the
 requested conversion:

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -48,7 +48,7 @@
 (define is-prec-comparison?
   (let ((compare-ops (Set prec-comparison)))
     (lambda (t)
-      (or (compare-ops t) (eq? t 'in)))))
+      (or (compare-ops t) (eq? t 'in) (eq? t 'as)))))
 
 ;; hash table of binary operators -> precedence
 (define prec-table (let ((t (table)))
@@ -60,6 +60,7 @@
                      (pushprec (map eval prec-names) 1)
                      t))
 (put! prec-table 'in (get prec-table '== 0)) ; add `in` to the prec-table
+(put! prec-table 'as (get prec-table '== 0)) ; add `as` to the prec-table
 (define (operator-precedence op) (get prec-table op 0))
 
 (define unary-ops '(+ - ! ¬ ~ |<:| |>:| √ ∛ ∜))


### PR DESCRIPTION
With this PR: `(12 as Float64) === 12.0`

Very similar to what [Rust](https://doc.rust-lang.org/reference.html#type-cast-expressions) does. 

I copied what was done with `in` on the parser side but that might be the wrong place for it? 

Would people like this? I certainly would find it a useful syntactic sugaring. I looked for previous proposals for `convert` syntax but couldn't find any, but I apologize if this has already been discussed.
