### PR TITLE
Fix heuristic that suppresses type warning for intrinsics

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -387,8 +387,8 @@ function is_intrinsic_expr(x::ANY)
     isa(x, IntrinsicFunction) && return true
     if isa(x, GlobalRef)
         x = x::GlobalRef
-        return (x.mod == Base && isdefined(Base, x.name) &&
-                isa(getfield(Base, x.name), IntrinsicFunction))
+        return (isdefined(x.mod, x.name) &&
+                isa(getfield(x.mod, x.name), IntrinsicFunction))
     elseif isa(x, TopNode)
         x = x::TopNode
         return (isdefined(Base, x.name) &&

--- a/base/show.jl
+++ b/base/show.jl
@@ -393,6 +393,8 @@ function is_intrinsic_expr(x::ANY)
         x = x::TopNode
         return (isdefined(Base, x.name) &&
                 isa(getfield(Base, x.name), IntrinsicFunction))
+    elseif isa(x, Expr)
+        return (x::Expr).typ === IntrinsicFunction
     end
     return false
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -85,19 +85,27 @@ module ImportIntrinsics15819
 # the heuristic for type instability warning.
 # This can be any intrinsic that needs boxing
 import Core.Intrinsics: sqrt_llvm, box, unbox
+# Use import
 sqrt15819(x::Float64) = box(Float64, sqrt_llvm(unbox(Float64, x)))
+# Use fully qualified name
+sqrt15819(x::Float32) = box(Float32, Core.Intrinsics.sqrt_llvm(unbox(Float32, x)))
 end
+foo11122(x) = @fastmath x - 1.0
 
-# issue #13568 and #15819
+# issue #11122, #13568 and #15819
 @test !warntype_hastag(+, Tuple{Int,Int}, tag)
 @test !warntype_hastag(-, Tuple{Int,Int}, tag)
 @test !warntype_hastag(*, Tuple{Int,Int}, tag)
 @test !warntype_hastag(/, Tuple{Int,Int}, tag)
+@test !warntype_hastag(foo11122, Tuple{Float32}, tag)
+@test !warntype_hastag(foo11122, Tuple{Float64}, tag)
+@test !warntype_hastag(foo11122, Tuple{Int}, tag)
 @test !warntype_hastag(sqrt, Tuple{Int}, tag)
 @test !warntype_hastag(sqrt, Tuple{Float64}, tag)
 @test !warntype_hastag(^, Tuple{Float64,Int32}, tag)
 @test !warntype_hastag(^, Tuple{Float32,Int32}, tag)
 @test !warntype_hastag(ImportIntrinsics15819.sqrt15819, Tuple{Float64}, tag)
+@test !warntype_hastag(ImportIntrinsics15819.sqrt15819, Tuple{Float32}, tag)
 
 end
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -80,11 +80,24 @@ show(iob, expand(:(x->x^2)))
 str = takebuf_string(iob)
 @test isempty(search(str, tag))
 
-# issue #13568
+module ImportIntrinsics15819
+# Make sure changing the lookup path of an intrinsic doesn't break
+# the heuristic for type instability warning.
+# This can be any intrinsic that needs boxing
+import Core.Intrinsics: sqrt_llvm, box, unbox
+sqrt15819(x::Float64) = box(Float64, sqrt_llvm(unbox(Float64, x)))
+end
+
+# issue #13568 and #15819
 @test !warntype_hastag(+, Tuple{Int,Int}, tag)
 @test !warntype_hastag(-, Tuple{Int,Int}, tag)
 @test !warntype_hastag(*, Tuple{Int,Int}, tag)
 @test !warntype_hastag(/, Tuple{Int,Int}, tag)
+@test !warntype_hastag(sqrt, Tuple{Int}, tag)
+@test !warntype_hastag(sqrt, Tuple{Float64}, tag)
+@test !warntype_hastag(^, Tuple{Float64,Int32}, tag)
+@test !warntype_hastag(^, Tuple{Float32,Int32}, tag)
+@test !warntype_hastag(ImportIntrinsics15819.sqrt15819, Tuple{Float64}, tag)
 
 end
 


### PR DESCRIPTION
When the intrinsic is not looked up directly in `Base`.

Closes #15819
