### PR TITLE
Make falses(A) and trues(A) not change their argument

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -235,8 +235,33 @@ function fill!(B::BitArray, x)
     return B
 end
 
-falses(args...) = fill!(BitArray(args...), false)
-trues(args...) = fill!(BitArray(args...), true)
+"""
+    falses(dims)
+
+Create a `BitArray` with all values set to `false`.
+"""
+falses(dims::Dims) = fill!(BitArray(dims), false)
+falses(dims::Integer...) = falses(dims)
+"""
+    falses(A)
+
+Create a `BitArray` with all values set to `false` of the same shape as `A`.
+"""
+falses(A::AbstractArray) = falses(size(A))
+
+"""
+    trues(dims)
+
+Create a `BitArray` with all values set to `true`.
+"""
+trues(dims::Dims) = fill!(BitArray(dims), true)
+trues(dims::Integer...) = trues(dims)
+"""
+    trues(A)
+
+Create a `BitArray` with all values set to `true` of the same shape as `A`.
+"""
+trues(A::AbstractArray) = trues(size(A))
 
 function one(x::BitMatrix)
     m, n = size(x)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1125,13 +1125,6 @@ results to `r`.
 any!
 
 """
-    falses(dims)
-
-Create a `BitArray` with all values set to `false`.
-"""
-falses
-
-"""
     filter!(function, collection)
 
 Update `collection`, removing elements for which `function` is `false`. For associative
@@ -7824,13 +7817,6 @@ x == fld(x,y)*y + mod(x,y)
 ```
 """
 mod
-
-"""
-    trues(dims)
-
-Create a `BitArray` with all values set to `true`.
-"""
-trues
 
 """
     qr(A [,pivot=Val{false}][;thin=true]) -> Q, R, [p]

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -76,7 +76,9 @@ Function                                            Description
                                                     ``type`` not specified
 :func:`ones(A) <ones>`                              an array of all ones of same element type and shape of ``A``
 :func:`trues(dims...) <trues>`                      a ``Bool`` array with all values ``true``
+:func:`trues(A) <trues>`                            a ``Bool`` array with all values ``true`` and the shape of ``A``
 :func:`falses(dims...) <falses>`                    a ``Bool`` array with all values ``false``
+:func:`falses(A) <falses>`                          a ``Bool`` array with all values ``false`` and the shape of ``A``
 :func:`reshape(A, dims...) <reshape>`               an array with the same data as the given array, but with
                                                     different dimensions.
 :func:`copy(A) <copy>`                              copy ``A``

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -191,11 +191,23 @@ Constructors
 
    Create a ``BitArray`` with all values set to ``true``\ .
 
+.. function:: trues(A)
+
+   .. Docstring generated from Julia source
+
+   Create a ``BitArray`` with all values set to ``true`` of the same shape as ``A``\ .
+
 .. function:: falses(dims)
 
    .. Docstring generated from Julia source
 
    Create a ``BitArray`` with all values set to ``false``\ .
+
+.. function:: falses(A)
+
+   .. Docstring generated from Julia source
+
+   Create a ``BitArray`` with all values set to ``false`` of the same shape as ``A``\ .
 
 .. function:: fill(x, dims)
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -43,6 +43,26 @@ s1, s2, s3, s4 = 5, 8, 3, 4
 allsizes = [((), BitArray{0}), ((v1,), BitVector),
             ((n1,n2), BitMatrix), ((s1,s2,s3,s4), BitArray{4})]
 
+# trues and falses
+for (sz,T) in allsizes
+    a = falses(sz...)
+    @test a == falses(sz)
+    @test !any(a)
+    @test sz == size(a)
+    b = trues(sz...)
+    @test b == trues(sz)
+    @test all(b)
+    @test sz == size(b)
+    c = trues(a)
+    @test all(c)
+    @test !any(a)
+    @test sz == size(c)
+    d = falses(b)
+    @test !any(d)
+    @test all(b)
+    @test sz == size(d)
+end
+
 ## Conversions ##
 
 for (sz,T) in allsizes


### PR DESCRIPTION
Presently, we have:

```
julia> a=[false true];

julia> falses(a)
1x2 BitArray{2}:
 false  false

julia> a
1x2 BitArray{2}:
 false  false
```

which is undocumented and certainly surprising. This PR makes  `falses(A)` and `trues(A)` not change their argument and documents this syntax.
