### PR TITLE
Better line number information for the REPL

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -153,7 +153,7 @@ function syntax_deprecation_warnings(f::Function, warn::Bool)
     end
 end
 
-function parse_input_line(s::ByteString)
+function parse_input_line(s::ByteString; filename::ByteString="none")
     # (expr, pos) = parse(s, 1)
     # (ex, pos) = ccall(:jl_parse_string, Any,
     #                   (Ptr{UInt8},Csize_t,Int32,Int32),
@@ -162,7 +162,8 @@ function parse_input_line(s::ByteString)
     #     throw(ParseError("extra input after end of expression"))
     # end
     # expr
-    ccall(:jl_parse_input_line, Any, (Ptr{UInt8}, Csize_t), s, sizeof(s))
+    ccall(:jl_parse_input_line, Any, (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t),
+        s, sizeof(s), filename, sizeof(filename))
 end
 parse_input_line(s::AbstractString) = parse_input_line(bytestring(s))
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -697,12 +697,13 @@ static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v)
 }
 
 // this is used to parse a line of repl input
-JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len)
+JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len, const char *filename, size_t filename_len)
 {
     jl_ast_context_t *ctx = jl_ast_ctx_enter();
     fl_context_t *fl_ctx = &ctx->fl;
     value_t s = cvalue_static_cstrn(fl_ctx, str, len);
-    value_t e = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-parse-string")), s);
+    value_t files = cvalue_static_cstrn(fl_ctx, filename, filename_len);
+    value_t e = fl_applyn(fl_ctx, 2, symbol_value(symbol(fl_ctx, "jl-parse-string")), s, files);
     jl_value_t *res = e == fl_ctx->FL_EOF ? jl_nothing : scm_to_julia(fl_ctx, e, 0);
     jl_ast_ctx_leave(ctx);
     return res;

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -52,7 +52,9 @@ JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
 {
     jl_value_t *r;
     JL_TRY {
-        jl_value_t *ast = jl_parse_input_line(str, strlen(str));
+        char *filename = "none";
+        jl_value_t *ast = jl_parse_input_line(str, strlen(str),
+                filename, strlen(filename));
         JL_GC_PUSH1(&ast);
         r = jl_toplevel_eval(ast);
         JL_GC_POP();

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -122,8 +122,9 @@
                                    (julia-parse inp parse-atom))))))
       (cons expr (io.pos inp)))))
 
-(define (jl-parse-string s)
-  (parser-wrap (lambda ()
+(define (jl-parse-string s filename)
+  (with-bindings ((current-filename (symbol filename)))
+    (parser-wrap (lambda ()
                  (let ((inp  (make-token-stream (open-input-string s))))
                    ;; parse all exprs into a (toplevel ...) form
                    (let loop ((exprs '()))
@@ -137,7 +138,7 @@
                                  (else (cons 'toplevel (reverse! exprs))))
                            (if (and (pair? expr) (eq? (car expr) 'toplevel))
                                (loop (nreconc (cdr expr) exprs))
-                               (loop (cons expr exprs))))))))))
+                               (loop (cons expr exprs)))))))))))
 
 (define (jl-parse-all io filename)
   (unwind-protect

--- a/src/julia.h
+++ b/src/julia.h
@@ -1195,7 +1195,8 @@ JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname);
 JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz);
 
 // front end interface
-JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len);
+JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len,
+                                             const char *filename, size_t filename_len);
 JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
                                          int pos0, int greedy);
 JL_DLLEXPORT int jl_parse_depwarn(int warn);


### PR DESCRIPTION
Before:

```
julia> f() = error()
f (generic function with 1 method)

julia> f()
ERROR:
 in f() at ./none:1
 in eval(::Module, ::Any) at ./boot.jl:237

julia> using Gallium; @enter f()
Body
├─ none: 1
└─ Return
   └─ Call
      └─ Main.error
```

after:

```
julia> f()
ERROR:
 in f() at ./REPL[1]:1
 in eval(::Module, ::Any) at ./boot.jl:237

julia> using Gallium; @enter f()
1 f() = error()

About to run: Main.error
```

cc @JeffBezanson for the parser interface change
