### PR TITLE
Fix associative types not being shown in full at the REPL. Fixes #14684

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -3,6 +3,7 @@
 # fallback text/plain representation of any type:
 writemime(io::IO, ::MIME"text/plain", x) = showcompact(io, x)
 writemime(io::IO, ::MIME"text/plain", x::Number) = show(io, x)
+writemime(io::IO, ::MIME"text/plain", x::Associative) = showdict(io, x)
 
 function writemime(io::IO, ::MIME"text/plain", f::Function)
     ft = typeof(f)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -336,3 +336,19 @@ withenv("JULIA_EDITOR" => nothing, "VISUAL" => nothing, "EDITOR" => nothing) do
     ENV["JULIA_EDITOR"] = "\"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl\" -w"
     @test Base.editor() == ["/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl", "-w"]
 end
+
+# Issue #14684: `display` should prints associative types in full.
+let d = Dict(1 => 2, 3 => 45)
+    buf = IOBuffer()
+    td = TextDisplay(buf)
+    display(td, d)
+    result = bytestring(td.io)
+
+    @test contains(result, summary(d))
+
+    # Is every pair in the string?
+    # Compare by removing spaces
+    for el in d
+        @test contains(replace(result, " ", ""), string(el))
+    end
+end


### PR DESCRIPTION
Edit: Be aware I am new to this, so feel free to correct me. :)

This PR reinstates a method for `writemime` which does the pretty-printing for a `Associative` which @vtjnash removed at some point several months ago in preparation for the functionality to be integrated with `show`. See https://github.com/JuliaLang/julia/issues/14684#issuecomment-172042769.

My intention for this PR is to provide a stop-gap until that integration it completed.
