### PR TITLE
Fix macro hygiene when calling the macro in the same module.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -606,6 +606,9 @@ function docm(meta, ex, define = true)
     # Don't try to redefine expressions. This is only needed for `Base` img gen since
     # otherwise calling `loaddocs` would redefine all documented functions and types.
     def = define ? x : nothing
+    if isa(x, GlobalRef) && (x::GlobalRef).mod == current_module()
+        x = (x::GlobalRef).name
+    end
 
     # Keywords using the `@kw_str` macro in `base/docs/basedocs.jl`.
     #

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -9,11 +9,11 @@ transpose(F::Factorization) = error("transpose not implemented for $(typeof(F))"
 ctranspose(F::Factorization) = error("ctranspose not implemented for $(typeof(F))")
 
 macro assertposdef(A, info)
-   :(($info)==0 ? $A : throw(PosDefException($info)))
+   :($(esc(info)) == 0 ? $(esc(A)) : throw(PosDefException($(esc(info)))))
 end
 
 macro assertnonsingular(A, info)
-   :(($info)==0 ? $A : throw(SingularException($info)))
+   :($(esc(info)) == 0 ? $(esc(A)) : throw(SingularException($(esc(info)))))
 end
 
 function logdet(F::Factorization)

--- a/base/sparse/cholmod_h.jl
+++ b/base/sparse/cholmod_h.jl
@@ -75,5 +75,5 @@ type CHOLMODException <: Exception
 end
 
 macro isok(A)
-    :($A == TRUE || throw(CHOLMODException("")))
+    :($(esc(A)) == TRUE || throw(CHOLMODException("")))
 end

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -54,7 +54,7 @@ function umferror(status::Integer)
 end
 
 macro isok(A)
-    :(umferror($A))
+    :(umferror($(esc(A))))
 end
 
 # check the size of SuiteSparse_long

--- a/src/ast.c
+++ b/src/ast.c
@@ -108,13 +108,18 @@ value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint32_t na
     jl_ptls_t ptls = jl_get_ptls_states();
     // tells whether a var is defined in and *by* the current module
     argcount(fl_ctx, "defined-julia-global", nargs, 1);
-    (void)tosymbol(fl_ctx, args[0], "defined-julia-global");
-    if (ptls->current_module == NULL)
+    jl_module_t *mod = ptls->current_module;
+    jl_sym_t *sym = (jl_sym_t*)scm_to_julia(fl_ctx, args[0], 0);
+    if (jl_is_globalref(sym)) {
+        mod = jl_globalref_mod(sym);
+        sym = jl_globalref_name(sym);
+    }
+    if (!jl_is_symbol(sym))
+        type_error(fl_ctx, "defined-julia-global", "symbol", args[0]);
+    if (!mod)
         return fl_ctx->F;
-    jl_sym_t *var = jl_symbol(symbol_name(fl_ctx, args[0]));
-    jl_binding_t *b =
-        (jl_binding_t*)ptrhash_get(&ptls->current_module->bindings, var);
-    return (b != HT_NOTFOUND && b->owner==ptls->current_module) ? fl_ctx->T : fl_ctx->F;
+    jl_binding_t *b = (jl_binding_t*)ptrhash_get(&mod->bindings, sym);
+    return (b != HT_NOTFOUND && b->owner == mod) ? fl_ctx->T : fl_ctx->F;
 }
 
 value_t fl_current_julia_module(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
@@ -177,14 +182,14 @@ value_t fl_invoke_julia_macro(fl_context_t *fl_ctx, value_t *args, uint32_t narg
     fl_gc_handle(fl_ctx, &scm);
     value_t scmresult;
     jl_module_t *defmod = mfunc->def->module;
-    if (defmod == NULL || defmod == ptls->current_module) {
-        scmresult = fl_cons(fl_ctx, scm, fl_ctx->F);
-    }
-    else {
-        value_t opaque = cvalue(fl_ctx, jl_ast_ctx(fl_ctx)->jvtype, sizeof(void*));
-        *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = (jl_value_t*)defmod;
-        scmresult = fl_cons(fl_ctx, scm, opaque);
-    }
+    /* if (defmod == NULL || defmod == ptls->current_module) { */
+    /*     scmresult = fl_cons(fl_ctx, scm, fl_ctx->F); */
+    /* } */
+    /* else { */
+    value_t opaque = cvalue(fl_ctx, jl_ast_ctx(fl_ctx)->jvtype, sizeof(void*));
+    *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = (jl_value_t*)defmod;
+    scmresult = fl_cons(fl_ctx, scm, opaque);
+    /* } */
     fl_free_gc_handles(fl_ctx, 1);
 
     JL_GC_POP();
@@ -610,6 +615,19 @@ static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v)
         return julia_to_list2(fl_ctx, (jl_value_t*)inert_sym, jl_fieldref(v,0));
     if (jl_typeis(v, jl_newvarnode_type))
         return julia_to_list2(fl_ctx, (jl_value_t*)newvar_sym, jl_fieldref(v,0));
+    if (jl_typeis(v, jl_globalref_type)) {
+        jl_module_t *m = jl_globalref_mod(v);
+        jl_sym_t *sym = jl_globalref_name(v);
+        if (m == jl_core_module)
+            return julia_to_list2(fl_ctx, (jl_value_t*)core_sym,
+                                  (jl_value_t*)sym);
+        value_t args = julia_to_list2(fl_ctx, (jl_value_t*)m, (jl_value_t*)sym);
+        fl_gc_handle(fl_ctx, &args);
+        value_t hd = julia_to_scm_(fl_ctx, (jl_value_t*)globalref_sym);
+        value_t scmv = fl_cons(fl_ctx, hd, args);
+        fl_free_gc_handles(fl_ctx, 1);
+        return scmv;
+    }
     if (jl_is_long(v) && fits_fixnum(jl_unbox_long(v)))
         return fixnum(jl_unbox_long(v));
     if (jl_is_ssavalue(v))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1800,6 +1800,14 @@
        (error (string "invalid assignment location \"" (deparse lhs) "\"")))
       (else
        (case (car lhs)
+         ((globalref)
+          ;; M.b =
+          (let* ((rhs (caddr e))
+                 (rr  (if (or (symbol-like? rhs) (atom? rhs)) rhs (make-ssavalue))))
+            `(block
+              ,.(if (eq? rr rhs) '() `((= ,rr ,(expand-forms rhs))))
+              (= ,lhs ,rr)
+              (unnecessary ,rr))))
          ((|.|)
           ;; a.b =
           (let* ((a   (cadr lhs))

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -423,7 +423,7 @@
                (error (cadr form)))
            (let ((form (car form))
                  (m    (cdr form)))
-             ;; m is the macro's def module, or #f if def env === use env
+             ;; m is the macro's def module
              (rename-symbolic-labels
               (julia-expand-macros
                (resolve-expansion-vars form m))))))

--- a/test/core.jl
+++ b/test/core.jl
@@ -3490,7 +3490,7 @@ end
 
 # issue 13855
 macro m13855()
-    Expr(:localize, :(() -> x))
+    Expr(:localize, :(() -> $(esc(:x))))
 end
 @noinline function foo13855(x)
     @m13855()
@@ -4794,3 +4794,30 @@ end
 @test let_Box4()() == 44
 @test let_Box5()() == 46
 @test let_noBox()() == 21
+
+module TestModuleAssignment
+using Base.Test
+@eval $(GlobalRef(TestModuleAssignment, :x)) = 1
+@test x == 1
+@eval $(GlobalRef(TestModuleAssignment, :x)) = 2
+@test x == 2
+end
+
+# issue #14893
+module M14893
+x = 14893
+macro m14893()
+    :x
+end
+function f14893()
+    x = 1
+    @m14893
+end
+end
+function f14893()
+    x = 2
+    M14893.@m14893
+end
+
+@test f14893() == 14893
+@test M14893.f14893() == 14893


### PR DESCRIPTION
There is a surprising number of base code that relies on the wrong behavior....

One broken test/code that need to be fixed on this commit is the [MacroGlobalFunction test](https://github.com/JuliaLang/julia/commit/a8284df44d61bdeb3f03779ee9cbcb6fdd04a8c4#diff-75b23cc61d190dd99feab17b8e297ee3L3463). The test doesn't work if the macro is used outside the module so I think the fix is correct. However, should the macro expander detect this case and avoid modifying the function name that is defined to be global already?

Closes #14893

c.c. @JeffBezanson about the test mentioned above and since the code was added a long time ago (https://github.com/JuliaLang/julia/commit/605bc65c59451b567bd64e750c1e659424759fe2) I can't really find a explanation why the check is necessary.
