### PR TITLE
Fixes #15739: Compact REPL printouts of an `Associative` use brackets when appropriate

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -77,12 +77,10 @@ function showdict{K,V}(io::IO, t::Associative{K,V}; compact = false)
             print(io, '(')
             first = true
             n = 0
-            for (k, v) in t
+            for pair in t
                 first || print(io, ',')
                 first = false
-                show(recur_io, k)
-                print(io, "=>")
-                show(recur_io, v)
+                show(recur_io, pair)
                 n+=1
                 limit && n >= 10 && (print(io, "…"); break)
             end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -294,11 +294,17 @@ for d in (Dict("\n" => "\n", "1" => "\n", "\n" => "2"),
     @test !isempty(summary(values(d)))
 end
 
-# Issue #15739 - `Pair`s of `Pair`s should enclose their parts in parentheses.
+# Issue #15739 - Compact REPL printouts of an `Associative` use brackets when appropriate
 let d = Dict((1=>2) => (3=>45), (3=>10) => (10=>11))
     buf = IOBuffer()
     showcompact(buf, d)
-    @test bytestring(buf) == "Dict((3=>10)=>(10=>11),(1=>2)=>(3=>45))"
+
+    # Check explicitly for the expected strings, since the CPU bitness effects
+    # dictionary ordering.
+    result = bytestring(buf)
+    @test contains(result, "Dict")
+    @test contains(result, "(1=>2)=>(3=>45)")
+    @test contains(result, "(3=>10)=>(10=>11)")
 end
 
 # issue #9463

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -294,6 +294,13 @@ for d in (Dict("\n" => "\n", "1" => "\n", "\n" => "2"),
     @test !isempty(summary(values(d)))
 end
 
+# Issue #15739 - `Pair`s of `Pair`s should enclose their parts in parentheses.
+let d = Dict((1=>2) => (3=>45), (3=>10) => (10=>11))
+    buf = IOBuffer()
+    showcompact(buf, d)
+    @test bytestring(buf) == "Dict((3=>10)=>(10=>11),(1=>2)=>(3=>45))"
+end
+
 # issue #9463
 type Alpha end
 Base.show(io::IO, ::Alpha) = print(io,"α")


### PR DESCRIPTION
Displaying a `Dict` in compact format manually prints out the pairs in the form `key=>value` which is problematic if either the key or value is a `Pair`, itself.

This PR defers the printing of the ~~keys and the values~~ key-value pairs to `show`.

E.g:

On master:

``` julia
julia> Dict( (1=>2)=>(3=>10), (2=>4)=>(6=>20) )
Dict(2=>4=>6=>20,1=>2=>3=>10)
```

With this PR: 

``` julia
julia> Dict( (1=>2)=>(3=>10), (2=>4)=>(6=>20) )
Dict((2=>4)=>(6=>20),(1=>2)=>(3=>10))
```
