### PR TITLE
WIP: use interpreter to execute functions that are all generic calls

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -177,8 +177,8 @@ function _iisconst(s::Symbol, sv)
 end
 
 _ieval(x::ANY, sv) =
-    ccall(:jl_interpret_toplevel_expr_in, Any, (Any, Any, Any, Any),
-          sv.mod, x, svec(), svec())
+    ccall(:jl_interpret_toplevel_expr_in, Any, (Any, Any, Ptr{Void}),
+          sv.mod, x, C_NULL)
 
 _topmod(sv::InferenceState) = _topmod(sv.mod)
 _topmod(m::Module) = ccall(:jl_base_relative_to, Any, (Any,), m)::Module

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2812,6 +2812,11 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
                 return result;
             }
         }
+        if (ctx->allGeneric && (jl_is_topnode(args[0]) || jl_is_globalref(args[0]))) {
+            // inline called constants for the benefit of the interpreter
+            // TODO: nicer way to do this
+            args[0] = jl_new_struct(jl_quotenode_type, (jl_value_t*)f); jl_gc_wb(((jl_expr_t*)expr)->args, args[0]);
+        }
     }
 
     // special case for known builtin not handled by emit_builtin_call

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2823,6 +2823,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
     if (f && jl_subtype(f, (jl_value_t*)jl_builtin_type, 1)) {
         std::map<jl_fptr_t,Function*>::iterator it = builtin_func_map.find(jl_get_builtin_fptr(f));
         if (it != builtin_func_map.end()) {
+            ctx->nGenericCalls++;
             theFptr = (*it).second;
             result = mark_julia_type(emit_jlcall(theFptr, V_null, &args[1], nargs, ctx), true, expr_type(expr,ctx), ctx);
             JL_GC_POP();

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -568,6 +568,8 @@ typedef struct {
     int nReqArgs;
     std::vector<bool> boundsCheck;
     std::vector<bool> inbounds;
+    bool allGeneric;
+    int nGenericCalls;
 
     CallInst *ptlsStates;
 #ifdef JULIA_ENABLE_THREADING
@@ -847,29 +849,38 @@ static void to_function(jl_lambda_info_t *li)
         JL_UNLOCK(codegen);
         jl_rethrow_with_add("error compiling %s", jl_symbol_name(li->name));
     }
-    // record that this function name came from this linfo,
-    // so we can build a reverse mapping for debug-info.
-    if (li->name != anonymous_sym) {
-        const DataLayout &DL =
-#ifdef LLVM35
-            m->getDataLayout();
-#else
-            *jl_data_layout;
-#endif
-        // but don't remember anonymous symbols because
-        // they may not be rooted in the gc for the life of the program,
-        // and the runtime doesn't notify us when the code becomes unreachable :(
-        jl_add_linfo_in_flight((specf ? specf : f)->getName(), li, DL);
-    }
 
-    // success. add the result to the execution engine now
-    jl_finalize_module(std::move(m));
-    li->functionID = jl_assign_functionID(f, 0);
-    if (specf)
-        li->specFunctionID = jl_assign_functionID(specf, 1);
-    if (f->getFunctionType() != jl_func_sig)
-        // mark the pointer as jl_fptr_sparam_t calling convention
-        li->jlcall_api = 1;
+    if (li->jlcall_api != 2) {
+        // record that this function name came from this linfo,
+        // so we can build a reverse mapping for debug-info.
+        if (li->name != anonymous_sym) {
+            const DataLayout &DL =
+#ifdef LLVM35
+                m->getDataLayout();
+#else
+                *jl_data_layout;
+#endif
+            // but don't remember anonymous symbols because
+            // they may not be rooted in the gc for the life of the program,
+            // and the runtime doesn't notify us when the code becomes unreachable :(
+            jl_add_linfo_in_flight((specf ? specf : f)->getName(), li, DL);
+        }
+
+        // success. add the result to the execution engine now
+        jl_finalize_module(std::move(m));
+
+        li->functionID = jl_assign_functionID(f, 0);
+        if (specf)
+            li->specFunctionID = jl_assign_functionID(specf, 1);
+        if (f->getFunctionType() != jl_func_sig)
+            // mark the pointer as jl_fptr_sparam_t calling convention
+            li->jlcall_api = 1;
+    }
+    else {
+        li->functionObjects.functionObject = NULL;
+        li->functionObjects.specFunctionObject = NULL;
+        li->functionObjects.cFunctionList = NULL;
+    }
 
     // done compiling: restore global state
     if (old != NULL) {
@@ -991,6 +1002,8 @@ uint64_t jl_get_llvm_fptr(llvm::Function *llvmf)
 // and forces compilation of the lambda info
 extern "C" void jl_generate_fptr(jl_lambda_info_t *li)
 {
+    if (li->jlcall_api == 2)
+        return;
     JL_LOCK(codegen);
     // objective: assign li->fptr
     assert(li->functionObjects.functionObject);
@@ -1009,6 +1022,8 @@ extern "C" void jl_generate_fptr(jl_lambda_info_t *li)
 // or generate object code for it
 extern "C" void jl_compile_linfo(jl_lambda_info_t *li)
 {
+    if (li->jlcall_api == 2)
+        return;
     if (li->functionObjects.functionObject == NULL) {
         // objective: assign li->functionObject
         to_function(li);
@@ -2782,6 +2797,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
     if (f != NULL) {
         // function is a compile-time constant
         if (jl_typeis(f, jl_intrinsic_type)) {
+            ctx->allGeneric = false;
             result = emit_intrinsic((intrinsic)*(uint32_t*)jl_data_ptr(f), args, nargs, ctx);
             if (result.typ == (jl_value_t*)jl_any_type) // the select_value intrinsic may be missing type information
                 result = remark_julia_type(result, expr_type(expr, ctx));
@@ -2791,6 +2807,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
         if (jl_subtype(f, (jl_value_t*)jl_builtin_type, 1)) {
             bool handled = emit_builtin_call(&result, (jl_value_t*)f, args, nargs, ctx, expr);
             if (handled) {
+                ctx->allGeneric = false;
                 JL_GC_POP();
                 return result;
             }
@@ -2819,7 +2836,9 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
                   jl_sprint((jl_value_t*)aty));
               }*/
             jl_lambda_info_t *li = jl_get_specialization1((jl_tupletype_t*)aty);
-            if (li != NULL) {
+            // TODO: if li->jlcall_api == 2 then directly call interpreter
+            if (li != NULL && li->jlcall_api != 2) {
+                ctx->allGeneric = false;
                 assert(li->functionObjects.functionObject != NULL);
                 theFptr = (Value*)li->functionObjects.functionObject;
                 jl_cgval_t fval;
@@ -2860,6 +2879,7 @@ static jl_cgval_t emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
                                   myargs, ConstantInt::get(T_int32, nargs));
 #endif
     result = mark_julia_type(callval, true, expr_type(expr, ctx), ctx);
+    ctx->nGenericCalls++;
 
     JL_GC_POP();
     return result;
@@ -3333,6 +3353,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
         return ghostValue(jl_void_type);
     }
     else if (head == static_typeof_sym) {
+        ctx->allGeneric = false;
         jl_value_t *extype = expr_type((jl_value_t*)ex, ctx);
         if (jl_is_type_type(extype)) {
             extype = jl_tparam0(extype);
@@ -3952,6 +3973,8 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
     ctx.inbounds.push_back(false);
     ctx.boundsCheck.push_back(false);
     ctx.spvals_ptr = NULL;
+    ctx.allGeneric = true;
+    ctx.nGenericCalls = 0;
 
     // step 2. process var-info lists to see what vars need boxing
     int n_gensyms = jl_is_long(lam->gensymtypes) ? jl_unbox_long(lam->gensymtypes) : jl_array_len(lam->gensymtypes);
@@ -4793,6 +4816,11 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
     }
 
     JL_GC_POP();
+
+    if (ctx.allGeneric && ctx.nGenericCalls > 0) {
+        lam->jlcall_api = 2;
+        lam->code = code; jl_gc_wb(lam, lam->code);
+    }
 
     return std::unique_ptr<Module>(M);
 }

--- a/src/dump.c
+++ b/src/dump.c
@@ -839,8 +839,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         // save functionObject pointers
         write_int32(s, li->functionID);
         write_int32(s, li->specFunctionID);
-        if (li->functionID)
-            write_int8(s, li->jlcall_api);
+        write_int8(s, li->jlcall_api);
         write_int8(s, li->needs_sparam_vals_ducttape);
     }
     else if (jl_typeis(v, jl_module_type)) {
@@ -1473,7 +1472,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         func_llvm = read_int32(s);
         cfunc_llvm = read_int32(s);
         jl_delayed_fptrs(li, func_llvm, cfunc_llvm);
-        li->jlcall_api = func_llvm ? read_int8(s) : 0;
+        li->jlcall_api = read_int8(s);
         li->needs_sparam_vals_ducttape = read_int8(s);
         return (jl_value_t*)li;
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -883,6 +883,8 @@ static jl_value_t *jl_call_unspecialized(jl_svec_t *sparam_vals, jl_lambda_info_
     assert(jl_svec_len(meth->sparam_syms) == jl_svec_len(sparam_vals));
     if (__likely(meth->jlcall_api == 0))
         return meth->fptr(args[0], &args[1], nargs-1);
+    else if (meth->jlcall_api == 2)
+        return jl_interpret_call(meth, args, nargs, sparam_vals);
     else
         return ((jl_fptr_sparam_t)meth->fptr)(sparam_vals, args[0], &args[1], nargs-1);
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -14,15 +14,20 @@
 extern "C" {
 #endif
 
-static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *lam);
-static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, jl_lambda_info_t *lam,
-                             int start, int toplevel);
+typedef struct {
+    jl_lambda_info_t *lam;
+    jl_value_t **locals;
+    jl_svec_t *sparam_vals;
+} interpreter_state;
+
+static jl_value_t *eval(jl_value_t *e, interpreter_state *s);
+static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, int start, int toplevel);
 jl_value_t *jl_eval_module_expr(jl_expr_t *ex);
 int jl_is_toplevel_only_expr(jl_value_t *e);
 
 jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e)
 {
-    return eval(e, NULL, NULL);
+    return eval(e, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
@@ -31,10 +36,11 @@ JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_
     jl_value_t *v=NULL;
     jl_module_t *last_m = jl_current_module;
     jl_module_t *task_last_m = jl_current_task->current_module;
+    interpreter_state s = { .lam = lam, .locals = NULL, .sparam_vals = NULL };
 
     JL_TRY {
         jl_current_task->current_module = jl_current_module = m;
-        v = eval(e, NULL, lam);
+        v = eval(e, &s);
     }
     JL_CATCH {
         jl_current_module = last_m;
@@ -47,14 +53,13 @@ JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_
     return v;
 }
 
-static jl_value_t *do_call(jl_value_t **args, size_t nargs, jl_value_t **locals,
-                           jl_lambda_info_t *lam)
+static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s)
 {
     jl_value_t **argv;
     JL_GC_PUSHARGS(argv, nargs);
     size_t i;
     for(i=0; i < nargs; i++)
-        argv[i] = eval(args[i], locals, lam);
+        argv[i] = eval(args[i], s);
     jl_value_t *result = jl_apply_generic(argv, nargs);
     JL_GC_POP();
     return result;
@@ -122,80 +127,73 @@ static int jl_linfo_ngensyms(jl_lambda_info_t *li)
     return jl_is_long(li->gensymtypes) ? jl_unbox_long(li->gensymtypes) : jl_array_len(li->gensymtypes);
 }
 
-static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *lam)
+static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
 {
-    if (jl_is_symbol(e)) {
-        jl_value_t *v = jl_get_global(jl_current_module, (jl_sym_t*)e);
-        if (v == NULL)
-            jl_undefined_var_error((jl_sym_t*)e);
-        return v;
-    }
+    jl_lambda_info_t *lam = s==NULL ? NULL : s->lam;
     if (jl_is_gensym(e)) {
         ssize_t genid = ((jl_gensym_t*)e)->id;
-        if (genid >= jl_linfo_ngensyms(lam) || genid < 0 || locals == NULL)
+        if (genid >= jl_linfo_ngensyms(lam) || genid < 0 || s->locals == NULL)
             jl_error("access to invalid GenSym location");
-        else
-            return locals[jl_linfo_nslots(lam) + genid];
+        return s->locals[jl_linfo_nslots(lam) + genid];
     }
-    if (jl_is_quotenode(e)) {
-        return jl_fieldref(e,0);
+    if (jl_typeis(e, jl_slot_type)) {
+        ssize_t n = jl_slot_number(e);
+        if (n > jl_linfo_nslots(lam) || n < 1 || s->locals == NULL)
+            jl_error("access to invalid slot number");
+        jl_value_t *v = s->locals[n-1];
+        if (v == NULL)
+            jl_undefined_var_error((jl_sym_t*)jl_cellref(lam->slotnames,n-1));
+        return v;
     }
+    jl_module_t *modu = lam == NULL ? jl_current_module : lam->module;
     if (jl_is_topnode(e)) {
         jl_sym_t *s = (jl_sym_t*)jl_fieldref(e,0);
-        jl_value_t *v = jl_get_global(jl_base_relative_to(jl_current_module),s);
+        jl_value_t *v = jl_get_global(jl_base_relative_to(modu), s);
         if (v == NULL)
             jl_undefined_var_error(s);
         return v;
     }
+    if (jl_is_globalref(e)) {
+        jl_sym_t *s = jl_globalref_name(e);
+        jl_value_t *v = jl_get_global(jl_globalref_mod(e), s);
+        if (v == NULL)
+            jl_undefined_var_error(s);
+        return v;
+    }
+    if (jl_is_quotenode(e)) {
+        return jl_fieldref(e,0);
+    }
+    if (jl_is_symbol(e)) {  // bare symbols appear in toplevel exprs not wrapped in `thunk`
+        jl_value_t *v = jl_get_global(modu, (jl_sym_t*)e);
+        if (v == NULL)
+            jl_undefined_var_error((jl_sym_t*)e);
+        return v;
+    }
     if (!jl_is_expr(e)) {
-        if (jl_typeis(e, jl_slot_type)) {
-            ssize_t n = jl_slot_number(e);
-            if (n > jl_linfo_nslots(lam) || n < 1 || locals == NULL)
-                jl_error("access to invalid slot number");
-            jl_value_t *v = locals[n-1];
-            if (v == NULL)
-                jl_undefined_var_error((jl_sym_t*)jl_cellref(lam->slotnames,n-1));
-            return v;
-        }
-        if (jl_is_globalref(e)) {
-            jl_value_t *gfargs[2] = {(jl_value_t*)jl_globalref_mod(e), (jl_value_t*)jl_globalref_name(e)};
-            return jl_f_getfield(NULL, gfargs, 2);
-        }
-        if (jl_is_linenode(e)) {
-            jl_lineno = jl_linenode_line(e);
-        }
-        if (jl_is_newvarnode(e)) {
-            jl_value_t *var = jl_fieldref(e,0);
-            assert(jl_typeis(var,jl_slot_type));
-            ssize_t n = jl_slot_number(var);
-            assert(n <= jl_linfo_nslots(lam) && n > 0);
-            locals[n-1] = NULL;
-            return (jl_value_t*)jl_nothing;
-        }
         return e;
     }
     jl_expr_t *ex = (jl_expr_t*)e;
     jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
     size_t nargs = jl_array_len(ex->args);
     if (ex->head == call_sym) {
-        return do_call(args, nargs, locals, lam);
+        return do_call(args, nargs, s);
     }
     else if (ex->head == assign_sym) {
         jl_value_t *sym = args[0];
-        jl_value_t *rhs = eval(args[1], locals, lam);
+        jl_value_t *rhs = eval(args[1], s);
         if (jl_is_gensym(sym)) {
             ssize_t genid = ((jl_gensym_t*)sym)->id;
             if (genid >= jl_linfo_ngensyms(lam) || genid < 0)
                 jl_error("assignment to invalid GenSym location");
-            locals[jl_linfo_nslots(lam) + genid] = rhs;
+            s->locals[jl_linfo_nslots(lam) + genid] = rhs;
         }
         else if (jl_typeis(sym,jl_slot_type)) {
             ssize_t n = jl_slot_number(sym);
             assert(n <= jl_linfo_nslots(lam) && n > 0);
-            locals[n-1] = rhs;
+            s->locals[n-1] = rhs;
         }
         else {
-            jl_module_t *m = jl_current_module;
+            jl_module_t *m = modu;
             if (jl_is_globalref(sym)) {
                 m = jl_globalref_mod(sym);
                 sym = (jl_value_t*)jl_globalref_name(sym);
@@ -209,13 +207,13 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         return rhs;
     }
     else if (ex->head == new_sym) {
-        jl_value_t *thetype = eval(args[0], locals, lam);
+        jl_value_t *thetype = eval(args[0], s);
         jl_value_t *v=NULL;
         JL_GC_PUSH2(&thetype, &v);
         assert(jl_is_structtype(thetype));
         v = jl_new_struct_uninit((jl_datatype_t*)thetype);
         for(size_t i=1; i < nargs; i++) {
-            jl_set_nth_field(v, i-1, eval(args[i], locals, lam));
+            jl_set_nth_field(v, i-1, eval(args[i], s));
         }
         JL_GC_POP();
         return v;
@@ -223,22 +221,27 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
     else if (ex->head == null_sym) {
         return (jl_value_t*)jl_nothing;
     }
-    else if (ex->head == body_sym) {
-        return eval_body(ex->args, locals, lam, 0, 0);
-    }
     else if (ex->head == static_parameter_sym) {
         ssize_t n = jl_unbox_long(args[0]);
         assert(n > 0);
+        if (s->sparam_vals)
+            return jl_svecref(s->sparam_vals, n-1);
         // static parameter val unknown needs to be an error for ccall
         if (n > jl_svec_len(lam->sparam_vals))
             jl_error("could not determine static parameter value");
         return jl_svecref(lam->sparam_vals, n-1);
     }
-    else if (ex->head == exc_sym) {
-        return jl_exception_in_transit;
+    else if (ex->head == inert_sym) {
+        return args[0];
+    }
+    else if (ex->head == copyast_sym) {
+        return jl_copy_ast(eval(args[0], s));
     }
     else if (ex->head == static_typeof_sym) {
         return (jl_value_t*)jl_any_type;
+    }
+    else if (ex->head == exc_sym) {
+        return jl_exception_in_transit;
     }
     else if (ex->head == method_sym) {
         jl_sym_t *fname = (jl_sym_t*)args[0];
@@ -249,9 +252,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
             jl_value_t *bp_owner=NULL;
             jl_binding_t *b=NULL;
             if (bp == NULL) {
-                b = jl_get_binding_for_method_def(jl_current_module, fname);
+                b = jl_get_binding_for_method_def(modu, fname);
                 bp = &b->value;
-                bp_owner = (jl_value_t*)jl_current_module;
+                bp_owner = (jl_value_t*)modu;
             }
             jl_value_t *gf = jl_generic_function_def(fname, bp, bp_owner, b);
             if (jl_expr_nargs(ex) == 1)
@@ -260,19 +263,16 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
 
         jl_value_t *atypes=NULL, *meth=NULL;
         JL_GC_PUSH2(&atypes, &meth);
-        atypes = eval(args[1], locals, lam);
-        meth = eval(args[2], locals, lam);
+        atypes = eval(args[1], s);
+        meth = eval(args[2], s);
         jl_method_def((jl_svec_t*)atypes, (jl_lambda_info_t*)meth, args[3]);
         JL_GC_POP();
         return jl_nothing;
     }
-    else if (ex->head == copyast_sym) {
-        return jl_copy_ast(eval(args[0], locals, lam));
-    }
     else if (ex->head == const_sym) {
         jl_value_t *sym = args[0];
         assert(jl_is_symbol(sym));
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)sym);
+        jl_binding_t *b = jl_get_binding_wr(modu, (jl_sym_t*)sym);
         jl_declare_constant(b);
         return (jl_value_t*)jl_nothing;
     }
@@ -281,13 +281,13 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         // TODO: handle type decls
         for (size_t i=0; i < jl_array_len(ex->args); i++) {
             assert(jl_is_symbol(args[i]));
-            jl_get_binding_wr(jl_current_module, (jl_sym_t*)args[i]);
+            jl_get_binding_wr(modu, (jl_sym_t*)args[i]);
         }
         return (jl_value_t*)jl_nothing;
     }
     else if (ex->head == abstracttype_sym) {
         jl_value_t *name = args[0];
-        jl_value_t *para = eval(args[1], locals, lam);
+        jl_value_t *para = eval(args[1], s);
         jl_value_t *super = NULL;
         jl_value_t *temp = NULL;
         jl_datatype_t *dt = NULL;
@@ -295,12 +295,12 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         assert(jl_is_svec(para));
         assert(jl_is_symbol(name));
         dt = jl_new_abstracttype(name, jl_any_type, (jl_svec_t*)para);
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
+        jl_binding_t *b = jl_get_binding_wr(modu, (jl_sym_t*)name);
         temp = b->value;
         check_can_assign_type(b);
         b->value = (jl_value_t*)dt;
         jl_gc_wb_binding(b, dt);
-        super = eval(args[2], locals, lam);
+        super = eval(args[2], s);
         jl_set_datatype_super(dt, super);
         jl_reinstantiate_inner_types(dt);
         b->value = temp;
@@ -316,9 +316,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         jl_datatype_t *dt = NULL;
         JL_GC_PUSH4(&para, &super, &temp, &dt);
         assert(jl_is_symbol(name));
-        para = eval(args[1], locals, lam);
+        para = eval(args[1], s);
         assert(jl_is_svec(para));
-        vnb  = eval(args[2], locals, lam);
+        vnb  = eval(args[2], s);
         if (!jl_is_long(vnb))
             jl_errorf("invalid declaration of bits type %s",
                       jl_symbol_name((jl_sym_t*)name));
@@ -327,12 +327,12 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
             jl_errorf("invalid number of bits in type %s",
                       jl_symbol_name((jl_sym_t*)name));
         dt = jl_new_bitstype(name, jl_any_type, (jl_svec_t*)para, nb);
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
+        jl_binding_t *b = jl_get_binding_wr(modu, (jl_sym_t*)name);
         temp = b->value;
         check_can_assign_type(b);
         b->value = (jl_value_t*)dt;
         jl_gc_wb_binding(b, dt);
-        super = eval(args[3], locals, lam);
+        super = eval(args[3], s);
         jl_set_datatype_super(dt, super);
         jl_reinstantiate_inner_types(dt);
         b->value = temp;
@@ -345,18 +345,18 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
     else if (ex->head == compositetype_sym) {
         jl_value_t *name = args[0];
         assert(jl_is_symbol(name));
-        jl_value_t *para = eval(args[1], locals, lam);
+        jl_value_t *para = eval(args[1], s);
         assert(jl_is_svec(para));
         jl_value_t *temp = NULL;
         jl_value_t *super = NULL;
         jl_datatype_t *dt = NULL;
         JL_GC_PUSH4(&para, &super, &temp, &dt);
-        temp = eval(args[2], locals, lam);  // field names
+        temp = eval(args[2], s);  // field names
         dt = jl_new_datatype((jl_sym_t*)name, jl_any_type, (jl_svec_t*)para,
                              (jl_svec_t*)temp, NULL,
                              0, args[5]==jl_true ? 1 : 0, jl_unbox_long(args[6]));
 
-        jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
+        jl_binding_t *b = jl_get_binding_wr(modu, (jl_sym_t*)name);
         temp = b->value;  // save old value
         // temporarily assign so binding is available for field types
         check_can_assign_type(b);
@@ -364,11 +364,11 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         jl_gc_wb_binding(b,dt);
 
         JL_TRY {
-            super = eval(args[3], locals, lam);
+            super = eval(args[3], s);
             jl_set_datatype_super(dt, super);
             // operations that can fail
             inside_typedef = 1;
-            dt->types = (jl_svec_t*)eval(args[4], locals, lam);
+            dt->types = (jl_svec_t*)eval(args[4], s);
             jl_gc_wb(dt, dt->types);
             inside_typedef = 0;
             for(size_t i=0; i < jl_svec_len(dt->types); i++) {
@@ -404,12 +404,11 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         JL_GC_POP();
         return (jl_value_t*)jl_nothing;
     }
-    else if (ex->head == line_sym) {
-        jl_lineno = jl_unbox_long(jl_exprarg(ex,0));
-        return (jl_value_t*)jl_nothing;
-    }
     else if (ex->head == module_sym) {
         return jl_eval_module_expr(ex);
+    }
+    else if (ex->head == thunk_sym) {
+        return jl_toplevel_eval((jl_value_t*)ex);
     }
     else if (ex->head == error_sym || ex->head == jl_incomplete_sym) {
         if (nargs == 0)
@@ -418,26 +417,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
             jl_errorf("syntax: %s", jl_string_data(args[0]));
         jl_throw(args[0]);
     }
-    else if (ex->head == boundscheck_sym) {
-        return (jl_value_t*)jl_nothing;
-    }
-    else if (ex->head == inbounds_sym) {
-        return (jl_value_t*)jl_nothing;
-    }
-    else if (ex->head == fastmath_sym) {
-        return (jl_value_t*)jl_nothing;
-    }
-    else if (ex->head == simdloop_sym) {
-        return (jl_value_t*)jl_nothing;
-    }
-    else if (ex->head == meta_sym) {
-        return (jl_value_t*)jl_nothing;
-    }
-    else if (ex->head == inert_sym) {
-        return args[0];
-    }
-    else if (ex->head == thunk_sym) {
-        return jl_toplevel_eval((jl_value_t*)ex);
+    else if (ex->head == boundscheck_sym || ex->head == inbounds_sym || ex->head == fastmath_sym ||
+             ex->head == simdloop_sym || ex->head == meta_sym || ex->head == type_goto_sym) {
+        return jl_nothing;
     }
     jl_errorf("unsupported or misplaced expression %s", jl_symbol_name(ex->head));
     return (jl_value_t*)jl_nothing;
@@ -445,21 +427,10 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
 
 jl_value_t *jl_toplevel_eval_body(jl_array_t *stmts)
 {
-    ssize_t ngensym = 0;
-    size_t i, l = jl_array_len(stmts);
-    for (i = 0; i < l; i++) {
-        ssize_t maxid = jl_max_jlgensym_in(jl_cellref(stmts, i))+1;
-        if (maxid > ngensym)
-            ngensym = maxid;
-    }
-    jl_value_t **locals = NULL;
-    assert(ngensym == 0);
-    jl_value_t *ret = eval_body(stmts, locals, NULL, 0, 1);
-    return ret;
+    return eval_body(stmts, NULL, 0, 1);
 }
 
-static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, jl_lambda_info_t *lam,
-                             int start, int toplevel)
+static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, int start, int toplevel)
 {
     jl_handler_t __eh;
     size_t i=start, ns = jl_array_len(stmts);
@@ -472,10 +443,10 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, jl_lambda_i
             i = jl_gotonode_label(stmt)-1;
             continue;
         }
-        if (jl_is_expr(stmt)) {
+        else if (jl_is_expr(stmt)) {
             jl_sym_t *head = ((jl_expr_t*)stmt)->head;
             if (head == goto_ifnot_sym) {
-                jl_value_t *cond = eval(jl_exprarg(stmt,0), locals, lam);
+                jl_value_t *cond = eval(jl_exprarg(stmt,0), s);
                 if (cond == jl_false) {
                     i = jl_unbox_long(jl_exprarg(stmt, 1))-1;
                     continue;
@@ -489,12 +460,12 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, jl_lambda_i
                 if (toplevel && jl_is_toplevel_only_expr(ex))
                     return jl_toplevel_eval(ex);
                 else
-                    return eval(ex, locals, lam);
+                    return eval(ex, s);
             }
             else if (head == enter_sym) {
                 jl_enter_handler(&__eh);
                 if (!jl_setjmp(__eh.eh_ctx,1)) {
-                    return eval_body(stmts, locals, lam, i+1, toplevel);
+                    return eval_body(stmts, s, i+1, toplevel);
                 }
                 else {
 #ifdef _OS_WINDOWS_
@@ -509,18 +480,29 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, jl_lambda_i
                 int hand_n_leave = jl_unbox_long(jl_exprarg(stmt,0));
                 jl_pop_handler(hand_n_leave);
             }
+            else if (head == line_sym) {
+                if (toplevel)
+                    jl_lineno = jl_unbox_long(jl_exprarg(stmt,0));
+                // TODO: interpreted function line numbers
+            }
+            else if (toplevel && jl_is_toplevel_only_expr(stmt)) {
+                jl_toplevel_eval(stmt);
+            }
             else {
-                if (toplevel && jl_is_toplevel_only_expr(stmt))
-                    jl_toplevel_eval(stmt);
-                else
-                    eval(stmt, locals, lam);
+                eval(stmt, s);
             }
         }
-        else {
-            if (toplevel && jl_is_toplevel_only_expr(stmt))
-                jl_toplevel_eval(stmt);
-            else
-                eval(stmt, locals, lam);
+        else if (jl_is_linenode(stmt)) {
+            if (toplevel)
+                jl_lineno = jl_linenode_line(stmt);
+            // TODO: interpreted function line numbers
+        }
+        else if (jl_is_newvarnode(stmt)) {
+            jl_value_t *var = jl_fieldref(stmt,0);
+            assert(jl_typeis(var,jl_slot_type));
+            ssize_t n = jl_slot_number(var);
+            assert(n <= jl_linfo_nslots(s->lam) && n > 0);
+            s->locals[n-1] = NULL;
         }
         i++;
     }
@@ -528,14 +510,28 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, jl_lambda_i
     return NULL;
 }
 
-jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam)
+jl_value_t *jl_interpret_call(jl_lambda_info_t *lam, jl_value_t **args, uint32_t nargs, jl_svec_t *sparam_vals)
 {
     jl_array_t *stmts = lam->code;
+    assert(jl_typeis(stmts, jl_array_any_type));
     jl_value_t **locals;
     JL_GC_PUSHARGS(locals, jl_linfo_nslots(lam) + jl_linfo_ngensyms(lam));
-    jl_value_t *r = eval_body(stmts, locals, lam, 0, 1);
+    interpreter_state s = { .lam = lam, .locals = locals, .sparam_vals = sparam_vals };
+    size_t i;
+    for(i=0; i < lam->nargs; i++) {
+        if (lam->isva && i == lam->nargs-1)
+            locals[i] = jl_f_tuple(NULL, &args[i], nargs-i);
+        else
+            locals[i] = args[i];
+    }
+    jl_value_t *r = eval_body(stmts, &s, 0, lam->nargs==0);
     JL_GC_POP();
     return r;
+}
+
+jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam)
+{
+    return jl_interpret_call(lam, NULL, 0, NULL);
 }
 
 #ifdef __cplusplus

--- a/src/julia.h
+++ b/src/julia.h
@@ -204,7 +204,8 @@ typedef struct _jl_lambda_info_t {
 
     // hidden fields:
     uint8_t called;  // bit flags: whether each of the first 8 arguments is called
-    uint8_t jlcall_api : 1;     // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t
+    // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t, 2 = interpreted
+    uint8_t jlcall_api : 2;
     uint8_t inCompile : 1;
     // if there are intrinsic calls, sparams are probably required to compile successfully,
     // and so unspecialized will be created for each linfo instead of once in linfo->def.

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -57,6 +57,7 @@ STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 
 void jl_generate_fptr(jl_lambda_info_t *li);
 void jl_compile_linfo(jl_lambda_info_t *li);
+jl_value_t *jl_interpret_call(jl_lambda_info_t *lam, jl_value_t **args, uint32_t nargs, jl_svec_t *sparam_vals);
 
 // invoke (compiling if necessary) the jlcall function pointer for a method
 STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_value_t **args, uint32_t nargs)
@@ -67,6 +68,8 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_val
     }
     if (meth->jlcall_api == 0)
         return meth->fptr(args[0], &args[1], nargs-1);
+    else if (meth->jlcall_api == 2)
+        return jl_interpret_call(meth, args, nargs, NULL);
     else
         return ((jl_fptr_sparam_t)meth->fptr)(meth->sparam_vals, args[0], &args[1], nargs-1);
 }


### PR DESCRIPTION
This hooks up the interpreter for functions that only call `jl_apply_generic` and therefore don't really need native code generation.

So far, things are generally slower. I might be doing something wrong, or the interpreter might just be really slow.

Almost all tests pass, except some related to stack traces and line numbers. We might have to add a special mechanism for finding locations in interpreted functions. `boundscheck` test fails due to missing support for runtime intrinsics.
