### PR TITLE
RFC: Add API for programatic tracing of specializations/new methods

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -254,7 +254,7 @@ uncompressed_ast(l::LambdaInfo) =
 # Printing code representations in IR and assembly
 function _dump_function(f, t::ANY, native, wrapper, strip_ir_metadata, dump_module)
     t = tt_cons(Core.Typeof(f), to_tuple_type(t))
-    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Any, Bool, Bool), f, t, wrapper, native)
+    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Bool, Bool), t, wrapper, native)
 
     if llvmf == C_NULL
         error("no method found for the specified argument types")

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -373,6 +373,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *tvars, jl_svec_
     li->pure = 0;
     li->called = 0xff;
     li->needs_sparam_vals_ducttape = 2;
+    li->traced = 0;
     if (ast != NULL) {
         JL_GC_PUSH1(&li);
         jl_lambda_info_set_ast(li, ast);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1174,14 +1174,15 @@ void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name)
 // this is paired with jl_dump_function_ir and jl_dump_function_asm in particular ways:
 // misuse will leak memory or cause read-after-free
 extern "C" JL_DLLEXPORT
-void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper, bool getdeclarations)
+void *jl_get_llvmf(jl_tupletype_t *tt, bool getwrapper, bool getdeclarations)
 {
     jl_lambda_info_t *linfo = NULL;
     JL_GC_PUSH2(&linfo, &tt);
     if (tt != NULL) {
         linfo = jl_get_specialization1(tt);
         if (linfo == NULL) {
-            linfo = jl_method_lookup_by_type(jl_gf_mtable(f), tt, 0, 0);
+            linfo = jl_method_lookup_by_type(
+                ((jl_datatype_t*)jl_tparam0(tt))->name->mt, tt, 0, 0);
             if (linfo == NULL) {
                 JL_GC_POP();
                 return NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1475,6 +1475,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         jl_delayed_fptrs(li, func_llvm, cfunc_llvm);
         li->jlcall_api = func_llvm ? read_int8(s) : 0;
         li->needs_sparam_vals_ducttape = read_int8(s);
+        li->traced = 0;
         return (jl_value_t*)li;
     }
     else if (vtag == (jl_value_t*)jl_module_type) {

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -308,6 +308,31 @@ JL_DLLEXPORT const char *jl_git_commit(void)
     return commit;
 }
 
+JL_DLLEXPORT void jl_trace_linfo(jl_lambda_info_t *li)
+{
+    assert(jl_is_lambda_info(li));
+    li->traced = 1;
+}
+
+JL_DLLEXPORT void jl_untrace_linfo(jl_lambda_info_t *li)
+{
+    assert(jl_is_lambda_info(li));
+    li->traced = 0;
+}
+
+void (*jl_linfo_tracer)(jl_lambda_info_t *tracee) = 0;
+JL_DLLEXPORT void jl_register_tracer(void (*callback)(jl_lambda_info_t *tracee))
+{
+    jl_linfo_tracer = callback;
+}
+
+void (*jl_newmeth_tracer)(jl_methlist_t *tracee) = 0;
+JL_DLLEXPORT void jl_register_newmeth_tracer(void (*callback)(jl_methlist_t *tracee))
+{
+    jl_newmeth_tracer = callback;
+}
+
+
 // Create function versions of some useful macros
 JL_DLLEXPORT jl_taggedvalue_t *(jl_astaggedvalue)(jl_value_t *v)
 {

--- a/src/julia.h
+++ b/src/julia.h
@@ -210,6 +210,9 @@ typedef struct _jl_lambda_info_t {
     // and so unspecialized will be created for each linfo instead of once in linfo->def.
     // 0 = no, 1 = yes, 2 = not yet known
     uint8_t needs_sparam_vals_ducttape : 2;
+    // If this flag is set, the system will call a callback if a specialization
+    // is added to this lambda info. See jl_register_tracer below.
+    uint8_t traced : 1;
     jl_fptr_t fptr;             // jlcall entry point
 
     // On the old JIT, handles to all Functions generated for this linfo
@@ -1242,6 +1245,12 @@ JL_DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len);
 JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                                        jl_lambda_info_t *lam);
 JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m);
+
+// tracing
+JL_DLLEXPORT void jl_trace_linfo(jl_lambda_info_t *li);
+JL_DLLEXPORT void jl_untrace_linfo(jl_lambda_info_t *li);
+JL_DLLEXPORT void jl_register_tracer(void (*callback)(jl_lambda_info_t *tracee));
+JL_DLLEXPORT void jl_register_newmeth_tracer(void (*callback)(jl_methlist_t *tracee));
 
 // AST access
 JL_DLLEXPORT int jl_is_rest_arg(jl_value_t *ex);

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -276,7 +276,7 @@ definitely_not_in_sysimg() = nothing
 for (f,t) in ((definitely_not_in_sysimg,Tuple{}),
         (Base.throw_boundserror,Tuple{UnitRange{Int64},Int64}))
     t = Base.tt_cons(Core.Typeof(f), Base.to_tuple_type(t))
-    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Any, Bool, Bool), f, t, false, true)
+    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Bool, Bool), t, false, true)
     @test llvmf != C_NULL
     @test ccall(:jl_get_llvm_fptr, Ptr{Void}, (Ptr{Void},), llvmf) != C_NULL
 end


### PR DESCRIPTION
Suppose, hypothetically that some person may want to write a debugger for julia. In that case said person would want to be informed when new methods are added to the system such that they can be checked against any breakpoint conditions that the debugger may have. This adds a minimal such implementation that allows one to register a callback to be informed of such events. Potential points of design discussion:
- Only have once callback with a flag to indicate the kind of event?
- Are these the only places where new specializations/methods are getting added?
- Do we have a problem with calling back arbitrary code at these points.

@JeffBezanson 
