### PR TITLE
Faster BitArray packing and related operations

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -291,7 +291,7 @@ end
 
 ## Conversions ##
 
-convert{T,N}(::Type{Array{T}}, B::BitArray{N}) = convert(Array{T,N},B)
+convert{T,N}(::Type{Array{T}}, B::BitArray{N}) = convert(Array{T,N}, B)
 convert{T,N}(::Type{Array{T,N}}, B::BitArray{N}) = _convert(Array{T,N}, B) # see #15801
 function _convert{T,N}(::Type{Array{T,N}}, B::BitArray{N})
     A = Array(T, size(B))
@@ -302,7 +302,7 @@ function _convert{T,N}(::Type{Array{T,N}}, B::BitArray{N})
     return A
 end
 
-convert{T,N}(::Type{BitArray}, A::AbstractArray{T,N}) = convert(BitArray{N},A)
+convert{T,N}(::Type{BitArray}, A::AbstractArray{T,N}) = convert(BitArray{N}, A)
 function convert{T,N}(::Type{BitArray{N}}, A::AbstractArray{T,N})
     B = BitArray(size(A))
     Bc = B.chunks
@@ -405,7 +405,7 @@ function _unsafe_setindex!(B::BitArray, X::AbstractArray, I::BitArray)
     length(Bc) == length(Ic) || throw_boundserror(B, I)
     lc = length(Bc)
     lx = length(X)
-    last_chunk_len = Base._mod64(length(B)-1)+1
+    last_chunk_len = _mod64(length(B)-1)+1
 
     c = 1
     for i = 1:lc
@@ -1557,7 +1557,7 @@ end
 transpose(B::BitVector) = reshape(copy(B), 1, length(B))
 
 # fast 8x8 bit transpose from Henry S. Warrens's "Hacker's Delight"
-# http://www.hackersdelight.org/HDcode/transpose8.c.txt
+# http://www.hackersdelight.org/hdcodetxt/transpose8.c.txt
 function transpose8x8(x::UInt64)
     y = x
     t = (y $ (y >>> 7)) & 0x00aa00aa00aa00aa

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -103,39 +103,8 @@ end
 const bitcache_chunks = 64 # this can be changed
 const bitcache_size = 64 * bitcache_chunks # do not change this
 
-function bpack(z::UInt64)
-    z |= z >>> 7
-    z |= z >>> 14
-    z |= z >>> 28
-    z &= 0xFF
-    return z
-end
-
-function dumpbitcache(Bc::Vector{UInt64}, bind::Int, C::Vector{Bool})
-    ind = 1
-    nc = min(bitcache_chunks, length(Bc)-bind+1)
-    C8 = reinterpret(UInt64, C)
-    nc8 = (nc >>> 3) << 3
-    @inbounds for i = 1:nc8
-        c = UInt64(0)
-        for j = 0:8:63
-            c |= (bpack(C8[ind]) << j)
-            ind += 1
-        end
-        Bc[bind] = c
-        bind += 1
-    end
-    ind = (ind-1) << 3 + 1
-    @inbounds for i = (nc8+1):nc
-        c = UInt64(0)
-        for j = 0:63
-            c |= (UInt64(C[ind]) << j)
-            ind += 1
-        end
-        Bc[bind] = c
-        bind += 1
-    end
-end
+dumpbitcache(Bc::Vector{UInt64}, bind::Int, C::Vector{Bool}) =
+    Base.copy_to_bitarray_chunks!(Bc, ((bind - 1) << 6) + 1, C, 1, min(bitcache_size, (length(Bc)-bind+1) << 6))
 
 # using cartesian indexing
 function gen_broadcast_body_cartesian_tobitarray(nd::Int, narrays::Int, f)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -223,9 +223,9 @@ function gen_broadcast_function_tobitarray(genbody::Function, nd::Int, narrays::
 end
 
 for (Bsig, Asig, gbf, gbb) in
-    ((BitArray                          , Union{Array,BitArray,Number}                   ,
+    ((BitArray                          , Union{Array,BitArray,Number}            ,
       :gen_broadcast_function_tobitarray, :gen_broadcast_body_iter_tobitarray     ),
-     (Any                               , Union{Array,BitArray,Number}                   ,
+     (Any                               , Union{Array,BitArray,Number}            ,
       :gen_broadcast_function           , :gen_broadcast_body_iter                ),
      (BitArray                          , Any                                     ,
       :gen_broadcast_function_tobitarray, :gen_broadcast_body_cartesian_tobitarray),

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -627,12 +627,13 @@ end
     return B
 end
 
-@inline function setindex!(B::BitArray, x::Bool, I0::UnitRange{Int})
+@inline function setindex!(B::BitArray, x, I0::UnitRange{Int})
     @boundscheck checkbounds(B, I0)
+    y = Bool(x)
     l0 = length(I0)
     l0 == 0 && return B
     f0 = first(I0)
-    fill_chunks!(B.chunks, x, f0, l0)
+    fill_chunks!(B.chunks, y, f0, l0)
     return B
 end
 
@@ -672,13 +673,14 @@ end
     end
 end
 
-@inline function setindex!(B::BitArray, x::Bool, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@inline function setindex!(B::BitArray, x, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
     @boundscheck checkbounds(B, I0, I...)
     _unsafe_setindex!(B, x, I0, I...)
 end
-@generated function _unsafe_setindex!(B::BitArray, x::Bool, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@generated function _unsafe_setindex!(B::BitArray, x, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
     N = length(I)
     quote
+        y = Bool(x)
         f0 = first(I0)
         l0 = length(I0)
         l0 == 0 && return B
@@ -698,7 +700,7 @@ end
         @nloops($N, i, d->I[d],
                 d->nothing, # PRE
                 d->(ind += stride_lst_d - gap_lst_d), # POST
-                fill_chunks!(B.chunks, x, ind, l0) # BODY
+                fill_chunks!(B.chunks, y, ind, l0) # BODY
                 )
 
         return B

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -617,9 +617,9 @@ end
 # contiguous multidimensional indexing: if the first dimension is a range,
 # we can get some performance from using copy_chunks!
 
-@inline function setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int})
+@inline function setindex!(B::BitArray, X::BitArray, I0::Union{Colon,UnitRange{Int}})
     @boundscheck checkbounds(B, I0)
-    l0 = length(I0)
+    l0 = index_lengths(B, I0)[1]
     setindex_shape_check(X, l0)
     l0 == 0 && return B
     f0 = first(I0)
@@ -627,22 +627,23 @@ end
     return B
 end
 
-@inline function setindex!(B::BitArray, x, I0::UnitRange{Int})
+@inline function setindex!(B::BitArray, x, I0::Union{Colon,UnitRange{Int}})
     @boundscheck checkbounds(B, I0)
     y = Bool(x)
-    l0 = length(I0)
+    l0 = index_lengths(B, I0)[1]
     l0 == 0 && return B
     f0 = first(I0)
     fill_chunks!(B.chunks, y, f0, l0)
     return B
 end
 
-@inline function setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@inline function setindex!(B::BitArray, X::BitArray, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     @boundscheck checkbounds(B, I0, I...)
     _unsafe_setindex!(B, X, I0, I...)
 end
-@generated function _unsafe_setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@generated function _unsafe_setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int}, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     N = length(I)
+    rangeexp = [I[d] == Colon ? :(1:size(B, $(d+1))) : :(I[$d]) for d = 1:N]
     quote
         idxlens = @ncall $N index_lengths B I0 d->I[d]
         @ncall $N setindex_shape_check X idxlens[1] d->idxlens[d+1]
@@ -662,11 +663,12 @@ end
         end
 
         refind = 1
-        @nloops($N, i, d->I[d],
+        Bc = B.chunks
+        @nloops($N, i, d->$rangeexp[d],
                 d->nothing, # PRE
                 d->(ind += stride_lst_d - gap_lst_d), # POST
                 begin # BODY
-                    copy_chunks!(B.chunks, ind, X.chunks, refind, l0)
+                    copy_chunks!(Bc, ind, X.chunks, refind, l0)
                     refind += l0
                 end)
 
@@ -674,21 +676,24 @@ end
     end
 end
 
-@inline function setindex!(B::BitArray, x, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@inline function setindex!(B::BitArray, x, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     @boundscheck checkbounds(B, I0, I...)
     _unsafe_setindex!(B, x, I0, I...)
 end
-@generated function _unsafe_setindex!(B::BitArray, x, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
+@generated function _unsafe_setindex!(B::BitArray, x, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     N = length(I)
+    rangeexp = [I[d] == Colon ? :(1:size(B, $(d+1))) : :(I[$d]) for d = 1:N]
     quote
         y = Bool(x)
+        idxlens = @ncall $N index_lengths B I0 d->I[d]
+
         f0 = first(I0)
-        l0 = length(I0)
+        l0 = idxlens[1]
         l0 == 0 && return B
         @nexprs $N d->(isempty(I[d]) && return B)
 
         gap_lst_1 = 0
-        @nexprs $N d->(gap_lst_{d+1} = length(I[d]))
+        @nexprs $N d->(gap_lst_{d+1} = idxlens[d+1])
         stride = 1
         ind = f0
         @nexprs $N d->begin
@@ -698,7 +703,7 @@ end
             gap_lst_{d+1} *= stride
         end
 
-        @nloops($N, i, d->I[d],
+        @nloops($N, i, d->$rangeexp[d],
                 d->nothing, # PRE
                 d->(ind += stride_lst_d - gap_lst_d), # POST
                 fill_chunks!(B.chunks, y, ind, l0) # BODY

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -259,7 +259,7 @@ end
     dest
 end
 
-# Always index with the exactly indices provided.
+# Always index with exactly the indices provided.
 @generated function _unsafe_getindex!(dest::AbstractArray, src::AbstractArray, I::Union{Real, AbstractVector, Colon}...)
     N = length(I)
     quote
@@ -551,7 +551,7 @@ end
 
 # contiguous multidimensional indexing: if the first dimension is a range,
 # we can get some performance from using copy_chunks!
-@inline function _unsafe_getindex!(X::BitArray, B::BitArray, I0::Union{UnitRange{Int}, Colon})
+@inline function _unsafe_getindex!(X::BitArray, B::BitArray, I0::Union{UnitRange{Int},Colon})
     copy_chunks!(X.chunks, 1, B.chunks, first(I0), index_lengths(B, I0)[1])
     return X
 end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -81,7 +81,31 @@ for (sz,T) in allsizes
     @check_bit_operation size(b1)   Tuple{Vararg{Int}}
 
     b2 = similar(b1)
+    u1 = bitunpack(b1)
     @check_bit_operation copy!(b2, b1) T
+    @check_bit_operation copy!(b2, u1) T
+end
+
+for n in [1; 1023:1025]
+    b1 = falses(n)
+    for m in [1; 10; 1023:1025]
+        u1 = ones(Bool, m)
+        for fu! in [u->fill!(u, true), u->rand!(u)]
+            fu!(u1)
+            c1 = convert(Vector{Int}, u1)
+            for i1 in [1; 10; 53:65; 1013:1015; 1020:1025], i2 in [1; 3; 10; 511:513], l in [1; 5; 10; 511:513; 1023:1025]
+                for fb! in [b->fill!(b, false), b->rand!(b)]
+                    fb!(b1)
+                    if i1 < 1 || i1 > n || (i2 + l - 1 > m) || (i1 + l - 1 > n)
+                        @test_throws BoundsError copy!(b1, i1, u1, i2, l)
+                    else
+                        @check_bit_operation copy!(b1, i1, u1, i2, l) BitArray
+                        @check_bit_operation copy!(b1, i1, c1, i2, l) BitArray
+                    end
+                end
+            end
+        end
+    end
 end
 
 @test_throws ArgumentError size(trues(5),0)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -7,12 +7,16 @@ tc{N}(r1::BitArray{N}, r2::Union{BitArray{N},Array{Bool,N}}) = true
 tc{T}(r1::T, r2::T) = true
 tc(r1,r2) = false
 
+bitcheck(b::BitArray) = length(b.chunks) == 0 || (b.chunks[end] == b.chunks[end] & Base._msk_end(b))
+bitcheck(x) = true
+
 function check_bitop(ret_type, func, args...)
     r1 = func(args...)
     r2 = func(map(x->(isa(x, BitArray) ? bitunpack(x) : x), args)...)
     @test isa(r1, ret_type)
     @test tc(r1, r2)
     @test isequal(r1, convert(ret_type, r2))
+    @test bitcheck(r1)
 end
 
 macro check_bit_operation(ex, ret_type)
@@ -38,7 +42,7 @@ v1 = 260
 # matrices size
 n1, n2 = 17, 20
 # arrays size
-s1, s2, s3, s4 = 5, 8, 3, 4
+s1, s2, s3, s4 = 5, 8, 3, 7
 
 allsizes = [((), BitArray{0}), ((v1,), BitVector),
             ((n1,n2), BitMatrix), ((s1,s2,s3,s4), BitArray{4})]


### PR DESCRIPTION
This patch accelerates the following operations:
- broadcasting operations which return BitArrays (e.g. `.==`)
- packing operations of Arrays into BitArrays (with a specialized case for `Array{Bool}`):
  - extends the signature of `copy!` to `copy!(dest::BitArray, doffs::Integer, src::Array, soffs::Integer, n::Integer)` and to `copy!(dest::BitArray, src::Array)`
  - uses the new `copy!` in `convert` operations
  - factors out an `unsafe_copy!` version like for Arrays
- indexing of BitArrays with contiguous first indexing expression:
  - adds `Colon` in the signatures such that `b[:]` is as fast as `b[1:end]`
  - removes `Bool` from scalar signatures such that `b[:] = 1` is as fast as `b[:] = true`
  - also implements some TODO's which were left in the multidimensional.jl code

Also adds tests and a small comment to explain the logic of the faster packing trick.

For reference, the faster broadcasting is all due to avoiding a loop of the form `0:8:63` which required a relatively expensive modulus operation. To my surprise, that represented a large portion of the time spent when packing.

Some code may be generalizable to AbstractArrays but the `copy!(src, soffs, dest, doffs, n)` signature inherently uses linear indexing, so it's not totally straightforward.
