### PR TITLE
Allow global/local function f(), fix #15844

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1215,7 +1215,7 @@
               ,.(map (lambda (x) `(,what ,x)) vars)
               ,.(reverse assigns)))
         (let ((x (car b)))
-          (cond ((assignment-like? x)
+          (cond ((or (assignment-like? x) (function-def? x))
                  (loop (cdr b)
                        (cons (assigned-name (cadr x)) vars)
                        (cons `(,(car x) ,(decl-var (cadr x)) ,(caddr x))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -412,3 +412,26 @@ test_parseerror("if false\nelseif\nend", "missing condition in \"elseif\" at non
 
 # issue #15830
 @test expand(parse("foo(y = (global x)) = y")) == Expr(:error, "misplaced \"global\" declaration")
+
+# issue #15844
+function glob_fn(x)
+    x
+end
+
+function add_method_to_glob_fn!()
+    global function glob_fn(x::Int)
+        -x
+    end
+end
+
+function add_method_to_local_fn!()
+    local function glob_fn(x::Int)
+        -x
+    end
+end
+
+@test glob_fn(1) == 1
+@test add_method_to_local_fn!() ≠ glob_fn
+@test glob_fn(1) == 1
+@test add_method_to_glob_fn!() == glob_fn
+@test glob_fn(1) == -1


### PR DESCRIPTION
Allows function definitions following `local` and `global` keywords. Resolves #15844.
