### PR TITLE
documents using keyword arguments with remotecall

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -8668,6 +8668,7 @@ readavailable
     remotecall(func, id, args...)
 
 Call a function asynchronously on the given arguments on the specified process. Returns a `Future`.
+If using keyword arguments for `func`, `remotecall` can be called with `remotecall(()->func(args...; kw...), id)`.
 """
 remotecall
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -287,7 +287,8 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   Call a function asynchronously on the given arguments on the specified process. Returns a ``Future``\ .
+   Call a function asynchronously on the given arguments on the specified process. Returns a ``Future``\ . If using keyword arguments for `func`\ , ``remotecall`` can be called with
+   ``remotecall(()->func(args...;kw...), id)``.
 
 .. function:: Future()
 


### PR DESCRIPTION
In response to issue  #3200, I thought adding to the documentation for using keyword arguments with `remotecall` would he helpful to other users.
