### PR TITLE
Workaround clang bug on OSX when the tls variable is too large

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -52,7 +52,8 @@ typedef struct _jl_tls_states_t {
     jl_jmp_buf *safe_restore;
     int16_t tid;
     size_t bt_size;
-    uintptr_t bt_data[JL_MAX_BT_SIZE + 1];
+    // JL_MAX_BT_SIZE + 1 elements long
+    uintptr_t *bt_data;
 } jl_tls_states_t;
 
 #ifdef __MIC__

--- a/src/threading.c
+++ b/src/threading.c
@@ -105,6 +105,13 @@ static void ti_initthread(int16_t tid)
     ptls->pgcstack = NULL;
     ptls->gc_state = 0; // GC unsafe
     ptls->current_module = NULL;
+    void *bt_data = malloc(sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
+    if (bt_data == NULL) {
+        jl_printf(JL_STDERR, "could not allocate backtrace buffer\n");
+        gc_debug_critical_error();
+        abort();
+    }
+    ptls->bt_data = (uintptr_t*)bt_data;
 #ifdef JULIA_ENABLE_THREADING
     jl_all_heaps[tid] = jl_mk_thread_heap();
 #else


### PR DESCRIPTION
By allocating the buffer at runtime with `mmap`.

Fixes #15647 
