### PR TITLE
Add type parameter to Core.cconvert

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -295,7 +295,7 @@ Task(f::ANY) = ccall(:jl_new_task, Ref{Task}, (Any, Int), f, 0)
 # so the methods and ccall's in Core aren't permitted to use convert
 convert(::Type{Any}, x::ANY) = x
 convert{T}(::Type{T}, x::T) = x
-cconvert(T::Type, x) = convert(T, x)
+cconvert{T}(::Type{T}, x) = convert(T, x)
 unsafe_convert{T}(::Type{T}, x::T) = x
 
 # primitive array constructors


### PR DESCRIPTION
In order to help type inference when calling array constructor.

Implement https://github.com/JuliaLang/julia/issues/15044#issuecomment-189756472.

Fixes #15044, which is a ~2x regression when constructing small arrays.
