### PR TITLE
replace nan_dom_err intrinsic with an inline function

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -230,7 +230,6 @@ add_tfunc(lt_float, 2, 2, cmp_tfunc)
 add_tfunc(le_float, 2, 2, cmp_tfunc)
 add_tfunc(fpiseq, 2, 2, cmp_tfunc)
 add_tfunc(fpislt, 2, 2, cmp_tfunc)
-add_tfunc(nan_dom_err, 2, 2, (a, b)->a)
 add_tfunc(Core.Intrinsics.ccall, 3, IInf,
     function(fptr, rt, at, a...)
         if !isType(rt)

--- a/base/math.jl
+++ b/base/math.jl
@@ -30,7 +30,7 @@ import Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              significand_mask, significand_bits, exponent_bits, exponent_bias
 
 
-import Core.Intrinsics: nan_dom_err, sqrt_llvm, box, unbox, powi_llvm
+import Core.Intrinsics: sqrt_llvm, box, unbox, powi_llvm
 
 # non-type specific math functions
 
@@ -129,6 +129,9 @@ exp10(x::Float64) = 10.0^x
 exp10(x::Float32) = 10.0f0^x
 exp10(x::Integer) = exp10(float(x))
 @vectorize_1arg Number exp10
+
+# utility for converting NaN return to DomainError
+@inline nan_dom_err(f, x) = isnan(f) & !isnan(x) ? throw(DomainError()) : f
 
 # functions that return NaN on non-NaN argument for domain error
 for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1365,15 +1365,6 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, 
 #endif
     }
 
-    case nan_dom_err: {
-        // nan_dom_err(f, x) throw DomainError if isnan(f)&&!isnan(x)
-        Value *f = FP(x); x = FP(y);
-        raise_exception_unless(builder.CreateOr(builder.CreateFCmpORD(f,f),
-                                                builder.CreateFCmpUNO(x,x)),
-                               prepare_global(jldomerr_var), ctx);
-        return f;
-    }
-
     case abs_float:
     {
         x = FP(x);

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -84,7 +84,6 @@
     ADD_I(checked_udiv_int, 2) \
     ADD_I(checked_srem_int, 2) \
     ADD_I(checked_urem_int, 2) \
-    ADD_I(nan_dom_err, 2) \
     /*  functions */ \
     ADD_I(abs_float, 1) \
     ADD_I(copysign_float, 2) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -436,7 +436,6 @@ JL_DLLEXPORT jl_value_t *jl_checked_udiv_int(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_checked_srem_int(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_checked_urem_int(jl_value_t *a, jl_value_t *b);
 
-JL_DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_ceil_llvm(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_floor_llvm(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_trunc_llvm(jl_value_t *a);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -866,28 +866,6 @@ checked_iintrinsic_slow(LLVMDiv_uov, checked_udiv_int, u)
 checked_iintrinsic_slow(LLVMRem_sov, checked_srem_int,  )
 checked_iintrinsic_slow(LLVMRem_uov, checked_urem_int, u)
 
-JL_DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b)
-{
-    jl_value_t *ty = jl_typeof(a);
-    if (jl_typeof(b) != ty)
-        jl_error("nan_dom_err: types of a and b must match");
-    if (!jl_is_bitstype(ty))
-        jl_error("nan_dom_err: values are not bitstypes");
-    switch (jl_datatype_size(ty)) {
-        case 4:
-            if (isnan(*(float*)a) && !isnan(*(float*)b))
-                jl_throw(jl_domain_exception);
-            break;
-        case 8:
-            if (isnan(*(double*)a) && !isnan(*(double*)b))
-                jl_throw(jl_domain_exception);
-            break;
-        default:
-            jl_error("nan_dom_err: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
-    }
-    return a;
-}
-
 // functions
 #define flipsign(a, b) \
         (b >= 0) ? a : -a


### PR DESCRIPTION
IIRC, this only existed because it predated `@inline`. The new version generates the same code as the intrinsic did.
