### PR TITLE
Add tracing for linfo compilation

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -375,6 +375,7 @@ JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(jl_svec_t *sparam_syms)
     li->sparam_vals = jl_emptysvec;
     li->fptr = NULL;
     li->jlcall_api = 0;
+    li->compile_traced = 0;
     li->functionObjectsDecls.functionObject = NULL;
     li->functionObjectsDecls.specFunctionObject = NULL;
     li->functionObjectsDecls.cFunctionList = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1476,6 +1476,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         cfunc_llvm = read_int32(s);
         jl_delayed_fptrs(li, func_llvm, cfunc_llvm);
         li->jlcall_api = func_llvm ? read_int8(s) : 0;
+        li->compile_traced = 0;
         return (jl_value_t*)li;
     }
     else if (vtag == (jl_value_t*)jl_module_type) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -287,7 +287,7 @@ static jl_tupletype_t *join_tsig(jl_tupletype_t *tt, jl_tupletype_t *sig)
 static jl_value_t *ml_matches(union jl_typemap_t ml, int offs,
                               jl_tupletype_t *type, int lim);
 
-extern void (*jl_linfo_tracer)(jl_lambda_info_t *tracee);
+extern void (*jl_method_tracer)(jl_lambda_info_t *tracee);
 
 static jl_lambda_info_t *cache_method(jl_methtable_t *mt, union jl_typemap_t *cache, jl_value_t *parent,
                                       jl_tupletype_t *type, jl_tupletype_t *origtype,
@@ -588,8 +588,8 @@ static jl_lambda_info_t *cache_method(jl_methtable_t *mt, union jl_typemap_t *ca
     }
     JL_GC_POP();
     JL_UNLOCK(&codegen_lock);
-    if (definition->traced && jl_linfo_tracer)
-        jl_linfo_tracer(newmeth);
+    if (definition->traced && jl_method_tracer)
+        jl_method_tracer(newmeth);
     return newmeth;
 }
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -320,10 +320,22 @@ JL_DLLEXPORT void jl_untrace_method(jl_method_t *m)
     m->traced = 0;
 }
 
-void (*jl_linfo_tracer)(jl_lambda_info_t *tracee) = 0;
-JL_DLLEXPORT void jl_register_tracer(void (*callback)(jl_lambda_info_t *tracee))
+JL_DLLEXPORT void jl_trace_linfo(jl_lambda_info_t *linfo)
 {
-    jl_linfo_tracer = callback;
+    assert(jl_is_lambda_info(linfo));
+    linfo->compile_traced = 1;
+}
+
+JL_DLLEXPORT void jl_untrace_linfo(jl_lambda_info_t *linfo)
+{
+    assert(jl_is_lambda_info(linfo));
+    linfo->compile_traced = 0;
+}
+
+void (*jl_method_tracer)(jl_lambda_info_t *tracee) = 0;
+JL_DLLEXPORT void jl_register_method_tracer(void (*callback)(jl_lambda_info_t *tracee))
+{
+    jl_method_tracer = callback;
 }
 
 void (*jl_newmeth_tracer)(jl_method_t *tracee) = 0;
@@ -331,6 +343,13 @@ JL_DLLEXPORT void jl_register_newmeth_tracer(void (*callback)(jl_method_t *trace
 {
     jl_newmeth_tracer = callback;
 }
+
+void (*jl_linfo_tracer)(jl_lambda_info_t *tracee) = 0;
+JL_DLLEXPORT void jl_register_linfo_tracer(void (*callback)(jl_lambda_info_t *tracee))
+{
+    jl_linfo_tracer = callback;
+}
+
 
 
 // Create function versions of some useful macros

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3522,7 +3522,7 @@ void jl_init_types(void)
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaInfo"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(24,
+                        jl_svec(25,
                                 jl_symbol("code"),
                                 jl_symbol("slotnames"),
                                 jl_symbol("slottypes"),
@@ -3541,10 +3541,11 @@ void jl_init_types(void)
                                 jl_symbol("inInference"),
                                 jl_symbol("inCompile"),
                                 jl_symbol("jlcall_api"),
+                                jl_symbol(""),
                                 jl_symbol("fptr"),
                                 jl_symbol(""), jl_symbol(""), jl_symbol(""),
                                 jl_symbol(""), jl_symbol("")),
-                        jl_svec(24,
+                        jl_svec(25,
                                 jl_any_type,
                                 jl_array_any_type,
                                 jl_any_type,
@@ -3557,6 +3558,7 @@ void jl_init_types(void)
                                 jl_any_type,
                                 jl_method_type,
                                 jl_int32_type,
+                                jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type,
@@ -3617,10 +3619,10 @@ void jl_init_types(void)
     jl_svecset(jl_simplevector_type->types, 0, jl_long_type);
     jl_svecset(jl_typename_type->types, 6, jl_long_type);
     jl_svecset(jl_methtable_type->types, 3, jl_long_type);
-    jl_svecset(jl_lambda_info_type->types, 18, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 19, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 20, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 21, jl_voidpointer_type);
+    jl_svecset(jl_lambda_info_type->types, 22, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -243,6 +243,7 @@ typedef struct _jl_lambda_info_t {
     int8_t inInference; // flags to tell if inference is running on this function
     int8_t inCompile; // flag to tell if codegen is running on this function
     int8_t jlcall_api; // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t
+    int8_t compile_traced; // if set will notify callback if this linfo is compiled
     jl_fptr_t fptr; // jlcall entry point
 
 // hidden fields:
@@ -1300,7 +1301,10 @@ JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m);
 // tracing
 JL_DLLEXPORT void jl_trace_method(jl_method_t *m);
 JL_DLLEXPORT void jl_untrace_method(jl_method_t *m);
-JL_DLLEXPORT void jl_register_tracer(void (*callback)(jl_lambda_info_t *tracee));
+JL_DLLEXPORT void jl_trace_linfo(jl_lambda_info_t *linfo);
+JL_DLLEXPORT void jl_untrace_linfo(jl_lambda_info_t *linfo);
+JL_DLLEXPORT void jl_register_linfo_tracer(void (*callback)(jl_lambda_info_t *tracee));
+JL_DLLEXPORT void jl_register_method_tracer(void (*callback)(jl_lambda_info_t *tracee));
 JL_DLLEXPORT void jl_register_newmeth_tracer(void (*callback)(jl_method_t *tracee));
 
 // AST access

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -383,7 +383,7 @@ test_typed_ast_printing(g15714, Tuple{Vector{Float32}},
 tracefoo(x, y) = x+y
 didtrace = false
 tracer(x::Ptr{Void}) = (@test isa(unsafe_pointer_to_objref(x), LambdaInfo); global didtrace = true; nothing)
-ccall(:jl_register_tracer, Void, (Ptr{Void},), cfunction(tracer, Void, (Ptr{Void},)))
+ccall(:jl_register_method_tracer, Void, (Ptr{Void},), cfunction(tracer, Void, (Ptr{Void},)))
 meth = which(tracefoo,Tuple{Any,Any}).func
 ccall(:jl_trace_method, Void, (Any,), meth)
 @test tracefoo(1, 2) == 3
@@ -392,7 +392,7 @@ ccall(:jl_untrace_method, Void, (Any,), meth)
 didtrace = false
 @test tracefoo(1.0, 2.0) == 3.0
 @test !didtrace
-ccall(:jl_register_tracer, Void, (Ptr{Void},), C_NULL)
+ccall(:jl_register_method_tracer, Void, (Ptr{Void},), C_NULL)
 
 # Method Tracing test
 methtracer(x::Ptr{Void}) = (@test isa(unsafe_pointer_to_objref(x), Method); global didtrace = true; nothing)


### PR DESCRIPTION
In #15890, @vtjnash was concerned that requesting the linfo's llvm function when the specialization is created can assert on some code paths. This adds an extra tracing callback that fires just after an linfo is compiled. 
