### PR TITLE
Specify the tls model of the static tls variable

### DIFF
--- a/ui/repl.c
+++ b/ui/repl.c
@@ -38,7 +38,7 @@ extern "C" {
 static JL_CONST_FUNC jl_tls_states_t *jl_get_ptls_states_static(void)
 {
 #  if !defined(_COMPILER_MICROSOFT_)
-    static __thread jl_tls_states_t tls_states;
+    static __attribute__((tls_model("local-exec"))) __thread jl_tls_states_t tls_states;
 #  else
     static __declspec(thread) jl_tls_states_t tls_states;
 #  endif


### PR DESCRIPTION
Instead of letting the linker patch it. (And as I've learned from @Keno recently, the linker can actually patch a GD model to a LE/IE one, by effectively, IIUC, inlining a function call...)

This saves a few instructions for stack manipulation (see asm below), not that it has noticable performance impact...

Before,

``` asm
Dump of assembler code for function jl_get_ptls_states_static:
   0x0000000000401940 <+0>:     push   %rbp
   0x0000000000401941 <+1>:     mov    %rsp,%rbp
   0x0000000000401944 <+4>:     data16 data16 data16 mov %fs:0x0,%rax
   0x0000000000401950 <+16>:    pop    %rbp
   0x0000000000401951 <+17>:    add    $0xfffffffffffffeb8,%rax
   0x0000000000401957 <+23>:    retq   
End of assembler dump.
```

After

``` asm
Dump of assembler code for function jl_get_ptls_states_static:
   0x00000000004018b0 <+0>:     mov    %fs:0x0,%rax
   0x00000000004018b9 <+9>:     add    $0xfffffffffffffeb8,%rax
   0x00000000004018bf <+15>:    retq   
End of assembler dump.
```

Threading CI passed [Travis](https://travis-ci.org/JuliaLang/julia/builds/123697174), [AppVeyor](https://ci.appveyor.com/project/JuliaLang/julia/build/1.0.586)
