### PR TITLE
Optimize and clean up lock

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -470,7 +470,8 @@ int jl_array_store_unboxed(jl_value_t *el_type);
 int jl_array_isdefined(jl_value_t **args, int nargs);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 
-JL_DEFINE_MUTEX_EXT(codegen)
+extern jl_mutex_t typecache_lock;
+extern jl_mutex_t codegen_lock;
 
 #if defined(__APPLE__) && defined(JULIA_ENABLE_THREADING)
 void jl_mach_gc_begin(void);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -132,7 +132,10 @@ static inline unsigned long JL_CONST_FUNC jl_thread_self(void)
 // Workaround a GCC bug when using store with release order by using the
 // stronger version instead.
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67458
-#    define jl_atomic_store_release(obj, val) jl_atomic_store(obj, val)
+#    define jl_atomic_store_release(obj, val) do {      \
+        jl_signal_fence();                              \
+        __atomic_store_n(obj, val, __ATOMIC_RELEASE);   \
+    } while (0)
 #  endif
 #  define jl_atomic_load(obj)                   \
     __atomic_load_n(obj, __ATOMIC_SEQ_CST)
@@ -259,7 +262,7 @@ JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void);
 extern JL_DLLEXPORT jl_tls_states_t jl_tls_states;
 #define jl_get_ptls_states() (&jl_tls_states)
 #define jl_gc_state() ((int8_t)0)
-#define jl_gc_safepoint()
+#define jl_gc_safepoint() do {} while (0)
 STATIC_INLINE int8_t jl_gc_state_set(int8_t state, int8_t old_state)
 {
     (void)state;
@@ -300,73 +303,85 @@ STATIC_INLINE int8_t jl_gc_state_save_and_set(int8_t state)
 #define jl_gc_safe_leave(state) ((void)jl_gc_state_set((state), JL_GC_STATE_SAFE))
 JL_DLLEXPORT void (jl_gc_safepoint)(void);
 
-// Locks
-#ifdef JULIA_ENABLE_THREADING
-#define JL_DEFINE_MUTEX(m)                                                \
-    uint64_t volatile m ## _mutex = 0;                                    \
-    int32_t m ## _lock_count = 0;                                         \
-    void jl_unlock_## m ## _func(void)                                    \
-    {                                                                     \
-        JL_UNLOCK_RAW(m);                                                 \
-    }
+// Recursive spin lock
+typedef struct {
+    volatile unsigned long owner;
+    uint32_t count;
+} jl_mutex_t;
 
-#define JL_DEFINE_MUTEX_EXT(m)                                            \
-    extern uint64_t volatile m ## _mutex;                                 \
-    extern int32_t m ## _lock_count;                                      \
-    void jl_unlock_## m ## _func(void);
+static inline void jl_lock_frame_push(jl_mutex_t *lock);
+static inline void jl_lock_frame_pop(void);
 
-#define JL_LOCK_WAIT(m, wait_ex) do {                                   \
-        if (m ## _mutex == jl_thread_self()) {                          \
-            ++m ## _lock_count;                                         \
-        }                                                               \
-        else {                                                          \
-            for (;;) {                                                  \
-                if (m ## _mutex == 0 &&                                 \
-                    jl_atomic_compare_exchange(&m ## _mutex, 0,         \
-                                               jl_thread_self()) == 0) { \
-                    m ## _lock_count = 1;                               \
-                    break;                                              \
-                }                                                       \
-                wait_ex;                                                \
-                jl_cpu_pause();                                         \
-            }                                                           \
-        }                                                               \
-    } while (0)
-
-#define JL_UNLOCK_RAW(m) do {                                           \
-        if (m ## _mutex == jl_thread_self()) {                          \
-            --m ## _lock_count;                                         \
-            if (m ## _lock_count == 0) {                                \
-                jl_atomic_compare_exchange(&m ## _mutex, jl_thread_self(), 0); \
-                jl_cpu_wake();                                          \
-            }                                                           \
-        }                                                               \
-        else {                                                          \
-            assert(0 && "Unlocking a lock in a different thread.");     \
-        }                                                               \
-    } while (0)
-
-// JL_LOCK is a GC safe point while JL_LOCK_NOGC is not
+// JL_LOCK and jl_mutex_lock are GC safe points while JL_LOCK_NOGC
+// and jl_mutex_lock_nogc are not.
 // Always use JL_LOCK unless no one holding the lock can trigger a GC or GC
 // safepoint. JL_LOCK_NOGC should only be needed for GC internal locks.
-#define JL_LOCK(m) do {                                 \
-        JL_LOCK_WAIT(m, jl_gc_safepoint());             \
-        jl_lock_frame_push(jl_unlock_## m ## _func);    \
-    } while (0)
-#define JL_UNLOCK(m) do {                       \
-        JL_UNLOCK_RAW(m);                       \
-        if (__likely(jl_current_task))          \
-            jl_current_task->locks.len--;       \
-    } while (0)
-#define JL_LOCK_NOGC(m) JL_LOCK_WAIT(m, )
-#define JL_UNLOCK_NOGC(m) JL_UNLOCK_RAW(m)
+// The JL_LOCK* and JL_UNLOCK* macros are no-op for non-threading build
+// while the jl_mutex_* functions are always locking and unlocking the locks.
+
+static inline void jl_mutex_wait(jl_mutex_t *lock, int safepoint)
+{
+    unsigned long self = jl_thread_self();
+    unsigned long owner = jl_atomic_load_acquire(&lock->owner);
+    if (owner == self) {
+        lock->count++;
+        return;
+    }
+    while (1) {
+        if (owner == 0 &&
+            jl_atomic_compare_exchange(&lock->owner, 0, self) == 0) {
+            lock->count = 1;
+            return;
+        }
+        if (safepoint)
+            jl_gc_safepoint();
+        jl_cpu_pause();
+        owner = lock->owner;
+    }
+}
+
+static inline void jl_mutex_lock_nogc(jl_mutex_t *lock)
+{
+    jl_mutex_wait(lock, 0);
+}
+
+static inline void jl_mutex_lock(jl_mutex_t *lock)
+{
+    jl_mutex_wait(lock, 1);
+    jl_lock_frame_push(lock);
+}
+
+static inline void jl_mutex_unlock_nogc(jl_mutex_t *lock)
+{
+    assert(lock->owner == jl_thread_self() &&
+           "Unlocking a lock in a different thread.");
+    if (--lock->count == 0) {
+        jl_atomic_store_release(&lock->owner, 0);
+        jl_cpu_wake();
+    }
+}
+
+static inline void jl_mutex_unlock(jl_mutex_t *lock)
+{
+    jl_mutex_unlock_nogc(lock);
+    jl_lock_frame_pop();
+}
+
+// Locks
+#ifdef JULIA_ENABLE_THREADING
+#define JL_LOCK(m) jl_mutex_lock(m)
+#define JL_UNLOCK(m) jl_mutex_unlock(m)
+#define JL_LOCK_NOGC(m) jl_mutex_lock_nogc(m)
+#define JL_UNLOCK_NOGC(m) jl_mutex_unlock_nogc(m)
 #else // JULIA_ENABLE_THREADING
-#define JL_DEFINE_MUTEX(m)
-#define JL_DEFINE_MUTEX_EXT(m)
-#define JL_LOCK(m) do {} while (0)
-#define JL_UNLOCK(m) do {} while (0)
-#define JL_LOCK_NOGC(m) do {} while (0)
-#define JL_UNLOCK_NOGC(m) do {} while (0)
+static inline void jl_mutex_check_type(jl_mutex_t *m)
+{
+    (void)m;
+}
+#define JL_LOCK(m) jl_mutex_check_type(m)
+#define JL_UNLOCK(m) jl_mutex_check_type(m)
+#define JL_LOCK_NOGC(m) jl_mutex_check_type(m)
+#define JL_UNLOCK_NOGC(m) jl_mutex_check_type(m)
 #endif // JULIA_ENABLE_THREADING
 
 #ifdef __cplusplus

--- a/src/threading.c
+++ b/src/threading.c
@@ -152,8 +152,8 @@ static jl_value_t *ti_run_fun(jl_svec_t *args)
 
 
 // lock for code generation
-JL_DEFINE_MUTEX(codegen)
-JL_DEFINE_MUTEX(typecache)
+jl_mutex_t codegen_lock;
+jl_mutex_t typecache_lock;
 
 #ifdef JULIA_ENABLE_THREADING
 


### PR DESCRIPTION
This PR has two related goals.
1. Minor clean up of the lock code and make it available on non-threading build.
   - Wrap the lock in a `jl_mutex_t` type.
     
     This also fix the last remaining non-C-like syntax introduced by the threading branch...
   - Make `jl_mutex_*` available on non-threading build too.
     
     This will be useful for synchronization with the signal thread. The `JL_{UN,}LOCK*` macros
     are still disabled for non-threading build although type checks are added to make sure they
     are used correctly. (Working towards a cheap solution of https://github.com/JuliaLang/julia/issues/2622)
     
     This add ~100 bytes of global variable to `libjulia.so` which is unlikely to cause any change in
     binary size.
     
     IIUC it is better if the locks doesn't share a cacheline so we can add padding or alignments to
     `jl_mutex_t` later.
2. Optimize lock performance
   - Avoid calling `uv_thread_self` multiple times.
   - Use a different workaround for GCC bug in `store_release` and use it in unlock.
     
     This saves a lot of cpu cycles compare to sequential consistent store or compare and exchange.

Timing of `LOCK_NOGC` `UNLOCK_NOGC` pair before,

``` jl
julia> @benchmark test2()
================ Benchmark Results ========================
     Time per evaluation: 24.80 ns [24.35 ns, 25.25 ns]
Proportion of time in GC: 0.00% [0.00%, 0.00%]
        Memory allocated: 0.00 bytes
   Number of allocations: 0 allocations
       Number of samples: 5701
   Number of evaluations: 458401
         R² of OLS model: 0.951
 Time spent benchmarking: 3.54 s
```

After,

``` jl
julia> @benchmark test2()
================ Benchmark Results ========================
     Time per evaluation: 12.07 ns [11.88 ns, 12.27 ns]
Proportion of time in GC: 0.00% [0.00%, 0.00%]
        Memory allocated: 0.00 bytes
   Number of allocations: 0 allocations
       Number of samples: 6101
   Number of evaluations: 670901
         R² of OLS model: 0.959
 Time spent benchmarking: 3.67 s
```
