### PR TITLE
merge specializations and tfunc

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -566,14 +566,13 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(void)
     jl_method_t *m =
         (jl_method_t*)newobj((jl_value_t*)jl_method_type,
                              NWORDS(sizeof(jl_method_t)));
-    m->tfunc.unknown = jl_nothing;
+    m->specializations.unknown = jl_nothing;
     m->sig = NULL;
     m->tvars = NULL;
     m->ambig = NULL;
     m->roots = NULL;
     m->module = jl_current_module;
     m->lambda_template = NULL;
-    m->specializations = NULL;
     m->name = NULL;
     m->file = null_sym;
     m->line = 0;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3592,7 +3592,7 @@ void jl_init_types(void)
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(16,
+                        jl_svec(15,
                                 jl_symbol("name"),
                                 jl_symbol("module"),
                                 jl_symbol("file"),
@@ -3601,7 +3601,6 @@ void jl_init_types(void)
                                 jl_symbol("tvars"),
                                 jl_symbol("ambig"),
                                 jl_symbol("specializations"),
-                                jl_symbol("tfunc"),
                                 jl_symbol("lambda_template"),
                                 jl_symbol("roots"),
                                 jl_symbol("invokes"),
@@ -3609,7 +3608,7 @@ void jl_init_types(void)
                                 jl_symbol("isstaged"),
                                 jl_symbol("needs_sparam_vals_ducttape"),
                                 jl_symbol("")),
-                        jl_svec(16,
+                        jl_svec(15,
                                 jl_sym_type,
                                 jl_module_type,
                                 jl_sym_type,
@@ -3617,7 +3616,6 @@ void jl_init_types(void)
                                 jl_type_type,
                                 jl_any_type,
                                 jl_any_type, // Union{Array, Void}
-                                jl_array_any_type,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_array_any_type,
@@ -3626,7 +3624,7 @@ void jl_init_types(void)
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type),
-                        0, 1, 9);
+                        0, 1, 8);
 
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaInfo"),
@@ -3681,7 +3679,7 @@ void jl_init_types(void)
                                 jl_int32_type, jl_int32_type),
                         0, 1, 10);
     jl_svecset(jl_lambda_info_type->types, 9, jl_lambda_info_type);
-    jl_svecset(jl_method_type->types, 9, jl_lambda_info_type);
+    jl_svecset(jl_method_type->types, 8, jl_lambda_info_type);
 
     jl_typector_type =
         jl_new_datatype(jl_symbol("TypeConstructor"),

--- a/src/julia.h
+++ b/src/julia.h
@@ -202,10 +202,8 @@ typedef struct _jl_method_t {
     // list of potentially-ambiguous methods (nothing = none, Vector{Any} of Methods otherwise)
     jl_value_t *ambig;
 
-    // array of all lambda infos with code generated from this one
-    jl_array_t *specializations;
-    // table of all argument types for which we've inferred this code
-    union jl_typemap_t tfunc;
+    // table of all argument types for which we've inferred or compiled this code
+    union jl_typemap_t specializations;
 
     // the AST template (or, for isstaged, code for the generator)
     struct _jl_lambda_info_t *lambda_template;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -563,7 +563,7 @@ static jl_typemap_entry_t *jl_typemap_assoc_by_type_(jl_typemap_entry_t *ml, jl_
             else {
                 // TODO: this is missing the actual subtype test,
                 // which works currently because types is typically a leaf tt,
-                // or inexact is set (which then does the subtype test)
+                // or inexact is set (which then does a sort of subtype test via jl_types_equal)
                 // but this isn't entirely general
                 jl_value_t *ti = jl_lookup_match((jl_value_t*)types, (jl_value_t*)ml->sig, penv, ml->tvars);
                 resetenv = 1;
@@ -642,24 +642,32 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
         // called object is the primary key for constructors, otherwise first argument
         jl_value_t *ty = NULL;
         size_t l = jl_datatype_nfields(types);
+        int isva = 0;
         // compute the type at offset `offs` into `types`, which may be a Vararg
         if (l <= offs + 1) {
             ty = jl_tparam(types, l - 1);
-            if (jl_is_vararg_type(ty))
+            if (jl_is_vararg_type(ty)) {
                 ty = jl_tparam0(ty);
-            else if (l <= offs)
+                isva = 1;
+            }
+            else if (l <= offs) {
                 ty = NULL;
+            }
         }
         else if (l > offs) {
             ty = jl_tparam(types, offs);
         }
         // If there is a type at offs, look in the optimized caches
-        if (ty) {
-            if (!subtype && jl_is_any(ty))
+        if (!subtype) {
+            if (ty && jl_is_any(ty))
                 return jl_typemap_assoc_by_type(cache->any, types, penv, subtype_inexact__sigseq_useenv, subtype, offs+1);
+            if (isva) // in lookup mode, want to match Vararg exactly, not as a subtype
+                ty = NULL;
+        }
+        if (ty) {
             if (cache->targ != (void*)jl_nothing && jl_is_type_type(ty)) {
                 jl_value_t *a0 = jl_tparam0(ty);
-                if (jl_is_datatype(a0)) {
+                if (cache->targ != (void*)jl_nothing && jl_is_datatype(a0)) {
                     union jl_typemap_t ml = mtcache_hash_lookup(cache->targ, a0, 1, offs);
                     if (ml.unknown != jl_nothing) {
                         jl_typemap_entry_t *li = jl_typemap_assoc_by_type(ml, types, penv,
@@ -667,6 +675,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
                         if (li) return li;
                     }
                 }
+                if (!subtype && is_cache_leaf(a0)) return NULL;
             }
             if (cache->arg1 != (void*)jl_nothing && jl_is_datatype(ty)) {
                 union jl_typemap_t ml = mtcache_hash_lookup(cache->arg1, ty, 0, offs);
@@ -676,6 +685,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
                     if (li) return li;
                 }
             }
+            if (!subtype && is_cache_leaf(ty)) return NULL;
         }
         // Always check the list (since offs doesn't always start at 0)
         if (subtype) {


### PR DESCRIPTION
~~1) by resetting all method table caches and inferring everything in specializations, we can avoid needing to perform a two-stage inference (& the associated complexity with allowing a module to be replaced during compilation)~~

this merges the LambdaInfo `tfunc` and `specializations` fields, to slightly reduce duplication. it now contains any lambda (or rettype) that was considered worth creating by either dispatch or inference, without prejudice

intermediate type inference results are fetched from the `active` queue to accommodate
