### PR TITLE
Support keyword arguments in all remotecall* functions

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2748,9 +2748,9 @@ mapping the SharedArray
 indexpids
 
 """
-    remotecall_wait(func, id, args...)
+    remotecall_wait(func, id, args...; kwargs...)
 
-Perform `wait(remotecall(...))` in one message.
+Perform `wait(remotecall(...))` in one message. Keyword arguments, if any, are passed through to `func`.
 """
 remotecall_wait
 
@@ -5396,10 +5396,10 @@ value is a range of indexes where the matching sequence is found, such that `s[s
 search
 
 """
-    remotecall_fetch(func, id, args...)
+    remotecall_fetch(func, id, args...; kwargs...)
 
-Perform `fetch(remotecall(...))` in one message. Any remote exceptions are captured in a
-`RemoteException` and thrown.
+Perform `fetch(remotecall(...))` in one message.  Keyword arguments, if any, are passed through to `func`.
+Any remote exceptions are captured in a `RemoteException` and thrown.
 """
 remotecall_fetch
 
@@ -8665,10 +8665,10 @@ result is a `Vector{UInt8,1}`.
 readavailable
 
 """
-    remotecall(func, id, args...)
+    remotecall(func, id, args...; kwargs...)
 
 Call a function asynchronously on the given arguments on the specified process. Returns a `Future`.
-If using keyword arguments for `func`, `remotecall` can be called with `remotecall(()->func(args...; kw...), id)`.
+Keyword arguments, if any, are passed through to `func`.
 """
 remotecall
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -285,11 +285,11 @@ General Parallel Computing Support
 
    Note that ``f`` must be made available to all worker processes; see :ref:`Code Availability and Loading Packages <man-parallel-computing-code-availability>` for details.
 
-.. function:: remotecall(func, id, args...)
+.. function:: remotecall(func, id, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
-   Call a function asynchronously on the given arguments on the specified process. Returns a ``Future``\ . If using keyword arguments for ``func``\ , ``remotecall`` can be called with ``remotecall(()->func(args...; kw...), id)``\ .
+   Call a function asynchronously on the given arguments on the specified process. Returns a ``Future``\ . Keyword arguments, if any, are passed through to ``func``\ .
 
 .. function:: Future()
 
@@ -351,23 +351,23 @@ General Parallel Computing Support
    * ``RemoteChannel``\ : Wait for and get the value of a remote reference. Exceptions raised are   same as for a ``Future`` .
    * ``Channel`` : Wait for and get the first available item from the channel.
 
-.. function:: remotecall_wait(func, id, args...)
+.. function:: remotecall_wait(func, id, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
-   Perform ``wait(remotecall(...))`` in one message.
+   Perform ``wait(remotecall(...))`` in one message. Keyword arguments, if any, are passed through to ``func``\ .
 
-.. function:: remotecall_fetch(func, id, args...)
-
-   .. Docstring generated from Julia source
-
-   Perform ``fetch(remotecall(...))`` in one message. Any remote exceptions are captured in a ``RemoteException`` and thrown.
-
-.. function:: remotecall_fetch(f, pool::WorkerPool, args...)
+.. function:: remotecall_fetch(func, id, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
-   Call ``f(args...)`` on one of the workers in ``pool``\ .
+   Perform ``fetch(remotecall(...))`` in one message.  Keyword arguments, if any, are passed through to ``func``\ . Any remote exceptions are captured in a ``RemoteException`` and thrown.
+
+.. function:: remotecall_fetch(f, pool::WorkerPool, args...; kwargs...)
+
+   .. Docstring generated from Julia source
+
+   Call ``f(args...; kwargs...)`` on one of the workers in ``pool``\ . Waits for completion and returns the result.
 
 .. function:: remote([::WorkerPool], f) -> Function
 


### PR DESCRIPTION
This PR enables support for keyword arguments in all remote invocations via the `remotecall*` family of functions. It does this by passing through any keyword arguments specified to the remote invocation.

Closes #3200 
