### PR TITLE
eliminate stage0 inference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,15 +211,10 @@ CORE_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/tuple.jl)
 BASE_SRCS := $(shell find $(JULIAHOME)/base -name \*.jl)
 
-$(build_private_libdir)/inference0.ji: $(CORE_SRCS) | $(build_private_libdir)
+$(build_private_libdir)/inference.ji: $(CORE_SRCS) | $(build_private_libdir)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --output-ji $(call cygpath_w,$@) -f \
 		coreimg.jl)
-
-$(build_private_libdir)/inference.ji: $(build_private_libdir)/inference0.ji
-	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --output-ji $(call cygpath_w,$@) -f \
-		-J $(call cygpath_w,$<) coreimg.jl)
 
 RELBUILDROOT := $(shell $(JULIAHOME)/contrib/relative_path.sh "$(JULIAHOME)/base" "$(BUILDROOT)/base/")
 COMMA:=,

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1984,7 +1984,7 @@ function type_annotate!(linfo::LambdaInfo, states::Array{Any,1}, sv::ANY, rettyp
     for i = 1:nargs
         decls[i] = widenconst(states[1][i].typ)
     end
-    body = linfo.code
+    body = linfo.code::Array{Any,1}
     for i=1:length(body)
         st_i = states[i]
         if st_i !== ()

--- a/src/init.c
+++ b/src/init.c
@@ -777,13 +777,6 @@ static void julia_save(void)
     JL_GC_POP();
 }
 
-jl_function_t *jl_typeinf_func=NULL;
-
-JL_DLLEXPORT void jl_set_typeinf_func(jl_value_t *f)
-{
-    jl_typeinf_func = (jl_function_t*)f;
-}
-
 static jl_value_t *core(char *name)
 {
     return jl_get_global(jl_core_module, jl_symbol(name));

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -201,7 +201,7 @@ jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e);
 jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
                            jl_lambda_info_t *li, int sparams, int allow_alloc);
 int jl_is_toplevel_only_expr(jl_value_t *e);
-void jl_type_infer(jl_lambda_info_t *li);
+void jl_type_infer(jl_lambda_info_t *li, int force);
 void jl_lambda_info_set_ast(jl_lambda_info_t *li, jl_value_t *ast);
 
 jl_lambda_info_t *jl_get_unspecialized(jl_lambda_info_t *method);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -118,15 +118,12 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
             jl_errorf("invalid redefinition of constant %s",
                       jl_symbol_name(name));
         }
-        if (jl_generating_output() && jl_options.incremental) {
-            jl_errorf("cannot replace module %s during incremental compile",
+        if (jl_generating_output()) {
+            jl_errorf("cannot replace module %s during compilation",
                       jl_symbol_name(name));
         }
-        if (!jl_generating_output()) {
-            // suppress warning "replacing module Core.Inference" during bootstrapping
-            jl_printf(JL_STDERR, "WARNING: replacing module %s\n",
-                      jl_symbol_name(name));
-        }
+        jl_printf(JL_STDERR, "WARNING: replacing module %s\n",
+                  jl_symbol_name(name));
     }
     jl_module_t *newm = jl_new_module(name);
     newm->parent = parent_module;
@@ -544,7 +541,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
 
     thk->specTypes = (jl_tupletype_t*)jl_typeof(jl_emptytuple); // no gc_wb needed
     if (ewc) {
-        jl_type_infer(thk);
+        jl_type_infer(thk, 0);
         jl_value_t *dummy_f_arg=NULL;
         result = jl_call_method_internal(thk, &dummy_f_arg, 1);
     }


### PR DESCRIPTION
all it did was ensure that everything in specializations was inferred
and require a lot of complex infrastructure to make it acceptable to
replace a module during compilation

but instead we can just infer everything in specializations directly

(cherry-picked from #15918)
