### PR TITLE
Add compact printing for Nullable

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -22,11 +22,19 @@ convert{T}(::Type{Nullable{T}}, ::Void) = Nullable{T}()
 convert(   ::Type{Nullable   }, ::Void) = Nullable{Union{}}()
 
 function show{T}(io::IO, x::Nullable{T})
-    print(io, "Nullable{", T, "}(")
-    if !isnull(x)
-        show(io, x.value)
+    if limit_output(io)
+        if isnull(x)
+            print(io, "#NULL")
+        else
+            show(io, x.value)
+        end
+    else
+        print(io, "Nullable{", T, "}(")
+        if !isnull(x)
+            show(io, x.value)
+        end
+        print(io, ')')
     end
-    print(io, ')')
 end
 
 get(x::Nullable) = x.isnull ? throw(NullException()) : x.value

--- a/base/show.jl
+++ b/base/show.jl
@@ -1495,7 +1495,8 @@ end
 function array_eltype_show_how(X)
     e = eltype(X)
     leaf = isleaftype(e)
-    plain = e<:Number || e<:AbstractString
+    plain = e<:Number || e<:AbstractString ||
+            (e<:Nullable && (eltype(e)<:Number || eltype(e)<:AbstractString))
     if isa(e,DataType) && e === e.name.primary
         str = string(e.name)
     else

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -75,69 +75,50 @@ for T in types
     @test x.value === v
 end
 
-p1s = [
-    "Nullable{Bool}()",
-    "Nullable{Char}()",
-    "Nullable{Float16}()",
-    "Nullable{Float32}()",
-    "Nullable{Float64}()",
-    "Nullable{Int128}()",
-    "Nullable{Int16}()",
-    "Nullable{Int32}()",
-    "Nullable{Int64}()",
-    "Nullable{Int8}()",
-    "Nullable{UInt16}()",
-    "Nullable{UInt32}()",
-    "Nullable{UInt64}()",
-    "Nullable{UInt8}()",
-]
-
-p2s = [
-    "Nullable{Bool}(false)",
-    "Nullable{Char}('\0')",
-    "Nullable{Float16}(Float16(0.0))",
-    "Nullable{Float32}(0.0f0)",
-    "Nullable{Float64}(0.0)",
-    "Nullable{Int128}(0)",
-    "Nullable{Int16}(0)",
-    "Nullable{Int32}(0)",
-    "Nullable{Int64}(0)",
-    "Nullable{Int8}(0)",
-    "Nullable{UInt16}(0x0000)",
-    "Nullable{UInt32}(0x00000000)",
-    "Nullable{UInt64}(0x0000000000000000)",
-    "Nullable{UInt8}(0x00)",
-]
-
-p3s = [
-    "Nullable{Bool}(true)",
-    "Nullable{Char}('\x01')",
-    "Nullable{Float16}(Float16(1.0))",
-    "Nullable{Float32}(1.0f0)",
-    "Nullable{Float64}(1.0)",
-    "Nullable{Int128}(1)",
-    "Nullable{Int16}(1)",
-    "Nullable{Int32}(1)",
-    "Nullable{Int64}(1)",
-    "Nullable{Int8}(1)",
-    "Nullable{UInt16}(0x0001)",
-    "Nullable{UInt32}(0x00000001)",
-    "Nullable{UInt64}(0x0000000000000001)",
-    "Nullable{UInt8}(0x01)",
-]
-
 # show{T}(io::IO, x::Nullable{T})
-io = IOBuffer()
+io1 = IOBuffer()
+io2 = IOBuffer()
 for (i, T) in enumerate(types)
     x1 = Nullable{T}()
     x2 = Nullable(zero(T))
     x3 = Nullable(one(T))
-    show(io, x1)
-    takebuf_string(io) == p1s[i]
-    show(io, x2)
-    takebuf_string(io) == p2s[i]
-    show(io, x3)
-    takebuf_string(io) == p3s[i]
+    show(io1, x1)
+    @test takebuf_string(io1) == @sprintf("Nullable{%s}()", T)
+    show(io1, x2)
+    show(io2, get(x2))
+    @test takebuf_string(io1) == @sprintf("Nullable{%s}(%s)", T, takebuf_string(io2))
+    show(io1, x3)
+    show(io2, get(x3))
+    @test takebuf_string(io1) == @sprintf("Nullable{%s}(%s)", T, takebuf_string(io2))
+
+    a1 = [x2]
+    show(io1, a1)
+    show(io2, x2)
+    @test takebuf_string(io1) ==
+        @sprintf("Nullable{%s}[%s]", string(T), takebuf_string(io2))
+end
+
+# showcompact(io::IO, x::Nullable)
+io1 = IOBuffer()
+io2 = IOBuffer()
+for (i, T) in enumerate(types)
+    x1 = Nullable{T}()
+    x2 = Nullable(zero(T))
+    x3 = Nullable(one(T))
+    showcompact(io1, x1)
+    @test takebuf_string(io1) == "#NULL"
+    showcompact(io1, x2)
+    showcompact(io2, get(x2))
+    @test takebuf_string(io1) == takebuf_string(io2)
+    showcompact(io1, x3)
+    showcompact(io2, get(x3))
+    @test takebuf_string(io1) == takebuf_string(io2)
+
+    a1 = [x2]
+    showcompact(io1, a1)
+    showcompact(io2, x2)
+    @test takebuf_string(io1) ==
+        @sprintf("Nullable{%s}[%s]", string(T), takebuf_string(io2))
 end
 
 # get(x::Nullable)


### PR DESCRIPTION
This allows for a more readable printing for Array{Nullable},
and avoids the need for special casing it in array wrappers (like
NamedArrays).

Also simplify the testing code by generating output automatically.
Add tests for array representations.

Cc: @johnmyleswhite, @davidgold, @davidavdav, @vtjnash 
