### PR TITLE
Addrequire

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -85,9 +85,8 @@ add(pkg::AbstractString, vers::VersionNumber...) = cd(Entry.add,pkg,vers...)
 """
     addrequire(requirefile)
 
-Loads a REQUIRE file and adds all packages listed. This first checks if there is a specified
-julia version, and if so, whether the currently installed version is compatible. Next, this
-adds a requirement entry for each package to `Pkg.dir("REQUIRE")` and calls `Pkg.resolve()`.
+Loads a REQUIRE file, adds a requirement entry for each package to `Pkg.dir("REQUIRE")`
+and calls `Pkg.resolve()`.
 """
 addrequire(requirefile::AbstractString) = Entry.addrequire(requirefile)
 

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -4,7 +4,7 @@ module Pkg
 
 export Dir, Types, Reqs, Cache, Read, Query, Resolve, Write, Entry, Git
 export dir, init, rm, add, available, installed, status, clone, checkout,
-       update, resolve, test, build, free, pin, PkgError, setprotocol!
+       update, resolve, test, build, free, pin, PkgError, setprotocol!, addrequire
 
 const DEFAULT_META = "https://github.com/JuliaLang/METADATA.jl"
 const META_BRANCH = "metadata-v2"
@@ -81,6 +81,15 @@ Add a requirement entry for `pkg` to `Pkg.dir("REQUIRE")` and call `Pkg.resolve(
 intervals for `pkg`.
 """
 add(pkg::AbstractString, vers::VersionNumber...) = cd(Entry.add,pkg,vers...)
+
+"""
+    addrequire(requirefile)
+
+Loads a REQUIRE file and adds all packages listed. This first checks if there is a specified
+julia version, and if so, whether the currently installed version is compatible. Next, this
+adds a requirement entry for each package to `Pkg.dir("REQUIRE")` and calls `Pkg.resolve()`.
+"""
+addrequire(requirefile::AbstractString) = Entry.addrequire(requirefile)
 
 """
     available() -> Vector{ASCIIString}


### PR DESCRIPTION
Addition of a function addrequire(filename) to the Pkg module.

Loads a REQUIRE file, adds a requirement entry for each package to `Pkg.dir("REQUIRE")` and calls `Pkg.resolve()`. This uses the same low level package management functions used in normal julia modules to parse the REQUIRE so it respects version information and macros to specify operating systems.

Currently this function does not compare the julia version in the REPL to the julia version requested in the REQUIRE, it will just attempt to install correct versions of all listed packages in the current julia library folder - I could add this if it is a useful feature to have.
