### PR TITLE
Adding support for silent option to download

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -130,17 +130,6 @@ Obtain the contents of an `IOBuffer` as an array, without copying. Afterwards, t
 takebuf_array
 
 """
-    download(url,[localfile])
-
-Download a file from the given url, optionally renaming it to the given local file name.
-Note that this function relies on the availability of external tools such as `curl`, `wget`
-or `fetch` to download the file and is provided for convenience. For production use or
-situations in which more options are needed, please use a package that provides the desired
-functionality instead.
-"""
-download
-
-"""
     @everywhere
 
 Execute an expression on all processes. Errors on any of the processes are collected into a

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -189,11 +189,17 @@
 
    If ``follow_symlinks=false``\ , and ``src`` is a symbolic link, ``dst`` will be created as a symbolic link. If ``follow_symlinks=true`` and ``src`` is a symbolic link, ``dst`` will be a copy of the file or directory ``src`` refers to.
 
-.. function:: download(url,[localfile])
+.. function:: download(url, [localfile]; silent=false)
 
    .. Docstring generated from Julia source
 
-   Download a file from the given url, optionally renaming it to the given local file name. Note that this function relies on the availability of external tools such as ``curl``\ , ``wget`` or ``fetch`` to download the file and is provided for convenience. For production use or situations in which more options are needed, please use a package that provides the desired functionality instead.
+   Download a file from the given url and save it to localfile, or to a temporary file if localfile is ommited. Passing ``silent=true`` will suppress progress indicators. Note that this function relies on the availability of external tools such as ``curl``\ , ``wget`` or ``fetch`` to download the file and is provided for convenience. For production use or situations in which more options are needed, please use a package that provides the desired functionality instead.
+
+   Platform-Specific details
+   *************************
+
+
+   On windows, a full URL must be provided, including the protocol prefix (e.g "http://" for HTTP)
 
 .. function:: mv(src::AbstractString,dst::AbstractString; remove_destination::Bool=false)
 

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -33,7 +33,7 @@ function choosetests(choices = [])
         "markdown", "base64", "serialize", "misc", "threads",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
-        "boundscheck", "error"
+        "boundscheck", "error", "interactiveutil"
     ]
 
     if Base.USE_GPL_LIBS
@@ -79,7 +79,7 @@ function choosetests(choices = [])
         prepend!(tests, linalgtests)
     end
 
-    net_required_for = ["socket", "parallel"]
+    net_required_for = ["socket", "parallel", "interactiveutil"]
     net_on = true
     try
         getipaddr()

--- a/test/interactiveutil.jl
+++ b/test/interactiveutil.jl
@@ -1,0 +1,128 @@
+### Testing download(url,[localfile],[silent=false])
+
+"Runs a function, and returns stdout, stderr, and the result."
+function check_output(func::Function, args...; kwargs...)
+    originalSTDOUT = STDOUT
+    originalSTDERR = STDERR
+    (errRead, errWrite) = redirect_stderr()
+    (outRead, outWrite) = redirect_stdout()
+
+    try
+        result = func(args...; kwargs...)
+        # Ensure both streams are written to or readavailable waits forever.
+        write(STDOUT, "\n")
+        write(STDERR, "\n")
+
+        errstr = UTF8String(readavailable(errRead))
+        outstr = UTF8String(readavailable(outRead))
+        # Remove the manually added \n from stdout and stderr
+        return (chomp(outstr), chomp(errstr), result)
+    catch exception
+        # Immediately restore output so errors are printed.
+        redirect_stderr(originalSTDERR)
+        redirect_stdout(originalSTDOUT)
+        println("Error checking output of $func: args=$args, kwargs=$kwargs - $exception")
+        rethrow(exception)
+    finally
+        redirect_stderr(originalSTDERR)
+        redirect_stdout(originalSTDOUT)
+        close(outRead)
+        close(errRead)
+        close(errWrite)
+        close(outWrite)
+    end
+end
+
+port = 2000 #Changes to next unused port after this
+
+function start_server(html::AbstractString)
+    global server_running, port
+    (port, server) = listenany(port)
+    html_len = length(html)
+    response = """
+    HTTP/1.1 200 OK
+    Content-Length: $html_len
+    Content-Type: text/html
+    Connection: Closed
+
+    $html"""
+
+    server_running = true
+    @async begin
+        while server_running
+            sock = accept(server)
+            readline(sock)
+            write(sock, response)
+            close(sock)
+        end
+    end
+end
+
+function stop_server()
+    global server_running
+    server_running = false
+end
+
+function run_test()
+    global port
+    html = "<html>success</html>"
+    port = 2000
+    start_server(html)
+
+    address = @windows ? "http://localhost:$port" : "localhost:$port"
+
+    downloader = :unknown
+    @unix_only for checkcmd in (:curl, :wget, :fetch)
+        if success(`which $checkcmd`)
+            downloader = checkcmd
+            break
+        end
+    end
+
+    # Test verbose download, no specified file
+    outstr, errstr, result = check_output(download, address)
+    downloaded_html = readstring(result)
+    @test downloaded_html == html
+    if downloader in (:curl, :wget)
+        # Progress appears on stderr for curl and wget
+        @test length(errstr) > 50
+        @test length(outstr) == 0
+    else
+        @test length(errstr) == 0
+        @test length(outstr) == 0
+    end
+
+    # Test silent download, no specified file
+    outstr, errstr, result = check_output(download, address; silent=true)
+    downloaded_html = readstring(result)
+    @test downloaded_html == html
+    @test length(errstr) == 0
+    @test length(outstr) == 0
+
+    output_file = tempname()
+
+    # Test verbose, specified file
+    outstr, errstr, result = check_output(download, address, output_file)
+    downloaded_html = readstring(output_file)
+    @test downloaded_html == html
+    if downloader in (:curl, :wget)
+        # Progress appears on stderr for curl and wget
+        @test length(errstr) > 50
+        @test length(outstr) == 0
+    else
+        @test length(errstr) == 0
+        @test length(outstr) == 0
+    end
+
+    # Test silent download, specified file
+    outstr, errstr, result = check_output(download, address, output_file; silent=true)
+    downloaded_html = readstring(output_file)
+    @test downloaded_html == html
+    @test length(errstr) == 0
+    @test length(outstr) == 0
+
+    stop_server()
+end
+
+# Test cannot currently run on windows, since it requires @async support
+@unix_only run_test()


### PR DESCRIPTION
Adding support for the silent=Bool keyword when calling download.
The default behaviour is to display progress indicators in wget and curl, to match the previous behaviour of download(). Passing silent=true will hide output from wget and curl.
This is primarly aimed at making download usable in async environments, without causing jumbled output.
The relevant documentation is also updated to note the new parameter, and that windows URLs must have the http:// suffix (wget / curl adds it automatically)

A previous pull request was made against the release-0.4 branch accidentally - see https://github.com/invenia/julia/pull/2 All comments from there should be addressed in this
