### PR TITLE
fixed error in `LibGit2.merge!` when a branch does not have a remote

### DIFF
--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -391,7 +391,7 @@ function merge!(repo::GitRepo;
                 with(upstream(head_ref)) do tr_brn_ref
                     if tr_brn_ref === nothing
                         throw(GitError(Error.Merge, Error.ERROR,
-                                   "There is no tracking information for the current branch."))
+                                       "There is no tracking information for the current branch."))
                     end
                     [GitAnnotated(repo, tr_brn_ref)]
                 end
@@ -416,7 +416,7 @@ function rebase!(repo::GitRepo, upstream::AbstractString="", newbase::AbstractSt
             with(upstream(head_ref)) do brn_ref
                 if brn_ref === nothing
                     throw(GitError(Error.Rebase, Error.ERROR,
-                               "There is no tracking information for the current branch."))
+                                   "There is no tracking information for the current branch."))
                 end
                 GitAnnotated(repo, brn_ref)
             end

--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -388,9 +388,13 @@ function merge!(repo::GitRepo;
             else # try to get tracking remote branch for the head
                 if !isattached(repo)
                     throw(GitError(Error.Merge, Error.ERROR,
-                                   "There is no tracking information for the current branch."))
+                                   "Repository HEAD is detached. Remote tracking branch cannot be used."))
                 end
                 with(upstream(head_ref)) do tr_brn_ref
+                    if tr_brn_ref === nothing
+                        throw(GitError(Error.Merge, Error.ERROR,
+                                   "There is no tracking information for the current branch."))
+                    end
                     [GitAnnotated(repo, tr_brn_ref)]
                 end
             end

--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -297,11 +297,11 @@ function clone{P<:AbstractPayload}(repo_url::AbstractString, repo_path::Abstract
                remote_cb::Ptr{Void} = C_NULL,
                payload::Nullable{P}=Nullable{AbstractPayload}())
     # setup clone options
+    lbranch = Base.cconvert(Cstring, bytestring(branch))
     fetch_opts=FetchOptions(callbacks = RemoteCallbacks(credentials_cb(), payload))
     clone_opts = CloneOptions(
                 bare = Cint(isbare),
-                checkout_branch = isempty(branch) ? Cstring_NULL :
-                                  convert(Cstring, pointer(branch)),
+                checkout_branch = isempty(lbranch) ? Cstring(C_NULL) : Base.unsafe_convert(Cstring, lbranch),
                 fetch_opts=fetch_opts,
                 remote_cb = remote_cb
             )

--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -157,8 +157,6 @@ function fetch{T<:AbstractString, P<:AbstractPayload}(repo::GitRepo;
     try
         fo = FetchOptions(callbacks=RemoteCallbacks(credentials_cb(), payload))
         fetch(rmt, refspecs, msg="from $(url(rmt))", options = fo)
-    catch err
-        warn("fetch: $err")
     finally
         finalize(rmt)
     end

--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -416,6 +416,10 @@ function rebase!(repo::GitRepo, upstream::AbstractString="", newbase::AbstractSt
         head_ann = GitAnnotated(repo, head_ref)
         upst_ann  = if isempty(upstream)
             with(upstream(head_ref)) do brn_ref
+                if brn_ref === nothing
+                    throw(GitError(Error.Rebase, Error.ERROR,
+                               "There is no tracking information for the current branch."))
+                end
                 GitAnnotated(repo, brn_ref)
             end
         else

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -13,7 +13,7 @@ type PkgError <: Exception
     msg::AbstractString
     ex::Nullable{Exception}
 end
-PkgError(msg::AbstractString) = PkgError(msg, nothing)
+PkgError(msg::AbstractString) = PkgError(msg, Nullable{Exception}())
 
 for file in split("dir types reqs cache read query resolve write entry git")
     include("pkg/$file.jl")

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -11,7 +11,9 @@ const META_BRANCH = "metadata-v2"
 
 type PkgError <: Exception
     msg::AbstractString
+    ex::Nullable{Exception}
 end
+PkgError(msg::AbstractString) = PkgError(msg, nothing)
 
 for file in split("dir types reqs cache read query resolve write entry git")
     include("pkg/$file.jl")

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -14,6 +14,21 @@ type PkgError <: Exception
     ex::Nullable{Exception}
 end
 PkgError(msg::AbstractString) = PkgError(msg, Nullable{Exception}())
+function Base.showerror(io::IO, pkgerr::PkgError)
+    print(io, pkgerr.msg)
+    if !isnull(pkgerr.ex)
+        pkgex = get(pkgerr.ex)
+        if isa(pkgex, CompositeException)
+            for cex in pkgex
+                print(io, "\n=> ")
+                showerror(io, cex)
+            end
+        else
+            print(io, "\n")
+            showerror(io, pkgex)
+        end
+    end
+end
 
 for file in split("dir types reqs cache read query resolve write entry git")
     include("pkg/$file.jl")

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -43,8 +43,15 @@ function prefetch(pkg::AbstractString, url::AbstractString, sha1s::Vector)
             # clone repo, free it at the end
             LibGit2.clone(normalized_url, cache, isbare = true, remote_cb = LibGit2.mirror_cb())
         catch err
+            errmsg = if isa(err, LibGit2.Error.GitError)
+                "Cannot clone $pkg from $normalized_url. $(err.msg)"
+            elseif isa(err, InterruptException)
+                "Package `$pkg` prefetching was interrupted."
+            else
+                "Uknown error: $err"
+            end
             isdir(cache) && rm(cache, recursive=true)
-            throw(PkgError("Cannot clone $pkg from $normalized_url. $(err.msg)"))
+            throw(PkgError(errmsg))
         end
     end
     try

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -48,7 +48,7 @@ function prefetch(pkg::AbstractString, url::AbstractString, sha1s::Vector)
             elseif isa(err, InterruptException)
                 "Package `$pkg` prefetching was interrupted."
             else
-                "Uknown error: $err"
+                "Unknown error: $err"
             end
             isdir(cache) && rm(cache, recursive=true)
             throw(PkgError(errmsg))

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -350,8 +350,8 @@ function update(branch::AbstractString)
                 LibGit2.rebase!(repo, "origin/$branch")
             end
         catch err
-            mex = CapturedException(err, catch_backtrace())
-            throw(PkgError("METADATA cannot be updated. Resolve problems manually in $(Pkg.dir("METADATA")).", mex))
+            cex = CapturedException(err, catch_backtrace())
+            throw(PkgError("METADATA cannot be updated. Resolve problems manually in $(Pkg.dir("METADATA")).", cex))
         end
     end
     deferred_errors = CompositeException()
@@ -361,9 +361,8 @@ function update(branch::AbstractString)
         try
             Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
         catch err
-            push!(deferred_errors,
-                    PkgError("Package $pkg: unable to update cache.",
-                            CapturedException(err, catch_backtrace())))
+            cex = CapturedException(err, catch_backtrace())
+            push!(deferred_errors, PkgError("Package $pkg: unable to update cache.", cex))
         end
     end
     instd = Read.installed(avail)
@@ -372,9 +371,8 @@ function update(branch::AbstractString)
         try
             Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
         catch err
-            push!(deferred_errors,
-                    PkgError("Package $pkg: unable to update cache.",
-                            CapturedException(err, catch_backtrace())))
+            cex = CapturedException(err, catch_backtrace())
+            push!(deferred_errors, PkgError("Package $pkg: unable to update cache.", cex))
         end
     end
     fixed = Read.fixed(avail,instd)
@@ -391,16 +389,15 @@ function update(branch::AbstractString)
                         LibGit2.fetch(repo)
                         LibGit2.merge!(repo, fastforward=true)
                     catch err
-                        push!(deferred_errors,
-                                PkgError("Package $pkg cannot be updated.",
-                                        CapturedException(err, catch_backtrace())))
+                        cex = CapturedException(err, catch_backtrace())
+                        push!(deferred_errors, PkgError("Package $pkg cannot be updated.", cex))
                         success = false
                     end
                     if success
                         post_sha = string(LibGit2.head_oid(repo))
                         branch = LibGit2.branch(repo)
                         info("Updating $pkg $branch...",
-                              prev_sha != post_sha ? " $(prev_sha[1:8]) → $(post_sha[1:8])" : "")
+                            prev_sha != post_sha ? " $(prev_sha[1:8]) → $(post_sha[1:8])" : "")
                     end
                 end
             end
@@ -409,9 +406,8 @@ function update(branch::AbstractString)
             try
                 Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
             catch err
-                push!(deferred_errors,
-                        PkgError("Package $pkg: unable to update cache.",
-                                CapturedException(err, catch_backtrace())))
+                cex = CapturedException(err, catch_backtrace())
+                push!(deferred_errors, PkgError("Package $pkg: unable to update cache.", cex))
             end
         end
     end

--- a/base/task.jl
+++ b/base/task.jl
@@ -3,7 +3,7 @@
 ## basic task functions and TLS
 
 # Container for a captured exception and its backtrace. Can be serialized.
-type CapturedException
+type CapturedException <: Exception
     ex::Any
     processed_bt::Vector{Any}
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -78,6 +78,7 @@ mktempdir() do dir
     commit_msg2 = randstring(10)
     commit_oid1 = LibGit2.Oid()
     commit_oid2 = LibGit2.Oid()
+    commit_oid3 = LibGit2.Oid()
     test_branch = "test_branch"
     tag1 = "tag1"
     tag2 = "tag2"
@@ -209,7 +210,7 @@ mktempdir() do dir
                 println(repo_file, randstring(10))
                 flush(repo_file)
                 LibGit2.add!(repo, test_file)
-                LibGit2.commit(repo, randstring(10); author=test_sig, committer=test_sig)
+                commit_oid3 = LibGit2.commit(repo, randstring(10); author=test_sig, committer=test_sig)
 
                 println(repo_file, commit_msg2)
                 flush(repo_file)
@@ -350,6 +351,18 @@ mktempdir() do dir
             head_oid = LibGit2.head_oid(repo)
             LibGit2.reset!(repo, head_oid, LibGit2.Consts.RESET_HARD)
             @test isfile(joinpath(test_repo, test_file))
+
+            # Detach HEAD - no merge
+            LibGit2.checkout!(repo, string(commit_oid3))
+            @test_throws LibGit2.Error.GitError LibGit2.merge!(repo, fastforward=true)
+
+            # Switch to a branch without remote - no merge
+            LibGit2.branch!(repo, test_branch)
+            @test_throws LibGit2.Error.GitError LibGit2.merge!(repo, fastforward=true)
+
+            # Switch to the master branch
+            LibGit2.branch!(repo, "master")
+
         finally
             finalize(repo)
         end


### PR DESCRIPTION
and made exceptions more informative.
