### PR TITLE
Check for errors in Expected<T> returned by LLVM 3.9.

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -921,6 +921,7 @@ bool jl_dylib_DI_for_fptr(size_t pointer, const llvm::object::ObjectFile **obj, 
                     // the file rather than reusing the one in memory. We may want to revisit
                     // that in the future (ideally, once we support fewer LLVM versions).
                     errorobj = llvm::object::ObjectFile::createObjectFile(fname);
+                    assert(errorobj);
 #ifdef LLVM36
                     auto binary = errorobj.get().takeBinary();
                     *obj = binary.first.release();
@@ -957,6 +958,14 @@ bool jl_dylib_DI_for_fptr(size_t pointer, const llvm::object::ObjectFile **obj, 
                 }
 #endif
             }
+#ifdef LLVM39
+            else {
+                // TODO: report the error instead of silently consuming it?
+                //       jl_error might run into the same error again...
+                consumeError(errorobj.takeError());
+            }
+#endif
+
             // update cache
             objfileentry_t entry = {*obj,*context,*slide,*section_slide};
             objfilemap[fbase] = entry;


### PR DESCRIPTION
Not doing so makes LLVM abort when the Expected<T> goes out of scope.

According to the docs:

```
/// There are two ways to set the checked flag, depending on what state the
/// Error instance is in. For Error instances indicating success, it
/// is sufficient to invoke the boolean conversion operator. E.g.:
///
///   ...
///
/// For Error instances representing failure, you must use the either the
/// handleErrors or handleAllErrors function with a typed handler. E.g.:
///
///   ...
```

So I made sure there's either an `assert` or an explicit error handling path.
