### PR TITLE
separate Slot into SlotNumber and TypedSlot to save space

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -139,7 +139,7 @@ export
     StackOverflowError, SegmentationFault, UndefRefError, UndefVarError, TypeError,
     # AST representation
     Expr, GotoNode, LabelNode, LineNumberNode, QuoteNode, TopNode,
-    GlobalRef, NewvarNode, GenSym, Slot,
+    GlobalRef, NewvarNode, GenSym, Slot, SlotNumber, TypedSlot,
     # object model functions
     fieldtype, getfield, setfield!, nfields, throw, tuple, is, ===, isdefined, eval,
     # sizeof    # not exported, to avoid conflicting with Base.sizeof
@@ -277,13 +277,13 @@ _new(typ::Symbol, argty::Symbol) = eval(:((::Type{$typ})(n::$argty) = $(Expr(:ne
 _new(:LabelNode, :Int)
 _new(:GotoNode, :Int)
 _new(:TopNode, :Symbol)
-_new(:NewvarNode, :Slot)
+_new(:NewvarNode, :SlotNumber)
 _new(:QuoteNode, :ANY)
 _new(:GenSym, :Int)
 eval(:((::Type{LineNumberNode})(f::Symbol, l::Int) = $(Expr(:new, :LineNumberNode, :f, :l))))
 eval(:((::Type{GlobalRef})(m::Module, s::Symbol) = $(Expr(:new, :GlobalRef, :m, :s))))
-eval(:((::Type{Slot})(n::Int) = $(Expr(:new, :Slot, :n, Any))))
-eval(:((::Type{Slot})(n::Int, t::ANY) = $(Expr(:new, :Slot, :n, :t))))
+eval(:((::Type{SlotNumber})(n::Int) = $(Expr(:new, :SlotNumber, :n))))
+eval(:((::Type{TypedSlot})(n::Int, t::ANY) = $(Expr(:new, :TypedSlot, :n, :t))))
 
 Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool), name, std_imports)
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -35,16 +35,14 @@ copy(e::Expr) = (n = Expr(e.head);
                  n.args = astcopy(e.args);
                  n.typ = e.typ;
                  n)
-copy(s::Slot) = Slot(s.id, s.typ)
 
 # copy parts of an AST that the compiler mutates
-astcopy(x::Union{Slot,Expr}) = copy(x)
+astcopy(x::Expr) = copy(x)
 astcopy(x::Array{Any,1}) = Any[astcopy(a) for a in x]
 astcopy(x) = x
 
 ==(x::Expr, y::Expr) = x.head === y.head && isequal(x.args, y.args)
 ==(x::QuoteNode, y::QuoteNode) = isequal(x.value, y.value)
-==(x::Slot, y::Slot) = x.id === y.id && x.typ === y.typ
 
 expand(x::ANY) = ccall(:jl_expand, Any, (Any,), x)
 macroexpand(x::ANY) = ccall(:jl_macroexpand, Any, (Any,), x)

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -63,7 +63,6 @@ else
 end
 
 hash(x::QuoteNode, h::UInt) = hash(x.value, hash(QuoteNode, h))
-hash(x::Slot, h::UInt) = hash(x.id, hash(x.typ, hash(Slot, h)))
 
 # hashing ranges by component at worst leads to collisions for very similar ranges
 const hashr_seed = UInt === UInt64 ? 0x80707b6821b70087 : 0x21b70087

--- a/base/show.jl
+++ b/base/show.jl
@@ -526,7 +526,7 @@ show_unquoted(io::IO, ex::TopNode, ::Int, ::Int)        = print(io,"top(",ex.nam
 show_unquoted(io::IO, ex::GlobalRef, ::Int, ::Int)      = print(io, ex.mod, '.', ex.name)
 
 function show_unquoted(io::IO, ex::Slot, ::Int, ::Int)
-    typ = ex.typ
+    typ = isa(ex,TypedSlot) ? ex.typ : Any
     slotid = ex.id
     li = get(io, :LAMBDAINFO, false)
     if isa(li, LambdaInfo)
@@ -545,7 +545,7 @@ function show_unquoted(io::IO, ex::Slot, ::Int, ::Int)
         print(io, "_", slotid)
     end
     emphstate = typeemphasize(io)
-    if emphstate || typ !== Any
+    if emphstate || (typ !== Any && isa(ex,TypedSlot))
         show_expr_type(io, typ, emphstate)
     end
 end

--- a/doc/devdocs/ast.rst
+++ b/doc/devdocs/ast.rst
@@ -30,6 +30,13 @@ The following data types exist in lowered form:
 
 ``Slot``
     identifies arguments and local variables by consecutive numbering.
+    ``Slot`` is an abstract type with subtypes ``SlotNumber`` and ``TypedSlot``.
+    Both types have an integer-valued ``id`` field giving the slot index.
+    Most slots have the same type at all uses, and so are represented with
+    ``SlotNumber``. The types of these slots are found in the ``slottypes``
+    field of their ``LambdaInfo`` object.
+    Slots that require per-use type annotations are represented with
+    ``TypedSlot``, which has a ``typ`` field.
 
 ``LambdaInfo``
     wraps the IR of each method.

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -1057,6 +1057,7 @@ UIBOX_FUNC(uint16, uint16_t, 1)
 UIBOX_FUNC(uint32, uint32_t, 1)
 UIBOX_FUNC(char,   uint32_t, 1)
 UIBOX_FUNC(gensym, size_t, 1)
+UIBOX_FUNC(slotnumber, size_t, 1)
 #ifdef _P64
 SIBOX_FUNC(int64,  int64_t, 1)
 UIBOX_FUNC(uint64, uint64_t, 1)
@@ -1084,8 +1085,10 @@ void jl_init_int32_int64_cache(void)
         boxed_int64_cache[i]  = jl_box64(jl_int64_type, i-NBOX_C/2);
 #ifdef _P64
         boxed_gensym_cache[i] = jl_box64(jl_gensym_type, i);
+        boxed_slotnumber_cache[i] = jl_box64(jl_slotnumber_type, i);
 #else
         boxed_gensym_cache[i] = jl_box32(jl_gensym_type, i);
+        boxed_slotnumber_cache[i] = jl_box32(jl_slotnumber_type, i);
 #endif
     }
     for(i=0; i < 256; i++) {
@@ -1124,6 +1127,7 @@ void jl_mark_box_caches(void)
         jl_gc_setmark(boxed_char_cache[i]);
         jl_gc_setmark(boxed_uint64_cache[i]);
         jl_gc_setmark(boxed_gensym_cache[i]);
+        jl_gc_setmark(boxed_slotnumber_cache[i]);
     }
 }
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -443,13 +443,8 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
             hd = car_(e);
             if (hd == jl_ast_ctx(fl_ctx)->jlgensym_sym)
                 return jl_box_gensym(numval(car_(cdr_(e))));
-            else if (hd == jl_ast_ctx(fl_ctx)->slot_sym) {
-                jl_value_t *slotnum = jl_box_long(numval(car_(cdr_(e))));
-                JL_GC_PUSH1(&slotnum);
-                jl_value_t *res = jl_new_struct(jl_slot_type, slotnum, jl_any_type);
-                JL_GC_POP();
-                return res;
-            }
+            else if (hd == jl_ast_ctx(fl_ctx)->slot_sym)
+                return jl_box_slotnumber(numval(car_(cdr_(e))));
             else if (hd == jl_ast_ctx(fl_ctx)->null_sym && llength(e) == 1)
                 return jl_nothing;
         }
@@ -677,7 +672,7 @@ static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v)
     // GC Note: jl_fieldref(v, 0) allocate for LabelNode, GotoNode
     //          but we don't need a GC root here because julia_to_list2
     //          shouldn't allocate in this case.
-    if (jl_typeis(v, jl_slot_type))
+    if (jl_is_slot(v))
         return julia_to_list2(fl_ctx, (jl_value_t*)slot_sym, jl_fieldref(v,0));
     if (jl_typeis(v, jl_labelnode_type))
         return julia_to_list2(fl_ctx, (jl_value_t*)label_sym, jl_fieldref(v,0));

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1142,7 +1142,9 @@ void jl_init_primitives(void)
     add_builtin("TypeMapLevel", (jl_value_t*)jl_typemap_level_type);
     add_builtin("Symbol", (jl_value_t*)jl_sym_type);
     add_builtin("GenSym", (jl_value_t*)jl_gensym_type);
-    add_builtin("Slot", (jl_value_t*)jl_slot_type);
+    add_builtin("Slot", (jl_value_t*)jl_abstractslot_type);
+    add_builtin("SlotNumber", (jl_value_t*)jl_slotnumber_type);
+    add_builtin("TypedSlot", (jl_value_t*)jl_typedslot_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);
     add_builtin("Builtin", (jl_value_t*)jl_builtin_type);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -857,8 +857,14 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
         jl_array_t *gensym_types = (jl_array_t*)ctx->linfo->gensymtypes;
         return jl_cellref(gensym_types, idx);
     }
-    if (jl_typeis(e, jl_slot_type)) {
-        jl_value_t *typ = jl_slot_get_type(e);
+    if (jl_typeis(e, jl_slotnumber_type)) {
+        jl_array_t *slot_types = (jl_array_t*)ctx->linfo->slottypes;
+        if (!jl_is_array(slot_types))
+            return (jl_value_t*)jl_any_type;
+        return jl_cellref(slot_types, jl_slot_number(e)-1);
+    }
+    if (jl_typeis(e, jl_typedslot_type)) {
+        jl_value_t *typ = jl_typedslot_get_type(e);
         if (jl_is_typevar(typ))
             typ = ((jl_tvar_t*)typ)->ub;
         return typ;
@@ -1558,7 +1564,7 @@ static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t id
 
 static bool might_need_root(jl_value_t *ex)
 {
-    return (!jl_is_symbol(ex) && !jl_typeis(ex, jl_slot_type) && !jl_is_gensym(ex) &&
+    return (!jl_is_symbol(ex) && !jl_is_slot(ex) && !jl_is_gensym(ex) &&
             !jl_is_bool(ex) && !jl_is_quotenode(ex) && !jl_is_byte_string(ex) &&
             !jl_is_globalref(ex));
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1521,7 +1521,7 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
             return jl_get_global(mod, sym);
         return NULL;
     }
-    if (jl_typeis(ex,jl_slot_type))
+    if (jl_is_slot(ex))
         return NULL;
     if (jl_is_gensym(ex)) {
         ssize_t idx = ((jl_gensym_t*)ex)->id;
@@ -2889,7 +2889,7 @@ static jl_cgval_t emit_local(jl_value_t *slotload, jl_codectx_t *ctx)
         jl_value_t *typ;
         if (ctx->linfo->inferred) {
             // use the better type from inference for this load
-            typ = jl_slot_get_type(slotload);
+            typ = expr_type(slotload, ctx);
             if (jl_is_typevar(typ))
                 typ = ((jl_tvar_t*)typ)->ub;
         }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -148,7 +148,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         return v;
     }
     if (!jl_is_expr(e)) {
-        if (jl_typeis(e, jl_slot_type)) {
+        if (jl_is_slot(e)) {
             ssize_t n = jl_slot_number(e);
             if (n > jl_linfo_nslots(lam) || n < 1 || locals == NULL)
                 jl_error("access to invalid slot number");
@@ -166,7 +166,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
         }
         if (jl_is_newvarnode(e)) {
             jl_value_t *var = jl_fieldref(e,0);
-            assert(jl_typeis(var,jl_slot_type));
+            assert(jl_is_slot(var));
             ssize_t n = jl_slot_number(var);
             assert(n <= jl_linfo_nslots(lam) && n > 0);
             locals[n-1] = NULL;
@@ -189,7 +189,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
                 jl_error("assignment to invalid GenSym location");
             locals[jl_linfo_nslots(lam) + genid] = rhs;
         }
-        else if (jl_typeis(sym,jl_slot_type)) {
+        else if (jl_is_slot(sym)) {
             ssize_t n = jl_slot_number(sym);
             assert(n <= jl_linfo_nslots(lam) && n > 0);
             locals[n-1] = rhs;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -26,7 +26,9 @@ jl_datatype_t *jl_typename_type;
 jl_datatype_t *jl_sym_type;
 jl_datatype_t *jl_symbol_type;
 jl_datatype_t *jl_gensym_type;
-jl_datatype_t *jl_slot_type;
+jl_datatype_t *jl_abstractslot_type;
+jl_datatype_t *jl_slotnumber_type;
+jl_datatype_t *jl_typedslot_type;
 jl_datatype_t *jl_simplevector_type;
 jl_typename_t *jl_tuple_typename;
 jl_tupletype_t *jl_anytuple_type;
@@ -3356,9 +3358,16 @@ void jl_init_types(void)
                                      jl_svec1(jl_symbol("id")),
                                      jl_svec1(jl_long_type), 0, 0, 1);
 
-    jl_slot_type = jl_new_datatype(jl_symbol("Slot"), jl_any_type, jl_emptysvec,
-                                   jl_svec(2, jl_symbol("id"), jl_symbol("typ")),
-                                   jl_svec(2, jl_long_type, jl_any_type), 0, 0, 2);
+    jl_abstractslot_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Slot"), jl_any_type,
+                                               jl_emptysvec);
+
+    jl_slotnumber_type = jl_new_datatype(jl_symbol("SlotNumber"), jl_abstractslot_type, jl_emptysvec,
+                                         jl_svec1(jl_symbol("id")),
+                                         jl_svec1(jl_long_type), 0, 0, 1);
+
+    jl_typedslot_type = jl_new_datatype(jl_symbol("TypedSlot"), jl_abstractslot_type, jl_emptysvec,
+                                        jl_svec(2, jl_symbol("id"), jl_symbol("typ")),
+                                        jl_svec(2, jl_long_type, jl_any_type), 0, 0, 2);
 
     jl_init_int32_int64_cache();
 
@@ -3466,7 +3475,7 @@ void jl_init_types(void)
     jl_newvarnode_type =
         jl_new_datatype(jl_symbol("NewvarNode"), jl_any_type, jl_emptysvec,
                         jl_svec(1, jl_symbol("slot")),
-                        jl_svec(1, jl_slot_type), 0, 0, 1);
+                        jl_svec(1, jl_slotnumber_type), 0, 0, 1);
 
     jl_topnode_type =
         jl_new_datatype(jl_symbol("TopNode"), jl_any_type, jl_emptysvec,

--- a/src/julia.h
+++ b/src/julia.h
@@ -436,7 +436,9 @@ extern JL_DLLEXPORT jl_datatype_t *jl_typector_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_sym_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_symbol_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_gensym_type;
-extern JL_DLLEXPORT jl_datatype_t *jl_slot_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_abstractslot_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_slotnumber_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_typedslot_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_simplevector_type;
 extern JL_DLLEXPORT jl_typename_t *jl_tuple_typename;
 extern JL_DLLEXPORT jl_datatype_t *jl_anytuple_type;
@@ -726,7 +728,7 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x)
 #define jl_linenode_line(x) (((intptr_t*)x)[1])
 #define jl_labelnode_label(x) (((intptr_t*)x)[0])
 #define jl_slot_number(x) (((intptr_t*)x)[0])
-#define jl_slot_get_type(x) (((jl_value_t**)x)[1])
+#define jl_typedslot_get_type(x) (((jl_value_t**)x)[1])
 #define jl_gotonode_label(x) (((intptr_t*)x)[0])
 #define jl_globalref_mod(s) (*(jl_module_t**)s)
 #define jl_globalref_name(s) (((jl_sym_t**)s)[1])
@@ -841,7 +843,7 @@ static inline uint32_t jl_fielddesc_size(int8_t fielddesc_type)
 #define jl_is_bool(v)        jl_typeis(v,jl_bool_type)
 #define jl_is_symbol(v)      jl_typeis(v,jl_sym_type)
 #define jl_is_gensym(v)      jl_typeis(v,jl_gensym_type)
-#define jl_is_slot(v)        jl_typeis(v,jl_slot_type)
+#define jl_is_slot(v)        (jl_typeis(v,jl_slotnumber_type) || jl_typeis(v,jl_typedslot_type))
 #define jl_is_expr(v)        jl_typeis(v,jl_expr_type)
 #define jl_is_globalref(v)   jl_typeis(v,jl_globalref_type)
 #define jl_is_labelnode(v)   jl_typeis(v,jl_labelnode_type)
@@ -1037,6 +1039,7 @@ JL_DLLEXPORT jl_value_t *jl_box_float32(float x);
 JL_DLLEXPORT jl_value_t *jl_box_float64(double x);
 JL_DLLEXPORT jl_value_t *jl_box_voidpointer(void *x);
 JL_DLLEXPORT jl_value_t *jl_box_gensym(size_t x);
+JL_DLLEXPORT jl_value_t *jl_box_slotnumber(size_t x);
 JL_DLLEXPORT jl_value_t *jl_box8 (jl_datatype_t *t, int8_t  x);
 JL_DLLEXPORT jl_value_t *jl_box16(jl_datatype_t *t, int16_t x);
 JL_DLLEXPORT jl_value_t *jl_box32(jl_datatype_t *t, int32_t x);

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -95,9 +95,9 @@ let a = QuoteNode(1), b = QuoteNode(1.0)
     @test (hash(a)==hash(b)) == (a==b)
 end
 
-let a = Expr(:block, Slot(1, Any)),
-    b = Expr(:block, Slot(1, Any)),
-    c = Expr(:block, Slot(3, Any))
+let a = Expr(:block, TypedSlot(1, Any)),
+    b = Expr(:block, TypedSlot(1, Any)),
+    c = Expr(:block, TypedSlot(3, Any))
     @test a == b && hash(a) == hash(b)
     @test a != c && hash(a) != hash(c)
     @test b != c && hash(b) != hash(c)


### PR DESCRIPTION
Also serialize SlotNumber and GenSym more efficiently. This shaves 3-4% off sys.so and makes inference slightly faster.
