### PR TITLE
Use deprecate_binding for RemoteRef

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -896,7 +896,7 @@ function isexecutable(st::Filesystem.StatStruct)
 end
 export isreadable, iswritable, isexecutable
 
-@deprecate RemoteRef RemoteChannel
+@deprecate_binding RemoteRef RemoteChannel
 
 function tty_size()
     depwarn("tty_size is deprecated. use `displaysize(io)` as a replacement", :tty_size)


### PR DESCRIPTION
Currently in master there's a deprecation for `RemoteRef` (see #14458), but it's not sufficient for function declarations:

``` jl
julia> foo(rr::RemoteRef) = 7
ERROR: ArgumentError: invalid type for argument rr in method definition for foo at REPL[1]:1
 in eval(::Module, ::Any) at ./boot.jl:236
```

This switches it to `@deprecate_binding`, which does suffice. CC @amitmurthy.
