### PR TITLE
Remove precompiled=no on windows.

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -73,12 +73,7 @@ jl_options_t jl_options = { 0,    // quiet
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
                             JL_OPTIONS_HANDLE_SIGNALS_ON,
-#ifdef _OS_WINDOWS_
-// TODO remove this when using LLVM 3.5+
-                            JL_OPTIONS_USE_PRECOMPILED_NO,
-#else
                             JL_OPTIONS_USE_PRECOMPILED_YES,
-#endif
                             JL_OPTIONS_USE_COMPILECACHE_YES,
                             NULL, // bindto
                             NULL, // outputbc


### PR DESCRIPTION
As LLVM has been upgraded, is there any reason for not removing `precompiled=no` on windows? It reduces startup time and the test seem to pass on 64bit.
