### PR TITLE
Use compact output for all types when showing arrays

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2888,9 +2888,12 @@ Show an expression and result, returning the result.
 """
     showcompact(x)
 
-Show a more compact representation of a value. This is used for printing array elements.
-If a new type has a different compact representation,
+Show a more compact representation of a value.
+
+This is used for printing array elements. If a new type has a different compact representation,
 it should test `get(io, :compact, false)` in its normal `show` method.
+A compact representation should skip any type information, which would be redundant
+with that printed once for the whole array.
 """
 showcompact
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1528,15 +1528,13 @@ end
 # returns compact, prefix
 function array_eltype_show_how(X)
     e = eltype(X)
-    leaf = isleaftype(e)
-    plain = e<:Number || e<:AbstractString ||
-            (e<:Nullable && (eltype(e)<:Number || eltype(e)<:AbstractString))
     if isa(e,DataType) && e === e.name.primary
-        str = string(e.name)
+        str = string(e.name) # Print "Array" rather than "Array{T,N}"
     else
         str = string(e)
     end
-    leaf&&plain, (!isempty(X) && (e===Float64 || e===Int || (leaf && !plain)) ? "" : str)
+    # Types hard-coded here are those which are created by default for a given syntax
+    isleaftype(e), (!isempty(X) && (e===Float64 || e===Int || e===Char) ? "" : str)
 end
 
 function show_vector(io::IO, v, opn, cls)

--- a/doc/manual/networking-and-streams.rst
+++ b/doc/manual/networking-and-streams.rst
@@ -105,7 +105,7 @@ the difference between the two)::
 IO Output Contextual Properties
 -------------------------------
 
-Sometimes IO output can benefit from the ability to pass contextual information into show methods. The ``IOContext`` object provides this framework for associating arbitrary metadata with an IO object. For example, ``showlimited`` adds a hinting parameter to the IO object that the invoked show method should print a shorter output (if applicable).
+Sometimes IO output can benefit from the ability to pass contextual information into show methods. The ``IOContext`` object provides this framework for associating arbitrary metadata with an IO object. For example, ``showcompact`` adds a hinting parameter to the IO object that the invoked show method should print a shorter output (if applicable).
 
 Working with Files
 ------------------

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -434,7 +434,9 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   Show a more compact representation of a value. This is used for printing array elements. If a new type has a different compact representation, it should test ``get(io, :compact, false)`` in its normal ``show`` method.
+   Show a more compact representation of a value.
+
+   This is used for printing array elements. If a new type has a different compact representation, it should test ``get(io, :compact, false)`` in its normal ``show`` method. A compact representation should skip any type information, which would be redundant with that printed once for the whole array.
 
 .. function:: showall(x)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1132,7 +1132,7 @@ immutable Foo2509; foo::Int; end
 # issue #2517
 immutable Foo2517; end
 @test repr(Foo2517()) == "Foo2517()"
-@test repr(Array(Foo2517,1)) == "[Foo2517()]"
+@test repr(Array(Foo2517,1)) == "Foo2517[Foo2517()]"
 @test Foo2517() === Foo2517()
 
 # issue #1474


### PR DESCRIPTION
Any custom type can now declare whether it supports compact output,
in which case array printing will include type information only once
using a prefix.

Also fix a reference to showlimited() -> showcompact().

Cf. https://github.com/JuliaLang/julia/pull/15928#discussion_r60117681
