### PR TITLE
compute `inline_worthy` after inference and cache it

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1426,7 +1426,11 @@ function typeinf_edge(method::Method, atypes::ANY, sparams::SimpleVector, needtr
             end
         elseif isa(code,LambdaInfo)
             @assert code.inferred
-            return (code, code.rettype, true)
+            if !isdefined(code, :code) && needtree
+                # has been inferred before but code was deleted. re-run.
+            else
+                return (code, code.rettype, true)
+            end
         else
             # otherwise this is an InferenceState from a different bootstrap stage's
             # copy of the inference code; ignore it.
@@ -1463,7 +1467,7 @@ function typeinf_edge(method::Method, atypes::ANY, sparams::SimpleVector, needtr
             end
         end
         # add lam to be inferred and record the edge
-        if isa(caller, LambdaInfo)
+        if isa(caller, LambdaInfo) && isdefined(caller, :code)
             linfo = caller
         elseif method.isstaged
             if !isleaftype(atypes)

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -387,6 +387,7 @@ JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(jl_svec_t *sparam_syms)
     li->inCompile = 0;
     li->def = NULL;
     li->pure = 0;
+    li->inlineable = 0;
     return li;
 }
 
@@ -467,6 +468,7 @@ static jl_lambda_info_t *jl_clone_thunk(jl_lambda_info_t *linfo, jl_tupletype_t 
     new_linfo->gensymtypes = linfo->gensymtypes;
     new_linfo->sparam_vals = linfo->sparam_vals;
     new_linfo->pure = linfo->pure;
+    new_linfo->inlineable = linfo->inlineable;
     new_linfo->nargs = linfo->nargs;
     new_linfo->isva = linfo->isva;
     new_linfo->rettype = linfo->rettype;

--- a/src/dump.c
+++ b/src/dump.c
@@ -853,6 +853,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         jl_serialize_value(s, (jl_value_t*)li->unspecialized_ducttape);
         write_int8(s, li->inferred);
         write_int8(s, li->pure);
+        write_int8(s, li->inlineable);
         write_int8(s, li->isva);
         write_int32(s, li->nargs);
         jl_serialize_value(s, (jl_value_t*)li->def);
@@ -1458,6 +1459,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         if (li->unspecialized_ducttape) jl_gc_wb(li, li->unspecialized_ducttape);
         li->inferred = read_int8(s);
         li->pure = read_int8(s);
+        li->inlineable = read_int8(s);
         li->isva = read_int8(s);
         li->nargs = read_int32(s);
         li->def = (jl_method_t*)jl_deserialize_value(s, (jl_value_t**)&li->def);

--- a/src/dump.c
+++ b/src/dump.c
@@ -474,7 +474,7 @@ static int jl_prune_tcache(jl_typemap_entry_t *ml, void *closure)
         jl_value_t *ret = ml->func.value;
         if (jl_is_lambda_info(ret)) {
             jl_array_t *code = ((jl_lambda_info_t*)ret)->code;
-            if (jl_is_array(code) && jl_array_len(code) > 500) {
+            if (code!=NULL && jl_is_array(code) && jl_array_len(code) > 500) {
                 ml->func.value = ((jl_lambda_info_t*)ret)->rettype;
                 jl_gc_wb(ml, ml->func.value);
             }
@@ -2052,6 +2052,7 @@ JL_DLLEXPORT jl_array_t *jl_compress_ast(jl_lambda_info_t *li, jl_array_t *ast)
     JL_SIGATOMIC_BEGIN();
     JL_LOCK(&dump_lock); // Might GC
     assert(jl_is_lambda_info(li));
+    assert(jl_is_array(ast));
     DUMP_MODES last_mode = mode;
     mode = MODE_AST;
     ios_t dest;

--- a/src/gf.c
+++ b/src/gf.c
@@ -941,7 +941,7 @@ jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types)
     } JL_CATCH {
         goto not_found;
     }
-    if (sf == NULL || sf->code == NULL || sf->inInference)
+    if (sf == NULL || sf->inInference)
         goto not_found;
     if (sf->functionObjectsDecls.functionObject == NULL) {
         if (sf->fptr != NULL)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3522,7 +3522,7 @@ void jl_init_types(void)
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaInfo"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(24,
+                        jl_svec(25,
                                 jl_symbol("code"),
                                 jl_symbol("slotnames"),
                                 jl_symbol("slottypes"),
@@ -3538,13 +3538,14 @@ void jl_init_types(void)
                                 jl_symbol("isva"),
                                 jl_symbol("inferred"),
                                 jl_symbol("pure"),
+                                jl_symbol("inlineable"),
                                 jl_symbol("inInference"),
                                 jl_symbol("inCompile"),
                                 jl_symbol("jlcall_api"),
                                 jl_symbol("fptr"),
                                 jl_symbol(""), jl_symbol(""), jl_symbol(""),
                                 jl_symbol(""), jl_symbol("")),
-                        jl_svec(24,
+                        jl_svec(25,
                                 jl_any_type,
                                 jl_array_any_type,
                                 jl_any_type,
@@ -3557,6 +3558,7 @@ void jl_init_types(void)
                                 jl_any_type,
                                 jl_method_type,
                                 jl_int32_type,
+                                jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type,
@@ -3617,10 +3619,10 @@ void jl_init_types(void)
     jl_svecset(jl_simplevector_type->types, 0, jl_long_type);
     jl_svecset(jl_typename_type->types, 6, jl_long_type);
     jl_svecset(jl_methtable_type->types, 3, jl_long_type);
-    jl_svecset(jl_lambda_info_type->types, 18, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 19, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 20, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 21, jl_voidpointer_type);
+    jl_svecset(jl_lambda_info_type->types, 22, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3568,7 +3568,7 @@ void jl_init_types(void)
                                 jl_any_type,
                                 jl_any_type, jl_any_type, jl_any_type,
                                 jl_int32_type, jl_int32_type),
-                        0, 1, 10);
+                        0, 1, 0);
     jl_svecset(jl_lambda_info_type->types, 9, jl_lambda_info_type);
     jl_svecset(jl_method_type->types, 6, jl_lambda_info_type);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -240,6 +240,7 @@ typedef struct _jl_lambda_info_t {
     int8_t isva;
     int8_t inferred;
     int8_t pure;
+    int8_t inlineable;
     int8_t inInference; // flags to tell if inference is running on this function
     int8_t inCompile; // flag to tell if codegen is running on this function
     int8_t jlcall_api; // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t


### PR DESCRIPTION
This avoids repeating the computation for the same piece of code, and allows rejecting inlining before calling jl_uncompress_ast in more cases.

This should be generally faster. The only reason it might be slower AFAICT would be if we end up calling inline_worthy for lots of functions that previously never had inlining attempts by call sites. However inline_worthy itself should be pretty cheap.
