### PR TITLE
more efficient muladd for complex/real operations

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -124,6 +124,10 @@ inv{T<:Integer}(z::Complex{T}) = inv(float(z))
 *(z::Complex, w::Complex) = Complex(real(z) * real(w) - imag(z) * imag(w),
                                     real(z) * imag(w) + imag(z) * real(w))
 
+muladd(z::Complex, w::Complex, x::Complex) =
+    Complex(muladd(real(z), real(w), real(x)) - imag(z)*imag(w), # TODO: use mulsub given #15985
+            muladd(real(z), imag(w), muladd(imag(z), real(w), imag(x))))
+
 # handle Bool and Complex{Bool}
 # avoid type signature ambiguity warnings
 +(x::Bool, z::Complex{Bool}) = Complex(x + real(z), imag(z))
@@ -162,6 +166,15 @@ end
 -(z::Complex, x::Real) = Complex(real(z) - x, imag(z))
 *(x::Real, z::Complex) = Complex(x * real(z), x * imag(z))
 *(z::Complex, x::Real) = Complex(x * real(z), x * imag(z))
+
+muladd(x::Real, z::Complex, y::Number) = muladd(z, x, y)
+muladd(z::Complex, x::Real, y::Real) = Complex(muladd(real(z),x,y), imag(z)*x)
+muladd(z::Complex, x::Real, w::Complex) =
+    Complex(muladd(real(z),x,real(w)), muladd(imag(z),x,imag(w)))
+muladd(x::Real, y::Real, z::Complex) = Complex(muladd(x,y,real(z)), imag(z))
+muladd(z::Complex, w::Complex, x::Real) =
+    Complex(muladd(real(z), real(w), x) - imag(z)*imag(w), # TODO: use mulsub given #15985
+            muladd(real(z), imag(w), imag(z) * real(w)))
 
 /(a::Real, z::Complex) = a*inv(z)
 /(z::Complex, x::Real) = Complex(real(z)/x, imag(z)/x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -74,7 +74,7 @@ macro evalpoly(z, p...)
         ai = symbol("a", i)
         push!(as, :($ai = $a))
         a = :(muladd(r, $ai, $b))
-        b = :(muladd(-s, $ai, $(esc(p[i]))))
+        b = :($(esc(p[i])) - s * $ai) # see issue #15985 on fused mul-subtract
     end
     ai = :a0
     push!(as, :($ai = $a))
@@ -82,7 +82,7 @@ macro evalpoly(z, p...)
              :(x = real(tt)),
              :(y = imag(tt)),
              :(r = x + x),
-             :(s = x*x + y*y),
+             :(s = muladd(x, x, y*y)),
              as...,
              :(muladd($ai, tt, $b)))
     R = Expr(:macrocall, symbol("@horner"), :tt, map(esc, p)...)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -904,6 +904,11 @@ end
 # issue #10926
 @test typeof(π - 1im) == Complex{Float64}
 
+# issue #15969: specialized muladd for complex types
+for x in (3, 3+13im), y in (2, 2+7im), z in (5, 5+11im)
+    @test muladd(x,y,z) == x*y + z
+end
+
 # issue #11839: type stability for Complex{Int64}
 let x = 1+im
     @inferred sin(x)


### PR DESCRIPTION
Fixes #15969, and corrects some efficiency problems in `@evalpoly` introduced in #9881.
