### PR TITLE
Disable fastisel for -O3

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5759,7 +5759,8 @@ extern "C" void jl_init_codegen(void)
                                " Is the LLVM backend for this CPU enabled?");
 #if defined(USE_MCJIT) && !defined(_CPU_ARM_)
     // FastISel seems to be buggy for ARM. Ref #13321
-    jl_TargetMachine->setFastISel(true);
+    if (jl_options.opt_level < 3)
+        jl_TargetMachine->setFastISel(true);
 #endif
 
 #ifdef USE_ORCJIT


### PR DESCRIPTION
There are at least two cases where fastisel generates worse instruction (https://github.com/JuliaLang/julia/commit/1df19b8d165dc637e43c57ba7471ea2732c63cea#commitcomment-17200932 , https://github.com/JuliaLang/julia/issues/11592#issuecomment-150823967)

The downside is that we build the sysimg by with `-O3` so this might make it slightly slower.

@Keno 

Close #15985
