### PR TITLE
RFC: Support getindex for Repeated and Take iterators

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -226,6 +226,11 @@ function done(it::Take, state)
     return n <= 0 || done(it.xs, xs_state)
 end
 
+@inline function getindex(it::Take, i::Integer)
+    @boundscheck 1 <= i <= length(it) || throw(BoundsError(it, i))
+    it.xs[i]
+end
+
 # Drop -- iterator through all but the first n elements
 
 immutable Drop{I}
@@ -295,6 +300,11 @@ iteratorsize{O}(::Type{Repeated{O}}) = IsInfinite()
 start(it::Repeated) = nothing
 next(it::Repeated, state) = (it.x, nothing)
 done(it::Repeated, state) = false
+
+@inline function getindex(it::Repeated, i::Integer)
+    @boundscheck i >= 1 || throw(BoundsError(it, i))
+    it.x
+end
 
 repeated(x, n::Int) = take(repeated(x), n)
 

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -172,6 +172,18 @@ let i = 0
         i <= 10 || break
     end
 end
+let it = repeated(1, 10)
+    for i in 1:10
+        @test it[i] == 1
+    end
+    @test_throws BoundsError it[0]
+    @test_throws BoundsError it[11]
+end
+let it = repeated(1)
+    @test_throws BoundsError it[0]
+    @test it[1] == 1
+    @test it[100] == 1
+end
 
 
 # product


### PR DESCRIPTION
This allows using `repeated()` to create a vector-like object.

The goal of this PR is to allow using `repeated(1, N)` as a more general solution to the idea of a `Ones` type (see https://github.com/JuliaStats/StatsBase.jl/issues/135). The idea is to always write algorithms in their most general form accepting numeric weights, and make the non-weighted form use a special object returning only unit weights.

If I'm correct, with proper inlining, `repeated(1, N)` will/can be as efficient as as `Ones` type for which the return value is known at compile time. Though even if that doesn't work, this PR makes sense for other use cases.

I've marked it as RFC because I wonder whether it wouldn't be better to make `repeated(::Any, ::Integer)` return a new `NRepeated` type which would be a subtype of `AbstractVector`. Indeed, even if I added `getindex` methods, `Take{Repeated}}` objects can't be passed to functions expecting a vector, which could be annoying. Comments welcome!
