### PR TITLE
clean up some cases of messy IR generation

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2625,9 +2625,10 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
         push!(body.args, lastexpr)
         push!(body.args, Expr(:call, TopNode(:error), "fatal error in type inference"))
         lastexpr = nothing
-    else
-        @assert isa(lastexpr,Expr) "inference.jl:1774"
-        @assert is(lastexpr.head,:return) "inference.jl:1775"
+    elseif !(isa(lastexpr,Expr) && lastexpr.head === :return)
+        # code sometimes ends with a meta node, e.g. inbounds pop
+        push!(body.args, lastexpr)
+        lastexpr = nothing
     end
     for a in body.args
         push!(stmts, a)
@@ -2667,9 +2668,20 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     end
 
     if !isempty(stmts) && !propagate_inbounds
-        # inlined statements are out-of-bounds by default
-        unshift!(stmts, Expr(:inbounds, false))
-        push!(stmts, Expr(:inbounds, :pop))
+        # avoid redundant inbounds annotations
+        s_1, s_end = stmts[1], stmts[end]
+        i = 2
+        while length(stmts) > i && ((isa(s_1,Expr)&&s_1.head===:line) || isa(s_1,LineNumberNode))
+            s_1 = stmts[i]
+            i += 1
+        end
+        if isa(s_1, Expr) && s_1.head === :inbounds && s_1.args[1] === false &&
+            isa(s_end, Expr) && s_end.head === :inbounds && s_end.args[1] === :pop
+        else
+            # inlined statements are out-of-bounds by default
+            unshift!(stmts, Expr(:inbounds, false))
+            push!(stmts, Expr(:inbounds, :pop))
+        end
     end
 
     if isa(expr,Expr)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2496,7 +2496,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
 
         islocal = false # if the argument name is also used as a local variable,
                         # we need to keep it as a variable name
-        if linfo.slotflags[i] != 0
+        if linfo.slotflags[i]&18 != 0
             islocal = true
             aeitype = tmerge(aeitype, linfo.slottypes[i])
         end

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -284,8 +284,9 @@ jl_value_t *jl_resolve_globals(jl_value_t *expr, jl_lambda_info_t *lam)
     else if (jl_is_expr(expr)) {
         jl_expr_t *e = (jl_expr_t*)expr;
         if (jl_is_toplevel_only_expr(expr) || e->head == const_sym || e->head == copyast_sym ||
-                 e->head == global_sym || e->head == quote_sym || e->head == inert_sym ||
-                 e->head == line_sym || e->head == meta_sym) {
+            e->head == global_sym || e->head == quote_sym || e->head == inert_sym ||
+            e->head == line_sym || e->head == meta_sym || e->head == inbounds_sym ||
+            e->head == boundscheck_sym || e->head == simdloop_sym) {
         }
         else {
             if (e->head == call_sym && jl_expr_nargs(e) == 3 && jl_is_quotenode(jl_exprarg(e,2)) &&

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3136,20 +3136,16 @@ f(x) = yt(x)
             ((implicit-global) #f)
             ((const) (emit e))
 
-            ;; metadata
-            ((inbounds)
-             ;; TODO: this should not be here but sometimes ends up in tail position, e.g.
-             ;; `f(x) = @inbounds return x`
-             (cond (tail  (emit-return e))
-                   (value e)
-                   (else  (emit e))))
             ;; top level expressions returning values
             ((abstract_type bits_type composite_type thunk toplevel module)
              (if tail (emit-return e) (emit e)))
             ;; other top level expressions and metadata
-            ((import importall using export line meta boundscheck simdloop)
-             (emit e)
-             (if tail (emit-return '(null)) '(null)))
+            ((import importall using export line meta inbounds boundscheck simdloop)
+             (let ((have-ret? (and (pair? code) (pair? (car code)) (eq? (caar code) 'return))))
+               (emit e)
+               (if (and tail (not have-ret?))
+                   (emit-return '(null)))
+               '(null)))
             ((...)
              (error "\"...\" expression outside call"))
             (else

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -226,7 +226,7 @@
                                    ,(resolve-expansion-vars-with-new-env (caddr arg) env m inarg))))
                              (else
                               `(global ,(resolve-expansion-vars-with-new-env arg env m inarg))))))
-           ((using import importall export meta) (map unescape e))
+           ((using import importall export meta line inbounds boundscheck simdloop) (map unescape e))
            ((macrocall)
             (if (or (eq? (cadr e) '@label) (eq? (cadr e) '@goto)) e
                 `(macrocall ,.(map (lambda (x)


### PR DESCRIPTION
The first commit deals with the following unnecessary temp var:

```
julia> code_typed(rand!, (Vector{Float64},))
1-element Array{Any,1}:
 LambdaInfo for rand!
:(begin  # random.jl, line 212:
        __temp__::Base.Random.#rand! = Base.Random.rand! # random.jl, line 327:
        return (__temp__::Base.Random.#rand!)(Base.Random.GLOBAL_RNG,A::Array{Float64,1},(Base.arraylen)(A::Array{Float64,1})::Int64,Base.Random.CloseOpen)::Array{Float64,1}
    end::Array{Float64,1})
```

This was spotted by @DrTodd13.

The next commits deal with several issues with very messy inbounds annotations that can be seen here:

```
julia> function f()
        r = rand()
       end
f (generic function with 1 method)

julia> @code_typed f()
1-element Array{Any,1}:
 LambdaInfo for f
:(begin  # REPL[1], line 2:
        $(Expr(:inbounds, false)) # random.jl, line 206:
        $(Expr(:inbounds, false)) # random.jl, line 101:
        $(Expr(:inbounds, false)) # random.jl, line 90:
        unless ((top(getfield))(Base.Random.GLOBAL_RNG,:idx)::Int64 === (Base.box)(Int64,(Base.sext_int)(Int64,Base.Random.MTCacheLength)))::Bool goto 16 # random.jl, line 86:
        (Base.Random.dsfmt_fill_array_close1_open2!)((top(getfield))(Base.Random.GLOBAL_RNG,:state)::Base.dSFMT.DSFMT_state,(top(ccall))(:jl_array_ptr,(top(apply_type))(Base.Ptr,Float64)::Type{Ptr{Float64}},(top(svec))(Base.Any)::SimpleVector,(top(getfield))(Base.Random.GLOBAL_RNG,:vals)::Array{Float64,1},0)::Ptr{Float64},(Base.arraylen)((top(getfield))(Base.Random.GLOBAL_RNG,:vals)::Array{Float64,1})::Int64)::Void # random.jl, line 87: # random.jl, line 81:
        (top(setfield!))(Base.Random.GLOBAL_RNG,:idx,0)::Int64
        __temp__@_3::Union{Bool,Int64} = 0
        goto 18
        16: 
        __temp__@_3::Union{Bool,Int64} = false
        18: 
        $(Expr(:inbounds, :pop))
        __temp__@_3::Union{Bool,Int64}
        $(Expr(:inbounds, false)) # random.jl, line 97:
        $(Expr(:inbounds, false)) # random.jl, line 96:
        $(Expr(:inbounds, false)) # random.jl, line 83:
        $(Expr(:inbounds, true))
        GenSym(1) = (Base.box)(Int64,(Base.add_int)((top(getfield))(Base.Random.GLOBAL_RNG,:idx)::Int64,1))
        (top(setfield!))(Base.Random.GLOBAL_RNG,:idx,GenSym(1))::Int64
        __temp__@_4::Float64 = (Base.arrayref)((top(getfield))(Base.Random.GLOBAL_RNG,:vals)::Array{Float64,1},GenSym(1))::Float64
        goto 33
        __temp__@_4::Float64 = $(Expr(:inbounds, :((top(getfield))(Base,:pop))))
        33: 
        $(Expr(:inbounds, :pop))
        $(Expr(:inbounds, :pop))
        $(Expr(:inbounds, :pop))
        $(Expr(:inbounds, :pop))
        $(Expr(:inbounds, :pop))
        GenSym(0) = (Base.box)(Base.Float64,(Base.sub_float)(__temp__@_4::Float64,1.0))
        r::Float64 = GenSym(0)
        return GenSym(0)
    end::Float64)
```

After my changes:

```
julia> @code_typed f()
1-element Array{Any,1}:
 LambdaInfo for f
:(begin  # REPL[2], line 2: # random.jl, line 206: # random.jl, line 101:
        $(Expr(:inbounds, false)) # random.jl, line 90:
        unless ((top(getfield))(Base.Random.GLOBAL_RNG,:idx)::Int64 === (Base.box)(Int64,(Base.sext_int)(Int64,Base.Random.MTCacheLength)))::Bool goto 14 # random.jl, line 86:
        (Base.Random.dsfmt_fill_array_close1_open2!)((top(getfield))(Base.Random.GLOBAL_RNG,:state)::Base.dSFMT.DSFMT_state,(top(ccall))(:jl_array_ptr,(top(apply_type))(Base.Ptr,Float64)::Type{Ptr{Float64}},(top(svec))(Base.Any)::SimpleVector,(top(getfield))(Base.Random.GLOBAL_RNG,:vals)::Array{Float64,1},0)::Ptr{Float64},(Base.arraylen)((top(getfield))(Base.Random.GLOBAL_RNG,:vals)::Array{Float64,1})::Int64)::Void # random.jl, line 87: # random.jl, line 81:
        (top(setfield!))(Base.Random.GLOBAL_RNG,:idx,0)::Int64
        __temp__@_3::Union{Bool,Int64} = 0
        goto 16
        14: 
        __temp__@_3::Union{Bool,Int64} = false
        16: 
        $(Expr(:inbounds, :pop))
        __temp__@_3::Union{Bool,Int64} # random.jl, line 97: # random.jl, line 96:
        $(Expr(:inbounds, false)) # random.jl, line 83:
        $(Expr(:inbounds, true))
        GenSym(1) = (Base.box)(Int64,(Base.add_int)((top(getfield))(Base.Random.GLOBAL_RNG,:idx)::Int64,1))
        (top(setfield!))(Base.Random.GLOBAL_RNG,:idx,GenSym(1))::Int64
        __temp__@_4::Float64 = (Base.arrayref)((top(getfield))(Base.Random.GLOBAL_RNG,:vals)::Array{Float64,1},GenSym(1))::Float64
        goto 29
        $(Expr(:inbounds, :pop))
        29: 
        $(Expr(:inbounds, :pop))
        GenSym(0) = (Base.box)(Base.Float64,(Base.sub_float)(__temp__@_4::Float64,1.0))
        r::Float64 = GenSym(0)
        return GenSym(0)
    end::Float64)
```
