### PR TITLE
Corrected typo

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -48,7 +48,7 @@ certain blocks.
 Julia uses `lexical scoping <https://en.wikipedia.org/wiki/Scope_%28computer_science%29#Lexical_scoping_vs._dynamic_scoping>`_,
 meaning that a function's scope does not inherit from its caller's
 scope, but from the scope in which the function was defined.
-For example, in the following code the ``x`` inside ``foo`` is refers
+For example, in the following code the ``x`` inside ``foo`` refers
 to the ``x`` in the global scope of its module ``Bar``::
 
     module Bar


### PR DESCRIPTION
```foo`` is refers to...` was corrected to ```foo`` refers to...`
