### PR TITLE
RFC: Enable threading build by default, but with only 1 thread

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -869,7 +869,7 @@ UNTRUSTED_SYSTEM_LIBM := 1
 endif
 
 # Threads
-ifeq ($(JULIA_THREADS), 1)
+ifneq ($(JULIA_THREADS), 0)
 JCPPFLAGS += -DJULIA_ENABLE_THREADING
 endif
 

--- a/src/options.h
+++ b/src/options.h
@@ -97,7 +97,7 @@
 
 // defaults for # threads
 #define NUM_THREADS_NAME                "JULIA_NUM_THREADS"
-#define DEFAULT_NUM_THREADS             4
+#define DEFAULT_NUM_THREADS             1
 
 // affinitization behavior
 #define MACHINE_EXCLUSIVE_NAME          "JULIA_EXCLUSIVE"


### PR DESCRIPTION
unless you opt in to setting JULIA_NUM_THREADS
closes #15743 

Anything else I missed here? Let's see what kind of regressions this might bring:
`runbenchmarks(ALL, vs = "JuliaLang/julia:master")`
