### PR TITLE
Keep the llvmcall function in its parent module

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -774,8 +774,6 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             jl_error(stream.str().c_str());
         }
         f = m->getFunction(ir_name);
-
-        f->removeFromParent();
     }
     else {
         assert(isPtr);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4789,6 +4789,7 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
     // step 14, Apply LLVM level inlining
     for(std::vector<CallInst*>::iterator it = ctx.to_inline.begin(); it != ctx.to_inline.end(); ++it) {
         Function *inlinef = (*it)->getCalledFunction();
+        assert(inlinef->getParent());
         InlineFunctionInfo info;
         if (!InlineFunction(*it,info))
             jl_error("Inlining Pass failed");

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -167,3 +167,16 @@ module ObjLoadTest
     do_the_call()
     @test didcall
 end
+
+# Test for proper parenting
+let
+    function foo()
+        # this IR snippet triggers an optimization relying
+        # on the llvmcall function having a parent module
+        Base.llvmcall(
+         """%1 = getelementptr i64, i64* null, i64 1
+            ret void""",
+        Void, Tuple{})
+    end
+    code_llvm(DevNull, foo, ())
+end


### PR DESCRIPTION
Certain LLVM optimizations don't expect a parentless function, causing a segfault when inlining the llvmcall function.

Specific case I ran into: during inlining, `SimplifyInstruction` is called on the inlined function's instructions, passing along the module's data layout. The llvmcall function not having a parent, this DL is invalid, and causes a nullptr deref later on.

@Keno: I'm not sure why you added this in 3a1d2f7e5e936aede75518820fc5e186ee66ac61? Keeping the llvmcall body in `jl_Module` instead seems to work fine, and the function is still removed when inlining succeeds.
