### PR TITLE
Extend code_* reflection methods to accept function types

### DIFF
--- a/doc/devdocs/reflection.rst
+++ b/doc/devdocs/reflection.rst
@@ -112,15 +112,34 @@ variable assignments:
 
 Inspecting the lowered form for functions requires selection of the specific method to display,
 because generic functions may have many methods with different type signatures. For this purpose,
-method-specific code-lowering is available using :func:`code_lowered(f::Function, (Argtypes...)) <code_lowered>`,
-and the type-inferred form is available using :func:`code_typed(f::Function, (Argtypes...)) <code_typed>`.
-:func:`code_warntype(f::Function, (Argtypes...)) <code_warntype>` adds
+method-specific code-lowering is available using :func:`code_lowered(f, (Argtypes...)) <code_lowered>`,
+and the type-inferred form is available using :func:`code_typed(f, (Argtypes...)) <code_typed>`.
+:func:`code_warntype(f, (Argtypes...)) <code_warntype>` adds
 highlighting to the output of :func:`code_typed` (see :ref:`man-code-warntype`).
 
 Closer to the machine, the LLVM intermediate representation of a function may be printed using by
-:func:`code_llvm(f::Function, (Argtypes...)) <code_llvm>`, and finally the compiled machine code is
-available using :func:`code_native(f::Function, (Argtypes...) <code_native>` (this will trigger JIT
+:func:`code_llvm(f, (Argtypes...)) <code_llvm>`, and finally the compiled machine code is
+available using :func:`code_native(f, (Argtypes...) <code_native>` (this will trigger JIT
 compilation/code generation for any function which has not previously been called).
+
+In order to specify the function whose code you want to inspect, you can either pass a
+:obj:`Function` object (eg. by spelling out the function's name), or pass its type. The
+latter is especially handy for generated functions::
+
+.. doctest::
+
+   julia> foo() = println("hello")
+   foo (generic function with 1 method)
+
+   julia> @generated bar(ft) = code_lowered(ft, ())
+   bar (generic function with 1 method)
+
+   julia> bar(foo)
+   1-element Array{Any,1}:
+    LambdaInfo for foo
+   :(begin  # REPL[1], line 1:
+           return (Main.println)("hello")
+       end)
 
 For convenience, there are macro versions of the above functions which take standard function calls
 and expand argument types automatically::

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -21,6 +21,10 @@ end
 function test_code_reflection(freflect, f, types, tester)
     tester(freflect, f, types)
     tester(freflect, f, (types.parameters...))
+    if !isa(f, Type)
+        tester(freflect, typeof(f), types)
+        tester(freflect, typeof(f), (types.parameters...))
+    end
 end
 
 function test_code_reflections(tester, freflect)


### PR DESCRIPTION
This is useful for `@generated` functions, and necessary for functions where it's impossible to get an instance from its type (ie. closures):

``` julia
# create a closure
function foo()
    i = 10
    f = function bar()
        println(i)
        i -= 1
    end
    return f
end
f = foo()

println(code_typed(f, ()))

@generated function bar(ft)
    println(code_typed(ft, ()))

    # before this PR, we'd have to convert ft->f
    # which doesn't always work
    f = ft.instance
    code_typed(f, ())
end
bar(f)
```

I'm not sure about the `code_lowered(Module, ())` case though, which cannot work if passing a `typeof` instead.
