### PR TITLE
Fix stack overflow in unsafe_convert, eliminate ambiguity-causing methods

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -96,11 +96,8 @@ function reinterpret{T,S,N}(::Type{T}, a::Array{S}, dims::NTuple{N,Int})
     ccall(:jl_reshape_array, Array{T,N}, (Any, Any, Any), Array{T,N}, a, dims)
 end
 
-reshape(a::Vector, dims::Tuple{Int}) = reshape_a(a, dims)
-reshape{N}(a::Array, dims::NTuple{N,Int}) = reshape_a(a, dims)
-
 # reshaping to same # of dimensions
-function reshape_a{T,N}(a::Array{T,N}, dims::NTuple{N,Int})
+function reshape{T,N}(a::Array{T,N}, dims::NTuple{N,Int})
     if prod(dims) != length(a)
         throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(length(a))"))
     end
@@ -111,7 +108,7 @@ function reshape_a{T,N}(a::Array{T,N}, dims::NTuple{N,Int})
 end
 
 # reshaping to different # of dimensions
-function reshape_a{T,N}(a::Array{T}, dims::NTuple{N,Int})
+function reshape{T,N}(a::Array{T}, dims::NTuple{N,Int})
     if prod(dims) != length(a)
         throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(length(a))"))
     end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -463,11 +463,7 @@ function copy!(dest::BitArray, src::Array)
     return unsafe_copy!(dest, 1, src, 1, length(src))
 end
 
-reshape(B::BitVector, dims::Tuple{Int}) = reshape_ba(B, dims)
-reshape(B::BitArray,  dims::Tuple{Int}) = reshape_ba(B, dims)
-reshape{N}(B::BitArray, dims::NTuple{N,Int}) = reshape_ba(B, dims)
-
-function reshape_ba{N}(B::BitArray, dims::NTuple{N,Int})
+function reshape{N}(B::BitArray, dims::NTuple{N,Int})
     prod(dims) == length(B) ||
         throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(length(B))"))
     dims == size(B) && return B

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -27,6 +27,7 @@ cconvert(::Type{Ptr{Int8}}, s::AbstractString) = bytestring(s)
 
 unsafe_convert{T}(::Type{Ptr{T}}, a::Array{T}) = ccall(:jl_array_ptr, Ptr{T}, (Any,), a)
 unsafe_convert{S,T}(::Type{Ptr{S}}, a::AbstractArray{T}) = convert(Ptr{S}, unsafe_convert(Ptr{T}, a))
+unsafe_convert{T}(::Type{Ptr{T}}, a::AbstractArray{T}) = error("conversion to pointer not defined for $(typeof(a))")
 
 # unsafe pointer to array conversions
 function pointer_to_array{T}(p::Ptr{T}, d::Integer, own::Bool=false)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -140,10 +140,4 @@ setindex!(A::ReshapedRange, val, index::ReshapedIndex) = _rs_setindex!_err()
 
 _rs_setindex!_err() = error("indexed assignment fails for a reshaped range; consider calling collect")
 
-typealias ArrayT{N, T} Array{T,N}
-convert{T,S,N}(::Type{Array{T,N}}, V::ReshapedArray{S,N}) = copy!(Array(T, size(V)), V)
-convert{T,N}(::Type{ArrayT{N}}, V::ReshapedArray{T,N}) = copy!(Array(T, size(V)), V)
-
 unsafe_convert{T}(::Type{Ptr{T}}, a::ReshapedArray{T}) = unsafe_convert(Ptr{T}, parent(a))
-unsafe_convert{T,N,P<:ReshapedArray,I<:Tuple{Vararg{Union{RangeIndex, NoSlice}}}}(::Type{Ptr{T}}, V::SubArray{T,N,P,I}) =
-    unsafe_convert(Ptr{T}, V.parent) + (first_index(V)-1)*sizeof(T)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -34,23 +34,25 @@ start(R::ReshapedArrayIterator) = start(R.iter)
 end
 length(R::ReshapedArrayIterator) = length(R.iter)
 
-function reshape(parent::AbstractArray, dims::Dims)
+reshape(parent::AbstractArray, dims::Dims) = _reshape(parent, dims)
+reshape(parent::AbstractArray, len::Integer) = reshape(parent, (Int(len),))
+reshape(parent::AbstractArray, dims::Int...) = reshape(parent, dims)
+
+function _reshape(parent::AbstractArray, dims::Dims)
     prod(dims) == length(parent) || throw(DimensionMismatch("parent has $(length(parent)) elements, which is incompatible with size $dims"))
-    _reshape((parent, linearindexing(parent)), dims)
+    __reshape((parent, linearindexing(parent)), dims)
 end
-reshape(R::ReshapedArray, dims::Dims) = reshape(R.parent, dims)
-reshape(a::AbstractArray, len::Int) = reshape(a, (len,))
-reshape(a::AbstractArray, dims::Int...) = reshape(a, dims)
+_reshape(R::ReshapedArray, dims::Dims) = _reshape(R.parent, dims)
 
 # When reshaping Vector->Vector, don't wrap with a ReshapedArray
-reshape{T}(v::ReshapedArray{T,1}, dims::Tuple{Int}) = reshape(v.parent, dims[1])
-reshape(v::AbstractVector, dims::Tuple{Int}) = reshape(v, dims[1])
-function reshape(v::AbstractVector, len::Int)
+_reshape{T}(v::ReshapedArray{T,1}, dims::Tuple{Int}) = _reshape(v.parent, dims)
+function _reshape(v::AbstractVector, dims::Tuple{Int})
+    len = dims[1]
     len == length(v) || throw(DimensionMismatch("parent has $(length(v)) elements, which is incompatible with length $len"))
     v
 end
 
-function _reshape(p::Tuple{AbstractArray,LinearSlow}, dims::Dims)
+function __reshape(p::Tuple{AbstractArray,LinearSlow}, dims::Dims)
     parent = p[1]
     strds = front(size_strides(parent))
     strds1 = map(s->max(1,s), strds)  # for resizing empty arrays
@@ -58,7 +60,7 @@ function _reshape(p::Tuple{AbstractArray,LinearSlow}, dims::Dims)
     ReshapedArray(parent, dims, reverse(mi))
 end
 
-function _reshape(p::Tuple{AbstractArray,LinearFast}, dims::Dims)
+function __reshape(p::Tuple{AbstractArray,LinearFast}, dims::Dims)
     parent = p[1]
     ReshapedArray(parent, dims, ())
 end

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -236,11 +236,7 @@ length(S::SharedArray) = prod(S.dims)
 size(S::SharedArray) = S.dims
 linearindexing{S<:SharedArray}(::Type{S}) = LinearFast()
 
-reshape(a::SharedVector, dims::Tuple{Int}) = reshape_sa(a, dims)
-reshape(a::SharedArray,  dims::Tuple{Int}) = reshape_sa(a, dims)
-reshape{N}(a::SharedArray, dims::NTuple{N,Int}) = reshape_sa(a, dims)
-
-function reshape_sa{T,N}(a::SharedArray{T}, dims::NTuple{N,Int})
+function reshape{T,N}(a::SharedArray{T}, dims::NTuple{N,Int})
     (length(a) != prod(dims)) && throw(DimensionMismatch("dimensions must be consistent with array size"))
     refs = Array(Future, length(a.pids))
     for (i, p) in enumerate(a.pids)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -439,8 +439,6 @@ similar(S::SharedArray, T) = similar(S.s, T, size(S))
 similar(S::SharedArray, dims::Dims) = similar(S.s, eltype(S), dims)
 similar(S::SharedArray) = similar(S.s, eltype(S), size(S))
 
-map(f, S::SharedArray) = (S2 = similar(S); S2[:] = S[:]; map!(f, S2); S2)
-
 reduce(f, S::SharedArray) =
     mapreduce(fetch, f,
               Any[ @spawnat p reduce(f, S.loc_subarr_1d) for p in procs(S) ])

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -262,7 +262,7 @@ compute_first_index(f, s, parent, dim, I::Tuple{Any, Vararg{Any}}) =
 compute_first_index(f, s, parent, dim, I::Tuple{}) = f
 
 
-unsafe_convert{T,N,P<:Array,I<:Tuple{Vararg{Union{RangeIndex, NoSlice}}}}(::Type{Ptr{T}}, V::SubArray{T,N,P,I}) =
+unsafe_convert{T,N,P,I<:Tuple{Vararg{Union{RangeIndex, NoSlice}}}}(::Type{Ptr{T}}, V::SubArray{T,N,P,I}) =
     unsafe_convert(Ptr{T}, V.parent) + (first_index(V)-1)*sizeof(T)
 
 pointer(V::FastSubArray, i::Int) = pointer(V.parent, V.first_index + V.stride1*(i-1))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -87,8 +87,23 @@ a = reshape(b, (2, 2, 2, 2, 2))
 @test a[2,1,2,2,1] == b[14]
 @test a[2,2,2,2,2] == b[end]
 
-# reshaping linearslow arrays
 a = collect(reshape(1:5, 1, 5))
+# reshaping linearfast SubArrays
+s = sub(a, :, 2:4)
+r = reshape(s, (length(s),))
+@test length(r) == 3
+@test r[1] == 2
+@test r[3,1] == 4
+@test r[Base.ReshapedIndex(CartesianIndex((1,2)))] == 3
+@test parent(reshape(r, (1,3))) === r.parent === s
+@test parentindexes(r) == (1:1, 1:3)
+@test reshape(r, (3,)) === r
+@test convert(Array{Int,1}, r) == [2,3,4]
+@test_throws MethodError convert(Array{Int,2}, r)
+@test convert(Array{Int}, r) == [2,3,4]
+@test Base.unsafe_convert(Ptr{Int}, r) == Base.unsafe_convert(Ptr{Int}, s)
+
+# reshaping linearslow SubArrays
 s = sub(a, :, [2,3,5])
 r = reshape(s, length(s))
 @test length(r) == 3
@@ -98,6 +113,10 @@ r = reshape(s, length(s))
 @test parent(reshape(r, (1,3))) === r.parent === s
 @test parentindexes(r) == (1:1, 1:3)
 @test reshape(r, (3,)) === r
+@test convert(Array{Int,1}, r) == [2,3,5]
+@test_throws MethodError convert(Array{Int,2}, r)
+@test convert(Array{Int}, r) == [2,3,5]
+@test_throws ErrorException Base.unsafe_convert(Ptr{Int}, r)
 r[2] = -1
 @test a[3] == -1
 a = zeros(0, 5)  # an empty linearslow array

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -909,4 +909,3 @@ for tid in [id_other, id_me, Base.default_worker_pool()]
     test_f_args(13, f_args, tid, 1; kw1=4, kw2=8)
     test_f_args(15, f_args, tid, 1, 2; kw1=4, kw2=8)
 end
-


### PR DESCRIPTION
Master:

``` jl
julia> a = collect(1:5)
5-element Array{Int64,1}:
 1
 2
 3
 4
 5

julia> b = sub(a, 2:4)
3-element SubArray{Int64,1,Array{Int64,1},Tuple{UnitRange{Int64}},true}:
 2
 3
 4

julia> Base.unsafe_convert(Ptr{Int}, b)
Ptr{Int64} @0x00007fd73feaba58

julia> c = sub(a, [2,3,5])
3-element SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}:
 2
 3
 5

julia> Base.unsafe_convert(Ptr{Int}, c)
ERROR: StackOverflowError:
 in unsafe_convert(::Type{Ptr{Int64}}, ::SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}) at ./pointer.jl:0
 in unsafe_convert(::Type{Ptr{Int64}}, ::SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}) at ./pointer.jl:29 (repeats 79995 times)
```

This PR:

``` jl
julia> Base.unsafe_convert(Ptr{Int}, c)
ERROR: conversion to pointer not defined for SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}
 in error(::ASCIIString) at ./error.jl:21
 [inlined code] from ./strings/io.jl:53
 in unsafe_convert(::Type{Ptr{Int64}}, ::SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}) at ./pointer.jl:30
 in eval(::Module, ::Any) at ./boot.jl:236
```

This also eliminates some unnecessary methods for `ReshapedArrays` to avoid ambiguity warnings in packages.
