### PR TITLE
inference of splatting constant containers

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -47,6 +47,9 @@ end
 
 isassigned{N}(B::BitArray{N}, i::Int) = 1 <= i <= length(B)
 
+# Traits for linear indexing
+linearindexing{A<:BitArray}(::Type{A}) = LinearFast()
+
 ## aux functions ##
 
 const _msk64 = ~UInt64(0)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -7,6 +7,14 @@ const Bottom = Union{}
 abstract AbstractSet{T}
 abstract Associative{K,V}
 
+const (<:) = issubtype
+
+==(x,y) = x === y
+!=(x,y) = !(x==y)
+!==(x,y) = !(x===y)
+
+supertype(T::DataType) = T.super
+
 # The real @inline macro is not available until after array.jl, so this
 # internal macro splices the meta Expr directly into the function body.
 macro _inline_meta()

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -873,8 +873,10 @@ function precise_container_types(args, types, vtypes::VarTable, sv)
         ai = args[i]
         ti = types[i]
         tti = widenconst(ti)
-        if isa(ai,Expr) && ai.head === :call && (abstract_evals_to_constant(ai.args[1], svec, vtypes, sv) ||
-                                                 abstract_evals_to_constant(ai.args[1], tuple, vtypes, sv))
+        if isa(ti, Const) && (isa(ti.val, SimpleVector) || isa(ti.val, Tuple))
+            result[i] = Any[ abstract_eval_constant(x) for x in ti.val ]
+        elseif isa(ai,Expr) && ai.head === :call && (abstract_evals_to_constant(ai.args[1], svec, vtypes, sv) ||
+                                                     abstract_evals_to_constant(ai.args[1], tuple, vtypes, sv))
             aa = ai.args
             result[i] = Any[ (isa(aa[j],Expr) ? aa[j].typ : abstract_eval(aa[j],vtypes,sv)) for j=2:length(aa) ]
             if _any(isvarargtype, result[i])

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2333,7 +2333,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
         if (is(f,apply_type) || is(f,fieldtype) || is(f,typeof) ||
             istopfunction(topmod, f, :typejoin) ||
             istopfunction(topmod, f, :promote_type))
-            if effect_free(argexprs[2], sv, true)
+            if length(argexprs) < 2 || effect_free(argexprs[2], sv, true)
                 return (e.typ.parameters[1],())
             else
                 return (e.typ.parameters[1], Any[argexprs[2]])

--- a/base/int.jl
+++ b/base/int.jl
@@ -190,6 +190,9 @@ trailing_ones(x::Integer) = trailing_zeros(~x)
 
 ## integer conversions ##
 
+# Int32 with Int64 promotion needed early
+promote_rule{T<:Union{Int8,Int16,Int32}}(::Type{Int64}, ::Type{T}) = Int64
+
 for to in BitInteger_types, from in (BitInteger_types...,Bool)
     if !(to === from)
         if to.size < from.size
@@ -290,7 +293,6 @@ promote_rule(::Type{Int8}, ::Type{Int16})   = Int16
 promote_rule(::Type{UInt8}, ::Type{UInt16}) = UInt16
 promote_rule{T<:Union{Int8,Int16}}(::Type{Int32}, ::Type{T})    = Int32
 promote_rule{T<:Union{UInt8,UInt16}}(::Type{UInt32}, ::Type{T}) = UInt32
-promote_rule{T<:Union{Int8,Int16,Int32}}(::Type{Int64}, ::Type{T})     = Int64
 promote_rule{T<:Union{UInt8,UInt16,UInt32}}(::Type{UInt64}, ::Type{T}) = UInt64
 promote_rule{T<:BitSigned64}(::Type{Int128}, ::Type{T})    = Int128
 promote_rule{T<:BitUnsigned64}(::Type{UInt128}, ::Type{T}) = UInt128

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -10,9 +10,6 @@ using Base: LinearFast, LinearSlow, AbstractCartesianIndex, fill_to_length, tail
 
 export CartesianIndex, CartesianRange
 
-# Traits for linear indexing
-linearindexing{A<:BitArray}(::Type{A}) = LinearFast()
-
 # CartesianIndex
 immutable CartesianIndex{N} <: AbstractCartesianIndex{N}
     I::NTuple{N,Int}

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1,14 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-## types ##
-
-const (<:) = issubtype
-
-supertype(T::DataType) = T.super
-
 ## generic comparison ##
 
-==(x, y) = x === y
 isequal(x, y) = x == y
 
 ## minimally-invasive changes to test == causing NotComparableError
@@ -45,10 +38,8 @@ end
 
 ## comparison fallbacks ##
 
-!=(x,y) = !(x==y)
 const ≠ = !=
 const ≡ = is
-!==(x,y) = !is(x,y)
 const ≢ = !==
 
 <(x,y) = isless(x,y)

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -252,3 +252,10 @@ end
 let g() = Int <: Real ? 1 : ""
     @test Base.return_types(g, Tuple{}) == [Int]
 end
+
+# issue #10880
+function cat10880(a, b)
+    Tuple{a.parameters..., b.parameters...}
+end
+@test Base.return_types(cat10880, Tuple{Type{Tuple{Int8,Int16}},Type{Tuple{Int32}}})[1] ==
+    Type{Tuple{Int8,Int16,Int32}}


### PR DESCRIPTION
I noticed a bunch of errors during bootstrap, such as `<: not defined` while trying to pure_eval_call `typejoin`, and some other similar issues. I also hit a problem due to the linearindexing trait of BitArray being defined way, way later than the type itself.
