### PR TITLE
RFC: Use realpath() when checking if precompiled modules have moved

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -547,7 +547,7 @@ function stale_cachefile(modpath, cachefile)
             return true # invalid cache file
         end
         modules, files = cache_dependencies(io)
-        if files[1][1] != modpath
+        if realpath(files[1][1]) != realpath(modpath)
             return true # cache file was compiled from a different path
         end
         for (f,ftime) in files

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -30,3 +30,49 @@ let paddedname = "Ztest_sourcepath.jl"
     filename = SubString(paddedname, 2, length(paddedname))
     @test Base.find_in_path(filename) == abspath(paddedname[2:end])
 end
+
+# Verify that a symlink to a module does not result in that module being
+# recompiled unnecessarily (see Issue #16007).
+@unix_only let original_dir = mktempdir()
+    new_dir = mktempdir()
+    try
+        # To test this, we create a new empty module called SymlinkPrecompileTest
+        # which will live inside a temporary folder.
+        pkg_dir = joinpath(original_dir, "SymlinkPrecompileTest")
+        mkdir(pkg_dir)
+        src_dir = joinpath(pkg_dir, "src")
+        mkdir(src_dir)
+
+        # The module code contains an explicit __precompile__ directive:
+        open(joinpath(src_dir, "SymlinkPrecompileTest.jl"), "w") do f
+            write(f, """
+            __precompile__(true)
+            module SymlinkPrecompileTest
+            end
+            """)
+        end
+
+        # Now we spawn a new julia process, with our module available on the
+        # LOAD_PATH. This will trigger precompilation of the module.
+        run(`$(JULIA_HOME)/julia -e "unshift!(LOAD_PATH, \"$(original_dir)\"); using SymlinkPrecompileTest"`)
+
+        # We can verify that the module was compiled and store the timestamp of the
+        # cache file.
+        cache_path = joinpath(Base.LOAD_CACHE_PATH[1], "SymlinkPrecompileTest.ji")
+        @test Base.isfile(cache_path)
+        cache_modification_time = mtime(cache_path)
+
+        # Now we create a new directory and symlink our module's folder into that
+        # directory
+        symlink(pkg_dir, joinpath(new_dir, "SymlinkPrecompileTest"))
+
+        # Running julia with the new directory in LOAD_PATH should *not* trigger
+        # recompilation of the module, so the cache file's modification time should
+        # not change.
+        run(`$(JULIA_HOME)/julia -e "unshift!(LOAD_PATH, \"$(new_dir)\"); using SymlinkPrecompileTest"`)
+        @test mtime(cache_path) == cache_modification_time
+    finally
+        rm(original_dir, recursive=true)
+        rm(new_dir, recursive=true)
+    end
+end


### PR DESCRIPTION
I brought this up in #16007 and figured I would open a PR to show what the solution looks like. In summary: I think that loading a symlink to a precompiled module should not trigger recompilation, as long as the canonical path of the module has not changed. This PR fixes the issue and adds a test to verify the fix. 

I'd appreciate input on this, specifically: 
- are there edge cases in which a symlinked module definitely _should_ force a recompilation? 
- is the test I've provided too brittle since, for example, it relies on the current way precompiled modules are named and stored in `LOAD_CACHE_PATH[1]/<modulename>.ji`?

Fixes #16007 
