### PR TITLE
Faster empty array creation

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -138,6 +138,7 @@ function getindex(T::Type, vals...)
     end
     return a
 end
+getindex(T::Type) = Array{T}(0)
 
 function getindex(::Type{Any}, vals::ANY...)
     a = Array(Any,length(vals))
@@ -146,6 +147,7 @@ function getindex(::Type{Any}, vals::ANY...)
     end
     return a
 end
+getindex(::Type{Any}) = Array{Any}(0)
 
 function fill!(a::Union{Array{UInt8}, Array{Int8}}, x::Integer)
     ccall(:memset, Ptr{Void}, (Ptr{Void}, Cint, Csize_t), a, x, length(a))


### PR DESCRIPTION
The splatting penalty strikes again. I'm hopeful this should solve a major julia-0.5 performance regression in the FixedPointNumbers tests (see Travis times with https://github.com/JeffBezanson/FixedPointNumbers.jl/pull/42).

Master:

``` jl
julia> using FixedPointNumbers, Base.Test

julia> @time include("ufixed.jl")
 27.989304 seconds (32.03 M allocations: 1.601 GB, 1.25% gc time)
Test Passed
  Expression: prod(a,1) == [acmp]
   Evaluated: [7.68002] == [7.68002]
```

This PR:

``` jl
julia> @time include("ufixed.jl")
  8.070790 seconds (32.06 M allocations: 1.602 GB, 3.97% gc time)
Test Passed
  Expression: prod(a,1) == [acmp]
   Evaluated: [7.68002] == [7.68002]
```

More generally, creating an empty array with the `T[]` syntax is very widespread, so I think this is generally worthwhile.
