### PR TITLE
Use × instead of x when printing array dimensions, continued

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -235,22 +235,22 @@ kw"quote"
 `'` is the conjugate transposition operator:
 
     julia> A = reshape(1:4, 2,2)
-    2x2 Array{Int64,2}:
+    2×2 Array{Int64,2}:
      1  3
      2  4
 
     julia> A'
-    2x2 Array{Int64,2}:
+    2×2 Array{Int64,2}:
      1  2
      3  4
 
     julia> B = A + im
-    2x2 Array{Complex{Int64},2}:
+    2×2 Array{Complex{Int64},2}:
      1+1im  3+1im
      2+1im  4+1im
 
     julia> B'
-    2x2 Array{Complex{Int64},2}:
+    2×2 Array{Complex{Int64},2}:
      1-1im  2-1im
      3-1im  4-1im
 
@@ -262,22 +262,22 @@ kw"'"
 `.'` is the transposition operator:
 
     julia> A = reshape(1:4, 2,2)
-    2x2 Array{Int64,2}:
+    2×2 Array{Int64,2}:
      1  3
      2  4
 
     julia> A.'
-    2x2 Array{Int64,2}:
+    2×2 Array{Int64,2}:
      1  2
      3  4
 
     julia> B = A + im
-    2x2 Array{Complex{Int64},2}:
+    2×2 Array{Complex{Int64},2}:
      1+1im  3+1im
      2+1im  4+1im
 
     julia> B.'
-    2x2 Array{Complex{Int64},2}:
+    2×2 Array{Complex{Int64},2}:
      1+1im  2+1im
      3+1im  4+1im
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2657,7 +2657,7 @@ Example for a sparse 2-d array:
 
 ```jldoctest
 julia> A = sparse([1, 1, 2], [1, 3, 1], [1, 2, -5])
-2x3 sparse matrix with 3 Int64 entries:
+2×3 sparse matrix with 3 Int64 nonzero entries:
         [1, 1]  =  1
         [2, 1]  =  -5
         [1, 3]  =  2
@@ -3012,23 +3012,23 @@ julia> a, b, c, d, e, f = 1, 2, 3, 4, 5, 6
 (1,2,3,4,5,6)
 
 julia> [a b c; d e f]
-2x3 Array{Int64,2}:
+2×3 Array{Int64,2}:
  1  2  3
  4  5  6
 
 julia> hvcat((3,3), a,b,c,d,e,f)
-2x3 Array{Int64,2}:
+2×3 Array{Int64,2}:
  1  2  3
  4  5  6
 
 julia> [a b;c d; e f]
-3x2 Array{Int64,2}:
+3×2 Array{Int64,2}:
  1  2
  3  4
  5  6
 
 julia> hvcat((2,2,2), a,b,c,d,e,f)
-3x2 Array{Int64,2}:
+3×2 Array{Int64,2}:
  1  2
  3  4
  5  6
@@ -5339,7 +5339,7 @@ overwriting the existing value of `Y`. Note that `Y` must not be aliased with ei
 julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; Y = similar(B); A_mul_B!(Y, A, B);
 
 julia> Y
-2x2 Array{Float64,2}:
+2×2 Array{Float64,2}:
  3.0  3.0
  7.0  7.0
 ```
@@ -6295,7 +6295,7 @@ For example, `similar(1:10, 1, 4)` returns an uninitialized `Array{Int,2}` since
 neither mutable nor support 2 dimensions:
 
     julia> similar(1:10, 1, 4)
-    1x4 Array{Int64,2}:
+    1×4 Array{Int64,2}:
      4419743872  4374413872  4419743888  0
 
 Conversely, `similar(trues(10,10), 2)` returns an uninitialized `BitVector` with two
@@ -6310,7 +6310,7 @@ Since `BitArray`s can only store elements of type `Bool`, however, if you reques
 different element type it will create a regular `Array` instead:
 
     julia> similar(falses(10), Float64, 2, 4)
-    2x4 Array{Float64,2}:
+    2×4 Array{Float64,2}:
      2.18425e-314  2.18425e-314  2.18425e-314  2.18425e-314
      2.18425e-314  2.18425e-314  2.18425e-314  2.18425e-314
 """
@@ -9385,7 +9385,7 @@ isxdigit
 """
     fill(x, dims)
 
-Create an array filled with the value `x`. For example, `fill(1.0, (10,10))` returns a 10x10
+Create an array filled with the value `x`. For example, `fill(1.0, (10,10))` returns a 10×10
 array of floats, with each element initialized to `1.0`.
 
 If `x` is an object reference, all elements will refer to the same object. `fill(Foo(),
@@ -9974,7 +9974,7 @@ on the `permute` and `scale` keyword arguments. The eigenvectors are returned co
 ```jldoctest
 julia> eig([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
 ([1.0,3.0,18.0],
-3x3 Array{Float64,2}:
+3×3 Array{Float64,2}:
  1.0  0.0  0.0
  0.0  1.0  0.0
  0.0  0.0  1.0)

--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -267,7 +267,7 @@ function showfftdims(io, sz::Dims, istride::Dims, T)
     elseif length(sz) == 1
         print(io, sz[1], "-element")
     else
-        print(io, join(sz, "x"))
+        print(io, join(sz, "×"))
     end
     if istride == colmajorstrides(sz)
         print(io, " array of ", T)
@@ -310,7 +310,7 @@ function show{T,K,inplace}(io::IO, p::r2rFFTWPlan{T,K,inplace})
             print(io, "^", length(K))
         end
     else
-        print(io, join(map(kind2string, K), "x"))
+        print(io, join(map(kind2string, K), "×"))
     end
     print(io, " plan for ")
     showfftdims(io, p.sz, p.istride, T)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -80,7 +80,7 @@ function Base.showarray(io::IO, S::SparseMatrixCSC;
                    header::Bool=true, repr=false)
     # TODO: repr?
     if header
-        print(io, S.m, "x", S.n, " sparse matrix with ", nnz(S), " ", eltype(S), " entries:")
+        print(io, S.m, "×", S.n, " sparse matrix with ", nnz(S), " ", eltype(S), " nonzero entries:")
     end
 
     limit::Bool = Base.limit_output(io)

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -636,7 +636,7 @@ function showarray(io::IO, x::AbstractSparseVector;
 end
 
 function summary(x::AbstractSparseVector)
-    string("Sparse vector of length ", length(x), ", with ", length(nonzeros(x)),
+    string("Sparse vector of length ", length(x), " with ", length(nonzeros(x)),
            " ",  eltype(x), " nonzero entries:")
 end
 

--- a/doc/devdocs/subarrays.rst
+++ b/doc/devdocs/subarrays.rst
@@ -168,7 +168,7 @@ the size of the array.  It therefore can miss some cases in which the
 stride happens to be uniform::
 
  julia> A = reshape(1:4*2, 4, 2)
- 4x2 Array{Int64,2}:
+ 4×2 Array{Int64,2}:
   1  5
   2  6
   3  7
@@ -186,7 +186,7 @@ efficiently.  However, success in this case depends on the size of the
 array: if the first dimension instead were odd, ::
 
  julia> A = reshape(1:5*2, 5, 2)
- 5x2 Array{Int64,2}:
+ 5×2 Array{Int64,2}:
   1   6
   2   7
   3   8

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -148,11 +148,11 @@ the element type of the result.
 .. doctest::
 
     julia> [[1 2] [3 4]]
-    1x4 Array{Int64,2}:
+    1×4 Array{Int64,2}:
      1  2  3  4
 
     julia> Int8[[1 2] [3 4]]
-    1x4 Array{Int8,2}:
+    1×4 Array{Int8,2}:
      1  2  3  4
 
 .. _comprehensions:
@@ -294,14 +294,14 @@ Example:
 .. doctest::
 
     julia> x = reshape(1:16, 4, 4)
-    4x4 Array{Int64,2}:
+    4×4 Array{Int64,2}:
      1  5   9  13
      2  6  10  14
      3  7  11  15
      4  8  12  16
 
     julia> x[2:3, 2:end-1]
-    2x2 Array{Int64,2}:
+    2×2 Array{Int64,2}:
      6  10
      7  11
 
@@ -349,7 +349,7 @@ Example:
 .. doctest::
 
     julia> x = reshape(1:9, 3, 3)
-    3x3 Array{Int64,2}:
+    3×3 Array{Int64,2}:
      1  4  7
      2  5  8
      3  6  9
@@ -358,7 +358,7 @@ Example:
     -1
 
     julia> x
-    3x3 Array{Int64,2}:
+    3×3 Array{Int64,2}:
      1  -1  -1
      2  -1  -1
      3   6   9
@@ -475,7 +475,7 @@ the name of the function to vectorize. Here is a simple example:
     square(x) at none:1
 
     julia> square([1 2 4; 5 6 7])
-    2x3 Array{Int64,2}:
+    2×3 Array{Int64,2}:
       1   4  16
      25  36  49
 
@@ -492,7 +492,7 @@ vector to the size of the matrix:
     julia> a = rand(2,1); A = rand(2,3);
 
     julia> repmat(a,1,3)+A
-    2x3 Array{Float64,2}:
+    2×3 Array{Float64,2}:
      1.20813  1.82068  1.25387
      1.56851  1.86401  1.67846
 
@@ -505,16 +505,16 @@ function elementwise:
 .. doctest::
 
     julia> broadcast(+, a, A)
-    2x3 Array{Float64,2}:
+    2×3 Array{Float64,2}:
      1.20813  1.82068  1.25387
      1.56851  1.86401  1.67846
 
     julia> b = rand(1,2)
-    1x2 Array{Float64,2}:
+    1×2 Array{Float64,2}:
      0.867535  0.00457906
 
     julia> broadcast(+, a, b)
-    2x2 Array{Float64,2}:
+    2×2 Array{Float64,2}:
      1.71056  0.847604
      1.73659  0.873631
 
@@ -588,7 +588,7 @@ stride parameters.
 .. doctest::
 
     julia> a = rand(10,10)
-    10x10 Array{Float64,2}:
+    10×10 Array{Float64,2}:
      0.561255   0.226678   0.203391  0.308912   …  0.750307  0.235023   0.217964
      0.718915   0.537192   0.556946  0.996234      0.666232  0.509423   0.660788
      0.493501   0.0565622  0.118392  0.493498      0.262048  0.940693   0.252965
@@ -601,7 +601,7 @@ stride parameters.
      0.507762   0.573567   0.220124  0.165816      0.211049  0.433277   0.539476
 
     julia> b = sub(a, 2:2:8,2:2:4)
-    4x2 SubArray{Float64,2,Array{Float64,2},Tuple{StepRange{Int64,Int64},StepRange{Int64,Int64}},1}:
+    4×2 SubArray{Float64,2,Array{Float64,2},Tuple{StepRange{Int64,Int64},StepRange{Int64,Int64}},1}:
      0.537192  0.996234
      0.736979  0.228787
      0.991511  0.74485
@@ -610,14 +610,14 @@ stride parameters.
     julia> (q,r) = qr(b);
 
     julia> q
-    4x2 Array{Float64,2}:
+    4×2 Array{Float64,2}:
      -0.338809   0.78934
      -0.464815  -0.230274
      -0.625349   0.194538
      -0.527347  -0.534856
 
     julia> r
-    2x2 Array{Float64,2}:
+    2×2 Array{Float64,2}:
      -1.58553  -0.921517
       0.0       0.866567
 
@@ -686,10 +686,10 @@ you can use the same names with an ``sp`` prefix:
 .. doctest::
 
     julia> spzeros(3,5)
-    3x5 sparse matrix with 0 Float64 entries:
+    3×5 sparse matrix with 0 Float64 nonzero entries:
 
     julia> speye(3,5)
-    3x5 sparse matrix with 3 Float64 entries:
+    3×5 sparse matrix with 3 Float64 nonzero entries:
             [1, 1]  =  1.0
             [2, 2]  =  1.0
             [3, 3]  =  1.0
@@ -705,7 +705,7 @@ values. ``sparse(I,J,V)`` constructs a sparse matrix such that
     julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
     julia> S = sparse(I,J,V)
-    5x18 sparse matrix with 4 Int64 entries:
+    5×18 sparse matrix with 4 Int64 nonzero entries:
             [1 ,  4]  =  1
             [4 ,  7]  =  2
             [5 ,  9]  =  3
@@ -728,7 +728,7 @@ into a sparse matrix using the :func:`sparse` function:
 .. doctest::
 
     julia> sparse(eye(5))
-    5x5 sparse matrix with 5 Float64 entries:
+    5×5 sparse matrix with 5 Float64 nonzero entries:
             [1, 1]  =  1.0
             [2, 2]  =  1.0
             [3, 3]  =  1.0

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -405,7 +405,7 @@ It will be evaluated and returned depending on the preceding conditionals:
 .. doctest::
 
     julia> true && (x = rand(2,2))
-    2x2 Array{Float64,2}:
+    2×2 Array{Float64,2}:
      0.768448  0.673959
      0.940515  0.395453
 

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -213,7 +213,7 @@ and get a list of LaTeX matches as well::
 
     julia> e\^1[TAB] = [1 0]
     julia> e¹ = [1 0]
-    1x2 Array{Int64,2}:
+    1×2 Array{Int64,2}:
      1  0
 
     julia> \sqrt[TAB]2     # √ is equivalent to the sqrt() function

--- a/doc/manual/interfaces.rst
+++ b/doc/manual/interfaces.rst
@@ -83,7 +83,7 @@ Now, when we ask Julia to :func:`collect` all the elements into an array it can 
 .. doctest::
 
     julia> collect(Squares(100))' # transposed to save space
-    1x100 Array{Int64,2}:
+    1×100 Array{Int64,2}:
      1  4  9  16  25  36  49  64  81  100  …  9025  9216  9409  9604  9801  10000
 
 While we can rely upon generic implementations, we can also extend specific methods where we know there is a simpler algorithm.  For example, there's a formula to compute the sum of squares, so we can override the generic iterative version with a more performant solution:
@@ -209,7 +209,7 @@ Note that it's very important to specify the two parameters of the ``AbstractArr
      49
 
     julia> s \ rand(7,2)
-    1x2 Array{Float64,2}:
+    1×2 Array{Float64,2}:
      0.0151876  0.0179393
 
 As a more complicated example, let's define our own toy N-dimensional sparse-like array type built on top of ``Dict``:
@@ -239,19 +239,19 @@ Notice that this is a ``LinearSlow`` array, so we must manually define :func:`ge
 .. doctest::
 
     julia> A = SparseArray(Float64,3,3)
-    3x3 SparseArray{Float64,2}:
+    3×3 SparseArray{Float64,2}:
      0.0  0.0  0.0
      0.0  0.0  0.0
      0.0  0.0  0.0
 
     julia> rand!(A)
-    3x3 SparseArray{Float64,2}:
+    3×3 SparseArray{Float64,2}:
      0.28119   0.0203749  0.0769509
      0.209472  0.287702   0.640396
      0.251379  0.859512   0.873544
 
     julia> A[:] = 1:length(A); A
-    3x3 SparseArray{Float64,2}:
+    3×3 SparseArray{Float64,2}:
      1.0  4.0  7.0
      2.0  5.0  8.0
      3.0  6.0  9.0
@@ -261,7 +261,7 @@ The result of indexing an ``AbstractArray`` can itself be an array (for instance
 .. doctest::
 
     julia> A[1:2,:]
-    2x3 SparseArray{Float64,2}:
+    2×3 SparseArray{Float64,2}:
      1.0  4.0  7.0
      2.0  5.0  8.0
 
@@ -270,7 +270,7 @@ In this example it is accomplished by defining ``Base.similar{T}(A::SparseArray,
 .. doctest::
 
     julia> A + 4
-    3x3 SparseArray{Float64,2}:
+    3×3 SparseArray{Float64,2}:
      5.0   8.0  11.0
      6.0   9.0  12.0
      7.0  10.0  13.0

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -62,7 +62,7 @@ equal the number of CPU cores on the machine.
     Future(2,1,6,Nullable{Any}())
 
     julia> fetch(s)
-    2x2 Float64 Array:
+    2×2 Array{Float64,2}:
      1.60401  1.50111
      1.17457  1.15741
 
@@ -137,7 +137,7 @@ type the following into the Julia prompt::
            end
 
     julia> rand2(2,2)
-    2x2 Float64 Array:
+    2×2 Array{Float64,2}:
      0.153756  0.368514
      1.15119   0.918912
 
@@ -405,8 +405,8 @@ different sizes::
     M = Matrix{Float64}[rand(800,800), rand(600,600), rand(800,800), rand(600,600)]
     pmap(svd, M)
 
-If one process handles both 800x800 matrices and another handles both
-600x600 matrices, we will not get as much scalability as we could. The
+If one process handles both 800×800 matrices and another handles both
+600×600 matrices, we will not get as much scalability as we could. The
 solution is to make a local task to "feed" work to each process when
 it completes its current task. For example, consider a simple :func:`pmap`
 implementation::
@@ -578,7 +578,7 @@ Here's a brief example:
    4
 
   julia> S = SharedArray(Int, (3,4), init = S -> S[Base.localindexes(S)] = myid())
-  3x4 SharedArray{Int64,2}:
+  3×4 SharedArray{Int64,2}:
    2  2  3  4
    2  3  3  4
    2  3  4  4
@@ -587,7 +587,7 @@ Here's a brief example:
   7
 
   julia> S
-  3x4 SharedArray{Int64,2}:
+  3×4 SharedArray{Int64,2}:
    2  2  3  4
    2  3  3  4
    2  7  4  4
@@ -599,7 +599,7 @@ You can, of course, divide the work any way you wish:
 .. doctest::
 
   julia> S = SharedArray(Int, (3,4), init = S -> S[indexpids(S):length(procs(S)):length(S)] = myid())
-  3x4 SharedArray{Int64,2}:
+  3×4 SharedArray{Int64,2}:
    2  2  2  2
    3  3  3  3
    4  4  4  4

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -795,7 +795,7 @@ that the array is ordered ``[1 3 2 4]``, not ``[1 2 3 4]``):
 .. doctest::
 
     julia> x = [1 2; 3 4]
-    2x2 Array{Int64,2}:
+    2×2 Array{Int64,2}:
      1  2
      3  4
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -54,7 +54,7 @@ Basic functions
    .. doctest::
 
        julia> A = sparse([1, 1, 2], [1, 3, 1], [1, 2, -5])
-       2x3 sparse matrix with 3 Int64 entries:
+       2×3 sparse matrix with 3 Int64 nonzero entries:
                [1, 1]  =  1
                [2, 1]  =  -5
                [1, 3]  =  2
@@ -213,7 +213,7 @@ Constructors
 
    .. Docstring generated from Julia source
 
-   Create an array filled with the value ``x``\ . For example, ``fill(1.0, (10,10))`` returns a 10x10 array of floats, with each element initialized to ``1.0``\ .
+   Create an array filled with the value ``x``\ . For example, ``fill(1.0, (10,10))`` returns a 10×10 array of floats, with each element initialized to ``1.0``\ .
 
    If ``x`` is an object reference, all elements will refer to the same object. ``fill(Foo(), dims)`` will return an array filled with the result of evaluating ``Foo()`` once.
 
@@ -242,7 +242,7 @@ Constructors
    .. code-block:: julia
 
        julia> similar(1:10, 1, 4)
-       1x4 Array{Int64,2}:
+       1×4 Array{Int64,2}:
         4419743872  4374413872  4419743888  0
 
    Conversely, ``similar(trues(10,10), 2)`` returns an uninitialized ``BitVector`` with two elements since ``BitArray``\ s are both mutable and can support 1-dimensional arrays:
@@ -259,7 +259,7 @@ Constructors
    .. code-block:: julia
 
        julia> similar(falses(10), Float64, 2, 4)
-       2x4 Array{Float64,2}:
+       2×4 Array{Float64,2}:
         2.18425e-314  2.18425e-314  2.18425e-314  2.18425e-314
         2.18425e-314  2.18425e-314  2.18425e-314  2.18425e-314
 
@@ -421,23 +421,23 @@ Indexing, Assignment, and Concatenation
        (1,2,3,4,5,6)
 
        julia> [a b c; d e f]
-       2x3 Array{Int64,2}:
+       2×3 Array{Int64,2}:
         1  2  3
         4  5  6
 
        julia> hvcat((3,3), a,b,c,d,e,f)
-       2x3 Array{Int64,2}:
+       2×3 Array{Int64,2}:
         1  2  3
         4  5  6
 
        julia> [a b;c d; e f]
-       3x2 Array{Int64,2}:
+       3×2 Array{Int64,2}:
         1  2
         3  4
         5  6
 
        julia> hvcat((2,2,2), a,b,c,d,e,f)
-       3x2 Array{Int64,2}:
+       3×2 Array{Int64,2}:
         1  2
         3  4
         5  6

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -429,7 +429,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
        julia> eig([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
        ([1.0,3.0,18.0],
-       3x3 Array{Float64,2}:
+       3×3 Array{Float64,2}:
         1.0  0.0  0.0
         0.0  1.0  0.0
         0.0  0.0  1.0)

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -507,7 +507,7 @@ Mathematical Operators
        julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; Y = similar(B); A_mul_B!(Y, A, B);
 
        julia> Y
-       2x2 Array{Float64,2}:
+       2×2 Array{Float64,2}:
         3.0  3.0
         7.0  7.0
 


### PR DESCRIPTION
Commit bde452d (https://github.com/JuliaLang/julia/pull/15910) missed sparse matrices and docs. Also make sparse
array summary line closer to sparse matrices and other arrays.
By the way, fix very old docs in which the summary line for
standard arrays was out of date.

The new output for sparse vectors is:

``` julia
julia> sparse([1,2])
2-element sparse vector with 2 Int64 entries:
  [1]  =  1
  [2]  =  2
```

Compare with sparse matrix and standard vector:

``` julia
julia> sparse([1 2])
1×2 sparse matrix with 2 Int64 entries:
    [1, 1]  =  1
    [1, 2]  =  2

julia> [1,2]
2-element Array{Int64,1}:
 1
 2
```

We could imagine making the printing of sparse matrix/vector close to other arrays, e.g. `1×2 SparseMatrixCSC{Int64} with 2 entries:`.
