### PR TITLE
More aggressive allocation elimination.

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2430,7 +2430,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
             # argument tuple is not used as a whole, so convert function body
             # to one accepting the exact number of arguments we have.
             newnames = unique_names(ast,valen)
-            replace_getfield!(ast, body, vaname, newnames, sv, 1)
+            replace_getfield!(ast, body, vaname, newnames, sv)
             na = na-1+valen
 
             # if the argument name is also used as a local variable,
@@ -3039,7 +3039,7 @@ function remove_redundant_temp_vars(linfo, sa, T)
     gensym_types = linfo.gensymtypes
     bexpr = Expr(:block); bexpr.args = linfo.code
     for (v,init) in sa
-        if (isa(init, Slot) && !is_var_assigned(linfo, init))
+        if (isa(init, Slot) && !is_var_assigned(linfo, init::Slot))
             # this transformation is not valid for vars used before def.
             # we need to preserve the point of assignment to know where to
             # throw errors (issue #4645).
@@ -3092,8 +3092,9 @@ symequal(x::GenSym, y::GenSym) = is(x.id,y.id)
 symequal(x::Slot  , y::Slot)   = is(x.id,y.id)
 symequal(x::ANY   , y::ANY)    = is(x,y)
 
-function occurs_outside_getfield(e::ANY, sym::ANY, sv::InferenceState, field_count, field_names)
-    if e===sym || (isa(e,Slot) && isa(sym,Slot) && e.id == sym.id)
+function occurs_outside_getfield(linfo::LambdaInfo, e::ANY, sym::ANY,
+                                 sv::InferenceState, field_count, field_names)
+    if e===sym || (isa(e,Slot) && isa(sym,Slot) && (e::Slot).id == (sym::Slot).id)
         return true
     end
     if isa(e,Expr)
@@ -3109,10 +3110,21 @@ function occurs_outside_getfield(e::ANY, sym::ANY, sv::InferenceState, field_cou
             return true
         end
         if is(e.head,:(=))
-            return occurs_outside_getfield(e.args[2], sym, sv, field_count, field_names)
+            return occurs_outside_getfield(linfo, e.args[2], sym, sv,
+                                           field_count, field_names)
         else
+            if (e.head === :block && isa(sym, Slot) &&
+                linfo.slotflags[(sym::Slot).id] & 32 == 0)
+                # This is the used-undef flag according to Jeff
+                ignore_void = true
+            else
+                ignore_void = false
+            end
             for a in e.args
-                if occurs_outside_getfield(a, sym, sv, field_count, field_names)
+                if ignore_void && isa(a, Slot) && (a::Slot).id == (sym::Slot).id
+                    continue
+                end
+                if occurs_outside_getfield(linfo, a, sym, sv, field_count, field_names)
                     return true
                 end
             end
@@ -3149,7 +3161,7 @@ function _getfield_elim_pass!(e::Expr, sv)
         e1 = e.args[2]
         j = e.args[3]
         if isa(e1,Expr)
-            alloc = is_immutable_allocation(e1, sv)
+            alloc = is_allocation(e1, sv)
             if !is(alloc, false)
                 flen, fnames = alloc
                 if isa(j,QuoteNode)
@@ -3184,16 +3196,16 @@ end
 
 _getfield_elim_pass!(e::ANY, sv) = e
 
-# check if e is a successful allocation of an immutable struct
+# check if e is a successful allocation of an struct
 # if it is, returns (n,f) such that it is always valid to call
 # getfield(..., 1 <= x <= n) or getfield(..., x in f) on the result
-function is_immutable_allocation(e :: ANY, sv::InferenceState)
+function is_allocation(e :: ANY, sv::InferenceState)
     isa(e, Expr) || return false
     if is_known_call(e, tuple, sv)
         return (length(e.args)-1,())
     elseif e.head === :new
         typ = widenconst(exprtype(e, sv))
-        if isleaftype(typ) && !typ.mutable
+        if isleaftype(typ)
             @assert(isa(typ,DataType))
             nf = length(e.args)-1
             names = fieldnames(typ)
@@ -3210,7 +3222,7 @@ function is_immutable_allocation(e :: ANY, sv::InferenceState)
     false
 end
 
-# eliminate allocation of unnecessary immutables
+# eliminate allocation of unnecessary objects
 # that are only used as arguments to safe getfield calls
 function alloc_elim_pass!(linfo::LambdaInfo, sv::InferenceState)
     body = linfo.code
@@ -3221,49 +3233,98 @@ function alloc_elim_pass!(linfo::LambdaInfo, sv::InferenceState)
     i = 1
     while i < length(body)
         e = body[i]
-        if !(isa(e,Expr) && is(e.head,:(=)) && (isa(e.args[1], GenSym) ||
-                                                (isa(e.args[1],Slot) && haskey(vs, e.args[1].id))))
+        if !isa(e, Expr)
             i += 1
             continue
         end
-        var = e.args[1]
-        rhs = e.args[2]
-        alloc = is_immutable_allocation(rhs, sv)
-        if !is(alloc,false)
+        e = e::Expr
+        if e.head === :(=) && (isa(e.args[1], GenSym) ||
+                               (isa(e.args[1],Slot) && haskey(vs, e.args[1].id)))
+            var = e.args[1]
+            rhs = e.args[2]
+        else
+            var = nothing
+            rhs = e
+        end
+        alloc = is_allocation(rhs, sv)
+        if alloc !== false
             nv, field_names = alloc
             tup = rhs.args
-            if occurs_outside_getfield(bexpr, var, sv, nv, field_names)
+            # This makes sure the value doesn't escape so we can elide
+            # allocation of mutable types too
+            if (var !== nothing &&
+                occurs_outside_getfield(linfo, bexpr, var, sv, nv, field_names))
                 i += 1
                 continue
             end
 
             deleteat!(body, i)  # remove tuple allocation
             # convert tuple allocation to a series of local var assignments
-            vals = cell(nv)
             n_ins = 0
-            for j=1:nv
-                tupelt = tup[j+1]
-                if isa(tupelt,Number) || isa(tupelt,AbstractString) || isa(tupelt,QuoteNode)
-                    vals[j] = tupelt
-                else
-                    elty = exprtype(tupelt,sv)
-                    tmpv = newvar!(sv, elty)
-                    tmp = Expr(:(=), tmpv, tupelt)
-                    insert!(body, i+n_ins, tmp)
-                    vals[j] = tmpv
-                    n_ins += 1
+            if var === nothing
+                for j=1:nv
+                    tupelt = tup[j+1]
+                    if !(isa(tupelt,Number) || isa(tupelt,AbstractString) ||
+                         isa(tupelt,QuoteNode) || isa(tupelt, GenSym))
+                        insert!(body, i+n_ins, tupelt)
+                        n_ins += 1
+                    end
+                end
+            else
+                vals = cell(nv)
+                for j=1:nv
+                    tupelt = tup[j+1]
+                    if (isa(tupelt,Number) || isa(tupelt,AbstractString) ||
+                        isa(tupelt,QuoteNode) || isa(tupelt, GenSym))
+                        vals[j] = tupelt
+                    else
+                        elty = exprtype(tupelt,sv)
+                        tmpv = newvar!(sv, elty)
+                        tmp = Expr(:(=), tmpv, tupelt)
+                        insert!(body, i+n_ins, tmp)
+                        vals[j] = tmpv
+                        n_ins += 1
+                    end
+                end
+                replace_getfield!(linfo, bexpr, var, vals, field_names, sv)
+                if isa(var, Slot) && linfo.slotflags[(var::Slot).id] & 32 == 0
+                    # occurs_outside_getfield might have allowed
+                    # void use of the slot, we need to delete them too
+                    i -= delete_void_use!(body, var::Slot, i)
                 end
             end
-            i += n_ins
-            replace_getfield!(linfo, bexpr, var, vals, field_names, sv, i)
+            # Do not increment counter and do the optimization recursively
+            # on the allocation of fields too.
+            # This line can probably be added back for linear IR
+            # i += n_ins
         else
             i += 1
         end
     end
 end
 
-function replace_getfield!(linfo::LambdaInfo, e::Expr, tupname, vals, field_names, sv, i0)
-    for i = i0:length(e.args)
+# Return the number of expressions deleted before `i0`
+function delete_void_use!(body, var::Slot, i0)
+    narg = length(body)
+    i = 1
+    ndel = 0
+    while i <= narg
+        a = body[i]
+        if isa(a, Slot) && (a::Slot).id == var.id
+            deleteat!(body, i)
+            if i + ndel < i0
+                ndel += 1
+            end
+            narg -= 1
+        else
+            i += 1
+        end
+    end
+    ndel
+end
+
+function replace_getfield!(linfo::LambdaInfo, e::Expr, tupname, vals, field_names, sv)
+    for i = 1:length(e.args)
         a = e.args[i]
         if isa(a,Expr) && is_known_call(a, getfield, sv) &&
             symequal(a.args[2],tupname)
@@ -3292,7 +3353,7 @@ function replace_getfield!(linfo::LambdaInfo, e::Expr, tupname, vals, field_name
             end
             e.args[i] = val
         elseif isa(a, Expr)
-            replace_getfield!(linfo, a::Expr, tupname, vals, field_names, sv, 1)
+            replace_getfield!(linfo, a::Expr, tupname, vals, field_names, sv)
         end
     end
 end


### PR DESCRIPTION
- Mutable allocations that aren't mutated or escaped
  
  I'm not sure why we were not doing this before since we have a very conservative escape check.
  Maybe there's some subtlety I'm not seeing?
  
  ``` jl
  julia> type A{T}
             a::T
         end
  
  julia> f(x) = A(x).a
  f (generic function with 1 method)
  
  julia> @code_warntype f(1)
  Variables:
    #self#::#f
    x::Int64
  
  Body:
    begin  # REPL[2], line 1: # REPL[1], line 2: # REPL[1], line 2:
        (top(getfield))(Main,:A)::Type{A{T}}
        return x::Int64
    end::Int64
  ```
  
  (It might be more useful if this can happen before type inference.)
  
  ``` jl
  julia> type B
             a
         end
  
  julia> g(x) = B(x).a
  g (generic function with 1 method)
  
  julia> @code_warntype g(1)
  Variables:
    #self#::#g
    x::Int64
  
  Body:
    begin  # REPL[5], line 1:
        return x::Int64
    end::Any
  
  julia> @code_llvm g(1)
  
  define %jl_value_t* @julia_g_54031(i64) #0 {
  top:
    %1 = call %jl_value_t* @jl_box_int64(i64 signext %0)
    ret %jl_value_t* %1
  }
  ```
- Allocations that aren't used (Fix #12415)
  
  ``` jl
  julia> f(a, b) = ((a, b); nothing)
  f (generic function with 2 methods)
  
  julia> @code_warntype f([], [])
  Variables:
    #self#::#f
    a::Array{Any,1}
    b::Array{Any,1}
  
  Body:
    begin  # REPL[8], line 1:
        a::Array{Any,1}
        b::Array{Any,1}
        return Main.nothing
    end::Void
  
  julia> @code_llvm f([], [])
  
  define void @julia_f_54044(%jl_value_t*, %jl_value_t*) #0 {
  top:
    ret void
  }
  ```
  
  This happens probably mainly due to inlining...
- Allocations of fields that aren't used or escaped
  
  ``` jl
  julia> function f(a, b, c)
             j = (a, (b, c))
             j[1] + j[2][1]
         end
  f (generic function with 1 method)
  
  julia> @code_warntype f(1, 2, "")
  Variables:
    #self#::#f
    a::Int64
    b::Int64
    c::ASCIIString
    j::Tuple{Int64,Tuple{Int64,ASCIIString}}
  
  Body:
    begin  # REPL[1], line 2:
        GenSym(0) = a::Int64
        GenSym(2) = b::Int64
        GenSym(3) = c::ASCIIString # REPL[1], line 3:
        return (Base.box)(Int64,(Base.add_int)(GenSym(0),GenSym(2)))
    end::Int64
  
  julia> @code_llvm f(1, 2, "")
  
  define i64 @julia_f_54032(i64, i64, %jl_value_t*) #0 {
  top:
    %3 = add i64 %1, %0
    ret i64 %3
  }
  ```

The optimization still can't catch all the obvious cases. The cases I found where it still fails to optimize are mainly due to not tracing variable assignments, e.g. (note the `GenSym(1) = GenSym(0)` should be trivially optimized out since both are ssa values),

``` jl
julia> function f(a, b, c)
           x, (y, z) = (a, (b, c))
           x + y
       end
f (generic function with 1 method)

julia> @code_warntype f(1, 2, "")
Variables:
  #self#::#f
  a::Int64
  b::Int64
  c::ASCIIString
  x::Int64
  y::Int64
  z::ASCIIString
  #temp#::Int64

Body:
  begin  # REPL[1], line 2:
      GenSym(0) = (top(tuple))(b::Int64,c::ASCIIString)::Tuple{Int64,ASCIIString}
      GenSym(1) = GenSym(0)
      #temp#::Int64 = 1
      GenSym(4) = (Base.getfield)(GenSym(1),1)::Union{ASCIIString,Int64}
      GenSym(5) = (Base.box)(Int64,(Base.add_int)(1,1))
      y::Int64 = GenSym(4)
      #temp#::Int64 = GenSym(5)
      GenSym(6) = (Base.getfield)(GenSym(1),2)::Union{ASCIIString,Int64}
      GenSym(7) = (Base.box)(Int64,(Base.add_int)(2,1))
      z::ASCIIString = GenSym(6)
      #temp#::Int64 = GenSym(7)
      a::Int64
      GenSym(0) # REPL[1], line 3:
      return (Base.box)(Int64,(Base.add_int)(a::Int64,y::Int64))
  end::Int64
```

Or not handling dummy use of variable in the ast (Note the `j::Tuple{Int64,Int64,ASCIIString}` at the end disables the optimization)

``` jl
julia> function f(a, b, c)
           j = (a, b, c)
           x, y, z = j
           x + y
       end
f (generic function with 1 method)

julia> @code_warntype f(1, 2, "")
Variables:
  #self#::#f
  a::Int64
  b::Int64
  c::ASCIIString
  j::Tuple{Int64,Int64,ASCIIString}
  x::Int64
  y::Int64
  z::ASCIIString
  #temp#::Int64

Body:
  begin  # REPL[1], line 2:
      j::Tuple{Int64,Int64,ASCIIString} = (top(tuple))(a::Int64,b::Int64,c::ASCIIString)::Tuple{Int64,Int64,ASCIIString} # REPL[1], line 3:
      #temp#::Int64 = 1
      GenSym(3) = (Base.getfield)(j::Tuple{Int64,Int64,ASCIIString},1)::Union{ASCIIString,Int64}
      GenSym(4) = (Base.box)(Int64,(Base.add_int)(1,1))
      x::Int64 = GenSym(3)
      #temp#::Int64 = GenSym(4)
      GenSym(5) = (Base.getfield)(j::Tuple{Int64,Int64,ASCIIString},2)::Union{ASCIIString,Int64}
      GenSym(6) = (Base.box)(Int64,(Base.add_int)(2,1))
      y::Int64 = GenSym(5)
      #temp#::Int64 = GenSym(6)
      GenSym(7) = (Base.getfield)(j::Tuple{Int64,Int64,ASCIIString},3)::Union{ASCIIString,Int64}
      GenSym(8) = (Base.box)(Int64,(Base.add_int)(3,1))
      z::ASCIIString = GenSym(7)
      #temp#::Int64 = GenSym(8)
      j::Tuple{Int64,Int64,ASCIIString} # REPL[1], line 4:
      return (Base.box)(Int64,(Base.add_int)(x::Int64,y::Int64))
  end::Int64
```

For the second one, is there a way to check if the use can be ignored in a way that doesn't trigger https://github.com/JuliaLang/julia/issues/6846 ?
