### PR TITLE
WIP: Lazy store to gc slots

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -217,6 +217,8 @@ JL_DLLEXPORT void jl_pop_handler(int n)
 
 // primitives -----------------------------------------------------------------
 
+// WARNING: there might be pending GC root when calling this function
+// This function must NOT allocate
 static int bits_equal(void *a, void *b, int sz)
 {
     switch (sz) {
@@ -248,6 +250,8 @@ static int bits_equal(void *a, void *b, int sz)
 // The solution is to keep the code in jl_egal simple and split out the
 // (more) complex cases into their own functions which are marked with
 // NOINLINE.
+// WARNING: there might be pending GC root when calling this function
+// This function must NOT allocate
 static int NOINLINE compare_svec(jl_svec_t *a, jl_svec_t *b)
 {
     size_t l = jl_svec_len(a);
@@ -261,6 +265,8 @@ static int NOINLINE compare_svec(jl_svec_t *a, jl_svec_t *b)
 }
 
 // See comment above for an explanation of NOINLINE.
+// WARNING: there might be pending GC root when calling this function
+// This function must NOT allocate
 static int NOINLINE compare_fields(jl_value_t *a, jl_value_t *b, jl_datatype_t *dt)
 {
     size_t nf = jl_datatype_nfields(dt);
@@ -291,6 +297,8 @@ static int NOINLINE compare_fields(jl_value_t *a, jl_value_t *b, jl_datatype_t *
     return 1;
 }
 
+// WARNING: there might be pending GC root when calling this function
+// This function must NOT allocate
 JL_DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b)
 {
     // warning: a,b may NOT have been gc-rooted by the caller

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1441,7 +1441,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                 ai + sret < fargt_sig.size() ? fargt_sig.at(ai + sret) : fargt_vasig,
                 false, byRef, issigned, ctx);
     }
-
+    flush_pending_store(ctx);
 
     // make LLVM function object for the target
     // keep this close to the function call, so that the compiler can
@@ -1557,6 +1557,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             assert(newst.isboxed);
             // copy the data from the return value to the new struct
             builder.CreateAlignedStore(result, builder.CreateBitCast(newst.V, prt->getPointerTo()), 16); // julia gc is aligned 16
+            flush_pending_store(ctx);
             return newst;
         }
         else if (jlrt != prt) {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -445,6 +445,7 @@ static jl_value_t* try_eval(jl_value_t *ex, jl_codectx_t *ctx, const char *failu
 
 static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     JL_NARGS(cglobal, 1, 2);
     jl_value_t *rt=NULL;
     Value *res;
@@ -651,6 +652,7 @@ public:
 // llvmcall(ir, (rettypes...), (argtypes...), args...)
 static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     JL_NARGSV(llvmcall, 3)
     jl_value_t *rt = NULL, *at = NULL, *ir = NULL, *decl = NULL;
     jl_svec_t *stt = NULL;
@@ -1037,6 +1039,7 @@ static std::string generate_func_sig(
 // ccall(pointer, rettype, (argtypes...), args...)
 static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     JL_NARGSV(ccall, 3);
     jl_value_t *rt=NULL, *at=NULL;
     JL_GC_PUSH2(&rt, &at);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -871,7 +871,7 @@ static jl_cgval_t mark_or_box_ccall_result(Value *result, bool isboxed, jl_value
         Value *runtime_bt = boxed(emit_expr(rt_expr, ctx), ctx);
         int nb = sizeof(void*);
         return mark_julia_type(
-                init_bits_value(emit_allocobj(nb), runtime_bt, result),
+                init_bits_value(emit_allocobj(nb, ctx), runtime_bt, result),
                 true,
                 (jl_value_t*)jl_pointer_type, ctx);
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1007,6 +1007,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
 
 static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, jl_datatype_t *jt, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     jl_value_t *jfty = jl_field_type(jt,idx);
     Type *elty = julia_type_to_llvm(jfty);
     assert(elty != NULL);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -696,6 +696,7 @@ static bool is_bounds_check_block(jl_codectx_t *ctx)
 #define CHECK_BOUNDS 1
 static Value *emit_bounds_check(const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     Value *im1 = builder.CreateSub(i, ConstantInt::get(T_size, 1));
 #if CHECK_BOUNDS==1
     if ((!is_inbounds(ctx) &&

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -580,6 +580,7 @@ static void emit_error(const std::string &txt, jl_codectx_t *ctx)
 
 static void error_unless(Value *cond, const std::string &msg, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
     BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
     builder.CreateCondBr(cond, passBB, failBB);
@@ -934,6 +935,7 @@ static Value *data_pointer(const jl_cgval_t &x, jl_codectx_t *ctx, Type *astype 
 
 static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, Value *idx, jl_datatype_t *stt, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     size_t nfields = jl_datatype_nfields(stt);
     if (strct.ispointer) { // boxed or stack
         if (is_datatype_all_pointers(stt)) {
@@ -1543,6 +1545,7 @@ static void emit_checked_write_barrier(jl_codectx_t *ctx, Value *parent, Value *
 static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t idx0,
                           const jl_cgval_t &rhs, jl_codectx_t *ctx, bool checked, bool wb)
 {
+    flush_pending_store(ctx);
     if (sty->mutabl || !checked) {
         assert(strct.ispointer);
         Value *addr = builder.CreateGEP(data_pointer(strct, ctx, T_pint8),

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1580,6 +1580,7 @@ static bool might_need_root(jl_value_t *ex)
 
 static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, jl_codectx_t *ctx)
 {
+    flush_pending_store(ctx);
     assert(jl_is_datatype(ty));
     assert(jl_is_leaf_type(ty));
     assert(nargs>0);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3825,7 +3825,6 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
     }
 
     for (size_t i = 0; i < nargs; i++) {
-        flush_pending_store(&ctx);
         Value *val = &*AI++;
         jl_value_t *jargty = jl_nth_slot_type(lam->specTypes, i+1);  // +1 because argt excludes function
         bool isboxed, argboxed;
@@ -3888,7 +3887,6 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
             }
             else {
                 arg = emit_unbox(t, inputarg, jargty);
-                flush_pending_store(&ctx);
                 assert(!isa<UndefValue>(arg));
                 if (t->isAggregateType()) {
 #ifndef NDEBUG
@@ -3907,7 +3905,7 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
         }
     }
 
-    flush_pending_store(&ctx);
+    flush_pending_store_final(&ctx);
     // Create the call
     jl_cgval_t retval;
     if (specsig) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3865,7 +3865,7 @@ static Function *gen_cfun_wrapper(jl_lambda_info_t *lam, jl_function_t *ff, jl_v
             bool issigned = jl_signed_type && jl_subtype(jargty, (jl_value_t*)jl_signed_type, 0);
             val = llvm_type_rewrite(val, val->getType(), fargt[i], true, byRefList[i], issigned, &ctx);
             if (isboxed) {
-                Value *mem = emit_allocobj(jl_datatype_size(jargty));
+                Value *mem = emit_allocobj(jl_datatype_size(jargty), &ctx);
                 builder.CreateStore(literal_pointer_val((jl_value_t*)jargty),
                                     emit_typeptr_addr(mem));
                 builder.CreateAlignedStore(val,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2952,7 +2952,6 @@ static jl_cgval_t emit_call(jl_expr_t *ex, jl_codectx_t *ctx)
 
 static void undef_var_error_if_null(Value *v, jl_sym_t *name, jl_codectx_t *ctx)
 {
-    flush_pending_store(ctx);
     Value *ok = builder.CreateICmpNE(v, V_null);
     BasicBlock *err = BasicBlock::Create(getGlobalContext(), "err", ctx->f);
     BasicBlock *ifok = BasicBlock::Create(getGlobalContext(), "ok");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3129,7 +3129,6 @@ static jl_cgval_t emit_local(jl_value_t *slotload, jl_codectx_t *ctx)
 static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
 {
     if (jl_is_gensym(l)) {
-        flush_pending_store(ctx);
         ssize_t idx = ((jl_gensym_t*)l)->id;
         assert(idx >= 0);
         assert(!ctx->gensym_assigned.at(idx));
@@ -3167,10 +3166,10 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
         assert(jl_is_slot(l));
     if (bp == NULL && s != NULL)
         bp = global_binding_pointer(ctx->module, s, &bnd, true, ctx);
-    flush_pending_store(ctx);
     if (bp != NULL) { // it's a global
         assert(bnd);
         Value *rval = boxed(emit_expr(r, ctx), ctx, false); // no root needed since this is about to be assigned to a global
+        // Does not allocate!
 #ifdef LLVM37
         builder.CreateCall(prepare_call(jlcheckassign_func),
                            {literal_pointer_val(bnd),

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2225,6 +2225,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
     jl_value_t *rt1=NULL, *rt2=NULL, *rt3=NULL;
     JL_GC_PUSH3(&rt1, &rt2, &rt3);
 
+    flush_pending_store(ctx);
     if (f==jl_builtin_is && nargs==2) {
         // handle simple static expressions with no side-effects
         rt1 = static_eval(args[1], ctx, true);
@@ -2871,7 +2872,6 @@ static jl_cgval_t emit_call_function_object(jl_lambda_info_t *li, const jl_cgval
 
 static jl_cgval_t emit_call(jl_expr_t *ex, jl_codectx_t *ctx)
 {
-    flush_pending_store(ctx);
     jl_value_t *expr = (jl_value_t*)ex;
     jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
     size_t arglen = jl_array_dim0(ex->args);

--- a/src/gc.c
+++ b/src/gc.c
@@ -1579,6 +1579,8 @@ static void reset_remset(void)
     }
 }
 
+// WARNING, there might be pending GC root when calling this function
+// This is **NOT** a gc safepoint!
 JL_DLLEXPORT void jl_gc_queue_root(jl_value_t *ptr)
 {
     FOR_CURRENT_HEAP () {
@@ -1599,6 +1601,8 @@ JL_DLLEXPORT void jl_gc_queue_root(jl_value_t *ptr)
     }
 }
 
+// WARNING: there might be pending GC root when calling this function
+// This function must NOT allocate. This is NOT a gc safepoint
 void gc_queue_binding(jl_binding_t *bnd)
 {
     FOR_CURRENT_HEAP () {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -873,9 +873,9 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     }
 
     switch (f) {
-    case ccall: return emit_ccall(args, nargs, ctx);
-    case cglobal: return emit_cglobal(args, nargs, ctx);
-    case llvmcall: return emit_llvmcall(args, nargs, ctx);
+    case ccall: flush_pending_store(ctx); return emit_ccall(args, nargs, ctx);
+    case cglobal: flush_pending_store(ctx); return emit_cglobal(args, nargs, ctx);
+    case llvmcall: flush_pending_store(ctx); return emit_llvmcall(args, nargs, ctx);
     case arraylen:
         return mark_julia_type(emit_arraylen(emit_expr(args[1], ctx), args[1], ctx), false,
                                jl_long_type, ctx);
@@ -885,6 +885,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Value *func = prepare_call(runtime_func[f]);
         if (nargs == 1) {
             Value *x = boxed(emit_expr(args[1], ctx), ctx);
+            flush_pending_store_final(ctx);
 #ifdef LLVM37
             r = builder.CreateCall(func, {x});
 #else
@@ -894,6 +895,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         else if (nargs == 2) {
             Value *x = boxed(emit_expr(args[1], ctx), ctx);
             Value *y = boxed(emit_expr(args[2], ctx), ctx);
+            flush_pending_store_final(ctx);
 #ifdef LLVM37
             r = builder.CreateCall(func, {x, y});
 #else
@@ -904,6 +906,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
             Value *x = boxed(emit_expr(args[1], ctx), ctx);
             Value *y = boxed(emit_expr(args[2], ctx), ctx);
             Value *z = boxed(emit_expr(args[3], ctx), ctx);
+            flush_pending_store_final(ctx);
 #ifdef LLVM37
             r = builder.CreateCall(func, {x, y, z});
 #else
@@ -1019,7 +1022,6 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     }
 
     case select_value: {
-        // STORE FLUSHED
         Value *isfalse = emit_condition(args[1], "select_value", ctx); // emit the first argument
         jl_value_t *t1 = expr_type(args[2], ctx);
         jl_value_t *t2 = expr_type(args[3], ctx);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -873,9 +873,9 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     }
 
     switch (f) {
-    case ccall: flush_pending_store(ctx); return emit_ccall(args, nargs, ctx);
-    case cglobal: flush_pending_store(ctx); return emit_cglobal(args, nargs, ctx);
-    case llvmcall: flush_pending_store(ctx); return emit_llvmcall(args, nargs, ctx);
+    case ccall: return emit_ccall(args, nargs, ctx);
+    case cglobal: return emit_cglobal(args, nargs, ctx);
+    case llvmcall: return emit_llvmcall(args, nargs, ctx);
     case arraylen:
         return mark_julia_type(emit_arraylen(emit_expr(args[1], ctx), args[1], ctx), false,
                                jl_long_type, ctx);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -315,7 +315,6 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt)
 static Value *auto_unbox(const jl_cgval_t &v, jl_codectx_t *ctx)
 {
     jl_value_t *bt = v.typ;
-    flush_pending_store(ctx);
     if (!jl_is_bitstype(bt)) {
         // This can be reached with a direct invalid call to an Intrinsic, such as:
         //   Intrinsics.neg_int("")
@@ -333,9 +332,7 @@ static Value *auto_unbox(const jl_cgval_t &v, jl_codectx_t *ctx)
         return NULL;
     }
     assert(!to->isAggregateType()); // expecting some sort of jl_bitstype
-    auto res = emit_unbox(to, v, bt);
-    flush_pending_store(ctx);
-    return res;
+    return emit_unbox(to, v, bt);
 }
 static Value *auto_unbox(jl_value_t *x, jl_codectx_t *ctx)
 {
@@ -404,7 +401,6 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
     }
 
     Type *llvmt = staticeval_bitstype(bt);
-    flush_pending_store(ctx);
     int nb = jl_datatype_size(bt);
 
     // Examine the second argument //
@@ -452,7 +448,6 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
             vxt = llvmt;
         vx = builder.CreateLoad(data_pointer(v, ctx,
                     vxt == T_int1 ? T_pint8 : vxt->getPointerTo()));
-        flush_pending_store(ctx);
     }
 
     vxt = vx->getType();
@@ -483,7 +478,6 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
 
     // Examine the second argument //
     jl_cgval_t v = emit_expr(x, ctx);
-    flush_pending_store(ctx);
 
     if (bt == NULL || !jl_is_leaf_type(bt)) {
         // dynamically-determined type; evaluate.
@@ -493,7 +487,6 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
             // always fixed size
             nb = jl_datatype_size(bt);
             llvmt = staticeval_bitstype(bt);
-            flush_pending_store(ctx);
             alignment = ((jl_datatype_t*)bt)->alignment;
         }
         else {
@@ -506,7 +499,6 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
             }
             nb = jl_datatype_size(bt);
             llvmt = staticeval_bitstype(bt);
-            flush_pending_store(ctx);
             alignment = ((jl_datatype_t*)bt)->alignment;
         }
         Value *runtime_bt = boxed(bt_value, ctx);
@@ -521,7 +513,6 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
             prepare_call(builder.CreateMemCpy(newobj, data_pointer(v, ctx, T_pint8), nb, alignment)->getCalledValue());
             mark_gc_use(ctx, v);
         }
-        flush_pending_store(ctx);
         return mark_julia_type(newobj, true, bt ? bt : (jl_value_t*)jl_any_type, ctx);
     }
 
@@ -532,7 +523,6 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
     }
 
     Type *llvmt = staticeval_bitstype(bt);
-    flush_pending_store(ctx);
     if (v.typ == bt)
         return v;
 
@@ -547,7 +537,6 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
             return jl_cgval_t();
         }
     }
-    flush_pending_store(ctx);
 
     Type *vxt = vx->getType();
     if (llvmt == T_int1) {
@@ -580,11 +569,9 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
 static jl_cgval_t generic_trunc(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx, bool check, bool signd)
 {
     jl_value_t *jlto = staticeval_bitstype(targ, "trunc_int", ctx);
-    flush_pending_store(ctx);
     if (!jlto) return jl_cgval_t(); // jlto threw an error
     Type *to = staticeval_bitstype(jlto);
     Value *ix = JL_INT(auto_unbox(x, ctx));
-    flush_pending_store(ctx);
     if (ix->getType() == T_void) return jl_cgval_t(); // auto_unbox threw an error
     Value *ans = builder.CreateTrunc(ix, to);
     if (check) {
@@ -602,7 +589,6 @@ static jl_cgval_t generic_sext(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ct
     if (!jlto) return jl_cgval_t(); // jlto threw an error
     Type *to = staticeval_bitstype(jlto);
     Value *ix = JL_INT(auto_unbox(x, ctx));
-    flush_pending_store(ctx);
     if (ix->getType() == T_void) return jl_cgval_t(); // auto_unbox threw an error
     Value *ans = builder.CreateSExt(ix, to);
     return mark_julia_type(ans, false, jlto, ctx);
@@ -611,11 +597,9 @@ static jl_cgval_t generic_sext(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ct
 static jl_cgval_t generic_zext(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx)
 {
     jl_value_t *jlto = staticeval_bitstype(targ, "zext_int", ctx);
-    flush_pending_store(ctx);
     if (!jlto) return jl_cgval_t(); // jlto threw an error
     Type *to = staticeval_bitstype(jlto);
     Value *ix = JL_INT(auto_unbox(x, ctx));
-    flush_pending_store(ctx);
     if (ix->getType() == T_void) return jl_cgval_t(); // auto_unbox threw an error
     Value *ans = builder.CreateZExt(ix, to);
     return mark_julia_type(ans, false, jlto, ctx);
@@ -658,11 +642,9 @@ static Value *emit_eqfui(Value *x, Value *y)
 static jl_cgval_t emit_checked_fptosi(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx)
 {
     jl_value_t *jlto = staticeval_bitstype(targ, "checked_fptosi", ctx);
-    flush_pending_store(ctx);
     if (!jlto) return jl_cgval_t();
     Type *to = staticeval_bitstype(jlto);
     Value *fx = FP(auto_unbox(x, ctx));
-    flush_pending_store(ctx);
     if (fx->getType() == T_void) return jl_cgval_t(); // auto_unbox threw an error
     Value *ans = builder.CreateFPToSI(fx, to);
     if (fx->getType() == T_float32 && to == T_int32) {
@@ -680,11 +662,9 @@ static jl_cgval_t emit_checked_fptosi(jl_value_t *targ, jl_value_t *x, jl_codect
 static jl_cgval_t emit_checked_fptoui(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx)
 {
     jl_value_t *jlto = staticeval_bitstype(targ, "checked_fptoui", ctx);
-    flush_pending_store(ctx);
     if (!jlto) return jl_cgval_t();
     Type *to = staticeval_bitstype(jlto);
     Value *fx = FP(auto_unbox(x, ctx));
-    flush_pending_store(ctx);
     if (fx->getType() == T_void) return jl_cgval_t(); // auto_unbox threw an error
     Value *ans = builder.CreateFPToUI(fx, to);
     if (fx->getType() == T_float32 && to == T_int32) {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1019,8 +1019,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     }
 
     case select_value: {
-        Value *isfalse = emit_condition(args[1], "select_value", ctx); // emit the first argument
         // STORE FLUSHED
+        Value *isfalse = emit_condition(args[1], "select_value", ctx); // emit the first argument
         jl_value_t *t1 = expr_type(args[2], ctx);
         jl_value_t *t2 = expr_type(args[3], ctx);
         bool isboxed;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -511,7 +511,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
         }
         else {
             prepare_call(builder.CreateMemCpy(newobj, data_pointer(v, ctx, T_pint8), nb, alignment)->getCalledValue());
-            mark_gc_use(v);
+            mark_gc_use(ctx, v);
         }
         return mark_julia_type(newobj, true, bt ? bt : (jl_value_t*)jl_any_type, ctx);
     }
@@ -1050,8 +1050,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
                     boxed(x, ctx));
         }
         jl_value_t *jt = (t1 == t2 ? t1 : (jl_value_t*)jl_any_type);
-        mark_gc_use(x);
-        mark_gc_use(y);
+        mark_gc_use(ctx, x);
+        mark_gc_use(ctx, y);
         return mark_julia_type(ifelse_result, isboxed, jt, ctx);
     }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -103,6 +103,8 @@ void *allocb(size_t sz);
 void gc_queue_binding(jl_binding_t *bnd);
 void gc_setmark_buf(void *buf, int);
 
+// WARNING: there might be pending GC root when calling this function
+// This function must NOT allocate. This is NOT a gc safepoint
 STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_value_t*
 {
     if (__unlikely((jl_astaggedvalue(bnd)->gc_bits & 1) == 1 &&

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -185,7 +185,7 @@ void collapseRedundantRoots()
             // such that the first store can be trivially replaced with just "other" and delete the chain
             // or if is used for store, but the value is never needed
             StoreInst *theStore = NULL;
-            unsigned n_stores = 0;
+            int n_stores = 0;
             bool variable_slot = true; // whether this gc-root is only used as a variable-slot; e.g. whether theLoad is theValue
             LoadInst *theLoad = NULL;
             for (User::use_iterator use = callInst->use_begin(), usee = callInst->use_end(); use != usee; ) {
@@ -214,7 +214,7 @@ void collapseRedundantRoots()
                     else {
                         if (theLoad) {
                             // multiple live loads, this is hard to optimize, so skip it
-                            n_stores = 0;
+                            n_stores = -1;
                             break;
                         }
                         theLoad = loadInst;
@@ -222,12 +222,12 @@ void collapseRedundantRoots()
                 }
                 else {
                     // what is this? oh, well. skip trying to optimize this gc-root
-                    n_stores = 0;
+                    n_stores = -1;
                     break;
                 }
             }
 
-            if (n_stores == 0)
+            if (n_stores == -1)
                 continue;
 
             if (theLoad == NULL) {

--- a/src/module.c
+++ b/src/module.c
@@ -532,6 +532,8 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
     }
 }
 
+// WARNING: there might be pending GC root when calling this function
+// This function must NOT allocate
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
 {
     if (b->constp && b->value != NULL) {

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -50,6 +50,8 @@ JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
 }
 
 // run time version of pointerset intrinsic (warning: x is not gc-rooted)
+// WARNING: there may be pending GC roots when calling this function
+// DO NOT allocate anything in this function!
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i)
 {
     JL_TYPECHK(pointerset, pointer, p);


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/15457
This should also help implementing GC transition in codegen since `GC unsafe` ≈ `there's pending GC stores`.

Commits 1-22 are the iterative process of delaying when gc stores are flushed which should help bisecting if there's any missing root. I'll squash them when this is ready.

@vtjnash It seems that not having a load or a kill doesn't mean the root is not needed? So how exactly can one tell the lifetime of a root?

For example, the LLVM IR generated for the following code on this PR,

``` jl
function f2()
    a = Ref(1)
    b = a
    g()
    b
end
```

``` llvm
define %jl_value_t* @julia_f2_53239() #0 {
top:
  %a = alloca %jl_value_t*
  %b = alloca %jl_value_t*
  %0 = call %jl_value_t** @julia.gc_root_decl()
  %1 = call %jl_value_t** @julia.gc_root_decl()
  %2 = call %jl_value_t** @julia.gc_root_decl()
  %3 = call %jl_value_t*** @jl_get_ptls_states()
  call void @llvm.dbg.declare(metadata %jl_value_t** %a, metadata !11, metadata !16), !dbg !17
  call void @llvm.dbg.declare(metadata %jl_value_t** %b, metadata !15, metadata !16), !dbg !17
  %4 = call %jl_value_t* @jl_gc_alloc_1w(), !dbg !18
  %5 = bitcast %jl_value_t* %4 to %jl_value_t**, !dbg !18
  %6 = getelementptr %jl_value_t*, %jl_value_t** %5, i64 -1, !dbg !18
  store %jl_value_t* inttoptr (i64 139959089228864 to %jl_value_t*), %jl_value_t** %6, !dbg !18
  %7 = bitcast %jl_value_t* %4 to i8*, !dbg !18
  %8 = getelementptr i8, i8* %7, i64 0, !dbg !18
  %9 = bitcast i8* %8 to i64*, !dbg !18
  %10 = getelementptr i64, i64* %9, i64 0, !dbg !18
  store i64 1, i64* %10, align 16, !dbg !18, !tbaa !22
  store %jl_value_t* %4, %jl_value_t** %b, !dbg !24
  store %jl_value_t* %4, %jl_value_t** %1, !dbg !24
  store %jl_value_t* %4, %jl_value_t** %0, !dbg !24
  store %jl_value_t* %4, %jl_value_t** %a, !dbg !24
  call void @julia_g_53240() #0, !dbg !24
  %11 = load %jl_value_t*, %jl_value_t** %b, !dbg !25
  ret %jl_value_t* %11, !dbg !25
}
```

(on master the difference is that there's one more store to `%2` after the call and a few more load before the call). One of `%0` or `%1` should be the necessary root when calling `g` but it seems that none of them are loaded from or marked as use after the call either on master or on this PR.
