### PR TITLE
Also trace new methods from precompiled modules

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -63,7 +63,7 @@ JL_DLLEXPORT void jl_register_method_tracer(void (*callback)(jl_lambda_info_t *t
     jl_method_tracer = (tracer_cb)callback;
 }
 
-static tracer_cb jl_newmeth_tracer = NULL;
+tracer_cb jl_newmeth_tracer = NULL;
 JL_DLLEXPORT void jl_register_newmeth_tracer(void (*callback)(jl_method_t *tracee))
 {
     jl_newmeth_tracer = (tracer_cb)callback;
@@ -872,8 +872,6 @@ void jl_method_table_insert(jl_methtable_t *mt, jl_tupletype_t *type, jl_tuplety
         check_ambiguous_matches(mt->defs, newentry);
     invalidate_conflicting(&mt->cache, (jl_value_t*)type, (jl_value_t*)mt);
     update_max_args(mt, type);
-    if (jl_newmeth_tracer)
-        jl_call_tracer(jl_newmeth_tracer, (jl_value_t*)method);
     JL_SIGATOMIC_END();
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -721,6 +721,7 @@ static jl_lambda_info_t *expr_to_lambda(jl_expr_t *f)
     return li;
 }
 
+extern tracer_cb jl_newmeth_tracer;
 JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_lambda_info_t *f, jl_value_t *isstaged)
 {
     // argdata is svec({types...}, svec(typevars...))
@@ -786,6 +787,8 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_lambda_info_t *f, jl_valu
     }
 
     jl_method_table_insert(mt, argtypes, NULL, m, tvars);
+    if (jl_newmeth_tracer)
+        jl_call_tracer(jl_newmeth_tracer, (jl_value_t*)m);
 
     if (jl_boot_file_loaded && f->code && jl_typeis(f->code, jl_array_any_type)) {
         f->code = jl_compress_ast(f, f->code);


### PR DESCRIPTION
Setting breakpoints using Gallium works well, except when the method you want is part of a precompiled modules since the method table gets deserialized directly, so the tracer never picks it up. Fix that by calling the tracer callback on all loaded methods after a precompiled module is loaded. cc @vtjnash to see if there is a better place for this.
