### PR TITLE
add explicit error paths for common misunderstandings in pure contexts

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -745,6 +745,8 @@ JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
 jl_value_t *jl_parse_eval_all(const char *fname, size_t len,
                               const char *content, size_t contentlen)
 {
+    if (in_pure_callback)
+        jl_error("cannot use include inside a generated function");
     jl_ast_context_t *ctx = jl_ast_ctx_enter();
     fl_context_t *fl_ctx = &ctx->fl;
     value_t f, ast;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -514,7 +514,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex)
     return jl_toplevel_eval_in_warn(m, ex, 0);
 }
 
-JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_warn)
+jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_warn)
 {
     static int jl_warn_on_eval = 0;
     int last_delay_warn = jl_warn_on_eval;
@@ -539,6 +539,8 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex
             jl_printf(JL_STDERR, "\n  ** incremental compilation may be broken for these modules **\n\n");
         }
     }
+    if (in_pure_callback && !delay_warn)
+        jl_error("eval cannot be used in a generated function");
     JL_TRY {
         jl_warn_on_eval = delay_warn && (jl_warn_on_eval || m != last_m); // compute whether a warning was suppressed
         jl_current_task->current_module = jl_current_module = m;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -963,7 +963,7 @@ static void jl_finalize_module(std::unique_ptr<Module> uniquem)
 
 // this ensures that llvmf has been emitted to the execution engine,
 // returning the function pointer to it
-extern void callback_triggered_linfos();
+extern void jl_callback_triggered_linfos(void);
 static uint64_t getAddressForFunction(llvm::Function *llvmf)
 {
 #ifdef JL_DEBUG_BUILD
@@ -974,7 +974,7 @@ static uint64_t getAddressForFunction(llvm::Function *llvmf)
     uint64_t ret = jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
     // delay executing trace callbacks until here to make sure there's no
     // recursive compilation.
-    callback_triggered_linfos();
+    jl_callback_triggered_linfos();
     return ret;
 #else
     return (uint64_t)jl_ExecutionEngine->getPointerToFunction(

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -214,19 +214,16 @@ struct strrefcomp {
 };
 #endif
 
-extern "C" {
-    extern void (*jl_linfo_tracer)(jl_lambda_info_t *tracee);
-}
-
-std::vector<jl_lambda_info_t*> triggered_linfos;
-void callback_triggered_linfos()
+extern "C" tracer_cb jl_linfo_tracer;
+static std::vector<jl_lambda_info_t*> triggered_linfos;
+void jl_callback_triggered_linfos(void)
 {
     if (triggered_linfos.empty())
         return;
     if (jl_linfo_tracer) {
         std::vector<jl_lambda_info_t*> to_process(std::move(triggered_linfos));
         for (jl_lambda_info_t *linfo : to_process)
-            jl_linfo_tracer(linfo);
+            jl_call_tracer(jl_linfo_tracer, (jl_value_t*)linfo);
     }
 }
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -308,50 +308,6 @@ JL_DLLEXPORT const char *jl_git_commit(void)
     return commit;
 }
 
-JL_DLLEXPORT void jl_trace_method(jl_method_t *m)
-{
-    assert(jl_is_method(m));
-    m->traced = 1;
-}
-
-JL_DLLEXPORT void jl_untrace_method(jl_method_t *m)
-{
-    assert(jl_is_method(m));
-    m->traced = 0;
-}
-
-JL_DLLEXPORT void jl_trace_linfo(jl_lambda_info_t *linfo)
-{
-    assert(jl_is_lambda_info(linfo));
-    linfo->compile_traced = 1;
-}
-
-JL_DLLEXPORT void jl_untrace_linfo(jl_lambda_info_t *linfo)
-{
-    assert(jl_is_lambda_info(linfo));
-    linfo->compile_traced = 0;
-}
-
-void (*jl_method_tracer)(jl_lambda_info_t *tracee) = 0;
-JL_DLLEXPORT void jl_register_method_tracer(void (*callback)(jl_lambda_info_t *tracee))
-{
-    jl_method_tracer = callback;
-}
-
-void (*jl_newmeth_tracer)(jl_method_t *tracee) = 0;
-JL_DLLEXPORT void jl_register_newmeth_tracer(void (*callback)(jl_method_t *tracee))
-{
-    jl_newmeth_tracer = callback;
-}
-
-void (*jl_linfo_tracer)(jl_lambda_info_t *tracee) = 0;
-JL_DLLEXPORT void jl_register_linfo_tracer(void (*callback)(jl_lambda_info_t *tracee))
-{
-    jl_linfo_tracer = callback;
-}
-
-
-
 // Create function versions of some useful macros
 JL_DLLEXPORT jl_taggedvalue_t *(jl_astaggedvalue)(jl_value_t *v)
 {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1291,8 +1291,6 @@ JL_DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n);
 // compiler
 JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex);
-JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex,
-                                                  int delay_warn);
 JL_DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len);
 JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                                        jl_lambda_info_t *lam);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -16,6 +16,13 @@
 extern "C" {
 #endif
 
+// execution of certain certain unpure
+// statements is prohibited from certain
+// callbacks (such as generated functions)
+extern int in_pure_callback;
+typedef void (*tracer_cb)(jl_value_t *tracee);
+void jl_call_tracer(tracer_cb callback, jl_value_t *tracee);
+
 extern size_t jl_page_size;
 #define jl_stack_lo (jl_get_ptls_states()->stack_lo)
 #define jl_stack_hi (jl_get_ptls_states()->stack_hi)
@@ -191,6 +198,8 @@ jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
 jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast);
+jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex,
+                                     int delay_warn);
 
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);

--- a/src/task.c
+++ b/src/task.c
@@ -383,6 +383,8 @@ JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg)
     }
     if (jl_in_finalizer)
         jl_error("task switch not allowed from inside gc finalizer");
+    if (in_pure_callback)
+        jl_error("task switch not allowed from inside staged function");
     int8_t gc_state = jl_gc_unsafe_enter();
     jl_task_arg_in_transit = arg;
     ctx_switch(t, &t->ctx);

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -157,3 +157,35 @@ end
     :(y->y)
 end
 @test (_g_f_with_inner(1))(8) == 8
+
+# @generated functions errors
+global gf_err_ref = Ref{Int}()
+
+gf_err_ref[] = 0
+let gf_err, tsk = @async nothing # create a Task for yield to try to run
+    @generated function gf_err()
+        gf_err_ref[] += 1
+        yield()
+        gf_err_ref[] += 1000
+    end
+    @test_throws ErrorException gf_err()
+    @test_throws ErrorException gf_err()
+    @test gf_err_ref[] == 2
+end
+
+gf_err_ref[] = 0
+let gf_err2
+    @generated function gf_err2{f}(::f)
+        gf_err_ref[] += 1
+        reflect = f.instance
+        gf_err_ref[] += 1
+        reflect(+, (Int,Int))
+        gf_err_ref[] += 1000
+        return nothing
+    end
+    @test_throws ErrorException gf_err2(code_typed)
+    @test_throws ErrorException gf_err2(code_llvm)
+    @test_throws ErrorException gf_err2(code_native)
+    @test gf_err_ref[] == 6
+    @test gf_err2(code_lowered) == nothing
+end


### PR DESCRIPTION
generic functions have a few callbacks provided for observing certain operations (generated functions and lambda info tracers). however, because these are callbacks, the runtime system can get corrupted or hit c-style hard `assert` / `abort` conditions if they attempt anything impure or runtime-state dependent (such as inference).

this still misses some paths, but a complete solution would require an enforcing pure interpreter
while this is only attempting to provide rapid feedback against doing something
that might cause the runtime to run into assertion failures if it were allowed to proceed

also make tracer functions and the Base.Workqueue switching more robust after encountering errors
