### PR TITLE
Lb/libvariables

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -128,6 +128,7 @@ private_libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(p
 datarootdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(datarootdir))
 docdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(docdir))
 sysconfdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(sysconfdir))
+includedir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(includedir) $(sysconfdir))
 
 INSTALL_F = $(JULIAHOME)/contrib/install.sh 644
 INSTALL_M = $(JULIAHOME)/contrib/install.sh 755

--- a/base/Makefile
+++ b/base/Makefile
@@ -63,6 +63,9 @@ endif
 	@echo "const SYSCONFDIR = \"$(sysconfdir_rel)\"" >> $@
 	@echo "const DATAROOTDIR = \"$(datarootdir_rel)\"" >> $@
 	@echo "const DOCDIR = \"$(docdir_rel)\"" >> $@
+	@echo "const LIBDIR = \"$(libdir_rel)\"" >> $@
+	@echo "const INCLUDEDIR = \"$(includedir_rel)\"" >> $@
+
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible


### PR DESCRIPTION
This PR adds LIBDIR and INCLUDEDIR constants to build_h.jl, so that packages may access the C libraries directly if needed.

There remains to modify the binary distributions so that the header files (include/gmp.h, for example) are included.
