### PR TITLE
Added LIBDIR and INCLUDEDIR consts

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -179,6 +179,7 @@ private_libdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(
 datarootdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(datarootdir))
 docdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(docdir))
 sysconfdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(sysconfdir))
+includedir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(includedir))
 
 INSTALL_F := $(JULIAHOME)/contrib/install.sh 644
 INSTALL_M := $(JULIAHOME)/contrib/install.sh 755

--- a/base/Makefile
+++ b/base/Makefile
@@ -65,6 +65,8 @@ endif
 	@echo "const SYSCONFDIR = \"$(sysconfdir_rel)\"" >> $@
 	@echo "const DATAROOTDIR = \"$(datarootdir_rel)\"" >> $@
 	@echo "const DOCDIR = \"$(docdir_rel)\"" >> $@
+	@echo "const LIBDIR = \"$(libdir_rel)\"" >> $@
+	@echo "const INCLUDEDIR = \"$(includedir_rel)\"" >> $@
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible


### PR DESCRIPTION
This PR adds const's LIBDIR and INCLUDEDIR to build_h.jl, so that packages can access the compiled (e.g. C) libraries.

There remains to make sure that distributions include the header files (include/gmp.h, for example) and not just the library files (lib/libgmp.dylib, lib/libgmp.so).
