### PR TITLE
improve circular reference printing

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -60,8 +60,6 @@ end
 
 showdict(t::Associative; kw...) = showdict(STDOUT, t; kw...)
 function showdict{K,V}(io::IO, t::Associative{K,V}; compact = false)
-    (:SHOWN_SET => t) in io && (print(io, "#= circular reference =#"); return)
-
     recur_io = IOContext(io, :SHOWN_SET => t)
     limit::Bool = limit_output(io)
     if compact
@@ -75,14 +73,16 @@ function showdict{K,V}(io::IO, t::Associative{K,V}; compact = false)
                 print(io, typeof(t))
             end
             print(io, '(')
-            first = true
-            n = 0
-            for pair in t
-                first || print(io, ',')
-                first = false
-                show(recur_io, pair)
-                n+=1
-                limit && n >= 10 && (print(io, "…"); break)
+            if !show_circular(io, t)
+                first = true
+                n = 0
+                for pair in t
+                    first || print(io, ',')
+                    first = false
+                    show(recur_io, pair)
+                    n+=1
+                    limit && n >= 10 && (print(io, "…"); break)
+                end
             end
             print(io, ')')
         end
@@ -92,7 +92,8 @@ function showdict{K,V}(io::IO, t::Associative{K,V}; compact = false)
     # Otherwise show more descriptively, with one line per key/value pair
     print(io, summary(t))
     isempty(t) && return
-    print(io, ":")
+    print(io, ":\n  ")
+    show_circular(io, t) && return
     if limit
         sz = displaysize(io)
         rows, cols = sz[1] - 3, sz[2]
@@ -113,8 +114,10 @@ function showdict{K,V}(io::IO, t::Associative{K,V}; compact = false)
         rows = cols = 0
     end
 
+    first = true
     for (i, (k, v)) in enumerate(t)
-        print(io, "\n  ")
+        first || print(io, "\n  ")
+        first = false
         limit && i > rows && (print(io, rpad("⋮", keylen), " => ⋮"); break)
 
         if limit

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1188,23 +1188,22 @@ static size_t jl_show_svec(JL_STREAM *out, jl_svec_t *t, char *head, char *opn, 
     return n;
 }
 
-#define MAX_DEPTH 25
+struct recur_list {
+    struct recur_list *prev;
+    jl_value_t *v;
+};
 
-static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth);
+static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth);
 
 // `v` might be pointing to a field inlined in a structure therefore
 // `jl_typeof(v)` may not be the same with `vt` and only `vt` should be
 // used to determine the type of the value.
 // This is necessary to make sure that this function doesn't allocate any
 // memory through the Julia GC
-static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v,
-                                jl_datatype_t *vt, int depth)
+static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt,
+                                struct recur_list *depth)
 {
-    if (depth > MAX_DEPTH) { // cheap way of bailing out of cycles
-        return jl_printf(out, "•");
-    }
     size_t n = 0;
-    depth++;
     if ((uintptr_t)vt < 4096U) {
         n += jl_printf(out, "<?#%p::%p>", v, vt);
     }
@@ -1300,7 +1299,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v,
 #endif
     }
     else if (vt == jl_float32_type) {
-        n += jl_printf(out, "%g", *(float*)v);
+        n += jl_printf(out, "%gf", *(float*)v);
     }
     else if (vt == jl_float64_type) {
         n += jl_printf(out, "%g", *(double*)v);
@@ -1405,6 +1404,24 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v,
         size_t j, tlen = jl_array_len(v);
         jl_array_t *av = (jl_array_t*)v;
         jl_datatype_t *el_type = (jl_datatype_t*)jl_tparam0(vt);
+        int nlsep = 0;
+        if (av->flags.ptrarray) {
+            // print arrays with newlines, unless the elements are probably small
+            for (j = 0; j < tlen; j++) {
+                jl_value_t *p = jl_cellref(av, j);
+                if (p != NULL && (uintptr_t)p >= 4096U) {
+                    jl_value_t *p_ty = jl_typeof(p);
+                    if ((uintptr_t)p_ty >= 4096U) {
+                        if (!jl_isbits(p_ty)) {
+                            nlsep = 1;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        if (nlsep && tlen > 1)
+            n += jl_printf(out, "\n  ");
         for (j = 0; j < tlen; j++) {
             if (av->flags.ptrarray) {
                 n += jl_static_show_x(out, jl_cellref(v, j), depth);
@@ -1413,10 +1430,9 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v,
                 char *ptr = ((char*)av->data) + j * av->elsize;
                 n += jl_static_show_x_(out, (jl_value_t*)ptr, el_type, depth);
             }
-            if (j != tlen-1)
-                n += jl_printf(out, ", ");
+            if (j != tlen - 1)
+                n += jl_printf(out, nlsep ? ",\n  " : ", ");
         }
-        if (j < tlen) n += jl_printf(out, " ...");
         n += jl_printf(out, "]");
     }
     else if (vt == jl_loaderror_type) {
@@ -1479,17 +1495,25 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v,
     return n;
 }
 
-static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
+static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth)
 {
     // mimic jl_show, but never calling a julia method and
-    // (hopefully) never allocate through julia gc
+    // never allocate through julia gc
     if (v == NULL) {
         return jl_printf(out, "#<null>");
     }
     else if ((uintptr_t)v < 4096U) {
         return jl_printf(out, "#<%d>", (int)(uintptr_t)v);
     }
-    return jl_static_show_x_(out, v, (jl_datatype_t*)jl_typeof(v), depth);
+    unsigned int dist = 1;
+    struct recur_list this_item = {depth, v}, *p = depth;
+    while (p) {
+        if (p->v == v)
+            return jl_printf(out, "<circular reference @-%u>", dist);
+        dist++;
+        p = p->prev;
+    }
+    return jl_static_show_x_(out, v, (jl_datatype_t*)jl_typeof(v), &this_item);
 }
 
 JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
@@ -1540,7 +1564,7 @@ JL_DLLEXPORT void jl_(void *jl_value)
     jl_jmp_buf buf;
     jl_safe_restore = &buf;
     if (!jl_setjmp(buf, 0)) {
-        (void)jl_static_show((JL_STREAM*)STDERR_FILENO, (jl_value_t*)jl_value);
+        jl_static_show((JL_STREAM*)STDERR_FILENO, (jl_value_t*)jl_value);
         jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
     }
     else {

--- a/test/show.jl
+++ b/test/show.jl
@@ -408,3 +408,9 @@ A = reshape(1:16,4,4)
 @test sprint(show, :(break)) == ":(break)"
 @test_repr "continue"
 @test_repr "break"
+
+let x = [], y = []
+    push!(x, y)
+    push!(y, x)
+    @test replstr(x) == "1-element Array{Any,1}:\n Any[Any[Any[#= circular reference @-2 =#]]]"
+end


### PR DESCRIPTION
since we've started to use `jl_static_show` fairly heavily internally (for, e.g. printing function signatures, unexpected errors in fatal handlers or from lowering), this makes it more bail out of cycles with exactness instead of depending on the MAX_DEPTH heuristic.

also improves printing of a few other areas I noticed in the process (clearer printing of arrays makes `jl_(jl_uncompress_ast(meth, meth->code))` output readable, adds `f` to Float32 for disambiguation, normalize `#= circular reference =#` printing in a few places / avoid a stack overflow / add a depth counter to give some context)
