### PR TITLE
Compact REPL printouts of `Associative`s should never be verbose

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -79,7 +79,7 @@ function showdict{K,V}(io::IO, t::Associative{K,V}; compact = false)
                 for pair in t
                     first || print(io, ',')
                     first = false
-                    show(recur_io, pair)
+                    show_with_brackets(recur_io, pair) # never show verbose pairs
                     n+=1
                     limit && n >= 10 && (print(io, "…"); break)
                 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -195,19 +195,37 @@ print(io::IO, n::Unsigned) = print(io, dec(n))
 
 show{T}(io::IO, p::Ptr{T}) = print(io, typeof(p), " @0x$(hex(UInt(p), WORD_SIZE>>2))")
 
-function show(io::IO, p::Pair)
-    if typeof(p.first) != typeof(p).parameters[1] ||
-       typeof(p.second) != typeof(p).parameters[2]
-        return show_default(io, p)
-    end
+"""
+Displays a `Pair`, but surrounds the elements with brackets if they are also `Pair`s
 
+e.g: `1=>2=>3=>4` => "1=>(2=>(3=>4))"
+"""
+function show_with_brackets(io::IO, p::Pair)
     isa(p.first,Pair) && print(io, "(")
     show(io, p.first)
     isa(p.first,Pair) && print(io, ")")
+
     print(io, "=>")
+
     isa(p.second,Pair) && print(io, "(")
     show(io, p.second)
     isa(p.second,Pair) && print(io, ")")
+end
+
+function show(io::IO, p::Pair)
+    # Display Pairs so one can easily tell what type the Pair actually is
+    # if there could be confusion.
+
+    decl_T1, decl_T2 = typeof(p).parameters[1], typeof(p).parameters[2]
+    T1,      T2      = typeof(p.first),         typeof(p.second)
+
+    if decl_T1 != T1 || decl_T2 != T2
+        return show_default(io, p) # Pair{Any,Any}(1,Pair{Int64,Int64}(2,2))
+    end
+
+
+    # But otherwise, display it concisely.
+    show_with_brackets(io, p) # 1=>(2=>2)
 end
 
 function show(io::IO, m::Module)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -295,7 +295,8 @@ for d in (Dict("\n" => "\n", "1" => "\n", "\n" => "2"),
 end
 
 # Issue #15739 - Compact REPL printouts of an `Associative` use brackets when appropriate
-let d = Dict((1=>2) => (3=>45), (3=>10) => (10=>11))
+#                and don't show verbose type information.
+let d  = Dict(1=>(3=>45), 0x03=>10, 25=>25.0, (3=>4)=>(5=>10))
     buf = IOBuffer()
     showcompact(buf, d)
 
@@ -303,8 +304,17 @@ let d = Dict((1=>2) => (3=>45), (3=>10) => (10=>11))
     # dictionary ordering.
     result = bytestring(buf)
     @test contains(result, "Dict")
-    @test contains(result, "(1=>2)=>(3=>45)")
-    @test contains(result, "(3=>10)=>(10=>11)")
+    @test contains(result, "1=>(3=>45)")
+    @test contains(result, "0x03=>10")
+    @test contains(result, "25=>25.0")
+    @test contains(result, "(3=>4)=>(5=>10)")
+
+    # Check explicitly for the **lack** of verbose type information.
+    # See showdict(IO, Pair).
+    @test !contains(result, "Pair{Int64,Pair{Int64,Int64}}")
+    @test !contains(result, "Pair{UInt8,Int64}")
+    @test !contains(result, "Pair{Int64,Float64}")
+    @test !contains(result, "Pair{Pair{Int64,Int64},Pair{Int64,Int64}}")
 end
 
 # issue #9463


### PR DESCRIPTION
Fix #15739. Again.

```
julia> d = Dict(1 => "hi"); show(d)
Dict{Any,Any}(Pair{Any,Any}(1,"hi"))
```

In this PR:

```
julia> d = Dict(1 => "hi"); show(d)
Dict(1=>"hi")
```

This also covers the previous cases from PR https://github.com/JuliaLang/julia/pull/15853, including `Pair`s as values and/or keys.

This was caused by `show(IO, Pair)` calling `show_default(IO, Pair)` if the type parameters
of the `Pair` did not match the actual types contained within. e.g: `Pair{Any,Any}(1, 2)`.

Also updated tests to cover this case, and be more robust.

cc @Keno @vtjnash 
