### PR TITLE
Fixed up docs for changed dump function.

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1036,11 +1036,7 @@ function dump(io::IO, x::DataType, n::Int, indent)
             for idx in 1:length(fields)
                 println(io)
                 print(io, indent, "  ", fields[idx], "::")
-                #if isa(x.types[idx], DataType)
-                #    xdump(fn, io, fieldtype(x,idx), n - 1, string(indent, "  "))
-                #else
-                    print(io, fieldtype(x,idx))
-                #end
+                print(io, fieldtype(x,idx))
             end
         end
     end

--- a/contrib/BBEditTextWrangler-julia.plist
+++ b/contrib/BBEditTextWrangler-julia.plist
@@ -1216,7 +1216,6 @@
             <string>writesto</string>
             <string>wstring</string>
             <string>xcorr</string>
-            <string>xdump</string>
             <string>yield</string>
             <string>yieldto</string>
             <string>zero</string>

--- a/doc/devdocs/types.rst
+++ b/doc/devdocs/types.rst
@@ -90,7 +90,7 @@ Let's look at these types a little more closely:
    julia> Array
    Array{T,N}
 
-   julia> xdump(Array)
+   julia> dump(Array)
    Array{T,N}::DataType  <: DenseArray{T,N}
 
 This indicates that :obj:`Array` is a shorthand for ``Array{T,N}``.  If
@@ -104,7 +104,7 @@ parameters:
    julia> T,N = Array.parameters
    svec(T,N)
 
-   julia> xdump(T)
+   julia> dump(T)
    TypeVar
      name: Symbol T
      lb: Union{}
@@ -133,7 +133,7 @@ one can extract the underlying :obj:`TypeVar`:
    m = start(methods(g))
    p = m.sig.parameters
    tv = p[1]
-   xdump(tv)
+   dump(tv)
 
 .. testoutput:: s
 
@@ -169,14 +169,14 @@ parameters. For example:
    julia> p3 = start(methods(h3)).sig.parameters
    svec(Array{T<:Real,N},T<:Real)
 
-   julia> xdump(p1[1].parameters[1])
+   julia> dump(p1[1].parameters[1])
    TypeVar
      name: Symbol T
      lb: Union{}
      ub: Any::DataType  <: Any
      bound: Bool false
 
-   julia> xdump(p3[1].parameters[1])
+   julia> dump(p3[1].parameters[1])
    TypeVar
      name: Symbol T
      lb: Union{}
@@ -310,7 +310,7 @@ the type, which is an object of type :obj:`TypeName`:
 
 .. doctest::
 
-   julia> xdump(Array.name)
+   julia> dump(Array.name)
    TypeName
      name: Symbol Array
      module: Module Core

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -227,7 +227,7 @@ Constructors
 
    .. Docstring generated from Julia source
 
-   Create an array with the same data as the given array, but with different dimensions. An implementation for a particular type of array may choose whether the data is copied or shared.
+   Create an array with the same data as the given array, but with different dimensions.
 
 .. function:: similar(array, [element_type=eltype(array)], [dims=size(array)])
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -511,13 +511,7 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   Show all user-visible structure of a value.
-
-.. function:: xdump(x)
-
-   .. Docstring generated from Julia source
-
-   Show all structure of a value, including all fields of objects.
+   Show every part of the representation of a value.
 
 .. function:: readstring(stream::IO)
               readstring(filename::AbstractString)


### PR DESCRIPTION
For #15707. In addition:
- Some commented out code referring to `xdump` was removed from `base/show.jl`.
- `doc/stdlib/arrays.rst` was updated from building docs.
