### PR TITLE
Support isless for CartesianIndex

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -3,7 +3,7 @@
 ### Multidimensional iterators
 module IteratorsMD
 
-import Base: eltype, length, size, start, done, next, last, getindex, setindex!, linearindexing, min, max, eachindex, ndims, iteratorsize
+import Base: eltype, length, size, start, done, next, last, getindex, setindex!, linearindexing, min, max, isless, eachindex, ndims, iteratorsize
 importall ..Base.Operators
 import Base: simd_outer_range, simd_inner_length, simd_index, @generated
 import Base: @nref, @ncall, @nif, @nexprs, LinearFast, LinearSlow, to_index, AbstractCartesianIndex
@@ -72,6 +72,15 @@ end
     :($I($(args...)))
 end
 *(index::CartesianIndex,a::Integer)=*(a,index)
+
+# comparison
+@inline isless{N}(I1::CartesianIndex{N}, I2::CartesianIndex{N}) = _isless(0, I1.I, I2.I)
+@inline function _isless{N}(ret, I1::NTuple{N,Int}, I2::NTuple{N,Int})
+    newret = ifelse(ret==0, icmp(I1[N], I2[N]), ret)
+    _isless(newret, Base.front(I1), Base.front(I2))
+end
+_isless(ret, ::Tuple{}, ::Tuple{}) = ifelse(ret==1, true, false)
+icmp(a, b) = ifelse(isless(a,b), 1, ifelse(a==b, 0, -1))
 
 # Iteration
 immutable CartesianRange{I<:CartesianIndex}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1197,6 +1197,11 @@ I2 = CartesianIndex((-1,5,2))
 
 @test length(I1) == 3
 
+@test isless(CartesianIndex((1,1)), CartesianIndex((2,1)))
+@test isless(CartesianIndex((1,1)), CartesianIndex((1,2)))
+@test isless(CartesianIndex((2,1)), CartesianIndex((1,2)))
+@test !isless(CartesianIndex((1,2)), CartesianIndex((2,1)))
+
 a = spzeros(2,3)
 @test CartesianRange(size(a)) == eachindex(a)
 a[CartesianIndex{2}(2,3)] = 5


### PR DESCRIPTION
`isless(I1, I2)` returns true if `I1` would be visited before `I2` during `CartesianRange` iteration.

``` jl
julia> isless(CartesianIndex((5,4)), CartesianIndex((3,7)))
true
```

Also nicely efficient:

``` jl
julia> @code_llvm isless(CartesianIndex((5,4)), CartesianIndex((3,7)))

define i1 @julia_isless_53462(%CartesianIndex*, %CartesianIndex*) #0 {
top:
  %2 = getelementptr inbounds %CartesianIndex, %CartesianIndex* %0, i64 0, i32 0, i64 1
  %3 = getelementptr inbounds %CartesianIndex, %CartesianIndex* %1, i64 0, i32 0, i64 1
  %4 = load i64, i64* %2, align 8
  %5 = load i64, i64* %3, align 8
  %6 = icmp sge i64 %4, %5
  %7 = icmp ne i64 %4, %5
  %8 = sext i1 %7 to i64
  %9 = select i1 %6, i64 %8, i64 1
  %10 = getelementptr inbounds %CartesianIndex, %CartesianIndex* %0, i64 0, i32 0, i64 0
  %11 = getelementptr inbounds %CartesianIndex, %CartesianIndex* %1, i64 0, i32 0, i64 0
  %12 = icmp ne i64 %9, 0
  %13 = load i64, i64* %10, align 8
  %14 = load i64, i64* %11, align 8
  %15 = icmp sge i64 %13, %14
  %16 = icmp ne i64 %13, %14
  %17 = sext i1 %16 to i64
  %18 = select i1 %15, i64 %17, i64 1
  %19 = select i1 %12, i64 %9, i64 %18
  %not. = icmp eq i64 %19, 1
  ret i1 %not.
}
```
