### PR TITLE
Rework type promotion for scalar ∘ array and array ∘ scalar

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1041,9 +1041,9 @@ for f in (:+, :-)
 end
 for (f) in (:.+, :.-)
     for (arg1, arg2, T, fargs) in ((:(B::BitArray), :(x::Bool)    , Int                                   , :(b, x)),
-                                   (:(B::BitArray), :(x::Number)  , :(promote_array_type($f, typeof(x), Bool)), :(b, x)),
+                                   (:(B::BitArray), :(x::Number)  , :(promote_array_type($f, BitArray, typeof(x))), :(b, x)),
                                    (:(x::Bool)    , :(B::BitArray), Int                                   , :(x, b)),
-                                   (:(x::Number)  , :(B::BitArray), :(promote_array_type($f, typeof(x), Bool)), :(x, b)))
+                                   (:(x::Number)  , :(B::BitArray), :(promote_array_type($f, typeof(x), BitArray)), :(x, b)))
         @eval function ($f)($arg1, $arg2)
             r = Array($T, size(B))
             bi = start(B)
@@ -1082,7 +1082,7 @@ function div(x::Bool, B::BitArray)
 end
 function div(x::Number, B::BitArray)
     all(B) || throw(DivideError())
-    pt = promote_array_type(div, typeof(x), Bool)
+    pt = promote_array_type(div, typeof(x), BitArray)
     y = div(x, true)
     reshape(pt[ y for i = 1:length(B) ], size(B))
 end
@@ -1103,7 +1103,7 @@ function mod(x::Bool, B::BitArray)
 end
 function mod(x::Number, B::BitArray)
     all(B) || throw(DivideError())
-    pt = promote_array_type(mod, typeof(x), Bool)
+    pt = promote_array_type(mod, typeof(x), BitArray)
     y = mod(x, true)
     reshape(pt[ y for i = 1:length(B) ], size(B))
 end
@@ -1111,7 +1111,7 @@ end
 for f in (:div, :mod)
     @eval begin
         function ($f)(B::BitArray, x::Number)
-            F = Array(promote_array_type($f, typeof(x), Bool), size(B))
+            F = Array(promote_array_type($f, BitArray, typeof(x)), size(B))
             for i = 1:length(F)
                 F[i] = ($f)(B[i], x)
             end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -32,6 +32,10 @@ promote_op{T<:Real,S<:Real}(op, ::Type{Complex{T}}, ::Type{S}) =
     Complex{promote_op(op,T,S)}
 promote_op{T<:Real,S<:Real}(op, ::Type{T}, ::Type{Complex{S}}) =
     Complex{promote_op(op,T,S)}
+promote_op{T<:Integer,S<:Integer}(::typeof(^), ::Type{T}, ::Type{Complex{S}}) =
+    Complex{Float64}
+promote_op{T<:Integer,S<:Integer}(::typeof(.^), ::Type{T}, ::Type{Complex{S}}) =
+    Complex{Float64}
 
 widen{T}(::Type{Complex{T}}) = Complex{widen(T)}
 
@@ -803,7 +807,7 @@ big{T<:AbstractFloat,N}(A::AbstractArray{Complex{T},N}) = convert(AbstractArray{
 
 ## promotion to complex ##
 
-promote_array_type{S<:Union{Complex, Real}, AT<:AbstractFloat}(F, ::Type{S}, ::Type{Complex{AT}}) = Complex{AT}
+promote_array_type{S<:Union{Complex, Real}, AT<:AbstractFloat, P}(F, ::Type{S}, ::Type{Complex{AT}}, ::Type{P}) = Complex{AT}
 
 function complex{S<:Real,T<:Real}(A::AbstractArray{S}, B::AbstractArray{T})
     if size(A) != size(B); throw(DimensionMismatch()); end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -116,3 +116,14 @@ rt = Base.return_types(broadcast, Tuple{Function, Array{Float64, 3}, Array{Int, 
 @test length(rt) == 1 && rt[1] == Array{Float64, 3}
 rt = Base.return_types(broadcast!, Tuple{Function, Array{Float64, 3}, Array{Float64, 3}, Array{Int, 1}})
 @test length(rt) == 1 && rt[1] == Array{Float64, 3}
+
+# issue 14725
+let a = Number[2, 2.0, 4//2, 2+0im] / 2
+    @test eltype(a) == Number
+end
+let a = Real[2, 2.0, 4//2] / 2
+    @test eltype(a) == Real
+end
+let a = Real[2, 2.0, 4//2] / 2.0
+    @test eltype(a) == Real
+end


### PR DESCRIPTION
The first commit is relative direct fix of #14725, rewriting `./`, `.\`, and `.^` for the mixed scalar/array case to make use of `promote_eltype_op`.

The second commit supersedes the first (I will squash if the end result is deemed good). It rewrites the whole promotion part for mixed scalar/array operations to have all special-casing in the promotion, not in the definition of the operation. To this end `promote_array_type` is rewritten to a two-step procedure. In the first step, `promote_array_type` is invoked with the scalar and the array type (not its element type!) in correct order. This is the interface that is used for invoking. However, it just delegates to `promote_array_type` giving three types: scalar, array element, and result of `promote_op` with the arguments in correct order. This is important because (potentially) `promote_op(.^, Ta, Tb) != promote_op(.^, Tb, Ta)`. By default, this step returns the promoted type, but here specialization may be used to e.g. ensure that `eltype([0.0f0]+1)==Float32`. I am not exactly happy with both steps having the same function name, though, and wonder whether the first step should not simply replace `promote_eltype_op` for this case (I'm not sure about the implied contract of `promote_eltype_op`). Opinions?
