### PR TITLE
RFC: seachsorted(a,x,by=f) no longer applies `by` to the key argument x

### DIFF
--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -35,8 +35,8 @@ numTypes = [ Int8,  Int16,  Int32,  Int64,  Int128,
             UInt8, UInt16, UInt32, UInt64, UInt128,
             Float16, Float32, Float64, BigInt, BigFloat]
 
-@test searchsorted([1:10;], 1, by=(x -> x >= 5)) == 1:4
-@test searchsorted([1:10;], 10, by=(x -> x >= 5)) == 5:10
+@test searchsorted([1:10;], false, by=(x -> x >= 5)) == 1:4
+@test searchsorted([1:10;], true, by=(x -> x >= 5)) == 5:10
 @test searchsorted([1:5; 1:5; 1:5], 1, 6, 10, Forward) == 6:6
 @test searchsorted(ones(15), 1, 6, 10, Forward) == 6:10
 
@@ -52,8 +52,8 @@ for R in numTypes, T in numTypes
     @test searchsorted(1:3, T(2)) == 2:2
     @test searchsorted(1:3, T(4)) == 4:3
 
-    @test searchsorted(R[1:10;], T(1), by=(x -> x >= 5)) == 1:4
-    @test searchsorted(R[1:10;], T(10), by=(x -> x >= 5)) == 5:10
+    @test searchsorted(R[1:10;], false, by=(x -> x >= 5)) == 1:4
+    @test searchsorted(R[1:10;], true, by=(x -> x >= 5)) == 5:10
     @test searchsorted(R[1:5; 1:5; 1:5], T(1), 6, 10, Forward) == 6:6
     @test searchsorted(ones(R, 15), T(1), 6, 10, Forward) == 6:10
 end


### PR DESCRIPTION
Following #9429, this pull request modifies `searchsorted` and friends to not apply to optional `by` argument to the sought for key `x`. As explained in #9429, this makes sense because it is not always possible to come up with a value x such that `by(x)` is the determinant is the binary search. In addition to the examples in #9429, consider a line of people ordered according to height. It is possible that a user is interested in the first person taller then 1.66 meters, even though no person in the line-up actually has that height.

The behaviour of `searchsorted` before these modifications can be achieved by calling

```
searchsorted(a,f(x),by=f)
```

The tests in `test/sorting.jl` have been modified to pass. In particular, consider:

```
@test searchsorted([1:10], false, by=(x -> x >=5)) == 1:4
```

Before, this test read

```
@test searchsorted([1:10], 1, by=(x-> x >=5)) == 1:4
```

This demonstrates how unnatural the previous behaviour was. The key `1` is arbitrarily chosen from the set of values that give `by(x) == false`. In addition, the previous behaviour obfuscates that in order for `searchsorted` to work correctly, it relies on the Julia convention `false < true`.
