### PR TITLE
Fix compile errors on llvm svn

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
 #include "llvm-version.h"
+#include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/APFloat.h>
 #include <llvm/Support/MathExtras.h>

--- a/src/abi_arm.cpp
+++ b/src/abi_arm.cpp
@@ -293,7 +293,7 @@ Type *preferred_llvm_type(jl_value_t *ty, bool isret)
     if (align > 8)
         align = 8;
 
-    Type *T = Type::getIntNTy(getGlobalContext(), align*8);
+    Type *T = Type::getIntNTy(jl_LLVMContext, align*8);
     return ArrayType::get(T, (dt->size + align - 1) / align);
 }
 

--- a/src/abi_win32.cpp
+++ b/src/abi_win32.cpp
@@ -69,7 +69,7 @@ Type *preferred_llvm_type(jl_value_t *ty, bool isret)
     // rewrite integer sized (non-sret) struct to the corresponding integer
     if (!dt->nfields || use_sret(NULL, ty))
         return NULL;
-    return Type::getIntNTy(getGlobalContext(), dt->size * 8);
+    return Type::getIntNTy(jl_LLVMContext, dt->size * 8);
 }
 
 bool need_private_copy(jl_value_t *ty, bool byRef)

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -69,7 +69,7 @@ Type *preferred_llvm_type(jl_value_t *ty, bool isret)
         return NULL;
     size_t size = jl_datatype_size(ty);
     if (size > 0 && size <= 8 && !jl_is_bitstype(ty))
-        return Type::getIntNTy(getGlobalContext(), size*8);
+        return Type::getIntNTy(jl_LLVMContext, size*8);
     return NULL;
 }
 

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -212,7 +212,7 @@ Type *preferred_llvm_type(jl_value_t *ty, bool isret)
             if (size >= 8)
                 types[0] = T_int64;
             else
-                types[0] = Type::getIntNTy(getGlobalContext(), size*8);
+                types[0] = Type::getIntNTy(jl_LLVMContext, size*8);
             break;
         case Sse:
             if (size <= 4)
@@ -228,7 +228,7 @@ Type *preferred_llvm_type(jl_value_t *ty, bool isret)
             return types[0];
         case Integer:
             assert(size > 8);
-            types[1] = Type::getIntNTy(getGlobalContext(), (size-8)*8);
+            types[1] = Type::getIntNTy(jl_LLVMContext, (size-8)*8);
             return StructType::get(jl_LLVMContext,ArrayRef<Type*>(&types[0],2));
         case Sse:
             if (size <= 12)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -281,9 +281,9 @@ static Value *julia_to_native(Type *to, bool toboxed, jl_value_t *jlto, const jl
         // emit maybe copy
         *needStackRestore = true;
         Value *jvt = emit_typeof_boxed(jvinfo, ctx);
-        BasicBlock *mutableBB = BasicBlock::Create(getGlobalContext(),"is-mutable",ctx->f);
-        BasicBlock *immutableBB = BasicBlock::Create(getGlobalContext(),"is-immutable",ctx->f);
-        BasicBlock *afterBB = BasicBlock::Create(getGlobalContext(),"after",ctx->f);
+        BasicBlock *mutableBB = BasicBlock::Create(jl_LLVMContext,"is-mutable",ctx->f);
+        BasicBlock *immutableBB = BasicBlock::Create(jl_LLVMContext,"is-immutable",ctx->f);
+        BasicBlock *afterBB = BasicBlock::Create(jl_LLVMContext,"after",ctx->f);
         Value *ismutable = builder.CreateTrunc(
                 tbaa_decorate(tbaa_datatype, builder.CreateLoad(
                         builder.CreateGEP(builder.CreatePointerCast(jvt, T_pint8),
@@ -1246,7 +1246,11 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(nargt == 0);
         JL_GC_POP();
 #ifdef JULIA_ENABLE_THREADING
+#ifdef LLVM39
+        builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
+#else
         builder.CreateFence(SequentiallyConsistent, SingleThread);
+#endif
         Value *addr;
         if (imaging_mode) {
             assert(ctx->signalPage);
@@ -1257,7 +1261,11 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                 ConstantInt::get(T_size, (uintptr_t)jl_gc_signal_page), T_pint8);
         }
         builder.CreateLoad(addr, true);
+#ifdef LLVM39
+        builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
+#else
         builder.CreateFence(SequentiallyConsistent, SingleThread);
+#endif
 #endif
         return ghostValue(jl_void_type);
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -54,7 +54,7 @@ static Value *stringConstPtr(const std::string &txt)
                                     ArrayType::get(T_int8, pooledtxt.size()),
                                     true,
                                     GlobalVariable::PrivateLinkage,
-                                    ConstantDataArray::get(getGlobalContext(),
+                                    ConstantDataArray::get(jl_LLVMContext,
                                                            ArrayRef<unsigned char>(
                                                            (const unsigned char*)pooledtxt.data(),
                                                            pooledtxt.size())),
@@ -573,14 +573,14 @@ static void emit_error(const std::string &txt, jl_codectx_t *ctx)
 {
     just_emit_error(txt, ctx);
     builder.CreateUnreachable();
-    BasicBlock *cont = BasicBlock::Create(getGlobalContext(),"after_error",ctx->f);
+    BasicBlock *cont = BasicBlock::Create(jl_LLVMContext,"after_error",ctx->f);
     builder.SetInsertPoint(cont);
 }
 
 static void error_unless(Value *cond, const std::string &msg, jl_codectx_t *ctx)
 {
-    BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
-    BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
+    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+    BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
     builder.CreateCondBr(cond, passBB, failBB);
     builder.SetInsertPoint(failBB);
     just_emit_error(msg, ctx);
@@ -591,8 +591,8 @@ static void error_unless(Value *cond, const std::string &msg, jl_codectx_t *ctx)
 
 static void raise_exception_unless(Value *cond, Value *exc, jl_codectx_t *ctx)
 {
-    BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
-    BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
+    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+    BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
     builder.CreateCondBr(cond, passBB, failBB);
     builder.SetInsertPoint(failBB);
 #ifdef LLVM37
@@ -664,8 +664,8 @@ static void emit_typecheck(const jl_cgval_t &x, jl_value_t *type, const std::str
     else {
         istype = builder.CreateICmpEQ(emit_typeof_boxed(x,ctx), literal_pointer_val(type));
     }
-    BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
-    BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
+    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+    BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
     builder.CreateCondBr(istype, passBB, failBB);
     builder.SetInsertPoint(failBB);
 
@@ -699,8 +699,8 @@ static Value *emit_bounds_check(const jl_cgval_t &ainfo, jl_value_t *ty, Value *
          jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_OFF) ||
          jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_ON) {
         Value *ok = builder.CreateICmpULT(im1, len);
-        BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
-        BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
+        BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+        BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
         builder.CreateCondBr(ok, passBB, failBB);
         builder.SetInsertPoint(failBB);
         if (!ty) { // jl_value_t** tuple (e.g. the vararg)
@@ -1212,8 +1212,8 @@ static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, size_
         jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_ON;
     BasicBlock *failBB=NULL, *endBB=NULL;
     if (bc) {
-        failBB = BasicBlock::Create(getGlobalContext(), "oob");
-        endBB = BasicBlock::Create(getGlobalContext(), "idxend");
+        failBB = BasicBlock::Create(jl_LLVMContext, "oob");
+        endBB = BasicBlock::Create(jl_LLVMContext, "idxend");
     }
 #endif
     Value **idxs = (Value**)alloca(sizeof(Value*)*nidxs);
@@ -1228,7 +1228,7 @@ static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, size_
                 k >= nd ? ConstantInt::get(T_size, 1) : emit_arraysize(ainfo, ex, k+1, ctx);
 #if CHECK_BOUNDS==1
             if (bc) {
-                BasicBlock *okBB = BasicBlock::Create(getGlobalContext(), "ib");
+                BasicBlock *okBB = BasicBlock::Create(jl_LLVMContext, "ib");
                 // if !(i < d) goto error
                 builder.CreateCondBr(builder.CreateICmpULT(ii, d), okBB, failBB);
                 ctx->f->getBasicBlockList().push_back(okBB);
@@ -1453,8 +1453,8 @@ static void emit_cpointercheck(const jl_cgval_t &x, const std::string &msg, jl_c
     Value *istype =
         builder.CreateICmpEQ(emit_nthptr(t, (ssize_t)(offsetof(jl_datatype_t,name)/sizeof(char*)), tbaa_datatype),
                              literal_pointer_val((jl_value_t*)jl_pointer_type->name));
-    BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
-    BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
+    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+    BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
     builder.CreateCondBr(istype, passBB, failBB);
     builder.SetInsertPoint(failBB);
 
@@ -1502,9 +1502,9 @@ static void emit_write_barrier(jl_codectx_t *ctx, Value *parent, Value *ptr)
     //builder.CreateCall(expect_func, {parent_marked, ConstantInt::get(T_int1, 0)});
     Value *parent_marked = builder.CreateICmpEQ(parent_mark_bits, ConstantInt::get(T_size, 1));
 
-    BasicBlock *cont = BasicBlock::Create(getGlobalContext(), "cont");
-    BasicBlock *barrier_may_trigger = BasicBlock::Create(getGlobalContext(), "wb_may_trigger", ctx->f);
-    BasicBlock *barrier_trigger = BasicBlock::Create(getGlobalContext(), "wb_trigger", ctx->f);
+    BasicBlock *cont = BasicBlock::Create(jl_LLVMContext, "cont");
+    BasicBlock *barrier_may_trigger = BasicBlock::Create(jl_LLVMContext, "wb_may_trigger", ctx->f);
+    BasicBlock *barrier_trigger = BasicBlock::Create(jl_LLVMContext, "wb_trigger", ctx->f);
     builder.CreateCondBr(parent_marked, barrier_may_trigger, cont);
 
     builder.SetInsertPoint(barrier_may_trigger);
@@ -1522,8 +1522,8 @@ static void emit_checked_write_barrier(jl_codectx_t *ctx, Value *parent, Value *
 {
     BasicBlock *cont;
     Value *not_null = builder.CreateICmpNE(ptr, V_null);
-    BasicBlock *if_not_null = BasicBlock::Create(getGlobalContext(), "wb_not_null", ctx->f);
-    cont = BasicBlock::Create(getGlobalContext(), "cont");
+    BasicBlock *if_not_null = BasicBlock::Create(jl_LLVMContext, "wb_not_null", ctx->f);
+    cont = BasicBlock::Create(jl_LLVMContext, "cont");
     builder.CreateCondBr(not_null, if_not_null, cont);
     builder.SetInsertPoint(if_not_null);
     emit_write_barrier(ctx, parent, ptr);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -810,9 +810,9 @@ static Value *emit_checked_srem_int(Value *x, Value *den, jl_codectx_t *ctx)
     Type *t = den->getType();
     raise_exception_unless(builder.CreateICmpNE(den, ConstantInt::get(t,0)),
                            prepare_global(jldiverr_var), ctx);
-    BasicBlock *m1BB = BasicBlock::Create(getGlobalContext(),"minus1",ctx->f);
-    BasicBlock *okBB = BasicBlock::Create(getGlobalContext(),"oksrem",ctx->f);
-    BasicBlock *cont = BasicBlock::Create(getGlobalContext(),"after_srem",ctx->f);
+    BasicBlock *m1BB = BasicBlock::Create(jl_LLVMContext,"minus1",ctx->f);
+    BasicBlock *okBB = BasicBlock::Create(jl_LLVMContext,"oksrem",ctx->f);
+    BasicBlock *cont = BasicBlock::Create(jl_LLVMContext,"after_srem",ctx->f);
     PHINode *ret = PHINode::Create(t, 2);
     builder.CreateCondBr(builder.CreateICmpEQ(den,ConstantInt::get(t,-1,true)),
                          m1BB, okBB);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -109,9 +109,6 @@ static void addOptimizationPasses(T *PM)
     PM->add(createDeadStoreEliminationPass());  // Delete dead stores
 #if !defined(INSTCOMBINE_BUG)
     if (jl_options.opt_level >= 3) {
-#ifdef LLVM39
-        initializeDemandedBitsPass(*PassRegistry::getPassRegistry());
-#endif
         PM->add(createSLPVectorizerPass());     // Vectorize straight-line code
     }
 #endif
@@ -256,7 +253,7 @@ class JuliaOJIT {
                         continue;
                     if (!(Flags & object::BasicSymbolRef::SF_Exported))
                         continue;
-                    ErrorOr<StringRef> Name = Symbol.getName();
+                    auto Name = Symbol.getName();
                     orc::JITSymbol Sym = JIT.CompileLayer.findSymbolIn(H, *Name, true);
                     assert(Sym);
                     // note: calling getAddress here eagerly finalizes H


### PR DESCRIPTION
- Explicitly include `<llvm/ADT/ArrayRef.h>`
- Remove all use of `getGlobalContext()`
- `AtomicOrdering` becomes scoped
- Ambiguity when comparing `DITypeRef` with `DIDerivedType*` (possible LLVM bug? @Keno ?)

Compilation of the c++ code passes on LLVM 3.3 (with `-std=c++11`)
