### PR TITLE
Fix generic atomic operation support on Linux with LLVM svn

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -197,6 +197,22 @@ extern RTDyldMemoryManager *createRTDyldMemoryManagerUnix();
 #define CUSTOM_MEMORY_MANAGER() new SectionMemoryManager
 #endif
 
+#ifdef _OS_LINUX_
+// Resolve non-lock free atomic functions in the libatomic library.
+// This is the library that provides support for c11/c++11 atomic operations.
+static uint64_t resolve_atomic(const char *name)
+{
+    static void *atomic_hdl = jl_load_dynamic_library_e("libatomic.so",
+                                                        JL_RTLD_LOCAL);
+    static const char *const atomic_prefix = "__atomic_";
+    if (!atomic_hdl)
+        return 0;
+    if (strncmp(name, atomic_prefix, strlen(atomic_prefix)) != 0)
+        return 0;
+    return (uintptr_t)jl_dlsym_e(atomic_hdl, name);
+}
+#endif
+
 // A simplified model of the LLVM ExecutionEngine that implements only the methods that Julia needs
 // but tries to roughly match the API anyways so that compatibility is easier
 class JuliaOJIT {
@@ -396,6 +412,10 @@ public:
                             // Step 2: Search the program symbols
                             if (uint64_t addr = SectionMemoryManager::getSymbolAddressInProcess(Name))
                                 return RuntimeDyld::SymbolInfo(addr, JITSymbolFlags::Exported);
+#ifdef _OS_LINUX_
+                            if (uint64_t addr = resolve_atomic(Name.c_str()))
+                                return RuntimeDyld::SymbolInfo(addr, JITSymbolFlags::Exported);
+#endif
                             // Return failure code
                             return RuntimeDyld::SymbolInfo(nullptr);
                           },


### PR DESCRIPTION
By looking up the symbol in libatomic.
We shouldn't really need to provide this library since it should be part of the platform ABI.

Only `__atomic_` function is supported now since I can't find where is the old `__sync_` functions defined (if they exist at all) so this fixes the issue with atomic operations only on llvm svn, when llvm starts to emit `__atomic_` functions instead of `__sync_` ones.

As a background, these are necessary because (IIUC) the instruction/functions emitted should be consistent on the same platform so it can't really use the atomic instructions if it is not used by the platform ABI. I'm not sure if there's a way to tell LLVM that certain atomic ops doesn't have to be consistent with others.
