### PR TITLE
Added copying of header files to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,11 @@ endif
 			fi \
 		done \
 	done
+	# this could be improved: for example, the libraries for suitesparse
+	# are not included, because they already don't appear in the build tree
+	for inc in $(build_includedir)/*.h; do \
+		$(INSTALL_F) $$inc $(DESTDIR)$(includedir) ; \
+	done
 
 	# Copy in libssl and libcrypto if they exist
 ifeq ($(OS),Linux)


### PR DESCRIPTION
This PR adds 3 lines to the 'install' rule so that header files are copied from the build tree to the install tree.
It's not yet perfect in making the private Julia libraries accessible to packages, because e.g. Suitesparse's files are not copied (they don't appear in the build tree).
