### PR TITLE
make flush(stream) return nothing

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -35,7 +35,6 @@ function flush(s::IOStream)
     bad = ccall(:ios_flush, Cint, (Ptr{Void},), s.ios) != 0
     sigatomic_end()
     systemerror("flush", bad)
-    s
 end
 iswritable(s::IOStream) = ccall(:ios_get_writable, Cint, (Ptr{Void},), s.ios)!=0
 isreadable(s::IOStream) = ccall(:ios_get_readable, Cint, (Ptr{Void},), s.ios)!=0

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -831,14 +831,14 @@ end
 
 function flush(s::LibuvStream)
     if isnull(s.sendbuf)
-        return s
+        return
     end
     buf = get(s.sendbuf)
     if nb_available(buf) > 0
         arr = takebuf_array(buf)        # Array of UInt8s
         uv_write(s, arr)
     end
-    return s
+    return
 end
 
 buffer_writes(s::LibuvStream, bufsize) = (s.sendbuf=PipeBuffer(bufsize); s)
@@ -1038,4 +1038,4 @@ end
 
 # If buffer_writes is called, it will delay notifying waiters till a flush is called.
 buffer_writes(s::BufferStream, bufsize=0) = (s.buffer_writes=true; s)
-flush(s::BufferStream) = (notify(s.r_c; all=true); s)
+flush(s::BufferStream) = (notify(s.r_c; all=true); nothing)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -197,7 +197,7 @@ let bstream = BufferStream()
     a = rand(UInt8,10)
     write(bstream,a)
     @test !eof(bstream)
-    flush(bstream)
+    @test flush(bstream) === nothing
     b = read(bstream,UInt8)
     @test a[1] == b
     b = read(bstream,UInt8)

--- a/test/read.jl
+++ b/test/read.jl
@@ -473,7 +473,8 @@ f2 = Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
 @test skip(f2, 10) == f2
 @test eof(f1)
 @test eof(f2)
-@test write(f1, '*') == 1; @test flush(f1) == f1
+@test write(f1, '*') == 1
+@test flush(f1) === nothing
 @test !eof(f2)
 @test skip(f2, 1) == f2
 @test write(f2, '*') == 1


### PR DESCRIPTION
The current `flush(stream)` function returns `stream` or `nothing` depends on the type of `stream` argument. For example, `flush(::TextTerminal)` and `flush(::DevNullStream)` will return `nothing` but `flush(::IOStream)` and `flush(::BufferStream)` will return the first argument. This pull request fixes the inconsistency and makes it always return `nothing`. It is also reasonable to make it return the first argument, but it is not quite useful.

Exactly speaking, this is a breaking change, but I believe nobody depends on this behavior and will not break any code.
