### PR TITLE
make close(stream) return nothing

### DIFF
--- a/base/base64.jl
+++ b/base/base64.jl
@@ -150,6 +150,7 @@ function close(b::Base64EncodePipe)
         end
         b.nb = 0
     end
+    nothing
 end
 
 # like sprint, but returns base64 string

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -24,7 +24,7 @@ closed_exception() = InvalidStateException("Channel is closed.", :closed)
 function close(c::Channel)
     c.state = :closed
     notify_error(c::Channel, closed_exception())
-    c
+    nothing
 end
 isopen(c::Channel) = (c.state == :open)
 

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -96,7 +96,7 @@ function close(f::File)
     uv_error("close", err)
     f.handle = RawFD(-1)
     f.open = false
-    return f
+    return nothing
 end
 
 # sendfile is the most efficient way to copy a file (or any file descriptor)

--- a/base/poll.jl
+++ b/base/poll.jl
@@ -149,7 +149,6 @@ type _FDWatcher
                         FDWatchers[fdnum] = nothing
                     end
                     notify(t.notify, FDEvent(true, true, false))
-                    nothing
                 end
             end
             nothing

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -999,7 +999,12 @@ type BufferStream <: LibuvStream
 end
 
 isopen(s::BufferStream) = s.is_open
-close(s::BufferStream) = (s.is_open = false; notify(s.r_c; all=true); notify(s.close_c; all=true); nothing)
+function close(s::BufferStream)
+    s.is_open = false
+    notify(s.r_c; all=true)
+    notify(s.close_c; all=true)
+    nothing
+end
 read(s::BufferStream, ::Type{UInt8}) = (wait_readnb(s, 1); read(s.buffer, UInt8))
 unsafe_read(s::BufferStream, a::Ptr{UInt8}, nb::UInt) = (wait_readnb(s, Int(nb)); unsafe_read(s.buffer, a, nb))
 nb_available(s::BufferStream) = nb_available(s.buffer)

--- a/test/base64.jl
+++ b/test/base64.jl
@@ -13,13 +13,13 @@ fname = tempname()
 open(fname, "w") do f
     opipe = Base64EncodePipe(f)
     write(opipe,inputText)
-    close(opipe)
+    @test close(opipe) === nothing
 end
 
 open(fname, "r") do f
     ipipe = Base64DecodePipe(f)
     @test readstring(ipipe) == inputText
-    close(ipipe)
+    @test close(ipipe) === nothing
 end
 rm(fname)
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -7,7 +7,9 @@ starttime = time()
 pwd_ = pwd()
 dir = mktempdir()
 file = joinpath(dir, "afile.txt")
-close(open(file,"w")) # like touch, but lets the operating system update the timestamp for greater precision on some platforms (windows)
+# like touch, but lets the operating system update the timestamp
+# for greater precision on some platforms (windows)
+@test close(open(file,"w")) === nothing
 
 subdir = joinpath(dir, "adir")
 mkdir(subdir)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -207,7 +207,7 @@ let bstream = BufferStream()
     @test !eof(bstream)
     read!(bstream,c)
     @test c == a[3:10]
-    close(bstream)
+    @test close(bstream) === nothing
     @test eof(bstream)
     @test nb_available(bstream) == 0
 end


### PR DESCRIPTION
Continued from #16076. I've just found that `close(stream)` is also inconsistent about the return value. This pull request makes it always return `nothing`.
