### PR TITLE
Add missing promote_op method for Nullable

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -25,6 +25,7 @@ convert(   ::Type{Nullable   }, ::Void) = Nullable{Union{}}()
 
 promote_rule{S,T}(::Type{Nullable{S}}, ::Type{T}) = Nullable{promote_type(S, T)}
 promote_rule{S,T}(::Type{Nullable{S}}, ::Type{Nullable{T}}) = Nullable{promote_type(S, T)}
+promote_op{S,T}(op::Any, ::Type{Nullable{S}}, ::Type{Nullable{T}}) = Nullable{promote_op(op, S, T)}
 
 function show{T}(io::IO, x::Nullable{T})
     if get(io, :compact, false)

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -276,6 +276,13 @@ end
 @test promote_type(Nullable{Union{}}, Int) === Nullable{Int}
 @test promote_type(Nullable{Float64}, Nullable{Int}) === Nullable{Float64}
 @test promote_type(Nullable{Union{}}, Nullable{Int}) === Nullable{Int}
+@test promote_type(Nullable{Date}, Nullable{DateTime}) === Nullable{DateTime}
+
+@test Base.promote_op(+, Nullable{Int}, Nullable{Int}) == Nullable{Int}
+@test Base.promote_op(-, Nullable{Int}, Nullable{Int}) == Nullable{Int}
+@test Base.promote_op(+, Nullable{Float64}, Nullable{Int}) == Nullable{Float64}
+@test Base.promote_op(-, Nullable{Float64}, Nullable{Int}) == Nullable{Float64}
+@test Base.promote_op(-, Nullable{DateTime}, Nullable{DateTime}) == Nullable{Base.Dates.Millisecond}
 
 # issue #11675
 @test repr(Nullable()) == "Nullable{Union{}}()"


### PR DESCRIPTION
I noticed that these promotion methods were missing for `Nullable` types when working with the following code:

``` julia
julia> using NullableArrays

julia> NullableArray([DateTime(2016)]) - NullableArray([DateTime(2015)])
ERROR: MethodError: Cannot `convert` an object of type Base.Dates.Millisecond to an object of type DateTime
This may have arisen from a call to the constructor DateTime(...),
since type constructors fall back to convert methods.
Closest candidates are:
  convert(::Type{DateTime}, ::Date)
  convert{R<:Real}(::Type{DateTime}, ::R<:Real)
  convert{T}(::Type{T}, ::T)
  ...
 [inlined code] from ./nullable.jl:40
 in -(::NullableArrays.NullableArray{DateTime,1}, ::NullableArrays.NullableArray{DateTime,1}) at ./arraymath.jl:85
 in eval(::Module, ::Any) at ./boot.jl:236
```

These changes should be backported to 0.4. The `promote_op` test will need to be updated to work on 0.4 and 0.5.
