### PR TITLE
RFC: add a typemap level specifically for Any

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -276,6 +276,7 @@ function visit(f, mc::TypeMapLevel)
         end
     end
     mc.list !== nothing && visit(f, mc.list)
+    mc.any !== nothing && visit(f, mc.any)
     nothing
 end
 function visit(f, d::TypeMapEntry)

--- a/src/dump.c
+++ b/src/dump.c
@@ -933,8 +933,9 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
                         offsetof(jl_typemap_level_t, arg1) == 0 * sizeof(jl_value_t*) &&
                         offsetof(jl_typemap_level_t, targ) == 1 * sizeof(jl_value_t*) &&
                         offsetof(jl_typemap_level_t, linear) == 2 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, key) == 3 * sizeof(jl_value_t*) &&
-                        sizeof(jl_typemap_level_t) == 4 * sizeof(jl_value_t*));
+                        offsetof(jl_typemap_level_t, any) == 3 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, key) == 4 * sizeof(jl_value_t*) &&
+                        sizeof(jl_typemap_level_t) == 5 * sizeof(jl_value_t*));
                     if (node->arg1 != (void*)jl_nothing) {
                         jl_array_t *a = jl_alloc_cell_1d(0);
                         for (i = 0, l = jl_array_len(node->arg1); i < l; i++) {
@@ -960,6 +961,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
                         jl_serialize_value(s, jl_nothing);
                     }
                     jl_serialize_value(s, node->linear);
+                    jl_serialize_value(s, node->any.unknown);
                     jl_serialize_value(s, node->key);
                     return;
                 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3386,9 +3386,9 @@ void jl_init_types(void)
 
     jl_typemap_level_type =
         jl_new_datatype(jl_symbol("TypeMapLevel"), jl_any_type, jl_emptysvec,
-                        jl_svec(4, jl_symbol("arg1"), jl_symbol("targ"), jl_symbol("list"), jl_symbol("key")),
-                        jl_svec(4, jl_any_type,       jl_any_type,       jl_any_type,       jl_any_type),
-                        0, 1, 3);
+                        jl_svec(5, jl_symbol("arg1"), jl_symbol("targ"), jl_symbol("list"), jl_symbol("any"), jl_symbol("key")),
+                        jl_svec(5, jl_any_type,       jl_any_type,       jl_any_type,       jl_any_type,      jl_any_type),
+                        0, 1, 4);
 
     jl_typemap_entry_type =
         jl_new_datatype(jl_symbol("TypeMapEntry"), jl_any_type, jl_emptysvec,

--- a/src/julia.h
+++ b/src/julia.h
@@ -409,6 +409,7 @@ typedef struct _jl_typemap_level_t {
     jl_array_t *arg1; // Array{union jl_typemap_t}
     jl_array_t *targ; // Array{union jl_typemap_t}
     jl_typemap_entry_t *linear; // union jl_typemap_t (but no more levels)
+    union jl_typemap_t any; // type at offs is Any
     jl_value_t *key; // [nullable]
 } jl_typemap_level_t;
 


### PR DESCRIPTION
I don't think this comes up often in the cache, but I think it may be beneficial in a few cases. specifically, it ensures the following sort of cache signature can hit one of the optimized caches:

`f(a::ANY, b) = ...`

or the following set of methods gets a fast lookup path instead of the linear list scan:

`for i = 1:100; @eval f(a, b::Val{i}) = i; end`

~~this reveals a couple of missing ambiguity warnings stemming from call -> convert translation. I'm assuming that fallback method will go away so I'm not working around them even though it's probably now calling the wrong method. (except I had to work around the one that made the core test fail).~~
edit: that was from a serious bug in the PR. those methods are probably ambiguous, but the detection I thought I was seeing in this PR was an implementation mistake
