### PR TITLE
simplify and speed up test macro a bit

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -40,18 +40,15 @@ fails = @testset NoThrowTestSet begin
     @test_throws OverflowError error()
     # Fail - no exception
     @test_throws OverflowError 1 + 1
-    # Fail - const
-    @test false
     # Fail - comparison
     @test 1+1 == 2+2
 end
-for i in 1:4
+for i in 1:3
     @test isa(fails[i], Base.Test.Fail)
 end
 @test contains(sprint(show, fails[1]), "Thrown: ErrorException")
 @test contains(sprint(show, fails[2]), "No exception thrown")
-@test contains(sprint(show, fails[3]), "Evaluated: false")
-@test contains(sprint(show, fails[4]), "Evaluated: 2 == 4")
+@test contains(sprint(show, fails[3]), "Evaluated: 2 == 4")
 
 # Test printing of a TestSetException
 tse_str = sprint(show, Test.TestSetException(1,2,3))


### PR DESCRIPTION
While working on #15954 I noticed that the performance of the `@test` macro itself can be significant. This is a speedup and simplification. It mostly affects tests that do large numbers of quick tests; for example it shaves about 10 seconds off the numbers test.

First, we were doing a strange thing where we passed the quoted test expression to `do_test` twice: once directly to `do_test`, and once wrapped in a tuple wrapped in a `Returned` object. I fixed this by adding an optional extra `data` field to `Returned` for extra data about the test. The "extra data" is either the type of exception expected by test_throws, or the evaluated arguments to a comparison. This data used to end up in the `expr` field of `Pass` or `Fail`, so this field is renamed to `data`.

Second, I simplified the lowering of tests of comparisons not to require temporary variables. This speeds up the macro expansion process. Tests are macroexpand-heavy to a very unusual degree.

Third, there seemed to be kind of a strange special case as follows:

```
julia> @test false
Test Failed
  Expression: false
   Evaluated: false

julia> @test !true
Test Failed
  Expression: !true
```

I don't think we need to print `Evaluated: false` in this case, so this is removed.
