### PR TITLE
fix ordering dependence of method cache insertion

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3829,7 +3829,7 @@ static Function *jl_cfunction_object(jl_function_t *ff, jl_value_t *declrt, jl_t
     cfunc_sig = (jl_value_t*)jl_apply_tuple_type((jl_svec_t*)cfunc_sig);
 
     // check the cache
-    if (jl_cfunction_list.unknown != NULL) {
+    if (jl_cfunction_list.unknown != jl_nothing) {
         jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(jl_cfunction_list, (jl_tupletype_t*)cfunc_sig, NULL, 1, 0, /*offs*/0);
         if (sf) {
             Function *f = (Function*)jl_unbox_voidpointer(sf->func.value);
@@ -3838,9 +3838,6 @@ static Function *jl_cfunction_object(jl_function_t *ff, jl_value_t *declrt, jl_t
                return f;
             }
         }
-    }
-    else {
-        jl_cfunction_list.unknown = jl_nothing;
     }
     jl_typemap_entry_t *sf = jl_typemap_insert(&jl_cfunction_list, (jl_value_t*)jl_cfunction_list.unknown, (jl_tupletype_t*)cfunc_sig,
             jl_emptysvec, NULL, jl_emptysvec, NULL, /*offs*/0, &cfunction_cache, NULL);

--- a/src/gc.c
+++ b/src/gc.c
@@ -1995,8 +1995,9 @@ static void pre_mark(void)
         gc_push_root(jl_an_empty_cell, 0);
     if (jl_module_init_order != NULL)
         gc_push_root(jl_module_init_order, 0);
-    if (jl_cfunction_list.unknown != NULL)
-        gc_push_root(jl_cfunction_list.unknown, 0);
+    gc_push_root(jl_cfunction_list.unknown, 0);
+    gc_push_root(jl_anytuple_type_type, 0);
+    gc_push_root(jl_ANY_flag, 0);
 
     // objects currently being finalized
     for(i=0; i < to_finalize.len; i++) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -32,6 +32,7 @@ jl_datatype_t *jl_typedslot_type;
 jl_datatype_t *jl_simplevector_type;
 jl_typename_t *jl_tuple_typename;
 jl_tupletype_t *jl_anytuple_type;
+jl_datatype_t *jl_anytuple_type_type;
 jl_datatype_t *jl_ntuple_type;
 jl_typename_t *jl_ntuple_typename;
 jl_datatype_t *jl_vararg_type;
@@ -3702,6 +3703,12 @@ void jl_init_types(void)
     slot_sym = jl_symbol("slot");
     static_parameter_sym = jl_symbol("static_parameter");
     compiler_temp_sym = jl_symbol("#temp#");
+
+    tttvar = jl_new_typevar(jl_symbol("T"),
+                                  (jl_value_t*)jl_bottom_type,
+                                  (jl_value_t*)jl_anytuple_type);
+    jl_anytuple_type_type = jl_wrap_Type((jl_value_t*)tttvar);
+    jl_cfunction_list.unknown = jl_nothing;
 }
 
 #ifdef __cplusplus

--- a/src/julia.h
+++ b/src/julia.h
@@ -443,6 +443,7 @@ extern JL_DLLEXPORT jl_datatype_t *jl_simplevector_type;
 extern JL_DLLEXPORT jl_typename_t *jl_tuple_typename;
 extern JL_DLLEXPORT jl_datatype_t *jl_anytuple_type;
 #define jl_tuple_type jl_anytuple_type
+extern JL_DLLEXPORT jl_datatype_t *jl_anytuple_type_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_ntuple_type;
 extern JL_DLLEXPORT jl_typename_t *jl_ntuple_typename;
 extern JL_DLLEXPORT jl_datatype_t *jl_vararg_type;


### PR DESCRIPTION
previously, a cache entry would be widened beyond the
despecialization heuristic, creating an ordering dependence
such that after inserting a Function into the cache (as Any)
or a Tuple (as DataType), no more methods would attempt to specialize
that slot

@JeffBezanson I think this should fix the issue you noted https://github.com/JuliaLang/julia/pull/15934#issuecomment-212972781

In particular, given the command sequence:

``` julia
f(x) = x
f(+)
f(-)
f(2)
```

before:

``` julia
julia> typeof(f).name.mt.cache
f(x) at REPL[1]:1

julia> typeof(f).name.mt.cache.next
nothing
```

after:

``` julia
julia> typeof(f).name.mt.cache
f(x::Int64) at REPL[1]:1

julia> typeof(f).name.mt.cache.next
f(x::Function) at REPL[1]:1

julia> typeof(f).name.mt.cache.next.next
nothing
```
