### PR TITLE
Fix #15572 by improving BLAS.scal and BLAS.scal! docstrings

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -96,14 +96,14 @@ end
 """
     scal!(n, a, X, incx)
 
-Overwrite `X` with `a*X`. Returns `X`.
+Overwrite `X` with `a*X` for the first `n` elements of array `X` with stride `incx`. Returns `X`.
 """
 function scal! end
 
 """
     scal(n, a, X, incx)
 
-Returns `a*X`.
+Returns `X` scaled by `a` for the first `n` elements of array `X` with stride `incx`.
 """
 function scal end
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1001,3 +1001,4 @@ dense counterparts. The following functions are specific to sparse arrays.
              # perform sparse wizardry...
           end
        end
+

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1347,13 +1347,13 @@ Usually a function has 4 methods defined, one each for ``Float64``,
 
    .. Docstring generated from Julia source
 
-   Overwrite ``X`` with ``a*X``\ . Returns ``X``\ .
+   Overwrite ``X`` with ``a*X`` for the first ``n`` elements of array ``X`` with stride ``incx``\ . Returns ``X``\ .
 
 .. function:: scal(n, a, X, incx)
 
    .. Docstring generated from Julia source
 
-   Returns ``a*X``\ .
+   Returns ``X`` scaled by ``a`` for the first ``n`` elements of array ``X`` with stride ``incx``\ .
 
 .. function:: ger!(alpha, x, y, A)
 


### PR DESCRIPTION
For some reason, that extra line in `doc/stdlib/arrays.rst` really wants to be added when I generate the `.rst` files, so I included it.
