### PR TITLE
fix #16089

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -102,7 +102,7 @@ type InferenceState
                     end
                     s[1][la] = VarState(Tuple,false)
                 else
-                    s[1][la] = VarState(limit_tuple_depth(tupletype_tail(atypes,la)),false)
+                    s[1][la] = VarState(tuple_tfunc(limit_tuple_depth(tupletype_tail(atypes,la))),false)
                 end
                 la -= 1
             end

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -88,13 +88,15 @@ end
 qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{false}}) = QRCompactWY(LAPACK.geqrt!(A, min(minimum(size(A)), 36))...)
 qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{true}}) = QRPivoted(LAPACK.geqp3!(A)...)
 qrfact!{T<:BlasFloat}(A::StridedMatrix{T}) = qrfact!(A, Val{false})
-qrfact{T<:BlasFloat}(A::StridedMatrix{T}, args...) = qrfact!(copy(A), args...)
+qrfact{T<:BlasFloat}(A::StridedMatrix{T}, arg) = qrfact!(copy(A), arg)
+qrfact{T<:BlasFloat}(A::StridedMatrix{T}) = qrfact!(copy(A))
 
 # Generic fallbacks
 qrfact!(A::StridedMatrix, ::Type{Val{false}}) = qrfactUnblocked!(A)
 qrfact!(A::StridedMatrix, ::Type{Val{true}}) = qrfactPivotedUnblocked!(A)
 qrfact!(A::StridedMatrix) = qrfact!(A, Val{false})
-qrfact{T}(A::StridedMatrix{T}, args...) = qrfact!(copy_oftype(A, typeof(zero(T)/norm(one(T)))), args...)
+qrfact{T}(A::StridedMatrix{T}, arg) = qrfact!(copy_oftype(A, typeof(zero(T)/norm(one(T)))), arg)
+qrfact{T}(A::StridedMatrix{T}) = qrfact!(copy_oftype(A, typeof(zero(T)/norm(one(T)))))
 qrfact(x::Number) = qrfact(fill(x,1,1))
 
 qr(A::Union{Number, AbstractMatrix}, pivot::Union{Type{Val{false}}, Type{Val{true}}}=Val{false}; thin::Bool=true) =

--- a/test/core.jl
+++ b/test/core.jl
@@ -3848,3 +3848,8 @@ test_metadata_matches(f3, Tuple{})
 test_metadata_matches(f4, Tuple{})
 
 end
+
+# issue #16089
+f16089(args...) = typeof(args)
+g16089() = f16089(UInt8)
+@test g16089() === Tuple{DataType}


### PR DESCRIPTION
Forming the type of a vararg tuple needed to call `tuple_tfunc`.
