### PR TITLE
Support sub2ind(A, i, j)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -975,9 +975,8 @@ end
     Expr(:block,meta,exprs...,Expr(:tuple,[symbol(:s,i) for i=1:N]...))
 end
 
-# TODO in v0.5: either deprecate line 1 or add line 2
 ind2sub(a::AbstractArray, ind::Integer) = ind2sub(size(a), ind)
-# sub2ind(a::AbstractArray, I::Integer...) = sub2ind(size(a), I...)
+sub2ind(a::AbstractArray, I::Integer...) = sub2ind(size(a), I...)
 
 function sub2ind{T<:Integer}(dims::Tuple{Vararg{Integer}}, I::AbstractVector{T}...)
     N = length(dims)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -368,9 +368,6 @@ end
 @deprecate flipud(A::AbstractArray) flipdim(A, 1)
 @deprecate fliplr(A::AbstractArray) flipdim(A, 2)
 
-@deprecate sub2ind{T<:Integer}(dims::Array{T}, sub::Array{T}) sub2ind(tuple(dims...), sub...)
-@deprecate ind2sub!{T<:Integer}(sub::Array{T}, dims::Array{T}, ind::T) ind2sub!(sub, tuple(dims...), ind)
-
 @deprecate strftime     Libc.strftime
 @deprecate strptime     Libc.strptime
 @deprecate flush_cstdio Libc.flush_cstdio

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1044,6 +1044,11 @@ function i7197()
     ind2sub(size(S), 5)
 end
 @test i7197() == (2,2)
+A = reshape(collect(1:9), (3,3))
+@test ind2sub(size(A), 6) == (3,2)
+@test sub2ind(size(A), 3, 2) == 6
+@test ind2sub(A, 6) == (3,2)
+@test sub2ind(A, 3, 2) == 6
 
 # PR #9256
 function pr9256()


### PR DESCRIPTION
We're far enough in to 0.5 that I think it's fair to remove 0.4 deprecations and implement the new behavior.

Finishes #10337, and is the complement of #9256.
