### PR TITLE
Revise modular arithmetic using Periods

### DIFF
--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -65,17 +65,24 @@ Base.isless{P<:Period}(x::P,y::P) = isless(value(x),value(y))
 =={P<:Period}(x::P,y::P) = value(x) == value(y)
 
 # Period Arithmetic, grouped by dimensionality:
-import Base: div, mod, rem, gcd, lcm, +, -, *, /, %, .+, .-, .*, .%
+import Base: div, fld, mod, rem, gcd, lcm, +, -, *, /, %, .+, .-, .*, .%
 for op in (:+,:-,:lcm,:gcd)
     @eval ($op){P<:Period}(x::P,y::P) = P(($op)(value(x),value(y)))
 end
 
-for op in (:/,:%,:div,:mod)
+for op in (:/,:div,:fld)
     @eval begin
         ($op){P<:Period}(x::P,y::P) = ($op)(value(x),value(y))
         ($op){P<:Period}(x::P,y::Real) = P(($op)(value(x),Int64(y)))
     end
 end
+
+for op in (:rem,:mod)
+    @eval begin
+        ($op){P<:Period}(x::P,y::P) = P(($op)(value(x),value(y)))
+    end
+end
+
 /{P<:Period}(X::StridedArray{P}, y::P) = X ./ y
 %{P<:Period}(X::StridedArray{P}, y::P) = X .% y
 *{P<:Period}(x::P,y::Real) = P(value(x) * Int64(y))
@@ -83,9 +90,9 @@ end
 .*{P<:Period}(y::Real, X::StridedArray{P}) = X .* y
 for (op,Ty,Tz) in ((:.*,Real,:P),
                    (:./,:P,Float64), (:./,Real,:P),
-                   (:.%,:P,Int64), (:.%,Integer,:P),
                    (:div,:P,Int64), (:div,Integer,:P),
-                   (:mod,:P,Int64), (:mod,Integer,:P))
+                   (:.%,:P,:P),
+                   (:mod,:P,:P))
     sop = string(op)
     op_ = sop[1] == '.' ? symbol(sop[2:end]) : op
     @eval begin
@@ -102,9 +109,6 @@ end
 # intfuncs
 Base.gcdx{T<:Period}(a::T,b::T) = ((g,x,y)=gcdx(value(a),value(b)); return T(g),x,y)
 Base.abs{T<:Period}(a::T) = T(abs(value(a)))
-
-# Like Base.steprem in range.jl, but returns the correct type for Periods
-Base.steprem(start::Period,stop::Period,step::Period) = (stop-start) % value(step)
 
 periodisless(::Period,::Year)        = true
 periodisless(::Period,::Month)       = true

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -80,6 +80,7 @@ end
 for op in (:rem,:mod)
     @eval begin
         ($op){P<:Period}(x::P,y::P) = P(($op)(value(x),value(y)))
+        ($op){P<:Period}(x::P,y::Real) = P(($op)(value(x),Int64(y)))
     end
 end
 

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -14,7 +14,19 @@
 @test lcm(Dates.Year(10), Dates.Year(4)) == Dates.Year(20)
 @test div(Dates.Year(10),Dates.Year(3)) == 3
 @test div(Dates.Year(10),Dates.Year(4)) == 2
+@test div(Dates.Year(10),4) == Dates.Year(2)
 @test Dates.Year(10) / Dates.Year(4) == 2.5
+
+@test mod(Dates.Year(10),Dates.Year(4)) == Dates.Year(2)
+@test mod(Dates.Year(-10),Dates.Year(4)) == Dates.Year(2)
+@test mod(Dates.Year(10),4) == Dates.Year(2)
+@test mod(Dates.Year(-10),4) == Dates.Year(2)
+
+@test rem(Dates.Year(10),Dates.Year(4)) == Dates.Year(2)
+@test rem(Dates.Year(-10),Dates.Year(4)) == Dates.Year(-2)
+@test rem(Dates.Year(10),4) == Dates.Year(2)
+@test rem(Dates.Year(-10),4) == Dates.Year(-2)
+
 t = Dates.Year(1)
 t2 = Dates.Year(2)
 @test ([t,t,t,t,t] + Dates.Year(1)) == ([t2,t2,t2,t2,t2])

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -9,7 +9,7 @@
 @test Dates.Year(1) + Dates.Year(1) == Dates.Year(2)
 @test Dates.Year(1) - Dates.Year(1) == zero(Dates.Year)
 @test_throws MethodError Dates.Year(1) * Dates.Year(1) == Dates.Year(1)
-@test Dates.Year(10) % Dates.Year(4) == 2
+@test Dates.Year(10) % Dates.Year(4) == Dates.Year(2)
 @test gcd(Dates.Year(10), Dates.Year(4)) == Dates.Year(2)
 @test lcm(Dates.Year(10), Dates.Year(4)) == Dates.Year(20)
 @test div(Dates.Year(10),Dates.Year(3)) == 3
@@ -22,9 +22,9 @@ t2 = Dates.Year(2)
 @test ([t2,t2,t2,t2,t2] - Dates.Year(1)) == ([t,t,t,t,t])
 @test_throws MethodError ([t,t,t,t,t] .* Dates.Year(1)) == ([t,t,t,t,t])
 @test ([t,t,t,t,t] * 1) == ([t,t,t,t,t])
-@test ([t,t,t,t,t] .% t2) == ([1,1,1,1,1])
+@test ([t,t,t,t,t] .% t2) == ([t,t,t,t,t])
 @test div([t,t,t,t,t],Dates.Year(1)) == ([1,1,1,1,1])
-@test mod([t,t,t,t,t],Dates.Year(2)) == ([1,1,1,1,1])
+@test mod([t,t,t,t,t],Dates.Year(2)) == ([t,t,t,t,t])
 @test [t,t,t] / t2 == [0.5,0.5,0.5]
 @test abs(-t) == t
 
@@ -143,6 +143,7 @@ y2 = Dates.Year(2)
 @test typemax(Dates.Year) == Dates.Year(typemax(Int64))
 @test typemax(Dates.Year) + y == Dates.Year(-9223372036854775808)
 @test typemin(Dates.Year) == Dates.Year(-9223372036854775808)
+
 #Period-Real arithmetic
 @test_throws MethodError y + 1 == Dates.Year(2)
 @test_throws MethodError y + true == Dates.Year(2)
@@ -154,14 +155,20 @@ y2 = Dates.Year(2)
 @test div(y,2) == Dates.Year(0)
 @test_throws MethodError div(2,y) == Dates.Year(2)
 @test div(y,y) == 1
-@test y*10 % 5 == Dates.Year(0)
+@test y*10 % Dates.Year(5) == Dates.Year(0)
 @test_throws MethodError (y > 3) == false
 @test_throws MethodError (4 < y) == false
 @test 1 != y
 t = [y,y,y,y,y]
 @test t .+ Dates.Year(2) == [Dates.Year(3),Dates.Year(3),Dates.Year(3),Dates.Year(3),Dates.Year(3)]
-dt = Dates.DateTime(2012,12,21)
+
+let x = Dates.Year(5), y = Dates.Year(2)
+    @test div(x,y)*y + rem(x,y) == x
+    @test fld(x,y)*y + mod(x,y) == x
+end
+
 # Associativity
+dt = Dates.DateTime(2012,12,21)
 test = ((((((((dt + y) - m) + w) - d) + h) - mi) + s) - ms)
 @test test == dt + y - m + w - d + h - mi + s - ms
 @test test == y - m + w - d + dt + h - mi + s - ms


### PR DESCRIPTION
After playing around with modular arithmetic with `Period`s I discovered that `mod` and `rem` had some strange behaviours:

``` julia
julia> using Base.Dates

julia> x, y = Second(5), Second(2)
(5 seconds,2 seconds)

julia> div(x,y)  # Correct
2

julia> rem(x,y)  # Expected result to be `Second(1)`
1

julia> div(x,y)*y + rem(x,y) == x  # Should return `true`
ERROR: MethodError: no method matching +(::Base.Dates.Second, ::Int64)
Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...)
  +(::Char, ::Integer)
  +(::Complex{Bool}, ::Real)
  ...
 in eval(::Module, ::Any) at ./boot.jl:236
```

I have updated the code such that `mod` and `rem` now return `Period`s rather than `Int64`s. Additionally I also added support for `fld` for `Period`s.
