### PR TITLE
Rewrite confusing explanation of do...end syntax.

### DIFF
--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -591,12 +591,13 @@ This is accomplished by the following definition::
         end
     end
 
-In contrast to the :func:`map` example, here ``io`` is initialized by the
-*result* of ``open("outfile", "w")``.  The stream is then passed to
-your anonymous function, which performs the writing; finally, the
-:func:`open` function ensures that the stream is closed after your
-function exits.  The ``try/finally`` construct will be described in
-:ref:`man-control-flow`.
+Here, :func:`open` first opens the file for writing and then passes
+the resulting output stream to the anonymous function you defined
+in the ``do ... end`` block. After your function exits, :func:`open`
+will make sure that the stream is properly closed, regardless of
+whether your function exited normally or threw an exception.
+(The ``try/finally`` construct will be described in
+:ref:`man-control-flow`.)
 
 With the ``do`` block syntax, it helps to check the documentation or
 implementation to know how the arguments of the user function are


### PR DESCRIPTION
Current explanation says 

> "In contrast to the :func:`map` example, here io is initialized by the result of `open("outfile", "w")`".

This is confusing: my first reading was that, whereas in the :func:`map` example above, the construction was equivalent to `map(anonymous_function, [A, B, C])`,  in the example with :func:`open`, the construction was equivalent to `open("outfile", "w") |> anonymous_function!`. Which is of course crazy.

I think what the author was trying to convey was that in the first example, the anonymous function does not try to modify contents of its arguments, whereas in the second one, the whole point is that the anon function be able to act on the stream (so if it were a named function, it'd bear an exclamation mark).

However, "_result_" in "`io` is initialized by the _result_ of the <open function>" creates the impression that :func:`open` returns that result, which is then passed to the anon function, whereas, of course, anon f. is executed within :func:`open`.
