### PR TITLE
RFC: Remove find type assertion to allow other iterables

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -777,7 +777,7 @@ function findprev(testf::Function, A, start::Integer)
 end
 findlast(testf::Function, A) = findprev(testf, A, length(A))
 
-function find(testf::Function, A::AbstractArray)
+function find(testf::Function, A)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return
     tmpI = Array(Int, 0)
@@ -791,9 +791,10 @@ function find(testf::Function, A::AbstractArray)
     I
 end
 
-function find(A::AbstractArray)
-    nnzA = countnz(A)
-    I = similar(A, Int, nnzA)
+function find(A)
+    cA = typeof(A) <: AbstractArray ? A : collect(A)
+    nnzA = countnz(cA)
+    I = similar(cA, Int, nnzA)
     count = 1
     for (i,a) in enumerate(A)
         if a != 0

--- a/base/array.jl
+++ b/base/array.jl
@@ -792,9 +792,8 @@ function find(testf::Function, A)
 end
 
 function find(A)
-    cA = typeof(A) <: AbstractArray ? A : collect(A)
-    nnzA = countnz(cA)
-    I = similar(cA, Int, nnzA)
+    nnzA = countnz(A)
+    I = Vector{Int}(nnzA)
     count = 1
     for (i,a) in enumerate(A)
         if a != 0

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -369,9 +369,6 @@ s = "julia"
 g = graphemes("日本語")
 @test find(g) == [1,2,3]
 @test find(isascii, g) == Int[]
-c = combinations(1:4, 3)
-@test find(c) == [1,2,3,4]
-@test find(a -> 2 in a, c) == [1,2,4]
 
 ## findn ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -362,6 +362,17 @@ a = [0,1,2,3,0,1,2,3]
 @test findprev(isodd, [2,4,5,3,9,2,0], 7) == 5
 @test findprev(isodd, [2,4,5,3,9,2,0], 2) == 0
 
+# find with general iterables
+s = "julia"
+@test find(s) == [1,2,3,4,5]
+@test find(c -> c == 'l', s) == [3]
+g = graphemes("日本語")
+@test find(g) == [1,2,3]
+@test find(isascii, g) == Int[]
+c = combinations(1:4, 3)
+@test find(c) == [1,2,3,4]
+@test find(a -> 2 in a, c) == [1,2,4]
+
 ## findn ##
 
 b = findn(ones(2,2,2,2))


### PR DESCRIPTION
This implements and tests #16022.
