### PR TITLE
Fix an error in stacktraces.rst

### DIFF
--- a/doc/manual/stacktraces.rst
+++ b/doc/manual/stacktraces.rst
@@ -219,7 +219,7 @@ A call to :func:`backtrace` returns a vector of ``Ptr{Void}``, which may then be
      [inlined code from REPL.jl:3] eval_user_input at REPL.jl:62
      [inlined code from REPL.jl:92] anonymous at task.jl:63
 
-Notice that the vector returned by :func:`backtrace` had 15 pointers, while the vector returned by :func:`stacktrace` only has 3. This is because, by default, :func:`stacktrace` removes any lower-level C functions from the stack. If you want to include stack frames from C calls, you can do it like this::
+Notice that the vector returned by :func:`backtrace` had 15 pointers, while the vector returned by :func:`stacktrace` only has 4. This is because, by default, :func:`stacktrace` removes any lower-level C functions from the stack. If you want to include stack frames from C calls, you can do it like this::
 
     julia> stacktrace(stack, true)
     15-element Array{StackFrame,1}:


### PR DESCRIPTION
The vector returned by function `stacktrace`  has 4 elements not 3.
