### PR TITLE
RFC: clean up method reflection

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -285,7 +285,7 @@ function get_type_call(expr::Expr)
     length(mt) == 1 || return (Any, false)
     m = first(mt)
     # Typeinference
-    linfo = Base.func_for_method_checked(m[3].func, Tuple{args...})
+    linfo = Base.func_for_method_checked(m[3], Tuple{args...})
     (tree, return_type) = Core.Inference.typeinf(linfo, m[1], m[2])
     return return_type, true
 end
@@ -321,7 +321,7 @@ function complete_methods(ex_org::Expr)
     out = UTF8String[]
     t_in = Tuple{Core.Typeof(func), args_ex...} # Input types
     na = length(args_ex)+1
-    Base.visit(methods(func)) do method
+    for method in methods(func)
         # Check if the method's type signature intersects the input types
         typeintersect(Tuple{method.sig.parameters[1 : min(na, end)]...}, t_in) != Union{} &&
             push!(out,string(method))

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -6916,7 +6916,7 @@ less(f::AbstractString, ?)
 Show the definition of a function using the default pager, optionally specifying a tuple of
 types to indicate which method to see.
 """
-less(m::TypeMapEntry, ?)
+less(func, ?)
 
 """
     sqrtm(A)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -44,7 +44,7 @@ macro generated(f)
 end
 
 
-tuple_type_head(::Type{Union{}}) = throw(MethodError(tuple_type_head, (Type{Union{}},)))
+tuple_type_head(::Type{Union{}}) = throw(MethodError(tuple_type_head, (Union{},)))
 function tuple_type_head{T<:Tuple}(::Type{T})
     @_pure_meta
     T.parameters[1]

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -383,9 +383,8 @@ function type_close_enough(x::ANY, t::ANY)
 end
 
 # `methodswith` -- shows a list of methods using the type given
-function methodswith(t::Type, f::Function, showparents::Bool=false, meths = TypeMapEntry[])
-    mt = typeof(f).name.mt
-    visit(mt) do d
+function methodswith(t::Type, f::Function, showparents::Bool=false, meths = Method[])
+    for d in methods(f)
         if any(x -> (type_close_enough(x, t) ||
                      (showparents ? (t <: x && (!isa(x,TypeVar) || x.ub != Any)) :
                       (isa(x,TypeVar) && x.ub != Any && t == x.ub)) &&
@@ -398,7 +397,7 @@ function methodswith(t::Type, f::Function, showparents::Bool=false, meths = Type
 end
 
 function methodswith(t::Type, m::Module, showparents::Bool=false)
-    meths = TypeMapEntry[]
+    meths = Method[]
     for nm in names(m)
         if isdefined(m, nm)
             f = getfield(m, nm)
@@ -411,7 +410,7 @@ function methodswith(t::Type, m::Module, showparents::Bool=false)
 end
 
 function methodswith(t::Type, showparents::Bool=false)
-    meths = TypeMapEntry[]
+    meths = Method[]
     mainmod = current_module()
     # find modules in Main
     for nm in names(mainmod)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -314,6 +314,8 @@ function serialize(s::SerializationState, meth::Method)
     serialize(s, meth.name)
     serialize(s, meth.file)
     serialize(s, meth.line)
+    serialize(s, meth.sig)
+    serialize(s, meth.tvars)
     serialize(s, meth.isstaged)
     serialize(s, meth.lambda_template)
     if isdefined(meth, :roots)
@@ -585,6 +587,8 @@ function deserialize(s::SerializationState, ::Type{Method})
     name = deserialize(s)::Symbol
     file = deserialize(s)::Symbol
     line = deserialize(s)
+    sig = deserialize(s)
+    tvars = deserialize(s)
     isstaged = deserialize(s)::Bool
     template = deserialize(s)::LambdaInfo
     tag = Int32(read(s.io, UInt8)::UInt8)
@@ -598,6 +602,8 @@ function deserialize(s::SerializationState, ::Type{Method})
         meth.name = name
         meth.file = file
         meth.line = line
+        meth.sig = sig
+        meth.tvars = tvars
         meth.isstaged = isstaged
         meth.lambda_template = template
         roots === nothing || (meth.roots = roots)

--- a/src/dump.c
+++ b/src/dump.c
@@ -1441,7 +1441,9 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         m->file = (jl_sym_t*)jl_deserialize_value(s, NULL);
         m->line = read_int32(s);
         m->sig = (jl_tupletype_t*)jl_deserialize_value(s, (jl_value_t**)&m->sig);
+        jl_gc_wb(m, m->sig);
         m->tvars = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&m->tvars);
+        jl_gc_wb(m, m->tvars);
         m->called = read_int8(s);
         m->module = (jl_module_t*)jl_deserialize_value(s, (jl_value_t**)&m->module);
         jl_gc_wb(m, m->module);

--- a/src/dump.c
+++ b/src/dump.c
@@ -839,6 +839,8 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         write_int8(s, m->isstaged);
         jl_serialize_value(s, (jl_value_t*)m->file);
         write_int32(s, m->line);
+        jl_serialize_value(s, (jl_value_t*)m->sig);
+        jl_serialize_value(s, (jl_value_t*)m->tvars);
         write_int8(s, m->called);
         jl_serialize_value(s, (jl_value_t*)m->module);
         jl_serialize_value(s, (jl_value_t*)m->roots);
@@ -1000,10 +1002,8 @@ static int jl_serialize_methcache_from_mod(jl_typemap_entry_t *ml, void *closure
         jl_serialize_value(env->s, env->mod);
         jl_serialize_value(env->s, env->name);
         write_int8(env->s, env->iskw);
-        jl_serialize_value(env->s, ml->sig);
         jl_serialize_value(env->s, ml->simplesig);
         jl_serialize_value(env->s, ml->func.method);
-        jl_serialize_value(env->s, ml->tvars);
     }
     return 1;
 }
@@ -1440,6 +1440,8 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         m->isstaged = read_int8(s);
         m->file = (jl_sym_t*)jl_deserialize_value(s, NULL);
         m->line = read_int32(s);
+        m->sig = (jl_tupletype_t*)jl_deserialize_value(s, (jl_value_t**)&m->sig);
+        m->tvars = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&m->tvars);
         m->called = read_int8(s);
         m->module = (jl_module_t*)jl_deserialize_value(s, (jl_value_t**)&m->module);
         jl_gc_wb(m, m->module);
@@ -1678,11 +1680,9 @@ static void jl_deserialize_lambdas_from_mod(ios_t *s)
         int8_t iskw = read_int8(s);
         if (iskw)
             gf = jl_get_kwsorter(((jl_datatype_t*)jl_typeof(gf))->name);
-        jl_tupletype_t *type = (jl_tupletype_t*)jl_deserialize_value(s, NULL);
         jl_tupletype_t *simpletype = (jl_tupletype_t*)jl_deserialize_value(s, NULL);
         jl_method_t *meth = (jl_method_t*)jl_deserialize_value(s, NULL);
-        jl_svec_t *tvars = (jl_svec_t*)jl_deserialize_value(s, NULL);
-        jl_method_table_insert(jl_gf_mtable(gf), type, simpletype, meth, tvars);
+        jl_method_table_insert(jl_gf_mtable(gf), meth, simpletype);
     }
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -579,7 +579,7 @@ static jl_lambda_info_t *cache_method(jl_methtable_t *mt, union jl_typemap_t *ca
                     cache_with_orig = 1;
                     break;
                 }
-                if (((jl_typemap_entry_t*)jl_svecref(m, 2))->func.method != definition) {
+                if (((jl_method_t*)jl_svecref(m, 2)) != definition) {
                     guards++;
                 }
             }
@@ -593,7 +593,7 @@ static jl_lambda_info_t *cache_method(jl_methtable_t *mt, union jl_typemap_t *ca
             guards = 0;
             for(i = 0, l = jl_array_len(temp); i < l; i++) {
                 jl_value_t *m = jl_cellref(temp, i);
-                if (((jl_typemap_entry_t*)jl_svecref(m,2))->func.method != definition) {
+                if (((jl_method_t*)jl_svecref(m,2)) != definition) {
                     jl_svecset(guardsigs, guards, (jl_tupletype_t*)jl_svecref(m, 0));
                     guards++;
                     //jl_typemap_insert(cache, parent, (jl_tupletype_t*)jl_svecref(m, 0),
@@ -854,14 +854,13 @@ static void update_max_args(jl_methtable_t *mt, jl_tupletype_t *type)
         mt->max_args = na;
 }
 
-void jl_method_table_insert(jl_methtable_t *mt, jl_tupletype_t *type, jl_tupletype_t *simpletype,
-                            jl_method_t *method, jl_svec_t *tvars)
+void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype)
 {
-    assert(jl_is_tuple_type(type));
     assert(jl_is_method(method));
     assert(jl_is_mtable(mt));
-    if (jl_svec_len(tvars) == 1)
-        tvars = (jl_svec_t*)jl_svecref(tvars, 0);
+    jl_tupletype_t *type = method->sig;
+    jl_svec_t *tvars = method->tvars;
+    assert(jl_is_tuple_type(type));
     JL_SIGATOMIC_BEGIN();
     jl_value_t *oldvalue;
     jl_typemap_entry_t *newentry = jl_typemap_insert(&mt->defs, (jl_value_t*)mt,
@@ -1698,7 +1697,7 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
             closure->t = (jl_value_t*)jl_false;
             return 0; // terminate search
         }
-        closure->matc = jl_svec(3, closure->match.ti, closure->match.env, ml);
+        closure->matc = jl_svec(3, closure->match.ti, closure->match.env, ml->func.method);
         /*
           Check whether all static parameters matched. If not, then we
           have an argument type like Vector{T{Int,_}}, and a signature like

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3498,11 +3498,13 @@ void jl_init_types(void)
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(13,
+                        jl_svec(15,
                                 jl_symbol("name"),
                                 jl_symbol("module"),
                                 jl_symbol("file"),
                                 jl_symbol("line"),
+                                jl_symbol("sig"),
+                                jl_symbol("tvars"),
                                 jl_symbol("specializations"),
                                 jl_symbol("tfunc"),
                                 jl_symbol("lambda_template"),
@@ -3512,11 +3514,13 @@ void jl_init_types(void)
                                 jl_symbol("isstaged"),
                                 jl_symbol("needs_sparam_vals_ducttape"),
                                 jl_symbol("")),
-                        jl_svec(13,
+                        jl_svec(15,
                                 jl_sym_type,
                                 jl_module_type,
                                 jl_sym_type,
                                 jl_int32_type,
+                                jl_type_type,
+                                jl_any_type,
                                 jl_array_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -3526,7 +3530,7 @@ void jl_init_types(void)
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type),
-                        0, 1, 7);
+                        0, 1, 9);
 
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaInfo"),
@@ -3579,7 +3583,7 @@ void jl_init_types(void)
                                 jl_int32_type, jl_int32_type),
                         0, 1, 10);
     jl_svecset(jl_lambda_info_type->types, 9, jl_lambda_info_type);
-    jl_svecset(jl_method_type->types, 6, jl_lambda_info_type);
+    jl_svecset(jl_method_type->types, 8, jl_lambda_info_type);
 
     jl_typector_type =
         jl_new_datatype(jl_symbol("TypeConstructor"),

--- a/src/julia.h
+++ b/src/julia.h
@@ -194,6 +194,11 @@ typedef struct _jl_method_t {
     jl_sym_t *file;
     int32_t line;
 
+    // method's type signature. partly redundant with lambda_template->specTypes
+    jl_tupletype_t *sig;
+    // bound type variables (static parameters). redundant with TypeMapEntry->tvars
+    jl_svec_t *tvars;
+
     // array of all lambda infos with code generated from this one
     jl_array_t *specializations;
     // table of all argument types for which we've inferred this code
@@ -1003,7 +1008,7 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
                                         uint32_t na);
 JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
 JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(jl_svec_t *sparams);
-JL_DLLEXPORT jl_method_t *jl_new_method(jl_lambda_info_t *definition, jl_sym_t *name, jl_tupletype_t *sig, int isstaged);
+JL_DLLEXPORT jl_method_t *jl_new_method(jl_lambda_info_t *definition, jl_sym_t *name, jl_tupletype_t *sig, jl_svec_t *tvars, int isstaged);
 JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...);
 JL_DLLEXPORT jl_svec_t *jl_svec1(void *a);
 JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -173,8 +173,7 @@ jl_value_t *jl_type_match_morespecific(jl_value_t *a, jl_value_t *b);
 int jl_types_equal_generic(jl_value_t *a, jl_value_t *b, int useenv);
 jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np);
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p);
-void jl_method_table_insert(jl_methtable_t *mt, jl_tupletype_t *type, jl_tupletype_t *simpletype,
-                            jl_method_t *method, jl_svec_t *tvars);
+void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
 jl_value_t *jl_mk_builtin_func(const char *name, jl_fptr_t fptr);
 STATIC_INLINE int jl_is_type(jl_value_t *v)
 {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -755,8 +755,7 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_lambda_info_t *f, jl_valu
     if (jl_subtype(ftype, (jl_value_t*)jl_builtin_type, 0))
         jl_error("cannot add methods to a builtin function");
 
-    jl_tupletype_t *sig = isstaged == jl_true ? jl_anytuple_type : argtypes;
-    m = jl_new_method(f, name, sig, isstaged == jl_true);
+    m = jl_new_method(f, name, argtypes, tvars, isstaged == jl_true);
     f = m->lambda_template; // because jl_new_method makes a copy
     jl_check_static_parameter_conflicts(m, tvars);
 
@@ -786,7 +785,7 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_lambda_info_t *f, jl_valu
         }
     }
 
-    jl_method_table_insert(mt, argtypes, NULL, m, tvars);
+    jl_method_table_insert(mt, m, NULL);
     if (jl_newmeth_tracer)
         jl_call_tracer(jl_newmeth_tracer, (jl_value_t*)m);
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -2302,10 +2302,12 @@ let f
         (::typeof(f))(x::newtype10373) = println("$f")
     end
 end
-@test methods(f10373).defs.func.name == :f10373
-@test methods(f10373).defs.next.func.name == :f10373
-@test methods(g10373).defs.func.name == :g10373
-@test methods(g10373).defs.next.func.name == :g10373
+for m in methods(f10373)
+    @test m.name == :f10373
+end
+for m in methods(g10373)
+    @test m.name == :g10373
+end
 
 # issue #7221
 f7221{T<:Number}(::T) = 1

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -190,7 +190,7 @@ let
     @test Base.function_name(foo7648)==:foo7648
     @test Base.function_module(foo7648, (Any,))==TestMod7648
     @test basename(functionloc(foo7648, (Any,))[1]) == "reflection.jl"
-    @test methods(TestMod7648.TestModSub9475.foo7648).defs==@which foo7648(5)
+    @test first(methods(TestMod7648.TestModSub9475.foo7648)) == @which foo7648(5)
     @test TestMod7648==@which foo7648
     @test TestMod7648.TestModSub9475==@which a9475
 end
@@ -213,7 +213,7 @@ const a_value = 1
 end
 
 # issue #13264
-@test isa((@which vcat(1...)), TypeMapEntry)
+@test isa((@which vcat(1...)), Method)
 
 # issue #13464
 let t13464 = "hey there sailor"
@@ -295,7 +295,7 @@ let
     @test which(m, Tuple{Int,Symbol})==@which @macrotest 1 a
     @test which(m, Tuple{Int,Int})==@which @macrotest 1 1
 
-    @test methods(m,Tuple{Int, Int})[1]==@which MacroTest.@macrotest 1 1
+    @test first(methods(m,Tuple{Int, Int}))==@which MacroTest.@macrotest 1 1
     @test functionloc(@which @macrotest 1 1) == @functionloc @macrotest 1 1
 end
 
@@ -384,7 +384,7 @@ tracefoo(x, y) = x+y
 didtrace = false
 tracer(x::Ptr{Void}) = (@test isa(unsafe_pointer_to_objref(x), LambdaInfo); global didtrace = true; nothing)
 ccall(:jl_register_method_tracer, Void, (Ptr{Void},), cfunction(tracer, Void, (Ptr{Void},)))
-meth = which(tracefoo,Tuple{Any,Any}).func
+meth = which(tracefoo,Tuple{Any,Any})
 ccall(:jl_trace_method, Void, (Any,), meth)
 @test tracefoo(1, 2) == 3
 ccall(:jl_untrace_method, Void, (Any,), meth)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -202,7 +202,7 @@ s = "max("
 c, r, res = test_complete(s)
 @test !res
 @test let found = false
-    Base.visit(methods(max)) do m
+    for m in methods(max)
         if !found
             found = (c[1] == string(m))
         end
@@ -216,7 +216,7 @@ end
 s = "CompletionFoo.test(1,1, "
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(methods(CompletionFoo.test, Tuple{Int, Int})[1])
+@test c[1] == string(first(methods(CompletionFoo.test, Tuple{Int, Int})))
 @test length(c) == 3
 @test r == 1:18
 @test s[r] == "CompletionFoo.test"
@@ -224,7 +224,7 @@ c, r, res = test_complete(s)
 s = "CompletionFoo.test(CompletionFoo.array,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(methods(CompletionFoo.test, Tuple{Array{Int, 1}, Any})[1])
+@test c[1] == string(first(methods(CompletionFoo.test, Tuple{Array{Int, 1}, Any})))
 @test length(c) == 2
 @test r == 1:18
 @test s[r] == "CompletionFoo.test"
@@ -232,7 +232,7 @@ c, r, res = test_complete(s)
 s = "CompletionFoo.test(1,1,1,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(methods(CompletionFoo.test, Tuple{Any, Any, Any})[1])
+@test c[1] == string(first(methods(CompletionFoo.test, Tuple{Any, Any, Any})))
 @test r == 1:18
 @test s[r] == "CompletionFoo.test"
 
@@ -252,7 +252,7 @@ c, r, res = test_complete(s)
 
 s = "prevind(\"θ\",1,"
 c, r, res = test_complete(s)
-@test c[1] == string(methods(prevind, Tuple{UTF8String, Int})[1])
+@test c[1] == string(first(methods(prevind, Tuple{UTF8String, Int})))
 @test r == 1:7
 @test s[r] == "prevind"
 
@@ -260,26 +260,26 @@ for (T, arg) in [(ASCIIString,"\")\""),(Char, "')'")]
     s = "(1, CompletionFoo.test2($arg,"
     c, r, res = test_complete(s)
     @test length(c) == 1
-    @test c[1] == string(methods(CompletionFoo.test2, Tuple{T,})[1])
+    @test c[1] == string(first(methods(CompletionFoo.test2, Tuple{T,})))
     @test r == 5:23
     @test s[r] == "CompletionFoo.test2"
 end
 
 s = "(1, CompletionFoo.test2(`)`,"
 c, r, res = test_complete(s)
-@test c[1] == string(methods(CompletionFoo.test2, Tuple{Cmd})[1])
+@test c[1] == string(first(methods(CompletionFoo.test2, Tuple{Cmd})))
 @test length(c) == 1
 
 s = "CompletionFoo.test3([1, 2] + CompletionFoo.varfloat,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})[1])
+@test c[1] == string(first(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
 @test length(c) == 1
 
 s = "CompletionFoo.test3([1.,2.], 1.,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})[1])
+@test c[1] == string(first(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
 @test r == 1:19
 @test length(c) == 1
 @test s[r] == "CompletionFoo.test3"
@@ -287,7 +287,7 @@ c, r, res = test_complete(s)
 s = "CompletionFoo.test4(\"e\",r\" \","
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(methods(CompletionFoo.test4, Tuple{ASCIIString, Regex})[1])
+@test c[1] == string(first(methods(CompletionFoo.test4, Tuple{ASCIIString, Regex})))
 @test r == 1:19
 @test length(c) == 1
 @test s[r] == "CompletionFoo.test4"
@@ -296,13 +296,13 @@ s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
 c, r, res = test_complete(s)
 @test !res
 @test length(c) == 1
-@test c[1] == string(methods(CompletionFoo.test5, Tuple{BitArray{1}})[1])
+@test c[1] == string(first(methods(CompletionFoo.test5, Tuple{BitArray{1}})))
 
 s = "CompletionFoo.test4(CompletionFoo.test_y_array[1]()[1], CompletionFoo.test_y_array[1]()[2], "
 c, r, res = test_complete(s)
 @test !res
 @test length(c) == 1
-@test c[1] == string(methods(CompletionFoo.test4, Tuple{ASCIIString, ASCIIString})[1])
+@test c[1] == string(first(methods(CompletionFoo.test4, Tuple{ASCIIString, ASCIIString})))
 
 # Test that string escaption is handled correct
 s = """CompletionFoo.test4("\\"","""

--- a/test/show.jl
+++ b/test/show.jl
@@ -332,9 +332,9 @@ let repr = sprint(io -> writemime(io,"text/html", methods(f5971)))
 end
 
 if isempty(Base.GIT_VERSION_INFO.commit)
-    @test contains(Base.url(methods(eigs).defs),"https://github.com/JuliaLang/julia/tree/v$VERSION/base/linalg/arnoldi.jl#L")
+    @test contains(Base.url(first(methods(eigs))),"https://github.com/JuliaLang/julia/tree/v$VERSION/base/linalg/arnoldi.jl#L")
 else
-    @test contains(Base.url(methods(eigs).defs),"https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/linalg/arnoldi.jl#L")
+    @test contains(Base.url(first(methods(eigs))),"https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/linalg/arnoldi.jl#L")
 end
 
 # print_matrix should be able to handle small and large objects easily, test by


### PR DESCRIPTION
This does a few things to improve the results from `methods`, and clean up some internals:
- Adds back the `sig` and `tvars` fields to `Method`. Although technically redundant, this makes `Method` more intuitive for describing a method definition.
- Removes most uses of `TypeMapEntry` in reflection, de-coupling the method cache representation from anything user-facing.
- Fixes #16042 in passing.

Finally, we had a problem where `methods(f)` returned a full MethodTable (except sometimes!), but `methods(f, t)` returned an array of `Method`s. Those types are printed differently, plus we are only able to show keyword arguments if we have access to the `MethodTable`, due to how kwargs are implemented. We could always use `MethodTable`, but it's not iterable and building one is a very non-trivial process just for showing a list of methods.

To address this I added a `MethodSet` type, so we can return any subset of methods with a consistent interface and printing. This solves all of the problems, but I don't quite love it, so suggestions are welcome.

This could be used in `methodswith` as well, except that it can return methods from multiple functions so it doesn't quite fit.

Another option would be to return matches from a function's keyword arg sorter as well, so you'd get 2 entries in a returned array for each method with keyword args. The downside is that these are not really methods of the same function, and have non-obvious argument lists.
