### PR TITLE
Correct line numbers for module docstrings.

### DIFF
--- a/base/docs/core.jl
+++ b/base/docs/core.jl
@@ -20,7 +20,7 @@ lazy_iterpolate(x) = isexpr(x, :string) ? Expr(:call, Core.svec, x.args...) : x
 
 function docm(str, x)
     out = esc(Expr(:call, doc!, lazy_iterpolate(str), Expr(:quote, x)))
-    isexpr(x, :module) ? Expr(:toplevel, esc(x), out) :
+    isexpr(x, :module) ? Expr(:toplevel, out, esc(x)) :
     isexpr(x, :call) ? out : Expr(:block, esc(x), out)
 end
 docm(x) = isexpr(x, :->) ? docm(x.args[1], x.args[2].args[2]) : error("invalid '@doc'.")

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -45,10 +45,9 @@ end
 
 # General tests for docstrings.
 
-module DocsTest
-
+const LINE_NUMBER = @__LINE__
 "DocsTest"
-DocsTest
+module DocsTest
 
 "f-1"
 function f(x)
@@ -162,11 +161,13 @@ function multidoc! end
 
 end
 
-@test docstrings_equal(@doc(DocsTest), doc"DocsTest")
-
-# Check that plain docstrings store a module reference.
-# https://github.com/JuliaLang/julia/pull/13017#issuecomment-138618663
-@test meta(DocsTest)[@var(DocsTest)].docs[Union{}].data[:module] == DocsTest
+let md = meta(DocsTest)[@var(DocsTest)]
+    @test docstrings_equal(md.docs[Union{}], doc"DocsTest")
+    # Check that plain docstrings store a module reference.
+    # https://github.com/JuliaLang/julia/pull/13017#issuecomment-138618663
+    @test md.docs[Union{}].data[:module] == DocsTest
+    @test md.docs[Union{}].data[:linenumber] == LINE_NUMBER
+end
 
 let f = @var(DocsTest.f)
     md = meta(DocsTest)[f]


### PR DESCRIPTION
Nested `@doc` calls were causing line numbers for modules to be stored incorrectly.
