### PR TITLE
Makes syntax highlighters work with banner pasted verbatim.

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -268,7 +268,7 @@ function banner(io::IO = STDOUT)
            $(d1)_$(tx)       $(jl)_$(tx) $(d2)_$(d3)(_)$(d4)_$(tx)     |  A fresh approach to technical computing
           $(d1)(_)$(jl)     | $(d2)(_)$(tx) $(d4)(_)$(tx)    |  Documentation: https://docs.julialang.org
            $(jl)_ _   _| |_  __ _$(tx)   |  Type \"?help\" for help.
-          $(jl)| | | | | | |/ _` |$(tx)  |
+          $(jl)| | | | | | |/ _' |$(tx)  |
           $(jl)| | |_| | | | (_| |$(tx)  |  Version $(VERSION)$(commit_date)
          $(jl)_/ |\\__'_|_|_|\\__'_|$(tx)  |  $(commit_string)
         $(jl)|__/$(tx)                   |  $(Sys.MACHINE)
@@ -280,7 +280,7 @@ function banner(io::IO = STDOUT)
            _       _ _(_)_     |  A fresh approach to technical computing
           (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
            _ _   _| |_  __ _   |  Type \"?help\" for help.
-          | | | | | | |/ _` |  |
+          | | | | | | |/ _' |  |
           | | |_| | | | (_| |  |  Version $(VERSION)$(commit_date)
          _/ |\\__'_|_|_|\\__'_|  |  $(commit_string)
         |__/                   |  $(Sys.MACHINE)

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -1,0 +1,172 @@
+.. _man-getting-started:
+
+*****************
+ Getting Started
+*****************
+
+Julia installation is straightforward, whether using precompiled
+binaries or compiling from source. Download and install Julia by
+following the instructions at
+`http://julialang.org/downloads/ <http://julialang.org/downloads/>`_.
+
+The easiest way to learn and experiment with Julia is by starting an
+interactive session (also known as a read-eval-print loop or "repl")
+by double-clicking the Julia executable or running ``julia`` from the
+command line::
+
+    $ julia
+                   _
+       _       _ _(_)_     |  A fresh approach to technical computing
+      (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
+       _ _   _| |_  __ _   |  Type "?help" for help.
+      | | | | | | |/ _' |  |
+      | | |_| | | | (_| |  |  Version 0.5.0-dev+2440 (2016-02-01 02:22 UTC)
+     _/ |\__'_|_|_|\__'_|  |  Commit 2bb94d6 (11 days old master)
+    |__/                   |  x86_64-apple-darwin13.1.0
+
+    julia> 1 + 2
+    3
+
+    julia> ans
+    3
+
+To exit the interactive session, type ``^D`` — the control key
+together with the ``d`` key or type ``quit()``. When run in interactive
+mode, ``julia`` displays a banner and prompts the user for input. Once
+the user has entered a complete expression, such as ``1 + 2``, and
+hits enter, the interactive session evaluates the expression and shows
+its value. If an expression is entered into an interactive session
+with a trailing semicolon, its value is not shown. The variable
+``ans`` is bound to the value of the last evaluated expression whether
+it is shown or not. The ``ans`` variable is only bound in interactive
+sessions, not when Julia code is run in other ways.
+
+To evaluate expressions written in a source file ``file.jl``, write
+``include("file.jl")``.
+
+To run code in a file non-interactively, you can give it as the first
+argument to the julia command::
+
+    $ julia script.jl arg1 arg2...
+
+As the example implies, the following command-line arguments to julia
+are taken as command-line arguments to the program ``script.jl``, passed
+in the global constant ``ARGS``. The name of the script itself is passed
+in as the global ``PROGRAM_FILE``. Note that ``ARGS`` is also set when script
+code is given using the ``-e`` option on the command line (see the ``julia``
+help output below) but ``PROGRAM_FILE`` will be empty. For example, to just
+print the arguments given to a script, you could do this::
+
+    $ julia -e 'println(PROGRAM_FILE); for x in ARGS; println(x); end' foo bar
+
+    foo
+    bar
+
+Or you could put that code into a script and run it::
+
+    $ echo 'println(PROGRAM_FILE); for x in ARGS; println(x); end' > script.jl
+    $ julia script.jl foo bar
+    script.jl
+    foo
+    bar
+
+The ``--`` delimiter can be used to separate command-line args to the scriptfile from args to Julia::
+
+    $ julia --color=yes -O -- foo.jl arg1 arg2..
+
+Julia can be started in parallel mode with either the ``-p`` or the
+``--machinefile`` options. ``-p n`` will launch an additional ``n`` worker
+processes, while ``--machinefile file`` will launch a worker for each line in
+file ``file``. The machines defined in ``file`` must be accessible via a
+passwordless ``ssh`` login, with Julia installed at the same location as the
+current host. Each machine definition takes the form
+``[count*][user@]host[:port] [bind_addr[:port]]`` . ``user`` defaults to current user,
+``port`` to the standard ssh port. ``count`` is the number of workers to spawn
+on the node, and defaults to 1. The optional ``bind-to bind_addr[:port]``
+specifies the ip-address and port that other workers should use to
+connect to this worker.
+
+
+If you have code that you want executed whenever julia is run, you can
+put it in ``~/.juliarc.jl``:
+
+.. raw:: latex
+
+    \begin{CJK*}{UTF8}{mj}
+
+::
+
+    $ echo 'println("Greetings! 你好! 안녕하세요?")' > ~/.juliarc.jl
+    $ julia
+    Greetings! 你好! 안녕하세요?
+
+    ...
+
+.. raw:: latex
+
+    \end{CJK*}
+
+There are various ways to run Julia code and provide options, similar to
+those available for the ``perl`` and ``ruby`` programs::
+
+    julia [switches] -- [programfile] [args...]
+     -v, --version             Display version information
+     -h, --help                Print this message
+
+     -J, --sysimage <file>     Start up with the given system image file
+     --precompiled={yes|no}    Use precompiled code from system image if available
+     --compilecache={yes|no}   Enable/disable incremental precompilation of modules
+     -H, --home <dir>          Set location of julia executable
+     --startup-file={yes|no}   Load ~/.juliarc.jl
+     -f, --no-startup          Don't load ~/.juliarc (deprecated, use --startup-file=no)
+     -F                        Load ~/.juliarc (deprecated, use --startup-file=yes)
+     --handle-signals={yes|no} Enable or disable Julia's default signal handlers
+
+     -e, --eval <expr>         Evaluate <expr>
+     -E, --print <expr>        Evaluate and show <expr>
+     -P, --post-boot <expr>    Evaluate <expr>, but don't disable interactive mode (deprecated, use -i -e instead)
+     -L, --load <file>         Load <file> immediately on all processors
+
+     -p, --procs {N|auto}      Integer value N launches N additional local worker processes
+                               "auto" launches as many workers as the number of local cores
+     --machinefile <file>      Run processes on hosts listed in <file>
+
+     -i                        Interactive mode; REPL runs and isinteractive() is true
+     -q, --quiet               Quiet startup (no banner)
+     --color={yes|no}          Enable or disable color text
+     --history-file={yes|no}   Load or save history
+     --no-history-file         Don't load history file (deprecated, use --history-file=no)
+
+     --compile={yes|no|all}    Enable or disable compiler, or request exhaustive compilation
+     -C, --cpu-target <target> Limit usage of cpu features up to <target>
+     -O, --optimize            Run time-intensive code optimizations
+     --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)
+     --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)
+     --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)
+
+     --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings ("error" turns warnings into errors)
+
+     --output-o name           Generate an object file (including system image data)
+     --output-ji name          Generate a system image data file (.ji)
+     --output-bc name          Generate LLVM bitcode (.bc)
+
+     --output-incremental=no   Generate an incremental output file (rather than complete)
+
+     --code-coverage={none|user|all}, --code-coverage
+                               Count executions of source lines (omitting setting is equivalent to "user")
+     --track-allocation={none|user|all}, --track-allocation
+                               Count bytes allocated by each source line
+
+Resources
+---------
+
+In addition to this manual, there are various other resources that may
+help new users get started with Julia:
+
+- `Julia and IJulia cheatsheet <http://math.mit.edu/~stevenj/Julia-cheatsheet.pdf>`_
+- `Learn Julia in a few minutes <http://learnxinyminutes.com/docs/julia/>`_
+- `Tutorial for Homer Reid's numerical analysis class <http://homerreid.dyndns.org/teaching/18.330/JuliaProgramming.shtml>`_
+- `An introductory presentation <https://raw.githubusercontent.com/ViralBShah/julia-presentations/master/Fifth-Elephant-2013/Fifth-Elephant-2013.pdf>`_
+- `Videos from the Julia tutorial at MIT <http://julialang.org/blog/2013/03/julia-tutorial-MIT/>`_
+- `Forio Julia Tutorials <http://forio.com/labs/julia-studio/tutorials/>`_
+

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -1,0 +1,254 @@
+.. _man-interacting-with-julia:
+
+************************
+ Interacting With Julia
+************************
+
+Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into the ``julia`` executable.  In addition to allowing quick and easy evaluation of Julia statements, it has a searchable history, tab-completion, many helpful keybindings, and dedicated help and shell modes.  The REPL can be started by simply calling julia with no arguments or double-clicking on the executable::
+
+    $ julia
+                   _
+       _       _ _(_)_     |  A fresh approach to technical computing
+      (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
+       _ _   _| |_  __ _   |  Type "help()" to list help topics
+      | | | | | | |/ _' |  |
+      | | |_| | | | (_| |  |  Version 0.3.0-prerelease+2834 (2014-04-30 03:13 UTC)
+     _/ |\__'_|_|_|\__'_|  |  Commit 64f437b (0 days old master)
+    |__/                   |  x86_64-apple-darwin13.1.0
+
+    julia>
+
+To exit the interactive session, type ``^D`` — the control key together with the ``d`` key on a blank line — or type ``quit()`` followed by the return or enter key. The REPL greets you with a banner and a ``julia>`` prompt.
+
+The different prompt modes
+--------------------------
+
+The Julian mode
+~~~~~~~~~~~~~~~
+
+The REPL has four main modes of operation.  The first and most common is the Julian prompt.  It is the default mode of operation; each new line initially starts with ``julia>``.  It is here that you can enter Julia expressions.  Hitting return or enter after a complete expression has been entered will evaluate the entry and show the result of the last expression.
+
+.. doctest::
+
+    julia> string(1 + 2)
+    "3"
+
+There are a number useful features unique to interactive work. In addition to showing the result, the REPL also binds the result to the variable ``ans``.  A trailing semicolon on the line can be used as a flag to suppress showing the result.
+
+.. doctest::
+
+    julia> string(3 * 4);
+
+    julia> ans
+    "12"
+
+Help mode
+~~~~~~~~~
+
+When the cursor is at the beginning of the line, the prompt can be changed to a help mode by typing ``?``.  Julia will attempt to print help or documentation for anything entered in help mode::
+
+    julia> ? # upon typing ?, the prompt changes (in place) to: help>
+
+    help> string
+    Base.string(xs...)
+
+       Create a string from any values using the "print" function.
+
+In addition to function names, complete function calls may be entered to see which method is called for the given argument(s).  Macros, types and variables can also be queried::
+
+    help> string(1)
+    string(x::Union{Int16,Int128,Int8,Int32,Int64}) at string.jl:1553
+
+    help> @printf
+    Base.@printf([io::IOStream], "%Fmt", args...)
+
+       Print arg(s) using C "printf()" style format specification
+       string. Optionally, an IOStream may be passed as the first argument
+       to redirect output.
+
+    help> AbstractString
+    DataType   : AbstractString
+      supertype: Any
+      subtypes : Any[DirectIndexString,RepString,RevString{T<:AbstractString},RopeString,SubString{T<:AbstractString},UTF16String,UTF8String]
+
+Help mode can be exited by pressing backspace at the beginning of the line.
+
+.. _man-shell-mode:
+
+Shell mode
+~~~~~~~~~~
+
+Just as help mode is useful for quick access to documentation, another common task is to use the system shell to execute system commands.  Just as ``?`` entered help mode when at the beginning of the line, a semicolon (``;``) will enter the shell mode.  And it can be exited by pressing backspace at the beginning of the line.
+
+::
+
+    julia> ; # upon typing ;, the prompt changes (in place) to: shell>
+
+    shell> echo hello
+    hello
+
+Search modes
+~~~~~~~~~~~~
+
+In all of the above modes, the executed lines get saved to a history file, which can be searched.  To initiate an incremental search through the previous history, type ``^R`` — the control key together with the ``r`` key.  The prompt will change to ``(reverse-i-search)`':``, and as you type the search query will appear in the quotes.  The most recent result that matches the query will dynamically update to the right of the colon as more is typed.  To find an older result using the same query, simply type ``^R`` again.
+
+Just as ``^R`` is a reverse search, ``^S`` is a forward search, with the prompt ``(i-search)`':``.  The two may be used in conjunction with each other to move through the previous or next matching results, respectively.
+
+
+Key bindings
+------------
+
+The Julia REPL makes great use of key bindings.  Several control-key bindings were already introduced above (``^D`` to exit, ``^R`` and ``^S`` for searching), but there are many more.  In addition to the control-key, there are also meta-key bindings.  These vary more by platform, but most terminals  default to using alt- or option- held down with a key to send the meta-key (or can be configured to do so).
+
++------------------------+----------------------------------------------------+
+| **Program control**                                                         |
++------------------------+----------------------------------------------------+
+| ``^D``                 | Exit (when buffer is empty)                        |
++------------------------+----------------------------------------------------+
+| ``^C``                 | Interrupt or cancel                                |
++------------------------+----------------------------------------------------+
+| ``^L``                 | Clear console screen                               |
++------------------------+----------------------------------------------------+
+| Return/Enter, ``^J``   | New line, executing if it is complete              |
++------------------------+----------------------------------------------------+
+| meta-Return/Enter      | Insert new line without executing it               |
++------------------------+----------------------------------------------------+
+| ``?`` or ``;``         | Enter help or shell mode (when at start of a line) |
++------------------------+----------------------------------------------------+
+| ``^R``, ``^S``         | Incremental history search, described above        |
++------------------------+----------------------------------------------------+
+| **Cursor movement**                                                         |
++------------------------+----------------------------------------------------+
+| Right arrow, ``^F``    | Move right one character                           |
++------------------------+----------------------------------------------------+
+| Left arrow, ``^B``     | Move left one character                            |
++------------------------+----------------------------------------------------+
+| Home, ``^A``           | Move to beginning of line                          |
++------------------------+----------------------------------------------------+
+| End, ``^E``            | Move to end of line                                |
++------------------------+----------------------------------------------------+
+| ``^P``                 | Change to the previous or next history entry       |
++------------------------+----------------------------------------------------+
+| ``^N``                 | Change to the next history entry                   |
++------------------------+----------------------------------------------------+
+| Up arrow               | Move up one line (or to the previous history entry)|
++------------------------+----------------------------------------------------+
+| Down arrow             | Move down one line (or to the next history entry)  |
++------------------------+----------------------------------------------------+
+| Page-up                | Change to the previous history entry that matches  |
+|                        | the text before the cursor                         |
++------------------------+----------------------------------------------------+
+| Page-down              | Change to the next history entry that matches the  |
+|                        | text before the cursor                             |
++------------------------+----------------------------------------------------+
+| ``meta-F``             | Move right one word                                |
++------------------------+----------------------------------------------------+
+| ``meta-B``             | Move left one word                                 |
++------------------------+----------------------------------------------------+
+| **Editing**                                                                 |
++------------------------+----------------------------------------------------+
+| Backspace, ``^H``      | Delete the previous character                      |
++------------------------+----------------------------------------------------+
+| Delete, ``^D``         | Forward delete one character (when buffer has text)|
++------------------------+----------------------------------------------------+
+| meta-Backspace         | Delete the previous word                           |
++------------------------+----------------------------------------------------+
+| ``meta-D``             | Forward delete the next word                       |
++------------------------+----------------------------------------------------+
+| ``^W``                 | Delete previous text up to the nearest whitespace  |
++------------------------+----------------------------------------------------+
+| ``^K``                 | "Kill" to end of line, placing the text in a buffer|
++------------------------+----------------------------------------------------+
+| ``^Y``                 | "Yank" insert the text from the kill buffer        |
++------------------------+----------------------------------------------------+
+| ``^T``                 | Transpose the characters about the cursor          |
++------------------------+----------------------------------------------------+
+
+Customizing keybindings
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Julia's REPL keybindings may be fully customized to a user's preferences by passing a dictionary to ``REPL.setup_interface()``. The keys of this dictionary may be characters or strings. The key ``'*'`` refers to the default action. Control plus character ``x`` bindings are indicated with ``"^x"``. Meta plus ``x`` can be written ``"\\Mx"``. The values of the custom keymap must be ``nothing`` (indicating that the input should be ignored) or functions that accept the signature ``(PromptState, AbstractREPL, Char)``. The ``REPL.setup_interface()`` function must be called before the REPL is initialized, by registering the operation with ``atreplinit()``. For example, to bind the up and down arrow keys to move through history without prefix search, one could put the following code in ``.juliarc.jl``::
+
+    import Base: LineEdit, REPL
+
+    const mykeys = Dict{Any,Any}(
+      # Up Arrow
+      "\e[A" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_prev(s, LineEdit.mode(s).hist)),
+      # Down Arrow
+      "\e[B" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_next(s, LineEdit.mode(s).hist))
+    )
+
+    function customize_keys(repl)
+      repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys)
+    end
+
+    atreplinit(customize_keys)
+
+Users should refer to ``base/LineEdit.jl`` to discover the available actions on key input.
+
+Tab completion
+--------------
+
+In both the Julian and help modes of the REPL, one can enter the first few characters of a function or type and then press the tab key to get a list all matches::
+
+    julia> stri
+    stride     strides     string      stringmime  strip
+
+    julia> Stri
+    StridedArray    StridedVecOrMat  AbstractString
+    StridedMatrix   StridedVector
+
+The tab key can also be used to substitute LaTeX math symbols with their Unicode equivalents,
+and get a list of LaTeX matches as well::
+
+    julia> \pi[TAB]
+    julia> π
+    π = 3.1415926535897...
+
+    julia> e\_1[TAB] = [1,0]
+    julia> e₁ = [1,0]
+    2-element Array{Int64,1}:
+     1
+     0
+
+    julia> e\^1[TAB] = [1 0]
+    julia> e¹ = [1 0]
+    1×2 Array{Int64,2}:
+     1  0
+
+    julia> \sqrt[TAB]2     # √ is equivalent to the sqrt() function
+    julia> √2
+    1.4142135623730951
+
+    julia> \hbar[TAB](h) = h / 2\pi[TAB]
+    julia> ħ(h) = h / 2π
+    ħ (generic function with 1 method)
+
+    julia> \h[TAB]
+    \hat              \heartsuit         \hksearow          \hookleftarrow     \hslash
+    \hbar             \hermitconjmatrix  \hkswarow          \hookrightarrow    \hspace
+
+A full list of tab-completions can be found in the :ref:`man-unicode-input` section of the manual.
+
+
+Customizing Colors
+~~~~~~~~~~~~~~~~~~
+
+The colors used by Julia and the REPL can be customized, as well. To change the color of the Julia
+prompt you can add something like the following to your ``juliarc.jl`` file::
+
+    Base.active_repl.prompt_color = Base.text_colors[:cyan]
+
+The available color keys in ``Base.text_colors`` are ``:black``, ``:red``, ``:green``, ``:yellow``,
+``:blue``, ``:magenta``, ``:cyan``, ``:white``, ``:normal``, and ``:bold``. Similarly, you can
+change the colors for the help and shell prompts and input and answer text by setting the
+appropriate member of ``Base.active_repl`` (respectively, ``help_color``, ``shell_color``,
+``input_color``, and ``answer_color``). For the latter two, be sure that the ``envcolors`` member
+is also set to false.
+
+You can also customize the color used to render warning and informational messages by
+setting the appropriate environment variable. For instance, to render warning messages in yellow and
+informational messages in cyan you can add the following to your ``juliarc.jl`` file::
+
+    ENV["JULIA_WARN_COLOR"] = :yellow
+    ENV["JULIA_INFO_COLOR"] = :cyan


### PR DESCRIPTION
julia-dev thread:
- https://groups.google.com/forum/#!topic/julia-dev/Nn5jAgOPgzs

I'd like to propose changing the back tick for a single quote or something similar, this little change makes every syntax highlighting tool I've tested, work with a snippet of Julia code that includes the Julia Banner. Notice how with the back tick in the default banner, syntax highlighting is messed up, this happens in many editors too.

original with a back-tick (highlight messed up):
- https://gist.github.com/Ismael-VC/57a6c99531579f29c4c77ff8859ea545#file-backtick-jl

```
  __ _
 / _` |
| (_| |
 \__'_|
```

with a single quote (highlight works):
- https://gist.github.com/Ismael-VC/57a6c99531579f29c4c77ff8859ea545#file-single_quote-jl

```
  __ _
 / _' |
| (_| |
 \__'_|
```

with an accent (highlight works):
- https://gist.github.com/Ismael-VC/57a6c99531579f29c4c77ff8859ea545#file-accent-jl

```
  __ _
 / _´ |
| (_| |
 \__'_|
```
