### PR TITLE
RFC: Don't suggest other type constructors in closest method suggestions in REPL 

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -289,15 +289,7 @@ function show_method_candidates(io::IO, ex::MethodError)
             print(buf, "  ")
             if !(func <: s1)
                 # function itself doesn't match
-                print(buf, "(")
-                if Base.have_color
-                    Base.with_output_color(:red, buf) do buf
-                        print(buf, "::", s1)
-                    end
-                else
-                    print(buf, "!Matched::", s1)
-                end
-                print(buf, ")")
+                return
             else
                 use_constructor_syntax = func.name === Type.name && !isa(func.parameters[1],TypeVar)
                 print(buf, use_constructor_syntax ? func.parameters[1] : func.name.mt.name)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/issues/16118#issuecomment-216032491 shows how for type constructors, the current code that suggests closest methods upon `MethodError` walks through ALL constructors and counts how many arguments match.

This means that type constructors that for example take a bunch of  `Any` will always have all it's argument match and always be suggested as a top closest candidate:

``` jl
julia> type Foo; a; end

julia> Foo(1,2)
ERROR: MethodError: no method matching Foo(::Int64, ::Int64)
Closest candidates are:
  (::Type{BoundsError})(::ANY, ::ANY)
  (::Type{TypeError})(::Any, ::Any, ::Any, ::Any)
  (::Type{TypeConstructor})(::ANY, ::ANY)
  ...
 in eval(::Module, ::Any) at ./boot.jl:243
```

This PR would simply not print a closest match for anything except for the type constructor, like this:

``` jl
julia> type Foo2; a; b; end

julia> Foo(1,2) # Foo2 or any other constructor is not suggested
ERROR: MethodError: no method matching Foo(::Int64, ::Int64)
Closest candidates are:
  Foo(::Any)
  Foo{T}(::Any)
 in eval(::Module, ::Any) at ./boot.jl:236
```

This is consistent with how functions are being suggested. We don't list all other functions that happened to have arguments match so why should we do it for type constructors?

``` jl
julia> foo(a::Int) = a
foo (generic function with 1 method)

julia> foo2(a::Float64) = a
foo2 (generic function with 1 method)

julia> foo(1.0) # No closest method matches
ERROR: MethodError: no method matching foo(::Float64)
 in eval(::Module, ::Any) at ./boot.jl:237
```

It also matches how I personally always use the suggestions which is that I mess up with the type for one of the fields in a type with a lot of fields and I want to know which field I messed up on.

Further comments and ideas are welcome.
