### PR TITLE
Remove mention of issue #2818 from 0.4 manual

### DIFF
--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -564,12 +564,6 @@ Use ``Ptr{T}`` if the memory is expected to be populated by ``C`` (without type-
 Use ``Ref{T}`` if you have an ``isbits`` type,
 but you want to turn it into a pointer to a struct in another struct definition.
 
-See issue #2818 for some work that needs to be done to simplify this so that Julia
-types can be used to recursively mirror c-style structs,
-without requiring as much manual management of the ``Ptr`` conversions.
-After #2818 is implemented, it will be true that an ``Vector{T}`` will be equivalent to
-an ``Ptr{Ptr{T}}``. That is currently not true, and the conversion must be explicitly.
-
 Mapping C Functions to Julia
 ----------------------------
 


### PR DESCRIPTION
As noted [here](https://github.com/JuliaLang/julia/pull/10579#issuecomment-83840990), I think this should be removed from the `release-0.4`.  Another option is to just cherry-pick @jiahao's a70ecdb437a77927b142aa56d48eb4a0b894f3e6 onto `release-0.4`.  As far as I can tell, everything  written there should be compatible with 0.4, but I'm not certain, so I have only this minimal change in this PR.
