### PR TITLE
Fix libatomic lookup and atomic test on 32bit ARM

### DIFF
--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -14,8 +14,10 @@ export
     atomic_fence
 
 # Disable 128-bit types on 32-bit Intel sytems due to LLVM problems;
-# see <https://github.com/JuliaLang/julia/issues/14818>
-if Base.ARCH === :i686
+# see <https://github.com/JuliaLang/julia/issues/14818> (fixed on LLVM 3.9)
+# 128-bit atomics do not exist on AArch32.
+if (VersionNumber(Base.libllvm_version) < v"3.9-" && Base.ARCH === :i686) ||
+        startswith(string(Base.ARCH), "arm")
     const inttypes = (Int8, Int16, Int32, Int64,
                       UInt8, UInt16, UInt32, UInt64)
 else

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -202,7 +202,7 @@ extern RTDyldMemoryManager *createRTDyldMemoryManagerUnix();
 // This is the library that provides support for c11/c++11 atomic operations.
 static uint64_t resolve_atomic(const char *name)
 {
-    static void *atomic_hdl = jl_load_dynamic_library_e("libatomic.so",
+    static void *atomic_hdl = jl_load_dynamic_library_e("libatomic",
                                                         JL_RTLD_LOCAL);
     static const char *const atomic_prefix = "__atomic_";
     if (!atomic_hdl)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -238,8 +238,9 @@ test_fence()
 let atomic_types = [Int8, Int16, Int32, Int64, Int128,
                     UInt8, UInt16, UInt32, UInt64, UInt128,
                     Float16, Float32, Float64]
-    # Temporarily omit 128-bit types
-    if Base.ARCH === :i686
+    # Temporarily omit 128-bit types on 32bit x86
+    # 128-bit atomics do not exist on AArch32.
+    if Base.ARCH === :i686 || startswith(string(Base.ARCH), "arm")
         filter!(T -> sizeof(T)<=8, atomic_types)
     end
     for T in atomic_types


### PR DESCRIPTION
- Using `libatomic.so` breaks the soname lookup (Ref https://github.com/staticfloat/julia-buildbot/issues/44).
- 128bit atomic should work on 32bit x86 on llvm-svn now (It should always use the `__atomic_*` function on x86).
- Disable 128bit atomic on 32bit ARM. AFAIK it's not supported. (There's not such instruction and `libatomic` doesn't support it)
