### PR TITLE
Small update to pushmeta! devdocs

### DIFF
--- a/doc/devdocs/meta.rst
+++ b/doc/devdocs/meta.rst
@@ -47,7 +47,7 @@ to specify additional information.
 
 To use the metadata, you have to parse these ``:meta`` expressions.
 If your implementation can be performed within Julia, ``Base.popmeta!`` is
-very handy: ``popmeta!(body, :symbol)`` will scan a function *body*
+very handy: ``Base.popmeta!(body, :symbol)`` will scan a function *body*
 expression (one without the function signature) for a ``:meta``
 expression, extract any arguments, and return a tuple ``(found::Bool,
 args::Array{Any})``. If the metadata did not have any arguments, or

--- a/doc/devdocs/meta.rst
+++ b/doc/devdocs/meta.rst
@@ -20,7 +20,7 @@ the implementation of the ``@inline`` macro::
         esc(_inline(ex))
     end
 
-    _inline(ex::Expr) = pushmeta!(ex, :inline)
+    _inline(ex::Expr) = Base.pushmeta!(ex, :inline)
     _inline(arg) = arg
 
 Here, ``ex`` is expected to be an expression defining a function.
@@ -46,7 +46,7 @@ necessary. If ``args`` is specified, a nested expression containing
 to specify additional information.
 
 To use the metadata, you have to parse these ``:meta`` expressions.
-If your implementation can be performed within Julia, ``popmeta!`` is
+If your implementation can be performed within Julia, ``Base.popmeta!`` is
 very handy: ``popmeta!(body, :symbol)`` will scan a function *body*
 expression (one without the function signature) for a ``:meta``
 expression, extract any arguments, and return a tuple ``(found::Bool,


### PR DESCRIPTION
A tiny PR - two updates to these docs to indicate that `pushmeta!` and `popmeta!` are not exported by Base. This had a fellow Julia user stumped for some time... With this change, the examples will run exactly as printed. 

Please close this PR if this documentation detail was intentional.
