### PR TITLE
Trivial documentation fix: added some commas.

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -34,7 +34,7 @@ introducing scope blocks are:
 | :ref:`local <man-local-scope>` | :ref:`soft <man-soft-scope>` | for, while, list-comprehensions,                  |
 |                                |                              | try-catch-finally, let                            |
 |                                +------------------------------+---------------------------------------------------+
-|                                | :ref:`hard <man-hard-scope>` | functions (either syntax, anonymous & do-blocks)  |
+|                                | :ref:`hard <man-hard-scope>` | functions (either syntax, anonymous & do-blocks), |
 |                                |                              | type, immutable, macro                            |
 +--------------------------------+------------------------------+---------------------------------------------------+
 
@@ -223,7 +223,7 @@ Hard Local Scope
 ^^^^^^^^^^^^^^^^
 
 Hard local scopes are introduced by function definitions (in all their
-forms), type & immutable-blocks and macro-definitions.
+forms), type & immutable-blocks, and macro-definitions.
 
    In a hard local scope, all variables are inherited from its parent
    scope unless:
@@ -349,7 +349,7 @@ Thus their default is to fully access all variables in their parent
 scope.
 
 Conversely, the code inside blocks which introduce a hard local scope
-(function, type and macro definitions) can be executed at any place in
+(function, type, and macro definitions) can be executed at any place in
 a program.  Remotely changing the state of global variables in other
 modules should be done with care and thus this is an opt-in feature
 requiring the ``global`` keyword.


### PR DESCRIPTION
First is a missing comma from an enumeration, the other two are serial commas.

(note: this was PR #16149 before, but I messed up the git workflow there so I am resubmitting.)
