### PR TITLE
Drop other argument of fkeep! (in favour of closures if needed)

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -1645,7 +1645,7 @@ function sort{Tv,Ti}(x::SparseVector{Tv,Ti}; kws...)
     SparseVector(n,newnzind,newnzvals)
 end
 
-function fkeep!(x::SparseVector, f, other, trim::Bool = true)
+function fkeep!(x::SparseVector, f, trim::Bool = true)
     n = x.n
     nzind = x.nzind
     nzval = x.nzval
@@ -1655,7 +1655,7 @@ function fkeep!(x::SparseVector, f, other, trim::Bool = true)
         xi = nzind[xk]
         xv = nzval[xk]
         # If this element should be kept, rewrite in new position
-        if f(xi, xv, other)
+        if f(xi, xv)
             if x_writepos != xk
                 nzind[x_writepos] = xi
                 nzval[x_writepos] = xv
@@ -1676,7 +1676,7 @@ function fkeep!(x::SparseVector, f, other, trim::Bool = true)
     x
 end
 
-droptol!(x::SparseVector, tol, trim::Bool = true) = fkeep!(x, (i, x, tol) -> abs(x) > tol, tol, trim)
+droptol!(x::SparseVector, tol, trim::Bool = true) = fkeep!(x, (i, x) -> abs(x) > tol, trim)
 
-dropzeros!(x::SparseVector, trim::Bool = true) = fkeep!(x, (i, x, other) -> x != 0, nothing, trim)
+dropzeros!(x::SparseVector, trim::Bool = true) = fkeep!(x, (i, x) -> x != 0, trim)
 dropzeros(x::SparseVector, trim::Bool = true) = dropzeros!(copy(x), trim)

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -890,8 +890,8 @@ let x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 7)
 
     xdrop = copy(x)
     # This will keep index 1, 3, 4, 7 in xdrop
-    f_drop(i, x, other) = (abs(x) == 1.) || (i in [1, 7])
-    Base.SparseArrays.fkeep!(xdrop, f_drop, Void)
+    f_drop(i, x) = (abs(x) == 1.) || (i in [1, 7])
+    Base.SparseArrays.fkeep!(xdrop, f_drop)
     @test exact_equal(xdrop, SparseVector(7, [1, 3, 4, 7], [3., -1., 1., 3.]))
 end
 


### PR DESCRIPTION
- Pro: slightly cleaner code (at least IHMO)
- Con: no deprecation (would fail if a boolean `other` argument is used and how to deprecate a function from a submodule? ); but `fkeep!` seems not to be used outside Julia itself anyway
