### PR TITLE
update @ccallable to expect a return type declaration

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -209,11 +209,7 @@ function ccallable(f::Function, rt::Type, argt::Type, name::Union{AbstractString
     ccall(:jl_extern_c, Void, (Any, Any, Any, Cstring), f, rt, argt, name)
 end
 
-function ccallable(f::Function, argt::Type, name::Union{AbstractString,Symbol}=string(f))
-    ccall(:jl_extern_c, Void, (Any, Ptr{Void}, Any, Cstring), f, C_NULL, argt, name)
-end
-
-macro ccallable(def)
+macro ccallable(rt, def)
     if isa(def,Expr) && (def.head === :(=) || def.head === :function)
         sig = def.args[1]
         if sig.head === :call
@@ -227,7 +223,7 @@ macro ccallable(def)
             end
             return quote
                 $(esc(def))
-                ccallable($(esc(name)), $(Expr(:curly, :Tuple, map(esc, at)...)))
+                ccallable($(esc(name)), $(esc(rt)), $(Expr(:curly, :Tuple, map(esc, at)...)), $(string(name)))
             end
         end
     end

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -406,7 +406,13 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, bool *isboxed)
             }
 #ifndef NDEBUG
             // If LLVM and Julia disagree about alignment, much trouble ensues, so check it!
-            unsigned llvm_alignment = jl_ExecutionEngine->getDataLayout().getABITypeAlignment((Type*)jst->struct_decl);
+            const DataLayout &DL =
+#ifdef LLVM36
+                jl_ExecutionEngine->getDataLayout();
+#else
+                *jl_ExecutionEngine->getDataLayout();
+#endif
+            unsigned llvm_alignment = DL.getABITypeAlignment((Type*)jst->struct_decl);
             unsigned julia_alignment = jst->alignment;
             assert(llvm_alignment==julia_alignment);
 #endif


### PR DESCRIPTION
since jl_extern_c now supports generic dispatch and unconstrained return types
a declaration of intent is required,
instead of relying on type-inference result as was done previously
(implicit in the jl_extern_c code)

(I noticed also that this doesn't appear to be documented at all. I'm thinking of adding to doc/devdocs/sysimg.rst with reference to http://juliacomputing.com/blog/2016/02/09/static-julia.html. Unless someone has another thought for a better place for this content? I think at least a mention and a link from `cfunction` would also be appropriate.)
