### PR TITLE
fix sort and select to work for immutable arrays such as ranges

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -66,7 +66,7 @@ select!(v::AbstractVector, k::Union{Int,OrdinalRange};
     lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward) =
     select!(v, k, ord(lt,by,rev,order))
 
-select(v::AbstractVector, k::Union{Int,OrdinalRange}; kws...) = select!(copy(v), k; kws...)
+select(v::AbstractVector, k::Union{Int,OrdinalRange}; kws...) = select!(copy!(similar(v), v), k; kws...)
 
 
 # reference on sorted binary search:
@@ -410,7 +410,7 @@ function sort!(v::AbstractVector;
     sort!(v, alg, ord(lt,by,rev,order))
 end
 
-sort(v::AbstractVector; kws...) = sort!(copy(v); kws...)
+sort(v::AbstractVector; kws...) = sort!(copy!(similar(v), v); kws...)
 
 
 ## selectperm: the permutation to sort the first k elements of an array ##

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -118,6 +118,9 @@ end
 
 @test sort(UnitRange(1,2)) == UnitRange(1,2)
 @test sort!(UnitRange(1,2)) == UnitRange(1,2)
+@test sort(1:10, rev=true) == collect(10:-1:1)
+@test sort(-3:3, by=abs) == [0,-1,1,-2,2,-3,3]
+@test select(1:10, 4) == 4
 
 @test 0 in UInt(0):100:typemax(UInt)
 @test last(UInt(0):100:typemax(UInt)) in UInt(0):100:typemax(UInt)


### PR DESCRIPTION
As was discussed recently [on julia-users](https://groups.google.com/d/msg/julia-users/hPy6xBy5KB0/anPrkRj-CAAJ), the `sort` (and also `select`) functions did not work in general for ranges.   The problem was that `sort(a; ...)` called `sort!(copy(a); ...)`, but `copy(a)` returns an (immutable) range for ranges.

Elsewhere in `Base`, where we want to ensure a mutable copy, we call `similar(a)`.  (Since `similar` is documented to return an "uninitialized" array, it pretty much has to be a mutable array type to be useful.)   So, I changed the `sort` and `select` functions to do the same thing.

(The alternative would be to remove the specialized `copy(r::Range) = r` method for ranges, but that wouldn't help for user-defined immutable array types, unless we document that `copy` is supposed to produce a mutable copy.  But it seems potentially useful to call `copy(a)` just to make a copy of the array that can't be changed by the caller, e.g. when initializing a data structure, and in that case the current behavior for `Range` is optimal.)
