### PR TITLE
only use 'true and 'false in ASTs instead of scheme #f and #t

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -428,10 +428,6 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
     }
     if (fl_isstring(fl_ctx, e))
         return jl_pchar_to_string((char*)cvalue_data(e), cvalue_len(e));
-    if (e == fl_ctx->F)
-        return jl_false;
-    if (e == fl_ctx->T)
-        return jl_true;
     if (iscons(e) || e == fl_ctx->NIL) {
         value_t hd;
         jl_sym_t *sym;
@@ -616,9 +612,9 @@ static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v)
     if (jl_is_symbol(v))
         return symbol(fl_ctx, jl_symbol_name((jl_sym_t*)v));
     if (v == jl_true)
-        return fl_ctx->T;
+        return jl_ast_ctx(fl_ctx)->true_sym;
     if (v == jl_false)
-        return fl_ctx->F;
+        return jl_ast_ctx(fl_ctx)->false_sym;
     if (v == jl_nothing)
         return fl_cons(fl_ctx, jl_ast_ctx(fl_ctx)->null_sym, fl_ctx->NIL);
     if (jl_is_expr(v)) {

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1190,7 +1190,7 @@
                 (loc (begin (if (newline? (peek-token s))
                                 (skip-ws-and-comments (ts:port s)))
                             (line-number-node s))))
-            (begin0 (list 'type (if (eq? word 'type) #t #f)
+            (begin0 (list 'type (if (eq? word 'type) 'true 'false)
                           sig (add-filename-to-block! (parse-block s) loc))
                     (expect-end s word)))))
        ((bitstype)
@@ -1213,9 +1213,9 @@
             (take-token s)
             (cond
              ((eq? nxt 'end)
-              (list* 'try try-block catchv
+              (list* 'try try-block (or catchv 'false)
                      ;; default to empty catch block in `try ... end`
-                     (or catchb (if finalb #f '(block)))
+                     (or catchb (if finalb 'false '(block)))
                      (if finalb (list finalb) '())))
              ((and (eq? nxt 'catch)
                    (not catchb))
@@ -1236,7 +1236,7 @@
                             (if var?
                                 catch-block
                                 `(block ,var ,@(cdr catch-block)))
-                            (and var? var)
+                            (if var? var 'false)
                             finalb)))))
              ((and (eq? nxt 'finally)
                    (not finalb))
@@ -1273,7 +1273,7 @@
                (loc  (line-number-node s))
                (body (parse-block s (lambda (s) (parse-docstring s parse-eq)))))
           (expect-end s word)
-          (list 'module (eq? word 'module) name
+          (list 'module (if (eq? word 'module) 'true 'false) name
                 (if (eq? word 'module)
                     (list* 'block
                            ;; add definitions for module-local eval

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -440,3 +440,7 @@ add_method_to_glob_fn!()
 @test_throws ParseError parse("function catch() end")
 @test_throws ParseError parse("function end() end")
 @test_throws ParseError parse("function finally() end")
+
+# PR #16170
+@test expand(parse("true(x) = x")) == Expr(:error, "invalid function name \"true\"")
+@test expand(parse("false(x) = x")) == Expr(:error, "invalid function name \"false\"")


### PR DESCRIPTION
This is a purely internal change. We were not clear about whether scheme boolean values were allowed in ASTs to represent julia Bools. This led to the following anomalous behavior, observed by @stevenhao:

```
julia> false(x) = x

julia> true(x) = x
ERROR: syntax: invalid method name "true"
 in eval(::Module, ::Any) at ./boot.jl:236
```

where the first one gave no error and added a method to `Bool`. Now only the symbols `true` and `false` are used in ASTs, and both expressions above give an error.
