### PR TITLE
Fix HessenbergQ

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4615,16 +4615,6 @@ Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x)``.
 hankelh1
 
 """
-    hessfact(A)
-
-Compute the Hessenberg decomposition of `A` and return a `Hessenberg` object. If `F` is the
-factorization object, the unitary matrix can be accessed with `F[:Q]` and the Hessenberg
-matrix with `F[:H]`. When `Q` is extracted, the resulting type is the `HessenbergQ` object,
-and may be converted to a regular matrix with [`full`](:func:`full`).
-"""
-hessfact
-
-"""
     gcdx(x,y)
 
 Computes the greatest common (positive) divisor of `x` and `y` and their Bézout

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -229,6 +229,7 @@ include("linalg/triangular.jl")
 
 include("linalg/factorization.jl")
 include("linalg/qr.jl")
+include("linalg/hessenberg.jl")
 include("linalg/lq.jl")
 include("linalg/eigen.jl")
 include("linalg/svd.jl")

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -508,11 +508,15 @@ end
     end
     @inbounds begin
         for j = 1:n
+            # dot
             vAj = A[1, j]
             for i = 2:m
                 vAj += x[i]'*A[i, j]
             end
+
             vAj = τ'*vAj
+
+            # ger
             A[1, j] -= vAj
             for i = 2:m
                 A[i, j] -= x[i]*vAj

--- a/base/linalg/hessenberg.jl
+++ b/base/linalg/hessenberg.jl
@@ -1,0 +1,84 @@
+immutable Hessenberg{T,S<:AbstractMatrix} <: Factorization{T}
+    factors::S
+    τ::Vector{T}
+    Hessenberg(factors::AbstractMatrix{T}, τ::Vector{T}) = new(factors, τ)
+end
+Hessenberg{T}(factors::AbstractMatrix{T}, τ::Vector{T}) = Hessenberg{T,typeof(factors)}(factors, τ)
+
+Hessenberg(A::StridedMatrix) = Hessenberg(LAPACK.gehrd!(A)...)
+
+hessfact!{T<:BlasFloat}(A::StridedMatrix{T}) = Hessenberg(A)
+
+hessfact{T<:BlasFloat}(A::StridedMatrix{T}) = hessfact!(copy(A))
+function hessfact{T}(A::StridedMatrix{T})
+    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
+    return hessfact!(copy_oftype(A, S))
+end
+
+"""
+    hessfact(A)
+
+Compute the Hessenberg decomposition of `A` and return a `Hessenberg` object. If `F` is the
+factorization object, the unitary matrix can be accessed with `F[:Q]` and the Hessenberg
+matrix with `F[:H]`. When `Q` is extracted, the resulting type is the `HessenbergQ` object,
+and may be converted to a regular matrix with [`full`](:func:`full`).
+"""
+hessfact
+
+
+immutable HessenbergQ{T,S<:AbstractMatrix} <: AbstractMatrix{T}
+    factors::S
+    τ::Vector{T}
+    HessenbergQ(factors::AbstractMatrix{T}, τ::Vector{T}) = new(factors, τ)
+end
+HessenbergQ{T}(factors::AbstractMatrix{T}, τ::Vector{T}) = HessenbergQ{T,typeof(factors)}(factors, τ)
+HessenbergQ(A::Hessenberg) = HessenbergQ(A.factors, A.τ)
+size(A::HessenbergQ, args...) = size(A.factors, args...)
+
+function getindex(A::Hessenberg, d::Symbol)
+    d == :Q && return HessenbergQ(A)
+    d == :H && return triu(A.factors, -1)
+    throw(KeyError(d))
+end
+
+function getindex(A::HessenbergQ, i::Integer, j::Integer)
+    x = zeros(eltype(A), size(A, 1))
+    x[i] = 1
+    y = zeros(eltype(A), size(A, 2))
+    y[j] = 1
+    return dot(x, A_mul_B!(A, y))
+end
+
+## reconstruct the original matrix
+full{T<:BlasFloat}(A::HessenbergQ{T}) = LAPACK.orghr!(1, size(A.factors, 1), copy(A.factors), A.τ)
+function full(F::Hessenberg)
+    fq = full(F[:Q])
+    return (fq * F[:H]) * fq'
+end
+
+A_mul_B!{T<:BlasFloat}(Q::HessenbergQ{T}, X::StridedVecOrMat{T}) =
+    LAPACK.ormhr!('L', 'N', 1, size(Q.factors, 1), Q.factors, Q.τ, X)
+A_mul_B!{T<:BlasFloat}(X::StridedMatrix{T}, Q::HessenbergQ{T}) =
+    LAPACK.ormhr!('R', 'N', 1, size(Q.factors, 1), Q.factors, Q.τ, X)
+Ac_mul_B!{T<:BlasFloat}(Q::HessenbergQ{T}, X::StridedVecOrMat{T}) =
+    LAPACK.ormhr!('L', ifelse(T<:Real, 'T', 'C'), 1, size(Q.factors, 1), Q.factors, Q.τ, X)
+A_mul_Bc!{T<:BlasFloat}(X::StridedMatrix{T}, Q::HessenbergQ{T}) =
+    LAPACK.ormhr!('R', ifelse(T<:Real, 'T', 'C'), 1, size(Q.factors, 1), Q.factors, Q.τ, X)
+
+
+function (*){T,S}(Q::HessenbergQ{T}, X::StridedVecOrMat{S})
+    TT = typeof(zero(T)*zero(S) + zero(T)*zero(S))
+    return A_mul_B!(Q, copy_oftype(X, TT))
+end
+function (*){T,S}(X::StridedVecOrMat{S}, Q::HessenbergQ{T})
+    TT = typeof(zero(T)*zero(S) + zero(T)*zero(S))
+    return A_mul_B!(copy_oftype(X, TT), Q)
+end
+function Ac_mul_B{T,S}(Q::HessenbergQ{T}, X::StridedVecOrMat{S})
+    TT = typeof(zero(T)*zero(S) + zero(T)*zero(S))
+    return Ac_mul_B!(Q, copy_oftype(X, TT))
+end
+function A_mul_Bc{T,S}(X::StridedVecOrMat{S}, Q::HessenbergQ{T})
+    TT = typeof(zero(T)*zero(S) + zero(T)*zero(S))
+    return A_mul_Bc!(copy_oftype(X, TT), Q)
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -66,7 +66,8 @@ function choosetests(choices = [])
                    "linalg/lapack", "linalg/tridiag", "linalg/bidiag",
                    "linalg/diagonal", "linalg/pinv", "linalg/givens",
                    "linalg/cholesky", "linalg/lu", "linalg/symmetric",
-                   "linalg/generic", "linalg/uniformscaling", "linalg/lq"]
+                   "linalg/generic", "linalg/uniformscaling", "linalg/lq",
+                   "linalg/hessenberg"]
     if Base.USE_GPL_LIBS
         push!(linalgtests, "linalg/arnoldi")
     end

--- a/test/linalg/hessenberg.jl
+++ b/test/linalg/hessenberg.jl
@@ -1,0 +1,34 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+debug = false
+using Base.Test
+
+using Base.LinAlg: BlasComplex, BlasFloat, BlasReal, QRPivoted
+
+let n = 10
+
+    srand(1234321)
+
+    Areal  = randn(n,n)/2
+    Aimg   = randn(n,n)/2
+
+    for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+        A = eltya == Int ?
+                rand(1:7, n, n) :
+                convert(Matrix{eltya}, eltya <: Complex ?
+                    complex(Areal, Aimg) :
+                    Areal)
+
+    debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
+
+        if eltya != BigFloat
+            H = hessfact(A)
+            @test size(H[:Q], 1) == size(A, 1)
+            @test size(H[:Q], 2) == size(A, 2)
+            @test_throws KeyError H[:Z]
+            @test_approx_eq full(H) A
+            @test_approx_eq (H[:Q] * H[:H]) * H[:Q]' A
+            @test_approx_eq (H[:Q]' * A) * H[:Q]     H[:H]
+        end
+    end
+end

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -137,16 +137,6 @@ debug && println("Matmul with QR factorizations")
             @test_throws BoundsError size(q,-1)
             @test_throws DimensionMismatch q * eye(Int8,n+4)
         end
-
-debug && println("Hessenberg")
-        if eltya != BigFloat
-            hA = hessfact(a)
-            @test size(hA[:Q],1) == size(a,1)
-            @test size(hA[:Q],2) == size(a,2)
-            @test_throws KeyError hA[:Z]
-            @test_approx_eq full(hA) a
-            @test_approx_eq full(Base.LinAlg.HessenbergQ(hA)) full(hA[:Q])
-        end
     end
 end
 


### PR DESCRIPTION
Accidentally, I noticed that the `HessenbergQ` didn't work for its main purpose, i.e. multiplication. This PR adds multiplication methods for `HessenbergQ`.

I thought about simply removing the type but a search revealed that at least one package actually uses the type so I'll a potential removal of the type to a more general cleanup. At that time, a package like `LinearAlgebra.jl` might also be in a better shape for taking over some of the functionality from base. The i.e. impact on total test time should be small, i.e. something like 2-3 seconds.

I'm also restructuring the files such that the Hessenberg functionality is now in its own file instead of in the end of `qr.jl` and I'm moving the documentation entry into that new file from `docs/helpdb/Base.jl`. 
