### PR TITLE
Fix Symbol redefinition warnings

### DIFF
--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -45,7 +45,6 @@ if !isdefined(Main, :Base)
 end
 
 # Symbol constructors
-Symbol(s::Symbol) = s
 Symbol(s::ASCIIString) = Symbol(s.data)
 Symbol(s::UTF8String) = Symbol(s.data)
 Symbol(a::Array{UInt8,1}) =

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -44,6 +44,13 @@ if !isdefined(Main, :Base)
     (::Type{T}){T}(arg) = convert(T, arg)::T
 end
 
+# Symbol constructors
+Symbol(s::Symbol) = s
+Symbol(s::ASCIIString) = Symbol(s.data)
+Symbol(s::UTF8String) = Symbol(s.data)
+Symbol(a::Array{UInt8,1}) =
+    ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int32), a, length(a))
+
 # core array operations
 include("abstractarray.jl")
 include("array.jl")

--- a/base/dates/arithmetic.jl
+++ b/base/dates/arithmetic.jl
@@ -67,7 +67,7 @@ end
 (-)(y::Period,x::TimeType) = x - y
 
 for op in (:.+, :.-)
-    op_ = Symbol(string(op)[2])
+    op_ = Symbol(string(op)[2:end])
     @eval begin
         # GeneralPeriod, AbstractArray{TimeType}
         ($op){T<:TimeType}(x::AbstractArray{T}, y::GeneralPeriod) =

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -95,7 +95,7 @@ for (op,Ty,Tz) in ((:.*,Real,:P),
                    (:.%,:P,:P),
                    (:mod,:P,:P))
     sop = string(op)
-    op_ = sop[1] == '.' ? Symbol(sop[2]) : op
+    op_ = sop[1] == '.' ? Symbol(sop[2:end]) : op
     @eval begin
         function ($op){P<:Period}(X::StridedArray{P},y::$Ty)
             Z = similar(X, $Tz)
@@ -234,7 +234,7 @@ GeneralPeriod = Union{Period,CompoundPeriod}
 (+){P<:GeneralPeriod}(x::StridedArray{P}) = x
 
 for op in (:.+, :.-)
-    op_ = Symbol(string(op)[2])
+    op_ = Symbol(string(op)[2:end])
     @eval begin
         function ($op){P<:GeneralPeriod}(X::StridedArray{P},y::GeneralPeriod)
             Z = similar(X, CompoundPeriod)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1079,7 +1079,6 @@ export
     gensym,
     macroexpand,
     parse,
-    symbol,
 
 # help and reflection
     apropos,

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -2,13 +2,6 @@
 
 ## symbols ##
 
-Symbol(s::Symbol) = s
-Symbol(s::ASCIIString) = Symbol(s.data)
-Symbol(s::UTF8String) = Symbol(s.data)
-Symbol(a::Array{UInt8,1}) =
-    ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int32), a, length(a))
-Symbol(x...) = Symbol(string(x...))
-
 gensym() = ccall(:jl_gensym, Ref{Symbol}, ())
 
 gensym(s::ASCIIString) = gensym(s.data)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -51,6 +51,9 @@ include("refpointer.jl")
 include("checked.jl")
 importall .Checked
 
+# vararg Symbol constructor
+Symbol(x...) = Symbol(string(x...))
+
 # array structures
 include("abstractarray.jl")
 include("subarray.jl")

--- a/contrib/BBEditTextWrangler-julia.plist
+++ b/contrib/BBEditTextWrangler-julia.plist
@@ -1117,7 +1117,6 @@
             <string>svdvals!</string>
             <string>svdvals</string>
             <string>sylvester</string>
-            <string>symbol</string>
             <string>symdiff!</string>
             <string>symdiff</string>
             <string>symlink</string>
@@ -1495,6 +1494,7 @@
         <string>SubOrDArray</string>
         <string>SubString</string>
         <string>SVDDense</string>
+        <string>Symbol</string>
         <string>Symmetric</string>
         <string>SymTridiagonal</string>
         <string>Sys</string>

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -138,9 +138,8 @@ used as one building-block of expressions:
     julia> typeof(ans)
     Symbol
 
-:obj:`Symbol`\ s can also be created using :func:`symbol`, which takes any
-number of arguments and creates a new symbol by concatenating their string
-representations together:
+The :obj:`Symbol` constructor takes any number of arguments and creates a
+new symbol by concatenating their string representations together:
 
 .. doctest::
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -3870,11 +3870,11 @@ end
 # issue #16096
 module M16096
 macro iter()
-  quote
-    @inline function foo(sub)
-      it = 1
+    quote
+        @inline function foo(sub)
+            it = 1
+        end
     end
-  end
 end
 end
 let ex = expand(:(@M16096.iter))


### PR DESCRIPTION
And fix a review issue from #16154.

If there's a cleaner place to put these methods to avoid redefinition warnings, suggestions are welcome. `Symbol` is a builtin type and `base/expr.jl` gets included both in `coreimg.jl` and `sysimg.jl`, but looks like the vararg `Symbol` constructor is not needed in Inference (and `string` isn't defined yet there anyway).
