### PR TITLE
Use safepoint to deliver SIGINT

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1562,6 +1562,7 @@ function typeinf_loop(frame)
         frame.inworkq || typeinf_frame(frame)
         return
     end
+    ccall(:jl_sigatomic_begin, Void, ())
     try
         in_typeinf_loop = true
         # the core type-inference algorithm
@@ -1608,6 +1609,7 @@ function typeinf_loop(frame)
         println(ex)
         ccall(:jlbacktrace, Void, ())
     end
+    ccall(:jl_sigatomic_end, Void, ())
     nothing
 end
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,7 @@ SRCS := \
 	jltypes gf typemap ast builtins module interpreter \
 	alloc dlload sys init task array dump toplevel jl_uv jlapi signal-handling \
 	simplevector APInt-C runtime_intrinsics runtime_ccall \
-	threadgroup threading stackwalk gc
+	threadgroup threading stackwalk gc safepoint
 
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen disasm debuginfo llvm-simdloop llvm-gcroot

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -194,7 +194,7 @@ JL_CALLABLE(jl_f_throw)
 
 JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
 {
-    JL_SIGATOMIC_BEGIN();
+    // Must have no safepoint
     eh->prev = jl_current_task->eh;
     eh->gcstack = jl_pgcstack;
 #ifdef JULIA_ENABLE_THREADING
@@ -202,9 +202,6 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     eh->locks_len = jl_current_task->locks.len;
 #endif
     jl_current_task->eh = eh;
-    // TODO: this should really go after setjmp(). see comment in
-    // ctx_switch in task.c.
-    JL_SIGATOMIC_END();
 }
 
 JL_DLLEXPORT void jl_pop_handler(int n)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1243,27 +1243,16 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!isVa);
         assert(nargt == 0);
         JL_GC_POP();
-#ifdef JULIA_ENABLE_THREADING
 #ifdef LLVM39
         builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
 #else
         builder.CreateFence(SequentiallyConsistent, SingleThread);
 #endif
-        Value *addr;
-        if (imaging_mode) {
-            assert(ctx->signalPage);
-            addr = ctx->signalPage;
-        }
-        else {
-            addr = builder.CreateIntToPtr(
-                ConstantInt::get(T_size, (uintptr_t)jl_gc_signal_page), T_pint8);
-        }
-        builder.CreateLoad(addr, true);
+        builder.CreateLoad(ctx->signalPage, true);
 #ifdef LLVM39
         builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
 #else
         builder.CreateFence(SequentiallyConsistent, SingleThread);
-#endif
 #endif
         return ghostValue(jl_void_type);
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1717,3 +1717,20 @@ static Value *emit_exc_in_transit(jl_codectx_t *ctx)
     Constant *offset = ConstantInt::getSigned(T_int32, offsetof(jl_tls_states_t, exception_in_transit) / sizeof(void*));
     return builder.CreateGEP(pexc_in_transit, ArrayRef<Value*>(offset), "jl_exception_in_transit");
 }
+
+static void emit_signal_fence(void)
+{
+#ifdef LLVM39
+    builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
+#else
+    builder.CreateFence(SequentiallyConsistent, SingleThread);
+#endif
+}
+
+static Value *emit_defer_signal(jl_codectx_t *ctx)
+{
+    Value *ptls = builder.CreateBitCast(ctx->ptlsStates,
+                                        PointerType::get(T_sigatomic, 0));
+    Constant *offset = ConstantInt::getSigned(T_int32, offsetof(jl_tls_states_t, defer_signal) / sizeof(sig_atomic_t));
+    return builder.CreateGEP(ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
+}

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -455,7 +455,7 @@ static bool deserves_sret(jl_value_t *dt, Type *T)
 static Value *emit_nthptr_addr(Value *v, ssize_t n)
 {
     return builder.CreateGEP(builder.CreateBitCast(v, T_ppjlvalue),
-                             ConstantInt::get(T_size, (ssize_t)n));
+                             ConstantInt::get(T_size, n));
 }
 
 static Value *emit_nthptr_addr(Value *v, Value *idx)
@@ -474,6 +474,13 @@ static Value *emit_nthptr_recast(Value *v, Value *idx, MDNode *tbaa, Type *ptype
 {
     // p = (jl_value_t**)v; *(ptype)&p[n]
     Value *vptr = emit_nthptr_addr(v, idx);
+    return tbaa_decorate(tbaa,builder.CreateLoad(builder.CreateBitCast(vptr,ptype), false));
+}
+
+static Value *emit_nthptr_recast(Value *v, ssize_t n, MDNode *tbaa, Type *ptype)
+{
+    // p = (jl_value_t**)v; *(ptype)&p[n]
+    Value *vptr = emit_nthptr_addr(v, n);
     return tbaa_decorate(tbaa,builder.CreateLoad(builder.CreateBitCast(vptr,ptype), false));
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -344,8 +344,8 @@ static GlobalVariable *jltls_states_func_ptr = NULL;
 static size_t jltls_states_func_idx = 0;
 #endif
 // Imaging mode only (non-imaging mode use pointer directly)
-static GlobalVariable *jl_gc_signal_page_ptr = NULL;
-static size_t jl_gc_signal_page_idx = 0;
+static GlobalVariable *jl_safepoint_page_ptr = NULL;
+static size_t jl_safepoint_page_idx = 0;
 
 // important functions
 static Function *jlnew_func;
@@ -3432,11 +3432,11 @@ static void allocate_gc_frame(BasicBlock *b0, jl_codectx_t *ctx)
     ctx->ptlsStates = builder.CreateCall(prepare_call(jltls_states_func));
     if (imaging_mode) {
         ctx->signalPage =
-            tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jl_gc_signal_page_ptr)));
+            tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jl_safepoint_page_ptr)));
     }
     else {
         ctx->signalPage = builder.CreateIntToPtr(
-            ConstantInt::get(T_size, (uintptr_t)jl_gc_signal_page), T_pint8);
+            ConstantInt::get(T_size, (uintptr_t)jl_safepoint_page), T_pint8);
     }
 }
 
@@ -5171,10 +5171,10 @@ static void init_julia_llvm_env(Module *m)
     }
 #endif
     if (imaging_mode) {
-        jl_gc_signal_page_ptr =
-            jl_emit_sysimg_slot(m, T_pint8, "jl_gc_signal_page.ptr",
-                                (uintptr_t)jl_gc_signal_page,
-                                jl_gc_signal_page_idx);
+        jl_safepoint_page_ptr =
+            jl_emit_sysimg_slot(m, T_pint8, "jl_safepoint_page.ptr",
+                                (uintptr_t)jl_safepoint_page,
+                                jl_safepoint_page_idx);
     }
 
     std::vector<Type*> args1(0);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -246,6 +246,7 @@ static IntegerType *T_uint64;
 
 static IntegerType *T_char;
 static IntegerType *T_size;
+static IntegerType *T_sigatomic;
 
 static Type *T_float16;
 static Type *T_float32;
@@ -4970,6 +4971,7 @@ static void init_julia_llvm_env(Module *m)
         T_size = T_uint64;
     else
         T_size = T_uint32;
+    T_sigatomic = Type::getIntNTy(jl_LLVMContext, sizeof(sig_atomic_t) * 8);
     T_psize = PointerType::get(T_size, 0);
     T_float16 = Type::getHalfTy(jl_LLVMContext);
     T_float32 = Type::getFloatTy(jl_LLVMContext);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1340,6 +1340,7 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
         return (jl_value_t*)jl_pchar_to_array((char*)fptr, symsize);
     }
 
+    int8_t gc_state = jl_gc_safe_enter();
     jl_dump_asm_internal(fptr, symsize, slide,
 #ifndef USE_MCJIT
             context,
@@ -1355,6 +1356,7 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
 #ifndef LLVM37
     fstream.flush();
 #endif
+    jl_gc_safe_leave(gc_state);
 
     return jl_cstr_to_string(const_cast<char*>(stream.str().c_str()));
 }

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -1674,9 +1674,7 @@ void RTDyldMemoryManagerUnix::registerEHFrames(uint8_t *Addr,
     di->start_ip = start_ip;
     di->end_ip = end_ip;
 
-    JL_SIGATOMIC_BEGIN();
     _U_dyn_register(di);
-    JL_SIGATOMIC_END();
 }
 
 void RTDyldMemoryManagerUnix::deregisterEHFrames(uint8_t *Addr,

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -70,6 +70,11 @@ extern ExecutionEngine *jl_ExecutionEngine;
 typedef object::SymbolRef SymRef;
 #endif
 
+// Any function that acquires this lock must be either a unmanaged thread
+// or in the GC safe region and must NOT allocate anything through the GC
+// while holding this lock.
+// Certain functions in this file might be called from an unmanaged thread
+// and cannot have any interaction with the julia runtime
 static uv_rwlock_t threadsafe;
 
 extern "C" void jl_init_debuginfo()
@@ -128,6 +133,7 @@ extern "C" EXCEPTION_DISPOSITION _seh_exception_handler(PEXCEPTION_RECORD Except
 static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnname,
         uint8_t *Section, size_t Allocated, uint8_t *UnwindData)
 {
+    // GC safe
     DWORD mod_size = 0;
 #if defined(_CPU_X86_64_)
 #if !defined(USE_MCJIT)
@@ -244,9 +250,10 @@ public:
     virtual void NotifyFunctionEmitted(const Function &F, void *Code,
                                        size_t Size, const EmittedFunctionDetails &Details)
     {
+        // This function modify linfo->fptr in GC safe region.
+        // This should be fine since the GC won't scan this field.
         int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_wrlock(&threadsafe);
-        jl_gc_safe_leave(gc_state);
         StringRef sName = F.getName();
         StringMap<jl_lambda_info_t*>::iterator linfo_it = linfo_in_flight.find(sName);
         jl_lambda_info_t *linfo = NULL;
@@ -266,13 +273,12 @@ public:
             const_cast<Function*>(&F)->deleteBody();
 #endif
         uv_rwlock_wrunlock(&threadsafe);
+        jl_gc_safe_leave(gc_state);
     }
 
     std::map<size_t, FuncInfo, revcomp>& getMap()
     {
-        int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_rdlock(&threadsafe);
-        jl_gc_safe_leave(gc_state);
         return info;
     }
 #endif // ifndef USE_MCJIT
@@ -301,9 +307,10 @@ public:
     virtual void NotifyObjectEmitted(const ObjectImage &obj)
 #endif
     {
+        // This function modify linfo->fptr in GC safe region.
+        // This should be fine since the GC won't scan this field.
         int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_wrlock(&threadsafe);
-        jl_gc_safe_leave(gc_state);
 #ifdef LLVM36
         object::section_iterator Section = debugObj.section_begin();
         object::section_iterator EndSection = debugObj.section_end();
@@ -563,6 +570,7 @@ public:
 #endif
 #endif
         uv_rwlock_wrunlock(&threadsafe);
+        jl_gc_safe_leave(gc_state);
     }
 
     // must implement if we ever start freeing code
@@ -571,9 +579,7 @@ public:
 
     std::map<size_t, ObjectInfo, revcomp>& getObjectMap()
     {
-        int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_rdlock(&threadsafe);
-        jl_gc_safe_leave(gc_state);
         return objectmap;
     }
 #endif // USE_MCJIT
@@ -1103,12 +1109,17 @@ int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide, int64_t *se
 extern "C"
 JL_DLLEXPORT jl_value_t *jl_get_dobj_data(uint64_t fptr)
 {
+    // Used by Gallium.jl
     const object::ObjectFile *object = NULL;
     DIContext *context;
     int64_t slide, section_slide;
+    int8_t gc_state = jl_gc_safe_enter();
     if (!jl_DI_for_fptr(fptr, NULL, &slide, NULL, &object, NULL))
-        if (!jl_dylib_DI_for_fptr(fptr, &object, &context, &slide, &section_slide, false, NULL, NULL, NULL, NULL))
+        if (!jl_dylib_DI_for_fptr(fptr, &object, &context, &slide, &section_slide, false, NULL, NULL, NULL, NULL)) {
+            jl_gc_safe_leave(gc_state);
             return jl_nothing;
+        }
+    jl_gc_safe_leave(gc_state);
     if (object == NULL)
         return jl_nothing;
     return (jl_value_t*)jl_ptr_to_array_1d((jl_value_t*)jl_array_uint8_type,
@@ -1119,6 +1130,8 @@ JL_DLLEXPORT jl_value_t *jl_get_dobj_data(uint64_t fptr)
 extern "C"
 JL_DLLEXPORT uint64_t jl_get_section_start(uint64_t fptr)
 {
+    // Used by Gallium.jl
+    int8_t gc_state = jl_gc_safe_enter();
     std::map<size_t, ObjectInfo, revcomp> &objmap = jl_jit_events->getObjectMap();
     std::map<size_t, ObjectInfo, revcomp>::iterator fit = objmap.lower_bound(fptr);
 
@@ -1134,6 +1147,7 @@ JL_DLLEXPORT uint64_t jl_get_section_start(uint64_t fptr)
        }
     }
     uv_rwlock_rdunlock(&threadsafe);
+    jl_gc_safe_leave(gc_state);
     return ret;
 }
 
@@ -1688,6 +1702,7 @@ RTDyldMemoryManager* createRTDyldMemoryManagerUnix()
 extern "C"
 uint64_t jl_getUnwindInfo(uint64_t dwAddr)
 {
+    // Might be called from unmanaged thread
     std::map<size_t, ObjectInfo, revcomp> &objmap = jl_jit_events->getObjectMap();
     std::map<size_t, ObjectInfo, revcomp>::iterator it = objmap.lower_bound(dwAddr);
     uint64_t ipstart = 0; // ip of the start of the section (if found)
@@ -1701,6 +1716,7 @@ uint64_t jl_getUnwindInfo(uint64_t dwAddr)
 extern "C"
 uint64_t jl_getUnwindInfo(uint64_t dwAddr)
 {
+    // Might be called from unmanaged thread
     std::map<size_t, FuncInfo, revcomp> &info = jl_jit_events->getMap();
     std::map<size_t, FuncInfo, revcomp>::iterator it = info.lower_bound(dwAddr);
     uint64_t ipstart = 0; // ip of the first instruction in the function (if found)

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -294,6 +294,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #endif
                           )
 {
+    // GC safe
     // Get the host information
     std::string TripleName;
     if (TripleName.empty())

--- a/src/dump.c
+++ b/src/dump.c
@@ -232,9 +232,9 @@ static int jl_load_sysimg_so(void)
         *sysimg_gvars[tls_getter_idx - 1] =
             (jl_value_t*)jl_get_ptls_states_getter();
 #endif
-        size_t signal_page_idx = *(size_t*)jl_dlsym(jl_sysimg_handle,
-                                                    "jl_gc_signal_page_idx");
-        *sysimg_gvars[signal_page_idx - 1] = (jl_value_t*)jl_gc_signal_page;
+        size_t safepoint_idx = *(size_t*)jl_dlsym(jl_sysimg_handle,
+                                                  "jl_safepoint_page_idx");
+        *sysimg_gvars[safepoint_idx - 1] = (jl_value_t*)jl_safepoint_page;
         const char *cpu_target = (const char*)jl_dlsym(jl_sysimg_handle, "jl_sysimg_cpu_target");
         if (strcmp(cpu_target,jl_options.cpu_target) != 0)
             jl_error("Julia and the system image were compiled for different architectures.\n"

--- a/src/dump.c
+++ b/src/dump.c
@@ -232,9 +232,6 @@ static int jl_load_sysimg_so(void)
         *sysimg_gvars[tls_getter_idx - 1] =
             (jl_value_t*)jl_get_ptls_states_getter();
 #endif
-        size_t safepoint_idx = *(size_t*)jl_dlsym(jl_sysimg_handle,
-                                                  "jl_safepoint_page_idx");
-        *sysimg_gvars[safepoint_idx - 1] = (jl_value_t*)jl_safepoint_page;
         const char *cpu_target = (const char*)jl_dlsym(jl_sysimg_handle, "jl_sysimg_cpu_target");
         if (strcmp(cpu_target,jl_options.cpu_target) != 0)
             jl_error("Julia and the system image were compiled for different architectures.\n"

--- a/src/dump.c
+++ b/src/dump.c
@@ -231,10 +231,10 @@ static int jl_load_sysimg_so(void)
                                                    "jl_ptls_states_getter_idx");
         *sysimg_gvars[tls_getter_idx - 1] =
             (jl_value_t*)jl_get_ptls_states_getter();
+#endif
         size_t signal_page_idx = *(size_t*)jl_dlsym(jl_sysimg_handle,
                                                     "jl_gc_signal_page_idx");
         *sysimg_gvars[signal_page_idx - 1] = (jl_value_t*)jl_gc_signal_page;
-#endif
         const char *cpu_target = (const char*)jl_dlsym(jl_sysimg_handle, "jl_sysimg_cpu_target");
         if (strcmp(cpu_target,jl_options.cpu_target) != 0)
             jl_error("Julia and the system image were compiled for different architectures.\n"

--- a/src/init.c
+++ b/src/init.c
@@ -544,6 +544,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     ios_set_io_wait_func = jl_set_io_wait;
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),
                                     // best to call this first, since it also initializes libuv
+    jl_init_signal_async();
     restore_signals();
     jl_resolve_sysimg_location(rel);
     // loads sysimg if available, and conditionally sets jl_options.cpu_target

--- a/src/init.c
+++ b/src/init.c
@@ -534,7 +534,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     // Make sure we finalize the tls callback before starting any threads.
     jl_get_ptls_states_getter();
 #endif
-    jl_gc_signal_init();
+    jl_safepoint_init();
     libsupport_init();
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),
                                     // best to call this first, since it also initializes libuv

--- a/src/init.c
+++ b/src/init.c
@@ -528,6 +528,11 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
         jl_options.load = abspath(jl_options.load);
 }
 
+static void jl_set_io_wait(int v)
+{
+    jl_get_ptls_states()->io_wait = v;
+}
+
 void _julia_init(JL_IMAGE_SEARCH rel)
 {
 #ifdef JULIA_ENABLE_THREADING
@@ -536,6 +541,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 #endif
     jl_safepoint_init();
     libsupport_init();
+    ios_set_io_wait_func = jl_set_io_wait;
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),
                                     // best to call this first, since it also initializes libuv
     restore_signals();

--- a/src/init.c
+++ b/src/init.c
@@ -533,8 +533,8 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 #ifdef JULIA_ENABLE_THREADING
     // Make sure we finalize the tls callback before starting any threads.
     jl_get_ptls_states_getter();
-    jl_gc_signal_init();
 #endif
+    jl_gc_signal_init();
     libsupport_init();
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),
                                     // best to call this first, since it also initializes libuv

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -812,7 +812,6 @@ static void* jl_emit_and_add_to_shadow(GlobalVariable *gv, void *gvarinit = NULL
 #endif
 }
 
-#ifdef JULIA_ENABLE_THREADING // only used in the threading build
 // Emit a slot in the system image to be filled at sysimg init time.
 // Returns the global var. Fill `idx` with 1-base index in the sysimg gv.
 // Use as an optimization for runtime constant addresses to have one less
@@ -840,7 +839,6 @@ static GlobalVariable *jl_emit_sysimg_slot(Module *m, Type *typ, const char *nam
     idx = jl_sysimg_gvars.size();
     return gv;
 }
-#endif
 
 static void* jl_get_global(GlobalVariable *gv)
 {
@@ -915,13 +913,13 @@ static void jl_gen_llvm_globaldata(llvm::Module *mod, ValueToValueMapTy &VMap,
                                  GlobalVariable::ExternalLinkage,
                                  ConstantInt::get(T_size, jltls_states_func_idx),
                                  "jl_ptls_states_getter_idx"));
+#endif
     addComdat(new GlobalVariable(*mod,
                                  T_size,
                                  true,
                                  GlobalVariable::ExternalLinkage,
                                  ConstantInt::get(T_size, jl_gc_signal_page_idx),
                                  "jl_gc_signal_page_idx"));
-#endif
 
     Constant *feature_string = ConstantDataArray::getString(jl_LLVMContext, jl_options.cpu_target);
     addComdat(new GlobalVariable(*mod,

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -918,8 +918,8 @@ static void jl_gen_llvm_globaldata(llvm::Module *mod, ValueToValueMapTy &VMap,
                                  T_size,
                                  true,
                                  GlobalVariable::ExternalLinkage,
-                                 ConstantInt::get(T_size, jl_gc_signal_page_idx),
-                                 "jl_gc_signal_page_idx"));
+                                 ConstantInt::get(T_size, jl_safepoint_page_idx),
+                                 "jl_safepoint_page_idx"));
 
     Constant *feature_string = ConstantDataArray::getString(jl_LLVMContext, jl_options.cpu_target);
     addComdat(new GlobalVariable(*mod,

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -812,10 +812,11 @@ static void* jl_emit_and_add_to_shadow(GlobalVariable *gv, void *gvarinit = NULL
 #endif
 }
 
+#ifdef JULIA_ENABLE_THREADING
 // Emit a slot in the system image to be filled at sysimg init time.
 // Returns the global var. Fill `idx` with 1-base index in the sysimg gv.
 // Use as an optimization for runtime constant addresses to have one less
-// load.
+// load. (Used only by threading).
 static GlobalVariable *jl_emit_sysimg_slot(Module *m, Type *typ, const char *name,
                                            uintptr_t init, size_t &idx)
 {
@@ -839,6 +840,7 @@ static GlobalVariable *jl_emit_sysimg_slot(Module *m, Type *typ, const char *nam
     idx = jl_sysimg_gvars.size();
     return gv;
 }
+#endif
 
 static void* jl_get_global(GlobalVariable *gv)
 {
@@ -914,12 +916,6 @@ static void jl_gen_llvm_globaldata(llvm::Module *mod, ValueToValueMapTy &VMap,
                                  ConstantInt::get(T_size, jltls_states_func_idx),
                                  "jl_ptls_states_getter_idx"));
 #endif
-    addComdat(new GlobalVariable(*mod,
-                                 T_size,
-                                 true,
-                                 GlobalVariable::ExternalLinkage,
-                                 ConstantInt::get(T_size, jl_safepoint_page_idx),
-                                 "jl_safepoint_page_idx"));
 
     Constant *feature_string = ConstantDataArray::getString(jl_LLVMContext, jl_options.cpu_target);
     addComdat(new GlobalVariable(*mod,

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -229,7 +229,7 @@ JL_DLLEXPORT void jl_sigatomic_begin(void)
 
 JL_DLLEXPORT void jl_sigatomic_end(void)
 {
-    if (jl_defer_signal == 0)
+    if (jl_get_ptls_states()->defer_signal == 0)
         jl_error("sigatomic_end called in non-sigatomic region");
     JL_SIGATOMIC_END();
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1420,6 +1420,7 @@ typedef struct _jl_handler_t {
 #ifdef JULIA_ENABLE_THREADING
     size_t locks_len;
 #endif
+    sig_atomic_t defer_signal;
 } jl_handler_t;
 
 typedef struct _jl_task_t {
@@ -1506,8 +1507,11 @@ static inline void jl_lock_frame_pop(void)
 
 STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
 {
-    // This function should **NOT** have any safepoint before restoring
-    // the GC state at the end.
+    // `eh` may not be `jl_current_task->eh`. See `jl_pop_handler`
+    // This function should **NOT** have any safepoint before the ones at the
+    // end.
+    sig_atomic_t old_defer_signal = jl_get_ptls_states()->defer_signal;
+    int8_t old_gc_state = jl_get_ptls_states()->gc_state;
     jl_current_task->eh = eh->prev;
     jl_pgcstack = eh->gcstack;
 #ifdef JULIA_ENABLE_THREADING
@@ -1518,9 +1522,14 @@ STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
         locks->len = eh->locks_len;
     }
 #endif
-    // This should be the last since this can trigger a safepoint
-    // that throws a SIGINT.
-    jl_gc_state_save_and_set(eh->gc_state);
+    jl_get_ptls_states()->defer_signal = eh->defer_signal;
+    jl_get_ptls_states()->gc_state = eh->gc_state;
+    if (old_gc_state && !eh->gc_state) {
+        jl_gc_safepoint();
+    }
+    if (old_defer_signal && !eh->defer_signal) {
+        jl_sigint_safepoint();
+    }
 }
 
 JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -292,6 +292,7 @@ jl_value_t *skip_meta(jl_array_t *body);
 int has_meta(jl_array_t *body, jl_sym_t *sym);
 
 // backtraces
+// Might be called from unmanaged thread
 uint64_t jl_getUnwindInfo(uint64_t dwBase);
 #ifdef _OS_WINDOWS_
 #include <dbghelp.h>

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -266,9 +266,9 @@ void jl_set_base_ctx(char *__stk);
 void jl_init_threading(void);
 void jl_start_threads(void);
 void jl_shutdown_threading(void);
+void jl_gc_signal_init(void);
 #ifdef JULIA_ENABLE_THREADING
 jl_get_ptls_states_func jl_get_ptls_states_getter(void);
-void jl_gc_signal_init(void);
 void jl_gc_signal_wait(void);
 #endif
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -268,6 +268,12 @@ void jl_start_threads(void);
 void jl_shutdown_threading(void);
 
 // Whether the GC is running
+extern char *jl_safepoint_pages;
+STATIC_INLINE int jl_addr_is_safepoint(uintptr_t addr)
+{
+    uintptr_t safepoint_addr = (uintptr_t)jl_safepoint_pages;
+    return addr >= safepoint_addr && addr < safepoint_addr + jl_page_size * 3;
+}
 extern volatile uint32_t jl_gc_running;
 // All the functions are safe to be called from within a signal handler
 // provided that the thread will not be interrupted by another asynchronous

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -255,6 +255,7 @@ void jl_init_root_task(void *stack, size_t ssize);
 void jl_init_serializer(void);
 void jl_gc_init(void);
 void jl_init_restored_modules(jl_array_t *init_order);
+void jl_init_signal_async(void);
 
 void _julia_init(JL_IMAGE_SEARCH rel);
 #ifdef COPY_STACKS
@@ -309,6 +310,7 @@ void jl_safepoint_defer_sigint(void);
 // Return `1` if the sigint should be delivered and `0` if there's no sigint
 // to be delivered.
 int jl_safepoint_consume_sigint(void);
+void jl_wake_libuv(void);
 
 #ifdef JULIA_ENABLE_THREADING
 jl_get_ptls_states_func jl_get_ptls_states_getter(void);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -285,13 +285,13 @@ JL_DLLEXPORT void (jl_cpu_wake)(void);
 
 // Accessing the tls variables, gc safepoint and gc states
 JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void);
-JL_DLLEXPORT extern volatile size_t *jl_gc_signal_page;
+JL_DLLEXPORT extern volatile size_t *jl_safepoint_page;
 // This triggers a SegFault when we are in GC
 // Assign it to a variable to make sure the compiler emit the load
 // and to avoid Clang warning for -Wunused-volatile-lvalue
 #define jl_gc_safepoint() do {                          \
         jl_signal_fence();                              \
-        size_t safepoint_load = *jl_gc_signal_page;     \
+        size_t safepoint_load = *jl_safepoint_page;     \
         jl_signal_fence();                              \
         (void)safepoint_load;                           \
     } while (0)

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -1,0 +1,171 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+#include "julia.h"
+#include "julia_internal.h"
+#include "threading.h"
+#ifndef _OS_WINDOWS_
+#include <sys/mman.h>
+#if defined(_OS_DARWIN_) && !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* static uint32_t jl_signal_pending = 0; */
+volatile uint32_t jl_gc_running = 0;
+JL_DLLEXPORT volatile size_t *jl_safepoint_page = NULL;
+// The number of safepoints enabled on the two pages.
+// The first page, the one before `jl_safepoint_page` is the SIGINT page.
+// The second page, the one pointed to by `jl_safepoint_page` is the GC page.
+uint8_t jl_safepoint_enable_cnt[3] = {0, 0, 0};
+
+// This lock should be acquired before enabling/disabling the safepoint
+// or accessing one of the following variables:
+//
+// * jl_gc_running
+// * jl_signal_pending
+// * jl_safepoint_enable_cnt
+//
+// Additionally accessing `jl_gc_running` should use acquire/release
+// load/store so that threads waiting for the GC doesn't have to also
+// fight on the safepoint lock...
+//
+// Acquiring and releasing this lock should use the `jl_mutex_*_nogc` functions
+jl_mutex_t safepoint_lock;
+
+static void jl_safepoint_enable(int idx)
+{
+    // safepoint_lock should be held
+    assert(0 <= idx && idx < 3);
+    if (jl_safepoint_enable_cnt[idx]++ != 0) {
+        // We expect this to be enabled at most twice
+        // one for the GC, one for SIGINT.
+        // Update this if this is not the case anymore in the future.
+        assert(jl_safepoint_enable_cnt[idx] <= 2);
+        return;
+    }
+    // Now that we are requested to mprotect the page and it wasn't already.
+    char *pageaddr = (char*)jl_safepoint_page + jl_page_size * (idx - 1);
+#ifdef _OS_WINDOWS_
+    DWORD old_prot;
+    VirtualProtect(pageaddr, jl_page_size, PAGE_NOACCESS, &old_prot);
+#else
+    mprotect(pageaddr, jl_page_size, PROT_NONE);
+#endif
+}
+
+static void jl_safepoint_disable(int idx)
+{
+    // safepoint_lock should be held
+    assert(0 <= idx && idx < 3);
+    if (--jl_safepoint_enable_cnt[idx] != 0) {
+        assert(jl_safepoint_enable_cnt[idx] > 0);
+        return;
+    }
+    // Now that we are requested to un-mprotect the page and no one else
+    // want it to be kept protected.
+    char *pageaddr = (char*)jl_safepoint_page + jl_page_size * (idx - 1);
+#ifdef _OS_WINDOWS_
+    DWORD old_prot;
+    VirtualProtect(pageaddr, jl_page_size, PAGE_READONLY, &old_prot);
+#else
+    mprotect(pageaddr, jl_page_size, PROT_READ);
+#endif
+}
+
+void jl_safepoint_init(void)
+{
+    // jl_page_size isn't available yet.
+    size_t pgsz = jl_getpagesize();
+#ifdef _OS_WINDOWS_
+    char *addr = (char*)VirtualAlloc(NULL, pgsz * 3, MEM_COMMIT, PAGE_READONLY);
+#else
+    char *addr = (char*)mmap(0, pgsz * 3, PROT_READ,
+                             MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (addr == MAP_FAILED)
+        addr = NULL;
+#endif
+    if (addr == NULL) {
+        jl_printf(JL_STDERR, "could not allocate GC synchronization page\n");
+        gc_debug_critical_error();
+        abort();
+    }
+    // The signal page is for the gc safepoint.
+    // The page before it is the sigint pending flag.
+    jl_safepoint_page = (size_t*)(addr + pgsz);
+}
+
+int jl_safepoint_start_gc(void)
+{
+#ifdef JULIA_ENABLE_THREADING
+    // The thread should have set this already
+    assert(jl_get_ptls_states()->gc_state == JL_GC_STATE_WAITING);
+    jl_mutex_lock_nogc(&safepoint_lock);
+    // In case multiple threads enter the GC at the same time, only allow
+    // one of them to actually run the collection. We can't just let the
+    // master thread do the GC since it might be running unmanaged code
+    // and can take arbitrarily long time before hitting a safe point.
+    if (jl_atomic_compare_exchange(&jl_gc_running, 0, 1) != 0) {
+        jl_mutex_unlock_nogc(&safepoint_lock);
+        jl_safepoint_wait_gc();
+        return 0;
+    }
+    jl_safepoint_enable(1);
+    jl_safepoint_enable(2);
+    jl_mutex_unlock_nogc(&safepoint_lock);
+    return 1;
+#else
+    // For single thread, GC should not call itself (in finalizers) before
+    // setting `jl_gc_running` to false so this should never happen.
+    assert(!jl_gc_running);
+    jl_gc_running = 1;
+    return 1;
+#endif
+}
+
+void jl_safepoint_end_gc(void)
+{
+    assert(jl_gc_running);
+#ifdef JULIA_ENABLE_THREADING
+    jl_mutex_lock_nogc(&safepoint_lock);
+    // Need to reset the page protection before resetting the flag since
+    // the thread will trigger a segfault immediately after returning from
+    // the signal handler.
+    jl_safepoint_disable(2);
+    jl_safepoint_disable(1);
+    jl_atomic_store_release(&jl_gc_running, 0);
+#  ifdef __APPLE__
+    // This wakes up other threads on mac.
+    jl_mach_gc_end();
+#  endif
+    jl_mutex_unlock_nogc(&safepoint_lock);
+#else
+    jl_gc_running = 0;
+#endif
+}
+
+void jl_safepoint_wait_gc(void)
+{
+#ifdef JULIA_ENABLE_THREADING
+    // The thread should have set this is already
+    assert(jl_get_ptls_states()->gc_state != 0);
+    // Use normal volatile load in the loop.
+    // Use a acquire load to make sure the GC result is visible on this thread.
+    while (jl_gc_running || jl_atomic_load_acquire(&jl_gc_running)) {
+        jl_cpu_pause(); // yield?
+    }
+#else
+    assert(0 && "No one should wait for the GC on another thread");
+#endif
+}
+
+void jl_safepoint_enable_sigint(void);
+void jl_safepoint_defer_sigint(void);
+int jl_safepoint_consume_sigint(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -23,11 +23,35 @@ static const    uint64_t GIGA = 1000000000ULL;
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
 
-volatile sig_atomic_t jl_signal_pending = 0;
-volatile sig_atomic_t jl_defer_signal = 0;
+static uint64_t jl_last_sigint_trigger = 0;
+static void jl_clear_force_sigint(void)
+{
+    jl_last_sigint_trigger = 0;
+}
 
-int exit_on_sigint = 0;
-JL_DLLEXPORT void jl_exit_on_sigint(int on) {exit_on_sigint = on;}
+static int jl_check_force_sigint(void)
+{
+    static double accum_weight = 0;
+    uint64_t cur_time = uv_hrtime();
+    uint64_t dt = cur_time - jl_last_sigint_trigger;
+    uint64_t last_t = jl_last_sigint_trigger;
+    jl_last_sigint_trigger = cur_time;
+    if (last_t == 0) {
+        accum_weight = 0;
+        return 0;
+    }
+    double new_weight = accum_weight * exp(-(dt / 1e9)) + 0.3;
+    if (!isnormal(new_weight))
+        new_weight = 0;
+    accum_weight = new_weight;
+    return new_weight > 1;
+}
+
+static int exit_on_sigint = 0;
+JL_DLLEXPORT void jl_exit_on_sigint(int on)
+{
+    exit_on_sigint = on;
+}
 
 // what to do on SIGINT
 JL_DLLEXPORT void jl_sigint_action(void)

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -293,6 +293,9 @@ static void jl_try_deliver_sigint(void)
         jl_clear_force_sigint();
         jl_throw_in_thread(0, thread, jl_interrupt_exception);
     }
+    else {
+        jl_wake_libuv();
+    }
 
     ret = thread_resume(thread);
     HANDLE_MACH_ERROR("thread_resume", ret);

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -166,7 +166,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     HANDLE_MACH_ERROR("thread_get_state", ret);
     uint64_t fault_addr = exc_state.__faultvaddr;
 #ifdef JULIA_ENABLE_THREADING
-    if (fault_addr == (uintptr_t)jl_safepoint_page) {
+    if (jl_addr_is_safepoint(fault_addr)) {
         jl_mutex_lock_nogc(&safepoint_lock);
         if (!jl_gc_running) {
             // GC is done before we get the message, do nothing and return

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -90,9 +90,9 @@ static void segv_handler(int sig, siginfo_t *info, void *context)
     assert(sig == SIGSEGV || sig == SIGBUS);
 
 #ifdef JULIA_ENABLE_THREADING
-    if (info->si_addr == jl_gc_signal_page) {
+    if (info->si_addr == jl_safepoint_page) {
         jl_unblock_signal(sig);
-        jl_gc_signal_wait();
+        jl_set_gc_and_wait();
         return;
     }
 #endif

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -172,6 +172,7 @@ static void jl_try_deliver_sigint(void)
 {
     jl_tls_states_t *ptls = jl_all_task_states[0].ptls;
     jl_safepoint_enable_sigint();
+    jl_wake_libuv();
     jl_atomic_store_release(&ptls->signal_request, 2);
     // This also makes sure `sleep` is aborted.
     pthread_kill(jl_all_task_states[0].system_id, SIGUSR2);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -90,7 +90,7 @@ static void segv_handler(int sig, siginfo_t *info, void *context)
     assert(sig == SIGSEGV || sig == SIGBUS);
 
 #ifdef JULIA_ENABLE_THREADING
-    if (info->si_addr == jl_safepoint_page) {
+    if (jl_addr_is_safepoint((uintptr_t)info->si_addr)) {
         jl_unblock_signal(sig);
         jl_set_gc_and_wait();
         return;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -38,7 +38,6 @@ unsigned sig_stack_size = SIGSTKSZ;
 #endif
 
 static pthread_t signals_thread;
-static volatile int remote_sig;
 
 static int is_addr_on_stack(jl_tls_states_t *ptls, void *addr)
 {
@@ -89,13 +88,23 @@ static void segv_handler(int sig, siginfo_t *info, void *context)
 {
     assert(sig == SIGSEGV || sig == SIGBUS);
 
-#ifdef JULIA_ENABLE_THREADING
     if (jl_addr_is_safepoint((uintptr_t)info->si_addr)) {
         jl_unblock_signal(sig);
+#ifdef JULIA_ENABLE_THREADING
         jl_set_gc_and_wait();
+        // Do not raise sigint on worker thread
+        if (ti_tid != 0)
+            return;
+#endif
+        if (jl_get_ptls_states()->defer_signal) {
+            jl_safepoint_defer_sigint();
+        }
+        else if (jl_safepoint_consume_sigint()) {
+            jl_clear_force_sigint();
+            jl_throw(jl_interrupt_exception);
+        }
         return;
     }
-#endif
     if (jl_safe_restore || is_addr_on_stack(jl_get_ptls_states(), info->si_addr)) { // stack overflow, or restarting jl_
         jl_unblock_signal(sig);
         jl_throw(jl_stackovf_exception);
@@ -131,51 +140,54 @@ static void allocate_segv_handler(void)
 }
 
 static unw_context_t *volatile signal_context;
-static volatile int waiting_for;
 static pthread_mutex_t in_signal_lock;
 static pthread_cond_t exit_signal_cond;
 static pthread_cond_t signal_caught_cond;
 
-static void jl_thread_suspend_and_get_state(int tid, unw_context_t **ctx, int sig)
+static void jl_thread_suspend_and_get_state(int tid, unw_context_t **ctx)
 {
     pthread_mutex_lock(&in_signal_lock);
-    remote_sig = sig;
-    waiting_for = tid;
+    jl_tls_states_t *ptls = jl_all_task_states[tid].ptls;
+    jl_atomic_store_release(&ptls->signal_request, 1);
     pthread_kill(jl_all_task_states[tid].system_id, SIGUSR2);
     pthread_cond_wait(&signal_caught_cond, &in_signal_lock);  // wait for thread to acknowledge
-    assert(waiting_for == 0);
+    assert(jl_atomic_load_acquire(&ptls->signal_request) == 0);
     *ctx = signal_context;
 }
 
 static void jl_thread_resume(int tid, int sig)
 {
     (void)sig;
-    remote_sig = 0;
-    waiting_for = tid;
+    jl_tls_states_t *ptls = jl_all_task_states[tid].ptls;
+    jl_atomic_store_release(&ptls->signal_request, 1);
     pthread_cond_broadcast(&exit_signal_cond);
     pthread_cond_wait(&signal_caught_cond, &in_signal_lock); // wait for thread to acknowledge
-    assert(waiting_for == 0);
+    assert(jl_atomic_load_acquire(&ptls->signal_request) == 0);
     pthread_mutex_unlock(&in_signal_lock);
 }
 
-
-static inline void wait_barrier(void)
+// Throw jl_interrupt_exception if the master thread is in a signal async region
+// or if SIGINT happens too often.
+static void jl_try_deliver_sigint(void)
 {
-    if (waiting_for < 0) {
-        if (jl_atomic_fetch_add(&waiting_for, 1) == -1) {
-            pthread_cond_broadcast(&signal_caught_cond);
-        }
-    }
-    else {
-        pthread_cond_broadcast(&signal_caught_cond);
-        waiting_for = 0;
-    }
+    jl_tls_states_t *ptls = jl_all_task_states[0].ptls;
+    jl_safepoint_enable_sigint();
+    jl_atomic_store_release(&ptls->signal_request, 2);
+    // This also makes sure `sleep` is aborted.
+    pthread_kill(jl_all_task_states[0].system_id, SIGUSR2);
 }
+
+// request:
+// 0: nothing
+// 1: get state
+// 3: throw sigint if `!defer_signal && io_wait` or if force throw threshold
+//    is reached
 void usr2_handler(int sig, siginfo_t *info, void *ctx)
 {
     ucontext_t *context = (ucontext_t*)ctx;
-    if ((remote_sig > 0 && waiting_for < 0) || waiting_for == ti_tid) {
-        int realsig = remote_sig;
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    sig_atomic_t request = jl_atomic_exchange(&ptls->signal_request, 0);
+    if (request == 1) {
 #ifdef __APPLE__
         signal_context = (unw_context_t*)&context->uc_mcontext->__ss;
 #else
@@ -183,20 +195,25 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx)
 #endif
 
         pthread_mutex_lock(&in_signal_lock);
-        wait_barrier();
+        pthread_cond_broadcast(&signal_caught_cond);
         pthread_cond_wait(&exit_signal_cond, &in_signal_lock);
-        wait_barrier();
+        request = jl_atomic_exchange(&ptls->signal_request, 0);
+        assert(request == 1);
+        (void)request;
+        pthread_cond_broadcast(&signal_caught_cond);
         pthread_mutex_unlock(&in_signal_lock);
-
-        if (ti_tid == 0 && realsig == SIGINT) {
-            if (jl_defer_signal) {
-                jl_signal_pending = realsig;
-            }
-            else {
-                jl_signal_pending = 0;
-                jl_unblock_signal(sig);
-                jl_throw(jl_interrupt_exception);
-            }
+    }
+    else if (request == 2) {
+        jl_unblock_signal(sig);
+        int force = jl_check_force_sigint();
+        if (force || (!ptls->defer_signal && ptls->io_wait)) {
+            jl_safepoint_consume_sigint();
+            if (force)
+                jl_safe_printf("WARNING: Force throwing a SIGINT\n");
+            // Force a throw
+            jl_clear_force_sigint();
+            // TODO: implement `jl_throw_in_ctx` -- Jameson
+            jl_throw(jl_interrupt_exception);
         }
     }
 }
@@ -351,8 +368,19 @@ static void *signal_listener(void *arg)
         profile = (sig == SIGUSR1);
 #  endif
 #endif
+        if (sig == SIGINT) {
+            if (exit_on_sigint) {
+                critical = 1;
+            }
+            else {
+                jl_try_deliver_sigint();
+                continue;
+            }
+        }
+        else {
+            critical = 0;
+        }
 
-        critical = (sig == SIGINT && exit_on_sigint);
         critical |= (sig == SIGTERM);
         critical |= (sig == SIGABRT);
         critical |= (sig == SIGQUIT);
@@ -367,7 +395,7 @@ static void *signal_listener(void *arg)
         // (so that thread zero gets notified last)
         for (i = jl_n_threads; i-- > 0; ) {
             // notify thread to stop
-            jl_thread_suspend_and_get_state(i, &signal_context, sig);
+            jl_thread_suspend_and_get_state(i, &signal_context);
 
             // do backtrace on thread contexts for critical signals
             // this part must be signal-handler safe

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -169,8 +169,7 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
                 return EXCEPTION_CONTINUE_EXECUTION;
             case EXCEPTION_ACCESS_VIOLATION:
 #ifdef JULIA_ENABLE_THREADING
-                if (ExceptionInfo->ExceptionRecord->ExceptionInformation[1] ==
-                    (intptr_t)jl_safepoint_page) {
+                if (jl_addr_is_safepoint(ExceptionInfo->ExceptionRecord->ExceptionInformation[1])) {
                     jl_set_gc_and_wait();
                     return EXCEPTION_CONTINUE_EXECUTION;
                 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -45,6 +45,7 @@ static void jl_try_throw_sigint(void)
 {
     jl_tls_states_t *ptls = jl_get_ptls_states();
     jl_safepoint_enable_sigint();
+    jl_wake_libuv();
     int force = jl_check_force_sigint();
     if (force || (!ptls->defer_signal && ptls->io_wait)) {
         jl_safepoint_consume_sigint();
@@ -127,6 +128,7 @@ static void jl_try_deliver_sigint(void)
 {
     jl_tls_states_t *ptls = jl_all_task_states[0].ptls;
     jl_safepoint_enable_sigint();
+    jl_wake_libuv();
     if ((DWORD)-1 == SuspendThread(hMainThread)) {
         // error
         jl_safe_printf("error: SuspendThread failed\n");

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -170,8 +170,8 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
             case EXCEPTION_ACCESS_VIOLATION:
 #ifdef JULIA_ENABLE_THREADING
                 if (ExceptionInfo->ExceptionRecord->ExceptionInformation[1] ==
-                    (intptr_t)jl_gc_signal_page) {
-                    jl_gc_signal_wait();
+                    (intptr_t)jl_safepoint_page) {
+                    jl_set_gc_and_wait();
                     return EXCEPTION_CONTINUE_EXECUTION;
                 }
 #endif

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -41,6 +41,21 @@ static char *strsignal(int sig)
     return "?";
 }
 
+static void jl_try_throw_sigint(void)
+{
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_safepoint_enable_sigint();
+    int force = jl_check_force_sigint();
+    if (force || (!ptls->defer_signal && ptls->io_wait)) {
+        jl_safepoint_consume_sigint();
+        if (force)
+            jl_safe_printf("WARNING: Force throwing a SIGINT\n");
+        // Force a throw
+        jl_clear_force_sigint();
+        jl_throw(jl_interrupt_exception);
+    }
+}
+
 void __cdecl crt_sig_handler(int sig, int num)
 {
     CONTEXT Context;
@@ -62,13 +77,9 @@ void __cdecl crt_sig_handler(int sig, int num)
         break;
     case SIGINT:
         signal(SIGINT, (void (__cdecl *)(int))crt_sig_handler);
-        if (jl_defer_signal) {
-            jl_signal_pending = sig;
-        }
-        else {
-            jl_signal_pending = 0;
-            jl_sigint_action();
-        }
+        if (exit_on_sigint)
+            jl_exit(130); // 128 + SIGINT
+        jl_try_throw_sigint();
         break;
     default: // SIGSEGV, (SSIGTERM, IGILL)
         memset(&Context, 0, sizeof(Context));
@@ -111,6 +122,46 @@ void jl_throw_in_ctx(jl_value_t *excpt, CONTEXT *ctxThread, int bt)
 
 HANDLE hMainThread = INVALID_HANDLE_VALUE;
 
+// Try to throw the exception in the master thread.
+static void jl_try_deliver_sigint(void)
+{
+    jl_tls_states_t *ptls = jl_all_task_states[0].ptls;
+    jl_safepoint_enable_sigint();
+    if ((DWORD)-1 == SuspendThread(hMainThread)) {
+        // error
+        jl_safe_printf("error: SuspendThread failed\n");
+        return;
+    }
+    int force = jl_check_force_sigint();
+    if (force || (!ptls->defer_signal && ptls->io_wait)) {
+        jl_safepoint_consume_sigint();
+        if (force)
+            jl_safe_printf("WARNING: Force throwing a SIGINT\n");
+        // Force a throw
+        jl_clear_force_sigint();
+        CONTEXT ctxThread;
+        memset(&ctxThread, 0, sizeof(CONTEXT));
+        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+        if (!GetThreadContext(hMainThread, &ctxThread)) {
+            // error
+            jl_safe_printf("error: GetThreadContext failed\n");
+            return;
+        }
+        jl_throw_in_ctx(jl_interrupt_exception, &ctxThread, 1);
+        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+        if (!SetThreadContext(hMainThread, &ctxThread)) {
+            jl_safe_printf("error: SetThreadContext failed\n");
+            // error
+            return;
+        }
+    }
+    if ((DWORD)-1 == ResumeThread(hMainThread)) {
+        jl_safe_printf("error: ResumeThread failed\n");
+        // error
+        return;
+    }
+}
+
 static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guarantee __stdcall
 {
     int sig;
@@ -121,38 +172,9 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
         // etc.
         default: sig = SIGTERM; break;
     }
-    if (jl_defer_signal) {
-        jl_signal_pending = sig;
-    }
-    else {
-        jl_signal_pending = 0;
-        if (exit_on_sigint) jl_exit(130);
-        if ((DWORD)-1 == SuspendThread(hMainThread)) {
-            //error
-            jl_safe_printf("error: SuspendThread failed\n");
-            return 0;
-        }
-        CONTEXT ctxThread;
-        memset(&ctxThread,0,sizeof(CONTEXT));
-        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
-        if (!GetThreadContext(hMainThread, &ctxThread)) {
-            //error
-            jl_safe_printf("error: GetThreadContext failed\n");
-            return 0;
-        }
-        jl_throw_in_ctx(jl_interrupt_exception, &ctxThread, 1);
-        ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
-        if (!SetThreadContext(hMainThread,&ctxThread)) {
-            jl_safe_printf("error: SetThreadContext failed\n");
-            //error
-            return 0;
-        }
-        if ((DWORD)-1 == ResumeThread(hMainThread)) {
-            jl_safe_printf("error: ResumeThread failed\n");
-            //error
-            return 0;
-        }
-    }
+    if (exit_on_sigint)
+        jl_exit(128 + sig); // 128 + SIGINT
+    jl_try_deliver_sigint();
     return 1;
 }
 
@@ -168,12 +190,23 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
                 jl_throw_in_ctx(jl_stackovf_exception, ExceptionInfo->ContextRecord,in_ctx&&pSetThreadStackGuarantee);
                 return EXCEPTION_CONTINUE_EXECUTION;
             case EXCEPTION_ACCESS_VIOLATION:
-#ifdef JULIA_ENABLE_THREADING
                 if (jl_addr_is_safepoint(ExceptionInfo->ExceptionRecord->ExceptionInformation[1])) {
+#ifdef JULIA_ENABLE_THREADING
                     jl_set_gc_and_wait();
+                    // Do not raise sigint on worker thread
+                    if (ti_tid != 0)
+                        return EXCEPTION_CONTINUE_EXECUTION;
+#endif
+                    if (jl_get_ptls_states()->defer_signal) {
+                        jl_safepoint_defer_sigint();
+                    }
+                    else if (jl_safepoint_consume_sigint()) {
+                        jl_clear_force_sigint();
+                        jl_throw_in_ctx(jl_interrupt_exception,
+                                        ExceptionInfo->ContextRecord, in_ctx);
+                    }
                     return EXCEPTION_CONTINUE_EXECUTION;
                 }
-#endif
                 if (ExceptionInfo->ExceptionRecord->ExceptionInformation[0] == 1) { // writing to read-only memory (e.g. mmap)
                     jl_throw_in_ctx(jl_readonlymemory_exception, ExceptionInfo->ContextRecord,in_ctx);
                     return EXCEPTION_CONTINUE_EXECUTION;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -70,6 +70,7 @@ typedef struct {
     char local[IOS_INLSIZE];
 } ios_t;
 
+extern void (*ios_set_io_wait_func)(int);
 /* low-level interface functions */
 JL_DLLEXPORT size_t ios_read(ios_t *s, char *dest, size_t n);
 JL_DLLEXPORT size_t ios_readall(ios_t *s, char *dest, size_t n);

--- a/src/task.c
+++ b/src/task.c
@@ -496,6 +496,7 @@ static void init_task(jl_task_t *t, char *stack)
 // yield to exception handler
 void JL_NORETURN throw_internal(jl_value_t *e)
 {
+    jl_get_ptls_states()->io_wait = 0;
     if (jl_safe_restore)
         jl_longjmp(*jl_safe_restore, 1);
     jl_gc_unsafe_enter();

--- a/src/threading.c
+++ b/src/threading.c
@@ -113,6 +113,7 @@ static void ti_initthread(int16_t tid)
         ptls->safepoint = (size_t*)(jl_safepoint_pages + jl_page_size * 2 +
                                     sizeof(size_t));
     }
+    ptls->defer_signal = 0;
     ptls->current_module = NULL;
     void *bt_data = malloc(sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
     if (bt_data == NULL) {

--- a/src/threading.c
+++ b/src/threading.c
@@ -104,6 +104,15 @@ static void ti_initthread(int16_t tid)
     ptls->tid = tid;
     ptls->pgcstack = NULL;
     ptls->gc_state = 0; // GC unsafe
+    // Conditionally initialize the safepoint address. See comment in
+    // `safepoint.c`
+    if (tid == 0) {
+        ptls->safepoint = (size_t*)(jl_safepoint_pages + jl_page_size);
+    }
+    else {
+        ptls->safepoint = (size_t*)(jl_safepoint_pages + jl_page_size * 2 +
+                                    sizeof(size_t));
+    }
     ptls->current_module = NULL;
     void *bt_data = malloc(sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
     if (bt_data == NULL) {

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -834,7 +834,7 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
             *overwritten = ml->func.value;
         if (newvalue == NULL)  // don't overwrite with guard entries
             return ml;
-        JL_SIGATOMIC_BEGIN();
+        // sigatomic begin
         ml->sig = type;
         jl_gc_wb(ml, ml->sig);
         ml->simplesig = simpletype;
@@ -846,7 +846,7 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
         ml->func.value = newvalue;
         if (newvalue)
             jl_gc_wb(ml, newvalue);
-        JL_SIGATOMIC_END();
+        // sigatomic end
         return ml;
     }
     if (overwritten != NULL)

--- a/test/core.jl
+++ b/test/core.jl
@@ -2192,10 +2192,11 @@ end
 @unix_only begin
     ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
     @test_throws InterruptException begin
-        #ccall(:raise, Void, (Cint,), 2) # llvm installs a custom version on Darwin that resolves to pthread_kill(pthread_self(), sig), which isn't what we want
-        Libc.systemsleep(0.1)
         ccall(:kill, Void, (Cint, Cint,), getpid(), 2)
-        Libc.systemsleep(0.2) # wait for SIGINT to arrive
+        for i in 1:10
+            Libc.systemsleep(0.1)
+            ccall(:jl_gc_safepoint, Void, ()) # wait for SIGINT to arrive
+        end
     end
     ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -2200,6 +2200,16 @@ end
     end
     ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
 end
+let
+    # Exception frame automatically restores sigatomic counter.
+    Base.sigatomic_begin()
+    @test_throws ErrorException begin
+        for i = 1:2
+            Base.sigatomic_end()
+        end
+    end
+    Base.sigatomic_end()
+end
 
 # pull request #9534
 @test try; a,b,c = 1,2; catch ex; (ex::BoundsError).a === (1,2) && ex.i == 3; end


### PR DESCRIPTION
This implements @vtjnash 's [idea](https://github.com/JuliaLang/julia/issues/14675#issuecomment-171810732) of delivering sigint in a safer way, without having to add sigatomic to everywhere. This also solves a few performance issues along the way. A brief summary of the differences,
- Make GC safepoint thread local
  
  And create 3 signal pages. See the comment in `safepoint.c` for detail.
  This have a very minor performance hit for accessing safepoint. However, I think we can avoid the safepoint and GC transition around gcframe setup and gcframe pop on x86 so this shouldn't be a big issue. (On ARM, the atomic release store is more expensive than two GC safepoint so we may use a normal store with two safepoint instead, the performance hit of making the safepoint thread local is still very minor in this case though (~5-10% for empty GC frame push/pop, cheaper than the tls getter call....)).
- Use the GC safepoint mechanism (i.e. SegFault) to deliver InterruptException at known points
  
  This automatically makes `ccall` of external library `sigatomic`. (Fix #1468, Fix #2622). In order to avoid waiting too long before the exception is delivered when running unmanaged code, this also implement waking up libuv, abort syscall and abort libsupport io (this use a hack but can be generalized if needed) when sigint arrives. This also implement force throwing of exception if SIGINT arrives too frequently so that one can use `Ctrl-C` to force abort some dead loop. A warning will be printed in such case since it bypass the safe path and even sigatomic.
  
  The most important consequence IMHO is that pressing `Ctrl-C` during sysimg compilation should no longer segfault =)
  
  This should also make it easier to implement #14675.
- Make parser and type inference calls sigatomic
  
  sigatomic is much cheaper (see below) now so it is now used to protect important runtime code to not be interrupted by `Ctrl-C`.
- Clean up safepoint and sigatomic, optimize try-catch and `sigatomic`
  - Split out `safepoint.c`, make `defer_signal` thread local and avoid the expensive atomic ops
  - Make `defer_signal` task local and automatically restore on expection. This eliminate the try-catch needed before in `disable_sigint`.
    
    This is technically breaking but `sigatomic_begin` and `sigatomic_end` aren't exported.
  - Inline `jl_sigatomic_begin` and `jl_sigatomic_end` in codegen.
  
  Benchmarking try-catch and `disable_sigint`
  
  ``` jl
  julia> @inline f1() = try end
  f1 (generic function with 1 method)
  
  julia> @inline f2() = disable_sigint(()->nothing)
  f2 (generic function with 1 method)
  
  julia> g1(n) = for i in 1:n
             f1()
         end
  g1 (generic function with 1 method)
  
  julia> g2(n) = for i in 1:n
             f2()
         end
  g2 (generic function with 1 method)
  
  julia> function k(n)
             @time g1(n)
             @time g2(n)
         end
  k (generic function with 1 method)
  ```
  
  Timing before
  
  ``` jl
  julia> k(10_000_000)
    0.264041 seconds
    0.401437 seconds
  ```
  
  Timing after
  
  ``` jl
  julia> k(10_000_000)
    0.122592 seconds                                                                
    0.012506 seconds
  ```

Close https://github.com/JuliaLang/julia/pull/12333
Close #12309
