### PR TITLE
R microbenchmark: Use microbenchmark for much higher accuracy in timing

### DIFF
--- a/test/perf/micro/perf.R
+++ b/test/perf/micro/perf.R
@@ -1,4 +1,5 @@
 require(compiler)
+require(microbenchmark)
 
 assert = function(bool) {
     if (!bool) stop('Assertion failed')
@@ -8,7 +9,7 @@ timeit = function(name, f, ..., times=5) {
     tmin = Inf
     f = cmpfun(f)
     for (t in 1:times) {
-        t = system.time(f(...))["elapsed"]
+        t = microbenchmark(f(...), times = 1)$time/1e9  # divided by 1e9 since the unit derived from microbenchmark is nanosecond
         if (t < tmin) tmin = t
     }
     cat(sprintf("r,%s,%.8f\n", name, tmin*1000))


### PR DESCRIPTION
The main change is:

``` r
 t = system.time(f(...))["elapsed"]
```

TO

``` r
t = microbenchmark(f(...), times = 1)$time/1e9
```

in time counting function. microbenchmark() function can achieve accuracy to nanosecond unit. This is also I divide it with 1e9 (1 second = 1 nanosecond \* 1e9)
