### PR TITLE
fix #16165

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2048,7 +2048,11 @@ end
 function substitute!(e::ANY, na, argexprs, spvals, offset)
     if isa(e, Slot)
         if 1 <= e.id <= na
-            return argexprs[e.id]
+            ae = argexprs[e.id]
+            if isa(e, TypedSlot) && isa(ae, Slot)
+                return TypedSlot(ae.id, e.typ)
+            end
+            return ae
         end
         if isa(e, SlotNumber)
             return SlotNumber(e.id+offset)

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -67,3 +67,7 @@ function bar()
 end
 @test_throws UndefVarError bar()
 
+# issue #16165
+@inline f16165(x) = (x = UInt(x) + 1)
+g16165(x) = f16165(x)
+@test g16165(1) === (UInt(1) + 1)


### PR DESCRIPTION
Inlining bug where a TypedSlot annotation got dropped when replacing an argument with a newly-generated temp slot.
