### PR TITLE
Fix compilation error on msys2

### DIFF
--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -86,6 +86,8 @@ case $(uname) in
 esac
 
 # Download most recent Julia binary for dependencies
+# Fix directory not found error during decompression on msys2
+mkdir -p usr/Git/usr
 if ! [ -e julia-installer.exe ]; then
   f=julia-latest-win$bits.exe
   echo "Downloading $f"


### PR DESCRIPTION
I get a directory not found error when trying to compile 32bit julia in a 64bit Windows 7 virtual machine with msys2. Creating the missing directory seems to fix the error for me. (The error seems to come from decompression and I'm not sure why it throws an error or which 7z I'm using...)

@tkelman 
