### PR TITLE
More general indexing [4]

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -569,7 +569,7 @@ function writedlm(io::IO, a::AbstractMatrix, dlm; opts...)
     pb = PipeBuffer()
     nr = size(a, 1)
     nc = size(a, 2)
-    for i = 1:nr
+    for i = 1:nr  # fixme (iter): improve if timholy/ArrayIteration.jl is merged into Base
         for j = 1:nc
             writedlm_cell(pb, a[i, j], dlm, quotes)
             j == nc ? write(pb,'\n') : print(pb,dlm)

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -220,19 +220,19 @@ Date(dt::AbstractString,df::DateFormat=ISODateFormat) = Date(parse(dt,df)...)
 format(dt::TimeType,f::AbstractString;locale::AbstractString="english") = format(dt,DateFormat(f,locale))
 
 # vectorized
-DateTime{T<:AbstractString}(y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = DateTime(y,DateFormat(format,locale))
-function DateTime{T<:AbstractString}(y::AbstractArray{T},df::DateFormat=ISODateTimeFormat)
-    return reshape(DateTime[DateTime(parse(y[i],df)...) for i in 1:length(y)], size(y))
+DateTime{T<:AbstractString}(Y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = DateTime(Y,DateFormat(format,locale))
+function DateTime{T<:AbstractString}(Y::AbstractArray{T},df::DateFormat=ISODateTimeFormat)
+    return reshape(DateTime[DateTime(parse(y,df)...) for y in Y], size(Y))
 end
-Date{T<:AbstractString}(y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Date(y,DateFormat(format,locale))
-function Date{T<:AbstractString}(y::AbstractArray{T},df::DateFormat=ISODateFormat)
-    return reshape(Date[Date(parse(y[i],df)...) for i in 1:length(y)], size(y))
+Date{T<:AbstractString}(Y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Date(Y,DateFormat(format,locale))
+function Date{T<:AbstractString}(Y::AbstractArray{T},df::DateFormat=ISODateFormat)
+    return reshape(Date[Date(parse(y,df)...) for y in Y], size(Y))
 end
 
-format{T<:TimeType}(y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Dates.format(y,DateFormat(format,locale))
-function format(y::AbstractArray{Date},df::DateFormat=ISODateFormat)
-    return reshape([Dates.format(y[i],df) for i in 1:length(y)], size(y))
+format{T<:TimeType}(Y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Dates.format(Y,DateFormat(format,locale))
+function format(Y::AbstractArray{Date},df::DateFormat=ISODateFormat)
+    return reshape([Dates.format(y,df) for y in Y], size(Y))
 end
-function format(y::AbstractArray{DateTime},df::DateFormat=ISODateTimeFormat)
-    return reshape([Dates.format(y[i],df) for i in 1:length(y)], size(y))
+function format(Y::AbstractArray{DateTime},df::DateFormat=ISODateTimeFormat)
+    return reshape([Dates.format(y,df) for y in Y], size(Y))
 end

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -99,8 +99,8 @@ for (op,Ty,Tz) in ((:.*,Real,:P),
     @eval begin
         function ($op){P<:Period}(X::StridedArray{P},y::$Ty)
             Z = similar(X, $Tz)
-            for i = 1:length(X)
-                @inbounds Z[i] = ($op_)(X[i],y)
+            for (Idst, Isrc) in zip(eachindex(Z), eachindex(X))
+                @inbounds Z[Idst] = ($op_)(X[Isrc],y)
             end
             return Z
         end
@@ -238,8 +238,8 @@ for op in (:.+, :.-)
     @eval begin
         function ($op){P<:GeneralPeriod}(X::StridedArray{P},y::GeneralPeriod)
             Z = similar(X, CompoundPeriod)
-            for i = 1:length(X)
-                @inbounds Z[i] = ($op_)(X[i],y)
+            for (Idst, Isrc) in zip(eachindex(Z), eachindex(X))
+                @inbounds Z[Idst] = ($op_)(X[Isrc],y)
             end
             return Z
         end

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -326,7 +326,7 @@ end
 function digits!{T<:Integer}(a::AbstractArray{T,1}, n::Integer, base::Integer=10)
     2 <= base || throw(ArgumentError("base must be ≥ 2, got $base"))
     base - 1 <= typemax(T) || throw(ArgumentError("type $T too small for base $base"))
-    for i = 1:length(a)
+    for i in eachindex(a)
         a[i] = rem(n, base)
         n = div(n, base)
     end


### PR DESCRIPTION
Another portion of improvements for more efficient iteration over different types of arrays. This PR covers lines from 

```
broadcast.jl, cartesian.jl (tricky?) 
```

to 

```
hashing2.jl, interactiveutil.jl, intfuncs.jl, intset.jl 
```

from [this list](https://github.com/JuliaLang/julia/pull/15434#issuecomment-194991739) **except for** `cartesian.jl`, which may need more careful treatment (especially in macros).
