### PR TITLE
Also skip linalg/triangular on osx travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_install:
         export LDFLAGS="-L$(brew --prefix openblas-julia)/lib -L$(brew --prefix suite-sparse-julia)/lib";
         export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib:/lib:/usr/lib:$(brew --prefix openblas-julia)/lib:$(brew --prefix suite-sparse-julia)/lib:$(brew --prefix arpack-julia)/lib";
         make $BUILDOPTS -C contrib -f repackage_system_suitesparse4.make;
-        TESTSTORUN="all --skip subarray"; fi # TODO: re enable this if possible without timing out
+        TESTSTORUN="all --skip linalg/triangular subarray"; fi # TODO: re enable these if possible without timing out
     - git clone -q git://git.kitenet.net/moreutils
 script:
     - make -C moreutils mispipe

--- a/base/unicode/utf8.jl
+++ b/base/unicode/utf8.jl
@@ -307,7 +307,6 @@ function convert(::Type{String}, a::Vector{UInt8}, invalids_as::AbstractString)
     end
     String(a)
 end
-convert(::Type{String}, s::AbstractString) = utf8(bytestring(s))
 
 """
 Converts an already validated vector of `UInt16` or `UInt32` to a `String`

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -471,3 +471,7 @@ let A = rand(10), sA = sub(copy(A), :)
     permute!(sA, collect(Int16, 1:10))
     @test A == sA
 end
+
+# the following segfaults with LLVM 3.8 on Windows, ref #15417
+@test collect(sub(sub(reshape(1:13^3, 13, 13, 13), 3:7, 6, :), 1:2:5, :, 1:2:5)) ==
+    cat(3,[68,70,72],[406,408,410],[744,746,748])


### PR DESCRIPTION
should give a bit more leeway on timeouts

and add a test that was causing segfaults on windows with llvm 3.8 in #15417 but is no longer hit by the subarray tests since #15431 was merged, and remove a duplicate `convert` method that's causing a warning during bootstrap
