### PR TITLE
add logging() to redirect info/warn/error()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,9 @@ Library improvements
     implemented; the semantics are as if the `Nullable` were a container with
     zero or one elements ([#16961]).
 
+  * `logging` can be used to redirect `info`, `warn`, and `error` messages
+    either universally or on a per-module/function basis ([#16213]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -110,16 +110,6 @@ function ip_matches_func(ip, func::Symbol)
     return false
 end
 
-function display_error(io::IO, er, bt)
-    print_with_color(Base.error_color(), io, "ERROR: "; bold = true)
-    # remove REPL-related frames from interactive printing
-    eval_ind = findlast(addr->Base.REPL.ip_matches_func(addr, :eval), bt)
-    if eval_ind != 0
-        bt = bt[1:eval_ind-1]
-    end
-    showerror(IOContext(io, :limit => true), er, bt)
-end
-
 immutable REPLDisplay{R<:AbstractREPL} <: Display
     repl::R
 end
@@ -144,8 +134,7 @@ function print_response(errio::IO, val::ANY, bt, show_value::Bool, have_color::B
         try
             Base.sigatomic_end()
             if bt !== nothing
-                display_error(errio, val, bt)
-                println(errio)
+                Base.display_error(errio, val, bt)
                 iserr, lasterr = false, ()
             else
                 if val !== nothing && show_value

--- a/base/error.jl
+++ b/base/error.jl
@@ -19,6 +19,14 @@
 ## native julia error handling ##
 
 error(s::AbstractString) = throw(ErrorException(s))
+
+"""
+    error(msg...)
+
+Raise an `ErrorException` with the given message.
+
+See also [`logging`](@ref).
+"""
 error(s...) = throw(ErrorException(Main.Base.string(s...)))
 
 rethrow() = ccall(:jl_rethrow, Bottom, ())

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -810,6 +810,7 @@ export
     isxdigit,
     join,
     lcfirst,
+    logging,
     lowercase,
     lpad,
     lstrip,

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -153,6 +153,13 @@ function stacktrace(trace::Vector{Ptr{Void}}, c_funcs::Bool=false)
 
     # Remove frame for this function (and any functions called by this function).
     remove_frames!(stack, :stacktrace)
+
+    # is there a better way?  the func symbol has a number suffix which changes.
+    # it's possible that no test is needed and we could just shift! all the time.
+    # this line was added to PR #16213 because otherwise stacktrace() != stacktrace(false).
+    # not sure why.  possibly b/c of re-ordering of base/sysimg.jl
+    !isempty(stack) && startswith(string(stack[1].func),"jlcall_stacktrace") && shift!(stack)
+    stack
 end
 
 stacktrace(c_funcs::Bool=false) = stacktrace(backtrace(), c_funcs)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -311,6 +311,10 @@ include("REPLCompletions.jl")
 include("REPL.jl")
 include("client.jl")
 
+# Stack frames and traces
+include("stacktraces.jl")
+importall .StackTraces
+
 # misc useful functions & macros
 include("util.jl")
 
@@ -341,10 +345,6 @@ include("libgit2/libgit2.jl")
 
 # package manager
 include("pkg/pkg.jl")
-
-# Stack frames and traces
-include("stacktraces.jl")
-importall .StackTraces
 
 # profiler
 include("profile.jl")

--- a/doc/src/stdlib/io-network.md
+++ b/doc/src/stdlib/io-network.md
@@ -66,6 +66,7 @@ Base.println
 Base.print_with_color
 Base.info
 Base.warn
+Base.logging
 Base.Printf.@printf
 Base.Printf.@sprintf
 Base.sprint

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -28,6 +28,113 @@ let bt = backtrace()
     end
 end
 
+# PR #16213
+module Logging
+    function bar(io)
+        info(io,"barinfo")
+        warn(io,"barwarn")
+        Base.display_error(io,"barerror",backtrace())
+    end
+    function pooh(io)
+        info(io,"poohinfo")
+        warn(io,"poohwarn")
+        Base.display_error(io,"pooherror",backtrace())
+    end
+end
+function foo(io)
+    info(io,"fooinfo")
+    warn(io,"foowarn")
+    Base.display_error(io,"fooerror",backtrace())
+end
+
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+
+logging(DevNull, TestMain_misc.Logging, :bar;  kind=:info)
+@test all(contains.(sprint(Logging.bar), ["WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull, TestMain_misc.Logging;  kind=:info)
+@test all(contains.(sprint(Logging.bar), ["WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull;  kind=:info)
+@test all(contains.(sprint(Logging.bar), ["WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(kind=:info)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+
+logging(DevNull, TestMain_misc.Logging, :bar;  kind=:warn)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull, TestMain_misc.Logging;  kind=:warn)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull;  kind=:warn)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "ERROR: \"fooerror\""]))
+
+logging(kind=:warn)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+
+logging(DevNull, TestMain_misc.Logging, :bar;  kind=:error)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn"]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull, TestMain_misc.Logging;  kind=:error)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn"]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn"]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull;  kind=:error)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn"]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn"]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn"]))
+
+logging(kind=:error)
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+
+logging(DevNull, TestMain_misc.Logging, :bar)
+@test sprint(Logging.bar) == ""
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull, TestMain_misc.Logging)
+@test sprint(Logging.bar) == ""
+@test sprint(Logging.pooh) == ""
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
+logging(DevNull)
+@test sprint(Logging.bar) == ""
+@test sprint(Logging.pooh) == ""
+@test sprint(foo) == ""
+
+logging()
+@test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn", "ERROR: \"barerror\""]))
+@test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
+@test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
+
 # test assert() method
 @test_throws AssertionError assert(false)
 let res = assert(true)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -541,7 +541,7 @@ end # let exename
 
 # Test containers in error messages are limited #18726
 let io = IOBuffer()
-    REPL.display_error(io,
+    Base.display_error(io,
         try [][trues(6000)]
         catch e
             e


### PR DESCRIPTION
this PR provides a mechanism by which info, warning, and error messages can be ~~organized hierarchically and~~ selectively redirected to an IO stream of your choice.  ~~a keyword argument provided to warn identifies it's position within the hierarchy by subclassing a new abstract type `Warning`.~~  a new command `logging()` is used to maintain a ~~set of branches within the hierarchy~~ mapping between the kind of message, and optionally specific modules and/or functions, to a stream.

for example, given this module:

```
module Foo
    function bar()
        info("barinfo")
        warn("barwarn")
        error("barerror")
    end
    function pooh()
        info("poohinfo")
        warn("poohwarn")
        error("pooherror")
    end
end
```

the user could selectively mute `warn()` in `pooh()` by

```
julia> Foo.bar()
INFO: barinfo (Foo.bar)
WARNING: barwarn (Foo.bar)
ERROR: barerror
 in bar() at ./REPL[1]:5
 in eval(::Module, ::Any) at ./boot.jl:230

julia> Foo.pooh()
INFO: poohinfo (Foo.pooh)
WARNING: poohwarn (Foo.pooh)
ERROR: pooherror
 in pooh() at ./REPL[1]:10
 in eval(::Module, ::Any) at ./boot.jl:230

julia> logging(DevNull, Foo, :pooh, kind=:warn)

julia> Foo.bar()
INFO: barinfo (Foo.bar)
WARNING: barwarn (Foo.bar)
ERROR: barerror
 in bar() at ./REPL[1]:5
 in eval(::Module, ::Any) at ./boot.jl:230

julia> Foo.pooh()
INFO: poohinfo (Foo.pooh)
ERROR: pooherror
 in pooh() at ./REPL[1]:10
 in eval(::Module, ::Any) at ./boot.jl:230

julia> 
```
