### PR TITLE
Fix typo in variables-and-scoping.rst

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -202,7 +202,7 @@ variables::
     end
 
     julia> x
-    11
+    12
 
 Within soft scopes, the `global` keyword is never necessary, although
 allowed.  The only case when it would change the semantics is


### PR DESCRIPTION
Fixed 11 to 12 in output of soft local scope example. 
