### PR TITLE
fix inconsistent use of strlen in jl_load

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -722,7 +722,7 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len,
     jl_ast_context_t *ctx = jl_ast_ctx_enter();
     fl_context_t *fl_ctx = &ctx->fl;
     value_t f, ast;
-    f = cvalue_static_cstring(fl_ctx, fname);
+    f = cvalue_static_cstrn(fl_ctx, fname, len);
     fl_gc_handle(fl_ctx, &f);
     if (content != NULL) {
         value_t t = cvalue_static_cstrn(fl_ctx, content, contentlen);

--- a/src/init.c
+++ b/src/init.c
@@ -647,7 +647,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
                 jl_current_module;
         }
 
-        jl_load("boot.jl", sizeof("boot.jl"));
+        jl_load("boot.jl", sizeof("boot.jl")-1);
         jl_get_builtin_hooks();
         jl_boot_file_loaded = 1;
         jl_init_box_caches();


### PR DESCRIPTION
I noticed that `init.c` was calling `jl_load("boot.jl", sizeof("boot.jl"))`, which is wrong because the second argument is supposed to be the string length, but `sizeof` on a literal string is the string length + 1 to include the terminating NUL char.

Also, I noticed that the `jl_parse_eval_all` function wasn't actually using the `len` parameter in one place where it could have exploited it.
