### PR TITLE
Add getindex test for HessenbergQ

### DIFF
--- a/test/linalg/hessenberg.jl
+++ b/test/linalg/hessenberg.jl
@@ -29,6 +29,8 @@ let n = 10
             @test_approx_eq full(H) A
             @test_approx_eq (H[:Q] * H[:H]) * H[:Q]' A
             @test_approx_eq (H[:Q]' * A) * H[:Q]     H[:H]
+            #getindex for HessenbergQ
+            @test_approx_eq H[:Q][1,1] full(H[:Q])[1,1]
         end
     end
 end


### PR DESCRIPTION
Apparently missed according to latest coverage.
