### PR TITLE
Do not warn for cfunction of `Union{}` return type

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3524,13 +3524,13 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     if (lam != NULL) {
         name = jl_symbol_name(lam->def->name);
         astrt = lam->rettype;
-        if (astrt == (jl_value_t*)jl_bottom_type) {
-            // a function that doesn't return must have throw an error
-            // across the c-frame, which is generally a bad idea
-            jl_printf(JL_STDERR, "WARNING: cfunction: %s does not return", name);
-        }
-        else if (jl_type_intersection(astrt, declrt) == jl_bottom_type) {
-            jl_errorf("WARNING: cfunction: return type of %s does not match", name);
+        if (astrt != (jl_value_t*)jl_bottom_type &&
+            jl_type_intersection(astrt, declrt) == jl_bottom_type) {
+            // Do not warn if the function does not return since it is
+            // occasionally required by the C API (typically error callbacks)
+            // and doesn't capture the majority of the case when a function
+            // may throw.
+            jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match", name);
         }
         if (!lam->functionObjectsDecls.functionObject) {
             jl_errorf("ERROR: cfunction: compiling %s failed", name);


### PR DESCRIPTION
This warning is bad for a few reasons.
1. While it is true a function that throws an error across C frames is usually a bad idea, this is needed in unusual case for error callback from C library. Even if this is caused by a user error, a function that always throw should be much easier to be caught during testing.
2. The function could be an infinity loop without throwing any error.
3. The warning doesn't capture the majority of the case where the function may throw.

Also changed the error for type mismatch to a warning especially since the error message starts with `WARNING`...

Ref https://groups.google.com/forum/?fromgroups=#!topic/julia-users/k0_c6TTCBw0
@vtjnash 
