### PR TITLE
allow iterables in fftshift and ifftshift

### DIFF
--- a/base/dft.jl
+++ b/base/dft.jl
@@ -345,14 +345,14 @@ fftshift(x)
 
 function fftshift(x,dim)
     s = zeros(Int,ndims(x))
-    s[dim] = div(size(x,dim),2)
+    map(s[i] = div(size(x,i),2), dim)
     circshift(x, s)
 end
 
 """
     fftshift(x,dim)
 
-Swap the first and second halves of the given dimension of array `x`.
+Swap the first and second halves of the given dimension or iterable of dimensions of array `x`.
 """
 fftshift(x,dim)
 
@@ -367,7 +367,7 @@ ifftshift
 
 function ifftshift(x,dim)
     s = zeros(Int,ndims(x))
-    s[dim] = -div(size(x,dim),2)
+    map(s[i] = -div(size(x,i),2), dim)
     circshift(x, s)
 end
 

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -345,7 +345,7 @@ fftshift(x)
 
 function fftshift(x,dim)
     s = zeros(Int,ndims(x))
-    map(i -> s[i] = div(size(x,i),2), dim)
+    for i in dim; s[i] = div(size(x,i),2); end
     circshift(x, s)
 end
 
@@ -367,7 +367,7 @@ ifftshift
 
 function ifftshift(x,dim)
     s = zeros(Int,ndims(x))
-    map(i -> s[i] = -div(size(x,i),2), dim)
+    for i in dim; s[i] = -div(size(x,i),2); end
     circshift(x, s)
 end
 

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -345,7 +345,7 @@ fftshift(x)
 
 function fftshift(x,dim)
     s = zeros(Int,ndims(x))
-    map(s[i] = div(size(x,i),2), dim)
+    map(i -> s[i] = div(size(x,i),2), dim)
     circshift(x, s)
 end
 
@@ -367,7 +367,7 @@ ifftshift
 
 function ifftshift(x,dim)
     s = zeros(Int,ndims(x))
-    map(s[i] = -div(size(x,i),2), dim)
+    map(i -> s[i] = -div(size(x,i),2), dim)
     circshift(x, s)
 end
 

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -26,12 +26,24 @@ si = [0.9967207836936347,-1.4940914728163142,1.2841226760316475,-0.4524417279474
 @test_throws ArgumentError filt!([1, 2], [1], [1], [1])
 @test xcorr([1, 2], [3, 4]) == [4, 11, 6]
 
+# Shift-Functions
 @test fftshift([1 2 3]) == [3 1 2]
 @test fftshift([1, 2, 3]) == [3, 1, 2]
 @test fftshift([1 2 3; 4 5 6]) == [6 4 5; 3 1 2]
+
+@test fftshift([1 2 3; 4 5 6], 1) == [4 5 6; 1 2 3]
+@test fftshift([1 2 3; 4 5 6], ()) == [1 2 3; 4 5 6]
+@test fftshift([1 2 3; 4 5 6], (1,2)) == [6 4 5; 3 1 2]
+@test fftshift([1 2 3; 4 5 6], 1:2) == [6 4 5; 3 1 2]
+
 @test ifftshift([1 2 3]) == [2 3 1]
 @test ifftshift([1, 2, 3]) == [2, 3, 1]
 @test ifftshift([1 2 3; 4 5 6]) == [5 6 4; 2 3 1]
+
+@test ifftshift([1 2 3; 4 5 6], 1) == [4 5 6; 1 2 3]
+@test ifftshift([1 2 3; 4 5 6], ()) == [1 2 3; 4 5 6]
+@test ifftshift([1 2 3; 4 5 6], (1,2)) == [5 6 4; 2 3 1]
+@test ifftshift([1 2 3; 4 5 6], 1:2) == [5 6 4; 2 3 1]
 
 # Convolution
 a = [1., 2., 1., 2.]


### PR DESCRIPTION
In the case of shifting multiple but not all axis of a multidimensional array now requires multiple fftshift commands (which, if I am correct, includes multiple array copys). The map-function is abstract enough to allow both iterables and scalar arguments, so I see no reason to not include this behaviour.

Please excuse any misuse of GIT and its functions.
