### PR TITLE
check for embedded NUL char in jl_load (for include)

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -731,6 +731,7 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len,
         fl_free_gc_handles(fl_ctx, 1);
     }
     else {
+        assert(memchr(fname, 0, len) == NULL); // was checked already in jl_load
         ast = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "jl-parse-file")), f);
     }
     fl_free_gc_handles(fl_ctx, 1);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -559,6 +559,8 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v)
 
 JL_DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len)
 {
+    if (NULL != memchr(fname, 0, len))
+        jl_exceptionf(jl_argumenterror_type, "file name may not contain \\0");
     if (jl_current_module->istopmod) {
         jl_printf(JL_STDOUT, "%s\r\n", fname);
 #ifdef _OS_WINDOWS_

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -4,6 +4,8 @@ using Base.Test
 
 @test @__LINE__ == 5
 
+@test_throws ArgumentError include("test_sourcepath.jl\0")
+
 include("test_sourcepath.jl")
 thefname = "the fname!//\\&\0\1*"
 @test include_string("include_string_test() = @__FILE__", thefname)() == Base.source_path()

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -4,7 +4,7 @@ using Base.Test
 
 @test @__LINE__ == 5
 
-@test_throws ArgumentError include("test_sourcepath.jl\0")
+@test_throws ArgumentError Core.include("test_sourcepath.jl\0")
 
 include("test_sourcepath.jl")
 thefname = "the fname!//\\&\0\1*"


### PR DESCRIPTION
This fixes a bug I noticed in #16218, in which `include("foo.jl\0")` would erroneously succeed if `"foo.jl"` existed, because the filename would be silently truncated at the NUL char (similar to #10991).

I did an audit of the other functions in `src/*.h`, and I couldn't find any other problems of this kind.
