### PR TITLE
Make `foo` local in tuple and llvmcall test

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -654,7 +654,7 @@ end
 
 # Method specificity
 begin
-    local f
+    local f, A
     f{T}(dims::Tuple{}, A::AbstractArray{T,0}) = 1
     f{T,N}(dims::NTuple{N,Int}, A::AbstractArray{T,N}) = 2
     f{T,M,N}(dims::NTuple{M,Int}, A::AbstractArray{T,N}) = 3

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -166,6 +166,7 @@ end
 
 # Test for proper parenting
 if VersionNumber(Base.libllvm_version) >= v"3.6" # llvm 3.6 changed the syntax for a gep, so just ignore this test on older versions
+    local foo
     function foo()
         # this IR snippet triggers an optimization relying
         # on the llvmcall function having a parent module

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -65,32 +65,33 @@
 @test eltype((1,2.0, false)) === Any
 @test eltype(()) === Union{}
 
+begin
+    local foo
+    ## mapping ##
+    foo() = 2
+    foo(x) = 2x
+    foo(x, y) = x + y
+    foo(x, y, z) = x + y + z
 
-## mapping ##
-foo() = 2
-foo(x) = 2x
-foo(x, y) = x + y
-foo(x, y, z) = x + y + z
+    # 1 argument
+    @test map(foo, ()) === ()
+    @test map(foo, (1,)) === (2,)
+    @test map(foo, (1,2)) === (2,4)
+    @test map(foo, (1,2,3,4)) === (2,4,6,8)
 
-# 1 argument
-@test map(foo, ()) === ()
-@test map(foo, (1,)) === (2,)
-@test map(foo, (1,2)) === (2,4)
-@test map(foo, (1,2,3,4)) === (2,4,6,8)
+    # 2 arguments
+    @test map(foo, (), ()) === ()
+    @test map(foo, (1,), (1,)) === (2,)
+    @test map(foo, (1,2), (1,2)) === (2,4)
+    @test map(foo, (1,2,3,4), (1,2,3,4)) === (2,4,6,8)
 
-# 2 arguments
-@test map(foo, (), ()) === ()
-@test map(foo, (1,), (1,)) === (2,)
-@test map(foo, (1,2), (1,2)) === (2,4)
-@test map(foo, (1,2,3,4), (1,2,3,4)) === (2,4,6,8)
-
-# n arguments
-@test map(foo, (), (), ()) === ()
-@test map(foo, (), (1,2,3), (1,2,3)) === ()
-@test map(foo, (1,), (1,), (1,)) === (3,)
-@test map(foo, (1,2), (1,2), (1,2)) === (3,6)
-@test map(foo, (1,2,3,4), (1,2,3,4), (1,2,3,4)) === (3,6,9,12)
-
+    # n arguments
+    @test map(foo, (), (), ()) === ()
+    @test map(foo, (), (1,2,3), (1,2,3)) === ()
+    @test map(foo, (1,), (1,), (1,)) === (3,)
+    @test map(foo, (1,2), (1,2), (1,2)) === (3,6)
+    @test map(foo, (1,2,3,4), (1,2,3,4), (1,2,3,4)) === (3,6,9,12)
+end
 
 ## comparison ##
 @test isequal((), ())


### PR DESCRIPTION
Noticed because of the method overwrite warning when tuple and llvmcall tests happened to be running on the same process...
