### PR TITLE
Fixup for new SIGINT handling

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -169,14 +169,6 @@ set of characters) is provided, instead remove characters contained in it.
 lstrip
 
 """
-    reenable_sigint(f::Function)
-
-Re-enable Ctrl-C handler during execution of a function. Temporarily reverses the effect of
-`disable_sigint`.
-"""
-reenable_sigint
-
-"""
     indmin(itr) -> Integer
 
 Returns the index of the minimum element in a collection.
@@ -4389,19 +4381,6 @@ base
 An indexing operation into an array, `a`, tried to access an out-of-bounds element, `i`.
 """
 BoundsError
-
-"""
-    disable_sigint(f::Function)
-
-Disable Ctrl-C handler during execution of a function, for calling external code that is not
-interrupt safe. Intended to be called using `do` block syntax as follows:
-
-    disable_sigint() do
-        # interrupt-unsafe code
-        ...
-    end
-"""
-disable_sigint
 
 """
     hist2d(M, e1, e2) -> (edge1, edge2, counts)

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -134,7 +134,7 @@
 
    .. Docstring generated from Julia source
 
-   Disable Ctrl-C handler during execution of a function, for calling external code that is not interrupt safe. Intended to be called using ``do`` block syntax as follows:
+   Disable Ctrl-C handler during execution of a function on the current task, for calling external code that may call julia code that is not interrupt safe. Intended to be called using ``do`` block syntax as follows:
 
    .. code-block:: julia
 
@@ -142,6 +142,8 @@
            # interrupt-unsafe code
            ...
        end
+
+   This is not needed on worker threads (``Threads.threadid() != 1``\ ) since the ``InterruptException`` will only be delivered to the master thread. External functions that do not call julia code or julia runtime automatically disable sigint during their execution.
 
 .. function:: reenable_sigint(f::Function)
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -49,6 +49,16 @@ extern "C" {
 
 static uv_async_t signal_async;
 
+#ifdef _OS_WINDOWS_
+// uv_async_t is buggy on windows. Initializing one breaks the sysimg build.
+void jl_wake_libuv(void)
+{
+}
+
+void jl_init_signal_async(void)
+{
+}
+#else
 static void jl_signal_async_cb(uv_async_t *hdl)
 {
     // This should abort the current loop and the julia code it returns to
@@ -66,6 +76,7 @@ void jl_init_signal_async(void)
 {
     uv_async_init(jl_io_loop, &signal_async, jl_signal_async_cb);
 }
+#endif
 
 extern jl_module_t *jl_old_base_module;
 static jl_value_t *close_cb = NULL;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -275,3 +275,6 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes`
         end
     end
 end
+
+# Make sure `julia --lisp` doesn't break
+run(pipeline(DevNull, `$(Base.julia_cmd()) --lisp`, DevNull))


### PR DESCRIPTION
(The three tags each describes one commit.)
- (Hopefully) fix windows buildbot (a.k.a. workaround libuv bug...)
- Add test for `--lisp` cmdline option
- Update doc for `disable_sigint`.
