### PR TITLE
Fixed bug, added tests for UMFPACK ldivs

### DIFF
--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -394,8 +394,8 @@ end
 A_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Vector{T}) = solve(lu, b, UMFPACK_A)
 A_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Matrix{T}) = solve(lu, b, UMFPACK_A)
 function A_ldiv_B!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb})
-    r = solve(lu, [convert(Tlu,real(be)) for be in b], UMFPACK_A)
-    i = solve(lu, [convert(Tlu,imag(be)) for be in b], UMFPACK_A)
+    r = solve(lu, [convert(Float64,real(be)) for be in b], UMFPACK_A)
+    i = solve(lu, [convert(Float64,imag(be)) for be in b], UMFPACK_A)
     Tb[r[k]+im*i[k] for k = 1:length(r)]
 end
 

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -29,12 +29,29 @@ for Tv in (Float64, Complex128)
         @test_approx_eq x float([1:5;])
 
         @test norm(A*x-b,1) < eps(1e4)
+        x = Base.SparseArrays.A_ldiv_B!(lua,complex(b,zeros(b)))
+        @test_approx_eq x float([1:5;])
+
+        @test norm(A*x-b,1) < eps(1e4)
 
         b = [8., 20., 13., 6., 17.]
         x = lua'\b
         @test_approx_eq x float([1:5;])
 
         @test norm(A'*x-b,1) < eps(1e4)
+        x = Base.SparseArrays.Ac_ldiv_B!(lua,complex(b,zeros(b)))
+        @test_approx_eq x float([1:5;])
+
+        @test norm(A'*x-b,1) < eps(1e4)
+        x = lua.'\b
+        @test_approx_eq x float([1:5;])
+
+        @test norm(A.'*x-b,1) < eps(1e4)
+        x = Base.SparseArrays.At_ldiv_B!(lua,complex(b,zeros(b)))
+        @test_approx_eq x float([1:5;])
+
+        @test norm(A.'*x-b,1) < eps(1e4)
+
 
         # Element promotion and type inference
         @inferred lua\ones(Int, size(A, 2))
@@ -98,4 +115,5 @@ let
     @test size(F, 1) == m
     @test size(F, 2) == n
     @test size(F, 3) == 1
+    @test_throws ArgumentError size(F,-1)
 end


### PR DESCRIPTION
That `Tlu` type didn't exist. Added tests for the three in-place `ldiv` methods.

I added a missing error-throw test for `size` as well.
