### PR TITLE
Fix similar(::Array, ::UInt)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -122,10 +122,10 @@ similar{T}(a::Array{T,1})             = Array(T, size(a,1))
 similar{T}(a::Array{T,2})             = Array(T, size(a,1), size(a,2))
 similar{T}(a::Array{T,1}, dims::Dims) = Array(T, dims)
 similar{T}(a::Array{T,1}, m::Int)     = Array(T, m)
-similar{T}(a::Array{T,1}, S)          = Array(S, size(a,1))
+similar{T}(a::Array{T,1}, S::Type)    = Array(S, size(a,1))
 similar{T}(a::Array{T,2}, dims::Dims) = Array(T, dims)
 similar{T}(a::Array{T,2}, m::Int)     = Array(T, m)
-similar{T}(a::Array{T,2}, S)          = Array(S, size(a,1), size(a,2))
+similar{T}(a::Array{T,2}, S::Type)    = Array(S, size(a,1), size(a,2))
 
 # T[x...] constructs Array{T,1}
 function getindex(T::Type, vals...)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1589,3 +1589,10 @@ end
 @test f15894(ones(Int, 100)) == 100
 
 end
+
+# issue #16247
+let A = zeros(3,3)
+    @test size(A[:,0x1:0x2]) == (3, 2)
+    @test size(A[:,UInt(1):UInt(2)]) == (3,2)
+    @test size(similar(A, UInt(3), 0x3)) == size(similar(A, (UInt(3), 0x3))) == (3,3)
+end


### PR DESCRIPTION
The integer was getting interpreted as a type -- simply ensure that the type argument is indeed a type.  Fixes #16247
