### PR TITLE
more complete ambiguity detection

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -155,7 +155,7 @@ similar{T}(a::AbstractArray{T}, dims::DimsInteger)       = similar(a, T, dims)
 similar{T}(a::AbstractArray{T}, dims::Integer...)        = similar(a, T, dims)
 similar(   a::AbstractArray, T::Type, dims::Integer...)  = similar(a, T, dims)
 # similar creates an Array by default
-similar(   a::AbstractArray, T::Type, dims::DimsInteger) = Array(T, dims...)
+similar(   a::AbstractArray, T::Type, dims::DimsInteger) = similar(a, T, convert(Dims, dims))
 similar(   a::AbstractArray, T::Type, dims::Dims)        = Array(T, dims)
 
 ## from general iterable to any array

--- a/base/array.jl
+++ b/base/array.jl
@@ -117,15 +117,15 @@ end
 
 ## Constructors ##
 
-similar(a::Array, T, dims::Dims)      = Array(T, dims)
-similar{T}(a::Array{T,1})             = Array(T, size(a,1))
-similar{T}(a::Array{T,2})             = Array(T, size(a,1), size(a,2))
-similar{T}(a::Array{T,1}, dims::Dims) = Array(T, dims)
-similar{T}(a::Array{T,1}, m::Int)     = Array(T, m)
-similar{T}(a::Array{T,1}, S::Type)    = Array(S, size(a,1))
-similar{T}(a::Array{T,2}, dims::Dims) = Array(T, dims)
-similar{T}(a::Array{T,2}, m::Int)     = Array(T, m)
-similar{T}(a::Array{T,2}, S::Type)    = Array(S, size(a,1), size(a,2))
+similar(a::Array, T::Type, dims::Dims) = Array(T, dims)
+similar{T}(a::Array{T,1})              = Array(T, size(a,1))
+similar{T}(a::Array{T,2})              = Array(T, size(a,1), size(a,2))
+similar{T}(a::Array{T,1}, dims::Dims)  = Array(T, dims)
+similar{T}(a::Array{T,1}, m::Int)      = Array(T, m)
+similar{T}(a::Array{T,1}, S::Type)     = Array(S, size(a,1))
+similar{T}(a::Array{T,2}, dims::Dims)  = Array(T, dims)
+similar{T}(a::Array{T,2}, m::Int)      = Array(T, m)
+similar{T}(a::Array{T,2}, S::Type)     = Array(S, size(a,1), size(a,2))
 
 # T[x...] constructs Array{T,1}
 function getindex(T::Type, vals...)

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -61,4 +61,5 @@ rem(x::Bool, y::Bool) = y ? false : throw(DivideError())
 mod(x::Bool, y::Bool) = rem(x,y)
 
 promote_op(op, ::Type{Bool}, ::Type{Bool}) = typeof(op(true, true))
+promote_op(::typeof(^), ::Type{Bool}, ::Type{Bool}) = Bool
 promote_op{T<:Integer}(::typeof(^), ::Type{Bool}, ::Type{T}) = Bool

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -127,7 +127,7 @@ for T in (Range, BitArray, StridedArray, AbstractArray)
 end
 
 log(::Irrational{:e}) = 1 # use 1 to correctly promote expressions like log(x)/log(e)
-log(::Irrational{:e}, x) = log(x)
+log(::Irrational{:e}, x::Number) = log(x)
 
 # align along = for nice Array printing
 function alignment(io::IO, x::Irrational)

--- a/base/linalg/hessenberg.jl
+++ b/base/linalg/hessenberg.jl
@@ -33,7 +33,8 @@ immutable HessenbergQ{T,S<:AbstractMatrix} <: AbstractMatrix{T}
 end
 HessenbergQ{T}(factors::AbstractMatrix{T}, τ::Vector{T}) = HessenbergQ{T,typeof(factors)}(factors, τ)
 HessenbergQ(A::Hessenberg) = HessenbergQ(A.factors, A.τ)
-size(A::HessenbergQ, args...) = size(A.factors, args...)
+size(A::HessenbergQ, d) = size(A.factors, d)
+size(A::HessenbergQ) = size(A.factors)
 
 function getindex(A::Hessenberg, d::Symbol)
     d == :Q && return HessenbergQ(A)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -22,7 +22,8 @@ end
 typealias HermOrSym{T,S} Union{Hermitian{T,S}, Symmetric{T,S}}
 typealias RealHermSymComplexHerm{T<:Real,S} Union{Hermitian{T,S}, Symmetric{T,S}, Hermitian{Complex{T},S}}
 
-size(A::HermOrSym, args...) = size(A.data, args...)
+size(A::HermOrSym, d) = size(A.data, d)
+size(A::HermOrSym) = size(A.data)
 @inline function getindex(A::Symmetric, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     @inbounds r = (A.uplo == 'U') == (i < j) ? A.data[i, j] : A.data[j, i]

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -17,7 +17,8 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
             return $t{eltype(A), typeof(A)}(A)
         end
 
-        size(A::$t, args...) = size(A.data, args...)
+        size(A::$t, d) = size(A.data, d)
+        size(A::$t) = size(A.data)
 
         convert{T,S}(::Type{$t{T}}, A::$t{T,S}) = A
         convert{Tnew,Told,S}(::Type{$t{Tnew}}, A::$t{Told,S}) = (Anew = convert(AbstractMatrix{Tnew}, A.data); $t(Anew))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -196,6 +196,11 @@ using .IteratorsMD
 # Bounds-checking specialization
 # Specializing for a fixed number of arguments provides a ~25%
 # improvement over the general definitions in abstractarray.jl
+
+# This is annoying, but we must first define logical indexing to avoid ambiguities
+_internal_checkbounds(A::AbstractVector, I::AbstractVector{Bool}) = length(A) == length(I) || throw_boundserror(A, I)
+_internal_checkbounds(A::AbstractVector, I::AbstractArray{Bool}) = size(A) == size(I) || throw_boundserror(A, I)
+
 for N = 1:5
     args = [:($(Symbol(:I, d))) for d = 1:N]
     targs = [:($(Symbol(:I, d))::Union{Colon,Number,AbstractArray}) for d = 1:N]  # prevent co-opting the CartesianIndex version
@@ -215,9 +220,6 @@ for N = 1:5
         end
     end
 end
-# This is annoying, but we must also define logical indexing to avoid ambiguities
-_internal_checkbounds(A::AbstractVector, I::AbstractArray{Bool}) = size(A) == size(I) || throw_boundserror(A, I)
-_internal_checkbounds(A::AbstractVector, I::AbstractVector{Bool}) = length(A) == length(I) || throw_boundserror(A, I)
 
 # Bounds-checking with CartesianIndex
 @inline function checkbounds(::Type{Bool}, ::Tuple{}, I1::CartesianIndex)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -340,6 +340,9 @@ function round{T}(::Type{T}, x::Rational{Bool})
     convert(T, x)
 end
 
+round{T}(::Type{T}, x::Rational{Bool}, ::RoundingMode{:Nearest}) = round(T, x)
+round{T}(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesAway}) = round(T, x)
+round{T}(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesUp}) = round(T, x)
 round{T}(::Type{T}, x::Rational{Bool}, ::RoundingMode) = round(T, x)
 
 trunc{T}(x::Rational{T}) = Rational(trunc(T,x))

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -72,7 +72,7 @@ size_strides(out::Tuple) = out
 size(A::ReshapedArray) = A.dims
 size(A::ReshapedArray, d) = d <= ndims(A) ? A.dims[d] : 1
 similar(A::ReshapedArray, eltype::Type) = similar(parent(A), eltype, size(A))
-similar(A::ReshapedArray, eltype::Type, dims...) = similar(parent(A), eltype, dims...)
+similar(A::ReshapedArray, eltype::Type, dims::Dims) = similar(parent(A), eltype, dims...)
 linearindexing{R<:ReshapedArrayLF}(::Type{R}) = LinearFast()
 parent(A::ReshapedArray) = A.parent
 parentindexes(A::ReshapedArray) = map(s->1:s, size(parent(A)))

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -430,8 +430,8 @@ function shmem_randn(dims; kwargs...)
 end
 shmem_randn(I::Int...; kwargs...) = shmem_randn(I; kwargs...)
 
-similar(S::SharedArray, T, dims::Dims) = similar(S.s, T, dims)
-similar(S::SharedArray, T) = similar(S.s, T, size(S))
+similar(S::SharedArray, T::Type, dims::Dims) = similar(S.s, T, dims)
+similar(S::SharedArray, T::Type) = similar(S.s, T, size(S))
 similar(S::SharedArray, dims::Dims) = similar(S.s, eltype(S), dims)
 similar(S::SharedArray) = similar(S.s, eltype(S), size(S))
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -241,7 +241,7 @@ end
 
 similar(S::SparseMatrixCSC, Tv::Type=eltype(S))   = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), Array(Tv, length(S.nzval)))
 similar{Tv,Ti,TvNew,TiNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{TiNew}) = SparseMatrixCSC(S.m, S.n, convert(Array{TiNew},S.colptr), convert(Array{TiNew}, S.rowval), Array(TvNew, length(S.nzval)))
-similar{Tv, N}(S::SparseMatrixCSC, ::Type{Tv}, d::NTuple{N, Integer}) = spzeros(Tv, d...)
+similar{Tv}(S::SparseMatrixCSC, ::Type{Tv}, d::Dims) = spzeros(Tv, d...)
 
 function convert{Tv,Ti,TvS,TiS}(::Type{SparseMatrixCSC{Tv,Ti}}, S::SparseMatrixCSC{TvS,TiS})
     if Tv == TvS && Ti == TiS

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -67,7 +67,7 @@ viewindexing(I::Tuple{AbstractArray, Vararg{Any}}) = LinearSlow()
 size(V::SubArray) = V.dims
 length(V::SubArray) = prod(V.dims)
 
-similar(V::SubArray, T, dims::Dims) = similar(V.parent, T, dims)
+similar(V::SubArray, T::Type, dims::Dims) = similar(V.parent, T, dims)
 
 parent(V::SubArray) = V.parent
 parentindexes(V::SubArray) = V.indexes

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -60,51 +60,51 @@ ambig(x, y::Integer) = 3
 
 # Automatic detection of ambiguities
 module Ambig1
-
 ambig(x, y) = 1
 ambig(x::Integer, y) = 2
 ambig(x, y::Integer) = 3
-
 end
 
 ambs = detect_ambiguities(Ambig1)
 @test length(ambs) == 1
 
 module Ambig2
-
 ambig(x, y) = 1
 ambig(x::Integer, y) = 2
 ambig(x, y::Integer) = 3
 ambig(x::Number, y) = 4
-
 end
 
 ambs = detect_ambiguities(Ambig2)
 @test length(ambs) == 2
 
 module Ambig3
-
 ambig(x, y) = 1
 ambig(x::Integer, y) = 2
 ambig(x, y::Integer) = 3
 ambig(x::Int, y::Int) = 4
-
 end
 
 ambs = detect_ambiguities(Ambig3)
 @test length(ambs) == 1
 
 module Ambig4
-
 ambig(x, y) = 1
 ambig(x::Int, y) = 2
 ambig(x, y::Int) = 3
 ambig(x::Int, y::Int) = 4
-
 end
-
 ambs = detect_ambiguities(Ambig4)
 @test length(ambs) == 0
+
+module Ambig5
+ambig(x::Int8, y) = 1
+ambig(x::Integer, y) = 2
+ambig(x, y::Int) = 3
+end
+
+ambs = detect_ambiguities(Ambig5)
+@test length(ambs) == 2
 
 # Test that Core and Base are free of ambiguities
 @test isempty(detect_ambiguities(Core, Base; imported=true))


### PR DESCRIPTION
previously we stopped checking for ambiguities as soon as we reached the definition. this assumed that jl_args_morespecific was transitive, but in actuality it is only a partial sort and we build the typemap assuming no ambiguities, which sometimes made it even less accurate at finding them.

~~note that I needed to partially revert to printing ambiguities or this doesn't make it very far in bootstrap before throwing a method ambiguity error. the RFH (request for help) is to crowd-source resolving these ambiguities (or determining which aren't applicable due to that argument combination not being meaningful).~~

ref #16252
ref https://github.com/JuliaLang/julia/pull/16220#discussion_r62260888

~~edit: additionally, due to some recent change, we seem to be unable to detect the ambiguities with Varargs previously computed by https://travis-ci.org/JuliaLang/julia/jobs/126188063~~
edit2: I mistake in that PR was making it possible to compute that ambiguity (while breaking everything else), it's not a recent regression to be unable to compute that.
