### PR TITLE
Fix example in documentation

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -202,7 +202,7 @@ variables::
     end
 
     julia> x
-    11
+    12
 
 Within soft scopes, the `global` keyword is never necessary, although
 allowed.  The only case when it would change the semantics is


### PR DESCRIPTION
There was a wrong output for the example of scoping of for-loops variables.
