### PR TITLE
Document VecElement.  Support call-by-value of SIMD types on 64-bit x86.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,8 @@ Command-line option changes
 Compiler/Runtime improvements
 -----------------------------
 
+  * Machine SIMD types can be represented in Julia as a homogeneous tuple of `VecElement` ([#15244]).
+
 Breaking changes
 ----------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -86,6 +86,7 @@
    stdlib/libdl
    stdlib/profile
    stdlib/stacktraces
+   stdlib/simd-types
 
 .. _devdocs:
 

--- a/doc/stdlib/index.rst
+++ b/doc/stdlib/index.rst
@@ -27,3 +27,4 @@
    libc
    libdl
    profile
+   simd-types

--- a/doc/stdlib/simd-types.rst
+++ b/doc/stdlib/simd-types.rst
@@ -1,0 +1,37 @@
+.. _stdlib-simd-types:
+
+****************
+ SIMD Support
+****************
+
+Type ``VecElement{T}`` is intended for building libraries of SIMD operations.
+Practical use of it requires using ``llvmcall``. The type is defined as::
+
+    immutable VecElement{T}
+        value::T
+    end
+
+It has a special compilation rule: a homogeneous tuple of ``VecElement{T}``
+maps to an LLVM ``vector`` type when ``T`` is a bitstype and the tuple
+length is in the set {2-6,8-10,16}.
+
+At ``-O3``, the compiler *might* automatically vectorize operations
+on such tuples. For example, the following program, when compiled
+with ``julia -O3`` generates two SIMD addition instructions (``addps``)
+on x86 systems::
+
+    typealias m128 NTuple{4,VecElement{Float32}}
+
+    function add(a::m128, b::m128)
+        (VecElement(a[1].value+b[1].value),
+         VecElement(a[2].value+b[2].value),
+         VecElement(a[3].value+b[3].value),
+         VecElement(a[4].value+b[4].value))
+    end
+
+    triple(c::m128) = add(add(c,c),c)
+
+    code_native(triple,(m128,))
+
+However, since the automatic vectorization cannot be relied upon,
+future use will mostly be via libraries that use ``llvmcall``.

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -37,19 +37,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "abi_x86_vec.h"
 
 struct AbiState {
 };
 
 const AbiState default_abi_state = {};
 
-
 bool use_sret(AbiState *state, jl_value_t *ty)
 {
     if(!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
         return false;
     size_t size = jl_datatype_size(ty);
-    if (size <= 8)
+    if (size <= 8 || is_native_simd_type(ty))
         return false;
     return true;
 }

--- a/src/abi_x86_vec.h
+++ b/src/abi_x86_vec.h
@@ -1,0 +1,25 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+#ifndef ABI_X86_VEC_H
+#define ABI_X86_VEC_H
+
+// Determine if object of bitstype ty maps to a __m128, __m256, or __m512 type in C.
+static bool is_native_simd_type(jl_value_t *ty) {
+    size_t size = jl_datatype_size(ty);
+    if (size!=16 && size!=32 && size!=64)
+        // Wrong size for xmm, ymm, or zmm register.
+        return false;
+    uint32_t n = jl_datatype_nfields(ty);
+    if (n<2)
+        // Not mapped to SIMD register.
+        return false;
+    jl_value_t *ft0 = jl_field_type(ty, 0);
+    for (uint32_t i = 1; i < n; ++i)
+        if (jl_field_type(ty, i)!=ft0)
+            // Not homogeneous
+            return false;
+    // Type is homogeneous.  Check if it maps to LLVM vector.
+    return jl_special_vector_alignment(n,ft0) != 0;
+}
+
+#endif

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -388,3 +388,21 @@ JL_DLLEXPORT void set_verbose(int level) {
 JL_DLLEXPORT void *test_echo_p(void *p) {
     return p;
 }
+
+#if defined(_CPU_X86_64_)
+
+#include <xmmintrin.h>
+
+JL_DLLEXPORT __m128i test_m128i(__m128i a, __m128i b, __m128i c, __m128i d ) {
+    // 64-bit x86 has only level 2 SSE, which does not have a <4 x int32> multiplication,
+    // so we use floating-point instead, and assume caller knows about the hack.
+    return _mm_add_epi32(a,
+                         _mm_cvtps_epi32(_mm_mul_ps(_mm_cvtepi32_ps(b),
+                                                    _mm_cvtepi32_ps(_mm_sub_epi32(c,d)))));
+}
+
+JL_DLLEXPORT __m128 test_m128(__m128 a, __m128 b, __m128 c, __m128 d ) {
+    return _mm_add_ps(a, _mm_mul_ps(b, _mm_sub_ps(c, d)));
+}
+
+#endif

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1407,15 +1407,14 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
     }
 
     size_t nargs = 0;
-    ConstantStruct *cst = NULL;
-    ConstantVector *cvec = NULL;
-    ConstantArray *carr = NULL;
-    if ((cst = dyn_cast<ConstantStruct>(constant)) != NULL)
+    if (ConstantStruct *cst = dyn_cast<ConstantStruct>(constant))
         nargs = cst->getType()->getNumElements();
-    else if ((cvec = dyn_cast<ConstantVector>(constant)) != NULL)
+    else if (ConstantVector *cvec = dyn_cast<ConstantVector>(constant))
         nargs = cvec->getType()->getNumElements();
-    else if ((carr = dyn_cast<ConstantArray>(constant)) != NULL)
+    else if (ConstantArray *carr = dyn_cast<ConstantArray>(constant))
         nargs = carr->getType()->getNumElements();
+    else if (ConstantDataVector *cdv = dyn_cast<ConstantDataVector>(constant))
+        nargs = cdv->getType()->getNumElements();
     else if (isa<Function>(constant))
         return NULL;
     else


### PR DESCRIPTION
This pull request documents `VecElement` and fixes issue #16138 for 64-bit x86.  (Bug discovered while writing this documentation!)

Open issues: 
- how to fix 32-bit x86?  I can probably figure it out if someone can explain how to force a 32-bit build of Julia on a 64-bit host.
- how to test?  How do I write a test that needs custom C code, and will only run on x86 platforms?
