### PR TITLE
Do not call jl_set_typeof on initialized value.

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -85,6 +85,7 @@ typedef struct {
     ((jl_value_t*)(jl_astaggedvalue(v)->type_bits & ~(uintptr_t)15))
 static inline void jl_set_typeof(void *v, void *t)
 {
+    // Do not call this on a value that is already initialized.
     jl_taggedvalue_t *tag = jl_astaggedvalue(v);
     tag->type = (jl_value_t*)t;
 }

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -532,7 +532,6 @@ static NOINLINE int true_main(int argc, char *argv[])
         int i;
         for (i=0; i < argc; i++) {
             jl_value_t *s = (jl_value_t*)jl_cstr_to_string(argv[i]);
-            jl_set_typeof(s,jl_string_type);
             jl_arrayset(args, s, i);
         }
     }


### PR DESCRIPTION
This is one of the most unsafe thing one can do to the GC. (Yes, in this case the type layout is compatible and the value isn't visible to the GC yet but this usage can easily break due to minor changes in the code....)

Ref https://github.com/JuliaLang/julia/commit/b3cc1a40188ec5cca19f84876df23ebc2310764d#diff-4487cf24854d3caa595fc78061793550R235 luckily this is not necessary anymore..
