### PR TITLE
Support qrfact(::AbstractMatrix)

### DIFF
--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -88,15 +88,13 @@ end
 qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{false}}) = QRCompactWY(LAPACK.geqrt!(A, min(minimum(size(A)), 36))...)
 qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{true}}) = QRPivoted(LAPACK.geqp3!(A)...)
 qrfact!{T<:BlasFloat}(A::StridedMatrix{T}) = qrfact!(A, Val{false})
-qrfact{T<:BlasFloat}(A::StridedMatrix{T}, arg) = qrfact!(copy(A), arg)
-qrfact{T<:BlasFloat}(A::StridedMatrix{T}) = qrfact!(copy(A))
 
 # Generic fallbacks
 qrfact!(A::StridedMatrix, ::Type{Val{false}}) = qrfactUnblocked!(A)
 qrfact!(A::StridedMatrix, ::Type{Val{true}}) = qrfactPivotedUnblocked!(A)
 qrfact!(A::StridedMatrix) = qrfact!(A, Val{false})
-qrfact{T}(A::StridedMatrix{T}, arg) = qrfact!(copy_oftype(A, typeof(zero(T)/norm(one(T)))), arg)
-qrfact{T}(A::StridedMatrix{T}) = qrfact!(copy_oftype(A, typeof(zero(T)/norm(one(T)))))
+qrfact{T}(A::AbstractMatrix{T}, arg) = qrfact!(copy_oftype(A, typeof(zero(T)/norm(one(T)))), arg)
+qrfact{T}(A::AbstractMatrix{T}) = qrfact!(copy_oftype(A, typeof(zero(T)/norm(one(T)))))
 qrfact(x::Number) = qrfact(fill(x,1,1))
 
 qr(A::Union{Number, AbstractMatrix}, pivot::Union{Type{Val{false}}, Type{Val{true}}}=Val{false}; thin::Bool=true) =
@@ -541,4 +539,3 @@ end
 ## Lower priority: Add LQ, QL and RQ factorizations
 
 # FIXME! Should add balancing option through xgebal
-

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -171,3 +171,6 @@ end
 
 @test qr(Int[]) == (Int[],1)
 @test Base.LinAlg.qr!(Int[1]) == (Int[1],1)
+
+B = rand(7,2)
+@test_approx_eq (1:7)\B collect(1:7)\B


### PR DESCRIPTION
See discussion about a breakage caused by ReshapedArrays starting at https://github.com/JuliaLang/julia/pull/15449#issuecomment-217719922.

It's likely that this won't be the last of breakages by ReshapedArrays: overall they have been an effective tool for discovering places we should remove needless specification of `Array` or `StridedArray` (e.g., f6f616ce50e40b4337feb79a8bad20519ff75e86). Unfortunately, unless someone is willing to start on a systematic audit, there's a strong likelihood that "usage in the wild" will turn up yet more places.
