### PR TITLE
Improve performance of size(::BitVector, d)

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -40,15 +40,10 @@ length(B::BitArray) = B.len
 size(B::BitVector) = (B.len,)
 size(B::BitArray) = B.dims
 
-function size(B::BitVector, d)
-    if d == 1
-        return B.len
-    elseif d > 1
-        return 1
-    end
-    throw(ArgumentError("dimension must be ≥ 1, got $d"))
+@inline function size(B::BitVector, d)
+    d < 1 && throw_boundserror(size(B), d)
+    ifelse(d == 1, B.len, 1)
 end
-size{N}(B::BitArray{N}, d) = (d>N ? 1 : B.dims[d])
 
 isassigned{N}(B::BitArray{N}, i::Int) = 1 <= i <= length(B)
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -128,7 +128,7 @@ for n in [1; 1023:1025]
     end
 end
 
-@test_throws ArgumentError size(trues(5),0)
+@test_throws BoundsError size(trues(5),0)
 
 timesofar("utils")
 


### PR DESCRIPTION
For me this papers over #16243. (I looked into this because I recently refactored `checkbounds`, and was worried it was my fault.)

@carlobaldassi, when `d < 1` is it OK to throw `BoundsError` instead of `ArgumentError`? julia is totally inconsistent on this issue, but for `BitArrays` with `ndims>1`, that was (and remains) the error thrown.
