### PR TITLE
Fix convert(Array{Int}, ::Range{Int})

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -236,8 +236,9 @@ end
 
 convert{T,n}(::Type{Array{T}}, x::Array{T,n}) = x
 convert{T,n}(::Type{Array{T,n}}, x::Array{T,n}) = x
-convert{T,n,S}(::Type{Array{T}}, x::Array{S,n}) = convert(Array{T,n}, x)
-convert{T,n,S}(::Type{Array{T,n}}, x::Array{S,n}) = copy!(similar(x,T), x)
+
+convert{T,n,S}(::Type{Array{T}}, x::AbstractArray{S,n}) = convert(Array{T,n}, x)
+convert{T,n,S}(::Type{Array{T,n}}, x::AbstractArray{S,n}) = copy!(Array(T, size(x)), x)
 
 promote_rule{T,n,S}(::Type{Array{T,n}}, ::Type{Array{S,n}}) = Array{promote_type(T,S),n}
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -690,3 +690,12 @@ let A = -1:1, B = -1.0:1.0
     @test ~A == [0,-1,-2]
     @test typeof(~A) == Vector{Int}
 end
+
+# conversion to Array
+let r = 1:3, a = [1,2,3]
+    @test convert(Array, r) == a
+    @test convert(Array{Int}, r) == a
+    @test convert(Array{Float64}, r) == a
+    @test convert(Array{Int,1}, r) == a
+    @test convert(Array{Float64,1}, r) == a
+end


### PR DESCRIPTION
convert(Array, ...) and convert(Array{Int,1}, ...) worked,
but not the one-parameter version.
