### PR TITLE
Revert extra tests for DictChannel failure

### DIFF
--- a/test/examples.jl
+++ b/test/examples.jl
@@ -59,10 +59,10 @@ end
 
 # Run the remote on pid 1, since runtests may terminate workers
 # at any time depending on memory usage
-@test remotecall_fetch(1, dc_path) do f
+remotecall_fetch(1, dc_path) do f
     include(f)
-    return :infungible
-end === :infungible
+    nothing
+end
 
 defined_on_master = false
 if remotecall_fetch(isdefined, 1, :DictChannel) == false

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -47,37 +47,13 @@ end
 dc_path = joinpath(dir, "dictchannel.jl")
 myid() == 1 || include(dc_path)
 
-# The checks to see if DictChannel is defined is to identify the root cause of
-# https://github.com/JuliaLang/julia/issues/16091 .
-# To be removed once fixed.
-defined_on_worker = false
-if (myid() != 1) && !isdefined(:DictChannel)
-    error("myid : $(myid()). DictChannel not defined.")
-else
-    defined_on_worker = true
-end
-
 # Run the remote on pid 1, since runtests may terminate workers
 # at any time depending on memory usage
 remotecall_fetch(1, dc_path) do f
     include(f)
     nothing
 end
-
-defined_on_master = false
-if remotecall_fetch(isdefined, 1, :DictChannel) == false
-    error("myid : $(myid()). DictChannel not defined on 1")
-else
-    defined_on_master = true
-end
-
-dc = nothing
-try
-    dc=RemoteChannel(()->DictChannel(), 1)
-catch e
-    println("myid : ", myid(), ", dc_path : ", dc_path, ", defined_on_worker:", defined_on_worker, ", defined_on_master: ", defined_on_master)
-    rethrow(e)
-end
+dc=RemoteChannel(()->DictChannel(), 1)
 @test typeof(dc) == RemoteChannel{DictChannel}
 
 @test isready(dc) == false

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -767,11 +767,6 @@ if DoFullTest
     end
     sleep(0.5)  # Give some time for the above error to be printed
 
-    # github PR #14456
-    for n = 1:10^6
-        fetch(@spawnat myid() myid())
-    end
-
 @unix_only begin
     function test_n_remove_pids(new_pids)
         for p in new_pids
@@ -909,3 +904,9 @@ for tid in [id_other, id_me, Base.default_worker_pool()]
     test_f_args(13, f_args, tid, 1; kw1=4, kw2=8)
     test_f_args(15, f_args, tid, 1, 2; kw1=4, kw2=8)
 end
+
+# github PR #14456
+for n = 1:10^5
+    fetch(@spawnat myid() myid())
+end
+


### PR DESCRIPTION
In light of https://github.com/JuliaLang/julia/commit/7348cfe2d017cce657af60f3c2d7f5cae6f60564 revert extra tests in `test/examples.jl` . Also run a reduced number of loops of #15923 under travis/AV . This adds around 2 seconds.
