### PR TITLE
RFC: Fix unchecked accesses to Expected<T>

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1273,14 +1273,18 @@ static uint64_t compute_obj_symsize(const object::ObjectFile *obj, uint64_t offs
             uint64_t Addr;
             object::section_iterator Sect = ESection;
 #ifdef LLVM38
-            Sect = Sym.getSection().get();
+            auto SectOrError = Sym.getSection();
+            assert(SectOrError);
+            Sect = SectOrError.get();
 #else
             if (Sym.getSection(Sect)) continue;
 #endif
             if (Sect == ESection) continue;
             if (Sect != Section) continue;
 #ifdef LLVM37
-            Addr = Sym.getAddress().get();
+            auto AddrOrError = Sym.getAddress();
+            assert(AddrOrError);
+            Addr = AddrOrError.get();
 #else
             if (Sym.getAddress(Addr)) continue;
 #endif

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -343,7 +343,9 @@ public:
         for (const object::SymbolRef &sym_iter : debugObj.symbols()) {
             StringRef sName;
 #ifdef LLVM37
-            sName = sym_iter.getName().get();
+            auto sNameOrError = sym_iter.getName();
+            assert(sNameOrError);
+            sName = sNameOrError.get();
 #else
             sym_iter.getName(sName);
 #endif
@@ -357,14 +359,20 @@ public:
             if (pAddr) {
                 uint64_t Addr, SectionAddr, SectionLoadAddr;
 #if defined(LLVM38)
-                Addr = sym_iter.getAddress().get();
-                Section = sym_iter.getSection().get();
+                auto AddrOrError = sym_iter.getAddress();
+                assert(AddrOrError);
+                Addr = AddrOrError.get();
+                auto SectionOrError = sym_iter.getSection();
+                assert(SectionOrError);
+                Section = SectionOrError.get();
                 assert(Section != EndSection && Section->isText());
                 SectionAddr = Section->getAddress();
                 Section->getName(sName);
                 SectionLoadAddr = getLoadAddress(sName);
 #elif defined(LLVM37)
-                Addr = sym_iter.getAddress().get();
+                auto AddrOrError = sym_iter.getAddress();
+                assert(AddrOrError);
+                Addr = AddrOrError.get();
                 sym_iter.getSection(Section);
                 assert(Section != EndSection && Section->isText());
                 Section->getName(sName);
@@ -419,14 +427,20 @@ public:
         for(const auto &sym_size : symbols) {
             const object::SymbolRef &sym_iter = sym_size.first;
 #ifdef LLVM39
-            object::SymbolRef::Type SymbolType = sym_iter.getType().get();
+            auto SymbolTypeOrError = sym_iter.getType();
+            assert(SymbolTypeOrError);
+            object::SymbolRef::Type SymbolType = SymbolTypeOrError.get();
 #else
             object::SymbolRef::Type SymbolType = sym_iter.getType();
 #endif
             if (SymbolType != object::SymbolRef::ST_Function) continue;
-            uint64_t Addr = sym_iter.getAddress().get();
+            auto AddrOrError = sym_iter.getAddress();
+            assert(AddrOrError);
+            uint64_t Addr = AddrOrError.get();
 #ifdef LLVM38
-            Section = sym_iter.getSection().get();
+            auto SectionOrError = sym_iter.getSection();
+            assert(SectionOrError);
+            Section = SectionOrError.get();
 #else
             sym_iter.getSection(Section);
 #endif
@@ -441,7 +455,9 @@ public:
             uint64_t SectionLoadAddr = L.getSectionLoadAddress(secName);
 #endif
             Addr -= SectionAddr - SectionLoadAddr;
-            StringRef sName = sym_iter.getName().get();
+            auto sNameOrError = sym_iter.getName();
+            assert(sNameOrError);
+            StringRef sName = sNameOrError.get();
             uint64_t SectionSize = Section->getSize();
             size_t Size = sym_size.second;
 #if defined(_OS_WINDOWS_)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -269,13 +269,15 @@ class JuliaOJIT {
                         continue;
                     if (!(Flags & object::BasicSymbolRef::SF_Exported))
                         continue;
-                    auto Name = Symbol.getName();
-                    orc::JITSymbol Sym = JIT.CompileLayer.findSymbolIn(H, *Name, true);
+                    auto NameOrError = Symbol.getName();
+                    assert(NameOrError);
+                    auto Name = NameOrError.get();
+                    orc::JITSymbol Sym = JIT.CompileLayer.findSymbolIn(H, Name, true);
                     assert(Sym);
                     // note: calling getAddress here eagerly finalizes H
                     // as an alternative, we could store the JITSymbol instead
                     // (which would present a lazy-initializer functor interface instead)
-                    JIT.LocalSymbolTable[*Name] = (void*)(uintptr_t)Sym.getAddress();
+                    JIT.LocalSymbolTable[Name] = (void*)(uintptr_t)Sym.getAddress();
                 }
             }
         }


### PR DESCRIPTION
Hi everyone,

when trying to build Julia together with LLVM 3.9, I noticed that the build fails with the following error message:

```
Expected<T> must be checked before access or destruction.
Expected<T> value was in success state. (Note: Expected<T> values in success mode must still be checked prior to being destroyed).
Aborted (core dumped)
```

My Make.user looks as follows:

```
USE_SYSTEM_LLVM:=1
LLVM_CONFIG:=$(MY_LLVM_BUILD)/bin/llvm-config
```

`MY_LLVM_BUILD` points to a manually built LLVM installation of version 3.9, retrieved from LLVM's git mirror and compiled via `cmake && make` (i.e. no options have been passed to the build). The error can also be reproduced with the following Make.user:

```
LLVM_VER:=svn
LLVM_ASSERTIONS:=1
LLVM_DEBUG:=1
```

There are a number of places in debuginfo.cpp and jitlayers.cpp where `Expected<T>` values are accessed without checking beforehand if they contain an `Error`. This results in the above error message and execution gets aborted.

The given pull request fixes these usages of `Expected<T>` such that the build process with LLVM 3.9 is working again.

Furthermore, after having fixed the build, it turned out that, when running `make testall`, a few tests also fail due to unchecked accesses to `Expected<T>` values. However, I've not yet been able to identify the particular test cases that fail, since the error messages do not appear consistently after the same test cases when running the tests repeatedly. Are the tests maybe running asynchronously such that their output does not necessarily appear in order?

Since this is my first pull request here, I apologize in case I overlooked anything important.

Any comments are appreciated, thank you!
