### PR TITLE
RFC: Fix #13957 by refactoring _svds

### DIFF
--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1244,7 +1244,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    | real or complex | inverse with level shift ``sigma`` | :math:`(A - \sigma B )^{-1}B = v\nu` |
    +-----------------+------------------------------------+--------------------------------------+
 
-.. function:: svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000) -> ([left_sv,] s, [right_sv,] nconv, niter, nmult, resid)
+.. function:: svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000, ncv=2*nsv, u0=zeros((0,)), v0=zeros((0,))) -> (SVD([left_sv,] s, [right_sv,]), nconv, niter, nmult, resid)
 
    .. Docstring generated from Julia source
 
@@ -1253,16 +1253,17 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    **Inputs**
 
    * ``A``\ : Linear operator whose singular values are desired. ``A`` may be represented   as a subtype of ``AbstractArray``\ , e.g., a sparse matrix, or any other type   supporting the four methods ``size(A)``\ , ``eltype(A)``\ , ``A * vector``\ , and   ``A' * vector``\ .
-   * ``nsv``\ : Number of singular values.
+   * ``nsv``\ : Number of singular values. Default: 6.
    * ``ritzvec``\ : If ``true``\ , return the left and right singular vectors ``left_sv`` and ``right_sv``\ .    If ``false``\ , omit the singular vectors. Default: ``true``\ .
    * ``tol``\ : tolerance, see :func:`eigs`\ .
-   * ``maxiter``\ : Maximum number of iterations, see :func:`eigs`\ .
+   * ``maxiter``\ : Maximum number of iterations, see :func:`eigs`\ . Default: 1000.
+   * ``ncv``\ : Maximum size of the Krylov subspace, see :func:`eigs` (there called ``nev``\ ). Default: ``2*nsv``\ .
+   * ``u0``\ : Initial guess for the first left Krylov vector. It may have length ``m`` (the first dimension of ``A``\ ), or 0.
+   * ``v0``\ : Initial guess for the first right Krylov vector. It may have length ``n`` (the second dimension of ``A``\ ), or 0.
 
    **Outputs**
 
-   * ``left_sv``\ : Left singular vectors (only if ``ritzvec = true``\ ).
-   * ``s``\ : A vector of length ``nsv`` containing the requested singular values.
-   * ``right_sv``\ : Right singular vectors (only if ``ritzvec = true``\ ).
+   * ``svd``\ : An ``SVD`` object containing the left singular vectors, the requested values, and the right singular vectors. If ``ritzvec = false``\ , the left and right singular vectors will be empty.
    * ``nconv``\ : Number of converged singular values.
    * ``niter``\ : Number of iterations.
    * ``nmult``\ : Number of matrix–vector products used.

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -158,15 +158,15 @@ let # svds test
     S2 = svd(full(A))
 
     ## singular values match:
-    @test_approx_eq S1[2] S2[2][1:2]
+    @test_approx_eq S1[1][:S] S2[2][1:2]
 
     ## 1st left singular vector
-    s1_left = sign(S1[1][3,1]) * S1[1][:,1]
+    s1_left = sign(S1[1][:U][3,1]) * S1[1][:U][:,1]
     s2_left = sign(S2[1][3,1]) * S2[1][:,1]
     @test_approx_eq s1_left s2_left
 
     ## 1st right singular vector
-    s1_right = sign(S1[3][3,1]) * S1[3][:,1]
+    s1_right = sign(S1[1][:Vt][3,1]) * S1[1][:Vt][:,1]
     s2_right = sign(S2[3][3,1]) * S2[3][:,1]
     @test_approx_eq s1_right s2_right
 
@@ -174,12 +174,14 @@ let # svds test
     debug && println("Issue 10329")
     B = sparse(diagm([1.0, 2.0, 34.0, 5.0, 6.0]))
     S3 = svds(B, ritzvec=false, nsv=2)
-    @test_approx_eq S3[1] [34.0, 6.0]
+    @test_approx_eq S3[1][:S] [34.0, 6.0]
     S4 = svds(B, nsv=2)
-    @test_approx_eq S4[2] [34.0, 6.0]
+    @test_approx_eq S4[1][:S] [34.0, 6.0]
 
     @test_throws ArgumentError svds(A,nsv=0)
     @test_throws ArgumentError svds(A,nsv=20)
+    @test_throws DimensionMismatch svds(A,nsv=2,u0=rand(size(A,1)+1))
+    @test_throws DimensionMismatch svds(A,nsv=2,v0=rand(size(A,2)+1))
 end
 
 debug && println("complex svds")
@@ -189,20 +191,22 @@ let # complex svds test
     S2 = svd(full(A))
 
     ## singular values match:
-    @test_approx_eq S1[2] S2[2][1:2]
+    @test_approx_eq S1[1][:S] S2[2][1:2]
 
     ## left singular vectors
-    s1_left = abs(S1[1][:,1:2])
+    s1_left = abs(S1[1][:U][:,1:2])
     s2_left = abs(S2[1][:,1:2])
     @test_approx_eq s1_left s2_left
 
     ## right singular vectors
-    s1_right = abs(S1[3][:,1:2])
+    s1_right = abs(S1[1][:Vt][:,1:2])
     s2_right = abs(S2[3][:,1:2])
     @test_approx_eq s1_right s2_right
 
     @test_throws ArgumentError svds(A,nsv=0)
     @test_throws ArgumentError svds(A,nsv=20)
+    @test_throws DimensionMismatch svds(A,nsv=2,u0=complex(rand(size(A,1)+1)))
+    @test_throws DimensionMismatch svds(A,nsv=2,v0=complex(rand(size(A,2)+1)))
 end
 
 # test promotion


### PR DESCRIPTION
Added `ncv` and `v0` kwargs. Redid some documentation. Output is now a
SVD object in either `ritzvec` case, with empty/non-empty singular
vectors.
