### PR TITLE
Look for fesetround in libm rather than the executable

### DIFF
--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -9,6 +9,8 @@ export
     rounding, setrounding,
     get_zero_subnormals, set_zero_subnormals
 
+const libm = Base.libm_name
+
 ## rounding modes ##
 immutable RoundingMode{T} end
 
@@ -41,8 +43,8 @@ function from_fenv(r::Integer)
     end
 end
 
-setrounding_raw{T<:Union{Float32,Float64}}(::Type{T},i::Integer) = ccall(:fesetround, Int32, (Int32,), i)
-rounding_raw{T<:Union{Float32,Float64}}(::Type{T}) = ccall(:fegetround, Int32, ())
+setrounding_raw{T<:Union{Float32,Float64}}(::Type{T},i::Integer) = ccall((:fesetround, libm), Int32, (Int32,), i)
+rounding_raw{T<:Union{Float32,Float64}}(::Type{T}) = ccall((:fegetround, libm), Int32, ())
 
 setrounding{T<:Union{Float32,Float64}}(::Type{T},r::RoundingMode) = setrounding_raw(T,to_fenv(r))
 rounding{T<:Union{Float32,Float64}}(::Type{T}) = from_fenv(rounding_raw(T))

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -78,6 +78,12 @@ Array{T}(::Type{T}, m::Integer)                       = Array{T,1}(Int(m))
 Array{T}(::Type{T}, m::Integer,n::Integer)            = Array{T,2}(Int(m),Int(n))
 Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) = Array{T,3}(Int(m),Int(n),Int(o))
 
+# For OS specific stuff
+include(String(vcat(length(Core.ARGS)>=2?Core.ARGS[2].data:"".data, "build_h.jl".data))) # include($BUILDROOT/base/build_h.jl)
+include(String(vcat(length(Core.ARGS)>=2?Core.ARGS[2].data:"".data, "version_git.jl".data))) # include($BUILDROOT/base/version_git.jl)
+include("osutils.jl")
+include("c.jl")
+
 # numeric operations
 include("hashing.jl")
 include("rounding.jl")
@@ -111,12 +117,6 @@ typealias StridedArray{T,N,A<:Union{DenseArray,StridedReshapedArray},I<:Tuple{Va
 typealias StridedVector{T,A<:Union{DenseArray,StridedReshapedArray},I<:Tuple{Vararg{Union{RangeIndex, NoSlice, AbstractCartesianIndex}}}}  Union{DenseArray{T,1}, SubArray{T,1,A,I}, StridedReshapedArray{T,1}}
 typealias StridedMatrix{T,A<:Union{DenseArray,StridedReshapedArray},I<:Tuple{Vararg{Union{RangeIndex, NoSlice, AbstractCartesianIndex}}}}  Union{DenseArray{T,2}, SubArray{T,2,A,I}, StridedReshapedArray{T,2}}
 typealias StridedVecOrMat{T} Union{StridedVector{T}, StridedMatrix{T}}
-
-# For OS specific stuff
-include(String(vcat(length(Core.ARGS)>=2?Core.ARGS[2].data:"".data, "build_h.jl".data))) # include($BUILDROOT/base/build_h.jl)
-include(String(vcat(length(Core.ARGS)>=2?Core.ARGS[2].data:"".data, "version_git.jl".data))) # include($BUILDROOT/base/version_git.jl)
-include("osutils.jl")
-include("c.jl")
 
 # Core I/O
 include("io.jl")


### PR DESCRIPTION
We usually get lucky because GCC's runtime library includes this functions.
However, their proper place is in the math library and Clang's runtime
library does not include these functions on windows, so without this change
the function is not found.

Also bump openlibm to include the latest changes that make openlibm
work with clang on windows.
