### PR TITLE
Restrict interface bindings and test connections 

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -217,8 +217,8 @@ function process_options(opts::JLOptions)
         startup && load_juliarc()
 
         # startup worker
-        if opts.worker != 0
-            start_worker() # does not return
+        if opts.worker != C_NULL
+            start_worker(bytestring(opts.worker)) # does not return
         end
         # add processors
         if opts.nprocs > 0

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -10485,3 +10485,10 @@ to. This is useful when writing custom `serialize` methods for a type, which opt
 data written out depending on the receiving process id.
 """
 Base.worker_id_from_socket
+
+"""
+    Base.cluster_cookie([cookie]) -> cookie
+
+Returns the cluster cookie. If a cookie is passed, also sets it as the cluster cookie.
+"""
+Base.cluster_cookie

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -73,6 +73,7 @@ function init_parallel()
     global PGRP
     global LPROC
     LPROC.id = 1
+    cluster_cookie(randstring())
     assert(isempty(PGRP.workers))
     register_worker(LPROC)
 end

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -35,8 +35,9 @@ end
 
 
 function check_addprocs_args(kwargs)
+    valid_kw_names = collect(keys(default_addprocs_params()))
     for keyname in kwargs
-        !(keyname[1] in [:dir, :exename, :exeflags, :topology]) && throw(ArgumentError("Invalid keyword argument $(keyname[1])"))
+        !(keyname[1] in valid_kw_names) && throw(ArgumentError("Invalid keyword argument $(keyname[1])"))
     end
 end
 
@@ -93,7 +94,7 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     if length(machine_bind) > 1
         exeflags = `--bind-to $(machine_bind[2]) $exeflags`
     end
-    exeflags = `$exeflags --worker`
+    exeflags = `$exeflags --worker $(cluster_cookie())`
 
     machine_def = split(machine_bind[1], ':')
     # if this machine def has a port number, add the port information to the ssh flags
@@ -217,15 +218,15 @@ end
 
 
 # LocalManager
-
 immutable LocalManager <: ClusterManager
     np::Integer
+    restrict::Bool  # Restrict binding to 127.0.0.1 only
 end
 
 addprocs(; kwargs...) = addprocs(Sys.CPU_CORES; kwargs...)
-function addprocs(np::Integer; kwargs...)
+function addprocs(np::Integer; restrict=true, kwargs...)
     check_addprocs_args(kwargs)
-    addprocs(LocalManager(np); kwargs...)
+    addprocs(LocalManager(np, restrict); kwargs...)
 end
 
 show(io::IO, manager::LocalManager) = println(io, "LocalManager()")
@@ -234,10 +235,11 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
     dir = params[:dir]
     exename = params[:exename]
     exeflags = params[:exeflags]
+    bind_to = manager.restrict ? `127.0.0.1` : `$(LPROC.bind_addr)`
 
     for i in 1:manager.np
         io, pobj = open(pipeline(detach(
-                setenv(`$(julia_cmd(exename)) $exeflags --bind-to $(LPROC.bind_addr) --worker`, dir=dir)),
+                setenv(`$(julia_cmd(exename)) $exeflags --bind-to $bind_to --worker $(cluster_cookie())`, dir=dir)),
             stderr=STDERR), "r")
         wconfig = WorkerConfig()
         wconfig.process = pobj
@@ -331,15 +333,7 @@ function connect_w2w(pid::Int, config::WorkerConfig)
     (rhost, rport) = get(config.connect_at)
     config.host = rhost
     config.port = rport
-    if get(get(config.environ), :self_is_local, false) && get(get(config.environ), :r_is_local, false)
-        # If on localhost, use the loopback address - this addresses
-        # the special case of system suspend wherein the local ip
-        # may be changed upon system awake.
-        (s, bind_addr) = connect_to_worker("127.0.0.1", rport)
-    else
-        (s, bind_addr)= connect_to_worker(rhost, rport)
-    end
-
+    (s, bind_addr) = connect_to_worker(rhost, rport)
     (s,s)
 end
 
@@ -375,24 +369,16 @@ function socket_reuse_port()
 end
 
 function connect_to_worker(host::AbstractString, port::Integer)
-    # Connect to the loopback port if requested host has the same ipaddress as self.
     s = socket_reuse_port()
-    if host == string(LPROC.bind_addr)
-        s = connect(s, "127.0.0.1", UInt16(port))
-    else
-        s = connect(s, host, UInt16(port))
-    end
+    connect(s, host, UInt16(port))
 
     # Avoid calling getaddrinfo if possible - involves a DNS lookup
     # host may be a stringified ipv4 / ipv6 address or a dns name
-    if host == "localhost"
-        bind_addr = "127.0.0.1"
-    else
-        try
-            bind_addr = string(parse(IPAddr,host))
-        catch
-            bind_addr = string(getaddrinfo(host))
-        end
+    bind_addr = nothing
+    try
+        bind_addr = string(parse(IPAddr,host))
+    catch
+        bind_addr = string(getaddrinfo(host))
     end
     (s, bind_addr)
 end

--- a/base/options.jl
+++ b/base/options.jl
@@ -25,7 +25,7 @@ immutable JLOptions
     depwarn::Int8
     can_inline::Int8
     fast_math::Int8
-    worker::Int8
+    worker::Ptr{UInt8}
     handle_signals::Int8
     use_precompiled::Int8
     use_compilecache::Int8

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -743,8 +743,8 @@ end
 
 ## Utility functions
 
-function listenany(default_port)
-    addr = InetAddr(IPv4(UInt32(0)),default_port)
+function listenany(host::IPAddr, default_port)
+    addr = InetAddr(host, default_port)
     while true
         sock = TCPServer()
         if bind(sock,addr) && _listen(sock) == 0
@@ -757,6 +757,7 @@ function listenany(default_port)
         end
     end
 end
+listenany(default_port) = listenany(IPv4(UInt32(0)),default_port)
 
 function getsockname(sock::Union{TCPServer,TCPSocket})
     rport = Ref{Cushort}(0)

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -535,6 +535,12 @@ General Parallel Computing Support
 
    A low-level API which given a ``IO`` connection, returns the pid of the worker it is connected to. This is useful when writing custom ``serialize`` methods for a type, which optimizes the data written out depending on the receiving process id.
 
+.. function:: Base.cluster_cookie([cookie]) -> cookie
+
+   .. Docstring generated from Julia source
+
+   Returns the cluster cookie. If a cookie is passed, also sets it as the cluster cookie.
+
 Shared Arrays
 -------------
 

--- a/examples/clustermanager/0mq/ZMQCM.jl
+++ b/examples/clustermanager/0mq/ZMQCM.jl
@@ -197,7 +197,7 @@ end
 function launch(manager::ZMQCMan, params::Dict, launched::Array, c::Condition)
     #println("launch $(params[:np])")
     for i in 1:params[:np]
-        io, pobj = open(`julia worker.jl $i`, "r")
+        io, pobj = open(`julia worker.jl $i $(Base.cluster_cookie())`, "r")
 
         wconfig = WorkerConfig()
         wconfig.userdata = Dict(:zid=>i, :io=>io)
@@ -228,9 +228,9 @@ function connect(manager::ZMQCMan, pid::Int, config::WorkerConfig)
 end
 
 # WORKER
-function start_worker(zid)
+function start_worker(zid, cookie)
     #println("start_worker")
-    Base.init_worker(ZMQCMan())
+    Base.init_worker(cookie, ZMQCMan())
     init_node(zid)
 
     while true

--- a/examples/clustermanager/0mq/worker.jl
+++ b/examples/clustermanager/0mq/worker.jl
@@ -2,4 +2,4 @@
 
 include("ZMQCM.jl")
 
-start_worker(parse(Int,ARGS[1]))
+start_worker(parse(Int,ARGS[1]), ARGS[2])

--- a/examples/clustermanager/simple/UnixDomainCM.jl
+++ b/examples/clustermanager/simple/UnixDomainCM.jl
@@ -8,10 +8,11 @@ end
 
 function launch(manager::UnixDomainCM, params::Dict, launched::Array, c::Condition)
 #    println("launch $(manager.np)")
+    cookie = Base.cluster_cookie()
     for i in 1:manager.np
         sockname = tempname()
         try
-            cmd = `$(params[:exename]) $(@__FILE__) udwrkr $sockname`
+            cmd = `$(params[:exename]) $(@__FILE__) udwrkr $sockname $cookie`
             io, pobj = open(cmd, "r")
 
             wconfig = WorkerConfig()
@@ -58,8 +59,8 @@ function connect(manager::UnixDomainCM, pid::Int, config::WorkerConfig)
 end
 
 # WORKER
-function start_worker(sockname)
-    Base.init_worker(UnixDomainCM(0))
+function start_worker(sockname, cookie)
+    Base.init_worker(cookie, UnixDomainCM(0))
 
     srvr = listen(ascii(sockname))
     while true
@@ -87,5 +88,5 @@ end
 
 if (length(ARGS) > 0) && (ARGS[1] == "udwrkr")
     # script has been launched as a worker
-    start_worker(ARGS[2])
+    start_worker(ARGS[2], ARGS[3])
 end

--- a/src/julia.h
+++ b/src/julia.h
@@ -1669,7 +1669,7 @@ typedef struct {
     int8_t depwarn;
     int8_t can_inline;
     int8_t fast_math;
-    int8_t worker;
+    const char *worker;
     int8_t handle_signals;
     int8_t use_precompiled;
     int8_t use_compilecache;

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -41,7 +41,7 @@ function Base.launch(manager::TopoTestManager, params::Dict, launched::Array, c:
 
     for i in 1:manager.np
         io, pobj = open(pipeline(detach(
-            setenv(`$(Base.julia_cmd(exename)) $exeflags --bind-to $(Base.LPROC.bind_addr) --worker`, dir=dir)); stderr=STDERR), "r")
+            setenv(`$(Base.julia_cmd(exename)) $exeflags --bind-to $(Base.LPROC.bind_addr) --worker $(Base.cluster_cookie())`, dir=dir)); stderr=STDERR), "r")
         wconfig = WorkerConfig()
         wconfig.process = pobj
         wconfig.io = io

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -169,7 +169,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "math-mode",       required_argument, 0, opt_math_mode },
         { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
-        { "worker",          no_argument,       0, opt_worker },
+        { "worker",          required_argument, 0, opt_worker },
         { "bind-to",         required_argument, 0, opt_bind_to },
         { "lisp",            no_argument,       &lisp_prompt, 1 },
         { 0, 0, 0, 0 }
@@ -435,7 +435,7 @@ restart_switch:
                 jl_errorf("julia: invalid argument to --math-mode (%s)", optarg);
             break;
         case opt_worker:
-            jl_options.worker = 1;
+            jl_options.worker = strdup(optarg);
             break;
         case opt_bind_to:
             jl_options.bindto = strdup(optarg);


### PR DESCRIPTION
This PR does the following:
- `addprocs` restricts socket bindings to `127.0.0.1`, the default ip or a specified `bind-to` address. Currently we listen on all interfaces.
- `addprocs(N)` by default binds only to `127.0.0.1`. 
- `addprocs(N); addprocs(["some_host"])` will no longer work.
- `addprocs(N; restrict=false); addprocs(["some_host"])` is the alternative for adding local workers and then adding workers from a remote host.
- `SSHManager` now binds only to the specified ip or to the first interface ip returned by `getipaddr`.
- A cluster now has a "cookie" which is shared by all processes. The master generates a random string, which is then passed to the workers via startup parameter `--worker <cookie>`.
- All incoming socket connections are validated by ensuring that the first message received has the cluster cookie.

This PR addresses basic hygiene by avoiding unnecessary socket bindings and testing for connections. Full fledged security requirements are best addressed through a custom ClusterManager.

Doc updates are pending. 
