### PR TITLE
Replace headers with bold in generated docs.

### DIFF
--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -156,7 +156,7 @@ function getdoc(state::State, file::AbstractString, input::Vector)
         # Push the rst text for the docstring into the output.
         mod, (binding, typesig), docstr = state.validdocs[signature]
         md  = Markdown.MD(Base.Docs.parsedoc(docstr).content[2:end])
-        rst = Base.Markdown.rst(md)
+        rst = Base.Markdown.rst(dropheaders(md))
         push!(output, "   .. Docstring generated from Julia source", "")
         for line in split(rst, '\n')
             line = isempty(line) ? "" : string(" "^3, line)
@@ -176,6 +176,11 @@ function getdoc(state::State, file::AbstractString, input::Vector)
     end
     return output
 end
+
+# Replace headers in docs with bold since Sphinx does not allow headers inside docstrings.
+dropheaders(md) = Markdown.MD(map(bold, md.content))
+bold(x::Markdown.Header) = Markdown.Paragraph(Markdown.Bold(x.text))
+bold(other) = other
 
 # Utilities.
 

--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -551,9 +551,7 @@ Periods
 
    Due to the canonicalization, ``CompoundPeriod`` is also useful for converting time periods into more human-comprehensible forms.
 
-   Examples
-   ********
-
+   **Examples**
 
    .. code-block:: julia
 


### PR DESCRIPTION
This replaces all headers within docstrings with bold font when generating the standard lib docs. This does not affect the rendering of docs within the REPL.

Fixes #16296.
