### PR TITLE
close #8269: grow arrays incrementally by factors of 1.5 rather than 2

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -897,11 +897,12 @@ STATIC_INLINE void jl_array_grow_at_end(jl_array_t *a, size_t idx,
     if (__unlikely(reqmaxsize > a->maxsize)) {
         size_t nb1 = idx * elsz;
         size_t nbinc = inc * elsz;
-        // if the requested size is more than 2x current maxsize, grow exactly
-        // otherwise double the maxsize
-        size_t newmaxsize = reqmaxsize >= a->maxsize * 2
+        // if the requested size is more than 1.5x current maxsize, grow exactly
+        // otherwise use 1.5x the maxsize
+        size_t growmaxsize = (a->maxsize*3)>>1;
+        size_t newmaxsize = reqmaxsize >= growmaxsize
                           ? (reqmaxsize < 4 ? 4 : reqmaxsize)
-                          : a->maxsize * 2;
+                          : growmaxsize;
         newmaxsize = limit_overallocation(a, n, newmaxsize, inc);
         size_t oldmaxsize = a->maxsize;
         int newbuf = array_resize_buffer(a, newmaxsize);


### PR DESCRIPTION
As discussed in #8269, many authors seem to consider this to be a good idea.  The patch seems trivial.

I tried a quick benchmark, and the performance ~~difference was barely measurable (if anything, a 1% slowdown)~~ (whoops, screwed up the patch) was **_3–15% faster**_ after this patch.

``` jl
function grow(n)
    a = Int[]
    for i = 1:n
        push!(a, i)
    end
    return a
end
@time grow(10^8);
```

It's apparently faster in both theory and practice, and wastes less memory.  Seems worthwhile.
