### PR TITLE
LibGit2 `credentials` callback overhaul

### DIFF
--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -27,75 +27,159 @@ end
 """Credentials callback function
 
 Function provides different credential acquisition functionality w.r.t. a connection protocol.
-If payload is provided then `payload_ptr` should contain `LibGit2.AbstractPayload` object.
+If payload is provided then `payload_ptr` should contain `LibGit2.AbstractCredentials` object.
 
-For `LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT` type, if payload contains fields: `user` & `pass` they are used to create authentication credentials.
-In addition, if payload has field `used` it can be set to `true` to indicate that payload was used and abort callback with error. This behavior is required to avoid repeated authentication calls with incorrect credentials.
+For `LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT` type, if payload contains fields:
+`user` & `pass`, they are used to create authentication credentials.
+Empty `user` name and `pass`word trigger authentication error.
+
+For `LibGit2.Consts.CREDTYPE_SSH_KEY` type, if payload contains fields:
+`user`, `prvkey`, `pubkey` & `pass`, they are used to create authentication credentials.
+Empty `user` name triggers authentication error.
+
+Order of credential checks (if supported):
+- ssh key pair (ssh-agent if specified in payload's `usesshagent` field)
+- plain text
+
+**Note**: Due to the specifics of `libgit2` authentication procedure, when authentication fails,
+this function is called again without any indication whether authentication was successful or not.
+To avoid an infinite loop from repeatedly using the same faulty credentials,
+`checkused!` function can be called to test if credentials were used if call returns `true` value.
+Used credentials trigger user prompt for (re)entering required information.
+`UserPasswordCredentials` and `CachedCredentials` are implemented using a call counting strategy
+that prevents repeated usage of faulty credentials.
 """
 function credentials_callback(cred::Ptr{Ptr{Void}}, url_ptr::Cstring,
                               username_ptr::Cstring,
                               allowed_types::Cuint, payload_ptr::Ptr{Void})
-    err = 1
+    err = 0
     url = String(url_ptr)
 
-    if isset(allowed_types, Cuint(Consts.CREDTYPE_USERPASS_PLAINTEXT))
-        username = userpass = ""
-        if payload_ptr != C_NULL
-            payload = unsafe_pointer_to_objref(payload_ptr)
-            if isa(payload, AbstractPayload)
-                isused(payload) && return Cint(-1)
-                username = user(payload)
-                userpass = password(payload)
-                setused!(payload, true)
+    # parse url for schema and host
+    urlparts = match(urlmatcher, url)
+    schema = urlparts.captures[1]
+    host = urlparts.captures[5]
+    schema = schema === nothing ? "" : schema*"://"
+
+    # get credentials object from payload pointer
+    creds = EmptyCredentials()
+    if payload_ptr != C_NULL
+        tmpobj = unsafe_pointer_to_objref(payload_ptr)
+        if isa(tmpobj, AbstractCredentials)
+            creds = tmpobj
+        end
+    end
+    isusedcreds = checkused!(creds)
+
+    # use ssh key or ssh-agent
+    if isset(allowed_types, Cuint(Consts.CREDTYPE_SSH_KEY))
+        credid = "ssh://$host"
+
+        # set ssh-agent trigger for first use
+        if creds[:usesshagent, credid] === nothing
+            creds[:usesshagent, credid] = "Y"
+        end
+
+        # first try ssh-agent if credentials support its usage
+        if creds[:usesshagent, credid] == "Y"
+            err = ccall((:git_cred_ssh_key_from_agent, :libgit2), Cint,
+                         (Ptr{Ptr{Void}}, Cstring), cred, username_ptr)
+            creds[:usesshagent, credid] = "U" # used ssh-agent only one time
+            err == 0 && return Cint(0)
+        end
+
+        errcls, errmsg = Error.last_error()
+        if errcls != Error.None
+            # Check if we used ssh-agent
+            if creds[:usesshagent, credid] == "U"
+                println("ERROR: $errmsg ssh-agent")
+                creds[:usesshagent, credid] = "E" # reported ssh-agent error
+            else
+                println("ERROR: $errmsg")
             end
+            flush(STDOUT)
         end
-        if isempty(username)
-            username = prompt("Username for '$url'")
-        end
-        if isempty(userpass)
-            userpass = prompt("Password for '$username@$url'", password=true)
-        end
-
-        isempty(username) && isempty(userpass) && return Cint(-1)
-
-        err = ccall((:git_cred_userpass_plaintext_new, :libgit2), Cint,
-                     (Ptr{Ptr{Void}}, Cstring, Cstring),
-                     cred, username, userpass)
-        err == 0 && return Cint(0)
-    elseif isset(allowed_types, Cuint(Consts.CREDTYPE_SSH_KEY)) && err > 0
-        # use ssh-agent
-        err = ccall((:git_cred_ssh_key_from_agent, :libgit2), Cint,
-                     (Ptr{Ptr{Void}}, Cstring), cred, username_ptr)
-        err == 0 && return Cint(0)
-    elseif isset(allowed_types, Cuint(Consts.CREDTYPE_SSH_CUSTOM)) && err > 0
-        # for SSH we need key info, look for environment vars SSH_* as well
 
         # if username is not provided, then prompt for it
-        username = if username_ptr == Cstring_NULL
-            prompt("Username for '$url'")
+        username = if username_ptr == Cstring(C_NULL)
+            uname = creds[:user, credid] # check if credentials were already used
+            uname !== nothing && !isusedcreds ? uname : prompt("Username for '$schema$host'")
         else
             String(username_ptr)
         end
+        creds[:user, credid] = username # save credentials
 
-        publickey = if "SSH_PUB_KEY" in keys(ENV)
-            ENV["GITHUB_PUB_KEY"]
+        # For SSH we need a private key location
+        privatekey = if haskey(ENV,"SSH_KEY_PATH")
+            ENV["SSH_KEY_PATH"]
         else
-            keydef = homedir()*"/.ssh/id_rsa.pub"
-            prompt("Public key location", default=keydef)
+            keydefpath = creds[:prvkey, credid] # check if credentials were already used
+            if keydefpath !== nothing && !isusedcreds
+                keydefpath # use cached value
+            else
+                keydefpath = if keydefpath === nothing
+                    homedir()*"/.ssh/id_rsa"
+                end
+                prompt("Private key location for '$schema$username@$host'", default=keydefpath)
+            end
         end
+        creds[:prvkey, credid] = privatekey # save credentials
 
-        privatekey = if "SSH_PRV_KEY" in keys(ENV)
-            ENV["GITHUB_PRV_KEY"]
+        # For SSH we need a public key location, look for environment vars SSH_* as well
+        publickey = if haskey(ENV,"SSH_PUB_KEY_PATH")
+            ENV["SSH_PUB_KEY_PATH"]
         else
-            keydef = homedir()*"/.ssh/id_rsa"
-            prompt("Private key location", default=keydef)
+            keydefpath = creds[:pubkey, credid] # check if credentials were already used
+            if keydefpath !== nothing && !isusedcreds
+                keydefpath # use cached value
+            else
+                keydefpath = if keydefpath === nothing
+                    privatekey*".pub"
+                end
+                if isfile(keydefpath)
+                    keydefpath
+                else
+                    prompt("Public key location for '$schema$username@$host'", default=keydefpath)
+                end
+            end
         end
+        creds[:pubkey, credid] = publickey # save credentials
 
-        passphrase= get(ENV,"SSH_PRV_KEY_PASS","0") == "0" ? "" : prompt("Private key passphrase", password=true)
+        passphrase = if haskey(ENV,"SSH_KEY_PASS")
+            ENV["SSH_KEY_PASS"]
+        else
+            passdef = creds[:pass, credid] # check if credentials were already used
+            passdef !== nothing && !isusedcreds ? passdef : prompt("Passphrase for $privatekey", password=true)
+        end
+        creds[:pass, credid] = passphrase # save credentials
+
+        isempty(username) && return Cint(Error.EAUTH)
 
         err = ccall((:git_cred_ssh_key_new, :libgit2), Cint,
                      (Ptr{Ptr{Void}}, Cstring, Cstring, Cstring, Cstring),
                      cred, username, publickey, privatekey, passphrase)
+        err == 0 && return Cint(0)
+    end
+
+    if isset(allowed_types, Cuint(Consts.CREDTYPE_USERPASS_PLAINTEXT))
+        credid = "$schema$host"
+        username = creds[:user, credid]
+        if username === nothing || isusedcreds
+            username = prompt("Username for '$schema$host'")
+            creds[:user, credid] = username # save credentials
+        end
+
+        userpass = creds[:pass, credid]
+        if userpass === nothing || isusedcreds
+            userpass = prompt("Password for '$schema$username@$host'", password=true)
+            creds[:pass, credid] = userpass # save credentials
+        end
+
+        isempty(username) && isempty(userpass) && return Cint(Error.EAUTH)
+
+        err = ccall((:git_cred_userpass_plaintext_new, :libgit2), Cint,
+                     (Ptr{Ptr{Void}}, Cstring, Cstring),
+                     cred, username, userpass)
         err == 0 && return Cint(0)
     end
 

--- a/base/libgit2/consts.jl
+++ b/base/libgit2/consts.jl
@@ -274,6 +274,11 @@ Option flags for `GitRepo`.
                         CREDTYPE_USERNAME           = Cuint(1 << 5),
                         CREDTYPE_SSH_MEMORY         = Cuint(1 << 6))
 
+    @enum(GIT_FEATURE, FEATURE_THREADS = Cuint(1 << 0),
+                       FEATURE_HTTPS   = Cuint(1 << 1),
+                       FEATURE_SSH     = Cuint(1 << 2),
+                       FEATURE_NSEC    = Cuint(1 << 3))
+
 if LibGit2.version() >= v"0.24.0"
     """
 Priority level of a config file.

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+const urlmatcher = r"^(http[s]?|git|ssh)?(:\/\/)?((\w+)@)?([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$"
+
 function version()
     major = Ref{Cint}(0)
     minor = Ref{Cint}(0)
@@ -10,14 +12,25 @@ function version()
 end
 
 isset(val::Integer, flag::Integer) = (val & flag == flag)
+reset(val::Integer, flag::Integer) = (val &= ~flag)
+toggle(val::Integer, flag::Integer) = (val |= flag)
 
 function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)
     msg = !isempty(default) ? msg*" [$default]:" : msg*":"
     uinput = if password
-        String(ccall(:getpass, Cstring, (Cstring,), msg))
+        Base.getpass(msg)
     else
         print(msg)
         chomp(readline(STDIN))
     end
     isempty(uinput) ? default : uinput
+end
+
+function features()
+    feat = ccall((:git_libgit2_features, :libgit2), Cint, ())
+    res = Consts.GIT_FEATURE[]
+    for f in instances(Consts.GIT_FEATURE)
+        isset(feat, Cuint(f)) && push!(res, f)
+    end
+    return res
 end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -375,6 +375,7 @@ function update(branch::AbstractString)
             push!(deferred_errors, PkgError("Package $pkg: unable to update cache.", cex))
         end
     end
+    creds = LibGit2.CachedCredentials()
     fixed = Read.fixed(avail,instd)
     for (pkg,ver) in fixed
         ispath(pkg,".git") || continue
@@ -386,7 +387,8 @@ function update(branch::AbstractString)
                     prev_sha = string(LibGit2.head_oid(repo))
                     success = true
                     try
-                        LibGit2.fetch(repo)
+                        LibGit2.fetch(repo, payload = Nullable(creds))
+                        LibGit2.reset!(creds)
                         LibGit2.merge!(repo, fastforward=true)
                     catch err
                         cex = CapturedException(err, catch_backtrace())

--- a/base/util.jl
+++ b/base/util.jl
@@ -410,7 +410,7 @@ julia_exename() = ccall(:jl_is_debugbuild,Cint,())==0 ? "julia" : "julia-debug"
                 p[plen += 1] = c
             end
         end
-        return bytestring(pointer(p), plen)
+        return String(pointer(p), plen)
     finally
         fill!(p, 0) # don't leave password in memory
     end
@@ -418,4 +418,4 @@ julia_exename() = ccall(:jl_is_debugbuild,Cint,())==0 ? "julia" : "julia-debug"
     return ""
 end
 
-@unix_only getpass(prompt::AbstractString) = bytestring(ccall(:getpass, Cstring, (Cstring,), prompt))
+@unix_only getpass(prompt::AbstractString) = String(ccall(:getpass, Cstring, (Cstring,), prompt))

--- a/base/util.jl
+++ b/base/util.jl
@@ -390,3 +390,32 @@ function julia_cmd(julia=joinpath(JULIA_HOME, julia_exename()))
 end
 
 julia_exename() = ccall(:jl_is_debugbuild,Cint,())==0 ? "julia" : "julia-debug"
+
+@windows_only function getpass(prompt::AbstractString)
+    print(prompt)
+    flush(STDOUT)
+    p = Array(UInt8, 128) # mimic Unix getpass in ignoring more than 128-char passwords
+                          # (also avoids any potential memory copies arising from push!)
+    try
+        plen = 0
+        while true
+            c = ccall(:_getch, UInt8, ())
+            if c == 0xff || c == UInt8('\n') || c == UInt8('\r')
+                break # EOF or return
+            elseif c == 0x00 || c == 0xe0
+                ccall(:_getch, UInt8, ()) # ignore function/arrow keys
+            elseif c == UInt8('\b') && plen > 0
+                plen -= 1 # delete last character on backspace
+            elseif !iscntrl(Char(c)) && plen < 128
+                p[plen += 1] = c
+            end
+        end
+        return bytestring(pointer(p), plen)
+    finally
+        fill!(p, 0) # don't leave password in memory
+    end
+
+    return ""
+end
+
+@unix_only getpass(prompt::AbstractString) = bytestring(ccall(:getpass, Cstring, (Cstring,), prompt))

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -21,22 +21,30 @@ mktempdir() do dir
                 finalize(repo)
             end
         #end
+
         #@testset "with incorrect url" begin
-            repo_path = joinpath(dir, "Example2")
-            # credential are required because github try authenticate on uknown repo
-            x = Nullable(LibGit2.UserPasswordCredentials("X","X"))
-            @test_throws LibGit2.Error.GitError LibGit2.clone(https_prefix*repo_url*randstring(10), repo_path, payload=x)
+            try
+                repo_path = joinpath(dir, "Example2")
+                # credentials are required because github tries to authenticate on unknown repo
+                cred = LibGit2.UserPasswordCredentials("","") # empty credentials cause authentication error
+                LibGit2.clone(https_prefix*repo_url*randstring(10), repo_path, payload=Nullable(cred))
+                error("unexpected")
+            catch ex
+                @test isa(ex, LibGit2.Error.GitError)
+                @test ex.code == LibGit2.Error.EAUTH
+            end
         #end
 
-        try
-            #@testset "with 'ssh' protocol (by default is not supported)" begin
+        #TODO: remove or condition on libgit2 features this test when ssh protocol will be supported
+        #@testset "with 'ssh' protocol (by default is not supported)" begin
+            try
                 repo_path = joinpath(dir, "Example3")
                 @test_throws LibGit2.Error.GitError LibGit2.clone(ssh_prefix*repo_url, repo_path)
-            #end
-        catch ex
-            # but we cloned succesfully, so check that repo was created
-            ex.fail == 1 && @test isdir(joinpath(path, ".git"))
-        end
+            catch ex
+                # but we cloned succesfully, so check that repo was created
+                ex.fail == 1 && @test isdir(joinpath(path, ".git"))
+            end
+        #end
     #end
 end
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -459,6 +459,57 @@ mktempdir() do dir
             finalize(repo)
         end
     #end
+
+    #@testset "Credentials" begin
+        creds = LibGit2.EmptyCredentials()
+        @test LibGit2.checkused!(creds)
+        @test LibGit2.reset!(creds) === nothing
+        @test creds[:user] === nothing
+        @test creds[:pass] === nothing
+        @test creds[:pubkey, "localhost"] === nothing
+
+        creds_user = "USER"
+        creds_pass = "PASS"
+        creds = LibGit2.UserPasswordCredentials(creds_user, creds_pass)
+        @test !LibGit2.checkused!(creds)
+        @test !LibGit2.checkused!(creds)
+        @test !LibGit2.checkused!(creds)
+        @test LibGit2.checkused!(creds)
+        @test LibGit2.reset!(creds) == 3
+        @test !LibGit2.checkused!(creds)
+        @test creds.count == 2
+        @test creds[:user] == creds_user
+        @test creds[:pass] == creds_pass
+        @test creds[:pubkey] === nothing
+        @test creds[:user, "localhost"] == creds_user
+        @test creds[:pubkey, "localhost"] === nothing
+        @test creds[:usesshagent, "localhost"] == "Y"
+        creds[:usesshagent, "localhost"] = "E"
+        @test creds[:usesshagent, "localhost"] == "E"
+
+        creds = LibGit2.CachedCredentials()
+        @test !LibGit2.checkused!(creds)
+        @test !LibGit2.checkused!(creds)
+        @test !LibGit2.checkused!(creds)
+        @test LibGit2.checkused!(creds)
+        @test LibGit2.reset!(creds) == 3
+        @test !LibGit2.checkused!(creds)
+        @test creds.count == 2
+        @test creds[:user, "localhost"] === nothing
+        @test creds[:pass, "localhost"] === nothing
+        @test creds[:pubkey, "localhost"] === nothing
+        @test creds[:prvkey, "localhost"] === nothing
+        @test creds[:usesshagent, "localhost"] === nothing
+        creds[:user, "localhost"] = creds_user
+        creds[:pass, "localhost"] = creds_pass
+        creds[:usesshagent, "localhost"] = "Y"
+        @test creds[:user] === nothing
+        @test creds[:user, "localhost2"] === nothing
+        @test creds[:user, "localhost"] == creds_user
+        @test creds[:pass, "localhost"] == creds_pass
+        @test creds[:pubkey, "localhost"] === nothing
+        @test creds[:usesshagent, "localhost"] == "Y"
+    #end
 end
 
 #end


### PR DESCRIPTION
Update of the LibGit2 `credentials` callback:
- handle https & ssh connections
- new credential types
- caching support
- `getpass` version for Windows [#8228]

I added a credentials caching to `Pkg.update` which should be helpful when ssh support will arrive,  #16041.
