### PR TITLE
Use inlineasm as signal fence on ARM and AArch64

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -102,6 +102,9 @@
 #include <llvm/ExecutionEngine/JITMemoryManager.h>
 #include <llvm/ExecutionEngine/Interpreter.h>
 #endif
+#if defined(_CPU_ARM_) || defined(_CPU_AARCH64_)
+#  include <llvm/IR/InlineAsm.h>
+#endif
 
 using namespace llvm;
 


### PR DESCRIPTION
In order to work around LLVM bug.

LLVM currently emit a thread fence instead of a signal fence on ARM and AArch64.
This is extremely inefficient and adds dependency of `__sync_*` functions.

The inline asm is not supported by the old JIT, which is not supported on ARM anyway....
