### PR TITLE
make setindex with colon fall back to fill!

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -383,6 +383,9 @@ function setindex!{T}(A::Array{T}, X::Array{T}, c::Colon)
     return A
 end
 
+setindex!(A::Array, x::Number, ::Colon) = fill!(A, x)
+setindex!{T, N}(A::Array{T, N}, x::Number, ::Vararg{Colon, N}) = fill!(A, x)
+
 # efficiently grow an array
 
 function _growat!(a::Vector, i::Integer, delta::Integer)


### PR DESCRIPTION
Update to #13459. Fixes #16302 for `Arrays`. @mbauman mentioned in https://github.com/JuliaLang/julia/pull/13459#issuecomment-218308064 that this could be extended to `AbstractArray` but that it has the extra complication of dealing with the vararg call.

For now, this at least improves the situation for `Arrays` as compared to the results in #16302.

``` jl
julia> function foo(A)
           for i = 1:10^6
               A[:] = 0
           end
       end
foo (generic function with 1 method)

julia> @time foo([3,4,5])
  0.005799 seconds (5 allocations: 272 bytes)
```

cc @stevengj 
