### PR TITLE
RFC: nextprime(::BigInt)

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -8561,6 +8561,14 @@ true
 isprime(::BigInt, ?)
 
 """
+    nextprime(x::BigInt) -> BigInt
+
+
+Find the next prime number greater than `x`. Uses a probabilistic algorithm to identify primes.
+"""
+nextprime(::BigInt)
+
+"""
     >(x, y)
 
 Greater-than comparison operator. Generally, new types should implement `<` instead of this

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -407,6 +407,7 @@ export
     nextfloat,
     nextpow,
     nextpow2,
+    nextprime,
     nextprod,
     num,
     num2hex,

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -2,7 +2,7 @@
 
 module GMP
 
-export BigInt
+export BigInt, nextprime
 
 import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), ($),
              binomial, cmp, convert, div, divrem, factorial, fld, gcd, gcdx, lcm, mod,
@@ -542,6 +542,12 @@ end
 ndigits(x::BigInt, b::Integer=10) = x.size == 0 ? 1 : ndigits0z(x,b)
 
 isprime(x::BigInt, reps=25) = ccall((:__gmpz_probab_prime_p,:libgmp), Cint, (Ptr{BigInt}, Cint), &x, reps) > 0
+
+function nextprime(y::BigInt)
+    x = BigInt()
+    ccall((:__gmpz_nextprime,:libgmp), Void, (Ptr{BigInt},Ptr{BigInt}), &x, &y)
+    x
+end
 
 prevpow2(x::BigInt) = x.size < 0 ? -prevpow2(-x) : (x <= 2 ? x : one(BigInt) << (ndigits(x, 2)-1))
 nextpow2(x::BigInt) = x.size < 0 ? -nextpow2(-x) : (x <= 2 ? x : one(BigInt) << ndigits(x-1, 2))

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -223,6 +223,7 @@ g = parse(BigInt,"-1")
 @test isprime(parse(BigInt,"359334085968622831041960188598043661065388726959079837"))
 @test !isprime(BigInt(1))
 @test !isprime(BigInt(10000000020))
+@test nextprime(big(1000000007)) == 1000000009
 
 @test trailing_ones(a) == 8
 @test trailing_zeros(b) == 2


### PR DESCRIPTION
On StackExchange someone asked for a wrapper of the GMP next_prime routine. If there is interest, here is a pull request for a new function nextprime.  But compared with the naive 

```
nextprime2(y) = let x = y+1; while(!isprime(x)) x += 1; end; x; end
```

I get

```
x = big(1931)*prod(big(primes(1,1933)))÷7230 - 30244 #location of a big prime gap of size 66520
julia> @time nextprime2(x) - x
 33.357414 seconds (199.57 k allocations: 25.378 MB, 0.02% gc time)
66520

julia> @time nextprime(x) - x
 49.900821 seconds (11 allocations: 3.398 KB)
66520
```

Am I missing something or is `__gmpz_nextprime` worse than __gmpz_probab_prime_p (both use 25 reps standard)?

@pabloferz 
