### PR TITLE
Fixed `LibGit2.PushOptions` for v0.24.0

### DIFF
--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -380,16 +380,32 @@ MergeOptions(; flags::Cint = Cint(0),
                  file_favor,
                  file_flags)
 
-immutable PushOptions
-    version::Cuint
-    parallelism::Cint
-    callbacks::RemoteCallbacks
+if LibGit2.version() >= v"0.24.0"
+    immutable PushOptions
+        version::Cuint
+        parallelism::Cint
+        callbacks::RemoteCallbacks
+        custom_headers::StrArrayStruct
+    end
+    PushOptions(; parallelism::Cint=one(Cint),
+                  callbacks::RemoteCallbacks=RemoteCallbacks(),
+                  custom_headers::StrArrayStruct = StrArrayStruct()) =
+        PushOptions(one(Cuint),
+                    parallelism,
+                    callbacks,
+                    custom_headers)
+else
+    immutable PushOptions
+        version::Cuint
+        parallelism::Cint
+        callbacks::RemoteCallbacks
+    end
+    PushOptions(; parallelism::Cint=one(Cint),
+                  callbacks::RemoteCallbacks=RemoteCallbacks()) =
+        PushOptions(one(Cuint),
+                    parallelism,
+                    callbacks)
 end
-PushOptions(; parallelism::Cint=one(Cint),
-              callbacks::RemoteCallbacks=RemoteCallbacks()) =
-    PushOptions(one(Cuint),
-                parallelism,
-                callbacks)
 
 immutable IndexTime
     seconds::Int64


### PR DESCRIPTION
Added missing `custom_headers` field in `LibGit2.PushOptions` for v0.24.0.
Responsible for `PkgDev.jl` crashes, see issues [#35](https://github.com/JuliaLang/PkgDev.jl/issues/35) & [#40](https://github.com/JuliaLang/PkgDev.jl/issues/40).
