### PR TITLE
Change `llvmcall` docs binding

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -587,7 +587,7 @@ functions for further details). In most cases, this simply results in a call to
 
 See `test/llvmcall.jl` for usage examples.
 """
-kw"llvmcall"
+Core.Intrinsics.llvmcall
 
 """
 `begin...end` denotes a block of code.


### PR DESCRIPTION
The docstring for `llvmcall` was bound to a keyword rather than the actual intrinsic `Core.Intrinsics.llvmcall`.

This produced the following odd behaviour when trying to find the docs:

```
help?> llvmcall

... docs ...

julia> llvmcall
ERROR: UndefVarError: llvmcall not defined

help?> Base.llvmcall

... no docs ...

julia> Base.llvmcall
(intrinsic function #90)
```
