### PR TITLE
Better sizehint for primes

### DIFF
--- a/base/primes.jl
+++ b/base/primes.jl
@@ -78,12 +78,13 @@ primesmask(n::Integer) = n <= typemax(Int) ? primesmask(Int(n)) :
 
 function primes(lo::Int, hi::Int)
     lo ≤ hi || throw(ArgumentError("the condition lo ≤ hi must be met"))
+    lo = max(2, lo) # note: if now lo > hi, then hi < 7
     list = Int[]
     lo ≤ 2 ≤ hi && push!(list, 2)
     lo ≤ 3 ≤ hi && push!(list, 3)
     lo ≤ 5 ≤ hi && push!(list, 5)
     hi < 7 && return list
-    sizehint!(list, floor(Int, hi / log(hi)))
+    sizehint!(list, floor(Int, hi / log(hi) - lo / log(lo)))
     sieve = _primesmask(max(7, lo), hi)
     lwi = wheel_index(lo - 1)
     @inbounds for i = 1:length(sieve)   # don't use eachindex here

--- a/base/primes.jl
+++ b/base/primes.jl
@@ -84,7 +84,7 @@ function primes(lo::Int, hi::Int)
     lo ≤ 3 ≤ hi && push!(list, 3)
     lo ≤ 5 ≤ hi && push!(list, 5)
     hi < 7 && return list
-    sizehint!(list, floor(Int, hi / log(hi) - lo / log(lo)))
+    sizehint!(list,  5 + floor(Int, hi / (log(hi) - 1.12) -  lo / (log(lo) - 1.12*(lo > 7))) ) # http://projecteuclid.org/euclid.rmjm/1181070157
     sieve = _primesmask(max(7, lo), hi)
     lwi = wheel_index(lo - 1)
     @inbounds for i = 1:length(sieve)   # don't use eachindex here

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2253,6 +2253,9 @@ for T in [Int,BigInt], n = [1:1000;1000000]
         @test s[k] == primesmask(k, k)[1]
     end
 end
+let i = rand(1:2^(3*min(WORD_SIZE,64)÷4))
+    @test primes(i,i+1476) == filter(isprime, i:i + 1476) == filter(isprime, big(i:i + 1476))
+end
 
 @test !isprime(1000000003)
 @test !isprime(1000000005)


### PR DESCRIPTION
Better sizehint for `primes(lo,hi)`.

Before it failed for 1 << lo < hi as the sizehint! actually consumed  `hi / log(hi)` memory independent of `lo`, but the needed size is better approximated by  `hi / log(hi) - lo/log(lo)`. Add a test which test `primes` and friends on short intervals with `1 << lo`.
