### PR TITLE
Declare `jl_` in `julia.h`

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -50,8 +50,6 @@ JL_DLLEXPORT jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p, size_t *osiz
 #include <stdio.h>
 #endif
 
-void jl_(void *jl_value);
-
 // mark verification
 #ifdef GC_VERIFY
 static jl_value_t *lostval = 0;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1641,6 +1641,8 @@ JL_DLLEXPORT jl_value_t *jl_stderr_obj(void);
 JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
 JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type);
 JL_DLLEXPORT void jlbacktrace(void);
+// Mainly for debugging, use `void*` so that no type cast is needed in C++.
+JL_DLLEXPORT void jl_(void *jl_value);
 
 // julia options -----------------------------------------------------------
 // NOTE: This struct needs to be kept in sync with JLOptions type in base/options.jl


### PR DESCRIPTION
It's way too annoy having to declare it every time for debugging. (Especially in C++ code where you can't even use without declaration and swallow the warning....).
