### PR TITLE
Fixed incorrect variable name in `LibGit2.upstream`

### DIFF
--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -122,7 +122,7 @@ function lookup_branch(repo::GitRepo,
     if err == Int(Error.ENOTFOUND)
         return nothing
     elseif err != Int(Error.GIT_OK)
-        if repo_ptr_ptr[] != C_NULL
+        if ref_ptr_ptr[] != C_NULL
             finalize(GitReference(ref_ptr_ptr[]))
         end
         throw(Error.GitError(err))
@@ -138,7 +138,7 @@ function upstream(ref::GitReference)
     if err == Int(Error.ENOTFOUND)
         return nothing
     elseif err != Int(Error.GIT_OK)
-        if repo_ptr_ptr[] != C_NULL
+        if ref_ptr_ptr[] != C_NULL
             finalize(GitReference(ref_ptr_ptr[]))
         end
         throw(Error.GitError(err))

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -73,6 +73,13 @@ function isbranch(ref::GitReference)
     return err == 1
 end
 
+function isremote(ref::GitReference)
+    isempty(ref) && return false
+    err = ccall((:git_reference_is_remote, :libgit2), Cint,
+                  (Ptr{Void},), ref.ptr)
+    return err == 1
+end
+
 function peel{T <: GitObject}(::Type{T}, ref::GitReference)
     git_otype = getobjecttype(T)
     obj_ptr_ptr = Ref{Ptr{Void}}(C_NULL)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -79,6 +79,7 @@ mktempdir() do dir
     commit_oid1 = LibGit2.Oid()
     commit_oid2 = LibGit2.Oid()
     commit_oid3 = LibGit2.Oid()
+    master_branch = "master"
     test_branch = "test_branch"
     tag1 = "tag1"
     tag2 = "tag2"
@@ -250,21 +251,30 @@ mktempdir() do dir
                 brref = LibGit2.head(repo)
                 try
                     @test LibGit2.isbranch(brref)
+                    @test !LibGit2.isremote(brref)
                     @test LibGit2.name(brref) == "refs/heads/master"
-                    @test LibGit2.shortname(brref) == "master"
+                    @test LibGit2.shortname(brref) == master_branch
                     @test LibGit2.ishead(brref)
-                    @test LibGit2.upstream(brref) == nothing
+                    @test LibGit2.upstream(brref) === nothing
                     @test repo.ptr == LibGit2.owner(brref).ptr
-                    @test brnch == "master"
-                    @test LibGit2.headname(repo) == "master"
+                    @test brnch == master_branch
+                    @test LibGit2.headname(repo) == master_branch
                     LibGit2.branch!(repo, test_branch, string(commit_oid1), set_head=false)
-                    @test LibGit2.lookup_branch(repo, test_branch, true) == nothing
+
+                    @test LibGit2.lookup_branch(repo, test_branch, true) === nothing
+                    tbref = LibGit2.lookup_branch(repo, test_branch, false)
+                    try
+                        @test LibGit2.shortname(tbref) == test_branch
+                        @test LibGit2.upstream(tbref) === nothing
+                    finally
+                        finalize(tbref)
+                    end
                 finally
                     finalize(brref)
                 end
 
                 branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
-                @test "master" in branches
+                @test master_branch in branches
                 @test test_branch in branches
             finally
                 finalize(repo)
@@ -366,7 +376,7 @@ mktempdir() do dir
             @test_throws LibGit2.Error.GitError LibGit2.merge!(repo, fastforward=true)
 
             # Switch to the master branch
-            LibGit2.branch!(repo, "master")
+            LibGit2.branch!(repo, master_branch)
 
         finally
             finalize(repo)
@@ -388,8 +398,17 @@ mktempdir() do dir
 
                 # all tag in place
                 branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
-                @test "master" in branches
+                @test master_branch in branches
                 @test test_branch in branches
+
+                # issue #16337
+                tag2ref = LibGit2.GitReference(repo, "refs/tags/$tag2")
+                try
+                    @test_throws LibGit2.Error.GitError LibGit2.upstream(tag2ref)
+                finally
+                    finalize(tag2ref)
+                end
+
             finally
                 finalize(repo)
             end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -248,15 +248,20 @@ mktempdir() do dir
             try
                 brnch = LibGit2.branch(repo)
                 brref = LibGit2.head(repo)
-                @test LibGit2.isbranch(brref)
-                @test LibGit2.name(brref) == "refs/heads/master"
-                @test LibGit2.shortname(brref) == "master"
-                @test LibGit2.ishead(brref)
-                @test LibGit2.upstream(brref) == nothing
-                @test repo.ptr == LibGit2.owner(brref).ptr
-                @test brnch == "master"
-                @test LibGit2.headname(repo) == "master"
-                LibGit2.branch!(repo, test_branch, string(commit_oid1), set_head=false)
+                try
+                    @test LibGit2.isbranch(brref)
+                    @test LibGit2.name(brref) == "refs/heads/master"
+                    @test LibGit2.shortname(brref) == "master"
+                    @test LibGit2.ishead(brref)
+                    @test LibGit2.upstream(brref) == nothing
+                    @test repo.ptr == LibGit2.owner(brref).ptr
+                    @test brnch == "master"
+                    @test LibGit2.headname(repo) == "master"
+                    LibGit2.branch!(repo, test_branch, string(commit_oid1), set_head=false)
+                    @test LibGit2.lookup_branch(repo, test_branch, true) == nothing
+                finally
+                    finalize(brref)
+                end
 
                 branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
                 @test "master" in branches


### PR DESCRIPTION
Fixed typos in `LibGit2.lookup_branch` and `LibGit2.upstream`
