### PR TITLE
unroll jl_typemap_intersection_node_visitor more

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1058,7 +1058,7 @@ jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types)
 {
     jl_typemap_entry_t *entry = NULL;
     assert(jl_nparams(types) > 0);
-    if (!jl_is_leaf_type((jl_value_t*)types))
+    if (!jl_is_leaf_type((jl_value_t*)types) || jl_has_typevars((jl_value_t*)types))
         return NULL;
     assert(jl_is_datatype(jl_tparam0(types)));
 

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -9,8 +9,8 @@
 #include <unistd.h>
 #endif
 
-#define MAX_METHLIST_COUNT 32 // this can strongly affect the sysimg size and speed!
-#define INIT_CACHE_SIZE 16 // must be a power-of-two
+#define MAX_METHLIST_COUNT 12 // this can strongly affect the sysimg size and speed!
+#define INIT_CACHE_SIZE 8 // must be a power-of-two
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
this makes the users of typemap-intersection (ambiguity / cache invalidation and ml-lookup) a bit faster by taking better advantage of the tree structure to prune unreachable branches
