### PR TITLE
Fix error on copy of expr with partially undefined Array

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -29,7 +29,13 @@ copy(e::Expr) = (n = Expr(e.head);
 
 # copy parts of an AST that the compiler mutates
 astcopy(x::Expr) = copy(x)
-astcopy(x::Array{Any,1}) = Any[astcopy(a) for a in x]
+function astcopy(x::Array{Any,1})
+    r = Array(Any,length(x))
+    for i in eachindex(x)
+        @inbounds isdefined(x, i) && (r[i] = astcopy(x[i]))
+    end
+    r
+end
 astcopy(x) = x
 
 ==(x::Expr, y::Expr) = x.head === y.head && isequal(x.args, y.args)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4119,3 +4119,10 @@ let a = Any[]
     @test (push!(a,10); f()) - (push!(a,2); f()) == 8
     @test a == [10, 2]
 end
+
+# Copying Exprs that contain arrays with undefiend elements
+# should not error
+let a = Array(Any,1)
+    expr = :(f($a))
+    @test expr !== copy(expr)
+end


### PR DESCRIPTION
Fixes https://github.com/Keno/Gallium.jl/issues/91
