### PR TITLE
Add svdvals for SparseMatrixCSC

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-import Base.LinAlg: checksquare
+import Base.LinAlg: checksquare, svdvals
 
 ## Functions to switch to 0-based indexing to call external sparse solvers
 
@@ -898,6 +898,11 @@ function factorize{Ti}(A::Hermitian{Complex{Float64}, SparseMatrixCSC{Complex{Fl
         isa(e, PosDefException) || rethrow(e)
         return ldltfact(A)
     end
+end
+
+function svdvals(A::SparseMatrixCSC)
+    Asvd, nconv, niter, nmult, resid = svds(A; nsv=min(size(A)...), ritzvec=false)
+    return Asvd[:S]
 end
 
 chol(A::SparseMatrixCSC) = error("Use cholfact() instead of chol() for sparse matrices.")

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1329,6 +1329,12 @@ let
     @test eltype(m) == Int32
 end
 
+let
+    m = sprand(10, 20, 0.1)
+    fm = full(m)
+    @test svdvals(m) ≈ svdvals(fm)
+end
+
 # 16073
 @inferred sprand(1, 1, 1.0)
 @inferred sprand(1, 1, 1.0, rand, Float64)


### PR DESCRIPTION
Now that `_svds` has been refactored, we can have a cute convenient interface for the `svdvals` of a sparse matrix.
