### PR TITLE
Re-DLLEXPORT `jl_read_soname`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5672,8 +5672,6 @@ static inline SmallVector<std::string,10> getTargetFeatures() {
     return attr;
 }
 
-extern "C" void jl_init_debuginfo(void);
-
 extern "C" void jl_init_codegen(void)
 {
     const char *const argv_tailmerge[] = {"", "-enable-tail-merge=0"}; // NOO TOUCHIE; NO TOUCH! See #922
@@ -5692,6 +5690,7 @@ extern "C" void jl_init_codegen(void)
     imaging_mode = jl_generating_output();
 #endif
     jl_init_debuginfo();
+    jl_init_runtime_ccall();
 
 #ifndef LLVM34
     // this option disables LLVM's signal handlers

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -176,7 +176,6 @@ static void *jl_load_dynamic_library_(const char *modname, unsigned flags, int t
                     // Do the no-ext one last if hasext == 1
                     const char *ext = extensions[i + hasext];
                     path[0] = '\0';
-                    handle = NULL;
                     if (dl_path[len-1] == PATHSEPSTRING[0])
                         snprintf(path, PATHBUF, "%s%s%s", dl_path, modname, ext);
                     else
@@ -197,7 +196,6 @@ static void *jl_load_dynamic_library_(const char *modname, unsigned flags, int t
         // Do the no-ext one last if hasext == 1
         const char *ext = extensions[i + hasext];
         path[0] = '\0';
-        handle = NULL;
         snprintf(path, PATHBUF, "%s%s", modname, ext);
         handle = jl_dlopen(path, flags);
         if (handle)
@@ -205,15 +203,10 @@ static void *jl_load_dynamic_library_(const char *modname, unsigned flags, int t
     }
 
 #if defined(__linux__) || defined(__FreeBSD__)
-// check map of versioned libs from "libX" to full soname "libX.so.ver"
-    {
-        const char *soname = jl_lookup_soname(modname, strlen(modname));
-        if (soname) {
-            handle = jl_dlopen(soname, flags);
-            if (handle)
-                goto done;
-        }
-    }
+    // check map of versioned libs from "libX" to full soname "libX.so.ver"
+    handle = jl_dlopen_soname(modname, strlen(modname), flags);
+    if (handle)
+        goto done;
 #endif
 
 notfound:

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -257,6 +257,8 @@ void jl_init_serializer(void);
 void jl_gc_init(void);
 void jl_init_restored_modules(jl_array_t *init_order);
 void jl_init_signal_async(void);
+void jl_init_debuginfo(void);
+void jl_init_runtime_ccall(void);
 
 void _julia_init(JL_IMAGE_SEARCH rel);
 #ifdef COPY_STACKS
@@ -423,6 +425,7 @@ void *jl_get_library(const char *f_lib);
 JL_DLLEXPORT void *jl_load_and_lookup(const char *f_lib, const char *f_name,
                                       void **hnd);
 const char *jl_dlfind_win32(const char *name);
+void *jl_dlopen_soname(const char *pfx, size_t n, unsigned flags);
 
 // libuv wrappers:
 JL_DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);

--- a/test/libdl.jl
+++ b/test/libdl.jl
@@ -171,4 +171,8 @@ let dl = C_NULL
     end
 end
 
+if OS_NAME in (:Linux, :FreeBSD)
+    ccall(:jl_read_sonames, Void, ())
+end
+
 end


### PR DESCRIPTION
This was un`DLLEXPORT`ed in https://github.com/JuliaLang/julia/pull/13485 but it is still necessary for `BinDeps` after new packages are installed. This is causing travis failure for packages that use the package manager providers (e.g. [GSL.jl](https://travis-ci.org/jiahao/GSL.jl/jobs/111071566))

Also make the usage in base thread safe. `jl_lookup_soname` is still not threadsafe but could be made so if necessary (the easiest and non-breaking way would be internalizing it with a symbol, changing the API is also possible).

@vtjnash 
