### PR TITLE
Limit valid syntax for "function call" docstrings

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -663,9 +663,9 @@ end
 
 function docerror(ex)
     txt = """
-    invalid doc expression:
+    cannot document the following expression:
 
-    @doc "..." $(isa(ex, AbstractString) ? repr(ex) : ex)"""
+    $(isa(ex, AbstractString) ? repr(ex) : ex)"""
     if isexpr(ex, :macrocall)
         txt *= "\n\n'$(ex.args[1])' not documentable. See 'Base.@__doc__' docs for details."
     end

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -482,6 +482,16 @@ function objectdoc(str, def, expr, sig = :(Union{}))
     end
 end
 
+function calldoc(str, def)
+    args = def.args[2:end]
+    if isempty(args) || all(validcall, args)
+        objectdoc(str, nothing, def, signature(def))
+    else
+        docerror(def)
+    end
+end
+validcall(x) = isa(x, Symbol) || isexpr(x, [:(::), :..., :kw, :parameters])
+
 function moduledoc(meta, def, def′)
     name  = namify(def′)
     docex = Expr(:call, doc!, bindingexpr(name),
@@ -613,7 +623,7 @@ function docm(meta, ex, define = true)
     #
     isexpr(x, FUNC_HEADS) &&  isexpr(x.args[1], :call) ? objectdoc(meta, def, x, signature(x)) :
     isexpr(x, :function)  && !isexpr(x.args[1], :call) ? objectdoc(meta, def, x) :
-    isexpr(x, :call)                                   ? objectdoc(meta, nothing, x, signature(x)) :
+    isexpr(x, :call)                                   ? calldoc(meta, x) :
 
     # Type definitions.
     #

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -456,6 +456,28 @@ end
 # Issues.
 # =======
 
+# Issue #16359. Error message for invalid doc syntax.
+
+for each in [ # valid syntax
+        :(f()),
+        :(f(x)),
+        :(f(x::Int)),
+        :(f(x...)),
+        :(f(x = 1)),
+        :(f(; x = 1))
+    ]
+    @test Meta.isexpr(Docs.docm("...", each), :block)
+end
+for each in [ # invalid syntax
+        :(f("...")),
+        :(f(1, 2)),
+        :(f(() -> ()))
+    ]
+    result = Docs.docm("...", each)
+    @test Meta.isexpr(result, :call)
+    @test result.args[1] === error
+end
+
 # Issue #15424. Non-markdown docstrings.
 
 module I15424


### PR DESCRIPTION
Restricts allowed syntax for docstrings that use function call syntax, i.e

``` julia
"..."
func(x)
```

Only symbols, type asserts, and keyword args are allowed. Other syntax such as strings, numbers, or `do` blocks will now raise errors.

This should help catch errors such as the one linked to in issue #16359.
