### PR TITLE
Add convert(::Type{Nullable}, x) method

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -9,6 +9,7 @@ Nullable() = Nullable{Union{}}()
 eltype{T}(::Type{Nullable{T}}) = T
 
 convert{T}(::Type{Nullable{T}}, x::Nullable{T}) = x
+convert(   ::Type{Nullable   }, x::Nullable   ) = x
 
 convert{T}(t::Type{Nullable{T}}, x::Any) = convert(t, convert(T, x))
 
@@ -17,6 +18,7 @@ function convert{T}(::Type{Nullable{T}}, x::Nullable)
 end
 
 convert{T}(::Type{Nullable{T}}, x::T) = Nullable{T}(x)
+convert{T}(::Type{Nullable   }, x::T) = Nullable{T}(x)
 
 convert{T}(::Type{Nullable{T}}, ::Void) = Nullable{T}()
 convert(   ::Type{Nullable   }, ::Void) = Nullable{Union{}}()

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -262,5 +262,10 @@ end
 @test isnull(convert(Nullable{Int}, nothing))
 @test isa(convert(Nullable{Int}, nothing), Nullable{Int})
 
+@test convert(Nullable, 1) === Nullable(1)
+@test convert(Nullable, Nullable(1)) === Nullable(1)
+@test isequal(convert(Nullable, "a"), Nullable("a"))
+@test isequal(convert(Nullable, Nullable("a")), Nullable("a"))
+
 # issue #11675
 @test repr(Nullable()) == "Nullable{Union{}}()"


### PR DESCRIPTION
Until now, only convert{T}(::Type{Nullable{T}}, x::T) was supported.
