### PR TITLE
fix #undef access error in randperm(::BigInt)

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -1353,7 +1353,9 @@ function randperm(r::AbstractRNG, n::Integer)
     mask = 3
     @inbounds for i = 2:Int(n)
         j = 1 + rand_lt(r, i, mask)
-        a[i] = a[j]
+        if i != j # a[i] is uninitialized (and could be #undef)
+            a[i] = a[j]
+        end
         a[j] = i
         i == 1+mask && (mask = 2mask + 1)
     end

--- a/test/random.jl
+++ b/test/random.jl
@@ -372,6 +372,7 @@ let mta = MersenneTwister(42), mtb = MersenneTwister(42)
     @test shuffle!(mta,collect(1:10)) == shuffle!(mtb,collect(1:10))
 
     @test randperm(mta,10) == randperm(mtb,10)
+    @test randperm(mta,big(10)) == randperm(mtb,big(10)) # cf. #16376
     @test randperm(0) == []
     @test_throws ErrorException randperm(-1)
 


### PR DESCRIPTION
The following failed most of the time: `randperm(big(10))` because of accessing `#undef` values in an array of `BigInt`. The fix here is the simplest solution and does not seem to slow down the function.
