### PR TITLE
RFC: Remove printing of array elements in BoundsError

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -72,9 +72,14 @@ function showerror(io::IO, ex::BoundsError)
     print(io, "BoundsError")
     if isdefined(ex, :a)
         print(io, ": attempt to access ")
-        writemime(io, MIME"text/plain"(), ex.a)
+        if isa(ex.a, AbstractArray)
+            print(io, summary(ex.a))
+        else
+            writemime(io, MIME"text/plain"(), ex.a)
+        end
         if isdefined(ex, :i)
-            print(io, "\n  at index [")
+            !isa(ex.a, AbstractArray) && print(io, "\n ")
+            print(io, " at index [")
             if isa(ex.i, Range)
                 print(io, ex.i)
             else

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -185,9 +185,9 @@ let undefvar
     @test contains(err_str, "Exponentiation yielding a complex result requires a complex argument")
 
     err_str = @except_str [5,4,3][-2,1] BoundsError
-    @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1}:\n 5\n 4\n 3\n  at index [-2,1]"
+    @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [-2,1]"
     err_str = @except_str [5,4,3][1:5] BoundsError
-    @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1}:\n 5\n 4\n 3\n  at index [1:5]"
+    @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [1:5]"
 
     err_str = @except_str 0::Bool TypeError
     @test err_str == "TypeError: non-boolean ($Int) used in boolean context"


### PR DESCRIPTION
This changes the way `BoundsError` is printed for indexing an `AbstractArrays` out of bounds to be less verbose by not printing the elements of the array.
## Prior Art
### Matlab

``` matlab
>> a = rand(4,1,3);

>> a(5,1,3)
Index exceeds matrix dimensions
```
### Python

``` python
>>> a = np.random.rand(4,1,3)
>>> a[4,0,2]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: index 4 is out of bounds for axis 0 with size 4
```
### Julia

``` julia
julia> a = rand(4,5,3)

julia> a[5,1,3]
ERROR: BoundsError: attempt to access 4×5×3 Array{Float64,3}:
[:, :, 1] =
 0.456963  0.685772  0.52135    0.579532   0.338808 
 0.602841  0.404709  0.0367834  0.661417   0.624859 
 0.323797  0.874132  0.385623   0.0475311  0.887019 
 0.787783  0.293591  0.142013   0.683206   0.0965115

[:, :, 2] =
 0.00639549  0.712747  0.0792785  0.319483   0.0649216
 0.331905    0.820174  0.586466   0.286078   0.663316 
 0.562826    0.550261  0.919584   0.80283    0.0900435
 0.419224    0.594741  0.263056   0.0148166  0.460143 

[:, :, 3] =
 0.47631   0.68042    0.122584  0.333958  0.996547 
 0.109148  0.717857   0.905563  0.706234  0.0196865
 0.674617  0.530712   0.529243  0.639963  0.413288 
 0.895385  0.0492984  0.117677  0.520309  0.565513 
  at index [5,1,3]
 in getindex(::Array{Float64,3}, ::Int64, ::Int64, ::Int64, ::Vararg{Int64,N}) at ./array.jl:311
 in eval(::Module, ::Any) at ./boot.jl:230
```

Personally I usually have problems locating the two important things in this Red Sea; the dimensions of the array, and the index I tried to access. This PR changes the error to simply not print the array elements at all:

``` julia
julia> a[5,1,3]
ERROR: BoundsError: attempt to access 4×5×3 Array{Float64,3} at index [5,1,3]
 in getindex(::Array{Float64,3}, ::Int64, ::Int64, ::Int64, ::Vararg{Int64,N}) at ./array.jl:311
 in eval(::Module, ::Any) at ./boot.jl:226
```
