### PR TITLE
RFC: Fix LibGit2.rebase! (Fixes #16366)

### DIFF
--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -515,10 +515,11 @@ if LibGit2.version() >= v"0.24.0"
         checkout_opts::CheckoutOptions
     end
     RebaseOptions(; quiet::Cint = Cint(1),
+                    inmemory::Cint = Cint(0),
                     rewrite_notes_ref::Cstring = Cstring_NULL,
                     merge_opts::MergeOptions = MergeOptions(),
                     checkout_opts::CheckoutOptions = CheckoutOptions()) =
-        RebaseOptions(one(Cuint), quiet, Cint(0), rewrite_notes_ref, merge_opts, checkout_opts)
+        RebaseOptions(one(Cuint), quiet, inmemory, rewrite_notes_ref, merge_opts, checkout_opts)
 else
     immutable RebaseOptions
         version::Cuint

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -357,28 +357,60 @@ immutable DiffDelta
 end
 DiffDelta() = DiffDelta(Cint(0), UInt32(0), UInt16(0), UInt16(0), DiffFile(), DiffFile())
 
-immutable MergeOptions
-    version::Cuint
-    flags::Cint
-    rename_threshold::Cuint
-    target_limit::Cuint
-    metric::Ptr{Void}
-    file_favor::Cint
-    file_flags::Cuint
+if LibGit2.version() >= v"0.24.0"
+    immutable MergeOptions
+        version::Cuint
+        flags::Cint
+        rename_threshold::Cuint
+        target_limit::Cuint
+        metric::Ptr{Void}
+        recursion_limit::Cuint
+        # default_driver::Cstring  # TODO: to be added in v"0.25.0" (?)
+        file_favor::Cint
+        file_flags::Cuint
+    end
+    MergeOptions(; flags::Cint = Cint(0),
+                   rename_threshold::Cuint = Cuint(50),
+                   target_limit::Cuint = Cuint(200),
+                   metric::Ptr{Void} = C_NULL,
+                   recursion_limit::Cuint = Cuint(0),
+                   # default_driver::Cstring = Cstring_NULL,
+                   file_favor::Cint = Cint(Consts.MERGE_FILE_FAVOR_NORMAL),
+                   file_flags::Cuint = Cuint(Consts.MERGE_FILE_DEFAULT)) =
+        MergeOptions(one(Cuint),
+                     flags,
+                     rename_threshold,
+                     target_limit,
+                     metric,
+                     recursion_limit,
+                     # default_driver,
+                     file_favor,
+                     file_flags)
+else
+    immutable MergeOptions
+        version::Cuint
+        flags::Cint
+        rename_threshold::Cuint
+        target_limit::Cuint
+        metric::Ptr{Void}
+        file_favor::Cint
+        file_flags::Cuint
+    end
+    MergeOptions(; flags::Cint = Cint(0),
+                   rename_threshold::Cuint = Cuint(50),
+                   target_limit::Cuint = Cuint(200),
+                   metric::Ptr{Void} = C_NULL,
+                   file_favor::Cint = Cint(Consts.MERGE_FILE_FAVOR_NORMAL),
+                   file_flags::Cuint = Cuint(Consts.MERGE_FILE_DEFAULT)) =
+        MergeOptions(one(Cuint),
+                     flags,
+                     rename_threshold,
+                     target_limit,
+                     metric,
+                     file_favor,
+                     file_flags)
 end
-MergeOptions(; flags::Cint = Cint(0),
-               rename_threshold::Cuint = Cuint(50),
-               target_limit::Cuint = Cuint(200),
-               metric::Ptr{Void} = C_NULL,
-               file_favor::Cint = Cint(Consts.MERGE_FILE_FAVOR_NORMAL),
-               file_flags::Cuint = Cuint(Consts.MERGE_FILE_DEFAULT)) =
-    MergeOptions(one(Cuint),
-                 flags,
-                 rename_threshold,
-                 target_limit,
-                 metric,
-                 file_favor,
-                 file_flags)
+
 
 if LibGit2.version() >= v"0.24.0"
     immutable PushOptions

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -357,7 +357,8 @@ immutable DiffDelta
 end
 DiffDelta() = DiffDelta(Cint(0), UInt32(0), UInt16(0), UInt16(0), DiffFile(), DiffFile())
 
-if LibGit2.version() >= v"0.24.0"
+# TODO: double check this when libgit2 v0.25.0 is released
+if LibGit2.version() >= v"0.25.0"
     immutable MergeOptions
         version::Cuint
         flags::Cint
@@ -365,7 +366,7 @@ if LibGit2.version() >= v"0.24.0"
         target_limit::Cuint
         metric::Ptr{Void}
         recursion_limit::Cuint
-        # default_driver::Cstring  # TODO: to be added in v"0.25.0" (?)
+        default_driver::Cstring
         file_favor::Cint
         file_flags::Cuint
     end
@@ -374,7 +375,7 @@ if LibGit2.version() >= v"0.24.0"
                    target_limit::Cuint = Cuint(200),
                    metric::Ptr{Void} = C_NULL,
                    recursion_limit::Cuint = Cuint(0),
-                   # default_driver::Cstring = Cstring_NULL,
+                   default_driver::Cstring = Cstring_NULL,
                    file_favor::Cint = Cint(Consts.MERGE_FILE_FAVOR_NORMAL),
                    file_flags::Cuint = Cuint(Consts.MERGE_FILE_DEFAULT)) =
         MergeOptions(one(Cuint),
@@ -383,7 +384,33 @@ if LibGit2.version() >= v"0.24.0"
                      target_limit,
                      metric,
                      recursion_limit,
-                     # default_driver,
+                     default_driver,
+                     file_favor,
+                     file_flags)
+elseif LibGit2.version() >= v"0.24.0"
+    immutable MergeOptions
+        version::Cuint
+        flags::Cint
+        rename_threshold::Cuint
+        target_limit::Cuint
+        metric::Ptr{Void}
+        recursion_limit::Cuint
+        file_favor::Cint
+        file_flags::Cuint
+    end
+    MergeOptions(; flags::Cint = Cint(0),
+                   rename_threshold::Cuint = Cuint(50),
+                   target_limit::Cuint = Cuint(200),
+                   metric::Ptr{Void} = C_NULL,
+                   recursion_limit::Cuint = Cuint(0),
+                   file_favor::Cint = Cint(Consts.MERGE_FILE_FAVOR_NORMAL),
+                   file_flags::Cuint = Cuint(Consts.MERGE_FILE_DEFAULT)) =
+        MergeOptions(one(Cuint),
+                     flags,
+                     rename_threshold,
+                     target_limit,
+                     metric,
+                     recursion_limit,
                      file_favor,
                      file_flags)
 else

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -375,6 +375,14 @@ mktempdir() do dir
             LibGit2.branch!(repo, test_branch)
             @test_throws LibGit2.Error.GitError LibGit2.merge!(repo, fastforward=true)
 
+            # Set the username and email for the test_repo (needed for rebase)
+            cfg = LibGit2.GitConfig(repo)
+            LibGit2.set!(cfg, "user.name", "AAAA")
+            LibGit2.set!(cfg, "user.email", "BBBB@BBBB.COM")
+
+            # Try rebasing on master instead
+            LibGit2.rebase!(repo, master_branch)
+
             # Switch to the master branch
             LibGit2.branch!(repo, master_branch)
 


### PR DESCRIPTION
Right now, `LibGit2.rebase!` gives

``` julia
julia> LibGit2.rebase!(repo, "master")
ERROR: GitError(Code:ERROR, Class:Invalid, Invalid version 0 on git_checkout_options)
 [inlined code] from ./libgit2/error.jl:98
 in #GitRebase#73(::Nullable{Base.LibGit2.GitAnnotated}, ::Base.LibGit2.RebaseOptions, ::Type{T}, ::Base.LibGit2.GitRepo, ::Base.LibGit2.GitAnnotated, ::Base.LibGit2.GitAnnotated) at ./libgit2/rebase.jl:7
 in (::Base.LibGit2.##120#122{Base.LibGit2.GitRepo,String})(::Base.LibGit2.GitReference) at ./libgit2.jl:429
 in with(::Base.LibGit2.##120#122{Base.LibGit2.GitRepo,String}, ::Base.LibGit2.GitReference) at ./libgit2/types.jl:613
 in rebase!(::Base.LibGit2.GitRepo, ::String) at ./libgit2.jl:413
 in eval(::Module, ::Any) at ./boot.jl:226
```

[`checkout_opts::CheckoutOptions` is the last member of `RebaseOptions`](https://github.com/JuliaLang/julia/blob/5d52f0273d3ba8130da22af52083a71924b0c059/base/libgit2/types.jl#L450-L456).  

Digging into this, I found that [`MergeOptions`](https://github.com/JuliaLang/julia/blob/5d52f0273d3ba8130da22af52083a71924b0c059/base/libgit2/types.jl#L360-L368) seems to be missing a couple of members from [`git_merge_options`](https://github.com/libgit2/libgit2/blob/c148533024319689fca016f7c452d556265bb13f/include/git2/merge.h#L238-L290), which would cause a misalignment of the members of `RebaseOptions` when passed to libgit2.

Unfortunately, the error is still there even after this change, so either I didn't do this right, or there seems to be some other reason for the error.

I don't know when I'll have time to work on this again, so any help in finishing it up would be appreciated.

Cc: @nalimilan @wildart @tkelman 
