### PR TITLE
implement pre-run REPL hooks.

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -878,6 +878,9 @@ function run_frontend(repl::LineEditREPL, backend)
         interface = repl.interface
     end
     repl.backendref = backend
+    if length(Base.pre_run_repl_hooks) > 0
+        Base._atreplrun(repl)
+    end
     run_interface(repl.t, interface)
     dopushdisplay && popdisplay(d)
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -311,6 +311,22 @@ function _atreplinit(repl)
     end
 end
 
+const pre_run_repl_hooks = []
+
+atreplrun(f::Function) = (unshift!(pre_run_repl_hooks, f); nothing)
+
+function _atreplrun(repl)
+    for f in pre_run_repl_hooks
+        try
+            f(repl)
+        catch err
+            show(STDERR, err)
+            println(STDERR)
+        end
+    end
+end
+
+
 function _start()
     empty!(ARGS)
     append!(ARGS, Core.ARGS)


### PR DESCRIPTION
Implemented user hooks that are called after the REPL is created and setup, just before starting the REPL loop.

In .juliarc.jl, you can include code like this:

if isdefined(Base, :atreplrun)
    Base.atreplrun( (repl)->repl.interface.modes[1].prompt = "newprompt>" )
end

to install a hook. Call atreplrun repeatedly to push hooks, all of which are run (more or less) just before the loop is entered.

Some people think this is useful.  But, considering  WIP: Add hook API to REPL #13545, maybe  a more general solution is needed. 

 Committer: John Lapeyre lapeyre@ribot
 On branch gjl/replhooks
 Changes to be committed:
    modified:   base/REPL.jl
    modified:   base/client.jl
