### PR TITLE
Clean up of gc debugging and page management code

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -7,7 +7,7 @@
 # high-resolution relative time, in nanoseconds
 time_ns() = ccall(:jl_hrtime, UInt64, ())
 
-# This type must be kept in sync with the C struct in src/gc.c
+# This type must be kept in sync with the C struct in src/gc.h
 immutable GC_Num
     allocd      ::Int64 # GC internal
     freed       ::Int64 # GC internal
@@ -40,7 +40,7 @@ immutable GC_Diff
 end
 
 function GC_Diff(new::GC_Num, old::GC_Num)
-    # logic from gc.c:jl_gc_total_bytes
+    # logic from `src/gc.c:jl_gc_total_bytes`
     old_allocd = old.allocd + Int64(old.collect) + Int64(old.total_allocd)
     new_allocd = new.allocd + Int64(new.collect) + Int64(new.total_allocd)
     return GC_Diff(new_allocd - old_allocd,

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,7 @@ SRCS := \
 	jltypes gf typemap ast builtins module interpreter \
 	alloc dlload sys init task array dump toplevel jl_uv jlapi signal-handling \
 	simplevector APInt-C runtime_intrinsics runtime_ccall \
-	threadgroup threading stackwalk gc gc-debug safepoint
+	threadgroup threading stackwalk gc gc-debug gc-pages safepoint
 
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen disasm debuginfo llvm-simdloop llvm-gcroot
@@ -119,6 +119,7 @@ $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/codegen_internal.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h
+$(BUILDDIR)/gc-pages.o $(BUILDDIR)/gc-pages.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/signal-handling.o $(BUILDDIR)/signal-handling.dbg.obj: $(addprefix $(SRCDIR)/,signals-*.c)
 $(BUILDDIR)/dump.o $(BUILDDIR)/dump.dbg.obj: $(addprefix $(SRCDIR)/,common_symbols1.inc common_symbols2.inc)
 $(addprefix $(BUILDDIR)/,threading.o threading.dbg.obj gc.o gc.dbg.obj init.c init.dbg.obj task.o task.dbg.obj): $(addprefix $(SRCDIR)/,threading.h threadgroup.h)

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,7 @@ SRCS := \
 	jltypes gf typemap ast builtins module interpreter \
 	alloc dlload sys init task array dump toplevel jl_uv jlapi signal-handling \
 	simplevector APInt-C runtime_intrinsics runtime_ccall \
-	threadgroup threading stackwalk gc safepoint
+	threadgroup threading stackwalk gc gc-debug safepoint
 
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen disasm debuginfo llvm-simdloop llvm-gcroot
@@ -117,7 +117,8 @@ $(BUILDDIR)/anticodegen.o $(BUILDDIR)/anticodegen.dbg.obj: $(SRCDIR)/intrinsics.
 $(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: $(SRCDIR)/codegen_internal.h
 $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/codegen_internal.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
-$(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc-debug.c
+$(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h
+$(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/signal-handling.o $(BUILDDIR)/signal-handling.dbg.obj: $(addprefix $(SRCDIR)/,signals-*.c)
 $(BUILDDIR)/dump.o $(BUILDDIR)/dump.dbg.obj: $(addprefix $(SRCDIR)/,common_symbols1.inc common_symbols2.inc)
 $(addprefix $(BUILDDIR)/,threading.o threading.dbg.obj gc.o gc.dbg.obj init.c init.dbg.obj task.o task.dbg.obj): $(addprefix $(SRCDIR)/,threading.h threadgroup.h)

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -1,5 +1,13 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
+#include "gc.h"
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Useful function in debugger to find page/region metadata
 jl_gc_pagemeta_t *jl_gc_page_metadata(void *data)
 {
@@ -45,19 +53,14 @@ JL_DLLEXPORT jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p, size_t *osiz
     return (jl_taggedvalue_t*)tag;
 }
 
-#ifdef GC_DEBUG_ENV
-#include <inttypes.h>
-#include <stdio.h>
-#endif
-
 // mark verification
 #ifdef GC_VERIFY
-static jl_value_t *lostval = 0;
+jl_value_t *lostval = NULL;
 static arraylist_t lostval_parents;
 static arraylist_t lostval_parents_done;
-static int verifying;
+int gc_verifying;
 
-static void add_lostval_parent(jl_value_t *parent)
+void add_lostval_parent(jl_value_t *parent)
 {
     for(int i = 0; i < lostval_parents_done.len; i++) {
         if ((jl_value_t*)lostval_parents_done.items[i] == parent)
@@ -69,35 +72,6 @@ static void add_lostval_parent(jl_value_t *parent)
     }
     arraylist_push(&lostval_parents, parent);
 }
-
-#define verify_val(v) do {                                              \
-        if (lostval == (jl_value_t*)(v) && (v) != 0) {                  \
-            jl_printf(JL_STDOUT,                                        \
-                      "Found lostval %p at %s:%d oftype: ",             \
-                      (void*)(lostval), __FILE__, __LINE__);            \
-            jl_static_show(JL_STDOUT, jl_typeof(v));                    \
-            jl_printf(JL_STDOUT, "\n");                                 \
-        }                                                               \
-    } while(0);
-
-
-#define verify_parent(ty, obj, slot, args...) do {                      \
-        if (*(jl_value_t**)(slot) == lostval &&                         \
-            (jl_value_t*)(obj) != lostval) {                            \
-            jl_printf(JL_STDOUT, "Found parent %p %p at %s:%d\n",       \
-                      (void*)(ty), (void*)(obj), __FILE__, __LINE__);   \
-            jl_printf(JL_STDOUT, "\tloc %p : ", (void*)(slot));         \
-            jl_printf(JL_STDOUT, args);                                 \
-            jl_printf(JL_STDOUT, "\n");                                 \
-            jl_printf(JL_STDOUT, "\ttype: ");                           \
-            jl_static_show(JL_STDOUT, jl_typeof(obj));                  \
-            jl_printf(JL_STDOUT, "\n");                                 \
-            add_lostval_parent((jl_value_t*)(obj));                     \
-        }                                                               \
-    } while(0);
-
-#define verify_parent1(ty,obj,slot,arg1) verify_parent(ty,obj,slot,arg1)
-#define verify_parent2(ty,obj,slot,arg1,arg2) verify_parent(ty,obj,slot,arg1,arg2)
 
 /*
  How to debug a missing write barrier :
@@ -131,7 +105,7 @@ static arraylist_t bits_save[4];
 static void clear_mark(int bits)
 {
     gcval_t *pv;
-    if (!verifying) {
+    if (!gc_verifying) {
         for (int i = 0; i < 4; i++) {
             bits_save[i].len = 0;
         }
@@ -141,7 +115,7 @@ static void clear_mark(int bits)
         v = current_heap->big_objects;
         while (v != NULL) {
             void *gcv = &v->header;
-            if (!verifying) arraylist_push(&bits_save[gc_bits(gcv)], gcv);
+            if (!gc_verifying) arraylist_push(&bits_save[gc_bits(gcv)], gcv);
             gc_bits(gcv) = bits;
             v = v->next;
         }
@@ -150,7 +124,7 @@ static void clear_mark(int bits)
     v = big_objects_marked;
     while (v != NULL) {
         void *gcv = &v->header;
-        if (!verifying) arraylist_push(&bits_save[gc_bits(gcv)], gcv);
+        if (!gc_verifying) arraylist_push(&bits_save[gc_bits(gcv)], gcv);
         gc_bits(gcv) = bits;
         v = v->next;
     }
@@ -170,7 +144,7 @@ static void clear_mark(int bits)
                         pv = (gcval_t*)(pg->data + GC_PAGE_OFFSET);
                         char *lim = (char*)pv + GC_PAGE_SZ - GC_PAGE_OFFSET - pool->osize;
                         while ((char*)pv <= lim) {
-                            if (!verifying) arraylist_push(&bits_save[gc_bits(pv)], pv);
+                            if (!gc_verifying) arraylist_push(&bits_save[gc_bits(pv)], pv);
                             gc_bits(pv) = bits;
                             pv = (gcval_t*)((char*)pv + pool->osize);
                         }
@@ -230,13 +204,13 @@ static void gc_verify_track(void)
     } while(lostval != NULL);
 }
 
-static void gc_verify(void)
+void gc_verify(void)
 {
     lostval = NULL;
     lostval_parents.len = 0;
     lostval_parents_done.len = 0;
     clear_mark(GC_CLEAN);
-    verifying = 1;
+    gc_verifying = 1;
     pre_mark();
     post_mark(&finalizer_list, 1);
     post_mark(&finalizer_list_marked, 1);
@@ -254,7 +228,7 @@ static void gc_verify(void)
         }
     }
     if (lostval == NULL) {
-        verifying = 0;
+        gc_verifying = 0;
         restore();  // we did not miss anything
         return;
     }
@@ -264,34 +238,9 @@ static void gc_verify(void)
     gc_debug_critical_error();
     abort();
 }
-
-#else
-#define gc_verify()
-#define verify_val(v)
-#define verify_parent1(ty,obj,slot,arg1)
-#define verify_parent2(ty,obj,slot,arg1,arg2)
 #endif
 
 #ifdef GC_DEBUG_ENV
-
-typedef struct {
-    uint64_t num;
-    uint64_t next;
-
-    uint64_t min;
-    uint64_t interv;
-    uint64_t max;
-    unsigned short random[3];
-} jl_alloc_num_t;
-
-typedef struct {
-    int sweep_mask;
-    int wait_for_debugger;
-    jl_alloc_num_t pool;
-    jl_alloc_num_t other;
-    jl_alloc_num_t print;
-} jl_gc_debug_env_t;
-
 JL_DLLEXPORT jl_gc_debug_env_t jl_gc_debug_env = {
     GC_MARKED_NOESC,
     0,
@@ -299,6 +248,7 @@ JL_DLLEXPORT jl_gc_debug_env_t jl_gc_debug_env = {
     {0, UINT64_MAX, 0, 0, 0, {0, 0, 0}},
     {0, UINT64_MAX, 0, 0, 0, {0, 0, 0}}
 };
+static char *gc_stack_lo;
 
 static void gc_debug_alloc_setnext(jl_alloc_num_t *num)
 {
@@ -349,26 +299,12 @@ static int gc_debug_alloc_check(jl_alloc_num_t *num)
     return 1;
 }
 
-static char *gc_stack_lo;
-static void gc_debug_init(void)
-{
-    gc_stack_lo = (char*)gc_get_stack_ptr();
-    char *env = getenv("JULIA_GC_NO_GENERATIONAL");
-    if (env && strcmp(env, "0") != 0)
-        jl_gc_debug_env.sweep_mask = GC_MARKED;
-    env = getenv("JULIA_GC_WAIT_FOR_DEBUGGER");
-    jl_gc_debug_env.wait_for_debugger = env && strcmp(env, "0") != 0;
-    gc_debug_alloc_init(&jl_gc_debug_env.pool, "POOL");
-    gc_debug_alloc_init(&jl_gc_debug_env.other, "OTHER");
-    gc_debug_alloc_init(&jl_gc_debug_env.print, "PRINT");
-}
-
-static inline int gc_debug_check_pool(void)
+int gc_debug_check_pool(void)
 {
     return gc_debug_alloc_check(&jl_gc_debug_env.pool);
 }
 
-static inline int gc_debug_check_other(void)
+int gc_debug_check_other(void)
 {
     return gc_debug_alloc_check(&jl_gc_debug_env.other);
 }
@@ -393,7 +329,7 @@ void gc_debug_critical_error(void)
     }
 }
 
-static inline void gc_debug_print(void)
+void gc_debug_print(void)
 {
     if (!gc_debug_alloc_check(&jl_gc_debug_env.print))
         return;
@@ -426,21 +362,13 @@ static void gc_scrub_range(char *stack_lo, char *stack_hi)
     }
 }
 
-static void gc_scrub(char *stack_hi)
+void gc_scrub(char *stack_hi)
 {
     gc_scrub_range(gc_stack_lo, stack_hi);
 }
-
 #else
-
-static inline int gc_debug_check_other(void)
+void gc_debug_critical_error(void)
 {
-    return 0;
-}
-
-static inline int gc_debug_check_pool(void)
-{
-    return 0;
 }
 
 void gc_debug_print_status(void)
@@ -452,34 +380,14 @@ void gc_debug_print_status(void)
                    "(Pool: %" PRIu64 "; Big: %" PRIu64 "); GC: %d\n",
                    pool_count + big_count, pool_count, big_count, gc_num.pause);
 }
-
-void gc_debug_critical_error(void)
-{
-}
-
-static inline void gc_debug_print(void)
-{
-}
-
-static inline void gc_debug_init(void)
-{
-}
-
-static void gc_scrub(char *stack_hi)
-{
-    (void)stack_hi;
-}
-
 #endif
 
 #ifdef OBJPROFILE
 static htable_t obj_counts[3];
 static htable_t obj_sizes[3];
-static inline void objprofile_count(void *ty, int old, int sz)
+void objprofile_count(void *ty, int old, int sz)
 {
-#ifdef GC_VERIFY
-    if (verifying) return;
-#endif
+    if (gc_verifying) return;
     if ((intptr_t)ty <= 0x10) {
         ty = (void*)jl_buff_tag;
     }
@@ -500,7 +408,7 @@ static inline void objprofile_count(void *ty, int old, int sz)
         *((intptr_t*)bp) += sz;
 }
 
-static void objprofile_reset(void)
+void objprofile_reset(void)
 {
     for(int g=0; g < 3; g++) {
         htable_reset(&obj_counts[g], 0);
@@ -548,7 +456,7 @@ static void objprofile_print(htable_t nums, htable_t sizes)
     }
 }
 
-static void objprofile_printall(void)
+void objprofile_printall(void)
 {
     jl_printf(JL_STDERR, "Transient mark :\n");
     objprofile_print(obj_counts[0], obj_sizes[0]);
@@ -557,28 +465,37 @@ static void objprofile_printall(void)
     jl_printf(JL_STDERR, "Remset :\n");
     objprofile_print(obj_counts[2], obj_sizes[2]);
 }
+#endif
 
-static void objprofile_init(void)
+void gc_debug_init(void)
 {
+#ifdef GC_DEBUG_ENV
+    gc_stack_lo = (char*)gc_get_stack_ptr();
+    char *env = getenv("JULIA_GC_NO_GENERATIONAL");
+    if (env && strcmp(env, "0") != 0)
+        jl_gc_debug_env.sweep_mask = GC_MARKED;
+    env = getenv("JULIA_GC_WAIT_FOR_DEBUGGER");
+    jl_gc_debug_env.wait_for_debugger = env && strcmp(env, "0") != 0;
+    gc_debug_alloc_init(&jl_gc_debug_env.pool, "POOL");
+    gc_debug_alloc_init(&jl_gc_debug_env.other, "OTHER");
+    gc_debug_alloc_init(&jl_gc_debug_env.print, "PRINT");
+#endif
+
+#ifdef GC_VERIFY
+    for (int i = 0; i < 4; i++)
+        arraylist_new(&bits_save[i], 0);
+    arraylist_new(&lostval_parents, 0);
+    arraylist_new(&lostval_parents_done, 0);
+#endif
+
+#ifdef OBJPROFILE
     for (int g = 0;g < 3;g++) {
         htable_new(&obj_counts[g], 0);
         htable_new(&obj_sizes[g], 0);
     }
-}
-#else
-static inline void objprofile_count(void *ty, int old, int sz)
-{
+#endif
 }
 
-static inline void objprofile_printall(void)
-{
-}
-
-static inline void objprofile_reset(void)
-{
-}
-
-static void objprofile_init(void)
-{
+#ifdef __cplusplus
 }
 #endif

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -111,8 +111,8 @@ static void clear_mark(int bits)
         }
     }
     bigval_t *v;
-    FOR_EACH_HEAP () {
-        v = current_heap->big_objects;
+    for (int i = 0;i < jl_n_threads;i++) {
+        v = jl_all_task_states[i].ptls->heap.big_objects;
         while (v != NULL) {
             void *gcv = &v->header;
             if (!gc_verifying) arraylist_push(&bits_save[gc_bits(gcv)], gcv);
@@ -139,9 +139,9 @@ static void clear_mark(int bits)
                 for (int j = 0; j < 32; j++) {
                     if (!((line >> j) & 1)) {
                         jl_gc_pagemeta_t *pg = page_metadata(region->pages[pg_i*32 + j].data + GC_PAGE_OFFSET);
-                        pool_t *pool;
-                        FOR_HEAP (pg->thread_n)
-                            pool = &current_heap->norm_pools[pg->pool_n];
+                        jl_tls_states_t *ptls =
+                            jl_all_task_states[pg->thread_n].ptls;
+                        jl_gc_pool_t *pool = &ptls->heap.norm_pools[pg->pool_n];
                         pv = (gcval_t*)(pg->data + GC_PAGE_OFFSET);
                         char *lim = (char*)pv + GC_PAGE_SZ - GC_PAGE_OFFSET - pool->osize;
                         while ((char*)pv <= lim) {

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -130,8 +130,9 @@ static void clear_mark(int bits)
     }
 
     for (int h = 0; h < REGION_COUNT; h++) {
-        region_t *region = regions[h];
-        if (!region) break;
+        region_t *region = &regions[h];
+        if (!region->pages)
+            break;
         for (int pg_i = 0; pg_i < REGION_PG_COUNT/32; pg_i++) {
             uint32_t line = region->freemap[pg_i];
             if (!!~line) {

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -133,7 +133,7 @@ static void clear_mark(int bits)
         region_t *region = &regions[h];
         if (!region->pages)
             break;
-        for (int pg_i = 0; pg_i < REGION_PG_COUNT/32; pg_i++) {
+        for (int pg_i = 0; pg_i < region->pg_cnt / 32; pg_i++) {
             uint32_t line = region->freemap[pg_i];
             if (!!~line) {
                 for (int j = 0; j < 32; j++) {

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -77,7 +77,7 @@ static void jl_gc_alloc_region(region_t *region)
 {
     int pg_cnt = region_pg_cnt;
     const size_t pages_sz = sizeof(jl_gc_page_t) * pg_cnt;
-    const size_t freemap_sz = sizeof(uint32_t) * pg_cnt / 32;
+    const size_t allocmap_sz = sizeof(uint32_t) * pg_cnt / 32;
     char *mem = NULL;
     while (1) {
         if (__likely((mem = jl_gc_try_alloc_region(pg_cnt))))
@@ -95,17 +95,16 @@ static void jl_gc_alloc_region(region_t *region)
         }
     }
     region->pages = (jl_gc_page_t*)mem;
-    region->freemap = (uint32_t*)(mem + pages_sz);
-    region->meta = (jl_gc_pagemeta_t*)(mem + pages_sz +freemap_sz);
+    region->allocmap = (uint32_t*)(mem + pages_sz);
+    region->meta = (jl_gc_pagemeta_t*)(mem + pages_sz +allocmap_sz);
     region->lb = 0;
     region->ub = 0;
     region->pg_cnt = pg_cnt;
 #ifdef _OS_WINDOWS_
-    VirtualAlloc(region->freemap, pg_cnt / 8, MEM_COMMIT, PAGE_READWRITE);
+    VirtualAlloc(region->allocmap, pg_cnt / 8, MEM_COMMIT, PAGE_READWRITE);
     VirtualAlloc(region->meta, pg_cnt * sizeof(jl_gc_pagemeta_t),
                  MEM_COMMIT, PAGE_READWRITE);
 #endif
-    memset(region->freemap, 0xff, pg_cnt / 8);
 }
 
 NOINLINE void *jl_gc_alloc_page(void)
@@ -119,7 +118,7 @@ NOINLINE void *jl_gc_alloc_page(void)
         if (region->pages == NULL)
             jl_gc_alloc_region(region);
         for (i = region->lb; i < region->pg_cnt / 32; i++) {
-            if (region->freemap[i])
+            if (~region->allocmap[i])
                 break;
         }
         if (i == region->pg_cnt / 32) {
@@ -139,15 +138,15 @@ NOINLINE void *jl_gc_alloc_page(void)
         region->ub = i;
 
 #if defined(_COMPILER_MINGW_)
-    int j = __builtin_ffs(region->freemap[i]) - 1;
+    int j = __builtin_ffs(~region->allocmap[i]) - 1;
 #elif defined(_COMPILER_MICROSOFT_)
     unsigned long j;
-    _BitScanForward(&j, region->freemap[i]);
+    _BitScanForward(&j, ~region->allocmap[i]);
 #else
-    int j = ffs(region->freemap[i]) - 1;
+    int j = ffs(~region->allocmap[i]) - 1;
 #endif
 
-    region->freemap[i] &= ~(uint32_t)(1 << j);
+    region->allocmap[i] |= (uint32_t)(1 << j);
     void *ptr = region->pages[i * 32 + j].data;
 #ifdef _OS_WINDOWS_
     VirtualAlloc(ptr, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
@@ -174,8 +173,8 @@ void jl_gc_free_page(void *p)
     }
     assert(i < REGION_COUNT && region->pages != NULL);
     uint32_t msk = (uint32_t)(1 << (pg_idx % 32));
-    assert(!(region->freemap[pg_idx/32] & msk));
-    region->freemap[pg_idx/32] ^= msk;
+    assert(region->allocmap[pg_idx/32] & msk);
+    region->allocmap[pg_idx/32] ^= msk;
     free(region->meta[pg_idx].ages);
     // tell the OS we don't need these pages right now
     size_t decommit_size = GC_PAGE_SZ;
@@ -185,10 +184,13 @@ void jl_gc_free_page(void *p)
         decommit_size = jl_page_size;
         p = (void*)((uintptr_t)region->pages[pg_idx].data & ~(jl_page_size - 1)); // round down to the nearest page
         pg_idx = page_index(region, p);
-        if (pg_idx + n_pages > region->pg_cnt) goto no_decommit;
+        if (pg_idx + n_pages > region->pg_cnt)
+            goto no_decommit;
         for (; n_pages--; pg_idx++) {
             msk = (uint32_t)(1 << ((pg_idx % 32)));
-            if (!(region->freemap[pg_idx/32] & msk)) goto no_decommit;
+            if (region->allocmap[pg_idx / 32] & msk) {
+                goto no_decommit;
+            }
         }
     }
 #ifdef _OS_WINDOWS_

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -1,0 +1,155 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+#include "gc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// A region is contiguous storage for up to REGION_PG_COUNT naturally aligned GC_PAGE_SZ pages
+// It uses a very naive allocator (see jl_gc_alloc_page & jl_gc_free_page)
+#if defined(_P64)
+#define REGION_PG_COUNT 16*8*4096 // 8G because virtual memory is cheap
+#else
+#define REGION_PG_COUNT 8*4096 // 512M
+#endif
+
+static jl_mutex_t pagealloc_lock;
+static size_t current_pg_count = 0;
+
+NOINLINE void *jl_gc_alloc_page(void)
+{
+    void *ptr = NULL;
+    int i;
+    region_t *region;
+    int region_i = 0;
+    JL_LOCK_NOGC(&pagealloc_lock);
+    while(region_i < REGION_COUNT) {
+        region = &regions[region_i];
+        if (region->pages == NULL) {
+            int pg_cnt = REGION_PG_COUNT;
+            const size_t pages_sz = sizeof(jl_gc_page_t) * pg_cnt;
+            const size_t freemap_sz = sizeof(uint32_t) * pg_cnt / 32;
+            const size_t meta_sz = sizeof(jl_gc_pagemeta_t) * pg_cnt;
+            size_t alloc_size = pages_sz + freemap_sz + meta_sz;
+#ifdef _OS_WINDOWS_
+            char *mem = (char*)VirtualAlloc(NULL, alloc_size + GC_PAGE_SZ,
+                                            MEM_RESERVE, PAGE_READWRITE);
+#else
+            if (GC_PAGE_SZ > jl_page_size)
+                alloc_size += GC_PAGE_SZ;
+            char *mem = (char*)mmap(0, alloc_size, PROT_READ | PROT_WRITE, MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            mem = mem == MAP_FAILED ? NULL : mem;
+#endif
+            if (mem == NULL) {
+                jl_printf(JL_STDERR, "could not allocate pools\n");
+                gc_debug_critical_error();
+                abort();
+            }
+            if (GC_PAGE_SZ > jl_page_size) {
+                // round data pointer up to the nearest gc_page_data-aligned
+                // boundary if mmap didn't already do so.
+                mem = (char*)gc_page_data(mem + GC_PAGE_SZ - 1);
+            }
+            region->pages = (jl_gc_page_t*)mem;
+            region->freemap = (uint32_t*)(mem + pages_sz);
+            region->meta = (jl_gc_pagemeta_t*)(mem + pages_sz +freemap_sz);
+            region->lb = 0;
+            region->ub = 0;
+            region->pg_cnt = pg_cnt;
+#ifdef _OS_WINDOWS_
+            VirtualAlloc(region->freemap, region->pg_cnt / 8,
+                         MEM_COMMIT, PAGE_READWRITE);
+            VirtualAlloc(region->meta, region->pg_cnt * sizeof(jl_gc_pagemeta_t),
+                         MEM_COMMIT, PAGE_READWRITE);
+#endif
+            memset(region->freemap, 0xff, region->pg_cnt / 8);
+        }
+        for (i = region->lb; i < region->pg_cnt / 32; i++) {
+            if (region->freemap[i])
+                break;
+        }
+        if (i == region->pg_cnt / 32) {
+            // region full
+            region_i++;
+            continue;
+        }
+        break;
+    }
+    if (region_i >= REGION_COUNT) {
+        jl_printf(JL_STDERR, "increase REGION_COUNT or allocate less memory\n");
+        gc_debug_critical_error();
+        abort();
+    }
+    if (region->lb < i)
+        region->lb = i;
+    if (region->ub < i)
+        region->ub = i;
+
+#if defined(_COMPILER_MINGW_)
+    int j = __builtin_ffs(region->freemap[i]) - 1;
+#elif defined(_COMPILER_MICROSOFT_)
+    unsigned long j;
+    _BitScanForward(&j, region->freemap[i]);
+#else
+    int j = ffs(region->freemap[i]) - 1;
+#endif
+
+    region->freemap[i] &= ~(uint32_t)(1 << j);
+    ptr = region->pages[i*32 + j].data;
+#ifdef _OS_WINDOWS_
+    VirtualAlloc(ptr, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
+#endif
+    current_pg_count++;
+#ifdef GC_FINAL_STATS
+    max_pg_count = max_pg_count < current_pg_count ? current_pg_count : max_pg_count;
+#endif
+    JL_UNLOCK_NOGC(&pagealloc_lock);
+    return ptr;
+}
+
+void jl_gc_free_page(void *p)
+{
+    int pg_idx = -1;
+    int i;
+    region_t *region = regions;
+    for (i = 0; i < REGION_COUNT && regions[i].pages != NULL; i++) {
+        region = &regions[i];
+        pg_idx = page_index(region, p);
+        if (pg_idx >= 0 && pg_idx < region->pg_cnt) {
+            break;
+        }
+    }
+    assert(i < REGION_COUNT && region->pages != NULL);
+    uint32_t msk = (uint32_t)(1 << (pg_idx % 32));
+    assert(!(region->freemap[pg_idx/32] & msk));
+    region->freemap[pg_idx/32] ^= msk;
+    free(region->meta[pg_idx].ages);
+    // tell the OS we don't need these pages right now
+    size_t decommit_size = GC_PAGE_SZ;
+    if (GC_PAGE_SZ < jl_page_size) {
+        // ensure so we don't release more memory than intended
+        size_t n_pages = (GC_PAGE_SZ + jl_page_size - 1) / GC_PAGE_SZ;
+        decommit_size = jl_page_size;
+        p = (void*)((uintptr_t)region->pages[pg_idx].data & ~(jl_page_size - 1)); // round down to the nearest page
+        pg_idx = page_index(region, p);
+        if (pg_idx + n_pages > region->pg_cnt) goto no_decommit;
+        for (; n_pages--; pg_idx++) {
+            msk = (uint32_t)(1 << ((pg_idx % 32)));
+            if (!(region->freemap[pg_idx/32] & msk)) goto no_decommit;
+        }
+    }
+#ifdef _OS_WINDOWS_
+    VirtualFree(p, decommit_size, MEM_DECOMMIT);
+#else
+    madvise(p, decommit_size, MADV_DONTNEED);
+#endif
+no_decommit:
+    if (region->lb > pg_idx / 32)
+        region->lb = pg_idx / 32;
+    current_pg_count--;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/gc.c
+++ b/src/gc.c
@@ -806,11 +806,11 @@ static void sweep_pool_region(gcval_t ***pfl, int region_i, int sweep_mask)
     int ub = 0;
     int lb = region->lb;
     for (int pg_i = 0; pg_i <= region->ub; pg_i++) {
-        uint32_t line = region->freemap[pg_i];
-        if (!!~line) {
+        uint32_t line = region->allocmap[pg_i];
+        if (line) {
             ub = pg_i;
             for (int j = 0; j < 32; j++) {
-                if (!((line >> j) & 1)) {
+                if ((line >> j) & 1) {
                     jl_gc_pagemeta_t *pg = &region->meta[pg_i*32 + j];
                     int p_n = pg->pool_n;
                     int t_n = pg->thread_n;

--- a/src/gc.c
+++ b/src/gc.c
@@ -2041,6 +2041,7 @@ jl_thread_heap_t *jl_mk_thread_heap(void)
 // System-wide initializations
 void jl_gc_init(void)
 {
+    jl_gc_init_page();
     gc_debug_init();
 
     arraylist_new(&finalizer_list, 0);

--- a/src/gc.h
+++ b/src/gc.h
@@ -330,6 +330,7 @@ extern jl_thread_heap_t *const jl_thread_heap;
 
 // GC pages
 
+void jl_gc_init_page(void);
 NOINLINE void *jl_gc_alloc_page(void);
 void jl_gc_free_page(void *p);
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -1,0 +1,224 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+/*
+  allocation and garbage collection
+  . non-moving, precise mark and sweep collector
+  . pool-allocates small objects, keeps big objects on a simple list
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
+#include <assert.h>
+#include <inttypes.h>
+#include "julia.h"
+#include "julia_internal.h"
+#include "threading.h"
+#ifndef _OS_WINDOWS_
+#include <sys/mman.h>
+#if defined(_OS_DARWIN_) && !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#endif
+
+// manipulating mark bits
+
+#define GC_CLEAN 0 // freshly allocated
+#define GC_MARKED 1 // reachable and old
+#define GC_QUEUED 2 // if it is reachable it will be marked as old
+#define GC_MARKED_NOESC (GC_MARKED | GC_QUEUED) // reachable and young
+
+#define GC_PAGE_LG2 14 // log2(size of a page)
+#define GC_PAGE_SZ (1 << GC_PAGE_LG2) // 16k
+#define GC_PAGE_OFFSET (JL_SMALL_BYTE_ALIGNMENT - (sizeof_jl_taggedvalue_t % JL_SMALL_BYTE_ALIGNMENT))
+
+// A region is contiguous storage for up to REGION_PG_COUNT naturally aligned GC_PAGE_SZ pages
+// It uses a very naive allocator (see malloc_page & free_page)
+#if defined(_P64) && !defined(_COMPILER_MICROSOFT_)
+#define REGION_PG_COUNT 16*8*4096 // 8G because virtual memory is cheap
+#else
+#define REGION_PG_COUNT 8*4096 // 512M
+#endif
+#define REGION_COUNT 8
+
+// This struct must be kept in sync with the Julia type of the same name in base/util.jl
+typedef struct {
+    int64_t     allocd;
+    int64_t     freed;
+    uint64_t    malloc;
+    uint64_t    realloc;
+    uint64_t    poolalloc;
+    uint64_t    bigalloc;
+    uint64_t    freecall;
+    uint64_t    total_time;
+    uint64_t    total_allocd;
+    uint64_t    since_sweep;
+    size_t      interval;
+    int         pause;
+    int         full_sweep;
+} jl_gc_num_t;
+
+// layout for small (<2k) objects
+
+typedef struct _buff_t {
+    union {
+        uintptr_t header;
+        struct _buff_t *next;
+        uintptr_t flags;
+        jl_value_t *type; // 16-bytes aligned
+        struct {
+            uintptr_t gc_bits:2;
+            uintptr_t pooled:1;
+        };
+    };
+    char data[];
+} buff_t;
+typedef buff_t gcval_t;
+
+// layout for big (>2k) objects
+
+typedef struct _bigval_t {
+    struct _bigval_t *next;
+    struct _bigval_t **prev; // pointer to the next field of the prev entry
+    union {
+        size_t sz;
+        uintptr_t age : 2;
+    };
+    #ifdef _P64 // Add padding so that char data[] below is 64-byte aligned
+        // (8 pointers of 8 bytes each) - (4 other pointers in struct)
+        void *_padding[8 - 4];
+    #else
+        // (16 pointers of 4 bytes each) - (4 other pointers in struct)
+        void *_padding[16 - 4];
+    #endif
+    //struct buff_t <>;
+    union {
+        uintptr_t header;
+        uintptr_t flags;
+        uintptr_t gc_bits:2;
+    };
+    // must be 64-byte aligned here, in 32 & 64 bit modes
+    char data[];
+} bigval_t;
+
+// data structure for tracking malloc'd arrays.
+
+typedef struct _mallocarray_t {
+    jl_array_t *a;
+    struct _mallocarray_t *next;
+} mallocarray_t;
+
+typedef struct _pool_t {
+    gcval_t *freelist;   // root of list of free objects
+    gcval_t *newpages;   // root of list of chunks of free objects
+    uint16_t end_offset; // stored to avoid computing it at each allocation
+    uint16_t osize;      // size of objects in this pool
+    uint16_t nfree;      // number of free objects in page pointed into by free_list
+} pool_t;
+
+// pool page metadata
+typedef struct {
+    struct {
+        uint16_t pool_n : 8; // index (into norm_pool) of pool that owns this page
+        uint16_t allocd : 1; // true if an allocation happened in this page since last sweep
+        uint16_t gc_bits : 2; // this is a bitwise | of all gc_bits in this page
+    };
+    uint16_t nfree; // number of free objects in this page.
+                    // invalid if pool that owns this page is allocating objects from this page.
+    uint16_t osize; // size of each object in this page
+    uint16_t fl_begin_offset; // offset of first free object in this page
+    uint16_t fl_end_offset;   // offset of last free object in this page
+    uint16_t thread_n;        // index (into jl_thread_heap) of heap that owns this page
+    char *data;
+    uint8_t *ages;
+} jl_gc_pagemeta_t;
+
+typedef struct {
+    char data[GC_PAGE_SZ];
+} jl_gc_page_t
+#if !defined(_COMPILER_MICROSOFT_) && !(defined(_COMPILER_MINGW_) && defined(_COMPILER_CLANG_))
+__attribute__((aligned(GC_PAGE_SZ)))
+#endif
+;
+
+typedef struct {
+    // Page layout:
+    //  Padding: GC_PAGE_OFFSET
+    //  Blocks: osize * n
+    //    Tag: sizeof_jl_taggedvalue_t
+    //    Data: <= osize - sizeof_jl_taggedvalue_t
+    jl_gc_page_t pages[REGION_PG_COUNT]; // must be first, to preserve page alignment
+    uint32_t freemap[REGION_PG_COUNT/32];
+    jl_gc_pagemeta_t meta[REGION_PG_COUNT];
+} region_t
+;
+
+// Variables that become fields of a thread-local struct in the thread-safe version.
+typedef struct _jl_thread_heap_t {
+    // variable for tracking weak references
+    arraylist_t weak_refs;
+
+    // variables for tracking malloc'd arrays
+    mallocarray_t *mallocarrays;
+    mallocarray_t *mafreelist;
+
+    // variables for tracking big objects
+    bigval_t *big_objects;
+
+    // variables for tracking "remembered set"
+    arraylist_t rem_bindings;
+    arraylist_t _remset[2]; // contains jl_value_t*
+    // lower bound of the number of pointers inside remembered values
+    int remset_nptr;
+    arraylist_t *remset;
+    arraylist_t *last_remset;
+
+    // variables for allocating objects from pools
+#ifdef _P64
+#define N_POOLS 41
+#else
+#define N_POOLS 43
+#endif
+    pool_t norm_pools[N_POOLS];
+} jl_thread_heap_t;
+
+typedef struct {
+    int index;
+    jl_thread_heap_t *heap;
+} jl_each_heap_index_t;
+
+typedef struct {
+    int i;
+    jl_thread_heap_t *heap;
+} jl_single_heap_index_t;
+
+#define bigval_header(data) container_of((data), bigval_t, header)
+
+// round an address inside a gcpage's data to its beginning
+STATIC_INLINE char *gc_page_data(void *x)
+{
+    return (char*)(((uintptr_t)x >> GC_PAGE_LG2) << GC_PAGE_LG2);
+}
+
+STATIC_INLINE gcval_t *page_pfl_beg(jl_gc_pagemeta_t *p)
+{
+    return (gcval_t*)(p->data + p->fl_begin_offset);
+}
+
+STATIC_INLINE gcval_t *page_pfl_end(jl_gc_pagemeta_t *p)
+{
+    return (gcval_t*)(p->data + p->fl_end_offset);
+}
+
+STATIC_INLINE int page_index(region_t *region, void *data)
+{
+    return (gc_page_data(data) - region->pages->data) / GC_PAGE_SZ;
+}
+
+#define gc_bits(o) (((gcval_t*)(o))->gc_bits)
+#define gc_marked(o)  (((gcval_t*)(o))->gc_bits & GC_MARKED)
+#define _gc_setmark(o, mark_mode) (((gcval_t*)(o))->gc_bits = mark_mode)
+
+extern jl_gc_num_t gc_num;

--- a/src/gc.h
+++ b/src/gc.h
@@ -211,11 +211,6 @@ STATIC_INLINE int page_index(region_t *region, void *data)
     return (gc_page_data(data) - region->pages->data) / GC_PAGE_SZ;
 }
 
-STATIC_INLINE uint8_t *page_age(jl_gc_pagemeta_t *pg)
-{
-    return pg->ages;
-}
-
 #define gc_bits(o) (((gcval_t*)(o))->gc_bits)
 #define gc_marked(o)  (((gcval_t*)(o))->gc_bits & GC_MARKED)
 #define _gc_setmark(o, mark_mode) (((gcval_t*)(o))->gc_bits = mark_mode)

--- a/src/gc.h
+++ b/src/gc.h
@@ -167,7 +167,7 @@ typedef struct {
     //    Tag: sizeof_jl_taggedvalue_t
     //    Data: <= osize - sizeof_jl_taggedvalue_t
     jl_gc_page_t *pages; // [pg_cnt]; must be first, to preserve page alignment
-    uint32_t *freemap; // [pg_cnt / 32]
+    uint32_t *allocmap; // [pg_cnt / 32]
     jl_gc_pagemeta_t *meta; // [pg_cnt]
     int pg_cnt;
     // store a lower bound of the first free page in each region

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -259,6 +259,7 @@ void jl_init_restored_modules(jl_array_t *init_order);
 void jl_init_signal_async(void);
 void jl_init_debuginfo(void);
 void jl_init_runtime_ccall(void);
+void jl_mk_thread_heap(jl_thread_heap_t *heap);
 
 void _julia_init(JL_IMAGE_SEARCH rel);
 #ifdef COPY_STACKS

--- a/src/threading.h
+++ b/src/threading.h
@@ -18,11 +18,6 @@ extern "C" {
 extern jl_thread_task_state_t *jl_all_task_states;
 extern JL_DLLEXPORT int jl_n_threads;  // # threads we're actually using
 
-#ifdef JULIA_ENABLE_THREADING
-// GC
-extern struct _jl_thread_heap_t **jl_all_heaps;
-#endif
-
 // thread state
 enum {
     TI_THREAD_INIT,


### PR DESCRIPTION
This is a rewrite of https://github.com/JuliaLang/julia/pull/13968 with a few related clean ups.
- Remove most of the GC macros that are hard to reason about. (or make code searching harder).
- Split page management and debugging code into separate compilation units.
- Move `jl_thread_heap_t` into `jl_tls_states_t`. Remove some infrastructures for accessing TLS variables on a different thread that exists before `jl_tls_states_t`.
- Increase maximum region count, make region size dynamic. (Fix #10390.)

I believe most of the changes should only affect slow path.
