### PR TITLE
emit a trap instruction before an inferred unreachable function return

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1546,9 +1546,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     JL_GC_POP();
     if (rt == jl_bottom_type) {
         // Do this after we marked all the GC uses.
-        builder.CreateUnreachable();
-        BasicBlock *newBB = BasicBlock::Create(jl_LLVMContext, "after_noret", ctx->f);
-        builder.SetInsertPoint(newBB);
+        CreateTrap(builder);
     }
     // Finally we need to box the result into julia type
     // However, if we have already created a box for the return


### PR DESCRIPTION
@Keno as you requested

``` julia
julia> f() = f()
f (generic function with 1 method)

julia> g() = f()
g (generic function with 1 method)

julia> @code_llvm g()

; Function Attrs: noreturn
define void @julia_g_49908() #0 {
top:
  call void @julia_f_49909()
  call void @llvm.trap()
  unreachable
}
```
