### PR TITLE
make a default flush(io)=nothing method for all IO streams

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -155,6 +155,8 @@ Library improvements
 
   * The new `Base.StackTraces` module makes stack traces easier to use programmatically. ([#14469])
 
+  * There is now a default no-op `flush(io)` function for all `IO` types ([#16403]).
+
 Deprecated or removed
 ---------------------
 
@@ -225,3 +227,4 @@ Deprecated or removed
 [#15550]: https://github.com/JuliaLang/julia/issues/15550
 [#15609]: https://github.com/JuliaLang/julia/issues/15609
 [#15763]: https://github.com/JuliaLang/julia/issues/15763
+[#16403]: https://github.com/JuliaLang/julia/issues/16403

--- a/NEWS.md
+++ b/NEWS.md
@@ -153,7 +153,7 @@ Library improvements
 
     * `extrema` can now operate over a region ([#15550]).
 
-  * The new `Base.StackTraces` module makes stack traces easier to use programmatically. ([#14469])
+  * The new `Base.StackTraces` module makes stack traces easier to use programmatically ([#14469]).
 
   * There is now a default no-op `flush(io)` function for all `IO` types ([#16403]).
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -409,4 +409,4 @@ ismarked(io::IO) = io.mark >= 0
 
 # Make sure all IO streams support flush, even if only as a no-op,
 # to make it easier to write generic I/O code.
-flush(io::IO) = io
+flush(io::IO) = nothing

--- a/base/io.jl
+++ b/base/io.jl
@@ -406,3 +406,7 @@ function reset{T<:IO}(io::T)
 end
 
 ismarked(io::IO) = io.mark >= 0
+
+# Make sure all IO streams support flush, even if only as a no-op,
+# to make it easier to write generic I/O code.
+flush(io::IO) = io

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -212,4 +212,4 @@ let bstream = BufferStream()
     @test nb_available(bstream) == 0
 end
 
-@test isa(flush(IOBuffer()), IOBuffer) # should be a no-op
+@test flush(IOBuffer()) === nothing # should be a no-op

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -211,3 +211,5 @@ let bstream = BufferStream()
     @test eof(bstream)
     @test nb_available(bstream) == 0
 end
+
+@test isa(flush(IOBuffer()), IOBuffer) # should be a no-op


### PR DESCRIPTION
I noticed that there is no `flush(::IOBuffer)` function, even as a no-op, which makes it error-prone to write generic code that operates on `IO` streams.  See tbreloff/Plots.jl#258 and stevengj/PyCall.jl#272.

This PR just adds a generic `flush(io::IO)=nothing` fallback method, which should be safe since `flush` is only loosely defined in terms of side effects anyway.
