### PR TITLE
Allow building julia with more than one worker thread by default

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -55,6 +55,8 @@ USE_INTEL_JITEVENTS ?= 0
 USEICC  ?= 0
 USEIFC  ?= 0
 
+JULIA_THREADS := 1 # Enable threading with one thread
+
 ifeq ($(USE_MKL), 1)
 $(warning "The julia make variable USE_MKL has been renamed to USE_INTEL_MKL")
 USE_INTEL_MKL := 1
@@ -896,7 +898,7 @@ endif
 
 # Threads
 ifneq ($(JULIA_THREADS), 0)
-JCPPFLAGS += -DJULIA_ENABLE_THREADING
+JCPPFLAGS += -DJULIA_ENABLE_THREADING -DJULIA_NUM_THREADS=$(JULIA_THREADS)
 endif
 
 # Intel VTune Amplifier

--- a/src/options.h
+++ b/src/options.h
@@ -97,7 +97,9 @@
 
 // defaults for # threads
 #define NUM_THREADS_NAME                "JULIA_NUM_THREADS"
-#define DEFAULT_NUM_THREADS             1
+#ifndef JULIA_NUM_THREADS
+#  define JULIA_NUM_THREADS 1
+#endif
 
 // affinitization behavior
 #define MACHINE_EXCLUSIVE_NAME          "JULIA_EXCLUSIVE"

--- a/src/threading.c
+++ b/src/threading.c
@@ -282,13 +282,15 @@ void jl_init_threading(void)
 
     // how many threads available, usable
     int max_threads = jl_cpu_cores();
-    jl_n_threads = DEFAULT_NUM_THREADS;
+    jl_n_threads = JULIA_NUM_THREADS;
     cp = getenv(NUM_THREADS_NAME);
     if (cp) {
         jl_n_threads = (uint64_t)strtol(cp, NULL, 10);
     }
     if (jl_n_threads > max_threads)
         jl_n_threads = max_threads;
+    if (jl_n_threads <= 0)
+        jl_n_threads = 1;
 
     // set up space for per-thread heaps
     jl_all_heaps = (struct _jl_thread_heap_t **)malloc(jl_n_threads * sizeof(void*));


### PR DESCRIPTION
Without patching C file...

Mainly for the buildbot (for threading CI I've been enabling it with a patch https://github.com/JuliaLang/julia/commit/c0b13a622707a7eed3a72167adfb5ef938c1644b but I don't know how to do this on the buildbot)

While I'm at it, also make setting `JULIA_NUM_THREADS=0` not crashing...
