### PR TITLE
WIP: Initial prototype of how to exclude code from Base

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -67,6 +67,11 @@ endif
 	@echo "const DOCDIR = \"$(docdir_rel)\"" >> $@
 	@echo "const LIBDIR = \"$(libdir_rel)\"" >> $@
 	@echo "const INCLUDEDIR = \"$(includedir_rel)\"" >> $@
+ifeq ($(NODATES), 1)
+	@echo "const NODATES = true" >> $@
+else
+	@echo "const NODATES = false" >> $@
+endif
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible

--- a/base/excluded.jl
+++ b/base/excluded.jl
@@ -1,0 +1,22 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+module Excluded
+
+macro exclude(typexpr)
+    f = typexpr.args[2]
+    if typexpr.head == :type
+        return quote
+            export $f
+            type $f
+                $(f)() = throw(ArgumentError("`$($f)` has been excluded in this build"))
+            end
+        end
+    end
+end
+
+export Dates
+module Dates end
+@exclude type Date end
+@exclude type DateTime end
+
+end # module

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -78,6 +78,9 @@ Array{T}(::Type{T}, m::Integer)                       = Array{T,1}(Int(m))
 Array{T}(::Type{T}, m::Integer,n::Integer)            = Array{T,2}(Int(m),Int(n))
 Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) = Array{T,3}(Int(m),Int(n),Int(o))
 
+include("excluded.jl")
+using .Excluded
+
 # numeric operations
 include("hashing.jl")
 include("rounding.jl")
@@ -323,8 +326,10 @@ include("profile.jl")
 importall .Profile
 
 # dates
-include("Dates.jl")
-import .Dates: Date, DateTime, now
+if !NODATES
+    include("Dates.jl")
+    import .Dates: Date, DateTime, now
+end
 
 # sparse matrices, vectors, and sparse linear algebra
 include("sparse.jl")


### PR DESCRIPTION
An idea of getting started on #5155.

Currently implemented:
- ability to do `make NODATES=1` when building julia
- creation of an `Excluded` module for pre-definitions of modules/types to potentially exclude
- With a regular `make`, everything works as before, with `make NODATES=1`, `Date` and `DateTime` types are defined, but any usage immediately errors

Additional things to think about:
- This is obviously one of the simplest cases of code that is almost completely stand-alone
- What about "more entangled" code like BigInt/BigFloat where usage is more wide-spread?
- Do we actually need something like the `Excluded` module? I found it at least allowed the type definitions so that any downstream code was still able to be _defined_, even if any downstream usage would immediately error.
- Where should these theoretical "default packages" live? In the `base/` directory? In a stand-alone github repo? A mix of both? (if the latter, we probably need some more make magic to first fetch a repo (if the code is to be included) so that it can be included in sysimg.jl)
