### PR TITLE
WIP: typemap split on non-leaf TypeNames

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -301,6 +301,19 @@ function visit(f, mc::TypeMapLevel)
             isdefined(e, i) && visit(f, e[i])
         end
     end
+    mc.linear_leaf !== nothing && visit(f, mc.linear_leaf)
+    if mc.tname !== nothing
+        e = mc.tname::Vector{Any}
+        for i in 1:length(e)
+            isdefined(e, i) && visit(f, e[i])
+        end
+    end
+    if mc.name1 !== nothing
+        e = mc.name1::Vector{Any}
+        for i in 1:length(e)
+            isdefined(e, i) && visit(f, e[i])
+        end
+    end
     mc.list !== nothing && visit(f, mc.list)
     mc.any !== nothing && visit(f, mc.any)
     nothing

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -289,6 +289,7 @@ function visit(f, mt::MethodTable)
     nothing
 end
 function visit(f, mc::TypeMapLevel)
+    mc.bottom !== nothing && visit(f, mc.bottom)
     if mc.targ !== nothing
         e = mc.targ::Vector{Any}
         for i in 1:length(e)
@@ -301,7 +302,6 @@ function visit(f, mc::TypeMapLevel)
             isdefined(e, i) && visit(f, e[i])
         end
     end
-    mc.linear_leaf !== nothing && visit(f, mc.linear_leaf)
     if mc.tname !== nothing
         e = mc.tname::Vector{Any}
         for i in 1:length(e)

--- a/src/dump.c
+++ b/src/dump.c
@@ -939,16 +939,22 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
                     // (which will need to be rehashed during deserialization anyhow)
                     jl_typemap_level_t *node = (jl_typemap_level_t*)v;
                     assert( // make sure this type has the expected ordering
-                        offsetof(jl_typemap_level_t, arg1) == 0 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, targ) == 2 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, linear) == 4 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, any) == 5 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, key) == 6 * sizeof(jl_value_t*) &&
-                        sizeof(jl_typemap_level_t) == 7 * sizeof(jl_value_t*));
+                        offsetof(jl_typemap_level_t, targ) == 0 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, arg1) == 2 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, tname) == 4 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, name1) == 6 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, linear) == 8 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, any) == 9 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, key) == 10 * sizeof(jl_value_t*) &&
+                        sizeof(jl_typemap_level_t) == 11 * sizeof(jl_value_t*));
+                    jl_serialize_value(s, jl_nothing);
+                    jl_serialize_value(s, node->targ.values);
                     jl_serialize_value(s, jl_nothing);
                     jl_serialize_value(s, node->arg1.values);
                     jl_serialize_value(s, jl_nothing);
-                    jl_serialize_value(s, node->targ.values);
+                    jl_serialize_value(s, node->tname.values);
+                    jl_serialize_value(s, jl_nothing);
+                    jl_serialize_value(s, node->name1.values);
                     jl_serialize_value(s, node->linear);
                     jl_serialize_value(s, node->any.unknown);
                     jl_serialize_value(s, node->key);

--- a/src/dump.c
+++ b/src/dump.c
@@ -939,14 +939,16 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
                     // (which will need to be rehashed during deserialization anyhow)
                     jl_typemap_level_t *node = (jl_typemap_level_t*)v;
                     assert( // make sure this type has the expected ordering
-                        offsetof(jl_typemap_level_t, targ) == 0 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, arg1) == 2 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, tname) == 4 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, name1) == 6 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, linear) == 8 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, any) == 9 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, key) == 10 * sizeof(jl_value_t*) &&
-                        sizeof(jl_typemap_level_t) == 11 * sizeof(jl_value_t*));
+                        offsetof(jl_typemap_level_t, bottom) == 0 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, targ) == 1 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, arg1) == 3 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, tname) == 5 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, name1) == 7 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, linear) == 9 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, any) == 10 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, key) == 11 * sizeof(jl_value_t*) &&
+                        sizeof(jl_typemap_level_t) == 12 * sizeof(jl_value_t*));
+                    jl_serialize_value(s, node->bottom);
                     jl_serialize_value(s, jl_nothing);
                     jl_serialize_value(s, node->targ.values);
                     jl_serialize_value(s, jl_nothing);
@@ -993,7 +995,7 @@ struct jl_serialize_methcache_from_mod_env {
 static int jl_serialize_methcache_from_mod(jl_typemap_entry_t *ml, void *closure)
 {
     struct jl_serialize_methcache_from_mod_env *env = (struct jl_serialize_methcache_from_mod_env*)closure;
-    if (module_in_worklist(ml->func.method->module)) {
+    if (module_in_worklist(ml->func.method->module) && !ml->weak) {
         jl_serialize_value(env->s, ml->func.method);
         jl_serialize_value(env->s, ml->simplesig);
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3678,15 +3678,23 @@ void jl_init_types(void)
 
     jl_typemap_level_type =
         jl_new_datatype(jl_symbol("TypeMapLevel"), jl_any_type, jl_emptysvec,
-                        jl_svec(7,
-                            jl_symbol("index_arg1"),
-                            jl_symbol("arg1"),
+                        jl_svec(11,
                             jl_symbol("index_targ"),
                             jl_symbol("targ"),
+                            jl_symbol("index_arg1"),
+                            jl_symbol("arg1"),
+                            jl_symbol("index_tname"),
+                            jl_symbol("tname"),
+                            jl_symbol("index_name1"),
+                            jl_symbol("name1"),
                             jl_symbol("list"),
                             jl_symbol("any"),
                             jl_symbol("key")),
-                        jl_svec(7,
+                        jl_svec(11,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
@@ -3694,7 +3702,7 @@ void jl_init_types(void)
                             jl_any_type,
                             jl_any_type,
                             jl_any_type),
-                        0, 1, 6);
+                        0, 1, 10);
 
     jl_typemap_entry_type =
         jl_new_datatype(jl_symbol("TypeMapEntry"), jl_any_type, jl_emptysvec,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3678,7 +3678,8 @@ void jl_init_types(void)
 
     jl_typemap_level_type =
         jl_new_datatype(jl_symbol("TypeMapLevel"), jl_any_type, jl_emptysvec,
-                        jl_svec(11,
+                        jl_svec(12,
+                            jl_symbol("bottom"),
                             jl_symbol("index_targ"),
                             jl_symbol("targ"),
                             jl_symbol("index_arg1"),
@@ -3690,7 +3691,8 @@ void jl_init_types(void)
                             jl_symbol("list"),
                             jl_symbol("any"),
                             jl_symbol("key")),
-                        jl_svec(11,
+                        jl_svec(12,
+                            jl_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
@@ -3702,11 +3704,11 @@ void jl_init_types(void)
                             jl_any_type,
                             jl_any_type,
                             jl_any_type),
-                        0, 1, 10);
+                        0, 1, 11);
 
     jl_typemap_entry_type =
         jl_new_datatype(jl_symbol("TypeMapEntry"), jl_any_type, jl_emptysvec,
-                        jl_svec(9, jl_symbol("next"),
+                        jl_svec(10, jl_symbol("next"),
                                    jl_symbol("sig"),
                                    jl_symbol("tvars"),
                                    jl_symbol("simplesig"),
@@ -3714,13 +3716,15 @@ void jl_init_types(void)
                                    jl_symbol("func"),
                                    jl_symbol("isleafsig"),
                                    jl_symbol("issimplesig"),
-                                   jl_symbol("va")),
-                        jl_svec(9, jl_any_type, // Union{TypeMapEntry, Void}
+                                   jl_symbol("va"),
+                                   jl_symbol("weak")),
+                        jl_svec(10, jl_any_type, // Union{TypeMapEntry, Void}
                                    jl_type_type, // TupleType
                                    jl_any_type, // Union{SimpleVector{TypeVar}, TypeVar}
                                    jl_any_type, // TupleType
                                    jl_any_type, // SimpleVector{TupleType}
                                    jl_any_type, // Any
+                                   jl_bool_type,
                                    jl_bool_type,
                                    jl_bool_type,
                                    jl_bool_type),

--- a/src/julia.h
+++ b/src/julia.h
@@ -416,6 +416,7 @@ typedef struct _jl_typemap_entry_t {
     int8_t isleafsig; // isleaftype(sig) & !any(isType, sig) : unsorted and very fast
     int8_t issimplesig; // all(isleaftype | isAny | isType | isVararg, sig) : sorted and fast
     int8_t va; // isVararg(sig)
+    int8_t weak; // will never overwrite a signature
 } jl_typemap_entry_t;
 
 // one level in a TypeMap tree
@@ -426,11 +427,12 @@ struct jl_ordereddict_t {
 };
 typedef struct _jl_typemap_level_t {
     JL_DATA_TYPE
+    jl_typemap_entry_t *bottom; // union jl_typemap_t (but no more levels) for entries which have no type at offs
     struct jl_ordereddict_t targ; // contains Type{LeafType}
     struct jl_ordereddict_t arg1; // contains LeafType
     struct jl_ordereddict_t tname; // contains non-abstract Type{TypeName}
     struct jl_ordereddict_t name1; // contains non-abstract TypeName
-    jl_typemap_entry_t *linear; // union jl_typemap_t (but no more levels)
+    jl_typemap_entry_t *linear; // union jl_typemap_t (but no more levels) - most entries usually end up here
     union jl_typemap_t any; // type at offs is Any
     jl_value_t *key; // [nullable]
 } jl_typemap_level_t;
@@ -999,7 +1001,9 @@ STATIC_INLINE int jl_is_leaf_type_(jl_value_t *v)
 
 // type constructors
 JL_DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name);
-JL_DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name,jl_value_t *lb,jl_value_t *ub);
+JL_DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name, jl_value_t *lb, jl_value_t *ub);
+JL_DLLEXPORT jl_tvar_t *jl_new_typevar_(jl_sym_t *name, jl_value_t *lb,
+                                        jl_value_t *ub, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params);
 JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params);
 JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np);

--- a/src/julia.h
+++ b/src/julia.h
@@ -300,7 +300,7 @@ typedef struct {
     jl_value_t *primary;
     jl_svec_t *cache;        // sorted array
     jl_svec_t *linearcache;  // unsorted array
-    intptr_t uid;
+    uint32_t uid;
     struct _jl_methtable_t *mt;
 } jl_typename_t;
 
@@ -426,8 +426,10 @@ struct jl_ordereddict_t {
 };
 typedef struct _jl_typemap_level_t {
     JL_DATA_TYPE
-    struct jl_ordereddict_t arg1;
-    struct jl_ordereddict_t targ;
+    struct jl_ordereddict_t targ; // contains Type{LeafType}
+    struct jl_ordereddict_t arg1; // contains LeafType
+    struct jl_ordereddict_t tname; // contains non-abstract Type{TypeName}
+    struct jl_ordereddict_t name1; // contains non-abstract TypeName
     jl_typemap_entry_t *linear; // union jl_typemap_t (but no more levels)
     union jl_typemap_t any; // type at offs is Any
     jl_value_t *key; // [nullable]

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -25,6 +25,55 @@ static int jl_is_any(jl_value_t *t1)
              !((jl_tvar_t*)t1)->bound));
 }
 
+// the goal here is to compute if sig is more-specific
+// than something we can put into the TypeName-based hash tables
+static int jl_args_morespecific_typename(jl_value_t *t1)
+{
+    if (jl_is_typector(t1))
+        t1 = (jl_value_t*)((jl_typector_t*)t1)->body;
+    if (jl_is_uniontype(t1)) {
+        jl_uniontype_t *ut = (jl_uniontype_t*)t1;
+        size_t i, l = jl_svec_len(ut->types);
+        for (i = 0; i < l; i++) {
+            if (jl_args_morespecific_typename(jl_svecref(ut->types, i)))
+                return 1;
+        }
+        return 0;
+    }
+    else if (jl_is_typevar(t1)) {
+        return jl_args_morespecific_typename(((jl_tvar_t*)t1)->ub);
+    }
+    else if (jl_is_tuple(t1)) {
+        return 0;
+    }
+    else if (jl_is_type_type(t1)) {
+        return jl_args_morespecific_typename(jl_tparam0(t1));
+    }
+    else if (jl_is_datatype(t1)) {
+        return !((jl_datatype_t*)t1)->abstract && !is_kind(t1);
+    }
+    return 0;
+}
+
+static jl_value_t* jl_type_extract_name(jl_value_t *t1)
+{
+    if (jl_is_typector(t1))
+        t1 = (jl_value_t*)((jl_typector_t*)t1)->body;
+    if (jl_is_vararg_type(t1)) {
+        return jl_type_extract_name(jl_tparam0(t1));
+    }
+    else if (jl_is_typevar(t1)) {
+        return jl_type_extract_name(((jl_tvar_t*)t1)->ub);
+    }
+    else if (jl_is_datatype(t1)) {
+        jl_datatype_t *dt = (jl_datatype_t*)t1;
+        if (!dt->abstract && !is_kind(t1) && dt->name != jl_tuple_typename)
+            return (jl_value_t*)dt->name;
+    }
+    return NULL;
+}
+
+
 // ----- Type Signature Subtype Testing ----- //
 
 static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_t n)
@@ -238,9 +287,13 @@ static jl_array_t *jl_alloc_int_1d(size_t np, size_t len)
 static inline
 union jl_typemap_t mtcache_hash_lookup(const struct jl_ordereddict_t *a, jl_value_t *ty, int8_t tparam, int8_t offs)
 {
-    uintptr_t uid = ((jl_datatype_t*)ty)->uid;
+    uintptr_t uid;
     union jl_typemap_t ml;
     ml.unknown = jl_nothing;
+    if (tparam & 2)
+       uid = ((jl_typename_t*)ty)->uid;
+    else
+       uid = ((jl_datatype_t*)ty)->uid;
     if (!uid)
         return ml;
     size_t idx = jl_intref(a->indexes, uid & (a->indexes->nrows-1));
@@ -255,8 +308,10 @@ union jl_typemap_t mtcache_hash_lookup(const struct jl_ordereddict_t *a, jl_valu
         else {
             assert(jl_typeof(ml.unknown) == (jl_value_t*)jl_typemap_entry_type);
             t = jl_field_type(ml.leaf->sig, offs);
-            if (tparam)
+            if (tparam & 1)
                 t = jl_tparam0(t);
+            if (tparam & 2)
+                t = jl_type_extract_name(t);
         }
         if (t != ty)
             ml.unknown = jl_nothing;
@@ -284,28 +339,33 @@ static void mtcache_rehash(struct jl_ordereddict_t *pa, size_t newlen, jl_value_
     for (i = 1; i <= nval; i++) {
         union jl_typemap_t ml;
         ml.unknown = jl_array_ptr_ref(pa->values, i - 1);
-        if (ml.unknown == jl_nothing)
-            continue;
-        jl_value_t *t;
-        if (jl_typeof(ml.unknown) == (jl_value_t*)jl_typemap_level_type) {
-            t = ml.node->key;
-        }
-        else {
-            assert(jl_typeof(ml.unknown) == (jl_value_t*)jl_typemap_entry_type);
-            t = jl_field_type(ml.leaf->sig, offs);
-            if (tparam)
-                t = jl_tparam0(t);
-        }
-        uintptr_t uid = ((jl_datatype_t*)t)->uid;
-        size_t newi = uid & (newlen - 1);
-        if (jl_intref(n, newi) == 0) {
-            jl_intset(n, newi, i);
-        }
-        else {
-            // hash collision: start over after doubling the size again
-            i = 0;
-            newlen *= 2;
-            n = jl_alloc_int_1d(nval + 1, newlen);
+        if (ml.unknown != jl_nothing) {
+            jl_value_t *t;
+            if (jl_typeof(ml.unknown) == (jl_value_t*)jl_typemap_level_type) {
+                t = ml.node->key;
+            }
+            else {
+                t = jl_field_type(ml.leaf->sig, offs);
+                if (tparam & 1)
+                    t = jl_tparam0(t);
+                if (tparam & 2)
+                    t = jl_type_extract_name(t);
+            }
+            uintptr_t uid;
+            if (tparam & 2)
+                uid = ((jl_typename_t*)t)->uid;
+            else
+                uid = ((jl_datatype_t*)t)->uid;
+            size_t newi = uid & (newlen - 1);
+            if (jl_intref(n, newi) == 0) {
+                jl_intset(n, newi, i);
+            }
+            else {
+                // hash collision: start over after doubling the size again
+                i = 0;
+                newlen *= 2;
+                n = jl_alloc_int_1d(nval + 1, newlen);
+            }
         }
     }
     pa->indexes = n;
@@ -330,6 +390,10 @@ void jl_typemap_rehash(union jl_typemap_t ml, int8_t offs) {
             jl_typemap_rehash_array(&ml.node->targ, ml.unknown, 1, offs);
         if (ml.node->arg1.values != (void*)jl_nothing)
             jl_typemap_rehash_array(&ml.node->arg1, ml.unknown, 0, offs);
+        if (ml.node->tname.values != (void*)jl_nothing)
+            jl_typemap_rehash_array(&ml.node->tname, ml.unknown, 3, offs);
+        if (ml.node->name1.values != (void*)jl_nothing)
+            jl_typemap_rehash_array(&ml.node->name1, ml.unknown, 2, offs);
         jl_typemap_rehash(ml.node->any, offs+1);
     }
 }
@@ -337,48 +401,57 @@ void jl_typemap_rehash(union jl_typemap_t ml, int8_t offs) {
 static union jl_typemap_t *mtcache_hash_bp(struct jl_ordereddict_t *pa, jl_value_t *ty,
                                            int8_t tparam, int8_t offs, jl_value_t *parent)
 {
-    if (jl_is_datatype(ty)) {
-        uintptr_t uid = ((jl_datatype_t*)ty)->uid;
+    uintptr_t uid;
+    if (tparam & 2) {
+        //if (ty == jl_datatype_type->name || ty == jl_typector_type->name)
+        //    return NULL; // this is already handled in jl_type_extract_name
+        uid = ((jl_typename_t*)ty)->uid;
+    }
+    else {
+        if (!jl_is_datatype(ty))
+            return NULL;
+        uid = ((jl_datatype_t*)ty)->uid;
         if (!uid || is_kind(ty) || jl_has_typevars(ty))
             // be careful not to put non-leaf types or DataType/TypeConstructor in the cache here,
             // since they should have a lower priority and need to go into the sorted list
             return NULL;
-        if (pa->values == (void*)jl_nothing) {
-            pa->indexes = jl_alloc_int_1d(0, INIT_CACHE_SIZE);
-            jl_gc_wb(parent, pa->indexes);
-            pa->values = jl_alloc_vec_any(0);
-            jl_gc_wb(parent, pa->values);
-        }
-        while (1) {
-            size_t slot = uid & (pa->indexes->nrows - 1);
-            size_t idx = jl_intref(pa->indexes, slot);
-            if (idx == 0) {
-                jl_array_ptr_1d_push(pa->values, jl_nothing);
-                idx = jl_array_len(pa->values);
-                if (idx > jl_max_int(pa->indexes))
-                    mtcache_rehash(pa, jl_array_len(pa->indexes), parent, tparam, offs);
-                jl_intset(pa->indexes, slot, idx);
-                return &((union jl_typemap_t*)jl_array_data(pa->values))[idx - 1];
-            }
-            union jl_typemap_t *pml = &((union jl_typemap_t*)jl_array_data(pa->values))[idx - 1];
-            if (pml->unknown == jl_nothing)
-                return pml;
-            jl_value_t *t;
-            if (jl_typeof(pml->unknown) == (jl_value_t*)jl_typemap_level_type) {
-                t = pml->node->key;
-            }
-            else {
-                assert(jl_typeof(pml->unknown) == (jl_value_t*)jl_typemap_entry_type);
-                t = jl_field_type(pml->leaf->sig, offs);
-                if (tparam)
-                    t = jl_tparam0(t);
-            }
-            if (t == ty)
-                return pml;
-            mtcache_rehash(pa, jl_array_len(pa->indexes) * 2, parent, tparam, offs);
-        }
     }
-    return NULL;
+    if (pa->values == (void*)jl_nothing) {
+        pa->indexes = jl_alloc_int_1d(0, INIT_CACHE_SIZE);
+        jl_gc_wb(parent, pa->indexes);
+        pa->values = jl_alloc_vec_any(0);
+        jl_gc_wb(parent, pa->values);
+    }
+    while (1) {
+        size_t slot = uid & (pa->indexes->nrows - 1);
+        size_t idx = jl_intref(pa->indexes, slot);
+        if (idx == 0) {
+            jl_array_ptr_1d_push(pa->values, jl_nothing);
+            idx = jl_array_len(pa->values);
+            if (idx > jl_max_int(pa->indexes))
+                mtcache_rehash(pa, jl_array_len(pa->indexes), parent, tparam, offs);
+            jl_intset(pa->indexes, slot, idx);
+            return &((union jl_typemap_t*)jl_array_data(pa->values))[idx - 1];
+        }
+        union jl_typemap_t *pml = &((union jl_typemap_t*)jl_array_data(pa->values))[idx - 1];
+        if (pml->unknown == jl_nothing)
+            return pml;
+        jl_value_t *t;
+        if (jl_typeof(pml->unknown) == (jl_value_t*)jl_typemap_level_type) {
+            t = pml->node->key;
+        }
+        else {
+            assert(jl_typeof(pml->unknown) == (jl_value_t*)jl_typemap_entry_type);
+            t = jl_field_type(pml->leaf->sig, offs);
+            if (tparam & 1)
+                t = jl_tparam0(t);
+            if (tparam & 2)
+                t = jl_type_extract_name(t);
+        }
+        if (t == ty)
+            return pml;
+        mtcache_rehash(pa, jl_array_len(pa->indexes) * 2, parent, tparam, offs);
+    }
 }
 
 
@@ -445,6 +518,12 @@ int jl_typemap_visitor(union jl_typemap_t cache, jl_typemap_visitor_fptr fptr, v
         if (cache.node->arg1.values != (void*)jl_nothing)
             if (!jl_typemap_array_visitor(&cache.node->arg1, fptr, closure))
                 return 0;
+        if (cache.node->tname.values != (void*)jl_nothing)
+            if (!jl_typemap_array_visitor(&cache.node->tname, fptr, closure))
+                return 0;
+        if (cache.node->name1.values != (void*)jl_nothing)
+            if (!jl_typemap_array_visitor(&cache.node->name1, fptr, closure))
+                return 0;
         if (!jl_typemap_node_visitor(cache.node->linear, fptr, closure))
             return 0;
         return jl_typemap_visitor(cache.node->any, fptr, closure);
@@ -468,11 +547,32 @@ static int jl_typemap_intersection_array_visitor(struct jl_ordereddict_t *a, jl_
     union jl_typemap_t *data = (union jl_typemap_t*)jl_array_data(a->values);
     for (i = 0; i < l; i++) {
         union jl_typemap_t ml = data[i];
-        if (ml.unknown == jl_nothing)
-            continue;
         jl_value_t *t;
-        if (jl_typeof(ml.unknown) == (jl_value_t*)jl_typemap_level_type) {
-            t = ml.node->key;
+        if (ml.unknown != jl_nothing) {
+            if (jl_typeof(ml.unknown) == (jl_value_t*)jl_typemap_level_type) {
+                t = ml.node->key;
+            }
+            else {
+                t = jl_field_type(ml.leaf->sig, offs);
+                if (tparam & 1)
+                    t = jl_tparam0(t);
+            }
+            if (tparam & 2) {
+                // TODO: fast path rejection test
+                if (!jl_typemap_intersection_visitor(ml, offs+1, closure))
+                    return 0;
+            } else {
+                if (ty == (jl_value_t*)jl_any_type || // easy case: Any always matches
+                    (tparam ?  // need to compute `ty <: Type{t}`
+                     (jl_is_uniontype(ty) || // punt on Union{...} right now
+                      jl_typeof(t) == ty || // deal with kinds (e.g. ty == DataType && t == Type{t})
+                      (jl_is_type_type(ty) && (jl_is_typevar(jl_tparam0(ty)) ?
+                                               jl_subtype(t, ((jl_tvar_t*)jl_tparam0(ty))->ub, 0) : // deal with ty == Type{<:T}
+                                               jl_subtype(t, jl_tparam0(ty), 0)))) // deal with ty == Type{T{#<:T}}
+                            : jl_subtype(t, ty, 0))) // `t` is a leaftype, so intersection test becomes subtype
+                    if (!jl_typemap_intersection_visitor(ml, offs+1, closure))
+                        return 0;
+            }
         }
         else {
             t = jl_field_type(ml.leaf->sig, offs);
@@ -574,6 +674,17 @@ int jl_typemap_intersection_visitor(union jl_typemap_t map, int offs,
                     // else an array scan is required to check subtypes
                     if (!jl_typemap_intersection_array_visitor(&cache->arg1, ty, 0, offs, closure)) return 0;
                 }
+            }
+        }
+        if (ty) {
+            if (cache->tname.values != (void*)jl_nothing) {
+                // TODO: optimized fast path
+                //jl_value_t *typetype = jl_is_type_type(ty) ? jl_tparam0(ty) : NULL;
+                if (!jl_typemap_intersection_array_visitor(&cache->tname, ty, 3, offs, closure)) return 0;
+            }
+            if (cache->name1.values != (void*)jl_nothing) {
+                // TODO: optimized fast path
+                if (!jl_typemap_intersection_array_visitor(&cache->name1, ty, 2, offs, closure)) return 0;
             }
         }
         if (!jl_typemap_intersection_node_visitor(map.node->linear, closure))
@@ -735,7 +846,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
         else if (l > offs) {
             ty = jl_tparam(types, offs);
         }
-        // If there is a type at offs, look in the optimized caches
+        // If there is a type at offs, look in the optimized leaf type caches
         if (!subtype) {
             if (ty && jl_is_any(ty))
                 return jl_typemap_assoc_by_type(cache->any, types, penv, subtype_inexact__sigseq_useenv, subtype, offs+1);
@@ -764,6 +875,31 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
                 }
             }
             if (!subtype && is_cache_leaf(ty)) return NULL;
+        }
+        // if there is a type at offs, now look at the optimized TypeName caches
+        if (ty) {
+            if (cache->tname.values != (void*)jl_nothing && jl_is_type_type(ty)) {
+                jl_value_t *a0 = jl_type_extract_name(jl_tparam0(ty));
+                if (a0) {
+                    union jl_typemap_t ml = mtcache_hash_lookup(&cache->tname, a0, 3, offs);
+                    if (ml.unknown != jl_nothing) {
+                        jl_typemap_entry_t *li = jl_typemap_assoc_by_type(ml, types, penv,
+                                subtype_inexact__sigseq_useenv, subtype, offs+1);
+                        if (li) return li;
+                    }
+                }
+            }
+            if (cache->name1.values != (void*)jl_nothing) {
+                jl_value_t *a0 = jl_type_extract_name(ty);
+                if (a0) {
+                    union jl_typemap_t ml = mtcache_hash_lookup(&cache->name1, a0, 2, offs);
+                    if (ml.unknown != jl_nothing) {
+                        jl_typemap_entry_t *li = jl_typemap_assoc_by_type(ml, types, penv,
+                                subtype_inexact__sigseq_useenv, subtype, offs+1);
+                        if (li) return li;
+                    }
+                }
+            }
         }
         // Always check the list (since offs doesn't always start at 0)
         if (subtype) {
@@ -858,9 +994,10 @@ nomatch:
 
 jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs)
 {
+    jl_value_t *a1 = NULL, *ty = NULL;
     if (n > offs) {
-        jl_value_t *a1 = args[offs];
-        jl_value_t *ty = (jl_value_t*)jl_typeof(a1);
+        a1 = args[offs];
+        ty = (jl_value_t*)jl_typeof(a1);
         assert(jl_is_datatype(ty));
         if (ty == (jl_value_t*)jl_datatype_type && cache->targ.values != (void*)jl_nothing) {
             union jl_typemap_t ml_or_cache = mtcache_hash_lookup(&cache->targ, a1, 1, offs);
@@ -869,6 +1006,16 @@ jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_v
         }
         if (cache->arg1.values != (void*)jl_nothing) {
             union jl_typemap_t ml_or_cache = mtcache_hash_lookup(&cache->arg1, ty, 0, offs);
+            jl_typemap_entry_t *ml = jl_typemap_assoc_exact(ml_or_cache, args, n, offs+1);
+            if (ml) return ml;
+        }
+        if (ty == (jl_value_t*)jl_datatype_type && cache->tname.values != (void*)jl_nothing) {
+            union jl_typemap_t ml_or_cache = mtcache_hash_lookup(&cache->tname, (jl_value_t*)((jl_datatype_t*)a1)->name, 3, offs);
+            jl_typemap_entry_t *ml = jl_typemap_assoc_exact(ml_or_cache, args, n, offs+1);
+            if (ml) return ml;
+        }
+        if (cache->name1.values != (void*)jl_nothing) {
+            union jl_typemap_t ml_or_cache = mtcache_hash_lookup(&cache->name1, (jl_value_t*)((jl_datatype_t*)ty)->name, 2, offs);
             jl_typemap_entry_t *ml = jl_typemap_assoc_exact(ml_or_cache, args, n, offs+1);
             if (ml) return ml;
         }
@@ -912,6 +1059,10 @@ static jl_typemap_level_t *jl_new_typemap_level(void)
     cache->targ.values = (jl_array_t*)jl_nothing;
     cache->arg1.indexes = (jl_array_t*)jl_nothing;
     cache->arg1.values = (jl_array_t*)jl_nothing;
+    cache->tname.indexes = (jl_array_t*)jl_nothing;
+    cache->tname.values = (jl_array_t*)jl_nothing;
+    cache->name1.indexes = (jl_array_t*)jl_nothing;
+    cache->name1.values = (jl_array_t*)jl_nothing;
     return cache;
 }
 
@@ -1000,15 +1151,27 @@ static void jl_typemap_level_insert_(jl_typemap_level_t *cache, jl_typemap_entry
         return jl_typemap_insert_generic(&cache->any, (jl_value_t*)cache, newrec, (jl_value_t*)jl_any_type, offs+1, tparams);
     // Don't put Varargs in the optimized caches (too hard to handle in lookup and bp)
     if (t1 && !isva) {
-        // if t1 != jl_typetype_type and the argument is Type{...}, this
-        // method has specializations for singleton kinds and we use
-        // the table indexed for that purpose.
+        // try to put in leaf type caches
         if (t1 != (jl_value_t*)jl_typetype_type && jl_is_type_type(t1)) {
+            // if t1 != jl_typetype_type and the argument is Type{...}, this
+            // method has specializations for singleton kinds and we use
+            // the table indexed for that purpose.
             jl_value_t *a0 = jl_tparam0(t1);
             if (jl_typemap_array_insert_(&cache->targ, a0, newrec, (jl_value_t*)cache, 1, offs, tparams))
                 return;
         }
         if (jl_typemap_array_insert_(&cache->arg1, t1, newrec, (jl_value_t*)cache, 0, offs, tparams))
+            return;
+
+        // try to put in TypeName caches
+        jl_value_t *a0;
+        if (jl_is_type_type(t1)) {
+            a0 = jl_type_extract_name(jl_tparam0(t1));
+            if (a0 && jl_typemap_array_insert_(&cache->tname, a0, newrec, (jl_value_t*)cache, 3, offs, tparams))
+                return;
+        }
+        a0 = jl_type_extract_name(t1);
+        if (a0 && jl_typemap_array_insert_(&cache->name1, a0, newrec, (jl_value_t*)cache, 2, offs, tparams))
             return;
     }
     jl_typemap_list_insert_(&cache->linear, (jl_value_t*)cache, newrec, tparams);


### PR DESCRIPTION
There's still a few TODO items to get full use of this optimization, but I figured I'd give a sneak peek at some of the numbers I think I'm getting. Currently, this seems to give about a 50% speedup on loading precompiled files and makes the most significant dent to-date in https://github.com/JuliaLang/julia/issues/15048:

``` julia
~/julia-master$ time ./julia -e 'using DataFrames'
real    0m32.365s
user    0m31.650s
sys 0m2.069s
~/julia-master$ time ./julia -e 'using DataFrames'
real    0m0.917s
user    0m0.871s
sys 0m0.143s
```

``` julia
~/julia$ time ./julia -e 'using DataFrames'
real    0m24.753s
user    0m24.297s
sys 0m1.900s
~/julia$ time ./julia -e 'using DataFrames'
real    0m0.742s
user    0m0.696s
sys 0m0.139s
```

I think this should finally gets us to the realm where #15048 is caused by general slow startup issues (which may be helped by #5155) and not specific to reloading method tables :)

The longer technical explanation for what this patch does is that it creates a new hashmap level in the TypeMap object that splits on the uid of the names of concrete types. This gives us the following sorted levels:
- Type{LeafType} hash-table
- LeafType hash-table
- ~~linear-sorted list of the stuff that goes here (the technical definition of stuff is `jl_args_morespecific_typename`)~~
- linear-sorted list of signatures shorter than `offs` (prevents matching varargs)
- Type{Concrete TypeName} hash-table (possibly split via `jl_args_morespecific_typename` from another sig)
- Concrete TypeName hash-table (also possibly split)
- linear-sorted list of everything else
- `::Any`
