### PR TITLE
Static evaluation of method_exists (when true)

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -6918,23 +6918,6 @@ true
 method_exists
 
 """
-    @method_exists(f, tt)
-
-Determine whether the given generic function `f` has a method matching
-the given tuple `tt` of argument types. When used in a function, if
-the method exists at the time the function is compiled, this statement
-simple gets replaced by `true` (and hence has no runtime overhead). If
-the function does not exist, then it is equivalent to the function
-form, `method_exists`.
-
-```jldoctest
-julia> @method_exists(length, Tuple{Array})
-true
-```
-"""
-:@method_exists
-
-"""
     nextpow(a, x)
 
 The smallest `a^n` not less than `x`, where `n` is a non-negative integer. `a` must be

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -6908,7 +6908,7 @@ EnvHash
     method_exists(f, Tuple type) -> Bool
 
 Determine whether the given generic function has a method matching the given
-[`Tuple`](:obj:`Tuple`) of argument types.
+[`Tuple`](:obj:`Tuple`) of argument types. See also `@method_exists`.
 
 ```jldoctest
 julia> method_exists(length, Tuple{Array})
@@ -6916,6 +6916,23 @@ true
 ```
 """
 method_exists
+
+"""
+    @method_exists(f, tt)
+
+Determine whether the given generic function `f` has a method matching
+the given tuple `tt` of argument types. When used in a function, if
+the method exists at the time the function is compiled, this statement
+simple gets replaced by `true` (and hence has no runtime overhead). If
+the function does not exist, then it is equivalent to the function
+form, `method_exists`.
+
+```jldoctest
+julia> @method_exists(length, Tuple{Array})
+true
+```
+"""
+:@method_exists
 
 """
     nextpow(a, x)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1358,6 +1358,7 @@ export
     @which,
     @edit,
     @functionloc,
+    @method_exists,
     @less,
     @code_typed,
     @code_warntype,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -443,6 +443,23 @@ end
 # For static evaluation of method_exists, when it evaluates to true.
 # We don't evaluate it at compile-time when false, because someone
 # might define the missing method later.
+"""
+    @method_exists(f, tt)
+
+Determine whether the given generic function `f` has a method matching
+the given tuple `tt` of argument types. When used in a function, if
+the method exists at the time the function is compiled, this statement
+simply gets replaced by `true` (and hence has no runtime overhead). If
+the function does not exist, then it is equivalent to the function
+form, `method_exists`.
+
+```jldoctest
+julia> @method_exists(length, Tuple{Array})
+true
+```
+"""
+:@method_exists
+
 macro method_exists(f, tt)
     exmt = :(typeof($f).name.mt)  # get the method table for f
     # Form the tuple-type of the function + argument types

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -626,11 +626,22 @@ Generic Functions
 
    .. Docstring generated from Julia source
 
-   Determine whether the given generic function has a method matching the given :obj:`Tuple` of argument types.
+   Determine whether the given generic function has a method matching the given :obj:`Tuple` of argument types. See also ``@method_exists``\ .
 
    .. doctest::
 
        julia> method_exists(length, Tuple{Array})
+       true
+
+.. function:: @method_exists(f, tt)
+
+   .. Docstring generated from Julia source
+
+   Determine whether the given generic function ``f`` has a method matching the given tuple ``tt`` of argument types. When used in a function, if the method exists at the time the function is compiled, this statement simple gets replaced by ``true`` (and hence has no runtime overhead). If the function does not exist, then it is equivalent to the function form, ``method_exists``\ .
+
+   .. doctest::
+
+       julia> @method_exists(length, Tuple{Array})
        true
 
 .. function:: applicable(f, args...) -> Bool

--- a/src/julia.h
+++ b/src/julia.h
@@ -1209,6 +1209,9 @@ STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 JL_DLLEXPORT void jl_module_run_initializer(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
+// methods
+JL_DLLEXPORT int jl_method_exists(jl_methtable_t *mt, jl_tupletype_t *types);
+
 // eq hash tables
 JL_DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val);
 JL_DLLEXPORT jl_value_t *jl_eqtable_get(jl_array_t *h, void *key,

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -439,3 +439,44 @@ fLargeTable() = 4
 # issue #15280
 function f15280(x) end
 @test functionloc(f15280)[2] > 0
+
+# Static evaluation of method_exists (#16422)
+meth16422(x::Int, y::Int) = 0
+function static_meth_exists_tt()
+    # As a tuple-type
+    if @method_exists(meth16422, Tuple{Int,Int})
+        return true
+    end
+    false
+end
+@test static_meth_exists_tt()
+io = IOBuffer()
+code_llvm(io, static_meth_exists_tt, ())
+str = takebuf_string(io)
+@test contains(str, "top:\n  ret i1 true\n}")
+
+function static_meth_exists_t()
+    # As a tuple
+    if @method_exists(meth16422, (Int,Int))
+        return true
+    end
+    false
+end
+@test static_meth_exists_t()
+io = IOBuffer()
+code_llvm(io, static_meth_exists_t, ())
+str = takebuf_string(io)
+@test contains(str, "top:\n  ret i1 true\n}")
+
+function static_meth_not_exists()
+    if @method_exists(meth16422, Tuple{Int,String})
+        return true
+    end
+    false
+end
+@test !static_meth_not_exists()
+code_llvm(io, static_meth_not_exists, ())
+str = takebuf_string(io)
+@test !contains(str, "ret i1 true") && !contains(str, "ret i1 false")
+meth16422(x::Int, y::String) = 1
+@test static_meth_not_exists()  # define it later, should be true


### PR DESCRIPTION
Given that I encouraged @nalimilan to shoot for #16401, I felt I should chip in by trying to figure out how to evaluate `method_exists` at compile time. Also of apparent interest to @stevengj (#7088).

I tried to simply follow #7088, but there are clearly some differences. Here's my test script:

``` jl
function foo(a, b)
    if ccall(:jl_method_exists, Cint, (Any, Any), typeof(-).name.mt, Tuple{typeof(-), typeof(a), typeof(b)}) != 0
        return a - b
    end
    b
end

function foo2(a, b)
    if my_method_exists(-, (typeof(a), typeof(b)))
        return a - b
    end
    b
end

@inline function my_method_exists(f, t)
    return ccall(:jl_method_exists, Cint, (Any, Any), typeof(f).name.mt, makett(f, t)) != 0
end

using Base.@pure

@pure function makett(f, t)
    t1 = Base.to_tuple_type(t)
    Tuple{isa(f,Type) ? Type{f} : typeof(f), t1.parameters...}
end
```

Following with gdb, it's clear that `foo` works (confirmed by `@code_native`, though in contrast with `isleaftype` this happy outcome is not revealed with `@code_warntype`). However, with `foo2` it doesn't. It also doesn't work if I evaluate `makett` and store it in a variable before issuing the `ccall`. Do I have to statically evaluate the call to `makett`, or am I barking up the wrong tree here?
