### PR TITLE
Making `\` work with SparseMatrix.CHOLMOD.Factor and SubArrays

### DIFF
--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -809,7 +809,7 @@ get_perm(FC::FactorComponent) = get_perm(Factor(FC))
 #########################
 
 # Convertion/construction
-function convert{T<:VTypes}(::Type{Dense{T}}, A::VecOrMat)
+function convert{T<:VTypes}(::Type{Dense{T}}, A::StridedVecOrMat)
     d = allocate_dense(size(A, 1), size(A, 2), stride(A, 2), T)
     s = unsafe_load(d.p)
     for i in eachindex(A)
@@ -817,7 +817,7 @@ function convert{T<:VTypes}(::Type{Dense{T}}, A::VecOrMat)
     end
     d
 end
-function convert(::Type{Dense}, A::VecOrMat)
+function convert(::Type{Dense}, A::StridedVecOrMat)
     T = promote_type(eltype(A), Float64)
     return convert(Dense{T}, A)
 end
@@ -1464,7 +1464,7 @@ Ac_ldiv_B(L::FactorComponent, B) = ctranspose(L)\B
 
 (\){T}(L::Factor{T}, B::Dense{T}) = solve(CHOLMOD_A, L, B)
 (\)(L::Factor{Float64}, B::VecOrMat{Complex{Float64}}) = L\real(B) + L\imag(B)
-(\)(L::Factor, b::Vector) = Vector(L\convert(Dense{eltype(L)}, b))
+(\)(L::Factor, b::StridedVector) = Vector(L\convert(Dense{eltype(L)}, b))
 (\)(L::Factor, B::Matrix) = Matrix(L\convert(Dense{eltype(L)}, B))
 (\)(L::Factor, B::Sparse) = spsolve(CHOLMOD_A, L, B)
 # When right hand side is sparse, we have to ensure that the rhs is not marked as symmetric.

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1465,7 +1465,7 @@ Ac_ldiv_B(L::FactorComponent, B) = ctranspose(L)\B
 (\){T}(L::Factor{T}, B::Dense{T}) = solve(CHOLMOD_A, L, B)
 (\)(L::Factor{Float64}, B::VecOrMat{Complex{Float64}}) = L\real(B) + L\imag(B)
 (\)(L::Factor, b::StridedVector) = Vector(L\convert(Dense{eltype(L)}, b))
-(\)(L::Factor, B::Matrix) = Matrix(L\convert(Dense{eltype(L)}, B))
+(\)(L::Factor, B::StridedMatrix) = Matrix(L\convert(Dense{eltype(L)}, B))
 (\)(L::Factor, B::Sparse) = spsolve(CHOLMOD_A, L, B)
 # When right hand side is sparse, we have to ensure that the rhs is not marked as symmetric.
 (\)(L::Factor, B::SparseVecOrMat) = sparse(spsolve(CHOLMOD_A, L, Sparse(B, 0)))

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -632,3 +632,10 @@ Fnew = deserialize(b)
 @test_throws MethodError cholfact(speye(BigFloat, 5))
 @test_throws MethodError cholfact(Symmetric(speye(BigFloat, 5)))
 @test_throws MethodError cholfact(Hermitian(speye(Complex{BigFloat}, 5)))
+
+# test \ for Factor and StridedVecOrMat
+let x = rand(5)
+    A = cholfact(sparse(diagm(x.\1)))
+    @test_approx_eq A\sub(ones(10),1:2:10) x
+    @test_approx_eq A\slice(eye(5,5),:,:) diagm(x)
+end


### PR DESCRIPTION
This is needed by #16294 (see the discussion over there).

CC @andreasnoack 
