### PR TITLE
allow in place solving for UMFPACK

### DIFF
--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -251,7 +251,7 @@ for itype in UmfpackIndexTypes
         end
         function solve!(x::VecOrMat{Float64}, lu::UmfpackLU{Float64,$itype}, b::VecOrMat{Float64}, typ::Integer)
             if x === b
-                 throw(ArgumentError("output array must not be aliased with input array"))
+                throw(ArgumentError("output array must not be aliased with input array"))
             end
             umfpack_numeric!(lu)
             (size(b,1) == lu.m) && (size(b) == size(x)) || throw(DimensionMismatch())
@@ -267,7 +267,7 @@ for itype in UmfpackIndexTypes
         end
         function solve!(x::VecOrMat{Complex128}, lu::UmfpackLU{Complex128,$itype}, b::VecOrMat{Complex128}, typ::Integer)
             if x === b
-                 throw(ArgumentError("output array must not be aliased with input array"))
+                throw(ArgumentError("output array must not be aliased with input array"))
             end
             umfpack_numeric!(lu)
             (size(b,1) == lu.m) && (size(b) == size(x)) || throw(DimensionMismatch())

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -250,6 +250,9 @@ for itype in UmfpackIndexTypes
             return U
         end
         function solve!(x::VecOrMat{Float64}, lu::UmfpackLU{Float64,$itype}, b::VecOrMat{Float64}, typ::Integer)
+            if x === b
+                 throw(ArgumentError("output array must not be aliased with input array"))
+            end
             umfpack_numeric!(lu)
             (size(b,1) == lu.m) && (size(b) == size(x)) || throw(DimensionMismatch())
             joff = 1
@@ -263,6 +266,9 @@ for itype in UmfpackIndexTypes
             x
         end
         function solve!(x::VecOrMat{Complex128}, lu::UmfpackLU{Complex128,$itype}, b::VecOrMat{Complex128}, typ::Integer)
+            if x === b
+                 throw(ArgumentError("output array must not be aliased with input array"))
+            end
             umfpack_numeric!(lu)
             (size(b,1) == lu.m) && (size(b) == size(x)) || throw(DimensionMismatch())
             n = size(b,1)
@@ -382,8 +388,8 @@ for (f!, umfpack) in ((:A_ldiv_B!, :UMFPACK_A),
                       (:At_ldiv_B!, :UMFPACK_Aat))
     @eval begin
         $f!{T<:UMFVTypes}(x::VecOrMat{T}, lu::UmfpackLU{T}, b::VecOrMat{T}) = solve!(x, lu, b, $umfpack)
-        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Vector{T}) = $f!(similar(b), lu, b)
-        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Matrix{T}) = $f!(similar(b), lu, b)
+        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Vector{T}) = $f!(b, lu, copy(b))
+        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Matrix{T}) = $f!(b, lu, copy(b))
 
         function $f!{Tb<:Complex}(x::Vector{Tb}, lu::UmfpackLU{Float64}, b::Vector{Tb})
             n = size(b, 1)
@@ -398,7 +404,7 @@ for (f!, umfpack) in ((:A_ldiv_B!, :UMFPACK_A),
             end
             return x
         end
-        $f!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb}) = $f!(similar(b), lu, b)
+        $f!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb}) = $f!(b, lu, copy(b))
     end
 end
 

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -266,27 +266,15 @@ for itype in UmfpackIndexTypes
             umfpack_numeric!(lu)
             (size(b,1) == lu.m) && (size(b) == size(x)) || throw(DimensionMismatch())
             n = size(b,1)
-            br = Array{Float64}(n)
-            bi = Array{Float64}(n)
-            xr = Array{Float64}(n)
-            xi = Array{Float64}(n)
-            joff = 0
+            joff = 1
             for k = 1:size(b,2)
-                for j = 1:n
-                    bj = b[joff+j]
-                    br[j] = real(bj)
-                    bi[j] = imag(bj)
-                end
                 @isok ccall(($sol_c, :libumfpack), $itype,
                             ($itype, Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Float64},
                              Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
                              Ptr{Void}, Ptr{Float64}, Ptr{Float64}),
-                            typ, lu.colptr, lu.rowval, real(lu.nzval), imag(lu.nzval),
-                            xr, xi, br, bi,
+                            typ, lu.colptr, lu.rowval, lu.nzval, C_NULL,
+                            pointer(x, joff), C_NULL, pointer(b, joff), C_NULL,
                             lu.numeric, umf_ctrl, umf_info)
-                for j = 1:n
-                    x[joff+j] = complex(xr[j],xi[j])
-                end
                 joff += n
             end
             x

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -249,10 +249,9 @@ for itype in UmfpackIndexTypes
             U.numeric = tmp[1]
             return U
         end
-        function solve(lu::UmfpackLU{Float64,$itype}, b::VecOrMat{Float64}, typ::Integer)
+        function solve!(x::VecOrMat{Float64}, lu::UmfpackLU{Float64,$itype}, b::VecOrMat{Float64}, typ::Integer)
             umfpack_numeric!(lu)
-            size(b,1)==lu.m || throw(DimensionMismatch())
-            x = similar(b)
+            (size(b,1) == lu.m) && (size(b) == size(x)) || throw(DimensionMismatch())
             joff = 1
             for k = 1:size(b,2)
                 @isok ccall(($sol_r, :libumfpack), $itype,
@@ -263,10 +262,9 @@ for itype in UmfpackIndexTypes
             end
             x
         end
-        function solve(lu::UmfpackLU{Complex128,$itype}, b::VecOrMat{Complex128}, typ::Integer)
+        function solve!(x::VecOrMat{Complex128}, lu::UmfpackLU{Complex128,$itype}, b::VecOrMat{Complex128}, typ::Integer)
             umfpack_numeric!(lu)
-            size(b,1)==lu.m || throw(DimensionMismatch())
-            x = similar(b)
+            (size(b,1) == lu.m) && (size(b) == size(x)) || throw(DimensionMismatch())
             n = size(b,1)
             br = Array{Float64}(n)
             bi = Array{Float64}(n)
@@ -391,26 +389,29 @@ function nnz(lu::UmfpackLU)
 end
 
 ### Solve with Factorization
-A_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Vector{T}) = solve(lu, b, UMFPACK_A)
-A_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Matrix{T}) = solve(lu, b, UMFPACK_A)
-function A_ldiv_B!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb})
-    r = solve(lu, [convert(Float64,real(be)) for be in b], UMFPACK_A)
-    i = solve(lu, [convert(Float64,imag(be)) for be in b], UMFPACK_A)
-    Tb[r[k]+im*i[k] for k = 1:length(r)]
-end
+for (f!, umfpack) in ((:A_ldiv_B!, :UMFPACK_A),
+                      (:Ac_ldiv_B!, :UMFPACK_At),
+                      (:At_ldiv_B!, :UMFPACK_Aat))
+    @eval begin
+        $f!{T<:UMFVTypes}(x::VecOrMat{T}, lu::UmfpackLU{T}, b::VecOrMat{T}) = solve!(x, lu, b, $umfpack)
+        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Vector{T}) = $f!(similar(b), lu, b)
+        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Matrix{T}) = $f!(similar(b), lu, b)
 
-Ac_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::VecOrMat{T}) = solve(lu, b, UMFPACK_At)
-function Ac_ldiv_B!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb})
-    r = solve(lu, [convert(Float64,real(be)) for be in b], UMFPACK_At)
-    i = solve(lu, [convert(Float64,imag(be)) for be in b], UMFPACK_At)
-    Tb[r[k]+im*i[k] for k = 1:length(r)]
-end
-
-At_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::VecOrMat{T}) = solve(lu, b, UMFPACK_Aat)
-function At_ldiv_B!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb})
-    r = solve(lu, [convert(Float64,real(be)) for be in b], UMFPACK_Aat)
-    i = solve(lu, [convert(Float64,imag(be)) for be in b], UMFPACK_Aat)
-    Tb[r[k]+im*i[k] for k = 1:length(r)]
+        function $f!{Tb<:Complex}(x::Vector{Tb}, lu::UmfpackLU{Float64}, b::Vector{Tb})
+            n = size(b, 1)
+            # TODO: Optionally let user allocate these and pass in somehow
+            r = similar(b, Float64)
+            i = similar(b, Float64)
+            solve!(r, lu, convert(Vector{Float64}, real(b)), $umfpack)
+            solve!(i, lu, convert(Vector{Float64}, imag(b)), $umfpack)
+            # We have checked size in solve!
+            @inbounds for k in eachindex(x)
+                x[k] = Tb(r[k] + im*i[k])
+            end
+            return x
+        end
+        $f!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb}) = $f!(similar(b), lu, b)
+    end
 end
 
 function getindex(lu::UmfpackLU, d::Symbol)

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -20,38 +20,47 @@ for Tv in (Float64, Complex128)
         @test nnz(lua) == 18
         @test_throws KeyError lua[:Z]
         L,U,p,q,Rs = lua[:(:)]
-        @test_approx_eq (Diagonal(Rs) * A)[p,q] L * U
+        @test (Diagonal(Rs) * A)[p,q] ≈ L * U
 
-        @test_approx_eq det(lua) det(full(A))
+        det(lua) ≈ det(full(A))
 
         b = [8., 45., -3., 3., 19.]
         x = lua\b
-        @test_approx_eq x float([1:5;])
+        @test x ≈ float([1:5;])
 
         @test norm(A*x-b,1) < eps(1e4)
-        x = Base.SparseArrays.A_ldiv_B!(lua,complex(b,zeros(b)))
-        @test_approx_eq x float([1:5;])
+        z = complex(b,zeros(b))
+        x = Base.SparseArrays.A_ldiv_B!(lua, z)
+        @test x ≈ float([1:5;])
+        y = similar(z)
+        A_ldiv_B!(y, lua,z)
+        @test y ≈ x
 
         @test norm(A*x-b,1) < eps(1e4)
 
         b = [8., 20., 13., 6., 17.]
         x = lua'\b
-        @test_approx_eq x float([1:5;])
+        @test x ≈ float([1:5;])
 
         @test norm(A'*x-b,1) < eps(1e4)
         x = Base.SparseArrays.Ac_ldiv_B!(lua,complex(b,zeros(b)))
-        @test_approx_eq x float([1:5;])
+        @test x ≈ float([1:5;])
+        y = similar(x)
+        Base.SparseArrays.Ac_ldiv_B!(y, lua,complex(b,zeros(b)))
+        @test y ≈ x
 
         @test norm(A'*x-b,1) < eps(1e4)
         x = lua.'\b
-        @test_approx_eq x float([1:5;])
+        @test x ≈ float([1:5;])
 
         @test norm(A.'*x-b,1) < eps(1e4)
         x = Base.SparseArrays.At_ldiv_B!(lua,complex(b,zeros(b)))
-        @test_approx_eq x float([1:5;])
+        @test x ≈ float([1:5;])
+        y = similar(x)
+        Base.SparseArrays.At_ldiv_B!(y, lua,complex(b,zeros(b)))
+        @test y ≈ x
 
         @test norm(A.'*x-b,1) < eps(1e4)
-
 
         # Element promotion and type inference
         @inferred lua\ones(Int, size(A, 2))
@@ -63,7 +72,7 @@ for Ti in Base.SparseArrays.UMFPACK.UMFITypes.types
     Ac = convert(SparseMatrixCSC{Complex128,Ti}, Ac0)
     lua = lufact(Ac)
     L,U,p,q,Rs = lua[:(:)]
-    @test_approx_eq (Diagonal(Rs) * Ac)[p,q] L * U
+    @test (Diagonal(Rs) * Ac)[p,q] ≈ L * U
 end
 
 for elty in (Float64, Complex128)
@@ -71,13 +80,13 @@ for elty in (Float64, Complex128)
         A = sparse([1:min(m,n); rand(1:m, 10)], [1:min(m,n); rand(1:n, 10)], elty == Float64 ? randn(min(m, n) + 10) : complex(randn(min(m, n) + 10), randn(min(m, n) + 10)))
         F = lufact(A)
         L, U, p, q, Rs = F[:(:)]
-        @test_approx_eq (Diagonal(Rs) * A)[p,q] L * U
+        @test (Diagonal(Rs) * A)[p,q] ≈ L * U
     end
 end
 
 #4523 - complex sparse \
 x = speye(2) + im * speye(2)
-@test_approx_eq (x*(lufact(x) \ ones(2))) ones(2)
+@test (x*(lufact(x) \ ones(2))) ≈ ones(2)
 
 @test det(sparse([1,3,3,1], [1,1,3,3], [1,1,1,1])) == 0
 

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -32,8 +32,9 @@ for Tv in (Float64, Complex128)
         z = complex(b,zeros(b))
         x = Base.SparseArrays.A_ldiv_B!(lua, z)
         @test x ≈ float([1:5;])
+        @test z === x
         y = similar(z)
-        A_ldiv_B!(y, lua,z)
+        A_ldiv_B!(y, lua, complex(b,zeros(b)))
         @test y ≈ x
 
         @test norm(A*x-b,1) < eps(1e4)
@@ -43,10 +44,12 @@ for Tv in (Float64, Complex128)
         @test x ≈ float([1:5;])
 
         @test norm(A'*x-b,1) < eps(1e4)
-        x = Base.SparseArrays.Ac_ldiv_B!(lua,complex(b,zeros(b)))
+        z = complex(b,zeros(b))
+        x = Base.SparseArrays.Ac_ldiv_B!(lua, z)
         @test x ≈ float([1:5;])
+        @test x === z
         y = similar(x)
-        Base.SparseArrays.Ac_ldiv_B!(y, lua,complex(b,zeros(b)))
+        Base.SparseArrays.Ac_ldiv_B!(y, lua, complex(b,zeros(b)))
         @test y ≈ x
 
         @test norm(A'*x-b,1) < eps(1e4)
@@ -125,4 +128,11 @@ let
     @test size(F, 2) == n
     @test size(F, 3) == 1
     @test_throws ArgumentError size(F,-1)
+end
+
+let
+    a = rand(5)
+    @test_throws ArgumentError Base.SparseArrays.UMFPACK.solve!(a, lufact(speye(5,5)), a, Base.SparseArrays.UMFPACK.UMFPACK_A)
+    aa = complex(a)
+    @test_throws ArgumentError Base.SparseArrays.UMFPACK.solve!(aa, lufact(complex(speye(5,5))), aa, Base.SparseArrays.UMFPACK.UMFPACK_A)
 end


### PR DESCRIPTION
A bit of progress towards JuliaLang/LinearAlgebra.jl#216. 

This allows for using the `A_ldiv_B!(X, A, B)` for UMFPACK factorizations:

``` jl
julia> q = zeros(5); A_ldiv_B!(q, lufact(speye(5,5)), rand(5)); q
5-element Array{Float64,1}:
 0.0227636
 0.69521  
 0.451239 
 0.668502 
 0.511458 
```

~~This is not yet completely satisfactory because for complex factorizations there are for example 4 temporary arrays being created in the function that does the `ccall`~~. In general, we need something like JuliaLang/LinearAlgebra.jl#328 that can allocate everything needed for a certain function.

Any comments @andreasnoack, @JaredCrean2, other peeps?
