### PR TITLE
Making it an error to reduce over an empty collection of AbstractCmd with & operator

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -94,6 +94,9 @@ immutable AndCmds <: AbstractCmd
     AndCmds(a::AbstractCmd, b::AbstractCmd) = new(a, b)
 end
 
+hash(x::AndCmds, h::UInt) = hash(x.a, hash(x.b, h))
+==(x::AndCmds, y::AndCmds) = x.a == y.a && x.b == y.b
+
 shell_escape(cmd::Cmd) = shell_escape(cmd.exec...)
 
 function show(io::IO, cmd::Cmd)
@@ -235,6 +238,8 @@ setenv(cmd::Cmd; dir="") = Cmd(cmd; dir=dir)
 (&)(left::AbstractCmd, right::AbstractCmd) = AndCmds(left, right)
 redir_out(src::AbstractCmd, dest::AbstractCmd) = OrCmds(src, dest)
 redir_err(src::AbstractCmd, dest::AbstractCmd) = ErrOrCmds(src, dest)
+Base.mr_empty{T2<:Base.AbstractCmd}(f, op::typeof(&), T1::Type{T2}) =
+    throw(ArgumentError("reducing over an empty collection of type $T1 with operator & is not allowed"))
 
 # Stream Redirects
 redir_out(dest::Redirectable, src::AbstractCmd) = CmdRedirect(src, dest, STDIN_NO)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -344,7 +344,6 @@ end
 @windows_only ENV["PATH"] = oldpath
 
 # equality tests for Cmd
-
 @test Base.Cmd(``) == Base.Cmd(``)
 @test Base.Cmd(`lsof -i :9090`) == Base.Cmd(`lsof -i :9090`)
 @test Base.Cmd(`echo test`) == Base.Cmd(`echo test`)
@@ -354,3 +353,12 @@ end
 @test Base.Set([``, ``]) == Base.Set([``])
 @test Set([``, `echo`]) != Set([``, ``])
 @test Set([`echo`, ``, ``, `echo`]) == Set([`echo`, ``])
+
+# equality tests for AndCmds
+@test Base.AndCmds(`echo abc`, `echo def`) == Base.AndCmds(`echo abc`, `echo def`)
+@test Base.AndCmds(`echo abc`, `echo def`) != Base.AndCmds(`echo abc`, `echo xyz`)
+
+# tests for reducing over collection of Cmd
+@test_throws ArgumentError reduce(&, Base.AbstractCmd[])
+@test_throws ArgumentError reduce(&, Base.Cmd[])
+@test reduce(&, [`echo abc`, `echo def`, `echo hij`]) == `echo abc` & `echo def` & `echo hij`


### PR DESCRIPTION
Also adding `hash` and `==` function for `AndCmds` to facilitate unit testing. It might make sense for equality on `AndCmds` to ignore the order of the commands, but my implementation is probably sufficient for now.

Previously, reducing over an empty collection of `AbstractCmd` would return `true`, which was confusing and probably not intended since it's not meant to be a bitwise operator in the `AbstractCmd` context.
