### PR TITLE
Add the corresponding iterator trait to ``size(::Number) = ()``

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -11,6 +11,8 @@ ndims(x::Number) = 0
 ndims{T<:Number}(::Type{T}) = 0
 length(x::Number) = 1
 endof(x::Number) = 1
+iteratorsize{T<:Number}(::Type{T}) = HasShape()
+
 getindex(x::Number) = x
 function getindex(x::Number, i::Integer)
     @_inline_meta

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -38,6 +38,9 @@ end
 @test isequal(filter(x->(x>10), [0 1 2 3 2 1 0]), [])
 @test isequal(filter((ss)->length(ss)==3, ["abcd", "efg", "hij", "klmn", "opq"]), ["efg", "hij", "opq"])
 
+# numbers
+@test size(collect(1)) == size(1)
+
 # zip and filter iterators
 # issue #4718
 @test collect(filter(x->x[1], zip([true, false, true, false],"abcd"))) == [(true,'a'),(true,'c')]


### PR DESCRIPTION
This makes numbers well behaved with the `product` iterator and with `collect`: For example now

```
size(collect(1)) == size(1)
```

and after merging  #16437 thanks to #15431 

```
size(A[1:3,1,1:3]) == size(Base.product(1:3,1,1:3))
```

for an array `A`.
