### PR TITLE
Remove `jl_thread_task_state_t`

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -112,7 +112,7 @@ static void clear_mark(int bits)
     }
     bigval_t *v;
     for (int i = 0;i < jl_n_threads;i++) {
-        v = jl_all_task_states[i].ptls->heap.big_objects;
+        v = jl_all_tls_states[i]->heap.big_objects;
         while (v != NULL) {
             void *gcv = &v->header;
             if (!gc_verifying) arraylist_push(&bits_save[gc_bits(gcv)], gcv);
@@ -139,8 +139,7 @@ static void clear_mark(int bits)
                 for (int j = 0; j < 32; j++) {
                     if ((line >> j) & 1) {
                         jl_gc_pagemeta_t *pg = page_metadata(region->pages[pg_i*32 + j].data + GC_PAGE_OFFSET);
-                        jl_tls_states_t *ptls =
-                            jl_all_task_states[pg->thread_n].ptls;
+                        jl_tls_states_t *ptls = jl_all_tls_states[pg->thread_n];
                         jl_gc_pool_t *pool = &ptls->heap.norm_pools[pg->pool_n];
                         pv = (gcval_t*)(pg->data + GC_PAGE_OFFSET);
                         char *lim = (char*)pv + GC_PAGE_SZ - GC_PAGE_OFFSET - pool->osize;

--- a/src/gc.h
+++ b/src/gc.h
@@ -244,7 +244,7 @@ void pre_mark(void);
 void post_mark(arraylist_t *list, int dryrun);
 void gc_debug_init(void);
 
-#define jl_thread_heap (&jl_get_ptls_states()->heap)
+#define jl_thread_heap (jl_get_ptls_states()->heap)
 
 // GC pages
 

--- a/src/init.c
+++ b/src/init.c
@@ -650,8 +650,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
         jl_current_module = jl_core_module;
         for (int t = 0;t < jl_n_threads;t++) {
-            jl_all_task_states[t].ptls->root_task->current_module =
-                jl_current_module;
+            jl_all_tls_states[t]->root_task->current_module = jl_current_module;
         }
 
         jl_load("boot.jl", sizeof("boot.jl")-1);
@@ -694,9 +693,8 @@ void _julia_init(JL_IMAGE_SEARCH rel)
         jl_add_standard_imports(jl_main_module);
     }
     jl_current_module = jl_main_module;
-    for(int t = 0;t < jl_n_threads;t++) {
-        jl_all_task_states[t].ptls->root_task->current_module =
-            jl_current_module;
+    for (int t = 0;t < jl_n_threads;t++) {
+        jl_all_tls_states[t]->root_task->current_module = jl_current_module;
     }
 
     // This needs to be after jl_start_threads
@@ -800,12 +798,13 @@ static jl_value_t *basemod(char *name)
 void jl_get_builtin_hooks(void)
 {
     int t;
-    for(t=0; t < jl_n_threads; t++) {
-        jl_all_task_states[t].ptls->root_task->tls = jl_nothing;
-        jl_all_task_states[t].ptls->root_task->consumers = jl_nothing;
-        jl_all_task_states[t].ptls->root_task->donenotify = jl_nothing;
-        jl_all_task_states[t].ptls->root_task->exception = jl_nothing;
-        jl_all_task_states[t].ptls->root_task->result = jl_nothing;
+    for (t = 0; t < jl_n_threads; t++) {
+        jl_tls_states_t *ptls = jl_all_tls_states[t];
+        ptls->root_task->tls = jl_nothing;
+        ptls->root_task->consumers = jl_nothing;
+        ptls->root_task->donenotify = jl_nothing;
+        ptls->root_task->exception = jl_nothing;
+        ptls->root_task->result = jl_nothing;
     }
 
     jl_char_type    = (jl_datatype_t*)core("Char");

--- a/src/julia.h
+++ b/src/julia.h
@@ -1465,12 +1465,6 @@ typedef struct _jl_task_t {
 #endif
 } jl_task_t;
 
-typedef struct {
-    jl_tls_states_t *ptls;
-    uv_thread_t system_id;
-    void *signal_stack;
-} jl_thread_task_state_t;
-
 #define jl_current_task (jl_get_ptls_states()->current_task)
 #define jl_root_task (jl_get_ptls_states()->root_task)
 #define jl_exception_in_transit (jl_get_ptls_states()->exception_in_transit)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -34,7 +34,6 @@ extern unsigned sig_stack_size;
 
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
-#define jl_in_finalizer (jl_get_ptls_states()->in_finalizer)
 
 STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 {
@@ -153,7 +152,7 @@ JL_CALLABLE(jl_f_intrinsic_call);
 extern jl_function_t *jl_unprotect_stack_func;
 void jl_install_default_signal_handlers(void);
 void restore_signals(void);
-void *jl_install_thread_signal_handler(void);
+void jl_install_thread_signal_handler(void);
 
 jl_fptr_t jl_get_builtin_fptr(jl_value_t *b);
 
@@ -261,9 +260,6 @@ void jl_init_runtime_ccall(void);
 void jl_mk_thread_heap(jl_thread_heap_t *heap);
 
 void _julia_init(JL_IMAGE_SEARCH rel);
-#ifdef COPY_STACKS
-#define jl_stackbase (jl_get_ptls_states()->stackbase)
-#endif
 
 void jl_set_base_ctx(char *__stk);
 
@@ -398,11 +394,6 @@ JL_DLLEXPORT void jl_raise_debugger(void);
 int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline);
 JL_DLLEXPORT void jl_gdblookup(uintptr_t ip);
 jl_value_t *jl_uncompress_ast_(jl_lambda_info_t*, jl_value_t*, int);
-#ifdef COPY_STACKS
-// the base of the stack we will copy this task's stack to
-// when switchting to it
-JL_DLLEXPORT char *jl_task_stackbase(jl_task_t *task);
-#endif
 // *to is NULL or malloc'd pointer, from is allowed to be NULL
 STATIC_INLINE char *jl_copy_str(char **to, const char *from)
 {

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -102,6 +102,11 @@ typedef struct _jl_tls_states_t {
     // we can make this more general (similar to defer_signal) if necessary
     volatile sig_atomic_t io_wait;
     jl_thread_heap_t heap;
+#ifndef _OS_WINDOWS_
+    // These are only used on unix now
+    pthread_t system_id;
+    void *signal_stack;
+#endif
 } jl_tls_states_t;
 
 #ifdef __MIC__

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -126,7 +126,7 @@ HANDLE hMainThread = INVALID_HANDLE_VALUE;
 // Try to throw the exception in the master thread.
 static void jl_try_deliver_sigint(void)
 {
-    jl_tls_states_t *ptls = jl_all_task_states[0].ptls;
+    jl_tls_states_t *ptls = jl_all_tls_states[0];
     jl_safepoint_enable_sigint();
     jl_wake_libuv();
     if ((DWORD)-1 == SuspendThread(hMainThread)) {
@@ -401,7 +401,7 @@ void jl_install_default_signal_handlers(void)
     SetUnhandledExceptionFilter(exception_handler);
 }
 
-void *jl_install_thread_signal_handler(void)
+void jl_install_thread_signal_handler(void)
 {
     // Ensure the stack overflow handler has enough space to collect the backtrace
     ULONG StackSizeInBytes = sig_stack_size;
@@ -410,5 +410,4 @@ void *jl_install_thread_signal_handler(void)
             pSetThreadStackGuarantee = NULL;
         }
     }
-    return NULL;
 }

--- a/src/threading.h
+++ b/src/threading.h
@@ -15,7 +15,7 @@ extern "C" {
 
 // thread ID
 #define ti_tid (jl_get_ptls_states()->tid)
-extern jl_thread_task_state_t *jl_all_task_states;
+extern jl_tls_states_t **jl_all_tls_states;
 extern JL_DLLEXPORT int jl_n_threads;  // # threads we're actually using
 
 // thread state


### PR DESCRIPTION
Basically yet another minor tls access clean up.

Also initialize `system_id` to the value we actually use it as (`pthread_t` in signal handling) instead of `uv_thread_t` (which is `pthread_t` on unix but something random on windows...). I was really confused since it was initialized really inconsistently on windows, but it turns out that it was not used there....
