### PR TITLE
Fix \ bug introduced in PR#15354 by removing parent of sub.

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -24,15 +24,17 @@ inv{T}(F::Factorization{T}) = A_ldiv_B!(F, eye(T, size(F,1)))
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
 function (\){T<:BlasReal}(F::Factorization{T}, B::AbstractVector{Complex{T}})
-    c2r = reshape(transpose(reinterpret(T, parent(B), (2, length(B)))), size(B, 1), 2*size(B, 2))
+    c2r = reshape(transpose(reinterpret(T, B, (2, length(B)))), size(B, 1), 2*size(B, 2))
     x = A_ldiv_B!(F, c2r)
     return reinterpret(Complex{T}, transpose(reshape(x, div(length(x), 2), 2)), (size(F,2),))
 end
 function (\){T<:BlasReal}(F::Factorization{T}, B::AbstractMatrix{Complex{T}})
-    c2r = reshape(transpose(reinterpret(T, parent(B), (2, length(B)))), size(B, 1), 2*size(B, 2))
+    c2r = reshape(transpose(reinterpret(T, B, (2, length(B)))), size(B, 1), 2*size(B, 2))
     x = A_ldiv_B!(F, c2r)
     return reinterpret(Complex{T}, transpose(reshape(x, div(length(x), 2), 2)), (size(F,2), size(B,2)))
 end
+
+(\){T<:BlasReal}(F::Factorization{T}, B::SubArray) = F\copy(B)
 
 for (f1, f2) in ((:\, :A_ldiv_B!),
                  (:Ac_ldiv_B, :Ac_ldiv_B!),

--- a/test/linalg/bunchkaufman.jl
+++ b/test/linalg/bunchkaufman.jl
@@ -104,3 +104,12 @@ let
         end
     end
 end
+
+# test example due to @timholy in PR 15354
+let
+    A = rand(6,5); A = A'*A
+    F = cholfact(A);
+    v6 = rand(Complex128, 6)
+    v5 = sub(v6, 1:5)
+    @test F\v5 == F\v6[1:5]
+end


### PR DESCRIPTION
As @timholy pointed out in #15354 I, quite embarrassingly, introduced a bug in A\v for A being a `Factorization`, and v being a `SubArray` with complex elements, by inappropriately using `parent`. I have proposed a one-line fix, which does not at all use `SubArray`s in a good way, but it will give the correct result. I guess this is related to the whole discussion on inefficient fallback methods. I am happy to take advice and criticism if there's a better way.

_edit:_ didn't run all tests locally, so didn't catch the problems visible at CIs. I'll try to fix it.
_edit^2:_ fixed by defining it in the most general ("Factorization","SubArray") case.
