### PR TITLE
Make deps/configure-llvm work with CMake.

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -813,7 +813,11 @@ get-llvm: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TA
 else
 get-llvm: $(LLVM_SRC_DIR)/configure
 endif
+ifeq ($(LLVM_USE_CMAKE),1)
+configure-llvm: $(LLVM_BUILDDIR_withtype)/CMakeCache.txt
+else
 configure-llvm: $(LLVM_BUILDDIR_withtype)/config.status
+endif
 compile-llvm: $(LLVM_OBJ_SOURCE)
 check-llvm: $(LLVM_BUILDDIR_withtype)/checked
 install-llvm: $(LLVM_OBJ_TARGET)


### PR DESCRIPTION
Didn't work:

```
$ make -C deps configure-llvm LLVM_USE_CMAKE=1
make: *** No rule to make target 'build/llvm-3.7.1/build_Release/config.status', needed by 'configure-llvm'.  Stop.
```
