### PR TITLE
A few easy thread safety fixes

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -711,7 +711,7 @@ void jl_set_gs_ctr(uint32_t ctr) { gs_ctr = ctr; }
 
 JL_DLLEXPORT jl_sym_t *jl_gensym(void)
 {
-    static char name[16];
+    char name[16];
     char *n;
     n = uint2str(&name[2], sizeof(name)-2, gs_ctr, 10);
     *(--n) = '#'; *(--n) = '#';
@@ -721,7 +721,7 @@ JL_DLLEXPORT jl_sym_t *jl_gensym(void)
 
 JL_DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
 {
-    static char gs_name[14];
+    char gs_name[14];
     if (symbol_nbytes(len) >= SYM_POOL_SIZE)
         jl_exceptionf(jl_argumenterror_type, "Symbol length exceeds maximum");
     if (memchr(str, 0, len))

--- a/src/ast.c
+++ b/src/ast.c
@@ -310,7 +310,7 @@ static jl_sym_t *scmsym_to_julia(fl_context_t *fl_ctx, value_t s)
 {
     assert(issymbol(s));
     if (fl_isgensym(fl_ctx, s)) {
-        static char gsname[16];
+        char gsname[16];
         char *n = uint2str(&gsname[1], sizeof(gsname)-1,
                            ((gensym_t*)ptr(s))->id, 10);
         *(--n) = '#';

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -212,7 +212,6 @@ static Module *shadow_output;
 #define jl_Module ctx->f->getParent()
 #define jl_builderModule builder.GetInsertBlock()->getParent()->getParent()
 static MDBuilder *mbuilder;
-static std::map<int, std::string> argNumberStrings;
 #ifdef LLVM38
 static legacy::PassManager *PM;
 #else

--- a/src/threadgroup.h
+++ b/src/threadgroup.h
@@ -43,6 +43,4 @@ int  ti_threadgroup_fork(ti_threadgroup_t *tg, int16_t ext_tid,
 int  ti_threadgroup_join(ti_threadgroup_t *tg, int16_t ext_tid);
 int  ti_threadgroup_destroy(ti_threadgroup_t *tg);
 
-extern ti_threadgroup_t *tgworld;
-
 #endif  /* THREADGROUP_H */

--- a/src/threading.c
+++ b/src/threading.c
@@ -161,10 +161,10 @@ jl_mutex_t typecache_lock;
 #ifdef JULIA_ENABLE_THREADING
 
 // only one thread group for now
-ti_threadgroup_t *tgworld;
+static ti_threadgroup_t *tgworld;
 
 // for broadcasting work to threads
-ti_threadwork_t threadwork;
+static ti_threadwork_t threadwork;
 
 #if PROFILE_JL_THREADING
 uint64_t prep_ns;


### PR DESCRIPTION
The static buffer for symbols was added in https://github.com/JuliaLang/julia/commit/6eef572c31c0cede7bde8682a0c0457db31c7305#commitcomment-10112067 . I don't really understand why it was changed this way though. (Sure, thread safety wasn't an issue, but) I believe 16bytes on the stack in a non-recursive function is unlikely going to be more expensive than a static buffer? I would even expect the stack buffer to be more likely in the cache....
