### PR TITLE
Change default file creation mode to match Linux

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -892,7 +892,7 @@ ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int tru
     fd = _wopen(fname_w, flags | O_BINARY | O_NOINHERIT, _S_IREAD | _S_IWRITE);
     set_io_wait_begin(0);
 #else
-    fd = open_cloexec(fname, flags, S_IRUSR | S_IWUSR /* 0600 */ | S_IRGRP | S_IROTH /* 0644 */);
+    fd = open_cloexec(fname, flags, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH /* 0666 */);
 #endif
     s = ios_fd(s, fd, 1, 1);
     if (fd == -1)


### PR DESCRIPTION
Ref #16466. Changes default file creation mode (for *nix) from u=rw, g=r, o=r to
u=rw, g=rw, o=rw (Linux default). Note that with the default umask
(0022), the resulting permissions do not change. It is only with a more
permissive umask (e.g.  0000) that the resulting permissions would be
different.
