### PR TITLE
Fix compilation on LLVM 3.9

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -830,7 +830,8 @@ static unsigned julia_alignment(Value* /*ptr*/, jl_value_t *jltype, unsigned ali
     return alignment;
 }
 
-static LoadInst *build_load (Value *ptr, jl_value_t *jltype) {
+static LoadInst *build_load(Value *ptr, jl_value_t *jltype)
+{
     return builder.CreateAlignedLoad(ptr, julia_alignment(ptr, jltype, 0));
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5729,7 +5729,7 @@ extern "C" void jl_init_codegen(void)
         .setTargetOptions(options)
 #if (defined(_OS_LINUX_) && defined(_CPU_X86_64_)) || defined(CODEGEN_TLS)
         .setRelocationModel(Reloc::PIC_)
-#else
+#elif !defined(LLVM39)
         .setRelocationModel(Reloc::Default)
 #endif
 #ifdef CODEGEN_TLS

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -343,7 +343,10 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #else
     MCContext Ctx(*MAI, *MRI, MOFI.get(), &SrcMgr);
 #endif
-#ifdef LLVM37
+#ifdef LLVM39
+    MOFI->InitMCObjectFileInfo(TheTriple, /* PIC */ false,
+                               CodeModel::Default, Ctx);
+#elif LLVM37
     MOFI->InitMCObjectFileInfo(TheTriple, Reloc::Default, CodeModel::Default, Ctx);
 #else
     MOFI->InitMCObjectFileInfo(TripleName, Reloc::Default, CodeModel::Default, Ctx);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1005,6 +1005,8 @@ static void jl_dump_shadow(char *fname, int jit_model, const char *sysimg_data, 
         jl_TargetMachine->Options,
 #if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
         Reloc::PIC_,
+#elif defined(LLVM39)
+        jit_model ? Reloc::PIC_ : Optional<Reloc::Model>(),
 #else
         jit_model ? Reloc::PIC_ : Reloc::Default,
 #endif


### PR DESCRIPTION
`Reloc::Default` is removed.
