### PR TITLE
fix possible type instability in rationalize.

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -142,7 +142,7 @@ function rationalize{T<:Integer}(::Type{T}, x::AbstractFloat; tol::Real=eps(x))
 
     # find optimal semiconvergent
     # smallest a such that x-a*y < a*t+tt
-    a = max(cld(x-tt,y+t),0.0)
+    a = cld(x-tt,y+t)
     try
         ia = convert(T,a)
         np = checked_add(checked_mul(ia,p),pp)


### PR DESCRIPTION
use of `max` is actually redundant here.
