### PR TITLE
Deprecate OS_NAME properly

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1231,6 +1231,7 @@ export
     @osx_only,
     @linux_only
 
+export OS_NAME
 const OS_NAME =
     if Sys.KERNEL === :Darwin
         :OSX

--- a/contrib/BBEditTextWrangler-julia.plist
+++ b/contrib/BBEditTextWrangler-julia.plist
@@ -1401,7 +1401,6 @@
         <string>Operators</string>
         <string>Order</string>
         <string>OrdinalRange</string>
-        <string>OS_NAME</string>
         <string>Pair</string>
         <string>ParseError</string>
         <string>PartialQuickSort</string>

--- a/contrib/julia.lang
+++ b/contrib/julia.lang
@@ -108,7 +108,6 @@
       <keyword>ARGS</keyword>
       <keyword>LOAD_PATH</keyword>
       <keyword>CPU_CORES</keyword>
-      <keyword>OS_NAME</keyword>
       <keyword>C_NULL</keyword>
       <keyword>WORD_SIZE</keyword>
       <keyword>VERSION</keyword>

--- a/contrib/julia.xml
+++ b/contrib/julia.xml
@@ -281,7 +281,6 @@
       <item> C_NULL </item>
       <item> CPU_CORES </item>
       <item> DL_LOAD_PATH </item>
-      <item> OS_NAME </item>
       <item> ENDIAN_BOM </item>
       <item> ENV </item>
       <item> Inf </item>

--- a/doc/manual/handling-operating-system-variation.rst
+++ b/doc/manual/handling-operating-system-variation.rst
@@ -5,7 +5,7 @@
 *************************************
 
 When dealing with platform libraries, it is often necessary to provide special cases
-for various platforms. The variable ``OS_NAME`` can be used to write these special
+for various platforms. The variable ``Sys.KERNEL`` can be used to write these special
 cases. There are several functions intended to make this easier:
 ``is_unix``, ``is_linux``, ``is_apple``, ``is_bsd``, and ``is_windows``. These may be used as follows::
 


### PR DESCRIPTION
it was formerly exported, so the deprecation needs to be as well
this broke BinDeps and probably others
