### PR TITLE
Deprecate cell() in favor of Array{Any}()

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -897,7 +897,7 @@ end
 # fallback definition of hvcat in terms of hcat and vcat
 function hvcat(rows::Tuple{Vararg{Int}}, as...)
     nbr = length(rows)  # number of block rows
-    rs = cell(nbr)
+    rs = Array{Any}(nbr)
     a = 1
     for i = 1:nbr
         rs[i] = hcat(as[a:a-1+rows[i]]...)
@@ -908,7 +908,7 @@ end
 
 function typed_hvcat(T::Type, rows::Tuple{Vararg{Int}}, as...)
     nbr = length(rows)  # number of block rows
-    rs = cell(nbr)
+    rs = Array{Any}(nbr)
     a = 1
     for i = 1:nbr
         rs[i] = hcat(as[a:a-1+rows[i]]...)
@@ -1065,7 +1065,7 @@ function mapslices(f, A::AbstractArray, dims::AbstractVector)
 
     otherdims = setdiff(alldims, dims)
 
-    idx = cell(ndimsA)
+    idx = Array{Any}(ndimsA)
     fill!(idx, 1)
     Asliceshape = tuple(dimsA[dims]...)
     itershape   = tuple(dimsA[otherdims]...)
@@ -1084,7 +1084,7 @@ function mapslices(f, A::AbstractArray, dims::AbstractVector)
     Rsize[dims] = [size(r1)...; ones(Int,max(0,length(dims)-ndims(r1)))]
     R = similar(r1, tuple(Rsize...))
 
-    ridx = cell(ndims(R))
+    ridx = Array{Any}(ndims(R))
     fill!(ridx, 1)
     for d in dims
         ridx[d] = 1:size(R,d)

--- a/base/array.jl
+++ b/base/array.jl
@@ -163,9 +163,6 @@ end
 fill(v, dims::Dims)       = fill!(Array{typeof(v)}(dims), v)
 fill(v, dims::Integer...) = fill!(Array{typeof(v)}(dims...), v)
 
-cell(dims::Integer...)   = Array{Any}(dims...)
-cell(dims::Tuple{Vararg{Integer}}) = Array{Any}(convert(Tuple{Vararg{Int}}, dims))
-
 for (fname, felt) in ((:zeros,:zero), (:ones,:one))
     @eval begin
         ($fname)(T::Type, dims...)       = fill!(Array{T}(dims...), ($felt)(T))

--- a/base/base.jl
+++ b/base/base.jl
@@ -83,7 +83,7 @@ gc(full::Bool=true) = ccall(:jl_gc_collect, Void, (Cint,), full)
 gc_enable(on::Bool) = ccall(:jl_gc_enable, Cint, (Cint,), on)!=0
 
 # used by { } syntax
-function cell_1d(xs::ANY...)
+function vector_any(xs::ANY...)
     n = length(xs)
     a = Array{Any}(n)
     for i=1:n
@@ -92,7 +92,7 @@ function cell_1d(xs::ANY...)
     a
 end
 
-function cell_2d(nr, nc, xs::ANY...)
+function matrix_any(nr, nc, xs::ANY...)
     a = Array{Any}(nr,nc)
     for i=1:(nr*nc)
         arrayset(a,xs[i],i)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -702,6 +702,9 @@ hist2d(v::AbstractMatrix) = hist2d(v, sturges(size(v,1)))
 
 
 
+@deprecate cell(dims::Integer...) Array{Any}(dims...)
+@deprecate cell(dims::Tuple{Vararg{Integer}}) Array{Any}(dims)
+
 # During the 0.5 development cycle, do not add any deprecations below this line
 # To be deprecated in 0.6
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -342,8 +342,8 @@ push!(t::Associative, p::Pair, q::Pair, r::Pair...) = push!(push!(push!(t, p), q
 # hashing objects by identity
 
 type ObjectIdDict <: Associative{Any,Any}
-    ht::Array{Any,1}
-    ObjectIdDict() = new(cell(32))
+    ht::Vector{Any}
+    ObjectIdDict() = new(Vector{Any}(32))
 
     function ObjectIdDict(itr)
         d = ObjectIdDict()
@@ -383,7 +383,7 @@ function delete!(t::ObjectIdDict, key::ANY)
     t
 end
 
-empty!(t::ObjectIdDict) = (t.ht = cell(length(t.ht)); t)
+empty!(t::ObjectIdDict) = (t.ht = Vector{Any}(length(t.ht)); t)
 
 _oidd_nextind(a, i) = reinterpret(Int,ccall(:jl_eqtable_nextind, Csize_t, (Any, Csize_t), a, i))
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3650,7 +3650,7 @@ readdlm(source, delim, T, eol)
     readdlm(source, delim::Char, eol::Char; options...)
 
 If all data is numeric, the result will be a numeric array. If some elements cannot be
-parsed as numbers, a cell array of numbers and strings is returned.
+parsed as numbers, a heterogeneous array of numbers and strings is returned.
 """
 readdlm(source, delim::Char, eol::Char)
 
@@ -3665,8 +3665,8 @@ readdlm(source, delim::Char, T::Type)
     readdlm(source, delim::Char; options...)
 
 The end of line delimiter is taken as `n`. If all data is numeric, the result will be a
-numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and
-strings is returned.
+numeric array. If some elements cannot be parsed as numbers, a heterogeneous array of
+numbers and strings is returned.
 """
 readdlm(source, delim::Char)
 
@@ -3683,7 +3683,8 @@ readdlm(source, T::Type)
 
 The columns are assumed to be separated by one or more whitespaces. The end of line
 delimiter is taken as `n`. If all data is numeric, the result will be a numeric array. If
-some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+some elements cannot be parsed as numbers, a heterogeneous array of numbers and strings
+is returned.
 """
 readdlm(source)
 
@@ -9541,14 +9542,6 @@ a string. A character is classified as lowercase if it belongs to Unicode catego
 Letter: Lowercase.
 """
 islower
-
-"""
-    cell(dims)
-
-Construct an uninitialized cell array (heterogeneous array). `dims` can be either a tuple or
-a series of integer arguments.
-"""
-cell
 
 """
     read(stream::IO, nb=typemax(Int); all=true)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -490,7 +490,6 @@ export
     broadcast_getindex,
     broadcast_setindex!,
     cat,
-    cell,
     checkbounds,
     circshift,
     clamp!,

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -873,7 +873,7 @@ end
 function precise_container_types(args, types, vtypes::VarTable, sv)
     n = length(args)
     assert(n == length(types))
-    result = cell(n)
+    result = Vector{Any}(n)
     for i = 1:n
         ai = args[i]
         ti = types[i]
@@ -2942,7 +2942,7 @@ function inlining_pass(e::Expr, sv, linfo)
     end
 
     for ninline = 1:100
-        ata = cell(length(e.args))
+        ata = Vector{Any}(length(e.args))
         ata[1] = ft
         for i = 2:length(e.args)
             a = exprtype(e.args[i], sv)
@@ -2970,7 +2970,7 @@ function inlining_pass(e::Expr, sv, linfo)
 
         if is(f,_apply)
             na = length(e.args)
-            newargs = cell(na-2)
+            newargs = Vector{Any}(na-2)
             for i = 3:na
                 aarg = e.args[i]
                 t = widenconst(exprtype(aarg,sv))
@@ -3337,7 +3337,7 @@ function alloc_elim_pass!(linfo::LambdaInfo, sv::InferenceState)
                     end
                 end
             else
-                vals = cell(nv)
+                vals = Vector{Any}(nv)
                 for j=1:nv
                     tupelt = tup[j+1]
                     if (isa(tupelt,Number) || isa(tupelt,AbstractString) ||

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -57,7 +57,7 @@ end
 function launch(manager::SSHManager, params::Dict, launched::Array, launch_ntfy::Condition)
     # Launch one worker on each unique host in parallel. Additional workers are launched later.
     # Wait for all launches to complete.
-    launch_tasks = cell(length(manager.machines))
+    launch_tasks = Vector{Any}(length(manager.machines))
 
     for (i,(machine, cnt)) in enumerate(manager.machines)
         let machine=machine, cnt=cnt

--- a/base/markdown/Julia/interp.jl
+++ b/base/markdown/Julia/interp.jl
@@ -39,7 +39,7 @@ end
 
 toexpr(x) = x
 
-toexpr(xs::Vector{Any}) = Expr(:cell1d, map(toexpr, xs)...)
+toexpr(xs::Vector{Any}) = Expr(:vectany, map(toexpr, xs)...)
 
 function deftoexpr(T)
     @eval function toexpr(md::$T)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1476,8 +1476,8 @@ end
 
 additional_io_objs=Dict()
 function launch_additional(np::Integer, cmd::Cmd)
-    io_objs = cell(np)
-    addresses = cell(np)
+    io_objs = Vector{Any}(np)
+    addresses = Vector{Any}(np)
 
     for i in 1:np
         io, pobj = open(pipeline(detach(cmd), stderr=STDERR), "r")

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -40,26 +40,26 @@ function typejoin(a::ANY, b::ANY)
         end
         if laf < lbf
             if isvarargtype(ap[lar]) && !afixed
-                c = cell(laf)
+                c = Vector{Any}(laf)
                 c[laf] = Vararg{typejoin(ap[lar].parameters[1], tailjoin(bp,laf))}
                 n = laf-1
             else
-                c = cell(laf+1)
+                c = Vector{Any}(laf+1)
                 c[laf+1] = Vararg{tailjoin(bp,laf+1)}
                 n = laf
             end
         elseif lbf < laf
             if isvarargtype(bp[lbr]) && !bfixed
-                c = cell(lbf)
+                c = Vector{Any}(lbf)
                 c[lbf] = Vararg{typejoin(bp[lbr].parameters[1], tailjoin(ap,lbf))}
                 n = lbf-1
             else
-                c = cell(lbf+1)
+                c = Vector{Any}(lbf+1)
                 c[lbf+1] = Vararg{tailjoin(ap,lbf+1)}
                 n = lbf
             end
         else
-            c = cell(laf)
+            c = Vector{Any}(laf)
             n = laf
         end
         for i = 1:n
@@ -78,7 +78,7 @@ function typejoin(a::ANY, b::ANY)
             end
             # join on parameters
             n = length(a.parameters)
-            p = cell(n)
+            p = Vector{Any}(n)
             for i = 1:n
                 ai, bi = a.parameters[i], b.parameters[i]
                 if ai === bi || (isa(ai,Type) && isa(bi,Type) && typeseq(ai,bi))

--- a/base/show.jl
+++ b/base/show.jl
@@ -419,7 +419,7 @@ const expr_infix = Set{Symbol}([:(:), :(->), Symbol("::")])
 const expr_infix_any = union(expr_infix, expr_infix_wide)
 const all_ops = union(quoted_syms, uni_ops, expr_infix_any)
 const expr_calls  = Dict(:call =>('(',')'), :calldecl =>('(',')'), :ref =>('[',']'), :curly =>('{','}'))
-const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'), :cell1d=>("Any[","]"),
+const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'), :vectany=>("Any[","]"),
                          :hcat =>('[',']'), :row =>('[',']'), :vect=>('[',']'))
 
 ## AST decoding helpers ##
@@ -661,7 +661,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         end
 
     # list (i.e. "(1,2,3)" or "[1,2,3]")
-    elseif haskey(expr_parens, head)               # :tuple/:vcat/:cell1d
+    elseif haskey(expr_parens, head)               # :tuple/:vcat/:vectany
         op, cl = expr_parens[head]
         if head === :vcat
             sep = ";"

--- a/doc/devdocs/object.rst
+++ b/doc/devdocs/object.rst
@@ -148,7 +148,7 @@ Arrays::
     jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
     jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc);
     jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z);
-    jl_array_t *jl_alloc_cell_1d(size_t n);
+    jl_array_t *jl_alloc_array_ptr_1d(size_t n);
 
 Note that many of these have alternative allocation functions for various special-purposes.
 The list here reflects the more common usages, but a more complete list can be found by reading the `julia.h header file

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -68,7 +68,6 @@ dimension sizes passed as a variable number of arguments.
 Function                                            Description
 =================================================== =====================================================================
 :func:`Array{type}(dims...) <Array>`                an uninitialized dense array
-:func:`cell(dims...) <cell>`                        an uninitialized cell array (heterogeneous array)
 :func:`zeros(type, dims...) <zeros>`                an array of all zeros of specified type, defaults to ``Float64`` if
                                                     ``type`` not specified
 :func:`zeros(A) <zeros>`                            an array of all zeros of same element type and shape of ``A``

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -414,7 +414,7 @@ implementation::
     function pmap(f, lst)
         np = nprocs()  # determine the number of processes available
         n = length(lst)
-        results = cell(n)
+        results = Vector{Any}(n)
         i = 1
         # function to produce the next work item from the queue.
         # in this case it's just an index.

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -485,8 +485,7 @@ Annotate values taken from untyped locations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is often convenient to work with data structures that may contain
-values of any type, such as cell
-arrays (arrays of type ``Array{Any}``). But, if you're using one of
+values of any type (arrays of type ``Array{Any}``). But, if you're using one of
 these structures and happen to know the type of an element, it helps to
 share this knowledge with the compiler::
 
@@ -977,7 +976,7 @@ Optimize network I/O during parallel execution
 
 When executing a remote function in parallel::
 
-    responses = cell(nworkers())
+    responses = Vector{Any}(nworkers())
     @sync begin
         for (idx, pid) in enumerate(workers())
             @async responses[idx] = remotecall_fetch(pid, foo, args...)
@@ -986,7 +985,7 @@ When executing a remote function in parallel::
 
 is faster than::
 
-    refs = cell(nworkers())
+    refs = Vector{Any}(nworkers())
     for (idx, pid) in enumerate(workers())
         refs[idx] = @spawnat pid foo(args...)
     end

--- a/doc/manual/style-guide.rst
+++ b/doc/manual/style-guide.rst
@@ -151,7 +151,7 @@ It is usually not much help to construct arrays like the following::
 
     a = Array{Union{Int,AbstractString,Tuple,Array}}(n)
 
-In this case :func:`cell(n) <cell>` is better. It is also more helpful to the compiler
+In this case ``Array{Any}(n)`` is better. It is also more helpful to the compiler
 to annotate specific uses (e.g. ``a[i]::Int``) than to try to pack many
 alternatives into one type.
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -149,12 +149,6 @@ Constructors
 
    Construct a 1-d array of the specified type. This is usually called with the syntax ``Type[]``\ . Element values can be specified using ``Type[a,b,c,...]``\ .
 
-.. function:: cell(dims)
-
-   .. Docstring generated from Julia source
-
-   Construct an uninitialized cell array (heterogeneous array). ``dims`` can be either a tuple or a series of integer arguments.
-
 .. function:: zeros(type, dims)
 
    .. Docstring generated from Julia source

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -580,7 +580,7 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+   If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a heterogeneous array of numbers and strings is returned.
 
 .. function:: readdlm(source, delim::Char, T::Type; options...)
 
@@ -592,7 +592,7 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   The end of line delimiter is taken as ``n``\ . If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+   The end of line delimiter is taken as ``n``\ . If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a heterogeneous array of numbers and strings is returned.
 
 .. function:: readdlm(source, T::Type; options...)
 
@@ -604,7 +604,7 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   The columns are assumed to be separated by one or more whitespaces. The end of line delimiter is taken as ``n``\ . If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+   The columns are assumed to be separated by one or more whitespaces. The end of line delimiter is taken as ``n``\ . If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a heterogeneous array of numbers and strings is returned.
 
 .. function:: writedlm(f, A, delim='\\t')
 

--- a/doc/stdlib/punctuation.rst
+++ b/doc/stdlib/punctuation.rst
@@ -30,7 +30,7 @@ symbol      meaning
 ``[;]``     also vertical concatenation
 ``[  ]``    with space-separated expressions, horizontal concatenation
 ``T{ }``    parametric type instantiation
-``{  }``    construct a cell array (deprecated in 0.4 in favor of ``Any[]``)
+``{  }``    construct a heterogeneous array (deprecated in 0.4 in favor of ``Any[]``)
 ``;``       statement separator
 ``,``       separate function arguments or tuple components
 ``?``       3-argument conditional operator (conditional ? if_true : if_false)

--- a/examples/hpl.jl
+++ b/examples/hpl.jl
@@ -111,7 +111,7 @@ function hpl_par(A::Matrix, b::Vector, blocksize::Integer, run_parallel::Bool)
     B_rows[end] = n
     B_cols = [B_rows, [n+1]]
     nB = length(B_rows)
-    depend = cell(nB, nB)
+    depend = Array{Any}(nB, nB)
 
     ## Small matrix case
     if nB <= 1

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -55,7 +55,7 @@ jl_datatype_t *jl_ref_type;
 jl_datatype_t *jl_pointer_type;
 jl_datatype_t *jl_void_type;
 jl_datatype_t *jl_voidpointer_type;
-jl_value_t *jl_an_empty_cell=NULL;
+jl_value_t *jl_an_empty_array_ptr=NULL;
 jl_value_t *jl_stackovf_exception;
 #ifdef SEGV_EXCEPTION
 jl_value_t *jl_segv_exception;
@@ -319,7 +319,7 @@ void jl_lambda_info_set_ast(jl_lambda_info_t *li, jl_value_t *ast)
     jl_value_t *ssavalue_types = jl_lam_ssavalues((jl_expr_t*)ast);
     assert(jl_is_long(ssavalue_types));
     size_t nssavalue = jl_unbox_long(ssavalue_types);
-    li->slotnames = jl_alloc_cell_1d(nslots);
+    li->slotnames = jl_alloc_array_ptr_1d(nslots);
     jl_gc_wb(li, li->slotnames);
     li->slottypes = jl_nothing;
     li->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
@@ -328,8 +328,8 @@ void jl_lambda_info_set_ast(jl_lambda_info_t *li, jl_value_t *ast)
     jl_gc_wb(li, li->ssavaluetypes);
     int i;
     for(i=0; i < nslots; i++) {
-        jl_value_t *vi = jl_cellref(vis, i);
-        jl_sym_t *name = (jl_sym_t*)jl_cellref(vi, 0);
+        jl_value_t *vi = jl_array_ptr_ref(vis, i);
+        jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(vi, 0);
         assert(jl_is_symbol(name));
         char *str = jl_symbol_name(name);
         if (i > 0 && name != unused_sym) {
@@ -342,13 +342,13 @@ void jl_lambda_info_set_ast(jl_lambda_info_t *li, jl_value_t *ast)
                     name = compiler_temp_sym;
             }
         }
-        jl_cellset(li->slotnames, i, name);
-        jl_array_uint8_set(li->slotflags, i, jl_unbox_long(jl_cellref(vi, 2)));
+        jl_array_ptr_set(li->slotnames, i, name);
+        jl_array_uint8_set(li->slotflags, i, jl_unbox_long(jl_array_ptr_ref(vi, 2)));
     }
     jl_array_t *args = jl_lam_args((jl_expr_t*)ast);
     size_t narg = jl_array_len(args);
     li->nargs = narg;
-    li->isva = narg > 0 && jl_is_rest_arg(jl_cellref(args, narg - 1));
+    li->isva = narg > 0 && jl_is_rest_arg(jl_array_ptr_ref(args, narg - 1));
 }
 
 JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(jl_svec_t *sparam_syms)
@@ -410,23 +410,23 @@ static jl_lambda_info_t *jl_instantiate_staged(jl_method_t *generator, jl_tuplet
         ex = jl_exprn(lambda_sym, 2);
 
         int nargs = func->nargs;
-        jl_array_t *argnames = jl_alloc_cell_1d(nargs);
-        jl_cellset(ex->args, 0, argnames);
+        jl_array_t *argnames = jl_alloc_array_ptr_1d(nargs);
+        jl_array_ptr_set(ex->args, 0, argnames);
         for (i = 0; i < nargs; i++)
-            jl_cellset(argnames, i, jl_cellref(func->slotnames, i));
+            jl_array_ptr_set(argnames, i, jl_array_ptr_ref(func->slotnames, i));
 
         jl_expr_t *scopeblock = jl_exprn(jl_symbol("scope-block"), 1);
-        jl_cellset(ex->args, 1, scopeblock);
+        jl_array_ptr_set(ex->args, 1, scopeblock);
         jl_expr_t *body = jl_exprn(jl_symbol("block"), 2);
-        jl_cellset(((jl_expr_t*)jl_exprarg(ex,1))->args, 0, body);
+        jl_array_ptr_set(((jl_expr_t*)jl_exprarg(ex,1))->args, 0, body);
         linenum = jl_box_long(generator->line);
         jl_value_t *linenode = jl_new_struct(jl_linenumbernode_type, linenum);
-        jl_cellset(body->args, 0, linenode);
+        jl_array_ptr_set(body->args, 0, linenode);
 
         // invoke code generator
         assert(jl_nparams(tt) == jl_array_len(argnames) ||
                (func->isva && (jl_nparams(tt) >= jl_array_len(argnames) - 1)));
-        jl_cellset(body->args, 1,
+        jl_array_ptr_set(body->args, 1,
                 jl_call_staged(sparam_vals, func, jl_svec_data(tt->parameters), jl_nparams(tt)));
 
         if (func->sparam_syms != jl_emptysvec) {
@@ -454,7 +454,7 @@ static jl_lambda_info_t *jl_instantiate_staged(jl_method_t *generator, jl_tuplet
 
         jl_array_t *stmts = func->code;
         for(i = 0, l = jl_array_len(stmts); i < l; i++) {
-            jl_cellset(stmts, i, jl_resolve_globals(jl_cellref(stmts, i), func));
+            jl_array_ptr_set(stmts, i, jl_resolve_globals(jl_array_ptr_ref(stmts, i), func));
         }
         in_pure_callback = last_in;
     }
@@ -531,7 +531,7 @@ JL_DLLEXPORT void jl_method_init_properties(jl_method_t *m)
     int i;
     uint8_t called=0;
     for(i=1; i < li->nargs && i <= 8; i++) {
-        jl_value_t *ai = jl_cellref(li->slotnames,i);
+        jl_value_t *ai = jl_array_ptr_ref(li->slotnames,i);
         if (ai == (jl_value_t*)unused_sym) continue;
         if (jl_array_uint8_ref(li->slotflags,i)&64)
             called |= (1<<(i-1));
@@ -596,7 +596,7 @@ jl_method_t *jl_new_method(jl_lambda_info_t *definition, jl_sym_t *name, jl_tupl
         jl_array_t *stmts = definition->code;
         int i, l;
         for(i = 0, l = jl_array_len(stmts); i < l; i++) {
-            jl_cellset(stmts, i, jl_resolve_globals(jl_cellref(stmts, i), definition));
+            jl_array_ptr_set(stmts, i, jl_resolve_globals(jl_array_ptr_ref(stmts, i), definition));
         }
         jl_method_init_properties(m);
     }
@@ -1227,7 +1227,7 @@ JL_DLLEXPORT jl_value_t *jl_box_bool(int8_t x)
 
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
 {
-    jl_array_t *ar = n==0 ? (jl_array_t*)jl_an_empty_cell : jl_alloc_cell_1d(n);
+    jl_array_t *ar = n==0 ? (jl_array_t*)jl_an_empty_array_ptr : jl_alloc_array_ptr_1d(n);
     JL_GC_PUSH1(&ar);
     jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
     jl_set_typeof(ex, jl_expr_type);
@@ -1242,10 +1242,10 @@ JL_CALLABLE(jl_f__expr)
 {
     JL_NARGSV(Expr, 1);
     JL_TYPECHK(Expr, symbol, args[0]);
-    jl_array_t *ar = jl_alloc_cell_1d(nargs-1);
+    jl_array_t *ar = jl_alloc_array_ptr_1d(nargs-1);
     JL_GC_PUSH1(&ar);
     for(size_t i=0; i < nargs-1; i++)
-        jl_cellset(ar, i, args[i+1]);
+        jl_array_ptr_set(ar, i, args[i+1]);
     jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
     jl_set_typeof(ex, jl_expr_type);
     ex->head = (jl_sym_t*)args[0];

--- a/src/array.c
+++ b/src/array.c
@@ -384,7 +384,7 @@ JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str)
     return jl_pchar_to_string(str, strlen(str));
 }
 
-JL_DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n)
+JL_DLLEXPORT jl_array_t *jl_alloc_array_ptr_1d(size_t n)
 {
     return jl_alloc_array_1d(jl_array_any_type, n);
 }
@@ -757,19 +757,19 @@ JL_DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec)
     a->offset = newoffs;
 }
 
-JL_DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item)
+JL_DLLEXPORT void jl_array_ptr_1d_push(jl_array_t *a, jl_value_t *item)
 {
     assert(jl_typeis(a, jl_array_any_type));
     jl_array_grow_end(a, 1);
-    jl_cellset(a, jl_array_dim(a,0)-1, item);
+    jl_array_ptr_set(a, jl_array_dim(a,0)-1, item);
 }
 
-JL_DLLEXPORT void jl_cell_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c)
+JL_DLLEXPORT void jl_array_ptr_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c)
 {
     assert(jl_typeis(a, jl_array_any_type));
     jl_array_grow_end(a, 2);
-    jl_cellset(a, jl_array_dim(a,0)-2, b);
-    jl_cellset(a, jl_array_dim(a,0)-1, c);
+    jl_array_ptr_set(a, jl_array_dim(a,0)-2, b);
+    jl_array_ptr_set(a, jl_array_dim(a,0)-1, c);
 }
 
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a)

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -36,7 +36,7 @@
                  (string #\( (deparse-arglist (cdr e))
                          (if (length= e 2) #\, "")
                          #\)))
-                ((cell1d) (string #\{ (deparse-arglist (cdr e)) #\}))
+                ((vectany) (string #\{ (deparse-arglist (cdr e)) #\}))
                 ((call)   (string (deparse (cadr e)) #\( (deparse-arglist (cddr e)) #\)))
                 ((ref)    (string (deparse (cadr e)) #\[ (deparse-arglist (cddr e)) #\]))
                 ((curly)  (string (deparse (cadr e)) #\{ (deparse-arglist (cddr e)) #\}))

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -438,9 +438,9 @@ JL_CALLABLE(jl_f__apply)
             argarr = (jl_array_t*)jl_apply(args, nargs);
             assert(jl_typeis(argarr, jl_array_any_type));
             jl_array_grow_beg(argarr, 1);
-            jl_cellset(argarr, 0, f);
+            jl_array_ptr_set(argarr, 0, f);
             args[0] = f;
-            jl_value_t *result = jl_apply(jl_cell_data(argarr), jl_array_len(argarr));
+            jl_value_t *result = jl_apply(jl_array_ptr_data(argarr), jl_array_len(argarr));
             JL_GC_POP();
             return result;
         }
@@ -457,7 +457,7 @@ JL_CALLABLE(jl_f__apply)
         newargs = jl_svec_data(arg_heap);
     }
     // GC Note: here we assume that the the return value of `jl_svecref`,
-    //          `jl_cellref` will not be young if `arg_heap` becomes old
+    //          `jl_array_ptr_ref` will not be young if `arg_heap` becomes old
     //          since they are allocated before `arg_heap`. Otherwise,
     //          we need to add write barrier for !onstack
     newargs[0] = f;
@@ -485,7 +485,7 @@ JL_CALLABLE(jl_f__apply)
             size_t al = jl_array_len(aai);
             if (aai->flags.ptrarray) {
                 for (j = 0; j < al; j++) {
-                    jl_value_t *arg = jl_cellref(aai, j);
+                    jl_value_t *arg = jl_array_ptr_ref(aai, j);
                     // apply with array splatting may have embedded NULL value
                     // #11772
                     if (__unlikely(arg == NULL))
@@ -1395,7 +1395,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         if (av->flags.ptrarray) {
             // print arrays with newlines, unless the elements are probably small
             for (j = 0; j < tlen; j++) {
-                jl_value_t *p = jl_cellref(av, j);
+                jl_value_t *p = jl_array_ptr_ref(av, j);
                 if (p != NULL && (uintptr_t)p >= 4096U) {
                     jl_value_t *p_ty = jl_typeof(p);
                     if ((uintptr_t)p_ty >= 4096U) {
@@ -1411,7 +1411,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
             n += jl_printf(out, "\n  ");
         for (j = 0; j < tlen; j++) {
             if (av->flags.ptrarray) {
-                n += jl_static_show_x(out, jl_cellref(v, j), depth);
+                n += jl_static_show_x(out, jl_array_ptr_ref(v, j), depth);
             }
             else {
                 char *ptr = ((char*)av->data) + j * av->elsize;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -936,13 +936,13 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
         int idx = ((jl_ssavalue_t*)e)->id;
         assert(jl_is_array(ctx->linfo->ssavaluetypes));
         jl_array_t *ssavalue_types = (jl_array_t*)ctx->linfo->ssavaluetypes;
-        return jl_cellref(ssavalue_types, idx);
+        return jl_array_ptr_ref(ssavalue_types, idx);
     }
     if (jl_typeis(e, jl_slotnumber_type)) {
         jl_array_t *slot_types = (jl_array_t*)ctx->linfo->slottypes;
         if (!jl_is_array(slot_types))
             return (jl_value_t*)jl_any_type;
-        return jl_cellref(slot_types, jl_slot_number(e)-1);
+        return jl_array_ptr_ref(slot_types, jl_slot_number(e)-1);
     }
     if (jl_typeis(e, jl_typedslot_type)) {
         jl_value_t *typ = jl_typedslot_get_type(e);

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -168,7 +168,7 @@ static void *jl_load_dynamic_library_(const char *modname, unsigned flags, int t
         if (DL_LOAD_PATH != NULL) {
             size_t j;
             for (j = 0; j < jl_array_len(DL_LOAD_PATH); j++) {
-                char *dl_path = jl_string_data(jl_cell_data(DL_LOAD_PATH)[j]);
+                char *dl_path = jl_string_data(jl_array_ptr_data(DL_LOAD_PATH)[j]);
                 size_t len = strlen(dl_path);
                 if (len == 0)
                     continue;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1463,8 +1463,8 @@ void pre_mark(void)
     }
 
     // invisible builtin values
-    if (jl_an_empty_cell != NULL)
-        gc_push_root(jl_an_empty_cell, 0);
+    if (jl_an_empty_array_ptr != NULL)
+        gc_push_root(jl_an_empty_array_ptr, 0);
     if (jl_module_init_order != NULL)
         gc_push_root(jl_module_init_order, 0);
     gc_push_root(jl_cfunction_list.unknown, 0);

--- a/src/init.c
+++ b/src/init.c
@@ -633,7 +633,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
     jl_start_threads();
 
-    jl_an_empty_cell = (jl_value_t*)jl_alloc_cell_1d(0);
+    jl_an_empty_array_ptr = (jl_value_t*)jl_alloc_array_ptr_1d(0);
     jl_init_serializer();
 
     if (!jl_options.image_file) {
@@ -739,12 +739,12 @@ static void julia_save(void)
 
     jl_array_t *worklist = jl_module_init_order;
     JL_GC_PUSH1(&worklist);
-    jl_module_init_order = jl_alloc_cell_1d(0);
+    jl_module_init_order = jl_alloc_array_ptr_1d(0);
     int i, l = jl_array_len(worklist);
     for (i = 0; i < l; i++) {
         jl_value_t *m = jl_arrayref(worklist, i);
         if (jl_module_get_initializer((jl_module_t*)m)) {
-            jl_cell_1d_push(jl_module_init_order, m);
+            jl_array_ptr_1d_push(jl_module_init_order, m);
         }
     }
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -147,7 +147,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
                 jl_error("access to invalid slot number");
             jl_value_t *v = locals[n-1];
             if (v == NULL)
-                jl_undefined_var_error((jl_sym_t*)jl_cellref(lam->slotnames,n-1));
+                jl_undefined_var_error((jl_sym_t*)jl_array_ptr_ref(lam->slotnames,n-1));
             return v;
         }
         if (jl_is_globalref(e)) {
@@ -453,7 +453,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, jl_lambda_i
     while (1) {
         if (i >= ns)
             jl_error("`body` expression must terminate in `return`. Use `block` instead.");
-        jl_value_t *stmt = jl_cellref(stmts,i);
+        jl_value_t *stmt = jl_array_ptr_ref(stmts,i);
         if (jl_is_gotonode(stmt)) {
             i = jl_gotonode_label(stmt)-1;
             continue;

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1985,21 +1985,21 @@
            (let ((vex (parse-cat s #\])))
              (if (null? vex) '(vect) vex)))
 
-          ;; cell expression
+          ;; Array{Any} expression
           ((eqv? t #\{ )
            (take-token s)
            (if (eqv? (require-token s) #\})
                (begin (syntax-deprecation s "{}" "[]")
                       (take-token s)
-                      '(cell1d))
+                      '(vectany))
                (let ((vex (parse-cat s #\} #t)))
                  (if (null? vex)
                      (begin (syntax-deprecation s "{}" "[]")
-                            '(cell1d))
+                            '(vectany))
                      (case (car vex)
                        ((vect)
                         (syntax-deprecation s "{a,b, ...}" "Any[a,b, ...]")
-                        `(cell1d ,@(cdr vex)))
+                        `(vectany ,@(cdr vex)))
                        ((comprehension)
                         (syntax-deprecation s "{a for a in b}" "Any[a for a in b]")
                         `(typed_comprehension (top Any) ,@(cdr vex)))
@@ -2011,7 +2011,7 @@
                         `(typed_dict (=> (top Any) (top Any)) ,@(cdr vex)))
                        ((hcat)
                         (syntax-deprecation s "{a b ...}" "Any[a b ...]")
-                        `(cell2d 1 ,(length (cdr vex)) ,@(cdr vex)))
+                        `(matrany 1 ,(length (cdr vex)) ,@(cdr vex)))
                        (else  ; (vcat ...)
                         (if (and (pair? (cadr vex)) (eq? (caadr vex) 'row))
                             (let ((nr (length (cdr vex)))
@@ -2023,10 +2023,10 @@
                                                (eq? (car x) 'row)
                                                (length= (cdr x) nc)))
                                         (cddr vex)))
-                                  (error "inconsistent shape in cell expression"))
+                                  (error "inconsistent shape in Array{Any} expression"))
                               (begin
                                 (syntax-deprecation s "{a b; c d}" "Any[a b; c d]")
-                                `(cell2d ,nr ,nc
+                                `(matrany ,nr ,nc
                                          ,@(apply append
                                                   ;; transpose to storage order
                                                   (apply map list
@@ -2034,10 +2034,10 @@
                             (if (any (lambda (x) (and (pair? x)
                                                       (eq? (car x) 'row)))
                                      (cddr vex))
-                                (error "inconsistent shape in cell expression")
+                                (error "inconsistent shape in Array{Any} expression")
                                 (begin
                                   (syntax-deprecation s "{a,b, ...}" "Any[a,b, ...]")
-                                  `(cell1d ,@(cdr vex)))))))))))
+                                  `(vectany ,@(cdr vex)))))))))))
 
           ;; string literal
           ((eqv? t #\")

--- a/src/julia.h
+++ b/src/julia.h
@@ -495,7 +495,7 @@ extern JL_DLLEXPORT jl_value_t *jl_inexact_exception;
 extern JL_DLLEXPORT jl_value_t *jl_undefref_exception;
 extern JL_DLLEXPORT jl_value_t *jl_interrupt_exception;
 extern JL_DLLEXPORT jl_datatype_t *jl_boundserror_type;
-extern JL_DLLEXPORT jl_value_t *jl_an_empty_cell;
+extern JL_DLLEXPORT jl_value_t *jl_an_empty_array_ptr;
 
 extern JL_DLLEXPORT jl_datatype_t *jl_bool_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_char_type;
@@ -698,12 +698,12 @@ JL_DLLEXPORT size_t jl_array_len_(jl_array_t *a);
 #define jl_array_data_owner_offset(ndims) (offsetof(jl_array_t,ncols) + sizeof(size_t)*(1+jl_array_ndimwords(ndims))) // in bytes
 #define jl_array_data_owner(a) (*((jl_value_t**)((char*)a + jl_array_data_owner_offset(jl_array_ndims(a)))))
 
-STATIC_INLINE jl_value_t *jl_cellref(void *a, size_t i)
+STATIC_INLINE jl_value_t *jl_array_ptr_ref(void *a, size_t i)
 {
     assert(i < jl_array_len(a));
     return ((jl_value_t**)(jl_array_data(a)))[i];
 }
-STATIC_INLINE jl_value_t *jl_cellset(void *a, size_t i, void *x)
+STATIC_INLINE jl_value_t *jl_array_ptr_set(void *a, size_t i, void *x)
 {
     assert(i < jl_array_len(a));
     ((jl_value_t**)(jl_array_data(a)))[i] = (jl_value_t*)x;
@@ -730,7 +730,7 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x)
 }
 
 #define jl_exprarg(e,n) (((jl_value_t**)jl_array_data(((jl_expr_t*)(e))->args))[n])
-#define jl_exprargset(e, n, v) jl_cellset(((jl_expr_t*)(e))->args, n, v)
+#define jl_exprargset(e, n, v) jl_array_ptr_set(((jl_expr_t*)(e))->args, n, v)
 #define jl_expr_nargs(e) jl_array_len(((jl_expr_t*)(e))->args)
 
 #define jl_fieldref(s,i) jl_get_nth_field(((jl_value_t*)s),i)
@@ -753,7 +753,7 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x)
 // get a pointer to the data in a datatype
 #define jl_data_ptr(v)  ((jl_value_t**)v)
 
-#define jl_cell_data(a)   ((jl_value_t**)((jl_array_t*)a)->data)
+#define jl_array_ptr_data(a)   ((jl_value_t**)((jl_array_t*)a)->data)
 #define jl_string_data(s) ((char*)((jl_array_t*)jl_data_ptr(s)[0])->data)
 #define jl_string_len(s)  (jl_array_len((jl_array_t*)(jl_data_ptr(s)[0])))
 #define jl_iostr_data(s)  ((char*)((jl_array_t*)jl_data_ptr(s)[0])->data)
@@ -1147,7 +1147,7 @@ JL_DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str);
 JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a);
-JL_DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_ptr_1d(size_t n);
 JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed
@@ -1156,8 +1156,8 @@ JL_DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
 JL_DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc);
 JL_DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
 JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz);
-JL_DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
-JL_DLLEXPORT void jl_cell_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c);
+JL_DLLEXPORT void jl_array_ptr_1d_push(jl_array_t *a, jl_value_t *item);
+JL_DLLEXPORT void jl_array_ptr_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c);
 JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim);
 // property access
 JL_DLLEXPORT void *jl_array_ptr(jl_array_t *a);

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -17,9 +17,9 @@
   (if (splice-expr? x)
       (if (= d 0)
           (cadr (cadr (cadr x)))
-          (list 'cell1d
+          (list 'vectany
                 (wrap-with-splice (julia-bq-expand (cadr (cadr (cadr x))) (- d 1)))))
-      (list 'cell1d (julia-bq-expand x d))))
+      (list 'vectany (julia-bq-expand x d))))
 
 (define (julia-bq-expand x d)
   (cond ((or (eq? x 'true) (eq? x 'false))  x)

--- a/src/module.c
+++ b/src/module.c
@@ -568,7 +568,7 @@ JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
     for(int i=(int)m->usings.len-1; i >= 0; --i) {
         jl_array_grow_end(a, 1);
         jl_module_t *imp = (jl_module_t*)m->usings.items[i];
-        jl_cellset(a,jl_array_dim0(a)-1, (jl_value_t*)imp);
+        jl_array_ptr_set(a,jl_array_dim0(a)-1, (jl_value_t*)imp);
     }
     JL_GC_POP();
     return (jl_value_t*)a;
@@ -588,7 +588,7 @@ JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
                 !b->deprecated && !hidden) {
                 jl_array_grow_end(a, 1);
                 //XXX: change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:
-                jl_cellset(a, jl_array_dim0(a)-1, (jl_value_t*)b->name);
+                jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)b->name);
             }
         }
     }

--- a/src/sys.c
+++ b/src/sys.c
@@ -688,7 +688,7 @@ static BOOL CALLBACK jl_EnumerateLoadedModulesProc64(
     jl_array_grow_end((jl_array_t*)a, 1);
     //XXX: change to jl_arrayset if array storage allocation for Array{String,1} changes:
     jl_value_t *v = jl_cstr_to_string(ModuleName);
-    jl_cellset(a, jl_array_dim0(a)-1, v);
+    jl_array_ptr_set(a, jl_array_dim0(a)-1, v);
     return TRUE;
 }
 // Takes a handle (as returned from dlopen()) and returns the absolute path to the image loaded

--- a/src/table.c
+++ b/src/table.c
@@ -17,7 +17,7 @@ void jl_idtable_rehash(jl_array_t **pa, size_t newsz)
     size_t sz = jl_array_len(*pa);
     size_t i;
     void **ol = (void**)(*pa)->data;
-    jl_array_t *newa = jl_alloc_cell_1d(newsz);
+    jl_array_t *newa = jl_alloc_array_ptr_1d(newsz);
     // keep the original array in the original slot since we need `ol`
     // to be valid in the loop below.
     JL_GC_PUSH1(&newa);

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -171,7 +171,7 @@ union jl_typemap_t mtcache_hash_lookup(jl_array_t *a, jl_value_t *ty, int8_t tpa
     ml.unknown = jl_nothing;
     if (!uid)
         return ml;
-    ml.unknown = jl_cellref(a, uid & (a->nrows-1));
+    ml.unknown = jl_array_ptr_ref(a, uid & (a->nrows-1));
     if (ml.unknown != NULL && ml.unknown != jl_nothing) {
         jl_value_t *t;
         if (jl_typeof(ml.unknown) == (jl_value_t*)jl_typemap_level_type) {
@@ -207,7 +207,7 @@ static void mtcache_rehash(jl_array_t **pa, jl_value_t *parent, int8_t tparam, i
     size_t i, len = jl_array_len(*pa);
     size_t newlen = next_power_of_two(len) * 2;
     jl_value_t **d = (jl_value_t**)jl_array_data(*pa);
-    jl_array_t *n = jl_alloc_cell_1d(newlen);
+    jl_array_t *n = jl_alloc_array_ptr_1d(newlen);
     for (i = 1; i <= len; i++) {
         union jl_typemap_t ml;
         ml.unknown = d[i - 1];
@@ -230,7 +230,7 @@ static void mtcache_rehash(jl_array_t **pa, jl_value_t *parent, int8_t tparam, i
                 // hash collision: start over after doubling the size again
                 i = 0;
                 newlen *= 2;
-                n = jl_alloc_cell_1d(newlen);
+                n = jl_alloc_array_ptr_1d(newlen);
             }
         }
     }
@@ -244,7 +244,7 @@ void jl_typemap_rehash_array(jl_array_t **pa, jl_value_t *parent, int8_t tparam,
     size_t i, len = (*pa)->nrows;
     for (i = 0; i < len; i++) {
         union jl_typemap_t ml;
-        ml.unknown = jl_cellref(*pa, i);
+        ml.unknown = jl_array_ptr_ref(*pa, i);
         assert(ml.unknown != NULL);
         jl_typemap_rehash(ml, offs+1);
     }
@@ -270,7 +270,7 @@ static union jl_typemap_t *mtcache_hash_bp(jl_array_t **pa, jl_value_t *ty,
             // since they should have a lower priority and need to go into the sorted list
             return NULL;
         if (*pa == (void*)jl_nothing) {
-            *pa = jl_alloc_cell_1d(INIT_CACHE_SIZE);
+            *pa = jl_alloc_array_ptr_1d(INIT_CACHE_SIZE);
             jl_gc_wb(parent, *pa);
         }
         while (1) {

--- a/test/core.jl
+++ b/test/core.jl
@@ -522,7 +522,7 @@ function const_implies_local()
 end
 @test const_implies_local() === (1, 0)
 
-a = cell(3)
+a = Vector{Any}(3)
 for i=1:3
     let ii = i
         a[i] = x->x+ii
@@ -555,7 +555,7 @@ end
 
 let
     local a
-    a = cell(2)
+    a = Vector{Any}(2)
     @test !isdefined(a,1) && !isdefined(a,2)
     a[1] = 1
     @test isdefined(a,1) && !isdefined(a,2)
@@ -578,7 +578,7 @@ end
 
 let
     local a
-    a = cell(2)
+    a = Vector{Any}(2)
     @test !isassigned(a,1) && !isassigned(a,2)
     a[1] = 1
     @test isassigned(a,1) && !isassigned(a,2)
@@ -3035,7 +3035,7 @@ type D11597{T} <: C11597{T} d::T end
 @test_throws TypeError repr(D11597(1.0))
 
 # issue #11772
-@test_throws UndefRefError (cell(5)...)
+@test_throws UndefRefError (Vector{Any}(5)...)
 
 # issue #11813
 let a = UInt8[1, 107, 66, 88, 2, 99, 254, 13, 0, 0, 0, 0]

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -11,7 +11,7 @@
 n = 20
 intvls = [2, .2, .1, .005]
 
-pipe_fds = cell(n)
+pipe_fds = Vector{Any}(n)
 for i in 1:n
     @static if is_windows()
         pipe_fds[i] = Array{Libc.WindowsRawSocket}(2)

--- a/test/show.jl
+++ b/test/show.jl
@@ -2,9 +2,9 @@
 
 replstr(x) = sprint((io,x) -> show(IOContext(io, multiline=true, limit=true), MIME("text/plain"), x), x)
 
-@test replstr(cell(2)) == "2-element Array{Any,1}:\n #undef\n #undef"
-@test replstr(cell(2,2)) == "2×2 Array{Any,2}:\n #undef  #undef\n #undef  #undef"
-@test replstr(cell(2,2,2)) == "2×2×2 Array{Any,3}:\n[:, :, 1] =\n #undef  #undef\n #undef  #undef\n\n[:, :, 2] =\n #undef  #undef\n #undef  #undef"
+@test replstr(Array{Any}(2)) == "2-element Array{Any,1}:\n #undef\n #undef"
+@test replstr(Array{Any}(2,2)) == "2×2 Array{Any,2}:\n #undef  #undef\n #undef  #undef"
+@test replstr(Array{Any}(2,2,2)) == "2×2×2 Array{Any,3}:\n[:, :, 1] =\n #undef  #undef\n #undef  #undef\n\n[:, :, 2] =\n #undef  #undef\n #undef  #undef"
 
 immutable T5589
     names::Vector{String}

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -522,7 +522,7 @@ static NOINLINE int true_main(int argc, char *argv[])
     if (jl_core_module != NULL) {
         jl_array_t *args = (jl_array_t*)jl_get_global(jl_core_module, jl_symbol("ARGS"));
         if (args == NULL) {
-            args = jl_alloc_cell_1d(0);
+            args = jl_alloc_array_ptr_1d(0);
             JL_GC_PUSH1(&args);
             jl_set_const(jl_core_module, jl_symbol("ARGS"), (jl_value_t*)args);
             JL_GC_POP();


### PR DESCRIPTION
This MATLAB-ism feels out of place in Julia, and isn't used very often
in the code base. This change also makes the names of C functions more
consistent with other ones.

(Note that most of the changes happen in C code, and aren't strictly needed to clean the Julia API.)
