### PR TITLE
Make `sign(::Rational)` return an rational

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -160,7 +160,7 @@ den(x::Integer) = one(x)
 num(x::Rational) = x.num
 den(x::Rational) = x.den
 
-sign(x::Rational) = sign(x.num)
+sign(x::Rational) = oftype(x, sign(x.num))
 signbit(x::Rational) = signbit(x.num)
 copysign(x::Rational, y::Real) = copysign(x.num,y) // x.den
 copysign(x::Rational, y::Rational) = copysign(x.num,y.num) // x.den

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -451,6 +451,9 @@ end
 @test sign(-0//1) == 0
 @test sign(1//0) == 1
 @test sign(-1//0) == -1
+@test isa(sign(2//3), Rational{Int})
+@test isa(2//3 + 2//3im, Complex{Rational{Int}})
+@test isa(sign(2//3 + 2//3im), Complex{Float64})
 @test sign(one(UInt)) == 1
 @test sign(zero(UInt)) == 0
 


### PR DESCRIPTION
I believe we generally do this when the result is representable by the same type.

This fixes a type stability in complex rational division.

This doesn't seem to break any existing tests.....
