### PR TITLE
WIP: Integrate Polly and make it available via `@polly` macro

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -222,6 +222,7 @@ BUILD_LLVM_CLANG := 0
 # set to 1 to get lldb (often does not work, no chance with llvm3.2 and earlier)
 # see http://lldb.llvm.org/build.html for dependencies
 BUILD_LLDB := 0
+USE_POLLY := 0
 
 # Cross-compile
 #XC_HOST := i686-w64-mingw32

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1421,6 +1421,7 @@ export
     @simd,
     @inline,
     @noinline,
+    @polly,
 
     @assert,
     @enum,

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -71,6 +71,13 @@ macro propagate_inbounds(ex)
     end
 end
 
+"""
+Tells the compiler to apply the polyhedral optimizer Polly to a function.
+"""
+macro polly(ex)
+    esc(isa(ex, Expr) ? pushmeta!(ex, :polly) : ex)
+end
+
 ## some macro utilities ##
 
 find_vars(e) = find_vars(e, [])

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,10 +37,17 @@ SRCS := \
 	simplevector APInt-C runtime_intrinsics runtime_ccall \
 	threadgroup threading stackwalk gc gc-debug gc-pages safepoint
 
+LLVMLINK :=
+
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen disasm debuginfo llvm-simdloop llvm-gcroot
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
+ifeq ($(USE_POLLY),1)
+LLVMLINK += -lPolly -lPollyISL
+FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --src-root)/tools/polly/include
+FLAGS += -DUSE_POLLY
+endif
 else
 SRCS += anticodegen
 LLVM_LIBS := support
@@ -51,12 +58,12 @@ HEADERS := $(addprefix $(SRCDIR)/,julia.h julia_threads.h julia_internal.h optio
 # In LLVM < 3.4, --ldflags includes both options and libraries, so use it both before and after --libs
 # In LLVM >= 3.4, --ldflags has only options, and --system-libs has the libraries.
 ifneq ($(USE_LLVM_SHLIB),1)
-LLVMLINK := $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --libs $(LLVM_LIBS)) $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --system-libs 2> /dev/null)
+LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --libs $(LLVM_LIBS)) $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --system-libs 2> /dev/null)
 else
 ifeq ($(LLVM_USE_CMAKE),1)
-LLVMLINK := $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM
+LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM
 else
-LLVMLINK := $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM-$(shell $(LLVM_CONFIG_HOST) --version)
+LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM-$(shell $(LLVM_CONFIG_HOST) --version)
 endif
 FLAGS += -DLLVM_SHLIB
 endif

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -102,6 +102,7 @@ jl_sym_t *pure_sym; jl_sym_t *simdloop_sym;
 jl_sym_t *meta_sym; jl_sym_t *compiler_temp_sym;
 jl_sym_t *inert_sym; jl_sym_t *vararg_sym;
 jl_sym_t *unused_sym; jl_sym_t *static_parameter_sym;
+jl_sym_t *polly_sym;
 
 typedef struct {
     int64_t a;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -69,6 +69,10 @@ static void addOptimizationPasses(T *PM)
 
     PM->add(createEarlyCSEPass()); //// ****
 
+#ifdef USE_POLLY
+    polly::registerPollyPasses(*PM);
+#endif
+
     PM->add(createLoopIdiomPass()); //// ****
     PM->add(createLoopRotatePass());           // Rotate loops.
     // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3786,6 +3786,7 @@ void jl_init_types(void)
     slot_sym = jl_symbol("slot");
     static_parameter_sym = jl_symbol("static_parameter");
     compiler_temp_sym = jl_symbol("#temp#");
+    polly_sym = jl_symbol("polly");
 
     tttvar = jl_new_typevar(jl_symbol("T"),
                                   (jl_value_t*)jl_bottom_type,

--- a/src/julia.h
+++ b/src/julia.h
@@ -570,6 +570,7 @@ extern jl_sym_t *copyast_sym; extern jl_sym_t *fastmath_sym;
 extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
 extern jl_sym_t *meta_sym; extern jl_sym_t *list_sym;
 extern jl_sym_t *inert_sym; extern jl_sym_t *static_parameter_sym;
+extern jl_sym_t *polly_sym;
 
 // gc -------------------------------------------------------------------------
 


### PR DESCRIPTION
This is a first attempt to integrate the polyhedral optimizer [Polly](http://polly.llvm.org/) into Julia in the context of my [GSoC project](https://docs.google.com/document/d/1s5mmSW965qmOEbHiM3O4XFz-Vd7cy9TxX9RQaTK_SQo/edit?usp=sharing). Since (for now) it is not yet clear whether it's beneficial to turn on Polly by default, it adds a macro `@polly` which can be used to explicitly annotate functions that should be optimized via Polly. The `@polly` macro relies on the `:meta` mechanism to instruct Julia's LLVM code-generator whether to apply Polly to a particular function or not. Since Polly is simply a collection of LLVM passes this involves to selectively "turn on" these passes for the respective function. Therefore, in `emit_function`, where the lowering to LLVM IR happens, I check whether the given function is marked with the special `:meta`-symbol `:polly` and accordingly mark the generated LLVM function with an attribute `PollySkipFnAttr` (this attribute is already provided by Polly and allows to tell Polly to skip its optimizations for a certain function).

I do not know how I can "automatically" test whether Polly is executed for a certain function or not, so for now I had to manually verify that Polly is invoked for a function when `@polly` is present.

Since these changes also regard the build process of Julia I added a build option `USE_POLLY` which can be used to enable/disable these features (which is `0` by default to ensure the standard build is not influenced). When `USE_POLLY` is set to `1`, Julia will be linked against Polly's static libraries `libPolly.a` and `libPollyISL.a`. For now, the build expects these libraries in the `lib` directory of the used LLVM installation, which basically means that LLVM has to be built manually together with Polly (like described [here](http://polly.llvm.org/get_started.html)). So to successfully build Julia to enable these features, it would be necessary to have a Make.user that contains the following configurations, where YOUR_LLVM_BUILD_DIR points to the according LLVM installation containing Polly:

```
USE_SYSTEM_LLVM:=1
USE_POLLY:=1
LLVM_CONFIG:=$(YOUR_LLVM_BUILD_DIR)/bin/llvm-config
```

So to make the build a little more "user-friendly" it would be nice to have Polly be downloaded and built automatically which I'll try to solve next. Basically, this will require changing `deps/Makefile` to download Polly from its svn/git repository.

Please feel free to post your thoughts and suggestions on this.
