### PR TITLE
RFC: (wip) use distinct expr head for kwcall after lowering

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1023,7 +1023,7 @@ function abstract_call(f::ANY, fargs, argtypes::Vector{Any}, vtypes::VarTable, s
     return abstract_call_gf_by_type(f, atype, sv)
 end
 
-function abstract_eval_call(e, vtypes::VarTable, sv::InferenceState)
+function abstract_eval_call(e::Expr, vtypes::VarTable, sv::InferenceState)
     argtypes = Any[abstract_eval(a, vtypes, sv) for a in e.args]
     #print("call ", e.args[1], argtypes, "\n\n")
     for x in argtypes
@@ -1072,7 +1072,7 @@ function abstract_eval(e::ANY, vtypes::VarTable, sv::InferenceState)
     e = e::Expr
     # handle:
     # call  null  new  &  static_typeof
-    if is(e.head,:call)
+    if is(e.head,:call) || is(e.head,:kwcall)
         t = abstract_eval_call(e, vtypes, sv)
     elseif is(e.head,:null)
         t = Void
@@ -1205,7 +1205,7 @@ function abstract_interpret(e::ANY, vtypes::VarTable, sv::InferenceState)
             # don't bother for GlobalRef
             return StateUpdate(lhs, VarState(t,false), vtypes)
         end
-    elseif is(e.head,:call)
+    elseif is(e.head,:call) || is(e.head,:kwcall)
         t = abstract_eval(e, vtypes, sv)
         t === Bottom && return ()
     elseif is(e.head,:gotoifnot)

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -71,7 +71,8 @@ jl_value_t *jl_memory_exception;
 jl_value_t *jl_readonlymemory_exception;
 union jl_typemap_t jl_cfunction_list;
 
-jl_sym_t *call_sym;    jl_sym_t *dots_sym;
+jl_sym_t *call_sym;    jl_sym_t *kwcall_sym;
+jl_sym_t *dots_sym;
 jl_sym_t *module_sym;  jl_sym_t *slot_sym;
 jl_sym_t *empty_sym;
 jl_sym_t *export_sym;  jl_sym_t *import_sym;

--- a/src/ast.c
+++ b/src/ast.c
@@ -933,7 +933,9 @@ JL_DLLEXPORT int jl_is_rest_arg(jl_value_t *ex)
     if (!jl_is_expr(atype)) return 0;
     if (((jl_expr_t*)atype)->head == dots_sym)
         return 1;
-    if (atype->head != call_sym || jl_array_len(atype->args) < 3 || jl_array_len(atype->args) > 4)
+    if (atype->head != call_sym && atype->head != kwcall_sym)
+        return 0;
+    if (jl_array_len(atype->args) < 3 || jl_array_len(atype->args) > 4)
         return 0;
     return ((jl_sym_t*)jl_exprarg(atype,1)) == vararg_sym;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1753,7 +1753,7 @@ static void simple_escape_analysis(jl_value_t *expr, bool esc, jl_codectx_t *ctx
         esc = true;
         jl_expr_t *e = (jl_expr_t*)expr;
         size_t i;
-        if (e->head == call_sym || e->head == new_sym) {
+        if (e->head == call_sym || e->head == kwcall_sym || e->head == new_sym) {
             int alen = jl_array_dim0(e->args);
             jl_value_t *f = jl_exprarg(e,0);
             simple_escape_analysis(f, esc, ctx);
@@ -3200,7 +3200,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
         builder.CreateCondBr(isfalse, ifnot, ifso);
         builder.SetInsertPoint(ifso);
     }
-    else if (head == call_sym) {
+    else if (head == call_sym || head == kwcall_sym) {
         if (ctx->linfo->def) { // don't bother codegen constant-folding for toplevel
             jl_value_t *c = static_eval(expr, ctx, true, true);
             if (c) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -2408,7 +2408,7 @@ void jl_init_serializer(void)
                      // everything above here represents a class of object rather only than a literal
 
                      jl_emptysvec, jl_emptytuple, jl_false, jl_true, jl_nothing, jl_any_type,
-                     call_sym, goto_ifnot_sym, return_sym, body_sym, line_sym,
+                     call_sym, kwcall_sym, goto_ifnot_sym, return_sym, body_sym, line_sym,
                      lambda_sym, jl_symbol("tuple"), assign_sym,
 
                      // empirical list of very common symbols

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -170,7 +170,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, jl_lambda_info_t *la
     jl_expr_t *ex = (jl_expr_t*)e;
     jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
     size_t nargs = jl_array_len(ex->args);
-    if (ex->head == call_sym) {
+    if (ex->head == call_sym || ex->head == kwcall_sym) {
         return do_call(args, nargs, locals, lam);
     }
     else if (ex->head == assign_sym) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3732,6 +3732,7 @@ void jl_init_types(void)
 
     empty_sym = jl_symbol("");
     call_sym = jl_symbol("call");
+    kwcall_sym = jl_symbol("kwcall");
     quote_sym = jl_symbol("quote");
     inert_sym = jl_symbol("inert");
     top_sym = jl_symbol("top");

--- a/src/julia.h
+++ b/src/julia.h
@@ -541,7 +541,8 @@ extern JL_DLLEXPORT jl_value_t *jl_false;
 extern JL_DLLEXPORT jl_value_t *jl_nothing;
 
 // some important symbols
-extern jl_sym_t *call_sym;    extern jl_sym_t *empty_sym;
+extern jl_sym_t *call_sym; extern jl_sym_t *kwcall_sym;
+extern jl_sym_t *empty_sym;
 extern jl_sym_t *dots_sym;    extern jl_sym_t *vararg_sym;
 extern jl_sym_t *quote_sym;   extern jl_sym_t *newvar_sym;
 extern jl_sym_t *top_sym;     extern jl_sym_t *dot_sym;


### PR DESCRIPTION
I'm considering moving the lowering for kwcall out of julia-syntax.scm. While this is probably more elegant (and much easier to get working), it also obscures the syntactic information from the later optimization passes.

This PR is just intended to be just enough of the implementation to show where behavior would diverge if the representation of a kwcall was to change, but without actually changing it.
