### PR TITLE
reduce TypeMap memory wastage

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -938,38 +938,17 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
                     // perform some compression on the typemap levels
                     // (which will need to be rehashed during deserialization anyhow)
                     jl_typemap_level_t *node = (jl_typemap_level_t*)v;
-                    size_t i, l;
                     assert( // make sure this type has the expected ordering
                         offsetof(jl_typemap_level_t, arg1) == 0 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, targ) == 1 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, linear) == 2 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, any) == 3 * sizeof(jl_value_t*) &&
-                        offsetof(jl_typemap_level_t, key) == 4 * sizeof(jl_value_t*) &&
-                        sizeof(jl_typemap_level_t) == 5 * sizeof(jl_value_t*));
-                    if (node->arg1 != (void*)jl_nothing) {
-                        jl_array_t *a = jl_alloc_vec_any(0);
-                        for (i = 0, l = jl_array_len(node->arg1); i < l; i++) {
-                            jl_value_t *d = jl_array_ptr_ref(node->arg1, i);
-                            if (d != NULL && d != jl_nothing)
-                                jl_array_ptr_1d_push(a, d);
-                        }
-                        jl_serialize_value(s, a);
-                    }
-                    else {
-                        jl_serialize_value(s, jl_nothing);
-                    }
-                    if (node->targ != (void*)jl_nothing) {
-                        jl_array_t *a = jl_alloc_vec_any(0);
-                        for (i = 0, l = jl_array_len(node->targ); i < l; i++) {
-                            jl_value_t *d = jl_array_ptr_ref(node->targ, i);
-                            if (d != NULL && d != jl_nothing)
-                                jl_array_ptr_1d_push(a, d);
-                        }
-                        jl_serialize_value(s, a);
-                    }
-                    else {
-                        jl_serialize_value(s, jl_nothing);
-                    }
+                        offsetof(jl_typemap_level_t, targ) == 2 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, linear) == 4 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, any) == 5 * sizeof(jl_value_t*) &&
+                        offsetof(jl_typemap_level_t, key) == 6 * sizeof(jl_value_t*) &&
+                        sizeof(jl_typemap_level_t) == 7 * sizeof(jl_value_t*));
+                    jl_serialize_value(s, jl_nothing);
+                    jl_serialize_value(s, node->arg1.values);
+                    jl_serialize_value(s, jl_nothing);
+                    jl_serialize_value(s, node->targ.values);
                     jl_serialize_value(s, node->linear);
                     jl_serialize_value(s, node->any.unknown);
                     jl_serialize_value(s, node->key);

--- a/src/gf.c
+++ b/src/gf.c
@@ -981,19 +981,23 @@ static void invalidate_conflicting(union jl_typemap_t *pml, jl_value_t *type, jl
     jl_typemap_entry_t **pl;
     if (jl_typeof(pml->unknown) == (jl_value_t*)jl_typemap_level_type) {
         jl_typemap_level_t *cache = pml->node;
-        if (cache->arg1 != (void*)jl_nothing) {
-            for(int i=0; i < jl_array_len(cache->arg1); i++) {
-                union jl_typemap_t *pl = &((union jl_typemap_t*)jl_array_data(cache->arg1))[i];
-                if (pl->unknown && pl->unknown != jl_nothing) {
-                    invalidate_conflicting(pl, type, (jl_value_t*)cache->arg1, shadowed);
+        if (cache->arg1.values != (void*)jl_nothing) {
+            size_t i, l = jl_array_len(cache->arg1.values);
+            union jl_typemap_t *d = (union jl_typemap_t*)jl_array_data(cache->arg1.values);
+            for (i = 0; i < l; i++) {
+                union jl_typemap_t *pl = &d[i];
+                if (pl->unknown != jl_nothing) {
+                    invalidate_conflicting(pl, type, (jl_value_t*)cache->arg1.values, shadowed);
                 }
             }
         }
-        if (cache->targ != (void*)jl_nothing) {
-            for(int i=0; i < jl_array_len(cache->targ); i++) {
-                union jl_typemap_t *pl = &((union jl_typemap_t*)jl_array_data(cache->targ))[i];
-                if (pl->unknown && pl->unknown != jl_nothing) {
-                    invalidate_conflicting(pl, type, (jl_value_t*)cache->targ, shadowed);
+        if (cache->targ.values != (void*)jl_nothing) {
+            size_t i, l = jl_array_len(cache->targ.values);
+            union jl_typemap_t *d = (union jl_typemap_t*)jl_array_data(cache->targ.values);
+            for (i = 0; i < l; i++) {
+                union jl_typemap_t *pl = &d[i];
+                if (pl->unknown != jl_nothing) {
+                    invalidate_conflicting(pl, type, (jl_value_t*)cache->targ.values, shadowed);
                 }
             }
         }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3678,9 +3678,23 @@ void jl_init_types(void)
 
     jl_typemap_level_type =
         jl_new_datatype(jl_symbol("TypeMapLevel"), jl_any_type, jl_emptysvec,
-                        jl_svec(5, jl_symbol("arg1"), jl_symbol("targ"), jl_symbol("list"), jl_symbol("any"), jl_symbol("key")),
-                        jl_svec(5, jl_any_type,       jl_any_type,       jl_any_type,       jl_any_type,      jl_any_type),
-                        0, 1, 4);
+                        jl_svec(7,
+                            jl_symbol("index_arg1"),
+                            jl_symbol("arg1"),
+                            jl_symbol("index_targ"),
+                            jl_symbol("targ"),
+                            jl_symbol("list"),
+                            jl_symbol("any"),
+                            jl_symbol("key")),
+                        jl_svec(7,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type),
+                        0, 1, 6);
 
     jl_typemap_entry_type =
         jl_new_datatype(jl_symbol("TypeMapEntry"), jl_any_type, jl_emptysvec,

--- a/src/julia.h
+++ b/src/julia.h
@@ -418,10 +418,14 @@ typedef struct _jl_typemap_entry_t {
 
 // one level in a TypeMap tree
 // indexed by key if it is a sublevel in an array
+struct jl_ordereddict_t {
+    jl_array_t *indexes; // Array{Int{8,16,32}}
+    jl_array_t *values; // Array{union jl_typemap_t}
+};
 typedef struct _jl_typemap_level_t {
     JL_DATA_TYPE
-    jl_array_t *arg1; // Array{union jl_typemap_t}
-    jl_array_t *targ; // Array{union jl_typemap_t}
+    struct jl_ordereddict_t arg1;
+    struct jl_ordereddict_t targ;
     jl_typemap_entry_t *linear; // union jl_typemap_t (but no more levels)
     union jl_typemap_t any; // type at offs is Any
     jl_value_t *key; // [nullable]


### PR DESCRIPTION
the TypeMap structure is usually very sparsely populated
switching to an OrderedDict implementation allows
faster iteration (the filled cells don't have gaps)
and the index array can use a small memory footprint
