### PR TITLE
type stable `strides`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -38,6 +38,11 @@ function first(itr)
 end
 last(a) = a[end]
 
+"""
+    stride(A, k)
+
+Returns the distance in memory (in number of elements) between adjacent elements in dimension `k`.
+"""
 function stride(a::AbstractArray, i::Integer)
     if i > ndims(a)
         return length(a)
@@ -49,7 +54,18 @@ function stride(a::AbstractArray, i::Integer)
     return s
 end
 
-strides(a::AbstractArray) = ntuple(i->stride(a,i), ndims(a))::Dims
+strides{T}(A::AbstractArray{T,0}) = ()
+"""
+    strides(A)
+
+Returns a tuple of the memory strides in each dimension.
+"""
+strides(A::AbstractArray) = _strides((1,), A)
+_strides{T,N}(out::NTuple{N}, A::AbstractArray{T,N}) = out
+function _strides{M,T,N}(out::NTuple{M}, A::AbstractArray{T,N})
+    @_inline_meta
+    _strides((out..., out[M]*size(A, M)), A)
+end
 
 function isassigned(a::AbstractArray, i::Int...)
     # TODO

--- a/base/array.jl
+++ b/base/array.jl
@@ -25,10 +25,6 @@ length(a::Array) = arraylen(a)
 elsize{T}(a::Array{T}) = isbits(T) ? sizeof(T) : sizeof(Ptr)
 sizeof(a::Array) = elsize(a) * length(a)
 
-strides{T}(a::Array{T,1}) = (1,)
-strides{T}(a::Array{T,2}) = (1, size(a,1))
-strides{T}(a::Array{T,3}) = (1, size(a,1), size(a,1)*size(a,2))
-
 function isassigned{T}(a::Array{T}, i::Int...)
     ii = sub2ind(size(a), i...)
     1 <= ii <= length(a) || return false

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1212,13 +1212,6 @@ Returns a tuple `(filename,line)` giving the location of a `Method` definition.
 functionloc(m)
 
 """
-    stride(A, k)
-
-Returns the distance in memory (in number of elements) between adjacent elements in dimension `k`.
-"""
-stride
-
-"""
     last(coll)
 
 Get the last element of an ordered collection, if it can be computed in O(1) time. This is
@@ -4187,13 +4180,6 @@ broadcast!
 Compute the cross product of two 3-vectors.
 """
 cross
-
-"""
-    strides(A)
-
-Returns a tuple of the memory strides in each dimension.
-"""
-strides
 
 """
     keys(collection)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -229,6 +229,7 @@ function test_primitives{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     @test last(B) == B[length(B)]
 
     # strides(a::AbstractArray)
+    @inferred strides(B)
     strides_B = strides(B)
     for (i, _stride) in enumerate(collect(strides_B))
         @test _stride == stride(B, i)


### PR DESCRIPTION
This PR introduces a type stable definition for `strides`, and a companion replacement for `stride` that looks nicer (though that's up to interpretation and debate). I think / hope that this follows the (non `@generated function`) programming style of some of the other array changes introduced by @timholy and @mbauman .
