### PR TITLE
WIP: Faster implementation of linreg

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -6672,31 +6672,6 @@ two strings. For example
 join
 
 """
-    linreg(x, y) -> a, b
-
-Perform linear regression. Returns `a` and `b` such that `a + b*x` is the closest straight
-line to the given points `(x, y)`, i.e., such that the squared error between `y` and `a +
-b*x` is minimized.
-
-**Example**:
-
-    using PyPlot
-    x = [1.0:12.0;]
-    y = [5.5, 6.3, 7.6, 8.8, 10.9, 11.79, 13.48, 15.02, 17.77, 20.81, 22.0, 22.99]
-    a, b = linreg(x, y)          # Linear regression
-    plot(x, y, "o")              # Plot (x, y) points
-    plot(x, [a+b*i for i in x])  # Plot line determined by linear regression
-"""
-linreg(x,y)
-
-"""
-    linreg(x, y, w)
-
-Weighted least-squares linear regression.
-"""
-linreg(x,y,w)
-
-"""
     polygamma(m, x)
 
 Compute the polygamma function of order `m` of argument `x` (the `(m+1)th` derivative of the

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -417,12 +417,40 @@ istriu(x::Number) = true
 istril(x::Number) = true
 isdiag(x::Number) = true
 
-linreg{T<:Number}(X::AbstractVector{T}, y::AbstractVector{T}) = [ones(T, size(X,1)) X] \ y
+"""
+    linreg(x, y)
 
-# weighted least squares
-function linreg(x::AbstractVector, y::AbstractVector, w::AbstractVector)
-    sw = sqrt(w)
-    [sw sw.*x] \ (sw.*y)
+Perform simple linear regression using Ordinary Least Squares. Returns `a` and `b` such
+that `a + b*x` is the closest straight line to the given points `(x, y)`, i.e., such that
+the squared error between `y` and `a + b*x` is minimized.
+
+Examples:
+
+    using PyPlot
+    x = 1.0:12.0
+    y = [5.5, 6.3, 7.6, 8.8, 10.9, 11.79, 13.48, 15.02, 17.77, 20.81, 22.0, 22.99]
+    a, b = linreg(x, y)          # Linear regression
+    plot(x, y, "o")              # Plot (x, y) points
+    plot(x, a + b*x)             # Plot line determined by linear regression
+
+See also:
+
+`\\`, `cov`, `std`, `mean`
+
+"""
+function linreg(x::AbstractVector, y::AbstractVector)
+    # Least squares given
+    # Y = a + b*X
+    # where
+    # b = cov(X, Y)/var(X)
+    # a = mean(Y) - b*mean(X)
+    size(x) == size(y) || throw(DimensionMismatch("x and y must be the same size"))
+    mx = mean(x)
+    my = mean(y)
+    # don't need to worry about the scaling (n vs n - 1) since they cancel in the ratio
+    b = Base.covm(x, mx, y, my)/Base.varm(x, mx)
+    a = my - b*mx
+    return (a, b)
 end
 
 # multiply by diagonal matrix as vector

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1020,28 +1020,26 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Concatenate matrices block-diagonally. Currently only implemented for sparse matrices.
 
-.. function:: linreg(x, y) -> a, b
+.. function:: linreg(x, y)
 
    .. Docstring generated from Julia source
 
-   Perform linear regression. Returns ``a`` and ``b`` such that ``a + b*x`` is the closest straight line to the given points ``(x, y)``\ , i.e., such that the squared error between ``y`` and ``a + b*x`` is minimized.
+   Perform simple linear regression using Ordinary Least Squares. Returns ``a`` and ``b`` such that ``a + b*x`` is the closest straight line to the given points ``(x, y)``\ , i.e., such that the squared error between ``y`` and ``a + b*x`` is minimized.
 
-   **Example**:
+   Examples:
 
    .. code-block:: julia
 
        using PyPlot
-       x = [1.0:12.0;]
+       x = 1.0:12.0
        y = [5.5, 6.3, 7.6, 8.8, 10.9, 11.79, 13.48, 15.02, 17.77, 20.81, 22.0, 22.99]
        a, b = linreg(x, y)          # Linear regression
        plot(x, y, "o")              # Plot (x, y) points
-       plot(x, [a+b*i for i in x])  # Plot line determined by linear regression
+       plot(x, a + b*x)             # Plot line determined by linear regression
 
-.. function:: linreg(x, y, w)
+   See also:
 
-   .. Docstring generated from Julia source
-
-   Weighted least-squares linear regression.
+   ``\``\ , ``cov``\ , ``std``\ , ``mean``
 
 .. function:: expm(A)
 
@@ -2214,4 +2212,3 @@ set of functions in future releases.
    Solves the Sylvester matrix equation ``A * X +/- X * B = scale*C`` where ``A`` and ``B`` are both quasi-upper triangular. If ``transa = N``\ , ``A`` is not modified. If ``transa = T``\ , ``A`` is transposed. If ``transa = C``\ , ``A`` is conjugate transposed. Similarly for ``transb`` and ``B``\ . If ``isgn = 1``\ , the equation ``A * X + X * B = scale * C`` is solved. If ``isgn = -1``\ , the equation ``A * X - X * B = scale * C`` is solved.
 
    Returns ``X`` (overwriting ``C``\ ) and ``scale``\ .
-

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -65,10 +65,51 @@ let X = [3  9   5;
     @test_throws ArgumentError diff(X,-1)
 end
 
-x = float([1:12;])
+# test linrange
+# make sure unequal input arrays throw an error
+x = [2; 5; 6]
+y = [3; 7; 10; 10]
+@test_throws DimensionMismatch linreg(x, y)
+x = [2 5 6]
+y = [3; 7; 10]
+@test_throws MethodError linreg(x, y)
+
+# check (UnitRange, Array)
+x = 1:12
 y = [5.5; 6.3; 7.6; 8.8; 10.9; 11.79; 13.48; 15.02; 17.77; 20.81; 22.0; 22.99]
-@test_approx_eq linreg(x,y) [2.5559090909090867, 1.6960139860139862]
-@test_approx_eq linreg(sub(x,1:6),sub(y,1:6)) [3.8366666666666642,1.3271428571428574]
+@test_approx_eq [linreg(x,y)...] [2.5559090909090867, 1.6960139860139862]
+@test_approx_eq [linreg(sub(x,1:6),sub(y,1:6))...] [3.8366666666666642,1.3271428571428574]
+
+# check (LinSpace, UnitRange)
+x = linspace(1.0, 12.0, 100)
+y = -100:-1
+@test_approx_eq [linreg(x, y)...] [-109.0, 9.0]
+
+# check (UnitRange, UnitRange)
+x = 1:12
+y = 12:-1:1
+@test_approx_eq [linreg(x, y)...] [13.0, -1.0]
+
+# check (LinSpace, LinSpace)
+x = linspace(-5, 10, 100)
+y = linspace(50, 200, 100)
+@test_approx_eq [linreg(x, y)...] [100.0, 10.0]
+
+# check (Array, Array)
+# Anscombe's quartet (https://en.wikipedia.org/wiki/Anscombe%27s_quartet)
+x123 = [10.0; 8.0; 13.0; 9.0; 11.0; 14.0; 6.0; 4.0; 12.0; 7.0; 5.0]
+y1 = [8.04; 6.95; 7.58; 8.81; 8.33; 9.96; 7.24; 4.26; 10.84; 4.82; 5.68]
+@test_approx_eq_eps [linreg(x123, y1)...] [3.0, 0.5] 10e-5
+
+y2 = [9.14; 8.14; 8.74; 8.77; 9.26; 8.10; 6.12; 3.10; 9.13; 7.26; 4.74]
+@test_approx_eq_eps [linreg(x123, y2)...] [3.0, 0.5] 10e-3
+
+y3 = [7.46; 6.77; 12.74; 7.11; 7.81; 8.84; 6.08; 5.39; 8.15; 6.42; 5.73]
+@test_approx_eq_eps [linreg(x123, y3)...] [3.0, 0.5] 10e-3
+
+x4 = [8.0; 8.0; 8.0; 8.0; 8.0; 8.0; 8.0; 19.0; 8.0; 8.0; 8.0]
+y4 = [6.58; 5.76; 7.71; 8.84; 8.47; 7.04; 5.25; 12.50; 5.56; 7.91; 6.89]
+@test_approx_eq_eps [linreg(x4, y4)...] [3.0, 0.5] 10e-3
 
 # test diag
 let A = eye(4)


### PR DESCRIPTION
Move from using the general matrix division operator to an explicit loop to calculate the OLS without extra memory allocation.
