### PR TITLE
Partition iterator inherits IteratorSize

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -490,6 +490,7 @@ type PartitionIterator{T}
 end
 
 eltype{T}(::Type{PartitionIterator{T}}) = Vector{eltype(T)}
+iteratorsize{T}(::Type{PartitionIterator{T}}) = iteratorsize(T)
 
 function length(itr::PartitionIterator)
     l = length(itr.c)


### PR DESCRIPTION
A currently failing test is `collect(Base.partition(Base.flatten([1,2,3,4,5]), 4)) == [[1,2,3,4],[5]]` which can be added to the bulk of iterator tests in #16437 .
