### PR TITLE
Clean up temporary files from tests

### DIFF
--- a/test/compile.jl
+++ b/test/compile.jl
@@ -127,7 +127,6 @@ finally
 end
 
 # test --compilecache=no command line option
-dir = mktempdir()
 let dir = mktempdir(),
     Time_module = :Time4b3a94a1a081a8cb
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -2345,7 +2345,8 @@ end === nothing
 # issue #10221
 module GCbrokentype
 OLD_STDOUT = STDOUT
-file = open(tempname(), "w")
+fname = tempname()
+file = open(fname, "w")
 redirect_stdout(file)
 versioninfo()
 try
@@ -2356,6 +2357,7 @@ end
 gc()
 redirect_stdout(OLD_STDOUT)
 close(file)
+rm(fname)
 end
 
 # issue #10373

--- a/test/file.jl
+++ b/test/file.jl
@@ -289,6 +289,7 @@ my_tempdir = tempdir()
 path = tempname()
 # Issue #9053.
 @test ispath(path) == is_windows()
+ispath(path) && rm(path)
 
 (p, f) = mktemp()
 print(f, "Here is some text")

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -636,7 +636,7 @@ if is_windows()
         s = "cd(\"$(file[1:2])"
         c,r = test_complete(s)
         @test r == length(s) - 1:length(s)
-        @test file  in c
+        @test (length(c) > 1 && file in c) || (["$file\""] == c)
     end
     rm(tmp)
 end


### PR DESCRIPTION
and make replcompletions test more robust to only finding a single completion

In combination with other tests setting random seeds, I actually fairly often see collisions in my `/tmp` folder of directories that haven't been deleted from past test runs. Some of those are from tests that fail and it's a little harder to keep track of those, but at least these I found as being created even when tests succeed, then not being cleaned up.

~~There are still 3 left in the parallel test here https://github.com/JuliaLang/julia/blob/fe23b883f2fd4277c804aa7136fbda774d87029a/test/parallel_exec.jl#L360-L362 that I'm not quite sure what to do about, I've tried forcing finalization of the `SharedArray`s there but so far haven't gotten anything to work.~~ fixed, yay
