### PR TITLE
Use the old value for the OS_NAME deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1233,9 +1233,7 @@ export
 
 export OS_NAME
 const OS_NAME =
-    if Sys.KERNEL === :Darwin
-        :OSX
-    elseif Sys.KERNEL === :NT
+    if Sys.KERNEL === :NT
         :Windows
     else
         Sys.KERNEL


### PR DESCRIPTION
otherwise this deprecation is breaking for code that reads this constant
