### PR TITLE
WIP static dispatch for kwargs and structural fields

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -117,7 +117,7 @@ export
     # key types
     Any, DataType, Vararg, ANY, NTuple,
     Tuple, Type, TypeConstructor, TypeName, TypeVar, Union, Void,
-    SimpleVector, AbstractArray, DenseArray,
+    SimpleVector, AbstractArray, DenseArray, Struct,
     # special objects
     Function, LambdaInfo, Method, MethodTable, TypeMapEntry, TypeMapLevel,
     Module, Symbol, Task, Array, WeakRef, VecElement,
@@ -332,15 +332,28 @@ end
 atdoc     = (str, expr) -> Expr(:escape, expr)
 atdoc!(λ) = global atdoc = λ
 
+immutable KwKeys{names}
+end
+function structdiff
+end
+function structmerge
+end
+function fieldname
+end
+function structadd
+end
+Struct(;args...) = args
 module TopModule
     # this defines the types that lowering expects to be defined in a (top) module
     # that are usually inherited from Core, but could be defined custom for a module
-    using Core: Box, IntrinsicFunction, Builtin,
+    using Core: Box, IntrinsicFunction, Builtin, Struct, KwKeys,
             arrayref, arrayset, arraysize,
-            _expr, _apply, typeassert, apply_type, svec, kwfunc
-    export Box, IntrinsicFunction, Builtin,
+            _expr, _apply, typeassert, apply_type, svec, kwfunc, fieldname,
+            struct, structdiff, structmerge, structadd
+    export Box, IntrinsicFunction, Builtin, Struct, KwKeys,
             arrayref, arrayset, arraysize,
-            _expr, _apply, typeassert, apply_type, svec, kwfunc
+            _expr, _apply, typeassert, apply_type, svec, kwfunc, fieldname,
+            struct, structdiff, structmerge, structadd
 end
 using .TopModule
 ccall(:jl_set_istopmod, Void, (Bool,), true)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2375,11 +2375,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     if isa(f,IntrinsicFunction) || ft ⊑ IntrinsicFunction
         return NF
     end
-    #=println("F ==============")
-    println(f)
-    println(istopfunction(topmod,f,:struct))
-    println(e.typ)
-    println("================")=#
+
     if (is(f, Core.struct) &&
         e.typ <: Core.Struct && isleaftype(e.typ))
         new_e = Expr(:new, e.typ, argexprs[3:end]...)

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -74,7 +74,7 @@ function arg_decl_parts(m::Method)
 end
 
 function kwarg_decl(sig::ANY, kwtype::DataType)
-    sig = Tuple{kwtype, Array, sig.parameters...}
+    sig = Tuple{kwtype, Struct, sig.parameters...}
     kwli = ccall(:jl_methtable_lookup, Any, (Any, Any), kwtype.name.mt, sig)
     if kwli !== nothing
         kwli = kwli::Method

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -805,7 +805,7 @@ end
 function remotecall(f, w::Worker, args...; kwargs...)
     rr = Future(w)
     #println("$(myid()) asking for $rr")
-    send_msg(w, CallMsg{:call}(f, args, kwargs, remoteref_id(rr)))
+    send_msg(w, CallMsg{:call}(f, args, [kwargs...], remoteref_id(rr)))
     rr
 end
 
@@ -823,7 +823,7 @@ function remotecall_fetch(f, w::Worker, args...; kwargs...)
     oid = RRID()
     rv = lookup_ref(oid)
     rv.waitingfor = w.id
-    send_msg(w, CallMsg{:call_fetch}(f, args, kwargs, oid))
+    send_msg(w, CallMsg{:call_fetch}(f, args, [kwargs...], oid))
     v = take!(rv)
     delete!(PGRP.refs, oid)
     isa(v, RemoteException) ? throw(v) : v
@@ -840,7 +840,7 @@ function remotecall_wait(f, w::Worker, args...; kwargs...)
     rv = lookup_ref(prid)
     rv.waitingfor = w.id
     rr = Future(w)
-    send_msg(w, CallWaitMsg(f, args, kwargs, remoteref_id(rr), prid))
+    send_msg(w, CallWaitMsg(f, args, [kwargs...], remoteref_id(rr), prid))
     v = fetch(rv.c)
     delete!(PGRP.refs, prid)
     isa(v, RemoteException) && throw(v)
@@ -860,7 +860,7 @@ function remote_do(f, w::LocalProcess, args...; kwargs...)
 end
 
 function remote_do(f, w::Worker, args...; kwargs...)
-    send_msg(w, RemoteDoMsg(f, args, kwargs))
+    send_msg(w, RemoteDoMsg(f, args, [kwargs...]))
     nothing
 end
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -56,8 +56,8 @@ end
 
 Get the name of field `i` of a `DataType`.
 """
-fieldname(t::DataType, i::Integer) = t.name.names[i]::Symbol
-fieldname{T<:Tuple}(t::Type{T}, i::Integer) = i < 1 || i > nfields(t) ? throw(BoundsError(t, i)) : Int(i)
+Core.fieldname(t::DataType, i::Integer) = isdefined(t,:names) ? t.names[i]::Symbol : t.name.names[i]::Symbol
+Core.fieldname{T<:Tuple}(t::Type{T}, i::Integer) = i < 1 || i > nfields(t) ? throw(BoundsError(t, i)) : Int(i)
 
 """
     fieldnames(x::DataType)

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -60,6 +60,8 @@ jl_value_t *jl_stackovf_exception;
 #ifdef SEGV_EXCEPTION
 jl_value_t *jl_segv_exception;
 #endif
+jl_typename_t *jl_struct_typename;
+jl_datatype_t *jl_struct_type;
 JL_DLLEXPORT jl_value_t *jl_diverror_exception;
 JL_DLLEXPORT jl_value_t *jl_domain_exception;
 JL_DLLEXPORT jl_value_t *jl_overflow_exception;
@@ -160,7 +162,7 @@ void jl_assign_bits(void *dest, jl_value_t *bits)
 
 JL_DLLEXPORT int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
 {
-    jl_svec_t *fn = t->name->names;
+    jl_svec_t *fn = jl_field_names(t);
     for(size_t i=0; i < jl_svec_len(fn); i++) {
         if (jl_svecref(fn,i) == (jl_value_t*)fld) {
             return (int)i;
@@ -829,6 +831,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields, int8_t
     // corruption otherwise.
     t->fielddesc_type = fielddesc_type;
     t->nfields = nfields;
+    t->names = NULL;
     t->haspadding = 0;
     t->pointerfree = 0;
     t->depth = 0;

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -30,7 +30,7 @@ DECLARE_BUILTIN(fieldtype);  DECLARE_BUILTIN(arrayref);
 DECLARE_BUILTIN(arrayset);   DECLARE_BUILTIN(arraysize);
 DECLARE_BUILTIN(apply_type); DECLARE_BUILTIN(applicable);
 DECLARE_BUILTIN(invoke);     DECLARE_BUILTIN(_expr);
-
+DECLARE_BUILTIN(struct);
 #ifdef __cplusplus
 }
 #endif

--- a/src/dump.c
+++ b/src/dump.c
@@ -72,7 +72,7 @@ static const jl_fptr_t id_to_fptrs[] = {
   jl_f_getfield, jl_f_setfield, jl_f_fieldtype, jl_f_nfields,
   jl_f_arrayref, jl_f_arrayset, jl_f_arraysize, jl_f_apply_type,
   jl_f_applicable, jl_f_invoke, jl_unprotect_stack, jl_f_sizeof, jl_f__expr,
-  jl_f_intrinsic_call,
+  jl_f_intrinsic_call, jl_f_struct,
   NULL };
 
 // pointers to non-AST-ish objects in a compressed tree
@@ -568,6 +568,7 @@ static void jl_serialize_datatype(ios_t *s, jl_datatype_t *dt)
 
     jl_serialize_value(s, dt->parameters);
     jl_serialize_value(s, dt->name);
+    jl_serialize_value(s, dt->names);
     jl_serialize_value(s, dt->super);
 }
 
@@ -1242,6 +1243,8 @@ static jl_value_t *jl_deserialize_datatype(ios_t *s, int pos, jl_value_t **loc)
     jl_gc_wb(dt, dt->parameters);
     dt->name = (jl_typename_t*)jl_deserialize_value(s, (jl_value_t**)&dt->name);
     jl_gc_wb(dt, dt->name);
+    dt->names = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&dt->names);
+    jl_gc_wb(dt, dt->names);
     dt->super = (jl_datatype_t*)jl_deserialize_value(s, (jl_value_t**)&dt->super);
     jl_gc_wb(dt, dt->super);
     if (datatype_list) {
@@ -1249,7 +1252,7 @@ static jl_value_t *jl_deserialize_datatype(ios_t *s, int pos, jl_value_t **loc)
             dt->name == jl_pointer_type->name || dt->name == jl_type_type->name ||
             dt->name == jl_simplevector_type->name || dt->name == jl_abstractarray_type->name ||
             dt->name == jl_densearray_type->name || dt->name == jl_tuple_typename ||
-            dt->name == jl_vararg_type->name) {
+            dt->name == jl_vararg_type->name || dt->name == jl_struct_typename) {
             // builtin types are not serialized, so their caches aren't
             // explicitly saved. so we reconstruct the caches of builtin
             // parametric types here.
@@ -2472,7 +2475,7 @@ void jl_init_serializer(void)
                      jl_typector_type->name, jl_intrinsic_type->name, jl_task_type->name,
                      jl_labelnode_type->name, jl_linenumbernode_type->name, jl_builtin_type->name,
                      jl_gotonode_type->name, jl_quotenode_type->name,
-                     jl_globalref_type->name,
+                     jl_globalref_type->name, jl_struct_type->name, jl_struct_type, jl_tparam0(jl_struct_type), jl_tparam1(jl_struct_type),
 
                      jl_root_task,
 

--- a/src/init.c
+++ b/src/init.c
@@ -841,6 +841,8 @@ void jl_get_builtin_hooks(void)
     jl_string_type = (jl_datatype_t*)core("String");
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
     jl_vecelement_typename = ((jl_datatype_t*)core("VecElement"))->name;
+    jl_struct_type = ((jl_datatype_t*)core("Struct"));
+    jl_struct_typename = jl_struct_type->name;
 }
 
 JL_DLLEXPORT void jl_get_system_hooks(void)
@@ -868,6 +870,7 @@ void jl_get_builtins(void)
     jl_builtin_arrayset = core("arrayset");     jl_builtin_arraysize = core("arraysize");
     jl_builtin_apply_type = core("apply_type"); jl_builtin_applicable = core("applicable");
     jl_builtin_invoke = core("invoke");         jl_builtin__expr = core("_expr");
+    jl_builtin_struct = core("struct");
 }
 
 #ifdef __cplusplus

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -475,7 +475,7 @@
                           (let ((rkw (make-ssavalue)))
                             `(block
                               (= ,rkw ,restkw-expr)
-                              (if (comparison (call (core nfields) ,rkw) === 0)
+                              (if (comparison (call (core nfields) (call (core typeof) ,rkw)) === 0)
                                   (block)
                                   (call (top kwerr)
                                         (call (core fieldname) (call (core typeof) ,rkw) 1)))))

--- a/src/julia.h
+++ b/src/julia.h
@@ -331,10 +331,11 @@ typedef struct _jl_datatype_t {
     int32_t ninitialized;
     // memoized properties
     int32_t depth;
+    jl_svec_t *names;
+    // hidden fields:
     int8_t hastypevars; // bound
     int8_t haswildcard; // unbound
     int8_t isleaftype;
-    // hidden fields:
     uint32_t nfields;
     uint32_t alignment : 29;  // strictest alignment over all fields
     uint32_t haspadding : 1;  // has internal undefined bytes
@@ -478,6 +479,8 @@ extern JL_DLLEXPORT jl_datatype_t *jl_array_type;
 extern JL_DLLEXPORT jl_typename_t *jl_array_typename;
 extern JL_DLLEXPORT jl_datatype_t *jl_weakref_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_string_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_struct_type;
+extern JL_DLLEXPORT jl_typename_t *jl_struct_typename;
 extern JL_DLLEXPORT jl_datatype_t *jl_errorexception_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_argumenterror_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_loaderror_type;
@@ -764,7 +767,17 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x)
 #define jl_gf_name(f)   (jl_gf_mtable(f)->name)
 
 // struct type info
-#define jl_field_name(st,i)    (jl_sym_t*)jl_svecref(((jl_datatype_t*)st)->name->names, (i))
+STATIC_INLINE jl_svec_t *jl_field_names(jl_datatype_t *st)
+{
+    jl_svec_t *names = st->names;
+    if (!names)
+        names = st->name->names;
+    return names;
+}
+STATIC_INLINE jl_sym_t *jl_field_name(jl_datatype_t *st, size_t i)
+{
+    return (jl_sym_t*)jl_svecref(jl_field_names(st), i);
+}
 #define jl_field_type(st,i)    jl_svecref(((jl_datatype_t*)st)->types, (i))
 #define jl_datatype_size(t)    (((jl_datatype_t*)t)->size)
 #define jl_datatype_nfields(t) (((jl_datatype_t*)(t))->nfields)

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -175,7 +175,7 @@ function test4974(;kwargs...)
     end
 end
 
-@test test4974(a=1) == (2, [(:a, 1)])
+@test test4974(a=1) == (2, Struct(a=1))
 
 # issue #7704, computed keywords
 @test kwf1(1; (:tens, 2)) == 21


### PR DESCRIPTION
I tried a couple approaches for kwargs but this one I like.
It introduces a structural named-fields counterpart to tuple types (unimaginatively called `Struct`). You can make a `Struct(x = 1.0, y = 2.0)` and it has type `Struct{(:x,:y),Tuple{Float,Float}}` with fields `x` and `y`.

There is a couple functions to merge or diff them and it uses that as the basis for kwargs splatting and unpacking.

This PR is not ready yet and is up here mostly to discuss the implications. The problematic one are probably over-specialization and the use of staged functions in the implementation (as always).

Assuming we want this, here are a few points I'm wondering about :
- Should we aim to merge those things with `Tuple` so that we have only one kind of structural type. We'd get dispatch-on-kwargs for "free" (== retrofit all code that touches tuple types ... hem). This is probably a long term question and keeping them separate is a decent first step in that direction anyway.
- Should they be covariant ? I'm guessing yes.
- Should they have vararg forms ? I'm guessing yes too, so you could match on "at least those fields with those types"
- Should they have an optional-field form ? Like `{x::Int, y?::Int}` that has `{x::Int,y::Int}` and `{x::Int}` as subtypes. I tink this is necessary if we want to express our current kwarg semantics using only normal dispatch and avoid generating a lot of methods.
- Should we always sort fields ? For now `Struct` types take ordering into account but the kwarg lowering/merging/diffing always keeps them sorted to avoid generating a specialization for every permutation.

Other than that, it currently seem to work when used as a replacement for our current kwarg lowering and we get specialization, inlining, inference etc.
Going forward with this we can probably remove a bit of the `kwfunc` business but for now I only did minimal integration.

I feel that the `Struct` type is interesting in itself anyway.
