### PR TITLE
Minor cleanup on BitArray constructors to fully allow for Integer types

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -27,7 +27,7 @@ type BitArray{N} <: DenseArray{Bool, N}
 end
 
 BitArray{N}(dims::NTuple{N,Int}) = BitArray{N}(dims...)
-BitArray(dims::Int...) = BitArray(dims)
+BitArray(dims::Integer...) = BitArray(map(Int,dims))
 
 typealias BitVector BitArray{1}
 typealias BitMatrix BitArray{2}
@@ -386,7 +386,7 @@ end
 Create a `BitArray` with all values set to `false`.
 """
 falses(dims::Dims) = fill!(BitArray(dims), false)
-falses(dims::Integer...) = falses(dims)
+falses(dims::Integer...) = falses(map(Int,dims))
 """
     falses(A)
 
@@ -400,7 +400,7 @@ falses(A::AbstractArray) = falses(size(A))
 Create a `BitArray` with all values set to `true`.
 """
 trues(dims::Dims) = fill!(BitArray(dims), true)
-trues(dims::Integer...) = trues(dims)
+trues(dims::Integer...) = trues(map(Int,dims))
 """
     trues(A)
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1341,3 +1341,16 @@ uv = Array(v)
 B = bitrand(10,10)
 uB = Array(B)
 @test diag(uB) == Array(diag(B))
+
+# test non-Int dims constructor
+A = BitArray(Int32(10))
+B = BitArray(Int64(10))
+@test A == B
+
+A = trues(Int32(10))
+B = trues(Int64(10))
+@test A == B
+
+A = falses(Int32(10))
+B = falses(Int64(10))
+@test A == B


### PR DESCRIPTION
This came up from the following behavior on my 64-bit system:

``` julia
julia> BitArray(Int64(10))
10-element BitArray{1}:
 false
 false
 false
 false
 false
 false
 false
 false
 false
 false

julia> BitArray(Int32(10))
ERROR: MethodError: `convert` has no method matching convert(::Type{BitArray{N}}, ::Int32)
This may have arisen from a call to the constructor BitArray{N}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert{T,N}(::Type{BitArray{N}}, ::AbstractArray{T,N})
  convert{T}(::Type{T}, ::T)
  ...
 in call at essentials.jl:56

julia> falses(Int64(10))
10-element BitArray{1}:
 false
 false
 false
 false
 false
 false
 false
 false
 false
 false

julia> falses(Int32(10))
ERROR: MethodError: `convert` has no method matching convert(::Type{BitArray{N}}, ::Int32)
This may have arisen from a call to the constructor BitArray{N}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert{T,N}(::Type{BitArray{N}}, ::AbstractArray{T,N})
  convert{T}(::Type{T}, ::T)
  ...
 in call at essentials.jl:56
 in falses at bitarray.jl:238
```

CC: @carlobaldassi 
