### PR TITLE
Clean up the pivot selection for QuickSort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -241,26 +241,17 @@ end
 @inline function selectpivot!(v::AbstractVector, lo::Int, hi::Int, o::Ordering)
     @inbounds begin
         mi = (lo+hi)>>>1
-
-        # sort the values in v[lo], v[mi], v[hi]
-
-        if lt(o, v[mi], v[lo])
+        if lt(o, v[lo], v[mi])
             v[mi], v[lo] = v[lo], v[mi]
         end
-        if lt(o, v[hi], v[mi])
-            if lt(o, v[hi], v[lo])
-                v[lo], v[mi], v[hi] = v[hi], v[lo], v[mi]
-            else
-                v[hi], v[mi] = v[mi], v[hi]
+        if lt(o, v[hi], v[lo])
+            v[lo], v[hi] = v[hi], v[lo]
+            if lt(o, v[lo], v[mi])
+                v[mi], v[lo] = v[lo], v[mi]
             end
         end
-
-        # move v[mi] to v[lo] and use it as the pivot
-        v[lo], v[mi] = v[mi], v[lo]
         pivot = v[lo]
     end
-
-    # return the pivot
     return pivot
 end
 


### PR DESCRIPTION
This is and improvement to the current `selectpivot!`, that selects the pivot for the partition in the `QuickSort` algorithm.

Currently the method always orders the three elements and then swaps the first and middle elements. This change saves a little by ordering in such a way that `v[hi]` is the greatest and `v[mi]` the smallest, so there is no need of a swapping at the end.

For comparison the current implementation generates the following machine code

``` asm
;julia> @code_native selectpivot!(v, i, j, Base.Order.Forward)
    .text
Filename: sort.jl
Source line: 247
    pushq   %rbp
    movq    %rsp, %rbp
Source line: 247
    movq    (%rdi), %rcx
    movq    -8(%rcx,%rsi,8), %r8
Source line: 243
    leaq    (%rdx,%rsi), %rax
    shrq    %rax
Source line: 247
    movq    -8(%rcx,%rax,8), %r9
    cmpq    %r8, %r9
    jge L46
Source line: 248
    movq    %r8, -8(%rcx,%rax,8)
    movq    (%rdi), %rcx
    movq    %r9, -8(%rcx,%rsi,8)
Source line: 250
L46:    movq    (%rdi), %rcx
    movq    -8(%rcx,%rax,8), %r8
    movq    -8(%rcx,%rdx,8), %r9
    cmpq    %r8, %r9
    jge L121
Source line: 251
    movq    -8(%rcx,%rsi,8), %r10
    cmpq    %r10, %r9
    jge L108
Source line: 252
    movq    %r9, -8(%rcx,%rsi,8)
    movq    (%rdi), %rcx
    movq    %r10, -8(%rcx,%rax,8)
    movq    (%rdi), %rcx
    movq    %r8, -8(%rcx,%rdx,8)
    jmpq    L121
Source line: 254
L108:   movq    %r8, -8(%rcx,%rdx,8)
    movq    (%rdi), %rcx
    movq    %r9, -8(%rcx,%rax,8)
Source line: 259
L121:   movq    (%rdi), %rdx
    movq    -8(%rdx,%rsi,8), %r8
    movq    -8(%rdx,%rax,8), %rcx
    movq    %rcx, -8(%rdx,%rsi,8)
    movq    (%rdi), %rcx
    movq    %r8, -8(%rcx,%rax,8)
Source line: 260
    movq    (%rdi), %rax
    movq    -8(%rax,%rsi,8), %rax
Source line: 264
    popq    %rbp
    ret
```

while the change produces

``` asm
;julia> @code_native selectpivot!(v, i, j, Base.Order.Forward)
    .text
Filename: none
Source line: 4
    pushq   %rbp
    movq    %rsp, %rbp
Source line: 4
    movq    (%rdi), %rcx
    movq    -8(%rcx,%rsi,8), %r8
Source line: 3
    leaq    (%rdx,%rsi), %rax
    shrq    %rax
Source line: 4
    movq    -8(%rcx,%rax,8), %r9
    cmpq    %r9, %r8
    jge L46
Source line: 5
    movq    %r9, -8(%rcx,%rsi,8)
    movq    (%rdi), %rcx
    movq    %r8, -8(%rcx,%rax,8)
Source line: 7
L46:    movq    (%rdi), %rcx
    movq    -8(%rcx,%rsi,8), %r9
    movq    -8(%rcx,%rdx,8), %r8
    cmpq    %r9, %r8
    jge L116
Source line: 8
    movq    %r9, -8(%rcx,%rdx,8)
    movq    (%rdi), %rcx
    movq    %r8, -8(%rcx,%rsi,8)
Source line: 9
    movq    (%rdi), %rcx
    movq    -8(%rcx,%rax,8), %rdx
    movq    -8(%rcx,%rsi,8), %r8
    cmpq    %rdx, %r8
    jge L116
Source line: 10
    movq    %rdx, -8(%rcx,%rsi,8)
    movq    (%rdi), %rcx
    movq    %r8, -8(%rcx,%rax,8)
Source line: 13
L116:   movq    (%rdi), %rax
    movq    -8(%rax,%rsi,8), %rax
Source line: 15
    popq    %rbp
    ret
```

This seems to give near a 10% speed up for `sort` and `sortperm` in some tests I made.

CC @StefanKarpinski
