### PR TITLE
Add logdet for Triangular types

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -563,8 +563,11 @@ function det{T}(A::AbstractMatrix{T})
 end
 det(x::Number) = x
 
-logdet(A::AbstractMatrix) = logdet(lufact(A))
 logabsdet(A::AbstractMatrix) = logabsdet(lufact(A))
+function logdet(A::AbstractMatrix)
+    d,s = logabsdet(A)
+    return d + log(s)
+end
 
 # isapprox: approximate equality of arrays [like isapprox(Number,Number)]
 function isapprox{T<:Number,S<:Number}(x::AbstractArray{T}, y::AbstractArray{S}; rtol::Real=Base.rtoldefault(T,S), atol::Real=0, norm::Function=vecnorm)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1825,8 +1825,22 @@ function eigvecs{T}(A::AbstractTriangular{T})
 end
 det{T}(A::UnitUpperTriangular{T}) = one(T)
 det{T}(A::UnitLowerTriangular{T}) = one(T)
+logdet{T}(A::UnitUpperTriangular{T}) = zero(T)
+logdet{T}(A::UnitLowerTriangular{T}) = zero(T)
+logabsdet{T}(A::UnitUpperTriangular{T}) = zero(T), one(T)
+logabsdet{T}(A::UnitLowerTriangular{T}) = zero(T), one(T)
 det{T}(A::UpperTriangular{T}) = prod(diag(A.data))
 det{T}(A::LowerTriangular{T}) = prod(diag(A.data))
+function logabsdet{T}(A::Union{UpperTriangular{T},LowerTriangular{T}})
+    sgn = one(T)
+    abs_det = zero(real(T))
+    @inbounds for i in 1:size(A,1)
+        diag_i = A.data[i,i]
+        sgn *= sign(diag_i)
+        abs_det += log(abs(diag_i))
+    end
+    return abs_det, sgn
+end
 
 eigfact(A::AbstractTriangular) = Eigen(eigvals(A), eigvecs(A))
 

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -225,6 +225,7 @@ for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloa
 
         # Determinant
         @test_approx_eq_eps det(A1) det(lufact(full(A1))) sqrt(eps(real(float(one(elty1)))))*n*n
+        @test_approx_eq_eps logdet(A1) logdet(lufact(full(A1))) sqrt(eps(real(float(one(elty1)))))*n*n
 
         # Matrix square root
         @test sqrtm(A1) |> t -> t*t ≈ A1


### PR DESCRIPTION
Somehow we didn't have `logdet` working for these. Added now with tests.
