### PR TITLE
[release-0.4] Add a manifest file for the sake of dlopening Python 2.7 extensions on Windows

### DIFF
--- a/contrib/windows/julia-manifest.xml
+++ b/contrib/windows/julia-manifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.VC90.CRT" version="9.0.21022.8" processorArchitecture="amd64" publicKeyToken="1fc8b3b9a1e18e3b"></assemblyIdentity>
+    </dependentAssembly>
+  </dependency>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!--The ID below indicates application support for Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!--The ID below indicates application support for Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!--The ID below indicates application support for Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!--The ID below indicates application support for Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!--The ID below indicates application support for Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/contrib/windows/julia.rc
+++ b/contrib/windows/julia.rc
@@ -1,4 +1,5 @@
 #include <winver.h>
+#include <winuser.h>
 1 VERSIONINFO
 FILEVERSION     JLVER
 PRODUCTVERSION  JLVER
@@ -31,3 +32,4 @@ BEGIN
   END
 END
 2 ICON "julia.ico"
+1 RT_MANIFEST "julia-manifest.xml"


### PR DESCRIPTION
fixes https://github.com/stevengj/PyCall.jl/issues/87

(cherry picked from commit 098a0cc42254c53f1b1d819bea224c3dd6291e04)
backport of #16442
