### PR TITLE
Fix a typo in methods.rst

### DIFF
--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -223,7 +223,7 @@ pairs of arguments to which no other method definition applies.
 
 Although it seems a simple concept, multiple dispatch on the types of
 values is perhaps the single most powerful and central feature of the
-Julia language. Core operations typically have dozens of methods::
+Julia language. Core operations typically have dozens of methods:
 
 .. doctest::
 


### PR DESCRIPTION
Fix a typo in methods.rst which causes [code in doctest](http://docs.julialang.org/en/latest/manual/methods) display abnormally.
