### PR TITLE
don't truncate Dict printing when everything fits

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -105,11 +105,18 @@ function show{K,V}(io::IO, t::Associative{K,V})
 
         # determine max key width to align the output, caching the strings
         ks = Array{AbstractString}(min(rows, length(t)))
+        vs = Array{AbstractString}(min(rows, length(t)))
         keylen = 0
-        for (i, k) in enumerate(keys(t))
+        vallen = 0
+        for (i, (k, v)) in enumerate(t)
             i > rows && break
             ks[i] = sprint(0, show, k, env=recur_io)
-            keylen = clamp(length(ks[i]), keylen, div(cols, 3))
+            vs[i] = sprint(0, show, v, env=recur_io)
+            keylen = clamp(length(ks[i]), keylen, cols)
+            vallen = clamp(length(vs[i]), vallen, cols)
+        end
+        if keylen > max(div(cols, 2), cols - vallen)
+            keylen = max(cld(cols, 3), cols - vallen)
         end
     else
         rows = cols = 0
@@ -130,8 +137,7 @@ function show{K,V}(io::IO, t::Associative{K,V})
         print(io, " => ")
 
         if limit
-            val = sprint(0, show, v, env=recur_io)
-            val = _truncate_at_width_or_chars(val, cols - keylen, "\r\n")
+            val = _truncate_at_width_or_chars(vs[i], cols - keylen, "\r\n")
             print(io, val)
         else
             show(recur_io, v)


### PR DESCRIPTION
The display of `Dict`'s has recently (< 1 week) changed, and by default truncates the keys to 1/3rd of the available horizontal size. I guess this heuristic is based on the fact that usually values are more valuable than keys? (cf. #5706, cc @mbauman). The bug is that keys are truncated even when all key-value pairs could be fully printed. Eg:

```
julia> factor(340282366920938463463374607431768211507*3)
Dict{BigInt,Int64} with 2 entries:
   3                                     => 1
   340282366920938463463374607431768211… => 1
```

The minimum fix is to truncate to 1/3rd of the screen only when something has to be truncated. I added here a little bit of logic:
1. if the keys fit in half the screen, then do that (and truncate only the values), 
2. otherwise truncate them to what it takes to show fully the values (but no less than 1/3rd).

The idea is that some might prefer to see fully the keys rather than to have both the keys and values truncated. We could add one more step:
1. if values fit in 2/3rd, then truncate only the keys (to minimum 1/3rd of the screen),
2. otherwise follow algorithm above.

We could also decide to give the same treatment to both keys and values (and why not, write a slighly more involved algorithm which maximizes the number of entries (key or value) fully shown, but I wanted feedback before bothering with that).
