### PR TITLE
deprecate `broadcast_function` and `broadcast!_function`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,7 @@ module Broadcast
 using ..Cartesian
 using Base: promote_op, promote_eltype, promote_eltype_op, @get!, _msk_end, unsafe_bitgetindex
 import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^
-export broadcast, broadcast!, broadcast_function, broadcast!_function, bitbroadcast
+export broadcast, broadcast!, bitbroadcast
 export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##
@@ -220,9 +220,6 @@ end
 broadcast(f, As...) = broadcast!(f, Array{promote_eltype_op(f, As...)}(broadcast_shape(As...)), As...)
 
 bitbroadcast(f, As...) = broadcast!(f, BitArray(broadcast_shape(As...)), As...)
-
-broadcast!_function(f) = (B, As...) -> broadcast!(f, B, As...)
-broadcast_function(f) = (As...) -> broadcast(f, As...)
 
 broadcast_getindex(src::AbstractArray, I::AbstractArray...) = broadcast_getindex!(Array{eltype(src)}(broadcast_shape(I...)), src, I...)
 @generated function broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::AbstractArray...)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1273,6 +1273,9 @@ end
 @deprecate print_unescaped unescape_string
 @deprecate print_joined join
 
+@deprecate broadcast!_function(f) (B, As...) -> broadcast!(f, B, As...)
+@deprecate broadcast_function(f)  (As...) -> broadcast(f, As...)
+
 ##### histogram #####
 
 ## nice-valued ranges for histograms

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3483,15 +3483,6 @@ not representable.
 trunc
 
 """
-    broadcast_function(f)
-
-Returns a function `broadcast_f` such that
-`broadcast_function(f)(As...) === broadcast(f, As...)`. Most useful in the form
-`const broadcast_f = broadcast_function(f)`.
-"""
-broadcast_function
-
-"""
     unsafe_convert(T,x)
 
 Convert `x` to a value of type `T`
@@ -5624,15 +5615,6 @@ the results need to be used judiciously. See [Manual](:ref:`man-code-warntype`) 
 information.
 """
 code_warntype
-
-"""
-```
-broadcast!_function(f)
-```
-
-Like `broadcast_function`, but for `broadcast!`.
-"""
-broadcast!_function
 
 """
     setrounding(T, mode)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -486,9 +486,7 @@ export
 # arrays
     bitbroadcast,
     broadcast!,
-    broadcast!_function,
     broadcast,
-    broadcast_function,
     broadcast_getindex,
     broadcast_setindex!,
     cat,

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -316,18 +316,6 @@ All mathematical operations and functions are supported for arrays
 
    Like ``broadcast``\ , but allocates a ``BitArray`` to store the result, rather then an ``Array``\ .
 
-.. function:: broadcast_function(f)
-
-   .. Docstring generated from Julia source
-
-   Returns a function ``broadcast_f`` such that ``broadcast_function(f)(As...) === broadcast(f, As...)``\ . Most useful in the form ``const broadcast_f = broadcast_function(f)``\ .
-
-.. function:: broadcast!_function(f)
-
-   .. Docstring generated from Julia source
-
-   Like ``broadcast_function``\ , but for ``broadcast!``\ .
-
 Indexing, Assignment, and Concatenation
 ---------------------------------------
 


### PR DESCRIPTION
closes #16601
