### PR TITLE
WIP: Improve performance for depwarn

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -58,24 +58,22 @@ end
 
 function depwarn(msg, funcsym)
     opts = JLOptions()
-    if opts.depwarn > 0
+    if opts.depwarn == 1  # raise a warning
         ln = Int(unsafe_load(cglobal(:jl_lineno, Cint)))
         fn = String(unsafe_load(cglobal(:jl_filename, Ptr{Cchar})))
         bt = backtrace()
         caller = firstcaller(bt, funcsym)
-        if opts.depwarn == 1 # raise a warning
-            warn(msg, once=(caller != C_NULL), key=caller, bt=bt,
-                 filename=fn, lineno=ln)
-        elseif opts.depwarn == 2 # raise an error
-            throw(ErrorException(msg))
-        end
+        warn(msg, once=(caller != C_NULL), key=caller, bt=bt, filename=fn, lineno=ln)
+    elseif opts.depwarn == 2  # raise an error
+        throw(ErrorException(msg))
     end
 end
 
 function firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol)
     # Identify the calling line
     i = 1
-    while i <= length(bt)
+    len = length(bt)
+    while i <= len
         lkups = StackTraces.lookup(bt[i])
         i += 1
         for lkup in lkups
@@ -88,7 +86,7 @@ function firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol)
         end
     end
     @label found
-    if i <= length(bt)
+    if i <= len
         return bt[i]
     end
     return C_NULL

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -59,10 +59,17 @@ end
 function depwarn(msg, funcsym)
     opts = JLOptions()
     if opts.depwarn == 1  # raise a warning
+        caller = firstcaller(backtrace(5), funcsym)
+        if caller != C_NULL
+            (caller in have_warned) && return
+            bt = backtrace()
+        else
+            bt = backtrace()
+            caller = firstcaller(bt, funcsym)
+            (caller in have_warned) && return
+        end
         ln = Int(unsafe_load(cglobal(:jl_lineno, Cint)))
         fn = String(unsafe_load(cglobal(:jl_filename, Ptr{Cchar})))
-        bt = backtrace()
-        caller = firstcaller(bt, funcsym)
         warn(msg, once=(caller != C_NULL), key=caller, bt=bt, filename=fn, lineno=ln)
     elseif opts.depwarn == 2  # raise an error
         throw(ErrorException(msg))

--- a/base/error.jl
+++ b/base/error.jl
@@ -27,7 +27,7 @@ rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
 function backtrace_caller(name::Symbol, callers::Integer=0)
     ccall(:jl_backtrace_caller, Ptr{Void}, (Ref{Symbol}, Int32), name, callers)
 end
-backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32, Int32, Int32), false, -1, false)
+backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32,), false)
 catch_backtrace() = ccall(:jl_get_backtrace, Array{Ptr{Void},1}, ())
 
 ## keyword arg lowering generates calls to this ##

--- a/base/error.jl
+++ b/base/error.jl
@@ -24,8 +24,8 @@ error(s...) = throw(Main.Base.ErrorException(Main.Base.string(s...)))
 rethrow() = ccall(:jl_rethrow, Bottom, ())
 rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
 
-function backtrace(limit::Integer)
-    ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32, Int32, Int32), false, limit, true)
+function backtrace_caller(name::Symbol, callers::Integer=0)
+    ccall(:jl_backtrace_caller, Ptr{Void}, (Ref{Symbol}, Int32), name, callers)
 end
 backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32, Int32, Int32), false, -1, false)
 catch_backtrace() = ccall(:jl_get_backtrace, Array{Ptr{Void},1}, ())

--- a/base/error.jl
+++ b/base/error.jl
@@ -23,7 +23,11 @@ error(s...) = throw(Main.Base.ErrorException(Main.Base.string(s...)))
 
 rethrow() = ccall(:jl_rethrow, Bottom, ())
 rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
-backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32,), false)
+
+function backtrace(limit::Integer)
+    ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32, Int32, Int32), false, limit, true)
+end
+backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32, Int32, Int32), false, -1, false)
 catch_backtrace() = ccall(:jl_get_backtrace, Array{Ptr{Void},1}, ())
 
 ## keyword arg lowering generates calls to this ##

--- a/base/util.jl
+++ b/base/util.jl
@@ -300,7 +300,14 @@ function julia_cmd(julia=joinpath(JULIA_HOME, julia_exename()))
               else
                   "yes"
               end
-    `$julia -C$cpu_target -J$image_file --compile=$compile`
+    depwarn = if opts.depwarn == 0
+                  "no"
+              elseif opts.depwarn == 2
+                  "error"
+              else
+                  "yes"
+              end
+    `$julia -C$cpu_target -J$image_file --compile=$compile --depwarn=$depwarn`
 end
 
 julia_exename() = ccall(:jl_is_debugbuild,Cint,())==0 ? "julia" : "julia-debug"

--- a/src/init.c
+++ b/src/init.c
@@ -68,7 +68,7 @@ jl_options_t jl_options = { 0,    // quiet
                             0,    // malloc_log
                             2,    // opt_level
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
-                            1,    // depwarn
+                            JL_OPTIONS_DEPWARN_ON, // depwarn
                             1,    // can_inline
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -99,3 +99,11 @@ let
     @test i1 > 0 && i2 > 0
     @test b1[i1].line != b2[i2].line
 end
+
+let
+    @noinline a_16617() = Base.backtrace_caller(:a_16617, 1)  # Return the caller of `a_16617`
+    @noinline b_16617() = a_16617()
+    caller = b_16617()
+
+    @test first(StackTraces.lookup(caller)).func == :b_16617
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -33,7 +33,7 @@ function choosetests(choices = [])
         "markdown", "base64", "serialize", "misc", "threads",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
-        "boundscheck", "error", "ambiguous"
+        "boundscheck", "error", "ambiguous", "deprecated",
     ]
 
     if Base.USE_GPL_LIBS

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -2,15 +2,6 @@
 
 # Note: Tests usually run with `--depwarn=error` (2)
 
-let
-    @noinline a_16617() = backtrace()
-    @noinline b_16617() = a_16617()
-    bt = b_16617()
-
-    caller = Base.firstcaller(bt, :a_16617)  # Determine the caller of `a_16617`
-    @test first(StackTraces.lookup(caller)).func == :b_16617
-end
-
 # Calling the same deprecated function from different callers should generate multiple
 # warnings
 let

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,40 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+# Note: Tests usually run with `--depwarn=error` (2)
+
+let
+    @noinline a_16617() = backtrace()
+    @noinline b_16617() = a_16617()
+    bt = b_16617()
+
+    caller = Base.firstcaller(bt, :a_16617)  # Determine the caller of `a_16617`
+    @test first(StackTraces.lookup(caller)).func == :b_16617
+end
+
+# Calling the same deprecated function from different callers should generate multiple
+# warnings
+let
+    io = IOBuffer()
+    @noinline deprecated_16617() = Base.depwarn(io, "message", :deprecated_16617, mode=1)
+    @noinline f1_16617() = deprecated_16617()
+    @noinline f2_16617() = deprecated_16617()
+    @noinline function f3_16617()
+        f1_16617()
+        f2_16617()
+    end
+    f3_16617()  # This line should print two depwarn
+    @test length(matchall(r"WARNING", readstring(seekstart(io)))) == 2
+end
+
+# Calling the same deprecated function from the same caller should result in one warning.
+let
+    io = IOBuffer()
+    @noinline deprecated_16617() = Base.depwarn(io, "message", :deprecated_16617, mode=1)
+    @noinline g1_16617() = deprecated_16617()
+    @noinline function g2_16617()
+        g1_16617()
+        g1_16617()
+    end
+    g2_16617()  # This line should print only one depwarn
+    @test length(matchall(r"WARNING", readstring(seekstart(io)))) == 1
+end


### PR DESCRIPTION
During my investigation into why Appveyor CI was [consistently timing out](https://ci.appveyor.com/project/quinnj/timezones-jl/build/1.0.106) for TimeZones.jl on the nightly release of Julia I discovered that issue came from deprecation warnings.

Even though Julia avoids printing repeated deprecation warnings it will always compute the backtraces when encountering a deprecation. Running within a Windows VM `@time Pkg.build("TimeZones")` took 2073 seconds while this PR only takes 254 seconds (~8x improvement).

~~I personally don't think that a full stack trace is necessary for a deprecation warning so I think this is a reasonable solution. If others disagree~~ we could probably improve performance by only performing a backtrace once we know the deprecation warning will be displayed.

Remaining work for this PR includes:
- [ ] ~~Removing the `funcsym` parameter from `depwarn`~~
- [x] Test cases
