### PR TITLE
The Tuples at the End of the Universe

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3,7 +3,7 @@
 #### parameters limiting potentially-infinite types ####
 const MAX_TYPEUNION_LEN = 3
 const MAX_TYPE_DEPTH = 7
-const MAX_TUPLETYPE_LEN  = 8
+const MAX_TUPLETYPE_LEN  = 42
 const MAX_TUPLE_DEPTH = 4
 
 const MAX_TUPLE_SPLAT = 16


### PR DESCRIPTION
Re-up MAX_TUPLETYPE_LEN (redo of #15080). Since this is the sequel, it clearly needed a new name.

As discussed in https://github.com/JuliaLang/julia/pull/15021#issuecomment-217539471. Re-fixes the performance problem mentioned in #16626 on master, for arrays of any reasonable dimensionality.
