### PR TITLE
Rewrite GC page metadata for sweeping fast path

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -496,6 +496,62 @@ void gc_debug_init(void)
 #endif
 }
 
+// Simple and dumb way to count cells with different gc bits in allocated pages
+// Use as ground truth for debugging memory-leak-like issues.
+static int64_t poolobj_sizes[4];
+static int64_t empty_pages;
+
+static void gc_count_pool_page(jl_gc_pagemeta_t *pg)
+{
+    int osize = pg->osize;
+    char *data = pg->data;
+    gcval_t *v = (gcval_t*)(data + GC_PAGE_OFFSET);
+    char *lim = (char*)v + GC_PAGE_SZ - GC_PAGE_OFFSET - osize;
+    int has_live = 0;
+    while ((char*)v <= lim) {
+        int bits = gc_bits(v);
+        if (bits & GC_MARKED)
+            has_live = 1;
+        poolobj_sizes[bits] += osize;
+        v = (gcval_t*)((char*)v + osize);
+    }
+    if (!has_live) {
+        empty_pages++;
+    }
+}
+
+static void gc_count_pool_region(region_t *region)
+{
+    for (int pg_i = 0; pg_i < region->pg_cnt / 32; pg_i++) {
+        uint32_t line = region->allocmap[pg_i];
+        if (line) {
+            for (int j = 0; j < 32; j++) {
+                if ((line >> j) & 1) {
+                    gc_count_pool_page(&region->meta[pg_i*32 + j]);
+                }
+            }
+        }
+    }
+}
+
+void gc_count_pool(void)
+{
+    memset(&poolobj_sizes, 0, sizeof(poolobj_sizes));
+    empty_pages = 0;
+    for (int i = 0; i < REGION_COUNT; i++) {
+        if (regions[i].pages) {
+            gc_count_pool_region(&regions[i]);
+        }
+    }
+    jl_safe_printf("****** Pool stat: ******\n");
+    for (int i = 0;i < 4;i++)
+        jl_safe_printf("bits(%d): %"  PRId64 "\n", i, poolobj_sizes[i]);
+    // empty_pages is inaccurate after the sweep since young objects are
+    // also GC_CLEAN
+    jl_safe_printf("free pages: % "  PRId64 "\n", empty_pages);
+    jl_safe_printf("************************\n");
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -348,8 +348,8 @@ static void gc_scrub_range(char *stack_lo, char *stack_hi)
             continue;
         jl_gc_pagemeta_t *pg = page_metadata(tag);
         // Make sure the sweep rebuild the freelist
-        pg->allocd = 1;
-        pg->gc_bits = 0x3;
+        pg->has_marked = 1;
+        pg->has_young = 1;
         // Find the age bit
         char *page_begin = gc_page_data(tag) + GC_PAGE_OFFSET;
         int obj_id = (((char*)tag) - page_begin) / osize;
@@ -358,6 +358,7 @@ static void gc_scrub_range(char *stack_lo, char *stack_hi)
         // (especially on 32bit where it's more likely to have pointer-like
         //  bit patterns)
         *ages &= ~(1 << (obj_id % 8));
+        // set mark to GC_MARKED_NOESC (young and marked)
         memset(tag, 0xff, osize);
     }
 }

--- a/src/gc.h
+++ b/src/gc.h
@@ -154,11 +154,17 @@ typedef struct {
         //
         // For a quick sweep preceded by a full sweep. If this bit is set,
         // the page needs to be swept. If this bit is not set, there could
-        // still be old dead objects in the page.
+        // still be old dead objects in the page and `nold` and `prev_nold`
+        // should be used to determine if the page needs to be swept.
         uint16_t has_young: 1;
     };
-    uint16_t nfree; // number of free objects in this page.
-                    // invalid if pool that owns this page is allocating objects from this page.
+    // number of old objects in this page
+    uint16_t nold;
+    // number of old objects in this page during the previous full sweep
+    uint16_t prev_nold;
+    // number of free objects in this page.
+    // invalid if pool that owns this page is allocating objects from this page.
+    uint16_t nfree;
     uint16_t osize; // size of each object in this page
     uint16_t fl_begin_offset; // offset of first free object in this page
     uint16_t fl_end_offset;   // offset of last free object in this page

--- a/src/gc.h
+++ b/src/gc.h
@@ -138,9 +138,24 @@ typedef struct _mallocarray_t {
 // pool page metadata
 typedef struct {
     struct {
-        uint16_t pool_n : 8; // index (into norm_pool) of pool that owns this page
-        uint16_t allocd : 1; // true if an allocation happened in this page since last sweep
-        uint16_t gc_bits : 2; // this is a bitwise | of all gc_bits in this page
+        // index of pool that owns this page
+        uint16_t pool_n : 8;
+        // Whether any cell in the page is marked
+        // This bit is set before sweeping iff there's live cells in the page.
+        // Note that before marking or after sweeping there can be live
+        // (and young) cells in the page for `!has_marked`.
+        uint16_t has_marked: 1;
+        // Whether any cell was live and young **before sweeping**.
+        // For a normal sweep (quick sweep that is NOT preceded by a
+        // full sweep) this bit is set iff there are young or newly dead
+        // objects in the page and the page needs to be swept.
+        //
+        // For a full sweep, this bit should be ignored.
+        //
+        // For a quick sweep preceded by a full sweep. If this bit is set,
+        // the page needs to be swept. If this bit is not set, there could
+        // still be old dead objects in the page.
+        uint16_t has_young: 1;
     };
     uint16_t nfree; // number of free objects in this page.
                     // invalid if pool that owns this page is allocating objects from this page.

--- a/src/gc.h
+++ b/src/gc.h
@@ -338,6 +338,9 @@ static inline void objprofile_reset(void)
 }
 #endif
 
+// For debugging
+void gc_count_pool(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This implements a slightly modified version of the page metadata part of the bit swapping generational GC (the part currently implemented is actually simpler due to not having to worry about the other gc bit...). @carnaval 
- Delete `gc_bits` and `allocd` in page metadata which are not enough to accurately
  record the necessary information.
- Add `has_marked` and `has_young` to identify free pages and untouched pages.

TODO:
- [x] Implement the fast path for sweep2 (i.e. a quick sweep that is after a full sweep). This requires keeping a counter of live old objects in the page.
- [x] Implement a fallback full collection heuristic based on heap size as suggested by @vtjnash 

Fixes #15543 
Replaces https://github.com/JuliaLang/julia/pull/13993
