### PR TITLE
RFC: Add convert methods from iterables to array/vector/matrix

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2,6 +2,38 @@
 
 ## array.jl: Dense arrays
 
+"""
+    Array{T}(dims)
+    Vector{T}(m)
+    Matrix{T}(m, n)
+
+`Array{T}(dims)` constructs an uninitialized dense array with element type `T`. `dims` may
+be a tuple or a series of integer arguments, each giving the size of the corresponding
+dimension. `Vector{T}(m)` and `Matrix{T}(m, n)` are aliases to create one- and two-
+dimensional arrays.
+
+The syntax `Array(T, dims)` is also available, but deprecated.
+
+
+    Array{[T],[N]}(itr)
+    Vector{[T]}(itr)
+    Matrix{[T]}(itr)
+
+Return an array of all elements in collection `itr`.
+
+`Array(itr)` creates an array of the same element type and size as `itr`, while
+`Array{T}(itr)` and `Array{T,N}(itr)` allow specifying the element type and
+dimensionality of the result. `Vector{T}(itr)` and `Matrix{T}(itr)` are aliases
+to create one- and two-dimensional arrays.
+
+`Array{T,1}(itr)` and `Vector{T}(itr)` convert multidimensional collections
+to vectors using the column-major convention. On the other hand, `Array{T,N}(itr)`
+and `Matrix{T}(itr)` only accept collections of the same rank (i.e. `N` for general
+array and `2` for matrix): use `squeeze` or `reshape` on the result to add or remove
+dimensions.
+"""
+Array
+
 typealias Vector{T} Array{T,1}
 typealias Matrix{T} Array{T,2}
 typealias VecOrMat{T} Union{Vector{T}, Matrix{T}}
@@ -194,13 +226,37 @@ end
 
 ## Conversions ##
 
-convert{T,n}(::Type{Array{T}}, x::Array{T,n}) = x
-convert{T,n}(::Type{Array{T,n}}, x::Array{T,n}) = x
+convert{T,N}(::Type{Array{T}}, x::Array{T,N}) = x
+convert{T,N}(::Type{Array{T,N}}, x::Array{T,N}) = x
+# Defined to prevent ambiguities
+convert{T}(::Type{Vector{T}}, x::Vector{T}) = x
+convert{T}(::Type{Matrix{T}}, x::Matrix{T}) = x
 
-convert{T,n,S}(::Type{Array{T}}, x::AbstractArray{S, n}) = convert(Array{T, n}, x)
-convert{T,n,S}(::Type{Array{T,n}}, x::AbstractArray{S,n}) = copy!(Array{T}(size(x)), x)
+convert{T,N,S}(::Type{Array{T}}, x::AbstractArray{S, N}) = convert(Array{T, N}, x)
+convert{T,N,S}(::Type{Array{T,N}}, x::AbstractArray{S,N}) = copy!(Array{T}(size(x)), x)
 
-promote_rule{T,n,S}(::Type{Array{T,n}}, ::Type{Array{S,n}}) = Array{promote_type(T,S),n}
+convert{S}(::Type{Vector}, x::AbstractArray{S,1}) = convert(Vector{S}, x)
+convert{S}(::Type{Matrix}, x::AbstractArray{S,2}) = convert(Matrix{S}, x)
+
+function _check_itr_dim(itr, N)
+    if !isa(iteratorsize(itr), HasShape)
+        throw(DimensionMismatch("cannot convert iterator of type $(typeof(itr)) with unknown size to an Array{T, $N}"))
+    elseif ndims(itr) != N
+        throw(DimensionMismatch("cannot convert iterator of type $(typeof(itr)) with size $(size(itr)) to an Array{T, $N}"))
+    end
+end
+
+convert(::Type{Array}, itr::Any) = collect(itr)
+convert{T}(::Type{Array{T}}, itr::Any) = collect(T, itr)
+convert{T,N}(::Type{Array{T,N}}, itr::Any) = (_check_itr_dim(itr, N); collect(T, itr))
+
+convert(::Type{Vector}, itr::Any) = vec(collect(itr))
+convert{T}(::Type{Vector{T}}, itr::Any) = vec(collect(T, itr))
+
+convert(::Type{Matrix}, itr::Any) = (_check_itr_dim(itr, 2); collect(itr))
+convert{T}(::Type{Matrix{T}}, itr::Any) = (_check_itr_dim(itr, 2); collect(T, itr))
+
+promote_rule{T,N,S}(::Type{Array{T,N}}, ::Type{Array{S,N}}) = Array{promote_type(T,S),N}
 
 ## copying iterators to containers
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -473,6 +473,8 @@ end
 
 convert{T,N}(::Type{Array{T}}, B::BitArray{N}) = convert(Array{T,N}, B)
 convert{T,N}(::Type{Array{T,N}}, B::BitArray{N}) = _convert(Array{T,N}, B) # see #15801
+convert{T}(::Type{Vector{T}}, B::BitVector) = _convert(Vector{T}, B) # fix ambiguities
+convert{T}(::Type{Matrix{T}}, B::BitMatrix) = _convert(Matrix{T}, B) # fix ambiguities
 function _convert{T,N}(::Type{Array{T,N}}, B::BitArray{N})
     A = Array{T}(size(B))
     Bc = B.chunks

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -7244,15 +7244,6 @@ for the effects of compilation.
 :@allocated
 
 """
-    Array(dims)
-
-`Array{T}(dims)` constructs an uninitialized dense array with element type `T`. `dims` may
-be a tuple or a series of integer arguments. The syntax `Array(T, dims)` is also available,
-but deprecated.
-"""
-Array
-
-"""
     isreal(x) -> Bool
 
 Test whether `x` or all its elements are numerically equal to some real number.

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -525,3 +525,64 @@ A = TSlowNIndexes(rand(2,2))
 #16381
 @inferred size(rand(3,2,1), 2, 1)
 @inferred size(rand(3,2,1), 2, 1, 3)
+
+# conversion to arrays
+let v = collect(1:15), m = reshape(v, 5, 3),
+    sv = sparse(v), sm = sparse(m),
+    r = 1:15, t = take(1:20, 15),
+    g1 = (i for i in 1:15), g2 = ((j-1)*5+i for i in 1:5, j in 1:3)
+    for x in (v, m, sv, sm, r, t, g1, g2)
+        @test Vector(x) == convert(Vector, x) == v
+        @test Vector{Int}(x) == convert(Vector{Int}, x) == v
+        @test Vector{Float64}(x) == convert(Vector{Float64}, x) == v
+    end
+
+    for x in (v, sv, r, t, g1)
+        @test Array(x) == convert(Array, x) == v
+        @test Array{Int}(x) == convert(Array{Int}, x) == v
+        @test Array{Float64}(x) == convert(Array{Float64}, x) == v
+
+        @test_throws DimensionMismatch Matrix(x)
+        @test_throws DimensionMismatch convert(Matrix, x)
+
+        @test_throws DimensionMismatch Matrix{Int}(x)
+        @test_throws DimensionMismatch convert(Matrix{Int}, x)
+
+        @test_throws DimensionMismatch Matrix{Float64}(x)
+        @test_throws DimensionMismatch convert(Matrix{Float64}, x)
+
+        @test_throws DimensionMismatch Array{Int, 3}(x)
+        @test_throws DimensionMismatch convert(Array{Int, 3}, x)
+
+        @test_throws DimensionMismatch Array{Float64, 3}(x)
+        @test_throws DimensionMismatch convert(Array{Float64, 3}, x)
+    end
+
+    for x in (m, sm, g2)
+        @test Matrix(x) == convert(Matrix, x) == m
+        @test Matrix{Int}(x) == convert(Matrix{Int}, x) == m
+        @test Matrix{Float64}(x) == convert(Matrix{Float64}, x) == m
+
+        @test Array(x) == convert(Array, x) == m
+        @test Array{Int}(x) == convert(Array{Int}, x) == m
+        @test Array{Float64}(x) == convert(Array{Float64}, x) == m
+
+        @test_throws DimensionMismatch Array{Int, 3}(x)
+        @test_throws DimensionMismatch convert(Array{Int, 3}, x)
+
+        @test_throws DimensionMismatch Array{Float64, 3}(x)
+        @test_throws DimensionMismatch convert(Array{Float64, 3}, x)
+    end
+end
+
+@test convert(Array, 1) == ones()
+@test convert(Array{Int}, 1) == ones()
+@test convert(Array{Float64}, 1) == ones()
+@test_throws DimensionMismatch convert(Array{Int,3}, 1)
+@test_throws DimensionMismatch convert(Array{Float64,3}, 1)
+@test convert(Vector, 1) == ones(1)
+@test convert(Vector{Int}, 1) == ones(1)
+@test convert(Vector{Float64}, 1) == ones(1)
+@test_throws DimensionMismatch convert(Matrix, 1)
+@test_throws DimensionMismatch convert(Matrix{Int}, 1)
+@test_throws DimensionMismatch convert(Matrix{Float64}, 1)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -100,7 +100,7 @@ r = reshape(s, (length(s),))
 @test parentindexes(r) == (1:1, 1:3)
 @test reshape(r, (3,)) === r
 @test convert(Array{Int,1}, r) == [2,3,4]
-@test_throws MethodError convert(Array{Int,2}, r)
+@test_throws DimensionMismatch convert(Array{Int,2}, r)
 @test convert(Array{Int}, r) == [2,3,4]
 @test Base.unsafe_convert(Ptr{Int}, r) == Base.unsafe_convert(Ptr{Int}, s)
 
@@ -115,7 +115,7 @@ r = reshape(s, length(s))
 @test parentindexes(r) == (1:1, 1:3)
 @test reshape(r, (3,)) === r
 @test convert(Array{Int,1}, r) == [2,3,5]
-@test_throws MethodError convert(Array{Int,2}, r)
+@test_throws DimensionMismatch convert(Array{Int,2}, r)
 @test convert(Array{Int}, r) == [2,3,5]
 @test_throws ErrorException Base.unsafe_convert(Ptr{Int}, r)
 r[2] = -1

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -151,7 +151,7 @@ end
 let
     d = Dict{String, Vector{Int}}()
     d["a"] = [1, 2]
-    @test_throws MethodError d["b"] = 1
+    @test_throws MethodError d["b"] = :a
     @test isa(repr(d), AbstractString)  # check that printable without error
 end
 


### PR DESCRIPTION
These allow using `Vector(itr)` or `Array(itr)` as a replacement for
`collect()`. Though two significant exceptions only work with the `convert()`
syntax: integers and tuples, for which special constructors already exist
to create uninitialized arrays.

---

This is a first step towards https://github.com/JuliaLang/julia/issues/16029. I think this PR makes sense on its own, despite from the obvious issue regarding integers and tuples, which makes deprecating `collect` hard at this point.

Apart from this, I'd like to hear your opinions about what to do in case of dimension mismatch: should we allow converting between collections of different number of dimensions? For now, `Vector(itr)` calls `vec` using the column-major convention. But for higher rank (i.e. `Array{T, N}` when `N>2` is specified), an error is raised if the number of dimensions do not match. I think a reasonable behavior would be to drop trailing singleton dimensions (`squeeze`) or add missing dimensions at the end (no function for this?). Does that make sense to you?

A notable special case of this are scalars: ATM, the `convert(Array, 1)` gives an `Array{Int,0}`, and `convert(Vector, 1)` gives a `Vector{Int}`. For higher rank, an error is printed, in line with the previous point.
