### PR TITLE
Support vector type in AArch64 C abi

### DIFF
--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -564,7 +564,8 @@ In the future, some of these restrictions may be reduced or eliminated.
 SIMD Values
 ~~~~~~~~~~~
 
-Note: This feature is currently implemented on 64-bit x86 platforms only.
+Note: This feature is currently implemented on 64-bit x86
+and AArch64 platforms only.
 
 If a C/C++ routine has an argument or return value that is a native
 SIMD type, the corresponding Julia type is a homogeneous tuple

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -843,7 +843,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields, int8_t
 // For sake of Ahead-Of-Time (AOT) compilation, this routine has to work
 // without LLVM being available.
 unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *t) {
-    if (!is_vecelement_type(t))
+    if (!jl_is_vecelement_type(t))
         return 0;
     // LLVM 3.7 and 3.8 either crash or generate wrong code for many
     // SIMD vector sizes N. It seems the rule is that N can have at
@@ -859,7 +859,7 @@ unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *t) {
         return 0;               // nfields has more than two 1s
     assert(jl_datatype_nfields(t)==1);
     jl_value_t *ty = jl_field_type(t, 0);
-    if( !jl_is_bitstype(ty) )
+    if (!jl_is_bitstype(ty))
         // LLVM requires that a vector element be a primitive type.
         // LLVM allows pointer types as vector elements, but until a
         // motivating use case comes up for Julia, we reject pointers.

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -449,4 +449,30 @@ JL_DLLEXPORT struct_aa64_2 test_aa64_fp16_2(int v1, float v2,
     return x;
 }
 
+#include <arm_neon.h>
+
+JL_DLLEXPORT int64x2_t test_aa64_vec_1(int32x2_t v1, float _v2, int32x2_t v3)
+{
+    int v2 = (int)_v2;
+    return vmovl_s32(v1 * v2 + v3);
+}
+
+// This is a homogenious short vector aggregate
+typedef struct {
+    int8x8_t v1;
+    float32x2_t v2;
+} struct_aa64_3;
+
+// This is NOT a homogenious short vector aggregate
+typedef struct {
+    float32x2_t v2;
+    int16x8_t v1;
+} struct_aa64_4;
+
+JL_DLLEXPORT struct_aa64_3 test_aa64_vec_2(struct_aa64_3 v1, struct_aa64_4 v2)
+{
+    struct_aa64_3 x = {v1.v1 + vmovn_s16(v2.v1), v1.v2 - v2.v2};
+    return x;
+}
+
 #endif

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -385,7 +385,7 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, bool *isboxed)
                 latypes.push_back(lty);
             }
             if (!isTuple) {
-                if (is_vecelement_type(jt))
+                if (jl_is_vecelement_type(jt))
                     // VecElement type is unwrapped in LLVM
                     jst->struct_decl = latypes[0];
                 else
@@ -1101,7 +1101,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
     }
     else if (strct.ispointer()) { // something stack allocated
         Value *addr;
-        if (is_vecelement_type((jl_value_t*)jt))
+        if (jl_is_vecelement_type((jl_value_t*)jt))
             // VecElement types are unwrapped in LLVM.
             addr = strct.V;
         else
@@ -1678,7 +1678,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             // or instead initialize the stack buffer with stores
             bool init_as_value = false;
             if (lt->isVectorTy() ||
-                is_vecelement_type(ty) ||
+                jl_is_vecelement_type(ty) ||
                 type_is_ghost(lt)) // maybe also check the size ?
                 init_as_value = true;
 
@@ -1714,7 +1714,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                             strct = builder.CreateInsertValue(strct, fval, ArrayRef<unsigned>(&idx,1));
                         else {
                             // Must be a VecElement type, which comes unwrapped in LLVM.
-                            assert(is_vecelement_type(ty));
+                            assert(jl_is_vecelement_type(ty));
                             strct = fval;
                         }
                     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -954,7 +954,7 @@ STATIC_INLINE int jl_is_tuple_type(void *t)
             ((jl_datatype_t*)(t))->name == jl_tuple_typename);
 }
 
-STATIC_INLINE int is_vecelement_type(jl_value_t* t)
+STATIC_INLINE int jl_is_vecelement_type(jl_value_t* t)
 {
     return (jl_is_datatype(t) &&
             ((jl_datatype_t*)(t))->name == jl_vecelement_typename);

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -531,7 +531,16 @@ typealias VecReg{N,T} NTuple{N,VecElement{T}}
 typealias V4xF32 VecReg{4,Float32}
 typealias V4xI32 VecReg{4,Int32}
 
-if Sys.ARCH==:x86_64
+immutable Struct_AA64_1
+    v1::Int32
+    v2::Int128
+end
+immutable Struct_AA64_2
+    v1::Float16
+    v2::Float64
+end
+
+if Sys.ARCH === :x86_64
 
     function test_sse(a1::V4xF32,a2::V4xF32,a3::V4xF32,a4::V4xF32)
         ccall((:test_m128, libccalltest), V4xF32, (V4xF32,V4xF32,V4xF32,V4xF32), a1, a2, a3, a4)
@@ -555,5 +564,30 @@ if Sys.ARCH==:x86_64
 
         # cfunction round-trip
         @test rt_sse(a1,a2,a3,a4) == r
+    end
+elseif Sys.ARCH === :aarch64
+    for v1 in 1:99:1000, v2 in -100:-1999:-20000
+        @test ccall((:test_aa64_i128_1, libccalltest), Int128,
+                    (Int64, Int128), v1, v2) == v1 * 2 - v2
+    end
+    for v1 in 1:4, v2 in -4:-1, v3_1 in 3:5, v3_2 in 7:9
+        res = ccall((:test_aa64_i128_2, libccalltest), Struct_AA64_1,
+                    (Int64, Int128, Struct_AA64_1),
+                    v1, v2, Struct_AA64_1(v3_1, v3_2))
+        expected = Struct_AA64_1(v1 ÷ 2 + 1 - v3_1, v2 * 2 - 1 - v3_2)
+        @test res === expected
+    end
+    for v1 in 1:4, v2 in -4:-1, v3 in 3:5, v4 in -(1:3)
+        res = ccall((:test_aa64_fp16_1, libccalltest), Float16,
+                    (Cint, Float32, Float64, Float16),
+                    v1, v2, v3, v4)
+        expected = Float16(v1 + v2 * 2 + v3 * 3 + v4 * 4)
+        @test res === expected
+
+        res = ccall((:test_aa64_fp16_2, libccalltest), Struct_AA64_2,
+                    (Cint, Float32, Float64, Float16),
+                    v1, v2, v3, v4)
+        expected = Struct_AA64_2(v4 / 2 + 1, v1 * 2 + v2 * 4 - v3)
+        @test res === expected
     end
 end


### PR DESCRIPTION
And add more tests about aarch64 specific features (`__fp16`, `__int128`, homogeneous short vector aggregate).
