### PR TITLE
GC clean up

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -540,9 +540,9 @@ void gc_count_pool(void)
     memset(&poolobj_sizes, 0, sizeof(poolobj_sizes));
     empty_pages = 0;
     for (int i = 0; i < REGION_COUNT; i++) {
-        if (regions[i].pages) {
-            gc_count_pool_region(&regions[i]);
-        }
+        if (!regions[i].pages)
+            break;
+        gc_count_pool_region(&regions[i]);
     }
     jl_safe_printf("****** Pool stat: ******\n");
     for (int i = 0;i < 4;i++)

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -474,7 +474,7 @@ void gc_debug_init(void)
     gc_stack_lo = (char*)gc_get_stack_ptr();
     char *env = getenv("JULIA_GC_NO_GENERATIONAL");
     if (env && strcmp(env, "0") != 0)
-        jl_gc_debug_env.sweep_mask = GC_MARKED;
+        jl_gc_debug_env.always_full = 1;
     env = getenv("JULIA_GC_WAIT_FOR_DEBUGGER");
     jl_gc_debug_env.wait_for_debugger = env && strcmp(env, "0") != 0;
     gc_debug_alloc_init(&jl_gc_debug_env.pool, "POOL");

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -152,9 +152,7 @@ NOINLINE void *jl_gc_alloc_page(void)
     VirtualAlloc(ptr, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
 #endif
     current_pg_count++;
-#ifdef GC_FINAL_STATS
-    max_pg_count = max_pg_count < current_pg_count ? current_pg_count : max_pg_count;
-#endif
+    gc_final_count_page(current_pg_count);
     JL_UNLOCK_NOGC(&pagealloc_lock);
     return ptr;
 }

--- a/src/gc.h
+++ b/src/gc.h
@@ -199,10 +199,7 @@ extern bigval_t *big_objects_marked;
 extern arraylist_t finalizer_list;
 extern arraylist_t finalizer_list_marked;
 extern arraylist_t to_finalize;
-
-// Counters
-// GC_FINAL_STATS only
-extern size_t max_pg_count;
+extern int64_t lazy_freed_pages;
 
 #define bigval_header(data) container_of((data), bigval_t, header)
 
@@ -269,6 +266,66 @@ NOINLINE void *jl_gc_alloc_page(void);
 void jl_gc_free_page(void *p);
 
 // GC debug
+
+#if defined(GC_TIME) || defined(GC_FINAL_STATS)
+void gc_settime_premark_end(void);
+void gc_settime_postmark_end(void);
+#else
+#define gc_settime_premark_end()
+#define gc_settime_postmark_end()
+#endif
+
+#ifdef GC_FINAL_STATS
+void gc_final_count_page(size_t pg_cnt);
+void gc_final_pause_end(int64_t t0, int64_t tend);
+#else
+#define gc_final_count_page(pg_cnt)
+#define gc_final_pause_end(t0, tend)
+#endif
+
+#ifdef GC_TIME
+void gc_time_pool_start(void);
+void gc_time_count_page(int freedall, int pg_skpd);
+void gc_time_pool_end(int sweep_full);
+
+void gc_time_big_start(void);
+void gc_time_count_big(int old_bits, int bits);
+void gc_time_big_end(void);
+
+void gc_time_mallocd_array_start(void);
+void gc_time_count_mallocd_array(int bits);
+void gc_time_mallocd_array_end(void);
+
+void gc_time_mark_pause(int64_t t0, int64_t scanned_bytes,
+                        int64_t perm_scanned_bytes);
+void gc_time_sweep_pause(uint64_t gc_end_t, int64_t actual_allocd,
+                         int64_t live_bytes, int64_t estimate_freed,
+                         int sweep_full);
+#else
+#define gc_time_pool_start()
+STATIC_INLINE void gc_time_count_page(int freedall, int pg_skpd)
+{
+    (void)freedall;
+    (void)pg_skpd;
+}
+#define gc_time_pool_end(sweep_full)
+#define gc_time_big_start()
+STATIC_INLINE void gc_time_count_big(int old_bits, int bits)
+{
+    (void)old_bits;
+    (void)bits;
+}
+#define gc_time_big_end()
+#define gc_time_mallocd_array_start()
+STATIC_INLINE void gc_time_count_mallocd_array(int bits)
+{
+    (void)bits;
+}
+#define gc_time_mallocd_array_end()
+#define gc_time_mark_pause(t0, scanned_bytes, perm_scanned_bytes)
+#define gc_time_sweep_pause(gc_end_t, actual_allocd, live_bytes,        \
+                            estimate_freed, sweep_full)
+#endif
 
 #ifdef GC_VERIFY
 extern jl_value_t *lostval;
@@ -352,6 +409,14 @@ static inline void objprofile_printall(void)
 static inline void objprofile_reset(void)
 {
 }
+#endif
+
+#ifdef MEMPROFILE
+static void gc_stats_all_pool(void);
+static void gc_stats_big_obj(void);
+#else
+#define gc_stats_all_pool()
+#define gc_stats_big_obj()
 #endif
 
 // For debugging

--- a/src/gc.h
+++ b/src/gc.h
@@ -56,7 +56,7 @@ typedef struct {
 } jl_alloc_num_t;
 
 typedef struct {
-    int sweep_mask;
+    int always_full;
     int wait_for_debugger;
     jl_alloc_num_t pool;
     jl_alloc_num_t other;
@@ -312,13 +312,13 @@ extern int gc_verifying;
 
 #ifdef GC_DEBUG_ENV
 JL_DLLEXPORT extern jl_gc_debug_env_t jl_gc_debug_env;
-#define gc_quick_sweep_mask jl_gc_debug_env.sweep_mask
+#define gc_sweep_always_full jl_gc_debug_env.always_full
 int gc_debug_check_other(void);
 int gc_debug_check_pool(void);
 void gc_debug_print(void);
 void gc_scrub(char *stack_hi);
 #else
-#define gc_quick_sweep_mask GC_MARKED_NOESC
+#define gc_sweep_always_full 0
 static inline int gc_debug_check_other(void)
 {
     return 0;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -128,11 +128,7 @@ STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr) // parent isa jl_val
 
 void gc_debug_print_status(void);
 void gc_debug_critical_error(void);
-#if defined(GC_FINAL_STATS)
 void jl_print_gc_stats(JL_STREAM *s);
-#else
-#define jl_print_gc_stats(s) ((void)s)
-#endif
 int jl_assign_type_uid(void);
 jl_value_t *jl_cache_type_(jl_datatype_t *type);
 int  jl_get_t_uid_ctr(void);

--- a/src/options.h
+++ b/src/options.h
@@ -56,8 +56,8 @@
 // MEMPROFILE prints pool summary statistics after every GC
 //#define MEMPROFILE
 
-// GCTIME prints time taken by each phase of GC
-//#define GC_TIME
+// GC_TIME prints time taken by each phase of GC
+// #define GC_TIME
 
 // OBJPROFILE counts objects by type
 // #define OBJPROFILE


### PR DESCRIPTION
This is on top of https://github.com/JuliaLang/julia/pull/16632 to avoid massive merge conflict...

Main changes are,
- Delete left over logic from the incremental GC.
  
  We are making a lot of assumptions about the marking bit and the deleted part should be the easiest part to fix if we want the incremental behavior back at some point...
- Replace `sweep_mask` with `sweep_full`.
  
  The mask is effectively a bool for the two types of sweep we have.
- Move more debugging code into `gc-debug.c`
  
  This also remove some unnecessary counter increments for the build without these debug options enabled. (the release build might be able to optimize those out automatically).
