### PR TITLE
Undeprecate {os}_only macros

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -486,31 +486,16 @@ macro linux(qm,ex)
     depwarn("`@linux` is deprecated, use `@static is_linux()` instead", Symbol("@linux"))
     return @static is_linux() ? esc(ex.args[1]) : esc(ex.args[2])
 end
-macro windows_only(ex)
-    depwarn("`@windows_only` is deprecated, use `@static if is_windows()` instead", Symbol("@windows_only"))
-    return @static if is_windows() esc(ex) end
-end
-macro unix_only(ex)
-    depwarn("`@unix_only` is deprecated, use `@static if is_unix()` instead", Symbol("@unix_only"))
-    return @static if is_unix() esc(ex) end
-end
 macro osx_only(ex)
-    depwarn("`@osx_only` is deprecated, use `@static if is_apple()` instead", Symbol("@osx_only"))
+    depwarn("`@osx_only` is deprecated, use `@apple_only` instead", Symbol("@osx_only"))
     return @static if is_apple() esc(ex) end
-end
-macro linux_only(ex)
-    depwarn("`@linux_only` is deprecated, use `@static if is_linux()` instead", Symbol("@linux_only"))
-    return @static if is_linux() esc(ex) end
 end
 export
     @windows,
     @unix,
     @osx,
     @linux,
-    @windows_only,
-    @unix_only,
-    @osx_only,
-    @linux_only
+    @osx_only
 
 export OS_NAME
 const OS_NAME =

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1372,6 +1372,11 @@ export
     is_apple,
     is_bsd,
     is_unix,
+    @windows_only,
+    @linux_only,
+    @apple_only,
+    @bsd_only,
+    @unix_only,
 
     # tasks
     @schedule,

--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -81,3 +81,48 @@ let KERNEL = ccall(:jl_get_UNAME, Any, ())
         @eval $f() = $(getfield(current_module(),f)(KERNEL))
     end
 end
+
+"""
+    @windows_only
+
+Convenenience macro for executing code only on Windows
+"""
+macro windows_only(ex)
+    return @static if is_windows() esc(ex) end
+end
+
+"""
+    @unix_only
+
+Convenenience macro for executing code only on unix-based operating systems
+"""
+macro unix_only(ex)
+    return @static if is_unix() esc(ex) end
+end
+
+"""
+    @apple_only
+
+Convenenience macro for executing code only on OSX
+"""
+macro apple_only(ex)
+    return @static if is_apple() esc(ex) end
+end
+
+"""
+    @linux_only
+
+Convenenience macro for executing code only on linux-based operating systems
+"""
+macro linux_only(ex)
+    return @static if is_linux() esc(ex) end
+end
+
+"""
+    @bsd_only
+
+Convenenience macro for executing code only on bsd-based operating systems
+"""
+macro bsd_only(ex)
+    return @static if is_bsd() esc(ex) end
+end


### PR DESCRIPTION
I kind of feel that #16219 threw the `os_only` baby out with the `os` bathwater, so-to-speak.  I think it's great having a macro which statically evaluates items at top scope, but feel that the readability of code using the `@{os}_only` macros went down dramatically when they were deprecated.  So I'd like to reintroduce them based on the `@static` macro, with a few small changes:
- `@osx_only` is now `@apple_only`, to match the change in #16219
- Added `@bsd_only`

Thoughts/opinions?
