### PR TITLE
minor reorganization of pmap code 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,9 +69,8 @@ Breaking changes
     in a `MethodError`. ([#6190])
 
   * `pmap` keyword arguments `err_retry=true` and `err_stop=false` are deprecated.
-    `pmap` no longer retries or returns `Exception` objects in the result collection.
-    `pmap(retry(f), c)` or `pmap(@catch(f), c)` can be used instead.
-    ([#15409](https://github.com/JuliaLang/julia/pull/15409#discussion_r57494701)).
+    Action to be taken on errors can be specified via the `on_error` keyword argument.
+    Retry is specified via `retry_n`, `retry_on` and `retry_max_delay`.
 
   * `reshape` is now defined to always share data with the original array.
     If a reshaped copy is needed, use `copy(reshape(a))` or `copy!` to a new array of

--- a/base/error.jl
+++ b/base/error.jl
@@ -50,12 +50,13 @@ macro assert(ex, msgs...)
     :($(esc(ex)) ? $(nothing) : throw(Main.Base.AssertionError($msg)))
 end
 
+# NOTE: Please keep the constant values specified below in sync with the doc string
 const DEFAULT_RETRY_N = 1
 const DEFAULT_RETRY_ON = e->true
 const DEFAULT_RETRY_MAX_DELAY = 10.0
 
 """
-    retry(f, [retry_on]; n=DEFAULT_RETRY_N, max_delay=DEFAULT_RETRY_MAX_DELAY) -> Function
+    retry(f, [retry_on]; n=1, max_delay=10.0) -> Function
 
 Returns a lambda that retries function `f` up to `n` times in the
 event of an exception. If `retry_on` is a `Type` then retry only
@@ -83,8 +84,9 @@ function retry(f::Function, retry_on::Function=DEFAULT_RETRY_ON; n=DEFAULT_RETRY
                     rethrow(e)
                 end
             end
-            sleep(delay)
-            delay = min(max_delay, delay * (0.8 + (rand() * 0.4)) * 5)
+            delay = min(max_delay, delay)
+            sleep(delay * (0.8 + (rand() * 0.2)))
+            delay = delay * 5
         end
     end
 end

--- a/base/pmap.jl
+++ b/base/pmap.jl
@@ -6,7 +6,7 @@ type BatchProcessingError <: Exception
 end
 
 """
-    pgenerate([::WorkerPool], f, c...) -> (iterator, process_batch_errors)
+    pgenerate([::WorkerPool], f, c...) -> iterator
 
 Apply `f` to each element of `c` in parallel using available workers and tasks.
 
@@ -19,87 +19,16 @@ Note that `f` must be made available to all worker processes; see
 and Loading Packages <man-parallel-computing-code-availability>`)
 for details.
 """
-function pgenerate(p::WorkerPool, f, c; distributed=true, batch_size=1, on_error=nothing,
-                                        retry_n=0,
-                                        retry_max_delay=DEFAULT_RETRY_MAX_DELAY,
-                                        retry_on=DEFAULT_RETRY_ON)
-    # Don't do remote calls if there are no workers.
-    if (length(p) == 0) || (length(p) == 1 && fetch(p.channel) == myid())
-        distributed = false
+function pgenerate(p::WorkerPool, f, c)
+    if length(p) == 0
+        return AsyncGenerator(f, c)
     end
-
-    # Don't do batching if not doing remote calls.
-    if !distributed
-        batch_size = 1
-    end
-
-    # If not batching, do simple remote call.
-    if batch_size == 1
-        if distributed
-            f = remote(p, f)
-        end
-
-        if retry_n > 0
-            f = wrap_retry(f, retry_on, retry_n, retry_max_delay)
-        end
-        if on_error != nothing
-            f = wrap_on_error(f, on_error)
-        end
-        return (AsyncGenerator(f, c), nothing)
-    else
-        batches = batchsplit(c, min_batch_count = length(p) * 3,
-                                max_batch_size = batch_size)
-
-        # During batch processing, We need to ensure that if on_error is set, it is called
-        # for each element in error, and that we return as many elements as the original list.
-        # retry, if set, has to be called element wise and we will do a best-effort
-        # to ensure that we do not call mapped function on the same element more than retry_n.
-        # This guarantee is not possible in case of worker death / network errors, wherein
-        # we will retry the entire batch on a new worker.
-        f = wrap_on_error(f, (x,e)->BatchProcessingError(x,e); capture_data=true)
-        f = wrap_batch(f, p, on_error)
-        return (flatten(AsyncGenerator(f, batches)),
-                (p, f, results)->process_batch_errors!(p, f, results, on_error, retry_on, retry_n, retry_max_delay))
-    end
+    batches = batchsplit(c, min_batch_count = length(p) * 3)
+    return flatten(AsyncGenerator(remote(p, b -> asyncmap(f, b)), batches))
 end
-
-pgenerate(p::WorkerPool, f, c1, c...; kwargs...) = pgenerate(p, a->f(a...), zip(c1, c...); kwargs...)
-
-pgenerate(f, c; kwargs...) = pgenerate(default_worker_pool(), f, c; kwargs...)
-pgenerate(f, c1, c...; kwargs...) = pgenerate(a->f(a...), zip(c1, c...); kwargs...)
-
-function wrap_on_error(f, on_error; capture_data=false)
-    return x -> begin
-        try
-            f(x)
-        catch e
-            if capture_data
-                on_error(x, e)
-            else
-                on_error(e)
-            end
-        end
-    end
-end
-
-wrap_retry(f, retry_on, n, max_delay) = retry(f, retry_on; n=n, max_delay=max_delay)
-
-function wrap_batch(f, p, on_error)
-    f = asyncmap_batch(f)
-    return batch -> begin
-        try
-            remotecall_fetch(f, p, batch)
-        catch e
-            if on_error != nothing
-                return Any[BatchProcessingError(batch[i], e) for i in 1:length(batch)]
-            else
-                rethrow(e)
-            end
-        end
-    end
-end
-
-asyncmap_batch(f) = batch -> asyncmap(f, batch)
+pgenerate(p::WorkerPool, f, c1, c...) = pgenerate(p, a->f(a...), zip(c1, c...))
+pgenerate(f, c) = pgenerate(default_worker_pool(), f, c)
+pgenerate(f, c1, c...) = pgenerate(a->f(a...), zip(c1, c...))
 
 """
     pmap([::WorkerPool], f, c...; distributed=true, batch_size=1, on_error=nothing, retry_n=0, retry_max_delay=DEFAULT_RETRY_MAX_DELAY, retry_on=DEFAULT_RETRY_ON) -> collection
@@ -141,14 +70,92 @@ The following are equivalent:
 * `pmap(f, c; retry_n=1)` and `asyncmap(retry(remote(f)),c)`
 * `pmap(f, c; retry_n=1, on_error=e->e)` and `asyncmap(x->try retry(remote(f))(x) catch e; e end, c)`
 """
-function pmap(p::WorkerPool, f, c...; kwargs...)
-    results_iter, process_errors! = pgenerate(p, f, c...; kwargs...)
-    results = collect(results_iter)
-    if isa(process_errors!, Function)
-        process_errors!(p, f, results)
+function pmap(p::WorkerPool, f, c;  distributed=true, batch_size=1, on_error=nothing,
+                                    retry_n=0,
+                                    retry_max_delay=DEFAULT_RETRY_MAX_DELAY,
+                                    retry_on=DEFAULT_RETRY_ON)
+    f_orig = f
+    # Don't do remote calls if there are no workers.
+    if (length(p) == 0) || (length(p) == 1 && fetch(p.channel) == myid())
+        distributed = false
     end
-    results
+
+    # Don't do batching if not doing remote calls.
+    if !distributed
+        batch_size = 1
+    end
+
+    # If not batching, do simple remote call.
+    if batch_size == 1
+        if distributed
+            f = remote(p, f)
+        end
+
+        if retry_n > 0
+            f = wrap_retry(f, retry_on, retry_n, retry_max_delay)
+        end
+        if on_error != nothing
+            f = wrap_on_error(f, on_error)
+        end
+        return collect(AsyncGenerator(f, c))
+    else
+        batches = batchsplit(c, min_batch_count = length(p) * 3,
+                                max_batch_size = batch_size)
+
+        # During batch processing, We need to ensure that if on_error is set, it is called
+        # for each element in error, and that we return as many elements as the original list.
+        # retry, if set, has to be called element wise and we will do a best-effort
+        # to ensure that we do not call mapped function on the same element more than retry_n.
+        # This guarantee is not possible in case of worker death / network errors, wherein
+        # we will retry the entire batch on a new worker.
+        if (on_error != nothing) || (retry_n > 0)
+            f = wrap_on_error(f, (x,e)->BatchProcessingError(x,e); capture_data=true)
+        end
+        f = wrap_batch(f, p, on_error)
+        results = collect(flatten(AsyncGenerator(f, batches)))
+        if (on_error != nothing) || (retry_n > 0)
+            process_batch_errors!(p, f_orig, results, on_error, retry_on, retry_n, retry_max_delay)
+        end
+        return results
+    end
 end
+
+pmap(p::WorkerPool, f, c1, c...; kwargs...) = pmap(p, a->f(a...), zip(c1, c...); kwargs...)
+pmap(f, c; kwargs...) = pmap(default_worker_pool(), f, c; kwargs...)
+pmap(f, c1, c...; kwargs...) = pmap(a->f(a...), zip(c1, c...); kwargs...)
+
+function wrap_on_error(f, on_error; capture_data=false)
+    return x -> begin
+        try
+            f(x)
+        catch e
+            if capture_data
+                on_error(x, e)
+            else
+                on_error(e)
+            end
+        end
+    end
+end
+
+wrap_retry(f, retry_on, n, max_delay) = retry(f, retry_on; n=n, max_delay=max_delay)
+
+function wrap_batch(f, p, on_error)
+    f = asyncmap_batch(f)
+    return batch -> begin
+        try
+            remotecall_fetch(f, p, batch)
+        catch e
+            if on_error != nothing
+                return Any[BatchProcessingError(batch[i], e) for i in 1:length(batch)]
+            else
+                rethrow(e)
+            end
+        end
+    end
+end
+
+asyncmap_batch(f) = batch -> asyncmap(f, batch)
 
 function process_batch_errors!(p, f, results, on_error, retry_on, retry_n, retry_max_delay)
     # Handle all the ones in error in another pmap, with batch size set to 1

--- a/base/pmap.jl
+++ b/base/pmap.jl
@@ -65,7 +65,7 @@ end
 
 pgenerate(p::WorkerPool, f, c1, c...; kwargs...) = pgenerate(p, a->f(a...), zip(c1, c...); kwargs...)
 
-pgenerate(f, c; kwargs...) = pgenerate(default_worker_pool(), f, c...; kwargs...)
+pgenerate(f, c; kwargs...) = pgenerate(default_worker_pool(), f, c; kwargs...)
 pgenerate(f, c1, c...; kwargs...) = pgenerate(a->f(a...), zip(c1, c...); kwargs...)
 
 function wrap_on_error(f, on_error; capture_data=false)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1210,7 +1210,7 @@ Errors
 
    An error occurred when running a module's ``__init__`` function. The actual error thrown is available in the ``.error`` field.
 
-.. function:: retry(f, [retry_on]; n=DEFAULT_RETRY_N, max_delay=DEFAULT_RETRY_MAX_DELAY) -> Function
+.. function:: retry(f, [retry_on]; n=1, max_delay=10.0) -> Function
 
    .. Docstring generated from Julia source
 


### PR DESCRIPTION
This PR moves out error handling and retry logic from `pgenerate` to `pmap`. `pgenerate` returns an iterator and does not support error handling and retry now. As discussed in https://github.com/JuliaLang/julia/pull/15975 
