### PR TITLE
Escape elementwise operators in :obj: links

### DIFF
--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -294,11 +294,11 @@ work on arrays. For example, ``0 .< A .< 1`` gives a boolean array whose
 entries are true where the corresponding elements of ``A`` are between 0
 and 1.
 
-The operator :obj:`.<` is intended for array objects; the operation
+The operator :obj:`.\< <Base..\<>` is intended for array objects; the operation
 ``A .< B`` is valid only if ``A`` and ``B`` have the same dimensions.  The
 operator returns an array with boolean entries and with the same dimensions
 as ``A`` and ``B``.  Such operators are called *elementwise*; Julia offers a
-suite of elementwise operators: :obj:`.*`, :obj:`.+`, etc.  Some of the elementwise
+suite of elementwise operators: :obj:`.* <Base..*>`, :obj:`.+ <Base..+>`, etc.  Some of the elementwise
 operators can take a scalar operand such as the example ``0 .< A .< 1`` in
 the preceding paragraph.
 This notation means that the scalar operand should be replicated for each entry of

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -147,7 +147,7 @@ noteworthy differences:
   multiplication in Julia, equivalent to R's ``A %*% B``. In R, this same
   notation would perform an element-wise (Hadamard) product. To get the
   element-wise multiplication operation, you need to write ``A .* B`` in Julia.
-- Julia performs matrix transposition using the :obj:`.'` operator and conjugated
+- Julia performs matrix transposition using the :obj:`.' <Base..'>` operator and conjugated
   transposition using the :obj:`'` operator. Julia's ``A.'`` is therefore
   equivalent to R's ``t(A)``.
 - Julia does not require parentheses when writing ``if`` statements or


### PR DESCRIPTION
A dot is significant in Sphinx cross refs, and gets stripped causing #16259. The link target can be explicitly set using the syntax:

```
:role:`title <target>`
```

in which case the dot characters appear to be preserved as the title and links work.
