### PR TITLE
Duplicated definition in julia.h

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -665,8 +665,6 @@ JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
 
 // object accessors -----------------------------------------------------------
 
-#define jl_typeis(v,t) (jl_typeof(v)==(jl_value_t*)(t))
-
 #define jl_svec_len(t)              (((jl_svec_t*)(t))->length)
 #define jl_svec_set_len_unsafe(t,n) (((jl_svec_t*)(t))->length=(n))
 #define jl_svec_data(t) ((jl_value_t**)((char*)(t) + sizeof(jl_svec_t)))


### PR DESCRIPTION
`#define jl_typeis(v,t) (jl_typeof(v)==(jl_value_t*)(t))` occurred twice in `julia.h`. They are in line 92 and line 668.
