### PR TITLE
Keyword display improvements

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -323,10 +323,15 @@ function complete_methods(ex_org::Expr)
     out = String[]
     t_in = Tuple{Core.Typeof(func), args_ex...} # Input types
     na = length(args_ex)+1
-    for method in methods(func)
+    ml = methods(func)
+    kwtype = isdefined(ml.mt, :kwsorter) ? Nullable{DataType}(typeof(ml.mt.kwsorter)) : Nullable{DataType}()
+    io = IOBuffer()
+    for method in ml
         # Check if the method's type signature intersects the input types
-        typeintersect(Tuple{method.sig.parameters[1 : min(na, end)]...}, t_in) != Union{} &&
-            push!(out,string(method))
+        if typeintersect(Tuple{method.sig.parameters[1 : min(na, end)]...}, t_in) != Union{}
+            show(io, method, kwtype=kwtype)
+            push!(out, takebuf_string(io))
+        end
     end
     return out
 end

--- a/base/error.jl
+++ b/base/error.jl
@@ -27,7 +27,7 @@ backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32,), false
 catch_backtrace() = ccall(:jl_get_backtrace, Array{Ptr{Void},1}, ())
 
 ## keyword arg lowering generates calls to this ##
-kwerr(kw) = error("unrecognized keyword argument \"", kw, "\"")
+kwerr(kw, args...) = throw(MethodError(typeof(args[1]).name.mt.kwsorter, (kw,args...)))
 
 ## system error handling ##
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -78,7 +78,13 @@ function kwarg_decl(sig::ANY, kwtype::DataType)
     kwli = ccall(:jl_methtable_lookup, Any, (Any, Any), kwtype.name.mt, sig)
     if kwli !== nothing
         kwli = kwli::Method
-        return filter(x->!('#' in string(x)), kwli.lambda_template.slotnames[kwli.lambda_template.nargs+1:end])
+        kws = filter(x->!('#' in string(x)), kwli.lambda_template.slotnames[kwli.lambda_template.nargs+1:end])
+        # ensure the kwarg... is always printed last. The order of the arguments are not
+        # necessarily the same as defined in the function
+        i = findfirst(x -> endswith(string(x), "..."), kws)
+        i==0 && return kws
+        push!(kws, kws[i])
+        return deleteat!(kws,i)
     end
     return ()
 end

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -493,7 +493,8 @@
                                    ,else)))
                           (if (null? restkw)
                               ;; if no rest kw, give error for unrecognized
-                              `(call (top kwerr) ,elt)
+                              `(call (top kwerr) ,kw ,@(map arg-name pargl),@(if (null? vararg) '()
+                                (list `(... ,(arg-name (car vararg))))))
                               ;; otherwise add to rest keywords
                               `(ccall 'jl_cell_1d_push Void (tuple Any Any)
                                       ,rkw (tuple ,elt

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -397,7 +397,8 @@
                   sparams))
          (keyword-sparam-names
           (map (lambda (s) (if (symbol? s) s (cadr s))) keyword-sparams)))
-    (let ((kw (gensy)) (i (gensy)) (ii (gensy)) (elt (gensy)) (rkw (gensy))
+    (let ((kw (gensy)) (i (gensy)) (ii (gensy)) (elt (gensy))
+          (rkw (if (null? restkw) '() (symbol (string (car restkw) "..."))))
           (mangled (symbol (string "#" (if name (undot-name name) 'call) "#"
                                    (string (current-julia-module-counter)))))
           (flags (map (lambda (x) (gensy)) vals)))

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -9,7 +9,7 @@ kwf1(ones; tens=0, hundreds=0) = ones + 10*tens + 100*hundreds
 @test kwf1(3, tens=7, hundreds=2) == 273
 
 @test_throws MethodError kwf1()             # no method, too few args
-@test_throws ErrorException kwf1(1, z=0)    # unsupported keyword
+@test_throws MethodError kwf1(1, z=0)    # unsupported keyword
 @test_throws MethodError kwf1(1, 2)         # no method, too many positional args
 
 # keyword args plus varargs
@@ -18,7 +18,7 @@ kwf2(x, rest...; y=1) = (x, y, rest)
 @test isequal(kwf2(0,1,2), (0, 1, (1,2)))
 @test isequal(kwf2(0,1,2,y=88), (0, 88, (1,2)))
 @test isequal(kwf2(0,y=88,1,2), (0, 88, (1,2)))
-@test_throws ErrorException kwf2(0, z=1)
+@test_throws MethodError kwf2(0, z=1)
 @test_throws MethodError kwf2(y=1)
 
 # keyword arg with declared type
@@ -191,7 +191,7 @@ let f = (x;a=1,b=2)->(x, a, b)
     @test f(0) === (0, 1, 2)
     @test f(1,a=10,b=20) === (1,10,20)
     @test f(0,b=88) === (0, 1, 88)
-    @test_throws ErrorException f(0,z=1)
+    @test_throws MethodError f(0,z=1)
 end
 @test ((a=2)->10a)(3) == 30
 @test ((a=2)->10a)() == 20

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -43,6 +43,8 @@ module CompletionFoo
     const a=x->x
     test6()=[a, a]
 
+    kwtest(; x=1, y=2, w...) = pass
+
     array = [1, 1]
     varfloat = 0.1
 
@@ -324,6 +326,12 @@ c, r, res = test_complete(s)
 @test !res
 @test length(c) == 2
 #################################################################
+
+s = "CompletionFoo.kwtest( "
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 1
+@test contains(c[1], "x, y, w...")
 
 # Test of inference based getfield completion
 s = "\"\"."

--- a/test/show.jl
+++ b/test/show.jl
@@ -325,10 +325,14 @@ end
 
 f5971(x, y...; z=1, w...) = nothing
 let repr = sprint(io -> show(io,"text/plain", methods(f5971)))
-    @test contains(repr, "f5971(x, y...; z)")
+    @test contains(repr, "f5971(x, y...; z, w...)")
 end
 let repr = sprint(io -> show(io,"text/html", methods(f5971)))
-    @test contains(repr, "f5971(x, y...; <i>z</i>)")
+    @test contains(repr, "f5971(x, y...; <i>z, w...</i>)")
+end
+f16580(x, y...; z=1, w=y+x, q...) = nothing
+let repr = sprint(io -> show(io,"text/html", methods(f16580)))
+    @test contains(repr, "f16580(x, y...; <i>z, w, q...</i>)")
 end
 
 if isempty(Base.GIT_VERSION_INFO.commit)


### PR DESCRIPTION
This PR implements several improvement to how keywords is presented to the user. The additions in each commit is listed bellow
- 1. adds display of variable keyword arguments such as `kwargs...`. This change causes the vararg keywords to be displayed in method list and other places.
- 2. adds the display of keywords to method completion 

```
julia> split(<tab>
split{T<:SubString{T<:AbstractString}}(str::T, splitter; limit, keep) at strings/util.jl:126
split(str::AbstractString) at strings/util.jl:151
split{T<:AbstractString}(str::T, splitter; limit, keep) at strings/util.jl:127
```
- 3. Make the generic error thrown by `kwerr` throw a MethodError. This allows for display of other method candidates, handled by the fourth commit.
- 4. Add so method errors caused by keywords is displayed as the original method, with a text stating if the keyword didn't match. This fixes #15639

Example from #15639:

```
type FooCon
    x
end
type BarCon
    x
end
function addConstraint(c::FooCon)
    println("addCon(FooCon)")
end
function addConstraint(c::BarCon; uncset=nothing)
    println("addCon(BarCon,$uncset)")
    # Oh, BarCon was suppossed to be a FooCon, let me erroneously pass
    # on this kwarg which isn't supported
    addConstraint(FooCon(c.x), uncset=uncset)
end
julia> addConstraint(BarCon(1))
addCon(BarCon,nothing)
ERROR: MethodError: no method matching addConstraint(::FooCon; uncset=nothing)
Closest candidates are:
  addConstraint(::FooCon) got an unrecognized keyword argument "uncset"
  addConstraint(::BarCon; uncset)
 in #addConstraint#1(::Void, ::Function, ::BarCon) at ./REPL[4]:5
 in addConstraint(::BarCon) at ./REPL[4]:2
 in eval(::Module, ::Any) at ./boot.jl:225
 in macro expansion at ./REPL.jl:92 [inlined]
 in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
```

Note to reviewer please check if the changes in `src/julia-syntax.scm` is correct as this is my first encounter with lisp.
