### PR TITLE
Fix compilation on LLVM39

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -555,10 +555,12 @@ public:
         return NewF;
     }
 
-#ifdef LLVM38
-    virtual Value *materializeDeclFor(Value *V)
+#if defined(LLVM39)
+    virtual Value *materialize(Value *V) override
+#elif defined(LLVM38)
+    virtual Value *materializeDeclFor(Value *V) override
 #else
-    virtual Value *materializeValueFor (Value *V)
+    virtual Value *materializeValueFor (Value *V) override
 #endif
     {
         Function *F = dyn_cast<Function>(V);


### PR DESCRIPTION
Function renaming again. Add `override` to make sure any future changes are more likely to be caught.
