### PR TITLE
Give Flatten-iterator HasLength() in some cases

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -478,8 +478,13 @@ Put differently, the elements of the argument iterator are concatenated. Example
 flatten(itr) = Flatten(itr)
 
 eltype{I}(::Type{Flatten{I}}) = eltype(eltype(I))
-iteratorsize{I}(::Type{Flatten{I}}) = SizeUnknown()
 iteratoreltype{I}(::Type{Flatten{I}}) = iteratoreltype(eltype(I))
+
+flatten_iteratorsize{T<:Tuple}(::Union{HasShape, HasLength}, b::Type{T}) = HasLength()
+flatten_iteratorsize(a, b) = SizeUnknown()
+flatten_length{T<:Tuple}(f, ::Type{T}) = isleaftype(T) ? nfields(T)*length(f.it) : throw(ArgumentError("Cannot compute length of a tuple-type which is not a leaf-type"))
+length{I}(f::Flatten{I}) = flatten_length(f, eltype(I))
+iteratorsize{I}(::Type{Flatten{I}}) = isleaftype(eltype(I)) ? flatten_iteratorsize(iteratorsize(I), eltype(I)) : SizeUnknown()# eltype is always defined
 
 function start(f::Flatten)
     local inner, s2

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -371,8 +371,11 @@ import Base.flatten
 @test collect(flatten(Any[flatten(Any[1:2, 4:5]), flatten(Any[6:7, 8:9])])) == Any[1,2,4,5,6,7,8,9]
 @test collect(flatten(Any[flatten(Any[1:2, 6:5]), flatten(Any[6:7, 8:9])])) == Any[1,2,6,7,8,9]
 @test collect(flatten(Any[2:1])) == Any[]
+@test length(flatten(zip(1:3,4:6))) == 6
+
 @test eltype(flatten(UnitRange{Int8}[1:2, 3:4])) == Int8
 @test_throws ArgumentError collect(flatten(Any[]))
+@test_throws ArgumentError length(flatten(NTuple[(1,),()]))
 
 # foreach
 let


### PR DESCRIPTION
It is worthwhile to give some flattened iterators with elements of known type the trait `HasLength`.
This PR does this for iterators with elements of type tuple.

The length can be easily computed from the length of the iterator and the nfields of the tuple-type. This makes it for example possible to use a flattened zip as input of IteratorND and a naive `vcat` for iterators becomes simply

```
function itervcat(a...)
    z = zip(a...)
    Base.IteratorND(Base.flatten(z), (length(a), size(z)...))
end
```

This PR only gives the HasLength trait to Base.Flatten. The function `itervcat` just  illustrates the usefulness.

The check for `isleaftype` gets optimized away:

```
@code_typed Base.iteratorsize(Base.flatten(zip(1:3)))
1-element Array{Any,1}:
 LambdaInfo for iteratorsize
:(begin  # generator.jl, line 34:
        # meta: location iterator.jl iteratorsize # iterator.jl, line 488:
        $(QuoteNode(true))
        # meta: pop location
        return $(Expr(:new, :(Base.HasLength)))
    end::Base.HasLength)
```
