### PR TITLE
cleanup redundant docstring for nextprod

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -154,12 +154,6 @@ end
 
 Next integer not less than `n` that can be written as ``\\prod k_i^{p_i}`` for integers
 ``p_1``, ``p_2``, etc.
-
-For a list of integers i1, i2, i3, find the smallest
-
-    i1^n1 * i2^n2 * i3^n3 >= x
-
-for integer n1, n2, n3
 """
 function nextprod(a::Vector{Int}, x)
     if x > typemax(Int)

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1421,14 +1421,6 @@ Mathematical Functions
 
    Next integer not less than ``n`` that can be written as :math:`\prod k_i^{p_i}` for integers :math:`p_1`\ , :math:`p_2`\ , etc.
 
-   For a list of integers i1, i2, i3, find the smallest
-
-   .. code-block:: julia
-
-       i1^n1 * i2^n2 * i3^n3 >= x
-
-   for integer n1, n2, n3
-
 .. function:: invmod(x,m)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
Was caused by the merge of docstring and comment in 93911dd5.
