### PR TITLE
Escaped double-quote which was messing up syntax highlighting

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3637,7 +3637,7 @@ the file is large, and is only read once and not written to.
 If `ignore_invalid_chars` is `true`, bytes in `source` with invalid character encoding will
 be ignored. Otherwise an error is thrown indicating the offending character position.
 
-If `quotes` is `true`, column enclosed within double-quote (") characters are allowed to
+If `quotes` is `true`, column enclosed within double-quote (\") characters are allowed to
 contain new lines and column delimiters. Double-quote characters within a quoted field must
 be escaped with another double-quote.  Specifying `dims` as a tuple of the expected rows and
 columns (including header, if any) may speed up reading of large files.  If `comments` is


### PR DESCRIPTION
Escaping a double-quote isn't necessary in a triple-quoted string but it was causing my syntax highlighting to break (sublime text).
