### PR TITLE
Make Pkg.update() return nothing

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -423,6 +423,7 @@ function update(branch::AbstractString)
 
     # Print deferred errors
     length(deferred_errors) > 0 && throw(PkgError("Update finished with errors.", deferred_errors))
+    nothing
 end
 
 


### PR DESCRIPTION
When `Pkg.update()` finishes with no error, `false` is returned which can confuse users.

Current state is:

```
INFO: Updating OpenGene master... b28b0d93 → c3139d86
INFO: Computing changes...
INFO: Removing BufferedStreams v0.1.1
INFO: Removing Libz v0.1.1
false

julia> 
```
