### PR TITLE
RFC: Function argument to `mean`, akin to `sum`

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -9,7 +9,7 @@ function mean(f::Callable, iterable)
     end
     count = 1
     value, state = next(iterable, state)
-    total = f(value)
+    total = f(value) + zero(f(value))
     while !done(iterable, state)
         value, state = next(iterable, state)
         total += f(value)

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -2,7 +2,7 @@
 
 ##### mean #####
 
-function mean(iterable)
+function mean(f::Callable, iterable)
     state = start(iterable)
     if done(iterable, state)
         throw(ArgumentError("mean of empty collection undefined: $(repr(iterable))"))
@@ -11,11 +11,13 @@ function mean(iterable)
     total, state = next(iterable, state)
     while !done(iterable, state)
         value, state = next(iterable, state)
-        total += value
+        total += f(value)
         count += 1
     end
     return total/count
 end
+mean(iterable) = mean(identity, iterable)
+mean(f::Callable, A::AbstractArray) = sum(f, A) / length(A)
 mean(A::AbstractArray) = sum(A) / length(A)
 
 function mean!{T}(R::AbstractArray{T}, A::AbstractArray)

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -9,7 +9,8 @@ function mean(f::Callable, iterable)
     end
     count = 1
     value, state = next(iterable, state)
-    total = f(value) + zero(f(value))
+    f_value = f(value)
+    total = f_value + zero(f_value)
     while !done(iterable, state)
         value, state = next(iterable, state)
         total += f(value)

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -8,7 +8,8 @@ function mean(f::Callable, iterable)
         throw(ArgumentError("mean of empty collection undefined: $(repr(iterable))"))
     end
     count = 1
-    total, state = next(iterable, state)
+    value, state = next(iterable, state)
+    total = f(value)
     while !done(iterable, state)
         value, state = next(iterable, state)
         total += f(value)

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -2,6 +2,11 @@
 
 ##### mean #####
 
+"""
+    mean(f::Function, v)
+
+Apply the function `f` to each element of `v` and take the mean.
+"""
 function mean(f::Callable, iterable)
     state = start(iterable)
     if done(iterable, state)

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1680,7 +1680,7 @@ Statistics
 
    .. Docstring generated from Julia source
 
-   Apply the function `f` to each element of `v` and take the mean.
+   Apply the function ``f`` to each element of ``v`` and take the mean.
 
 .. function:: mean!(r, v)
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1676,6 +1676,12 @@ Statistics
 
    Compute the mean of whole array ``v``\ , or optionally along the dimensions in ``region``\ . Note: Julia does not ignore ``NaN`` values in the computation. For applications requiring the handling of missing data, the ``DataArray`` package is recommended.
 
+.. function:: mean(f::Function, v)
+
+   .. Docstring generated from Julia source
+
+   Apply the function `f` to each element of `v` and take the mean.
+
 .. function:: mean!(r, v)
 
    .. Docstring generated from Julia source

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -57,7 +57,7 @@ end
 @test mean([1 2 3; 4 5 6], 1) == [2.5 3.5 4.5]
 @test mean(i->i+1, 0:2) == 2.
 @test mean(isodd, [3]) == 1.
-@test mean(x->3x, (1,1)) == 2.
+@test mean(x->3x, (1,1)) == 3.
 
 @test isnan(mean([NaN]))
 @test isnan(mean([0.0,NaN]))

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -55,6 +55,9 @@ end
 @test mean([1,2,3]) == 2.
 @test mean([0 1 2; 4 5 6], 1) == [2.  3.  4.]
 @test mean([1 2 3; 4 5 6], 1) == [2.5 3.5 4.5]
+@test mean(i->i+1, 0:2) === 2.
+@test mean(isodd, [3]) === 1.
+@test mean(x->3x, (1,1)) === 2.
 
 @test isnan(mean([NaN]))
 @test isnan(mean([0.0,NaN]))

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -55,9 +55,9 @@ end
 @test mean([1,2,3]) == 2.
 @test mean([0 1 2; 4 5 6], 1) == [2.  3.  4.]
 @test mean([1 2 3; 4 5 6], 1) == [2.5 3.5 4.5]
-@test mean(i->i+1, 0:2) == 2.
-@test mean(isodd, [3]) == 1.
-@test mean(x->3x, (1,1)) == 3.
+@test mean(i->i+1, 0:2) === 2.
+@test mean(isodd, [3]) === 1.
+@test mean(x->3x, (1,1)) === 3.
 
 @test isnan(mean([NaN]))
 @test isnan(mean([0.0,NaN]))

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -55,9 +55,9 @@ end
 @test mean([1,2,3]) == 2.
 @test mean([0 1 2; 4 5 6], 1) == [2.  3.  4.]
 @test mean([1 2 3; 4 5 6], 1) == [2.5 3.5 4.5]
-@test mean(i->i+1, 0:2) === 2.
-@test mean(isodd, [3]) === 1.
-@test mean(x->3x, (1,1)) === 2.
+@test mean(i->i+1, 0:2) == 2.
+@test mean(isodd, [3]) == 1.
+@test mean(x->3x, (1,1)) == 2.
 
 @test isnan(mean([NaN]))
 @test isnan(mean([0.0,NaN]))


### PR DESCRIPTION
The functions `sum` and `prod` both accept a `Callable` argument that's mapped over the input before being reduced. This PR adds that functionality to `mean` as well.

It's faster and uses less memory than calling `map` then `mean`. Here are some timing results on my computer:

``` julia
julia> @time mean_pr(isodd, 1:100_000_000)
  0.185983 seconds (1.59 M allocations: 30.847 MB, 5.89% gc time)
0.5

julia> @time mean_pr(isodd, 1:100_000_000)
  0.132717 seconds (1.57 M allocations: 30.000 MB, 2.48% gc time)
0.5

julia> @time mean_pr(isodd, 1:100_000_000)
  0.142011 seconds (1.57 M allocations: 30.000 MB, 2.58% gc time)
0.5

julia> @time Base.mean(map(isodd, 1:100_000_000))
  0.422005 seconds (13.29 k allocations: 95.957 MB, 0.39% gc time)
0.5

julia> @time Base.mean(map(isodd, 1:100_000_000))
  0.408025 seconds (12 allocations: 95.368 MB, 2.34% gc time)
0.5

julia> @time Base.mean(map(isodd, 1:100_000_000))
  0.373496 seconds (12 allocations: 95.368 MB, 2.46% gc time)
0.5
```
