### PR TITLE
remove the ability for codegen to compute specialized call sites 

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -977,10 +977,8 @@ function abstract_call(f::ANY, fargs, argtypes::Vector{Any}, vtypes::VarTable, s
     elseif is(f,Core.kwfunc)
         if length(fargs) == 2
             ft = widenconst(argtypes[2])
-            if isa(ft,DataType) && !ft.abstract
-                if isdefined(ft.name.mt, :kwsorter)
-                    return typeof(ft.name.mt.kwsorter)
-                end
+            if isa(ft,DataType) && isdefined(ft.name, :mt) && isdefined(ft.name.mt, :kwsorter)
+                return Const(ft.name.mt.kwsorter)
             end
         end
         return Any
@@ -1017,7 +1015,7 @@ function abstract_call(f::ANY, fargs, argtypes::Vector{Any}, vtypes::VarTable, s
     return abstract_call_gf_by_type(f, atype, sv)
 end
 
-function abstract_eval_call(e, vtypes::VarTable, sv::InferenceState)
+function abstract_eval_call(e::Expr, vtypes::VarTable, sv::InferenceState)
     argtypes = Any[abstract_eval(a, vtypes, sv) for a in e.args]
     #print("call ", e.args[1], argtypes, "\n\n")
     for x in argtypes
@@ -1548,16 +1546,17 @@ function typeinf_ext(linfo::LambdaInfo)
             # This case occurs when the IR for a function has been deleted.
             # `code` will be a newly-created LambdaInfo, and we need to copy its
             # contents to the existing one to copy the info to the method cache.
-            linfo.inferred = true
-            linfo.inInference = false
+            linfo.inInference = true
             linfo.code = code.code
             linfo.slotnames = code.slotnames
             linfo.slottypes = code.slottypes
             linfo.slotflags = code.slotflags
             linfo.ssavaluetypes = code.ssavaluetypes
-            linfo.rettype = code.rettype
             linfo.pure = code.pure
             linfo.inlineable = code.inlineable
+            ccall(:jl_set_lambda_rettype, Void, (Any, Any), linfo, code.rettype)
+            linfo.inferred = true
+            linfo.inInference = false
         end
         return code
     else
@@ -1931,15 +1930,15 @@ function finish(me::InferenceState)
     # determine and cache inlineability
     me.linfo.inlineable = isinlineable(me.linfo)
 
-    me.linfo.inferred = true
-    me.linfo.inInference = false
-    me.linfo.pure = ispure
     if isdefined(me.linfo, :def)
         # compress code for non-toplevel thunks
         compressedtree = ccall(:jl_compress_ast, Any, (Any,Any), me.linfo, me.linfo.code)
         me.linfo.code = compressedtree
     end
-    me.linfo.rettype = me.bestguess
+    me.linfo.pure = ispure
+    ccall(:jl_set_lambda_rettype, Void, (Any, Any), me.linfo, me.bestguess)
+    me.linfo.inferred = true
+    me.linfo.inInference = false
 
     # lazy-delete the item from active for several reasons:
     # efficiency, correctness, and recursion-safety
@@ -2310,9 +2309,10 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     end
     # special-case inliners for known pure functions that compute types
     if isType(e.typ) && !has_typevars(e.typ.parameters[1],true)
-        if (is(f,apply_type) || is(f,fieldtype) || is(f,typeof) ||
+        if (is(f, apply_type) || is(f, fieldtype) || is(f, typeof) ||
             istopfunction(topmod, f, :typejoin) ||
             istopfunction(topmod, f, :promote_type))
+            # XXX: compute effect_free for the actual arguments
             if length(argexprs) < 2 || effect_free(argexprs[2], sv, true)
                 return (e.typ.parameters[1],())
             else
@@ -2320,17 +2320,36 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
             end
         end
     end
-    if isa(f,IntrinsicFunction) || ft ⊑ IntrinsicFunction
+    if is(f, Core.kwfunc) && length(argexprs) == 2 && isa(e.typ, Const)
+        if effect_free(argexprs[2], sv, true)
+            return (e.typ.val, ())
+        else
+            return (e.typ.val, Any[argexprs[2]])
+        end
+    end
+    if isa(f, IntrinsicFunction) || ft ⊑ IntrinsicFunction ||
+            isa(f, Builtin) || ft ⊑ Builtin
         return NF
     end
 
-    atype = argtypes_to_type(atypes)
-    if length(atype.parameters) - 1 > MAX_TUPLETYPE_LEN
-        atype = limit_tuple_type(atype)
+    atype_unlimited = argtypes_to_type(atypes)
+    if length(atype_unlimited.parameters) - 1 > MAX_TUPLETYPE_LEN
+        atype = limit_tuple_type(atype_unlimited)
+    else
+        atype = atype_unlimited
+    end
+    function invoke_NF()
+        # converts a :call to :invoke
+        cache_linfo = ccall(:jl_get_spec_lambda, Any, (Any,), atype_unlimited)
+        if cache_linfo !== nothing
+            e.head = :invoke
+            unshift!(e.args, cache_linfo)
+        end
+        return NF
     end
     meth = _methods_by_ftype(atype, 1)
     if meth === false || length(meth) != 1
-        return NF
+        return invoke_NF()
     end
     meth = meth[1]::SimpleVector
     metharg = meth[1]::Type
@@ -2364,7 +2383,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
         if !inline_incompletematch_allowed || !isdefined(Main,:Base)
             # provide global disable if this optimization is not desirable
             # need Main.Base defined for MethodError
-            return NF
+            return invoke_NF()
         end
     end
 
@@ -2395,9 +2414,10 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     # end
 
     (linfo, ty, inferred) = typeinf(method, metharg, methsp, false)
-    if !inferred || linfo === nothing
-        return NF
-    elseif !linfo.inlineable
+    if linfo === nothing || !inferred
+        return invoke_NF()
+    end
+    if !linfo.inlineable
         # TODO
         #=
         if incompletematch
@@ -2420,15 +2440,15 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
             body.args = Any[Expr(:return, newcall)]
             ast = Expr(:lambda, newnames, Any[[], locals, [], 0], body)
         else
-            return NF
+            return invoke_NF()
         end
         =#
-        return NF
+        return invoke_NF()
     elseif linfo.code === nothing
         (linfo, ty, inferred) = typeinf(method, metharg, methsp, true)
     end
-    if linfo === nothing || !inferred || !linfo.inlineable
-        return NF
+    if linfo === nothing || !inferred || !linfo.inlineable || (ast = linfo.code) === nothing
+        return invoke_NF()
     end
 
     na = linfo.nargs
@@ -2468,10 +2488,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     methargs = metharg.parameters
     nm = length(methargs)
 
-    ast = linfo.code
-    if ast === nothing
-        return NF
-    elseif !isa(ast,Array{Any,1})
+    if !isa(ast, Array{Any,1})
         ast = ccall(:jl_uncompress_ast, Any, (Any,Any), linfo, ast)
     else
         ast = copy_exprargs(ast)

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -162,32 +162,8 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         end
     else
         linfo = get(frame.linfo)
-        params =
-            if isdefined(linfo, :specTypes)
-                linfo.specTypes.parameters
-            else
-                nothing
-            end
-        if params !== nothing
-            ft = params[1]
-            if ft <: Function && isempty(ft.parameters) &&
-                    isdefined(ft.name.module, ft.name.mt.name) &&
-                    ft == typeof(getfield(ft.name.module, ft.name.mt.name))
-                print(io, ft.name.mt.name)
-            elseif isa(ft, DataType) && is(ft.name, Type.name) && isleaftype(ft)
-                f = ft.parameters[1]
-                print(io, f)
-            else
-                print(io, "(::", ft, ")")
-            end
-            first = true
-            print(io, '(')
-            for i = 2:length(params)
-                first || print(io, ", ")
-                first = false
-                print(io, "::", params[i])
-            end
-            print(io, ')')
+        if isdefined(linfo, :specTypes)
+            Base.show_lambda_types(io, linfo.specTypes.parameters)
         else
             print(io, linfo.name)
         end

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -9,6 +9,11 @@
 
 ## basic UTF-8 decoding & iteration ##
 
+is_surrogate_lead(c::Unsigned) = ((c & ~0x003ff) == 0xd800)
+is_surrogate_trail(c::Unsigned) = ((c & ~0x003ff) == 0xdc00)
+is_surrogate_codeunit(c::Unsigned) = ((c & ~0x007ff) == 0xd800)
+is_valid_continuation(c) = ((c & 0xc0) == 0x80)
+
 const utf8_offset = [
     0x00000000, 0x00003080,
     0x000e2080, 0x03c82080,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -136,6 +136,7 @@ include("iobuffer.jl")
 
 # strings & printing
 include("char.jl")
+include("intfuncs.jl")
 include("strings/strings.jl")
 include("unicode/unicode.jl")
 include("parse.jl")
@@ -151,7 +152,6 @@ using .Libc: getpid, gethostname, time
 include("libdl.jl")
 using .Libdl: DL_LOAD_PATH
 include("env.jl")
-include("intfuncs.jl")
 
 # nullable types
 include("nullable.jl")

--- a/base/unicode/checkstring.jl
+++ b/base/unicode/checkstring.jl
@@ -3,11 +3,6 @@
 ## Functions to check validity of UTF-8, UTF-16, and UTF-32 encoded strings,
 #  and also to return information necessary to convert to other encodings
 
-is_surrogate_lead(c::Unsigned) = ((c & ~0x003ff) == 0xd800)
-is_surrogate_trail(c::Unsigned) = ((c & ~0x003ff) == 0xdc00)
-is_surrogate_codeunit(c::Unsigned) = ((c & ~0x007ff) == 0xd800)
-is_valid_continuation(c) = ((c & 0xc0) == 0x80)
-
 ## Return flags for check_string function
 
 const UTF_LONG = 1              ##< Long encodings are present

--- a/doc/devdocs/ast.rst
+++ b/doc/devdocs/ast.rst
@@ -74,8 +74,12 @@ Expr types
 These symbols appear in the ``head`` field of ``Expr``\s in lowered form.
 
 ``call``
-    function call. ``args[1]`` is the function to call, ``args[2:end]`` are the
-    arguments.
+    function call (dynamic dispatch). ``args[1]`` is the function to call,
+    ``args[2:end]`` are the arguments.
+
+``invoke``
+    function call (static dispatch). ``args[1]`` is the LambdaInfo to call,
+    ``args[2:end]`` are the arguments (including the function that is being called, at ``args[2]``).
 
 ``static_parameter``
     reference a static parameter by index.

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -71,7 +71,8 @@ jl_value_t *jl_memory_exception;
 jl_value_t *jl_readonlymemory_exception;
 union jl_typemap_t jl_cfunction_list;
 
-jl_sym_t *call_sym;    jl_sym_t *dots_sym;
+jl_sym_t *call_sym;    jl_sym_t *invoke_sym;
+jl_sym_t *dots_sym;
 jl_sym_t *module_sym;  jl_sym_t *slot_sym;
 jl_sym_t *empty_sym;
 jl_sym_t *export_sym;  jl_sym_t *import_sym;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -956,6 +956,8 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
             if (idx >= jl_svec_len(ctx->linfo->sparam_vals))
                 return (jl_value_t*)jl_any_type;
             e = jl_svecref(ctx->linfo->sparam_vals, idx);
+            if (jl_is_typevar(e))
+                return (jl_value_t*)jl_any_type;
             goto type_of_constant;
         }
         jl_value_t *typ = ((jl_expr_t*)e)->etype;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1355,12 +1355,12 @@ static Value *init_bits_value(Value *newv, Value *jt, Value *v, MDNode *tbaa)
     return newv;
 }
 static Value *as_value(Type *t, const jl_cgval_t&);
-static Value *init_bits_cgval(Value *newv, const jl_cgval_t& v, MDNode *tbaa, Type *t, jl_codectx_t *ctx)
+static Value *init_bits_cgval(Value *newv, const jl_cgval_t& v, MDNode *tbaa, jl_codectx_t *ctx)
 {
     Value *jt = literal_pointer_val(v.typ);
     if (v.ispointer()) {
         init_tag(newv, jt);
-        builder.CreateMemCpy(newv, data_pointer(v,ctx,PointerType::get(t,0)), jl_datatype_size(v.typ), sizeof(void*));
+        builder.CreateMemCpy(newv, data_pointer(v, ctx, T_pint8), jl_datatype_size(v.typ), sizeof(void*));
         return newv;
     }
     else {
@@ -1530,7 +1530,7 @@ static Value *boxed(const jl_cgval_t &vinfo, jl_codectx_t *ctx, bool gcrooted)
         return literal_pointer_val(jb->instance);
     }
     else {
-        box = init_bits_cgval(emit_allocobj(jl_datatype_size(jt)), vinfo, jb->mutabl ? tbaa_mutab : tbaa_immut, t, ctx);
+        box = init_bits_cgval(emit_allocobj(jl_datatype_size(jt)), vinfo, jb->mutabl ? tbaa_mutab : tbaa_immut, ctx);
     }
 
     if (gcrooted) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -867,7 +867,6 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         jl_serialize_value(s, (jl_value_t*)li->sparam_syms);
         jl_serialize_value(s, (jl_value_t*)li->sparam_vals);
         jl_serialize_value(s, (jl_value_t*)li->specTypes);
-        jl_serialize_value(s, (jl_value_t*)li->unspecialized_ducttape);
         write_int8(s, li->inferred);
         write_int8(s, li->pure);
         write_int8(s, li->inlineable);
@@ -1501,8 +1500,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         jl_gc_wb(li, li->sparam_vals);
         li->specTypes = (jl_tupletype_t*)jl_deserialize_value(s, (jl_value_t**)&li->specTypes);
         if (li->specTypes) jl_gc_wb(li, li->specTypes);
-        li->unspecialized_ducttape = (jl_lambda_info_t*)jl_deserialize_value(s, (jl_value_t**)&li->unspecialized_ducttape);
-        if (li->unspecialized_ducttape) jl_gc_wb(li, li->unspecialized_ducttape);
+        li->unspecialized_ducttape = NULL;
         li->inferred = read_int8(s);
         li->pure = read_int8(s);
         li->inlineable = read_int8(s);
@@ -2413,7 +2411,7 @@ void jl_init_serializer(void)
                      // everything above here represents a class of object rather than only a literal
 
                      jl_emptysvec, jl_emptytuple, jl_false, jl_true, jl_nothing, jl_any_type,
-                     call_sym, goto_ifnot_sym, return_sym, body_sym, line_sym,
+                     call_sym, invoke_sym, goto_ifnot_sym, return_sym, body_sym, line_sym,
                      lambda_sym, jl_symbol("tuple"), assign_sym,
 
                      // empirical list of very common symbols

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -209,11 +209,14 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
         ssize_t n = jl_unbox_long(args[0]);
         assert(n > 0);
         if (s->sparam_vals)
-            return jl_svecref(s->sparam_vals, n-1);
+            return jl_svecref(s->sparam_vals, n - 1);
+        if (n <= jl_svec_len(lam->sparam_vals)) {
+            jl_value_t *sp = jl_svecref(lam->sparam_vals, n - 1);
+            if (!jl_is_typevar(sp))
+                return sp;
+        }
         // static parameter val unknown needs to be an error for ccall
-        if (n > jl_svec_len(lam->sparam_vals))
-            jl_error("could not determine static parameter value");
-        return jl_svecref(lam->sparam_vals, n-1);
+        jl_error("could not determine static parameter value");
     }
     else if (ex->head == inert_sym) {
         return args[0];

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -67,6 +67,20 @@ static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s
     return result;
 }
 
+static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state *s)
+{
+    jl_value_t **argv;
+    JL_GC_PUSHARGS(argv, nargs - 1);
+    size_t i;
+    for (i = 1; i < nargs; i++)
+        argv[i - 1] = eval(args[i], s);
+    jl_lambda_info_t *meth = (jl_lambda_info_t*)args[0];
+    assert(jl_is_lambda_info(meth) && !meth->inInference);
+    jl_value_t *result = jl_call_method_internal(meth, argv, nargs - 1);
+    JL_GC_POP();
+    return result;
+}
+
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
 {
     jl_value_t *v = jl_get_global(m, e);
@@ -172,6 +186,9 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
     size_t nargs = jl_array_len(ex->args);
     if (ex->head == call_sym) {
         return do_call(args, nargs, s);
+    }
+    else if (ex->head == invoke_sym) {
+        return do_invoke(args, nargs, s);
     }
     else if (ex->head == new_sym) {
         jl_value_t *thetype = eval(args[0], s);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -505,7 +505,12 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
             vx = builder.CreateBitCast(vx, llvmt);
     }
 
-    return mark_julia_type(vx, false, bt, ctx);
+    if (jl_is_leaf_type(bt))
+        return mark_julia_type(vx, false, bt, ctx);
+    else
+        return mark_julia_type(
+            init_bits_value(emit_allocobj(nb), boxed(bt_value, ctx), vx, tbaa_immut),
+            true, bt, ctx);
 }
 
 // put a bits type tag on some value

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3809,6 +3809,7 @@ void jl_init_types(void)
 
     empty_sym = jl_symbol("");
     call_sym = jl_symbol("call");
+    invoke_sym = jl_symbol("invoke");
     quote_sym = jl_symbol("quote");
     inert_sym = jl_symbol("inert");
     top_sym = jl_symbol("top");

--- a/src/julia.h
+++ b/src/julia.h
@@ -545,7 +545,8 @@ extern JL_DLLEXPORT jl_value_t *jl_false;
 extern JL_DLLEXPORT jl_value_t *jl_nothing;
 
 // some important symbols
-extern jl_sym_t *call_sym;    extern jl_sym_t *empty_sym;
+extern jl_sym_t *call_sym;    extern jl_sym_t *invoke_sym;
+extern jl_sym_t *empty_sym;
 extern jl_sym_t *dots_sym;    extern jl_sym_t *vararg_sym;
 extern jl_sym_t *quote_sym;   extern jl_sym_t *newvar_sym;
 extern jl_sym_t *top_sym;     extern jl_sym_t *dot_sym;
@@ -1379,6 +1380,7 @@ STATIC_INLINE int jl_vinfo_usedundef(uint8_t vi)
 // calling into julia ---------------------------------------------------------
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_invoke(jl_lambda_info_t *meth, jl_value_t **args, uint32_t nargs);
 
 STATIC_INLINE
 jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -72,6 +72,7 @@ STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 jl_lambda_info_t *jl_type_infer(jl_lambda_info_t *li, int force);
 void jl_generate_fptr(jl_lambda_info_t *li);
 void jl_compile_linfo(jl_lambda_info_t *li);
+JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
 jl_lambda_info_t *jl_compile_for_dispatch(jl_lambda_info_t *li);
 
 // invoke (compiling if necessary) the jlcall function pointer for a method

--- a/src/threading.c
+++ b/src/threading.c
@@ -395,8 +395,7 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_svec_t *args)
     int8_t gc_state = jl_gc_unsafe_enter();
     JL_GC_PUSH1(&argtypes);
     argtypes = arg_type_tuple(jl_svec_data(args), jl_svec_len(args));
-    jl_lambda_info_t *li = jl_get_specialization1(argtypes);
-    jl_generate_fptr(li);
+    jl_compile_hint(argtypes);
 
     threadwork.command = TI_THREADWORK_RUN;
     // TODO jb/functions: lookup and store jlcall fptr here

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -79,7 +79,7 @@ static void jl_module_load_time_initialize(jl_module_t *m)
             jl_value_t *tt = jl_is_type(f) ? (jl_value_t*)jl_wrap_Type(f) : jl_typeof(f);
             JL_GC_PUSH1(&tt);
             tt = (jl_value_t*)jl_apply_tuple_type_v(&tt, 1);
-            jl_get_specialization1((jl_tupletype_t*)tt);
+            jl_compile_hint((jl_tupletype_t*)tt);
             JL_GC_POP();
         }
     }

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -5,14 +5,14 @@
 # issue 9770
 @noinline x9770() = false
 function f9770(x)
-    if x9770()
+    return if x9770()
         g9770(:a, :foo)
     else
         x
     end
 end
 function g9770(x,y)
-   if isa(y, Symbol)
+   return if isa(y, Symbol)
        f9770(x)
    else
        g9770(:a, :foo)
@@ -58,7 +58,7 @@ function g3182(t::DataType)
     # subtype of Type, but we cannot infer the T in Type{T} just
     # by knowing (at compile time) that the argument is a DataType.
     # however the ::Type{T} method should still match at run time.
-    f3182(t)
+    return f3182(t)
 end
 @test g3182(Complex) == 0
 
@@ -107,7 +107,7 @@ barTuple2() = fooTuple{tuple(:y)}()
 # issue #12476
 function f12476(a)
     (k, v) = a
-    v
+    return v
 end
 @inferred f12476(1.0 => 1)
 
@@ -143,14 +143,17 @@ f12826{I<:Integer}(v::Vector{I}) = v[1]
 
 
 # non-terminating inference, issue #14009
+# non-terminating codegen, issue #16201
 type A14009{T}; end
 A14009{T}(a::T) = A14009{T}()
 f14009(a) = rand(Bool) ? f14009(A14009(a)) : a
 code_typed(f14009, (Int,))
+code_llvm(DevNull, f14009, (Int,))
 
 type B14009{T}; end
 g14009(a) = g14009(B14009{a})
 code_typed(g14009, (Type{Int},))
+code_llvm(DevNull, f14009, (Int,))
 
 
 # issue #9232
@@ -164,6 +167,7 @@ result_type9232{T1<:Number,T2<:Number}(::Type{T1}, ::Type{T2}) = arithtype9232(T
 function g10878(x; kw...); end
 invoke_g10878() = invoke(g10878, Tuple{Any}, 1)
 @code_typed invoke_g10878()
+code_llvm(DevNull, invoke_g10878, ())
 
 
 # issue #10930


### PR DESCRIPTION
The new `Expr(:invoke)` has a similar structure to `Expr(:call)`, but where the first entry in the args array is the exact LambdaInfo to call

Inference has already computed this direct-call information, so it's a net-code deletion to handle it there, so that codegen can be dumber.
