### PR TITLE
Fix inference recursion due to finalizers

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1570,7 +1570,7 @@ function typeinf_loop(frame)
         frame.inworkq || typeinf_frame(frame)
         return
     end
-    ccall(:jl_sigatomic_begin, Void, ())
+    ccall(:jl_typeinf_begin, Void, ())
     try
         in_typeinf_loop = true
         # the core type-inference algorithm
@@ -1617,7 +1617,7 @@ function typeinf_loop(frame)
         println(ex)
         ccall(:jlbacktrace, Void, ())
     end
-    ccall(:jl_sigatomic_end, Void, ())
+    ccall(:jl_typeinf_end, Void, ())
     nothing
 end
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -687,12 +687,12 @@ static jl_sym_t *_jl_symbol(const char *str, size_t len)
         JL_LOCK(&symbol_table_lock); // Might GC
         // Someone might have updated it, check and look up again
         if (*slot != NULL && (node = symtab_lookup(slot, str, len, &slot))) {
-            JL_UNLOCK(&symbol_table_lock);
+            JL_UNLOCK(&symbol_table_lock); // Might GC
             return node;
         }
         node = mk_symbol(str, len);
         jl_atomic_store_release(slot, node);
-        JL_UNLOCK(&symbol_table_lock);
+        JL_UNLOCK(&symbol_table_lock); // Might GC
     }
     return node;
 }

--- a/src/array.c
+++ b/src/array.c
@@ -595,6 +595,8 @@ static void array_resize_buffer(jl_array_t *a, size_t newlen, size_t oldlen, siz
         }
         memcpy(newdata + offsnb, (char*)a->data, oldnbytes);
     }
+    assert(oldlen == a->nrows &&
+           "Race condition detected: recursive resizing on the same array.");
 
     a->data = newdata + offsnb;
     a->flags.isshared = 0;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -194,15 +194,18 @@ JL_CALLABLE(jl_f_throw)
 
 JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_task_t *current_task = ptls->current_task;
     // Must have no safepoint
-    eh->prev = jl_current_task->eh;
-    eh->gcstack = jl_pgcstack;
+    eh->prev = current_task->eh;
+    eh->gcstack = ptls->pgcstack;
 #ifdef JULIA_ENABLE_THREADING
-    eh->gc_state = jl_gc_state();
-    eh->locks_len = jl_current_task->locks.len;
+    eh->gc_state = ptls->gc_state;
+    eh->locks_len = current_task->locks.len;
 #endif
-    eh->defer_signal = jl_get_ptls_states()->defer_signal;
-    jl_current_task->eh = eh;
+    eh->defer_signal = ptls->defer_signal;
+    eh->finalizers_inhibited = ptls->finalizers_inhibited;
+    current_task->eh = eh;
 }
 
 JL_DLLEXPORT void jl_pop_handler(int n)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1958,7 +1958,7 @@ static jl_value_t *lookup_type(jl_typename_t *tn, jl_value_t **key, size_t n)
     JL_LOCK(&typecache_lock); // Might GC
     ssize_t idx = lookup_type_idx(tn, key, n, ord);
     jl_value_t *t = (idx < 0) ? NULL : jl_svecref(ord ? tn->cache : tn->linearcache, idx);
-    JL_UNLOCK(&typecache_lock);
+    JL_UNLOCK(&typecache_lock); // Might GC
     return t;
 }
 
@@ -2033,7 +2033,7 @@ jl_value_t *jl_cache_type_(jl_datatype_t *type)
             type = (jl_datatype_t*)jl_svecref(ord ? type->name->cache : type->name->linearcache, idx);
         else
             cache_insert_type((jl_value_t*)type, ~idx, ord);
-        JL_UNLOCK(&typecache_lock);
+        JL_UNLOCK(&typecache_lock); // Might GC
     }
     return (jl_value_t*)type;
 }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -96,7 +96,6 @@ jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types
 // MSVC miscalculates sizeof(jl_taggedvalue_t) because
 // empty structs are a GNU extension
 #define sizeof_jl_taggedvalue_t (sizeof(void*))
-void jl_gc_inhibit_finalizers(int state);
 void jl_gc_setmark(jl_value_t *v);
 void jl_gc_sync_total_bytes(void);
 void jl_gc_track_malloced_array(jl_array_t *a);


### PR DESCRIPTION
- Make inhibit finalizers thread local
- Restore inhibit finalizer states on exception
- Disable finalizer and sigint when acquiring a normal runtime lock
- Make inference atomic to finalizers and thread safe
  (including introspection code path)

This is a slightly stripped and modified version of https://github.com/JuliaLang/julia/pull/16204. Main differences are,
- Rename the function to `jl_gc_enable_finalizers` and make it automatically increment and decrement a counter instead of letting the user save it.
- Use it for all the cases we acquire a normal runtime lock also set sigatomic at the same time.
  
  Finalizers and signals are really like a different thread except that you can't protect against it with a lock. This is not necessary for NOGC locks since their critical regions are not allowed to have allocation (so no finalizers) or safepoint (so no sigint).
- Only finalizers on the current thread is disabled, thread synchronization is not part of this and can't be done automatically. (a lock should be used).
- This does NOT make array thread safe or finalizer safe. The C code is the wrong level to do this. I did add an assertion to detect such error though.

This strangely triggers really reliably on some build on the https://github.com/JuliaLang/julia/pull/16632 branch. Backtrace below, where the array at `0xd29495a0` is `Core.Inference.active`.

```
#0  array_resize_buffer (a=0xd29495a0, newlen=128, oldlen=64, offs=0) at /home/yuyichao/projects/julia/gc/cleanup2/src/array.c:600
#1  0xf5f45abe in jl_array_grow_end (a=0xd29495a0, inc=1) at /home/yuyichao/projects/julia/gc/cleanup2/src/array.c:641
#2  0xf2cc7fba in push! () at array.jl:464
#3  julia_Type_40 (linfo=0xd557f2b0, atypes=0xd557f260, sparams=0xd2174010, optimize=0) at inference.jl:167
#4  0xf2cc8361 in jlcall_Type_40 () from /home/yuyichao/projects/julia/gc/cleanup2/usr/lib/julia/sys-debug.so
#5  0xf5f1a181 in jl_call_method_internal (meth=0xd521e220, args=0xffd9f6f8, nargs=5) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia_internal.h:88
#6  0xf5f1f60a in jl_apply_generic (args=0xffd9f6f8, nargs=5) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:1595
#7  0xf2d0f246 in julia_typeinf_edge_860 (method=..., atypes=0xd557f260, sparams=0xd2174010, needtree=0, optimize=0, cached=0, caller=0xd557f2b0) at inference.jl:1500
#8  0xf5f1a181 in jl_call_method_internal (meth=0xd28081a0, args=0xffd9f930, nargs=8) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia_internal.h:88
#9  0xf5f1f60a in jl_apply_generic (args=0xffd9f930, nargs=8) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:1595
#10 0xf2cc2da2 in julia_typeinf_ext_0 (linfo=0xd557f2b0) at inference.jl:1542
#11 0xf5f1a181 in jl_call_method_internal (meth=0xd298fdf0, args=0xffd9fab4, nargs=2) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia_internal.h:88
#12 0xf5f1f60a in jl_apply_generic (args=0xffd9fab4, nargs=2) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:1595
#13 0xf5f19e23 in jl_apply (args=0xffd9fab4, nargs=2) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia.h:1386
#14 0xf5f1ae5a in jl_type_infer (li=0xd557f2b0, force=0) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:219
#15 0xf5f1c596 in cache_method (mt=0xd3657590, cache=0xd3657598, parent=0xd3657590, type=0xd557f260, origtype=0x0, m=0xd36575d0, sparams=0xd2174010)
    at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:678
#16 0xf5f1c7a7 in jl_mt_assoc_by_type (mt=0xd3657590, tt=0xd557f260, cache=1, inexact=0) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:711
#17 0xf5f1f576 in jl_apply_generic (args=0xffd9fd54, nargs=2) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:1574
#18 0xf5f789ab in jl_apply (args=0xffd9fd54, nargs=2) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia.h:1386
#19 0xf5f7931a in run_finalizer (o=0xd57380d0, ff=0xd34ceb88) at /home/yuyichao/projects/julia/gc/cleanup2/src/gc.c:113
#20 0xf5f79616 in jl_gc_run_finalizers_in_list (list=0xffd9fe7c) at /home/yuyichao/projects/julia/gc/cleanup2/src/gc.c:160
#21 0xf5f7972c in run_finalizers () at /home/yuyichao/projects/julia/gc/cleanup2/src/gc.c:182
#22 0xf5f7df38 in jl_gc_collect (full=0) at /home/yuyichao/projects/julia/gc/cleanup2/src/gc.c:1743
#23 0xf5f7adad in __pool_alloc (p=0xf594d178, osize=544, end_offset=15788) at /home/yuyichao/projects/julia/gc/cleanup2/src/gc.c:693
#24 0xf5f7b063 in pool_alloc (p=0xf594d178) at /home/yuyichao/projects/julia/gc/cleanup2/src/gc.c:751
#25 0xf5f7dffd in allocb (sz=512) at /home/yuyichao/projects/julia/gc/cleanup2/src/gc.c:1762
#26 0xf5f457b1 in array_resize_buffer (a=0xd29495a0, newlen=128, oldlen=64, offs=0) at /home/yuyichao/projects/julia/gc/cleanup2/src/array.c:593
#27 0xf5f45abe in jl_array_grow_end (a=0xd29495a0, inc=1) at /home/yuyichao/projects/julia/gc/cleanup2/src/array.c:641
#28 0xf2cc7fba in push! () at array.jl:464
#29 julia_Type_40 (linfo=0xd5be41f0, atypes=0xd5be41a0, sparams=0xd2174010, optimize=0) at inference.jl:167
#30 0xf2cc8361 in jlcall_Type_40 () from /home/yuyichao/projects/julia/gc/cleanup2/usr/lib/julia/sys-debug.so
#31 0xf5f1a181 in jl_call_method_internal (meth=0xd521e220, args=0xffda08c8, nargs=5) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia_internal.h:88
#32 0xf5f1f60a in jl_apply_generic (args=0xffda08c8, nargs=5) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:1595
#33 0xf2ceab41 in julia_typeinf_edge_559 (method=..., atypes=0xd5be41a0, sparams=0xd2174010, needtree=0, optimize=0, cached=0, caller=...) at inference.jl:1500
#34 0xf2ceb82b in jlcall_typeinf_edge_559 () from /home/yuyichao/projects/julia/gc/cleanup2/usr/lib/julia/sys-debug.so
#35 0xf5f1a181 in jl_call_method_internal (meth=0xd2808150, args=0xffda0aa8, nargs=8) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia_internal.h:88
#36 0xf5f1f60a in jl_apply_generic (args=0xffda0aa8, nargs=8) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:1595
#37 0xf2ce9884 in julia_typeinf_edge_558 (method=..., atypes=0xd5be41a0, sparams=0xd2174010, caller=...) at inference.jl:1527
#38 0xf2ce9907 in jlcall_typeinf_edge_558 () from /home/yuyichao/projects/julia/gc/cleanup2/usr/lib/julia/sys-debug.so
#39 0xf5f1a181 in jl_call_method_internal (meth=0xd2808060, args=0xffda0ddc, nargs=5) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia_internal.h:88
#40 0xf5f1f60a in jl_apply_generic (args=0xffda0ddc, nargs=5) at /home/yuyichao/projects/julia/gc/cleanup2/src/gf.c:1595
#41 0xf2ce8a62 in julia_abstract_call_gf_by_type_524 (f=0xd507e7ac, argtype=0xd5be41a0, sv=...) at inference.jl:852
#42 0xf2ce8f30 in jlcall_abstract_call_gf_by_type_524 () from /home/yuyichao/projects/julia/gc/cleanup2/usr/lib/julia/sys-debug.so
#43 0xf5f1a181 in jl_call_method_internal (meth=0xd27991e0, args=0xffda115c, nargs=4) at /home/yuyichao/projects/julia/gc/cleanup2/src/julia_internal.h:88
```

@vtjnash 
