### PR TITLE
Print LLVM version for LLVM-SVN build

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -337,6 +337,9 @@ ifneq ($(LLVM_GIT_VER),)
 	(cd $(LLVM_SRC_DIR) && \
 		git checkout $(LLVM_GIT_VER))
 endif # LLVM_GIT_VER
+	# Debug output only. Disable pager and ignore error.
+	(cd $(LLVM_SRC_DIR) && \
+		git show HEAD --stat | cat) || true
 endif # LLVM_VER
 ifneq ($(LLVM_VER),svn)
 ifneq ($(LLVM_CLANG_TAR),)


### PR DESCRIPTION
I realized recently that https://github.com/staticfloat/julia-buildbot/pull/43 doesn't really work since we fetch from git and llvm can't figure out the related version number. Hopefully this works better....
