### PR TITLE
Fix #16100. Allow opting out of all `@boundscheck` blocks with `--check-bounds=no`.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4782,7 +4782,11 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
         }
         else if (is_inbounds(&ctx) && is_bounds_check_block(&ctx) &&
                  jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_ON) {
-            // elide bounds check blocks
+            // elide bounds check blocks in inbounds context
+        }
+        else if (is_bounds_check_block(&ctx) &&
+                 jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_OFF) {
+            // elide bounds check blocks when turned off by options
         }
         else {
             emit_stmtpos(stmt, &ctx);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4780,7 +4780,8 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
             // always emit expressions that update the boundscheck stack
             emit_stmtpos(stmt, &ctx);
         }
-        else if (is_inbounds(&ctx) && is_bounds_check_block(&ctx)) {
+        else if (is_inbounds(&ctx) && is_bounds_check_block(&ctx) &&
+                 jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_ON) {
             // elide bounds check blocks
         }
         else {

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -1,154 +1,18 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module TestBoundsCheck
+# run boundscheck tests on separate workers launched with --check-bounds={default,yes,no}
 
-using Base.Test
-
-@enum BCOption bc_default bc_on bc_off
-bc_opt = BCOption(Base.JLOptions().check_bounds)
-
-# test for boundscheck block eliminated at same level
-@inline function A1()
-    r = 0
-    @boundscheck r += 1
-    return r
+cmd = `$(Base.julia_cmd()) --depwarn=error boundscheck_exec.jl`
+if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR))
+    error("boundscheck test failed, cmd : $cmd")
 end
 
-@noinline function A1_noinline()
-    r = 0
-    @boundscheck r += 1
-    return r
+cmd = `$(Base.julia_cmd()) --check-bounds=yes --depwarn=error boundscheck_exec.jl`
+if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR))
+    error("boundscheck test failed, cmd : $cmd")
 end
 
-function A1_inbounds()
-    r = 0
-    @inbounds begin
-        @boundscheck r += 1
-    end
-    return r
-end
-
-if bc_opt == bc_default
-    @test A1() == 1
-    @test A1_inbounds() == 0
-elseif bc_opt == bc_on
-    @test A1() == 1
-    @test A1_inbounds() == 1
-else
-    @test A1() == 0
-    @test A1_inbounds() == 0
-end
-
-# test for boundscheck block eliminated one layer deep, if the called method is inlined
-@inline function A2()
-    r = A1()+1
-    return r
-end
-
-function A2_inbounds()
-    @inbounds r = A1()+1
-    return r
-end
-
-function A2_notinlined()
-    @inbounds r = A1_noinline()+1
-    return r
-end
-
-Base.@propagate_inbounds function A2_propagate_inbounds()
-    r = A1()+1
-    return r
-end
-
-if bc_opt == bc_default
-    @test A2() == 2
-    @test A2_inbounds() == 1
-    @test A2_notinlined() == 2
-    @test A2_propagate_inbounds() == 2
-elseif bc_opt == bc_on
-    @test A2() == 2
-    @test A2_inbounds() == 2
-    @test A2_notinlined() == 2
-    @test A2_propagate_inbounds() == 2
-else
-    @test A2() == 1
-    @test A2_inbounds() == 1
-    @test A2_notinlined() == 1
-    @test A2_propagate_inbounds() == 1
-end
-
-# test boundscheck NOT eliminated two layers deep, unless propagated
-
-function A3()
-    r = A2()+1
-    return r
-end
-
-function A3_inbounds()
-    @inbounds r = A2()+1
-    return r
-end
-
-function A3_inbounds2()
-    @inbounds r = A2_propagate_inbounds()+1
-    return r
-end
-
-if bc_opt == bc_default
-    @test A3() == 3
-    @test A3_inbounds() == 3
-    @test A3_inbounds2() == 2
-elseif bc_opt == bc_on
-    @test A3() == 3
-    @test A3_inbounds() == 3
-    @test A3_inbounds2() == 3
-else
-    @test A3() == 2
-    @test A3_inbounds() == 2
-    @test A3_inbounds2() == 2
-end
-
-# swapped nesting order of @boundscheck and @inbounds
-function A1_nested()
-    r = 0
-    @boundscheck @inbounds r += 1
-    return r
-end
-
-if bc_opt == bc_default || bc_opt == bc_on
-    @test A1_nested() == 1
-else
-    @test A1_nested() == 0
-end
-
-# elide a throw
-cb(x) = x > 0 || throw(BoundsError())
-
-function B1()
-    y = [1,2,3]
-    @inbounds begin
-        @boundscheck cb(0)
-    end
-    return 0
-end
-
-if bc_opt == bc_default || bc_opt == bc_off
-    @test B1() == 0
-else
-    @test_throws BoundsError B1()
-end
-
-# elide a simple branch
-cond(x) = x > 0 ? x : -x
-
-function B2()
-    y = [1,2,3]
-    @inbounds begin
-        @boundscheck cond(0)
-    end
-    return 0
-end
-
-@test B2() == 0
-
+cmd = `$(Base.julia_cmd()) --check-bounds=no --depwarn=error boundscheck_exec.jl`
+if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR))
+    error("boundscheck test failed, cmd : $cmd")
 end

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -1,0 +1,154 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+module TestBoundsCheck
+
+using Base.Test
+
+@enum BCOption bc_default bc_on bc_off
+bc_opt = BCOption(Base.JLOptions().check_bounds)
+
+# test for boundscheck block eliminated at same level
+@inline function A1()
+    r = 0
+    @boundscheck r += 1
+    return r
+end
+
+@noinline function A1_noinline()
+    r = 0
+    @boundscheck r += 1
+    return r
+end
+
+function A1_inbounds()
+    r = 0
+    @inbounds begin
+        @boundscheck r += 1
+    end
+    return r
+end
+
+if bc_opt == bc_default
+    @test A1() == 1
+    @test A1_inbounds() == 0
+elseif bc_opt == bc_on
+    @test A1() == 1
+    @test A1_inbounds() == 1
+else
+    @test A1() == 0
+    @test A1_inbounds() == 0
+end
+
+# test for boundscheck block eliminated one layer deep, if the called method is inlined
+@inline function A2()
+    r = A1()+1
+    return r
+end
+
+function A2_inbounds()
+    @inbounds r = A1()+1
+    return r
+end
+
+function A2_notinlined()
+    @inbounds r = A1_noinline()+1
+    return r
+end
+
+Base.@propagate_inbounds function A2_propagate_inbounds()
+    r = A1()+1
+    return r
+end
+
+if bc_opt == bc_default
+    @test A2() == 2
+    @test A2_inbounds() == 1
+    @test A2_notinlined() == 2
+    @test A2_propagate_inbounds() == 2
+elseif bc_opt == bc_on
+    @test A2() == 2
+    @test A2_inbounds() == 2
+    @test A2_notinlined() == 2
+    @test A2_propagate_inbounds() == 2
+else
+    @test A2() == 1
+    @test A2_inbounds() == 1
+    @test A2_notinlined() == 1
+    @test A2_propagate_inbounds() == 1
+end
+
+# test boundscheck NOT eliminated two layers deep, unless propagated
+
+function A3()
+    r = A2()+1
+    return r
+end
+
+function A3_inbounds()
+    @inbounds r = A2()+1
+    return r
+end
+
+function A3_inbounds2()
+    @inbounds r = A2_propagate_inbounds()+1
+    return r
+end
+
+if bc_opt == bc_default
+    @test A3() == 3
+    @test A3_inbounds() == 3
+    @test A3_inbounds2() == 2
+elseif bc_opt == bc_on
+    @test A3() == 3
+    @test A3_inbounds() == 3
+    @test A3_inbounds2() == 3
+else
+    @test A3() == 2
+    @test A3_inbounds() == 2
+    @test A3_inbounds2() == 2
+end
+
+# swapped nesting order of @boundscheck and @inbounds
+function A1_nested()
+    r = 0
+    @boundscheck @inbounds r += 1
+    return r
+end
+
+if bc_opt == bc_default || bc_opt == bc_on
+    @test A1_nested() == 1
+else
+    @test A1_nested() == 0
+end
+
+# elide a throw
+cb(x) = x > 0 || throw(BoundsError())
+
+function B1()
+    y = [1,2,3]
+    @inbounds begin
+        @boundscheck cb(0)
+    end
+    return 0
+end
+
+if bc_opt == bc_default || bc_opt == bc_off
+    @test B1() == 0
+else
+    @test_throws BoundsError B1()
+end
+
+# elide a simple branch
+cond(x) = x > 0 ? x : -x
+
+function B2()
+    y = [1,2,3]
+    @inbounds begin
+        @boundscheck cond(0)
+    end
+    return 0
+end
+
+@test B2() == 0
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,13 @@ move_to_node1("compile")
 # since it starts a lot of workers and can easily exceed the maximum memory
 max_worker_rss != typemax(Csize_t) && move_to_node1("parallel")
 
+# boundscheck test handled specially because it should be run without
+# --check-bounds=yes
+boundscheck_test = "boundscheck" in tests
+if boundscheck_test
+    splice!(tests, findfirst(tests, "boundscheck"))
+end
+
 cd(dirname(@__FILE__)) do
     n = 1
     if net_on
@@ -78,6 +85,13 @@ cd(dirname(@__FILE__)) do
     for t in node1_tests
         n > 1 && print("\tFrom worker 1:\t")
         runtests(t)
+    end
+
+    if boundscheck_test
+        p = addprocs(1)[1]
+        remotecall_fetch(()->include("testdefs.jl"), p)
+        resp = remotecall_fetch(() -> runtests("boundscheck"), p)
+        push!(results, ("boundscheck", resp))
     end
 
     println("    \033[32;1mSUCCESS\033[0m")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,8 +23,6 @@ move_to_node1("compile")
 # since it starts a lot of workers and can easily exceed the maximum memory
 max_worker_rss != typemax(Csize_t) && move_to_node1("parallel")
 
-boundscheck_test = "boundscheck" in tests
-
 cd(dirname(@__FILE__)) do
     n = 1
     if net_on
@@ -61,21 +59,6 @@ cd(dirname(@__FILE__)) do
                     end
                 end
             end
-        end
-    end
-
-    # also run boundscheck test with --check-bounds=default and --check-bounds=no
-    if boundscheck_test
-        procs = [addprocs(1)[1], addprocs(1; exeflags=`--check-bounds=no`)[1]]
-        for p in procs
-            remotecall_fetch(()->include("testdefs.jl"), p)
-            local resp
-            try
-                resp = remotecall_fetch(() -> runtests("boundscheck"), p)
-            catch e
-                resp = e
-            end
-            push!(results, ("boundscheck", resp))
         end
     end
 


### PR DESCRIPTION
Also now properly respect `--check-bounds=yes` for such blocks. To test it, I launch two extra processes with appropriate `execflags`. I'm not familiar with the use case of the `net_on` variable in `runtests.jl`. Is that something I should be concerned about for launching these extra processes?
