### PR TITLE
Try to improve AppVeyor memory usage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 environment:
 #  USEMSVC: "1"
-  JULIA_TEST_MAXRSS_MB: 500
   matrix:
   - ARCH: "i686"
+    JULIA_TEST_MAXRSS_MB: 500
   - ARCH: "x86_64"
+    JULIA_TEST_MAXRSS_MB: 450
 
 # Only build on master and PR's for now, not personal branches
 # Whether or not PR's get built is determined in the webhook settings


### PR DESCRIPTION
- Run `parallel` test after others
- Decrease the max_rss to 450 MB

![appveyor memory usage](http://paste.opensuse.org/images/40866226.png)

See the memory usage on AppVeyor above, we've been running really close to the memory limit on win64. This is largely irrelevant with how much memory we use (due to `JULIA_TEST_MAXRSS_MB`), but more how they are scheduled and the distribution of memory usage. The few offenders:
- `linalg/triangular` typically uses ~850MB of memory. This is less of an issue since this is the first test
- `subarray` typically uses 1000~1250MB of memory, depending which worker it is running on (and whether the worker is restarted).
- `parallel` starts 4 workers, each uses 100~150MB of memory (this is an estimate)
- `cmdlineargs` also spawns processes but usually one at a time

The OOM issue usually occurs when `subarray` and `parallel` (and sometimes `cmdlineargs`) are running at the same time (typical error message includes `__init__` error when loading external libraries on newly created processed).

This PR tries to work around this issue by reducing the max rss a little more and do not run the parallel test on workers with constraint memory. The new max rss on appveyor is estimated from `(2400 #= total memory =# - 1000 #= min subarray peak =#) / 3 #= number of works when the subarray test is runnig =# ~ 466`. We may still reduce this by a little to acount for the worst case but let's see how this value works....
