### PR TITLE
Ensure Cstrings are null terminated

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -86,6 +86,11 @@ function unsafe_convert(::Type{Cstring}, s::String)
     if containsnul(p, sizeof(s))
         throw(ArgumentError("embedded NULs are not allowed in C strings: $(repr(s))"))
     end
+    if unsafe_load(p, sizeof(s)+1) != 0
+        # ensure null terminated, copying if necessary
+        s = String(s.data)
+        p = unsafe_convert(Ptr{Cchar}, s)
+    end
     return Cstring(p)
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -248,6 +248,13 @@ let s = "ba\0d"
     @test_throws ArgumentError Base.unsafe_convert(Cstring, s)
     @test_throws ArgumentError Base.unsafe_convert(Cwstring, wstring(s))
 end
+# issue 16499: ensure Cstrings are NUL terminated
+let s = "aaaa"
+    a = pointer_to_string(pointer(s.data),2)
+    @test sizeof(a) == 2
+    b = pointer_to_string(Base.unsafe_convert(Cstring,a))
+    @test sizeof(b) == 2
+end
 
 cstrdup(s) = @static is_windows() ? ccall(:_strdup, Cstring, (Cstring,), s) : ccall(:strdup, Cstring, (Cstring,), s)
 let p = cstrdup("hello")


### PR DESCRIPTION
Should fix #16499. Two things I'm not sure about:
1. whether it is okay to use `unsafe_load` in this manner?
2. is this the appropriate place to call `String`, or should it be done in `cconvert`?
