### PR TITLE
More tests for PriorityQueue

### DIFF
--- a/test/priorityqueue.jl
+++ b/test/priorityqueue.jl
@@ -38,7 +38,18 @@ ks, vs = 1:n, rand(1:pmax, n)
 pq = PriorityQueue(ks, vs)
 priorities = Dict(zip(ks, vs))
 test_issorted!(pq, priorities)
+pq = PriorityQueue(ks, vs)
+lowpri = findmin(vs)
+@test peek(pq)[2] == pq[ks[lowpri[2]]]
 
+# building from two lists - error throw
+ks, vs = 1:n+1, rand(1:pmax, n)
+@test_throws ArgumentError PriorityQueue(ks, vs)
+
+#enqueue error throw
+ks, vs = 1:n, rand(1:pmax, n)
+pq = PriorityQueue(ks, vs)
+@test_throws ArgumentError enqueue!(pq, 1, 10)
 
 # enqueing via enqueue!
 pq = PriorityQueue()


### PR DESCRIPTION
Some error throws were untested, and so was `peek`.
