### PR TITLE
RFC: Download and build Polly when USE_POLLY=1

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -6,10 +6,19 @@ LLVM_GIT_URL_COMPILER_RT ?= $(LLVM_GIT_URL_BASE)/compiler-rt.git
 LLVM_GIT_URL_LLDB ?= $(LLVM_GIT_URL_BASE)/lldb.git
 LLVM_GIT_URL_LIBCXX ?= $(LLVM_GIT_URL_BASE)/libcxx.git
 LLVM_GIT_URL_LIBCXXABI ?= $(LLVM_GIT_URL_BASE)/libcxxabi.git
+LLVM_GIT_URL_POLLY ?= $(LLVM_GIT_URL_BASE)/polly.git
 
 ifeq ($(BUILD_LLDB), 1)
 BUILD_LLVM_CLANG := 1
 # because it's a build requirement
+endif
+
+ifeq ($(USE_POLLY),1)
+ifeq ($(USE_SYSTEM_LLVM),0)
+ifneq ($(LLVM_VER),svn)
+$(error USE_POLLY=1 requires LLVM_VER=svn)
+endif
+endif
 endif
 
 ifeq ($(LLVM_DEBUG),1)
@@ -379,6 +388,16 @@ ifneq ($(LLVM_GIT_VER_LLDB),)
 		git checkout $(LLVM_GIT_VER_LLDB))
 endif # LLVM_GIT_VER_CLANG
 endif # BUILD_LLDB
+ifeq ($(USE_POLLY),1)
+	([ ! -d $(LLVM_SRC_DIR)/tools/polly ] && \
+		git clone $(LLVM_GIT_URL_POLLY) $(LLVM_SRC_DIR)/tools/polly  ) || \
+		(cd $(LLVM_SRC_DIR)/tools/polly  && \
+		git pull --ff-only)
+ifneq ($(LLVM_GIT_VER_POLLY),)
+	(cd $(LLVM_SRC_DIR)/tools/polly && \
+		git checkout $(LLVM_GIT_VER_POLLY))
+endif # LLVM_GIT_VER_POLLY
+endif # USE_POLLY
 endif # LLVM_VER
 	touch -c $@
 
@@ -521,4 +540,7 @@ update-llvm:
 	([ -d "$(LLVM_SRC_DIR)/tools/clang"  ] || exit 0;          cd $(LLVM_SRC_DIR)/tools/clang; git pull --ff-only)
 	([ -d "$(LLVM_SRC_DIR)/projects/compiler-rt" ] || exit 0;  cd $(LLVM_SRC_DIR)/projects/compiler-rt; git pull --ff-only)
 	([ -d "$(LLVM_SRC_DIR)/tools/lldb" ] || exit 0;            cd $(LLVM_SRC_DIR)/tools/lldb; git pull --ff-only)
+ifeq ($(USE_POLLY),1)
+	([ -d "$(LLVM_SRC_DIR)/tools/polly" ] || exit 0;           cd $(LLVM_SRC_DIR)/tools/polly; git pull --ff-only)
+endif
 endif


### PR DESCRIPTION
This enables the build process to automatically download and build Polly. An earlier version of this functionality has already been part of #16531, but as proposed by @tkelman I've set up this separate PR for it.

In its current state, this PR allows to enable Polly more easily - it only requires the following lines in a `Make.user` file and its no longer needed to download/build Polly+LLVM yourself:

```
USE_POLLY:=1
LLVM_VER:=svn
```

As you can see, it is currently required to use the svn version of LLVM for this. However, if desired I can generalize this and test whether it is possible to use older versions of Polly/LLVM as well here (so far this was not my primary focus for this).

If there's anything that's unclear or if there's something important that I missed, I'll be glad about questions/comments/advice.
@tobig @vtjnash @timholy 
