### PR TITLE
Check for socket close condition when reading cookie/version

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1040,6 +1040,10 @@ end
 function process_hdr(s, validate_cookie)
     if validate_cookie
         cookie = read(s, HDR_COOKIE_LEN)
+        if length(cookie) < HDR_COOKIE_LEN
+            error("Cookie read failed. Connection closed by peer.")
+        end
+
         self_cookie = cluster_cookie()
         for i in 1:HDR_COOKIE_LEN
             if UInt8(self_cookie[i]) != cookie[i]
@@ -1051,7 +1055,12 @@ function process_hdr(s, validate_cookie)
     # When we have incompatible julia versions trying to connect to each other,
     # and can be detected, raise an appropriate error.
     # For now, just return the version.
-    return VersionNumber(strip(String(read(s, HDR_VERSION_LEN))))
+    version = read(s, HDR_VERSION_LEN)
+    if length(version) < HDR_VERSION_LEN
+        error("Version read failed. Connection closed by peer.")
+    end
+
+    return VersionNumber(strip(String(version)))
 end
 
 function handle_msg(msg::CallMsg{:call}, r_stream, w_stream, version)


### PR DESCRIPTION
Adds a check to see if the required number of bytes have been read for cookie/version. Currently, the absence of a check leads to a misleading error message. Ref: https://github.com/JuliaParallel/ClusterManagers.jl/pull/37#issuecomment-223278398 
