### PR TITLE
more accurate names for identifiers that refer to `Array{Any}`s

### DIFF
--- a/doc/devdocs/object.rst
+++ b/doc/devdocs/object.rst
@@ -148,7 +148,7 @@ Arrays::
     jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
     jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc);
     jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z);
-    jl_array_t *jl_alloc_array_ptr_1d(size_t n);
+    jl_array_t *jl_alloc_vec_any(size_t n);
 
 Note that many of these have alternative allocation functions for various special-purposes.
 The list here reflects the more common usages, but a more complete list can be found by reading the `julia.h header file

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -55,7 +55,7 @@ jl_datatype_t *jl_ref_type;
 jl_datatype_t *jl_pointer_type;
 jl_datatype_t *jl_void_type;
 jl_datatype_t *jl_voidpointer_type;
-jl_value_t *jl_an_empty_array_ptr=NULL;
+jl_value_t *jl_an_empty_vec_any=NULL;
 jl_value_t *jl_stackovf_exception;
 #ifdef SEGV_EXCEPTION
 jl_value_t *jl_segv_exception;
@@ -319,7 +319,7 @@ void jl_lambda_info_set_ast(jl_lambda_info_t *li, jl_value_t *ast)
     jl_value_t *ssavalue_types = jl_lam_ssavalues((jl_expr_t*)ast);
     assert(jl_is_long(ssavalue_types));
     size_t nssavalue = jl_unbox_long(ssavalue_types);
-    li->slotnames = jl_alloc_array_ptr_1d(nslots);
+    li->slotnames = jl_alloc_vec_any(nslots);
     jl_gc_wb(li, li->slotnames);
     li->slottypes = jl_nothing;
     li->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
@@ -410,7 +410,7 @@ static jl_lambda_info_t *jl_instantiate_staged(jl_method_t *generator, jl_tuplet
         ex = jl_exprn(lambda_sym, 2);
 
         int nargs = func->nargs;
-        jl_array_t *argnames = jl_alloc_array_ptr_1d(nargs);
+        jl_array_t *argnames = jl_alloc_vec_any(nargs);
         jl_array_ptr_set(ex->args, 0, argnames);
         for (i = 0; i < nargs; i++)
             jl_array_ptr_set(argnames, i, jl_array_ptr_ref(func->slotnames, i));
@@ -1227,7 +1227,7 @@ JL_DLLEXPORT jl_value_t *jl_box_bool(int8_t x)
 
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
 {
-    jl_array_t *ar = n==0 ? (jl_array_t*)jl_an_empty_array_ptr : jl_alloc_array_ptr_1d(n);
+    jl_array_t *ar = n==0 ? (jl_array_t*)jl_an_empty_vec_any : jl_alloc_vec_any(n);
     JL_GC_PUSH1(&ar);
     jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
     jl_set_typeof(ex, jl_expr_type);
@@ -1242,7 +1242,7 @@ JL_CALLABLE(jl_f__expr)
 {
     JL_NARGSV(Expr, 1);
     JL_TYPECHK(Expr, symbol, args[0]);
-    jl_array_t *ar = jl_alloc_array_ptr_1d(nargs-1);
+    jl_array_t *ar = jl_alloc_vec_any(nargs-1);
     JL_GC_PUSH1(&ar);
     for(size_t i=0; i < nargs-1; i++)
         jl_array_ptr_set(ar, i, args[i+1]);

--- a/src/array.c
+++ b/src/array.c
@@ -384,7 +384,7 @@ JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str)
     return jl_pchar_to_string(str, strlen(str));
 }
 
-JL_DLLEXPORT jl_array_t *jl_alloc_array_ptr_1d(size_t n)
+JL_DLLEXPORT jl_array_t *jl_alloc_vec_any(size_t n)
 {
     return jl_alloc_array_1d(jl_array_any_type, n);
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -92,7 +92,7 @@ static void jl_ast_preserve(fl_context_t *fl_ctx, jl_value_t *obj)
     assert(ctx->roots);
     jl_array_t *roots = *ctx->roots;
     if (!roots) {
-        roots = *ctx->roots = jl_alloc_array_ptr_1d(1);
+        roots = *ctx->roots = jl_alloc_vec_any(1);
         jl_array_ptr_set(roots, 0, obj);
     }
     else {
@@ -342,8 +342,8 @@ static jl_svec_t *full_svec(fl_context_t *fl_ctx, value_t e, int expronly)
 static jl_value_t *full_list(fl_context_t *fl_ctx, value_t e, int expronly)
 {
     size_t ln = llength(e);
-    if (ln == 0) return jl_an_empty_array_ptr;
-    jl_array_t *ar = jl_alloc_array_ptr_1d(ln);
+    if (ln == 0) return jl_an_empty_vec_any;
+    jl_array_t *ar = jl_alloc_vec_any(ln);
     JL_GC_PUSH1(&ar);
     size_t i=0;
     while (iscons(e)) {
@@ -358,8 +358,8 @@ static jl_value_t *full_list(fl_context_t *fl_ctx, value_t e, int expronly)
 static jl_value_t *full_list_of_lists(fl_context_t *fl_ctx, value_t e, int expronly)
 {
     size_t ln = llength(e);
-    if (ln == 0) return jl_an_empty_array_ptr;
-    jl_array_t *ar = jl_alloc_array_ptr_1d(ln);
+    if (ln == 0) return jl_an_empty_vec_any;
+    jl_array_t *ar = jl_alloc_vec_any(ln);
     JL_GC_PUSH1(&ar);
     size_t i=0;
     while (iscons(e)) {
@@ -470,7 +470,7 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
             e = cdr_(e);
 
             value_t ee = car_(e);
-            vinf = jl_alloc_array_ptr_1d(3);
+            vinf = jl_alloc_vec_any(3);
             jl_array_ptr_set(vinf, 0, full_list_of_lists(fl_ctx, car_(ee), eo));
             ee = cdr_(ee);
             jl_array_ptr_set(vinf, 1, full_list_of_lists(fl_ctx, car_(ee), eo));
@@ -565,7 +565,7 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
         JL_GC_PUSH1(&ex);
         // allocate a fresh args array for empty exprs passed to macros
         if (eo && n == 0) {
-            ex->args = jl_alloc_array_ptr_1d(0);
+            ex->args = jl_alloc_vec_any(0);
             jl_gc_wb(ex, ex->args);
         }
         for(i=0; i < n; i++) {
@@ -860,12 +860,12 @@ jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr)
 {
     // `(lambda () (() () () ()) ,expr)
     jl_expr_t *le=NULL, *bo=NULL; jl_value_t *vi=NULL;
-    jl_value_t *mt = jl_an_empty_array_ptr;
+    jl_value_t *mt = jl_an_empty_vec_any;
     jl_lambda_info_t *li = NULL;
     JL_GC_PUSH4(&le, &vi, &bo, &li);
     le = jl_exprn(lambda_sym, 3);
     jl_array_ptr_set(le->args, 0, mt);
-    vi = (jl_value_t*)jl_alloc_array_ptr_1d(3);
+    vi = (jl_value_t*)jl_alloc_vec_any(3);
     jl_array_ptr_set(vi, 0, mt);
     jl_array_ptr_set(vi, 1, mt);
     // front end always wraps toplevel exprs with ssavalues in (thunk (lambda () ...))
@@ -952,7 +952,7 @@ JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr)
         JL_GC_PUSH2(&ne, &expr);
         ne = jl_exprn(e->head, l);
         if (l == 0) {
-            ne->args = jl_alloc_array_ptr_1d(0);
+            ne->args = jl_alloc_vec_any(0);
             jl_gc_wb(ne, ne->args);
         }
         else {
@@ -968,7 +968,7 @@ JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr)
         size_t i, l = jl_array_len(a);
         jl_array_t *na = NULL;
         JL_GC_PUSH2(&na, &expr);
-        na = jl_alloc_array_ptr_1d(l);
+        na = jl_alloc_vec_any(l);
         for(i=0; i < l; i++)
             jl_array_ptr_set(na, i, jl_copy_ast(jl_array_ptr_ref(a,i)));
         JL_GC_POP();

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1864,7 +1864,7 @@ static void jl_add_linfo_root(jl_lambda_info_t *li, jl_value_t *val)
     JL_GC_PUSH1(&val);
     jl_method_t *m = li->def;
     if (m->roots == NULL) {
-        m->roots = jl_alloc_array_ptr_1d(1);
+        m->roots = jl_alloc_vec_any(1);
         jl_gc_wb(m, m->roots);
         jl_array_ptr_set(m->roots, 0, val);
     }

--- a/src/dump.c
+++ b/src/dump.c
@@ -938,7 +938,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
                         offsetof(jl_typemap_level_t, key) == 4 * sizeof(jl_value_t*) &&
                         sizeof(jl_typemap_level_t) == 5 * sizeof(jl_value_t*));
                     if (node->arg1 != (void*)jl_nothing) {
-                        jl_array_t *a = jl_alloc_array_ptr_1d(0);
+                        jl_array_t *a = jl_alloc_vec_any(0);
                         for (i = 0, l = jl_array_len(node->arg1); i < l; i++) {
                             jl_value_t *d = jl_array_ptr_ref(node->arg1, i);
                             if (d != NULL && d != jl_nothing)
@@ -950,7 +950,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
                         jl_serialize_value(s, jl_nothing);
                     }
                     if (node->targ != (void*)jl_nothing) {
-                        jl_array_t *a = jl_alloc_array_ptr_1d(0);
+                        jl_array_t *a = jl_alloc_vec_any(0);
                         for (i = 0, l = jl_array_len(node->targ); i < l; i++) {
                             jl_value_t *d = jl_array_ptr_ref(node->targ, i);
                             if (d != NULL && d != jl_nothing)
@@ -1982,7 +1982,7 @@ static void jl_restore_system_image_from_stream(ios_t *f)
     mode = MODE_SYSTEM_IMAGE;
     arraylist_new(&backref_list, 250000);
 
-    datatype_list = jl_alloc_array_ptr_1d(0);
+    datatype_list = jl_alloc_vec_any(0);
 
     jl_main_module = (jl_module_t*)jl_deserialize_value(f, NULL);
     jl_top_module = (jl_module_t*)jl_deserialize_value(f, NULL);
@@ -2084,7 +2084,7 @@ JL_DLLEXPORT jl_array_t *jl_compress_ast(jl_lambda_info_t *li, jl_array_t *ast)
     int en = jl_gc_enable(0); // Might GC
 
     if (li->def->roots == NULL) {
-        li->def->roots = jl_alloc_array_ptr_1d(0);
+        li->def->roots = jl_alloc_vec_any(0);
         jl_gc_wb(li->def, li->def->roots);
     }
     tree_literal_values = li->def->roots;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1461,8 +1461,8 @@ void pre_mark(void)
     }
 
     // invisible builtin values
-    if (jl_an_empty_array_ptr != NULL)
-        gc_push_root(jl_an_empty_array_ptr, 0);
+    if (jl_an_empty_vec_any != NULL)
+        gc_push_root(jl_an_empty_vec_any, 0);
     if (jl_module_init_order != NULL)
         gc_push_root(jl_module_init_order, 0);
     gc_push_root(jl_cfunction_list.unknown, 0);

--- a/src/init.c
+++ b/src/init.c
@@ -633,7 +633,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
     jl_start_threads();
 
-    jl_an_empty_array_ptr = (jl_value_t*)jl_alloc_array_ptr_1d(0);
+    jl_an_empty_vec_any = (jl_value_t*)jl_alloc_vec_any(0);
     jl_init_serializer();
 
     if (!jl_options.image_file) {
@@ -739,7 +739,7 @@ static void julia_save(void)
 
     jl_array_t *worklist = jl_module_init_order;
     JL_GC_PUSH1(&worklist);
-    jl_module_init_order = jl_alloc_array_ptr_1d(0);
+    jl_module_init_order = jl_alloc_vec_any(0);
     int i, l = jl_array_len(worklist);
     for (i = 0; i < l; i++) {
         jl_value_t *m = jl_arrayref(worklist, i);

--- a/src/julia.h
+++ b/src/julia.h
@@ -495,7 +495,7 @@ extern JL_DLLEXPORT jl_value_t *jl_inexact_exception;
 extern JL_DLLEXPORT jl_value_t *jl_undefref_exception;
 extern JL_DLLEXPORT jl_value_t *jl_interrupt_exception;
 extern JL_DLLEXPORT jl_datatype_t *jl_boundserror_type;
-extern JL_DLLEXPORT jl_value_t *jl_an_empty_array_ptr;
+extern JL_DLLEXPORT jl_value_t *jl_an_empty_vec_any;
 
 extern JL_DLLEXPORT jl_datatype_t *jl_bool_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_char_type;
@@ -1147,7 +1147,7 @@ JL_DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str);
 JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a);
-JL_DLLEXPORT jl_array_t *jl_alloc_array_ptr_1d(size_t n);
+JL_DLLEXPORT jl_array_t *jl_alloc_vec_any(size_t n);
 JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed

--- a/src/table.c
+++ b/src/table.c
@@ -17,7 +17,7 @@ void jl_idtable_rehash(jl_array_t **pa, size_t newsz)
     size_t sz = jl_array_len(*pa);
     size_t i;
     void **ol = (void**)(*pa)->data;
-    jl_array_t *newa = jl_alloc_array_ptr_1d(newsz);
+    jl_array_t *newa = jl_alloc_vec_any(newsz);
     // keep the original array in the original slot since we need `ol`
     // to be valid in the loop below.
     JL_GC_PUSH1(&newa);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -74,7 +74,7 @@ static void jl_module_load_time_initialize(jl_module_t *m)
     int build_mode = jl_generating_output();
     if (build_mode) {
         if (jl_module_init_order == NULL)
-            jl_module_init_order = jl_alloc_array_ptr_1d(0);
+            jl_module_init_order = jl_alloc_vec_any(0);
         jl_array_ptr_1d_push(jl_module_init_order, (jl_value_t*)m);
         jl_function_t *f = jl_module_get_initializer(m);
         if (f) {

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -215,7 +215,7 @@ static void mtcache_rehash(jl_array_t **pa, jl_value_t *parent, int8_t tparam, i
     size_t i, len = jl_array_len(*pa);
     size_t newlen = next_power_of_two(len) * 2;
     jl_value_t **d = (jl_value_t**)jl_array_data(*pa);
-    jl_array_t *n = jl_alloc_array_ptr_1d(newlen);
+    jl_array_t *n = jl_alloc_vec_any(newlen);
     for (i = 1; i <= len; i++) {
         union jl_typemap_t ml;
         ml.unknown = d[i - 1];
@@ -238,7 +238,7 @@ static void mtcache_rehash(jl_array_t **pa, jl_value_t *parent, int8_t tparam, i
                 // hash collision: start over after doubling the size again
                 i = 0;
                 newlen *= 2;
-                n = jl_alloc_array_ptr_1d(newlen);
+                n = jl_alloc_vec_any(newlen);
             }
         }
     }
@@ -278,7 +278,7 @@ static union jl_typemap_t *mtcache_hash_bp(jl_array_t **pa, jl_value_t *ty,
             // since they should have a lower priority and need to go into the sorted list
             return NULL;
         if (*pa == (void*)jl_nothing) {
-            *pa = jl_alloc_array_ptr_1d(INIT_CACHE_SIZE);
+            *pa = jl_alloc_vec_any(INIT_CACHE_SIZE);
             jl_gc_wb(parent, *pa);
         }
         while (1) {

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -522,7 +522,7 @@ static NOINLINE int true_main(int argc, char *argv[])
     if (jl_core_module != NULL) {
         jl_array_t *args = (jl_array_t*)jl_get_global(jl_core_module, jl_symbol("ARGS"));
         if (args == NULL) {
-            args = jl_alloc_array_ptr_1d(0);
+            args = jl_alloc_vec_any(0);
             JL_GC_PUSH1(&args);
             jl_set_const(jl_core_module, jl_symbol("ARGS"), (jl_value_t*)args);
             JL_GC_POP();


### PR DESCRIPTION
These changes were supposed to be part of #16515.
