### PR TITLE
reduce MAX_TUPLETYPE_LEN

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3,7 +3,7 @@
 #### parameters limiting potentially-infinite types ####
 const MAX_TYPEUNION_LEN = 3
 const MAX_TYPE_DEPTH = 7
-const MAX_TUPLETYPE_LEN  = 42
+const MAX_TUPLETYPE_LEN  = 15
 const MAX_TUPLE_DEPTH = 4
 
 const MAX_TUPLE_SPLAT = 16


### PR DESCRIPTION
A less ambitious version of #16628. The overhead of this in the compiler is quite significant, and not really worth the tradeoff of better-performing 42-dimensional arrays. This parameter controls how far inference will follow recursion, so for example a recursive variadic function might be analyzed 42 times. Eventually we will need a smarter, more surgical fix for this issue, so that we can specialize code for high-dimensional arrays while still avoiding non-termination.
