### PR TITLE
simplify creation of LambdaInfos

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -777,7 +777,7 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len,
             else if (head == line_sym)
                 jl_lineno = jl_unbox_long(jl_exprarg(form,0));
             else
-                result = jl_toplevel_eval_flex(form, 1);
+                result = jl_toplevel_eval_flex(form, 1, 1);
             JL_SIGATOMIC_BEGIN();
             ast = cdr_(ast);
         }

--- a/src/ast.c
+++ b/src/ast.c
@@ -323,54 +323,6 @@ static jl_sym_t *scmsym_to_julia(fl_context_t *fl_ctx, value_t s)
 
 static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int expronly);
 
-static jl_svec_t *full_svec(fl_context_t *fl_ctx, value_t e, int expronly)
-{
-    size_t ln = llength(e);
-    if (ln == 0) return jl_emptysvec;
-    jl_svec_t *ar = jl_alloc_svec_uninit(ln);
-    JL_GC_PUSH1(&ar);
-    size_t i=0;
-    while (iscons(e)) {
-        jl_svecset(ar, i, scm_to_julia_(fl_ctx, car_(e), expronly));
-        e = cdr_(e);
-        i++;
-    }
-    JL_GC_POP();
-    return ar;
-}
-
-static jl_value_t *full_list(fl_context_t *fl_ctx, value_t e, int expronly)
-{
-    size_t ln = llength(e);
-    if (ln == 0) return jl_an_empty_vec_any;
-    jl_array_t *ar = jl_alloc_vec_any(ln);
-    JL_GC_PUSH1(&ar);
-    size_t i=0;
-    while (iscons(e)) {
-        jl_array_ptr_set(ar, i, scm_to_julia_(fl_ctx, car_(e), expronly));
-        e = cdr_(e);
-        i++;
-    }
-    JL_GC_POP();
-    return (jl_value_t*)ar;
-}
-
-static jl_value_t *full_list_of_lists(fl_context_t *fl_ctx, value_t e, int expronly)
-{
-    size_t ln = llength(e);
-    if (ln == 0) return jl_an_empty_vec_any;
-    jl_array_t *ar = jl_alloc_vec_any(ln);
-    JL_GC_PUSH1(&ar);
-    size_t i=0;
-    while (iscons(e)) {
-        jl_array_ptr_set(ar, i, full_list(fl_ctx, car_(e),expronly));
-        e = cdr_(e);
-        i++;
-    }
-    JL_GC_POP();
-    return (jl_value_t*)ar;
-}
-
 static jl_value_t *scm_to_julia(fl_context_t *fl_ctx, value_t e, int expronly)
 {
     jl_value_t *v = NULL;
@@ -457,44 +409,6 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
         else
             sym = list_sym;
         size_t n = llength(e)-1;
-        size_t i;
-        if (sym == lambda_sym) {
-            jl_expr_t *ex = jl_exprn(lambda_sym, n);
-            jl_svec_t *tvars = NULL;
-            jl_array_t *vinf = NULL;
-            jl_lambda_info_t *nli = NULL;
-            JL_GC_PUSH4(&ex, &tvars, &vinf, &nli);
-            e = cdr_(e);
-            value_t largs = car_(e);
-            jl_array_ptr_set(ex->args, 0, full_list(fl_ctx, largs, eo));
-            e = cdr_(e);
-
-            value_t ee = car_(e);
-            vinf = jl_alloc_vec_any(3);
-            jl_array_ptr_set(vinf, 0, full_list_of_lists(fl_ctx, car_(ee), eo));
-            ee = cdr_(ee);
-            jl_array_ptr_set(vinf, 1, full_list_of_lists(fl_ctx, car_(ee), eo));
-            ee = cdr_(ee);
-            jl_array_ptr_set(vinf, 2, isfixnum(car_(ee)) ?
-                       jl_box_long(numval(car_(ee))) :
-                       full_list(fl_ctx,car_(ee),eo));
-            ee = cdr_(ee);
-            tvars = full_svec(fl_ctx, car_(ee), eo);
-            assert(!iscons(cdr_(ee)));
-            jl_array_ptr_set(ex->args, 1, vinf);
-            e = cdr_(e);
-
-            for(i=2; i < n; i++) {
-                assert(iscons(e));
-                jl_array_ptr_set(ex->args, i, scm_to_julia_(fl_ctx, car_(e), eo));
-                e = cdr_(e);
-            }
-            nli = jl_new_lambda_info_uninit(tvars);
-            jl_lambda_info_set_ast(nli, (jl_value_t*)ex);
-            JL_GC_POP();
-            return (jl_value_t*)nli;
-        }
-
         if (issymbol(hd))
             e = cdr_(e);
         else
@@ -561,21 +475,24 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
         else if (sym == inert_sym && !iscons(car_(e))) {
             sym = quote_sym;
         }
-        jl_expr_t *ex = jl_exprn(sym, n);
+        jl_value_t *ex = (jl_value_t*)jl_exprn(sym, n);
         JL_GC_PUSH1(&ex);
         // allocate a fresh args array for empty exprs passed to macros
         if (eo && n == 0) {
-            ex->args = jl_alloc_vec_any(0);
-            jl_gc_wb(ex, ex->args);
+            ((jl_expr_t*)ex)->args = jl_alloc_vec_any(0);
+            jl_gc_wb(ex, ((jl_expr_t*)ex)->args);
         }
+        size_t i;
         for(i=0; i < n; i++) {
             assert(iscons(e));
-            jl_array_ptr_set(ex->args, i, scm_to_julia_(fl_ctx, car_(e), eo));
+            jl_array_ptr_set(((jl_expr_t*)ex)->args, i, scm_to_julia_(fl_ctx, car_(e), eo));
             e = cdr_(e);
         }
+        if (sym == lambda_sym)
+            ex = (jl_value_t*)jl_new_lambda_info_from_ast((jl_expr_t*)ex);
         JL_GC_POP();
         if (sym == list_sym)
-            return (jl_value_t*)ex->args;
+            return (jl_value_t*)((jl_expr_t*)ex)->args;
         return (jl_value_t*)ex;
     }
     if (iscprim(e) && cp_class((cprim_t*)ptr(e)) == fl_ctx->wchartype) {
@@ -865,11 +782,12 @@ jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr)
     JL_GC_PUSH4(&le, &vi, &bo, &li);
     le = jl_exprn(lambda_sym, 3);
     jl_array_ptr_set(le->args, 0, mt);
-    vi = (jl_value_t*)jl_alloc_vec_any(3);
+    vi = (jl_value_t*)jl_alloc_vec_any(4);
     jl_array_ptr_set(vi, 0, mt);
     jl_array_ptr_set(vi, 1, mt);
     // front end always wraps toplevel exprs with ssavalues in (thunk (lambda () ...))
     jl_array_ptr_set(vi, 2, jl_box_long(0));
+    jl_array_ptr_set(vi, 3, mt);
     jl_array_ptr_set(le->args, 1, vi);
     if (!jl_is_expr(expr) || ((jl_expr_t*)expr)->head != body_sym) {
         bo = jl_exprn(body_sym, 1);
@@ -878,54 +796,12 @@ jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr)
         expr = (jl_value_t*)bo;
     }
     jl_array_ptr_set(le->args, 2, expr);
-    li = jl_new_lambda_info_uninit(jl_emptysvec);
-    jl_lambda_info_set_ast(li, (jl_value_t*)le);
+    li = jl_new_lambda_info_from_ast(le);
     JL_GC_POP();
     return li;
 }
 
 // syntax tree accessors
-
-// get array of formal argument expressions
-jl_array_t *jl_lam_args(jl_expr_t *l)
-{
-    assert(jl_is_expr(l));
-    assert(l->head == lambda_sym);
-    jl_value_t *ae = jl_exprarg(l,0);
-    assert(jl_is_array(ae));
-    return (jl_array_t*)ae;
-}
-
-// get array of var info records (for args and locals)
-jl_array_t *jl_lam_vinfo(jl_expr_t *l)
-{
-    assert(jl_is_expr(l));
-    jl_value_t *le = jl_exprarg(l, 1);
-    assert(jl_is_array(le));
-    jl_value_t *ll = jl_array_ptr_ref(le, 0);
-    assert(jl_is_array(ll));
-    return (jl_array_t*)ll;
-}
-
-// get array of types for SSAValues, or its length (if not type-inferred)
-jl_value_t *jl_lam_ssavalues(jl_expr_t *l)
-{
-    assert(jl_is_expr(l));
-    jl_value_t *le = jl_exprarg(l, 1);
-    assert(jl_is_array(le));
-    assert(jl_array_len(le) == 3);
-    return jl_array_ptr_ref(le, 2);
-}
-
-// get array of body forms
-jl_expr_t *jl_lam_body(jl_expr_t *l)
-{
-    assert(jl_is_expr(l));
-    jl_value_t *be = jl_exprarg(l, 2);
-    assert(jl_is_expr(be));
-    assert(((jl_expr_t*)be)->head == body_sym);
-    return (jl_expr_t*)be;
-}
 
 JL_DLLEXPORT int jl_is_rest_arg(jl_value_t *ex)
 {

--- a/src/gf.c
+++ b/src/gf.c
@@ -141,7 +141,7 @@ jl_value_t *jl_mk_builtin_func(const char *name, jl_fptr_t fptr)
 {
     jl_sym_t *sname = jl_symbol(name);
     jl_value_t *f = jl_new_generic_function_with_supertype(sname, jl_core_module, jl_builtin_type, 0);
-    jl_lambda_info_t *li = jl_new_lambda_info_uninit(jl_emptysvec);
+    jl_lambda_info_t *li = jl_new_lambda_info_uninit();
     li->fptr = fptr;
     // TODO jb/functions: what should li->ast be?
     li->code = (jl_array_t*)jl_an_empty_vec_any; jl_gc_wb(li, li->code);

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -85,8 +85,8 @@
                              (scope-block
                               (block ,@(map (lambda (v) `(implicit-global ,v)) gv)
                                      ,ex))))))
-          (if (and (null? (car (caddr th)))
-                   (= 0 (caddr (caddr th))))
+          (if (and (null? (cdadr (caddr th)))
+                   (= 0 (cadddr (caddr th))))
               ;; if no locals, return just body of function
               (cadddr th)
               `(thunk ,th))))))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1003,7 +1003,8 @@ JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...);
 JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
                                         uint32_t na);
 JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
-JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(jl_svec_t *sparams);
+JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(void);
+JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_from_ast(jl_expr_t *ast);
 JL_DLLEXPORT jl_method_t *jl_new_method(jl_lambda_info_t *definition, jl_sym_t *name, jl_tupletype_t *sig, jl_svec_t *tvars, int isstaged);
 JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...);
 JL_DLLEXPORT jl_svec_t *jl_svec1(void *a);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -191,7 +191,7 @@ jl_function_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module);
 jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
-jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast);
+jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded);
 jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex,
                                      int delay_warn);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -205,7 +205,6 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
                            jl_lambda_info_t *li, int sparams, int allow_alloc);
 int jl_is_toplevel_only_expr(jl_value_t *e);
 void jl_type_infer(jl_lambda_info_t *li, int force);
-void jl_lambda_info_set_ast(jl_lambda_info_t *li, jl_value_t *ast);
 jl_value_t *jl_call_scm_on_ast(char *funcname, jl_value_t *expr);
 
 jl_lambda_info_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *types,
@@ -213,13 +212,6 @@ jl_lambda_info_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *t
 jl_lambda_info_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache);
 jl_value_t *jl_gf_invoke(jl_tupletype_t *types, jl_value_t **args, size_t nargs);
 
-jl_array_t *jl_lam_args(jl_expr_t *l);
-jl_array_t *jl_lam_vinfo(jl_expr_t *l);
-jl_array_t *jl_lam_capt(jl_expr_t *l);
-jl_value_t *jl_lam_ssavalues(jl_expr_t *l);
-jl_array_t *jl_lam_staticparams(jl_expr_t *l);
-int jl_lam_vars_captured(jl_expr_t *ast);
-jl_expr_t *jl_lam_body(jl_expr_t *l);
 jl_value_t *jl_first_argument_datatype(jl_value_t *argtypes);
 int jl_has_intrinsics(jl_lambda_info_t *li, jl_value_t *v, jl_module_t *m);
 


### PR DESCRIPTION
This removes a bunch of redundant code for translating the output of lowering to LambdaInfo objects.

It was also odd that `sparam_syms` was the one argument to `jl_new_lambda_info_uninit`, so it now takes 0 arguments.
