### PR TITLE
Set Symbol's to GC_MARKED on allocation.

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -32,11 +32,6 @@ extern "C" {
 
 // manipulating mark bits
 
-#define GC_CLEAN 0 // freshly allocated
-#define GC_MARKED 1 // reachable and old
-#define GC_QUEUED 2 // if it is reachable it will be marked as old
-#define GC_MARKED_NOESC (GC_MARKED | GC_QUEUED) // reachable and young
-
 #define GC_PAGE_LG2 14 // log2(size of a page)
 #define GC_PAGE_SZ (1 << GC_PAGE_LG2) // 16k
 #define GC_PAGE_OFFSET (JL_SMALL_BYTE_ALIGNMENT - (sizeof_jl_taggedvalue_t % JL_SMALL_BYTE_ALIGNMENT))

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -16,6 +16,11 @@
 extern "C" {
 #endif
 
+#define GC_CLEAN 0 // freshly allocated
+#define GC_MARKED 1 // reachable and old
+#define GC_QUEUED 2 // if it is reachable it will be marked as old
+#define GC_MARKED_NOESC (GC_MARKED | GC_QUEUED) // reachable and young
+
 // useful constants
 extern jl_methtable_t *jl_type_type_mt;
 


### PR DESCRIPTION
To avoid triggering write barriers on them.

This is effectively special cased in marking so that objects referencing symbols won't be put into remset but the write barrier will still be triggered.

I'll be shocked if this has a big impact but who knows.....
