### PR TITLE
Some hacks to make building with llvm 3.3 easier

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,11 @@ include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/llvm-ver.make
 
 override CFLAGS += $(JCFLAGS)
+ifeq ($(LLVM_VER),3.3)
+override CXXFLAGS += $(JCXXFLAGS) -std=c++11
+else
 override CXXFLAGS += $(JCXXFLAGS)
+endif
 override CPPFLAGS += $(JCPPFLAGS)
 
 # -I BUILDDIR comes before -I SRCDIR so that the user can override <options.h> on a per-build-directory basis

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4082,7 +4082,11 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
 
     std::stringstream funcName;
     // try to avoid conflicts in the global symbol table
-    funcName << "julia_" << ctx.name;
+    funcName << "julia_" << ctx.name
+#if (defined(_OS_LINUX_) && !defined(LLVM34))
+        + (ctx.name[0] == '@') ? 1 : 0
+#endif
+    ;
 
     Function *fwrap = NULL;
     funcName << "_" << globalUnique++;


### PR DESCRIPTION
drop @ char from julia_@ symbol names on linux otherwise the linker complains
about "version node not found for symbol julia_@stat_call_..."

add `-std=c++11` since some c++11 constructs are now used in `src`,
but llvm 3.3's llvm-config doesn't add the `-std=c++11` flag

there are a bunch of test failures that we could also make llvm-version-conditional, but this at least makes things easier to build

edit: initially had a travis timeout because I cleared out the cache for llvm build changes, restarted now that the cache has been repopulated - old log backed up at https://gist.github.com/ec81a93f4041a45c0aed3f8fd2cca14a, it's pretty long and uninteresting
