### PR TITLE
Better backtick behaviour

### DIFF
--- a/base/markdown/Common/Common.jl
+++ b/base/markdown/Common/Common.jl
@@ -6,5 +6,5 @@ include("inline.jl")
 @flavor common [list, indentcode, blockquote, hashheader, horizontalrule,
                 paragraph,
 
-                linebreak, escapes, inline_tex, inline_code,
+                linebreak, escapes, inline_code,
                 asterisk_bold, asterisk_italic, image, footnote, link]

--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -61,5 +61,5 @@ end
 @flavor github [list, indentcode, blockquote, fencedcode, hashheader,
                 github_table, github_paragraph,
 
-                linebreak, escapes, en_dash, inline_tex, inline_code, asterisk_bold,
+                linebreak, escapes, en_dash, inline_code, asterisk_bold,
                 asterisk_italic, image, footnote, link]

--- a/base/markdown/Julia/Julia.jl
+++ b/base/markdown/Julia/Julia.jl
@@ -10,5 +10,5 @@ include("interp.jl")
 @flavor julia [blocktex, blockinterp, hashheader, list, indentcode, fencedcode,
                blockquote, github_table, horizontalrule, setextheader, paragraph,
 
-               linebreak, escapes, tex, interp, en_dash, inline_tex, inline_code,
+               linebreak, escapes, tex, interp, en_dash, inline_code,
                asterisk_bold, asterisk_italic, image, footnote, link]

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1983,7 +1983,7 @@ set of functions in future releases.
 
    Computes the (upper if ``uplo = U``\ , lower if ``uplo = L``\ ) pivoted Cholesky decomposition of positive-definite matrix ``A`` with a user-set tolerance ``tol``\ . ``A`` is overwritten by its Cholesky decomposition.
 
-   Returns ``A``\ , the pivots ``piv``\ , the rank of ``A``\ , and an ``info`` code. If ``info = 0``\ , the factorization succeeded. If ``info = i > 0 `, then `A`` is indefinite or rank-deficient.
+   Returns ``A``\ , the pivots ``piv``\ , the rank of ``A``\ , and an ``info`` code. If ``info = 0``\ , the factorization succeeded. If ``info = i > 0``\ , then ``A`` is indefinite or rank-deficient.
 
 .. function:: ptsv!(D, E, B)
 

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -409,3 +409,57 @@ let in_dollars =
     @test latex_doc == dollars
     @test latex_doc == backticks
 end
+
+# Nested backticks for inline code and math.
+
+let t_1 = "`code` ``math`` ```code``` ````math```` `````code`````",
+    t_2 = "`` `math` `` ``` `code` ``code`` ``` ```` `math` ``math`` ```math``` ````",
+    t_3 = "`` ` `` ``` `` ` `` ` ` ```",
+    t_4 = """`code
+    over several
+    lines` ``math
+    over several
+    lines`` ``math with
+    ` some extra ` ` backticks`
+    ``""",
+    t_5 = "``code at end of string`",
+    t_6 = "```math at end of string``"
+    @test Markdown.parse(t_1) == MD(Paragraph([
+        Code("code"),
+        " ",
+        LaTeX("math"),
+        " ",
+        Code("code"),
+        " ",
+        LaTeX("math"),
+        " ",
+        Code("code"),
+    ]))
+    @test Markdown.parse(t_2) == MD(Paragraph([
+        LaTeX("`math`"),
+        " ",
+        Code("`code` ``code``"),
+        " ",
+        LaTeX("`math` ``math`` ```math```"),
+    ]))
+    @test Markdown.parse(t_3) == MD(Paragraph([
+        LaTeX("`"),
+        " ",
+        Code("`` ` `` ` `"),
+    ]))
+    @test Markdown.parse(t_4) == MD(Paragraph([
+        Code("code over several lines"),
+        " ",
+        LaTeX("math over several lines"),
+        " ",
+        LaTeX("math with ` some extra ` ` backticks`")
+    ]))
+    @test Markdown.parse(t_5) == MD(Paragraph([
+        "`",
+        Code("code at end of string"),
+    ]))
+    @test Markdown.parse(t_6) == MD(Paragraph([
+        "`",
+        LaTeX("math at end of string"),
+    ]))
+end


### PR DESCRIPTION
This extends the backtick syntax in the markdown parser to generalise the "one tick = code" and "two ticks = math" rule to "odd number of ticks = code" and "even number of ticks = math".

Doing this regains the nesting behaviour of backticks and allows both inline code and math to contain arbitrary sequences of backticks so long as enough backticks are used to wrap the code/math.

(Running `genstdlib.jl` picked up an edgecase that wasn't being parsed correctly before this change.)
