### PR TITLE
Set DestSharedLibDir when building LLVM

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -87,7 +87,7 @@ LLVM_FLAGS += --disable-profiling --enable-static $(LLVM_TARGET_FLAGS)
 LLVM_FLAGS += --disable-bindings --disable-docs --disable-libedit --disable-terminfo
 # LLVM has weird install prefixes (see llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/Makefile.config for the full list)
 # We map them here to the "normal" ones, which means just prefixing "PROJ_" to the variable name.
-LLVM_MFLAGS := PROJ_libdir=$(build_libdir) PROJ_bindir=$(build_depsbindir) PROJ_includedir=$(build_includedir)
+LLVM_MFLAGS := PROJ_libdir=$(build_libdir) PROJ_bindir=$(build_depsbindir) PROJ_includedir=$(build_includedir) DestSharedLibDir=$(build_shlibdir)
 ifeq ($(LLVM_ASSERTIONS), 1)
 LLVM_FLAGS += --enable-assertions
 LLVM_CMAKE += -DLLVM_ENABLE_ASSERTIONS:BOOL=ON


### PR DESCRIPTION
should fix #16759 - bad interaction between #16723 and #14863 on Windows

(not pushing to master because I'm double-checking in a clean build on both Windows and Linux that this works properly)

edit: works so far
