### PR TITLE
change identity comparisons to use isequal

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1494,11 +1494,11 @@ activate(m::ModalInterface, s::MIState, termbuf, term::TextTerminal) =
 
 commit_changes(t::UnixTerminal, termbuf) = write(t, takebuf_array(termbuf.out_stream))
 function transition(f::Function, s::MIState, mode)
-    if mode == :abort
+    if mode === :abort
         s.aborted = true
         return
     end
-    if mode == :reset
+    if mode === :reset
         reset_state(s)
         return
     end
@@ -1599,16 +1599,16 @@ function prompt!(term, prompt, s = init_state(term, prompt))
                 warn(e)
                 state = :done
             end
-            if state == :abort
+            if state === :abort
                 return buffer(s), false, false
-            elseif state == :done
+            elseif state === :done
                 return buffer(s), true, false
-            elseif state == :suspend
+            elseif state === :suspend
                 if is_unix()
                     return buffer(s), true, true
                 end
             else
-                @assert state == :ok
+                @assert state === :ok
             end
         end
     finally

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -377,7 +377,7 @@ end
 function mode_idx(hist::REPLHistoryProvider, mode)
     c = :julia
     for (k,v) in hist.mode_mapping
-        v == mode && (c = k)
+        isequal(v, mode) && (c = k)
     end
     return c
 end
@@ -387,7 +387,7 @@ function add_history(hist::REPLHistoryProvider, s)
     isempty(strip(str)) && return
     mode = mode_idx(hist, LineEdit.mode(s))
     !isempty(hist.history) &&
-        mode == hist.modes[end] && str == hist.history[end] && return
+        isequal(mode, hist.modes[end]) && str == hist.history[end] && return
     push!(hist.modes, mode)
     push!(hist.history, str)
     hist.history_file === nothing && return
@@ -457,13 +457,13 @@ function history_prev(s::LineEdit.MIState, hist::REPLHistoryProvider,
         save_idx::Int = hist.cur_idx)
     hist.last_idx = -1
     m = history_move(s, hist, hist.cur_idx-1, save_idx)
-    if m == :ok
+    if m === :ok
         LineEdit.move_input_start(s)
         LineEdit.reset_key_repeats(s) do
             LineEdit.move_line_end(s)
         end
         LineEdit.refresh_line(s)
-    elseif m == :skip
+    elseif m === :skip
         hist.cur_idx -= 1
         history_prev(s, hist, save_idx)
     else
@@ -481,10 +481,10 @@ function history_next(s::LineEdit.MIState, hist::REPLHistoryProvider,
         hist.last_idx = -1
     end
     m = history_move(s, hist, cur_idx+1, save_idx)
-    if m == :ok
+    if m === :ok
         LineEdit.move_input_end(s)
         LineEdit.refresh_line(s)
-    elseif m == :skip
+    elseif m === :skip
         hist.cur_idx += 1
         history_next(s, hist, save_idx)
     else
@@ -508,7 +508,7 @@ function history_move_prefix(s::LineEdit.PrefixSearchState,
     for idx in idxs
         if (idx == max_idx) || (startswith(hist.history[idx], prefix) && (hist.history[idx] != cur_response || hist.modes[idx] != LineEdit.mode(s)))
             m = history_move(s, hist, idx)
-            if m == :ok
+            if m === :ok
                 if idx == max_idx
                     # on resuming the in-progress edit, leave the cursor where the user last had it
                 elseif isempty(prefix)
@@ -520,7 +520,7 @@ function history_move_prefix(s::LineEdit.PrefixSearchState,
                 end
                 LineEdit.refresh_line(s)
                 return :ok
-            elseif m == :skip
+            elseif m === :skip
                 return history_move_prefix(s,hist,prefix,backwards,idx)
             end
         end

--- a/base/array.jl
+++ b/base/array.jl
@@ -650,7 +650,7 @@ end
 function lexcmp(a::Array{UInt8,1}, b::Array{UInt8,1})
     c = ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
               a, b, min(length(a),length(b)))
-    c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
+    return c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
 end
 
 function reverse(A::AbstractVector, s=1, n=length(A))
@@ -664,7 +664,7 @@ function reverse(A::AbstractVector, s=1, n=length(A))
     for i = n+1:length(A)
         B[i] = A[i]
     end
-    B
+    return B
 end
 reverseind(a::AbstractVector, i::Integer) = length(a) + 1 - i
 
@@ -680,7 +680,7 @@ function reverse!(v::AbstractVector, s=1, n=length(v))
         v[i], v[r] = v[r], v[i]
         r -= 1
     end
-    v
+    return v
 end
 
 function vcat{T}(arrays::Vector{T}...)
@@ -712,7 +712,7 @@ function hcat{T}(V::Vector{T}...)
             throw(DimensionMismatch("vectors must have same lengths"))
         end
     end
-    [ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]
+    return [ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]
 end
 
 hcat(A::Matrix...) = typed_hcat(promote_eltype(A...), A...)
@@ -764,7 +764,7 @@ function findprev(A, start::Integer)
     for i = start:-1:1
         A[i] != 0 && return i
     end
-    0
+    return 0
 end
 findlast(A) = findprev(A, length(A))
 
@@ -773,7 +773,7 @@ function findprev(A, v, start::Integer)
     for i = start:-1:1
         A[i] == v && return i
     end
-    0
+    return 0
 end
 findlast(A, v) = findprev(A, v, length(A))
 
@@ -782,7 +782,7 @@ function findprev(testf::Function, A, start::Integer)
     for i = start:-1:1
         testf(A[i]) && return i
     end
-    0
+    return 0
 end
 findlast(testf::Function, A) = findprev(testf, A, length(A))
 
@@ -797,7 +797,7 @@ function find(testf::Function, A)
     end
     I = Array{Int}(length(tmpI))
     copy!(I, tmpI)
-    I
+    return I
 end
 
 function find(A)

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -116,9 +116,17 @@ function DateFormat(f::AbstractString, locale::AbstractString="english")
         last_offset = m.offset + width
     end
 
-    tran = last_offset > endof(f) ? r"(?=\s|$)" : replace(f[last_offset:end], r"\\(.)", s"\1")
     if !isempty(params)
-        slot = tran == "" ? FixedWidthSlot(params...) : DelimitedSlot(params..., tran)
+        if last_offset > endof(f)
+            slot = DelimitedSlot(params..., r"(?=\s|$)")
+        else
+            tran = replace(f[last_offset:end], r"\\(.)", s"\1")
+            if tran == ""
+                slot = FixedWidthSlot(params...)
+            else
+                slot = DelimitedSlot(params..., tran)
+            end
+        end
         push!(slots,slot)
     end
 
@@ -165,7 +173,7 @@ function parse(x::AbstractString,df::DateFormat)
     cursor = 1
     for slot in df.slots
         cursor, pe = getslot(x,slot,df.locale,cursor)
-        pe != nothing && (isa(pe,Period) ? push!(periods,pe) : push!(extra,pe))
+        pe !== nothing && (isa(pe,Period) ? push!(periods,pe) : push!(extra,pe))
         cursor > endof(x) && break
     end
     sort!(periods,rev=true,lt=periodisless)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -9,15 +9,7 @@ haskey(d::Associative, k) = in(k,keys(d))
 function in(p::Pair, a::Associative, valcmp=(==))
     v = get(a,p[1],secret_table_token)
     if !is(v, secret_table_token)
-        if valcmp === is
-            is(v, p[2]) && return true
-        elseif valcmp === (==)
-            ==(v, p[2]) && return true
-        elseif valcmp === isequal
-            isequal(v, p[2]) && return true
-        else
-            valcmp(v, p[2]) && return true
-        end
+        valcmp(v, p[2]) && return true
     end
     return false
 end
@@ -30,7 +22,7 @@ end
 
 function summary(t::Associative)
     n = length(t)
-    string(typeof(t), " with ", n, (n==1 ? " entry" : " entries"))
+    return string(typeof(t), " with ", n, (n==1 ? " entry" : " entries"))
 end
 
 function _truncate_at_width_or_chars(str, width, chars="", truncmark="…")
@@ -964,15 +956,7 @@ function in(key_value::Pair, dict::ImmutableDict, valcmp=(==))
     key, value = key_value
     while isdefined(dict, :parent)
         if dict.key == key
-            if valcmp === is
-                is(value, dict.value) && return true
-            elseif valcmp === (==)
-                ==(value, dict.value) && return true
-            elseif valcmp === isequal
-                isequal(value, dict.value) && return true
-            else
-                valcmp(value, dict.value) && return true
-            end
+            valcmp(value, dict.value) && return true
         end
         dict = dict.parent
     end

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -393,8 +393,8 @@ const keywords = Dict{Symbol, DocStr}()
 isdoc(s::AbstractString) = true
 
 isdoc(x) = isexpr(x, :string) ||
-    (isexpr(x, :macrocall) && x.args[1] == Symbol("@doc_str")) ||
-    (isexpr(x, :call) && x.args[1] == Base.Markdown.doc_str)
+    (isexpr(x, :macrocall) && x.args[1] === Symbol("@doc_str")) ||
+    (isexpr(x, :call) && x.args[1] === Base.Markdown.doc_str)
 
 function unblock(ex)
     isexpr(ex, :block) || return ex
@@ -498,7 +498,7 @@ function moduledoc(meta, def, def′)
     docex = Expr(:call, doc!, bindingexpr(name),
         docexpr(lazy_iterpolate(meta), metadata(name))
     )
-    if def == nothing
+    if def === nothing
         esc(:(eval($name, $(quot(docex)))))
     else
         def = unblock(def)

--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -141,7 +141,7 @@ function repl(s::Symbol)
     end
 end
 
-isregex(x) = isexpr(x, :macrocall, 2) && x.args[1] == Symbol("@r_str") && !isempty(x.args[2])
+isregex(x) = isexpr(x, :macrocall, 2) && x.args[1] === Symbol("@r_str") && !isempty(x.args[2])
 
 repl(ex::Expr) = isregex(ex) ? :(apropos($ex)) : _repl(ex)
 
@@ -154,7 +154,7 @@ function _repl(x)
     if isexpr(x, :call)
         # Handles function call syntax where each argument is an atom (symbol, number, etc.)
         t = Base.gen_call_with_extracted_types(doc, x)
-        (isexpr(t, :call, 3) && t.args[1] == doc) && (docs = t)
+        (isexpr(t, :call, 3) && t.args[1] === doc) && (docs = t)
     end
     if isfield(x)
         quote

--- a/base/error.jl
+++ b/base/error.jl
@@ -80,7 +80,7 @@ function retry(f::Function, retry_on::Function=DEFAULT_RETRY_ON; n=DEFAULT_RETRY
             try
                 return f(args...)
             catch e
-                if i > n || try retry_on(e) end != true
+                if i > n || try retry_on(e) end !== true
                     rethrow(e)
                 end
             end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3152,7 +3152,7 @@ end
 # boundscheck context in the method body
 function inbounds_meta_elim_pass!(code::Array{Any,1})
     if findfirst(x -> isa(x, Expr) &&
-                      ((x.head === :inbounds && x.args[1] == true) || x.head === :boundscheck),
+                      ((x.head === :inbounds && x.args[1] === true) || x.head === :boundscheck),
                  code) == 0
         filter!(x -> !(isa(x, Expr) && x.head === :inbounds), code)
     end

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -535,7 +535,7 @@ end
 
 function test_existing_ref(r::AbstractRemoteRef)
     found = getkey(client_refs, r, false)
-    if !is(found,false)
+    if found !== false
         if client_refs[r] == true
             @assert r.where > 0
             if isa(r, Future) && isnull(found.v) && !isnull(r.v)
@@ -640,7 +640,7 @@ function del_client(pg, id, client)
 # 14445 is fixed.
     @async begin
         rv = get(pg.refs, id, false)
-        if rv != false
+        if rv !== false
             delete!(rv.clientset, client)
             if isempty(rv.clientset)
                 delete!(pg.refs, id)
@@ -1366,7 +1366,7 @@ function setup_launched_worker(manager, wconfig, launched_q)
     # process on the remote machine, with a request to start additional workers of the
     # same type. This is done by setting an appropriate value to `WorkerConfig.cnt`.
     cnt = get(wconfig.count, 1)
-    if cnt == :auto
+    if cnt === :auto
         cnt = get(wconfig.environ)[:cpu_cores]
     end
     cnt = cnt - 1   # Removing self from the requested number
@@ -1757,12 +1757,12 @@ function terminate_all_workers()
 
     if nprocs() > 1
         ret = rmprocs(workers(); waitfor=0.5)
-        if ret != :ok
+        if ret !== :ok
             warn("Forcibly interrupting busy workers")
             # Might be computation bound, interrupt them and try again
             interrupt(workers())
             ret = rmprocs(workers(); waitfor=0.5)
-            if ret != :ok
+            if ret !== :ok
                 warn("Unable to terminate all workers")
             end
         end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -628,7 +628,7 @@ end
 end
 @generated function _unsafe_setindex!(B::BitArray, X::Union{BitArray,Array}, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     N = length(I)
-    rangeexp = [I[d] == Colon ? :(1:size(B, $(d+1))) : :(I[$d]) for d = 1:N]
+    rangeexp = [I[d] === Colon ? :(1:size(B, $(d+1))) : :(I[$d]) for d = 1:N]
     quote
         idxlens = @ncall $N index_lengths B I0 d->I[d]
         @ncall $N setindex_shape_check X idxlens[1] d->idxlens[d+1]
@@ -667,7 +667,7 @@ end
 end
 @generated function _unsafe_setindex!(B::BitArray, x, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     N = length(I)
-    rangeexp = [I[d] == Colon ? :(1:size(B, $(d+1))) : :(I[$d]) for d = 1:N]
+    rangeexp = [I[d] === Colon ? :(1:size(B, $(d+1))) : :(I[$d]) for d = 1:N]
     quote
         y = Bool(x)
         idxlens = @ncall $N index_lengths B I0 d->I[d]

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -8,9 +8,22 @@ supertype(T::DataType) = T.super
 
 ## generic comparison ##
 
-==(x,y) = x === y
-
+==(x, y) = x === y
 isequal(x, y) = x == y
+
+## minimally-invasive changes to test == causing NotComparableError
+# export NotComparableError
+# =={T}(x::T, y::T) = x === y
+# immutable NotComparableError <: Exception end
+# const NotComparable = NotComparableError()
+# ==(x::ANY, y::ANY) = NotComparable
+# !(e::NotComparableError) = throw(e)
+# isequal(x, y) = (x == y) === true
+
+## alternative NotComparableError which captures context
+# immutable NotComparableError; a; b; end
+# ==(x::ANY, y::ANY) = NotComparableError(x, y)
+
 isequal(x::AbstractFloat, y::AbstractFloat) = (isnan(x) & isnan(y)) | (signbit(x) == signbit(y)) & (x == y)
 isequal(x::Real,          y::AbstractFloat) = (isnan(x) & isnan(y)) | (signbit(x) == signbit(y)) & (x == y)
 isequal(x::AbstractFloat, y::Real         ) = (isnan(x) & isnan(y)) | (signbit(x) == signbit(y)) & (x == y)
@@ -27,6 +40,8 @@ function !=(T::Type, S::Type)
     @_pure_meta
     !(T == S)
 end
+==(T::TypeVar, S::Type) = false
+==(T::Type, S::TypeVar) = false
 
 ## comparison fallbacks ##
 

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -176,11 +176,11 @@ function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=tru
     if raise && isa(ex,Expr) && is(ex.head,:error)
         throw(ParseError(ex.args[1]))
     end
-    if ex == ()
+    if ex === ()
         raise && throw(ParseError("end of input"))
         ex = Expr(:error, "end of input")
     end
-    ex, pos+1 # C is zero-based, Julia is 1-based
+    return ex, pos+1 # C is zero-based, Julia is 1-based
 end
 
 function parse(str::AbstractString; raise::Bool=true)

--- a/base/pmap.jl
+++ b/base/pmap.jl
@@ -94,7 +94,7 @@ function pmap(p::WorkerPool, f, c;  distributed=true, batch_size=1, on_error=not
         if retry_n > 0
             f = wrap_retry(f, retry_on, retry_n, retry_max_delay)
         end
-        if on_error != nothing
+        if on_error !== nothing
             f = wrap_on_error(f, on_error)
         end
         return collect(AsyncGenerator(f, c))
@@ -108,12 +108,12 @@ function pmap(p::WorkerPool, f, c;  distributed=true, batch_size=1, on_error=not
         # to ensure that we do not call mapped function on the same element more than retry_n.
         # This guarantee is not possible in case of worker death / network errors, wherein
         # we will retry the entire batch on a new worker.
-        if (on_error != nothing) || (retry_n > 0)
+        if (on_error !== nothing) || (retry_n > 0)
             f = wrap_on_error(f, (x,e)->BatchProcessingError(x,e); capture_data=true)
         end
         f = wrap_batch(f, p, on_error)
         results = collect(flatten(AsyncGenerator(f, batches)))
-        if (on_error != nothing) || (retry_n > 0)
+        if (on_error !== nothing) || (retry_n > 0)
             process_batch_errors!(p, f_orig, results, on_error, retry_on, retry_n, retry_max_delay)
         end
         return results
@@ -146,7 +146,7 @@ function wrap_batch(f, p, on_error)
         try
             remotecall_fetch(f, p, batch)
         catch e
-            if on_error != nothing
+            if on_error !== nothing
                 return Any[BatchProcessingError(batch[i], e) for i in 1:length(batch)]
             else
                 rethrow(e)
@@ -159,7 +159,7 @@ asyncmap_batch(f) = batch -> asyncmap(f, batch)
 
 function process_batch_errors!(p, f, results, on_error, retry_on, retry_n, retry_max_delay)
     # Handle all the ones in error in another pmap, with batch size set to 1
-    if (on_error != nothing) || (retry_n > 0)
+    if (on_error !== nothing) || (retry_n > 0)
         reprocess = []
         for (idx, v) in enumerate(results)
             if isa(v, BatchProcessingError)
@@ -177,7 +177,7 @@ function process_batch_errors!(p, f, results, on_error, retry_on, retry_n, retry
                                                     retry_on=retry_on,
                                                     retry_n=retry_n,
                                                     retry_max_delay=retry_max_delay)
-            elseif on_error != nothing
+            elseif on_error !== nothing
                 error_processed = map(on_error, exceptions)
             else
                 throw(CompositeException(exceptions))

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -734,7 +734,7 @@ function gen_g(flags::String, width::Int, precision::Int, c::Char)
     # print space padding
     if !('-' in flags) && !('0' in flags)
         padexpr = dynamic_pad(:width, :padding, ' ')
-        push!(blk.args, :(if padding != nothing
+        push!(blk.args, :(if padding !== nothing
                           $padexpr; end))
     end
     # print sign
@@ -744,7 +744,7 @@ function gen_g(flags::String, width::Int, precision::Int, c::Char)
     # print zero padding
     if !('-' in flags) && '0' in flags
         padexpr = dynamic_pad(:width, :padding, '0')
-        push!(blk.args, :(if padding != nothing
+        push!(blk.args, :(if padding !== nothing
                           $padexpr; end))
     end
     # finally print value
@@ -752,7 +752,7 @@ function gen_g(flags::String, width::Int, precision::Int, c::Char)
     # print space padding
     if '-' in flags
         padexpr = dynamic_pad(:width, :padding, ' ')
-        push!(blk.args, :(if padding != nothing
+        push!(blk.args, :(if padding !== nothing
                           $padexpr; end))
     end
 
@@ -1132,7 +1132,7 @@ function _printf(macroname, io, fmt, args)
 
     has_splatting = false
     for arg in args
-       if typeof(arg) == Expr && arg.head == :...
+       if isa(arg, Expr) && arg.head == :...
           has_splatting = true
           break
        end

--- a/base/process.jl
+++ b/base/process.jl
@@ -709,7 +709,7 @@ function arg_gen(head, tail...)
     for h = head, t = tail
         push!(vals, cstr(string(h,t)))
     end
-    vals
+    return vals
 end
 
 function cmd_gen(parsed)
@@ -717,11 +717,11 @@ function cmd_gen(parsed)
     for arg in parsed
         append!(args, arg_gen(arg...))
     end
-    Cmd(args)
+    return Cmd(args)
 end
 
 macro cmd(str)
-    :(cmd_gen($(shell_parse(str)[1])))
+    return :(cmd_gen($(shell_parse(str)[1])))
 end
 
 wait(x::Process)      = if !process_exited(x); stream_wait(x, x.exitnotify); end

--- a/base/show.jl
+++ b/base/show.jl
@@ -697,7 +697,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         end
 
         # scalar multiplication (i.e. "100x")
-        if (func == :(*) &&
+        if (func === :* &&
             length(func_args)==2 && isa(func_args[1], Real) && isa(func_args[2], Symbol))
             if func_prec <= prec
                 show_enclosed_list(io, '(', func_args, "", ')', indent, func_prec)
@@ -955,8 +955,8 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
 end
 
 function ismodulecall(ex::Expr)
-    ex.head == :call && (ex.args[1] == GlobalRef(Base,:getfield) ||
-                         ex.args[1] == GlobalRef(Core,:getfield)) &&
+    return ex.head == :call && (ex.args[1] === GlobalRef(Base,:getfield) ||
+                                ex.args[1] === GlobalRef(Core,:getfield)) &&
         isa(ex.args[2], Symbol) &&
         isdefined(current_module(), ex.args[2]) &&
         isa(getfield(current_module(), ex.args[2]), Module)

--- a/base/version.jl
+++ b/base/version.jl
@@ -96,8 +96,8 @@ function VersionNumber(v::AbstractString)
     if prerl !== nothing && !isempty(prerl) && prerl[1] == '-'
         prerl = prerl[2:end] # strip leading '-'
     end
-    prerl = prerl !== nothing ? split_idents(prerl) : minus == "-" ? ("",) : ()
-    build = build !== nothing ? split_idents(build) : plus  == "+" ? ("",) : ()
+    prerl = prerl !== nothing ? split_idents(prerl) : minus !== nothing ? ("",) : ()
+    build = build !== nothing ? split_idents(build) : plus  !== nothing ? ("",) : ()
     VersionNumber(major, minor, patch, prerl, build)
 end
 

--- a/examples/queens.jl
+++ b/examples/queens.jl
@@ -13,7 +13,7 @@ function solve(x, y, n, d=Array{Vector{Int}}(0))
     for py = 1:y
       if !hitsany([px, py], d)
         s = solve(x, y, n-1, addqueen(d, [px, py]))
-        s != nothing && return s
+        s !== nothing && return s
       end
     end
   end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -437,7 +437,7 @@ function test_map(::Type{TestAbstractArray})
         # map with different result types
         let m = mapf(x->x+1, Number[1, 2.0])
             # FIXME why is this different for asyncmap?
-            @test mapf != map || isa(m, Vector{Real})
+            @test mapf !== map || isa(m, Vector{Real})
             @test m == Real[2, 3.0]
         end
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -29,7 +29,7 @@ macro macro_doctest() end
 @doc "Helps test if macros can be documented with `@doc \"...\" -> @...`." ->
 :@macro_doctest
 
-@test (@doc @macro_doctest) != nothing
+@test (@doc @macro_doctest) !== nothing
 
 # issue #11548
 

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -712,16 +712,16 @@ function walk_args(i)
     if i > length(pmap_args)
         kwargs = []
         for (k,v) in kwdict
-            if v != :default
+            if v !== :default
                 push!(kwargs, (k,v))
             end
         end
 
         data = [1:100...]
 
-        testw = kwdict[:distributed] == false ? [1] : workers()
+        testw = kwdict[:distributed] === false ? [1] : workers()
 
-        if (kwdict[:on_error] == :default) && (kwdict[:retry_n] == :default)
+        if (kwdict[:on_error] === :default) && (kwdict[:retry_n] === :default)
             mapf = x -> (x*2, myid())
             results_test = pmap_res -> begin
                 results = [x[1] for x in pmap_res]
@@ -731,7 +731,7 @@ function walk_args(i)
                     @test p in pids
                 end
             end
-        elseif kwdict[:retry_n] != :default
+        elseif kwdict[:retry_n] !== :default
             mapf = x -> iseven(myid()) ? error("foobar") : (x*2, myid())
             results_test = pmap_res -> begin
                 results = [x[1] for x in pmap_res]
@@ -745,7 +745,7 @@ function walk_args(i)
                     end
                 end
             end
-        else (kwdict[:on_error] != :default) && (kwdict[:retry_n] == :default)
+        else (kwdict[:on_error] !== :default) && (kwdict[:retry_n] === :default)
             mapf = x -> iseven(x) ? error("foobar") : (x*2, myid())
             results_test = pmap_res -> begin
                 w = testw

--- a/test/test.jl
+++ b/test/test.jl
@@ -56,7 +56,7 @@ tse_str = sprint(show, Test.TestSetException(1,2,3))
 @test contains(tse_str, "2 failed")
 @test contains(tse_str, "3 errored")
 
-@test Test.finish(Test.FallbackTestSet()) != nothing
+@test Test.finish(Test.FallbackTestSet()) !== nothing
 
 OLD_STDOUT = STDOUT
 catch_out = IOStream("")
@@ -134,11 +134,10 @@ try
         end
     end
 end
-    # These lines shouldn't be called
-    redirect_stdout(OLD_STDOUT)
-    error("No exception was thrown!")
+# These lines shouldn't be called
+redirect_stdout(OLD_STDOUT)
+error("No exception was thrown!")
 catch ex
-
     @test isa(ex, Test.TestSetException)
     @test ex.pass  == 24
     @test ex.fail  == 6


### PR DESCRIPTION
this makes it now possible to make `==` with non-comparable items an error (ref #15983), since these notions are no longer coupled, but it _does not_ make that change now

~~it does change `in` to use `isequal` (#9381), but that's a small part of the change, so I might move that to another branch while that issue is still under discussion~~ edit: now extracted from this PR to https://github.com/JuliaLang/julia/compare/jn/notequal...jn/in-isequal
