### PR TITLE
add irrational constant ° = pi/180, for converting degrees to radians

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -115,6 +115,10 @@ Library improvements
       package provides the old-style `handler` functionality, for compatibility
       with code that needs to support both Julia v0.4 and v0.5.
 
+  * New `°` constant (which can be typed by tab-completing `\degree`) equal
+    to `π/180`, useful for defining angles in degrees, e.g. `30°`, in a way
+    that is automatically converted to radians.
+
   * The functions `remotecall`, `remotecall_fetch`, and `remotecall_wait` now have the
     function argument as the first argument to allow for do-block syntax ([#13338]).
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -5349,7 +5349,9 @@ readlink
 """
     deg2rad(x)
 
-Convert `x` from degrees to radians.
+Convert `x` from degrees to radians.   Note that the constant `°` is
+also useful for this purpose: it is defined as ``π/180``, so multiplying
+by it converts degrees to radians, e.g. `30°` gives the angle ``π/6``.
 """
 deg2rad
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -201,6 +201,7 @@ export
     γ, eulergamma,
     catalan,
     φ, golden,
+    °,
     I,
 
 # Operators

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -106,6 +106,7 @@ big(x::Irrational) = convert(BigFloat,x)
 @irrational γ        0.57721566490153286061  euler
 @irrational catalan  0.91596559417721901505  catalan
 @irrational φ        1.61803398874989484820  (1+sqrt(big(5)))/2
+@irrational °      0.0174532925199432957692  big(π)/180
 
 # aliases
 const pi = π

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -195,6 +195,11 @@ General Number Functions and Constants
 
    The golden ratio
 
+.. data:: °
+
+   The constant π/180, useful for converting degrees to radians.
+   For example, ``30°`` gives the angle π/6.
+
 .. data:: Inf
 
    Positive infinity of type ``Float64``
@@ -599,4 +604,3 @@ As ``BigInt`` represents unbounded integers, the interval must be specified (e.g
    Create an array of the size ``jumps`` of initialized ``MersenneTwister`` RNG objects where the first RNG object given as a parameter and following ``MersenneTwister`` RNGs in the array initialized such that a state of the RNG object in the array would be moved forward (without generating numbers) from a previous RNG object array element on a particular number of steps encoded by the jump polynomial ``jumppoly``\ .
 
    Default jump polynomial moves forward ``MersenneTwister`` RNG state by 10^20 steps.
-

--- a/test/math.jl
+++ b/test/math.jl
@@ -801,5 +801,7 @@ let A = [1 2; 3 4]; B = [5 6; 7 8]; C = [9 10; 11 12]
     @test muladd(A,B,C) == A*B + C
 end
 
+@test sin(37°) ≈ sind(37)
+
 @test Base.Math.f32(complex(1.0,1.0)) == complex(Float32(1.),Float32(1.))
 @test Base.Math.f16(complex(1.0,1.0)) == complex(Float16(1.),Float16(1.))


### PR DESCRIPTION
This allows you to have a constant like `30°` yield the angle in radians, as discussed in #16760.

On the one hand, this syntax is almost _too_ cute.  On the other hand, it's not clear what else one could do with the `°` identifier, and wanting to define angular constants in degrees is undeniably common and useful.   (Declaring it to be a special `Degree` type, while it would allow for more error checking, seems like it would get too intrusive ... too many functions would need new methods if we introduced a new numeric type.)

The main other option discussed in #16760 would be to define `°` as a postfix operator equivalent to `deg2rad`, probably with high precedence.   This is also workable, but would disallow `°` in identifiers, and it's not at all clear to me that an expression like `φ°` should be a function call rather than just a variable name.
