### PR TITLE
Don't create temporaries in real eigfact.

### DIFF
--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -34,11 +34,13 @@ function eigfact!{T<:BlasReal}(A::StridedMatrix{T}; permute::Bool=true, scale::B
     evec = zeros(Complex{T}, n, n)
     j = 1
     while j <= n
-        if WI[j] == 0.0
-            evec[:,j] = VR[:,j]
+        if WI[j] == 0
+            evec[:,j] = slice(VR, :, j)
         else
-            evec[:,j]   = VR[:,j] + im*VR[:,j+1]
-            evec[:,j+1] = VR[:,j] - im*VR[:,j+1]
+            for i = 1:n
+                evec[i,j]   = VR[i,j] + im*VR[i,j+1]
+                evec[i,j+1] = VR[i,j] - im*VR[i,j+1]
+            end
             j += 1
         end
         j += 1
@@ -128,11 +130,13 @@ function eigfact!{T<:BlasReal}(A::StridedMatrix{T}, B::StridedMatrix{T})
     vecs = zeros(Complex{T}, n, n)
     j = 1
     while j <= n
-        if alphai[j] == 0.0
-            vecs[:,j] = vr[:,j]
+        if alphai[j] == 0
+            vecs[:,j] = slice(vr, :, j)
         else
-            vecs[:,j  ] = vr[:,j] + im*vr[:,j+1]
-            vecs[:,j+1] = vr[:,j] - im*vr[:,j+1]
+            for i = 1:n
+                vecs[i,j  ] = vr[i,j] + im*vr[i,j+1]
+                vecs[i,j+1] = vr[i,j] - im*vr[i,j+1]
+            end
             j += 1
         end
         j += 1


### PR DESCRIPTION
@stevengj The reason for the allocation was much simpler than expected. When creating the eigenvector matrix from the LAPACK output, the columns were fetched Matlab-like and therefore a lot of temporaries were created. By avoiding the temporaries, I get

``` jl
julia> @time eig(randn(1000,1000));
  2.206440 seconds (115 allocations: 38.461 MB, 0.29% gc time)
```

As noted in JuliaLang/LinearAlgebra.jl#337, the many extra allocations have a modest effect on the timings, though. The eigenvalue computation completely dominates.

Fixes JuliaLang/LinearAlgebra.jl#337 
