### PR TITLE
WIP/RFC: allow resize! to initialize new elements

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -494,6 +494,14 @@ function resize!(a::Vector, nl::Integer)
     return a
 end
 
+function resize!(filler, a::Vector, nl::Integer)
+    l = length(a)
+    resize!(a, nl)
+    fill!(filler, a, l+1, nl)
+end
+
+resize!(a::Vector, nl::Integer, default) = resize!(_->default, a, nl)
+
 function sizehint!(a::Vector, sz::Integer)
     ccall(:jl_array_sizehint, Void, (Any, UInt), a, sz)
     a

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -522,6 +522,14 @@ function fill!{T}(A::AbstractArray{T}, x)
     A
 end
 
+function fill!(filler, A::AbstractArray, start::Integer, stop::Integer)
+    start >= 1 && stop <= length(A) || throw(BoundsError())
+    for i in start:stop
+        @inbounds A[i] = filler(i)
+    end
+    A
+end
+
 function copy!{T,N}(dest::AbstractArray{T,N}, src::AbstractArray{T,N})
     length(dest) >= length(src) || throw(BoundsError())
     for (Isrc, Idest) in zip(eachindex(src), eachindex(dest))


### PR DESCRIPTION
This makes `resize!(A, n, default)` initialize new elements with a `default` value in case of (positive) growth. A more general version `resize(filler, A, n)` is also introduced which initializes `A[i]` with `filler(i)`. This can be useful in particular when the default values must be distinct objects (e.g. `resize!(_->Int[], Vector{Vector{Int}}(), 2)`). 

For reference, the corresponding [resize function in C++](http://www.cplusplus.com/reference/vector/vector/resize/) accepts such a default value (and also rust [apparently](https://doc.rust-lang.org/std/vec/struct.Vec.html)).

I implemented this by adding a method to `fill!`, but I'm not sure it's the right solution: `fill!(filler, A::AbstractArray, start::Integer, stop::Integer)`. 
If this becomes public API, it would then makes sense to have default values for `start/stop`: `fill!(filler, A::AbstractArray)`, but then there could be ambiguity with  `fill!(A::AbstractArray, default)` if `default` is of type `AbstractArray`. 
I can simply rename this method to `_fill!` to postpone the discussion of an extended `fill!` API.

If the idea receives support, I will write docs/tests and a similar version for `BitArray{1}` should also probably exist.
