### PR TITLE
Fix syntax error in examples/hpl.jl

### DIFF
--- a/examples/hpl.jl
+++ b/examples/hpl.jl
@@ -51,7 +51,7 @@ end ## hpl()
 ### Panel factorization ###
 
 function panel_factor_seq(A, I, col_dep)
-    n = size (A, 1)
+    n = size(A, 1)
 
     ## Enforce dependencies
     #wait(col_dep)
@@ -70,7 +70,7 @@ end ## panel_factor_seq()
 ### Trailing update ###
 
 function trailing_update_seq(A, I, J, panel_p, row_dep, col_dep)
-    n = size (A, 1)
+    n = size(A, 1)
 
     ## Enforce dependencies
     #wait(row_dep, col_dep)


### PR DESCRIPTION
Removed spaces to fix syntax error in examples/hpl.jl from `size (A, 1)` to `size(A,1)`
