### PR TITLE
WIP: Fix building of LLVM dll when using cmake on Windows

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -438,6 +438,7 @@ $(eval $(call LLVM_PATCH,llvm-3.7.1_3))
 $(eval $(call LLVM_PATCH,llvm-D14260))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_bindir))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_winshlib))
+$(eval $(call LLVM_PATCH,llvm-3.8.0_winshlibcmake))
 $(eval $(call LLVM_PATCH,llvm-nodllalias))
 $(LLVM_SRC_DIR)/llvm-nodllalias.patch-applied: $(LLVM_SRC_DIR)/llvm-3.8.0_winshlib.patch-applied
 # Cygwin and openSUSE still use win32-threads mingw, https://llvm.org/bugs/show_bug.cgi?id=26365

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -415,23 +415,19 @@ $(eval $(call LLVM_PATCH,instcombine-llvm-3.3))
 $(eval $(call LLVM_PATCH,int128-vector.llvm-3.3))
 $(eval $(call LLVM_PATCH,osx-10.10.llvm-3.3))
 $(eval $(call LLVM_PATCH,win64-int128.llvm-3.3))
-else ifeq ($(LLVM_VER),3.7.0)
+else ifeq($(LLVM_VER_SHORT),3.7)
+ifeq ($(LLVM_VER),3.7.0)
 $(eval $(call LLVM_PATCH,llvm-3.7.0))
+endif
 $(eval $(call LLVM_PATCH,llvm-3.7.1))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_2))
-$(eval $(call LLVM_PATCH,llvm-3.7.1_3))
-$(eval $(call LLVM_PATCH,llvm-D14260))
 $(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1.patch-applied
-else ifeq ($(LLVM_VER),3.7.1)
-$(eval $(call LLVM_PATCH,llvm-3.7.1))
-$(eval $(call LLVM_PATCH,llvm-3.7.1_2))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_3))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_symlinks))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_bindir))
 $(LLVM_SRC_DIR)/llvm-3.8.0_bindir.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1_symlinks.patch-applied
 $(eval $(call LLVM_PATCH,llvm-D14260))
 $(eval $(call LLVM_PATCH,llvm-nodllalias))
-$(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1.patch-applied
 $(LLVM_SRC_DIR)/llvm-nodllalias.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied
 else ifeq ($(LLVM_VER),3.8.0)
 $(eval $(call LLVM_PATCH,llvm-3.7.1_3))

--- a/deps/patches/llvm-3.8.0_winshlibcmake.patch
+++ b/deps/patches/llvm-3.8.0_winshlibcmake.patch
@@ -1,0 +1,26 @@
+diff --git a/tools/llvm-shlib/CMakeLists.txt b/tools/llvm-shlib/CMakeLists.txt
+index 2356103..9603793 100644
+--- a/tools/llvm-shlib/CMakeLists.txt
++++ b/tools/llvm-shlib/CMakeLists.txt
+@@ -41,7 +41,7 @@ endif()
+ add_llvm_library(LLVM SHARED DISABLE_LLVM_LINK_LLVM_DYLIB SONAME ${SOURCES})
+ 
+ list(REMOVE_DUPLICATES LIB_NAMES)
+-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") # FIXME: It should be "GNU ld for elf"
++if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR MINGW) # FIXME: It should be "GNU ld for elf"
+   # GNU ld doesn't resolve symbols in the version script.
+   set(LIB_NAMES -Wl,--whole-archive ${LIB_NAMES} -Wl,--no-whole-archive)
+ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+diff --git a/tools/lto/lto.exports b/tools/lto/lto.exports
+index 8bc2b0f..765d893 100644
+--- a/tools/lto/lto.exports
++++ b/tools/lto/lto.exports
+@@ -40,8 +40,3 @@ lto_codegen_optimize
+ lto_codegen_compile_optimized
+ lto_codegen_set_should_internalize
+ lto_codegen_set_should_embed_uselists
+-LLVMCreateDisasm
+-LLVMCreateDisasmCPU
+-LLVMDisasmDispose
+-LLVMDisasmInstruction
+-LLVMSetDisasmOptions


### PR DESCRIPTION
I got a little carried away with fixing LLVM build issues, whoops. This is maybe a little hacky.

Need to remove some LLVM exports from liblto otherwise they give
multiple definition errors - not sure if we need these?
