### PR TITLE
Send TypeName objects only once to workers 

### DIFF
--- a/base/clusterserialize.jl
+++ b/base/clusterserialize.jl
@@ -1,0 +1,70 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+import .Serializer: known_object_data, object_number, serialize_cycle, deserialize_cycle, writetag,
+                      __deserialized_types__, serialize_typename_body, deserialize_typename_body,
+                      TYPENAME_TAG, object_numbers
+
+type ClusterSerializer{I<:IO} <: AbstractSerializer
+    io::I
+    counter::Int
+    table::ObjectIdDict
+
+    sent_objects::Dict{UInt64, Bool} # used by serialize (track objects sent)
+
+    ClusterSerializer(io::I) = new(io, 0, ObjectIdDict(), Dict())
+end
+ClusterSerializer(io::IO) = ClusterSerializer{typeof(io)}(io)
+
+function deserialize(s::ClusterSerializer, ::Type{TypeName})
+    number, full_body_sent = deserialize(s)
+    makenew = false
+    known = haskey(known_object_data, number)
+    if !full_body_sent
+        if !known
+            error("Expected object in cache. Not found.")
+        else
+            tn = known_object_data[number]::TypeName
+        end
+    else
+        name = deserialize(s)
+        mod = deserialize(s)
+        if known
+            tn = known_object_data[number]::TypeName
+        elseif mod !== __deserialized_types__ && isdefined(mod, name)
+            tn = getfield(mod, name).name
+            # TODO: confirm somehow that the types match
+            #warn(mod, ".", name, " isdefined, need not have been serialized")
+            name = tn.name
+            mod = tn.module
+        else
+            name = gensym()
+            mod = __deserialized_types__
+            tn = ccall(:jl_new_typename_in, Ref{TypeName}, (Any, Any), name, mod)
+            makenew = true
+        end
+    end
+    deserialize_cycle(s, tn)
+    full_body_sent && deserialize_typename_body(s, tn, number, name, mod, makenew)
+    !known && (known_object_data[number] = tn)
+    if !haskey(object_numbers, tn)
+        object_numbers[tn] = number
+    end
+    return tn
+end
+
+function serialize(s::ClusterSerializer, t::TypeName)
+    serialize_cycle(s, t) && return
+    writetag(s.io, TYPENAME_TAG)
+
+    identifier = object_number(t)
+    if !haskey(s.sent_objects, identifier)
+        serialize(s, (identifier, true))
+        serialize(s, t.name)
+        serialize(s, t.module)
+        serialize_typename_body(s, t)
+        s.sent_objects[identifier] = true
+#        println(t.module, ":", t.name, ", id:", identifier, " sent")
+    else
+        serialize(s, (identifier, false))
+#        println(t.module, ":", t.name, ", id:", identifier, " NOT sent")
+    end
+end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -395,9 +395,10 @@ copy(o::ObjectIdDict) = ObjectIdDict(o)
 
 get!(o::ObjectIdDict, key, default) = (o[key] = get(o, key, default))
 
-# SerializationState type needed as soon as ObjectIdDict is available
+abstract AbstractSerializer
 
-type SerializationState{I<:IO}
+# Serializer type needed as soon as ObjectIdDict is available
+type SerializationState{I<:IO} <: AbstractSerializer
     io::I
     counter::Int
     table::ObjectIdDict

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -101,6 +101,7 @@ export
     RoundNearestTiesUp,
     RoundToZero,
     RoundUp,
+    AbstractSerializer,
     SerializationState,
     Set,
     SharedArray,

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
+import .Serializer: serialize_cycle, serialize_type, writetag, UNDEFREF_TAG
 
 type SharedArray{T,N} <: DenseArray{T,N}
     dims::NTuple{N,Int}
@@ -348,12 +349,12 @@ end
 
 # Don't serialize s (it is the complete array) and
 # pidx, which is relevant to the current process only
-function serialize(s::SerializationState, S::SharedArray)
-    Serializer.serialize_cycle(s, S) && return
-    Serializer.serialize_type(s, typeof(S))
+function serialize(s::AbstractSerializer, S::SharedArray)
+    serialize_cycle(s, S) && return
+    serialize_type(s, typeof(S))
     for n in SharedArray.name.names
         if n in [:s, :pidx, :loc_subarr_1d]
-            Serializer.writetag(s.io, Serializer.UNDEFREF_TAG)
+            writetag(s.io, UNDEFREF_TAG)
         elseif n == :refs
             v = getfield(S, n)
             if isa(v[1], Future)
@@ -369,8 +370,8 @@ function serialize(s::SerializationState, S::SharedArray)
     end
 end
 
-function deserialize{T,N}(s::SerializationState, t::Type{SharedArray{T,N}})
-    S = invoke(deserialize, Tuple{SerializationState, DataType}, s, t)
+function deserialize{T,N}(s::AbstractSerializer, t::Type{SharedArray{T,N}})
+    S = invoke(deserialize, Tuple{AbstractSerializer, DataType}, s, t)
     init_loc_flds(S)
     S
 end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -63,7 +63,7 @@ end
 # provide a custom serializer that skips attempting to serialize the `outer_linfo`
 # which is likely to contain complex references, types, and module references
 # that may not exist on the receiver end
-function serialize(s::SerializationState, frame::StackFrame)
+function serialize(s::AbstractSerializer, frame::StackFrame)
     Serializer.serialize_type(s, typeof(frame))
     serialize(s, frame.func)
     serialize(s, frame.file)
@@ -73,7 +73,7 @@ function serialize(s::SerializationState, frame::StackFrame)
     write(s.io, frame.pointer)
 end
 
-function deserialize(s::SerializationState, ::Type{StackFrame})
+function deserialize(s::AbstractSerializer, ::Type{StackFrame})
     func = deserialize(s)
     file = deserialize(s)
     line = read(s.io, Int)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -238,6 +238,7 @@ importall .Enums
 include("serialize.jl")
 importall .Serializer
 include("channels.jl")
+include("clusterserialize.jl")
 include("multi.jl")
 include("workerpool.jl")
 include("pmap.jl")

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -999,3 +999,15 @@ retval = @parallel (+) for _ in 1:10
     rand(rng)
 end
 @test retval > 0.0 && retval < 10.0
+
+# serialization tests
+wrkr1 = workers()[1]
+wrkr2 = workers()[end]
+
+@test remotecall_fetch(p->remotecall_fetch(myid, p), wrkr1, wrkr2) == wrkr2
+
+# Send f to wrkr1 and wrkr2. Then try calling f on wrkr2 from wrkr1
+f_myid = ()->myid()
+@test wrkr1 == remotecall_fetch(f_myid, wrkr1)
+@test wrkr2 == remotecall_fetch(f_myid, wrkr2)
+@test wrkr2 == remotecall_fetch((f, p)->remotecall_fetch(f, p), wrkr1, f_myid, wrkr2)


### PR DESCRIPTION
This PR sends TypeName objects only once as a means to address https://github.com/JuliaLang/julia/issues/16508 as suggested in https://github.com/JuliaLang/julia/pull/16695#issuecomment-223344933 .

Only a marginal improvement in timings for the test code in https://github.com/JuliaLang/julia/pull/16695 .

@JeffBezanson - it appears that many more types need to be cached.

Related:  https://github.com/JuliaLang/julia/issues/16558
