### PR TITLE
fix contrib/install.sh when using busybox awk

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -20,7 +20,7 @@ for SRC in $ARGS; do
 
     # If there are surrounding quotes, remove them.  We do this simply by knowing that the destination is always an absolute path
     if [ "$(echo $DESTFILE | head -c1)" != "/" ]; then
-        DESTFILE=$(echo $DESTFILE | awk '{print substr($0, 2, length-2)}')
+        DESTFILE=$(echo $DESTFILE | awk '{print substr($0, 2, length($0)-2)}')
     fi
 
     # Do the chmod dance, and ignore errors on platforms that don't like setting permissions of symlinks


### PR DESCRIPTION
```
/ # echo foobar | busybox awk '{print substr($0, 2, length-2)}'
awk: cmd. line:1: Unexpected token
/ # echo foobar | busybox awk '{print substr($0, 2, length($0)-2)}'
ooba
/ # echo foobar | gawk '{print substr($0, 2, length-2)}'
ooba
/ # echo foobar | gawk '{print substr($0, 2, length($0)-2)}'
ooba
```
