### PR TITLE
document Vararg{T,N} and NTuple

### DIFF
--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -1009,7 +1009,7 @@ methods (see :ref:`man-varargs-functions`).
 
 The type ``Vararg{T,N}`` corresponds to exactly ``N`` elements of type ``T``.  ``NTuple{N,T}`` is
 a convenient alias for ``Tuple{Vararg{T,N}}``, i.e. a tuple type containing exactly
-``N`` elements of ``T``.
+``N`` elements of type ``T``.
 
 
 .. _man-singleton-types:

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -1007,6 +1007,11 @@ Notice that ``Vararg{T}`` matches zero or more elements of type ``T``.
 Vararg tuple types are used to represent the arguments accepted by varargs
 methods (see :ref:`man-varargs-functions`).
 
+The type ``Vararg{T,N}`` matches exactly ``N`` elements of ``T``.  ``NTuple{N,T}`` is
+a convenient alias for ``Tuple{Vararg{T,N}}``, i.e. a tuple type matching exactly
+``N`` elements of ``T``.
+
+
 .. _man-singleton-types:
 
 Singleton Types

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -1007,7 +1007,7 @@ Notice that ``Vararg{T}`` corresponds to zero or more elements of type ``T``.
 Vararg tuple types are used to represent the arguments accepted by varargs
 methods (see :ref:`man-varargs-functions`).
 
-The type ``Vararg{T,N}`` corresponds to exactly ``N`` elements of ``T``.  ``NTuple{N,T}`` is
+The type ``Vararg{T,N}`` corresponds to exactly ``N`` elements of type ``T``.  ``NTuple{N,T}`` is
 a convenient alias for ``Tuple{Vararg{T,N}}``, i.e. a tuple type containing exactly
 ``N`` elements of ``T``.
 

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -1003,12 +1003,12 @@ which denotes any number of trailing elements:
     julia> isa(("1",1,2,3.0), Tuple{AbstractString,Vararg{Int}})
     false
 
-Notice that ``Vararg{T}`` matches zero or more elements of type ``T``.
+Notice that ``Vararg{T}`` corresponds to zero or more elements of type ``T``.
 Vararg tuple types are used to represent the arguments accepted by varargs
 methods (see :ref:`man-varargs-functions`).
 
-The type ``Vararg{T,N}`` matches exactly ``N`` elements of ``T``.  ``NTuple{N,T}`` is
-a convenient alias for ``Tuple{Vararg{T,N}}``, i.e. a tuple type matching exactly
+The type ``Vararg{T,N}`` corresponds to exactly ``N`` elements of ``T``.  ``NTuple{N,T}`` is
+a convenient alias for ``Tuple{Vararg{T,N}}``, i.e. a tuple type containing exactly
 ``N`` elements of ``T``.
 
 


### PR DESCRIPTION
`Vararg{T,N}` seems to be new in 0.5 (not sure which PR provided it), and it was just mentioned on the mailing list that `NTuple` was poorly documented.
