### PR TITLE
Skip terminator record in `processFDEs`

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -1312,7 +1312,9 @@ static const char *processFDE(const char *Entry, callback f)
     uint32_t Length = *((const uint32_t *)P);
     P += 4;
     uint32_t Offset = *((const uint32_t *)P);
-    if (Offset != 0) {
+    // Offset == 0: CIE
+    // Length == 0: Terminator
+    if (Offset != 0 && Length != 0) {
         f(Entry);
     }
     return P + Length;


### PR DESCRIPTION
This is what causing a segfault for Keno's remote memory manager on https://github.com/JuliaLang/julia/pull/16777 (So it's buffer reuse not address reuse...)

@Keno I assume the OSX unwinder doesn't care about the terminator record? Otherwise I can move this to the linux one too.
