### PR TITLE
Try not to use address of local variable as stack address to copy.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -57,10 +57,7 @@ arraylist_t to_finalize;
 
 NOINLINE uintptr_t gc_get_stack_ptr(void)
 {
-    void *dummy = NULL;
-    // The mask is to suppress the compiler warning about returning
-    // address of local variable
-    return (uintptr_t)&dummy & ~(uintptr_t)15;
+    return (uintptr_t)jl_get_frame_addr();
 }
 
 #define should_timeout() 0

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -651,6 +651,18 @@ jl_value_t *jl_lookup_match(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, jl_s
 
 unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *field_type);
 
+STATIC_INLINE void *jl_get_frame_addr(void)
+{
+#ifdef __GNUC__
+    return __builtin_frame_address(0);
+#else
+    void *dummy = NULL;
+    // The mask is to suppress the compiler warning about returning
+    // address of local variable
+    return (void*)((uintptr_t)&dummy & ~(uintptr_t)15);
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/task.c
+++ b/src/task.c
@@ -144,8 +144,8 @@ static void NOINLINE save_stack(jl_tls_states_t *ptls, jl_task_t *t)
 {
     if (t->state == done_sym || t->state == failed_sym)
         return;
-    volatile char *_x;
-    size_t nb = (char*)ptls->stackbase - (char*)&_x;
+    char *frame_addr = (char*)jl_get_frame_addr();
+    size_t nb = (char*)ptls->stackbase - frame_addr;
     char *buf;
     if (t->stkbuf == NULL || t->bufsz < nb) {
         buf = (char*)allocb(nb);
@@ -156,7 +156,7 @@ static void NOINLINE save_stack(jl_tls_states_t *ptls, jl_task_t *t)
         buf = (char*)t->stkbuf;
     }
     t->ssize = nb;
-    memcpy(buf, (char*)&_x, nb);
+    memcpy(buf, frame_addr, nb);
     // this task's stack could have been modified after
     // it was marked by an incremental collection
     // move the barrier back instead of walking it again here


### PR DESCRIPTION
This can trigger bounds check on some libc.

Fixes #16792
