### PR TITLE
correct the method cache's usage of typemap simplesig

### DIFF
--- a/src/typemap.c
+++ b/src/typemap.c
@@ -992,6 +992,8 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
         jl_value_t *decl = jl_field_type(type, i);
         if (decl == (jl_value_t*)jl_datatype_type)
             newrec->isleafsig = 0; // Type{} may have a higher priority than DataType
+        else if (decl == (jl_value_t*)jl_typector_type)
+            newrec->isleafsig = 0; // Type{} may have a higher priority than TypeConstructor
         else if (jl_is_type_type(decl))
             newrec->isleafsig = 0; // Type{} may need special processing to compute the match
         else if (jl_is_vararg_type(decl))

--- a/test/core.jl
+++ b/test/core.jl
@@ -207,12 +207,14 @@ let T = TypeVar(:T, Tuple{Vararg{RangeIndex}}, true)
 end
 
 # issue #11840
+typealias TT11840{T} Tuple{T,T}
 f11840(::Type) = "Type"
 f11840(::DataType) = "DataType"
 f11840{T<:Tuple}(::Type{T}) = "Tuple"
 @test f11840(Type) == "DataType"
 @test f11840(AbstractVector) == "Type"
 @test f11840(Tuple) == "Tuple"
+@test f11840(TT11840) == "Tuple"
 
 g11840(::DataType) = 1
 g11840(::Type) = 2
@@ -222,6 +224,7 @@ g11840{T<:Tuple}(sig::Type{T}) = 3
 @test g11840(Vector.body) == 1
 @test g11840(Vector) == 2
 @test g11840(Tuple) == 3
+@test g11840(TT11840) == 3
 
 g11840b(::DataType) = 1
 g11840b(::Type) = 2
@@ -233,6 +236,7 @@ g11840b(::Type) = 2
 @test g11840b(Vector) == 2
 @test g11840b(Vector.body) == 1
 #@test g11840b(Tuple) == 3
+#@test g11840b(TT11840) == 3
 
 h11840(::DataType) = '1'
 h11840(::Type) = '2'
@@ -244,6 +248,7 @@ h11840{T<:Tuple}(::Type{T}) = '4'
 @test h11840(Union{Vector, Matrix}) == '2'
 @test h11840(Union{Vector.body, Matrix.body}) == '2'
 @test h11840(Tuple) == '4'
+@test h11840(TT11840) == '4'
 
 # join
 @test typejoin(Int8,Int16) === Signed

--- a/test/core.jl
+++ b/test/core.jl
@@ -220,7 +220,19 @@ g11840{T<:Tuple}(sig::Type{T}) = 3
 @test g11840(Vector.body) == 1
 @test g11840(Vector) == 2
 @test g11840(Vector.body) == 1
+@test g11840(Vector) == 2
 @test g11840(Tuple) == 3
+
+g11840b(::DataType) = 1
+g11840b(::Type) = 2
+# FIXME: how to compute that the guard entry is still required,
+# even though Type{Vector} ∩ DataType = Bottom and this method would set cache_with_orig = true
+#g11840b{T<:Tuple}(sig::Type{T}) = 3
+@test g11840b(Vector) == 2
+@test g11840b(Vector.body) == 1
+@test g11840b(Vector) == 2
+@test g11840b(Vector.body) == 1
+#@test g11840b(Tuple) == 3
 
 h11840(::DataType) = '1'
 h11840(::Type) = '2'


### PR DESCRIPTION
fixes a performance issue found by @carnaval where we were continuously evicting the same entries from the cache. This likely shouldn't have been affecting too many places, but it was causing the misc test to fail the allocated test with no-inline, and may have slowed down `cconvert{T}(Type{T}, x::T)` also (compiling inference.ji seems to be a bit faster with this).
