### PR TITLE
RFC: LLVM patch adjustments

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -47,7 +47,6 @@ CMAKE_CC_ARG := $(CC_ARG) $(DEPS_CFLAGS)
 CMAKE_CXX_ARG := $(CXX_ARG) $(DEPS_CXXFLAGS)
 
 CMAKE_COMMON := -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)
-CMAKE_COMMON += -DCMAKE_INSTALL_BINDIR:PATH=$(shell $(JULIAHOME)/contrib/relative_path.sh $(build_prefix) $(build_depsbindir))
 ifneq ($(VERBOSE), 0)
 CMAKE_COMMON += -DCMAKE_VERBOSE_MAKEFILE=ON
 endif

--- a/deps/NATIVE.cmake
+++ b/deps/NATIVE.cmake
@@ -2,4 +2,3 @@
 # ref http://lists.llvm.org/pipermail/llvm-dev/2016-February/095366.html
 set(CMAKE_C_COMPILER cc)
 set(CMAKE_CXX_COMPILER c++)
-set(CMAKE_INSTALL_BINDIR tools)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -83,6 +83,7 @@ LLVM_LDFLAGS := $(LDFLAGS)
 LLVM_TARGETS := host
 LLVM_TARGET_FLAGS := --enable-targets=$(LLVM_TARGETS)
 LLVM_CMAKE += -DLLVM_TARGETS_TO_BUILD:STRING="$(LLVM_TARGETS)" -DCMAKE_BUILD_TYPE="$(LLVM_CMAKE_BUILDTYPE)"
+LLVM_CMAKE += -DLLVM_TOOLS_INSTALL_DIR=$(shell $(JULIAHOME)/contrib/relative_path.sh $(build_prefix) $(build_depsbindir))
 LLVM_FLAGS += --disable-profiling --enable-static $(LLVM_TARGET_FLAGS)
 LLVM_FLAGS += --disable-bindings --disable-docs --disable-libedit --disable-terminfo
 # LLVM has weird install prefixes (see llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/Makefile.config for the full list)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -403,12 +403,14 @@ endif # LLVM_VER
 	touch -c $@
 
 # Apply version-specific LLVM patches
+LLVM_PATCH_PREV:=
 LLVM_PATCH_LIST:=
 define LLVM_PATCH
-$$(LLVM_SRC_DIR)/$1.patch-applied: $(LLVM_SRC_DIR)/configure | $$(SRCDIR)/patches/$1.patch
+$$(LLVM_SRC_DIR)/$1.patch-applied: $(LLVM_SRC_DIR)/configure | $$(SRCDIR)/patches/$1.patch $(LLVM_PATCH_PREV)
 	cd $$(LLVM_SRC_DIR) && patch -p1 < $$(SRCDIR)/patches/$1.patch
 	echo 1 > $$@
-LLVM_PATCH_LIST += $$(LLVM_SRC_DIR)/$1.patch-applied
+LLVM_PATCH_PREV := $$(LLVM_SRC_DIR)/$1.patch-applied
+LLVM_PATCH_LIST += $(LLVM_PATCH_PREV)
 endef
 ifeq ($(LLVM_VER),3.3)
 $(eval $(call LLVM_PATCH,llvm-3.3))
@@ -422,28 +424,23 @@ $(eval $(call LLVM_PATCH,llvm-3.7.0))
 endif
 $(eval $(call LLVM_PATCH,llvm-3.7.1))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_2))
-$(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1.patch-applied
 $(eval $(call LLVM_PATCH,llvm-3.7.1_3))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_symlinks))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_bindir))
-$(LLVM_SRC_DIR)/llvm-3.8.0_bindir.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1_symlinks.patch-applied
 $(eval $(call LLVM_PATCH,llvm-D14260))
 $(eval $(call LLVM_PATCH,llvm-nodllalias))
-$(LLVM_SRC_DIR)/llvm-nodllalias.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied
 else ifeq ($(LLVM_VER),3.8.0)
 $(eval $(call LLVM_PATCH,llvm-3.7.1_3))
 $(eval $(call LLVM_PATCH,llvm-D14260))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_bindir))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_winshlib))
 $(eval $(call LLVM_PATCH,llvm-nodllalias))
-$(LLVM_SRC_DIR)/llvm-nodllalias.patch-applied: $(LLVM_SRC_DIR)/llvm-3.8.0_winshlib.patch-applied
 # Cygwin and openSUSE still use win32-threads mingw, https://llvm.org/bugs/show_bug.cgi?id=26365
 $(eval $(call LLVM_PATCH,llvm-3.8.0_threads))
 # fix replutil test on unix
 $(eval $(call LLVM_PATCH,llvm-D17165-D18583))
 # Segfault for aggregate load
 $(eval $(call LLVM_PATCH,llvm-D17326_unpack_load))
-$(LLVM_SRC_DIR)/llvm-D17326_unpack_load.patch-applied: $(LLVM_SRC_DIR)/llvm-D14260.patch-applied
 $(eval $(call LLVM_PATCH,llvm-D17712))
 $(eval $(call LLVM_PATCH,llvm-PR26180))
 $(eval $(call LLVM_PATCH,llvm-PR27046))

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -416,23 +416,19 @@ $(eval $(call LLVM_PATCH,instcombine-llvm-3.3))
 $(eval $(call LLVM_PATCH,int128-vector.llvm-3.3))
 $(eval $(call LLVM_PATCH,osx-10.10.llvm-3.3))
 $(eval $(call LLVM_PATCH,win64-int128.llvm-3.3))
-else ifeq ($(LLVM_VER),3.7.0)
+else ifeq ($(LLVM_VER_SHORT),3.7)
+ifeq ($(LLVM_VER),3.7.0)
 $(eval $(call LLVM_PATCH,llvm-3.7.0))
+endif
 $(eval $(call LLVM_PATCH,llvm-3.7.1))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_2))
-$(eval $(call LLVM_PATCH,llvm-3.7.1_3))
-$(eval $(call LLVM_PATCH,llvm-D14260))
 $(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1.patch-applied
-else ifeq ($(LLVM_VER),3.7.1)
-$(eval $(call LLVM_PATCH,llvm-3.7.1))
-$(eval $(call LLVM_PATCH,llvm-3.7.1_2))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_3))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_symlinks))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_bindir))
 $(LLVM_SRC_DIR)/llvm-3.8.0_bindir.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1_symlinks.patch-applied
 $(eval $(call LLVM_PATCH,llvm-D14260))
 $(eval $(call LLVM_PATCH,llvm-nodllalias))
-$(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1.patch-applied
 $(LLVM_SRC_DIR)/llvm-nodllalias.patch-applied: $(LLVM_SRC_DIR)/llvm-3.7.1_2.patch-applied
 else ifeq ($(LLVM_VER),3.8.0)
 $(eval $(call LLVM_PATCH,llvm-3.7.1_3))

--- a/deps/patches/llvm-3.8.0_bindir.patch
+++ b/deps/patches/llvm-3.8.0_bindir.patch
@@ -1,5 +1,19 @@
+difft a/CMakeLists.txt b/CMakeLists.txt
+index 46ca944..83cd3ba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -201,6 +201,9 @@ endif()
+ 
+ set(LLVM_LIBDIR_SUFFIX "" CACHE STRING "Define suffix of library directory name (32/64)" )
+ 
++set(LLVM_TOOLS_INSTALL_DIR "bin" CACHE STRING "Path for binary subdirectroy (defaults to 'bin')")
++mark_as_advanced(LLVM_TOOLS_INSTALL_DIR)
++
+ # They are used as destination of target generators.
+ set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
+ set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX})
 diff --git a/cmake/modules/AddLLVM.cmake b/cmake/modules/AddLLVM.cmake
-index cc7445f..117960c 100644
+index cc7445f..789555a 100644
 --- a/cmake/modules/AddLLVM.cmake
 +++ b/cmake/modules/AddLLVM.cmake
 @@ -771,7 +771,7 @@ macro(add_llvm_tool name)
@@ -7,7 +21,7 @@ index cc7445f..117960c 100644
        install(TARGETS ${name}
                EXPORT LLVMExports
 -              RUNTIME DESTINATION bin
-+              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++              RUNTIME DESTINATION ${LLVM_TOOLS_INSTALL_DIR}
                COMPONENT ${name})
  
        if (NOT CMAKE_CONFIGURATION_TYPES)
@@ -16,12 +30,12 @@ index cc7445f..117960c 100644
  
    install(SCRIPT ${INSTALL_SYMLINK}
 -          CODE "install_symlink(${full_name} ${full_dest} bin)"
-+          CODE "install_symlink(${full_name} ${full_dest} ${CMAKE_INSTALL_BINDIR})"
++          CODE "install_symlink(${full_name} ${full_dest} ${LLVM_TOOLS_INSTALL_DIR})"
            COMPONENT ${component})
  
    if (NOT CMAKE_CONFIGURATION_TYPES AND NOT ARG_ALWAYS_GENERATE)
 diff --git a/cmake/modules/TableGen.cmake b/cmake/modules/TableGen.cmake
-index fca7d1b..8ae6bf3 100644
+index fca7d1b..c88ee3fc 100644
 --- a/cmake/modules/TableGen.cmake
 +++ b/cmake/modules/TableGen.cmake
 @@ -141,7 +141,7 @@ macro(add_tablegen target project)
@@ -29,7 +43,8 @@ index fca7d1b..8ae6bf3 100644
      install(TARGETS ${target}
              EXPORT LLVMExports
 -            RUNTIME DESTINATION bin)
-+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++            RUNTIME DESTINATION ${LLVM_TOOLS_INSTALL_DIR})
    endif()
    set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${target})
  endmacro()
+ --git a/CMakeLists.txt b/CMakeLists.txt


### PR DESCRIPTION
My LLVM build patch got applied but then immediately reverted, apparently when you build with ninja the cmake `GNUInstallDirs` module is not loaded by default. The modifications here are more like my original proposed patch which makes a new LLVM-specific name for this option. Hopefully upstream will commit it tomorrow.

Also some minor tweaks to the patch list, and making LLVM patches apply sequentially by default to avoid race conditions or having to manually specify patch dependencies when multiple patches touch the same files.
