### PR TITLE
Use correct shebangs on .sh files

### DIFF
--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # This file collects git info and create a julia file with the GIT_VERSION_INFO struct

--- a/contrib/check-whitespace.sh
+++ b/contrib/check-whitespace.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # Check for trailing white space in source files;

--- a/contrib/commit-name.sh
+++ b/contrib/commit-name.sh
@@ -1,6 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-last_tag=$(git describe --tags --abbrev=0)
-echo -n "0.4.0-dev+"
-git rev-list ${1-HEAD} ^$last_tag | wc -l | sed -e 's/[^[:digit:]]//g'
+# Need to be run from a julia repo clone
+# First argument (Optional) is a ref to the commit
+
+gitref=${1:-HEAD}
+
+last_tag=$(git describe --tags --abbrev=0 "$gitref")
+ver=$(git show "$gitref:VERSION")
+nb=$(git rev-list --count "$gitref" "^$last_tag")
+echo "$ver+$nb"

--- a/contrib/mac/app/run-install-name-tool-change.sh
+++ b/contrib/mac/app/run-install-name-tool-change.sh
@@ -11,7 +11,7 @@ WRONG_PREFIX=$2
 RIGHT_PREFIX="@executable_path/../$3"
 ACTION=$4
 
-if [ "x$ACTION" == "xchange" ]; then
+if [ "x$ACTION" = "xchange" ]; then
     libs="`otool -L $LIBRARY 2>/dev/null | fgrep compatibility | cut -d\( -f1 | grep $WRONG_PREFIX | sort | uniq`"
     for lib in $libs; do
 	if ! echo $lib | grep --silent "@executable_path" ; then
@@ -19,7 +19,7 @@ if [ "x$ACTION" == "xchange" ]; then
 	    install_name_tool -change $lib $fixed $LIBRARY
 	fi
     done;
-elif [ "x$ACTION" == "xid" ]; then
+elif [ "x$ACTION" = "xid" ]; then
     lib="`otool -D $LIBRARY 2>/dev/null | grep ^$WRONG_PREFIX`"
     install_name_tool -id "$RIGHT_PREFIX/$lib" $LIBRARY;
 fi

--- a/contrib/mac/mac-gtk.sh
+++ b/contrib/mac/mac-gtk.sh
@@ -1,6 +1,5 @@
+#!/bin/sh
 # This file is a part of Julia. License is MIT: http://julialang.org/license
-
-#/bin/sh
 
 # This script will attempt to download and build GTK+-3,
 # including dependencies, in ~/gtk (also puts stuff in

--- a/test/perf/micro/java/setup.sh
+++ b/test/perf/micro/java/setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 mvn compile exec:java


### PR DESCRIPTION
Some of the shell files were using bash features with /bin/sh, others could have safely used /bin/sh. Now all .sh files pass `checkbashisms`.

Partially addresses #16819.
