### PR TITLE
restore vararg tuple elision optimization for `f(a...)`

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -393,6 +393,27 @@ JL_CALLABLE(jl_f_typeassert)
     return args[0];
 }
 
+// perform f(args...) on stack
+JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t nargs)
+{
+    nargs++;
+    int onstack = (nargs < jl_page_size/sizeof(jl_value_t*));
+    jl_value_t **newargs;
+    JL_GC_PUSHARGS(newargs, onstack ? nargs : 1);
+    jl_svec_t *arg_heap = NULL;
+    newargs[0] = f;  // make sure f is rooted
+    if (!onstack) {
+        arg_heap = jl_alloc_svec(nargs);
+        newargs[0] = (jl_value_t*)arg_heap;
+        newargs = jl_svec_data(arg_heap);
+        newargs[0] = f;
+    }
+    memcpy(&newargs[1], args, (nargs-1)*sizeof(jl_value_t*));
+    jl_value_t *ret = jl_apply_generic(newargs, nargs);
+    JL_GC_POP();
+    return ret;
+}
+
 static jl_function_t *jl_append_any_func;
 
 JL_CALLABLE(jl_f__apply)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -97,6 +97,8 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_val
 
 jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types);
 
+JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t nargs);
+
 #define GC_MAX_SZCLASS (2032-sizeof(void*))
 // MSVC miscalculates sizeof(jl_taggedvalue_t) because
 // empty structs are a GNU extension


### PR DESCRIPTION
This was a remaining TODO item from `jb/functions`. It allows us to avoid allocating a tuple for `x` where `x` is used in the context `f(x...)`. Not a large impact, but helps some of the performance regressions a small amount.
