### PR TITLE
RFC: specialized calling convention for pure functions that return a constant

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -407,6 +407,7 @@ JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(void)
     li->inInference = 0;
     li->inCompile = 0;
     li->def = NULL;
+    li->constval = NULL;
     li->pure = 0;
     li->inlineable = 0;
     return li;
@@ -525,6 +526,7 @@ static jl_lambda_info_t *jl_copy_lambda(jl_lambda_info_t *linfo)
     new_linfo->isva = linfo->isva;
     new_linfo->rettype = linfo->rettype;
     new_linfo->def = linfo->def;
+    new_linfo->constval = linfo->constval;
     return new_linfo;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -998,6 +998,7 @@ uint64_t jl_get_llvm_fptr(llvm::Function *llvmf)
 // and forces compilation of the lambda info
 extern "C" void jl_generate_fptr(jl_lambda_info_t *li)
 {
+    if (li->jlcall_api == 2) return;
     JL_LOCK(&codegen_lock);
     // objective: assign li->fptr
     assert(li->functionObjectsDecls.functionObject);
@@ -1014,7 +1015,11 @@ extern "C" void jl_generate_fptr(jl_lambda_info_t *li)
 // or generate object code for it
 extern "C" void jl_compile_linfo(jl_lambda_info_t *li)
 {
-    if (li->functionObjectsDecls.functionObject == NULL) {
+    if (li->jlcall_api == 2) {
+        // delete code for functions reduced to a constant
+        jl_set_lambda_code_null(li);
+    }
+    else if (li->functionObjectsDecls.functionObject == NULL) {
         // objective: assign li->functionObject
         to_function(li);
     }
@@ -1162,6 +1167,15 @@ void *jl_get_llvmf(jl_tupletype_t *tt, bool getwrapper, bool getdeclarations)
         else {
             return specf;
         }
+    }
+    if (linfo->jlcall_api == 2) {
+        // normally we don't generate native code for these functions, so need an exception here
+        if (linfo->functionObjectsDecls.functionObject == NULL)
+            to_function(linfo);
+        jl_set_lambda_code_null(linfo);
+    }
+    else {
+        jl_compile_linfo(linfo);
     }
     Function *llvmf;
     if (!getwrapper && linfo->functionObjectsDecls.specFunctionObject != NULL) {
@@ -2688,8 +2702,11 @@ static jl_cgval_t emit_invoke(jl_expr_t *ex, jl_codectx_t *ctx)
     jl_lambda_info_t *li = (jl_lambda_info_t*)args[0];
     assert(jl_is_lambda_info(li));
 
-    jl_cgval_t result;
-    if (li->functionObjectsDecls.functionObject == NULL) {
+    if (li->jlcall_api == 2) {
+        assert(li->constval);
+        return mark_julia_const(li->constval);
+    }
+    else if (li->functionObjectsDecls.functionObject == NULL) {
         assert(!li->inCompile);
         if (li->code == jl_nothing && !li->inInference && li->inferred) {
             // XXX: it was inferred in the past, so it's almost valid to re-infer it now
@@ -2700,6 +2717,7 @@ static jl_cgval_t emit_invoke(jl_expr_t *ex, jl_codectx_t *ctx)
         }
     }
     Value *theFptr = (Value*)li->functionObjectsDecls.functionObject;
+    jl_cgval_t result;
     if (theFptr && li->jlcall_api == 0) {
         jl_cgval_t fval = emit_expr(args[1], ctx);
         result = emit_call_function_object(li, fval, theFptr, &args[1], nargs - 1, (jl_value_t*)ex, ctx);
@@ -3519,7 +3537,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
             // may throw.
             jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match", name);
         }
-        if (!lam->functionObjectsDecls.functionObject) {
+        if (!lam->functionObjectsDecls.functionObject && lam->jlcall_api != 2) {
             jl_errorf("ERROR: cfunction: compiling %s failed", name);
         }
     }
@@ -3593,6 +3611,13 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
         }
         myargs = NULL;
     }
+    else if (lam->jlcall_api == 2) {
+        nargs = 0; // arguments not needed
+        specsig = false;
+        jlfunc_sret = false;
+        myargs = NULL;
+        theFptr = NULL;
+    }
     else {
         theFptr = (Function*)lam->functionObjectsDecls.functionObject;
         specsig = false;
@@ -3602,7 +3627,6 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
             "",
             /*InsertBefore*/ctx.ptlsStates);
     }
-    assert(theFptr);
 
     // first emit the arguments
     for (size_t i = 0; i < nargs; i++) {
@@ -3706,6 +3730,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     // Create the call
     jl_cgval_t retval;
     if (lam == NULL) {
+        assert(theFptr);
         assert(nargs >= 0);
 #ifdef LLVM37
         Value *ret = builder.CreateCall(prepare_call(theFptr), {myargs,
@@ -3717,13 +3742,18 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
         retval = mark_julia_type(ret, true, astrt, &ctx);
     }
     else if (specsig) {
+        assert(theFptr);
         bool retboxed;
         CallInst *call = builder.CreateCall(prepare_call(theFptr), ArrayRef<Value*>(args));
         call->setAttributes(theFptr->getAttributes());
         (void)julia_type_to_llvm(astrt, &retboxed);
         retval = mark_julia_type(jlfunc_sret ? (Value*)builder.CreateLoad(result) : (Value*)call, retboxed, astrt, &ctx);
     }
+    else if (lam->jlcall_api == 2) {
+        retval = mark_julia_const(lam->constval);
+    }
     else {
+        assert(theFptr);
         assert(nargs >= 0);
         // for jlcall, we need to pass the function object even if it is a ghost.
         // here we reconstruct the function instance from its type (first elt of argt)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3801,7 +3801,7 @@ void jl_init_types(void)
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaInfo"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(25,
+                        jl_svec(26,
                                 jl_symbol("rettype"),
                                 jl_symbol("sparam_syms"),
                                 jl_symbol("sparam_vals"),
@@ -3813,6 +3813,7 @@ void jl_init_types(void)
                                 jl_symbol("slotflags"),
                                 jl_symbol("unspecialized_ducttape"),
                                 jl_symbol("def"),
+                                jl_symbol("constval"),
                                 jl_symbol("nargs"),
                                 jl_symbol("isva"),
                                 jl_symbol("inferred"),
@@ -3825,7 +3826,7 @@ void jl_init_types(void)
                                 jl_symbol("fptr"),
                                 jl_symbol(""), jl_symbol(""),
                                 jl_symbol(""), jl_symbol("")),
-                        jl_svec(25,
+                        jl_svec(26,
                                 jl_any_type,
                                 jl_simplevector_type,
                                 jl_simplevector_type,
@@ -3837,6 +3838,7 @@ void jl_init_types(void)
                                 jl_array_uint8_type,
                                 jl_any_type,
                                 jl_method_type,
+                                jl_any_type,
                                 jl_int32_type,
                                 jl_bool_type,
                                 jl_bool_type,
@@ -3844,7 +3846,7 @@ void jl_init_types(void)
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type,
-                                jl_bool_type,
+                                jl_uint8_type,
                                 jl_bool_type,
                                 jl_any_type,
                                 jl_any_type, jl_any_type,
@@ -3900,9 +3902,9 @@ void jl_init_types(void)
     jl_svecset(jl_simplevector_type->types, 0, jl_long_type);
     jl_svecset(jl_typename_type->types, 6, jl_long_type);
     jl_svecset(jl_methtable_type->types, 3, jl_long_type);
-    jl_svecset(jl_lambda_info_type->types, 20, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 21, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 22, jl_voidpointer_type);
+    jl_svecset(jl_lambda_info_type->types, 23, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -246,6 +246,7 @@ typedef struct _jl_lambda_info_t {
     jl_array_t *slotflags;  // local var bit flags
     struct _jl_lambda_info_t *unspecialized_ducttape; // if template can't be compiled due to intrinsics, an un-inferred executable copy may get stored here
     jl_method_t *def; // method this is specialized from, (null if this is a toplevel thunk)
+    jl_value_t *constval;  // value of the function if jlcall_api==2
     int32_t nargs;
     int8_t isva;
     int8_t inferred;
@@ -253,7 +254,7 @@ typedef struct _jl_lambda_info_t {
     int8_t inlineable;
     int8_t inInference; // flags to tell if inference is running on this function
     int8_t inCompile; // flag to tell if codegen is running on this function
-    int8_t jlcall_api; // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t
+    int8_t jlcall_api; // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t, 2 = constval
     int8_t compile_traced; // if set will notify callback if this linfo is compiled
     jl_fptr_t fptr; // jlcall entry point
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -90,8 +90,10 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_val
         mfptr = jl_compile_for_dispatch(mfptr);
     if (mfptr->jlcall_api == 0)
         return mfptr->fptr(args[0], &args[1], nargs-1);
-    else
+    else if (mfptr->jlcall_api == 1)
         return ((jl_fptr_sparam_t)mfptr->fptr)(meth->sparam_vals, args[0], &args[1], nargs-1);
+    else
+        return meth->constval;
 }
 
 jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types);


### PR DESCRIPTION
This allows deleting their code and avoiding native code gen entirely. This happens a fair amount due to functions like `promote_type`, `zero`, trait functions, etc. It's about 8% of all inferred functions in the system image. However since such functions tend to be very small, the gains are not as much as that number might imply.
