### PR TITLE
use associative branch predictor in dispatch

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1422,6 +1422,7 @@ void jl_mark_box_caches(void);
 
 extern jl_module_t *jl_old_base_module;
 extern jl_array_t *jl_module_init_order;
+extern jl_typemap_entry_t *call_cache[N_CALL_CACHE];
 
 // mark the initial root set
 void pre_mark(void)
@@ -1452,6 +1453,9 @@ void pre_mark(void)
     gc_push_root(jl_cfunction_list.unknown, 0);
     gc_push_root(jl_anytuple_type_type, 0);
     gc_push_root(jl_ANY_flag, 0);
+    for (i = 0; i < N_CALL_CACHE; i++)
+        if (call_cache[i])
+            gc_push_root(call_cache[i], 0);
 
     jl_mark_box_caches();
     //gc_push_root(jl_unprotect_stack_func, 0);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1541,20 +1541,85 @@ static jl_value_t *verify_type(jl_value_t *v)
     return v;
 }
 
+STATIC_INLINE int sig_match_fast(jl_value_t **args, jl_value_t **sig, size_t i, size_t n)
+{
+    // NOTE: This function is a huge performance hot spot!!
+    for (; i < n; i++) {
+        jl_value_t *decl = sig[i];
+        jl_value_t *a = args[i];
+        if ((jl_value_t*)jl_typeof(a) != decl) {
+            /*
+              we are only matching concrete types here, and those types are
+              hash-consed, so pointer comparison should work.
+            */
+            return 0;
+        }
+    }
+    return 1;
+}
+
+//STATIC_INLINE jl_typemap_entry_t *sig2_match_fast(jl_value_t **args, jl_typemap_entry_t *entry1, jl_typemap_entry_t *entry2, size_t n)
+//{
+//    // NOTE: This function is a huge performance hot spot!!
+//    jl_value_t **sig1 = jl_svec_data(entry1->sig->parameters);
+//    jl_value_t **sig2 = jl_svec_data(entry2->sig->parameters);
+//    size_t i;
+//    for (i = 0; i < n; i++) {
+//        jl_value_t *decl1 = sig1[i];
+//        jl_value_t *decl2 = sig2[i];
+//        jl_value_t *a = args[i];
+//        jl_value_t *ta = jl_typeof(a);
+//        if (ta != decl1) {
+//            /*
+//              we are only matching concrete types here, and those types are
+//              hash-consed, so pointer comparison should work.
+//            */
+//            return sig_match_fast(args, sig2, i, n) ? entry2 : NULL;
+//        }
+//        if (ta != decl2) {
+//            /*
+//              we are only matching concrete types here, and those types are
+//              hash-consed, so pointer comparison should work.
+//            */
+//            return sig_match_fast(args, sig1, i, n) ? entry1 : NULL;
+//        }
+//    }
+//    return entry1;
+//}
+
+jl_typemap_entry_t *call_cache[N_CALL_CACHE];
+static uint8_t pick_which[N_CALL_CACHE];
+#ifdef JL_GF_PROFILE
+void call_cache_stats() {
+    int pick_which_stat[4] = {0, 0, 0, 0};
+    int i, count = 0;
+    for (i = 0; i < N_CALL_CACHE; i++) {
+        if (call_cache[i])
+            count++;
+    }
+    for (i = 0; i < N_CALL_CACHE; i++) {
+        ++pick_which_stat[pick_which[i] & 3];
+    }
+    jl_safe_printf("cache occupied: %d / %d; pick_which stats: {%d, %d, %d, %d}\n",
+            count, N_CALL_CACHE,
+            pick_which_stat[0], pick_which_stat[1], pick_which_stat[2], pick_which_stat[3]);
+}
+#endif
+
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
 {
-    jl_value_t *F = args[0];
-    jl_methtable_t *mt = jl_gf_mtable(F);
 #ifdef JL_GF_PROFILE
     mt->ncalls++;
 #endif
 #ifdef JL_TRACE
     int traceen = trace_en; //&& ((char*)&mt < jl_stack_hi-6000000);
     if (traceen)
-        show_call(F, &args[1], nargs-1);
+        show_call(args[0], &args[1], nargs-1);
 #endif
+
     /*
       search order:
+      check associative hash based on callsite address for leafsig match
       look at concrete signatures
       if there is an exact match, return it
       otherwise look for a matching generic signature
@@ -1562,7 +1627,117 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
       if no generic match, use the concrete one even if inexact
       otherwise instantiate the generic method and use it
     */
-    jl_typemap_entry_t *entry = jl_typemap_assoc_exact(mt->cache, args, nargs, jl_cachearg_offset(mt));
+    int callsite = int32hash((uintptr_t)__builtin_return_address(0));
+    // implementation 1
+//    int cache_idx1 = (callsite) & (N_CALL_CACHE - 1);
+//    int cache_idx2 = (callsite >> 16) & (N_CALL_CACHE - 1);
+//    jl_typemap_entry_t *entry1 = call_cache[cache_idx1];
+//    jl_typemap_entry_t *entry2 = call_cache[cache_idx2];
+//    jl_methtable_t *mt = NULL;
+//    jl_typemap_entry_t *entry = NULL;
+//    if (entry1 && nargs == jl_svec_len(entry1->sig->parameters)) {
+//        if (entry2 && nargs == jl_svec_len(entry2->sig->parameters))
+//            entry = sig2_match_fast(args, entry1, entry2, nargs);
+//        else if (sig_match_fast(args, jl_svec_data(entry1->sig->parameters), 0, nargs))
+//            entry = entry1;
+//    }
+//    else if (entry2 && nargs == jl_svec_len(entry2->sig->parameters)) {
+//        if (sig_match_fast(args, jl_svec_data(entry2->sig->parameters), 0, nargs))
+//            entry = entry2;
+//    }
+//
+//    if (entry == NULL) {
+//        jl_value_t *F = args[0];
+//        mt = jl_gf_mtable(F);
+//        entry = jl_typemap_assoc_exact(mt->cache, args, nargs, jl_cachearg_offset(mt));
+//        if (entry && entry->isleafsig && entry->simplesig == (void*)jl_nothing && entry->guardsigs == jl_emptysvec) {
+//            switch (++pick_which[cache_idx1] & 1) {
+//            case 0:
+//                call_cache[cache_idx1] = entry;
+//                break;
+//            case 1:
+//                call_cache[cache_idx2] = entry;
+//                break;
+//            }
+//        }
+//    }
+
+    // implementation 2
+//    int cache_idx1 = (callsite) & (N_CALL_CACHE - 1);
+//    int cache_idx2 = (callsite >> 8) & (N_CALL_CACHE - 1);
+//    int cache_idx3 = (callsite >> 16) & (N_CALL_CACHE - 1);
+//    int cache_idx4 = (callsite >> 24) & (N_CALL_CACHE - 1);
+//    jl_typemap_entry_t *entry = call_cache[cache_idx1];
+//    jl_methtable_t *mt = NULL;
+//    if (!entry || nargs != jl_svec_len(entry->sig->parameters) ||
+//            !sig_match_fast(args, jl_svec_data(entry->sig->parameters), nargs)) {
+//        entry = call_cache[cache_idx2];
+//        if (!entry || nargs != jl_svec_len(entry->sig->parameters) ||
+//                !sig_match_fast(args, jl_svec_data(entry->sig->parameters), nargs)) {
+//            entry = call_cache[cache_idx3];
+//            if (!entry || nargs != jl_svec_len(entry->sig->parameters) ||
+//                    !sig_match_fast(args, jl_svec_data(entry->sig->parameters), nargs)) {
+//                entry = call_cache[cache_idx4];
+//                if (!entry || nargs != jl_svec_len(entry->sig->parameters) ||
+//                    !sig_match_fast(args, jl_svec_data(entry->sig->parameters), nargs)) {
+//
+//                    jl_value_t *F = args[0];
+//                    mt = jl_gf_mtable(F);
+//                    entry = jl_typemap_assoc_exact(mt->cache, args, nargs, jl_cachearg_offset(mt));
+//                    if (entry && entry->isleafsig && entry->simplesig == (void*)jl_nothing && entry->guardsigs == jl_emptysvec) {
+//                        switch (++pick_which[cache_idx1] & 3) {
+//                        case 0:
+//                            call_cache[cache_idx1] = entry;
+//                            break;
+//                        case 1:
+//                            call_cache[cache_idx2] = entry;
+//                            break;
+//                        case 2:
+//                            call_cache[cache_idx3] = entry;
+//                            break;
+//                        case 3:
+//                            call_cache[cache_idx4] = entry;
+//                            break;
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
+
+    // implementation 3
+    // compute the entry hashes
+    // use different parts of the value
+    // so that a collision across all of
+    // them is less likely
+    uint32_t cache_idx[4] = {
+        (callsite) & (N_CALL_CACHE - 1),
+        (callsite >> 8) & (N_CALL_CACHE - 1),
+        (callsite >> 16) & (N_CALL_CACHE - 1),
+        (callsite >> 24 | callsite << 8) & (N_CALL_CACHE - 1)};
+    jl_typemap_entry_t *entry = NULL;
+    jl_methtable_t *mt = NULL;
+    int i;
+    // check each cache entry to see if it matches
+    for (i = 0; i < 4; i++) {
+        entry = call_cache[cache_idx[i]];
+        if (entry && nargs == jl_svec_len(entry->sig->parameters) &&
+            sig_match_fast(args, jl_svec_data(entry->sig->parameters), 0, nargs)) {
+            break;
+        }
+    }
+    // if no method was found in the associative cache, check the full cache
+    if (i == 4) {
+        jl_value_t *F = args[0];
+        mt = jl_gf_mtable(F);
+        entry = jl_typemap_assoc_exact(mt->cache, args, nargs, jl_cachearg_offset(mt));
+        if (entry && entry->isleafsig && entry->simplesig == (void*)jl_nothing && entry->guardsigs == jl_emptysvec) {
+            // put the entry into the cache if is valid for a leaftype lookup,
+            // using pick_which to slightly randomize where it ends up
+            call_cache[cache_idx[++pick_which[cache_idx[0]] & 3]] = entry;
+        }
+    }
+
     jl_lambda_info_t *mfunc = NULL;
     jl_tupletype_t *tt = NULL;
     if (entry == NULL) {
@@ -1579,7 +1754,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
                 show_call(F, args, nargs);
 #endif
             JL_GC_POP();
-            jl_method_error((jl_function_t*)F, args, nargs);
+            jl_method_error((jl_function_t*)args[0], args, nargs);
             // unreachable
         }
         jl_value_t *res = jl_call_method_internal(mfunc, args, nargs);

--- a/src/options.h
+++ b/src/options.h
@@ -8,6 +8,8 @@
 // Build-time options for debugging, tweaking, and selecting alternative
 // implementations of core features.
 
+#define N_CALL_CACHE 4096
+
 // object layout options ------------------------------------------------------
 
 // how much space we're willing to waste if an array outgrows its


### PR DESCRIPTION
this includes several alternative implementations for your consideration:
performance on my machine seemed to be about the same, so I went with the simplest

also removes the LRU optimization from typemap,
in favor of this thread-safe cache

ref #16128
closes https://github.com/JuliaLang/julia/pull/11862
