### PR TITLE
ndigits: check for invalid bases (fix #16766)

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -8,8 +8,8 @@ import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
              binomial, cmp, convert, div, divrem, factorial, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, powermod,
              sum, trailing_zeros, trailing_ones, count_ones, base, tryparse_internal,
-             bin, oct, dec, hex, isequal, invmod, prevpow2, nextpow2, ndigits0z, widen, signed, unsafe_trunc, trunc,
-             iszero, big, flipsign, signbit
+             bin, oct, dec, hex, isequal, invmod, prevpow2, nextpow2, ndigits0z,
+             ndigits0znb, widen, signed, unsafe_trunc, trunc, iszero, big, flipsign, signbit
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -581,6 +581,7 @@ end
 
 function ndigits0z(x::BigInt, b::Integer=10)
     b < 2 && throw(DomainError())
+    x.size == 0 && return 0 # for consistency with other ndigits0z methods
     if ispow2(b) && 2 <= b <= 62 # GMP assumes b is in this range
         Int(ccall((:__gmpz_sizeinbase,:libgmp), Csize_t, (Ptr{BigInt}, Cint), &x, b))
     else
@@ -600,7 +601,6 @@ function ndigits0z(x::BigInt, b::Integer=10)
         end
     end
 end
-ndigits(x::BigInt, b::Integer=10) = iszero(x) ? 1 : ndigits0z(x,b)
 
 # below, ONE is always left-shifted by at least one digit, so a new BigInt is
 # allocated, which can be safely mutated

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -8,8 +8,8 @@ import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
              binomial, cmp, convert, div, divrem, factorial, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, powermod,
              sum, trailing_zeros, trailing_ones, count_ones, base, tryparse_internal,
-             bin, oct, dec, hex, isequal, invmod, prevpow2, nextpow2, ndigits0z,
-             ndigits0znb, widen, signed, unsafe_trunc, trunc, iszero, big, flipsign, signbit
+             bin, oct, dec, hex, isequal, invmod, prevpow2, nextpow2, ndigits0zpb,
+             widen, signed, unsafe_trunc, trunc, iszero, big, flipsign, signbit
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -579,7 +579,7 @@ function base(b::Integer, n::BigInt, pad::Integer)
     String(buf)
 end
 
-function ndigits0z(x::BigInt, b::Integer=10)
+function ndigits0zpb(x::BigInt, b::Integer)
     b < 2 && throw(DomainError())
     x.size == 0 && return 0 # for consistency with other ndigits0z methods
     if ispow2(b) && 2 <= b <= 62 # GMP assumes b is in this range

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -278,10 +278,10 @@ ndigits_mismatch(n) = ndigits(n) != ndigits(BigInt(n))
 @test !any(ndigits_mismatch, 8192:9999)
 
 # The following should not crash (#16579)
-ndigits(rand(big.(-999:999)), rand(63:typemax(Int)))
-ndigits(rand(big.(-999:999)), big(2)^rand(2:999))
+ndigits(big(rand(Int)), rand(63:typemax(Int)))
+ndigits(big(rand(Int)), big(2)^rand(2:999))
 
-for i in big.([-20:-1;1:20])
+for i in big.([-20:-1;1:20; rand(Int)])
     for b in -10:1
         @test_throws DomainError ndigits(i, b)
     end

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -281,11 +281,13 @@ ndigits_mismatch(n) = ndigits(n) != ndigits(BigInt(n))
 ndigits(big(rand(Int)), rand(63:typemax(Int)))
 ndigits(big(rand(Int)), big(2)^rand(2:999))
 
-for i in big.([-20:-1;1:20; rand(Int)])
-    for b in -10:1
-        @test_throws DomainError ndigits(i, b)
+for x in big.([-20:20; rand(Int)])
+    for b in -1:1
+        @test_throws DomainError ndigits(x, b)
     end
 end
+
+@test Base.ndigits0zpb(big(0), big(rand(2:100))) == 0
 
 # conversion from float
 @test BigInt(2.0) == BigInt(2.0f0) == BigInt(big(2.0)) == 2

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -85,8 +85,14 @@ end
 
 @test ndigits(146, -3) == 5
 
-let n = rand(Int)
+let (n, b) = rand(Int, 2)
+    -1 <= b <= 1 && (b = 2) # invalid bases
     @test ndigits(n) == ndigits(big(n)) == ndigits(n, 10)
+    @test ndigits(n, b) == ndigits(big(n), b)
+end
+
+for b in -1:1
+    @test_throws DomainError ndigits(rand(Int), b)
 end
 @test ndigits(Int8(5)) == ndigits(5)
 

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -99,6 +99,10 @@ end
 # issue #19367
 @test ndigits(Int128(2)^64, 256) == 9
 
+# test unsigned bases
+@test ndigits(9, 0x2) == 4
+@test ndigits(0x9, 0x2) == 4
+
 @test bin('3') == "110011"
 @test bin('3',7) == "0110011"
 @test bin(3) == "11"


### PR DESCRIPTION
I made `ndigits(x, b)` with `-1 <= b <= 1` an error in all cases, even if `x == 0`, as I thought it was more consistent. There were a lot of dispatch methods `ndigits[0z][nb](x, [b])`, so it's possible I messed up one of the paths.
Also I removed the `ndigits(::BigInt, [b])` method, to handle the base check in only one place, the drawback being that we then compare `x == 0` instead of the probably more efficient `x.size == 0`.
Hopefully this is overall a simplification of the `ndigits` logic.
