### PR TITLE
Fixes for compact printing

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -97,7 +97,7 @@ macro enum(T,syms...)
                 print(io, x)
             else
                 print(io, x, "::")
-                show(IOContext(io, :multiline => false), typeof(x))
+                showcompact(io, typeof(x))
                 print(io, " = ", Int(x))
             end
         end

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2855,12 +2855,14 @@ Show an expression and result, returning the result.
 """
     showcompact(x)
 
-Show a more compact representation of a value.
+Show a compact representation of a value.
 
-This is used for printing array elements. If a new type has a different compact representation,
-it should test `get(io, :compact, false)` in its normal `show` method.
-A compact representation should skip any type information, which would be redundant
-with that printed once for the whole array.
+This is used for printing array elements without repeating type information (which would
+be redundant with that printed once for the whole array), and without line breaks inside
+the representation of an element.
+
+To offer a compact representation different from its standard one, a custom type should
+test `get(io, :compact, false)` in its normal `show` method.
 """
 showcompact
 

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -35,9 +35,11 @@ function show{T}(io::IO, x::Nullable{T})
             show(io, x.value)
         end
     else
-        print(io, "Nullable{", T, "}(")
+        print(io, "Nullable{")
+        showcompact(io, eltype(x))
+        print(io, "}(")
         if !isnull(x)
-            show(io, x.value)
+            showcompact(io, x.value)
         end
         print(io, ')')
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1542,9 +1542,18 @@ end
 showcompact(x) = showcompact(STDOUT, x)
 function showcompact(io::IO, x)
     if get(io, :compact, false)
-        show(io, x)
+        if !get(io, :multiline, false)
+            show(io, x)
+        else
+            show(IOContext(io, :multiline => false), x)
+        end
     else
-        show(IOContext(io, :compact => true), x)
+        if get(io, :multiline, false)
+            show(IOContext(io, :compact => true), x)
+        else
+            show(IOContext(IOContext(io, :compact => true),
+                           :multiline => false), x)
+        end
     end
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1548,7 +1548,7 @@ function showcompact(io::IO, x)
             show(IOContext(io, :multiline => false), x)
         end
     else
-        if get(io, :multiline, false)
+        if !get(io, :multiline, false)
             show(IOContext(io, :compact => true), x)
         else
             show(IOContext(IOContext(io, :compact => true),

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -434,9 +434,11 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   Show a more compact representation of a value.
+   Show a compact representation of a value.
 
-   This is used for printing array elements. If a new type has a different compact representation, it should test ``get(io, :compact, false)`` in its normal ``show`` method. A compact representation should skip any type information, which would be redundant with that printed once for the whole array.
+   This is used for printing array elements without repeating type information (which would be redundant with that printed once for the whole array), and without line breaks inside the representation of an element.
+
+   To offer a compact representation different from its standard one, a custom type should test ``get(io, :compact, false)`` in its normal ``show`` method.
 
 .. function:: showall(x)
 

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -85,10 +85,10 @@ for (i, T) in enumerate(types)
     show(io1, x1)
     @test takebuf_string(io1) == @sprintf("Nullable{%s}()", T)
     show(io1, x2)
-    show(io2, get(x2))
+    showcompact(io2, get(x2))
     @test takebuf_string(io1) == @sprintf("Nullable{%s}(%s)", T, takebuf_string(io2))
     show(io1, x3)
-    show(io2, get(x3))
+    showcompact(io2, get(x3))
     @test takebuf_string(io1) == @sprintf("Nullable{%s}(%s)", T, takebuf_string(io2))
 
     a1 = [x2]
@@ -101,6 +101,13 @@ for (i, T) in enumerate(types)
     show(IOContext(io2, compact=true), x2)
     @test takebuf_string(io1) ==
         @sprintf("Nullable{%s}[%s]", string(T), takebuf_string(io2))
+end
+
+module NullableTestEnum
+    io = IOBuffer()
+    @enum TestEnum a b
+    show(io, Nullable(a))
+    Base.Test.@test takebuf_string(io) == "Nullable{NullableTestEnum.TestEnum}(a)"
 end
 
 # showcompact(io::IO, x::Nullable)

--- a/test/show.jl
+++ b/test/show.jl
@@ -447,3 +447,16 @@ end
 # PR #16651
 @test !contains(repr(ones(10,10)), "\u2026")
 @test contains(sprint((io,x)->show(IOContext(io,:limit=>true), x), ones(30,30)), "\u2026")
+
+# showcompact() also sets :multiline=>false (#16817)
+let io = IOBuffer()
+    x = [1, 2]
+    showcompact(io, x)
+    @test takebuf_string(io) == "[1,2]"
+    showcompact(IOContext(io, :multiline=>true), x)
+    @test takebuf_string(io) == "[1,2]"
+    showcompact(IOContext(io, :compact=>true), x)
+    @test takebuf_string(io) == "[1,2]"
+    showcompact(IOContext(IOContext(io, :compact=>true), :multiline=>true), x)
+    @test takebuf_string(io) == "[1,2]"
+end


### PR DESCRIPTION
This is a follow-up from https://github.com/JuliaLang/julia/pull/16817. I think the second commit is uncontroversial. 

The first one may need more design discussion. Setting `:multiline=>false` in `showcompact` sounds logical, but it's slightly annoying that it breaks the direct correspondence with the `:compact=>true` `IOContext` property. I don't know whether that's a problem or not. It could be good to rename either the method or the property, but we'd need to find a non-breaking solution.
