### PR TITLE
GC bits clean up and more precise write barrier

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -640,7 +640,7 @@ static uintptr_t hash_symbol(const char *str, size_t len)
 
 static size_t symbol_nbytes(size_t len)
 {
-    return (sizeof_jl_taggedvalue_t + sizeof(jl_sym_t) + len + 1 + 7) & -8;
+    return (sizeof(jl_taggedvalue_t) + sizeof(jl_sym_t) + len + 1 + 7) & -8;
 }
 
 static jl_sym_t *mk_symbol(const char *str, size_t len)
@@ -667,7 +667,7 @@ static jl_sym_t *mk_symbol(const char *str, size_t len)
 #endif
     sym = (jl_sym_t*)jl_valueof(tag);
     // set to old marked since we don't need write barrier on it.
-    tag->type_bits = ((uintptr_t)jl_sym_type) | GC_MARKED;
+    tag->header = ((uintptr_t)jl_sym_type) | GC_MARKED;
     sym->left = sym->right = NULL;
     sym->hash = hash_symbol(str, len);
     memcpy(jl_symbol_name(sym), str, len);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -667,7 +667,7 @@ static jl_sym_t *mk_symbol(const char *str, size_t len)
 #endif
     sym = (jl_sym_t*)jl_valueof(tag);
     // set to old marked since we don't need write barrier on it.
-    tag->header = ((uintptr_t)jl_sym_type) | GC_MARKED;
+    tag->header = ((uintptr_t)jl_sym_type) | GC_OLD_MARKED;
     sym->left = sym->right = NULL;
     sym->hash = hash_symbol(str, len);
     memcpy(jl_symbol_name(sym), str, len);

--- a/src/array.c
+++ b/src/array.c
@@ -603,7 +603,7 @@ static void array_resize_buffer(jl_array_t *a, size_t newlen, size_t oldlen, siz
     if (a->flags.ptrarray || es==1)
         memset(newdata+offsnb+oldnbytes, 0, nbytes-oldnbytes-offsnb);
     if (a->flags.how == 1)
-        jl_gc_wb_buf(a, newdata);
+        jl_gc_wb_buf(a, newdata, newlen * es);
     a->maxsize = newlen;
 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -1544,7 +1544,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
                 break;
             jl_binding_t *b = jl_get_binding_wr(m, name);
             b->value = jl_deserialize_value(s, &b->value);
-            jl_gc_wb_buf(m, b);
+            jl_gc_wb_buf(m, b, sizeof(jl_binding_t));
             if (b->value != NULL) jl_gc_wb(m, b->value);
             b->globalref = jl_deserialize_value(s, &b->globalref);
             if (b->globalref != NULL) jl_gc_wb(m, b->globalref);

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -362,8 +362,8 @@ static void gc_scrub_range(char *stack_lo, char *stack_hi)
         //  bit patterns)
         *ages &= ~(1 << (obj_id % 8));
         memset(tag, 0xff, osize);
-        // set mark to GC_MARKED_NOESC (young and marked)
-        tag->bits.gc = GC_MARKED_NOESC;
+        // set mark to GC_MARKED (young and marked)
+        tag->bits.gc = GC_MARKED;
     }
 }
 

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -361,8 +361,9 @@ static void gc_scrub_range(char *stack_lo, char *stack_hi)
         // (especially on 32bit where it's more likely to have pointer-like
         //  bit patterns)
         *ages &= ~(1 << (obj_id % 8));
-        // set mark to GC_MARKED_NOESC (young and marked)
         memset(tag, 0xff, osize);
+        // set mark to GC_MARKED_NOESC (young and marked)
+        tag->bits.gc = GC_MARKED_NOESC;
     }
 }
 

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -183,8 +183,8 @@ static void gc_verify_track(void)
         for(int i = 0; i < lostval_parents.len; i++) {
             lostval_parent = (jl_value_t*)lostval_parents.items[i];
             int clean_len = bits_save[GC_CLEAN].len;
-            for(int j = 0; j < clean_len + bits_save[GC_QUEUED].len; j++) {
-                void *p = bits_save[j >= clean_len ? GC_QUEUED : GC_CLEAN].items[j >= clean_len ? j - clean_len : j];
+            for(int j = 0; j < clean_len + bits_save[GC_OLD].len; j++) {
+                void *p = bits_save[j >= clean_len ? GC_OLD : GC_CLEAN].items[j >= clean_len ? j - clean_len : j];
                 if (jl_valueof(p) == lostval_parent) {
                     lostval = lostval_parent;
                     lostval_parent = NULL;
@@ -219,8 +219,8 @@ void gc_verify(void)
     gc_mark_object_list(&finalizer_list_marked, 0);
     visit_mark_stack();
     int clean_len = bits_save[GC_CLEAN].len;
-    for(int i = 0; i < clean_len + bits_save[GC_QUEUED].len; i++) {
-        jl_taggedvalue_t *v = (jl_taggedvalue_t*)bits_save[i >= clean_len ? GC_QUEUED : GC_CLEAN].items[i >= clean_len ? i - clean_len : i];
+    for(int i = 0; i < clean_len + bits_save[GC_OLD].len; i++) {
+        jl_taggedvalue_t *v = (jl_taggedvalue_t*)bits_save[i >= clean_len ? GC_OLD : GC_CLEAN].items[i >= clean_len ? i - clean_len : i];
         if (gc_marked(v->bits.gc)) {
             jl_printf(JL_STDERR, "Error. Early free of %p type :", v);
             jl_(jl_typeof(jl_valueof(v)));
@@ -740,7 +740,7 @@ static size_t pool_stats(jl_gc_pool_t *p, size_t *pwaste, size_t *np,
             }
             else {
                 nused++;
-                if (v->bits.gc == GC_MARKED) {
+                if (v->bits.gc == GC_OLD_MARKED) {
                     nold++;
                 }
             }

--- a/src/gc.h
+++ b/src/gc.h
@@ -101,7 +101,6 @@ typedef struct _bigval_t {
         uintptr_t header;
         struct {
             uintptr_t gc:2;
-            uintptr_t pooled:1;
         } bits;
     };
     // must be 64-byte aligned here, in 32 & 64 bit modes
@@ -238,11 +237,15 @@ STATIC_INLINE region_t *find_region(void *ptr, int maybe)
     return NULL;
 }
 
-STATIC_INLINE jl_gc_pagemeta_t *page_metadata(void *data)
+STATIC_INLINE jl_gc_pagemeta_t *page_metadata_(void *data, region_t *r)
 {
-    region_t *r = find_region(data, 0);
     int pg_idx = page_index(r, (char*)data - GC_PAGE_OFFSET);
     return &r->meta[pg_idx];
+}
+
+STATIC_INLINE jl_gc_pagemeta_t *page_metadata(void *data)
+{
+    return page_metadata_(data, find_region(data, 0));
 }
 
 STATIC_INLINE void gc_big_object_unlink(const bigval_t *hdr)

--- a/src/gc.h
+++ b/src/gc.h
@@ -217,7 +217,7 @@ STATIC_INLINE int gc_marked(int bits)
 
 STATIC_INLINE int gc_old(int bits)
 {
-    return bits == GC_OLD || bits == GC_OLD_MARKED;
+    return (bits & GC_OLD) != 0;
 }
 
 NOINLINE uintptr_t gc_get_stack_ptr(void);

--- a/src/gc.h
+++ b/src/gc.h
@@ -208,9 +208,15 @@ STATIC_INLINE int page_index(region_t *region, void *data)
     return (gc_page_data(data) - region->pages->data) / GC_PAGE_SZ;
 }
 
-#define gc_bits(o) (((jl_taggedvalue_t*)(o))->bits.gc)
-#define gc_marked(o)  (((jl_taggedvalue_t*)(o))->bits.gc & GC_MARKED)
-#define _gc_setmark(o, mark_mode) (((jl_taggedvalue_t*)(o))->bits.gc = mark_mode)
+STATIC_INLINE int gc_marked(int bits)
+{
+    return (bits & GC_MARKED) != 0;
+}
+
+STATIC_INLINE int gc_old(int bits)
+{
+    return bits == GC_QUEUED || bits == GC_MARKED;
+}
 
 NOINLINE uintptr_t gc_get_stack_ptr(void);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -77,7 +77,6 @@ struct _jl_taggedvalue_t {
         jl_value_t *type; // 16-byte aligned
         struct {
             uintptr_t gc:2;
-            uintptr_t pooled:1;
         } bits;
     };
     // jl_value_t value;

--- a/src/julia.h
+++ b/src/julia.h
@@ -649,15 +649,15 @@ JL_DLLEXPORT void jl_gc_queue_root(jl_value_t *root); // root isa jl_value_t*
 STATIC_INLINE void jl_gc_wb(void *parent, void *ptr)
 {
     // parent and ptr isa jl_value_t*
-    if (__unlikely((jl_astaggedvalue(parent)->bits.gc & 1) == 1 &&
+    if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 &&
                    (jl_astaggedvalue(ptr)->bits.gc & 1) == 0))
         jl_gc_queue_root((jl_value_t*)parent);
 }
 
 STATIC_INLINE void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
 {
-    // if ptr is marked
-    if (__unlikely((jl_astaggedvalue(ptr)->bits.gc & 1) == 1)) {
+    // if ptr is old
+    if (__unlikely(jl_astaggedvalue(ptr)->bits.gc & 2)) {
         jl_gc_queue_root((jl_value_t*)ptr);
     }
 }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -112,7 +112,7 @@ void gc_setmark_buf(void *buf, int);
 
 STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_value_t*
 {
-    if (__unlikely((jl_astaggedvalue(bnd)->bits.gc & 1) == 1 &&
+    if (__unlikely(jl_astaggedvalue(bnd)->bits.gc == 3 &&
                    (jl_astaggedvalue(val)->bits.gc & 1) == 0))
         gc_queue_binding(bnd);
 }
@@ -120,9 +120,9 @@ STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_
 STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr) // parent isa jl_value_t*
 {
     // if parent is marked and buf is not
-    if (__unlikely((jl_astaggedvalue(parent)->bits.gc & 1) == 1))
-        //            (jl_astaggedvalue(bufptr)->bits.gc) != 1))
-        gc_setmark_buf(bufptr, jl_astaggedvalue(parent)->bits.gc);
+    if (__unlikely(jl_astaggedvalue(parent)->bits.gc & 1)) {
+        gc_setmark_buf(bufptr, 3);
+    }
 }
 
 void gc_debug_print_status(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -100,9 +100,6 @@ jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types
 JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t nargs);
 
 #define GC_MAX_SZCLASS (2032-sizeof(void*))
-// MSVC miscalculates sizeof(jl_taggedvalue_t) because
-// empty structs are a GNU extension
-#define sizeof_jl_taggedvalue_t (sizeof(void*))
 void jl_gc_setmark(jl_value_t *v);
 void jl_gc_sync_total_bytes(void);
 void jl_gc_track_malloced_array(jl_array_t *a);
@@ -115,17 +112,17 @@ void gc_setmark_buf(void *buf, int);
 
 STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_value_t*
 {
-    if (__unlikely((jl_astaggedvalue(bnd)->gc_bits & 1) == 1 &&
-                   (jl_astaggedvalue(val)->gc_bits & 1) == 0))
+    if (__unlikely((jl_astaggedvalue(bnd)->bits.gc & 1) == 1 &&
+                   (jl_astaggedvalue(val)->bits.gc & 1) == 0))
         gc_queue_binding(bnd);
 }
 
 STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr) // parent isa jl_value_t*
 {
     // if parent is marked and buf is not
-    if (__unlikely((jl_astaggedvalue(parent)->gc_bits & 1) == 1))
-        //            (jl_astaggedvalue(bufptr)->gc_bits) != 1))
-        gc_setmark_buf(bufptr, jl_astaggedvalue(parent)->gc_bits);
+    if (__unlikely((jl_astaggedvalue(parent)->bits.gc & 1) == 1))
+        //            (jl_astaggedvalue(bufptr)->bits.gc) != 1))
+        gc_setmark_buf(bufptr, jl_astaggedvalue(parent)->bits.gc);
 }
 
 void gc_debug_print_status(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -21,6 +21,9 @@ extern "C" {
 #define GC_QUEUED 2 // if it is reachable it will be marked as old
 #define GC_MARKED_NOESC (GC_MARKED | GC_QUEUED) // reachable and young
 
+#define GC_OLD_MARKED GC_MARKED
+#define GC_OLD GC_QUEUED
+
 // useful constants
 extern jl_methtable_t *jl_type_type_mt;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -16,13 +16,10 @@
 extern "C" {
 #endif
 
-#define GC_CLEAN 0 // freshly allocated
-#define GC_MARKED 1 // reachable and old
-#define GC_QUEUED 2 // if it is reachable it will be marked as old
-#define GC_MARKED_NOESC (GC_MARKED | GC_QUEUED) // reachable and young
-
-#define GC_OLD_MARKED GC_MARKED
-#define GC_OLD GC_QUEUED
+#define GC_CLEAN  0 // freshly allocated
+#define GC_MARKED 1 // reachable and young
+#define GC_OLD    2 // if it is reachable it will be marked as old
+#define GC_OLD_MARKED (GC_OLD | GC_MARKED) // reachable and old
 
 // useful constants
 extern jl_methtable_t *jl_type_type_mt;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -108,7 +108,7 @@ void jl_gc_run_all_finalizers(void);
 void *allocb(size_t sz);
 
 void gc_queue_binding(jl_binding_t *bnd);
-void gc_setmark_buf(void *buf, int);
+void gc_setmark_buf(void *buf, int, size_t);
 
 STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_value_t*
 {
@@ -117,11 +117,11 @@ STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_
         gc_queue_binding(bnd);
 }
 
-STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr) // parent isa jl_value_t*
+STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr, size_t minsz) // parent isa jl_value_t*
 {
     // if parent is marked and buf is not
     if (__unlikely(jl_astaggedvalue(parent)->bits.gc & 1)) {
-        gc_setmark_buf(bufptr, 3);
+        gc_setmark_buf(bufptr, 3, minsz);
     }
 }
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -29,8 +29,8 @@
 #include <signal.h>
 
 typedef struct {
-    struct _buff_t *freelist;   // root of list of free objects
-    struct _buff_t *newpages;   // root of list of chunks of free objects
+    jl_taggedvalue_t *freelist;   // root of list of free objects
+    jl_taggedvalue_t *newpages;   // root of list of chunks of free objects
     uint16_t end_offset; // stored to avoid computing it at each allocation
     uint16_t osize;      // size of objects in this pool
     uint16_t nfree;      // number of free objects in page pointed into by free_list

--- a/src/module.c
+++ b/src/module.c
@@ -106,7 +106,7 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
     b = new_binding(var);
     b->owner = m;
     *bp = b;
-    jl_gc_wb_buf(m, b);
+    jl_gc_wb_buf(m, b, sizeof(jl_binding_t));
     return *bp;
 }
 
@@ -146,7 +146,7 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_
     b = new_binding(var);
     b->owner = m;
     *bp = b;
-    jl_gc_wb_buf(m, b);
+    jl_gc_wb_buf(m, b, sizeof(jl_binding_t));
     return *bp;
 }
 
@@ -316,7 +316,7 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
             nb->imported = (explici!=0);
             nb->deprecated = b->deprecated;
             *bp = nb;
-            jl_gc_wb_buf(to, nb);
+            jl_gc_wb_buf(to, nb, sizeof(jl_binding_t));
         }
     }
 }
@@ -387,7 +387,7 @@ JL_DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s)
         // don't yet know who the owner is
         b->owner = NULL;
         *bp = b;
-        jl_gc_wb_buf(from, b);
+        jl_gc_wb_buf(from, b, sizeof(jl_binding_t));
     }
     assert(*bp != HT_NOTFOUND);
     (*bp)->exportp = 1;

--- a/src/task.c
+++ b/src/task.c
@@ -566,9 +566,10 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
 #else
     JL_GC_PUSH1(&t);
 
-    char *stk = allocb(ssize+pagesz+(pagesz-1));
+    size_t stkbuf_sz = ssize + pagesz + (pagesz - 1);
+    char *stk = allocb(stkbuf_sz);
     t->stkbuf = stk;
-    jl_gc_wb_buf(t, t->stkbuf);
+    jl_gc_wb_buf(t, t->stkbuf, stkbuf_sz);
     stk = (char*)LLT_ALIGN((uintptr_t)stk, pagesz);
     // add a guard page to detect stack overflow
     if (mprotect(stk, pagesz-1, PROT_NONE) == -1)


### PR DESCRIPTION
- Merge `gcval_t` and `buff_t` into `jl_taggedvalue_t`
- More explicit typing in the GC (to distinguish value pointer and tagged pointer)
- Flip the meaning of `GC_MARKED=0x1` and `GC_MARKED_NOESC=0x3` so that the `0x2` bit always means old.
  
  It took me a while to get used to `GC_MARKED` being young......
- Make the write barrier more precise such that old object that has write barrier triggered won't trigger the write barrier as the child.
  
  This add one more instruction on x86 but AFAICT it doesn't affect performance.
- Delete the `pooled` flag from `jl_taggedvalue_t`
- Random other cleanups.

@carnaval 
