### PR TITLE
RFC: ensure the array constructors are generally using leaftypes

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -348,7 +348,7 @@ similar{T}(a::AbstractArray{T}, dims::DimOrInd...)       = similar(a, T, to_shap
 similar(   a::AbstractArray, T::Type, dims::DimOrInd...) = similar(a, T, to_shape(dims))
 similar(   a::AbstractArray, T::Type, dims)              = similar(a, T, to_shape(dims))
 # similar creates an Array by default
-similar(   a::AbstractArray, T::Type, dims::Dims)        = Array{T,nfields(dims)}(dims)
+similar{N}(a::AbstractArray, T::Type, dims::Dims{N})     = Array{T,N}(dims)
 
 to_shape(::Tuple{}) = ()
 to_shape(dims::Dims) = dims

--- a/base/array.jl
+++ b/base/array.jl
@@ -114,38 +114,38 @@ end
 
 ## Constructors ##
 
-similar(a::Array, T::Type, dims::Dims) = Array{T}(dims)
-similar{T}(a::Array{T,1})              = Array{T}(size(a,1))
-similar{T}(a::Array{T,2})              = Array{T}(size(a,1), size(a,2))
-similar{T}(a::Array{T,1}, dims::Dims)  = Array{T}(dims)
-similar{T}(a::Array{T,1}, m::Int)      = Array{T}(m)
-similar{T}(a::Array{T,1}, S::Type)     = Array{S}(size(a,1))
-similar{T}(a::Array{T,2}, dims::Dims)  = Array{T}(dims)
-similar{T}(a::Array{T,2}, m::Int)      = Array{T}(m)
-similar{T}(a::Array{T,2}, S::Type)     = Array{S}(size(a,1), size(a,2))
+similar(a::Array, T::Type, dims::Dims) = Array{T,nfields(dims)}(dims)
+similar{T}(a::Array{T,1})              = Array{T,1}(size(a,1))
+similar{T}(a::Array{T,2})              = Array{T,2}(size(a,1), size(a,2))
+similar{T}(a::Array{T,1}, dims::Dims)  = Array{T,nfields(dims)}(dims)
+similar{T}(a::Array{T,1}, m::Int)      = Array{T,1}(m)
+similar{T}(a::Array{T,1}, S::Type)     = Array{S,1}(size(a,1))
+similar{T}(a::Array{T,2}, dims::Dims)  = Array{T,nfields(dims)}(dims)
+similar{T}(a::Array{T,2}, m::Int)      = Array{T,1}(m)
+similar{T}(a::Array{T,2}, S::Type)     = Array{S,2}(size(a,1), size(a,2))
 
 # T[x...] constructs Array{T,1}
 function getindex(T::Type, vals...)
-    a = Array{T}(length(vals))
+    a = Array{T,1}(length(vals))
     @inbounds for i = 1:length(vals)
         a[i] = vals[i]
     end
     return a
 end
 
-getindex(T::Type) = Array{T}(0)
-getindex(T::Type, x) = (a = Array{T}(1); @inbounds a[1] = x; a)
-getindex(T::Type, x, y) = (a = Array{T}(2); @inbounds (a[1] = x; a[2] = y); a)
-getindex(T::Type, x, y, z) = (a = Array{T}(3); @inbounds (a[1] = x; a[2] = y; a[3] = z); a)
+getindex(T::Type) = Array{T,1}(0)
+getindex(T::Type, x) = (a = Array{T,1}(1); @inbounds a[1] = x; a)
+getindex(T::Type, x, y) = (a = Array{T,1}(2); @inbounds (a[1] = x; a[2] = y); a)
+getindex(T::Type, x, y, z) = (a = Array{T,1}(3); @inbounds (a[1] = x; a[2] = y; a[3] = z); a)
 
 function getindex(::Type{Any}, vals::ANY...)
-    a = Array{Any}(length(vals))
+    a = Array{Any,1}(length(vals))
     @inbounds for i = 1:length(vals)
         a[i] = vals[i]
     end
     return a
 end
-getindex(::Type{Any}) = Array{Any}(0)
+getindex(::Type{Any}) = Array{Any,1}(0)
 
 function fill!(a::Union{Array{UInt8}, Array{Int8}}, x::Integer)
     ccall(:memset, Ptr{Void}, (Ptr{Void}, Cint, Csize_t), a, x, length(a))
@@ -195,7 +195,7 @@ convert{T,n}(::Type{Array{T}}, x::Array{T,n}) = x
 convert{T,n}(::Type{Array{T,n}}, x::Array{T,n}) = x
 
 convert{T,n,S}(::Type{Array{T}}, x::AbstractArray{S, n}) = convert(Array{T, n}, x)
-convert{T,n,S}(::Type{Array{T,n}}, x::AbstractArray{S,n}) = copy!(Array{T}(size(x)), x)
+convert{T,n,S}(::Type{Array{T,n}}, x::AbstractArray{S,n}) = copy!(Array{T,n}(size(x)), x)
 
 promote_rule{T,n,S}(::Type{Array{T,n}}, ::Type{Array{S,n}}) = Array{promote_type(T,S),n}
 
@@ -647,7 +647,7 @@ function vcat{T}(arrays::Vector{T}...)
     for a in arrays
         n += length(a)
     end
-    arr = Array{T}(n)
+    arr = Array{T,1}(n)
     ptr = pointer(arr)
     if isbits(T)
         elsz = Core.sizeof(T)
@@ -763,13 +763,13 @@ findlast(testf::Function, A) = findprev(testf, A, length(A))
 function find(testf::Function, A)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return
-    tmpI = Array{Int}(0)
+    tmpI = Array{Int,1}(0)
     for (i,a) = enumerate(A)
         if testf(a)
             push!(tmpI, i)
         end
     end
-    I = Array{Int}(length(tmpI))
+    I = Array{Int,1}(length(tmpI))
     copy!(I, tmpI)
     return I
 end
@@ -787,8 +787,8 @@ function find(A)
     return I
 end
 
-find(x::Number) = x == 0 ? Array{Int}(0) : [1]
-find(testf::Function, x::Number) = !testf(x) ? Array{Int}(0) : [1]
+find(x::Number) = x == 0 ? Array{Int,1}(0) : [1]
+find(testf::Function, x::Number) = !testf(x) ? Array{Int,1}(0) : [1]
 
 findn(A::AbstractVector) = find(A)
 
@@ -811,7 +811,7 @@ function findnz{T}(A::AbstractMatrix{T})
     nnzA = countnz(A)
     I = zeros(Int, nnzA)
     J = zeros(Int, nnzA)
-    NZs = Array{T}(nnzA)
+    NZs = Array{T,1}(nnzA)
     count = 1
     if nnzA > 0
         for j=1:size(A,2), i=1:size(A,1)
@@ -874,7 +874,7 @@ function indexin(a::AbstractArray, b::AbstractArray)
 end
 
 function findin(a, b)
-    ind = Array{Int}(0)
+    ind = Array{Int,1}(0)
     bset = Set(b)
     @inbounds for (i,ai) in enumerate(a)
         ai in bset && push!(ind, i)
@@ -969,7 +969,7 @@ end
 function setdiff(a, b)
     args_type = promote_type(eltype(a), eltype(b))
     bset = Set(b)
-    ret = Array{args_type}(0)
+    ret = Array{args_type,1}(0)
     seen = Set{eltype(a)}()
     for a_elem in a
         if !in(a_elem, seen) && !in(a_elem, bset)

--- a/base/array.jl
+++ b/base/array.jl
@@ -114,15 +114,13 @@ end
 
 ## Constructors ##
 
-similar(a::Array, T::Type, dims::Dims) = Array{T,nfields(dims)}(dims)
-similar{T}(a::Array{T,1})              = Array{T,1}(size(a,1))
-similar{T}(a::Array{T,2})              = Array{T,2}(size(a,1), size(a,2))
-similar{T}(a::Array{T,1}, dims::Dims)  = Array{T,nfields(dims)}(dims)
-similar{T}(a::Array{T,1}, m::Int)      = Array{T,1}(m)
-similar{T}(a::Array{T,1}, S::Type)     = Array{S,1}(size(a,1))
-similar{T}(a::Array{T,2}, dims::Dims)  = Array{T,nfields(dims)}(dims)
-similar{T}(a::Array{T,2}, m::Int)      = Array{T,1}(m)
-similar{T}(a::Array{T,2}, S::Type)     = Array{S,2}(size(a,1), size(a,2))
+similar{T}(a::Array{T,1})                    = Array{T,1}(size(a,1))
+similar{T}(a::Array{T,2})                    = Array{T,2}(size(a,1), size(a,2))
+similar{T}(a::Array{T,1}, S::Type)           = Array{S,1}(size(a,1))
+similar{T}(a::Array{T,2}, S::Type)           = Array{S,2}(size(a,1), size(a,2))
+similar{T}(a::Array{T}, m::Int)              = Array{T,1}(m)
+similar{N}(a::Array, T::Type, dims::Dims{N}) = Array{T,N}(dims)
+similar{T,N}(a::Array{T}, dims::Dims{N})     = Array{T,N}(dims)
 
 # T[x...] constructs Array{T,1}
 function getindex(T::Type, vals...)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -325,8 +325,8 @@ typealias NTuple{N,T} Tuple{Vararg{T,N}}
 (::Type{Array{T,2}}){T}() = Array{T,2}(0, 0)
 
 # TODO: possibly turn these into deprecations
-Array{T,N}(::Type{T}, d::NTuple{N,Int}) = Array{T}(d)
-Array{T}(::Type{T}, d::Int...) = Array{T}(d)
+Array{T,N}(::Type{T}, d::NTuple{N,Int})   = Array{T,N}(d)
+Array{T}(::Type{T}, d::Int...)            = Array(T, d)
 Array{T}(::Type{T}, m::Int)               = Array{T,1}(m)
 Array{T}(::Type{T}, m::Int,n::Int)        = Array{T,2}(m,n)
 Array{T}(::Type{T}, m::Int,n::Int,o::Int) = Array{T,3}(m,n,o)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -85,7 +85,7 @@ include("array.jl")
 (::Type{Matrix})(m::Integer, n::Integer) = Matrix{Any}(Int(m), Int(n))
 
 # TODO: possibly turn these into deprecations
-Array{T}(::Type{T}, d::Integer...) = Array{T}(convert(Tuple{Vararg{Int}}, d))
+Array{T}(::Type{T}, d::Integer...) = Array(T, convert(Tuple{Vararg{Int}}, d))
 Array{T}(::Type{T}, m::Integer)                       = Array{T,1}(Int(m))
 Array{T}(::Type{T}, m::Integer,n::Integer)            = Array{T,2}(Int(m),Int(n))
 Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) = Array{T,3}(Int(m),Int(n),Int(o))


### PR DESCRIPTION
this makes for faster dynamic dispatch and apply-type construction, but also makes for slower rand_mat_stat since `length(::Tuple)` can't be inferred (and thus the array constructor can't be inlined).

ref #16128
