### PR TITLE
RFC: Add a fallback method for sort, plus one for strings

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -413,6 +413,13 @@ end
 sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...)
 
 
+## other iterables and fallback ##
+
+sort(s::String; kws...) = String(sort(collect(s); kws...))
+sort(n::Number) = throw(MethodError("no method matching sort(::Number)"))
+sort(itr; kws...) = sort(collect(itr); kws...)
+
+
 ## selectperm: the permutation to sort the first k elements of an array ##
 
 selectperm(v::AbstractVector, k::Union{Integer,OrdinalRange}; kwargs...) =

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -416,7 +416,7 @@ sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...)
 ## other iterables and fallback ##
 
 sort(s::String; kws...) = String(sort(collect(s); kws...))
-sort(n::Number) = throw(MethodError("no method matching sort(::Number)"))
+sort(n::Number) = throw(MethodError(sort, n))
 sort(itr; kws...) = sort(collect(itr); kws...)
 
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -348,3 +348,11 @@ end
 
 # issue #12833 - type stability of sort
 @test Base.return_types(sort, (Vector{Int},)) == [Vector{Int}]
+
+# general iterables
+@test sort(take([3,2,1], 2)) == [2,3]
+@test sort(drop([1,3,2], 1)) == [2,3]
+@test sort("Julia") == "Jailu"
+@test sort("Julia", by=isupper) == "uliaJ"
+@test sort(graphemes("bca")) == collect(graphemes("abc"))
+@test_throws MethodError sort(1)


### PR DESCRIPTION
Sorting a string returns a string, sorting a number is a `MethodError`, and sorting other iterables `collect`s them first and returns an array. I separated numbers into a separate call because otherwise the `MethodError` text isn't so useful.
