### PR TITLE
deprecate 3-argument convert to String

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -299,28 +299,6 @@ function convert(::Type{String}, dat::Vector{UInt8})
     String(buf)
 end
 
-function convert(::Type{String}, a::Vector{UInt8}, invalids_as::AbstractString)
-    l = length(a)
-    idx = 1
-    iscopy = false
-    while idx <= l
-        if !is_valid_continuation(a[idx])
-            nextidx = idx+1+utf8_trailing[a[idx]+1]
-            (nextidx <= (l+1)) && (idx = nextidx; continue)
-        end
-        !iscopy && (a = copy(a); iscopy = true)
-        endn = idx
-        while endn <= l
-            !is_valid_continuation(a[endn]) && break
-            endn += 1
-        end
-        (endn > idx) && (endn -= 1)
-        splice!(a, idx:endn, invalids_as.data)
-        l = length(a)
-    end
-    String(a)
-end
-
 """
 Converts an already validated vector of `UInt16` or `UInt32` to a `String`
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -154,14 +154,6 @@ end
 @test lcfirst("")==""
 @test lcfirst("*")=="*"
 
-#more String tests
-@test convert(String, UInt8[32,107,75], "*") == " kK"
-@test convert(String, UInt8[132,107,75], "*") == "*kK"
-@test convert(String, UInt8[32,107,75], "αβ") == " kK"
-@test convert(String, UInt8[132,107,75], "αβ") == "αβkK"
-@test convert(String, UInt8[], "*") == ""
-@test convert(String, UInt8[255], "αβ") == "αβ"
-
 # test AbstractString functions at beginning of string.jl
 immutable tstStringType <: AbstractString
     data::Array{UInt8,1}


### PR DESCRIPTION
This deprecation is kind of a cheat since it changes behavior and ignores the replacement argument, but I think that may be fine since I doubt that this 3-argument convert is widely used (and never should have existed in the first place).
