### PR TITLE
allow parsing `{ }` vector and matrix syntax, for use by macros

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -82,19 +82,11 @@ finalize(o::ANY) = ccall(:jl_finalize, Void, (Any,), o)
 gc(full::Bool=true) = ccall(:jl_gc_collect, Void, (Cint,), full)
 gc_enable(on::Bool) = ccall(:jl_gc_enable, Cint, (Cint,), on)!=0
 
-# used by { } syntax
+# used by interpolating quote and some other things in the front end
 function vector_any(xs::ANY...)
     n = length(xs)
     a = Array{Any}(n)
-    for i=1:n
-        arrayset(a,xs[i],i)
-    end
-    a
-end
-
-function matrix_any(nr, nc, xs::ANY...)
-    a = Array{Any}(nr,nc)
-    for i=1:(nr*nc)
+    @inbounds for i = 1:n
         arrayset(a,xs[i],i)
     end
     a

--- a/base/markdown/Julia/interp.jl
+++ b/base/markdown/Julia/interp.jl
@@ -39,7 +39,7 @@ end
 
 toexpr(x) = x
 
-toexpr(xs::Vector{Any}) = Expr(:vectany, map(toexpr, xs)...)
+toexpr(xs::Vector{Any}) = Expr(:call, GlobalRef(Base,:vector_any), map(toexpr, xs)...)
 
 function deftoexpr(T)
     @eval function toexpr(md::$T)

--- a/base/show.jl
+++ b/base/show.jl
@@ -419,7 +419,7 @@ const expr_infix = Set{Symbol}([:(:), :(->), Symbol("::")])
 const expr_infix_any = union(expr_infix, expr_infix_wide)
 const all_ops = union(quoted_syms, uni_ops, expr_infix_any)
 const expr_calls  = Dict(:call =>('(',')'), :calldecl =>('(',')'), :ref =>('[',']'), :curly =>('{','}'))
-const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'), :vectany=>("Any[","]"),
+const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'),
                          :hcat =>('[',']'), :row =>('[',']'), :vect=>('[',']'))
 
 ## AST decoding helpers ##
@@ -661,7 +661,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         end
 
     # list (i.e. "(1,2,3)" or "[1,2,3]")
-    elseif haskey(expr_parens, head)               # :tuple/:vcat/:vectany
+    elseif haskey(expr_parens, head)               # :tuple/:vcat
         op, cl = expr_parens[head]
         if head === :vcat
             sep = ";"

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -36,7 +36,7 @@
                  (string #\( (deparse-arglist (cdr e))
                          (if (length= e 2) #\, "")
                          #\)))
-                ((vectany) (string #\{ (deparse-arglist (cdr e)) #\}))
+                ((cell1d) (string #\{ (deparse-arglist (cdr e)) #\}))
                 ((call)   (string (deparse (cadr e)) #\( (deparse-arglist (cddr e)) #\)))
                 ((ref)    (string (deparse (cadr e)) #\[ (deparse-arglist (cddr e)) #\]))
                 ((curly)  (string (deparse (cadr e)) #\{ (deparse-arglist (cddr e)) #\}))

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -17,9 +17,9 @@
   (if (splice-expr? x)
       (if (= d 0)
           (cadr (cadr (cadr x)))
-          (list 'vectany
+          (list 'call '(top vector_any)
                 (wrap-with-splice (julia-bq-expand (cadr (cadr (cadr x))) (- d 1)))))
-      (list 'vectany (julia-bq-expand x d))))
+      (list 'call '(top vector_any) (julia-bq-expand x d))))
 
 (define (julia-bq-expand x d)
   (cond ((or (eq? x 'true) (eq? x 'false))  x)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -499,12 +499,12 @@ end
 @test_throws ParseError parse("--x")
 @test_throws ParseError parse("stagedfunction foo(x); end")
 
-@test_throws ParseError parse("{1,2,3}")
-@test_throws ParseError parse("{1 2 3 4}")
-@test_throws ParseError parse("{1,2; 3,4}")
+#@test_throws ParseError parse("{1,2,3}")
+#@test_throws ParseError parse("{1 2 3 4}")
+#@test_throws ParseError parse("{1,2; 3,4}")
 @test_throws ParseError parse("{x for x in 1:10}")
 @test_throws ParseError parse("{x=>y for (x,y) in zip([1,2,3],[4,5,6])}")
-@test_throws ParseError parse("{:a=>1, :b=>2}")
+#@test_throws ParseError parse("{:a=>1, :b=>2}")
 
 # this now is parsed as getindex(Pair{Any,Any}, ...)
 @test_throws MethodError eval(parse("(Any=>Any)[]"))


### PR DESCRIPTION
This is an adjustment to the "cell" syntax deprecations. They can now be parsed, with the same expression heads as in 0.4, to allow use in macros. It's a safe bet that we will not eliminate `{ }` permanently, just change its meaning, so it makes sense to at least parse it. This also eliminates all internal uses of the cell1d and cell2d expression heads, making it safe to simply delete them when necessary.
