### PR TITLE
Replace '\\' with '/' for Windows filenames in Base.url

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -174,6 +174,7 @@ function url(m::Method)
     file = string(m.file)
     line = m.line
     line <= 0 || ismatch(r"In\[[0-9]+\]", file) && return ""
+    is_windows() && (file = replace(file, '\\', '/'))
     if inbase(M)
         if isempty(Base.GIT_VERSION_INFO.commit)
             # this url will only work if we're on a tagged release
@@ -190,7 +191,7 @@ function url(m::Method)
                     u = match(LibGit2.GITHUB_REGEX,u).captures[1]
                     commit = string(LibGit2.head_oid(repo))
                     root = LibGit2.path(repo)
-                    if startswith(file, root)
+                    if startswith(file, root) || startswith(realpath(file), root)
                         "https://github.com/$u/tree/$commit/"*file[length(root)+1:end]*"#L$line"
                     else
                         fileurl(file)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -185,6 +185,13 @@ temp_pkg_dir() do
         Pkg.pin("Example", v"0.4.0")
         @test Pkg.update() == nothing
         Pkg.installed()["Example"] == v"0.4.0"
+
+        # bug identified in #16850, Base.url \ vs / for non-Base methods
+        include(Pkg.dir("Example","src","Example.jl"))
+        meth = first(methods(Example.domath))
+        fname = string(meth.file)
+        @test ('\\' in fname) == is_windows()
+        @test startswith(Base.url(meth), "https://github.com/JuliaLang/Example.jl/tree")
     end
 
     # add a directory that is not a git repository


### PR DESCRIPTION
Backslashes aren't valid in urls, and this happens to also fix the outside-of-base
code below that uses libgit2 since `LibGit2.path` always uses forward slashes
(behavior inherited from the underlying `git_repository_path` function)

~~wip until I write some tests to cover the cases this fixes~~
