### PR TITLE
Mark tls getter call as pure again.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3447,6 +3447,7 @@ static void finalize_gc_frame(Function *F)
         Value *getter = tbaa_decorate(tbaa_const,
                                       new LoadInst(GV, "", ptlsStates));
         ptlsStates->setCalledFunction(getter);
+        ptlsStates->setAttributes(jltls_states_func->getAttributes());
     }
 #else
     ptlsStates->replaceAllUsesWith(prepare_global(jltls_states_var, M));


### PR DESCRIPTION
This was lost in one of the codegen refactoring a long time ago....

Fix #16804
