### PR TITLE
Use memcmp to optimize == for bit integer arrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -880,15 +880,16 @@ function lexcmp(a::Array{UInt8,1}, b::Array{UInt8,1})
 end
 
 # use memcmp for == on bit integer types
-=={T<:BitInteger,N}(a::Array{T,N}, b::Array{T,N}) =
-    size(a) == size(b) &&
-    ccall(:memcmp, Int32, (Ptr{T}, Ptr{T}, UInt), a, b, sizeof(T) * length(a)) == 0
+function =={T<:BitInteger,N}(a::Array{T,N}, b::Array{T,N})
+    size(a) == size(b) && 0 == ccall(
+        :memcmp, Int32, (Ptr{T}, Ptr{T}, UInt), a, b, sizeof(T) * length(a))
+end
 
 # this is ~20% faster than the generic implementation above for very small arrays
 function =={T<:BitInteger}(a::Array{T,1}, b::Array{T,1})
     len = length(a)
-    len == length(b) && ccall(
-        :memcmp, Int32, (Ptr{T}, Ptr{T}, UInt), a, b, sizeof(T) * len) == 0
+    len == length(b) && 0 == ccall(
+        :memcmp, Int32, (Ptr{T}, Ptr{T}, UInt), a, b, sizeof(T) * len)
 end
 
 function reverse(A::AbstractVector, s=1, n=length(A))

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -157,11 +157,7 @@ isless(a::AbstractString, b::AbstractString) = cmp(a,b) < 0
 cmp(a::String, b::String) = lexcmp(a.data, b.data)
 cmp(a::Symbol, b::Symbol) = Int(sign(ccall(:strcmp, Int32, (Cstring, Cstring), a, b)))
 
-function ==(a::String, b::String)
-    len = length(a.data)
-    return len == length(b.data) &&
-        0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a.data, b.data, len)
-end
+==(a::String, b::String) = a.data == b.data
 isless(a::Symbol, b::Symbol) = cmp(a,b) < 0
 
 ## Generic validation functions ##


### PR DESCRIPTION
After https://github.com/JuliaLang/julia/pull/16855, it's faster to compare two arrays for equality with `String(a) == String(b)` than with `a == b`. No joke!

``` julia
julia> using BenchmarkTools

julia> const A = repeat([0x01:0x7F;], outer=10000);

julia> const B = repeat([0x01:0x7F;], outer=10000);

julia> @benchmark A == B
BenchmarkTools.Trial: 
  samples:          2271
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     1.99 ms (0.00% GC)
  median time:      2.27 ms (0.00% GC)
  mean time:        2.20 ms (0.00% GC)
  maximum time:     2.46 ms (0.00% GC)

julia> @benchmark String(A) == String(B)
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  32.00 bytes
  allocs estimate:  2
  minimum time:     76.32 μs (0.00% GC)
  median time:      80.60 μs (0.00% GC)
  mean time:        82.95 μs (0.00% GC)
  maximum time:     314.34 μs (0.00% GC)
```

In fact, the fastest (non-String) way to compare byte arrays for equality seems to be `lexcmp`, which uses `memcmp` behind the hood:

``` julia
julia> @benchmark lexcmp(A, B) == 0
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     76.49 μs (0.00% GC)
  median time:      86.93 μs (0.00% GC)
  mean time:        89.47 μs (0.00% GC)
  maximum time:     450.16 μs (0.00% GC)
```

I think it makes sense to move this optimization up one level, from strings to arrays. I'm not entirely sure what the scope should be—currently it's for one-dimensional arrays of integral types that are at most 64 bits and not `Bool`, which is a bit arbitrary. It doesn't work for floating point types because of `NaN` behaviour, and I'm a little unclear about the semantics of `Bool` in Julia, but I think it might work for that also, if safe.
