### PR TITLE
ndigits: fix (harmless) bug introduced when deprecating WORD_SIZE

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -184,7 +184,7 @@ function ndigits0z(x::UInt128)
 end
 ndigits0z(x::Integer) = ndigits0z(unsigned(abs(x)))
 
-const ndigits_max_mul = Core.sizeof(Int32) == 4 ? 69000000 : 290000000000000000
+const ndigits_max_mul = Core.sizeof(Int) == 4 ? 69000000 : 290000000000000000
 
 function ndigits0znb(n::Int, b::Int)
     d = 0


### PR DESCRIPTION
I checked also all other instances where WORD_SIZE was replaced in #16219, but didn't see other problems.
