### PR TITLE
kwsorter typemap microefficiency

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -147,6 +147,8 @@ export
 
 const (===) = is
 
+typealias AnyVector Array{Any,1}
+
 abstract Number
 abstract Real     <: Number
 abstract AbstractFloat <: Real

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -74,7 +74,7 @@ function arg_decl_parts(m::Method)
 end
 
 function kwarg_decl(sig::ANY, kwtype::DataType)
-    sig = Tuple{kwtype, Array, sig.parameters...}
+    sig = Tuple{kwtype, Core.AnyVector, sig.parameters...}
     kwli = ccall(:jl_methtable_lookup, Any, (Any, Any), kwtype.name.mt, sig)
     if kwli !== nothing
         kwli = kwli::Method

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -355,7 +355,7 @@
   (or (number? x) (string? x) (char? x) (and (pair? x) (memq (car x) '(quote inert)))
       (eq? x 'true) (eq? x 'false)))
 
-(define empty-vector-any '(call (core Array) (core Any) 0))
+(define empty-vector-any '(call (core AnyVector) 0))
 
 (define (keywords-method-def-expr name sparams argl body isstaged rett)
   (let* ((kargl (cdar argl))  ;; keyword expressions (= k v)
@@ -461,7 +461,7 @@
           `((|::|
              ;; if there are optional positional args, we need to be able to reference the function name
              ,(if (any kwarg? pargl) (gensy) UNUSED)
-             (call (core kwftype) ,ftype)) (:: ,kw (core Array)) ,@pargl ,@vararg)
+             (call (core kwftype) ,ftype)) (:: ,kw (core AnyVector)) ,@pargl ,@vararg)
           `(block
             ;; initialize keyword args to their defaults, or set a flag telling
             ;; whether this keyword needs to be set.


### PR DESCRIPTION
using a leaftype for the kw argument lets the TypeMap split the defs list more efficiently
