### PR TITLE
Lispy Cartesian iteration

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -378,30 +378,12 @@ end
     end
 end
 
-# Cartesian indexing
-function cartindex_exprs(indexes, syms)
-    exprs = Any[]
-    for (i,ind) in enumerate(indexes)
-        if ind <: CartesianIndex
-            for j = 1:length(ind)
-                push!(exprs, :($syms[$i][$j]))
-            end
-        else
-            push!(exprs, :($syms[$i]))
-        end
-    end
-    if isempty(exprs)
-        push!(exprs, 1)  # Handle the zero-dimensional case
-    end
-    exprs
+@propagate_inbounds function _getindex{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
+    getindex(A, IteratorsMD._flatten((), I...)...)
 end
-@generated function _getindex{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
-    :(@_propagate_inbounds_meta; getindex(A, $(cartindex_exprs(I, :I)...)))
+@propagate_inbounds function _setindex!{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, v, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
+    setindex!(A, v, IteratorsMD._flatten((), I...)...)
 end
-@generated function _setindex!{T,N}(l::LinearIndexing, A::AbstractArray{T,N}, v, I::Union{Real,AbstractArray,Colon,CartesianIndex}...)
-    :(@_propagate_inbounds_meta; setindex!(A, v, $(cartindex_exprs(I, :I)...)))
-end
-
 
 ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1262,8 +1262,8 @@ I2 = CartesianIndex((-1,5,2))
 @test length(CartesianIndex{3}((1,2))) == 3
 @test length(CartesianIndex{3}(1,2,3)) == 3
 @test length(CartesianIndex{3}((1,2,3))) == 3
-@test_throws DimensionMismatch CartesianIndex{3}(1,2,3,4)
-@test_throws DimensionMismatch CartesianIndex{3}((1,2,3,4))
+@test_throws ArgumentError CartesianIndex{3}(1,2,3,4)
+@test_throws ArgumentError CartesianIndex{3}((1,2,3,4))
 
 @test length(I1) == 3
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -40,7 +40,7 @@
 
 ## filling to specified length
 @test @inferred(Base.fill_to_length((1,2,3), -1, Val{5})) == (1,2,3,-1,-1)
-@test_throws ErrorException Base.fill_to_length((1,2,3), -1, Val{2})
+@test_throws ArgumentError Base.fill_to_length((1,2,3), -1, Val{2})
 
 ## iterating ##
 @test start((1,2,3)) === 1
@@ -72,18 +72,21 @@ begin
     foo(x) = 2x
     foo(x, y) = x + y
     foo(x, y, z) = x + y + z
+    longtuple = ntuple(identity, 20)
 
     # 1 argument
     @test map(foo, ()) === ()
     @test map(foo, (1,)) === (2,)
     @test map(foo, (1,2)) === (2,4)
     @test map(foo, (1,2,3,4)) === (2,4,6,8)
+    @test map(foo, longtuple) === ntuple(i->2i,20)
 
     # 2 arguments
     @test map(foo, (), ()) === ()
     @test map(foo, (1,), (1,)) === (2,)
     @test map(foo, (1,2), (1,2)) === (2,4)
     @test map(foo, (1,2,3,4), (1,2,3,4)) === (2,4,6,8)
+    @test map(foo, longtuple, longtuple) === ntuple(i->2i,20)
 
     # n arguments
     @test map(foo, (), (), ()) === ()
@@ -91,6 +94,7 @@ begin
     @test map(foo, (1,), (1,), (1,)) === (3,)
     @test map(foo, (1,2), (1,2), (1,2)) === (3,6)
     @test map(foo, (1,2,3,4), (1,2,3,4), (1,2,3,4)) === (3,6,9,12)
+    @test map(foo, longtuple, longtuple, longtuple) === ntuple(i->3i,20)
 end
 
 ## comparison ##


### PR DESCRIPTION
This gets rid of all of the `@generated` functions in IteratorsMD (the implementation of `CartesianIndex`/`CartesianRange`). It also optimized `map` on tuples.

No idea how this performs, let's ask @nanosoldier `runbenchmarks("array", vs=":master")`.
