### PR TITLE
avoid double-finalizing SharedArray sdata

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -226,7 +226,6 @@ function finalize_refs{T,N}(S::SharedArray{T,N})
         empty!(S.pids)
         empty!(S.refs)
         init_loc_flds(S)
-        finalize(S.s)
         S.s = Array{T}(ntuple(d->0,N))
     end
     S


### PR DESCRIPTION
fix #16782
