### PR TITLE
Fix get(x::Nullable{Union{}}, y) and add tests for Nullable{Union{}}

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -5447,22 +5447,6 @@ Compute the cotangent of `x`, where `x` is in radians.
 cot
 
 """
-    get(x)
-
-Attempt to access the value of the `Nullable` object, `x`. Returns the value if it is
-present; otherwise, throws a `NullException`.
-"""
-get(x)
-
-"""
-    get(x, y)
-
-Attempt to access the value of the `Nullable{T}` object, `x`. Returns
-the value if it is present; otherwise, returns `convert(T, y)`.
-"""
-get(x,y)
-
-"""
     get(collection, key, default)
 
 Return the value stored for the given key, or the given default value if no mapping for the

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -45,15 +45,21 @@ function show{T}(io::IO, x::Nullable{T})
     end
 end
 
-get(x::Nullable) = x.isnull ? throw(NullException()) : x.value
+"""
+    get(x::Nullable[, y])
 
-@inline function get{T}(x::Nullable{T}, y)
-    if isbits(T)
-        ifelse(x.isnull, convert(T, y), x.value)
+Attempt to access the value of `x`. Returns the value if it is present;
+otherwise, returns `y` if provided, or throws a `NullException` if not.
+"""
+@inline function get{S,T}(x::Nullable{S}, y::T)
+    if isbits(S)
+        ifelse(x.isnull, y, x.value)
     else
-        x.isnull ? convert(T, y) : x.value
+        x.isnull ? y : x.value
     end
 end
+
+get(x::Nullable) = x.isnull ? throw(NullException()) : x.value
 
 isnull(x::Nullable) = x.isnull
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -47,7 +47,7 @@ Basic functions
 
    .. Docstring generated from Julia source
 
-   Returns a tuple specifying the "shape" of array ``A``\ . For arrays with conventional indexing (indices start at 1), this is equivalent to ``size(A)``\ ; otherwise it is equivalent to ``incides(A)``\ .
+   Returns a tuple specifying the "shape" of array ``A``\ . For arrays with conventional indexing (indices start at 1), this is equivalent to ``size(A)``\ ; otherwise it is equivalent to ``indices(A)``\ .
 
 .. function:: shape(A, d)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -728,17 +728,11 @@ Nullables
 
    Wrap value ``x`` in an object of type ``Nullable``\ , which indicates whether a value is present. ``Nullable(x)`` yields a non-empty wrapper, and ``Nullable{T}()`` yields an empty instance of a wrapper that might contain a value of type ``T``\ .
 
-.. function:: get(x)
+.. function:: get(x::Nullable[, y])
 
    .. Docstring generated from Julia source
 
-   Attempt to access the value of the ``Nullable`` object, ``x``\ . Returns the value if it is present; otherwise, throws a ``NullException``\ .
-
-.. function:: get(x, y)
-
-   .. Docstring generated from Julia source
-
-   Attempt to access the value of the ``Nullable{T}`` object, ``x``\ . Returns the value if it is present; otherwise, returns ``convert(T, y)``\ .
+   Attempt to access the value of ``x``\ . Returns the value if it is present; otherwise, returns ``y`` if provided, or throws a ``NullException`` if not.
 
 .. function:: isnull(x)
 

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -144,12 +144,17 @@ for T in types
     @test get(x3) === one(T)
 end
 
+@test_throws NullException get(Nullable())
+
 # get{S, T}(x::Nullable{S}, y::T)
 for T in types
+    x0 = Nullable()
     x1 = Nullable{T}()
     x2 = Nullable(zero(T))
     x3 = Nullable(one(T))
 
+    @test get(x0, zero(T)) === zero(T)
+    @test get(x0, one(T)) === one(T)
     @test get(x1, zero(T)) === zero(T)
     @test get(x1, one(T)) === one(T)
     @test get(x2, one(T)) === zero(T)
@@ -167,12 +172,20 @@ for T in types
     @test isnull(x3) === false
 end
 
+@test isnull(Nullable())
+
 # function isequal{S, T}(x::Nullable{S}, y::Nullable{T})
 for T in types
+    x0 = Nullable()
     x1 = Nullable{T}()
     x2 = Nullable{T}()
     x3 = Nullable(zero(T))
     x4 = Nullable(one(T))
+
+    @test isequal(x0, x1) === true
+    @test isequal(x0, x2) === true
+    @test isequal(x0, x3) === false
+    @test isequal(x0, x4) === false
 
     @test isequal(x1, x1) === true
     @test isequal(x1, x2) === true
@@ -197,10 +210,16 @@ end
 
 # function =={S, T}(x::Nullable{S}, y::Nullable{T})
 for T in types
+    x0 = Nullable()
     x1 = Nullable{T}()
     x2 = Nullable{T}()
     x3 = Nullable(zero(T))
     x4 = Nullable(one(T))
+
+    @test_throws NullException (x0 == x1)
+    @test_throws NullException (x0 == x2)
+    @test_throws NullException (x0 == x3)
+    @test_throws NullException (x0 == x4)
 
     @test_throws NullException (x1 == x1)
     @test_throws NullException (x1 == x2)
@@ -225,16 +244,21 @@ end
 
 # function hash(x::Nullable, h::UInt)
 for T in types
+    x0 = Nullable()
     x1 = Nullable{T}()
     x2 = Nullable{T}()
     x3 = Nullable(zero(T))
     x4 = Nullable(one(T))
 
+    @test isa(hash(x0), UInt)
     @test isa(hash(x1), UInt)
     @test isa(hash(x2), UInt)
     @test isa(hash(x3), UInt)
     @test isa(hash(x4), UInt)
 
+    @test hash(x0) == hash(x2)
+    @test hash(x0) != hash(x3)
+    @test hash(x0) != hash(x4)
     @test hash(x1) == hash(x2)
     @test hash(x1) != hash(x3)
     @test hash(x1) != hash(x4)


### PR DESCRIPTION
It failed since conversion of y to Union{} wasn't possible. Add tests
for Nullable() everywhere the behavior of a null is tested.

This generates type stable code according to `@code_warntype` (except of course when the promotion rules give `Any`).

Cc: @TotalVerb @johnmyleswhite 
