### PR TITLE
[release-0.4] Fix wrong output of a code example

### DIFF
--- a/doc/manual/networking-and-streams.rst
+++ b/doc/manual/networking-and-streams.rst
@@ -21,7 +21,6 @@ taking the stream as their first argument, e.g.::
 
     julia> write(STDOUT,"Hello World");  # suppress return value 11 with ;
     Hello World
-
     julia> read(STDIN,Char)
 
     '\n'


### PR DESCRIPTION
Fix wrong output of a code example.

Related to #16903 
