### PR TITLE
RFC: move FastISel <= -O1

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5764,7 +5764,7 @@ extern "C" void jl_init_codegen(void)
                                " Is the LLVM backend for this CPU enabled?");
 #if defined(USE_MCJIT) && (!defined(_CPU_ARM_) && !defined(_CPU_PPC64_))
     // FastISel seems to be buggy for ARM. Ref #13321
-    if (jl_options.opt_level < 3)
+    if (jl_options.opt_level < 2)
         jl_TargetMachine->setFastISel(true);
 #endif
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -22,7 +22,7 @@ static void addOptimizationPasses(T *PM)
     PM->add(llvm::createMemorySanitizerPass(true));
 #   endif
 #endif
-    if (jl_options.opt_level <= 1) {
+    if (jl_options.opt_level == 0) {
         return;
     }
 #ifdef LLVM37


### PR DESCRIPTION
fix #16375, but need to see what effect this would have on travis times
