### PR TITLE
Make more pieces of "ord" type-stable

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -65,11 +65,13 @@ ordtype(o::By,              vs::AbstractArray) = try typeof(o.by(vs[1])) catch; 
 ordtype(o::Ordering,        vs::AbstractArray) = eltype(vs)
 
 function ord(lt, by, rev::Bool, order::Ordering=Forward)
-    o = (lt===isless) & (by===identity) ? order  :
-        (lt===isless) & (by!==identity) ? By(by) :
-        (lt!==isless) & (by===identity) ? Lt(lt) :
-                                          Lt((x,y)->lt(by(x),by(y)))
+    o = ordcore(lt, by, order)
     rev ? ReverseOrdering(o) : o
 end
+
+ordcore(::typeof(isless), ::typeof(identity), order) = order
+ordcore(::typeof(isless), by,                 order) = By(by)
+ordcore(lt,               ::typeof(identity), order) = Lt(lt)
+ordcore(lt,               by,                 order) = Lt((x,y)->lt(by(x),by(y)))
 
 end


### PR DESCRIPTION
Now that functions have types, much of the logic in selecting an ordering can be done via dispatch. The only remaining source of type-instability is `rev`; it might be worth considering a variant that accepts `Val{true}`/`Val{false}` for this parameter.

This PR does not, by itself, speed anything up. However, if we later fix the type instability in `rev`, then the following benchmark suggests that things might get much better:

``` jl
using Base.Sort: Ordering, Forward, Perm, ord, DEFAULT_UNSTABLE

function runsort1(v, n)
    p0 = collect(1:length(v))
    p = copy(p0)
    s = 0
    for i = 1:n
        copy!(p, p0)
        sortperm!(p, v)
        s += p[mod1(i, length(p))]   # this line just makes sure that LLVM doesn't skip the sortperm!
    end
    s
end

function runsort2(v, n, perm)
    p0 = collect(1:length(v))
    p = copy(p0)
    s = 0
    for i = 1:n
        copy!(p, p0)
        sort!(p, DEFAULT_UNSTABLE, perm)
        s += p[mod1(i, length(p))]
    end
    s
end

v = rand(5)
perm = Perm(ord(isless,identity,false,Forward),v)

runsort1(v, 1)
runsort2(v, 1, perm)
@time 1
@time runsort1(v, 10^4)
@time runsort2(v, 10^4, perm)
```

with result

```
julia> include("/tmp/runsort.jl")
  0.000003 seconds (149 allocations: 9.013 KB)
  0.057827 seconds (30.01 k allocations: 469.219 KB)
  0.001143 seconds (20.01 k allocations: 312.969 KB)
30000
```

CC @kmsquire.
