### PR TITLE
implement copy and == for MersenneTwister (fix #15698)

### DIFF
--- a/base/dSFMT.jl
+++ b/base/dSFMT.jl
@@ -2,6 +2,8 @@
 
 module dSFMT
 
+import Base: copy, copy!, ==
+
 export DSFMT_state, dsfmt_get_min_array_size, dsfmt_get_idstring,
        dsfmt_init_gen_rand, dsfmt_init_by_array, dsfmt_gv_init_by_array,
        dsfmt_fill_array_close_open!, dsfmt_fill_array_close1_open2!,
@@ -21,9 +23,15 @@ const JPOLY1e21  = "e172e20c5d2de26b567c0cace9e7c6cc4407bd5ffcd22ca59d37b73d54fd
 
 type DSFMT_state
     val::Vector{Int32}
-    DSFMT_state() = new(Array{Int32}(JN32))
-    DSFMT_state(val::Vector{Int32}) = new(val)
+
+    DSFMT_state(val::Vector{Int32} = zeros(Int32, JN32)) =
+        new(length(val) == JN32 ? val : throw(DomainError()))
 end
+
+copy!(dst::DSFMT_state, src::DSFMT_state) = (copy!(dst.val, src.val); dst)
+copy(src::DSFMT_state) = DSFMT_state(copy(src.val))
+
+==(s1::DSFMT_state, s2::DSFMT_state) = s1.val == s2.val
 
 function dsfmt_get_idstring()
     idstring = ccall((:dsfmt_get_idstring,:libdSFMT),

--- a/base/random.jl
+++ b/base/random.jl
@@ -126,7 +126,7 @@ end
 @inline rand_ui2x52_raw(r::MersenneTwister) = rand_ui52_raw(r) % UInt128 << 64 | rand_ui52_raw(r)
 
 function srand(r::MersenneTwister, seed::Vector{UInt32})
-    r.seed = seed
+    copy!(resize!(r.seed, length(seed)), seed)
     dsfmt_init_by_array(r.state, r.seed)
     mt_setempty!(r)
     return r

--- a/test/random.jl
+++ b/test/random.jl
@@ -436,3 +436,11 @@ end
                                          zeros(Float64, 10), 0)
 @test_throws DomainError MersenneTwister(zeros(UInt32, 1), Base.dSFMT.DSFMT_state(),
                                          zeros(Float64, Base.Random.MTCacheLength), -1)
+
+# seed is private to MersenneTwister
+let seed = rand(UInt32, 10)
+    r = MersenneTwister(seed)
+    @test r.seed == seed && r.seed !== seed
+    resize!(seed, 4)
+    @test r.seed != seed
+end

--- a/test/random.jl
+++ b/test/random.jl
@@ -414,3 +414,25 @@ end
 # test that the following is not an error (#16925)
 srand(typemax(UInt))
 srand(typemax(UInt128))
+
+# copy and ==
+let seed = rand(UInt32, 10)
+    r = MersenneTwister(seed)
+    @test r == MersenneTwister(seed) # r.vals should be all zeros
+    s = copy(r)
+    @test s == r && s !== r
+    skip, len = rand(0:2000, 2)
+    for j=1:skip
+        rand(r)
+        rand(s)
+    end
+    @test rand(r, len) == rand(s, len)
+    @test s == r
+end
+
+# MersenneTwister initialization with invalid values
+@test_throws DomainError Base.dSFMT.DSFMT_state(zeros(Int32, rand(0:Base.dSFMT.JN32-1)))
+@test_throws DomainError MersenneTwister(zeros(UInt32, 1), Base.dSFMT.DSFMT_state(),
+                                         zeros(Float64, 10), 0)
+@test_throws DomainError MersenneTwister(zeros(UInt32, 1), Base.dSFMT.DSFMT_state(),
+                                         zeros(Float64, Base.Random.MTCacheLength), -1)


### PR DESCRIPTION
`copy` uses a new `MersenneTwister` constructor corresponding to a default constructor (takes 1 arg per field). While this is not strictly necessary, this will also be useful in addition to an upcoming PR.
I also made the `seed` field not an alias of the argument of `srand`.
