### PR TITLE
enable seeding of GLOBAL_RNG when running tests

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -697,19 +697,23 @@ end
 
 """
     Base.runtests(tests=["all"], numcores=ceil(Int, Sys.CPU_CORES / 2);
-                  exit_on_error=false)
+                  exit_on_error=false, [seed])
 
 Run the Julia unit tests listed in `tests`, which can be either a string or an array of
 strings, using `numcores` processors. If `exit_on_error` is `false`, when one test
 fails, all remaining tests in other files will still be run; they are otherwise discarded,
 when `exit_on_error == true`.
+If a seed is provided via the keyword argument, it is used to seed the
+global RNG in the context where the tests are run; otherwise the seed is chosen randomly.
 """
 function runtests(tests = ["all"], numcores = ceil(Int, Sys.CPU_CORES / 2);
-                  exit_on_error=false)
+                  exit_on_error=false,
+                  seed::Union{BitInteger,Void}=nothing)
     if isa(tests,AbstractString)
         tests = split(tests)
     end
     exit_on_error && push!(tests, "--exit-on-error")
+    seed != nothing && push!(tests, "--seed=0x$(hex(seed % UInt128))") # cast to UInt128 to avoid a minus sign
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_CORES"] = "$numcores"
     try

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -2,7 +2,7 @@
 
 @doc """
 
-`tests, net_on, exit_on_error = choosetests(choices)` selects a set of tests to be
+`tests, net_on, exit_on_error, seed = choosetests(choices)` selects a set of tests to be
 run. `choices` should be a vector of test names; if empty or set to
 `["all"]`, all tests are selected.
 
@@ -10,14 +10,21 @@ This function also supports "test collections": specifically, "linalg"
  refers to collections of tests in the correspondingly-named
 directories.
 
-Upon return, `tests` is a vector of fully-expanded test names,
-`net_on` is true if networking is available (required for some tests),
-and `exit_on_error` is true if an error in one test should cancel
-remaining tests to be run (otherwise, all tests are run unconditionally).
+Upon return:
+  - `tests` is a vector of fully-expanded test names,
+  - `net_on` is true if networking is available (required for some tests),
+  - `exit_on_error` is true if an error in one test should cancel
+    remaining tests to be run (otherwise, all tests are run unconditionally),
+  - `seed` is a seed which will be used to initialize the global RNG for each
+    test to be run.
 
-Two options can be passed to `choosetests` by including a special token
-in the `choices` argument: "--skip", which makes all tests coming after
-be skipped, and "--exit-on-error" which sets the value of `exit_on_error`.
+Three options can be passed to `choosetests` by including a special token
+in the `choices` argument:
+   - "--skip", which makes all tests coming after be skipped,
+   - "--exit-on-error" which sets the value of `exit_on_error`,
+   - "--seed=SEED", which sets the value of `seed` to `SEED`
+     (parsed as an `UInt128`); `seed` is otherwise initialized randomly.
+     This option can be used to reproduce failed tests.
 """ ->
 function choosetests(choices = [])
     testnames = [
@@ -58,6 +65,7 @@ function choosetests(choices = [])
     tests = []
     skip_tests = []
     exit_on_error = false
+    seed = rand(RandomDevice(), UInt128)
 
     for (i, t) in enumerate(choices)
         if t == "--skip"
@@ -65,6 +73,8 @@ function choosetests(choices = [])
             break
         elseif t == "--exit-on-error"
             exit_on_error = true
+        elseif startswith(t, "--seed=")
+            seed = parse(UInt128, t[8:end])
         else
             push!(tests, t)
         end
@@ -177,5 +187,5 @@ function choosetests(choices = [])
 
     filter!(x -> !(x in skip_tests), tests)
 
-    tests, net_on, exit_on_error
+    tests, net_on, exit_on_error, seed
 end

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -2,7 +2,7 @@
 
 using Test
 
-function runtests(name, isolate=true)
+function runtests(name, isolate=true; seed=nothing)
     old_print_setting = Test.TESTSET_PRINT_ENABLE[]
     Test.TESTSET_PRINT_ENABLE[] = false
     try
@@ -17,6 +17,7 @@ function runtests(name, isolate=true)
         @eval(m, using Test)
         ex = quote
             @timed @testset $"$name" begin
+                srand($seed)
                 include($"$name.jl")
             end
         end


### PR DESCRIPTION
When a test fails, the seed `failseed` of the global RNG is printed. It's then possible to reproduce the failure via `julia runtests.jl failedtest --seed=failseed`.

Before running this command, if one then wants to re-run the particular test in another context (e.g. at the REPL while debugging), one can insert in failedtest.jl right before the failing test the following line to dump the RNG state: `write(open("/tmp/RNG_RESTORE.jl", "w"), "copy!(Base.GLOBAL_RNG, $(Base.GLOBAL_RNG))")`. Then to restore the state (e.g. at the REPL): `include("/tmp/RNG_RESTORE.jl")`. 
This almost implements https://github.com/JuliaLang/julia/pull/8339#issuecomment-55588256, except that the state is not printed automatically.
This is not very clean, so I hesitate to document it (and if so, where?).
Note: this depends on ~the unmerged~  #16919 for `copy!`.

I am not familiar at all with the file runtests.jl, so careful review is needed.
