### PR TITLE
RFC: try to simplify information flow around inference

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1141,7 +1141,7 @@ void *jl_get_llvmf(jl_tupletype_t *tt, bool getwrapper, bool getdeclarations)
 
     if (linfo->code == jl_nothing) {
         // re-infer if we've deleted the code
-        jl_type_infer(linfo, 0);
+        linfo = jl_type_infer(linfo, 0);
         if (linfo->code == jl_nothing) {
             JL_GC_POP();
             return NULL;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -69,7 +69,7 @@ STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
     return jv;
 }
 
-void jl_type_infer(jl_lambda_info_t *li, int force);
+jl_lambda_info_t *jl_type_infer(jl_lambda_info_t *li, int force);
 void jl_generate_fptr(jl_lambda_info_t *li);
 void jl_compile_linfo(jl_lambda_info_t *li);
 jl_lambda_info_t *jl_compile_for_dispatch(jl_lambda_info_t *li);


### PR DESCRIPTION
Attempting some cleanup here. cc @vtjnash 
- Remove code for copying data from one LambdaInfo to another; instead have only one LambdaInfo.
- `typeinf_edge` was calling `jl_specializations_insert` on a LambdaInfo even if it already came from the cache.
- Combine creating and caching specializations into one step.
- Be more careful about where `linfo->inInference` is set to 1.
- In general try to avoid potential re-entrance problems in typeinf.
