### PR TITLE
MIT-licensed SparseMatrixCSC permute[!] and refactored [c]transpose[!]

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -558,6 +558,7 @@ export
     ones,
     parent,
     parentindexes,
+    permute,
     permute!,
     permutedims,
     permutedims!,

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -24,14 +24,14 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     hcat, hvcat, imag, indmax, ishermitian, kron, length, log, log1p, max, min,
     maximum, minimum, norm, one, promote_eltype, real, reinterpret, reshape, rot180,
     rotl90, rotr90, round, scale!, setindex!, similar, size, transpose, tril,
-    triu, vcat, vec
+    triu, vcat, vec, permute!
 
 import Base.Broadcast: eltype_plus, broadcast_shape
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, dropzeros, etree,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm, speye, spones,
-    sprand, sprandn, spzeros, symperm, nnz
+    sprand, sprandn, spzeros, symperm, nnz, permute
 
 include("abstractsparse.jl")
 include("sparsematrix.jl")

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1062,3 +1062,32 @@ dense counterparts. The following functions are specific to sparse arrays.
 
    For an in-place version and algorithmic information, see :func:`Base.SparseArrays.dropzeros!`\ .
 
+.. function:: permute{Tv,Ti,Tp<:Integer,Tq<:Integer}(A::SparseMatrixCSC{Tv,Ti}, p::AbstractVector{Tp},
+..............    q::AbstractVector{Tq})
+
+   .. Docstring generated from Julia source
+
+   Bilaterally permute ``A``\ , returning ``PAQ`` (``A[p,q]``\ ). Column-permutation ``q``\ 's length must match ``A``\ 's column count (``length(q) == A.n``\ ). Row-permutation ``p``\ 's length must match ``A``\ 's row count (``length(p) == A.m``\ ).
+
+   For expert drivers and additional information, see :func:`Base.SparseArrays.permute!`\ .
+
+.. function:: permute!{Tv,Ti,Tp<:Integer,Tq<:Integer}(X::SparseMatrixCSC{Tv,Ti}, A::SparseMatrixCSC{Tv,Ti},
+..............    p::AbstractVector{Tp}, q::AbstractVector{Tq}[, C::SparseMatrixCSC{Tv,Ti}])
+
+   .. Docstring generated from Julia source
+
+   Bilaterally permute ``A``\ , storing result ``PAQ`` (``A[p,q]``\ ) in ``X``\ . Stores intermediate result ``(AQ)^T`` (``transpose(A[:,q])``\ ) in optional argument ``C`` if present. Requires that none of ``X``\ , ``A``\ , and, if present, ``C`` alias each other; to store result ``PAQ`` back into ``A``\ , use the following method lacking ``X``\ :
+
+   .. code-block:: julia
+
+       permute!{Tv,Ti,Tp<:Integer,Tq<:Integer}(A::SparseMatrixCSC{Tv,Ti}, p::AbstractVector{Tp},
+           q::AbstractVector{Tq}[, C::SparseMatrixCSC{Tv,Ti}[, workcolptr::Vector{Ti}]])
+
+   ``X``\ 's dimensions must match those of ``A`` (``X.m == A.m`` and ``X.n == A.n``\ ), and ``X`` must have enough storage to accommodate all allocated entries in ``A`` (``length(X.rowval) >= nnz(A)`` and ``length(X.nzval) >= nnz(A)``\ ). Column-permutation ``q``\ 's length must match ``A``\ 's column count (``length(q) == A.n``\ ). Row-permutation ``p``\ 's length must match ``A``\ 's row count (``length(p) == A.m``\ ).
+
+   ``C``\ 's dimensions must match those of ``transpose(A)`` (``C.m == A.n`` and ``C.n == A.m``\ ), and ``C`` must have enough storage to accommodate all allocated entries in ``A`` (``length(C.rowval)`` >= nnz(A)``and``\ length(C.nzval) >= nnz(A)`).
+
+   For additional (algorithmic) information, and for versions of these methods that forgo argument checking, see (unexported) parent methods :func:`Base.SparseArrays.unchecked_noalias_permute!` and :func:`Base.SparseArrays.unchecked_aliasing_permute!`\ .
+
+   See also: :func:`Base.SparseArrays.permute`
+


### PR DESCRIPTION
Followup to #13001, #14631, #14702, #14798, and #15242. This pull request refactors `[c]transpsose[!]` methods operating on `SparseMatrixCSC`s and introduces accompanying MIT-licensed `permute[!]` methods as a replacement for `csc_permute`. Details:

The first commit refactors the `[c]transpose[!]` methods: (1) such that the later-introduced `permute[!]` methods share the `[c]tranpose[!]` methods' code insofar as possible; and (2) taking advantage of #16371 for better structuring. Part of (1) is replacing `qftranspose!` with a more general `halfperm!`; in that replacement, the permutation vector convention changes to match that seemingly used elsewhere in Julia (such that `halfperm!(X, A, q)` now produces `X = transpose(A[:,q])` and consequently `permute(A, p, q)` produces `A[p,q]` --- desired behavior?). This first commit also adds several tests for those `[c]tranpsose[!]` methods.

Would one of the powers that be ask NanoSoldier to run the sparse performance tests to check for regressions in `[c]transpose[!]`?

The second commit introduces `permute[!]` methods operating on `SparseMatrixCSC`s (intended to replace and extend the functionality of `csc_permute`), documents those methods, and adds a set of associated tests. In anticipation of heap-referencing immutables one day being stack-allocatable, the present interface operates solely on `SparseMatrixCSC`s rather than also providing methods working on sets of vectors constituting `SparseMatrixCSC`s. The second commit exports `permute` from `SparseArrays` but does not place an entry in `exports.jl` (should it?).

 Concerning `permute[!]`'s performance, these benchmarks

``` julia
using Benchmarks: @benchmark, SummaryStatistics
import Base.SparseArrays.permute
import Base.SparseArrays.csc_permute

function prettytimes(bench)
    stats = SummaryStatistics(bench)
    timecenter = stats.elapsed_time_center
    timelower = get(stats.elapsed_time_lower)
    timeupper = get(stats.elapsed_time_upper)
    # based on Benchmarks.pretty_time_string
    timecenter < 1_000.0 ? (scalefactor = 1.0; units = "ns") :
        timecenter < 1_000_000.0 ? (scalefactor = 1_000.0; units = "μs") :
            timecenter < 1_000_000_000.0 ? (scalefactor = 1_000_000.0; units = "ms") :
                (scalefactor = 1_000_000_000.0; units = " s")
    @sprintf("%6.2f%s [%6.2f,%6.2f]", timecenter/scalefactor, units, timelower/scalefactor, timeupper/scalefactor)
end

smallN, smallerN = 600, 400;
smallsqrA = sprand(smallN, smallN, 0.01);
smalltallA = sprand(smallN, smallerN, 0.01);
smallwideA = sprand(smallerN, smallN, 0.01);
largeN, largerN = 50000, 100000;
largesqrA = sprand(largerN, largerN, 0.001);
largetallA = sprand(largerN, largeN, 0.001);
largewideA = sprand(largeN, largerN, 0.001);
psmall = randperm(smallN); qsmall = randperm(smallN);
psmaller = randperm(smallerN); qsmaller = randperm(smallerN);
plarge = randperm(largeN); qlarge = randperm(largeN);
plarger = randperm(largerN); qlarger = randperm(largerN);

wm, wt = 12, 24;
println(" $(lpad("method ", wm)) $(lpad("small square A", wt)), $(lpad("small tall A", wt)), $(lpad("small wide A", wt)) | $(lpad("large square A", wt)), $(lpad("large tall A", wt)), $(lpad("large wide A", wt)) ")
@printf("%s: %s , %s , %s | %s, %s , %s\n", lpad("permute", wm),
    prettytimes(@benchmark permute(smallsqrA, psmall, qsmall)),
    prettytimes(@benchmark permute(smalltallA, psmall, qsmaller)),
    prettytimes(@benchmark permute(smallwideA, psmaller, qsmall)),
    prettytimes(@benchmark permute(largesqrA, plarger, qlarger)),
    prettytimes(@benchmark permute(largetallA, plarger, qlarge)),
    prettytimes(@benchmark permute(largewideA, plarge, qlarger)) )
@printf("%s: %s , %s , %s | %s, %s , %s\n", lpad("csc_permute", wm),
    prettytimes(@benchmark csc_permute(smallsqrA, psmall, qsmall)),
    prettytimes(@benchmark csc_permute(smalltallA, psmall, qsmaller)),
    prettytimes(@benchmark csc_permute(smallwideA, psmaller, qsmall)),
    prettytimes(@benchmark csc_permute(largesqrA, plarger, qlarger)),
    prettytimes(@benchmark csc_permute(largetallA, plarger, qlarge)),
    prettytimes(@benchmark csc_permute(largewideA, plarge, qlarger)) )
```

yield

``` julia
      method              small square A,                small tall A,              small wide A |            large square A,               large tall A,              large wide A
     permute:  59.50 μs [ 31.30, 87.71] ,  34.03 μs [ 32.35, 35.72] ,  41.43 μs [ 11.05, 71.80] |   1.27  s [  1.14,  1.39], 569.81 ms [529.28,610.35] , 567.68 ms [521.41,613.95]
 csc_permute: 107.57 μs [ 77.89,137.25] ,  69.29 μs [ 26.74,111.83] ,  74.63 μs [ 35.43,113.82] |   1.39  s [  1.27,  1.51], 639.68 ms [568.00,711.36] , 660.11 ms [585.24,734.98]
```

and `permute` requires signicantly less memory than `csc_permute`

``` julia
julia> @benchmark permute(largesqrA, plarger, qlarger)
================ Benchmark Results ========================
     Time per evaluation: 1.31 s [1.20 s, 1.42 s]
Proportion of time in GC: 9.83% [2.53%, 17.14%]
        Memory allocated: 306.57 mb
   Number of allocations: 14 allocations
       Number of samples: 6
   Number of evaluations: 6
 Time spent benchmarking: 9.70 s


julia> @benchmark csc_permute(largesqrA, plarger, qlarger)
================ Benchmark Results ========================
     Time per evaluation: 1.41 s [1.24 s, 1.58 s]
Proportion of time in GC: 12.20% [1.38%, 23.03%]
        Memory allocated: 459.87 mb
   Number of allocations: 31 allocations
       Number of samples: 5
   Number of evaluations: 5
 Time spent benchmarking: 9.03 s
```

To avoid tangling this PR and #16070, this PR does not presently remove/deprecate `csc_permute`. @KristofferC, what would you like me to do here with respect to #16070?

`symperm` remains on my radar.
