### PR TITLE
cleanup some old code

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -1,9 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-type ErrorException <: Exception
-    msg::AbstractString
-end
-
 type SystemError <: Exception
     prefix::AbstractString
     errnum::Int32

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -129,7 +129,7 @@ export
     # string types
     Char, DirectIndexString, AbstractString, String,
     # errors
-    BoundsError, DivideError, DomainError, Exception, InexactError,
+    ErrorException, BoundsError, DivideError, DomainError, Exception, InexactError,
     InterruptException, OutOfMemoryError, ReadOnlyMemoryError, OverflowError,
     StackOverflowError, SegmentationFault, UndefRefError, UndefVarError, TypeError,
     # AST representation
@@ -184,6 +184,10 @@ function Typeof end
 (f::typeof(Typeof))(x::ANY) = isa(x,Type) ? Type{x} : typeof(x)
 
 abstract Exception
+type ErrorException <: Exception
+    msg::AbstractString
+    ErrorException(msg::AbstractString) = new(msg)
+end
 immutable BoundsError        <: Exception
     a::Any
     i::Any

--- a/base/error.jl
+++ b/base/error.jl
@@ -18,8 +18,8 @@
 
 ## native julia error handling ##
 
-error(s::AbstractString) = throw(Main.Base.ErrorException(s))
-error(s...) = throw(Main.Base.ErrorException(Main.Base.string(s...)))
+error(s::AbstractString) = throw(ErrorException(s))
+error(s...) = throw(ErrorException(Main.Base.string(s...)))
 
 rethrow() = ccall(:jl_rethrow, Bottom, ())
 rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -911,16 +911,14 @@ JL_DLLEXPORT jl_value_t *jl_stdout_obj(void)
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stdout_obj = jl_get_global(jl_base_module, jl_symbol("STDOUT"));
-    if (stdout_obj != NULL) return stdout_obj;
-    return jl_get_global(jl_base_module, jl_symbol("OUTPUT_STREAM"));
+    return stdout_obj;
 }
 
 JL_DLLEXPORT jl_value_t *jl_stderr_obj(void)
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stderr_obj = jl_get_global(jl_base_module, jl_symbol("STDERR"));
-    if (stderr_obj != NULL) return stderr_obj;
-    return jl_get_global(jl_base_module, jl_symbol("OUTPUT_STREAM"));
+    return stderr_obj;
 }
 
 static jl_function_t *jl_show_gf=NULL;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1433,7 +1433,6 @@ void visit_mark_stack(void)
 
 void jl_mark_box_caches(void);
 
-extern jl_module_t *jl_old_base_module;
 extern jl_array_t *jl_module_init_order;
 extern jl_typemap_entry_t *call_cache[N_CALL_CACHE];
 
@@ -1442,7 +1441,6 @@ void pre_mark(void)
 {
     // modules
     gc_push_root(jl_main_module, 0);
-    if (jl_old_base_module) gc_push_root(jl_old_base_module, 0);
     gc_push_root(jl_internal_main_module, 0);
 
     size_t i;

--- a/src/gf.c
+++ b/src/gf.c
@@ -954,7 +954,7 @@ void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args)
         (jl_value_t*)f,
         args
     };
-    if (jl_base_module) {
+    if (fargs[0]) {
         jl_throw(jl_apply_generic(fargs, 3));
     }
     else {

--- a/src/init.c
+++ b/src/init.c
@@ -820,6 +820,7 @@ void jl_get_builtin_hooks(void)
     jl_number_type = (jl_datatype_t*)core("Number");
     jl_signed_type = (jl_datatype_t*)core("Signed");
 
+    jl_errorexception_type = (jl_datatype_t*)core("ErrorException");
     jl_stackovf_exception  = jl_new_struct_uninit((jl_datatype_t*)core("StackOverflowError"));
     jl_diverror_exception  = jl_new_struct_uninit((jl_datatype_t*)core("DivideError"));
     jl_domain_exception    = jl_new_struct_uninit((jl_datatype_t*)core("DomainError"));
@@ -844,9 +845,8 @@ void jl_get_builtin_hooks(void)
 
 JL_DLLEXPORT void jl_get_system_hooks(void)
 {
-    if (jl_errorexception_type) return; // only do this once
+    if (jl_argumenterror_type) return; // only do this once
 
-    jl_errorexception_type = (jl_datatype_t*)basemod("ErrorException");
     jl_argumenterror_type = (jl_datatype_t*)basemod("ArgumentError");
     jl_methoderror_type = (jl_datatype_t*)basemod("MethodError");
     jl_loaderror_type = (jl_datatype_t*)basemod("LoadError");

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -78,22 +78,13 @@ void jl_init_signal_async(void)
 }
 #endif
 
-extern jl_module_t *jl_old_base_module;
-static jl_value_t *close_cb = NULL;
-
 static void jl_uv_call_close_callback(jl_value_t *val)
 {
-    jl_value_t *cb;
-    if (!jl_old_base_module) {
-        if (close_cb == NULL)
-            close_cb = jl_get_global(jl_base_module, jl_symbol("_uv_hook_close"));
-        cb = close_cb;
-    }
-    else {
-        cb = jl_get_global(jl_base_relative_to(((jl_datatype_t*)jl_typeof(val))->name->module), jl_symbol("_uv_hook_close"));
-    }
-    assert(cb);
-    jl_value_t *args[2] = {cb,val};
+    jl_value_t *args[2];
+    args[0] = jl_get_global(jl_base_relative_to(((jl_datatype_t*)jl_typeof(val))->name->module),
+            jl_symbol("_uv_hook_close")); // topmod(typeof(val))._uv_hook_close
+    args[1] = val;
+    assert(args[0]);
     jl_apply(args, 2);
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -29,7 +29,6 @@ JL_DLLEXPORT int jl_lineno = 0; // need to update jl_critical_error if this is T
 // current file name
 JL_DLLEXPORT const char *jl_filename = "no file"; // need to update jl_critical_error if this is TLS
 
-jl_module_t *jl_old_base_module = NULL;
 // the Main we started with, in case it is switched
 jl_module_t *jl_internal_main_module = NULL;
 
@@ -131,16 +130,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
 
     if (parent_module == jl_main_module && name == jl_symbol("Base")) {
         // pick up Base module during bootstrap
-        jl_old_base_module = jl_base_module;
         jl_base_module = newm;
-        // reinitialize global variables
-        // to pick up new types from Base
-        jl_errorexception_type = NULL;
-        jl_argumenterror_type = NULL;
-        jl_methoderror_type = NULL;
-        jl_loaderror_type = NULL;
-        jl_initerror_type = NULL;
-        jl_current_task->tls = jl_nothing; // may contain an entry for :SOURCE_FILE that is not valid in the new base
     }
     // export all modules from Main
     if (parent_module == jl_main_module)


### PR DESCRIPTION
remove old code that supported bootstrapping while replacing Base (jl_old_base_module)
and move ErrorException to Core, since it is pretty important to the compiler
