### PR TITLE
Don't declare nested anonymous types

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -70,14 +70,15 @@ extern "C" {
 
 typedef struct _jl_value_t jl_value_t;
 
+struct _jl_bits_t {
+    uintptr_t gc:2;
+};
 struct _jl_taggedvalue_t {
     union {
         uintptr_t header;
         jl_taggedvalue_t *next;
         jl_value_t *type; // 16-byte aligned
-        struct {
-            uintptr_t gc:2;
-        } bits;
+        struct _jl_bits_t bits;
     };
     // jl_value_t value;
 };


### PR DESCRIPTION
This addresses this warning:
./julia.h:78:9: warning: anonymous types declared in an anonymous union are an
      extension [-Wnested-anon-types]
        struct {
