### PR TITLE
Always display header when `show`/`print`ing empty sparse matrices

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -77,8 +77,8 @@ convenient iterating over a sparse matrix :
 nzrange(S::SparseMatrixCSC, col::Integer) = S.colptr[col]:(S.colptr[col+1]-1)
 
 function Base.show(io::IO, S::SparseMatrixCSC)
-    if get(io, :multiline, false)
-        print(io, S.m, "×", S.n, " sparse matrix with ", nnz(S), " ", eltype(S), " nonzero entries:")
+    if get(io, :multiline, false) || (nnz(S) == 0)
+        print(io, S.m, "×", S.n, " sparse matrix with ", nnz(S), " ", eltype(S), " nonzero entries", nnz(S) == 0 ? "" : ":")
     end
 
     limit::Bool = get(io, :limit, false)


### PR DESCRIPTION
In #11661, the simple fix of always displaying a header when `show`/`print`ing empty sparse matrices seemingly received no objections. This pull request naively implements that fix.

Behavior on master:

``` julia
julia> foo = sprand(5, 5, 0.0)
5×5 sparse matrix with 0 Float64 nonzero entries:

julia> show(foo)

julia> print(foo)

```

Behavior on this pull request's branch:

``` julia
julia> foo = sprand(5, 5, 0.0)
5×5 sparse matrix with 0 Float64 nonzero entries

julia> show(foo)
5×5 sparse matrix with 0 Float64 nonzero entries
julia> print(foo)
5×5 sparse matrix with 0 Float64 nonzero entries
```

Thoughts?
