### PR TITLE
Test, document, and export dropzeros[!]

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -707,6 +707,8 @@ export
 
 # sparse
     full,
+    dropzeros,
+    dropzeros!,
 
 # bitarrays
     falses,

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -29,7 +29,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
 import Base.Broadcast: eltype_plus, broadcast_shape
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
-    SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, etree,
+    SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, dropzeros, etree,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm, speye, spones,
     sprand, sprandn, spzeros, symperm, nnz
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -795,7 +795,24 @@ end
 droptol!(A::SparseMatrixCSC, tol, trim::Bool = true) =
     fkeep!(A, (i, j, x) -> abs(x) > tol, trim)
 
+"""
+    dropzeros!(A::SparseMatrixCSC, trim::Bool = true)
+
+Removes stored numerical zeros from `A`, optionally trimming resulting excess space from
+`A.rowval` and `A.nzval` when `trim` is `true`.
+
+For an out-of-place version, see [`dropzeros`](:func:`Base.SparseArrays.dropzeros`). For
+algorithmic information, see [`Base.SparseArrays.fkeep!`](:func:`Base.SparseArrays.fkeep!`).
+"""
 dropzeros!(A::SparseMatrixCSC, trim::Bool = true) = fkeep!(A, (i, j, x) -> x != 0, trim)
+"""
+    dropzeros(A::SparseMatrixCSC, trim::Bool = true)
+
+Generates a copy of `A` and removes stored numerical zeros from that copy, optionally
+trimming excess space from the result's `rowval` and `nzval` arrays when `trim` is `true`.
+
+For an in-place version and algorithmic information, see [`dropzeros!`](:func:`Base.SparseArrays.dropzeros!`).
+"""
 dropzeros(A::SparseMatrixCSC, trim::Bool = true) = dropzeros!(copy(A), trim)
 
 

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -1689,8 +1689,26 @@ end
 
 droptol!(x::SparseVector, tol, trim::Bool = true) = fkeep!(x, (i, x) -> abs(x) > tol, trim)
 
+"""
+    dropzeros!(x::SparseVector, trim::Bool = true)
+
+Removes stored numerical zeros from `x`, optionally trimming resulting excess space from
+`x.nzind` and `x.nzval` when `trim` is `true`.
+
+For an out-of-place version, see [`dropzeros`](:func:`Base.SparseArrays.dropzeros`). For
+algorithmic information, see [`Base.SparseArrays.fkeep!`](:func:`Base.SparseArrays.fkeep!`).
+"""
 dropzeros!(x::SparseVector, trim::Bool = true) = fkeep!(x, (i, x) -> x != 0, trim)
+"""
+    dropzeros(x::SparseVector, trim::Bool = true)
+
+Generates a copy of `x` and removes numerical zeros from that copy, optionally trimming
+excess space from the result's `nzind` and `nzval` arrays when `trim` is `true`.
+
+For an in-place version and algorithmic information, see [`dropzeros!`](:func:`Base.SparseArrays.dropzeros!`).
+"""
 dropzeros(x::SparseVector, trim::Bool = true) = dropzeros!(copy(x), trim)
+
 
 function _fillnonzero!{Tv,Ti}(arr::SparseMatrixCSC{Tv, Ti}, val)
     m, n = size(arr)

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1036,3 +1036,34 @@ dense counterparts. The following functions are specific to sparse arrays.
           end
        end
 
+.. function:: dropzeros!(A::SparseMatrixCSC, trim::Bool = true)
+
+   .. Docstring generated from Julia source
+
+   Removes stored numerical zeros from ``A``\ , optionally trimming resulting excess space from ``A.rowval`` and ``A.nzval`` when ``trim`` is ``true``\ .
+
+   For an out-of-place version, see :func:`Base.SparseArrays.dropzeros`\ . For algorithmic information, see :func:`Base.SparseArrays.fkeep!`\ .
+
+.. function:: dropzeros(A::SparseMatrixCSC, trim::Bool = true)
+
+   .. Docstring generated from Julia source
+
+   Generates a copy of ``A`` and removes stored numerical zeros from that copy, optionally trimming excess space from the result's ``rowval`` and ``nzval`` arrays when ``trim`` is ``true``\ .
+
+   For an in-place version and algorithmic information, see :func:`Base.SparseArrays.dropzeros!`\ .
+
+.. function:: dropzeros!(x::SparseVector, trim::Bool = true)
+
+   .. Docstring generated from Julia source
+
+   Removes stored numerical zeros from ``x``\ , optionally trimming resulting excess space from ``x.nzind`` and ``x.nzval`` when ``trim`` is ``true``\ .
+
+   For an out-of-place version, see :func:`Base.SparseArrays.dropzeros`\ . For algorithmic information, see :func:`Base.SparseArrays.fkeep!`\ .
+
+.. function:: dropzeros(x::SparseVector, trim::Bool = true)
+
+   .. Docstring generated from Julia source
+
+   Generates a copy of ``x`` and removes numerical zeros from that copy, optionally trimming excess space from the result's ``nzind`` and ``nzval`` arrays when ``trim`` is ``true``\ .
+
+   For an in-place version and algorithmic information, see :func:`Base.SparseArrays.dropzeros!`\ .


### PR DESCRIPTION
In #15242/#14798 and related threads, concensus formed in favor of exporting `dropzeros[!]` with the shift to retaining stored numerical zeros in `SparseMatrixCSC`s. This pull request more extensively tests, documents, and exports `dropzeros[!]`. (@tkelman, other behaviors I should test?) Best!
