### PR TITLE
Don't use O_CLOEXEC if it is not defined

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -260,7 +260,11 @@ static int self_mem_fd = -1;
 
 static int init_self_mem()
 {
-    int fd = open("/proc/self/mem", O_RDWR | O_SYNC | O_CLOEXEC);
+    int fd = open("/proc/self/mem", O_RDWR | O_SYNC
+#ifdef O_CLOEXEC
+        | O_CLOEXEC
+#endif
+        );
     if (fd == -1)
         return -1;
     // buffer to check if write works;


### PR DESCRIPTION
cc @yuyichao, ref https://build.julialang.org/builders/package_tarball64/builds/475/steps/make%20binary-dist/logs/stdio - what consequences does this have? The buildbots use a very old kernel.
