### PR TITLE
more inference fixes

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -41,7 +41,7 @@ first(t::Tuple) = t[1]
 # eltype
 
 eltype(::Type{Tuple{}}) = Bottom
-eltype{T,_}(::Type{NTuple{_,T}}) = T
+eltype{T}(::Type{Tuple{Vararg{T}}}) = T
 
 # front (the converse of tail: it skips the last entry)
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -119,7 +119,7 @@ JL_DLLEXPORT jl_typemap_entry_t *jl_specializations_insert(jl_method_t *m, jl_tu
 
 JL_DLLEXPORT jl_value_t *jl_specializations_lookup(jl_method_t *m, jl_tupletype_t *type)
 {
-    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(m->specializations, type, NULL, 1, /*subtype*/0, /*offs*/0);
+    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(m->specializations, type, NULL, 2, /*subtype*/0, /*offs*/0);
     if (!sf)
         return jl_nothing;
     return sf->func.value;
@@ -127,7 +127,7 @@ JL_DLLEXPORT jl_value_t *jl_specializations_lookup(jl_method_t *m, jl_tupletype_
 
 JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_tupletype_t *type)
 {
-    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(mt->defs, type, NULL, 1, /*subtype*/0, /*offs*/0);
+    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(mt->defs, type, NULL, 2, /*subtype*/0, /*offs*/0);
     if (!sf)
         return jl_nothing;
     return sf->func.value;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -514,8 +514,11 @@ int jl_typemap_intersection_visitor(union jl_typemap_t map, int offs,
 
 int sigs_eq(jl_value_t *a, jl_value_t *b, int useenv)
 {
-    if (jl_has_typevars(a) || jl_has_typevars(b)) {
-        return jl_types_equal_generic(a,b,useenv);
+    // useenv == 0 : subtyping + ensure typevars correspond
+    // useenv == 1 : subtyping + ensure typevars correspond + fail if bound != bound in some typevar match
+    // useenv == 2 : ignore typevars (because UnionAll getting lost in intersection can cause jl_types_equal to fail in the wrong direction for some purposes)
+    if (useenv != 2 && (jl_has_typevars(a) || jl_has_typevars(b))) {
+        return jl_types_equal_generic(a, b, useenv);
     }
     return jl_subtype(a, b, 0) && jl_subtype(b, a, 0);
 }

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -252,3 +252,9 @@ end
 let g() = Int <: Real ? 1 : ""
     @test Base.return_types(g, Tuple{}) == [Int]
 end
+
+typealias NInt{N} Tuple{Vararg{Int, N}}
+@test Base.eltype(NInt) === Int
+fNInt(x::NInt) = (x...)
+gNInt() = f(x)
+@code_typed gNInt()


### PR DESCRIPTION
`--compile=all` is broken right now. This should fix most of the issues, although #16907 introduced a new segfault:

``` julia
$ ./julia --compile=all -J usr/lib/julia/sys.dylib --output-o y.o --startup-file=no -e nothing
(lldb) r
Process 74790 launched: './usr/bin/julia' (x86_64)
found 26662 uncompiled methods for compile-all
WARNING: could not attach metadata for @simd loop.
 265 / 26662
signal (11): Segmentation fault: 11
while loading no file, in expression starting on line 0
_ZL13emit_functionP17_jl_lambda_info_tP20_jl_llvm_functions_t at /Users/jameson/julia/src/codegen.cpp:4008
_ZL11to_functionP17_jl_lambda_info_t at /Users/jameson/julia/src/codegen.cpp:824
_compile_all_deq at /Users/jameson/julia/src/gf.c:1358
julia_save at /Users/jameson/julia/src/init.c:733
main at /Users/jameson/julia/./usr/bin/julia (unknown line)
Allocations: 37935807 (Pool: 37934653; Big: 1154); GC: 54
```
