### PR TITLE
Clear Comdats in llvmcall

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -528,6 +528,8 @@ public:
 
         SmallVector<ReturnInst*, 8> Returns;
         llvm::CloneFunctionInto(NewF,F,VMap,true,Returns,"",NULL,NULL,this);
+        NewF->setComdat(nullptr);
+        NewF->setSection("");
     }
 
     Function *CloneFunction(Function *F)
@@ -552,6 +554,7 @@ public:
         Function *NewF = destModule->getFunction(F->getName());
         if (!NewF) {
             NewF = function_proto(F);
+            NewF->setComdat(nullptr);
             destModule->getFunctionList().push_back(NewF);
         }
         return NewF;
@@ -609,6 +612,7 @@ public:
                 NULL,
                 GV->getName());
             newGV->copyAttributesFrom(GV);
+            newGV->setComdat(nullptr);
             if (GV->isDeclaration())
                 return newGV;
             if (!GV->getName().empty()) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1,5 +1,6 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
+#include <iostream>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 
 // Except for parts of this file which were copied from LLVM, under the UIUC license (marked below).
@@ -398,9 +399,15 @@ public:
             if (F->isDeclaration()) {
                 if (F->use_empty())
                     F->eraseFromParent();
-                else
-                    assert(F->isIntrinsic() || findUnmangledSymbol(F->getName()) ||
-                            SectionMemoryManager::getSymbolAddressInProcess(F->getName()));
+                else if (!(F->isIntrinsic() ||
+                           findUnmangledSymbol(F->getName()) ||
+                           SectionMemoryManager::getSymbolAddressInProcess(
+                               F->getName()))) {
+                    std::cerr << "FATAL ERROR: "
+                              << "Symbol \"" << F->getName().str() << "\""
+                              << "not found";
+                    abort();
+                }
             }
         }
 #endif


### PR DESCRIPTION
They are not really useful in the JIT context and this should work around https://github.com/Keno/Cxx.jl/issues/261.
