### PR TITLE
some updates to code metadata handling

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1927,6 +1927,8 @@ function finish(me::InferenceState)
         end
         alloc_elim_pass!(me.linfo, me)
         getfield_elim_pass!(me.linfo, me)
+        # remove placeholders
+        filter!(x->x!==nothing, me.linfo.code)
         reindex_labels!(me.linfo, me)
     end
     widen_all_consts!(me.linfo)
@@ -1935,7 +1937,9 @@ function finish(me::InferenceState)
     me.linfo.pure = ispure
 
     # determine and cache inlineability
-    me.linfo.inlineable = isinlineable(me.linfo)
+    if !me.linfo.inlineable
+        me.linfo.inlineable = isinlineable(me.linfo)
+    end
 
     if !me.needtree
         me.needtree = me.linfo.inlineable || ccall(:jl_is_cacheable_sig, Int32, (Any, Any, Any),
@@ -2736,13 +2740,16 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
         end
     end
 
-   if !isempty(stmts)
-       if all(stmt -> isa(stmt,Expr) && stmt.head === :line || isa(stmt, LineNumberNode), stmts)
-           empty!(stmts)
-       else
-           unshift!(stmts, Expr(:meta, :push_loc, linfo.def.file, linfo.def.name))
-           push!(stmts, Expr(:meta, :pop_loc))
-       end
+    if !isempty(stmts)
+        if all(stmt -> (isa(stmt,Expr) && stmt.head === :line) || isa(stmt, LineNumberNode) || stmt === nothing,
+               stmts)
+            empty!(stmts)
+        else
+            isa(stmts[1], LineNumberNode) && shift!(stmts)
+            unshift!(stmts, Expr(:meta, :push_loc, linfo.def.file, linfo.def.name, linfo.def.line))
+            isa(stmts[end], LineNumberNode) && pop!(stmts)
+            push!(stmts, Expr(:meta, :pop_loc))
+        end
     end
     if !isempty(stmts) && !propagate_inbounds
         # avoid redundant inbounds annotations
@@ -2779,16 +2786,14 @@ const inline_incompletematch_allowed = false
 inline_worthy(body::ANY, cost::Integer) = true
 
 # should the expression be part of the inline cost model
-function inline_ignore(ex)
+function inline_ignore(ex::ANY)
     isa(ex, LineNumberNode) ||
+    ex === nothing ||
     isa(ex, Expr) && ((ex::Expr).head === :line ||
                       (ex::Expr).head === :meta)
 end
 
 function inline_worthy(body::Expr, cost::Integer=1000) # precondition: 0 < cost; nominal cost = 1000
-    if popmeta!(body, :inline)[1]
-        return true
-    end
     if popmeta!(body, :noinline)[1]
         return false
     end

--- a/src/ast.c
+++ b/src/ast.c
@@ -874,16 +874,7 @@ JL_DLLEXPORT int jl_operator_precedence(char *sym)
     return res;
 }
 
-jl_value_t *skip_meta(jl_array_t *body)
-{
-    jl_value_t *body1 = jl_array_ptr_ref(body,0);
-    if (jl_is_expr(body1) && ((jl_expr_t*)body1)->head == meta_sym
-        && jl_array_len(body) > 1)
-        body1 = jl_array_ptr_ref(body,1);
-    return body1;
-}
-
-int has_meta(jl_array_t *body, jl_sym_t *sym)
+int jl_has_meta(jl_array_t *body, jl_sym_t *sym)
 {
     size_t i, l = jl_array_len(body);
     for (i = 0; i < l; i++) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3245,9 +3245,6 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
                                literal_pointer_val(bnd));
         }
     }
-    else if (head == null_sym) {
-        return ghostValue(jl_void_type);
-    }
     else if (head == static_typeof_sym) {
         jl_value_t *extype = expr_type((jl_value_t*)ex, ctx);
         if (jl_is_type_type(extype)) {
@@ -3369,8 +3366,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
         jl_value_t *arg = args[0];
         if (jl_is_quotenode(arg)) {
             jl_value_t *arg1 = jl_fieldref(arg,0);
-            if (!((jl_is_expr(arg1) && ((jl_expr_t*)arg1)->head!=null_sym) ||
-                  jl_typeis(arg1,jl_array_any_type) || jl_is_quotenode(arg1))) {
+            if (!(jl_is_expr(arg1) || jl_typeis(arg1,jl_array_any_type) || jl_is_quotenode(arg1))) {
                 // elide call to jl_copy_ast when possible
                 return emit_expr(arg, ctx);
             }
@@ -4155,7 +4151,7 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
 #endif
 
 #ifdef USE_POLLY
-    if (!has_meta(code, polly_sym)) {
+    if (!jl_has_meta(code, polly_sym)) {
         f->addFnAttr(polly::PollySkipFnAttr);
     }
 #endif
@@ -4172,24 +4168,14 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
         (jl_options.code_coverage == JL_LOG_USER && in_user_code);
     bool do_malloc_log = jl_options.malloc_log  == JL_LOG_ALL ||
         (jl_options.malloc_log    == JL_LOG_USER && in_user_code);
-    jl_value_t *stmt = skip_meta(stmts);
     StringRef filename = "<missing>";
     StringRef dbgFuncName = ctx.name;
     int lno = -1;
-    // look for initial (line num filename [funcname]) node, [funcname] for kwarg methods.
-    if (jl_is_linenode(stmt)) {
-        lno = jl_linenode_line(stmt);
-    }
-    else if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == line_sym &&
-             jl_array_dim0(((jl_expr_t*)stmt)->args) > 0) {
-        jl_value_t *a1 = jl_exprarg(stmt,0);
-        if (jl_is_long(a1))
-            lno = jl_unbox_long(a1);
-    }
-    if (lno == -1 && lam->def)
+    if (lam->def) {
         lno = lam->def->line;
-    if (lam->def && lam->def->file != empty_sym)
-        filename = jl_symbol_name(lam->def->file);
+        if (lam->def->file != empty_sym)
+            filename = jl_symbol_name(lam->def->file);
+    }
     ctx.file = filename;
     int toplineno = lno;
 
@@ -4689,10 +4675,20 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
                 DI_sp_stack.push_back(SP);
                 DI_loc_stack.push_back(builder.getCurrentDebugLocation());
                 std::string inl_name;
-                if (jl_array_len(stmt_e->args) > 2)
-                    inl_name = jl_symbol_name((jl_sym_t*)jl_exprarg(stmt_e, 2));
-                else
+                int inlined_func_lineno = 0;
+                if (jl_array_len(stmt_e->args) > 2) {
+                    size_t ii;
+                    for(ii=2; ii < jl_array_len(stmt_e->args); ii++) {
+                        jl_value_t *arg = jl_exprarg(stmt_e, ii);
+                        if (jl_is_symbol(arg))
+                            inl_name = jl_symbol_name((jl_sym_t*)arg);
+                        else if (jl_is_long(arg))
+                            inlined_func_lineno = jl_unbox_long(arg);
+                    }
+                }
+                else {
                     inl_name = "macro expansion";
+                }
                 SP = dbuilder.createFunction(new_file,
                                              inl_name + ";",
                                              inl_name,
@@ -4705,7 +4701,7 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
                                              0,
                                              true,
                                              nullptr);
-                builder.SetCurrentDebugLocation(DebugLoc::get(0, 0, (MDNode*)SP, builder.getCurrentDebugLocation()));
+                builder.SetCurrentDebugLocation(DebugLoc::get(inlined_func_lineno, 0, (MDNode*)SP, builder.getCurrentDebugLocation()));
             }
             else if (meta_arg == (jl_value_t*)jl_symbol("pop_loc")) {
                 SP = DI_sp_stack.back();

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -202,9 +202,6 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
         JL_GC_POP();
         return v;
     }
-    else if (ex->head == null_sym) {
-        return (jl_value_t*)jl_nothing;
-    }
     else if (ex->head == static_parameter_sym) {
         ssize_t n = jl_unbox_long(args[0]);
         assert(n > 0);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3942,7 +3942,6 @@ void jl_init_types(void)
     using_sym = jl_symbol("using");
     importall_sym = jl_symbol("importall");
     assign_sym = jl_symbol("=");
-    null_sym = jl_symbol("null");
     body_sym = jl_symbol("body");
     colons_sym = jl_symbol("::");
     method_sym = jl_symbol("method");
@@ -3978,6 +3977,7 @@ void jl_init_types(void)
     static_parameter_sym = jl_symbol("static_parameter");
     compiler_temp_sym = jl_symbol("#temp#");
     polly_sym = jl_symbol("polly");
+    inline_sym = jl_symbol("inline");
 
     tttvar = jl_new_typevar(jl_symbol("T"),
                                   (jl_value_t*)jl_bottom_type,

--- a/src/julia.h
+++ b/src/julia.h
@@ -560,7 +560,7 @@ extern jl_sym_t *importall_sym; extern jl_sym_t *using_sym;
 extern jl_sym_t *goto_sym;    extern jl_sym_t *goto_ifnot_sym;
 extern jl_sym_t *label_sym;   extern jl_sym_t *return_sym;
 extern jl_sym_t *lambda_sym;  extern jl_sym_t *assign_sym;
-extern jl_sym_t *null_sym;    extern jl_sym_t *body_sym;
+extern jl_sym_t *body_sym;
 extern jl_sym_t *method_sym;  extern jl_sym_t *slot_sym;
 extern jl_sym_t *enter_sym;   extern jl_sym_t *leave_sym;
 extern jl_sym_t *exc_sym;     extern jl_sym_t *new_sym;
@@ -575,7 +575,7 @@ extern jl_sym_t *copyast_sym; extern jl_sym_t *fastmath_sym;
 extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
 extern jl_sym_t *meta_sym; extern jl_sym_t *list_sym;
 extern jl_sym_t *inert_sym; extern jl_sym_t *static_parameter_sym;
-extern jl_sym_t *polly_sym;
+extern jl_sym_t *polly_sym; extern jl_sym_t *inline_sym;
 
 // gc -------------------------------------------------------------------------
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -326,8 +326,7 @@ uint32_t jl_module_next_counter(jl_module_t *m);
 void jl_fptr_to_llvm(jl_fptr_t fptr, jl_lambda_info_t *lam, int specsig);
 jl_tupletype_t *arg_type_tuple(jl_value_t **args, size_t nargs);
 
-jl_value_t *skip_meta(jl_array_t *body);
-int has_meta(jl_array_t *body, jl_sym_t *sym);
+int jl_has_meta(jl_array_t *body, jl_sym_t *sym);
 
 // backtraces
 typedef struct {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -428,7 +428,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
     }
 
     jl_expr_t *ex = (jl_expr_t*)e;
-    if (ex->head == null_sym || ex->head == error_sym || ex->head == jl_incomplete_sym) {
+    if (ex->head == error_sym || ex->head == jl_incomplete_sym) {
         // expression types simple enough not to need expansion
         return jl_interpret_toplevel_expr(e);
     }

--- a/test/core.jl
+++ b/test/core.jl
@@ -3342,7 +3342,7 @@ typealias PossiblyInvalidUnion{T} Union{T,Int}
 @test split(string(gensym("abc")),'#')[3] == "abc"
 
 # meta nodes for optional positional arguments
-@test Base.uncompressed_ast(expand(:(@inline f(p::Int=2) = 3)).args[2].args[3])[1].args[1] === :inline
+@test expand(:(@inline f(p::Int=2) = 3)).args[2].args[3].inlineable
 
 # issue #13007
 call13007{T,N}(::Type{Array{T,N}}) = 0

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -364,10 +364,7 @@ function test_typed_ast_printing(f::ANY, types::ANY, must_used_vars)
     for str in (sprint(io->code_warntype(io, f, types)),
                 sprint(io->show(io, li)))
         # Test to make sure the clearing of file path below works
-        # If we don't store the full path in line number node/ast printing
-        # anymore, the test and the string replace below should be fixed.
-        @test contains(str, @__FILE__)
-        str = replace(str, @__FILE__, "")
+        @test string(li.def.file) == @__FILE__
         for var in must_used_vars
             @test contains(str, string(var))
         end


### PR DESCRIPTION
- detect pure and inline meta once, in the front end
- remove `skip_meta` since it probably assumes too much about where meta nodes occur
- add jl_ prefix to has_meta
- remove location/pure/inline meta early, in the front end
  (the first line node isn't needed, since this info is in the Method object)
- remove null_sym; this Expr head doesn't occur in the IR
