### PR TITLE
Simple but inelegant fix for #16548

### DIFF
--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1416,3 +1416,6 @@ let m = 5
     ltintmat = LowerTriangular(rand(1:5, m, m))
     @test isapprox(At_ldiv_B(ltintmat, sparse(intmat)), At_ldiv_B(ltintmat, intmat))
 end
+
+# Test temporary fix for issue #16548 in PR #16979. Brittle. Expect to remove with `\` revisions.
+@test which(\, (SparseMatrixCSC, AbstractVecOrMat)).module == Base.SparseArrays


### PR DESCRIPTION
This pull request contains a simple but inelegant fix for JuliaLang/LinearAlgebra.jl#333.

By inelegant I mean this fix: (1) replicates code nearly verbatim between `factorize` and `\` in base/sparse/linalg.jl, and replicates some logic between those methods and `\` in base/linalg/generic.jl; and (2) includes a brittle test, almost certain to break if someone eliminates the code replication between the two preceding `\` methods. (A note on the test's brittleness and expected eventual removal appears adjacent to the test.)

Hence, though this fix may serve for the immediate future, eventually a better approach should replace it. A couple thoughts on better approaches:

A little metaprogramming could superficially eliminate the code replication between `factorize` and `\` in base/sparse/linalg.jl, but those methods are short enough that the likely net impact of such metaprogramming would be obfuscation.

Taking a step back, `\` classifies the LHS, factors the classified LHS, and then solves a system with the factored LHS. `factorize` classifies the LHS and then factors the classified LHS. Of course somehow decoupling classification, factorization, and solution, then composing those elements to form `\` (both dense and sparse) and `factorize` from the same code, would be ideal. But decoupling seems to make type inference an issue, so no dice?

@andreasnoack @tkelman, other thoughts? Should this be discussed immediately, or should a simple fix like this one stand for now and additional discussion be deferred to another day/thread?

Best!
