### PR TITLE
POC/WIP/RFC: faster integer parsing; define `parse` semantics

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -59,6 +59,7 @@ function unsafe_read(s::IO, p::Ptr{UInt8}, n::UInt)
     nothing
 end
 
+unsafe_read(s::IO, ::Type{UInt8}) = read(s, UInt8)
 
 # Generic wrappers around other IO objects
 abstract AbstractPipe <: IO

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -92,6 +92,13 @@ end
     return byte
 end
 
+@inline function unsafe_read(from::AbstractIOBuffer, ::Type{UInt8})
+    ptr = from.ptr
+    @inbounds byte = from.data[ptr]
+    from.ptr = ptr + 1
+    return byte
+end
+
 function peek(from::AbstractIOBuffer)
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
     if from.ptr > from.size


### PR DESCRIPTION
Now that I've drawn you in with my carrot of a headline, I also want to discuss what I consider a fundamental design flaw in our current parsing functions. Currently, we have Exhibit A:

``` julia
parse(T, str, base) => T, throw errors on invalid values
tryparse(T, str, base) => Nullable{T}, return Nullable{T}() on invalid values
```

The problem, as I see it, is we're utilizing `Nullable` not to represent nullability, but as a form of control flow; basically as a way to avoid having to do a try-catch block as a safeguard against invalid inputs.

This conflicts with a fundamental principle of parsing, which in my book could be stated as:

> For a given textual input, `parse(input, T)` returns a valid instance of T or the absence of a T. Non-valid inputs are _always_ errors.

I think this importance distinction can result in subtle bugs in a user's current code, Exhibit B:

``` julia
# hey ma, look, I'm parsing integers!
parse(Int, "12345") => Int

# careful son, you should use `tryparse` in case there are missing values
tryparse(Int, "") => Nullable{Int}()

# uh-oh ma, I did a bad thing, I'm unknowingly mis-parsing entire columns of string data
tryparse(Int, "very important string data") => Nullable{Int}()
```

The new semantics I propose are this, Exhibit C:

``` julia
parse(input, T) => Nullable{T}, returns Nullable{T}() on missing/absent/empty data, raises errors on invalid inputs

# e.g.
parse("12345", Int) => Nullable{Int}(12345)
parse("", Int) => Nullable{Int}()
parse("very important string data", Int) => ERROR
```

If you need to sanitize or control flow around invalid inputs, then sanitize or use control flow; nullability should be left to it's job of missingness.

This PR is half-baked right now because I wanted a chance to throw the change in semantics out there and get feedback before plowing ahead to re-organize float parsing similarly (and move it from C to julia).

I'll also note the drastically simpler (i.e. smaller and more legible), yet 4x-10x faster net implementation of integer parsing as we define it to be based on the new semantic and on an IO instead of string.

I'm viewing this as a solid step one to making Base Julia parsing machinery world-class in functionality and performance. Future iterations will involve incorporating more type richness (Dates/DateTimes), greater parsing machinery (utilizing the `Options` type for specifying delimiters and such), and eventually the excisement of `datafmt.jl`, which, according to my forecasts, could be re-implemented in about 20 lines of code with the right parsing machinery in place.

Some benchmarks for dessert:

``` julia
julia> function t1(n)
           strings = Vector{IOBuffer}(n)
           for i = 1:n
               strings[i] = IOBuffer(string(rand(Int8)))
           end
           opts = Base.Options{10}()
           tic()
           for i = 1:n
               parse(strings[i], Int8, opts)
           end
           return toc()
       end
t1 (generic function with 1 method)

julia> function t2(n)
           strings = Vector{String}(n)
           for i = 1:n
               strings[i] = string(rand(Int8))
           end
           tic()
           for i = 1:n
               parse(Int8, strings[i])
           end
           return toc()
       end
```

Warmed-up results:

``` julia
julia> t1(100000)
elapsed time: 0.003442966 seconds
0.003442966

julia> t2(100000)
elapsed time: 0.023639765 seconds
0.023639765
```
