### PR TITLE
Fix documentation for `base`

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4211,11 +4211,10 @@ Pick a random element or array of random elements from the set of values specifi
 rand
 
 """
-    base(base, n, [pad])
+    base(base::Integer, n::Integer, [pad::Integer])
 
 Convert an integer to a string in the given base, optionally specifying a number of digits
-to pad to. The base can be specified as either an integer, or as a `UInt8` array of
-character values to use as digit symbols.
+to pad to.
 """
 base
 


### PR DESCRIPTION
It has not been possible to specify a UInt8 array of character values to use  as digit symbols, since 
https://github.com/JuliaLang/julia/commit/7a3d7f6b37051e5636dd671af422dcd734cf79d7
(Almost 2 years ago)
