### PR TITLE
Generalize broadcast to handle tuples and scalars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@ This section lists changes that do not have deprecation warnings.
     for `real(z) < 0`, which differs from `log(gamma(z))` by multiples of 2π
     in the imaginary part ([#18330]).
 
+  * `broadcast` now handles tuples, and treats any argument that is not a tuple
+    or an array as a "scalar" ([#16986]).
+
 Library improvements
 --------------------
 
@@ -638,6 +641,7 @@ Language tooling improvements
 [#16854]: https://github.com/JuliaLang/julia/issues/16854
 [#16953]: https://github.com/JuliaLang/julia/issues/16953
 [#16972]: https://github.com/JuliaLang/julia/issues/16972
+[#16986]: https://github.com/JuliaLang/julia/issues/16986
 [#17033]: https://github.com/JuliaLang/julia/issues/17033
 [#17037]: https://github.com/JuliaLang/julia/issues/17037
 [#17075]: https://github.com/JuliaLang/julia/issues/17075

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -53,8 +53,8 @@ promote_array_type{S<:Integer}(::typeof(.\), ::Type{S}, ::Type{Bool}, T::Type) =
 promote_array_type{S<:Integer}(F, ::Type{S}, ::Type{Bool}, T::Type) = T
 
 for f in (:+, :-, :div, :mod, :&, :|, :$)
-    @eval ($f){R,S}(A::AbstractArray{R}, B::AbstractArray{S}) =
-        _elementwise($f, promote_op($f, R, S), A, B)
+    @eval ($f)(A::AbstractArray, B::AbstractArray) =
+        _elementwise($f, promote_eltype_op($f, A, B), A, B)
 end
 function _elementwise(op, ::Type{Any}, A::AbstractArray, B::AbstractArray)
     promote_shape(A, B) # check size compatibility

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -261,6 +261,7 @@ maybe_oneto() = OneTo(1)
 
 ### From abstractarray.jl: Internal multidimensional indexing definitions ###
 getindex(x::Number, i::CartesianIndex{0}) = x
+getindex(t::Tuple, I...) = getindex(t, IteratorsMD.flatten(I)...)
 
 # These are not defined on directly on getindex to avoid
 # ambiguities for AbstractArray subtypes. See the note in abstractarray.jl

--- a/base/number.jl
+++ b/base/number.jl
@@ -99,6 +99,8 @@ zero{T<:Number}(::Type{T}) = convert(T,0)
 one(x::Number)  = oftype(x,1)
 one{T<:Number}(::Type{T}) = convert(T,1)
 
+_default_type(::Type{Number}) = Int
+
 """
     factorial(n)
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -196,7 +196,7 @@ function _mapreducedim!{T,N}(f, op, R::AbstractArray, A::AbstractArray{T,N})
         return R
     end
     indsAt, indsRt = safe_tail(indices(A)), safe_tail(indices(R)) # handle d=1 manually
-    keep, Idefault = Broadcast.newindexer(indsAt, indsRt)
+    keep, Idefault = Broadcast.shapeindexer(indsAt, indsRt)
     if reducedim1(R, A)
         # keep the accumulator as a local variable when reducing along the first dimension
         i1 = first(indices1(R))
@@ -331,7 +331,7 @@ function findminmax!{T,N}(f, Rval, Rind, A::AbstractArray{T,N})
     # If we're reducing along dimension 1, for efficiency we can make use of a temporary.
     # Otherwise, keep the result in Rval/Rind so that we traverse A in storage order.
     indsAt, indsRt = safe_tail(indices(A)), safe_tail(indices(Rval))
-    keep, Idefault = Broadcast.newindexer(indsAt, indsRt)
+    keep, Idefault = Broadcast.shapeindexer(indsAt, indsRt)
     k = 0
     if reducedim1(Rval, A)
         i1 = first(indices1(Rval))

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -26,7 +26,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     rotl90, rotr90, round, scale!, setindex!, similar, size, transpose, tril,
     triu, vec, permute!
 
-import Base.Broadcast: broadcast_shape
+import Base.Broadcast: broadcast_indices
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, dropzeros,

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1509,8 +1509,8 @@ end
 function gen_broadcast_body_sparse(f::Function, is_first_sparse::Bool)
     F = Expr(:quote, f)
     quote
-        Base.Broadcast.check_broadcast_shape(indices(B), A_1)
-        Base.Broadcast.check_broadcast_shape(indices(B), A_2)
+        Base.Broadcast.check_broadcast_indices(indices(B), A_1)
+        Base.Broadcast.check_broadcast_indices(indices(B), A_2)
 
         colptrB = B.colptr; rowvalB = B.rowval; nzvalB = B.nzval
         colptr1 = A_1.colptr; rowval1 = A_1.rowval; nzval1 = A_1.nzval
@@ -1673,8 +1673,8 @@ function gen_broadcast_body_zpreserving(f::Function, is_first_sparse::Bool)
         op2 = :(val1)
     end
     quote
-        Base.Broadcast.check_broadcast_shape(indices(B), $A1)
-        Base.Broadcast.check_broadcast_shape(indices(B), $A2)
+        Base.Broadcast.check_broadcast_indices(indices(B), $A1)
+        Base.Broadcast.check_broadcast_indices(indices(B), $A2)
 
         nnzB = isempty(B) ? 0 :
                nnz($A1) * div(B.n, ($A1).n) * div(B.m, ($A1).m)
@@ -1743,16 +1743,16 @@ end
 
 
 broadcast{Tv1,Ti1,Tv2,Ti2}(f::Function, A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) =
-                 broadcast!(f, spzeros(promote_type(Tv1, Tv2), promote_type(Ti1, Ti2), to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
+                 broadcast!(f, spzeros(promote_type(Tv1, Tv2), promote_type(Ti1, Ti2), to_shape(broadcast_indices(A_1, A_2))), A_1, A_2)
 
 @inline broadcast_zpreserving!(args...) = broadcast!(args...)
 @inline broadcast_zpreserving(args...) = broadcast(args...)
 broadcast_zpreserving{Tv1,Ti1,Tv2,Ti2}(f::Function, A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) =
-                 broadcast_zpreserving!(f, spzeros(promote_type(Tv1, Tv2), promote_type(Ti1, Ti2), to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
+                 broadcast_zpreserving!(f, spzeros(promote_type(Tv1, Tv2), promote_type(Ti1, Ti2), to_shape(broadcast_indices(A_1, A_2))), A_1, A_2)
 broadcast_zpreserving{Tv,Ti}(f::Function, A_1::SparseMatrixCSC{Tv,Ti}, A_2::Union{Array,BitArray,Number}) =
-                 broadcast_zpreserving!(f, spzeros(promote_eltype(A_1, A_2), Ti, to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
+                 broadcast_zpreserving!(f, spzeros(promote_eltype(A_1, A_2), Ti, to_shape(broadcast_indices(A_1, A_2))), A_1, A_2)
 broadcast_zpreserving{Tv,Ti}(f::Function, A_1::Union{Array,BitArray,Number}, A_2::SparseMatrixCSC{Tv,Ti}) =
-                 broadcast_zpreserving!(f, spzeros(promote_eltype(A_1, A_2), Ti, to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
+                 broadcast_zpreserving!(f, spzeros(promote_eltype(A_1, A_2), Ti, to_shape(broadcast_indices(A_1, A_2))), A_1, A_2)
 
 
 ## Binary arithmetic and boolean operators
@@ -1766,7 +1766,7 @@ for op in (+, -, min, max, &, |, $)
                 throw(DimensionMismatch(""))
             end
             Tv = promote_op($op, Tv1, Tv2)
-            B =  spzeros(Tv, promote_type(Ti1, Ti2), to_shape(broadcast_shape(A_1, A_2)))
+            B =  spzeros(Tv, promote_type(Ti1, Ti2), to_shape(broadcast_indices(A_1, A_2)))
             $body
             B
         end
@@ -1808,15 +1808,15 @@ end # macro
 (.^)(A::Array, B::SparseMatrixCSC) = (.^)(A, full(B))
 
 .+{Tv1,Ti1,Tv2,Ti2}(A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) =
-    broadcast!(+, spzeros(promote_op(+, Tv1, Tv2), promote_type(Ti1, Ti2), to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
+    broadcast!(+, spzeros(promote_op(+, Tv1, Tv2), promote_type(Ti1, Ti2), to_shape(broadcast_indices(A_1, A_2))), A_1, A_2)
 
 function .-{Tva,Tia,Tvb,Tib}(A::SparseMatrixCSC{Tva,Tia}, B::SparseMatrixCSC{Tvb,Tib})
-    broadcast!(-, spzeros(promote_op(-, Tva, Tvb), promote_type(Tia, Tib), to_shape(broadcast_shape(A, B))), A, B)
+    broadcast!(-, spzeros(promote_op(-, Tva, Tvb), promote_type(Tia, Tib), to_shape(broadcast_indices(A, B))), A, B)
 end
 
 ## element-wise comparison operators returning SparseMatrixCSC ##
-.<{Tv1,Ti1,Tv2,Ti2}(A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) = broadcast!(<, spzeros( Bool, promote_type(Ti1, Ti2), to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
-.!={Tv1,Ti1,Tv2,Ti2}(A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) = broadcast!(!=, spzeros( Bool, promote_type(Ti1, Ti2), to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
+.<{Tv1,Ti1,Tv2,Ti2}(A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) = broadcast!(<, spzeros( Bool, promote_type(Ti1, Ti2), to_shape(broadcast_indices(A_1, A_2))), A_1, A_2)
+.!={Tv1,Ti1,Tv2,Ti2}(A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) = broadcast!(!=, spzeros( Bool, promote_type(Ti1, Ti2), to_shape(broadcast_indices(A_1, A_2))), A_1, A_2)
 
 ## full equality
 function ==(A1::SparseMatrixCSC, A2::SparseMatrixCSC)

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -116,7 +116,7 @@ function centralize_sumabs2!{S,T,N}(R::AbstractArray{S}, A::AbstractArray{T,N}, 
         return R
     end
     indsAt, indsRt = safe_tail(indices(A)), safe_tail(indices(R)) # handle d=1 manually
-    keep, Idefault = Broadcast.newindexer(indsAt, indsRt)
+    keep, Idefault = Broadcast.shapeindexer(indsAt, indsRt)
     if reducedim1(R, A)
         i1 = first(indices1(R))
         @inbounds for IA in CartesianRange(indsAt)

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -526,6 +526,27 @@ function elementwise:
 
 Elementwise operators such as ``.+`` and ``.*`` perform broadcasting if necessary. There is also a :func:`broadcast!` function to specify an explicit destination, and :func:`broadcast_getindex` and :func:`broadcast_setindex!` that broadcast the indices before indexing.   Moreover, ``f.(args...)`` is equivalent to ``broadcast(f, args...)``, providing a convenient syntax to broadcast any function (:ref:`man-dot-vectorizing`).
 
+Additionally, :func:`broadcast` is not limited to arrays (see the function documentation), it also handles tuples and treats any argument that is not an array or a tuple as a "scalar".
+
+.. doctest::
+
+    julia> convert.(Float32, [1, 2])
+    2-element Array{Float32,1}:
+     1.0
+     2.0
+
+    julia> ceil.((UInt8,), [1.2 3.4; 5.6 6.7])
+    2×2 Array{UInt8,2}:
+     0x02  0x04
+     0x06  0x07
+
+    julia> string.(1:3, ". ", ["First", "Second", "Third"])
+    3-element Array{String,1}:
+     "1. First"
+     "2. Second"
+     "3. Third"
+
+
 Implementation
 --------------
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -597,7 +597,13 @@ All mathematical operations and functions are supported for arrays
 
    .. Docstring generated from Julia source
 
-   Broadcasts the arrays ``As`` to a common size by expanding singleton dimensions, and returns an array of the results ``f(as...)`` for each position.
+   Broadcasts the arrays, tuples and/or scalars ``As`` to a container of the appropriate type and dimensions. In this context, anything that is not a subtype of ``AbstractArray`` or ``Tuple`` is considered a scalar. The resulting container is stablished by the following rules:
+
+   * If all the arguments are scalars, it returns a scalar.
+   * If the arguments are tuples and zero or more scalars, it returns a tuple.
+   * If there is at least an array in the arguments, it returns an array (and treats tuples as 1-dimensional arrays) expanding singleton dimensions.
+
+   A special syntax exists for broadcasting: ``f.(args...)`` is equivalent to ``broadcast(f, args...)``\ , and nested ``f.(g.(args...))`` calls are fused into a single broadcast loop.
 
    .. doctest::
 
@@ -624,6 +630,29 @@ All mathematical operations and functions are supported for arrays
          8   9
         11  12
         14  15
+
+       julia> parse.(Int, ["1", "2"])
+       2-element Array{Int64,1}:
+        1
+        2
+
+       julia> abs.((1, -2))
+       (1,2)
+
+       julia> broadcast(+, 1.0, (0, -2.0))
+       (1.0,-1.0)
+
+       julia> broadcast(+, 1.0, (0, -2.0), [1])
+       2-element Array{Float64,1}:
+        2.0
+        0.0
+
+       julia> string.(("one","two","three","four"), ": ", 1:4)
+       4-element Array{String,1}:
+        "one: 1"
+        "two: 2"
+        "three: 3"
+        "four: 4"
 
 .. function:: broadcast!(f, dest, As...)
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -2,7 +2,8 @@
 
 module TestBroadcastInternals
 
-using Base.Broadcast: broadcast_shape, check_broadcast_shape, newindex, _bcs, _bcsm
+using Base.Broadcast: broadcast_indices, check_broadcast_indices,
+                      check_broadcast_shape, newindex, _bcs, _bcsm
 using Base: Test, OneTo
 
 @test @inferred(_bcs((), (3,5), (3,5))) == (3,5)
@@ -18,28 +19,28 @@ using Base: Test, OneTo
 @test_throws DimensionMismatch _bcs((), (-1:1, 2:6), (-1:1, 2:5))
 @test_throws DimensionMismatch _bcs((), (-1:1, 2:5), (2, 2:5))
 
-@test @inferred(broadcast_shape(zeros(3,4), zeros(3,4))) == (OneTo(3),OneTo(4))
-@test @inferred(broadcast_shape(zeros(3,4), zeros(3)))   == (OneTo(3),OneTo(4))
-@test @inferred(broadcast_shape(zeros(3),   zeros(3,4))) == (OneTo(3),OneTo(4))
-@test @inferred(broadcast_shape(zeros(3), zeros(1,4), zeros(1))) == (OneTo(3),OneTo(4))
+@test @inferred(broadcast_indices(zeros(3,4), zeros(3,4))) == (OneTo(3),OneTo(4))
+@test @inferred(broadcast_indices(zeros(3,4), zeros(3)))   == (OneTo(3),OneTo(4))
+@test @inferred(broadcast_indices(zeros(3),   zeros(3,4))) == (OneTo(3),OneTo(4))
+@test @inferred(broadcast_indices(zeros(3), zeros(1,4), zeros(1))) == (OneTo(3),OneTo(4))
 
-check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3,5))
-check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3,1))
-check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3))
-check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3,5), zeros(3))
-check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3,5), 1)
-check_broadcast_shape((OneTo(3),OneTo(5)), 5, 2)
-@test_throws DimensionMismatch check_broadcast_shape((OneTo(3),OneTo(5)), zeros(2,5))
-@test_throws DimensionMismatch check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3,4))
-@test_throws DimensionMismatch check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3,4,2))
-@test_throws DimensionMismatch check_broadcast_shape((OneTo(3),OneTo(5)), zeros(3,5), zeros(2))
+check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3,5))
+check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3,1))
+check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3))
+check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3,5), zeros(3))
+check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3,5), 1)
+check_broadcast_indices((OneTo(3),OneTo(5)), 5, 2)
+@test_throws DimensionMismatch check_broadcast_indices((OneTo(3),OneTo(5)), zeros(2,5))
+@test_throws DimensionMismatch check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3,4))
+@test_throws DimensionMismatch check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3,4,2))
+@test_throws DimensionMismatch check_broadcast_indices((OneTo(3),OneTo(5)), zeros(3,5), zeros(2))
+check_broadcast_indices((-1:1, 6:9), 1)
 
 check_broadcast_shape((-1:1, 6:9), (-1:1, 6:9))
 check_broadcast_shape((-1:1, 6:9), (-1:1, 1))
 check_broadcast_shape((-1:1, 6:9), (1, 6:9))
 @test_throws DimensionMismatch check_broadcast_shape((-1:1, 6:9), (-1, 6:9))
 @test_throws DimensionMismatch check_broadcast_shape((-1:1, 6:9), (-1:1, 6))
-check_broadcast_shape((-1:1, 6:9), 1)
 
 ci(x) = CartesianIndex(x)
 @test @inferred(newindex(ci((2,2)), (true, true), (-1,-1)))   == ci((2,2))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -328,3 +328,12 @@ end
 let A17984 = []
     @test isa(abs.(A17984), Array{Any,1})
 end
+
+# Issue #16966
+@test parse.(Int, "1") == 1
+@test parse.(Int, ["1", "2"]) == [1, 2]
+@test trunc.((Int,), [1.2, 3.4]) == [1, 3]
+@test abs.((1, -2)) == (1, 2)
+@test broadcast(+, 1.0, (0, -2.0)) == (1.0,-1.0)
+@test broadcast(+, 1.0, (0, -2.0), [1]) == [2.0, 0.0]
+@test broadcast(*, ["Hello"], ", ", ["World"], "!") == ["Hello, World!"]


### PR DESCRIPTION
This addresses #16966 and should also help a little with ~~#4883 and~~ #16285.

**EDITED:** Here is a little demo tested locally (also, needs #17389 to work properly)

```
julia> parse.(Int, ["1", "2"])
2-element Array{Int64,1}:
 1
 2

julia> convert.(Float32, [1,2])
2-element Array{Float32,1}:
 1.0
 2.0

julia> trunc.((Int,), [1.2, 3.4])
2-element Array{Int64,1}:
 1
 3

julia> ceil.(UInt8, [1.2 3.4; 5.6 6.7])
2×2 Array{UInt8,2}:
 0x02  0x04
 0x06  0x07

julia> abs.((1, -2))
(1,2)

julia> broadcast(+, 1.0, (0, -2.0))
(1.0,-1.0)

julia> broadcast(+, 1.0, (0, -2.0), [1])
2-element Array{Float64,1}:
 2.0
 0.0

julia> broadcast(*, ["Look", "I'm", "...with"], " ", ["ma'", "broadcasting", "scalars"], "!")
3-element Array{String,1}:
 "Look ma'!"        
 "I'm broadcasting!"
"...with scalars!"
```

~~I just have a question though, can the following be written in a form that would make it pure? Or is it pure? (I have not completely clear the concept of pureness).~~

~~`promote_eltype_op{T}(op, Ts::AbstractArray{DataType}, ::AbstractArray{T}) = typejoin([promote_op(op, S, T) for S in Ts]...)`~~

TODO:
- [x] Tests pass
- [x] Add tests
- [x] Check performance
- [x] Docs
