### PR TITLE
Julia 0.4.6 backport of #16584

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -707,8 +707,8 @@ function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
             end
         end
     catch
-        kill(pobj)
         close(io)
+        kill(pobj)
         rethrow()
     finally
         isfile(errfile) && Base.rm(errfile)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -649,9 +649,9 @@ end
 function build!(pkgs::Vector, buildstream::IO, seen::Set)
     for pkg in pkgs
         pkg == "julia" && continue
-        pkg in seen && continue
-        build!(Read.requires_list(pkg),buildstream,push!(seen,pkg))
+        pkg in seen ? continue : push!(seen,pkg)
         Read.isinstalled(pkg) || error("$pkg is not an installed package")
+        build!(Read.requires_list(pkg),buildstream,seen)
         path = abspath(pkg,"deps","build.jl")
         isfile(path) || continue
         println(buildstream, path) # send to build process for evalfile

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -232,8 +232,7 @@ end"""
         end
     end
 
-    # issue # 15948
-    # Non-installed but registered packages cause the SIGTERM issue consistently.
+    # issue #15948
     let package = "Example"
         Pkg.rm(package)  # Remove package if installed
         @test Pkg.installed(package) == nothing  # Registered with METADATA but not installed

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -231,4 +231,14 @@ end"""
             @test covlines[i] == covline
         end
     end
+
+    # issue # 15948
+    # Non-installed but registered packages cause the SIGTERM issue consistently.
+    let package = "Example"
+        Pkg.rm(package)  # Remove package if installed
+        @test Pkg.installed(package) == nothing  # Registered with METADATA but not installed
+        msg = readall(ignorestatus(`$(Base.julia_cmd()) -f -e "redirect_stderr(STDOUT); Pkg.build(\"$package\")"`))
+        @test contains(msg, "$package is not an installed package")
+        @test !contains(msg, "signal (15)")
+    end
 end


### PR DESCRIPTION
A Julia 0.4 compatible version of #16584. The original PR didn't backport cleanly to 0.4 as `PkgError` was missing and in the tests `readstring` was used. 
