### PR TITLE
Implement deepcopy for BigInt and BigFloat

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -554,4 +554,14 @@ Base.checked_fld(a::BigInt, b::BigInt) = fld(a, b)
 Base.checked_mod(a::BigInt, b::BigInt) = mod(a, b)
 Base.checked_cld(a::BigInt, b::BigInt) = cld(a, b)
 
+function Base.deepcopy_internal(x::BigInt, stackdict::ObjectIdDict)
+    if haskey(stackdict, x)
+        return stackdict[x]
+    end
+    y = BigInt()
+    ccall((:__gmpz_set,:libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}), &y, &x)
+    stackdict[x] = y
+    return y
+end
+
 end # module

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -880,4 +880,18 @@ get_emin_max() = ccall((:mpfr_get_emin_max, :libmpfr), Clong, ())
 set_emax!(x) = ccall((:mpfr_set_emax, :libmpfr), Void, (Clong,), x)
 set_emin!(x) = ccall((:mpfr_set_emin, :libmpfr), Void, (Clong,), x)
 
+function Base.deepcopy_internal(x::BigFloat, stackdict::ObjectIdDict)
+    if haskey(stackdict, x)
+        return stackdict[x]
+    end
+    N = precision(x)
+    y = BigFloat(zero(Clong), zero(Cint), zero(Clong), C_NULL)
+    ccall((:mpfr_init2,:libmpfr), Void, (Ptr{BigFloat}, Clong), &y, N)
+    finalizer(y, Base.GMP._mpfr_clear_func)
+    ccall((:mpfr_set, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32),
+          &y, &x, ROUNDING_MODE[end])
+    stackdict[x] = y
+    return y
+end
+
 end #module

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -214,6 +214,8 @@ importall .Sort
 # version
 include("version.jl")
 
+function deepcopy_internal end
+
 # BigInts and BigFloats
 include("gmp.jl")
 importall .GMP

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -82,3 +82,29 @@ let a1 = Base.svec(1, 2, 3, []), a2 = Base.svec(1, 2, 3)
     @test a3 !== b3
     @test a3[1] === a3[2]
 end
+
+# issue #16667
+let x = BigInt[1:1000;], y = deepcopy(x), v
+    # Finalize the original values to make sure the deep copy is indeed
+    # independent
+    for v in x
+        finalize(v)
+    end
+    # Allocate some memory to make it more likely to trigger an error
+    # if `deepcopy` went wrong
+    x = BigInt[1:1000;]
+    @test y == x
+end
+let x = BigFloat[1:1000;], y, z, v
+    y, z = setprecision(2) do
+        deepcopy(x), BigFloat[1:1000;]
+    end
+    for v in x
+        finalize(v)
+    end
+    x = BigFloat[1:1000;]
+    # Make sure the difference in precision doesn't affect deep copy
+    @test y == x
+    # Check that the setprecision indeed does something
+    @test z != x
+end


### PR DESCRIPTION
Workaround #16667 for `BigFloat` and `BigInt`

I was hoping that someone that have actually used `gmp`/`mpfr` can implement this since it took me a while to figure out the right function that `copy`s the value (it was called `assignment` in the doc)

Replaces https://github.com/JuliaLang/julia/pull/16826
