### PR TITLE
Correction to Date adjuster API docstring

### DIFF
--- a/base/dates/adjusters.jl
+++ b/base/dates/adjusters.jl
@@ -160,14 +160,14 @@ end
 # Constructors using DateFunctions
 
 """
-    Date(f::Function, y[, m]; step=Day(1), negate=false, limit=10000) -> Date
+    Date(f::Function, y[, m, d]; step=Day(1), negate=false, limit=10000) -> Date
 
 Create a `Date` through the adjuster API. The starting point will be constructed from the
-provided `y, m` arguments, and will be adjusted until `f::Function` returns `true`. The step
-size in adjusting can be provided manually through the `step` keyword. If `negate=true`,
-then the adjusting will stop when `f::Function` returns `false` instead of `true`. `limit`
-provides a limit to the max number of iterations the adjustment API will pursue before
-throwing an error (given that `f::Function` is never satisfied).
+provided `y, m, d` arguments, and will be adjusted until `f::Function` returns `true`. The
+step size in adjusting can be provided manually through the `step` keyword. If
+`negate=true`, then the adjusting will stop when `f::Function` returns `false` instead of
+`true`. `limit` provides a limit to the max number of iterations the adjustment API will
+pursue before throwing an error (given that `f::Function` is never satisfied).
 """
 function Date(func::Function,y,m=1,d=1;step::Period=Day(1),negate::Bool=false,limit::Int=10000)
     return adjust(DateFunction(func,negate,Date(y,m,d)),Date(y,m,d),step,limit)

--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -181,11 +181,11 @@ Alternatively, you can write ``using Base.Dates`` to bring all exported function
 
    Construct a ``Date`` type by ``Period`` type parts. Arguments may be in any order. ``Date`` parts not provided will default to the value of ``Dates.default(period)``\ .
 
-.. function:: Date(f::Function, y[, m]; step=Day(1), negate=false, limit=10000) -> Date
+.. function:: Date(f::Function, y[, m, d]; step=Day(1), negate=false, limit=10000) -> Date
 
    .. Docstring generated from Julia source
 
-   Create a ``Date`` through the adjuster API. The starting point will be constructed from the provided ``y, m`` arguments, and will be adjusted until ``f::Function`` returns ``true``\ . The step size in adjusting can be provided manually through the ``step`` keyword. If ``negate=true``\ , then the adjusting will stop when ``f::Function`` returns ``false`` instead of ``true``\ . ``limit`` provides a limit to the max number of iterations the adjustment API will pursue before throwing an error (given that ``f::Function`` is never satisfied).
+   Create a ``Date`` through the adjuster API. The starting point will be constructed from the provided ``y, m, d`` arguments, and will be adjusted until ``f::Function`` returns ``true``\ . The step size in adjusting can be provided manually through the ``step`` keyword. If ``negate=true``\ , then the adjusting will stop when ``f::Function`` returns ``false`` instead of ``true``\ . ``limit`` provides a limit to the max number of iterations the adjustment API will pursue before throwing an error (given that ``f::Function`` is never satisfied).
 
 .. function:: Date(dt::DateTime) -> Date
 


### PR DESCRIPTION
I noticed the day parameter `d` was missing from the docstring. Probably should be backported.
