### PR TITLE
Make popmeta! search further than the first meta expression

### DIFF
--- a/doc/devdocs/meta.rst
+++ b/doc/devdocs/meta.rst
@@ -45,10 +45,10 @@ to specify additional information.
 To use the metadata, you have to parse these ``:meta`` expressions.
 If your implementation can be performed within Julia, ``Base.popmeta!`` is
 very handy: ``Base.popmeta!(body, :symbol)`` will scan a function *body*
-expression (one without the function signature) for a ``:meta``
-expression, extract any arguments, and return a tuple ``(found::Bool,
-args::Array{Any})``. If the metadata did not have any arguments, or
-``:symbol`` was not found, the ``args`` array will be empty.
+expression (one without the function signature) for the first ``:meta``
+expression containing ``:symbol``, extract any arguments, and return a tuple
+``(found::Bool, args::Array{Any})``. If the metadata did not have any
+arguments, or ``:symbol`` was not found, the ``args`` array will be empty.
 
 Not yet provided is a convenient infrastructure for parsing ``:meta``
 expressions from C++.


### PR DESCRIPTION
With the `:push_loc` mechanism for source file tracking, it's now common to have more than one meta expression per function body, at least in generated functions.  This means that `popmeta!` needs to search further than the first meta expression to avoid ignoring metadata, including inline annotations.

I generalized findmeta_block a bit to take a predicate invoked on the meta expression argument list, and used this to upgrade `popmeta!()`.  Fixes #16712 - problems originally noticed in inference `inline_worthy()`.
