### PR TITLE
Support `append!(::Vector, iter)`

### DIFF
--- a/base/collections.jl
+++ b/base/collections.jl
@@ -17,6 +17,25 @@ export
     peek
 
 
+# Some algorithms that can be defined only after infrastructure is in place
+Base.append!(a::Vector, iter) = _append!(a, Base.iteratorsize(iter), iter)
+
+function _append!(a, ::Base.HasLength, iter)
+    n = length(a)
+    resize!(a, n+length(iter))
+    @inbounds for (i,item) in zip(n+1:length(a), iter)
+        a[i] = item
+    end
+    a
+end
+
+function _append!(a, ::Base.IteratorSize, iter)
+    for item in iter
+        push!(a, item)
+    end
+    a
+end
+
 # Heap operations on flat arrays
 # ------------------------------
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1043,6 +1043,10 @@ A = [1,2]
 @test append!(A, A) == [1,2,1,2]
 @test prepend!(A, A) == [1,2,1,2,1,2,1,2]
 
+A = [1,2]
+s = Set([1,2,3])
+@test sort(append!(A, s)) == [1,1,2,2,3]
+
 # cases where shared arrays can/can't be grown
 A = [1 3;2 4]
 B = reshape(A, 4)


### PR DESCRIPTION
Triggered by noticing that we didn't support `append!(::Vector, ::Set)`.
