### PR TITLE
Lazy initialize gmp and mpfr finalizers

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -44,13 +44,10 @@ type BigInt <: Integer
     function BigInt()
         b = new(zero(Cint), zero(Cint), C_NULL)
         ccall((:__gmpz_init,:libgmp), Void, (Ptr{BigInt},), &b)
-        finalizer(b, _gmp_clear_func)
+        finalizer(b, cglobal((:__gmpz_clear, :libgmp)))
         return b
     end
 end
-
-_gmp_clear_func = C_NULL
-_mpfr_clear_func = C_NULL
 
 function __init__()
     try
@@ -60,8 +57,6 @@ function __init__()
                          "Please rebuild Julia."))
         end
 
-        global _gmp_clear_func = cglobal((:__gmpz_clear, :libgmp))
-        global _mpfr_clear_func = cglobal((:mpfr_clear, :libmpfr))
         ccall((:__gmp_set_memory_functions, :libgmp), Void,
               (Ptr{Void},Ptr{Void},Ptr{Void}),
               cglobal(:jl_gc_counted_malloc),

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -51,7 +51,7 @@ type BigFloat <: AbstractFloat
         N = precision(BigFloat)
         z = new(zero(Clong), zero(Cint), zero(Clong), C_NULL)
         ccall((:mpfr_init2,:libmpfr), Void, (Ptr{BigFloat}, Clong), &z, N)
-        finalizer(z, Base.GMP._mpfr_clear_func)
+        finalizer(z, cglobal((:mpfr_clear, :libmpfr)))
         return z
     end
     # Not recommended for general use
@@ -887,7 +887,7 @@ function Base.deepcopy_internal(x::BigFloat, stackdict::ObjectIdDict)
     N = precision(x)
     y = BigFloat(zero(Clong), zero(Cint), zero(Clong), C_NULL)
     ccall((:mpfr_init2,:libmpfr), Void, (Ptr{BigFloat}, Clong), &y, N)
-    finalizer(y, Base.GMP._mpfr_clear_func)
+    finalizer(y, cglobal((:mpfr_clear, :libmpfr)))
     ccall((:mpfr_set, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32),
           &y, &x, ROUNDING_MODE[end])
     stackdict[x] = y


### PR DESCRIPTION
`cglobal` is done at codegen time not runtime so there's no need to use a global variable for these.

This also make the `finalizer` call type stable and makes construction of `BigFloat` and `BigInt` 5-20% faster.

This will cause a minor behavioral change when the symbol can't be found. In the old version, it would print an warning at init time and silently ignore the error at runtime, In the new version, it will raise a runtime error.
Given that all of these are only in `try-catch` after https://github.com/JuliaLang/julia/pull/12742, I assume we don't support a version of gmp that doesn't have these symbols and a runtime error should be better (if it is at all possible to have the init symbol but not the clear symbol....).
