### PR TITLE
Add pinv fallback for AbstractTriangular, fix #16486

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1838,3 +1838,4 @@ for func in (:svd, :svdfact, :svdfact!, :svdvals)
 end
 
 factorize(A::AbstractTriangular) = A
+pinv{T<:BlasFloat}(A::AbstractTriangular{T}) = pinv(full(A))

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -221,6 +221,7 @@ for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloa
         # make sure the call to LAPACK works right
         if elty1 <: BlasFloat
             @test_approx_eq Base.LinAlg.inv!(copy(A1)) inv(lufact(full(A1)))
+            @test_approx_eq pinv(A1) pinv(full(A1))
         end
 
         # Determinant


### PR DESCRIPTION
The call to svdfact will fail without the condition that T <:
BlasFloat.
