### PR TITLE
Added more docs for factorize, cleaned up LDLt

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -7950,15 +7950,6 @@ Return the index of the first element of `A` for which `predicate` returns `true
 findfirst
 
 """
-    factorize(A)
-
-Compute a convenient factorization (including LU, Cholesky, Bunch-Kaufman, LowerTriangular,
-UpperTriangular) of `A`, based upon the type of the input matrix. The return value can then
-be reused for efficient solving of multiple systems. For example: `A=factorize(A); x=A\\b; y=A\\C`.
-"""
-factorize
-
-"""
     promote_rule(type1, type2)
 
 Specifies what type should be used by `promote` when given values of types `type1` and

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -362,6 +362,40 @@ function inv{T}(A::StridedMatrix{T})
     return convert(typeof(parent(Ai)), Ai)
 end
 
+"""
+    factorize(A)
+
+Compute a convenient factorization of `A`, based upon the type of the input matrix.
+`factorize` checks `A` to see if it is symmetric/triangular/etc. if `A` is passed
+as a generic matrix. `factorize` checks every element of `A` to verify/rule out
+each property. It will short-circuit as soon as it can rule out symmetry/triangular
+structure. The return value can be reused for efficient solving of multiple
+systems. For example: `A=factorize(A); x=A\\b; y=A\\C`.
+
+| Properties of `A`          | type of factorization                          |
+|:---------------------------|:-----------------------------------------------|
+| Positive-definite          | Cholesky (see [`cholfact`](:func:`cholfact`))  |
+| Dense Symmetric/Hermitian  | Bunch-Kaufman (see [`bkfact`](:func:`bkfact`)) |
+| Sparse Symmetric/Hermitian | LDLt (see [`ldltfact`](:func:`ldltfact`))      |
+| Triangular                 | Triangular                                     |
+| Diagonal                   | Diagonal                                       |
+| Bidiagonal                 | Bidiagonal                                     |
+| Tridiagonal                | LU (see [`lufact`](:func:`lufact`))            |
+| Symmetric real tridiagonal | LDLt (see [`ldltfact`](:func:`ldltfact`))      |
+| General square             | LU (see [`lufact`](:func:`lufact`))            |
+| General non-square         | QR (see [`qrfact`](:func:`qrfact`))            |
+
+If `factorize` is called on a Hermitian positive-definite matrix, for instance, then `factorize`
+will return a Cholesky factorization.
+
+Example:
+```julia
+A = diagm(rand(5)) + diagm(rand(4),1); #A is really bidiagonal
+factorize(A) #factorize will check to see that A is already factorized
+```
+This returns a `5×5 Bidiagonal{Float64}`, which can now be passed to other linear algebra functions
+(e.g. eigensolvers) which will use specialized methods for `Bidiagonal` types.
+"""
 function factorize{T}(A::StridedMatrix{T})
     m, n = size(A)
     if m == n

--- a/base/linalg/lq.jl
+++ b/base/linalg/lq.jl
@@ -21,13 +21,13 @@ LQPackedQ{T}(factors::AbstractMatrix{T}, τ::Vector{T}) = LQPackedQ{T,typeof(fac
     lqfact!(A) -> LQ
 
 Compute the LQ factorization of `A`, using the input
-matrix as a workspace. See also [`lq`](:func:`lq).
+matrix as a workspace. See also [`lq`](:func:`lq`).
 """
 lqfact!{T<:BlasFloat}(A::StridedMatrix{T}) = LQ(LAPACK.gelqf!(A)...)
 """
     lqfact(A) -> LQ
 
-Compute the LQ factorization of `A`. See also [`lq`](:func:`lq).
+Compute the LQ factorization of `A`. See also [`lq`](:func:`lq`).
 """
 lqfact{T<:BlasFloat}(A::StridedMatrix{T})  = lqfact!(copy(A))
 lqfact(x::Number) = lqfact(fill(x,1,1))

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1252,9 +1252,13 @@ function cholfact!{Tv}(F::Factor{Tv}, A::Sparse{Tv}; shift::Real=0.0)
 end
 
 """
-    cholfact!(F::Factor, A::Union{SparseMatrixCSC{<:Real},SparseMatrixCSC{Complex{<:Real}},Symmetric{<:Real,SparseMatrixCSC{<:Real,SuiteSparse_long}},Hermitian{Complex{<:Real},SparseMatrixCSC{Complex{<:Real},SuiteSparse_long}}}; shift = 0.0) -> CHOLMOD.Factor
+    cholfact!(F::Factor, A; shift = 0.0) -> CHOLMOD.Factor
 
 Compute the Cholesky (``LL'``) factorization of `A`, reusing the symbolic factorization `F`.
+`A` must be a `SparseMatrixCSC`, `Symmetric{SparseMatrixCSC}`, or
+`Hermitian{SparseMatrixCSC}`. Note that even if `A` doesn't
+have the type tag, its structure and values must still be
+symmetric/Hermitian.
 
 ** Note **
 
@@ -1289,9 +1293,13 @@ function cholfact(A::Sparse; shift::Real=0.0,
 end
 
 """
-    cholfact(::Union{SparseMatrixCSC{<:Real},SparseMatrixCSC{Complex{<:Real}},Symmetric{<:Real,SparseMatrixCSC{<:Real,SuiteSparse_long}},Hermitian{Complex{<:Real},SparseMatrixCSC{Complex{<:Real},SuiteSparse_long}}}; shift = 0.0, perm = Int[]) -> CHOLMOD.Factor
+    cholfact(A; shift = 0.0, perm = Int[]) -> CHOLMOD.Factor
 
 Compute the Cholesky factorization of a sparse positive definite matrix `A`.
+`A` must be a `SparseMatrixCSC`, `Symmetric{SparseMatrixCSC}`, or
+`Hermitian{SparseMatrixCSC}`. Note that even if `A` doesn't
+have the type tag, its structure and values must still be
+symmetric/Hermitian.
 A fill-reducing permutation is used.
 `F = cholfact(A)` is most frequently used to solve systems of equations with `F\\b`,
 but also the methods `diag`, `det`, `logdet` are defined for `F`.
@@ -1342,9 +1350,13 @@ function ldltfact!{Tv}(F::Factor{Tv}, A::Sparse{Tv}; shift::Real=0.0)
 end
 
 """
-    ldltfact!(F::Factor, A::Union{SparseMatrixCSC{<:Real},SparseMatrixCSC{Complex{<:Real}},Symmetric{<:Real,SparseMatrixCSC{<:Real,SuiteSparse_long}},Hermitian{Complex{<:Real},SparseMatrixCSC{Complex{<:Real},SuiteSparse_long}}}; shift = 0.0) -> CHOLMOD.Factor
+    ldltfact!(F::Factor, A; shift = 0.0) -> CHOLMOD.Factor
 
 Compute the ``LDL'`` factorization of `A`, reusing the symbolic factorization `F`.
+`A` must be a `SparseMatrixCSC`, `Symmetric{SparseMatrixCSC}`, or
+`Hermitian{SparseMatrixCSC}`. Note that even if `A` doesn't
+have the type tag, its structure and values must still be
+symmetric/Hermitian.
 
 ** Note **
 
@@ -1379,9 +1391,13 @@ function ldltfact(A::Sparse; shift::Real=0.0,
 end
 
 """
-    ldltfact(::Union{SparseMatrixCSC{<:Real},SparseMatrixCSC{Complex{<:Real}},Symmetric{<:Real,SparseMatrixCSC{<:Real,SuiteSparse_long}},Hermitian{Complex{<:Real},SparseMatrixCSC{Complex{<:Real},SuiteSparse_long}}}; shift = 0.0, perm=Int[]) -> CHOLMOD.Factor
+    ldltfact(A; shift = 0.0, perm=Int[]) -> CHOLMOD.Factor
 
-Compute the ``LDL'`` factorization of a sparse symmetric or Hermitian matrix.
+Compute the ``LDL'`` factorization of a sparse matrix `A`.
+`A` must be a `SparseMatrixCSC`, `Symmetric{SparseMatrixCSC}`, or
+`Hermitian{SparseMatrixCSC}`. Note that even if `A` doesn't
+have the type tag, its structure and values must still be
+symmetric/Hermitian.
 A fill-reducing permutation is used.
 `F = ldltfact(A)` is most frequently used to solve systems of equations `A*x = b` with `F\\b`.
 The returned factorization object `F` also supports the methods `diag`,


### PR DESCRIPTION
Added a table to the `factorize` docs, explaining what types a
user can expect the function to output depending on what they put in.
Also removed a very long and (IMO) unclear type signature for sparse
`ldltfact`.
