### PR TITLE
remove Core.TopModule

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -12,6 +12,8 @@ typealias DenseVecOrMat{T} Union{DenseVector{T}, DenseMatrix{T}}
 
 ## Basic functions ##
 
+import Core: arraysize, arrayset, arrayref
+
 size(a::Array, d) = arraysize(a, d)
 size(a::Vector) = (arraysize(a,1),)
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -139,7 +139,7 @@ export
     fieldtype, getfield, setfield!, nfields, throw, tuple, is, ===, isdefined, eval,
     # sizeof    # not exported, to avoid conflicting with Base.sizeof
     # type reflection
-    issubtype, typeof, isa,
+    issubtype, typeof, isa, typeassert,
     # method reflection
     applicable, invoke,
     # constants
@@ -373,16 +373,4 @@ show(a::ANY) = show(STDOUT, a)
 print(a::ANY...) = print(STDOUT, a...)
 println(a::ANY...) = println(STDOUT, a...)
 
-
-module TopModule
-    # this defines the types that lowering expects to be defined in a (top) module
-    # that are usually inherited from Core, but could be defined custom for a module
-    using Core: Box, IntrinsicFunction, Builtin,
-            arrayref, arrayset, arraysize,
-            _expr, _apply, typeassert, apply_type, svec, kwfunc
-    export Box, IntrinsicFunction, Builtin,
-            arrayref, arrayset, arraysize,
-            _expr, _apply, typeassert, apply_type, svec, kwfunc
-end
-using .TopModule
 ccall(:jl_set_istopmod, Void, (Bool,), true)

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 Main.Core.eval(Main.Core, :(baremodule Inference
-using Core.TopModule, Core.Intrinsics
+using Core.Intrinsics
 import Core: print, println, show, write, unsafe_write, STDOUT, STDERR
 if false # show that the IO system is already (relatively) operational
     print("HELLO")

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -17,7 +17,7 @@ function deepcopy_internal(x::SimpleVector, stackdict::ObjectIdDict)
     if haskey(stackdict, x)
         return stackdict[x]
     end
-    y = svec(Any[deepcopy_internal(x[i], stackdict) for i = 1:length(x)]...)
+    y = Core.svec(Any[deepcopy_internal(x[i], stackdict) for i = 1:length(x)]...)
     stackdict[x] = y
     return y
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -100,7 +100,7 @@ function append_any(xs...)
                 ccall(:jl_array_grow_end, Void, (Any, UInt), out, 16)
                 l += 16
             end
-            arrayset(out, y, i)
+            Core.arrayset(out, y, i)
             i += 1
         end
     end
@@ -109,7 +109,7 @@ function append_any(xs...)
 end
 
 # simple Array{Any} operations needed for bootstrap
-setindex!(A::Array{Any}, x::ANY, i::Int) = arrayset(A, x, i)
+setindex!(A::Array{Any}, x::ANY, i::Int) = Core.arrayset(A, x, i)
 
 function length_checked_equal(args...)
     n = length(args[1])
@@ -184,7 +184,7 @@ end
 
 map(f, v::SimpleVector) = Any[ f(v[i]) for i = 1:length(v) ]
 
-getindex(v::SimpleVector, I::AbstractArray) = svec(Any[ v[i] for i in I ]...)
+getindex(v::SimpleVector, I::AbstractArray) = Core.svec(Any[ v[i] for i in I ]...)
 
 function isassigned(v::SimpleVector, i::Int)
     1 <= i <= length(v) || return false

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+import Core: _apply, svec, apply_type, Builtin, IntrinsicFunction
+
 #### parameters limiting potentially-infinite types ####
 const MAX_TYPEUNION_LEN = 3
 const MAX_TYPE_DEPTH = 7
@@ -292,7 +294,7 @@ add_tfunc(Core.sizeof, 1, 1, x->Int)
 add_tfunc(nfields, 1, 1, x->(isa(x,Const) ? Const(nfields(x.val)) :
                              isType(x) && isleaftype(x.parameters[1]) ? Const(nfields(x.parameters[1])) :
                              Int))
-add_tfunc(_expr, 1, IInf, (args...)->Expr)
+add_tfunc(Core._expr, 1, IInf, (args...)->Expr)
 add_tfunc(applicable, 1, IInf, (f, args...)->Bool)
 add_tfunc(Core.Intrinsics.arraylen, 1, 1, x->Int)
 add_tfunc(arraysize, 2, 2, (a,d)->Int)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -246,14 +246,14 @@ function MethodList(mt::MethodTable)
 end
 
 function methods(f::ANY, t::ANY)
-    if isa(f,Builtin)
+    if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end
     t = to_tuple_type(t)
     return MethodList(Method[m[3] for m in _methods(f,t,-1)], typeof(f).name.mt)
 end
 
-methods(f::Builtin) = MethodList(Method[], typeof(f).name.mt)
+methods(f::Core.Builtin) = MethodList(Method[], typeof(f).name.mt)
 
 function methods(f::ANY)
     # return all matches
@@ -372,7 +372,7 @@ function return_types(f::ANY, types::ANY=Tuple)
 end
 
 function which(f::ANY, t::ANY)
-    if isa(f,Builtin)
+    if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end
     t = to_tuple_type(t)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -2,7 +2,8 @@
 
 module Serializer
 
-import Base: GMP, Bottom, svec, unsafe_convert, uncompressed_ast
+import Base: GMP, Bottom, unsafe_convert, uncompressed_ast
+import Core: svec
 using Base: ViewIndex, index_lengths
 
 export serialize, deserialize

--- a/base/show.jl
+++ b/base/show.jl
@@ -142,7 +142,7 @@ function show(io::IO, f::Function)
     ft = typeof(f)
     mt = ft.name.mt
     if get(io, :multiline, false)
-        if isa(f, Builtin)
+        if isa(f, Core.Builtin)
             print(io, mt.name, " (built-in function)")
         else
             name = mt.name
@@ -163,8 +163,8 @@ function show(io::IO, f::Function)
     end
 end
 
-function show(io::IO, x::IntrinsicFunction)
-    print(io, "(intrinsic function #", box(Int32,unbox(IntrinsicFunction,x)), ")")
+function show(io::IO, x::Core.IntrinsicFunction)
+    print(io, "(intrinsic function #", box(Int32, unbox(Core.IntrinsicFunction, x)), ")")
 end
 
 function show(io::IO, x::Union)
@@ -467,13 +467,13 @@ unquoted(ex::QuoteNode)  = ex.value
 unquoted(ex::Expr)       = ex.args[1]
 
 function is_intrinsic_expr(x::ANY)
-    isa(x, IntrinsicFunction) && return true
+    isa(x, Core.IntrinsicFunction) && return true
     if isa(x, GlobalRef)
         x = x::GlobalRef
         return (isdefined(x.mod, x.name) &&
-                isa(getfield(x.mod, x.name), IntrinsicFunction))
+                isa(getfield(x.mod, x.name), Core.IntrinsicFunction))
     elseif isa(x, Expr)
-        return (x::Expr).typ === IntrinsicFunction
+        return (x::Expr).typ === Core.IntrinsicFunction
     end
     return false
 end
@@ -487,10 +487,10 @@ const indent_width = 4
 function show_expr_type(io::IO, ty, emph)
     if is(ty, Function)
         print(io, "::F")
-    elseif is(ty, IntrinsicFunction)
+    elseif is(ty, Core.IntrinsicFunction)
         print(io, "::I")
     else
-        if emph && (!isleaftype(ty) || ty == Box)
+        if emph && (!isleaftype(ty) || ty == Core.Box)
             emphasize(io, "::$ty")
         else
             print(io, "::$ty")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -2,7 +2,7 @@
 
 baremodule Base
 
-using Core.TopModule, Core.Intrinsics
+using Core.Intrinsics
 ccall(:jl_set_istopmod, Void, (Bool,), true)
 include = Core.include
 include("coreio.jl")

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -69,8 +69,8 @@ end
 @test isnull(deepcopy(Nullable{Array}()))
 
 # issue #15250
-let a1 = Base.svec(1, 2, 3, []), a2 = Base.svec(1, 2, 3)
-    a3 = Base.svec(a1,a1)
+let a1 = Core.svec(1, 2, 3, []), a2 = Core.svec(1, 2, 3)
+    a3 = Core.svec(a1,a1)
     b1 = deepcopy(a1)
     @test a1 == b1
     @test a1 !== b1

--- a/test/core.jl
+++ b/test/core.jl
@@ -3874,7 +3874,7 @@ end
 
 # issue #15370
 @test isdefined(Core, :Box)
-@test isdefined(Base, :Box)
+@test !isdefined(Base, :Box)
 @test !isdefined(Main, :Box)
 
 # issue #1784
@@ -4301,8 +4301,8 @@ end
 type C16767{T}
     b::A16767{C16767{:a}}
 end
-@test B16767.types[1].types[1].parameters[1].types === Base.svec(A16767{B16767})
-@test C16767.types[1].types[1].parameters[1].types === Base.svec(A16767{C16767{:a}})
+@test B16767.types[1].types[1].parameters[1].types === Core.svec(A16767{B16767})
+@test C16767.types[1].types[1].parameters[1].types === Core.svec(A16767{C16767{:a}})
 
 # issue #16340
 function f16340{T}(x::T)


### PR DESCRIPTION
this was a relic of before `(core ...)` was an option for lowering. this is just a small bit of cleanup
