### PR TITLE
Remove documentation of factorial(n,k)

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -6994,13 +6994,6 @@ If `n` is not an `Integer`, `factorial(n)` is equivalent to [`gamma(n+1)`](:func
 factorial(n)
 
 """
-    factorial(n,k)
-
-Compute `factorial(n)/factorial(k)`.
-"""
-factorial(n,k)
-
-"""
     bitrand([rng], [dims...])
 
 Generate a `BitArray` of random boolean values.

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1347,12 +1347,6 @@ Mathematical Functions
 
    Factorial of ``n``\ .  If ``n`` is an :obj:`Integer`\ , the factorial is computed as an integer (promoted to at least 64 bits).  Note that this may overflow if ``n`` is not small, but you can use ``factorial(big(n))`` to compute the result exactly in arbitrary precision. If ``n`` is not an ``Integer``\ , ``factorial(n)`` is equivalent to :func:`gamma(n+1) <gamma>`\ .
 
-.. function:: factorial(n,k)
-
-   .. Docstring generated from Julia source
-
-   Compute ``factorial(n)/factorial(k)``\ .
-
 .. function:: gcd(x,y)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
This method for `factorial' has been moved to Combinatorics packages.
