### PR TITLE
type inference runtime correctness (oldworld)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,9 @@ Language changes
     for `.*` etcetera.  This also means that "dot operations" automatically
     fuse into a single loop, along with other dot calls `f.(x)`. ([#17623])
 
+  * Newly defined methods are no longer callable from the same dynamic runtime
+    scope they were defined in ([#17057]).
+
 Breaking changes
 ----------------
 
@@ -49,6 +52,10 @@ This section lists changes that do not have deprecation warnings.
 
   * `broadcast` now treats `Ref` (except for `Ptr`) arguments as 0-dimensional
     arrays ([#18965]).
+
+  * The runtime now enforces when new method definitions can take effect ([#17057]).
+    The flip-side of this is that new method definitions should now reliably actually
+    take effect, and be called when evaluating new code ([#265]).
 
 Library improvements
 --------------------

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -66,7 +66,7 @@ function eval_user_input(ast::ANY, backend::REPLBackend)
                 value = eval(Main, ast)
                 backend.in_eval = false
                 # note: value wrapped in a closure to ensure it doesn't get passed through expand
-                eval(Main, Expr(:(=), :ans, Expr(:call, ()->value)))
+                eval(Main, Expr(:body, Expr(:(=), :ans, QuoteNode(value)), Expr(:return, nothing)))
                 put!(backend.response_channel, (value, nothing))
             end
             break
@@ -153,9 +153,9 @@ function print_response(errio::IO, val::ANY, bt, show_value::Bool, have_color::B
                 if val !== nothing && show_value
                     try
                         if specialdisplay === nothing
-                            display(val)
+                            eval(Main, Expr(:body, Expr(:return, Expr(:call, display, QuoteNode(val)))))
                         else
-                            display(specialdisplay,val)
+                            eval(Main, Expr(:body, Expr(:return, Expr(:call, specialdisplay, QuoteNode(val)))))
                         end
                     catch err
                         println(errio, "Error showing value of type ", typeof(val), ":")

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -281,11 +281,12 @@ function get_type_call(expr::Expr)
         found ? push!(args, typ) : push!(args, Any)
     end
     # use _methods_by_ftype as the function is supplied as a type
-    mt = Base._methods_by_ftype(Tuple{ft, args...}, -1)
+    world = typemax(UInt)
+    mt = Base._methods_by_ftype(Tuple{ft, args...}, -1, world)
     length(mt) == 1 || return (Any, false)
     m = first(mt)
     # Typeinference
-    params = Core.Inference.InferenceParams()
+    params = Core.Inference.InferenceParams(world)
     return_type = Core.Inference.typeinf_type(m[3], m[1], m[2], true, params)
     return_type === nothing && return (Any, false)
     return (return_type, true)

--- a/base/base.jl
+++ b/base/base.jl
@@ -57,7 +57,10 @@ Alternatively, there is no unique most-specific method.
 type MethodError <: Exception
     f
     args
+    world::UInt
+    MethodError(f::ANY, args::ANY, world::UInt) = new(f, args, world)
 end
+MethodError(f::ANY, args::ANY) = MethodError(f, args, typemax(UInt))
 
 """
     EOFError()

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -308,6 +308,7 @@ unsafe_convert{T}(::Type{T}, x::T) = x
 
 typealias NTuple{N,T} Tuple{Vararg{T,N}}
 
+
 # primitive array constructors
 (::Type{Array{T,N}}){T,N}(d::NTuple{N,Int}) =
     ccall(:jl_new_array, Array{T,N}, (Any,Any), Array{T,N}, d)
@@ -336,6 +337,15 @@ Array{T}(::Type{T}, d::Int...)            = Array(T, d)
 Array{T}(::Type{T}, m::Int)               = Array{T,1}(m)
 Array{T}(::Type{T}, m::Int,n::Int)        = Array{T,2}(m,n)
 Array{T}(::Type{T}, m::Int,n::Int,o::Int) = Array{T,3}(m,n,o)
+
+
+# primitive Symbol constructors
+Symbol(s::String) = Symbol(s.data)
+function Symbol(a::Array{UInt8,1})
+    return ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int),
+          ccall(:jl_array_ptr, Ptr{UInt8}, (Any,), a),
+          Intrinsics.arraylen(a))
+end
 
 
 # docsystem basics

--- a/base/client.jl
+++ b/base/client.jl
@@ -142,12 +142,13 @@ function eval_user_input(ast::ANY, show_value)
             else
                 ast = expand(ast)
                 value = eval(Main, ast)
-                eval(Main, Expr(:(=), :ans, Expr(:call, ()->value)))
-                if value!==nothing && show_value
+                eval(Main, Expr(:body, Expr(:(=), :ans, QuoteNode(value)), Expr(:return, nothing)))
+                if !(value === nothing) && show_value
                     if have_color
                         print(answer_color())
                     end
-                    try display(value)
+                    try
+                        eval(Main, Expr(:body, Expr(:return, Expr(:call, display, QuoteNode(value)))))
                     catch err
                         println(STDERR, "Evaluation succeeded, but an error occurred while showing value of type ", typeof(value), ":")
                         rethrow(err)

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -38,11 +38,6 @@ if !isdefined(Main, :Base)
     (::Type{T}){T}(arg) = convert(T, arg)::T
 end
 
-# Symbol constructors
-Symbol(s::String) = Symbol(s.data)
-Symbol(a::Array{UInt8,1}) =
-    ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int32), a, length(a))
-
 # core array operations
 include("array.jl")
 include("abstractarray.jl")

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -6,14 +6,16 @@ import Core: print, println, show, write, unsafe_write, STDOUT, STDERR
 
 ccall(:jl_set_istopmod, Void, (Bool,), false)
 
-eval(x) = Core.eval(Inference,x)
-eval(m,x) = Core.eval(m,x)
+eval(x) = Core.eval(Inference, x)
+eval(m, x) = Core.eval(m, x)
 
-include = Core.include
+const include = Core.include
+# conditional to allow redefining Core.Inference after base exists
+isdefined(Main, :Base) || ((::Type{T}){T}(arg) = convert(T, arg)::T)
 
 ## Load essential files and libraries
-include("ctypes.jl")
 include("essentials.jl")
+include("ctypes.jl")
 include("generator.jl")
 include("reflection.jl")
 include("options.jl")
@@ -33,10 +35,6 @@ include("operators.jl")
 include("pointer.jl")
 const checked_add = +
 const checked_sub = -
-if !isdefined(Main, :Base)
-    # conditional to allow redefining Core.Inference after base exists
-    (::Type{T}){T}(arg) = convert(T, arg)::T
-end
 
 # core array operations
 include("array.jl")

--- a/base/docs/core.jl
+++ b/base/docs/core.jl
@@ -7,7 +7,7 @@ import ..esc, ..push!, ..getindex, ..current_module, ..unsafe_load, ..Csize_t
 function doc!(str, ex)
     ptr  = unsafe_load(Core.Intrinsics.cglobal(:jl_filename, Ptr{UInt8}))
     len  = ccall(:strlen, Csize_t, (Ptr{UInt8},), ptr)
-    file = ccall(:jl_symbol_n, Any, (Ptr{UInt8}, Int32), ptr, len)
+    file = ccall(:jl_symbol_n, Any, (Ptr{UInt8}, Csize_t), ptr, len)
     line = unsafe_load(Core.Intrinsics.cglobal(:jl_lineno, Int32)) # Cint
     push!(DOCS, (current_module(), ex, str, file, line))
 end

--- a/base/error.jl
+++ b/base/error.jl
@@ -38,7 +38,9 @@ systemerror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(str
 assert(x) = x ? nothing : throw(Main.Base.AssertionError())
 macro assert(ex, msgs...)
     msg = isempty(msgs) ? ex : msgs[1]
-    if !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))
+    if isa(msg, AbstractString)
+        msg = msg # pass-through
+    elseif !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))
         # message is an expression needing evaluating
         msg = :(Main.Base.string($(esc(msg))))
     elseif isdefined(Main, :Base) && isdefined(Main.Base, :string)
@@ -47,7 +49,7 @@ macro assert(ex, msgs...)
         # string() might not be defined during bootstrap
         msg = :(Main.Base.string($(Expr(:quote,msg))))
     end
-    :($(esc(ex)) ? $(nothing) : throw(Main.Base.AssertionError($msg)))
+    return :($(esc(ex)) ? $(nothing) : throw(Main.Base.AssertionError($msg)))
 end
 
 # NOTE: Please keep the constant values specified below in sync with the doc string

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -7,6 +7,8 @@ const MAX_TYPEUNION_LEN = 3
 const MAX_TYPE_DEPTH = 7
 
 immutable InferenceParams
+    world::UInt
+
     # optimization
     inlining::Bool
 
@@ -17,11 +19,15 @@ immutable InferenceParams
     MAX_UNION_SPLITTING::Int
 
     # reasonable defaults
-    InferenceParams(;inlining::Bool=inlining_enabled(),
-                    tupletype_len::Int=15, tuple_depth::Int=4,
-                    tuple_splat::Int=16, union_splitting::Int=4) =
-        new(inlining, tupletype_len,
+    function InferenceParams(world::UInt;
+                    inlining::Bool = inlining_enabled(),
+                    tupletype_len::Int = 15,
+                    tuple_depth::Int = 4,
+                    tuple_splat::Int = 16,
+                    union_splitting::Int = 4)
+        return new(world, inlining, tupletype_len,
             tuple_depth, tuple_splat, union_splitting)
+    end
 end
 
 const UNION_SPLIT_MISMATCH_ERROR = false
@@ -63,13 +69,15 @@ type InferenceState
     mod::Module
     currpc::LineNum
 
-    params::InferenceParams
-
     # info on the state of inference and the linfo
+    params::InferenceParams
     linfo::MethodInstance # used here for the tuple (specTypes, env, Method)
     src::CodeInfo
+    min_valid::UInt
+    max_valid::UInt
     nargs::Int
     stmt_types::Vector{Any}
+    stmt_edges::Vector{Any}
     # return type
     bestguess #::Type
     # current active instruction pointers
@@ -86,11 +94,13 @@ type InferenceState
     # call-graph edges connecting from a caller to a callee (and back)
     # we shouldn't need to iterate edges very often, so we use it to optimize the lookup from edge -> linenum
     # whereas backedges is optimized for iteration
-    edges::ObjectIdDict #Dict{InferenceState, Vector{LineNum}}
+    edges::ObjectIdDict # a Dict{InferenceState, Vector{LineNum}}
     backedges::Vector{Tuple{InferenceState, Vector{LineNum}}}
     # iteration fixed-point detection
     fixedpoint::Bool
     inworkq::Bool
+    const_api::Bool
+    const_ret::Bool
 
     # TODO: put these in InferenceParams (depends on proper multi-methodcache support)
     optimize::Bool
@@ -117,9 +127,10 @@ type InferenceState
         src.ssavaluetypes = Any[ NF for i = 1:(src.ssavaluetypes::Int) ]
 
         n = length(code)
-        s = Any[ () for i = 1:n ]
+        s_types = Any[ () for i = 1:n ]
         # initial types
-        s[1] = Any[ VarState(Bottom, true) for i = 1:nslots ]
+        s_types[1] = Any[ VarState(Bottom, true) for i = 1:nslots ]
+        s_edges = Any[ () for i = 1:n ]
 
         atypes = linfo.specTypes
         nargs = toplevel ? 0 : linfo.def.nargs
@@ -130,9 +141,9 @@ type InferenceState
                     if la > 1
                         atypes = Tuple{Any[Any for i = 1:(la - 1)]..., Tuple.parameters[1]}
                     end
-                    s[1][la] = VarState(Tuple, false)
+                    s_types[1][la] = VarState(Tuple, false)
                 else
-                    s[1][la] = VarState(tuple_tfunc(limit_tuple_depth(params, tupletype_tail(atypes, la))), false)
+                    s_types[1][la] = VarState(tuple_tfunc(limit_tuple_depth(params, tupletype_tail(atypes, la))), false)
                 end
                 la -= 1
             end
@@ -164,10 +175,10 @@ type InferenceState
                     # replace singleton types with their equivalent Const object
                     atyp = Const(atyp.instance)
                 end
-                s[1][i] = VarState(atyp, false)
+                s_types[1][i] = VarState(atyp, false)
             end
             for i = (laty + 1):la
-                s[1][i] = VarState(lastatype, false)
+                s_types[1][i] = VarState(lastatype, false)
             end
         else
             @assert la == 0 # wrong number of arguments
@@ -184,16 +195,29 @@ type InferenceState
         W = IntSet()
         push!(W, 1) #initial pc to visit
 
-        inmodule = toplevel ? current_module() : linfo.def.module # toplevel thunks are inferred in the current module
+        if !toplevel
+            meth = linfo.def
+            inmodule = meth.module
+        else
+            inmodule = current_module() # toplevel thunks are inferred in the current module
+        end
+
+        if cached && !toplevel
+            min_valid = min_world(linfo.def)
+            max_valid = max_world(linfo.def)
+        else
+            min_valid = typemax(UInt)
+            max_valid = typemin(UInt)
+        end
         frame = new(
-            sp, nl, inmodule, 0,
-            params,
-            linfo, src, nargs, s, Union{}, W, 1, n,
+            sp, nl, inmodule, 0, params,
+            linfo, src, min_valid, max_valid,
+            nargs, s_types, s_edges, Union{}, W, 1, n,
             cur_hand, handler_at, n_handlers,
             ssavalue_uses, ssavalue_init,
-            ObjectIdDict(), #Dict{InferenceState, Vector{LineNum}}(),
+            ObjectIdDict(), # Dict{InferenceState, Vector{LineNum}}(),
             Vector{Tuple{InferenceState, Vector{LineNum}}}(),
-            false, false, optimize, cached, false)
+            false, false, false, false, optimize, cached, false)
         push!(active, frame)
         nactive[] += 1
         return frame
@@ -703,7 +727,7 @@ function invoke_tfunc(f::ANY, types::ANY, argtype::ANY, sv::InferenceState)
     ft = type_typeof(f)
     types = Tuple{ft, types.parameters...}
     argtype = Tuple{ft, argtype.parameters...}
-    entry = ccall(:jl_gf_invoke_lookup, Any, (Any,), types)
+    entry = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), types, sv.params.world)
     if entry === nothing
         return Any
     end
@@ -829,7 +853,7 @@ end
 
 #### recursing into expression ####
 
-function abstract_call_gf_by_type(f::ANY, argtype::ANY, sv::InferenceState)
+function abstract_call_gf_by_type(f::ANY, atype::ANY, sv::InferenceState)
     tm = _topmod(sv)
     # don't consider more than N methods. this trades off between
     # compiler performance and generated code performance.
@@ -838,27 +862,43 @@ function abstract_call_gf_by_type(f::ANY, argtype::ANY, sv::InferenceState)
     # It is important for N to be >= the number of methods in the error()
     # function, so we can still know that error() is always Bottom.
     # here I picked 4.
-    argtype = limit_tuple_type(argtype, sv.params)
+    argtype = limit_tuple_type(atype, sv.params)
     argtypes = argtype.parameters
-    applicable = _methods_by_ftype(argtype, 4)
+    ft = argtypes[1] # TODO: ccall jl_first_argument_datatype here
+    isa(ft, DataType) || return Any # the function being called is unknown. can't properly handle this backedge right now
+    isdefined(ft.name, :mt) || return Any # not callable. should be Bottom, but can't track this backedge right now
+    if ft.name === Type.name
+        tname = ft.parameters[1]
+        if isa(tname, TypeVar)
+            tname = tname.ub
+        end
+        if isa(tname, TypeConstructor)
+            tname = tname.body
+        end
+        if !isa(tname, DataType)
+            # can't track the backedge to the ctor right now
+            # for things like Union
+            return Any
+        end
+    end
+    min_valid = UInt[typemin(UInt)]
+    max_valid = UInt[typemax(UInt)]
+    applicable = _methods_by_ftype(argtype, 4, sv.params.world, min_valid, max_valid)
     rettype = Bottom
     if applicable === false
         # this means too many methods matched
         return Any
     end
     x::Array{Any,1} = applicable
-    if isempty(x)
-        # no methods match
-        # TODO: it would be nice to return Bottom here, but during bootstrap we
-        # often compile code that calls methods not defined yet, so it is much
-        # safer just to fall back on dynamic dispatch.
-        return Any
-    end
+    fullmatch = false
     for (m::SimpleVector) in x
         sig = m[1]::DataType
         method = m[3]::Method
         sparams = m[2]::SimpleVector
         recomputesvec = false
+        if !fullmatch && typeseq(sig, argtype)
+            fullmatch = true
+        end
 
         # limit argument type tuple growth
         lsig = length(m[3].sig.parameters)
@@ -969,7 +1009,16 @@ function abstract_call_gf_by_type(f::ANY, argtype::ANY, sv::InferenceState)
             break
         end
     end
-    # if rettype is Bottom we've found a method not found error
+    if !(fullmatch || rettype === Any)
+        # also need an edge to the method table in case something gets
+        # added that did not intersect with any existing method
+        add_mt_backedge(ft.name.mt, argtype, sv)
+        update_valid_age!(min_valid[1], max_valid[1], sv)
+    end
+    if isempty(x)
+        # TODO: this is needed because type intersection is wrong in some cases
+        return Any
+    end
     #print("=> ", rettype, "\n")
     return rettype
 end
@@ -1073,7 +1122,9 @@ function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv:
         end
     end
 
-    meth = _methods_by_ftype(atype, 1)
+    min_valid = UInt[typemin(UInt)]
+    max_valid = UInt[typemax(UInt)]
+    meth = _methods_by_ftype(atype, 1, sv.params.world, min_valid, max_valid)
     if meth === false || length(meth) != 1
         return false
     end
@@ -1086,7 +1137,9 @@ function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv:
 
     args = Any[ (a=argtypes[i]; isa(a,Const) ? a.val : a.parameters[1]) for i in 2:length(argtypes) ]
     try
-        return abstract_eval_constant(f(args...))
+        value = Core._apply_pure(f, args)
+        # TODO: add some sort of edge(s)
+        return abstract_eval_constant(value)
     catch
         return false
     end
@@ -1552,7 +1605,90 @@ end
 inlining_enabled() = (JLOptions().can_inline == 1)
 coverage_enabled() = (JLOptions().code_coverage != 0)
 
-function code_for_method(method::Method, atypes::ANY, sparams::SimpleVector, preexisting::Bool=false)
+# TODO: track the worlds for which this InferenceState
+# is being used, and split it if the WIP requires it?
+function converge_valid_age!(sv::InferenceState)
+    # push the validity range of sv into its fixedpoint callers
+    # recursing as needed to cover the graph
+    for (i, _) in sv.backedges
+        if i.fixedpoint
+            updated = false
+            if i.min_valid < sv.min_valid
+                i.min_valid = sv.min_valid
+                updated = true
+            end
+            if i.max_valid > sv.max_valid
+                i.max_valid = sv.max_valid
+                updated = true
+            end
+            @assert !isdefined(i.linfo, :def) || !i.cached || i.min_valid <= i.params.world <= i.max_valid "invalid age range update"
+            if updated
+                converge_valid_age!(i)
+            end
+        end
+    end
+    nothing
+end
+
+# work towards converging the valid age range for sv
+function update_valid_age!(min_valid::UInt, max_valid::UInt, sv::InferenceState)
+    sv.min_valid = max(sv.min_valid, min_valid)
+    sv.max_valid = min(sv.max_valid, max_valid)
+    @assert !isdefined(sv.linfo, :def) || !sv.cached || sv.min_valid <= sv.params.world <= sv.max_valid "invalid age range update"
+    nothing
+end
+update_valid_age!(edge::InferenceState, sv::InferenceState) = update_valid_age!(edge.min_valid, edge.max_valid, sv)
+update_valid_age!(li::MethodInstance, sv::InferenceState) = update_valid_age!(min_world(li), max_world(li), sv)
+
+# temporarily accumulate our edges to later add as backedges in the callee
+function add_backedge(li::MethodInstance, caller::InferenceState)
+    isdefined(caller.linfo, :def) || return # don't add backedges to toplevel exprs
+    if caller.stmt_edges[caller.currpc] === ()
+        caller.stmt_edges[caller.currpc] = []
+    end
+    push!(caller.stmt_edges[caller.currpc], li)
+    update_valid_age!(li, caller)
+    nothing
+end
+
+# temporarily accumulate our no method errors to later add as backedges in the callee method table
+function add_mt_backedge(mt::MethodTable, typ::ANY, caller::InferenceState)
+    isdefined(caller.linfo, :def) || return # don't add backedges to toplevel exprs
+    if caller.stmt_edges[caller.currpc] === ()
+        caller.stmt_edges[caller.currpc] = []
+    end
+    push!(caller.stmt_edges[caller.currpc], mt)
+    push!(caller.stmt_edges[caller.currpc], typ)
+    nothing
+end
+
+# add the real backedges now
+function finalize_backedges(frame::InferenceState)
+    toplevel = !isdefined(frame.linfo, :def)
+    if !toplevel && frame.cached && frame.max_valid == typemax(UInt)
+        caller = frame.linfo
+        for edges in frame.stmt_edges
+            i = 1
+            while i <= length(edges)
+                to = edges[i]
+                if isa(to, MethodInstance)
+                    ccall(:jl_method_instance_add_backedge, Void, (Any, Any), to, caller)
+                    i += 1
+                else
+                    typeassert(to, MethodTable)
+                    typ = edges[i + 1]
+                    ccall(:jl_method_table_add_backedge, Void, (Any, Any, Any), to, typ, caller)
+                    i += 2
+                end
+            end
+        end
+    end
+end
+
+function code_for_method(method::Method, atypes::ANY, sparams::SimpleVector, world::UInt, preexisting::Bool=false)
+    if world < min_world(method) || world > max_world(method)
+        return nothing
+    end
     if method.isstaged && !isleaftype(atypes)
         # don't call staged functions on abstract types.
         # (see issues #8504, #10230)
@@ -1564,33 +1700,48 @@ function code_for_method(method::Method, atypes::ANY, sparams::SimpleVector, pre
         if method.specializations !== nothing
             # check cached specializations
             # for an existing result stored there
-            return ccall(:jl_specializations_lookup, Any, (Any, Any), method, atypes)
+            return ccall(:jl_specializations_lookup, Any, (Any, Any, UInt), method, atypes, world)
         end
         return nothing
     end
-    return ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), method, atypes, sparams)
+    return ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any, UInt), method, atypes, sparams, world)
 end
 
+function typeinf_active(linfo::MethodInstance)
+    for infstate in active
+        infstate === nothing && continue
+        infstate = infstate::InferenceState
+        if linfo === infstate.linfo
+            return infstate
+        end
+    end
+    return nothing
+end
+
+function add_backedge(frame::InferenceState, caller::InferenceState, currpc::Int)
+    update_valid_age!(frame, caller)
+    if haskey(caller.edges, frame)
+        Ws = caller.edges[frame]::Vector{Int}
+        if !(currpc in Ws)
+            push!(Ws, currpc)
+        end
+    else
+        Ws = Int[currpc]
+        caller.edges[frame] = Ws
+        push!(frame.backedges, (caller, Ws))
+    end
+end
 
 # build (and start inferring) the inference frame for the linfo
 function typeinf_frame(linfo::MethodInstance, caller, optimize::Bool, cached::Bool,
                        params::InferenceParams)
-    frame = nothing
-    if linfo.inInference
+    if cached && linfo.inInference
         # inference on this signature may be in progress,
         # find the corresponding frame in the active list
-        for infstate in active
-            infstate === nothing && continue
-            infstate = infstate::InferenceState
-            if linfo === infstate.linfo
-                frame = infstate
-                break
-            end
-        end
+        frame = typeinf_active(linfo)
         # TODO: this assertion seems iffy
         assert(frame !== nothing)
     else
-        # TODO: verify again here that linfo wasn't just inferred
         # inference not started yet, make a new frame for a new lambda
         if linfo.def.isstaged
             try
@@ -1602,25 +1753,16 @@ function typeinf_frame(linfo::MethodInstance, caller, optimize::Bool, cached::Bo
         else
             src = get_source(linfo)
         end
-        linfo.inInference = true
+        cached && (linfo.inInference = true)
         frame = InferenceState(linfo, src, optimize, cached, params)
     end
     frame = frame::InferenceState
 
-    if isa(caller, InferenceState) && !caller.inferred
+    if isa(caller, InferenceState)
         # if we were called from inside inference, the caller will be the InferenceState object
         # for which the edge was required
-        if haskey(caller.edges, frame)
-            Ws = caller.edges[frame]::Vector{Int}
-            if !(caller.currpc in Ws)
-                push!(Ws, caller.currpc)
-            end
-        else
-            @assert caller.currpc > 0
-            Ws = Int[caller.currpc]
-            caller.edges[frame] = Ws
-            push!(frame.backedges, (caller, Ws))
-        end
+        @assert caller.currpc > 0
+        add_backedge(frame, caller, caller.currpc)
     end
     typeinf_loop(frame)
     return frame
@@ -1628,7 +1770,7 @@ end
 
 # compute (and cache) an inferred AST and return the current best estimate of the result type
 function typeinf_edge(method::Method, atypes::ANY, sparams::SimpleVector, caller::InferenceState)
-    code = code_for_method(method, atypes, sparams)
+    code = code_for_method(method, atypes, sparams, caller.params.world)
     code === nothing && return Any
     code = code::MethodInstance
     if isdefined(code, :inferred)
@@ -1637,6 +1779,7 @@ function typeinf_edge(method::Method, atypes::ANY, sparams::SimpleVector, caller
         # so need to check whether the code itself is also inferred
         inf = code.inferred
         if !isa(inf, CodeInfo) || (inf::CodeInfo).inferred
+            add_backedge(code, caller)
             if isdefined(code, :inferred_const)
                 return abstract_eval_constant(code.inferred_const)
             else
@@ -1655,57 +1798,59 @@ end
 # compute an inferred AST and return type
 function typeinf_code(method::Method, atypes::ANY, sparams::SimpleVector,
                       optimize::Bool, cached::Bool, params::InferenceParams)
-    code = code_for_method(method, atypes, sparams)
+    code = code_for_method(method, atypes, sparams, params.world)
     code === nothing && return (nothing, Any)
     return typeinf_code(code::MethodInstance, optimize, cached, params)
 end
 function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,
                       params::InferenceParams)
     for i = 1:2 # test-and-lock-and-test
+        i == 2 && ccall(:jl_typeinf_begin, Void, ())
         if cached && isdefined(linfo, :inferred)
             # see if this code already exists in the cache
             # staged functions make this hard since they have two "inferred" conditions,
             # so need to check whether the code itself is also inferred
             inf = linfo.inferred
-            if linfo.jlcall_api == 2
-                method = linfo.def
-                tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
-                tree.code = Any[ Expr(:return, QuoteNode(inf)) ]
-                tree.slotnames = Any[ compiler_temp_sym for i = 1:method.nargs ]
-                tree.slotflags = UInt8[ 0 for i = 1:method.nargs ]
-                tree.slottypes = nothing
-                tree.ssavaluetypes = 0
-                tree.inferred = true
-                tree.pure = true
-                tree.inlineable = true
-                i == 2 && ccall(:jl_typeinf_end, Void, ())
-                return (tree, linfo.rettype)
-            elseif isa(inf, CodeInfo)
-                if (inf::CodeInfo).inferred
+            if min_world(linfo) <= params.world <= max_world(linfo)
+                if linfo.jlcall_api == 2
+                    method = linfo.def
+                    tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
+                    tree.code = Any[ Expr(:return, QuoteNode(inf)) ]
+                    tree.slotnames = Any[ compiler_temp_sym for i = 1:method.nargs ]
+                    tree.slotflags = UInt8[ 0 for i = 1:method.nargs ]
+                    tree.slottypes = nothing
+                    tree.ssavaluetypes = 0
+                    tree.inferred = true
+                    tree.pure = true
+                    tree.inlineable = true
                     i == 2 && ccall(:jl_typeinf_end, Void, ())
-                    return (inf, linfo.rettype)
+                    return svec(linfo, tree, linfo.rettype)
+                elseif isa(inf, CodeInfo)
+                    if (inf::CodeInfo).inferred
+                        i == 2 && ccall(:jl_typeinf_end, Void, ())
+                        return svec(linfo, inf, linfo.rettype)
+                    end
                 end
-            else
-                cached = false # don't need to save the new result
             end
         end
-        i == 1 && ccall(:jl_typeinf_begin, Void, ())
     end
     frame = typeinf_frame(linfo, nothing, optimize, cached, params)
     ccall(:jl_typeinf_end, Void, ())
-    frame === nothing && return (nothing, Any)
+    frame === nothing && return svec(nothing, nothing, Any)
     frame = frame::InferenceState
-    frame.inferred || return (nothing, Any)
-    return (frame.src, widenconst(frame.bestguess))
+    frame.inferred || return svec(nothing, nothing, Any)
+    frame.cached || return svec(nothing, frame.src, widenconst(frame.bestguess))
+    return svec(frame.linfo, frame.src, widenconst(frame.bestguess))
 end
 
 # compute (and cache) an inferred AST and return the inferred return type
 function typeinf_type(method::Method, atypes::ANY, sparams::SimpleVector,
                       cached::Bool, params::InferenceParams)
-    code = code_for_method(method, atypes, sparams)
+    code = code_for_method(method, atypes, sparams, params.world)
     code === nothing && return nothing
     code = code::MethodInstance
     for i = 1:2 # test-and-lock-and-test
+        i == 2 && ccall(:jl_typeinf_begin, Void, ())
         if cached && isdefined(code, :inferred)
             # see if this rettype already exists in the cache
             # staged functions make this hard since they have two "inferred" conditions,
@@ -1716,7 +1861,6 @@ function typeinf_type(method::Method, atypes::ANY, sparams::SimpleVector,
                 return code.rettype
             end
         end
-        i == 1 && ccall(:jl_typeinf_begin, Void, ())
     end
     frame = typeinf_frame(code, nothing, cached, cached, params)
     ccall(:jl_typeinf_end, Void, ())
@@ -1726,21 +1870,21 @@ function typeinf_type(method::Method, atypes::ANY, sparams::SimpleVector,
     return widenconst(frame.bestguess)
 end
 
-function typeinf_ext(linfo::MethodInstance)
+function typeinf_ext(linfo::MethodInstance, world::UInt)
     if isdefined(linfo, :def)
         # method lambda - infer this specialization via the method cache
-        (code, typ) = typeinf_code(linfo, true, true, InferenceParams())
-        return code
+        return typeinf_code(linfo, true, true, InferenceParams(world))
     else
         # toplevel lambda - infer directly
         linfo.inInference = true
         ccall(:jl_typeinf_begin, Void, ())
         frame = InferenceState(linfo, linfo.inferred::CodeInfo,
-                               true, true, InferenceParams())
+                               true, true, InferenceParams(world))
         typeinf_loop(frame)
         ccall(:jl_typeinf_end, Void, ())
         @assert frame.inferred # TODO: deal with this better
-        return frame.src
+        @assert frame.linfo === linfo
+        return svec(linfo, frame.src, linfo.rettype)
     end
 end
 
@@ -1781,7 +1925,21 @@ function typeinf_loop(frame)
                     end
                 end
                 for i in length(fplist):-1:1
-                    finish(fplist[i]) # this may add incomplete work to active
+                    # optimize and record the results
+                    # the reverse order makes it more likely to inline a callee into its caller
+                    optimize(fplist[i]::InferenceState) # this may add incomplete work to active
+                end
+                for i in fplist
+                    # push valid ages from each node across the graph cycle
+                    converge_valid_age!(i::InferenceState)
+                end
+                for i in fplist
+                    # record the results
+                    finish(i::InferenceState)
+                end
+                for i in fplist
+                    # update and record all of the back edges for the finished world
+                    finalize_backedges(i::InferenceState)
                 end
             end
         end
@@ -1830,6 +1988,7 @@ function typeinf_frame(frame)
             delete!(W, pc)
             frame.currpc = pc
             frame.cur_hand = frame.handler_at[pc]
+            frame.stmt_edges[pc] === () || empty!(frame.stmt_edges[pc])
             stmt = frame.src.code[pc]
             changes = abstract_interpret(stmt, s[pc]::Array{Any,1}, frame)
             if changes === ()
@@ -1969,13 +2128,18 @@ function typeinf_frame(frame)
 
     if finished || frame.fixedpoint
         if finished
+            optimize(frame)
             finish(frame)
+            finalize_backedges(frame)
         else # fixedpoint propagation
-            for (i,_) in frame.edges
+            for (i, _) in frame.edges
                 i = i::InferenceState
                 if !i.fixedpoint
-                    i.inworkq || push!(workq, i)
-                    i.inworkq = true
+                    update_valid_age!(i, frame) # work towards converging age at the same time
+                    if !i.inworkq
+                        push!(workq, i)
+                        i.inworkq = true
+                    end
                     i.fixedpoint = true
                 end
             end
@@ -1992,7 +2156,7 @@ function unmark_fixedpoint(frame::InferenceState)
     # based upon (recursively) assuming that frame was stuck
     if frame.fixedpoint
         frame.fixedpoint = false
-        for (i,_) in frame.backedges
+        for (i, _) in frame.backedges
             unmark_fixedpoint(i)
         end
     end
@@ -2024,10 +2188,11 @@ function isinlineable(m::Method, src::CodeInfo)
 end
 
 # inference completed on `me`
-# update the MethodInstance and notify the edges
-function finish(me::InferenceState)
-    for (i,_) in me.edges
-        @assert (i::InferenceState).fixedpoint
+# now converge the optimization work
+function optimize(me::InferenceState)
+    for (i, _) in me.edges
+        i = i::InferenceState
+        @assert i.fixedpoint
     end
     # below may call back into inference and
     # see this InferenceState is in an incomplete state
@@ -2044,9 +2209,8 @@ function finish(me::InferenceState)
     end
     type_annotate!(me)
 
-    do_coverage = coverage_enabled()
-    force_noinline = false
     # run optimization passes on fulltree
+    force_noinline = false
     if me.optimize
         # This pass is required for the AST to be valid in codegen
         # if any `SSAValue` is created by type inference. Ref issue #6068
@@ -2060,6 +2224,7 @@ function finish(me::InferenceState)
         getfield_elim_pass!(me)
         # Clean up for `alloc_elim_pass!` and `getfield_elim_pass!`
         void_use_elim_pass!(me)
+        do_coverage = coverage_enabled()
         meta_elim_pass!(me.src.code::Array{Any,1}, me.src.propagate_inbounds, do_coverage)
         # Pop metadata before label reindexing
         force_noinline = popmeta!(me.src.code::Array{Any,1}, :noinline)[1]
@@ -2067,79 +2232,115 @@ function finish(me::InferenceState)
     end
     widen_all_consts!(me.src)
 
-    if isa(me.bestguess, Const)
-        bg = me.bestguess::Const
-        const_ret = true
-        inferred_const = bg.val
-    elseif isconstType(me.bestguess, true)
-        const_ret = true
-        inferred_const = me.bestguess.parameters[1]
-    else
-        const_ret = false
-        inferred_const = nothing
-    end
-
-    const_api = false
-    ispure = me.src.pure
-    inferred = me.src
-    if const_ret && inferred_const !== nothing
+    if isa(me.bestguess, Const) || isconstType(me.bestguess, true)
+        me.const_ret = true
+        ispure = me.src.pure
         if !ispure && length(me.src.code) < 10
             ispure = true
             for stmt in me.src.code
                 if !statement_effect_free(stmt, me.src, me.mod)
-                    ispure = false; break
+                    ispure = false
+                    break
                 end
             end
             if ispure
                 for fl in me.src.slotflags
                     if (fl & Slot_UsedUndef) != 0
-                        ispure = false; break
+                        ispure = false
+                        break
                     end
                 end
             end
         end
+        me.src.pure = ispure
+
+        do_coverage = coverage_enabled()
         if ispure && !do_coverage
             # use constant calling convention
-            inferred = inferred_const
             # Do not emit `jlcall_api == 2` if coverage is enabled
             # so that we don't need to add coverage support
             # to the `jl_call_method_internal` fast path
             # Still set pure flag to make sure `inference` tests pass
             # and to possibly enable more optimization in the future
-            const_api = true
+            me.const_api = true
+            force_noinline || (me.src.inlineable = true)
         end
-        me.src.pure = ispure
     end
 
     # determine and cache inlineability
     if !me.src.inlineable && !force_noinline && isdefined(me.linfo, :def)
-        me.src.inlineable = const_api || isinlineable(me.linfo.def, me.src)
+        me.src.inlineable = isinlineable(me.linfo.def, me.src)
     end
+    me.src.inferred = true
+    nothing
+end
 
+# inference completed on `me`
+# update the MethodInstance and notify the edges
+function finish(me::InferenceState)
+    me.currpc = 1 # used by add_backedge
     if me.cached
         toplevel = !isdefined(me.linfo, :def)
         if !toplevel
-            if !const_api
-                keeptree = me.src.inlineable || ccall(:jl_is_cacheable_sig, Int32, (Any, Any, Any),
-                    me.linfo.specTypes, me.linfo.def.sig, me.linfo.def) != 0
-                if !keeptree
-                    inferred = nothing
-                else
-                    # compress code for non-toplevel thunks
-                    inferred.code = ccall(:jl_compress_ast, Any, (Any, Any), me.linfo.def, inferred.code)
+            min_valid = me.min_valid
+            max_valid = me.max_valid
+        else
+            min_valid = UInt(0)
+            max_valid = UInt(0)
+        end
+
+        # check if the existing me.linfo metadata is also sufficient to describe the current inference result
+        # to decide if it is worth caching it again (which would also clear any generated code)
+        already_inferred = false
+        if isdefined(me.linfo, :inferred)
+            inf = me.linfo.inferred
+            if !isa(inf, CodeInfo) || (inf::CodeInfo).inferred
+                if min_world(me.linfo) == min_valid && max_world(me.linfo) == max_valid
+                    already_inferred = true
                 end
             end
         end
-        const_flags = (const_ret) << 1 | const_api
-        ccall(:jl_set_lambda_rettype, Void, (Any, Any, Int32, Any, Any),
-              me.linfo, widenconst(me.bestguess), const_flags,
-              inferred_const, inferred)
-    end
 
-    me.src.inferred = true
-    me.linfo.inInference = false
-    # finalize and record the linfo result
-    me.inferred = true
+        if !already_inferred
+            const_flags = (me.const_ret) << 1 | me.const_api
+            if me.const_ret
+                if isa(me.bestguess, Const)
+                    inferred_const = (me.bestguess::Const).val
+                else
+                    @assert isconstType(me.bestguess, true)
+                    inferred_const = me.bestguess.parameters[1]
+                end
+            else
+                inferred_const = nothing
+            end
+            if me.const_api
+                # use constant calling convention
+                inferred_result = inferred_const
+            else
+                inferred_result = me.src
+            end
+
+            if !toplevel
+                if !me.const_api
+                    keeptree = me.src.inlineable || ccall(:jl_is_cacheable_sig, Int32, (Any, Any, Any),
+                        me.linfo.specTypes, me.linfo.def.sig, me.linfo.def) != 0
+                    if !keeptree
+                        inferred_result = nothing
+                    else
+                        # compress code for non-toplevel thunks
+                        inferred_result.code = ccall(:jl_compress_ast, Any, (Any, Any), me.linfo.def, inferred_result.code)
+                    end
+                end
+            end
+            cache = ccall(:jl_set_method_inferred, Ref{MethodInstance}, (Any, Any, Any, Any, Int32, UInt, UInt),
+                me.linfo, widenconst(me.bestguess), inferred_const, inferred_result,
+                const_flags, min_valid, max_valid)
+            if cache !== me.linfo
+                me.linfo.inInference = false
+                me.linfo = cache
+            end
+        end
+    end
 
     # lazy-delete the item from active for several reasons:
     # efficiency, correctness, and recursion-safety
@@ -2147,14 +2348,19 @@ function finish(me::InferenceState)
     active[findlast(active, me)] = nothing
 
     # update all of the callers by traversing the backedges
-    for (i,_) in me.backedges
+    for (i, _) in me.backedges
         if !me.fixedpoint || !i.fixedpoint
             # wake up each backedge, unless both me and it already reached a fixed-point (cycle resolution stage)
             delete!(i.edges, me)
             i.inworkq || push!(workq, i)
             i.inworkq = true
         end
+        add_backedge(me.linfo, i)
     end
+
+    # finalize and record the linfo result
+    me.cached && (me.linfo.inInference = false)
+    me.inferred = true
     nothing
 end
 
@@ -2579,8 +2785,9 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
             function splitunion(atypes::Vector{Any}, i::Int)
                 if i == 0
                     local sig = argtypes_to_type(atypes)
-                    local li = ccall(:jl_get_spec_lambda, Any, (Any,), sig)
+                    local li = ccall(:jl_get_spec_lambda, Any, (Any, UInt), sig, sv.params.world)
                     li === nothing && return false
+                    add_backedge(li, sv)
                     local stmt = []
                     push!(stmt, Expr(:(=), linfo_var, li))
                     spec_hit === nothing && (spec_hit = genlabel(sv))
@@ -2623,7 +2830,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
                 append!(stmts, match)
                 if error_label !== nothing
                     push!(stmts, error_label)
-                    push!(stmts, Expr(:call, GlobalRef(_topmod(sv.mod), :error), "error in type inference due to #265"))
+                    push!(stmts, Expr(:call, GlobalRef(_topmod(sv.mod), :error), "fatal error in type inference (type bound)"))
                 end
                 local ret_var, merge
                 if spec_miss !== nothing
@@ -2646,8 +2853,9 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
                 return (ret_var, stmts)
             end
         else
-            local cache_linfo = ccall(:jl_get_spec_lambda, Any, (Any,), atype_unlimited)
+            local cache_linfo = ccall(:jl_get_spec_lambda, Any, (Any, UInt), atype_unlimited, sv.params.world)
             cache_linfo === nothing && return NF
+            add_backedge(cache_linfo, sv)
             e.head = :invoke
             unshift!(e.args, cache_linfo)
             return e
@@ -2663,7 +2871,9 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     else
         atype = atype_unlimited
     end
-    meth = _methods_by_ftype(atype, 1)
+    min_valid = UInt[typemin(UInt)]
+    max_valid = UInt[typemax(UInt)]
+    meth = _methods_by_ftype(atype, 1, sv.params.world, min_valid, max_valid)
     if meth === false || length(meth) != 1
         return invoke_NF()
     end
@@ -2728,11 +2938,12 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     end
 
     # see if the method has been previously inferred (and cached)
-    linfo = code_for_method(method, metharg, methsp, !force_infer) # Union{Void, MethodInstance}
+    linfo = code_for_method(method, metharg, methsp, sv.params.world, !force_infer) # Union{Void, MethodInstance}
     isa(linfo, MethodInstance) || return invoke_NF()
     linfo = linfo::MethodInstance
     if linfo.jlcall_api == 2
         # in this case function can be inlined to a constant
+        add_backedge(linfo, sv)
         return inline_as_constant(linfo.inferred, argexprs, sv)
     end
 
@@ -2753,9 +2964,12 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
         frame.stmt_types[1][3] = VarState(atypes[3], false)
         typeinf_loop(frame)
     else
-        if isdefined(linfo, :inferred)
+        if isdefined(linfo, :inferred) && isa(linfo.inferred, CodeInfo) && (linfo.inferred::CodeInfo).inferred
             # use cache
             src = linfo.inferred
+        elseif linfo.inInference
+            # use WIP
+            frame = typeinf_active(linfo)
         elseif force_infer
             # create inferred code on-demand
             # but if we decided in the past not to try to infer this particular signature
@@ -2768,12 +2982,21 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     # compute the return value
     if isa(frame, InferenceState)
         frame = frame::InferenceState
-        frame.inferred || return invoke_NF()
         linfo = frame.linfo
         src = frame.src
-        if linfo.jlcall_api == 2
-            # in this case function can be inlined to a constant
-            return inline_as_constant(linfo.inferred, argexprs, sv)
+        if frame.const_api # handle like jlcall_api == 2
+            if frame.inferred || !frame.cached
+                add_backedge(frame.linfo, sv)
+            else
+                add_backedge(frame, sv, 0)
+            end
+            if isa(frame.bestguess, Const)
+                inferred_const = (frame.bestguess::Const).val
+            else
+                @assert isconstType(frame.bestguess, true)
+                inferred_const = frame.bestguess.parameters[1]
+            end
+            return inline_as_constant(inferred_const, argexprs, sv)
         end
         rettype = widenconst(frame.bestguess)
     else
@@ -2786,6 +3009,15 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     ast = src.code
     if !src.inferred || !src.inlineable
         return invoke_NF()
+    end
+
+    # create the backedge
+    if isa(frame, InferenceState) && !frame.inferred && frame.cached
+        # in this case, the actual backedge linfo hasn't been computed
+        # yet, but will be when inference on the frame finishes
+        add_backedge(frame, sv, 0)
+    else
+        add_backedge(linfo, sv)
     end
 
     spvals = Any[]
@@ -2906,7 +3138,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     lastexpr = pop!(body.args)
     if isa(lastexpr,LabelNode)
         push!(body.args, lastexpr)
-        push!(body.args, Expr(:call, GlobalRef(_topmod(sv.mod),:error), "fatal error in type inference"))
+        push!(body.args, Expr(:call, GlobalRef(_topmod(sv.mod), :error), "fatal error in type inference (lowering)"))
         lastexpr = nothing
     elseif !(isa(lastexpr,Expr) && lastexpr.head === :return)
         # code sometimes ends with a meta node, e.g. inbounds pop
@@ -2947,13 +3179,14 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
         end
     end
 
-    do_coverage = coverage_enabled()
     inlining_ignore = function (stmt::ANY)
         isa(stmt, Expr) && return is_meta_expr(stmt::Expr)
         isa(stmt, LineNumberNode) && return true
         stmt === nothing && return true
         return false
     end
+
+    do_coverage = coverage_enabled()
     if do_coverage
         line = method.line
         if !isempty(stmts) && isa(stmts[1], LineNumberNode)
@@ -4089,11 +4322,10 @@ function reindex_labels!(sv::InferenceState)
     end
 end
 
-function return_type(f::ANY, t::ANY, params::InferenceParams=InferenceParams())
-    # NOTE: if not processed by pure_eval_call during inference, a call to return_type
-    #       might use difference InferenceParams than the method it is contained in...
+function return_type(f::ANY, t::ANY)
+    params = InferenceParams(ccall(:jl_get_tls_world_age, UInt, ()))
     rt = Union{}
-    for m in _methods(f, t, -1)
+    for m in _methods(f, t, -1, params.world)
         ty = typeinf_type(m[3], m[1], m[2], true, params)
         ty === nothing && return Any
         rt = tmerge(rt, ty)
@@ -4120,7 +4352,7 @@ let fs = Any[typeinf_ext, typeinf_loop, typeinf_edge, occurs_outside_getfield, e
         end
     end
     for f in fs
-        for m in _methods_by_ftype(Tuple{typeof(f), Vararg{Any}}, 10)
+        for m in _methods_by_ftype(Tuple{typeof(f), Vararg{Any}}, 10, typemax(UInt))
             # remove any TypeVars from the intersection
             typ = Any[m[1].parameters...]
             for i = 1:length(typ)
@@ -4128,7 +4360,7 @@ let fs = Any[typeinf_ext, typeinf_loop, typeinf_edge, occurs_outside_getfield, e
                     typ[i] = typ[i].ub
                 end
             end
-            typeinf_type(m[3], Tuple{typ...}, m[2], true, InferenceParams())
+            typeinf_type(m[3], Tuple{typ...}, m[2], true, InferenceParams(typemax(UInt)))
         end
     end
 end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1735,6 +1735,7 @@ end
 # build (and start inferring) the inference frame for the linfo
 function typeinf_frame(linfo::MethodInstance, caller, optimize::Bool, cached::Bool,
                        params::InferenceParams)
+    # println(params.world, ' ', linfo)
     if cached && linfo.inInference
         # inference on this signature may be in progress,
         # find the corresponding frame in the active list

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -58,9 +58,9 @@ function arg_decl_parts(m::Method)
     return tv, decls, file, line
 end
 
-function kwarg_decl(sig::ANY, kwtype::DataType)
-    sig = Tuple{kwtype, Core.AnyVector, sig.parameters...}
-    kwli = ccall(:jl_methtable_lookup, Any, (Any, Any), kwtype.name.mt, sig)
+function kwarg_decl(m::Method, kwtype::DataType)
+    sig = Tuple{kwtype, Core.AnyVector, m.sig.parameters...}
+    kwli = ccall(:jl_methtable_lookup, Any, (Any, Any, UInt), kwtype.name.mt, sig, max_world(m))
     if kwli !== nothing
         kwli = kwli::Method
         src = kwli.isstaged ? kwli.unspecialized.inferred : kwli.source
@@ -104,7 +104,7 @@ function show(io::IO, m::Method; kwtype::Nullable{DataType}=Nullable{DataType}()
     join(io, [isempty(d[2]) ? d[1] : d[1]*"::"*d[2] for d in decls[2:end]],
                  ", ", ", ")
     if !isnull(kwtype)
-        kwargs = kwarg_decl(m.sig, get(kwtype))
+        kwargs = kwarg_decl(m, get(kwtype))
         if !isempty(kwargs)
             print(io, "; ")
             join(io, kwargs, ", ", ", ")
@@ -227,7 +227,7 @@ function show(io::IO, ::MIME"text/html", m::Method; kwtype::Nullable{DataType}=N
     join(io, [isempty(d[2]) ? d[1] : d[1]*"::<b>"*d[2]*"</b>"
                       for d in decls[2:end]], ", ", ", ")
     if !isnull(kwtype)
-        kwargs = kwarg_decl(m.sig, get(kwtype))
+        kwargs = kwarg_decl(m, get(kwtype))
         if !isempty(kwargs)
             print(io, "; <i>")
             join(io, kwargs, ", ", ", ")

--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -454,6 +454,9 @@ precompile(Base.string, (String, String, Char))
 precompile(Base.string, (String, String, Int))
 precompile(Base.vect, (Base.LineEdit.Prompt, String))
 
+# Speed up type inference in the post-Base world redefinition of convert
+isdefined(Core, :Inference) && Base.code_typed(Base.code_typed)
+
 # Speeding up addprocs for LocalManager
 precompile(Base.start_worker, ())
 precompile(Base.start_worker, (Base.TTY,))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -342,7 +342,7 @@ tt_cons(t::ANY, tup::ANY) = (@_pure_meta; Tuple{t, (isa(tup, Type) ? tup.paramet
 
 Returns an array of lowered ASTs for the methods matching the given generic function and type signature.
 """
-function code_lowered(f, t::ANY=Tuple)
+function code_lowered(f::ANY, t::ANY=Tuple)
     asts = map(methods(f, t)) do m
         m = m::Method
         return uncompressed_ast(m, m.isstaged ? m.unspecialized.inferred : m.source)
@@ -352,13 +352,16 @@ end
 
 # low-level method lookup functions used by the compiler
 
-function _methods(f::ANY,t::ANY,lim)
+function _methods(f::ANY, t::ANY, lim::Int, world::UInt)
     ft = isa(f,Type) ? Type{f} : typeof(f)
     tt = isa(t,Type) ? Tuple{ft, t.parameters...} : Tuple{ft, t...}
-    return _methods_by_ftype(tt, lim)
+    return _methods_by_ftype(tt, lim, world)
 end
 
-function _methods_by_ftype(t::ANY, lim)
+function _methods_by_ftype(t::ANY, lim::Int, world::UInt)
+    return _methods_by_ftype(t, lim, world, UInt[typemin(UInt)], UInt[typemax(UInt)])
+end
+function _methods_by_ftype(t::ANY, lim::Int, world::UInt, min::Array{UInt,1}, max::Array{UInt,1})
     tp = t.parameters::SimpleVector
     nu = 1
     for ti in tp
@@ -367,15 +370,16 @@ function _methods_by_ftype(t::ANY, lim)
         end
     end
     if 1 < nu <= 64
-        return _methods(Any[tp...], length(tp), lim, [])
+        return _methods_by_ftype(Any[tp...], length(tp), lim, [], world, min, max)
     end
     # XXX: the following can return incorrect answers that the above branch would have corrected
-    return ccall(:jl_matching_methods, Any, (Any,Cint,Cint), t, lim, 0)
+    return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), t, lim, 0, world, min, max)
 end
 
-function _methods(t::Array,i,lim::Integer,matching::Array{Any,1})
+function _methods_by_ftype(t::Array, i, lim::Integer, matching::Array{Any,1}, world::UInt, min::Array{UInt,1}, max::Array{UInt,1})
     if i == 0
-        new = ccall(:jl_matching_methods, Any, (Any,Cint,Cint), Tuple{t...}, lim, 0)
+        world = typemax(UInt)
+        new = ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), Tuple{t...}, lim, 0, world, min, max)
         new === false && return false
         append!(matching, new::Array{Any,1})
     else
@@ -383,14 +387,14 @@ function _methods(t::Array,i,lim::Integer,matching::Array{Any,1})
         if isa(ti, Union)
             for ty in (ti::Union).types
                 t[i] = ty
-                if _methods(t,i-1,lim,matching) === false
+                if _methods_by_ftype(t, i - 1, lim, matching, world, min, max) === false
                     t[i] = ti
                     return false
                 end
             end
             t[i] = ti
         else
-            return _methods(t,i-1,lim,matching)
+            return _methods_by_ftype(t, i - 1, lim, matching, world, min, max)
         end
     end
     return matching
@@ -430,7 +434,8 @@ function methods(f::ANY, t::ANY)
         throw(ArgumentError("argument is not a generic function"))
     end
     t = to_tuple_type(t)
-    return MethodList(Method[m[3] for m in _methods(f,t,-1)], typeof(f).name.mt)
+    world = typemax(UInt)
+    return MethodList(Method[m[3] for m in _methods(f, t, -1, world)], typeof(f).name.mt)
 end
 
 methods(f::Core.Builtin) = MethodList(Method[], typeof(f).name.mt)
@@ -438,7 +443,10 @@ methods(f::Core.Builtin) = MethodList(Method[], typeof(f).name.mt)
 function methods_including_ambiguous(f::ANY, t::ANY)
     ft = isa(f,Type) ? Type{f} : typeof(f)
     tt = isa(t,Type) ? Tuple{ft, t.parameters...} : Tuple{ft, t...}
-    ms = ccall(:jl_matching_methods, Any, (Any,Cint,Cint), tt, -1, 1)::Array{Any,1}
+    world = typemax(UInt)
+    min = UInt[typemin(UInt)]
+    max = UInt[typemax(UInt)]
+    ms = ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), tt, -1, 1, world, min, max)::Array{Any,1}
     return MethodList(Method[m[3] for m in ms], typeof(f).name.mt)
 end
 function methods(f::ANY)
@@ -523,6 +531,7 @@ function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool,
         throw(ArgumentError("argument is not a generic function"))
     end
     # get the MethodInstance for the method match
+    world = typemax(UInt)
     meth = which(f, t)
     t = to_tuple_type(t)
     ft = isa(f, Type) ? Type{f} : typeof(f)
@@ -530,21 +539,21 @@ function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool,
     (ti, env) = ccall(:jl_match_method, Any, (Any, Any, Any),
                       tt, meth.sig, meth.tvars)::SimpleVector
     meth = func_for_method_checked(meth, tt)
-    linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any), meth, tt, env)
+    linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any, UInt), meth, tt, env, world)
     # get the code for it
-    return _dump_function(linfo, native, wrapper, strip_ir_metadata, dump_module, syntax, optimize, params)
+    return _dump_function_linfo(linfo, world, native, wrapper, strip_ir_metadata, dump_module, syntax, optimize, params)
 end
 
-function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool,
-                        strip_ir_metadata::Bool, dump_module::Bool, syntax::Symbol=:att,
-                        optimize::Bool=true, params::CodegenParams=CodegenParams())
+function _dump_function_linfo(linfo::Core.MethodInstance, world::UInt, native::Bool, wrapper::Bool,
+                              strip_ir_metadata::Bool, dump_module::Bool, syntax::Symbol=:att,
+                              optimize::Bool=true, params::CodegenParams=CodegenParams())
     if syntax != :att && syntax != :intel
         throw(ArgumentError("'syntax' must be either :intel or :att"))
     end
     if native
-        llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, Bool, CodegenParams), linfo, wrapper, params)
+        llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, UInt, Bool, CodegenParams), linfo, world, wrapper, params)
     else
-        llvmf = ccall(:jl_get_llvmf_defn, Ptr{Void}, (Any, Bool, Bool, CodegenParams), linfo, wrapper, optimize, params)
+        llvmf = ccall(:jl_get_llvmf_defn, Ptr{Void}, (Any, UInt, Bool, Bool, CodegenParams), linfo, world, wrapper, optimize, params)
     end
     if llvmf == C_NULL
         error("could not compile the specified method")
@@ -612,10 +621,11 @@ function code_typed(f::ANY, types::ANY=Tuple; optimize=true)
     end
     types = to_tuple_type(types)
     asts = []
-    params = Core.Inference.InferenceParams()
-    for x in _methods(f, types, -1)
+    world = typemax(UInt)
+    params = Core.Inference.InferenceParams(world)
+    for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)
-        (code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, optimize, params)
+        (_, code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, optimize, params)
         code === nothing && error("inference not successful") # Inference disabled?
         push!(asts, uncompressed_ast(meth, code) => ty)
     end
@@ -629,8 +639,9 @@ function return_types(f::ANY, types::ANY=Tuple)
     end
     types = to_tuple_type(types)
     rt = []
-    params = Core.Inference.InferenceParams()
-    for x in _methods(f, types, -1)
+    world = typemax(UInt)
+    params = Core.Inference.InferenceParams(world)
+    for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)
         ty = Core.Inference.typeinf_type(meth, x[1], x[2], true, params)
         ty === nothing && error("inference not successful") # Inference disabled?
@@ -659,7 +670,7 @@ function which(f::ANY, t::ANY)
     else
         ft = isa(f,Type) ? Type{f} : typeof(f)
         tt = Tuple{ft, t.parameters...}
-        m = ccall(:jl_gf_invoke_lookup, Any, (Any,), tt)
+        m = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), tt, typemax(UInt))
         if m === nothing
             error("no method found for the specified argument types")
         end
@@ -765,13 +776,14 @@ true
 function method_exists(f::ANY, t::ANY)
     t = to_tuple_type(t)
     t = Tuple{isa(f,Type) ? Type{f} : typeof(f), t.parameters...}
-    return ccall(:jl_method_exists, Cint, (Any, Any), typeof(f).name.mt, t) != 0
+    return ccall(:jl_method_exists, Cint, (Any, Any, UInt), typeof(f).name.mt, t,
+        typemax(UInt)) != 0
 end
 
 function isambiguous(m1::Method, m2::Method)
     ti = typeintersect(m1.sig, m2.sig)
     ti === Bottom && return false
-    ml = _methods_by_ftype(ti, -1)
+    ml = _methods_by_ftype(ti, -1, typemax(UInt))
     isempty(ml) && return true
     for m in ml
         if ti <: m[3].sig
@@ -780,3 +792,8 @@ function isambiguous(m1::Method, m2::Method)
     end
     return true
 end
+
+min_world(m::Method) = reinterpret(UInt, m.min_world)
+max_world(m::Method) = reinterpret(UInt, m.max_world)
+min_world(m::Core.MethodInstance) = reinterpret(UInt, m.min_world)
+max_world(m::Core.MethodInstance) = reinterpret(UInt, m.max_world)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -335,8 +335,13 @@ function showerror(io::IO, ex::MethodError)
         basef = getfield(Base, name)
         if basef !== ex.f && method_exists(basef, arg_types)
             println(io)
-            print(io, "you may have intended to import Base.", name)
+            print(io, "You may have intended to import Base.", name)
         end
+    end
+    if method_exists(ex.f, arg_types)
+        curworld = ccall(:jl_get_world_counter, UInt, ())
+        println(io)
+        print(io, "The applicable method may be too new: running in world age $(ex.world), while current world is $(curworld).")
     end
     if !is_arg_types
         # Check for row vectors used where a column vector is intended.
@@ -514,7 +519,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                 kwords = Symbol[]
                 if isdefined(ft.name.mt, :kwsorter)
                     kwsorter_t = typeof(ft.name.mt.kwsorter)
-                    kwords = kwarg_decl(method.sig, kwsorter_t)
+                    kwords = kwarg_decl(method, kwsorter_t)
                     length(kwords) > 0 && print(buf, "; ", join(kwords, ", "))
                 end
                 print(buf, ")")
@@ -535,6 +540,13 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                         end
                     end
                 end
+                if ex.world < min_world(method)
+                    print(buf, " (method too new to be called from this world context.)")
+                end
+                if ex.world > max_world(method)
+                    print(buf, " (method deleted before this world age.)")
+                end
+                # TODO: indicate if it's in the wrong world
                 push!(lines, (buf, right_matches))
             end
         end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2253,8 +2253,8 @@ for (Bsig, A1sig, A2sig, gbb, funcname) in
         global $funcname
         function $funcname(f::Function, B::$Bsig, A1::$A1sig, A2::$A2sig)
             func       = @get! cache  f  gen_broadcast_function_sparse($gbb, f, ($A1sig) <: SparseMatrixCSC)
-            func(B, A1, A2)
-            B
+            eval(Expr(:call, () -> func(B, A1, A2))) # need eval because func was just created by gen_broadcast_function_sparse
+            return B
         end
     end  # let broadcast_cache
 end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2253,7 +2253,9 @@ for (Bsig, A1sig, A2sig, gbb, funcname) in
         global $funcname
         function $funcname(f::Function, B::$Bsig, A1::$A1sig, A2::$A2sig)
             func       = @get! cache  f  gen_broadcast_function_sparse($gbb, f, ($A1sig) <: SparseMatrixCSC)
-            eval(Expr(:call, () -> func(B, A1, A2))) # need eval because func was just created by gen_broadcast_function_sparse
+            # need eval because func was just created by gen_broadcast_function_sparse
+            # TODO: convert this to a generated function
+            eval(current_module(), Expr(:body, Expr(:return, Expr(:call, QuoteNode(func), QuoteNode(B), QuoteNode(A1), QuoteNode(A2)))))
             return B
         end
     end  # let broadcast_cache

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -19,8 +19,12 @@ INCLUDE_STATE = 1 # include = Core.include
 
 include("coreio.jl")
 
-eval(x) = Core.eval(Base,x)
-eval(m,x) = Core.eval(m,x)
+eval(x) = Core.eval(Base, x)
+eval(m, x) = Core.eval(m, x)
+(::Type{T}){T}(arg) = convert(T, arg)::T
+(::Type{VecElement{T}}){T}(arg) = VecElement{T}(convert(T, arg))
+convert{T<:VecElement}(::Type{T}, arg) = T(arg)
+convert{T<:VecElement}(::Type{T}, arg::T) = arg
 
 # init core docsystem
 import Core: @doc, @__doc__, @doc_str
@@ -42,8 +46,8 @@ if false
 end
 
 ## Load essential files and libraries
-include("ctypes.jl")
 include("essentials.jl")
+include("ctypes.jl")
 include("base.jl")
 include("generator.jl")
 include("reflection.jl")
@@ -63,10 +67,6 @@ include("int.jl")
 include("operators.jl")
 include("pointer.jl")
 include("refpointer.jl")
-(::Type{T}){T}(arg) = convert(T, arg)::T
-(::Type{VecElement{T}}){T}(arg) = VecElement{T}(convert(T, arg))
-convert{T<:VecElement}(::Type{T}, arg) = T(arg)
-convert{T<:VecElement}(::Type{T}, arg::T) = arg
 include("checked.jl")
 importall .Checked
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -70,12 +70,6 @@ convert{T<:VecElement}(::Type{T}, arg::T) = arg
 include("checked.jl")
 importall .Checked
 
-# Symbol constructors
-if !isdefined(Core, :Inference)
-    Symbol(s::String) = Symbol(s.data)
-    Symbol(a::Array{UInt8,1}) =
-        ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int32), a, length(a))
-end
 # vararg Symbol constructor
 Symbol(x...) = Symbol(string(x...))
 

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -64,6 +64,7 @@ The following data types exist in lowered form:
 
     Marks a point where a variable is created. This has the effect of resetting a variable to undefined.
 
+
 ### Expr types
 
 These symbols appear in the `head` field of `Expr`s in lowered form.
@@ -192,9 +193,10 @@ These symbols appear in the `head` field of `Expr`s in lowered form.
 
       * `:pop_loc`: returns to the source location before the matching `:push_loc`.
 
+
 ### Method
 
-A unique'd container describing the shared metadata for a single (unspecialized) method.
+A unique'd container describing the shared metadata for a single method.
 
   * `name`, `module`, `file`, `line`, `sig`
 
@@ -222,6 +224,11 @@ A unique'd container describing the shared metadata for a single (unspecialized)
   * `nargs`, `isva`, `called`, `isstaged`
 
     Descriptive bit-fields for the source code of this Method.
+
+  * `min_world` / `max_world`
+
+    The range of world ages for which this method is visible to dispatch.
+
 
 ### MethodInstance
 
@@ -264,9 +271,16 @@ for important details on how to modify these fields safely.
 
     The ABI to use when calling `fptr`. Some significant ones include:
 
-      * 0 - not compiled yet
+      * 0 - Not compiled yet.
       * 1 - JL_CALLABLE `jl_value_t *(*)(jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`
-      * 2 - constant (stored in `inferred`)
+      * 2 - Constant (value stored in `inferred`)
+      * 3 - With Static-parameters forwarded `jl_value_t *(*)(jl_svec_t *sparams, jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`
+      * 4 - Run in interpreter `jl_value_t *(*)(jl_method_instance_t *meth, jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`
+
+  * `min_world` / `max_world`
+
+    The range of world ages for which this method instance is valid to be called.
+
 
 ### CodeInfo
 
@@ -319,6 +333,7 @@ Boolean properties:
 
     Whether this is known to be a pure function of its arguments, without respect to the
     state of the method caches or other mutable global state.
+
 
 ## Surface syntax AST
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -655,6 +655,7 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(void)
     return m;
 }
 
+jl_array_t *jl_all_methods;
 jl_method_t *jl_new_method(jl_code_info_t *definition,
                            jl_sym_t *name,
                            jl_tupletype_t *sig,
@@ -692,6 +693,17 @@ jl_method_t *jl_new_method(jl_code_info_t *definition,
         m->unspecialized->inferred = (jl_value_t*)m->source;
         m->source = NULL;
     }
+
+#ifdef RECORD_METHOD_ORDER
+    if (jl_all_methods == NULL)
+        jl_all_methods = jl_alloc_vec_any(0);
+#endif
+    if (jl_all_methods != NULL) {
+        while (jl_array_len(jl_all_methods) < jl_world_counter)
+            jl_array_ptr_1d_push(jl_all_methods, NULL);
+        jl_array_ptr_1d_push(jl_all_methods, (jl_value_t*)m);
+    }
+
     JL_GC_POP();
     return m;
 }

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -22,7 +22,7 @@ extern "C" {
 DECLARE_BUILTIN(throw);      DECLARE_BUILTIN(is);
 DECLARE_BUILTIN(typeof);     DECLARE_BUILTIN(sizeof);
 DECLARE_BUILTIN(issubtype);  DECLARE_BUILTIN(isa);
-DECLARE_BUILTIN(typeassert); DECLARE_BUILTIN(_apply);
+DECLARE_BUILTIN(_apply);     DECLARE_BUILTIN(_apply_pure);
 DECLARE_BUILTIN(isdefined);  DECLARE_BUILTIN(nfields);
 DECLARE_BUILTIN(tuple);      DECLARE_BUILTIN(svec);
 DECLARE_BUILTIN(getfield);   DECLARE_BUILTIN(setfield);
@@ -30,6 +30,7 @@ DECLARE_BUILTIN(fieldtype);  DECLARE_BUILTIN(arrayref);
 DECLARE_BUILTIN(arrayset);   DECLARE_BUILTIN(arraysize);
 DECLARE_BUILTIN(apply_type); DECLARE_BUILTIN(applicable);
 DECLARE_BUILTIN(invoke);     DECLARE_BUILTIN(_expr);
+DECLARE_BUILTIN(typeassert);
 
 #ifdef __cplusplus
 }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -689,7 +689,10 @@ static jl_value_t* try_eval(jl_value_t *ex, jl_codectx_t *ctx, const char *failu
     if (constant || jl_is_ssavalue(ex))
         return constant;
     JL_TRY {
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = ctx->world;
         constant = jl_interpret_toplevel_expr_in(ctx->module, ex, ctx->source, ctx->linfo->sparam_vals);
+        jl_get_ptls_states()->world_age = last_age;
     }
     JL_CATCH {
         if (compiletime)

--- a/src/gc.c
+++ b/src/gc.c
@@ -105,7 +105,10 @@ static void run_finalizer(jl_ptls_t ptls, jl_value_t *o, jl_value_t *ff)
     assert(!jl_typeis(ff, jl_voidpointer_type));
     jl_value_t *args[2] = {ff,o};
     JL_TRY {
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_world_counter;
         jl_apply(args, 2);
+        jl_get_ptls_states()->world_age = last_age;
     }
     JL_CATCH {
         jl_printf(JL_STDERR, "error in running finalizer: ");

--- a/src/gc.c
+++ b/src/gc.c
@@ -1543,6 +1543,7 @@ void visit_mark_stack(jl_ptls_t ptls)
 
 extern jl_array_t *jl_module_init_order;
 extern jl_typemap_entry_t *call_cache[N_CALL_CACHE];
+extern jl_array_t *jl_all_methods;
 
 // mark the initial root set
 void pre_mark(jl_ptls_t ptls)
@@ -1575,6 +1576,8 @@ void pre_mark(jl_ptls_t ptls)
     for (i = 0; i < N_CALL_CACHE; i++)
         if (call_cache[i])
             gc_push_root(ptls, call_cache[i], 0);
+    if (jl_all_methods != NULL)
+        gc_push_root(ptls, jl_all_methods, 0);
 
     jl_mark_box_caches(ptls);
     //gc_push_root(ptls, jl_unprotect_stack_func, 0);

--- a/src/init.c
+++ b/src/init.c
@@ -203,7 +203,10 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
         jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_atexit"));
         if (f != NULL) {
             JL_TRY {
+                size_t last_age = jl_get_ptls_states()->world_age;
+                jl_get_ptls_states()->world_age = jl_get_world_counter();
                 jl_apply(&f, 1);
+                jl_get_ptls_states()->world_age = last_age;
             }
             JL_CATCH {
                 jl_printf(JL_STDERR, "\natexit hook threw an error: ");

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -100,8 +100,12 @@ static void jl_uv_closeHandle(uv_handle_t *handle)
     if (handle == (uv_handle_t*)JL_STDERR)
         JL_STDERR = (JL_STREAM*)STDERR_FILENO;
     // also let the client app do its own cleanup
-    if (handle->type != UV_FILE && handle->data)
+    if (handle->type != UV_FILE && handle->data) {
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_world_counter;
         jl_uv_call_close_callback((jl_value_t*)handle->data);
+        jl_get_ptls_states()->world_age = last_age;
+    }
     if (handle == (uv_handle_t*)&signal_async)
         return;
     free(handle);

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -59,7 +59,10 @@ JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
         jl_value_t *ast = jl_parse_input_line(str, strlen(str),
                 filename, strlen(filename));
         JL_GC_PUSH1(&ast);
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_get_world_counter();
         r = jl_toplevel_eval(ast);
+        jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
     }
@@ -126,7 +129,10 @@ JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t na
         argv[0] = (jl_value_t*)f;
         for(int i=1; i<nargs+1; i++)
             argv[i] = args[i-1];
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(argv, nargs+1);
+        jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
     }
@@ -141,7 +147,10 @@ JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
     jl_value_t *v;
     JL_TRY {
         JL_GC_PUSH1(&f);
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(&f, 1);
+        jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
     }
@@ -158,7 +167,10 @@ JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, 2);
         argv[0] = f; argv[1] = a;
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(argv, 2);
+        jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
     }
@@ -175,7 +187,10 @@ JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, 3);
         argv[0] = f; argv[1] = a; argv[2] = b;
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(argv, 3);
+        jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
     }
@@ -193,7 +208,10 @@ JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, 4);
         argv[0] = f; argv[1] = a; argv[2] = b; argv[3] = c;
+        size_t last_age = jl_get_ptls_states()->world_age;
+        jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(argv, 4);
+        jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3600,12 +3600,13 @@ void jl_init_types(void)
     jl_methtable_type->name->mt = jl_new_method_table(jl_methtable_type->name->name, ptls->current_module);
     jl_methtable_type->super = jl_any_type;
     jl_methtable_type->parameters = jl_emptysvec;
-    jl_methtable_type->name->names = jl_svec(8, jl_symbol("name"), jl_symbol("defs"),
+    jl_methtable_type->name->names = jl_svec(9, jl_symbol("name"), jl_symbol("defs"),
                                              jl_symbol("cache"), jl_symbol("max_args"),
                                              jl_symbol("kwsorter"), jl_symbol("module"),
-                                             jl_symbol(""), jl_symbol(""));
-    jl_methtable_type->types = jl_svec(8, jl_sym_type, jl_any_type, jl_any_type, jl_any_type/*jl_long*/,
-                                       jl_any_type, jl_any_type/*module*/, jl_any_type/*long*/, jl_any_type/*int32*/);
+                                             jl_symbol("backedges"), jl_symbol(""), jl_symbol(""));
+    jl_methtable_type->types = jl_svec(9, jl_sym_type, jl_any_type, jl_any_type, jl_any_type/*jl_long*/,
+                                       jl_any_type, jl_any_type/*module*/,
+                                       jl_any_type/*any vector*/, jl_any_type/*long*/, jl_any_type/*int32*/);
     jl_methtable_type->uid = jl_assign_type_uid();
     jl_methtable_type->instance = NULL;
     jl_methtable_type->struct_decl = NULL;
@@ -3751,24 +3752,30 @@ void jl_init_types(void)
 
     jl_typemap_entry_type =
         jl_new_datatype(jl_symbol("TypeMapEntry"), jl_any_type, jl_emptysvec,
-                        jl_svec(9, jl_symbol("next"),
-                                   jl_symbol("sig"),
-                                   jl_symbol("tvars"),
-                                   jl_symbol("simplesig"),
-                                   jl_symbol("guardsigs"),
-                                   jl_symbol("func"),
-                                   jl_symbol("isleafsig"),
-                                   jl_symbol("issimplesig"),
-                                   jl_symbol("va")),
-                        jl_svec(9, jl_any_type, // Union{TypeMapEntry, Void}
-                                   jl_type_type, // TupleType
-                                   jl_any_type, // Union{SimpleVector{TypeVar}, TypeVar}
-                                   jl_any_type, // TupleType
-                                   jl_any_type, // SimpleVector{TupleType}
-                                   jl_any_type, // Any
-                                   jl_bool_type,
-                                   jl_bool_type,
-                                   jl_bool_type),
+                        jl_svec(11,
+                            jl_symbol("next"),
+                            jl_symbol("sig"),
+                            jl_symbol("tvars"),
+                            jl_symbol("simplesig"),
+                            jl_symbol("guardsigs"),
+                            jl_symbol("min_world"),
+                            jl_symbol("max_world"),
+                            jl_symbol("func"),
+                            jl_symbol("isleafsig"),
+                            jl_symbol("issimplesig"),
+                            jl_symbol("va")),
+                        jl_svec(11,
+                            jl_any_type, // Union{TypeMapEntry, Void}
+                            jl_type_type, // TupleType
+                            jl_any_type, // Union{SimpleVector{TypeVar}, TypeVar}
+                            jl_any_type, // TupleType
+                            jl_any_type, // SimpleVector{TupleType}
+                            jl_long_type, // Int
+                            jl_long_type, // Int
+                            jl_any_type, // Any
+                            jl_bool_type,
+                            jl_bool_type,
+                            jl_bool_type),
                         0, 1, 5);
 
     jl_function_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Function"), jl_any_type, jl_emptysvec);
@@ -3854,9 +3861,6 @@ void jl_init_types(void)
                         jl_svec(2, jl_symbol("mod"), jl_symbol("name")),
                         jl_svec(2, jl_module_type, jl_sym_type), 0, 0, 2);
 
-    jl_svecset(jl_typename_type->types, 1, jl_module_type);
-    jl_svecset(jl_methtable_type->types, 5, jl_module_type);
-
     jl_code_info_type =
         jl_new_datatype(jl_symbol("CodeInfo"),
                         jl_any_type, jl_emptysvec,
@@ -3885,13 +3889,15 @@ void jl_init_types(void)
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(18,
+                        jl_svec(20,
                                 jl_symbol("name"),
                                 jl_symbol("module"),
                                 jl_symbol("file"),
                                 jl_symbol("line"),
                                 jl_symbol("sig"),
                                 jl_symbol("tvars"),
+                                jl_symbol("min_world"),
+                                jl_symbol("max_world"),
                                 jl_symbol("ambig"),
                                 jl_symbol("specializations"),
                                 jl_symbol("sparam_syms"),
@@ -3904,15 +3910,17 @@ void jl_init_types(void)
                                 jl_symbol("isva"),
                                 jl_symbol("isstaged"),
                                 jl_symbol("needs_sparam_vals_ducttape")),
-                        jl_svec(18,
+                        jl_svec(20,
                                 jl_sym_type,
                                 jl_module_type,
                                 jl_sym_type,
                                 jl_int32_type,
                                 jl_type_type,
-                                jl_any_type,
+                                jl_any_type, // Union{TypeVar, SimpleVector}
+                                jl_long_type,
+                                jl_long_type,
                                 jl_any_type, // Union{Array, Void}
-                                jl_any_type,
+                                jl_any_type, // TypeMap
                                 jl_simplevector_type,
                                 jl_code_info_type,
                                 jl_any_type, // jl_method_instance_type
@@ -3923,31 +3931,37 @@ void jl_init_types(void)
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type),
-                        0, 1, 9);
+                        0, 1, 11);
 
     jl_method_instance_type =
         jl_new_datatype(jl_symbol("MethodInstance"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(13,
+                        jl_svec(16,
                                 jl_symbol("specTypes"),
                                 jl_symbol("rettype"),
                                 jl_symbol("sparam_vals"),
+                                jl_symbol("backedges"),
                                 jl_symbol("inferred"),
                                 jl_symbol("inferred_const"),
                                 jl_symbol("def"),
+                                jl_symbol("min_world"),
+                                jl_symbol("max_world"),
                                 jl_symbol("inInference"),
                                 jl_symbol("jlcall_api"),
                                 jl_symbol(""),
                                 jl_symbol("fptr"),
                                 jl_symbol("unspecialized_ducttape"),
                                 jl_symbol(""), jl_symbol("")),
-                        jl_svec(13,
+                        jl_svec(16,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_simplevector_type,
                                 jl_any_type,
                                 jl_any_type,
+                                jl_any_type,
                                 jl_method_type,
+                                jl_long_type,
+                                jl_long_type,
                                 jl_bool_type,
                                 jl_uint8_type,
                                 jl_bool_type,
@@ -4007,19 +4021,22 @@ void jl_init_types(void)
     jl_svecset(jl_datatype_type->types, 16, jl_bool_type);
     jl_svecset(jl_tvar_type->types, 3, jl_bool_type);
     jl_svecset(jl_simplevector_type->types, 0, jl_long_type);
+    jl_svecset(jl_typename_type->types, 1, jl_module_type);
     jl_svecset(jl_typename_type->types, 6, jl_long_type);
     jl_svecset(jl_methtable_type->types, 3, jl_long_type);
+    jl_svecset(jl_methtable_type->types, 5, jl_module_type);
+    jl_svecset(jl_methtable_type->types, 6, jl_array_any_type);
 #ifdef __LP64__
-    jl_svecset(jl_methtable_type->types, 6, jl_int64_type); // unsigned long
+    jl_svecset(jl_methtable_type->types, 7, jl_int64_type); // unsigned long
 #else
-    jl_svecset(jl_methtable_type->types, 6, jl_int32_type); // DWORD
+    jl_svecset(jl_methtable_type->types, 7, jl_int32_type); // DWORD
 #endif
-    jl_svecset(jl_methtable_type->types, 7, jl_int32_type); // uint32_t
-    jl_svecset(jl_method_type->types, 10, jl_method_instance_type);
-    jl_svecset(jl_method_instance_type->types, 9, jl_voidpointer_type);
-    jl_svecset(jl_method_instance_type->types, 10, jl_voidpointer_type);
-    jl_svecset(jl_method_instance_type->types, 11, jl_voidpointer_type);
+    jl_svecset(jl_methtable_type->types, 8, jl_int32_type); // uint32_t
+    jl_svecset(jl_method_type->types, 12, jl_method_instance_type);
     jl_svecset(jl_method_instance_type->types, 12, jl_voidpointer_type);
+    jl_svecset(jl_method_instance_type->types, 13, jl_voidpointer_type);
+    jl_svecset(jl_method_instance_type->types, 14, jl_voidpointer_type);
+    jl_svecset(jl_method_instance_type->types, 15, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -39,12 +39,14 @@ extern "C" {
 
 // useful constants
 extern jl_methtable_t *jl_type_type_mt;
+extern size_t jl_world_counter;
 
 typedef void (*tracer_cb)(jl_value_t *tracee);
 void jl_call_tracer(tracer_cb callback, jl_value_t *tracee);
 
 extern size_t jl_page_size;
 extern jl_function_t *jl_typeinf_func;
+extern size_t jl_typeinf_world;
 
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
@@ -190,10 +192,10 @@ STATIC_INLINE void *jl_gc_alloc_buf(jl_ptls_t ptls, size_t sz)
     return jl_gc_alloc(ptls, sz, (void*)jl_buff_tag);
 }
 
-jl_code_info_t *jl_type_infer(jl_method_instance_t *li, int force);
-jl_generic_fptr_t jl_generate_fptr(jl_method_instance_t *li, void *F);
-jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t *li, jl_code_info_t *src, const jl_cgparams_t *params);
-jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t *li);
+jl_code_info_t *jl_type_infer(jl_method_instance_t **li, size_t world, int force);
+jl_generic_fptr_t jl_generate_fptr(jl_method_instance_t *li, void *F, size_t world);
+jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t *src, size_t world, const jl_cgparams_t *params);
+jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **li, size_t world);
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
 jl_code_info_t *jl_new_code_info_from_ast(jl_expr_t *ast);
 jl_method_t *jl_new_method(jl_code_info_t *definition,
@@ -213,10 +215,11 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_method_instance_t *meth, jl
     if (fptr.jlcall_api == 2)
         return meth->inferred;
     if (__unlikely(fptr.fptr == NULL || fptr.jlcall_api == 0)) {
+        size_t world = jl_get_ptls_states()->world_age;
         // first see if it likely needs to be compiled
         void *F = meth->functionObjectsDecls.functionObject;
         if (!F) // ask codegen to try to turn it into llvm code
-            F = jl_compile_for_dispatch(meth).functionObject;
+            F = jl_compile_for_dispatch(&meth, world).functionObject;
         if (meth->jlcall_api == 2)
             return meth->inferred;
         // if it hasn't been inferred, try using the unspecialized meth cache instead
@@ -234,7 +237,7 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_method_instance_t *meth, jl
         }
         if (!fptr.fptr || fptr.jlcall_api == 0) {
             // ask codegen to make the fptr
-            fptr = jl_generate_fptr(meth, F);
+            fptr = jl_generate_fptr(meth, F, world);
             if (fptr.jlcall_api == 2)
                 return meth->inferred;
         }
@@ -290,8 +293,8 @@ void jl_set_t_uid_ctr(int i);
 uint32_t jl_get_gs_ctr(void);
 void jl_set_gs_ctr(uint32_t ctr);
 
-void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args);
-void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t **args, size_t na);
+void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args, size_t world);
+void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t **args, size_t na, size_t world);
 jl_value_t *jl_get_exceptionf(jl_datatype_t *exception_type, const char *fmt, ...);
 
 JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t);
@@ -363,11 +366,11 @@ int jl_is_toplevel_only_expr(jl_value_t *e);
 jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr);
 
 jl_method_instance_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *types,
-                                           int cache, int inexact, int allow_exec);
-jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache);
+                                               int cache, int inexact, int allow_exec, size_t world);
+jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache, size_t world);
 jl_value_t *jl_gf_invoke(jl_tupletype_t *types, jl_value_t **args, size_t nargs);
 
-jl_datatype_t *jl_first_argument_datatype(jl_value_t *argtypes);
+JL_DLLEXPORT jl_datatype_t *jl_first_argument_datatype(jl_value_t *argtypes);
 int jl_has_intrinsics(jl_method_instance_t *li, jl_value_t *v, jl_module_t *m);
 
 jl_value_t *jl_nth_slot_type(jl_tupletype_t *sig, size_t i);
@@ -479,11 +482,13 @@ int32_t jl_jlcall_api(/*llvm::Function*/const void *function);
 JL_DLLEXPORT jl_array_t *jl_idtable_rehash(jl_array_t *a, size_t newsz);
 
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
-jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types);
+jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types, size_t world);
 JL_DLLEXPORT int jl_has_call_ambiguities(jl_tupletype_t *types, jl_method_t *m);
 jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_tupletype_t *types, jl_svec_t *sp);
-JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_tupletype_t *type);
-JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams);
+JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_tupletype_t *type, size_t world);
+JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams, size_t world);
+JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, jl_method_instance_t *caller);
+JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_value_t *caller);
 
 uint32_t jl_module_next_counter(jl_module_t *m);
 void jl_fptr_to_llvm(jl_fptr_t fptr, jl_method_instance_t *lam, int specsig);
@@ -764,21 +769,22 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
                                       jl_tupletype_t *simpletype, jl_svec_t *guardsigs,
                                       jl_value_t *newvalue, int8_t offs,
                                       const struct jl_typemap_info *tparams,
+                                      size_t min_world, size_t max_world,
                                       jl_value_t **overwritten);
 
 jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_tupletype_t *types, jl_svec_t **penv,
-        int8_t subtype_inexact__sigseq_useenv, int8_t subtype, int8_t offs);
+        int8_t subtype_inexact__sigseq_useenv, int8_t subtype, int8_t offs, size_t world);
 static jl_typemap_entry_t *const INEXACT_ENTRY = (jl_typemap_entry_t*)(uintptr_t)-1;
-jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs);
-jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t **args, size_t n);
-STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(union jl_typemap_t ml_or_cache, jl_value_t **args, size_t n, int8_t offs)
+jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs, size_t world);
+jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t **args, size_t n, size_t world);
+STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(union jl_typemap_t ml_or_cache, jl_value_t **args, size_t n, int8_t offs, size_t world)
 {
     // NOTE: This function is a huge performance hot spot!!
     if (jl_typeof(ml_or_cache.unknown) == (jl_value_t*)jl_typemap_entry_type) {
-        return jl_typemap_entry_assoc_exact(ml_or_cache.leaf, args, n);
+        return jl_typemap_entry_assoc_exact(ml_or_cache.leaf, args, n, world);
     }
     else if (jl_typeof(ml_or_cache.unknown) == (jl_value_t*)jl_typemap_level_type) {
-        return jl_typemap_level_assoc_exact(ml_or_cache.node, args, n, offs);
+        return jl_typemap_level_assoc_exact(ml_or_cache.node, args, n, offs, world);
     }
     return NULL;
 }

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -68,6 +68,7 @@ typedef struct {
 #define JL_MAX_BT_SIZE 80000
 typedef struct _jl_tls_states_t {
     struct _jl_gcframe_t *pgcstack;
+    size_t world_age;
     struct _jl_value_t *exception_in_transit;
     volatile size_t *safepoint;
     // Whether it is safe to execute GC at the same time.

--- a/src/options.h
+++ b/src/options.h
@@ -27,6 +27,11 @@
 // delete julia IR for non-inlineable functions after they're codegen'd
 #define JL_DELETE_NON_INLINEABLE 1
 
+// fill in the jl_all_methods in world-counter order
+// so that it is possible to map (in a debugger) from
+// an inferred world validity range back to the offending definition
+// #define RECORD_METHOD_ORDER
+
 // GC options -----------------------------------------------------------------
 
 // debugging options

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -596,11 +596,14 @@ int sigs_eq(jl_value_t *a, jl_value_t *b, int useenv)
   there tends to be lots of variation there. The type of the 0th argument
   (the function) is always the same for most functions.
 */
-static jl_typemap_entry_t *jl_typemap_assoc_by_type_(jl_typemap_entry_t *ml, jl_tupletype_t *types, int8_t inexact, jl_svec_t **penv)
+static jl_typemap_entry_t *jl_typemap_assoc_by_type_(jl_typemap_entry_t *ml, jl_tupletype_t *types,
+                                                     int8_t inexact, jl_svec_t **penv, size_t world)
 {
     size_t n = jl_field_count(types);
     int typesisva = n == 0 ? 0 : jl_is_vararg_type(jl_tparam(types, n-1));
-    while (ml != (void*)jl_nothing) {
+    for (; ml != (void*)jl_nothing; ml = ml->next) {
+        if (world < ml->min_world || world > ml->max_world)
+            continue; // ignore replaced methods
         size_t lensig = jl_field_count(ml->sig);
         if (lensig == n || (ml->va && lensig <= n+1)) {
             int resetenv = 0, ismatch = 1;
@@ -681,19 +684,19 @@ static jl_typemap_entry_t *jl_typemap_assoc_by_type_(jl_typemap_entry_t *ml, jl_
             if (resetenv)
                 *penv = jl_emptysvec;
         }
-        ml = ml->next;
     }
     return NULL;
 }
 
-static jl_typemap_entry_t *jl_typemap_lookup_by_type_(jl_typemap_entry_t *ml, jl_tupletype_t *types, int8_t useenv)
+static jl_typemap_entry_t *jl_typemap_lookup_by_type_(jl_typemap_entry_t *ml, jl_tupletype_t *types, int8_t useenv, size_t world)
 {
-    while (ml != (void*)jl_nothing) {
+    for (; ml != (void*)jl_nothing; ml = ml->next) {
+        if (world < ml->min_world || world > ml->max_world)
+            continue;
         // TODO: more efficient
         if (sigs_eq((jl_value_t*)types, (jl_value_t*)ml->sig, useenv)) {
             return ml;
         }
-        ml = ml->next;
     }
     return NULL;
 }
@@ -702,7 +705,7 @@ static jl_typemap_entry_t *jl_typemap_lookup_by_type_(jl_typemap_entry_t *ml, jl
 // this is the general entry point for looking up a type in the cache
 // (as a subtype, or with typeseq)
 jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_tupletype_t *types, jl_svec_t **penv,
-                                             int8_t subtype_inexact__sigseq_useenv, int8_t subtype, int8_t offs)
+                                             int8_t subtype_inexact__sigseq_useenv, int8_t subtype, int8_t offs, size_t world)
 {
     if (jl_typeof(ml_or_cache.unknown) == (jl_value_t*)jl_typemap_level_type) {
         jl_typemap_level_t *cache = ml_or_cache.node;
@@ -727,7 +730,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
         // If there is a type at offs, look in the optimized caches
         if (!subtype) {
             if (ty && jl_is_any(ty))
-                return jl_typemap_assoc_by_type(cache->any, types, penv, subtype_inexact__sigseq_useenv, subtype, offs+1);
+                return jl_typemap_assoc_by_type(cache->any, types, penv, subtype_inexact__sigseq_useenv, subtype, offs+1, world);
             if (isva) // in lookup mode, want to match Vararg exactly, not as a subtype
                 ty = NULL;
         }
@@ -738,7 +741,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
                     union jl_typemap_t ml = mtcache_hash_lookup(&cache->targ, a0, 1, offs);
                     if (ml.unknown != jl_nothing) {
                         jl_typemap_entry_t *li = jl_typemap_assoc_by_type(ml, types, penv,
-                                subtype_inexact__sigseq_useenv, subtype, offs+1);
+                                subtype_inexact__sigseq_useenv, subtype, offs+1, world);
                         if (li) return li;
                     }
                 }
@@ -748,7 +751,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
                 union jl_typemap_t ml = mtcache_hash_lookup(&cache->arg1, ty, 0, offs);
                 if (ml.unknown != jl_nothing) {
                     jl_typemap_entry_t *li = jl_typemap_assoc_by_type(ml, types, penv,
-                            subtype_inexact__sigseq_useenv, subtype, offs+1);
+                            subtype_inexact__sigseq_useenv, subtype, offs+1, world);
                     if (li) return li;
                 }
             }
@@ -756,41 +759,43 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
         }
         // Always check the list (since offs doesn't always start at 0)
         if (subtype) {
-            jl_typemap_entry_t *li = jl_typemap_assoc_by_type_(cache->linear, types, subtype_inexact__sigseq_useenv, penv);
+            jl_typemap_entry_t *li = jl_typemap_assoc_by_type_(cache->linear, types, subtype_inexact__sigseq_useenv, penv, world);
             if (li) return li;
-            return jl_typemap_assoc_by_type(cache->any, types, penv, subtype_inexact__sigseq_useenv, subtype, offs+1);
+            return jl_typemap_assoc_by_type(cache->any, types, penv, subtype_inexact__sigseq_useenv, subtype, offs+1, world);
         }
         else {
-            return jl_typemap_lookup_by_type_(cache->linear, types, subtype_inexact__sigseq_useenv);
+            return jl_typemap_lookup_by_type_(cache->linear, types, subtype_inexact__sigseq_useenv, world);
         }
     }
     else {
         return subtype ?
-            jl_typemap_assoc_by_type_(ml_or_cache.leaf, types, subtype_inexact__sigseq_useenv, penv) :
-            jl_typemap_lookup_by_type_(ml_or_cache.leaf, types, subtype_inexact__sigseq_useenv);
+            jl_typemap_assoc_by_type_(ml_or_cache.leaf, types, subtype_inexact__sigseq_useenv, penv, world) :
+            jl_typemap_lookup_by_type_(ml_or_cache.leaf, types, subtype_inexact__sigseq_useenv, world);
     }
 }
 
-jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_value_t **args, size_t n)
+jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_value_t **args, size_t n, size_t world)
 {
     // some manually-unrolled common special cases
     while (ml->simplesig == (void*)jl_nothing && ml->guardsigs == jl_emptysvec && ml->isleafsig) {
         // use a tight loop for a long as possible
-        if (n == jl_field_count(ml->sig) && jl_typeof(args[0]) == jl_tparam(ml->sig, 0)) {
-            if (n == 1)
-                return ml;
-            if (n == 2) {
-                if (jl_typeof(args[1]) == jl_tparam(ml->sig, 1))
+        if (world >= ml->min_world && world <= ml->max_world) {
+            if (n == jl_field_count(ml->sig) && jl_typeof(args[0]) == jl_tparam(ml->sig, 0)) {
+                if (n == 1)
                     return ml;
-            }
-            else if (n == 3) {
-                if (jl_typeof(args[1]) == jl_tparam(ml->sig, 1) &&
-                    jl_typeof(args[2]) == jl_tparam(ml->sig, 2))
-                    return ml;
-            }
-            else {
-                if (sig_match_leaf(args, jl_svec_data(ml->sig->parameters), n))
-                    return ml;
+                if (n == 2) {
+                    if (jl_typeof(args[1]) == jl_tparam(ml->sig, 1))
+                        return ml;
+                }
+                else if (n == 3) {
+                    if (jl_typeof(args[1]) == jl_tparam(ml->sig, 1) &&
+                        jl_typeof(args[2]) == jl_tparam(ml->sig, 2))
+                        return ml;
+                }
+                else {
+                    if (sig_match_leaf(args, jl_svec_data(ml->sig->parameters), n))
+                        return ml;
+                }
             }
         }
         ml = ml->next;
@@ -798,7 +803,9 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
             return NULL;
     }
 
-    while (ml != (void*)jl_nothing) {
+    for (; ml != (void*)jl_nothing; ml = ml->next) {
+        if (world < ml->min_world || world > ml->max_world)
+            continue; // ignore replaced methods
         size_t lensig = jl_field_count(ml->sig);
         if (lensig == n || (ml->va && lensig <= n+1)) {
             if (ml->simplesig != (void*)jl_nothing) {
@@ -806,24 +813,24 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
                 int isva = lensimplesig > 0 && jl_is_vararg_type(jl_tparam(ml->simplesig, lensimplesig - 1));
                 if (lensig == n || (isva && lensimplesig <= n + 1)) {
                     if (!sig_match_simple(args, n, jl_svec_data(ml->simplesig->parameters), isva, lensimplesig))
-                        goto nomatch;
+                        continue;
                 }
                 else {
-                    goto nomatch;
+                    continue;
                 }
             }
 
             if (ml->isleafsig) {
                 if (!sig_match_leaf(args, jl_svec_data(ml->sig->parameters), n))
-                    goto nomatch;
+                    continue;
             }
             else if (ml->issimplesig) {
                 if (!sig_match_simple(args, n, jl_svec_data(ml->sig->parameters), ml->va, lensig))
-                    goto nomatch;
+                    continue;
             }
             else {
                 if (!jl_tuple_subtype(args, n, ml->sig, 1))
-                    goto nomatch;
+                    continue;
             }
 
             size_t i, l;
@@ -838,14 +845,14 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
                 }
             }
             return ml;
-        }
 nomatch:
-        ml = ml->next;
+            continue;
+        }
     }
     return NULL;
 }
 
-jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs)
+jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs, size_t world)
 {
     if (n > offs) {
         jl_value_t *a1 = args[offs];
@@ -853,21 +860,21 @@ jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_v
         assert(jl_is_datatype(ty));
         if (ty == (jl_value_t*)jl_datatype_type && cache->targ.values != (void*)jl_nothing) {
             union jl_typemap_t ml_or_cache = mtcache_hash_lookup(&cache->targ, a1, 1, offs);
-            jl_typemap_entry_t *ml = jl_typemap_assoc_exact(ml_or_cache, args, n, offs+1);
+            jl_typemap_entry_t *ml = jl_typemap_assoc_exact(ml_or_cache, args, n, offs+1, world);
             if (ml) return ml;
         }
         if (cache->arg1.values != (void*)jl_nothing) {
             union jl_typemap_t ml_or_cache = mtcache_hash_lookup(&cache->arg1, ty, 0, offs);
-            jl_typemap_entry_t *ml = jl_typemap_assoc_exact(ml_or_cache, args, n, offs+1);
+            jl_typemap_entry_t *ml = jl_typemap_assoc_exact(ml_or_cache, args, n, offs+1, world);
             if (ml) return ml;
         }
     }
     if (cache->linear != (jl_typemap_entry_t*)jl_nothing) {
-        jl_typemap_entry_t *ml = jl_typemap_entry_assoc_exact(cache->linear, args, n);
+        jl_typemap_entry_t *ml = jl_typemap_entry_assoc_exact(cache->linear, args, n, world);
         if (ml) return ml;
     }
     if (cache->any.unknown != jl_nothing)
-        return jl_typemap_assoc_exact(cache->any, args, n, offs+1);
+        return jl_typemap_assoc_exact(cache->any, args, n, offs+1, world);
     return NULL;
 }
 
@@ -1008,39 +1015,28 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
                                       jl_tupletype_t *simpletype, jl_svec_t *guardsigs,
                                       jl_value_t *newvalue, int8_t offs,
                                       const struct jl_typemap_info *tparams,
+                                      size_t min_world, size_t max_world,
                                       jl_value_t **overwritten)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
+    assert(min_world > 0 && max_world > 0);
     assert(jl_is_tuple_type(type));
     if (!simpletype) {
         simpletype = (jl_tupletype_t*)jl_nothing;
     }
 
     if ((jl_value_t*)simpletype == jl_nothing) {
-        jl_typemap_entry_t *ml = jl_typemap_assoc_by_type(*cache, type, NULL, 1, 0, offs);
+        jl_typemap_entry_t *ml = jl_typemap_assoc_by_type(*cache, type, NULL, 1, 0, offs, min_world);
         if (ml && ml->simplesig == (void*)jl_nothing) {
+            if (newvalue == ml->func.value) // no change. TODO: involve world in computation!
+                return ml;
             if (overwritten != NULL)
                 *overwritten = ml->func.value;
             if (newvalue == NULL)  // don't overwrite with guard entries
                 return ml;
-            // sigatomic begin
-            ml->sig = type;
-            jl_gc_wb(ml, ml->sig);
-            ml->simplesig = simpletype;
-            jl_gc_wb(ml, ml->simplesig);
-            ml->tvars = tvars;
-            jl_gc_wb(ml, ml->tvars);
-            ml->va = jl_is_va_tuple(type);
-            // TODO: `l->func` or `l->func->roots` might need to be rooted
-            ml->func.value = newvalue;
-            if (newvalue)
-                jl_gc_wb(ml, newvalue);
-            // sigatomic end
-            return ml;
+            ml->max_world = min_world - 1;
         }
     }
-    if (overwritten != NULL)
-        *overwritten = NULL;
 
     jl_typemap_entry_t *newrec =
         (jl_typemap_entry_t*)jl_gc_alloc(ptls, sizeof(jl_typemap_entry_t),
@@ -1051,6 +1047,8 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
     newrec->func.value = newvalue;
     newrec->guardsigs = guardsigs;
     newrec->next = (jl_typemap_entry_t*)jl_nothing;
+    newrec->min_world = min_world;
+    newrec->max_world = max_world;
     // compute the complexity of this type signature
     newrec->va = jl_is_va_tuple(type);
     newrec->issimplesig = (tvars == jl_emptysvec); // a TypeVar environment needs an complex matching test

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -15,7 +15,8 @@ Upon return, `tests` is a vector of fully-expanded test names, and
 """ ->
 function choosetests(choices = [])
     testnames = [
-        "linalg", "subarray", "core", "inference", "keywordargs", "numbers",
+        "linalg", "subarray", "core", "inference", "worlds",
+        "keywordargs", "numbers",
         "printf", "char", "strings", "triplequote", "unicode",
         "dates", "dict", "hashing", "iobuffer", "staged", "offsetarray",
         "arrayops", "tuple", "reduce", "reducedim", "random", "abstractarray",

--- a/test/core.jl
+++ b/test/core.jl
@@ -3367,7 +3367,7 @@ typealias PossiblyInvalidUnion{T} Union{T,Int}
 # issue #13007
 call13007{T,N}(::Type{Array{T,N}}) = 0
 call13007(::Type{Array}) = 1
-@test length(Base._methods(call13007, Tuple{Type{TypeVar(:_,Array)}}, 4)) == 2
+@test length(Base._methods(call13007, Tuple{Type{TypeVar(:_,Array)}}, 4, typemax(UInt))) == 2
 
 # detecting cycles during type intersection, e.g. #1631
 cycle_in_solve_tvar_constraints{S}(::Type{Nullable{S}}, x::S) = 0

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -6,7 +6,8 @@ using Base.Test
 
 include("test_sourcepath.jl")
 thefname = "the fname!//\\&\1*"
-@test include_string("include_string_test() = @__FILE__", thefname)() == Base.source_path()
+include_string_test_func = include_string("include_string_test() = @__FILE__", thefname)
+@test include_string_test_func() == Base.source_path()
 @test include_string("Base.source_path()", thefname) == Base.source_path()
 @test basename(@__FILE__) == "loading.jl"
 @test isabspath(@__FILE__)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -339,10 +339,15 @@ end
 
 # test jl_get_llvm_fptr. We test functions both in and definitely not in the system image
 definitely_not_in_sysimg() = nothing
-for (f,t) in ((definitely_not_in_sysimg,Tuple{}),
-        (Base.throw_boundserror,Tuple{UnitRange{Int64},Int64}))
-    t = Base.tt_cons(Core.Typeof(f), Base.to_tuple_type(t))
-    llvmf = ccall(:jl_get_llvmf, Ptr{Void}, (Any, Bool, Bool), t, false, true)
+for (f, t) in Any[(definitely_not_in_sysimg, Tuple{}),
+                  (Base.:+, Tuple{Int, Int})]
+    meth = which(f, t)
+    tt = Tuple{typeof(f), t.parameters...}
+    env = (ccall(:jl_match_method, Any, (Any, Any, Any), tt, meth.sig, meth.tvars))[2]
+    world = typemax(UInt)
+    linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any, UInt), meth, tt, env, world)
+    params = Base.CodegenParams()
+    llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, UInt, Bool, Base.CodegenParams), linfo::Core.MethodInstance, world, true, params)
     @test llvmf != C_NULL
     @test ccall(:jl_get_llvm_fptr, Ptr{Void}, (Ptr{Void},), llvmf) != C_NULL
 end
@@ -586,6 +591,7 @@ end
 
 # PR #18888: code_typed shouldn't cache if not optimizing
 let
+    world = typemax(UInt)
     f18888() = return nothing
     m = first(methods(f18888, Tuple{}))
     @test m.specializations === nothing
@@ -593,11 +599,11 @@ let
 
     code_typed(f18888, Tuple{}; optimize=false)
     @test m.specializations !== nothing  # uncached, but creates the specializations entry
-    code = Core.Inference.code_for_method(m, Tuple{ft}, Core.svec(), true)
+    code = Core.Inference.code_for_method(m, Tuple{ft}, Core.svec(), world, true)
     @test !isdefined(code, :inferred)
 
     code_typed(f18888, Tuple{}; optimize=true)
-    code = Core.Inference.code_for_method(m, Tuple{ft}, Core.svec(), true)
+    code = Core.Inference.code_for_method(m, Tuple{ft}, Core.svec(), world, true)
     @test isdefined(code, :inferred)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ cd(dirname(@__FILE__)) do
         n > 1 && print("\tFrom worker 1:\t")
         local resp
         try
-            resp = runtests(t)
+            resp = eval(Expr(:call, () -> runtests(t))) # runtests is defined by the include above
         catch e
             resp = [e]
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ cd(dirname(@__FILE__)) do
                     push!(results, (test, resp))
                     if (isa(resp[end], Integer) && (resp[end] > max_worker_rss)) || isa(resp, Exception)
                         if n > 1
-                            rmprocs(p, waitfor=0.5)
+                            rmprocs(p, waitfor=5.0)
                             p = addprocs(1; exename=test_exename, exeflags=test_exeflags)[1]
                             remotecall_fetch(()->include("testdefs.jl"), p)
                         else

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -154,9 +154,14 @@ end
 
 # @generated functions including inner functions
 @generated function _g_f_with_inner(x)
-    :(y->y)
+    return :(y -> y)
 end
 @test_throws ErrorException _g_f_with_inner(1)
+
+@generated function _g_f_with_inner2(x)
+    return y -> y
+end
+@test _g_f_with_inner2(1)(2) == 2
 
 # @generated functions errors
 global gf_err_ref = Ref{Int}()

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -1,0 +1,152 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+# tests for accurate updating of method tables
+
+tls_world_age() = ccall(:jl_get_tls_world_age, UInt, ())
+world_counter() = ccall(:jl_get_world_counter, UInt, ())
+@test typemax(UInt) > world_counter() == tls_world_age() > 0
+
+# test simple method replacement
+begin
+    g265a() = f265a(0)
+    f265a(x::Any) = 1
+    @test g265a() == 1
+    @test Base.return_types(g265a, ()) == Any[Int]
+    @test Core.Inference.return_type(g265a, ()) == Int
+
+    f265a(x::Any) = 2.0
+    @test g265a() == 2.0
+
+    @test Base.return_types(g265a, ()) == Any[Float64]
+    @test Core.Inference.return_type(g265a, ()) == Float64
+end
+
+# test signature widening
+begin
+    f265b(x::Int) = 1
+    let ty = Any[1, 2.0e0]
+        global g265b(i::Int) = f265b(ty[i])
+    end
+    @test g265b(1) == 1
+    @test Base.return_types(g265b, (Int,)) == Any[Int]
+    @test Core.Inference.return_type(g265b, (Int,)) == Int
+
+    f265b(x::Any) = 2.0
+    @test g265b(1) == 1
+    @test g265b(2) == 2.0
+    @test Base.return_types(g265b, (Int,)) == Any[Union{Int, Float64}]
+    @test Core.Inference.return_type(g265b, (Int,)) == Union{Int, Float64}
+end
+
+# test signature narrowing
+begin
+    g265c() = f265c(0)
+    f265c(x::Any) = 1
+    @test g265c() == 1
+    @test Base.return_types(g265c, ()) == Any[Int]
+    @test Core.Inference.return_type(g265c, ()) == Int
+
+    f265c(x::Int) = 2.0
+    @test g265c() == 2.0
+
+    @test Base.return_types(g265c, ()) == Any[Float64]
+    @test Core.Inference.return_type(g265c, ()) == Float64
+end
+
+# test constructor narrowing
+type A265{T}
+    field1::T
+end
+A265_() = A265(1)
+@test (A265_()::A265{Int}).field1 === 1
+A265(fld::Int) = A265(Float64(fld))
+@test (A265_()::A265{Float64}).field1 === 1.0e0
+
+# test constructor widening
+type B265{T}
+    field1::T
+    # dummy arg is present to prevent (::Type{T}){T}(arg) from matching the test calls
+    B265(field1::Any, dummy::Void) = new(field1) # prevent generation of outer ctor
+end
+  # define some constructors
+B265(x::Int, dummy::Void) = B265{Int}(x, dummy)
+let ty = Any[1, 2.0e0, 3.0f0]
+    global B265_(i::Int) = B265(ty[i], nothing)
+end
+  # test for correct answers
+@test (B265_(1)::B265{Int}).field1 === 1
+@test_throws MethodError B265_(2)
+@test_throws MethodError B265_(3)
+@test Base.return_types(B265_, (Int,)) == Any[B265{Int}]
+@test Core.Inference.return_type(B265_, (Int,)) == B265{Int}
+
+  # add new constructors
+B265(x::Float64, dummy::Void) = B265{Float64}(x, dummy)
+B265(x::Any, dummy::Void) = B265{UInt8}(x, dummy)
+
+  # make sure answers are updated
+@test (B265_(1)::B265{Int}).field1 === 1
+@test (B265_(2)::B265{Float64}).field1 === 2.0e0
+@test (B265_(3)::B265{UInt8}).field1 === 0x03
+
+@test Base.return_types(B265_, (Int,)) == Any[Union{B265{Float64}, B265{Int}, B265{UInt8}}]
+@test Core.Inference.return_type(B265_, (Int,)) == Union{B265{Float64}, B265{Int}, B265{UInt8}}
+
+
+# test oldworld call / inference
+g265() = [f265(x) for x in 1:3.]
+wc265 = world_counter()
+f265(::Any) = 1.0
+@test wc265 + 1 == world_counter()
+t265 = @async begin
+    local ret = nothing
+    while true
+        (f, args) = produce(ret)
+        ret = f(args...)
+    end
+end
+@test consume(t265) === nothing
+wc265 = world_counter()
+@test consume(t265, world_counter, ()) == wc265
+@test consume(t265, tls_world_age, ()) == wc265
+f265(::Int) = 1
+@test consume(t265, world_counter, ()) == wc265 + 1 == world_counter() == tls_world_age()
+@test consume(t265, tls_world_age, ()) == wc265
+
+@test g265() == Int[1, 1, 1]
+@test Core.Inference.return_type(f265, (Any,)) == Union{Float64, Int}
+@test Core.Inference.return_type(f265, (Int,)) == Int
+@test Core.Inference.return_type(f265, (Float64,)) == Float64
+
+@test consume(t265, g265, ()) == Float64[1.0, 1.0, 1.0]
+@test consume(t265, Core.Inference.return_type, (f265, (Any,))) == Float64
+@test consume(t265, Core.Inference.return_type, (f265, (Int,))) == Float64
+@test consume(t265, Core.Inference.return_type, (f265, (Float64,))) == Float64
+@test consume(t265, Core.Inference.return_type, (f265, (Float64,))) == Float64
+
+
+# test that reflection ignores worlds
+@test Base.return_types(f265, (Any,)) == Any[Int, Float64]
+@test consume(t265, Base.return_types, (f265, (Any,))) == Any[Int, Float64]
+
+
+# test for method errors
+h265() = true
+loc_h265 = "$(Base.source_path()):$(@__LINE__ - 1)"
+@test h265()
+@test_throws MethodError consume(t265, h265, ())
+@test_throws MethodError wait(t265)
+@test istaskdone(t265)
+let ex = t265.exception
+    @test ex.f == h265
+    @test ex.args == ()
+    @test ex.world == wc265
+    str = sprint(showerror, ex)
+    wc = world_counter()
+    cmp = """
+        MethodError: no method matching h265()
+        The applicable method may be too new: running in world age $wc265, while current world is $wc."""
+    @test startswith(str, cmp)
+    cmp = "\n  h265() at $loc_h265 (method too new to be called from this world context.)"
+    @test contains(str, cmp)
+end

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -150,3 +150,16 @@ let ex = t265.exception
     cmp = "\n  h265() at $loc_h265 (method too new to be called from this world context.)"
     @test contains(str, cmp)
 end
+
+# test for generated function correctness
+# and min/max world computation validity of cache_method
+f_gen265(x) = 1
+@generated g_gen265(x) = f_gen265(x)
+@generated h_gen265(x) = :(f_gen265(x))
+f_gen265(x::Int) = 2
+f_gen265(x::Type{Int}) = 3
+@generated g_gen265b(x) = f_gen265(x)
+@test h_gen265(0) == 2
+@test g_gen265(0) == 1
+@test f_gen265(Int) == 3
+@test g_gen265b(0) == 3

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -121,7 +121,10 @@ static NOINLINE int true_main(int argc, char *argv[])
 
     if (start_client) {
         JL_TRY {
+            size_t last_age = jl_get_ptls_states()->world_age;
+            jl_get_ptls_states()->world_age = jl_get_world_counter();
             jl_apply(&start_client, 1);
+            jl_get_ptls_states()->world_age = last_age;
         }
         JL_CATCH {
             jl_no_exc_handler(jl_exception_in_transit);


### PR DESCRIPTION
This ~~starts to~~ implement[s] ~~the runtime structures to track~~ type-inference correctness of our statically computed type inference information. It handles ensuring that old (on stack) code won't see mutations to the method tables. ~~Next step will be to~~ [It now] tracks this information more carefully through inference to build and store all of the edges for invalidation to ensure that evaluating new code only sees the newest code.

TODO:
- [x] docs
- [x] get inference running in the correct world
- [x] teach inlineable to call inference for sv.world
- [x] correct handling of `optimize=false` flag to `code_typed`
- [x] review code for other critical TODOs
- [x] get staged functions running in the correct world
- [x] compute incremental precompile edges
- [x] scrub documentation. emphasize difference between methods and bindings, move `@generated` function example
- [x] get inference `finish` to add the backedge to the right MethodInstance even while resolving cycles
- [x] add default values of the extra arguments to _methods_by_ftype
- [x] investigate how to handle serialize/deserialize
- [x] incrementally forward deserialize the backedges
- [x] NEWs entry
- [x] change cfunction to capture the current world

Later followup work:
- [ ] look for optimizations
- [ ] dead world pruning
- [ ] try to do some inference of unspecialized (esp. during compile-all)
- [ ] make "rpc server" example better
- [ ] devdocs quickly summarizing how/when the world counter is updated, how min/max ages are updated, and how to temporarily run in different worlds, and the meaning of backedge.
 
fix https://github.com/JuliaLang/julia/issues/265
