### PR TITLE
Fix inconsistent use of GNU_SOURCE

### DIFF
--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -6,7 +6,7 @@ $(eval $(call git-external,libuv,LIBUV,configure,.libs/libuv.la,$(SRCDIR)/srccac
 UV_SRC_TARGET := $(BUILDDIR)/$(LIBUV_SRC_DIR)/.libs/libuv.la
 UV_OBJ_TARGET := $(build_libdir)/libuv.la
 
-UV_CFLAGS :=
+UV_CFLAGS := -D_GNU_SOURCE
 ifeq ($(USEMSVC), 1)
 UV_CFLAGS += -DBUILDING_UV_SHARED
 endif


### PR DESCRIPTION
Julia is built with GNU_SOURCE,
defined here: https://github.com/JuliaLang/julia/blob/master/src/Makefile#L21
but the embedded copy of libuv is not.  See https://bugs.debian.org/748573

This results in the following warning:

```
old definition in module `sys' file /usr/include/x86_64-linux-gnu/sys/resource.h line 87
signed int (enum __rusage_who, struct rusage *)
new definition in module `core' file /usr/include/x86_64-linux-gnu/sys/resource.h line 87
signed int (signed int, struct rusage *)
```
