### PR TITLE
WIP: Manual Fixes. JuliaCon 2016 Edition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,7 @@ Make sure that [Travis](http://www.travis-ci.org) greenlights the pull request w
  - use lower case with underscores for method names
  - it is generally preferred to use ASCII operators and identifiers over
    Unicode equivalents whenever possible
+ - in docstring refer to the language as "Julia" and the executable as "`julia`"
 
 #### General Formatting Guidelines For C code contributions
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -193,7 +193,7 @@ typeintersect
 """
     pointer(array [, index])
 
-Get the native address of an array or string element. Be careful to ensure that a julia
+Get the native address of an array or string element. Be careful to ensure that a Julia
 reference to `a` exists as long as this pointer will be used. This function is "unsafe" like
 `unsafe_convert`.
 
@@ -593,7 +593,7 @@ valtype
     edit(path::AbstractString, [line])
 
 Edit a file or directory optionally providing a line number to edit the file at. Returns to
-the julia prompt when you quit the editor.
+the `julia` prompt when you quit the editor.
 """
 edit(path::AbstractString, line=?)
 
@@ -3083,7 +3083,7 @@ addprocs()
 addprocs(machines; keyword_args...) -> List of process identifiers
 ```
 
-Add processes on remote machines via SSH. Requires julia to be installed in the same
+Add processes on remote machines via SSH. Requires `julia` to be installed in the same
 location on each node, or to be available via a shared file system.
 
 `machines` is a vector of machine specifications.  Worker are started for each specification.
@@ -3113,7 +3113,7 @@ Keyword arguments:
 * `dir`: specifies the working directory on the workers. Defaults to the host's current
          directory (as found by `pwd()`)
 
-* `exename`: name of the julia executable. Defaults to `"\$JULIA_HOME/julia"` or
+* `exename`: name of the `julia` executable. Defaults to `"\$JULIA_HOME/julia"` or
              `"\$JULIA_HOME/julia-debug"` as the case may be.
 
 * `exeflags`: additional flags passed to the worker processes.
@@ -3466,7 +3466,7 @@ Convert `x` to a value of type `T`
 In cases where `convert` would need to take a Julia object and turn it into a `Ptr`, this
 function should be used to define and perform that conversion.
 
-Be careful to ensure that a julia reference to `x` exists as long as the result of this
+Be careful to ensure that a Julia reference to `x` exists as long as the result of this
 function will be used. Accordingly, the argument `x` to this function should never be an
 expression, only a variable name or field reference. For example, `x=a.b.c` is acceptable,
 but `x=[a,b,c]` is not.
@@ -6571,7 +6571,7 @@ error
     less(file::AbstractString, [line])
 
 Show a file using the default pager, optionally providing a starting line number. Returns to
-the julia prompt when you quit the pager.
+the `julia` prompt when you quit the pager.
 """
 less(f::AbstractString, ?)
 
@@ -7470,7 +7470,7 @@ listenany
 """
     getpid() -> Int32
 
-Get julia's process ID.
+Get Julia's process ID.
 """
 getpid
 
@@ -8938,7 +8938,7 @@ redirect_stdout
 """
     redirect_stdout(stream)
 
-Replace `STDOUT` by stream for all C and julia level output to `STDOUT`. Note that `stream`
+Replace `STDOUT` by stream for all C and Julia level output to `STDOUT`. Note that `stream`
 must be a TTY, a `Pipe` or a `TCPSocket`.
 """
 redirect_stdout(stream)

--- a/doc/devdocs/ast.rst
+++ b/doc/devdocs/ast.rst
@@ -229,7 +229,7 @@ There is generally a different expression head for each visually distinct
 syntactic form.
 Examples will be given in s-expression syntax. Each parenthesized list corresponds
 to an Expr, where the first element is the head.
-For example ``(call f x)`` corresponds to ``Expr(:call, :f, :x)`` in julia.
+For example ``(call f x)`` corresponds to ``Expr(:call, :f, :x)`` in Julia.
 
 Calls
 ~~~~~

--- a/doc/devdocs/backtraces.rst
+++ b/doc/devdocs/backtraces.rst
@@ -10,14 +10,14 @@ If you've been directed to this page, find the symptom that best matches what yo
 
 * `Segfaults when running a script`_
 
-* `Errors during julia startup`_
+* `Errors during Julia startup`_
 
 .. _version info:
 
 Version/Environment info
 ------------------------
 
-No matter the error, we will always need to know what version of julia you are running. When julia first starts up, a header is printed out with a version number and date.  If your version is ``0.2.0`` or higher, please include the output of ``versioninfo()`` in any report you create::
+No matter the error, we will always need to know what version of Julia you are running. When Julia first starts up, a header is printed out with a version number and date.  If your version is ``0.2.0`` or higher, please include the output of ``versioninfo()`` in any report you create::
 
  julia> versioninfo()
  Julia Version 0.3.3-pre+25
@@ -37,9 +37,9 @@ No matter the error, we will always need to know what version of julia you are r
 Segfaults during bootstrap (sysimg.jl)
 --------------------------------------
 
-Segfaults toward the end of the ``make`` process of building julia are a common symptom of something going wrong while julia is preparsing the corpus of code in the ``base/`` folder.  Many factors can contribute toward this process dying unexpectedly, however it is as often as not due to an error in the C-code portion of julia, and as such must typically be debugged with a debug build inside of ``gdb``.  Explicitly:
+Segfaults toward the end of the ``make`` process of building Julia are a common symptom of something going wrong while Julia is preparsing the corpus of code in the ``base/`` folder.  Many factors can contribute toward this process dying unexpectedly, however it is as often as not due to an error in the C-code portion of Julia, and as such must typically be debugged with a debug build inside of ``gdb``.  Explicitly:
 
-Create a debug build of julia::
+Create a debug build of Julia::
 
   $ cd <julia_root>
   $ make debug
@@ -49,7 +49,7 @@ Note that this process will likely fail with the same error as a normal ``make``
   $ cd base/
   $ gdb -x ../contrib/debug_bootstrap.gdb
 
-This will start ``gdb``, attempt to run the bootstrap process using the debug build of julia, and print out a backtrace if (when) it segfaults.  You may need to hit ``<enter>`` a few times to get the full backtrace.  Create a gist_ with the backtrace, the `version info`_, and any other pertinent information you can think of and open a new issue_ on Github with a link to the gist.
+This will start ``gdb``, attempt to run the bootstrap process using the debug build of Julia, and print out a backtrace if (when) it segfaults.  You may need to hit ``<enter>`` a few times to get the full backtrace.  Create a gist_ with the backtrace, the `version info`_, and any other pertinent information you can think of and open a new issue_ on Github with a link to the gist.
 
 
 .. _Segfaults when running a script:
@@ -57,7 +57,7 @@ This will start ``gdb``, attempt to run the bootstrap process using the debug bu
 Segfaults when running a script
 -------------------------------
 
-The procedure is very similar to `Segfaults during bootstrap (sysimg.jl)`_.  Create a debug build of Julia, and run your script inside of a debugged julia process::
+The procedure is very similar to `Segfaults during bootstrap (sysimg.jl)`_.  Create a debug build of Julia, and run your script inside of a debugged Julia process::
 
   $ cd <julia_root>
   $ make debug
@@ -73,12 +73,12 @@ Note that ``gdb`` will sit there, waiting for instructions.  Type ``r`` to run t
 Create a gist_ with the backtrace, the `version info`_, and any other pertinent information you can think of and open a new issue_ on Github with a link to the gist.
 
 
-.. _Errors during julia startup:
+.. _Errors during Julia startup:
 
-Errors during julia startup
+Errors during Julia startup
 ---------------------------
 
-Occasionally errors occur during julia's startup process (especially when using binary distributions, as opposed to compiling from source) such as the following::
+Occasionally errors occur during Julia's startup process (especially when using binary distributions, as opposed to compiling from source) such as the following::
 
   $ julia
   exec: error -5
@@ -101,7 +101,7 @@ Glossary
 
 A few terms have been used as shorthand in this guide:
 
-* ``<julia_root>`` refers to the root directory of the julia source tree; e.g. it should contain folders such as ``base``, ``deps``, ``src``, ``test``, etc.....
+* ``<julia_root>`` refers to the root directory of the Julia source tree; e.g. it should contain folders such as ``base``, ``deps``, ``src``, ``test``, etc.....
 
 .. _gist: https://gist.github.com
 .. _issue: https://github.com/JuliaLang/julia/issues?state=open

--- a/doc/devdocs/cartesian.rst
+++ b/doc/devdocs/cartesian.rst
@@ -77,7 +77,7 @@ The first argument to both of these macros is the number of
 expressions, which must be an integer. When you're writing a function
 that you intend to work in multiple dimensions, this may not be
 something you want to hard-code. If you're writing code that
-you need to work with older julia versions, currently you
+you need to work with older Julia versions, currently you
 should use the ``@ngenerate`` macro described in `an older version of this documentation <http://docs.julialang.org/en/release-0.3/devdocs/cartesian/#supplying-the-number-of-expressions>`_.
 
 Starting in Julia 0.4-pre, the recommended approach is to use

--- a/doc/devdocs/debuggingtips.rst
+++ b/doc/devdocs/debuggingtips.rst
@@ -12,11 +12,11 @@ Within ``gdb``, any ``jl_value_t*`` object ``obj`` can be displayed using
 
    (gdb) call jl_(obj)
 
-The object will be displayed in the julia session, not in the gdb session.
+The object will be displayed in the ``julia`` session, not in the gdb session.
 This is a useful way to discover the types and values of objects being
 manipulated by Julia's C code.
 
-Similarly, if you're debugging some of julia's internals (e.g.,
+Similarly, if you're debugging some of Julia's internals (e.g.,
 ``inference.jl``), you can print ``obj`` using
 ::
 
@@ -44,11 +44,11 @@ Useful Julia functions for Inspecting those variables
 -----------------------------------------------------
 
 - ``jl_gdblookup($rip)`` :: For looking up the current function and line. (use ``$eip`` on i686 platforms)
-- ``jlbacktrace()`` :: For dumping the current julia backtrace stack to stderr. Only usable after ``record_backtrace()`` has been called.
+- ``jlbacktrace()`` :: For dumping the current Julia backtrace stack to stderr. Only usable after ``record_backtrace()`` has been called.
 - ``jl_dump_llvm_value(Value*)`` :: For invoking ``Value->dump()`` in gdb, where it doesn't work natively. For example, ``f->linfo->functionObject``, ``f->linfo->specFunctionObject``, and ``to_function(f->linfo)``.
 - ``Type->dump()`` :: only works in lldb. Note: add something like ``;1`` to prevent lldb from printing its prompt over the output
 - ``jl_eval_string("expr")`` :: for invoking side-effects to modify the current state or to lookup symbols
-- ``jl_typeof(jl_value_t*)`` :: for extracting the type tag of a julia value (in gdb, call ``macro define jl_typeof jl_typeof`` first, or pick something short like ``ty`` for the first arg to define a shorthand)
+- ``jl_typeof(jl_value_t*)`` :: for extracting the type tag of a Julia value (in gdb, call ``macro define jl_typeof jl_typeof`` first, or pick something short like ``ty`` for the first arg to define a shorthand)
 
 
 Inserting breakpoints for inspection from gdb
@@ -101,7 +101,7 @@ Dealing with signals
 Julia requires a few signal to function property. The profiler uses ``SIGUSR2``
 for sampling and the garbage collector uses ``SIGSEGV`` for threads
 synchronization. If you are debugging some code that uses the profiler or
-multiple julia threads, you may want to let the debugger ignore these signals
+multiple threads, you may want to let the debugger ignore these signals
 since they can be triggered very often during normal operations. The command to
 do this in GDB is (replace ``SIGSEGV`` with ``SIGUSRS`` or other signals you
 want to ignore)::
@@ -116,7 +116,7 @@ If you are debugging a segfault with threaded code, you can set a breakpoint on
 ``jl_critical_error`` (``sigdie_handler`` should also work on Linux and BSD) in
 order to only catch the actual segfault rather than the GC synchronization points.
 
-Debugging during julia's build process (bootstrap)
+Debugging during Julia's build process (bootstrap)
 --------------------------------------------------
 
 Errors that occur during ``make`` need special handling. Julia is built in two stages, constructing

--- a/doc/devdocs/meta.rst
+++ b/doc/devdocs/meta.rst
@@ -8,7 +8,7 @@ Talking to the compiler (the ``:meta`` mechanism)
 In some circumstances, one might wish to provide hints or instructions
 that a given block of code has special properties: you might always
 want to inline it, or you might want to turn on special compiler
-optimization passes.  Starting with version 0.4, julia has a
+optimization passes.  Starting with version 0.4, Julia has a
 convention that these instructions can be placed inside a ``:meta``
 expression, which is typically (but not necessarily) the first
 expression in the body of a function.

--- a/doc/devdocs/types.rst
+++ b/doc/devdocs/types.rst
@@ -63,7 +63,7 @@ tuple-type describing the types of the arguments, and ``sig`` is a
 tuple-type specifying the types in the function's signature.)  For
 this algorithm to work, it's important that methods be sorted by their
 specificity, and that the search begins with the most specific
-methods.  Consequently, julia also implements a partial order on
+methods.  Consequently, Julia also implements a partial order on
 types; this is achieved by functionality that is similar to ``<:``,
 but with differences that will be discussed below.
 

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -769,7 +769,7 @@ Warnings and informational messages
 
 Julia also provides other functions that write messages to the standard error
 I/O, but do not throw any :exc:`Exception`\ s and hence do not interrupt
-execution.:
+execution:
 
 .. doctest::
 

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -153,8 +153,8 @@ to one and zero:
 
 The method signatures for conversion methods are often quite a bit more
 involved than this example, especially for parametric types. The example
-above is meant to be pedagogical, and is not the actual julia behaviour.
-This is the actual implementation in julia::
+above is meant to be pedagogical, and is not the actual Julia behaviour.
+This is the actual implementation in Julia::
 
     convert{T<:Real}(::Type{T}, z::Complex) = (imag(z)==0 ? convert(T,real(z)) :
                                                throw(InexactError()))

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -18,15 +18,15 @@ We start with a simple C program that initializes Julia and calls some Julia cod
 
   int main(int argc, char *argv[])
   {
-      /* required: setup the julia context */
+      /* required: setup the Julia context */
       jl_init(NULL);
 
-      /* run julia commands */
+      /* run Julia commands */
       jl_eval_string("print(sqrt(2.0))");
 
-      /* strongly recommended: notify julia that the
+      /* strongly recommended: notify Julia that the
            program is about to terminate. this allows
-           julia time to cleanup pending write requests
+           Julia time to cleanup pending write requests
            and run all finalizers
       */
       jl_atexit_hook(0);

--- a/doc/manual/faq.rst
+++ b/doc/manual/faq.rst
@@ -536,13 +536,13 @@ Memory
 Why does ``x += y`` allocate memory when ``x`` and ``y`` are arrays?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In julia, ``x += y`` gets replaced during parsing by ``x = x + y``.
+In Julia, ``x += y`` gets replaced during parsing by ``x = x + y``.
 For arrays, this has the consequence that, rather than storing the
 result in the same location in memory as ``x``, it allocates a new
 array to store the result.
 
 While this behavior might surprise some, the choice is deliberate. The
-main reason is the presence of ``immutable`` objects within julia,
+main reason is the presence of ``immutable`` objects within Julia,
 which cannot change their value once created.  Indeed, a number is an
 immutable object; the statements ``x = 5; x += 1`` do not modify the
 meaning of ``5``, they modify the value bound to ``x``. For an

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -622,8 +622,8 @@ convenient for data processing, but in other languages vectorization is also
 often required for performance: if loops are slow, the "vectorized" version of a
 function can call fast library code written in a low-level language.   In Julia,
 vectorized functions are *not* required for performance, and indeed it is often
-beneficial to write your own loops (:ref:`man-performance-tips`:), but they can
-still be convenient.  Therefore, *any* Julia function ``f`` can be applied
+beneficial to write your own loops (see :ref:`man-performance-tips`), but they
+can still be convenient.  Therefore, *any* Julia function ``f`` can be applied
 elementwise to any array (or other collection) with the syntax ``f.(A)``.
 
 Of course, you can omit the dot if you write a specialized "vector" method
@@ -634,7 +634,7 @@ which functions you want to vectorize.
 More generally, ``f.(args...)`` is actually equivalent to
 ``broadcast(f, args...)``, which allows you to operate on multiple
 arrays (even of different shapes), or a mix of arrays and scalars
-(:ref:`man-broadcasting`:).   For example, if you have ``f(x,y) = 3x + 4y``,
+(see :ref:`man-broadcasting`).  For example, if you have ``f(x,y) = 3x + 4y``,
 then ``f.(pi,A)`` will return a new array consisting of ``f(pi,a)`` for each
 ``a`` in ``A``, and ``f.(vector1,vector2)`` will return a new vector
 consisting of ``f(vector1[i],vector2[i])`` for each index ``i``

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -389,9 +389,11 @@ be a tuple:
     (1,2,(3,4))
 
 Also, the function that arguments are spliced into need not be a varargs
-function (although it often is)::
+function (although it often is):
 
-    baz(a,b) = a + b
+.. doctest::
+
+    julia> baz(a,b) = a + b;
 
     julia> args = [1,2]
     2-element Array{Int64,1}:
@@ -408,7 +410,10 @@ function (although it often is)::
      3
 
     julia> baz(args...)
-    no method baz(Int64,Int64,Int64)
+    ERROR: MethodError: no method matching baz(::Int64, ::Int64, ::Int64)
+    Closest candidates are:
+      baz(::Any, ::Any)
+    ...
 
 As you can see, if the wrong number of elements are in the spliced
 container, then the function call will fail, just as it would if too

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -107,7 +107,9 @@ put it in ``~/.juliarc.jl``:
     \end{CJK*}
 
 There are various ways to run Julia code and provide options, similar to
-those available for the ``perl`` and ``ruby`` programs::
+those available for the ``perl`` and ``ruby`` programs:
+
+.. code-block:: none
 
     julia [switches] -- [programfile] [args...]
      -v, --version             Display version information

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -49,7 +49,7 @@ argument to the julia command::
 
     $ julia script.jl arg1 arg2...
 
-As the example implies, the following command-line arguments to julia
+As the example implies, the following command-line arguments to ``julia``
 are taken as command-line arguments to the program ``script.jl``, passed
 in the global constant ``ARGS``. The name of the script itself is passed
 in as the global ``PROGRAM_FILE``. Note that ``ARGS`` is also set when script
@@ -87,7 +87,7 @@ specifies the ip-address and port that other workers should use to
 connect to this worker.
 
 
-If you have code that you want executed whenever julia is run, you can
+If you have code that you want executed whenever Julia is run, you can
 put it in ``~/.juliarc.jl``:
 
 .. raw:: latex
@@ -116,7 +116,7 @@ those available for the ``perl`` and ``ruby`` programs::
      -J, --sysimage <file>     Start up with the given system image file
      --precompiled={yes|no}    Use precompiled code from system image if available
      --compilecache={yes|no}   Enable/disable incremental precompilation of modules
-     -H, --home <dir>          Set location of julia executable
+     -H, --home <dir>          Set location of `julia` executable
      --startup-file={yes|no}   Load ~/.juliarc.jl
      --handle-signals={yes|no} Enable or disable Julia's default signal handlers
 

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -45,7 +45,7 @@ To evaluate expressions written in a source file ``file.jl``, write
 ``include("file.jl")``.
 
 To run code in a file non-interactively, you can give it as the first
-argument to the julia command::
+argument to the ``julia`` command::
 
     $ julia script.jl arg1 arg2...
 

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -4,7 +4,7 @@
  Interacting With Julia
 ************************
 
-Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into the ``julia`` executable.  In addition to allowing quick and easy evaluation of Julia statements, it has a searchable history, tab-completion, many helpful keybindings, and dedicated help and shell modes.  The REPL can be started by simply calling julia with no arguments or double-clicking on the executable::
+Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into the ``julia`` executable.  In addition to allowing quick and easy evaluation of Julia statements, it has a searchable history, tab-completion, many helpful keybindings, and dedicated help and shell modes.  The REPL can be started by simply calling ``julia`` with no arguments or double-clicking on the executable::
 
     $ julia
                    _

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -351,6 +351,22 @@ Control flow      ``&&`` followed by ``||`` followed by ``?``
 Assignments       ``= += -= *= /= //= \= ^= ÷= %= |= &= $= <<= >>= >>>=`` and ``.+= .-= .*= ./= .//= .\= .^= .÷= .%=``
 ================= =============================================================================================
 
+.. _man-elementary-functions:
+
+Elementary Functions
+~~~~~~~~~~~~~~~~~~~~
+
+Julia provides a comprehensive collection of mathematical functions and
+operators. These mathematical operations are defined over as broad a
+class of numerical values as permit sensible definitions, including
+integers, floating-point numbers, rationals, and complexes, wherever
+such definitions make sense.
+
+Moreover, these functions (like any Julia function) can be applied
+in "vectorized" fashion to arrays and other collections with the
+syntax ``f.(A)``, e.g. ``sin.(A)`` will compute the elementwise
+sine of each element of an array ``A``.  See :ref:`man-dot-vectorizing`:.
+
 .. _man-numerical-conversions:
 
 Numerical Conversions
@@ -417,22 +433,6 @@ The following examples show the different forms.
 
 See :ref:`man-conversion-and-promotion` for how to define your own
 conversions and promotions.
-
-.. _man-elementary-functions:
-
-Elementary Functions
---------------------
-
-Julia provides a comprehensive collection of mathematical functions and
-operators. These mathematical operations are defined over as broad a
-class of numerical values as permit sensible definitions, including
-integers, floating-point numbers, rationals, and complexes, wherever
-such definitions make sense.
-
-Moreover, these functions (like any Julia function) can be applied
-in "vectorized" fashion to arrays and other collections with the
-syntax ``f.(A)``, e.g. ``sin.(A)`` will compute the elementwise
-sine of each element of an array ``A``.  See :ref:`man-dot-vectorizing`:.
 
 .. _man-rounding-functions:
 

--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -260,7 +260,7 @@ to reduce this time.
 There are two mechanisms that can achieve this:
 incremental compile and custom system image.
 
-To create a custom system image that can be used to start julia with the -J option,
+To create a custom system image that can be used when starting Julia with the ``-J`` option,
 recompile Julia after modifying the file ``base/userimg.jl`` to require the desired modules.
 
 To create an incremental precompiled module file, add

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -466,7 +466,7 @@ are several possible approaches, here is one that is widely used:
   run the tests:
 
   + From Julia, run :func:`Pkg.test("Foo") <Pkg.test>`: this will run your
-    tests in a separate (new) julia process.
+    tests in a separate (new) ``julia`` process.
   + From Julia, ``include("runtests.jl")`` from the package's ``test/`` folder
     (it's possible the file has a different name, look for one that runs all
     the tests): this allows you to run the tests repeatedly in the same session

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -167,7 +167,7 @@ the following code::
 
     end
 
-Starting julia with ``julia -p 2``, you can use this to verify the following:
+Starting Julia with ``julia -p 2``, you can use this to verify the following:
 
 - :func:`include("DummyModule.jl") <include>` loads the file on just a single process (whichever one executes the statement).
 - ``using DummyModule`` causes the module to be loaded on all processes; however, the module is brought into scope only on the one executing the statement.
@@ -202,7 +202,7 @@ The base Julia installation has in-built support for two types of clusters:
 - A local cluster specified with the ``-p`` option as shown above.
 
 - A cluster spanning machines using the ``--machinefile`` option. This uses a passwordless
-  ``ssh`` login to start julia worker processes (from the same path as the current host)
+  ``ssh`` login to start Julia worker processes (from the same path as the current host)
   on the specified machines.
 
 Functions :func:`addprocs`, :func:`rmprocs`, :func:`workers`, and others are available as a programmatic means of
@@ -729,15 +729,15 @@ handles mapping the shared segment being released sooner.
 ClusterManagers
 ---------------
 
-The launching, management and networking of julia processes into a logical
+The launching, management and networking of Julia processes into a logical
 cluster is done via cluster managers. A :obj:`ClusterManager` is responsible for
 
 - launching worker processes in a cluster environment
 - managing events during the lifetime of each worker
 - optionally, a cluster manager can also provide data transport
 
-A julia cluster has the following characteristics:
-- The initial julia process, also called the ``master`` is special and has a julia id of 1.
+A Julia cluster has the following characteristics:
+- The initial Julia process, also called the ``master`` is special and has a id of 1.
 - Only the ``master`` process can add or remove worker processes.
 - All processes can directly communicate with each other.
 
@@ -750,11 +750,11 @@ Connections between workers (using the in-built TCP/IP transport) is established
 - The cluster manager captures the stdout's of each worker and makes it available to the master process
 - The master process parses this information and sets up TCP/IP connections to each worker
 - Every worker is also notified of other workers in the cluster
-- Each worker connects to all workers whose julia id is less than its own id
+- Each worker connects to all workers whose id is less than its own id
 - In this way a mesh network is established, wherein every worker is directly connected with every other worker
 
 
-While the default transport layer uses plain TCP sockets, it is possible for a julia cluster to provide
+While the default transport layer uses plain TCP sockets, it is possible for a Julia cluster to provide
 its own transport.
 
 Julia provides two in-built cluster managers:
@@ -860,7 +860,7 @@ If ``io`` is not specified, ``host`` and ``port`` are used to connect.
 For example, a cluster manager may launch a single worker per node, and use that to launch
 additional workers. ``count`` with an integer value ``n`` will launch a total of ``n`` workers,
 while a value of ``:auto`` will launch as many workers as cores on that machine.
-``exename`` is the name of the julia executable including the full path.
+``exename`` is the name of the Julia executable including the full path.
 ``exeflags`` should be set to the required command line arguments for new workers.
 
 ``tunnel``, ``bind_addr``, ``sshflags`` and ``max_parallel`` are used when a ssh tunnel is
@@ -884,14 +884,14 @@ Cluster Managers with custom transports
 ---------------------------------------
 
 Replacing the default TCP/IP all-to-all socket connections with a custom transport layer is a little more involved.
-Each julia process has as many communication tasks as the workers it is connected to. For example, consider a julia cluster of
+Each Julia process has as many communication tasks as the workers it is connected to. For example, consider a Julia cluster of
 32 processes in a all-to-all mesh network:
 
-- Each julia process thus has 31 communication tasks
+- Each Julia process thus has 31 communication tasks
 - Each task handles all incoming messages from a single remote worker in a message processing loop
 - The message processing loop waits on an ``AsyncStream`` object - for example, a TCP socket in the default implementation, reads an entire
   message, processes it and waits for the next one
-- Sending messages to a process is done directly from any julia task - not just communication tasks - again, via the appropriate
+- Sending messages to a process is done directly from any Julia task - not just communication tasks - again, via the appropriate
   ``AsyncStream`` object
 
 Replacing the default transport involves the new implementation to setup connections to remote workers, and to provide appropriate
@@ -904,17 +904,17 @@ The default implementation (which uses TCP/IP sockets) is implemented as ``conne
 
 ``connect`` should return a pair of ``AsyncStream`` objects, one for reading data sent from worker ``pid``,
 and the other to write data that needs to be sent to worker ``pid``. Custom cluster managers can use an in-memory ``BufferStream``
-as the plumbing to proxy data between the custom, possibly non-AsyncStream transport and julia's in-built parallel infrastructure.
+as the plumbing to proxy data between the custom, possibly non-AsyncStream transport and Julia's in-built parallel infrastructure.
 
 A ``BufferStream`` is an in-memory ``IOBuffer`` which behaves like an ``AsyncStream``.
 
-Folder ``examples/clustermanager/0mq`` is an example of using ZeroMQ is connect julia workers in a star network with a 0MQ broker in the middle.
-Note: The julia processes are still all *logically* connected to each other - any worker can message any other worker directly without any
+Folder ``examples/clustermanager/0mq`` is an example of using ZeroMQ is connect Julia workers in a star network with a 0MQ broker in the middle.
+Note: The Julia processes are still all *logically* connected to each other - any worker can message any other worker directly without any
 awareness of 0MQ being used as the transport layer.
 
 When using custom transports:
 
-- julia workers must NOT be started with ``--worker``. Starting with ``--worker`` will result in the newly launched
+- Julia workers must NOT be started with ``--worker``. Starting with ``--worker`` will result in the newly launched
   workers defaulting to the TCP/IP socket transport implementation
 - For every incoming logical connection with a worker, ``Base.process_messages(rd::AsyncStream, wr::AsyncStream)`` must be called.
   This launches a new task that handles reading and writing of messages from/to the worker represented by the ``AsyncStream`` objects

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -860,7 +860,7 @@ If ``io`` is not specified, ``host`` and ``port`` are used to connect.
 For example, a cluster manager may launch a single worker per node, and use that to launch
 additional workers. ``count`` with an integer value ``n`` will launch a total of ``n`` workers,
 while a value of ``:auto`` will launch as many workers as cores on that machine.
-``exename`` is the name of the Julia executable including the full path.
+``exename`` is the name of the ``julia`` executable including the full path.
 ``exeflags`` should be set to the required command line arguments for new workers.
 
 ``tunnel``, ``bind_addr``, ``sshflags`` and ``max_parallel`` are used when a ssh tunnel is

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -751,16 +751,16 @@ This might be worthwhile when the following are true:
   ``Array{Car{:Honda,:Accord},N}``.
 
 When the latter holds, a function processing such a homogenous array
-can be productively specialized: julia knows the type of each element
+can be productively specialized: Julia knows the type of each element
 in advance (all objects in the container have the same concrete type),
-so julia can "look up" the correct method calls when the function is
+so Julia can "look up" the correct method calls when the function is
 being compiled (obviating the need to check at run-time) and thereby
 emit efficient code for processing the whole list.
 
 When these do not hold, then it's likely that you'll get no benefit;
 worse, the resulting "combinatorial explosion of types" will be
 counterproductive.  If ``items[i+1]`` has a different type than
-``item[i]``, julia has to look up the type at run-time, search for the
+``item[i]``, Julia has to look up the type at run-time, search for the
 appropriate method in method tables, decide (via type intersection)
 which one matches, determine whether it has been JIT-compiled yet (and
 do so if not), and then make the call. In essence, you're asking the
@@ -773,7 +773,7 @@ lookup, and (3) a "switch" statement can be found `on the mailing list
 <https://groups.google.com/d/msg/julia-users/jUMu9A3QKQQ/qjgVWr7vAwAJ>`_.
 
 Perhaps even worse than the run-time impact is the compile-time
-impact: julia will compile specialized functions for each different
+impact: Julia will compile specialized functions for each different
 ``Car{Make, Model}``; if you have hundreds or thousands of such types,
 then every function that accepts such an object as a parameter (from a
 custom ``get_year`` function you might write yourself, to the generic

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -593,11 +593,15 @@ quite what is needed. For these kinds of situations, Julia provides
 :ref:`non-standard string literals <man-non-standard-string-literals2>`.
 A non-standard string literal looks like
 a regular double-quoted string literal, but is immediately prefixed by
-an identifier, and doesn't behave quite like a normal string literal. Regular
+an identifier, and doesn't behave quite like a normal string literal. The
+convention is that non-standard literals with uppercase prefixes produce
+actual string objects, while those with lowercase prefixes produce
+non-string objects like byte arrays or compiled regular expressions. Regular
 expressions, byte array literals and version number literals, as described
 below, are some examples of non-standard string literals. Other examples are
 given in the :ref:`metaprogramming <man-non-standard-string-literals2>`
 section.
+
 
 Regular Expressions
 -------------------
@@ -828,11 +832,8 @@ Byte Array Literals
 
 Another useful non-standard string literal is the byte-array string
 literal: ``b"..."``. This form lets you use string notation to express
-literal byte arrays — i.e. arrays of ``UInt8`` values. The convention is
-that non-standard literals with uppercase prefixes produce actual string
-objects, while those with lowercase prefixes produce non-string objects
-like byte arrays or compiled regular expressions. The rules for byte
-array literals are the following:
+literal byte arrays — i.e. arrays of ``UInt8`` values. The rules for
+byte array literals are the following:
 
 -  ASCII characters and ASCII escapes produce a single byte.
 -  ``\x`` and octal escape sequences produce the *byte* corresponding to

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -948,7 +948,7 @@ would only run with stable ``0.2`` versions, and exclude such versions as
 
 Another non-standard version specification extension allows one to use a trailing
 ``+`` to express an upper limit on build versions, e.g.  ``VERSION >
-"v"0.2-rc1+"`` can be used to mean any version above ``0.2-rc1`` and any of its
+v"0.2-rc1+"`` can be used to mean any version above ``0.2-rc1`` and any of its
 builds: it will return ``false`` for version ``v"0.2-rc1+win64"`` and ``true``
 for ``v"0.2-rc2"``.
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -68,7 +68,7 @@ Getting Around
 
    .. Docstring generated from Julia source
 
-   Edit a file or directory optionally providing a line number to edit the file at. Returns to the julia prompt when you quit the editor.
+   Edit a file or directory optionally providing a line number to edit the file at. Returns to the ``julia`` prompt when you quit the editor.
 
 .. function:: edit(function, [types])
 
@@ -86,7 +86,7 @@ Getting Around
 
    .. Docstring generated from Julia source
 
-   Show a file using the default pager, optionally providing a starting line number. Returns to the julia prompt when you quit the pager.
+   Show a file using the default pager, optionally providing a starting line number. Returns to the ``julia`` prompt when you quit the pager.
 
 .. function:: less(function, [types])
 
@@ -891,7 +891,7 @@ System
 
    .. Docstring generated from Julia source
 
-   Get julia's process ID.
+   Get Julia's process ID.
 
 .. function:: time()
 

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -46,7 +46,7 @@
 
    In cases where ``convert`` would need to take a Julia object and turn it into a ``Ptr``\ , this function should be used to define and perform that conversion.
 
-   Be careful to ensure that a julia reference to ``x`` exists as long as the result of this function will be used. Accordingly, the argument ``x`` to this function should never be an expression, only a variable name or field reference. For example, ``x=a.b.c`` is acceptable, but ``x=[a,b,c]`` is not.
+   Be careful to ensure that a Julia reference to ``x`` exists as long as the result of this function will be used. Accordingly, the argument ``x`` to this function should never be an expression, only a variable name or field reference. For example, ``x=a.b.c`` is acceptable, but ``x=[a,b,c]`` is not.
 
    The ``unsafe`` prefix on this function indicates that using the result of this function after the ``x`` argument to this function is no longer accessible to the program may cause undefined behavior, including program corruption or segfaults, at any later time.
 
@@ -108,7 +108,7 @@
 
    .. Docstring generated from Julia source
 
-   Get the native address of an array or string element. Be careful to ensure that a julia reference to ``a`` exists as long as this pointer will be used. This function is "unsafe" like ``unsafe_convert``\ .
+   Get the native address of an array or string element. Be careful to ensure that a Julia reference to ``a`` exists as long as this pointer will be used. This function is "unsafe" like ``unsafe_convert``\ .
 
    Calling ``Ref(array[, index])`` is generally preferable to this function.
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -342,7 +342,7 @@ General I/O
 
    .. Docstring generated from Julia source
 
-   Replace ``STDOUT`` by stream for all C and julia level output to ``STDOUT``\ . Note that ``stream`` must be a TTY, a ``Pipe`` or a ``TCPSocket``\ .
+   Replace ``STDOUT`` by stream for all C and Julia level output to ``STDOUT``\ . Note that ``stream`` must be a TTY, a ``Pipe`` or a ``TCPSocket``\ .
 
 .. function:: redirect_stderr([stream])
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -161,7 +161,7 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   Add processes on remote machines via SSH. Requires julia to be installed in the same location on each node, or to be available via a shared file system.
+   Add processes on remote machines via SSH. Requires ``julia`` to be installed in the same location on each node, or to be available via a shared file system.
 
    ``machines`` is a vector of machine specifications.  Worker are started for each specification.
 
@@ -185,7 +185,7 @@ General Parallel Computing Support
 
    * ``dir``\ : specifies the working directory on the workers. Defaults to the host's current          directory (as found by ``pwd()``\ )
 
-   * ``exename``\ : name of the julia executable. Defaults to ``"$JULIA_HOME/julia"`` or              ``"$JULIA_HOME/julia-debug"`` as the case may be.
+   * ``exename``\ : name of the ``julia`` executable. Defaults to ``"$JULIA_HOME/julia"`` or              ``"$JULIA_HOME/julia-debug"`` as the case may be.
 
    * ``exeflags``\ : additional flags passed to the worker processes.
 

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -500,3 +500,4 @@
    .. Docstring generated from Julia source
 
    Create a string from the address of a NUL-terminated UTF-32 string. A copy is made; the pointer can be safely freed. If ``length`` is specified, the string does not have to be NUL-terminated.
+

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -306,7 +306,7 @@ gives a `Broken` `Result`.
 
    .. Docstring generated from Julia source
 
-   For use to indicate a test that should pass but currently intermittently fails. Does not evaluate the expression.
+   For use to indicate a test that should pass but currently intermittently fails. Does not evaluate the expression, which makes it useful for tests of not-yet-implemented functionality.
 
 Creating Custom ``AbstractTestSet`` Types
 -----------------------------------------

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -60,7 +60,7 @@ static const char opts[]  =
     " -J, --sysimage <file>     Start up with the given system image file\n"
     " --precompiled={yes|no}    Use precompiled code from system image if available\n"
     " --compilecache={yes|no}   Enable/disable incremental precompilation of modules\n"
-    " -H, --home <dir>          Set location of julia executable\n"
+    " -H, --home <dir>          Set location of `julia` executable\n"
     " --startup-file={yes|no}   Load ~/.juliarc.jl\n"
     " --handle-signals={yes|no} Enable or disable Julia's default signal handlers\n\n"
 


### PR DESCRIPTION
I've been re-reading the manual to discover any new features I may have missed over the last year. During my reading so far I've found some issues:
1. "Elementary Functions" section seemed very out of place. Mainly the problem is that it breaks up two sections that both talked about rounding
2.  The "Byte Array Literals" section contained a sentence talking about non-standard string literals conventions. I've moved it to a more appropriate area
3. Found a trivial typo in the "Version Number Literals" section
