### PR TITLE
Towards #12251 and #12153, reimplement all full(X) method defs. as convert(Array, X) and add convert(AbstractArray, X) methods for Factorizations

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -114,7 +114,6 @@ function Base.replace_in_print_matrix(A::Bidiagonal,i::Integer,j::Integer,s::Abs
 end
 
 #Converting from Bidiagonal to dense Matrix
-full{T}(M::Bidiagonal{T}) = convert(Matrix{T}, M)
 function convert{T}(::Type{Matrix{T}}, A::Bidiagonal)
     n = size(A, 1)
     B = zeros(T, n, n)
@@ -130,6 +129,8 @@ function convert{T}(::Type{Matrix{T}}, A::Bidiagonal)
     return B
 end
 convert{T}(::Type{Matrix}, A::Bidiagonal{T}) = convert(Matrix{T}, A)
+convert(::Type{Array}, A::Bidiagonal) = convert(Matrix, A)
+full(A::Bidiagonal) = convert(Array, A)
 promote_rule{T,S}(::Type{Matrix{T}}, ::Type{Bidiagonal{S}})=Matrix{promote_type(T,S)}
 
 #Converting from Bidiagonal to Tridiagonal

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -324,11 +324,20 @@ convert{T}(::Type{CholeskyPivoted{T}},C::CholeskyPivoted) =
     CholeskyPivoted(AbstractMatrix{T}(C.factors),C.uplo,C.piv,C.rank,C.tol,C.info)
 convert{T}(::Type{Factorization{T}}, C::CholeskyPivoted) = convert(CholeskyPivoted{T}, C)
 
-full{T,S}(C::Cholesky{T,S}) = C.uplo == 'U' ? C[:U]'C[:U] : C[:L]*C[:L]'
-function full(F::CholeskyPivoted)
+convert(::Type{AbstractMatrix}, C::Cholesky) = C.uplo == 'U' ? C[:U]'C[:U] : C[:L]*C[:L]'
+convert(::Type{AbstractArray}, C::Cholesky) = convert(AbstractMatrix, C)
+convert(::Type{Matrix}, C::Cholesky) = convert(Array, convert(AbstractArray, C))
+convert(::Type{Array}, C::Cholesky) = convert(Matrix, C)
+full(C::Cholesky) = convert(Array, C)
+
+function convert(::Type{AbstractMatrix}, F::CholeskyPivoted)
     ip = invperm(F[:p])
-    return (F[:L] * F[:U])[ip,ip]
+    (F[:L] * F[:U])[ip,ip]
 end
+convert(::Type{AbstractArray}, F::CholeskyPivoted) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::CholeskyPivoted) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::CholeskyPivoted) = convert(Matrix, F)
+full(F::CholeskyPivoted) = convert(Array, F)
 
 copy(C::Cholesky) = Cholesky(copy(C.factors), C.uplo)
 copy(C::CholeskyPivoted) = CholeskyPivoted(copy(C.factors), C.uplo, C.piv, C.rank, C.tol, C.info)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -23,6 +23,9 @@ convert{T}(::Type{Diagonal{T}}, D::Diagonal) = Diagonal{T}(convert(Vector{T}, D.
 convert{T}(::Type{AbstractMatrix{T}}, D::Diagonal) = convert(Diagonal{T}, D)
 convert{T}(::Type{UpperTriangular}, A::Diagonal{T}) = UpperTriangular(A)
 convert{T}(::Type{LowerTriangular}, A::Diagonal{T}) = LowerTriangular(A)
+convert(::Type{Matrix}, D::Diagonal) = diagm(D.diag)
+convert(::Type{Array}, D::Diagonal) = convert(Matrix, D)
+full(D::Diagonal) = convert(Array, D)
 
 function similar{T}(D::Diagonal, ::Type{T})
     return Diagonal{T}(similar(D.diag, T))
@@ -38,8 +41,6 @@ function size(D::Diagonal,d::Integer)
     end
     return d<=2 ? length(D.diag) : 1
 end
-
-full(D::Diagonal) = diagm(D.diag)
 
 @inline function getindex(D::Diagonal, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -182,5 +182,11 @@ end
 
 eigvecs(A::AbstractMatrix, B::AbstractMatrix) = eigvecs(eigfact(A, B))
 
+# Conversion methods
+
 ## Can we determine the source/result is Real?  This is not stored in the type Eigen
-full(F::Eigen) = F.vectors * Diagonal(F.values) / F.vectors
+convert(::Type{AbstractMatrix}, F::Eigen) = F.vectors * Diagonal(F.values) / F.vectors
+convert(::Type{AbstractArray}, F::Eigen) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::Eigen) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::Eigen) = convert(Matrix, F)
+full(F::Eigen) = convert(Array, F)

--- a/base/linalg/hessenberg.jl
+++ b/base/linalg/hessenberg.jl
@@ -53,11 +53,14 @@ function getindex(A::HessenbergQ, i::Integer, j::Integer)
 end
 
 ## reconstruct the original matrix
-full{T<:BlasFloat}(A::HessenbergQ{T}) = LAPACK.orghr!(1, size(A.factors, 1), copy(A.factors), A.τ)
-function full(F::Hessenberg)
-    fq = full(F[:Q])
-    return (fq * F[:H]) * fq'
-end
+convert{T<:BlasFloat}(::Type{Matrix}, A::HessenbergQ{T}) = LAPACK.orghr!(1, size(A.factors, 1), copy(A.factors), A.τ)
+convert(::Type{Array}, A::HessenbergQ) = convert(Matrix, A)
+full(A::HessenbergQ) = convert(Array, A)
+convert(::Type{AbstractMatrix}, F::Hessenberg) = (fq = full(F[:Q]); (fq * F[:H]) * fq')
+convert(::Type{AbstractArray}, F::Hessenberg) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::Hessenberg) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::Hessenberg) = convert(Matrix, F)
+full(F::Hessenberg) = convert(Array, F)
 
 A_mul_B!{T<:BlasFloat}(Q::HessenbergQ{T}, X::StridedVecOrMat{T}) =
     LAPACK.ormhr!('L', 'N', 1, size(Q.factors, 1), Q.factors, Q.τ, X)

--- a/base/linalg/ldlt.jl
+++ b/base/linalg/ldlt.jl
@@ -76,11 +76,16 @@ function A_ldiv_B!{T}(S::LDLt{T,SymTridiagonal{T}}, B::AbstractVecOrMat{T})
     return B
 end
 
-## reconstruct the original matrix, which is tridiagonal
-function full(F::LDLt)
+# Conversion methods
+function convert(::Type{SymTridiagonal}, F::LDLt)
     e = copy(F.data.ev)
     d = copy(F.data.dv)
     e .*= d[1:end-1]
     d[2:end] += e .* F.data.ev
     SymTridiagonal(d, e)
 end
+convert(::Type{AbstractMatrix}, F::LDLt) = convert(SymTridiagonal, F)
+convert(::Type{AbstractArray}, F::LDLt) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::LDLt) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::LDLt) = convert(Matrix, F)
+full(F::LDLt) = convert(Array, F)

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -169,13 +169,23 @@ function qr!(v::AbstractVector)
     __normalize!(v, nrm), nrm
 end
 
-
-convert{T}(::Type{QR{T}},A::QR) = QR(convert(AbstractMatrix{T}, A.factors), convert(Vector{T}, A.τ))
+# Conversions
+convert{T}(::Type{QR{T}}, A::QR) = QR(convert(AbstractMatrix{T}, A.factors), convert(Vector{T}, A.τ))
 convert{T}(::Type{Factorization{T}}, A::QR) = convert(QR{T}, A)
-convert{T}(::Type{QRCompactWY{T}},A::QRCompactWY) = QRCompactWY(convert(AbstractMatrix{T}, A.factors), convert(AbstractMatrix{T}, A.T))
+convert{T}(::Type{QRCompactWY{T}}, A::QRCompactWY) = QRCompactWY(convert(AbstractMatrix{T}, A.factors), convert(AbstractMatrix{T}, A.T))
 convert{T}(::Type{Factorization{T}}, A::QRCompactWY) = convert(QRCompactWY{T}, A)
-convert{T}(::Type{QRPivoted{T}},A::QRPivoted) = QRPivoted(convert(AbstractMatrix{T}, A.factors), convert(Vector{T}, A.τ), A.jpvt)
+convert(::Type{AbstractMatrix}, F::Union{QR,QRCompactWY}) = F[:Q] * F[:R]
+convert(::Type{AbstractArray}, F::Union{QR,QRCompactWY}) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::Union{QR,QRCompactWY}) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::Union{QR,QRCompactWY}) = convert(Matrix, F)
+full(F::Union{QR,QRCompactWY}) = convert(Array, F)
+convert{T}(::Type{QRPivoted{T}}, A::QRPivoted) = QRPivoted(convert(AbstractMatrix{T}, A.factors), convert(Vector{T}, A.τ), A.jpvt)
 convert{T}(::Type{Factorization{T}}, A::QRPivoted) = convert(QRPivoted{T}, A)
+convert(::Type{AbstractMatrix}, F::QRPivoted) = (F[:Q] * F[:R])[:,invperm(F[:p])]
+convert(::Type{AbstractArray}, F::QRPivoted) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::QRPivoted) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::QRPivoted) = convert(Matrix, F)
+full(F::QRPivoted) = convert(Array, F)
 
 function getindex(A::QR, d::Symbol)
     m, n = size(A)
@@ -218,11 +228,6 @@ function getindex{T}(A::QRPivoted{T}, d::Symbol)
     end
 end
 
-## reconstruct the original matrix
-full(F::QR) = F[:Q] * F[:R]
-full(F::QRCompactWY) = F[:Q] * F[:R]
-full(F::QRPivoted) = (F[:Q] * F[:R])[:,invperm(F[:p])]
-
 # Type-stable interface to get Q
 getq(A::QRCompactWY) = QRCompactWYQ(A.factors,A.T)
 getq(A::Union{QR, QRPivoted}) = QRPackedQ(A.factors,A.τ)
@@ -245,13 +250,21 @@ convert{T}(::Type{QRPackedQ{T}}, Q::QRPackedQ) = QRPackedQ(convert(AbstractMatri
 convert{T}(::Type{AbstractMatrix{T}}, Q::QRPackedQ) = convert(QRPackedQ{T}, Q)
 convert{S}(::Type{QRCompactWYQ{S}}, Q::QRCompactWYQ) = QRCompactWYQ(convert(AbstractMatrix{S}, Q.factors), convert(AbstractMatrix{S}, Q.T))
 convert{S}(::Type{AbstractMatrix{S}}, Q::QRCompactWYQ) = convert(QRCompactWYQ{S}, Q)
+convert{T}(::Type{Matrix}, A::Union{QRPackedQ{T},QRCompactWYQ{T}}) = A_mul_B!(A, eye(T, size(A.factors, 1), minimum(size(A.factors))))
+convert(::Type{Array}, A::Union{QRPackedQ,QRCompactWYQ}) = convert(Matrix, A)
+function full{T}(A::Union{QRPackedQ{T},QRCompactWYQ{T}}; thin::Bool = true)
+    if thin
+        convert(Array, A)
+    else
+        A_mul_B!(A, eye(T, size(A.factors, 1)))
+    end
+end
 
 size(A::Union{QR,QRCompactWY,QRPivoted}, dim::Integer) = size(A.factors, dim)
 size(A::Union{QR,QRCompactWY,QRPivoted}) = size(A.factors)
 size(A::Union{QRPackedQ,QRCompactWYQ}, dim::Integer) = 0 < dim ? (dim <= 2 ? size(A.factors, 1) : 1) : throw(BoundsError())
 size(A::Union{QRPackedQ,QRCompactWYQ}) = size(A, 1), size(A, 2)
 
-full{T}(A::Union{QRPackedQ{T},QRCompactWYQ{T}}; thin::Bool=true) = A_mul_B!(A, thin ? eye(T, size(A.factors,1), minimum(size(A.factors))) : eye(T, size(A.factors,1)))
 
 function getindex(A::Union{QRPackedQ,QRCompactWYQ}, i::Integer, j::Integer)
     x = zeros(eltype(A), size(A, 1))

--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -206,7 +206,12 @@ function schur(A::StridedMatrix, B::StridedMatrix)
     SchurF[:S], SchurF[:T], SchurF[:Q], SchurF[:Z], SchurF[:alpha], SchurF[:beta]
 end
 
-full(F::Schur) = (F.Z * F.T) * F.Z'
+# Conversion
+convert(::Type{AbstractMatrix}, F::Schur) = (F.Z * F.T) * F.Z'
+convert(::Type{AbstractArray}, F::Schur) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::Schur) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::Schur) = convert(Matrix, F)
+full(F::Schur) = convert(Array, F)
 
 copy(F::Schur) = Schur(copy(F.T), copy(F.Z), copy(F.values))
 copy(F::GeneralizedSchur) = GeneralizedSchur(copy(F.S), copy(F.T), copy(F.alpha), copy(F.beta), copy(F.Q), copy(F.Z))

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -8,7 +8,6 @@ convert{T}(::Type{SymTridiagonal}, A::Diagonal{T})=SymTridiagonal(A.diag, zeros(
 convert{T}(::Type{Tridiagonal}, A::Diagonal{T})=Tridiagonal(zeros(T, size(A.diag,1)-1), A.diag, zeros(T, size(A.diag,1)-1))
 convert(::Type{LowerTriangular}, A::Bidiagonal) = !A.isupper ? LowerTriangular(full(A)) : throw(ArgumentError("Bidiagonal matrix must have lower off diagonal to be converted to LowerTriangular"))
 convert(::Type{UpperTriangular}, A::Bidiagonal) = A.isupper ? UpperTriangular(full(A)) : throw(ArgumentError("Bidiagonal matrix must have upper off diagonal to be converted to UpperTriangular"))
-convert(::Type{Matrix}, D::Diagonal) = diagm(D.diag)
 
 function convert(::Type{UnitUpperTriangular}, A::Diagonal)
     if !all(A.diag .== one(eltype(A)))

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -236,4 +236,9 @@ function svdvals{TA,TB}(A::StridedMatrix{TA}, B::StridedMatrix{TB})
     return svdvals!(copy_oftype(A, S), copy_oftype(B, S))
 end
 
-full(F::SVD) = (F.U * Diagonal(F.S)) * F.Vt
+# Conversion
+convert(::Type{AbstractMatrix}, F::SVD) = (F.U * Diagonal(F.S)) * F.Vt
+convert(::Type{AbstractArray}, F::SVD) = convert(AbstractMatrix, F)
+convert(::Type{Matrix}, F::SVD) = convert(Array, convert(AbstractArray, F))
+convert(::Type{Array}, F::SVD) = convert(Matrix, F)
+full(F::SVD) = convert(Array, F)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -80,8 +80,11 @@ function similar{T}(A::Hermitian, ::Type{T})
     return Hermitian(B)
 end
 
-full(A::Symmetric) = copytri!(copy(A.data), A.uplo)
-full(A::Hermitian) = copytri!(copy(A.data), A.uplo, true)
+# Conversion
+convert(::Type{Matrix}, A::Symmetric) = copytri!(convert(Matrix, copy(A.data)), A.uplo)
+convert(::Type{Matrix}, A::Hermitian) = copytri!(convert(Matrix, copy(A.data)), A.uplo, true)
+convert(::Type{Array}, A::Union{Symmetric,Hermitian}) = convert(Matrix, A)
+full(A::Union{Symmetric,Hermitian}) = convert(Array, A)
 parent(A::HermOrSym) = A.data
 convert{T,S<:AbstractMatrix}(::Type{Symmetric{T,S}},A::Symmetric{T,S}) = A
 convert{T,S<:AbstractMatrix}(::Type{Symmetric{T,S}},A::Symmetric) = Symmetric{T,S}(convert(S,A.data),A.uplo)
@@ -89,6 +92,7 @@ convert{T}(::Type{AbstractMatrix{T}}, A::Symmetric) = Symmetric(convert(Abstract
 convert{T,S<:AbstractMatrix}(::Type{Hermitian{T,S}},A::Hermitian{T,S}) = A
 convert{T,S<:AbstractMatrix}(::Type{Hermitian{T,S}},A::Hermitian) = Hermitian{T,S}(convert(S,A.data),A.uplo)
 convert{T}(::Type{AbstractMatrix{T}}, A::Hermitian) = Hermitian(convert(AbstractMatrix{T}, A.data), Symbol(A.uplo))
+
 copy{T,S}(A::Symmetric{T,S}) = (B = copy(A.data); Symmetric{T,typeof(B)}(B,A.uplo))
 copy{T,S}(A::Hermitian{T,S}) = (B = copy(A.data); Hermitian{T,typeof(B)}(B,A.uplo))
 ishermitian(A::Hermitian) = true

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -48,7 +48,8 @@ imag(A::LowerTriangular) = LowerTriangular(imag(A.data))
 imag(A::UnitLowerTriangular) = LowerTriangular(tril!(imag(A.data),-1))
 imag(A::UnitUpperTriangular) = UpperTriangular(triu!(imag(A.data),1))
 
-full(A::AbstractTriangular) = convert(Matrix, A)
+convert(::Type{Array}, A::AbstractTriangular) = convert(Matrix, A)
+full(A::AbstractTriangular) = convert(Array, A)
 parent(A::AbstractTriangular) = A.data
 
 # then handle all methods that requires specific handling of upper/lower and unit diagonal

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -36,7 +36,6 @@ function SymTridiagonal(A::AbstractMatrix)
     end
 end
 
-full{T}(M::SymTridiagonal{T}) = convert(Matrix{T}, M)
 convert{T}(::Type{SymTridiagonal{T}}, S::SymTridiagonal) =
     SymTridiagonal(convert(Vector{T}, S.dv), convert(Vector{T}, S.ev))
 convert{T}(::Type{AbstractMatrix{T}}, S::SymTridiagonal) =
@@ -55,6 +54,8 @@ function convert{T}(::Type{Matrix{T}}, M::SymTridiagonal{T})
     return Mf
 end
 convert{T}(::Type{Matrix}, M::SymTridiagonal{T}) = convert(Matrix{T}, M)
+convert(::Type{Array}, M::SymTridiagonal) = convert(Matrix, M)
+full(M::SymTridiagonal) = convert(Array, M)
 
 size(A::SymTridiagonal) = (length(A.dv), length(A.dv))
 function size(A::SymTridiagonal, d::Integer)
@@ -365,7 +366,6 @@ function size(M::Tridiagonal, d::Integer)
     end
 end
 
-full{T}(M::Tridiagonal{T}) = convert(Matrix{T}, M)
 function convert{T}(::Type{Matrix{T}}, M::Tridiagonal{T})
     A = zeros(T, size(M))
     for i = 1:length(M.d)
@@ -378,6 +378,8 @@ function convert{T}(::Type{Matrix{T}}, M::Tridiagonal{T})
     A
 end
 convert{T}(::Type{Matrix}, M::Tridiagonal{T}) = convert(Matrix{T}, M)
+convert(::Type{Array}, M::Tridiagonal) = convert(Matrix, M)
+full(M::Tridiagonal) = convert(Array, M)
 function similar{T}(M::Tridiagonal, ::Type{T})
     Tridiagonal{T}(similar(M.dl, T), similar(M.d, T), similar(M.du, T), similar(M.du2, T))
 end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -276,8 +276,22 @@ function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, M::AbstractMatrix)
                              m, n)
 end
 convert{T}(::Type{AbstractMatrix{T}}, A::SparseMatrixCSC) = convert(SparseMatrixCSC{T}, A)
-convert(::Type{Matrix}, S::SparseMatrixCSC) = full(S)
 convert(::Type{SparseMatrixCSC}, M::Matrix) = sparse(M)
+
+function convert{Tv}(::Type{Matrix}, S::SparseMatrixCSC{Tv})
+    # Handle cases where zero(Tv) is not defined but the array is dense.
+    A = length(S) == nnz(S) ? Array{Tv}(S.m, S.n) : zeros(Tv, S.m, S.n)
+    for Sj in 1:S.n
+        for Sk in nzrange(S, Sj)
+            Si = S.rowval[Sk]
+            Sv = S.nzval[Sk]
+            A[Si, Sj] = Sv
+        end
+    end
+    return A
+end
+convert(::Type{Array}, S::SparseMatrixCSC) = convert(Matrix, S)
+full(S::SparseMatrixCSC) = convert(Array, S)
 
 """
     full(S)
@@ -285,16 +299,6 @@ convert(::Type{SparseMatrixCSC}, M::Matrix) = sparse(M)
 Convert a sparse matrix or vector `S` into a dense matrix or vector.
 """
 full
-
-function full{Tv}(S::SparseMatrixCSC{Tv})
-    # Handle cases where zero(Tv) is not defined but the array is dense.
-    # (Should we really worry about this?)
-    A = length(S) == nnz(S) ? Array{Tv}(S.m, S.n) : zeros(Tv, S.m, S.n)
-    for col = 1 : S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
-        A[S.rowval[k], col] = S.nzval[k]
-    end
-    return A
-end
 
 float(S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), float(copy(S.nzval)))
 

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -662,20 +662,23 @@ convert{TvD,Tv,Ti}(::Type{SparseMatrixCSC{TvD}}, x::AbstractSparseVector{Tv,Ti})
 convert{Tv,Ti}(::Type{SparseMatrixCSC}, x::AbstractSparseVector{Tv,Ti}) =
     convert(SparseMatrixCSC{Tv,Ti}, x)
 
-
-### Array manipulation
-
-function full{Tv}(x::AbstractSparseVector{Tv})
+function convert{Tv}(::Type{Vector}, x::AbstractSparseVector{Tv})
     n = length(x)
-    n == 0 && return Array{Tv}(0)
+    n == 0 && return Vector{Tv}(0)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
     r = zeros(Tv, n)
-    for i = 1:length(nzind)
-        r[nzind[i]] = nzval[i]
+    for k in 1:nnz(x)
+        i = nzind[k]
+        v = nzval[k]
+        r[i] = v
     end
     return r
 end
+convert(::Type{Array}, x::AbstractSparseVector) = convert(Vector, x)
+full(x::AbstractSparseVector) = convert(Array, x)
+
+### Array manipulation
 
 vec(x::AbstractSparseVector) = x
 copy(x::AbstractSparseVector) =


### PR DESCRIPTION
First step towards JuliaLang/LinearAlgebra.jl#231 (edit: and now JuliaLang/LinearAlgebra.jl#229 as well) (edit: explanation and plan now described in https://github.com/JuliaLang/julia/pull/17066#issuecomment-228113687). This pull request reduces every `full(X)` method definition to `convert(Array, X)` (apart from the `AbstractArray` no-op fallback and the `approx_full` methods in `test.jl`):

```
~/pkg/julia$ grep -rn -e 'function full[{(]' -e 'full\({.*}\)\?(.*).* =' base/
base//abstractarray.jl:663:full(x::AbstractArray) = x
base//linalg/bidiag.jl:107:full(A::Bidiagonal) = convert(Array, A)
base//linalg/cholesky.jl:329:full(C::Cholesky) = convert(Array, C)
base//linalg/cholesky.jl:333:full(F::CholeskyPivoted) = convert(Array, F)
base//linalg/diagonal.jl:28:full(D::Diagonal) = convert(Array, D)
base//linalg/eigen.jl:190:full(F::Eigen) = convert(Array, F)
base//linalg/hessenberg.jl:58:full(A::HessenbergQ) = convert(Array, A)
base//linalg/hessenberg.jl:61:full(F::Hessenberg) = convert(Array, F)
base//linalg/ldlt.jl:91:full(F::LDLt) = convert(Array, F)
base//linalg/lq.jl:93:full(A::LQ) = convert(Array, A)
base//linalg/lq.jl:109:full(A::LQPackedQ; thin::Bool = true) = convert(Array, A, thin = thin)
base//linalg/lu.jl:438:full(F::LU) = convert(Array, F)
base//linalg/lu.jl:478:full{T}(F::Base.LinAlg.LU{T,Tridiagonal{T}}) = convert(Array, F)
base//linalg/qr.jl:179:full(F::Union{QR,QRCompactWY}) = convert(Array, F)
base//linalg/qr.jl:184:full(F::QRPivoted) = convert(Array, F)
base//linalg/qr.jl:252:full(A::Union{QRPackedQ,QRCompactWYQ}; thin::Bool = true) = convert(Array, A, thin = thin)
base//linalg/schur.jl:212:full(F::Schur) = convert(Array, F)
base//linalg/svd.jl:242:full(F::SVD) = convert(Array, F)
base//linalg/symmetric.jl:87:full(A::Union{Symmetric,Hermitian}) = convert(Array, A)
base//linalg/triangular.jl:52:full(A::AbstractTriangular) = convert(Array, A)
base//linalg/tridiag.jl:58:full(M::SymTridiagonal) = convert(Array, M)
base//linalg/tridiag.jl:382:full(M::Tridiagonal) = convert(Array, M)
base//sparse/sparsematrix.jl:293:full(S::SparseMatrixCSC) = convert(Array, S)
base//sparse/sparsevector.jl:679:full(x::AbstractSparseVector) = convert(Array, x)
base//test.jl:821:approx_full(x::AbstractArray) = x
base//test.jl:822:approx_full(x::Number) = x
base//test.jl:823:approx_full(x) = full(x)
```

This change should enable drop-in replacement of `full(X)` calls with `convert(Array, X)` throughout `base/`, the next step towards JuliaLang/LinearAlgebra.jl#231. Some notes:

For non-`Factorization` types, each `full(X)` method is now part of a block like

``` julia
convert(::Type{Matrix}, A::SparseMatrixCSC) = ...
convert(::Type{Array}, A::SparseMatrixCSC) = convert(Matrix, A)
full(A::SparseMatrixCSC) = convert(Array, A)
```

or

``` julia
convert(::Type{Vector}, x::AbstractSparseVector) = ...
convert(::Type{Array}, x::AbstractSparseVector) = convert(Vector, x)
full(x::AbstractSparseVector) = convert(Array, x)
```

such that generic methods may call `convert(Array, foo)` for arbitrary presently-`full`-able `foo`, and hence don't need to know whether `foo` naturally converts to a `Matrix`, `Vector`, etc. In some cases parametric `convert{T}(::Type{Matrix{T}}, X)` methods already existed; this pull request preserves those methods and implements the `convert(::Type{Matrix}, X)` and `convert(::Type{Array}, X)` methods as children thereof. But it does not introduce such parametric definitions where they did not previously exist.

Edit: For `Factorization` types, as a simultaneous attack on JuliaLang/LinearAlgebra.jl#229, each `full(X)` method is now part of a block like

``` julia
convert(::Type{AbstractMatrix}, F::Cholesky) = ...
convert(::Type{AbstractArray}, F::Cholesky) = convert(AbstractMatrix, F)
convert(::Type{Matrix}, F::Cholesky) = convert(Array, convert(AbstractArray, F))
convert(::Type{Array}, F::Cholesky) = convert(Matrix, F)
full(F::Cholesky) = convert(Array, F)
```

where `convert(::Type{AbstractMatrix}, F::Cholesky)` recovers the original matrix, not necessarily as an `Array`.

For `Symmetric`/`Hermitian` types, the former `full` semantics also differed from the norm:

``` julia
full(A::Symmetric) = copytri!(copy(A.data), A.uplo)
```

which does not necessarily return an `Array`. This pull request effectively changes the behavior to

``` julia
full(A::Symmetric) = copytri!(convert(Array, copy(A.data)), A.uplo)
```

This change leaves a void where the (potentially useful) former behavior lived. Perhaps this behavior needs a separate name, and perhaps unification with the conceptually similar `full!` methods for `XTriangular` types, all of which return a copy of the underlying data modified such that it matches (in the `AbstractArray` comparison sense) the `Symmetric`/`Hermitian`/`XTriangular`-wrapped object. Thoughts?

Best!
