### PR TITLE
Cleanup of tryparse_internal methods

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -328,7 +328,7 @@ function dlm_fill(T::DataType, offarr::Vector{Vector{Int}}, dims::NTuple{2,Integ
 end
 
 function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{Bool,2}, row::Int, col::Int)
-    n = tryparse_internal(Bool, sbuff, startpos, endpos, false)
+    n = tryparse_internal(Bool, sbuff, startpos, endpos, 0, false)
     isnull(n) || (cells[row, col] = get(n))
     isnull(n)
 end
@@ -360,7 +360,7 @@ function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{Any,2}, 
         isnull(ni64) || (cells[row, col] = get(ni64); return false)
 
         # check Bool
-        nb = tryparse_internal(Bool, sbuff, startpos, endpos, false)
+        nb = tryparse_internal(Bool, sbuff, startpos, endpos, 0, false)
         isnull(nb) || (cells[row, col] = get(nb); return false)
 
         # check float64

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -83,6 +83,10 @@ function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, end
     bstr = startpos == start(s) && endpos == endof(s) ? String(s) : String(SubString(s,startpos,endpos))
 
     sgn, base, i = Base.parseint_preamble(true,base,bstr,start(bstr),endof(bstr))
+    if !(2 <= base <= 62)
+        raise && throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
+        return _n
+    end
     if i == 0
         raise && throw(ArgumentError("premature end of integer: $(repr(bstr))"))
         return _n

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -62,7 +62,10 @@ safe_mul{T<:Integer}(n1::T, n2::T) = ((n2 >   0) ? ((n1 > div(typemax(T),n2)) ||
 function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base::Integer, raise::Bool)
     _n = Nullable{T}()
     sgn, base, i = parseint_preamble(T<:Signed, base, s, startpos, endpos)
-    (2 <= base <= 62) || throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
+    if !(2 <= base <= 62)
+        raise && throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
+        return _n
+    end
     if i == 0
         raise && throw(ArgumentError("premature end of integer: $(repr(SubString(s,startpos,endpos)))"))
         return _n

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -54,23 +54,15 @@ function parseint_preamble(signed::Bool, base::Int, s::AbstractString, startpos:
     return sgn, base, j
 end
 
-function tryparse_internal(::Type{Bool}, sbuff::String, startpos::Int, endpos::Int, raise::Bool)
-    len = endpos-startpos+1
-    p = pointer(sbuff)+startpos-1
-    (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), p, "true", 4)) && (return Nullable(true))
-    (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), p, "false", 5)) && (return Nullable(false))
-    raise && throw(ArgumentError("invalid Bool representation: $(repr(SubString(s,startpos,endpos)))"))
-    Nullable{Bool}()
-end
-
 safe_add{T<:Integer}(n1::T, n2::T) = ((n2 > 0) ? (n1 > (typemax(T) - n2)) : (n1 < (typemin(T) - n2))) ? Nullable{T}() : Nullable{T}(n1 + n2)
 safe_mul{T<:Integer}(n1::T, n2::T) = ((n2 >   0) ? ((n1 > div(typemax(T),n2)) || (n1 < div(typemin(T),n2))) :
                                       (n2 <  -1) ? ((n1 > div(typemin(T),n2)) || (n1 < div(typemax(T),n2))) :
                                       ((n2 == -1) && n1 == typemin(T))) ? Nullable{T}() : Nullable{T}(n1 * n2)
 
-function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base::Int, a::Int, raise::Bool)
+function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base::Integer, raise::Bool)
     _n = Nullable{T}()
     sgn, base, i = parseint_preamble(T<:Signed, base, s, startpos, endpos)
+    (2 <= base <= 62) || throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
     if i == 0
         raise && throw(ArgumentError("premature end of integer: $(repr(SubString(s,startpos,endpos)))"))
         return _n
@@ -84,6 +76,7 @@ function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::I
     base = convert(T,base)
     m::T = div(typemax(T)-base+1,base)
     n::T = 0
+    a::Int = base <= 36 ? 10 : 36
     while n <= m
         d::T = '0' <= c <= '9' ? c-'0'    :
                'A' <= c <= 'Z' ? c-'A'+10 :
@@ -131,19 +124,23 @@ function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::I
     end
     return Nullable{T}(n)
 end
-tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, base::Int, raise::Bool) =
-    tryparse_internal(T,s,start(s),endof(s),base,raise)
-tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base::Int, raise::Bool) =
-    tryparse_internal(T, s, startpos, endpos, base, base <= 36 ? 10 : 36, raise)
-tryparse{T<:Integer}(::Type{T}, s::AbstractString, base::Int) =
-    2 <= base <= 62 ? tryparse_internal(T,s,Int(base),false) : throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
-tryparse{T<:Integer}(::Type{T}, s::AbstractString) = tryparse_internal(T,s,0,false)
 
-function parse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer)
-    (2 <= base <= 62) || throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
-    get(tryparse_internal(T, s, base, true))
+function tryparse_internal(::Type{Bool}, sbuff::AbstractString, startpos::Int, endpos::Int, base::Integer, raise::Bool)
+    len = endpos-startpos+1
+    p = pointer(sbuff)+startpos-1
+    (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), p, "true", 4)) && (return Nullable(true))
+    (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), p, "false", 5)) && (return Nullable(false))
+    raise && throw(ArgumentError("invalid Bool representation: $(repr(SubString(s,startpos,endpos)))"))
+    Nullable{Bool}()
 end
-parse{T<:Integer}(::Type{T}, s::AbstractString) = get(tryparse_internal(T, s, 0, true))
+
+function tryparse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer=0)
+    return tryparse_internal(T, s, start(s), endof(s), base, false)
+end
+
+function parse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer=0)
+    return get(tryparse_internal(T, s, start(s), endof(s), base, true))
+end
 
 ## string to float functions ##
 

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -893,7 +893,7 @@ end
 
 deserialize(s::AbstractSerializer, ::Type{BigFloat}) = parse(BigFloat, deserialize(s))
 
-deserialize(s::AbstractSerializer, ::Type{BigInt}) = get(GMP.tryparse_internal(BigInt, deserialize(s), 62, true))
+deserialize(s::AbstractSerializer, ::Type{BigInt}) = parse(BigInt, deserialize(s), 62)
 
 function deserialize(s::AbstractSerializer, t::Type{Regex})
     pattern = deserialize(s)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -528,3 +528,12 @@ let err = try
     end
     @test err.line == 7
 end
+
+# issue #17065
+@test parse(Int, "2") === 2
+@test parse(Bool, "true") === true
+@test parse(Bool, "false") === false
+@test get(tryparse(Bool, "true")) === get(Nullable{Bool}(true))
+@test get(tryparse(Bool, "false")) === get(Nullable{Bool}(false))
+@test_throws ArgumentError parse(Int, "2", 1)
+@test_throws ArgumentError parse(Int, "2", 63)


### PR DESCRIPTION
which were probably written before we had default positional arguments. As they were, they weren't allowing Bool parsing to pass through to the right tryparse_internal(Bool, ...) method. Fixes #17065
