### PR TITLE
Towards #12251 part 2, replace all full(X) calls with convert(Array, X) and migrate tests

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -896,7 +896,7 @@ function typed_vcat{T}(::Type{T}, V::AbstractVector...)
     for Vk in V
         n += length(Vk)
     end
-    a = similar(full(V[1]), T, n)
+    a = similar(convert(Array, V[1]), T, n)
     pos = 1
     for k=1:length(V)
         Vk = V[k]
@@ -924,7 +924,7 @@ function typed_hcat{T}(::Type{T}, A::AbstractVecOrMat...)
         nd = ndims(Aj)
         ncols += (nd==2 ? size(Aj,2) : 1)
     end
-    B = similar(full(A[1]), T, nrows, ncols)
+    B = similar(convert(Array, A[1]), T, nrows, ncols)
     pos = 1
     if dense
         for k=1:nargs
@@ -956,7 +956,7 @@ function typed_vcat{T}(::Type{T}, A::AbstractMatrix...)
             throw(ArgumentError("number of columns of each array must match (got $(map(x->size(x,2), A)))"))
         end
     end
-    B = similar(full(A[1]), T, nrows, ncols)
+    B = similar(convert(Array, A[1]), T, nrows, ncols)
     pos = 1
     for k=1:nargs
         Ak = A[k]
@@ -1003,7 +1003,7 @@ function cat_t(catdims, typeC::Type, X...)
         end
     end
 
-    C = similar(isa(X[1],AbstractArray) ? full(X[1]) : [X[1]], typeC, tuple(dimsC...))
+    C = similar(isa(X[1],AbstractArray) ? convert(Array, X[1]) : [X[1]], typeC, tuple(dimsC...))
     if length(catdims)>1
         fill!(C,0)
     end
@@ -1075,7 +1075,7 @@ function typed_hvcat{T}(::Type{T}, rows::Tuple{Vararg{Int}}, as::AbstractMatrix.
         a += rows[i]
     end
 
-    out = similar(full(as[1]), T, nr, nc)
+    out = similar(convert(Array, as[1]), T, nr, nc)
 
     a = 1
     r = 1

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -18,7 +18,7 @@ end
 Constructs an upper (`isupper=true`) or lower (`isupper=false`) bidiagonal matrix using the
 given diagonal (`dv`) and off-diagonal (`ev`) vectors.  The result is of type `Bidiagonal`
 and provides efficient specialized linear solvers, but may be converted into a regular
-matrix with [`full`](:func:`full`). `ev`'s length must be one less than the length of `dv`.
+matrix with [`convert(Array, _)`](:func:`convert`). `ev`'s length must be one less than the length of `dv`.
 
 **Example**
 
@@ -38,7 +38,7 @@ Bidiagonal(dv::AbstractVector, ev::AbstractVector) = throw(ArgumentError("did yo
 Constructs an upper (`uplo='U'`) or lower (`uplo='L'`) bidiagonal matrix using the
 given diagonal (`dv`) and off-diagonal (`ev`) vectors.  The result is of type `Bidiagonal`
 and provides efficient specialized linear solvers, but may be converted into a regular
-matrix with [`full`](:func:`full`). `ev`'s length must be one less than the length of `dv`.
+matrix with [`convert(Array, _)`](:func:`convert`). `ev`'s length must be one less than the length of `dv`.
 
 **Example**
 
@@ -302,7 +302,7 @@ end
 function A_mul_B_td!(C::AbstractMatrix, A::BiTriSym, B::BiTriSym)
     check_A_mul_B!_sizes(C, A, B)
     n = size(A,1)
-    n <= 3 && return A_mul_B!(C, full(A), full(B))
+    n <= 3 && return A_mul_B!(C, convert(Array, A), convert(Array, B))
     fill!(C, zero(eltype(C)))
     Al = diag(A, -1)
     Ad = diag(A, 0)
@@ -361,7 +361,7 @@ function A_mul_B_td!(C::AbstractVecOrMat, A::BiTriSym, B::AbstractVecOrMat)
     if size(C,2) != nB
         throw(DimensionMismatch("A has second dimension $nA, B has $(size(B,2)), C has $(size(C,2)) but all must match"))
     end
-    nA <= 3 && return A_mul_B!(C, full(A), full(B))
+    nA <= 3 && return A_mul_B!(C, convert(Array, A), convert(Array, B))
     l = diag(A, -1)
     d = diag(A, 0)
     u = diag(A, 1)
@@ -382,7 +382,7 @@ end
 function A_mul_B_td!(C::AbstractMatrix, A::AbstractMatrix, B::BiTriSym)
     check_A_mul_B!_sizes(C, A, B)
     n = size(A,1)
-    n <= 3 && return A_mul_B!(C, full(A), full(B))
+    n <= 3 && return A_mul_B!(C, convert(Array, A), convert(Array, B))
     m = size(B,2)
     Bl = diag(B, -1)
     Bd = diag(B, 0)
@@ -412,12 +412,12 @@ end
 
 SpecialMatrix = Union{Bidiagonal, SymTridiagonal, Tridiagonal}
 # to avoid ambiguity warning, but shouldn't be necessary
-*(A::AbstractTriangular, B::SpecialMatrix) = full(A) * full(B)
-*(A::SpecialMatrix, B::SpecialMatrix) = full(A) * full(B)
+*(A::AbstractTriangular, B::SpecialMatrix) = convert(Array, A) * convert(Array, B)
+*(A::SpecialMatrix, B::SpecialMatrix) = convert(Array, A) * convert(Array, B)
 
 #Generic multiplication
 for func in (:*, :Ac_mul_B, :A_mul_Bc, :/, :A_rdiv_Bc)
-    @eval ($func){T}(A::Bidiagonal{T}, B::AbstractVector{T}) = ($func)(full(A), B)
+    @eval ($func){T}(A::Bidiagonal{T}, B::AbstractVector{T}) = ($func)(convert(Array, A), B)
 end
 
 #Linear solvers

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -173,7 +173,7 @@ expm(x::Number) = exp(x)
 function expm!{T<:BlasFloat}(A::StridedMatrix{T})
     n = checksquare(A)
     if ishermitian(A)
-        return full(expm(Hermitian(A)))
+        return convert(Array, expm(Hermitian(A)))
     end
     ilo, ihi, scale = LAPACK.gebal!('B', A)    # modifies A
     nA   = norm(A, 1)
@@ -285,13 +285,13 @@ triangular factor.
 function logm(A::StridedMatrix)
     # If possible, use diagonalization
     if ishermitian(A)
-        return full(logm(Hermitian(A)))
+        return convert(Array, logm(Hermitian(A)))
     end
 
     # Use Schur decomposition
     n = checksquare(A)
     if istriu(A)
-        retmat = full(logm(UpperTriangular(complex(A))))
+        retmat = convert(Array, logm(UpperTriangular(complex(A))))
         d = diag(A)
     else
         S,Q,d = schur(complex(A))
@@ -322,27 +322,27 @@ logm(a::Complex) = log(a)
 
 function sqrtm{T<:Real}(A::StridedMatrix{T})
     if issymmetric(A)
-        return full(sqrtm(Symmetric(A)))
+        return convert(Array, sqrtm(Symmetric(A)))
     end
     n = checksquare(A)
     if istriu(A)
-        return full(sqrtm(UpperTriangular(A)))
+        return convert(Array, sqrtm(UpperTriangular(A)))
     else
         SchurF = schurfact(complex(A))
-        R = full(sqrtm(UpperTriangular(SchurF[:T])))
+        R = convert(Array, sqrtm(UpperTriangular(SchurF[:T])))
         return SchurF[:vectors] * R * SchurF[:vectors]'
     end
 end
 function sqrtm{T<:Complex}(A::StridedMatrix{T})
     if ishermitian(A)
-        return full(sqrtm(Hermitian(A)))
+        return convert(Array, sqrtm(Hermitian(A)))
     end
     n = checksquare(A)
     if istriu(A)
-        return full(sqrtm(UpperTriangular(A)))
+        return convert(Array, sqrtm(UpperTriangular(A)))
     else
         SchurF = schurfact(A)
-        R = full(sqrtm(UpperTriangular(SchurF[:T])))
+        R = convert(Array, sqrtm(UpperTriangular(SchurF[:T])))
         return SchurF[:vectors] * R * SchurF[:vectors]'
     end
 end

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -310,7 +310,7 @@ svdvals(D::Diagonal) = [svdvals(v) for v in D.diag]
 function svd{T<:Number}(D::Diagonal{T})
     S   = abs(D.diag)
     piv = sortperm(S, rev = true)
-    U   = full(Diagonal(D.diag ./ S))
+    U   = convert(Array, Diagonal(D.diag ./ S))
     Up  = hcat([U[:,i] for i = 1:length(D.diag)][piv]...)
     V   = eye(D)
     Vp  = hcat([V[:,i] for i = 1:length(D.diag)][piv]...)

--- a/base/linalg/hessenberg.jl
+++ b/base/linalg/hessenberg.jl
@@ -23,7 +23,7 @@ end
 Compute the Hessenberg decomposition of `A` and return a `Hessenberg` object. If `F` is the
 factorization object, the unitary matrix can be accessed with `F[:Q]` and the Hessenberg
 matrix with `F[:H]`. When `Q` is extracted, the resulting type is the `HessenbergQ` object,
-and may be converted to a regular matrix with [`full`](:func:`full`).
+and may be converted to a regular matrix with [`convert(Array, _)`](:func:`convert`).
 """
 hessfact
 
@@ -56,7 +56,7 @@ end
 convert{T<:BlasFloat}(::Type{Matrix}, A::HessenbergQ{T}) = LAPACK.orghr!(1, size(A.factors, 1), copy(A.factors), A.τ)
 convert(::Type{Array}, A::HessenbergQ) = convert(Matrix, A)
 full(A::HessenbergQ) = convert(Array, A)
-convert(::Type{AbstractMatrix}, F::Hessenberg) = (fq = full(F[:Q]); (fq * F[:H]) * fq')
+convert(::Type{AbstractMatrix}, F::Hessenberg) = (fq = convert(Array, F[:Q]); (fq * F[:H]) * fq')
 convert(::Type{AbstractArray}, F::Hessenberg) = convert(AbstractMatrix, F)
 convert(::Type{Matrix}, F::Hessenberg) = convert(Array, convert(AbstractArray, F))
 convert(::Type{Array}, F::Hessenberg) = convert(Matrix, F)

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -308,7 +308,7 @@ factorize(A::Tridiagonal) = lufact(A)
 function getindex{T}(F::Base.LinAlg.LU{T,Tridiagonal{T}}, d::Symbol)
     m, n = size(F)
     if d == :L
-        L = full(Bidiagonal(ones(T, n), F.factors.dl, false))
+        L = convert(Array, Bidiagonal(ones(T, n), F.factors.dl, false))
         for i = 2:n
             tmp = L[F.ipiv[i], 1:i - 1]
             L[F.ipiv[i], 1:i - 1] = L[i, 1:i - 1]
@@ -316,7 +316,7 @@ function getindex{T}(F::Base.LinAlg.LU{T,Tridiagonal{T}}, d::Symbol)
         end
         return L
     elseif d == :U
-        U = full(Bidiagonal(F.factors.d, F.factors.du, true))
+        U = convert(Array, Bidiagonal(F.factors.d, F.factors.du, true))
         for i = 1:n - 2
             U[i,i + 2] = F.factors.du2[i]
         end

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -174,12 +174,13 @@ qr(A::Union{Number, AbstractMatrix}, pivot::Union{Type{Val{false}}, Type{Val{tru
     _qr(A, pivot, thin=thin)
 function _qr(A::Union{Number, AbstractMatrix}, ::Type{Val{false}}; thin::Bool=true)
     F = qrfact(A, Val{false})
-    full(getq(F), thin=thin), F[:R]::Matrix{eltype(F)}
+    (thin ? convert(Array, getq(F)) : thickQ(getq(F))), F[:R]::Matrix{eltype(F)}
 end
 function _qr(A::Union{Number, AbstractMatrix}, ::Type{Val{true}}; thin::Bool=true)
     F = qrfact(A, Val{true})
-    full(getq(F), thin=thin), F[:R]::Matrix{eltype(F)}, F[:p]::Vector{BlasInt}
+    (thin ? convert(Array, getq(F)) : thickQ(getq(F))), F[:R]::Matrix{eltype(F)}, F[:p]::Vector{BlasInt}
 end
+
 
 """
     qr(v::AbstractVector)
@@ -324,6 +325,8 @@ function full{T}(A::Union{QRPackedQ{T},QRCompactWYQ{T}}; thin::Bool = true)
         A_mul_B!(A, eye(T, size(A.factors, 1)))
     end
 end
+
+thickQ{T}(Q::Union{QRPackedQ{T},QRCompactWYQ{T}}) = A_mul_B!(Q, eye(T, size(Q.factors, 1)))
 
 size(A::Union{QR,QRCompactWY,QRPivoted}, dim::Integer) = size(A.factors, dim)
 size(A::Union{QR,QRCompactWY,QRPivoted}) = size(A.factors)

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -6,21 +6,21 @@
 convert{T}(::Type{Bidiagonal}, A::Diagonal{T})=Bidiagonal(A.diag, zeros(T, size(A.diag,1)-1), true)
 convert{T}(::Type{SymTridiagonal}, A::Diagonal{T})=SymTridiagonal(A.diag, zeros(T, size(A.diag,1)-1))
 convert{T}(::Type{Tridiagonal}, A::Diagonal{T})=Tridiagonal(zeros(T, size(A.diag,1)-1), A.diag, zeros(T, size(A.diag,1)-1))
-convert(::Type{LowerTriangular}, A::Bidiagonal) = !A.isupper ? LowerTriangular(full(A)) : throw(ArgumentError("Bidiagonal matrix must have lower off diagonal to be converted to LowerTriangular"))
-convert(::Type{UpperTriangular}, A::Bidiagonal) = A.isupper ? UpperTriangular(full(A)) : throw(ArgumentError("Bidiagonal matrix must have upper off diagonal to be converted to UpperTriangular"))
+convert(::Type{LowerTriangular}, A::Bidiagonal) = !A.isupper ? LowerTriangular(convert(Array, A)) : throw(ArgumentError("Bidiagonal matrix must have lower off diagonal to be converted to LowerTriangular"))
+convert(::Type{UpperTriangular}, A::Bidiagonal) = A.isupper ? UpperTriangular(convert(Array, A)) : throw(ArgumentError("Bidiagonal matrix must have upper off diagonal to be converted to UpperTriangular"))
 
 function convert(::Type{UnitUpperTriangular}, A::Diagonal)
     if !all(A.diag .== one(eltype(A)))
         throw(ArgumentError("matrix cannot be represented as UnitUpperTriangular"))
     end
-    UnitUpperTriangular(full(A))
+    UnitUpperTriangular(convert(Array, A))
 end
 
 function convert(::Type{UnitLowerTriangular}, A::Diagonal)
     if !all(A.diag .== one(eltype(A)))
         throw(ArgumentError("matrix cannot be represented as UnitLowerTriangular"))
     end
-    UnitLowerTriangular(full(A))
+    UnitLowerTriangular(convert(Array, A))
 end
 
 function convert(::Type{Diagonal}, A::Union{Bidiagonal, SymTridiagonal})
@@ -72,14 +72,14 @@ function convert(::Type{Tridiagonal}, A::SymTridiagonal)
 end
 
 function convert(::Type{Diagonal}, A::AbstractTriangular)
-    if full(A) != diagm(diag(A))
+    if convert(Array, A) != diagm(diag(A))
         throw(ArgumentError("matrix cannot be represented as Diagonal"))
     end
     Diagonal(diag(A))
 end
 
 function convert(::Type{Bidiagonal}, A::AbstractTriangular)
-    fA = full(A)
+    fA = convert(Array, A)
     if fA == diagm(diag(A)) + diagm(diag(fA, 1), 1)
         return Bidiagonal(diag(A), diag(fA,1), true)
     elseif fA == diagm(diag(A)) + diagm(diag(fA, -1), -1)
@@ -92,7 +92,7 @@ end
 convert(::Type{SymTridiagonal}, A::AbstractTriangular) = convert(SymTridiagonal, convert(Tridiagonal, A))
 
 function convert(::Type{Tridiagonal}, A::AbstractTriangular)
-    fA = full(A)
+    fA = convert(Array, A)
     if fA == diagm(diag(A)) + diagm(diag(fA, 1), 1) + diagm(diag(fA, -1), -1)
         return Tridiagonal(diag(fA, -1), diag(A), diag(fA,1))
     else
@@ -154,12 +154,12 @@ for op in (:+, :-)
     end
     for matrixtype in (:SymTridiagonal,:Tridiagonal,:Bidiagonal,:Matrix)
         @eval begin
-            ($op)(A::AbstractTriangular, B::($matrixtype)) = ($op)(full(A), B)
-            ($op)(A::($matrixtype), B::AbstractTriangular) = ($op)(A, full(B))
+            ($op)(A::AbstractTriangular, B::($matrixtype)) = ($op)(convert(Array, A), B)
+            ($op)(A::($matrixtype), B::AbstractTriangular) = ($op)(A, convert(Array, B))
         end
     end
 end
 
 A_mul_Bc!(A::AbstractTriangular, B::QRCompactWYQ) = A_mul_Bc!(full!(A),B)
 A_mul_Bc!(A::AbstractTriangular, B::QRPackedQ) = A_mul_Bc!(full!(A),B)
-A_mul_Bc(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc(full(A), B)
+A_mul_Bc(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc(convert(Array, A), B)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -174,8 +174,8 @@ A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(C::StridedMatrix{T}, A::StridedMatrix{T}
 A_mul_B!{T<:BlasComplex,S<:StridedMatrix}(C::StridedMatrix{T}, A::Hermitian{T,S}, B::StridedMatrix{T}) = BLAS.hemm!('L', A.uplo, one(T), A.data, B, zero(T), C)
 A_mul_B!{T<:BlasComplex,S<:StridedMatrix}(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,S}) = BLAS.hemm!('R', B.uplo, one(T), B.data, A, zero(T), C)
 
-*(A::HermOrSym, B::HermOrSym) = full(A)*full(B)
-*(A::StridedMatrix, B::HermOrSym) = A*full(B)
+*(A::HermOrSym, B::HermOrSym) = convert(Array, A)*convert(Array, B)
+*(A::StridedMatrix, B::HermOrSym) = A*convert(Array, B)
 
 bkfact(A::HermOrSym) = bkfact(A.data, Symbol(A.uplo), issymmetric(A))
 factorize(A::HermOrSym) = bkfact(A)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -362,7 +362,7 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 +(A::UnitLowerTriangular, B::LowerTriangular) = LowerTriangular(tril(A.data, -1) + B.data + I)
 +(A::UnitUpperTriangular, B::UnitUpperTriangular) = UpperTriangular(triu(A.data, 1) + triu(B.data, 1) + 2I)
 +(A::UnitLowerTriangular, B::UnitLowerTriangular) = LowerTriangular(tril(A.data, -1) + tril(B.data, -1) + 2I)
-+(A::AbstractTriangular, B::AbstractTriangular) = full(A) + full(B)
++(A::AbstractTriangular, B::AbstractTriangular) = convert(Array, A) + convert(Array, B)
 
 -(A::UpperTriangular, B::UpperTriangular) = UpperTriangular(A.data - B.data)
 -(A::LowerTriangular, B::LowerTriangular) = LowerTriangular(A.data - B.data)
@@ -372,15 +372,15 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 -(A::UnitLowerTriangular, B::LowerTriangular) = LowerTriangular(tril(A.data, -1) - B.data + I)
 -(A::UnitUpperTriangular, B::UnitUpperTriangular) = UpperTriangular(triu(A.data, 1) - triu(B.data, 1))
 -(A::UnitLowerTriangular, B::UnitLowerTriangular) = LowerTriangular(tril(A.data, -1) - tril(B.data, -1))
--(A::AbstractTriangular, B::AbstractTriangular) = full(A) - full(B)
+-(A::AbstractTriangular, B::AbstractTriangular) = convert(Array, A) - convert(Array, B)
 
 ######################
 # BlasFloat routines #
 ######################
 
 A_mul_B!(A::Tridiagonal, B::AbstractTriangular) = A*full!(B)
-A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::Tridiagonal) = A_mul_B!(C, full(A), B)
-A_mul_B!(C::AbstractMatrix, A::Tridiagonal, B::AbstractTriangular) = A_mul_B!(C, A, full(B))
+A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::Tridiagonal) = A_mul_B!(C, convert(Array, A), B)
+A_mul_B!(C::AbstractMatrix, A::Tridiagonal, B::AbstractTriangular) = A_mul_B!(C, A, convert(Array, B))
 A_mul_B!(C::AbstractVector, A::AbstractTriangular, B::AbstractVector) = A_mul_B!(A, copy!(C, B))
 A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
 A_mul_B!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
@@ -437,7 +437,7 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
             elseif p == Inf
                 return inv(LAPACK.trcon!('I', $uploc, $isunitc, A.data))
             else #use fallback
-                return cond(full(A), p)
+                return cond(convert(Array, A), p)
             end
         end
     end
@@ -1321,7 +1321,7 @@ end
 ## Some Triangular-Triangular cases. We might want to write taylored methods for these cases, but I'm not sure it is worth it.
 for t in (UpperTriangular, UnitUpperTriangular, LowerTriangular, UnitLowerTriangular)
     @eval begin
-        (*)(A::Tridiagonal, B::$t) = A_mul_B!(full(A), B)
+        (*)(A::Tridiagonal, B::$t) = A_mul_B!(convert(Array, A), B)
     end
 end
 
@@ -1848,7 +1848,7 @@ eigfact(A::AbstractTriangular) = Eigen(eigvals(A), eigvecs(A))
 #Generic singular systems
 for func in (:svd, :svdfact, :svdfact!, :svdvals)
     @eval begin
-        ($func)(A::AbstractTriangular) = ($func)(full(A))
+        ($func)(A::AbstractTriangular) = ($func)(convert(Array, A))
     end
 end
 

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -19,7 +19,7 @@ end
 
 Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal,
 respectively. The result is of type `SymTridiagonal` and provides efficient specialized
-eigensolvers, but may be converted into a regular matrix with [`full`](:func:`full`).
+eigensolvers, but may be converted into a regular matrix with [`convert(Array, _)`](:func:`convert`).
 """
 SymTridiagonal{T}(dv::Vector{T}, ev::Vector{T}) = SymTridiagonal{T}(dv, ev)
 
@@ -327,7 +327,7 @@ end
 
 Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal,
 respectively.  The result is of type `Tridiagonal` and provides efficient specialized linear
-solvers, but may be converted into a regular matrix with [`full`](:func:`full`).
+solvers, but may be converted into a regular matrix with [`convert(Array, _)`](:func:`convert`).
 The lengths of `dl` and `du` must be one less than the length of `d`.
 """
 # Basic constructor takes in three dense vectors of same type

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -61,7 +61,7 @@ for (t1, t2) in ((:UnitUpperTriangular, :UpperTriangular),
 end
 
 function (-)(J::UniformScaling, UL::Union{UpperTriangular,UnitUpperTriangular})
-    ULnew = similar(full(UL), promote_type(eltype(J), eltype(UL)))
+    ULnew = similar(convert(Array, UL), promote_type(eltype(J), eltype(UL)))
     n = size(ULnew, 1)
     ULold = UL.data
     for j = 1:n
@@ -77,7 +77,7 @@ function (-)(J::UniformScaling, UL::Union{UpperTriangular,UnitUpperTriangular})
     return UpperTriangular(ULnew)
 end
 function (-)(J::UniformScaling, UL::Union{LowerTriangular,UnitLowerTriangular})
-    ULnew = similar(full(UL), promote_type(eltype(J), eltype(UL)))
+    ULnew = similar(convert(Array, UL), promote_type(eltype(J), eltype(UL)))
     n = size(ULnew, 1)
     ULold = UL.data
     for j = 1:n

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -292,8 +292,8 @@ end
 A_ldiv_B!{T,Ti}(L::LowerTriangular{T,SparseMatrixCSC{T,Ti}}, B::StridedVecOrMat) = fwdTriSolve!(L.data, B)
 A_ldiv_B!{T,Ti}(U::UpperTriangular{T,SparseMatrixCSC{T,Ti}}, B::StridedVecOrMat) = bwdTriSolve!(U.data, B)
 
-(\){T,Ti}(L::LowerTriangular{T,SparseMatrixCSC{T,Ti}}, B::SparseMatrixCSC) = A_ldiv_B!(L, full(B))
-(\){T,Ti}(U::UpperTriangular{T,SparseMatrixCSC{T,Ti}}, B::SparseMatrixCSC) = A_ldiv_B!(U, full(B))
+(\){T,Ti}(L::LowerTriangular{T,SparseMatrixCSC{T,Ti}}, B::SparseMatrixCSC) = A_ldiv_B!(L, convert(Array, B))
+(\){T,Ti}(U::UpperTriangular{T,SparseMatrixCSC{T,Ti}}, B::SparseMatrixCSC) = A_ldiv_B!(U, convert(Array, B))
 
 ## triu, tril
 
@@ -504,7 +504,7 @@ function norm(A::SparseMatrixCSC,p::Real=2)
         return float(real(zero(eltype(A))))
     elseif m == 1 || n == 1
         # TODO: compute more efficiently using A.nzval directly
-        return norm(full(A), p)
+        return norm(convert(Array, A), p)
     else
         Tnorm = typeof(float(real(zero(eltype(A)))))
         Tsum = promote_type(Float64,Tnorm)
@@ -519,7 +519,7 @@ function norm(A::SparseMatrixCSC,p::Real=2)
             end
             return convert(Tnorm, nA)
         elseif p==2
-            throw(ArgumentError("2-norm not yet implemented for sparse matrices. Try norm(full(A)) or norm(A, p) where p=1 or Inf."))
+            throw(ArgumentError("2-norm not yet implemented for sparse matrices. Try norm(convert(Array, A)) or norm(A, p) where p=1 or Inf."))
         elseif p==Inf
             rowSum = zeros(Tsum,m)
             for i=1:length(A.nzval)
@@ -544,7 +544,7 @@ function cond(A::SparseMatrixCSC, p::Real=2)
         normA = norm(A, Inf)
         return normA * normAinv
     elseif p == 2
-        throw(ArgumentError("2-norm condition number is not implemented for sparse matrices, try cond(full(A), 2) instead"))
+        throw(ArgumentError("2-norm condition number is not implemented for sparse matrices, try cond(convert(Array, A), 2) instead"))
     else
         throw(ArgumentError("second argument must be either 1 or Inf, got $p"))
     end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1688,39 +1688,39 @@ for (op, pro) in ((+,   :eltype_plus),
     end
 end # macro
 
-(.+)(A::SparseMatrixCSC, B::Number) = full(A) .+ B
-( +)(A::SparseMatrixCSC, B::Array ) = full(A)  + B
-(.+)(A::Number, B::SparseMatrixCSC) = A .+ full(B)
-( +)(A::Array , B::SparseMatrixCSC) = A  + full(B)
+(.+)(A::SparseMatrixCSC, B::Number) = convert(Array, A) .+ B
+( +)(A::SparseMatrixCSC, B::Array ) = convert(Array, A)  + B
+(.+)(A::Number, B::SparseMatrixCSC) = A .+ convert(Array, B)
+( +)(A::Array , B::SparseMatrixCSC) = A  + convert(Array, B)
 
-(.-)(A::SparseMatrixCSC, B::Number) = full(A) .- B
-( -)(A::SparseMatrixCSC, B::Array ) = full(A)  - B
-(.-)(A::Number, B::SparseMatrixCSC) = A .- full(B)
-( -)(A::Array , B::SparseMatrixCSC) = A  - full(B)
+(.-)(A::SparseMatrixCSC, B::Number) = convert(Array, A) .- B
+( -)(A::SparseMatrixCSC, B::Array ) = convert(Array, A)  - B
+(.-)(A::Number, B::SparseMatrixCSC) = A .- convert(Array, B)
+( -)(A::Array , B::SparseMatrixCSC) = A  - convert(Array, B)
 
 (.*)(A::AbstractArray, B::AbstractArray) = broadcast_zpreserving(*, A, B)
 (.*)(A::SparseMatrixCSC, B::Number) = SparseMatrixCSC(A.m, A.n, copy(A.colptr), copy(A.rowval), A.nzval .* B)
 (.*)(A::Number, B::SparseMatrixCSC) = SparseMatrixCSC(B.m, B.n, copy(B.colptr), copy(B.rowval), A .* B.nzval)
 
 (./)(A::SparseMatrixCSC, B::Number) = SparseMatrixCSC(A.m, A.n, copy(A.colptr), copy(A.rowval), A.nzval ./ B)
-(./)(A::Number, B::SparseMatrixCSC) = (./)(A, full(B))
-(./)(A::SparseMatrixCSC, B::Array) = (./)(full(A), B)
-(./)(A::Array, B::SparseMatrixCSC) = (./)(A, full(B))
-(./)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (./)(full(A), full(B))
+(./)(A::Number, B::SparseMatrixCSC) = (./)(A, convert(Array, B))
+(./)(A::SparseMatrixCSC, B::Array) = (./)(convert(Array, A), B)
+(./)(A::Array, B::SparseMatrixCSC) = (./)(A, convert(Array, B))
+(./)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (./)(convert(Array,  A), convert(Array, B))
 
-(.\)(A::SparseMatrixCSC, B::Number) = (.\)(full(A), B)
+(.\)(A::SparseMatrixCSC, B::Number) = (.\)(convert(Array, A), B)
 (.\)(A::Number, B::SparseMatrixCSC) = SparseMatrixCSC(B.m, B.n, copy(B.colptr), copy(B.rowval), A .\ B.nzval )
-(.\)(A::SparseMatrixCSC, B::Array) = (.\)(full(A), B)
-(.\)(A::Array, B::SparseMatrixCSC) = (.\)(A, full(B))
-(.\)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (.\)(full(A), full(B))
+(.\)(A::SparseMatrixCSC, B::Array) = (.\)(convert(Array, A), B)
+(.\)(A::Array, B::SparseMatrixCSC) = (.\)(A, convert(Array, B))
+(.\)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (.\)(convert(Array,  A), convert(Array, B))
 
 (.^)(A::SparseMatrixCSC, B::Number) =
     B==0 ? sparse(ones(typeof(one(eltype(A)).^B), A.m, A.n)) :
            SparseMatrixCSC(A.m, A.n, copy(A.colptr), copy(A.rowval), A.nzval .^ B)
 (.^)(::Irrational{:e}, B::SparseMatrixCSC) = exp(B)
-(.^)(A::Number, B::SparseMatrixCSC) = (.^)(A, full(B))
-(.^)(A::SparseMatrixCSC, B::Array) = (.^)(full(A), B)
-(.^)(A::Array, B::SparseMatrixCSC) = (.^)(A, full(B))
+(.^)(A::Number, B::SparseMatrixCSC) = (.^)(A, convert(Array, B))
+(.^)(A::SparseMatrixCSC, B::Array) = (.^)(convert(Array, A), B)
+(.^)(A::Array, B::SparseMatrixCSC) = (.^)(A, convert(Array, B))
 
 .+{Tv1,Ti1,Tv2,Ti2}(A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) =
    broadcast!(+, spzeros(eltype_plus(A_1, A_2), promote_type(Ti1, Ti2), to_shape(broadcast_shape(A_1, A_2))), A_1, A_2)
@@ -2854,11 +2854,11 @@ setindex!(A::SparseMatrixCSC, x::Matrix, I::AbstractVector{Bool}, J::AbstractVec
 setindex!{T<:Integer}(A::SparseMatrixCSC, x::Matrix, I::AbstractVector{T}, J::AbstractVector{Bool}) = setindex!(A, sparse(x), I, find(J))
 setindex!{T<:Integer}(A::SparseMatrixCSC, x::Matrix, I::AbstractVector{Bool}, J::AbstractVector{T}) = setindex!(A, sparse(x), find(I),J)
 
-setindex!(A::Matrix, x::SparseMatrixCSC, I::Integer, J::AbstractVector{Bool}) = setindex!(A, full(x), I, find(J))
-setindex!(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{Bool}, J::Integer) = setindex!(A, full(x), find(I), J)
-setindex!(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{Bool}, J::AbstractVector{Bool}) = setindex!(A, full(x), find(I), find(J))
-setindex!{T<:Integer}(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{T}, J::AbstractVector{Bool}) = setindex!(A, full(x), I, find(J))
-setindex!{T<:Integer}(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{Bool}, J::AbstractVector{T}) = setindex!(A, full(x), find(I), J)
+setindex!(A::Matrix, x::SparseMatrixCSC, I::Integer, J::AbstractVector{Bool}) = setindex!(A, convert(Array, x), I, find(J))
+setindex!(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{Bool}, J::Integer) = setindex!(A, convert(Array, x), find(I), J)
+setindex!(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{Bool}, J::AbstractVector{Bool}) = setindex!(A, convert(Array, x), find(I), find(J))
+setindex!{T<:Integer}(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{T}, J::AbstractVector{Bool}) = setindex!(A, convert(Array, x), I, find(J))
+setindex!{T<:Integer}(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{Bool}, J::AbstractVector{T}) = setindex!(A, convert(Array, x), find(I), J)
 
 setindex!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, x, I::AbstractVector{Bool}) = throw(BoundsError())
 function setindex!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, x, I::AbstractMatrix{Bool})

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -154,7 +154,7 @@ lufact{Tv<:Union{Complex32,Complex64}, Ti<:UMFITypes}(A::SparseMatrixCSC{Tv,Ti})
 lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}}) =
     throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",
     "Try lufact(convert(SparseMatrixCSC{Float64/Complex128,Int}, A)) for ",
-    "sparse floating point LU using UMFPACK or lufact(full(A)) for generic ",
+    "sparse floating point LU using UMFPACK or lufact(convert(Array, A)) for generic ",
     "dense LU.")))
 lufact(A::SparseMatrixCSC) = lufact(float(A))
 lufact(A::SparseMatrixCSC, pivot::Type{Val{false}}) = lufact(A)

--- a/base/test.jl
+++ b/base/test.jl
@@ -817,7 +817,7 @@ end
 
 approx_full(x::AbstractArray) = x
 approx_full(x::Number) = x
-approx_full(x) = full(x)
+approx_full(x) = convert(Array, x)
 
 function test_approx_eq(va, vb, Eps, astr, bstr)
     va = approx_full(va)

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -831,7 +831,7 @@ reference.
 +----------------------------------------+----------------------------------+--------------------------------------------+
 | :func:`speye(n) <speye>`               | :func:`eye(n) <eye>`             | Creates a *n*-by-*n* identity matrix.      |
 +----------------------------------------+----------------------------------+--------------------------------------------+
-| :func:`full(S) <full>`                 | :func:`sparse(A) <sparse>`       | Interconverts between dense                |
+| :func:`convert(Array, S) <convert>`    | :func:`sparse(A) <sparse>`       | Interconverts between dense                |
 |                                        |                                  | and sparse formats.                        |
 +----------------------------------------+----------------------------------+--------------------------------------------+
 | :func:`sprand(m,n,d) <sprand>`         | :func:`rand(m,n) <rand>`         | Creates a *m*-by-*n* random matrix (of     |

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -110,7 +110,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Constructs an upper (``isupper=true``\ ) or lower (``isupper=false``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . ``ev``\ 's length must be one less than the length of ``dv``\ .
+   Constructs an upper (``isupper=true``\ ) or lower (``isupper=false``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert`\ . ``ev``\ 's length must be one less than the length of ``dv``\ .
 
    **Example**
 
@@ -125,7 +125,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Constructs an upper (``uplo='U'``\ ) or lower (``uplo='L'``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . ``ev``\ 's length must be one less than the length of ``dv``\ .
+   Constructs an upper (``uplo='U'``\ ) or lower (``uplo='L'``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert`\ . ``ev``\ 's length must be one less than the length of ``dv``\ .
 
    **Example**
 
@@ -154,13 +154,13 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal, respectively. The result is of type ``SymTridiagonal`` and provides efficient specialized eigensolvers, but may be converted into a regular matrix with :func:`full`\ .
+   Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal, respectively. The result is of type ``SymTridiagonal`` and provides efficient specialized eigensolvers, but may be converted into a regular matrix with :func:`convert`\ .
 
 .. function:: Tridiagonal(dl, d, du)
 
    .. Docstring generated from Julia source
 
-   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
+   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert`\ . The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
 
 .. function:: Symmetric(A, uplo=:U)
 
@@ -658,7 +658,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Compute the Hessenberg decomposition of ``A`` and return a ``Hessenberg`` object. If ``F`` is the factorization object, the unitary matrix can be accessed with ``F[:Q]`` and the Hessenberg matrix with ``F[:H]``\ . When ``Q`` is extracted, the resulting type is the ``HessenbergQ`` object, and may be converted to a regular matrix with :func:`full`\ .
+   Compute the Hessenberg decomposition of ``A`` and return a ``Hessenberg`` object. If ``F`` is the factorization object, the unitary matrix can be accessed with ``F[:Q]`` and the Hessenberg matrix with ``F[:H]``\ . When ``Q`` is extracted, the resulting type is the ``HessenbergQ`` object, and may be converted to a regular matrix with :func:`convert`\ .
 
 .. function:: hessfact!(A)
 
@@ -974,7 +974,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
+   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert`\ . The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
 
 .. function:: rank(M)
 

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -89,7 +89,7 @@ end
 x = sprand(10, 10, 0.5)
 x[1] = 1
 x.nzval[1] = 0
-@test hash(x) == hash(full(x))
+@test hash(x) == hash(convert(Array, x))
 
 let a = QuoteNode(1), b = QuoteNode(1.0)
     @test (hash(a)==hash(b)) == (a==b)

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -155,7 +155,7 @@ debug && println("real svds")
 let # svds test
     A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
     S1 = svds(A, nsv = 2)
-    S2 = svd(full(A))
+    S2 = svd(convert(Array, A))
 
     ## singular values match:
     @test S1[1][:S] ≈ S2[2][1:2]
@@ -196,7 +196,7 @@ debug && println("complex svds")
 let # complex svds test
     A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp(im*[2.0:2:10;]))
     S1 = svds(A, nsv = 2)
-    S2 = svd(full(A))
+    S2 = svd(convert(Array, A))
 
     ## singular values match:
     @test S1[1][:S] ≈ S2[2][1:2]

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -62,12 +62,12 @@ for relty in (Int, Float32, Float64, BigFloat), elty in (relty, Complex{relty})
 
         @test size(T, 1) == size(T, 2) == n
         @test size(T) == (n, n)
-        @test full(T) == diagm(dv) + diagm(ev, isupper?1:-1)
-        @test Bidiagonal(full(T), isupper) == T
+        @test convert(Array, T) == diagm(dv) + diagm(ev, isupper?1:-1)
+        @test Bidiagonal(convert(Array, T), isupper) == T
         @test big(T) == T
-        @test full(abs(T)) == abs(diagm(dv)) + abs(diagm(ev, isupper?1:-1))
-        @test full(real(T)) == real(diagm(dv)) + real(diagm(ev, isupper?1:-1))
-        @test full(imag(T)) == imag(diagm(dv)) + imag(diagm(ev, isupper?1:-1))
+        @test convert(Array, abs(T)) == abs(diagm(dv)) + abs(diagm(ev, isupper?1:-1))
+        @test convert(Array, real(T)) == real(diagm(dv)) + real(diagm(ev, isupper?1:-1))
+        @test convert(Array, imag(T)) == imag(diagm(dv)) + imag(diagm(ev, isupper?1:-1))
         z = zeros(elty, n)
 
         debug && println("Idempotent tests")
@@ -113,7 +113,7 @@ for relty in (Int, Float32, Float64, BigFloat), elty in (relty, Complex{relty})
                 b += im*convert(Matrix{elty}, rand(1:10, n, 2))
             end
         end
-        Tfull = full(T)
+        Tfull = convert(Array, T)
         condT = cond(map(Complex128,Tfull))
         promty = typeof((zero(relty)*zero(relty) + zero(relty)*zero(relty))/one(relty))
         if relty != BigFloat
@@ -184,7 +184,7 @@ for relty in (Int, Float32, Float64, BigFloat), elty in (relty, Complex{relty})
 
         debug && println("Singular systems")
         if (elty <: BlasReal)
-            @test full(svdfact(T)) ≈ full(svdfact!(copy(Tfull)))
+            @test convert(Array, svdfact(T)) ≈ convert(Array, svdfact!(copy(Tfull)))
             @test svdvals(Tfull) ≈ svdvals(T)
             u1, d1, v1 = svd(Tfull)
             u2, d2, v2 = svd(T)
@@ -206,9 +206,9 @@ for relty in (Int, Float32, Float64, BigFloat), elty in (relty, Complex{relty})
             dv = convert(Vector{elty}, relty <: AbstractFloat ? randn(n) : rand(1:10, n))
             ev = convert(Vector{elty}, relty <: AbstractFloat ? randn(n-1) : rand(1:10, n-1))
             T2 = Bidiagonal(dv, ev, isupper2)
-            Tfull2 = full(T2)
+            Tfull2 = convert(Array, T2)
             for op in (+, -, *)
-                @test full(op(T, T2)) ≈ op(Tfull, Tfull2)
+                @test convert(Array, op(T, T2)) ≈ op(Tfull, Tfull2)
             end
         end
 
@@ -234,7 +234,7 @@ A = Bidiagonal(ones(Float32,10),ones(Float32,9),true)
 B = rand(Float64,10,10)
 C = Tridiagonal(rand(Float64,9),rand(Float64,10),rand(Float64,9))
 @test promote_rule(Matrix{Float64}, Bidiagonal{Float64}) == Matrix{Float64}
-@test promote(B,A) == (B,convert(Matrix{Float64},full(A)))
+@test promote(B,A) == (B,convert(Matrix{Float64},convert(Array, A)))
 @test promote(C,A) == (C,Tridiagonal(zeros(Float64,9),convert(Vector{Float64},A.dv),convert(Vector{Float64},A.ev)))
 
 import Base.LinAlg: fillslots!, UnitLowerTriangular
@@ -271,14 +271,14 @@ let #fill!
         b = Bidiagonal(randn(1,1), true)
         st = SymTridiagonal(randn(1,1))
         for x in (b, st)
-            @test full(fill!(x, val)) == fill!(full(x), val)
+            @test convert(Array, fill!(x, val)) == fill!(convert(Array, x), val)
         end
         b = Bidiagonal(randn(2,2), true)
         st = SymTridiagonal(randn(3), randn(2))
         t = Tridiagonal(randn(3,3))
         for x in (b, t, st)
             @test_throws ArgumentError fill!(x, val)
-            @test full(fill!(x, 0)) == fill!(full(x), 0)
+            @test convert(Array, fill!(x, 0)) == fill!(convert(Array, x), 0)
         end
     end
 end

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -46,7 +46,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     for i=1:n, j=1:n
         @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
     end
-    E = abs(apd - full(capd))
+    E = abs(apd - convert(Array, capd))
     for i=1:n, j=1:n
         @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
     end
@@ -65,13 +65,13 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     end
 
     # test chol of 2x2 Strang matrix
-    S = convert(AbstractMatrix{eltya},full(SymTridiagonal([2,2],[-1])))
+    S = convert(AbstractMatrix{eltya},convert(Array, SymTridiagonal([2,2],[-1])))
     U = Bidiagonal([2,sqrt(eltya(3))],[-1],true) / sqrt(eltya(2))
-    @test full(chol(S)) ≈ full(U)
+    @test convert(Array, chol(S)) ≈ convert(Array, U)
 
     #lower Cholesky factor
     lapd = cholfact(apd, :L)
-    @test full(lapd) ≈ apd
+    @test convert(Array, lapd) ≈ apd
     l = lapd[:L]
     @test l*l' ≈ apd
     @test triu(capd.factors) ≈ lapd[:U]
@@ -95,12 +95,12 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         if isreal(apd)
             @test apd*inv(cpapd) ≈ eye(n)
         end
-        @test full(cpapd) ≈ apd
+        @test convert(Array, cpapd) ≈ apd
         #getindex
         @test_throws KeyError cpapd[:Z]
 
         @test size(cpapd) == size(apd)
-        @test full(copy(cpapd)) ≈ apd
+        @test convert(Array, copy(cpapd)) ≈ apd
         @test det(cpapd) ≈ det(apd)
         @test cpapd[:P]*cpapd[:L]*cpapd[:U]*cpapd[:P]' ≈ apd
     end
@@ -151,9 +151,9 @@ begin
     # Cholesky factor of Matrix with non-commutative elements, here 2x2-matrices
 
     X = Matrix{Float64}[0.1*rand(2,2) for i in 1:3, j = 1:3]
-    L = full(Base.LinAlg._chol!(X*X', LowerTriangular))
-    U = full(Base.LinAlg._chol!(X*X', UpperTriangular))
-    XX = full(X*X')
+    L = convert(Array, Base.LinAlg._chol!(X*X', LowerTriangular))
+    U = convert(Array, Base.LinAlg._chol!(X*X', UpperTriangular))
+    XX = convert(Array, X*X')
 
     @test sum(sum(norm, L*L' - XX)) < eps()
     @test sum(sum(norm, U'*U - XX)) < eps()
@@ -167,8 +167,8 @@ for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
         A = randn(5,5)
     end
     A = convert(Matrix{elty}, A'A)
-    @test full(cholfact(A)[:L]) ≈ full(invoke(Base.LinAlg._chol!, Tuple{AbstractMatrix, Type{LowerTriangular}}, copy(A), LowerTriangular))
-    @test full(cholfact(A)[:U]) ≈ full(invoke(Base.LinAlg._chol!, Tuple{AbstractMatrix, Type{UpperTriangular}}, copy(A), UpperTriangular))
+    @test convert(Array, cholfact(A)[:L]) ≈ convert(Array, invoke(Base.LinAlg._chol!, Tuple{AbstractMatrix, Type{LowerTriangular}}, copy(A), LowerTriangular))
+    @test convert(Array, cholfact(A)[:U]) ≈ convert(Array, invoke(Base.LinAlg._chol!, Tuple{AbstractMatrix, Type{UpperTriangular}}, copy(A), UpperTriangular))
 end
 
 # Test up- and downdates

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -120,12 +120,12 @@ debug && println("Factorize")
     @test factorize(A) == Bidiagonal(d,e,true)
     if eltya <: Real
         A = diagm(d) + diagm(e,1) + diagm(e,-1)
-        @test full(factorize(A)) ≈ full(factorize(SymTridiagonal(d,e)))
+        @test convert(Array, factorize(A)) ≈ convert(Array, factorize(SymTridiagonal(d,e)))
         A = diagm(d) + diagm(e,1) + diagm(e,-1) + diagm(f,2) + diagm(f,-2)
         @test inv(factorize(A)) ≈ inv(factorize(Symmetric(A)))
     end
     A = diagm(d) + diagm(e,1) + diagm(e2,-1)
-    @test full(factorize(A)) ≈ full(factorize(Tridiagonal(e2,d,e)))
+    @test convert(Array, factorize(A)) ≈ convert(Array, factorize(Tridiagonal(e2,d,e)))
     A = diagm(d) + diagm(e,1) + diagm(f,2)
     @test factorize(A) == UpperTriangular(A)
 end # for eltya

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -27,9 +27,9 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
     @test typeof(convert(Diagonal{Complex64},D)) == Diagonal{Complex64}
     @test typeof(convert(AbstractMatrix{Complex64},D))   == Diagonal{Complex64}
 
-    @test full(real(D)) == real(DM)
-    @test full(abs(D)) == abs(DM)
-    @test full(imag(D)) == imag(DM)
+    @test convert(Array, real(D)) == real(DM)
+    @test convert(Array, abs(D)) == abs(DM)
+    @test convert(Array, imag(D)) == imag(DM)
 
     @test parent(D) == d
     @test diag(D) == d
@@ -79,12 +79,12 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
                 @test_throws SingularException A_ldiv_B!(Diagonal(zeros(relty,n)),copy(v))
                 b = rand(elty,n,n)
                 b = sparse(b)
-                @test A_ldiv_B!(D,copy(b)) ≈ full(D)\full(b)
+                @test A_ldiv_B!(D,copy(b)) ≈ convert(Array, D)\convert(Array, b)
                 @test_throws SingularException A_ldiv_B!(Diagonal(zeros(elty,n)),copy(b))
                 b = view(rand(elty,n),collect(1:n))
                 b2 = copy(b)
                 c = A_ldiv_B!(D,b)
-                d = full(D)\b2
+                d = convert(Array, D)\b2
                 for i in 1:n
                     @test c[i] ≈ d[i]
                 end
@@ -101,23 +101,23 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
             D2 = Diagonal(d)
             DM2= diagm(d)
             for op in (+, -, *)
-                @test full(op(D, D2)) ≈ op(DM, DM2)
+                @test convert(Array, op(D, D2)) ≈ op(DM, DM2)
             end
             # binary ops with plain numbers
             a = rand()
-            @test full(a*D) ≈ a*DM
-            @test full(D*a) ≈ DM*a
-            @test full(D/a) ≈ DM/a
+            @test convert(Array, a*D) ≈ a*DM
+            @test convert(Array, D*a) ≈ DM*a
+            @test convert(Array, D/a) ≈ DM/a
             if relty <: BlasFloat
                 b = rand(elty,n,n)
                 b = sparse(b)
-                @test A_mul_B!(copy(D), copy(b)) ≈ full(D)*full(b)
-                @test At_mul_B!(copy(D), copy(b)) ≈ full(D).'*full(b)
-                @test Ac_mul_B!(copy(D), copy(b)) ≈ full(D)'*full(b)
+                @test A_mul_B!(copy(D), copy(b)) ≈ convert(Array, D)*convert(Array, b)
+                @test At_mul_B!(copy(D), copy(b)) ≈ convert(Array, D).'*convert(Array, b)
+                @test Ac_mul_B!(copy(D), copy(b)) ≈ convert(Array, D)'*convert(Array, b)
             end
 
-            @test U.'*D ≈ U.'*full(D)
-            @test U'*D ≈ U'*full(D)
+            @test U.'*D ≈ U.'*convert(Array, D)
+            @test U'*D ≈ U'*convert(Array, D)
 
             #division of two Diagonals
             @test D/D2 ≈ Diagonal(D.diag./D2.diag)
@@ -155,7 +155,7 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
             debug && println("conj and transpose")
             @test transpose(D) == D
             if elty <: BlasComplex
-                @test full(conj(D)) ≈ conj(DM)
+                @test convert(Array, conj(D)) ≈ conj(DM)
                 @test ctranspose(D) == conj(D)
             end
 
@@ -233,7 +233,7 @@ end
 # inv
 for d in (randn(n), [1, 2, 3], [1im, 2im, 3im])
     D = Diagonal(d)
-    @test inv(D) ≈ inv(full(D))
+    @test inv(D) ≈ inv(convert(Array, D))
 end
 @test_throws SingularException inv(Diagonal(zeros(n)))
 @test_throws SingularException inv(Diagonal([0, 1, 2]))

--- a/test/linalg/hessenberg.jl
+++ b/test/linalg/hessenberg.jl
@@ -26,11 +26,11 @@ debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
             @test size(H[:Q], 2) == size(A, 2)
             @test size(H[:Q]) == size(A)
             @test_throws KeyError H[:Z]
-            @test full(H) ≈ A
+            @test convert(Array, H) ≈ A
             @test (H[:Q] * H[:H]) * H[:Q]' ≈ A
             @test (H[:Q]' *A) * H[:Q] ≈ H[:H]
             #getindex for HessenbergQ
-            @test H[:Q][1,1] ≈ full(H[:Q])[1,1]
+            @test H[:Q][1,1] ≈ convert(Array, H[:Q])[1,1]
         end
     end
 end

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -46,7 +46,7 @@ let # gebrd, bdsqr & throw for bdsdc
         d, e = convert(Vector{elty}, randn(n)), convert(Vector{elty}, randn(n - 1))
         U, Vt, C = eye(elty, n), eye(elty, n), eye(elty, n)
         s, _ = LAPACK.bdsqr!('U', copy(d), copy(e), Vt, U, C)
-        @test full(Bidiagonal(d, e, true)) ≈ U*Diagonal(s)*Vt
+        @test convert(Array, Bidiagonal(d, e, true)) ≈ U*Diagonal(s)*Vt
 
         @test_throws ArgumentError LAPACK.bdsqr!('A', d, e, Vt, U, C)
         @test_throws DimensionMismatch LAPACK.bdsqr!('U', d, [e; 1], Vt, U, C)

--- a/test/linalg/lq.jl
+++ b/test/linalg/lq.jl
@@ -52,25 +52,25 @@ debug && println("LQ decomposition")
                 @test size(lqa[:Q],3) == 1
                 @test Base.LinAlg.getq(lqa) == lqa[:Q]
                 @test_throws KeyError lqa[:Z]
-                @test full(lqa') ≈ a'
+                @test convert(Array, lqa') ≈ a'
                 @test lqa * lqa' ≈ a * a'
                 @test lqa' * lqa ≈ a' * a
-                @test q*full(q, thin = false)' ≈ eye(eltya,n)
+                @test q*Base.LinAlg.thickQ(q)' ≈ eye(eltya,n)
                 @test l*q ≈ a
-                @test full(lqa) ≈ a
-                @test full(copy(lqa)) ≈ a
+                @test convert(Array, lqa) ≈ a
+                @test convert(Array, copy(lqa)) ≈ a
                 @test_approx_eq_eps a*(lqa\b) b 3000ε
                 @test_approx_eq_eps lqa*b qra[:Q]*qra[:R]*b 3000ε
-                @test_approx_eq_eps A_mul_Bc(eye(eltyb,size(q.factors,2)),q)*full(q, thin=false) eye(n) 5000ε
+                @test_approx_eq_eps A_mul_Bc(eye(eltyb,size(q.factors,2)),q)*Base.LinAlg.thickQ(q) eye(n) 5000ε
                 if eltya != Int
                     @test eye(eltyb,n)*q ≈ convert(AbstractMatrix{tab},q)
                 end
-                @test_approx_eq_eps q*b full(q, thin=false)*b 100ε
-                @test_approx_eq_eps q.'*b full(q, thin=false).'*b 100ε
-                @test_approx_eq_eps q'*b full(q, thin=false)'*b 100ε
-                @test_approx_eq_eps a*q a*full(q, thin=false) 100ε
-                @test_approx_eq_eps a*q.' a*full(q, thin=false).' 100ε
-                @test_approx_eq_eps a*q' a*full(q, thin=false)' 100ε
+                @test_approx_eq_eps q*b Base.LinAlg.thickQ(q)*b 100ε
+                @test_approx_eq_eps q.'*b Base.LinAlg.thickQ(q).'*b 100ε
+                @test_approx_eq_eps q'*b Base.LinAlg.thickQ(q)'*b 100ε
+                @test_approx_eq_eps a*q a*Base.LinAlg.thickQ(q) 100ε
+                @test_approx_eq_eps a*q.' a*Base.LinAlg.thickQ(q).' 100ε
+                @test_approx_eq_eps a*q' a*Base.LinAlg.thickQ(q)' 100ε
                 @test_throws DimensionMismatch q*b[1:n1 + 1]
                 @test_throws DimensionMismatch Ac_mul_B(q,ones(eltya,n+2,n+2))
                 @test_throws DimensionMismatch ones(eltyb,n+2,n+2)*q
@@ -80,10 +80,10 @@ debug && println("LQ decomposition")
 debug && println("Matmul with LQ factorizations")
         lqa = lqfact(a[:,1:n1])
         l,q = lqa[:L], lqa[:Q]
-        @test full(q)*full(q)' ≈ eye(eltya,n1)
-        @test (full(q,thin=false)'*full(q,thin=false))[1:n1,:] ≈ eye(eltya,n1,n)
+        @test convert(Array, q)*convert(Array, q)' ≈ eye(eltya,n1)
+        @test (Base.LinAlg.thickQ(q)'*Base.LinAlg.thickQ(q))[1:n1,:] ≈ eye(eltya,n1,n)
         @test_throws DimensionMismatch A_mul_B!(eye(eltya,n+1),q)
-        @test Ac_mul_B!(q,full(q)) ≈ eye(eltya,n1)
+        @test Ac_mul_B!(q,convert(Array, q)) ≈ eye(eltya,n1)
         @test_throws DimensionMismatch A_mul_Bc!(eye(eltya,n+1),q)
         @test_throws BoundsError size(q,-1)
     end

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -36,7 +36,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     if eltya <: BlasFloat
         num = rand(eltya)
         @test lu(num) == (one(eltya),num,1)
-        @test full(lufact(num)) ≈ eltya[num]
+        @test convert(Array, lufact(num)) ≈ eltya[num]
     end
     for eltyb in (Float32, Float64, Complex64, Complex128, Int)
         b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex(breal, bimg) : breal)
@@ -68,7 +68,7 @@ debug && println("(Automatic) Square LU decomposition")
                 @test norm(a'*(lua'\a') - a', 1) < ε*κ*n^2
                 @test norm(a*(lua\c) - c, 1) < ε*κ*n # c is a vector
                 @test norm(a'*(lua'\c) - c, 1) < ε*κ*n # c is a vector
-                @test full(lua) ≈ a
+                @test convert(Array, lua) ≈ a
                 if eltya <: Real && eltyb <: Real
                     @test norm(a.'*(lua.'\b) - b,1) < ε*κ*n*2 # Two because the right hand side has two columns
                     @test norm(a.'*(lua.'\c) - c,1) < ε*κ*n
@@ -81,13 +81,13 @@ debug && println("(Automatic) Square LU decomposition")
         end
 
 debug && println("Tridiagonal LU")
-        κd    = cond(full(d),1)
+        κd    = cond(convert(Array, d),1)
         lud   = lufact(d)
         @test lufact(lud) == lud
         @test_throws KeyError lud[:Z]
-        @test lud[:L]*lud[:U] ≈ lud[:P]*full(d)
-        @test lud[:L]*lud[:U] ≈ full(d)[lud[:p],:]
-        @test full(lud) ≈ d
+        @test lud[:L]*lud[:U] ≈ lud[:P]*convert(Array, d)
+        @test lud[:L]*lud[:U] ≈ convert(Array, d)[lud[:p],:]
+        @test convert(Array, lud) ≈ d
         f = zeros(eltyb, n+1)
         @test_throws DimensionMismatch lud\f
         @test_throws DimensionMismatch lud.'\f
@@ -102,17 +102,17 @@ debug && println("Tridiagonal LU")
 
                 @test norm(d*(lud\b) - b, 1) < ε*κd*n*2 # Two because the right hand side has two columns
                 if eltya <: Real
-                    @test norm((lud.'\b) - full(d.')\b, 1) < ε*κd*n*2 # Two because the right hand side has two columns
+                    @test norm((lud.'\b) - convert(Array, d.')\b, 1) < ε*κd*n*2 # Two because the right hand side has two columns
                 end
                 if eltya <: Complex
-                    @test norm((lud'\b) - full(d')\b, 1) < ε*κd*n*2 # Two because the right hand side has two columns
+                    @test norm((lud'\b) - convert(Array, d')\b, 1) < ε*κd*n*2 # Two because the right hand side has two columns
                 end
             end
         end
         if eltya <: BlasFloat && eltyb <: BlasFloat
             e = rand(eltyb,n,n)
             @test norm(e/lud - e/d,1) < ε*κ*n^2
-            @test norm((lud.'\e') - full(d.')\e',1) < ε*κd*n^2
+            @test norm((lud.'\e') - convert(Array, d.')\e',1) < ε*κd*n^2
             #test singular
             du = rand(eltya,n-1)
             dl = rand(eltya,n-1)
@@ -136,11 +136,11 @@ end
 
 # test conversion routine
 a = Tridiagonal(rand(9),rand(10),rand(9))
-fa = full(a)
+fa = convert(Array, a)
 falu = lufact(fa)
 alu = lufact(a)
 falu = convert(typeof(falu),alu)
-@test full(alu) == fa
+@test convert(Array, alu) == fa
 
 # Test rational matrices
 ## Integrate in general tests when more linear algebra is implemented in julia

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -336,7 +336,7 @@ A = [RootInt(3) RootInt(5)]
 
 function test_mul(C, A, B)
     A_mul_B!(C, A, B)
-    @test full(A) * full(B) ≈ C
+    @test convert(Array, A) * convert(Array, B) ≈ C
     @test A*B ≈ C
 end
 

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -46,15 +46,15 @@ debug && println("QR decomposition (without pivoting)")
                 @inferred qr(a)
                 q, r  = qra[:Q], qra[:R]
                 @test_throws KeyError qra[:Z]
-                @test q'*full(q, thin=false) ≈ eye(n)
-                @test q*full(q, thin=false)' ≈ eye(n)
-                @test q'*eye(n)' ≈ full(q, thin=false)'
-                @test full(q, thin=false)'q ≈ eye(n)
-                @test eye(n)'q' ≈ full(q, thin=false)'
+                @test q'*Base.LinAlg.thickQ(q) ≈ eye(n)
+                @test q*Base.LinAlg.thickQ(q)' ≈ eye(n)
+                @test q'*eye(n)' ≈ Base.LinAlg.thickQ(q)'
+                @test Base.LinAlg.thickQ(q)'q ≈ eye(n)
+                @test eye(n)'q' ≈ Base.LinAlg.thickQ(q)'
                 @test q*r ≈ a
                 @test_approx_eq_eps a*(qra\b) b 3000ε
-                @test full(qra) ≈ a
-                @test_approx_eq_eps A_mul_Bc(eye(eltyb,size(q.factors,2)),q)*full(q, thin=false) eye(n) 5000ε
+                @test convert(Array, qra) ≈ a
+                @test_approx_eq_eps A_mul_Bc(eye(eltyb,size(q.factors,2)),q)*Base.LinAlg.thickQ(q) eye(n) 5000ε
                 if eltya != Int
                     @test eye(eltyb,n)*q ≈ convert(AbstractMatrix{tab},q)
                     ac = copy(a)
@@ -66,14 +66,14 @@ debug && println("Thin QR decomposition (without pivoting)")
                 @inferred qr(a[:,1:n1], Val{false})
                 q,r   = qra[:Q], qra[:R]
                 @test_throws KeyError qra[:Z]
-                @test q'*full(q, thin=false) ≈ eye(n)
-                @test q'*full(q) ≈ eye(n,n1)
+                @test q'*Base.LinAlg.thickQ(q) ≈ eye(n)
+                @test q'*convert(Array, q) ≈ eye(n,n1)
                 @test q*r ≈ a[:,1:n1]
-                @test_approx_eq_eps q*b[1:n1] full(q)*b[1:n1] 100ε
-                @test_approx_eq_eps q*b full(q, thin=false)*b 100ε
+                @test_approx_eq_eps q*b[1:n1] convert(Array, q)*b[1:n1] 100ε
+                @test_approx_eq_eps q*b Base.LinAlg.thickQ(q)*b 100ε
                 @test_throws DimensionMismatch q*b[1:n1 + 1]
                 @test_throws DimensionMismatch b[1:n1 + 1]*q'
-                @test_approx_eq_eps A_mul_Bc(UpperTriangular(eye(eltyb,size(q.factors,2))),q)*full(q, thin=false) eye(n1,n) 5000ε
+                @test_approx_eq_eps A_mul_Bc(UpperTriangular(eye(eltyb,size(q.factors,2))),q)*Base.LinAlg.thickQ(q) eye(n1,n) 5000ε
                 if eltya != Int
                     @test eye(eltyb,n)*q ≈ convert(AbstractMatrix{tab},q)
                 end
@@ -86,14 +86,14 @@ debug && println("(Automatic) Fat (pivoted) QR decomposition")
                 q,r = qrpa[:Q], qrpa[:R]
                 @test_throws KeyError qrpa[:Z]
                 p = qrpa[:p]
-                @test q'*full(q, thin=false) ≈ eye(n1)
-                @test q*full(q, thin=false)' ≈ eye(n1)
-                @test (UpperTriangular(eye(eltya,size(q,2)))*q')*full(q, thin=false) ≈ eye(n1)
+                @test q'*Base.LinAlg.thickQ(q) ≈ eye(n1)
+                @test q*Base.LinAlg.thickQ(q)' ≈ eye(n1)
+                @test (UpperTriangular(eye(eltya,size(q,2)))*q')*Base.LinAlg.thickQ(q) ≈ eye(n1)
                 @test q*r ≈ (isa(qrpa,QRPivoted) ? a[1:n1,p] : a[1:n1,:])
                 @test q*r[:,invperm(p)] ≈ a[1:n1,:]
                 @test q*r*qrpa[:P].' ≈ a[1:n1,:]
                 @test_approx_eq_eps a[1:n1,:]*(qrpa\b[1:n1]) b[1:n1] 5000ε
-                @test full(qrpa) ≈ a[1:5,:]
+                @test convert(Array, qrpa) ≈ a[1:5,:]
                 @test_throws DimensionMismatch q*b[1:n1+1]
                 @test_throws DimensionMismatch b[1:n1+1]*q'
                 if eltya != Int
@@ -105,14 +105,14 @@ debug && println("(Automatic) Thin (pivoted) QR decomposition")
                 q,r = qrpa[:Q], qrpa[:R]
                 @test_throws KeyError qrpa[:Z]
                 p = qrpa[:p]
-                @test q'*full(q, thin=false) ≈ eye(n)
-                @test q*full(q, thin=false)' ≈ eye(n)
+                @test q'*Base.LinAlg.thickQ(q) ≈ eye(n)
+                @test q*Base.LinAlg.thickQ(q)' ≈ eye(n)
                 @test q*r ≈ a[:,p]
                 @test q*r[:,invperm(p)] ≈ a[:,1:n1]
-                @test full(qrpa) ≈ a[:,1:5]
+                @test convert(Array, qrpa) ≈ a[:,1:5]
                 @test_throws DimensionMismatch q*b[1:n1+1]
                 @test_throws DimensionMismatch b[1:n1+1]*q'
-                @test_approx_eq_eps A_mul_Bc(UpperTriangular(eye(eltyb,size(q.factors,2))),q)*full(q, thin=false) eye(n1,n) 5000ε
+                @test_approx_eq_eps A_mul_Bc(UpperTriangular(eye(eltyb,size(q.factors,2))),q)*Base.LinAlg.thickQ(q) eye(n1,n) 5000ε
                 if eltya != Int
                     @test eye(eltyb,n)*q ≈ convert(AbstractMatrix{tab},q)
                 end
@@ -123,9 +123,9 @@ debug && println("Matmul with QR factorizations")
         if eltya != Int
             qrpa = factorize(a[:,1:n1])
             q, r = qrpa[:Q], qrpa[:R]
-            @test A_mul_B!(full(q, thin=false)',q) ≈ eye(n)
+            @test A_mul_B!(Base.LinAlg.thickQ(q)',q) ≈ eye(n)
             @test_throws DimensionMismatch A_mul_B!(eye(eltya,n+1),q)
-            @test A_mul_Bc!(full(q, thin=false),q) ≈ eye(n)
+            @test A_mul_Bc!(Base.LinAlg.thickQ(q),q) ≈ eye(n)
             @test_throws DimensionMismatch A_mul_Bc!(eye(eltya,n+1),q)
             @test_throws BoundsError size(q,-1)
             @test_throws DimensionMismatch Base.LinAlg.A_mul_B!(q,zeros(eltya,n1+1))
@@ -133,9 +133,9 @@ debug && println("Matmul with QR factorizations")
 
             qra = qrfact(a[:,1:n1], Val{false})
             q, r = qra[:Q], qra[:R]
-            @test A_mul_B!(full(q, thin=false)',q) ≈ eye(n)
+            @test A_mul_B!(Base.LinAlg.thickQ(q)',q) ≈ eye(n)
             @test_throws DimensionMismatch A_mul_B!(eye(eltya,n+1),q)
-            @test A_mul_Bc!(full(q, thin=false),q) ≈ eye(n)
+            @test A_mul_Bc!(Base.LinAlg.thickQ(q),q) ≈ eye(n)
             @test_throws DimensionMismatch A_mul_Bc!(eye(eltya,n+1),q)
             @test_throws BoundsError size(q,-1)
             @test_throws DimensionMismatch q * eye(Int8,n+4)
@@ -154,7 +154,7 @@ end
 # Issue 7304
 let
     A = [-√.5 -√.5; -√.5 √.5]
-    Q = full(qrfact(A)[:Q])
+    Q = convert(Array, qrfact(A)[:Q])
     @test vecnorm(A-Q) < eps()
 end
 

--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -38,7 +38,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
         @test sort(real(f[:values])) ≈ sort(real(d))
         @test sort(imag(f[:values])) ≈ sort(imag(d))
         @test istriu(f[:Schur]) || eltype(a)<:Real
-        @test full(f) ≈ a
+        @test convert(Array, f) ≈ a
         @test_throws KeyError f[:A]
 
     debug && println("Reorder Schur")

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -11,11 +11,11 @@ let a=[1.0:n;]
    A=Diagonal(a)
    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, LowerTriangular, UpperTriangular, Matrix]
        debug && println("newtype is $(newtype)")
-       @test full(convert(newtype, A)) == full(A)
+       @test convert(Array, convert(newtype, A)) == convert(Array, A)
    end
    for newtype in [Base.LinAlg.UnitUpperTriangular, Base.LinAlg.UnitLowerTriangular]
        @test_throws ArgumentError convert(newtype, A)
-       @test full(convert(newtype, Diagonal(ones(n)))) == eye(n)
+       @test convert(Array, convert(newtype, Diagonal(ones(n)))) == eye(n)
    end
 
    for isupper in (true, false)
@@ -23,56 +23,56 @@ let a=[1.0:n;]
        A=Bidiagonal(a, [1.0:n-1;], isupper)
        for newtype in [Bidiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
            debug && println("newtype is $(newtype)")
-           @test full(convert(newtype, A)) == full(A)
-           @test full(newtype(A)) == full(A)
+           @test convert(Array, convert(newtype, A)) == convert(Array, A)
+           @test convert(Array, newtype(A)) == convert(Array, A)
        end
        @test_throws ArgumentError convert(SymTridiagonal, A)
        A=Bidiagonal(a, zeros(n-1), isupper) #morally Diagonal
        for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
            debug && println("newtype is $(newtype)")
-           @test full(convert(newtype, A)) == full(A)
-           @test full(newtype(A)) == full(A)
+           @test convert(Array, convert(newtype, A)) == convert(Array, A)
+           @test convert(Array, newtype(A)) == convert(Array, A)
        end
    end
 
    A = SymTridiagonal(a, [1.0:n-1;])
    for newtype in [Tridiagonal, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test convert(Array, convert(newtype, A)) == convert(Array, A)
    end
    for newtype in [Diagonal, Bidiagonal]
        @test_throws ArgumentError convert(newtype,A)
    end
    A = SymTridiagonal(a, zeros(n-1))
-   @test full(convert(Bidiagonal,A)) == full(A)
+   @test convert(Array, convert(Bidiagonal,A)) == convert(Array, A)
 
    A = Tridiagonal(zeros(n-1), [1.0:n;], zeros(n-1)) #morally Diagonal
    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test convert(Array, convert(newtype, A)) == convert(Array, A)
    end
    A = Tridiagonal(ones(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
    for newtype in [SymTridiagonal, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test convert(Array, convert(newtype, A)) == convert(Array, A)
    end
    for newtype in [Diagonal, Bidiagonal]
        @test_throws ArgumentError convert(newtype,A)
    end
    A = Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
-   @test full(convert(Bidiagonal, A)) == full(A)
+   @test convert(Array, convert(Bidiagonal, A)) == convert(Array, A)
    A = UpperTriangular(Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)))
-   @test full(convert(Bidiagonal, A)) == full(A)
+   @test convert(Array, convert(Bidiagonal, A)) == convert(Array, A)
    A = Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)) #not morally Diagonal
-   @test full(convert(Bidiagonal, A)) == full(A)
+   @test convert(Array, convert(Bidiagonal, A)) == convert(Array, A)
    A = LowerTriangular(Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)))
-   @test full(convert(Bidiagonal, A)) == full(A)
+   @test convert(Array, convert(Bidiagonal, A)) == convert(Array, A)
    @test_throws ArgumentError convert(SymTridiagonal,A)
 
-   A = LowerTriangular(full(Diagonal(a))) #morally Diagonal
+   A = LowerTriangular(convert(Array, Diagonal(a))) #morally Diagonal
    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, LowerTriangular, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test convert(Array, convert(newtype, A)) == convert(Array, A)
    end
-   A = UpperTriangular(full(Diagonal(a))) #morally Diagonal
+   A = UpperTriangular(convert(Array, Diagonal(a))) #morally Diagonal
    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, UpperTriangular, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test convert(Array, convert(newtype, A)) == convert(Array, A)
    end
    A = UpperTriangular(triu(rand(n,n)))
    for newtype in [Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal]
@@ -80,7 +80,7 @@ let a=[1.0:n;]
    end
    A = Diagonal(a)
    for newtype in [UpperTriangular, LowerTriangular]
-       @test full(convert(newtype,A)) == full(A)
+       @test convert(Array, convert(newtype,A)) == convert(Array, A)
    end
 end
 
@@ -92,26 +92,26 @@ let a=[1.0:n;]
        for type2 in Spectypes
            B = convert(type1,A)
            C = convert(type2,A)
-           @test full(B + C) ≈ full(A + A)
-           @test full(B - C) ≈ full(A - A)
+           @test convert(Array, B + C) ≈ convert(Array, A + A)
+           @test convert(Array, B - C) ≈ convert(Array, A - A)
        end
    end
    B = SymTridiagonal(a, ones(n-1))
    for Spectype in [Diagonal, Bidiagonal, Tridiagonal, Matrix]
-       @test full(B + convert(Spectype,A)) ≈ full(B + A)
-       @test full(convert(Spectype,A) + B) ≈ full(B + A)
-       @test full(B - convert(Spectype,A)) ≈ full(B - A)
-       @test full(convert(Spectype,A) - B) ≈ full(A - B)
+       @test convert(Array, B + convert(Spectype,A)) ≈ convert(Array, B + A)
+       @test convert(Array, convert(Spectype,A) + B) ≈ convert(Array, B + A)
+       @test convert(Array, B - convert(Spectype,A)) ≈ convert(Array, B - A)
+       @test convert(Array, convert(Spectype,A) - B) ≈ convert(Array, A - B)
    end
 
    C = rand(n,n)
    for TriType in [Base.LinAlg.UnitLowerTriangular, Base.LinAlg.UnitUpperTriangular, UpperTriangular, LowerTriangular]
        D = TriType(C)
        for Spectype in [Diagonal, Bidiagonal, Tridiagonal, Matrix]
-           @test full(D + convert(Spectype,A)) ≈ full(D + A)
-           @test full(convert(Spectype,A) + D) ≈ full(A + D)
-           @test full(D - convert(Spectype,A)) ≈ full(D - A)
-           @test full(convert(Spectype,A) - D) ≈ full(A - D)
+           @test convert(Array, D + convert(Spectype,A)) ≈ convert(Array, D + A)
+           @test convert(Array, convert(Spectype,A) + D) ≈ convert(Array, A + D)
+           @test convert(Array, D - convert(Spectype,A)) ≈ convert(Array, D - A)
+           @test convert(Array, convert(Spectype,A) - D) ≈ convert(Array, A - D)
        end
    end
 end
@@ -122,9 +122,9 @@ for typ in [UpperTriangular,LowerTriangular,Base.LinAlg.UnitUpperTriangular,Base
     atri = typ(a)
     b = rand(n,n)
     qrb = qrfact(b,Val{true})
-    @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
-    @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
+    @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ convert(Array, atri) * qrb[:Q]'
+    @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ convert(Array, atri) * qrb[:Q]'
     qrb = qrfact(b,Val{false})
-    @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
-    @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
+    @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ convert(Array, atri) * qrb[:Q]'
+    @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ convert(Array, atri) * qrb[:Q]'
 end

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -39,7 +39,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
         usv = svdfact(a)
         @test usv[:S] === svdvals(usv)
         @test usv[:U] * (Diagonal(usv[:S]) * usv[:Vt]) ≈ a
-        @test full(usv) ≈ a
+        @test convert(Array, usv) ≈ a
         @test usv[:Vt]' ≈ usv[:V]
         @test_throws KeyError usv[:Z]
         b = rand(eltya,n)

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -56,8 +56,8 @@ let n=10
         @test isa(similar(Symmetric(asym), Int, (3,2)), Matrix{Int})
         @test isa(similar(Hermitian(asym), Int, (3,2)), Matrix{Int})
 
-        # full
-        @test asym == full(Hermitian(asym))
+        # convert(Array, _)
+        @test asym == convert(Array, Hermitian(asym))
 
         # parent
 
@@ -111,7 +111,7 @@ let n=10
         eig(Hermitian(asym), d[1] - 1, (d[2] + d[3])/2) # same result, but checks that method works
         @test eigvals(Hermitian(asym), 1:2) ≈ d[1:2]
         @test eigvals(Hermitian(asym), d[1] - 1, (d[2] + d[3])/2) ≈ d[1:2]
-        @test full(eigfact(asym)) ≈ asym
+        @test convert(Array, eigfact(asym)) ≈ asym
 
         # relation to svdvals
         @test sum(sort(abs(eigvals(Hermitian(asym))))) == sum(sort(svdvals(Hermitian(asym))))
@@ -213,7 +213,7 @@ end
 #Issue #7933
 let A7933 = [1 2; 3 4]
     B7933 = copy(A7933)
-    C7933 = full(Symmetric(A7933))
+    C7933 = convert(Array, Symmetric(A7933))
     @test A7933 == B7933
 end
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -42,7 +42,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
         F[i,i+1] = du[i]
         F[i+1,i] = dl[i]
     end
-    @test full(T) == F
+    @test convert(Array, T) == F
 
     # elementary operations on tridiagonals
     @test conj(T) == Tridiagonal(conj(dl), conj(d), conj(du))
@@ -62,7 +62,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     @test Tridiagonal(dl, d, du) + Tridiagonal(du, d, dl) == SymTridiagonal(2d, dl+du)
     @test SymTridiagonal(d, dl) + Tridiagonal(dl, d, du) == Tridiagonal(dl + dl, d+d, dl+du)
     @test convert(SymTridiagonal,Tridiagonal(Ts)) == Ts
-    @test full(convert(SymTridiagonal{Complex64},Tridiagonal(Ts))) == convert(Matrix{Complex64},full(Ts))
+    @test convert(Array, convert(SymTridiagonal{Complex64},Tridiagonal(Ts))) == convert(Matrix{Complex64},convert(Array, Ts))
     if elty == Int
         vv = rand(1:100, n)
         BB = rand(1:100, n, 2)
@@ -101,7 +101,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     # symmetric tridiagonal
     if elty <: Real
         Ts = SymTridiagonal(d, dl)
-        Fs = full(Ts)
+        Fs = convert(Array, Ts)
         Tldlt = factorize(Ts)
         @test_throws DimensionMismatch Tldlt\rand(elty,n+1)
         @test size(Tldlt) == size(Ts)
@@ -119,7 +119,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
             invFsv = Fs\vv
             x = Ts\vv
             @test x ≈ invFsv
-            @test full(full(Tldlt)) ≈ Fs
+            @test convert(Array, convert(Array, Tldlt)) ≈ Fs
         end
 
         # similar
@@ -237,7 +237,7 @@ let n = 12 #Size of matrix problem to test
         @test_throws ArgumentError SymTridiagonal(rand(n,n))
 
         A = SymTridiagonal(a, b)
-        fA = map(elty <: Complex ? Complex128 : Float64, full(A))
+        fA = map(elty <: Complex ? Complex128 : Float64, convert(Array, A))
 
         debug && println("getindex")
         @test_throws BoundsError A[n+1,1]
@@ -289,10 +289,10 @@ let n = 12 #Size of matrix problem to test
         @test B - A == A - B
 
         debug && println("Multiplication with strided vector")
-        @test A*ones(n) ≈ full(A)*ones(n)
+        @test A*ones(n) ≈ convert(Array, A)*ones(n)
 
         debug && println("Multiplication with strided matrix")
-        @test A*ones(n, 2) ≈ full(A)*ones(n, 2)
+        @test A*ones(n, 2) ≈ convert(Array, A)*ones(n, 2)
 
         debug && println("Eigensystems")
         if elty <: Real
@@ -312,13 +312,13 @@ let n = 12 #Size of matrix problem to test
 
             debug && println("stegr! call with index range")
             F = eigfact(SymTridiagonal(a, b),1:2)
-            fF = eigfact(Symmetric(full(SymTridiagonal(a, b))),1:2)
+            fF = eigfact(Symmetric(convert(Array, SymTridiagonal(a, b))),1:2)
             Test.test_approx_eq_modphase(F[:vectors], fF[:vectors])
             @test F[:values] ≈ fF[:values]
 
             debug && println("stegr! call with value range")
             F = eigfact(SymTridiagonal(a, b),0.0,1.0)
-            fF = eigfact(Symmetric(full(SymTridiagonal(a, b))),0.0,1.0)
+            fF = eigfact(Symmetric(convert(Array, SymTridiagonal(a, b))),0.0,1.0)
             Test.test_approx_eq_modphase(F[:vectors], fF[:vectors])
             @test F[:values] ≈ fF[:values]
         end
@@ -332,15 +332,15 @@ let n = 12 #Size of matrix problem to test
         end
 
         B = SymTridiagonal(a, b)
-        fB = map(elty <: Complex ? Complex128 : Float64, full(B))
+        fB = map(elty <: Complex ? Complex128 : Float64, convert(Array, B))
 
         for op in (+, -, *)
-            @test full(op(A, B)) ≈ op(fA, fB)
+            @test convert(Array, op(A, B)) ≈ op(fA, fB)
         end
         α = rand(elty)
-        @test full(α*A) ≈ α*full(A)
-        @test full(A*α) ≈ full(A)*α
-        @test full(A/α) ≈ full(A)/α
+        @test convert(Array, α*A) ≈ α*convert(Array, A)
+        @test convert(Array, A*α) ≈ convert(Array, A)*α
+        @test convert(Array, A/α) ≈ convert(Array, A)/α
 
         debug && println("A_mul_B!")
         @test_throws DimensionMismatch A_mul_B!(zeros(elty,n,n),B,ones(elty,n+1,n))
@@ -363,7 +363,7 @@ let n = 12 #Size of matrix problem to test
 
         @test_throws ArgumentError Tridiagonal(a,a,a)
         A = Tridiagonal(a, b, c)
-        fA = map(elty <: Complex ? Complex128 : Float64, full(A))
+        fA = map(elty <: Complex ? Complex128 : Float64, convert(Array, A))
 
         debug && println("Similar, size, and copy!")
         B = similar(A)
@@ -411,22 +411,21 @@ let n = 12 #Size of matrix problem to test
         end
 
         debug && println("Multiplication with strided vector")
-        @test A*ones(n) ≈ full(A)*ones(n)
+        @test A*ones(n) ≈ convert(Array, A)*ones(n)
 
         debug && println("Multiplication with strided matrix")
-        @test A*ones(n, 2) ≈ full(A)*ones(n, 2)
-
+        @test A*ones(n, 2) ≈ convert(Array, A)*ones(n, 2)
 
         B = Tridiagonal(a, b, c)
-        fB = map(elty <: Complex ? Complex128 : Float64, full(B))
+        fB = map(elty <: Complex ? Complex128 : Float64, convert(Array, B))
 
         for op in (+, -, *)
-            @test full(op(A, B)) ≈ op(fA, fB)
+            @test convert(Array, op(A, B)) ≈ op(fA, fB)
         end
         α = rand(elty)
-        @test full(α*A) ≈ α*full(A)
-        @test full(A*α) ≈ full(A)*α
-        @test full(A/α) ≈ full(A)/α
+        @test convert(Array, α*A) ≈ α*convert(Array, A)
+        @test convert(Array, A*α) ≈ convert(Array, A)*α
+        @test convert(Array, A/α) ≈ convert(Array, A)/α
 
         @test_throws ArgumentError convert(SymTridiagonal{elty},A)
 

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -76,10 +76,10 @@ let AA = randn(2, 2)
             else
                 T = LowerTriangular(view(randn(3,3), 1:3, 1:3))
             end
-            @test T + J == full(T) + J
-            @test J + T == J + full(T)
-            @test T - J == full(T) - J
-            @test J - T == J - full(T)
+            @test T + J == convert(Array, T) + J
+            @test J + T == J + convert(Array, T)
+            @test T - J == convert(Array, T) - J
+            @test J - T == J - convert(Array, T)
             @test T\I == inv(T)
 
             if atype == "Array"
@@ -87,10 +87,10 @@ let AA = randn(2, 2)
             else
                 T = LinAlg.UnitLowerTriangular(view(randn(3,3), 1:3, 1:3))
             end
-            @test T + J == full(T) + J
-            @test J + T == J + full(T)
-            @test T - J == full(T) - J
-            @test J - T == J - full(T)
+            @test T + J == convert(Array, T) + J
+            @test J + T == J + convert(Array, T)
+            @test T - J == convert(Array, T) - J
+            @test J - T == J - convert(Array, T)
             @test T\I == inv(T)
 
             if atype == "Array"
@@ -98,10 +98,10 @@ let AA = randn(2, 2)
             else
                 T = UpperTriangular(view(randn(3,3), 1:3, 1:3))
             end
-            @test T + J == full(T) + J
-            @test J + T == J + full(T)
-            @test T - J == full(T) - J
-            @test J - T == J - full(T)
+            @test T + J == convert(Array, T) + J
+            @test J + T == J + convert(Array, T)
+            @test T - J == convert(Array, T) - J
+            @test J - T == J - convert(Array, T)
             @test T\I == inv(T)
 
             if atype == "Array"
@@ -109,10 +109,10 @@ let AA = randn(2, 2)
             else
                 T = LinAlg.UnitUpperTriangular(view(randn(3,3), 1:3, 1:3))
             end
-            @test T + J == full(T) + J
-            @test J + T == J + full(T)
-            @test T - J == full(T) - J
-            @test J - T == J - full(T)
+            @test T + J == convert(Array, T) + J
+            @test J + T == J + convert(Array, T)
+            @test T - J == convert(Array, T) - J
+            @test J - T == J - convert(Array, T)
             @test T\I == inv(T)
 
             @test I\A == A

--- a/test/perf/threads/stockcorr/pstockcorr.jl
+++ b/test/perf/threads/stockcorr/pstockcorr.jl
@@ -78,7 +78,7 @@ function pstockcorr(n)
     SimulPriceB[1,:] = CurrentPrice[2]
 
     ## Generating the paths of stock prices by Geometric Brownian Motion
-    const UpperTriangle = full(chol(Corr))    # UpperTriangle Matrix by Cholesky decomposition
+    const UpperTriangle = convert(Array, chol(Corr))    # UpperTriangle Matrix by Cholesky decomposition
 
     # Optimization: pre-allocate these for performance
     # NOTE: the new GC will hopefully fix this, but currently GC time

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -356,8 +356,8 @@ for elty in (Float64, Complex{Float64})
 
     # Factor
     @test_throws ArgumentError cholfact(A1)
-    @test_throws Base.LinAlg.PosDefException cholfact(A1 + A1' - 2eigmax(full(A1 + A1'))I)
-    @test_throws Base.LinAlg.PosDefException cholfact(A1 + A1', shift=-2eigmax(full(A1 + A1')))
+    @test_throws Base.LinAlg.PosDefException cholfact(A1 + A1' - 2eigmax(convert(Array, A1 + A1'))I)
+    @test_throws Base.LinAlg.PosDefException cholfact(A1 + A1', shift=-2eigmax(convert(Array, A1 + A1')))
     @test_throws ArgumentError ldltfact(A1 + A1' - 2real(A1[1,1])I)
     @test_throws ArgumentError ldltfact(A1 + A1', shift=-2real(A1[1,1]))
     @test_throws ArgumentError cholfact(A1)
@@ -372,19 +372,19 @@ for elty in (Float64, Complex{Float64})
     @test F\CHOLMOD.Sparse(sparse(ones(elty, 5))) ≈ A1pd\ones(5)
     @test_throws DimensionMismatch F\CHOLMOD.Dense(ones(elty, 4))
     @test_throws DimensionMismatch F\CHOLMOD.Sparse(sparse(ones(elty, 4)))
-    @test F'\ones(elty, 5) ≈ full(A1pd)'\ones(5)
-    @test F'\sparse(ones(elty, 5)) ≈ full(A1pd)'\ones(5)
-    @test logdet(F) ≈ logdet(full(A1pd))
+    @test F'\ones(elty, 5) ≈ convert(Array, A1pd)'\ones(5)
+    @test F'\sparse(ones(elty, 5)) ≈ convert(Array, A1pd)'\ones(5)
+    @test logdet(F) ≈ logdet(convert(Array, A1pd))
     @test det(F) == exp(logdet(F))
     let # to test supernodal, we must use a larger matrix
         Ftmp = sprandn(100,100,0.1)
         Ftmp = Ftmp'Ftmp + I
-        @test logdet(cholfact(Ftmp)) ≈ logdet(full(Ftmp))
+        @test logdet(cholfact(Ftmp)) ≈ logdet(convert(Array, Ftmp))
     end
-    @test logdet(ldltfact(A1pd)) ≈ logdet(full(A1pd))
+    @test logdet(ldltfact(A1pd)) ≈ logdet(convert(Array, A1pd))
     @test isposdef(A1pd)
     @test !isposdef(A1)
-    @test !isposdef(A1 + A1' |> t -> t - 2eigmax(full(t))*I)
+    @test !isposdef(A1 + A1' |> t -> t - 2eigmax(convert(Array, t))*I)
 
     if elty <: Real
         @test CHOLMOD.issymmetric(Sparse(A1pd, 0))

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -7,7 +7,7 @@ using Base.Test
 @test Base.SparseArrays.indtype(sparse(ones(Int8,2),ones(Int8,2),rand(2))) == Int8
 
 # check sparse matrix construction
-@test isequal(full(sparse(complex(ones(5,5),ones(5,5)))), complex(ones(5,5),ones(5,5)))
+@test isequal(convert(Array, sparse(complex(ones(5,5),ones(5,5)))), complex(ones(5,5),ones(5,5)))
 @test_throws ArgumentError sparse([1,2,3], [1,2], [1,2,3], 3, 3)
 @test_throws ArgumentError sparse([1,2,3], [1,2,3], [1,2], 3, 3)
 @test_throws ArgumentError sparse([1,2,3], [1,2,3], [1,2,3], 0, 1)
@@ -22,8 +22,8 @@ do33 = ones(3)
 @test isequal(se33 * se33, se33)
 
 # check sparse binary op
-@test all(full(se33 + convert(SparseMatrixCSC{Float32,Int32}, se33)) == 2*eye(3))
-@test all(full(se33 * convert(SparseMatrixCSC{Float32,Int32}, se33)) == eye(3))
+@test all(convert(Array, se33 + convert(SparseMatrixCSC{Float32,Int32}, se33)) == 2*eye(3))
+@test all(convert(Array, se33 * convert(SparseMatrixCSC{Float32,Int32}, se33)) == eye(3))
 
 # check horiz concatenation
 @test all([se33 se33] == sparse([1, 2, 3, 1, 2, 3], [1, 2, 3, 4, 5, 6], ones(6)))
@@ -52,7 +52,7 @@ se33_i32 = speye(Int32, 3, 3)
 # check mixed sparse-dense concatenation
 sz33 = spzeros(3, 3)
 de33 = eye(3)
-@test  all([se33 de33; sz33 se33] == full([se33 se33; sz33 se33 ]))
+@test  all([se33 de33; sz33 se33] == convert(Array, [se33 se33; sz33 se33 ]))
 
 # check splicing + concatenation on
 # random instances, with nested vcat
@@ -66,9 +66,9 @@ end
 a116 = copy(reshape(1:16, 4, 4))
 s116 = sparse(a116)
 p = [4, 1, 2, 3, 2]
-@test full(s116[p,:]) == a116[p,:]
-@test full(s116[:,p]) == a116[:,p]
-@test full(s116[p,p]) == a116[p,p]
+@test convert(Array, s116[p,:]) == a116[p,:]
+@test convert(Array, s116[:,p]) == a116[:,p]
+@test convert(Array, s116[p,p]) == a116[p,p]
 
 # sparse assign
 p = [4, 1, 3]
@@ -97,16 +97,16 @@ end
 for i = 1:5
     a = sprand(10, 5, 0.5)
     b = rand(5)
-    @test maximum(abs(a*b - full(a)*b)) < 100*eps()
+    @test maximum(abs(a*b - convert(Array, a)*b)) < 100*eps()
 end
 
 # sparse matrix * BitArray
 A = sprand(5,5,0.2)
 B = trues(5)
-@test A*B ≈ full(A)*B
+@test A*B ≈ convert(Array, A)*B
 B = trues(5,5)
-@test A*B ≈ full(A)*B
-@test B*A ≈ B*full(A)
+@test A*B ≈ convert(Array, A)*B
+@test B*A ≈ B*convert(Array, A)
 
 # complex matrix-vector multiplication and left-division
 if Base.USE_GPL_LIBS
@@ -117,91 +117,91 @@ for i = 1:5
     d = randn(5) + im*randn(5)
     α = rand(Complex128)
     β = rand(Complex128)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(A_mul_B!(similar(b), a, b) - full(a)*b)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
-    @test (maximum(abs(A_mul_B!(similar(c), a, c) - full(a)*c)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
-    @test (maximum(abs((a'*c + d) - (full(a)'*c + d))) < 1000*eps())
-    @test (maximum(abs((α*a.'*c + β*d) - (α*full(a).'*c + β*d))) < 1000*eps())
-    @test (maximum(abs((a.'*c + d) - (full(a).'*c + d))) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(A_mul_B!(similar(b), a, b) - convert(Array, a)*b)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
+    @test (maximum(abs(A_mul_B!(similar(c), a, c) - convert(Array, a)*c)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
+    @test (maximum(abs((a'*c + d) - (convert(Array, a)'*c + d))) < 1000*eps())
+    @test (maximum(abs((α*a.'*c + β*d) - (α*convert(Array, a).'*c + β*d))) < 1000*eps())
+    @test (maximum(abs((a.'*c + d) - (convert(Array, a).'*c + d))) < 1000*eps())
     c = randn(6) + im*randn(6)
     @test_throws DimensionMismatch α*a.'*c + β*c
     @test_throws DimensionMismatch α*a.'*ones(5) + β*c
 
     a = speye(5) + 0.1*sprandn(5, 5, 0.2) + 0.1*im*sprandn(5, 5, 0.2)
     b = randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 
     a = speye(5) + tril(0.1*sprandn(5, 5, 0.2))
     b = randn(5,3) + im*randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 
     a = speye(5) + tril(0.1*sprandn(5, 5, 0.2) + 0.1*im*sprandn(5, 5, 0.2))
     b = randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 
     a = speye(5) + triu(0.1*sprandn(5, 5, 0.2))
     b = randn(5,3) + im*randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 
     a = speye(5) + triu(0.1*sprandn(5, 5, 0.2) + 0.1*im*sprandn(5, 5, 0.2))
     b = randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 
     a = speye(5) + triu(0.1*sprandn(5, 5, 0.2))
     b = randn(5,3) + im*randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 
     a = spdiagm(randn(5)) + im*spdiagm(randn(5))
     b = randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 
     b = randn(5,3) + im*randn(5,3)
-    @test (maximum(abs(a*b - full(a)*b)) < 100*eps())
-    @test (maximum(abs(a'b - full(a)'b)) < 100*eps())
-    @test (maximum(abs(a.'b - full(a).'b)) < 100*eps())
-    @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
-    @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
-    @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+    @test (maximum(abs(a*b - convert(Array, a)*b)) < 100*eps())
+    @test (maximum(abs(a'b - convert(Array, a)'b)) < 100*eps())
+    @test (maximum(abs(a.'b - convert(Array, a).'b)) < 100*eps())
+    @test (maximum(abs(a\b - convert(Array, a)\b)) < 1000*eps())
+    @test (maximum(abs(a'\b - convert(Array, a')\b)) < 1000*eps())
+    @test (maximum(abs(a.'\b - convert(Array, a.')\b)) < 1000*eps())
 end
 end
 
@@ -209,24 +209,24 @@ end
 for i = 1:5
     a = sprand(10, 5, 0.7)
     b = sprand(5, 15, 0.3)
-    @test maximum(abs(a*b - full(a)*full(b))) < 100*eps()
-    @test maximum(abs(Base.SparseArrays.spmatmul(a,b,sortindices=:sortcols) - full(a)*full(b))) < 100*eps()
-    @test maximum(abs(Base.SparseArrays.spmatmul(a,b,sortindices=:doubletranspose) - full(a)*full(b))) < 100*eps()
-    @test full(kron(a,b)) == kron(full(a), full(b))
-    @test full(kron(full(a),b)) == kron(full(a), full(b))
-    @test full(kron(a,full(b))) == kron(full(a), full(b))
+    @test maximum(abs(a*b - convert(Array, a)*convert(Array, b))) < 100*eps()
+    @test maximum(abs(Base.SparseArrays.spmatmul(a,b,sortindices=:sortcols) - convert(Array, a)*convert(Array, b))) < 100*eps()
+    @test maximum(abs(Base.SparseArrays.spmatmul(a,b,sortindices=:doubletranspose) - convert(Array, a)*convert(Array, b))) < 100*eps()
+    @test convert(Array, kron(a,b)) == kron(convert(Array, a), convert(Array, b))
+    @test convert(Array, kron(convert(Array, a),b)) == kron(convert(Array, a), convert(Array, b))
+    @test convert(Array, kron(a,convert(Array, b))) == kron(convert(Array, a), convert(Array, b))
     c = sparse(rand(Float32,5,5))
     d = sparse(rand(Float64,5,5))
-    @test full(kron(c,d)) == kron(full(c),full(d))
+    @test convert(Array, kron(c,d)) == kron(convert(Array, c),convert(Array, d))
     f = Diagonal(rand(5))
-    @test full(a*f) == full(a)*f
-    @test full(f*b) == f*full(b)
+    @test convert(Array, a*f) == convert(Array, a)*f
+    @test convert(Array, f*b) == f*convert(Array, b)
 end
 
 # scale and scale!
 sA = sprandn(3, 7, 0.5)
 sC = similar(sA)
-dA = full(sA)
+dA = convert(Array, sA)
 b = randn(7)
 @test dA * Diagonal(b) == sA * Diagonal(b)
 @test dA * Diagonal(b) == scale!(sC, sA, b)
@@ -286,7 +286,7 @@ end
 
 # conj
 cA = sprandn(5,5,0.2) + im*sprandn(5,5,0.2)
-@test full(conj(cA)) == conj(full(cA))
+@test convert(Array, conj(cA)) == conj(convert(Array, cA))
 
 # Test SparseMatrixCSC [c]transpose[!] and permute[!] methods
 let smalldim = 5, largedim = 10, nzprob = 0.4
@@ -326,19 +326,19 @@ let smalldim = 5, largedim = 10, nzprob = 0.4
         A = sprand(m, n, nzprob)
         At = transpose(A)
         # transpose[!]
-        fullAt = transpose(full(A))
+        fullAt = transpose(convert(Array, A))
         @test transpose(A) == fullAt
         @test transpose!(similar(At), A) == fullAt
         # ctranspose[!]
         C = A + im*A/2
-        fullCh = ctranspose(full(C))
+        fullCh = ctranspose(convert(Array, C))
         @test ctranspose(C) == fullCh
         @test ctranspose!(similar(sparse(fullCh)), C) == fullCh
         # permute[!]
         p = randperm(m)
         q = randperm(n)
-        fullPAQ = full(A)[p,q]
-        @test permute(A, p, q) == sparse(full(A[p,q]))
+        fullPAQ = convert(Array, A)[p,q]
+        @test permute(A, p, q) == sparse(convert(Array, A[p,q]))
         @test permute!(similar(A), A, p, q) == fullPAQ
         @test permute!(similar(A), A, p, q, similar(At)) == fullPAQ
         @test permute!(copy(A), p, q) == fullPAQ
@@ -349,19 +349,19 @@ end
 
 # transpose of SubArrays
 A = view(sprandn(10, 10, 0.3), 1:4, 1:4)
-@test  transpose(full(A)) == full(transpose(A))
-@test ctranspose(full(A)) == full(ctranspose(A))
+@test  transpose(convert(Array, A)) == convert(Array, transpose(A))
+@test ctranspose(convert(Array, A)) == convert(Array, ctranspose(A))
 
 # exp
 A = sprandn(5,5,0.2)
-@test e.^A ≈ e.^full(A)
+@test e.^A ≈ e.^convert(Array, A)
 
 # reductions
 pA = sparse(rand(3, 7))
 
 for arr in (se33, sA, pA)
     for f in (sum, prod, minimum, maximum, var)
-        farr = full(arr)
+        farr = convert(Array, arr)
         @test f(arr) ≈ f(farr)
         @test f(arr, 1) ≈ f(farr, 1)
         @test f(arr, 2) ≈ f(farr, 2)
@@ -399,7 +399,7 @@ for f in (sum, prod, minimum, maximum, var)
 end
 
 # spdiagm
-@test full(spdiagm((ones(2), ones(2)), (0, -1), 3, 3)) ==
+@test convert(Array, spdiagm((ones(2), ones(2)), (0, -1), 3, 3)) ==
                        [1.0  0.0  0.0; 1.0  1.0  0.0;  0.0  1.0  0.0]
 
 # issue #4986, reinterpret
@@ -417,7 +417,7 @@ K,J,V = findnz(SparseMatrixCSC(2,1,[1,3],[1,2],[1.0,0.0]))
 
 # https://groups.google.com/d/msg/julia-users/Yq4dh8NOWBQ/GU57L90FZ3EJ
 A = speye(Bool, 5)
-@test find(A) == find(x -> x == true, A) == find(full(A))
+@test find(A) == find(x -> x == true, A) == find(convert(Array, A))
 
 
 # issue #5824
@@ -463,16 +463,16 @@ end
 
 # Unary functions
 a = sprand(5,15, 0.5)
-afull = full(a)
+afull = convert(Array, a)
 for op in (:sin, :cos, :tan, :ceil, :floor, :abs, :abs2)
     @eval begin
-        @test ($op)(afull) == full($(op)(a))
+        @test ($op)(afull) == convert(Array, $(op)(a))
     end
 end
 
 for op in (:ceil, :floor)
     @eval begin
-        @test ($op)(Int,afull) == full($(op)(Int,a))
+        @test ($op)(Int,afull) == convert(Array, $(op)(Int,a))
     end
 end
 
@@ -499,42 +499,42 @@ for (aa116, ss116) in [(a116, s116), (ad116, sd116)]
     @test ss116[:,:] == copy(ss116)
 
     # range indexing
-    @test full(ss116[i,:]) == aa116[i,:]
-    @test full(ss116[:,j]) == aa116[:,j]
-    @test full(ss116[i,1:2:end]) == aa116[i,1:2:end]
-    @test full(ss116[1:2:end,j]) == aa116[1:2:end,j]
-    @test full(ss116[i,end:-2:1]) == aa116[i,end:-2:1]
-    @test full(ss116[end:-2:1,j]) == aa116[end:-2:1,j]
+    @test convert(Array, ss116[i,:]) == aa116[i,:]
+    @test convert(Array, ss116[:,j]) == aa116[:,j]
+    @test convert(Array, ss116[i,1:2:end]) == aa116[i,1:2:end]
+    @test convert(Array, ss116[1:2:end,j]) == aa116[1:2:end,j]
+    @test convert(Array, ss116[i,end:-2:1]) == aa116[i,end:-2:1]
+    @test convert(Array, ss116[end:-2:1,j]) == aa116[end:-2:1,j]
     # float-range indexing is not supported
 
     # sorted vector indexing
-    @test full(ss116[i,[3:2:end-3;]]) == aa116[i,[3:2:end-3;]]
-    @test full(ss116[[3:2:end-3;],j]) == aa116[[3:2:end-3;],j]
-    @test full(ss116[i,[end-3:-2:1;]]) == aa116[i,[end-3:-2:1;]]
-    @test full(ss116[[end-3:-2:1;],j]) == aa116[[end-3:-2:1;],j]
+    @test convert(Array, ss116[i,[3:2:end-3;]]) == aa116[i,[3:2:end-3;]]
+    @test convert(Array, ss116[[3:2:end-3;],j]) == aa116[[3:2:end-3;],j]
+    @test convert(Array, ss116[i,[end-3:-2:1;]]) == aa116[i,[end-3:-2:1;]]
+    @test convert(Array, ss116[[end-3:-2:1;],j]) == aa116[[end-3:-2:1;],j]
 
     # unsorted vector indexing with repetition
     p = [4, 1, 2, 3, 2, 6]
-    @test full(ss116[p,:]) == aa116[p,:]
-    @test full(ss116[:,p]) == aa116[:,p]
-    @test full(ss116[p,p]) == aa116[p,p]
+    @test convert(Array, ss116[p,:]) == aa116[p,:]
+    @test convert(Array, ss116[:,p]) == aa116[:,p]
+    @test convert(Array, ss116[p,p]) == aa116[p,p]
 
     # bool indexing
     li = bitrand(size(aa116,1))
     lj = bitrand(size(aa116,2))
-    @test full(ss116[li,j]) == aa116[li,j]
-    @test full(ss116[li,:]) == aa116[li,:]
-    @test full(ss116[i,lj]) == aa116[i,lj]
-    @test full(ss116[:,lj]) == aa116[:,lj]
-    @test full(ss116[li,lj]) == aa116[li,lj]
+    @test convert(Array, ss116[li,j]) == aa116[li,j]
+    @test convert(Array, ss116[li,:]) == aa116[li,:]
+    @test convert(Array, ss116[i,lj]) == aa116[i,lj]
+    @test convert(Array, ss116[:,lj]) == aa116[:,lj]
+    @test convert(Array, ss116[li,lj]) == aa116[li,lj]
 
     # empty indices
     for empty in (1:0, Int[])
-        @test full(ss116[empty,:]) == aa116[empty,:]
-        @test full(ss116[:,empty]) == aa116[:,empty]
-        @test full(ss116[empty,lj]) == aa116[empty,lj]
-        @test full(ss116[li,empty]) == aa116[li,empty]
-        @test full(ss116[empty,empty]) == aa116[empty,empty]
+        @test convert(Array, ss116[empty,:]) == aa116[empty,:]
+        @test convert(Array, ss116[:,empty]) == aa116[:,empty]
+        @test convert(Array, ss116[empty,lj]) == aa116[empty,lj]
+        @test convert(Array, ss116[li,empty]) == aa116[li,empty]
+        @test convert(Array, ss116[empty,empty]) == aa116[empty,empty]
     end
 
     # out of bounds indexing
@@ -564,7 +564,7 @@ S1290 = SparseMatrixCSC(3, 3, UInt8[1,1,1,1], UInt8[], Int64[])
     S1290[end] = 3
     @test S1290[end] == (S1290[1] + S1290[2,2])
     @test 6 == sum(diag(S1290))
-    @test full(S1290)[[3,1],1] == full(S1290[[3,1],1])
+    @test convert(Array, S1290)[[3,1],1] == convert(Array, S1290[[3,1],1])
 # end
 
 
@@ -659,8 +659,8 @@ let A = speye(Int, 5), I=1:10, X=reshape([trues(10); falses(15)],5,5)
 end
 
 let S = sprand(50, 30, 0.5, x->round(Int,rand(x)*100)), I = sprand(Bool, 50, 30, 0.2)
-    FS = full(S)
-    FI = full(I)
+    FS = convert(Array, S)
+    FI = convert(Array, I)
     @test sparse(FS[FI]) == S[I] == S[FI]
     @test sum(S[FI]) + sum(S[!FI]) == sum(S)
 
@@ -724,7 +724,7 @@ let A = sprand(5,5,0.5,(n)->rand(Float64,n)), ACPY = copy(A)
 end
 
 # indmax, indmin, findmax, findmin
-let S = sprand(100,80, 0.5), A = full(S)
+let S = sprand(100,80, 0.5), A = convert(Array, S)
     @test indmax(S) == indmax(A)
     @test indmin(S) == indmin(A)
     @test findmin(S) == findmin(A)
@@ -734,7 +734,7 @@ let S = sprand(100,80, 0.5), A = full(S)
     end
 end
 
-let S = spzeros(10,8), A = full(S)
+let S = spzeros(10,8), A = convert(Array, S)
     @test indmax(S) == indmax(A) == 1
     @test indmin(S) == indmin(A) == 1
 end
@@ -915,7 +915,7 @@ end
 
 # issue #9917
 @test sparse([]') == reshape(sparse([]), 1, 0)
-@test full(sparse([])) == zeros(0)
+@test convert(Array, sparse([])) == zeros(0)
 @test_throws BoundsError sparse([])[1]
 @test_throws BoundsError sparse([])[1] = 1
 x = speye(100)
@@ -949,22 +949,22 @@ end
 # test sparse constructors from special matrices
 T = Tridiagonal(randn(4),randn(5),randn(4))
 S = sparse(T)
-@test norm(full(T) - full(S)) == 0.0
+@test norm(convert(Array, T) - convert(Array, S)) == 0.0
 T = SymTridiagonal(randn(5),rand(4))
 S = sparse(T)
-@test norm(full(T) - full(S)) == 0.0
+@test norm(convert(Array, T) - convert(Array, S)) == 0.0
 B = Bidiagonal(randn(5),randn(4),true)
 S = sparse(B)
-@test norm(full(B) - full(S)) == 0.0
+@test norm(convert(Array, B) - convert(Array, S)) == 0.0
 B = Bidiagonal(randn(5),randn(4),false)
 S = sparse(B)
-@test norm(full(B) - full(S)) == 0.0
+@test norm(convert(Array, B) - convert(Array, S)) == 0.0
 
 # promotion in spdiagm
 @test spdiagm(([1,2],[3.5],[4+5im]), (0,1,-1), 2,2) == [1 3.5; 4+5im 2]
 
 #Test broadcasting of sparse matrixes
-let  A = sprand(10,10,0.3), B = sprand(10,10,0.3), CF = rand(10,10), AF = full(A), BF = full(B), C = sparse(CF)
+let  A = sprand(10,10,0.3), B = sprand(10,10,0.3), CF = rand(10,10), AF = convert(Array, A), BF = convert(Array, B), C = sparse(CF)
     @test A .* B == AF .* BF
     @test A[1,:] .* B == AF[1,:] .* BF
     @test A[:,1] .* B == AF[:,1] .* BF
@@ -1056,18 +1056,18 @@ A = speye(5)
 @test size(similar(A,Complex128,Int8)) == (5,5)
 @test typeof(similar(A,Complex128,Int8)) == SparseMatrixCSC{Complex128,Int8}
 @test similar(A,Complex128,(6,6)) == spzeros(Complex128,6,6)
-@test convert(Matrix,A) == full(A)
+@test convert(Matrix,A) == convert(Array, A)
 
 # test float
 A = sprand(Bool, 5,5,0.0)
 @test eltype(float(A)) == Float64  # issue #11658
 A = sprand(Bool, 5,5,0.2)
-@test float(A) == float(full(A))
+@test float(A) == float(convert(Array, A))
 
 # test sparsevec
 A = sparse(ones(5,5))
-@test all(full(sparsevec(A)) .== ones(25))
-@test all(full(sparsevec([1:5;],1)) .== ones(5))
+@test all(convert(Array, sparsevec(A)) .== ones(25))
+@test all(convert(Array, sparsevec([1:5;],1)) .== ones(5))
 @test_throws ArgumentError sparsevec([1:5;], [1:4;])
 
 #test sparse
@@ -1145,11 +1145,11 @@ end
 
 # triu/tril
 A = sprand(5,5,0.2)
-AF = full(A)
-@test full(triu(A,1)) == triu(AF,1)
-@test full(tril(A,1)) == tril(AF,1)
-@test full(triu!(copy(A), 2)) == triu(AF,2)
-@test full(tril!(copy(A), 2)) == tril(AF,2)
+AF = convert(Array, A)
+@test convert(Array, triu(A,1)) == triu(AF,1)
+@test convert(Array, tril(A,1)) == tril(AF,1)
+@test convert(Array, triu!(copy(A), 2)) == triu(AF,2)
+@test convert(Array, tril!(copy(A), 2)) == tril(AF,2)
 @test_throws BoundsError tril(A,6)
 @test_throws BoundsError tril(A,-6)
 @test_throws BoundsError triu(A,6)
@@ -1257,10 +1257,10 @@ nonzeros(A1)[2:5]=0
 
 # UniformScaling
 A = sprandn(10,10,0.5)
-@test A + I == full(A) + I
-@test I + A == I + full(A)
-@test A - I == full(A) - I
-@test I - A == I - full(A)
+@test A + I == convert(Array, A) + I
+@test I + A == I + convert(Array, A)
+@test A - I == convert(Array, A) - I
+@test I - A == I - convert(Array, A)
 
 # Test error path if triplet vectors are not all the same length (#12177)
 @test_throws ArgumentError sparse([1,2,3], [1,2], [1,2,3], 3, 3)
@@ -1288,15 +1288,15 @@ end
 Ac = sprandn(10,10,.1) + im* sprandn(10,10,.1)
 Ar = sprandn(10,10,.1)
 Ai = ceil(Int,Ar*100)
-@test norm(Ac,1) ≈ norm(full(Ac),1)
-@test norm(Ac,Inf) ≈ norm(full(Ac),Inf)
-@test vecnorm(Ac) ≈ vecnorm(full(Ac))
-@test norm(Ar,1) ≈ norm(full(Ar),1)
-@test norm(Ar,Inf) ≈ norm(full(Ar),Inf)
-@test vecnorm(Ar) ≈ vecnorm(full(Ar))
-@test norm(Ai,1) ≈ norm(full(Ai),1)
-@test norm(Ai,Inf) ≈ norm(full(Ai),Inf)
-@test vecnorm(Ai) ≈ vecnorm(full(Ai))
+@test norm(Ac,1) ≈ norm(convert(Array, Ac),1)
+@test norm(Ac,Inf) ≈ norm(convert(Array, Ac),Inf)
+@test vecnorm(Ac) ≈ vecnorm(convert(Array, Ac))
+@test norm(Ar,1) ≈ norm(convert(Array, Ar),1)
+@test norm(Ar,Inf) ≈ norm(convert(Array, Ar),Inf)
+@test vecnorm(Ar) ≈ vecnorm(convert(Array, Ar))
+@test norm(Ai,1) ≈ norm(convert(Array, Ai),1)
+@test norm(Ai,Inf) ≈ norm(convert(Array, Ai),Inf)
+@test vecnorm(Ai) ≈ vecnorm(convert(Array, Ai))
 
 # test sparse matrix cond
 A = sparse(reshape([1.0],1,1))
@@ -1305,10 +1305,10 @@ Ar = sprandn(20,20,.5)
 @test cond(A,1) == 1.0
 # For a discussion of the tolerance, see #14778
 if Base.USE_GPL_LIBS
-    @test 0.99 <= cond(Ar, 1) \ norm(Ar, 1) * norm(inv(full(Ar)), 1) < 3
-    @test 0.99 <= cond(Ac, 1) \ norm(Ac, 1) * norm(inv(full(Ac)), 1) < 3
-    @test 0.99 <= cond(Ar, Inf) \ norm(Ar, Inf) * norm(inv(full(Ar)), Inf) < 3
-    @test 0.99 <= cond(Ac, Inf) \ norm(Ac, Inf) * norm(inv(full(Ac)), Inf) < 3
+    @test 0.99 <= cond(Ar, 1) \ norm(Ar, 1) * norm(inv(convert(Array, Ar)), 1) < 3
+    @test 0.99 <= cond(Ac, 1) \ norm(Ac, 1) * norm(inv(convert(Array, Ac)), 1) < 3
+    @test 0.99 <= cond(Ar, Inf) \ norm(Ar, Inf) * norm(inv(convert(Array, Ar)), Inf) < 3
+    @test 0.99 <= cond(Ac, Inf) \ norm(Ac, Inf) * norm(inv(convert(Array, Ac)), Inf) < 3
 end
 @test_throws ArgumentError cond(A,2)
 @test_throws ArgumentError cond(A,3)
@@ -1324,9 +1324,9 @@ Aci = ceil(Int64,100*sprand(20,20,.5))+ im*ceil(Int64,sprand(20,20,.5))
 Ar = sprandn(20,20,.5)
 Ari = ceil(Int64,100*Ar)
 if Base.USE_GPL_LIBS
-    @test_approx_eq_eps Base.SparseArrays.normestinv(Ac,3) norm(inv(full(Ac)),1) 1e-4
-    @test_approx_eq_eps Base.SparseArrays.normestinv(Aci,3) norm(inv(full(Aci)),1) 1e-4
-    @test_approx_eq_eps Base.SparseArrays.normestinv(Ar) norm(inv(full(Ar)),1) 1e-4
+    @test_approx_eq_eps Base.SparseArrays.normestinv(Ac,3) norm(inv(convert(Array, Ac)),1) 1e-4
+    @test_approx_eq_eps Base.SparseArrays.normestinv(Aci,3) norm(inv(convert(Array, Aci)),1) 1e-4
+    @test_approx_eq_eps Base.SparseArrays.normestinv(Ar) norm(inv(convert(Array, Ar)),1) 1e-4
     @test_throws ArgumentError Base.SparseArrays.normestinv(Ac,0)
     @test_throws ArgumentError Base.SparseArrays.normestinv(Ac,21)
 end
@@ -1357,32 +1357,32 @@ let
     @test typeof(min(A13024, B13024)) == SparseMatrixCSC{Bool,Int}
 
     for op in (+, -, &, |, $, max, min)
-        @test op(A13024, B13024) == op(full(A13024), full(B13024))
+        @test op(A13024, B13024) == op(convert(Array, A13024), convert(Array, B13024))
     end
 end
 
 let A = 2. * speye(5,5)
-    @test full(spones(A)) == eye(full(A))
+    @test convert(Array, spones(A)) == eye(convert(Array, A))
 end
 
 let
     A = spdiagm(rand(5)) + sprandn(5,5,0.2) + im*sprandn(5,5,0.2)
     A = A + A'
-    @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(full(A))))
+    @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(convert(Array, A))))
     A = spdiagm(rand(5)) + sprandn(5,5,0.2) + im*sprandn(5,5,0.2)
     A = A*A'
-    @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(full(A))))
+    @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(convert(Array, A))))
     A = spdiagm(rand(5)) + sprandn(5,5,0.2)
     A = A + A.'
-    @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(full(A))))
+    @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(convert(Array, A))))
     A = spdiagm(rand(5)) + sprandn(5,5,0.2)
     A = A*A.'
-    @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(full(A))))
+    @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(convert(Array, A))))
     @test factorize(triu(A)) == triu(A)
     @test isa(factorize(triu(A)), UpperTriangular{Float64, SparseMatrixCSC{Float64, Int}})
     @test factorize(tril(A)) == tril(A)
     @test isa(factorize(tril(A)), LowerTriangular{Float64, SparseMatrixCSC{Float64, Int}})
-    @test !Base.USE_GPL_LIBS || factorize(A[:,1:4])\ones(size(A,1)) ≈ full(A[:,1:4])\ones(size(A,1))
+    @test !Base.USE_GPL_LIBS || factorize(A[:,1:4])\ones(size(A,1)) ≈ convert(Array, A[:,1:4])\ones(size(A,1))
     @test_throws ErrorException chol(A)
     @test_throws ErrorException lu(A)
     @test_throws ErrorException eig(A)
@@ -1414,12 +1414,12 @@ let
     @test issparse(LinAlg.UnitLowerTriangular(m))
     @test issparse(UpperTriangular(m))
     @test issparse(LinAlg.UnitUpperTriangular(m))
-    @test issparse(Symmetric(full(m))) == false
-    @test issparse(Hermitian(full(m))) == false
-    @test issparse(LowerTriangular(full(m))) == false
-    @test issparse(LinAlg.UnitLowerTriangular(full(m))) == false
-    @test issparse(UpperTriangular(full(m))) == false
-    @test issparse(LinAlg.UnitUpperTriangular(full(m))) == false
+    @test issparse(Symmetric(convert(Array, m))) == false
+    @test issparse(Hermitian(convert(Array, m))) == false
+    @test issparse(LowerTriangular(convert(Array, m))) == false
+    @test issparse(LinAlg.UnitLowerTriangular(convert(Array, m))) == false
+    @test issparse(UpperTriangular(convert(Array, m))) == false
+    @test issparse(LinAlg.UnitUpperTriangular(convert(Array, m))) == false
 end
 
 let

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -26,11 +26,11 @@ let x = spv_x1
     @test nonzeros(x) == [1.25, -0.75, 3.5]
 end
 
-# full
+# convert(Array, _)
 
 for (x, xf) in [(spv_x1, x1_full)]
-    @test isa(full(x), Vector{Float64})
-    @test full(x) == xf
+    @test isa(convert(Array, x), Vector{Float64})
+    @test convert(Array, x) == xf
 end
 
 ### Show
@@ -173,7 +173,7 @@ let x = sprand(100, 0.5)
     r = x[I]
     @test isa(r, SparseVector{Float64,Int})
     @test all(nonzeros(r) .!= 0.0)
-    @test full(r) == full(x)[I]
+    @test convert(Array, r) == convert(Array, x)[I]
 end
 
 # setindex
@@ -354,11 +354,11 @@ let x = spv_x1, xf = x1_full
 
     xm = convert(SparseMatrixCSC, x)
     @test isa(xm, SparseMatrixCSC{Float64,Int})
-    @test full(xm) == reshape(xf, 8, 1)
+    @test convert(Array, xm) == reshape(xf, 8, 1)
 
     xm = convert(SparseMatrixCSC{Float32}, x)
     @test isa(xm, SparseMatrixCSC{Float32,Int})
-    @test full(xm) == reshape(convert(Vector{Float32}, xf), 8, 1)
+    @test convert(Array, xm) == reshape(convert(Vector{Float32}, xf), 8, 1)
 end
 
 
@@ -378,22 +378,22 @@ let m = 80, n = 100
     @test nnz(H) == tnnz
     Hr = zeros(m, n)
     for j = 1:n
-        Hr[:,j] = full(A[j])
+        Hr[:,j] = convert(Array, A[j])
     end
-    @test full(H) == Hr
+    @test convert(Array, H) == Hr
 
     V = vcat(A...)
     @test isa(V, SparseVector{Float64,Int})
     @test length(V) == m * n
     Vr = vec(Hr)
-    @test full(V) == Vr
+    @test convert(Array, V) == Vr
 end
 
 
 ## sparsemat: combinations with sparse matrix
 
 let S = sprand(4, 8, 0.5)
-    Sf = full(S)
+    Sf = convert(Array, S)
     @assert isa(Sf, Matrix{Float64})
 
     # get a single column
@@ -401,84 +401,84 @@ let S = sprand(4, 8, 0.5)
         col = S[:, j]
         @test isa(col, SparseVector{Float64,Int})
         @test length(col) == size(S,1)
-        @test full(col) == Sf[:,j]
+        @test convert(Array, col) == Sf[:,j]
     end
 
     # Get a reshaped vector
     v = S[:]
     @test isa(v, SparseVector{Float64,Int})
     @test length(v) == length(S)
-    @test full(v) == Sf[:]
+    @test convert(Array, v) == Sf[:]
 
     # Get a linear subset
     for i=0:length(S)
         v = S[1:i]
         @test isa(v, SparseVector{Float64,Int})
         @test length(v) == i
-        @test full(v) == Sf[1:i]
+        @test convert(Array, v) == Sf[1:i]
     end
     for i=1:length(S)+1
         v = S[i:end]
         @test isa(v, SparseVector{Float64,Int})
         @test length(v) == length(S) - i + 1
-        @test full(v) == Sf[i:end]
+        @test convert(Array, v) == Sf[i:end]
     end
     for i=0:div(length(S),2)
         v = S[1+i:end-i]
         @test isa(v, SparseVector{Float64,Int})
         @test length(v) == length(S) - 2i
-        @test full(v) == Sf[1+i:end-i]
+        @test convert(Array, v) == Sf[1+i:end-i]
     end
 end
 
 let r = [1,10], S = sparse(r, r, r)
-    Sf = full(S)
+    Sf = convert(Array, S)
     @assert isa(Sf, Matrix{Int})
 
     inds = [1,1,1,1,1,1]
     v = S[inds]
     @test isa(v, SparseVector{Int,Int})
     @test length(v) == length(inds)
-    @test full(v) == Sf[inds]
+    @test convert(Array, v) == Sf[inds]
 
     inds = [2,2,2,2,2,2]
     v = S[inds]
     @test isa(v, SparseVector{Int,Int})
     @test length(v) == length(inds)
-    @test full(v) == Sf[inds]
+    @test convert(Array, v) == Sf[inds]
 
     # get a single column
     for j = 1:size(S,2)
         col = S[:, j]
         @test isa(col, SparseVector{Int,Int})
         @test length(col) == size(S,1)
-        @test full(col) == Sf[:,j]
+        @test convert(Array, col) == Sf[:,j]
     end
 
     # Get a reshaped vector
     v = S[:]
     @test isa(v, SparseVector{Int,Int})
     @test length(v) == length(S)
-    @test full(v) == Sf[:]
+    @test convert(Array, v) == Sf[:]
 
     # Get a linear subset
     for i=0:length(S)
         v = S[1:i]
         @test isa(v, SparseVector{Int,Int})
         @test length(v) == i
-        @test full(v) == Sf[1:i]
+        @test convert(Array, v) == Sf[1:i]
     end
     for i=1:length(S)+1
         v = S[i:end]
         @test isa(v, SparseVector{Int,Int})
         @test length(v) == length(S) - i + 1
-        @test full(v) == Sf[i:end]
+        @test convert(Array, v) == Sf[i:end]
     end
     for i=0:div(length(S),2)
         v = S[1+i:end-i]
         @test isa(v, SparseVector{Int,Int})
         @test length(v) == length(S) - 2i
-        @test full(v) == Sf[1+i:end-i]
+        @test convert(Array, v) == Sf[1+i:end-i]
     end
 end
 
@@ -487,10 +487,10 @@ end
 ### Data
 
 rnd_x0 = sprand(50, 0.6)
-rnd_x0f = full(rnd_x0)
+rnd_x0f = convert(Array, rnd_x0)
 
 rnd_x1 = sprand(50, 0.7) * 4.0
-rnd_x1f = full(rnd_x1)
+rnd_x1f = convert(Array, rnd_x1)
 
 spv_x1 = SparseVector(8, [2, 5, 6], [1.25, -0.75, 3.5])
 spv_x2 = SparseVector(8, [1, 2, 6, 7], [3.25, 4.0, -5.5, -6.0])
@@ -517,10 +517,10 @@ let x = spv_x1, x2 = x2 = spv_x2
     @test exact_equal(x - x2, xb)
     @test exact_equal(x2 - x, -xb)
 
-    @test full(x) + x2 == full(xa)
-    @test full(x) - x2 == full(xb)
-    @test x + full(x2) == full(xa)
-    @test x - full(x2) == full(xb)
+    @test convert(Array, x) + x2 == convert(Array, xa)
+    @test convert(Array, x) - x2 == convert(Array, xb)
+    @test x + convert(Array, x2) == convert(Array, xa)
+    @test x - convert(Array, x2) == convert(Array, xb)
 
     # multiplies
     xm = SparseVector(8, [2, 6], [5.0, -19.25])
@@ -528,8 +528,8 @@ let x = spv_x1, x2 = x2 = spv_x2
     @test exact_equal(x .* x2, xm)
     @test exact_equal(x2 .* x, xm)
 
-    @test full(x) .* x2 == full(xm)
-    @test x .* full(x2) == full(xm)
+    @test convert(Array, x) .* x2 == convert(Array, xm)
+    @test x .* convert(Array, x2) == convert(Array, xm)
 
     # max & min
     @test exact_equal(max(x, x), x)
@@ -569,7 +569,7 @@ function check_nz2z_z2z{T}(f::Function, x::SparseVector{T}, xf::Vector{T})
     isa(r, AbstractSparseVector) || error("$f(x) is not a sparse vector.")
     eltype(r) == R || error("$f(x) results in eltype = $(eltype(r)), expect $R")
     all(r.nzval .!= 0) || error("$f(x) contains zeros in nzval.")
-    full(r) == f(xf) || error("Incorrect results found in $f(x).")
+    convert(Array, r) == f(xf) || error("Incorrect results found in $f(x).")
 end
 
 for f in [floor, ceil, trunc, round]
@@ -656,14 +656,14 @@ end
 ### BLAS Level-1
 
 let x = sprand(16, 0.5), x2 = sprand(16, 0.4)
-    xf = full(x)
-    xf2 = full(x2)
+    xf = convert(Array, x)
+    xf2 = convert(Array, x2)
 
     # axpy!
     for c in [1.0, -1.0, 2.0, -2.0]
-        y = full(x)
+        y = convert(Array, x)
         @test is(Base.axpy!(c, x2, y), y)
-        @test y == full(x2 * c + x)
+        @test y == convert(Array, x2 * c + x)
     end
 
     # scale
@@ -689,15 +689,15 @@ let x = sprand(16, 0.5), x2 = sprand(16, 0.4)
         @test dot(x2, x2) == sumabs2(x2)
         @test dot(x, x2) ≈ dv
         @test dot(x2, x) ≈ dv
-        @test dot(full(x), x2) ≈ dv
-        @test dot(x, full(x2)) ≈ dv
+        @test dot(convert(Array, x), x2) ≈ dv
+        @test dot(x, convert(Array, x2)) ≈ dv
     end
 end
 
 let x = complex(sprand(32, 0.6), sprand(32, 0.6)),
     y = complex(sprand(32, 0.6), sprand(32, 0.6))
-    xf = full(x)::Vector{Complex128}
-    yf = full(y)::Vector{Complex128}
+    xf = convert(Array, x)::Vector{Complex128}
+    yf = convert(Array, y)::Vector{Complex128}
     @test dot(x, x) ≈ dot(xf, xf)
     @test dot(x, y) ≈ dot(xf, yf)
 end
@@ -708,7 +708,7 @@ end
 ## dense A * sparse x -> dense y
 
 let A = randn(9, 16), x = sprand(16, 0.7)
-    xf = full(x)
+    xf = convert(Array, x)
     for α in [0.0, 1.0, 2.0], β in [0.0, 0.5, 1.0]
         y = rand(9)
         rr = α*A*xf + β*y
@@ -721,7 +721,7 @@ let A = randn(9, 16), x = sprand(16, 0.7)
 end
 
 let A = randn(16, 9), x = sprand(16, 0.7)
-    xf = full(x)
+    xf = convert(Array, x)
     for α in [0.0, 1.0, 2.0], β in [0.0, 0.5, 1.0]
         y = rand(9)
         rr = α*A'xf + β*y
@@ -736,8 +736,8 @@ end
 ## sparse A * sparse x -> dense y
 
 let A = sprandn(9, 16, 0.5), x = sprand(16, 0.7)
-    Af = full(A)
-    xf = full(x)
+    Af = convert(Array, A)
+    xf = convert(Array, x)
     for α in [0.0, 1.0, 2.0], β in [0.0, 0.5, 1.0]
         y = rand(9)
         rr = α*Af*xf + β*y
@@ -750,8 +750,8 @@ let A = sprandn(9, 16, 0.5), x = sprand(16, 0.7)
 end
 
 let A = sprandn(16, 9, 0.5), x = sprand(16, 0.7)
-    Af = full(A)
-    xf = full(x)
+    Af = convert(Array, A)
+    xf = convert(Array, x)
     for α in [0.0, 1.0, 2.0], β in [0.0, 0.5, 1.0]
         y = rand(9)
         rr = α*Af'xf + β*y
@@ -766,9 +766,9 @@ end
 let A = complex(sprandn(7, 8, 0.5), sprandn(7, 8, 0.5)),
     x = complex(sprandn(8, 0.6), sprandn(8, 0.6)),
     x2 = complex(sprandn(7, 0.75), sprandn(7, 0.75))
-    Af = full(A)
-    xf = full(x)
-    x2f = full(x2)
+    Af = convert(Array, A)
+    xf = convert(Array, x)
+    x2f = convert(Array, x2)
     @test SparseArrays.densemv(A, x; trans='N') ≈ Af * xf
     @test SparseArrays.densemv(A, x2; trans='T') ≈ Af.' * x2f
     @test SparseArrays.densemv(A, x2; trans='C') ≈ Af'x2f
@@ -777,39 +777,39 @@ end
 ## sparse A * sparse x -> sparse y
 
 let A = sprandn(9, 16, 0.5), x = sprand(16, 0.7), x2 = sprand(9, 0.7)
-    Af = full(A)
-    xf = full(x)
-    x2f = full(x2)
+    Af = convert(Array, A)
+    xf = convert(Array, x)
+    x2f = convert(Array, x2)
 
     y = A*x
     @test isa(y, SparseVector{Float64,Int})
     @test all(nonzeros(y) .!= 0.0)
-    @test full(y) ≈ Af * xf
+    @test convert(Array, y) ≈ Af * xf
 
     y = At_mul_B(A, x2)
     @test isa(y, SparseVector{Float64,Int})
     @test all(nonzeros(y) .!= 0.0)
-    @test full(y) ≈ Af'x2f
+    @test convert(Array, y) ≈ Af'x2f
 end
 
 let A = complex(sprandn(7, 8, 0.5), sprandn(7, 8, 0.5)),
     x = complex(sprandn(8, 0.6), sprandn(8, 0.6)),
     x2 = complex(sprandn(7, 0.75), sprandn(7, 0.75))
-    Af = full(A)
-    xf = full(x)
-    x2f = full(x2)
+    Af = convert(Array, A)
+    xf = convert(Array, x)
+    x2f = convert(Array, x2)
 
     y = A*x
     @test isa(y, SparseVector{Complex128,Int})
-    @test full(y) ≈ Af * xf
+    @test convert(Array, y) ≈ Af * xf
 
     y = At_mul_B(A, x2)
     @test isa(y, SparseVector{Complex128,Int})
-    @test full(y) ≈ Af.' * x2f
+    @test convert(Array, y) ≈ Af.' * x2f
 
     y = Ac_mul_B(A, x2)
     @test isa(y, SparseVector{Complex128,Int})
-    @test full(y) ≈ Af'x2f
+    @test convert(Array, y) ≈ Af'x2f
 end
 
 # left-division operations involving triangular matrices and sparse vectors (#14005)
@@ -950,7 +950,7 @@ end
 sv = sparse(1:10)
 sm = convert(SparseMatrixCSC, sv)
 sv[1] = 0
-@test full(sm)[2:end] == collect(2:10)
+@test convert(Array, sm)[2:end] == collect(2:10)
 
 # Ensure that sparsevec with all-zero values returns an array of zeros
 @test sparsevec([1,2,3],[0,0,0]) == [0,0,0]
@@ -976,8 +976,8 @@ s14013 = sparse([10.0 0.0 30.0; 0.0 1.0 0.0])
 a14013 = [10.0 0.0 30.0; 0.0 1.0 0.0]
 @test s14013 == a14013
 @test vec(s14013) == s14013[:] == a14013[:]
-@test full(s14013)[1,:] == s14013[1,:] == a14013[1,:] == [10.0, 0.0, 30.0]
-@test full(s14013)[2,:] == s14013[2,:] == a14013[2,:] == [0.0, 1.0, 0.0]
+@test convert(Array, s14013)[1,:] == s14013[1,:] == a14013[1,:] == [10.0, 0.0, 30.0]
+@test convert(Array, s14013)[2,:] == s14013[2,:] == a14013[2,:] == [0.0, 1.0, 0.0]
 
 # Issue 14046
 s14046 = sprand(5, 1.0)
@@ -1009,9 +1009,9 @@ for Tv in [Float32, Float64, Int64, Int32, Complex128]
             sparr = Sp(arr)
             fillval = rand(Tv)
             fill!(sparr, fillval)
-            @test full(sparr) == fillval * ones(arr)
+            @test convert(Array, sparr) == fillval * ones(arr)
             fill!(sparr, 0)
-            @test full(sparr) == zeros(arr)
+            @test convert(Array, sparr) == zeros(arr)
         end
     end
 end

--- a/test/sparsedir/spqr.jl
+++ b/test/sparsedir/spqr.jl
@@ -25,8 +25,8 @@ for eltyA in (Float64, Complex{Float64})
         end
 
         @inferred A\B
-        @test A\B[:,1] ≈ full(A)\B[:,1]
-        @test A\B ≈ full(A)\B
+        @test A\B[:,1] ≈ convert(Array, A)\B[:,1]
+        @test A\B ≈ convert(Array, A)\B
         @test_throws DimensionMismatch A\B[1:m-1,:]
         @test A[1:9,:]*(A[1:9,:]\ones(eltyB, 9)) ≈ ones(9) # Underdetermined system
 

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -23,7 +23,7 @@ for Tv in (Float64, Complex128)
         L,U,p,q,Rs = lua[:(:)]
         @test (Diagonal(Rs) * A)[p,q] ≈ L * U
 
-        det(lua) ≈ det(full(A))
+        det(lua) ≈ det(convert(Array, A))
 
         b = [8., 45., -3., 3., 19.]
         x = lua\b


### PR DESCRIPTION
Second step towards JuliaLang/LinearAlgebra.jl#231 (for a description of the overall objective and plan, see https://github.com/JuliaLang/julia/pull/17066#issuecomment-228113687). This pull request replaces all `full(X)` calls with `convert(Array, X)` and accordingly migrates tests and documentation. Thanks and best!
