### PR TITLE
Optimize finalizers

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -70,14 +70,16 @@ function finalizer(o::ANY, f::ANY)
     if isimmutable(o)
         error("objects of type ", typeof(o), " cannot be finalized")
     end
-    ccall(:jl_gc_add_finalizer, Void, (Any,Any), o, f)
+    ccall(:jl_gc_add_finalizer_th, Void, (Ptr{Void}, Any, Any),
+          Core.getptls(), o, f)
 end
 function finalizer{T}(o::T, f::Ptr{Void})
     @_inline_meta
     if isimmutable(T)
         error("objects of type ", T, " cannot be finalized")
     end
-    ccall(:jl_gc_add_ptr_finalizer, Void, (Any, Ptr{Void}), o, f)
+    ccall(:jl_gc_add_ptr_finalizer, Void, (Ptr{Void}, Any, Ptr{Void}),
+          Core.getptls(), o, f)
 end
 
 finalize(o::ANY) = ccall(:jl_finalize, Void, (Any,), o)

--- a/base/base.jl
+++ b/base/base.jl
@@ -72,6 +72,13 @@ function finalizer(o::ANY, f::ANY)
     end
     ccall(:jl_gc_add_finalizer, Void, (Any,Any), o, f)
 end
+function finalizer{T}(o::T, f::Ptr{Void})
+    @_inline_meta
+    if isimmutable(T)
+        error("objects of type ", T, " cannot be finalized")
+    end
+    ccall(:jl_gc_add_ptr_finalizer, Void, (Any, Ptr{Void}), o, f)
+end
 
 finalize(o::ANY) = ccall(:jl_finalize, Void, (Any,), o)
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -225,6 +225,9 @@ immutable String <: AbstractString
     String(d::Array{UInt8,1}) = new(d)
 end
 
+# This should always be inlined
+getptls() = ccall(:jl_get_ptls_states, Ptr{Void}, ())
+
 include(fname::String) = ccall(:jl_load_, Any, (Any,), fname)
 
 eval(e::ANY) = eval(Main, e)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1235,6 +1235,17 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         emit_signal_fence();
         return ghostValue(jl_void_type);
     }
+    if (fptr == (void(*)(void))&jl_get_ptls_states ||
+        ((!f_lib || (intptr_t)f_lib == 2) && f_name &&
+         strcmp(f_name, "jl_get_ptls_states") == 0)) {
+        assert(lrt == T_pint8);
+        assert(!isVa);
+        assert(nargt == 0);
+        JL_GC_POP();
+        return mark_or_box_ccall_result(
+            builder.CreateBitCast(ctx->ptlsStates, lrt),
+            retboxed, args[2], rt, static_rt, ctx);
+    }
     if (fptr == &jl_sigatomic_begin ||
         ((!f_lib || (intptr_t)f_lib == 2) && f_name &&
          strcmp(f_name, "jl_sigatomic_begin") == 0)) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1318,6 +1318,7 @@ static uint64_t compute_obj_symsize(const object::ObjectFile *obj, uint64_t offs
 extern "C" JL_DLLEXPORT
 const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
     std::string code;
     llvm::raw_string_ostream stream(code);
 #ifndef LLVM37
@@ -1362,7 +1363,7 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
         return (jl_value_t*)jl_pchar_to_array((char*)fptr, symsize);
     }
 
-    int8_t gc_state = jl_gc_safe_enter();
+    int8_t gc_state = jl_gc_safe_enter(ptls);
     jl_dump_asm_internal(fptr, symsize, slide,
 #ifndef USE_MCJIT
             context,
@@ -1378,7 +1379,7 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
 #ifndef LLVM37
     fstream.flush();
 #endif
-    jl_gc_safe_leave(gc_state);
+    jl_gc_safe_leave(ptls, gc_state);
 
     return jl_cstr_to_string(const_cast<char*>(stream.str().c_str()));
 }

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -172,7 +172,10 @@ static void gc_verify_track(void)
         clear_mark(GC_CLEAN);
         pre_mark();
         gc_mark_object_list(&to_finalize, 0);
-        gc_mark_object_list(&finalizer_list, 0);
+        for (int i = 0;i < jl_n_threads;i++) {
+            jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+            gc_mark_object_list(&ptls2->finalizers, 0);
+        }
         gc_mark_object_list(&finalizer_list_marked, 0);
         visit_mark_stack();
         if (lostval_parents.len == 0) {
@@ -215,7 +218,10 @@ void gc_verify(void)
     gc_verifying = 1;
     pre_mark();
     gc_mark_object_list(&to_finalize, 0);
-    gc_mark_object_list(&finalizer_list, 0);
+    for (int i = 0;i < jl_n_threads;i++) {
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+        gc_mark_object_list(&ptls2->finalizers, 0);
+    }
     gc_mark_object_list(&finalizer_list_marked, 0);
     visit_mark_stack();
     int clean_len = bits_save[GC_CLEAN].len;

--- a/src/gc.c
+++ b/src/gc.c
@@ -6,8 +6,10 @@
 extern "C" {
 #endif
 
-// Protect all access to `finalizer_list`, `finalizer_list_marked` and
-// `to_finalize`.
+// Protect all access to `finalizer_list_marked` and `to_finalize`.
+// For accessing `ptls->finalizers`, the lock is needed if a thread is
+// is going to realloc the buffer (of it's own list) or accessing the
+// list of another thread
 static jl_mutex_t finalizers_lock;
 
 /**
@@ -51,11 +53,10 @@ region_t regions[REGION_COUNT];
 bigval_t *big_objects_marked = NULL;
 
 // finalization
-// `finalizer_list` and `finalizer_list_marked` might have tagged pointers.
+// `ptls->finalizers` and `finalizer_list_marked` might have tagged pointers.
 // If an object pointer has the lowest bit set, the next pointer is an unboxed
 // c function pointer.
 // `to_finalize` should not have tagged pointers.
-arraylist_t finalizer_list;
 arraylist_t finalizer_list_marked;
 arraylist_t to_finalize;
 
@@ -70,14 +71,14 @@ NOINLINE uintptr_t gc_get_stack_ptr(void)
 static void jl_gc_wait_for_the_world(void)
 {
     for (int i = 0;i < jl_n_threads;i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
         // FIXME: The acquire load pairs with the release stores
         // in the signal handler of safepoint so we are sure that
         // all the stores on those threads are visible. However,
         // we're currently not using atomic stores in mutator threads.
         // We should either use atomic store release there too or use signals
         // to flush the memory operations on those threads.
-        while (!ptls->gc_state || !jl_atomic_load_acquire(&ptls->gc_state)) {
+        while (!ptls2->gc_state || !jl_atomic_load_acquire(&ptls2->gc_state)) {
             jl_cpu_pause(); // yield?
         }
     }
@@ -113,19 +114,21 @@ static void run_finalizer(jl_value_t *o, jl_value_t *ff)
     }
 }
 
+// if `need_sync` is true, the `list` is the `finalizers` list of another
+// thead and we need additional synchronizations
 static void finalize_object(arraylist_t *list, jl_value_t *o,
-                            arraylist_t *copied_list)
+                            arraylist_t *copied_list, int need_sync)
 {
-    for (int i = 0; i < list->len; i+=2) {
-        void *v = list->items[i];
+    // The acquire load makes sure that the first `len` objects are valid
+    size_t len = need_sync ? jl_atomic_load_acquire(&list->len) : list->len;
+    size_t oldlen = len;
+    void **items = list->items;
+    for (size_t i = 0; i < len; i += 2) {
+        void *v = items[i];
+        int move = 0;
         if (o == (jl_value_t*)gc_ptr_clear_tag(v, 1)) {
-            void *f = list->items[i + 1];
-            if (i < list->len - 2) {
-                list->items[i] = list->items[list->len-2];
-                list->items[i+1] = list->items[list->len-1];
-                i -= 2;
-            }
-            list->len -= 2;
+            void *f = items[i + 1];
+            move = 1;
             if (gc_ptr_tag(v, 1)) {
                 ((void (*)(void*))f)(o);
             }
@@ -134,6 +137,25 @@ static void finalize_object(arraylist_t *list, jl_value_t *o,
                 arraylist_push(copied_list, f);
             }
         }
+        if (move || __unlikely(!v)) {
+            if (i < len - 2) {
+                items[i] = items[len - 2];
+                items[i + 1] = items[len - 1];
+                i -= 2;
+            }
+            len -= 2;
+        }
+    }
+    if (oldlen == len)
+        return;
+    if (need_sync) {
+        if (__unlikely(jl_atomic_compare_exchange(&list->len,
+                                                  oldlen, len) != oldlen)) {
+            memset(items[len], 0, (oldlen - len) * sizeof(void*));
+        }
+    }
+    else {
+        list->len = len;
     }
 }
 
@@ -141,9 +163,10 @@ static void finalize_object(arraylist_t *list, jl_value_t *o,
 // be pointers to `jl_value_t` objects
 static void jl_gc_push_arraylist(arraylist_t *list)
 {
-    list->items[0] = (void*)(((uintptr_t)list->len - 2) << 1);
-    list->items[1] = jl_pgcstack;
-    jl_pgcstack = (jl_gcframe_t*)list->items;
+    void **items = list->items;
+    items[0] = (void*)(((uintptr_t)list->len - 2) << 1);
+    items[1] = jl_pgcstack;
+    jl_pgcstack = (jl_gcframe_t*)items;
 }
 
 // Same assumption as `jl_gc_push_arraylist`. Requires the finalizers lock
@@ -197,10 +220,13 @@ JL_DLLEXPORT void jl_gc_enable_finalizers(int on)
 
 static void schedule_all_finalizers(arraylist_t *flist)
 {
-    // Multi-thread version should steal the entire list while holding a lock.
-    for(size_t i=0; i < flist->len; i+=2) {
-        void *v = flist->items[i];
-        void *f = flist->items[i + 1];
+    void **items = flist->items;
+    size_t len = flist->len;
+    for(size_t i = 0; i < len; i+=2) {
+        void *v = items[i];
+        void *f = items[i + 1];
+        if (__unlikely(!v))
+            continue;
         if (!gc_ptr_tag(v, 1)) {
             schedule_finalization(v, f);
         }
@@ -210,41 +236,64 @@ static void schedule_all_finalizers(arraylist_t *flist)
 
 void jl_gc_run_all_finalizers(void)
 {
-    JL_LOCK_NOGC(&finalizers_lock);
-    schedule_all_finalizers(&finalizer_list);
+    for (int i = 0;i < jl_n_threads;i++) {
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+        schedule_all_finalizers(&ptls2->finalizers);
+    }
     schedule_all_finalizers(&finalizer_list_marked);
-    JL_UNLOCK_NOGC(&finalizers_lock);
     run_finalizers();
 }
 
-static void gc_add_ptr_finalizer(jl_value_t *v, void *f)
+static void gc_add_finalizer_(jl_tls_states_t *ptls, void *v, void *f)
 {
-    arraylist_push(&finalizer_list, (void*)(((uintptr_t)v) | 1));
-    arraylist_push(&finalizer_list, f);
+    int8_t gc_state = jl_gc_unsafe_enter(ptls);
+    arraylist_t *a = &ptls->finalizers;
+    size_t oldlen = jl_atomic_load_acquire(&a->len);
+    if (__unlikely(oldlen + 2 > a->max)) {
+        JL_LOCK_NOGC(&finalizers_lock);
+        arraylist_grow(a, 2);
+        a->len = oldlen;
+        JL_UNLOCK_NOGC(&finalizers_lock);
+    }
+    void **items = a->items;
+    items[oldlen] = v;
+    items[oldlen + 1] = f;
+    jl_atomic_store_release(&a->len, oldlen + 2);
+    jl_gc_unsafe_leave(ptls, gc_state);
+}
+
+STATIC_INLINE void gc_add_ptr_finalizer(jl_tls_states_t *ptls,
+                                        jl_value_t *v, void *f)
+{
+    gc_add_finalizer_(ptls, (void*)(((uintptr_t)v) | 1), f);
+}
+
+JL_DLLEXPORT void jl_gc_add_finalizer_th(jl_tls_states_t *ptls,
+                                         jl_value_t *v, jl_function_t *f)
+{
+    if (__unlikely(jl_typeis(f, jl_voidpointer_type))) {
+        gc_add_ptr_finalizer(ptls, v, jl_unbox_voidpointer(f));
+    }
+    else {
+        gc_add_finalizer_(ptls, v, f);
+    }
 }
 
 JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f)
 {
-    JL_LOCK_NOGC(&finalizers_lock);
-    if (__unlikely(jl_typeis(f, jl_voidpointer_type))) {
-        gc_add_ptr_finalizer(v, jl_unbox_voidpointer(f));
-    }
-    else {
-        arraylist_push(&finalizer_list, v);
-        arraylist_push(&finalizer_list, f);
-    }
-    JL_UNLOCK_NOGC(&finalizers_lock);
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_gc_add_finalizer_th(ptls, v, f);
 }
 
-JL_DLLEXPORT void jl_gc_add_ptr_finalizer(jl_value_t *v, void *f)
+JL_DLLEXPORT void jl_gc_add_ptr_finalizer(jl_tls_states_t *ptls,
+                                          jl_value_t *v, void *f)
 {
-    JL_LOCK_NOGC(&finalizers_lock);
-    gc_add_ptr_finalizer(v, f);
-    JL_UNLOCK_NOGC(&finalizers_lock);
+    gc_add_ptr_finalizer(ptls, v, f);
 }
 
 JL_DLLEXPORT void jl_finalize(jl_value_t *o)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
     JL_LOCK_NOGC(&finalizers_lock);
     // Copy the finalizers into a temporary list so that code in the finalizer
     // won't change the list as we loop through them.
@@ -255,8 +304,11 @@ JL_DLLEXPORT void jl_finalize(jl_value_t *o)
     arraylist_push(&copied_list, NULL); // pgcstack to be filled later
     // No need to check the to_finalize list since the user is apparently
     // still holding a reference to the object
-    finalize_object(&finalizer_list, o, &copied_list);
-    finalize_object(&finalizer_list_marked, o, &copied_list);
+    for (int i = 0;i < jl_n_threads;i++) {
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+        finalize_object(&ptls2->finalizers, o, &copied_list, ptls != ptls2);
+    }
+    finalize_object(&finalizer_list_marked, o, &copied_list, 0);
     if (copied_list.len > 2) {
         // This releases the finalizers lock.
         jl_gc_run_finalizers_in_list(&copied_list);
@@ -497,7 +549,8 @@ static inline int maybe_collect(void)
         jl_gc_collect(0);
         return 1;
     }
-    jl_gc_safepoint();
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_gc_safepoint_(ptls);
     return 0;
 }
 
@@ -515,11 +568,11 @@ JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value)
 static void sweep_weak_refs(void)
 {
     for (int i = 0;i < jl_n_threads;i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
         size_t n = 0;
         size_t ndel = 0;
-        size_t l = ptls->heap.weak_refs.len;
-        void **lst = ptls->heap.weak_refs.items;
+        size_t l = ptls2->heap.weak_refs.len;
+        void **lst = ptls2->heap.weak_refs.items;
         if (l == 0)
             continue;
         while (1) {
@@ -539,7 +592,7 @@ static void sweep_weak_refs(void)
             lst[n] = lst[n + ndel];
             lst[n+ndel] = tmp;
         }
-        ptls->heap.weak_refs.len -= ndel;
+        ptls2->heap.weak_refs.len -= ndel;
     }
 }
 
@@ -675,9 +728,9 @@ static void sweep_malloced_arrays(void)
 {
     gc_time_mallocd_array_start();
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
-        mallocarray_t *ma = ptls->heap.mallocarrays;
-        mallocarray_t **pma = &ptls->heap.mallocarrays;
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
+        mallocarray_t *ma = ptls2->heap.mallocarrays;
+        mallocarray_t **pma = &ptls2->heap.mallocarrays;
         while (ma != NULL) {
             mallocarray_t *nxt = ma->next;
             int bits = jl_astaggedvalue(ma->a)->bits.gc;
@@ -688,8 +741,8 @@ static void sweep_malloced_arrays(void)
                 *pma = nxt;
                 assert(ma->a->flags.how == 2);
                 jl_gc_free_array(ma->a);
-                ma->next = ptls->heap.mafreelist;
-                ptls->heap.mafreelist = ma;
+                ma->next = ptls2->heap.mafreelist;
+                ptls2->heap.mafreelist = ma;
             }
             gc_time_count_mallocd_array(bits);
             ma = nxt;
@@ -702,8 +755,8 @@ static void sweep_malloced_arrays(void)
 static inline jl_taggedvalue_t *reset_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_taggedvalue_t *fl)
 {
     pg->nfree = (GC_PAGE_SZ - GC_PAGE_OFFSET) / p->osize;
-    jl_tls_states_t *ptls = jl_all_tls_states[pg->thread_n];
-    pg->pool_n = p - ptls->heap.norm_pools;
+    jl_tls_states_t *ptls2 = jl_all_tls_states[pg->thread_n];
+    pg->pool_n = p - ptls2->heap.norm_pools;
     memset(pg->ages, 0, GC_PAGE_SZ / 8 / p->osize + 1);
     jl_taggedvalue_t *beg = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
     jl_taggedvalue_t *end = (jl_taggedvalue_t*)((char*)beg + (pg->nfree - 1)*p->osize);
@@ -732,6 +785,7 @@ static NOINLINE void add_page(jl_gc_pool_t *p)
 static inline jl_taggedvalue_t *__pool_alloc(jl_gc_pool_t *p, int osize,
                                              int end_offset)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
 #ifdef MEMDEBUG
     return alloc_big(osize);
 #endif
@@ -743,7 +797,7 @@ static inline jl_taggedvalue_t *__pool_alloc(jl_gc_pool_t *p, int osize,
         //gc_num.allocd += osize;
     }
     else {
-        jl_gc_safepoint();
+        jl_gc_safepoint_(ptls);
     }
     gc_num.poolalloc++;
     // first try to use the freelist
@@ -986,8 +1040,8 @@ static void sweep_pool_region(jl_taggedvalue_t ***pfl, int region_i, int sweep_f
                     jl_gc_pagemeta_t *pg = &region->meta[pg_i*32 + j];
                     int p_n = pg->pool_n;
                     int t_n = pg->thread_n;
-                    jl_tls_states_t *ptls = jl_all_tls_states[t_n];
-                    jl_gc_pool_t *p = &ptls->heap.norm_pools[p_n];
+                    jl_tls_states_t *ptls2 = jl_all_tls_states[t_n];
+                    jl_gc_pool_t *p = &ptls2->heap.norm_pools[p_n];
                     int osize = pg->osize;
                     pfl[t_n * JL_GC_N_POOLS + p_n] = sweep_page(p, pg, pfl[t_n * JL_GC_N_POOLS + p_n], sweep_full, osize);
                 }
@@ -1017,9 +1071,9 @@ static void gc_sweep_pool(int sweep_full)
     // update metadata of pages that were pointed to by freelist or newpages from a pool
     // i.e. pages being the current allocation target
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
         for (int i = 0; i < JL_GC_N_POOLS; i++) {
-            jl_gc_pool_t *p = &ptls->heap.norm_pools[i];
+            jl_gc_pool_t *p = &ptls2->heap.norm_pools[i];
             jl_taggedvalue_t *last = p->freelist;
             if (last) {
                 jl_gc_pagemeta_t *pg = page_metadata(last);
@@ -1048,9 +1102,9 @@ static void gc_sweep_pool(int sweep_full)
 
     // null out terminal pointers of free lists and cache back pg->nfree in the jl_gc_pool_t
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
         for (int i = 0; i < JL_GC_N_POOLS; i++) {
-            jl_gc_pool_t *p = &ptls->heap.norm_pools[i];
+            jl_gc_pool_t *p = &ptls2->heap.norm_pools[i];
             *pfl[t_i * JL_GC_N_POOLS + i] = NULL;
             if (p->freelist) {
                 p->nfree = page_metadata(p->freelist)->nfree;
@@ -1086,12 +1140,12 @@ static void grow_mark_stack(void)
 static void reset_remset(void)
 {
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
-        arraylist_t *tmp = ptls->heap.remset;
-        ptls->heap.remset = ptls->heap.last_remset;
-        ptls->heap.last_remset = tmp;
-        ptls->heap.remset->len = 0;
-        ptls->heap.remset_nptr = 0;
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
+        arraylist_t *tmp = ptls2->heap.remset;
+        ptls2->heap.remset = ptls2->heap.last_remset;
+        ptls2->heap.last_remset = tmp;
+        ptls2->heap.remset->len = 0;
+        ptls2->heap.remset_nptr = 0;
     }
 }
 
@@ -1219,25 +1273,25 @@ static void gc_mark_task_stack(jl_task_t *ta, int d)
 {
     int stkbuf = (ta->stkbuf != (void*)(intptr_t)-1 && ta->stkbuf != NULL);
     int16_t tid = ta->tid;
-    jl_tls_states_t *ptls = jl_all_tls_states[tid];
+    jl_tls_states_t *ptls2 = jl_all_tls_states[tid];
     if (stkbuf) {
 #ifdef COPY_STACKS
         gc_setmark_buf(ta->stkbuf, jl_astaggedvalue(ta)->bits.gc, ta->bufsz);
 #else
         // stkbuf isn't owned by julia for the root task
-        if (ta != ptls->root_task) {
+        if (ta != ptls2->root_task) {
             gc_setmark_buf(ta->stkbuf, jl_astaggedvalue(ta)->bits.gc,
                            ta->ssize);
         }
 #endif
     }
-    if (ta == ptls->current_task) {
-        gc_mark_stack((jl_value_t*)ta, ptls->pgcstack, 0, d);
+    if (ta == ptls2->current_task) {
+        gc_mark_stack((jl_value_t*)ta, ptls2->pgcstack, 0, d);
     }
     else if (stkbuf) {
         intptr_t offset;
 #ifdef COPY_STACKS
-        offset = (char *)ta->stkbuf - ((char *)ptls->stackbase - ta->ssize);
+        offset = (char *)ta->stkbuf - ((char *)ptls2->stackbase - ta->ssize);
 #else
         offset = 0;
 #endif
@@ -1260,12 +1314,16 @@ NOINLINE static void gc_mark_task(jl_task_t *ta, int d)
 
 void gc_mark_object_list(arraylist_t *list, size_t start)
 {
-    for (size_t i = start;i < list->len;i++) {
-        void *v = list->items[i];
+    void **items = list->items;
+    size_t len = list->len;
+    for (size_t i = start;i < len;i++) {
+        void *v = items[i];
+        if (__unlikely(!v))
+            continue;
         if (gc_ptr_tag(v, 1)) {
             v = gc_ptr_clear_tag(v, 1);
             i++;
-            assert(i < list->len);
+            assert(i < len);
         }
         gc_push_root(v, 0);
     }
@@ -1474,15 +1532,15 @@ void pre_mark(void)
 
     size_t i;
     for(i=0; i < jl_n_threads; i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
         // current_module might not have a value when the thread is not
         // running.
-        if (ptls->current_module)
-            gc_push_root(ptls->current_module, 0);
-        gc_push_root(ptls->current_task, 0);
-        gc_push_root(ptls->root_task, 0);
-        gc_push_root(ptls->exception_in_transit, 0);
-        gc_push_root(ptls->task_arg_in_transit, 0);
+        if (ptls2->current_module)
+            gc_push_root(ptls2->current_module, 0);
+        gc_push_root(ptls2->current_task, 0);
+        gc_push_root(ptls2->root_task, 0);
+        gc_push_root(ptls2->exception_in_transit, 0);
+        gc_push_root(ptls2->task_arg_in_transit, 0);
     }
 
     // invisible builtin values
@@ -1513,23 +1571,36 @@ void pre_mark(void)
 // this must happen last in the mark phase.
 static void post_mark(arraylist_t *list)
 {
-    for (size_t i=0; i < list->len; i+=2) {
-        void *v0 = list->items[i];
+    void **items = list->items;
+    size_t len = list->len;
+    for (size_t i=0; i < len; i+=2) {
+        void *v0 = items[i];
         int is_cptr = gc_ptr_tag(v0, 1);
         void *v = gc_ptr_clear_tag(v0, 1);
-        void *fin = list->items[i+1];
+        if (__unlikely(!v0)) {
+            // remove from this list
+            if (i < len - 2) {
+                items[i] = items[len - 2];
+                items[i + 1] = items[len - 1];
+                i -= 2;
+            }
+            len -= 2;
+            continue;
+        }
+
+        void *fin = items[i+1];
         int isfreed = !gc_marked(jl_astaggedvalue(v)->bits.gc);
         int isold = (list != &finalizer_list_marked &&
                      jl_astaggedvalue(v)->bits.gc == GC_OLD_MARKED &&
                      (is_cptr || jl_astaggedvalue(fin)->bits.gc == GC_OLD_MARKED));
         if (isfreed || isold) {
             // remove from this list
-            if (i < list->len - 2) {
-                list->items[i] = list->items[list->len-2];
-                list->items[i+1] = list->items[list->len-1];
+            if (i < len - 2) {
+                items[i] = items[len - 2];
+                items[i + 1] = items[len - 1];
                 i -= 2;
             }
-            list->len -= 2;
+            len -= 2;
         }
         if (isfreed) {
             // schedule finalizer or execute right away if it is not julia code
@@ -1546,6 +1617,7 @@ static void post_mark(arraylist_t *list)
             arraylist_push(&finalizer_list_marked, fin);
         }
     }
+    list->len = len;
 }
 
 // collector entry point and control
@@ -1564,7 +1636,7 @@ JL_DLLEXPORT int jl_gc_enable(int on)
         // enable -> disable
         jl_atomic_fetch_add(&jl_gc_disable_counter, 1);
         // check if the GC is running and wait for it to finish
-        jl_gc_safepoint();
+        jl_gc_safepoint_(ptls);
     }
     return prev;
 }
@@ -1608,39 +1680,39 @@ static void _jl_gc_collect(int full, char *stack_hi)
     // 1. mark every object in the remset
     reset_remset();
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
         // avoid counting remembered objects & bindings twice in perm_scanned_bytes
-        for (int i = 0; i < ptls->heap.last_remset->len; i++) {
-            jl_value_t *item = (jl_value_t*)ptls->heap.last_remset->items[i];
+        for (int i = 0; i < ptls2->heap.last_remset->len; i++) {
+            jl_value_t *item = (jl_value_t*)ptls2->heap.last_remset->items[i];
             objprofile_count(jl_typeof(item), 2, 0);
             jl_astaggedvalue(item)->bits.gc = GC_OLD_MARKED;
         }
-        for (int i = 0; i < ptls->heap.rem_bindings.len; i++) {
-            void *ptr = ptls->heap.rem_bindings.items[i];
+        for (int i = 0; i < ptls2->heap.rem_bindings.len; i++) {
+            void *ptr = ptls2->heap.rem_bindings.items[i];
             jl_astaggedvalue(ptr)->bits.gc = GC_OLD_MARKED;
         }
 
-        for (int i = 0; i < ptls->heap.last_remset->len; i++) {
-            jl_value_t *item = (jl_value_t*)ptls->heap.last_remset->items[i];
+        for (int i = 0; i < ptls2->heap.last_remset->len; i++) {
+            jl_value_t *item = (jl_value_t*)ptls2->heap.last_remset->items[i];
             push_root(item, 0, GC_OLD_MARKED);
         }
     }
 
     // 2. mark every object in a remembered binding
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
         int n_bnd_refyoung = 0;
-        for (int i = 0; i < ptls->heap.rem_bindings.len; i++) {
-            jl_binding_t *ptr = (jl_binding_t*)ptls->heap.rem_bindings.items[i];
+        for (int i = 0; i < ptls2->heap.rem_bindings.len; i++) {
+            jl_binding_t *ptr = (jl_binding_t*)ptls2->heap.rem_bindings.items[i];
             // A null pointer can happen here when the binding is cleaned up
             // as an exception is thrown after it was already queued (#10221)
             if (!ptr->value) continue;
             if (gc_push_root(ptr->value, 0)) {
-                ptls->heap.rem_bindings.items[n_bnd_refyoung] = ptr;
+                ptls2->heap.rem_bindings.items[n_bnd_refyoung] = ptr;
                 n_bnd_refyoung++;
             }
         }
-        ptls->heap.rem_bindings.len = n_bnd_refyoung;
+        ptls2->heap.rem_bindings.len = n_bnd_refyoung;
     }
 
     // 3. walk roots
@@ -1656,12 +1728,18 @@ static void _jl_gc_collect(int full, char *stack_hi)
     // mark the object moved to the marked list from the
     // `finalizer_list` by `post_mark`
     size_t orig_marked_len = finalizer_list_marked.len;
-    post_mark(&finalizer_list);
+    for (int i = 0;i < jl_n_threads;i++) {
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+        post_mark(&ptls2->finalizers);
+    }
     if (prev_sweep_full) {
         post_mark(&finalizer_list_marked);
         orig_marked_len = 0;
     }
-    gc_mark_object_list(&finalizer_list, 0);
+    for (int i = 0;i < jl_n_threads;i++) {
+        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+        gc_mark_object_list(&ptls2->finalizers, 0);
+    }
     gc_mark_object_list(&finalizer_list_marked, orig_marked_len);
     // "Flush" the mark stack before flipping the reset_age bit
     // so that the objects are not incorrectly resetted.
@@ -1734,19 +1812,19 @@ static void _jl_gc_collect(int full, char *stack_hi)
     // 6. if it is a quick sweep, put back the remembered objects in queued state
     // so that we don't trigger the barrier again on them.
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
         if (!sweep_full) {
-            for (int i = 0; i < ptls->heap.remset->len; i++) {
-                jl_astaggedvalue(ptls->heap.remset->items[i])->bits.gc = GC_MARKED;
+            for (int i = 0; i < ptls2->heap.remset->len; i++) {
+                jl_astaggedvalue(ptls2->heap.remset->items[i])->bits.gc = GC_MARKED;
             }
-            for (int i = 0; i < ptls->heap.rem_bindings.len; i++) {
-                void *ptr = ptls->heap.rem_bindings.items[i];
+            for (int i = 0; i < ptls2->heap.rem_bindings.len; i++) {
+                void *ptr = ptls2->heap.rem_bindings.items[i];
                 jl_astaggedvalue(ptr)->bits.gc = GC_MARKED;
             }
         }
         else {
-            ptls->heap.remset->len = 0;
-            ptls->heap.rem_bindings.len = 0;
+            ptls2->heap.remset->len = 0;
+            ptls2->heap.rem_bindings.len = 0;
         }
     }
 
@@ -1777,13 +1855,13 @@ JL_DLLEXPORT void jl_gc_collect(int full)
     char *stack_hi = (char*)gc_get_stack_ptr();
     gc_debug_print();
 
-    int8_t old_state = jl_gc_state();
+    int8_t old_state = jl_gc_state(ptls);
     ptls->gc_state = JL_GC_STATE_WAITING;
     // `jl_safepoint_start_gc()` makes sure only one thread can
     // run the GC.
     if (!jl_safepoint_start_gc()) {
         // Multithread only. See assertion in `safepoint.c`
-        jl_gc_state_set(old_state, JL_GC_STATE_WAITING);
+        jl_gc_state_set(ptls, old_state, JL_GC_STATE_WAITING);
         return;
     }
     // no-op for non-threading
@@ -1797,7 +1875,7 @@ JL_DLLEXPORT void jl_gc_collect(int full)
 
     // no-op for non-threading
     jl_safepoint_end_gc();
-    jl_gc_state_set(old_state, JL_GC_STATE_WAITING);
+    jl_gc_state_set(ptls, old_state, JL_GC_STATE_WAITING);
 
     // Only disable finalizers on current thread
     // Doing this on all threads is racy (it's impossible to check
@@ -1869,8 +1947,9 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc_3w(void)
 }
 
 // Per-thread initialization (when threading is fully implemented)
-void jl_mk_thread_heap(jl_thread_heap_t *heap)
+void jl_mk_thread_heap(jl_tls_states_t *ptls)
 {
+    jl_thread_heap_t *heap = &ptls->heap;
     const int *szc = sizeclasses;
     jl_gc_pool_t *p = heap->norm_pools;
     for(int i=0; i < JL_GC_N_POOLS; i++) {
@@ -1890,6 +1969,7 @@ void jl_mk_thread_heap(jl_thread_heap_t *heap)
     heap->last_remset = &heap->_remset[1];
     arraylist_new(heap->remset, 0);
     arraylist_new(heap->last_remset, 0);
+    arraylist_new(&ptls->finalizers, 0);
 }
 
 // System-wide initializations
@@ -1898,7 +1978,6 @@ void jl_gc_init(void)
     jl_gc_init_page();
     gc_debug_init();
 
-    arraylist_new(&finalizer_list, 0);
     arraylist_new(&finalizer_list_marked, 0);
     arraylist_new(&to_finalize, 0);
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -219,6 +219,16 @@ STATIC_INLINE int gc_old(int bits)
     return (bits & GC_OLD) != 0;
 }
 
+STATIC_INLINE uintptr_t gc_ptr_tag(void *v, uintptr_t mask)
+{
+    return ((uintptr_t)v) & mask;
+}
+
+STATIC_INLINE void *gc_ptr_clear_tag(void *v, uintptr_t mask)
+{
+    return (void*)(((uintptr_t)v) & ~mask);
+}
+
 NOINLINE uintptr_t gc_get_stack_ptr(void);
 
 STATIC_INLINE region_t *find_region(void *ptr, int maybe)
@@ -355,7 +365,7 @@ void add_lostval_parent(jl_value_t *parent);
     } while(0);
 
 #define verify_parent(ty, obj, slot, args...) do {                      \
-        if (*(jl_value_t**)(slot) == lostval &&                         \
+        if (gc_ptr_clear_tag(*(void**)(slot), 3) == (void*)lostval &&   \
             (jl_value_t*)(obj) != lostval) {                            \
             jl_printf(JL_STDOUT, "Found parent %p %p at %s:%d\n",       \
                       (void*)(ty), (void*)(obj), __FILE__, __LINE__);   \

--- a/src/gc.h
+++ b/src/gc.h
@@ -178,7 +178,6 @@ typedef struct {
 extern jl_gc_num_t gc_num;
 extern region_t regions[REGION_COUNT];
 extern bigval_t *big_objects_marked;
-extern arraylist_t finalizer_list;
 extern arraylist_t finalizer_list_marked;
 extern arraylist_t to_finalize;
 extern int64_t lazy_freed_pages;

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -136,9 +136,10 @@ JL_DLLEXPORT void *jl_uv_write_handle(uv_write_t *req) { return req->handle; }
 
 JL_DLLEXPORT int jl_run_once(uv_loop_t *loop)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
     if (loop) {
         loop->stop_flag = 0;
-        jl_gc_safepoint();
+        jl_gc_safepoint_(ptls);
         return uv_run(loop,UV_RUN_ONCE);
     }
     else return 0;
@@ -146,18 +147,20 @@ JL_DLLEXPORT int jl_run_once(uv_loop_t *loop)
 
 JL_DLLEXPORT void jl_run_event_loop(uv_loop_t *loop)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
     if (loop) {
         loop->stop_flag = 0;
-        jl_gc_safepoint();
+        jl_gc_safepoint_(ptls);
         uv_run(loop,UV_RUN_DEFAULT);
     }
 }
 
 JL_DLLEXPORT int jl_process_events(uv_loop_t *loop)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
     if (loop) {
         loop->stop_flag = 0;
-        jl_gc_safepoint();
+        jl_gc_safepoint_(ptls);
         return uv_run(loop,UV_RUN_NOWAIT);
     }
     else return 0;

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -326,27 +326,32 @@ JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
 
 JL_DLLEXPORT int8_t (jl_gc_unsafe_enter)(void)
 {
-    return jl_gc_unsafe_enter();
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    return jl_gc_unsafe_enter(ptls);
 }
 
 JL_DLLEXPORT void (jl_gc_unsafe_leave)(int8_t state)
 {
-    jl_gc_unsafe_leave(state);
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_gc_unsafe_leave(ptls, state);
 }
 
 JL_DLLEXPORT int8_t (jl_gc_safe_enter)(void)
 {
-    return jl_gc_safe_enter();
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    return jl_gc_safe_enter(ptls);
 }
 
 JL_DLLEXPORT void (jl_gc_safe_leave)(int8_t state)
 {
-    jl_gc_safe_leave(state);
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_gc_safe_leave(ptls, state);
 }
 
 JL_DLLEXPORT void (jl_gc_safepoint)(void)
 {
-    jl_gc_safepoint();
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_gc_safepoint_(ptls);
 }
 
 JL_DLLEXPORT void (jl_cpu_pause)(void)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1520,7 +1520,7 @@ STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
     ptls->gc_state = eh->gc_state;
     ptls->finalizers_inhibited = eh->finalizers_inhibited;
     if (old_gc_state && !eh->gc_state) {
-        jl_gc_safepoint();
+        jl_gc_safepoint_(ptls);
     }
     if (old_defer_signal && !eh->defer_signal) {
         jl_sigint_safepoint();

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -238,7 +238,7 @@ void jl_init_restored_modules(jl_array_t *init_order);
 void jl_init_signal_async(void);
 void jl_init_debuginfo(void);
 void jl_init_runtime_ccall(void);
-void jl_mk_thread_heap(jl_thread_heap_t *heap);
+void jl_mk_thread_heap(jl_tls_states_t *ptls);
 
 void _julia_init(JL_IMAGE_SEARCH rel);
 
@@ -296,13 +296,13 @@ void jl_wake_libuv(void);
 jl_get_ptls_states_func jl_get_ptls_states_getter(void);
 static inline void jl_set_gc_and_wait(void)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
     // reading own gc state doesn't need atomic ops since no one else
     // should store to it.
-    int8_t state = jl_gc_state();
-    jl_atomic_store_release(&jl_get_ptls_states()->gc_state,
-                            JL_GC_STATE_WAITING);
+    int8_t state = jl_gc_state(ptls);
+    jl_atomic_store_release(&ptls->gc_state, JL_GC_STATE_WAITING);
     jl_safepoint_wait_gc();
-    jl_atomic_store_release(&jl_get_ptls_states()->gc_state, state);
+    jl_atomic_store_release(&ptls->gc_state, state);
 }
 #endif
 

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -350,10 +350,11 @@ size_t rec_backtrace_ctx_dwarf(uintptr_t *data, size_t maxsize,
 
 JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
 {
+    jl_tls_states_t *ptls = jl_get_ptls_states();
     jl_frame_t *frames = NULL;
-    int8_t gc_state = jl_gc_safe_enter();
+    int8_t gc_state = jl_gc_safe_enter(ptls);
     int n = jl_getFunctionInfo(&frames, (uintptr_t)ip, skipC, 0);
-    jl_gc_safe_leave(gc_state);
+    jl_gc_safe_leave(ptls, gc_state);
     jl_value_t *rs = (jl_value_t*)jl_alloc_svec(n);
     JL_GC_PUSH1(&rs);
     for (int i = 0; i < n; i++) {

--- a/src/support/arraylist.c
+++ b/src/support/arraylist.c
@@ -22,9 +22,9 @@ arraylist_t *arraylist_new(arraylist_t *a, size_t size)
     }
     else {
         a->items = (void**)LLT_ALLOC(size*sizeof(void*));
+        if (a->items == NULL) return NULL;
         a->max = size;
     }
-    if (a->items == NULL) return NULL;
     return a;
 }
 
@@ -39,31 +39,35 @@ void arraylist_free(arraylist_t *a)
 
 void arraylist_grow(arraylist_t *a, size_t n)
 {
-    if (a->len+n > a->max) {
+    size_t len = a->len;
+    size_t newlen = len + n;
+    if (newlen > a->max) {
         if (a->items == &a->_space[0]) {
             void **p = (void**)LLT_ALLOC((a->len+n)*sizeof(void*));
             if (p == NULL) return;
-            memcpy(p, a->items, a->len*sizeof(void*));
+            memcpy(p, a->items, len * sizeof(void*));
             a->items = p;
-            a->max = a->len+n;
+            a->max = newlen;
         }
         else {
-            size_t nm = a->max*2;
-            if (nm == 0) nm = 1;
-            while (a->len+n > nm) nm*=2;
-            void **p = (void**)LLT_REALLOC(a->items, nm*sizeof(void*));
+            size_t nm = a->max * 2;
+            if (nm == 0)
+                nm = 1;
+            while (newlen > nm)
+                nm *= 2;
+            void **p = (void**)LLT_REALLOC(a->items, nm * sizeof(void*));
             if (p == NULL) return;
             a->items = p;
             a->max = nm;
         }
     }
-    a->len += n;
+    a->len = newlen;
 }
 
 void arraylist_push(arraylist_t *a, void *elt)
 {
     arraylist_grow(a, 1);
-    a->items[a->len-1] = elt;
+    a->items[a->len - 1] = elt;
 }
 
 void *arraylist_pop(arraylist_t *a)


### PR DESCRIPTION
- Avoid boxing the pointer for C function finalizers
- Make `finalizer_list` thread local and rewrite `jl_finalize` to avoid a lock when adding a finalizer.
  
  (This is the unusual case where we want to optimize the writer not the reader.)

This also includes a little bit of work towards passing the TLS pointer around more explicitly to reduce TLS access overhead.

Benchmarked using the following code

``` jl
julia> g3(n) = for i in 1:n
           x = Ref(0)
           finalizer(x, cglobal(:strlen))
       end
```

Timing on master

``` jl
julia> @time g3(1000_000_000)
 49.696651 seconds (1.00 G allocations: 14.901 GB, 15.12% gc time)
```

On this PR

``` jl
julia> @time g3(1000_000_000)
 17.206249 seconds (1.00 G allocations: 14.901 GB, 37.19% gc time)
```

(The GC time is high since the GC has to run all the finalizers)
