### PR TITLE
Performance tweaks for PermutedDimsArray

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -70,6 +70,10 @@ function isperm(A)
     true
 end
 
+isperm(p::Tuple{}) = true
+isperm(p::Tuple{Int}) = p[1] == 1
+isperm(p::Tuple{Int,Int}) = ((p[1] == 1) & (p[2] == 2)) | ((p[1] == 2) & (p[2] == 1))
+
 function permute!!{T<:Integer}(a, p::AbstractVector{T})
     count = 0
     start = 0
@@ -146,6 +150,11 @@ function invperm(a::AbstractVector)
         b[j] = i
     end
     b
+end
+
+function invperm(p::Union{Tuple{},Tuple{Int},Tuple{Int,Int}})
+    isperm(p) || throw(ArgumentError("argument is not a permutation"))
+    p  # in dimensions 0-2, every permutation is its own inverse
 end
 invperm(a::Tuple) = (invperm([a...])...,)
 

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -12,7 +12,6 @@ immutable PermutedDimsArray{T,N,perm,iperm,AA<:AbstractArray} <: AbstractArray{T
     dims::NTuple{N,Int}
 
     function PermutedDimsArray(data::AA)
-        # TODO optimize isperm & invperm for low dimensions?
         (isa(perm, NTuple{N,Int}) && isa(iperm, NTuple{N,Int})) || error("perm and iperm must both be NTuple{$N,Int}")
         isperm(perm) || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
         all(map(d->iperm[perm[d]]==d, 1:N)) || throw(ArgumentError(string(perm, " and ", iperm, " must be inverses")))

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -7,41 +7,41 @@ using Base: IndicesStartAt1, IndicesBehavior, indicesbehavior
 export permutedims
 
 # Some day we will want storage-order-aware iteration, so put perm in the parameters
-immutable PermutedDimsArray{T,N,AA<:AbstractArray,perm} <: AbstractArray{T,N}
+immutable PermutedDimsArray{T,N,perm,iperm,AA<:AbstractArray} <: AbstractArray{T,N}
     parent::AA
-    iperm::NTuple{N,Int}
     dims::NTuple{N,Int}
 
     function PermutedDimsArray(data::AA)
         # TODO optimize isperm & invperm for low dimensions?
-        isa(perm, NTuple{N,Int}) || error("perm must be an NTuple{$N,Int}")
-        (length(perm) == N && isperm(perm)) || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
-        iperm = invperm(perm)
-        new(data, iperm, genperm(size(data), perm))
+        (isa(perm, NTuple{N,Int}) && isa(iperm, NTuple{N,Int})) || error("perm and iperm must both be NTuple{$N,Int}")
+        isperm(perm) || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
+        all(map(d->iperm[perm[d]]==d, 1:N)) || throw(ArgumentError(string(perm, " and ", iperm, " must be inverses")))
+        new(data, genperm(size(data), perm))
     end
 end
 
 function PermutedDimsArray{T,N}(data::AbstractArray{T,N}, perm)
     length(perm) == N || throw(ArgumentError(string(p, " is not a valid permutation of dimensions 1:", N)))
-    PermutedDimsArray{T,N,typeof(data),(perm...,)}(data)
+    iperm = invperm(perm)
+    PermutedDimsArray{T,N,(perm...,),(iperm...,),typeof(data)}(data)
 end
 
 Base.parent(A::PermutedDimsArray) = A.parent
 Base.size(A::PermutedDimsArray) = A.dims
-Base.indices{T,N,AA,perm}(A::PermutedDimsArray{T,N,AA,perm}, d) = indices(parent(A), perm[d])
+Base.indices{T,N,perm}(A::PermutedDimsArray{T,N,perm}, d) = indices(parent(A), perm[d])
 
-@inline function Base.getindex{T,N}(A::PermutedDimsArray{T,N}, I::Vararg{Int,N})
+@inline function Base.getindex{T,N,perm,iperm}(A::PermutedDimsArray{T,N,perm,iperm}, I::Vararg{Int,N})
     @boundscheck checkbounds(A, I...)
-    @inbounds val = getindex(A.parent, genperm(I, A.iperm)...)
+    @inbounds val = getindex(A.parent, genperm(I, iperm)...)
     val
 end
-@inline function Base.setindex!{T,N}(A::PermutedDimsArray{T,N}, val, I::Vararg{Int,N})
+@inline function Base.setindex!{T,N,perm,iperm}(A::PermutedDimsArray{T,N,perm,iperm}, val, I::Vararg{Int,N})
     @boundscheck checkbounds(A, I...)
-    @inbounds setindex!(A.parent, val, genperm(I, A.iperm)...)
+    @inbounds setindex!(A.parent, val, genperm(I, iperm)...)
     val
 end
 
-# Could use ntuple(d->I[perm[d]], Val{N}) once #15276 is solved
+# For some reason this is faster than ntuple(d->I[perm[d]], Val{N}) (#15276?)
 @inline genperm{N}(I::NTuple{N}, perm::Dims{N}) = _genperm((), I, perm...)
 _genperm(out, I) = out
 @inline _genperm(out, I, p, perm...) = _genperm((out..., I[p]), I, perm...)
@@ -69,7 +69,7 @@ function Base.copy!{T,N}(dest::PermutedDimsArray{T,N}, src::AbstractArray{T,N})
 end
 Base.copy!(dest::PermutedDimsArray, src::AbstractArray) = _copy!(dest, src)
 
-function _copy!{T,N,AA,perm}(P::PermutedDimsArray{T,N,AA,perm}, src)
+function _copy!{T,N,perm}(P::PermutedDimsArray{T,N,perm}, src)
     # If dest/src are "close to dense," then it pays to be cache-friendly.
     # Determine the first permuted dimension
     d = 0  # d+1 will hold the first permuted dimension of src

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -17,6 +17,18 @@
 p = shuffle([1:1000;])
 @test isperm(p)
 @test all(invperm(invperm(p)) .== p)
+@test isperm(()) == true
+@test isperm((1,)) == true
+@test isperm((2,)) == false
+@test isperm((1,2)) == true
+@test isperm((2,1)) == true
+@test isperm((2,2)) == false
+@test isperm((1,3)) == false
+@test invperm(()) == ()
+@test invperm((1,)) == (1,)
+@test invperm((1,2)) == (1,2)
+@test invperm((2,1)) == (2,1)
+@test_throws ArgumentError invperm((1,3))
 
 push!(p, 1)
 @test !isperm(p)


### PR DESCRIPTION
The first commit leads to a ~10% speed improvement in `getindex`-heavy benchmarks, and on a summation benchmark makes the performance of a PermutedDimsArray identical to an Array when each is traversed in its own memory order:

``` jl
# Compute sum in row-major order
function mysum_rm{T}(A::AbstractMatrix{T})
    s = zero(T)
    @inbounds for i = indices(A,1), j = indices(A,2)
        s += A[i,j]
    end
    s
end

# Compute sum in column-major order
function mysum_cm{T}(A::AbstractMatrix{T})
    s = zero(T)
    @inbounds for j = indices(A,2), i = indices(A,1)
        s += A[i,j]
    end
    s
end
```

The second commit specializes `isperm` and `invperm` for very small tuples, and leads to a >2-fold speed improvement in construction of such low-dimensional views.

I'm happy with this version of the definition of PermutedDimsArray, so we might be able to export it. But given that `copy!` is the only method currently that's been performance-optimized (and only in one direction), I'd actually rather leave this buried for julia-0.5.
