### PR TITLE
Optimize allocation in generated code

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -854,7 +854,7 @@ static jl_cgval_t mark_or_box_ccall_result(Value *result, bool isboxed, jl_value
         int nb = sizeof(void*);
         // TODO: can this be tighter than tbaa_value?
         return mark_julia_type(
-            init_bits_value(emit_allocobj(nb), runtime_bt, result, tbaa_value),
+            init_bits_value(emit_allocobj(ctx, nb), runtime_bt, result, tbaa_value),
             true, (jl_value_t*)jl_pointer_type, ctx);
     }
     return mark_julia_type(result, isboxed, rt, ctx);

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -139,8 +139,8 @@ static void clear_mark(int bits)
                 for (int j = 0; j < 32; j++) {
                     if ((line >> j) & 1) {
                         jl_gc_pagemeta_t *pg = page_metadata(region->pages[pg_i*32 + j].data + GC_PAGE_OFFSET);
-                        jl_tls_states_t *ptls = jl_all_tls_states[pg->thread_n];
-                        jl_gc_pool_t *pool = &ptls->heap.norm_pools[pg->pool_n];
+                        jl_tls_states_t *ptls2 = jl_all_tls_states[pg->thread_n];
+                        jl_gc_pool_t *pool = &ptls2->heap.norm_pools[pg->pool_n];
                         pv = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
                         char *lim = (char*)pv + GC_PAGE_SZ - GC_PAGE_OFFSET - pool->osize;
                         while ((char*)pv <= lim) {
@@ -660,9 +660,9 @@ void gc_time_mark_pause(int64_t t0, int64_t scanned_bytes,
     int64_t last_remset_len = 0;
     int64_t remset_nptr = 0;
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t_i];
-        last_remset_len += ptls->heap.last_remset->len;
-        remset_nptr = ptls->heap.remset_nptr;
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
+        last_remset_len += ptls2->heap.last_remset->len;
+        remset_nptr = ptls2->heap.remset_nptr;
     }
     jl_printf(JL_STDOUT, "GC mark pause %.2f ms | "
               "scanned %" PRId64 " kB = %" PRId64 " + %" PRId64 " | "
@@ -779,14 +779,14 @@ void gc_stats_all_pool(void)
     size_t nb=0, w, tw=0, no=0,tp=0, nold=0,noldbytes=0, np, nol;
     for (int i = 0; i < JL_GC_N_POOLS; i++) {
         for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-            jl_tls_states_t *ptls = jl_all_tls_states[t_i];
-            size_t b = pool_stats(&ptls->heap.norm_pools[i], &w, &np, &nol);
+            jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
+            size_t b = pool_stats(&ptls2->heap.norm_pools[i], &w, &np, &nol);
             nb += b;
-            no += (b / ptls->heap.norm_pools[i].osize);
+            no += (b / ptls2->heap.norm_pools[i].osize);
             tw += w;
             tp += np;
             nold += nol;
-            noldbytes += nol * ptls->heap.norm_pools[i].osize;
+            noldbytes += nol * ptls2->heap.norm_pools[i].osize;
         }
     }
     jl_printf(JL_STDOUT,

--- a/src/init.c
+++ b/src/init.c
@@ -798,12 +798,12 @@ void jl_get_builtin_hooks(void)
 {
     int t;
     for (t = 0; t < jl_n_threads; t++) {
-        jl_tls_states_t *ptls = jl_all_tls_states[t];
-        ptls->root_task->tls = jl_nothing;
-        ptls->root_task->consumers = jl_nothing;
-        ptls->root_task->donenotify = jl_nothing;
-        ptls->root_task->exception = jl_nothing;
-        ptls->root_task->result = jl_nothing;
+        jl_tls_states_t *ptls2 = jl_all_tls_states[t];
+        ptls2->root_task->tls = jl_nothing;
+        ptls2->root_task->consumers = jl_nothing;
+        ptls2->root_task->donenotify = jl_nothing;
+        ptls2->root_task->exception = jl_nothing;
+        ptls2->root_task->result = jl_nothing;
     }
 
     jl_char_type    = (jl_datatype_t*)core("Char");

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -509,7 +509,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
         return mark_julia_type(vx, false, bt, ctx);
     else
         return mark_julia_type(
-            init_bits_value(emit_allocobj(nb), boxed(bt_value, ctx), vx, tbaa_immut),
+            init_bits_value(emit_allocobj(ctx, nb), boxed(bt_value, ctx), vx, tbaa_immut),
             true, bt, ctx);
 }
 
@@ -550,7 +550,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
         Value *runtime_bt = boxed(bt_value, ctx);
         // XXX: emit type validity check on runtime_bt (bitstype of size nb)
 
-        Value *newobj = emit_allocobj(nb);
+        Value *newobj = emit_allocobj(ctx, nb);
         tbaa_decorate(tbaa_tag, builder.CreateStore(runtime_bt, emit_typeptr_addr(newobj)));
         if (!v.ispointer()) {
             tbaa_decorate(tbaa_value, builder.CreateAlignedStore(emit_unbox(llvmt, v, v.typ), builder.CreatePointerCast(newobj, llvmt->getPointerTo()), alignment));
@@ -774,7 +774,7 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
         }
         assert(jl_is_datatype(ety));
         uint64_t size = jl_datatype_size(ety);
-        Value *strct = emit_allocobj(size);
+        Value *strct = emit_allocobj(ctx, size);
         tbaa_decorate(tbaa_tag, builder.CreateStore(literal_pointer_val((jl_value_t*)ety),
                                                     emit_typeptr_addr(strct)));
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -43,6 +43,11 @@ extern unsigned sig_stack_size;
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
 
+JL_DLLEXPORT void *jl_gc_pool_alloc(jl_tls_states_t *ptls, jl_gc_pool_t *p,
+                                    int osize, int end_offset);
+JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_tls_states_t *ptls, size_t allocsz);
+int jl_gc_classify_pools(size_t sz, int *osize, int *end_offset);
+
 STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 {
     jl_value_t *jv = NULL;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -27,16 +27,16 @@ void jl_mach_gc_end(void)
         uintptr_t item = (uintptr_t)suspended_threads.items[i];
         int16_t tid = (int16_t)item;
         int8_t gc_state = (int8_t)(item >> 8);
-        jl_tls_states_t *ptls = jl_all_tls_states[tid];
-        jl_atomic_store_release(&ptls->gc_state, gc_state);
-        thread_resume(pthread_mach_thread_np(ptls->system_id));
+        jl_tls_states_t *ptls2 = jl_all_tls_states[tid];
+        jl_atomic_store_release(&ptls2->gc_state, gc_state);
+        thread_resume(pthread_mach_thread_np(ptls2->system_id));
     }
     suspended_threads.len = 0;
 }
 
 // Suspend the thread and return `1` if the GC is running.
 // Otherwise return `0`
-static int jl_mach_gc_wait(jl_tls_states_t *ptls,
+static int jl_mach_gc_wait(jl_tls_states_t *ptls2,
                            mach_port_t thread, int16_t tid)
 {
     jl_mutex_lock_nogc(&safepoint_lock);
@@ -47,8 +47,8 @@ static int jl_mach_gc_wait(jl_tls_states_t *ptls,
         return 0;
     }
     // Otherwise, set the gc state of the thread, suspend and record it
-    int8_t gc_state = ptls->gc_state;
-    jl_atomic_store_release(&ptls->gc_state, JL_GC_STATE_WAITING);
+    int8_t gc_state = ptls2->gc_state;
+    jl_atomic_store_release(&ptls2->gc_state, JL_GC_STATE_WAITING);
     uintptr_t item = tid | (((uintptr_t)gc_state) << 16);
     arraylist_push(&suspended_threads, (void*)item);
     thread_suspend(thread);
@@ -126,13 +126,13 @@ void jl_throw_in_thread(int tid, mach_port_t thread, jl_value_t *exception)
     x86_thread_state64_t state;
     kern_return_t ret = thread_get_state(thread, x86_THREAD_STATE64, (thread_state_t)&state, &count);
     HANDLE_MACH_ERROR("thread_get_state", ret);
-    jl_tls_states_t *ptls = jl_all_tls_states[tid];
+    jl_tls_states_t *ptls2 = jl_all_tls_states[tid];
 
-    ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE,
-                                      (bt_context_t*)&state);
-    ptls->exception_in_transit = exception;
+    ptls2->bt_size = rec_backtrace_ctx(ptls2->bt_data, JL_MAX_BT_SIZE,
+                                       (bt_context_t*)&state);
+    ptls2->exception_in_transit = exception;
 
-    uint64_t rsp = (uint64_t)ptls->signal_stack + sig_stack_size;
+    uint64_t rsp = (uint64_t)ptls2->signal_stack + sig_stack_size;
     rsp &= -16; // ensure 16-byte alignment
 
     // push (null) $RIP onto the stack
@@ -166,15 +166,15 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
 #endif
     int16_t tid;
 #ifdef JULIA_ENABLE_THREADING
-    jl_tls_states_t *ptls = NULL;
+    jl_tls_states_t *ptls2 = NULL;
     for (tid = 0;tid < jl_n_threads;tid++) {
-        jl_tls_states_t *_ptls = jl_all_tls_states[tid];
-        if (pthread_mach_thread_np(_ptls->system_id) == thread) {
-            ptls = _ptls;
+        jl_tls_states_t *_ptls2 = jl_all_tls_states[tid];
+        if (pthread_mach_thread_np(_ptls2->system_id) == thread) {
+            ptls2 = _ptls2;
             break;
         }
     }
-    if (!ptls) {
+    if (!ptls2) {
         // We don't know about this thread, let the kernel try another handler
         // instead. This shouldn't actually happen since we only register the
         // handler for the threads we know about.
@@ -182,7 +182,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
         return KERN_INVALID_ARGUMENT;
     }
 #else
-    jl_tls_states_t *ptls = &jl_tls_states;
+    jl_tls_states_t *ptls2 = &jl_tls_states;
     tid = 0;
 #endif
     kern_return_t ret = thread_get_state(thread, x86_EXCEPTION_STATE64, (thread_state_t)&exc_state, &exc_count);
@@ -190,12 +190,12 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     uint64_t fault_addr = exc_state.__faultvaddr;
     if (jl_addr_is_safepoint(fault_addr)) {
 #ifdef JULIA_ENABLE_THREADING
-        if (jl_mach_gc_wait(ptls, thread, tid))
+        if (jl_mach_gc_wait(ptls2, thread, tid))
             return KERN_SUCCESS;
-        if (ptls->tid != 0)
+        if (ptls2->tid != 0)
             return KERN_SUCCESS;
 #endif
-        if (ptls->defer_signal) {
+        if (ptls2->defer_signal) {
             jl_safepoint_defer_sigint();
         }
         else if (jl_safepoint_consume_sigint()) {
@@ -210,7 +210,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     if (msync((void*)(fault_addr & ~(jl_page_size - 1)), 1, MS_ASYNC) == 0) { // check if this was a valid address
 #endif
         jl_value_t *excpt;
-        if (is_addr_on_stack(ptls, (void*)fault_addr)) {
+        if (is_addr_on_stack(ptls2, (void*)fault_addr)) {
             excpt = jl_stackovf_exception;
         }
 #ifdef SEGV_EXCEPTION
@@ -232,7 +232,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
         kern_return_t ret = thread_get_state(thread, x86_THREAD_STATE64, (thread_state_t)&state, &count);
         HANDLE_MACH_ERROR("thread_get_state", ret);
         jl_critical_error(SIGSEGV, (unw_context_t*)&state,
-                          ptls->bt_data, &ptls->bt_size);
+                          ptls2->bt_data, &ptls2->bt_size);
         return KERN_INVALID_ARGUMENT;
     }
 }
@@ -247,8 +247,8 @@ static void attach_exception_port(thread_port_t thread)
 
 static void jl_thread_suspend_and_get_state(int tid, unw_context_t **ctx)
 {
-    jl_tls_states_t *ptls = jl_all_tls_states[tid];
-    mach_port_t tid_port = pthread_mach_thread_np(ptls->system_id);
+    jl_tls_states_t *ptls2 = jl_all_tls_states[tid];
+    mach_port_t tid_port = pthread_mach_thread_np(ptls2->system_id);
 
     kern_return_t ret = thread_suspend(tid_port);
     HANDLE_MACH_ERROR("thread_suspend", ret);
@@ -267,8 +267,8 @@ static void jl_thread_suspend_and_get_state(int tid, unw_context_t **ctx)
 
 static void jl_thread_resume(int tid, int sig)
 {
-    jl_tls_states_t *ptls = jl_all_tls_states[tid];
-    mach_port_t thread = pthread_mach_thread_np(ptls->system_id);
+    jl_tls_states_t *ptls2 = jl_all_tls_states[tid];
+    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
     kern_return_t ret = thread_resume(thread);
     HANDLE_MACH_ERROR("thread_resume", ret);
 }
@@ -277,8 +277,8 @@ static void jl_thread_resume(int tid, int sig)
 // or if SIGINT happens too often.
 static void jl_try_deliver_sigint(void)
 {
-    jl_tls_states_t *ptls = jl_all_tls_states[0];
-    mach_port_t thread = pthread_mach_thread_np(ptls->system_id);
+    jl_tls_states_t *ptls2 = jl_all_tls_states[0];
+    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
 
     kern_return_t ret = thread_suspend(thread);
     HANDLE_MACH_ERROR("thread_suspend", ret);
@@ -289,7 +289,7 @@ static void jl_try_deliver_sigint(void)
 
     jl_safepoint_enable_sigint();
     int force = jl_check_force_sigint();
-    if (force || (!ptls->defer_signal && ptls->io_wait)) {
+    if (force || (!ptls2->defer_signal && ptls2->io_wait)) {
         jl_safepoint_consume_sigint();
         if (force)
             jl_safe_printf("WARNING: Force throwing a SIGINT\n");

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -126,7 +126,7 @@ HANDLE hMainThread = INVALID_HANDLE_VALUE;
 // Try to throw the exception in the master thread.
 static void jl_try_deliver_sigint(void)
 {
-    jl_tls_states_t *ptls = jl_all_tls_states[0];
+    jl_tls_states_t *ptls2 = jl_all_tls_states[0];
     jl_safepoint_enable_sigint();
     jl_wake_libuv();
     if ((DWORD)-1 == SuspendThread(hMainThread)) {
@@ -135,7 +135,7 @@ static void jl_try_deliver_sigint(void)
         return;
     }
     int force = jl_check_force_sigint();
-    if (force || (!ptls->defer_signal && ptls->io_wait)) {
+    if (force || (!ptls2->defer_signal && ptls2->io_wait)) {
         jl_safepoint_consume_sigint();
         if (force)
             jl_safe_printf("WARNING: Force throwing a SIGINT\n");


### PR DESCRIPTION
- Passing TLS pointer explicitly to the GC
- Inline pool offset and metadata for all pool sizes instead of only few special cases.

This cuts down 15-25% allocating time for small objects in the generated code (where all the allocation size is known).
