### PR TITLE
Fix #16326: use typesof in code_* for all :call expressions

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -150,12 +150,8 @@ repl(str::AbstractString) = :(apropos($str))
 repl(other) = :(@doc $(esc(other)))
 
 function _repl(x)
-    docs = :(@doc $(esc(x)))
-    if isexpr(x, :call)
-        # Handles function call syntax where each argument is an atom (symbol, number, etc.)
-        t = Base.gen_call_with_extracted_types(doc, x)
-        (isexpr(t, :call, 3) && t.args[1] === doc) && (docs = t)
-    end
+    docs = (isexpr(x, :call) && !any(isexpr(x, :(::)) for x in x.args)) ?
+        Base.gen_call_with_extracted_types(doc, x) : :(@doc $(esc(x)))
     if isfield(x)
         quote
             if isa($(esc(x.args[1])), DataType)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -278,7 +278,8 @@ typesof(args...) = Tuple{map(a->(isa(a,Type) ? Type{a} : typeof(a)), args)...}
 gen_call_with_extracted_types(fcn, ex0::Symbol) = Expr(:call, fcn, Meta.quot(ex0))
 function gen_call_with_extracted_types(fcn, ex0)
     if isa(ex0, Expr) &&
-        any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex0.args)
+          (any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex0.args) ||
+           ex0.head == :call)
         # keyword args not used in dispatch, so just remove them
         args = filter(a->!(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex0.args)
         return Expr(:call, fcn, esc(args[1]),


### PR DESCRIPTION
Not sure about `The tricky cases [...] like ref for getindex, vcat, etc.`, but this fixes #16326 and #16487.
