### PR TITLE
RFC/WIP: flisp repl mode

### DIFF
--- a/base/FlispREPL.jl
+++ b/base/FlispREPL.jl
@@ -1,0 +1,82 @@
+module FlispREPL
+
+import Base: LineEdit, REPL
+
+type FlispCompletionProvider <: LineEdit.CompletionProvider
+    l::REPL.LineEditREPL
+end
+
+function return_callback(p::LineEdit.PromptState)
+    # TODO ... something less dumb
+    buf = takebuf_string(copy(LineEdit.buffer(p)))
+    local sp = 0
+    for c in buf
+      c == '(' && (sp += 1; continue)
+      c == ')' && (sp -= 1; continue)
+    end
+    sp <= 0
+end
+
+fl_eval_string(x::String) = ccall(:jl_flisp_eval, Any, (Ptr{UInt8}, Csize_t), x, sizeof(x))
+
+function evaluate_flisp(s::String)
+    local res
+    try
+        res = fl_eval_string(s)
+    catch e
+        display("error during flisp evaluation: ", e)
+        return nothing
+    end
+    print(STDOUT, res)
+end
+
+function setup_repl(enabled::Bool)
+    # bail out if we don't have a repl
+    if !isdefined(Base, :active_repl) return end
+
+    repl = Base.active_repl
+    main_mode = Base.active_repl.interface.modes[1]
+
+    # disable repl if requested
+    if (!enabled)
+        delete!(main_mode.keymap_dict, ')')
+        return
+    end
+
+    panel = LineEdit.Prompt("flisp> ";
+                            prompt_prefix = Base.text_colors[:white],
+                            prompt_suffix = main_mode.prompt_suffix,
+                            on_enter = return_callback)
+
+    hp = main_mode.hist
+    hp.mode_mapping[:flisp] = panel
+    panel.hist = hp
+    panel.on_done = REPL.respond(evaluate_flisp, repl, panel;
+                                 pass_empty = false)
+    panel.complete = nothing
+
+    const flisp_keymap = Dict{Any,Any}(
+        ')' =>
+            function (s,args...)
+                if isempty(s) || position(LineEdit.buffer(s)) == 0
+                    buf = copy(LineEdit.buffer(s))
+                    LineEdit.transition(s, panel) do
+                        LineEdit.state(s, panel).input_buffer = buf
+                    end
+                else
+                    LineEdit.edit_insert(s, ')')
+                end
+            end)
+
+    search_prompt, skeymap = LineEdit.setup_search_keymap(hp)
+    mk = REPL.mode_keymap(main_mode)
+    b = Dict{Any,Any}[skeymap, mk, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]
+    panel.keymap_dict = LineEdit.keymap(b)
+
+    main_mode.keymap_dict = LineEdit.keymap_merge(main_mode.keymap_dict, flisp_keymap)
+    nothing
+end
+
+end # module
+
+toggle_flisp_repl(; enabled::Bool = true) = FlispREPL.setup_repl(enabled)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -296,6 +296,7 @@ include("LineEdit.jl")
 include("REPLCompletions.jl")
 include("REPL.jl")
 include("client.jl")
+include("FlispREPL.jl")
 
 # misc useful functions & macros
 include("util.jl")

--- a/src/ast.c
+++ b/src/ast.c
@@ -608,6 +608,19 @@ JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len, const 
     return res;
 }
 
+JL_DLLEXPORT jl_value_t *jl_flisp_eval(const char *str, size_t len)
+{
+    jl_ast_context_t *ctx = jl_ast_ctx_enter();
+    fl_context_t *fl_ctx = &ctx->fl;
+    value_t s = cvalue_static_cstrn(fl_ctx, str, len);
+
+    value_t e = fl_applyn(fl_ctx, 1, symbol_value(symbol(fl_ctx, "fl-eval-string")), s);
+
+    jl_value_t *res = e == fl_ctx->FL_EOF ? jl_nothing : scm_to_julia(fl_ctx, e, 0);
+    jl_ast_ctx_leave(ctx);
+    return res;
+}
+
 // this is for parsing one expression out of a string, keeping track of
 // the current position.
 JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -218,6 +218,12 @@
   (parser-wrap (lambda ()
                  (julia-expand-macros expr))))
 
+; helper for flisp repl
+(define (fl-eval-string s)
+    (string (trycatch
+                (eval (read (open-input-string s)))
+                (lambda (e) e))))
+
 ; run whole frontend on a string. useful for testing.
 (define (fe str)
   (expand-toplevel-expr (julia-parse str)))


### PR DESCRIPTION
flisp mode is entered with ')'.

```
julia> Base.toggle_flisp_repl()

julia> )

flisp> (+ 1 2 3)
6

flisp> (jl-parse-string "type Foo end" "")
(type true Foo (block (line 1 )))
...
```

Happy to make the Julia part a package if preferred. The supporting changes to base are small.
