### PR TITLE
remove io :multiline attribute

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -85,14 +85,14 @@ macro enum(T,syms...)
         let insts = ntuple(i->$(esc(typename))($values[i]), $(length(vals)))
             Base.instances(::Type{$(esc(typename))}) = insts
         end
-        function Base.print(io::IO,x::$(esc(typename)))
+        function Base.print(io::IO, x::$(esc(typename)))
             for (sym, i) in $vals
                 if i == Int32(x)
                     print(io, sym); break
                 end
             end
         end
-        function Base.show(io::IO,x::$(esc(typename)))
+        function Base.show(io::IO, x::$(esc(typename)))
             if get(io, :compact, false)
                 print(io, x)
             else
@@ -101,16 +101,15 @@ macro enum(T,syms...)
                 print(io, " = ", Int(x))
             end
         end
-        function Base.show(io::IO,t::Type{$(esc(typename))})
-            if get(io, :multiline, false)
-                print(io, "Enum ")
-                Base.show_datatype(io, t)
-                print(io, ":")
-                for (sym, i) in $vals
-                    print(io, "\n", sym, " = ", i)
-                end
-            else
-                Base.show_datatype(io, t)
+        function Base.show(io::IO, t::Type{$(esc(typename))})
+            Base.show_datatype(io, t)
+        end
+        function Base.show(io::IO, ::MIME"text/plain", t::Type{$(esc(typename))})
+            print(io, "Enum ")
+            Base.show_datatype(io, t)
+            print(io, ":")
+            for (sym, i) in $vals
+                print(io, "\n", sym, " = ", i)
             end
         end
     end

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -108,10 +108,10 @@ end
 
 ==(a::REPLDisplay, b::REPLDisplay) = a.repl === b.repl
 
-function display(d::REPLDisplay, ::MIME"text/plain", x)
+function display(d::REPLDisplay, mime::MIME"text/plain", x)
     io = outstream(d.repl)
     Base.have_color && write(io, answer_color(d.repl))
-    show(IOContext(io, multiline=true, limit=true), MIME("text/plain"), x)
+    show(IOContext(io, :limit => true), mime, x)
     println(io)
 end
 display(d::REPLDisplay, x) = display(d, MIME("text/plain"), x)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -788,6 +788,19 @@ function symperm{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, pinv::Vector{Ti})
         "Pkg.add(\"SuiteSparse\") to install SuiteSparse on Julia v0.5."))
 end
 
+# needs to be a macro so that we can use ::@mime(s) in type declarations
+eval(Multimedia, quote
+export @MIME
+macro MIME(s)
+    Base.warn_once("@MIME(\"\") is deprecated, use MIME\"\" instead.")
+    if isa(s,AbstractString)
+        :(MIME{$(Expr(:quote, Symbol(s)))})
+    else
+        :(MIME{Symbol($s)})
+    end
+end
+end)
+
 # During the 0.5 development cycle, do not add any deprecations below this line
 # To be deprecated in 0.6
 

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -168,15 +168,12 @@ svdfact(M::Bidiagonal; thin::Bool=true) = svdfact!(copy(M),thin=thin)
 ####################
 
 function show(io::IO, M::Bidiagonal)
-    if get(io, :multiline, false)
-        Base.showarray(io, M)
-    else
-        println(io, summary(M), ":")
-        print(io, " diag:")
-        print_matrix(io, (M.dv)')
-        print(io, M.isupper?"\n super:":"\n sub:")
-        print_matrix(io, (M.ev)')
-    end
+    # TODO: make this readable and one-line
+    println(io, summary(M), ":")
+    print(io, " diag:")
+    print_matrix(io, (M.dv)')
+    print(io, M.isupper?"\n super:":"\n sub:")
+    print_matrix(io, (M.ev)')
 end
 
 size(M::Bidiagonal) = (length(M.dv), length(M.dv))

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -3,7 +3,7 @@
 module Multimedia
 
 export Display, display, pushdisplay, popdisplay, displayable, redisplay,
-   MIME, @MIME, @MIME_str, reprmime, stringmime, istextmime,
+   MIME, @MIME_str, reprmime, stringmime, istextmime,
    mimewritable, TextDisplay
 
 ###########################################################################
@@ -17,16 +17,6 @@ import Base: show, print, string, convert
 MIME(s) = MIME{Symbol(s)}()
 show{mime}(io::IO, ::MIME{mime}) = print(io, "MIME type ", string(mime))
 print{mime}(io::IO, ::MIME{mime}) = print(io, mime)
-
-# needs to be a macro so that we can use ::@mime(s) in type declarations
-macro MIME(s)
-    Base.warn_once("@MIME(\"\") is deprecated, use MIME\"\" instead.")
-    if isa(s,AbstractString)
-        :(MIME{$(Expr(:quote, Symbol(s)))})
-    else
-        :(MIME{Symbol($s)})
-    end
-end
 
 macro MIME_str(s)
     :(MIME{$(Expr(:quote, Symbol(s)))})

--- a/base/range.jl
+++ b/base/range.jl
@@ -236,25 +236,13 @@ linspace(start::Real, stop::Real, len::Real=50) =
     linspace(promote(AbstractFloat(start), AbstractFloat(stop))..., len)
 
 function show(io::IO, r::LinSpace)
-    if get(io, :multiline, false)
-        # show for linspace, e.g.
-        # linspace(1,3,7)
-        # 7-element LinSpace{Float64}:
-        #   1.0,1.33333,1.66667,2.0,2.33333,2.66667,3.0
-        print(io, summary(r))
-        if !isempty(r)
-            println(io, ":")
-            print_range(io, r)
-        end
-    else
-        print(io, "linspace(")
-        show(io, first(r))
-        print(io, ',')
-        show(io, last(r))
-        print(io, ',')
-        show(io, length(r))
-        print(io, ')')
-    end
+    print(io, "linspace(")
+    show(io, first(r))
+    print(io, ',')
+    show(io, last(r))
+    print(io, ',')
+    show(io, length(r))
+    print(io, ')')
 end
 
 """
@@ -497,9 +485,7 @@ function getindex{T}(r::LinSpace{T}, s::OrdinalRange)
     return linspace(vfirst, vlast, sl)
 end
 
-function show(io::IO, r::Range)
-    print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
-end
+show(io::IO, r::Range) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
 show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
 
 =={T<:Range}(r::T, s::T) = (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1093,6 +1093,10 @@ function showfactor(io::IO, F::Factor)
     @printf(io, "nnz: %13d\n", nnz(F))
 end
 
+# getindex not defined for these, so don't use the normal array printer
+show(io::IO, ::MIME"text/plain", FC::FactorComponent) = show(io, FC)
+show(io::IO, ::MIME"text/plain", F::Factor) = show(io, F)
+
 isvalid(A::Dense) = check_dense(A)
 isvalid(A::Sparse) = check_sparse(A)
 isvalid(A::Factor) = check_factor(A)
@@ -1115,6 +1119,7 @@ function size(F::Factor, i::Integer)
     end
     return 1
 end
+size(F::Factor) = (size(F, 1), size(F, 2))
 
 linearindexing(::Dense) = LinearFast()
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -76,9 +76,17 @@ convenient iterating over a sparse matrix :
 """
 nzrange(S::SparseMatrixCSC, col::Integer) = S.colptr[col]:(S.colptr[col+1]-1)
 
+function Base.show(io::IO, ::MIME"text/plain", S::SparseMatrixCSC)
+    print(io, S.m, "×", S.n, " sparse matrix with ", nnz(S), " ", eltype(S), " nonzero entries")
+    if nnz(S) != 0
+        print(io, ":")
+        show(io, S)
+    end
+end
+
 function Base.show(io::IO, S::SparseMatrixCSC)
-    if get(io, :multiline, false) || (nnz(S) == 0)
-        print(io, S.m, "×", S.n, " sparse matrix with ", nnz(S), " ", eltype(S), " nonzero entries", nnz(S) == 0 ? "" : ":")
+    if nnz(S) == 0
+        return show(io, MIME("text/plain"), S)
     end
 
     limit::Bool = get(io, :limit, false)
@@ -91,9 +99,9 @@ function Base.show(io::IO, S::SparseMatrixCSC)
     pad = ndigits(max(S.m,S.n))
     k = 0
     sep = "\n\t"
-    io = IOContext(io, multiline=false)
+    io = IOContext(io)
     if !haskey(io, :compact)
-        io = IOContext(io, compact=true)
+        io = IOContext(io, :compact => true)
     end
     for col = 1:S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
         if k < half_screen_rows || k > nnz(S)-half_screen_rows

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -607,23 +607,25 @@ getindex(x::AbstractSparseVector, ::Colon) = copy(x)
 
 ### show and friends
 
+function show(io::IO, ::MIME"text/plain", x::AbstractSparseVector)
+    println(io, summary(x))
+    show(io, x)
+end
+
 function show(io::IO, x::AbstractSparseVector)
+    # TODO: make this a one-line form
     n = length(x)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
     xnnz = length(nzind)
 
-    if get(io, :multiline, false)
-        println(io, summary(x))
-    end
-
     limit::Bool = get(io, :limit, false)
     half_screen_rows = limit ? div(displaysize(io)[1] - 8, 2) : typemax(Int)
     pad = ndigits(n)
     sep = "\n\t"
-    io = IOContext(io, multiline=false)
+    io = IOContext(io)
     if !haskey(io, :compact)
-        io = IOContext(io, compact=true)
+        io = IOContext(io, :compact => true)
     end
     for k = 1:length(nzind)
         if k < half_screen_rows || k > xnnz - half_screen_rows

--- a/base/task.jl
+++ b/base/task.jl
@@ -48,12 +48,6 @@ end
 
 function show(io::IO, t::Task)
     print(io, "Task ($(t.state)) @0x$(hex(convert(UInt, pointer_from_objref(t)), Sys.WORD_SIZE>>2))")
-    if get(io, :multiline, false)
-        if t.state == :failed
-            println(io)
-            showerror(io, CapturedException(t.result, t.backtrace))
-        end
-    end
 end
 
 macro task(ex)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -268,8 +268,8 @@ for d in (Dict("\n" => "\n", "1" => "\n", "\n" => "2"),
     for cols in (12, 40, 80), rows in (2, 10, 24)
         # Ensure output is limited as requested
         s = IOBuffer()
-        io = Base.IOContext(s, limit=true, displaysize=(rows, cols), multiline=true)
-        Base.show(io, d)
+        io = Base.IOContext(s, limit=true, displaysize=(rows, cols))
+        Base.show(io, MIME("text/plain"), d)
         out = split(takebuf_string(s),'\n')
         for line in out[2:end]
             @test strwidth(line) <= cols
@@ -278,8 +278,8 @@ for d in (Dict("\n" => "\n", "1" => "\n", "\n" => "2"),
 
         for f in (keys, values)
             s = IOBuffer()
-            io = Base.IOContext(s, limit=true, displaysize=(rows, cols), multiline=true)
-            Base.show(io, f(d))
+            io = Base.IOContext(s, limit=true, displaysize=(rows, cols))
+            Base.show(io, MIME("text/plain"), f(d))
             out = split(takebuf_string(s),'\n')
             for line in out[2:end]
                 @test strwidth(line) <= cols
@@ -311,9 +311,9 @@ end
 type Alpha end
 Base.show(io::IO, ::Alpha) = print(io,"α")
 let sbuff = IOBuffer(),
-    io = Base.IOContext(sbuff, limit=true, displaysize=(10, 20), multiline=true)
+    io = Base.IOContext(sbuff, limit=true, displaysize=(10, 20))
 
-    Base.show(io, Dict(Alpha()=>1))
+    Base.show(io, MIME("text/plain"), Dict(Alpha()=>1))
     @test !contains(String(sbuff), "…")
     @test endswith(String(sbuff), "α => 1")
 end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -178,7 +178,7 @@ str = takebuf_string(io)
 show(io, S)
 str = takebuf_string(io)
 @test str == "[1 3; 2 4]"
-show(IOContext(io, multiline=true), A)
+show(io, MIME("text/plain"), A)
 strs = split(strip(takebuf_string(io)), '\n')
 @test strs[2] == " 1  3"
 @test strs[3] == " 2  4"
@@ -188,7 +188,7 @@ str = takebuf_string(io)
 show(io, parent(v))
 @test str == takebuf_string(io)
 function cmp_showf(printfunc, io, A)
-    ioc = IOContext(io, limit=true, multiline=true, compact=true)
+    ioc = IOContext(io, limit=true, compact=true)
     printfunc(ioc, A)
     str1 = takebuf_string(io)
     printfunc(ioc, parent(A))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -569,7 +569,7 @@ end
 
 # stringmime/show should display the range or linspace nicely
 # to test print_range in range.jl
-replstrmime(x) = sprint((io,x) -> show(IOContext(io, multiline=true, limit=true), MIME("text/plain"), x), x)
+replstrmime(x) = sprint((io,x) -> show(IOContext(io, limit=true), MIME("text/plain"), x), x)
 @test replstrmime(1:4) == "1:4"
 @test stringmime("text/plain", 1:4) == "1:4"
 @test stringmime("text/plain", linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -392,10 +392,10 @@ end
 
 # Issue #14684: `display` should prints associative types in full.
 let d = Dict(1 => 2, 3 => 45)
-    buf = IOContext(IOBuffer(), multiline=true)
+    buf = IOBuffer()
     td = TextDisplay(buf)
     display(td, d)
-    result = String(td.io.io)
+    result = String(td.io)
 
     @test contains(result, summary(d))
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-replstr(x) = sprint((io,x) -> show(IOContext(io, multiline=true, limit=true), MIME("text/plain"), x), x)
+replstr(x) = sprint((io,x) -> show(IOContext(io, limit=true), MIME("text/plain"), x), x)
 
 @test replstr(Array{Any}(2)) == "2-element Array{Any,1}:\n #undef\n #undef"
 @test replstr(Array{Any}(2,2)) == "2×2 Array{Any,2}:\n #undef  #undef\n #undef  #undef"
@@ -490,18 +490,13 @@ let io = IOBuffer()
     x = [1, 2]
     showcompact(io, x)
     @test takebuf_string(io) == "[1,2]"
-    showcompact(IOContext(io, :multiline=>true), x)
-    @test takebuf_string(io) == "[1,2]"
     showcompact(IOContext(io, :compact=>true), x)
-    @test takebuf_string(io) == "[1,2]"
-    showcompact(IOContext(IOContext(io, :compact=>true), :multiline=>true), x)
     @test takebuf_string(io) == "[1,2]"
 end
 
 # PR 17117
 # test show array
 let s  = IOBuffer(Array{UInt8}(0), true, true)
-    io = IOContext(s, multiline=true)
-    Base.showarray(io, [1,2,3], header = false)
+    Base.showarray(s, [1,2,3], false, header = false)
     @test String(resize!(s.data, s.size)) == " 1\n 2\n 3"
 end

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -591,7 +591,12 @@ Dp = spdiagm(dp)
 sparse(cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))); gc()
 
 # Issue 11747 - Wrong show method defined for FactorComponent
-Base.show(IOBuffer(), MIME"text/plain"(), cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))[:L])
+let v = cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))[:L]
+    for s in (sprint(show, MIME("text/plain"), v), sprint(show, v))
+        @test contains(s, "method: simplicial")
+        @test !contains(s, "#undef")
+    end
+end
 
 # Element promotion and type inference
 @inferred cholfact(As)\ones(Int, size(As, 1))


### PR DESCRIPTION
this attribute doesn't nest properly,
and functions just end up branching almost the entire code based
on this parameter, so it's cleaner as a separate method

fix JuliaLang/julia#17087
fix JuliaLang/julia#16910
fix JuliaLang/julia#17090
