### PR TITLE
More explicit TLS access and GC allocation optimization

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -82,7 +82,8 @@ function finalizer{T}(o::T, f::Ptr{Void})
           Core.getptls(), o, f)
 end
 
-finalize(o::ANY) = ccall(:jl_finalize, Void, (Any,), o)
+finalize(o::ANY) = ccall(:jl_finalize_th, Void, (Ptr{Void}, Any,),
+                         Core.getptls(), o)
 
 gc(full::Bool=true) = ccall(:jl_gc_collect, Void, (Cint,), full)
 gc_enable(on::Bool) = ccall(:jl_gc_enable, Cint, (Cint,), on)!=0

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -248,7 +248,8 @@ end
 type WeakRef
     value
     WeakRef() = WeakRef(nothing)
-    WeakRef(v::ANY) = ccall(:jl_gc_new_weakref, Ref{WeakRef}, (Any,), v)
+    WeakRef(v::ANY) = ccall(:jl_gc_new_weakref_th, Ref{WeakRef},
+                            (Ptr{Void}, Any), getptls(), v)
 end
 
 TypeVar(n::Symbol) =

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -576,6 +576,7 @@ JL_DLLEXPORT void jl_method_init_properties(jl_method_t *m)
 
 JL_DLLEXPORT jl_method_t *jl_new_method_uninit(void)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_method_t *m =
         (jl_method_t*)newobj((jl_value_t*)jl_method_type,
                              NWORDS(sizeof(jl_method_t)));
@@ -584,7 +585,7 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(void)
     m->tvars = NULL;
     m->ambig = NULL;
     m->roots = NULL;
-    m->module = jl_current_module;
+    m->module = ptls->current_module;
     m->lambda_template = NULL;
     m->name = NULL;
     m->file = empty_sym;
@@ -841,7 +842,8 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
 
 JL_DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name)
 {
-    return jl_new_typename_in(name, jl_current_module);
+    jl_ptls_t ptls = jl_get_ptls_states();
+    return jl_new_typename_in(name, ptls->current_module);
 }
 
 jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
@@ -986,6 +988,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super
                                             int abstract, int mutabl,
                                             int ninitialized)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_datatype_t *t=NULL;
     jl_typename_t *tn=NULL;
     JL_GC_PUSH2(&t, &tn);
@@ -1032,7 +1035,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super
         else {
             tn = jl_new_typename((jl_sym_t*)name);
             if (!abstract) {
-                tn->mt = jl_new_method_table(name, jl_current_module);
+                tn->mt = jl_new_method_table(name, ptls->current_module);
                 jl_gc_wb(tn, tn->mt);
             }
         }

--- a/src/ast.c
+++ b/src/ast.c
@@ -105,35 +105,39 @@ static value_t julia_to_scm(fl_context_t *fl_ctx, jl_value_t *v);
 
 value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     // tells whether a var is defined in and *by* the current module
     argcount(fl_ctx, "defined-julia-global", nargs, 1);
     (void)tosymbol(fl_ctx, args[0], "defined-julia-global");
-    if (jl_current_module == NULL)
+    if (ptls->current_module == NULL)
         return fl_ctx->F;
     jl_sym_t *var = jl_symbol(symbol_name(fl_ctx, args[0]));
     jl_binding_t *b =
-        (jl_binding_t*)ptrhash_get(&jl_current_module->bindings, var);
-    return (b != HT_NOTFOUND && b->owner==jl_current_module) ? fl_ctx->T : fl_ctx->F;
+        (jl_binding_t*)ptrhash_get(&ptls->current_module->bindings, var);
+    return (b != HT_NOTFOUND && b->owner==ptls->current_module) ? fl_ctx->T : fl_ctx->F;
 }
 
 value_t fl_current_julia_module(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     value_t opaque = cvalue(fl_ctx, jl_ast_ctx(fl_ctx)->jvtype, sizeof(void*));
-    *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = (jl_value_t*)jl_current_module;
+    *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = (jl_value_t*)ptls->current_module;
     return opaque;
 }
 
 value_t fl_current_module_counter(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     static uint32_t fallback_counter = 0;
-    if (jl_current_module == NULL)
+    if (ptls->current_module == NULL)
         return fixnum(++fallback_counter);
     else
-        return fixnum(jl_module_next_counter(jl_current_module));
+        return fixnum(jl_module_next_counter(ptls->current_module));
 }
 
 value_t fl_invoke_julia_macro(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (nargs < 1)
         argcount(fl_ctx, "invoke-julia-macro", nargs, 1);
     jl_lambda_info_t *mfunc = NULL;
@@ -158,7 +162,7 @@ value_t fl_invoke_julia_macro(fl_context_t *fl_ctx, value_t *args, uint32_t narg
     JL_CATCH {
         JL_GC_POP();
         value_t opaque = cvalue(fl_ctx, jl_ast_ctx(fl_ctx)->jvtype, sizeof(void*));
-        *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = jl_exception_in_transit;
+        *(jl_value_t**)cv_data((cvalue_t*)ptr(opaque)) = ptls->exception_in_transit;
         return fl_list2(fl_ctx, jl_ast_ctx(fl_ctx)->error_sym, opaque);
     }
     // protect result from GC, otherwise it could be freed during future
@@ -172,7 +176,7 @@ value_t fl_invoke_julia_macro(fl_context_t *fl_ctx, value_t *args, uint32_t narg
     fl_gc_handle(fl_ctx, &scm);
     value_t scmresult;
     jl_module_t *defmod = mfunc->def->module;
-    if (defmod == NULL || defmod == jl_current_module) {
+    if (defmod == NULL || defmod == ptls->current_module) {
         scmresult = fl_cons(fl_ctx, scm, fl_ctx->F);
     }
     else {
@@ -232,6 +236,7 @@ static jl_ast_context_list_t *jl_ast_ctx_freed = NULL;
 
 static jl_ast_context_t *jl_ast_ctx_enter(void)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     JL_SIGATOMIC_BEGIN();
     JL_LOCK_NOGC(&flisp_lock);
     jl_ast_context_list_t *node;
@@ -239,7 +244,7 @@ static jl_ast_context_t *jl_ast_ctx_enter(void)
     // First check if the current task is using one of the contexts
     for (node = jl_ast_ctx_using;node;(node = node->next)) {
         ctx = jl_ast_context_list_item(node);
-        if (ctx->task == jl_current_task) {
+        if (ctx->task == ptls->current_task) {
             ctx->ref++;
             JL_UNLOCK_NOGC(&flisp_lock);
             return ctx;
@@ -251,7 +256,7 @@ static jl_ast_context_t *jl_ast_ctx_enter(void)
         jl_ast_context_list_insert(&jl_ast_ctx_using, node);
         ctx = jl_ast_context_list_item(node);
         ctx->ref = 1;
-        ctx->task = jl_current_task;
+        ctx->task = ptls->current_task;
         ctx->roots = NULL;
         JL_UNLOCK_NOGC(&flisp_lock);
         return ctx;
@@ -260,7 +265,7 @@ static jl_ast_context_t *jl_ast_ctx_enter(void)
     ctx = (jl_ast_context_t*)calloc(1, sizeof(jl_ast_context_t));
     // ctx->roots is NULL already due to calloc.
     ctx->ref = 1;
-    ctx->task = jl_current_task;
+    ctx->task = ptls->current_task;
     node = &ctx->list;
     jl_ast_context_list_insert(&jl_ast_ctx_using, node);
     JL_UNLOCK_NOGC(&flisp_lock);
@@ -283,10 +288,11 @@ static void jl_ast_ctx_leave(jl_ast_context_t *ctx)
 
 void jl_init_frontend(void)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (jl_ast_ctx_using || jl_ast_ctx_freed)
         return;
     jl_ast_main_ctx.ref = 1;
-    jl_ast_main_ctx.task = jl_current_task;
+    jl_ast_main_ctx.task = ptls->current_task;
     jl_ast_context_list_insert(&jl_ast_ctx_using, &jl_ast_main_ctx.list);
     jl_init_ast_ctx(&jl_ast_main_ctx);
     // To match the one in jl_ast_ctx_leave
@@ -344,6 +350,7 @@ extern int64_t conv_to_int64(void *data, numerictype_t tag);
 
 static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (fl_isnumber(fl_ctx, e)) {
         int64_t i64;
         if (isfixnum(e)) {
@@ -444,7 +451,7 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, int eo)
             if (sym == top_sym) {
                 scmv = scm_to_julia_(fl_ctx,car_(e),0);
                 assert(jl_is_symbol(scmv));
-                temp = jl_module_globalref(jl_base_relative_to(jl_current_module), (jl_sym_t*)scmv);
+                temp = jl_module_globalref(jl_base_relative_to(ptls->current_module), (jl_sym_t*)scmv);
                 JL_GC_POP();
                 return temp;
             }
@@ -644,6 +651,7 @@ JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
 jl_value_t *jl_parse_eval_all(const char *fname,
                               const char *content, size_t contentlen)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (in_pure_callback)
         jl_error("cannot use include inside a generated function");
     jl_ast_context_t *ctx = jl_ast_ctx_enter();
@@ -717,7 +725,7 @@ jl_value_t *jl_parse_eval_all(const char *fname,
             jl_rethrow();
         else
             jl_rethrow_other(jl_new_struct(jl_loaderror_type, form, result,
-                                           jl_exception_in_transit));
+                                           ptls->exception_in_transit));
     }
     JL_GC_POP();
     return result;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -210,9 +210,10 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
 
 JL_DLLEXPORT void jl_pop_handler(int n)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (__unlikely(n <= 0))
         return;
-    jl_handler_t *eh = jl_current_task->eh;
+    jl_handler_t *eh = ptls->current_task->eh;
     while (--n > 0)
         eh = eh->prev;
     jl_eh_restore_state(eh);
@@ -540,6 +541,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex)
 
 jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_warn)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     static int jl_warn_on_eval = 0;
     int last_delay_warn = jl_warn_on_eval;
     if (m == NULL)
@@ -548,8 +550,8 @@ jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_w
         return jl_eval_global_var(m, (jl_sym_t*)ex);
     jl_value_t *v=NULL;
     int last_lineno = jl_lineno;
-    jl_module_t *last_m = jl_current_module;
-    jl_module_t *task_last_m = jl_current_task->current_module;
+    jl_module_t *last_m = ptls->current_module;
+    jl_module_t *task_last_m = ptls->current_task->current_module;
     if (!delay_warn && jl_options.incremental && jl_generating_output()) {
         if (m != last_m) {
             jl_printf(JL_STDERR, "WARNING: eval from module %s to %s:    \n",
@@ -567,27 +569,28 @@ jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_w
         jl_error("eval cannot be used in a generated function");
     JL_TRY {
         jl_warn_on_eval = delay_warn && (jl_warn_on_eval || m != last_m); // compute whether a warning was suppressed
-        jl_current_task->current_module = jl_current_module = m;
+        ptls->current_task->current_module = ptls->current_module = m;
         v = jl_toplevel_eval(ex);
     }
     JL_CATCH {
         jl_warn_on_eval = last_delay_warn;
         jl_lineno = last_lineno;
-        jl_current_module = last_m;
-        jl_current_task->current_module = task_last_m;
+        ptls->current_module = last_m;
+        ptls->current_task->current_module = task_last_m;
         jl_rethrow();
     }
     jl_warn_on_eval = last_delay_warn;
     jl_lineno = last_lineno;
-    jl_current_module = last_m;
-    jl_current_task->current_module = task_last_m;
+    ptls->current_module = last_m;
+    ptls->current_task->current_module = task_last_m;
     assert(v);
     return v;
 }
 
 JL_CALLABLE(jl_f_isdefined)
 {
-    jl_module_t *m = jl_current_module;
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_module_t *m = ptls->current_module;
     jl_sym_t *s=NULL;
     JL_NARGSV(isdefined, 1);
     if (jl_is_array(args[0])) {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -854,7 +854,7 @@ static jl_cgval_t mark_or_box_ccall_result(Value *result, bool isboxed, jl_value
         int nb = sizeof(void*);
         // TODO: can this be tighter than tbaa_value?
         return mark_julia_type(
-            init_bits_value(emit_allocobj(ctx, nb), runtime_bt, result, tbaa_value),
+            init_bits_value(emit_allocobj(ctx, nb, runtime_bt), result, tbaa_value),
             true, (jl_value_t*)jl_pointer_type, ctx);
     }
     return mark_julia_type(result, isboxed, rt, ctx);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1010,6 +1010,7 @@ static std::string generate_func_sig(
 // ccall(pointer, rettype, (argtypes...), args...)
 static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     JL_NARGSV(ccall, 3);
     jl_value_t *rt=NULL, *at=NULL;
     JL_GC_PUSH2(&rt, &at);
@@ -1069,9 +1070,10 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                 }
             }
             if (rt == NULL) {
-                if (jl_exception_in_transit && jl_typeis(jl_exception_in_transit,
-                                                         jl_undefvarerror_type)
-                                            && jl_is_symbol(args[2])) {
+                if (ptls->exception_in_transit &&
+                    jl_typeis(ptls->exception_in_transit,
+                              jl_undefvarerror_type) &&
+                    jl_is_symbol(args[2])) {
                     std::string msg = "ccall return type undefined: " +
                                       std::string(jl_symbol_name((jl_sym_t*)args[2]));
                     emit_error(msg.c_str(), ctx);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3709,9 +3709,8 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
                 (void)julia_type_to_llvm(jargty, &isboxed);
                 if (isboxed) {
                     // passed an unboxed T, but want something boxed
-                    Value *mem = emit_allocobj(&ctx, jl_datatype_size(jargty));
-                    tbaa_decorate(tbaa_tag, builder.CreateStore(literal_pointer_val((jl_value_t*)jargty),
-                                                                emit_typeptr_addr(mem)));
+                    Value *mem = emit_allocobj(&ctx, jl_datatype_size(jargty),
+                                               literal_pointer_val((jl_value_t*)jargty));
                     tbaa_decorate(jl_is_mutable(jargty) ? tbaa_mutab : tbaa_immut,
                                   builder.CreateAlignedStore(val,
                                                              builder.CreateBitCast(mem, val->getType()->getPointerTo()),

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1334,7 +1334,7 @@ static uint64_t compute_obj_symsize(const object::ObjectFile *obj, uint64_t offs
 extern "C" JL_DLLEXPORT
 const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     std::string code;
     llvm::raw_string_ostream stream(code);
 #ifndef LLVM37

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -248,7 +248,7 @@ public:
     virtual void NotifyFunctionEmitted(const Function &F, void *Code,
                                        size_t Size, const EmittedFunctionDetails &Details)
     {
-        jl_tls_states_t *ptls = jl_get_ptls_states();
+        jl_ptls_t ptls = jl_get_ptls_states();
         // This function modify linfo->fptr in GC safe region.
         // This should be fine since the GC won't scan this field.
         int8_t gc_state = jl_gc_safe_enter(ptls);
@@ -307,7 +307,7 @@ public:
     virtual void NotifyObjectEmitted(const ObjectImage &obj)
 #endif
     {
-        jl_tls_states_t *ptls = jl_get_ptls_states();
+        jl_ptls_t ptls = jl_get_ptls_states();
         // This function modify linfo->fptr in GC safe region.
         // This should be fine since the GC won't scan this field.
         int8_t gc_state = jl_gc_safe_enter(ptls);
@@ -1183,7 +1183,7 @@ int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide, int64_t *se
 extern "C"
 JL_DLLEXPORT jl_value_t *jl_get_dobj_data(uint64_t fptr)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     // Used by Gallium.jl
     const object::ObjectFile *object = NULL;
     DIContext *context;
@@ -1205,7 +1205,7 @@ JL_DLLEXPORT jl_value_t *jl_get_dobj_data(uint64_t fptr)
 extern "C"
 JL_DLLEXPORT uint64_t jl_get_section_start(uint64_t fptr)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     // Used by Gallium.jl
     int8_t gc_state = jl_gc_safe_enter(ptls);
     std::map<size_t, ObjectInfo, revcomp> &objmap = jl_jit_events->getObjectMap();

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -139,7 +139,7 @@ static void clear_mark(int bits)
                 for (int j = 0; j < 32; j++) {
                     if ((line >> j) & 1) {
                         jl_gc_pagemeta_t *pg = page_metadata(region->pages[pg_i*32 + j].data + GC_PAGE_OFFSET);
-                        jl_tls_states_t *ptls2 = jl_all_tls_states[pg->thread_n];
+                        jl_ptls_t ptls2 = jl_all_tls_states[pg->thread_n];
                         jl_gc_pool_t *pool = &ptls2->heap.norm_pools[pg->pool_n];
                         pv = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
                         char *lim = (char*)pv + GC_PAGE_SZ - GC_PAGE_OFFSET - pool->osize;
@@ -173,7 +173,7 @@ static void gc_verify_track(void)
         pre_mark();
         gc_mark_object_list(&to_finalize, 0);
         for (int i = 0;i < jl_n_threads;i++) {
-            jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+            jl_ptls_t ptls2 = jl_all_tls_states[i];
             gc_mark_object_list(&ptls2->finalizers, 0);
         }
         gc_mark_object_list(&finalizer_list_marked, 0);
@@ -219,7 +219,7 @@ void gc_verify(void)
     pre_mark();
     gc_mark_object_list(&to_finalize, 0);
     for (int i = 0;i < jl_n_threads;i++) {
-        jl_tls_states_t *ptls2 = jl_all_tls_states[i];
+        jl_ptls_t ptls2 = jl_all_tls_states[i];
         gc_mark_object_list(&ptls2->finalizers, 0);
     }
     gc_mark_object_list(&finalizer_list_marked, 0);
@@ -660,7 +660,7 @@ void gc_time_mark_pause(int64_t t0, int64_t scanned_bytes,
     int64_t last_remset_len = 0;
     int64_t remset_nptr = 0;
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
+        jl_ptls_t ptls2 = jl_all_tls_states[t_i];
         last_remset_len += ptls2->heap.last_remset->len;
         remset_nptr = ptls2->heap.remset_nptr;
     }
@@ -779,7 +779,7 @@ void gc_stats_all_pool(void)
     size_t nb=0, w, tw=0, no=0,tp=0, nold=0,noldbytes=0, np, nol;
     for (int i = 0; i < JL_GC_N_POOLS; i++) {
         for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-            jl_tls_states_t *ptls2 = jl_all_tls_states[t_i];
+            jl_ptls_t ptls2 = jl_all_tls_states[t_i];
             size_t b = pool_stats(&ptls2->heap.norm_pools[i], &w, &np, &nol);
             nb += b;
             no += (b / ptls2->heap.norm_pools[i].osize);

--- a/src/gc.h
+++ b/src/gc.h
@@ -32,15 +32,10 @@ extern "C" {
 
 // manipulating mark bits
 
-#define GC_PAGE_LG2 14 // log2(size of a page)
-#define GC_PAGE_SZ (1 << GC_PAGE_LG2) // 16k
-#define GC_PAGE_OFFSET (JL_SMALL_BYTE_ALIGNMENT - (sizeof(jl_taggedvalue_t) % JL_SMALL_BYTE_ALIGNMENT))
-
 // 8G * 32768 = 2^48
 // It's really unlikely that we'll actually allocate that much though...
 #define REGION_COUNT 32768
 
-#define jl_buff_tag ((uintptr_t)0x4eade800)
 #define jl_malloc_tag ((void*)0xdeadaa01)
 #define jl_singleton_tag ((void*)0xdeadaa02)
 
@@ -278,6 +273,7 @@ void pre_mark(jl_ptls_t ptls);
 void gc_mark_object_list(jl_ptls_t ptls, arraylist_t *list, size_t start);
 void visit_mark_stack(jl_ptls_t ptls);
 void gc_debug_init(void);
+void jl_mark_box_caches(jl_ptls_t ptls);
 
 // GC pages
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -147,7 +147,7 @@ typedef struct {
     uint16_t osize; // size of each object in this page
     uint16_t fl_begin_offset; // offset of first free object in this page
     uint16_t fl_end_offset;   // offset of last free object in this page
-    uint16_t thread_n;        // index (into jl_thread_heap) of heap that owns this page
+    uint16_t thread_n;        // thread id of the heap that owns this page
     char *data;
     uint8_t *ages;
 } jl_gc_pagemeta_t;
@@ -278,8 +278,6 @@ void pre_mark(void);
 void gc_mark_object_list(arraylist_t *list, size_t start);
 void visit_mark_stack(void);
 void gc_debug_init(void);
-
-#define jl_thread_heap (jl_get_ptls_states()->heap)
 
 // GC pages
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -274,9 +274,9 @@ STATIC_INLINE void gc_big_object_link(bigval_t *hdr, bigval_t **list)
     *list = hdr;
 }
 
-void pre_mark(void);
-void gc_mark_object_list(arraylist_t *list, size_t start);
-void visit_mark_stack(void);
+void pre_mark(jl_ptls_t ptls);
+void gc_mark_object_list(jl_ptls_t ptls, arraylist_t *list, size_t start);
+void visit_mark_stack(jl_ptls_t ptls);
 void gc_debug_init(void);
 
 // GC pages
@@ -349,7 +349,7 @@ STATIC_INLINE void gc_time_count_mallocd_array(int bits)
 
 #ifdef GC_VERIFY
 extern jl_value_t *lostval;
-void gc_verify(void);
+void gc_verify(jl_ptls_t ptls);
 void add_lostval_parent(jl_value_t *parent);
 #define verify_val(v) do {                                              \
         if (lostval == (jl_value_t*)(v) && (v) != 0) {                  \
@@ -380,7 +380,7 @@ void add_lostval_parent(jl_value_t *parent);
 #define verify_parent2(ty,obj,slot,arg1,arg2) verify_parent(ty,obj,slot,arg1,arg2)
 extern int gc_verifying;
 #else
-#define gc_verify()
+#define gc_verify(ptls)
 #define verify_val(v)
 #define verify_parent1(ty,obj,slot,arg1)
 #define verify_parent2(ty,obj,slot,arg1,arg2)

--- a/src/gf.c
+++ b/src/gf.c
@@ -82,6 +82,7 @@ JL_DLLEXPORT void jl_register_linfo_tracer(void (*callback)(jl_lambda_info_t *tr
 
 void jl_call_tracer(tracer_cb callback, jl_value_t *tracee)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     int last_in = in_pure_callback;
     JL_TRY {
         in_pure_callback = 1;
@@ -91,7 +92,7 @@ void jl_call_tracer(tracer_cb callback, jl_value_t *tracee)
     JL_CATCH {
         in_pure_callback = last_in;
         jl_printf(JL_STDERR, "WARNING: tracer callback function threw an error:\n");
-        jl_static_show(JL_STDERR, jl_exception_in_transit);
+        jl_static_show(JL_STDERR, ptls->exception_in_transit);
         jl_printf(JL_STDERR, "\n");
         jlbacktrace();
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -1087,6 +1087,7 @@ void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletyp
 
 void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *fargs[3] = {
         (jl_value_t*)jl_methoderror_type,
         (jl_value_t*)f,
@@ -1099,8 +1100,8 @@ void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args)
         jl_printf((JL_STREAM*)STDERR_FILENO, "A method error occurred before the base MethodError type was defined. Aborting...\n");
         jl_static_show((JL_STREAM*)STDERR_FILENO,(jl_value_t*)f); jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
         jl_static_show((JL_STREAM*)STDERR_FILENO,args); jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
-        jl_bt_size = rec_backtrace(jl_bt_data, JL_MAX_BT_SIZE);
-        jl_critical_error(0, NULL, jl_bt_data, &jl_bt_size);
+        ptls->bt_size = rec_backtrace(ptls->bt_data, JL_MAX_BT_SIZE);
+        jl_critical_error(0, NULL, ptls->bt_data, &ptls->bt_size);
         abort();
     }
     // not reached

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -400,7 +400,7 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
         }
         jl_compute_field_offsets(dt);
         if (para == (jl_value_t*)jl_emptysvec && jl_is_datatype_make_singleton(dt)) {
-            dt->instance = newstruct(dt);
+            dt->instance = jl_gc_alloc(ptls, 0, dt);
             jl_gc_wb(dt, dt->instance);
         }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -507,7 +507,8 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
         return mark_julia_type(vx, false, bt, ctx);
     else
         return mark_julia_type(
-            init_bits_value(emit_allocobj(ctx, nb), boxed(bt_value, ctx), vx, tbaa_immut),
+            init_bits_value(emit_allocobj(ctx, nb, boxed(bt_value, ctx)),
+                            vx, tbaa_immut),
             true, bt, ctx);
 }
 
@@ -548,8 +549,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
         Value *runtime_bt = boxed(bt_value, ctx);
         // XXX: emit type validity check on runtime_bt (bitstype of size nb)
 
-        Value *newobj = emit_allocobj(ctx, nb);
-        tbaa_decorate(tbaa_tag, builder.CreateStore(runtime_bt, emit_typeptr_addr(newobj)));
+        Value *newobj = emit_allocobj(ctx, nb, runtime_bt);
         if (!v.ispointer()) {
             tbaa_decorate(tbaa_value, builder.CreateAlignedStore(emit_unbox(llvmt, v, v.typ), builder.CreatePointerCast(newobj, llvmt->getPointerTo()), alignment));
         }
@@ -772,9 +772,8 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
         }
         assert(jl_is_datatype(ety));
         uint64_t size = jl_datatype_size(ety);
-        Value *strct = emit_allocobj(ctx, size);
-        tbaa_decorate(tbaa_tag, builder.CreateStore(literal_pointer_val((jl_value_t*)ety),
-                                                    emit_typeptr_addr(strct)));
+        Value *strct = emit_allocobj(ctx, size,
+                                     literal_pointer_val((jl_value_t*)ety));
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, ((jl_datatype_t*)ety)->alignment)));
         thePtr = builder.CreateGEP(builder.CreateBitCast(thePtr, T_pint8), im1);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -136,7 +136,7 @@ JL_DLLEXPORT void *jl_uv_write_handle(uv_write_t *req) { return req->handle; }
 
 JL_DLLEXPORT int jl_run_once(uv_loop_t *loop)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (loop) {
         loop->stop_flag = 0;
         jl_gc_safepoint_(ptls);
@@ -147,7 +147,7 @@ JL_DLLEXPORT int jl_run_once(uv_loop_t *loop)
 
 JL_DLLEXPORT void jl_run_event_loop(uv_loop_t *loop)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (loop) {
         loop->stop_flag = 0;
         jl_gc_safepoint_(ptls);
@@ -157,7 +157,7 @@ JL_DLLEXPORT void jl_run_event_loop(uv_loop_t *loop)
 
 JL_DLLEXPORT int jl_process_events(uv_loop_t *loop)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (loop) {
         loop->stop_flag = 0;
         jl_gc_safepoint_(ptls);
@@ -351,7 +351,8 @@ JL_DLLEXPORT int jl_fs_chown(char *path, int uid, int gid)
 JL_DLLEXPORT int jl_fs_write(int handle, const char *data, size_t len,
                              int64_t offset)
 {
-    if (jl_safe_restore)
+    jl_ptls_t ptls = jl_get_ptls_states();
+    if (ptls->safe_restore)
         return write(handle, data, len);
     uv_fs_t req;
     uv_buf_t buf[1];

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -229,7 +229,8 @@ JL_DLLEXPORT void jl_sigatomic_begin(void)
 
 JL_DLLEXPORT void jl_sigatomic_end(void)
 {
-    if (jl_get_ptls_states()->defer_signal == 0)
+    jl_ptls_t ptls = jl_get_ptls_states();
+    if (ptls->defer_signal == 0)
         jl_error("sigatomic_end called in non-sigatomic region");
     JL_SIGATOMIC_END();
 }
@@ -326,31 +327,31 @@ JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
 
 JL_DLLEXPORT int8_t (jl_gc_unsafe_enter)(void)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     return jl_gc_unsafe_enter(ptls);
 }
 
 JL_DLLEXPORT void (jl_gc_unsafe_leave)(int8_t state)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_gc_unsafe_leave(ptls, state);
 }
 
 JL_DLLEXPORT int8_t (jl_gc_safe_enter)(void)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     return jl_gc_safe_enter(ptls);
 }
 
 JL_DLLEXPORT void (jl_gc_safe_leave)(int8_t state)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_gc_safe_leave(ptls, state);
 }
 
 JL_DLLEXPORT void (jl_gc_safepoint)(void)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_gc_safepoint_(ptls);
 }
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -69,13 +69,15 @@ JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
 
 JL_DLLEXPORT jl_value_t *jl_exception_occurred(void)
 {
-    return jl_exception_in_transit == jl_nothing ? NULL :
-        jl_exception_in_transit;
+    jl_ptls_t ptls = jl_get_ptls_states();
+    return ptls->exception_in_transit == jl_nothing ? NULL :
+        ptls->exception_in_transit;
 }
 
 JL_DLLEXPORT void jl_exception_clear(void)
 {
-    jl_exception_in_transit = jl_nothing;
+    jl_ptls_t ptls = jl_get_ptls_states();
+    ptls->exception_in_transit = jl_nothing;
 }
 
 // get the name of a type as a string

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3456,6 +3456,7 @@ extern void jl_init_int32_int64_cache(void);
 
 void jl_init_types(void)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     arraylist_new(&partial_inst, 0);
     // create base objects
     jl_datatype_type = jl_new_uninitialized_datatype(11, 1);
@@ -3473,7 +3474,7 @@ void jl_init_types(void)
     jl_any_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Any"), NULL, jl_emptysvec);
     jl_any_type->super = jl_any_type;
     jl_type_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Type"), jl_any_type, jl_emptysvec);
-    jl_type_type_mt = jl_new_method_table(jl_type_type->name->name, jl_current_module);
+    jl_type_type_mt = jl_new_method_table(jl_type_type->name->name, ptls->current_module);
     jl_type_type->name->mt = jl_type_type_mt;
 
     // initialize them. lots of cycles.
@@ -3510,7 +3511,7 @@ void jl_init_types(void)
 
     jl_typename_type->name = jl_new_typename(jl_symbol("TypeName"));
     jl_typename_type->name->primary = (jl_value_t*)jl_typename_type;
-    jl_typename_type->name->mt = jl_new_method_table(jl_typename_type->name->name, jl_current_module);
+    jl_typename_type->name->mt = jl_new_method_table(jl_typename_type->name->name, ptls->current_module);
     jl_typename_type->super = jl_any_type;
     jl_typename_type->parameters = jl_emptysvec;
     jl_typename_type->name->names = jl_svec(8, jl_symbol("name"), jl_symbol("module"),
@@ -3531,7 +3532,7 @@ void jl_init_types(void)
 
     jl_methtable_type->name = jl_new_typename(jl_symbol("MethodTable"));
     jl_methtable_type->name->primary = (jl_value_t*)jl_methtable_type;
-    jl_methtable_type->name->mt = jl_new_method_table(jl_methtable_type->name->name, jl_current_module);
+    jl_methtable_type->name->mt = jl_new_method_table(jl_methtable_type->name->name, ptls->current_module);
     jl_methtable_type->super = jl_any_type;
     jl_methtable_type->parameters = jl_emptysvec;
     jl_methtable_type->name->names = jl_svec(6, jl_symbol("name"), jl_symbol("defs"),
@@ -3550,7 +3551,7 @@ void jl_init_types(void)
 
     jl_sym_type->name = jl_new_typename(jl_symbol("Symbol"));
     jl_sym_type->name->primary = (jl_value_t*)jl_sym_type;
-    jl_sym_type->name->mt = jl_new_method_table(jl_sym_type->name->name, jl_current_module);
+    jl_sym_type->name->mt = jl_new_method_table(jl_sym_type->name->name, ptls->current_module);
     jl_sym_type->super = jl_any_type;
     jl_sym_type->parameters = jl_emptysvec;
     jl_sym_type->name->names = jl_emptysvec;
@@ -3567,7 +3568,7 @@ void jl_init_types(void)
 
     jl_simplevector_type->name = jl_new_typename(jl_symbol("SimpleVector"));
     jl_simplevector_type->name->primary = (jl_value_t*)jl_simplevector_type;
-    jl_simplevector_type->name->mt = jl_new_method_table(jl_simplevector_type->name->name, jl_current_module);
+    jl_simplevector_type->name->mt = jl_new_method_table(jl_simplevector_type->name->name, ptls->current_module);
     jl_simplevector_type->super = jl_any_type;
     jl_simplevector_type->parameters = jl_emptysvec;
     jl_simplevector_type->name->names = jl_svec(1, jl_symbol("length"));

--- a/src/julia.h
+++ b/src/julia.h
@@ -1508,7 +1508,7 @@ static inline void jl_lock_frame_pop(void)
 
 STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_task_t *current_task = ptls->current_task;
     // `eh` may not be `jl_current_task->eh`. See `jl_pop_handler`
     // This function should **NOT** have any safepoint before the ones at the
@@ -1532,7 +1532,7 @@ STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
         jl_gc_safepoint_(ptls);
     }
     if (old_defer_signal && !eh->defer_signal) {
-        jl_sigint_safepoint();
+        jl_sigint_safepoint(ptls);
     }
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -105,7 +105,7 @@ void jl_gc_setmark(jl_value_t *v);
 void jl_gc_sync_total_bytes(void);
 void jl_gc_track_malloced_array(jl_array_t *a);
 void jl_gc_count_allocd(size_t sz);
-void jl_gc_run_all_finalizers(void);
+void jl_gc_run_all_finalizers(jl_ptls_t ptls);
 void *allocb(size_t sz);
 
 void gc_queue_binding(jl_binding_t *bnd);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -40,35 +40,116 @@ extern unsigned sig_stack_size;
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
 
-JL_DLLEXPORT void *jl_gc_pool_alloc(jl_ptls_t ptls, jl_gc_pool_t *p,
-                                    int osize, int end_offset);
+JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, jl_gc_pool_t *p,
+                                          int osize, int end_offset);
 JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t allocsz);
 int jl_gc_classify_pools(size_t sz, int *osize, int *end_offset);
 
-STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
+// pools are 16376 bytes large (GC_POOL_SZ - GC_PAGE_OFFSET)
+static const int jl_gc_sizeclasses[JL_GC_N_POOLS] = {
+#ifdef _P64
+    8,
+#else
+    4, 8, 12,
+#endif
+
+    // 16 pools at 16-byte spacing
+    16, 32, 48, 64, 80, 96, 112, 128,
+    144, 160, 176, 192, 208, 224, 240, 256,
+
+    // the following tables are computed for maximum packing efficiency via the formula:
+    // sz=(div(2^14-8,rng)÷16)*16; hcat(sz, (2^14-8)÷sz, 2^14-(2^14-8)÷sz.*sz)'
+
+    // rng = 60:-4:32 (8 pools)
+    272, 288, 304, 336, 368, 400, 448, 496,
+//   60,  56,  53,  48,  44,  40,  36,  33, /pool
+//   64, 256, 272, 256, 192, 384, 256,  16, bytes lost
+
+    // rng = 30:-2:16 (8 pools)
+    544, 576, 624, 672, 736, 816, 896, 1008,
+//   30,  28,  26,  24,  22,  20,  18,  16, /pool
+//   64, 256, 160, 256, 192,  64, 256, 256, bytes lost
+
+    // rng = 15:-1:8 (8 pools)
+    1088, 1168, 1248, 1360, 1488, 1632, 1808, 2032
+//    15,   14,   13,   12,   11,   10,    9,    8, /pool
+//    64,   32,  160,   64,   16,   64,  112,  128, bytes lost
+};
+
+STATIC_INLINE int JL_CONST_FUNC jl_gc_szclass(size_t sz)
 {
-    jl_value_t *jv = NULL;
-    switch (nfields) {
-    case 0:
-        jv = (jl_value_t*)jl_gc_alloc_0w(); break;
-    case 1:
-        jv = (jl_value_t*)jl_gc_alloc_1w(); break;
-    case 2:
-        jv = (jl_value_t*)jl_gc_alloc_2w(); break;
-    case 3:
-        jv = (jl_value_t*)jl_gc_alloc_3w(); break;
-    default:
-        jv = (jl_value_t*)jl_gc_allocobj(nfields * sizeof(void*));
-    }
-    jl_set_typeof(jv, type);
-    return jv;
+#ifdef _P64
+    if (sz <=    8)
+        return 0;
+    const int N = 0;
+#else
+    if (sz <=   12)
+        return (sz + 3) / 4 - 1;
+    const int N = 2;
+#endif
+    if (sz <=  256)
+        return (sz + 15) / 16 + N;
+    if (sz <=  496)
+        return 16 - 16376 / 4 / LLT_ALIGN(sz, 16 * 4) + 16 + N;
+    if (sz <= 1008)
+        return 16 - 16376 / 2 / LLT_ALIGN(sz, 16 * 2) + 24 + N;
+    return     16 - 16376 / 1 / LLT_ALIGN(sz, 16 * 1) + 32 + N;
 }
 
-STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
+#ifdef __GNUC__
+#  define jl_is_constexpr(e) __builtin_constant_p(e)
+#else
+#  define jl_is_constexpr(e) (0)
+#endif
+#define JL_SMALL_BYTE_ALIGNMENT 16
+#define JL_CACHE_BYTE_ALIGNMENT 64
+#define GC_POOL_END_OFS(osize) ((((GC_PAGE_SZ - GC_PAGE_OFFSET)/(osize)) - 1)*(osize) + GC_PAGE_OFFSET)
+#define GC_PAGE_LG2 14 // log2(size of a page)
+#define GC_PAGE_SZ (1 << GC_PAGE_LG2) // 16k
+#define GC_PAGE_OFFSET (JL_SMALL_BYTE_ALIGNMENT - (sizeof(jl_taggedvalue_t) % JL_SMALL_BYTE_ALIGNMENT))
+#define GC_MAX_SZCLASS (2032-sizeof(void*))
+
+STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
 {
-    jl_value_t *jv = (jl_value_t*)jl_gc_allocobj(type->size);
-    jl_set_typeof(jv, type);
-    return jv;
+    const size_t allocsz = sz + sizeof(jl_taggedvalue_t);
+    if (allocsz < sz) // overflow in adding offs, size was "negative"
+        jl_throw(jl_memory_exception);
+    jl_value_t *v;
+    if (allocsz <= GC_MAX_SZCLASS + sizeof(jl_taggedvalue_t)) {
+        int pool_id = jl_gc_szclass(allocsz);
+        jl_gc_pool_t *p = &ptls->heap.norm_pools[pool_id];
+        int osize;
+        int endoff;
+        if (jl_is_constexpr(allocsz)) {
+            osize = jl_gc_sizeclasses[pool_id];
+            endoff = GC_POOL_END_OFS(osize);
+        }
+        else {
+            osize = p->osize;
+            endoff = p->end_offset;
+        }
+        v = jl_gc_pool_alloc(ptls, p, osize, endoff);
+    }
+    else {
+        v = jl_gc_big_alloc(ptls, allocsz);
+    }
+    jl_set_typeof(v, ty);
+    return v;
+}
+JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty);
+// On GCC, only inline when sz is constant
+#ifdef __GNUC__
+#  define jl_gc_alloc(ptls, sz, ty)                             \
+    (__builtin_constant_p(sz) ? jl_gc_alloc_(ptls, sz, ty) :    \
+     (jl_gc_alloc)(ptls, sz, ty))
+#else
+#  define jl_gc_alloc(ptls, sz) jl_gc_alloc_(ptls, sz, ty)
+#endif
+
+#define jl_buff_tag ((uintptr_t)0x4eade800)
+STATIC_INLINE void *jl_gc_alloc_buf(jl_ptls_t ptls, size_t sz)
+{
+    return jl_gc_alloc(ptls, sz, (void*)jl_buff_tag);
 }
 
 jl_lambda_info_t *jl_type_infer(jl_lambda_info_t *li, int force);
@@ -100,13 +181,11 @@ jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types
 
 JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t nargs);
 
-#define GC_MAX_SZCLASS (2032-sizeof(void*))
-void jl_gc_setmark(jl_value_t *v);
+void jl_gc_setmark(jl_ptls_t ptls, jl_value_t *v);
 void jl_gc_sync_total_bytes(void);
-void jl_gc_track_malloced_array(jl_array_t *a);
+void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a);
 void jl_gc_count_allocd(size_t sz);
 void jl_gc_run_all_finalizers(jl_ptls_t ptls);
-void *allocb(size_t sz);
 
 void gc_queue_binding(jl_binding_t *bnd);
 void gc_setmark_buf(jl_ptls_t ptls, void *buf, int, size_t);
@@ -585,10 +664,6 @@ STATIC_INLINE void jl_free_aligned(void *p)
     free(p);
 }
 #endif
-
-#define JL_SMALL_BYTE_ALIGNMENT 16
-#define JL_CACHE_BYTE_ALIGNMENT 64
-
 
 // -- typemap.c -- //
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -109,7 +109,7 @@ void jl_gc_run_all_finalizers(void);
 void *allocb(size_t sz);
 
 void gc_queue_binding(jl_binding_t *bnd);
-void gc_setmark_buf(void *buf, int, size_t);
+void gc_setmark_buf(jl_ptls_t ptls, void *buf, int, size_t);
 
 STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_value_t*
 {
@@ -122,7 +122,8 @@ STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr, size_t minsz) // par
 {
     // if parent is marked and buf is not
     if (__unlikely(jl_astaggedvalue(parent)->bits.gc & 1)) {
-        gc_setmark_buf(bufptr, 3, minsz);
+        jl_ptls_t ptls = jl_get_ptls_states();
+        gc_setmark_buf(ptls, bufptr, 3, minsz);
     }
 }
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -33,7 +33,6 @@ typedef struct {
     jl_taggedvalue_t *newpages;   // root of list of chunks of free objects
     uint16_t end_offset; // stored to avoid computing it at each allocation
     uint16_t osize;      // size of objects in this pool
-    uint16_t nfree;      // number of free objects in page pointed into by free_list
 } jl_gc_pool_t;
 
 typedef struct {

--- a/src/module.c
+++ b/src/module.c
@@ -18,8 +18,9 @@ jl_module_t *jl_top_module=NULL;
 
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 {
-    jl_module_t *m = (jl_module_t*)jl_gc_allocobj(sizeof(jl_module_t));
-    jl_set_typeof(m, jl_module_type);
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_module_t *m = (jl_module_t*)jl_gc_alloc(ptls, sizeof(jl_module_t),
+                                               jl_module_type);
     JL_GC_PUSH1(&m);
     assert(jl_is_symbol(name));
     m->name = name;
@@ -70,8 +71,9 @@ JL_DLLEXPORT uint8_t jl_istopmod(jl_module_t *mod)
 
 static jl_binding_t *new_binding(jl_sym_t *name)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     assert(jl_is_symbol(name));
-    jl_binding_t *b = (jl_binding_t*)allocb(sizeof(jl_binding_t));
+    jl_binding_t *b = (jl_binding_t*)jl_gc_alloc_buf(ptls, sizeof(jl_binding_t));
     b->name = name;
     b->value = NULL;
     b->owner = NULL;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -52,7 +52,7 @@ static void JL_NORETURN jl_throw_in_ctx(jl_value_t *e, void *sigctx)
     if (!ptls->safe_restore)
         ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE,
                                           jl_to_bt_context(sigctx));
-    jl_exception_in_transit = e;
+    ptls->exception_in_transit = e;
     // TODO throw the error by modifying sigctx for supported platforms
     // This will avoid running the atexit handler on the signal stack
     // if no excepiton handler is registered.

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -112,7 +112,7 @@ void jl_throw_in_ctx(jl_value_t *excpt, CONTEXT *ctxThread, int bt)
 #endif
     ptls->bt_size = bt ? rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE,
                                            ctxThread) : 0;
-    jl_exception_in_transit = excpt;
+    ptls->exception_in_transit = excpt;
 #if defined(_CPU_X86_64_)
     *(DWORD64*)Rsp = 0;
     ctxThread->Rsp = Rsp;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -43,7 +43,7 @@ static char *strsignal(int sig)
 
 static void jl_try_throw_sigint(void)
 {
-    jl_tls_states_t *ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_safepoint_enable_sigint();
     jl_wake_libuv();
     int force = jl_check_force_sigint();
@@ -59,6 +59,7 @@ static void jl_try_throw_sigint(void)
 
 void __cdecl crt_sig_handler(int sig, int num)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     CONTEXT Context;
     switch (sig) {
     case SIGFPE:
@@ -85,7 +86,7 @@ void __cdecl crt_sig_handler(int sig, int num)
     default: // SIGSEGV, (SSIGTERM, IGILL)
         memset(&Context, 0, sizeof(Context));
         RtlCaptureContext(&Context);
-        jl_critical_error(sig, &Context, jl_bt_data, &jl_bt_size);
+        jl_critical_error(sig, &Context, ptls->bt_data, &ptls->bt_size);
         raise(sig);
     }
 }
@@ -100,6 +101,7 @@ void restore_signals(void)
 
 void jl_throw_in_ctx(jl_value_t *excpt, CONTEXT *ctxThread, int bt)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     assert(excpt != NULL);
 #if defined(_CPU_X86_64_)
     DWORD64 Rsp = (ctxThread->Rsp&(DWORD64)-16) - 8;
@@ -108,7 +110,8 @@ void jl_throw_in_ctx(jl_value_t *excpt, CONTEXT *ctxThread, int bt)
 #else
 #error WIN16 not supported :P
 #endif
-    jl_bt_size = bt ? rec_backtrace_ctx(jl_bt_data, JL_MAX_BT_SIZE, ctxThread) : 0;
+    ptls->bt_size = bt ? rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE,
+                                           ctxThread) : 0;
     jl_exception_in_transit = excpt;
 #if defined(_CPU_X86_64_)
     *(DWORD64*)Rsp = 0;
@@ -126,7 +129,7 @@ HANDLE hMainThread = INVALID_HANDLE_VALUE;
 // Try to throw the exception in the master thread.
 static void jl_try_deliver_sigint(void)
 {
-    jl_tls_states_t *ptls2 = jl_all_tls_states[0];
+    jl_ptls_t ptls2 = jl_all_tls_states[0];
     jl_safepoint_enable_sigint();
     jl_wake_libuv();
     if ((DWORD)-1 == SuspendThread(hMainThread)) {
@@ -182,6 +185,7 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
 
 static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo, int in_ctx)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (ExceptionInfo->ExceptionRecord->ExceptionFlags == 0) {
         switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {
             case EXCEPTION_INT_DIVIDE_BY_ZERO:
@@ -196,10 +200,10 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
 #ifdef JULIA_ENABLE_THREADING
                     jl_set_gc_and_wait();
                     // Do not raise sigint on worker thread
-                    if (ti_tid != 0)
+                    if (ptls->tid != 0)
                         return EXCEPTION_CONTINUE_EXECUTION;
 #endif
-                    if (jl_get_ptls_states()->defer_signal) {
+                    if (ptls->defer_signal) {
                         jl_safepoint_defer_sigint();
                     }
                     else if (jl_safepoint_consume_sigint()) {
@@ -262,7 +266,8 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
         jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
         jl_gdblookup((uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
-        jl_critical_error(0, ExceptionInfo->ContextRecord, jl_bt_data, &jl_bt_size);
+        jl_critical_error(0, ExceptionInfo->ContextRecord,
+                          ptls->bt_data, &ptls->bt_size);
         static int recursion = 0;
         if (recursion++)
             exit(1);
@@ -400,8 +405,9 @@ void jl_install_default_signal_handlers(void)
     SetUnhandledExceptionFilter(exception_handler);
 }
 
-void jl_install_thread_signal_handler(void)
+void jl_install_thread_signal_handler(jl_ptls_t ptls)
 {
+    (void)ptls;
     // Ensure the stack overflow handler has enough space to collect the backtrace
     ULONG StackSizeInBytes = sig_stack_size;
     if (pSetThreadStackGuarantee) {

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -21,8 +21,9 @@ JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
 
 JL_DLLEXPORT jl_svec_t *jl_svec1(void *a)
 {
-    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_2w();
-    jl_set_typeof(v, jl_simplevector_type);
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc(ptls, sizeof(void*) * 2,
+                                           jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 1);
     jl_svecset(v, 0, a);
     return v;
@@ -30,8 +31,9 @@ JL_DLLEXPORT jl_svec_t *jl_svec1(void *a)
 
 JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
 {
-    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_3w();
-    jl_set_typeof(v, jl_simplevector_type);
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc(ptls, sizeof(void*) * 3,
+                                           jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 2);
     jl_svecset(v, 0, a);
     jl_svecset(v, 1, b);
@@ -40,8 +42,10 @@ JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
 
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (n == 0) return jl_emptysvec;
-    jl_svec_t *jv = (jl_svec_t*)newobj((jl_value_t*)jl_simplevector_type, n+1);
+    jl_svec_t *jv = (jl_svec_t*)jl_gc_alloc(ptls, (n + 1) * sizeof(void*),
+                                            jl_simplevector_type);
     jl_svec_set_len_unsafe(jv, n);
     return jv;
 }

--- a/src/threading.c
+++ b/src/threading.c
@@ -313,11 +313,12 @@ static void ti_init_master_thread(void)
 // all threads call this function to run user code
 static jl_value_t *ti_run_fun(jl_svec_t *args)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     JL_TRY {
         jl_apply(jl_svec_data(args), jl_svec_len(args));
     }
     JL_CATCH {
-        return jl_exception_in_transit;
+        return ptls->exception_in_transit;
     }
     return jl_nothing;
 }
@@ -404,11 +405,11 @@ void ti_threadfun(void *arg)
                 //       enter GC unsafe region when starting the work.
                 int8_t gc_state = jl_gc_unsafe_enter(ptls);
                 // This is probably always NULL for now
-                jl_module_t *last_m = jl_current_module;
+                jl_module_t *last_m = ptls->current_module;
                 JL_GC_PUSH1(&last_m);
-                jl_current_module = work->current_module;
+                ptls->current_module = work->current_module;
                 ti_run_fun(work->args);
-                jl_current_module = last_m;
+                ptls->current_module = last_m;
                 JL_GC_POP();
                 jl_gc_unsafe_leave(ptls, gc_state);
             }
@@ -671,7 +672,7 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_svec_t *args)
     threadwork.fun = NULL;
     threadwork.args = args;
     threadwork.ret = jl_nothing;
-    threadwork.current_module = jl_current_module;
+    threadwork.current_module = ptls->current_module;
 
 #if PROFILE_JL_THREADING
     uint64_t tcompile = uv_hrtime();

--- a/src/threading.h
+++ b/src/threading.h
@@ -14,8 +14,7 @@ extern "C" {
 #define PROFILE_JL_THREADING            1
 
 // thread ID
-#define ti_tid (jl_get_ptls_states()->tid)
-extern jl_tls_states_t **jl_all_tls_states;
+extern jl_ptls_t *jl_all_tls_states;
 extern JL_DLLEXPORT int jl_n_threads;  // # threads we're actually using
 
 // thread state

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -41,11 +41,13 @@ JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m)
 
 JL_DLLEXPORT jl_module_t *jl_new_main_module(void)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (jl_generating_output() && jl_options.incremental)
         jl_error("cannot call workspace() in incremental compile mode");
 
     // switch to a new top-level module
-    if (jl_current_module != jl_main_module && jl_current_module != NULL && jl_main_module != NULL)
+    if (ptls->current_module != jl_main_module &&
+        ptls->current_module != NULL && jl_main_module != NULL)
         jl_error("Main can only be replaced from the top level");
 
     jl_module_t *old_main = jl_main_module;
@@ -54,14 +56,14 @@ JL_DLLEXPORT jl_module_t *jl_new_main_module(void)
     jl_main_module->parent = jl_main_module;
     if (old_main) // don't block continued loading of incremental caches
         jl_main_module->uuid = old_main->uuid;
-    jl_current_module = jl_main_module;
+    ptls->current_module = jl_main_module;
 
     jl_core_module->parent = jl_main_module;
     jl_set_const(jl_main_module, jl_symbol("Core"),
                  (jl_value_t*)jl_core_module);
     jl_set_global(jl_core_module, jl_symbol("Main"),
                   (jl_value_t*)jl_main_module);
-    jl_current_task->current_module = jl_main_module;
+    ptls->current_task->current_module = jl_main_module;
 
     return old_main;
 }
@@ -91,6 +93,7 @@ static void jl_module_load_time_initialize(jl_module_t *m)
 extern void jl_get_system_hooks(void);
 jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     static arraylist_t module_stack;
     static int initialized=0;
     static jl_module_t *outermost = NULL;
@@ -99,7 +102,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
         initialized = 1;
     }
     assert(ex->head == module_sym);
-    jl_module_t *last_module = jl_current_module;
+    jl_module_t *last_module = ptls->current_module;
     if (jl_array_len(ex->args) != 3 || !jl_is_expr(jl_exprarg(ex,2))) {
         jl_error("syntax: malformed module expression");
     }
@@ -108,7 +111,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
     if (!jl_is_symbol(name)) {
         jl_type_error("module", (jl_value_t*)jl_sym_type, (jl_value_t*)name);
     }
-    jl_module_t *parent_module = jl_current_module;
+    jl_module_t *parent_module = ptls->current_module;
     jl_binding_t *b = jl_get_binding_wr(parent_module, name);
     jl_declare_constant(b);
     if (b->value != NULL) {
@@ -145,8 +148,8 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
 
     jl_value_t *defaultdefs = NULL, *form = NULL;
     JL_GC_PUSH3(&last_module, &defaultdefs, &form);
-    jl_module_t *task_last_m = jl_current_task->current_module;
-    jl_current_task->current_module = jl_current_module = newm;
+    jl_module_t *task_last_m = ptls->current_task->current_module;
+    ptls->current_task->current_module = ptls->current_module = newm;
     jl_module_t *prev_outermost = outermost;
     size_t stackidx = module_stack.len;
     if (outermost == NULL)
@@ -168,15 +171,15 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
         }
     }
     JL_CATCH {
-        jl_current_module = last_module;
-        jl_current_task->current_module = task_last_m;
+        ptls->current_module = last_module;
+        ptls->current_task->current_module = task_last_m;
         outermost = prev_outermost;
         module_stack.len = stackidx;
         jl_rethrow();
     }
     JL_GC_POP();
-    jl_current_module = last_module;
-    jl_current_task->current_module = task_last_m;
+    ptls->current_module = last_module;
+    ptls->current_task->current_module = task_last_m;
     outermost = prev_outermost;
 
 #if 0
@@ -202,7 +205,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
 
     arraylist_push(&module_stack, newm);
 
-    if (outermost == NULL || jl_current_module == jl_main_module) {
+    if (outermost == NULL || ptls->current_module == jl_main_module) {
         JL_TRY {
             size_t i, l=module_stack.len;
             for(i = stackidx; i < l; i++) {
@@ -317,6 +320,7 @@ static jl_value_t *require_func=NULL;
 
 static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     // in .A.B.C, first find a binding for A in the chain of module scopes
     // following parent links. then evaluate the rest of the path from there.
     // in A.B, look for A in Main first.
@@ -329,7 +333,7 @@ static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
         m = jl_main_module;
     }
     else {
-        m = jl_current_module;
+        m = ptls->current_module;
         while (1) {
             var = (jl_sym_t*)jl_array_ptr_ref(args,i);
             if (!jl_is_symbol(var)) jl_type_error("import or using", (jl_value_t*)jl_sym_type, (jl_value_t*)var);
@@ -378,7 +382,7 @@ static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
         }
         if (retrying && require_func) {
             jl_printf(JL_STDERR, "WARNING: requiring \"%s\" in module \"%s\" did not define a corresponding module.\n", jl_symbol_name(var),
-                      jl_symbol_name(jl_current_module->name));
+                      jl_symbol_name(ptls->current_module->name));
             return NULL;
         }
         else {
@@ -417,6 +421,7 @@ int jl_is_toplevel_only_expr(jl_value_t *e)
 
 jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     //jl_show(ex);
     //jl_printf(JL_STDOUT, "\n");
     if (!jl_is_expr(e)) {
@@ -444,7 +449,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
         m = (jl_module_t*)jl_eval_global_var(m, name);
         if (!jl_is_module(m))
             jl_errorf("invalid %s statement: name exists but does not refer to a module", jl_symbol_name(ex->head));
-        jl_module_importall(jl_current_module, m);
+        jl_module_importall(ptls->current_module, m);
         return jl_nothing;
     }
     else if (ex->head == using_sym) {
@@ -455,10 +460,10 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
             jl_error("syntax: malformed \"using\" statement");
         jl_module_t *u = (jl_module_t*)jl_eval_global_var(m, name);
         if (jl_is_module(u)) {
-            jl_module_using(jl_current_module, u);
+            jl_module_using(ptls->current_module, u);
         }
         else {
-            jl_module_use(jl_current_module, m, name);
+            jl_module_use(ptls->current_module, m, name);
         }
         return jl_nothing;
     }
@@ -468,7 +473,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
         jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(ex->args, jl_array_len(ex->args)-1);
         if (!jl_is_symbol(name))
             jl_error("syntax: malformed \"import\" statement");
-        jl_module_import(jl_current_module, m, name);
+        jl_module_import(ptls->current_module, m, name);
         return jl_nothing;
     }
     else if (ex->head == export_sym) {
@@ -476,7 +481,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
             jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(ex->args, i);
             if (!jl_is_symbol(name))
                 jl_error("syntax: malformed \"export\" statement");
-            jl_module_export(jl_current_module, name);
+            jl_module_export(ptls->current_module, name);
         }
         return jl_nothing;
     }
@@ -511,10 +516,10 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
         thk = (jl_lambda_info_t*)jl_exprarg(ex,0);
         assert(jl_is_lambda_info(thk));
         assert(jl_typeis(thk->code, jl_array_any_type));
-        ewc = jl_eval_with_compiler_p(thk, (jl_array_t*)thk->code, fast, jl_current_module);
+        ewc = jl_eval_with_compiler_p(thk, (jl_array_t*)thk->code, fast, ptls->current_module);
     }
     else {
-        if (head && jl_eval_expr_with_compiler_p((jl_value_t*)ex, fast, jl_current_module)) {
+        if (head && jl_eval_expr_with_compiler_p((jl_value_t*)ex, fast, ptls->current_module)) {
             thk = jl_wrap_expr((jl_value_t*)ex);
             ewc = 1;
         }
@@ -553,7 +558,8 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v)
 
 JL_DLLEXPORT jl_value_t *jl_load(const char *fname)
 {
-    if (jl_current_module->istopmod) {
+    jl_ptls_t ptls = jl_get_ptls_states();
+    if (ptls->current_module->istopmod) {
         jl_printf(JL_STDOUT, "%s\r\n", fname);
 #ifdef _OS_WINDOWS_
         uv_run(uv_default_loop(), (uv_run_mode)1);
@@ -632,6 +638,7 @@ void jl_check_static_parameter_conflicts(jl_method_t *m, jl_svec_t *t)
 JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp, jl_value_t *bp_owner,
                                                  jl_binding_t *bnd)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *gf=NULL;
 
     assert(name && bp);
@@ -645,7 +652,7 @@ JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp
     if (bnd)
         bnd->constp = 1;
     if (*bp == NULL) {
-        jl_module_t *module = (bnd ? bnd->owner : jl_current_module);
+        jl_module_t *module = (bnd ? bnd->owner : ptls->current_module);
         gf = (jl_value_t*)jl_new_generic_function(name, module);
         *bp = gf;
         if (bp_owner) jl_gc_wb(bp_owner, gf);

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -826,8 +826,10 @@ static void jl_typemap_list_insert_sorted(jl_typemap_entry_t **pml, jl_value_t *
 
 static jl_typemap_level_t *jl_new_typemap_level(void)
 {
-    jl_typemap_level_t *cache = (jl_typemap_level_t*)jl_gc_allocobj(sizeof(jl_typemap_level_t));
-    jl_set_typeof(cache, jl_typemap_level_type);
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_typemap_level_t *cache =
+        (jl_typemap_level_t*)jl_gc_alloc(ptls, sizeof(jl_typemap_level_t),
+                                         jl_typemap_level_type);
     cache->key = NULL;
     cache->linear = (jl_typemap_entry_t*)jl_nothing;
     cache->any.unknown = jl_nothing;
@@ -942,6 +944,7 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
                                       const struct jl_typemap_info *tparams,
                                       jl_value_t **overwritten)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     assert(jl_is_tuple_type(type));
     if (!simpletype) {
         simpletype = (jl_tupletype_t*)jl_nothing;
@@ -973,8 +976,9 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
     if (overwritten != NULL)
         *overwritten = NULL;
 
-    jl_typemap_entry_t *newrec = (jl_typemap_entry_t*)jl_gc_allocobj(sizeof(jl_typemap_entry_t));
-    jl_set_typeof(newrec, jl_typemap_entry_type);
+    jl_typemap_entry_t *newrec =
+        (jl_typemap_entry_t*)jl_gc_alloc(ptls, sizeof(jl_typemap_entry_t),
+                                         jl_typemap_entry_type);
     newrec->sig = type;
     newrec->simplesig = simpletype;
     newrec->tvars = tvars;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 #if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_) && !defined(_OS_WINDOWS_)
-JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *jl_get_ptls_states_static(void)
+JL_DLLEXPORT JL_CONST_FUNC jl_ptls_t jl_get_ptls_states_static(void)
 {
     static __attribute__((tls_model("local-exec"))) __thread jl_tls_states_t tls_states;
     return &tls_states;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -470,12 +470,13 @@ restart_switch:
 
 static int exec_program(char *program)
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     int err = 0;
- again: ;
+  again: ;
     JL_TRY {
         if (err) {
             jl_value_t *errs = jl_stderr_obj();
-            jl_value_t *e = jl_exception_in_transit;
+            jl_value_t *e = ptls->exception_in_transit;
             if (errs != NULL) {
                 jl_show(errs, e);
             }
@@ -528,6 +529,7 @@ static void print_profile(void)
 
 static NOINLINE int true_main(int argc, char *argv[])
 {
+    jl_ptls_t ptls = jl_get_ptls_states();
     if (jl_core_module != NULL) {
         jl_array_t *args = (jl_array_t*)jl_get_global(jl_core_module, jl_symbol("ARGS"));
         if (args == NULL) {
@@ -573,7 +575,7 @@ static NOINLINE int true_main(int argc, char *argv[])
             jl_value_t *val = (jl_value_t*)jl_eval_string(line);
             if (jl_exception_occurred()) {
                 jl_printf(JL_STDERR, "error during run:\n");
-                jl_static_show(JL_STDERR, jl_exception_in_transit);
+                jl_static_show(JL_STDERR, ptls->exception_in_transit);
                 jl_exception_clear();
             }
             else if (val) {
@@ -590,7 +592,7 @@ static NOINLINE int true_main(int argc, char *argv[])
                 line = NULL;
             }
             jl_printf(JL_STDERR, "\nparser error:\n");
-            jl_static_show(JL_STDERR, jl_exception_in_transit);
+            jl_static_show(JL_STDERR, ptls->exception_in_transit);
             jl_printf(JL_STDERR, "\n");
             jlbacktrace();
         }


### PR DESCRIPTION
The main goal of this PR is a small step toward more explicit TLS access in the C code and an experiment of passing TLS pointer around explicitly in the GC. Most of the explicit calls of `jl_get_ptls_states()` added in this PR (except GC ones and maybe some signal handling ones) do not cross function boundaries.

As for passing the TLS pointer explicitly as function argument, it is faster or the same in most of the case. On Linux, I measured a few percent improvement in GC time (both by running a function with the same allocation pattern or calling GC directly). This improvement might be larger for OSX since, as we recently learned, it doesn't have a static TLS model =(.

However, there is [one case](https://github.com/JuliaLang/julia/commit/7fd627d615b94ff57bd9f7786155ddc91862d23e#diff-31b93f4272eaeede3738531e90317e0cR769) where passing the TLS pointer generates slower code (it can increase the pool allocation time by ~15%). My current explanation is that the user (`jl_gc_pool_alloc`, previously `__pool_alloc`) only calls this function in a slow branch in the middle of the fast path and keeping an unused value alive increases the register pressure in the fast path.....

This also simplifies and further optimizes GC allocation functions, especially in C. `newobj`, `newstruct`, `jl_gc_allocobj`, `jl_gc_alloc_*w`, `allocb` are all merged into `jl_gc_alloc` and the compile time pool address lookup optimization is generalized to all sizes. This also removes the double initialization of the tag when allocating memory.

This is based on https://github.com/JuliaLang/julia/pull/16893 (which should be ready now) to reduce conflicts. See [here](https://github.com/JuliaLang/julia/compare/yyc/gc/array...yyc/threads/chain-ptls?expand=1) for actual diff.
