### PR TITLE
Add kwarg for disabling headers in arrays

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1536,7 +1536,7 @@ end
 
 show(io::IO, X::AbstractArray) = showarray(io, X)
 
-function showarray(io::IO, X::AbstractArray)
+function showarray(io::IO, X::AbstractArray; header = true)
     repr = !get(io, :multiline, false)
     if repr && ndims(X) == 1
         return show_vector(io, X, "[", "]")
@@ -1549,9 +1549,9 @@ function showarray(io::IO, X::AbstractArray)
         # override usual show method for Vector{Method}: don't abbreviate long lists
         io = IOContext(io, :limit => false)
     end
-    !repr && print(io, summary(X))
+    (!repr && header) && print(io, summary(X))
     if !isempty(X)
-        !repr && println(io, ":")
+        (!repr && header) && println(io, ":")
         if ndims(X) == 0
             if isassigned(X)
                 return show(io, X[])

--- a/test/show.jl
+++ b/test/show.jl
@@ -493,3 +493,11 @@ let io = IOBuffer()
     showcompact(IOContext(IOContext(io, :compact=>true), :multiline=>true), x)
     @test takebuf_string(io) == "[1,2]"
 end
+
+# PR 17117
+# test show array
+let s  = IOBuffer(Array{UInt8}(0), true, true)
+    io = IOContext(s, multiline=true)
+    Base.showarray(io, [1,2,3], header = false)
+    @test String(resize!(s.data, s.size)) == " 1\n 2\n 3"
+end


### PR DESCRIPTION
Hi, I wanted to re-enable the option to not display the header. This would be useful for any package that tries to provide an array interface. and would like to display their own type summaries instead of the default `Array{T,N}`. 
