### PR TITLE
Optimize TLS access on mac

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -366,7 +366,7 @@ STATIC_INLINE int8_t jl_gc_state_set(jl_tls_states_t *ptls,
 }
 #else // ifndef JULIA_ENABLE_THREADING
 typedef jl_tls_states_t *(*jl_get_ptls_states_func)(void);
-#ifndef _OS_DARWIN_
+#if !defined(_OS_DARWIN_) && !defined(_OS_WINDOWS_)
 JL_DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f);
 #endif
 // Make sure jl_gc_state() is always a rvalue

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -366,7 +366,9 @@ STATIC_INLINE int8_t jl_gc_state_set(jl_tls_states_t *ptls,
 }
 #else // ifndef JULIA_ENABLE_THREADING
 typedef jl_tls_states_t *(*jl_get_ptls_states_func)(void);
+#ifndef _OS_DARWIN_
 JL_DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f);
+#endif
 // Make sure jl_gc_state() is always a rvalue
 #define jl_gc_state(ptls) ((int8_t)ptls->gc_state)
 STATIC_INLINE int8_t jl_gc_state_set(jl_tls_states_t *ptls,

--- a/src/threading.c
+++ b/src/threading.c
@@ -30,7 +30,7 @@ extern "C" {
 #include "threading.h"
 
 #ifdef JULIA_ENABLE_THREADING
-#  ifdef _OS_DARWIN_
+#  if defined(_OS_DARWIN_)
 // Mac doesn't seem to have static TLS model so the runtime TLS getter
 // registration will only add overhead to TLS access. The `__thread` variables
 // are emulated with `pthread_key_t` so it is actually faster to use it directly.
@@ -62,15 +62,50 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
     // for codegen
     return &jl_get_ptls_states_fast;
 }
+#  elif defined(_OS_WINDOWS_)
+// Apparently windows doesn't have a static TLS model (or one that can be
+// reliably used from a shared library) either..... Use `TLSAlloc` instead.
+
+static DWORD jl_tls_key;
+
+// Put this here for now. We can move this out later if we find more use for it.
+BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason,
+                       IN LPVOID Reserved)
+{
+    switch (nReason) {
+    case DLL_PROCESS_ATTACH:
+        jl_tls_key = TlsAlloc();
+        assert(jl_tls_key != TLS_OUT_OF_INDEXES);
+        // Fall through
+    case DLL_THREAD_ATTACH:
+        TlsSetValue(jl_tls_key, calloc(1, sizeof(jl_tls_states_t)));
+        break;
+    case DLL_THREAD_DETACH:
+        free(TlsGetValue(jl_tls_key));
+        TlsSetValue(jl_tls_key, NULL);
+        break;
+    case DLL_PROCESS_DETACH:
+        free(TlsGetValue(jl_tls_key));
+        TlsFree(jl_tls_key);
+        break;
+    }
+}
+
+JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
+{
+    return TlsGetValue(jl_tls_key);
+}
+
+jl_get_ptls_states_func jl_get_ptls_states_getter(void)
+{
+    // for codegen
+    return &jl_get_ptls_states;
+}
 #  else
 // fallback provided for embedding
 static JL_CONST_FUNC jl_tls_states_t *jl_get_ptls_states_fallback(void)
 {
-#  if !defined(_COMPILER_MICROSOFT_)
     static __thread jl_tls_states_t tls_states;
-#  else
-    static __declspec(thread) jl_tls_states_t tls_states;
-#  endif
     return &tls_states;
 }
 static jl_tls_states_t *jl_get_ptls_states_init(void);

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -34,7 +34,7 @@
 extern "C" {
 #endif
 
-#ifdef JULIA_ENABLE_THREADING
+#if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_)
 static JL_CONST_FUNC jl_tls_states_t *jl_get_ptls_states_static(void)
 {
 #  if !defined(_COMPILER_MICROSOFT_)
@@ -660,7 +660,7 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
         argv[i] = (wchar_t*)arg;
     }
 #endif
-#ifdef JULIA_ENABLE_THREADING
+#if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_)
     // We need to make sure this function is called before any reference to
     // TLS variables. Since the compiler is free to move calls to
     // `jl_get_ptls_states()` around, we should avoid referencing TLS

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -34,14 +34,10 @@
 extern "C" {
 #endif
 
-#if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_)
+#if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_) && !defined(_OS_WINDOWS_)
 static JL_CONST_FUNC jl_tls_states_t *jl_get_ptls_states_static(void)
 {
-#  if !defined(_COMPILER_MICROSOFT_)
     static __attribute__((tls_model("local-exec"))) __thread jl_tls_states_t tls_states;
-#  else
-    static __declspec(thread) jl_tls_states_t tls_states;
-#  endif
     return &tls_states;
 }
 #endif
@@ -660,7 +656,7 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
         argv[i] = (wchar_t*)arg;
     }
 #endif
-#if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_)
+#if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_) && !defined(_OS_WINDOWS_)
     // We need to make sure this function is called before any reference to
     // TLS variables. Since the compiler is free to move calls to
     // `jl_get_ptls_states()` around, we should avoid referencing TLS


### PR DESCRIPTION
According to @Keno, it doesn't have static TLS model and the TLS variables are emulated with `pthread_key_t`. Use `pthread` directly since it is actually faster.

@vtjnash
