### PR TITLE
specialize on dict keys

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -696,12 +696,15 @@ function _setindex!(h::Dict, v, key, index)
 end
 
 function setindex!{K,V}(h::Dict{K,V}, v0, key0)
-    key = convert(K,key0)
-    if !isequal(key,key0)
+    key = convert(K, key0)
+    if !isequal(key, key0)
         throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
-    v = convert(V, v0)
+    setindex!(h, v0, key)
+end
 
+function setindex!{K,V}(h::Dict{K,V}, v0, key::K)
+    v = convert(V, v0)
     index = ht_keyindex2(h, key)
 
     if index > 0
@@ -719,12 +722,15 @@ function get!{K,V}(h::Dict{K,V}, key0, default)
     if !isequal(key,key0)
         throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
+    get!(h, key, default)
+end
 
+function get!{K, V}(h::Dict{K,V}, key::K, default)
     index = ht_keyindex2(h, key)
 
     index > 0 && return h.vals[index]
 
-    v = convert(V,  default)
+    v = convert(V, default)
     _setindex!(h, v, key, -index)
     return v
 end
@@ -734,7 +740,10 @@ function get!{K,V}(default::Callable, h::Dict{K,V}, key0)
     if !isequal(key,key0)
         throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
+    get!(default, h, key)
+end
 
+function get!{K,V}(default::Callable, h::Dict{K,V}, key::K)
     index = ht_keyindex2(h, key)
 
     index > 0 && return h.vals[index]


### PR DESCRIPTION
Currently, in `setindex!` for `Dict`, all keys need to be checked for equality against their converted version even if the key type being indexed and the keytype in the dictionary match. For some tuples (like those with `DataType` apparently) this `isequal` is a significant unnecessary cost).

An example benchmark I am running is:

``` jl
function foo()
    a = Dict{Tuple{Int, Int, DataType}, Int}()
    a[(1,3,Float64)] = 2
    a[(1,2,Float32)] = 2
    a[(2,2,Int)] = 2
    a[(1,2,Int32)] = 2
    a[(3,2,Float64)] = 2
    a[(1,2,Float32)] = 2

    @time for i in 1:10^5
        a[(1,3,Float64)] = 3
        a[(1,2,Float32)] = 3
        a[(1,2,Int32)] = 3
    end
end
```

Before this PR the above takes about 1 s and after 0.2 s. 
.
