### PR TITLE
#16071: restrict typed variable declaration to `local x::T` and `global x::T`…

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -125,6 +125,8 @@
 (define end-symbol #f)
 ; treat newline like ordinary whitespace instead of as a potential separator
 (define whitespace-newline #f)
+; after the keywords `global` or `local`, the LHS of assignments can be typed.
+(define allow-typed-assignments #f)
 
 (define current-filename 'none)
 
@@ -158,6 +160,10 @@
 
 (define-macro (without-whitespace-newline . body)
   `(with-bindings ((whitespace-newline #f))
+                  ,@body))
+
+(define-macro (with-typed-assignments . body)
+  `(with-bindings ((allow-typed-assignments #f))
                   ,@body))
 
 ;; --- lexer ---
@@ -924,7 +930,14 @@
     (let ((t (peek-token s)))
       (case t
         ((|::|) (take-token s)
-         (loop (list t ex (parse-call s))))
+        ; (loop (list t ex (parse-call s))))
+         (let ((exx (list t ex (parse-call s))))
+            (if (and (not allow-typed-assignments)
+                      (is-prec-assignment? (peek-token s)))
+              (syntax-deprecation s
+                (string "Type statement on left hand side of assignment.")
+                (string "Use with `local` or `global` first.")))
+            (loop exx)))
         ((->)   (take-token s)
          ;; -> is unusual: it binds tightly on the left and
          ;; loosely on the right.
@@ -1160,7 +1173,7 @@
                (const (and (eq? (peek-token s) 'const)
                            (take-token s)))
                (expr  (cons word
-			    (parse-comma-separated-assignments s))))
+			    (parse-comma-separated-typed-assignments s))))
           (if const
               `(const ,expr)
               expr)))
@@ -1393,8 +1406,14 @@
         ((#\,)  (take-token s) (loop (cons r exprs)))
         (else   (reverse! (cons r exprs)))))))
 
+
 (define (parse-comma-separated-assignments s)
   (parse-comma-separated s parse-eq*))
+
+
+(define (parse-comma-separated-typed-assignments s)
+  (with-typed-assignments
+    (parse-comma-separated-assignments s)))
 
 ;; as above, but allows both "i=r" and "i in r"
 (define (parse-iteration-spec s)


### PR DESCRIPTION
This is my first Julia pull request, so tell me if I'm doing it wrong. This is a fix to #16071. My deprecation message is:

```
          (syntax-deprecation s
            (string "Type statement on left hand side of assignment.")
            (string "Use with `local` or `global` first.")))
```

Also, this doesn't catch the case where the LHS is in parentheses or otherwise complicated (such as tuple assignment where only the first tuple item is typed.)
