### PR TITLE
Partial package updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -142,6 +142,9 @@ Library improvements
     * Package-development functions like `Pkg.tag` and `Pkg.publish`
       have been moved to an external [PkgDev] package ([#13387]).
 
+    * Updating only a subset of the packages is now supported,
+      e.g. `Pkg.update("Example")` ([#17132])
+
   * The `Base.Test` module now has a `@testset` feature to bundle
     tests together and delay throwing an error until the end ([#13062]).
 

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -349,7 +349,7 @@ function pin(pkg::AbstractString, ver::VersionNumber)
     pin(pkg, avail[ver].sha1)
 end
 
-function update(branch::AbstractString)
+function update(branch::AbstractString, upkgs::Set{String})
     info("Updating METADATA...")
     with(GitRepo, "METADATA") do repo
         try
@@ -390,7 +390,14 @@ function update(branch::AbstractString)
         end
     end
     instd = Read.installed(avail)
-    free  = Read.free(instd)
+    reqs = Reqs.parse("REQUIRE")
+    if !isempty(upkgs)
+        for (pkg, (v,f)) in instd
+            satisfies(pkg, v, reqs) || throw(PkgError("Package $pkg: current package status does not satisfy the requirements, cannot do a partial update; use `Pkg.update()`"))
+        end
+    end
+    dont_update = Query.partial_update_mask(instd, avail, upkgs)
+    free  = Read.free(instd,dont_update)
     for (pkg,ver) in free
         try
             Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
@@ -400,10 +407,11 @@ function update(branch::AbstractString)
         end
     end
     creds = LibGit2.CachedCredentials()
-    fixed = Read.fixed(avail,instd)
+    fixed = Read.fixed(avail,instd,dont_update)
     stopupdate = false
     for (pkg,ver) in fixed
         ispath(pkg,".git") || continue
+        pkg in dont_update && continue
         with(GitRepo, pkg) do repo
             if LibGit2.isattached(repo)
                 if LibGit2.isdirty(repo)
@@ -443,7 +451,7 @@ function update(branch::AbstractString)
         end
     end
     info("Computing changes...")
-    resolve(Reqs.parse("REQUIRE"), avail, instd, fixed, free)
+    resolve(reqs, avail, instd, fixed, free)
     # Don't use instd here since it may have changed
     updatehook(sort!(collect(keys(installed()))))
 

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -198,11 +198,14 @@ Pin `pkg` at registered version `version`.
 pin(pkg::AbstractString, ver::VersionNumber) = cd(Entry.pin,pkg,ver)
 
 """
-    update()
+    update(pkgs...)
 
 Update the metadata repo – kept in `Pkg.dir("METADATA")` – then update any fixed packages
 that can safely be pulled from their origin; then call `Pkg.resolve()` to determine a new
 optimal set of packages versions.
+
+Without arguments, updates all installed packages. When one or more package names are provided as
+arguments, only those packages and their dependencies are updated.
 """
 update(upkgs::AbstractString...) = cd(Entry.update,Dir.getmetabranch(),Set{String}([upkgs...]))
 

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -204,7 +204,7 @@ Update the metadata repo – kept in `Pkg.dir("METADATA")` – then update any f
 that can safely be pulled from their origin; then call `Pkg.resolve()` to determine a new
 optimal set of packages versions.
 """
-update() = cd(Entry.update,Dir.getmetabranch())
+update(upkgs::AbstractString...) = cd(Entry.update,Dir.getmetabranch(),Set{String}([upkgs...]))
 
 """
     resolve()

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -90,6 +90,62 @@ function partial_update_mask(instd::Dict{String,Tuple{VersionNumber,Bool}}, avai
     return dont_update
 end
 
+# Try to produce some helpful message in case of a partial update which does not go all the way
+# (Does not do a full analysis, it only checks requirements and direct dependents.)
+function check_partial_updates(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}}, want::Dict{String,VersionNumber}, fixed::Dict{String,Fixed}, upkgs::Set{String})
+    for p in upkgs
+        if !haskey(want, p)
+            if !haskey(fixed, p)
+                warn("Something went wrong with the update of package $p, please submit a bug report")
+                continue
+            end
+            v = fixed[p].version
+        else
+            v = want[p]
+            if haskey(fixed, p) && v != fixed[p].version
+                warn("Something went wrong with the update of package $p, please submit a bug report")
+                continue
+            end
+        end
+        haskey(deps, p) || continue
+        vers = sort!(collect(keys(deps[p])))
+        higher_vers = vers[vers .> v]
+        isempty(higher_vers) && continue # package p has been set to the highest available version
+
+        # Determine if there are packages which depend on `p` and somehow prevent its update to
+        # the latest version
+        blocking_parents = Set{String}()
+        for (p1,d1) in deps
+            p1 in upkgs && continue # package `p1` is among the ones to be updated, skip the check
+            haskey(fixed, p1) || continue # if package `p1` is not fixed, it can't be blocking
+            r1 = fixed[p1].requires # get `p1` requirements
+            haskey(r1, p) || continue # check if package `p1` requires `p`
+            vs1 = r1[p] # get the versions of `p` allowed by `p1` requirements
+            any(hv in vs1 for hv in higher_vers) && continue # package `p1` would allow some of the higher versions,
+                                                             # therefore it's not responsible for blocking `p`
+            push!(blocking_parents, p1) # package `p1` is blocking the update of `p`
+        end
+
+        # Determine if the update of `p` is prevented by explicit user-provided requirements
+        blocking_reqs = (haskey(reqs, p) && all(hv ∉ reqs[p] for hv in higher_vers))
+
+        # Determine if the update of `p` is prevented by it being fixed (e.g. it's dirty, or pinned...)
+        isfixed = haskey(fixed, p)
+
+        msg = "Package $p was set to version $v, but a higher version $(vers[end]) exists.\n"
+        if isfixed
+            msg *= "      The package is fixed. You can try using `Pkg.free(\"$p\")` to update it."
+        elseif blocking_reqs
+            msg *= "      The update is prevented by explicit requirements constraints. Edit your REQUIRE file to change this."
+        elseif !isempty(blocking_parents)
+            msg *= string("      To install the latest version, you could try updating these packages as well: ", join(blocking_parents, ", ", " and "), ".")
+        else
+            msg *= "      To install the latest version, you could try doing a full update with `Pkg.update()`."
+        end
+        info(msg)
+    end
+end
+
 typealias PackageState Union{Void,VersionNumber}
 
 function diff(have::Dict, want::Dict, avail::Dict, fixed::Dict)

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -216,11 +216,11 @@ function installed(avail::Dict=available())
     return pkgs
 end
 
-function fixed(avail::Dict=available(), inst::Dict=installed(avail),
+function fixed(avail::Dict=available(), inst::Dict=installed(avail), dont_update::Set{String}=Set{String}(),
     julia_version::VersionNumber=VERSION)
     pkgs = Dict{String,Fixed}()
     for (pkg,(ver,fix)) in inst
-        fix || continue
+        (fix || pkg in dont_update) || continue
         ap = get(avail,pkg,Dict{VersionNumber,Available}())
         pkgs[pkg] = Fixed(ver,requires_dict(pkg,ap))
     end
@@ -228,10 +228,10 @@ function fixed(avail::Dict=available(), inst::Dict=installed(avail),
     return pkgs
 end
 
-function free(inst::Dict=installed())
+function free(inst::Dict=installed(), dont_update::Set{String}=Set{String}())
     pkgs = Dict{String,VersionNumber}()
     for (pkg,(ver,fix)) in inst
-        fix && continue
+        (fix || pkg in dont_update) && continue
         pkgs[pkg] = ver
     end
     return pkgs

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -209,6 +209,15 @@ A package is considered fixed if it is one of the following:
 If any of these are the case, the package manager cannot freely change the installed version of the package, so its requirements must be satisfied by whatever other package versions it picks.
 The combination of top-level requirements in ``~/.julia/v0.4/REQUIRE`` and the requirement of fixed packages are used to determine what should be installed.
 
+You can also update only a subset of the installed packages, by providing arguments to the `Pkg.update` function. In that case, only the packages provided as arguments and their dependencies will be updated::
+
+    julia> Pkg.update("Example")
+    INFO: Updating METADATA...
+    INFO: Computing changes...
+    INFO: Upgrading Example: v0.4.0 => 0.4.1
+
+This partial update process still computes the new set of package versions according to top-level requirements and "fixed" packages, but it additionally considers all other packages except those explicitly provided, and their dependencies, as fixed.
+
 Checkout, Pin and Free
 ----------------------
 

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -105,11 +105,13 @@ Functions for package development (e.g. ``tag``, ``publish``, etc.) have been mo
 
    Prints out a summary of what version and state ``pkg``\ , specifically, is in.
 
-.. function:: update()
+.. function:: update(pkgs...)
 
    .. Docstring generated from Julia source
 
    Update the metadata repo – kept in ``Pkg.dir("METADATA")`` – then update any fixed packages that can safely be pulled from their origin; then call ``Pkg.resolve()`` to determine a new optimal set of packages versions.
+
+   Without arguments, updates all installed packages. When one or more package names are provided as arguments, only those packages and their dependencies are updated.
 
 .. function:: checkout(pkg, [branch="master"]; merge=true, pull=true)
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -56,7 +56,7 @@ macro grab_outputs(ex)
 end
 
 # Test basic operations: adding or removing a package, status, free
-#Also test for the existence of REQUIRE and META_Branch
+# Also test for the existence of REQUIRE and META_BRANCH
 temp_pkg_dir() do
     @test isfile(joinpath(Pkg.dir(),"REQUIRE"))
     @test isfile(joinpath(Pkg.dir(),"META_BRANCH"))
@@ -219,69 +219,69 @@ temp_pkg_dir() do
     # Various pin/free/re-pin/change-pin patterns (issue #17176)
     begin
         ret, out, err = @grab_outputs Pkg.free("Example")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Freeing Example")
 
         ret, out, err = @grab_outputs Pkg.pin("Example")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test ismatch(r"INFO: Creating Example branch pinned\.[0-9a-f]{8}\.tmp", err)
         @test !contains(err, "INFO: No packages to install, update or remove")
         branchid = replace(err, r".*pinned\.([0-9a-f]{8})\.tmp.*"s, s"\1")
         vers = Pkg.installed("Example")
 
         ret, out, err = @grab_outputs Pkg.free("Example")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Freeing Example")
 
         ret, out, err = @grab_outputs Pkg.pin("Example", v"0.4.0")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Creating Example branch pinned.b1990792.tmp")
         @test contains(err, "INFO: No packages to install, update or remove")
         @test Pkg.installed("Example") == v"0.4.0"
 
         ret, out, err = @grab_outputs Pkg.pin("Example", v"0.4.0")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Package Example is already pinned to the selected commit")
         @test !contains(err, "INFO: No packages to install, update or remove")
         @test Pkg.installed("Example") == v"0.4.0"
 
         ret, out, err = @grab_outputs Pkg.pin("Example")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Package Example is already pinned")
         @test !contains(err, "INFO: No packages to install, update or remove")
         @test Pkg.installed("Example") == v"0.4.0"
 
         ret, out, err = @grab_outputs Pkg.update()
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Package Example: skipping update (pinned)...")
         @test Pkg.installed("Example") == v"0.4.0"
 
         ret, out, err = @grab_outputs Pkg.pin("Example", v"0.3.1")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Creating Example branch pinned.d1ef7b00.tmp")
         @test contains(err, "INFO: No packages to install, update or remove")
         @test Pkg.installed("Example") == v"0.3.1"
 
         ret, out, err = @grab_outputs Pkg.pin("Example", v"0.4.0")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Package Example: checking out existing branch pinned.b1990792.tmp")
         @test contains(err, "INFO: No packages to install, update or remove")
         @test Pkg.installed("Example") == v"0.4.0"
 
         ret, out, err = @grab_outputs Pkg.free("Example")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Freeing Example")
         @test contains(err, "INFO: No packages to install, update or remove")
         @test Pkg.installed("Example") == vers
 
         ret, out, err = @grab_outputs Pkg.pin("Example")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Package Example: checking out existing branch pinned.$branchid.tmp")
         @test !contains(err, "INFO: No packages to install, update or remove")
         @test Pkg.installed("Example") == vers
 
         ret, out, err = @grab_outputs Pkg.free("Example")
-        @test ret == nothing && out == ""
+        @test ret === nothing && out == ""
         @test contains(err, "INFO: Freeing Example")
         @test Pkg.installed("Example") == vers
     end


### PR DESCRIPTION
This introduces the possibility to do `Pkg.update(pkgs...)` and only update a subset of the packages.

The result is that only the packages explicitly provided and their dependencies will be updated, everything else is kept fixed.

For example:

```
julia> Pkg.update("Colors")
INFO: Updating METADATA...
INFO: Computing changes...
INFO: Upgrading Colors: v0.6.4 => v0.6.5
INFO: Upgrading Compat: v0.8.1 => v0.8.2
```

Also, the packages explicitly provided will never get downgraded (which is a rare occurrence, but in principle may happen with a full `Pkg.update()`).

In case the update fails to install the latest version of the packages explicitly provided, an info message is emitted, and some analysis is attempted to suggest possible causes (a full analysis is basically out of the question, and unlikely to be of any practical relevance IMO). For example, in a case in which I had artificially capped the version of `Colors.jl`:

```
julia> Pkg.update("Colors")
INFO: Updating METADATA...
INFO: Computing changes...
INFO: Package Colors was set to version 0.6.4, but a higher version 0.6.5 exists.
      The update is prevented by explicit requirements constraints. Edit your REQUIRE file to change this.
INFO: No packages to install, update or remove
```

Still missing: ~~tests, perhaps extra docs (? Someone please advise me on this, I only updated the docstring and it works in the repl, should I do something else?), probably some note in NEWS.~~

We may also want to add a keyword argument to truly restrict the update to the packages given as arguments, not their dependencies (e.g. `dependencies=false`? Suggestions welcome). This however would require some additional work, especially to perform the analysis afterwards. Maybe it can be done as a second PR.

I tried to test this functionality in a variety of cases (registered packages, unregistered ones, dirty ones, checked out, etc.) but it would be best if other people could put this to test as well.

[edit by tkelman: closes #13487]
