### PR TITLE
Remove VC90 from julia-manifest

### DIFF
--- a/contrib/windows/julia-manifest.xml
+++ b/contrib/windows/julia-manifest.xml
@@ -7,11 +7,6 @@
       </requestedPrivileges>
     </security>
   </trustInfo>
-  <dependency>
-    <dependentAssembly>
-      <assemblyIdentity type="win32" name="Microsoft.VC90.CRT" version="9.0.21022.8" processorArchitecture="amd64" publicKeyToken="1fc8b3b9a1e18e3b"></assemblyIdentity>
-    </dependentAssembly>
-  </dependency>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!--The ID below indicates application support for Windows Vista -->


### PR DESCRIPTION
so the typical julia.exe does not have any extra msvc runtime
installation requirements

x-ref https://github.com/JuliaLang/julia/pull/16442#issuecomment-228513630, cc @AndyGreenwell, @ihnorton, @stevengj 

So if you want to use pycall with python 2 and have the correct msvc runtime installed on your system, starting Julia via `julia-manifest.exe` will work correctly with `@pyimport zmq` or similar, but the usual `julia.exe` won't. I can't think of any other situation at the moment that would need this manifest stuff, but I may be wrong. This should be documented somewhere, but I think that somewhere should be in PyCall. The additional executable is pretty small, on the order of 500 kb.
