### PR TITLE
Fix compilation on LLVM svn

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -59,7 +59,11 @@ static Value *stringConstPtr(const std::string &txt)
                                                            (const unsigned char*)pooledtxt.data(),
                                                            pooledtxt.size())),
                                     ssno.str());
+#ifdef LLVM39
+            gv->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+#else
             gv->setUnnamedAddr(true);
+#endif
             pooledval->second = gv;
             jl_ExecutionEngine->addGlobalMapping(gv, (void*)(uintptr_t)pooledtxt.data());
         }


### PR DESCRIPTION
`GlobalValue::setUnnamedAddr`

Ref https://github.com/llvm-mirror/llvm/commit/63b34cdf342b8265d98357008765b2563dd04e6c
