### PR TITLE
Fix bugs in definitions of several Float16 methods (ref #17148).

### DIFF
--- a/base/float16.jl
+++ b/base/float16.jl
@@ -154,7 +154,7 @@ end
 
 for func in (:div,:fld,:cld,:rem,:mod,:atan2,:hypot)
     @eval begin
-        $func(a::Float16,b::Float16) = Float16($func(Float32(a),Float32(a)))
+        $func(a::Float16,b::Float16) = Float16($func(Float32(a),Float32(b)))
     end
 end
 

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -143,3 +143,6 @@ end
 
 #  #9939 (and #9897)
 @test rationalize(Float16(0.1)) == 1//10
+
+# issue #17148
+@test rem(Float16(1.2), Float16(one(1.2))) == 0.20019531f0


### PR DESCRIPTION
This PR fixes the bug in https://github.com/JuliaLang/julia/blob/861100c15b050885297430e7afc24c7a638de982/base/float16.jl#L157 where the first positional argument is accidentally used in several Float16 methods. Fixes #17148
