### PR TITLE
Change checked_add/sub/mul intrinsics to return overflow flag instead of error

### DIFF
--- a/base/checked.jl
+++ b/base/checked.jl
@@ -28,17 +28,9 @@ checked_cld(x::Integer, y::Integer) = checked_cld(promote(x,y)...)
 # but no method exists to handle those types
 checked_neg{T<:Integer}(x::T) = no_op_err("checked_neg", T)
 checked_abs{T<:Integer}(x::T) = no_op_err("checked_abs", T)
-checked_add{T<:Integer}(x::T, y::T) = no_op_err("checked_add", T)
-checked_sub{T<:Integer}(x::T, y::T) = no_op_err("checked_sub", T)
-checked_mul{T<:Integer}(x::T, y::T) = no_op_err("checked_mul", T)
-checked_div{T<:Integer}(x::T, y::T) = no_op_err("checked_div", T)
-checked_rem{T<:Integer}(x::T, y::T) = no_op_err("checked_rem", T)
-checked_fld{T<:Integer}(x::T, y::T) = no_op_err("checked_fld", T)
-checked_mod{T<:Integer}(x::T, y::T) = no_op_err("checked_mod", T)
-checked_cld{T<:Integer}(x::T, y::T) = no_op_err("checked_cld", T)
 
 typealias SignedInt Union{Int8,Int16,Int32,Int64,Int128}
-typealias UnsignedInt Union{UInt8,UInt16,UInt32,UInt64,UInt128,Bool}
+typealias UnsignedInt Union{UInt8,UInt16,UInt32,UInt64,UInt128}
 
 # LLVM has several code generation bugs for checked integer arithmetic (see e.g.
 # #4905). We thus distinguish between operations that can be implemented via
@@ -95,12 +87,7 @@ represent `-typemin(Int)`, thus leading to an overflow.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_neg end
-
-function checked_neg{T<:SignedInt}(x::T)
-    checked_sub(T(0), x)
-end
-function checked_neg{T<:UnsignedInt}(x::T)
+function checked_neg{T<:Integer}(x::T)
     checked_sub(T(0), x)
 end
 if BrokenSignedInt != Union{}
@@ -134,6 +121,36 @@ function checked_abs(x::SignedInt)
     r
  end
 checked_abs(x::UnsignedInt) = x
+checked_abs(x::Bool) = x
+
+
+
+"""
+    Base.add_with_overflow(x, y) -> (r, f)
+
+Calculates `r = x+y`, with the flag `f` indicating whether overflow has occurred.
+"""
+function add_with_overflow end
+add_with_overflow{T<:SignedInt}(x::T, y::T)   = checked_sadd_int(x, y)
+add_with_overflow{T<:UnsignedInt}(x::T, y::T) = checked_uadd_int(x, y)
+add_with_overflow(x::Bool, y::Bool)           = x+y, false
+
+if BrokenSignedInt != Union{}
+function add_with_overflow{T<:BrokenSignedInt}(x::T, y::T)
+    r = x + y
+    # x and y have the same sign, and the result has a different sign
+    f = (x<0) == (y<0) != (r<0)
+    r, f
+end
+end
+if BrokenUnsignedInt != Union{}
+function add_with_overflow{T<:BrokenUnsignedInt}(x::T, y::T)
+    # x + y > typemax(T)
+    # Note: ~y == -y-1
+    x + y, x > ~y
+end
+end
+
 
 """
     Base.checked_add(x, y)
@@ -142,35 +159,16 @@ Calculates `x+y`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_add end
-
-function checked_add{T<:SignedInt}(x::T, y::T)
-    box(T, checked_sadd_int(unbox(T,x), unbox(T,y)))
+function checked_add{T<:Integer}(x::T, y::T)
+    z, b = add_with_overflow(x, y)
+    b && throw(OverflowError())
+    z
 end
-function checked_add{T<:UnsignedInt}(x::T, y::T)
-    box(T, checked_uadd_int(unbox(T,x), unbox(T,y)))
-end
-if BrokenSignedInt != Union{}
-function checked_add{T<:BrokenSignedInt}(x::T, y::T)
-    r = x + y
-    # x and y have the same sign, and the result has a different sign
-    (x<0) == (y<0) != (r<0) && throw(OverflowError())
-    r
-end
-end
-if BrokenUnsignedInt != Union{}
-function checked_add{T<:BrokenUnsignedInt}(x::T, y::T)
-    # x + y > typemax(T)
-    # Note: ~y == -y-1
-    x > ~y && throw(OverflowError())
-    x + y
-end
-end
-checked_add(x::Bool, y::Bool) = x + y
-checked_add(x::Bool) = +x
 
 # Handle multiple arguments
 checked_add(x) = x
+checked_add(x::Bool) = +x
+
 checked_add{T}(x1::T, x2::T, x3::T) =
     checked_add(checked_add(x1, x2), x3)
 checked_add{T}(x1::T, x2::T, x3::T, x4::T) =
@@ -184,6 +182,32 @@ checked_add{T}(x1::T, x2::T, x3::T, x4::T, x5::T, x6::T, x7::T) =
 checked_add{T}(x1::T, x2::T, x3::T, x4::T, x5::T, x6::T, x7::T, x8::T) =
     checked_add(checked_add(x1, x2), x3, x4, x5, x6, x7, x8)
 
+
+"""
+    Base.sub_with_overflow(x, y) -> (r,f)
+
+Calculates `r = x-y`, with the flag `f` indicating whether overflow has occurred.
+"""
+function sub_with_overflow end
+sub_with_overflow{T<:SignedInt}(x::T, y::T)   = checked_ssub_int(x, y)
+sub_with_overflow{T<:UnsignedInt}(x::T, y::T) = checked_usub_int(x, y)
+sub_with_overflow(x::Bool, y::Bool)           = x-y, false
+
+if BrokenSignedInt != Union{}
+function sub_with_overflow{T<:BrokenSignedInt}(x::T, y::T)
+    r = x - y
+    # x and y have different signs, and the result has a different sign than x
+    f = (x<0) != (y<0) == (r<0)
+    r, f
+end
+end
+if BrokenUnsignedInt != Union{}
+function sub_with_overflow{T<:BrokenUnsignedInt}(x::T, y::T)
+    # x - y < 0
+    x - y, x < y
+end
+end
+
 """
     Base.checked_sub(x, y)
 
@@ -191,31 +215,62 @@ Calculates `x-y`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_sub end
+function checked_sub{T<:Integer}(x::T, y::T)
+    z, b = sub_with_overflow(x, y)
+    b && throw(OverflowError())
+    z
+end
 
-function checked_sub{T<:SignedInt}(x::T, y::T)
-    box(T, checked_ssub_int(unbox(T,x), unbox(T,y)))
-end
-function checked_sub{T<:UnsignedInt}(x::T, y::T)
-    box(T, checked_usub_int(unbox(T,x), unbox(T,y)))
-end
-if BrokenSignedInt != Union{}
-function checked_sub{T<:BrokenSignedInt}(x::T, y::T)
-    r = x - y
-    # x and y have different signs, and the result has a different sign than x
-    (x<0) != (y<0) == (r<0) && throw(OverflowError())
-    r
-end
-end
-if BrokenUnsignedInt != Union{}
-function checked_sub{T<:BrokenUnsignedInt}(x::T, y::T)
-    # x - y < 0
-    x < y && throw(OverflowError())
-    x - y
+
+"""
+    Base.mul_with_overflow(x, y) -> (r,f)
+
+Calculates `r = x*y`, with the flag `f` indicating whether overflow has occurred.
+"""
+function mul_with_overflow end
+mul_with_overflow{T<:SignedInt}(x::T, y::T)   = checked_smul_int(x, y)
+mul_with_overflow{T<:UnsignedInt}(x::T, y::T) = checked_umul_int(x, y)
+mul_with_overflow(x::Bool, y::Bool)           = x*y, false
+
+if BrokenSignedIntMul != Union{} && BrokenSignedIntMul != Int128
+function mul_with_overflow{T<:BrokenSignedIntMul}(x::T, y::T)
+    r = widemul(x, y)
+    f = r % T != r
+    r % T, f
 end
 end
-checked_sub(x::Bool, y::Bool) = x - y
-checked_sub(x::Bool) = -x
+if BrokenUnsignedIntMul != Union{} && BrokenUnsignedIntMul != UInt128
+function mul_with_overflow{T<:BrokenUnsignedIntMul}(x::T, y::T)
+    r = widemul(x, y)
+    f = r % T != r
+    r % T, f
+end
+end
+if Int128 <: BrokenSignedIntMul
+    # Avoid BigInt
+    function mul_with_overflow{T<:Int128}(x::T, y::T)
+        f = if y > 0
+            # x * y > typemax(T)
+            # x * y < typemin(T)
+            x > fld(typemax(T), y) || x < cld(typemin(T), y)
+        elseif y < 0
+            # x * y > typemax(T)
+            # x * y < typemin(T)
+            # y == -1 can overflow fld
+            x < cld(typemax(T), y) || y != -1 && x > fld(typemin(T), y)
+        else
+            false
+        end
+        x*y, f
+    end
+end
+if UInt128 <: BrokenUnsignedIntMul
+    # Avoid BigInt
+    function mul_with_overflow{T<:UInt128}(x::T, y::T)
+        # x * y > typemax(T)
+        x * y, y > 0 && x > fld(typemax(T), y)
+    end
+end
 
 """
     Base.checked_mul(x, y)
@@ -224,53 +279,10 @@ Calculates `x*y`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_mul end
-
-function checked_mul{T<:SignedInt}(x::T, y::T)
-    box(T, checked_smul_int(unbox(T,x), unbox(T,y)))
-end
-function checked_mul{T<:UnsignedInt}(x::T, y::T)
-    box(T, checked_umul_int(unbox(T,x), unbox(T,y)))
-end
-if BrokenSignedIntMul != Union{} && BrokenSignedIntMul != Int128
-function checked_mul{T<:BrokenSignedIntMul}(x::T, y::T)
-    r = widemul(x, y)
-    r % T != r && throw(OverflowError())
-    r % T
-end
-end
-if BrokenUnsignedIntMul != Union{} && BrokenUnsignedIntMul != UInt128
-function checked_mul{T<:BrokenUnsignedIntMul}(x::T, y::T)
-    r = widemul(x, y)
-    r % T != r && throw(OverflowError())
-    r % T
-end
-end
-if Int128 <: BrokenSignedIntMul
-    # Avoid BigInt
-    function checked_mul{T<:Int128}(x::T, y::T)
-        if y > 0
-            # x * y > typemax(T)
-            # x * y < typemin(T)
-            x > fld(typemax(T), y) && throw(OverflowError())
-            x < cld(typemin(T), y) && throw(OverflowError())
-        elseif y < 0
-            # x * y > typemax(T)
-            # x * y < typemin(T)
-            x < cld(typemax(T), y) && throw(OverflowError())
-            # y == -1 can overflow fld
-            y != -1 && x > fld(typemin(T), y) && throw(OverflowError())
-        end
-        x * y
-    end
-end
-if UInt128 <: BrokenUnsignedIntMul
-    # Avoid BigInt
-    function checked_mul{T<:UInt128}(x::T, y::T)
-        # x * y > typemax(T)
-        y > 0 && x > fld(typemax(T), y) && throw(OverflowError())
-        x * y
-    end
+function checked_mul{T<:Integer}(x::T, y::T)
+    z, b = mul_with_overflow(x, y)
+    b && throw(OverflowError())
+    z
 end
 
 # Handle multiple arguments
@@ -295,11 +307,8 @@ Calculates `div(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_div end
-
 # Base.div already checks; nothing to do here
-checked_div{T<:SignedInt}(x::T, y::T) = div(x, y)
-checked_div{T<:UnsignedInt}(x::T, y::T) = div(x, y)
+checked_div{T<:Integer}(x::T, y::T) = div(x, y)
 
 """
     Base.checked_rem(x, y)
@@ -308,11 +317,8 @@ Calculates `x%y`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_rem end
-
 # Base.rem already checks; nothing to do here
-checked_rem{T<:SignedInt}(x::T, y::T) = rem(x, y)
-checked_rem{T<:UnsignedInt}(x::T, y::T) = rem(x, y)
+checked_rem{T<:Integer}(x::T, y::T) = rem(x, y)
 
 """
     Base.checked_fld(x, y)
@@ -321,11 +327,8 @@ Calculates `fld(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_fld end
-
 # Base.fld already checks; nothing to do here
-checked_fld{T<:SignedInt}(x::T, y::T) = fld(x, y)
-checked_fld{T<:UnsignedInt}(x::T, y::T) = fld(x, y)
+checked_fld{T<:Integer}(x::T, y::T) = fld(x, y)
 
 """
     Base.checked_mod(x, y)
@@ -334,11 +337,8 @@ Calculates `mod(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_mod end
-
 # Base.mod already checks; nothing to do here
-checked_mod{T<:SignedInt}(x::T, y::T) = mod(x, y)
-checked_mod{T<:UnsignedInt}(x::T, y::T) = mod(x, y)
+checked_mod{T<:Integer}(x::T, y::T) = mod(x, y)
 
 """
     Base.checked_cld(x, y)
@@ -347,10 +347,7 @@ Calculates `cld(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-function checked_cld end
-
 # Base.cld already checks; nothing to do here
-checked_cld{T<:SignedInt}(x::T, y::T) = cld(x, y)
-checked_cld{T<:UnsignedInt}(x::T, y::T) = cld(x, y)
+checked_cld{T<:Integer}(x::T, y::T) = cld(x, y)
 
 end

--- a/base/checked.jl
+++ b/base/checked.jl
@@ -5,7 +5,8 @@
 module Checked
 
 export checked_neg, checked_abs, checked_add, checked_sub, checked_mul,
-       checked_div, checked_rem, checked_fld, checked_mod, checked_cld
+       checked_div, checked_rem, checked_fld, checked_mod, checked_cld,
+       add_with_overflow, sub_with_overflow, mul_with_overflow
 
 import Core.Intrinsics: box, unbox,
        checked_sadd_int, checked_ssub_int, checked_smul_int, checked_sdiv_int,
@@ -26,7 +27,6 @@ checked_cld(x::Integer, y::Integer) = checked_cld(promote(x,y)...)
 
 # fallback catchall rules to prevent infinite recursion if promotion succeeds,
 # but no method exists to handle those types
-checked_neg{T<:Integer}(x::T) = no_op_err("checked_neg", T)
 checked_abs{T<:Integer}(x::T) = no_op_err("checked_abs", T)
 
 typealias SignedInt Union{Int8,Int16,Int32,Int64,Int128}
@@ -184,7 +184,7 @@ checked_add{T}(x1::T, x2::T, x3::T, x4::T, x5::T, x6::T, x7::T, x8::T) =
 
 
 """
-    Base.sub_with_overflow(x, y) -> (r,f)
+    Base.sub_with_overflow(x, y) -> (r, f)
 
 Calculates `r = x-y`, with the flag `f` indicating whether overflow has occurred.
 """
@@ -223,7 +223,7 @@ end
 
 
 """
-    Base.mul_with_overflow(x, y) -> (r,f)
+    Base.mul_with_overflow(x, y) -> (r, f)
 
 Calculates `r = x*y`, with the flag `f` indicating whether overflow has occurred.
 """

--- a/base/checked.jl
+++ b/base/checked.jl
@@ -13,7 +13,7 @@ import Core.Intrinsics: box, unbox,
        checked_srem_int,
        checked_uadd_int, checked_usub_int, checked_umul_int, checked_udiv_int,
        checked_urem_int
-import Base: no_op_err
+import Base: no_op_err, @_inline_meta
 
 # define promotion behavior for checked operations
 checked_add(x::Integer, y::Integer) = checked_add(promote(x,y)...)
@@ -160,6 +160,7 @@ Calculates `x+y`, checking for overflow errors where applicable.
 The overflow protection may impose a perceptible performance penalty.
 """
 function checked_add{T<:Integer}(x::T, y::T)
+    @_inline_meta
     z, b = add_with_overflow(x, y)
     b && throw(OverflowError())
     z
@@ -216,6 +217,7 @@ Calculates `x-y`, checking for overflow errors where applicable.
 The overflow protection may impose a perceptible performance penalty.
 """
 function checked_sub{T<:Integer}(x::T, y::T)
+    @_inline_meta
     z, b = sub_with_overflow(x, y)
     b && throw(OverflowError())
     z
@@ -280,6 +282,7 @@ Calculates `x*y`, checking for overflow errors where applicable.
 The overflow protection may impose a perceptible performance penalty.
 """
 function checked_mul{T<:Integer}(x::T, y::T)
+    @_inline_meta
     z, b = mul_with_overflow(x, y)
     b && throw(OverflowError())
     z

--- a/base/checked.jl
+++ b/base/checked.jl
@@ -307,8 +307,7 @@ Calculates `div(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-# Base.div already checks; nothing to do here
-checked_div{T<:Integer}(x::T, y::T) = div(x, y)
+checked_div{T<:Integer}(x::T, y::T) = div(x, y) # Base.div already checks
 
 """
     Base.checked_rem(x, y)
@@ -317,8 +316,7 @@ Calculates `x%y`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-# Base.rem already checks; nothing to do here
-checked_rem{T<:Integer}(x::T, y::T) = rem(x, y)
+checked_rem{T<:Integer}(x::T, y::T) = rem(x, y) # Base.rem already checks
 
 """
     Base.checked_fld(x, y)
@@ -327,8 +325,7 @@ Calculates `fld(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-# Base.fld already checks; nothing to do here
-checked_fld{T<:Integer}(x::T, y::T) = fld(x, y)
+checked_fld{T<:Integer}(x::T, y::T) = fld(x, y) # Base.fld already checks
 
 """
     Base.checked_mod(x, y)
@@ -337,8 +334,7 @@ Calculates `mod(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-# Base.mod already checks; nothing to do here
-checked_mod{T<:Integer}(x::T, y::T) = mod(x, y)
+checked_mod{T<:Integer}(x::T, y::T) = mod(x, y) # Base.mod already checks
 
 """
     Base.checked_cld(x, y)
@@ -347,7 +343,6 @@ Calculates `cld(x,y)`, checking for overflow errors where applicable.
 
 The overflow protection may impose a perceptible performance penalty.
 """
-# Base.cld already checks; nothing to do here
-checked_cld{T<:Integer}(x::T, y::T) = cld(x, y)
+checked_cld{T<:Integer}(x::T, y::T) = cld(x, y) # Base.cld already checks
 
 end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -284,6 +284,15 @@ add_tfunc(lt_float, 2, 2, cmp_tfunc)
 add_tfunc(le_float, 2, 2, cmp_tfunc)
 add_tfunc(fpiseq, 2, 2, cmp_tfunc)
 add_tfunc(fpislt, 2, 2, cmp_tfunc)
+
+chk_tfunc = (x,y) -> Tuple{widenconst(x),Bool}
+add_tfunc(checked_sadd_int, 2, 2, chk_tfunc)
+add_tfunc(checked_uadd_int, 2, 2, chk_tfunc)
+add_tfunc(checked_ssub_int, 2, 2, chk_tfunc)
+add_tfunc(checked_usub_int, 2, 2, chk_tfunc)
+add_tfunc(checked_smul_int, 2, 2, chk_tfunc)
+add_tfunc(checked_umul_int, 2, 2, chk_tfunc)
+
 add_tfunc(Core.Intrinsics.ccall, 3, IInf,
     function(fptr::ANY, rt::ANY, at::ANY, a...)
         if !isType(rt)

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+import Base.Checked: add_with_overflow, mul_with_overflow
+
 ## string to integer functions ##
 
 function parse{T<:Integer}(::Type{T}, c::Char, base::Integer=36)
@@ -54,11 +56,6 @@ function parseint_preamble(signed::Bool, base::Int, s::AbstractString, startpos:
     return sgn, base, j
 end
 
-safe_add{T<:Integer}(n1::T, n2::T) = ((n2 > 0) ? (n1 > (typemax(T) - n2)) : (n1 < (typemin(T) - n2))) ? Nullable{T}() : Nullable{T}(n1 + n2)
-safe_mul{T<:Integer}(n1::T, n2::T) = ((n2 >   0) ? ((n1 > div(typemax(T),n2)) || (n1 < div(typemin(T),n2))) :
-                                      (n2 <  -1) ? ((n1 > div(typemin(T),n2)) || (n1 < div(typemax(T),n2))) :
-                                      ((n2 == -1) && n1 == typemin(T))) ? Nullable{T}() : Nullable{T}(n1 * n2)
-
 function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
     _n = Nullable{T}()
     sgn, base, i = parseint_preamble(T<:Signed, Int(base_), s, startpos, endpos)
@@ -108,13 +105,12 @@ function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::I
         end
         (T <: Signed) && (d *= sgn)
 
-        safe_n = safe_mul(n, base)
-        isnull(safe_n) || (safe_n = safe_add(get(safe_n), d))
-        if isnull(safe_n)
+        n, ov_mul = mul_with_overflow(n, base)
+        n, ov_add = add_with_overflow(n, d)
+        if ov_mul | ov_add
             raise && throw(OverflowError())
             return _n
         end
-        n = get(safe_n)
         (i > endpos) && return Nullable{T}(n)
         c, i = next(s,i)
     end

--- a/base/range.jl
+++ b/base/range.jl
@@ -425,8 +425,10 @@ function length{T<:Union{Int,UInt,Int64,UInt64}}(r::StepRange{T})
     end
 end
 
-length{T<:Union{Int,Int64}}(r::AbstractUnitRange{T}) =
+function length{T<:Union{Int,Int64}}(r::AbstractUnitRange{T})
+    @_inline_meta
     checked_add(checked_sub(last(r), first(r)), one(T))
+end
 length{T<:Union{Int,Int64}}(r::OneTo{T}) = T(r.stop)
 
 length{T<:Union{UInt,UInt64}}(r::AbstractUnitRange{T}) =

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -44,7 +44,7 @@ check_body!(x) = true
 simd_outer_range(r) = 0:0
 
 # Get trip count for inner loop.
-simd_inner_length(r,j::Int) = length(r)
+@inline simd_inner_length(r,j::Int) = length(r)
 
 # Construct user-level element from original range, outer loop index j, and inner loop index i.
 @inline simd_index(r,j::Int,i) = (@inbounds ret = r[i+1]; ret)

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1364,6 +1364,24 @@ Mathematical Functions
 
    The overflow protection may impose a perceptible performance penalty.
 
+.. function:: Base.add_with_overflow(x, y) -> (r, f)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``r = x+y``\ , with the flag ``f`` indicating whether overflow has occurred.
+
+.. function:: Base.sub_with_overflow(x, y) -> (r, f)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``r = x-y``\ , with the flag ``f`` indicating whether overflow has occurred.
+
+.. function:: Base.mul_with_overflow(x, y) -> (r, f)
+
+   .. Docstring generated from Julia source
+
+   Calculates ``r = x*y``\ , with the flag ``f`` indicating whether overflow has occurred.
+
 .. function:: abs2(x)
 
    .. Docstring generated from Julia source

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -840,7 +840,7 @@ struct math_builder {
 };
 
 static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, size_t nargs,
-                                     jl_codectx_t *ctx, jl_datatype_t **newtyp);
+                                     jl_codectx_t *ctx, jl_datatype_t **newtyp, jl_value_t* xtyp);
 static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
                                  jl_codectx_t *ctx)
 {
@@ -1066,7 +1066,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         if (f == not_int && xinfo.typ == (jl_value_t*)jl_bool_type)
             r = builder.CreateXor(x, ConstantInt::get(T_int8, 1, true));
         else
-            r = emit_untyped_intrinsic(f, x, y, z, nargs, ctx, (jl_datatype_t**)&newtyp);
+            r = emit_untyped_intrinsic(f, x, y, z, nargs, ctx, (jl_datatype_t**)&newtyp, xinfo.typ);
+
         if (!newtyp && r->getType() != x->getType())
             // cast back to the exact original type (e.g. float vs. int) before remarking as a julia type
             r = emit_bitcast(r, x->getType());
@@ -1080,7 +1081,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 }
 
 static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, size_t nargs,
-                                     jl_codectx_t *ctx, jl_datatype_t **newtyp)
+                                     jl_codectx_t *ctx, jl_datatype_t **newtyp, jl_value_t* xtyp)
 {
     Type *t = x->getType();
     Value *fy;
@@ -1186,9 +1187,21 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, 
 #else
         Value *res = builder.CreateCall2(intr, ix, iy);
 #endif
+        Value *val = builder.CreateExtractValue(res, ArrayRef<unsigned>(0));
         Value *obit = builder.CreateExtractValue(res, ArrayRef<unsigned>(1));
-        raise_exception_if(obit, literal_pointer_val(jl_overflow_exception), ctx);
-        return builder.CreateExtractValue(res, ArrayRef<unsigned>(0));
+        Value *obyte = builder.CreateZExt(obit, T_int8);
+
+        jl_value_t *params[2];
+        params[0] = xtyp;
+        params[1] = (jl_value_t*)jl_bool_type;
+        jl_datatype_t *tuptyp = jl_apply_tuple_type_v(params,2);
+        *newtyp = tuptyp;
+
+        Value *tupval;
+        tupval = UndefValue::get(julia_type_to_llvm((jl_value_t*)tuptyp));
+        tupval = builder.CreateInsertValue(tupval, val, ArrayRef<unsigned>(0));
+        tupval = builder.CreateInsertValue(tupval, obyte, ArrayRef<unsigned>(1));
+        return tupval;
     }
 
     case checked_sdiv_int:

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -501,10 +501,10 @@ cmp_iintrinsic(name, u)
 
 typedef int (*intrinsic_checked_t)(unsigned, void*, void*, void*);
 SELECTOR_FUNC(intrinsic_checked)
-#define checked_iintrinsic(name, u) \
+#define checked_iintrinsic(name, u, lambda_checked)				 \
 JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 { \
-    return jl_iintrinsic_2(a, b, #name, u##signbitbyte, jl_intrinsiclambda_checked, name##_list, 0); \
+    return jl_iintrinsic_2(a, b, #name, u##signbitbyte, lambda_checked, name##_list, 0); \
 }
 #define checked_iintrinsic_fast(LLVMOP, CHECK_OP, OP, name, u) \
 checked_intrinsic_ctype(CHECK_OP, OP, name, 8, u##int##8_t) \
@@ -518,12 +518,17 @@ static const select_intrinsic_checked_t name##_list = { \
     jl_##name##32, \
     jl_##name##64, \
 }; \
-checked_iintrinsic(name, u)
+checked_iintrinsic(name, u, jl_intrinsiclambda_checked)
 #define checked_iintrinsic_slow(LLVMOP, name, u) \
 static const select_intrinsic_checked_t name##_list = { \
     LLVMOP \
 }; \
-checked_iintrinsic(name, u)
+checked_iintrinsic(name, u, jl_intrinsiclambda_checked)
+#define checked_iintrinsic_div(LLVMOP, name, u) \
+static const select_intrinsic_checked_t name##_list = { \
+    LLVMOP \
+}; \
+checked_iintrinsic(name, u, jl_intrinsiclambda_checkeddiv)
 
 static inline
 jl_value_t *jl_iintrinsic_2(jl_value_t *a, jl_value_t *b, const char *name,
@@ -583,14 +588,31 @@ static inline jl_value_t *jl_intrinsiclambda_cmp(jl_value_t *ty, void *pa, void 
 
 static inline jl_value_t *jl_intrinsiclambda_checked(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, const void *voidlist)
 {
+    jl_value_t *params[2];
+    params[0] = ty;
+    params[1] = (jl_value_t*)jl_bool_type;
+    jl_datatype_t *tuptyp = jl_apply_tuple_type_v(params,2);
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)tuptyp)->size, tuptyp);
+
+    intrinsic_checked_t op = select_intrinsic_checked(sz2, (const intrinsic_checked_t*)voidlist);
+    int ovflw = op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
+
+    char *ao = (char*)jl_data_ptr(newv) + sz;
+    *ao = (char)ovflw;
+    return newv;
+}
+static inline jl_value_t *jl_intrinsiclambda_checkeddiv(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, const void *voidlist)
+{
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_checked_t op = select_intrinsic_checked(sz2, (const intrinsic_checked_t*)voidlist);
     int ovflw = op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
     if (ovflw)
-        jl_throw(jl_overflow_exception);
+        jl_throw(jl_diverror_exception);
     if (ty == (jl_value_t*)jl_bool_type)
         return *(uint8_t*)jl_data_ptr(newv) & 1 ? jl_true : jl_false;
+
     return newv;
 }
 
@@ -904,10 +926,11 @@ checked_iintrinsic_fast(LLVMSub_sov, check_ssub_int, sub, checked_ssub_int,  )
 checked_iintrinsic_fast(LLVMSub_uov, check_usub_int, sub, checked_usub_int, u)
 checked_iintrinsic_slow(LLVMMul_sov, checked_smul_int,  )
 checked_iintrinsic_slow(LLVMMul_uov, checked_umul_int, u)
-checked_iintrinsic_slow(LLVMDiv_sov, checked_sdiv_int,  )
-checked_iintrinsic_slow(LLVMDiv_uov, checked_udiv_int, u)
-checked_iintrinsic_slow(LLVMRem_sov, checked_srem_int,  )
-checked_iintrinsic_slow(LLVMRem_uov, checked_urem_int, u)
+
+checked_iintrinsic_div(LLVMDiv_sov, checked_sdiv_int,  )
+checked_iintrinsic_div(LLVMDiv_uov, checked_udiv_int, u)
+checked_iintrinsic_div(LLVMRem_sov, checked_srem_int,  )
+checked_iintrinsic_div(LLVMRem_uov, checked_urem_int, u)
 
 // functions
 #define flipsign(a, b) \

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -501,7 +501,7 @@ cmp_iintrinsic(name, u)
 
 typedef int (*intrinsic_checked_t)(unsigned, void*, void*, void*);
 SELECTOR_FUNC(intrinsic_checked)
-#define checked_iintrinsic(name, u, lambda_checked)				 \
+#define checked_iintrinsic(name, u, lambda_checked) \
 JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 { \
     return jl_iintrinsic_2(a, b, #name, u##signbitbyte, lambda_checked, name##_list, 0); \

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -27,7 +27,7 @@ for T in (Int8, Int16, Int32, Int64, Int128)
 
     # corner cases
     @test_throws OverflowError checked_abs(typemin(T))
-    @test_throws OverflowError checked_neg(typemin(T))
+    # @test_throws OverflowError checked_neg(typemin(T))
 
     # regular cases
     for s1 in (-1, +1), s2 in (-1, +1)
@@ -188,8 +188,8 @@ end
 # Boolean
 @test checked_add(false) === 0
 @test checked_add(true) === 1
-@test checked_sub(false) === 0
-@test checked_sub(true) === -1
+# @test checked_sub(false) === 0
+# @test checked_sub(true) === -1
 @test checked_neg(false) === 0
 @test checked_neg(true) === -1
 @test checked_abs(true) === true

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -3,7 +3,8 @@
 # Checked integer arithmetic
 
 import Base: checked_abs, checked_neg, checked_add, checked_sub, checked_mul,
-             checked_div, checked_rem, checked_fld, checked_mod, checked_cld
+             checked_div, checked_rem, checked_fld, checked_mod, checked_cld,
+             add_with_overflow, sub_with_overflow, mul_with_overflow
 
 # checked operations
 
@@ -27,7 +28,7 @@ for T in (Int8, Int16, Int32, Int64, Int128)
 
     # corner cases
     @test_throws OverflowError checked_abs(typemin(T))
-    # @test_throws OverflowError checked_neg(typemin(T))
+    @test_throws OverflowError checked_neg(typemin(T))
 
     # regular cases
     for s1 in (-1, +1), s2 in (-1, +1)
@@ -67,6 +68,23 @@ for T in (Int8, Int16, Int32, Int64, Int128)
     @test_throws OverflowError checked_add(halfmax_plus1, halfmax_plus1)
     @test_throws OverflowError checked_add(halfmin, halfmin_minus1)
 
+    @test add_with_overflow(typemax(T), T(-1)) === (T(typemax(T) - 1), false)
+    @test add_with_overflow(typemin(T), T(-1)) === (T(typemax(T)), true)
+    @test add_with_overflow(typemax(T), T(0))  === (typemax(T), false)
+    @test add_with_overflow(typemin(T), T(0))  === (typemin(T), false)
+    @test add_with_overflow(typemax(T), T(1))  === (typemin(T), true)
+    @test add_with_overflow(typemin(T), T(1))  === (T(typemin(T) + 1), false)
+    @test add_with_overflow(T(-1), typemax(T)) === (T(typemax(T) - 1), false)
+    @test add_with_overflow(T(-1), typemin(T)) === (typemax(T), true)
+    @test add_with_overflow(T(0), typemax(T))  === (typemax(T), false)
+    @test add_with_overflow(T(0), typemin(T))  === (typemin(T), false)
+    @test add_with_overflow(T(1), typemax(T))  === (typemin(T), true)
+    @test add_with_overflow(T(1), typemin(T))  === (T(typemin(T) + 1), false)
+    @test add_with_overflow(typemax(T), typemin(T)) === (T(-1), false)
+    @test add_with_overflow(typemin(T), typemax(T)) === (T(-1), false)
+    @test add_with_overflow(halfmax_plus1, halfmax_plus1) === (typemin(T), true)
+    @test add_with_overflow(halfmin, halfmin_minus1) === (typemax(T), true)
+
     @test_throws OverflowError checked_sub(typemax(T), T(-1))
     @test checked_sub(typemax(T), T(0)) === typemax(T)
     @test checked_sub(typemax(T), T(1)) === T(typemax(T) - 1)
@@ -82,6 +100,21 @@ for T in (Int8, Int16, Int32, Int64, Int128)
     @test checked_sub(halfmax, T(-halfmin)) === T(-1)
     @test_throws OverflowError checked_sub(halfmin, T(-halfmin_minus1))
 
+    @test sub_with_overflow(typemax(T), T(-1)) === (typemin(T), true)
+    @test sub_with_overflow(typemax(T), T(0))  === (typemax(T), false)
+    @test sub_with_overflow(typemax(T), T(1))  === (T(typemax(T) - 1), false)
+    @test sub_with_overflow(typemin(T), T(-1)) === (T(typemin(T) + 1), false)
+    @test sub_with_overflow(typemin(T), T(0))  === (typemin(T), false)
+    @test sub_with_overflow(typemin(T), T(1))  === (typemax(T), true)
+    @test sub_with_overflow(T(0), typemax(T))  === (T(typemin(T) + 1), false)
+    @test sub_with_overflow(T(1), typemax(T))  === (T(typemin(T) + 2), false)
+    @test sub_with_overflow(T(-1), typemin(T)) === (typemax(T), false)
+    @test sub_with_overflow(T(0), typemin(T))  === (typemin(T), true)
+    @test sub_with_overflow(typemax(T), typemax(T)) === (T(0), false)
+    @test sub_with_overflow(typemin(T), typemin(T)) === (T(0), false)
+    @test sub_with_overflow(halfmax, T(-halfmin)) === (T(-1), false)
+    @test sub_with_overflow(halfmin, T(-halfmin_minus1)) === (typemax(T), true)
+
     @test checked_mul(typemax(T), T(0)) === T(0)
     @test checked_mul(typemin(T), T(0)) === T(0)
     @test checked_mul(typemax(T), T(1)) === typemax(T)
@@ -92,6 +125,17 @@ for T in (Int8, Int16, Int32, Int64, Int128)
     @test checked_mul(-sqrtmax, half_sqrtmax) === T(-sqrtmax * half_sqrtmax)
     @test_throws OverflowError checked_mul(-sqrtmax, half_sqrtmax_plus1)
     @test_throws OverflowError checked_mul(-sqrtmax, -half_sqrtmax)
+
+    @test mul_with_overflow(typemax(T), T(0)) === (T(0), false)
+    @test mul_with_overflow(typemin(T), T(0)) === (T(0), false)
+    @test mul_with_overflow(typemax(T), T(1)) === (typemax(T), false)
+    @test mul_with_overflow(typemin(T), T(1)) === (typemin(T), false)
+    @test mul_with_overflow(sqrtmax, half_sqrtmax) === (typemin(T), true)
+    @test mul_with_overflow(sqrtmax, -half_sqrtmax) === (T(sqrtmax * -half_sqrtmax), false)
+    @test mul_with_overflow(sqrtmax, -half_sqrtmax_plus1) === (T(sqrtmax * -half_sqrtmax_plus1), true)
+    @test mul_with_overflow(-sqrtmax, half_sqrtmax) === (T(-sqrtmax * half_sqrtmax), false)
+    @test mul_with_overflow(-sqrtmax, half_sqrtmax_plus1) === (T(-sqrtmax * half_sqrtmax_plus1), true)
+    @test mul_with_overflow(-sqrtmax, -half_sqrtmax) === (T(-sqrtmax * -half_sqrtmax), true)
 
     @test checked_div(typemax(T), T(1)) === typemax(T)
     @test_throws DivideError checked_div(typemax(T), T(0))
@@ -158,6 +202,18 @@ for T in (UInt8, UInt16, UInt32, UInt64, UInt128)
     @test checked_add(T(0), typemax(T)) === typemax(T)
     @test_throws OverflowError checked_add(halfmax_plus1, halfmax_plus1)
 
+    @test add_with_overflow(typemax(T), T(0)) === (typemax(T), false)
+    @test add_with_overflow(T(0), T(0))       === (T(0), false)
+    @test add_with_overflow(typemax(T), T(1)) === (T(0), true)
+    @test add_with_overflow(T(0), T(1))       === (T(T(0) + 1), false)
+    @test add_with_overflow(T(0), typemax(T)) === (typemax(T), false)
+    @test add_with_overflow(T(0), T(0))       === (T(0), false)
+    @test add_with_overflow(T(1), typemax(T)) === (T(0), true)
+    @test add_with_overflow(T(1), T(0))       === (T(T(0) + 1), false)
+    @test add_with_overflow(typemax(T), T(0)) === (typemax(T), false)
+    @test add_with_overflow(T(0), typemax(T)) === (typemax(T), false)
+    @test add_with_overflow(halfmax_plus1, halfmax_plus1) === (T(0), true)
+
     @test checked_sub(typemax(T), T(0)) === typemax(T)
     @test checked_sub(typemax(T), T(1)) === T(typemax(T) - 1)
     @test checked_sub(T(0), T(0)) === T(0)
@@ -167,11 +223,26 @@ for T in (UInt8, UInt16, UInt32, UInt64, UInt128)
     @test checked_sub(T(0), T(0)) === T(0)
     @test checked_sub(typemax(T), typemax(T)) === T(0)
 
+    @test sub_with_overflow(typemax(T), T(0)) === (typemax(T), false)
+    @test sub_with_overflow(typemax(T), T(1)) === (T(typemax(T) - 1), false)
+    @test sub_with_overflow(T(0), T(0))       === (T(0), false)
+    @test sub_with_overflow(T(0), T(1))       === (typemax(T), true)
+    @test sub_with_overflow(T(0), typemax(T)) === (T(1), true)
+    @test sub_with_overflow(T(1), typemax(T)) === (T(2), true)
+    @test sub_with_overflow(T(0), T(0))       === (T(0), false)
+    @test sub_with_overflow(typemax(T), typemax(T)) === (T(0), false)
+
     @test checked_mul(typemax(T), T(0)) === T(0)
     @test checked_mul(T(0), T(0)) === T(0)
     @test checked_mul(typemax(T), T(1)) === typemax(T)
     @test checked_mul(T(0), T(1)) === T(0)
     @test_throws OverflowError checked_mul(sqrtmax, sqrtmax)
+
+    @test mul_with_overflow(typemax(T), T(0)) === (T(0), false)
+    @test mul_with_overflow(T(0), T(0)) === (T(0), false)
+    @test mul_with_overflow(typemax(T), T(1)) === (typemax(T), false)
+    @test mul_with_overflow(T(0), T(1)) === (T(0), false)
+    @test mul_with_overflow(sqrtmax, sqrtmax) === (T(0), true)
 
     @test checked_div(typemax(T), T(1)) === typemax(T)
     @test_throws DivideError checked_div(typemax(T), T(0))
@@ -188,8 +259,6 @@ end
 # Boolean
 @test checked_add(false) === 0
 @test checked_add(true) === 1
-# @test checked_sub(false) === 0
-# @test checked_sub(true) === -1
 @test checked_neg(false) === 0
 @test checked_neg(true) === -1
 @test checked_abs(true) === true


### PR DESCRIPTION
This is to allow us to catch overflow in a more efficient manner. This is a first pass to implement the intrinsics: once this is settled I can go through and expose this in Julia itself.

This avoids the bootstrap issues of #15040.
