### PR TITLE
Sort versions without build after versions with build

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -123,8 +123,8 @@ function ident_cmp(A::Tuple{Vararg{Union{Int,String}}},
        c = ident_cmp(a,b)
        (c != 0) && return c
     end
-    done(A,i) && !done(B,j) ? -1 :
-    !done(A,i) && done(B,j) ? +1 : 0
+    done(A,i) && !done(B,j) ? +1 :
+    !done(A,i) && done(B,j) ? -1 : 0
 end
 
 function ==(a::VersionNumber, b::VersionNumber)


### PR DESCRIPTION
Currently we have v"0.5.0-dev" < v"0.5.0-dev+1". This breaks (at least) Compat for Julia installs where no build information is available.

I propose to change how versions are compared: If no build information is available, assume it is the very latest build, instead of assuming it is the oldest build.
