### PR TITLE
fix #4883, result type of `broadcast` for arbitrary functions

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -196,3 +196,7 @@ end
 let a = broadcast(Float32, [3, 4, 5])
     @test eltype(a) == Float32
 end
+
+# issue #4883
+@test isa(broadcast(tuple, [1 2 3], ["a", "b", "c"]), Matrix{Tuple{Int,String}})
+@test isa(broadcast((x,y)->(x==1?1.0:x,y), [1 2 3], ["a", "b", "c"]), Matrix{Tuple{Real,String}})


### PR DESCRIPTION
Silly demo:

```
julia> broadcast(tuple, [1 2 3], ["a", "b", "c"])
3×3 Array{Tuple{Int64,String},2}:
 (1,"a")  (2,"a")  (3,"a")
 (1,"b")  (2,"b")  (3,"b")
 (1,"c")  (2,"c")  (3,"c")

julia> broadcast((x,y)->(rand(Bool)?1.0:x,y), [1 2 3], ["a", "b", "c"])
3×3 Array{Tuple{Real,String},2}:
 (1.0,"a")  (2,"a")    (1.0,"a")
 (1,"b")    (1.0,"b")  (1.0,"b")
 (1.0,"c")  (1.0,"c")  (1.0,"c")
```

This still uses `promote_eltype_op`, but falls back to the "map" algorithm when that returns `Any`.

Reducing the size of this code is a good challenge for the future. The problems are performance, and handling index ranges and iteration order of the output properly in `collect`. Another issue is that you can't use `@simd` on a `while` loop.
