### PR TITLE
win: precompile=yes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ notifications:
           - http://julia.mit.edu:8000/travis-hook
 before_install:
     - make check-whitespace
-    - JULIA_SYSIMG_BUILD_FLAGS="--output-ji ../usr/lib/julia/sys.ji"
     - if [ `uname` = "Linux" ]; then
         contrib/travis_fastfail.sh || exit 1;
         mkdir -p $HOME/bin;
@@ -93,7 +92,7 @@ script:
     - make -C moreutils mispipe
     - make $BUILDOPTS -C base version_git.jl.phony
     - moreutils/mispipe "make $BUILDOPTS NO_GIT=1 -C deps" bar > deps.log || cat deps.log
-    - make $BUILDOPTS NO_GIT=1 JULIA_SYSIMG_BUILD_FLAGS="$JULIA_SYSIMG_BUILD_FLAGS" prefix=/tmp/julia install | moreutils/ts -s "%.s"
+    - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - make $BUILDOPTS NO_GIT=1 build-stats
     - du -sk /tmp/julia/*
     - if [ `uname` = "Darwin" ]; then
@@ -102,8 +101,8 @@ script:
         done;
       fi
     - cd .. && mv julia julia2
-    - cp /tmp/julia/lib/julia/sys.ji local.ji && /tmp/julia/bin/julia -J local.ji -e 'true' &&
-        /tmp/julia/bin/julia-debug -J local.ji -e 'true' && rm local.ji
+    - /tmp/julia/bin/julia --precompiled=no -e 'true' &&
+      /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
     - /tmp/julia/bin/julia -e 'versioninfo()'
     - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 && cd /tmp/julia/share/julia/test &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,6 @@ build_script:
 
 test_script:
   - usr\bin\julia -e "versioninfo()"
-  - copy usr\lib\julia\sys.ji local.ji && usr\bin\julia -J local.ji -e "true" && del local.ji
+  - usr\bin\julia --precompiled=no -e "true"
   - cd test && ..\usr\bin\julia --check-bounds=yes runtests.jl all &&
       ..\usr\bin\julia --check-bounds=yes runtests.jl libgit2-online pkg

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -166,7 +166,6 @@ for lib in SUITESPARSE ARPACK BLAS LAPACK FFTW \
 done
 echo 'override LIBLAPACK = $(LIBBLAS)' >> Make.user
 echo 'override LIBLAPACKNAME = $(LIBBLASNAME)' >> Make.user
-echo 'JULIA_SYSIMG_BUILD_FLAGS=--output-ji ../usr/lib/julia/sys.ji' >> Make.user
 
 # Remaining dependencies:
 # libuv since its static lib is no longer included in the binaries

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -128,9 +128,6 @@ void jl_add_linfo_in_flight(StringRef name, jl_lambda_info_t *linfo, const DataL
 }
 
 #if defined(_OS_WINDOWS_)
-#if defined(_CPU_X86_64_)
-extern "C" EXCEPTION_DISPOSITION _seh_exception_handler(PEXCEPTION_RECORD ExceptionRecord,void *EstablisherFrame, PCONTEXT ContextRecord, void *DispatcherContext);
-#endif
 static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnname,
         uint8_t *Section, size_t Allocated, uint8_t *UnwindData)
 {
@@ -143,7 +140,7 @@ static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnnam
     if (!catchjmp[0]) {
         catchjmp[0] = 0x48;
         catchjmp[1] = 0xb8; // mov RAX, QWORD PTR [...]
-        *(uint64_t*)(&catchjmp[2]) = (uint64_t)&_seh_exception_handler;
+        *(uint64_t*)(&catchjmp[2]) = (uint64_t)&__julia_personality;
         catchjmp[10] = 0xff;
         catchjmp[11] = 0xe0; // jmp RAX
         UnwindData[0] = 0x09; // version info, UNW_FLAG_EHANDLER
@@ -421,9 +418,9 @@ public:
         assert(SectionAddrCheck);
         assert(SectionLoadOffset != 1);
         catchjmp[SectionLoadOffset] = 0x48;
-        catchjmp[SectionLoadOffset + 1] = 0xb8; // mov RAX, QWORD PTR [&_seh_exception_handle]
+        catchjmp[SectionLoadOffset + 1] = 0xb8; // mov RAX, QWORD PTR [&__julia_personality]
         *(uint64_t*)(&catchjmp[SectionLoadOffset + 2]) =
-            (uint64_t)&_seh_exception_handler;
+            (uint64_t)&__julia_personality;
         catchjmp[SectionLoadOffset + 10] = 0xff;
         catchjmp[SectionLoadOffset + 11] = 0xe0; // jmp RAX
         UnwindData[SectionLoadOffset] = 0x09; // version info, UNW_FLAG_EHANDLER

--- a/src/init.c
+++ b/src/init.c
@@ -73,12 +73,7 @@ jl_options_t jl_options = { 0,    // quiet
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
                             JL_OPTIONS_HANDLE_SIGNALS_ON,
-#ifdef _OS_WINDOWS_
-// TODO remove this when using LLVM 3.5+
-                            JL_OPTIONS_USE_PRECOMPILED_NO,
-#else
                             JL_OPTIONS_USE_PRECOMPILED_YES,
-#endif
                             JL_OPTIONS_USE_COMPILECACHE_YES,
                             NULL, // bindto
                             NULL, // outputbc

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -532,28 +532,35 @@ ExecutionEngine *jl_ExecutionEngine;
 #endif
 
 // MSVC's link.exe requires each function declaration to have a Comdat section
-// rather than litter the code with conditionals,
+// So rather than litter the code with conditionals,
 // all global values that get emitted call this function
 // and it decides whether the definition needs a Comdat section and adds the appropriate declaration
 // TODO: consider moving this into jl_add_to_shadow or jl_dump_shadow? the JIT doesn't care, so most calls are now no-ops
 template<class T> // for GlobalObject's
 static T *addComdat(T *G)
 {
-#if defined(_OS_WINDOWS_) && defined(_COMPILER_MICROSOFT_)
+#if defined(_OS_WINDOWS_) && defined(LLVM35)
     if (imaging_mode && !G->isDeclaration()) {
-#ifdef LLVM35
         // Add comdat information to make MSVC link.exe happy
+        // it's valid to emit this for ld.exe too,
+        // but makes it very slow to link for no benefit
+#if defined(_COMPILER_MICROSOFT_)
         if (G->getParent() == shadow_output) {
             Comdat *jl_Comdat = G->getParent()->getOrInsertComdat(G->getName());
             // ELF only supports Comdat::Any
             jl_Comdat->setSelectionKind(Comdat::NoDuplicates);
             G->setComdat(jl_Comdat);
         }
+#endif
         // add __declspec(dllexport) to everything marked for export
         if (G->getLinkage() == GlobalValue::ExternalLinkage)
             G->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
         else
             G->setDLLStorageClass(GlobalValue::DefaultStorageClass);
+#if defined(_CPU_X86_64_)
+        // Add unwind exception personalities to functions to handle async exceptions
+        if (Function *F = dyn_cast<Function>(G))
+            F->setPersonalityFn(juliapersonality_func);
 #endif
     }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -343,6 +343,8 @@ typedef struct {
 uint64_t jl_getUnwindInfo(uint64_t dwBase);
 #ifdef _OS_WINDOWS_
 #include <dbghelp.h>
+JL_DLLEXPORT EXCEPTION_DISPOSITION __julia_personality(
+        PEXCEPTION_RECORD ExceptionRecord, void *EstablisherFrame, PCONTEXT ContextRecord, void *DispatcherContext);
 extern HANDLE hMainThread;
 typedef CONTEXT bt_context_t;
 #if defined(_CPU_X86_64_)

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -278,8 +278,7 @@ static LONG WINAPI exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
 }
 
 #if defined(_CPU_X86_64_)
-EXCEPTION_DISPOSITION _seh_exception_handler(PEXCEPTION_RECORD ExceptionRecord, void *EstablisherFrame, PCONTEXT ContextRecord, void *DispatcherContext)
-{
+JL_DLLEXPORT EXCEPTION_DISPOSITION __julia_personality(PEXCEPTION_RECORD ExceptionRecord, void *EstablisherFrame, PCONTEXT ContextRecord, void *DispatcherContext) {
     EXCEPTION_POINTERS ExceptionInfo;
     ExceptionInfo.ExceptionRecord = ExceptionRecord;
     ExceptionInfo.ContextRecord = ContextRecord;

--- a/src/threading.c
+++ b/src/threading.c
@@ -18,6 +18,7 @@ TODO:
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "julia.h"
 #include "julia_internal.h"
@@ -89,11 +90,12 @@ BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason,
         TlsFree(jl_tls_key);
         break;
     }
+    return 1; // success
 }
 
 JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
 {
-    return TlsGetValue(jl_tls_key);
+    return (jl_tls_states_t*)TlsGetValue(jl_tls_key);
 }
 
 jl_get_ptls_states_func jl_get_ptls_states_getter(void)
@@ -545,7 +547,7 @@ JL_DLLEXPORT void jl_threading_profile(void)
     if (!fork_ns) return;
 
     printf("\nti profile:\n");
-    printf("prep: %g (%llu)\n", NS_TO_SECS(prep_ns), (unsigned long long)prep_ns);
+    printf("prep: %g (%" PRIu64 ")\n", NS_TO_SECS(prep_ns), prep_ns);
 
     uint64_t min, max, avg;
     ti_timings(fork_ns, &min, &max, &avg);


### PR DESCRIPTION
This should be the last item for making the sys.dll image reliable on x86_64. I didn't test x86, so for all I know, it's probably been doing just fine with `--precompile=yes` (since the OS is less demanding).

(Personality is a technical term ≠ Personification)
