### PR TITLE
Fix TLS getter on windows

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -89,11 +89,12 @@ BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason,
         TlsFree(jl_tls_key);
         break;
     }
+    return TRUE;
 }
 
 JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
 {
-    return TlsGetValue(jl_tls_key);
+    return (jl_tls_states_t*)TlsGetValue(jl_tls_key);
 }
 
 jl_get_ptls_states_func jl_get_ptls_states_getter(void)


### PR DESCRIPTION
- Missing `DllMain` return value
- Missing cast in `jl_get_ptls_states`

Ref https://github.com/JuliaLang/julia/commit/09a0be0b9b4fe566edded466ba7a41b3c826e492#commitcomment-18054381

Use a PR mainly to make sure the `return TRUE;` in `DllMain` works...
