### PR TITLE
Add alignment attribute to pointerset/pointerref

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -352,8 +352,8 @@ type CoreSTDOUT <: IO end
 type CoreSTDERR <: IO end
 const STDOUT = CoreSTDOUT()
 const STDERR = CoreSTDERR()
-io_pointer(::CoreSTDOUT) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stdout, Ptr{Void}), 1)
-io_pointer(::CoreSTDERR) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stderr, Ptr{Void}), 1)
+io_pointer(::CoreSTDOUT) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stdout, Ptr{Void}), 1, 1)
+io_pointer(::CoreSTDERR) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stderr, Ptr{Void}), 1, 1)
 
 unsafe_write(io::IO, x::Ptr{UInt8}, nb::UInt) =
     (ccall(:jl_uv_puts, Void, (Ptr{Void}, Ptr{UInt8}, UInt), io_pointer(io), x, nb); nb)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -6608,7 +6608,7 @@ Convolution of two vectors. Uses FFT algorithm.
 conv
 
 """
-    unsafe_store!(p::Ptr{T},x,i::Integer)
+    unsafe_store!(p::Ptr{T}, x, [i::Integer=1])
 
 Store a value of type `T` to the address of the ith element (1-indexed) starting at `p`.
 This is equivalent to the C expression `p[i-1] = x`.
@@ -8184,7 +8184,7 @@ throw this exception.
 ProcessExitedException
 
 """
-    unsafe_load(p::Ptr{T},i::Integer)
+    unsafe_load(p::Ptr{T}, [i::Integer=1])
 
 Load a value of type `T` from the address of the ith element (1-indexed) starting at `p`.
 This is equivalent to the C expression `p[i-1]`.

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -302,12 +302,12 @@ add_tfunc(Core._expr, 1, IInf, (args...)->Expr)
 add_tfunc(applicable, 1, IInf, (f, args...)->Bool)
 add_tfunc(Core.Intrinsics.arraylen, 1, 1, x->Int)
 add_tfunc(arraysize, 2, 2, (a,d)->Int)
-add_tfunc(pointerref, 2, 2,
-          function (a,i)
+add_tfunc(pointerref, 3, 3,
+          function (a,i,align)
               a = widenconst(a)
               isa(a,DataType) && a<:Ptr && isa(a.parameters[1],Union{Type,TypeVar}) ? a.parameters[1] : Any
           end)
-add_tfunc(pointerset, 3, 3, (a,v,i)->a)
+add_tfunc(pointerset, 4, 4, (a,v,i,align)->a)
 
 function typeof_tfunc(t::ANY)
     if isa(t,Const)

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -60,11 +60,9 @@ end
 unsafe_wrap{N,I<:Integer}(Atype::Type, p::Ptr, dims::NTuple{N,I}, own::Bool=false) =
     unsafe_wrap(Atype, p, convert(Tuple{Vararg{Int}}, dims), own)
 
-unsafe_load(p::Ptr,i::Integer) = pointerref(p, Int(i))
-unsafe_load(p::Ptr) = unsafe_load(p, 1)
-unsafe_store!(p::Ptr{Any}, x::ANY, i::Integer) = pointerset(p, x, Int(i))
-unsafe_store!{T}(p::Ptr{T}, x, i::Integer) = pointerset(p, convert(T,x), Int(i))
-unsafe_store!{T}(p::Ptr{T}, x) = pointerset(p, convert(T,x), 1)
+unsafe_load(p::Ptr, i::Integer=1) = pointerref(p, Int(i), 1)
+unsafe_store!(p::Ptr{Any}, x::ANY, i::Integer=1) = pointerset(p, x, Int(i), 1)
+unsafe_store!{T}(p::Ptr{T}, x, i::Integer=1) = pointerset(p, convert(T,x), Int(i), 1)
 
 # unsafe pointer to string conversions (don't make a copy, unlike unsafe_string)
 # (Cstring versions are in c.jl)

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -60,7 +60,7 @@
 
    Neither ``convert`` nor ``cconvert`` should take a Julia object and turn it into a ``Ptr``\ .
 
-.. function:: unsafe_load(p::Ptr{T},i::Integer)
+.. function:: unsafe_load(p::Ptr{T}, [i::Integer=1])
 
    .. Docstring generated from Julia source
 
@@ -68,7 +68,7 @@
 
    The ``unsafe`` prefix on this function indicates that no validation is performed on the pointer ``p`` to ensure that it is valid. Incorrect usage may segfault your program or return garbage answers, in the same manner as C.
 
-.. function:: unsafe_store!(p::Ptr{T},x,i::Integer)
+.. function:: unsafe_store!(p::Ptr{T}, x, [i::Integer=1])
 
    .. Docstring generated from Julia source
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -430,6 +430,7 @@ static Function *jlcall_frame_func;
 
 static std::vector<Type *> two_pvalue_llvmt;
 static std::vector<Type *> three_pvalue_llvmt;
+static std::vector<Type *> four_pvalue_llvmt;
 
 static std::map<jl_fptr_t, Function*> builtin_func_map;
 
@@ -5128,6 +5129,10 @@ static void init_julia_llvm_env(Module *m)
     three_pvalue_llvmt.push_back(T_pjlvalue);
     three_pvalue_llvmt.push_back(T_pjlvalue);
     three_pvalue_llvmt.push_back(T_pjlvalue);
+    four_pvalue_llvmt.push_back(T_pjlvalue);
+    four_pvalue_llvmt.push_back(T_pjlvalue);
+    four_pvalue_llvmt.push_back(T_pjlvalue);
+    four_pvalue_llvmt.push_back(T_pjlvalue);
     V_null = Constant::getNullValue(T_pjlvalue);
 
     std::vector<Type*> ftargs(0);
@@ -5366,11 +5371,11 @@ static void init_julia_llvm_env(Module *m)
                          "jl_get_binding_or_error", m);
     add_named_global(jlgetbindingorerror_func, &jl_get_binding_or_error);
 
-    jlpref_func = Function::Create(FunctionType::get(T_pjlvalue, two_pvalue_llvmt, false),
+    jlpref_func = Function::Create(FunctionType::get(T_pjlvalue, three_pvalue_llvmt, false),
                             Function::ExternalLinkage,
                             "jl_pointerref", m);
 
-    jlpset_func = Function::Create(FunctionType::get(T_pjlvalue, three_pvalue_llvmt, false),
+    jlpset_func = Function::Create(FunctionType::get(T_pjlvalue, four_pvalue_llvmt, false),
                             Function::ExternalLinkage,
                             "jl_pointerset", m);
 

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -97,8 +97,8 @@
     ADD_I(powi_llvm, 2) \
     ALIAS(sqrt_llvm_fast, sqrt_llvm) \
     /*  pointer access */ \
-    ADD_I(pointerref, 2) \
-    ADD_I(pointerset, 3) \
+    ADD_I(pointerref, 3) \
+    ADD_I(pointerset, 4) \
     /* c interface */ \
     ALIAS(ccall, ccall) \
     ALIAS(cglobal, cglobal) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -515,8 +515,8 @@ extern JL_DLLEXPORT jl_value_t *jl_segv_exception;
 const char *jl_intrinsic_name(int f);
 
 JL_DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v);
-JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i);
-JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i);
+JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align);
+JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
 
 JL_DLLEXPORT jl_value_t *jl_neg_int(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_add_int(jl_value_t *a, jl_value_t *b);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -32,10 +32,12 @@ JL_DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v)
 }
 
 // run time version of pointerref intrinsic (warning: i is not rooted)
-JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
+JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align)
 {
     JL_TYPECHK(pointerref, pointer, p);
-    JL_TYPECHK(pointerref, long, i);
+    JL_TYPECHK(pointerref, long, i)
+    JL_TYPECHK(pointerref, long, align);
+    // TODO: alignment
     jl_value_t *ety = jl_tparam0(jl_typeof(p));
     if (ety == (jl_value_t*)jl_any_type) {
         jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));
@@ -51,10 +53,12 @@ JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
 }
 
 // run time version of pointerset intrinsic (warning: x is not gc-rooted)
-JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i)
+JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i, jl_value_t *align)
 {
     JL_TYPECHK(pointerset, pointer, p);
     JL_TYPECHK(pointerset, long, i);
+    JL_TYPECHK(pointerref, long, align);
+    // TODO: alignment
     jl_value_t *ety = jl_tparam0(jl_typeof(p));
     if (ety == (jl_value_t*)jl_any_type) {
         jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));

--- a/test/core.jl
+++ b/test/core.jl
@@ -1031,7 +1031,10 @@ let
     local X, p
     X = FooBar[ FooBar(3,1), FooBar(4,4) ]
     p = pointer(X)
+    @test unsafe_load(p) == FooBar(3,1)
     @test unsafe_load(p, 2) == FooBar(4,4)
+    unsafe_store!(p, FooBar(8,4))
+    @test X[1] == FooBar(8,4)
     unsafe_store!(p, FooBar(7,3), 1)
     @test X[1] == FooBar(7,3)
 end


### PR DESCRIPTION
Currently, `pointerset` and `pointerref` perform unaligned loads and stores, which hurts performance on hardware where unaligned memory operations are not supported (eg. GPUs). This PR adds an alignment attribute to the relevant intrinsics, exposed as an optional argument to `unsafe_load` and `unsafe_store`.

Additionally, I've switched some codegen internals over to using const `jl_cgval_t`s (bulk replacement), some of which are required to be able to statically reason through the alignment argument when passing `sizeof(T)` to `pointerset`/`pointerref`. (Turns out inference cannot reason about this yes; I tried adding a `tfunc` for `Core.sizeof` returning a constant value, but it didn't help.)

cc @carnaval 
