### PR TITLE
Fix wrong check in typemap.

### DIFF
--- a/src/typemap.c
+++ b/src/typemap.c
@@ -798,11 +798,11 @@ jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_v
             if (ml) return ml;
         }
     }
-    if (jl_typeof(cache->linear) != (jl_value_t*)jl_nothing) {
+    if (cache->linear != (jl_typemap_entry_t*)jl_nothing) {
         jl_typemap_entry_t *ml = jl_typemap_entry_assoc_exact(cache->linear, args, n);
         if (ml) return ml;
     }
-    if (jl_typeof(cache->any.unknown) != (jl_value_t*)jl_nothing)
+    if (cache->any.unknown != jl_nothing)
         return jl_typemap_assoc_exact(cache->any, args, n, offs+1);
     return NULL;
 }


### PR DESCRIPTION
`cache->linear` and `cache->any.unknown` are both initialized to `jl_nothing` in `jl_new_typemap_level`.

Spotted with ASAN:

```
==21947==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60a00000efd8 at pc 0x7ffb85df1255 bp 0x7ffd7cc8dd80 sp 0x7ffd7cc8dd78
READ of size 8 at 0x60a00000efd8 thread T0
    #0 0x7ffb85df1254 in jl_typemap_entry_assoc_exact src/typemap.c:713:16
    #1 0x7ffb85df2041 in jl_typemap_level_assoc_exact src/typemap.c:802:34
    #2 0x7ffb85ddbe4e in jl_typemap_assoc_exact src/julia_internal.h:623:16
    #3 0x7ffb85ddbe4e in jl_apply_generic src/gf.c:1894
    #4 0x7ffb75b86d80  (<unknown module>)
    #5 0x7ffb85ddc2b5 in jl_call_method_internal src/julia_internal.h:92:16
    #6 0x7ffb85ddc2b5 in jl_apply_generic src/gf.c:1921
    #7 0x7ffb75b84928  (<unknown module>)
    #8 0x7ffb85ddc28c in jl_call_method_internal src/julia_internal.h:92:16
    #9 0x7ffb85ddc28c in jl_apply_generic src/gf.c:1931
    #10 0x7ffb85e1f39c in do_call src/interpreter.c:65:26
    #11 0x7ffb85e17efe in eval src/interpreter.c:188:16
    #12 0x7ffb85e1e897 in eval_body src/interpreter.c:465:28
    #13 0x7ffb85e1f0e6 in jl_interpret_call src/interpreter.c:573:21
    #14 0x7ffb85e5bc09 in jl_toplevel_eval_flex src/toplevel.c:543:18
    #15 0x7ffb85dfa7d6 in jl_parse_eval_all src/ast.c:699:26
    #16 0x7ffb85e5d3b5 in jl_load src/toplevel.c:569:12
    #17 0x7ffb75b74092  (<unknown module>)
    #18 0x7ffb85ddc28c in jl_call_method_internal src/julia_internal.h:92:16
    #19 0x7ffb85ddc28c in jl_apply_generic src/gf.c:1931
    #20 0x7ffb85e1f39c in do_call src/interpreter.c:65:26
    #21 0x7ffb85e17efe in eval src/interpreter.c:188:16
    #22 0x7ffb85e5b9eb in jl_toplevel_eval_flex src/toplevel.c:529:26
    #23 0x7ffb85e59190 in jl_eval_module_expr src/toplevel.c:167:19
    #24 0x7ffb85e5b203 in jl_toplevel_eval_flex src/toplevel.c:436:16
    #25 0x7ffb85e074c5 in jl_toplevel_eval_in_warn src/builtins.c:571:13
    #26 0x7ffb75b7392d  (<unknown module>)
    #27 0x7ffb85ddc28c in jl_call_method_internal src/julia_internal.h:92:16
    #28 0x7ffb85ddc28c in jl_apply_generic src/gf.c:1931
    #29 0x7ffb85e1f39c in do_call src/interpreter.c:65:26
    #30 0x7ffb85e17efe in eval src/interpreter.c:188:16
    #31 0x7ffb85e5b9eb in jl_toplevel_eval_flex src/toplevel.c:529:26
    #32 0x7ffb85dfa7d6 in jl_parse_eval_all src/ast.c:699:26
    #33 0x7ffb85e5d3b5 in jl_load src/toplevel.c:569:12
    #34 0x4e3e2d in exec_program ui/repl.c:486:9
    #35 0x4e375d in true_main ui/repl.c:553:20
    #36 0x4e3363 in main ui/repl.c:674:15
    #37 0x7ffb84b27b44 in __libc_start_main /build/glibc-uPj9cH/glibc-2.19/csu/libc-start.c:287
    #38 0x41c785 in _start (build/usr/bin/julia+0x41c785)

0x60a00000efd8 is located 24 bytes to the right of 64-byte region [0x60a00000ef80,0x60a00000efc0)
allocated by thread T0 here:
    #0 0x4b4705 in posix_memalign deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:124:3
    #1 0x7ffb85e9f33b in jl_malloc_aligned src/julia_internal.h:560:9
    #2 0x7ffb85e9f33b in alloc_big src/gc.c:608
    #3 0x7ffb85ea3abd in __pool_alloc src/gc.c:790:12
    #4 0x7ffb85ea3abd in _pool_alloc src/gc.c:850
    #5 0x7ffb85ea3abd in jl_gc_alloc_0w src/gc.c:1952
    #6 0x7ffb85dc876e in jl_init_types src/jltypes.c:3451:18
    #7 0x7ffb85e336bc in _julia_init src/init.c:620:5
    #8 0x7ffb85e3639c in julia_init src/task.c:277:5
    #9 0x4e333b in main ui/repl.c:673:5
    #10 0x7ffb84b27b44 in __libc_start_main /build/glibc-uPj9cH/glibc-2.19/csu/libc-start.c:287

SUMMARY: AddressSanitizer: heap-buffer-overflow src/typemap.c:713:16 in jl_typemap_entry_assoc_exact
Shadow bytes around the buggy address:
  0x0c147fff9da0: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
  0x0c147fff9db0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c147fff9dc0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c147fff9dd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c147fff9de0: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
=>0x0c147fff9df0: 00 00 00 00 00 00 00 00 fa fa fa[fa]fa fa fa fa
  0x0c147fff9e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c147fff9e10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c147fff9e20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c147fff9e30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c147fff9e40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==21947==ABORTING
```
