### PR TITLE
make complex givensAlgorithm type stable

### DIFF
--- a/base/linalg/givens.jl
+++ b/base/linalg/givens.jl
@@ -170,7 +170,7 @@ function givensAlgorithm{T<:AbstractFloat}(f::Complex{T}, g::Complex{T})
 
         if f == 0
             cs = zero(T)
-            r = hypot(real(g), imag(g))
+            r = complex(hypot(real(g), imag(g)))
         # do complex/real division explicitly with two real divisions
             d = hypot(real(gs), imag(gs))
             sn = complex(real(gs)/d, -imag(gs)/d)

--- a/test/linalg/givens.jl
+++ b/test/linalg/givens.jl
@@ -61,10 +61,12 @@ for elty in (Float32, Float64, Complex64, Complex128)
         G, r = givens(x[2], x[4], 2, 4)
         @test (G*x)[2] ≈ r
         @test abs((G*x)[4]) < eps(real(elty))
+        @inferred givens(x[2], x[4], 2, 4)
 
         G, r = givens(x, 2, 4)
         @test (G*x)[2] ≈ r
         @test abs((G*x)[4]) < eps(real(elty))
+        @inferred givens(x, 2, 4)
 
         G, r = givens(x, 4, 2)
         @test (G*x)[4] ≈ r


### PR DESCRIPTION
`Base.LinAlg.givensAlgorithm` was not stable for complex inputs because of one `if` branch where a real value of `r` was returned, whereas the main branch returns a complex `r`. This PR provides a fix and `@inferred` tests. 

Review? @jiahao 
