### PR TITLE
Address space-preserving bitcast

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -283,6 +283,21 @@ static Value *literal_pointer_val(jl_binding_t *p)
     return julia_gv("jl_bnd#", p->name, p->owner, p);
 }
 
+// bitcast a value, but preserve its address space when dealing with pointer types
+static Value *emit_bitcast(Value *v, Type *jl_value)
+{
+    if (isa<PointerType>(jl_value) &&
+        v->getType()->getPointerAddressSpace() != jl_value->getPointerAddressSpace()) {
+        // Cast to the proper address space
+        Type *jl_value_addr =
+                PointerType::get(cast<PointerType>(jl_value)->getElementType(),
+                                 v->getType()->getPointerAddressSpace());
+        return builder.CreateBitCast(v, jl_value_addr);
+    } else {
+        return builder.CreateBitCast(v, jl_value);
+    }
+}
+
 static Value *julia_binding_gv(Value *bv)
 {
     return builder.
@@ -295,7 +310,7 @@ static Value *julia_binding_gv(jl_binding_t *b)
     // emit a literal_pointer_val to the value field of a jl_binding_t
     // binding->value are prefixed with *
     Value *bv = imaging_mode ?
-        builder.CreateBitCast(julia_gv("*", b->name, b->owner, b), T_ppjlvalue) :
+        emit_bitcast(julia_gv("*", b->name, b->owner, b), T_ppjlvalue) :
         literal_static_pointer_val(b,T_ppjlvalue);
     return julia_binding_gv(bv);
 }
@@ -468,13 +483,13 @@ static bool deserves_sret(jl_value_t *dt, Type *T)
 
 static Value *emit_nthptr_addr(Value *v, ssize_t n)
 {
-    return builder.CreateGEP(builder.CreateBitCast(v, T_ppjlvalue),
+    return builder.CreateGEP(emit_bitcast(v, T_ppjlvalue),
                              ConstantInt::get(T_size, n));
 }
 
 static Value *emit_nthptr_addr(Value *v, Value *idx)
 {
-    return builder.CreateGEP(builder.CreateBitCast(v, T_ppjlvalue), idx);
+    return builder.CreateGEP(emit_bitcast(v, T_ppjlvalue), idx);
 }
 
 static Value *emit_nthptr(Value *v, ssize_t n, MDNode *tbaa)
@@ -488,14 +503,14 @@ static Value *emit_nthptr_recast(Value *v, Value *idx, MDNode *tbaa, Type *ptype
 {
     // p = (jl_value_t**)v; *(ptype)&p[n]
     Value *vptr = emit_nthptr_addr(v, idx);
-    return tbaa_decorate(tbaa,builder.CreateLoad(builder.CreateBitCast(vptr,ptype), false));
+    return tbaa_decorate(tbaa,builder.CreateLoad(emit_bitcast(vptr,ptype), false));
 }
 
 static Value *emit_nthptr_recast(Value *v, ssize_t n, MDNode *tbaa, Type *ptype)
 {
     // p = (jl_value_t**)v; *(ptype)&p[n]
     Value *vptr = emit_nthptr_addr(v, n);
-    return tbaa_decorate(tbaa,builder.CreateLoad(builder.CreateBitCast(vptr,ptype), false));
+    return tbaa_decorate(tbaa,builder.CreateLoad(emit_bitcast(vptr,ptype), false));
 }
 
 static Value *emit_typeptr_addr(Value *p)
@@ -541,20 +556,19 @@ static Value *emit_typeof_boxed(const jl_cgval_t &p, jl_codectx_t *ctx)
 static Value *emit_datatype_types(Value *dt)
 {
     return tbaa_decorate(tbaa_const, builder.
-        CreateLoad(builder.
-                   CreateBitCast(builder.
-                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
-                                           ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
-                                 T_ppjlvalue)));
+        CreateLoad(emit_bitcast(builder.
+                                CreateGEP(emit_bitcast(dt, T_pint8),
+                                          ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
+                                T_ppjlvalue)));
 }
 
 static Value *emit_datatype_nfields(Value *dt)
 {
     Value *nf = tbaa_decorate(tbaa_const, builder.CreateLoad(
         tbaa_decorate(tbaa_const, builder.CreateLoad(
-            builder.CreateBitCast(
+            emit_bitcast(
                 builder.CreateGEP(
-                    builder.CreateBitCast(dt, T_pint8),
+                    emit_bitcast(dt, T_pint8),
                     ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
                 T_pint32->getPointerTo())))));
 #ifdef _P64
@@ -566,18 +580,17 @@ static Value *emit_datatype_nfields(Value *dt)
 static Value *emit_datatype_size(Value *dt)
 {
     Value *size = tbaa_decorate(tbaa_const, builder.
-        CreateLoad(builder.
-                   CreateBitCast(builder.
-                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
-                                           ConstantInt::get(T_size, offsetof(jl_datatype_t, size))),
-                                 T_pint32)));
+        CreateLoad(emit_bitcast(builder.
+                                CreateGEP(emit_bitcast(dt, T_pint8),
+                                          ConstantInt::get(T_size, offsetof(jl_datatype_t, size))),
+                                T_pint32)));
     return size;
 }
 
 static Value *emit_datatype_mutabl(Value *dt)
 {
     Value *mutabl = tbaa_decorate(tbaa_const, builder.
-        CreateLoad(builder.CreateGEP(builder.CreateBitCast(dt, T_pint8),
+        CreateLoad(builder.CreateGEP(emit_bitcast(dt, T_pint8),
                                      ConstantInt::get(T_size, offsetof(jl_datatype_t, mutabl)))));
     return builder.CreateTrunc(mutabl, T_int1);
 }
@@ -585,7 +598,7 @@ static Value *emit_datatype_mutabl(Value *dt)
 static Value *emit_datatype_abstract(Value *dt)
 {
     Value *abstract = tbaa_decorate(tbaa_const, builder.
-        CreateLoad(builder.CreateGEP(builder.CreateBitCast(dt, T_pint8),
+        CreateLoad(builder.CreateGEP(emit_bitcast(dt, T_pint8),
                                      ConstantInt::get(T_size, offsetof(jl_datatype_t, abstract)))));
     return builder.CreateTrunc(abstract, T_int1);
 }
@@ -861,6 +874,7 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
     if (type_is_ghost(elty))
         return ghostValue(jltype);
     Value *data;
+    // TODO: preserving_pointercast?
     if (ptr->getType()->getContainedType(0) != elty)
         data = builder.CreatePointerCast(ptr, PointerType::get(elty, 0));
     else
@@ -907,7 +921,7 @@ static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
     }
     Value *data;
     if (ptr->getType()->getContainedType(0) != elty)
-        data = builder.CreateBitCast(ptr, PointerType::get(elty, 0));
+        data = emit_bitcast(ptr, PointerType::get(elty, 0));
     else
         data = ptr;
     Instruction *store = builder.CreateAlignedStore(r, builder.CreateGEP(data, idx_0based), isboxed ? alignment : julia_alignment(r, jltype, alignment));
@@ -1003,7 +1017,7 @@ static Value *data_pointer(const jl_cgval_t &x, jl_codectx_t *ctx, Type *astype 
 {
     Value *data = x.constant ? boxed(x, ctx) : x.V;
     if (data->getType() != astype)
-        data = builder.CreateBitCast(data, astype);
+        data = emit_bitcast(data, astype);
     return data;
 }
 
@@ -1087,11 +1101,11 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
     Value *fldv = NULL;
     if (strct.isboxed) {
         Value *addr =
-            builder.CreateGEP(builder.CreateBitCast(boxed(strct, ctx), T_pint8),
+            builder.CreateGEP(emit_bitcast(boxed(strct, ctx), T_pint8),
                               ConstantInt::get(T_size, jl_field_offset(jt,idx)));
         MDNode *tbaa = strct.tbaa;
         if (jl_field_isptr(jt, idx)) {
-            Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(builder.CreateBitCast(addr, T_ppjlvalue)));
+            Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
             if (idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
             jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx, true);
@@ -1187,7 +1201,7 @@ static Value *emit_arraylen_prim(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
 #ifdef LLVM37
                                           nullptr,
 #endif
-                                          builder.CreateBitCast(t,jl_parray_llvmt),
+                                          emit_bitcast(t,jl_parray_llvmt),
                                           1); //index (not offset) of length field in jl_parray_llvmt
 
     MDNode *tbaa = arraytype_constshape(ty) ? tbaa_const : tbaa_arraylen;
@@ -1227,7 +1241,7 @@ static Value *emit_arrayptr(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
 #ifdef LLVM37
                                           nullptr,
 #endif
-                                          builder.CreateBitCast(t,jl_parray_llvmt),
+                                          emit_bitcast(t,jl_parray_llvmt),
                                           0); //index (not offset) of data field in jl_parray_llvmt
 
     MDNode *tbaa = arraytype_constshape(tinfo.typ) ? tbaa_const : tbaa_arrayptr;
@@ -1262,14 +1276,14 @@ static Value *emit_arrayflags(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
 #ifdef LLVM37
                             nullptr,
 #endif
-                            builder.CreateBitCast(t, jl_parray_llvmt),
+                            emit_bitcast(t, jl_parray_llvmt),
                             arrayflag_field);
     return tbaa_decorate(tbaa_arrayflags, builder.CreateLoad(addr));
 }
 
 static void assign_arrayvar(jl_arrayvar_t &av, const jl_cgval_t &ainfo, jl_codectx_t *ctx)
 {
-    tbaa_decorate(tbaa_arrayptr,builder.CreateStore(builder.CreateBitCast(emit_arrayptr(ainfo, ctx),
+    tbaa_decorate(tbaa_arrayptr,builder.CreateStore(emit_bitcast(emit_arrayptr(ainfo, ctx),
                                                     av.dataptr->getType()->getContainedType(0)),
                                                     av.dataptr));
     builder.CreateStore(emit_arraylen_prim(ainfo, ctx), av.len);
@@ -1351,7 +1365,7 @@ static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size,
 static Value *init_bits_value(Value *newv, Value *v, MDNode *tbaa)
 {
     // newv should already be tagged
-    tbaa_decorate(tbaa, builder.CreateAlignedStore(v, builder.CreateBitCast(newv, PointerType::get(v->getType(),0)), sizeof(void*))); // min alignment in julia's gc is pointer-aligned
+    tbaa_decorate(tbaa, builder.CreateAlignedStore(v, emit_bitcast(newv, PointerType::get(v->getType(),0)), sizeof(void*))); // min alignment in julia's gc is pointer-aligned
     return newv;
 }
 static Value *as_value(Type *t, const jl_cgval_t&);
@@ -1570,7 +1584,7 @@ static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size, Value *jt)
     int osize;
     int end_offset;
     int offset = jl_gc_classify_pools(static_size, &osize, &end_offset);
-    Value *ptls_ptr = builder.CreateBitCast(ctx->ptlsStates, T_pint8);
+    Value *ptls_ptr = emit_bitcast(ctx->ptlsStates, T_pint8);
     Value *v;
     if (offset < 0) {
         Value *args[] = {ptls_ptr,
@@ -1597,7 +1611,7 @@ static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size,
 // if ptr is NULL this emits a write barrier _back_
 static void emit_write_barrier(jl_codectx_t *ctx, Value *parent, Value *ptr)
 {
-    Value *parenttag = builder.CreateBitCast(emit_typeptr_addr(parent), T_psize);
+    Value *parenttag = emit_bitcast(emit_typeptr_addr(parent), T_psize);
     Value *parent_type = tbaa_decorate(tbaa_tag, builder.CreateLoad(parenttag));
     Value *parent_bits = builder.CreateAnd(parent_type, 3);
 
@@ -1611,11 +1625,11 @@ static void emit_write_barrier(jl_codectx_t *ctx, Value *parent, Value *ptr)
     builder.CreateCondBr(parent_old_marked, barrier_may_trigger, cont);
 
     builder.SetInsertPoint(barrier_may_trigger);
-    Value *ptr_mark_bit = builder.CreateAnd(tbaa_decorate(tbaa_tag, builder.CreateLoad(builder.CreateBitCast(emit_typeptr_addr(ptr), T_psize))), 1);
+    Value *ptr_mark_bit = builder.CreateAnd(tbaa_decorate(tbaa_tag, builder.CreateLoad(emit_bitcast(emit_typeptr_addr(ptr), T_psize))), 1);
     Value *ptr_not_marked = builder.CreateICmpEQ(ptr_mark_bit, ConstantInt::get(T_size, 0));
     builder.CreateCondBr(ptr_not_marked, barrier_trigger, cont);
     builder.SetInsertPoint(barrier_trigger);
-    builder.CreateCall(prepare_call(queuerootfun), builder.CreateBitCast(parent, T_pjlvalue));
+    builder.CreateCall(prepare_call(queuerootfun), emit_bitcast(parent, T_pjlvalue));
     builder.CreateBr(cont);
     ctx->f->getBasicBlockList().push_back(cont);
     builder.SetInsertPoint(cont);
@@ -1645,7 +1659,7 @@ static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t id
         jl_value_t *jfty = jl_svecref(sty->types, idx0);
         if (jl_field_isptr(sty, idx0)) {
             Value *r = boxed(rhs, ctx, false); // don't need a temporary gcroot since it'll be rooted by strct (but should ensure strct is rooted via mark_gc_use)
-            tbaa_decorate(strct.tbaa, builder.CreateStore(r, builder.CreateBitCast(addr, T_ppjlvalue)));
+            tbaa_decorate(strct.tbaa, builder.CreateStore(r, emit_bitcast(addr, T_ppjlvalue)));
             if (wb && strct.isboxed) emit_checked_write_barrier(ctx, boxed(strct, ctx), r);
             mark_gc_use(strct);
         }
@@ -1754,7 +1768,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                 tbaa_decorate(strctinfo.tbaa, builder.CreateStore(
                         V_null,
                         builder.CreatePointerCast(
-                            builder.CreateGEP(builder.CreateBitCast(strct, T_pint8),
+                            builder.CreateGEP(emit_bitcast(strct, T_pint8),
                                 ConstantInt::get(T_size, jl_field_offset(sty,i))),
                             T_ppjlvalue)));
             }
@@ -1795,7 +1809,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
 
 static Value *emit_exc_in_transit(jl_codectx_t *ctx)
 {
-    Value *pexc_in_transit = builder.CreateBitCast(ctx->ptlsStates, T_ppjlvalue);
+    Value *pexc_in_transit = emit_bitcast(ctx->ptlsStates, T_ppjlvalue);
     Constant *offset = ConstantInt::getSigned(T_int32, offsetof(jl_tls_states_t, exception_in_transit) / sizeof(void*));
     return builder.CreateGEP(pexc_in_transit, ArrayRef<Value*>(offset), "jl_exception_in_transit");
 }
@@ -1820,7 +1834,7 @@ static void emit_signal_fence(void)
 
 static Value *emit_defer_signal(jl_codectx_t *ctx)
 {
-    Value *ptls = builder.CreateBitCast(ctx->ptlsStates,
+    Value *ptls = emit_bitcast(ctx->ptlsStates,
                                         PointerType::get(T_sigatomic, 0));
     Constant *offset = ConstantInt::getSigned(T_int32, offsetof(jl_tls_states_t, defer_signal) / sizeof(sig_atomic_t));
     return builder.CreateGEP(ptls, ArrayRef<Value*>(offset), "jl_defer_signal");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2391,9 +2391,9 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                             Value *own_ptr;
                             if (jl_is_long(ndp)) {
                                 own_ptr = tbaa_decorate(tbaa_const, builder.CreateLoad(
-                                    builder.CreateBitCast(
+                                    emit_bitcast(
                                         builder.CreateConstGEP1_32(
-                                            builder.CreateBitCast(aryv, T_pint8),
+                                            emit_bitcast(aryv, T_pint8),
                                             jl_array_data_owner_offset(nd)),
                                         T_ppjlvalue)));
                             }
@@ -2552,7 +2552,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                 Value *types_len = emit_datatype_nfields(tyv);
                 Value *idx = emit_unbox(T_size, emit_expr(args[2], ctx), (jl_value_t*)jl_long_type);
                 emit_bounds_check(ty, (jl_value_t*)jl_datatype_type, idx, types_len, ctx);
-                Value *fieldtyp = tbaa_decorate(tbaa_const, builder.CreateLoad(builder.CreateGEP(builder.CreateBitCast(types_svec, T_ppjlvalue), idx)));
+                Value *fieldtyp = tbaa_decorate(tbaa_const, builder.CreateLoad(builder.CreateGEP(emit_bitcast(types_svec, T_ppjlvalue), idx)));
                 *ret = mark_julia_type(fieldtyp, true, expr_type(expr, ctx), ctx);
                 JL_GC_POP();
                 return true;
@@ -2864,7 +2864,7 @@ static Value *global_binding_pointer(jl_module_t *m, jl_sym_t *s,
             PHINode *p = builder.CreatePHI(T_pjlvalue, 2);
             p->addIncoming(cachedval, currentbb);
             p->addIncoming(bval, not_found);
-            return julia_binding_gv(builder.CreateBitCast(p, T_ppjlvalue));
+            return julia_binding_gv(emit_bitcast(p, T_ppjlvalue));
         }
         if (b->deprecated) cg_bdw(b, ctx);
     }
@@ -2892,7 +2892,7 @@ static jl_cgval_t emit_sparam(size_t i, jl_codectx_t *ctx)
     }
     assert(ctx->spvals_ptr != NULL);
     Value *bp = builder.CreateConstInBoundsGEP1_32(LLVM37_param(T_pjlvalue)
-            builder.CreateBitCast(ctx->spvals_ptr, T_ppjlvalue),
+            emit_bitcast(ctx->spvals_ptr, T_ppjlvalue),
             i + sizeof(jl_svec_t) / sizeof(jl_value_t*));
     return mark_julia_type(tbaa_decorate(tbaa_const, builder.CreateLoad(bp)), true, jl_any_type, ctx);
 }
@@ -3635,7 +3635,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
         if (jlfunc_sret) {
             // fuse the two sret together, or emit an alloca to hold it
             if (sret)
-                result = builder.CreateBitCast(sretPtr, theFptr->getFunctionType()->getParamType(0));
+                result = emit_bitcast(sretPtr, theFptr->getFunctionType()->getParamType(0));
             else
                 result = builder.CreateAlloca(theFptr->getFunctionType()->getParamType(0)->getContainedType(0));
             args.push_back(result);
@@ -3713,7 +3713,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
                                                literal_pointer_val((jl_value_t*)jargty));
                     tbaa_decorate(jl_is_mutable(jargty) ? tbaa_mutab : tbaa_immut,
                                   builder.CreateAlignedStore(val,
-                                                             builder.CreateBitCast(mem, val->getType()->getPointerTo()),
+                                                             emit_bitcast(mem, val->getType()->getPointerTo()),
                                                              16)); // julia's gc gives 16-byte aligned addresses
                     inputarg = mark_julia_type(mem, true, jargty, &ctx);
                 }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -86,7 +86,7 @@ static Value *FP(Value *v)
 {
     if (v->getType()->isFloatingPointTy())
         return v;
-    return builder.CreateBitCast(v, FT(v->getType()));
+    return emit_bitcast(v, FT(v->getType()));
 }
 
 // convert float type to same-size int type
@@ -129,7 +129,7 @@ static Value *JL_INT(Value *v)
         return v;
     if (t->isPointerTy())
         return builder.CreatePtrToInt(v, JL_INTT(t));
-    return builder.CreateBitCast(v, JL_INTT(t));
+    return emit_bitcast(v, JL_INTT(t));
 }
 
 static Value *uint_cnvt(Type *to, Value *x)
@@ -302,7 +302,7 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
     Value *p = x.constant ? literal_pointer_val(x.constant) : x.V;
     Type *ptype = (to == T_int1 ? T_pint8 : to->getPointerTo());
     if (p->getType() != ptype)
-        p = builder.CreateBitCast(p, ptype);
+        p = emit_bitcast(p, ptype);
 
     Value *unboxed = NULL;
     if (to == T_int1)
@@ -500,7 +500,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
         else if (!vxt->isPointerTy() && llvmt->isPointerTy())
             vx = builder.CreateIntToPtr(vx, llvmt);
         else
-            vx = builder.CreateBitCast(vx, llvmt);
+            vx = emit_bitcast(vx, llvmt);
     }
 
     if (jl_is_leaf_type(bt))
@@ -603,7 +603,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
         else if (!vxt->isPointerTy() && llvmt->isPointerTy())
             vx = builder.CreateIntToPtr(vx, llvmt);
         else
-            vx = builder.CreateBitCast(vx, llvmt);
+            vx = emit_bitcast(vx, llvmt);
     }
 
     return mark_julia_type(vx, false, bt, ctx);
@@ -762,7 +762,7 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
         if (ety == (jl_value_t*)jl_any_type)
             return mark_julia_type(
                     builder.CreateLoad(builder.CreateGEP(
-                        builder.CreateBitCast(thePtr, T_ppjlvalue),
+                        emit_bitcast(thePtr, T_ppjlvalue),
                         im1)),
                     true,
                     ety, ctx);
@@ -776,8 +776,8 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
                                      literal_pointer_val((jl_value_t*)ety));
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, ((jl_datatype_t*)ety)->layout->alignment)));
-        thePtr = builder.CreateGEP(builder.CreateBitCast(thePtr, T_pint8), im1);
-        prepare_call(builder.CreateMemCpy(builder.CreateBitCast(strct, T_pint8),
+        thePtr = builder.CreateGEP(emit_bitcast(thePtr, T_pint8), im1);
+        prepare_call(builder.CreateMemCpy(emit_bitcast(strct, T_pint8),
                              thePtr, size, 1)->getCalledValue());
         return mark_julia_type(strct, true, ety, ctx);
     }
@@ -835,7 +835,7 @@ static jl_cgval_t emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, j
         uint64_t size = ((jl_datatype_t*)ety)->size;
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, ((jl_datatype_t*)ety)->layout->alignment)));
-        prepare_call(builder.CreateMemCpy(builder.CreateGEP(builder.CreateBitCast(thePtr, T_pint8), im1),
+        prepare_call(builder.CreateMemCpy(builder.CreateGEP(emit_bitcast(thePtr, T_pint8), im1),
                              data_pointer(val, ctx, T_pint8), size, 1)->getCalledValue());
     }
     else {
@@ -1131,7 +1131,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
             r = emit_untyped_intrinsic(f, x, y, z, nargs, ctx, (jl_datatype_t**)&newtyp);
         if (!newtyp && r->getType() != x->getType())
             // cast back to the exact original type (e.g. float vs. int) before remarking as a julia type
-            r = builder.CreateBitCast(r, x->getType());
+            r = emit_bitcast(r, x->getType());
         if (r->getType() == T_int1)
             r = builder.CreateZExt(r, T_int8);
         return mark_julia_type(r, false, newtyp ? newtyp : xinfo.typ, ctx);
@@ -1424,11 +1424,11 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, 
                                   x);
 #else
         Type *intt = JL_INTT(x->getType());
-        Value *bits = builder.CreateBitCast(FP(x), intt);
+        Value *bits = emit_bitcast(FP(x), intt);
         Value *absbits =
             builder.CreateAnd(bits,
                               ConstantInt::get(intt, APInt::getSignedMaxValue(((IntegerType*)intt)->getBitWidth())));
-        return builder.CreateBitCast(absbits, x->getType());
+        return emit_bitcast(absbits, x->getType());
 #endif
     }
     case copysign_float:
@@ -1436,8 +1436,8 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, 
         x = FP(x);
         fy = FP(y);
         Type *intt = JL_INTT(x->getType());
-        Value *bits = builder.CreateBitCast(x, intt);
-        Value *sbits = builder.CreateBitCast(fy, intt);
+        Value *bits = emit_bitcast(x, intt);
+        Value *sbits = emit_bitcast(fy, intt);
         unsigned nb = ((IntegerType*)intt)->getBitWidth();
         APInt notsignbit = APInt::getSignedMaxValue(nb);
         APInt signbit0(nb, 0); signbit0.setBit(nb-1);
@@ -1448,7 +1448,7 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value *x, Value *y, Value *z, 
                              builder.CreateAnd(sbits,
                                                ConstantInt::get(intt,
                                                                 signbit0)));
-        return builder.CreateBitCast(rbits, x->getType());
+        return emit_bitcast(rbits, x->getType());
     }
     case flipsign_int:
     {


### PR DESCRIPTION
This replaces manual calls to `IRBuilder.CreateBitcast` with calls to `emit_bitcast` (take 2 of #9423), which preserves the address space of a pointer when casting it to a different type. This is useful for GPU programming, where address spaces are used to denote different kinds of memory.

This shouldn't have any impact, really.
