### PR TITLE
Fix several issues with `Pkg.pin()`

### DIFF
--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -100,6 +100,20 @@ function isfixed(pkg::AbstractString, prepo::LibGit2.GitRepo, avail::Dict=availa
     return res
 end
 
+function ispinned(pkg::AbstractString)
+    ispath(pkg,".git") || return false
+    LibGit2.with(LibGit2.GitRepo, pkg) do repo
+        return ispinned(repo)
+    end
+end
+
+function ispinned(prepo::LibGit2.GitRepo)
+    LibGit2.isattached(prepo) || return false
+    br = LibGit2.branch(prepo)
+    # note: regex is based on the naming scheme used in Entry.pin()
+    return ismatch(r"^pinned\.[0-9a-f]{8}\.tmp$", br)
+end
+
 function installed_version(pkg::AbstractString, prepo::LibGit2.GitRepo, avail::Dict=available(pkg))
     ispath(pkg,".git") || return typemin(VersionNumber)
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -184,7 +184,7 @@ temp_pkg_dir() do
 
         Pkg.pin("Example", v"0.4.0")
         @test Pkg.update() == nothing
-        Pkg.installed()["Example"] == v"0.4.0"
+        @test Pkg.installed()["Example"] == v"0.4.0"
 
         # bug identified in #16850, Base.url \ vs / for non-Base methods
         include(Pkg.dir("Example","src","Example.jl"))


### PR DESCRIPTION
- Actually check out the branch after creation (fix #17176)
- Activate test in test/pkg.jl
- Avoid trying to update a pinned package (and emit info message)
- Allow to pin a package several times without producing errors
- Fix the cases in which `resolve()` is called after a `pin()`

~~More tests should be added. I'm working on it, but in the meanwhile~~ this could already be merged, if everything seems in order to people who actually know LibGit2 well.

cc @wildart
