### PR TITLE
Prevent pool allocations under MEMDEBUG

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -14,9 +14,9 @@ jl_gc_pagemeta_t *jl_gc_page_metadata(void *data)
     return page_metadata(data);
 }
 
-region_t *jl_gc_find_region(void *ptr, int maybe)
+region_t *jl_gc_find_region(void *ptr)
 {
-    return find_region(ptr, maybe);
+    return find_region(ptr);
 }
 
 // Find the memory block in the pool that owns the byte pointed to by p.
@@ -26,7 +26,7 @@ region_t *jl_gc_find_region(void *ptr, int maybe)
 // the end of the page.
 JL_DLLEXPORT jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p, size_t *osize_p)
 {
-    region_t *r = find_region(p, 1);
+    region_t *r = find_region(p);
     // Not in the pool
     if (!r)
         return NULL;

--- a/src/gc.c
+++ b/src/gc.c
@@ -434,7 +434,7 @@ static inline int gc_setmark_big(jl_taggedvalue_t *o, int mark_mode)
         o->bits.gc = mark_mode;
         return 0;
     }
-    assert(find_region(o, 1) == NULL);
+    assert(find_region(o) == NULL);
     bigval_t *hdr = bigval_header(o);
     int bits = o->bits.gc;
     if (mark_reset_age && !gc_marked(bits)) {
@@ -513,7 +513,7 @@ static inline int gc_setmark_pool_(jl_taggedvalue_t *o, int mark_mode,
 
 static inline int gc_setmark_pool(jl_taggedvalue_t *o, int mark_mode)
 {
-    return gc_setmark_pool_(o, mark_mode, find_region(o, 0));
+    return gc_setmark_pool_(o, mark_mode, find_region(o));
 }
 
 static inline int gc_setmark(jl_value_t *v, int sz)
@@ -533,7 +533,7 @@ inline void gc_setmark_buf(void *o, int mark_mode, size_t minsz)
     // where the size estimate is a little off so we do a pool lookup to make
     // sure.
     if (minsz <= GC_MAX_SZCLASS) {
-        region_t *r = find_region(buf, 1);
+        region_t *r = find_region(buf);
         if (r) {
             gc_setmark_pool_(buf, mark_mode, r);
             return;

--- a/src/gc.c
+++ b/src/gc.c
@@ -473,6 +473,7 @@ static inline int gc_setmark_pool_(jl_taggedvalue_t *o, int mark_mode,
 #ifdef MEMDEBUG
     return gc_setmark_big(o, mark_mode);
 #endif
+    assert(r != NULL);
     if (gc_verifying) {
         o->bits.gc = mark_mode;
         return mark_mode;

--- a/src/gc.h
+++ b/src/gc.h
@@ -242,12 +242,12 @@ STATIC_INLINE region_t *find_region(void *ptr, int maybe)
         }
     }
     (void)maybe;
-    assert(maybe && "find_region failed");
     return NULL;
 }
 
 STATIC_INLINE jl_gc_pagemeta_t *page_metadata_(void *data, region_t *r)
 {
+    assert(r != NULL);
     int pg_idx = page_index(r, (char*)data - GC_PAGE_OFFSET);
     return &r->meta[pg_idx];
 }

--- a/src/gc.h
+++ b/src/gc.h
@@ -230,7 +230,7 @@ STATIC_INLINE void *gc_ptr_clear_tag(void *v, uintptr_t mask)
 
 NOINLINE uintptr_t gc_get_stack_ptr(void);
 
-STATIC_INLINE region_t *find_region(void *ptr, int maybe)
+STATIC_INLINE region_t *find_region(void *ptr)
 {
     // on 64bit systems we could probably use a single region and remove this loop
     for (int i = 0; i < REGION_COUNT && regions[i].pages; i++) {
@@ -241,7 +241,6 @@ STATIC_INLINE region_t *find_region(void *ptr, int maybe)
             return region;
         }
     }
-    (void)maybe;
     return NULL;
 }
 
@@ -254,7 +253,7 @@ STATIC_INLINE jl_gc_pagemeta_t *page_metadata_(void *data, region_t *r)
 
 STATIC_INLINE jl_gc_pagemeta_t *page_metadata(void *data)
 {
-    return page_metadata_(data, find_region(data, 0));
+    return page_metadata_(data, find_region(data));
 }
 
 STATIC_INLINE void gc_big_object_unlink(const bigval_t *hdr)


### PR DESCRIPTION
More work on getting the build through ASAN (which enables MEMDEBUG).
