### PR TITLE
Fixes 2 issues with the Cholesky update/downdate tests

### DIFF
--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -175,9 +175,12 @@ end
 let A = complex(randn(10,5), randn(10, 5)), v = complex(randn(5), randn(5))
     for uplo in (:U, :L)
         AcA = A'A
+        BcB = AcA + v*v'
+        BcB = (BcB + BcB')/2
         F = cholfact(AcA, uplo)
-        @test LinAlg.lowrankupdate(F, v)[uplo] ≈ cholfact(AcA + v*v')[uplo]
-        @test LinAlg.lowrankdowndate(F, v)[uplo] ≈ cholfact(AcA - v*v')[uplo]
+        G = cholfact(BcB, uplo)
+        @test LinAlg.lowrankupdate(F, v)[uplo] ≈ G[uplo]
+        @test LinAlg.lowrankdowndate(G, v)[uplo] ≈ F[uplo]
     end
 end
 


### PR DESCRIPTION
1. It was possible to get random matrices which would not be positive definite when down-dated (e.g. if I ran the block with `srand(1)`. I have no idea how this didn't become an issue more often.
2. Apparently `v*v'` isn't Hermitian when using the system BLAS on Power.

cc: @andreasnoack @vtjnash 
