### PR TITLE
Propagate --compilecache flag for Pkg.test

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -700,8 +700,9 @@ function test!(pkg::AbstractString,
             try
                 color = Base.have_color? "--color=yes" : "--color=no"
                 codecov = coverage? ["--code-coverage=user", "--inline=no"] : ["--code-coverage=none"]
+                compilecache = "--compilecache=" * (Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
                 julia_exe = Base.julia_cmd()
-                run(`$julia_exe --check-bounds=yes $codecov $color $test_path`)
+                run(`$julia_exe --check-bounds=yes $codecov $color $compilecache $test_path`)
                 info("$pkg tests passed")
             catch err
                 warnbanner(err, label="[ ERROR: $pkg ]")


### PR DESCRIPTION
Rational behind this change is to allow disabling the compile cache when running package tests:

```
julia --compilecache=no -e 'Pkg.test("...")'
```
