### PR TITLE
Append newline to the end of dump methods

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1031,6 +1031,7 @@ function dump(io::IO, x::SimpleVector, n::Int, indent)
             end
         end
     end
+    isempty(indent) && println(io)
     nothing
 end
 
@@ -1056,6 +1057,7 @@ function dump(io::IO, x::ANY, n::Int, indent)
     else
         !isa(x,Function) && print(io, " ", x)
     end
+    isempty(indent) && println(io)
     nothing
 end
 
@@ -1093,12 +1095,19 @@ function dump(io::IO, x::Array, n::Int, indent)
             end
         end
     end
+    isempty(indent) && println(io)
     nothing
 end
-dump(io::IO, x::Symbol, n::Int, indent) = print(io, typeof(x), " ", x)
+function dump(io::IO, x::Symbol, n::Int, indent)
+    print(io, typeof(x), " ", x)
+    isempty(indent) && println(io)
+end
 
 # Types
-dump(io::IO, x::Union, n::Int, indent) = print(io, x)
+function dump(io::IO, x::Union, n::Int, indent)
+    print(io, x)
+    isempty(indent) && println(io)
+end
 
 function dump(io::IO, x::DataType, n::Int, indent)
     print(io, x)
@@ -1115,6 +1124,7 @@ function dump(io::IO, x::DataType, n::Int, indent)
             end
         end
     end
+    isempty(indent) && println(io)
     nothing
 end
 
@@ -1158,6 +1168,7 @@ function dumptype(io::IO, x::ANY, n::Int, indent)
             end
         end
     end
+    isempty(indent) && println(io)
 end
 
 # For abstract types, use _dumptype only if it's a form that will be called

--- a/base/show.jl
+++ b/base/show.jl
@@ -1101,12 +1101,14 @@ end
 function dump(io::IO, x::Symbol, n::Int, indent)
     print(io, typeof(x), " ", x)
     isempty(indent) && println(io)
+    nothing
 end
 
 # Types
 function dump(io::IO, x::Union, n::Int, indent)
     print(io, x)
     isempty(indent) && println(io)
+    nothing
 end
 
 function dump(io::IO, x::DataType, n::Int, indent)
@@ -1169,6 +1171,7 @@ function dumptype(io::IO, x::ANY, n::Int, indent)
         end
     end
     isempty(indent) && println(io)
+    nothing
 end
 
 # For abstract types, use _dumptype only if it's a form that will be called

--- a/test/show.jl
+++ b/test/show.jl
@@ -500,3 +500,9 @@ let s  = IOBuffer(Array{UInt8}(0), true, true)
     Base.showarray(s, [1,2,3], false, header = false)
     @test String(resize!(s.data, s.size)) == " 1\n 2\n 3"
 end
+
+# The `dump` function should alway have a trailing newline
+let io = IOBuffer()
+    dump(io, :(x = 1))
+    @test takebuf_string(io)[end] == '\n'
+end


### PR DESCRIPTION
The doctest system doesn't deal very well with examples that don't have a trailing newline. Originally mentioned in #17106 and in the [julia-dev forums](https://groups.google.com/forum/#!topic/julia-dev/uHpfvBkClTc)

This is my first time making modifications to the `dump` methods. Let me know if there's something I didn't consider.
