### PR TITLE
Fix documentation for `base` (round2)

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4204,11 +4204,9 @@ rand
 """
     base(base, n, [pad])
 
-Convert an integer to a string in the given base, optionally specifying a number of digits
-to pad to. The base can be specified as either an integer, or as a `UInt8` array of
-character values to use as digit symbols.
+Convert an integer to a string in the given base, optionally specifying a number of digits to pad to.
 """
-base
+base(base, n, pad)
 
 """
     BoundsError([a],[i])

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4204,11 +4204,9 @@ rand
 """
     base(base, n, [pad])
 
-Convert an integer to a string in the given base, optionally specifying a number of digits
-to pad to. The base can be specified as either an integer, or as a `UInt8` array of
-character values to use as digit symbols.
+Convert an integer to a string in the given base, optionally specifying a number of digits to pad to. 
 """
-base
+base(base, n, pad)
 
 """
     BoundsError([a],[i])

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4204,7 +4204,7 @@ rand
 """
     base(base, n, [pad])
 
-Convert an integer to a string in the given base, optionally specifying a number of digits to pad to. 
+Convert an integer to a string in the given base, optionally specifying a number of digits to pad to.
 """
 base(base, n, pad)
 

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -40,7 +40,7 @@ Data Formats
 
    .. Docstring generated from Julia source
 
-   Convert an integer to a string in the given base, optionally specifying a number of digits to pad to. The base can be specified as either an integer, or as a ``UInt8`` array of character values to use as digit symbols.
+   Convert an integer to a string in the given base, optionally specifying a number of digits to pad to.
 
 .. function:: digits([T], n, [base], [pad])
 


### PR DESCRIPTION
=Updated docs for base, with regard to there being no option to specify symbol lists

This is a retry at https://github.com/JuliaLang/julia/pull/16983
Because I am having difficulties.

> It has not been possible to specify a UInt8 array of character values to use  as digit symbols, since 
> https://github.com/JuliaLang/julia/commit/7a3d7f6b37051e5636dd671af422dcd734cf79d7
> (Almost 2 years ago)
