### PR TITLE
fix callsite remotecall_fetch notification for deserialization errors

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -896,7 +896,7 @@ function remotecall_fetch(f, w::Worker, args...; kwargs...)
     oid = RRID()
     rv = lookup_ref(oid)
     rv.waitingfor = w.id
-    send_msg(w, MsgHeader(oid), CallMsg{:call_fetch}(f, args, kwargs))
+    send_msg(w, MsgHeader(RRID(0,0), oid), CallMsg{:call_fetch}(f, args, kwargs))
     v = take!(rv)
     delete!(PGRP.refs, oid)
     isa(v, RemoteException) ? throw(v) : v
@@ -1189,7 +1189,7 @@ end
 function handle_msg(msg::CallMsg{:call_fetch}, header, r_stream, w_stream, version)
     @schedule begin
         v = run_work_thunk(()->msg.f(msg.args...; msg.kwargs...), false)
-        deliver_result(w_stream, :call_fetch, header.response_oid, v)
+        deliver_result(w_stream, :call_fetch, header.notify_oid, v)
     end
 end
 

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -582,17 +582,11 @@ function deserialize(s::AbstractSerializer, ::Type{Module})
     if isa(path,Tuple) && path !== ()
         # old version
         for mname in path
-            if !isdefined(m,mname)
-                warn("Module $mname not defined on process $(myid())")  # an error seemingly fails
-            end
             m = getfield(m,mname)::Module
         end
     else
         mname = path
         while mname !== ()
-            if !isdefined(m,mname)
-                warn("Module $mname not defined on process $(myid())")  # an error seemingly fails
-            end
             m = getfield(m,mname)::Module
             mname = deserialize(s)
         end

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -1027,9 +1027,17 @@ f_myid = ()->myid()
 @test wrkr2 == remotecall_fetch((f, p)->remotecall_fetch(f, p), wrkr1, f_myid, wrkr2)
 
 # Deserialization error recovery test
+# locally defined module, but unavailable on workers
+module LocalFoo
+    global foo=1
+end
+
 let
+    @test_throws RemoteException remotecall_fetch(()->LocalFoo.foo, 2)
+
     bad_thunk = ()->NonexistantModule.f()
     @test_throws RemoteException remotecall_fetch(bad_thunk, 2)
+
     # Test that the stream is still usable
     @test remotecall_fetch(()->:test,2) == :test
     ref = remotecall(bad_thunk, 2)


### PR DESCRIPTION
Closes #3680 .

Appears that we were not notifying the waiting reference on the calling process on deserialization errors. Have also removed warnings printed when a module was not found locally, since this is being handled at higher level now. 
