### PR TITLE
Fix OOB in debuginfo.

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -696,7 +696,6 @@ static int lookup_pointer(DIContext *context, jl_frame_t **frames,
         free(*frames);
         *frames = new_frames;
     }
-    jl_lambda_info_t *outer_linfo = (*frames)[n_frames-1].linfo;
     for (int i = 0; i < n_frames; i++) {
         bool inlined_frame = i != n_frames - 1;
         DILineInfo info;
@@ -717,7 +716,7 @@ static int lookup_pointer(DIContext *context, jl_frame_t **frames,
         if (inlined_frame) {
             frame->inlined = 1;
             frame->fromC = fromC;
-            if (outer_linfo) {
+            if (jl_lambda_info_t *outer_linfo = (*frames)[n_frames-1].linfo) {
                 std::size_t semi_pos = func_name.find(';');
                 if (semi_pos != std::string::npos) {
                     func_name = func_name.substr(0, semi_pos);


### PR DESCRIPTION
```
==2992==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x604000990f80 at pc 0x7f51c05f6246 bp 0x7ffd4792ad70 sp 0x7ffd4792ad68
READ of size 8 at 0x604000990f80 thread T0
    #0 0x7f51c05f6245 in lookup_pointer(llvm::DIContext*, jl_frame_t**, unsigned long, int, int) /src/debuginfo.cpp:699:59
    #1 0x7f51c05f706e in jl_getDylibFunctionInfo(jl_frame_t**, unsigned long, int, int) /src/debuginfo.cpp:1136:16
    #2 0x7f51c05f59ec in jl_getFunctionInfo /src/debuginfo.cpp:1331:12
    #3 0x7f51c048359d in jl_lookup_code_address /src/stackwalk.c:375:13
    #4 0x7f51af31d64f in julia_lookup_22808 stacktraces.jl:95
    #5 0x7f4f90db9576  (<unknown module>)
    #6 0x7f4f90db9f10  (<unknown module>)
    #7 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #8 0x7f51c037da6c in jl_invoke /src/gf.c:29:12
    #9 0x7f4f90db9302  (<unknown module>)
    #10 0x7f4f90db9395  (<unknown module>)
    #11 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #12 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #13 0x7f4f90db90bf  (<unknown module>)
    #14 0x7f4f90db8d2e  (<unknown module>)
    #15 0x7f4f90db8dc9  (<unknown module>)
    #16 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #17 0x7f51c037da6c in jl_invoke /src/gf.c:29:12
    #18 0x7f4f90db8b76  (<unknown module>)
    #19 0x7f4f90db8bc2  (<unknown module>)
    #20 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #21 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #22 0x7f4f90db88c2  (<unknown module>)
    #23 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #24 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #25 0x7f4f90db8539  (<unknown module>)
    #26 0x7f4f90db85cd  (<unknown module>)
    #27 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #28 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #29 0x7f4f90db8272  (<unknown module>)
    #30 0x7f4f90db82dd  (<unknown module>)
    #31 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #32 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #33 0x7f4f90db69f1  (<unknown module>)
    #34 0x7f4f90db6bfc  (<unknown module>)
    #35 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #36 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #37 0x7f51af1dc3ae in julia_run_interface_18871 LineEdit.jl:1570
    #38 0x7f51af1dc54f in jlcall_run_interface_18871 (/build/sanitize/usr/lib/julia/sys-debug.so+0x32f54f)
    #39 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #40 0x7f51c03872f6 in jl_apply_generic /src/gf.c:1931:23
    #41 0x7f51af1ea94d in julia_run_frontend_19143 REPL.jl:882
    #42 0x7f4f90db39a3  (<unknown module>)
    #43 0x7f4f90db3a29  (<unknown module>)
    #44 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #45 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #46 0x7f51af207d99 in julia__start_19480 client.jl:364
    #47 0x7f51af2081d4 in jlcall__start_19480 (/build/sanitize/usr/lib/julia/sys-debug.so+0x35b1d4)
    #48 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #49 0x7f51c03872f6 in jl_apply_generic /src/gf.c:1931:23
    #50 0x4e1344 in jl_apply /ui/../src/julia.h:1396:12
    #51 0x4e0b44 in true_main /ui/repl.c:546:9
    #52 0x4e042b in main /ui/repl.c:674:15
    #53 0x7f51bf038740 in __libc_start_main (/usr/lib/libc.so.6+0x20740)
    #54 0x419408 in _start (/build/sanitize/usr/bin/julia-debug+0x419408)

0x604000990f80 is located 8 bytes to the right of 40-byte region [0x604000990f50,0x604000990f78)
==2992==AddressSanitizer CHECK failed: /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_allocator.cc:665 "((id)) != (0)" (0x0, 0x0)
    #0 0x4b8eed in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_rtl.cc:67:3
    #1 0x4bcd81 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/sanitizer_common/sanitizer_common.cc:159:5
    #2 0x4196f8 in GetStackTraceFromId /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_allocator.cc:665:3
    #3 0x4196f8 in __asan::AsanChunkView::GetAllocStack() /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_allocator.cc:672
    #4 0x4b3588 in __asan::DescribeHeapAddress(unsigned long, unsigned long) /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_report.cc:551:28
    #5 0x4b4d96 in __asan::DescribeAddress(unsigned long, unsigned long, char const*) /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_report.cc:590:3
    #6 0x4b5824 in __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_report.cc:1108:3
    #7 0x4b6de5 in __asan_report_load8 /deps/srccache/llvm-3.8.0/projects/compiler-rt/lib/asan/asan_rtl.cc:132:1
    #8 0x7f51c05f6245 in lookup_pointer(llvm::DIContext*, jl_frame_t**, unsigned long, int, int) /src/debuginfo.cpp:699:59
    #9 0x7f51c05f706e in jl_getDylibFunctionInfo(jl_frame_t**, unsigned long, int, int) /src/debuginfo.cpp:1136:16
    #10 0x7f51c05f59ec in jl_getFunctionInfo /src/debuginfo.cpp:1331:12
    #11 0x7f51c048359d in jl_lookup_code_address /src/stackwalk.c:375:13
    #12 0x7f51af31d64f in julia_lookup_22808 stacktraces.jl:95
    #13 0x7f4f90db9576  (<unknown module>)
    #14 0x7f4f90db9f10  (<unknown module>)
    #15 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #16 0x7f51c037da6c in jl_invoke /src/gf.c:29:12
    #17 0x7f4f90db9302  (<unknown module>)
    #18 0x7f4f90db9395  (<unknown module>)
    #19 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #20 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #21 0x7f4f90db90bf  (<unknown module>)
    #22 0x7f4f90db8d2e  (<unknown module>)
    #23 0x7f4f90db8dc9  (<unknown module>)
    #24 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #25 0x7f51c037da6c in jl_invoke /src/gf.c:29:12
    #26 0x7f4f90db8b76  (<unknown module>)
    #27 0x7f4f90db8bc2  (<unknown module>)
    #28 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #29 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #30 0x7f4f90db88c2  (<unknown module>)
    #31 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #32 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #33 0x7f4f90db8539  (<unknown module>)
    #34 0x7f4f90db85cd  (<unknown module>)
    #35 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #36 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #37 0x7f4f90db8272  (<unknown module>)
    #38 0x7f4f90db82dd  (<unknown module>)
    #39 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #40 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #41 0x7f4f90db69f1  (<unknown module>)
    #42 0x7f4f90db6bfc  (<unknown module>)
    #43 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #44 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #45 0x7f51af1dc3ae in julia_run_interface_18871 LineEdit.jl:1570
    #46 0x7f51af1dc54f in jlcall_run_interface_18871 (/build/sanitize/usr/lib/julia/sys-debug.so+0x32f54f)
    #47 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #48 0x7f51c03872f6 in jl_apply_generic /src/gf.c:1931:23
    #49 0x7f51af1ea94d in julia_run_frontend_19143 REPL.jl:882
    #50 0x7f4f90db39a3  (<unknown module>)
    #51 0x7f4f90db3a29  (<unknown module>)
    #52 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #53 0x7f51c038717a in jl_apply_generic /src/gf.c:1921:27
    #54 0x7f51af207d99 in julia__start_19480 client.jl:364
    #55 0x7f51af2081d4 in jlcall__start_19480 (/build/sanitize/usr/lib/julia/sys-debug.so+0x35b1d4)
    #56 0x7f51c037dbee in jl_call_method_internal /src/julia_internal.h:100:16
    #57 0x7f51c03872f6 in jl_apply_generic /src/gf.c:1931:23
    #58 0x4e1344 in jl_apply /ui/../src/julia.h:1396:12
    #59 0x4e0b44 in true_main /ui/repl.c:546:9
    #60 0x4e042b in main /ui/repl.c:674:15
    #61 0x7f51bf038740 in __libc_start_main (/usr/lib/libc.so.6+0x20740)
    #62 0x419408 in _start (/build/sanitize/usr/bin/julia-debug+0x419408)
```
