### PR TITLE
BigFloat constructors with given precision and/or rounding mode

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -132,17 +132,31 @@ function BigFloat(x, prec::Int)
     end
 end
 
+"""
+    BigFloat(x, prec::Int, rounding::RoundingMode)
+
+Create a representation of `x` as a `BigFloat` with precision `prec` and rounding mode `rounding`.
+"""
 function BigFloat(x, prec::Int, rounding::RoundingMode)
     setrounding(BigFloat, rounding) do
         BigFloat(x, prec)
     end
 end
 
+"""
+    BigFloat(x, rounding::RoundingMode)
+
+Create a representation of `x` as a `BigFloat` with the current global precision and rounding mode `rounding`.
+"""
 function BigFloat(x::Union{Integer, AbstractFloat, String}, rounding::RoundingMode)
     BigFloat(x, precision(BigFloat), rounding)
 end
 
+"""
+    BigFloat(x::String)
 
+Create a representation of the string `x` as a `BigFloat`.
+"""
 BigFloat(x::String) = parse(BigFloat, x)
 
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -133,7 +133,7 @@ function BigFloat(x, prec::Int, rounding::RoundingMode)
     end
 end
 
-function BigFloat(x, rounding::RoundingMode)
+function BigFloat(x::Union{Integer, AbstractFloat, String}, rounding::RoundingMode)
     BigFloat(x, precision(BigFloat), rounding)
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -121,6 +121,11 @@ convert(::Type{Rational}, x::BigFloat) = convert(Rational{BigInt}, x)
 convert(::Type{AbstractFloat}, x::BigInt) = BigFloat(x)
 
 # generic constructor with arbitrary precision:
+"""
+    BigFloat(x, prec::Int)
+
+Create a representation of `x` as a `BigFloat` with precision `prec`.
+"""
 function BigFloat(x, prec::Int)
     setprecision(BigFloat, prec) do
         BigFloat(x)

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -102,10 +102,19 @@ The `BigFloat` type implements arbitrary-precision floating-point arithmetic usi
 
 ```@docs
 Base.precision
+Base.MPFR.precision(::Type{BigFloat})
 Base.MPFR.setprecision
 ```
 
+### Additional constructors for `BigFloat`
+```@docs
+Base.MPFR.BigFloat(x, prec::Int)
+BigFloat(x::Union{Integer, AbstractFloat, String}, rounding::RoundingMode)
+Base.MPFR.BigFloat(x, prec::Int, rounding::RoundingMode)
+Base.MPFR.BigFloat(x::String)
+```
 ## Random Numbers
+
 
 Random number generation in Julia uses the [Mersenne Twister library](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/#dSFMT)
 via `MersenneTwister` objects. Julia has a global RNG, which is used by default. Other RNG types

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -873,3 +873,26 @@ let b = IOBuffer()
 end
 
 @test isnan(sqrt(BigFloat(NaN)))
+
+# PR 17217 -- BigFloat constructors with given precision and rounding mode
+
+# test constructors and `big` with additional precision and rounding mode:
+
+for prec in (10, 100, 1000)
+    for val in ("3.1", pi, "-1.3", 3.1)
+        let
+            a = BigFloat(val)
+            b = BigFloat(val, prec)
+            c = BigFloat(val, RoundUp)
+            d = BigFloat(val, prec, RoundDown)
+            e = BigFloat(val, prec, RoundUp)
+
+            @test precision(a) == precision(BigFloat)
+            @test precision(b) == prec
+            @test precision(c) == precision(BigFloat)
+            @test precision(d) == prec
+            @test precision(e) == prec
+            (val != 3.1) && @test e > d     # rounding has no effect when constructing from Float64
+        end
+    end
+end


### PR DESCRIPTION
This is only the uncontroversial and simple part of #13155 that strictly adds (rather than changing) functionality: it adds constructors for `BigFloat` with given precision and rounding mode, so that you can do the following:
```
julia> BigFloat(3.1)  # currently exists
3.100000000000000088817841970012523233890533447265625000000000000000000000000000

julia> BigFloat("3.1")   # add constructor with a string
3.099999999999999999999999999999999999999999999999999999999999999999999999999986

julia> BigFloat(3.1, 100)  # specify precision; use current global rounding mode
3.1000000000000000888178419700125

julia> BigFloat("3.1", RoundUp)   # use current precision; specify rounding mode
3.100000000000000000000000000000000000000000000000000000000000000000000000000021

julia> BigFloat("3.1", 100, RoundUp)  # specify both precision and rounding mode
3.1000000000000000000000000000019

julia> BigFloat(pi, 53, RoundUp)
3.1415926535897936

julia> BigFloat(pi, 53, RoundDown)
3.1415926535897931
```

cc @simonbyrne 
