### PR TITLE
Fix #17219: conditionally lower ccall first arg

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3018,8 +3018,12 @@ f(x) = yt(x)
             ((call new)
              (let* ((ccall? (and (eq? (car e) 'call) (equal? (cadr e) '(core ccall))))
                     (args (if ccall?
-                              ;; NOTE: first 3 arguments of ccall must be left in place
-                              (append (list-head (cdr e) 4)
+                              ;; NOTE: 2nd and 3rd arguments of ccall must be left in place
+                              ;;       the 1st should be compiled if an atom.
+                              (append (list (cadr e))
+                                      (cond (atom? (caddr e) (compile-args (list (caddr e)) break-labels))
+                                            (else (caddr e)))
+                                      (list-head (cdddr e) 2)
                                       (compile-args (list-tail e 5) break-labels))
                               (compile-args (cdr e) break-labels)))
                     (callex (cons (car e) args)))

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -570,6 +570,13 @@ foo13031(x,y,z) = z
 foo13031p = cfunction(foo13031, Cint, (Ref{Tuple{}},Ref{Tuple{}},Cint))
 ccall(foo13031p, Cint, (Ref{Tuple{}},Ref{Tuple{}},Cint), (), (), 8)
 
+# issue 17219
+function ccall_reassigned_ptr(ptr::Ptr{Void})
+    ptr = Libdl.dlsym(Libdl.dlopen(libccalltest), "test_echo_p")
+    ccall(ptr, Any, (Any,), "foo")
+end
+@test ccall_reassigned_ptr(C_NULL) == "foo"
+
 # @threadcall functionality
 threadcall_test_func(x) =
     @threadcall((:testUcharX, libccalltest), Int32, (UInt8,), x % UInt8)


### PR DESCRIPTION
Without this compile step, ccall uses the first slotted version of the variable
regardless of whether it has been reassigned in the function body.

Fixes #17219
Fixes https://github.com/aviks/JavaCall.jl/issues/37

See https://groups.google.com/forum/#!msg/julia-users/DyTQmsQaQl4/KmxQHSqACQAJ
