### PR TITLE
some optimizations to startup time

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -10,6 +10,7 @@ time_ns() = ccall(:jl_hrtime, UInt64, ())
 # This type must be kept in sync with the C struct in src/gc.h
 immutable GC_Num
     allocd      ::Int64 # GC internal
+    deferred_alloc::Int64
     freed       ::Int64 # GC internal
     malloc      ::UInt64
     realloc     ::UInt64

--- a/src/gc.h
+++ b/src/gc.h
@@ -66,6 +66,7 @@ typedef struct {
 // This struct must be kept in sync with the Julia type of the same name in base/util.jl
 typedef struct {
     int64_t     allocd;
+    int64_t     deferred_alloc;
     int64_t     freed;
     uint64_t    malloc;
     uint64_t    realloc;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1901,6 +1901,21 @@ static int typekey_compare(jl_datatype_t *tt, jl_value_t **key, size_t n)
     return 0;
 }
 
+static int dt_compare(const void *ap, const void *bp)
+{
+    jl_datatype_t *a = *(jl_datatype_t**)ap;
+    jl_datatype_t *b = *(jl_datatype_t**)bp;
+    if (a == b) return 0;
+    if (b == NULL) return -1;
+    if (a == NULL) return 1;
+    return typekey_compare(b, jl_svec_data(a->parameters), jl_svec_len(a->parameters));
+}
+
+void jl_resort_type_cache(jl_svec_t *c)
+{
+    qsort(jl_svec_data(c), jl_svec_len(c), sizeof(jl_value_t*), dt_compare);
+}
+
 static int typekey_eq(jl_datatype_t *tt, jl_value_t **key, size_t n)
 {
     size_t j;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -129,8 +129,10 @@ STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr, size_t minsz) // par
 void gc_debug_print_status(void);
 void gc_debug_critical_error(void);
 void jl_print_gc_stats(JL_STREAM *s);
+void jl_gc_reset_alloc_count(void);
 int jl_assign_type_uid(void);
 jl_value_t *jl_cache_type_(jl_datatype_t *type);
+void jl_resort_type_cache(jl_svec_t *c);
 int  jl_get_t_uid_ctr(void);
 void jl_set_t_uid_ctr(int i);
 uint32_t jl_get_gs_ctr(void);


### PR DESCRIPTION
With this, `time ./julia -e 0` goes from 0.4 sec to 0.25 sec on my system.
- We were doing a full gc right after loading the sysimg, which is not necessary as basically everything is live. I hint this to the GC by resetting its allocation count after loading.
- A lot of time was spent re-inserting types into the caches for builtin types. Instead, I believe the caches can just be saved and restored directly.
- Allocations with GC disabled could end up calling jl_gc_collect and checking the gc_disabled flag on every allocation. Defer the check to when gc is re-enabled.
