### PR TITLE
Revert "Speed up iteration with numbers"

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -50,9 +50,9 @@ angle(z::Real) = atan2(zero(z), z)
 
 widemul(x::Number, y::Number) = widen(x)*widen(y)
 
-start(x::Number) = 0  # see #16687
-next(x::Number, state) = (x, state+1)
-done(x::Number, state) = state == 1
+start(x::Number) = false
+next(x::Number, state) = (x, true)
+done(x::Number, state) = state
 isempty(x::Number) = false
 in(x::Number, y::Number) = x == y
 


### PR DESCRIPTION
This reverts commit 526695c40b538951a234fc1168344a481c67a438, aka #16687. Jeff's fix to codegen on Bools, #17225, fixes the test case in that issue.

Let's see if benchmarks agree: @nanosoldier `runbenchmarks(ALL, vs=":master")`.
