### PR TITLE
move hidden fields of leaftype datatypes into a separate struct

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2387,7 +2387,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     end
     if length(atypes)==3 && is(f,unbox)
         at3 = widenconst(atypes[3])
-        if isa(at3,DataType) && !at3.mutable && at3.pointerfree
+        if isa(at3,DataType) && !at3.mutable && at3.layout != C_NULL && datatype_pointerfree(at3)
             # remove redundant unbox
             return (e.args[3],())
         end

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -2,7 +2,7 @@
 
 module Serializer
 
-import Base: GMP, Bottom, unsafe_convert, uncompressed_ast
+import Base: GMP, Bottom, unsafe_convert, uncompressed_ast, datatype_pointerfree
 import Core: svec
 using Base: ViewIndex, index_lengths
 
@@ -90,7 +90,7 @@ end
 
 # cycle handling
 function serialize_cycle(s::AbstractSerializer, x)
-    if !isimmutable(x) && !typeof(x).pointerfree
+    if !isimmutable(x) && !datatype_pointerfree(typeof(x))
         offs = get(s.table, x, -1)
         if offs != -1
             writetag(s.io, BACKREF_TAG)
@@ -530,7 +530,7 @@ function deserialize(s::AbstractSerializer)
 end
 
 function deserialize_cycle(s::AbstractSerializer, x::ANY)
-    if !isimmutable(x) && !typeof(x).pointerfree
+    if !isimmutable(x) && !datatype_pointerfree(typeof(x))
         s.table[s.counter] = x
         s.counter += 1
     end

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -44,33 +44,25 @@ struct AbiState {
 
 const AbiState default_abi_state = {};
 
-bool use_sret(AbiState *state, jl_value_t *ty)
+bool use_sret(AbiState *state, jl_datatype_t *dt)
 {
-    // Assume (jl_is_datatype(ty) && !jl_is_abstracttype(ty) &&
-    //         !jl_is_array_type(ty))
-    if (jl_is_cpointer_type(ty))
-        return false;
-    size_t size = jl_datatype_size(ty);
-    if (size <= 8 || is_native_simd_type(ty))
+    size_t size = jl_datatype_size(dt);
+    if (size <= 8 || is_native_simd_type(dt))
         return false;
     return true;
 }
 
-void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg)
+void needPassByRef(AbiState *state, jl_datatype_t *dt, bool *byRef, bool *inReg)
 {
-    if(!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
-        return;
-    size_t size = jl_datatype_size(ty);
+    size_t size = jl_datatype_size(dt);
     if (size > 8)
         *byRef = true;
 }
 
-Type *preferred_llvm_type(jl_value_t *ty, bool isret)
+Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
 {
-    if (!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
-        return NULL;
-    size_t size = jl_datatype_size(ty);
-    if (size > 0 && size <= 8 && !jl_is_bitstype(ty))
+    size_t size = jl_datatype_size(dt);
+    if (size > 0 && size <= 8 && !jl_is_bitstype(dt))
         return Type::getIntNTy(jl_LLVMContext, size*8);
     return NULL;
 }

--- a/src/abi_x86_vec.h
+++ b/src/abi_x86_vec.h
@@ -4,22 +4,22 @@
 #define ABI_X86_VEC_H
 
 // Determine if object of bitstype ty maps to a __m128, __m256, or __m512 type in C.
-static bool is_native_simd_type(jl_value_t *ty) {
-    size_t size = jl_datatype_size(ty);
-    if (size!=16 && size!=32 && size!=64)
+static bool is_native_simd_type(jl_datatype_t *dt) {
+    size_t size = jl_datatype_size(dt);
+    if (size != 16 && size != 32 && size != 64)
         // Wrong size for xmm, ymm, or zmm register.
         return false;
-    uint32_t n = jl_datatype_nfields(ty);
+    uint32_t n = jl_datatype_nfields(dt);
     if (n<2)
         // Not mapped to SIMD register.
         return false;
-    jl_value_t *ft0 = jl_field_type(ty, 0);
+    jl_value_t *ft0 = jl_field_type(dt, 0);
     for (uint32_t i = 1; i < n; ++i)
-        if (jl_field_type(ty, i)!=ft0)
+        if (jl_field_type(dt, i) != ft0)
             // Not homogeneous
             return false;
     // Type is homogeneous.  Check if it maps to LLVM vector.
-    return jl_special_vector_alignment(n,ft0) != 0;
+    return jl_special_vector_alignment(n, ft0) != 0;
 }
 
 #endif

--- a/src/array.c
+++ b/src/array.c
@@ -22,9 +22,10 @@ extern "C" {
 
 // array constructors ---------------------------------------------------------
 
-static inline int store_unboxed(jl_value_t *el_type)
+static inline int store_unboxed(jl_value_t *el_type) // jl_isbits
 {
-    return jl_is_leaf_type(el_type) && jl_is_immutable(el_type) && jl_is_pointerfree((jl_datatype_t*)el_type);
+    return jl_is_leaf_type(el_type) && jl_is_immutable(el_type) &&
+        ((jl_datatype_t*)el_type)->layout && ((jl_datatype_t*)el_type)->layout->pointerfree;
 }
 
 int jl_array_store_unboxed(jl_value_t *el_type)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -282,7 +282,7 @@ static int NOINLINE compare_fields(jl_value_t *a, jl_value_t *b, jl_datatype_t *
         }
         else {
             jl_datatype_t *ft = (jl_datatype_t*)jl_field_type(dt, f);
-            if (!ft->haspadding) {
+            if (!ft->layout->haspadding) {
                 eq = bits_equal(ao, bo, jl_field_size(dt, f));
             }
             else {
@@ -739,7 +739,7 @@ JL_CALLABLE(jl_f_fieldtype)
     int field_index;
     if (jl_is_long(args[1])) {
         field_index = jl_unbox_long(args[1]) - 1;
-        if (field_index < 0 || field_index >= jl_datatype_nfields(st))
+        if (field_index < 0 || field_index >= jl_field_count(st))
             jl_bounds_error(args[0], args[1]);
     }
     else {
@@ -755,7 +755,7 @@ JL_CALLABLE(jl_f_nfields)
     jl_value_t *x = args[0];
     if (!jl_is_datatype(x))
         x = jl_typeof(x);
-    return jl_box_long(jl_datatype_nfields(x));
+    return jl_box_long(jl_field_count(x));
 }
 
 // conversion -----------------------------------------------------------------
@@ -1084,7 +1084,7 @@ static uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
         else {
             jl_datatype_t *fieldtype = (jl_datatype_t*)jl_field_type(dt, f);
             assert(jl_is_datatype(fieldtype) && !fieldtype->abstract && !fieldtype->mutabl);
-            if (fieldtype->haspadding)
+            if (fieldtype->layout->haspadding)
                 u = jl_object_id_((jl_value_t*)fieldtype, (jl_value_t*)vo);
             else
                 u = bits_hash(vo, jl_field_size(dt, f));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1993,7 +1993,7 @@ static Value *emit_bits_compare(const jl_cgval_t &arg1, const jl_cgval_t &arg2, 
     if (at->isAggregateType()) { // Struct or Array
         assert(arg1.ispointer() && arg2.ispointer());
         size_t sz = jl_datatype_size(arg1.typ);
-        if (sz > 512 && !((jl_datatype_t*)arg1.typ)->haspadding) {
+        if (sz > 512 && !((jl_datatype_t*)arg1.typ)->layout->haspadding) {
 #ifdef LLVM37
             Value *answer = builder.CreateCall(prepare_call(memcmp_func),
                             {

--- a/src/gf.c
+++ b/src/gf.c
@@ -331,7 +331,7 @@ static int very_general_type(jl_value_t *t)
 
 jl_value_t *jl_nth_slot_type(jl_tupletype_t *sig, size_t i)
 {
-    size_t len = jl_datatype_nfields(sig);
+    size_t len = jl_field_count(sig);
     if (len == 0)
         return NULL;
     if (i < len-1)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -532,7 +532,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
             // always fixed size
             nb = jl_datatype_size(bt);
             llvmt = staticeval_bitstype(bt);
-            alignment = ((jl_datatype_t*)bt)->alignment;
+            alignment = ((jl_datatype_t*)bt)->layout->alignment;
         }
         else {
             bt = v.typ;
@@ -544,7 +544,7 @@ static jl_cgval_t generic_unbox(jl_value_t *targ, jl_value_t *x, jl_codectx_t *c
             }
             nb = jl_datatype_size(bt);
             llvmt = staticeval_bitstype(bt);
-            alignment = ((jl_datatype_t*)bt)->alignment;
+            alignment = ((jl_datatype_t*)bt)->layout->alignment;
         }
         Value *runtime_bt = boxed(bt_value, ctx);
         // XXX: emit type validity check on runtime_bt (bitstype of size nb)
@@ -775,7 +775,7 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
         Value *strct = emit_allocobj(ctx, size,
                                      literal_pointer_val((jl_value_t*)ety));
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
-                    LLT_ALIGN(size, ((jl_datatype_t*)ety)->alignment)));
+                    LLT_ALIGN(size, ((jl_datatype_t*)ety)->layout->alignment)));
         thePtr = builder.CreateGEP(builder.CreateBitCast(thePtr, T_pint8), im1);
         prepare_call(builder.CreateMemCpy(builder.CreateBitCast(strct, T_pint8),
                              thePtr, size, 1)->getCalledValue());
@@ -834,7 +834,7 @@ static jl_cgval_t emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, j
         assert(jl_is_datatype(ety));
         uint64_t size = ((jl_datatype_t*)ety)->size;
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
-                    LLT_ALIGN(size, ((jl_datatype_t*)ety)->alignment)));
+                    LLT_ALIGN(size, ((jl_datatype_t*)ety)->layout->alignment)));
         prepare_call(builder.CreateMemCpy(builder.CreateGEP(builder.CreateBitCast(thePtr, T_pint8), im1),
                              data_pointer(val, ctx, T_pint8), size, 1)->getCalledValue());
     }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -263,6 +263,7 @@ jl_value_t *jl_type_intersection_matching(jl_value_t *a, jl_value_t *b,
                                           jl_svec_t **penv, jl_svec_t *tvars);
 jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
+jl_datatype_t *jl_new_uninitialized_datatype(void);
 jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
                                    jl_svec_t *parameters);
 void jl_precompute_memoized_dt(jl_datatype_t *dt);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -44,7 +44,7 @@ JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
     else {
         if (!jl_is_datatype(ety))
             jl_error("pointerref: invalid pointer");
-        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->alignment);
+        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->layout->alignment);
         char *pp = (char*)jl_unbox_long(p) + (jl_unbox_long(i)-1)*nb;
         return jl_new_bits(ety, pp);
     }
@@ -63,7 +63,7 @@ JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t 
     else {
         if (!jl_is_datatype(ety))
             jl_error("pointerset: invalid pointer");
-        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->alignment);
+        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->layout->alignment);
         char *pp = (char*)jl_unbox_long(p) + (jl_unbox_long(i)-1)*nb;
         if (jl_typeof(x) != ety)
             jl_error("pointerset: type mismatch in assign");

--- a/src/sys.c
+++ b/src/sys.c
@@ -605,14 +605,16 @@ JL_DLLEXPORT long jl_SC_CLK_TCK(void)
 
 JL_DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
 {
-    if (field > jl_datatype_nfields(ty) || field < 1)
+    if (ty->layout == NULL || field > jl_datatype_nfields(ty) || field < 1)
         jl_bounds_error_int((jl_value_t*)ty, field);
     return jl_field_offset(ty, field - 1);
 }
 
 JL_DLLEXPORT size_t jl_get_alignment(jl_datatype_t *ty)
 {
-    return ty->alignment;
+    if (ty->layout == NULL)
+        jl_error("non-leaf type doesn't have an alignment");
+    return ty->layout->alignment;
 }
 
 // Takes a handle (as returned from dlopen()) and returns the absolute path to the image loaded

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -461,7 +461,7 @@ int jl_typemap_intersection_visitor(union jl_typemap_t map, int offs,
     if (jl_typeof(map.unknown) == (jl_value_t*)jl_typemap_level_type) {
         jl_typemap_level_t *cache = map.node;
         jl_value_t *ty = NULL;
-        size_t l = jl_datatype_nfields(closure->type);
+        size_t l = jl_field_count(closure->type);
         if (closure->va && l <= offs + 1) {
             ty = closure->va;
         }
@@ -535,13 +535,13 @@ int sigs_eq(jl_value_t *a, jl_value_t *b, int useenv)
 */
 static jl_typemap_entry_t *jl_typemap_assoc_by_type_(jl_typemap_entry_t *ml, jl_tupletype_t *types, int8_t inexact, jl_svec_t **penv)
 {
-    size_t n = jl_datatype_nfields(types);
+    size_t n = jl_field_count(types);
     while (ml != (void*)jl_nothing) {
-        size_t lensig = jl_datatype_nfields(ml->sig);
+        size_t lensig = jl_field_count(ml->sig);
         if (lensig == n || (ml->va && lensig <= n+1)) {
             int resetenv = 0, ismatch = 1;
             if (ml->simplesig != (void*)jl_nothing) {
-                size_t lensimplesig = jl_datatype_nfields(ml->simplesig);
+                size_t lensimplesig = jl_field_count(ml->simplesig);
                 int isva = lensimplesig > 0 && jl_is_vararg_type(jl_tparam(ml->simplesig, lensimplesig - 1));
                 if (lensig == n || (isva && lensimplesig <= n + 1))
                     ismatch = sig_match_by_type_simple(jl_svec_data(types->parameters), n,
@@ -644,7 +644,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_
         jl_typemap_level_t *cache = ml_or_cache.node;
         // called object is the primary key for constructors, otherwise first argument
         jl_value_t *ty = NULL;
-        size_t l = jl_datatype_nfields(types);
+        size_t l = jl_field_count(types);
         int isva = 0;
         // compute the type at offset `offs` into `types`, which may be a Vararg
         if (l <= offs + 1) {
@@ -712,7 +712,7 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
     // some manually-unrolled common special cases
     while (ml->simplesig == (void*)jl_nothing && ml->guardsigs == jl_emptysvec && ml->isleafsig) {
         // use a tight loop for a long as possible
-        if (n == jl_datatype_nfields(ml->sig) && jl_typeof(args[0]) == jl_tparam(ml->sig, 0)) {
+        if (n == jl_field_count(ml->sig) && jl_typeof(args[0]) == jl_tparam(ml->sig, 0)) {
             if (n == 1)
                 return ml;
             if (n == 2) {
@@ -735,10 +735,10 @@ jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *ml, jl_valu
     }
 
     while (ml != (void*)jl_nothing) {
-        size_t lensig = jl_datatype_nfields(ml->sig);
+        size_t lensig = jl_field_count(ml->sig);
         if (lensig == n || (ml->va && lensig <= n+1)) {
             if (ml->simplesig != (void*)jl_nothing) {
-                size_t lensimplesig = jl_datatype_nfields(ml->simplesig);
+                size_t lensimplesig = jl_field_count(ml->simplesig);
                 int isva = lensimplesig > 0 && jl_is_vararg_type(jl_tparam(ml->simplesig, lensimplesig - 1));
                 if (lensig == n || (isva && lensimplesig <= n + 1)) {
                     if (!sig_match_simple(args, n, jl_svec_data(ml->simplesig->parameters), isva, lensimplesig))
@@ -901,7 +901,7 @@ static int jl_typemap_array_insert_(jl_array_t **cache, jl_value_t *key, jl_type
 static void jl_typemap_level_insert_(jl_typemap_level_t *cache, jl_typemap_entry_t *newrec, int8_t offs,
         const struct jl_typemap_info *tparams)
 {
-    size_t l = jl_datatype_nfields(newrec->sig);
+    size_t l = jl_field_count(newrec->sig);
     // compute the type at offset `offs` into `sig`, which may be a Vararg
     jl_value_t *t1 = NULL;
     int isva = 0;
@@ -991,7 +991,7 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
     newrec->isleafsig = newrec->issimplesig && !newrec->va; // entirely leaf types don't need to be sorted
     JL_GC_PUSH1(&newrec);
     size_t i, l;
-    for (i = 0, l = jl_datatype_nfields(type); i < l && newrec->issimplesig; i++) {
+    for (i = 0, l = jl_field_count(type); i < l && newrec->issimplesig; i++) {
         jl_value_t *decl = jl_field_type(type, i);
         if (decl == (jl_value_t*)jl_datatype_type)
             newrec->isleafsig = 0; // Type{} may have a higher priority than DataType


### PR DESCRIPTION
this shaves a sizeable amount off the system image (almost 10%)
