### PR TITLE
Corrected Chinese text for UDHR

### DIFF
--- a/doc/manual/variables.rst
+++ b/doc/manual/variables.rst
@@ -45,8 +45,8 @@ the language will not treat variables differently based on their names).
     julia> customary_phrase = "Hello world!"
     "Hello world!"
 
-    julia> UniversalDeclarationOfHumanRightsStart = "人人生而自由，在尊严和权力上一律平等。"
-    "人人生而自由，在尊严和权力上一律平等。"
+    julia> UniversalDeclarationOfHumanRightsStart = "人人生而自由，在尊严和权利上一律平等。"
+    "人人生而自由，在尊严和权利上一律平等。"
 
 .. raw:: latex
 


### PR DESCRIPTION
Corrected Chinese text in `UniversalDeclarationOfHumanRightsstart`.
See [Chinese text on UDHR](http://www.un.org/chinese/hr/issue/udhr.htm).
