### PR TITLE
reduce number of types saved in the system image

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1424,29 +1424,43 @@ inlining_enabled() = (JLOptions().can_inline == 1)
 function typeinf_edge(method::Method, atypes::ANY, sparams::SimpleVector, needtree::Bool, optimize::Bool, cached::Bool, caller)
     local code = nothing
     local frame = nothing
+    local really_dont_need_tree = false
     if isa(caller, LambdaInfo)
         code = caller
     elseif cached
         # check cached specializations
         # for an existing result stored there
-        if !is(method.specializations, nothing)
+        if method.specializations !== nothing
             code = ccall(:jl_specializations_lookup, Any, (Any, Any), method, atypes)
-            if isa(code, Void)
-                # something completely new
-            elseif isa(code, LambdaInfo)
-                # something existing
-                if code.inferred && !(needtree && code.code === nothing)
+        end
+        if code === nothing && !needtree && ccall(:jl_is_cacheable_sig, Int32, (Any, Any, Any),
+                                                  atypes, method.sig, method)==0 && !isleaftype(atypes)
+            really_dont_need_tree = true
+            retty = ccall(:jl_tfunc_lookup, Any, (Any, Any), method, atypes)
+            if isa(retty, Type)
+                return (nothing, retty, true)
+            elseif isa(retty, LambdaInfo)
+                code = retty
+                if code.inferred
                     return (code, code.rettype, true)
                 end
-            else
-                # sometimes just a return type is stored here. if a full AST
-                # is not needed, we can return it.
-                typeassert(code, Type)
-                if !needtree
-                    return (nothing, code, true)
-                end
-                code = nothing
             end
+        end
+        if code === nothing
+            # something completely new
+        elseif isa(code, LambdaInfo)
+            # something existing
+            if code.inferred && !(needtree && code.code === nothing)
+                return (code, code.rettype, true)
+            end
+        else
+            # sometimes just a return type is stored here. if a full AST
+            # is not needed, we can return it.
+            typeassert(code, Type)
+            if !needtree
+                return (nothing, code, true)
+            end
+            code = nothing
         end
     end
 
@@ -1497,6 +1511,8 @@ function typeinf_edge(method::Method, atypes::ANY, sparams::SimpleVector, needtr
         catch
             return (nothing, Any, false)
         end
+    elseif really_dont_need_tree #!needtree && !isleaftype(atypes)
+        linfo = ccall(:jl_tfunc_get_linfo, Ref{LambdaInfo}, (Any, Any, Any), method, atypes, sparams)
     else
         linfo = specialize_method(method, atypes, sparams, cached)
     end
@@ -1995,9 +2011,11 @@ function finish(me::InferenceState)
             compressedtree = ccall(:jl_compress_ast, Any, (Any,Any), me.linfo, me.linfo.code)
             me.linfo.code = compressedtree
         end
-    else
-        ccall(:jl_set_lambda_code_null, Void, (Any,), me.linfo)
-        me.linfo.inlineable = false
+    elseif !isleaftype(me.linfo.specTypes)
+        ccall(:jl_tfunc_clear_linfo, Void, (Any, Any), me.linfo.def, me.linfo.specTypes)
+    #else
+    #    ccall(:jl_set_lambda_code_null, Void, (Any,), me.linfo)
+    #    me.linfo.inlineable = false
     end
 
     me.linfo.inferred = true

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -584,6 +584,7 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(void)
     jl_method_t *m =
         (jl_method_t*)jl_gc_alloc(ptls, sizeof(jl_method_t), jl_method_type);
     m->specializations.unknown = jl_nothing;
+    m->tfunc.unknown = jl_nothing;
     m->sig = NULL;
     m->tvars = NULL;
     m->ambig = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1441,6 +1441,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         if (usetable)
             arraylist_push(&backref_list, m);
         m->specializations.unknown = jl_deserialize_value(s, (jl_value_t**)&m->specializations);
+        m->tfunc.unknown = jl_nothing;
         jl_gc_wb(m, m->specializations.unknown);
         m->name = (jl_sym_t*)jl_deserialize_value(s, NULL);
         jl_gc_wb(m, m->name);

--- a/src/gf.c
+++ b/src/gf.c
@@ -120,10 +120,11 @@ static int8_t jl_cachearg_offset(jl_methtable_t *mt)
 JL_DLLEXPORT jl_lambda_info_t *jl_get_specialized(jl_method_t *m, jl_tupletype_t *types, jl_svec_t *sp);
 
 // get or create the LambdaInfo for a specialization
-JL_DLLEXPORT jl_lambda_info_t *jl_specializations_get_linfo(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams)
+static jl_lambda_info_t *typemap_get_linfo_(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams,
+                                            union jl_typemap_t *ptm)
 {
     JL_LOCK(&m->writelock);
-    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(m->specializations, type, NULL, 1, /*subtype*/0, /*offs*/0);
+    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(*ptm, type, NULL, 1, /*subtype*/0, /*offs*/0);
     if (sf && jl_is_lambda_info(sf->func.value) && ((jl_lambda_info_t*)sf->func.value)->code != jl_nothing) {
         JL_UNLOCK(&m->writelock);
         return (jl_lambda_info_t*)sf->func.value;
@@ -131,15 +132,41 @@ JL_DLLEXPORT jl_lambda_info_t *jl_specializations_get_linfo(jl_method_t *m, jl_t
     jl_lambda_info_t *li = jl_get_specialized(m, type, sparams);
     JL_GC_PUSH1(&li);
     // TODO: fuse lookup and insert steps
-    jl_typemap_insert(&m->specializations, (jl_value_t*)m, type, jl_emptysvec, NULL, jl_emptysvec, (jl_value_t*)li, 0, &tfunc_cache, NULL);
+    jl_typemap_insert(ptm, (jl_value_t*)m, type, jl_emptysvec, NULL, jl_emptysvec, (jl_value_t*)li, 0, &tfunc_cache, NULL);
     JL_UNLOCK(&m->writelock);
     JL_GC_POP();
     return li;
 }
 
+JL_DLLEXPORT jl_lambda_info_t *jl_specializations_get_linfo(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams)
+{
+    return typemap_get_linfo_(m, type, sparams, &m->specializations);
+}
+
+JL_DLLEXPORT jl_lambda_info_t *jl_tfunc_get_linfo(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams)
+{
+    return typemap_get_linfo_(m, type, sparams, &m->tfunc);
+}
+
+JL_DLLEXPORT void jl_tfunc_clear_linfo(jl_method_t *m, jl_tupletype_t *type)
+{
+    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(m->tfunc, type, NULL, 1, /*subtype*/0, /*offs*/0);
+    if (sf && jl_is_lambda_info(sf->func.value)) {
+        sf->func.value = ((jl_lambda_info_t*)sf->func.value)->rettype;
+    }
+}
+
 JL_DLLEXPORT jl_value_t *jl_specializations_lookup(jl_method_t *m, jl_tupletype_t *type)
 {
     jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(m->specializations, type, NULL, 2, /*subtype*/0, /*offs*/0);
+    if (!sf)
+        return jl_nothing;
+    return sf->func.value;
+}
+
+JL_DLLEXPORT jl_value_t *jl_tfunc_lookup(jl_method_t *m, jl_tupletype_t *type)
+{
+    jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(m->tfunc, type, NULL, 2, /*subtype*/0, /*offs*/0);
     if (!sf)
         return jl_nothing;
     return sf->func.value;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3793,7 +3793,7 @@ void jl_init_types(void)
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(15,
+                        jl_svec(16,
                                 jl_symbol("name"),
                                 jl_symbol("module"),
                                 jl_symbol("file"),
@@ -3802,6 +3802,7 @@ void jl_init_types(void)
                                 jl_symbol("tvars"),
                                 jl_symbol("ambig"),
                                 jl_symbol("specializations"),
+                                jl_symbol("tfunc"),
                                 jl_symbol("lambda_template"),
                                 jl_symbol("roots"),
                                 jl_symbol("invokes"),
@@ -3809,7 +3810,7 @@ void jl_init_types(void)
                                 jl_symbol("isstaged"),
                                 jl_symbol("needs_sparam_vals_ducttape"),
                                 jl_symbol("")),
-                        jl_svec(15,
+                        jl_svec(16,
                                 jl_sym_type,
                                 jl_module_type,
                                 jl_sym_type,
@@ -3817,6 +3818,7 @@ void jl_init_types(void)
                                 jl_type_type,
                                 jl_any_type,
                                 jl_any_type, // Union{Array, Void}
+                                jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_array_any_type,
@@ -3880,7 +3882,7 @@ void jl_init_types(void)
                                 jl_any_type, jl_any_type),
                         0, 1, 7);
     jl_svecset(jl_lambda_info_type->types, 9, jl_lambda_info_type);
-    jl_svecset(jl_method_type->types, 8, jl_lambda_info_type);
+    jl_svecset(jl_method_type->types, 9, jl_lambda_info_type);
 
     jl_typector_type =
         jl_new_datatype(jl_symbol("TypeConstructor"),

--- a/src/julia.h
+++ b/src/julia.h
@@ -211,6 +211,8 @@ typedef struct _jl_method_t {
 
     // table of all argument types for which we've inferred or compiled this code
     union jl_typemap_t specializations;
+    // table mapping argument types to return types, for which we don't have code
+    union jl_typemap_t tfunc;
 
     // the AST template (or, for isstaged, code for the generator)
     struct _jl_lambda_info_t *lambda_template;


### PR DESCRIPTION
This shaves 5-10% from the system image by leaving out intermediate types used by inference that are usually not needed again. Also saves memory by allowing us to delete unused LambdaInfos earlier at runtime.
Seems to work ok, but there could be slowdowns in the case where we actually do need some of this info after reloading the system image.
