### PR TITLE
Fix handling of `Array` argument type in `ccall`.

### DIFF
--- a/src/abi_aarch64.cpp
+++ b/src/abi_aarch64.cpp
@@ -356,7 +356,8 @@ static Type *classify_arg(jl_value_t *ty, bool *fpreg, bool *onstack,
 
 bool use_sret(AbiState*, jl_value_t *ty)
 {
-    // Assume jl_is_datatype(ty) && !jl_is_abstracttype(ty)
+    // Assume (jl_is_datatype(ty) && !jl_is_abstracttype(ty) &&
+    //         !jl_is_array_type(ty))
     // Section 5.5
     // If the type, T, of the result of a function is such that
     //
@@ -375,7 +376,7 @@ bool use_sret(AbiState*, jl_value_t *ty)
 
 Type *preferred_llvm_type(jl_value_t *ty, bool)
 {
-    if (!jl_is_datatype(ty) || jl_is_abstracttype(ty))
+    if (!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_array_type(ty))
         return NULL;
     jl_datatype_t *dt = (jl_datatype_t*)ty;
     if (Type *fptype = get_llvm_fp_or_vectype(dt))

--- a/src/abi_arm.cpp
+++ b/src/abi_arm.cpp
@@ -206,7 +206,8 @@ static void classify_return_arg(jl_value_t *ty, bool *reg,
 
 bool use_sret(AbiState *state, jl_value_t *ty)
 {
-    // Assume jl_is_datatype(ty) && !jl_is_abstracttype(ty)
+    // Assume (jl_is_datatype(ty) && !jl_is_abstracttype(ty) &&
+    //         !jl_is_array_type(ty))
 
     bool reg = false;
     bool onstack = false;
@@ -254,7 +255,7 @@ static void classify_arg(jl_value_t *ty, bool *reg,
 
 Type *preferred_llvm_type(jl_value_t *ty, bool isret)
 {
-    if (!jl_is_datatype(ty) || jl_is_abstracttype(ty))
+    if (!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_array_type(ty))
         return NULL;
     jl_datatype_t *dt = (jl_datatype_t*)ty;
 

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -46,7 +46,9 @@ const AbiState default_abi_state = {};
 
 bool use_sret(AbiState *state, jl_value_t *ty)
 {
-    if(!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
+    // Assume (jl_is_datatype(ty) && !jl_is_abstracttype(ty) &&
+    //         !jl_is_array_type(ty))
+    if (jl_is_cpointer_type(ty))
         return false;
     size_t size = jl_datatype_size(ty);
     if (size <= 8 || is_native_simd_type(ty))

--- a/src/abi_x86.cpp
+++ b/src/abi_x86.cpp
@@ -56,7 +56,9 @@ inline bool is_complex128(jl_value_t *ty)
 
 bool use_sret(AbiState *state, jl_value_t *ty)
 {
-    if (!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
+    // Assume (jl_is_datatype(ty) && !jl_is_abstracttype(ty) &&
+    //         !jl_is_array_type(ty))
+    if (jl_is_cpointer_type(ty))
         return false;
     size_t size = jl_datatype_size(ty);
     if (size == 0)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -892,7 +892,8 @@ static std::string generate_func_sig(
         if (*prt == NULL)
             *prt = *lrt;
 
-        if (jl_is_datatype(rt) && !jl_is_abstracttype(rt) && use_sret(&abi, rt)) {
+        if (jl_is_datatype(rt) && !jl_is_abstracttype(rt) &&
+            !jl_is_array_type(rt) && use_sret(&abi, rt)) {
             paramattrs.push_back(AttrBuilder());
             paramattrs[0].clear();
 #if !defined(_OS_WINDOWS_) || defined(LLVM35) // llvm used to use the old mingw ABI, skipping this marking works around that difference

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -849,3 +849,14 @@ else
 warn("ccall: no VecReg tests run for this platform")
 
 end
+
+# Special calling convention for `Array`
+function f17204(a)
+    b = similar(a)
+    for i in eachindex(a)
+        b[i] = a[i] + 10
+    end
+    return b
+end
+@test ccall(cfunction(f17204, Vector{Any}, Tuple{Vector{Any}}),
+            Vector{Any}, (Vector{Any},), Any[1:10;]) == Any[11:20;]


### PR DESCRIPTION
Fixes #17204 Add test for Array calling convention.

(The aarch64 ABI was saved due to the conservative handling of bitstypes with strange sizes.....)
