### PR TITLE
Enable ifunc on ARM/AArch64/Power/Power64 for GCC 4.9+

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -146,7 +146,10 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
 // is not guaranteed to be reliable, we still need to fallback to the wrapper
 // version as the symbol address if we didn't find the static version in `ifunc`.
 #if defined(__GLIBC__) && (defined(_CPU_X86_64_) || defined(_CPU_X86_) || \
-                           defined(_CPU_AARCH64_) || defined(_CPU_ARM_))
+                           ((defined(_CPU_AARCH64_) || defined(_CPU_ARM_) || \
+                             defined(_CPU_PPC64_) || defined(_CPU_PPC_)) && \
+                            (__GNUC__ >= 5 || __GNUC_MINOR__ >= 9)))
+// Skip the `__GNUC__ >= 4` check since we require GCC 4.7+
 // Only enable this on architectures that are tested.
 // For example, GCC doesn't seem to support the `ifunc` attribute on power yet.
 #  if __GLIBC_PREREQ(2, 12)


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1067245, GCC 4.9 is the first version ifunc is enabled on those architectures.
