### PR TITLE
Speed up repl dot and method completion

### DIFF
--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -477,3 +477,7 @@ precompile(Base.set_valid_processes, (Array{Int, 1}, ))
 sprint(Markdown.term, @doc mean)
 sprint(Docs.repl_search, "mean")
 sprint(Docs.repl_corrections, "meen")
+
+# Speed up repl completions
+Base.REPLCompletions.completions("IOBuffer().",11)
+Base.REPLCompletions.completions("max([1],",8)


### PR DESCRIPTION
My test reveals this speeds up the initial delay in the completion machinery. The test is:

```
time ./julia -E 'Base.REPLCompletions.completions("IOBuffer().",11)'
time ./julia -E 'Base.REPLCompletions.completions("max([1,1]+1^2,1.0,",18)'
```

Before:

```
1.44user 0.88system 0:01.41elapsed
1.51user 0.85system 0:01.43elapsed
```

After:

```
1.08user 0.90system 0:01.04elapsed
1.38user 0.90system 0:01.35elapsed
```
