### PR TITLE
Don't store source expressions in docstrings

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -229,6 +229,8 @@ function doc!(b::Binding, str::DocStr, sig::ANY = Union{})
         push!(m.order, sig)
     end
     m.docs[sig] = str
+    str.data[:binding] = b
+    str.data[:typesig] = sig
     return b
 end
 
@@ -436,7 +438,6 @@ Build a `Dict` expression containing metadata captured from the expression `expr
 
 Fields that may be included in the returned `Dict`:
 
-- `:source`:     Source code for the given `expr`.
 - `:path`:       String representing the file where `expr` is defined.
 - `:linenumber`: Linenumber where `expr` is defined.
 - `:module`:     Module where the docstring is defined.
@@ -444,8 +445,6 @@ Fields that may be included in the returned `Dict`:
 """
 function metadata(expr)
     args = []
-    # Source code for the object being documented.
-    push!(args, :($(Pair)(:source, $(quot(expr)))))
     # Filename and linenumber of the docstring.
     push!(args, :($(Pair)(:path, $(Base).@__FILE__)))
     push!(args, :($(Pair)(:linenumber, $(unsafe_load(cglobal(:jl_lineno, Cint))))))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -181,6 +181,10 @@ let f = @var(DocsTest.f)
     md = meta(DocsTest)[f]
     @test docstrings_equal(md.docs[Tuple{Any}], doc"f-1")
     @test docstrings_equal(md.docs[Tuple{Any,Any}], doc"f-2")
+    @test md.docs[Tuple{Any}].data[:binding] === f
+    @test md.docs[Tuple{Any}].data[:typesig] === Tuple{Any}
+    @test md.docs[Tuple{Any,Any}].data[:binding] === f
+    @test md.docs[Tuple{Any,Any}].data[:typesig] === Tuple{Any,Any}
 end
 
 let s = @var(DocsTest.s)


### PR DESCRIPTION
Currently each docstring stores the `Expr` that it documents. With Documenter.jl I've not found any use for looking at the source expression since we can get the useful information through reflection
easier than traversing raw expressions.

Instead we store the `Binding` and type signature in place of the source, which is much more useful when auto-generating docs.

This was undocumented and I've not found anything relying on it within `METADATA` so should be fine to just remove.

As a bonus removing the source expressions saves 800KB in each of the `sys.*` files.
