### PR TITLE
A few test and dead-code cleanups

### DIFF
--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -3,15 +3,6 @@
 Main.Core.eval(Main.Core, :(baremodule Inference
 using Core.Intrinsics
 import Core: print, println, show, write, unsafe_write, STDOUT, STDERR
-if false # show that the IO system is already (relatively) operational
-    print("HELLO")
-    println(" WORLD")
-    show("αβγ :)"); println()
-    println(STDERR, "TEST")
-    println(STDERR, STDERR)
-    println(STDERR, 'a')
-    println(STDERR, 'α')
-end
 
 ccall(:jl_set_istopmod, Void, (Bool,), false)
 

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -128,12 +128,16 @@ function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::I
     return Nullable{T}(n)
 end
 
-function tryparse_internal(::Type{Bool}, sbuff::AbstractString, startpos::Int, endpos::Int, base::Integer, raise::Bool)
+function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
+        startpos::Int, endpos::Int, base::Integer, raise::Bool)
     len = endpos-startpos+1
     p = pointer(sbuff)+startpos-1
-    (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), p, "true", 4)) && (return Nullable(true))
-    (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), p, "false", 5)) && (return Nullable(false))
-    raise && throw(ArgumentError("invalid Bool representation: $(repr(SubString(s,startpos,endpos)))"))
+    (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
+        p, "true", 4)) && (return Nullable(true))
+    (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
+        p, "false", 5)) && (return Nullable(false))
+    raise && throw(ArgumentError("invalid Bool representation: " *
+        repr(SubString(sbuff, startpos, endpos))))
     Nullable{Bool}()
 end
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -27,16 +27,6 @@ if false
     show(io::IO, x::ANY) = Core.show(io, x)
     print(io::IO, a::ANY...) = Core.print(io, a...)
     println(io::IO, x::ANY...) = Core.println(io, x...)
-    if false # show that the IO system now (relatively) operational
-        print("HELLO")
-        println(" WORLD")
-        show("αβγ :)"); println()
-        println(STDERR, "TEST")
-        println(STDERR, STDERR)
-        println(STDERR, 'a')
-        println(STDERR, 'α')
-        show(STDOUT, 'α')
-    end
 end
 
 ## Load essential files and libraries

--- a/doc/stdlib/punctuation.rst
+++ b/doc/stdlib/punctuation.rst
@@ -30,7 +30,6 @@ symbol      meaning
 ``[;]``     also vertical concatenation
 ``[  ]``    with space-separated expressions, horizontal concatenation
 ``T{ }``    parametric type instantiation
-``{  }``    construct a heterogeneous array (deprecated in 0.4 in favor of ``Any[]``)
 ``;``       statement separator
 ``,``       separate function arguments or tuple components
 ``?``       3-argument conditional operator (conditional ? if_true : if_false)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -537,3 +537,6 @@ end
 @test get(tryparse(Bool, "false")) === get(Nullable{Bool}(false))
 @test_throws ArgumentError parse(Int, "2", 1)
 @test_throws ArgumentError parse(Int, "2", 63)
+
+# error throwing branch from #10560
+@test_throws ArgumentError Base.tryparse_internal(Bool, "foo", 1, 2, 10, true)

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -588,7 +588,10 @@ Dp = spdiagm(dp)
 @test_throws CHOLMOD.CHOLMODException Fs[:PLD]
 
 # Issue 11745 - row and column pointers were not sorted in sparse(Factor)
-sparse(cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))); gc()
+let A = Float64[10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]
+    @test sparse(cholfact(sparse(A))) ≈ A
+end
+gc()
 
 # Issue 11747 - Wrong show method defined for FactorComponent
 Base.show(IOBuffer(), MIME"text/plain"(), cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))[:L])

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -53,26 +53,22 @@ if valgrind_off
     @test_throws Base.UVError run(`foo_is_not_a_valid_command`)
 end
 
-if false
-    prefixer(prefix, sleep) = `perl -nle '$|=1; print "'$prefix' ", $_; sleep '$sleep';'`
-    @test success(pipeline(`perl -le '$|=1; for(0..2){ print; sleep 1 }'`,
+prefixer(prefix, sleep) = `perl -nle '$|=1; print "'$prefix' ", $_; sleep '$sleep';'`
+@test success(pipeline(`perl -le '$|=1; for(0..2){ print; sleep 1 }'`,
                        prefixer("A",2) & prefixer("B",2)))
-    @test success(pipeline(`perl -le '$|=1; for(0..2){ print; sleep 1 }'`,
+@test success(pipeline(`perl -le '$|=1; for(0..2){ print; sleep 1 }'`,
                        prefixer("X",3) & prefixer("Y",3) & prefixer("Z",3),
                        prefixer("A",2) & prefixer("B",2)))
-end
 
 @test  success(`true`)
 @test !success(`false`)
 @test success(pipeline(`true`, `true`))
-if false
-    @test  success(ignorestatus(`false`))
-    @test  success(pipeline(ignorestatus(`false`), `true`))
-    @test !success(pipeline(ignorestatus(`false`), `false`))
-    @test !success(ignorestatus(`false`) & `false`)
-    @test  success(ignorestatus(pipeline(`false`, `false`)))
-    @test  success(ignorestatus(`false` & `false`))
-end
+@test_broken  success(ignorestatus(`false`))
+@test_broken  success(pipeline(ignorestatus(`false`), `true`))
+@test !success(pipeline(ignorestatus(`false`), `false`))
+@test !success(ignorestatus(`false`) & `false`)
+@test_broken  success(ignorestatus(pipeline(`false`, `false`)))
+@test_broken  success(ignorestatus(`false` & `false`))
 
 # STDIN Redirection
 file = tempname()


### PR DESCRIPTION
Remove obsolete doc reference to discontinued `{ }` syntax.

Actually test a cholmod test that hasn't been checking its result at all.

Remove `if false` blocks, replace the still-broken cases under `test/` with `@test_broken`.

Restrict `tryparse_internal` signature for `Bool` since `pointer(sbuff)` won't be valid for arbitrary `AbstractString` types (x-ref #17078), add a test of the error-throwing branch which has a typo.
