### PR TITLE
Some power machines advertise themselves as powerpc64 and others as ppc64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -636,8 +636,8 @@ else
 ISX86:=0
 endif
 
-# If we are running on powerpc64, set certain options automatically
-ifneq (,$(findstring powerpc64,$(ARCH)))
+# If we are running on powerpc64 or ppc64, set certain options automatically
+ifneq (,$(filter $(ARCH), powerpc64 ppc64))
 JCFLAGS += -fsigned-char
 
 override LLVM_VER:=3.8.0


### PR DESCRIPTION
With this - the rest of the build goes through successfully.
