### PR TITLE
finetune the format of REPL help output

### DIFF
--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -112,47 +112,53 @@ those available for the ``perl`` and ``ruby`` programs:
 .. code-block:: none
 
     julia [switches] -- [programfile] [args...]
-     -v, --version             Display version information
-     -h, --help                Print this message
+     -v, --version              Display version information
+     -h, --help                 Print this message
 
-     -J, --sysimage <file>     Start up with the given system image file
-     --precompiled={yes|no}    Use precompiled code from system image if available
-     --compilecache={yes|no}   Enable/disable incremental precompilation of modules
-     -H, --home <dir>          Set location of `julia` executable
-     --startup-file={yes|no}   Load ~/.juliarc.jl
-     --handle-signals={yes|no} Enable or disable Julia's default signal handlers
+     -J, --sysimage <file>      Start up with the given system image file
+     --precompiled={yes|no}     Use precompiled code from system image if available
+     --compilecache={yes|no}    Enable/disable incremental precompilation of modules
+     -H, --home <dir>           Set location of `julia` executable
+     --startup-file={yes|no}    Load ~/.juliarc.jl
+     --handle-signals={yes|no}  Enable or disable Julia's default signal handlers
 
-     -e, --eval <expr>         Evaluate <expr>
-     -E, --print <expr>        Evaluate and show <expr>
-     -L, --load <file>         Load <file> immediately on all processors
+     -e, --eval <expr>          Evaluate <expr>
+     -E, --print <expr>         Evaluate and show <expr>
+     -L, --load <file>          Load <file> immediately on all processors
 
-     -p, --procs {N|auto}      Integer value N launches N additional local worker processes
-                               "auto" launches as many workers as the number of local cores
-     --machinefile <file>      Run processes on hosts listed in <file>
+     -p, --procs {N|auto}       Integer value N launches N additional local worker processes
+                                "auto" launches as many workers as the number of local cores
+     --machinefile <file>       Run processes on hosts listed in <file>
 
-     -i                        Interactive mode; REPL runs and isinteractive() is true
-     -q, --quiet               Quiet startup (no banner)
-     --color={yes|no}          Enable or disable color text
-     --history-file={yes|no}   Load or save history
+     -i                         Interactive mode; REPL runs and isinteractive() is true
+     -q, --quiet                Quiet startup (no banner)
+     --color={yes|no}           Enable or disable color text
+     --history-file={yes|no}    Load or save history
 
-     --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation
-     -C, --cpu-target <target> Limit usage of cpu features up to <target>
-     -O, --optimize={0,1,2,3}  Set the optimization level (default 2 if unspecified or 3 if specified as -O)
-     --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)
-     --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)
-     --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)
+     --compile={yes|no|all|min} Enable or disable JIT compiler, or request exhaustive compilation
+     -C, --cpu-target <target>  Limit usage of cpu features up to <target>
+     -O, --optimize={0,1,2,3}   Set the optimization level (default 2 if unspecified or 3 if specified as -O)
+     --inline={yes|no}          Control whether inlining is permitted (overrides functions declared as @inline)
+     --check-bounds={yes|no}    Emit bounds checks always or never (ignoring declarations)
+     --math-mode={ieee,fast}    Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)
 
-     --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings ("error" turns warnings into errors)
+     --depwarn={yes|no|error}   Enable or disable syntax and method deprecation warnings ("error" turns warnings into errors)
 
-     --output-o name           Generate an object file (including system image data)
-     --output-ji name          Generate a system image data file (.ji)
-     --output-bc name          Generate LLVM bitcode (.bc)
-     --output-incremental=no   Generate an incremental output file (rather than complete)
+     --output-o name            Generate an object file (including system image data)
+     --output-ji name           Generate a system image data file (.ji)
+     --output-bc name           Generate LLVM bitcode (.bc)
+     --output-incremental=no    Generate an incremental output file (rather than complete)
 
      --code-coverage={none|user|all}, --code-coverage
-                               Count executions of source lines (omitting setting is equivalent to "user")
+                                Count executions of source lines (omitting setting is equivalent to "user")
      --track-allocation={none|user|all}, --track-allocation
-                               Count bytes allocated by each source line
+                                Count bytes allocated by each source line
+
+    Deprecated options:
+     -F                         Load ~/.juliarc (deprecated, use --startup-file=yes)
+     -f, --no-startup           Don't load ~/.juliarc (deprecated, use --startup-file=no)
+     -P, --post-boot <expr>     Evaluate <expr>, but don't disable interactive mode (deprecated, use -i -e instead)
+     --no-history-file          Don't load history file (deprecated, use --history-file=no)
 
 
 Resources

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -55,61 +55,61 @@ static int imagepathspecified = 0;
 
 static const char usage[] = "julia [switches] -- [programfile] [args...]\n";
 static const char opts[]  =
-    " -v, --version             Display version information\n"
-    " -h, --help                Print this message\n\n"
+    " -v, --version              Display version information\n"
+    " -h, --help                 Print this message\n\n"
 
     // startup options
-    " -J, --sysimage <file>     Start up with the given system image file\n"
-    " --precompiled={yes|no}    Use precompiled code from system image if available\n"
-    " --compilecache={yes|no}   Enable/disable incremental precompilation of modules\n"
-    " -H, --home <dir>          Set location of `julia` executable\n"
-    " --startup-file={yes|no}   Load ~/.juliarc.jl\n"
-    " --handle-signals={yes|no} Enable or disable Julia's default signal handlers\n\n"
+    " -J, --sysimage <file>      Start up with the given system image file\n"
+    " --precompiled={yes|no}     Use precompiled code from system image if available\n"
+    " --compilecache={yes|no}    Enable/disable incremental precompilation of modules\n"
+    " -H, --home <dir>           Set location of `julia` executable\n"
+    " --startup-file={yes|no}    Load ~/.juliarc.jl\n"
+    " --handle-signals={yes|no}  Enable or disable Julia's default signal handlers\n\n"
 
     // actions
-    " -e, --eval <expr>         Evaluate <expr>\n"
-    " -E, --print <expr>        Evaluate and show <expr>\n"
-    " -L, --load <file>         Load <file> immediately on all processors\n\n"
+    " -e, --eval <expr>          Evaluate <expr>\n"
+    " -E, --print <expr>         Evaluate and show <expr>\n"
+    " -L, --load <file>          Load <file> immediately on all processors\n\n"
 
     // parallel options
-    " -p, --procs {N|auto}      Integer value N launches N additional local worker processes\n"
-    "                           \"auto\" launches as many workers as the number of local cores\n"
-    " --machinefile <file>      Run processes on hosts listed in <file>\n\n"
+    " -p, --procs {N|auto}       Integer value N launches N additional local worker processes\n"
+    "                            \"auto\" launches as many workers as the number of local cores\n"
+    " --machinefile <file>       Run processes on hosts listed in <file>\n\n"
 
     // interactive options
-    " -i                        Interactive mode; REPL runs and isinteractive() is true\n"
-    " -q, --quiet               Quiet startup (no banner)\n"
-    " --color={yes|no}          Enable or disable color text\n"
-    " --history-file={yes|no}   Load or save history\n\n"
+    " -i                         Interactive mode; REPL runs and isinteractive() is true\n"
+    " -q, --quiet                Quiet startup (no banner)\n"
+    " --color={yes|no}           Enable or disable color text\n"
+    " --history-file={yes|no}    Load or save history\n\n"
 
     // code generation options
-    " --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation\n"
-    " -C, --cpu-target <target> Limit usage of cpu features up to <target>\n"
-    " -O, --optimize={0,1,2,3}  Set the optimization level (default 2 if unspecified or 3 if specified as -O)\n"
-    " --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)\n"
-    " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)\n"
-    " --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)\n\n"
+    " --compile={yes|no|all|min} Enable or disable JIT compiler, or request exhaustive compilation\n"
+    " -C, --cpu-target <target>  Limit usage of cpu features up to <target>\n"
+    " -O, --optimize={0,1,2,3}   Set the optimization level (default 2 if unspecified or 3 if specified as -O)\n"
+    " --inline={yes|no}          Control whether inlining is permitted (overrides functions declared as @inline)\n"
+    " --check-bounds={yes|no}    Emit bounds checks always or never (ignoring declarations)\n"
+    " --math-mode={ieee,fast}    Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)\n\n"
 
     // error and warning options
-    " --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings (\"error\" turns warnings into errors)\n\n"
+    " --depwarn={yes|no|error}   Enable or disable syntax and method deprecation warnings (\"error\" turns warnings into errors)\n\n"
 
     // compiler output options
-    " --output-o name           Generate an object file (including system image data)\n"
-    " --output-ji name          Generate a system image data file (.ji)\n"
-    " --output-bc name          Generate LLVM bitcode (.bc)\n"
-    " --output-incremental=no   Generate an incremental output file (rather than complete)\n\n"
+    " --output-o name            Generate an object file (including system image data)\n"
+    " --output-ji name           Generate a system image data file (.ji)\n"
+    " --output-bc name           Generate LLVM bitcode (.bc)\n"
+    " --output-incremental=no    Generate an incremental output file (rather than complete)\n\n"
 
     // instrumentation options
     " --code-coverage={none|user|all}, --code-coverage\n"
-    "                           Count executions of source lines (omitting setting is equivalent to \"user\")\n"
+    "                            Count executions of source lines (omitting setting is equivalent to \"user\")\n"
     " --track-allocation={none|user|all}, --track-allocation\n"
-    "                           Count bytes allocated by each source line\n\n"
+    "                            Count bytes allocated by each source line\n\n"
 
     "Deprecated options:\n"
-    " -F                        Load ~/.juliarc (deprecated, use --startup-file=yes)\n"
-    " -f, --no-startup          Don't load ~/.juliarc (deprecated, use --startup-file=no)\n"
-    " -P, --post-boot <expr>    Evaluate <expr>, but don't disable interactive mode (deprecated, use -i -e instead)\n"
-    " --no-history-file         Don't load history file (deprecated, use --history-file=no)\n";
+    " -F                         Load ~/.juliarc (deprecated, use --startup-file=yes)\n"
+    " -f, --no-startup           Don't load ~/.juliarc (deprecated, use --startup-file=no)\n"
+    " -P, --post-boot <expr>     Evaluate <expr>, but don't disable interactive mode (deprecated, use -i -e instead)\n"
+    " --no-history-file          Don't load history file (deprecated, use --history-file=no)\n";
 
 void parse_opts(int *argcp, char ***argvp)
 {


### PR DESCRIPTION
This PR aims to change the original `julia --help` output from

``` bash
julia --help
julia [switches] -- [programfile] [args...]

...

 --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation

...

```

to

``` bash
julia --help
julia [switches] -- [programfile] [args...]

...

 --compile={yes|no|all|min} Enable or disable JIT compiler, or request exhaustive compilation

...
```

. 

The options in the left and their interpretation in the right are separated by at least one space except `--compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation`.  This inconsistency makes me very uncomfortable.  But the distance between the options and their interpretations will become larger after shifting the interpretations one space towards right.

In the end,  I feel it's better to separate them.
