### PR TITLE
More efficient conversion in ^(::Complex, ::Complex)

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -450,7 +450,7 @@ function ^{T<:AbstractFloat}(z::Complex{T}, p::Complex{T})
     if p==2 #square
         zr, zi = reim(z)
         x = (zr-zi)*(zr+zi)
-        y = T(2)*zr*zi
+        y = T(2*zr*zi)
         if isnan(x)
             if isinf(y)
                 x = copysign(zero(T),zr)


### PR DESCRIPTION
This can avoid a costly allocation of e.g. BigInt(2).

Cf. https://github.com/JuliaLang/julia/pull/16995/files/f3eabc3abaae1a8c9d558e31467cbfeffaa5319e..732828ce8ec3d0519a0953338cc02f13312dfec9#r69392763.
