### PR TITLE
RFC: Implement poor man PLT

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -12,6 +12,8 @@ static Instruction *tbaa_decorate(MDNode *md, Instruction *load_or_store)
 
 static GlobalVariable *prepare_global(GlobalVariable *G, Module *M)
 {
+    if (G->getParent() == M)
+        return G;
     GlobalValue *local = M->getNamedValue(G->getName());
     if (!local) {
         local = global_proto(G, M);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3548,7 +3548,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     Type *fargt_vasig;
     std::vector<bool> inRegList(0);
     std::vector<bool> byRefList(0);
-    attr_type attrs;
+    AttributeSet attrs;
     Type *prt = NULL;
     int sret = 0;
     size_t nargs = jl_nparams(argt);


### PR DESCRIPTION
So that `ccall`s in the sysimg doesn't need any conditional branch.

Also use different GV's for the same symbol name that belongs to different libraries.

Not sure what's the best benchmark but here's a comparison of the assembly code before and after for `current_module()` on x64.

Before,

``` asm
Dump of assembler code for function julia_current_module_26201:
   0x00007ffff16fc300 <+0>:     push   %rbp
   0x00007ffff16fc301 <+1>:     mov    %rsp,%rbp
   0x00007ffff16fc304 <+4>:     push   %rbx
   0x00007ffff16fc305 <+5>:     sub    $0x18,%rsp
   0x00007ffff16fc309 <+9>:     callq  *0x1d437e9(%rip)        # 0x7ffff343faf8 <jl_get_ptls_states.ptr>
   0x00007ffff16fc30f <+15>:    mov    %rax,%rbx
   0x00007ffff16fc312 <+18>:    movq   $0x0,-0x10(%rbp)
   0x00007ffff16fc31a <+26>:    movq   $0x2,-0x20(%rbp)
   0x00007ffff16fc322 <+34>:    mov    (%rbx),%rax
   0x00007ffff16fc325 <+37>:    mov    %rax,-0x18(%rbp)
   0x00007ffff16fc329 <+41>:    lea    -0x20(%rbp),%rax
   0x00007ffff16fc32d <+45>:    mov    %rax,(%rbx)
   0x00007ffff16fc330 <+48>:    mov    0x1d43c21(%rip),%rcx        # 0x7ffff343ff58 <ccall_jl_get_current_module>
   0x00007ffff16fc337 <+55>:    test   %rcx,%rcx
   0x00007ffff16fc33a <+58>:    jne    0x7ffff16fc35b <julia_current_module_26201+91>
   0x00007ffff16fc33c <+60>:    lea    0x19b6fed(%rip),%rsi        # 0x7ffff30b3330
   0x00007ffff16fc343 <+67>:    mov    0x1d43586(%rip),%rdx        # 0x7ffff343f8d0
   0x00007ffff16fc34a <+74>:    xor    %edi,%edi
   0x00007ffff16fc34c <+76>:    callq  0x7ffff1453c80 <jl_load_and_lookup@plt>
   0x00007ffff16fc351 <+81>:    mov    %rax,%rcx
   0x00007ffff16fc354 <+84>:    mov    %rcx,0x1d43bfd(%rip)        # 0x7ffff343ff58 <ccall_jl_get_current_module>
   0x00007ffff16fc35b <+91>:    callq  *%rcx
   0x00007ffff16fc35d <+93>:    mov    %rax,-0x10(%rbp)
   0x00007ffff16fc361 <+97>:    mov    -0x18(%rbp),%rcx
   0x00007ffff16fc365 <+101>:   mov    %rcx,(%rbx)
   0x00007ffff16fc368 <+104>:   add    $0x18,%rsp
   0x00007ffff16fc36c <+108>:   pop    %rbx
   0x00007ffff16fc36d <+109>:   pop    %rbp
   0x00007ffff16fc36e <+110>:   retq   
End of assembler dump.
```

After

``` asm
Dump of assembler code for function julia_current_module_37299:
   0x00007ffff176d6d0 <+0>:     push   %rbp
   0x00007ffff176d6d1 <+1>:     mov    %rsp,%rbp
   0x00007ffff176d6d4 <+4>:     push   %rbx
   0x00007ffff176d6d5 <+5>:     sub    $0x18,%rsp
   0x00007ffff176d6d9 <+9>:     callq  *0x1ccf731(%rip)        # 0x7ffff343ce10 <jl_get_ptls_states.ptr>
   0x00007ffff176d6df <+15>:    mov    %rax,%rbx
   0x00007ffff176d6e2 <+18>:    movq   $0x0,-0x10(%rbp)
   0x00007ffff176d6ea <+26>:    movq   $0x2,-0x20(%rbp)
   0x00007ffff176d6f2 <+34>:    mov    (%rbx),%rax
   0x00007ffff176d6f5 <+37>:    mov    %rax,-0x18(%rbp)
   0x00007ffff176d6f9 <+41>:    lea    -0x20(%rbp),%rax
   0x00007ffff176d6fd <+45>:    mov    %rax,(%rbx)
   0x00007ffff176d700 <+48>:    callq  *0x1ccea2a(%rip)        # 0x7ffff343c130 <jlplt_jl_get_current_module_160_got>
   0x00007ffff176d706 <+54>:    mov    %rax,-0x10(%rbp)
   0x00007ffff176d70a <+58>:    mov    -0x18(%rbp),%rcx
   0x00007ffff176d70e <+62>:    mov    %rcx,(%rbx)
   0x00007ffff176d711 <+65>:    add    $0x18,%rsp
   0x00007ffff176d715 <+69>:    pop    %rbx
   0x00007ffff176d716 <+70>:    pop    %rbp
   0x00007ffff176d717 <+71>:    retq   
End of assembler dump.
```

Code for the corresponding "PLT"

``` asm
Dump of assembler code for function jlplt_jl_get_current_module_160:
   0x00007ffff13b8a10 <+0>:     push   %rax
   0x00007ffff13b8a11 <+1>:     mov    0x2084888(%rip),%rax        # 0x7ffff343d2a0 <ccall_jl_get_current_module_159>
   0x00007ffff13b8a18 <+8>:     test   %rax,%rax
   0x00007ffff13b8a1b <+11>:    jne    0x7ffff13b8a39 <jlplt_jl_get_current_module_160+41>
   0x00007ffff13b8a1d <+13>:    lea    0x1cef8dc(%rip),%rsi        # 0x7ffff30a8300
   0x00007ffff13b8a24 <+20>:    mov    0x20834c5(%rip),%rdx        # 0x7ffff343bef0
   0x00007ffff13b8a2b <+27>:    xor    %edi,%edi
   0x00007ffff13b8a2d <+29>:    callq  0x7ffff13b6cd0 <jl_load_and_lookup@plt>
   0x00007ffff13b8a32 <+34>:    mov    %rax,0x2084867(%rip)        # 0x7ffff343d2a0 <ccall_jl_get_current_module_159>
   0x00007ffff13b8a39 <+41>:    mov    %rax,0x20836f0(%rip)        # 0x7ffff343c130 <jlplt_jl_get_current_module_160_got>
   0x00007ffff13b8a40 <+48>:    pop    %rcx
   0x00007ffff13b8a41 <+49>:    jmpq   *%rax
End of assembler dump.
```

~~There might still be something strange about the GOT GV since the name doesn't show up in the disassembly and the address seems off.~~ Fixed
