### PR TITLE
Add tests for ccall arguments spilling

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3120,7 +3120,13 @@ function inlining_pass(e::Expr, sv::InferenceState)
     end
     has_stmts = false # needed to preserve order-of-execution
     for _i=length(eargs):-1:i0
-        i = (isccall && _i == 4) ? 2 : _i
+        if isccall && _i == 4
+            i = 2
+            isccallee = true
+        else
+            i = _i
+            isccallee = false
+        end
         ei = eargs[i]
         if isa(ei,Expr)
             ei = ei::Expr
@@ -3137,6 +3143,22 @@ function inlining_pass(e::Expr, sv::InferenceState)
             end
             res = inlining_pass(ei, sv)
             res1 = res[1]
+            res2 = res[2]
+            has_new_stmts = isa(res2, Array) && !isempty(res2::Array{Any,1})
+            if isccallee
+                restype = exprtype(res1, sv.src, sv.mod)
+                if isa(restype, Const)
+                    argloc[i] = restype.val
+                    if !effect_free(res1, sv.src, sv.mod, false)
+                        insert!(stmts, 1, res1)
+                    end
+                    if has_new_stmts
+                        prepend!(stmts, res2::Array{Any,1})
+                    end
+                    # Assume this is the last argument to process
+                    break
+                end
+            end
             if has_stmts && !effect_free(res1, sv.src, sv.mod, false)
                 restype = exprtype(res1, sv.src, sv.mod)
                 vnew = newvar!(sv, restype)
@@ -3145,15 +3167,13 @@ function inlining_pass(e::Expr, sv::InferenceState)
             else
                 argloc[i] = res1
             end
-            if isa(res[2],Array)
-                res2 = res[2]::Array{Any,1}
-                if !isempty(res2)
-                    prepend!(stmts,res2)
-                    if !has_stmts
-                        for stmt in res2
-                            if !effect_free(stmt, sv.src, sv.mod, true)
-                                has_stmts = true
-                            end
+            if has_new_stmts
+                res2 = res2::Array{Any,1}
+                prepend!(stmts, res2)
+                if !has_stmts && !(_i == i0)
+                    for stmt in res2
+                        if !effect_free(stmt, sv.src, sv.mod, true)
+                            has_stmts = true
                         end
                     end
                 end

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -574,6 +574,178 @@ test_huge(5a, r1);
 test_huge(5b, r1);
 #endif // _COMPILER_INTEL_
 
+// Enough arguments for architectures that uses registers for integer or
+// floating point arguments to spill.
+JL_DLLEXPORT int test_long_args_intp(int *a1, int *a2, int *a3, int *a4,
+                                     int *a5, int *a6, int *a7, int *a8,
+                                     int *a9, int *a10, int *a11, int *a12,
+                                     int *a13, int *a14)
+{
+    return (*a1 + *a2 + *a3 + *a4 + *a5 + *a6 + *a7 + *a8 + *a9 + *a10 +
+            *a11 + *a12 + *a13 + *a14);
+}
+
+JL_DLLEXPORT int test_long_args_int(int a1, int a2, int a3, int a4,
+                                    int a5, int a6, int a7, int a8,
+                                    int a9, int a10, int a11, int a12,
+                                    int a13, int a14)
+{
+    return (a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 +
+            a11 + a12 + a13 + a14);
+}
+
+JL_DLLEXPORT float test_long_args_float(float a1, float a2, float a3,
+                                        float a4, float a5, float a6,
+                                        float a7, float a8, float a9,
+                                        float a10, float a11, float a12,
+                                        float a13, float a14)
+{
+    return (a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 +
+            a11 + a12 + a13 + a14);
+}
+
+JL_DLLEXPORT double test_long_args_double(double a1, double a2, double a3,
+                                          double a4, double a5, double a6,
+                                          double a7, double a8, double a9,
+                                          double a10, double a11, double a12,
+                                          double a13, double a14)
+{
+    return (a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 +
+            a11 + a12 + a13 + a14);
+}
+
+typedef struct {
+    int *a;
+    int *b;
+} struct_spill_pint;
+
+JL_DLLEXPORT int test_spill_int1(int *v1, struct_spill_pint s)
+{
+    return *v1 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int2(int *v1, int *v2, struct_spill_pint s)
+{
+    return *v1 + *v2 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int3(int *v1, int *v2, int *v3, struct_spill_pint s)
+{
+    return *v1 + *v2 + *v3 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int4(int *v1, int *v2, int *v3, int *v4,
+                                 struct_spill_pint s)
+{
+    return *v1 + *v2 + *v3 + *v4 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int5(int *v1, int *v2, int *v3, int *v4, int *v5,
+                                 struct_spill_pint s)
+{
+    return *v1 + *v2 + *v3 + *v4 + *v5 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int6(int *v1, int *v2, int *v3, int *v4, int *v5,
+                                 int *v6, struct_spill_pint s)
+{
+    return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int7(int *v1, int *v2, int *v3, int *v4, int *v5,
+                                 int *v6, int *v7, struct_spill_pint s)
+{
+    return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int8(int *v1, int *v2, int *v3, int *v4, int *v5,
+                                 int *v6, int *v7, int *v8, struct_spill_pint s)
+{
+    return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *v8 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int9(int *v1, int *v2, int *v3, int *v4, int *v5,
+                                 int *v6, int *v7, int *v8, int *v9,
+                                 struct_spill_pint s)
+{
+    return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *v8 + *v9 + *s.a + *s.b;
+}
+
+JL_DLLEXPORT int test_spill_int10(int *v1, int *v2, int *v3, int *v4, int *v5,
+                                  int *v6, int *v7, int *v8, int *v9, int *v10,
+                                  struct_spill_pint s)
+{
+    return (*v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *v8 + *v9 + *v10 +
+            *s.a + *s.b);
+}
+
+typedef struct {
+    float a;
+    float b;
+} struct_spill_float;
+
+JL_DLLEXPORT float test_spill_float1(float v1, struct_spill_float s)
+{
+    return v1 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float2(float v1, float v2, struct_spill_float s)
+{
+    return v1 + v2 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float3(float v1, float v2, float v3,
+                                     struct_spill_float s)
+{
+    return v1 + v2 + v3 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float4(float v1, float v2, float v3, float v4,
+                                     struct_spill_float s)
+{
+    return v1 + v2 + v3 + v4 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float5(float v1, float v2, float v3, float v4,
+                                     float v5, struct_spill_float s)
+{
+    return v1 + v2 + v3 + v4 + v5 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float6(float v1, float v2, float v3, float v4,
+                                     float v5, float v6, struct_spill_float s)
+{
+    return v1 + v2 + v3 + v4 + v5 + v6 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float7(float v1, float v2, float v3, float v4,
+                                     float v5, float v6, float v7,
+                                     struct_spill_float s)
+{
+    return v1 + v2 + v3 + v4 + v5 + v6 + v7 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float8(float v1, float v2, float v3, float v4,
+                                     float v5, float v6, float v7, float v8,
+                                     struct_spill_float s)
+{
+    return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float9(float v1, float v2, float v3, float v4,
+                                     float v5, float v6, float v7, float v8,
+                                     float v9, struct_spill_float s)
+{
+    return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + s.a + s.b;
+}
+
+JL_DLLEXPORT float test_spill_float10(float v1, float v2, float v3, float v4,
+                                      float v5, float v6, float v7, float v8,
+                                      float v9, float v10, struct_spill_float s)
+{
+    return (v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + s.a + s.b);
+}
+
 JL_DLLEXPORT int get_c_int(void)
 {
     return c_int;

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1044,3 +1044,13 @@ function f17204(a)
 end
 @test ccall(cfunction(f17204, Vector{Any}, Tuple{Vector{Any}}),
             Vector{Any}, (Vector{Any},), Any[1:10;]) == Any[11:20;]
+
+# This used to trigger incorrect ccall callee inlining.
+# Not sure if there's a more reliable way to test this.
+# Do not put these in a function.
+@noinline g17413() = rand()
+@inline f17413() = (g17413(); g17413())
+ccall((:test_echo_p, libccalltest), Ptr{Void}, (Any,), f17413())
+for i in 1:3
+    ccall((:test_echo_p, libccalltest), Ptr{Void}, (Any,), f17413())
+end

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1054,3 +1054,84 @@ ccall((:test_echo_p, libccalltest), Ptr{Void}, (Any,), f17413())
 for i in 1:3
     ccall((:test_echo_p, libccalltest), Ptr{Void}, (Any,), f17413())
 end
+
+immutable SpillPint
+    a::Ptr{Cint}
+    b::Ptr{Cint}
+end
+Base.cconvert(::Type{SpillPint}, v::NTuple{2,Cint}) =
+    Base.cconvert(Ref{NTuple{2,Cint}}, v)
+function Base.unsafe_convert(::Type{SpillPint}, vr)
+    ptr = Base.unsafe_convert(Ref{NTuple{2,Cint}}, vr)
+    return SpillPint(ptr, ptr + 4)
+end
+
+macro test_spill_n(n::Int, intargs, floatargs)
+    fname_int = Symbol(:test_spill_int, n)
+    fname_float = Symbol(:test_spill_float, n)
+    quote
+        local ints = $(esc(intargs))
+        local floats = $(esc(intargs))
+        @test ccall(($(QuoteNode(fname_int)), libccalltest), Cint,
+                    ($((:(Ref{Cint}) for j in 1:n)...), SpillPint),
+                    $((:(ints[$j]) for j in 1:n)...),
+                    (ints[$n + 1], ints[$n + 2])) == sum(ints[1:($n + 2)])
+        @test ccall(($(QuoteNode(fname_float)), libccalltest), Float32,
+                    ($((:Float32 for j in 1:n)...), NTuple{2,Float32}),
+                    $((:(floats[$j]) for j in 1:n)...),
+                    (floats[$n + 1], floats[$n + 2])) == sum(floats[1:($n + 2)])
+    end
+end
+
+for i in 1:100
+    local intargs = rand(1:10000, 14)
+    local int32args = Int32.(intargs)
+    local intsum = sum(intargs)
+    local floatargs = rand(14)
+    local float32args = Float32.(floatargs)
+    local float32sum = sum(float32args)
+    local float64sum = sum(floatargs)
+    @test ccall((:test_long_args_intp, libccalltest), Cint,
+                (Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint},
+                 Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint},
+                 Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint},
+                 Ref{Cint}, Ref{Cint}),
+                intargs[1], intargs[2], intargs[3], intargs[4],
+                intargs[5], intargs[6], intargs[7], intargs[8],
+                intargs[9], intargs[10], intargs[11], intargs[12],
+                intargs[13], intargs[14]) == intsum
+    @test ccall((:test_long_args_int, libccalltest), Cint,
+                (Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint,
+                 Cint, Cint, Cint, Cint, Cint, Cint),
+                intargs[1], intargs[2], intargs[3], intargs[4],
+                intargs[5], intargs[6], intargs[7], intargs[8],
+                intargs[9], intargs[10], intargs[11], intargs[12],
+                intargs[13], intargs[14]) == intsum
+    @test ccall((:test_long_args_float, libccalltest), Float32,
+                (Float32, Float32, Float32, Float32, Float32, Float32,
+                 Float32, Float32, Float32, Float32, Float32, Float32,
+                 Float32, Float32),
+                floatargs[1], floatargs[2], floatargs[3], floatargs[4],
+                floatargs[5], floatargs[6], floatargs[7], floatargs[8],
+                floatargs[9], floatargs[10], floatargs[11], floatargs[12],
+                floatargs[13], floatargs[14]) ≈ float32sum
+    @test ccall((:test_long_args_double, libccalltest), Float64,
+                (Float64, Float64, Float64, Float64, Float64, Float64,
+                 Float64, Float64, Float64, Float64, Float64, Float64,
+                 Float64, Float64),
+                floatargs[1], floatargs[2], floatargs[3], floatargs[4],
+                floatargs[5], floatargs[6], floatargs[7], floatargs[8],
+                floatargs[9], floatargs[10], floatargs[11], floatargs[12],
+                floatargs[13], floatargs[14]) ≈ float64sum
+
+    @test_spill_n 1 int32args float32args
+    @test_spill_n 2 int32args float32args
+    @test_spill_n 3 int32args float32args
+    @test_spill_n 4 int32args float32args
+    @test_spill_n 5 int32args float32args
+    @test_spill_n 6 int32args float32args
+    @test_spill_n 7 int32args float32args
+    @test_spill_n 8 int32args float32args
+    @test_spill_n 9 int32args float32args
+    @test_spill_n 10 int32args float32args
+end


### PR DESCRIPTION
Add test for C functions with many integer or floating point arguments.

(This is the spilling part of https://github.com/JuliaLang/julia/issues/14912)

I'm not sure what exactly needs to be handled by the frontend but it seems that LLVM can handle the register/stack allocation detail as long as the arguments type are normalized to a few basic ones. None of the other ABIs (arm/aarch64/ppc/(win64?win32?x86?)) that passes values in registers handles spilling in the frontend.

@vtjnash 
