### PR TITLE
Docstrings for rounding modes

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -750,6 +750,14 @@ end
 
 #Rounding complex numbers
 #Requires two different RoundingModes for the real and imaginary components
+"""
+    round(z, RoundingModeReal, RoundingModeImaginary)
+
+Returns the nearest integral value of the same type as the complex-valued `z` to `z`,
+breaking ties using the specified [`RoundingMode`](:obj:`RoundingMode`)s. The first
+[`RoundingMode`](:obj:`RoundingMode`) is used for rounding the real components while the
+second is used for rounding the imaginary components.
+"""
 function round{T<:AbstractFloat, MR, MI}(z::Complex{T}, ::RoundingMode{MR}, ::RoundingMode{MI})
     Complex(round(real(z), RoundingMode{MR}()),
             round(imag(z), RoundingMode{MI}()))

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -955,7 +955,7 @@ julia> Float32(1/3, RoundUp)
 0.33333334f0
 ```
 
-See `rounding` for available rounding modes.
+See [`RoundingMode`](:obj:`RoundingMode`) for available rounding modes.
 """
 Float32
 
@@ -2977,7 +2977,7 @@ julia> Float64(pi, RoundUp)
 3.1415926535897936
 ```
 
-See `rounding` for available rounding modes.
+See [`RoundingMode`](:obj:`RoundingMode`) for available rounding modes.
 """
 Float64
 
@@ -5252,8 +5252,7 @@ Get the current floating point rounding mode for type `T`, controlling the round
 arithmetic functions ([`+`](:func:`+`), [`-`](:func:`-`), [`*`](:func:`*`), [`/`](:func:`/`)
 and [`sqrt`](:func:`sqrt`)) and type conversion.
 
-Valid modes are `RoundNearest`, `RoundToZero`, `RoundUp`, `RoundDown`, and `RoundFromZero`
-(`BigFloat` only).
+See [`RoundingMode`](:obj:`RoundingMode`) for available modes.
 """
 rounding
 
@@ -5444,7 +5443,8 @@ arithmetic functions ([`+`](:func:`+`), [`-`](:func:`-`), [`*`](:func:`*`), [`/`
 and [`sqrt`](:func:`sqrt`)) and type conversion.
 
 Note that this may affect other types, for instance changing the rounding mode of `Float64`
-will change the rounding mode of `Float32`. See `rounding` for available modes
+will change the rounding mode of `Float32`. See [`RoundingMode`](:obj:`RoundingMode`) for
+available modes.
 """
 setrounding(T, mode)
 
@@ -5459,7 +5459,7 @@ equivalent to:
     f()
     setrounding(T, old)
 
-See `rounding` for available rounding modes.
+See [`RoundingMode`](:obj:`RoundingMode`) for available rounding modes.
 """
 setrounding(f::Function, T, mode)
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2309,16 +2309,6 @@ For matrices or vectors ``A`` and ``B``, calculates ``A / Bᴴ``.
 A_rdiv_Bc
 
 """
-    round(z, RoundingModeReal, RoundingModeImaginary)
-
-Returns the nearest integral value of the same type as the complex-valued `z` to `z`,
-breaking ties using the specified [`RoundingMode`](:obj:`RoundingMode`)s. The first
-[`RoundingMode`](:obj:`RoundingMode`) is used for rounding the real components while the
-second is used for rounding the imaginary components.
-"""
-round(z::Real, ::Type{RoundingMode}, ::Type{RoundingMode})
-
-"""
     strwidth(s)
 
 Gives the number of columns needed to print a string.

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -5246,17 +5246,6 @@ Determine whether a stream is read-only.
 isreadonly
 
 """
-    rounding(T)
-
-Get the current floating point rounding mode for type `T`, controlling the rounding of basic
-arithmetic functions ([`+`](:func:`+`), [`-`](:func:`-`), [`*`](:func:`*`), [`/`](:func:`/`)
-and [`sqrt`](:func:`sqrt`)) and type conversion.
-
-See [`RoundingMode`](:obj:`RoundingMode`) for available modes.
-"""
-rounding
-
-"""
     code_llvm(f, types)
 
 Prints the LLVM bitcodes generated for running the method matching the given generic
@@ -5434,34 +5423,6 @@ the results need to be used judiciously. See [Manual](:ref:`man-code-warntype`) 
 information.
 """
 code_warntype
-
-"""
-    setrounding(T, mode)
-
-Set the rounding mode of floating point type `T`, controlling the rounding of basic
-arithmetic functions ([`+`](:func:`+`), [`-`](:func:`-`), [`*`](:func:`*`), [`/`](:func:`/`)
-and [`sqrt`](:func:`sqrt`)) and type conversion.
-
-Note that this may affect other types, for instance changing the rounding mode of `Float64`
-will change the rounding mode of `Float32`. See [`RoundingMode`](:obj:`RoundingMode`) for
-available modes.
-"""
-setrounding(T, mode)
-
-"""
-    setrounding(f::Function, T, mode)
-
-Change the rounding mode of floating point type `T` for the duration of `f`. It is logically
-equivalent to:
-
-    old = rounding(T)
-    setrounding(T, mode)
-    f()
-    setrounding(T, old)
-
-See [`RoundingMode`](:obj:`RoundingMode`) for available rounding modes.
-"""
-setrounding(f::Function, T, mode)
 
 """
     Mmap.sync!(array)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -52,9 +52,11 @@ end
     round([T,] x, [digits, [base]], [r::RoundingMode])
 
 Rounds `x` to an integer value according to the provided
-[`RoundingMode`](:obj:`RoundingMode`), returning a value of the same type as `x`. By default
-uses [`RoundNearest`](:obj:`RoundNearest`), which rounds to the nearest integer, with ties
-(fractional values of 0.5) being rounded to the nearest even integer.
+[`RoundingMode`](:obj:`RoundingMode`), returning a value of the same type as `x`. When not
+specifying a rounding mode the global mode will be used
+(see [`rounding`](:func:`rounding`)), which by default is round to the nearest integer
+([`RoundNearest`](:obj:`RoundNearest`) mode), with ties (fractional values of 0.5) being
+rounded to the nearest even integer.
 
 ```jldoctest
 julia> round(1.7)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -51,10 +51,10 @@ end
 """
     round([T,] x, [digits, [base]], [r::RoundingMode])
 
-`round(x)` rounds `x` to an integer value according to the default rounding mode (see
-[`RoundingMode`](:obj:`RoundingMode`)), returning a value of the same type as `x`. By default
-([`RoundNearest`](:obj:`RoundNearest`)), this will round to the nearest integer, with ties
-(fractional values of 0.5) being rounded to the even integer.
+Rounds `x` to an integer value according to the provided
+[`RoundingMode`](:obj:`RoundingMode`), returning a value of the same type as `x`. By default
+uses [`RoundNearest`](:obj:`RoundNearest`), which rounds to the nearest integer, with ties
+(fractional values of 0.5) being rounded to the nearest even integer.
 
 ```jldoctest
 julia> round(1.7)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -52,7 +52,7 @@ end
     round([T,] x, [digits, [base]], [r::RoundingMode])
 
 `round(x)` rounds `x` to an integer value according to the default rounding mode (see
-[`rounding`](:func:`rounding`)), returning a value of the same type as `x`. By default
+[`RoundingMode`](:obj:`RoundingMode`)), returning a value of the same type as `x`. By default
 ([`RoundNearest`](:obj:`RoundNearest`)), this will round to the nearest integer, with ties
 (fractional values of 0.5) being rounded to the even integer.
 

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -96,13 +96,49 @@ function from_fenv(r::Integer)
     end
 end
 
+"""
+    setrounding(T, mode)
+
+Set the rounding mode of floating point type `T`, controlling the rounding of basic
+arithmetic functions ([`+`](:func:`+`), [`-`](:func:`-`), [`*`](:func:`*`), [`/`](:func:`/`)
+and [`sqrt`](:func:`sqrt`)) and type conversion.
+
+Note that this may affect other types, for instance changing the rounding mode of `Float64`
+will change the rounding mode of `Float32`. See [`RoundingMode`](:obj:`RoundingMode`) for
+available modes.
+"""
+setrounding(T::Type, mode)
+
+"""
+    rounding(T)
+
+Get the current floating point rounding mode for type `T`, controlling the rounding of basic
+arithmetic functions ([`+`](:func:`+`), [`-`](:func:`-`), [`*`](:func:`*`), [`/`](:func:`/`)
+and [`sqrt`](:func:`sqrt`)) and type conversion.
+
+See [`RoundingMode`](:obj:`RoundingMode`) for available modes.
+"""
+:rounding
+
 setrounding_raw{T<:Union{Float32,Float64}}(::Type{T},i::Integer) = ccall(:fesetround, Int32, (Int32,), i)
 rounding_raw{T<:Union{Float32,Float64}}(::Type{T}) = ccall(:fegetround, Int32, ())
 
 setrounding{T<:Union{Float32,Float64}}(::Type{T},r::RoundingMode) = setrounding_raw(T,to_fenv(r))
 rounding{T<:Union{Float32,Float64}}(::Type{T}) = from_fenv(rounding_raw(T))
 
+"""
+    setrounding(f::Function, T, mode)
 
+Change the rounding mode of floating point type `T` for the duration of `f`. It is logically
+equivalent to:
+
+    old = rounding(T)
+    setrounding(T, mode)
+    f()
+    setrounding(T, old)
+
+See [`RoundingMode`](:obj:`RoundingMode`) for available rounding modes.
+"""
 function setrounding{T}(f::Function, ::Type{T}, rounding::RoundingMode)
     old_rounding_raw = rounding_raw(T)
     setrounding(T,rounding)

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -10,16 +10,66 @@ export
     get_zero_subnormals, set_zero_subnormals
 
 ## rounding modes ##
+"""
+    RoundingMode
+
+A type which controls rounding behavior. Currently supported rounding modes are:
+
+- [`RoundNearest`](:obj:`RoundNearest`) (default)
+- [`RoundNearestTiesAway`](:obj:`RoundNearestTiesAway`)
+- [`RoundNearestTiesUp`](:obj:`RoundNearestTiesUp`)
+- [`RoundToZero`](:obj:`RoundToZero`)
+- [`RoundFromZero`](:obj:`RoundFromZero`) (`BigFloat` only)
+- [`RoundUp`](:obj:`RoundUp`)
+- [`RoundDown`](:obj:`RoundDown`)
+"""
 immutable RoundingMode{T} end
 
+"""
+    RoundNearest
+
+The default rounding mode. Rounds to the nearest integer, with ties (fractional values of
+0.5) being rounded to the nearest even integer.
+"""
 const RoundNearest = RoundingMode{:Nearest}()
+
+"""
+    RoundToZero
+
+[`round`](:func:`round`) using this rounding mode is an alias for [`trunc`](:func:`trunc`).
+"""
 const RoundToZero = RoundingMode{:ToZero}()
+
+"""
+    RoundUp
+
+[`round`](:func:`round`) using this rounding mode is an alias for [`ceil`](:func:`ceil`).
+"""
 const RoundUp = RoundingMode{:Up}()
+
+"""
+    RoundDown
+
+[`round`](:func:`round`) using this rounding mode is an alias for [`floor`](:func:`floor`).
+"""
 const RoundDown = RoundingMode{:Down}()
+
 const RoundFromZero = RoundingMode{:FromZero}() # mpfr only
-# C-style round behaviour
+
+"""
+    RoundNearestTiesAway
+
+Rounds to nearest integer, with ties rounded away from zero (C/C++
+[`round`](:func:`round`) behaviour).
+"""
 const RoundNearestTiesAway = RoundingMode{:NearestTiesAway}()
-# Java-style round behaviour
+
+"""
+    RoundNearestTiesUp
+
+Rounds to nearest integer, with ties rounded toward positive infinity (Java/JavaScript
+[`round`](:func:`round`) behaviour).
+"""
 const RoundNearestTiesUp = RoundingMode{:NearestTiesUp}()
 
 to_fenv(::RoundingMode{:Nearest}) = JL_FE_TONEAREST

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -13,7 +13,12 @@ export
 """
     RoundingMode
 
-A type which controls rounding behavior. Currently supported rounding modes are:
+A type used for controlling the rounding mode of floating point operations (via
+[`rounding`](:func:`rounding`)/[`setrounding`](:func:`setrounding`) functions), or as
+optional arguments for rounding to the nearest integer (via the [`round`](:func:`round`)
+function).
+
+Currently supported rounding modes are:
 
 - [`RoundNearest`](:obj:`RoundNearest`) (default)
 - [`RoundNearestTiesAway`](:obj:`RoundNearestTiesAway`)

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -966,7 +966,7 @@ Mathematical Functions
 
    .. Docstring generated from Julia source
 
-   ``round(x)`` rounds ``x`` to an integer value according to the default rounding mode (see :func:`rounding`\ ), returning a value of the same type as ``x``\ . By default (:obj:`RoundNearest`\ ), this will round to the nearest integer, with ties (fractional values of 0.5) being rounded to the even integer.
+   ``round(x)`` rounds ``x`` to an integer value according to the default rounding mode (see :obj:`RoundingMode`\ ), returning a value of the same type as ``x``\ . By default (:obj:`RoundNearest`\ ), this will round to the nearest integer, with ties (fractional values of 0.5) being rounded to the even integer.
 
    .. doctest::
 
@@ -1011,43 +1011,55 @@ Mathematical Functions
           1.2
 
 
-.. data:: RoundingMode
+.. type:: RoundingMode
+
+   .. Docstring generated from Julia source
 
    A type which controls rounding behavior. Currently supported rounding modes are:
 
-   - :obj:`RoundNearest` (default)
-   - :obj:`RoundNearestTiesAway`
-   - :obj:`RoundNearestTiesUp`
-   - :obj:`RoundToZero`
-   - :obj:`RoundUp`
-   - :obj:`RoundDown`
+   * :obj:`RoundNearest` (default)
+   * :obj:`RoundNearestTiesAway`
+   * :obj:`RoundNearestTiesUp`
+   * :obj:`RoundToZero`
+   * :obj:`RoundFromZero` (``BigFloat`` only)
+   * :obj:`RoundUp`
+   * :obj:`RoundDown`
 
-.. data:: RoundNearest
+.. variable:: RoundNearest
 
-   The default rounding mode. Rounds to the nearest integer, with ties
-   (fractional values of 0.5) being rounded to the nearest even integer.
+   .. Docstring generated from Julia source
 
-.. data:: RoundNearestTiesAway
+   The default rounding mode. Rounds to the nearest integer, with ties (fractional values of 0.5) being rounded to the nearest even integer.
 
-   Rounds to nearest integer, with ties rounded away from zero (C/C++
-   :func:`round` behaviour).
+.. variable:: RoundNearestTiesAway
 
-.. data:: RoundNearestTiesUp
+   .. Docstring generated from Julia source
 
-   Rounds to nearest integer, with ties rounded toward positive infinity
-   (Java/JavaScript :func:`round` behaviour).
+   Rounds to nearest integer, with ties rounded away from zero (C/C++ :func:`round` behaviour).
 
-.. data:: RoundToZero
+.. variable:: RoundNearestTiesUp
 
-   :func:`round` using this rounding mode is an alias for :func:`trunc`.
+   .. Docstring generated from Julia source
 
-.. data:: RoundUp
+   Rounds to nearest integer, with ties rounded toward positive infinity (Java/JavaScript :func:`round` behaviour).
 
-   :func:`round` using this rounding mode is an alias for :func:`ceil`.
+.. variable:: RoundToZero
 
-.. data:: RoundDown
+   .. Docstring generated from Julia source
 
-   :func:`round` using this rounding mode is an alias for :func:`floor`.
+   :func:`round` using this rounding mode is an alias for :func:`trunc`\ .
+
+.. variable:: RoundUp
+
+   .. Docstring generated from Julia source
+
+   :func:`round` using this rounding mode is an alias for :func:`ceil`\ .
+
+.. variable:: RoundDown
+
+   .. Docstring generated from Julia source
+
+   :func:`round` using this rounding mode is an alias for :func:`floor`\ .
 
 .. function:: round(z, RoundingModeReal, RoundingModeImaginary)
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -966,7 +966,7 @@ Mathematical Functions
 
    .. Docstring generated from Julia source
 
-   Rounds ``x`` to an integer value according to the provided :obj:`RoundingMode`\ , returning a value of the same type as ``x``\ . By default uses :obj:`RoundNearest`\ , which rounds to the nearest integer, with ties (fractional values of 0.5) being rounded to the nearest even integer.
+   Rounds ``x`` to an integer value according to the provided :obj:`RoundingMode`\ , returning a value of the same type as ``x``\ . When not specifying a rounding mode the global mode will be used (see :func:`rounding`\ ), which by default is round to the nearest integer (:obj:`RoundNearest` mode), with ties (fractional values of 0.5) being rounded to the nearest even integer.
 
    .. doctest::
 
@@ -1015,7 +1015,9 @@ Mathematical Functions
 
    .. Docstring generated from Julia source
 
-   A type which controls rounding behavior. Currently supported rounding modes are:
+   A type used for controlling the rounding mode of floating point operations (via :func:`rounding`\ /:func:`setrounding` functions), or as optional arguments for rounding to the nearest integer (via the :func:`round` function).
+
+   Currently supported rounding modes are:
 
    * :obj:`RoundNearest` (default)
    * :obj:`RoundNearestTiesAway`

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -966,7 +966,7 @@ Mathematical Functions
 
    .. Docstring generated from Julia source
 
-   ``round(x)`` rounds ``x`` to an integer value according to the default rounding mode (see :obj:`RoundingMode`\ ), returning a value of the same type as ``x``\ . By default (:obj:`RoundNearest`\ ), this will round to the nearest integer, with ties (fractional values of 0.5) being rounded to the even integer.
+   Rounds ``x`` to an integer value according to the provided :obj:`RoundingMode`\ , returning a value of the same type as ``x``\ . By default uses :obj:`RoundNearest`\ , which rounds to the nearest integer, with ties (fractional values of 0.5) being rounded to the nearest even integer.
 
    .. doctest::
 

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -287,7 +287,7 @@ General Number Functions and Constants
        julia> Float32(1/3, RoundUp)
        0.33333334f0
 
-   See ``rounding`` for available rounding modes.
+   See :obj:`RoundingMode` for available rounding modes.
 
 .. function:: Float64(x [, mode::RoundingMode])
 
@@ -303,7 +303,7 @@ General Number Functions and Constants
        julia> Float64(pi, RoundUp)
        3.1415926535897936
 
-   See ``rounding`` for available rounding modes.
+   See :obj:`RoundingMode` for available rounding modes.
 
 .. function:: BigInt(x)
 
@@ -335,7 +335,7 @@ General Number Functions and Constants
 
    Get the current floating point rounding mode for type ``T``\ , controlling the rounding of basic arithmetic functions (:func:`+`\ , :func:`-`\ , :func:`*`\ , :func:`/` and :func:`sqrt`\ ) and type conversion.
 
-   Valid modes are ``RoundNearest``\ , ``RoundToZero``\ , ``RoundUp``\ , ``RoundDown``\ , and ``RoundFromZero`` (``BigFloat`` only).
+   See :obj:`RoundingMode` for available modes.
 
 .. function:: setrounding(T, mode)
 
@@ -343,7 +343,7 @@ General Number Functions and Constants
 
    Set the rounding mode of floating point type ``T``\ , controlling the rounding of basic arithmetic functions (:func:`+`\ , :func:`-`\ , :func:`*`\ , :func:`/` and :func:`sqrt`\ ) and type conversion.
 
-   Note that this may affect other types, for instance changing the rounding mode of ``Float64`` will change the rounding mode of ``Float32``\ . See ``rounding`` for available modes
+   Note that this may affect other types, for instance changing the rounding mode of ``Float64`` will change the rounding mode of ``Float32``\ . See :obj:`RoundingMode` for available modes.
 
 .. function:: setrounding(f::Function, T, mode)
 
@@ -358,7 +358,7 @@ General Number Functions and Constants
        f()
        setrounding(T, old)
 
-   See ``rounding`` for available rounding modes.
+   See :obj:`RoundingMode` for available rounding modes.
 
 .. function:: get_zero_subnormals() -> Bool
 


### PR DESCRIPTION
Converted the documentation in the manual to be the docstrings for the various rounding modes. Note that we are missing documentation regarding the `RoundFromZero` mode.
