### PR TITLE
Add admonition syntax to markdown parser

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -362,17 +362,6 @@ Returns `true` if `path` is a regular file, `false` otherwise.
 isfile
 
 """
-    symlink(target, link)
-
-Creates a symbolic link to `target` with the name `link`.
-
-!!! note
-    This function raises an error under operating systems that do not support
-    soft symbolic links, such as Windows XP.
-"""
-symlink
-
-"""
     task_local_storage(symbol)
 
 Look up the value of a symbol in the current task's task-local storage.
@@ -2318,64 +2307,6 @@ Mmap.Anonymous
 For matrices or vectors ``A`` and ``B``, calculates ``A / Bᴴ``.
 """
 A_rdiv_Bc
-
-"""
-    round([T,] x, [digits, [base]], [r::RoundingMode])
-
-`round(x)` rounds `x` to an integer value according to the default rounding mode (see
-[`rounding`](:func:`rounding`)), returning a value of the same type as `x`. By default
-([`RoundNearest`](:obj:`RoundNearest`)), this will round to the nearest integer, with ties
-(fractional values of 0.5) being rounded to the even integer.
-
-```jldoctest
-julia> round(1.7)
-2.0
-
-julia> round(1.5)
-2.0
-
-julia> round(2.5)
-2.0
-```
-
-The optional [`RoundingMode`](:obj:`RoundingMode`) argument will change how the number gets
-rounded.
-
-`round(T, x, [r::RoundingMode])` converts the result to type `T`, throwing an
-[`InexactError`](:exc:`InexactError`) if the value is not representable.
-
-`round(x, digits)` rounds to the specified number of digits after the decimal place (or
-before if negative). `round(x, digits, base)` rounds using a base other than 10.
-
-```jldoctest
-julia> round(pi, 2)
-3.14
-
-julia> round(pi, 3, 2)
-3.125
-```
-
-!!! note
-    Rounding to specified digits in bases other than 2 can be inexact when
-    operating on binary floating point numbers. For example, the `Float64`
-    value represented by `1.15` is actually *less* than 1.15, yet will be
-    rounded to 1.2.
-
-    ```jldoctest
-    julia> x = 1.15
-    1.15
-
-    julia> @sprintf "%.20f" x
-    "1.14999999999999991118"
-
-    julia> x < 115//100
-    true
-
-    julia> round(x, 1)
-    1.2
-    ```
-"""
-round(T::Type, x)
 
 """
     round(z, RoundingModeReal, RoundingModeImaginary)
@@ -4414,33 +4345,6 @@ Bitwise not.
 Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x)``.
 """
 hankelh1
-
-"""
-    gcdx(x,y)
-
-Computes the greatest common (positive) divisor of `x` and `y` and their Bézout
-coefficients, i.e. the integer coefficients `u` and `v` that satisfy
-``ux+vy = d = gcd(x,y)``.
-
-```jldoctest
-julia> gcdx(12, 42)
-(6,-3,1)
-```
-
-```jldoctest
-julia> gcdx(240, 46)
-(2,-9,47)
-```
-
-!!! note
-    Bézout coefficients are *not* uniquely defined. `gcdx` returns the minimal
-    Bézout coefficients that are computed by the extended Euclid algorithm.
-    (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients `u`
-    and `v` are minimal in the sense that ``|u| < |\\frac y d`` and ``|v| <
-    |\\frac x d``. Furthermore, the signs of `u` and `v` are chosen so that `d`
-    is positive.
-"""
-gcdx
 
 """
     rem(x, y)
@@ -8625,73 +8529,6 @@ eigvecs
 Converts the endianness of a value from Network byte order (big-endian) to that used by the Host.
 """
 ntoh
-
-"""
-    qrfact(A [,pivot=Val{false}]) -> F
-
-Computes the QR factorization of `A`. The return type of `F` depends on the element type of
-`A` and whether pivoting is specified (with `pivot==Val{true}`).
-
-| Return type   | `eltype(A)`     | `pivot`      | Relationship between `F` and `A` |
-|:--------------|:----------------|:-------------|:---------------------------------|
-| `QR`          | not `BlasFloat` | either       | `A==F[:Q]*F[:R]`                 |
-| `QRCompactWY` | `BlasFloat`     | `Val{false}` | `A==F[:Q]*F[:R]`                 |
-| `QRPivoted`   | `BlasFloat`     | `Val{true}`  | `A[:,F[:p]]==F[:Q]*F[:R]`        |
-
-`BlasFloat` refers to any of: `Float32`, `Float64`, `Complex64` or `Complex128`.
-
-The individual components of the factorization `F` can be accessed by indexing:
-
-| Component | Description                               | `QR`            | `QRCompactWY`      | `QRPivoted`     |
-|:----------|:------------------------------------------|:----------------|:-------------------|:----------------|
-| `F[:Q]`   | `Q` (orthogonal/unitary) part of `QR`     | ✓ (`QRPackedQ`) | ✓ (`QRCompactWYQ`) | ✓ (`QRPackedQ`) |
-| `F[:R]`   | `R` (upper right triangular) part of `QR` | ✓               | ✓                  | ✓               |
-| `F[:p]`   | pivot `Vector`                            |                 |                    | ✓               |
-| `F[:P]`   | (pivot) permutation `Matrix`              |                 |                    | ✓               |
-
-The following functions are available for the `QR` objects: `size`, `\\`. When `A` is
-rectangular, `\\` will return a least squares solution and if the solution is not unique,
-the one with smallest norm is returned.
-
-Multiplication with respect to either thin or full `Q` is allowed, i.e. both `F[:Q]*F[:R]`
-and `F[:Q]*A` are supported. A `Q` matrix can be converted into a regular matrix with
-[`full`](:func:`full`) which has a named argument `thin`.
-
-!!! note
-    `qrfact` returns multiple types because LAPACK uses several representations
-    that minimize the memory storage requirements of products of Householder
-    elementary reflectors, so that the `Q` and `R` matrices can be stored
-    compactly rather as two separate dense matrices.
-
-    The data contained in `QR` or `QRPivoted` can be used to construct the
-    `QRPackedQ` type, which is a compact representation of the rotation matrix:
-
-    ```math
-    Q = \\prod_{i=1}^{\\min(m,n)} (I - \\tau_i v_i v_i^T)
-    ```
-
-    where ``\\tau_i`` is the scale factor and ``v_i`` is the projection vector
-    associated with the ``i^{th}`` Householder elementary reflector.
-
-    The data contained in `QRCompactWY` can be used to construct the
-    `QRCompactWYQ` type, which is a compact representation of the rotation
-    matrix
-
-    ```math
-    Q = I + Y T Y^T
-    ```
-
-    where `Y` is ``m \\times r`` lower trapezoidal and `T` is ``r \\times r``
-    upper triangular. The *compact WY* representation [^Schreiber1989] is not
-    to be confused with the older, *WY* representation [^Bischof1987]. (The
-    LAPACK documentation uses `V` in lieu of `Y`.)
-
-    [^Bischof1987]: C Bischof and C Van Loan, "The WY representation for products of Householder matrices", SIAM J Sci Stat Comput 8 (1987), s2-s13. [doi:10.1137/0908009](http://dx.doi.org/10.1137/0908009)
-
-    [^Schreiber1989]: R Schreiber and C Van Loan, "A storage-efficient WY representation for products of Householder transformations", SIAM J Sci Stat Comput 10 (1989), 53-57. [doi:10.1137/0910005](http://dx.doi.org/10.1137/0910005)
-"""
-qrfact(A,?)
-
 
 """
     qrfact(A) -> SPQR.Factorization

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -366,10 +366,9 @@ isfile
 
 Creates a symbolic link to `target` with the name `link`.
 
-**note**
-
-This function raises an error under operating systems that do not support soft symbolic
-links, such as Windows XP.
+!!! note
+    This function raises an error under operating systems that do not support
+    soft symbolic links, such as Windows XP.
 """
 symlink
 
@@ -2356,25 +2355,25 @@ julia> round(pi, 3, 2)
 3.125
 ```
 
-**note**
+!!! note
+    Rounding to specified digits in bases other than 2 can be inexact when
+    operating on binary floating point numbers. For example, the `Float64`
+    value represented by `1.15` is actually *less* than 1.15, yet will be
+    rounded to 1.2.
 
-Rounding to specified digits in bases other than 2 can be inexact when operating on binary
-floating point numbers. For example, the `Float64` value represented by `1.15` is actually
-*less* than 1.15, yet will be rounded to 1.2.
+    ```jldoctest
+    julia> x = 1.15
+    1.15
 
-```jldoctest
-julia> x = 1.15
-1.15
+    julia> @sprintf "%.20f" x
+    "1.14999999999999991118"
 
-julia> @sprintf "%.20f" x
-"1.14999999999999991118"
+    julia> x < 115//100
+    true
 
-julia> x < 115//100
-true
-
-julia> round(x, 1)
-1.2
-```
+    julia> round(x, 1)
+    1.2
+    ```
 """
 round(T::Type, x)
 
@@ -4433,13 +4432,13 @@ julia> gcdx(240, 46)
 (2,-9,47)
 ```
 
-**note**
-
-Bézout coefficients are *not* uniquely defined. `gcdx` returns the minimal Bézout
-coefficients that are computed by the extended Euclid algorithm. (Ref: D. Knuth, TAoCP, 2/e,
-p. 325, Algorithm X.) These coefficients `u` and `v` are minimal in the sense that
-``|u| < |\\frac y d`` and ``|v| < |\\frac x d``. Furthermore, the signs of `u` and `v` are
-chosen so that `d` is positive.
+!!! note
+    Bézout coefficients are *not* uniquely defined. `gcdx` returns the minimal
+    Bézout coefficients that are computed by the extended Euclid algorithm.
+    (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients `u`
+    and `v` are minimal in the sense that ``|u| < |\\frac y d`` and ``|v| <
+    |\\frac x d``. Furthermore, the signs of `u` and `v` are chosen so that `d`
+    is positive.
 """
 gcdx
 
@@ -8658,37 +8657,38 @@ Multiplication with respect to either thin or full `Q` is allowed, i.e. both `F[
 and `F[:Q]*A` are supported. A `Q` matrix can be converted into a regular matrix with
 [`full`](:func:`full`) which has a named argument `thin`.
 
-**note**
+!!! note
+    `qrfact` returns multiple types because LAPACK uses several representations
+    that minimize the memory storage requirements of products of Householder
+    elementary reflectors, so that the `Q` and `R` matrices can be stored
+    compactly rather as two separate dense matrices.
 
-`qrfact` returns multiple types because LAPACK uses several representations that minimize
-the memory storage requirements of products of Householder elementary reflectors, so that
-the `Q` and `R` matrices can be stored compactly rather as two separate dense matrices.
+    The data contained in `QR` or `QRPivoted` can be used to construct the
+    `QRPackedQ` type, which is a compact representation of the rotation matrix:
 
-The data contained in `QR` or `QRPivoted` can be used to construct the `QRPackedQ` type,
-which is a compact representation of the rotation matrix:
+    ```math
+    Q = \\prod_{i=1}^{\\min(m,n)} (I - \\tau_i v_i v_i^T)
+    ```
 
-```math
-Q = \\prod_{i=1}^{\\min(m,n)} (I - \\tau_i v_i v_i^T)
-```
+    where ``\\tau_i`` is the scale factor and ``v_i`` is the projection vector
+    associated with the ``i^{th}`` Householder elementary reflector.
 
-where ``\\tau_i`` is the scale factor and ``v_i`` is the projection vector associated with
-the ``i^{th}`` Householder elementary reflector.
+    The data contained in `QRCompactWY` can be used to construct the
+    `QRCompactWYQ` type, which is a compact representation of the rotation
+    matrix
 
-The data contained in `QRCompactWY` can be used to construct the `QRCompactWYQ` type,
-which is a compact representation of the rotation matrix
+    ```math
+    Q = I + Y T Y^T
+    ```
 
-```math
-Q = I + Y T Y^T
-```
+    where `Y` is ``m \\times r`` lower trapezoidal and `T` is ``r \\times r``
+    upper triangular. The *compact WY* representation [^Schreiber1989] is not
+    to be confused with the older, *WY* representation [^Bischof1987]. (The
+    LAPACK documentation uses `V` in lieu of `Y`.)
 
-where `Y` is ``m \\times r`` lower trapezoidal and `T` is ``r \\times r`` upper
-triangular. The *compact WY* representation [^Schreiber1989] is not to be confused with the
-older, *WY* representation [^Bischof1987]. (The LAPACK documentation uses `V` in lieu of `Y`.)
+    [^Bischof1987]: C Bischof and C Van Loan, "The WY representation for products of Householder matrices", SIAM J Sci Stat Comput 8 (1987), s2-s13. [doi:10.1137/0908009](http://dx.doi.org/10.1137/0908009)
 
-[^Bischof1987]: C Bischof and C Van Loan, "The WY representation for products of Householder matrices", SIAM J Sci Stat Comput 8 (1987), s2-s13. [doi:10.1137/0908009](http://dx.doi.org/10.1137/0908009)
-
-[^Schreiber1989]: R Schreiber and C Van Loan, "A storage-efficient WY representation for products of Householder transformations", SIAM J Sci Stat Comput 10 (1989), 53-57. [doi:10.1137/0910005](http://dx.doi.org/10.1137/0910005)
-
+    [^Schreiber1989]: R Schreiber and C Van Loan, "A storage-efficient WY representation for products of Householder transformations", SIAM J Sci Stat Comput 10 (1989), 53-57. [doi:10.1137/0910005](http://dx.doi.org/10.1137/0910005)
 """
 qrfact(A,?)
 

--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -368,6 +368,7 @@ stripmd(x::AbstractString) = x  # base case
 stripmd(x::Void) = " "
 stripmd(x::Vector) = string(map(stripmd, x)...)
 stripmd(x::Markdown.BlockQuote) = "$(stripmd(x.content))"
+stripmd(x::Markdown.Admonition) = "$(stripmd(x.content))"
 stripmd(x::Markdown.Bold) = "$(stripmd(x.text))"
 stripmd(x::Markdown.Code) = "$(stripmd(x.code))"
 stripmd{N}(x::Markdown.Header{N}) = stripmd(x.text)

--- a/base/file.jl
+++ b/base/file.jl
@@ -422,6 +422,16 @@ end
 if is_windows()
     const UV_FS_SYMLINK_JUNCTION = 0x0002
 end
+
+"""
+    symlink(target, link)
+
+Creates a symbolic link to `target` with the name `link`.
+
+!!! note
+    This function raises an error under operating systems that do not support
+    soft symbolic links, such as Windows XP.
+"""
 function symlink(p::AbstractString, np::AbstractString)
     @static if is_windows()
         if Sys.windows_version() < Sys.WINDOWS_VISTA_VER

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -48,6 +48,63 @@ end
 @vectorize_1arg Number isinf
 @vectorize_1arg Number isfinite
 
+"""
+    round([T,] x, [digits, [base]], [r::RoundingMode])
+
+`round(x)` rounds `x` to an integer value according to the default rounding mode (see
+[`rounding`](:func:`rounding`)), returning a value of the same type as `x`. By default
+([`RoundNearest`](:obj:`RoundNearest`)), this will round to the nearest integer, with ties
+(fractional values of 0.5) being rounded to the even integer.
+
+```jldoctest
+julia> round(1.7)
+2.0
+
+julia> round(1.5)
+2.0
+
+julia> round(2.5)
+2.0
+```
+
+The optional [`RoundingMode`](:obj:`RoundingMode`) argument will change how the number gets
+rounded.
+
+`round(T, x, [r::RoundingMode])` converts the result to type `T`, throwing an
+[`InexactError`](:exc:`InexactError`) if the value is not representable.
+
+`round(x, digits)` rounds to the specified number of digits after the decimal place (or
+before if negative). `round(x, digits, base)` rounds using a base other than 10.
+
+```jldoctest
+julia> round(pi, 2)
+3.14
+
+julia> round(pi, 3, 2)
+3.125
+```
+
+!!! note
+    Rounding to specified digits in bases other than 2 can be inexact when
+    operating on binary floating point numbers. For example, the `Float64`
+    value represented by `1.15` is actually *less* than 1.15, yet will be
+    rounded to 1.2.
+
+    ```jldoctest
+    julia> x = 1.15
+    1.15
+
+    julia> @sprintf "%.20f" x
+    "1.14999999999999991118"
+
+    julia> x < 115//100
+    true
+
+    julia> round(x, 1)
+    1.2
+    ```
+"""
+round(T::Type, x)
 
 round(x::Real, ::RoundingMode{:ToZero}) = trunc(x)
 round(x::Real, ::RoundingMode{:Up}) = ceil(x)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -48,6 +48,31 @@ gcd{T<:Integer}(abc::AbstractArray{T}) = reduce(gcd,abc)
 lcm{T<:Integer}(abc::AbstractArray{T}) = reduce(lcm,abc)
 
 # return (gcd(a,b),x,y) such that ax+by == gcd(a,b)
+"""
+    gcdx(x,y)
+
+Computes the greatest common (positive) divisor of `x` and `y` and their Bézout
+coefficients, i.e. the integer coefficients `u` and `v` that satisfy
+``ux+vy = d = gcd(x,y)``.
+
+```jldoctest
+julia> gcdx(12, 42)
+(6,-3,1)
+```
+
+```jldoctest
+julia> gcdx(240, 46)
+(2,-9,47)
+```
+
+!!! note
+    Bézout coefficients are *not* uniquely defined. `gcdx` returns the minimal
+    Bézout coefficients that are computed by the extended Euclid algorithm.
+    (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients `u`
+    and `v` are minimal in the sense that ``|u| < |\\frac y d`` and ``|v| <
+    |\\frac x d``. Furthermore, the signs of `u` and `v` are chosen so that `d`
+    is positive.
+"""
 function gcdx{T<:Integer}(a::T, b::T)
     s0, s1 = one(T), zero(T)
     t0, t1 = s1, s0

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -50,30 +50,29 @@ The following keyword arguments are supported:
 iterations `niter` and the number of matrix vector multiplications `nmult`, as well as the
 final residual vector `resid`.
 
-**note**
+!!! note
+    The `sigma` and `which` keywords interact: the description of eigenvalues
+    searched for by `which` do _not_ necessarily refer to the eigenvalues of
+    `A`, but rather the linear operator constructed by the specification of the
+    iteration mode implied by `sigma`.
 
-The `sigma` and `which` keywords interact: the description of eigenvalues searched for by
-`which` do _not_ necessarily refer to the eigenvalues of `A`, but rather the linear operator
-constructed by the specification of the iteration mode implied by `sigma`.
+    | `sigma`         | iteration mode                   | `which` refers to eigenvalues of |
+    |:----------------|:---------------------------------|:---------------------------------|
+    | `nothing`       | ordinary (forward)               | ``A``                            |
+    | real or complex | inverse with level shift `sigma` | ``(A - \\sigma I )^{-1}``        |
 
-| `sigma`         | iteration mode                   | `which` refers to eigenvalues of |
-|:----------------|:---------------------------------|:---------------------------------|
-| `nothing`       | ordinary (forward)               | ``A``                            |
-| real or complex | inverse with level shift `sigma` | ``(A - \\sigma I )^{-1}``        |
+!!! note
+    Although `tol` has a default value, the best choice depends strongly on the
+    matrix `A`. We recommend that users _always_ specify a value for `tol`
+    which suits their specific needs.
 
-**note**
+    For details of how the errors in the computed eigenvalues are estimated, see:
 
-Although `tol` has a default value, the best choice depends strongly on the
-matrix `A`. We recommend that users _always_ specify a value for `tol` which
-suits their specific needs.
-
-For details of how the errors in the computed eigenvalues are estimated, see:
-
-* B. N. Parlett, "The Symmetric Eigenvalue Problem", SIAM: Philadelphia, 2/e
-  (1998), Ch. 13.2, "Accessing Accuracy in Lanczos Problems", pp. 290-292 ff.
-* R. B. Lehoucq and D. C. Sorensen, "Deflation Techniques for an Implicitly
-  Restarted Arnoldi Iteration", SIAM Journal on Matrix Analysis and
-  Applications (1996), 17(4), 789–821.  doi:10.1137/S0895479895281484
+    * B. N. Parlett, "The Symmetric Eigenvalue Problem", SIAM: Philadelphia, 2/e
+      (1998), Ch. 13.2, "Accessing Accuracy in Lanczos Problems", pp. 290-292 ff.
+    * R. B. Lehoucq and D. C. Sorensen, "Deflation Techniques for an Implicitly
+      Restarted Arnoldi Iteration", SIAM Journal on Matrix Analysis and
+      Applications (1996), 17(4), 789–821.  doi:10.1137/S0895479895281484
 """
 eigs(A; kwargs...) = eigs(A, I; kwargs...)
 eigs{T<:BlasFloat}(A::AbstractMatrix{T}, ::UniformScaling; kwargs...) = _eigs(A, I; kwargs...)

--- a/base/markdown/Common/Common.jl
+++ b/base/markdown/Common/Common.jl
@@ -3,7 +3,7 @@
 include("block.jl")
 include("inline.jl")
 
-@flavor common [list, indentcode, blockquote, hashheader, horizontalrule,
+@flavor common [list, indentcode, blockquote, admonition, hashheader, horizontalrule,
                 paragraph,
 
                 linebreak, escapes, inline_code,

--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -58,7 +58,7 @@ function github_paragraph(stream::IO, md::MD)
     return true
 end
 
-@flavor github [list, indentcode, blockquote, fencedcode, hashheader,
+@flavor github [list, indentcode, blockquote, admonition, fencedcode, hashheader,
                 github_table, github_paragraph,
 
                 linebreak, escapes, en_dash, inline_code, asterisk_bold,

--- a/base/markdown/Julia/Julia.jl
+++ b/base/markdown/Julia/Julia.jl
@@ -8,7 +8,7 @@
 include("interp.jl")
 
 @flavor julia [blocktex, blockinterp, hashheader, list, indentcode, fencedcode,
-               blockquote, github_table, horizontalrule, setextheader, paragraph,
+               blockquote, admonition, github_table, horizontalrule, setextheader, paragraph,
 
                linebreak, escapes, tex, interp, en_dash, inline_code,
                asterisk_bold, asterisk_italic, image, footnote, link]

--- a/base/markdown/render/html.jl
+++ b/base/markdown/render/html.jl
@@ -88,6 +88,15 @@ function html(io::IO, md::BlockQuote)
     end
 end
 
+function html(io::IO, md::Admonition)
+    withtag(io, :div, :class => "admonition $(md.category)") do
+        withtag(io, :p, :class => "admonition-title") do
+            print(io, md.title)
+        end
+        html(io, md.content)
+    end
+end
+
 function html(io::IO, md::List)
     withtag(io, md.ordered ? :ol : :ul) do
         for item in md.items

--- a/base/markdown/render/latex.jl
+++ b/base/markdown/render/latex.jl
@@ -58,6 +58,16 @@ function latex(io::IO, md::BlockQuote)
     end
 end
 
+function latex(io::IO, md::Admonition)
+    wrapblock(io, "quote") do
+        wrapinline(io, "textbf") do
+            print(io, md.category)
+        end
+        println(io, "\n\n", md.title, "\n")
+        latex(io, md.content)
+    end
+end
+
 function latex(io::IO, md::List)
     env = md.ordered ? "enumerate" : "itemize"
     wrapblock(io, env) do

--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -49,6 +49,16 @@ function plain(io::IO, q::BlockQuote)
     println(io)
 end
 
+function plain(io::IO, md::Admonition)
+    s = sprint(buf -> plain(buf, md.content))
+    title = md.title == ucfirst(md.category) ? "" : " \"$(md.title)\""
+    println(io, "!!! ", md.category, title)
+    for line in split(rstrip(s), "\n")
+        println(io, isempty(line) ? "" : "    ", line)
+    end
+    println(io)
+end
+
 function plain(io::IO, md::HorizontalRule)
     println(io, "-" ^ 3)
 end

--- a/base/markdown/render/rst.jl
+++ b/base/markdown/render/rst.jl
@@ -52,6 +52,16 @@ function rst(io::IO, q::BlockQuote)
     println(io)
 end
 
+function rst(io::IO, md::Admonition)
+    s = sprint(buf -> rst(buf, md.content))
+    title = md.title == ucfirst(md.category) ? "" : md.title
+    println(io, ".. ", md.category, "::", isempty(title) ? "" : " $title")
+    for line in split(rstrip(s), "\n")
+        println(io, isempty(line) ? "" : "   ", line)
+    end
+    println(io)
+end
+
 function rst(io::IO, md::HorizontalRule)
     println(io, "–" ^ 5)
 end

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -30,6 +30,16 @@ function term(io::IO, md::BlockQuote, columns)
     end
 end
 
+function term(io::IO, md::Admonition, columns)
+    print(io, " "^margin, "| ")
+    with_output_format(:bold, print, io, isempty(md.title) ? md.category : md.title)
+    println(io, "\n", " "^margin, "|")
+    s = sprint(io -> term(io, md.content, columns - 10))
+    for line in split(rstrip(s), "\n")
+        println(io, " "^margin, "|", line)
+    end
+end
+
 function term(io::IO, md::List, columns)
     for (i, point) in enumerate(md.items)
         print(io, " "^2margin, md.ordered ? "$i. " : "•  ")

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1264,12 +1264,11 @@ factorization `F`. `A` must be a `SparseMatrixCSC`, `Symmetric{SparseMatrixCSC}`
 or `Hermitian{SparseMatrixCSC}`. Note that even if `A` doesn't
 have the type tag, it must still be symmetric or Hermitian.
 
-** Note **
-
-This method uses the CHOLMOD library from SuiteSparse, which only supports
-doubles or complex doubles. Input matrices not of those element types will be
-converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
-appropriate.
+!!! note
+    This method uses the CHOLMOD library from SuiteSparse, which only supports
+    doubles or complex doubles. Input matrices not of those element types will
+    be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}`
+    as appropriate.
 """
 cholfact!{T<:Real}(F::Factor, A::Union{SparseMatrixCSC{T},
         SparseMatrixCSC{Complex{T}},
@@ -1319,15 +1318,14 @@ Setting optional `shift` keyword argument computes the factorization of
 it should be a permutation of `1:size(A,1)` giving the ordering to use
 (instead of CHOLMOD's default AMD ordering).
 
-** Note **
+!!! note
+    This method uses the CHOLMOD library from SuiteSparse, which only supports
+    doubles or complex doubles. Input matrices not of those element types will
+    be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}`
+    as appropriate.
 
-This method uses the CHOLMOD library from SuiteSparse, which only supports
-doubles or complex doubles. Input matrices not of those element types will be
-converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
-appropriate.
-
-Many other functions from CHOLMOD are wrapped but not exported from the
-`Base.SparseArrays.CHOLMOD` module.
+    Many other functions from CHOLMOD are wrapped but not exported from the
+    `Base.SparseArrays.CHOLMOD` module.
 """
 cholfact{T<:Real}(A::Union{SparseMatrixCSC{T}, SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
@@ -1361,12 +1359,11 @@ Compute the ``LDL'`` factorization of `A`, reusing the symbolic factorization `F
 `Hermitian{SparseMatrixCSC}`. Note that even if `A` doesn't
 have the type tag, it must still be symmetric or Hermitian.
 
-** Note **
-
-This method uses the CHOLMOD library from SuiteSparse, which only supports
-doubles or complex doubles. Input matrices not of those element types will be
-converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
-appropriate.
+!!! note
+    This method uses the CHOLMOD library from SuiteSparse, which only supports
+    doubles or complex doubles. Input matrices not of those element types will
+    be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}`
+    as appropriate.
 """
 ldltfact!{T<:Real}(F::Factor, A::Union{SparseMatrixCSC{T},
     SparseMatrixCSC{Complex{T}},
@@ -1417,15 +1414,14 @@ Setting optional `shift` keyword argument computes the factorization of
 it should be a permutation of `1:size(A,1)` giving the ordering to use
 (instead of CHOLMOD's default AMD ordering).
 
-** Note **
+!!! note
+    This method uses the CHOLMOD library from SuiteSparse, which only supports
+    doubles or complex doubles. Input matrices not of those element types will
+    be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}`
+    as appropriate.
 
-This method uses the CHOLMOD library from SuiteSparse, which only supports
-doubles or complex doubles. Input matrices not of those element types will be
-converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as
-appropriate.
-
-Many other functions from CHOLMOD are wrapped but not exported from the
-`Base.SparseArrays.CHOLMOD` module.
+    Many other functions from CHOLMOD are wrapped but not exported from the
+    `Base.SparseArrays.CHOLMOD` module.
 """
 ldltfact{T<:Real}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -65,9 +65,9 @@
 
    Creates a symbolic link to ``target`` with the name ``link``\ .
 
-   **note**
+   .. note::
+      This function raises an error under operating systems that do not support soft symbolic links, such as Windows XP.
 
-   This function raises an error under operating systems that do not support soft symbolic links, such as Windows XP.
 
 .. function:: readlink(path) -> AbstractString
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -326,11 +326,11 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Setting optional ``shift`` keyword argument computes the factorization of ``A+shift*I`` instead of ``A``\ . If the ``perm`` argument is nonempty, it should be a permutation of ``1:size(A,1)`` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
-   ** Note **
+   .. note::
+      This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
-   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
+      Many other functions from CHOLMOD are wrapped but not exported from the ``Base.SparseArrays.CHOLMOD`` module.
 
-   Many other functions from CHOLMOD are wrapped but not exported from the ``Base.SparseArrays.CHOLMOD`` module.
 
 .. function:: cholfact!(F::Factor, A; shift = 0.0) -> CHOLMOD.Factor
 
@@ -338,9 +338,9 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the Cholesky (:math:`LL'`\ ) factorization of ``A``\ , reusing the symbolic factorization ``F``\ . ``A`` must be a ``SparseMatrixCSC``\ , ``Symmetric{SparseMatrixCSC}``\ , or ``Hermitian{SparseMatrixCSC}``\ . Note that even if ``A`` doesn't have the type tag, it must still be symmetric or Hermitian.
 
-   ** Note **
+   .. note::
+      This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
-   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
 .. function:: cholfact!(A, uplo::Symbol, Val{false}) -> Cholesky
 
@@ -396,11 +396,11 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Setting optional ``shift`` keyword argument computes the factorization of ``A+shift*I`` instead of ``A``\ . If the ``perm`` argument is nonempty, it should be a permutation of ``1:size(A,1)`` giving the ordering to use (instead of CHOLMOD's default AMD ordering).
 
-   ** Note **
+   .. note::
+      This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
-   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
+      Many other functions from CHOLMOD are wrapped but not exported from the ``Base.SparseArrays.CHOLMOD`` module.
 
-   Many other functions from CHOLMOD are wrapped but not exported from the ``Base.SparseArrays.CHOLMOD`` module.
 
 .. function:: ldltfact!(F::Factor, A; shift = 0.0) -> CHOLMOD.Factor
 
@@ -408,9 +408,9 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the :math:`LDL'` factorization of ``A``\ , reusing the symbolic factorization ``F``\ . ``A`` must be a ``SparseMatrixCSC``\ , ``Symmetric{SparseMatrixCSC}``\ , or ``Hermitian{SparseMatrixCSC}``\ . Note that even if ``A`` doesn't have the type tag, it must still be symmetric or Hermitian.
 
-   ** Note **
+   .. note::
+      This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
-   This method uses the CHOLMOD library from SuiteSparse, which only supports doubles or complex doubles. Input matrices not of those element types will be converted to ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
 .. function:: ldltfact!(::SymTridiagonal) -> LDLt
 
@@ -498,29 +498,29 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Multiplication with respect to either thin or full ``Q`` is allowed, i.e. both ``F[:Q]*F[:R]`` and ``F[:Q]*A`` are supported. A ``Q`` matrix can be converted into a regular matrix with :func:`full` which has a named argument ``thin``\ .
 
-   **note**
+   .. note::
+      ``qrfact`` returns multiple types because LAPACK uses several representations that minimize the memory storage requirements of products of Householder elementary reflectors, so that the ``Q`` and ``R`` matrices can be stored compactly rather as two separate dense matrices.
 
-   ``qrfact`` returns multiple types because LAPACK uses several representations that minimize the memory storage requirements of products of Householder elementary reflectors, so that the ``Q`` and ``R`` matrices can be stored compactly rather as two separate dense matrices.
+      The data contained in ``QR`` or ``QRPivoted`` can be used to construct the ``QRPackedQ`` type, which is a compact representation of the rotation matrix:
 
-   The data contained in ``QR`` or ``QRPivoted`` can be used to construct the ``QRPackedQ`` type, which is a compact representation of the rotation matrix:
+      .. math::
 
-   .. math::
+          Q = \prod_{i=1}^{\min(m,n)} (I - \tau_i v_i v_i^T)
 
-       Q = \prod_{i=1}^{\min(m,n)} (I - \tau_i v_i v_i^T)
+      where :math:`\tau_i` is the scale factor and :math:`v_i` is the projection vector associated with the :math:`i^{th}` Householder elementary reflector.
 
-   where :math:`\tau_i` is the scale factor and :math:`v_i` is the projection vector associated with the :math:`i^{th}` Householder elementary reflector.
+      The data contained in ``QRCompactWY`` can be used to construct the ``QRCompactWYQ`` type, which is a compact representation of the rotation matrix
 
-   The data contained in ``QRCompactWY`` can be used to construct the ``QRCompactWYQ`` type, which is a compact representation of the rotation matrix
+      .. math::
 
-   .. math::
+          Q = I + Y T Y^T
 
-       Q = I + Y T Y^T
+      where ``Y`` is :math:`m \times r` lower trapezoidal and ``T`` is :math:`r \times r` upper triangular. The *compact WY* representation [Schreiber1989]_ is not to be confused with the older, *WY* representation [Bischof1987]_. (The LAPACK documentation uses ``V`` in lieu of ``Y``\ .)
 
-   where ``Y`` is :math:`m \times r` lower trapezoidal and ``T`` is :math:`r \times r` upper triangular. The *compact WY* representation [Schreiber1989]_ is not to be confused with the older, *WY* representation [Bischof1987]_. (The LAPACK documentation uses ``V`` in lieu of ``Y``\ .)
+      .. [Bischof1987] C Bischof and C Van Loan, "The WY representation for products of Householder matrices", SIAM J Sci Stat Comput 8 (1987), s2-s13. `doi:10.1137/0908009 <http://dx.doi.org/10.1137/0908009>`_
 
-   .. [Bischof1987] C Bischof and C Van Loan, "The WY representation for products of Householder matrices", SIAM J Sci Stat Comput 8 (1987), s2-s13. `doi:10.1137/0908009 <http://dx.doi.org/10.1137/0908009>`_
+      .. [Schreiber1989] R Schreiber and C Van Loan, "A storage-efficient WY representation for products of Householder transformations", SIAM J Sci Stat Comput 10 (1989), 53-57. `doi:10.1137/0910005 <http://dx.doi.org/10.1137/0910005>`_
 
-   .. [Schreiber1989] R Schreiber and C Van Loan, "A storage-efficient WY representation for products of Householder transformations", SIAM J Sci Stat Comput 10 (1989), 53-57. `doi:10.1137/0910005 <http://dx.doi.org/10.1137/0910005>`_
 
 .. function:: qrfact(A) -> SPQR.Factorization
 
@@ -1337,26 +1337,26 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    ``eigs`` returns the ``nev`` requested eigenvalues in ``d``\ , the corresponding Ritz vectors ``v`` (only if ``ritzvec=true``\ ), the number of converged eigenvalues ``nconv``\ , the number of iterations ``niter`` and the number of matrix vector multiplications ``nmult``\ , as well as the final residual vector ``resid``\ .
 
-   **note**
+   .. note::
+      The ``sigma`` and ``which`` keywords interact: the description of eigenvalues searched for by ``which`` do _not_ necessarily refer to the eigenvalues of ``A``\ , but rather the linear operator constructed by the specification of the iteration mode implied by ``sigma``\ .
 
-   The ``sigma`` and ``which`` keywords interact: the description of eigenvalues searched for by ``which`` do _not_ necessarily refer to the eigenvalues of ``A``\ , but rather the linear operator constructed by the specification of the iteration mode implied by ``sigma``\ .
+      +-----------------+------------------------------------+------------------------------------+
+      | ``sigma``       | iteration mode                     | ``which`` refers to eigenvalues of |
+      +=================+====================================+====================================+
+      | ``nothing``     | ordinary (forward)                 | :math:`A`                          |
+      +-----------------+------------------------------------+------------------------------------+
+      | real or complex | inverse with level shift ``sigma`` | :math:`(A - \sigma I )^{-1}`       |
+      +-----------------+------------------------------------+------------------------------------+
 
-   +-----------------+------------------------------------+------------------------------------+
-   | ``sigma``       | iteration mode                     | ``which`` refers to eigenvalues of |
-   +=================+====================================+====================================+
-   | ``nothing``     | ordinary (forward)                 | :math:`A`                          |
-   +-----------------+------------------------------------+------------------------------------+
-   | real or complex | inverse with level shift ``sigma`` | :math:`(A - \sigma I )^{-1}`       |
-   +-----------------+------------------------------------+------------------------------------+
 
-   **note**
+   .. note::
+      Although ``tol`` has a default value, the best choice depends strongly on the matrix ``A``\ . We recommend that users _always_ specify a value for ``tol`` which suits their specific needs.
 
-   Although ``tol`` has a default value, the best choice depends strongly on the matrix ``A``\ . We recommend that users _always_ specify a value for ``tol`` which suits their specific needs.
+      For details of how the errors in the computed eigenvalues are estimated, see:
 
-   For details of how the errors in the computed eigenvalues are estimated, see:
+      * B. N. Parlett, "The Symmetric Eigenvalue Problem", SIAM: Philadelphia, 2/e   (1998), Ch. 13.2, "Accessing Accuracy in Lanczos Problems", pp. 290-292 ff.
+      * R. B. Lehoucq and D. C. Sorensen, "Deflation Techniques for an Implicitly   Restarted Arnoldi Iteration", SIAM Journal on Matrix Analysis and   Applications (1996), 17(4), 789–821.  doi:10.1137/S0895479895281484
 
-   * B. N. Parlett, "The Symmetric Eigenvalue Problem", SIAM: Philadelphia, 2/e   (1998), Ch. 13.2, "Accessing Accuracy in Lanczos Problems", pp. 290-292 ff.
-   * R. B. Lehoucq and D. C. Sorensen, "Deflation Techniques for an Implicitly   Restarted Arnoldi Iteration", SIAM Journal on Matrix Analysis and   Applications (1996), 17(4), 789–821.  doi:10.1137/S0895479895281484
 
 .. function:: eigs(A, B; nev=6, ncv=max(20,2*nev+1), which="LM", tol=0.0, maxiter=300, sigma=nothing, ritzvec=true, v0=zeros((0,))) -> (d,[v,],nconv,niter,nmult,resid)
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -993,23 +993,23 @@ Mathematical Functions
        julia> round(pi, 3, 2)
        3.125
 
-   **note**
+   .. note::
+      Rounding to specified digits in bases other than 2 can be inexact when operating on binary floating point numbers. For example, the ``Float64`` value represented by ``1.15`` is actually *less* than 1.15, yet will be rounded to 1.2.
 
-   Rounding to specified digits in bases other than 2 can be inexact when operating on binary floating point numbers. For example, the ``Float64`` value represented by ``1.15`` is actually *less* than 1.15, yet will be rounded to 1.2.
+      .. doctest::
 
-   .. doctest::
+          julia> x = 1.15
+          1.15
 
-       julia> x = 1.15
-       1.15
+          julia> @sprintf "%.20f" x
+          "1.14999999999999991118"
 
-       julia> @sprintf "%.20f" x
-       "1.14999999999999991118"
+          julia> x < 115//100
+          true
 
-       julia> x < 115//100
-       true
+          julia> round(x, 1)
+          1.2
 
-       julia> round(x, 1)
-       1.2
 
 .. data:: RoundingMode
 
@@ -1375,9 +1375,9 @@ Mathematical Functions
        julia> gcdx(240, 46)
        (2,-9,47)
 
-   **note**
+   .. note::
+      Bézout coefficients are *not* uniquely defined. ``gcdx`` returns the minimal Bézout coefficients that are computed by the extended Euclid algorithm. (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients ``u`` and ``v`` are minimal in the sense that :math:`|u| < |\frac y d` and :math:`|v| < |\frac x d`\ . Furthermore, the signs of ``u`` and ``v`` are chosen so that ``d`` is positive.
 
-   Bézout coefficients are *not* uniquely defined. ``gcdx`` returns the minimal Bézout coefficients that are computed by the extended Euclid algorithm. (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients ``u`` and ``v`` are minimal in the sense that :math:`|u| < |\frac y d` and :math:`|v| < |\frac x d`\ . Furthermore, the signs of ``u`` and ``v`` are chosen so that ``d`` is positive.
 
 .. function:: ispow2(n) -> Bool
 

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -500,3 +500,4 @@
    .. Docstring generated from Julia source
 
    Create a string from the address of a NUL-terminated UTF-32 string. A copy is made; the pointer can be safely freed. If ``length`` is specified, the string does not have to be NUL-terminated.
+

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -463,3 +463,219 @@ let t_1 = "`code` ``math`` ```code``` ````math```` `````code`````",
         LaTeX("math at end of string"),
     ]))
 end
+
+# Admonitions.
+
+let t_1 =
+        """
+        # Foo
+
+        !!! note
+
+        !!! warning "custom title"
+
+        ## Bar
+
+        !!! danger ""
+
+        !!!
+        """,
+    t_2 =
+        """
+        !!! note
+            foo bar baz
+
+        !!! warning "custom title"
+            - foo
+            - bar
+            - baz
+
+            foo bar baz
+
+        !!! danger ""
+
+            ```
+            foo
+            ```
+
+                bar
+
+            # baz
+        """,
+    m_1 = Markdown.parse(t_1),
+    m_2 = Markdown.parse(t_2)
+
+    # Content Tests.
+
+    @test isa(m_1.content[2], Markdown.Admonition)
+    @test m_1.content[2].category == "note"
+    @test m_1.content[2].title == "Note"
+    @test m_1.content[2].content == []
+
+    @test isa(m_1.content[3], Markdown.Admonition)
+    @test m_1.content[3].category == "warning"
+    @test m_1.content[3].title == "custom title"
+    @test m_1.content[3].content == []
+
+    @test isa(m_1.content[5], Markdown.Admonition)
+    @test m_1.content[5].category == "danger"
+    @test m_1.content[5].title == ""
+    @test m_1.content[5].content == []
+
+    @test isa(m_1.content[6], Markdown.Paragraph)
+
+    @test isa(m_2.content[1], Markdown.Admonition)
+    @test m_2.content[1].category == "note"
+    @test m_2.content[1].title == "Note"
+    @test isa(m_2.content[1].content[1], Markdown.Paragraph)
+
+    @test isa(m_2.content[2], Markdown.Admonition)
+    @test m_2.content[2].category == "warning"
+    @test m_2.content[2].title == "custom title"
+    @test isa(m_2.content[2].content[1], Markdown.List)
+    @test isa(m_2.content[2].content[2], Markdown.Paragraph)
+
+    @test isa(m_2.content[3], Markdown.Admonition)
+    @test m_2.content[3].category == "danger"
+    @test m_2.content[3].title == ""
+    @test isa(m_2.content[3].content[1], Markdown.Code)
+    @test isa(m_2.content[3].content[2], Markdown.Code)
+    @test isa(m_2.content[3].content[3], Markdown.Header{1})
+
+    # Rendering Tests.
+
+    let out = Markdown.plain(m_1),
+        expected =
+            """
+            # Foo
+
+            !!! note
+            \n\n
+            !!! warning "custom title"
+            \n\n
+            ## Bar
+
+            !!! danger ""
+            \n\n
+            !!!
+            """
+        @test out == expected
+    end
+    let out = Markdown.rst(m_1),
+        expected =
+            """
+            Foo
+            ***
+            \n
+            .. note::
+            \n\n
+            .. warning:: custom title
+            \n\n
+            Bar
+            ===
+            \n
+            .. danger::
+            \n\n
+            !!!
+            """
+        @test out == expected
+    end
+    let out = Markdown.latex(m_1),
+        expected =
+            """
+            \\section{Foo}
+            \\begin{quote}
+            \\textbf{note}
+
+            Note
+
+            \\end{quote}
+            \\begin{quote}
+            \\textbf{warning}
+
+            custom title
+
+            \\end{quote}
+            \\subsection{Bar}
+            \\begin{quote}
+            \\textbf{danger}
+            \n\n
+            \\end{quote}
+            !!!
+            """
+        @test out == expected
+    end
+    let out = Markdown.html(m_1),
+        expected =
+            """
+            <h1>Foo</h1>
+            <div class="admonition note"><p class="admonition-title">Note</p></div>
+            <div class="admonition warning"><p class="admonition-title">custom title</p></div>
+            <h2>Bar</h2>
+            <div class="admonition danger"><p class="admonition-title"></p></div>
+            <p>&#33;&#33;&#33;</p>
+            """
+        @test out == expected
+    end
+
+    let out = Markdown.plain(m_2),
+        expected =
+            """
+            !!! note
+                foo bar baz
+
+
+            !!! warning "custom title"
+                  * foo
+                  * bar
+                  * baz
+
+                foo bar baz
+
+
+            !!! danger ""
+                ```
+                foo
+                ```
+
+                ```
+                bar
+                ```
+
+                # baz
+
+            """
+        @test out == expected
+    end
+    let out = Markdown.rst(m_2),
+        expected =
+            """
+            .. note::
+               foo bar baz
+
+
+            .. warning:: custom title
+               * foo
+               * bar
+               * baz
+
+               foo bar baz
+
+
+            .. danger::
+               .. code-block:: julia
+
+                   foo
+
+               .. code-block:: julia
+
+                   bar
+
+               baz
+               ***
+
+            """
+        @test out == expected
+    end
+end
+


### PR DESCRIPTION
As mentioned in #17269.

Syntax borrowed from https://pythonhosted.org/Markdown/extensions/admonition.html:

```
!!! {category} "{optional title}"

    {nested markdown blocks}
```

`category` can be any single lower case word. When no `title` is provided the title is taken from the `category`, but with the first letter capitalised. Any markdown syntax can be nested within an
admonition block.

I've also replaced all the occurrences of `**notes**` in the docs with proper `!!! notes` blocks, which appear to render nicely again like they did in `0.4`. Additionally the modified docstrings from `helpdb/Base.jl` have been moved inline.

~~Still to do: write some tests.~~
