### PR TITLE
MSVC compatibility fixes

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -992,7 +992,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
     uint64_t max_size = max_offset >> 1;
 
     uint32_t nfields = jl_svec_len(st->types);
-    jl_fielddesc32_t desc[nfields];
+    jl_fielddesc32_t* desc = (jl_fielddesc32_t*) alloca(nfields * sizeof(jl_fielddesc32_t));
     int haspadding = 0;
 
     for (size_t i = 0; i < nfields; i++) {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -143,7 +143,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty);
     (__builtin_constant_p(sz) ? jl_gc_alloc_(ptls, sz, ty) :    \
      (jl_gc_alloc)(ptls, sz, ty))
 #else
-#  define jl_gc_alloc(ptls, sz) jl_gc_alloc_(ptls, sz, ty)
+#  define jl_gc_alloc(ptls, sz, ty) jl_gc_alloc_(ptls, sz, ty)
 #endif
 
 #define jl_buff_tag ((uintptr_t)0x4eade800)


### PR DESCRIPTION
add missing third argument to jl_gc_alloc (f5b224db55c44f0479dca4e3768dbf8cc37ff6d0)

use alloca instead of variable length array (67e5f3d0ee4eb0c52d227fdbb11f1e8cde177258)
