### PR TITLE
docs: remove direct calls to require

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -282,7 +282,7 @@ The function ``count_heads`` simply adds together ``n`` random bits.
 Here is how we can perform some trials on two machines, and add together the
 results::
 
-    require("count_heads")
+    @everywhere include("count_heads.jl")
 
     a = @spawn count_heads(100000000)
     b = @spawn count_heads(100000000)

--- a/doc/manual/workflow-tips.rst
+++ b/doc/manual/workflow-tips.rst
@@ -75,7 +75,7 @@ issuing the command::
 
 If you further add the following to your ``.juliarc.jl`` file ::
 
-    isinteractive() && isfile("_init.jl") && require("_init.jl")
+    isfile("_init.jl") && include(joinpath(pwd(), "_init.jl"))
 
 then calling ``julia`` from that directory will run the initialization
 code without the additional command line argument.


### PR DESCRIPTION
Regarding the changes on _workflow-tips_:
- `isinteractive()` evaluates to false
- a call to `include("file.jl")` on `.juliarc.jl` looks for files at the user's home folder, so I added a call to `pwd()`.
