### PR TITLE
Don't touch files in the srccache.

### DIFF
--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -28,9 +28,6 @@ UV_FLAGS := --disable-shared $(UV_MFLAGS)
 endif
 
 $(BUILDDIR)/$(LIBUV_SRC_DIR)/config.status: $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/configure
-	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/aclocal.m4 # touch a few files to prevent autogen from getting called
-	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/Makefile.in
-	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/configure
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$< --with-pic $(CONFIGURE_COMMON) $(UV_FLAGS)


### PR DESCRIPTION
Touching files in the `srccache` messes up out-of-tree builds when switching builds:

```
$ make -C build_a
$ make -C build_b
--> touches libuv files in srccache
$ make -C build_a
--> rebuilds libuv, and as a consequence all of julia
```

@vtjnash you added these commands as part of 217ce61bc02eaa28b8bf9cfafc9ff77d3bd3d8f5, but are they still necessary? I couldn't trigger a run of `autogen`.
