### PR TITLE
fallback anticodegen compile to use interpreter, rather than error

### DIFF
--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -14,8 +14,6 @@ void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t
 int32_t jl_get_llvm_gv(jl_value_t *p) UNAVAILABLE
 void jl_write_malloc_log(void) UNAVAILABLE
 void jl_write_coverage_data(void) UNAVAILABLE
-void jl_generate_fptr(jl_lambda_info_t *li) UNAVAILABLE
-void jl_compile_linfo(jl_lambda_info_t *li) UNAVAILABLE
 
 JL_DLLEXPORT void jl_clear_malloc_data(void) UNAVAILABLE
 JL_DLLEXPORT void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
@@ -47,4 +45,13 @@ jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
 void jl_register_fptrs(uint64_t sysimage_base, void **fptrs, jl_lambda_info_t **linfos, size_t n)
 {
     (void)sysimage_base; (void)fptrs; (void)linfos; (void)n;
+}
+
+void jl_compile_linfo(jl_lambda_info_t *li) { }
+
+jl_value_t *jl_interpret_call(jl_lambda_info_t *lam, jl_value_t **args, uint32_t nargs);
+void jl_generate_fptr(jl_lambda_info_t *li)
+{
+    li->fptr = (jl_fptr_t)&jl_interpret_call;
+    li->jlcall_api = 3;
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -168,6 +168,7 @@ STATIC_INLINE int jl_array_ndimwords(uint32_t ndims)
 }
 
 typedef struct _jl_datatype_t jl_tupletype_t;
+struct _jl_lambda_info_t;
 
 // TypeMap is an implicitly defined type
 // that can consist of any of the following nodes:
@@ -187,6 +188,7 @@ union jl_typemap_t {
 // This defines the default ABI used by compiled julia functions.
 typedef jl_value_t *(*jl_fptr_t)(jl_value_t*, jl_value_t**, uint32_t);
 typedef jl_value_t *(*jl_fptr_sparam_t)(jl_svec_t*, jl_value_t*, jl_value_t**, uint32_t);
+typedef jl_value_t *(*jl_fptr_linfo_t)(struct _jl_lambda_info_t*, jl_value_t**, uint32_t, jl_svec_t*);
 
 typedef struct _jl_llvm_functions_t {
     void *functionObject;     // jlcall llvm Function

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -174,6 +174,8 @@ STATIC_INLINE jl_value_t *jl_call_method_internal(jl_lambda_info_t *meth, jl_val
         return ((jl_fptr_sparam_t)mfptr->fptr)(meth->sparam_vals, args[0], &args[1], nargs-1);
     else if (mfptr->jlcall_api == 2)
         return meth->constval;
+    else if (mfptr->jlcall_api == 3)
+        return ((jl_fptr_linfo_t)mfptr->fptr)(mfptr, &args[0], nargs, meth->sparam_vals);
     else
         abort();
 }


### PR DESCRIPTION
Makes anticodegen work a bit better, so that it can handle new code
