### PR TITLE
cut down number of Tuple types a bit

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2175,6 +2175,10 @@ static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **i
     if (istuple && ntp > 0 && jl_is_vararg_type(iparams[ntp - 1])) {
         // normalize Tuple{..., Vararg{Int, 3}} to Tuple{..., Int, Int, Int}
         jl_value_t *va = iparams[ntp - 1];
+        // return same `Tuple` object for types equal to it
+        if (ntp == 1 && jl_tparam0(va) == (jl_value_t*)jl_any_type &&
+            jl_tparam1(va) == jl_tparam1(jl_tparam0(jl_anytuple_type)))
+            return (jl_value_t*)jl_anytuple_type;
         if (jl_is_long(jl_tparam1(va))) {
             ssize_t nt = jl_unbox_long(jl_tparam1(va));
             if (nt < 0)


### PR DESCRIPTION
The system image contains a large number of Tuple types (~60000). This cuts down a bit by (1) removing unused types from the cache (~ 2000), (2) avoiding making copies of `Tuple` (there are only a couple hundred of them, but they are very easy to avoid so why not).
