### PR TITLE
Noteworthy differences: add two MATLAB/Julia idioms

### DIFF
--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -99,7 +99,18 @@ some noteworthy differences that may trip up Julia users accustomed to MATLAB:
 - Julia's ``type``\ s do not support dynamically adding fields at runtime,
   unlike MATLAB's ``class``\ es. Instead, use a :obj:`Dict`.
 - In Julia each module has its own global scope/namespace, whereas in
-  Matlab there is just one global scope.
+  MATLAB there is just one global scope.
+- In MATLAB, an idiomatic way to remove unwanted values is to use logical
+  indexing, like in the expression ``x(x>3)`` or in the statement
+  ``x(x>3) = []`` to modify ``x`` in-place. In contrast, Julia provides the
+  higher order functions :func:`filter` and a :func:`filter!`, allowing users
+  to write ``filter(z->z>3, x)`` and ``filter!(z->z>3, x)`` as alternatives to
+  the corresponding transliterations ``x[x.>3]`` and ``x = x[x.>3]``. Using
+  :func:`filter!` reduces the use of temporary arrays.
+- The analogue of extracting (or "dereferencing") all elements of a cell array,
+  e.g. in ``vertcat(A{:})`` in MATLAB, is written using the splat operator in
+  Julia, e.g. as ``vcat(A...)``.
+
 
 Noteworthy differences from R
 -----------------------------
@@ -221,6 +232,13 @@ noteworthy differences:
 - Julia does not support the ``NULL`` type.
 - Julia lacks the equivalent of R's ``assign`` or ``get``.
 - In Julia, ``return`` does not require parentheses.
+- In R, an idiomatic way to remove unwanted values is to use logical indexing,
+  like in the expression ``x[x>3]`` or in the statement ``x = x[x>3]`` to
+  modify ``x`` in-place. In contrast, Julia provides the higher order functions
+  :func:`filter` and a :func:`filter!`, allowing users to write
+  ``filter(z->z>3, x)`` and ``filter!(z->z>3, x)`` as alternatives to the
+  corresponding transliterations ``x[x.>3]`` and ``x = x[x.>3]``. Using
+  :func:`filter!` reduces the use of temporary arrays.
 
 
 Noteworthy differences from Python


### PR DESCRIPTION
Briefly describe two MATLAB idioms from @dgleich, and their Julia equivalents.

The first one is logical indexing of an array with a logical vector involving the array itself, like in `x(x>3)`. The recommendation is to use use `filter!` instead.

The second one is to describe extracting or "dereferencing" a cell array, an operation which in Julia uses splatting.
