### PR TITLE
fix LLVM assertion failure on VecElement of aggregate

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1727,13 +1727,12 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                     if (init_as_value) {
                         if (lt->isVectorTy())
                             strct = builder.CreateInsertElement(strct, fval, ConstantInt::get(T_int32,idx));
+                        else if (jl_is_vecelement_type(ty))
+                            strct = fval;  // VecElement type comes unwrapped in LLVM.
                         else if (lt->isAggregateType())
                             strct = builder.CreateInsertValue(strct, fval, ArrayRef<unsigned>(&idx,1));
-                        else {
-                            // Must be a VecElement type, which comes unwrapped in LLVM.
-                            assert(jl_is_vecelement_type(ty));
-                            strct = fval;
-                        }
+                        else
+                            assert(false);
                     }
                 }
                 idx++;

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -63,3 +63,5 @@ a = Vector{Gr{2,Float64}}(2)
 a[2] = Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
 a[1] = Gr(5.0, Bunch((VecElement(6.0), VecElement(7.0))), 8.0)
 @test a[2] == Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
+
+@test isa(VecElement((1,2)), VecElement{Tuple{Int,Int}})


### PR DESCRIPTION
I encountered this while rebasing #16622:

```
julia> VecElement((1,2))
julia: /home/jeff/src/julia-master/julia/deps/srccache/llvm-3.7.1/lib/IR/Instructions.cpp:1521: void llvm::InsertValueInst::init(llvm::Value*, llvm::Value*, llvm::ArrayRef<unsigned int>, const llvm::Twine&): Assertion `ExtractValueInst::getIndexedType(Agg->getType(), Idxs) == Val->getType() && "Inserted value must match indexed type!"' failed.
```

Now, perhaps one is not supposed to make a VecElement containing a struct-like type, but where this _actually_ arose was during `jl_compile_specializations`, which decided it needed to specialize the VecElement constructor for the disturbing type `VecElement{Base.##60#61{Int64, Int64}}`, which appears to be a VecElement of a closure. How that type arose is a future research question...
