### PR TITLE
Operations between Float16 and Integer now return Float16

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,28 @@
+Julia v0.6.0 Release Notes
+==========================
+
+New language features
+---------------------
+
+Language changes
+----------------
+
+Breaking changes
+----------------
+
+This section lists changes that do not have deprecation warnings.
+
+  * Operations between `Float16` and `Integers` now return `Float16` instead of `Float32`. ([#17261])
+
+Library improvements
+--------------------
+
+Compiler/Runtime improvements
+-----------------------------
+
+Deprecated or removed
+---------------------
+
 Julia v0.5.0 Release Notes
 ==========================
 
@@ -159,8 +184,6 @@ This section lists changes that do not have deprecation warnings.
 
   * `map` on a dictionary now expects a function that expects and returns a `Pair`.
     The result is now another dictionary instead of an array ([#16622]).
-
-  * Operations between `Float16` and `Integers` now return `Float16` instead of `Float32`. ([#17261])
 
 Library improvements
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -160,6 +160,8 @@ This section lists changes that do not have deprecation warnings.
   * `map` on a dictionary now expects a function that expects and returns a `Pair`.
     The result is now another dictionary instead of an array ([#16622]).
 
+  * Operations between `Float16` and `Integers` now return `Float16` instead of `Float32`. ([#17261])
+
 Library improvements
 --------------------
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -45,7 +45,7 @@ const NaN = NaN64
 ## conversions to floating-point ##
 convert(::Type{Float16}, x::Integer) = convert(Float16, convert(Float32,x))
 for t in (Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128)
-    @eval promote_rule(::Type{Float16}, ::Type{$t}) = Float32
+    @eval promote_rule(::Type{Float16}, ::Type{$t}) = Float16
 end
 promote_rule(::Type{Float16}, ::Type{Bool}) = Float16
 

--- a/base/float16.jl
+++ b/base/float16.jl
@@ -135,6 +135,7 @@ abs(x::Float16) = reinterpret(Float16, reinterpret(UInt16,x) & 0x7fff)
 for op in (:+,:-,:*,:/,:\,:^)
     @eval ($op)(a::Float16, b::Float16) = Float16(($op)(Float32(a), Float32(b)))
 end
+
 function fma(a::Float16, b::Float16, c::Float16)
     Float16(fma(Float32(a), Float32(b), Float32(c)))
 end

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -451,7 +451,6 @@ Compute the middle of a scalar value, which is equivalent to `x` itself, but of 
 # Specialized functions for real types allow for improved performance
 middle(x::Union{Bool,Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128}) = Float64(x)
 middle(x::AbstractFloat) = x
-middle(x::Float16) = Float32(x)
 middle(x::Real) = (x + zero(x)) / 1
 
 """

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -63,10 +63,10 @@ g = Float16(1.)
 @test f^g === Float16(2f0)
 @test f^-g === Float16(0.5f0)
 
-@test f + 2 === Float32(4f0)
-@test f - 2 === Float32(0f0)
-@test f*2 === Float32(4f0)
-@test f/2 === Float32(1f0)
+@test f + 2 === Float16(4f0)
+@test f - 2 === Float16(0f0)
+@test f*2 === Float16(4f0)
+@test f/2 === Float16(1f0)
 @test f + 2. === 4.
 @test f - 2. === 0.
 @test f*2. === 4.

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -120,11 +120,9 @@ end
 let eps = 1//BigInt(2)^7, one_eps = 1+eps,
     eps16 = Float16(Float32(eps)), one_eps16 = Float16(Float32(one_eps))
     @test eps16 == Float16(Float32(eps))
-    # Currently broken in Julia -- enable when "rationalize" is fixed;
-    # see <https://github.com/JuliaLang/julia/issues/9897>
-    # @test rationalize(BigInt, eps16, tol=0) == eps
+    @test rationalize(BigInt, eps16, tol=0) == eps
     @test one_eps16 == Float16(Float32(one_eps))
-    # @test rationalize(BigInt, one_eps16, tol=0) == one_eps
+    @test rationalize(BigInt, one_eps16, tol=0) == one_eps
     @test one_eps16 * one_eps16 - 1 != Float16(Float32(one_eps * one_eps - 1))
     @test (fma(one_eps16, one_eps16, -1) ==
            Float16(Float32(one_eps * one_eps - 1)))


### PR DESCRIPTION
Previously we would promote to Float32 leading to subtle type
instabilities when Float16 was used for computations instead of
a pure data-storage format.

Fixes #17261 
