### PR TITLE
fusion of nested f.(args) calls into a single broadcast call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,8 @@ New language features
   * Generators and comprehensions support filtering using `if` ([#550]) and nested
     iteration using multiple `for` keywords ([#4867]).
 
-  * Broadcasting syntax: ``f.(args...)`` is equivalent to ``broadcast(f, args...)`` ([#15032]).
+  * Broadcasting syntax: ``f.(args...)`` is equivalent to ``broadcast(f, args...)`` ([#15032]),
+    and nested `f.(g.(args...))` calls are fused into a single `broadcast` loop ([#17300]).
 
   * Macro expander functions are now generic, so macros can have multiple definitions
     (e.g. for different numbers of arguments, or optional arguments) ([#8846], [#9627]).
@@ -316,4 +317,5 @@ Deprecated or removed
 [#17037]: https://github.com/JuliaLang/julia/issues/17037
 [#17075]: https://github.com/JuliaLang/julia/issues/17075
 [#17266]: https://github.com/JuliaLang/julia/issues/17266
+[#17300]: https://github.com/JuliaLang/julia/issues/17300
 [#17374]: https://github.com/JuliaLang/julia/issues/17374

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -219,6 +219,7 @@ let A = [sqrt(i)+j for i = 1:3, j=1:4]
 end
 let x = sin.(1:10)
     @test atan2.((x->x+1).(x), (x->x+2).(x)) == atan2(x+1, x+2) == atan2(x.+1, x.+2)
+    @test sin.(atan2.([x+1,x+2]...)) == sin.(atan2.(x+1,x+2))
 end
 # Use side effects to check for loop fusion.  Note that, due to #17314,
 # a broadcasted function is currently called twice on the first element.

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -220,7 +220,7 @@ end
 let x = sin.(1:10)
     @test atan2.((x->x+1).(x), (x->x+2).(x)) == atan2(x+1, x+2) == atan2(x.+1, x.+2)
 end
-# Use side effects to check for loop fusion.  Note that, due to #8450,
+# Use side effects to check for loop fusion.  Note that, due to #17314,
 # a broadcasted function is currently called twice on the first element.
 let g = Int[]
     f17300(x) = begin; push!(g, x); x+1; end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -170,10 +170,10 @@ rt = Base.return_types(broadcast!, Tuple{Function, Array{Float64, 3}, Array{Floa
 @test length(rt) == 1 && rt[1] == Array{Float64, 3}
 
 # f.(args...) syntax (#15032)
-let x = [1,3.2,4.7], y = [3.5, pi, 1e-4], α = 0.2342
+let x = [1,3.2,4.7], y = [3.5, pi, 1e-4], α = 0.2342, n = 3
     @test sin.(x) == broadcast(sin, x)
     @test sin.(α) == broadcast(sin, α)
-    @test factorial.(3) == broadcast(factorial, 3)
+    @test factorial.(n) == broadcast(factorial, n)
     @test atan2.(x, y) == broadcast(atan2, x, y)
     @test atan2.(x, y') == broadcast(atan2, x, y')
     @test atan2.(x, α) == broadcast(atan2, x, α)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -170,10 +170,10 @@ rt = Base.return_types(broadcast!, Tuple{Function, Array{Float64, 3}, Array{Floa
 @test length(rt) == 1 && rt[1] == Array{Float64, 3}
 
 # f.(args...) syntax (#15032)
-let x = [1,3.2,4.7], y = [3.5, pi, 1e-4], α = 0.2342, n = 3
+let x = [1,3.2,4.7], y = [3.5, pi, 1e-4], α = 0.2342
     @test sin.(x) == broadcast(sin, x)
     @test sin.(α) == broadcast(sin, α)
-    @test factorial.(n) == broadcast(factorial, n)
+    @test factorial.(3) == broadcast(factorial, 3)
     @test atan2.(x, y) == broadcast(atan2, x, y)
     @test atan2.(x, y') == broadcast(atan2, x, y')
     @test atan2.(x, α) == broadcast(atan2, x, α)
@@ -220,6 +220,7 @@ end
 let x = sin.(1:10)
     @test atan2.((x->x+1).(x), (x->x+2).(x)) == atan2(x+1, x+2) == atan2(x.+1, x.+2)
     @test sin.(atan2.([x+1,x+2]...)) == sin.(atan2.(x+1,x+2))
+    @test sin.(atan2.(x, 3.7)) == broadcast(x -> sin(atan2(x,3.7)), x)
     @test atan2.(x, 3.7) == broadcast(x -> atan2(x,3.7), x) == broadcast(atan2, x, 3.7)
 end
 # Use side effects to check for loop fusion.  Note that, due to #17314,
@@ -236,6 +237,7 @@ let x = sin.(1:10), a = [x]
     @test atan2.(x, cos.(x)) == atan2.(a..., cos.(x)) == atan2(x, cos.(a...)) == atan2(a..., cos.(a...))
     @test ((args...)->cos(args[1])).(x) == cos.(x) == ((y,args...)->cos(y)).(x)
 end
+@test atan2.(3,4) == atan2(3,4) == (() -> atan2(3,4)).()
 
 # PR 16988
 @test Base.promote_op(+, Bool) === Int

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -238,6 +238,14 @@ let x = sin.(1:10), a = [x]
     @test ((args...)->cos(args[1])).(x) == cos.(x) == ((y,args...)->cos(y)).(x)
 end
 @test atan2.(3,4) == atan2(3,4) == (() -> atan2(3,4)).()
+# fusion with keyword args:
+let x = [1:4;]
+    f17300kw(x; y=0) = x + y
+    @test f17300kw.(x) == x
+    @test f17300kw.(x, y=1) == f17300kw.(x; y=1) == f17300kw.(x; [(:y,1)]...) == x .+ 1
+    @test f17300kw.(sin.(x), y=1) == f17300kw.(sin.(x); y=1) == sin.(x) .+ 1
+    @test sin.(f17300kw.(x, y=1)) == sin.(f17300kw.(x; y=1)) == sin.(x .+ 1)
+end
 
 # PR 16988
 @test Base.promote_op(+, Bool) === Int

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -223,7 +223,7 @@ let x = sin.(1:10)
     @test atan2.(x, 3.7) == broadcast(x -> atan2(x,3.7), x) == broadcast(atan2, x, 3.7)
 end
 # Use side effects to check for loop fusion.  Note that, due to #17314,
-# a broadcasted function is currently called twice on the first element.
+# a broadcasted function is currently called an extra time with an argument 1.
 let g = Int[]
     f17300(x) = begin; push!(g, x); x+1; end
     f17300.(f17300.(f17300.(1:3)))


### PR DESCRIPTION
As discussed in #16285 and suggested by @yuyichao, this PR implements fusion of nested `f.(args)` calls into a single `broadcast` loop.  For example, `sin.(cos.(x))` is transformed by the parser into `broadcast(x -> sin(cos(x)), x)`.  

Because this is a _syntactic guarantee_, there is no need to worry about side effects or function purity, so it is very different from loop fusion viewed as a compiler optimization.

To do:
- [x] Tests, lots of tests!
- [x] Documentation
- [x] Fix handling of splatting (after #17307 is merged)
  - [x] more splatting tests
- [x] Needs #17318 or similar to correct `func.(literals...)`.
- [x] Fix handling of keyword arguments.

Note that operators like `.+` are still handled separately, but the long-term plan in #16285 is to treat dot operators as `.(` calls.
