### PR TITLE
Simple perm gen allocator

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1225,8 +1225,8 @@ static jl_value_t *jl_deserialize_datatype(ios_t *s, int pos, jl_value_t **loc)
         uint16_t nf = read_uint16(s);
         uint8_t fielddesc_type = read_int8(s);
         size_t fielddesc_size = nf > 0 ? jl_fielddesc_size(fielddesc_type) : 0;
-        struct _jl_datatype_layout_t *layout = (struct _jl_datatype_layout_t*)malloc(
-                sizeof(struct _jl_datatype_layout_t) + nf * fielddesc_size);
+        jl_datatype_layout_t *layout = (jl_datatype_layout_t*)jl_gc_perm_alloc(
+                sizeof(jl_datatype_layout_t) + nf * fielddesc_size);
         layout->nfields = nf;
         layout->fielddesc_type = fielddesc_type;
         layout->alignment = read_int32(s);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3727,7 +3727,7 @@ void jl_init_types(void)
                         jl_emptysvec, jl_emptysvec, 0, 1, 0);
     jl_array_typename = jl_array_type->name;
     jl_array_type->ninitialized = 0;
-    static const struct _jl_datatype_layout_t _jl_array_layout = { 0, sizeof(void*), 0, 0, 0 };
+    static const jl_datatype_layout_t _jl_array_layout = { 0, sizeof(void*), 0, 0, 0 };
     jl_array_type->layout = &_jl_array_layout;
 
     jl_array_any_type =
@@ -3962,8 +3962,8 @@ void jl_init_types(void)
     jl_compute_field_offsets(jl_sym_type);
 
     // TODO: don't modify layout objects
-    ((struct _jl_datatype_layout_t*)jl_sym_type->layout)->pointerfree = 0;
-    ((struct _jl_datatype_layout_t*)jl_simplevector_type->layout)->pointerfree = 0;
+    ((jl_datatype_layout_t*)jl_sym_type->layout)->pointerfree = 0;
+    ((jl_datatype_layout_t*)jl_simplevector_type->layout)->pointerfree = 0;
 
     empty_sym = jl_symbol("");
     call_sym = jl_symbol("call");

--- a/src/julia.h
+++ b/src/julia.h
@@ -326,7 +326,7 @@ typedef struct {
     uint32_t offset;   // offset relative to data start, excluding type tag
 } jl_fielddesc32_t;
 
-struct _jl_datatype_layout_t {
+typedef struct {
     uint32_t nfields;
     uint32_t alignment : 28;  // strictest alignment over all fields
     uint32_t haspadding : 1;  // has internal undefined bytes
@@ -337,7 +337,7 @@ struct _jl_datatype_layout_t {
     //     jl_fielddesc16_t field16[];
     //     jl_fielddesc32_t field32[];
     // };
-};
+} jl_datatype_layout_t;
 
 typedef struct _jl_datatype_t {
     JL_DATA_TYPE
@@ -346,7 +346,7 @@ typedef struct _jl_datatype_t {
     jl_svec_t *parameters;
     jl_svec_t *types;
     jl_value_t *instance;  // for singletons
-    const struct _jl_datatype_layout_t *layout;
+    const jl_datatype_layout_t *layout;
     int32_t size; // TODO: move to _jl_datatype_layout_t
     int32_t ninitialized;
     uint32_t uid;
@@ -784,12 +784,12 @@ STATIC_INLINE char *jl_symbol_name_(jl_sym_t *s)
 }
 #define jl_symbol_name(s) jl_symbol_name_(s)
 
-#define jl_dt_layout_fields(d) ((const char*)(d) + sizeof(struct _jl_datatype_layout_t))
+#define jl_dt_layout_fields(d) ((const char*)(d) + sizeof(jl_datatype_layout_t))
 
 #define DEFINE_FIELD_ACCESSORS(f)                                             \
     static inline uint32_t jl_field_##f(jl_datatype_t *st, int i)             \
     {                                                                         \
-        const struct _jl_datatype_layout_t *ly = st->layout;                  \
+        const jl_datatype_layout_t *ly = st->layout;                          \
         assert(i >= 0 && (size_t)i < ly->nfields);                            \
         if (ly->fielddesc_type == 0) {                                        \
             return ((const jl_fielddesc8_t*)jl_dt_layout_fields(ly))[i].f;    \
@@ -806,7 +806,7 @@ DEFINE_FIELD_ACCESSORS(offset)
 DEFINE_FIELD_ACCESSORS(size)
 static inline int jl_field_isptr(jl_datatype_t *st, int i)
 {
-    const struct _jl_datatype_layout_t *ly = st->layout;
+    const jl_datatype_layout_t *ly = st->layout;
     assert(i >= 0 && (size_t)i < ly->nfields);
     return ((const jl_fielddesc8_t*)(jl_dt_layout_fields(ly) + (i << (ly->fielddesc_type + 1))))->isptr;
 }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -44,6 +44,9 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, jl_gc_pool_t *p,
                                           int osize, int end_offset);
 JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t allocsz);
 int jl_gc_classify_pools(size_t sz, int *osize, int *end_offset);
+extern jl_mutex_t gc_perm_lock;
+void *jl_gc_perm_alloc_nolock(size_t sz);
+void *jl_gc_perm_alloc(size_t sz);
 
 // pools are 16376 bytes large (GC_POOL_SZ - GC_PAGE_OFFSET)
 static const int jl_gc_sizeclasses[JL_GC_N_POOLS] = {

--- a/test/core.jl
+++ b/test/core.jl
@@ -3342,8 +3342,6 @@ typealias PossiblyInvalidUnion{T} Union{T,Int}
 @test_throws TypeError PossiblyInvalidUnion{1}
 
 # issue #12569
-@test_throws ArgumentError Symbol("x"^10_000_000)
-@test_throws ArgumentError gensym("x"^10_000_000)
 @test Symbol("x") === Symbol("x")
 @test split(string(gensym("abc")),'#')[3] == "abc"
 


### PR DESCRIPTION
Similar to the one already used by symbol and the RW allocator for codegen.
Currently used by symbols and type layout.

Also rename `struct _jl_datatype_layout_t` to `jl_datatype_layout_t`.

The block size of the pool was chosen to have a large enough threshold while having no more than 1% fragmentation. It also happens to be the right size we need at startup time (repl initialization use 1.3MB of it, ~0.9MB of symbols and 0.4MB of datatype layout).

This also removes the limit on the symbol length (not that it is a good idea to allocate one over the old limit) which made the symtab lock (now the `gc_perm` lock) `NOGC`.
