### PR TITLE
Use broadcast for array operators

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -266,44 +266,14 @@ end
 
 ## elementwise operators ##
 
-.÷(A::AbstractArray, B::AbstractArray) = broadcast(÷, A, B)
-.%(A::AbstractArray, B::AbstractArray) = broadcast(%, A, B)
-.<<(A::AbstractArray, B::AbstractArray) = broadcast(<<, A, B)
-.>>(A::AbstractArray, B::AbstractArray) = broadcast(>>, A, B)
-
+# should this be deprecated? Only use in Base is in sparsematrix.jl
 eltype_plus(As::AbstractArray...) = promote_eltype_op(+, As...)
 
-.+(As::AbstractArray...) = broadcast!(+, Array{eltype_plus(As...)}(to_shape(broadcast_shape(As...))), As...)
-
-function .-(A::AbstractArray, B::AbstractArray)
-    broadcast!(-, Array{promote_op(-, eltype(A), eltype(B))}(to_shape(broadcast_shape(A,B))), A, B)
+for op in (:÷, :%, :<<, :>>, :-, :/, :\, ://, :^)
+    @eval $(Symbol(:., op))(A::AbstractArray, B::AbstractArray) = broadcast($(op), A, B)
 end
-
-eltype_mul(As::AbstractArray...) = promote_eltype_op(*, As...)
-
-.*(As::AbstractArray...) = broadcast!(*, Array{eltype_mul(As...)}(to_shape(broadcast_shape(As...))), As...)
-
-function ./(A::AbstractArray, B::AbstractArray)
-    broadcast!(/, Array{promote_op(/, eltype(A), eltype(B))}(to_shape(broadcast_shape(A, B))), A, B)
-end
-
-function .\(A::AbstractArray, B::AbstractArray)
-    broadcast!(\, Array{promote_op(\, eltype(A), eltype(B))}(to_shape(broadcast_shape(A, B))), A, B)
-end
-
-typealias RatIntT{T<:Integer} Union{Type{Rational{T}},Type{T}}
-typealias CRatIntT{T<:Integer} Union{Type{Complex{Rational{T}}},Type{Complex{T}},Type{Rational{T}},Type{T}}
-type_rdiv{T<:Integer,S<:Integer}(::RatIntT{T}, ::RatIntT{S}) =
-    Rational{promote_type(T,S)}
-type_rdiv{T<:Integer,S<:Integer}(::CRatIntT{T}, ::CRatIntT{S}) =
-    Complex{Rational{promote_type(T,S)}}
-function .//(A::AbstractArray, B::AbstractArray)
-    broadcast!(//, Array{type_rdiv(eltype(A), eltype(B))}(to_shape(broadcast_shape(A, B))), A, B)
-end
-
-function .^(A::AbstractArray, B::AbstractArray)
-    broadcast!(^, Array{promote_op(^, eltype(A), eltype(B))}(to_shape(broadcast_shape(A, B))), A, B)
-end
+.+(As::AbstractArray...) = broadcast(+, As...)
+.*(As::AbstractArray...) = broadcast(*, As...)
 
 # ## element-wise comparison operators returning BitArray ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1668,3 +1668,22 @@ let A = zeros(3,3)
     @test size(A[:,UInt(1):UInt(2)]) == (3,2)
     @test size(similar(A, UInt(3), 0x3)) == size(similar(A, (UInt(3), 0x3))) == (3,3)
 end
+
+# issue 17254
+module AutoRetType
+
+using Base.Test
+
+immutable Foo end
+for op in (:+, :*, :÷, :%, :<<, :>>, :-, :/, :\, ://, :^)
+    @eval import Base.$(op)
+    @eval $(op)(::Foo, ::Foo) = Foo()
+end
+A = fill(Foo(), 10, 10)
+@test typeof(A+A) == Matrix{Foo}
+@test typeof(A-A) == Matrix{Foo}
+for op in (:.+, :.*, :.÷, :.%, :.<<, :.>>, :.-, :./, :.\, :.//, :.^)
+    @eval @test typeof($(op)(A,A)) == Matrix{Foo}
+end
+
+end


### PR DESCRIPTION
Ref #17254: Motivation is to have the machinery for figuring out the result type available. For the dot-operators, this can be seen as temporary until they are lowered to `op.()` syntax anyway (if that is still the plan).

Note that this does not fix the issue for other `AbstractArray` classes providing their own operator implementations.
