### PR TITLE
Fix AArch64 ABI segfault in early bootstrap

### DIFF
--- a/src/abi_aarch64.cpp
+++ b/src/abi_aarch64.cpp
@@ -83,7 +83,8 @@ static Type *get_llvm_fptype(jl_datatype_t *dt)
     default:
         return nullptr;
     }
-    return jl_is_floattype((jl_value_t*)dt) ? lltype : nullptr;
+    return ((jl_floatingpoint_type && jl_is_floattype((jl_value_t*)dt)) ?
+            lltype : nullptr);
 }
 
 static Type *get_llvm_fp_or_vectype(jl_datatype_t *dt)

--- a/src/abi_arm.cpp
+++ b/src/abi_arm.cpp
@@ -54,7 +54,8 @@ static Type *get_llvm_fptype(jl_datatype_t *dt)
     default:
         return NULL;
     }
-    return jl_is_floattype((jl_value_t*)dt) ? lltype : NULL;
+    return ((jl_floatingpoint_type && jl_is_floattype((jl_value_t*)dt)) ?
+            lltype : NULL);
 }
 
 static size_t isLegalHA(jl_datatype_t *dt, Type *&base);


### PR DESCRIPTION
This code path was not called this early in the bootstrap before since the abstract types were filtered out (now it is passed in as a `Ptr{Void}`).
