### PR TITLE
broadcasting over scalars should produce a scalar

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1504,6 +1504,7 @@ end
 
 map!{F}(f::F, dest::AbstractArray, As::AbstractArray...) = map_n!(f, dest, As)
 
+map(f) = f()
 map(f, iters...) = collect(Generator(f, iters...))
 
 # multi-item push!, unshift! (built on top of type-specific 1-item version)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -10,6 +10,11 @@ export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##
 
+# fallback routines for broadcasting with no arguments or with scalars
+# to just produce a scalar result:
+broadcast(f) = f()
+broadcast(f, x::Number...) = f(x...)
+
 ## Calculate the broadcast shape of the arguments, or error if incompatible
 # array inputs
 broadcast_shape() = ()

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -551,8 +551,8 @@ end
 @test isa(map(Set, Array[[1,2],[3,4]]), Vector{Set{Int}})
 
 # mapping over scalars and empty arguments:
-@test map(sin, 1) == sin(1)
-@test map(()->1234) == 1234
+@test map(sin, 1) === sin(1)
+@test map(()->1234) === 1234
 
 function test_UInt_indexing(::Type{TestAbstractArray})
     A = [1:100...]

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -550,6 +550,10 @@ end
 # issue #15689, mapping an abstract type
 @test isa(map(Set, Array[[1,2],[3,4]]), Vector{Set{Int}})
 
+# mapping over scalars and empty arguments:
+@test map(sin, 1) == sin(1)
+@test map(()->1234) == 1234
+
 function test_UInt_indexing(::Type{TestAbstractArray})
     A = [1:100...]
     _A = Expr(:quote, A)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -198,8 +198,8 @@ let a = broadcast(Float32, [3, 4, 5])
 end
 
 # broadcasting scalars:
-@test sin.(1) == broadcast(sin, 1) == sin(1)
-@test (()->1234).() == broadcast(()->1234) == 1234
+@test sin.(1) === broadcast(sin, 1) === sin(1)
+@test (()->1234).() === broadcast(()->1234) === 1234
 
 # issue #4883
 @test isa(broadcast(tuple, [1 2 3], ["a", "b", "c"]), Matrix{Tuple{Int,String}})

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -197,6 +197,10 @@ let a = broadcast(Float32, [3, 4, 5])
     @test eltype(a) == Float32
 end
 
+# broadcasting scalars:
+@test sin.(1) == broadcast(sin, 1) == sin(1)
+@test (()->1234).() == broadcast(()->1234) == 1234
+
 # issue #4883
 @test isa(broadcast(tuple, [1 2 3], ["a", "b", "c"]), Matrix{Tuple{Int,String}})
 @test isa(broadcast((x,y)->(x==1?1.0:x,y), [1 2 3], ["a", "b", "c"]), Matrix{Tuple{Real,String}})
@@ -211,5 +215,5 @@ end
 
 # PR 16988
 @test Base.promote_op(+, Bool) === Int
-@test isa(broadcast(+, true), Array{Int,0})
+@test isa(broadcast(+, [true]), Array{Int,1})
 @test Base.promote_op(Float64, Bool) === Float64


### PR DESCRIPTION
This changes `f.(numbers...)` to be equivalent to `f(numbers...)`.  Rationale:
- It is a longstanding convention that "dot" operators like `.^` are equivalent to the "non-dot" operator when acting on scalars, and we need to preserve this behavior if we want to change dot operators to use `broadcast` as per #16285.
- It makes it easier to write generic code that works equally well for vectors and scalars.
- `map(f, numbers...)` already returned `f(numbers...)`, and it is odd for `broadcast` to be different.

Also, I made the empty-argument case `f.()` or `map(f)` return `f()`, for much the same reasons.  (Previously, this threw an exception for both `map` and `broadcast`.) _Update:_ This also will give more consistent behavior for inlining literals in `f.(args...)` broadcast syntax (see below).
