### PR TITLE
fix a number of minor nits with inline line numbers

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2910,8 +2910,11 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
                stmts)
             empty!(stmts)
         else
-            isa(stmts[1], LineNumberNode) && shift!(stmts)
-            unshift!(stmts, Expr(:meta, :push_loc, linfo.def.file, linfo.def.name, linfo.def.line))
+            local line::Int = linfo.def.line
+            if isa(stmts[1], LineNumberNode)
+                line = shift!(stmts).line
+            end
+            unshift!(stmts, Expr(:meta, :push_loc, linfo.def.file, linfo.def.name, line))
             isa(stmts[end], LineNumberNode) && pop!(stmts)
             push!(stmts, Expr(:meta, :pop_loc))
         end

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1697,8 +1697,8 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         PointerType *funcptype = PointerType::get(functype,0);
         if (imaging_mode) {
 #ifdef LLVM37
-            // ARM, PPC, PPC64 (as of LLVM 3.9) doesn't support `musttail` for vararg functions.
-            // And musttail can't proceed unreachable, but is required for vararg (https://llvm.org/bugs/show_bug.cgi?id=23766)
+            // ARM, PPC, PPC64 (as of LLVM 3.9) don't support `musttail` for vararg functions.
+            // And musttail can't precede unreachable, but is required for vararg (https://llvm.org/bugs/show_bug.cgi?id=23766)
             if (functype->isVarArg())
                 llvmf = runtime_sym_lookup(funcptype, f_lib, f_name, ctx->f);
             else

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1395,7 +1395,7 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
 #ifndef USE_MCJIT
             context,
 #endif
-            objcontext,
+            object, objcontext,
 #ifdef LLVM37
             stream
 #else

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -12,6 +12,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #ifndef USE_MCJIT
                           std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
 #endif
+                          const object::ObjectFile *object,
                           llvm::DIContext *context,
 #ifdef LLVM37
                           raw_ostream &rstream

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -1281,9 +1281,8 @@ int jl_getFunctionInfo(jl_frame_t **frames_out, size_t pointer, int skipC, int n
 
         DISubprogram debugscope(prev.Loc.getScope(Ctx));
         jl_copy_str(&frames[0].file_name, debugscope.getFilename().str().c_str());
-        // the DISubprogram has the un-mangled name, so use that if
-        // available. However, if the scope need not be the current
-        // subprogram.
+        // The DISubprogram has the un-mangled name, so use that if
+        // available. However, the scope need not be the current subprogram.
         if (debugscope.getName().data() != NULL) {
             jl_copy_str(&frames[0].func_name, debugscope.getName().str().c_str());
         }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -803,7 +803,7 @@ static jl_cgval_t emit_runtime_pointerset(jl_value_t *e, jl_value_t *x, jl_value
 #ifdef LLVM37
     builder.CreateCall(prepare_call(jlpset_func), { boxed(parg, ctx), xarg, iarg, alignarg });
 #else
-    builder.CreateCall3(prepare_call(jlpset_func), boxed(parg, ctx), xarg, iarg, alignarg);
+    builder.CreateCall4(prepare_call(jlpset_func), boxed(parg, ctx), xarg, iarg, alignarg);
 #endif
     return parg;
 }

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -410,20 +410,21 @@ JL_DLLEXPORT void jl_gdblookup(uintptr_t ip)
     // it can be called from an unmanaged thread on OSX.
     // it means calling getFunctionInfo with noInline = 1
     jl_frame_t *frames = NULL;
-    int n = jl_getFunctionInfo(&frames, ip, 0, 1);
+    int n = jl_getFunctionInfo(&frames, ip, 0, 0);
     int i;
 
-    for(i=0; i < n; i++) {
+    for (i = 0; i < n; i++) {
         jl_frame_t frame = frames[i];
         if (!frame.func_name) {
             jl_safe_printf("unknown function (ip: %p)\n", (void*)ip);
         }
         else {
+            const char *inlined = frame.inlined ? " [inlined]" : "";
             if (frame.line != -1) {
-                jl_safe_printf("%s at %s:%" PRIuPTR "\n", frame.func_name, frame.file_name, (uintptr_t)frame.line);
+                jl_safe_printf("%s at %s:%" PRIuPTR "%s\n", frame.func_name, frame.file_name, (uintptr_t)frame.line, inlined);
             }
             else {
-                jl_safe_printf("%s at %s (unknown line)\n", frame.func_name, frame.file_name);
+                jl_safe_printf("%s at %s (unknown line)%s\n", frame.func_name, frame.file_name, inlined);
             }
             free(frame.func_name);
             free(frame.file_name);
@@ -435,8 +436,8 @@ JL_DLLEXPORT void jl_gdblookup(uintptr_t ip)
 JL_DLLEXPORT void jlbacktrace(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    size_t n = ptls->bt_size; // ptls->bt_size > 40 ? 40 : ptls->bt_size;
-    for (size_t i=0; i < n; i++)
+    size_t i, n = ptls->bt_size; // ptls->bt_size > 400 ? 400 : ptls->bt_size;
+    for (i = 0; i < n; i++)
         jl_gdblookup(ptls->bt_data[i] - 1);
 }
 


### PR DESCRIPTION
- the inlining pass would discard the first LineNumberNode, without
  checking that it matched the line number of the function declaration
- the CurrentDebugLocation shouldn't be set while emitting the prologue
- implement inlining info for pre-MCJIT llvm
- improve printing of relative symbols in disassembly (e.g. 'callq "_setindex!"')
  and hide the first line number if it is zero
- print inlining info during jl_gdblookup

also fix llvm 3.3 build

fix #17317
