### PR TITLE
fix a parsing bug in `try x catch 0 end`

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1246,7 +1246,12 @@
                       (loop (require-token s)
                             (if (or var? (not var))
                                 catch-block
-                                `(block ,loc ,var ,@(cdr catch-block)))
+                                `(block ,loc ,var
+                                        ,@(if (and (length= catch-block 2)
+                                                   (pair? (cadr catch-block))
+                                                   (eq? (caadr catch-block) 'line))
+                                              '()
+                                              (cdr catch-block))))
                             (if var? var 'false)
                             finalb)))))
              ((and (eq? nxt 'finally)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -450,6 +450,8 @@ add_method_to_glob_fn!()
 @test (try error(); catch 0; end) === 0
 @test (try error(); catch false; end) === false  # false and true are Bool literals, not variables
 @test (try error(); catch true; end) === true
+f16517() = try error(); catch 0; end
+@test f16517() === 0
 
 # issue #16671
 @test parse("1.") === 1.0


### PR DESCRIPTION
Even though this case already had a passing test, in a different context the parsing was somehow slightly different and didn't work.
