### PR TITLE
Remove test for #14722 (type instability in generic matmul)

### DIFF
--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -388,15 +388,3 @@ let
         @test_throws DimensionMismatch A_mul_B!(full43, full43, tri44)
     end
 end
-
-# Ensure that matrix multiplication with a narrower output type than input type does not
-# produce allocation in the inner loop (#14722), by ensuring allocation does not change
-# with the size of the input.
-C1 = Array(Float32, 5, 5)
-A1 = rand(Float64, 5, 5)
-B1 = rand(Float64, 5, 5)
-C2 = Array(Float32, 6, 6)
-A2 = rand(Float64, 6, 6)
-B2 = rand(Float64, 6, 6)
-A_mul_B!(C1, A1, B1)
-@test @allocated(A_mul_B!(C1, A1, B1)) == @allocated(A_mul_B!(C2, A2, B2))


### PR DESCRIPTION
I thought this test might be too picky, and it turns out it is. It apparently breaks with inlining disabled, which breaks coverage. Maybe the right way to ensure this doesn't regress is to add a case to BaseBenchmarks.jl.
