### PR TITLE
pmap speedup

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -51,7 +51,6 @@ function fetch(c::Channel)
 end
 
 function take!(c::Channel)
-    !isopen(c) && !isready(c) && throw(closed_exception())
     wait(c)
     v = shift!(c.data)
     notify(c.cond_put, nothing, false, false) # notify only one, since only one slot has become available for a put!.
@@ -64,6 +63,7 @@ isready(c::Channel) = n_avail(c) > 0
 
 function wait(c::Channel)
     while !isready(c)
+        !isopen(c) && throw(closed_exception())
         wait(c.cond_take)
     end
     nothing

--- a/base/workerpool.jl
+++ b/base/workerpool.jl
@@ -47,7 +47,21 @@ isready(pool::AbstractWorkerPool) = isready(pool.channel)
 
 put!(pool::AbstractWorkerPool, w::Int) = (put!(pool.channel, w); pool)
 
-workers(pool::AbstractWorkerPool) = collect(pool.workers)
+function workers(pool::AbstractWorkerPool)
+    if length(pool) == 0 && pool === default_worker_pool()
+        return [1]
+    else
+        return collect(pool.workers)
+    end
+end
+
+function nworkers(pool::AbstractWorkerPool)
+    if length(pool) == 0 && pool === default_worker_pool()
+        return 1
+    else
+        return length(pool.workers)
+    end
+end
 
 function take!(pool::AbstractWorkerPool)
     # Find an active worker

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -489,7 +489,7 @@ Base.done{N}(::GenericIterator{N}, i) = i > N ? true : false
 Base.iteratorsize{N}(::Type{GenericIterator{N}}) = Base.SizeUnknown()
 
 function test_map(::Type{TestAbstractArray})
-    empty_pool = WorkerPool()
+    empty_pool = WorkerPool([myid()])
     pmap_fallback = (f, c...) -> pmap(empty_pool, f, c...)
 
     for mapf in [map, asyncmap, pmap_fallback]

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -538,6 +538,24 @@ function testcpt()
 end
 testcpt()
 
+# Test multiple "for" loops waiting on the same channel which
+# is closed after adding a few elements.
+c=Channel()
+results=[]
+@sync begin
+    for i in 1:20
+        @async for i in c
+            push!(results, i)
+        end
+    end
+    sleep(1.0)
+    for i in 1:5
+        put!(c,i)
+    end
+    close(c)
+end
+@test sum(results) == 15
+
 @test_throws ArgumentError sleep(-1)
 @test_throws ArgumentError timedwait(()->false, 0.1, pollint=-0.5)
 

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -10,8 +10,12 @@ elseif Base.JLOptions().code_coverage == 2
     cov_flag = `--code-coverage=all`
 end
 
-# Test a `remote` invocation when no workers are present
+# Test a few "remote" invocations when no workers are present
 @test remote(myid)() == 1
+@test pmap(identity, 1:100) == [1:100...]
+@test 100 == @parallel (+) for i in 1:100
+        1
+    end
 
 addprocs(4; exeflags=`$cov_flag $inline_flag --check-bounds=yes --depwarn=error`)
 
@@ -819,7 +823,7 @@ end
 @test [1:100...] == pmap(x->x, Base.Generator(x->(sleep(0.0001); x), 1:100))
 
 # Test asyncmap
-@test allunique(asyncmap(x->object_id(current_task()), 1:100))
+@test allunique(asyncmap(x->(sleep(1.0);object_id(current_task())), 1:10))
 
 # CachingPool tests
 wp = CachingPool(workers())


### PR DESCRIPTION
Partially addresses #17301 

On my machine:

```
x = [bitrand(4,2) for i = 1:100000];   
@time pmap(identity, x);
```

this PR takes 8.8 seconds vs 6.6 seconds on 0.4
