### PR TITLE
tryparse should still throw an exception on invalid base

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -141,13 +141,16 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
     Nullable{Bool}()
 end
 
-function tryparse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer=0)
-    return tryparse_internal(T, s, start(s), endof(s), base, false)
-end
-
-function parse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer=0)
-    return get(tryparse_internal(T, s, start(s), endof(s), base, true))
-end
+check_valid_base(base) = 2 <= base <= 62 ? base :
+    throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
+tryparse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer) =
+    tryparse_internal(T, s, start(s), endof(s), check_valid_base(base), false)
+tryparse{T<:Integer}(::Type{T}, s::AbstractString) =
+    tryparse_internal(T, s, start(s), endof(s), 0, false)
+parse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer) =
+    get(tryparse_internal(T, s, start(s), endof(s), check_valid_base(base), true))
+parse{T<:Integer}(::Type{T}, s::AbstractString) =
+    get(tryparse_internal(T, s, start(s), endof(s), 0, true))
 
 ## string to float functions ##
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -538,5 +538,10 @@ end
 @test_throws ArgumentError parse(Int, "2", 1)
 @test_throws ArgumentError parse(Int, "2", 63)
 
+# issue #17333: tryparse should still throw on invalid base
+for T in (Int32, BigInt), base in (0,1,100)
+    @test_throws ArgumentError tryparse(T, "0", base)
+end
+
 # error throwing branch from #10560
 @test_throws ArgumentError Base.tryparse_internal(Bool, "foo", 1, 2, 10, true)


### PR DESCRIPTION
`tryparse` does not throw an exception on an invalid string, but it should still throw an `ArgumentError` if the `base` argument is invalid.   This fixes a regression apparently introduced by #17078.

In particular, this regression has broken the Compat.jl tests (see e.g. JuliaLang/Compat.jl#245, JuliaLang/Compat.jl#240).

cc: @yuyichao, @quinnj 
