### PR TITLE
Take advantage of inline-savvy backtraces in profile printing

### DIFF
--- a/base/profile.jl
+++ b/base/profile.jl
@@ -125,7 +125,7 @@ function getdict(data::Vector{UInt})
 end
 
 """
-    newdata, newdict = flatten(btdata, lidict)
+    flatten(btdata, lidict) -> (newdata, newdict)
 
 Produces "flattened" backtrace data. Individual instruction pointers
 sometimes correspond to a multi-frame backtrace due to inlining; in


### PR DESCRIPTION
Test case:

``` jl
@inline foo1(x) = foo2(x)
@inline foo2(x) = foo3(x)
@noinline foo3(x) = x ÷ 3

function bar(n)
    X = rand(1:10, n)
    Y = [foo1(x) for x in X]
end
```

Master:

``` jl
julia> Profile.print()
326 ./REPL.jl:92; macro expansion
 326 ./REPL.jl:62; eval_user_input(::Any, ::Base.REPL.REPLBackend)
  326 ./boot.jl:234; eval(::Module, ::Any)
   326 ./profile.jl:16; macro expansion;
    48  ./random.jl:0; rand
    189 /tmp/testprof.jl:6; bar(::Int64)
     181 ./random.jl:592; rand!(::MersenneTwister, ::Array{Int64,1}, ::Base.Random....
      7   ./random.jl:0; gen_rand
       7 ./dSFMT.jl:75; dsfmt_fill_array_close1_open2!(::Base.dSFMT.DSFMT_state, :...
      4   ./random.jl:0; mt_pop!
      6   ./random.jl:0; mt_setfull!
      11  ./random.jl:0; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{I...
      6   ./random.jl:528; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{I...
      5   ./random.jl:529; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{I...
      4   ./random.jl:531; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{I...
      127 ./random.jl:540; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{I...
     8   ./random.jl:540; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{I...
    89  /tmp/testprof.jl:7; bar(::Int64)
     6 /tmp/testprof.jl:0; foo3(::Int64)
     8 /tmp/testprof.jl:3; foo3(::Int64)
```

This is confusing because it looks like `gen_rand`, `mt_pop!`, `mt_setfull!`, and various variants of `rand` are all called from inside the `rand!` function at line 592. But that function is just

``` jl
function rand!(rng::AbstractRNG, A::AbstractArray, g::RangeGenerator)
    for i in eachindex(A)
        @inbounds A[i] = rand(rng, g)
    end
    return A
end
```

This PR:

``` jl
237 ./event.jl:46; (::Base.REPL.##1#2{Base.REPL.REPLBackend})()
 237 ./REPL.jl:92; macro expansion
  237 ./REPL.jl:62; eval_user_input(::Any, ::Base.REPL.REPLBackend)
   237 ./boot.jl:234; eval(::Module, ::Any)
    237 ./<missing>:?; anonymous
     237 ./profile.jl:16; macro expansion;
      203 /tmp/testprof.jl:6; bar(::Int64)
       199 ./random.jl:592; rand!(::MersenneTwister, ::Array{Int64,1}, ::Base.Random...
        15  ./random.jl:0; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{...
        8   ./random.jl:528; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{...
        3   ./random.jl:529; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{...
        17  ./random.jl:530; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{...
         17 ./random.jl:0; rand
          17 ./random.jl:0; rand_ui52_raw
           2  ./random.jl:0; rand_ui52_raw_inbounds
            2 ./random.jl:0; rand_inbounds
             2 ./random.jl:0; mt_pop!
           15 ./random.jl:0; reserve_1
            11 ./random.jl:0; gen_rand
             1  ./dSFMT.jl:73; dsfmt_fill_array_close1_open2!(::Base.dSFMT.DSFMT_stat...
             10 ./dSFMT.jl:75; dsfmt_fill_array_close1_open2!(::Base.dSFMT.DSFMT_stat...
            3  ./random.jl:108; gen_rand
             3 ./random.jl:0; mt_setfull!
        2   ./random.jl:531; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{...
        141 ./random.jl:540; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{...
       1   ./random.jl:0; rand
        1 ./random.jl:0; rand
       3   ./random.jl:540; rand(::MersenneTwister, ::Base.Random.RangeGeneratorInt{...
      33  /tmp/testprof.jl:7; bar(::Int64)
       9  /tmp/testprof.jl:0; foo3(::Int64)
       10 /tmp/testprof.jl:3; foo3(::Int64)
```

which seems rather clearer.

Might get even better with #17324 (but that's an independent improvement).

CC @MikeInnes, @Keno (for https://github.com/timholy/ProfileView.jl/issues/59).
