### PR TITLE
make sure parseint base can be any Integer type

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -76,13 +76,13 @@ signed(x::BigInt) = x
 
 convert(::Type{BigInt}, x::BigInt) = x
 
-function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, endpos::Int, base::Int, raise::Bool)
+function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
     _n = Nullable{BigInt}()
 
     # don't make a copy in the common case where we are parsing a whole String
     bstr = startpos == start(s) && endpos == endof(s) ? String(s) : String(SubString(s,startpos,endpos))
 
-    sgn, base, i = Base.parseint_preamble(true,base,bstr,start(bstr),endof(bstr))
+    sgn, base, i = Base.parseint_preamble(true,Int(base_),bstr,start(bstr),endof(bstr))
     if !(2 <= base <= 62)
         raise && throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
         return _n

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -59,9 +59,9 @@ safe_mul{T<:Integer}(n1::T, n2::T) = ((n2 >   0) ? ((n1 > div(typemax(T),n2)) ||
                                       (n2 <  -1) ? ((n1 > div(typemin(T),n2)) || (n1 < div(typemax(T),n2))) :
                                       ((n2 == -1) && n1 == typemin(T))) ? Nullable{T}() : Nullable{T}(n1 * n2)
 
-function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base::Integer, raise::Bool)
+function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
     _n = Nullable{T}()
-    sgn, base, i = parseint_preamble(T<:Signed, base, s, startpos, endpos)
+    sgn, base, i = parseint_preamble(T<:Signed, Int(base_), s, startpos, endpos)
     if !(2 <= base <= 62)
         raise && throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
         return _n

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -512,6 +512,14 @@ end
 # to be removed post 0.5
 #@test_throws MethodError eval(parse("(Any=>Any)[x=>y for (x,y) in zip([1,2,3],[4,5,6])]"))
 
+# make sure base can be any Integer
+for T in (Int, BigInt)
+    let n = parse(T, "123", Int8(10))
+        @test n == 123
+        @test isa(n, T)
+    end
+end
+
 # issue #16720
 let err = try
     include_string("module A


### PR DESCRIPTION
While working on #17333, I noticed that, although `parse` and `tryparse` accept `base::Integer`, only `Int` actually works because `parseint_preamble` requires an `Int`.  This fixes it.
