### PR TITLE
flatten the call chain of `checkbounds` a bit

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -190,13 +190,22 @@ Return `true` if the specified `indexes` are in bounds for the given `array`. Su
 `AbstractArray` should specialize this method if they need to provide custom bounds checking
 behaviors.
 """
+function checkbounds(::Type{Bool}, A::AbstractArray, i::Integer)
+    @_inline_meta
+    checkindex(Bool, linearindices(A), i)
+end
+function checkbounds{T}(::Type{Bool}, A::Union{Array{T,1},Range{T}}, i::Integer)
+    @_inline_meta
+    (1 <= i) & (i <= length(A))
+end
+function checkbounds(::Type{Bool}, A::AbstractArray, I::AbstractArray{Bool})
+    @_inline_meta
+    checkbounds_logical(A, I)
+end
 function checkbounds(::Type{Bool}, A::AbstractArray, I...)
     @_inline_meta
-    _chkbounds(A, I...)
+    checkbounds_indices(indices(A), I)
 end
-_chkbounds(A::AbstractArray, i::Integer) = (@_inline_meta; checkindex(Bool, linearindices(A), i))
-_chkbounds(A::AbstractArray, I::AbstractArray{Bool}) = (@_inline_meta; checkbounds_logical(A, I))
-_chkbounds(A::AbstractArray, I...) = (@_inline_meta; checkbounds_indices(indices(A), I))
 
 checkbounds_indices(::Tuple{},  ::Tuple{})    = true
 checkbounds_indices(::Tuple{}, I::Tuple{Any}) = (@_inline_meta; checkindex(Bool, 1:1, I[1]))


### PR DESCRIPTION
`checkbounds` is surprisingly complicated. The call chain consists of checkbounds -> checkbounds(Bool) -> _chkbounds -> checkindex and linearindices. This is especially an issue for ranges, where the bounds check code looks like:

```
        $(Expr(:boundscheck, true))
        SSAValue(6) = (Core.tuple)(i)::Tuple{Int64}
        $(Expr(:inbounds, false))
        # meta: location abstractarray.jl checkbounds 222
        # meta: location abstractarray.jl checkbounds 194
        SSAValue(8) = (Core.getfield)(SSAValue(6),1)::Int64
        # meta: location abstractarray.jl _chkbounds 197
        SSAValue(9) = $(Expr(:invoke, indices1(::LinSpace{Float64}), :(Base.indices1), SSAValue(5)))
        # meta: pop location
        # meta: pop location
        SSAValue(7) = (Base.box)(Base.Bool,(Base.and_int)((Base.sle_int)(1,SSAValue(8))::Bool,(Base.sle_int)(SSAValue(8),(Core.getfield)(SSAValue(9),:stop)::Int64)::Bool))
        unless SSAValue(7) goto 18
        #temp#@_4 = SSAValue(7)
        goto 20
        18: 
        #temp#@_4 = $(Expr(:invoke, throw_boundserror(::LinSpace{Float64}, ::Tuple{Int64}), :(Base.throw_boundserror), SSAValue(5), SSAValue(6)))
        20: 
        # meta: pop location
        $(Expr(:inbounds, :pop))
        #temp#@_4
        $(Expr(:boundscheck, :pop))
```

Yikes. This change simplifies it a bit, especially for `Vector` and `Range`, where the call to `indices` can easily be avoided.
