### PR TITLE
Fix #17105, @ inferred with kwargs

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -873,6 +873,7 @@ macro test_approx_eq(a, b)
     :(test_approx_eq($(esc(a)), $(esc(b)), $(string(a)), $(string(b))))
 end
 
+_args_and_call(args...; kwargs...) = (args[1:end-1], kwargs, args[end](args[1:end-1]...; kwargs...))
 """
     @inferred f(x)
 
@@ -912,12 +913,22 @@ julia> @inferred max(1,2)
 ```
 """
 macro inferred(ex)
-    ex.head == :call || error("@inferred requires a call expression")
+    Meta.isexpr(ex, :call)|| error("@inferred requires a call expression")
+    args = gensym()
+    kwargs = gensym()
+
+    # Need to only consturct a call with a kwargs if there are actually kwargs, since
+    # the inferred type depends on the presence/absence of kwargs
+    if any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex.args)
+        typecall = :($(ex.args[1])($(args)...; $(kwargs)...))
+    else
+        typecall = :($(ex.args[1])($(args)...))
+    end
+
     Base.remove_linenums!(quote
-        vals = ($([esc(ex.args[i]) for i = 2:length(ex.args)]...),)
-        inftypes = Base.return_types($(esc(ex.args[1])), Base.typesof(vals...))
+        $(esc(args)), $(esc(kwargs)), result = $(esc(Expr(:call, _args_and_call, ex.args[2:end]..., ex.args[1])))
+        inftypes = $(Base.gen_call_with_extracted_types(Base.return_types, typecall))
         @assert length(inftypes) == 1
-        result = $(esc(ex.args[1]))(vals...)
         rettype = isa(result, Type) ? Type{result} : typeof(result)
         rettype == inftypes[1] || error("return type $rettype does not match inferred return type $(inftypes[1])")
         result

--- a/base/test.jl
+++ b/base/test.jl
@@ -917,7 +917,7 @@ macro inferred(ex)
     args = gensym()
     kwargs = gensym()
 
-    # Need to only consturct a call with a kwargs if there are actually kwargs, since
+    # Need to only construct a call with a kwargs if there are actually kwargs, since
     # the inferred type depends on the presence/absence of kwargs
     if any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex.args)
         typecall = :($(ex.args[1])($(args)...; $(kwargs)...))

--- a/test/test.jl
+++ b/test/test.jl
@@ -278,6 +278,38 @@ for i in 1:6
     @test typeof(tss[i].results[4].results[1]) == (iseven(i) ? Pass : Fail)
 end
 
+# test @inferred
+function uninferrable_function(i)
+    q = [1, "1"]
+    return q[i]
+end
+
+@test_throws ErrorException @inferred(uninferrable_function(1))
+@test @inferred(identity(1)) == 1
+
+# Ensure @inferred only evaluates the arguments once
+inferred_test_global = 0
+function inferred_test_function()
+    global inferred_test_global
+    inferred_test_global += 1
+    true
+end
+@test @inferred inferred_test_function()
+@test inferred_test_global == 1
+
 # Issue #14928
 # Make sure abstract error type works.
 @test_throws Exception error("")
+
+# Issue #17105
+# @inferred with kwargs
+function inferrable_kwtest(x; y=1)
+    2x
+end
+function uninferrable_kwtest(x; y=1)
+    2x+y
+end
+@test @inferred(inferrable_kwtest(1)) == 2
+@test @inferred(inferrable_kwtest(1; y=1)) == 2
+@test @inferred(uninferrable_kwtest(1)) == 3
+@test_throws ErrorException @inferred(uninferrable_kwtest(1; y=2)) == 2


### PR DESCRIPTION
Also fixes #9818 (incorrect `@code_typed` with kwargs) since otherwise `@inferred` with kwargs would sometimes be wrong. This does not fix #17127, so `@code_typed` output is still not necessarily useful.

Someone who knows how keyword argument dispatch works should check that I'm doing this right.
