### PR TITLE
Fix several typos in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,8 @@ If you want to edit an existing docstring signature, you **first** have to chang
 edit the helpdb.jl or inline method docstrings.  The existing signatures in the `doc/stdlib/*.rst` files are pattern matched to base docstrings and the new content overwrites the content in `doc/stdlib/`.
 The signature definitions **must** be in sync or else the pattern match will fail and documentation will be lost in the result.
 To add entirely new methods to the `stdlib` documentation, first add the signature in the appropriate `doc/stdlib/*.rst` file before writing the docstring, rebuilding Julia, and re-running `doc/genstdlib.jl`.
-Pattern matching requires that multiline method signatures' inter-line character alignment in `doc/stdlib/*.rst` match that in the corresponding docstring. For example, docstring
+Pattern matching requires that multiline method signatures' inter-line character alignment in `doc/stdlib/*.rst` match that in the corresponding docstring. In the following example,
+
 ```julia
 """
     foo(bar, baz,
@@ -113,12 +114,25 @@ Pattern matching requires that multiline method signatures' inter-line character
 Foo `bar`, `baz`, `qux`, and `quux`.
 """
 ```
-will only match entries in `doc/stdlib/*.rst` of the form
-```rst
-.. function:: foo(bar, baz,
-..............    qux, quux)
+
+will only match entries in `doc/stdlib/*.rst` beginning with
+
 ```
-where `.` in the preceding snippet's second line is wildcard, and their number preceding indent-`    qux, quux)` matches the character count of `.. function:: `.
+.. function:: foo(bar, baz,
+                  qux, quux)
+```
+
+Note that the second line of the signature is indented by four spaces relative to `foo(bar, baz,`
+in the first line of the signature. This leading indent matches the indent used in the
+docstring exactly. If it did not match, such as in the following example,
+
+```
+.. function:: foo(bar, baz,
+                 qux, quux)
+```
+
+where three spaces instead of four are used then running `genstdlib.jl` will print a warning
+and not update the docstring.
 
 It is encouraged to write all new docstrings in Markdown markup.  If you need to write a more complicated docstring that contains cross-references or citations it can be written in a restructured text codeblock.
 Many of the existing docstrings are currently restructured text codeblocks and these will be transitioned to Markdown over time.  RST codeblocks are delineated with the triple-quote (\`\`\`rst  \`\`\`) Makdown codeblock syntax.

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -299,7 +299,7 @@ Create an uninitialized mutable array analogous to that specified by
 `storagetype`, but with `indices` specified by the last
 argument. `storagetype` might be a type or a function.
 
-    **Examples**:
+**Examples**:
 
     similar(Array{Int}, indices(A))
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -510,8 +510,13 @@ promote_type
 Returns a tuple of subscripts into an array with dimensions `dims`,
 corresponding to the linear index `index`.
 
-**Example**: `i, j, ... = ind2sub(size(A), indmax(A))` provides the
-indices of the maximum element
+**Example**:
+
+```
+i, j, ... = ind2sub(size(A), indmax(A))
+```
+
+provides the indices of the maximum element.
 """
 ind2sub(dims::Tuple, index::Int)
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -69,8 +69,8 @@ julia> gcdx(240, 46)
     Bézout coefficients are *not* uniquely defined. `gcdx` returns the minimal
     Bézout coefficients that are computed by the extended Euclid algorithm.
     (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients `u`
-    and `v` are minimal in the sense that ``|u| < |\\frac y d`` and ``|v| <
-    |\\frac x d``. Furthermore, the signs of `u` and `v` are chosen so that `d`
+    and `v` are minimal in the sense that ``|u| < |\\frac y d|`` and ``|v| <
+    |\\frac x d|``. Furthermore, the signs of `u` and `v` are chosen so that `d`
     is positive.
 """
 function gcdx{T<:Integer}(a::T, b::T)

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -52,7 +52,7 @@ final residual vector `resid`.
 
 !!! note
     The `sigma` and `which` keywords interact: the description of eigenvalues
-    searched for by `which` do _not_ necessarily refer to the eigenvalues of
+    searched for by `which` do *not* necessarily refer to the eigenvalues of
     `A`, but rather the linear operator constructed by the specification of the
     iteration mode implied by `sigma`.
 
@@ -138,16 +138,16 @@ X = sprand(10, 5, 0.2)
 eigs(X, nsv = 2, tol = 1e-3)
 ```
 
-**Note**
+!!! note
 
-The `sigma` and `which` keywords interact: the description of eigenvalues searched for by
-`which` do _not_ necessarily refer to the eigenvalue problem ``Av = Bv\\lambda``, but rather
-the linear operator constructed by the specification of the iteration mode implied by `sigma`.
+    The `sigma` and `which` keywords interact: the description of eigenvalues searched for by
+    `which` do *not* necessarily refer to the eigenvalue problem ``Av = Bv\\lambda``, but rather
+    the linear operator constructed by the specification of the iteration mode implied by `sigma`.
 
-| `sigma`         | iteration mode                   | `which` refers to the problem      |
-|:----------------|:---------------------------------|:-----------------------------------|
-| `nothing`       | ordinary (forward)               | ``Av = Bv\\lambda``                |
-| real or complex | inverse with level shift `sigma` | ``(A - \\sigma B )^{-1}B = v\\nu`` |
+    | `sigma`         | iteration mode                   | `which` refers to the problem      |
+    |:----------------|:---------------------------------|:-----------------------------------|
+    | `nothing`       | ordinary (forward)               | ``Av = Bv\\lambda``                |
+    | real or complex | inverse with level shift `sigma` | ``(A - \\sigma B )^{-1}B = v\\nu`` |
 """
 eigs(A, B; kwargs...) = _eigs(A, B; kwargs...)
 function _eigs(A, B;

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -134,7 +134,13 @@ Basic functions
 
    Returns a tuple of subscripts into an array with dimensions ``dims``\ , corresponding to the linear index ``index``\ .
 
-   **Example**: ``i, j, ... = ind2sub(size(A), indmax(A))`` provides the indices of the maximum element
+   **Example**:
+
+   .. code-block:: julia
+
+       i, j, ... = ind2sub(size(A), indmax(A))
+
+   provides the indices of the maximum element.
 
 .. function:: ind2sub(a, index) -> subscripts
 
@@ -277,9 +283,9 @@ Constructors
 
    Create an uninitialized mutable array analogous to that specified by ``storagetype``\ , but with ``indices`` specified by the last argument. ``storagetype`` might be a type or a function.
 
-   .. code-block:: julia
+   **Examples**:
 
-       **Examples**:
+   .. code-block:: julia
 
        similar(Array{Int}, indices(A))
 
@@ -1045,7 +1051,7 @@ dense counterparts. The following functions are specific to sparse arrays.
    For an in-place version and algorithmic information, see :func:`Base.SparseArrays.dropzeros!`\ .
 
 .. function:: permute{Tv,Ti,Tp<:Integer,Tq<:Integer}(A::SparseMatrixCSC{Tv,Ti}, p::AbstractVector{Tp},
-..............    q::AbstractVector{Tq})
+                  q::AbstractVector{Tq})
 
    .. Docstring generated from Julia source
 
@@ -1054,7 +1060,7 @@ dense counterparts. The following functions are specific to sparse arrays.
    For expert drivers and additional information, see :func:`Base.SparseArrays.permute!`\ .
 
 .. function:: permute!{Tv,Ti,Tp<:Integer,Tq<:Integer}(X::SparseMatrixCSC{Tv,Ti}, A::SparseMatrixCSC{Tv,Ti},
-..............    p::AbstractVector{Tp}, q::AbstractVector{Tq}[, C::SparseMatrixCSC{Tv,Ti}])
+                  p::AbstractVector{Tp}, q::AbstractVector{Tq}[, C::SparseMatrixCSC{Tv,Ti}])
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1338,7 +1338,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    ``eigs`` returns the ``nev`` requested eigenvalues in ``d``\ , the corresponding Ritz vectors ``v`` (only if ``ritzvec=true``\ ), the number of converged eigenvalues ``nconv``\ , the number of iterations ``niter`` and the number of matrix vector multiplications ``nmult``\ , as well as the final residual vector ``resid``\ .
 
    .. note::
-      The ``sigma`` and ``which`` keywords interact: the description of eigenvalues searched for by ``which`` do _not_ necessarily refer to the eigenvalues of ``A``\ , but rather the linear operator constructed by the specification of the iteration mode implied by ``sigma``\ .
+      The ``sigma`` and ``which`` keywords interact: the description of eigenvalues searched for by ``which`` do *not* necessarily refer to the eigenvalues of ``A``\ , but rather the linear operator constructed by the specification of the iteration mode implied by ``sigma``\ .
 
       +-----------------+------------------------------------+------------------------------------+
       | ``sigma``       | iteration mode                     | ``which`` refers to eigenvalues of |
@@ -1403,17 +1403,17 @@ Linear algebra functions in Julia are largely implemented by calling functions f
        X = sprand(10, 5, 0.2)
        eigs(X, nsv = 2, tol = 1e-3)
 
-   **Note**
+   .. note::
+      The ``sigma`` and ``which`` keywords interact: the description of eigenvalues searched for by ``which`` do *not* necessarily refer to the eigenvalue problem :math:`Av = Bv\lambda`\ , but rather the linear operator constructed by the specification of the iteration mode implied by ``sigma``\ .
 
-   The ``sigma`` and ``which`` keywords interact: the description of eigenvalues searched for by ``which`` do _not_ necessarily refer to the eigenvalue problem :math:`Av = Bv\lambda`\ , but rather the linear operator constructed by the specification of the iteration mode implied by ``sigma``\ .
+      +-----------------+------------------------------------+--------------------------------------+
+      | ``sigma``       | iteration mode                     | ``which`` refers to the problem      |
+      +=================+====================================+======================================+
+      | ``nothing``     | ordinary (forward)                 | :math:`Av = Bv\lambda`               |
+      +-----------------+------------------------------------+--------------------------------------+
+      | real or complex | inverse with level shift ``sigma`` | :math:`(A - \sigma B )^{-1}B = v\nu` |
+      +-----------------+------------------------------------+--------------------------------------+
 
-   +-----------------+------------------------------------+--------------------------------------+
-   | ``sigma``       | iteration mode                     | ``which`` refers to the problem      |
-   +=================+====================================+======================================+
-   | ``nothing``     | ordinary (forward)                 | :math:`Av = Bv\lambda`               |
-   +-----------------+------------------------------------+--------------------------------------+
-   | real or complex | inverse with level shift ``sigma`` | :math:`(A - \sigma B )^{-1}B = v\nu` |
-   +-----------------+------------------------------------+--------------------------------------+
 
 .. function:: svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000, ncv=2*nsv, u0=zeros((0,)), v0=zeros((0,))) -> (SVD([left_sv,] s, [right_sv,]), nconv, niter, nmult, resid)
 
@@ -1479,7 +1479,7 @@ according to the usual Julia convention.
 
    Compute ``A  B`` in-place and store the result in ``Y``\ , returning the result. If only two arguments are passed, then ``A_ldiv_B!(A, B)`` overwrites ``B`` with the result.
 
-   The argument ``A`` should *not* be a matrix.  Rather, instead of matrices it should be a factorization object (e.g. produced by :func:`factorize` or :func:`cholfact`\ ). The reason for this is that factorization itself is both expensive and typically allocates memory (although it can also be done in-place via, e.g., :func:`lufact`\ ), and performance-critical situations requiring ``A_ldiv_B!`` usually also require fine-grained control over the factorization of ``A``\ .
+   The argument ``A`` should *not* be a matrix.  Rather, instead of matrices it should be a factorization object (e.g. produced by :func:`factorize` or :func:`cholfact`\ ). The reason for this is that factorization itself is both expensive and typically allocates memory (although it can also be done in-place via, e.g., :func:`lufact!`\ ), and performance-critical situations requiring ``A_ldiv_B!`` usually also require fine-grained control over the factorization of ``A``\ .
 
 .. function:: A_ldiv_Bc(A, B)
 
@@ -2525,3 +2525,4 @@ set of functions in future releases.
    Solves the Sylvester matrix equation ``A * X +/- X * B = scale*C`` where ``A`` and ``B`` are both quasi-upper triangular. If ``transa = N``\ , ``A`` is not modified. If ``transa = T``\ , ``A`` is transposed. If ``transa = C``\ , ``A`` is conjugate transposed. Similarly for ``transb`` and ``B``\ . If ``isgn = 1``\ , the equation ``A * X + X * B = scale * C`` is solved. If ``isgn = -1``\ , the equation ``A * X - X * B = scale * C`` is solved.
 
    Returns ``X`` (overwriting ``C``\ ) and ``scale``\ .
+

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1267,7 +1267,7 @@ Mathematical Functions
        (2,-9,47)
 
    .. note::
-      Bézout coefficients are *not* uniquely defined. ``gcdx`` returns the minimal Bézout coefficients that are computed by the extended Euclid algorithm. (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients ``u`` and ``v`` are minimal in the sense that :math:`|u| < |\frac y d` and :math:`|v| < |\frac x d`\ . Furthermore, the signs of ``u`` and ``v`` are chosen so that ``d`` is positive.
+      Bézout coefficients are *not* uniquely defined. ``gcdx`` returns the minimal Bézout coefficients that are computed by the extended Euclid algorithm. (Ref: D. Knuth, TAoCP, 2/e, p. 325, Algorithm X.) These coefficients ``u`` and ``v`` are minimal in the sense that :math:`|u| < |\frac y d|` and :math:`|v| < |\frac x d|`\ . Furthermore, the signs of ``u`` and ``v`` are chosen so that ``d`` is positive.
 
 
 .. function:: ispow2(n) -> Bool


### PR DESCRIPTION
- Fix incorrect indent in an "Examples" section.
- Remove some leading `.`s from two `.. function` signatures.
- Use `*`, not `_`, for emphasis in `eigs` docs.
- Replace `Note` section with an admonition in `eigs`.
- Add closing `|`s for absolute values in `gcdx` docs.
