### PR TITLE
Remove unnecessary GC root on the return path

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -821,7 +821,7 @@ public:
 // llvmcall(ir, (rettypes...), (argtypes...), args...)
 static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
-    JL_NARGSV(llvmcall, 3)
+    JL_NARGSV(llvmcall, 3);
     jl_value_t *rt = NULL, *at = NULL, *ir = NULL, *decl = NULL;
     jl_svec_t *stt = NULL;
     JL_GC_PUSH5(&ir, &rt, &at, &stt, &decl);
@@ -1009,6 +1009,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         f->setLinkage(GlobalValue::LinkOnceODRLinkage);
 
     // the actual call
+    builder.CreateCall(prepare_call(gcroot_flush_func));
     CallInst *inst = builder.CreateCall(f, ArrayRef<Value*>(&argvals[0], nargt));
     if (isString)
         ctx->to_inline.push_back(inst);
@@ -1440,6 +1441,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!isVa);
         assert(nargt == 0);
         JL_GC_POP();
+        builder.CreateCall(prepare_call(gcroot_flush_func));
         emit_signal_fence();
         builder.CreateLoad(ctx->signalPage, true);
         emit_signal_fence();
@@ -1471,6 +1473,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!isVa);
         assert(nargt == 0);
         JL_GC_POP();
+        builder.CreateCall(prepare_call(gcroot_flush_func));
         Value *pdefer_sig = emit_defer_signal(ctx);
         Value *defer_sig = builder.CreateLoad(pdefer_sig);
         defer_sig = builder.CreateAdd(defer_sig,
@@ -1486,6 +1489,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!isVa);
         assert(nargt == 0);
         JL_GC_POP();
+        builder.CreateCall(prepare_call(gcroot_flush_func));
         Value *pdefer_sig = emit_defer_signal(ctx);
         Value *defer_sig = builder.CreateLoad(pdefer_sig);
         emit_signal_fence();

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -391,6 +391,7 @@ static Function *gcroot_func;
 static Function *gcstore_func;
 static Function *gckill_func;
 static Function *jlcall_frame_func;
+static Function *gcroot_flush_func;
 
 static std::vector<Type *> two_pvalue_llvmt;
 static std::vector<Type *> three_pvalue_llvmt;
@@ -3386,6 +3387,7 @@ static void finalize_gc_frame(Function *F)
     M->getOrInsertFunction(gckill_func->getName(), gckill_func->getFunctionType());
     M->getOrInsertFunction(gcstore_func->getName(), gcstore_func->getFunctionType());
     M->getOrInsertFunction(jlcall_frame_func->getName(), jlcall_frame_func->getFunctionType());
+    M->getOrInsertFunction(gcroot_flush_func->getName(), gcroot_flush_func->getFunctionType());
     Function *jl_get_ptls_states = M->getFunction("jl_get_ptls_states");
 
     CallInst *ptlsStates = NULL;
@@ -3456,6 +3458,7 @@ void finalize_gc_frame(Module *m)
     m->getFunction("julia.gc_root_kill")->eraseFromParent();
     m->getFunction("julia.gc_store")->eraseFromParent();
     m->getFunction("julia.jlcall_frame_decl")->eraseFromParent();
+    m->getFunction("julia.gcroot_flush")->eraseFromParent();
 }
 
 static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_tupletype_t *argt,
@@ -5594,6 +5597,11 @@ static void init_julia_llvm_env(Module *m)
                      Function::ExternalLinkage,
                      "julia.jlcall_frame_decl", m);
     add_named_global(jlcall_frame_func, (void*)NULL, /*dllimport*/false);
+
+    gcroot_flush_func = Function::Create(FunctionType::get(T_void, false),
+                                         Function::ExternalLinkage,
+                                         "julia.gcroot_flush", m);
+    add_named_global(gcroot_flush_func, (void*)NULL, /*dllimport*/false);
 
     // set up optimization passes
 #ifdef LLVM37


### PR DESCRIPTION
Replaces https://github.com/JuliaLang/julia/pull/16034

This is the simplest case I can think of to teach the gcroot pass about when it is necessary to root something. We might need more intrinsic functions in the future and also make this pass handle state transition.

Fixes #15457 

Simple test case `@code_llvm current_module()`

Before

``` ll
define %jl_value_t* @jlsys_current_module_52283() #0 !dbg !6 {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #2
  %ptls_i8 = getelementptr i8, i8* %thread_ptr, i64 -2672
  %ptls = bitcast i8* %ptls_i8 to %jl_value_t***
  %0 = alloca [3 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [3 x %jl_value_t*], [3 x %jl_value_t*]* %0, i64 0, i64 0
  %1 = getelementptr [3 x %jl_value_t*], [3 x %jl_value_t*]* %0, i64 0, i64 2
  store %jl_value_t* null, %jl_value_t** %1, align 8
  %2 = bitcast [3 x %jl_value_t*]* %0 to i64*
  store i64 2, i64* %2, align 8
  %3 = getelementptr [3 x %jl_value_t*], [3 x %jl_value_t*]* %0, i64 0, i64 1
  %4 = bitcast i8* %ptls_i8 to i64*
  %5 = load i64, i64* %4, align 8
  %6 = bitcast %jl_value_t** %3 to i64*
  store i64 %5, i64* %6, align 8
  store %jl_value_t** %.sub, %jl_value_t*** %ptls, align 8
  %7 = call %jl_value_t* inttoptr (i64 140737346433504 to %jl_value_t* ()*)()
  store %jl_value_t* %7, %jl_value_t** %1, align 8
  %8 = load i64, i64* %6, align 8
  store i64 %8, i64* %4, align 8
  ret %jl_value_t* %7
}
```

After

``` ll
define %jl_value_t* @jlsys_current_module_52365() #0 !dbg !6 {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #2
  %0 = call %jl_value_t* inttoptr (i64 140737327140320 to %jl_value_t* ()*)()
  ret %jl_value_t* %0
}
```

(Note that the inline asm is removed later by machine code passes)
