### PR TITLE
Revise checkbounds again

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -51,6 +51,9 @@ end
 indices1{T}(A::AbstractArray{T,0}) = OneTo(1)
 indices1{T}(A::AbstractArray{T})   = (@_inline_meta; indices(A)[1])
 
+unsafe_indices(A) = indices(A)
+unsafe_indices(r::Range) = (OneTo(unsafe_length(r)),) # Ranges use checked_sub for size
+
 """
     linearindices(A)
 
@@ -248,6 +251,7 @@ Throw an error if the specified `indexes` are not in bounds for the given `array
 function checkbounds(A::AbstractArray, I...)
     @_inline_meta
     checkbounds(Bool, A, I...) || throw_boundserror(A, I)
+    nothing
 end
 checkbounds(A::AbstractArray) = checkbounds(A, 1) # 0-d case
 
@@ -1211,8 +1215,6 @@ nextL(L, l::Integer) = L*l
 nextL(L, r::AbstractUnitRange) = L*unsafe_length(r)
 offsetin(i, l::Integer) = i-1
 offsetin(i, r::AbstractUnitRange) = i-first(r)
-unsafe_length(r::UnitRange) = r.stop-r.start+1
-unsafe_length(r::OneTo) = length(r)
 
 ind2sub(::Tuple{}, ind::Integer) = (@_inline_meta; ind == 1 ? () : throw(BoundsError()))
 ind2sub(dims::DimsInteger, ind::Integer) = (@_inline_meta; _ind2sub(dims, ind-1))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -45,8 +45,11 @@ function indices{T,N}(A::AbstractArray{T,N})
     map(s->OneTo(s), size(A))
 end
 
+# Performance optimization: get rid of a branch on `d` in `indices(A,
+# d)` for d=1. 1d arrays are heavily used, and the first dimension
+# comes up in other applications.
 indices1{T}(A::AbstractArray{T,0}) = OneTo(1)
-indices1{T}(A::AbstractArray{T})   = indices(A)[1]
+indices1{T}(A::AbstractArray{T})   = (@_inline_meta; indices(A)[1])
 
 """
     linearindices(A)
@@ -60,8 +63,8 @@ is `indices(A, 1)`.
 Calling this function is the "safe" way to write algorithms that
 exploit linear indexing.
 """
-linearindices(A) = 1:length(A)
-linearindices(A::AbstractVector) = indices1(A)
+linearindices(A)                 = (@_inline_meta; 1:length(A))
+linearindices(A::AbstractVector) = (@_inline_meta; indices1(A))
 eltype{T}(::Type{AbstractArray{T}}) = T
 eltype{T,N}(::Type{AbstractArray{T,N}}) = T
 elsize{T}(::AbstractArray{T}) = sizeof(T)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -154,8 +154,8 @@ linearindexing(::LinearIndexing, ::LinearIndexing) = LinearSlow()
 # The overall hierarchy is
 #     `checkbounds(A, I...)` ->
 #         `checkbounds(Bool, A, I...)` -> either of:
-#             - `checkbounds_indices(IA, I)` which calls `checkindex(Bool, inds, i)`
-#             - `checkbounds_logical(A, I)` when `I` is a single logical array
+#             - `checkbounds_logical(Bool, A, I)` when `I` is a single logical array
+#             - `checkbounds_indices(Bool, IA, I)` otherwise (uses `checkindex`)
 #
 # See the "boundscheck" devdocs for more information.
 #
@@ -177,61 +177,12 @@ See also `checkindex`.
 """
 function checkbounds(::Type{Bool}, A::AbstractArray, I...)
     @_inline_meta
-    checkbounds_indices(indices(A), I)
+    checkbounds_indices(Bool, indices(A), I)
 end
 function checkbounds(::Type{Bool}, A::AbstractArray, I::AbstractArray{Bool})
     @_inline_meta
-    checkbounds_logical(A, I)
+    checkbounds_logical(Bool, A, I)
 end
-
-"""
-    checkbounds_indices(IA, I)
-
-checks whether the "requested" indices in the tuple `I` fall within
-the bounds of the "permitted" indices specified by the tuple
-`IA`. This function recursively consumes elements of these tuples,
-usually in a 1-for-1 fashion,
-
-    checkbounds_indices((IA1, IA...), (I1, I...)) = checkindex(Bool, IA1, I1) &
-                                                    checkbounds_indices(IA, I)
-
-Note that `checkindex` is being used to perform the actual
-bounds-check for a single dimension of the array.
-
-There are two important exceptions to the 1-1 rule: linear indexing and
-CartesianIndex{N}, both of which may "consume" more than one element
-of `IA`.
-"""
-function checkbounds_indices(IA::Tuple, I::Tuple)
-    @_inline_meta
-    checkindex(Bool, IA[1], I[1]) & checkbounds_indices(tail(IA), tail(I))
-end
-checkbounds_indices(::Tuple{},  ::Tuple{})    = true
-checkbounds_indices(::Tuple{}, I::Tuple{Any}) = (@_inline_meta; checkindex(Bool, 1:1, I[1]))
-function checkbounds_indices(::Tuple{}, I::Tuple)
-    @_inline_meta
-    checkindex(Bool, 1:1, I[1]) & checkbounds_indices((), tail(I))
-end
-function checkbounds_indices(IA::Tuple{Any}, I::Tuple{Any})
-    @_inline_meta
-    checkindex(Bool, IA[1], I[1])
-end
-function checkbounds_indices(IA::Tuple, I::Tuple{Any})
-    @_inline_meta
-    checkindex(Bool, 1:prod(map(dimlength, IA)), I[1])  # linear indexing
-end
-
-"""
-    checkbounds_logical(A, I::AbstractArray{Bool})
-
-tests whether the logical array `I` is consistent with the indices of `A`.
-"""
-checkbounds_logical(A::AbstractArray, I::AbstractArray{Bool})   = indices(A) == indices(I)
-checkbounds_logical(A::AbstractArray, I::AbstractVector{Bool})  = length(A) == length(I)
-checkbounds_logical(A::AbstractVector, I::AbstractArray{Bool})  = length(A) == length(I)
-checkbounds_logical(A::AbstractVector, I::AbstractVector{Bool}) = indices(A) == indices(I)
-
-throw_boundserror(A, I) = (@_noinline_meta; throw(BoundsError(A, I)))
 
 """
     checkbounds(A, I...)
@@ -244,6 +195,74 @@ function checkbounds(A::AbstractArray, I...)
     nothing
 end
 checkbounds(A::AbstractArray) = checkbounds(A, 1) # 0-d case
+
+"""
+    checkbounds_indices(Bool, IA, I)
+
+Return `true` if the "requested" indices in the tuple `I` fall within
+the bounds of the "permitted" indices specified by the tuple
+`IA`. This function recursively consumes elements of these tuples,
+usually in a 1-for-1 fashion,
+
+    checkbounds_indices(Bool, (IA1, IA...), (I1, I...)) = checkindex(Bool, IA1, I1) &
+                                                          checkbounds_indices(Bool, IA, I)
+
+Note that `checkindex` is being used to perform the actual
+bounds-check for a single dimension of the array.
+
+There are two important exceptions to the 1-1 rule: linear indexing and
+CartesianIndex{N}, both of which may "consume" more than one element
+of `IA`.
+"""
+function checkbounds_indices(::Type{Bool}, IA::Tuple, I::Tuple)
+    @_inline_meta
+    checkindex(Bool, IA[1], I[1]) & checkbounds_indices(Bool, tail(IA), tail(I))
+end
+checkbounds_indices(::Type{Bool}, ::Tuple{},  ::Tuple{})    = true
+checkbounds_indices(::Type{Bool}, ::Tuple{}, I::Tuple{Any}) = (@_inline_meta; checkindex(Bool, 1:1, I[1]))
+function checkbounds_indices(::Type{Bool}, ::Tuple{}, I::Tuple)
+    @_inline_meta
+    checkindex(Bool, 1:1, I[1]) & checkbounds_indices(Bool, (), tail(I))
+end
+function checkbounds_indices(::Type{Bool}, IA::Tuple{Any}, I::Tuple{Any})
+    @_inline_meta
+    checkindex(Bool, IA[1], I[1])
+end
+function checkbounds_indices(::Type{Bool}, IA::Tuple, I::Tuple{Any})
+    @_inline_meta
+    checkindex(Bool, 1:prod(map(dimlength, IA)), I[1])  # linear indexing
+end
+
+"""
+    checkbounds_logical(Bool, A, I::AbstractArray{Bool})
+
+Return `true` if the logical array `I` is consistent with the indices
+of `A`. `I` and `A` should have the same size and compatible indices.
+"""
+function checkbounds_logical(::Type{Bool}, A::AbstractArray, I::AbstractArray{Bool})
+    indices(A) == indices(I)
+end
+function checkbounds_logical(::Type{Bool}, A::AbstractArray, I::AbstractVector{Bool})
+    length(A) == length(I)
+end
+function checkbounds_logical(::Type{Bool}, A::AbstractVector, I::AbstractArray{Bool})
+    length(A) == length(I)
+end
+function checkbounds_logical(::Type{Bool}, A::AbstractVector, I::AbstractVector{Bool})
+    indices(A) == indices(I)
+end
+
+"""
+    checkbounds_logical(A, I::AbstractArray{Bool})
+
+Throw an error if the logical array `I` is inconsistent with the indices of `A`.
+"""
+function checkbounds_logical(A, I::AbstractVector{Bool})
+    checkbounds_logical(Bool, A, I) || throw_boundserror(A, I)
+    nothing
+end
+
+throw_boundserror(A, I) = (@_noinline_meta; throw(BoundsError(A, I)))
 
 @generated function trailingsize{T,N,n}(A::AbstractArray{T,N}, ::Type{Val{n}})
     (isa(n, Int) && isa(N, Int)) || error("Must have concrete type")

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -156,10 +156,10 @@ using .IteratorsMD
 ## Bounds-checking with CartesianIndex
 @inline checkbounds_indices(::Tuple{},   I::Tuple{CartesianIndex,Vararg{Any}}) =
     checkbounds_indices((), (I[1].I..., tail(I)...))
-@inline checkbounds_indices(inds::Tuple{Any}, I::Tuple{CartesianIndex,Vararg{Any}}) =
-    checkbounds_indices(inds, (I[1].I..., tail(I)...))
-@inline checkbounds_indices(inds::Tuple, I::Tuple{CartesianIndex,Vararg{Any}}) =
-    checkbounds_indices(inds, (I[1].I..., tail(I)...))
+@inline checkbounds_indices(IA::Tuple{Any}, I::Tuple{CartesianIndex,Vararg{Any}}) =
+    checkbounds_indices(IA, (I[1].I..., tail(I)...))
+@inline checkbounds_indices(IA::Tuple, I::Tuple{CartesianIndex,Vararg{Any}}) =
+    checkbounds_indices(IA, (I[1].I..., tail(I)...))
 
 # Support indexing with an array of CartesianIndex{N}s
 # Here we try to consume N of the indices (if there are that many available)
@@ -167,12 +167,12 @@ using .IteratorsMD
 @inline function checkbounds_indices{N}(::Tuple{}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
     checkindex(Bool, (), I[1]) & checkbounds_indices((), tail(I))
 end
-@inline function checkbounds_indices{N}(inds::Tuple{Any}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
-    checkindex(Bool, inds, I[1]) & checkbounds_indices((), tail(I))
+@inline function checkbounds_indices{N}(IA::Tuple{Any}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+    checkindex(Bool, IA, I[1]) & checkbounds_indices((), tail(I))
 end
-@inline function checkbounds_indices{N}(inds::Tuple, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
-    inds1, indsrest = IteratorsMD.split(inds, Val{N})
-    checkindex(Bool, inds1, I[1]) & checkbounds_indices(indsrest, tail(I))
+@inline function checkbounds_indices{N}(IA::Tuple, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+    IA1, IArest = IteratorsMD.split(IA, Val{N})
+    checkindex(Bool, IA1, I[1]) & checkbounds_indices(IArest, tail(I))
 end
 
 function checkindex{N}(::Type{Bool}, inds::Tuple, I::AbstractArray{CartesianIndex{N}})

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -154,31 +154,31 @@ end  # IteratorsMD
 using .IteratorsMD
 
 ## Bounds-checking with CartesianIndex
-@inline checkbounds_indices(::Tuple{},   I::Tuple{CartesianIndex,Vararg{Any}}) =
-    checkbounds_indices((), (I[1].I..., tail(I)...))
-@inline checkbounds_indices(IA::Tuple{Any}, I::Tuple{CartesianIndex,Vararg{Any}}) =
-    checkbounds_indices(IA, (I[1].I..., tail(I)...))
-@inline checkbounds_indices(IA::Tuple, I::Tuple{CartesianIndex,Vararg{Any}}) =
-    checkbounds_indices(IA, (I[1].I..., tail(I)...))
+@inline checkbounds_indices(::Type{Bool}, ::Tuple{},   I::Tuple{CartesianIndex,Vararg{Any}}) =
+    checkbounds_indices(Bool, (), (I[1].I..., tail(I)...))
+@inline checkbounds_indices(::Type{Bool}, IA::Tuple{Any}, I::Tuple{CartesianIndex,Vararg{Any}}) =
+    checkbounds_indices(Bool, IA, (I[1].I..., tail(I)...))
+@inline checkbounds_indices(::Type{Bool}, IA::Tuple, I::Tuple{CartesianIndex,Vararg{Any}}) =
+    checkbounds_indices(Bool, IA, (I[1].I..., tail(I)...))
 
 # Support indexing with an array of CartesianIndex{N}s
 # Here we try to consume N of the indices (if there are that many available)
 # The first two simply handle ambiguities
-@inline function checkbounds_indices{N}(::Tuple{}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
-    checkindex(Bool, (), I[1]) & checkbounds_indices((), tail(I))
+@inline function checkbounds_indices{N}(::Type{Bool}, ::Tuple{}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+    checkindex(Bool, (), I[1]) & checkbounds_indices(Bool, (), tail(I))
 end
-@inline function checkbounds_indices{N}(IA::Tuple{Any}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
-    checkindex(Bool, IA, I[1]) & checkbounds_indices((), tail(I))
+@inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple{Any}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+    checkindex(Bool, IA, I[1]) & checkbounds_indices(Bool, (), tail(I))
 end
-@inline function checkbounds_indices{N}(IA::Tuple, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+@inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
     IA1, IArest = IteratorsMD.split(IA, Val{N})
-    checkindex(Bool, IA1, I[1]) & checkbounds_indices(IArest, tail(I))
+    checkindex(Bool, IA1, I[1]) & checkbounds_indices(Bool, IArest, tail(I))
 end
 
 function checkindex{N}(::Type{Bool}, inds::Tuple, I::AbstractArray{CartesianIndex{N}})
     b = true
     for i in I
-        b &= checkbounds_indices(inds, (i,))
+        b &= checkbounds_indices(Bool, inds, (i,))
     end
     b
 end

--- a/base/range.jl
+++ b/base/range.jl
@@ -326,12 +326,17 @@ step(r::AbstractUnitRange) = 1
 step(r::FloatRange) = r.step/r.divisor
 step{T}(r::LinSpace{T}) = ifelse(r.len <= 0, convert(T,NaN), (r.stop-r.start)/r.divisor)
 
-function length(r::StepRange)
+unsafe_length(r::Range) = length(r)  # generic fallback
+
+function unsafe_length(r::StepRange)
     n = Integer(div(r.stop+r.step - r.start, r.step))
     isempty(r) ? zero(n) : n
 end
-length(r::AbstractUnitRange) = Integer(last(r) - first(r) + 1)
-length(r::OneTo) = r.stop
+length(r::StepRange) = unsafe_length(r)
+unsafe_length(r::AbstractUnitRange) = Integer(last(r) - first(r) + 1)
+unsafe_length(r::OneTo) = r.stop
+length(r::AbstractUnitRange) = unsafe_length(r)
+length(r::OneTo) = unsafe_length(r)
 length(r::FloatRange) = Integer(r.len)
 length(r::LinSpace) = Integer(r.len + signbit(r.len - 1))
 

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -278,17 +278,11 @@ end
 # they are taken from the range/vector
 # Since bounds-checking is performance-critical and uses
 # indices, it's worth optimizing these implementations thoroughly
-indices(S::SubArray) = (@_inline_meta; _indices_sub(S, 1, S.indexes...))
-_indices_sub(S::SubArray, dim::Int) = ()
-_indices_sub(S::SubArray, dim::Int, ::Real, I...) = (@_inline_meta; _indices_sub(S, dim+1, I...))
-_indices_sub(S::SubArray, dim::Int, ::Colon, I...) = (@_inline_meta; (indices(parent(S), dim), _indices_sub(S, dim+1, I...)...))
-_indices_sub(S::SubArray, dim::Int, i1::AbstractArray, I...) = (@_inline_meta; (indices(i1)..., _indices_sub(S, dim+1, I...)...))
-indices1(S::SubArray) = (@_inline_meta; _indices1(S, 1, S.indexes...))
-_indices1(S::SubArray, dim) = OneTo(1)
-_indices1(S::SubArray, dim, i1::Real, I...) = (@_inline_meta; _indices1(S, dim+1, I...))
-_indices1(S::SubArray, dim, i1::Colon, I...) = (@_inline_meta; indices(parent(S), dim))
-_indices1(S::SubArray, dim, i1::AbstractArray, I...) = (@_inline_meta; indices1(i1))
-_indices1{T}(S::SubArray, dim, i1::AbstractArray{T,0}, I...) = (@_inline_meta; _indices1(S, dim+1, I...))
+indices(S::SubArray) = (@_inline_pure_meta; _indices_sub(S, indices(S.parent), S.indexes...))
+_indices_sub(S::SubArray, pinds) = ()
+_indices_sub(S::SubArray, pinds, ::Real, I...) = _indices_sub(S, tail(pinds), I...)
+_indices_sub(S::SubArray, pinds, ::Colon, I...) = (pinds[1], _indices_sub(S, tail(pinds), I...)...)
+_indices_sub(S::SubArray, pinds, i1::AbstractArray, I...) = (unsafe_indices(i1)..., _indices_sub(S, tail(pinds), I...)...)
 
 ## Compatability
 # deprecate?

--- a/doc/devdocs/boundscheck.rst
+++ b/doc/devdocs/boundscheck.rst
@@ -67,8 +67,8 @@ The overall hierarchy is:
 
 |   ``checkbounds(A, I...)`` which calls
 |     ``checkbounds(Bool, A, I...)`` which calls either of:
-|       ``checkbounds_logical(A, I)``  when ``I`` is a single logical array
-|       ``checkbounds_indices(indices(A), I)`` otherwise
+|       ``checkbounds_logical(Bool, A, I)``  when ``I`` is a single logical array
+|       ``checkbounds_indices(Bool, indices(A), I)`` otherwise
 |
 
 Here ``A`` is the array, and ``I`` contains the "requested" indices.
@@ -85,8 +85,8 @@ dimensions handled by calling another important function,
 ``checkindex``: typically,
 ::
 
-   checkbounds_indices((IA1, IA...), (I1, I...)) = checkindex(Bool, IA1, I1) &
-                                                   checkbounds_indices(IA, I)
+   checkbounds_indices(Bool, (IA1, IA...), (I1, I...)) = checkindex(Bool, IA1, I1) &
+                                                         checkbounds_indices(Bool, IA, I)
 
 so ``checkindex`` checks a single dimension.  All of these functions,
 including the unexported ``checkbounds_indices`` and

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -616,19 +616,21 @@ Indexing, Assignment, and Concatenation
 
    Check two array shapes for compatibility, allowing trailing singleton dimensions, and return whichever shape has more dimensions.
 
-.. function:: checkbounds(array, indexes...)
+.. function:: checkbounds(A, I...)
 
    .. Docstring generated from Julia source
 
-   Throw an error if the specified ``indexes`` are not in bounds for the given ``array``\ .
+   Throw an error if the specified indices ``I`` are not in bounds for the given array ``A``\ .
 
-.. function:: checkbounds(Bool, array, indexes...)
+.. function:: checkbounds(Bool, A, I...)
 
    .. Docstring generated from Julia source
 
-   Return ``true`` if the specified ``indexes`` are in bounds for the given ``array``\ . Subtypes of ``AbstractArray`` should specialize this method if they need to provide custom bounds checking behaviors.
+   Return ``true`` if the specified indices ``I`` are in bounds for the given array ``A``\ . Subtypes of ``AbstractArray`` should specialize this method if they need to provide custom bounds checking behaviors; however, in many cases one can rely on ``A``\ 's indices and ``checkindex``\ .
 
-.. function:: checkindex(Bool, inds::UnitRange, index)
+   See also ``checkindex``\ .
+
+.. function:: checkindex(Bool, inds::AbstractUnitRange, index)
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1080,4 +1080,3 @@ dense counterparts. The following functions are specific to sparse arrays.
    For additional (algorithmic) information, and for versions of these methods that forgo argument checking, see (unexported) parent methods :func:`Base.SparseArrays.unchecked_noalias_permute!` and :func:`Base.SparseArrays.unchecked_aliasing_permute!`\ .
 
    See also: :func:`Base.SparseArrays.permute`
-

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -222,6 +222,9 @@ let undefvar
     err_str = @except_strbt (-1)^0.25 DomainError
     @test contains(err_str, "Exponentiation yielding a complex result requires a complex argument")
 
+    err_str = @except_str (1,2,3)[4] BoundsError
+    @test err_str == "BoundsError: attempt to access (1,2,3)\n  at index [4]"
+
     err_str = @except_str [5,4,3][-2,1] BoundsError
     @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [-2,1]"
     err_str = @except_str [5,4,3][1:5] BoundsError


### PR DESCRIPTION
`checkbounds` was revised in #17137 and #17340, but the latter left a few dangling uncalled `_chkbnds` in `multidimensional.jl`. Here's another proposed revision that will hopefully be performant ~~(haven't had time to test yet)~~ and also be a cleaner & more general API. As a bonus, this version is the first (to my knowledge) to ever support arrays of `CartesianIndex`es, which will be important if we ever decide to make `find*` return such arrays. Finally, lots of tests added.

CC @JeffBezanson, @mbauman, @andreasnoack (ref https://github.com/JuliaParallel/DistributedArrays.jl/pull/74).
