### PR TITLE
Rename AbstractIOBuffer, it's not an abstract type

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -455,7 +455,7 @@ end
 
 @deprecate bytestring(s::Cstring) unsafe_string(s)
 @deprecate bytestring(v::Vector{UInt8}) String(copy(v))
-@deprecate bytestring(io::Base.AbstractIOBuffer) String(io)
+@deprecate bytestring(io::Base.IOBufferBase) String(io)
 @deprecate bytestring(p::Union{Ptr{Int8},Ptr{UInt8}}) unsafe_string(p)
 @deprecate bytestring(p::Union{Ptr{Int8},Ptr{UInt8}}, len::Integer) unsafe_string(p,len)
 @deprecate bytestring(s::AbstractString...) string(s...)
@@ -792,6 +792,8 @@ function transpose(x)
         :transpose)
     return x
 end
+
+@deprecate_binding AbstractIOBuffer IOBufferBase
 
 # During the 0.5 development cycle, do not add any deprecations below this line
 # To be deprecated in 0.6

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -13,7 +13,7 @@ abstract LibuvServer <: IOServer
 abstract LibuvStream <: IO
 
 # IO
-# +- AbstractIOBuffer{T<:AbstractArray{UInt8,1}} (not exported)
+# +- IOBufferBase{T<:AbstractArray{UInt8,1}} (not exported)
 # +- AbstractPipe (not exported)
 # .  +- Pipe
 # .  +- Process (not exported)
@@ -28,7 +28,7 @@ abstract LibuvStream <: IO
 # .  +- TCPSocket
 # .  +- TTY (not exported)
 # .  +- UDPSocket
-# +- IOBuffer = Base.AbstractIOBuffer{Array{UInt8,1}}
+# +- IOBuffer = Base.IOBufferBase{Array{UInt8,1}}
 # +- IOStream
 
 # IOServer

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -69,7 +69,7 @@ print(io::IO, s::AbstractString) = (write(io, s); nothing)
 write(io::IO, s::AbstractString) = (len = 0; for c in s; len += write(io, c); end; len)
 show(io::IO, s::AbstractString) = print_quoted(io, s)
 
-write(to::AbstractIOBuffer, s::SubString{String}) =
+write(to::IOBufferBase, s::SubString{String}) =
     s.endof==0 ? 0 : write_sub(to, s.string.data, s.offset + 1, nextind(s, s.endof) - 1)
 
 ## printing literal quoted string data ##

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -123,8 +123,8 @@ using :func:`convert`:
 .. doctest:: foo-func
 
     julia> function foo()
-             x::Int8 = 100
-             x
+               x::Int8 = 100
+               x
            end
     foo (generic function with 1 method)
 
@@ -251,7 +251,7 @@ An important use of abstract types is to provide default implementations for
 concrete types. To give a simple example, consider::
 
     function myplus(x,y)
-     x+y
+        x+y
     end
 
 The first thing to note is that the above argument declarations are equivalent
@@ -266,7 +266,7 @@ arguments based on the generic function given above, i.e., it implicitly
 defines and compiles::
 
     function myplus(x::Int,y::Int)
-     x+y
+        x+y
     end
 
 and finally, it invokes this specific method.
@@ -378,9 +378,9 @@ operator:
 .. doctest::
 
     julia> type Foo
-             bar
-             baz::Int
-             qux::Float64
+               bar
+               baz::Int
+               qux::Float64
            end
 
 Fields with no type annotation default to :obj:`Any`, and can accordingly
@@ -477,8 +477,8 @@ It is also possible to define *immutable* composite types by using
 the keyword ``immutable`` instead of ``type``::
 
     immutable Complex
-      real::Float64
-      imag::Float64
+        real::Float64
+        imag::Float64
     end
 
 Such types behave much like other composite types, except that instances
@@ -620,16 +620,16 @@ Parametric Composite Types
 
     abstract Pointy{T}
     type Point{T} <: Pointy{T}
-      x::T
-      y::T
+        x::T
+        y::T
     end
 
 Type parameters are introduced immediately after the type name,
 surrounded by curly braces::
 
     type Point{T}
-      x::T
-      y::T
+        x::T
+        y::T
     end
 
 This declaration defines a new parametric type, ``Point{T}``, holding
@@ -853,8 +853,8 @@ example, have declared ``Point{T}`` to be a subtype of ``Pointy{T}`` as
 follows::
 
     type Point{T} <: Pointy{T}
-      x::T
-      y::T
+        x::T
+        y::T
     end
 
 Given such a declaration, for each choice of ``T``, we have ``Point{T}``
@@ -883,7 +883,7 @@ Consider if we create a point-like implementation that only requires a
 single coordinate because the point is on the diagonal line *x = y*::
 
     type DiagPoint{T} <: Pointy{T}
-      x::T
+        x::T
     end
 
 Now both ``Point{Float64}`` and ``DiagPoint{Float64}`` are
@@ -928,8 +928,8 @@ Type parameters for parametric composite types can be restricted in the
 same manner::
 
     type Point{T<:Real} <: Pointy{T}
-      x::T
-      y::T
+        x::T
+        y::T
     end
 
 To give a real-world example of how all this parametric type
@@ -938,8 +938,8 @@ machinery can be useful, here is the actual definition of Julia's
 for simplicity), representing an exact ratio of integers::
 
     immutable Rational{T<:Integer} <: Real
-      num::T
-      den::T
+        num::T
+        den::T
     end
 
 It only makes sense to take ratios of integer values, so the parameter
@@ -958,8 +958,8 @@ of one field. For example, a 2-element tuple type resembles the following
 immutable type::
 
     immutable Tuple2{A,B}
-      a::A
-      b::B
+        a::A
+        b::B
     end
 
 However, there are three key differences:

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -661,7 +661,7 @@ However, ``Point`` itself is also a valid type object:
     Point{T}
 
 Here the ``T`` is the dummy type symbol used in the original declaration
-of ``Point``. What does ``Point`` by itself mean? It is an abstract type
+of ``Point``. What does ``Point`` by itself mean? It is a type
 that contains all the specific instances ``Point{Float64}``,
 ``Point{AbstractString}``, etc.:
 


### PR DESCRIPTION
rename `AbstractIOBuffer` to `IOBufferBase`
ref discussion at https://github.com/JuliaLang/julia/pull/11554#commitcomment-16067265

~~Luckily very little code in base and no code in registered packages is using the constructor
for this type, only in dispatch (or in `precompile` calls) so this change should in theory not
be very noticeable. After we branch for release-0.5 we should consider removing the
parameterization and just call the type `IOBuffer`, since it doesn't look like anyone ever
uses any other type for the `data` field.~~
