### PR TITLE
RFC/WIP: Try to run gcroot lowering after some LLVM optimizations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ SRCS := \
 	alloc dlload sys init task array dump toplevel jl_uv \
 	simplevector APInt-C runtime_intrinsics runtime_ccall \
 	threadgroup threading stackwalk gc gc-debug gc-pages \
-   	jlapi signal-handling safepoint jloptions timing
+	jlapi signal-handling safepoint jloptions timing
 
 ifeq ($(USEMSVC), 1)
 SRCS += getopt
@@ -49,7 +49,7 @@ endif
 LLVMLINK :=
 
 ifeq ($(JULIACODEGEN),LLVM)
-SRCS += codegen jitlayers disasm debuginfo llvm-simdloop llvm-gcroot cgmemmgr
+SRCS += codegen jitlayers disasm debuginfo llvm-simdloop llvm-ptls llvm-gcroot cgmemmgr
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -761,7 +761,7 @@ public:
     {
         Function *F = dyn_cast<Function>(V);
         if (F) {
-            if (F->isIntrinsic()) {
+            if (isIntrinsicFunction(F)) {
                 return destModule->getOrInsertFunction(F->getName(),F->getFunctionType());
             }
             if (F->isDeclaration() || F->getParent() != destModule) {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -184,7 +184,7 @@ static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib,
                               runtime_lib);
 }
 
-// Map from distinct callee's to it's GOT entry.
+// Map from distinct callee's to its GOT entry.
 // In principle the attribute, function type and calling convention
 // don't need to be part of the key but it seems impossible to forward
 // all the arguments without writing assembly directly.
@@ -1019,15 +1019,20 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
 
     // the actual call
     builder.CreateCall(prepare_call(gcroot_flush_func));
+    SmallVector<Value*, 16> gc_uses;
+    for (size_t i = 0; i < nargt; ++i) {
+        const jl_cgval_t &arg = argv[i];
+        push_gc_use(gc_uses, arg);
+    }
+    // Mark GC use before **and** after the llvmcall to make sure the arguments
+    // are alive during the llvmcall even if the llvmcall has `unreachable`.
+    // If the llvmcall generates GC safepoint, it might need to emit its own
+    // gckill.
+    mark_gc_uses(gc_uses);
     CallInst *inst = builder.CreateCall(f, ArrayRef<Value*>(&argvals[0], nargt));
     if (isString)
         ctx->to_inline.push_back(inst);
-
-    // after the llvmcall mark fake uses of all of the arguments to ensure the were live
-    for (size_t i = 0; i < nargt; ++i) {
-        const jl_cgval_t &arg = argv[i];
-        mark_gc_use(arg);
-    }
+    mark_gc_uses(gc_uses);
 
     JL_GC_POP();
 
@@ -1757,6 +1762,21 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     //for (int i = 0; i < (nargs - 3) / 2 + sret; ++i)
     //    argvals[i]->dump();
 
+    // Mark GC use before **and** after the ccall to make sure the arguments
+    // are alive during the ccall even if the function called is `noreturn`.
+    SmallVector<Value*, 16> gc_uses;
+    for(i = 4; i < nargs + 1; i += 2) {
+        // Current C function parameter
+        size_t ai = (i - 4) / 2;
+        push_gc_use(gc_uses, argv[ai]);
+
+        // Julia (expression) value of current parameter gcroot
+        jl_value_t *argi = args[i + 1];
+        if (jl_is_long(argi)) continue;
+        jl_cgval_t arg = emit_expr(argi, ctx);
+        push_gc_use(gc_uses, arg);
+    }
+    mark_gc_uses(gc_uses);
     // the actual call
     Value *ret = builder.CreateCall(prepare_call(llvmf),
                                     ArrayRef<Value*>(&argvals[0], (nargs - 3) / 2 + sret));
@@ -1774,20 +1794,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         ctx->f->addFnAttr(Attribute::StackProtectReq);
     }
 
-    // after the ccall itself, mark fake uses of all of the arguments to ensure the were live,
-    // and run over the gcroot list and make give them a `mark_gc_use`
-    for(i = 4; i < nargs + 1; i += 2) {
-        // Current C function parameter
-        size_t ai = (i - 4) / 2;
-        mark_gc_use(argv[ai]);
-
-        // Julia (expression) value of current parameter gcroot
-        jl_value_t *argi = args[i + 1];
-        if (jl_is_long(argi)) continue;
-        jl_cgval_t arg = emit_expr(argi, ctx);
-        mark_gc_use(arg);
-    }
-
+    mark_gc_uses(gc_uses);
     JL_GC_POP();
     if (rt == jl_bottom_type) {
         // Do this after we marked all the GC uses.

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -85,8 +85,7 @@
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>
 
-#if defined(_CPU_ARM_) || defined(_CPU_AARCH64_) ||             \
-    (defined(LLVM37) && defined(JULIA_ENABLE_THREADING))
+#if defined(_CPU_ARM_) || defined(_CPU_AARCH64_)
 #  include <llvm/IR/InlineAsm.h>
 #endif
 #if defined(USE_POLLY)
@@ -257,7 +256,7 @@ static MDNode *tbaa_arrayptr;       // The pointer inside a jl_array_t
 static MDNode *tbaa_arraysize;      // A size in a jl_array_t
 static MDNode *tbaa_arraylen;       // The len in a jl_array_t
 static MDNode *tbaa_arrayflags;     // The flags in a jl_array_t
-static MDNode *tbaa_const;      // Memory that is immutable by the time LLVM can see it
+MDNode *tbaa_const;             // Memory that is immutable by the time LLVM can see it
 
 // Basic DITypes
 #ifdef LLVM37
@@ -388,7 +387,6 @@ static Function *jlarray_data_owner_func;
 
 // placeholder functions
 static Function *gcroot_func;
-static Function *gcstore_func;
 static Function *gckill_func;
 static Function *jlcall_frame_func;
 static Function *gcroot_flush_func;
@@ -3399,87 +3397,15 @@ static void allocate_gc_frame(BasicBlock *b0, jl_codectx_t *ctx)
                                          PointerType::get(T_psize, 0));
 }
 
-void jl_codegen_finalize_temp_arg(CallInst *ptlsStates, Type *T_pjlvalue,
-                                  MDNode *tbaa_gcframe);
-static void finalize_gc_frame(Function *F)
-{
-    Module *M = F->getParent();
-    M->getOrInsertFunction(gcroot_func->getName(), gcroot_func->getFunctionType());
-    M->getOrInsertFunction(gckill_func->getName(), gckill_func->getFunctionType());
-    M->getOrInsertFunction(gcstore_func->getName(), gcstore_func->getFunctionType());
-    M->getOrInsertFunction(jlcall_frame_func->getName(), jlcall_frame_func->getFunctionType());
-    M->getOrInsertFunction(gcroot_flush_func->getName(), gcroot_flush_func->getFunctionType());
-    Function *jl_get_ptls_states = M->getFunction("jl_get_ptls_states");
-
-    CallInst *ptlsStates = NULL;
-    for (BasicBlock::iterator i = F->getEntryBlock().begin(), e = F->getEntryBlock().end(); i != e; ++i) {
-        if (CallInst *callInst = dyn_cast<CallInst>(&*i)) {
-            if (callInst->getCalledFunction() == jl_get_ptls_states) {
-                ptlsStates = callInst;
-                break;
-            }
-        }
-    }
-    if (!ptlsStates)
-        return;
-
-    jl_codegen_finalize_temp_arg(ptlsStates, T_pjlvalue, tbaa_gcframe);
-
-#ifdef JULIA_ENABLE_THREADING
-    if (imaging_mode) {
-        GlobalVariable *GV = prepare_global(jltls_states_func_ptr, M);
-        Value *getter = tbaa_decorate(tbaa_const,
-                                      new LoadInst(GV, "", ptlsStates));
-        ptlsStates->setCalledFunction(getter);
-        ptlsStates->setAttributes(jltls_states_func->getAttributes());
-    }
-    else if (jl_tls_offset != -1) {
-#ifdef LLVM37
-        // Replace the function call with inline assembly if we know
-        // how to generate it.
-        const char *asm_str = nullptr;
-#  if defined(_CPU_X86_64_)
-        asm_str = "movq %fs:0, $0";
-#  elif defined(_CPU_X86_)
-        asm_str = "movl %gs:0, $0";
-#  elif defined(_CPU_AARCH64_)
-        asm_str = "mrs $0, tpidr_el0";
-#  endif
-        assert(asm_str && "Cannot emit thread pointer for this architecture.");
-        static auto offset = ConstantInt::getSigned(T_size, jl_tls_offset);
-        static auto tp = InlineAsm::get(FunctionType::get(T_pint8, false),
-                                        asm_str, "=r", false);
-        Value *tls = CallInst::Create(tp, "thread_ptr", ptlsStates);
-        tls = GetElementPtrInst::Create(T_int8, tls, {offset},
-                                        "ptls_i8", ptlsStates);
-        tls = new BitCastInst(tls, PointerType::get(T_ppjlvalue, 0),
-                              "ptls", ptlsStates);
-        ptlsStates->replaceAllUsesWith(tls);
-        ptlsStates->eraseFromParent();
-#endif
-    }
-#else
-    ptlsStates->replaceAllUsesWith(prepare_global(jltls_states_var, M));
-    ptlsStates->eraseFromParent();
-#endif
-}
-
+void jl_codegen_finalize_temp_arg(Function *F, MDNode *tbaa_gcframe);
 void finalize_gc_frame(Module *m)
 {
     for (Module::iterator I = m->begin(), E = m->end(); I != E; ++I) {
         Function *F = &*I;
         if (F->isDeclaration())
             continue;
-        finalize_gc_frame(F);
+        jl_codegen_finalize_temp_arg(F, tbaa_gcframe);
     }
-#ifndef JULIA_ENABLE_THREADING
-    m->getFunction("jl_get_ptls_states")->eraseFromParent();
-#endif
-    m->getFunction("julia.gc_root_decl")->eraseFromParent();
-    m->getFunction("julia.gc_root_kill")->eraseFromParent();
-    m->getFunction("julia.gc_store")->eraseFromParent();
-    m->getFunction("julia.jlcall_frame_decl")->eraseFromParent();
-    m->getFunction("julia.gcroot_flush")->eraseFromParent();
 }
 
 static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_tupletype_t *argt,
@@ -5186,12 +5112,6 @@ static void init_julia_llvm_env(Module *m)
     jltls_states_func = Function::Create(FunctionType::get(PointerType::get(T_ppjlvalue, 0), false),
                                          Function::ExternalLinkage,
                                          "jl_get_ptls_states", m);
-    jltls_states_func->setAttributes(
-        jltls_states_func->getAttributes()
-        .addAttribute(jltls_states_func->getContext(),
-                      AttributeSet::FunctionIndex, Attribute::ReadNone)
-        .addAttribute(jltls_states_func->getContext(),
-                      AttributeSet::FunctionIndex, Attribute::NoUnwind));
     add_named_global(jltls_states_func, jl_get_ptls_states_getter());
     if (imaging_mode) {
         PointerType *pfunctype = jltls_states_func->getFunctionType()->getPointerTo();
@@ -5607,13 +5527,6 @@ static void init_julia_llvm_env(Module *m)
                      Function::ExternalLinkage,
                      "julia.gc_root_kill", m);
     add_named_global(gckill_func, (void*)NULL, /*dllimport*/false);
-
-    Type* gc_store_args[2] = { T_ppjlvalue, T_pjlvalue }; // [1] <= [2]
-    gcstore_func =
-        Function::Create(FunctionType::get(T_void, makeArrayRef(gc_store_args),  false),
-                     Function::ExternalLinkage,
-                     "julia.gc_store", m);
-    add_named_global(gcstore_func, (void*)NULL, /*dllimport*/false);
 
     jlcall_frame_func =
         Function::Create(FunctionType::get(T_ppjlvalue, ArrayRef<Type*>(T_int32), false),

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -240,7 +240,7 @@ static Type *T_pppint8;
 static Type *T_void;
 
 // type-based alias analysis nodes.  Indentation of comments indicates hierarchy.
-static MDNode *tbaa_gcframe;    // GC frame
+MDNode *tbaa_gcframe;           // GC frame
 // LLVM should have enough info for alias analysis of non-gcframe stack slot
 // this is mainly a place holder for `jl_cgval_t::tbaa`
 static MDNode *tbaa_stack;      // stack slot
@@ -1095,7 +1095,6 @@ void *jl_get_llvmf(jl_tupletype_t *tt, bool getwrapper, bool getdeclarations)
         Function *f, *specf;
         jl_llvm_functions_t declarations;
         std::unique_ptr<Module> m = emit_function(temp ? temp : linfo, &declarations);
-        finalize_gc_frame(m.get());
         jl_globalPM->run(*m.get());
         f = (llvm::Function*)declarations.functionObject;
         specf = (llvm::Function*)declarations.specFunctionObject;
@@ -3395,17 +3394,6 @@ static void allocate_gc_frame(BasicBlock *b0, jl_codectx_t *ctx)
     int nthfield = offsetof(jl_tls_states_t, safepoint) / sizeof(void*);
     ctx->signalPage = emit_nthptr_recast(ctx->ptlsStates, nthfield, tbaa_const,
                                          PointerType::get(T_psize, 0));
-}
-
-void jl_codegen_finalize_temp_arg(Function *F, MDNode *tbaa_gcframe);
-void finalize_gc_frame(Module *m)
-{
-    for (Module::iterator I = m->begin(), E = m->end(); I != E; ++I) {
-        Function *F = &*I;
-        if (F->isDeclaration())
-            continue;
-        jl_codegen_finalize_temp_arg(F, tbaa_gcframe);
-    }
 }
 
 static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_tupletype_t *argt,

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -114,6 +114,7 @@ void addOptimizationPasses(PassManager *PM)
 #   endif
 #endif
     if (jl_options.opt_level == 0) {
+        PM->add(createLowerPTLSPass(imaging_mode, tbaa_const));
         return;
     }
 #ifdef LLVM37
@@ -140,6 +141,9 @@ void addOptimizationPasses(PassManager *PM)
 #ifndef INSTCOMBINE_BUG
     PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
 #endif
+    // Let the InstCombine pass remove the unnecessary load of
+    // safepoint address first
+    PM->add(createLowerPTLSPass(imaging_mode, tbaa_const));
     PM->add(createSROAPass());                 // Break up aggregate allocas
 #ifndef INSTCOMBINE_BUG
     PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -64,7 +64,6 @@ GlobalVariable *jl_emit_sysimg_slot(Module *m, Type *typ, const char *name,
 void* jl_get_global(GlobalVariable *gv);
 GlobalVariable *jl_get_global_for(const char *cname, void *addr, Module *M);
 void jl_add_to_shadow(Module *m);
-void finalize_gc_frame(Module *m);
 void jl_finalize_function(Function *F, Module *collector = NULL);
 void jl_finalize_module(Module *m, bool shadow);
 
@@ -220,5 +219,12 @@ JL_DLLEXPORT extern LLVMContext &jl_LLVMContext;
 #endif
 
 extern MDNode *tbaa_const;
+extern MDNode *tbaa_gcframe;
 
 Pass *createLowerPTLSPass(bool imaging_mode, MDNode *tbaa_const);
+Pass *createLowerGCFramePass(MDNode *tbaa_gcframe);
+// Whether the Function is an llvm or julia intrinsic.
+static inline bool isIntrinsicFunction(Function *F)
+{
+    return F->isIntrinsic() || F->getName().startswith("julia.");
+}

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -218,3 +218,7 @@ JL_DLLEXPORT extern LLVMContext jl_LLVMContext;
 #else
 JL_DLLEXPORT extern LLVMContext &jl_LLVMContext;
 #endif
+
+extern MDNode *tbaa_const;
+
+Pass *createLowerPTLSPass(bool imaging_mode, MDNode *tbaa_const);

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -37,105 +37,35 @@ static struct {
 } jl_gc_frame_stats = {0};
 #endif
 
-class JuliaGCAllocator {
-public:
-    JuliaGCAllocator(CallInst *ptlsStates, Type *T_pjlvalue, MDNode *tbaa) :
-        F(*ptlsStates->getParent()->getParent()),
-        M(*F.getParent()),
-        T_int1(Type::getInt1Ty(F.getContext())),
-        T_int8(Type::getInt8Ty(F.getContext())),
-        T_int32(Type::getInt32Ty(F.getContext())),
-        T_int64(Type::getInt64Ty(F.getContext())),
-        V_null(Constant::getNullValue(T_pjlvalue)),
-        ptlsStates(ptlsStates),
-        gcframe(new AllocaInst(T_pjlvalue, ConstantInt::get(T_int32, 0))),
-        gcroot_func(M.getFunction("julia.gc_root_decl")),
-        gckill_func(M.getFunction("julia.gc_root_kill")),
-        gc_store_func(M.getFunction("julia.gc_store")),
-        jlcall_frame_func(M.getFunction("julia.jlcall_frame_decl")),
-        gcroot_flush_func(M.getFunction("julia.gcroot_flush")),
-        tbaa_gcframe(tbaa)
-    {
-/* Algorithm sketch:
- *  Compute liveness for each basic block
- *    liveness computed at the basic-block level for <inst, arg-offset> pairs
- *  Propagate liveness from each basic block to its predecessors
- *  Allocate argument slot for each jlcall frame
- */
-#ifdef JL_DEBUG_BUILD
-        gcframe->setName("gcrootframe");
-#endif
-        gcframe->insertAfter(ptlsStates);
-        assert(gcroot_func && gckill_func && jlcall_frame_func && gc_store_func);
-    }
-
-private:
-Function &F;
-Module &M;
-Type *const T_int1;
-Type *const T_int8;
-Type *const T_int32;
-Type *const T_int64;
-Value *const V_null;
-CallInst *const ptlsStates;
-AllocaInst *const gcframe;
-Function *const gcroot_func;
-Function *const gckill_func;
-Function *const gc_store_func;
-Function *const jlcall_frame_func;
-Function *const gcroot_flush_func;
-MDNode *const tbaa_gcframe;
-
 typedef std::pair<CallInst*, unsigned> frame_register;
-class liveness {
-public:
+struct liveness {
     typedef unsigned id;
     enum {
-        assign = 1<<0, // an assignment to a gcroot exists in the basic-block (potentially no live-in from the predecessor basic-blocks)
-        kill   = 1<<1, // a use of a gcroot exists in the basic-block (potentially a "kill" and no live-out to the successor basic-blocks)
-        live   = 1<<2  // the gcroot is live over the entire basic-block (the assign/kill are not dominating of entry/exit)
-            // live | kill | assign == a usage and assignment exist, but it is also live on exit, the entry liveness depends on whether a store or use is encountered first
-            // live | kill == a usage exists, but the value must be live for the entire basic-block since it is not the terminal usage in the domination tree
-            // kill | assign == a usage and definition exist in domination order, so the actual lifetime is only a subset of the basic-block
-            // live | assign == impossible (this would be strange)
+        // an assignment to a gcroot exists in the basic-block
+        // (potentially no live-in from the predecessor basic-blocks)
+        assign = 1<<0,
+        // a use of a gcroot exists in the basic-block
+        // (potentially a "kill" and no live-out to the successor basic-blocks)
+        kill   = 1<<1,
+        // the gcroot is live over the entire basic-block
+        // (the assign/kill are not dominating of entry/exit)
+        live   = 1<<2
+
+        // live | kill | assign:
+        //     a usage and assignment exist, but it is also live on exit,
+        //     the entry liveness depends on whether a store or use is
+        //     encountered first
+        // live | kill:
+        //     a usage exists,
+        //     but the value must be live for the entire basic-block
+        //     since it is not the terminal usage in the domination tree
+        // kill | assign:
+        //     a usage and definition exist in domination order,
+        //     so the actual lifetime is only a subset of the basic-block
+        // live | assign:
+        //     impossible (this would be strange)
     };
 };
-
-    void tbaa_decorate_gcframe(Instruction *inst, std::set<Instruction*> &visited)
-    {
-        if (visited.find(inst) != visited.end())
-            return;
-        visited.insert(inst);
-#ifdef LLVM35
-        Value::user_iterator I = inst->user_begin(), E = inst->user_end();
-#else
-        Value::use_iterator I = inst->use_begin(), E = inst->use_end();
-#endif
-        for (;I != E;++I) {
-            Instruction *user = dyn_cast<Instruction>(*I);
-            if (!user) {
-                continue;
-            } else if (isa<GetElementPtrInst>(user)) {
-                if (__likely(user->getOperand(0) == inst)) {
-                    tbaa_decorate_gcframe(user, visited);
-                }
-            } else if (isa<StoreInst>(user)) {
-                if (user->getOperand(1) == inst) {
-                    user->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_gcframe);
-                }
-            } else if (isa<LoadInst>(user)) {
-                user->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_gcframe);
-            } else if (isa<BitCastInst>(user)) {
-                tbaa_decorate_gcframe(user, visited);
-            }
-        }
-    }
-
-    void tbaa_decorate_gcframe(Instruction *inst)
-    {
-        std::set<Instruction*> visited;
-        tbaa_decorate_gcframe(inst, visited);
-    }
 
 #ifndef NDEBUG // llvm assertions build
 // gdb debugging code for inspecting the bb_uses map
@@ -153,7 +83,106 @@ void jl_dump_bb_uses(std::map<BasicBlock*, std::map<frame_register, liveness::id
 }
 #endif
 
-Instruction *get_pgcstack(Instruction *ptlsStates)
+static void tbaa_decorate_gcframe(Instruction *inst,
+                                  std::set<Instruction*> &visited,
+                                  MDNode *tbaa_gcframe)
+{
+    if (visited.find(inst) != visited.end())
+        return;
+    visited.insert(inst);
+#ifdef LLVM35
+    Value::user_iterator I = inst->user_begin(), E = inst->user_end();
+#else
+    Value::use_iterator I = inst->use_begin(), E = inst->use_end();
+#endif
+    for (;I != E;++I) {
+        Instruction *user = dyn_cast<Instruction>(*I);
+        if (!user) {
+            continue;
+        } else if (isa<GetElementPtrInst>(user)) {
+            if (__likely(user->getOperand(0) == inst)) {
+                tbaa_decorate_gcframe(user, visited, tbaa_gcframe);
+            }
+        } else if (isa<StoreInst>(user)) {
+            if (user->getOperand(1) == inst) {
+                user->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_gcframe);
+            }
+        } else if (isa<LoadInst>(user)) {
+            user->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_gcframe);
+        } else if (isa<BitCastInst>(user)) {
+            tbaa_decorate_gcframe(user, visited, tbaa_gcframe);
+        }
+    }
+}
+
+static void tbaa_decorate_gcframe(Instruction *inst, MDNode *tbaa_gcframe)
+{
+    std::set<Instruction*> visited;
+    tbaa_decorate_gcframe(inst, visited, tbaa_gcframe);
+}
+
+class JuliaGCAllocator {
+public:
+    JuliaGCAllocator(CallInst *ptlsStates, Type *T_pjlvalue, MDNode *tbaa) :
+        F(*ptlsStates->getParent()->getParent()),
+        M(*F.getParent()),
+        T_int1(Type::getInt1Ty(F.getContext())),
+        T_int8(Type::getInt8Ty(F.getContext())),
+        T_int32(Type::getInt32Ty(F.getContext())),
+        T_int64(Type::getInt64Ty(F.getContext())),
+        V_null(Constant::getNullValue(T_pjlvalue)),
+        ptlsStates(ptlsStates),
+        gcframe(new AllocaInst(T_pjlvalue, ConstantInt::get(T_int32, 0))),
+        gcroot_func(M.getFunction("julia.gc_root_decl")),
+        gckill_func(M.getFunction("julia.gc_root_kill")),
+        jlcall_frame_func(M.getFunction("julia.jlcall_frame_decl")),
+        gcroot_flush_func(M.getFunction("julia.gcroot_flush")),
+        tbaa_gcframe(tbaa)
+    {
+/* Algorithm sketch:
+ *  Compute liveness for each basic block
+ *    liveness computed at the basic-block level for <inst, arg-offset> pairs
+ *  Propagate liveness from each basic block to its predecessors
+ *  Allocate argument slot for each jlcall frame
+ */
+#ifdef JL_DEBUG_BUILD
+        gcframe->setName("gcrootframe");
+#endif
+        gcframe->insertAfter(ptlsStates);
+    }
+
+private:
+    Function &F;
+    Module &M;
+    Type *const T_int1;
+    Type *const T_int8;
+    Type *const T_int32;
+    Type *const T_int64;
+    Value *const V_null;
+    CallInst *const ptlsStates;
+    AllocaInst *const gcframe;
+    Function *const gcroot_func;
+    Function *const gckill_func;
+    Function *const jlcall_frame_func;
+    Function *const gcroot_flush_func;
+    MDNode *const tbaa_gcframe;
+
+    Instruction *get_pgcstack(Instruction *ptlsStates);
+    frame_register get_gcroot(Value *ptr);
+    void collapseRedundantRoots();
+    bool record_usage(CallInst *callInst,
+        std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses,
+        std::map<BasicBlock*, SmallBitVector> &regs_used,
+        unsigned &offset, bool commit=true);
+    unsigned find_space_for(CallInst *callInst,
+        std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses,
+        std::map<BasicBlock*, SmallBitVector> &regs_used);
+    void rearrangeRoots();
+public:
+    void allocate_frame();
+};
+
+Instruction *JuliaGCAllocator::get_pgcstack(Instruction *ptlsStates)
 {
     Constant *offset = ConstantInt::getSigned(T_int32, offsetof(jl_tls_states_t, pgcstack) / sizeof(void*));
     return GetElementPtrInst::Create(
@@ -163,7 +192,7 @@ Instruction *get_pgcstack(Instruction *ptlsStates)
             "jl_pgcstack");
 }
 
-frame_register get_gcroot(Value *ptr)
+frame_register JuliaGCAllocator::get_gcroot(Value *ptr)
 {
     frame_register frame;
     frame.first = dyn_cast<CallInst>(ptr);
@@ -173,7 +202,7 @@ frame_register get_gcroot(Value *ptr)
         if (GetElementPtrInst *gepInst = dyn_cast<GetElementPtrInst>(ptr)) {
             if (gepInst->getNumIndices() == 1) {
                 frame.first = dyn_cast<CallInst>(gepInst->getPointerOperand());
-                if (frame.first && frame.first->getCalledFunction() == jlcall_frame_func)
+                if (frame.first && frame.first->getCalledValue() == jlcall_frame_func)
                     frame.second = cast<ConstantInt>(gepInst->idx_begin()->get())->getZExtValue();
                 else
                     frame.first = NULL;
@@ -183,12 +212,12 @@ frame_register get_gcroot(Value *ptr)
     return frame;
 }
 
-void collapseRedundantRoots()
+void JuliaGCAllocator::collapseRedundantRoots()
 {
     for (BasicBlock::iterator I = gcframe->getParent()->begin(), E(gcframe); I != E; ) {
         CallInst* callInst = dyn_cast<CallInst>(&*I);
         ++I;
-        if (callInst && callInst->getCalledFunction() == gcroot_func) {
+        if (callInst && callInst->getCalledValue() == gcroot_func) {
             // see if a root is only used briefly for `store -> load -> store other` pattern or `store, store other`
             // such that the first store can be trivially replaced with just "other" and delete the chain
             // or if is used for store, but the value is never needed
@@ -290,7 +319,7 @@ void collapseRedundantRoots()
                         frame_register gcroot_other_gep = get_gcroot(theOther->getPointerOperand());
                         CallInst *gcroot_other = gcroot_other_gep.first;
                         // it could be a gcroot...
-                        if (gcroot_other && gcroot_other->getCalledFunction() == gcroot_func && theStore != NULL) {
+                        if (gcroot_other && gcroot_other->getCalledValue() == gcroot_func && theStore != NULL) {
                             // need to make sure there aren't any other uses of gcroot_other (including gckill)
                             // between the initial store and the replacement store
                             // TODO: do this better once we have liveness information for locals?
@@ -339,7 +368,7 @@ void collapseRedundantRoots()
                             }
                         }
                         // ...or it could be a jlcall frame
-                        else if (gcroot_other && gcroot_other->getCalledFunction() == jlcall_frame_func) {
+                        else if (gcroot_other && gcroot_other->getCalledValue() == jlcall_frame_func) {
                             // jlcall_frame_func slots are effectively SSA,
                             // so it's always safe to merge an earlier store into it
                             // but do need to update liveness information for this slot
@@ -386,10 +415,10 @@ void collapseRedundantRoots()
     }
 }
 
-bool record_usage(CallInst *callInst,
+bool JuliaGCAllocator::record_usage(CallInst *callInst,
         std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses,
         std::map<BasicBlock*, SmallBitVector> &regs_used,
-        unsigned &offset, bool commit=true)
+        unsigned &offset, bool commit)
 {
 /* record-usage(inst, bb-uses, regs-used, offset, commit=true)
  *     for (arg-offset, operand) in enumerate(arguments(inst))
@@ -447,7 +476,7 @@ bool record_usage(CallInst *callInst,
     return true;
 }
 
-unsigned find_space_for(CallInst *callInst,
+unsigned JuliaGCAllocator::find_space_for(CallInst *callInst,
         std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses,
         std::map<BasicBlock*, SmallBitVector> &regs_used)
 {
@@ -463,7 +492,7 @@ unsigned find_space_for(CallInst *callInst,
     return n;
 }
 
-void rearrangeRoots()
+void JuliaGCAllocator::rearrangeRoots()
 {
     for (auto BB = F.begin(), E(F.end()); BB != E; BB++) {
         auto terminst = BB->getTerminator();
@@ -481,14 +510,14 @@ void rearrangeRoots()
             if (LoadInst *loadInst = dyn_cast<LoadInst>(inst)) {
                 CallInst *loadAddr =
                     dyn_cast<CallInst>(loadInst->getPointerOperand());
-                if (loadAddr && loadAddr->getCalledFunction() == gcroot_func)
+                if (loadAddr && loadAddr->getCalledValue() == gcroot_func)
                     break;
                 continue;
             }
             if (StoreInst *storeInst = dyn_cast<StoreInst>(inst)) {
                 CallInst *storeAddr =
                     dyn_cast<CallInst>(storeInst->getPointerOperand());
-                if (storeAddr && storeAddr->getCalledFunction() == gcroot_func)
+                if (storeAddr && storeAddr->getCalledValue() == gcroot_func)
                     toRemove.push_back(storeInst);
                 continue;
             }
@@ -505,8 +534,7 @@ void rearrangeRoots()
     }
 }
 
-public:
-void allocate_frame()
+void JuliaGCAllocator::allocate_frame()
 {
     Instruction *last_gcframe_inst = gcframe;
     collapseRedundantRoots();
@@ -524,7 +552,7 @@ void allocate_frame()
     for (BasicBlock::iterator I = gcframe->getParent()->begin(), E(gcframe); I != E; ) {
         CallInst* callInst = dyn_cast<CallInst>(&*I);
         ++I;
-        if (callInst && callInst->getCalledFunction() == jlcall_frame_func) {
+        if (callInst && callInst->getCalledValue() == jlcall_frame_func) {
             BasicBlock *bb = NULL;
             unsigned arg_n = cast<ConstantInt>(callInst->getArgOperand(0))->getZExtValue();
             frames.push(std::make_pair(arg_n, callInst));
@@ -579,7 +607,7 @@ void allocate_frame()
             if (StoreInst *storeInst = dyn_cast<StoreInst>(i)) {
                 frame_register def = get_gcroot(storeInst->getPointerOperand());
                 if (CallInst *callInst = def.first) {
-                    if (callInst->getCalledFunction() == jlcall_frame_func) {
+                    if (callInst->getCalledValue() == jlcall_frame_func) {
                         std::map<frame_register, liveness::id>::iterator inuse_reg = inuse_list.find(def);
                         if (inuse_reg != inuse_list.end() && inuse_reg->second == liveness::kill) {
                             inuse_reg->second |= liveness::assign;
@@ -653,7 +681,7 @@ void allocate_frame()
             if (StoreInst *storeInst = dyn_cast<StoreInst>(&*i)) {
                 frame_register def = get_gcroot(storeInst->getPointerOperand());
                 if (CallInst *callInst = def.first) {
-                    if (callInst->getCalledFunction() == jlcall_frame_func) {
+                    if (callInst->getCalledValue() == jlcall_frame_func) {
                         std::map<frame_register, liveness::id>::iterator inuse_reg = inuse_list.find(def);
                         if (inuse_reg != inuse_list.end() && (inuse_reg->second & liveness::live)) {
                             inuse_reg->second |= liveness::assign;
@@ -710,7 +738,7 @@ void allocate_frame()
             ++i;
             // delete the now unused gckill information
             if (CallInst* callInst = dyn_cast<CallInst>(inst)) {
-                Value *callee = callInst->getCalledFunction();
+                Value *callee = callInst->getCalledValue();
                 if (callee == gckill_func || callee == gcroot_flush_func) {
                     callInst->eraseFromParent();
                 }
@@ -719,7 +747,7 @@ void allocate_frame()
             else if (StoreInst *storeInst = dyn_cast<StoreInst>(inst)) {
                 frame_register def = get_gcroot(storeInst->getPointerOperand());
                 if (CallInst *gcroot = def.first) {
-                    if (gcroot->getCalledFunction() == jlcall_frame_func) {
+                    if (gcroot->getCalledValue() == jlcall_frame_func) {
                         std::map<frame_register, liveness::id> &inuse_list = bb_uses[storeInst->getParent()];
                         std::map<frame_register, liveness::id>::iterator inuse_reg = inuse_list.find(def);
                         if (inuse_reg == inuse_list.end())
@@ -746,7 +774,7 @@ void allocate_frame()
         // finalize all of the jlcall frames by replacing all of the frames with the appropriate gep(tempslot)
         for (std::map<CallInst*, unsigned>::iterator frame = frame_offsets.begin(), framee = frame_offsets.end(); frame != framee; ++frame) {
             CallInst *gcroot = frame->first;
-            tbaa_decorate_gcframe(gcroot);
+            tbaa_decorate_gcframe(gcroot, tbaa_gcframe);
             Value* offset[1] = {ConstantInt::get(T_int32, frame->second)};
             GetElementPtrInst *gep = GetElementPtrInst::Create(LLVM37_param(NULL) tempSlot, makeArrayRef(offset));
             gep->insertAfter(last_gcframe_inst);
@@ -773,7 +801,7 @@ void allocate_frame()
         Instruction* inst = &*I;
         ++I;
         if (CallInst* callInst = dyn_cast<CallInst>(inst)) {
-            if (callInst->getCalledFunction() == gcroot_func) {
+            if (callInst->getCalledValue() == gcroot_func) {
                 unsigned offset = 2 + argSpaceSize++;
                 Instruction *argTempi = GetElementPtrInst::Create(LLVM37_param(NULL) gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, offset)));
                 argTempi->insertAfter(last_gcframe_inst);
@@ -806,7 +834,7 @@ void allocate_frame()
                     }
                 }
 #endif
-                tbaa_decorate_gcframe(callInst);
+                tbaa_decorate_gcframe(callInst, tbaa_gcframe);
                 callInst->replaceAllUsesWith(argTempi);
                 argTempi->takeName(callInst);
                 callInst->eraseFromParent();
@@ -896,11 +924,31 @@ void allocate_frame()
 #endif
 }
 
-};
-
-void jl_codegen_finalize_temp_arg(CallInst *ptlsStates, Type *T_pjlvalue,
-                                  MDNode *tbaa)
+void jl_codegen_finalize_temp_arg(Function *F, MDNode *tbaa)
 {
+    Module *M = F->getParent();
+
+    Function *ptls_getter = M->getFunction("jl_get_ptls_states");
+    if (!ptls_getter)
+        return;
+
+    CallInst *ptlsStates = NULL;
+    for (auto I = F->getEntryBlock().begin(), E = F->getEntryBlock().end();
+         I != E; ++I) {
+        if (CallInst *callInst = dyn_cast<CallInst>(&*I)) {
+            if (callInst->getCalledValue() == ptls_getter) {
+                ptlsStates = callInst;
+                break;
+            }
+        }
+    }
+    if (!ptlsStates)
+        return;
+
+    FunctionType *functype = ptls_getter->getFunctionType();
+    auto T_ppjlvalue =
+        cast<PointerType>(functype->getReturnType())->getElementType();
+    auto T_pjlvalue = cast<PointerType>(T_ppjlvalue)->getElementType();
     JuliaGCAllocator allocator(ptlsStates, T_pjlvalue, tbaa);
     allocator.allocate_frame();
 }

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -1,0 +1,193 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+#define DEBUG_TYPE "lower_ptls"
+#undef DEBUG
+
+// LLVM pass to optimize TLS access and remove references to julia intrinsics
+
+#include "llvm-version.h"
+#include "support/dtypes.h"
+
+#include <llvm/Pass.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/LLVMContext.h>
+
+#include "julia.h"
+#include "julia_internal.h"
+
+#if defined(LLVM37) && defined(JULIA_ENABLE_THREADING)
+#  include <llvm/IR/InlineAsm.h>
+#endif
+
+using namespace llvm;
+
+namespace {
+
+struct LowerPTLS: public ModulePass {
+    static char ID;
+    LowerPTLS(bool _imaging_mode=false, MDNode *_tbaa_const=nullptr)
+        : ModulePass(ID),
+          imaging_mode(_imaging_mode),
+          tbaa_const(_tbaa_const)
+    {}
+
+private:
+    bool imaging_mode;
+    MDNode *tbaa_const; // One `LLVMContext` only
+    bool runOnModule(Module &M) override;
+    void runOnFunction(LLVMContext &ctx, Module &M, Function *F,
+                       Function *ptls_getter, Type *T_ppjlvalue);
+};
+
+static void ensure_global(const char *name, Type *t, Module &M,
+                          bool dllimport=false)
+{
+    if (M.getNamedValue(name))
+        return;
+    GlobalVariable *proto = new GlobalVariable(M, t, false,
+                                               GlobalVariable::ExternalLinkage,
+                                               NULL, name);
+#ifdef _OS_WINDOWS_
+    // setting JL_DLLEXPORT correctly only matters when building a binary
+    // (global_proto will strip this from the JIT)
+    if (dllimport) {
+#ifdef LLVM35
+        // add the __declspec(dllimport) attribute
+        proto->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
+#else
+        proto->setLinkage(GlobalValue::DLLImportLinkage);
+#endif
+    }
+#else // _OS_WINDOWS_
+    (void)proto;
+#endif // _OS_WINDOWS_
+}
+
+void LowerPTLS::runOnFunction(LLVMContext &ctx, Module &M, Function *F,
+                              Function *ptls_getter, Type *T_ppjlvalue)
+{
+    CallInst *ptlsStates = NULL;
+    for (auto I = F->getEntryBlock().begin(), E = F->getEntryBlock().end();
+         I != E; ++I) {
+        if (CallInst *callInst = dyn_cast<CallInst>(&*I)) {
+            if (callInst->getCalledValue() == ptls_getter) {
+                ptlsStates = callInst;
+                break;
+            }
+        }
+    }
+    if (!ptlsStates)
+        return;
+
+    if (ptlsStates->use_empty()) {
+        ptlsStates->eraseFromParent();
+        return;
+    }
+
+#ifdef JULIA_ENABLE_THREADING
+    if (imaging_mode) {
+        GlobalVariable *GV = cast<GlobalVariable>(
+            M.getNamedValue("jl_get_ptls_states.ptr"));
+        LoadInst *getter = new LoadInst(GV, "", ptlsStates);
+        getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
+        ptlsStates->setCalledFunction(getter);
+        ptlsStates->addAttribute(AttributeSet::FunctionIndex,
+                                 Attribute::ReadNone);
+        ptlsStates->addAttribute(AttributeSet::FunctionIndex,
+                                 Attribute::NoUnwind);
+    }
+    else if (jl_tls_offset != -1) {
+#ifdef LLVM37
+        auto T_int8 = Type::getInt8Ty(ctx);
+        auto T_pint8 = PointerType::get(T_int8, 0);
+        auto T_size = (sizeof(size_t) == 8 ? Type::getInt64Ty(ctx) :
+                       Type::getInt32Ty(ctx));
+        // Replace the function call with inline assembly if we know
+        // how to generate it.
+        const char *asm_str = nullptr;
+#  if defined(_CPU_X86_64_)
+        asm_str = "movq %fs:0, $0";
+#  elif defined(_CPU_X86_)
+        asm_str = "movl %gs:0, $0";
+#  elif defined(_CPU_AARCH64_)
+        asm_str = "mrs $0, tpidr_el0";
+#  endif
+        assert(asm_str && "Cannot emit thread pointer for this architecture.");
+        auto offset = ConstantInt::getSigned(T_size, jl_tls_offset);
+        auto tp = InlineAsm::get(FunctionType::get(T_pint8, false),
+                                 asm_str, "=r", false);
+        Value *tls = CallInst::Create(tp, "thread_ptr", ptlsStates);
+        tls = GetElementPtrInst::Create(T_int8, tls, {offset},
+                                        "ptls_i8", ptlsStates);
+        tls = new BitCastInst(tls, PointerType::get(T_ppjlvalue, 0),
+                              "ptls", ptlsStates);
+        ptlsStates->replaceAllUsesWith(tls);
+        ptlsStates->eraseFromParent();
+#endif
+    }
+    else {
+        ptlsStates->addAttribute(AttributeSet::FunctionIndex,
+                                 Attribute::ReadNone);
+        ptlsStates->addAttribute(AttributeSet::FunctionIndex,
+                                 Attribute::NoUnwind);
+    }
+#else
+    ptlsStates->replaceAllUsesWith(M.getNamedValue("jl_tls_states"));
+    ptlsStates->eraseFromParent();
+#endif
+}
+
+static void eraseFunction(Module &M, const char *name)
+{
+    if (Function *f = M.getFunction(name)) {
+        f->eraseFromParent();
+    }
+}
+
+bool LowerPTLS::runOnModule(Module &M)
+{
+    // Cleanup for GC frame lowering.
+    eraseFunction(M, "julia.gc_root_decl");
+    eraseFunction(M, "julia.gc_root_kill");
+    eraseFunction(M, "julia.jlcall_frame_decl");
+    eraseFunction(M, "julia.gcroot_flush");
+
+    Function *ptls_getter = M.getFunction("jl_get_ptls_states");
+    if (!ptls_getter)
+        return true;
+    LLVMContext &ctx = M.getContext();
+    FunctionType *functype = ptls_getter->getFunctionType();
+    auto T_ppjlvalue =
+        cast<PointerType>(functype->getReturnType())->getElementType();
+#ifdef JULIA_ENABLE_THREADING
+    if (imaging_mode)
+        ensure_global("jl_get_ptls_states.ptr", functype->getPointerTo(), M);
+#else
+    ensure_global("jl_tls_states", T_ppjlvalue, M, imaging_mode);
+#endif
+    for (auto F = M.begin(), E = M.end(); F != E; ++F) {
+        if (F->isDeclaration())
+            continue;
+        runOnFunction(ctx, M, &*F, ptls_getter, T_ppjlvalue);
+    }
+#ifndef JULIA_ENABLE_THREADING
+    ptls_getter->eraseFromParent();
+#endif
+    return true;
+}
+
+char LowerPTLS::ID = 0;
+
+static RegisterPass<LowerPTLS> X("LowerPTLS", "LowerPTLS Pass",
+                                 false /* Only looks at CFG */,
+                                 false /* Analysis Pass */);
+
+} // anonymous namespace
+
+Pass *createLowerPTLSPass(bool imaging_mode, MDNode *tbaa_const)
+{
+    return new LowerPTLS(imaging_mode, tbaa_const);
+}


### PR DESCRIPTION
I believe some constant propagation (mostly store to load forwarding) would help some GC frame optimization to identify possible duplicate roots. Instead of making our own for special cases, it would be nice if we could let llvm do that. This requires running some LLVM passes before we do the GC frame lowering.

This PR solves the easy part of it, i.e. making the lowering a true LLVM pass and making sure we have enough information in the optimized IR for liveness analysis. (mostly to make sure that the `julia.gc_kill` won't be deleted due to dead branch).

The goal is to at least be able to run the lowering after mem2reg (and the instcombine after it). A lot of issues still need to be solve.
1. We need to trace back bitcast and gep when identifying the address of gcframe stores/loads
2. Need to make sure we can still identify the use of the value after llvm optimizes the IR (possibly by adding more explicit marks in the IR)

If this approach looks good and tests passes, we can probably merge this first and improve the algorithm later.

Based on https://github.com/JuliaLang/julia/pull/17352 to reduce conflicts.

c.c. @vtjnash 
