### PR TITLE
Avoid checking the diagonal for non-real elements when constructing Hermitians

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -211,6 +211,9 @@ This section lists changes that do not have deprecation warnings.
     the type of `n`). Use the corresponding mutating functions `randperm!` and `randcycle!`
     to control the array type ([#22723]).
 
+  * Hermitian now ignores any imaginary components in the diagonal instead of checking
+    the diagonal. ([#17367])
+
   * Worker-worker connections are setup lazily for an `:all_to_all` topology. Use keyword
     arg `lazy=false` to force all connections to be setup during a `addprocs` call. ([#22814])
 

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -928,8 +928,34 @@ convert(::Type{Sparse}, A::SparseMatrixCSC{Complex{Float32},<:ITypes}) =
     convert(Sparse, convert(SparseMatrixCSC{Complex{Float64},SuiteSparse_long}, A))
 convert(::Type{Sparse}, A::Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}}) =
     Sparse(A.data, A.uplo == 'L' ? -1 : 1)
-convert(::Type{Sparse}, A::Hermitian{Tv,SparseMatrixCSC{Tv,SuiteSparse_long}}) where {Tv<:VTypes} =
-    Sparse(A.data, A.uplo == 'L' ? -1 : 1)
+# The convert method for Hermitian is very similar to the general convert method, but we need to
+# remove any non real elements in the diagonal because, in contrast to BLAS/LAPACK these are not
+# ignored by CHOLMOD. If even tiny imaginary parts are present CHOLMOD will fail with a non-positive
+# definite/zero pivot error.
+function convert(::Type{Sparse}, AH::Hermitian{Tv,SparseMatrixCSC{Tv,SuiteSparse_long}}) where {Tv<:VTypes}
+    A = AH.data
+
+    # Here we allocate a Symmetric/Hermitian CHOLMOD.Sparse matrix so we only need to copy
+    # a single triangle of AH
+    o = allocate_sparse(A.m, A.n, length(A.nzval), true, true, AH.uplo == 'L' ? -1 : 1, Tv)
+    s = unsafe_load(o.p)
+    for i = 1:length(A.colptr)
+        unsafe_store!(s.p, A.colptr[i] - 1, i)
+    end
+    for i = 1:length(A.rowval)
+        unsafe_store!(s.i, A.rowval[i] - 1, i)
+    end
+    for j = 1:A.n
+        for ip = A.colptr[j]:A.colptr[j + 1] - 1
+            v = A.nzval[ip]
+            unsafe_store!(s.x, ifelse(A.rowval[ip] == j, real(v), v), ip)
+        end
+    end
+
+    @isok check_sparse(o)
+
+    return o
+end
 function convert(::Type{Sparse},
                  A::Union{SparseMatrixCSC{BigFloat,Ti},
                           Symmetric{BigFloat,SparseMatrixCSC{BigFloat,Ti}},

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -349,6 +349,12 @@ end
     @test eigvals(Mi7647) == eigvals(Mi7647, 0.5, 3.5) == [1.0:3.0;]
 end
 
+@testset "Hermitian wrapper ignores imaginary parts on diagonal" begin
+    A = [1.0+im 2.0; 2.0 0.0]
+    @test !ishermitian(A)
+    @test Hermitian(A)[1,1] == 1
+end
+
 @testset "Issue #7933" begin
     A7933 = [1 2; 3 4]
     B7933 = copy(A7933)
@@ -363,10 +369,10 @@ end
     @test_throws ArgumentError f(A, 1:4)
 end
 
-@testset "Issue #10671" begin
+@testset "Ignore imaginary part of Hermitian diagonal" begin
     A = [1.0+im 2.0; 2.0 0.0]
     @test !ishermitian(A)
-    @test_throws ArgumentError Hermitian(A)
+    @test diag(Hermitian(A)) == real(diag(A))
 end
 
 @testset "Issue #17780" begin

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -692,6 +692,14 @@ end
     @test F\b ≈ ones(m + n)
 end
 
+@testset "Test that imaginary parts in Hermitian{T,SparseMatrixCSC{T}} are ignored" begin
+    A = sparse([1,2,3,4,1], [1,2,3,4,2], [complex(2.0,1),2,2,2,1])
+    Fs = cholfact(Hermitian(A))
+    Fd = cholfact(Hermitian(Array(A)))
+    @test sparse(Fs) ≈ Hermitian(A)
+    @test Fs\ones(4) ≈ Fd\ones(4)
+end
+
 @testset "\\ '\\ and .'\\" begin
     # Test that \ and '\ and .'\ work for Symmetric and Hermitian. This is just
     # a dispatch exercise so it doesn't matter that the complex matrix has


### PR DESCRIPTION
The point in `Hermitian` is to create a Hermitian view of a matrix. Therefore, the error below, which is thrown on 0.4 and master, is causing frustration and has been reported several times.

``` jl
julia> complex(randn(3,3), randn(3,3)) |> t -> Hermitian(t'*(eye(3)/3)*t)
ERROR: ArgumentError: Cannot construct Hermitian from matrix with nonreal diagonals
 in call at linalg/symmetric.jl:16
 in call at linalg/symmetric.jl:14
 in anonymous at none:1
 in |> at operators.jl:198
```

This PR partly reverts #10672 by removing the check of the diagonal on construction.
