### PR TITLE
Add some docs to threading constructs

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -13,7 +13,7 @@ threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 """
     Threads.nthreads()
 
-Get the number of threads available to the Julia process. This is the inclusive upper bound 
+Get the number of threads available to the Julia process. This is the inclusive upper bound
 on `threadid()`.
 """
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
@@ -60,9 +60,9 @@ end
 """
     Threads.@threads
 
-A macro to parallelize a for-loop to run with multiple threads. This spawns `nthreads()` 
-number of threads, splits the iteration space amongst them, and iterates in parallel. 
-A barrier is placed at the end of the loop which waits for all the threads to finish 
+A macro to parallelize a for-loop to run with multiple threads. This spawns `nthreads()`
+number of threads, splits the iteration space amongst them, and iterates in parallel.
+A barrier is placed at the end of the loop which waits for all the threads to finish
 execution, and the loop returns.
 """
 macro threads(args...)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -3,7 +3,7 @@
 export threadid, nthreads, @threads
 
 """
-`threadid()`
+    `threadid()`
 
 Get the ID number of the current thread of execution. The master thread has ID `1`.
 """
@@ -11,9 +11,10 @@ threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
 # Inclusive upper bound on threadid()
 """
-`nthreads()`
+    `nthreads()`
 
-Get the number of threads available to the Julia process. This is the inclusive upper bound on `threadid()`.
+Get the number of threads available to the Julia process. This is the inclusive upper bound 
+on `threadid()`.
 """
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 
@@ -57,9 +58,12 @@ function _threadsfor(iter,lbody)
     end
 end
 """
-`@threads`
+    `@threads`
 
-A macro to parallelize a for-loop to run with multiple threads. This spawns `nthreads()` number of threads, splits the iteration space amongst them, and iterates in parallel. A barrier is placed at the end of the loop which waits for all the threads to finish execution, and the loop returns.
+A macro to parallelize a for-loop to run with multiple threads. This spawns `nthreads()` 
+number of threads, splits the iteration space amongst them, and iterates in parallel. 
+A barrier is placed at the end of the loop which waits for all the threads to finish 
+execution, and the loop returns.
 
 """
 macro threads(args...)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -3,7 +3,7 @@
 export threadid, nthreads, @threads
 
 """
-    threadid()
+    Threads.threadid()
 
 Get the ID number of the current thread of execution. The master thread has ID `1`.
 """
@@ -11,7 +11,7 @@ threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
 # Inclusive upper bound on threadid()
 """
-    nthreads()
+    Threads.nthreads()
 
 Get the number of threads available to the Julia process. This is the inclusive upper bound 
 on `threadid()`.
@@ -58,7 +58,7 @@ function _threadsfor(iter,lbody)
     end
 end
 """
-    @threads
+    Threads.@threads
 
 A macro to parallelize a for-loop to run with multiple threads. This spawns `nthreads()` 
 number of threads, splits the iteration space amongst them, and iterates in parallel. 

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -2,9 +2,19 @@
 
 export threadid, nthreads, @threads
 
+"""
+`threadid()`
+
+Get the ID number of the current thread of execution. The master thread has ID `0`.
+"""
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
 # Inclusive upper bound on threadid()
+"""
+`nthreads()`
+
+Get the number of threads available to the Julia process. This is the exclsuive upper bound on `threadid()`.
+"""
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 
 function _threadsfor(iter,lbody)
@@ -46,7 +56,12 @@ function _threadsfor(iter,lbody)
         ccall(:jl_threading_run, Void, (Any,), Core.svec($fun))
     end
 end
+"""
+`@threads`
 
+A macro to parallelize a for-loop to run with multiple threads. This spawns `nthreads()` number of threads, splits the iteration space amongst them, and iterates in parallel. A barrier is placed at the end of the loop which waits for all the threads to finish execution, and the loop returns.
+
+"""
 macro threads(args...)
     na = length(args)
     if na != 1

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -5,7 +5,7 @@ export threadid, nthreads, @threads
 """
 `threadid()`
 
-Get the ID number of the current thread of execution. The master thread has ID `0`.
+Get the ID number of the current thread of execution. The master thread has ID `1`.
 """
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
@@ -13,7 +13,7 @@ threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 """
 `nthreads()`
 
-Get the number of threads available to the Julia process. This is the exclsuive upper bound on `threadid()`.
+Get the number of threads available to the Julia process. This is the inclusive upper bound on `threadid()`.
 """
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -3,7 +3,7 @@
 export threadid, nthreads, @threads
 
 """
-    `threadid()`
+    threadid()
 
 Get the ID number of the current thread of execution. The master thread has ID `1`.
 """
@@ -11,7 +11,7 @@ threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
 # Inclusive upper bound on threadid()
 """
-    `nthreads()`
+    nthreads()
 
 Get the number of threads available to the Julia process. This is the inclusive upper bound 
 on `threadid()`.
@@ -58,13 +58,12 @@ function _threadsfor(iter,lbody)
     end
 end
 """
-    `@threads`
+    @threads
 
 A macro to parallelize a for-loop to run with multiple threads. This spawns `nthreads()` 
 number of threads, splits the iteration space amongst them, and iterates in parallel. 
 A barrier is placed at the end of the loop which waits for all the threads to finish 
 execution, and the loop returns.
-
 """
 macro threads(args...)
     na = length(args)

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -1019,8 +1019,8 @@ called ``JULIA_NUM_THREADS``. Now, let's start up Julia with 4 threads::
 
 (The above command works on bourne shells on Linux and OSX. Note that if you're using
 a C shell on these platforms, you should use the keyword ``set`` instead of ``export``.
-If you're on Windows, start up the command line in location of ``julia.exe`` and use ``set``
-of ``export``.)
+If you're on Windows, start up the command line in the location of ``julia.exe`` and
+use ``set`` instead of ``export``.)
 
 Let's verify there are 4 threads at our disposal. ::
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -999,20 +999,20 @@ functionality and interface should be considered experimental in nature and may 
 
 Multi-threading (Experimental)
 -------------------------------
-In addition to tasks, remote calls and remote references, Julia from v0.5 will natively support 
-multi-threading. Note that this section is experimental and the interfaces may change in the 
+In addition to tasks, remote calls and remote references, Julia from v0.5 will natively support
+multi-threading. Note that this section is experimental and the interfaces may change in the
 future.
 
-Setup 
+Setup
 =====
 
-By default, Julia starts up with a single thread of execution. This can be verified by 
+By default, Julia starts up with a single thread of execution. This can be verified by
 using the command :obj:`Threads.nthreads()`::
 
     julia> Threads.nthreads()
     1
 
-The number of threads Julia starts up with is controlled by an environment variable 
+The number of threads Julia starts up with is controlled by an environment variable
 called ``JULIA_NUM_THREADS``. Now, let's start up Julia with 4 threads::
 
     export JULIA_NUM_THREADS=4
@@ -1050,10 +1050,10 @@ Let's work a simple example using our native threads. Let us create an array of 
      0.0
      0.0
 
-Let us operate on this array simultaneously using 4 threads. We'll have each thread write 
-its thread ID into each location. 
+Let us operate on this array simultaneously using 4 threads. We'll have each thread write
+its thread ID into each location.
 
-Julia supports parallel loops using the :obj:`Threads.@threads` macro. This macro is affixed in front 
+Julia supports parallel loops using the :obj:`Threads.@threads` macro. This macro is affixed in front
 of a ``for`` loop to indicate to Julia that the loop is a multi-threaded region. ::
 
     Threads.@threads for i = 1:10
@@ -1075,7 +1075,7 @@ The iteration space is split amongst the threads, after which each thread writes
      4.0
      4.0
 
-Note that :obj:`Threads.@threads` does not have an optional reduction parameter like :obj:`@parallel`. 
+Note that :obj:`Threads.@threads` does not have an optional reduction parameter like :obj:`@parallel`.
 
 .. rubric:: Footnotes
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -1013,10 +1013,14 @@ using the command :obj:`Threads.nthreads()`::
     1
 
 The number of threads Julia starts up with is controlled by an environment variable 
-called ``JULIA_NUM_THREADS``. (Note that if you're using a C shell, you should use the keyword 
-``set`` instead of ``export``). Now, let's start up Julia with 4 threads::
+called ``JULIA_NUM_THREADS``. Now, let's start up Julia with 4 threads::
 
     export JULIA_NUM_THREADS=4
+
+(The above command works on bourne shells on Linux and OSX. Note that if you're using
+a C shell on these platforms, you should use the keyword ``set`` instead of ``export``.
+If you're on Windows, start up the command line in location of ``julia.exe`` and use ``set``
+of ``export``.)
 
 Let's verify there are 4 threads at our disposal. ::
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -1013,7 +1013,8 @@ using the command :obj:`Threads.nthreads()`::
     1
 
 The number of threads Julia starts up with is controlled by an environment variable 
-called ``JULIA_NUM_THREADS``. Now, let's start up Julia with 4 threads::
+called ``JULIA_NUM_THREADS``. (Note that if you're using a C shell, you should use the keyword 
+``set`` instead of ``export``). Now, let's start up Julia with 4 threads::
 
     export JULIA_NUM_THREADS=4
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -999,36 +999,38 @@ functionality and interface should be considered experimental in nature and may 
 
 Multi-threading (Experimental)
 -------------------------------
-In addition to tasks, remote calls and remote references, Julia from v0.5 will natively support multi-threading. 
+In addition to tasks, remote calls and remote references, Julia from v0.5 will natively support 
+multi-threading. Note that this section is experimental and the interfaces may change in the 
+future.
 
-### Setup 
-First, load the threading module into your workspace::
-
-    using Base.Threads
+Setup 
+=====
 
 By default, Julia starts up with a single thread of execution. This can be verified by 
-using the command :obj:`nthreads()`::
+using the command :obj:`Threads.nthreads()`::
 
-    julia> nthreads()
+    julia> Threads.nthreads()
     1
 
 The number of threads Julia starts up with is controlled by an environment variable 
-called `JULIA_NUM_THREADS`. Now, let's start up Julia with 4 threads.::
+called ``JULIA_NUM_THREADS``. Now, let's start up Julia with 4 threads::
+
     export JULIA_NUM_THREADS=4
 
-Let's verify there are 4 threads at our disposal::
+Let's verify there are 4 threads at our disposal. ::
 
-    julia> using Base.Threads
-    julia> nthreads()
+    julia> Threads.nthreads()
     4
 
-But we are currently on the master thread. To check, we use the command :obj:`threadid()`::
-    julia> threadid()
+But we are currently on the master thread. To check, we use the command :obj:`Threads.threadid()` ::
+
+    julia> Threads.threadid()
     1
 
-### `@threads`
+The ``@threads`` Macro
+=======================
 
-Let's work a simple example using our native threads. Let us create an array of zeros.::
+Let's work a simple example using our native threads. Let us create an array of zeros::
 
     julia> a = zeros(10)
     10-element Array{Float64,1}:
@@ -1046,10 +1048,10 @@ Let's work a simple example using our native threads. Let us create an array of 
 Let us operate on this array simultaneously using 4 threads. We'll have each thread write 
 its thread ID into each location. 
 
-Julia supports parallel loops using the :obj:`@threads` macro. This macro is affixed in front 
-of a `for` loop to indicate to Julia that the loop is a multi-threaded region. ::
+Julia supports parallel loops using the :obj:`Threads.@threads` macro. This macro is affixed in front 
+of a ``for`` loop to indicate to Julia that the loop is a multi-threaded region. ::
 
-    @threads for i = 1:10
+    Threads.@threads for i = 1:10
         a[i] = threadid()
     end
 
@@ -1068,7 +1070,7 @@ The iteration space is split amongst the threads, after which each thread writes
      4.0
      4.0
 
-Note that :obj:`@threads` does not have an optional reduction parameter like :obj:`@parallel`. 
+Note that :obj:`Threads.@threads` does not have an optional reduction parameter like :obj:`@parallel`. 
 
 .. rubric:: Footnotes
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -997,6 +997,79 @@ Keyword argument ``topology`` to ``addprocs`` is used to specify how the workers
 Currently sending a message between unconnected workers results in an error. This behaviour, as also the
 functionality and interface should be considered experimental in nature and may change in future releases.
 
+Multi-threading (Experimental)
+-------------------------------
+In addition to tasks, remote calls and remote references, Julia from v0.5 will natively support multi-threading. 
+
+### Setup 
+First, load the threading module into your workspace::
+
+    using Base.Threads
+
+By default, Julia starts up with a single thread of execution. This can be verified by 
+using the command :obj:`nthreads()`::
+
+    julia> nthreads()
+    1
+
+The number of threads Julia starts up with is controlled by an environment variable 
+called `JULIA_NUM_THREADS`. Now, let's start up Julia with 4 threads.::
+    export JULIA_NUM_THREADS=4
+
+Let's verify there are 4 threads at our disposal::
+
+    julia> using Base.Threads
+    julia> nthreads()
+    4
+
+But we are currently on the master thread. To check, we use the command :obj:`threadid()`::
+    julia> threadid()
+    1
+
+### `@threads`
+
+Let's work a simple example using our native threads. Let us create an array of zeros.::
+
+    julia> a = zeros(10)
+    10-element Array{Float64,1}:
+     0.0
+     0.0
+     0.0
+     0.0
+     0.0
+     0.0
+     0.0
+     0.0
+     0.0
+     0.0
+
+Let us operate on this array simultaneously using 4 threads. We'll have each thread write 
+its thread ID into each location. 
+
+Julia supports parallel loops using the :obj:`@threads` macro. This macro is affixed in front 
+of a `for` loop to indicate to Julia that the loop is a multi-threaded region. ::
+
+    @threads for i = 1:10
+        a[i] = threadid()
+    end
+
+The iteration space is split amongst the threads, after which each thread writes its thread ID to its assigned locations.::
+
+    julia> a
+    10-element Array{Float64,1}:
+     1.0
+     1.0
+     1.0
+     2.0
+     2.0
+     2.0
+     3.0
+     3.0
+     4.0
+     4.0
+
+Note that :obj:`@threads` does not have an optional reduction parameter like :obj:`@parallel`. 
+
 .. rubric:: Footnotes
 
 .. [#mpi2rma] In this context, MPI refers to the MPI-1 standard. Beginning with MPI-2, the MPI standards committee introduced a new set of communication mechanisms, collectively referred to as Remote Memory Access (RMA). The motivation for adding RMA to the MPI standard was to facilitate one-sided communication patterns. For additional information on the latest MPI standard, see http://www.mpi-forum.org/docs.

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -657,6 +657,24 @@ This experimental interface supports Julia's multi-threading
 capabilities. Types and function described here might (and likely
 will) change in the future.
 
+.. function:: Threads.threadid()
+
+   .. Docstring generated from Julia source
+
+   Get the ID number of the current thread of execution. The master thread has ID ``1``\ .
+
+.. function:: Threads.nthreads()
+
+   .. Docstring generated from Julia source
+
+   Get the number of threads available to the Julia process. This is the inclusive upper bound  on ``threadid()``\ .
+
+.. function:: Threads.@threads
+
+   .. Docstring generated from Julia source
+
+   A macro to parallelize a for-loop to run with multiple threads. This spawns ``nthreads()``  number of threads, splits the iteration space amongst them, and iterates in parallel.  A barrier is placed at the end of the loop which waits for all the threads to finish  execution, and the loop returns.
+
 .. function:: Threads.Atomic{T}
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
This adds some docs to `nthreads()`, `threadid()` and `@threads`. 

Fixes #16862.

cc: @yuyichao @ViralBShah 
