### PR TITLE
Fix #17366 (cmdline parsing of repeated `--`)

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -202,11 +202,7 @@ try_include(path::AbstractString) = isfile(path) && include(path)
 function process_options(opts::JLOptions)
     if !isempty(ARGS)
         idxs = find(x -> x == "--", ARGS)
-        if length(idxs) > 1
-            println(STDERR, "julia: redundant option terminator `--`")
-            exit(1)
-        end
-        deleteat!(ARGS, idxs)
+        length(idxs) > 0 && deleteat!(ARGS, idxs[1])
     end
     repl                  = true
     startup               = (opts.startupfile != 2)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -213,7 +213,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes`
             @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar --baz`) == "String[\"foo\",\"-bar\",\"--baz\"]"
             @test split(readchomp(`$exename -L $testfile $testfile`), '\n') == ["String[\"$(escape(testfile))\"]", "String[]"]
             @test !success(`$exename --foo $testfile`)
-            @test !success(`$exename -L $testfile -e 'exit(0)' -- foo -bar -- baz`)
+            @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar -- baz`) == "String[\"foo\",\"-bar\",\"--\",\"baz\"]"
         finally
             rm(testfile)
         end


### PR DESCRIPTION
This just passes through the `--` arguments from the command line after the first one (which is used as an argument separator).
Previously, passing more than one `--` raised an error, which seems overprotective: after all, consider that you could even have a file called `--` in the filesystem, if you're really into that sort of things...

So this fixes #17366, and it seems conceptually more correct to me (provided I didn't screw up, I'm not familiar with this code and command line parsing may have been assuming the previous behaviour for some reason, but I did not find any hint that it was).

I think this should also be backported, if it gets in.
