### PR TITLE
use -O0 mode for precompilation

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -455,7 +455,7 @@ function create_expr_cache(input::AbstractString, output::AbstractString)
             eval(Main, deserialize(STDIN))
         end
         """
-    io, pobj = open(pipeline(detach(`$(julia_cmd())
+    io, pobj = open(pipeline(detach(`$(julia_cmd()) -O0
                                     --output-ji $output --output-incremental=yes
                                     --startup-file=no --history-file=no
                                     --color=$(have_color ? "yes" : "no")

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -591,7 +591,7 @@ function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
             end
         end
     """
-    io, pobj = open(pipeline(detach(`$(Base.julia_cmd())
+    io, pobj = open(pipeline(detach(`$(Base.julia_cmd()) -O0
                                     --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
                                     --history-file=no
                                     --color=$(Base.have_color ? "yes" : "no")


### PR DESCRIPTION
it's rarely useful to run in -O2 mode when compiling code, since that work is usually thrown away quickly, but potentially greatly slowing down the precompilation process

ref #15048 (after PR: llvm 3.3: 25s; llvm 32s)
