### PR TITLE
disable gcroot creation for a value with an existing root

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1033,7 +1033,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
                         builder.CreateGEP(data_pointer(strct, ctx), idx)));
             if ((unsigned)stt->ninitialized != nfields)
                 null_pointer_check(fld, ctx);
-            *ret = mark_julia_type(fld, true, jl_any_type, ctx, true);
+            *ret = mark_julia_type(fld, true, jl_any_type, ctx, strct.gcroot || !strct.isimmutable);
             return true;
         }
         else if (is_tupletype_homogeneous(stt->types)) {
@@ -1110,7 +1110,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
             Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
             if (idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
-            jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx, true);
+            jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx, strct.gcroot || !strct.isimmutable);
             return ret;
         }
         else {


### PR DESCRIPTION
when loading a value from a struct that didn't need a local gcroot,
the loaded value also doesn't require a gcroot if the struct was immutable

fix #17342
