### PR TITLE
Avoid useless OOB checks for ccall array arguments

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -103,7 +103,7 @@ macro irrational(sym, val, def)
             c = BigFloat()
             ccall(($(string("mpfr_const_", def)), :libmpfr),
                   Cint, (Ptr{BigFloat}, Int32),
-                  &c, MPFR.ROUNDING_MODE[end])
+                  &c, MPFR.ROUNDING_MODE[])
             return c
         end
     end : quote

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -192,24 +192,24 @@ end
 
 function Base.start(bi::GitBranchIter)
     ref_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
-    btype = Cint[0]
+    btype = Ref{Cint}()
     err = ccall((:git_branch_next, :libgit2), Cint,
                  (Ptr{Ptr{Void}}, Ptr{Cint}, Ptr{Void}),
                   ref_ptr_ptr, btype, bi.ptr)
     err != Int(Error.GIT_OK) && return (nothing, -1, true)
-    return (GitReference(ref_ptr_ptr[]), btype[1], false)
+    return (GitReference(ref_ptr_ptr[]), btype[], false)
 end
 
 Base.done(bi::GitBranchIter, state) = Bool(state[3])
 
 function Base.next(bi::GitBranchIter, state)
     ref_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
-    btype = Cint[0]
+    btype = Ref{Cint}()
     err = ccall((:git_branch_next, :libgit2), Cint,
                  (Ptr{Ptr{Void}}, Ptr{Cint}, Ptr{Void}),
                   ref_ptr_ptr, btype, bi.ptr)
     err != Int(Error.GIT_OK) && return (state[1:2], (nothing, -1, true))
-    return (state[1:2], (GitReference(ref_ptr_ptr[]), btype[1], false))
+    return (state[1:2], (GitReference(ref_ptr_ptr[]), btype[], false))
 end
 
 Base.iteratorsize(::Type{GitBranchIter}) = Base.SizeUnknown()

--- a/base/math.jl
+++ b/base/math.jl
@@ -278,16 +278,16 @@ end
 
 modf(x) = rem(x,one(x)), trunc(x)
 
-const _modff_temp = Float32[0]
+const _modff_temp = Ref{Float32}()
 function modf(x::Float32)
     f = ccall((:modff,libm), Float32, (Float32,Ptr{Float32}), x, _modff_temp)
-    f, _modff_temp[1]
+    f, _modff_temp[]
 end
 
-const _modf_temp = Float64[0]
+const _modf_temp = Ref{Float64}()
 function modf(x::Float64)
     f = ccall((:modf,libm), Float64, (Float64,Ptr{Float64}), x, _modf_temp)
-    f, _modf_temp[1]
+    f, _modf_temp[]
 end
 
 ^(x::Float64, y::Float64) = nan_dom_err(ccall((:pow,libm),  Float64, (Float64,Float64), x, y), x+y)


### PR DESCRIPTION
For example:

```
julia> code_llvm(STDOUT, convert, (Type{BigFloat}, Float64))

define %jl_value_t* @jlsys_convert_55749(%jl_value_t*, double) #0 {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #3
  %ptls_i8 = getelementptr i8, i8* %thread_ptr, i64 -2672
  %ptls = bitcast i8* %ptls_i8 to %jl_value_t***
  %2 = alloca [5 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 0
  %3 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 2
  %4 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 3
  %5 = bitcast [5 x %jl_value_t*]* %2 to i64*
  %6 = bitcast %jl_value_t** %3 to i8*
  call void @llvm.memset.p0i8.i64(i8* %6, i8 0, i64 24, i32 8, i1 false)
  store i64 6, i64* %5, align 8
  %7 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 1
  %8 = bitcast i8* %ptls_i8 to i64*
  %9 = load i64, i64* %8, align 8
  %10 = bitcast %jl_value_t** %7 to i64*
  store i64 %9, i64* %10, align 8
  store %jl_value_t** %.sub, %jl_value_t*** %ptls, align 8
  %11 = call %jl_value_t* @jlsys_Type_40763(%jl_value_t* inttoptr (i64 140199224774320 to %jl_value_t*), %jl_value_t** null, i32 0)
  store %jl_value_t* %11, %jl_value_t** %3, align 8
  store %jl_value_t* %11, %jl_value_t** %4, align 8
  %12 = load i64, i64* inttoptr (i64 140199272501304 to i64*), align 8
  %13 = icmp eq i64 %12, 0
  br i1 %13, label %oob, label %idxend

oob:                                              ; preds = %top
  %14 = alloca i64, align 8
  store i64 0, i64* %14, align 8
  call void @jl_bounds_error_ints(%jl_value_t* inttoptr (i64 140199272501296 to %jl_value_t*), i64* nonnull %14, i64 1)
  unreachable

idxend:                                           ; preds = %top
  %15 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 4
  %16 = add i64 %12, -1
  %17 = load i32*, i32** inttoptr (i64 140199272501296 to i32**), align 16
  %18 = getelementptr i32, i32* %17, i64 %16
  %19 = load i32, i32* %18, align 4
  %20 = getelementptr inbounds %jl_value_t, %jl_value_t* %11, i64 0, i32 0
  %21 = call i32 inttoptr (i64 140199204219072 to i32 (%jl_value_t**, double, i32)*)(%jl_value_t** %20, double %1, i32 %19)
  store %jl_value_t* %11, %jl_value_t** %15, align 8
  %22 = load i64, i64* %10, align 8
  store i64 %22, i64* %8, align 8
  ret %jl_value_t* %11
}
```

Using `Ref` instead:

```
julia> code_llvm(STDOUT, convert, (Type{BigFloat}, Float64))

define %jl_value_t* @jlsys_convert_59993(%jl_value_t*, double) #0 {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #2
  %ptls_i8 = getelementptr i8, i8* %thread_ptr, i64 -2672
  %ptls = bitcast i8* %ptls_i8 to %jl_value_t***
  %2 = alloca [5 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 0
  %3 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 2
  %4 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 3
  %5 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 4
  %6 = bitcast [5 x %jl_value_t*]* %2 to i64*
  %7 = bitcast %jl_value_t** %3 to i8*
  call void @llvm.memset.p0i8.i64(i8* %7, i8 0, i64 24, i32 8, i1 false)
  store i64 6, i64* %6, align 8
  %8 = bitcast i8* %ptls_i8 to i64*
  %9 = load i64, i64* %8, align 8
  %10 = getelementptr [5 x %jl_value_t*], [5 x %jl_value_t*]* %2, i64 0, i64 1
  %11 = bitcast %jl_value_t** %10 to i64*
  store i64 %9, i64* %11, align 8
  store %jl_value_t** %.sub, %jl_value_t*** %ptls, align 8
  %12 = call %jl_value_t* @jlsys_Type_42117(%jl_value_t* inttoptr (i64 139622036636912 to %jl_value_t*), %jl_value_t** null, i32 0)
  store %jl_value_t* %12, %jl_value_t** %3, align 8
  store %jl_value_t* %12, %jl_value_t** %4, align 8
  %13 = load i32, i32* inttoptr (i64 139622082164144 to i32*), align 16
  %14 = getelementptr inbounds %jl_value_t, %jl_value_t* %12, i64 0, i32 0
  %15 = call i32 inttoptr (i64 139622022695808 to i32 (%jl_value_t**, double, i32)*)(%jl_value_t** %14, double %1, i32 %13)
  store %jl_value_t* %12, %jl_value_t** %5, align 8
  %16 = load i64, i64* %11, align 8
  store i64 %16, i64* %8, align 8
  ret %jl_value_t* %12
}
```

Addresses part of #7076
