### PR TITLE
Something is wrong with inference of promote_op on Float16

### DIFF
--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2770,7 +2770,12 @@ let types = (Base.BitInteger_types..., BigInt, Bool,
              Complex{Int}, Complex{UInt}, Complex32, Complex64, Complex128)
     for S in types
         for op in (+, -)
-            T = @inferred Base.promote_op(op, S)
+            if S === Float16 # type instability here?
+                @test_broken @inferred Base.promote_op(op, S)
+                T = Base.promote_op(op, S)
+            else
+                T = @inferred Base.promote_op(op, S)
+            end
             t = @inferred op(one(S))
             @test T === typeof(t)
         end
@@ -2780,8 +2785,15 @@ let types = (Base.BitInteger_types..., BigInt, Bool,
 
     for R in types, S in types
         for op in (+, -, *, /, ^)
-            T = @inferred Base.promote_op(op, R, S)
-            t = @inferred op(one(R), one(S))
+            if R in (Float16, Complex{Float16}) || S in (Float16, Complex{Float16})
+                @test_broken @inferred Base.promote_op(op, R, S)
+                T = Base.promote_op(op, R, S)
+                @test_broken @inferred op(one(R), one(S))
+                t = op(one(R), one(S))
+            else
+                T = @inferred Base.promote_op(op, R, S)
+                t = @inferred op(one(R), one(S))
+            end
             @test T === typeof(t)
         end
     end
@@ -2792,7 +2804,12 @@ let types = (Base.BitInteger_types..., BigInt, Bool,
              Float16, Float32, Float64, BigFloat)
     for S in types, T in types
         for op in (<, >, <=, >=, (==))
-            @test @inferred(Base.promote_op(op, S, T)) === Bool
+            if S === Float16 || T === Float16
+                @test_broken @inferred(Base.promote_op(op, S, T))
+                @test Base.promote_op(op, S, T) === Bool
+            else
+                @test @inferred(Base.promote_op(op, S, T)) === Bool
+            end
         end
     end
 end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/17313 passed tests a few days ago so this is probably a recent regression. There's a long queue on Travis (pyjulia was stuck blocking the entire JuliaLang queue for many hours earlier today due to misformatted yaml) but AppVeyor is totally idle right now, so if this passes on AppVeyor and nobody can propose a real fix by then I'll merge just so master isn't failing tests. Please revert this commit if you can fix the issue.
