### PR TITLE
Use test_throws instead of test_broken in Float16 numbers tests

### DIFF
--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2798,19 +2798,15 @@ let types = (Base.BitInteger_types..., BigInt, Bool,
                 else
                     t = @inferred op(one(R), one(S))
                 end
-            elseif R === Complex{Float16} || S === Complex{Float16}
+            elseif (R === Complex{Float16} || S === Complex{Float16}) &&
+                    ((R === Bool && op in (+, *, /, ^)) ||
+                    (S === Bool && op in (+, *)) ||
+                    (S in (R, Rational{Int}) && op === ^))
                 # broken, fixme then remove this branch too
-                if (R === Bool && op in (+, *, /, ^)) ||
-                        (S === Bool && op in (+, *)) ||
-                        (S in (R, Rational{Int}) && op === ^)
-                    @test_throws ErrorException @inferred(Base.promote_op(op, R, S))
-                    T = Base.promote_op(op, R, S)
-                    @test_throws ErrorException @inferred(op(one(R), one(S)))
-                    t = op(one(R), one(S))
-                else
-                    T = @inferred Base.promote_op(op, R, S)
-                    t = @inferred op(one(R), one(S))
-                end
+                @test_throws ErrorException @inferred(Base.promote_op(op, R, S))
+                T = Base.promote_op(op, R, S)
+                @test_throws ErrorException @inferred(op(one(R), one(S)))
+                t = op(one(R), one(S))
             else
                 T = @inferred Base.promote_op(op, R, S)
                 t = @inferred op(one(R), one(S))


### PR DESCRIPTION
Since test_broken is not good for things that currently error but when fixed will return non-boolean.

If you know how to fix the inference issue and get tests to pass with #17394 (377dede7c7e08b3a442579c59c86fcf3db5fa390) reverted, then please do so and close this PR.
