### PR TITLE
Disable osx and i686-linux travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,6 @@ sudo: false
 matrix:
   include:
     - os: linux
-      env: ARCH="i686"
-      compiler: "g++-5 -m32"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - bar
-            - time
-            - binutils
-            - gcc-5
-            - g++-5
-            - gcc-5-multilib
-            - g++-5-multilib
-            - make:i386
-            - libssl-dev:i386
-            - gfortran-5
-            - gfortran-5-multilib
-    - os: linux
       env: ARCH="x86_64"
       compiler: "g++-5 -m64"
       addons:
@@ -33,8 +14,6 @@ matrix:
             - time
             - g++-5
             - gfortran-5
-    - os: osx
-      env: ARCH="x86_64"
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/deps/srccache


### PR DESCRIPTION
The queue is getting out of hand. Losing the test coverage on PR's for these platforms is unfortunate, but we do have the buildbots that will test things that get merged to master (though they will do so after the fact, so this will rely on people keeping a close eye on the buildbots to avoid letting master stay broken for long on those platforms)

Hopefully this will be temporary and we can revert it when things are quieter. Or use a different service for at least one platform (Circle CI offers OSX builds but not on the free plan from what I can tell).
