### PR TITLE
Remove eltype_plus

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -271,9 +271,6 @@ end
 
 ## elementwise operators ##
 
-# should this be deprecated? Only use in Base is in sparsematrix.jl
-eltype_plus(As::AbstractArray...) = promote_eltype_op(+, As...)
-
 for op in (:÷, :%, :<<, :>>, :-, :/, :\, ://, :^)
     @eval $(Symbol(:., op))(A::AbstractArray, B::AbstractArray) = broadcast($(op), A, B)
 end

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -2,7 +2,7 @@
 
 module SparseArrays
 
-using Base: ReshapedArray, setindex_shape_check, to_shape
+using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape
 using Base.Sort: Forward
 using Base.LinAlg: AbstractTriangular, PosDefException
 
@@ -26,7 +26,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     rotl90, rotr90, round, scale!, setindex!, similar, size, transpose, tril,
     triu, vcat, vec, permute!
 
-import Base.Broadcast: eltype_plus, broadcast_shape
+import Base.Broadcast: broadcast_shape
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, dropzeros, etree,


### PR DESCRIPTION
Left over from #17313.

Note that [DataFrames](https://github.com/JuliaStats/DataArrays.jl) uses `eltype_plus`, so either this needs a deprecation (but am I right that I cannot put that in `deprecated.jl` because it has to go in the `Broadcast` submodule?) or [DataFrames](https://github.com/JuliaStats/DataArrays.jl) should get some lead time to use `promote_eltype_op(+, ...)` instead.
