### PR TITLE
make object_ids and hashes in precompiled modules more stable

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -818,7 +818,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     tn->cache = jl_emptysvec;
     tn->linearcache = jl_emptysvec;
     tn->names = NULL;
-    tn->uid = jl_assign_type_uid();
+    tn->hash = bitmix(bitmix(module ? module->uuid : 0, name->hash), 0xa1ada1da);
     tn->mt = NULL;
     JL_GC_PUSH1(&tn);
     tn->mt = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1663,7 +1663,6 @@ static jl_value_t *jl_deserialize_value_(jl_serializer_state *s, jl_value_t *vta
             if ((s->mode == MODE_MODULE || s->mode == MODE_MODULE_POSTWORK)) {
                 if (dt == jl_typename_type) {
                     jl_typename_t *tn = (jl_typename_t*)v;
-                    tn->uid = jl_assign_type_uid(); // make sure this has a new uid
                     tn->cache = jl_emptysvec; // the cache is refilled later (tag 5)
                     tn->linearcache = jl_emptysvec; // the cache is refilled later (tag 5)
                 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3524,7 +3524,7 @@ void jl_init_types(void)
     jl_typename_type->name->names = jl_svec(8, jl_symbol("name"), jl_symbol("module"),
                                             jl_symbol("names"), jl_symbol("primary"),
                                             jl_symbol("cache"), jl_symbol("linearcache"),
-                                            jl_symbol("uid"), jl_symbol("mt"));
+                                            jl_symbol("hash"), jl_symbol("mt"));
     jl_typename_type->types = jl_svec(8, jl_sym_type, jl_any_type, jl_simplevector_type,
                                       jl_type_type, jl_simplevector_type, jl_simplevector_type,
                                       jl_any_type, jl_any_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -300,7 +300,7 @@ typedef struct {
     jl_value_t *primary;
     jl_svec_t *cache;        // sorted array
     jl_svec_t *linearcache;  // unsorted array
-    intptr_t uid;
+    intptr_t hash;
     struct _jl_methtable_t *mt;
 } jl_typename_t;
 

--- a/src/module.c
+++ b/src/module.c
@@ -26,7 +26,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     m->name = name;
     m->parent = NULL;
     m->istopmod = 0;
-    m->uuid = uv_now(uv_default_loop());
+    m->uuid = jl_hrtime();
     m->counter = 0;
     htable_new(&m->bindings, 0);
     arraylist_new(&m->usings, 0);

--- a/src/support/hashing.h
+++ b/src/support/hashing.h
@@ -21,6 +21,12 @@ JL_DLLEXPORT uint64_t memhash_seed(const char *buf, size_t n, uint32_t seed);
 JL_DLLEXPORT uint32_t memhash32(const char *buf, size_t n);
 JL_DLLEXPORT uint32_t memhash32_seed(const char *buf, size_t n, uint32_t seed);
 
+#ifdef _P64
+#define bitmix(a,b) int64hash((a)^bswap_64(b))
+#else
+#define bitmix(a,b) int64to32hash((((uint64_t)a)<<32)|((uint64_t)b))
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This makes object_id and the default hash function reliable for types in precompiled modules.

I also discovered that module UUIDs were not very unique, since `uv_now` is not updated very often. Many submodules of Base actually had the same UUID.
