### PR TITLE
Move RST 'data' docstrings inline

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -6,15 +6,69 @@ import Core.Intrinsics: cglobal, box
 
 cfunction(f::Function, r, a) = ccall(:jl_function_ptr, Ptr{Void}, (Any, Any, Any), f, r, a)
 
+"""
+    Ptr{T}
+
+A memory address referring to data of type `T`.  However, there is no guarantee that the
+memory is actually valid, or that it actually represents data of the specified type.
+"""
+Ptr
+
+"""
+    Ref{T}
+
+An object that safely references data of type `T`. This type is guaranteed to point to
+valid, Julia-allocated memory of the correct type. The underlying data is protected from
+freeing by the garbage collector as long as the `Ref` itself is referenced.
+
+When passed as a `ccall` argument (either as a `Ptr` or `Ref` type), a `Ref` object will be
+converted to a native pointer to the data it references.
+
+There is no invalid (NULL) `Ref`.
+"""
+Ref
+
 if ccall(:jl_is_char_signed, Ref{Bool}, ())
     typealias Cchar Int8
 else
     typealias Cchar UInt8
 end
+"""
+    Cchar
+
+Equivalent to the native `char` c-type.
+"""
+Cchar
+
+"""
+    Cuchar
+
+Equivalent to the native `unsigned char` c-type (`UInt8`).
+"""
 typealias Cuchar UInt8
+"""
+    Cshort
+
+Equivalent to the native `signed short` c-type (`Int16`).
+"""
 typealias Cshort Int16
+"""
+    Cushort
+
+Equivalent to the native `unsigned short` c-type (`UInt16`).
+"""
 typealias Cushort UInt16
+"""
+    Cint
+
+Equivalent to the native `signed int` c-type (`Int32`).
+"""
 typealias Cint Int32
+"""
+    Cuint
+
+Equivalent to the native `unsigned int` c-type (`UInt32`).
+"""
 typealias Cuint UInt32
 if is_windows()
     typealias Clong Int32
@@ -25,14 +79,78 @@ else
     typealias Culong UInt
     typealias Cwchar_t Int32
 end
+"""
+    Clong
+
+Equivalent to the native `signed long` c-type.
+"""
+Clong
+"""
+    Culong
+
+Equivalent to the native `unsigned long` c-type.
+"""
+Culong
+"""
+    Cwchar_t
+
+Equivalent to the native `wchar_t` c-type (`Int32`).
+"""
+Cwchar_t
+
+"""
+    Cptrdiff_t
+
+Equivalent to the native `ptrdiff_t` c-type (`Int`).
+"""
 typealias Cptrdiff_t Int
+"""
+    Csize_t
+
+Equivalent to the native `size_t` c-type (`UInt`).
+"""
 typealias Csize_t UInt
+"""
+    Cssize_t
+
+Equivalent to the native `ssize_t` c-type.
+"""
 typealias Cssize_t Int
+"""
+    Cintmax_t
+
+Equivalent to the native `intmax_t` c-type (`Int64`).
+"""
 typealias Cintmax_t Int64
+"""
+    Cuintmax_t
+
+Equivalent to the native `uintmax_t` c-type (`UInt64`).
+"""
 typealias Cuintmax_t UInt64
+"""
+    Clonglong
+
+Equivalent to the native `signed long long` c-type (`Int64`).
+"""
 typealias Clonglong Int64
+"""
+    Culonglong
+
+Equivalent to the native `unsigned long long` c-type (`UInt64`).
+"""
 typealias Culonglong UInt64
+"""
+    Cfloat
+
+Equivalent to the native `float` c-type (`Float32`).
+"""
 typealias Cfloat Float32
+"""
+    Cdouble
+
+Equivalent to the native `double` c-type (`Float64`).
+"""
 typealias Cdouble Float64
 
 if !is_windows()

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -7,6 +7,11 @@ end
 Complex(x::Real, y::Real) = Complex(promote(x,y)...)
 Complex(x::Real) = Complex(x, zero(x))
 
+"""
+    im
+
+The imaginary unit.
+"""
 const im = Complex(false,true)
 
 typealias Complex128 Complex{Float64}

--- a/base/dates/types.jl
+++ b/base/dates/types.jl
@@ -2,6 +2,19 @@
 
 abstract AbstractTime
 
+"""
+    Period
+    Year
+    Month
+    Week
+    Day
+    Hour
+    Minute
+    Second
+    Millisecond
+
+`Period` types represent discrete, human representations of time.
+"""
 abstract Period     <: AbstractTime
 abstract DatePeriod <: Period
 abstract TimePeriod <: Period
@@ -19,10 +32,36 @@ for T in (:Hour,:Minute,:Second,:Millisecond)
     end
 end
 
-# Instant types represent different monotonically increasing timelines
+"""
+    Year(v)
+    Month(v)
+    Week(v)
+    Day(v)
+    Hour(v)
+    Minute(v)
+    Second(v)
+    Millisecond(v)
+
+Construct a `Period` type with the given `v` value. Input must be losslessly convertible
+to an `Int64`.
+"""
+Period(v)
+
+"""
+    Instant
+
+`Instant` types represent integer-based, machine representations of time as continuous
+timelines starting from an epoch.
+"""
 abstract Instant <: AbstractTime
 
-# UTInstant is based on UT seconds, or 1/86400th of a turn of the earth
+"""
+    UTInstant{T}
+
+The `UTInstant` represents a machine timeline based on UT time (1 day = one revolution of
+the earth). The `T` is a `Period` parameter that indicates the resolution or precision of
+the instant.
+"""
 immutable UTInstant{P<:Period} <: Instant
     periods::P
 end
@@ -43,16 +82,30 @@ immutable ISOCalendar <: Calendar end
 abstract TimeZone
 immutable UTC <: TimeZone end
 
-# TimeTypes wrap Instants to provide human representations of time
+"""
+    TimeType
+
+`TimeType` types wrap `Instant` machine instances to provide human representations of the
+machine instant. Both `DateTime` and `Date` are subtypes of `TimeType`.
+"""
 abstract TimeType <: AbstractTime
 
-# DateTime is a millisecond precision UTInstant interpreted by ISOCalendar
+"""
+    DateTime
+
+`DateTime` wraps a `UTInstant{Millisecond}` and interprets it according to the proleptic
+Gregorian calendar.
+"""
 immutable DateTime <: TimeType
     instant::UTInstant{Millisecond}
     DateTime(instant::UTInstant{Millisecond}) = new(instant)
 end
 
-# DateTime is a day precision UTInstant interpreted by ISOCalendar
+"""
+    Date
+
+`Date` wraps a `UTInstant{Day}` and interprets it according to the proleptic Gregorian calendar.
+"""
 immutable Date <: TimeType
     instant::UTInstant{Day}
     Date(instant::UTInstant{Day}) = new(instant)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -658,6 +658,13 @@ kw"immutable"
 kw"@__LINE__"
 
 """
+    ans
+
+A variable referring to the last computed value, automatically set at the interactive prompt.
+"""
+kw"ans"
+
+"""
     nothing
 
 The singleton instance of type `Void`, used by convention when there is no value to return
@@ -672,5 +679,17 @@ Equivalent to `Any` for dispatch purposes, but signals the compiler to skip code
 generation specialization for that field.
 """
 ANY
+
+"""
+    DevNull
+
+Used in a stream redirect to discard all data written to it. Essentially equivalent to
+/dev/null on Unix or NUL on Windows. Usage:
+
+```julia
+run(pipeline(`cat test.txt`, DevNull))
+```
+"""
+DevNull
 
 end

--- a/base/float.jl
+++ b/base/float.jl
@@ -2,13 +2,44 @@
 
 ## floating point traits ##
 
+"""
+    Inf16
+
+Positive infinity of type `Float16`.
+"""
 const Inf16 = box(Float16,unbox(UInt16,0x7c00))
+"""
+    NaN16
+
+A not-a-number value of type `Float16`.
+"""
 const NaN16 = box(Float16,unbox(UInt16,0x7e00))
+"""
+    Inf32
+
+Positive infinity of type `Float32`.
+"""
 const Inf32 = box(Float32,unbox(UInt32,0x7f800000))
+"""
+    NaN32
+
+A not-a-number value of type `Float32`.
+"""
 const NaN32 = box(Float32,unbox(UInt32,0x7fc00000))
 const Inf64 = box(Float64,unbox(UInt64,0x7ff0000000000000))
 const NaN64 = box(Float64,unbox(UInt64,0x7ff8000000000000))
+
+"""
+    Inf
+
+Positive infinity of type `Float64`.
+"""
 const Inf = Inf64
+"""
+    NaN
+
+A not-a-number value of type `Float64`.
+"""
 const NaN = NaN64
 
 ## conversions to floating-point ##

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -131,10 +131,44 @@ big(x::Irrational) = convert(BigFloat,x)
 @irrational φ        1.61803398874989484820  (1+sqrt(big(5)))/2
 
 # aliases
+"""
+    pi
+    π
+
+The constant pi.
+"""
 const pi = π
+
+"""
+    e
+    eu
+
+The constant e.
+"""
 const eu = e
+
+"""
+    γ
+    eulergamma
+
+Euler's constant.
+"""
 const eulergamma = γ
+
+"""
+    φ
+    golden
+
+The golden ratio.
+"""
 const golden = φ
+
+"""
+    catalan
+
+Catalan's constant.
+"""
+catalan
 
 # special behaviors
 

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -7,6 +7,11 @@ immutable UniformScaling{T<:Number}
     λ::T
 end
 
+"""
+    I
+
+An object of type `UniformScaling`, representing an identity matrix of any size.
+"""
 const I = UniformScaling(1)
 
 eltype{T}(::Type{UniformScaling{T}}) = T

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -11,7 +11,40 @@ export StackTrace, StackFrame, stacktrace, catch_stacktrace
 """
     StackFrame
 
-Stack information representing execution context.
+Stack information representing execution context, with the following fields:
+
+- `func::Symbol`
+
+  The name of the function containing the execution context.
+
+- `outer_linfo::Nullable{LambdaInfo}`
+
+  The LambdaInfo containing the execution context (if it could be found).
+
+- `file::Symbol`
+
+  The path to the file containing the execution context.
+
+- `line::Int`
+
+  The line number in the file containing the execution context.
+
+- `inlined_file::Symbol`
+
+  The path to the file containing the context for inlined code.
+
+- `inlined_line::Int`
+
+  The line number in the file containing the context for inlined code.
+
+- `from_c::Bool`
+
+  True if the code is from C.
+
+- `pointer::Int64`
+
+  Representation of the pointer to the execution context as returned by `backtrace`.
+
 """
 immutable StackFrame # this type should be kept platform-agnostic so that profiles can be dumped on one machine and read on another
     "the name of the function containing the execution context"

--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -12,6 +12,18 @@ function default_sysimg_path(debug=false)
     end
 end
 
+"""
+    build_sysimg(sysimg_path=default_sysimg_path, cpu_target="native", userimg_path=nothing; force=false)
+
+Rebuild the system image. Store it in `sysimg_path`, which defaults to a file named `sys.ji`
+that sits in the same folder as `libjulia.{so,dylib}`, except on Windows where it defaults
+to `JULIA_HOME/../lib/julia/sys.ji`.  Use the cpu instruction set given by `cpu_target`.
+Valid CPU targets are the same as for the `-C` option to `julia`, or the `-march` option to
+`gcc`.  Defaults to `native`, which means to use all CPU instructions available on the
+current processor. Include the user image file given by `userimg_path`, which should contain
+directives such as `using MyPackage` to include that package in the new system image. New
+system image will not replace an older image unless `force` is set to true.
+"""
 function build_sysimg(sysimg_path=nothing, cpu_target="native", userimg_path=nothing; force=false, debug=false)
     if sysimg_path == nothing
         sysimg_path = default_sysimg_path(debug)
@@ -157,7 +169,10 @@ end
 
 # When running this file as a script, try to do so with default values.  If arguments are passed
 # in, use them as the arguments to build_sysimg above
-if !isinteractive()
+#
+# Also check whether we are running `genstdlib.jl`, in which case we don't want to build a
+# system image and instead only need `build_sysimg`'s docstring to be available.
+if !isdefined(Main, :GenStdLib) && !isinteractive()
     if length(ARGS) > 5 || ("--help" in ARGS || "-h" in ARGS)
         println("Usage: build_sysimg.jl <sysimg_path> <cpu_target> <usrimg_path.jl> [--force] [--debug] [--help]")
         println("   <sysimg_path>    is an absolute, extensionless path to store the system image at")

--- a/doc/devdocs/sysimg.rst
+++ b/doc/devdocs/sysimg.rst
@@ -26,10 +26,9 @@ This will include a ``build_sysimg()`` function:
 
 .. function:: build_sysimg(sysimg_path=default_sysimg_path, cpu_target="native", userimg_path=nothing; force=false)
 
-   Rebuild the system image. Store it in ``sysimg_path``, which defaults to a file named ``sys.ji`` that sits in the same folder as ``libjulia.{so,dylib}``, except on Windows where it defaults to ``JULIA_HOME/../lib/julia/sys.ji``.
-   Use the cpu instruction set given by ``cpu_target``.  Valid CPU targets are the same as for the ``-C`` option to ``julia``, or the ``-march`` option to ``gcc``.  Defaults to ``native``, which means to use all CPU instructions available on the current processor.
-   Include the user image file given by ``userimg_path``, which should contain directives such as ``using MyPackage`` to include that package in the new system image.
-   New system image will not replace an older image unless ``force`` is set to true.
+   .. Docstring generated from Julia source
+
+   Rebuild the system image. Store it in ``sysimg_path``\ , which defaults to a file named ``sys.ji`` that sits in the same folder as ``libjulia.{so,dylib}``\ , except on Windows where it defaults to ``JULIA_HOME/../lib/julia/sys.ji``\ .  Use the cpu instruction set given by ``cpu_target``\ . Valid CPU targets are the same as for the ``-C`` option to ``julia``\ , or the ``-march`` option to ``gcc``\ .  Defaults to ``native``\ , which means to use all CPU instructions available on the current processor. Include the user image file given by ``userimg_path``\ , which should contain directives such as ``using MyPackage`` to include that package in the new system image. New system image will not replace an older image unless ``force`` is set to true.
 
 Note that this file can also be run as a script itself, with command line arguments taking the place of arguments passed to the ``build_sysimg`` function.  For example, to build a system image in ``/tmp/sys.{so,dll,dylib}``, with the ``core2`` CPU instruction set, a user image of ``~/userimg.jl`` and ``force`` set to ``true``, one would execute:
 ::

--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -200,4 +200,8 @@ validdocstr(other) = false
 
 end
 
+# The docstring for `build_sysimg` is defined is this file and included within the
+# `devdocs/sysimg.rst` file, so we include it here to make it visible to the docsystem.
+include(joinpath("..", "contrib", "build_sysimg.jl"))
+
 GenStdLib.translate(["manual", "stdlib", "devdocs"])

--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -3,7 +3,7 @@ module GenStdLib
 import Base.Docs: Binding, DocStr
 
 # Constants.
-const DOCSTRING_DIRECTIVE = r"^(.. (function|type|variable):: ).*"
+const DOCSTRING_DIRECTIVE = r"^(.. (function|type|variable|data):: ).*"
 
 # Types.
 

--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -3,7 +3,7 @@ module GenStdLib
 import Base.Docs: Binding, DocStr
 
 # Constants.
-const DOCSTRING_DIRECTIVE = r"^(.. (function|type|variable|data):: ).*"
+const DOCSTRING_DIRECTIVE = r"^(.. (function|type|data):: ).*"
 
 # Types.
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1080,3 +1080,4 @@ dense counterparts. The following functions are specific to sparse arrays.
    For additional (algorithmic) information, and for versions of these methods that forgo argument checking, see (unexported) parent methods :func:`Base.SparseArrays.unchecked_noalias_permute!` and :func:`Base.SparseArrays.unchecked_aliasing_permute!`\ .
 
    See also: :func:`Base.SparseArrays.permute`
+

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -228,8 +228,9 @@ Getting Around
 
 .. data:: ans
 
-   A variable referring to the last computed value, automatically set at the
-   interactive prompt.
+   .. Docstring generated from Julia source
+
+   A variable referring to the last computed value, automatically set at the interactive prompt.
 
 All Objects
 -----------
@@ -758,8 +759,13 @@ System
 
 .. data:: DevNull
 
-   Used in a stream redirect to discard all data written to it. Essentially equivalent to /dev/null on Unix or NUL on Windows.
-   Usage: ``run(pipeline(`cat test.txt`, DevNull))``
+   .. Docstring generated from Julia source
+
+   Used in a stream redirect to discard all data written to it. Essentially equivalent to /dev/null on Unix or NUL on Windows. Usage:
+
+   .. code-block:: julia
+
+       run(pipeline(`cat test.txt`, DevNull))
 
 .. function:: success(command)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -966,7 +966,7 @@ System
 
    A singleton of this type provides a hash table interface to environment variables.
 
-.. variable:: ENV
+.. data:: ENV
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -161,93 +161,127 @@
 
 .. data:: Ptr{T}
 
-   A memory address referring to data of type ``T``.
-   However, there is no guarantee that the memory is actually valid,
-   or that it actually represents data of the specified type.
+   .. Docstring generated from Julia source
+
+   A memory address referring to data of type ``T``\ .  However, there is no guarantee that the memory is actually valid, or that it actually represents data of the specified type.
 
 .. data:: Ref{T}
 
-   An object that safely references data of type ``T``.
-   This type is guaranteed to point to valid, Julia-allocated memory
-   of the correct type. The underlying data is protected from freeing by
-   the garbage collector as long as the ``Ref`` itself is referenced.
+   .. Docstring generated from Julia source
 
-   When passed as a ``ccall`` argument (either as a ``Ptr`` or ``Ref`` type),
-   a ``Ref`` object will be converted to a native pointer to the data it references.
+   An object that safely references data of type ``T``\ . This type is guaranteed to point to valid, Julia-allocated memory of the correct type. The underlying data is protected from freeing by the garbage collector as long as the ``Ref`` itself is referenced.
 
-   There is no invalid (NULL) ``Ref``.
+   When passed as a ``ccall`` argument (either as a ``Ptr`` or ``Ref`` type), a ``Ref`` object will be converted to a native pointer to the data it references.
+
+   There is no invalid (NULL) ``Ref``\ .
 
 .. data:: Cchar
 
-   Equivalent to the native ``char`` c-type
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``char`` c-type.
 
 .. data:: Cuchar
 
-   Equivalent to the native ``unsigned char`` c-type (UInt8)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``unsigned char`` c-type (``UInt8``\ ).
 
 .. data:: Cshort
 
-   Equivalent to the native ``signed short`` c-type (Int16)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``signed short`` c-type (``Int16``\ ).
 
 .. data:: Cushort
 
-   Equivalent to the native ``unsigned short`` c-type (UInt16)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``unsigned short`` c-type (``UInt16``\ ).
 
 .. data:: Cint
 
-   Equivalent to the native ``signed int`` c-type (Int32)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``signed int`` c-type (``Int32``\ ).
 
 .. data:: Cuint
 
-   Equivalent to the native ``unsigned int`` c-type (UInt32)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``unsigned int`` c-type (``UInt32``\ ).
 
 .. data:: Clong
 
-   Equivalent to the native ``signed long`` c-type
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``signed long`` c-type.
 
 .. data:: Culong
 
-   Equivalent to the native ``unsigned long`` c-type
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``unsigned long`` c-type.
 
 .. data:: Clonglong
 
-   Equivalent to the native ``signed long long`` c-type (Int64)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``signed long long`` c-type (``Int64``\ ).
 
 .. data:: Culonglong
 
-   Equivalent to the native ``unsigned long long`` c-type (UInt64)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``unsigned long long`` c-type (``UInt64``\ ).
 
 .. data:: Cintmax_t
 
-   Equivalent to the native ``intmax_t`` c-type (Int64)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``intmax_t`` c-type (``Int64``\ ).
 
 .. data:: Cuintmax_t
 
-   Equivalent to the native ``uintmax_t`` c-type (UInt64)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``uintmax_t`` c-type (``UInt64``\ ).
 
 .. data:: Csize_t
 
-   Equivalent to the native ``size_t`` c-type (UInt)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``size_t`` c-type (``UInt``\ ).
 
 .. data:: Cssize_t
 
-   Equivalent to the native ``ssize_t`` c-type
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``ssize_t`` c-type.
 
 .. data:: Cptrdiff_t
 
-   Equivalent to the native ``ptrdiff_t`` c-type (Int)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``ptrdiff_t`` c-type (``Int``\ ).
 
 .. data:: Cwchar_t
 
-   Equivalent to the native ``wchar_t`` c-type (Int32)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``wchar_t`` c-type (``Int32``\ ).
 
 .. data:: Cfloat
 
-   Equivalent to the native ``float`` c-type (Float32)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``float`` c-type (``Float32``\ ).
 
 .. data:: Cdouble
 
-   Equivalent to the native ``double`` c-type (Float64)
+   .. Docstring generated from Julia source
+
+   Equivalent to the native ``double`` c-type (``Float64``\ ).
 
 ****************
  LLVM Interface

--- a/doc/stdlib/constants.rst
+++ b/doc/stdlib/constants.rst
@@ -3,79 +3,79 @@
 Constants
 =========
 
-.. variable:: nothing
+.. data:: nothing
 
    .. Docstring generated from Julia source
 
    The singleton instance of type ``Void``\ , used by convention when there is no value to return (as in a C ``void`` function). Can be converted to an empty ``Nullable`` value.
 
-.. variable:: PROGRAM_FILE
+.. data:: PROGRAM_FILE
 
    .. Docstring generated from Julia source
 
    A string containing the script name passed to Julia from the command line. Note that the script name remains unchanged from within included files. Alternatively see :data:`@__FILE__`\ .
 
-.. variable:: ARGS
+.. data:: ARGS
 
    .. Docstring generated from Julia source
 
    An array of the command line arguments passed to Julia, as strings.
 
-.. variable:: C_NULL
+.. data:: C_NULL
 
    .. Docstring generated from Julia source
 
    The C null pointer constant, sometimes used when calling external code.
 
-.. variable:: VERSION
+.. data:: VERSION
 
    .. Docstring generated from Julia source
 
    A ``VersionNumber`` object describing which version of Julia is in use. For details see :ref:`man-version-number-literals`\ .
 
-.. variable:: LOAD_PATH
+.. data:: LOAD_PATH
 
    .. Docstring generated from Julia source
 
    An array of paths (as strings) where the ``require`` function looks for code.
 
-.. variable:: JULIA_HOME
+.. data:: JULIA_HOME
 
    .. Docstring generated from Julia source
 
    A string containing the full path to the directory containing the ``julia`` executable.
 
-.. variable:: ANY
+.. data:: ANY
 
    .. Docstring generated from Julia source
 
    Equivalent to ``Any`` for dispatch purposes, but signals the compiler to skip code generation specialization for that field.
 
-.. variable:: Sys.CPU_CORES
+.. data:: Sys.CPU_CORES
 
    .. Docstring generated from Julia source
 
    The number of CPU cores in the system.
 
-.. variable:: Sys.WORD_SIZE
+.. data:: Sys.WORD_SIZE
 
    .. Docstring generated from Julia source
 
    Standard word size on the current machine, in bits.
 
-.. variable:: Sys.KERNEL
+.. data:: Sys.KERNEL
 
    .. Docstring generated from Julia source
 
    A symbol representing the name of the operating system, as returned by ``uname`` of the build configuration.
 
-.. variable:: Sys.ARCH
+.. data:: Sys.ARCH
 
    .. Docstring generated from Julia source
 
    A symbol representing the architecture of the build configuration.
 
-.. variable:: Sys.MACHINE
+.. data:: Sys.MACHINE
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -17,6 +17,8 @@ Dates and Time Types
           Second
           Millisecond
 
+   .. Docstring generated from Julia source
+
    ``Period`` types represent discrete, human representations of time.
 
 .. type:: CompoundPeriod
@@ -27,21 +29,31 @@ Dates and Time Types
 
 .. data:: Instant
 
+   .. Docstring generated from Julia source
+
    ``Instant`` types represent integer-based, machine representations of time as continuous timelines starting from an epoch.
 
 .. data:: UTInstant{T}
+
+   .. Docstring generated from Julia source
 
    The ``UTInstant`` represents a machine timeline based on UT time (1 day = one revolution of the earth). The ``T`` is a ``Period`` parameter that indicates the resolution or precision of the instant.
 
 .. data:: TimeType
 
-   ``TimeType`` types wrap ``Instant`` machine instances to provide human representations of the machine instant. Both ``DateTime`` and ``Date`` are subtypes of ``TimeType``.
+   .. Docstring generated from Julia source
+
+   ``TimeType`` types wrap ``Instant`` machine instances to provide human representations of the machine instant. Both ``DateTime`` and ``Date`` are subtypes of ``TimeType``\ .
 
 .. data:: DateTime
+
+   .. Docstring generated from Julia source
 
    ``DateTime`` wraps a ``UTInstant{Millisecond}`` and interprets it according to the proleptic Gregorian calendar.
 
 .. data:: Date
+
+   .. Docstring generated from Julia source
 
    ``Date`` wraps a ``UTInstant{Day}`` and interprets it according to the proleptic Gregorian calendar.
 
@@ -538,6 +550,8 @@ Periods
           Minute(v)
           Second(v)
           Millisecond(v)
+
+   .. Docstring generated from Julia source
 
    Construct a ``Period`` type with the given ``v`` value. Input must be losslessly convertible to an ``Int64``\ .
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -7,19 +7,19 @@
 General I/O
 -----------
 
-.. variable:: STDOUT
+.. data:: STDOUT
 
    .. Docstring generated from Julia source
 
    Global variable referring to the standard out stream.
 
-.. variable:: STDERR
+.. data:: STDERR
 
    .. Docstring generated from Julia source
 
    Global variable referring to the standard error stream.
 
-.. variable:: STDIN
+.. data:: STDIN
 
    .. Docstring generated from Julia source
 
@@ -1012,7 +1012,7 @@ Network I/O
 
    Converts the endianness of a value from that used by the Host to Little-endian.
 
-.. variable:: ENDIAN_BOM
+.. data:: ENDIAN_BOM
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/libdl.rst
+++ b/doc/stdlib/libdl.rst
@@ -55,6 +55,8 @@ The names in :mod:`Base.Libdl` are not exported and need to be called e.g. as ``
 
 .. data:: dlext
 
+   .. Docstring generated from Julia source
+
    File extension for dynamic libraries (e.g. dll, dylib, so) on the current platform.
 
 .. function:: find_library(names, locations)

--- a/doc/stdlib/libdl.rst
+++ b/doc/stdlib/libdl.rst
@@ -22,14 +22,14 @@ The names in :mod:`Base.Libdl` are not exported and need to be called e.g. as ``
 
    Similar to :func:`dlopen`\ , except returns a ``NULL`` pointer instead of raising errors.
 
-.. variable:: RTLD_DEEPBIND
-              RTLD_FIRST
-              RTLD_GLOBAL
-              RTLD_LAZY
-              RTLD_LOCAL
-              RTLD_NODELETE
-              RTLD_NOLOAD
-              RTLD_NOW
+.. data:: RTLD_DEEPBIND
+          RTLD_FIRST
+          RTLD_GLOBAL
+          RTLD_LAZY
+          RTLD_LOCAL
+          RTLD_NODELETE
+          RTLD_NOLOAD
+          RTLD_NOW
 
    .. Docstring generated from Julia source
 
@@ -65,7 +65,7 @@ The names in :mod:`Base.Libdl` are not exported and need to be called e.g. as ``
 
    Searches for the first library in ``names`` in the paths in the ``locations`` list, ``DL_LOAD_PATH``\ , or system library paths (in that order) which can successfully be dlopen'd. On success, the return value will be one of the names (potentially prefixed by one of the paths in locations). This string can be assigned to a ``global const`` and used as the library name in future ``ccall``\ 's. On failure, it returns the empty string.
 
-.. variable:: DL_LOAD_PATH
+.. data:: DL_LOAD_PATH
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1894,7 +1894,9 @@ for ``Float64``, ``Float32``, ``Complex128``, and ``Complex64`` arrays.
 
 .. data:: I
 
-   An object of type ``UniformScaling``, representing an identity matrix of any size.
+   .. Docstring generated from Julia source
+
+   An object of type ``UniformScaling``\ , representing an identity matrix of any size.
 
 LAPACK Functions
 ----------------

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -904,37 +904,37 @@ Mathematical Functions
    * :obj:`RoundUp`
    * :obj:`RoundDown`
 
-.. variable:: RoundNearest
+.. data:: RoundNearest
 
    .. Docstring generated from Julia source
 
    The default rounding mode. Rounds to the nearest integer, with ties (fractional values of 0.5) being rounded to the nearest even integer.
 
-.. variable:: RoundNearestTiesAway
+.. data:: RoundNearestTiesAway
 
    .. Docstring generated from Julia source
 
    Rounds to nearest integer, with ties rounded away from zero (C/C++ :func:`round` behaviour).
 
-.. variable:: RoundNearestTiesUp
+.. data:: RoundNearestTiesUp
 
    .. Docstring generated from Julia source
 
    Rounds to nearest integer, with ties rounded toward positive infinity (Java/JavaScript :func:`round` behaviour).
 
-.. variable:: RoundToZero
+.. data:: RoundToZero
 
    .. Docstring generated from Julia source
 
    :func:`round` using this rounding mode is an alias for :func:`trunc`\ .
 
-.. variable:: RoundUp
+.. data:: RoundUp
 
    .. Docstring generated from Julia source
 
    :func:`round` using this rounding mode is an alias for :func:`ceil`\ .
 
-.. variable:: RoundDown
+.. data:: RoundDown
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -170,54 +170,78 @@ General Number Functions and Constants
 .. data:: pi
           π
 
-   The constant pi
+   .. Docstring generated from Julia source
+
+   The constant pi.
 
 .. data:: im
 
-   The imaginary unit
+   .. Docstring generated from Julia source
+
+   The imaginary unit.
 
 .. data:: e
           eu
 
-   The constant e
+   .. Docstring generated from Julia source
+
+   The constant e.
 
 .. data:: catalan
 
-   Catalan's constant
+   .. Docstring generated from Julia source
+
+   Catalan's constant.
 
 .. data:: γ
           eulergamma
 
-   Euler's constant
+   .. Docstring generated from Julia source
+
+   Euler's constant.
 
 .. data:: φ
           golden
 
-   The golden ratio
+   .. Docstring generated from Julia source
+
+   The golden ratio.
 
 .. data:: Inf
 
-   Positive infinity of type ``Float64``
+   .. Docstring generated from Julia source
+
+   Positive infinity of type ``Float64``\ .
 
 .. data:: Inf32
 
-   Positive infinity of type ``Float32``
+   .. Docstring generated from Julia source
+
+   Positive infinity of type ``Float32``\ .
 
 .. data:: Inf16
 
-   Positive infinity of type ``Float16``
+   .. Docstring generated from Julia source
+
+   Positive infinity of type ``Float16``\ .
 
 .. data:: NaN
 
-   A not-a-number value of type ``Float64``
+   .. Docstring generated from Julia source
+
+   A not-a-number value of type ``Float64``\ .
 
 .. data:: NaN32
 
-   A not-a-number value of type ``Float32``
+   .. Docstring generated from Julia source
+
+   A not-a-number value of type ``Float32``\ .
 
 .. data:: NaN16
 
-   A not-a-number value of type ``Float16``
+   .. Docstring generated from Julia source
+
+   A not-a-number value of type ``Float16``\ .
 
 .. function:: issubnormal(f) -> Bool
 

--- a/doc/stdlib/stacktraces.rst
+++ b/doc/stdlib/stacktraces.rst
@@ -10,36 +10,40 @@
 
 .. data:: StackFrame
 
-    Stack information representing execution context, with the following fields:
+   .. Docstring generated from Julia source
 
-    ``func::Symbol``
-        the name of the function containing the execution context
+   Stack information representing execution context, with the following fields:
 
-    ``outer_linfo::Nullable{LambdaInfo}``
-        the LambdaInfo containing the execution context (if it could be found)
+   * ``func::Symbol``
 
-    ``file::Symbol``
-        the path to the file containing the execution context
+     The name of the function containing the execution context.
+   * ``outer_linfo::Nullable{LambdaInfo}``
 
-    ``line::Int``
-        the line number in the file containing the execution context
+     The LambdaInfo containing the execution context (if it could be found).
+   * ``file::Symbol``
 
-    ``inlined_file::Symbol``
-        the path to the file containing the context for inlined code
+     The path to the file containing the execution context.
+   * ``line::Int``
 
-    ``inlined_line::Int``
-        the line number in the file containing the context for inlined code
+     The line number in the file containing the execution context.
+   * ``inlined_file::Symbol``
 
-    ``from_c::Bool``
-        true if the code is from C
+     The path to the file containing the context for inlined code.
+   * ``inlined_line::Int``
 
-    ``pointer::Int64``
-        representation of the pointer to the execution context as returned by ``backtrace``
+     The line number in the file containing the context for inlined code.
+   * ``from_c::Bool``
+
+     True if the code is from C.
+   * ``pointer::Int64``
+
+     Representation of the pointer to the execution context as returned by ``backtrace``\ .
 
 .. data:: StackTrace
 
-    An alias for ``Vector{StackFrame}`` provided for convenience; returned by calls to
-    ``stacktrace`` and ``catch_stacktrace``.
+   .. Docstring generated from Julia source
+
+   An alias for ``Vector{StackFrame}`` provided for convenience; returned by calls to ``stacktrace`` and ``catch_stacktrace``\ .
 
 .. function:: stacktrace([trace::Vector{Ptr{Void}},] [c_funcs::Bool=false]) -> StackTrace
 

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -482,3 +482,4 @@
    .. Docstring generated from Julia source
 
    General unescaping of traditional C and Unicode escape sequences. Reverse of :func:`escape_string`\ . See also :func:`unescape_string`\ .
+


### PR DESCRIPTION
This moves all `.. data::` docstrings found in the RST docs into `base/` source files, so all docstrings found in the docs are now actual docstrings. This will help with the markdown manual conversion.

Minor formatting changes include addition of some fullstops in several docstrings, and reformatting of the `StackTrace` docstring.

---

~~The only troublesome docstring is `build_sysimg` found in `/devdocs/sysimg.rst`, which doesn't actually exist as far as I can see. Not quite sure what to do about that one.~~ "Fixed" now: in https://github.com/JuliaLang/julia/pull/17417/commits/32185da99563d702e42cdae3748952d5c9691c99 I've `include`d the `contrib/build_sysimg.jl` file in `doc/genstdlib.jl` so that it's docstring can live in the appropriate place. Note that `build_sysimg` won't get called since I've made it's execution conditional on `GenStdLib` not being defined. If anyone has a more straightforward solution that would be great. 
