### PR TITLE
Seems OS X 10.6 isn't really supported..

### DIFF
--- a/DISTRIBUTING.md
+++ b/DISTRIBUTING.md
@@ -106,8 +106,7 @@ Note that if you want your `.app` to be able to run on OSX 10.6 Snow
 Leopard, you must pass `USE_SYSTEM_LIBUNWIND=1` as one of the make
 variables passed to both `make` processes.  This disables the use of
 `libosxunwind`, a more modern libunwind that relies on OS features
-available only in 10.7+.  This is the reason why we offer [separate
-downloads](http://julialang.org/downloads/) for OS X 10.6 and 10.7+.
+available only in 10.7+.  This is the reason why we support 10.7+ [while we did support 10.6 prior to Julia 0.3.0](http://julialang.org/downloads/platforms.html).
 
 Windows
 -------

--- a/DISTRIBUTING.md
+++ b/DISTRIBUTING.md
@@ -106,7 +106,7 @@ Note that if you want your `.app` to be able to run on OSX 10.6 Snow
 Leopard, you must pass `USE_SYSTEM_LIBUNWIND=1` as one of the make
 variables passed to both `make` processes.  This disables the use of
 `libosxunwind`, a more modern libunwind that relies on OS features
-available only in 10.7+.  This is the reason why we support 10.7+ [while we did support 10.6 prior to Julia 0.3.0](http://julialang.org/downloads/platforms.html).
+available only in 10.7+.  This is the reason why we support 10.7+ [while we did support 10.6 prior to Julia 0.3.0](http://julialang.org/downloads/platform.html).
 
 Windows
 -------


### PR DESCRIPTION
[OS X 10.6 unsupported by Apple in 2014 (even 10.7 and 10.8 are; and Firefox about to drop them all).]

http://julialang.org/downloads/platform.html
"Julia supports all OS X 10.7 and later. If you use Snow Leopard (OSX 10.6), Julia 0.2.1 was the last release of Julia that supported it."

https://www.reddit.com/r/Julia/comments/1uvtv8/any_julia_users_still_on_os_x_106_let_the_core/

"    Unofficially, we will probably still accept small patches that keep 10.6 support alive when built from source.

```
-viral"
```

https://groups.google.com/forum/?fromgroups=#!topic/julia-users/rBpf7nF2eLo

https://groups.google.com/forum/#!topic/julia-users/rBpf7nF2eLo

https://github.com/JuliaLang/julia/issues/4069

https://groups.google.com/forum/#!topic/julia-users/P0GOarodeUo
