### PR TITLE
DO NOT MERGE: build hang on `jl_mutex_unlock`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -2,6 +2,10 @@
 
 ## types ##
 
+typealias Dims{N} NTuple{N,Int}
+typealias DimsInteger{N} NTuple{N,Integer}
+typealias Indices{N} NTuple{N,AbstractUnitRange}
+
 const (<:) = issubtype
 
 supertype(T::DataType) = T.super
@@ -373,20 +377,24 @@ function promote_shape(a::Dims, b::Dims)
 end
 
 function promote_shape(a::AbstractArray, b::AbstractArray)
-    if ndims(a) < ndims(b)
+    promote_shape(indices(a), indices(b))
+end
+
+function promote_shape(a::Indices, b::Indices)
+    if length(a) < length(b)
         return promote_shape(b, a)
     end
-    for i=1:ndims(b)
-        if indices(a, i) != indices(b, i)
+    for i=1:length(b)
+        if a[i] != b[i]
             throw(DimensionMismatch("dimensions must match"))
         end
     end
-    for i=ndims(b)+1:ndims(a)
-        if indices(a, i) != 1:1
+    for i=length(b)+1:length(a)
+        if a[i] != 1:1
             throw(DimensionMismatch("dimensions must match"))
         end
     end
-    return indices(a)
+    return a
 end
 
 function throw_setindex_mismatch(X, I)
@@ -407,12 +415,12 @@ function setindex_shape_check(X::AbstractArray, I::Integer...)
     lj = length(I)
     i = j = 1
     while true
-        ii = size(X,i)
+        ii = unsafe_length(indices(X,i))
         jj = I[j]
         if i == li || j == lj
             while i < li
                 i += 1
-                ii *= size(X,i)
+                ii *= unsafe_length(indices(X,i))
             end
             while j < lj
                 j += 1
@@ -452,7 +460,7 @@ function setindex_shape_check{T}(X::AbstractArray{T,2}, i::Integer, j::Integer)
     if length(X) != i*j
         throw_setindex_mismatch(X, (i,j))
     end
-    sx1 = size(X,1)
+    sx1 = unsafe_length(indices(X,1))
     if !(i == 1 || i == sx1 || sx1 == 1)
         throw_setindex_mismatch(X, (i,j))
     end

--- a/base/range.jl
+++ b/base/range.jl
@@ -2,9 +2,6 @@
 
 ## 1-dimensional ranges ##
 
-typealias Dims{N} NTuple{N,Int}
-typealias DimsInteger{N} NTuple{N,Integer}
-
 abstract Range{T} <: AbstractArray{T,1}
 
 ## ordinal ranges

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -83,12 +83,12 @@ end
 function unsafe_view{T,N}(A::AbstractArray{T,N}, I::Vararg{ViewIndex,N})
     @_inline_meta
     J = to_indexes(I...)
-    SubArray(A, J, map(dimlength, index_shape(A, J...)))
+    SubArray(A, J, map(unsafe_length, index_shape(A, J...)))
 end
 function unsafe_view{T,N}(V::SubArray{T,N}, I::Vararg{ViewIndex,N})
     @_inline_meta
     idxs = reindex(V, V.indexes, to_indexes(I...))
-    SubArray(V.parent, idxs, map(dimlength, (index_shape(V.parent, idxs...))))
+    SubArray(V.parent, idxs, map(unsafe_length, (index_shape(V.parent, idxs...))))
 end
 
 # Re-indexing is the heart of a view, transforming A[i, j][x, y] to A[i[x], j[y]]
@@ -199,34 +199,25 @@ substrides(s, parent, dim, I::Tuple{Any, Vararg{Any}}) = throw(ArgumentError("st
 
 stride(V::SubArray, d::Integer) = d <= ndims(V) ? strides(V)[d] : strides(V)[end] * size(V)[end]
 
-compute_stride1(parent, I::Tuple) = compute_stride1(1, parent, 1, I)
-compute_stride1(s, parent, dim, I::Tuple{}) = s
-compute_stride1(s, parent, dim, I::Tuple{DroppedScalar, Vararg{Any}}) =
-    (@_inline_meta; compute_stride1(s*size(parent, dim), parent, dim+1, tail(I)))
-compute_stride1(s, parent, dim, I::Tuple{Range, Vararg{Any}}) = s*step(I[1])
-compute_stride1(s, parent, dim, I::Tuple{Colon, Vararg{Any}}) = s
-compute_stride1(s, parent, dim, I::Tuple{Any, Vararg{Any}}) = throw(ArgumentError("invalid strided index type $(typeof(I[1]))"))
+compute_stride1{N}(parent::AbstractArray, I::NTuple{N}) =
+    compute_stride1(1, fill_to_length(indices(parent), OneTo(1), Val{N}), I)
+compute_stride1(s, inds, I::Tuple{}) = s
+compute_stride1(s, inds, I::Tuple{DroppedScalar, Vararg{Any}}) =
+    (@_inline_meta; compute_stride1(s*unsafe_length(inds[1]), tail(inds), tail(I)))
+compute_stride1(s, inds, I::Tuple{Range, Vararg{Any}}) = s*step(I[1])
+compute_stride1(s, inds, I::Tuple{Colon, Vararg{Any}}) = s
+compute_stride1(s, inds, I::Tuple{Any, Vararg{Any}}) = throw(ArgumentError("invalid strided index type $(typeof(I[1]))"))
 
 iscontiguous(A::SubArray) = iscontiguous(typeof(A))
 iscontiguous{S<:SubArray}(::Type{S}) = false
 iscontiguous{F<:FastContiguousSubArray}(::Type{F}) = true
 
-# Fast linear SubArrays have their first index cached
-first_index(V::FastSubArray) = V.offset1 + V.stride1
-first_index(V::SubArray) = first_index(V.parent, V.indexes)
-function first_index(P::AbstractArray, indexes::Tuple)
-    f = first(linearindices(P))
-    s = 1
-    for i = 1:length(indexes)
-        f += (_first(indexes[i], P, i)-first(indices(P, i)))*s
-        s *= size(P, i)
-    end
-    f
+first_index(V::FastSubArray) = V.offset1 + V.stride1 # cached for fast linear SubArrays
+function first_index(V::SubArray)
+    P, I = parent(V), V.indexes
+    s1 = compute_stride1(P, I)
+    s1 + compute_offset1(P, s1, I)
 end
-_first(::Colon, P, ::Colon) = first(linearindices(P))
-_first(i, P, ::Colon) = first(i)
-_first(::Colon, P, d) = first(indices(P, d))
-_first(i, P, d) = first(i)
 
 # Computing the first index simply steps through the indices, accumulating the
 # sum of index each multiplied by the parent's stride.
@@ -238,17 +229,26 @@ compute_offset1(parent, stride1::Integer, I::Tuple) = (@_inline_meta; compute_of
 compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{Colon}, I::Tuple) = compute_linindex(parent, I) - stride1*first(indices(parent, dims[1]))  # index-preserving case
 compute_offset1(parent, stride1::Integer, dims, inds, I::Tuple) = compute_linindex(parent, I) - stride1  # linear indexing starts with 1
 
-compute_linindex(parent, I) = compute_linindex(1, 1, parent, 1, I)
-compute_linindex(f, s, parent, dim, I::Tuple{Real, Vararg{Any}}) =
-    (@_inline_meta; compute_linindex(f + (I[1]-first(indices(parent,dim)))*s, s*size(parent, dim), parent, dim+1, tail(I)))
+function compute_linindex{N}(parent, I::NTuple{N})
+    IP = fill_to_length(indices(parent), OneTo(1), Val{N})
+    compute_linindex(1, 1, IP, I)
+end
+function compute_linindex(f, s, IP::Tuple, I::Tuple{Real, Vararg{Any}})
+    @_inline_meta
+    Δi = I[1]-first(IP[1])
+    compute_linindex(f + Δi*s, s*unsafe_length(IP[1]), tail(IP), tail(I)))
+end
 # Just splat out the cartesian indices and continue
-compute_linindex(f, s, parent, dim, I::Tuple{AbstractCartesianIndex, Vararg{Any}}) =
-    (@_inline_meta; compute_linindex(f, s, parent, dim, (I[1].I..., tail(I)...)))
-compute_linindex(f, s, parent, dim, I::Tuple{Colon, Vararg{Any}}) =
-    (@_inline_meta; compute_linindex(f, s*size(parent, dim), parent, dim+1, tail(I)))
-compute_linindex(f, s, parent, dim, I::Tuple{Any, Vararg{Any}}) =
-    (@_inline_meta; compute_linindex(f + (first(I[1])-first(indices(parent,dim)))*s, s*size(parent, dim), parent, dim+1, tail(I)))
-compute_linindex(f, s, parent, dim, I::Tuple{}) = f
+compute_linindex(f, s, IP::Tuple, I::Tuple{AbstractCartesianIndex, Vararg{Any}}) =
+    (@_inline_meta; compute_linindex(f, s, IP, (I[1].I..., tail(I)...)))
+compute_linindex(f, s, IP::Tuple, I::Tuple{Colon, Vararg{Any}}) =
+    (@_inline_meta; compute_linindex(f, s*unsafe_length(IP[1]), tail(IP), tail(I)))
+function compute_linindex(f, s, IP::Tuple, I::Tuple{Any, Vararg{Any}})
+    @_inline_meta
+    Δi = first(I[1])-first(IP[1])
+    compute_linindex(f + Δi*s, s*unsafe_length(IP[1]), tail(IP), tail(I))
+end
+compute_linindex(f, s, IP::Tuple, I::Tuple{}) = f
 
 find_extended_dims(I) = (@_inline_meta; _find_extended_dims((), (), 1, I...))
 _find_extended_dims(dims, inds, dim) = dims, inds


### PR DESCRIPTION
I may have done something stupid here, but this hangs while building `subarray.jl` and gdb says it's in `jl_mutex_unlock` (the `JL_SIGATOMIC_END` call).

I can try to trim this down further, but this way I won't lose it.
