### PR TITLE
Add flag to add_procs to disable threading

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -112,29 +112,6 @@ function set_num_threads(n::Integer)
     return nothing
 end
 
-"""
-    get_num_threads(n)
-
-Get the number of threads the BLAS library can use.
-"""
-function get_num_threads()
-    blas = BLAS.vendor()
-    if blas == :openblas
-        return ccall((:openblas_get_num_threads, Base.libblas_name), Cint, ())
-    elseif blas == :openblas64
-        return ccall((:openblas_get_num_threads64_, Base.libblas_name), Cint, ())
-    elseif blas == :mkl
-        return ccall((:MKL_Get_Max_Num_Threads, Base.libblas_name), Cint, ())
-    end
-
-    # OSX BLAS looks at an environment variable
-    @static if is_apple()
-        return ENV["VECLIB_MAXIMUM_THREADS"]
-    end
-
-    return nothing
-end
-
 function check()
     blas = vendor()
     if blas == :openblas || blas == :openblas64

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -112,13 +112,10 @@ function set_num_threads(n::Integer)
     return nothing
 end
 
-type MKLNotImplementedException <: Exception end
-
 """
     get_num_threads(n)
 
-Set the number of threads the BLAS library should use. Does not work for MKL;
-raises MKLNotImplementedException.
+Get the number of threads the BLAS library can use.
 """
 function get_num_threads()
     blas = BLAS.vendor()
@@ -127,7 +124,7 @@ function get_num_threads()
     elseif blas == :openblas64
         return ccall((:openblas_get_num_threads64_, Base.libblas_name), Cint, ())
     elseif blas == :mkl
-        raise(MKLNotImplementedException())
+        return ccall((:MKL_Get_Max_Num_Threads, Base.libblas_name), Cint, ())
     end
 
     # OSX BLAS looks at an environment variable

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -110,6 +110,7 @@ This timeout can be controlled via environment variable `JULIA_WORKER_TIMEOUT`.
 The value of JULIA_WORKER_TIMEOUT` on the master process specifies the number of seconds a
 newly launched worker waits for connection establishment.
 """
+
 function addprocs(machines::AbstractVector; tunnel=false, sshflags=``, max_parallel=10, kwargs...)
     check_addprocs_args(kwargs)
     addprocs(SSHManager(machines); tunnel=tunnel, sshflags=sshflags, max_parallel=max_parallel, kwargs...)
@@ -213,6 +214,8 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     wconfig.exename = exename
     wconfig.count = cnt
     wconfig.max_parallel = params[:max_parallel]
+    wconfig.enable_threaded_blas = params[:enable_threaded_blas]
+
 
     push!(launched, wconfig)
     notify(launch_ntfy)
@@ -302,7 +305,8 @@ addprocs(; kwargs...) = addprocs(Sys.CPU_CORES; kwargs...)
 Launches workers using the in-built `LocalManager` which only launches workers on the
 local host. This can be used to take advantage of multiple cores. `addprocs(4)` will add 4
 processes on the local machine. If `restrict` is `true`, binding is restricted to
-`127.0.0.1`.
+`127.0.0.1`. Keyword args `dir`, `exename`, `exeflags`, `topology`, and
+`enable_threaded_blas` have the same effect as documented for `addprocs(machines)`.
 """
 function addprocs(np::Integer; restrict=true, kwargs...)
     check_addprocs_args(kwargs)
@@ -324,6 +328,7 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
         wconfig = WorkerConfig()
         wconfig.process = pobj
         wconfig.io = io
+        wconfig.enable_threaded_blas = params[:enable_threaded_blas]
         push!(launched, wconfig)
     end
 

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -79,6 +79,9 @@ Keyword arguments:
 * `dir`: specifies the working directory on the workers. Defaults to the host's current
          directory (as found by `pwd()`)
 
+ * `enable_threaded_blas`: if `true` then  BLAS will run on multiple threads in added
+                           processes. Default is `false`.
+
 * `exename`: name of the `julia` executable. Defaults to `"\$JULIA_HOME/julia"` or
              `"\$JULIA_HOME/julia-debug"` as the case may be.
 

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -110,7 +110,6 @@ This timeout can be controlled via environment variable `JULIA_WORKER_TIMEOUT`.
 The value of JULIA_WORKER_TIMEOUT` on the master process specifies the number of seconds a
 newly launched worker waits for connection establishment.
 """
-
 function addprocs(machines::AbstractVector; tunnel=false, sshflags=``, max_parallel=10, kwargs...)
     check_addprocs_args(kwargs)
     addprocs(SSHManager(machines); tunnel=tunnel, sshflags=sshflags, max_parallel=max_parallel, kwargs...)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1481,7 +1481,6 @@ function addprocs_locked(manager::ClusterManager; kwargs...)
 
             if !isempty(launched)
                 wconfig = shift!(launched)
-                wconfig.enable_threaded_blas = Nullable{Bool}(params[:enable_threaded_blas])
                 let wconfig=wconfig
                     @async setup_launched_worker(manager, wconfig, launched_q)
                 end

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -90,6 +90,7 @@ immutable JoinPGRPMsg <: AbstractMsg
     other_workers::Array
     topology::Symbol
     worker_pool
+    enable_threaded_blas::Bool
 end
 immutable JoinCompleteMsg <: AbstractMsg
     cpu_cores::Int
@@ -186,6 +187,9 @@ type WorkerConfig
     ident::Nullable{Any}      # Worker as identified by the Cluster Manager.
     # List of other worker idents this worker must connect with. Used with topology T_CUSTOM.
     connect_idents::Nullable{Array}
+
+    # Run multithreaded blas on worker
+    enable_threaded_blas::Nullable{Bool}
 
     function WorkerConfig()
         wc = new()
@@ -1240,6 +1244,10 @@ function handle_msg(msg::JoinPGRPMsg, header, r_stream, w_stream, version)
     register_worker(LPROC)
     topology(msg.topology)
 
+    if !msg.enable_threaded_blas
+        disable_threaded_libs()
+    end
+
     wait_tasks = Task[]
     for (connect_at, rpid) in msg.other_workers
         wconfig = WorkerConfig()
@@ -1399,7 +1407,6 @@ function init_worker(cookie::AbstractString, manager::ClusterManager=DefaultClus
     # transports will need to call this function with their own manager.
     global cluster_manager
     cluster_manager = manager
-    disable_threaded_libs()
 
     # Since our pid has yet to be set, ensure no RemoteChannel / Future  have been created or addprocs() called.
     assert(nprocs() <= 1)
@@ -1449,11 +1456,6 @@ function addprocs_locked(manager::ClusterManager; kwargs...)
     params = merge(default_addprocs_params(), AnyDict(kwargs))
     topology(Symbol(params[:topology]))
 
-    # some libs by default start as many threads as cores which leads to
-    # inefficient use of cores in a multi-process model.
-    # Should be a keyword arg?
-    disable_threaded_libs()
-
     # References to launched workers, filled when each worker is fully initialized and
     # has connected to all nodes.
     launched_q = Int[]   # Asynchronously filled by the launch method
@@ -1479,6 +1481,7 @@ function addprocs_locked(manager::ClusterManager; kwargs...)
 
             if !isempty(launched)
                 wconfig = shift!(launched)
+                wconfig.enable_threaded_blas = Nullable{Bool}(params[:enable_threaded_blas])
                 let wconfig=wconfig
                     @async setup_launched_worker(manager, wconfig, launched_q)
                 end
@@ -1510,7 +1513,8 @@ default_addprocs_params() = AnyDict(
     :topology => :all_to_all,
     :dir      => pwd(),
     :exename  => joinpath(JULIA_HOME,julia_exename()),
-    :exeflags => ``)
+    :exeflags => ``,
+    :enable_threaded_blas => false)
 
 
 function setup_launched_worker(manager, wconfig, launched_q)
@@ -1543,7 +1547,7 @@ function launch_n_additional_processes(manager, frompid, fromconfig, cnt, launch
             (bind_addr, port) = address
 
             wconfig = WorkerConfig()
-            for x in [:host, :tunnel, :sshflags, :exeflags, :exename]
+            for x in [:host, :tunnel, :sshflags, :exeflags, :exename, :enable_threaded_blas]
                 setfield!(wconfig, x, getfield(fromconfig, x))
             end
             wconfig.bind_addr = bind_addr
@@ -1625,7 +1629,8 @@ function create_worker(manager, wconfig)
 
     all_locs = map(x -> isa(x, Worker) ? (get(x.config.connect_at, ()), x.id) : ((), x.id, true), join_list)
     send_connection_hdr(w, true)
-    send_msg_now(w, MsgHeader(RRID(0,0), ntfy_oid), JoinPGRPMsg(w.id, all_locs, PGRP.topology, default_worker_pool()))
+    join_message = JoinPGRPMsg(w.id, all_locs, PGRP.topology, default_worker_pool(), get(wconfig.enable_threaded_blas, false))
+    send_msg_now(w, MsgHeader(RRID(0,0), ntfy_oid), join_message)
 
     @schedule manage(w.manager, w.id, w.config, :register)
     wait(rr_ntfy_join)

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -177,6 +177,7 @@ General Parallel Computing Support
    * ``sshflags``\ : specifies additional ssh options, e.g. ``sshflags=`-i /home/foo/bar.pem```
    * ``max_parallel``\ : specifies the maximum number of workers connected to in parallel at a host.                 Defaults to 10.
    * ``dir``\ : specifies the working directory on the workers. Defaults to the host's current        directory (as found by ``pwd()``\ )
+   * ``enable_threaded_blas``\ : if ``true`` then  BLAS will run on multiple threads in added                          processes. Default is ``false``\ .
    * ``exename``\ : name of the ``julia`` executable. Defaults to ``"$JULIA_HOME/julia"`` or            ``"$JULIA_HOME/julia-debug"`` as the case may be.
    * ``exeflags``\ : additional flags passed to the worker processes.
    * ``topology``\ : Specifies how the workers connect to each other. Sending a message           between unconnected workers results in an error.

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -147,7 +147,7 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   Launches workers using the in-built ``LocalManager`` which only launches workers on the local host. This can be used to take advantage of multiple cores. ``addprocs(4)`` will add 4 processes on the local machine. If ``restrict`` is ``true``\ , binding is restricted to ``127.0.0.1``\ .
+   Launches workers using the in-built ``LocalManager`` which only launches workers on the local host. This can be used to take advantage of multiple cores. ``addprocs(4)`` will add 4 processes on the local machine. If ``restrict`` is ``true``\ , binding is restricted to ``127.0.0.1``\ . Keyword args ``dir``\ , ``exename``\ , ``exeflags``\ , ``topology``\ , and ``enable_threaded_blas`` have the same effect as documented for ``addprocs(machines)``\ .
 
 .. function:: addprocs(; kwargs...) -> List of process identifiers
 

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -1136,7 +1136,7 @@ end
 function test_add_procs_threaded_blas()
     define_get_num_threads()
     if get_num_threads() == nothing
-        print("Skipping blas num threads tests due to unsupported blas version")
+        warn("Skipping blas num threads tests due to unsupported blas version")
         return
     end
     master_blas_thread_count = get_num_threads()


### PR DESCRIPTION
For #16729
Adds a flag `disable_threaded_libs` to `addprocs` instead of disabling libs by default and adds a test to exercise the flag
