### PR TITLE
Added definition `function_module(f)`

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2295,13 +2295,6 @@ Gives the number of columns needed to print a string.
 strwidth
 
 """
-    function_module(f::Function, types) -> Module
-
-Determine the module containing a given definition of a generic function.
-"""
-function_module
-
-"""
     hex(n, [pad])
 
 Convert an integer to a hexadecimal string, optionally specifying a number of digits to pad to.
@@ -2949,13 +2942,6 @@ julia> Float64(pi, RoundUp)
 See [`RoundingMode`](:obj:`RoundingMode`) for available rounding modes.
 """
 Float64
-
-"""
-    function_name(f::Function) -> Symbol
-
-Get the name of a generic `Function` as a symbol, or `:anonymous`.
-"""
-function_name
 
 """
 ```

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1304,19 +1304,31 @@ Reflection
 
    Get the name of field ``i`` of a ``DataType``\ .
 
+.. function:: Base.datatype_module(t::DataType) -> Module
+
+   .. Docstring generated from Julia source
+
+   Determine the module containing the definition of a ``DataType``\ .
+
 .. function:: isconst([m::Module], s::Symbol) -> Bool
 
    .. Docstring generated from Julia source
 
    Determine whether a global is declared ``const`` in a given ``Module``\ . The default ``Module`` argument is ``current_module()``\ .
 
-.. function:: function_name(f::Function) -> Symbol
+.. function:: Base.function_name(f::Function) -> Symbol
 
    .. Docstring generated from Julia source
 
    Get the name of a generic ``Function`` as a symbol, or ``:anonymous``\ .
 
-.. function:: function_module(f::Function, types) -> Module
+.. function:: Base.function_module(f::Function) -> Module
+
+   .. Docstring generated from Julia source
+
+   Determine the module containing the (first) definition of a generic function.
+
+.. function:: Base.function_module(f::Function, types) -> Module
 
    .. Docstring generated from Julia source
 
@@ -1434,4 +1446,3 @@ Internals
    .. Docstring generated from Julia source
 
    Compile the given function ``f`` for the argument tuple (of types) ``args``\ , but do not execute it.
-

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -163,19 +163,22 @@ not_const = 1
 
 module TestMod7648
 using Base.Test
-export a9475, c7648, foo7648
+export a9475, foo9475, c7648, foo7648, foo7648_nomethods, Foo7648
 
 const c7648 = 8
 d7648 = 9
 const f7648 = 10
 foo7648(x) = x
+function foo7648_nomethods end
+type Foo7648 end
 
     module TestModSub9475
     using Base.Test
     using ..TestMod7648
-    export a9475
+    export a9475, foo9475
     a9475 = 5
     b9475 = 7
+    foo9475(x) = x
     let
         @test Base.binding_module(:a9475) == current_module()
         @test Base.binding_module(:c7648) == TestMod7648
@@ -199,8 +202,10 @@ let
     @test Base.binding_module(TestMod7648, :d7648) == TestMod7648
     @test Base.binding_module(TestMod7648, :a9475) == TestMod7648.TestModSub9475
     @test Base.binding_module(TestMod7648.TestModSub9475, :b9475) == TestMod7648.TestModSub9475
-    @test Set(names(TestMod7648)) == Set([:TestMod7648, :a9475, :c7648, :foo7648])
-    @test Set(names(TestMod7648, true)) == Set([:TestMod7648, :TestModSub9475, :a9475, :c7648, :d7648, :f7648, :foo7648, Symbol("#foo7648"), :eval, Symbol("#eval")])
+    @test Set(names(TestMod7648))==Set([:TestMod7648, :a9475, :foo9475, :c7648, :foo7648, :foo7648_nomethods, :Foo7648])
+    @test Set(names(TestMod7648, true)) == Set([:TestMod7648, :TestModSub9475, :a9475, :foo9475, :c7648, :d7648, :f7648,
+                                                :foo7648, Symbol("#foo7648"), :foo7648_nomethods, Symbol("#foo7648_nomethods"),
+                                                :Foo7648, :eval, Symbol("#eval")])
     @test isconst(TestMod7648, :c7648)
     @test !isconst(TestMod7648, :d7648)
 end
@@ -211,6 +216,11 @@ let
     @test Base.binding_module(:c7648) == TestMod7648
     @test Base.function_name(foo7648) == :foo7648
     @test Base.function_module(foo7648, (Any,)) == TestMod7648
+    @test Base.function_module(foo7648) == TestMod7648
+    @test Base.function_module(foo7648_nomethods) == TestMod7648
+    @test Base.function_module(foo9475, (Any,)) == TestMod7648.TestModSub9475
+    @test Base.function_module(foo9475) == TestMod7648.TestModSub9475
+    @test Base.datatype_module(Foo7648) == TestMod7648
     @test basename(functionloc(foo7648, (Any,))[1]) == "reflection.jl"
     @test first(methods(TestMod7648.TestModSub9475.foo7648)) == @which foo7648(5)
     @test TestMod7648 == @which foo7648


### PR DESCRIPTION
This fixes #14636, as promised.

Also added equivalent function `datatype_module(dt)`, moved `function_name` to a better place further down in the file, and converted to in-line doc-strings.

Problem, when generating the documentation I get the warning:

```
WARNING: missing docs for signature:

    function_module(f::Function, types) -> Module
```
