### PR TITLE
Put build number in pre-release version instead of build metadata

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -208,13 +208,13 @@ A `VersionNumber` object describing which version of Julia is in use. For detail
 const VERSION = try
     ver = convert(VersionNumber, VERSION_STRING)
     if !isempty(ver.prerelease)
-        build_number = GIT_VERSION_INFO.build_number
-        if ver == v"0.5.0-pre"
-            # due to change of reference for counting commits from last tag to last change of VERSION file
-            build_number += 5578
+        if GIT_VERSION_INFO.build_number >= 0
+            ver = VersionNumber(ver.major, ver.minor, ver.patch, (ver.prerelease..., GIT_VERSION_INFO.build_number), ver.build)
+        else
+            println("WARNING: no build number found for pre-release version")
+            ver = VersionNumber(ver.major, ver.minor, ver.patch, (ver.prerelease..., "unknown"), ver.build)
         end
-        ver = VersionNumber(ver.major, ver.minor, ver.patch, ver.prerelease, (build_number,))
-    elseif GIT_VERSION_INFO.build_number != 0
+    elseif GIT_VERSION_INFO.build_number > 0
         println("WARNING: ignoring non-zero build number for VERSION")
     end
     ver

--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -73,7 +73,7 @@ fork_master_timestamp=$(git show -s $(git merge-base HEAD $(echo $origin)master)
 
 # Check for errrors and emit default value for missing numbers.
 if [ -z "$build_number" ]; then
-    build_number="0"
+    build_number="-1"
 fi
 if [ -z "$fork_master_distance" ]; then
     fork_master_distance="-1"

--- a/contrib/commit-name.sh
+++ b/contrib/commit-name.sh
@@ -32,7 +32,11 @@ else
         nb=$(expr $nb + 5578)
     fi
     if [ -n "$pre" ]; then
-        echo "$ver+$nb"
+        if [ $major = 0 -a $minor -le 5 ]; then
+            echo "$ver+$nb"
+        else
+            echo "$ver.$nb"
+        fi
     else
         echo $ver
     fi

--- a/contrib/commit-name.sh
+++ b/contrib/commit-name.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-# Need to be run from a julia repo clone
-# First argument (Optional) is a ref to the commit
+# Needs to be run from a julia repo clone
+# First argument (optional) is a ref to the commit
 
 gitref=${1:-HEAD}
 


### PR DESCRIPTION
Ref #17330.

If accepted, this PR should be merged soonish after VERSION is set to `0.6.0-dev`. (That's the assumption made in contrib/commit-name.sh.) Also, bin/version.sh in Compat would need adjustment. Surprisingly, I haven't found other places that would need to be changed. Surely I missed some?

Apart from switching from `0.6.0-dev+123` to `0.6.0-dev.123`, this PR handles the situation where the "build number" (=number of commits since latest tag) is zero (which usually means could not be determined) differently. Instead of omitting it, it adds `.unknown` if there is a pre-release version part in VERSION. E.g. `0.6.0` stays `0.6.0`, but `0.6.0-dev` becomes `0.6.0-dev.unknown`. OTOH, if VERSION is not a pre-release version but the "build number" is non-zero, it is ignored (and a corresponding message is printed). Would this be the right thing to do during preparation of a release?

CC @tkelman
