### PR TITLE
Isolate each test in a parentless module.

### DIFF
--- a/examples/lru_test.jl
+++ b/examples/lru_test.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-using LRUExample
+using .LRUExample
 
 TestLRU = LRUExample.UnboundedLRU{String, String}()
 TestBLRU = LRUExample.BoundedLRU{String, String}(1000)

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -9,6 +9,10 @@ ambig(x::Int, y::Int) = 4
 ambig(x::Number, y) = 5
 # END OF LINE NUMBER SENSITIVITY
 
+const curmod = current_module()
+const curmod_name = fullname(curmod)
+const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
+
 ambigs = Any[[], [3], [2,5], [], [3]]
 
 mt = methods(ambig)
@@ -52,8 +56,8 @@ let err = try
     io = IOBuffer()
     Base.showerror(io, err)
     lines = split(takebuf_string(io), '\n')
-    ambig_checkline(str) = startswith(str, "  ambig(x, y::Integer) in Main at") ||
-                           startswith(str, "  ambig(x::Integer, y) in Main at")
+    ambig_checkline(str) = startswith(str, "  ambig(x, y::Integer) in $curmod_str at") ||
+                           startswith(str, "  ambig(x::Integer, y) in $curmod_str at")
     @test ambig_checkline(lines[2])
     @test ambig_checkline(lines[3])
 end

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -23,7 +23,7 @@ FooBase_module = :FooBase4b3a94a1a081a8cb
     $Foo_module = 232
     $FooBase_module = 9134
 end
-using ConflictingBindings
+using .ConflictingBindings
 
 # this environment variable would affect some error messages being tested below
 # so we disable it for the tests below
@@ -379,7 +379,7 @@ let module_name = string("a",randstring())
     code = """module $(module_name)\nend\n"""
     write(file_name, code)
     reload(module_name)
-    @test typeof(eval(Symbol(module_name))) == Module
+    @test isa(eval(Main, Symbol(module_name)), Module)
     deleteat!(LOAD_PATH,1)
     rm(file_name)
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -2,6 +2,9 @@
 
 # test core language features
 const Bottom = Union{}
+const curmod = current_module()
+const curmod_name = fullname(curmod)
+const curmod_prefix = "$(["$m." for m in curmod_name]...)"
 
 macro testintersect(args...)
     _testintersect(args...)
@@ -1187,8 +1190,8 @@ immutable Foo2509; foo::Int; end
 
 # issue #2517
 immutable Foo2517; end
-@test repr(Foo2517()) == "Foo2517()"
-@test repr(Array{Foo2517}(1)) == "Foo2517[Foo2517()]"
+@test repr(Foo2517()) == "$(curmod_prefix)Foo2517()"
+@test repr(Array{Foo2517}(1)) == "$(curmod_prefix)Foo2517[$(curmod_prefix)Foo2517()]"
 @test Foo2517() === Foo2517()
 
 # issue #1474
@@ -2436,7 +2439,7 @@ let x,y,f
     y = f() # invoke llvm constant folding
     @test Int(0x468ace) === Int(y)
     @test x !== y
-    @test string(y) == "Int24(0x468ace)"
+    @test string(y) == "$(curmod_prefix)Int24(0x468ace)"
 end
 
 # issue #10570
@@ -3066,7 +3069,7 @@ x7864 = 1
 end
 
 @test_throws UndefVarError x7864
-using M7864
+using .M7864
 @test x7864 == 1
 
 # issue #11715

--- a/test/dates/adjusters.jl
+++ b/test/dates/adjusters.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module DatesAdjustersTests
-using Base.Test
 #trunc
 dt = Dates.Date(2012,12,21)
 @test trunc(dt,Dates.Year) == Dates.Date(2012)
@@ -460,4 +458,3 @@ end) == 251
     end
     return sum == 15
 end) == 15 # On average, there's one of those months every year
-end

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module DatesIo
-using Base.Test
 # Test string/show representation of Date
 @test string(Dates.Date(1,1,1)) == "0001-01-01" # January 1st, 1 AD/CE
 @test sprint(show, Dates.Date(1,1,1)) == "0001-01-01"
@@ -366,5 +364,3 @@ end
 @test Dates.Date("Apr 01 2014", "uuu dd yyyy") == Dates.Date(2014,4,1)
 @test_throws ArgumentError Dates.Date("Apr 01 xx 2014", "uuu dd zz yyyy")
 @test_throws ArgumentError Dates.Date("Apr 01 xx 2014", "uuu dd    yyyy")
-
-end

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module DatesPeriodTesting
-using Base.Test
 # Period testing
 @test -Dates.Year(1) == Dates.Year(-1)
 @test Dates.Year(1) > Dates.Year(0)
@@ -382,4 +380,3 @@ cpa = [1y+1s 1m+1s 1w+1s 1d+1s; 1h+1s 1mi+1s 2m+1s 1s+1ms]
 
 @test [1y+1s 1m+1s; 1w+1s 1d+1s] + [1y+1h 1y+1mi; 1y+1s 1y+1ms] == [2y+1h+1s 1y+1m+1mi+1s; 1y+1w+2s 1y+1d+1s+1ms]
 @test [1y+1s 1m+1s; 1w+1s 1d+1s] - [1y+1h 1y+1mi; 1y+1s 1y+1ms] == [1s-1h 1m+1s-1y-1mi; 1w-1y 1d+1s-1y-1ms]
-end

--- a/test/dates/types.jl
+++ b/test/dates/types.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module DatesTypesTests
-using Base.Test
 # Date internal algorithms
 @test Dates.totaldays(0,2,28) == -307
 @test Dates.totaldays(0,2,29) == -306
@@ -173,4 +171,3 @@ ms = Dates.Millisecond(1)
 
 @test isfinite(Dates.Date)
 @test isfinite(Dates.DateTime)
-end

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module TestEnums
+const curmod = current_module()
+const curmod_name = fullname(curmod)
+const curmod_prefix = "$(["$m." for m in curmod_name]...)"
 
 using Base.Test
 
@@ -156,7 +158,7 @@ end
 @test string(apple) == "apple"
 
 @test reprmime("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
-@test reprmime("text/plain", orange) == "orange::TestEnums.Fruit = 1"
+@test reprmime("text/plain", orange) == "orange::$(curmod_prefix)Fruit = 1"
 
 @enum LogLevel DEBUG INFO WARN ERROR CRITICAL
 @test DEBUG < CRITICAL
@@ -167,5 +169,3 @@ let b = IOBuffer()
     seekstart(b)
     @test deserialize(b) === apple
 end
-
-end # module

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -45,16 +45,18 @@ if is_unix()
 end
 
 dc_path = joinpath(dir, "dictchannel.jl")
-myid() == 1 || include(dc_path)
-
 # Run the remote on pid 1, since runtests may terminate workers
 # at any time depending on memory usage
-remotecall_fetch(1, dc_path) do f
-    include(f)
-    nothing
+main_ex = quote
+    myid() == 1 || include($dc_path)
+    remotecall_fetch(1, $dc_path) do f
+        include(f)
+        nothing
+    end
+    RemoteChannel(()->DictChannel(), 1)
 end
-dc=RemoteChannel(()->DictChannel(), 1)
-@test typeof(dc) == RemoteChannel{DictChannel}
+dc = eval(Main, main_ex)
+@test typeof(dc) == RemoteChannel{Main.DictChannel}
 
 @test isready(dc) == false
 put!(dc, 1, 2)
@@ -82,8 +84,7 @@ catch
 end
 
 if !zmq_found
-    eval(parse("module ZMQ end"))
+    eval(Main, parse("module ZMQ end"))
 end
 
 include(joinpath(dir, "clustermanager/0mq/ZMQCM.jl"))
-

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-isdefined(:TestHelpers) || include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
+isdefined(Main, :TestHelpers) || eval(Main, :(include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))))
 using TestHelpers
 
 const LIBGIT2_MIN_VER = v"0.23.0"

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 using Base.LineEdit
-isdefined(:TestHelpers) || include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
+isdefined(Main, :TestHelpers) || eval(Main, :(include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))))
 using TestHelpers
 
 function run_test(d,buf)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -117,6 +117,8 @@ end
 @test gc_enable(true)
 
 # test methodswith
+# `methodswith` relies on exported symbols
+export func4union, Base
 immutable NoMethodHasThisType end
 @test isempty(methodswith(NoMethodHasThisType))
 @test !isempty(methodswith(Int))

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -104,10 +104,13 @@ for (i, T) in enumerate(types)
 end
 
 module NullableTestEnum
-    io = IOBuffer()
-    @enum TestEnum a b
-    show(io, Nullable(a))
-    Base.Test.@test takebuf_string(io) == "Nullable{NullableTestEnum.TestEnum}(a)"
+const curmod = current_module()
+const curmod_name = fullname(curmod)
+const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+io = IOBuffer()
+@enum TestEnum a b
+show(io, Nullable(a))
+Base.Test.@test takebuf_string(io) == "Nullable{$(curmod_prefix)TestEnum}(a)"
 end
 
 # showcompact(io::IO, x::Nullable)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -1,7 +1,9 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-isdefined(:TestHelpers) || include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
+isdefined(Main, :TestHelpers) || eval(Main, :(include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))))
 using TestHelpers.OAs
+
+const OAs_name = join(fullname(OAs), ".")
 
 let
 # Basics
@@ -148,11 +150,11 @@ cmp_showf(Base.print_matrix, io, OffsetArray(rand(5,5), (10,-9)))       # rows&c
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(10^3,5), (10,-9)))    # columns fit
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(5,10^3), (10,-9)))    # rows fit
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(10^3,10^3), (10,-9))) # neither fits
-targets1 = ["0-dimensional TestHelpers.OAs.OffsetArray{Float64,0,Array{Float64,0}}:\n1.0",
-            "TestHelpers.OAs.OffsetArray{Float64,1,Array{Float64,1}} with indices 2:2:\n 1.0",
-            "TestHelpers.OAs.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:2×3:3:\n 1.0",
-            "TestHelpers.OAs.OffsetArray{Float64,3,Array{Float64,3}} with indices 2:2×3:3×4:4:\n[:, :, 4] =\n 1.0",
-            "TestHelpers.OAs.OffsetArray{Float64,4,Array{Float64,4}} with indices 2:2×3:3×4:4×5:5:\n[:, :, 4, 5] =\n 1.0"]
+targets1 = ["0-dimensional $OAs_name.OffsetArray{Float64,0,Array{Float64,0}}:\n1.0",
+            "$OAs_name.OffsetArray{Float64,1,Array{Float64,1}} with indices 2:2:\n 1.0",
+            "$OAs_name.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:2×3:3:\n 1.0",
+            "$OAs_name.OffsetArray{Float64,3,Array{Float64,3}} with indices 2:2×3:3×4:4:\n[:, :, 4] =\n 1.0",
+            "$OAs_name.OffsetArray{Float64,4,Array{Float64,4}} with indices 2:2×3:3×4:4×5:5:\n[:, :, 4, 5] =\n 1.0"]
 targets2 = ["(1.0,1.0)",
             "([1.0],[1.0])",
             "(\n[1.0],\n\n[1.0])",

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -655,7 +655,7 @@ module A15838
     const x = :a
 end
 module B15838
-    import A15838.@f
+    import ..A15838.@f
     macro f(x); return :x; end
     const x = :b
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -165,9 +165,13 @@ not_const = 1
 ## find bindings tests
 @test ccall(:jl_get_module_of_binding, Any, (Any, Any), Base, :sin)==Base
 
+const curmod = current_module()
+const curmod_name = fullname(curmod)
+
 module TestMod7648
 using Base.Test
 import Base.convert
+import ..curmod_name, ..curmod
 export a9475, foo9475, c7648, foo7648, foo7648_nomethods, Foo7648
 
 const c7648 = 8
@@ -180,6 +184,7 @@ type Foo7648 end
     module TestModSub9475
     using Base.Test
     using ..TestMod7648
+    import ..curmod_name
     export a9475, foo9475
     a9475 = 5
     b9475 = 7
@@ -188,7 +193,8 @@ type Foo7648 end
         @test Base.binding_module(:a9475) == current_module()
         @test Base.binding_module(:c7648) == TestMod7648
         @test Base.module_name(current_module()) == :TestModSub9475
-        @test Base.fullname(current_module()) == (:TestMod7648, :TestModSub9475)
+        @test Base.fullname(current_module()) == (curmod_name..., :TestMod7648,
+                                                  :TestModSub9475)
         @test Base.module_parent(current_module()) == TestMod7648
     end
     end # module TestModSub9475
@@ -199,7 +205,7 @@ let
     @test Base.binding_module(:d7648) == current_module()
     @test Base.binding_module(:a9475) == TestModSub9475
     @test Base.module_name(current_module()) == :TestMod7648
-    @test Base.module_parent(current_module()) == Main
+    @test Base.module_parent(current_module()) == curmod
 end
 end # module TestMod7648
 
@@ -213,13 +219,13 @@ let
                                                 :Foo7648, :eval, Symbol("#eval")])
     @test Set(names(TestMod7648, true, true)) == Set([:TestMod7648, :TestModSub9475, :a9475, :foo9475, :c7648, :d7648, :f7648,
                                                       :foo7648, Symbol("#foo7648"), :foo7648_nomethods, Symbol("#foo7648_nomethods"),
-                                                      :Foo7648, :eval, Symbol("#eval"), :convert])
+                                                      :Foo7648, :eval, Symbol("#eval"), :convert, :curmod_name, :curmod])
     @test isconst(TestMod7648, :c7648)
     @test !isconst(TestMod7648, :d7648)
 end
 
 let
-    using TestMod7648
+    using .TestMod7648
     @test Base.binding_module(:a9475) == TestMod7648.TestModSub9475
     @test Base.binding_module(:c7648) == TestMod7648
     @test Base.function_name(foo7648) == :foo7648
@@ -350,7 +356,7 @@ end
 end
 
 let
-    using MacroTest
+    using .MacroTest
     a = 1
     m = getfield(current_module(), Symbol("@macrotest"))
     @test which(m, Tuple{Int,Symbol})==@which @macrotest 1 a

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -2,7 +2,8 @@
 
 using Base.REPLCompletions
 
-module CompletionFoo
+ex = quote
+    module CompletionFoo
     type Test_y
         yy
     end
@@ -54,8 +55,11 @@ module CompletionFoo
     test_dict = Dict("abc"=>1, "abcd"=>10, :bar=>2, :bar2=>9, Base=>3,
                      contains=>4, `ls`=>5, 66=>7, 67=>8, ("q",3)=>11,
                      "α"=>12, :α=>13)
+    end
+    test_repl_comp_dict = CompletionFoo.test_dict
 end
-test_repl_comp_dict = CompletionFoo.test_dict
+ex.head = :toplevel
+eval(Main, ex)
 
 function temp_pkg_dir_noinit(fn::Function)
     # Used in tests below to set up and tear down a sandboxed package directory
@@ -226,7 +230,7 @@ end
 s = "CompletionFoo.test(1,1, "
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(first(methods(CompletionFoo.test, Tuple{Int, Int})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Int, Int})))
 @test length(c) == 3
 @test r == 1:18
 @test s[r] == "CompletionFoo.test"
@@ -234,7 +238,7 @@ c, r, res = test_complete(s)
 s = "CompletionFoo.test(CompletionFoo.array,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(first(methods(CompletionFoo.test, Tuple{Array{Int, 1}, Any})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Array{Int, 1}, Any})))
 @test length(c) == 2
 @test r == 1:18
 @test s[r] == "CompletionFoo.test"
@@ -242,7 +246,7 @@ c, r, res = test_complete(s)
 s = "CompletionFoo.test(1,1,1,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(first(methods(CompletionFoo.test, Tuple{Any, Any, Any})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Any, Any, Any})))
 @test r == 1:18
 @test s[r] == "CompletionFoo.test"
 
@@ -270,26 +274,26 @@ for (T, arg) in [(String,"\")\""),(Char, "')'")]
     s = "(1, CompletionFoo.test2($arg,"
     c, r, res = test_complete(s)
     @test length(c) == 1
-    @test c[1] == string(first(methods(CompletionFoo.test2, Tuple{T,})))
+    @test c[1] == string(first(methods(Main.CompletionFoo.test2, Tuple{T,})))
     @test r == 5:23
     @test s[r] == "CompletionFoo.test2"
 end
 
 s = "(1, CompletionFoo.test2(`)`,"
 c, r, res = test_complete(s)
-@test c[1] == string(first(methods(CompletionFoo.test2, Tuple{Cmd})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test2, Tuple{Cmd})))
 @test length(c) == 1
 
 s = "CompletionFoo.test3([1, 2] + CompletionFoo.varfloat,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(first(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
 @test length(c) == 1
 
 s = "CompletionFoo.test3([1.,2.], 1.,"
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(first(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
 @test r == 1:19
 @test length(c) == 1
 @test s[r] == "CompletionFoo.test3"
@@ -297,7 +301,7 @@ c, r, res = test_complete(s)
 s = "CompletionFoo.test4(\"e\",r\" \","
 c, r, res = test_complete(s)
 @test !res
-@test c[1] == string(first(methods(CompletionFoo.test4, Tuple{String, Regex})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test4, Tuple{String, Regex})))
 @test r == 1:19
 @test length(c) == 1
 @test s[r] == "CompletionFoo.test4"
@@ -306,13 +310,13 @@ s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
 c, r, res = test_complete(s)
 @test !res
 @test length(c) == 1
-@test c[1] == string(first(methods(CompletionFoo.test5, Tuple{BitArray{1}})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test5, Tuple{BitArray{1}})))
 
 s = "CompletionFoo.test4(CompletionFoo.test_y_array[1]()[1], CompletionFoo.test_y_array[1]()[2], "
 c, r, res = test_complete(s)
 @test !res
 @test length(c) == 1
-@test c[1] == string(first(methods(CompletionFoo.test4, Tuple{String, String})))
+@test c[1] == string(first(methods(Main.CompletionFoo.test4, Tuple{String, String})))
 
 # Test that string escaption is handled correct
 s = """CompletionFoo.test4("\\"","""

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -279,19 +279,22 @@ create_serialization_stream() do s # Base generic function
 end
 
 # Anonymous Functions
-create_serialization_stream() do s
-    local g() = :magic_token_anon_fun_test
-    serialize(s, g)
-    serialize(s, g)
+main_ex = quote
+    $create_serialization_stream() do s
+        local g() = :magic_token_anon_fun_test
+        serialize(s, g)
+        serialize(s, g)
 
-    seekstart(s)
-    local g2 = deserialize(s)
-    @test g2 !== g
-    @test g2() == :magic_token_anon_fun_test
-    @test g2() == :magic_token_anon_fun_test
-    @test deserialize(s) === g2
+        seekstart(s)
+        local g2 = deserialize(s)
+        $Test.@test g2 !== g
+        $Test.@test g2() == :magic_token_anon_fun_test
+        $Test.@test g2() == :magic_token_anon_fun_test
+        $Test.@test deserialize(s) === g2
+    end
 end
-
+# This needs to be run on `Main` since the serializer treats it differently.
+eval(Main, main_ex)
 
 # Task
 create_serialization_stream() do s # user-defined type array

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,5 +1,9 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+const curmod = current_module()
+const curmod_name = fullname(curmod)
+const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+
 replstr(x) = sprint((io,x) -> show(IOContext(io, limit=true), MIME("text/plain"), x), x)
 
 @test replstr(Array{Any}(2)) == "2-element Array{Any,1}:\n #undef\n #undef"
@@ -10,7 +14,7 @@ replstr(x) = sprint((io,x) -> show(IOContext(io, limit=true), MIME("text/plain")
 immutable T5589
     names::Vector{String}
 end
-@test replstr(T5589(Array{String,1}(100))) == "T5589(String[#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef  …  #undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef])"
+@test replstr(T5589(Array{String,1}(100))) == "$(curmod_prefix)T5589(String[#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef  …  #undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef,#undef])"
 
 @test replstr(parse("type X end")) == ":(type X # none, line 1:\n    end)"
 @test replstr(parse("immutable X end")) == ":(immutable X # none, line 1:\n    end)"
@@ -352,8 +356,8 @@ let
     @test sprint(show, B)  == "\n\t[1, 1]  =  #undef\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
     @test sprint(print, B) == "\n\t[1, 1]  =  #undef\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
     B[1,2] = T12960()
-    @test sprint(show, B)  == "\n\t[1, 1]  =  #undef\n\t[1, 2]  =  T12960()\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
-    @test sprint(print, B) == "\n\t[1, 1]  =  #undef\n\t[1, 2]  =  T12960()\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
+    @test sprint(show, B)  == "\n\t[1, 1]  =  #undef\n\t[1, 2]  =  $(curmod_prefix)T12960()\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
+    @test sprint(print, B) == "\n\t[1, 1]  =  #undef\n\t[1, 2]  =  $(curmod_prefix)T12960()\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
 end
 
 # issue #13127
@@ -363,7 +367,7 @@ function f13127()
     show(buf, f)
     takebuf_string(buf)
 end
-@test f13127() == "f"
+@test f13127() == "$(curmod_prefix)f"
 
 let a = Pair(1.0,2.0)
     @test sprint(show,a) == "1.0=>2.0"

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module VecElementTests
-using Base.Test
 make_value{T<:Integer}(::Type{T}, i::Integer) = 3*i%T
 make_value{T<:AbstractFloat}(::Type{T},i::Integer) = T(3*i)
 
@@ -67,5 +65,3 @@ a[1] = Gr(5.0, Bunch((VecElement(6.0), VecElement(7.0))), 8.0)
 @test a[2] == Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
 
 @test isa(VecElement((1,2)), VecElement{Tuple{Int,Int}})
-
-end


### PR DESCRIPTION
Replaces https://github.com/JuliaLang/julia/pull/9798.
This uses a parentless module (similar to https://github.com/JuliaLang/julia/pull/9798) since I was interested in the memory saving (not much but I haven't measured too carefully).

There are two test breakage that I need to workaround (instead of fixing).
1. Defining a new module on one process is not visible on another one, which breaks the `DictChannel` test in `examples`.
2. The dictionary key completion doesn't work for qualified names.

There might be a way to fix the first one (or just disable isolation for it as what I'm doing now is probably good enough). The second one is likely a bug that should be fixed.
