### PR TITLE
Build LLVM 3.8 with CMake

### DIFF
--- a/deps/llvm-ver.make
+++ b/deps/llvm-ver.make
@@ -11,7 +11,7 @@ ifeq ($(LLVM_VER_PATCH),)
 LLVM_VER_PATCH := 0
 endif
 
-ifeq ($(LLVM_VER_SHORT),$(filter $(LLVM_VER_SHORT),3.3 3.4 3.5 3.6 3.7 3.8))
+ifeq ($(LLVM_VER_SHORT),$(filter $(LLVM_VER_SHORT),3.3 3.4 3.5 3.6 3.7))
 LLVM_USE_CMAKE := 0
 else
 LLVM_USE_CMAKE := 1


### PR DESCRIPTION
Two reasons

1) 3.8.1 misidentifies itself as 3.8.0 if built with configure
2) I'd prefer if people started testing the CMake build on 3.8 rather than having a hard transition when 3.9 hits.

As far as I can tell the CMake build (with our patches at least) works well on 3.8.
