### PR TITLE
Add complex random normals

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1927,11 +1927,11 @@ Kronecker tensor product of two vectors or two matrices.
 kron
 
 """
-    randn([rng,] [T::Complex128,] [dims...])
+    randn([rng], [T::Type{Complex128}], [dims...])
 
 Generate a normally-distributed random number with mean 0 and standard deviation 1.
-The random numbers in the output are of type `Float64`, but `Complex128` can be
-passed as `T` to output normally distributed random complex numbers.
+The random numbers in the output are of type `Float64` by default, but `Complex128` can be
+passed as `T` to output circularly-symmetric normally distributed random complex numbers.
 Optionally generate an array of normally-distributed random numbers when `dims` is
 specified.
 """
@@ -9033,12 +9033,11 @@ no effect outside of compilation.
 include_dependency
 
 """
-    randn!([rng], A::Array{T,N})
+    randn!([rng], A::Array{Union{Float64,Complex128},N})
 
 Fill the array `A` with normally-distributed (mean 0, standard deviation 1) random numbers.
-The type `T` may be either `Float64` or `Complex128`. If `T` is `Complex128`, the array `A`
-will be filled with circularly polarized normally-distributed complex random numbers.
-Also see the rand function.
+If `A` is of type `Array{Complex128,N}`, it will be filled with circularly-symmetric normally-distributed
+random complex numbers.
 """
 randn!
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1927,10 +1927,13 @@ Kronecker tensor product of two vectors or two matrices.
 kron
 
 """
-    randn([rng], [dims...])
+    randn([rng,] [T::Complex128,] [dims...])
 
 Generate a normally-distributed random number with mean 0 and standard deviation 1.
-Optionally generate an array of normally-distributed random numbers.
+The random numbers in the output are of type `Float64`, but `Complex128` can be
+passed as `T` to output normally distributed random complex numbers.
+Optionally generate an array of normally-distributed random numbers when `dims` is
+specified.
 """
 randn
 
@@ -9030,9 +9033,11 @@ no effect outside of compilation.
 include_dependency
 
 """
-    randn!([rng], A::Array{Float64,N})
+    randn!([rng], A::Array{T,N})
 
 Fill the array `A` with normally-distributed (mean 0, standard deviation 1) random numbers.
+The type `T` may be either `Float64` or `Complex128`. If `T` is `Complex128`, the array `A`
+will be filled with circularly polarized normally-distributed complex random numbers.
 Also see the rand function.
 """
 randn!

--- a/base/random.jl
+++ b/base/random.jl
@@ -1157,6 +1157,25 @@ randn(dims::Integer...) = randn!(Array{Float64}(dims...))
 randn(rng::AbstractRNG, dims::Dims) = randn!(rng, Array{Float64}(dims))
 randn(rng::AbstractRNG, dims::Integer...) = randn!(rng, Array{Float64}(dims...))
 
+## Circularly-polarized complex normally distributed random numbers.
+const SQRT_HALF = 0.7071067811865475
+@inline function randn(rng::AbstractRNG, T::Type{Complex{Float64}})
+    Complex(SQRT_HALF * randn(rng), SQRT_HALF * randn(rng))
+end
+function randn!(rng::AbstractRNG, A::AbstractArray{Complex{Float64}})
+    for i in eachindex(A)
+        @inbounds A[i] = randn(rng, Complex{Float64})
+    end
+    A
+end
+
+randn!(A::AbstractArray{Complex{Float64}}) = randn!(GLOBAL_RNG, A)
+randn(T::Type{Complex{Float64}}) = randn(GLOBAL_RNG, T)
+randn(rng::AbstractRNG, T::Type{Complex{Float64}}, dims::Dims) = randn!(rng, Array{T}(dims))
+randn(rng::AbstractRNG, T::Type{Complex{Float64}}, dims::Int...) = randn!(rng, Array{T}(dims))
+randn(T::Type{Complex{Float64}}, dims::Dims) = randn!(GLOBAL_RNG, Array{T}(dims))
+randn(T::Type{Complex{Float64}}, dims::Int...) = randn!(GLOBAL_RNG, Array{T}(dims))
+
 @inline function randexp(rng::AbstractRNG=GLOBAL_RNG)
     @inbounds begin
         ri = rand_ui52(rng)

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -568,17 +568,17 @@ As ``BigInt`` represents unbounded integers, the interval must be specified (e.g
 
    Generate a ``BitArray`` of random boolean values.
 
-.. function:: randn([rng], [dims...])
+.. function:: randn([rng], [T::Type{Complex128}], [dims...])
 
    .. Docstring generated from Julia source
 
-   Generate a normally-distributed random number with mean 0 and standard deviation 1. Optionally generate an array of normally-distributed random numbers.
+   Generate a normally-distributed random number with mean 0 and standard deviation 1. The random numbers in the output are of type ``Float64`` by default, but ``Complex128`` can be passed as ``T`` to output circularly-symmetric normally distributed random complex numbers. Optionally generate an array of normally-distributed random numbers when ``dims`` is specified.
 
-.. function:: randn!([rng], A::Array{Float64,N})
+.. function:: randn!([rng], A::Array{Union{Float64,Complex128},N})
 
    .. Docstring generated from Julia source
 
-   Fill the array ``A`` with normally-distributed (mean 0, standard deviation 1) random numbers. Also see the rand function.
+   Fill the array ``A`` with normally-distributed (mean 0, standard deviation 1) random numbers. If ``A`` is of type ``Array{Complex128,N}``\ , it will be filled with circularly-symmetric normally-distributed random complex numbers.
 
 .. function:: randexp([rng], [dims...])
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -13,6 +13,7 @@ srand(0); rand(); x = rand(384);
 @test(typeof(rand(false:true)) === Bool)
 @test(typeof(rand(Char)) === Char)
 @test length(randn(4, 5)) == 20
+@test length(randn(Complex128, 4, 5)) == 20
 @test length(bitrand(4, 5)) == 20
 
 @test rand(MersenneTwister()) == 0.8236475079774124
@@ -59,6 +60,14 @@ A = zeros(2, 2)
 randn!(MersenneTwister(42), A)
 @test A == [-0.5560268761463861  0.027155338009193845;
             -0.444383357109696  -0.29948409035891055]
+
+# complex randn
+const SQRT_HALF = 0.7071067811865475
+@test randn(MersenneTwister(42), Complex128) == SQRT_HALF*Complex(-0.5560268761463861,-0.444383357109696)
+A = zeros(Complex128, 2, 2)
+randn!(MersenneTwister(42), A)
+@test A == SQRT_HALF*[Complex128(-0.5560268761463861,-0.444383357109696)    Complex128(1.7778610980573246,-1.14490153172882);
+            Complex128(0.027155338009193845,-0.29948409035891055) Complex128(-0.46860588216767457,0.15614346264074028)]
 
 for T in (Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128, BigInt,
           Float16, Float32, Float64, Rational{Int})
@@ -310,6 +319,12 @@ for rng in ([], [MersenneTwister()], [RandomDevice()])
         f!(rng..., Array{Float64}(2, 3)) ::Array{Float64, 2}
     end
 
+    randn(rng..., Complex128)                ::Complex128
+    randn(rng..., Complex128, 5)             ::Vector{Complex128}
+    randn(rng..., Complex128, 2, 3)          ::Array{Complex128, 2}
+    randn!(rng..., Array{Complex128}(5))     ::Array{Complex128}
+    randn!(rng..., Array{Complex128}(2, 3))  ::Array{Complex128, 2}
+
     bitrand(rng..., 5)             ::BitArray{1}
     bitrand(rng..., 2, 3)          ::BitArray{2}
     rand!(rng..., BitArray(5))     ::BitArray{1}
@@ -361,6 +376,8 @@ let mta = MersenneTwister(42), mtb = MersenneTwister(42)
     @test rand(mta,10) == rand(mtb,10)
     @test randn(mta) == randn(mtb)
     @test randn(mta,10) == randn(mtb,10)
+    @test randn(mta,Complex128) == randn(mtb,Complex128)
+    @test randn(mta,Complex128,10) == randn(mtb,Complex128,10)
     @test randexp(mta) == randexp(mtb)
     @test randexp(mta,10) == randexp(mtb,10)
     @test rand(mta,1:100) == rand(mtb,1:100)


### PR DESCRIPTION
As discussed in #9836.

This implementation is much simpler (for better or worse) than the one @rfourquet put together at https://github.com/rfourquet/julia/tree/rf/randn-complex, and lacks the advantage of playing nicer with `Float32` etc.
