### PR TITLE
typeassert syntax deprecations

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -86,10 +86,10 @@ if is_windows()
 start(hash::EnvHash) = (pos = ccall(:GetEnvironmentStringsW,stdcall,Ptr{UInt16},()); (pos,pos))
 function done(hash::EnvHash, block::Tuple{Ptr{UInt16},Ptr{UInt16}})
     if unsafe_load(block[1]) == 0
-        ccall(:FreeEnvironmentStringsW,stdcall,Int32,(Ptr{UInt16},),block[2])
+        ccall(:FreeEnvironmentStringsW, stdcall, Int32, (Ptr{UInt16},), block[2])
         return true
     end
-    false
+    return false
 end
 function next(hash::EnvHash, block::Tuple{Ptr{UInt16},Ptr{UInt16}})
     pos = block[1]
@@ -102,7 +102,7 @@ function next(hash::EnvHash, block::Tuple{Ptr{UInt16},Ptr{UInt16}})
     if m === nothing
         error("malformed environment entry: $env")
     end
-    (Pair{String,String}(m.captures[1], m.captures[2]), (pos+len*2, blk))
+    return (Pair{String,String}(m.captures[1], m.captures[2]), (pos+len*2, blk))
 end
 
 else # !windows
@@ -114,12 +114,12 @@ function next(::EnvHash, i)
     if env === nothing
         throw(BoundsError())
     end
-    env::String
+    env = env::String
     m = match(r"^(.*?)=(.*)$"s, env)
     if m === nothing
         error("malformed environment entry: $env")
     end
-    (Pair{String,String}(m.captures[1], m.captures[2]), i+1)
+    return (Pair{String,String}(m.captures[1], m.captures[2]), i+1)
 end
 
 end # os-test

--- a/base/float16.jl
+++ b/base/float16.jl
@@ -1,11 +1,11 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 function convert(::Type{Float32}, val::Float16)
-    ival::UInt32 = reinterpret(UInt16, val)
-    sign::UInt32 = (ival & 0x8000) >> 15
-    exp::UInt32  = (ival & 0x7c00) >> 10
-    sig::UInt32  = (ival & 0x3ff) >> 0
-    ret::UInt32
+    local ival::UInt32 = reinterpret(UInt16, val),
+          sign::UInt32 = (ival & 0x8000) >> 15,
+          exp::UInt32  = (ival & 0x7c00) >> 10,
+          sig::UInt32  = (ival & 0x3ff) >> 0,
+          ret::UInt32
 
     if exp == 0
         if sig == 0

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -70,7 +70,7 @@ show(io::IO, e::UVError) = print(io, e.prefix*": "*struverror(e)*" ("*uverrornam
 
 ## event loop ##
 
-eventloop() = global uv_eventloop::Ptr{Void}
+eventloop() = uv_eventloop::Ptr{Void}
 #mkNewEventLoop() = ccall(:jl_new_event_loop,Ptr{Void},()) # this would probably be fine, but is nowhere supported
 
 function run_event_loop()

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -1387,8 +1387,7 @@ end
 ### BLAS-2 / sparse A * sparse x -> dense y
 
 function densemv(A::SparseMatrixCSC, x::AbstractSparseVector; trans::Char='N')
-    xlen::Int
-    ylen::Int
+    local xlen::Int, ylen::Int
     m, n = size(A)
     if trans == 'N' || trans == 'n'
         xlen = n; ylen = m

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1684,8 +1684,10 @@
            (else
             `(block
               ,.(map (lambda (x)
-                       (if (decl? x)
-                           `(decl ,@(map expand-forms (cdr x)))
+                       (if (and (decl? x) (length= (cdr x) 2) (symbol? (cadr x)))
+                           (let ((str-x (deparse x)))
+                                (syntax-deprecation #f str-x (string "local " str-x))
+                                `(decl ,@(map expand-forms (cdr x))))
                            (expand-forms x)))
                      (butlast (cdr e)))
               ,(expand-forms (last (cdr e)))))))

--- a/test/core.jl
+++ b/test/core.jl
@@ -3134,8 +3134,9 @@ immutable Foo11874
 end
 
 function bar11874(x)
-   y::Foo11874
-   y=x
+   local y::Foo11874
+   y = x
+   nothing
 end
 
 Base.convert(::Type{Foo11874},x::Int) = float(x)


### PR DESCRIPTION
deprecations for #964 and #16071

this will let us reuse `global x::T` and `x::T = 1` to mean a typed global instead of the current meaning of `type-assert`

it will also let us reuse `x::T` (in statement position) to always mean typeassert, instead of sometimes meaning local variable declaration (depending on various positional and context rules)
