### PR TITLE
call utf8proc_category rather than utf8proc_get_property

### DIFF
--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -51,7 +51,7 @@ value_t fl_skipws(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     return skipped;
 }
 
-static int is_wc_cat_id_start(uint32_t wc, utf8proc_propval_t cat)
+static int is_wc_cat_id_start(uint32_t wc, utf8proc_category_t cat)
 {
     return (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LL ||
             cat == UTF8PROC_CATEGORY_LT || cat == UTF8PROC_CATEGORY_LM ||
@@ -110,8 +110,7 @@ JL_DLLEXPORT int jl_id_start_char(uint32_t wc)
         return 1;
     if (wc < 0xA1 || wc > 0x10ffff)
         return 0;
-    const utf8proc_property_t *prop = utf8proc_get_property(wc);
-    return is_wc_cat_id_start(wc, prop->category);
+    return is_wc_cat_id_start(wc, utf8proc_category((utf8proc_int32_t) wc));
 }
 
 JL_DLLEXPORT int jl_id_char(uint32_t wc)
@@ -121,8 +120,7 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
         return 1;
     if (wc < 0xA1 || wc > 0x10ffff)
         return 0;
-    const utf8proc_property_t *prop = utf8proc_get_property(wc);
-    utf8proc_propval_t cat = prop->category;
+    utf8proc_category_t cat = utf8proc_category((utf8proc_int32_t) wc);
     if (is_wc_cat_id_start(wc, cat)) return 1;
     if (cat == UTF8PROC_CATEGORY_MN || cat == UTF8PROC_CATEGORY_MC ||
         cat == UTF8PROC_CATEGORY_ND || cat == UTF8PROC_CATEGORY_PC ||


### PR DESCRIPTION
I noticed that flisp was accessing the `utf8proc_propval_t` struct directly to get the category code.  That should work fine, but we are trying to move away from that in the utf8proc API, and call accessor functions instead.  This PR changes it to call `utf8proc_category(codepoint)` instead (which was introduced in utf8proc 1.2), which should do exactly the same thing.

(I noticed this because I was going through how flisp calls utf8proc, since @tkelman mentioned an apparent problem with MSVC in JuliaLang/utf8proc#79.  I don't think this PR will fix anything with MSVC, though.)
