### PR TITLE
save time on appveyor by using libgit2 and deps from nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ before_install:
 script:
     - make -C moreutils mispipe
     - make $BUILDOPTS -C base version_git.jl.phony
+    - make $BUILDOPTS NO_GIT=1 -C deps distclean-libgit2 distclean-libssh2 distclean-mbedtls
     - moreutils/mispipe "make $BUILDOPTS NO_GIT=1 -C deps" bar > deps.log || cat deps.log
     - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - make $BUILDOPTS NO_GIT=1 build-stats

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -173,9 +173,9 @@ echo 'override LIBLAPACKNAME = $(LIBBLASNAME)' >> Make.user
 # libuv since its static lib is no longer included in the binaries
 # openlibm since we need it as a static library to work properly
 # utf8proc since its headers are not in the binary download
-echo 'override STAGE1_DEPS = libuv mbedtls' >> Make.user
-echo 'override STAGE2_DEPS = utf8proc libssh2' >> Make.user
-echo 'override STAGE3_DEPS = libgit2' >> Make.user
+echo 'override STAGE1_DEPS = libuv' >> Make.user
+echo 'override STAGE2_DEPS = utf8proc' >> Make.user
+echo 'override STAGE3_DEPS = ' >> Make.user
 
 if [ -n "$USEMSVC" ]; then
   # Openlibm doesn't build well with MSVC right now


### PR DESCRIPTION
rather than recompiling it and libssh2 and mbedtls every time
now that the nightlies include it
