### PR TITLE
WIP: lazy load the repl history

### DIFF
--- a/test/repl.jl
+++ b/test/repl.jl
@@ -244,8 +244,8 @@ begin
     hp = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:julia => repl_mode,
                                                    :shell => shell_mode,
                                                    :help  => help_mode))
-
-    REPL.hist_from_file(hp, IOBuffer(fakehistory))
+    hp.history_file = IOBuffer(fakehistory)
+    REPL.hist_from_file(hp)
     REPL.history_reset_state(hp)
 
     histp.hp = repl_mode.hist = shell_mode.hist = help_mode.hist = hp


### PR DESCRIPTION
This PR attempts to lazily load the repl history file since for very large histories this can take a bit of time.

The problem right now is that for the first up or down arrow press the repl thinks that the current index in the history is at the first entry of the history file. Thus a up arrow press will do nothing and a down arrow press will go to the second history entry.

I'm having a bit of hard time following the REPL code but so I'm not sure what I am missing. Putting this up here in case someone sees what is wrong / get the ball rolling. I opened the REPL code today so this whole approach might be wrong.. just saying.
