### PR TITLE
Pkg.free: correctly set target nullable object

### DIFF
--- a/base/libgit2/index.jl
+++ b/base/libgit2/index.jl
@@ -118,3 +118,13 @@ function Base.getindex(idx::GitIndex, i::Csize_t)
     return unsafe_load(convert(Ptr{IndexEntry}, ie_ptr), 1)
 end
 Base.getindex(idx::GitIndex, i::Int) = getindex(idx, Csize_t(i))
+
+function Base.find(path::String, idx::GitIndex)
+    pos_ref = Ref{Csize_t}(0)
+    ret = ccall((:git_index_find, :libgit2), Cint,
+                  (Ref{Csize_t}, Ptr{Void}, Cstring), pos_ref, idx.ptr, path)
+    ret == Error.ENOTFOUND && return Nullable{Csize_t}()
+    return Nullable(pos_ref[]+1)
+end
+
+stage(ie::IndexEntry) = ccall((:git_index_entry_stage, :libgit2), Cint, (Ptr{IndexEntry},), Ref(ie))

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -310,8 +310,13 @@ end
 
 """ git reset [<committish>] [--] <pathspecs>... """
 function reset!(repo::GitRepo, committish::AbstractString, pathspecs::AbstractString...)
-    target_obj = isempty(committish) ? Nullable{GitAnyObject}() :
-                                       Nullable(revparse(repo, committish))
+    target_obj = Nullable{GitAnyObject}()
+    if !isempty(committish)
+        obj = revparse(repo, committish)
+        if obj !== nothing
+            target_obj = Nullable(obj)
+        end
+    end
     try
         reset!(repo, target_obj, pathspecs...)
     finally

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -311,7 +311,8 @@ end
 """ git reset [<committish>] [--] <pathspecs>... """
 function reset!(repo::GitRepo, committish::AbstractString, pathspecs::AbstractString...)
     obj = revparse(repo, !isempty(committish) ? committish : Consts.HEAD_FILE)
-    obj === nothing && return # do not remove entries in the index matching the provided pathspecs with empty target commit tree
+    # do not remove entries in the index matching the provided pathspecs with empty target commit tree
+    obj === nothing && throw(GitError(Error.Object, Error.ERROR, "`$committish` not found"))
     try
         reset!(repo, Nullable(obj), pathspecs...)
     finally
@@ -322,7 +323,8 @@ end
 """ git reset [--soft | --mixed | --hard] <commit> """
 function reset!(repo::GitRepo, commit::Oid, mode::Cint = Consts.RESET_MIXED)
     obj = get(GitAnyObject, repo, commit)
-    obj === nothing && return # object must exist for reset
+    # object must exist for reset
+    obj === nothing && throw(GitError(Error.Object, Error.ERROR, "Commit `$(string(commit))` object not found"))
     try
         reset!(repo, obj, mode)
     finally

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -165,6 +165,7 @@ function checkout_head(repo::GitRepo; options::CheckoutOptions = CheckoutOptions
                  repo.ptr, Ref(options))
 end
 
+"""Updates some entries, determined by the `pathspecs`, in the index from the target commit tree."""
 function reset!{T<:AbstractString, S<:GitObject}(repo::GitRepo, obj::Nullable{S}, pathspecs::T...)
     with(StrArrayStruct(pathspecs...)) do sa
         @check ccall((:git_reset_default, :libgit2), Cint,
@@ -175,6 +176,7 @@ function reset!{T<:AbstractString, S<:GitObject}(repo::GitRepo, obj::Nullable{S}
     end
 end
 
+"""Sets the current head to the specified commit oid and optionally resets the index and working tree to match."""
 function reset!(repo::GitRepo, obj::GitObject, mode::Cint;
                checkout_opts::CheckoutOptions = CheckoutOptions())
     @check ccall((:git_reset, :libgit2), Cint,

--- a/base/libgit2/status.jl
+++ b/base/libgit2/status.jl
@@ -23,3 +23,12 @@ function Base.getindex(status::GitStatus, i::Csize_t)
     return unsafe_load(convert(Ptr{StatusEntry}, entry_ptr), 1)
 end
 Base.getindex(status::GitStatus, i::Int) = getindex(status, Csize_t(i))
+
+function status(repo::GitRepo, path::String)
+    status_ptr = Ref{Cuint}(0)
+    ret =  ccall((:git_status_file, :libgit2), Cint,
+                  (Ref{Cuint}, Ptr{Void}, Cstring),
+                  status_ptr, repo.ptr, path)
+    (ret == Cint(Error.ENOTFOUND) || ret == Cint(Error.EAMBIGUOUS)) && return Nullable{Cuint}()
+    return Nullable(status_ptr[])
+end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -506,7 +506,7 @@ mktempdir() do dir
             @test !LibGit2.isset(get(st_stg), LibGit2.Consts.STATUS_WT_MODIFIED)
 
             # try to unstage to unknown commit
-            @test_throws LibGit2.Error.GitError LibGit2.reset!(repo, "XYZ", test_file)    
+            @test_throws LibGit2.Error.GitError LibGit2.reset!(repo, "XYZ", test_file)
 
             # status should not change
             st_new = LibGit2.status(repo, test_file)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -506,7 +506,7 @@ mktempdir() do dir
             @test !LibGit2.isset(get(st_stg), LibGit2.Consts.STATUS_WT_MODIFIED)
 
             # try to unstage to unknown commit
-            LibGit2.reset!(repo, "XYZ", test_file)
+            @test_throws LibGit2.Error.GitError LibGit2.reset!(repo, "XYZ", test_file)    
 
             # status should not change
             st_new = LibGit2.status(repo, test_file)
@@ -518,6 +518,8 @@ mktempdir() do dir
             @test get(st_uns) == get(st_mod)
 
             # reset repo
+            @test_throws LibGit2.Error.GitError LibGit2.reset!(repo, LibGit2.Oid(), LibGit2.Consts.RESET_HARD)
+
             LibGit2.reset!(repo, LibGit2.head_oid(repo), LibGit2.Consts.RESET_HARD)
             open(joinpath(test_repo, test_file), "r") do io
                 @test read(io)[end] != 0x41


### PR DESCRIPTION
Fixed #17481 when target object was incorrectly set when commit was not found by `revparse`.
