### PR TITLE
Keep AddressSpace of global variables

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -795,7 +795,10 @@ public:
                 GV->isConstant(),
                 GlobalVariable::ExternalLinkage,
                 NULL,
-                GV->getName());
+                GV->getName(),
+                NULL,
+                GV->getThreadLocalMode(),
+                GV->getType()->getPointerAddressSpace());
             newGV->copyAttributesFrom(GV);
             newGV->setComdat(nullptr);
             if (GV->isDeclaration())


### PR DESCRIPTION
For backends, where AddressSpace information is important (NVPTX) we need to keep that information when moving global variables.

cc: @Keno @maleadt 
