### PR TITLE
Error if CC or CXX was specified in Make.user without override

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -483,6 +483,10 @@ ifeq (exists, $(shell [ -e $(BUILDROOT)/Make.user ] && echo exists ))
 include $(BUILDROOT)/Make.user
 endif
 
+ifneq ($(CC_BASE)$(CXX_BASE),$(shell echo $(CC) | cut -d' ' -f1)$(shell echo $(CXX) | cut -d' ' -f1))
+    $(error Forgot override directive on CC or CXX in Make.user? Cowardly refusing to build)
+endif
+
 ifeq ($(SANITIZE),1)
 ifeq ($(SANITIZE_MEMORY),1)
 SANITIZE_OPTS := -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer


### PR DESCRIPTION
This is a very common mistake to make and can lead to different dependencies
being built with different compilers, leading to all sorts of subtle errors.
Add a check to catch this instead.
