### PR TITLE
@static && || syntax

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -33,7 +33,7 @@ function choosetests(choices = [])
         "markdown", "base64", "serialize", "misc", "threads",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
-        "boundscheck", "error", "ambiguous", "cartesian", "asmvariant",
+        "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
         "channels"
     ]
     profile_skipped = false

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -207,24 +207,6 @@ end
     @test isa(ex, ErrorException) && ex.msg == "cannot assign variables in other modules"
 end
 
-@test !Base.is_unix(:Windows)
-@test !Base.is_linux(:Windows)
-@test Base.is_linux(:Linux)
-@test Base.is_windows(:Windows)
-@test Base.is_windows(:NT)
-@test !Base.is_windows(:Darwin)
-@test Base.is_apple(:Darwin)
-@test Base.is_apple(:Apple)
-@test !Base.is_apple(:Windows)
-@test Base.is_unix(:Darwin)
-@test Base.is_unix(:FreeBSD)
-@test_throws ArgumentError Base.is_unix(:BeOS)
-if !is_windows()
-    @test Sys.windows_version() === (0, 0)
-else
-    @test (Sys.windows_version()::Tuple{Int,Int})[1] > 0
-end
-
 # Issue 14173
 module Tmp14173
     export A

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -1,0 +1,26 @@
+@test !Base.is_unix(:Windows)
+@test !Base.is_linux(:Windows)
+@test Base.is_linux(:Linux)
+@test Base.is_windows(:Windows)
+@test Base.is_windows(:NT)
+@test !Base.is_windows(:Darwin)
+@test Base.is_apple(:Darwin)
+@test Base.is_apple(:Apple)
+@test !Base.is_apple(:Windows)
+@test Base.is_unix(:Darwin)
+@test Base.is_unix(:FreeBSD)
+@test_throws ArgumentError Base.is_unix(:BeOS)
+if !is_windows()
+    @test Sys.windows_version() === (0, 0)
+else
+    @test (Sys.windows_version()::Tuple{Int,Int})[1] > 0
+end
+
+@test (@static true ? 1 : 2) === 1
+@test (@static false ? 1 : 2) === 2
+@test (@static if true 1 end) === 1
+@test (@static if false 1 end) === nothing
+@test (@static true && 1) === 1
+@test (@static false && 1) === false
+@test (@static true || 1) === true
+@test (@static false || 1) === 1


### PR DESCRIPTION
expands @static syntax to include short-circuit evaluation, to facilitate making the build scripts for some packages (e.g. ImageMagick) more concise.
