### PR TITLE
De-purify IteratorsMD.flatten

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -25,13 +25,13 @@ CartesianIndex{N}(index::NTuple{N,Integer}) = CartesianIndex{N}(index)
 (::Type{CartesianIndex{N}}){N}() = CartesianIndex{N}(())
 # Un-nest passed CartesianIndexes
 CartesianIndex(index::Union{Integer, CartesianIndex}...) = CartesianIndex(flatten(index))
-Base.@pure flatten(I::Tuple{}) = I
-Base.@pure flatten(I::Tuple{Any}) = I
-Base.@pure flatten{N}(I::Tuple{CartesianIndex{N}}) = I[1].I
-Base.@pure flatten(I) = _flatten(I...)
-Base.@pure _flatten() = ()
-Base.@pure _flatten(i, I...)                 = (i, _flatten(I...)...)
-Base.@pure _flatten(i::CartesianIndex, I...) = (i.I..., _flatten(I...)...)
+flatten(I::Tuple{}) = I
+flatten(I::Tuple{Any}) = I
+flatten{N}(I::Tuple{CartesianIndex{N}}) = I[1].I
+@inline flatten(I) = _flatten(I...)
+@inline _flatten() = ()
+@inline _flatten(i, I...)                 = (i, _flatten(I...)...)
+@inline _flatten(i::CartesianIndex, I...) = (i.I..., _flatten(I...)...)
 CartesianIndex(index::Tuple{Vararg{Union{Integer, CartesianIndex}}}) = CartesianIndex(index...)
 
 # length


### PR DESCRIPTION
Ref @vtjnash concern at https://github.com/JuliaLang/julia/pull/17283#discussion_r71233113

I've run all the benchmarks locally, and don't find a single regression. So I don't think we need to run nanosoldier, though I have no objections whatsoever if someone wants to do that anyway.
