### PR TITLE
Fix dump(Any) test.

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -514,7 +514,7 @@ let repr = sprint(dump, Int64)
 end
 let repr = sprint(dump, Any)
     @test length(repr) > 100000
-    @test startswith(repr, "Any\n  Main.") || startswith(repr, "Any\n  Base.")
+    @test ismatch(r"^Any\n  [^ \t\n]", repr)
     @test endswith(repr, '\n')
     @test contains(repr, "     Base.Vector{T} = Array{T,1}\n")
     @test !contains(repr, "Core.Vector{T}")


### PR DESCRIPTION
I've seen this fail on travis at least twice. `dump(Any)` prints out a list of sub types but it could contain types from outside `Base` in undefined order. If one of the those types happens to be the first one printed, the original test will fail.
