### PR TITLE
add size to Important optional methods

### DIFF
--- a/doc/manual/interfaces.rst
+++ b/doc/manual/interfaces.rst
@@ -10,6 +10,7 @@ A lot of the power and extensibility in Julia comes from a collection of informa
 
 Iteration
 ---------
+
 ================================================== ======================== =====================================================================================
 Required methods                                                            Brief description
 ================================================== ======================== =====================================================================================
@@ -39,6 +40,7 @@ Value returned by :func:`iteratoreltype(IterType) <iteratoreltype>`  Required Me
 `HasEltype()`                                                        :func:`eltype(IterType) <eltype>`
 `EltypeUnknown()`                                                    (*none*)
 ==================================================================== ==================================
+
 Sequential iteration is implemented by the methods :func:`start`, :func:`done`, and :func:`next`. Instead of mutating objects as they are iterated over, Julia provides these three methods to keep track of the iteration state externally from the object. The :func:`start(iter) <start>` method returns the initial state for the iterable object ``iter``. That state gets passed along to :func:`done(iter, state) <done>`, which tests if there are any elements remaining, and :func:`next(iter, state) <next>`, which returns a tuple containing the current element and an updated ``state``. The ``state`` object can be anything, and is generally considered to be an implementation detail private to the iterable object.
 
 Any object defines these three methods is iterable and can be used in the :ref:`many functions that rely upon iteration <stdlib-collections-iteration>`. It can also be used directly in a ``for`` loop since the syntax::

--- a/doc/manual/interfaces.rst
+++ b/doc/manual/interfaces.rst
@@ -10,21 +10,35 @@ A lot of the power and extensibility in Julia comes from a collection of informa
 
 Iteration
 ---------
-
-================================================== ======================== ================================================
+================================================== ======================== =====================================================================================
 Required methods                                                            Brief description
-================================================== ======================== ================================================
+================================================== ======================== =====================================================================================
 :func:`start(iter) <start>`                                                 Returns the initial iteration state
 :func:`next(iter, state) <next>`                                            Returns the current item and the next state
 :func:`done(iter, state) <done>`                                            Tests if there are any items remaining
 **Important optional methods**                     **Default definition**   **Brief description**
+:func:`iteratorsize(IterType) <iteratorsize>`      ``HasLength()``          One of `HasLength()`, `HasShape()`, `IsInfinite()`, or `SizeUnknown()` as appropriate
+:func:`iteratoreltype(IterType) <iteratoreltype>`  ``HasEltype()``          Either `EltypeUnknown()` or `HasEltype()` as appropriate
 :func:`eltype(IterType) <eltype>`                  ``Any``                  The type the items returned by :func:`next`
 :func:`length(iter) <length>`                      (*undefined*)            The number of items, if known
 :func:`size(iter, [dim...]) <size>`                (*undefined*)            The number of items in each dimensions, if known
-:func:`iteratorsize(IterType) <iteratorsize>`      ``HasLength()``
-:func:`iteratoreltype(IterType) <iteratoreltype>`  ``HasEltype()``
-================================================== ======================== ================================================
+================================================== ======================== =====================================================================================
 
+================================================================ ======================================================================
+Value returned by :func:`iteratorsize(IterType) <iteratorsize>`  Required Methods
+================================================================ ======================================================================
+`HasLength()`                                                    :func:`length(iter) <length>`
+`HasShape()`                                                     :func:`length(iter) <length>`  and :func:`size(iter, [dim...]) <size>`
+`IsInfinite()`                                                   (*none*)
+`SizeUnknown()`                                                  (*none*)
+================================================================ ======================================================================
+
+==================================================================== ==================================
+Value returned by :func:`iteratoreltype(IterType) <iteratoreltype>`  Required Methods
+==================================================================== ==================================
+`HasEltype()`                                                        :func:`eltype(IterType) <eltype>`
+`EltypeUnknown()`                                                    (*none*)
+==================================================================== ==================================
 Sequential iteration is implemented by the methods :func:`start`, :func:`done`, and :func:`next`. Instead of mutating objects as they are iterated over, Julia provides these three methods to keep track of the iteration state externally from the object. The :func:`start(iter) <start>` method returns the initial state for the iterable object ``iter``. That state gets passed along to :func:`done(iter, state) <done>`, which tests if there are any elements remaining, and :func:`next(iter, state) <next>`, which returns a tuple containing the current element and an updated ``state``. The ``state`` object can be anything, and is generally considered to be an implementation detail private to the iterable object.
 
 Any object defines these three methods is iterable and can be used in the :ref:`many functions that rely upon iteration <stdlib-collections-iteration>`. It can also be used directly in a ``for`` loop since the syntax::

--- a/doc/manual/interfaces.rst
+++ b/doc/manual/interfaces.rst
@@ -11,18 +11,19 @@ A lot of the power and extensibility in Julia comes from a collection of informa
 Iteration
 ---------
 
-================================================== ======================== ===========================================
+================================================== ======================== ================================================
 Required methods                                                            Brief description
-================================================== ======================== ===========================================
+================================================== ======================== ================================================
 :func:`start(iter) <start>`                                                 Returns the initial iteration state
 :func:`next(iter, state) <next>`                                            Returns the current item and the next state
 :func:`done(iter, state) <done>`                                            Tests if there are any items remaining
 **Important optional methods**                     **Default definition**   **Brief description**
 :func:`eltype(IterType) <eltype>`                  ``Any``                  The type the items returned by :func:`next`
 :func:`length(iter) <length>`                      (*undefined*)            The number of items, if known
+:func:`size(iter, [dim...]) <size>`                (*undefined*)            The number of items in each dimensions, if known
 :func:`iteratorsize(IterType) <iteratorsize>`      ``HasLength()``
 :func:`iteratoreltype(IterType) <iteratoreltype>`  ``HasEltype()``
-================================================== ======================== ===========================================
+================================================== ======================== ================================================
 
 Sequential iteration is implemented by the methods :func:`start`, :func:`done`, and :func:`next`. Instead of mutating objects as they are iterated over, Julia provides these three methods to keep track of the iteration state externally from the object. The :func:`start(iter) <start>` method returns the initial state for the iterable object ``iter``. That state gets passed along to :func:`done(iter, state) <done>`, which tests if there are any elements remaining, and :func:`next(iter, state) <next>`, which returns a tuple containing the current element and an updated ``state``. The ``state`` object can be anything, and is generally considered to be an implementation detail private to the iterable object.
 

--- a/doc/manual/interfaces.rst
+++ b/doc/manual/interfaces.rst
@@ -21,7 +21,7 @@ Required methods                                                            Brie
 :func:`iteratoreltype(IterType) <iteratoreltype>`  ``HasEltype()``          Either `EltypeUnknown()` or `HasEltype()` as appropriate
 :func:`eltype(IterType) <eltype>`                  ``Any``                  The type the items returned by :func:`next`
 :func:`length(iter) <length>`                      (*undefined*)            The number of items, if known
-:func:`size(iter, [dim...]) <size>`                (*undefined*)            The number of items in each dimensions, if known
+:func:`size(iter, [dim...]) <size>`                (*undefined*)            The number of items in each dimension, if known
 ================================================== ======================== =====================================================================================
 
 ================================================================ ======================================================================


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/commit/e01dcf364ba65ab28b4e5f08297234955a0e6c51#commitcomment-18331656

`size` like length should be present in the list of methods.
[ci skip]
