### PR TITLE
Make `watch_file` return values consistent with docs

### DIFF
--- a/base/poll.jl
+++ b/base/poll.jl
@@ -392,13 +392,13 @@ function watch_file(s::AbstractString, timeout_s::Real=-1)
         if timeout_s >= 0
             result = fetimeout()
 
-            @schedule (try result = wait(fm); catch e; notify_error(wt, e); end; notify(wt))
+            @schedule (try _, result = wait(fm); catch e; notify_error(wt, e); end; notify(wt))
             @schedule (sleep(timeout_s); notify(wt))
 
             wait(wt)
             return result
         else
-            return wait(fm)
+            return wait(fm)[2]
         end
     finally
         close(fm)

--- a/test/file.jl
+++ b/test/file.jl
@@ -212,6 +212,19 @@ function test_touch(slval)
     @test ispath(tr[1]) && ispath(tr[2])
 end
 
+function test_watch_file_timeout(tval)
+    watch = @async watch_file(file, tval)
+    @test wait(watch) == Base.Filesystem.FileEvent(false, false, true)
+end
+
+function test_watch_file_change(tval)
+    watch = @async watch_file(file, tval)
+    sleep(tval/3)
+    open(file, "a") do f
+        write(f, "small change\n")
+    end
+    @test wait(watch) == Base.Filesystem.FileEvent(false, true, false)
+end
 
 function test_monitor_wait(tval)
     fm = FileMonitor(file)
@@ -247,6 +260,8 @@ test_monitor_wait(0.1)
 test_monitor_wait(0.1)
 test_monitor_wait_poll()
 test_monitor_wait_poll()
+test_watch_file_timeout(0.1)
+test_watch_file_change(6)
 
 @test_throws Base.UVError watch_file("nonexistantfile", 10)
 @test_throws Base.UVError poll_file("nonexistantfile", 2, 10)


### PR DESCRIPTION
Currently, `watch_file` returns a `Tuple{String, Base.FileSystem.FileEvent}` if it timesout, but a `Base.FileSystem.FileEvent` if it detects any changes.  This PR makes it so only the event is returned.
