### PR TITLE
RFC: Revise version number generation

### DIFF
--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -30,7 +30,6 @@ origin=$(git config -l 2>/dev/null | grep 'remote\.\w*\.url.*JuliaLang/julia.git
 if [ -z "$origin" ]; then
     origin="origin/"
 fi
-last_tag=$(git describe --tags --abbrev=0)
 git_time=$(git log -1 --pretty=format:%ct)
 
 #collect the contents
@@ -41,10 +40,15 @@ if [ -n "$(git status --porcelain)" ]; then
     commit_short="$commit_short"*
 fi
 branch=$(git branch | sed -n '/\* /s///p')
-# Some versions of wc (eg on OS X) add extra whitespace to their output.
-# The sed(1) call stops this from breaking the generated Julia's indentation by
-# stripping all non-digits.
-build_number=$(git rev-list HEAD ^$last_tag | wc -l | sed -e 's/[^[:digit:]]//g')
+
+topdir=$(git rev-parse --show-toplevel)
+verchanged=$(git blame -L ,1 -sl -- "$topdir/VERSION" | cut -f 1 -d " ")
+if [ $verchanged = 0000000000000000000000000000000000000000 ]; then
+    # uncommited change to VERSION
+    build_number=0
+else
+    build_number=$(git rev-list --count HEAD "^$verchanged")
+fi
 
 date_string=$git_time
 case $(uname) in

--- a/contrib/commit-name.sh
+++ b/contrib/commit-name.sh
@@ -6,7 +6,34 @@
 
 gitref=${1:-HEAD}
 
-last_tag=$(git describe --tags --abbrev=0 "$gitref")
 ver=$(git show "$gitref:VERSION")
-nb=$(git rev-list --count "$gitref" "^$last_tag")
-echo "$ver+$nb"
+major=$(echo $ver | cut -f 1 -d .)
+minor=$(echo $ver | cut -f 2 -d .)
+
+if [ $major = 0 -a $minor -lt 5 ]; then
+    # use tag based build number prior to 0.5.0-
+    last_tag=$(git describe --tags --abbrev=0 "$gitref")
+    nb=$(git rev-list --count "$gitref" "^$last_tag")
+    if [ $nb = 0 ]; then
+        echo $ver
+    else
+        echo "$ver+$nb"
+    fi
+else
+    topdir=$(git rev-parse --show-toplevel)
+    verchanged=$(git blame -L ,1 -sl $gitref -- "$topdir/VERSION" | cut -f 1 -d " ")
+    nb=$(git rev-list --count "$gitref" "^$verchanged")
+    pre=$(echo $ver | cut -s -f 2 -d "-")
+    if [ $ver = "0.5.0-dev" ]; then
+        # bump to 0.5.0-dev was one commit after tag during 0.5.0-dev
+        nb=$(expr $nb + 1)
+    elif [ $ver = "0.5.0-pre" ]; then
+        # bump to 0.5.0-pre was 5578 commits after tag
+        nb=$(expr $nb + 5578)
+    fi
+    if [ -n "$pre" ]; then
+        echo "$ver+$nb"
+    else
+        echo $ver
+    fi
+fi

--- a/test/version.jl
+++ b/test/version.jl
@@ -116,6 +116,7 @@ import Base.issupbuild
 # basic comparison
 VersionNumber(2, 3, 1) == VersionNumber(Int8(2), UInt32(3), Int32(1)) == v"2.3.1"
 @test v"2.3.0" < v"2.3.1" < v"2.4.8" < v"3.7.2"
+@test v"0.6.0-" < v"0.6.0-dev" < v"0.6.0-dev.123" < v"0.6.0-dev.unknown" < v"0.6.0-pre" < v"0.6.0"
 
 #lowerbound and upperbound
 import Base: lowerbound, upperbound


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/issues/17418#issuecomment-233871337, https://github.com/JuliaLang/julia/pull/17434#issuecomment-233872219

This changes the build number computation from "commits since last tag" to "commits since last change of VERSION file". The build number is append to "-dev" and "-pre" versions only, but also if zero. I.e. the commit that changes VERSION to `0.5.0-pre` will be version `0.5.0-pre+0`.

To avoid an inconsistency for 0.5.0-dev versions, the build number is increased by one for those. (VERSION file was set to `0.5.0-dev` in the first commit after the last tag.)

The `commit-name.sh` script is changed accordingly.
