### PR TITLE
Statically evaluate pointer vals + slight clean-up

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -656,12 +656,6 @@ static void raise_exception(Value *exc, jl_codectx_t *ctx,
     builder.SetInsertPoint(contBB);
 }
 
-static void raise_exception(GlobalVariable *exc, jl_codectx_t *ctx)
-{
-    raise_exception((Value*)tbaa_decorate(tbaa_const,
-                                          builder.CreateLoad(exc)), ctx);
-}
-
 // DO NOT PASS IN A CONST CONDITION!
 static void raise_exception_unless(Value *cond, Value *exc, jl_codectx_t *ctx)
 {
@@ -673,23 +667,10 @@ static void raise_exception_unless(Value *cond, Value *exc, jl_codectx_t *ctx)
 }
 
 // DO NOT PASS IN A CONST CONDITION!
-static void raise_exception_unless(Value *cond, GlobalVariable *exc,
-                                   jl_codectx_t *ctx)
-{
-    raise_exception_unless(cond, (Value*)tbaa_decorate(tbaa_const,builder.CreateLoad(exc, false)), ctx);
-}
-
-// DO NOT PASS IN A CONST CONDITION!
 static void raise_exception_if(Value *cond, Value *exc, jl_codectx_t *ctx)
 {
     raise_exception_unless(builder.CreateXor(cond, ConstantInt::get(T_int1,-1)),
                            exc, ctx);
-}
-
-// DO NOT PASS IN A CONST CONDITION!
-static void raise_exception_if(Value *cond, GlobalVariable *exc, jl_codectx_t *ctx)
-{
-    raise_exception_if(cond, (Value*)tbaa_decorate(tbaa_const, builder.CreateLoad(exc, false)), ctx);
 }
 
 static void null_pointer_check(Value *v, jl_codectx_t *ctx)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3009,7 +3009,7 @@ static Value *emit_condition(const jl_cgval_t &condV, const std::string &msg,
     }
     emit_typecheck(condV, (jl_value_t*)jl_bool_type, msg, ctx);
     if (condV.isboxed) {
-        return builder.CreateICmpEQ(boxed(condV, ctx), tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlfalse_var))));
+        return builder.CreateICmpEQ(boxed(condV, ctx), literal_pointer_val(jl_false));
     }
     // not a boolean
     return ConstantInt::get(T_int1,0); // TODO: replace with Undef


### PR DESCRIPTION
This PR improves `literal_pointer_val` (emission of literal pointer vals) and uses it in more places instead of current manual loads from associated global variables containing pointers. This makes that non-imaging code doesn't contain the extra step of loading the pointer from the global variable, but contains the pointer itself instead (see first commit message).

All but one cases are dealing with raising exceptions, which is relevant for NVPTX because we can't load the pointer from the global variable, yet we can use the pointer itself to determine the exception type (with most being ghost types). Also fixes `julia_bool`, but AFAICT that's only used where stuff is boxed and slow anyway.

Lastly, the entire `global_to_llvm` (and the `std::map` I added to keep track of the values) could probably be merged with `jl_get_global_for` and others in jitlayers, but it seems subtly different so I decided to keep the changes localized for now.
