### PR TITLE
Restore support for libgit2 0.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Julia uses the following external libraries, which are automatically downloaded 
 - **[PCRE]** (>= 10.00)      — Perl-compatible regular expressions library.
 - **[GMP]** (>= 5.0)         — GNU multiple precision arithmetic library, needed for `BigInt` support.
 - **[MPFR]** (>= 3.0)        — GNU multiple precision floating point library, needed for arbitrary precision floating point (`BigFloat`) support.
-- **[libgit2]** (>= 0.24)    — Git linkable library, used by Julia's package manager
+- **[libgit2]** (>= 0.23)    — Git linkable library, used by Julia's package manager
 - **[libssh2]** (>= 1.7)     — library for SSH transport, used by libgit2 for packages with SSH remotes
 - **[mbedtls]** (>= 2.2)     — library used for cryptography and transport layer security, used by libssh2
 - **[utf8proc]** (>= 2.0)    — a library for processing UTF-8 encoded Unicode strings

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -2,15 +2,15 @@
 
 #@testset "libgit2" begin
 
-const LIBGIT2_VER = v"0.24.0"
+const LIBGIT2_MIN_VER = v"0.23.0"
 
 #########
 # TESTS #
 #########
 
-#@testset "Check library verison" begin
+#@testset "Check library version" begin
     v = LibGit2.version()
-    @test  v.major == LIBGIT2_VER.major && v.minor >= LIBGIT2_VER.minor
+    @test  v.major == LIBGIT2_MIN_VER.major && v.minor >= LIBGIT2_MIN_VER.minor
 #end
 
 #@testset "Check library features" begin


### PR DESCRIPTION
Testing for >= 0.24 when we still branch to support 0.23 does not make
much sense.

Cf. https://github.com/JuliaLang/julia/pull/15587.

Cc: @wildart @tkelman
