### PR TITLE
Kill `end_offset`

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1558,8 +1558,7 @@ static void emit_cpointercheck(const jl_cgval_t &x, const std::string &msg, jl_c
 static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size, Value *jt)
 {
     int osize;
-    int end_offset;
-    int offset = jl_gc_classify_pools(static_size, &osize, &end_offset);
+    int offset = jl_gc_classify_pools(static_size, &osize);
     Value *ptls_ptr = emit_bitcast(ctx->ptlsStates, T_pint8);
     Value *v;
     if (offset < 0) {
@@ -1570,10 +1569,9 @@ static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size, Value *jt)
     }
     else {
         Value *pool_offs = ConstantInt::get(T_int32, offset);
-        Value *args[] = {ptls_ptr, pool_offs, ConstantInt::get(T_int32, osize),
-                         ConstantInt::get(T_int32, end_offset)};
+        Value *args[] = {ptls_ptr, pool_offs, ConstantInt::get(T_int32, osize)};
         v = builder.CreateCall(prepare_call(jlalloc_pool_func),
-                               ArrayRef<Value*>(args, 4));
+                               ArrayRef<Value*>(args, 3));
     }
     tbaa_decorate(tbaa_tag, builder.CreateStore(jt, emit_typeptr_addr(v)));
     return v;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1569,8 +1569,8 @@ static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size, Value *jt)
                                ArrayRef<Value*>(args, 2));
     }
     else {
-        Value *pool_ptr = builder.CreateConstGEP1_32(ptls_ptr, offset);
-        Value *args[] = {ptls_ptr, pool_ptr, ConstantInt::get(T_int32, osize),
+        Value *pool_offs = ConstantInt::get(T_int32, offset);
+        Value *args[] = {ptls_ptr, pool_offs, ConstantInt::get(T_int32, osize),
                          ConstantInt::get(T_int32, end_offset)};
         v = builder.CreateCall(prepare_call(jlalloc_pool_func),
                                ArrayRef<Value*>(args, 4));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5428,7 +5428,6 @@ static void init_julia_llvm_env(Module *m)
     alloc_pool_args.push_back(T_pint8);
     alloc_pool_args.push_back(T_int32);
     alloc_pool_args.push_back(T_int32);
-    alloc_pool_args.push_back(T_int32);
     jlalloc_pool_func =
         Function::Create(FunctionType::get(T_pjlvalue, alloc_pool_args, false),
                          Function::ExternalLinkage,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5426,7 +5426,7 @@ static void init_julia_llvm_env(Module *m)
 
     std::vector<Type*> alloc_pool_args(0);
     alloc_pool_args.push_back(T_pint8);
-    alloc_pool_args.push_back(T_pint8);
+    alloc_pool_args.push_back(T_int32);
     alloc_pool_args.push_back(T_int32);
     alloc_pool_args.push_back(T_int32);
     jlalloc_pool_func =

--- a/src/gc.c
+++ b/src/gc.c
@@ -786,9 +786,13 @@ static NOINLINE jl_taggedvalue_t *add_page(jl_gc_pool_t *p)
 }
 
 // Size includes the tag and the tag is not cleared!!
-JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, jl_gc_pool_t *p,
+JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
                                           int osize, int end_offset)
 {
+    // Use the pool offset instead of the pool address as the argument
+    // to workaround a llvm bug.
+    // Ref https://llvm.org/bugs/show_bug.cgi?id=27190
+    jl_gc_pool_t *p = (jl_gc_pool_t*)((char*)ptls + pool_offset);
     assert(ptls->gc_state == 0);
 #ifdef MEMDEBUG
     return jl_gc_big_alloc(ptls, osize);

--- a/src/gc.c
+++ b/src/gc.c
@@ -751,22 +751,24 @@ static void sweep_malloced_arrays(void)
 }
 
 // pool allocation
-static inline jl_taggedvalue_t *reset_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_taggedvalue_t *fl)
+static inline jl_taggedvalue_t *reset_page(const jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_taggedvalue_t *fl)
 {
+    assert(GC_PAGE_OFFSET >= sizeof(void*));
     pg->nfree = (GC_PAGE_SZ - GC_PAGE_OFFSET) / p->osize;
     jl_ptls_t ptls2 = jl_all_tls_states[pg->thread_n];
     pg->pool_n = p - ptls2->heap.norm_pools;
     memset(pg->ages, 0, GC_PAGE_SZ / 8 / p->osize + 1);
     jl_taggedvalue_t *beg = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
-    jl_taggedvalue_t *end = (jl_taggedvalue_t*)((char*)beg + (pg->nfree - 1)*p->osize);
-    end->next = fl;
+    jl_taggedvalue_t *next = (jl_taggedvalue_t*)pg->data;
+    next->next = fl;
     pg->has_young = 0;
     pg->has_marked = 0;
-    pg->fl_begin_offset = GC_PAGE_OFFSET;
-    pg->fl_end_offset = (char*)end - (char*)beg + GC_PAGE_OFFSET;
+    pg->fl_begin_offset = -1;
+    pg->fl_end_offset = -1;
     return beg;
 }
 
+// Add a new page to the pool. Discards any pages in `p->newpages` before.
 static NOINLINE jl_taggedvalue_t *add_page(jl_gc_pool_t *p)
 {
     // Do not pass in `ptls` as argument. This slows down the fast path
@@ -780,14 +782,14 @@ static NOINLINE jl_taggedvalue_t *add_page(jl_gc_pool_t *p)
     pg->osize = p->osize;
     pg->ages = (uint8_t*)malloc(GC_PAGE_SZ / 8 / p->osize + 1);
     pg->thread_n = ptls->tid;
-    jl_taggedvalue_t *fl = reset_page(p, pg, p->newpages);
+    jl_taggedvalue_t *fl = reset_page(p, pg, NULL);
     p->newpages = fl;
     return fl;
 }
 
 // Size includes the tag and the tag is not cleared!!
 JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
-                                          int osize, int end_offset)
+                                          int osize)
 {
     // Use the pool offset instead of the pool address as the argument
     // to workaround a llvm bug.
@@ -824,31 +826,36 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
     }
     // if the freelist is empty we reuse empty but not freed pages
     v = p->newpages;
-    if (__unlikely(!v))
-        v = add_page(p);
-    jl_taggedvalue_t *end = (jl_taggedvalue_t*)&(gc_page_data(v)[end_offset]);
-    if (__likely(v != end)) {
-        p->newpages = (jl_taggedvalue_t*)((char*)v + osize);
+    jl_taggedvalue_t *next = (jl_taggedvalue_t*)((char*)v + osize);
+    // If there's no pages left or the current page is used up,
+    // we need to use the slow path.
+    char *cur_page = gc_page_data((char*)v - 1);
+    if (__unlikely(!v || cur_page + GC_PAGE_SZ < (char*)next)) {
+        if (v) {
+            // like the freelist case,
+            // but only update the page metadata when it is full
+            jl_gc_pagemeta_t *pg = page_metadata((char*)v - 1);
+            assert(pg->osize == p->osize);
+            pg->nfree = 0;
+            pg->has_young = 1;
+            v = *(jl_taggedvalue_t**)cur_page;
+        }
+        // Not an else!!
+        if (!v)
+            v = add_page(p);
+        next = (jl_taggedvalue_t*)((char*)v + osize);
     }
-    else {
-        // like the freelist case, but only update the page metadata when it is full
-        jl_gc_pagemeta_t *pg = page_metadata(v);
-        assert(pg->osize == p->osize);
-        pg->nfree = 0;
-        pg->has_young = 1;
-        p->newpages = v->next;
-    }
+    p->newpages = next;
     return jl_valueof(v);
 }
 
-int jl_gc_classify_pools(size_t sz, int *osize, int *end_offset)
+int jl_gc_classify_pools(size_t sz, int *osize)
 {
     if (sz > GC_MAX_SZCLASS)
         return -1;
     size_t allocsz = sz + sizeof(jl_taggedvalue_t);
     int klass = jl_gc_szclass(allocsz);
     *osize = jl_gc_sizeclasses[klass];
-    *end_offset = GC_POOL_END_OFS(*osize);
     return (int)(intptr_t)(&((jl_ptls_t)0)->heap.norm_pools[klass]);
 }
 
@@ -875,10 +882,7 @@ static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_t
         // FIXME - need to do accounting on a per-thread basis
         // on quick sweeps, keep a few pages empty but allocated for performance
         if (!sweep_full && lazy_freed_pages <= default_collect_interval / GC_PAGE_SZ) {
-            jl_taggedvalue_t *begin = reset_page(p, pg, 0);
-            jl_taggedvalue_t **pend = (jl_taggedvalue_t**)((char*)begin + ((int)pg->nfree - 1)*osize);
-            jl_taggedvalue_t *npg = p->newpages;
-            *pend = npg;
+            jl_taggedvalue_t *begin = reset_page(p, pg, p->newpages);
             p->newpages = begin;
             begin->next = (jl_taggedvalue_t*)0;
             lazy_freed_pages++;
@@ -1046,8 +1050,10 @@ static void gc_sweep_pool(int sweep_full)
 
             last = p->newpages;
             if (last) {
-                jl_gc_pagemeta_t *pg = page_metadata(last);
-                pg->nfree = (GC_PAGE_SZ - ((char*)last - gc_page_data(last))) / p->osize;
+                char *last_p = (char*)last;
+                jl_gc_pagemeta_t *pg = page_metadata(last_p - 1);
+                assert(last_p - gc_page_data(last_p - 1) >= GC_PAGE_OFFSET);
+                pg->nfree = (GC_PAGE_SZ - (last_p - gc_page_data(last_p - 1))) / p->osize;
                 pg->has_young = 1;
             }
             p->newpages = NULL;
@@ -1865,7 +1871,6 @@ void jl_mk_thread_heap(jl_ptls_t ptls)
         p[i].osize = jl_gc_sizeclasses[i];
         p[i].freelist = NULL;
         p[i].newpages = NULL;
-        p[i].end_offset = GC_POOL_END_OFS(jl_gc_sizeclasses[i]);
     }
     arraylist_new(&heap->weak_refs, 0);
     heap->mallocarrays = NULL;

--- a/src/gc.h
+++ b/src/gc.h
@@ -30,7 +30,9 @@
 extern "C" {
 #endif
 
-// manipulating mark bits
+#define GC_PAGE_LG2 14 // log2(size of a page)
+#define GC_PAGE_SZ (1 << GC_PAGE_LG2) // 16k
+#define GC_PAGE_OFFSET (JL_SMALL_BYTE_ALIGNMENT - (sizeof(jl_taggedvalue_t) % JL_SMALL_BYTE_ALIGNMENT))
 
 // 8G * 32768 = 2^48
 // It's really unlikely that we'll actually allocate that much though...
@@ -157,7 +159,8 @@ __attribute__((aligned(GC_PAGE_SZ)))
 
 typedef struct {
     // Page layout:
-    //  Padding: GC_PAGE_OFFSET
+    //  Newpage freelist: sizeof(void*)
+    //  Padding: GC_PAGE_OFFSET - sizeof(void*)
     //  Blocks: osize * n
     //    Tag: sizeof(jl_taggedvalue_t)
     //    Data: <= osize - sizeof(jl_taggedvalue_t)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -42,7 +42,7 @@ extern unsigned sig_stack_size;
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
 
-JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, jl_gc_pool_t *p,
+JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
                                           int osize, int end_offset);
 JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t allocsz);
 int jl_gc_classify_pools(size_t sz, int *osize, int *end_offset);
@@ -133,7 +133,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
             osize = p->osize;
             endoff = p->end_offset;
         }
-        v = jl_gc_pool_alloc(ptls, p, osize, endoff);
+        v = jl_gc_pool_alloc(ptls, (char*)p - (char*)ptls, osize, endoff);
     }
     else {
         v = jl_gc_big_alloc(ptls, allocsz);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -31,7 +31,6 @@
 typedef struct {
     jl_taggedvalue_t *freelist;   // root of list of free objects
     jl_taggedvalue_t *newpages;   // root of list of chunks of free objects
-    uint16_t end_offset; // stored to avoid computing it at each allocation
     uint16_t osize;      // size of objects in this pool
 } jl_gc_pool_t;
 


### PR DESCRIPTION
As @JeffBezanson pointed out, we don't need this in the fast path of the allocator. In fact, we don't need this at all since we only use this to figure out if we are at the end of a page and this can be easily computed from the pointer itself.
