### PR TITLE
fix #17372, only accept `Int` in `reshape`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -7,6 +7,7 @@ typealias AbstractMatrix{T} AbstractArray{T,2}
 typealias AbstractVecOrMat{T} Union{AbstractVector{T}, AbstractMatrix{T}}
 typealias RangeIndex Union{Int, Range{Int}, AbstractUnitRange{Int}, Colon}
 typealias DimOrInd Union{Integer, AbstractUnitRange}
+typealias IntOrInd Union{Int, AbstractUnitRange}
 typealias DimsOrInds{N} NTuple{N,DimOrInd}
 
 macro _inline_pure_meta()

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -37,7 +37,7 @@ end
 length(R::ReshapedArrayIterator) = length(R.iter)
 
 reshape(parent::AbstractArray, shp::Tuple)        = _reshape(parent, to_shape(shp))
-reshape(parent::AbstractArray, dims::DimOrInd...) = reshape(parent, dims)
+reshape(parent::AbstractArray, dims::IntOrInd...) = reshape(parent, dims)
 
 reshape{T,N}(parent::AbstractArray{T,N}, ndims::Type{Val{N}}) = parent
 function reshape{T,AN,N}(parent::AbstractArray{T,AN}, ndims::Type{Val{N}})


### PR DESCRIPTION
I believe this is a bug, since it's very strange that passing an `Int32` resulted in a `ReshapedArray` while passing an `Int` resulted in an `Array`.

This synchronizes `DimOrInd` with other index-related types, all of which use `Int`. This will also affect packages like DistributedArrays, which also assume `Int`.
