### PR TITLE
improve a[...] .= handling of arrays of arrays and dicts of arrays

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -443,25 +443,20 @@ end
 ############################################################
 
 # x[...] .= f.(y...) ---> broadcast!(f, dotview(x, ...), y...).
-# The dotview function defaults to view, but we override it in
+# The dotview function defaults to getindex, but we override it in
 # a few cases to get the expected in-place behavior without affecting
 # explicit calls to view.   (All of this can go away if slices
 # are changed to generate views by default.)
 
-dotview(args...) = view(args...)
+dotview(args...) = getindex(args...)
+dotview(A::AbstractArray, args...) = view(A, args...)
 # avoid splatting penalty in common cases:
 for nargs = 0:5
     args = Symbol[Symbol("x",i) for i = 1:nargs]
-    eval(Expr(:(=), Expr(:call, :dotview, args...), Expr(:call, :view, args...)))
+    eval(Expr(:(=), Expr(:call, :dotview, args...),
+                    Expr(:call, :getindex, args...)))
+    eval(Expr(:(=), Expr(:call, :dotview, :(A::AbstractArray), args...),
+                    Expr(:call, :view, :A, args...)))
 end
-
-# for a[i...] .= ... where a is an array-of-arrays, just pass a[i...] directly
-# to broadcast!
-dotview{T<:AbstractArray,N,I<:Integer}(a::AbstractArray{T,N}, i::Vararg{I,N}) =
-    a[i...]
-
-# dict[k] .= ... should work if dict[k] is an array
-dotview(a::Associative, k) = a[k]
-dotview(a::Associative, k1, k2, ks...) = a[tuple(k1,k2,ks...)]
 
 end # module

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -450,6 +450,7 @@ end
 
 dotview(args...) = getindex(args...)
 dotview(A::AbstractArray, args...) = view(A, args...)
+dotview{T<:AbstractArray}(A::AbstractArray{T}, args...) = getindex(A, args...)
 # avoid splatting penalty in common cases:
 for nargs = 0:5
     args = Symbol[Symbol("x",i) for i = 1:nargs]

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,7 @@ module Broadcast
 using Base.Cartesian
 using Base: promote_op, promote_eltype, promote_eltype_op, @get!, _msk_end, unsafe_bitgetindex, linearindices, tail, OneTo, to_shape
 import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^
-export broadcast, broadcast!, bitbroadcast
+export broadcast, broadcast!, bitbroadcast, dotview
 export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##
@@ -439,5 +439,29 @@ for (sigA, sigB) in ((BitArray, BitArray),
         end
     end
 end
+
+############################################################
+
+# x[...] .= f.(y...) ---> broadcast!(f, dotview(x, ...), y...).
+# The dotview function defaults to view, but we override it in
+# a few cases to get the expected in-place behavior without affecting
+# explicit calls to view.   (All of this can go away if slices
+# are changed to generate views by default.)
+
+dotview(args...) = view(args...)
+# avoid splatting penalty in common cases:
+for nargs = 0:5
+    args = Symbol[Symbol("x",i) for i = 1:nargs]
+    eval(Expr(:(=), Expr(:call, :dotview, args...), Expr(:call, :view, args...)))
+end
+
+# for a[i...] .= ... where a is an array-of-arrays, just pass a[i...] directly
+# to broadcast!
+dotview{T<:AbstractArray,N,I<:Integer}(a::AbstractArray{T,N}, i::Vararg{I,N}) =
+    a[i...]
+
+# dict[k] .= ... should work if dict[k] is an array
+dotview(a::Associative, k) = a[k]
+dotview(a::Associative, k1, k2, ks...) = a[tuple(k1,k2,ks...)]
 
 end # module

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -660,7 +660,7 @@ calls do not allocate new arrays over and over again for the results
 except that, as above, the ``broadcast!`` loop is fused with any nested
 "dot" calls.  For example, ``X .= sin.(Y)`` is equivalent to
 ``broadcast!(sin, X, Y)``, overwriting ``X`` with ``sin.(Y)`` in-place.
-If the left-hand side is a ``getindex`` expression, e.g.
+If the left-hand side is an array-indexing expression, e.g.
 ``X[2:end] .= sin.(Y)``, then it translates to ``broadcast!`` on a ``view``,
 e.g. ``broadcast!(sin, view(X, 2:endof(X)), Y)``, so that the left-hand
 side is updated in-place.

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1549,7 +1549,7 @@
       (let* ((ex (partially-expand-ref expr))
              (stmts (butlast (cdr ex)))
              (refex (last    (cdr ex)))
-             (nuref `(call (top view) ,(caddr refex) ,@(cdddr refex))))
+             (nuref `(call (top dotview) ,(caddr refex) ,@(cdddr refex))))
         `(block ,@stmts ,nuref))
       expr))
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -274,6 +274,16 @@ let x = [1:4;], y = x
     x[2:end] .= 1:3
     @test y === x == [0,1,2,3]
 end
+let a = [[4, 5], [6, 7]]
+    a[1] .= 3
+    @test a == [[3, 3], [6, 7]]
+end
+let d = Dict(:foo => [1,3,7], (3,4) => [5,9])
+    d[:foo] .+= 2
+    @test d[:foo] == [3,5,9]
+    d[3,4] .-= 1
+    @test d[3,4] == [4,8]
+end
 
 # PR 16988
 @test Base.promote_op(+, Bool) === Int


### PR DESCRIPTION
My ideal in JuliaLang/julia#17510 was to have `x .= f.(y)` be a synonym for `broadcast!(f, x, y)`.   However, because slices return copies and not views, in JuliaLang/julia#17546 I had to modify this so that `x[...] .= f.(y)` turns into `broadcast!(f, view(x, ...), y)`.    This PR extends that solution so that in-place semantics are achieved for arrays of arrays and dictionaries of arrays, to fix a problem pointed out by @iamed2.

In particular, `x[...] .= f.(y)` now turns into `broadcast!(f, Base.dotview(x, ...), y)`.  The `dotview` function defaults to calling `view`, but we can override it for dictionaries and arrays-of-arrays to achieve the desired semantics without affecting explicit calls to `view`.
