### PR TITLE
remove REPL frames from interactive backtrace printing again

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -14,7 +14,7 @@ type CapturedException <: Exception
         # Process bt_raw so that it can be safely serialized
         bt_lines = Any[]
         process_func(args...) = push!(bt_lines, args)
-        process_backtrace(process_func, :(:), bt_raw, 1:100) # Limiting this to 100 lines.
+        process_backtrace(process_func, bt_raw, 100) # Limiting this to 100 lines.
 
         new(ex, bt_lines)
     end


### PR DESCRIPTION
Before:

```
julia> permute!(rand(5), [1,2])
ERROR: BoundsError: attempt to access 5-element Array{Float64,1} at index [0]
 in permute!!(::Array{Float64,1}, ::Array{Int64,1}) at ./combinatorics.jl:82
 in permute!(::Array{Float64,1}, ::Array{Int64,1}) at ./combinatorics.jl:107
 in eval(::Module, ::Any) at ./boot.jl:234
 in macro expansion at ./REPL.jl:92 [inlined]
 in (::Base.REPL.##3#4{Base.REPL.REPLBackend})() at ./event.jl:46
```

After:

```
julia> permute!(rand(5), [1,2])
ERROR: BoundsError: attempt to access 5-element Array{Float64,1} at index [0]
 in permute!!(::Array{Float64,1}, ::Array{Int64,1}) at ./combinatorics.jl:82
 in permute!(::Array{Float64,1}, ::Array{Int64,1}) at ./combinatorics.jl:107
```

Gives the same backtrace as 0.4 now. Also simplifies and improves the implementation of this: now the REPL is in charge of removing the frames it wants to, leaving that out of general backtrace printing code.
