### PR TITLE
documentation for besselhx

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4794,14 +4794,6 @@ Airy function derivative ``\\operatorname{Ai}'(x)``.
 airyaiprime
 
 """
-    besselh(nu, k, x)
-
-Bessel function of the third kind of order `nu` (Hankel function). `k` is either 1 or 2,
-selecting `hankelh1` or `hankelh2`, respectively.
-"""
-besselh
-
-"""
     prepend!(collection, items) -> collection
 
 Insert the elements of `items` to the beginning of `collection`.

--- a/base/special/bessel.jl
+++ b/base/special/bessel.jl
@@ -190,6 +190,15 @@ function _bessely(nu::Float64, z::Complex128, kode::Int32)
     end
 end
 
+"""
+    besselh(nu, [k=1,] x)
+
+Bessel function of the third kind of order `nu` (the Hankel function). `k` is either 1 or 2,
+selecting `hankelh1` or `hankelh2`, respectively.  `k` defaults to 1 if it is omitted.
+(See also [`besselhx`](:func:`besselhx`) for an exponentially scaled variant.)
+"""
+function besselh end
+
 function besselh(nu::Float64, k::Integer, z::Complex128)
     if nu < 0
         s = (k == 1) ? 1 : -1
@@ -197,6 +206,21 @@ function besselh(nu::Float64, k::Integer, z::Complex128)
     end
     return _besselh(nu,Int32(k),z,Int32(1))
 end
+
+"""
+    besselhx(nu, [k=1,] z)
+
+Compute the scaled Hankel function ``\\exp(∓iz) H_ν^{(k)}(z)``, where
+``k`` is 1 or 2, ``H_ν^{(k)}(z)`` is `besselh(nu, k, z)`, and ``∓`` is
+``-`` for ``k=1`` and ``+`` for ``k=2``.  `k` defaults to 1 if it is omitted.
+
+The reason for this function is that ``H_ν^{(k)}(z)`` is asymptotically
+proportional to ``\\exp(∓iz)/\\sqrt{z}`` for large ``|z|``, and so the
+[`besselh`](:func:`besselh`) function is susceptible to overflow or underflow
+when `z` has a large imaginary part.  The `besselhx` function cancels this
+exponential factor (analytically), so it avoids these problems.
+"""
+function besselhx end
 
 function besselhx(nu::Float64, k::Integer, z::Complex128)
     if nu < 0

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1480,11 +1480,19 @@ Mathematical Functions
 
    Scaled Bessel function of the third kind of order ``nu``\ , :math:`H^{(2)}_\nu(x) e^{x i}`\ .
 
-.. function:: besselh(nu, k, x)
+.. function:: besselh(nu, [k=1,] x)
 
    .. Docstring generated from Julia source
 
-   Bessel function of the third kind of order ``nu`` (Hankel function). ``k`` is either 1 or 2, selecting ``hankelh1`` or ``hankelh2``\ , respectively.
+   Bessel function of the third kind of order ``nu`` (the Hankel function). ``k`` is either 1 or 2, selecting ``hankelh1`` or ``hankelh2``\ , respectively.  ``k`` defaults to 1 if it is omitted. (See also :func:`besselhx` for an exponentially scaled variant.)
+
+.. function:: besselhx(nu, [k=1,] z)
+
+   .. Docstring generated from Julia source
+
+   Compute the scaled Hankel function :math:`\exp(∓iz) H_ν^{(k)}(z)`\ , where :math:`k` is 1 or 2, :math:`H_ν^{(k)}(z)` is ``besselh(nu, k, z)``\ , and :math:`∓` is :math:`-` for :math:`k=1` and :math:`+` for :math:`k=2`\ .  ``k`` defaults to 1 if it is omitted.
+
+   The reason for this function is that :math:`H_ν^{(k)}(z)` is asymptotically proportional to :math:`\exp(∓iz)/\sqrt{z}` for large :math:`|z|`\ , and so the :func:`besselh` function is susceptible to overflow or underflow when ``z`` has a large imaginary part.  The ``besselhx`` function cancels this exponential factor (analytically), so it avoids these problems.
 
 .. function:: besseli(nu, x)
 


### PR DESCRIPTION
Add docs for `besselhx`, whose absence was pointed out by @JeffBezanson in #17565.
