### PR TITLE
update docs for code_...

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -878,15 +878,6 @@ Get the local machine's host name.
 gethostname
 
 """
-    code_typed(f, types; optimize=true)
-
-Returns an array of lowered and type-inferred ASTs for the methods matching the given
-generic function and type signature. The keyword argument `optimize` controls whether
-additional optimizations, such as inlining, are also applied.
-"""
-code_typed
-
-"""
     hankelh1x(nu, x)
 
 Scaled Bessel function of the third kind of order `nu`, ``H^{(1)}_\\nu(x) e^{-x i}``.
@@ -4938,13 +4929,6 @@ Send a printed form of `x` to the operating system clipboard ("copy").
 clipboard(x)
 
 """
-    code_lowered(f, types)
-
-Returns an array of lowered ASTs for the methods matching the given generic function and type signature.
-"""
-code_lowered
-
-"""
     values(collection)
 
 Return an iterator over all values in a collection. `collect(values(d))` returns an array of values.
@@ -5188,16 +5172,6 @@ Determine whether a stream is read-only.
 isreadonly
 
 """
-    code_llvm(f, types)
-
-Prints the LLVM bitcodes generated for running the method matching the given generic
-function and type signature to [`STDOUT`](:const:`STDOUT`).
-
-All metadata and dbg.* calls are removed from the printed bitcode. Use code_llvm_raw for the full IR.
-"""
-code_llvm
-
-"""
     notify(condition, val=nothing; all=true, error=false)
 
 Wake up tasks waiting for a condition, passing them `val`. If `all` is `true` (the default),
@@ -5353,18 +5327,6 @@ The largest power of two not greater than `n`. Returns 0 for `n==0`, and returns
 `-prevpow2(-n)` for negative arguments.
 """
 prevpow2
-
-"""
-    code_warntype(f, types)
-
-Displays lowered and type-inferred ASTs for the methods matching the given generic function
-and type signature. The ASTs are annotated in such a way as to cause "non-leaf" types to be
-emphasized (if color is available, displayed in red). This serves as a warning of potential
-type instability. Not all non-leaf types are particularly problematic for performance, so
-the results need to be used judiciously. See [Manual](:ref:`man-code-warntype`) for more
-information.
-"""
-code_warntype
 
 """
     Mmap.sync!(array)
@@ -5564,14 +5526,6 @@ total bytes allocated, garbage collection time, and an object with various memor
 counters.
 """
 :@timed
-
-"""
-    code_native(f, types)
-
-Prints the native assembly instructions generated for running the method matching the given
-generic function and type signature to `STDOUT`.
-"""
-code_native
 
 """
     symdiff(s1,s2...)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -257,7 +257,7 @@ and type signature to `io` which defaults to `STDOUT`. The ASTs are annotated in
 as to cause "non-leaf" types to be emphasized (if color is available, displayed in red).
 This serves as a warning of potential type instability. Not all non-leaf types are particularly
 problematic for performance, so the results need to be used judiciously.
-See [Manual](:ref:`man-code-warntype`) for more code information.
+See [Manual](:ref:`man-code-warntype`) for more information.
 """
 function code_warntype(io::IO, f, t::ANY)
     emph_io = IOContext(io, :TYPEEMPHASIZE => true)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -248,6 +248,17 @@ versioninfo(verbose::Bool) = versioninfo(STDOUT,verbose)
 
 # displaying type-ambiguity warnings
 
+
+"""
+    code_warntype([io], f, types)
+
+Prints lowered and type-inferred ASTs for the methods matching the given generic function
+and type signature to `io` which defaults to `STDOUT`. The ASTs are annotated in such a way
+as to cause "non-leaf" types to be emphasized (if color is available, displayed in red).
+This serves as a warning of potential type instability. Not all non-leaf types are particularly
+problematic for performance, so the results need to be used judiciously.
+See [Manual](:ref:`man-code-warntype`) for more codeinformation.
+"""
 function code_warntype(io::IO, f, t::ANY)
     emph_io = IOContext(io, :TYPEEMPHASIZE => true)
     for li in code_typed(f, t)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -257,7 +257,7 @@ and type signature to `io` which defaults to `STDOUT`. The ASTs are annotated in
 as to cause "non-leaf" types to be emphasized (if color is available, displayed in red).
 This serves as a warning of potential type instability. Not all non-leaf types are particularly
 problematic for performance, so the results need to be used judiciously.
-See [Manual](:ref:`man-code-warntype`) for more codeinformation.
+See [Manual](:ref:`man-code-warntype`) for more code information.
 """
 function code_warntype(io::IO, f, t::ANY)
     emph_io = IOContext(io, :TYPEEMPHASIZE => true)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -369,7 +369,7 @@ code_llvm_raw(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types, false)
     code_native([io], f, types)
 
 Prints the native assembly instructions generated for running the method matching the given
-generic function to `io` which defaults to `STDOUT`.
+generic function and type signature to `io` which defaults to `STDOUT`.
 """
 code_native(io::IO, f::ANY, types::ANY=Tuple) =
     print(io, _dump_function(f, types, true, false, false, false))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -194,6 +194,11 @@ end
 
 tt_cons(t::ANY, tup::ANY) = (@_pure_meta; Tuple{t, (isa(tup, Type) ? tup.parameters : tup)...})
 
+"""
+    code_lowered(f, types)
+
+Returns an array of lowered ASTs for the methods matching the given generic function and type signature.
+"""
 code_lowered(f, t::ANY=Tuple) = map(m -> (m::Method).lambda_template, methods(f, t))
 
 # low-level method lookup functions used by the compiler
@@ -347,11 +352,25 @@ function _dump_function(f, t::ANY, native, wrapper, strip_ir_metadata, dump_modu
     return str
 end
 
+"""
+    code_llvm([io], f, types)
+
+Prints the LLVM bitcodes generated for running the method matching the given generic
+function and type signature to `io` which defaults to `STDOUT`.
+
+All metadata and dbg.* calls are removed from the printed bitcode. Use code_llvm_raw for the full IR.
+"""
 code_llvm(io::IO, f::ANY, types::ANY=Tuple, strip_ir_metadata=true, dump_module=false) =
     print(io, _dump_function(f, types, false, false, strip_ir_metadata, dump_module))
 code_llvm(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types)
 code_llvm_raw(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types, false)
 
+"""
+    code_native([io], f, types)
+
+Prints the native assembly instructions generated for running the method matching the given
+generic function to `io` which defaults to `STDOUT`.
+"""
 code_native(io::IO, f::ANY, types::ANY=Tuple) =
     print(io, _dump_function(f, types, true, false, false, false))
 code_native(f::ANY, types::ANY=Tuple) = code_native(STDOUT, f, types)
@@ -365,6 +384,14 @@ function func_for_method_checked(m::Method, types)
     return m
 end
 
+
+"""
+    code_typed(f, types; optimize=true)
+
+Returns an array of lowered and type-inferred ASTs for the methods matching the given
+generic function and type signature. The keyword argument `optimize` controls whether
+additional optimizations, such as inlining, are also applied.
+"""
 function code_typed(f::ANY, types::ANY=Tuple; optimize=true)
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     types = to_tuple_type(types)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1395,7 +1395,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Prints lowered and type-inferred ASTs for the methods matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ . The ASTs are annotated in such a way as to cause "non-leaf" types to be emphasized (if color is available, displayed in red). This serves as a warning of potential type instability. Not all non-leaf types are particularly problematic for performance, so the results need to be used judiciously. See :ref:`man-code-warntype` for more codeinformation.
+   Prints lowered and type-inferred ASTs for the methods matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ . The ASTs are annotated in such a way as to cause "non-leaf" types to be emphasized (if color is available, displayed in red). This serves as a warning of potential type instability. Not all non-leaf types are particularly problematic for performance, so the results need to be used judiciously. See :ref:`man-code-warntype` for more code information.
 
 .. function:: @code_warntype
 
@@ -1421,7 +1421,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Prints the native assembly instructions generated for running the method matching the given generic function to ``io`` which defaults to ``STDOUT``\ .
+   Prints the native assembly instructions generated for running the method matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ .
 
 .. function:: @code_native
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1395,7 +1395,7 @@ Internals
 
    .. Docstring generated from Julia source
 
-   Prints lowered and type-inferred ASTs for the methods matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ . The ASTs are annotated in such a way as to cause "non-leaf" types to be emphasized (if color is available, displayed in red). This serves as a warning of potential type instability. Not all non-leaf types are particularly problematic for performance, so the results need to be used judiciously. See :ref:`man-code-warntype` for more code information.
+   Prints lowered and type-inferred ASTs for the methods matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ . The ASTs are annotated in such a way as to cause "non-leaf" types to be emphasized (if color is available, displayed in red). This serves as a warning of potential type instability. Not all non-leaf types are particularly problematic for performance, so the results need to be used judiciously. See :ref:`man-code-warntype` for more information.
 
 .. function:: @code_warntype
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1391,11 +1391,11 @@ Internals
 
    Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_typed` on the resulting expression.
 
-.. function:: code_warntype(f, types)
+.. function:: code_warntype([io], f, types)
 
    .. Docstring generated from Julia source
 
-   Displays lowered and type-inferred ASTs for the methods matching the given generic function and type signature. The ASTs are annotated in such a way as to cause "non-leaf" types to be emphasized (if color is available, displayed in red). This serves as a warning of potential type instability. Not all non-leaf types are particularly problematic for performance, so the results need to be used judiciously. See :ref:`man-code-warntype` for more information.
+   Prints lowered and type-inferred ASTs for the methods matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ . The ASTs are annotated in such a way as to cause "non-leaf" types to be emphasized (if color is available, displayed in red). This serves as a warning of potential type instability. Not all non-leaf types are particularly problematic for performance, so the results need to be used judiciously. See :ref:`man-code-warntype` for more codeinformation.
 
 .. function:: @code_warntype
 
@@ -1403,11 +1403,11 @@ Internals
 
    Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_warntype` on the resulting expression.
 
-.. function:: code_llvm(f, types)
+.. function:: code_llvm([io], f, types)
 
    .. Docstring generated from Julia source
 
-   Prints the LLVM bitcodes generated for running the method matching the given generic function and type signature to :const:`STDOUT`\ .
+   Prints the LLVM bitcodes generated for running the method matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ .
 
    All metadata and dbg.* calls are removed from the printed bitcode. Use code_llvm_raw for the full IR.
 
@@ -1417,11 +1417,11 @@ Internals
 
    Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_llvm` on the resulting expression.
 
-.. function:: code_native(f, types)
+.. function:: code_native([io], f, types)
 
    .. Docstring generated from Julia source
 
-   Prints the native assembly instructions generated for running the method matching the given generic function and type signature to ``STDOUT``\ .
+   Prints the native assembly instructions generated for running the method matching the given generic function to ``io`` which defaults to ``STDOUT``\ .
 
 .. function:: @code_native
 


### PR DESCRIPTION
Moves the `code_` doc strings inline and add documentation to the optional first `io` argument when applicable.
