### PR TITLE
try harder not to leave passwords in memory

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -331,38 +331,69 @@ function transcode(::Type{UInt16}, src::Vector{UInt8})
 end
 
 function transcode(::Type{UInt8}, src::Vector{UInt16})
-    dst = UInt8[]
-    i, n = 1, length(src)
-    n > 0 || return dst
-    sizehint!(dst, n)
+    n = length(src)
+    n == 0 && return UInt8[]
+
+    # Precompute m = sizeof(dst).   This involves annoying duplication
+    # of the loop over the src array.   However, this is not just an
+    # optimization: it is problematic for security reasons to grow
+    # dst dynamically, because Base.winprompt uses this function to
+    # convert passwords to UTF-8 and we don't want to make unintentional
+    # copies of the password data.
     a = src[1]
+    i, m = 1, 0
     while true
-        if a < 0x80 # ASCII
-            push!(dst, a % UInt8)
+        if a < 0x80
+            m += 1
         elseif a < 0x800 # 2-byte UTF-8
-            push!(dst, 0xc0 | ((a >> 6) % UInt8),
-                       0x80 | ((a % UInt8) & 0x3f))
-        elseif a & 0xfc00 == 0xd800 && i < n
+            m += 2
+        elseif a & 0xfc00 == 0xd800 && i < length(src)
             b = src[i += 1]
-            if (b & 0xfc00) == 0xdc00
-                # 2-unit UTF-16 sequence => 4-byte UTF-8
-                a += 0x2840
-                push!(dst, 0xf0 | ((a >> 8) % UInt8),
-                           0x80 | ((a % UInt8) >> 2),
-                           0xf0 $ ((((a % UInt8) << 4) & 0x3f) $ (b >> 6) % UInt8),
-                           0x80 | ((b % UInt8) & 0x3f))
+            if (b & 0xfc00) == 0xdc00 # 2-unit UTF-16 sequence => 4-byte UTF-8
+                m += 4
             else
-                push!(dst, 0xe0 | ((a >> 12) % UInt8),
-                           0x80 | (((a >> 6) % UInt8) & 0x3f),
-                           0x80 | ((a % UInt8) & 0x3f))
+                m += 3
                 a = b; continue
             end
         else
             # 1-unit high UTF-16 or unpaired high surrogate
             # either way, encode as 3-byte UTF-8 code point
-            push!(dst, 0xe0 | ((a >> 12) % UInt8),
-                       0x80 | (((a >> 6) % UInt8) & 0x3f),
-                       0x80 | ((a % UInt8) & 0x3f))
+            m += 3
+        end
+        i < n || break
+        a = src[i += 1]
+    end
+
+    dst = Array(UInt8, m)
+    a = src[1]
+    i, j = 1, 0
+    while true
+        if a < 0x80 # ASCII
+            dst[j += 1] = a % UInt8
+        elseif a < 0x800 # 2-byte UTF-8
+            dst[j += 1] = 0xc0 | ((a >> 6) % UInt8)
+            dst[j += 1] = 0x80 | ((a % UInt8) & 0x3f)
+        elseif a & 0xfc00 == 0xd800 && i < n
+            b = src[i += 1]
+            if (b & 0xfc00) == 0xdc00
+                # 2-unit UTF-16 sequence => 4-byte UTF-8
+                a += 0x2840
+                dst[j += 1] = 0xf0 | ((a >> 8) % UInt8)
+                dst[j += 1] = 0x80 | ((a % UInt8) >> 2)
+                dst[j += 1] = 0xf0 $ ((((a % UInt8) << 4) & 0x3f) $ (b >> 6) % UInt8)
+                dst[j += 1] = 0x80 | ((b % UInt8) & 0x3f)
+            else
+                dst[j += 1] = 0xe0 | ((a >> 12) % UInt8)
+                dst[j += 1] = 0x80 | (((a >> 6) % UInt8) & 0x3f)
+                dst[j += 1] = 0x80 | ((a % UInt8) & 0x3f)
+                a = b; continue
+            end
+        else
+            # 1-unit high UTF-16 or unpaired high surrogate
+            # either way, encode as 3-byte UTF-8 code point
+            dst[j += 1] = 0xe0 | ((a >> 12) % UInt8)
+            dst[j += 1] = 0x80 | (((a >> 6) % UInt8) & 0x3f)
+            dst[j += 1] = 0x80 | ((a % UInt8) & 0x3f)
         end
         i < n || break
         a = src[i += 1]

--- a/base/c.jl
+++ b/base/c.jl
@@ -364,7 +364,7 @@ function transcode(::Type{UInt8}, src::Vector{UInt16})
         a = src[i += 1]
     end
 
-    dst = Array(UInt8, m)
+    dst = Array{UInt8}(m)
     a = src[1]
     i, j = 1, 0
     while true

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -775,3 +775,9 @@ function checkused!(p::CachedCredentials)
 end
 "Resets authentication failure protection count"
 reset!(p::CachedCredentials, cnt::Int=3) = (p.count = cnt)
+function Base.securezero!(p::CachedCredentials)
+    for cred in values(p.cred)
+        securezero!(cred.pass)
+        securezero!(cred.prvkey)
+    end
+end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -705,6 +705,8 @@ function getobjecttype(obj_type::Cint)
     end
 end
 
+import Base.securezero!
+
 "Credentials that support only `user` and `password` parameters"
 type UserPasswordCredentials <: AbstractCredentials
     user::AbstractString
@@ -721,6 +723,13 @@ function checkused!(p::UserPasswordCredentials)
 end
 "Resets authentication failure protection count"
 reset!(p::UserPasswordCredentials, cnt::Int=3) = (p.count = cnt)
+function securezero!(cred::UserPasswordCredentials)
+    securezero!(cred.user)
+    securezero!(cred.pass)
+    securezero!(cred.usesshagent)
+    cred.count = 0
+    return cred
+end
 
 "SSH credentials type"
 type SSHCredentials <: AbstractCredentials
@@ -733,13 +742,13 @@ type SSHCredentials <: AbstractCredentials
     SSHCredentials(u::AbstractString,p::AbstractString) = new(u,p,"","","Y")
     SSHCredentials() = SSHCredentials("","")
 end
-function Base.securezero!(cred::SSHCredentials)
+function securezero!(cred::SSHCredentials)
     securezero!(cred.user)
     securezero!(cred.pass)
     securezero!(cred.pubkey)
     securezero!(cred.prvkey)
     securezero!(cred.usesshagent)
-    cred
+    return cred
 end
 
 "Credentials that support caching"
@@ -783,7 +792,7 @@ function checkused!(p::CachedCredentials)
 end
 "Resets authentication failure protection count"
 reset!(p::CachedCredentials, cnt::Int=3) = (p.count = cnt)
-function Base.securezero!(p::CachedCredentials)
-    foreach(Base.securezero!, values(p.cred))
-    p
+function securezero!(p::CachedCredentials)
+    foreach(securezero!, values(p.cred))
+    return p
 end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -583,8 +583,8 @@ end
 StatusEntry() = StatusEntry(Cuint(0), C_NULL, C_NULL)
 
 immutable FetchHead
-    name::AbstractString
-    url::AbstractString
+    name::String
+    url::String
     oid::Oid
     ismerge::Bool
 end
@@ -645,8 +645,8 @@ end
 
 # Structure has the same layout as SignatureStruct
 type Signature
-    name::AbstractString
-    email::AbstractString
+    name::String
+    email::String
     time::Int64
     time_offset::Cint
 end
@@ -709,9 +709,9 @@ import Base.securezero!
 
 "Credentials that support only `user` and `password` parameters"
 type UserPasswordCredentials <: AbstractCredentials
-    user::AbstractString
-    pass::AbstractString
-    usesshagent::AbstractString  # used for ssh-agent authentication
+    user::String
+    pass::String
+    usesshagent::String  # used for ssh-agent authentication
     count::Int                   # authentication failure protection count
     function UserPasswordCredentials(u::AbstractString,p::AbstractString)
         c = new(u,p,"Y",3)
@@ -737,11 +737,11 @@ end
 
 "SSH credentials type"
 type SSHCredentials <: AbstractCredentials
-    user::AbstractString
-    pass::AbstractString
-    pubkey::AbstractString
-    prvkey::AbstractString
-    usesshagent::AbstractString  # used for ssh-agent authentication
+    user::String
+    pass::String
+    pubkey::String
+    prvkey::String
+    usesshagent::String  # used for ssh-agent authentication
 
     function SSHCredentials(u::AbstractString,p::AbstractString)
         c = new(u,p,"","","Y")
@@ -761,9 +761,9 @@ end
 
 "Credentials that support caching"
 type CachedCredentials <: AbstractCredentials
-    cred::Dict{AbstractString,SSHCredentials}
+    cred::Dict{String,SSHCredentials}
     count::Int            # authentication failure protection count
-    CachedCredentials() = new(Dict{AbstractString,SSHCredentials}(),3)
+    CachedCredentials() = new(Dict{String,SSHCredentials}(),3)
 end
 "Returns specific credential parameter value: first index is a credential
 parameter name, second index is a host name (with schema)"

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -713,7 +713,11 @@ type UserPasswordCredentials <: AbstractCredentials
     pass::AbstractString
     usesshagent::AbstractString  # used for ssh-agent authentication
     count::Int                   # authentication failure protection count
-    UserPasswordCredentials(u::AbstractString,p::AbstractString) = new(u,p,"Y",3)
+    function UserPasswordCredentials(u::AbstractString,p::AbstractString)
+        c = new(u,p,"Y",3)
+        finalizer(c, securezero!)
+        return c
+    end
 end
 "Checks if credentials were used or failed authentication, see `LibGit2.credentials_callback`"
 function checkused!(p::UserPasswordCredentials)
@@ -739,7 +743,11 @@ type SSHCredentials <: AbstractCredentials
     prvkey::AbstractString
     usesshagent::AbstractString  # used for ssh-agent authentication
 
-    SSHCredentials(u::AbstractString,p::AbstractString) = new(u,p,"","","Y")
+    function SSHCredentials(u::AbstractString,p::AbstractString)
+        c = new(u,p,"","","Y")
+        finalizer(c, securezero!)
+        return c
+    end
     SSHCredentials() = SSHCredentials("","")
 end
 function securezero!(cred::SSHCredentials)

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -733,6 +733,14 @@ type SSHCredentials <: AbstractCredentials
     SSHCredentials(u::AbstractString,p::AbstractString) = new(u,p,"","","Y")
     SSHCredentials() = SSHCredentials("","")
 end
+function Base.securezero!(cred::SSHCredentials)
+    securezero!(cred.user)
+    securezero!(cred.pass)
+    securezero!(cred.pubkey)
+    securezero!(cred.prvkey)
+    securezero!(cred.usesshagent)
+    cred
+end
 
 "Credentials that support caching"
 type CachedCredentials <: AbstractCredentials
@@ -776,8 +784,6 @@ end
 "Resets authentication failure protection count"
 reset!(p::CachedCredentials, cnt::Int=3) = (p.count = cnt)
 function Base.securezero!(p::CachedCredentials)
-    for cred in values(p.cred)
-        securezero!(cred.pass)
-        securezero!(cred.prvkey)
-    end
+    foreach(Base.securezero!, values(p.cred))
+    p
 end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -406,9 +406,9 @@ function update(branch::AbstractString, upkgs::Set{String})
             push!(deferred_errors, PkgError("Package $pkg: unable to update cache.", cex))
         end
     end
+    fixed = Read.fixed(avail,instd,dont_update)
     creds = LibGit2.CachedCredentials()
     try
-        fixed = Read.fixed(avail,instd,dont_update)
         stopupdate = false
         for (pkg,ver) in fixed
             ispath(pkg,".git") || continue

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -452,7 +452,7 @@ function update(branch::AbstractString, upkgs::Set{String})
             end
         end
     finally
-        securezero!(creds)
+        Base.securezero!(creds)
     end
     info("Computing changes...")
     resolve(reqs, avail, instd, fixed, free, upkgs)

--- a/base/util.jl
+++ b/base/util.jl
@@ -436,8 +436,7 @@ if is_windows()
         unsafe_securezero!(outbuf_data[], outbuf_size[])
         ccall((:CoTaskMemFree, "ole32.dll"), Void, (Ptr{Void},), outbuf_data[])
 
-        # Done.  Fixme: for non-ascii passwords, transcode may leave
-        # an extra copy of the password in memory (due to resizing its buffer).
+        # Done.
         passbuf_ = passbuf[1:passlen[]-1]
         result = Nullable((String(transcode(UInt8, usernamebuf[1:usernamelen[]-1])),
             String(transcode(UInt8, passbuf_))))

--- a/base/util.jl
+++ b/base/util.jl
@@ -326,7 +326,7 @@ function securezero! end
 securezero!(s::String) = securezero!(s.data)
 @noinline unsafe_securezero!{T}(p::Ptr{T}, len::Integer=1) =
     ccall(:memset, Ptr{T}, (Ptr{T}, Cint, Csize_t), p, 0, len*sizeof(T))
-unsafe_securezero!(p::Ptr{Void}, len=1) = securezero!(Ptr{UInt8}(p), len)
+unsafe_securezero!(p::Ptr{Void}, len=1) = Ptr{Void}(securezero!(Ptr{UInt8}(p), len))
 
 if is_windows()
 function getpass(prompt::AbstractString)

--- a/base/util.jl
+++ b/base/util.jl
@@ -326,7 +326,7 @@ function securezero! end
 securezero!(s::String) = securezero!(s.data)
 @noinline unsafe_securezero!{T}(p::Ptr{T}, len::Integer=1) =
     ccall(:memset, Ptr{T}, (Ptr{T}, Cint, Csize_t), p, 0, len*sizeof(T))
-unsafe_securezero!(p::Ptr{Void}, len=1) = Ptr{Void}(securezero!(Ptr{UInt8}(p), len))
+unsafe_securezero!(p::Ptr{Void}, len::Integer=1) = Ptr{Void}(unsafe_securezero!(Ptr{UInt8}(p), len))
 
 if is_windows()
 function getpass(prompt::AbstractString)

--- a/base/util.jl
+++ b/base/util.jl
@@ -321,12 +321,12 @@ Unlike `fill!(o,0)` and similar code, which might be optimized away by
 the compiler for objects about to be discarded, the `securezero!` function
 will always be called.
 """
-function securezero end
+function securezero! end
 @noinline securezero!{T<:Number}(a::AbstractArray{T}) = fill!(a, 0)
 securezero!(s::String) = securezero!(s.data)
-@noinline securezero!{T}(p::Ptr{T}, len::Integer=1) =
+@noinline unsafe_securezero!{T}(p::Ptr{T}, len::Integer=1) =
     ccall(:memset, Ptr{T}, (Ptr{T}, Cint, Csize_t), p, 0, len*sizeof(T))
-securezero!(p::Ptr{Void}, len=1) = securezero!(Ptr{UInt8}(p), len)
+unsafe_securezero!(p::Ptr{Void}, len=1) = securezero!(Ptr{UInt8}(p), len)
 
 if is_windows()
 function getpass(prompt::AbstractString)
@@ -433,7 +433,7 @@ if is_windows()
 
         # Step 4: Free the encrypted buffer
         # ccall(:SecureZeroMemory, Ptr{Void}, (Ptr{Void}, Csize_t), outbuf_data[], outbuf_size[]) - not an actual function
-        securezero!(outbuf_data[], outbuf_size[])
+        unsafe_securezero!(outbuf_data[], outbuf_size[])
         ccall((:CoTaskMemFree, "ole32.dll"), Void, (Ptr{Void},), outbuf_data[])
 
         # Done.  Fixme: for non-ascii passwords, transcode may leave

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -393,3 +393,20 @@ end
 optstring = sprint(show, Base.JLOptions())
 @test startswith(optstring, "JLOptions(")
 @test endswith(optstring, ")")
+
+# Base.securezero! functions (#17579)
+import Base: securezero!, unsafe_securezero!
+let a = [1,2,3]
+    @test securezero!(a) === a == [0,0,0]
+    a[:] = 1:3
+    @test unsafe_securezero!(pointer(a), length(a)) == pointer(a)
+    @test a == [0,0,0]
+    a[:] = 1:3
+    @test unsafe_securezero!(Ptr{Void}(pointer(a)), sizeof(a)) == Ptr{Void}(pointer(a))
+    @test a == [0,0,0]
+end
+let creds = Base.LibGit2.CachedCredentials()
+    creds[:pass, "foo"] = "bar"
+    securezero!(creds)
+    @test creds[:pass, "foo"] == "\0\0\0"
+end


### PR DESCRIPTION
For #17560, this PR tries harder to avoid leaving passwords in memory.
- It defines `Base.securezero!`, which is much like `fill!(a, 0)` except that it uses `@noinline` to prevent it from being inlined.  This should prevent LLVM from optimizing it away (since LLVM doesn't know whether the function call is pure).
- It modifies `getpass` and `Base.winprompt` to call `securezero!` on buffers containing passwords.
- It modifies `Pkg.update` to call `securezero!` on cached credentials after updating, and the credentials are zero-ed at various other places in LibGit2.  (At worst, they are zero-ed by the credentials finalizers.)

~~~It doesn't completely resolve #17560, because for non-ASCII passwords the `transcode` function may leave additional copies in memory as a side effect of resizing its buffer, but it hopefully takes us most of the way there.~~~ Fixes #17560.  I changed the `transcode` function to precompute the size of the output buffer rather than dynamically resizing via `push!`.
