### PR TITLE
fix llvm patch repeat application issue

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -407,7 +407,7 @@ endif # LLVM_VER
 LLVM_PATCH_PREV:=
 LLVM_PATCH_LIST:=
 define LLVM_PATCH
-$$(LLVM_SRC_DIR)/$1.patch-applied: $$(LLVM_SRC_DIR)/configure | $$(SRCDIR)/patches/$1.patch $$(LLVM_PATCH_PREV)
+$$(LLVM_SRC_DIR)/$1.patch-applied: | $$(LLVM_SRC_DIR)/CMakeLists.txt $$(SRCDIR)/patches/$1.patch $$(LLVM_PATCH_PREV)
 	cd $$(LLVM_SRC_DIR) && patch -p1 < $$(SRCDIR)/patches/$1.patch
 	echo 1 > $$@
 LLVM_PATCH_PREV := $$(LLVM_SRC_DIR)/$1.patch-applied


### PR DESCRIPTION
dependency on configure should be order-only (after the `|`)
since a patch modifies the file. also use CMakeLists.txt since
llvm's configure will be going away

cc @ViralBShah
