### PR TITLE
Remove sizeclass 12 on ARM and PPC32.

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -19,7 +19,7 @@
 #include <setjmp.h>
 #ifndef _OS_WINDOWS_
 #  define jl_jmp_buf sigjmp_buf
-#  if defined(_CPU_ARM_)
+#  if defined(_CPU_ARM_) || defined(_CPU_PPC_)
 #    define MAX_ALIGN 8
 #  elif defined(_CPU_AARCH64_)
 // int128 is 16 bytes aligned on aarch64

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -54,6 +54,10 @@ void *jl_gc_perm_alloc(size_t sz);
 static const int jl_gc_sizeclasses[JL_GC_N_POOLS] = {
 #ifdef _P64
     8,
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+    // ARM and PowerPC has max alignment of 8,
+    // make sure allocation of size 8 has that alignment.
+    4, 8,
 #else
     4, 8, 12,
 #endif
@@ -87,6 +91,10 @@ STATIC_INLINE int JL_CONST_FUNC jl_gc_szclass(size_t sz)
     if (sz <=    8)
         return 0;
     const int N = 0;
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+    if (sz <=    8)
+        return (sz + 3) / 4 - 1;
+    const int N = 1;
 #else
     if (sz <=   12)
         return (sz + 3) / 4 - 1;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -55,9 +55,11 @@ typedef struct {
 
     // variables for allocating objects from pools
 #ifdef _P64
-#define JL_GC_N_POOLS 41
+#  define JL_GC_N_POOLS 41
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+#  define JL_GC_N_POOLS 42
 #else
-#define JL_GC_N_POOLS 43
+#  define JL_GC_N_POOLS 43
 #endif
     jl_gc_pool_t norm_pools[JL_GC_N_POOLS];
 } jl_thread_heap_t;


### PR DESCRIPTION
We don't take alignment into account while doing allocation.
This makes sure that allocation of size 8 uses the 16 size class instead of the 12 size class and is properly aligned on these architectures.

Another possible fix is of course to take alignment into account when doing allocation but that will be a much more involved change.
