### PR TITLE
RFC: remove repl prompt prefix before parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,10 @@
 Julia v0.6.0 Release Notes
 ==========================
 
-New language features
----------------------
-
 Language changes
 ----------------
+
+* The REPL now supports something called *prompt pasting*. This activates when pasting a string which starts with `julia >` into the REPL. In that case, only expressions starting with `julia> ` are parsed, the rest are removed. This means that it is possible to paste a chunk of code that have been copied from a REPL session without having to scrub away prompts and outputs.
 
 Breaking changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,12 @@ Julia v0.6.0 Release Notes
 New language features
 ---------------------
 
-* The REPL now supports something called *prompt pasting*. This activates when pasting text that starts with `julia> ` into the REPL. In that case, only expressions starting with `julia> ` are parsed, the rest are removed. This makes it is possible to paste a chunk of code that have been copied from a REPL session without having to scrub away prompts and outputs. This can be disabled or enabled at will with `Base.REPL.enable_promptpaste(::Bool)`.
+  * The REPL now supports something called *prompt pasting*.
+    This activates when pasting text that starts with `julia> ` into the REPL.
+    In that case, only expressions starting with `julia> ` are parsed, the rest are removed.
+    This makes it possible to paste a chunk of code that has been copied from a REPL session
+    without having to scrub away prompts and outputs.
+    This can be disabled or enabled at will with `Base.REPL.enable_promptpaste(::Bool)`.
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
 Julia v0.6.0 Release Notes
 ==========================
 
+New language features
+---------------------
+
+* The REPL now supports something called *prompt pasting*. This activates when pasting text that starts with `julia> ` into the REPL. In that case, only expressions starting with `julia> ` are parsed, the rest are removed. This makes it is possible to paste a chunk of code that have been copied from a REPL session without having to scrub away prompts and outputs. This can be disabled or enabled at will with `Base.REPL.enable_promptpaste(::Bool)`.
+
 Language changes
 ----------------
-
-* The REPL now supports something called *prompt pasting*. This activates when pasting a string which starts with `julia >` into the REPL. In that case, only expressions starting with `julia> ` are parsed, the rest are removed. This means that it is possible to paste a chunk of code that have been copied from a REPL session without having to scrub away prompts and outputs.
 
 Breaking changes
 ----------------

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1302,9 +1302,14 @@ Must satisfy `0 < tabwidth <= 16`.
 """
 global tabwidth = 8
 
+const STANDARD_REPL_PROMPTS = ["julia> ", "help?> ", "shell> "]
+
 function bracketed_paste(s)
     ps = state(s, mode(s))
     input = readuntil(ps.terminal, "\e[201~")[1:(end-6)]
+    if ps.p.prompt in STANDARD_REPL_PROMPTS && startswith(input, ps.p.prompt)
+        input = input[sizeof(ps.p.prompt)+1:end]
+    end
     input = replace(input, '\r', '\n')
     if position(buffer(s)) == 0
         indent = Base.indentation(input; tabwidth=tabwidth)[1]

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1302,14 +1302,9 @@ Must satisfy `0 < tabwidth <= 16`.
 """
 global tabwidth = 8
 
-const STANDARD_REPL_PROMPTS = ["julia> ", "help?> ", "shell> "]
-
 function bracketed_paste(s)
     ps = state(s, mode(s))
     input = readuntil(ps.terminal, "\e[201~")[1:(end-6)]
-    if ps.p.prompt in STANDARD_REPL_PROMPTS && startswith(input, ps.p.prompt)
-        input = input[sizeof(ps.p.prompt)+1:end]
-    end
     input = replace(input, '\r', '\n')
     if position(buffer(s)) == 0
         indent = Base.indentation(input; tabwidth=tabwidth)[1]

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -36,7 +36,7 @@ abstract AbstractREPL
 
 answer_color(::AbstractREPL) = ""
 
-const JULIA_PROMT = "julia> "
+const JULIA_PROMPT = "julia> "
 
 type REPLBackend
     "channel for AST"
@@ -209,7 +209,7 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
     hit_eof = false
     while true
         Base.reseteof(repl.terminal)
-        write(repl.terminal, JULIA_PROMT)
+        write(repl.terminal, JULIA_PROMPT)
         line = ""
         ast = nothing
         interrupted = false
@@ -728,7 +728,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
     replc = REPLCompletionProvider(repl)
 
     # Set up the main Julia prompt
-    julia_prompt = Prompt(JULIA_PROMT;
+    julia_prompt = Prompt(JULIA_PROMPT;
         # Copy colors from the prompt object
         prompt_prefix = hascolor ? repl.prompt_color : "",
         prompt_suffix = hascolor ?
@@ -853,7 +853,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
                     end
                     # Check if input line starts with "julia> ", remove it if we are in prompt paste mode
                     jl_prompt_len = 7
-                     if (firstline || isprompt_paste) && (oldpos + jl_prompt_len <= sizeof(input) && input[oldpos:oldpos+jl_prompt_len-1] == JULIA_PROMT)
+                     if (firstline || isprompt_paste) && (oldpos + jl_prompt_len <= sizeof(input) && input[oldpos:oldpos+jl_prompt_len-1] == JULIA_PROMPT)
                         isprompt_paste = true
                         oldpos += jl_prompt_len
                     # If we are prompt pasting and current statement does not begin with julia> , skip to next line

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -844,11 +844,11 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
                 while c <= sizeof(input) && (input[c] == '\n' || input[c] == ' ' || input[c] == '\t')
                     c = nextind(input, c)
                 end
-                n_newlines = c - oldpos
+                n_whitespace_chars = c - oldpos
                 # Skip over prompt prefix if statement starts with it
                 jl_prompt_len = 7
                 if c + jl_prompt_len <= sizeof(input) && input[c:c+jl_prompt_len-1] == "julia> "
-                    oldpos += jl_prompt_len + n_newlines
+                    oldpos += jl_prompt_len + n_whitespace_chars
                 end
                 ast, pos = Base.syntax_deprecation_warnings(false) do
                     Base.parse(input, oldpos, raise=false)

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -838,6 +838,18 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
             oldpos = start(input)
             firstline = true
             while !done(input, oldpos) # loop until all lines have been executed
+                # Check if the next statement starts with "julia> ", in that case
+                # skip it. But first skip whitespace
+                c = oldpos
+                while c <= sizeof(input) && (input[c] == '\n' || input[c] == ' ' || input[c] == '\t')
+                    c = nextind(input, c)
+                end
+                n_newlines = c - oldpos
+                # Skip over prompt prefix if statement starts with it
+                jl_prompt_len = 7
+                if c + jl_prompt_len <= sizeof(input) && input[c:c+jl_prompt_len-1] == "julia> "
+                    oldpos += jl_prompt_len + n_newlines
+                end
                 ast, pos = Base.syntax_deprecation_warnings(false) do
                     Base.parse(input, oldpos, raise=false)
                 end

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -42,6 +42,8 @@ There are a number useful features unique to interactive work. In addition to sh
     julia> ans
     "12"
 
+In Julian mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL. In that case, only expressions starting with ``julia> `` are parsed, others are removed. This makes it is possible to paste a chunk of code that has been copied from a REPL session without having to scrub away prompts and outputs. This feature is enabled by default but can be disabled or enabled at will with `Base.REPL.enable_promptpaste(::Bool)`. If it is enabled, you can try it out by pasting the code block above this paragraph straight into the REPL. This feature does not work on the standard Windows command prompt due to its limitation at detecting when a paste occurs.
+
 Help mode
 ~~~~~~~~~
 

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -42,7 +42,7 @@ There are a number useful features unique to interactive work. In addition to sh
     julia> ans
     "12"
 
-In Julian mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL. In that case, only expressions starting with ``julia> `` are parsed, others are removed. This makes it is possible to paste a chunk of code that has been copied from a REPL session without having to scrub away prompts and outputs. This feature is enabled by default but can be disabled or enabled at will with `Base.REPL.enable_promptpaste(::Bool)`. If it is enabled, you can try it out by pasting the code block above this paragraph straight into the REPL. This feature does not work on the standard Windows command prompt due to its limitation at detecting when a paste occurs.
+In Julian mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL. In that case, only expressions starting with ``julia> `` are parsed, others are removed. This makes it is possible to paste a chunk of code that has been copied from a REPL session without having to scrub away prompts and outputs. This feature is enabled by default but can be disabled or enabled at will with ``Base.REPL.enable_promptpaste(::Bool)``. If it is enabled, you can try it out by pasting the code block above this paragraph straight into the REPL. This feature does not work on the standard Windows command prompt due to its limitation at detecting when a paste occurs.
 
 Help mode
 ~~~~~~~~~

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -42,7 +42,12 @@ There are a number useful features unique to interactive work. In addition to sh
     julia> ans
     "12"
 
-In Julian mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL. In that case, only expressions starting with ``julia> `` are parsed, others are removed. This makes it is possible to paste a chunk of code that has been copied from a REPL session without having to scrub away prompts and outputs. This feature is enabled by default but can be disabled or enabled at will with ``Base.REPL.enable_promptpaste(::Bool)``. If it is enabled, you can try it out by pasting the code block above this paragraph straight into the REPL. This feature does not work on the standard Windows command prompt due to its limitation at detecting when a paste occurs.
+In Julian mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL.
+In that case, only expressions starting with ``julia> `` are parsed, others are removed.
+This makes it is possible to paste a chunk of code that has been copied from a REPL session without having to scrub away prompts and outputs.
+This feature is enabled by default but can be disabled or enabled at will with ``Base.REPL.enable_promptpaste(::Bool)``.
+If it is enabled, you can try it out by pasting the code block above this paragraph straight into the REPL.
+This feature does not work on the standard Windows command prompt due to its limitation at detecting when a paste occurs.
 
 Help mode
 ~~~~~~~~~

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -42,7 +42,7 @@ There are a number useful features unique to interactive work. In addition to sh
     julia> ans
     "12"
 
-In Julian mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL.
+In Julia mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL.
 In that case, only expressions starting with ``julia> `` are parsed, others are removed.
 This makes it is possible to paste a chunk of code that has been copied from a REPL session without having to scrub away prompts and outputs.
 This feature is enabled by default but can be disabled or enabled at will with ``Base.REPL.enable_promptpaste(::Bool)``.

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -450,6 +450,7 @@ begin
     wait(c)
     @test tmpdirnow == tmpdir
     cd(curr_dir)
+    rm(tmpdir)
 
     write(stdin_write, '\x04')
     wait(repltask)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -424,7 +424,7 @@ begin
     sendrepl2("""\e[200~
             julia> type T17599; a::Int; end
 
-                function foo(julia)
+            julia> function foo(julia)
             julia> 3
                 end
 
@@ -436,21 +436,21 @@ begin
     @test T17599(3).a == 3
     @test !foo(2)
 
+    sendrepl2("""\e[200~
+            julia> goo(x) = x + 1
+            error()
+
+            julia> A = 4
+            4\e[201~
+             """)
+    wait(c)
+    @test A == 4
+    @test goo(4) == 5
+
     # Test prefix removal only active in bracket paste mode
     sendrepl2("julia = 4\n julia> 3 && (A = 1)\n")
     wait(c)
     @test A == 1
-
-    # Test shell> mode
-    mktempdir() do tmpdir
-        curr_dir = pwd()
-        write(stdin_write, ";")
-        write(stdin_write, "\e[200~shell> cd $(escape_string(tmpdir))\e[201~\n")
-        sendrepl2("tmpdirnow = pwd()")
-        wait(c)
-        @test tmpdirnow == realpath(tmpdir)
-        cd(curr_dir)
-    end
 
     # Close repl
     write(stdin_write, '\x04')


### PR DESCRIPTION
It is common to encounter example code that is posted with the REPL prefix included (typically `julia>`). This occurs in manual, doc tests and in forum posts etc. Usually one wants to quickly run this code in the REPL but then has to manually remove all the prompt prefixes first which can be a bit annoying.

This PR simply checks if the statement being evaluated in the REPL starts with the REPL prefix and in that case removes it.

As an example pasting this code block:

``` jl
julia> const x = 1;

julia> function foo(x)
           return x + 1
       end;

julia> type X
       x::Int
       end;
```

will be equivalent to pasting it without the `julia>` prefixes.

This is also implemented for the other REPL modes.

fixes https://github.com/JuliaLang/julia/issues/16383
