### PR TITLE
Use standard nomenclature for UNIX domain sockets

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1565,7 +1565,7 @@ connect(host=?, port)
 """
     connect(path) -> PipeEndpoint
 
-Connect to the Named Pipe / Domain Socket at `path`.
+Connect to the named pipe / UNIX domain socket at `path`.
 """
 connect(path)
 
@@ -7286,7 +7286,7 @@ listen(addr,port)
 """
     listen(path) -> PipeServer
 
-Create and listen on a Named Pipe / Domain Socket.
+Create and listen on a named pipe / UNIX domain socket.
 """
 listen(path)
 

--- a/doc/manual/networking-and-streams.rst
+++ b/doc/manual/networking-and-streams.rst
@@ -197,12 +197,12 @@ create various other kinds of servers::
     julia> listen(IPv6(0),2001) # Listens on port 2001 on all IPv6 interfaces
     TCPServer(active)
 
-    julia> listen("testsocket") # Listens on a domain socket/named pipe
+    julia> listen("testsocket") # Listens on a UNIX domain socket/named pipe
     PipeServer(active)
 
 Note that the return type of the last invocation is different. This is because
 this server does not listen on TCP, but rather on a named pipe (Windows)
-or domain socket (UNIX). The difference
+or UNIX domain socket (UNIX). The difference
 is subtle and has to do with the :func:`accept` and :func:`connect` methods. The :func:`accept`
 method retrieves a connection to the client that is connecting on the server we
 just created, while the :func:`connect` function connects to a server using the

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -886,7 +886,7 @@ Network I/O
 
    .. Docstring generated from Julia source
 
-   Connect to the Named Pipe / Domain Socket at ``path``\ .
+   Connect to the named pipe / UNIX domain socket at ``path``\ .
 
 .. function:: listen([addr,]port) -> TCPServer
 
@@ -898,7 +898,7 @@ Network I/O
 
    .. Docstring generated from Julia source
 
-   Create and listen on a Named Pipe / Domain Socket.
+   Create and listen on a named pipe / UNIX domain socket.
 
 .. function:: getaddrinfo(host)
 

--- a/examples/clustermanager/simple/README
+++ b/examples/clustermanager/simple/README
@@ -1,4 +1,4 @@
-This is a simple proof-of-concept that uses Unix Domain Sockets as transport.
+This is a simple proof-of-concept that uses UNIX domain sockets as transport.
 
 All commands must be run from `examples/clustermanager/simple` directory
 


### PR DESCRIPTION
UNIX modifies "domain", not "domain socket"; "UNIX domain" modifies "socket", and "domain socket" by itself is meaningless.

This matches the phrasing and capitalization from POSIX.1:

http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_10_17

---

I looked at some other recently submitted PRs, and [this comment](https://github.com/JuliaLang/julia/pull/17429#discussion_r70898083) suggested running "make docs" after a doc change, but when I did that it resulted in [some extraneous whitespace changes in `doc/stdlib/parallel.rst`](https://github.com/sorear/julia/commit/2edecf91).
