### PR TITLE
Pkg.status: always show commit sha if not on a tagged version

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -158,15 +158,14 @@ status(io::IO, pkg::AbstractString) = status(io, pkgname = pkg)
 function status(io::IO, pkg::AbstractString, ver::VersionNumber, fix::Bool)
     @printf io " - %-29s " pkg
     fix || return println(io,ver)
-    @printf io "%-19s" ver
+    @printf io "%-9s" ver
     if ispath(pkg,".git")
         prepo = GitRepo(pkg)
         try
+	    print(io, string(LibGit2.head_oid(prepo))[1:8], "  ")
             with(LibGit2.head(prepo)) do phead
                 if LibGit2.isattached(prepo)
                     print(io, LibGit2.shortname(phead))
-                else
-                    print(io, string(LibGit2.Oid(phead))[1:8])
                 end
             end
             attrs = AbstractString[]


### PR DESCRIPTION
Frequently we ask users to add the output of `Pkg.status()` to an issue to help with narrowing the problem, however we can only guess which commit they are on when they have packages checked out or otherwise on untagged versions.  This PR will always print the commit sha:

```
julia> Pkg.status()
15 required packages:
 - FactCheck                     0.4.3
 - GR                            0.13.0+  4b43f0b0  master
 - Gtk                           0.10.1
 - ImageMagick                   0.1.6+   bbdaf04d  master
 - PkgDev                        0.1.0
 - PlotRecipes                   0.0.6-   9d216776  master
 - PlotlyJS                      0.3.1+   8f7c3f4e  tb_0.5
 - Plots                         0.8.1+   e9dca92c  dev
 - ProfileView                   0.1.3
 - PyPlot                        2.2.0+   985eb4bb  master
 - RDatasets                     0.1.3
 - StatPlots                     0.0.3    e12b1d2c  master
 - UnicodePlots                  0.1.3
 - ValueHistories                0.0.3
 - VisualRegressionTests         0.0.5
72 additional packages:
 - BinDeps                       0.4.0
 - Blink                         0.3.4+   cbed6f12  master
 - Cairo                         0.2.33
 - Calculus                      0.1.15
 - Codecs                        0.1.5
 - ColorTypes                    0.2.5
 - ColorVectorSpace              0.1.5
 - Colors                        0.6.6
 - Compat                        0.8.6
 - Conda                         0.2.2
 - DataArrays                    0.3.6
 - DataFrames                    0.7.6
 - DataStructures                0.4.4
 - Distributions                 0.10.0
 - Docile                        0.5.23
 - DualNumbers                   0.2.2
 - FileIO                        0.1.0
 - FixedPointNumbers             0.1.4
 - FixedSizeArrays               0.2.2
 - Formatting                    0.1.5
 - GZip                          0.2.19
 - Glob                          1.0.2
 - Graphics                      0.1.3
 - Grid                          0.4.0
 - GtkUtilities                  0.0.9
 - Hiccup                        0.0.2
 - HttpCommon                    0.2.6
 - HttpParser                    0.1.1
 - HttpServer                    0.1.5
 - Images                        0.5.5+   f6155dd3  master
 - InspectDR                     0.0.6    1ec1c4fd  master
 - Iterators                     0.1.9
 - JSON                          0.6.0
 - KernelDensity                 0.1.2
 - LaTeXStrings                  0.1.6
 - Lazy                          0.10.1+  4f00746e  master
 - MacroTools                    0.3.0+   a1410ee3  master
 - MbedTLS                       0.2.5
 - Measures                      0.0.2
 - Mocking                       0.2.1
 - Mustache                      0.0.15
 - Mux                           0.2.0
 - NaNMath                       0.2.1
 - Nettle                        0.2.3
 - NumericIO                     0.0.4
 - Optim                         0.5.0
 - PDMats                        0.4.2
 - PlotDocs                      0.0.0-   4dae403f  master (unregistered)
 - PlotReferenceImages           0.0.0-   dc418bee  master (unregistered)
 - PlotUtils                     0.0.4    681b291a  master
 - PositiveFactorizations        0.0.1
 - PyCall                        1.6.3+   494f8316  master
 - RecipesBase                   0.0.6+   700de20b  master
 - Reexport                      0.0.3
 - Requires                      0.2.2+   5683745f  master
 - Rmath                         0.1.2
 - SHA                           0.1.2
 - SIUnits                       0.0.6
 - Showoff                       0.0.7
 - SortingAlgorithms             0.0.6
 - StatsBase                     0.9.0
 - StatsFuns                     0.3.0
 - TexExtensions                 0.0.3
 - TimeZones                     0.2.2
 - URIParser                     0.1.5
 - WebSockets                    0.1.2
 - WoodburyMatrices              0.2.0
 - Zlib                          0.1.12

julia> 
```
