### PR TITLE
Make StepRange safe for more number types

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -31,15 +31,7 @@ function steprange_last{T}(start::T, step, stop)
         last = stop
     else
         if (step > z) != (stop > start)
-            # empty range has a special representation where stop = start-1
-            # this is needed to avoid the wrap-around that can happen computing
-            # start - step, which leads to a range that looks very large instead
-            # of empty.
-            if step > z
-                last = start - one(stop-start)
-            else
-                last = start + one(stop-start)
-            end
+            last = steprange_last_empty(start, step, stop)
         else
             diff = stop - start
             if T<:Signed && (diff > zero(diff)) != (stop > start)
@@ -57,6 +49,21 @@ function steprange_last{T}(start::T, step, stop)
     end
     last
 end
+
+function steprange_last_empty{T<:Integer}(start::T, step, stop)
+    # empty range has a special representation where stop = start-1
+    # this is needed to avoid the wrap-around that can happen computing
+    # start - step, which leads to a range that looks very large instead
+    # of empty.
+    if step > zero(step)
+        last = start - one(stop-start)
+    else
+        last = start + one(stop-start)
+    end
+    last
+end
+# For types where x+one(x) may not be well-defined
+steprange_last_empty(start, step, stop) = start - step
 
 steprem(start,stop,step) = (stop-start) % step
 

--- a/test/dates/ranges.jl
+++ b/test/dates/ranges.jl
@@ -14,7 +14,7 @@ function test_all_combos()
                 @test length(dr) == 0
                 @test isempty(dr)
                 @test first(dr) == f1
-                @test last(dr) == f1-one(l1 - f1)
+                @test last(dr) < f1
                 @test length([i for i in dr]) == 0
                 @test_throws ArgumentError minimum(dr)
                 @test_throws ArgumentError maximum(dr)
@@ -23,8 +23,8 @@ function test_all_combos()
                 @test [dr;] == T[]
                 @test isempty(reverse(dr))
                 @test length(reverse(dr)) == 0
-                @test first(reverse(dr)) == f1-one(l1 - f1)
-                @test last(reverse(dr)) == f1
+                @test first(reverse(dr)) < f1
+                @test last(reverse(dr)) >= f1
                 @test issorted(dr)
                 @test sortperm(dr) == 1:1:0
                 @test !(f1 in dr)
@@ -66,7 +66,7 @@ function test_all_combos()
                 @test length(dr) == 0
                 @test isempty(dr)
                 @test first(dr) == l1
-                @test last(dr) == l1+one(l1 - f1)
+                @test last(dr) > l1
                 @test length([i for i in dr]) == 0
                 @test_throws ArgumentError minimum(dr)
                 @test_throws ArgumentError maximum(dr)
@@ -75,8 +75,8 @@ function test_all_combos()
                 @test [dr;] == T[]
                 @test isempty(reverse(dr))
                 @test length(reverse(dr)) == 0
-                @test first(reverse(dr)) == l1+one(l1 - f1)
-                @test last(reverse(dr)) == l1
+                @test first(reverse(dr)) > l1
+                @test last(reverse(dr)) <= l1
                 @test !issorted(dr)
                 @test sortperm(dr) == 0:-1:1
                 @test !(l1 in dr)
@@ -119,7 +119,7 @@ function test_all_combos()
                     @test length(dr) == 0
                     @test isempty(dr)
                     @test first(dr) == f1
-                    @test last(dr) == f1-one(l1 - f1)
+                    @test last(dr) < f1
                     @test length([i for i in dr]) == 0
                     @test_throws ArgumentError minimum(dr)
                     @test_throws ArgumentError maximum(dr)
@@ -128,8 +128,8 @@ function test_all_combos()
                     @test [dr;] == T[]
                     @test isempty(reverse(dr))
                     @test length(reverse(dr)) == 0
-                    @test first(reverse(dr)) == f1-one(l1 - f1)
-                    @test last(reverse(dr)) == f1
+                    @test first(reverse(dr)) < f1
+                    @test last(reverse(dr)) >= f1
                     @test issorted(dr)
                     @test sortperm(dr) == 1:1:0
                     @test !(f1 in dr)
@@ -171,7 +171,7 @@ function test_all_combos()
                     @test length(dr) == 0
                     @test isempty(dr)
                     @test first(dr) == l1
-                    @test last(dr) == l1+one(l1 - f1)
+                    @test last(dr) > l1
                     @test length([i for i in dr]) == 0
                     @test_throws ArgumentError minimum(dr)
                     @test_throws ArgumentError maximum(dr)
@@ -180,7 +180,7 @@ function test_all_combos()
                     @test [dr;] == T[]
                     @test isempty(reverse(dr))
                     @test length(reverse(dr)) == 0
-                    @test first(reverse(dr)) == l1+one(l1 - f1)
+                    @test first(reverse(dr)) > l1
                     @test last(reverse(dr)) <= l1
                     @test !issorted(dr)
                     @test sortperm(dr) == 0:-1:1


### PR DESCRIPTION
Currently `StepRange` is the only range type in Base that's potentially usable for objects where `x+one(x)` may not be definable. This relaxes what I suspect to be an unnecessary constraint---wraparound only seems relevant for `Integer` types.
