### PR TITLE
more compact lowering of return type decls on short functions

### DIFF
--- a/base/float16.jl
+++ b/base/float16.jl
@@ -144,21 +144,12 @@ end
 for op in (:<,:<=,:isless)
     @eval ($op)(a::Float16, b::Float16) = ($op)(Float32(a), Float32(b))
 end
-for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
-             :atanh,:exp,:log,:log2,:log10,:sqrt,:lgamma,:log1p,:erf,:erfc)
-    @eval begin
-        $func(a::Float16) = Float16($func(Float32(a)))
-        $func(a::Complex32) = Complex32($func(Complex64(a)))
-    end
-end
 
-for func in (:div,:fld,:cld,:rem,:mod,:atan2,:hypot)
+for func in (:div,:fld,:cld,:rem,:mod)
     @eval begin
         $func(a::Float16,b::Float16) = Float16($func(Float32(a),Float32(b)))
     end
 end
-
-ldexp(a::Float16, b::Integer) = Float16(ldexp(Float32(a), b))
 
 ^(x::Float16, y::Integer) = Float16(Float32(x)^y)
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -414,6 +414,24 @@ end
 # generic fallback; for number types, promotion.jl does promotion
 muladd(x,y,z) = x*y+z
 
+# Float16 definitions
+
+for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
+             :atanh,:exp,:log,:log2,:log10,:sqrt,:lgamma,:log1p,:erf,:erfc)
+    @eval begin
+        $func(a::Float16) = Float16($func(Float32(a)))
+        $func(a::Complex32) = Complex32($func(Complex64(a)))
+    end
+end
+
+for func in (:atan2,:hypot)
+    @eval begin
+        $func(a::Float16,b::Float16) = Float16($func(Float32(a),Float32(b)))
+    end
+end
+
+ldexp(a::Float16, b::Integer) = Float16(ldexp(Float32(a), b))
+
 # More special functions
 include("special/trig.jl")
 include("special/bessel.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -101,6 +101,7 @@ include("multinverses.jl")
 using .MultiplicativeInverses
 include("abstractarraymath.jl")
 include("arraymath.jl")
+include("float16.jl")
 
 # SIMD loops
 include("simdloop.jl")
@@ -186,7 +187,6 @@ include("math.jl")
 importall .Math
 const (√)=sqrt
 const (∛)=cbrt
-include("float16.jl")
 
 # multidimensional arrays
 include("cartesian.jl")

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2790,13 +2790,7 @@ let types = (Base.BitInteger_types..., BigInt, Bool,
              Complex{Int}, Complex{UInt}, Complex32, Complex64, Complex128)
     for S in types
         for op in (+, -)
-            if S === Float16
-                # broken, fixme then remove this branch
-                @test_throws ErrorException @inferred(Base.promote_op(op, S))
-                T = Base.promote_op(op, S)
-            else
-                T = @inferred Base.promote_op(op, S)
-            end
+            T = @inferred Base.promote_op(op, S)
             t = @inferred op(one(S))
             @test T === typeof(t)
         end
@@ -2806,13 +2800,7 @@ let types = (Base.BitInteger_types..., BigInt, Bool,
 
     for R in types, S in types
         for op in (+, -, *, /, ^)
-            if R === Float16 || S === Float16
-                # broken, fixme then remove this branch
-                @test_throws ErrorException @inferred(Base.promote_op(op, R, S))
-                T = Base.promote_op(op, R, S)
-            else
-                T = @inferred Base.promote_op(op, R, S)
-            end
+            T = @inferred Base.promote_op(op, R, S)
             t = @inferred op(one(R), one(S))
             @test T === typeof(t)
         end
@@ -2824,13 +2812,7 @@ let types = (Base.BitInteger_types..., BigInt, Bool,
              Float16, Float32, Float64, BigFloat)
     for S in types, T in types
         for op in (<, >, <=, >=, (==))
-            if S === Float16 || T === Float16
-                # broken, fixme then remove this branch
-                @test_throws ErrorException @inferred(Base.promote_op(op, S, T))
-                @test Base.promote_op(op, S, T) === Bool
-            else
-                @test @inferred(Base.promote_op(op, S, T)) === Bool
-            end
+            @test @inferred(Base.promote_op(op, S, T)) === Bool
         end
     end
 end


### PR DESCRIPTION
This fixes the large SIMD regressions in #17600, which were due to a failure to inline `afoldl`.
