### PR TITLE
Be consistent about dropping a dimension in slicedim. Fixes #17589.

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -59,9 +59,12 @@ imag{T<:Real}(x::AbstractArray{T}) = zero(x)
 \(A::Number, B::AbstractArray) = B ./ A
 
 # index A[:,:,...,i,:,:,...] where "i" is in dimension "d"
-# TODO: more optimized special cases
-slicedim(A::AbstractArray, d::Integer, i) =
-    A[[ n==d ? i : (indices(A,n)) for n in 1:ndims(A) ]...]
+function slicedim(A::AbstractArray, d::Integer, i)
+    d >= 1 || throw(ArgumentError("dimension must be ≥ 1"))
+    nd = ndims(A)
+    d > nd && (i == 1 || throw_boundserror(A, (ntuple(k->Colon(),nd)..., ntuple(k->1,d-1-nd)..., i)))
+    A[( n==d ? i : indices(A,n) for n in 1:nd )...]
+end
 
 function flipdim(A::AbstractVector, d::Integer)
     d > 0 || throw(ArgumentError("dimension to flip must be positive"))

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -96,41 +96,6 @@ end
 
 ## data movement ##
 
-# TODO?: replace with slice?
-function slicedim(A::Array, d::Integer, i::Integer)
-    if d < 1
-        throw(ArgumentError("dimension must be ≥ 1"))
-    end
-    d_in = size(A)
-    leading = d_in[1:(d-1)]
-    d_out = tuple(leading..., 1, d_in[(d+1):end]...)
-
-    M = prod(leading)
-    N = length(A)
-    stride = M * d_in[d]
-
-    B = similar(A, d_out)
-    index_offset = 1 + (i-1)*M
-
-    l = 1
-
-    if M==1
-        for j=0:stride:(N-stride)
-            B[l] = A[j + index_offset]
-            l += 1
-        end
-    else
-        for j=0:stride:(N-stride)
-            offs = j + index_offset
-            for k=0:(M-1)
-                B[l] = A[offs + k]
-                l += 1
-            end
-        end
-    end
-    return B
-end
-
 function flipdim{T}(A::Array{T}, d::Integer)
     if d < 1
         throw(ArgumentError("dimension d must be ≥ 1"))

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1243,7 +1243,7 @@ end
 function slicedim(A::BitArray, d::Integer, i::Integer)
     d_in = size(A)
     leading = d_in[1:(d-1)]
-    d_out = tuple(leading..., 1, d_in[(d+1):end]...)
+    d_out = tuple(leading..., d_in[(d+1):end]...)
 
     M = prod(leading)
     N = length(A)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1457,9 +1457,15 @@ A = 1:5
 B = 1.5:5.5
 @test A + B == 2.5:2.0:10.5
 
-#slice dim error
-A = zeros(5,5)
-@test_throws ArgumentError slicedim(A,0,1)
+# slicedim
+for A in (reshape(collect(1:20), 4, 5),
+          reshape(1:20, 4, 5))
+    @test slicedim(A, 1, 2) == collect(2:4:20)
+    @test slicedim(A, 2, 2) == collect(5:8)
+    @test_throws ArgumentError slicedim(A,0,1)
+    @test slicedim(A, 3, 1) == A
+    @test_throws BoundsError slicedim(A, 3, 2)
+end
 
 ###
 ### LinearSlow workout

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -857,7 +857,7 @@ b1 = bitrand(s1, s2, s3, s4)
 for d = 1 : 4
     j = rand(1:size(b1, d))
     #for j = 1 : size(b1, d)
-        @check_bit_operation slicedim(b1, d, j) BitArray{4}
+        @check_bit_operation slicedim(b1, d, j) BitArray{3}
     #end
     @check_bit_operation flipdim(b1, d) BitArray{4}
 end


### PR DESCRIPTION
Our tests for `slicedim` were also pretty bad, so I expanded those considerably.

CC @carlobaldassi, note that I changed the result shape on `BitArray` too. Hope that's OK.
