### PR TITLE
RFC: Restricts parameter type for randn & randexp to Float types for #17608.

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -1213,14 +1213,14 @@ let Floats = Union{Float16,Float32,Float64}
             $randfun!(A::AbstractArray) = $randfun!(GLOBAL_RNG, A)
 
             # generating arrays
-            $randfun{T}(rng::AbstractRNG, ::Type{T}, dims::Dims)       = $randfun!(rng, Array{T}(dims))
-            $randfun{T}(rng::AbstractRNG, ::Type{T}, dims::Integer...) = $randfun!(rng, Array{T}(dims...))
-            $randfun{T}(                  ::Type{T}, dims::Dims)       = $randfun(GLOBAL_RNG, T, dims)
-            $randfun{T}(                  ::Type{T}, dims::Integer...) = $randfun(GLOBAL_RNG, T, dims...)
-            $randfun(   rng::AbstractRNG,            dims::Dims)       = $randfun(rng, Float64, dims)
-            $randfun(   rng::AbstractRNG,            dims::Integer...) = $randfun(rng, Float64, dims...)
-            $randfun(                                dims::Dims)       = $randfun(GLOBAL_RNG, Float64, dims)
-            $randfun(                                dims::Integer...) = $randfun(GLOBAL_RNG, Float64, dims...)
+            $randfun{T}(rng::AbstractRNG, ::Type{T}, dims::Dims                     ) = $randfun!(rng, Array{T}(dims))
+            $randfun{T}(rng::AbstractRNG, ::Type{T}, dim0::Integer, dims::Integer...) = $randfun!(rng, Array{T}(dim0, dims...))
+            $randfun{T}(                  ::Type{T}, dims::Dims                     ) = $randfun(GLOBAL_RNG, T, dims)
+            $randfun{T}(                  ::Type{T}, dim0::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, T, dim0, dims...)
+            $randfun(   rng::AbstractRNG,            dims::Dims                     ) = $randfun(rng, Float64, dims)
+            $randfun(   rng::AbstractRNG,            dim0::Integer, dims::Integer...) = $randfun(rng, Float64, dim0, dims...)
+            $randfun(                                dims::Dims                     ) = $randfun(GLOBAL_RNG, Float64, dims)
+            $randfun(                                dim0::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, Float64, dim0, dims...)
         end
     end
 end

--- a/base/random.jl
+++ b/base/random.jl
@@ -1214,13 +1214,13 @@ let Floats = Union{Float16,Float32,Float64}
 
             # generating arrays
             $randfun{T}(rng::AbstractRNG, ::Type{T}, dims::Dims                     ) = $randfun!(rng, Array{T}(dims))
-            $randfun{T}(rng::AbstractRNG, ::Type{T}, dim0::Integer, dims::Integer...) = $randfun!(rng, Array{T}(dim0, dims...))
+            $randfun{T}(rng::AbstractRNG, ::Type{T}, dim1::Integer, dims::Integer...) = $randfun!(rng, Array{T}(dim1, dims...))
             $randfun{T}(                  ::Type{T}, dims::Dims                     ) = $randfun(GLOBAL_RNG, T, dims)
-            $randfun{T}(                  ::Type{T}, dim0::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, T, dim0, dims...)
+            $randfun{T}(                  ::Type{T}, dim1::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, T, dim1, dims...)
             $randfun(   rng::AbstractRNG,            dims::Dims                     ) = $randfun(rng, Float64, dims)
-            $randfun(   rng::AbstractRNG,            dim0::Integer, dims::Integer...) = $randfun(rng, Float64, dim0, dims...)
+            $randfun(   rng::AbstractRNG,            dim1::Integer, dims::Integer...) = $randfun(rng, Float64, dim1, dims...)
             $randfun(                                dims::Dims                     ) = $randfun(GLOBAL_RNG, Float64, dims)
-            $randfun(                                dim0::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, Float64, dim0, dims...)
+            $randfun(                                dim1::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, Float64, dim1, dims...)
         end
     end
 end

--- a/base/random.jl
+++ b/base/random.jl
@@ -1200,7 +1200,7 @@ let Floats = Union{Float16,Float32,Float64}
         @eval begin
             # scalars
             $randfun{T<:$Floats}(rng::AbstractRNG, ::Type{T}) = convert(T, $randfun(rng))
-            $randfun{T<:$Floats}(::Type{T}) = $randfun(GLOBAL_RNG, T)
+            $randfun{T}(::Type{T}) = $randfun(GLOBAL_RNG, T)
 
             # filling arrays
             function $randfun!{T}(rng::AbstractRNG, A::AbstractArray{T})
@@ -1214,13 +1214,14 @@ let Floats = Union{Float16,Float32,Float64}
 
             # generating arrays
             $randfun{T}(rng::AbstractRNG, ::Type{T}, dims::Dims                     ) = $randfun!(rng, Array{T}(dims))
+            # Note that this method explicitly does not define $randfun(rng, T), in order to prevent an infinite recursion.
             $randfun{T}(rng::AbstractRNG, ::Type{T}, dim1::Integer, dims::Integer...) = $randfun!(rng, Array{T}(dim1, dims...))
             $randfun{T}(                  ::Type{T}, dims::Dims                     ) = $randfun(GLOBAL_RNG, T, dims)
-            $randfun{T}(                  ::Type{T}, dim1::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, T, dim1, dims...)
+            $randfun{T}(                  ::Type{T}, dims::Integer...               ) = $randfun(GLOBAL_RNG, T, dims...)
             $randfun(   rng::AbstractRNG,            dims::Dims                     ) = $randfun(rng, Float64, dims)
-            $randfun(   rng::AbstractRNG,            dim1::Integer, dims::Integer...) = $randfun(rng, Float64, dim1, dims...)
+            $randfun(   rng::AbstractRNG,            dims::Integer...               ) = $randfun(rng, Float64, dims...)
             $randfun(                                dims::Dims                     ) = $randfun(GLOBAL_RNG, Float64, dims)
-            $randfun(                                dim1::Integer, dims::Integer...) = $randfun(GLOBAL_RNG, Float64, dim1, dims...)
+            $randfun(                                dims::Integer...               ) = $randfun(GLOBAL_RNG, Float64, dims...)
         end
     end
 end

--- a/test/random.jl
+++ b/test/random.jl
@@ -343,6 +343,23 @@ for rng in ([], [MersenneTwister()], [RandomDevice()])
     bitrand(rng..., 2, 3)          ::BitArray{2}
     rand!(rng..., BitArray(5))     ::BitArray{1}
     rand!(rng..., BitArray(2, 3))  ::BitArray{2}
+
+    # Test that you cannot call randn or randexp with non-Float types.
+    for r in [randn, randexp, randn!, randexp!]
+        @test_throws MethodError r(Int)
+        @test_throws MethodError r(Int32)
+        @test_throws MethodError r(Bool)
+        @test_throws MethodError r(String)
+        @test_throws MethodError r(AbstractFloat)
+        # TODO(#17627): Consider adding support for randn(BigFloat) and removing this test.
+        @test_throws MethodError r(BigFloat)
+
+        @test_throws MethodError r(Int64, (2,3))
+        @test_throws MethodError r(String, 1)
+
+        @test_throws MethodError r(rng..., Number, (2,3))
+        @test_throws MethodError r(rng..., Any, 1)
+    end
 end
 
 function hist(X,n)


### PR DESCRIPTION
Fixes `base/random.jl` and adds tests to `tests/random.jl` to restrict parametrized type parameter to one of `Float16,Float32,Float64`.

These functions already worked only for those types, but erroneously allowed parameters outside those three, with unintended behavior (crashing and infinite-looping). Now, this throws a `MethodError` if provided a non-float type-parameter.
