### PR TITLE
Fix markdown footnote parsing

### DIFF
--- a/base/markdown/Common/Common.jl
+++ b/base/markdown/Common/Common.jl
@@ -3,8 +3,8 @@
 include("block.jl")
 include("inline.jl")
 
-@flavor common [list, indentcode, blockquote, admonition, hashheader, horizontalrule,
+@flavor common [list, indentcode, blockquote, admonition, footnote, hashheader, horizontalrule,
                 paragraph,
 
                 linebreak, escapes, inline_code,
-                asterisk_bold, asterisk_italic, image, footnote, link]
+                asterisk_bold, asterisk_italic, image, footnote_link, link]

--- a/base/markdown/Common/block.jl
+++ b/base/markdown/Common/block.jl
@@ -121,6 +121,41 @@ function indentcode(stream::IO, block::MD)
     end
 end
 
+# --------
+# Footnote
+# --------
+
+type Footnote
+    id::String
+    text
+end
+
+function footnote(stream::IO, block::MD)
+    withstream(stream) do
+        regex = r"^\[\^(\w+)\]:"
+        str = startswith(stream, regex)
+        if isempty(str)
+            return false
+        else
+            ref = match(regex, str).captures[1]
+            buffer = IOBuffer()
+            write(buffer, readline(stream))
+            while !eof(stream)
+                if startswith(stream, "    ")
+                    write(buffer, readline(stream))
+                elseif blankline(stream)
+                    write(buffer, '\n')
+                else
+                    break
+                end
+            end
+            content = parse(seekstart(buffer)).content
+            push!(block, Footnote(ref, content))
+            return true
+        end
+    end
+end
+
 # ––––––
 # Quotes
 # ––––––

--- a/base/markdown/Common/inline.jl
+++ b/base/markdown/Common/inline.jl
@@ -92,18 +92,17 @@ function link(stream::IO, md::MD)
     end
 end
 
-type Footnote
-    id::String
-    text
-end
-
 @trigger '[' ->
-function footnote(stream::IO, md::MD)
+function footnote_link(stream::IO, md::MD)
     withstream(stream) do
-        startswith(stream, "[^") || return
-        id = readuntil(stream, ']', match = '[')
-        id ≡ nothing && return
-        Footnote(id, startswith(stream, ':') ? parseinline(stream, md) : nothing)
+        regex = r"^\[\^(\w+)\]"
+        str = startswith(stream, regex)
+        if isempty(str)
+            return
+        else
+            ref = match(regex, str).captures[1]
+            return Footnote(ref, nothing)
+        end
     end
 end
 

--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -58,8 +58,8 @@ function github_paragraph(stream::IO, md::MD)
     return true
 end
 
-@flavor github [list, indentcode, blockquote, admonition, fencedcode, hashheader,
+@flavor github [list, indentcode, blockquote, admonition, footnote, fencedcode, hashheader,
                 github_table, github_paragraph,
 
                 linebreak, escapes, en_dash, inline_code, asterisk_bold,
-                asterisk_italic, image, footnote, link]
+                asterisk_italic, image, footnote_link, link]

--- a/base/markdown/Julia/Julia.jl
+++ b/base/markdown/Julia/Julia.jl
@@ -8,7 +8,7 @@
 include("interp.jl")
 
 @flavor julia [blocktex, blockinterp, hashheader, list, indentcode, fencedcode,
-               blockquote, admonition, github_table, horizontalrule, setextheader, paragraph,
+               blockquote, admonition, footnote, github_table, horizontalrule, setextheader, paragraph,
 
                linebreak, escapes, tex, interp, en_dash, inline_code,
-               asterisk_bold, asterisk_italic, image, footnote, link]
+               asterisk_bold, asterisk_italic, image, footnote_link, link]

--- a/base/markdown/render/html.jl
+++ b/base/markdown/render/html.jl
@@ -88,6 +88,15 @@ function html(io::IO, md::BlockQuote)
     end
 end
 
+function html(io::IO, f::Footnote)
+    withtag(io, :div, :class => "footnote", :id => "footnote-$(f.id)") do
+        withtag(io, :p, :class => "footnote-title") do
+            print(io, f.id)
+        end
+        html(io, f.text)
+    end
+end
+
 function html(io::IO, md::Admonition)
     withtag(io, :div, :class => "admonition $(md.category)") do
         withtag(io, :p, :class => "admonition-title") do
@@ -148,6 +157,13 @@ end
 
 function htmlinline(io::IO, md::Image)
     tag(io, :img, :src=>md.url, :alt=>md.alt)
+end
+
+
+function htmlinline(io::IO, f::Footnote)
+    withtag(io, :a, :href => "#footnote-$(f.id)", :class => "footnote") do
+        print(io, "[", f.id, "]")
+    end
 end
 
 function htmlinline(io::IO, link::Link)

--- a/base/markdown/render/latex.jl
+++ b/base/markdown/render/latex.jl
@@ -58,6 +58,13 @@ function latex(io::IO, md::BlockQuote)
     end
 end
 
+
+function latex(io::IO, f::Footnote)
+    print(io, "\\footnotetext[", f.id, "]{")
+    latex(io, f.text)
+    println(io, "}")
+end
+
 function latex(io::IO, md::Admonition)
     wrapblock(io, "quote") do
         wrapinline(io, "textbf") do
@@ -133,6 +140,8 @@ function latexinline(io::IO, md::Image)
         println(io)
     end
 end
+
+latexinline(io::IO, f::Footnote) = print(io, "\\footnotemark[", f.id, "]")
 
 function latexinline(io::IO, md::Link)
     wrapinline(io, "href") do

--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -53,6 +53,23 @@ function plain(io::IO, q::BlockQuote)
     println(io)
 end
 
+function plain(io::IO, f::Footnote)
+    print(io, "[^", f.id, "]:")
+    s = sprint(io -> plain(io, f.text))
+    lines = split(rstrip(s), "\n")
+    # Single line footnotes are printed on the same line as their label
+    # rather than taking up an additional line.
+    if length(lines) == 1
+        println(io, " ", lines[1])
+    else
+        println(io)
+        for line in lines
+            println(io, isempty(line) ? "" : "    ", line)
+        end
+        println(io)
+    end
+end
+
 function plain(io::IO, md::Admonition)
     s = sprint(buf -> plain(buf, md.content))
     title = md.title == ucfirst(md.category) ? "" : " \"$(md.title)\""
@@ -90,12 +107,9 @@ end
 
 plaininline(io::IO, md::Vector) = !isempty(md) && plaininline(io, md...)
 
-plaininline(io::IO, link::Link) = plaininline(io, "[", link.text, "](", link.url, ")")
+plaininline(io::IO, f::Footnote) = print(io, "[^", f.id, "]")
 
-function plaininline(io::IO, md::Footnote)
-    print(io, "[^", md.id, "]")
-    md.text ≡ nothing || (print(io, ":"); plaininline(io, md.text))
-end
+plaininline(io::IO, link::Link) = plaininline(io, "[", link.text, "](", link.url, ")")
 
 plaininline(io::IO, md::Image) = plaininline(io, "![", md.alt, "](", md.url, ")")
 

--- a/base/markdown/render/rst.jl
+++ b/base/markdown/render/rst.jl
@@ -57,6 +57,23 @@ function rst(io::IO, q::BlockQuote)
     println(io)
 end
 
+function rst(io::IO, f::Footnote)
+    print(io, ".. [", f.id, "]")
+    s = sprint(io -> rst(io, f.text))
+    lines = split(rstrip(s), "\n")
+    # Single line footnotes are printed on the same line as their label
+    # rather than taking up an additional line.
+    if length(lines) == 1
+        println(io, " ", lines[1])
+    else
+        println(io)
+        for line in lines
+            println(io, isempty(line) ? "" : "   ", rstrip(line))
+        end
+        println(io)
+    end
+end
+
 function rst(io::IO, md::Admonition)
     s = sprint(buf -> rst(buf, md.content))
     title = md.title == ucfirst(md.category) ? "" : md.title
@@ -105,14 +122,7 @@ function rstinline(io::IO, md::Link)
     end
 end
 
-function rstinline(io::IO, md::Footnote)
-    if md.text ≡ nothing
-        print(io, "[", md.id, "]_")
-    else
-        print(io, ".. [", md.id, "]")
-        rstinline(io, md.text)
-    end
-end
+rstinline(io::IO, f::Footnote) = print(io, "[", f.id, "]_")
 
 rstescape(s) = replace(s, "\\", "\\\\")
 

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -40,6 +40,16 @@ function term(io::IO, md::Admonition, columns)
     end
 end
 
+function term(io::IO, f::Footnote, columns)
+    print(io, " "^margin, "| ")
+    with_output_format(:bold, print, io, "[^$(f.id)]")
+    println(io, "\n", " "^margin, "|")
+    s = sprint(io -> term(io, f.text, columns - 10))
+    for line in split(rstrip(s), "\n")
+        println(io, " "^margin, "|", line)
+    end
+end
+
 function term(io::IO, md::List, columns)
     for (i, point) in enumerate(md.items)
         print(io, " "^2margin, isordered(md) ? "$(i + md.ordered - 1). " : "•  ")
@@ -121,13 +131,10 @@ function terminline(io::IO, md::Image)
     terminline(io, "(Image: $(md.alt))")
 end
 
+terminline(io::IO, f::Footnote) = with_output_format(:bold, terminline, io, "[^$(f.id)]")
+
 function terminline(io::IO, md::Link)
     terminline(io, md.text)
-end
-
-function terminline(io::IO, md::Footnote)
-    print(io, "[^", md.id, "]")
-    md.text ≡ nothing || (print(io, ":"); terminline(io, md.text))
 end
 
 function terminline(io::IO, code::Code)


### PR DESCRIPTION
The markdown parser's footnote syntax was not able to parse anything other than single paragraphs. Multiple nested blocks were ignored, which doesn't match the behaviour of any markdown parsers that do support footnote syntax &ndash; most notably Pandoc.

Also adds missing rendering methods for `Footnote` for all output formats and some additional tests.
