### PR TITLE
Handle overflow correctly with DateTime ranges

### DIFF
--- a/stdlib/Dates/src/ranges.jl
+++ b/stdlib/Dates/src/ranges.jl
@@ -11,8 +11,12 @@ guess(a::Date, b::Date, c) = Int64(div(value(b - a), days(c)))
 len(a::Time, b::Time, c) = Int64(div(value(b - a), tons(c)))
 function len(a, b, c)
     lo, hi, st = min(a, b), max(a, b), abs(c)
-    i = guess(a, b, c) - 1
-    while lo + st * i <= hi
+    i = guess(a, b, c)
+    v = lo + st * i
+    prev = v  # Ensure `v` does not overflow
+    while v <= hi && prev <= v
+        prev = v
+        v += st
         i += 1
     end
     return i - 1

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -582,4 +582,18 @@ a = Dates.Time(23, 1, 1)
       hash([Date("2018-1-03"), Date("2018-1-04"), Date("2018-1-05")]) ==
       hash(Date("2018-1-03"):Day(1):Date("2018-1-05"))
 
+@testset "range overflow" begin
+    # DateTime ranges interactions with overflow. If not handled correctly `Dates.len` could
+    # infinite loop
+    @test length(DateTime(0):typemax(Millisecond):DateTime(0)) == 1
+    @test length(typemax(DateTime):typemax(Millisecond):typemax(DateTime)) == 1
+
+    # Overflow interaction is easier to comprehend with using UTM extremes
+    utm_typemin = DateTime(Dates.UTM(typemin(Int64)))
+    utm_typemax = DateTime(Dates.UTM(typemax(Int64)))
+
+    @test length(utm_typemax:Millisecond(1):utm_typemax) == 1
+    @test length(utm_typemin:-Millisecond(1):utm_typemin) == 1
 end
+
+end  # RangesTest module


### PR DESCRIPTION
I was experimenting with overflow and step ranges and discovered an issue with DateTime ranges.

``` julia
julia> import Base.Dates: UTM, Hour

julia> DateTime(UTM(typemax(Int64))):-Hour(1):(DateTime(UTM(typemax(Int64))) - Hour(2))
# Hangs
```

Note that typically `DateTime` works with a smaller maximum so typically users won't never encounter this problem.

``` julia
julia> DateTime(UTM(typemax(Int64)))
292277025-08-17T07:12:55.807

julia> typemax(DateTime)
146138512-12-31T23:59:59
```
