### PR TITLE
return LambdaInfo instead of array from @code_{typed,lowered}

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -338,11 +338,23 @@ function gen_call_with_extracted_types(fcn, ex0)
     exret
 end
 
-for fname in [:which, :less, :edit, :functionloc, :code_typed, :code_warntype,
-              :code_lowered, :code_llvm, :code_llvm_raw, :code_native]
+for fname in [:which, :less, :edit, :functionloc, :code_warntype,
+              :code_llvm, :code_llvm_raw, :code_native]
     @eval begin
         macro ($fname)(ex0)
             gen_call_with_extracted_types($(Expr(:quote,fname)), ex0)
+        end
+    end
+end
+
+for fname in [:code_typed, :code_lowered]
+    @eval begin
+        macro ($fname)(ex0)
+            thecall = gen_call_with_extracted_types($(Expr(:quote,fname)), ex0)
+            quote
+                results = $thecall
+                length(results) == 1 ? results[1] : results
+            end
         end
     end
 end


### PR DESCRIPTION
Showing arrays of LambdaInfo recently changed, giving this regression in user experience:

```
julia> @code_lowered 1+1
1-element Array{LambdaInfo,1}:
 LambdaInfo template for +{T<:Union{Int128,Int16,Int32,Int64,Int8,UInt128,UInt16,UInt32,UInt64,UInt8}}(x::T, y::T) at int.jl:32
```

With this PR the output is:

```
julia> @code_lowered 1+1
LambdaInfo template for +{T<:Union{Int128,Int16,Int32,Int64,Int8,UInt128,UInt16,UInt32,UInt64,UInt8}}(x::T, y::T) at int.jl:32
:(begin 
        nothing
        return (Base.box)($(Expr(:static_parameter, 1)),(Base.add_int)((Base.unbox)($(Expr(:static_parameter, 1)),x),(Base.unbox)($(Expr(:static_parameter, 1)),y)))
    end)
```

This means these two macros no longer return the same result as the non-macro versions. However, we have to either make this change or revert the change to LambdaInfo printing, since `@code_typed` is not very useful to me in its current state.
