### PR TITLE
run deps checks in `make binary-dist`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,6 +452,7 @@ endif
 ifneq ($(DESTDIR),)
 	$(error DESTDIR must not be set for make binary-dist)
 endif
+	@$(MAKE) -C $(BUILDROOT)/deps -f $(JULIAHOME)/deps/Makefile check
 	@$(MAKE) -C $(BUILDROOT) -f $(JULIAHOME)/Makefile install
 	cp $(JULIAHOME)/LICENSE.md $(BUILDROOT)/julia-$(JULIA_COMMIT)
 ifneq ($(OS), WINNT)

--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -39,6 +39,7 @@ $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-
 
 $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-checked: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
+# TODO: get these passing, remove the -
 	-$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@

--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -21,8 +21,7 @@ $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled: $(BUILDDIR)/patchelf-$(PATC
 
 $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-checked: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-	# disabled due to bug in v0.6
-	#$(MAKE) -C $(dir $@) check
+	$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
 

--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -21,7 +21,9 @@ $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled: $(BUILDDIR)/patchelf-$(PATC
 
 $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-checked: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
+ifeq (,$(filter $(ARCH), powerpc64le ppc64le)) # https://github.com/NixOS/patchelf/issues/105
 	$(MAKE) -C $(dir $@) check
+endif
 endif
 	echo 1 > $@
 

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -23,7 +23,7 @@ $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled: $(BUILDDIR)/pcre2-$(PCRE_VER)/buil
 	$(MAKE) -C $(dir $<) $(LIBTOOL_CCLD)
 	echo 1 > $@
 
-$(BUILDDIR)/pcre2-$(PCRE_VER)/checked: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
+$(BUILDDIR)/pcre2-$(PCRE_VER)/build-checked: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) check
 endif

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -25,9 +25,7 @@ $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled: $(BUILDDIR)/pcre2-$(PCRE_VER)/buil
 
 $(BUILDDIR)/pcre2-$(PCRE_VER)/checked: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-ifneq ($(OS),WINNT)
-	$(MAKE) -C $(dir $@) check -j1
-endif
+	$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
 

--- a/deps/suitesparse.mk
+++ b/deps/suitesparse.mk
@@ -47,7 +47,9 @@ $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSpar
 	echo 1 > $@
 
 $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-checked: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled
+ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) default $(SUITESPARSE_MFLAGS)
+endif
 	echo 1 > $@
 
 $(build_prefix)/manifest/suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled | $(build_prefix)/manifest

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -24,7 +24,8 @@ $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled: $(BUILDDIR)/libunwind-$(UNWI
 
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-checked: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-	$(MAKE) -C $(dir $@) check
+# TODO: get these passing, remove the -
+	-$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
 


### PR DESCRIPTION
A bunch of these were removed from the default build in https://github.com/JuliaLang/julia/pull/14517, but they should have been put in binary-dist or release-candidate. They take a fair amount of time and aren't needed for every single Julia source build, but it is a good idea to check against them for binaries or releases. They have a different set of test coverage than our Julia-level bindings for them.

WIP because:
- [x] depends on a ~~not-yet-merged~~ not-yet-tagged utf8proc PR to build its tests correctly
- [ ] ~~mbedtls and maybe~~ libunwind failures deserve looking into and should be fixable with hopefully not-too-complicated patches
- [ ] libssh2 is failing its tests on the buildbots but not locally - likely an old-centos issue?
- [ ] should be checked on all platforms we have buildbots for, currently running these
