### PR TITLE
Make sure the LLVM metadata is initialized before our custom LLVM pass

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4889,8 +4889,9 @@ extern "C" void jl_fptr_to_llvm(jl_fptr_t fptr, jl_lambda_info_t *lam, int specs
 #define V128_BUG
 #endif
 
-static void init_julia_llvm_env(Module *m)
+static void init_julia_llvm_meta(void)
 {
+    mbuilder = new MDBuilder(jl_LLVMContext);
     MDNode *tbaa_root = mbuilder->createTBAARoot("jtbaa");
     tbaa_gcframe = tbaa_make_child("jtbaa_gcframe", tbaa_root);
     tbaa_stack = tbaa_make_child("jtbaa_stack", tbaa_root);
@@ -4907,7 +4908,10 @@ static void init_julia_llvm_env(Module *m)
     tbaa_arraylen = tbaa_make_child("jtbaa_arraylen", tbaa_array);
     tbaa_arrayflags = tbaa_make_child("jtbaa_arrayflags", tbaa_array);
     tbaa_const = tbaa_make_child("jtbaa_const", tbaa_root, true);
+}
 
+static void init_julia_llvm_env(Module *m)
+{
     // every variable or function mapped in this function must be
     // exported from libjulia, to support static compilation
     T_int1  = Type::getInt1Ty(jl_LLVMContext);
@@ -5735,6 +5739,8 @@ extern "C" void jl_init_codegen(void)
         jl_TargetMachine->setFastISel(true);
 #endif
 
+    init_julia_llvm_meta();
+
 #ifdef USE_ORCJIT
     jl_ExecutionEngine = new JuliaOJIT(*jl_TargetMachine);
 #else
@@ -5750,8 +5756,6 @@ extern "C" void jl_init_codegen(void)
 #endif
     jl_ExecutionEngine->DisableLazyCompilation();
 #endif
-
-    mbuilder = new MDBuilder(jl_LLVMContext);
 
     // Now that the execution engine exists, initialize all modules
     jl_setup_module(engine_module);

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -980,5 +980,6 @@ void jl_dump_bb_uses(std::map<BasicBlock*, std::map<frame_register, liveness::id
 
 Pass *createLowerGCFramePass(MDNode *tbaa_gcframe)
 {
+    assert(tbaa_gcframe);
     return new LowerGCFrame(tbaa_gcframe);
 }

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -189,5 +189,6 @@ static RegisterPass<LowerPTLS> X("LowerPTLS", "LowerPTLS Pass",
 
 Pass *createLowerPTLSPass(bool imaging_mode, MDNode *tbaa_const)
 {
+    assert(tbaa_const);
     return new LowerPTLS(imaging_mode, tbaa_const);
 }


### PR DESCRIPTION
The issue is that the pass manager used for `code_llvm` is different from the one for JIT, which causes the really confusing result when we check the code with `code_llvm`........

Fix #17600

@JeffBezanson can you verify?
