### PR TITLE
Fix start_reading(stream, callback)

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -445,7 +445,7 @@ function notify_filled(stream::LibuvStream, nread::Int)
     more = true
     while more
         if isa(stream.readcb,Function)
-            nreadable = (stream.line_buffered ? Int(search(stream.buffer, '\n')) : nb_available(stream.buffer))
+            nreadable = (stream.line_buffered ? Int(search(stream.buffer, UInt8('\n'))) : nb_available(stream.buffer))
             if nreadable > 0
                 more = stream.readcb(stream, nreadable)
             else
@@ -674,7 +674,7 @@ function start_reading(stream::LibuvStream)
 end
 
 function start_reading(stream::LibuvStream, cb::Function)
-    failure = start_reading(stream)
+    failure_code = start_reading(stream)
     stream.readcb = cb
     nread = nb_available(stream.buffer)
     if nread > 0


### PR DESCRIPTION
This fixes two issues with the `start_reading` that takes a callback, which currently cannot be used since it throws an error immediately.

The `notify_filled` change is necessary since the `search(stream::IOBuffer, delim)` requires the delimiter to be of type `UInt8`, i.e. specifically

```
search(buf::Base.AbstractIOBuffer{Array{UInt8,1}}, delim::UInt8)
search(buf::Base.AbstractIOBuffer, delim::UInt8)
```

This error only surfaces when the stream has a `readcb` attached.

In `start_reading` it fixes a mismatch between variable names which makes the call fail with an `UndefVarError: failure_code not defined`.

---

It could probably use a test or two as well, since it seems that this particular method at least is currently not tested (nor used?).

With these changes the method _seems_ to work now, which I've tested with the [following example](https://gist.github.com/mortenpi/554d074a582748cf3af48dd25eccfcc7). It also shows the use case where this came up -- exploring options to capture `STDOUT` and `STDERR`, while trying to keep the order when `STDOUT` and `STDERR` are interleaved (which we need in Documenter.jl).
