### PR TITLE
Make convert(::Type{<:AbstractTriangular}, A::Diagonal) consistently preserve storage structure

### DIFF
--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -11,16 +11,18 @@ convert(::Type{UpperTriangular}, A::Bidiagonal) = A.isupper ? UpperTriangular(fu
 
 function convert(::Type{UnitUpperTriangular}, A::Diagonal)
     if !all(A.diag .== one(eltype(A)))
-        throw(ArgumentError("matrix cannot be represented as UnitUpperTriangular"))
+        throw(ArgumentError(string("Diagonal matrices with non-one entries on the ",
+            "diagonal cannot be converted to UnitUpperTriangular")))
     end
-    UnitUpperTriangular(full(A))
+    UnitUpperTriangular(A)
 end
 
 function convert(::Type{UnitLowerTriangular}, A::Diagonal)
     if !all(A.diag .== one(eltype(A)))
-        throw(ArgumentError("matrix cannot be represented as UnitLowerTriangular"))
+        throw(ArgumentError(string("Diagonal matrices with non-one entries on the ",
+            "diagonal cannot be converted to UnitLowerTriangular")))
     end
-    UnitLowerTriangular(full(A))
+    UnitLowerTriangular(A)
 end
 
 function convert(::Type{Diagonal}, A::Union{Bidiagonal, SymTridiagonal})

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -128,3 +128,13 @@ for typ in [UpperTriangular,LowerTriangular,Base.LinAlg.UnitUpperTriangular,Base
     @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
     @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
 end
+
+# Test conversion from Diagonal to <:AbstractTriangular
+let
+    unitdiagmat = Diagonal(ones(Int, 3))
+    # test that conversion from diagonal to triangular preserves diagonal storage structure
+    @test typeof(convert(LowerTriangular, unitdiagmat)) == LowerTriangular{Int,Diagonal{Int}}
+    @test typeof(convert(UpperTriangular, unitdiagmat)) == UpperTriangular{Int,Diagonal{Int}}
+    @test typeof(convert(Base.LinAlg.UnitLowerTriangular, unitdiagmat)) == Base.LinAlg.UnitLowerTriangular{Int,Diagonal{Int}}
+    @test typeof(convert(Base.LinAlg.UnitUpperTriangular, unitdiagmat)) == Base.LinAlg.UnitUpperTriangular{Int,Diagonal{Int}}
+end


### PR DESCRIPTION
`convert(::Type{LowerTriangular}, A::Diagonal)` and `convert(::Type{UpperTriangular}, A::Diagonal)` preserve `Diagonal` storage structure, respectively returning `LowerTriangular{T,Diagonal{T}}` and `UpperTriangular{T,Diagonal{T}}`. In contrast, `convert(::Type{UnitLowerTriangular}, A::Diagonal)` and `convert(::Type{UnitUpperTriangular})` discard the `Diagonal` storage structure via a `full` call, respectively returning `UnitLowerTriangular{T,Matrix{T}}` and `UnitUpperTriangular{T,Matrix{T}}`.

This pull request makes the latter (`Unit(Lower|Upper)Triangular`) methods preserve the `Diagonal` storage structure, consistent with the former (`(Lower|Upper)Triangular`) methods. Best!
