### PR TITLE
Deprecate 1 argument write. fix #17612

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -806,4 +806,6 @@ end)
 
 const _oldstyle_array_vcat_ = false
 
+@deprecate write(x) write(STDOUT::IO, x)
+
 # End deprecations scheduled for 0.6

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -191,8 +191,6 @@ function takebuf_raw(s::IOStream)
     return buf, sz
 end
 
-write(x) = write(STDOUT::IO, x)
-
 function readuntil(s::IOStream, delim::UInt8)
     ccall(:jl_readuntil, Array{UInt8,1}, (Ptr{Void}, UInt8), s.ios, delim)
 end


### PR DESCRIPTION
As Jeff points out in #17612, this is not a good shortcut for writing to `STDOUT`. To make the mater even worse if `write("a")` is executed it invokes the method in https://github.com/JuliaLang/julia/blob/d0a378de30046bc2d09e669296eb6a4e69585d83/base/io.jl#L93. This method will create an empty file named a, while `write(1)` would write data to `STDOUT`, this could be quite surprising.
