### PR TITLE
fix #13529, slowdown with large number of async `sleep` calls

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1815,7 +1815,7 @@ static void jl_reinit_item(jl_value_t *v, int how, arraylist_t *tracee_list)
             case 1: { // rehash ObjectIdDict
                 jl_array_t **a = (jl_array_t**)v;
                 // Assume *a don't need a write barrier
-                jl_idtable_rehash(a, jl_array_len(*a));
+                *a = jl_idtable_rehash(*a, jl_array_len(*a));
                 jl_gc_wb(v, *a);
                 break;
             }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -425,7 +425,7 @@ int32_t jl_get_llvm_gv(jl_value_t *p);
 int32_t jl_assign_functionID(/*llvm::Function*/void *function);
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns
-void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
+JL_DLLEXPORT jl_array_t *jl_idtable_rehash(jl_array_t *a, size_t newsz);
 
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
 jl_lambda_info_t *jl_get_specialization1(jl_tupletype_t *types);


### PR DESCRIPTION
The problem was performance degradation of ObjectIdDict with many deleted items. The table needs to be rehashed after a large number of deletions.
