### PR TITLE
RFC: Make isapprox compare element-wise when the vector norm is infinite

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1208,25 +1208,6 @@ Return ``\\exp(iz)``.
 cis
 
 """
-    isapprox(x, y; rtol::Real=sqrt(eps), atol::Real=0)
-
-Inexact equality comparison: `true` if `norm(x-y) <= atol + rtol*max(norm(x), norm(y))`. The
-default `atol` is zero and the default `rtol` depends on the types of `x` and `y`.
-
-For real or complex floating-point values, `rtol` defaults to
-`sqrt(eps(typeof(real(x-y))))`. This corresponds to requiring equality of about half of the
-significand digits. For other types, `rtol` defaults to zero.
-
-`x` and `y` may also be arrays of numbers, in which case `norm` defaults to `vecnorm` but
-may be changed by passing a `norm::Function` keyword argument. (For numbers, `norm` is the
-same thing as `abs`.)
-
-The binary operator `≈` is equivalent to `isapprox` with the default arguments, and `x ≉ y`
-is equivalent to `!isapprox(x,y)`.
-"""
-isapprox
-
-"""
     sinh(x)
 
 Compute hyperbolic sine of `x`.

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -240,7 +240,7 @@ significand digits. For other types, `rtol` defaults to zero.
 
 `x` and `y` may also be arrays of numbers, in which case `norm` defaults to `vecnorm` but
 may be changed by passing a `norm::Function` keyword argument. (For numbers, `norm` is the
-same thing as `abs`.) When `x` and `y` are arrays, if their norm is infinite (i.e. `±Inf`
+same thing as `abs`.) When `x` and `y` are arrays, if `norm(x-y)` is not finite (i.e. `±Inf`
 or `NaN`), the comparison falls back to checking whether all elements of `x` and `y` are
 approximately equal component-wise.
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -228,6 +228,25 @@ for f in (:round, :ceil, :floor, :trunc)
 end
 
 # isapprox: approximate equality of numbers
+"""
+    isapprox(x, y; rtol::Real=sqrt(eps), atol::Real=0)
+
+Inexact equality comparison: `true` if `norm(x-y) <= atol + rtol*max(norm(x), norm(y))`. The
+default `atol` is zero and the default `rtol` depends on the types of `x` and `y`.
+
+For real or complex floating-point values, `rtol` defaults to
+`sqrt(eps(typeof(real(x-y))))`. This corresponds to requiring equality of about half of the
+significand digits. For other types, `rtol` defaults to zero.
+
+`x` and `y` may also be arrays of numbers, in which case `norm` defaults to `vecnorm` but
+may be changed by passing a `norm::Function` keyword argument. (For numbers, `norm` is the
+same thing as `abs`.) When `x` and `y` are arrays, if their norm is infinite (i.e. `±Inf`
+or `NaN`), the comparison falls back to checking whether all elements of `x` and `y` are
+approximately equal component-wise.
+
+The binary operator `≈` is equivalent to `isapprox` with the default arguments, and `x ≉ y`
+is equivalent to `!isapprox(x,y)`.
+"""
 function isapprox(x::Number, y::Number; rtol::Real=rtoldefault(x,y), atol::Real=0)
     x == y || (isfinite(x) && isfinite(y) && abs(x-y) <= atol + rtol*max(abs(x), abs(y)))
 end

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -592,7 +592,7 @@ function isapprox{T<:Number,S<:Number}(x::AbstractArray{T}, y::AbstractArray{S};
         return d <= atol + rtol*max(norm(x), norm(y))
     else
         # Fall back to a component-wise approximate comparison
-        return all(map((a, b) -> isapprox(a, b; rtol=rtol, atol=atol), x, y))
+        return all(ab -> isapprox(ab[1], ab[2]; rtol=rtol, atol=atol), zip(x, y))
     end
 end
 

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -588,7 +588,12 @@ end
 # isapprox: approximate equality of arrays [like isapprox(Number,Number)]
 function isapprox{T<:Number,S<:Number}(x::AbstractArray{T}, y::AbstractArray{S}; rtol::Real=Base.rtoldefault(T,S), atol::Real=0, norm::Function=vecnorm)
     d = norm(x - y)
-    return isfinite(d) ? d <= atol + rtol*max(norm(x), norm(y)) : x == y
+    if isfinite(d)
+        return d <= atol + rtol*max(norm(x), norm(y))
+    else
+        # Fall back to a component-wise approximate comparison
+        return all(map((a, b) -> isapprox(a, b; rtol=rtol, atol=atol), x, y))
+    end
 end
 
 """

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -495,7 +495,7 @@ Mathematical Functions
 
    For real or complex floating-point values, ``rtol`` defaults to ``sqrt(eps(typeof(real(x-y))))``\ . This corresponds to requiring equality of about half of the significand digits. For other types, ``rtol`` defaults to zero.
 
-   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .) When ``x`` and ``y`` are arrays, if their norm is infinite (i.e. `±Inf` or `NaN`), the comparison falls back to checking whether all elements of ``x`` and ``y`` are approximately equal component-wise.
+   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .) When ``x`` and ``y`` are arrays, if their norm is infinite (i.e. ``±Inf`` or ``NaN``), the comparison falls back to checking whether all elements of ``x`` and ``y`` are approximately equal component-wise.
 
    The binary operator ``≈`` is equivalent to ``isapprox`` with the default arguments, and ``x ≉ y`` is equivalent to ``!isapprox(x,y)``\ .
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -495,7 +495,7 @@ Mathematical Functions
 
    For real or complex floating-point values, ``rtol`` defaults to ``sqrt(eps(typeof(real(x-y))))``\ . This corresponds to requiring equality of about half of the significand digits. For other types, ``rtol`` defaults to zero.
 
-   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .) When ``x`` and ``y`` are arrays, if their norm is infinite (i.e. ``±Inf`` or ``NaN``), the comparison falls back to checking whether all elements of ``x`` and ``y`` are approximately equal component-wise.
+   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .)
 
    The binary operator ``≈`` is equivalent to ``isapprox`` with the default arguments, and ``x ≉ y`` is equivalent to ``!isapprox(x,y)``\ .
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -495,7 +495,7 @@ Mathematical Functions
 
    For real or complex floating-point values, ``rtol`` defaults to ``sqrt(eps(typeof(real(x-y))))``\ . This corresponds to requiring equality of about half of the significand digits. For other types, ``rtol`` defaults to zero.
 
-   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .) When ``x`` and ``y`` are arrays, if their norm is infinite (i.e. ``±Inf`` or ``NaN``\ ), the comparison falls back to checking whether all elements of ``x`` and ``y`` are approximately equal component-wise.
+   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .) When ``x`` and ``y`` are arrays, if ``norm(x-y)`` is not finite (i.e. ``±Inf`` or ``NaN``\ ), the comparison falls back to checking whether all elements of ``x`` and ``y`` are approximately equal component-wise.
 
    The binary operator ``≈`` is equivalent to ``isapprox`` with the default arguments, and ``x ≉ y`` is equivalent to ``!isapprox(x,y)``\ .
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -495,7 +495,7 @@ Mathematical Functions
 
    For real or complex floating-point values, ``rtol`` defaults to ``sqrt(eps(typeof(real(x-y))))``\ . This corresponds to requiring equality of about half of the significand digits. For other types, ``rtol`` defaults to zero.
 
-   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .)
+   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .) When ``x`` and ``y`` are arrays, if their norm is infinite (i.e. `±Inf` or `NaN`), the comparison falls back to checking whether all elements of ``x`` and ``y`` are approximately equal component-wise.
 
    The binary operator ``≈`` is equivalent to ``isapprox`` with the default arguments, and ``x ≉ y`` is equivalent to ``!isapprox(x,y)``\ .
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -495,7 +495,7 @@ Mathematical Functions
 
    For real or complex floating-point values, ``rtol`` defaults to ``sqrt(eps(typeof(real(x-y))))``\ . This corresponds to requiring equality of about half of the significand digits. For other types, ``rtol`` defaults to zero.
 
-   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .)
+   ``x`` and ``y`` may also be arrays of numbers, in which case ``norm`` defaults to ``vecnorm`` but may be changed by passing a ``norm::Function`` keyword argument. (For numbers, ``norm`` is the same thing as ``abs``\ .) When ``x`` and ``y`` are arrays, if their norm is infinite (i.e. ``±Inf`` or ``NaN``\ ), the comparison falls back to checking whether all elements of ``x`` and ``y`` are approximately equal component-wise.
 
    The binary operator ``≈`` is equivalent to ``isapprox`` with the default arguments, and ``x ≉ y`` is equivalent to ``!isapprox(x,y)``\ .
 

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -282,3 +282,6 @@ end
 @test det([true false; false true]) == det(eye(Int, 2))
 
 @test_throws ArgumentError Base.LinAlg.char_uplo(:Z)
+
+# Issue 17650
+@test [0.01311489462160816, Inf] ≈ [0.013114894621608135, Inf]


### PR DESCRIPTION
Fixes #17650.

The discussion in that issue is over the fallback behavior when the norm of the difference is infinite. Currently we fall back to checking exact equality with `==`, but this implements the less stringent requirement of element-wise approximate equality in that case.
