### PR TITLE
Remove `full` from `similar(full(X), T, dims)` calls in generic concatenation methods

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1014,7 +1014,7 @@ function typed_vcat{T}(::Type{T}, V::AbstractVector...)
     for Vk in V
         n += length(Vk)
     end
-    a = similar(full(V[1]), T, n)
+    a = similar(V[1], T, n)
     pos = 1
     for k=1:length(V)
         Vk = V[k]
@@ -1042,7 +1042,7 @@ function typed_hcat{T}(::Type{T}, A::AbstractVecOrMat...)
         nd = ndims(Aj)
         ncols += (nd==2 ? size(Aj,2) : 1)
     end
-    B = similar(full(A[1]), T, nrows, ncols)
+    B = similar(A[1], T, nrows, ncols)
     pos = 1
     if dense
         for k=1:nargs
@@ -1074,7 +1074,7 @@ function typed_vcat{T}(::Type{T}, A::AbstractMatrix...)
             throw(ArgumentError("number of columns of each array must match (got $(map(x->size(x,2), A)))"))
         end
     end
-    B = similar(full(A[1]), T, nrows, ncols)
+    B = similar(A[1], T, nrows, ncols)
     pos = 1
     for k=1:nargs
         Ak = A[k]
@@ -1303,7 +1303,7 @@ function typed_hvcat{T}(::Type{T}, rows::Tuple{Vararg{Int}}, as::AbstractMatrix.
         a += rows[i]
     end
 
-    out = similar(full(as[1]), T, nr, nc)
+    out = similar(as[1], T, nr, nc)
 
     a = 1
     r = 1


### PR DESCRIPTION
Towards reintroducing JuliaLang/julia#17079, this pull request removes `full` from `similar(full(X), T, dims)` calls in the generic concatenation methods.

For an explanation of those `full` calls' purpose, see the first paragraph of https://github.com/JuliaLang/julia/pull/17079#issuecomment-234658313. See the preceding comments in that thread to understand why displacing those `full` calls is necessary to reintroduce JuliaLang/julia#17079 .

Contrary to the expectation I expressed in that comment, removing those `full` calls appears to _improve_ the degree to which the generic concatenation methods preserve structure:

**<details>**The code in [this gist](https://gist.github.com/Sacha0/e7fdbb3dc61840e8df9c339cdc28f0a1#file-typemapconcat-jl) determines, for all pairwise combinations of dense vectors, dense matrices, sparse vectors, sparse matrices, special matrices, and triangular, symmetric, and hermitian annotations of both dense and sparse matrices, the return type of prototypical `vcat`, `hcat`, `hvcat`, and `cat` calls, and prints the mappings `catmeth(typeA, typeB) -> typeRet`. [This gist](https://gist.github.com/Sacha0/e7fdbb3dc61840e8df9c339cdc28f0a1#file-master-concattypemap-jl) provides the output of that code on master, and [this gist](https://gist.github.com/Sacha0/e7fdbb3dc61840e8df9c339cdc28f0a1#file-defull-concattypemap-jl) the same with this PR. [This gist](https://gist.github.com/Sacha0/e7fdbb3dc61840e8df9c339cdc28f0a1#file-diff-concattypemap-diff) provides the diff. (Update: These gists are up to date, so the diff is now empty.)**</details>**

**tl;dr of details** To sum up the diff: When a sparse matrix or vector appears as the first argument in a concatenation call for which there exists no specialized method, on master the result is an `Array`, whereas with this PR the result remains sparse. Otherwise the results are identical.

This change makes JuliaLang/julia#2326 more apparent in that, for example, `hcat(SparseMatrixCSC, Bidiagonal)` would now produce a sparse matrix whereas `hcat(Bidiagonal, SparseMatrixCSC)` would still produce a dense matrix. Modifying the `Union`s in [this and the accompanying method definitions](https://github.com/JuliaLang/julia/blob/e717ded47a55d3526a10207d8d75ae5c9ab9646f/base/sparse/sparsematrix.jl#L3234) to include special matrix types would resolve that issue for special matrix types. But the same cannot be done for the annotation types. And absent the ability to write methods with `Vararg`s in positions other than last, I do not immediately see a way to resolve that issue for annotation types. (Edit: Ref. JuliaLang/julia#13130. Combinatorial explosion precludes extending the present strategy much?) Making the change necessary to handle special matrix types while punting to JuliaLang/julia#2326 on annotation types seems attractive. Other solutions? Thanks!
