### PR TITLE
Fix build for LLVM 4.0 after commit r276654

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -475,7 +475,10 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #else
         CE = TheTarget->createMCCodeEmitter(*MCII, *MRI, *STI, Ctx);
 #endif
-#ifdef LLVM34
+#ifdef LLVM40
+        MCTargetOptions Options;
+        MAB = TheTarget->createMCAsmBackend(*MRI, TripleName, MCPU, Options);
+#elif defined(LLVM34)
         MAB = TheTarget->createMCAsmBackend(*MRI, TripleName, MCPU);
 #else
         MAB = TheTarget->createMCAsmBackend(TripleName, MCPU);


### PR DESCRIPTION
In commit r276654 in LLVM the signature of `Target::createMCAsmBackend()` changed and now requires a fourth parameter of type `MCTargetOptions`. For our purposes it is sufficient to pass a default constructed `MCTargetOptions` instance since this seems to preserve the original behaviour.
