### PR TITLE
Use versioned directories for code bundled with Julia

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ script:
     - /tmp/julia/bin/julia --precompiled=no -e 'true' &&
         /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
     - /tmp/julia/bin/julia -e 'versioninfo()'
-    - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 && cd /tmp/julia/share/julia/test &&
+    - export JULIA_CPU_CORES=2 JULIA_TEST_MAXRSS_MB=600 && cd /tmp/julia/share/julia/v[0-9]*/test &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
     - cd `dirname $TRAVIS_BUILD_DIR` && mv julia2 julia && rm -rf julia/deps/build/julia-env

--- a/Make.inc
+++ b/Make.inc
@@ -156,6 +156,9 @@ SOMAJOR := $(JULIA_MAJOR_VERSION)
 SOMINOR := $(JULIA_MINOR_VERSION)
 endif
 
+# Versioned suffix for code bundled with Julia
+VERSDIR := v$(JULIA_MAJOR_VERSION).$(JULIA_MINOR_VERSION)
+
 ifneq ($(NO_GIT), 1)
 JULIA_COMMIT := $(shell git rev-parse --short=10 HEAD)
 else
@@ -199,8 +202,8 @@ build_libdir := $(build_prefix)/lib/$(MULTIARCH)
 endif
 
 # Private library directories
-private_libdir := $(libdir)/julia
-build_private_libdir := $(build_libdir)/julia
+private_libdir := $(libdir)/julia/$(VERSDIR)
+build_private_libdir := $(build_libdir)/julia/$(VERSDIR)
 
 # Calculate relative paths to libdir, private_libdir, datarootdir, and sysconfdir
 build_libdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(build_bindir) $(build_libdir))
@@ -848,12 +851,12 @@ else ifeq ($(OS), Darwin)
   RPATH := -Wl,-rpath,'@executable_path/$(build_libdir_rel)'
   RPATH_ORIGIN := -Wl,-rpath,'@loader_path/'
   RPATH_ESCAPED_ORIGIN := $(RPATH_ORIGIN)
-  RPATH_LIB := -Wl,-rpath,'@loader_path/' -Wl,-rpath,'@loader_path/julia/'
+  RPATH_LIB := -Wl,-rpath,'@loader_path/' -Wl,-rpath,'@loader_path/julia/$(VERSDIR)'
 else
   RPATH := -Wl,-rpath,'$$ORIGIN/$(build_libdir_rel)' -Wl,-rpath-link,$(build_shlibdir) -Wl,-z,origin
   RPATH_ORIGIN := -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
   RPATH_ESCAPED_ORIGIN := -Wl,-rpath,'\$$\$$ORIGIN' -Wl,-z,origin
-  RPATH_LIB := -Wl,-rpath,'$$ORIGIN' -Wl,-rpath,'$$ORIGIN/julia' -Wl,-z,origin
+  RPATH_LIB := -Wl,-rpath,'$$ORIGIN' -Wl,-rpath,'$$ORIGIN/julia/$(VERSDIR)' -Wl,-z,origin
 endif
 
 # --whole-archive

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,6 @@
 JULIAHOME := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 include $(JULIAHOME)/Make.inc
 
-# TODO: Code bundled with Julia should be installed into a versioned directory,
-# prefix/share/julia/VERSDIR, so that in the future one can have multiple
-# major versions of Julia installed concurrently. Third-party code that
-# is not controlled by Pkg should be installed into
-# prefix/share/julia/site/VERSDIR (not prefix/share/julia/VERSDIR/site ...
-# so that prefix/share/julia/VERSDIR can be overwritten without touching
-# third-party code).
-VERSDIR := v`cut -d. -f1-2 < $(JULIAHOME)/VERSION`
-
 #file name of make binary-dist result
 ifeq ($(JULIA_BINARYDIST_TARNAME),)
 	JULIA_BINARYDIST_TARNAME := julia-$(JULIA_COMMIT)-$(OS)-$(ARCH)
@@ -326,6 +317,10 @@ endef
 
 install: $(build_depsbindir)/stringreplace $(BUILDROOT)/doc/_build/html
 	@$(MAKE) $(QUIET_MAKE) all
+	# Third-party code that is not controlled by Pkg should be installed into
+	# prefix/share/julia/site/VERSDIR (not prefix/share/julia/VERSDIR/site)
+	# so that prefix/share/julia/VERSDIR can be overwritten without touching
+	# third-party code.
 	@for subdir in $(bindir) $(libexecdir) $(datarootdir)/julia/site/$(VERSDIR) $(docdir) $(man1dir) $(includedir)/julia $(libdir) $(private_libdir) $(sysconfdir); do \
 		mkdir -p $(DESTDIR)$$subdir; \
 	done

--- a/base/Makefile
+++ b/base/Makefile
@@ -66,6 +66,7 @@ endif
 	@echo "const DOCDIR = \"$(docdir_rel)\"" >> $@
 	@echo "const LIBDIR = \"$(libdir_rel)\"" >> $@
 	@echo "const INCLUDEDIR = \"$(includedir_rel)\"" >> $@
+	@echo "const VERSDIR = \"$(VERSDIR)\"" >> $@
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible

--- a/base/client.jl
+++ b/base/client.jl
@@ -270,10 +270,10 @@ end
 function load_juliarc()
     # If the user built us with a specific Base.SYSCONFDIR, check that location first for a juliarc.jl file
     #   If it is not found, then continue on to the relative path based on JULIA_HOME
-    if !isempty(Base.SYSCONFDIR) && isfile(joinpath(JULIA_HOME,Base.SYSCONFDIR,"julia","juliarc.jl"))
-        include(abspath(JULIA_HOME,Base.SYSCONFDIR,"julia","juliarc.jl"))
+    if !isempty(Base.SYSCONFDIR) && isfile(joinpath(JULIA_HOME,Base.SYSCONFDIR,"julia",Base.VERSDIR,"juliarc.jl"))
+        include(abspath(JULIA_HOME,Base.SYSCONFDIR,"julia",Base.VERSDIR,"juliarc.jl"))
     else
-        try_include(abspath(JULIA_HOME,"..","etc","julia","juliarc.jl"))
+        try_include(abspath(JULIA_HOME,"..","etc","julia",Base.VERSDIR,"juliarc.jl"))
     end
     try_include(abspath(homedir(),".juliarc.jl"))
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -36,12 +36,11 @@ const LOAD_PATH = String[]
 
 const LOAD_CACHE_PATH = String[]
 function init_load_path()
-    vers = "v$(VERSION.major).$(VERSION.minor)"
     if haskey(ENV, "JULIA_LOAD_PATH")
         prepend!(LOAD_PATH, split(ENV["JULIA_LOAD_PATH"], @static is_windows() ? ';' : ':'))
     end
-    push!(LOAD_PATH, abspath(JULIA_HOME, "..", "local", "share", "julia", "site", vers))
-    push!(LOAD_PATH, abspath(JULIA_HOME, "..", "share", "julia", "site", vers))
+    push!(LOAD_PATH, abspath(JULIA_HOME, "..", "local", "share", "julia", "site", Base.VERSDIR))
+    push!(LOAD_PATH, abspath(JULIA_HOME, "..", "share", "julia", "site", Base.VERSDIR))
     #push!(LOAD_CACHE_PATH, abspath(JULIA_HOME, "..", "lib", "julia")) #TODO: add a builtin location?
 end
 

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -560,7 +560,7 @@ function runtests(tests = ["all"], numcores = ceil(Int, Sys.CPU_CORES / 2))
     ENV2["JULIA_CPU_CORES"] = "$numcores"
     try
         run(setenv(`$(julia_cmd()) $(joinpath(JULIA_HOME,
-            Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))
+            Base.DATAROOTDIR, "julia", Base.VERSDIR, "test", "runtests.jl")) $tests`, ENV2))
     catch
         buf = PipeBuffer()
         versioninfo(buf)

--- a/test/libdl.jl
+++ b/test/libdl.jl
@@ -31,8 +31,8 @@ else
     dirname(abspath(Libdl.dlpath("libjulia")))
 end
 
-if isfile(joinpath(private_libdir,"julia","libccalltest."*Libdl.dlext))
-    private_libdir = joinpath(private_libdir, "julia")
+if isfile(joinpath(private_libdir, "julia", Base.VERSDIR, "libccalltest."*Libdl.dlext))
+    private_libdir = joinpath(private_libdir, "julia", Base.VERSDIR)
 end
 
 @test !isempty(Libdl.find_library(["libccalltest"], [private_libdir]))


### PR DESCRIPTION
This ensures multiple versions of libjulia can be installed in parallel.

Closes #17666
