### PR TITLE
Doc formatting fixes

### DIFF
--- a/doc/devdocs/ast.rst
+++ b/doc/devdocs/ast.rst
@@ -229,13 +229,13 @@ Calls
 =======================  ====================================
 Input                    AST
 =======================  ====================================
-f(x)                     (call f x)
-f(x, y=1, z=2)           (call f x (kw y 1) (kw z 2))
-f(x; y=1)                (call f (parameters (kw y 1)) x)
-f(x...)                  (call f (... x))
+``f(x)``                 ``(call f x)``
+``f(x, y=1, z=2)``       ``(call f x (kw y 1) (kw z 2))``
+``f(x; y=1)``            ``(call f (parameters (kw y 1)) x)``
+``f(x...)``              ``(call f (... x))``
 =======================  ====================================
 
-``Do`` syntax::
+``do`` syntax::
 
     f(x) do a,b
         body
@@ -258,54 +258,54 @@ Finally, chains of comparisons have their own special expression structure.
 =======================  ====================================
 Input                    AST
 =======================  ====================================
-x+y                      (call + x y)
-a+b+c+d                  (call + a b c d)
-2x                       (call * 2 x)
-a&&b                     (&& a b)
-x += 1                   (+= x 1)
-a ? 1 : 2                (if a 1 2)
-a:b                      (: a b)
-a:b:c                    (: a b c)
-a,b                      (tuple a b)
-a==b                     (comparison a == b)
-1<i<=n                   (comparison 1 < i <= n)
-a.b                      (. a (quote b))
-a.(b)                    (. a b)
+``x+y``                  ``(call + x y)``
+``a+b+c+d``              ``(call + a b c d)``
+``2x``                   ``(call * 2 x)``
+``a&&b``                 ``(&& a b)``
+``x += 1``               ``(+= x 1)``
+``a ? 1 : 2``            ``(if a 1 2)``
+``a:b``                  ``(: a b)``
+``a:b:c``                ``(: a b c)``
+``a,b``                  ``(tuple a b)``
+``a==b``                 ``(comparison a == b)``
+``1<i<=n``               ``(comparison 1 < i <= n)``
+``a.b``                  ``(. a (quote b))``
+``a.(b)``                ``(. a b)``
 =======================  ====================================
 
 Bracketed forms
 ~~~~~~~~~~~~~~~
 
-=======================  ====================================
-Input                    AST
-=======================  ====================================
-a[i]                     (ref a i)
-t[i;j]                   (typed_vcat t i j)
-t[i j]                   (typed_hcat t i j)
-t[a b; c d]              (typed_vcat t (row a b) (row c d))
-a{b}                     (curly a b)
-a{b;c}                   (curly a (parameters c) b)
-[x]                      (vect x)
-[x,y]                    (vect x y)
-[x;y]                    (vcat x y)
-[x y]                    (hcat x y)
-[x y; z t]               (vcat (row x y) (row z t))
-[x for y in z, a in b]   (comprehension x (= y z) (= a b))
-T[x for y in z]          (typed_comprehension T x (= y z))
-(a, b, c)                (tuple a b c)
-(a; b; c)                (block a (block b c))
-=======================  ====================================
+==========================  ======================================
+Input                       AST
+==========================  ======================================
+``a[i]``                    ``(ref a i)``
+``t[i;j]``                  ``(typed_vcat t i j)``
+``t[i j]``                  ``(typed_hcat t i j)``
+``t[a b; c d]``             ``(typed_vcat t (row a b) (row c d))``
+``a{b}``                    ``(curly a b)``
+``a{b;c}``                  ``(curly a (parameters c) b)``
+``[x]``                     ``(vect x)``
+``[x,y]``                   ``(vect x y)``
+``[x;y]``                   ``(vcat x y)``
+``[x y]``                   ``(hcat x y)``
+``[x y; z t]``              ``(vcat (row x y) (row z t))``
+``[x for y in z, a in b]``  ``(comprehension x (= y z) (= a b))``
+``T[x for y in z]``         ``(typed_comprehension T x (= y z))``
+``(a, b, c)``               ``(tuple a b c)``
+``(a; b; c)``               ``(block a (block b c))``
+==========================  ======================================
 
 Macros
 ~~~~~~
 
-=======================  ====================================
+=======================  =======================================
 Input                    AST
-=======================  ====================================
-@m x y                   (macrocall @m x y)
-Base.@m x y              (macrocall (. Base (quote @m)) x y)
-@Base.m x y              (macrocall (. Base (quote @m)) x y)
-=======================  ====================================
+=======================  =======================================
+``@m x y``               ``(macrocall @m x y)``
+``Base.@m x y``          ``(macrocall (. Base (quote @m)) x y)``
+``@Base.m x y``          ``(macrocall (. Base (quote @m)) x y)``
+=======================  =======================================
 
 Strings
 ~~~~~~~
@@ -313,12 +313,12 @@ Strings
 =======================  ====================================
 Input                    AST
 =======================  ====================================
-"a"                      "a"
-x"y"                     (macrocall @x_str "y")
-x"y"z                    (macrocall @x_str "y" "z")
-"x = $x"                 (string "x = " x)
-\`a b c\`                (macrocall @cmd "a b c")
-x ~ distr                (macrocall @~ x distr)
+``"a"``                  ``"a"``
+``x"y"``                 ``(macrocall @x_str "y")``
+``x"y"z``                ``(macrocall @x_str "y" "z")``
+``"x = $x"``             ``(string "x = " x)``
+```a b c```              ``(macrocall @cmd "a b c")``
+``x ~ distr``            ``(macrocall @~ x distr)``
 =======================  ====================================
 
 Doc string syntax::
@@ -326,22 +326,22 @@ Doc string syntax::
     "some docs"
     f(x) = x
 
-parses as ``(macrocall (|.| Base '@doc) "some docs" (= (call f x) (block x)))``
+parses as ``(macrocall (|.| Core '@doc) "some docs" (= (call f x) (block x)))``.
 
 Imports and such
 ~~~~~~~~~~~~~~~~
 
-=======================  ====================================
+=======================  ==============================================
 Input                    AST
-=======================  ====================================
-import a                 (import a)
-import a.b.c             (import a b c)
-import ...a              (import . . . a)
-import a.b, c.d          (toplevel (import a b) (import c d))
-import Base: x           (import Base x)
-import Base: x, y        (toplevel (import Base x) (import Base y))
-export a, b              (export a b)
-=======================  ====================================
+=======================  ==============================================
+``import a``             ``(import a)``
+``import a.b.c``         ``(import a b c)``
+``import ...a``          ``(import . . . a)``
+``import a.b, c.d``      ``(toplevel (import a b) (import c d))``
+``import Base: x``       ``(import Base x)``
+``import Base: x, y``    ``(toplevel (import Base x) (import Base y))``
+``export a, b``          ``(export a b)``
+=======================  ==============================================
 
 Numbers
 ~~~~~~~
@@ -349,13 +349,13 @@ Numbers
 Julia supports more number types than many scheme implementations,
 so not all numbers are represented directly as scheme numbers in the AST.
 
-=======================  ====================================
-Input                    AST
-=======================  ====================================
-11111111111111111111     (macrocall @int128_str "11111111111111111111")
-0xfffffffffffffffff      (macrocall @uint128_str "0xfffffffffffffffff")
-1111...many digits...    (macrocall @big_str "1111....")
-=======================  ====================================
+=========================  ==================================================
+Input                      AST
+=========================  ==================================================
+``11111111111111111111``   ``(macrocall @int128_str "11111111111111111111")``
+``0xfffffffffffffffff``    ``(macrocall @uint128_str "0xfffffffffffffffff")``
+``1111...many digits...``  ``(macrocall @big_str "1111....")``
+=========================  ==================================================
 
 Block forms
 ~~~~~~~~~~~

--- a/doc/manual/documentation.rst
+++ b/doc/manual/documentation.rst
@@ -50,95 +50,95 @@ As in the example above, we recommend following some simple conventions when wri
 documentation:
 
 1. Always show the signature of a function at the top of the documentation,
-with a four-space indent so that it is printed as Julia code.
+   with a four-space indent so that it is printed as Julia code.
 
-  This can be identical to the signature present in the Julia code
-  (like ``mean(x::AbstractArray)``), or a simplified form.
-  Optional arguments should be represented with their default values (i.e. ``f(x, y=1)``)
-  when possible, following the actual Julia syntax. Optional arguments which
-  do not have a default value should be put in brackets (i.e. ``f(x[, y])`` and
-  ``f(x[, y[, z]])``). An alternative solution is to use several lines: one without
-  optional arguments, the other(s) with them. This solution can also be used to document
-  several related methods of a given function. When a function accepts many keyword
-  arguments, only include a ``<keyword arguments>`` placeholder in the signature (i.e.
-  ``f(x; <keyword arguments>)``), and give the complete list under an ``# Arguments``
-  section (see point 4 below).
+   This can be identical to the signature present in the Julia code
+   (like ``mean(x::AbstractArray)``), or a simplified form.
+   Optional arguments should be represented with their default values (i.e. ``f(x, y=1)``)
+   when possible, following the actual Julia syntax. Optional arguments which
+   do not have a default value should be put in brackets (i.e. ``f(x[, y])`` and
+   ``f(x[, y[, z]])``). An alternative solution is to use several lines: one without
+   optional arguments, the other(s) with them. This solution can also be used to document
+   several related methods of a given function. When a function accepts many keyword
+   arguments, only include a ``<keyword arguments>`` placeholder in the signature (i.e.
+   ``f(x; <keyword arguments>)``), and give the complete list under an ``# Arguments``
+   section (see point 4 below).
 
 2. Include a single one-line sentence describing what the function does or what the
-object represents after the simplified signature block. If needed, provide more details
-in a second paragraph, after a blank line.
+   object represents after the simplified signature block. If needed, provide more details
+   in a second paragraph, after a blank line.
 
-  The one-line sentence should use the imperative form ("Do this", "Return that") instead
-  of the third person (do not write "Returns the length...") when documenting functions.
-  It should end with a period. If the meaning of a function cannot be summarized easily,
-  splitting it into separate composable parts could be beneficial (this should not be
-  taken as an absolute requirement for every single case though).
+   The one-line sentence should use the imperative form ("Do this", "Return that") instead
+   of the third person (do not write "Returns the length...") when documenting functions.
+   It should end with a period. If the meaning of a function cannot be summarized easily,
+   splitting it into separate composable parts could be beneficial (this should not be
+   taken as an absolute requirement for every single case though).
 
 3. Do not repeat yourself.
 
-  Since the function name is given by the signature, there is no need to
-  start the documentation with "The function ``bar``...": go straight to the point.
-  Similarly, if the signature specifies the types of the arguments, mentioning them
-  in the description is redundant.
+   Since the function name is given by the signature, there is no need to
+   start the documentation with "The function ``bar``...": go straight to the point.
+   Similarly, if the signature specifies the types of the arguments, mentioning them
+   in the description is redundant.
 
 4. Only provide an argument list when really necessary.
 
-  For simple functions, it is often clearer to mention the role of the arguments directly
-  in the description of the function's purpose. An argument list would only repeat
-  information already provided elsewhere. However, providing an argument list can be a good
-  idea for complex functions with many arguments (in particular keyword arguments).
-  In that case, insert it after the general description of the function, under
-  an ``# Arguments`` header, with one ``*`` bullet for each argument. The list should
-  mention the types and default values (if any) of the arguments::
+   For simple functions, it is often clearer to mention the role of the arguments directly
+   in the description of the function's purpose. An argument list would only repeat
+   information already provided elsewhere. However, providing an argument list can be a good
+   idea for complex functions with many arguments (in particular keyword arguments).
+   In that case, insert it after the general description of the function, under
+   an ``# Arguments`` header, with one ``*`` bullet for each argument. The list should
+   mention the types and default values (if any) of the arguments::
 
-    """
-    ...
-    # Arguments
-    * `n::Integer`: the number of elements to compute.
-    * `dim::Integer=1`: the dimensions along which to perform the computation.
-    ...
-    """
+       """
+       ...
+       # Arguments
+       * `n::Integer`: the number of elements to compute.
+       * `dim::Integer=1`: the dimensions along which to perform the computation.
+       ...
+       """
 
 5. Group examples under an ``# Examples`` section and use ````julia`` blocks instead of
-standard text.
+   standard text.
 
-  Examples should consist of verbatim copies of the Julia REPL, including the ``julia>``
-  prompt (see example above). This will be used in the future to allow running examples
-  automatically and checking that their actual output is consistent with that presented
-  in the documentation (a feature called *doctests*). This way, the code will be tested and
-  examples won't get out of date without notice.
+   Examples should consist of verbatim copies of the Julia REPL, including the ``julia>``
+   prompt (see example above). This will be used in the future to allow running examples
+   automatically and checking that their actual output is consistent with that presented
+   in the documentation (a feature called *doctests*). This way, the code will be tested and
+   examples won't get out of date without notice.
 
 6. Use backticks to identify code and equations.
 
-  Julia identifiers and code excerpts should always appear between backticks `````
-  to enable highlighting. Equations in the LaTeX syntax can be inserted between
-  double backticks ``````. Use Unicode characters rather than their LaTeX escape sequence,
-  i.e. ````α = 1```` rather than :samp:`\`\`\\\\alpha = 1\`\``.
+   Julia identifiers and code excerpts should always appear between backticks `````
+   to enable highlighting. Equations in the LaTeX syntax can be inserted between
+   double backticks ``````. Use Unicode characters rather than their LaTeX escape sequence,
+   i.e. ````α = 1```` rather than :samp:`\`\`\\\\alpha = 1\`\``.
 
 7. Place the starting and ending ``"""`` characters on lines by themselves.
 
-  That is, write::
+   That is, write::
 
-    """
-    ...
+       """
+       ...
 
-    ...
-    """
-    f(x, y) = ...
+       ...
+       """
+       f(x, y) = ...
 
-  rather than::
+   rather than::
 
-    """...
+       """...
 
-    ..."""
-    f(x, y) = ...
+       ..."""
+       f(x, y) = ...
 
-  This makes it more clear where docstrings start and end.
+   This makes it more clear where docstrings start and end.
 
 8. Respect the line length limit used in the surrounding code.
 
-  Docstrings are edited using the same tools as code. Therefore, the same conventions
-  should apply. It it advised to add line breaks after 92 characters.
+   Docstrings are edited using the same tools as code. Therefore, the same conventions
+   should apply. It it advised to add line breaks after 92 characters.
 
 Accessing Documentation
 -----------------------


### PR DESCRIPTION
Wrap all Julia and Lispy syntax in backticks in devdocs/ast.rst for formatting consistency.

Indent an ordered list correctly: Sphinx didn't parse the list correctly since it wasn't consistently indented to line up with the first line of each item.
