### PR TITLE
Moved parallel docs out of helpDB, updated and improved them

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -21,6 +21,15 @@ end
 Channel(sz::Int = DEF_CHANNEL_SZ) = Channel{Any}(sz)
 
 closed_exception() = InvalidStateException("Channel is closed.", :closed)
+
+"""
+    close(c::Channel)
+
+Closes a channel. An exception is thrown by:
+
+* `put!` on a closed channel.
+* `take!` and `fetch` on an empty, closed channel.
+"""
 function close(c::Channel)
     c.state = :closed
     notify_error(c::Channel, closed_exception())
@@ -33,6 +42,11 @@ type InvalidStateException <: Exception
     state::Symbol
 end
 
+"""
+    put!(c::Channel, v)
+
+Appends an item `v` to the channel `c`. Blocks if the channel is full.
+"""
 function put!(c::Channel, v)
     !isopen(c) && throw(closed_exception())
     while length(c.data) == c.sz_max
@@ -50,6 +64,11 @@ function fetch(c::Channel)
     c.data[1]
 end
 
+"""
+    take!(c::Channel)
+
+Removes and returns a value from a `Channel`. Blocks till data is available.
+"""
 function take!(c::Channel)
     wait(c)
     v = shift!(c.data)
@@ -59,6 +78,12 @@ end
 
 shift!(c::Channel) = take!(c)
 
+"""
+    isready(c::Channel)
+
+Determine whether a `Channel` has a value stored to it.
+`isready` on `Channel`s is non-blocking.
+"""
 isready(c::Channel) = n_avail(c) > 0
 
 function wait(c::Channel)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -106,26 +106,6 @@ functionality instead.
 download
 
 """
-    @everywhere
-
-Execute an expression on all processes. Errors on any of the processes are collected into a
-`CompositeException` and thrown. For example :
-
-    @everywhere bar=1
-
-will define `bar` under module `Main` on all processes.
-
-Unlike `@spawn` and `@spawnat`, `@everywhere` does not capture any local variables. Prefixing
-`@everywhere` with `@eval` allows us to broadcast local variables using interpolation :
-
-    foo = 1
-    @eval @everywhere bar=\$foo
-
-
-"""
-:@everywhere
-
-"""
     lstrip(string, [chars])
 
 Return `string` with any leading whitespace removed. If `chars` (a character, or vector or
@@ -209,13 +189,6 @@ Returns the method table for `f`.
 If `types` is specified, returns an array of methods whose types match.
 """
 methods
-
-"""
-    workers()
-
-Returns a list of all worker process identifiers.
-"""
-workers
 
 """
     isinteger(x) -> Bool
@@ -380,45 +353,6 @@ Return a tuple `(I, J, V)` where `I` and `J` are the row and column indexes of t
 values in matrix `A`, and `V` is a vector of the non-zero values.
 """
 findnz
-
-"""
-    Future()
-
-Create a `Future` on the local machine.
-"""
-Future()
-
-"""
-    Future(n)
-
-Create a `Future` on process `n`.
-"""
-Future(::Integer)
-
-"""
-    RemoteChannel()
-
-Make an reference to a `Channel{Any}(1)` on the local machine.
-"""
-RemoteChannel()
-
-"""
-    RemoteChannel(n)
-
-Make an reference to a `Channel{Any}(1)` on process `n`.
-"""
-RemoteChannel(::Integer)
-
-"""
-    RemoteChannel(f::Function, pid)
-
-Create references to remote channels of a specific size and type. `f()` is a function that
-when executed on `pid` must return an implementation of an `AbstractChannel`.
-
-For example, `RemoteChannel(()->Channel{Int}(10), pid)`, will return a reference to a
-channel of type `Int` and size 10 on `pid`.
-"""
-RemoteChannel(f::Function, pid)
 
 """
     foldl(op, v0, itr)
@@ -707,14 +641,6 @@ assert
 Compute the hyperbolic secant of `x`
 """
 sech
-
-"""
-    nworkers()
-
-Get the number of available worker processes. This is one less than `nprocs()`. Equal to
-`nprocs()` if `nprocs() == 1`.
-"""
-nworkers
 
 """
     filemode(file)
@@ -1059,26 +985,11 @@ Scaled modified Bessel function of the second kind of order `nu`, ``K_\\nu(x) e^
 besselkx
 
 """
-    myid()
-
-Get the id of the current process.
-"""
-myid
-
-"""
     oct(n, [pad])
 
 Convert an integer to an octal string, optionally specifying a number of digits to pad to.
 """
 oct
-
-"""
-    timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
-
-Waits till `testcb` returns `true` or for `secs` seconds, whichever is earlier. `testcb` is
-polled every `pollint` seconds.
-"""
-timedwait
 
 """
     sizeof(T)
@@ -1651,16 +1562,6 @@ sum!
 Close an I/O stream. Performs a `flush` first.
 """
 close(stream::IO)
-
-"""
-    close(Channel)
-
-Closes a channel. An exception is thrown by:
-
-* `put!` on a closed channel.
-* `take!` and `fetch` on an empty, closed channel.
-"""
-close(::Channel)
 
 """
     cospi(x)
@@ -2489,13 +2390,6 @@ Returns the index of the current worker into the `pids` vector, i.e., the list o
 mapping the SharedArray
 """
 indexpids
-
-"""
-    remotecall_wait(func, id, args...; kwargs...)
-
-Perform `wait(remotecall(...))` in one message. Keyword arguments, if any, are passed through to `func`.
-"""
-remotecall_wait
 
 """
     append!(collection, collection2) -> collection.
@@ -3758,20 +3652,6 @@ descriptive error string.
 DimensionMismatch
 
 """
-    take!(RemoteChannel)
-
-Fetch a value from a remote channel, also removing it in the process.
-"""
-take!(::RemoteChannel)
-
-"""
-    take!(Channel)
-
-Removes and returns a value from a `Channel`. Blocks till data is available.
-"""
-take!(::Channel)
-
-"""
     sort!(v, [alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
 
 Sort the vector `v` in place. `QuickSort` is used by default for numeric arrays while
@@ -4416,14 +4296,6 @@ Delete the mapping for the given key in a collection, and return the collection.
 delete!
 
 """
-    interrupt([pids...])
-
-Interrupt the current executing task on the specified workers. This is equivalent to
-pressing Ctrl-C on the local machine. If no arguments are given, all workers are interrupted.
-"""
-interrupt
-
-"""
     std(v[, region])
 
 Compute the sample standard deviation of a vector or array `v`, optionally along dimensions
@@ -4771,14 +4643,6 @@ value is a range of indexes where the matching sequence is found, such that `s[s
 `search(string, 'c')` = `index` such that `string[index] == 'c'`, or `0` if unmatched.
 """
 search
-
-"""
-    remotecall_fetch(func, id, args...; kwargs...)
-
-Perform `fetch(remotecall(...))` in one message.  Keyword arguments, if any, are passed through to `func`.
-Any remote exceptions are captured in a `RemoteException` and thrown.
-"""
-remotecall_fetch
 
 """
     contains(haystack, needle)
@@ -5241,13 +5105,6 @@ julia> A
 shift!
 
 """
-    @fetch
-
-Equivalent to `fetch(@spawn expr)`.
-"""
-:@fetch
-
-"""
     spawn(command)
 
 Run a command object asynchronously, returning the resulting `Process` object.
@@ -5646,30 +5503,6 @@ sind
 Return the minimum of the arguments. Operates elementwise over arrays.
 """
 min
-
-"""
-    isready(r::RemoteChannel)
-
-Determine whether a `RemoteChannel` has a value stored to it. Note that this function can
-cause race conditions, since by the time you receive its result it may no longer be true.
-However, it can be safely used on a `Future` since they are assigned only once.
-"""
-isready
-
-"""
-    isready(r::Future)
-
-Determine whether a `Future` has a value stored to it.
-
-If the argument `Future` is owned by a different node, this call will block to wait for the
-answer. It is recommended to wait for `r` in a separate task instead, or to use a local
-`Channel` as a proxy:
-
-    c = Channel(1)
-    @async put!(c, remotecall_fetch(long_computation, p))
-    isready(c)  # will not block
-"""
-    isready(r::Future)
 
 """
     InexactError()
@@ -6368,13 +6201,6 @@ Test whether a number is infinite.
 isinf
 
 """
-    @fetchfrom
-
-Equivalent to `fetch(@spawnat p expr)`.
-"""
-:@fetchfrom
-
-"""
     secd(x)
 
 Compute the secant of `x`, where `x` is in degrees.
@@ -6721,30 +6547,6 @@ An iterator that cycles through `iter` forever.
 cycle
 
 """
-    put!(RemoteChannel, value)
-
-Store a value to the remote channel. If the channel is full, blocks until space is available.
-Returns its first argument.
-"""
-put!(::RemoteChannel, value)
-
-"""
-    put!(Future, value)
-
-Store a value to a future. Future's are write-once remote references. A `put!` on an already
-set `Future` throws an Exception. All asynchronous remote calls return `Future`s and set the
-value to the return value of the call upon completion.
-"""
-put!(::Future, value)
-
-"""
-    put!(Channel, value)
-
-Appends an item to the channel. Blocks if the channel is full.
-"""
-put!(::Channel, value)
-
-"""
     operm(file)
 
 Like uperm but gets the permissions for people who neither own the file nor are a member of
@@ -6760,13 +6562,6 @@ to use a preallocated output array, both for performance and to control the prec
 output (e.g. to avoid overflow).
 """
 cumsum
-
-"""
-    rmprocs(pids...)
-
-Removes the specified workers.
-"""
-rmprocs
 
 """
     rpad(string, n, p)
@@ -6862,13 +6657,6 @@ Base.:(*)(s::AbstractString, t::AbstractString)
 Get the system time in seconds since the epoch, with fairly high (typically, microsecond) resolution.
 """
 time()
-
-"""
-    procs()
-
-Returns a list of all process identifiers.
-"""
-procs
 
 """
     procs(S::SharedArray)
@@ -7527,13 +7315,6 @@ retrieved by accessing `m.match` and the captured sequences can be retrieved by 
 match
 
 """
-    nprocs()
-
-Get the number of available processes.
-"""
-nprocs
-
-"""
     Ac_mul_B(A, B)
 
 For matrices or vectors ``A`` and ``B``, calculates ``Aᴴ⋅B``.
@@ -7611,14 +7392,6 @@ result is a `Vector{UInt8,1}`.
 readavailable
 
 """
-    remotecall(func, id, args...; kwargs...)
-
-Call a function asynchronously on the given arguments on the specified process. Returns a `Future`.
-Keyword arguments, if any, are passed through to `func`.
-"""
-remotecall
-
-"""
     slicedim(A, d, i)
 
 Return all the data of `A` where the index for dimension `d` equals `i`. Equivalent to
@@ -7640,14 +7413,6 @@ isa
 Less-than-or-equals comparison operator.
 """
 Base.:(<=)
-
-"""
-    ProcessExitedException()
-
-After a client Julia process has exited, further attempts to reference the dead child will
-throw this exception.
-"""
-ProcessExitedException
 
 """
     unsafe_load(p::Ptr{T}, [i::Integer=1])
@@ -8014,20 +7779,6 @@ Find the next index >= `i` of an element of `A` equal to `v` (using `==`), or `0
 findnext(A,v,i)
 
 """
-    fetch(x)
-
-Waits and fetches a value from `x` depending on the type of `x`. Does not remove the item fetched:
-
-* `Future`: Wait for and get the value of a Future. The fetched value is cached locally.
-  Further calls to `fetch` on the same reference return the cached value. If the remote value
-  is an exception, throws a `RemoteException` which captures the remote exception and backtrace.
-* `RemoteChannel`: Wait for and get the value of a remote reference. Exceptions raised are
-  same as for a `Future` .
-* `Channel` : Wait for and get the first available item from the channel.
-"""
-fetch
-
-"""
     angle(z)
 
 Compute the phase angle in radians of a complex number `z`.
@@ -8211,29 +7962,6 @@ julia> map(+, [1, 2, 3], [10, 20, 30])
 ```
 """
 map
-
-"""
-    @parallel
-
-A parallel for loop of the form :
-
-    @parallel [reducer] for var = range
-        body
-    end
-
-The specified range is partitioned and locally executed across all workers. In case an
-optional reducer function is specified, `@parallel` performs local reductions on each worker
-with a final reduction on the calling process.
-
-Note that without a reducer function, `@parallel` executes asynchronously, i.e. it spawns
-independent tasks on all available workers and returns immediately without waiting for
-completion. To wait for completion, prefix the call with `@sync`, like :
-
-    @sync @parallel for var = range
-        body
-    end
-"""
-:@parallel
 
 """
     throw(e)
@@ -9318,36 +9046,3 @@ Base.:$(x, y)
 Get the IP address and the port that the given TCP socket is connected to (or bound to, in the case of TCPServer).
 """
 getsockname
-
-"""
-    Base.remoteref_id(r::AbstractRemoteRef) -> (whence, id)
-
-A low-level API which returns the unique identifying tuple for a remote reference. A
-reference id is a tuple of two elements - pid where the reference was created from and a
-one-up number from that node.
-"""
-Base.remoteref_id
-
-"""
-    Base.channel_from_id(refid) -> c
-
-A low-level API which returns the backing AbstractChannel for an id returned by
-`remoteref_id`. The call is valid only on the node where the backing channel exists.
-"""
-Base.channel_from_id
-
-"""
-    Base.worker_id_from_socket(s::IO) -> pid
-
-A low-level API which given a `IO` connection, returns the pid of the worker it is connected
-to. This is useful when writing custom `serialize` methods for a type, which optimizes the
-data written out depending on the receiving process id.
-"""
-Base.worker_id_from_socket
-
-"""
-    Base.cluster_cookie([cookie]) -> cookie
-
-Returns the cluster cookie. If a cookie is passed, also sets it as the cluster cookie.
-"""
-Base.cluster_cookie

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -90,7 +90,7 @@ Keyword arguments:
   + `topology=:all_to_all`  :  All processes are connected to each other.
                       This is the default.
 
-  + `topology=:master_slave`  :  Only the driver process, i.e. pid 1 connects to the
+  + `topology=:master_slave`  :  Only the driver process, i.e. `pid` 1 connects to the
                         workers. The workers do not connect to each other.
 
   + `topology=:custom`  :  The `launch` method of the cluster manager specifes the
@@ -104,7 +104,7 @@ Environment variables :
 If the master process fails to establish a connection with a newly launched worker within
 60.0 seconds, the worker treats it as a fatal situation and terminates.
 This timeout can be controlled via environment variable `JULIA_WORKER_TIMEOUT`.
-The value of JULIA_WORKER_TIMEOUT` on the master process specifies the number of seconds a
+The value of `JULIA_WORKER_TIMEOUT` on the master process specifies the number of seconds a
 newly launched worker waits for connection establishment.
 """
 function addprocs(machines::AbstractVector; tunnel=false, sshflags=``, max_parallel=10, kwargs...)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -471,8 +471,8 @@ procs() = Int[x.id for x in PGRP.workers]
 """
     procs(pid::Integer)
 
-Returns a list of all process identifiers visible to worker `pid`.
-The result depends on the topology of the workgroup.
+Returns a list of all process identifiers on the same physical node.
+Specifically all workers bound to the same ip-address as `pid` are returned.
 """
 function procs(pid::Integer)
     if myid() == 1
@@ -578,7 +578,7 @@ end
     Base.worker_id_from_socket(s) -> pid
 
 A low-level API which given a `IO` connection or a `Worker`,
-returns the pid of the worker it is connected to.
+returns the `pid` of the worker it is connected to.
 This is useful when writing custom `serialize` methods for a type,
 which optimizes the data written out depending on the receiving process id.
 """
@@ -980,10 +980,9 @@ end
 """
     RemoteException(captured)
 
-Contains the `CapturedException` `captured`, which was
-generated on a worker and can be passed back to the first
-process as a result of `pmap` or other calls to workers
-(e.g. `remotecall_fetch`).
+Exceptions  on remote computations are captured and rethrown locally.  A `RemoteException`
+wraps the pid of the worker and a captured exception. A `CapturedException` captures the
+remote exception and a serializable form of the call stack when the exception was raised.
 """
 RemoteException(captured) = RemoteException(myid(), captured)
 function showerror(io::IO, re::RemoteException)

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -986,7 +986,7 @@ Keyword argument ``topology`` to ``addprocs`` is used to specify how the workers
 
 - ``:all_to_all`` : is the default, where all workers are connected to each other.
 
-- ``:master_slave`` : only the driver process, i.e. `pid` 1 has connections to the workers.
+- ``:master_slave`` : only the driver process, i.e. ``pid`` 1 has connections to the workers.
 
 - ``:custom`` : the ``launch`` method of the cluster manager specifies the connection topology.
   Fields ``ident`` and ``connect_idents`` in ``WorkerConfig`` are used to specify the  same.

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -217,6 +217,12 @@ General Parallel Computing Support
 
    Returns a list of all process identifiers.
 
+.. function:: procs(pid::Integer)
+
+   .. Docstring generated from Julia source
+
+   Returns a list of all process identifiers visible to worker ``pid``\ . The result depends on the topology of the workgroup.
+
 .. function:: workers()
 
    .. Docstring generated from Julia source
@@ -280,18 +286,6 @@ General Parallel Computing Support
    * ``pmap(f, c; distributed=false)`` and ``asyncmap(f,c)``
    * ``pmap(f, c; retry_n=1)`` and ``asyncmap(retry(remote(f)),c)``
    * ``pmap(f, c; retry_n=1, on_error=e->e)`` and ``asyncmap(x->try retry(remote(f))(x) catch e; e end, c)``
-
-.. function:: remotecall(f, w::LocalProcess, args...; kwargs...) -> Future
-
-   .. Docstring generated from Julia source
-
-   Call a function ``f`` asynchronously on the given arguments on the specified ``LocalProcess``\ . Returns a ``Future``\ . Keyword arguments, if any, are passed through to ``f``\ .
-
-.. function:: remotecall(f, w::Worker, args...; kwargs...) -> Future
-
-   .. Docstring generated from Julia source
-
-   Call a function ``f`` asynchronously on the given arguments on the specified ``Worker``\ . Returns a ``Future``\ . Keyword arguments, if any, are passed through to ``f``\ .
 
 .. function:: remotecall(f, id::Integer, args...; kwargs...) -> Future
 
@@ -363,35 +357,11 @@ General Parallel Computing Support
    * ``RemoteChannel``\ : Wait for and get the value of a remote reference. Exceptions raised are same as for a ``Future`` .
    * ``Channel`` : Wait for and get the first available item from the channel.
 
-.. function:: remotecall_wait(f, w::LocalProcess, args...; kwargs...)
-
-   .. Docstring generated from Julia source
-
-   Perform ``wait(remotecall(...))`` in one message on ``LocalProcess`` ``w``\ . Keyword arguments, if any, are passed through to ``f``\ .
-
-.. function:: remotecall_wait(f, w::Worker, args...; kwargs...)
-
-   .. Docstring generated from Julia source
-
-   Perform a faster ``wait(remotecall(...))`` in one message on ``Worker`` ``w``\ . Keyword arguments, if any, are passed through to ``f``\ .
-
 .. function:: remotecall_wait(f, id::Integer, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
    Perform a faster ``wait(remotecall(...))`` in one message on the ``Worker`` specified by worker id ``id``\ . Keyword arguments, if any, are passed through to ``f``\ .
-
-.. function:: remotecall_fetch(f, w::LocalProcess, args...; kwargs...)
-
-   .. Docstring generated from Julia source
-
-   Perform a faster ``fetch(remotecall(...))`` in one message. Keyword arguments, if any, are passed through to ``f``\ . Any remote exceptions are captured in a ``RemoteException`` and thrown.
-
-.. function:: remotecall_fetch(f, w::Worker, args...; kwargs...)
-
-   .. Docstring generated from Julia source
-
-   Perform a faster ``fetch(remotecall(...))`` in one message. Keyword arguments, if any, are passed through to ``f``\ . Any remote exceptions are captured in a ``RemoteException`` and thrown.
 
 .. function:: remotecall_fetch(f, id::Integer, args...; kwargs...)
 
@@ -428,6 +398,12 @@ General Parallel Computing Support
    .. Docstring generated from Julia source
 
    Removes and returns a value from a ``Channel``\ . Blocks till data is available.
+
+.. function:: isready(c::Channel)
+
+   .. Docstring generated from Julia source
+
+   Determine whether a ``Channel`` has a value stored to it. ``isready`` on ``Channel``\ s is non-blocking.
 
 .. function:: isready(rr::RemoteChannel, args...)
 
@@ -615,7 +591,7 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   A low-level API which returns the backing ``AbstractChannel`` for an ``id`` returned by ``remoteref_id``\ . The call is valid only on the node where the backing channel exists.
+   A low-level API which returns the backing ``AbstractChannel`` for an ``id`` returned by :func:`Base.remoteref_id`\ . The call is valid only on the node where the backing channel exists.
 
 .. function:: Base.worker_id_from_socket(s) -> pid
 
@@ -627,7 +603,7 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   Returns the cluster cookie, by default the ``LocalProcess`` cookie.
+   Returns the cluster cookie.
 
 .. function:: Base.cluster_cookie(cookie) -> cookie
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -223,13 +223,19 @@ General Parallel Computing Support
 
    Returns a list of all worker process identifiers.
 
-.. function:: rmprocs(pids...)
+.. function:: rmprocs(pids...; waitfor=0.0)
 
    .. Docstring generated from Julia source
 
-   Removes the specified workers.
+   Removes the specified workers. Note that only process 1 can add or remove workers - if another worker tries to call ``rmprocs``\ , an error will be thrown. The optional argument ``waitfor`` determines how long the first process will wait for the workers to shut down.
 
-.. function:: interrupt([pids...])
+.. function:: interrupt(pids::AbstractVector=workers())
+
+   .. Docstring generated from Julia source
+
+   Interrupt the current executing task on the specified workers. This is equivalent to pressing Ctrl-C on the local machine. If no arguments are given, all workers are interrupted.
+
+.. function:: interrupt(pids::Integer...)
 
    .. Docstring generated from Julia source
 
@@ -275,11 +281,23 @@ General Parallel Computing Support
    * ``pmap(f, c; retry_n=1)`` and ``asyncmap(retry(remote(f)),c)``
    * ``pmap(f, c; retry_n=1, on_error=e->e)`` and ``asyncmap(x->try retry(remote(f))(x) catch e; e end, c)``
 
-.. function:: remotecall(func, id, args...; kwargs...)
+.. function:: remotecall(f, w::LocalProcess, args...; kwargs...) -> Future
 
    .. Docstring generated from Julia source
 
-   Call a function asynchronously on the given arguments on the specified process. Returns a ``Future``\ . Keyword arguments, if any, are passed through to ``func``\ .
+   Call a function ``f`` asynchronously on the given arguments on the specified ``LocalProcess``\ . Returns a ``Future``\ . Keyword arguments, if any, are passed through to ``f``\ .
+
+.. function:: remotecall(f, w::Worker, args...; kwargs...) -> Future
+
+   .. Docstring generated from Julia source
+
+   Call a function ``f`` asynchronously on the given arguments on the specified ``Worker``\ . Returns a ``Future``\ . Keyword arguments, if any, are passed through to ``f``\ .
+
+.. function:: remotecall(f, id::Integer, args...; kwargs...) -> Future
+
+   .. Docstring generated from Julia source
+
+   Call a function ``f`` asynchronously on the given arguments on the specified process. Returns a ``Future``\ . Keyword arguments, if any, are passed through to ``f``\ .
 
 .. function:: Base.process_messages(r_stream::IO, w_stream::IO, incoming::Bool=true)
 
@@ -289,35 +307,33 @@ General Parallel Computing Support
 
 .. function:: Future()
 
-   .. Docstring generated from Julia source
-
-   Create a ``Future`` on the local machine.
-
-.. function:: Future(n)
+.. function:: RemoteException(captured)
 
    .. Docstring generated from Julia source
 
-   Create a ``Future`` on process ``n``\ .
+   Contains the ``CapturedException`` ``captured``\ , which was generated on a worker and can be passed back to the first process as a result of ``pmap`` or other calls to workers (e.g. ``remotecall_fetch``\ ).
 
-.. function:: RemoteChannel()
-
-   .. Docstring generated from Julia source
-
-   Make an reference to a ``Channel{Any}(1)`` on the local machine.
-
-.. function:: RemoteChannel(n)
+.. function:: Future(pid::Integer=myid())
 
    .. Docstring generated from Julia source
 
-   Make an reference to a ``Channel{Any}(1)`` on process ``n``\ .
+   Create a ``Future`` on process ``pid``\ . The default ``pid`` is the current process.
 
-.. function:: RemoteChannel(f::Function, pid)
+.. function:: RemoteChannel(pid::Integer=myid())
+
+   .. Docstring generated from Julia source
+
+   Make a reference to a ``Channel{Any}(1)`` on process ``pid``\ . The default ``pid`` is the current process.
+
+.. function:: RemoteChannel(f::Function, pid::Integer=myid())
 
    .. Docstring generated from Julia source
 
    Create references to remote channels of a specific size and type. ``f()`` is a function that when executed on ``pid`` must return an implementation of an ``AbstractChannel``\ .
 
    For example, ``RemoteChannel(()->Channel{Int}(10), pid)``\ , will return a reference to a channel of type ``Int`` and size 10 on ``pid``\ .
+
+   The default ``pid`` is the current process.
 
 .. function:: wait([x])
 
@@ -347,61 +363,85 @@ General Parallel Computing Support
    * ``RemoteChannel``\ : Wait for and get the value of a remote reference. Exceptions raised are same as for a ``Future`` .
    * ``Channel`` : Wait for and get the first available item from the channel.
 
-.. function:: remotecall_wait(func, id, args...; kwargs...)
+.. function:: remotecall_wait(f, w::LocalProcess, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
-   Perform ``wait(remotecall(...))`` in one message. Keyword arguments, if any, are passed through to ``func``\ .
+   Perform ``wait(remotecall(...))`` in one message on ``LocalProcess`` ``w``\ . Keyword arguments, if any, are passed through to ``f``\ .
 
-.. function:: remotecall_fetch(func, id, args...; kwargs...)
-
-   .. Docstring generated from Julia source
-
-   Perform ``fetch(remotecall(...))`` in one message.  Keyword arguments, if any, are passed through to ``func``\ . Any remote exceptions are captured in a ``RemoteException`` and thrown.
-
-.. function:: put!(RemoteChannel, value)
+.. function:: remotecall_wait(f, w::Worker, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
-   Store a value to the remote channel. If the channel is full, blocks until space is available. Returns its first argument.
+   Perform a faster ``wait(remotecall(...))`` in one message on ``Worker`` ``w``\ . Keyword arguments, if any, are passed through to ``f``\ .
 
-.. function:: put!(Future, value)
-
-   .. Docstring generated from Julia source
-
-   Store a value to a future. Future's are write-once remote references. A ``put!`` on an already set ``Future`` throws an Exception. All asynchronous remote calls return ``Future``\ s and set the value to the return value of the call upon completion.
-
-.. function:: put!(Channel, value)
+.. function:: remotecall_wait(f, id::Integer, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
-   Appends an item to the channel. Blocks if the channel is full.
+   Perform a faster ``wait(remotecall(...))`` in one message on the ``Worker`` specified by worker id ``id``\ . Keyword arguments, if any, are passed through to ``f``\ .
 
-.. function:: take!(RemoteChannel)
+.. function:: remotecall_fetch(f, w::LocalProcess, args...; kwargs...)
 
    .. Docstring generated from Julia source
 
-   Fetch a value from a remote channel, also removing it in the process.
+   Perform a faster ``fetch(remotecall(...))`` in one message. Keyword arguments, if any, are passed through to ``f``\ . Any remote exceptions are captured in a ``RemoteException`` and thrown.
 
-.. function:: take!(Channel)
+.. function:: remotecall_fetch(f, w::Worker, args...; kwargs...)
+
+   .. Docstring generated from Julia source
+
+   Perform a faster ``fetch(remotecall(...))`` in one message. Keyword arguments, if any, are passed through to ``f``\ . Any remote exceptions are captured in a ``RemoteException`` and thrown.
+
+.. function:: remotecall_fetch(f, id::Integer, args...; kwargs...)
+
+   .. Docstring generated from Julia source
+
+   Perform ``fetch(remotecall(...))`` in one message. Keyword arguments, if any, are passed through to ``f``\ . Any remote exceptions are captured in a ``RemoteException`` and thrown.
+
+.. function:: put!(rr::RemoteChannel, args...)
+
+   .. Docstring generated from Julia source
+
+   Store a set of values to the ``RemoteChannel``\ . If the channel is full, blocks until space is available. Returns its first argument.
+
+.. function:: put!(rr::Future, v)
+
+   .. Docstring generated from Julia source
+
+   Store a value to a ``Future`` ``rr``\ . ``Future``\ s are write-once remote references. A ``put!`` on an already set ``Future`` throws an ``Exception``\ . All asynchronous remote calls return ``Future``\ s and set the value to the return value of the call upon completion.
+
+.. function:: put!(c::Channel, v)
+
+   .. Docstring generated from Julia source
+
+   Appends an item ``v`` to the channel ``c``\ . Blocks if the channel is full.
+
+.. function:: take!(rr::RemoteChannel, args...)
+
+   .. Docstring generated from Julia source
+
+   Fetch value(s) from a remote channel, removing the value(s) in the processs.
+
+.. function:: take!(c::Channel)
 
    .. Docstring generated from Julia source
 
    Removes and returns a value from a ``Channel``\ . Blocks till data is available.
 
-.. function:: isready(r::RemoteChannel)
+.. function:: isready(rr::RemoteChannel, args...)
 
    .. Docstring generated from Julia source
 
    Determine whether a ``RemoteChannel`` has a value stored to it. Note that this function can cause race conditions, since by the time you receive its result it may no longer be true. However, it can be safely used on a ``Future`` since they are assigned only once.
 
-.. function:: isready(r::Future)
+.. function:: isready(rr::Future)
 
    .. Docstring generated from Julia source
 
    Determine whether a ``Future`` has a value stored to it.
 
-   If the argument ``Future`` is owned by a different node, this call will block to wait for the answer. It is recommended to wait for ``r`` in a separate task instead, or to use a local ``Channel`` as a proxy:
+   If the argument ``Future`` is owned by a different node, this call will block to wait for the answer. It is recommended to wait for ``rr`` in a separate task instead or to use a local ``Channel`` as a proxy:
 
    .. code-block:: julia
 
@@ -409,7 +449,7 @@ General Parallel Computing Support
        @async put!(c, remotecall_fetch(long_computation, p))
        isready(c)  # will not block
 
-.. function:: close(Channel)
+.. function:: close(c::Channel)
 
    .. Docstring generated from Julia source
 
@@ -569,25 +609,31 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   A low-level API which returns the unique identifying tuple for a remote reference. A reference id is a tuple of two elements - pid where the reference was created from and a one-up number from that node.
+   A low-level API which returns the unique identifying tuple for a remote reference. A reference id is a tuple of two elements - ``pid`` where the reference was created from and a one-up number from that node.
 
-.. function:: Base.channel_from_id(refid) -> c
-
-   .. Docstring generated from Julia source
-
-   A low-level API which returns the backing AbstractChannel for an id returned by ``remoteref_id``\ . The call is valid only on the node where the backing channel exists.
-
-.. function:: Base.worker_id_from_socket(s::IO) -> pid
+.. function:: Base.channel_from_id(id) -> c
 
    .. Docstring generated from Julia source
 
-   A low-level API which given a ``IO`` connection, returns the pid of the worker it is connected to. This is useful when writing custom ``serialize`` methods for a type, which optimizes the data written out depending on the receiving process id.
+   A low-level API which returns the backing ``AbstractChannel`` for an ``id`` returned by ``remoteref_id``\ . The call is valid only on the node where the backing channel exists.
 
-.. function:: Base.cluster_cookie([cookie]) -> cookie
+.. function:: Base.worker_id_from_socket(s) -> pid
 
    .. Docstring generated from Julia source
 
-   Returns the cluster cookie. If a cookie is passed, also sets it as the cluster cookie.
+   A low-level API which given a ``IO`` connection or a ``Worker``\ , returns the pid of the worker it is connected to. This is useful when writing custom ``serialize`` methods for a type, which optimizes the data written out depending on the receiving process id.
+
+.. function:: Base.cluster_cookie() -> cookie
+
+   .. Docstring generated from Julia source
+
+   Returns the cluster cookie, by default the ``LocalProcess`` cookie.
+
+.. function:: Base.cluster_cookie(cookie) -> cookie
+
+   .. Docstring generated from Julia source
+
+   Sets the passed cookie as the cluster cookie, then returns it.
 
 Shared Arrays
 -------------

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -182,12 +182,12 @@ General Parallel Computing Support
    * ``topology``\ : Specifies how the workers connect to each other. Sending a message           between unconnected workers results in an error.
 
      * ``topology=:all_to_all``  :  All processes are connected to each other.                   This is the default.
-     * ``topology=:master_slave``  :  Only the driver process, i.e. pid 1 connects to the                     workers. The workers do not connect to each other.
+     * ``topology=:master_slave``  :  Only the driver process, i.e. ``pid`` 1 connects to the                     workers. The workers do not connect to each other.
      * ``topology=:custom``  :  The ``launch`` method of the cluster manager specifes the               connection topology via fields ``ident`` and ``connect_idents`` in               ``WorkerConfig``\ . A worker with a cluster manager identity ``ident``               will connect to all workers specified in ``connect_idents``\ .
 
    Environment variables :
 
-   If the master process fails to establish a connection with a newly launched worker within 60.0 seconds, the worker treats it as a fatal situation and terminates. This timeout can be controlled via environment variable ``JULIA_WORKER_TIMEOUT``\ . The value of JULIA_WORKER_TIMEOUT` on the master process specifies the number of seconds a newly launched worker waits for connection establishment.
+   If the master process fails to establish a connection with a newly launched worker within 60.0 seconds, the worker treats it as a fatal situation and terminates. This timeout can be controlled via environment variable ``JULIA_WORKER_TIMEOUT``\ . The value of ``JULIA_WORKER_TIMEOUT`` on the master process specifies the number of seconds a newly launched worker waits for connection establishment.
 
 .. function:: addprocs(manager::ClusterManager; kwargs...) -> List of process identifiers
 
@@ -221,7 +221,7 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   Returns a list of all process identifiers visible to worker ``pid``\ . The result depends on the topology of the workgroup.
+   Returns a list of all process identifiers on the same physical node. Specifically all workers bound to the same ip-address as ``pid`` are returned.
 
 .. function:: workers()
 
@@ -299,13 +299,11 @@ General Parallel Computing Support
 
    Called by cluster managers using custom transports. It should be called when the custom transport implementation receives the first message from a remote worker. The custom transport must manage a logical connection to the remote worker and provide two ``IO`` objects, one for incoming messages and the other for messages addressed to the remote worker. If ``incoming`` is ``true``\ , the remote peer initiated the connection. Whichever of the pair initiates the connection sends the cluster cookie and its Julia version number to perform the authentication handshake.
 
-.. function:: Future()
-
 .. function:: RemoteException(captured)
 
    .. Docstring generated from Julia source
 
-   Contains the ``CapturedException`` ``captured``\ , which was generated on a worker and can be passed back to the first process as a result of ``pmap`` or other calls to workers (e.g. ``remotecall_fetch``\ ).
+   Exceptions  on remote computations are captured and rethrown locally.  A ``RemoteException`` wraps the pid of the worker and a captured exception. A ``CapturedException`` captures the remote exception and a serializable form of the call stack when the exception was raised.
 
 .. function:: Future(pid::Integer=myid())
 
@@ -581,11 +579,21 @@ General Parallel Computing Support
 
    Removes all cached functions from all participating workers.
 
-.. function:: Base.remoteref_id(r::AbstractRemoteRef) -> (whence, id)
+.. function:: Base.remoteref_id(r::AbstractRemoteRef) -> RRID
 
    .. Docstring generated from Julia source
 
-   A low-level API which returns the unique identifying tuple for a remote reference. A reference id is a tuple of two elements - ``pid`` where the reference was created from and a one-up number from that node.
+   ``Future``\ s and ``RemoteChannel``\ s are identified by fields:
+
+   ``where`` - refers to the node where the underlying object/storage referred to by the reference actually exists.
+
+   ``whence`` - refers to the node the remote reference was created from.  Note that this is different from the node where the underlying object  referred to actually exists. For example calling ``RemoteChannel(2)``  from the master process would result in a ``where`` value of 2 and  a ``whence`` value of 1.
+
+   ``id`` is unique across all references created from the worker specified by ``whence``\ .
+
+   Taken together,  ``whence`` and ``id`` uniquely identify a reference across all workers.
+
+   ``Base.remoteref_id`` is a low-level API which returns a ``Base.RRID``  object that wraps ``whence`` and ``id`` values of a remote reference.
 
 .. function:: Base.channel_from_id(id) -> c
 
@@ -597,7 +605,7 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   A low-level API which given a ``IO`` connection or a ``Worker``\ , returns the pid of the worker it is connected to. This is useful when writing custom ``serialize`` methods for a type, which optimizes the data written out depending on the receiving process id.
+   A low-level API which given a ``IO`` connection or a ``Worker``\ , returns the ``pid`` of the worker it is connected to. This is useful when writing custom ``serialize`` methods for a type, which optimizes the data written out depending on the receiving process id.
 
 .. function:: Base.cluster_cookie() -> cookie
 


### PR DESCRIPTION
Moved a bunch of docstrings inline. Changed things to reflect
the code that's actually in `multi.jl`. Documented `RemoteException`.

cc: @amitmurthy (again, sorry!)
