### PR TITLE
Don't zero `usesshagent`

### DIFF
--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -730,7 +730,6 @@ reset!(p::UserPasswordCredentials, cnt::Int=3) = (p.count = cnt)
 function securezero!(cred::UserPasswordCredentials)
     securezero!(cred.user)
     securezero!(cred.pass)
-    securezero!(cred.usesshagent)
     cred.count = 0
     return cred
 end
@@ -755,7 +754,6 @@ function securezero!(cred::SSHCredentials)
     securezero!(cred.pass)
     securezero!(cred.pubkey)
     securezero!(cred.prvkey)
-    securezero!(cred.usesshagent)
     return cred
 end
 


### PR DESCRIPTION
`usesshagent` is just a flag to determine whether or not to use the agent, so
zeroing it isn't necessary. Even worse, since it only gets a reference to one
of the flag strings (stored in the AST), zeroing them globally changes those
strings, disabling ssh-agent authentication entirely.

Fixes the problem noted in #16041.

cc @stevengj
