### PR TITLE
Fix #17675 (concatenations involving special matrices) and #17738 (concatenations involving sparse vectors)

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -3264,41 +3264,6 @@ function hcat(X::SparseMatrixCSC...)
     SparseMatrixCSC(m, n, colptr, rowval, nzval)
 end
 
-
-# Sparse/special/dense concatenation
-
-# TODO: A similar definition also exists in base/linalg/bidiag.jl. These definitions should
-# be consolidated in a more appropriate location, for example base/linalg/special.jl.
-SpecialArrays = Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}
-
-function hcat(Xin::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
-    X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
-    hcat(X...)
-end
-
-function vcat(Xin::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
-    X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
-    vcat(X...)
-end
-
-function hvcat(rows::Tuple{Vararg{Int}}, X::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
-    nbr = length(rows)  # number of block rows
-
-    tmp_rows = Array{SparseMatrixCSC}(nbr)
-    k = 0
-    @inbounds for i = 1 : nbr
-        tmp_rows[i] = hcat(X[(1 : rows[i]) + k]...)
-        k += rows[i]
-    end
-    vcat(tmp_rows...)
-end
-
-function cat(catdims, Xin::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
-    X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
-    T = promote_eltype(Xin...)
-    Base.cat_t(catdims, T, X...)
-end
-
 """
     blkdiag(A...)
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -3265,19 +3265,23 @@ function hcat(X::SparseMatrixCSC...)
 end
 
 
-# Sparse/dense concatenation
+# Sparse/special/dense concatenation
 
-function hcat(Xin::Union{Vector, Matrix, SparseMatrixCSC}...)
+# TODO: A similar definition also exists in base/linalg/bidiag.jl. These definitions should
+# be consolidated in a more appropriate location, for example base/linalg/special.jl.
+SpecialArrays = Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}
+
+function hcat(Xin::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
     X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
     hcat(X...)
 end
 
-function vcat(Xin::Union{Vector, Matrix, SparseMatrixCSC}...)
+function vcat(Xin::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
     X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
     vcat(X...)
 end
 
-function hvcat(rows::Tuple{Vararg{Int}}, X::Union{Vector, Matrix, SparseMatrixCSC}...)
+function hvcat(rows::Tuple{Vararg{Int}}, X::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
     nbr = length(rows)  # number of block rows
 
     tmp_rows = Array{SparseMatrixCSC}(nbr)
@@ -3289,7 +3293,7 @@ function hvcat(rows::Tuple{Vararg{Int}}, X::Union{Vector, Matrix, SparseMatrixCS
     vcat(tmp_rows...)
 end
 
-function cat(catdims, Xin::Union{Vector, Matrix, SparseMatrixCSC}...)
+function cat(catdims, Xin::Union{Vector, Matrix, SparseMatrixCSC, SpecialArrays}...)
     X = SparseMatrixCSC[issparse(x) ? x : sparse(x) for x in Xin]
     T = promote_eltype(Xin...)
     Base.cat_t(catdims, T, X...)

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -404,6 +404,41 @@ let m = 80, n = 100
     @test full(V) == Vr
 end
 
+# Test that concatenations of combinations of sparse vectors with various other
+# matrix/vector types yield sparse arrays
+let
+    N = 4
+    spvec = spzeros(N)
+    spmat = spzeros(N, 1)
+    densevec = ones(N)
+    densemat = ones(N, 1)
+    diagmat = Diagonal(ones(4))
+    # Test that concatenations of pairwise combinations of sparse vectors with dense
+    # vectors/matrices, sparse matrices, or special matrices yield sparse arrays
+    for othervecormat in (densevec, densemat, spmat)
+        @test issparse(vcat(spvec, othervecormat))
+        @test issparse(vcat(othervecormat, spvec))
+    end
+    for othervecormat in (densevec, densemat, spmat, diagmat)
+        @test issparse(hcat(spvec, othervecormat))
+        @test issparse(hcat(othervecormat, spvec))
+        @test issparse(hvcat((2,), spvec, othervecormat))
+        @test issparse(hvcat((2,), othervecormat, spvec))
+        @test issparse(cat((1,2), spvec, othervecormat))
+        @test issparse(cat((1,2), othervecormat, spvec))
+    end
+    # The preceding tests should cover multi-way combinations of those types, but for good
+    # measure test a few multi-way combinations involving those types
+    @test issparse(vcat(spvec, densevec, spmat, densemat))
+    @test issparse(vcat(densevec, spvec, densemat, spmat))
+    @test issparse(hcat(spvec, densemat, spmat, densevec, diagmat))
+    @test issparse(hcat(densemat, spmat, spvec, densevec, diagmat))
+    @test issparse(hvcat((5,), diagmat, densevec, spvec, densemat, spmat))
+    @test issparse(hvcat((5,), spvec, densemat, diagmat, densevec, spmat))
+    @test issparse(cat((1,2), densemat, diagmat, spmat, densevec, spvec))
+    @test issparse(cat((1,2), spvec, diagmat, densevec, spmat, densemat))
+end
+
 
 ## sparsemat: combinations with sparse matrix
 


### PR DESCRIPTION
This pull request's first commit addresses JuliaLang/LinearAlgebra.jl#349 by making `hcat`, `vcat`, `hvcat`, and `cat` yield sparse arrays when operating on combinations of special matrices with special matrices, sparse matrices, or dense matrices/vectors.

This pull request's second commit addresses JuliaLang/julia#17738 by making concatenations involving sparse matrices more consistently yield sparse arrays, concatenations involving both sparse vectors and special matrices included.

This pull request does not fix the behavior of combinations involving annotation/wrapper/view types such as `<:AbstractTriangular` (see JuliaLang/LinearAlgebra.jl#350).

Ref. JuliaLang/julia#17660. Best! (Edits: Rewritten for PR scope expansion.)
