### PR TITLE
Refactor libgit2 credential callback

### DIFF
--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -24,6 +24,155 @@ function mirror_callback(remote::Ptr{Ptr{Void}}, repo_ptr::Ptr{Void},
     return Cint(0)
 end
 
+function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
+        username_ptr, schema, host)
+    isusedcreds = checkused!(creds)
+
+    errcls, errmsg = Error.last_error()
+    if errcls != Error.None
+        # Check if we used ssh-agent
+        if creds.usesshagent == "U"
+            println("ERROR: $errmsg ssh-agent")
+            creds.usesshagent = "E" # reported ssh-agent error, disables ssh agent use for the future
+        else
+            println("ERROR: $errmsg")
+        end
+        flush(STDOUT)
+    end
+
+    # first try ssh-agent if credentials support its usage
+    if creds.usesshagent === nothing || creds.usesshagent == "Y" || creds.usesshagent == "U"
+        err = ccall((:git_cred_ssh_key_from_agent, :libgit2), Cint,
+                     (Ptr{Ptr{Void}}, Cstring), libgit2credptr, username_ptr)
+        creds.usesshagent = "U" # used ssh-agent only one time
+        err == 0 && return Cint(0)
+    end
+
+    # if username is not provided, then prompt for it
+    username = if username_ptr == Cstring(C_NULL)
+        uname = creds.user # check if credentials were already used
+        uname !== nothing && !isusedcreds ? uname : prompt("Username for '$schema$host'")
+    else
+        unsafe_string(username_ptr)
+    end
+    creds.user = username # save credentials
+    isempty(username) && return Cint(Error.EAUTH)
+
+    # For SSH we need a private key location
+    privatekey = if haskey(ENV,"SSH_KEY_PATH")
+        ENV["SSH_KEY_PATH"]
+    else
+        keydefpath = creds.prvkey # check if credentials were already used
+        keydefpath === nothing && (keydefpath = "")
+        if !isempty(keydefpath) && !isusedcreds
+            keydefpath # use cached value
+        else
+            defaultkeydefpath = joinpath(homedir(),".ssh","id_rsa")
+            if isempty(keydefpath) && isfile(defaultkeydefpath)
+                keydefpath = defaultkeydefpath
+            else
+                keydefpath =
+                    prompt("Private key location for '$schema$username@$host'", default=keydefpath)
+            end
+        end
+    end
+
+    # If the private key changed, invalidate the cached public key
+    (privatekey != creds.prvkey) &&
+        (creds.pubkey = "")
+    creds.prvkey = privatekey # save credentials
+
+    # For SSH we need a public key location, look for environment vars SSH_* as well
+    publickey = if haskey(ENV,"SSH_PUB_KEY_PATH")
+        ENV["SSH_PUB_KEY_PATH"]
+    else
+        keydefpath = creds.pubkey # check if credentials were already used
+        if keydefpath !== nothing && !isusedcreds
+            keydefpath # use cached value
+        else
+            if keydefpath === nothing || isempty(keydefpath)
+                keydefpath = privatekey*".pub"
+            end
+            if isfile(keydefpath)
+                keydefpath
+            else
+                prompt("Public key location for '$schema$username@$host'", default=keydefpath)
+            end
+        end
+    end
+    creds.pubkey = publickey # save credentials
+
+    passphrase_required = true
+    if !isfile(privatekey)
+        warn("Private key not found")
+    else
+        # In encrypted private keys, the second line is "Proc-Type: 4,ENCRYPTED"
+        open(privatekey) do f
+            passphrase_required = (readline(f); chomp(readline(f)) == "Proc-Type: 4,ENCRYPTED")
+        end
+    end
+
+    passphrase = if haskey(ENV,"SSH_KEY_PASS")
+       ENV["SSH_KEY_PASS"]
+    else
+        passdef = creds.pass # check if credentials were already used
+        passdef === nothing && (passdef = "")
+        if passphrase_required && (isempty(passdef) || isusedcreds)
+            if is_windows()
+                passdef = Base.winprompt(
+                    "Your SSH Key requires a password, please enter it now:",
+                    "Passphrase required", privatekey; prompt_username = false)
+                isnull(passdef) && return Cint(Error.EAUTH)
+                passdef = Base.get(passdef)[2]
+            else
+                passdef = prompt("Passphrase for $privatekey", password=true)
+            end
+        end
+        passdef
+    end
+    creds.pass = passphrase
+
+    err = ccall((:git_cred_ssh_key_new, :libgit2), Cint,
+                 (Ptr{Ptr{Void}}, Cstring, Cstring, Cstring, Cstring),
+                 libgit2credptr, username, publickey, privatekey, passphrase)
+    return err
+end
+
+function authenticate_userpass(creds::UserPasswordCredentials, libgit2credptr::Ptr{Ptr{Void}},
+        schema, host, urlusername)
+    isusedcreds = checkused!(creds)
+
+    username = creds.user
+    userpass = creds.pass
+    if is_windows()
+        if username === nothing || userpass === nothing || isusedcreds
+            res = Base.winprompt("Please enter your credentials for '$schema$host'", "Credentials required",
+                    username === nothing || isempty(username) ?
+                    urlusername : username; prompt_username = true)
+            isnull(res) && return Cint(Error.EAUTH)
+            username, userpass = Base.get(res)
+        end
+    else
+        if username === nothing || isusedcreds
+            username = prompt("Username for '$schema$host'", default = urlusername)
+        end
+
+        if userpass === nothing || isusedcreds
+            userpass = prompt("Password for '$schema$username@$host'", password=true)
+        end
+    end
+    creds.user = username # save credentials
+    creds.pass = userpass # save credentials
+
+    isempty(username) && isempty(userpass) && return Cint(Error.EAUTH)
+
+    err = ccall((:git_cred_userpass_plaintext_new, :libgit2), Cint,
+                 (Ptr{Ptr{Void}}, Cstring, Cstring),
+                 libgit2credptr, username, userpass)
+    err == 0 && return Cint(0)
+end
+
+
 """Credentials callback function
 
 Function provides different credential acquisition functionality w.r.t. a connection protocol.
@@ -50,7 +199,7 @@ Using credentials triggers a user prompt for (re)entering required information.
 `UserPasswordCredentials` and `CachedCredentials` are implemented using a call
 counting strategy that prevents repeated usage of faulty credentials.
 """
-function credentials_callback(cred::Ptr{Ptr{Void}}, url_ptr::Cstring,
+function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
                               username_ptr::Cstring,
                               allowed_types::Cuint, payload_ptr::Ptr{Void})
     err = 0
@@ -74,157 +223,42 @@ function credentials_callback(cred::Ptr{Ptr{Void}}, url_ptr::Cstring,
             creds_are_temp = false
         end
     end
-    isusedcreds = checkused!(creds)
 
     try
         # use ssh key or ssh-agent
         if isset(allowed_types, Cuint(Consts.CREDTYPE_SSH_KEY))
-            creds === nothing && (creds = SSHCredentials())
-            credid = "ssh://$host"
-
-            # first try ssh-agent if credentials support its usage
-            if creds[:usesshagent, credid] === nothing || creds[:usesshagent, credid] == "Y"
-                err = ccall((:git_cred_ssh_key_from_agent, :libgit2), Cint,
-                             (Ptr{Ptr{Void}}, Cstring), cred, username_ptr)
-                creds[:usesshagent, credid] = "U" # used ssh-agent only one time
-                err == 0 && return Cint(0)
+            sshcreds = get_creds!(creds, "ssh://$host", SSHCredentials())
+            if isa(sshcreds, SSHCredentials)
+                creds = sshcreds # To make sure these get cleaned up below
+                err = authenticate_ssh(creds, libgit2credptr, username_ptr, schema, host)
+                err == 0 && return err
             end
-
-            errcls, errmsg = Error.last_error()
-            if errcls != Error.None
-                # Check if we used ssh-agent
-                if creds[:usesshagent, credid] == "U"
-                    println("ERROR: $errmsg ssh-agent")
-                    creds[:usesshagent, credid] = "E" # reported ssh-agent error
-                else
-                    println("ERROR: $errmsg")
-                end
-                flush(STDOUT)
-            end
-
-            # if username is not provided, then prompt for it
-            username = if username_ptr == Cstring(C_NULL)
-                uname = creds[:user, credid] # check if credentials were already used
-                uname !== nothing && !isusedcreds ? uname : prompt("Username for '$schema$host'")
-            else
-                unsafe_string(username_ptr)
-            end
-            creds[:user, credid] = username # save credentials
-
-            # For SSH we need a private key location
-            privatekey = if haskey(ENV,"SSH_KEY_PATH")
-                ENV["SSH_KEY_PATH"]
-            else
-                keydefpath = creds[:prvkey, credid] # check if credentials were already used
-                keydefpath === nothing && (keydefpath = "")
-                if !isempty(keydefpath) && !isusedcreds
-                    keydefpath # use cached value
-                else
-                    defaultkeydefpath = joinpath(homedir(),".ssh","id_rsa")
-                    if isempty(keydefpath) && isfile(defaultkeydefpath)
-                        keydefpath = defaultkeydefpath
-                    else
-                        keydefpath =
-                            prompt("Private key location for '$schema$username@$host'", default=keydefpath)
-                    end
-                end
-            end
-
-            # If the private key changed, invalidate the cached public key
-            (privatekey != creds[:prvkey, credid]) &&
-                (creds[:pubkey, credid] = "")
-            creds[:prvkey, credid] = privatekey # save credentials
-
-            # For SSH we need a public key location, look for environment vars SSH_* as well
-            publickey = if haskey(ENV,"SSH_PUB_KEY_PATH")
-                ENV["SSH_PUB_KEY_PATH"]
-            else
-                keydefpath = creds[:pubkey, credid] # check if credentials were already used
-                if keydefpath !== nothing && !isusedcreds
-                    keydefpath # use cached value
-                else
-                    if keydefpath === nothing || isempty(keydefpath)
-                        keydefpath = privatekey*".pub"
-                    end
-                    if isfile(keydefpath)
-                        keydefpath
-                    else
-                        prompt("Public key location for '$schema$username@$host'", default=keydefpath)
-                    end
-                end
-            end
-            creds[:pubkey, credid] = publickey # save credentials
-
-            passphrase_required = true
-            if !isfile(privatekey)
-                warn("Private key not found")
-            else
-                # In encrypted private keys, the second line is "Proc-Type: 4,ENCRYPTED"
-                open(privatekey) do f
-                    passphrase_required = (readline(f); chomp(readline(f)) == "Proc-Type: 4,ENCRYPTED")
-                end
-           end
-
-           passphrase = if haskey(ENV,"SSH_KEY_PASS")
-               ENV["SSH_KEY_PASS"]
-           else
-                passdef = creds[:pass, credid] # check if credentials were already used
-                passdef === nothing && (passdef = "")
-                if passphrase_required && (isempty(passdef) || isusedcreds)
-                    if is_windows()
-                        passdef = Base.winprompt(
-                            "Your SSH Key requires a password, please enter it now:",
-                            "Passphrase required", privatekey; prompt_username = false)
-                        isnull(passdef) && return Cint(Error.EAUTH)
-                        passdef = Base.get(passdef)[2]
-                    else
-                        passdef = prompt("Passphrase for $privatekey", password=true)
-                    end
-                end
-                passdef
-            end
-            creds[:pass, credid] = passphrase
-
-            isempty(username) && return Cint(Error.EAUTH)
-
-            err = ccall((:git_cred_ssh_key_new, :libgit2), Cint,
-                         (Ptr{Ptr{Void}}, Cstring, Cstring, Cstring, Cstring),
-                         cred, username, publickey, privatekey, passphrase)
-            err == 0 && return Cint(0)
         end
 
         if isset(allowed_types, Cuint(Consts.CREDTYPE_USERPASS_PLAINTEXT))
-            creds === nothing && (creds = UserPasswordCredentials())
+            defaultcreds = UserPasswordCredentials()
             credid = "$schema$host"
-
-            username = creds[:user, credid]
-            userpass = creds[:pass, credid]
-            if is_windows()
-                if username === nothing || userpass === nothing || isusedcreds
-                    res = Base.winprompt("Please enter your credentials for '$schema$host'", "Credentials required",
-                            username === nothing || isempty(username) ?
-                            urlusername : username; prompt_username = true)
-                    isnull(res) && return Cint(Error.EAUTH)
-                    username, userpass = Base.get(res)
-                end
-            else
-                if username === nothing || isusedcreds
-                    username = prompt("Username for '$schema$host'", default = urlusername)
-                end
-
-                if userpass === nothing || isusedcreds
-                    userpass = prompt("Password for '$schema$username@$host'", password=true)
-                end
+            upcreds = get_creds!(creds, credid, defaultcreds)
+            # If there were stored SSH credentials, but we ended up here that must
+            # mean that something went wrong. Replace the SSH credentials by user/pass
+            # credentials
+            if !isa(upcreds, UserPasswordCredentials)
+                upcreds = defaultcreds
+                isa(creds, CachedCredentials) && (creds.creds[credid] = upcreds)
             end
-            creds[:user, credid] = username # save credentials
-            creds[:pass, credid] = userpass # save credentials
+            creds = upcreds # To make sure these get cleaned up below
+            return authenticate_userpass(creds, libgit2credptr, schema, host, urlusername)
+        end
 
-            isempty(username) && isempty(userpass) && return Cint(Error.EAUTH)
-
-            err = ccall((:git_cred_userpass_plaintext_new, :libgit2), Cint,
-                         (Ptr{Ptr{Void}}, Cstring, Cstring),
-                         cred, username, userpass)
-            err == 0 && return Cint(0)
+        # No authentication method we support succeeded. The most likely cause is
+        # that explicit credentials were passed in, but said credentials are incompatible
+        # with the remote host.
+        if err == 0
+            if (creds != nothing && !isa(creds, CachedCredentials))
+                warn("The explicitly provided credentials were incompatible with " *
+                     "the server's supported authentication methods")
+            end
+            err = Cint(Error.EAUTH)
         end
     finally
         # if credentials are not passed back to caller via payload,

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -113,7 +113,7 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
     end
 
     passphrase = if haskey(ENV,"SSH_KEY_PASS")
-       ENV["SSH_KEY_PASS"]
+        ENV["SSH_KEY_PASS"]
     else
         passdef = creds.pass # check if credentials were already used
         passdef === nothing && (passdef = "")

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -55,19 +55,6 @@ abstract AbstractPayload
 
 "Abstract credentials payload"
 abstract AbstractCredentials <: AbstractPayload
-"Returns a credentials parameter"
-function Base.getindex(p::AbstractCredentials, key, _=nothing)
-    ks = Symbol(key)
-    isdefined(p, ks) && return getfield(p, ks)
-    return nothing
-end
-"Sets credentials with `key` parameter to a value"
-function Base.setindex!(p::AbstractCredentials, val, key, _=nothing)
-    ks = Symbol(key)
-    @assert isdefined(p, ks)
-    setfield!(p, ks, val)
-    return p
-end
 "Checks if credentials were used"
 checkused!(p::AbstractCredentials) = true
 checkused!(p::Void) = false
@@ -711,22 +698,15 @@ import Base.securezero!
 type UserPasswordCredentials <: AbstractCredentials
     user::String
     pass::String
-    usesshagent::String  # used for ssh-agent authentication
     count::Int                   # authentication failure protection count
     function UserPasswordCredentials(u::AbstractString,p::AbstractString)
-        c = new(u,p,"Y",3)
+        c = new(u,p,3)
         finalizer(c, securezero!)
         return c
     end
+    UserPasswordCredentials() = UserPasswordCredentials("","")
 end
-"Checks if credentials were used or failed authentication, see `LibGit2.credentials_callback`"
-function checkused!(p::UserPasswordCredentials)
-    p.count <= 0 && return true
-    p.count -= 1
-    return false
-end
-"Resets authentication failure protection count"
-reset!(p::UserPasswordCredentials, cnt::Int=3) = (p.count = cnt)
+
 function securezero!(cred::UserPasswordCredentials)
     securezero!(cred.user)
     securezero!(cred.pass)
@@ -741,9 +721,10 @@ type SSHCredentials <: AbstractCredentials
     pubkey::String
     prvkey::String
     usesshagent::String  # used for ssh-agent authentication
+    count::Int
 
     function SSHCredentials(u::AbstractString,p::AbstractString)
-        c = new(u,p,"","","Y")
+        c = new(u,p,"","","Y",3)
         finalizer(c, securezero!)
         return c
     end
@@ -754,50 +735,31 @@ function securezero!(cred::SSHCredentials)
     securezero!(cred.pass)
     securezero!(cred.pubkey)
     securezero!(cred.prvkey)
+    cred.count = 0
     return cred
 end
 
 "Credentials that support caching"
 type CachedCredentials <: AbstractCredentials
-    cred::Dict{String,SSHCredentials}
+    cred::Dict{String,AbstractCredentials}
     count::Int            # authentication failure protection count
-    CachedCredentials() = new(Dict{String,SSHCredentials}(),3)
+    CachedCredentials() = new(Dict{String,AbstractCredentials}(),3)
 end
-"Returns specific credential parameter value: first index is a credential
-parameter name, second index is a host name (with schema)"
-function Base.getindex(p::CachedCredentials, keys...)
-    length(keys) != 2 && return nothing
-    key, host = keys
-    if haskey(p.cred, host)
-        creds = p.cred[host]
-        if isdefined(creds,key)
-            kval = getfield(creds, key)
-            !isempty(kval) && return kval
-        end
-    end
-    return nothing
-end
-"Sets specific credential parameter value: first index is a credential
-parameter name, second index is a host name (with schema)"
-function Base.setindex!(p::CachedCredentials, val, keys...)
-    length(keys) != 2 && return nothing
-    key, host = keys
-    if !haskey(p.cred, host)
-        p.cred[host] = SSHCredentials()
-    end
-    creds = p.cred[host]
-    @assert isdefined(creds,key)
-    setfield!(creds, key, val)
-    return p
-end
+
 "Checks if credentials were used or failed authentication, see `LibGit2.credentials_callback`"
-function checkused!(p::CachedCredentials)
+function checkused!(p::Union{UserPasswordCredentials, SSHCredentials})
     p.count <= 0 && return true
     p.count -= 1
     return false
 end
-"Resets authentication failure protection count"
-reset!(p::CachedCredentials, cnt::Int=3) = (p.count = cnt)
+reset!(p::Union{UserPasswordCredentials, SSHCredentials}, cnt::Int=3) = (p.count = cnt)
+reset!(p::CachedCredentials) = foreach(reset!, values(p.cred))
+
+"Obtained the cached credential for the given host+protocol (credid), or return and store the default if not found"
+get_creds!(collection::CachedCredentials, credid, default) = get!(collection.cred, credid, default)
+get_creds!(creds::AbstractCredentials, credid, default) = creds
+get_creds!(creds::Void, credid, default) = default
+
 function securezero!(p::CachedCredentials)
     foreach(securezero!, values(p.cred))
     return p

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -755,7 +755,7 @@ end
 reset!(p::Union{UserPasswordCredentials, SSHCredentials}, cnt::Int=3) = (p.count = cnt)
 reset!(p::CachedCredentials) = foreach(reset!, values(p.cred))
 
-"Obtained the cached credential for the given host+protocol (credid), or return and store the default if not found"
+"Obtain the cached credentials for the given host+protocol (credid), or return and store the default if not found"
 get_creds!(collection::CachedCredentials, credid, default) = get!(collection.cred, credid, default)
 get_creds!(creds::AbstractCredentials, credid, default) = creds
 get_creds!(creds::Void, credid, default) = default

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -564,40 +564,8 @@ mktempdir() do dir
         @test !LibGit2.checkused!(creds)
         @test !LibGit2.checkused!(creds)
         @test LibGit2.checkused!(creds)
-        @test LibGit2.reset!(creds) == 3
-        @test !LibGit2.checkused!(creds)
-        @test creds.count == 2
-        @test creds[:user] == creds_user
-        @test creds[:pass] == creds_pass
-        @test creds[:pubkey] === nothing
-        @test creds[:user, "localhost"] == creds_user
-        @test creds[:pubkey, "localhost"] === nothing
-        @test creds[:usesshagent, "localhost"] == "Y"
-        creds[:usesshagent, "localhost"] = "E"
-        @test creds[:usesshagent, "localhost"] == "E"
-
-        creds = LibGit2.CachedCredentials()
-        @test !LibGit2.checkused!(creds)
-        @test !LibGit2.checkused!(creds)
-        @test !LibGit2.checkused!(creds)
-        @test LibGit2.checkused!(creds)
-        @test LibGit2.reset!(creds) == 3
-        @test !LibGit2.checkused!(creds)
-        @test creds.count == 2
-        @test creds[:user, "localhost"] === nothing
-        @test creds[:pass, "localhost"] === nothing
-        @test creds[:pubkey, "localhost"] === nothing
-        @test creds[:prvkey, "localhost"] === nothing
-        @test creds[:usesshagent, "localhost"] === nothing
-        creds[:user, "localhost"] = creds_user
-        creds[:pass, "localhost"] = creds_pass
-        creds[:usesshagent, "localhost"] = "Y"
-        @test creds[:user] === nothing
-        @test creds[:user, "localhost2"] === nothing
-        @test creds[:user, "localhost"] == creds_user
-        @test creds[:pass, "localhost"] == creds_pass
-        @test creds[:pubkey, "localhost"] === nothing
-        @test creds[:usesshagent, "localhost"] == "Y"
+        @test creds.user == creds_user
+        @test creds.pass == creds_pass
     #end
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -406,7 +406,7 @@ let a = [1,2,3]
     @test a == [0,0,0]
 end
 let creds = Base.LibGit2.CachedCredentials()
-    creds[:pass, "foo"] = "bar"
+    LibGit2.get_creds!(creds, "foo", LibGit2.SSHCredentials()).pass = "bar"
     securezero!(creds)
-    @test creds[:pass, "foo"] == "\0\0\0"
+    @test LibGit2.get_creds!(creds, "foo", nothing).pass == "\0\0\0"
 end


### PR DESCRIPTION
Cleanly separate the SSHCredentials and UserPasswordCredentials to only use each type
when appropriate (the former for SSH keys, the latter for HTTPS for SSH password/keyboard-interactive
authentication). Previously the types would sometimes get confused and SSHCredentials
would be used for userpass authentication, since the field names happen to be a subset
(though they have different meaning, since the `pass` field in SSHCredentials is the
SSH key passphrase while the `pass` in UserPasswordCredentials is the remote user's
password).

Fix a couple issues in the process:
- Allow externally passed in credentials to reach the right place
- Don't skip using the SSH agent if there are two private packages
