### PR TITLE
Fix #17462, break/continue in an at-testset for loop

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -732,7 +732,12 @@ function testset_forloop(args, testloop)
         pop_testset()
         finish(ts)
     end
-    Expr(:comprehension, blk, [esc(v) for v in loopvars]...)
+    quote
+        arr = Array{Any,1}(0)
+        $(Expr(:for, Expr(:block, [esc(v) for v in loopvars]...),
+               :(push!(arr, $blk))))
+        arr
+    end
 end
 
 """

--- a/test/test.jl
+++ b/test/test.jl
@@ -313,3 +313,28 @@ end
 @test @inferred(inferrable_kwtest(1; y=1)) == 2
 @test @inferred(uninferrable_kwtest(1)) == 3
 @test_throws ErrorException @inferred(uninferrable_kwtest(1; y=2)) == 2
+
+# Issue #17462
+counter_17462_pre = 0
+counter_17462_post = 0
+@testset for x in [1,2,3,4]
+    counter_17462_pre += 1
+    if x == 1
+        @test counter_17462_pre == x
+        continue
+        @test false
+    elseif x == 3
+        @test counter_17462_pre == x
+        break
+        @test false
+    elseif x == 4
+        @test false
+    else
+        @test counter_17462_pre == x
+        @test x == 2
+        @test counter_17462_post == 0
+    end
+    counter_17462_post += 1
+end
+@test counter_17462_pre == 3
+@test counter_17462_post == 1


### PR DESCRIPTION
This fixes NearestNeighbors.jl.
