### PR TITLE
Reorganize pass-pipeline for Polly

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,6 +55,7 @@ LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)
 LLVMLINK += -lPolly -lPollyISL
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --src-root)/tools/polly/include
+FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --obj-root)/tools/polly/include
 FLAGS += -DUSE_POLLY
 endif
 else

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -24,6 +24,7 @@
 #if defined(USE_POLLY)
 #include <polly/RegisterPasses.h>
 #include <polly/LinkAllPasses.h>
+#include <polly/CodeGen/CodegenCleanup.h>
 #endif
 
 #include <llvm/Transforms/Scalar.h>
@@ -175,6 +176,7 @@ void addOptimizationPasses(PassManager *PM)
     PM->add(createInstructionCombiningPass());
     PM->add(polly::createCodePreparationPass());
     polly::registerPollyPasses(*PM);
+    PM->add(polly::createCodegenCleanupPass());
 #endif
     // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards
     PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -23,6 +23,7 @@
 #endif
 #if defined(USE_POLLY)
 #include <polly/RegisterPasses.h>
+#include <polly/LinkAllPasses.h>
 #endif
 
 #include <llvm/Transforms/Scalar.h>
@@ -172,6 +173,7 @@ void addOptimizationPasses(PassManager *PM)
     // above passes) introduces redundant phis that hinder Polly. Therefore we
     // run InstCombine here to remove them.
     PM->add(createInstructionCombiningPass());
+    PM->add(polly::createCodePreparationPass());
     polly::registerPollyPasses(*PM);
 #endif
     // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards


### PR DESCRIPTION
We now move Polly after LoopRotate since at this point the LLVM IR is more amenable to Polly. For example, a simple gemm kernel like

```
@polly function gemm!(A,B,C)
    m,n = size(A)
    n,o = size(B)
    @inbounds for i=1:m, j=1:o, k=1:n
        C[i,j] += A[i,k] * B[k,j]
    end
end
```

could not be optimized before this change. However, this new position after LoopRotate also makes it necessary to rerun InstCombine before Polly to get rid of hindering phi instructions that are introduced by LCSSA. Additionally, we add Polly's CodePreparation and CodegenCleanUp passes. Parts of these changes have already been discussed in https://groups.google.com/forum/#!topic/polly-dev/P2RZUlKRo0I. The reason why they were held back was to see if further adaptions to the pass-pipeline will become apparent, but for now this configuration seems to be convenient.

@tobig @vtjnash @timholy 
