### PR TITLE
RFC: change default max channel size to typemax(Int)

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -2,8 +2,6 @@
 
 abstract AbstractChannel
 
-const DEF_CHANNEL_SZ=32
-
 type Channel{T} <: AbstractChannel
     cond_take::Condition    # waiting for data to become available
     cond_put::Condition     # waiting for a writeable slot
@@ -13,12 +11,11 @@ type Channel{T} <: AbstractChannel
     sz_max::Int             # maximum size of channel
 
     function Channel(sz)
-        sz_max = sz == typemax(Int) ? typemax(Int) - 1 : sz
-        new(Condition(), Condition(), :open, Array{T}(0), sz_max)
+        new(Condition(), Condition(), :open, Array{T}(0), sz)
     end
 end
 
-Channel(sz::Int = DEF_CHANNEL_SZ) = Channel{Any}(sz)
+Channel(sz::Int = typemax(Int)) = Channel{Any}(sz)
 
 closed_exception() = InvalidStateException("Channel is closed.", :closed)
 function close(c::Channel)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3690,7 +3690,7 @@ a full channel block till an object is removed with `take!`.
 
 Other constructors:
 
-- `Channel()` - equivalent to `Channel{Any}(32)`
+- `Channel()` - equivalent to `Channel{Any}(typemax(Int))`
 - `Channel(sz::Int)` equivalent to `Channel{Any}(sz)`
 """
 Channel

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -137,7 +137,7 @@ Tasks
 
    Other constructors:
 
-   * ``Channel()`` - equivalent to ``Channel{Any}(32)``
+   * ``Channel()`` - equivalent to ``Channel{Any}(typemax(Int))``
    * ``Channel(sz::Int)`` equivalent to ``Channel{Any}(sz)``
 
 General Parallel Computing Support


### PR DESCRIPTION
Currently, if the size is unspecified, `Channel()` creates a channel with a max size of 32. The rationale for this at that time were 

1) Partially mimic the produce-consume lockstep task switching wherein each depended on the other. Having an unlimited max size would mean a producer task could just fill up a channel before any consumers were run.

2) It was mainly relevant when the implementation used a circular buffer which grew dynamically but was never shrunk. Now the backing store is an Array which resizes depending on the number of elements present.

I think the default should either be 0, 1 or unlimited(i.e., `typemax(Int)`) with my preference for unlimited.

A max size of 0 (which is currently not supported) would mimic golang's channels which require produce and consume to run in tandem, i.e., a `put!` on a channel of size 0 would block till a `take!` is called.
