### PR TITLE
Better documentation for performance annotations

### DIFF
--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -948,7 +948,7 @@ properties of the loop:
 A loop containing ``break``, ``continue``, or :obj:`@goto` will cause a
 compile-time error.
 
-To actually benefit from :obj:`@simd` current implementation, your loop
+To actually benefit from the current implementation of :obj:`@simd`, your loop
 should have the following additional properties:
 
 -  The loop must be an innermost loop.

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -931,8 +931,8 @@ Certain preconditions need to be met before using some of these macros.
 Both :obj:`@simd` and :obj:`@inbounds` do a simple rewrite of the expression 
 and delegate the optimizations to compiler, much like ``:meta`` expressions.
 This means they merely give the compiler license to optimize. Whether
-it actually does so depends on the compiler. As consequence how you 
-write the expressions will have a final say on the output.
+it actually does so depends on the compiler. How you write the expressions 
+will have a final say on the output.
 
 The range for a ``@simd for`` loop should be a one-dimensional range.
 A variable used for accumulating, such as ``s`` in the example, is called
@@ -962,7 +962,7 @@ should have the following additional properties:
 -  The stride should be unit stride.
 -  In some simple cases, for example with 2-3 arrays accessed in a loop, the
    LLVM auto-vectorization may kick in automatically, leading to no further
-   speedup with :obj:`@simd``.
+   speedup with :obj:`@simd`.
 
 While :obj:`@simd` needs to be placed in front of a loop, that is not the case 
 for :obj:`@inbounds`. It can be placed in front of any expression as long as it 
@@ -992,9 +992,8 @@ definition is in front of a loop.
                x[2]
            end
 
-Beware using it before a function declaration will have no effect, the 
-correct way to encapsule a function or block of code is inside a 
-``begin`` ``end`` statement.
+Be aware that using it before a function declaration will have no effect. 
+To use :obj:`@inbounds` on a block of code, put it before a ``begin ... end`` statement.
 
     julia> @inbounds function g(x)  #Won't remove bound checks nor warn you
                for i in 1:10

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -890,8 +890,7 @@ properties.
 
 Note: While :obj:`@simd` needs to be placed directly in front of a
 loop, both :obj:`@inbounds` and :obj:`@fastmath` can be applied to
-several statements at once, e.g. using ``begin`` ... ``end``, or even
-to a whole function.
+several statements at once, e.g. using ``begin`` ... ``end``.
 
 Here is an example with both :obj:`@inbounds` and :obj:`@simd` markup::
 

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -928,10 +928,10 @@ On a computer with a 2.4GHz Intel Core i5 processor, this produces::
     GFlop (SIMD) = 17.578554163920018
 
 Certain preconditions need to be met before using some of these macros.
-Both :obj:`@simd` and :obj:`@inbounds` do a simple rewrite of the expression 
+Both :obj:`@simd` and :obj:`@inbounds` do a simple rewrite of the expression
 and delegate the optimizations to compiler, much like ``:meta`` expressions.
 This means they merely give the compiler license to optimize. Whether
-it actually does so depends on the compiler. How you write the expressions 
+it actually does so depends on the compiler. How you write the expressions
 will have a final say on the output.
 
 The range for a ``@simd for`` loop should be a one-dimensional range.
@@ -948,7 +948,7 @@ properties of the loop:
 A loop containing ``break``, ``continue``, or :obj:`@goto` will cause a
 compile-time error.
 
-To actually benefit from :obj:`@simd` current implementation, your loop 
+To actually benefit from :obj:`@simd` current implementation, your loop
 should have the following additional properties:
 
 -  The loop must be an innermost loop.
@@ -964,21 +964,21 @@ should have the following additional properties:
    LLVM auto-vectorization may kick in automatically, leading to no further
    speedup with :obj:`@simd`.
 
-While :obj:`@simd` needs to be placed in front of a loop, that is not the case 
-for :obj:`@inbounds`. It can be placed in front of any expression as long as it 
-is inside a function, the only place where it could be outside of a function 
+While :obj:`@simd` needs to be placed in front of a loop, that is not the case
+for :obj:`@inbounds`. It can be placed in front of any expression as long as it
+is inside a function, the only place where it could be outside of a function
 definition is in front of a loop.
-
+::
     julia> x = [1]
 
     julia> @inbounds if true
                x[2]
            end
     ERROR: BoundsError: attempt to access 1-element Array{Int64,1} at index [2]
-     in getindex(::Array{Int64,1}, ::Int64) at ./array.jl:309
-     in eval(::Module, ::Any) at ./boot.jl:225
-     in macro expansion at ./REPL.jl:92 [inlined]
-     in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
+    in getindex(::Array{Int64,1}, ::Int64) at ./array.jl:309
+    in eval(::Module, ::Any) at ./boot.jl:225
+    in macro expansion at ./REPL.jl:92 [inlined]
+    in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
 
     julia> function f(x)
                @inbounds if true
@@ -992,15 +992,15 @@ definition is in front of a loop.
                x[2]
            end
 
-Be aware that using it before a function declaration will have no effect. 
+Be aware that using it before a function declaration will have no effect.
 To use :obj:`@inbounds` on a block of code, put it before a ``begin ... end`` statement.
-
+::
     julia> @inbounds function g(x)  #Won't remove bound checks nor warn you
                for i in 1:10
                    x[i] = x[i]^2
                end
            end
- 
+
     julia> function g(x)
                @inbounds begin
                    for i in 1:10
@@ -1008,7 +1008,7 @@ To use :obj:`@inbounds` on a block of code, put it before a ``begin ... end`` st
                    end
                end
            end
- 
+
 :obj:`@simd` can be placed in front of any expression without problems.
 
 Here is an example with all three kinds of markup. This program first

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -987,7 +987,7 @@ definition is in front of a loop.
            end
 
     julia> f(x)
- 
+
     julia> @inbounds for i in 1:10
                x[2]
            end


### PR DESCRIPTION
That sentence might make you think applying it to a function will remove bounds check.

> or even to a whole function

``` julia
@inbounds function f(...)
    ...
end
```

which is not true as seen [here](https://github.com/JuliaLang/IterativeSolvers.jl/pull/79#discussion_r72777612)
