### PR TITLE
Fix tests to ignore the startup file

### DIFF
--- a/examples/clustermanager/simple/UnixDomainCM.jl
+++ b/examples/clustermanager/simple/UnixDomainCM.jl
@@ -12,7 +12,7 @@ function launch(manager::UnixDomainCM, params::Dict, launched::Array, c::Conditi
     for i in 1:manager.np
         sockname = tempname()
         try
-            cmd = `$(params[:exename]) $(@__FILE__) udwrkr $sockname $cookie`
+            cmd = `$(params[:exename]) --startup-file=no $(@__FILE__) udwrkr $sockname $cookie`
             io, pobj = open(cmd, "r")
 
             wconfig = WorkerConfig()

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -2,17 +2,17 @@
 
 # run boundscheck tests on separate workers launched with --check-bounds={default,yes,no}
 
-cmd = `$(Base.julia_cmd()) --depwarn=error boundscheck_exec.jl`
+cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no boundscheck_exec.jl`
 if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR))
     error("boundscheck test failed, cmd : $cmd")
 end
 
-cmd = `$(Base.julia_cmd()) --check-bounds=yes --depwarn=error boundscheck_exec.jl`
+cmd = `$(Base.julia_cmd()) --check-bounds=yes --startup-file=no --depwarn=error boundscheck_exec.jl`
 if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR))
     error("boundscheck test failed, cmd : $cmd")
 end
 
-cmd = `$(Base.julia_cmd()) --check-bounds=no --depwarn=error boundscheck_exec.jl`
+cmd = `$(Base.julia_cmd()) --check-bounds=no --startup-file=no --depwarn=error boundscheck_exec.jl`
 if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR))
     error("boundscheck test failed, cmd : $cmd")
 end

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -197,7 +197,7 @@ let dir = mktempdir(),
             Base.compilecache(:Time4b3a94a1a081a8cb)
         end)
 
-        exename = `$(Base.julia_cmd()) --precompiled=yes`
+        exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
 
         testcode = """
             insert!(LOAD_PATH, 1, $(repr(dir)))

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -38,7 +38,7 @@ include(joinpath(dir, "queens.jl"))
 # cluster manager example through a new Julia session.
 if is_unix()
     script = joinpath(dir, "clustermanager/simple/test_simple.jl")
-    cmd = `$(Base.julia_cmd()) $script`
+    cmd = `$(Base.julia_cmd()) --startup-file=no $script`
     if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR)) && ccall(:jl_running_on_valgrind,Cint,()) == 0
         error("UnixDomainCM failed test, cmd : $cmd")
     end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1109,7 +1109,7 @@ function test_13559()
     run(`mkfifo $fn`)
     # use subprocess to write 127 bytes to FIFO
     writer_cmds = "x=open(\"$fn\", \"w\"); for i=1:127 write(x,0xaa); flush(x); sleep(0.1) end; close(x); quit()"
-    open(pipeline(`$(Base.julia_cmd()) -e $writer_cmds`, stderr=STDERR))
+    open(pipeline(`$(Base.julia_cmd()) --startup-file=no -e $writer_cmds`, stderr=STDERR))
     #quickly read FIFO, draining it and blocking but not failing with EOFError yet
     r = open(fn, "r")
     # 15 proper reads

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -11,7 +11,7 @@ elseif Base.JLOptions().code_coverage == 2
     cov_flag = `--code-coverage=all`
 end
 
-cmd = `$(Base.julia_cmd()) $inline_flag $cov_flag --check-bounds=yes --depwarn=error parallel_exec.jl`
+cmd = `$(Base.julia_cmd()) $inline_flag $cov_flag --check-bounds=yes --startup-file=no --depwarn=error parallel_exec.jl`
 
 if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR)) && ccall(:jl_running_on_valgrind,Cint,()) == 0
     error("Parallel test failed, cmd : $cmd")

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -17,7 +17,7 @@ end
         1
     end
 
-addprocs(4; exeflags=`$cov_flag $inline_flag --check-bounds=yes --depwarn=error`)
+addprocs(4; exeflags=`$cov_flag $inline_flag --check-bounds=yes --startup-file=no --depwarn=error`)
 
 # Test remote()
 let

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ cd(dirname(@__FILE__)) do
     n = 1
     if net_on
         n = min(8, Sys.CPU_CORES, length(tests))
-        n > 1 && addprocs(n; exeflags=`--check-bounds=yes --depwarn=error`)
+        n > 1 && addprocs(n; exeflags=`--check-bounds=yes --startup-file=no --depwarn=error`)
         BLAS.set_num_threads(1)
     end
 
@@ -50,7 +50,7 @@ cd(dirname(@__FILE__)) do
                     if (isa(resp, Integer) && (resp > max_worker_rss)) || isa(resp, Exception)
                         if n > 1
                             rmprocs(p, waitfor=0.5)
-                            p = addprocs(1; exeflags=`--check-bounds=yes --depwarn=error`)[1]
+                            p = addprocs(1; exeflags=`--check-bounds=yes --startup-file=no --depwarn=error`)[1]
                             remotecall_fetch(()->include("testdefs.jl"), p)
                         else
                             # single process testing, bail if mem limit reached, or, on an exception.

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -326,7 +326,7 @@ let fname = tempname()
         run(cmd)
     end
     """
-    @test success(pipeline(`$catcmd $fname`, `$exename -e $code`))
+    @test success(pipeline(`$catcmd $fname`, `$exename --startup-file=no -e $code`))
     rm(fname)
 end
 


### PR DESCRIPTION
To find the offending tests, it was helpful to use
a .juliarc.jl with just `error("don't include me")`.

Fixes #17642
