### PR TITLE
Improve REPL SIGINT user experience.

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -52,8 +52,10 @@ end
 
 function eval_user_input(ast::ANY, backend::REPLBackend)
     iserr, lasterr = false, ((), nothing)
+    Base.sigatomic_begin()
     while true
         try
+            Base.sigatomic_end()
             if iserr
                 put!(backend.response_channel, lasterr)
                 iserr, lasterr = false, ()
@@ -74,6 +76,7 @@ function eval_user_input(ast::ANY, backend::REPLBackend)
             iserr, lasterr = true, (err, catch_backtrace())
         end
     end
+    Base.sigatomic_end()
 end
 
 function start_repl_backend(repl_channel::Channel, response_channel::Channel)
@@ -136,8 +139,10 @@ function print_response(repl::AbstractREPL, val::ANY, bt, show_value::Bool, have
     print_response(outstream(repl), val, bt, show_value, have_color, specialdisplay(repl))
 end
 function print_response(errio::IO, val::ANY, bt, show_value::Bool, have_color::Bool, specialdisplay=nothing)
+    Base.sigatomic_begin()
     while true
         try
+            Base.sigatomic_end()
             if bt !== nothing
                 display_error(errio, val, bt)
                 println(errio)
@@ -166,6 +171,7 @@ function print_response(errio::IO, val::ANY, bt, show_value::Bool, have_color::B
             bt = catch_backtrace()
         end
     end
+    Base.sigatomic_end()
 end
 
 # A reference to a backend

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -389,7 +389,8 @@ static void *signal_listener(void *arg)
                 critical = 1;
             }
             else {
-                jl_try_deliver_sigint();
+                if (!jl_ignore_sigint())
+                    jl_try_deliver_sigint();
                 continue;
             }
         }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -81,7 +81,8 @@ void __cdecl crt_sig_handler(int sig, int num)
         signal(SIGINT, (void (__cdecl *)(int))crt_sig_handler);
         if (exit_on_sigint)
             jl_exit(130); // 128 + SIGINT
-        jl_try_throw_sigint();
+        if (!jl_ignore_sigint())
+            jl_try_throw_sigint();
         break;
     default: // SIGSEGV, (SSIGTERM, IGILL)
         memset(&Context, 0, sizeof(Context));
@@ -180,7 +181,8 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
     }
     if (exit_on_sigint)
         jl_exit(128 + sig); // 128 + SIGINT
-    jl_try_deliver_sigint();
+    if (!jl_ignore_sigint())
+        jl_try_deliver_sigint();
     return 1;
 }
 


### PR DESCRIPTION
- Add a SIGINT dead time after a force throw
  
  Fixes Jeff's issue in #17706
- Make the eval and print loop sigatomic to avoid sigint being delivered
  outside `try`-`catch` blocks.
