### PR TITLE
print homogeneous tuple types over length 3 compactly

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -200,10 +200,9 @@ function show_datatype(io::IO, x::DataType)
         !(has_tvar_env && x.name.primary === x))
         n = length(x.parameters)
 
-        # Print homogeneous tuples with more than 3 elements compactly
-        # as NTuple{N, T}
-        if length(unique(x.parameters)) == 1 && n > 3
-            show(io, "NTuple{", n, ',', x.parameters[1], "}")
+        # Print homogeneous tuples with more than 3 elements compactly as NTuple{N, T}
+        if n > 3 && all(i -> is(x.parameters[1], i), x.parameters)
+            print(io, "NTuple{", n, ',', x.parameters[1], "}")
         else
             show(io, x.name)
             # Do not print the type parameters for the primary type if we are

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -1,5 +1,12 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+# Document NTuple here where we have everything needed for the doc system
+"""
+    NTuple{N, T}
+
+A compact way of representing the type for a tuple of length `N` where all elements are of type `T`."""
+NTuple
+
 ## indexing ##
 
 length(t::Tuple) = nfields(t)

--- a/test/show.jl
+++ b/test/show.jl
@@ -570,3 +570,8 @@ end
 @test repr(:(f.(X,Y))) == ":(f.(X,Y))"
 @test repr(:(f.(X))) == ":(f.(X))"
 @test repr(:(f.())) == ":(f.())"
+
+# Test compact printing of homogeneous tuples
+@test repr(NTuple{7,Int64}) == "NTuple{7,Int64}"
+@test repr(Tuple{Float64, Float64, Float64, Float64}) == "NTuple{4,Float64}"
+@test repr(Tuple{Float32, Float32, Float32}) == "Tuple{Float32,Float32,Float32}"


### PR DESCRIPTION
Just an idea but for me it makes error messages a bit more easy to read. 
#### Before:

``` jl
julia> ForwardDiff.Partials{10, Float64}((2,2,2,2,2,2,2,2,2))
ERROR: TypeError: Type: in new, expected Tuple{Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64}, got Tuple{Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64}
 in ForwardDiff.Partials{10,Float64}(::Tuple{Int64,Int64,Int64,Int64,Int64,Int64,Int64,Int64,Int64}) at /home/kristoffer/.julia/v0.5/ForwardDiff/src/partials.jl:2
 in eval(::Module, ::Any) at ./boot.jl:226

julia> f(x::NTuple{8,Int}) = x
f (generic function with 1 method)

julia> f((1,2,3,4,5,6))
ERROR: MethodError: no method matching f(::Tuple{Int64,Int64,Int64,Int64,Int64,Int64})
 in eval(::Module, ::Any) at ./boot.jl:226
```
#### After:

``` jl
julia> ForwardDiff.Partials{10, Float64}((2,2,2,2,2,2,2,2,2))
ERROR: TypeError: Type: in new, expected NTuple{10,Float64}, got NTuple{9,Float64}
 in ForwardDiff.Partials{10,Float64}(::NTuple{9,Int64}) at /home/kricarl/.julia/v0.5/ForwardDiff/src/partials.jl:2

julia> f(x::NTuple{8,Int}) = x
f (generic function with 1 method)

julia> f((1,2,3,4,5,6))
ERROR: MethodError: no method matching f(::NTuple{6,Int64})
Closest candidates are:
  f(::NTuple{8,Int64}) at REPL[4]:1
```
