### PR TITLE
Make exit_on_sigint work again

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -141,6 +141,7 @@ suppress_excp_printing(t::Task) = isa(t.storage, ObjectIdDict) ? get(get_task_tl
 
 # runtime system hook called when a task finishes
 function task_done_hook(t::Task)
+    # `finish_task` sets `sigatomic` before entering this function
     err = (t.state == :failed)
     result = t.result
     handled = false
@@ -188,6 +189,8 @@ function task_done_hook(t::Task)
             end
         end
     end
+    # Clear sigatomic before waiting
+    sigatomic_end()
     wait()
 end
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1465,6 +1465,7 @@ JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e);
+JL_DLLEXPORT void JL_NORETURN jl_no_exc_handler(jl_value_t *e);
 
 #ifdef JULIA_ENABLE_THREADING
 static inline void jl_lock_frame_push(jl_mutex_t *lock)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -49,9 +49,6 @@ void jl_call_tracer(tracer_cb callback, jl_value_t *tracee);
 
 extern size_t jl_page_size;
 extern jl_function_t *jl_typeinf_func;
-#if defined(JL_USE_INTEL_JITEVENTS)
-extern unsigned sig_stack_size;
-#endif
 
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;

--- a/src/threading.c
+++ b/src/threading.c
@@ -777,14 +777,6 @@ void jl_init_threading(void)
     static jl_ptls_t _jl_all_tls_states;
     jl_all_tls_states = &_jl_all_tls_states;
     jl_n_threads = 1;
-
-#if defined(__linux__) && defined(JL_USE_INTEL_JITEVENTS)
-    if (jl_using_intel_jitevents)
-        // Intel VTune Amplifier needs at least 64k for alternate stack.
-        if (SIGSTKSZ < 1<<16)
-            sig_stack_size = 1<<16;
-#endif
-
     ti_init_master_thread();
 }
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -109,7 +109,12 @@ static NOINLINE int true_main(int argc, char *argv[])
         (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("_start")) : NULL;
 
     if (start_client) {
-        jl_apply(&start_client, 1);
+        JL_TRY {
+            jl_apply(&start_client, 1);
+        }
+        JL_CATCH {
+            jl_no_exc_handler(jl_exception_in_transit);
+        }
         return 0;
     }
 


### PR DESCRIPTION
- Add more `try`-`catch` and sigatomic for top-level code/new tasks
  
  So that we don't need to run `jl_exit` in strange (signal handler) context
  due to missing exception handler.
- Implement `jl_call_in_ctx` on unix.
  
  Use it to make sure that `jl_rethrow` and `jl_exit` are running on the right
  thread and right stack when an exception/exit is caused by a signal.
  
  Fix #17706

Tested locally on Linux x86/x64/aarch64/arm and Mac (windows sigint handling seems to be really unreliable in general). According to musl source code, it should work there too. Implementation on platforms that I don't have access to (FreeBSD, PowerPC) is left as an exercise for people who do. =)

This uses assembly to set the register values instead of using sigreturn since it doesn't work reliably on Mac and may not work in the future due to mitigation of [sigreturn oriented programming](https://en.wikipedia.org/wiki/Sigreturn-oriented_programming). (Just like all other low level features that we want to use that is blocked by security fixes....)

The final implementation is on the edge of what I'm happy to merge during feature freeze/backport after branching so I'll let others decide when this should be merge and whether it should be backported to 0.5 branch.
