### PR TITLE
Fix GC stack scrub when the GC is running on a worker thread

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -392,7 +392,8 @@ JL_DLLEXPORT extern jl_gc_debug_env_t jl_gc_debug_env;
 int gc_debug_check_other(void);
 int gc_debug_check_pool(void);
 void gc_debug_print(void);
-void gc_scrub(char *stack_hi);
+void gc_scrub_record_task(jl_task_t *ta);
+void gc_scrub(void);
 #else
 #define gc_sweep_always_full 0
 static inline int gc_debug_check_other(void)
@@ -406,9 +407,12 @@ static inline int gc_debug_check_pool(void)
 static inline void gc_debug_print(void)
 {
 }
-static inline void gc_scrub(char *stack_hi)
+static inline void gc_scrub_record_task(jl_task_t *ta)
 {
-    (void)stack_hi;
+    (void)ta;
+}
+static inline void gc_scrub(void)
+{
 }
 #endif
 
@@ -431,8 +435,8 @@ static inline void objprofile_reset(void)
 #endif
 
 #ifdef MEMPROFILE
-static void gc_stats_all_pool(void);
-static void gc_stats_big_obj(void);
+void gc_stats_all_pool(void);
+void gc_stats_big_obj(void);
 #else
 #define gc_stats_all_pool()
 #define gc_stats_big_obj()


### PR DESCRIPTION
Also scrub the stacks of all tasks instead of only the currently running one.

I believe this can be merged during feature freeze since this is a bug fix and doesn't really touch code that is built by default.
