### PR TITLE
Fix broken build after distclean-llvm.

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -534,7 +534,7 @@ clean-llvm:
 distclean-llvm:
 	-rm -rf $(LLVM_TAR) $(LLVM_CLANG_TAR) \
 		$(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR) \
-		$(LLVM_SRC_DIR) $(LLVM_BUILDDIR_withtype)
+		$(LLVM_SRC_DIR) $(LLVM_SRC_DIR).extracted $(LLVM_BUILDDIR_withtype)
 
 ifneq ($(LLVM_VER),svn)
 get-llvm: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR)


### PR DESCRIPTION
After running `distclean-llvm` the build currently fails with the following error message:

``` bash
/bin/sh: line 0: cd: /Users/helge/projects/julia/deps/srccache/llvm-3.7.1: No such file or directory
make[1]: *** [/Users/helge/projects/julia/deps/srccache/llvm-3.7.1/llvm-3.7.1.patch-applied] Error 1
make: *** [julia-deps] Error 2
```

This is fixed by removing the `$(LLVM_SRC_DIR).extracted` directory within the `distclean-llvm` target.
