### PR TITLE
two small syntax-related fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,9 @@ Language changes
   * Dictionary comprehension syntax `[ a=>b for x in y ]` is deprecated.
     Use `Dict(a=>b for x in y)` instead ([#16510]).
 
+  * Parentheses are no longer allowed around iteration specifications, e.g.
+    `for (i = 1:n)` ([#17668]).
+
 Library improvements
 --------------------
 

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -60,7 +60,7 @@
                              "")))
                 ((comparison) (apply string (map deparse (cdr e))))
                 ((in) (string (deparse (cadr e)) " in " (deparse (caddr e))))
-                ((ssavalue) (string "SSAValue(" (cdr e) ")"))
+                ((ssavalue) (string "SSAValue(" (cadr e) ")"))
                 ((line) (if (length= e 2)
                             (string "# line " (cadr e))
                             (string "# " (caddr e) ", line " (cadr e))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1415,7 +1415,8 @@
 
 ;; as above, but allows both "i=r" and "i in r"
 (define (parse-iteration-spec s)
-  (let* ((lhs (parse-pipes s))
+  (let* ((paren? (eqv? (require-token s) #\())
+         (lhs (parse-pipes s))
          (t   (peek-token s)))
     (cond ((memq t '(= in ∈))
            (take-token s)
@@ -1428,6 +1429,13 @@
              `(= ,lhs ,rhs)))
           ((and (eq? lhs ':) (closing-token? t))
            ':)
+          ((and paren? (length= lhs 4) (eq? (car lhs) 'call)
+                (memq (cadr lhs) '(in ∈)))
+           (syntax-deprecation s "for (...)" "for ...")
+           `(= ,@(cddr lhs)))
+          ((and paren? (length= lhs 3) (eq? (car lhs) '=))
+           (syntax-deprecation s "for (...)" "for ...")
+           lhs)
           (else (error "invalid iteration specification")))))
 
 (define (parse-comma-separated-iters s)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1469,6 +1469,9 @@
            `(block ,@(cdr e)
                    ,(expand-update-operator op op= (car e) rhs T))))
         (else
+         (if (and (pair? lhs)
+                  (not (memq (car lhs) '(|.| tuple vcat typed_hcat typed_vcat))))
+             (error (string "invalid assignment location \"" (deparse lhs) "\"")))
          (expand-update-operator- op op= lhs rhs declT))))
 
 (define (lower-update-op e)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -648,3 +648,5 @@ for op in ["+", "-", "\$", "|", ".+", ".-", "*", ".*"]
     @test_throws ParseError parse("$op in [+, -]")
 end
 
+# issue #17701
+@test expand(:(i==3 && i+=1)) == Expr(:error, "invalid assignment location \"==(i,3)&&i\"")


### PR DESCRIPTION
- Deprecation warning for parens in `for` expressions
- Error message for `i == 3 && i+=1`
