### PR TITLE
Move docstrings for timing macros/functions inline

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3,15 +3,6 @@
 # Base
 
 """
-    @time
-
-A macro to execute an expression, printing the time it took to execute, the number of
-allocations, and the total number of bytes its execution caused to be allocated, before
-returning the value of the expression.
-"""
-:@time
-
-"""
     systemerror(sysfunc, iftrue)
 
 Raises a `SystemError` for `errno` with the descriptive string `sysfunc` if `iftrue` is `true`
@@ -4830,13 +4821,6 @@ Compile the given function `f` for the argument tuple (of types) `args`, but do 
 precompile
 
 """
-    toc()
-
-Print and return the time elapsed since the last [`tic`](:func:`tic`).
-"""
-toc
-
-"""
     asinh(x)
 
 Compute the inverse hyperbolic sine of `x`.
@@ -5237,15 +5221,6 @@ Open a file and read its contents. `args` is passed to `read`: this is equivalen
 read(filename, args...)
 
 """
-    @timev
-
-This is a verbose version of the `@time` macro. It first prints the same information as
-`@time`, then any non-zero memory allocation counters, and then returns the value of the
-expression.
-"""
-:@timev
-
-"""
     isopen(object) -> Bool
 
 Determine whether an object - such as a stream, timer, or mmap -- is not yet closed. Once an
@@ -5312,15 +5287,6 @@ Get the next valid string index after `i`. Returns a value greater than `endof(s
 after the end of the string.
 """
 nextind
-
-"""
-    @timed
-
-A macro to execute an expression, and return the value of the expression, elapsed time,
-total bytes allocated, garbage collection time, and an object with various memory allocation
-counters.
-"""
-:@timed
 
 """
     symdiff(s1,s2...)
@@ -6005,13 +5971,6 @@ Get the number of fields of a `DataType`.
 nfields
 
 """
-    toq()
-
-Return, but do not print, the time elapsed since the last [`tic`](:func:`tic`).
-"""
-toq
-
-"""
     show(stream, mime, x)
 
 The `display` functions ultimately call `show` in order to write an object `x` as a
@@ -6606,17 +6565,6 @@ by `show` generally includes Julia-specific formatting and type information.
 """
 show(x)
 
-"""
-    @allocated
-
-A macro to evaluate an expression, discarding the resulting value, instead returning the
-total number of bytes allocated during evaluation of the expression. Note: the expression is
-evaluated inside a local function, instead of the current context, in order to eliminate the
-effects of compilation, however, there still may be some allocations due to JIT compilation.
-This also makes the results inconsistent with the `@time` macros, which do not try to adjust
-for the effects of compilation.
-"""
-:@allocated
 
 """
     Array(dims)
@@ -8064,14 +8012,6 @@ Return the index of the last element of `A` for which `predicate` returns `true`
 findlast(::Function, A)
 
 """
-    @elapsed
-
-A macro to evaluate an expression, discarding the resulting value, instead returning the
-number of seconds it took to execute as a floating-point number.
-"""
-:@elapsed
-
-"""
     findnext(A, i)
 
 Find the next index >= `i` of a non-zero element of `A`, or `0` if not found.
@@ -8112,14 +8052,6 @@ fetch
 Compute the phase angle in radians of a complex number `z`.
 """
 angle
-
-"""
-    tic()
-
-Set a timer to be read by the next call to [`toc`](:func:`toc`) or [`toq`](:func:`toq`). The
-macro call `@time expr` can also be used to time evaluation.
-"""
-tic
 
 """
     LoadError(file::AbstractString, line::Int, error)

--- a/base/util.jl
+++ b/base/util.jl
@@ -66,12 +66,23 @@ gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())
 # total number of bytes allocated so far
 gc_bytes() = ccall(:jl_gc_total_bytes, Int64, ())
 
+"""
+    tic()
+
+Set a timer to be read by the next call to [`toc`](:func:`toc`) or [`toq`](:func:`toq`). The
+macro call `@time expr` can also be used to time evaluation.
+"""
 function tic()
     t0 = time_ns()
     task_local_storage(:TIMERS, (t0, get(task_local_storage(), :TIMERS, ())))
     return t0
 end
 
+"""
+    toq()
+
+Return, but do not print, the time elapsed since the last [`tic`](:func:`tic`).
+"""
 function toq()
     t1 = time_ns()
     timers = get(task_local_storage(), :TIMERS, ())
@@ -83,6 +94,11 @@ function toq()
     (t1-t0)/1e9
 end
 
+"""
+    toc()
+
+Print and return the time elapsed since the last [`tic`](:func:`tic`).
+"""
 function toc()
     t = toq()
     println("elapsed time: ", t, " seconds")
@@ -149,6 +165,13 @@ function timev_print(elapsedtime, diff::GC_Diff)
     padded_nonzero_print(diff.full_sweep,   "full collections")
 end
 
+"""
+    @time
+
+A macro to execute an expression, printing the time it took to execute, the number of
+allocations, and the total number of bytes its execution caused to be allocated, before
+returning the value of the expression.
+"""
 macro time(ex)
     quote
         local stats = gc_num()
@@ -162,6 +185,13 @@ macro time(ex)
     end
 end
 
+"""
+    @timev
+
+This is a verbose version of the `@time` macro. It first prints the same information as
+`@time`, then any non-zero memory allocation counters, and then returns the value of the
+expression.
+"""
 macro timev(ex)
     quote
         local stats = gc_num()
@@ -173,7 +203,12 @@ macro timev(ex)
     end
 end
 
-# print nothing, return elapsed time
+"""
+    @elapsed
+
+A macro to evaluate an expression, discarding the resulting value, instead returning the
+number of seconds it took to execute as a floating-point number.
+"""
 macro elapsed(ex)
     quote
         local t0 = time_ns()
@@ -188,7 +223,16 @@ end
 # like:  @allocated y = foo()
 # will not work correctly, because it will set y in the context of
 # the local function made by the macro, not the current function
+"""
+    @allocated
 
+A macro to evaluate an expression, discarding the resulting value, instead returning the
+total number of bytes allocated during evaluation of the expression. Note: the expression is
+evaluated inside a local function, instead of the current context, in order to eliminate the
+effects of compilation, however, there still may be some allocations due to JIT compilation.
+This also makes the results inconsistent with the `@time` macros, which do not try to adjust
+for the effects of compilation.
+"""
 macro allocated(ex)
     quote
         let
@@ -203,7 +247,13 @@ macro allocated(ex)
     end
 end
 
-# print nothing, return value, elapsed time, bytes allocated & gc time
+"""
+    @timed
+
+A macro to execute an expression, and return the value of the expression, elapsed time,
+total bytes allocated, garbage collection time, and an object with various memory allocation
+counters.
+"""
 macro timed(ex)
     quote
         local stats = gc_num()

--- a/base/util.jl
+++ b/base/util.jl
@@ -81,7 +81,8 @@ end
 """
     toq()
 
-Return, but do not print, the time elapsed since the last [`tic`](:func:`tic`).
+Return, but do not print, the time elapsed since the last [`tic`](:func:`tic`). The
+macro calls `@timed expr` and `@elapsed expr` also return evaluation time.
 """
 function toq()
     t1 = time_ns()
@@ -97,7 +98,8 @@ end
 """
     toc()
 
-Print and return the time elapsed since the last [`tic`](:func:`tic`).
+Print and return the time elapsed since the last [`tic`](:func:`tic`). The macro call
+`@time expr` can also be used to time evaluation.
 """
 function toc()
     t = toq()
@@ -171,6 +173,9 @@ end
 A macro to execute an expression, printing the time it took to execute, the number of
 allocations, and the total number of bytes its execution caused to be allocated, before
 returning the value of the expression.
+
+See also [`@timev`](:ref:@timev), [`@timed`](:ref:@timed), [`@elapsed`](:ref:@elapsed), and
+[`@allocated`](:ref:@allocated).
 """
 macro time(ex)
     quote
@@ -191,6 +196,9 @@ end
 This is a verbose version of the `@time` macro. It first prints the same information as
 `@time`, then any non-zero memory allocation counters, and then returns the value of the
 expression.
+
+See also [`@time`](:ref:@time), [`@timed`](:ref:@timed), [`@elapsed`](:ref:@elapsed), and
+[`@allocated`](:ref:@allocated).
 """
 macro timev(ex)
     quote
@@ -208,6 +216,9 @@ end
 
 A macro to evaluate an expression, discarding the resulting value, instead returning the
 number of seconds it took to execute as a floating-point number.
+
+See also [`@time`](:ref:@time), [`@timev`](:ref:@timev), [`@timed`](:ref:@timed),
+and [`@allocated`](:ref:@allocated).
 """
 macro elapsed(ex)
     quote
@@ -232,6 +243,9 @@ evaluated inside a local function, instead of the current context, in order to e
 effects of compilation, however, there still may be some allocations due to JIT compilation.
 This also makes the results inconsistent with the `@time` macros, which do not try to adjust
 for the effects of compilation.
+
+See also [`@time`](:ref:@time), [`@timev`](:ref:@timev), [`@timed`](:ref:@timed),
+and [`@elapsed`](:ref:@elapsed).
 """
 macro allocated(ex)
     quote
@@ -253,6 +267,9 @@ end
 A macro to execute an expression, and return the value of the expression, elapsed time,
 total bytes allocated, garbage collection time, and an object with various memory allocation
 counters.
+
+See also [`@time`](:ref:@time), [`@timev`](:ref:@timev), [`@elapsed`](:ref:@elapsed), and
+[`@allocated`](:ref:@allocated).
 """
 macro timed(ex)
     quote

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -957,13 +957,13 @@ System
 
    .. Docstring generated from Julia source
 
-   Print and return the time elapsed since the last :func:`tic`\ .
+   Print and return the time elapsed since the last :func:`tic`\ . The macro call ``@time expr`` can also be used to time evaluation.
 
 .. function:: toq()
 
    .. Docstring generated from Julia source
 
-   Return, but do not print, the time elapsed since the last :func:`tic`\ .
+   Return, but do not print, the time elapsed since the last :func:`tic`\ . The macro calls ``@timed expr`` and ``@elapsed expr`` also return evaluation time.
 
 .. function:: @time
 
@@ -971,11 +971,15 @@ System
 
    A macro to execute an expression, printing the time it took to execute, the number of allocations, and the total number of bytes its execution caused to be allocated, before returning the value of the expression.
 
+   See also ```@timev`` <:ref:@timev>`_\ , ```@timed`` <:ref:@timed>`_\ , ```@elapsed`` <:ref:@elapsed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
+
 .. function:: @timev
 
    .. Docstring generated from Julia source
 
    This is a verbose version of the ``@time`` macro. It first prints the same information as ``@time``\ , then any non-zero memory allocation counters, and then returns the value of the expression.
+
+   See also ```@time`` <:ref:@time>`_\ , ```@timed`` <:ref:@timed>`_\ , ```@elapsed`` <:ref:@elapsed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
 
 .. function:: @timed
 
@@ -983,17 +987,23 @@ System
 
    A macro to execute an expression, and return the value of the expression, elapsed time, total bytes allocated, garbage collection time, and an object with various memory allocation counters.
 
+   See also ```@time`` <:ref:@time>`_\ , ```@timev`` <:ref:@timev>`_\ , ```@elapsed`` <:ref:@elapsed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
+
 .. function:: @elapsed
 
    .. Docstring generated from Julia source
 
    A macro to evaluate an expression, discarding the resulting value, instead returning the number of seconds it took to execute as a floating-point number.
 
+   See also ```@time`` <:ref:@time>`_\ , ```@timev`` <:ref:@timev>`_\ , ```@timed`` <:ref:@timed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
+
 .. function:: @allocated
 
    .. Docstring generated from Julia source
 
    A macro to evaluate an expression, discarding the resulting value, instead returning the total number of bytes allocated during evaluation of the expression. Note: the expression is evaluated inside a local function, instead of the current context, in order to eliminate the effects of compilation, however, there still may be some allocations due to JIT compilation. This also makes the results inconsistent with the ``@time`` macros, which do not try to adjust for the effects of compilation.
+
+   See also ```@time`` <:ref:@time>`_\ , ```@timev`` <:ref:@timev>`_\ , ```@timed`` <:ref:@timed>`_\ , and ```@elapsed`` <:ref:@elapsed>`_\ .
 
 .. function:: EnvHash() -> EnvHash
 


### PR DESCRIPTION
I've moved docstrings inline and included some cross references for `@time`, `@timev`, `@timed`, `@elapsed`, `@allocated`, `tic`, `toc`, and `toq`. Thanks!
