### PR TITLE
Change the documentation for `fld` 

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -5206,7 +5206,7 @@ julia> deleteat!([6, 5, 4, 3, 2, 1], 1:2:5)
 
 julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
 ERROR: ArgumentError: indices must be unique and sorted
- in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:534
+ in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:537
  ...
 ```
 """

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2603,7 +2603,7 @@ creates a task, and does not run it.
 """
     fld(x, y)
 
-Largest integer less than or equal to `x/y`.
+Largest integer `n` such that `y * n` less than or equal to `x`.
 """
 fld
 

--- a/doc/devdocs/reflection.rst
+++ b/doc/devdocs/reflection.rst
@@ -106,10 +106,7 @@ variable assignments:
    julia> expand( :(f() = 1) )
    :(begin
            $(Expr(:method, :f))
-           $(Expr(:method, :f, :((Core.svec)((Core.apply_type)(Tuple,(Core.Typeof)(f)),(Core.svec)())), Toplevel LambdaInfo thunk
-   :(begin  # none, line 1:
-           return 1
-       end), false))
+           $(Expr(:method, :f, :((Core.svec)((Core.apply_type)(Tuple,(Core.Typeof)(f)),(Core.svec)())), Toplevel LambdaInfo thunk, false))
            return f
        end)
 

--- a/doc/devdocs/types.rst
+++ b/doc/devdocs/types.rst
@@ -228,7 +228,7 @@ These therefore print identically, but they have very different behavior:
    julia> candid([1],3.2)
    ERROR: MethodError: no method matching candid(::Array{Int64,1}, ::Float64)
    Closest candidates are:
-     candid{T}(::Array{T,N}, !Matched::T)
+     candid{T}(::Array{T,N}, !Matched::T) at none:1
     ...
 
    julia> sneaky([1],3.2)
@@ -319,9 +319,11 @@ the type, which is an object of type :obj:`TypeName`:
      primary: Array{T,N} <: DenseArray{T,N}
      cache: SimpleVector
        ...
+
      linearcache: SimpleVector
        ...
-     uid: Int64 47
+
+     uid: Int64 -7900426068641098781
      mt: MethodTable
        name: Symbol Array
        defs: Void nothing

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -159,7 +159,7 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``:
     julia> sqrt(-1)
     ERROR: DomainError:
     sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
-     in sqrt(::Int64) at ./math.jl:149
+     in sqrt(::Int64) at ./math.jl:154
      ...
 
     julia> sqrt(-1 + 0im)

--- a/doc/manual/constructors.rst
+++ b/doc/manual/constructors.rst
@@ -327,8 +327,8 @@ types of the arguments given to the constructor. Here are some examples:
     julia> Point(1,2.5)
     ERROR: MethodError: no method matching Point{T<:Real}(::Int64, ::Float64)
     Closest candidates are:
-      Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real)
-      Point{T<:Real}{T}(::Any)
+      Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real) at none:2
+      Point{T<:Real}{T}(::Any) at sysimg.jl:53
      ...
 
     ## explicit T ##
@@ -426,8 +426,8 @@ However, other similar calls still don't work:
     julia> Point(1.5,2)
     ERROR: MethodError: no method matching Point{T<:Real}(::Float64, ::Int64)
     Closest candidates are:
-      Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real)
-      Point{T<:Real}{T}(::Any)
+      Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real) at none:2
+      Point{T<:Real}{T}(::Any) at sysimg.jl:53
      ...
 
 For a much more general way of making all such calls work sensibly, see

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -666,7 +666,7 @@ negative real value:
     julia> sqrt(-1)
     ERROR: DomainError:
     sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
-     in sqrt(::Int64) at ./math.jl:149
+     in sqrt(::Int64) at ./math.jl:154
      ...
 
 You may define your own exceptions in the following way:

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -412,7 +412,7 @@ function (although it often is):
     julia> baz(args...)
     ERROR: MethodError: no method matching baz(::Int64, ::Int64, ::Int64)
     Closest candidates are:
-      baz(::Any, ::Any)
+      baz(::Any, ::Any) at none:1
     ...
 
 As you can see, if the wrong number of elements are in the spliced

--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -95,24 +95,24 @@ Applying it to any other types of arguments will result in a :exc:`MethodError`:
     julia> f(2.0, 3)
     ERROR: MethodError: no method matching f(::Float64, ::Int64)
     Closest candidates are:
-      f(::Float64, !Matched::Float64)
-     ...
+      f(::Float64, !Matched::Float64) at none:1
+    ...
 
     julia> f(Float32(2.0), 3.0)
     ERROR: MethodError: no method matching f(::Float32, ::Float64)
     Closest candidates are:
-      f(!Matched::Float64, ::Float64)
-     ...
+      f(!Matched::Float64, ::Float64) at none:1
+    ...
 
     julia> f(2.0, "3.0")
     ERROR: MethodError: no method matching f(::Float64, ::String)
     Closest candidates are:
-      f(::Float64, !Matched::Float64)
-     ...
+      f(::Float64, !Matched::Float64) at none:1
+    ...
 
     julia> f("2.0", "3.0")
     ERROR: MethodError: no method matching f(::String, ::String)
-     ...
+    ...
 
 As you can see, the arguments must be precisely of type :obj:`Float64`.
 Other numeric types, such as integers or 32-bit floating-point values,
@@ -179,15 +179,16 @@ function ``f`` remains undefined, and applying it will still result in a
     julia> f("foo", 3)
     ERROR: MethodError: no method matching f(::String, ::Int64)
     Closest candidates are:
-      f(!Matched::Number, ::Number)
-     ...
+      f(!Matched::Number, ::Number) at none:1
+    ...
 
     julia> f()
     ERROR: MethodError: no method matching f()
     Closest candidates are:
-      f(!Matched::Float64, !Matched::Float64)
-      f(!Matched::Number, !Matched::Number)
-     ...
+      f(!Matched::Float64, !Matched::Float64) at none:1
+      f(!Matched::Number, !Matched::Number) at none:1
+    ...
+
 
 You can easily see which methods exist for a function by entering the
 function object itself in an interactive session:
@@ -379,8 +380,8 @@ signature:
     julia> myappend([1,2,3],2.5)
     ERROR: MethodError: no method matching myappend(::Array{Int64,1}, ::Float64)
     Closest candidates are:
-      myappend{T}(::Array{T,1}, !Matched::T)
-     ...
+      myappend{T}(::Array{T,1}, !Matched::T) at none:1
+    ...
 
     julia> myappend([1.0,2.0,3.0],4.0)
     4-element Array{Float64,1}:
@@ -392,8 +393,8 @@ signature:
     julia> myappend([1.0,2.0,3.0],4)
     ERROR: MethodError: no method matching myappend(::Array{Float64,1}, ::Int64)
     Closest candidates are:
-      myappend{T}(::Array{T,1}, !Matched::T)
-     ...
+      myappend{T}(::Array{T,1}, !Matched::T) at none:1
+    ...
 
 As you can see, the type of the appended element must match the element
 type of the vector it is appended to, or else a :exc:`MethodError` is raised.

--- a/doc/manual/stacktraces.rst
+++ b/doc/manual/stacktraces.rst
@@ -90,7 +90,6 @@ Each :obj:`StackFrame` contains the function name, file name, line number, lambd
 
     julia> top_frame.linfo
     Nullable{LambdaInfo}(LambdaInfo for eval(::Module, ::Any))
-    ...
 
     julia> top_frame.inlined
     false

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -553,8 +553,8 @@ contained in a string:
     julia> contains("Xylophon", 'o')
     ERROR: MethodError: no method matching contains(::String, ::Char)
     Closest candidates are:
-      contains(!Matched::Function, ::Any, !Matched::Any)
-      contains(::AbstractString, !Matched::AbstractString)
+      contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:402
+      contains(::AbstractString, !Matched::AbstractString) at strings/search.jl:310
      ...
 
 The last error is because ``'o'`` is a character literal, and :func:`contains`

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -769,8 +769,8 @@ each field:
     julia> Point{Float64}(1.0,2.0,3.0)
     ERROR: MethodError: no method matching Point{Float64}(::Float64, ::Float64, ::Float64)
     Closest candidates are:
-      Point{Float64}{T}(::Any, ::Any)
-      Point{Float64}{T}(::Any)
+      Point{Float64}{T}(::Any, ::Any) at none:3
+      Point{Float64}{T}(::Any) at sysimg.jl:53
      ...
 
 Only one default constructor is generated for parametric types, since

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -1162,7 +1162,7 @@ Dequeues
 
        julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
        ERROR: ArgumentError: indices must be unique and sorted
-        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:534
+        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:537
         ...
 
 .. function:: splice!(collection, index, [replacement]) -> item


### PR DESCRIPTION
This changes the docstring to "Largest integer `n` such that `y * n` less than or equal to `x`", at @yuyichao 's suggestion, and general approval in https://github.com/JuliaLang/julia/issues/17415. 

Also, this fixes #17415. 
