### PR TITLE
Improve `fld` documentation

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2603,7 +2603,7 @@ creates a task, and does not run it.
 """
     fld(x, y)
 
-Largest integer `n` such that `y * n` less than or equal to `x`. Note that this can be
+Largest integer `n` such that `y * n` is less than or equal to `x`. Note that this can be
 different from `floor(x/y)` due to floating point rounding.
 """
 fld

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2603,7 +2603,7 @@ creates a task, and does not run it.
 """
     fld(x, y)
 
-Largest integer less than or equal to `x/y`.
+Largest integer `n` such that `y * n` less than or equal to `x`.
 """
 fld
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2603,7 +2603,8 @@ creates a task, and does not run it.
 """
     fld(x, y)
 
-Largest integer `n` such that `y * n` less than or equal to `x`.
+Largest integer `n` such that `y * n` less than or equal to `x`. Note that this can be
+different from `floor(x/y)` due to floating point rounding.
 """
 fld
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -122,7 +122,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Largest integer less than or equal to ``x/y``\ .
+   Largest integer ``n`` such that ``y * n`` is less than or equal to ``x``\ . Note that this can be different from ``floor(x/y)`` due to floating point rounding.
 
 .. function:: cld(x, y)
 


### PR DESCRIPTION
This changes the docstring to "Largest integer n such that y \* n less than or equal to x", at @yuyichao 's suggestion, and general approval in #17415.

Also, this fixes #17415.
