### PR TITLE
WIP: Optimize exception frames allocation

### DIFF
--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -163,21 +163,8 @@ void LowerPTLS::runOnFunction(LLVMContext &ctx, Module &M, Function *F,
 #endif
 }
 
-static void eraseFunction(Module &M, const char *name)
-{
-    if (Function *f = M.getFunction(name)) {
-        f->eraseFromParent();
-    }
-}
-
 bool LowerPTLS::runOnModule(Module &M)
 {
-    // Cleanup for GC frame lowering.
-    eraseFunction(M, "julia.gc_root_decl");
-    eraseFunction(M, "julia.gc_root_kill");
-    eraseFunction(M, "julia.jlcall_frame_decl");
-    eraseFunction(M, "julia.gcroot_flush");
-
     Function *ptls_getter = M.getFunction("jl_get_ptls_states");
     if (!ptls_getter)
         return true;


### PR DESCRIPTION
- Make llvm-gcroot a ModulePass
- Use llvm-gcroot to calculate the minimum number of exception frames necessary.

This is an exercise for implementing a more precise liveness analysis and should also be useful for fixing https://github.com/JuliaLang/julia/issues/15369 without suffering from https://github.com/JuliaLang/julia/issues/17288.

The algorithm should be complete. Mark as WIP since this needs more cleanup, testing and possibly fixing compatibility with old LLVM versions. Should also wait after branching.
