### PR TITLE
Documentation formatting fixes

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -174,8 +174,8 @@ A macro to execute an expression, printing the time it took to execute, the numb
 allocations, and the total number of bytes its execution caused to be allocated, before
 returning the value of the expression.
 
-See also [`@timev`](:ref:@timev), [`@timed`](:ref:@timed), [`@elapsed`](:ref:@elapsed), and
-[`@allocated`](:ref:@allocated).
+See also [`@timev`](:func:`@timev`), [`@timed`](:func:`@timed`), [`@elapsed`](:func:`@elapsed`), and
+[`@allocated`](:func:`@allocated`).
 """
 macro time(ex)
     quote
@@ -197,8 +197,8 @@ This is a verbose version of the `@time` macro. It first prints the same informa
 `@time`, then any non-zero memory allocation counters, and then returns the value of the
 expression.
 
-See also [`@time`](:ref:@time), [`@timed`](:ref:@timed), [`@elapsed`](:ref:@elapsed), and
-[`@allocated`](:ref:@allocated).
+See also [`@time`](:func:`@time`), [`@timed`](:func:`@timed`), [`@elapsed`](:func:`@elapsed`), and
+[`@allocated`](:func:`@allocated`).
 """
 macro timev(ex)
     quote
@@ -217,8 +217,8 @@ end
 A macro to evaluate an expression, discarding the resulting value, instead returning the
 number of seconds it took to execute as a floating-point number.
 
-See also [`@time`](:ref:@time), [`@timev`](:ref:@timev), [`@timed`](:ref:@timed),
-and [`@allocated`](:ref:@allocated).
+See also [`@time`](:func:`@time`), [`@timev`](:func:`@timev`), [`@timed`](:func:`@timed`),
+and [`@allocated`](:func:`@allocated`).
 """
 macro elapsed(ex)
     quote
@@ -244,8 +244,8 @@ effects of compilation, however, there still may be some allocations due to JIT 
 This also makes the results inconsistent with the `@time` macros, which do not try to adjust
 for the effects of compilation.
 
-See also [`@time`](:ref:@time), [`@timev`](:ref:@timev), [`@timed`](:ref:@timed),
-and [`@elapsed`](:ref:@elapsed).
+See also [`@time`](:func:`@time`), [`@timev`](:func:`@timev`), [`@timed`](:func:`@timed`),
+and [`@elapsed`](:func:`@elapsed`).
 """
 macro allocated(ex)
     quote
@@ -268,8 +268,8 @@ A macro to execute an expression, and return the value of the expression, elapse
 total bytes allocated, garbage collection time, and an object with various memory allocation
 counters.
 
-See also [`@time`](:ref:@time), [`@timev`](:ref:@timev), [`@elapsed`](:ref:@elapsed), and
-[`@allocated`](:ref:@allocated).
+See also [`@time`](:func:`@time`), [`@timev`](:func:`@timev`), [`@elapsed`](:func:`@elapsed`), and
+[`@allocated`](:func:`@allocated`).
 """
 macro timed(ex)
     quote

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -121,7 +121,7 @@ own such constructs.)
 
 An important thing to remember is that, once fetched, a :class:`Future` will cache its value
 locally. Further :func:`fetch` calls do not entail a network hop. Once all referencing
-:class:`Future`s have fetched, the remote stored value is deleted.
+:class:`Future`\ s have fetched, the remote stored value is deleted.
 
 
 .. _man-parallel-computing-code-availability:
@@ -858,10 +858,12 @@ Custom cluster managers would typically specify only ``io`` or ``host`` / ``port
 - ``count``, ``exename`` and ``exeflags`` are relevant for launching additional workers from a worker.
   For example, a cluster manager may launch a single worker per node, and use that to launch
   additional workers.
-    - ``count`` with an integer value ``n`` will launch a total of ``n`` workers.
-    - ``count`` with a value of ``:auto`` will launch as many workers as cores on that machine.
-    - ``exename`` is the name of the ``julia`` executable including the full path.
-    - ``exeflags`` should be set to the required command line arguments for new workers.
+
+  - ``count`` with an integer value ``n`` will launch a total of ``n`` workers.
+  - ``count`` with a value of ``:auto`` will launch as many workers as cores on that machine.
+  - ``exename`` is the name of the ``julia`` executable including the full path.
+  - ``exeflags`` should be set to the required command line arguments for new workers.
+
 - ``tunnel``, ``bind_addr``, ``sshflags`` and ``max_parallel`` are used when a ssh tunnel is
   required to connect to the workers from the master process.
 - ``userdata`` is provided for custom cluster managers to store their own worker specific information.

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -971,7 +971,7 @@ System
 
    A macro to execute an expression, printing the time it took to execute, the number of allocations, and the total number of bytes its execution caused to be allocated, before returning the value of the expression.
 
-   See also ```@timev`` <:ref:@timev>`_\ , ```@timed`` <:ref:@timed>`_\ , ```@elapsed`` <:ref:@elapsed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
+   See also :func:`@timev`\ , :func:`@timed`\ , :func:`@elapsed`\ , and :func:`@allocated`\ .
 
 .. function:: @timev
 
@@ -979,7 +979,7 @@ System
 
    This is a verbose version of the ``@time`` macro. It first prints the same information as ``@time``\ , then any non-zero memory allocation counters, and then returns the value of the expression.
 
-   See also ```@time`` <:ref:@time>`_\ , ```@timed`` <:ref:@timed>`_\ , ```@elapsed`` <:ref:@elapsed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
+   See also :func:`@time`\ , :func:`@timed`\ , :func:`@elapsed`\ , and :func:`@allocated`\ .
 
 .. function:: @timed
 
@@ -987,7 +987,7 @@ System
 
    A macro to execute an expression, and return the value of the expression, elapsed time, total bytes allocated, garbage collection time, and an object with various memory allocation counters.
 
-   See also ```@time`` <:ref:@time>`_\ , ```@timev`` <:ref:@timev>`_\ , ```@elapsed`` <:ref:@elapsed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
+   See also :func:`@time`\ , :func:`@timev`\ , :func:`@elapsed`\ , and :func:`@allocated`\ .
 
 .. function:: @elapsed
 
@@ -995,7 +995,7 @@ System
 
    A macro to evaluate an expression, discarding the resulting value, instead returning the number of seconds it took to execute as a floating-point number.
 
-   See also ```@time`` <:ref:@time>`_\ , ```@timev`` <:ref:@timev>`_\ , ```@timed`` <:ref:@timed>`_\ , and ```@allocated`` <:ref:@allocated>`_\ .
+   See also :func:`@time`\ , :func:`@timev`\ , :func:`@timed`\ , and :func:`@allocated`\ .
 
 .. function:: @allocated
 
@@ -1003,7 +1003,7 @@ System
 
    A macro to evaluate an expression, discarding the resulting value, instead returning the total number of bytes allocated during evaluation of the expression. Note: the expression is evaluated inside a local function, instead of the current context, in order to eliminate the effects of compilation, however, there still may be some allocations due to JIT compilation. This also makes the results inconsistent with the ``@time`` macros, which do not try to adjust for the effects of compilation.
 
-   See also ```@time`` <:ref:@time>`_\ , ```@timev`` <:ref:@timev>`_\ , ```@timed`` <:ref:@timed>`_\ , and ```@elapsed`` <:ref:@elapsed>`_\ .
+   See also :func:`@time`\ , :func:`@timev`\ , :func:`@timed`\ , and :func:`@elapsed`\ .
 
 .. function:: EnvHash() -> EnvHash
 


### PR DESCRIPTION
Macro reference syntax uses `:func:` rather than `:ref:`, which is just for section titles. Add space between a backtick and next character to correctly parse reference. Correct indent of a sublist which sphinx parsed as a list within a blockquote within another list.
