### PR TITLE
fix 2 printing issues

### DIFF
--- a/base/grisu/grisu.jl
+++ b/base/grisu/grisu.jl
@@ -86,7 +86,7 @@ function _show(io::IO, x::AbstractFloat, mode, n::Int, typed, nanstr, infstr)
         else
             write(io, '0')
         end
-        write(io, typed && isa(x,Float32) ? 'f' : 'e')
+        write(io, isa(x,Float32) ? 'f' : 'e')
         write(io, dec(pt-1))
         typed && isa(x,Float16) && write(io, ")")
         return

--- a/base/show.jl
+++ b/base/show.jl
@@ -653,6 +653,10 @@ function show_generator(io, ex, indent)
         show_unquoted(io, ex.args[1], indent)
         print(io, " for ")
         show_unquoted(io, ex.args[2], indent)
+        for i = 3:length(ex.args)
+            print(io, ", ")
+            show_unquoted(io, ex.args[i], indent)
+        end
     end
 end
 
@@ -792,7 +796,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show_generator(io, args[1], indent)
         print(io, ']')
 
-    elseif head === :generator && length(args) == 2
+    elseif (head === :generator && length(args) >= 2) || (head === :flatten && length(args) == 1)
         print(io, '(')
         show_generator(io, ex, indent)
         print(io, ')')
@@ -801,9 +805,6 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show_unquoted(io, args[2], indent)
         print(io, " if ")
         show_unquoted(io, args[1], indent)
-
-    elseif head === :flatten && length(args) == 1
-        show_generator(io, ex, indent)
 
     elseif is(head, :ccall)
         show_unquoted(io, :ccall, indent)

--- a/test/show.jl
+++ b/test/show.jl
@@ -5,6 +5,7 @@ replstr(x) = sprint((io,x) -> show(IOContext(io, limit=true), MIME("text/plain")
 @test replstr(Array{Any}(2)) == "2-element Array{Any,1}:\n #undef\n #undef"
 @test replstr(Array{Any}(2,2)) == "2×2 Array{Any,2}:\n #undef  #undef\n #undef  #undef"
 @test replstr(Array{Any}(2,2,2)) == "2×2×2 Array{Any,3}:\n[:, :, 1] =\n #undef  #undef\n #undef  #undef\n\n[:, :, 2] =\n #undef  #undef\n #undef  #undef"
+@test replstr([1f10]) == "1-element Array{Float32,1}:\n 1.0f10"
 
 immutable T5589
     names::Vector{String}

--- a/test/show.jl
+++ b/test/show.jl
@@ -557,10 +557,11 @@ end
 @test repr(Core.svec(1,2)) == "svec(1,2)"
 
 # showing generator and comprehension expressions
-@test repr(:(x for x in y for z in w)) == ":(x for x = y for z = w)"
-@test repr(:(x for x in y if aa for z in w if bb)) == ":(x for x = y if aa for z = w if bb)"
+@test repr(:(x for x in y for z in w)) == ":((x for x = y for z = w))"
+@test repr(:(x for x in y if aa for z in w if bb)) == ":((x for x = y if aa for z = w if bb))"
 @test repr(:([x for x = y])) == ":([x for x = y])"
 @test repr(:([x for x = y if z])) == ":([x for x = y if z])"
+@test repr(:(z for z = 1:5, y = 1:5)) == ":((z for z = 1:5, y = 1:5))"
 
 for op in (:(.=), :(.+=), :(.&=))
     @test repr(parse("x $op y")) == ":(x $op y)"


### PR DESCRIPTION
- #17712, `show` of generator exprs with >1 range
- #17720, showcompact shows Float32s with `e` instead of `f`
