### PR TITLE
make flipdim require an in-bounds dimension argument

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -67,14 +67,14 @@ function slicedim(A::AbstractArray, d::Integer, i)
 end
 
 function flipdim(A::AbstractVector, d::Integer)
-    d > 0 || throw(ArgumentError("dimension to flip must be positive"))
-    d == 1 || return copy(A)
+    d == 1 || throw(ArgumentError("dimension to flip must be 1"))
     reverse(A)
 end
 
 function flipdim(A::AbstractArray, d::Integer)
     nd = ndims(A)
-    if d > nd || isempty(A)
+    1 ≤ d ≤ nd || throw(ArgumentError("dimension $d is not 1 ≤ $d ≤ $nd"))
+    if isempty(A)
         return copy(A)
     end
     inds = indices(A)

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -97,11 +97,9 @@ end
 ## data movement ##
 
 function flipdim{T}(A::Array{T}, d::Integer)
-    if d < 1
-        throw(ArgumentError("dimension d must be ≥ 1"))
-    end
     nd = ndims(A)
-    sd = d > nd ? 1 : size(A, d)
+    1 ≤ d ≤ nd || throw(ArgumentError("dimension $d is not 1 ≤ $d ≤ $nd"))
+    sd = size(A, d)
     if sd == 1 || isempty(A)
         return copy(A)
     end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1273,7 +1273,8 @@ end
 
 function flipdim(A::BitArray, d::Integer)
     nd = ndims(A)
-    sd = d > nd ? 1 : size(A, d)
+    1 ≤ d ≤ nd || throw(ArgumentError("dimension $d is not 1 ≤ $d ≤ $nd"))
+    sd = size(A, d)
     if sd == 1
         return copy(A)
     end

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1086,4 +1086,3 @@ dense counterparts. The following functions are specific to sparse arrays.
    For additional (algorithmic) information, and for versions of these methods that forgo argument checking, see (unexported) parent methods :func:`Base.SparseArrays.unchecked_noalias_permute!` and :func:`Base.SparseArrays.unchecked_aliasing_permute!`\ .
 
    See also: :func:`Base.SparseArrays.permute`
-

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1019,12 +1019,12 @@ end
 
 # flipdim
 @test isequal(flipdim([2,3,1], 1), [1,3,2])
-@test isequal(flipdim([2,3,1], 2), [2,3,1])
+@test_throws ArgumentError flipdim([2,3,1], 2)
 @test isequal(flipdim([2 3 1], 1), [2 3 1])
 @test isequal(flipdim([2 3 1], 2), [1 3 2])
 @test_throws ArgumentError flipdim([2,3,1], -1)
 @test isequal(flipdim(1:10, 1), 10:-1:1)
-@test isequal(flipdim(1:10, 2), 1:10)
+@test_throws ArgumentError flipdim(1:10, 2)
 @test_throws ArgumentError flipdim(1:10, -1)
 @test isequal(flipdim(Array{Int}(0,0),1), Array{Int}(0,0))  # issue #5872
 
@@ -1415,7 +1415,7 @@ ctranspose!(a,b)
 # flipdim
 a = rand(5,3)
 @test flipdim(flipdim(a,2),2) == a
-@test flipdim(a,3) == a
+@test_throws ArgumentError flipdim(a,3)
 
 # bounds checking for copy!
 a = rand(5,3)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -861,7 +861,7 @@ for d = 1 : 4
     #end
     @check_bit_operation flipdim(b1, d) BitArray{4}
 end
-@check_bit_operation flipdim(b1, 5) BitArray{4}
+@test_throws ArgumentError flipdim(b1, 5)
 
 b1 = bitrand(n1, n2)
 for k = 1 : 4


### PR DESCRIPTION
This fixes #17752.

Since the old behavior was clearly intentional (and was even tested for), I was initially inclined to wait until 0.6 for this.   That being said, I'm skeptical that anyone was relying on the old behavior — I couldn't find any (correct) examples in the packages, and in fact it looks like throwing an error would have caught a couple of bugs.

_Update:_ The consensus in #17752 seems to be to fix this now, for 0.5.
