### PR TITLE
restore getfield deprecation for foo.(1) etc.

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1682,7 +1682,9 @@
                    (else
                     (cf (cdr old-fargs) (cdr old-args)
                         (cons farg new-fargs) (cons arg new-args) renames varfarg vararg))))))
-          (cf (cdadr f) args '() '() '() '() '()))
+          (if (and (= (length args) 1) (integer? (car args)))
+              e ; hack: don't compress e.g. f.(1) so that deprecation for getfield works
+              (cf (cdadr f) args '() '() '() '() '())))
         e)) ; (not (fuse? e))
   (let ((e (compress-fuse (dot-to-fuse rhs))) ; an expression '(fuse func args) if expr is a dot call
         (lhs-view (ref-to-view lhs))) ; x[...] expressions on lhs turn in to view(x, ...) to update x in-place

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -174,6 +174,7 @@ rt = Base.return_types(broadcast!, Tuple{Function, Array{Float64, 3}, Array{Floa
 let x = [1,3.2,4.7], y = [3.5, pi, 1e-4], α = 0.2342
     @test sin.(x) == broadcast(sin, x)
     @test sin.(α) == broadcast(sin, α)
+    @test sin.(3.2) == broadcast(sin, 3.2) == sin(3.2)
     @test factorial.(3) == broadcast(factorial, 3)
     @test atan2.(x, y) == broadcast(atan2, x, y)
     @test atan2.(x, y') == broadcast(atan2, x, y')


### PR DESCRIPTION
This restores the deprecation warning for `object.(i)` when `i` is a literal integer, which was accidentally broken by ~~#17318~~ #17300 as noticed by @tkelman.

(I'm not sure how to do a regression test for a deprecation warning. 😕)
