### PR TITLE
Fix exit status of install.sh script

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -27,3 +27,5 @@ for SRC in $ARGS; do
     # TODO: Test if it's a symlink instead of having to redirect stderr to /dev/null
     chmod $PERMS $DESTFILE 2>/dev/null
 done
+
+exit 0


### PR DESCRIPTION
Otherwise it can return a non-zero status even in case of success, and make the build fail.

_This is part of an effort to upstream all patches in the Debian julia package._
