### PR TITLE
Improve fft documentation

### DIFF
--- a/base/dft.jl
+++ b/base/dft.jl
@@ -398,8 +398,8 @@ if Base.USE_GPL_LIBS
     Notes
     =====
         
-    * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by 
-    increasing number of threads. Use `FFTW.set_num_threads(np)` to use `np` threads, 
+    * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by
+    increasing number of threads. Use `FFTW.set_num_threads(np)` to use `np` threads,
     if you have `np` processors.
 
     * This performs a multidimensional FFT by default. Other languages such as Python and Octave

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -395,8 +395,17 @@ if Base.USE_GPL_LIBS
 
     A multidimensional FFT simply performs this operation along each transformed dimension of `A`.
 
-    Higher performance is usually possible with multi-threading. Use `FFTW.set_num_threads(np)`
-    to use `np` threads, if you have `np` processors.
+    Notes
+    =====
+        
+    * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by 
+    increasing number of threads. Use `FFTW.set_num_threads(np)` to use `np` threads, 
+    if you have `np` processors.
+
+    * This performs a multidimensional FFT by default. Other languages such as Python and Octave
+    perform a one-dimensional FFT along the first non-singleton dimension of the array. This is
+    worth noting while performing comparisons. For more details, refer to the "Noteworthy
+    Differences from other Languages" section of the manual.
     """ ->
     fft
 

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -395,16 +395,15 @@ if Base.USE_GPL_LIBS
 
     A multidimensional FFT simply performs this operation along each transformed dimension of `A`.
 
-!!! notes
-        
-    * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by
-    increasing number of threads. Use `FFTW.set_num_threads(np)` to use `np` threads,
-    if you have `np` processors.
+    !!! note
+        * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by
+          increasing number of threads. Use `FFTW.set_num_threads(np)` to use `np` threads,
+          if you have `np` processors.
 
-    * This performs a multidimensional FFT by default. Other languages such as Python and Octave
-    perform a one-dimensional FFT along the first non-singleton dimension of the array. This is
-    worth noting while performing comparisons. For more details, refer to the "Noteworthy
-    Differences from other Languages" section of the manual.
+        * This performs a multidimensional FFT by default. Other languages such as Python and Octave
+          perform a one-dimensional FFT along the first non-singleton dimension of the array. This is
+          worth noting while performing comparisons. For more details, refer to the "Noteworthy
+          Differences from other Languages" section of the manual.
     """ ->
     fft
 

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -400,10 +400,10 @@ if Base.USE_GPL_LIBS
           increasing number of threads. Use `FFTW.set_num_threads(Sys.CPU_CORES)` to use as many
           threads as cores on your system.
 
-        * This performs a multidimensional FFT by default. Other languages such as Python and Octave
-          perform a one-dimensional FFT along the first non-singleton dimension of the array. This is
-          worth noting while performing comparisons. For more details, refer to the "Noteworthy
-          Differences from other Languages" section of the manual.
+        * This performs a multidimensional FFT by default. FFT libraries in other languages such as
+          Python and Octave perform a one-dimensional FFT along the first non-singleton dimension
+          of the array. This is worth noting while performing comparisons. For more details,
+          refer to the "Noteworthy Differences from other Languages" section of the manual
     """ ->
     fft
 

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -403,7 +403,7 @@ if Base.USE_GPL_LIBS
         * This performs a multidimensional FFT by default. FFT libraries in other languages such as
           Python and Octave perform a one-dimensional FFT along the first non-singleton dimension
           of the array. This is worth noting while performing comparisons. For more details,
-          refer to the "Noteworthy Differences from other Languages" section of the manual
+          refer to the "Noteworthy Differences from other Languages" section of the manual.
     """ ->
     fft
 

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -403,7 +403,8 @@ if Base.USE_GPL_LIBS
         * This performs a multidimensional FFT by default. FFT libraries in other languages such as
           Python and Octave perform a one-dimensional FFT along the first non-singleton dimension
           of the array. This is worth noting while performing comparisons. For more details,
-          refer to the "Noteworthy Differences from other Languages" section of the manual.
+          refer to the ["Noteworthy Differences from other Languages"](:ref:`man-noteworthy-differences`)
+          section of the manual.
     """ ->
     fft
 

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -397,8 +397,8 @@ if Base.USE_GPL_LIBS
 
     !!! note
         * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by
-          increasing number of threads. Use `FFTW.set_num_threads(np)` to use `np` threads,
-          if you have `np` processors.
+          increasing number of threads. Use `FFTW.set_num_threads(Sys.CPU_CORES)` to use as many
+          threads as cores on your system.
 
         * This performs a multidimensional FFT by default. Other languages such as Python and Octave
           perform a one-dimensional FFT along the first non-singleton dimension of the array. This is

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -395,8 +395,7 @@ if Base.USE_GPL_LIBS
 
     A multidimensional FFT simply performs this operation along each transformed dimension of `A`.
 
-    Notes
-    =====
+!!! notes
         
     * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by
     increasing number of threads. Use `FFTW.set_num_threads(np)` to use `np` threads,

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -666,7 +666,7 @@ negative real value:
     julia> sqrt(-1)
     ERROR: DomainError:
     sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
-     in sqrt(::Int64) at ./math.jl:185
+    in sqrt(::Int64) at ./math.jl:185
      ...
 
 You may define your own exceptions in the following way:

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -666,7 +666,7 @@ negative real value:
     julia> sqrt(-1)
     ERROR: DomainError:
     sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
-    in sqrt(::Int64) at ./math.jl:185
+     in sqrt(::Int64) at ./math.jl:185
      ...
 
 You may define your own exceptions in the following way:

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1828,7 +1828,7 @@ multi-threading. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads.
 
    .. note::
       * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by increasing number of threads. Use ``FFTW.set_num_threads(Sys.CPU_CORES)`` to use as many threads as cores on your system.
-      * This performs a multidimensional FFT by default. Other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the "Noteworthy Differences from other Languages" section of the manual.
+      * This performs a multidimensional FFT by default. FFT libraries in other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the "Noteworthy Differences from other Languages" section of the manual
 
 
 .. function:: fft!(A [, dims])

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1805,9 +1805,7 @@ Signal Processing
 
 Fast Fourier transform (FFT) functions in Julia are
 implemented by calling functions from `FFTW
-<http://www.fftw.org>`_. By default, Julia does not use multi-threaded
-FFTW. Higher performance may be obtained by experimenting with
-multi-threading. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads.
+<http://www.fftw.org>`_.
 
 .. function:: fft(A [, dims])
 
@@ -1828,7 +1826,7 @@ multi-threading. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads.
 
    .. note::
       * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by increasing number of threads. Use ``FFTW.set_num_threads(Sys.CPU_CORES)`` to use as many threads as cores on your system.
-      * This performs a multidimensional FFT by default. FFT libraries in other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the "Noteworthy Differences from other Languages" section of the manual
+      * This performs a multidimensional FFT by default. FFT libraries in other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the "Noteworthy Differences from other Languages" section of the manual.
 
 
 .. function:: fft!(A [, dims])

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1826,7 +1826,10 @@ multi-threading. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads.
 
    A multidimensional FFT simply performs this operation along each transformed dimension of ``A``\ .
 
-   Higher performance is usually possible with multi-threading. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads, if you have ``np`` processors.
+   .. note::
+      * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by increasing number of threads. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads, if you have ``np`` processors.
+      * This performs a multidimensional FFT by default. Other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the "Noteworthy Differences from other Languages" section of the manual.
+
 
 .. function:: fft!(A [, dims])
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1827,7 +1827,7 @@ multi-threading. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads.
    A multidimensional FFT simply performs this operation along each transformed dimension of ``A``\ .
 
    .. note::
-      * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by increasing number of threads. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads, if you have ``np`` processors.
+      * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by increasing number of threads. Use ``FFTW.set_num_threads(Sys.CPU_CORES)`` to use as many threads as cores on your system.
       * This performs a multidimensional FFT by default. Other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the "Noteworthy Differences from other Languages" section of the manual.
 
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1826,7 +1826,7 @@ implemented by calling functions from `FFTW
 
    .. note::
       * Julia starts FFTW up with 1 thread by default. Higher performance is usually possible by increasing number of threads. Use ``FFTW.set_num_threads(Sys.CPU_CORES)`` to use as many threads as cores on your system.
-      * This performs a multidimensional FFT by default. FFT libraries in other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the "Noteworthy Differences from other Languages" section of the manual.
+      * This performs a multidimensional FFT by default. FFT libraries in other languages such as Python and Octave perform a one-dimensional FFT along the first non-singleton dimension of the array. This is worth noting while performing comparisons. For more details, refer to the :ref:`man-noteworthy-differences` section of the manual.
 
 
 .. function:: fft!(A [, dims])


### PR DESCRIPTION
[ci skip]

This PR tries to improve the documentation of `fft`, by talking about how FFTW starts up with 1-thread, and how `fft` in Julia is different from `fft` in other languages. This is related to  #17000.
