### PR TITLE
Moved docs out of helpDB, way more examples

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1338,6 +1338,16 @@ Call function `f` on each element of iterable `c`.
 For multiple iterable arguments, `f` is called elementwise.
 `foreach` should be used instead of `map` when the results of `f` are not
 needed, for example in `foreach(println, array)`.
+
+```jldoctest
+julia> a
+1:3:7
+
+julia> foreach(x->println(x^2),a)
+1
+16
+49
+```
 """
 foreach(f) = (f(); nothing)
 foreach(f, itr) = (for x in itr; f(x); end; nothing)

--- a/base/array.jl
+++ b/base/array.jl
@@ -824,6 +824,17 @@ function findnz{T}(A::AbstractMatrix{T})
     return (I, J, NZs)
 end
 
+"""
+    findmax(itr) -> (x, index)
+
+Returns the maximum element and its index.
+The collection must not be empty.
+
+```jldoctest
+julia> findmax([8,0.1,-9,pi])
+(8.0,1)
+```
+"""
 function findmax(a)
     if isempty(a)
         throw(ArgumentError("collection must be non-empty"))
@@ -842,6 +853,17 @@ function findmax(a)
     return (m, mi)
 end
 
+"""
+    findmin(itr) -> (x, index)
+
+Returns the minimum element and its index.
+The collection must not be empty.
+
+```jldoctest
+julia> findmax([8,0.1,-9,pi])
+(-9.0,3)
+```
+"""
 function findmin(a)
     if isempty(a)
         throw(ArgumentError("collection must be non-empty"))
@@ -860,16 +882,87 @@ function findmin(a)
     return (m, mi)
 end
 
+"""
+    indmax(itr) -> Integer
+
+Returns the index of the maximum element in a collection.
+```jldoctest
+julia> indmax([8,0.1,-9,pi])
+1
+```
+"""
 indmax(a) = findmax(a)[2]
+
+"""
+    indmin(itr) -> Integer
+
+Returns the index of the minimum element in a collection.
+```jldoctest
+julia> indmin([8,0.1,-9,pi])
+3
+```
+"""
 indmin(a) = findmin(a)[2]
 
 # similar to Matlab's ismember
-# returns a vector containing the highest index in b for each value in a that is a member of b
+"""
+    indexin(a, b)
+
+Returns a vector containing the highest index in `b` for
+each value in `a` that is a member of `b` . The output
+vector contains 0 wherever `a` is not a member of `b`.
+
+```jldoctest
+julia> a = ['a', 'b', 'c', 'b', 'd', 'a'];
+
+julia> b = ['a','b','c']
+
+julia> indexin(a,b)
+6-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 2
+ 0
+ 1
+
+julia> indexin(b,a)
+3-element Array{Int64,1}:
+ 6
+ 4
+ 3
+```
+"""
 function indexin(a::AbstractArray, b::AbstractArray)
     bdict = Dict(zip(b, 1:length(b)))
     [get(bdict, i, 0) for i in a]
 end
 
+"""
+    findin(a, b)
+
+Returns the indices of elements in collection `a` that appear in collection `b`.
+
+```jldoctest
+julia> a = collect(1:3:15)
+5-element Array{Int64,1}:
+  1
+  4
+  7
+ 10
+ 13
+
+julia> b = collect(2:4:10)
+3-element Array{Int64,1}:
+  2
+  6
+ 10
+
+julia> findin(a,b) # 10 is the only common element
+1-element Array{Int64,1}:
+ 4
+```
+"""
 function findin(a, b)
     ind = Array{Int,1}(0)
     bset = Set(b)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -80,13 +80,6 @@ the woken task.
 schedule
 
 """
-    step(r)
-
-Get the step size of a [`Range`](:obj:`Range`) object.
-"""
-step
-
-"""
     takebuf_array(b::IOBuffer)
 
 Obtain the contents of an `IOBuffer` as an array, without copying. Afterwards, the
@@ -112,13 +105,6 @@ Return `string` with any leading whitespace removed. If `chars` (a character, or
 set of characters) is provided, instead remove characters contained in it.
 """
 lstrip
-
-"""
-    indmin(itr) -> Integer
-
-Returns the index of the minimum element in a collection.
-"""
-indmin
 
 """
     powermod(x, p, m)
@@ -1214,14 +1200,6 @@ greater than 1, and `x` must not be less than 1.
 prevpow
 
 """
-    indexin(a, b)
-
-Returns a vector containing the highest index in `b` for each value in `a` that is a member
-of `b` . The output vector contains 0 wherever `a` is not a member of `b`.
-"""
-indexin
-
-"""
     permutedims(A, perm)
 
 Permute the dimensions of array `A`. `perm` is a vector specifying a permutation of length
@@ -1375,13 +1353,6 @@ reshape
 Like `randsubseq`, but the results are stored in `S` (which is resized as needed).
 """
 randsubseq!
-
-"""
-    maximum(itr)
-
-Returns the largest element in a collection.
-"""
-maximum(itr)
 
 """
     maximum(A, dims)
@@ -2474,13 +2445,6 @@ Largest integer less than or equal to `x/y`.
 fld
 
 """
-    indmax(itr) -> Integer
-
-Returns the index of the maximum element in a collection.
-"""
-indmax
-
-"""
     writecsv(filename, A)
 
 Equivalent to `writedlm` with `delim` set to comma.
@@ -3018,13 +2982,6 @@ Get the concrete type of `x`.
 typeof
 
 """
-    drop(iter, n)
-
-An iterator that generates all but the first `n` elements of `iter`.
-"""
-drop
-
-"""
     acsc(x)
 
 Compute the inverse cosecant of `x`, where the output is in radians
@@ -3177,13 +3134,6 @@ Compute the inverse error complementary function of a real `x`, defined by
 ``\\operatorname{erfc}(\\operatorname{erfcinv}(x)) = x``.
 """
 erfcinv
-
-"""
-    minabs(itr)
-
-Compute the minimum absolute value of a collection of values.
-"""
-minabs(itr)
 
 """
     minabs(A, dims)
@@ -3566,16 +3516,6 @@ An operation allocated too much memory for either the system or the garbage coll
 handle properly.
 """
 OutOfMemoryError
-
-"""
-    zip(iters...)
-
-For a set of iterable objects, returns an iterable of tuples, where the `i`th tuple contains
-the `i`th component of each input iterable.
-
-Note that [`zip`](:func:`zip`) is its own inverse: `collect(zip(zip(a...)...)) == collect(a)`.
-"""
-zip
 
 """
     SystemError(prefix::AbstractString, [errno::Int32])
@@ -4673,13 +4613,6 @@ Compute the inverse hyperbolic sine of `x`.
 asinh
 
 """
-    count(p, itr) -> Integer
-
-Count the number of elements in `itr` for which predicate `p` returns `true`.
-"""
-count
-
-"""
     atreplinit(f)
 
 Register a one-argument function to be called before the REPL interface is initialized in
@@ -4696,20 +4629,6 @@ Return `string` with any leading and trailing whitespace removed. If `chars` (a 
 or vector or set of characters) is provided, instead remove characters contained in it.
 """
 strip
-
-"""
-    findin(a, b)
-
-Returns the indices of elements in collection `a` that appear in collection `b`.
-"""
-findin
-
-"""
-    minimum(itr)
-
-Returns the smallest element in a collection.
-"""
-minimum(itr)
 
 """
     minimum(A, dims)
@@ -4765,13 +4684,6 @@ Like redirect_stdout, but for STDIN. Note that the order of the return tuple is 
 (rd,wr), i.e. data to be read from STDIN, may be written to wr.
 """
 redirect_stdin
-
-"""
-    minmax(x, y)
-
-Return `(min(x,y), max(x,y))`. See also: [`extrema`](:func:`extrema`) that returns `(minimum(x), maximum(x))`.
-"""
-minmax
 
 """
     mktemp([parent=tempdir()])
@@ -4908,13 +4820,6 @@ from or written to respectively. By default the buffer is readable but not writa
 last argument optionally specifies a size beyond which the buffer may not be grown.
 """
 IOBuffer(data=?)
-
-"""
-    findmax(itr) -> (x, index)
-
-Returns the maximum element and its index.
-"""
-findmax(itr)
 
 """
     findmax(A, dims) -> (maxval, index)
@@ -5528,30 +5433,11 @@ The highest value representable by the given (real) numeric `DataType`.
 typemax
 
 """
-    all(itr) -> Bool
-
-Test whether all elements of a boolean collection are `true`.
-"""
-all(itr)
-
-"""
     all(A, dims)
 
 Test whether all values along the given dimensions of an array are `true`.
 """
 all(A::AbstractArray, dims)
-
-"""
-    all(p, itr) -> Bool
-
-Determine whether predicate `p` returns `true` for all elements of `itr`.
-
-```jldoctest
-julia> all(i->(4<=i<=6), [4,5,6])
-true
-```
-"""
-all(p, itr)
 
 """
     bind(socket::Union{UDPSocket, TCPSocket}, host::IPAddr, port::Integer; ipv6only=false)
@@ -6994,13 +6880,6 @@ Compute the trigamma function of `x` (the logarithmic second derivative of `gamm
 trigamma
 
 """
-    findmin(itr) -> (x, index)
-
-Returns the minimum element and its index.
-"""
-findmin(itr)
-
-"""
     findmin(A, dims) -> (minval, index)
 
 For an array input, returns the value and index of the minimum over the given dimensions.
@@ -7496,13 +7375,6 @@ Convert a string to `String` type and check that it contains only ASCII data, ot
 throwing an `ArgumentError` indicating the position of the first non-ASCII byte.
 """
 ascii(s)
-
-"""
-    maxabs(itr)
-
-Compute the maximum absolute value of a collection of values.
-"""
-maxabs(itr)
 
 """
     maxabs(A, dims)
@@ -8100,25 +7972,11 @@ Get the additive identity element for the type of `x` (`x` can also specify the 
 zero
 
 """
-    any(itr) -> Bool
-
-Test whether any elements of a boolean collection are `true`.
-"""
-any(itr)
-
-"""
     any(A, dims)
 
 Test whether any values along the given dimensions of an array are `true`.
 """
 any(::AbstractArray,dims)
-
-"""
-    any(p, itr) -> Bool
-
-Determine whether predicate `p` returns `true` for any elements of `itr`.
-"""
-any(p,itr)
 
 """
     cosc(x)
@@ -8254,13 +8112,6 @@ not required) to convert subnormal inputs or outputs to zero. Returns `true` unl
 break identities such as `(x-y==0) == (x==y)`.
 """
 set_zero_subnormals
-
-"""
-    take(iter, n)
-
-An iterator that generates at most the first `n` elements of `iter`.
-"""
-take
 
 """
     frexp(val)
@@ -8865,14 +8716,6 @@ julia> A
 pop!(collection)
 
 """
-    filter(function, collection)
-
-Return a copy of `collection`, removing elements for which `function` is `false`. For
-associative collections, the function is passed two arguments (key and value).
-"""
-filter
-
-"""
     randperm([rng,] n)
 
 Construct a random permutation of length `n`. The optional `rng` argument specifies a random
@@ -8966,27 +8809,6 @@ unsafe_pointer_to_objref
 Remove a single trailing newline from a string.
 """
 chomp
-
-"""
-    enumerate(iter)
-
-An iterator that yields `(i, x)` where `i` is an index starting at 1, and
-`x` is the `i`th value from the given iterator. It's useful when you need
-not only the values `x` over which you are iterating, but also the index `i`
-of the iterations.
-
-```jldoctest
-julia> a = ["a", "b", "c"];
-
-julia> for (index, value) in enumerate(a)
-           println("\$index \$value")
-       end
-1 a
-2 b
-3 c
-```
-"""
-enumerate
 
 """
     >=(x, y)

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -17,7 +17,27 @@ _diff_length(a, b, A, B) = max(length(a)-length(b), 0)
 immutable Enumerate{I}
     itr::I
 end
-enumerate(itr) = Enumerate(itr)
+
+"""
+    enumerate(iter)
+
+An iterator that yields `(i, x)` where `i` is an index starting at 1, and
+`x` is the `i`th value from the given iterator. It's useful when you need
+not only the values `x` over which you are iterating, but also the index `i`
+of the iterations.
+
+```jldoctest
+julia> a = ["a", "b", "c"];
+
+julia> for (index, value) in enumerate(a)
+           println("\$index \$value")
+       end
+1 a
+2 b
+3 c
+```
+"""
+enumerate(iter) = Enumerate(iter)
 
 length(e::Enumerate) = length(e.itr)
 size(e::Enumerate) = size(e.itr)
@@ -83,6 +103,37 @@ immutable Zip{I, Z<:AbstractZipIterator} <: AbstractZipIterator
     a::I
     z::Z
 end
+
+"""
+    zip(iters...)
+
+For a set of iterable objects, returns an iterable of tuples, where the `i`th tuple contains
+the `i`th component of each input iterable.
+
+Note that [`zip`](:func:`zip`) is its own inverse: `collect(zip(zip(a...)...)) == collect(a)`.
+
+```jldoctest
+julia> a = 1:5
+1:5
+
+julia> b = ["e","d","b","c","a"]
+5-element Array{String,1}:
+ "e"
+ "d"
+ "b"
+ "c"
+ "a"
+
+julia> c = zip(a,b)
+Base.Zip2{UnitRange{Int64},Array{String,1}}(1:5,String["e","d","b","c","a"])
+
+julia> length(c)
+5
+
+julia> first(c)
+(1,"e")
+```
+"""
 zip(a, b, c...) = Zip(a, zip(b, c...))
 length(z::Zip) = _min_length(z.a, z.z, iteratorsize(z.a), iteratorsize(z.z))
 size(z::Zip) = promote_shape(size(z.a), size(z.z))
@@ -109,6 +160,26 @@ immutable Filter{F,I}
     flt::F
     itr::I
 end
+
+"""
+    filter(function, collection)
+
+Return a copy of `collection`, removing elements for which `function` is `false`. For
+associative collections, the function is passed two arguments (key and value).
+
+```jldocttest
+julia> a = 1:10
+1:10
+
+julia> filter(isodd, a)
+5-element Array{Int64,1}:
+ 1
+ 3
+ 5
+ 7
+ 9
+```
+"""
 filter(flt, itr) = Filter(flt, itr)
 
 start(f::Filter) = start_filter(f.flt, f.itr)
@@ -204,6 +275,32 @@ immutable Take{I}
     xs::I
     n::Int
 end
+
+"""
+    take(iter, n)
+
+An iterator that generates at most the first `n` elements of `iter`.
+
+```jldoctest
+julia> a = 1:2:11
+1:2:11
+
+julia> collect(a)
+6-element Array{Int64,1}:
+  1
+  3
+  5
+  7
+  9
+  11
+
+julia> collect(take(a,3))
+3-element Array{Int64,1}:
+  1
+  3
+  5
+```
+"""
 take(xs, n::Int) = Take(xs, n)
 
 eltype{I}(::Type{Take{I}}) = eltype(I)
@@ -232,6 +329,31 @@ immutable Drop{I}
     xs::I
     n::Int
 end
+
+"""
+    drop(iter, n)
+
+An iterator that generates all but the first `n` elements of `iter`.
+
+```jldoctest
+julia> a = 1:2:11
+1:2:11
+
+julia> collect(a)
+6-element Array{Int64,1}:
+  1
+  3
+  5
+  7
+  9
+  11
+
+julia> collect(drop(a,4))
+2-element Array{Int64,1}:
+  9
+  11
+```
+"""
 drop(xs, n::Int) = Drop(xs, n)
 
 eltype{I}(::Type{Drop{I}}) = eltype(I)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -81,6 +81,16 @@ cmp(x::Integer, y::Integer) = ifelse(isless(x,y), -1, ifelse(isless(y,x), 1, 0))
 
 max(x,y) = ifelse(y < x, x, y)
 min(x,y) = ifelse(y < x, y, x)
+"""
+    minmax(x, y)
+
+Return `(min(x,y), max(x,y))`. See also: [`extrema`](:func:`extrema`) that returns `(minimum(x), maximum(x))`.
+
+```jldoctest
+julia> minmax('c','b')
+('b','c')
+```
+"""
 minmax(x,y) = y < x ? (y, x) : (x, y)
 
 scalarmax(x,y) = max(x,y)

--- a/base/range.jl
+++ b/base/range.jl
@@ -332,6 +332,24 @@ isempty(r::AbstractUnitRange) = first(r) > last(r)
 isempty(r::FloatRange) = length(r) == 0
 isempty(r::LinSpace) = length(r) == 0
 
+"""
+    step(r)
+
+Get the step size of a [`Range`](:obj:`Range`) object.
+```jldoctest
+julia> step(1:10)
+1
+
+julia> step(1:2:10)
+2
+
+julia> step(2.5:0.3:10.9)
+0.3
+
+julia> step(linspace(2.5,10.9,85))
+0.1
+```
+"""
 step(r::StepRange) = r.step
 step(r::AbstractUnitRange) = 1
 step(r::FloatRange) = r.step/r.divisor

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -286,10 +286,58 @@ end
 maximum(f::Callable, a) = mapreduce(f, scalarmax, a)
 minimum(f::Callable, a) = mapreduce(f, scalarmin, a)
 
+"""
+    maximum(itr)
+
+Returns the largest element in a collection.
+
+```jldoctest
+julia> maximum(-20.5:10)
+9.5
+
+julia> maximum([1,2,3])
+3
+```
+"""
 maximum(a) = mapreduce(identity, scalarmax, a)
+
+"""
+    minimum(itr)
+
+Returns the smallest element in a collection.
+
+```jldoctest
+julia> minimum(-20.5:10)
+-20.5
+
+julia> minimum([1,2,3])
+1
+```
+"""
 minimum(a) = mapreduce(identity, scalarmin, a)
 
+"""
+    maxabs(itr)
+
+Compute the maximum absolute value of a collection of values.
+
+```jldoctest
+julia> maxabs([-1, 3, 4*im])
+4.0
+```
+"""
 maxabs(a) = mapreduce(abs, scalarmax, a)
+
+"""
+    minabs(itr)
+
+Compute the minimum absolute value of a collection of values.
+
+```jldoctest
+julia> minabs([-1, 3, 4*im])
+1.0
+```
+"""
 minabs(a) = mapreduce(abs, scalarmin, a)
 
 ## extrema
@@ -301,6 +349,14 @@ extrema(x::Real) = (x, x)
     extrema(itr) -> Tuple
 
 Compute both the minimum and maximum element in a single pass, and return them as a 2-tuple.
+
+```jldoctest
+julia> extrema(2:10)
+(2,10)
+
+julia> extrema([9,pi,4.5])
+(3.141592653589793,9.0)
+```
 """
 function extrema(itr)
     s = start(itr)
@@ -362,7 +418,18 @@ end
 
 ## all & any
 
+"""
+    any(itr) -> Bool
+
+Test whether any elements of a boolean collection are `true`.
+"""
 any(itr) = any(identity, itr)
+
+"""
+    all(itr) -> Bool
+
+Test whether all elements of a boolean collection are `true`.
+"""
 all(itr) = all(identity, itr)
 
 nonboolean_error(f, op) = throw(ArgumentError("""
@@ -375,6 +442,16 @@ or_bool_only(a::Bool, b::Bool) = a|b
 and_bool_only(a, b) = nonboolean_error(:all, :&)
 and_bool_only(a::Bool, b::Bool) = a&b
 
+"""
+    any(p, itr) -> Bool
+
+Determine whether predicate `p` returns `true` for any elements of `itr`.
+
+```jldoctest
+julia> any(i->(4<=i<=6), [3,5,7])
+true
+```
+"""
 any(f::Any, itr) = any(Predicate(f), itr)
 any(f::Predicate, itr) = mapreduce_sc_impl(f, |, itr)
 any(f::typeof(identity), itr) =
@@ -382,6 +459,16 @@ any(f::typeof(identity), itr) =
         mapreduce_sc_impl(f, |, itr) :
         reduce(or_bool_only, itr)
 
+"""
+    all(p, itr) -> Bool
+
+Determine whether predicate `p` returns `true` for all elements of `itr`.
+
+```jldoctest
+julia> all(i->(4<=i<=6), [4,5,6])
+true
+```
+"""
 all(f::Any, itr) = all(Predicate(f), itr)
 all(f::Predicate, itr) = mapreduce_sc_impl(f, &, itr)
 all(f::typeof(identity), itr) =
@@ -408,6 +495,16 @@ end
 
 ## countnz & count
 
+"""
+    count(p, itr) -> Integer
+
+Count the number of elements in `itr` for which predicate `p` returns `true`.
+
+```jldoctest
+julia> count(i->(4<=i<=6), [2,3,4,5,6])
+ 3
+```
+"""
 function count(pred, itr)
     n = 0
     for x in itr

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1086,3 +1086,4 @@ dense counterparts. The following functions are specific to sparse arrays.
    For additional (algorithmic) information, and for versions of these methods that forgo argument checking, see (unexported) parent methods :func:`Base.SparseArrays.unchecked_noalias_permute!` and :func:`Base.SparseArrays.unchecked_aliasing_permute!`\ .
 
    See also: :func:`Base.SparseArrays.permute`
+

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -55,6 +55,28 @@ type.
 
    Note that :func:`zip` is its own inverse: ``collect(zip(zip(a...)...)) == collect(a)``\ .
 
+   .. doctest::
+
+       julia> a = 1:5
+       1:5
+
+       julia> b = ["e","d","b","c","a"]
+       5-element Array{String,1}:
+        "e"
+        "d"
+        "b"
+        "c"
+        "a"
+
+       julia> c = zip(a,b)
+       Base.Zip2{UnitRange{Int64},Array{String,1}}(1:5,String["e","d","b","c","a"])
+
+       julia> length(c)
+       5
+
+       julia> first(c)
+       (1,"e")
+
 .. function:: enumerate(iter)
 
    .. Docstring generated from Julia source
@@ -90,11 +112,50 @@ type.
 
    An iterator that generates at most the first ``n`` elements of ``iter``\ .
 
+   .. doctest::
+
+       julia> a = 1:2:11
+       1:2:11
+
+       julia> collect(a)
+       6-element Array{Int64,1}:
+         1
+         3
+         5
+         7
+         9
+         11
+
+       julia> collect(take(a,3))
+       3-element Array{Int64,1}:
+         1
+         3
+         5
+
 .. function:: drop(iter, n)
 
    .. Docstring generated from Julia source
 
    An iterator that generates all but the first ``n`` elements of ``iter``\ .
+
+   .. doctest::
+
+       julia> a = 1:2:11
+       1:2:11
+
+       julia> collect(a)
+       6-element Array{Int64,1}:
+         1
+         3
+         5
+         7
+         9
+         11
+
+       julia> collect(drop(a,4))
+       2-element Array{Int64,1}:
+         9
+         11
 
 .. function:: cycle(iter)
 
@@ -230,11 +291,52 @@ Iterable Collections
 
    Returns a vector containing the highest index in ``b`` for each value in ``a`` that is a member of ``b`` . The output vector contains 0 wherever ``a`` is not a member of ``b``\ .
 
+   .. doctest::
+
+       julia> a = ['a', 'b', 'c', 'b', 'd', 'a'];
+
+       julia> b = ['a','b','c']
+
+       julia> indexin(a,b)
+       6-element Array{Int64,1}:
+        1
+        2
+        3
+        2
+        0
+        1
+
+       julia> indexin(b,a)
+       3-element Array{Int64,1}:
+        6
+        4
+        3
+
 .. function:: findin(a, b)
 
    .. Docstring generated from Julia source
 
    Returns the indices of elements in collection ``a`` that appear in collection ``b``\ .
+
+   .. doctest::
+
+       julia> a = collect(1:3:15)
+       5-element Array{Int64,1}:
+         1
+         4
+         7
+        10
+        13
+
+       julia> b = collect(2:4:10)
+       3-element Array{Int64,1}:
+         2
+         6
+        10
+
+       julia> findin(a,b) # 10 is the only common element
+       1-element Array{Int64,1}:
+        4
 
 .. function:: unique(itr[, dim])
 
@@ -308,6 +410,14 @@ Iterable Collections
 
    Returns the largest element in a collection.
 
+   .. doctest::
+
+       julia> maximum(-20.5:10)
+       9.5
+
+       julia> maximum([1,2,3])
+       3
+
 .. function:: maximum(A, dims)
 
    .. Docstring generated from Julia source
@@ -325,6 +435,14 @@ Iterable Collections
    .. Docstring generated from Julia source
 
    Returns the smallest element in a collection.
+
+   .. doctest::
+
+       julia> minimum(-20.5:10)
+       -20.5
+
+       julia> minimum([1,2,3])
+       1
 
 .. function:: minimum(A, dims)
 
@@ -344,6 +462,14 @@ Iterable Collections
 
    Compute both the minimum and maximum element in a single pass, and return them as a 2-tuple.
 
+   .. doctest::
+
+       julia> extrema(2:10)
+       (2,10)
+
+       julia> extrema([9,pi,4.5])
+       (3.141592653589793,9.0)
+
 .. function:: extrema(A,dims) -> Array{Tuple}
 
    .. Docstring generated from Julia source
@@ -356,17 +482,32 @@ Iterable Collections
 
    Returns the index of the maximum element in a collection.
 
+   .. doctest::
+
+       julia> indmax([8,0.1,-9,pi])
+       1
+
 .. function:: indmin(itr) -> Integer
 
    .. Docstring generated from Julia source
 
    Returns the index of the minimum element in a collection.
 
+   .. doctest::
+
+       julia> indmin([8,0.1,-9,pi])
+       3
+
 .. function:: findmax(itr) -> (x, index)
 
    .. Docstring generated from Julia source
 
-   Returns the maximum element and its index.
+   Returns the maximum element and its index. The collection must not be empty.
+
+   .. doctest::
+
+       julia> findmax([8,0.1,-9,pi])
+       (8.0,1)
 
 .. function:: findmax(A, dims) -> (maxval, index)
 
@@ -378,7 +519,12 @@ Iterable Collections
 
    .. Docstring generated from Julia source
 
-   Returns the minimum element and its index.
+   Returns the minimum element and its index. The collection must not be empty.
+
+   .. doctest::
+
+       julia> findmax([8,0.1,-9,pi])
+       (-9.0,3)
 
 .. function:: findmin(A, dims) -> (minval, index)
 
@@ -404,6 +550,11 @@ Iterable Collections
 
    Compute the maximum absolute value of a collection of values.
 
+   .. doctest::
+
+       julia> maxabs([-1, 3, 4*im])
+       4.0
+
 .. function:: maxabs(A, dims)
 
    .. Docstring generated from Julia source
@@ -421,6 +572,11 @@ Iterable Collections
    .. Docstring generated from Julia source
 
    Compute the minimum absolute value of a collection of values.
+
+   .. doctest::
+
+       julia> minabs([-1, 3, 4*im])
+       1.0
 
 .. function:: minabs(A, dims)
 
@@ -554,11 +710,21 @@ Iterable Collections
 
    Count the number of elements in ``itr`` for which predicate ``p`` returns ``true``\ .
 
+   .. doctest::
+
+       julia> count(i->(4<=i<=6), [2,3,4,5,6])
+        3
+
 .. function:: any(p, itr) -> Bool
 
    .. Docstring generated from Julia source
 
    Determine whether predicate ``p`` returns ``true`` for any elements of ``itr``\ .
+
+   .. doctest::
+
+       julia> any(i->(4<=i<=6), [3,5,7])
+       true
 
 .. function:: all(p, itr) -> Bool
 
@@ -576,6 +742,16 @@ Iterable Collections
    .. Docstring generated from Julia source
 
    Call function ``f`` on each element of iterable ``c``\ . For multiple iterable arguments, ``f`` is called elementwise. ``foreach`` should be used instead of ``map`` when the results of ``f`` are not needed, for example in ``foreach(println, array)``\ .
+
+   .. doctest::
+
+       julia> a
+       1:3:7
+
+       julia> foreach(x->println(x^2),a)
+       1
+       16
+       49
 
 .. function:: map(f, c...) -> collection
 
@@ -672,6 +848,20 @@ Iterable Collections
 
    Get the step size of a :obj:`Range` object.
 
+   .. doctest::
+
+       julia> step(1:10)
+       1
+
+       julia> step(1:2:10)
+       2
+
+       julia> step(2.5:0.3:10.9)
+       0.3
+
+       julia> step(linspace(2.5,10.9,85))
+       0.1
+
 .. function:: collect(collection)
 
    .. Docstring generated from Julia source
@@ -698,6 +888,19 @@ Iterable Collections
    .. Docstring generated from Julia source
 
    Return a copy of ``collection``\ , removing elements for which ``function`` is ``false``\ . For associative collections, the function is passed two arguments (key and value).
+
+   .. code-block:: julia
+
+       julia> a = 1:10
+       1:10
+
+       julia> filter(isodd, a)
+       5-element Array{Int64,1}:
+        1
+        3
+        5
+        7
+        9
 
 .. function:: filter!(function, collection)
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1012,6 +1012,11 @@ Mathematical Functions
 
    Return ``(min(x,y), max(x,y))``\ . See also: :func:`extrema` that returns ``(minimum(x), maximum(x))``\ .
 
+   .. doctest::
+
+       julia> minmax('c','b')
+       ('b','c')
+
 .. function:: clamp(x, lo, hi)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
Lots of our documentation for some relatively simple iterator methods
had no examples. I added a bunch, moved docstrings out of HelpDB, and
tried to illustrate some common use cases.
