### PR TITLE
fix #17785, process all keyword args left-to-right

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@ This section lists changes that do not have deprecation warnings.
 
   * Operations between `Float16` and `Integers` now return `Float16` instead of `Float32`. ([#17261])
 
+  * Keyword arguments are processed left-to-right: if the same keyword is specified more than
+    once, the rightmost occurrence takes precedence ([#17785]).
+
 Library improvements
 --------------------
 
@@ -616,6 +619,7 @@ Language tooling improvements
 [#17037]: https://github.com/JuliaLang/julia/issues/17037
 [#17075]: https://github.com/JuliaLang/julia/issues/17075
 [#17132]: https://github.com/JuliaLang/julia/issues/17132
+[#17261]: https://github.com/JuliaLang/julia/issues/17261
 [#17266]: https://github.com/JuliaLang/julia/issues/17266
 [#17300]: https://github.com/JuliaLang/julia/issues/17300
 [#17323]: https://github.com/JuliaLang/julia/issues/17323
@@ -626,3 +630,4 @@ Language tooling improvements
 [#17510]: https://github.com/JuliaLang/julia/issues/17510
 [#17546]: https://github.com/JuliaLang/julia/issues/17546
 [#17668]: https://github.com/JuliaLang/julia/issues/17668
+[#17785]: https://github.com/JuliaLang/julia/issues/17785

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -510,6 +510,13 @@ tuple, explicitly after a semicolon.  For example, ``plot(x, y;
 ``plot(x, y, width=2)``.  This is useful in situations where the
 keyword name is computed at runtime.
 
+The nature of keyword arguments makes it possible to specify the same
+argument more than once. For example, in the call
+``plot(x, y; options..., width=2)`` it is possible that the ``options``
+structure also contains a value for ``width``. In such a case the
+rightmost occurrence takes precedence; in this example, ``width``
+is certain to have the value ``2``.
+
 .. _man-evaluation-scope-default-values:
 
 Evaluation Scope of Default Values

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -218,3 +218,12 @@ end
 @test f9948(x=5) == 5
 @test_throws UndefVarError f9948()
 @test getx9948() == 3
+
+# issue #17785 - handle all sources of kwargs left-to-right
+g17785(; a=1, b=2) = (a, b)
+let opts = (:a=>3, :b=>4)
+    @test g17785(; a=5, opts...) == (3, 4)
+    @test g17785(; opts..., a=5) == (5, 4)
+    @test g17785(; opts..., a=5, b=6) == (5, 6)
+    @test g17785(; b=0, opts..., a=5) == (5, 4)
+end


### PR DESCRIPTION
We probably don't want to merge this now since it changes behavior, but I think it's a good change.

Link #17785.
