### PR TITLE
Move array documentation out of HelpDB, add examples

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1363,15 +1363,15 @@ julia> a = reshape(collect(1:16),(2,2,2,2))
 [:, :, 1, 1] =
  1  3
  2  4
-
+<BLANKLINE>
 [:, :, 2, 1] =
  5  7
  6  8
-
+<BLANKLINE>
 [:, :, 1, 2] =
   9  11
  10  12
-
+<BLANKLINE>
 [:, :, 2, 2] =
  13  15
  14  16
@@ -1380,13 +1380,13 @@ julia> mapslices(sum, a, [1,2])
 1×1×2×2 Array{Int64,4}:
 [:, :, 1, 1] =
  10
-
+<BLANKLINE>
 [:, :, 2, 1] =
  26
-
+<BLANKLINE>
 [:, :, 1, 2] =
  42
-
+<BLANKLINE>
 [:, :, 2, 2] =
  58
 ```

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1348,6 +1348,49 @@ foreach(f, itrs...) = (for z in zip(itrs...); f(z...); end; nothing)
 ## transform any set of dimensions
 ## dims specifies which dimensions will be transformed. for example
 ## dims==1:2 will call f on all slices A[:,:,...]
+"""
+    mapslices(f, A, dims)
+
+Transform the given dimensions of array `A` using function `f`. `f` is called on each slice
+of `A` of the form `A[...,:,...,:,...]`. `dims` is an integer vector specifying where the
+colons go in this expression. The results are concatenated along the remaining dimensions.
+For example, if `dims` is `[1,2]` and `A` is 4-dimensional, `f` is called on `A[:,:,i,j]`
+for all `i` and `j`.
+
+```jldoctest
+julia> A = rand(1:5, 2, 2, 2, 2)
+2×2×2×2 Array{Int64,4}:
+[:, :, 1, 1] =
+ 1  1
+ 3  4
+
+[:, :, 2, 1] =
+ 4  1
+ 5  3
+
+[:, :, 1, 2] =
+ 3  4
+ 1  3
+
+[:, :, 2, 2] =
+ 4  4
+ 4  1
+
+julia> mapslices(sum, A, [1,2])
+1×1×2×2 Array{Int64,4}:
+[:, :, 1, 1] =
+ 9
+
+[:, :, 2, 1] =
+ 13
+
+[:, :, 1, 2] =
+ 11
+
+[:, :, 2, 2] =
+ 13
+```
+"""
 mapslices(f, A::AbstractArray, dims) = mapslices(f, A, [dims...])
 function mapslices(f, A::AbstractArray, dims::AbstractVector)
     if isempty(dims)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1358,37 +1358,37 @@ For example, if `dims` is `[1,2]` and `A` is 4-dimensional, `f` is called on `A[
 for all `i` and `j`.
 
 ```jldoctest
-julia> A = rand(1:5, 2, 2, 2, 2)
+julia> a = reshape(collect(1:16),(2,2,2,2))
 2×2×2×2 Array{Int64,4}:
 [:, :, 1, 1] =
- 1  1
- 3  4
+ 1  3
+ 2  4
 
 [:, :, 2, 1] =
- 4  1
- 5  3
+ 5  7
+ 6  8
 
 [:, :, 1, 2] =
- 3  4
- 1  3
+  9  11
+ 10  12
 
 [:, :, 2, 2] =
- 4  4
- 4  1
+ 13  15
+ 14  16
 
-julia> mapslices(sum, A, [1,2])
+julia> mapslices(sum, a, [1,2])
 1×1×2×2 Array{Int64,4}:
 [:, :, 1, 1] =
- 9
+ 10
 
 [:, :, 2, 1] =
- 13
+ 26
 
 [:, :, 1, 2] =
- 11
+ 42
 
 [:, :, 2, 2] =
- 13
+ 58
 ```
 """
 mapslices(f, A::AbstractArray, dims) = mapslices(f, A, [dims...])

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -165,17 +165,15 @@ end
 Rotate matrix `A` left 90 degrees.
 
 ```jldoctest
-julia> a = rand(1:8,3,3)
-3×3 Array{Int64,2}:
- 6  8  8
- 3  1  8
- 6  1  3
+julia> a = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 
 julia> rotl90(a)
-3×3 Array{Int64,2}:
- 8  8  3
- 8  1  1
- 6  3  6
+2×2 Array{Int64,2}:
+ 2  4
+ 1  3
 ```
 """
 function rotl90(A::AbstractMatrix)
@@ -194,17 +192,15 @@ end
 Rotate matrix `A` right 90 degrees.
 
 ```jldoctest
-julia> a = rand(1:8,3,3)
-3×3 Array{Int64,2}:
- 4  6  1
- 8  8  1
- 7  4  8
+julia> a = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 
 julia> rotr90(a)
-3×3 Array{Int64,2}:
- 7  8  4
- 4  8  6
- 8  1  1
+2×2 Array{Int64,2}:
+ 3  1
+ 4  2
 ```
 """
 function rotr90(A::AbstractMatrix)
@@ -222,17 +218,15 @@ end
 Rotate matrix `A` 180 degrees.
 
 ```jldoctest
-julia> a = rand(1:8,3,3)
-3×3 Array{Int64,2}:
- 4  8  6
- 6  4  6
- 2  8  7
+julia> a = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 
 julia> rot180(a)
-3×3 Array{Int64,2}:
- 7  8  2
- 6  4  6
- 6  8  4
+2×2 Array{Int64,2}:
+ 4  3
+ 2  1
 ```
 """
 function rot180(A::AbstractMatrix)
@@ -251,35 +245,30 @@ Rotate matrix `A` left 90 degrees an integer `k` number of times.
 If `k` is zero or a multiple of four, this is equivalent to a `copy`.
 
 ```jldoctest
-julia> a = rand(1:8,3,3)
-3×3 Array{Int64,2}:
- 7  2  6
- 2  5  2
- 7  3  3
+julia> a = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 
 julia> rotl90(a,1)
-3×3 Array{Int64,2}:
- 6  2  3
- 2  5  3
- 7  2  7
+2×2 Array{Int64,2}:
+ 2  4
+ 1  3
 
 julia> rotl90(a,2)
-3×3 Array{Int64,2}:
- 3  3  7
- 2  5  2
- 6  2  7
+2×2 Array{Int64,2}:
+ 4  3
+ 2  1
 
 julia> rotl90(a,3)
-3×3 Array{Int64,2}:
- 7  2  7
- 3  5  2
- 3  2  6
+2×2 Array{Int64,2}:
+ 3  1
+ 4  2
 
 julia> rotl90(a,4)
-3×3 Array{Int64,2}:
- 7  2  6
- 2  5  2
- 7  3  3
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 ```
 """
 function rotl90(A::AbstractMatrix, k::Integer)
@@ -295,35 +284,30 @@ Rotate matrix `A` right 90 degrees an integer `k` number of times. If `k` is zer
 multiple of four, this is equivalent to a `copy`.
 
 ```jldoctest
-julia> a = rand(1:8,3,3)
-3×3 Array{Int64,2}:
- 7  8  1
- 3  1  6
- 7  2  1
+julia> a = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 
 julia> rotr90(a,1)
-3×3 Array{Int64,2}:
- 7  3  7
- 2  1  8
- 1  6  1
+2×2 Array{Int64,2}:
+ 3  1
+ 4  2
 
 julia> rotr90(a,2)
-3×3 Array{Int64,2}:
- 1  2  7
- 6  1  3
- 1  8  7
+2×2 Array{Int64,2}:
+ 4  3
+ 2  1
 
 julia> rotr90(a,3)
-3×3 Array{Int64,2}:
- 1  6  1
- 8  1  2
- 7  3  7
+2×2 Array{Int64,2}:
+ 2  4
+ 1  3
 
 julia> rotr90(a,4)
-3×3 Array{Int64,2}:
- 7  8  1
- 3  1  6
- 7  2  1
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 ```
 """
 rotr90(A::AbstractMatrix, k::Integer) = rotl90(A,-k)
@@ -334,23 +318,20 @@ Rotate matrix `A` 180 degrees an integer `k` number of times.
 If `k` is even, this is equivalent to a `copy`.
 
 ```jldoctest
-julia> a = rand(1:8,3,3)
-3×3 Array{Int64,2}:
- 5  6  3
- 6  7  2
- 2  1  6
+julia> a = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 
 julia> rot180(a,1)
-3×3 Array{Int64,2}:
- 6  1  2
- 2  7  6
- 3  6  5
+2×2 Array{Int64,2}:
+ 4  3
+ 2  1
 
 julia> rot180(a,2)
-3×3 Array{Int64,2}:
- 5  6  3
- 6  7  2
- 2  1  6
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
 ```
 """
 rot180(A::AbstractMatrix, k::Integer) = mod(k, 2) == 1 ? rot180(A) : copy(A)

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -159,6 +159,25 @@ function flipdim{T}(A::Array{T}, d::Integer)
     return B
 end
 
+"""
+    rotl90(A)
+
+Rotate matrix `A` left 90 degrees.
+
+```jldoctest
+julia> a = rand(1:8,3,3)
+3×3 Array{Int64,2}:
+ 6  8  8
+ 3  1  8
+ 6  1  3
+
+julia> rotl90(a)
+3×3 Array{Int64,2}:
+ 8  8  3
+ 8  1  1
+ 6  3  6
+```
+"""
 function rotl90(A::AbstractMatrix)
     ind1, ind2 = indices(A)
     B = similar(A, (ind2,ind1))
@@ -168,6 +187,26 @@ function rotl90(A::AbstractMatrix)
     end
     return B
 end
+
+"""
+    rotr90(A)
+
+Rotate matrix `A` right 90 degrees.
+
+```jldoctest
+julia> a = rand(1:8,3,3)
+3×3 Array{Int64,2}:
+ 4  6  1
+ 8  8  1
+ 7  4  8
+
+julia> rotr90(a)
+3×3 Array{Int64,2}:
+ 7  8  4
+ 4  8  6
+ 8  1  1
+```
+"""
 function rotr90(A::AbstractMatrix)
     ind1, ind2 = indices(A)
     B = similar(A, (ind2,ind1))
@@ -177,6 +216,25 @@ function rotr90(A::AbstractMatrix)
     end
     return B
 end
+"""
+    rot180(A)
+
+Rotate matrix `A` 180 degrees.
+
+```jldoctest
+julia> a = rand(1:8,3,3)
+3×3 Array{Int64,2}:
+ 4  8  6
+ 6  4  6
+ 2  8  7
+
+julia> rot180(a)
+3×3 Array{Int64,2}:
+ 7  8  2
+ 6  4  6
+ 6  8  4
+```
+"""
 function rot180(A::AbstractMatrix)
     B = similar(A)
     ind1, ind2 = indices(A,1), indices(A,2)
@@ -186,13 +244,115 @@ function rot180(A::AbstractMatrix)
     end
     return B
 end
+"""
+    rotl90(A, k)
+
+Rotate matrix `A` left 90 degrees an integer `k` number of times.
+If `k` is zero or a multiple of four, this is equivalent to a `copy`.
+
+```jldoctest
+julia> a = rand(1:8,3,3)
+3×3 Array{Int64,2}:
+ 7  2  6
+ 2  5  2
+ 7  3  3
+
+julia> rotl90(a,1)
+3×3 Array{Int64,2}:
+ 6  2  3
+ 2  5  3
+ 7  2  7
+
+julia> rotl90(a,2)
+3×3 Array{Int64,2}:
+ 3  3  7
+ 2  5  2
+ 6  2  7
+
+julia> rotl90(a,3)
+3×3 Array{Int64,2}:
+ 7  2  7
+ 3  5  2
+ 3  2  6
+
+julia> rotl90(a,4)
+3×3 Array{Int64,2}:
+ 7  2  6
+ 2  5  2
+ 7  3  3
+```
+"""
 function rotl90(A::AbstractMatrix, k::Integer)
     k = mod(k, 4)
     k == 1 ? rotl90(A) :
     k == 2 ? rot180(A) :
     k == 3 ? rotr90(A) : copy(A)
 end
+"""
+    rotr90(A, k)
+
+Rotate matrix `A` right 90 degrees an integer `k` number of times. If `k` is zero or a
+multiple of four, this is equivalent to a `copy`.
+
+```jldoctest
+julia> a = rand(1:8,3,3)
+3×3 Array{Int64,2}:
+ 7  8  1
+ 3  1  6
+ 7  2  1
+
+julia> rotr90(a,1)
+3×3 Array{Int64,2}:
+ 7  3  7
+ 2  1  8
+ 1  6  1
+
+julia> rotr90(a,2)
+3×3 Array{Int64,2}:
+ 1  2  7
+ 6  1  3
+ 1  8  7
+
+julia> rotr90(a,3)
+3×3 Array{Int64,2}:
+ 1  6  1
+ 8  1  2
+ 7  3  7
+
+julia> rotr90(a,4)
+3×3 Array{Int64,2}:
+ 7  8  1
+ 3  1  6
+ 7  2  1
+```
+"""
 rotr90(A::AbstractMatrix, k::Integer) = rotl90(A,-k)
+"""
+    rot180(A, k)
+
+Rotate matrix `A` 180 degrees an integer `k` number of times.
+If `k` is even, this is equivalent to a `copy`.
+
+```jldoctest
+julia> a = rand(1:8,3,3)
+3×3 Array{Int64,2}:
+ 5  6  3
+ 6  7  2
+ 2  1  6
+
+julia> rot180(a,1)
+3×3 Array{Int64,2}:
+ 6  1  2
+ 2  7  6
+ 3  6  5
+
+julia> rot180(a,2)
+3×3 Array{Int64,2}:
+ 5  6  3
+ 6  7  2
+ 2  1  6
+```
+"""
 rot180(A::AbstractMatrix, k::Integer) = mod(k, 2) == 1 ? rot180(A) : copy(A)
 
 ## Transpose ##

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -505,19 +505,6 @@ Get a backtrace object for the current program point.
 backtrace
 
 """
-    reducedim(f, A, dims[, initial])
-
-Reduce 2-argument function `f` along dimensions of `A`. `dims` is a vector specifying the
-dimensions to reduce, and `initial` is the initial value to use in the reductions. For `+`, `*`,
-`max` and `min` the `initial` argument is optional.
-
-The associativity of the reduction is implementation-dependent; if you need a particular
-associativity, e.g. left-to-right, you should write your own loop. See documentation for
-`reduce`.
-"""
-reducedim
-
-"""
     -(x)
 
 Unary minus operator.
@@ -1118,17 +1105,6 @@ representable.
 `digits` and `base` work as for [`round`](:func:`round`).
 """
 ceil
-
-"""
-    mapslices(f, A, dims)
-
-Transform the given dimensions of array `A` using function `f`. `f` is called on each slice
-of `A` of the form `A[...,:,...,:,...]`. `dims` is an integer vector specifying where the
-colons go in this expression. The results are concatenated along the remaining dimensions.
-For example, if `dims` is `[1,2]` and `A` is 4-dimensional, `f` is called on `A[:,:,i,j]`
-for all `i` and `j`.
-"""
-mapslices
 
 """
     issocket(path) -> Bool
@@ -2351,15 +2327,6 @@ Bessel function of the second kind of order 1, ``Y_1(x)``.
 bessely1
 
 """
-    cumprod(A, [dim])
-
-Cumulative product along a dimension `dim` (defaults to 1). See also
-[`cumprod!`](:func:`cumprod!`) to use a preallocated output array, both for performance and
-to control the precision of the output (e.g. to avoid overflow).
-"""
-cumprod
-
-"""
     besseljx(nu, x)
 
 Scaled Bessel function of the first kind of order `nu`, ``J_\\nu(x) e^{- | \\operatorname{Im}(x) |}``.
@@ -3106,21 +3073,6 @@ block to create a new scope with copies of all variables referenced in the expre
 :@async
 
 """
-    rotr90(A)
-
-Rotate matrix `A` right 90 degrees.
-"""
-rotr90(A)
-
-"""
-    rotr90(A, k)
-
-Rotate matrix `A` right 90 degrees an integer `k` number of times. If `k` is zero or a
-multiple of four, this is equivalent to a `copy`.
-"""
-rotr90(A, k)
-
-"""
     readdir([dir]) -> Vector{String}
 
 Returns the files and directories in the directory `dir` (or the current working directory if not given).
@@ -3592,21 +3544,6 @@ Number of ways to choose `k` out of `n` items.
 binomial
 
 """
-    rot180(A)
-
-Rotate matrix `A` 180 degrees.
-"""
-rot180(A)
-
-"""
-    rot180(A, k)
-
-Rotate matrix `A` 180 degrees an integer `k` number of times. If `k` is even, this is
-equivalent to a `copy`.
-"""
-rot180(A, k)
-
-"""
     .<=(x, y)
     .≤(x,y)
 
@@ -3978,21 +3915,6 @@ x == div(x,y)*y + rem(x,y)
 ```
 """
 rem
-
-"""
-    rotl90(A)
-
-Rotate matrix `A` left 90 degrees.
-"""
-rotl90(A)
-
-"""
-    rotl90(A, k)
-
-Rotate matrix `A` left 90 degrees an integer `k` number of times. If `k` is zero or a
-multiple of four, this is equivalent to a `copy`.
-"""
-rotl90(A, k)
 
 """
     info(msg)
@@ -5763,14 +5685,6 @@ handle comparison to other types via promotion rules where possible.
 Base.:(==)
 
 """
-    mapreducedim(f, op, A, dims[, initial])
-
-Evaluates to the same as `reducedim(op, map(f, A), dims, f(initial))`, but is generally
-faster because the intermediate array is avoided.
-"""
-mapreducedim
-
-"""
     seekstart(s)
 
 Seek a stream to its beginning.
@@ -6553,15 +6467,6 @@ Like uperm but gets the permissions for people who neither own the file nor are 
 the group owning the file
 """
 operm
-
-"""
-    cumsum(A, [dim])
-
-Cumulative sum along a dimension `dim` (defaults to 1). See also [`cumsum!`](:func:`cumsum!`)
-to use a preallocated output array, both for performance and to control the precision of the
-output (e.g. to avoid overflow).
-"""
-cumsum
 
 """
     rpad(string, n, p)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -504,17 +504,20 @@ to use a preallocated output array, both for performance and to control the prec
 output (e.g. to avoid overflow).
 
 ```jldoctest
-julia> a = rand(1:8,3,4)
-3×4 Array{Int64,2}:
- 7  4  1  1
- 7  6  5  4
- 3  5  7  7
+julia> a = [1 2 3; 4 5 6]
+2×3 Array{Int64,2}:
+ 1  2  3
+ 4  5  6
+
+julia> cumsum(a,1)
+2×3 Array{Int64,2}:
+ 1  2  3
+ 5  7  9
 
 julia> cumsum(a,2)
-3×4 Array{Int64,2}:
- 7  11  12  13
- 7  13  18  22
- 3   8  15  22
+2×3 Array{Int64,2}:
+ 1  3   6
+ 4  9  15
 ```
 """
 cumsum(A::AbstractArray, axis::Integer=1) =  cumsum!(similar(A, Base._cumsum_type(A)), A, axis)
@@ -527,17 +530,20 @@ Cumulative product along a dimension `dim` (defaults to 1). See also
 to control the precision of the output (e.g. to avoid overflow).
 
 ```jldoctest
-julia> a = rand(1:8,3,4)
-3×4 Array{Int64,2}:
- 8  1  7  8
- 7  2  3  6
- 5  3  6  6
+julia> a = [1 2 3; 4 5 6]
+2×3 Array{Int64,2}:
+ 1  2  3
+ 4  5  6
+
+julia> cumprod(a,1)
+2×3 Array{Int64,2}:
+ 1   2   3
+ 4  10  18
 
 julia> cumprod(a,2)
-3×4 Array{Int64,2}:
- 8   8  56  448
- 7  14  42  252
- 5  15  90  540
+2×3 Array{Int64,2}:
+ 1   2    6
+ 4  20  120
 ```
 """
 cumprod(A::AbstractArray, axis::Integer=1) = cumprod!(similar(A), A, axis)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -496,8 +496,50 @@ for (f, fmod, op) = ((:cummin, :_cummin!, :min), (:cummax, :_cummax!, :max))
     @eval ($f)(A::AbstractArray) = ($f)(A, 1)
 end
 
- cumsum(A::AbstractArray, axis::Integer=1) =  cumsum!(similar(A, Base._cumsum_type(A)), A, axis)
+"""
+    cumsum(A, dim=1)
+
+Cumulative sum along a dimension `dim` (defaults to 1). See also [`cumsum!`](:func:`cumsum!`)
+to use a preallocated output array, both for performance and to control the precision of the
+output (e.g. to avoid overflow).
+
+```jldoctest
+julia> a = rand(1:8,3,4)
+3×4 Array{Int64,2}:
+ 7  4  1  1
+ 7  6  5  4
+ 3  5  7  7
+
+julia> cumsum(a,2)
+3×4 Array{Int64,2}:
+ 7  11  12  13
+ 7  13  18  22
+ 3   8  15  22
+```
+"""
+cumsum(A::AbstractArray, axis::Integer=1) =  cumsum!(similar(A, Base._cumsum_type(A)), A, axis)
 cumsum!(B, A::AbstractArray) = cumsum!(B, A, 1)
+"""
+    cumprod(A, dim=1)
+
+Cumulative product along a dimension `dim` (defaults to 1). See also
+[`cumprod!`](:func:`cumprod!`) to use a preallocated output array, both for performance and
+to control the precision of the output (e.g. to avoid overflow).
+
+```jldoctest
+julia> a = rand(1:8,3,4)
+3×4 Array{Int64,2}:
+ 8  1  7  8
+ 7  2  3  6
+ 5  3  6  6
+
+julia> cumprod(a,2)
+3×4 Array{Int64,2}:
+ 8   8  56  448
+ 7  14  42  252
+ 5  15  90  540
+```
+"""
 cumprod(A::AbstractArray, axis::Integer=1) = cumprod!(similar(A), A, axis)
 cumprod!(B, A) = cumprod!(B, A, 1)
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -232,19 +232,12 @@ Evaluates to the same as `reducedim(op, map(f, A), region, f(v0))`, but is gener
 faster because the intermediate array is avoided.
 
 ```jldoctest
-julia> a = rand(1:5,4,4)
+julia> a = reshape(collect(1:16), (4,4))
 4×4 Array{Int64,2}:
- 1  2  4  1
- 5  5  3  1
- 2  4  3  3
- 1  5  3  2
-
-julia> mapreducedim(isodd, *, a, 2)
-4×1 Array{Bool,2}:
- false
- true
- false
- false
+ 1  5   9  13
+ 2  6  10  14
+ 3  7  11  15
+ 4  8  12  16
 
 julia> mapreducedim(isodd, *, a, 1)
 1×4 Array{Bool,2}:
@@ -272,23 +265,23 @@ associativity, e.g. left-to-right, you should write your own loop. See documenta
 [`reduce`](:func:`reduce`).
 
 ```jldoctest
-julia> a = rand(1:5,4,4)
+julia> a = reshape(collect(1:16), (4,4))
 4×4 Array{Int64,2}:
- 3  5  4  3
- 3  2  5  5
- 3  3  4  2
- 5  5  5  1
+ 1  5   9  13
+ 2  6  10  14
+ 3  7  11  15
+ 4  8  12  16
 
-julia> reducedim(max,a,2)
+julia> reducedim(max, a, 2)
 4×1 Array{Int64,2}:
- 5
- 5
- 4
- 5
+ 13
+ 14
+ 15
+ 16
 
-julia> reducedim(max,a,1)
+julia> reducedim(max, a, 1)
 1×4 Array{Int64,2}:
- 5  5  5  5
+ 4  8  12  16
 ```
 """
 reducedim(op, A::AbstractArray, region, v0) = mapreducedim(identity, op, A, region, v0)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -225,11 +225,72 @@ mapreducedim!(f, op, R::AbstractArray, A::AbstractArray) =
 reducedim!{RT}(op, R::AbstractArray{RT}, A::AbstractArray) =
     mapreducedim!(identity, op, R, A, zero(RT))
 
+"""
+    mapreducedim(f, op, A, region[, v0])
+
+Evaluates to the same as `reducedim(op, map(f, A), region, f(v0))`, but is generally
+faster because the intermediate array is avoided.
+
+```jldoctest
+julia> a = rand(1:5,4,4)
+4×4 Array{Int64,2}:
+ 1  2  4  1
+ 5  5  3  1
+ 2  4  3  3
+ 1  5  3  2
+
+julia> mapreducedim(isodd, *, a, 2)
+4×1 Array{Bool,2}:
+ false
+ true
+ false
+ false
+
+julia> mapreducedim(isodd, *, a, 1)
+1×4 Array{Bool,2}:
+ false  false  false  false
+
+julia> mapreducedim(isodd, |, a, 1, true)
+1×4 Array{Bool,2}:
+ true  true  true  true
+```
+"""
 mapreducedim(f, op, A::AbstractArray, region, v0) =
     mapreducedim!(f, op, reducedim_initarray(A, region, v0), A)
 mapreducedim{T}(f, op, A::AbstractArray{T}, region) =
     mapreducedim!(f, op, reducedim_init(f, op, A, region), A)
 
+"""
+    reducedim(f, A, region[, v0])
+
+Reduce 2-argument function `f` along dimensions of `A`. `region` is a vector specifying the
+dimensions to reduce, and `v0` is the initial value to use in the reductions. For `+`, `*`,
+`max` and `min` the `v0` argument is optional.
+
+The associativity of the reduction is implementation-dependent; if you need a particular
+associativity, e.g. left-to-right, you should write your own loop. See documentation for
+[`reduce`](:func:`reduce`).
+
+```jldoctest
+julia> a = rand(1:5,4,4)
+4×4 Array{Int64,2}:
+ 3  5  4  3
+ 3  2  5  5
+ 3  3  4  2
+ 5  5  5  1
+
+julia> reducedim(max,a,2)
+4×1 Array{Int64,2}:
+ 5
+ 5
+ 4
+ 5
+
+julia> reducedim(max,a,1)
+1×4 Array{Int64,2}:
+ 5  5  5  5
+```
+"""
 reducedim(op, A::AbstractArray, region, v0) = mapreducedim(identity, op, A, region, v0)
 reducedim(op, A::AbstractArray, region) = mapreducedim(identity, op, A, region)
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -952,15 +952,15 @@ Array functions
        [:, :, 1, 1] =
         1  3
         2  4
-
+       <BLANKLINE>
        [:, :, 2, 1] =
         5  7
         6  8
-
+       <BLANKLINE>
        [:, :, 1, 2] =
          9  11
         10  12
-
+       <BLANKLINE>
        [:, :, 2, 2] =
         13  15
         14  16
@@ -969,13 +969,13 @@ Array functions
        1×1×2×2 Array{Int64,4}:
        [:, :, 1, 1] =
         10
-
+       <BLANKLINE>
        [:, :, 2, 1] =
         26
-
+       <BLANKLINE>
        [:, :, 1, 2] =
         42
-
+       <BLANKLINE>
        [:, :, 2, 2] =
         58
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -657,11 +657,25 @@ Indexing, Assignment, and Concatenation
 Array functions
 ---------------
 
-.. function:: cumprod(A, [dim])
+.. function:: cumprod(A, dim=1)
 
    .. Docstring generated from Julia source
 
    Cumulative product along a dimension ``dim`` (defaults to 1). See also :func:`cumprod!` to use a preallocated output array, both for performance and to control the precision of the output (e.g. to avoid overflow).
+
+   .. doctest::
+
+       julia> a = rand(1:8,3,4)
+       3×4 Array{Int64,2}:
+        8  1  7  8
+        7  2  3  6
+        5  3  6  6
+
+       julia> cumprod(a,2)
+       3×4 Array{Int64,2}:
+        8   8  56  448
+        7  14  42  252
+        5  15  90  540
 
 .. function:: cumprod!(B, A, [dim])
 
@@ -669,11 +683,25 @@ Array functions
 
    Cumulative product of ``A`` along a dimension, storing the result in ``B``\ . The dimension defaults to 1.
 
-.. function:: cumsum(A, [dim])
+.. function:: cumsum(A, dim=1)
 
    .. Docstring generated from Julia source
 
    Cumulative sum along a dimension ``dim`` (defaults to 1). See also :func:`cumsum!` to use a preallocated output array, both for performance and to control the precision of the output (e.g. to avoid overflow).
+
+   .. doctest::
+
+       julia> a = rand(1:8,3,4)
+       3×4 Array{Int64,2}:
+        7  4  1  1
+        7  6  5  4
+        3  5  7  7
+
+       julia> cumsum(a,2)
+       3×4 Array{Int64,2}:
+        7  11  12  13
+        7  13  18  22
+        3   8  15  22
 
 .. function:: cumsum!(B, A, [dim])
 
@@ -717,11 +745,45 @@ Array functions
 
    Rotate matrix ``A`` 180 degrees.
 
+   .. doctest::
+
+       julia> a = rand(1:8,3,3)
+       3×3 Array{Int64,2}:
+        4  8  6
+        6  4  6
+        2  8  7
+
+       julia> rot180(a)
+       3×3 Array{Int64,2}:
+        7  8  2
+        6  4  6
+        6  8  4
+
 .. function:: rot180(A, k)
 
    .. Docstring generated from Julia source
 
    Rotate matrix ``A`` 180 degrees an integer ``k`` number of times. If ``k`` is even, this is equivalent to a ``copy``\ .
+
+   .. doctest::
+
+       julia> a = rand(1:8,3,3)
+       3×3 Array{Int64,2}:
+        5  6  3
+        6  7  2
+        2  1  6
+
+       julia> rot180(a,1)
+       3×3 Array{Int64,2}:
+        6  1  2
+        2  7  6
+        3  6  5
+
+       julia> rot180(a,2)
+       3×3 Array{Int64,2}:
+        5  6  3
+        6  7  2
+        2  1  6
 
 .. function:: rotl90(A)
 
@@ -729,11 +791,57 @@ Array functions
 
    Rotate matrix ``A`` left 90 degrees.
 
+   .. doctest::
+
+       julia> a = rand(1:8,3,3)
+       3×3 Array{Int64,2}:
+        6  8  8
+        3  1  8
+        6  1  3
+
+       julia> rotl90(a)
+       3×3 Array{Int64,2}:
+        8  8  3
+        8  1  1
+        6  3  6
+
 .. function:: rotl90(A, k)
 
    .. Docstring generated from Julia source
 
    Rotate matrix ``A`` left 90 degrees an integer ``k`` number of times. If ``k`` is zero or a multiple of four, this is equivalent to a ``copy``\ .
+
+   .. doctest::
+
+       julia> a = rand(1:8,3,3)
+       3×3 Array{Int64,2}:
+        7  2  6
+        2  5  2
+        7  3  3
+
+       julia> rotl90(a,1)
+       3×3 Array{Int64,2}:
+        6  2  3
+        2  5  3
+        7  2  7
+
+       julia> rotl90(a,2)
+       3×3 Array{Int64,2}:
+        3  3  7
+        2  5  2
+        6  2  7
+
+       julia> rotl90(a,3)
+       3×3 Array{Int64,2}:
+        7  2  7
+        3  5  2
+        3  2  6
+
+       julia> rotl90(a,4)
+       3×3 Array{Int64,2}:
+        7  2  6
+        2  5  2
+        7  3  3
 
 .. function:: rotr90(A)
 
@@ -741,31 +849,155 @@ Array functions
 
    Rotate matrix ``A`` right 90 degrees.
 
+   .. doctest::
+
+       julia> a = rand(1:8,3,3)
+       3×3 Array{Int64,2}:
+        4  6  1
+        8  8  1
+        7  4  8
+
+       julia> rotr90(a)
+       3×3 Array{Int64,2}:
+        7  8  4
+        4  8  6
+        8  1  1
+
 .. function:: rotr90(A, k)
 
    .. Docstring generated from Julia source
 
    Rotate matrix ``A`` right 90 degrees an integer ``k`` number of times. If ``k`` is zero or a multiple of four, this is equivalent to a ``copy``\ .
 
-.. function:: reducedim(f, A, dims[, initial])
+   .. doctest::
+
+       julia> a = rand(1:8,3,3)
+       3×3 Array{Int64,2}:
+        7  8  1
+        3  1  6
+        7  2  1
+
+       julia> rotr90(a,1)
+       3×3 Array{Int64,2}:
+        7  3  7
+        2  1  8
+        1  6  1
+
+       julia> rotr90(a,2)
+       3×3 Array{Int64,2}:
+        1  2  7
+        6  1  3
+        1  8  7
+
+       julia> rotr90(a,3)
+       3×3 Array{Int64,2}:
+        1  6  1
+        8  1  2
+        7  3  7
+
+       julia> rotr90(a,4)
+       3×3 Array{Int64,2}:
+        7  8  1
+        3  1  6
+        7  2  1
+
+.. function:: reducedim(f, A, region[, v0])
 
    .. Docstring generated from Julia source
 
-   Reduce 2-argument function ``f`` along dimensions of ``A``\ . ``dims`` is a vector specifying the dimensions to reduce, and ``initial`` is the initial value to use in the reductions. For ``+``\ , ``*``\ , ``max`` and ``min`` the ``initial`` argument is optional.
+   Reduce 2-argument function ``f`` along dimensions of ``A``\ . ``region`` is a vector specifying the dimensions to reduce, and ``v0`` is the initial value to use in the reductions. For ``+``\ , ``*``\ , ``max`` and ``min`` the ``v0`` argument is optional.
 
-   The associativity of the reduction is implementation-dependent; if you need a particular associativity, e.g. left-to-right, you should write your own loop. See documentation for ``reduce``\ .
+   The associativity of the reduction is implementation-dependent; if you need a particular associativity, e.g. left-to-right, you should write your own loop. See documentation for :func:`reduce`\ .
 
-.. function:: mapreducedim(f, op, A, dims[, initial])
+   .. doctest::
+
+       julia> a = rand(1:5,4,4)
+       4×4 Array{Int64,2}:
+        3  5  4  3
+        3  2  5  5
+        3  3  4  2
+        5  5  5  1
+
+       julia> reducedim(max,a,2)
+       4×1 Array{Int64,2}:
+        5
+        5
+        4
+        5
+
+       julia> reducedim(max,a,1)
+       1×4 Array{Int64,2}:
+        5  5  5  5
+
+.. function:: mapreducedim(f, op, A, region[, v0])
 
    .. Docstring generated from Julia source
 
-   Evaluates to the same as ``reducedim(op, map(f, A), dims, f(initial))``\ , but is generally faster because the intermediate array is avoided.
+   Evaluates to the same as ``reducedim(op, map(f, A), region, f(v0))``\ , but is generally faster because the intermediate array is avoided.
+
+   .. doctest::
+
+       julia> a = rand(1:5,4,4)
+       4×4 Array{Int64,2}:
+        1  2  4  1
+        5  5  3  1
+        2  4  3  3
+        1  5  3  2
+
+       julia> mapreducedim(isodd, *, a, 2)
+       4×1 Array{Bool,2}:
+        false
+        true
+        false
+        false
+
+       julia> mapreducedim(isodd, *, a, 1)
+       1×4 Array{Bool,2}:
+        false  false  false  false
+
+       julia> mapreducedim(isodd, |, a, 1, true)
+       1×4 Array{Bool,2}:
+        true  true  true  true
 
 .. function:: mapslices(f, A, dims)
 
    .. Docstring generated from Julia source
 
    Transform the given dimensions of array ``A`` using function ``f``\ . ``f`` is called on each slice of ``A`` of the form ``A[...,:,...,:,...]``\ . ``dims`` is an integer vector specifying where the colons go in this expression. The results are concatenated along the remaining dimensions. For example, if ``dims`` is ``[1,2]`` and ``A`` is 4-dimensional, ``f`` is called on ``A[:,:,i,j]`` for all ``i`` and ``j``\ .
+
+   .. doctest::
+
+       julia> A = rand(1:5, 2, 2, 2, 2)
+       2×2×2×2 Array{Int64,4}:
+       [:, :, 1, 1] =
+        1  1
+        3  4
+
+       [:, :, 2, 1] =
+        4  1
+        5  3
+
+       [:, :, 1, 2] =
+        3  4
+        1  3
+
+       [:, :, 2, 2] =
+        4  4
+        4  1
+
+       julia> mapslices(sum, A, [1,2])
+       1×1×2×2 Array{Int64,4}:
+       [:, :, 1, 1] =
+        9
+
+       [:, :, 2, 1] =
+        13
+
+       [:, :, 1, 2] =
+        11
+
+       [:, :, 2, 2] =
+        13
 
 .. function:: sum_kbn(A)
 
@@ -1086,3 +1318,4 @@ dense counterparts. The following functions are specific to sparse arrays.
    For additional (algorithmic) information, and for versions of these methods that forgo argument checking, see (unexported) parent methods :func:`Base.SparseArrays.unchecked_noalias_permute!` and :func:`Base.SparseArrays.unchecked_aliasing_permute!`\ .
 
    See also: :func:`Base.SparseArrays.permute`
+

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -665,17 +665,20 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,4)
-       3×4 Array{Int64,2}:
-        8  1  7  8
-        7  2  3  6
-        5  3  6  6
+       julia> a = [1 2 3; 4 5 6]
+       2×3 Array{Int64,2}:
+        1  2  3
+        4  5  6
+
+       julia> cumprod(a,1)
+       2×3 Array{Int64,2}:
+        1   2   3
+        4  10  18
 
        julia> cumprod(a,2)
-       3×4 Array{Int64,2}:
-        8   8  56  448
-        7  14  42  252
-        5  15  90  540
+       2×3 Array{Int64,2}:
+        1   2    6
+        4  20  120
 
 .. function:: cumprod!(B, A, [dim])
 
@@ -691,17 +694,20 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,4)
-       3×4 Array{Int64,2}:
-        7  4  1  1
-        7  6  5  4
-        3  5  7  7
+       julia> a = [1 2 3; 4 5 6]
+       2×3 Array{Int64,2}:
+        1  2  3
+        4  5  6
+
+       julia> cumsum(a,1)
+       2×3 Array{Int64,2}:
+        1  2  3
+        5  7  9
 
        julia> cumsum(a,2)
-       3×4 Array{Int64,2}:
-        7  11  12  13
-        7  13  18  22
-        3   8  15  22
+       2×3 Array{Int64,2}:
+        1  3   6
+        4  9  15
 
 .. function:: cumsum!(B, A, [dim])
 
@@ -747,17 +753,15 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,3)
-       3×3 Array{Int64,2}:
-        4  8  6
-        6  4  6
-        2  8  7
+       julia> a = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
        julia> rot180(a)
-       3×3 Array{Int64,2}:
-        7  8  2
-        6  4  6
-        6  8  4
+       2×2 Array{Int64,2}:
+        4  3
+        2  1
 
 .. function:: rot180(A, k)
 
@@ -767,23 +771,20 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,3)
-       3×3 Array{Int64,2}:
-        5  6  3
-        6  7  2
-        2  1  6
+       julia> a = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
        julia> rot180(a,1)
-       3×3 Array{Int64,2}:
-        6  1  2
-        2  7  6
-        3  6  5
+       2×2 Array{Int64,2}:
+        4  3
+        2  1
 
        julia> rot180(a,2)
-       3×3 Array{Int64,2}:
-        5  6  3
-        6  7  2
-        2  1  6
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
 .. function:: rotl90(A)
 
@@ -793,17 +794,15 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,3)
-       3×3 Array{Int64,2}:
-        6  8  8
-        3  1  8
-        6  1  3
+       julia> a = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
        julia> rotl90(a)
-       3×3 Array{Int64,2}:
-        8  8  3
-        8  1  1
-        6  3  6
+       2×2 Array{Int64,2}:
+        2  4
+        1  3
 
 .. function:: rotl90(A, k)
 
@@ -813,35 +812,30 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,3)
-       3×3 Array{Int64,2}:
-        7  2  6
-        2  5  2
-        7  3  3
+       julia> a = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
        julia> rotl90(a,1)
-       3×3 Array{Int64,2}:
-        6  2  3
-        2  5  3
-        7  2  7
+       2×2 Array{Int64,2}:
+        2  4
+        1  3
 
        julia> rotl90(a,2)
-       3×3 Array{Int64,2}:
-        3  3  7
-        2  5  2
-        6  2  7
+       2×2 Array{Int64,2}:
+        4  3
+        2  1
 
        julia> rotl90(a,3)
-       3×3 Array{Int64,2}:
-        7  2  7
-        3  5  2
-        3  2  6
+       2×2 Array{Int64,2}:
+        3  1
+        4  2
 
        julia> rotl90(a,4)
-       3×3 Array{Int64,2}:
-        7  2  6
-        2  5  2
-        7  3  3
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
 .. function:: rotr90(A)
 
@@ -851,17 +845,15 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,3)
-       3×3 Array{Int64,2}:
-        4  6  1
-        8  8  1
-        7  4  8
+       julia> a = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
        julia> rotr90(a)
-       3×3 Array{Int64,2}:
-        7  8  4
-        4  8  6
-        8  1  1
+       2×2 Array{Int64,2}:
+        3  1
+        4  2
 
 .. function:: rotr90(A, k)
 
@@ -871,35 +863,30 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:8,3,3)
-       3×3 Array{Int64,2}:
-        7  8  1
-        3  1  6
-        7  2  1
+       julia> a = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
        julia> rotr90(a,1)
-       3×3 Array{Int64,2}:
-        7  3  7
-        2  1  8
-        1  6  1
+       2×2 Array{Int64,2}:
+        3  1
+        4  2
 
        julia> rotr90(a,2)
-       3×3 Array{Int64,2}:
-        1  2  7
-        6  1  3
-        1  8  7
+       2×2 Array{Int64,2}:
+        4  3
+        2  1
 
        julia> rotr90(a,3)
-       3×3 Array{Int64,2}:
-        1  6  1
-        8  1  2
-        7  3  7
+       2×2 Array{Int64,2}:
+        2  4
+        1  3
 
        julia> rotr90(a,4)
-       3×3 Array{Int64,2}:
-        7  8  1
-        3  1  6
-        7  2  1
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
 
 .. function:: reducedim(f, A, region[, v0])
 
@@ -911,23 +898,23 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:5,4,4)
+       julia> a = reshape(collect(1:16), (4,4))
        4×4 Array{Int64,2}:
-        3  5  4  3
-        3  2  5  5
-        3  3  4  2
-        5  5  5  1
+        1  5   9  13
+        2  6  10  14
+        3  7  11  15
+        4  8  12  16
 
-       julia> reducedim(max,a,2)
+       julia> reducedim(max, a, 2)
        4×1 Array{Int64,2}:
-        5
-        5
-        4
-        5
+        13
+        14
+        15
+        16
 
-       julia> reducedim(max,a,1)
+       julia> reducedim(max, a, 1)
        1×4 Array{Int64,2}:
-        5  5  5  5
+        4  8  12  16
 
 .. function:: mapreducedim(f, op, A, region[, v0])
 
@@ -937,19 +924,12 @@ Array functions
 
    .. doctest::
 
-       julia> a = rand(1:5,4,4)
+       julia> a = reshape(collect(1:16), (4,4))
        4×4 Array{Int64,2}:
-        1  2  4  1
-        5  5  3  1
-        2  4  3  3
-        1  5  3  2
-
-       julia> mapreducedim(isodd, *, a, 2)
-       4×1 Array{Bool,2}:
-        false
-        true
-        false
-        false
+        1  5   9  13
+        2  6  10  14
+        3  7  11  15
+        4  8  12  16
 
        julia> mapreducedim(isodd, *, a, 1)
        1×4 Array{Bool,2}:
@@ -967,37 +947,37 @@ Array functions
 
    .. doctest::
 
-       julia> A = rand(1:5, 2, 2, 2, 2)
+       julia> a = reshape(collect(1:16),(2,2,2,2))
        2×2×2×2 Array{Int64,4}:
        [:, :, 1, 1] =
-        1  1
-        3  4
+        1  3
+        2  4
 
        [:, :, 2, 1] =
-        4  1
-        5  3
+        5  7
+        6  8
 
        [:, :, 1, 2] =
-        3  4
-        1  3
+         9  11
+        10  12
 
        [:, :, 2, 2] =
-        4  4
-        4  1
+        13  15
+        14  16
 
-       julia> mapslices(sum, A, [1,2])
+       julia> mapslices(sum, a, [1,2])
        1×1×2×2 Array{Int64,4}:
        [:, :, 1, 1] =
-        9
+        10
 
        [:, :, 2, 1] =
-        13
+        26
 
        [:, :, 1, 2] =
-        11
+        42
 
        [:, :, 2, 2] =
-        13
+        58
 
 .. function:: sum_kbn(A)
 


### PR DESCRIPTION
Lots of examples for things that are probably confusing for new
Julia users. Made `reducedim` and `mapreducedim` arguments more
similar to the ones for `reduce` and `mapreduce`.
