### PR TITLE
Restore type parameter for elementwise ops (fix #17794)

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -53,7 +53,7 @@ function _elementwise(op, ::Type{Any}, A::AbstractArray, B::AbstractArray)
     promote_shape(A, B) # check size compatibility
     return broadcast(op, A, B)
 end
-function _elementwise(op, T::Type, A::AbstractArray, B::AbstractArray)
+function _elementwise{T}(op, ::Type{T}, A::AbstractArray, B::AbstractArray)
     F = similar(A, T, promote_shape(A, B))
     for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
         @inbounds F[iF] = op(A[iA], B[iB])


### PR DESCRIPTION
Sorry for this one.

**Take away leasson:** When modifying functions that involve arrays, consult `@nanosoldier` before merging.
