### PR TITLE
Deoptimize TLS access

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -147,7 +147,7 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
 #if defined(__GLIBC__) && (defined(_CPU_X86_64_) || defined(_CPU_X86_) || \
                            ((defined(_CPU_AARCH64_) || defined(_CPU_ARM_) || \
                              defined(_CPU_PPC64_) || defined(_CPU_PPC_)) && \
-                            __GNUC__ >= 5))
+                            __GNUC__ >= 6))
 // Only enable this on architectures that are tested.
 // For example, GCC doesn't seem to support the `ifunc` attribute on power yet.
 #  if __GLIBC_PREREQ(2, 12)


### PR DESCRIPTION
- Apparently `ifunc` is not supported by gcc 5 on ARM
  
  Workaround https://github.com/JuliaLang/julia/issues/17264#issuecomment-236886331
- Try even harder to workaround LLVM bug when dealing with returntwice function
  
  Workaround https://github.com/JuliaLang/julia/issues/17793
