### PR TITLE
Fix `jl_static_show` for `bitstype`

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1479,7 +1479,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         size_t nb = jl_datatype_size(vt);
         size_t tlen = jl_datatype_nfields(vt);
         if (nb > 0 && tlen == 0) {
-            char *data = (char*)jl_data_ptr(v);
+            uint8_t *data = (uint8_t*)v;
             n += jl_printf(out, "0x");
             for(int i=nb-1; i >= 0; --i)
                 n += jl_printf(out, "%02" PRIx8, data[i]);


### PR DESCRIPTION
The byte gets sign extended when passing to the vararg `jl_printf` and then printed as an unsigned int which might come with unwanted `ffffff` prefix.

This happens on my machine where `PRIx8` is `x` which is the right format but doesn't truncate the input.... (If not for Windows support we could just use `hhx` formatting string).....
