### PR TITLE
Fix `@threadcall` argument passing.

### DIFF
--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -23,6 +23,8 @@ function without causing the main `julia` thread to become blocked. Concurrency
 is limited by size of the libuv thread pool, which defaults to 4 threads but
 can be increased by setting the `UV_THREADPOOL_SIZE` environment variable and
 restarting the `julia` process.
+
+Note that the called function should never call back into Julia.
 """
 macro threadcall(f, rettype, argtypes, argvals...)
     # check for usage errors
@@ -73,6 +75,7 @@ function do_threadcall(wrapper::Function, rettype::Type, argtypes::Vector, argva
         y = cconvert(T, x)
         push!(roots, y)
         unsafe_store!(convert(Ptr{T}, ptr), unsafe_convert(T, y))
+        ptr += sizeof(T)
     end
 
     # create return buffer

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -589,6 +589,10 @@ threadcall_test_func(x) =
 @test threadcall_test_func(3) == 1
 @test threadcall_test_func(259) == 1
 
+f17819(a,b) = Cint(a+b)
+cf17819 = cfunction(f17819, Cint, (Cint,Cint))
+@test @threadcall(cf17819, Cint, (Cint, Cint), 1, 2) == 3
+
 let n=3
     tids = Culong[]
     @sync for i in 1:10^n


### PR DESCRIPTION
Fixes #17819. Also document not being allowed to call back into Julia.
