### PR TITLE
RFC: Use JL_LLVM_VERSION instead of LLVMxx

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -11,7 +11,7 @@
 
 using namespace llvm;
 
-#ifdef LLVM39
+#if JL_LLVM_VERSION >= 30900
 inline uint64_t RoundUpToAlignment(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
     return alignTo(Value, Align, Skew);
 }
@@ -448,7 +448,7 @@ void LLVMTrunc(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPar
 
 extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_8(uint8_t Val) {
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
     return countTrailingZeros(Val);
 #else
     return CountTrailingZeros_32(Val);
@@ -457,7 +457,7 @@ unsigned countTrailingZeros_8(uint8_t Val) {
 
 extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_16(uint16_t Val) {
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
     return countTrailingZeros(Val);
 #else
     return CountTrailingZeros_32(Val);
@@ -466,7 +466,7 @@ unsigned countTrailingZeros_16(uint16_t Val) {
 
 extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_32(uint32_t Val) {
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
     return countTrailingZeros(Val);
 #else
     return CountTrailingZeros_32(Val);
@@ -475,7 +475,7 @@ unsigned countTrailingZeros_32(uint32_t Val) {
 
 extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_64(uint64_t Val) {
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
     return countTrailingZeros(Val);
 #else
     return CountTrailingZeros_64(Val);

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -9,8 +9,8 @@
 #include "julia.h"
 #include "julia_internal.h"
 
-#ifdef LLVM37
-#ifndef LLVM38
+#if JL_LLVM_VERSION >= 30700
+#if JL_LLVM_VERSION < 30800
 #  include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #endif
 #ifdef _OS_LINUX_
@@ -727,7 +727,7 @@ public:
     uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
                                  unsigned SectionID, StringRef SectionName,
                                  bool isReadOnly) override;
-#ifdef LLVM38
+#if JL_LLVM_VERSION >= 30800
     void notifyObjectLoaded(RuntimeDyld &Dyld,
                             const object::ObjectFile &Obj) override;
 #endif
@@ -802,7 +802,7 @@ uint8_t *RTDyldMemoryManagerJL::allocateDataSection(uintptr_t Size,
                                                      SectionName, isReadOnly);
 }
 
-#ifdef LLVM38
+#if JL_LLVM_VERSION >= 30800
 void RTDyldMemoryManagerJL::notifyObjectLoaded(RuntimeDyld &Dyld,
                                                const object::ObjectFile &Obj)
 {
@@ -855,7 +855,7 @@ void RTDyldMemoryManagerJL::deregisterEHFrames(uint8_t *Addr,
 
 }
 
-#ifndef LLVM38
+#if JL_LLVM_VERSION < 30800
 void notifyObjectLoaded(RTDyldMemoryManager *memmgr,
                         llvm::orc::ObjectLinkingLayerBase::ObjSetHandleT H)
 {
@@ -870,9 +870,9 @@ void *lookupWriteAddressFor(RTDyldMemoryManager *memmgr, void *rt_addr)
 }
 #endif
 
-#else // LLVM37
+#else // JL_LLVM_VERSION >= 30700
 typedef SectionMemoryManager RTDyldMemoryManagerJL;
-#endif // LLVM37
+#endif // JL_LLVM_VERSION >= 30700
 
 RTDyldMemoryManager* createRTDyldMemoryManager()
 {

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -1,6 +1,6 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
-#if defined(LLVM38) && !defined(LLVM37)
+#if defined(USE_ORCJIT) && JL_LLVM_VERSION <= 30800
 #  include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 void notifyObjectLoaded(RTDyldMemoryManager *memmgr,
                         llvm::orc::ObjectLinkingLayerBase::ObjSetHandleT H);
@@ -14,7 +14,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #endif
                           const object::ObjectFile *object,
                           llvm::DIContext *context,
-#ifdef LLVM37
+#if JL_LLVM_VERSION >= 30700
                           raw_ostream &rstream
 #else
                           formatted_raw_ostream &stream

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -25,7 +25,7 @@
 #include <llvm/ExecutionEngine/JITEventListener.h>
 #endif
 
-#ifdef LLVM37
+#if JL_LLVM_VERSION >= 30700
 #include "llvm/IR/LegacyPassManager.h"
 extern legacy::PassManager *jl_globalPM;
 #else
@@ -33,7 +33,7 @@ extern legacy::PassManager *jl_globalPM;
 extern PassManager *jl_globalPM;
 #endif
 
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
 #include <llvm/Target/TargetMachine.h>
 #endif
 
@@ -54,7 +54,7 @@ extern size_t jltls_states_func_idx;
 
 typedef struct {Value *gv; int32_t index;} jl_value_llvm; // uses 1-based indexing
 
-#ifdef LLVM37
+#if JL_LLVM_VERSION >= 30700
 void addOptimizationPasses(legacy::PassManager *PM);
 #else
 void addOptimizationPasses(PassManager *PM);
@@ -78,7 +78,7 @@ static inline GlobalVariable *global_proto(GlobalVariable *G, Module *M = NULL)
             G->isConstant(), GlobalVariable::ExternalLinkage,
             NULL, G->getName(),  G->getThreadLocalMode());
     proto->copyAttributesFrom(G);
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
     // DLLImport only needs to be set for the shadow module
     // it just gets annoying in the JIT
     proto->setDLLStorageClass(GlobalValue::DefaultStorageClass);
@@ -100,7 +100,7 @@ static inline Function *function_proto(Function *F, Module *M = NULL)
     // routine from `F`, since copying it and then resetting is more expensive
     // as well as introducing an extra use from this unowned function, which
     // can cause crashes in the LLVMContext's global destructor.
-#ifdef LLVM37
+#if JL_LLVM_VERSION >= 30700
     llvm::Constant *OldPersonalityFn = nullptr;
     if (F->hasPersonalityFn()) {
         OldPersonalityFn = F->getPersonalityFn();
@@ -112,12 +112,12 @@ static inline Function *function_proto(Function *F, Module *M = NULL)
      // as codegen may make decisions based on the presence of certain attributes
      NewF->copyAttributesFrom(F);
 
-#ifdef LLVM37
+#if JL_LLVM_VERSION >= 30700
     if (OldPersonalityFn)
         F->setPersonalityFn(OldPersonalityFn);
 #endif
 
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
     // DLLImport only needs to be set for the shadow module
     // it just gets annoying in the JIT
     NewF->setDLLStorageClass(GlobalValue::DefaultStorageClass);
@@ -137,7 +137,7 @@ static inline GlobalVariable *prepare_global(GlobalVariable *G, Module *M)
     return cast<GlobalVariable>(local);
 }
 
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
 void add_named_global(GlobalObject *gv, void *addr, bool dllimport);
 template<typename T>
 static inline void add_named_global(GlobalObject *gv, T *addr, bool dllimport = true)
@@ -154,7 +154,7 @@ static inline void add_named_global(GlobalValue *gv, T *addr, bool dllimport = t
 
 void jl_init_jit(Type *T_pjlvalue_);
 #ifdef USE_ORCJIT
-#ifdef LLVM40
+#if JL_LLVM_VERSION >= 40000
 typedef JITSymbol JL_JITSymbol;
 // The type that is similar to SymbolInfo on LLVM 4.0 is actually
 // `JITEvaluatedSymbol`. However, we only use this type when a JITSymbol
@@ -226,7 +226,7 @@ extern JuliaOJIT *jl_ExecutionEngine;
 #else
 extern ExecutionEngine *jl_ExecutionEngine;
 #endif
-#ifdef LLVM39
+#if JL_LLVM_VERSION >= 30900
 JL_DLLEXPORT extern LLVMContext jl_LLVMContext;
 #else
 JL_DLLEXPORT extern LLVMContext &jl_LLVMContext;

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -19,7 +19,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 
-#if defined(LLVM37) && defined(JULIA_ENABLE_THREADING)
+#if JL_LLVM_VERSION >= 30700 && defined(JULIA_ENABLE_THREADING)
 #  include <llvm/IR/InlineAsm.h>
 #endif
 
@@ -55,7 +55,7 @@ static void ensure_global(const char *name, Type *t, Module &M,
     // setting JL_DLLEXPORT correctly only matters when building a binary
     // (global_proto will strip this from the JIT)
     if (dllimport) {
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
         // add the __declspec(dllimport) attribute
         proto->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
 #else
@@ -100,7 +100,7 @@ void LowerPTLS::runOnFunction(LLVMContext &ctx, Module &M, Function *F,
         ptlsStates->addAttribute(AttributeSet::FunctionIndex,
                                  Attribute::NoUnwind);
     }
-#ifdef LLVM37
+#if JL_LLVM_VERSION >= 30700
     else if (jl_tls_offset != -1) {
         auto T_int8 = Type::getInt8Ty(ctx);
         auto T_pint8 = PointerType::get(T_int8, 0);

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -30,7 +30,7 @@ bool annotateSimdLoop(BasicBlock *incr)
     // Lazy initialization
     if (!simd_loop_mdkind) {
         simd_loop_mdkind = incr->getContext().getMDKindID("simd_loop");
-#ifdef LLVM36
+#if JL_LLVM_VERSION >= 30600
         simd_loop_md = MDNode::get(incr->getContext(), ArrayRef<Metadata*>());
 #else
         simd_loop_md = MDNode::get(incr->getContext(), ArrayRef<Value*>());
@@ -94,7 +94,7 @@ void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const
     for (Instruction *I = Phi; ; I=J) {
         J = NULL;
         // Find the user of instruction I that is within loop L.
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
         for (User *UI : I->users()) { /*}*/
             Instruction *U = cast<Instruction>(UI);
 #else
@@ -151,11 +151,11 @@ bool LowerSIMDLoop::runOnLoop(Loop *L, LPPassManager &LPM)
     DEBUG(dbgs() << "LSL: simd_loop found\n");
     BasicBlock *Lh = L->getHeader();
     DEBUG(dbgs() << "LSL: loop header: " << *Lh << "\n");
-#ifdef LLVM34
+#if JL_LLVM_VERSION >= 30400
     MDNode *n = L->getLoopID();
     if (!n) {
         // Loop does not have a LoopID yet, so give it one.
-#ifdef LLVM36
+#if JL_LLVM_VERSION >= 30600
         n = MDNode::get(Lh->getContext(), ArrayRef<Metadata*>(NULL));
 #else
         n = MDNode::get(Lh->getContext(), ArrayRef<Value*>(NULL));
@@ -167,7 +167,7 @@ bool LowerSIMDLoop::runOnLoop(Loop *L, LPPassManager &LPM)
     MDNode *n = MDNode::get(Lh->getContext(), ArrayRef<Value*>());
     L->getLoopLatch()->getTerminator()->setMetadata("llvm.loop.parallel", n);
 #endif
-#ifdef LLVM36
+#if JL_LLVM_VERSION >= 30600
     MDNode *m = MDNode::get(Lh->getContext(), ArrayRef<Metadata*>(n));
 #else
     MDNode *m = MDNode::get(Lh->getContext(), ArrayRef<Value*>(n));

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -2,53 +2,32 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR >= 0
-#define LLVM40 1
+// The LLVM version used, JL_LLVM_VERSION, is represented as a 5-digit integer
+// of the form ABBCC, where A is the major version, B is minor, and C is patch.
+// So for example, LLVM 3.7.0 is 30700.
+#define JL_LLVM_VERSION (LLVM_VERSION_MAJOR * 10000 + LLVM_VERSION_MINOR * 100 \
+                        + LLVM_VERSION_PATCH)
+
+#if JL_LLVM_VERSION != 30300 && JL_LLVM_VERSION < 30701
+    #error Only LLVM versions 3.3 and >= 3.7.1 are supported by Julia
 #endif
 
-#if defined(LLVM40) || (defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
-#define LLVM39 1
-#endif
-
-#if defined(LLVM40) || (defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 8)
-#define LLVM38 1
-#define USE_ORCJIT
-#endif
-
-#if defined(LLVM40) || (defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 7)
-#define LLVM37 1
-
+#if JL_LLVM_VERSION >= 30800
+    #define USE_ORCJIT
 // We enable ORCJIT only if we have our custom patches
-#ifndef SYSTEM_LLVM
-#define USE_ORCJIT
+#elif JL_LLVM_VERSION >= 30700 && !defined(SYSTEM_LLVM)
+    #define USE_ORCJIT
 #endif
 
+#if JL_LLVM_VERSION >= 30400
+    #define USE_MCJIT
 #endif
 
-#if defined(LLVM40) || (defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 6)
-#define LLVM36 1
-#endif
 
-#if defined(LLVM40) || (defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 5)
-#define LLVM35 1
+//temporary, since in some places USE_MCJIT may be used instead of the correct LLVM version test
+#ifdef USE_ORCJIT
+    #define USE_MCJIT
 #endif
-
-#if defined(LLVM40) || (defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 4)
-#define LLVM34 1
-#define USE_MCJIT
-#endif
-
-#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR >= 3
-#if defined(LLVM40) || LLVM_VERSION_MINOR >= 3
-#define LLVM33 1
-#endif
-#else
-#error LLVM versions < 3.3 are not supported by Julia
-#endif
-
-#ifdef USE_ORCJIT //temporary, since in some places USE_MCJIT may be used instead of the correct LLVM version test
-#define USE_MCJIT
-#endif
-#ifdef USE_ORCMCJIT //temporary, since in some places USE_MCJIT may be used instead of the correct LLVM version test
-#define USE_MCJIT
+#ifdef USE_ORCMCJIT
+    #define USE_MCJIT
 #endif

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -174,7 +174,7 @@ void *jl_load_and_lookup(const char *f_lib, const char *f_name, void **hnd)
 extern "C" JL_DLLEXPORT
 jl_value_t *jl_get_cpu_name(void)
 {
-#ifdef LLVM35
+#if JL_LLVM_VERSION >= 30500
     StringRef HostCPUName = llvm::sys::getHostCPUName();
 #else
     const std::string& HostCPUName = llvm::sys::getHostCPUName();


### PR DESCRIPTION
Fixes #9860.

As noted in the linked issue, the names `LLVM37`, `LLVM34`, etc. aren't immediately descriptive because they don't refer to specific versions but rather to ranges of versions. This implements the proposed fix of having a single `LLVM_VERSION` macro that holds the LLVM version as a two-digit number and instead of checking whether `LLVMxx` is defined, we check whether `LLVM_VERSION >= xx`. Similarly, checking whether `LLVMxx` is _not_ defined equates to `LLVM_VERSION < xx`.

This works locally, so fingers crossed that it works everywhere else...
