### PR TITLE
REPL completions for brackets and quotes.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+Julia v0.6.0 Release Notes
+==========================
+
+* Some automatic completion of brackets and quotations has been added to the REPL and are enabled by default. These can be disabled or enabled with the function `Base.REPL.enable_bracketmatch(enable::Bool)`.
+
 Julia v0.5.0 Release Notes
 ==========================
 

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -917,8 +917,9 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
                 edit_move_right(s)
             # Prev char or next char is not whitespace
             elseif AUTOMATIC_BRACKET_MATCH[] &&
-                    (position(b) > 0 && leftpeek(b) in all_brackets_ws) ||
-                    (!eof(b) && peek(b) in right_brackets_ws)
+                    ((position(b) > 0 && leftpeek(b) in all_brackets_ws) ||
+                     (!eof(b) && peek(b) in right_brackets_ws) ||
+                     b.size == 0)
                 edit_insert(s, v)
                 edit_insert(s, v)
                 edit_move_left(s)
@@ -941,10 +942,10 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
                 edit_move_right(s)
                 edit_backspace(s)
                 edit_backspace(s)
+                return
             end
-        else
-            edit_backspace(s)
         end
+        edit_backspace(s)
     end
 
     prefix_prompt, prefix_keymap = LineEdit.setup_prefix_keymap(hp, julia_prompt)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -433,6 +433,10 @@ begin
     sendrepl3("(\"\b\bB = 5\n")
     wait(c)
     @test B == 5
+
+    sendrepl3("\\sigma\t\\Sigma\t\e[D\b\e[C=3")
+    wait(c)
+    @test Σ == 3
     # close repl
     write(stdin_write, '\x04')
     wait(repltask)


### PR DESCRIPTION
Trying to upstream a bit more from https://github.com/KristofferC/PimpMyREPL.jl

This adds some convenience bracket completions that are common in editors. I basically replicated the behaviour I get from my editor that I like.

Example:

![](https://media.giphy.com/media/3owyoYkiwnUxtiqnQs/giphy.gif)
