### PR TITLE
Fix copy(region::Tuple) depwarn in FFTW

### DIFF
--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -459,7 +459,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
                                                                      region, flags::Integer, timelimit::Real)
         direction = K
         set_timelimit($Tr, timelimit)
-        R = copy(region)
+        R = isa(region, Tuple) ? region : copy(region)
         dims, howmany = dims_howmany(X, Y, [size(X)...], R)
         plan = ccall(($(string(fftw,"_plan_guru64_dft")),$lib),
                      PlanPtr,
@@ -477,7 +477,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
     @eval function (::Type{rFFTWPlan{$Tr,$FORWARD,inplace,N}}){inplace,N}(X::StridedArray{$Tr,N},
                                                                           Y::StridedArray{$Tc,N},
                                                                           region, flags::Integer, timelimit::Real)
-        R = copy(region)
+        R = isa(region, Tuple) ? region : copy(region)
         region = circshift([region...],-1) # FFTW halves last dim
         set_timelimit($Tr, timelimit)
         dims, howmany = dims_howmany(X, Y, [size(X)...], region)
@@ -497,7 +497,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
     @eval function (::Type{rFFTWPlan{$Tc,$BACKWARD,inplace,N}}){inplace,N}(X::StridedArray{$Tc,N},
                                                                            Y::StridedArray{$Tr,N},
                                                                            region, flags::Integer, timelimit::Real)
-        R = copy(region)
+        R = isa(region, Tuple) ? region : copy(region)
         region = circshift([region...],-1) # FFTW halves last dim
         set_timelimit($Tr, timelimit)
         dims, howmany = dims_howmany(X, Y, [size(Y)...], region)
@@ -518,7 +518,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
                                                                        Y::StridedArray{$Tr,N},
                                                                        region, kinds, flags::Integer,
                                                                        timelimit::Real)
-        R = copy(region)
+        R = isa(region, Tuple) ? region : copy(region)
         knd = fix_kinds(region, kinds)
         set_timelimit($Tr, timelimit)
         dims, howmany = dims_howmany(X, Y, [size(X)...], region)
@@ -540,7 +540,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
                                                                        Y::StridedArray{$Tc,N},
                                                                        region, kinds, flags::Integer,
                                                                        timelimit::Real)
-        R = copy(region)
+        R = isa(region, Tuple) ? region : copy(region)
         knd = fix_kinds(region, kinds)
         set_timelimit($Tr, timelimit)
         dims, howmany = dims_howmany(X, Y, [size(X)...], region)

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -3,6 +3,9 @@
 # fft
 a = rand(8) + im*rand(8)
 @test norm(ifft(fft(a)) - a) < 1e-8
+@test norm(ifft(fft(a,1),1) - a) < 1e-8
+@test norm(ifft(fft(a,[1]),[1]) - a) < 1e-8
+@test norm(ifft(fft(a,(1,)),(1,)) - a) < 1e-8
 
 m4 = [16.    2     3    13;
     5    11    10     8;


### PR DESCRIPTION
Fixes a deprecation warning about copying a Tuple (ref #15675).
