### PR TITLE
sharper inference of `===` with singletons

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -286,6 +286,9 @@ add_tfunc(is, 2, 2,
             return Const(x.parameters[1]===y.parameters[1])
         elseif typeintersect(widenconst(x), widenconst(y)) === Bottom
             return Const(false)
+        elseif (isa(x,Const) && y === typeof(x.val) && isdefined(y,:instance)) ||
+               (isa(y,Const) && x === typeof(y.val) && isdefined(x,:instance))
+            return Const(true)
         else
             return Bool
         end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -269,3 +269,8 @@ function f17572{A}(::Type{Val{A}})
 end
 # test that inference doesn't error
 @test isa(code_typed(f17572, (Type{Val{0}},)), Array)
+
+# === with singleton constants
+let f(x) = (x===nothing) ? 1 : 1.0
+    @test Base.return_types(f, (Void,)) == Any[Int]
+end


### PR DESCRIPTION
This constant-folds the fairly common case of comparisons like `x===nothing` or `x===()`, etc.
