### PR TITLE
Only download busybox-w32 when USE_GPL_LIBS is 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,11 @@ endif
 
 ifeq ($(OS), WINNT)
 	[ ! -d $(JULIAHOME)/dist-extras ] || ( cd $(JULIAHOME)/dist-extras && \
-		cp 7z.exe 7z.dll busybox.exe libexpat-1.dll zlib1.dll libgfortran-3.dll libquadmath-0.dll libstdc++-6.dll libgcc_s_s*-1.dll libssp-0.dll $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin )
+		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll libgfortran-3.dll libquadmath-0.dll libstdc++-6.dll libgcc_s_s*-1.dll libssp-0.dll $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin )
+ifeq ($(USE_GPL_LIBS), 1)
+	[ ! -d $(JULIAHOME)/dist-extras ] || ( cd $(JULIAHOME)/dist-extras && \
+		cp busybox.exe $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin )
+endif
 	cd $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 
 	# create file listing for uninstall. note: must have Windows path separators and line endings.
@@ -624,12 +628,15 @@ endif
 	cd $(JULIAHOME)/dist-extras && \
 	$(JLDOWNLOAD) http://downloads.sourceforge.net/sevenzip/7z920_extra.7z && \
 	$(JLDOWNLOAD) https://unsis.googlecode.com/files/nsis-2.46.5-Unicode-setup.exe && \
-	$(JLDOWNLOAD) busybox.exe http://frippery.org/files/busybox/busybox-w32-FRP-483-g31277ab.exe && \
 	chmod a+x 7z.exe && \
 	chmod a+x 7z.dll && \
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \
-	chmod a+x ./nsis/makensis.exe && \
+	chmod a+x ./nsis/makensis.exe
+ifeq ($(USE_GPL_LIBS), 1)
+	cd $(JULIAHOME)/dist-extras && \
+	$(JLDOWNLOAD) busybox.exe http://frippery.org/files/busybox/busybox-w32-FRP-483-g31277ab.exe && \
 	chmod a+x busybox.exe
+endif
 
 # various statistics about the build that may interest the user
 ifeq ($(USE_SYSTEM_LLVM), 1)


### PR DESCRIPTION
some of the spawn and cmdlineargs tests may fail in a no-GPL
Windows build if executed outside of the build environment
(all of which are GPL themselves...), we could either skip them
or try to get them to work via calling powershell or some other
non-GPL coreutils replacement (toybox? uutils? sbase + now-LPGL cygwin?)

x-ref discussion in https://github.com/JuliaLang/julia/issues/17839#issuecomment-237959046
