### PR TITLE
normalize deps Makefile targets and add uninstall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,12 +70,14 @@ before_install:
         ln -s /usr/bin/gcc-5 $HOME/bin/x86_64-linux-gnu-gcc;
         ln -s /usr/bin/g++-5 $HOME/bin/x86_64-linux-gnu-g++;
         gcc --version;
+        BAR="bar -i 30";
         BUILDOPTS="-j3 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1";
         echo "override ARCH=$ARCH" >> Make.user;
         TESTSTORUN="all";
       elif [ `uname` = "Darwin" ]; then
         brew update;
         brew install -v jq bar;
+        BAR="bar";
         contrib/travis_fastfail.sh || exit 1;
         brew tap staticfloat/julia;
         brew rm --force $(brew deps --HEAD julia);
@@ -96,7 +98,20 @@ before_install:
 script:
     - make -C moreutils mispipe
     - make $BUILDOPTS -C base version_git.jl.phony
-    - moreutils/mispipe "make $BUILDOPTS VERBOSE=0 -C deps" bar > deps.log || cat deps.log
+    # capture the log, but only print it if `make deps` fails
+    # try to show the end of the log first, because this log might be very long (> 4MB)
+    # and thus be truncated by travis
+    - moreutils/mispipe "make $BUILDOPTS VERBOSE=0 -C deps 2> deps-err.log" "$BAR" > deps.log ||
+        { echo "-- deps build log stderr tail 100 --------------------------------------";
+          tail -n 100 deps-err.log;
+          echo "-- deps build log stdout tail 100 --------------------------------------";
+          tail -n 100 deps.log;
+          echo "-- deps build log stderr all -------------------------------------------";
+          cat deps-err.log;
+          echo "-- deps build log stdout all -------------------------------------------";
+          cat deps.log;
+          echo "-- end of deps build log -----------------------------------------------";
+          false; }
     - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - make $BUILDOPTS NO_GIT=1 build-stats
     - du -sk /tmp/julia/*
@@ -113,9 +128,6 @@ script:
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
     - cd `dirname $TRAVIS_BUILD_DIR` && mv julia2 julia &&
-        rm -rf julia/deps/scratch/julia-env &&
-        rm -rf julia/deps/scratch/libssh2-*/CMakeFiles/Makefile2 &&
-        rm -rf julia/deps/scratch/curl-*/config.log &&
-        rm -rf julia/deps/scratch/curl-*/libtool
+        rm -rf julia/deps/scratch/julia-env
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ matrix:
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/deps/srccache
-    - $TRAVIS_BUILD_DIR/deps/build
+    - $TRAVIS_BUILD_DIR/deps/scratch
+    - $TRAVIS_BUILD_DIR/deps/usr-staging
 branches:
   only:
     - master
@@ -95,7 +96,7 @@ before_install:
 script:
     - make -C moreutils mispipe
     - make $BUILDOPTS -C base version_git.jl.phony
-    - moreutils/mispipe "make $BUILDOPTS NO_GIT=1 -C deps" bar > deps.log || cat deps.log
+    - moreutils/mispipe "make $BUILDOPTS VERBOSE=0 -C deps" bar > deps.log || cat deps.log
     - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - make $BUILDOPTS NO_GIT=1 build-stats
     - du -sk /tmp/julia/*
@@ -112,9 +113,9 @@ script:
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
     - cd `dirname $TRAVIS_BUILD_DIR` && mv julia2 julia &&
-        rm -rf julia/deps/build/julia-env &&
-        rm -rf julia/deps/build/libssh2-*/CMakeFiles/Makefile2 &&
-        rm -rf julia/deps/build/curl-*/config.log &&
-        rm -rf julia/deps/build/curl-*/libtool
+        rm -rf julia/deps/scratch/julia-env &&
+        rm -rf julia/deps/scratch/libssh2-*/CMakeFiles/Makefile2 &&
+        rm -rf julia/deps/scratch/curl-*/config.log &&
+        rm -rf julia/deps/scratch/curl-*/libtool
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg

--- a/Make.inc
+++ b/Make.inc
@@ -1004,9 +1004,8 @@ endif
 
 # ATLAS
 
-# ATLAS must have been previously built with "make -C deps compile-atlas" (without -jN),
-# or installed to usr/lib/libatlas from some another source (built as
-# a shared library, for your platform, single threaded)
+# ATLAS must have been previously  installed to usr/lib/libatlas
+# (built as a shared library, for your platform, single threaded)
 USE_ATLAS := 0
 ATLAS_LIBDIR := $(build_libdir)
 #or ATLAS_LIBDIR := /path/to/system/atlas/lib

--- a/Make.inc
+++ b/Make.inc
@@ -523,7 +523,7 @@ LDFLAGS += $(SANITIZE_LDFLAGS)
 #DEPS_CXXFLAGS += $(SANITIZE_OPTS)
 endif
 
-TAR=`which gtar 2>/dev/null || which tar 2>/dev/null`
+TAR := $(shell which gtar 2>/dev/null || which tar 2>/dev/null)
 TAR_TEST := $(shell $(TAR) --help 2>&1  | egrep 'bsdtar|strip-components')
 ifeq (,$(findstring components,$(TAR_TEST)))
 ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))

--- a/contrib/check-whitespace.sh
+++ b/contrib/check-whitespace.sh
@@ -16,6 +16,7 @@ file_patterns='
 *.scm
 *.inc
 *.make
+*.mk
 *.md
 *.rst
 *.sh

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,2 +1,3 @@
 /srccache
 /build
+/scratch

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -3,7 +3,7 @@ default: install
 SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME := $(abspath $(SRCDIR)/..)
 ifeq ($(abspath .),$(abspath $(SRCDIR)))
-BUILDDIR := build
+BUILDDIR := scratch
 else
 BUILDDIR := .
 endif
@@ -15,7 +15,7 @@ include $(SRCDIR)/tools/git-external.mk
 # Special comments:
 #
 # all targets in here should follow the same structure,
-# and provide a get-a, extract-a, configure-a, compile-a, check-a, and install-a
+# and provide a get-a, extract-a, configure-a, compile-a, check-a, fastcheck-a, and install-a
 # additionally all targets should be listed in the getall target for easier off-line compilation
 # if you are adding a new target, it can help to copy an similar, existing target
 #
@@ -30,6 +30,8 @@ include $(SRCDIR)/tools/git-external.mk
 # this is some magic Makefile trick that tells make
 # that all targets with a % in them on that line will
 # be rebuilt in a single invocation
+#
+# to debug 'define' rules, replace eval at the usage site with info or error
 #
 
 ## Overall configuration of which rules exist and should be run by default ##
@@ -142,6 +144,9 @@ DEP_LIBS += lapack
 endif
 endif
 
+DEP_LIBS_STAGED := $(filter-out suitesparse suitesparse-wrapper osxunwind virtualenv,$(DEP_LIBS)) # unlist targets that have not been converted to use the staged-install
+
+
 ## Common build target prefixes
 
 default: | $(build_prefix)
@@ -150,7 +155,10 @@ extract: $(addprefix extract-, $(DEP_LIBS))
 configure: $(addprefix configure-, $(DEP_LIBS))
 compile: $(addprefix compile-, $(DEP_LIBS))
 check: $(addprefix check-, $(DEP_LIBS))
+fastcheck: $(addprefix fastcheck-, $(DEP_LIBS))
+stage: $(addprefix stage-, $(DEP_LIBS_STAGED))
 install: $(addprefix install-, $(DEP_LIBS))
+uninstall: $(addprefix uninstall-, $(DEP_LIBS_STAGED))
 cleanall: $(addprefix clean-, $(DEP_LIBS))
 distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,4 +1,5 @@
 ## high-level setup ##
+default: install
 SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME := $(abspath $(SRCDIR)/..)
 ifeq ($(abspath .),$(abspath $(SRCDIR)))
@@ -8,12 +9,13 @@ BUILDDIR := .
 endif
 include $(SRCDIR)/Versions.make
 include $(JULIAHOME)/Make.inc
-include $(SRCDIR)/llvm-ver.make
+include $(SRCDIR)/tools/common.mk
+include $(SRCDIR)/tools/git-external.mk
 
 # Special comments:
 #
 # all targets in here should follow the same structure,
-# and provide a get-a, configure-a, compile-a, check-a, and install-a
+# and provide a get-a, extract-a, configure-a, compile-a, check-a, and install-a
 # additionally all targets should be listed in the getall target for easier off-line compilation
 # if you are adding a new target, it can help to copy an similar, existing target
 #
@@ -30,70 +32,15 @@ include $(SRCDIR)/llvm-ver.make
 # be rebuilt in a single invocation
 #
 
-## Some shared configuration options ##
-
-CONFIGURE_COMMON := --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir)) --bindir=$(abspath $(build_depsbindir)) $(CUSTOM_LD_LIBRARY_PATH)
-ifneq ($(XC_HOST),)
-CONFIGURE_COMMON += --host=$(XC_HOST)
-endif
-ifeq ($(OS),WINNT)
-ifneq ($(USEMSVC), 1)
-CONFIGURE_COMMON += LDFLAGS="$(LDFLAGS) -Wl,--stack,8388608"
-endif
-endif
-CONFIGURE_COMMON += F77="$(FC)" CC="$(CC) $(DEPS_CFLAGS)" CXX="$(CXX) $(DEPS_CXXFLAGS)"
-
-CMAKE_CC_ARG := $(CC_ARG) $(DEPS_CFLAGS)
-CMAKE_CXX_ARG := $(CXX_ARG) $(DEPS_CXXFLAGS)
-
-CMAKE_COMMON := -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DCMAKE_PREFIX_PATH=$(build_prefix)
-CMAKE_COMMON += -DCMAKE_INSTALL_LIBDIR=$(build_libdir) -DCMAKE_INSTALL_BINDIR=$(build_bindir)
-CMAKE_COMMON += -DLIB_INSTALL_DIR=$(build_shlibdir)
-ifneq ($(VERBOSE), 0)
-CMAKE_COMMON += -DCMAKE_VERBOSE_MAKEFILE=ON
-endif
-# The call to which here is to work around https://cmake.org/Bug/view.php?id=14366
-CMAKE_COMMON += -DCMAKE_C_COMPILER="$$(which $(CC_BASE))"
-ifneq ($(strip $(CMAKE_CC_ARG)),)
-CMAKE_COMMON += -DCMAKE_C_COMPILER_ARG1="$(CMAKE_CC_ARG)"
-endif
-CMAKE_COMMON += -DCMAKE_CXX_COMPILER="$(CXX_BASE)"
-ifneq ($(strip $(CMAKE_CXX_ARG)),)
-CMAKE_COMMON += -DCMAKE_CXX_COMPILER_ARG1="$(CMAKE_CXX_ARG)"
-endif
-
-ifeq ($(OS),WINNT)
-CMAKE_COMMON += -DCMAKE_SYSTEM_NAME=Windows
-ifneq ($(BUILD_OS),WINNT)
-CMAKE_COMMON += -DCMAKE_RC_COMPILER="$$(which $(CROSS_COMPILE)windres)"
-endif
-endif
-
-# For now this is LLVM specific, but I expect it won't be in the future
-ifeq ($(LLVM_USE_CMAKE),1)
-ifeq ($(CMAKE_GENERATOR),Ninja)
-CMAKE_GENERATOR_COMMAND := -G Ninja
-else ifeq ($(CMAKE_GENERATOR),make)
-CMAKE_GENERATOR_COMMAND := -G "Unix Makefiles"
-else
-$(error Unknown CMake generator '$(CMAKE_GENERATOR)'. Options are 'Ninja' and 'make')
-endif
-endif
-
-# If the top-level Makefile is called with environment variables,
-# they will override the values passed above to ./configure
-MAKE_COMMON := DESTDIR="" prefix=$(build_prefix) bindir=$(build_depsbindir) libdir=$(build_libdir) shlibdir=$(build_shlibdir) libexecdir=$(build_libexecdir) datarootdir=$(build_datarootdir) includedir=$(build_includedir) sysconfdir=$(build_sysconfdir) O=
-
-
 ## Overall configuration of which rules exist and should be run by default ##
 
 # prevent installing libs into usr/lib64 on opensuse
 unexport CONFIG_SITE
 
-ifeq ($(USE_GPL_LIBS), 1)
-DEP_LIBS := suitesparse-wrapper
-else
 DEP_LIBS :=
+
+ifeq ($(USE_GPL_LIBS), 1)
+DEP_LIBS += suitesparse-wrapper
 endif
 
 ifeq ($(USE_SYSTEM_LIBUV), 0)
@@ -164,22 +111,8 @@ DEP_LIBS += gmp
 endif
 
 ifeq ($(USE_SYSTEM_LIBGIT2), 0)
-ifeq ($(USE_SYSTEM_MBEDTLS), 0)
-DEP_LIBS += mbedtls
-endif
-
-ifeq ($(USE_SYSTEM_LIBSSH2), 0)
-DEP_LIBS += libssh2
-endif
-
-ifneq ($(OS), WINNT)
-ifeq ($(USE_SYSTEM_CURL), 0)
-DEP_LIBS += curl
-endif
-endif
-
 DEP_LIBS += libgit2
-endif # USE_SYSTEM_LIBGIT2
+endif
 
 ifeq ($(USE_SYSTEM_MPFR), 0)
 DEP_LIBS += mpfr
@@ -209,16 +142,11 @@ DEP_LIBS += lapack
 endif
 endif
 
-#Platform specific flags
-
-ifeq ($(OS), WINNT)
-LIBTOOL_CCLD := CCLD="$(CC) -no-undefined -avoid-version"
-endif
-
 ## Common build target prefixes
 
-default: install | $(build_prefix)
+default: | $(build_prefix)
 get: $(addprefix get-, $(DEP_LIBS))
+extract: $(addprefix extract-, $(DEP_LIBS))
 configure: $(addprefix configure-, $(DEP_LIBS))
 compile: $(addprefix compile-, $(DEP_LIBS))
 check: $(addprefix check-, $(DEP_LIBS))
@@ -227,35 +155,6 @@ cleanall: $(addprefix clean-, $(DEP_LIBS))
 distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)
 getall: get-llvm get-libuv get-pcre get-openlibm get-openspecfun get-dsfmt get-openblas get-lapack get-fftw get-suitesparse get-arpack get-unwind get-osxunwind get-gmp get-mpfr get-patchelf get-utf8proc get-virtualenv get-objconv get-mbedtls get-libssh2 get-curl get-libgit2
-
-## PATHS ##
-# sort is used to remove potential duplicates
-DIRS := $(sort $(build_bindir) $(build_depsbindir) $(build_libdir) $(build_includedir) $(build_sysconfdir) $(build_datarootdir) $(build_staging))
-
-$(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
-
-$(build_prefix): | $(DIRS)
-$(eval $(call dir_target,$(SRCDIR)/srccache))
-
-## A rule for calling `make install` ##
-#	rule: dependencies
-#   	$(call make-install,rel-build-directory,add-args)
-#   	touch -c $@
-# this rule ensures that make install is more nearly atomic
-# so it's harder to get half-installed (or half-reinstalled) dependencies
-MAKE_DESTDIR = "$(build_staging)/$1"
-define staged-install
-	rm -rf $(build_staging)/$1
-	$2
-	mkdir -p $(build_prefix)
-	cp -af $(build_staging)/$1$(build_prefix)/* $(build_prefix)
-endef
-
-define make-install
-	$(call staged-install,$1,+$(MAKE) -C $(BUILDDIR)/$1 install $(MAKE_COMMON) $2 DESTDIR=$(call MAKE_DESTDIR,$1))
-endef
-
-include $(SRCDIR)/tools/git-external.mk
 
 include $(SRCDIR)/llvm.mk
 include $(SRCDIR)/libuv.mk
@@ -278,9 +177,3 @@ include $(SRCDIR)/libssh2.mk
 include $(SRCDIR)/curl.mk
 include $(SRCDIR)/libgit2.mk
 include $(SRCDIR)/virtualenv.mk
-
-## phony targets ##
-
-.PHONY: default compile install cleanall distcleanall \
-	get-* configure-* compile-* check-* install-* \
-	clean-* distclean-* reinstall-* update-llvm

--- a/deps/arpack.mk
+++ b/deps/arpack.mk
@@ -52,6 +52,7 @@ $(SRCDIR)/srccache/arpack-ng-$(ARPACK_VER)-testA.mtx: | $(SRCDIR)/srccache
 $(SRCDIR)/srccache/arpack-ng-$(ARPACK_VER)/source-extracted: $(SRCDIR)/srccache/arpack-ng-$(ARPACK_VER).tar.gz
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) zxf $<
+	touch -c $(SRCDIR)/srccache/arpack-ng-$(ARPACK_VER)/configure # old target
 	echo 1 > $@
 
 $(SRCDIR)/srccache/arpack-ng-$(ARPACK_VER)/arpack-tests-blasint.patch-applied: $(SRCDIR)/srccache/arpack-ng-$(ARPACK_VER)/source-extracted

--- a/deps/arpack.mk
+++ b/deps/arpack.mk
@@ -6,11 +6,6 @@ else ifeq ($(USE_SYSTEM_LAPACK), 0)
 $(BUILDDIR)/arpack-ng-$(ARPACK_VER)/build-configured: | $(build_prefix)/manifest/lapack
 endif
 
-ifneq ($(PATCHELF),patchelf)
-# this is actually required by the stage-arpack target, but there's no easy way to hook into that
-$(BUILDDIR)/arpack-ng-$(ARPACK_VER)/build-compiled: | $(build_prefix)/manifest/patchelf
-endif
-
 ARPACK_FFLAGS := $(USE_BLAS_FFLAGS)
 ARPACK_CFLAGS :=
 
@@ -81,11 +76,6 @@ define ARPACK_INSTALL
 	$(call MAKE_INSTALL,$1,$2,$3)
 ifeq ($(OS), WINNT)
 	mv $2/$$(build_shlibdir)/libarpack-2.dll $2/$$(build_shlibdir)/libarpack.$$(SHLIB_EXT)
-endif
-ifeq ($(OS), Linux)
-	for filename in $2/$$(build_shlibdir)/libarpack.so* ; do \
-		[ -L $$$$filename ] || $$(PATCHELF_BIN) --set-rpath '$$$$ORIGIN' $$$$filename ;\
-	done
 endif
 endef
 

--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -2,10 +2,8 @@
 # LAPACK is built into OpenBLAS by default
 OPENBLAS_GIT_URL := git://github.com/xianyi/OpenBLAS.git
 OPENBLAS_TAR_URL = https://api.github.com/repos/xianyi/OpenBLAS/tarball/$1
-$(eval $(call git-external,openblas,OPENBLAS,Makefile,$(LIBBLASNAME).$(SHLIB_EXT),$(BUILDDIR)))
+$(eval $(call git-external,openblas,OPENBLAS,,,$(BUILDDIR)))
 
-OPENBLAS_OBJ_SOURCE := $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/$(LIBBLASNAME).$(SHLIB_EXT)
-OPENBLAS_OBJ_TARGET := $(build_shlibdir)/$(LIBBLASNAME).$(SHLIB_EXT)
 OPENBLAS_BUILD_OPTS := CC="$(CC)" FC="$(FC)" RANLIB="$(RANLIB)" FFLAGS="$(FFLAGS) $(JFFLAGS)" TARGET=$(OPENBLAS_TARGET_ARCH) BINARY=$(BINARY)
 
 # Thread support
@@ -44,7 +42,7 @@ ifeq ($(USE_BLAS64), 1)
 OPENBLAS_BUILD_OPTS += INTERFACE64=1 SYMBOLSUFFIX="$(OPENBLAS_SYMBOLSUFFIX)" LIBPREFIX="$(LIBBLASNAME)"
 ifeq ($(OS), Darwin)
 OPENBLAS_BUILD_OPTS += OBJCONV=$(abspath $(BUILDDIR)/objconv/objconv)
-$(OPENBLAS_OBJ_SOURCE): $(OBJCONV_SOURCE)
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled: | $(BUILDDIR)/objconv/build-compiled
 endif
 endif
 
@@ -76,117 +74,40 @@ endif
 # Do not overwrite the "-j" flag
 OPENBLAS_BUILD_OPTS += MAKE_NB_JOBS=0
 
-$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/config.status: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/Makefile
-	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' $<.system
-	touch $@
-$(OPENBLAS_OBJ_SOURCE): $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/config.status
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/source-extracted
+	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' $(dir $<)/Makefile.system
+	echo 1 > $@
+
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured
 	echo $(MAKE) -C $(dir $<) $(OPENBLAS_BUILD_OPTS) # echo first, so we only print the error message below in a failure case
 	@$(MAKE) -C $(dir $<) $(OPENBLAS_BUILD_OPTS) || (echo $(WARNCOLOR)"*** Clean the OpenBLAS build with 'make -C deps clean-openblas'. Rebuild with 'make OPENBLAS_USE_THREAD=0' if OpenBLAS had trouble linking libpthread.so, and with 'make OPENBLAS_TARGET_ARCH=NEHALEM' if there were errors building SandyBridge support. Both these options can also be used simultaneously. ***"$(ENDCOLOR) && false)
-	touch -c $@
-ifneq ($(USE_SYSTEM_BLAS),1)
-$(OPENBLAS_OBJ_TARGET): $(OPENBLAS_OBJ_SOURCE) | $(build_shlibdir)
-	cp -f $< $@
+	echo 1 > $@
+
+$(build_prefix)/manifest/openblas: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled | $(build_shlibdir) $(build_prefix)/manifest
+	cp -f $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/$(LIBBLASNAME).$(SHLIB_EXT) $(build_shlibdir)/$(LIBBLASNAME).$(SHLIB_EXT)
 ifeq ($(OS), Linux)
-	cd $(dir $@) && \
-	ln -sf $(LIBBLASNAME).$(SHLIB_EXT) $(LIBBLASNAME).$(SHLIB_EXT).0
+	ln -sf $(LIBBLASNAME).$(SHLIB_EXT) $(build_shlibdir)/$(LIBBLASNAME).$(SHLIB_EXT).0
 endif
-	$(INSTALL_NAME_CMD)$(LIBBLASNAME).$(SHLIB_EXT) $@
-endif
+	$(INSTALL_NAME_CMD)$(LIBBLASNAME).$(SHLIB_EXT) $(build_shlibdir)/$(LIBBLASNAME).$(SHLIB_EXT)
+	echo $(OPENBLAS_SHA1) > $@
 
 clean-openblas:
 	-$(MAKE) -C $(BUILDDIR)/$(OPENBLAS_SRC_DIR) clean
 
 get-openblas: $(OPENBLAS_SRC_FILE)
-configure-openblas: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/config.status
-compile-openblas: $(OPENBLAS_OBJ_SOURCE)
+extract-openblas: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/source-extracted
+configure-openblas: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured
+compile-openblas: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled
 check-openblas: compile-openblas
-install-openblas: $(OPENBLAS_OBJ_TARGET)
+install-openblas: $(build_prefix)/manifest/openblas
 
-
-## ATLAS (currently 3.10.0) ##
-
-# no threading, with full lapack, shared library
-# should always be compiled with (a real) gcc, it's
-# configure script will search for the best match
-# (gcc 4.7, gcc, clang,ICC/microsoft/others)
-ATLAS_OBJ_SOURCE := $(BUILDDIR)/atlas/build/lib/libsatlas.$(SHLIB_EXT)
-ATLAS_OBJ_TARGET := $(build_shlibdir)/libsatlas.$(SHLIB_EXT)
-ATLAS_FLAGS := --shared --prefix=$(build_prefix) --cc=gcc -t 0 \
-	--with-netlib-lapack-tarfile=$(JULIAHOME)/deps/lapack-$(LAPACK_VER).tgz
-ifeq ($(OS), WINNT)
-ATLAS_FLAGS += -b 32
-endif
-
-#force backwards compatibility (pick any 1)
-#ATLAS_FLAGS += -V 192 -A 13  # requires SSE2 (P4 & later)
-#ATLAS_FLAGS += -V 128 -A 12 # requires SSE1 (P3 & later)
-#ATLAS_FLAGS += -V -1 -A 11 # any x87 (PentiumPro or Athlon & later)
-#ATLAS_FLAGS += -A 25  # requires Corei132 (Corei232 doesn't have definition yet)
-
-$(SRCDIR)/srccache/atlas/configure:
-	git clone git://github.com/vtjnash/atlas-3.10.0.git $(SRCDIR)/srccache/atlas
-ifeq "$(MAKECMDGOALS)" "compile-atlas"
-# only allow building atlas as the sole target (without -jN)
-# since it internally handles parallelism, for tuning timing accuracy
-$(BUILDDIR)/atlas/Make.top: $(SRCDIR)/srccache/atlas/configure $(SRCDIR)/srccache/lapack-$(LAPACK_VER).tgz
-	mkdir -p $(dir $@)
-	cd $(dir $@) && \
-	$< $(ATLAS_FLAGS)
-	touch -c $@
-$(ATLAS_OBJ_SOURCE): $(BUILDDIR)/atlas/Make.top
-	$(MAKE) -C $(dir $<) -j1
-	touch -c $@
-else
-$(ATLAS_OBJ_SOURCE):
-	$(error cannot build atlas in parallel with anything else)
-endif
-
-$(ATLAS_OBJ_TARGET): $(ATLAS_OBJ_SOURCE)
-	cp -f $(ATLAS_OBJ_SOURCE) $@
-	$(INSTALL_NAME_CMD)libsatlas.$(SHLIB_EXT) $@
-	touch -c $@
-
-clean-atlas:
-	rm -rf $(BUILDDIR)/atlas/build
-distclean-atlas:
-	rm -rf $(BUILDDIR)/atlas
-
-get-atlas: $(SRCDIR)/srccache/atlas/configure $(SRCDIR)/srccache/lapack-$(LAPACK_VER).tgz
-configure-atlas: $(BUILDDIR)/atlas/Make.top
-compile-atlas: $(ATLAS_OBJ_SOURCE)
-check-atlas: compile-atlas
-install-atlas: $(ATLAS_OBJ_TARGET)
 
 ## Mac gfortran BLAS wrapper ##
-GFORTBLAS_FFLAGS :=
-ifeq ($(USE_BLAS64), 1)
-ifeq ($(USEIFC),1)
-GFORTBLAS_FFLAGS += -i8
-else
-GFORTBLAS_FFLAGS += -fdefault-integer-8
-endif
-endif
 ifeq ($(OS),Darwin)
-ifeq ($(USE_SYSTEM_BLAS),1)
-ifeq ($(USE_SYSTEM_LAPACK),0)
-GFORTBLAS_FFLAGS += -cpp -ffree-line-length-0 -ffixed-line-length-0 \
-			    -Dsasum=sasum_gfort -Dscasum=scasum_gfort \
-				-Dscnrm2=scnrm2_gfort -Dsdot=sdot_gfort \
-				-Dsdsdot=sdsdot_gfort -Dsnrm2=snrm2_gfort \
-				-Dcdotc=cdotc_gfort -Dcdotu=cdotu_gfort \
-				-Dzdotc=zdotc_gfort -Dzdotu=zdotu_gfort \
-				\
-			    -DSASUM=SASUM_GFORT -DSCASUM=SCASUM_GFORT \
-				-DSCNRM2=SCNRM2_GFORT -DSDOT=SDOT_GFORT \
-				-DSDSDOT=SDSDOT_GFORT -DSNRM2=SNRM2_GFORT \
-				-DCDOTC=CDOTC_GFORT -DCDOTU=CDOTU_GFORT \
-				-DZDOTC=ZDOTC_GFORT -DZDOTU=ZDOTU_GFORT
-endif
-endif
-
 $(BUILDDIR)/libgfortblas.$(SHLIB_EXT): $(SRCDIR)/gfortblas.c $(SRCDIR)/gfortblas.alias
 	$(CC) -Wall -O3 $(CPPFLAGS) $(CFLAGS) $(fPIC) -shared $< -o $@ -pipe \
 				-Wl,-reexport_framework,Accelerate -Wl,-alias_list,$(SRCDIR)/gfortblas.alias
+
 $(build_shlibdir)/libgfortblas.$(SHLIB_EXT): $(BUILDDIR)/libgfortblas.$(SHLIB_EXT)
 	cp -f $< $@
 	$(INSTALL_NAME_CMD)libgfortblas.$(SHLIB_EXT) $@
@@ -194,53 +115,58 @@ endif
 
 ## LAPACK ##
 
-ifeq ($(USE_SYSTEM_LAPACK), 0)
-LAPACK_OBJ_TARGET := $(build_shlibdir)/liblapack.$(SHLIB_EXT)
-LAPACK_OBJ_SOURCE := $(BUILDDIR)/lapack-$(LAPACK_VER)/liblapack.$(SHLIB_EXT)
-else
-LAPACK_OBJ_TARGET :=
-LAPACK_OBJ_SOURCE :=
-endif
-
-LAPACK_MFLAGS := NOOPT="$(FFLAGS) $(JFFLAGS) $(GFORTBLAS_FFLAGS) -O0" \
-    OPTS="$(FFLAGS) $(JFFLAGS) $(GFORTBLAS_FFLAGS)" FORTRAN="$(FC)" \
+LAPACK_MFLAGS := NOOPT="$(FFLAGS) $(JFFLAGS) $(USE_BLAS_FFLAGS) -O0" \
+    OPTS="$(FFLAGS) $(JFFLAGS) $(USE_BLAS_FFLAGS)" FORTRAN="$(FC)" \
     LOADER="$(FC)" BLASLIB="$(RPATH_ESCAPED_ORIGIN) $(LIBBLAS)"
 
 $(SRCDIR)/srccache/lapack-$(LAPACK_VER).tgz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ http://www.netlib.org/lapack/$(notdir $@)
-$(BUILDDIR)/lapack-$(LAPACK_VER)/make.inc: $(SRCDIR)/srccache/lapack-$(LAPACK_VER).tgz
+
+$(BUILDDIR)/lapack-$(LAPACK_VER)/source-extracted: $(SRCDIR)/srccache/lapack-$(LAPACK_VER).tgz
 	$(JLCHECKSUM) $<
 	mkdir -p $(BUILDDIR)
 	cd $(BUILDDIR) && $(TAR) zxf $<
 	cp $(dir $@)INSTALL/make.inc.gfortran $(dir $@)make.inc
-	touch -c $@
+	echo 1 > $@
+
 ifeq ($(USE_SYSTEM_BLAS), 0)
-$(BUILDDIR)/lapack-$(LAPACK_VER)/liblapack.a: | $(OPENBLAS_OBJ_TARGET)
+$(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0: | $(build_prefix)/manifest/openblas
 else ifeq ($(OS),Darwin)
-$(BUILDDIR)/lapack-$(LAPACK_VER)/liblapack.a: | $(build_shlibdir)/libgfortblas.$(SHLIB_EXT)
+$(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0: | $(build_shlibdir)/libgfortblas.$(SHLIB_EXT)
 endif
-$(BUILDDIR)/lapack-$(LAPACK_VER)/liblapack.a: $(BUILDDIR)/lapack-$(LAPACK_VER)/make.inc
+$(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0: $(BUILDDIR)/lapack-$(LAPACK_VER)/source-extracted
 	$(MAKE) -C $(dir $@) lapacklib $(LAPACK_MFLAGS)
-	touch -c $@
-$(BUILDDIR)/lapack-$(LAPACK_VER)/checked: $(BUILDDIR)/lapack-$(LAPACK_VER)/liblapack.a
+	echo 1 > $@
+
+$(BUILDDIR)/lapack-$(LAPACK_VER)/build-checked: $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0
 ifeq ($(BUILD_OS),$(OS))
 	$(MAKE) -C $(dir $@) lapack_testing $(LAPACK_MFLAGS) -k
 endif
-	touch $@
-$(LAPACK_OBJ_SOURCE): $(BUILDDIR)/lapack-$(LAPACK_VER)/liblapack.a
-	$(FC) -shared $(FFLAGS) $(JFFLAGS) $(dir $<)/SRC/*.o $(dir $<)/INSTALL/dlamch.o $(dir $<)/INSTALL/dsecnd_INT_ETIME.o $(dir $<)/INSTALL/ilaver.o $(dir $<)/INSTALL/slamch.o $(LIBBLAS) -o $@
-$(LAPACK_OBJ_TARGET): $(LAPACK_OBJ_SOURCE)
-	cp $< $@
-	$(INSTALL_NAME_CMD)liblapack.$(SHLIB_EXT) $@
+	echo 1 > $@
+
+$(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled: $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0 | $(build_prefix)/manifest
+	$(FC) -shared $(FFLAGS) $(JFFLAGS) $(dir $<)/SRC/*.o \
+		$(dir $<)/INSTALL/dlamch.o $(dir $<)/INSTALL/dsecnd_INT_ETIME.o \
+		$(dir $<)/INSTALL/ilaver.o $(dir $<)/INSTALL/slamch.o $(LIBBLAS) \
+		-o $(dir $<)/liblapack.$(SHLIB_EXT)
+	echo 1 > $@
+
+$(build_prefix)/manifest/lapack: $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled | $(build_shlibdir)
+	cp $(dir $<)/liblapack.$(SHLIB_EXT) $(build_shlibdir)/liblapack.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)liblapack.$(SHLIB_EXT) $(build_shlibdir)/liblapack.$(SHLIB_EXT)
+	echo $(LAPACK_VER) > $@
 
 clean-lapack:
+	-rm -f $(build_prefix)/manifest/lapack $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0 $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/lapack-$(LAPACK_VER) clean
-	-rm -f $(LAPACK_OBJ_SOURCE) $(LAPACK_OBJ_TARGET)
+
 distclean-lapack:
 	-rm -rf $(SRCDIR)/srccache/lapack-$(LAPACK_VER).tgz $(BUILDDIR)/lapack-$(LAPACK_VER)
 
+
 get-lapack: $(SRCDIR)/srccache/lapack-$(LAPACK_VER).tgz
-configure-lapack: $(BUILDDIR)/lapack-$(LAPACK_VER)/make.inc
-compile-lapack: $(LAPACK_OBJ_SOURCE)
-check-lapack: $(BUILDDIR)/lapack-$(LAPACK_VER)/checked
-install-lapack: $(LAPACK_OBJ_TARGET)
+extract-lapack: $(BUILDDIR)/lapack-$(LAPACK_VER)/source-extracted
+configure-lapack: extract-lapack
+compile-lapack: $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled
+check-lapack: $(BUILDDIR)/lapack-$(LAPACK_VER)/build-checked
+install-lapack: $(build_prefix)/manifest/lapack

--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -16,6 +16,7 @@ $(SRCDIR)/srccache/curl-$(CURL_VER).tar.bz2: | $(SRCDIR)/srccache
 $(SRCDIR)/srccache/curl-$(CURL_VER)/source-extracted: $(SRCDIR)/srccache/curl-$(CURL_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) jxf $(notdir $<)
+	touch -c $(SRCDIR)/srccache/curl-$(CURL_VER)/configure # old target
 	echo 1 > $@
 
 $(BUILDDIR)/curl-$(CURL_VER)/build-configured: $(SRCDIR)/srccache/curl-$(CURL_VER)/source-extracted

--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -1,11 +1,11 @@
 ## CURL ##
 
 ifeq ($(USE_SYSTEM_LIBSSH2), 0)
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: $(build_prefix)/manifest/libssh2
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/libssh2
 endif
 
 ifeq ($(USE_SYSTEM_MBEDTLS), 0)
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: $(build_prefix)/manifest/mbedtls
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/mbedtls
 endif
 
 CURL_LDFLAGS := $(RPATH_ESCAPED_ORIGIN)
@@ -41,15 +41,13 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/curl: $(BUILDDIR)/curl-$(CURL_VER)/build-compiled | $(build_prefix)/manifest
-	$(call make-install,curl-$(CURL_VER),$(LIBTOOL_CCLD))
-	$(INSTALL_NAME_CMD)libcurl.$(SHLIB_EXT) $(build_shlibdir)/libcurl.$(SHLIB_EXT)
-	echo $(CURL_VER) > $@
+$(eval $(call staged-install, \
+	curl,curl-$$(CURL_VER), \
+	MAKE_INSTALL,$$(LIBTOOL_CCLD),, \
+	$$(INSTALL_NAME_CMD)libcurl.$$(SHLIB_EXT) $$(build_shlibdir)/libcurl.$$(SHLIB_EXT)))
 
 clean-curl:
-	-rm -rf $(build_prefix)/manifest/curl \
-		$(BUILDDIR)/curl-$(CURL_VER)/build-configured $(BUILDDIR)/curl-$(CURL_VER)/build-compiled
-	-rm -f $(build_shlibdir)/libcurl*
+	-rm $(BUILDDIR)/curl-$(CURL_VER)/build-configured $(BUILDDIR)/curl-$(CURL_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/curl-$(CURL_VER) clean
 
 distclean-curl:
@@ -59,5 +57,5 @@ get-curl: $(SRCDIR)/srccache/curl-$(CURL_VER).tar.bz2
 extract-curl: $(SRCDIR)/srccache/curl-$(CURL_VER)/source-extracted
 configure-curl: $(BUILDDIR)/curl-$(CURL_VER)/build-configured
 compile-curl: $(BUILDDIR)/curl-$(CURL_VER)/build-compiled
+fastcheck-curl: #none
 check-curl: $(BUILDDIR)/curl-$(CURL_VER)/build-checked
-install-curl: $(build_prefix)/manifest/curl

--- a/deps/dsfmt.mk
+++ b/deps/dsfmt.mk
@@ -35,14 +35,20 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled | $(build_includedir) $(build_shlibdir) $(build_prefix)/manifest
-	cp $(dir $<)/dSFMT.h $(build_includedir)
-	cp $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT) $(build_shlibdir)/libdSFMT.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libdSFMT.$(SHLIB_EXT) $(build_shlibdir)/libdSFMT.$(SHLIB_EXT)
-	echo $(DSFMT_VER) > $@
+define DSFMT_INSTALL
+	mkdir -p $2/$$(build_includedir) $2/$$(build_libdir)
+	cp $1/dSFMT.h $2/$$(build_includedir)
+	cp $1/libdSFMT.$$(SHLIB_EXT) $2/$$(build_shlibdir)
+endef
+$(eval $(call staged-install, \
+	dsfmt,dsfmt-$(DSFMT_VER), \
+	DSFMT_INSTALL,, \
+	$$(DSFMT_OBJ_TARGET), \
+	$$(INSTALL_NAME_CMD)libdSFMT.$$(SHLIB_EXT) $$(build_shlibdir)/libdSFMT.$$(SHLIB_EXT)))
 
 clean-dsfmt:
-	-rm -f $(build_prefix)/manifest/dsfmt $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
+	-rm $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled
+	-rm $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
 
 distclean-dsfmt:
 	-rm -rf $(SRCDIR)/srccache/dsfmt*.tar.gz $(SRCDIR)/srccache/dsfmt-$(DSFMT_VER) $(BUILDDIR)/dsfmt-$(DSFMT_VER)
@@ -51,5 +57,5 @@ get-dsfmt: $(SRCDIR)/srccache/dsfmt-$(DSFMT_VER).tar.gz
 extract-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/source-extracted
 configure-dsfmt: extract-dsfmt
 compile-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled
+fastcheck-dsfmt: check-dsfmt
 check-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-checked
-install-dsfmt: $(build_prefix)/manifest/dsfmt

--- a/deps/dsfmt.mk
+++ b/deps/dsfmt.mk
@@ -1,8 +1,5 @@
 ## DSFMT ##
 
-DSFMT_OBJ_TARGET := $(build_shlibdir)/libdSFMT.$(SHLIB_EXT) $(build_includedir)/dSFMT.h
-DSFMT_OBJ_SOURCE := $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
-
 DSFMT_CFLAGS := $(CFLAGS) -DNDEBUG -DDSFMT_MEXP=19937 $(fPIC) -DDSFMT_DO_NOT_USE_OLD_NAMES
 ifneq ($(USEMSVC), 1)
 DSFMT_CFLAGS += -O3 -finline-functions -fomit-frame-pointer -fno-strict-aliasing \
@@ -17,33 +14,42 @@ endif
 $(SRCDIR)/srccache/dsfmt-$(DSFMT_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-src-$(DSFMT_VER).tar.gz
 	touch -c $@
-$(BUILDDIR)/dsfmt-$(DSFMT_VER)/config.status: $(SRCDIR)/srccache/dsfmt-$(DSFMT_VER).tar.gz
+
+$(BUILDDIR)/dsfmt-$(DSFMT_VER)/source-extracted: $(SRCDIR)/srccache/dsfmt-$(DSFMT_VER).tar.gz
 	$(JLCHECKSUM) $<
-	mkdir -p $(dir $@) && \
-	$(TAR) -C $(dir $@) --strip-components 1 -xf $< && \
+	-rm -r $(dir $@)
+	mkdir -p $(dir $@)
+	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
 	cd $(dir $@) && patch < $(SRCDIR)/patches/dSFMT.h.patch
 	cd $(dir $@) && patch < $(SRCDIR)/patches/dSFMT.c.patch
 	echo 1 > $@
-$(DSFMT_OBJ_SOURCE): $(BUILDDIR)/dsfmt-$(DSFMT_VER)/config.status
+
+$(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/source-extracted
 	cd $(dir $<) && \
 	$(CC) $(CPPFLAGS) $(DSFMT_CFLAGS) $(LDFLAGS) dSFMT.c -o libdSFMT.$(SHLIB_EXT)
-$(BUILDDIR)/dsfmt-$(DSFMT_VER)/checked: $(DSFMT_OBJ_SOURCE)
+	echo 1 > $@
+
+$(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-checked: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) std-check sse2-check
 endif
 	echo 1 > $@
-$(build_shlibdir)/libdSFMT%$(SHLIB_EXT) $(build_includedir)/dSFMT%h: $(DSFMT_OBJ_SOURCE) | $(build_includedir) $(build_shlibdir)
+
+$(build_prefix)/manifest/dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled | $(build_includedir) $(build_shlibdir) $(build_prefix)/manifest
 	cp $(dir $<)/dSFMT.h $(build_includedir)
-	cp $< $(build_shlibdir)/libdSFMT.$(SHLIB_EXT) && \
+	cp $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT) $(build_shlibdir)/libdSFMT.$(SHLIB_EXT)
 	$(INSTALL_NAME_CMD)libdSFMT.$(SHLIB_EXT) $(build_shlibdir)/libdSFMT.$(SHLIB_EXT)
+	echo $(DSFMT_VER) > $@
 
 clean-dsfmt:
-	-rm -f $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
+	-rm -f $(build_prefix)/manifest/dsfmt $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
+
 distclean-dsfmt:
 	-rm -rf $(SRCDIR)/srccache/dsfmt*.tar.gz $(SRCDIR)/srccache/dsfmt-$(DSFMT_VER) $(BUILDDIR)/dsfmt-$(DSFMT_VER)
 
 get-dsfmt: $(SRCDIR)/srccache/dsfmt-$(DSFMT_VER).tar.gz
-configure-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/config.status
-compile-dsfmt: $(DSFMT_OBJ_SOURCE)
-check-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/checked
-install-dsfmt: $(DSFMT_OBJ_TARGET)
+extract-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/source-extracted
+configure-dsfmt: extract-dsfmt
+compile-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled
+check-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-checked
+install-dsfmt: $(build_prefix)/manifest/dsfmt

--- a/deps/fftw.mk
+++ b/deps/fftw.mk
@@ -30,6 +30,7 @@ $(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted: $(SRCDIR)/srccache/fftw-$(
 	$(JLCHECKSUM) $<
 	mkdir -p $(dir $@) && \
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
+	touch -c $(SRCDIR)/srccache/fftw-$(FFTW_VER)/configure # old target
 	echo 1 > $@
 
 $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-configured: $(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted

--- a/deps/fftw.mk
+++ b/deps/fftw.mk
@@ -1,5 +1,11 @@
 ## FFTW ##
 
+ifneq ($(PATCHELF),patchelf)
+# actually required by the stage-fftw target, but there's no easy way to hook into that
+$(BUILDDIR)/fftw-$(FFTW_VER)-single/build-compiled: | $(build_prefix)/manifest/patchelf
+$(BUILDDIR)/fftw-$(FFTW_VER)-double/build-compiled: | $(build_prefix)/manifest/patchelf
+endif
+
 FFTW_CONFIG := --enable-shared --disable-fortran --disable-mpi --enable-threads
 ifneq (,$(findstring arm,$(ARCH)))
   FFTW_CONFIG +=
@@ -45,44 +51,34 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-compiled | $(build_prefix)/manifest
-	$(call make-install,fftw-$(FFTW_VER)-single,)
-ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libfftw3f.$(SHLIB_EXT) $(build_shlibdir)/libfftw3f.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(build_shlibdir)/libfftw3f_threads.$(SHLIB_EXT)
-	$(INSTALL_NAME_CHANGE_CMD) $(build_shlibdir)/libfftw3f.3.$(SHLIB_EXT) $(INSTALL_NAME_ID_DIR)libfftw3f.$(SHLIB_EXT) $(build_shlibdir)/libfftw3f_threads.$(SHLIB_EXT)
-else ifeq ($(OS), WINNT)
-	mv -f $(build_shlibdir)/libfftw3f-3.dll $(build_shlibdir)/libfftw3f.$(SHLIB_EXT)
-else ifeq ($(OS), Linux)
-	for filename in $(build_shlibdir)/libfftw3f_threads.so* ; do \
-		[ -L $$filename ] || $(PATCHELF_BIN) --set-rpath '$$ORIGIN' $$filename ;\
+define FFTW_INSTALL
+	$(call MAKE_INSTALL,$1,$2,)
+ifeq ($$(OS), WINNT)
+	mv $2/$$(build_shlibdir)/$3-3.dll $2/$$(build_shlibdir)/$3.dll
+endif
+ifeq ($$(OS), Linux)
+	for filename in $2/$$(build_shlibdir)/$3_threads.so* ; do \
+		[ -L $$$$filename ] || $$(PATCHELF_BIN) --set-rpath '$$$$ORIGIN' $$$$filename ;\
 	done
 endif
-	echo $(FFTW_VER) > $@
+endef
 
-$(build_prefix)/manifest/fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-compiled | $(build_prefix)/manifest
-	$(call make-install,fftw-$(FFTW_VER)-double,)
-ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(build_shlibdir)/libfftw3.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(build_shlibdir)/libfftw3_threads.$(SHLIB_EXT)
-	$(INSTALL_NAME_CHANGE_CMD) $(build_shlibdir)/libfftw3.3.$(SHLIB_EXT) $(INSTALL_NAME_ID_DIR)libfftw3.$(SHLIB_EXT) $(build_shlibdir)/libfftw3_threads.$(SHLIB_EXT)
-else ifeq ($(OS), WINNT)
-	mv -f $(build_shlibdir)/libfftw3-3.dll $(build_shlibdir)/libfftw3.$(SHLIB_EXT)
-else ifeq ($(OS), Linux)
-	for filename in $(build_shlibdir)/libfftw3_threads.so* ; do \
-		[ -L $$filename ] || $(PATCHELF_BIN) --set-rpath '$$ORIGIN' $$filename ;\
-	done
-endif
-	echo $(FFTW_VER) > $@
-
-ifneq ($(PATCHELF),patchelf)
-$(build_prefix)/manifest/fftw-single: $(PATCHELF)
-$(build_prefix)/manifest/fftw-double: $(PATCHELF)
-endif
+$(eval $(call staged-install, \
+	fftw-single,fftw-$(FFTW_VER)-single, \
+	FFTW_INSTALL,libfftw3f,, \
+	$$(INSTALL_NAME_CMD)libfftw3f.$$(SHLIB_EXT) $$(build_shlibdir)/libfftw3f.$$(SHLIB_EXT) && \
+	$$(INSTALL_NAME_CMD)libfftw3f_threads.$$(SHLIB_EXT) $$(build_shlibdir)/libfftw3f_threads.$$(SHLIB_EXT) && \
+	$$(INSTALL_NAME_CHANGE_CMD) $$(build_shlibdir)/libfftw3f.3.$$(SHLIB_EXT) $$(INSTALL_NAME_ID_DIR)libfftw3f.$$(SHLIB_EXT) $$(build_shlibdir)/libfftw3f_threads.$$(SHLIB_EXT)))
+$(eval $(call staged-install, \
+	fftw-double,fftw-$(FFTW_VER)-double, \
+	FFTW_INSTALL,libfftw3,, \
+	$$(INSTALL_NAME_CMD)libfftw3.$$(SHLIB_EXT) $$(build_shlibdir)/libfftw3.$$(SHLIB_EXT) && \
+	$$(INSTALL_NAME_CMD)libfftw3_threads.$$(SHLIB_EXT) $$(build_shlibdir)/libfftw3_threads.$$(SHLIB_EXT) && \
+	$$(INSTALL_NAME_CHANGE_CMD) $$(build_shlibdir)/libfftw3.3.$$(SHLIB_EXT) $$(INSTALL_NAME_ID_DIR)libfftw3.$$(SHLIB_EXT) $$(build_shlibdir)/libfftw3_threads.$$(SHLIB_EXT)))
 
 clean-fftw: clean-fftw-single clean-fftw-double
 clean-fftw-%:
-	-rm -f $(build_prefix)/manifest/fftw-% $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-compiled $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-configured
+	-rm $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-compiled $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-configured
 	-$(MAKE) -C $(BUILDDIR)/fftw-$(FFTW_VER)-% clean
 
 distclean-fftw: distclean-fftw-single distclean-fftw-double
@@ -96,19 +92,24 @@ get-fftw: get-fftw-single get-fftw-double
 extract-fftw: extract-fftw-single extract-fftw-double
 configure-fftw: configure-fftw-single configure-fftw-double
 compile-fftw: compile-fftw-single compile-fftw-double
+fastcheck-fftw: fastcheck-fftw-single fastcheck-fftw-double
 check-fftw: check-fftw-single check-fftw-double
+stage-fftw: stage-fftw-single stage-fftw-double
 install-fftw: install-fftw-single install-fftw-double
+uninstall-fftw: uninstall-fftw-single uninstall-fftw-double
+reinstall-fftw: reinstall-fftw-single reinstall-fftw-double
+
 
 get-fftw-single: $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz
 extract-fftw-single: $(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted
 configure-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-configured
 compile-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-compiled
+fastcheck-fftw-single: #none
 check-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-checked
-install-fftw-single: $(build_prefix)/manifest/fftw-single
 
 get-fftw-double: $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz
 extract-fftw-double: $(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted
 configure-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-configured
 compile-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-compiled
+fastcheck-fftw-double: #none
 check-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-checked
-install-fftw-double: $(build_prefix)/manifest/fftw-double

--- a/deps/fftw.mk
+++ b/deps/fftw.mk
@@ -1,13 +1,4 @@
 ## FFTW ##
-ifeq ($(OS),WINNT)
-FFTW_SINGLE_SRC_TARGET := $(BUILDDIR)/fftw-$(FFTW_VER)-single/.libs/libfftw3f-3.$(SHLIB_EXT)
-FFTW_DOUBLE_SRC_TARGET := $(BUILDDIR)/fftw-$(FFTW_VER)-double/.libs/libfftw3-3.$(SHLIB_EXT)
-else
-FFTW_SINGLE_SRC_TARGET := $(BUILDDIR)/fftw-$(FFTW_VER)-single/.libs/libfftw3f.$(SHLIB_EXT)
-FFTW_DOUBLE_SRC_TARGET := $(BUILDDIR)/fftw-$(FFTW_VER)-double/.libs/libfftw3.$(SHLIB_EXT)
-endif
-FFTW_SINGLE_OBJ_TARGET := $(build_shlibdir)/libfftw3f.$(SHLIB_EXT)
-FFTW_DOUBLE_OBJ_TARGET := $(build_shlibdir)/libfftw3.$(SHLIB_EXT)
 
 FFTW_CONFIG := --enable-shared --disable-fortran --disable-mpi --enable-threads
 ifneq (,$(findstring arm,$(ARCH)))
@@ -28,78 +19,72 @@ FFTW_ENABLE_double :=
 
 $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ http://www.fftw.org/$(notdir $@)
-$(SRCDIR)/srccache/fftw-$(FFTW_VER)/configure: $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz
+
+$(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted: $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz
 	$(JLCHECKSUM) $<
 	mkdir -p $(dir $@) && \
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
-	touch -c $@
-$(BUILDDIR)/fftw-$(FFTW_VER)-%/config.status: $(SRCDIR)/srccache/fftw-$(FFTW_VER)/configure
+	echo 1 > $@
+
+$(BUILDDIR)/fftw-$(FFTW_VER)-%/build-configured: $(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted
 	mkdir -p $(dir $@)
 	@# try to configure with avx support. if that fails, try again without it
 	cd $(dir $@) && \
-	($< $(CONFIGURE_COMMON) $(FFTW_CONFIG) $(FFTW_ENABLE_$*) --enable-avx || \
-	  $< $(CONFIGURE_COMMON) $(FFTW_CONFIG) $(FFTW_ENABLE_$*))
+	($(dir $<)/configure $(CONFIGURE_COMMON) $(FFTW_CONFIG) $(FFTW_ENABLE_$*) --enable-avx || \
+	  $(dir $<)/configure $(CONFIGURE_COMMON) $(FFTW_CONFIG) $(FFTW_ENABLE_$*))
 	$(MAKE) -C $(dir $@) clean
-	touch -c $@
+	echo 1 > $@
 
-$(FFTW_SINGLE_SRC_TARGET): $(BUILDDIR)/fftw-$(FFTW_VER)-single/config.status
+$(BUILDDIR)/fftw-$(FFTW_VER)-%/build-compiled: $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-configured
 	$(MAKE) -C $(dir $<)
-	touch -c $@
-$(BUILDDIR)/fftw-$(FFTW_VER)-single/checked: $(FFTW_SINGLE_SRC_TARGET)
+	echo 1 > $@
+
+$(BUILDDIR)/fftw-$(FFTW_VER)-%/build-checked: $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
-$(FFTW_SINGLE_OBJ_TARGET): $(FFTW_SINGLE_SRC_TARGET)
+
+$(build_prefix)/manifest/fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-compiled | $(build_prefix)/manifest
 	$(call make-install,fftw-$(FFTW_VER)-single,)
 ifeq ($(OS), Darwin)
 	$(INSTALL_NAME_CMD)libfftw3f.$(SHLIB_EXT) $(build_shlibdir)/libfftw3f.$(SHLIB_EXT)
 	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(build_shlibdir)/libfftw3f_threads.$(SHLIB_EXT)
 	$(INSTALL_NAME_CHANGE_CMD) $(build_shlibdir)/libfftw3f.3.$(SHLIB_EXT) $(INSTALL_NAME_ID_DIR)libfftw3f.$(SHLIB_EXT) $(build_shlibdir)/libfftw3f_threads.$(SHLIB_EXT)
 else ifeq ($(OS), WINNT)
-	mv -f $(build_shlibdir)/libfftw3f-3.dll $@
+	mv -f $(build_shlibdir)/libfftw3f-3.dll $(build_shlibdir)/libfftw3f.$(SHLIB_EXT)
 else ifeq ($(OS), Linux)
 	for filename in $(build_shlibdir)/libfftw3f_threads.so* ; do \
 		[ -L $$filename ] || $(PATCHELF_BIN) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
-	touch -c $@
+	echo $(FFTW_VER) > $@
 
-$(FFTW_DOUBLE_SRC_TARGET): $(BUILDDIR)/fftw-$(FFTW_VER)-double/config.status
-	$(MAKE) -C $(dir $<)
-	touch -c $@
-$(BUILDDIR)/fftw-$(FFTW_VER)-double/checked: $(FFTW_DOUBLE_SRC_TARGET)
-ifeq ($(OS),$(BUILD_OS))
-	$(MAKE) -C $(dir $@) check
-endif
-	echo 1 > $@
-$(FFTW_DOUBLE_OBJ_TARGET): $(FFTW_DOUBLE_SRC_TARGET)
+$(build_prefix)/manifest/fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-compiled | $(build_prefix)/manifest
 	$(call make-install,fftw-$(FFTW_VER)-double,)
 ifeq ($(OS), Darwin)
 	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(build_shlibdir)/libfftw3.$(SHLIB_EXT)
 	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(build_shlibdir)/libfftw3_threads.$(SHLIB_EXT)
 	$(INSTALL_NAME_CHANGE_CMD) $(build_shlibdir)/libfftw3.3.$(SHLIB_EXT) $(INSTALL_NAME_ID_DIR)libfftw3.$(SHLIB_EXT) $(build_shlibdir)/libfftw3_threads.$(SHLIB_EXT)
 else ifeq ($(OS), WINNT)
-	mv -f $(build_shlibdir)/libfftw3-3.dll $@
+	mv -f $(build_shlibdir)/libfftw3-3.dll $(build_shlibdir)/libfftw3.$(SHLIB_EXT)
 else ifeq ($(OS), Linux)
 	for filename in $(build_shlibdir)/libfftw3_threads.so* ; do \
 		[ -L $$filename ] || $(PATCHELF_BIN) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
-	touch -c $@
+	echo $(FFTW_VER) > $@
 
 ifneq ($(PATCHELF),patchelf)
-$(FFTW_DOUBLE_OBJ_TARGET): $(PATCHELF)
-$(FFTW_SINGLE_OBJ_TARGET): $(PATCHELF)
+$(build_prefix)/manifest/fftw-single: $(PATCHELF)
+$(build_prefix)/manifest/fftw-double: $(PATCHELF)
 endif
 
 clean-fftw: clean-fftw-single clean-fftw-double
-clean-fftw-single:
-	-$(MAKE) -C $(BUILDDIR)/fftw-$(FFTW_VER)-single clean
-	-rm -f $(FFTW_SINGLE_OBJ_TARGET)
-clean-fftw-double:
-	-$(MAKE) -C $(BUILDDIR)/fftw-$(FFTW_VER)-double clean
-	-rm -f $(FFTW_DOUBLE_OBJ_TARGET)
+clean-fftw-%:
+	-rm -f $(build_prefix)/manifest/fftw-% $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-compiled $(BUILDDIR)/fftw-$(FFTW_VER)-%/build-configured
+	-$(MAKE) -C $(BUILDDIR)/fftw-$(FFTW_VER)-% clean
+
 distclean-fftw: distclean-fftw-single distclean-fftw-double
 	-rm -rf $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz $(SRCDIR)/srccache/fftw-$(FFTW_VER)
 distclean-fftw-single:
@@ -108,19 +93,22 @@ distclean-fftw-double:
 	-rm -rf $(BUILDDIR)/fftw-$(FFTW_VER)-double
 
 get-fftw: get-fftw-single get-fftw-double
+extract-fftw: extract-fftw-single extract-fftw-double
 configure-fftw: configure-fftw-single configure-fftw-double
 compile-fftw: compile-fftw-single compile-fftw-double
 check-fftw: check-fftw-single check-fftw-double
 install-fftw: install-fftw-single install-fftw-double
 
 get-fftw-single: $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz
-configure-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/config.status
-compile-fftw-single: $(FFTW_SINGLE_SRC_TARGET)
-check-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/checked
-install-fftw-single: $(FFTW_SINGLE_OBJ_TARGET)
+extract-fftw-single: $(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted
+configure-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-configured
+compile-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-compiled
+check-fftw-single: $(BUILDDIR)/fftw-$(FFTW_VER)-single/build-checked
+install-fftw-single: $(build_prefix)/manifest/fftw-single
 
 get-fftw-double: $(SRCDIR)/srccache/fftw-$(FFTW_VER).tar.gz
-configure-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/config.status
-compile-fftw-double: $(FFTW_DOUBLE_SRC_TARGET)
-check-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/checked
-install-fftw-double: $(FFTW_DOUBLE_OBJ_TARGET)
+extract-fftw-double: $(SRCDIR)/srccache/fftw-$(FFTW_VER)/source-extracted
+configure-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-configured
+compile-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-compiled
+check-fftw-double: $(BUILDDIR)/fftw-$(FFTW_VER)-double/build-checked
+install-fftw-double: $(build_prefix)/manifest/fftw-double

--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -14,6 +14,7 @@ $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2: | $(SRCDIR)/srccache
 $(SRCDIR)/srccache/gmp-$(GMP_VER)/source-extracted: $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) jxf $<
+	touch -c $(SRCDIR)/srccache/gmp-$(GMP_VER)/configure # old target
 	echo 1 > $@
 
 $(SRCDIR)/srccache/gmp-$(GMP_VER)/build-patched: $(SRCDIR)/srccache/gmp-$(GMP_VER)/source-extracted

--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -1,8 +1,5 @@
 ## GMP ##
 
-GMP_SRC_TARGET := $(BUILDDIR)/gmp-$(GMP_VER)/.libs/libgmp.$(SHLIB_EXT)
-GMP_OBJ_TARGET := $(build_shlibdir)/libgmp.$(SHLIB_EXT)
-
 ifeq ($(SANITIZE),1)
 GMP_CONFIGURE_OPTS += --disable-assembly
 endif
@@ -13,45 +10,53 @@ endif
 
 $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://gmplib.org/download/gmp/$(notdir $@)
-$(SRCDIR)/srccache/gmp-$(GMP_VER)/configure: $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2
+
+$(SRCDIR)/srccache/gmp-$(GMP_VER)/source-extracted: $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) jxf $<
-	touch -c $@
-$(SRCDIR)/srccache/gmp-$(GMP_VER)/patched: $(SRCDIR)/srccache/gmp-$(GMP_VER)/configure
+	echo 1 > $@
+
+$(SRCDIR)/srccache/gmp-$(GMP_VER)/patched: $(SRCDIR)/srccache/gmp-$(GMP_VER)/source-extracted
 	cd $(dir $@) && patch < $(SRCDIR)/patches/gmp-exception.patch
 	echo 1 > $@
-$(BUILDDIR)/gmp-$(GMP_VER)/config.status: $(SRCDIR)/srccache/gmp-$(GMP_VER)/configure $(SRCDIR)/srccache/gmp-$(GMP_VER)/patched
+
+$(BUILDDIR)/gmp-$(GMP_VER)/build-configured: $(SRCDIR)/srccache/gmp-$(GMP_VER)/source-extracted $(SRCDIR)/srccache/gmp-$(GMP_VER)/patched
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$< $(CONFIGURE_COMMON) F77= --enable-shared --disable-static $(GMP_CONFIGURE_OPTS)
-	touch -c $@
-$(GMP_SRC_TARGET): $(BUILDDIR)/gmp-$(GMP_VER)/config.status
+	$(dir $<)/configure $(CONFIGURE_COMMON) F77= --enable-shared --disable-static $(GMP_CONFIGURE_OPTS)
+	echo 1 > $@
+
+$(BUILDDIR)/gmp-$(GMP_VER)/build-compiled: $(BUILDDIR)/gmp-$(GMP_VER)/build-configured
 	$(MAKE) -C $(dir $<) $(LIBTOOL_CCLD)
-	touch -c $@
-$(BUILDDIR)/gmp-$(GMP_VER)/checked: $(GMP_SRC_TARGET)
+	echo 1 > $@
+
+$(BUILDDIR)/gmp-$(GMP_VER)/build-checked: $(BUILDDIR)/gmp-$(GMP_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) $(LIBTOOL_CCLD) check
 endif
 	echo 1 > $@
-$(GMP_OBJ_TARGET): $(GMP_SRC_TARGET) | $(build_shlibdir) $(build_includedir)
+
+$(build_prefix)/manifest/gmp: $(BUILDDIR)/gmp-$(GMP_VER)/build-compiled | $(build_shlibdir) $(build_includedir) $(build_prefix)/manifest
 ifeq ($(BUILD_OS),WINNT)
 	-mv $(BUILDDIR)/gmp-$(GMP_VER)/.libs/gmp.dll $(BUILDDIR)/gmp-$(GMP_VER)/.libs/libgmp.dll
 endif
 	$(INSTALL_M) $(BUILDDIR)/gmp-$(GMP_VER)/.libs/libgmp.*$(SHLIB_EXT)* $(build_shlibdir)
 	$(INSTALL_F) $(BUILDDIR)/gmp-$(GMP_VER)/gmp.h $(build_includedir)
-	$(INSTALL_NAME_CMD)libgmp.$(SHLIB_EXT) $@
-	touch -c $@
+	$(INSTALL_NAME_CMD)libgmp.$(SHLIB_EXT) $(build_shlibdir)/libgmp.$(SHLIB_EXT)
+	echo $(GMP_VER) > $@
 
 clean-gmp:
+	-rm -f $(build_prefix)/manifest/gmp $(BUILDDIR)/gmp-$(GMP_VER)/build-configured $(BUILDDIR)/gmp-$(GMP_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/gmp-$(GMP_VER) clean
-	-rm -f $(GMP_OBJ_TARGET)
+
 distclean-gmp:
 	-rm -rf $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2 \
 		$(SRCDIR)/srccache/gmp-$(GMP_VER) \
 		$(BUILDDIR)/gmp-$(GMP_VER)
 
 get-gmp: $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2
-configure-gmp: $(BUILDDIR)/gmp-$(GMP_VER)/config.status
-compile-gmp: $(GMP_SRC_TARGET)
-check-gmp: $(BUILDDIR)/gmp-$(GMP_VER)/checked
-install-gmp: $(GMP_OBJ_TARGET)
+extract-gmp: $(SRCDIR)/srccache/gmp-$(GMP_VER)/source-extracted
+configure-gmp: $(BUILDDIR)/gmp-$(GMP_VER)/build-configured
+compile-gmp: $(BUILDDIR)/gmp-$(GMP_VER)/build-compiled
+check-gmp: $(BUILDDIR)/gmp-$(GMP_VER)/build-checked
+install-gmp: $(build_prefix)/manifest/gmp

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -2,7 +2,7 @@
 
 LIBGIT2_GIT_URL := git://github.com/libgit2/libgit2.git
 LIBGIT2_TAR_URL = https://api.github.com/repos/libgit2/libgit2/tarball/$1
-$(eval $(call git-external,libgit2,LIBGIT2,,,$(SRCDIR)/srccache))
+$(eval $(call git-external,libgit2,LIBGIT2,CMakeLists.txt,,$(SRCDIR)/srccache))
 
 ifeq ($(USE_SYSTEM_LIBSSH2), 0)
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/libssh2

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -2,10 +2,11 @@
 
 LIBSSH2_GIT_URL := git://github.com/libssh2/libssh2.git
 LIBSSH2_TAR_URL = https://api.github.com/repos/libssh2/libssh2/tarball/$1
-$(eval $(call git-external,libssh2,LIBSSH2,CMakeLists.txt,build/libssh2.$(SHLIB_EXT),$(SRCDIR)/srccache))
+$(eval $(call git-external,libssh2,LIBSSH2,,,$(SRCDIR)/srccache))
 
-LIBSSH2_OBJ_SOURCE := $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/src/libssh2.$(SHLIB_EXT)
-LIBSSH2_OBJ_TARGET := $(build_shlibdir)/libssh2.$(SHLIB_EXT)
+ifeq ($(USE_SYSTEM_MBEDTLS), 0)
+$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/mbedtls
+endif
 
 LIBSSH2_OPTS := $(CMAKE_COMMON) -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=OFF \
 		-DCMAKE_BUILD_TYPE=Release
@@ -23,47 +24,46 @@ ifeq ($(OS),Linux)
 LIBSSH2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
-$(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-mbedtls.patch-applied: | $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/CMakeLists.txt
+$(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-mbedtls.patch-applied: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-mbedtls.patch
 	echo 1 > $@
-$(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: | $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/CMakeLists.txt
+
+$(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-encryptedpem.patch
 	echo 1 > $@
 
-ifeq ($(USE_SYSTEM_MBEDTLS), 0)
-$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/Makefile: $(MBEDTLS_OBJ_TARGET)
-endif
-$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/Makefile: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/CMakeLists.txt $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-mbedtls.patch-applied $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied
+$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-mbedtls.patch-applied $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(CMAKE) $(dir $<) $(LIBSSH2_OPTS)
-	touch -c $@
+	echo 1 > $@
 
-$(LIBSSH2_OBJ_SOURCE): $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/Makefile
+$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured
 	$(MAKE) -C $(dir $<) libssh2
-	touch -c $@
+	echo 1 > $@
 
-$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/checked: $(LIBSSH2_OBJ_SOURCE)
+$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-checked: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) test
 endif
 	echo 1 > $@
 
-$(LIBSSH2_OBJ_TARGET): $(LIBSSH2_OBJ_SOURCE) | $(build_shlibdir)
+$(build_prefix)/manifest/libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled | $(build_shlibdir) $(build_prefix)/manifest
 ifeq ($(BUILD_OS),WINNT)
 	$(MAKE) -C $(BUILDDIR)/$(LIBSSH2_SRC_DIR) install
 else
 	$(call make-install,$(LIBSSH2_SRC_DIR),)
 endif
-	$(INSTALL_NAME_CMD)libssh2.$(SHLIB_EXT) $@
-	touch -c $(LIBSSH2_OBJ_TARGET)
+	$(INSTALL_NAME_CMD)libssh2.$(SHLIB_EXT) $(build_shlibdir)/libssh2.$(SHLIB_EXT)
+	echo $(LIBSSH2_SHA1) > $@
 
 clean-libssh2:
+	-rm -f $(build_prefix)/manifest/libssh2 $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(LIBSSH2_SRC_DIR) clean
-	-rm -f $(LIBSSH2_OBJ_TARGET)
 
 get-libssh2: $(LIBSSH2_SRC_FILE)
-configure-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/Makefile
-compile-libssh2: $(LIBSSH2_OBJ_SOURCE)
-check-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/checked
-install-libssh2: $(LIBSSH2_OBJ_TARGET)
+extract-libssh2: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted
+configure-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured
+compile-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
+check-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-checked
+install-libssh2: $(build_prefix)/manifest/libssh2

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -48,22 +48,19 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled | $(build_shlibdir) $(build_prefix)/manifest
-ifeq ($(BUILD_OS),WINNT)
-	$(MAKE) -C $(BUILDDIR)/$(LIBSSH2_SRC_DIR) install
-else
-	$(call make-install,$(LIBSSH2_SRC_DIR),)
-endif
-	$(INSTALL_NAME_CMD)libssh2.$(SHLIB_EXT) $(build_shlibdir)/libssh2.$(SHLIB_EXT)
-	echo $(LIBSSH2_SHA1) > $@
+$(eval $(call staged-install, \
+	libssh2,$(LIBSSH2_SRC_DIR), \
+	MAKE_INSTALL,,, \
+	$$(INSTALL_NAME_CMD)libssh2.$$(SHLIB_EXT) $$(build_shlibdir)/libssh2.$$(SHLIB_EXT)))
 
 clean-libssh2:
-	-rm -f $(build_prefix)/manifest/libssh2 $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
+	-rm $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(LIBSSH2_SRC_DIR) clean
+
 
 get-libssh2: $(LIBSSH2_SRC_FILE)
 extract-libssh2: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted
 configure-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured
 compile-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
+fastcheck-libssh2: check-libssh2
 check-libssh2: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-checked
-install-libssh2: $(build_prefix)/manifest/libssh2

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -2,7 +2,7 @@
 
 LIBSSH2_GIT_URL := git://github.com/libssh2/libssh2.git
 LIBSSH2_TAR_URL = https://api.github.com/repos/libssh2/libssh2/tarball/$1
-$(eval $(call git-external,libssh2,LIBSSH2,,,$(SRCDIR)/srccache))
+$(eval $(call git-external,libssh2,LIBSSH2,CMakeLists.txt,,$(SRCDIR)/srccache))
 
 ifeq ($(USE_SYSTEM_MBEDTLS), 0)
 $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/mbedtls

--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -1,7 +1,7 @@
 ## LIBUV ##
 LIBUV_GIT_URL:=git://github.com/JuliaLang/libuv.git
 LIBUV_TAR_URL=https://api.github.com/repos/JuliaLang/libuv/tarball/$1
-$(eval $(call git-external,libuv,LIBUV,,,$(SRCDIR)/srccache))
+$(eval $(call git-external,libuv,LIBUV,configure,,$(SRCDIR)/srccache))
 
 UV_CFLAGS := -D_GNU_SOURCE
 ifeq ($(USEMSVC), 1)

--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -43,15 +43,13 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled | $(build_prefix)/manifest
-	$(call make-install,$(LIBUV_SRC_DIR),)
-	$(INSTALL_NAME_CMD)libuv.$(SHLIB_EXT) $(build_shlibdir)/libuv.$(SHLIB_EXT)
-	echo $(LIBUV_SHA1) > $@
+$(eval $(call staged-install, \
+	libuv,$$(LIBUV_SRC_DIR), \
+	MAKE_INSTALL,,, \
+	$$(INSTALL_NAME_CMD)libuv.$$(SHLIB_EXT) $$(build_shlibdir)/libuv.$$(SHLIB_EXT)))
 
 clean-libuv:
-	-rm -rf $(build_prefix)/manifest/libuv \
-		$(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled \
-		$(build_libdir)/libuv.a $(build_libdir)/libuv.la $(build_includedir)/libuv.h $(build_includedir)/libuv-private
+	-rm -rf $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(LIBUV_SRC_DIR) clean
 
 
@@ -59,5 +57,5 @@ get-libuv: $(LIBUV_SRC_FILE)
 extract-libuv: $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/source-extracted
 configure-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured
 compile-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled
+fastcheck-libuv: #none
 check-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-checked
-install-libuv: $(build_prefix)/manifest/libuv

--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -1,10 +1,7 @@
 ## LIBUV ##
 LIBUV_GIT_URL:=git://github.com/JuliaLang/libuv.git
 LIBUV_TAR_URL=https://api.github.com/repos/JuliaLang/libuv/tarball/$1
-$(eval $(call git-external,libuv,LIBUV,configure,.libs/libuv.la,$(SRCDIR)/srccache))
-
-UV_SRC_TARGET := $(BUILDDIR)/$(LIBUV_SRC_DIR)/.libs/libuv.la
-UV_OBJ_TARGET := $(build_libdir)/libuv.la
+$(eval $(call git-external,libuv,LIBUV,,,$(SRCDIR)/srccache))
 
 UV_CFLAGS := -D_GNU_SOURCE
 ifeq ($(USEMSVC), 1)
@@ -27,33 +24,40 @@ else
 UV_FLAGS := --disable-shared $(UV_MFLAGS)
 endif
 
-$(BUILDDIR)/$(LIBUV_SRC_DIR)/config.status: $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/configure
+$(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured: $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/source-extracted
 	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/aclocal.m4 # touch a few files to prevent autogen from getting called
 	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/Makefile.in
 	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/configure
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$< --with-pic $(CONFIGURE_COMMON) $(UV_FLAGS)
-	touch -c $@
-$(UV_SRC_TARGET): $(BUILDDIR)/$(LIBUV_SRC_DIR)/config.status
+	$(dir $<)/configure --with-pic $(CONFIGURE_COMMON) $(UV_FLAGS)
+	echo 1 > $@
+
+$(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured
 	$(MAKE) -C $(dir $<) $(UV_MFLAGS)
-	touch -c $@
-$(BUILDDIR)/$(LIBUV_SRC_DIR)/checked: $(UV_SRC_TARGET)
+	echo 1 > $@
+
+$(BUILDDIR)/$(LIBUV_SRC_DIR)/build-checked: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	-$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
-$(UV_OBJ_TARGET): $(UV_SRC_TARGET)
+
+$(build_prefix)/manifest/libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled | $(build_prefix)/manifest
 	$(call make-install,$(LIBUV_SRC_DIR),)
 	$(INSTALL_NAME_CMD)libuv.$(SHLIB_EXT) $(build_shlibdir)/libuv.$(SHLIB_EXT)
-	touch -c $@
+	echo $(LIBUV_SHA1) > $@
 
 clean-libuv:
+	-rm -rf $(build_prefix)/manifest/libuv \
+		$(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled \
+		$(build_libdir)/libuv.a $(build_libdir)/libuv.la $(build_includedir)/libuv.h $(build_includedir)/libuv-private
 	-$(MAKE) -C $(BUILDDIR)/$(LIBUV_SRC_DIR) clean
-	-rm -rf $(build_libdir)/libuv.a $(build_libdir)/libuv.la $(build_includedir)/libuv.h $(build_includedir)/libuv-private
+
 
 get-libuv: $(LIBUV_SRC_FILE)
-configure-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/config.status
-compile-libuv: $(UV_SRC_TARGET)
-check-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/checked
-install-libuv: $(UV_OBJ_TARGET)
+extract-libuv: $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/source-extracted
+configure-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured
+compile-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-compiled
+check-libuv: $(BUILDDIR)/$(LIBUV_SRC_DIR)/build-checked
+install-libuv: $(build_prefix)/manifest/libuv

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -1,4 +1,6 @@
 ## LLVM ##
+include $(SRCDIR)/llvm-ver.make
+
 LLVM_GIT_URL_BASE ?= http://llvm.org/git
 LLVM_GIT_URL_LLVM ?= $(LLVM_GIT_URL_BASE)/llvm.git
 LLVM_GIT_URL_CLANG ?= $(LLVM_GIT_URL_BASE)/clang.git
@@ -43,12 +45,6 @@ LLVM_SRC_DIR:=$(SRCDIR)/srccache/llvm-$(LLVM_VER)
 LLVM_BUILD_DIR:=$(BUILDDIR)/llvm-$(LLVM_VER)
 LLVM_BUILDDIR_withtype := $(LLVM_BUILD_DIR)/build_$(LLVM_BUILDTYPE)
 LLVM_LIB_FILE := libLLVMCodeGen.a
-ifeq ($(LLVM_USE_CMAKE),1)
-LLVM_OBJ_SOURCE := $(LLVM_BUILDDIR_withtype)/lib/$(LLVM_LIB_FILE)
-else
-LLVM_OBJ_SOURCE := $(LLVM_BUILDDIR_withtype)/$(LLVM_FLAVOR)/lib/$(LLVM_LIB_FILE)
-endif
-LLVM_OBJ_TARGET := $(build_libdir)/$(LLVM_LIB_FILE)
 
 ifeq ($(LLVM_VER), 3.3)
 LLVM_TAR_EXT:=$(LLVM_VER).src.tar.gz
@@ -258,7 +254,7 @@ $(LLVM_LLDB_TAR): | $(SRCDIR)/srccache
 endif
 ifeq ($(BUILD_LLDB),1)
 $(LLVM_SRC_DIR)/tools/lldb:
-$(LLVM_SRC_DIR).extracted: $(LLVM_SRC_DIR)/tools/lldb
+$(LLVM_SRC_DIR)/source-extracted: $(LLVM_SRC_DIR)/tools/lldb
 endif
 
 # LLDB still relies on plenty of python 2.x infrastructure, without checking
@@ -278,13 +274,13 @@ ifeq ($(USEICC),1)
 LIBCXX_EXTRA_FLAGS := -Bstatic -lirc -Bdynamic
 endif
 
-$(LLVM_SRC_DIR)/projects/libcxx: $(LLVM_LIBCXX_TAR) | $(LLVM_SRC_DIR).extracted
+$(LLVM_SRC_DIR)/projects/libcxx: $(LLVM_LIBCXX_TAR) | $(LLVM_SRC_DIR)/source-extracted
 	([ ! -d $@ ] && \
 	git clone $(LLVM_GIT_URL_LIBCXX) $@  ) || \
 	(cd $@  && \
 	git pull --ff-only)
 $(LLVM_SRC_DIR)/projects/libcxx/.git/HEAD: | $(LLVM_SRC_DIR)/projects/libcxx/.git/HEAD
-$(LLVM_SRC_DIR)/projects/libcxxabi: $(LLVM_LIBCXXABI_TAR) | $(LLVM_SRC_DIR).extracted
+$(LLVM_SRC_DIR)/projects/libcxxabi: $(LLVM_LIBCXXABI_TAR) | $(LLVM_SRC_DIR)/source-extracted
 	([ ! -d $@ ] && \
 	git clone $(LLVM_GIT_URL_LIBCXXABI) $@ ) || \
 	(cd $@ && \
@@ -320,7 +316,7 @@ LIBCXX_DEPENDENCY := $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++.so.
 get-llvm: get-libcxx get-libcxxabi
 endif
 
-$(LLVM_SRC_DIR).extracted: | $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR)
+$(LLVM_SRC_DIR)/source-extracted: | $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR)
 ifneq ($(LLVM_CLANG_TAR),)
 	$(JLCHECKSUM) $(LLVM_CLANG_TAR)
 endif
@@ -403,20 +399,20 @@ endif # LLVM_GIT_VER_POLLY
 endif # USE_POLLY
 endif # LLVM_VER
 	# touch some extra files to ensure bisect works pretty well
+	touch -c $(LLVM_SRC_DIR).extracted
 	touch -c $(LLVM_SRC_DIR)/configure
 	touch -c $(LLVM_SRC_DIR)/CMakeLists.txt
 	echo 1 > $@
 
 # Apply version-specific LLVM patches
-LLVM_PATCH_PREV:=
-LLVM_PATCH_LIST:=
+LLVM_PATCH_PREV :=
 define LLVM_PATCH
-$$(LLVM_SRC_DIR)/$1.patch-applied: | $$(LLVM_SRC_DIR).extracted $$(SRCDIR)/patches/$1.patch $$(LLVM_PATCH_PREV)
+$$(LLVM_SRC_DIR)/$1.patch-applied: $$(LLVM_SRC_DIR)/source-extracted | $$(SRCDIR)/patches/$1.patch $$(LLVM_PATCH_PREV)
 	cd $$(LLVM_SRC_DIR) && patch -p1 < $$(SRCDIR)/patches/$1.patch
 	echo 1 > $$@
 LLVM_PATCH_PREV := $$(LLVM_SRC_DIR)/$1.patch-applied
-LLVM_PATCH_LIST += $$(LLVM_PATCH_PREV)
 endef
+
 ifeq ($(LLVM_VER),3.3)
 $(eval $(call LLVM_PATCH,llvm-3.3))
 $(eval $(call LLVM_PATCH,instcombine-llvm-3.3))
@@ -469,42 +465,43 @@ ifeq ($(BUILD_LLVM_CLANG),1)
 $(eval $(call LLVM_PATCH,compiler-rt-3.7.1))
 endif
 endif
+$(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_PATCH_PREV)
 
 ifeq ($(LLVM_USE_CMAKE),1)
 
-$(LLVM_BUILDDIR_withtype)/CMakeCache.txt: $(LLVM_SRC_DIR).extracted $(LLVM_PATCH_LIST) | $(llvm_python_workaround) $(LIBCXX_DEPENDENCY)
+$(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_SRC_DIR)/source-extracted | $(llvm_python_workaround) $(LIBCXX_DEPENDENCY)
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 		export PATH=$(llvm_python_workaround):$$PATH && \
 		$(CMAKE) $(LLVM_SRC_DIR) $(CMAKE_GENERATOR_COMMAND) $(CMAKE_COMMON) $(LLVM_CMAKE)
-	touch -c $@
+	echo 1 > $@
 
-$(LLVM_OBJ_SOURCE): $(LLVM_BUILDDIR_withtype)/CMakeCache.txt | $(llvm_python_workaround)
+$(LLVM_BUILDDIR_withtype)/build-compiled: $(LLVM_BUILDDIR_withtype)/build-configured | $(llvm_python_workaround)
 	cd $(LLVM_BUILDDIR_withtype) && \
 		export PATH=$(llvm_python_workaround):$$PATH && \
 		$(if $(filter $(CMAKE_GENERATOR),make), \
 		  $(MAKE), \
 		  $(CMAKE) --build .)
-	touch -c $@
+	echo 1 > $@
 
 else
 
-$(LLVM_BUILDDIR_withtype)/config.status: $(LLVM_SRC_DIR).extracted $(LLVM_PATCH_LIST) | $(llvm_python_workaround) $(LIBCXX_DEPENDENCY)
+$(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_SRC_DIR)/source-extracted | $(llvm_python_workaround) $(LIBCXX_DEPENDENCY)
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 		export PATH=$(llvm_python_workaround):$$PATH && \
 		$(LLVM_SRC_DIR)/configure $(CONFIGURE_COMMON) $(LLVM_CC) $(LLVM_FLAGS)
-	touch -c $@
+	echo 1 > $@
 
-$(LLVM_OBJ_SOURCE): $(LLVM_BUILDDIR_withtype)/config.status | $(llvm_python_workaround)
+$(LLVM_BUILDDIR_withtype)/build-compiled: $(LLVM_BUILDDIR_withtype)/build-configured | $(llvm_python_workaround)
 	cd $(LLVM_BUILDDIR_withtype) && \
 		export PATH=$(llvm_python_workaround):$$PATH && \
 		$(MAKE) $(LLVM_MFLAGS) $(MAKE_COMMON)
-	touch -c $@
+	echo 1 > $@
 
 endif # LLVM_USE_CMAKE
 
-$(LLVM_BUILDDIR_withtype)/checked: $(LLVM_OBJ_SOURCE) | $(llvm_python_workaround)
+$(LLVM_BUILDDIR_withtype)/build-checked: $(LLVM_BUILDDIR_withtype)/build-compiled | $(llvm_python_workaround)
 ifeq ($(OS),$(BUILD_OS))
 	cd $(LLVM_BUILDDIR_withtype) && \
 		export PATH=$(llvm_python_workaround):$$PATH && \
@@ -513,7 +510,9 @@ ifeq ($(OS),$(BUILD_OS))
 		  $(MAKE) $(LLVM_MFLAGS) check)
 endif
 	echo 1 > $@
-$(LLVM_OBJ_TARGET): $(LLVM_OBJ_SOURCE) | $(llvm_python_workaround)
+
+$(build_prefix)/manifest/llvm: | $(llvm_python_workaround)
+
 ifeq ($(LLVM_USE_CMAKE),1)
 	$(call staged-install,llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE),\
 	                      cd $(BUILDDIR)/llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE) &&\
@@ -522,33 +521,31 @@ else
 	$(call   make-install,llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE),\
 	                      $(LLVM_MFLAGS) PATH="$(llvm_python_workaround):$$PATH")
 endif # LLVM_USE_CMAKE
-	touch -c $@
+	echo $(LLVM_VER) > $@
 
 reinstall-llvm:
-	-rm $(LLVM_OBJ_TARGET)
+	-rm $(build_prefix)/manifest/llvm $(LLVM_BUILDDIR_withtype)/build-compiled
 	$(MAKE) -f $(SRCDIR)/Makefile -s install-llvm
 
 clean-llvm:
+	-rm -f $(build_prefix)/manifest/llvm $(LLVM_BUILDDIR_withtype)/build-configured $(LLVM_BUILDDIR_withtype)/build-compiled
 	-$(MAKE) -C $(LLVM_BUILDDIR_withtype) clean
-	-rm -f $(build_depsbindir)/llvm-config
+
 distclean-llvm:
 	-rm -rf $(LLVM_TAR) $(LLVM_CLANG_TAR) \
 		$(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR) \
-		$(LLVM_SRC_DIR) $(LLVM_SRC_DIR).extracted $(LLVM_BUILDDIR_withtype)
+		$(LLVM_SRC_DIR) $(LLVM_BUILDDIR_withtype)
 
 ifneq ($(LLVM_VER),svn)
 get-llvm: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR)
 else
-get-llvm: $(LLVM_SRC_DIR).extracted
+get-llvm: $(LLVM_SRC_DIR)/source-extracted
 endif
-ifeq ($(LLVM_USE_CMAKE),1)
-configure-llvm: $(LLVM_BUILDDIR_withtype)/CMakeCache.txt
-else
-configure-llvm: $(LLVM_BUILDDIR_withtype)/config.status
-endif
-compile-llvm: $(LLVM_OBJ_SOURCE)
-check-llvm: $(LLVM_BUILDDIR_withtype)/checked
-install-llvm: $(LLVM_OBJ_TARGET)
+extract-llvm: $(LLVM_SRC_DIR)/source-extracted
+configure-llvm: $(LLVM_BUILDDIR_withtype)/build-configured
+compile-llvm: $(LLVM_BUILDDIR_withtype)/build-compiled
+check-llvm: $(LLVM_BUILDDIR_withtype)/build-checked
+install-llvm: $(build_prefix)/manifest/llvm
 #todo: LLVM make check target is broken on julia.mit.edu (and really slow elsewhere)
 
 ifeq ($(LLVM_VER),svn)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -514,27 +514,24 @@ endif
 $(build_prefix)/manifest/llvm: | $(llvm_python_workaround)
 
 ifeq ($(LLVM_USE_CMAKE),1)
-	$(call staged-install,llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE),\
-	                      cd $(BUILDDIR)/llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE) &&\
-	                      $(CMAKE) -DCMAKE_INSTALL_PREFIX="$(call MAKE_DESTDIR,llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE))$(build_prefix)" -P cmake_install.cmake)
+CMAKE_INSTALL_LLVM = \
+	cd $1 && $(CMAKE) -DCMAKE_INSTALL_PREFIX="$2" -P cmake_install.cmake
+$(eval $(call staged-install,llvm,llvm-$$(LLVM_VER)/build_$$(LLVM_BUILDTYPE), \
+	CMAKE_INSTALL_LLVM,,,))
 else
-	$(call   make-install,llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE),\
-	                      $(LLVM_MFLAGS) PATH="$(llvm_python_workaround):$$PATH")
+$(eval $(call staged-install,llvm,llvm-$$(LLVM_VER)/build_$$(LLVM_BUILDTYPE), \
+	MAKE_INSTALL,$$(LLVM_MFLAGS) PATH="$$(llvm_python_workaround):$$$$PATH",,))
 endif # LLVM_USE_CMAKE
-	echo $(LLVM_VER) > $@
-
-reinstall-llvm:
-	-rm $(build_prefix)/manifest/llvm $(LLVM_BUILDDIR_withtype)/build-compiled
-	$(MAKE) -f $(SRCDIR)/Makefile -s install-llvm
 
 clean-llvm:
-	-rm -f $(build_prefix)/manifest/llvm $(LLVM_BUILDDIR_withtype)/build-configured $(LLVM_BUILDDIR_withtype)/build-compiled
+	-rm $(LLVM_BUILDDIR_withtype)/build-configured $(LLVM_BUILDDIR_withtype)/build-compiled
 	-$(MAKE) -C $(LLVM_BUILDDIR_withtype) clean
 
 distclean-llvm:
 	-rm -rf $(LLVM_TAR) $(LLVM_CLANG_TAR) \
 		$(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR) \
 		$(LLVM_SRC_DIR) $(LLVM_BUILDDIR_withtype)
+
 
 ifneq ($(LLVM_VER),svn)
 get-llvm: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LLVM_LLDB_TAR)
@@ -544,9 +541,10 @@ endif
 extract-llvm: $(LLVM_SRC_DIR)/source-extracted
 configure-llvm: $(LLVM_BUILDDIR_withtype)/build-configured
 compile-llvm: $(LLVM_BUILDDIR_withtype)/build-compiled
+fastcheck-llvm: #none
 check-llvm: $(LLVM_BUILDDIR_withtype)/build-checked
-install-llvm: $(build_prefix)/manifest/llvm
 #todo: LLVM make check target is broken on julia.mit.edu (and really slow elsewhere)
+
 
 ifeq ($(LLVM_VER),svn)
 update-llvm:

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -7,9 +7,6 @@ MBEDTLS_SRC = mbedtls-$(MBEDTLS_VER)-apache
 endif
 MBEDTLS_URL = https://tls.mbed.org/download/$(MBEDTLS_SRC).tgz
 
-MBEDTLS_OBJ_SOURCE := $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/library/libmbedcrypto.$(SHLIB_EXT)
-MBEDTLS_OBJ_TARGET := $(build_shlibdir)/libmbedcrypto.$(SHLIB_EXT)
-
 MBEDTLS_OPTS := $(CMAKE_COMMON) -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
     -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DENABLE_PROGRAMS=OFF -DCMAKE_BUILD_TYPE=Release
 
@@ -25,35 +22,36 @@ endif
 $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ $(MBEDTLS_URL)
 
-$(SRCDIR)/srccache/$(MBEDTLS_SRC)/CMakeLists.txt: $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz
+$(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted: $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz
 	$(JLCHECKSUM) $<
 	mkdir -p $(dir $@) && \
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
-	touch -c $@
-
-$(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied: | $(SRCDIR)/srccache/$(MBEDTLS_SRC)/CMakeLists.txt
-	cd $(SRCDIR)/srccache/$(MBEDTLS_SRC)/include/mbedtls && patch -p0 -f < $(SRCDIR)/patches/mbedtls-ssl.h.patch
 	echo 1 > $@
 
-$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/Makefile: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/CMakeLists.txt $(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied
+$(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted
+	cd $(SRCDIR)/srccache/$(MBEDTLS_SRC)/include/mbedtls && patch -p0 -f < $(SRCDIR)/patches/mbedtls-ssl.h.patch
+	echo 1 > $@
+$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied
+
+$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(CMAKE) $(dir $<) $(MBEDTLS_OPTS)
-	touch -c $@
+	echo 1 > $@
 
-$(MBEDTLS_OBJ_SOURCE): $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/Makefile
+$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured
 	$(MAKE) -C $(dir $<)
-	touch -c $@
+	echo 1 > $@
 
-$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/checked: $(MBEDTLS_OBJ_SOURCE)
+$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-checked: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) test
 endif
 	echo 1 > $@
 
-$(MBEDTLS_OBJ_TARGET): $(MBEDTLS_OBJ_SOURCE) | $(build_shlibdir)
+$(build_prefix)/manifest/mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled | $(build_shlibdir) $(build_prefix)/manifest
 ifeq ($(OS), WINNT)
-	cp $^ $(build_shlibdir)
+	cp $(dir $<)/library/libmbedcrypto.$(SHLIB_EXT) $(build_shlibdir)
 	cp $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/library/libmbedx509.$(SHLIB_EXT) $(build_shlibdir)
 	cp $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/library/libmbedtls.$(SHLIB_EXT) $(build_shlibdir)
 else
@@ -64,12 +62,14 @@ endif
 	$(INSTALL_NAME_CHANGE_CMD) libmbedx509.0.dylib @rpath/libmbedx509.$(SHLIB_EXT) $(build_shlibdir)/libmbedtls.$(SHLIB_EXT)
 	$(INSTALL_NAME_CHANGE_CMD) libmbedcrypto.0.dylib @rpath/libmbedcrypto.$(SHLIB_EXT) $(build_shlibdir)/libmbedtls.$(SHLIB_EXT)
 	$(INSTALL_NAME_CHANGE_CMD) libmbedcrypto.0.dylib @rpath/libmbedcrypto.$(SHLIB_EXT) $(build_shlibdir)/libmbedx509.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libmbedcrypto.$(SHLIB_EXT) $@
-	touch -c $(MBEDTLS_OBJ_TARGET)
+	$(INSTALL_NAME_CMD)libmbedcrypto.$(SHLIB_EXT) $(build_shlibdir)/libmbedcrypto.$(SHLIB_EXT)
+	echo $(MBEDTLS_VER) > $@
 
 clean-mbedtls:
+	-rm -f $(build_prefix)/manifest/mbedtls \
+		$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured \
+		$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/mbedtls-$(MBEDTLS_VER) clean
-	-rm -f $(MBEDTLS_OBJ_TARGET) $(build_shlibdir)/libmbed*
 
 distclean-mbedtls:
 	-rm -rf $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz \
@@ -77,7 +77,8 @@ distclean-mbedtls:
 		$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)
 
 get-mbedtls: $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz
-configure-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/Makefile
-compile-mbedtls: $(MBEDTLS_OBJ_SOURCE)
-check-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/checked
-install-mbedtls: $(MBEDTLS_OBJ_TARGET)
+extract-mbedtls: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted
+configure-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured
+compile-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled
+check-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-checked
+install-mbedtls: $(build_prefix)/manifest/mbedtls

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -26,6 +26,7 @@ $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted: $(SRCDIR)/srccache/$(MBEDTLS
 	$(JLCHECKSUM) $<
 	mkdir -p $(dir $@) && \
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
+	touch -c $(SRCDIR)/srccache/$(MBEDTLS_SRC)/CMakeLists.txt # old target
 	echo 1 > $@
 
 $(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted

--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -30,6 +30,7 @@ $(SRCDIR)/srccache/mpfr-$(MPFR_VER).tar.bz2: | $(SRCDIR)/srccache
 $(SRCDIR)/srccache/mpfr-$(MPFR_VER)/source-extracted: $(SRCDIR)/srccache/mpfr-$(MPFR_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) jxf $<
+	touch -c $(SRCDIR)/srccache/mpfr-$(MPFR_VER)/configure # old target
 	echo 1 > $@
 
 $(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured: $(SRCDIR)/srccache/mpfr-$(MPFR_VER)/source-extracted

--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -48,13 +48,13 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/mpfr: $(BUILDDIR)/mpfr-$(MPFR_VER)/build-compiled | $(build_prefix)/manifest
-	$(call make-install,mpfr-$(MPFR_VER),$(LIBTOOL_CCLD))
-	$(INSTALL_NAME_CMD)libmpfr.$(SHLIB_EXT) $(build_shlibdir)/libmpfr.$(SHLIB_EXT)
-	echo $(MPFR_VER) > $@
+$(eval $(call staged-install, \
+	mpfr,mpfr-$(MPFR_VER), \
+	MAKE_INSTALL,$$(LIBTOOL_CCLD),, \
+	$$(INSTALL_NAME_CMD)libmpfr.$$(SHLIB_EXT) $$(build_shlibdir)/libmpfr.$$(SHLIB_EXT)))
 
 clean-mpfr:
-	-rm -f $(build_prefix)/manifest/mpfr $(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured $(BUILDDIR)/mpfr-$(MPFR_VER)/build-compiled
+	-rm $(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured $(BUILDDIR)/mpfr-$(MPFR_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/mpfr-$(MPFR_VER) clean
 
 distclean-mpfr:
@@ -66,5 +66,5 @@ get-mpfr: $(SRCDIR)/srccache/mpfr-$(MPFR_VER).tar.bz2
 extract-mpfr: $(SRCDIR)/srccache/mpfr-$(MPFR_VER)/source-extracted
 configure-mpfr: $(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured
 compile-mpfr: $(BUILDDIR)/mpfr-$(MPFR_VER)/build-compiled
+fastcheck-mpfr: check-mpfr
 check-mpfr: $(BUILDDIR)/mpfr-$(MPFR_VER)/build-checked
-install-mpfr: $(build_prefix)/manifest/mpfr

--- a/deps/objconv.mk
+++ b/deps/objconv.mk
@@ -14,19 +14,20 @@ $(BUILDDIR)/objconv/build-compiled: $(BUILDDIR)/objconv/source-extracted
 	cd $(dir $<) && $(CXX) -o objconv -O2 *.cpp
 	echo 1 > $@
 
-$(build_prefix)/manifest/objconv: $(BUILDDIR)/objconv/build-compiled | $(build_depsbindir) $(build_prefix)/manifest
-	cp -f $(BUILDDIR)/objconv/objconv $(build_depsbindir)/objconv
-	echo 2.42 > $@
+$(eval $(call staged-install, \
+	objconv,objconv, \
+	BINFILE_INSTALL,$$(BUILDDIR)/objconv/objconv,,))
 
 clean-objconv:
-	-rm -f $(build_prefix)/manifest/objconv $(BUILDDIR)/objconv/build-compiled $(build_depsbindir)/objconv
+	-rm $(BUILDDIR)/objconv/build-compiled $(build_depsbindir)/objconv
 
 distclean-objconv:
 	-rm -rf $(SRCDIR)/srccache/objconv.zip $(BUILDDIR)/objconv
+
 
 get-objconv: $(SRCDIR)/srccache/objconv.zip
 extract-objconv: $(BUILDDIR)/objconv/source-extracted
 configure-objconv: extract-objconv
 compile-objconv: $(BUILDDIR)/objconv/build-compiled
+fastcheck-objconv: check-objconv
 check-objconv: compile-objconv
-install-objconv: $(build_prefix)/manifest/objconv

--- a/deps/openlibm.mk
+++ b/deps/openlibm.mk
@@ -9,18 +9,19 @@ $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/
 	$(MAKE) -C $(dir $<) $(OPENLIBM_FLAGS) $(MAKE_COMMON)
 	echo 1 > $@
 
-$(build_prefix)/manifest/openlibm: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled
-	$(call make-install,$(OPENLIBM_SRC_DIR),$(OPENLIBM_FLAGS))
-	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $(build_shlibdir)/libopenlibm.$(SHLIB_EXT)
-	echo $(OPENLIBM_SHA1) > $@
+$(eval $(call staged-install, \
+	openlibm,$$(OPENLIBM_SRC_DIR), \
+	MAKE_INSTALL,$$(OPENLIBM_FLAGS),, \
+	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $(build_shlibdir)/libopenlibm.$(SHLIB_EXT)))
 
 clean-openlibm:
-	-rm $(build_prefix)/manifest/openlibm $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled $(build_libdir)/libopenlibm.a
+	-rm $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled $(build_libdir)/libopenlibm.a
 	-$(MAKE) -C $(BUILDDIR)/$(OPENLIBM_SRC_DIR) distclean $(OPENLIBM_FLAGS)
+
 
 get-openlibm: $(OPENLIBM_SRC_FILE)
 extract-openlibm: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/source-extracted
 configure-openlibm: extract-openlibm
 compile-openlibm: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled
+fastcheck-openlibm: check-openlibm
 check-openlibm: compile-openlibm
-install-openlibm: $(build_prefix)/manifest/openlibm

--- a/deps/openlibm.mk
+++ b/deps/openlibm.mk
@@ -1,27 +1,26 @@
 ## openlibm ##
 OPENLIBM_GIT_URL := git://github.com/JuliaLang/openlibm.git
 OPENLIBM_TAR_URL = https://api.github.com/repos/JuliaLang/openlibm/tarball/$1
-$(eval $(call git-external,openlibm,OPENLIBM,Makefile,libopenlibm.$(SHLIB_EXT),$(BUILDDIR)))
+$(eval $(call git-external,openlibm,OPENLIBM,,,$(BUILDDIR)))
 
-OPENLIBM_OBJ_TARGET := $(build_shlibdir)/libopenlibm.$(SHLIB_EXT) $(build_libdir)/libopenlibm.a
-OPENLIBM_OBJ_SOURCE := $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/libopenlibm.$(SHLIB_EXT)
 OPENLIBM_FLAGS := ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
 
-$(OPENLIBM_OBJ_SOURCE): $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/Makefile
+$(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/source-extracted
 	$(MAKE) -C $(dir $<) $(OPENLIBM_FLAGS) $(MAKE_COMMON)
-	touch -c $@
-$(build_shlibdir)/libopenlibm%$(SHLIB_EXT) $(build_libdir)/libopenlibm%a: $(OPENLIBM_OBJ_SOURCE)
+	echo 1 > $@
+
+$(build_prefix)/manifest/openlibm: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled
 	$(call make-install,$(OPENLIBM_SRC_DIR),$(OPENLIBM_FLAGS))
 	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $(build_shlibdir)/libopenlibm.$(SHLIB_EXT)
-	touch -c $(OPENLIBM_OBJ_TARGET)
+	echo $(OPENLIBM_SHA1) > $@
 
 clean-openlibm:
+	-rm $(build_prefix)/manifest/openlibm $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled $(build_libdir)/libopenlibm.a
 	-$(MAKE) -C $(BUILDDIR)/$(OPENLIBM_SRC_DIR) distclean $(OPENLIBM_FLAGS)
-	-rm $(OPENLIBM_OBJ_TARGET)
-	-rm $(build_libdir)/libopenlibm.a
 
 get-openlibm: $(OPENLIBM_SRC_FILE)
-configure-openlibm: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/Makefile
-compile-openlibm: $(OPENLIBM_OBJ_SOURCE)
+extract-openlibm: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/source-extracted
+configure-openlibm: extract-openlibm
+compile-openlibm: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled
 check-openlibm: compile-openlibm
-install-openlibm: $(OPENLIBM_OBJ_TARGET)
+install-openlibm: $(build_prefix)/manifest/openlibm

--- a/deps/openspecfun.mk
+++ b/deps/openspecfun.mk
@@ -22,18 +22,19 @@ $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled: $(BUILDDIR)/$(OPENSPECFUN_SRC
 	$(MAKE) -C $(dir $<) $(OPENSPECFUN_FLAGS) $(MAKE_COMMON)
 	echo 1 > $@
 
-$(build_prefix)/manifest/openspecfun: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled
-	$(call make-install,$(OPENSPECFUN_SRC_DIR),$(OPENSPECFUN_FLAGS))
-	$(INSTALL_NAME_CMD)libopenspecfun.$(SHLIB_EXT) $(build_shlibdir)/libopenspecfun.$(SHLIB_EXT)
-	echo $(OPENSPECFUN_SHA1) > $@
+$(eval $(call staged-install, \
+	openspecfun,$$(OPENSPECFUN_SRC_DIR), \
+	MAKE_INSTALL,$$(OPENSPECFUN_FLAGS),, \
+	$$(INSTALL_NAME_CMD)libopenspecfun.$$(SHLIB_EXT) $$(build_shlibdir)/libopenspecfun.$$(SHLIB_EXT)))
 
 clean-openspecfun:
-	-rm $(build_prefix)/manifest/openspecfun $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled $(build_libdir)/libopenspecfun.a
+	-rm $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR) distclean $(OPENSPECFUN_FLAGS)
+
 
 get-openspecfun: $(OPENSPECFUN_SRC_FILE)
 extract-openspecfun: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/source-extracted
 configure-openspecfun: extract-openspecfun
 compile-openspecfun: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled
+fastcheck-openspecfun: check-openspecfun
 check-openspecfun: compile-openspecfun
-install-openspecfun: $(build_prefix)/manifest/openspecfun

--- a/deps/openspecfun.mk
+++ b/deps/openspecfun.mk
@@ -1,7 +1,7 @@
 ## openspecfun ##
 OPENSPECFUN_GIT_URL := git://github.com/JuliaLang/openspecfun.git
 OPENSPECFUN_TAR_URL = https://api.github.com/repos/JuliaLang/openspecfun/tarball/$1
-$(eval $(call git-external,openspecfun,OPENSPECFUN,Makefile,libopenspecfun.$(SHLIB_EXT),$(BUILDDIR)))
+$(eval $(call git-external,openspecfun,OPENSPECFUN,,,$(BUILDDIR)))
 
 # issue 8799
 OPENSPECFUN_CFLAGS := -O3 -std=c99
@@ -9,32 +9,31 @@ ifeq ($(USEICC),1)
   OPENSPECFUN_CFLAGS += -fp-model precise
 endif
 
-OPENSPECFUN_OBJ_TARGET := $(build_shlibdir)/libopenspecfun.$(SHLIB_EXT)
-OPENSPECFUN_OBJ_SOURCE := $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/libopenspecfun.$(SHLIB_EXT)
 OPENSPECFUN_FLAGS := ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" \
 	USECLANG=$(USECLANG) USEGCC=$(USEGCC) FFLAGS="$(JFFLAGS)" \
 	CFLAGS="$(CFLAGS) $(OPENSPECFUN_CFLAGS)" LDFLAGS="$(LDFLAGS) $(RPATH_ESCAPED_ORIGIN)"
 
 ifeq ($(USE_SYSTEM_LIBM),0)
   OPENSPECFUN_FLAGS += USE_OPENLIBM=1
-$(OPENSPECFUN_OBJ_SOURCE): $(OPENLIBM_OBJ_TARGET)
+$(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled: $(build_prefix)/manifest/openlibm
 endif
 
-$(OPENSPECFUN_OBJ_SOURCE): $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/Makefile
+$(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/source-extracted
 	$(MAKE) -C $(dir $<) $(OPENSPECFUN_FLAGS) $(MAKE_COMMON)
-	touch -c $@
-$(OPENSPECFUN_OBJ_TARGET): $(OPENSPECFUN_OBJ_SOURCE)
+	echo 1 > $@
+
+$(build_prefix)/manifest/openspecfun: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled
 	$(call make-install,$(OPENSPECFUN_SRC_DIR),$(OPENSPECFUN_FLAGS))
-	$(INSTALL_NAME_CMD)libopenspecfun.$(SHLIB_EXT) $@
-	touch -c $@
+	$(INSTALL_NAME_CMD)libopenspecfun.$(SHLIB_EXT) $(build_shlibdir)/libopenspecfun.$(SHLIB_EXT)
+	echo $(OPENSPECFUN_SHA1) > $@
 
 clean-openspecfun:
+	-rm $(build_prefix)/manifest/openspecfun $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled $(build_libdir)/libopenspecfun.a
 	-$(MAKE) -C $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR) distclean $(OPENSPECFUN_FLAGS)
-	-rm $(OPENSPECFUN_OBJ_TARGET)
-	-rm $(build_libdir)/libopenspecfun.a
 
 get-openspecfun: $(OPENSPECFUN_SRC_FILE)
-configure-openspecfun: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/Makefile
-compile-openspecfun: $(OPENSPECFUN_OBJ_SOURCE)
+extract-openspecfun: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/source-extracted
+configure-openspecfun: extract-openspecfun
+compile-openspecfun: $(BUILDDIR)/$(OPENSPECFUN_SRC_DIR)/build-compiled
 check-openspecfun: compile-openspecfun
-install-openspecfun: $(OPENSPECFUN_OBJ_TARGET)
+install-openspecfun: $(build_prefix)/manifest/openspecfun

--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -25,13 +25,12 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled | $(build_prefix)/manifest
-	$(call make-install,patchelf-$(PATCHELF_VER),)
-	echo $(PATCHELF_VER) > $@
+$(eval $(call staged-install, \
+	patchelf,patchelf-$(PATCHELF_VER), \
+	MAKE_INSTALL,$$(LIBTOOL_CCLD),,))
 
 clean-patchelf:
-	-rm -f $(build_prefix)/manifest/patchelf \
-		$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured \
+	-rm $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured \
 		$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/patchelf-$(PATCHELF_VER) clean
 
@@ -40,9 +39,9 @@ distclean-patchelf:
 		$(SRCDIR)/srccache/patchelf-$(PATCHELF_VER) \
 		$(BUILDDIR)/patchelf-$(PATCHELF_VER)
 
+
 get-patchelf: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz
 extract-patchelf: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/source-extracted
 configure-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured
 compile-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 check-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-checked
-install-patchelf: $(build_prefix)/manifest/patchelf

--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -1,42 +1,48 @@
 ## patchelf ##
 
-PATCHELF_SOURCE := $(BUILDDIR)/patchelf-$(PATCHELF_VER)/src/patchelf
-PATCHELF_TARGET := $(build_depsbindir)/patchelf
-
 $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ http://nixos.org/releases/patchelf/patchelf-$(PATCHELF_VER)/patchelf-$(PATCHELF_VER).tar.gz
-$(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/configure: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz
+
+$(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/source-extracted: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) zxf $<
-	touch -c $@
-$(BUILDDIR)/patchelf-$(PATCHELF_VER)/config.status: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/configure | $(LIBCXX_DEPENDENCY)
+	echo 1 > $@
+
+$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/source-extracted | $(LIBCXX_DEPENDENCY)
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$< $(CONFIGURE_COMMON) LDFLAGS="$(CXXLDFLAGS)" CPPFLAGS="$(CPPFLAGS)"
-	touch -c $@
-$(PATCHELF_SOURCE): $(BUILDDIR)/patchelf-$(PATCHELF_VER)/config.status
+	$(dir $<)/configure $(CONFIGURE_COMMON) LDFLAGS="$(CXXLDFLAGS)" CPPFLAGS="$(CPPFLAGS)"
+	echo 1 > $@
+
+$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured
 	$(MAKE) -C $(dir $<)
-	touch -c $@
-$(BUILDDIR)/patchelf-$(PATCHELF_VER)/checked: $(PATCHELF_SOURCE)
+	echo 1 > $@
+
+$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-checked: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	# disabled due to bug in v0.6
 	#$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
-$(PATCHELF_TARGET): $(PATCHELF_SOURCE)
+
+$(build_prefix)/manifest/patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled | $(build_prefix)/manifest
 	$(call make-install,patchelf-$(PATCHELF_VER),)
-	touch -c $@
+	echo $(PATCHELF_VER) > $@
 
 clean-patchelf:
+	-rm -f $(build_prefix)/manifest/patchelf \
+		$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured \
+		$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/patchelf-$(PATCHELF_VER) clean
-	-rm -f $(PATCHELF_OBJ_TARGET)
+
 distclean-patchelf:
 	-rm -rf $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz \
 		$(SRCDIR)/srccache/patchelf-$(PATCHELF_VER) \
 		$(BUILDDIR)/patchelf-$(PATCHELF_VER)
 
 get-patchelf: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz
-configure-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/config.status
-compile-patchelf: $(PATCHELF_SOURCE)
-check-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/checked
-install-patchelf: $(PATCHELF_TARGET)
+extract-patchelf: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/source-extracted
+configure-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured
+compile-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
+check-patchelf: $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-checked
+install-patchelf: $(build_prefix)/manifest/patchelf

--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -6,6 +6,7 @@ $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz: | $(SRCDIR)/srccache
 $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/source-extracted: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER).tar.gz
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) zxf $<
+	touch -c $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/configure # old target
 	echo 1 > $@
 
 $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/source-extracted | $(LIBCXX_DEPENDENCY)

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -10,6 +10,7 @@ $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2: | $(SRCDIR)/srccache
 $(SRCDIR)/srccache/pcre2-$(PCRE_VER)/source-extracted: $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) jxf $(notdir $<)
+	touch -c $(SRCDIR)/srccache/pcre2-$(PCRE_VER)/configure # old target
 	echo $1 > $@
 
 $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured: $(SRCDIR)/srccache/pcre2-$(PCRE_VER)/source-extracted

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -30,22 +30,22 @@ endif
 endif
 	echo 1 > $@
 
-$(build_prefix)/manifest/pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled | $(build_prefix)/manifest
-	$(call make-install,pcre2-$(PCRE_VER),$(LIBTOOL_CCLD))
-	$(INSTALL_NAME_CMD)libpcre2-8.$(SHLIB_EXT) $(build_shlibdir)/libpcre2-8.$(SHLIB_EXT)
-	echo $(PCRE_VER) > $@
+$(eval $(call staged-install, \
+	pcre,pcre2-$$(PCRE_VER), \
+	MAKE_INSTALL,$$(LIBTOOL_CCLD),, \
+	$$(INSTALL_NAME_CMD)libpcre2-8.$$(SHLIB_EXT) $$(build_shlibdir)/libpcre2-8.$$(SHLIB_EXT)))
 
 clean-pcre:
-	-rm -f $(build_shlibdir)/libpcre* $(build_prefix)/manifest/pcre \
-		$(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
+	-rm $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/pcre2-$(PCRE_VER) clean
 
 distclean-pcre:
 	-rm -rf $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2 $(SRCDIR)/srccache/pcre2-$(PCRE_VER) $(BUILDDIR)/pcre2-$(PCRE_VER)
 
+
 get-pcre: $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2
 extract-pcre: $(SRCDIR)/srccache/pcre2-$(PCRE_VER)/source-extracted
 configure-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured
 compile-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
+fastcheck-pcre: check-pcre
 check-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-checked
-install-pcre: $(build_prefix)/manifest/pcre

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -1,46 +1,51 @@
 ## PCRE ##
 
-PCRE_SRC_TARGET := $(BUILDDIR)/pcre2-$(PCRE_VER)/.libs/libpcre2-8.$(SHLIB_EXT)
-PCRE_OBJ_TARGET := $(build_shlibdir)/libpcre2-8.$(SHLIB_EXT)
-
 # Force optimization for PCRE flags (Issue #11668)
 PCRE_CFLAGS := -O3
 PCRE_LDFLAGS := $(RPATH_ESCAPED_ORIGIN)
 
 $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-$(PCRE_VER).tar.bz2
-$(SRCDIR)/srccache/pcre2-$(PCRE_VER)/configure: $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2
+
+$(SRCDIR)/srccache/pcre2-$(PCRE_VER)/source-extracted: $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) jxf $(notdir $<)
-	touch -c $@
-$(BUILDDIR)/pcre2-$(PCRE_VER)/config.status: $(SRCDIR)/srccache/pcre2-$(PCRE_VER)/configure
+	echo $1 > $@
+
+$(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured: $(SRCDIR)/srccache/pcre2-$(PCRE_VER)/source-extracted
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$< $(CONFIGURE_COMMON) --enable-jit --includedir=$(build_includedir) CFLAGS="$(CFLAGS) $(PCRE_CFLAGS)" LDFLAGS="$(LDFLAGS) $(PCRE_LDFLAGS)"
-	touch -c $@
-$(PCRE_SRC_TARGET): $(BUILDDIR)/pcre2-$(PCRE_VER)/config.status
+	$(dir $<)/configure $(CONFIGURE_COMMON) --enable-jit --includedir=$(build_includedir) CFLAGS="$(CFLAGS) $(PCRE_CFLAGS)" LDFLAGS="$(LDFLAGS) $(PCRE_LDFLAGS)"
+	echo 1 > $@
+
+$(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured
 	$(MAKE) -C $(dir $<) $(LIBTOOL_CCLD)
-	touch -c $@
-$(BUILDDIR)/pcre2-$(PCRE_VER)/checked: $(PCRE_SRC_TARGET)
+	echo 1 > $@
+
+$(BUILDDIR)/pcre2-$(PCRE_VER)/checked: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 ifneq ($(OS),WINNT)
 	$(MAKE) -C $(dir $@) check -j1
 endif
 endif
 	echo 1 > $@
-$(PCRE_OBJ_TARGET): $(PCRE_SRC_TARGET)
+
+$(build_prefix)/manifest/pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled | $(build_prefix)/manifest
 	$(call make-install,pcre2-$(PCRE_VER),$(LIBTOOL_CCLD))
-	$(INSTALL_NAME_CMD)libpcre2-8.$(SHLIB_EXT) $@
-	touch -c $@
+	$(INSTALL_NAME_CMD)libpcre2-8.$(SHLIB_EXT) $(build_shlibdir)/libpcre2-8.$(SHLIB_EXT)
+	echo $(PCRE_VER) > $@
 
 clean-pcre:
+	-rm -f $(build_shlibdir)/libpcre* $(build_prefix)/manifest/pcre \
+		$(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/pcre2-$(PCRE_VER) clean
-	-rm -f $(build_shlibdir)/libpcre*
+
 distclean-pcre:
 	-rm -rf $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2 $(SRCDIR)/srccache/pcre2-$(PCRE_VER) $(BUILDDIR)/pcre2-$(PCRE_VER)
 
 get-pcre: $(SRCDIR)/srccache/pcre2-$(PCRE_VER).tar.bz2
-configure-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/config.status
-compile-pcre: $(PCRE_SRC_TARGET)
-check-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/checked
-install-pcre: $(PCRE_OBJ_TARGET)
+extract-pcre: $(SRCDIR)/srccache/pcre2-$(PCRE_VER)/source-extracted
+configure-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured
+compile-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
+check-pcre: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-checked
+install-pcre: $(build_prefix)/manifest/pcre

--- a/deps/suitesparse.mk
+++ b/deps/suitesparse.mk
@@ -73,12 +73,20 @@ $(build_prefix)/manifest/suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)
 	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(build_shlibdir)/libspqr.$(SHLIB_EXT)
 	echo $(SUITESPARSE_VER) > $@
 
-clean-suitesparse:
-	-rm -f $(build_prefix)/manifest/suitesparse $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled
+clean-suitesparse: clean-suitesparse-wrapper
+	-rm $(build_prefix)/manifest/suitesparse $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled
+	-rm $(build_shlibdir)/libsuitesparseconfig.$(SHLIB_EXT) \
+		$(build_shlibdir)/libamd.$(SHLIB_EXT) \
+		$(build_shlibdir)/libcolamd.$(SHLIB_EXT) \
+		$(build_shlibdir)/libcamd.$(SHLIB_EXT) \
+		$(build_shlibdir)/libccolamd.$(SHLIB_EXT) \
+		$(build_shlibdir)/libcholmod.$(SHLIB_EXT) \
+		$(build_shlibdir)/libumfpack.$(SHLIB_EXT) \
+		$(build_shlibdir)/libspqr.$(SHLIB_EXT)
 	-rm -fr $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/lib
 	-$(MAKE) -C $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER) clean
 
-distclean-suitesparse:
+distclean-suitesparse: clean-suitesparse-wrapper
 	-rm -rf $(SRCDIR)/srccache/SuiteSparse-$(SUITESPARSE_VER).tar.gz \
 		$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)
 
@@ -86,6 +94,7 @@ get-suitesparse: $(SRCDIR)/srccache/SuiteSparse-$(SUITESPARSE_VER).tar.gz
 extract-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/source-extracted
 configure-suitesparse: extract-suitesparse
 compile-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled
+fastcheck-suitesparse: #none
 check-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-checked
 install-suitesparse: $(build_prefix)/manifest/suitesparse install-suitesparse-wrapper
 
@@ -115,5 +124,6 @@ get-suitesparse-wrapper:
 extract-suitesparse-wrapper:
 configure-suitesparse-wrapper:
 compile-suitesparse-wrapper:
+fastcheck-suitesparse-wrapper: #none
 check-suitesparse-wrapper:
 install-suitesparse-wrapper: $(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT)

--- a/deps/suitesparse.mk
+++ b/deps/suitesparse.mk
@@ -1,8 +1,5 @@
 ## SUITESPARSE ##
 
-SUITESPARSE_OBJ_SOURCE := $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/UMFPACK/Lib/libumfpack.a
-SUITESPARSE_OBJ_TARGET := $(build_shlibdir)/libspqr.$(SHLIB_EXT)
-
 ifeq ($(USE_BLAS64), 1)
 UMFPACK_CONFIG := -DLONGBLAS='long long'
 CHOLMOD_CONFIG := -DLONGBLAS='long long'
@@ -29,32 +26,31 @@ SUITESPARSE_MFLAGS := CC="$(CC)" CXX="$(CXX)" F77="$(FC)" AR="$(AR)" RANLIB="$(R
 
 $(SRCDIR)/srccache/SuiteSparse-$(SUITESPARSE_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ http://faculty.cse.tamu.edu/davis/SuiteSparse/$(notdir $@)
-$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/Makefile: $(SRCDIR)/srccache/SuiteSparse-$(SUITESPARSE_VER).tar.gz
+
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/source-extracted: $(SRCDIR)/srccache/SuiteSparse-$(SUITESPARSE_VER).tar.gz
 	$(JLCHECKSUM) $<
 	mkdir -p $(dir $@)
 	$(TAR) -C $(dir $@) --strip-components 1 -zxf $<
-	touch -c $@
+	echo 1 > $@
 
-$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-winclang.patch-applied: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/Makefile
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-winclang.patch-applied: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/source-extracted
 	cd $(dir $@) && patch -p0 < $(SRCDIR)/patches/SuiteSparse-winclang.patch
 	echo 1 > $@
 
-ifeq ($(USE_ATLAS), 1)
-$(SUITESPARSE_OBJ_SOURCE): | $(ATLAS_OBJ_TARGET)
-endif
-
 ifeq ($(USE_SYSTEM_BLAS), 0)
-$(SUITESPARSE_OBJ_SOURCE): | $(OPENBLAS_OBJ_TARGET)
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: | $(build_prefix)/manifest/openblas
 else ifeq ($(USE_SYSTEM_LAPACK), 0)
-$(SUITESPARSE_OBJ_SOURCE): | $(LAPACK_OBJ_TARGET)
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: | $(build_prefix)/manifest/lapack
 endif
-$(SUITESPARSE_OBJ_SOURCE): $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/Makefile $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-winclang.patch-applied
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/source-extracted $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-winclang.patch-applied
 	$(MAKE) -C $(dir $<) library $(SUITESPARSE_MFLAGS)
-	touch -c $@
-$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/checked: $(SUITESPARSE_OBJ_SOURCE)
+	echo 1 > $@
+
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-checked: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled
 	$(MAKE) -C $(dir $@) default $(SUITESPARSE_MFLAGS)
-	touch $@
-$(SUITESPARSE_OBJ_TARGET): $(SUITESPARSE_OBJ_SOURCE)
+	echo 1 > $@
+
+$(build_prefix)/manifest/suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled | $(build_prefix)/manifest
 	mkdir -p $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/lib && \
 	cd $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/lib && \
 	rm -f *.a && \
@@ -75,20 +71,23 @@ $(SUITESPARSE_OBJ_TARGET): $(SUITESPARSE_OBJ_SOURCE)
 	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(build_shlibdir)/libumfpack.$(SHLIB_EXT) && \
 	$(CXX) -shared $(WHOLE_ARCHIVE) libspqr.a $(NO_WHOLE_ARCHIVE) -o $(build_shlibdir)/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(build_shlibdir) -lcholmod -lcolamd -lamd -lsuitesparseconfig $(LIBLAPACK) $(LIBBLAS) $(RPATH_ORIGIN) && \
 	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(build_shlibdir)/libspqr.$(SHLIB_EXT)
+	echo $(SUITESPARSE_VER) > $@
 
 clean-suitesparse:
-	-$(MAKE) -C $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER) clean
+	-rm -f $(build_prefix)/manifest/suitesparse $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled
 	-rm -fr $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/lib
-	-rm -f $(SUITESPARSE_OBJ_TARGET)
+	-$(MAKE) -C $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER) clean
+
 distclean-suitesparse:
 	-rm -rf $(SRCDIR)/srccache/SuiteSparse-$(SUITESPARSE_VER).tar.gz \
 		$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)
 
 get-suitesparse: $(SRCDIR)/srccache/SuiteSparse-$(SUITESPARSE_VER).tar.gz
-configure-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/Makefile
-compile-suitesparse: $(SUITESPARSE_OBJ_SOURCE)
-check-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/checked
-install-suitesparse: $(SUITESPARSE_OBJ_TARGET) install-suitesparse-wrapper
+extract-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/source-extracted
+configure-suitesparse: extract-suitesparse
+compile-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled
+check-suitesparse: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-checked
+install-suitesparse: $(build_prefix)/manifest/suitesparse install-suitesparse-wrapper
 
 # SUITESPARSE WRAPPER
 
@@ -98,7 +97,7 @@ SUITESPARSE_LIB := -lumfpack -lcholmod -lamd -lcamd -lcolamd -lspqr
 else
 SUITESPARSE_INC := -I $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/CHOLMOD/Include -I $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse_config -I $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SPQR/Include
 SUITESPARSE_LIB := -L$(build_shlibdir) -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
-$(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT):  $(SUITESPARSE_OBJ_TARGET)
+$(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT): $(build_prefix)/manifest/suitesparse
 endif
 
 $(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT): $(SRCDIR)/SuiteSparse_wrapper.c
@@ -109,9 +108,11 @@ $(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT): $(SRCDIR)/SuiteSparse_wra
 
 clean-suitesparse-wrapper:
 	-rm -f $(build_shlibdir)/libsuitesparse_wrapper.$(SHLIB_EXT)
+
 distclean-suitesparse-wrapper: clean-suitesparse-wrapper
 
 get-suitesparse-wrapper:
+extract-suitesparse-wrapper:
 configure-suitesparse-wrapper:
 compile-suitesparse-wrapper:
 check-suitesparse-wrapper:

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -1,0 +1,125 @@
+## Some shared configuration options ##
+
+CONFIGURE_COMMON := --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir)) --bindir=$(abspath $(build_depsbindir)) $(CUSTOM_LD_LIBRARY_PATH)
+ifneq ($(XC_HOST),)
+CONFIGURE_COMMON += --host=$(XC_HOST)
+endif
+ifeq ($(OS),WINNT)
+ifneq ($(USEMSVC), 1)
+CONFIGURE_COMMON += LDFLAGS="$(LDFLAGS) -Wl,--stack,8388608"
+endif
+endif
+CONFIGURE_COMMON += F77="$(FC)" CC="$(CC) $(DEPS_CFLAGS)" CXX="$(CXX) $(DEPS_CXXFLAGS)"
+
+CMAKE_CC_ARG := $(CC_ARG) $(DEPS_CFLAGS)
+CMAKE_CXX_ARG := $(CXX_ARG) $(DEPS_CXXFLAGS)
+
+CMAKE_COMMON := -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DCMAKE_PREFIX_PATH=$(build_prefix)
+CMAKE_COMMON += -DCMAKE_INSTALL_LIBDIR=$(build_libdir) -DCMAKE_INSTALL_BINDIR=$(build_bindir)
+CMAKE_COMMON += -DLIB_INSTALL_DIR=$(build_shlibdir)
+ifneq ($(VERBOSE), 0)
+CMAKE_COMMON += -DCMAKE_VERBOSE_MAKEFILE=ON
+endif
+# The call to which here is to work around https://cmake.org/Bug/view.php?id=14366
+CMAKE_COMMON += -DCMAKE_C_COMPILER="$$(which $(CC_BASE))"
+ifneq ($(strip $(CMAKE_CC_ARG)),)
+CMAKE_COMMON += -DCMAKE_C_COMPILER_ARG1="$(CMAKE_CC_ARG)"
+endif
+CMAKE_COMMON += -DCMAKE_CXX_COMPILER="$(CXX_BASE)"
+ifneq ($(strip $(CMAKE_CXX_ARG)),)
+CMAKE_COMMON += -DCMAKE_CXX_COMPILER_ARG1="$(CMAKE_CXX_ARG)"
+endif
+
+ifeq ($(OS),WINNT)
+CMAKE_COMMON += -DCMAKE_SYSTEM_NAME=Windows
+ifneq ($(BUILD_OS),WINNT)
+CMAKE_COMMON += -DCMAKE_RC_COMPILER="$$(which $(CROSS_COMPILE)windres)"
+endif
+endif
+
+# For now this is LLVM specific, but I expect it won't be in the future
+ifeq ($(LLVM_USE_CMAKE),1)
+ifeq ($(CMAKE_GENERATOR),Ninja)
+CMAKE_GENERATOR_COMMAND := -G Ninja
+else ifeq ($(CMAKE_GENERATOR),make)
+CMAKE_GENERATOR_COMMAND := -G "Unix Makefiles"
+else
+$(error Unknown CMake generator '$(CMAKE_GENERATOR)'. Options are 'Ninja' and 'make')
+endif
+endif
+
+# If the top-level Makefile is called with environment variables,
+# they will override the values passed above to ./configure
+MAKE_COMMON := DESTDIR="" prefix=$(build_prefix) bindir=$(build_depsbindir) libdir=$(build_libdir) shlibdir=$(build_shlibdir) libexecdir=$(build_libexecdir) datarootdir=$(build_datarootdir) includedir=$(build_includedir) sysconfdir=$(build_sysconfdir) O=
+
+
+#Platform specific flags
+
+ifeq ($(OS), WINNT)
+LIBTOOL_CCLD := CCLD="$(CC) -no-undefined -avoid-version"
+endif
+
+# Cross-deps flags
+
+USE_BLAS_FFLAGS :=
+ifeq ($(USE_BLAS64), 1)
+ifeq ($(USEIFC),1)
+USE_BLAS_FFLAGS += -i8
+else
+USE_BLAS_FFLAGS += -fdefault-integer-8
+endif
+endif
+
+ifeq ($(OS),Darwin)
+ifeq ($(USE_SYSTEM_BLAS),1)
+ifeq ($(USE_SYSTEM_LAPACK),0)
+USE_BLAS_FFLAGS += -cpp -ffree-line-length-0 -ffixed-line-length-0 \
+                   -Dsasum=sasum_gfort -Dscasum=scasum_gfort \
+                   -Dscnrm2=scnrm2_gfort -Dsdot=sdot_gfort \
+                   -Dsdsdot=sdsdot_gfort -Dsnrm2=snrm2_gfort \
+                   -Dcdotc=cdotc_gfort -Dcdotu=cdotu_gfort \
+                   -Dzdotc=zdotc_gfort -Dzdotu=zdotu_gfort \
+                   \
+                   -DSASUM=SASUM_GFORT -DSCASUM=SCASUM_GFORT \
+                   -DSCNRM2=SCNRM2_GFORT -DSDOT=SDOT_GFORT \
+                   -DSDSDOT=SDSDOT_GFORT -DSNRM2=SNRM2_GFORT \
+                   -DCDOTC=CDOTC_GFORT -DCDOTU=CDOTU_GFORT \
+                   -DZDOTC=ZDOTC_GFORT -DZDOTU=ZDOTU_GFORT
+endif
+endif
+endif
+
+
+## PATHS ##
+# sort is used to remove potential duplicates
+DIRS := $(sort $(build_bindir) $(build_depsbindir) $(build_libdir) $(build_includedir) $(build_sysconfdir) $(build_datarootdir) $(build_staging) $(build_prefix)/manifest)
+
+$(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
+
+$(build_prefix): | $(DIRS)
+$(eval $(call dir_target,$(SRCDIR)/srccache))
+
+
+## A rule for calling `make install` ##
+#	rule: dependencies
+#   	$(call make-install,rel-build-directory,add-args)
+#   	touch -c $@
+# this rule ensures that make install is more nearly atomic
+# so it's harder to get half-installed (or half-reinstalled) dependencies
+MAKE_DESTDIR = "$(build_staging)/$1"
+define staged-install
+	rm -rf $(build_staging)/$1
+	$2
+	mkdir -p $(build_prefix)
+	cp -af $(build_staging)/$1$(build_prefix)/* $(build_prefix)
+endef
+
+define make-install
+	$(call staged-install,$1,+$(MAKE) -C $(BUILDDIR)/$1 install $(MAKE_COMMON) $2 DESTDIR=$(call MAKE_DESTDIR,$1))
+endef
+
+## phony targets ##
+
+.PHONY: default get extract configure compile install cleanall distcleanall \
+	get-* extract-* configure-* compile-* check-* install-* \
+	clean-* distclean-* reinstall-* update-llvm

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -144,7 +144,9 @@ $$(build_staging)/$2.tgz: $$(BUILDDIR)/$2/build-compiled
 	rm -rf $$(build_staging)/$2
 	mkdir -p $$(build_staging)/$2$$(build_prefix)
 	$(call $3,$$(BUILDDIR)/$2,$$(build_staging)/$2,$4)
-	cd $$(build_staging)/$2$$(build_prefix) && tar -czf $$@ .
+	cd $$(build_staging)/$2$$(build_prefix) && tar -czf $$@.tmp .
+	rm -rf $$(build_staging)/$2
+	mv $$@.tmp $$@
 
 $$(build_prefix)/manifest/$(strip $1): $$(build_staging)/$2.tgz | $(build_prefix)/manifest
 	mkdir -p $$(build_prefix)

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -154,10 +154,10 @@ $$(build_prefix)/manifest/$(strip $1): $$(build_staging)/$2.tgz | $(build_prefix
 endef
 
 ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))
-#gnu make
+#gnu tar
 UNTAR = $(TAR) xzf
 else
-#bsd make
+#bsd tar
 UNTAR = $(TAR) xUzf
 endif
 

--- a/deps/tools/git-external.mk
+++ b/deps/tools/git-external.mk
@@ -33,6 +33,9 @@ $5/$1/.git/HEAD: | $$($2_SRC_FILE)/HEAD
 	-cd $$($2_SRC_FILE) && git fetch -q $$($2_GIT_URL) $$($2_BRANCH):remotes/origin/$$($2_BRANCH)
 	git clone -q --depth=10 --branch $$($2_BRANCH) $$($2_SRC_FILE) $5/$1
 	cd $5/$1 && git remote set-url origin $$($2_GIT_URL)
+#ifneq ($3,)
+	touch -c $5/$1/$3 # old target
+#endif
 	echo 1 > $5/$1/source-extracted
 ifneq ($5,$$(BUILDDIR))
 $$(BUILDDIR)/$1:

--- a/deps/tools/git-external.mk
+++ b/deps/tools/git-external.mk
@@ -3,8 +3,8 @@
 #   $(eval $(call git-external,dirname,VARNAME,file_from_download,file_from_compile,SRCDIR)
 # dirname is the folder name to create
 # VARNAME is the uppercased variable name prefix
-# file_from_download is the name of a file inside the git repo to indicate when it's cloned (relative to dirname)
-# file_from_compile is the rule to run to compile the dependency (relative to dirname)
+# file_from_download (deprecated)
+# file_from_compile (deprecated)
 # SRCDIR is either $(SRCDIR)/srccache or $(BUILDDIR), depending on whether the target supports out-of-tree builds
 #
 # also, in a file named dirname.version, define variables VARNAME_BRANCH and VARNAME_SHA1
@@ -17,7 +17,7 @@
 #   VARNAME_SRC_DIR = source directory for the output, relative to $(SRCDIR)/srccache or $(BUILDDIR)
 #   VARNAME_SRC_FILE = target file for make get-VARNAME target
 #   dirname:
-#   dirname/file_from_download:
+#   dirname/source-extracted:
 #   distclean-dirname:
 #
 define git-external
@@ -33,20 +33,20 @@ $5/$1/.git/HEAD: | $$($2_SRC_FILE)/HEAD
 	-cd $$($2_SRC_FILE) && git fetch -q $$($2_GIT_URL) $$($2_BRANCH):remotes/origin/$$($2_BRANCH)
 	git clone -q --depth=10 --branch $$($2_BRANCH) $$($2_SRC_FILE) $5/$1
 	cd $5/$1 && git remote set-url origin $$($2_GIT_URL)
-	touch -c $5/$1/$3
+	echo 1 > $5/$1/source-extracted
 ifneq ($5,$$(BUILDDIR))
 $$(BUILDDIR)/$1:
 	mkdir -p $$@
-$5/$1/$3: | $$(BUILDDIR)/$1
+$5/$1/source-extracted: | $$(BUILDDIR)/$1
 endif
-$5/$1/$3: $$(SRCDIR)/$1.version | $5/$1/.git/HEAD
+$5/$1/source-extracted: $$(SRCDIR)/$1.version | $5/$1/.git/HEAD
 	# try to update the cache, if that fails, attempt to continue anyways (the ref might already be local)
 	-cd $$(SRCDIR)/srccache/$1.git && git fetch -q $$($2_GIT_URL) $$($2_BRANCH):remotes/origin/$$($2_BRANCH)
 	cd $5/$1 && git fetch -q $$(SRCDIR)/srccache/$1.git remotes/origin/$$($2_BRANCH):remotes/origin/$$($2_BRANCH)
 	cd $5/$1 && git checkout -q --detach $$($2_SHA1)
 	@[ '$$($2_SHA1)' = "$$$$(cd $5/$1 && git show -s --format='%H' HEAD)" ] || echo $$(WARNCOLOR)'==> warning: SHA1 hash did not match $1.version file'$$(ENDCOLOR)
-	touch -c $$@
-$5/$1/$4: $5/$1/.git/HEAD
+	echo 1 > $$@
+$5/$1/source-compiled: $5/$1/.git/HEAD
 $$($2_SRC_FILE): | $$($2_SRC_FILE)/HEAD
 	touch -c $$@
 
@@ -56,11 +56,12 @@ $2_SRC_DIR := $1-$$($2_SHA1)
 $2_SRC_FILE := $$(SRCDIR)/srccache/$$($2_SRC_DIR).tar.gz
 $$($2_SRC_FILE): | $$(SRCDIR)/srccache
 	$$(JLDOWNLOAD) $$@ $$(call $2_TAR_URL,$$($2_SHA1))
-$5/$$($2_SRC_DIR)/$3: $$($2_SRC_FILE)
+$5/$$($2_SRC_DIR)/source-extracted: $$($2_SRC_FILE)
 	$$(JLCHECKSUM) $$<
-	mkdir -p $$(dir $$@) && \
+	-rm -r $$(dir $$@)
+	mkdir -p $$(dir $$@)
 	$(TAR) -C $$(dir $$@) --strip-components 1 -xf $$<
-	touch -c $$@
+	echo 1 > $$@
 endif # DEPS_GIT
 
 distclean-$1:

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -5,9 +5,11 @@ LIBUNWIND_CPPFLAGS :=
 
 $(SRCDIR)/srccache/libunwind-$(UNWIND_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://s3.amazonaws.com/julialang/src/libunwind-$(UNWIND_VER).tar.gz
+
 $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER).tar.gz
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) xfz $<
+	touch -c $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/configure # old target
 	echo 1 > $@
 
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -1,87 +1,93 @@
 ## UNWIND ##
 
-LIBUNWIND_TARGET_OBJ := $(build_libdir)/libunwind.a
-LIBUNWIND_TARGET_SOURCE := $(BUILDDIR)/libunwind-$(UNWIND_VER)/src/.libs/libunwind.a
 LIBUNWIND_CFLAGS := -U_FORTIFY_SOURCE $(fPIC)
 LIBUNWIND_CPPFLAGS :=
 
 $(SRCDIR)/srccache/libunwind-$(UNWIND_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://s3.amazonaws.com/julialang/src/libunwind-$(UNWIND_VER).tar.gz
-$(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/configure: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER).tar.gz
+$(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER).tar.gz
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) xfz $<
-	touch -c $@
-$(BUILDDIR)/libunwind-$(UNWIND_VER)/config.status: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/configure
+	echo 1 > $@
+
+$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$< $(CONFIGURE_COMMON) CPPFLAGS="$(CPPFLAGS) $(LIBUNWIND_CPPFLAGS)" CFLAGS="$(CFLAGS) $(LIBUNWIND_CFLAGS)" --disable-shared --disable-minidebuginfo
-	touch -c $@
-$(LIBUNWIND_TARGET_SOURCE): $(BUILDDIR)/libunwind-$(UNWIND_VER)/config.status
+	$(dir $<)/configure $(CONFIGURE_COMMON) CPPFLAGS="$(CPPFLAGS) $(LIBUNWIND_CPPFLAGS)" CFLAGS="$(CFLAGS) $(LIBUNWIND_CFLAGS)" --disable-shared --disable-minidebuginfo
+	echo 1 > $@
+
+$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured
 	$(MAKE) -C $(dir $<)
-	touch -c $@
-$(BUILDDIR)/libunwind-$(UNWIND_VER)/checked: $(LIBUNWIND_TARGET_SOURCE)
+	echo 1 > $@
+
+$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-checked: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
+
 #todo: libunwind tests are known to fail, so they aren't run
-$(LIBUNWIND_TARGET_OBJ): $(LIBUNWIND_TARGET_SOURCE)
+$(build_prefix)/manifest/unwind: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled | $(build_prefix)/manifest
 	$(call make-install,libunwind-$(UNWIND_VER),)
 ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
 	@# workaround for configure script bug
 	mv $(build_prefix)/lib64/libunwind*.a $(build_libdir)
 endif
-	touch $@
+	echo $(UNWIND_VER) > $@
 
 clean-unwind:
+	-rm -f $(build_prefix)/manifest/unwind $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/libunwind-$(UNWIND_VER) clean
-	-rm -f $(LIBUNWIND_TARGET_OBJ) $(LIBUNWIND_TARGET_SOURCE)
+
 distclean-unwind:
 	-rm -rf $(SRCDIR)/srccache/libunwind-$(UNWIND_VER).tar.gz \
 		$(SRCDIR)/srccache/libunwind-$(UNWIND_VER) \
 		$(BUILDDIR)/libunwind-$(UNWIND_VER)
 
 get-unwind: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER).tar.gz
-configure-unwind: $(BUILDDIR)/libunwind-$(UNWIND_VER)/config.status
-compile-unwind: $(LIBUNWIND_TARGET_SOURCE)
-check-unwind: $(BUILDDIR)/libunwind-$(UNWIND_VER)/checked
-install-unwind: $(LIBUNWIND_TARGET_OBJ)
+extract-unwind: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted
+configure-unwind: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured
+compile-unwind: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
+check-unwind: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-checked
+install-unwind: $(build_prefix)/manifest/unwind
+
 
 ## OS X Unwind ##
 
 OSXUNWIND_FLAGS := ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) CFLAGS="$(CFLAGS) -ggdb3 -O0" CXXFLAGS="$(CXXFLAGS) -ggdb3 -O0" SFLAGS="-ggdb3" LDFLAGS="$(LDFLAGS) -Wl,-macosx_version_min,10.7"
 
-OSXUNWIND_OBJ_TARGET := $(build_shlibdir)/libosxunwind.$(SHLIB_EXT)
-OSXUNWIND_OBJ_SOURCE := $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/libosxunwind.$(SHLIB_EXT)
-
 $(SRCDIR)/srccache/libosxunwind-$(OSXUNWIND_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://github.com/JuliaLang/libosxunwind/archive/v$(OSXUNWIND_VER).tar.gz
 
-$(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/Makefile: $(SRCDIR)/srccache/libosxunwind-$(OSXUNWIND_VER).tar.gz
+$(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/source-extracted: $(SRCDIR)/srccache/libosxunwind-$(OSXUNWIND_VER).tar.gz
 	$(JLCHECKSUM) $<
 	mkdir -p $(BUILDDIR)
 	cd $(BUILDDIR) && $(TAR) xfz $<
-	touch -c $@
+	echo 1 > $@
 
-$(OSXUNWIND_OBJ_SOURCE): $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/Makefile
+$(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/build-compiled: $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/source-extracted
 	$(MAKE) -C $(dir $<) $(OSXUNWIND_FLAGS)
-	touch -c $@
-$(OSXUNWIND_OBJ_TARGET): $(OSXUNWIND_OBJ_SOURCE) | $(build_shlibdir)
-	cp $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/libosxunwind.a $(build_libdir)/libosxunwind.a
-	cp $< $@
-	cp -R $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/include/* $(build_includedir)
-	$(INSTALL_NAME_CMD)libosxunwind.$(SHLIB_EXT) $@
+	echo 1 > $@
+
+$(build_prefix)/manifest/osxunwind: $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/build-compiled | $(build_shlibdir) $(build_prefix)/manifest
+	cp $(dir $<)/libosxunwind.a $(build_libdir)/libosxunwind.a
+	cp $(dir $<)/libosxunwind.$(SHLIB_EXT) $(build_shlibdir)/libosxunwind.$(SHLIB_EXT)
+	cp -R $(dir $<)/include/* $(build_includedir)
+	$(INSTALL_NAME_CMD)libosxunwind.$(SHLIB_EXT) $(build_shlibdir)/libosxunwind.$(SHLIB_EXT)
+	echo $(OSXUNWIND_VER) > $(build_prefix)/manifest/osxunwind
 
 clean-osxunwind:
+	-rm $(build_prefix)/manifest/libuv $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER) clean $(OSXUNWIND_FLAGS)
-	-rm $(OSXUNWIND_OBJ_TARGET)
+
 distclean-osxunwind:
 	-rm -rf $(SRCDIR)/srccache/libosxunwind-$(OSXUNWIND_VER).tar.gz \
 		$(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)
 
 
 get-osxunwind: $(SRCDIR)/srccache/libosxunwind-$(OSXUNWIND_VER).tar.gz
-configure-osxunwind: $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/Makefile
-compile-osxunwind: $(OSXUNWIND_OBJ_SOURCE)
+extract-osxunwind: $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/source-extracted
+configure-osxunwind: extract-osxunwind
+compile-osxunwind: $(BUILDDIR)/libosxunwind-$(OSXUNWIND_VER)/build-compiled
 check-osxunwind: compile-osxunwind
-install-osxunwind: $(OSXUNWIND_OBJ_TARGET)
+install-osxunwind: $(build_prefix)/manifest/osxunwind

--- a/deps/utf8proc.mk
+++ b/deps/utf8proc.mk
@@ -1,34 +1,40 @@
 ## UTF8PROC ##
 UTF8PROC_GIT_URL := git://github.com/JuliaLang/utf8proc.git
 UTF8PROC_TAR_URL = https://api.github.com/repos/JuliaLang/utf8proc/tarball/$1
-$(eval $(call git-external,utf8proc,UTF8PROC,Makefile,libutf8proc.a,$(BUILDDIR)))
+$(eval $(call git-external,utf8proc,UTF8PROC,,,$(BUILDDIR)))
 
-UTF8PROC_SRC_TARGET := $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/libutf8proc.a
 UTF8PROC_OBJ_LIB    := $(build_libdir)/libutf8proc.a
 UTF8PROC_OBJ_HEADER := $(build_includedir)/utf8proc.h
-UTF8PROC_OBJ_TARGET := $(UTF8PROC_OBJ_LIB) $(UTF8PROC_OBJ_HEADER)
 UTF8PROC_CFLAGS     := -O2
 UTF8PROC_MFLAGS     := CC="$(CC) $(DEPS_CFLAGS)" CFLAGS="$(CFLAGS) $(UTF8PROC_CFLAGS)" PICFLAG="$(fPIC)" AR="$(AR)"
 
-$(UTF8PROC_SRC_TARGET): $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/Makefile
+$(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/source-extracted
 	$(MAKE) -C $(dir $<) $(UTF8PROC_MFLAGS) libutf8proc.a
-	touch -c $@
-$(BUILDDIR)/$(UTF8PROC_SRC_DIR)/checked: $(UTF8PROC_SRC_TARGET)
+	echo 1 > $@
+
+$(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-checked: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) $(UTF8PROC_MFLAGS) check
 endif
 	echo 1 > $@
-$(UTF8PROC_OBJ_LIB): $(UTF8PROC_SRC_TARGET)
-	cp -f $< $@
-$(UTF8PROC_OBJ_HEADER): $(UTF8PROC_SRC_TARGET)
+
+$(UTF8PROC_OBJ_LIB): $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
+	cp -f $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/libutf8proc.a $@
+
+$(UTF8PROC_OBJ_HEADER): $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
 	cp -f $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/utf8proc.h $@
 
+$(build_prefix)/manifest/utf8proc : $(UTF8PROC_OBJ_LIB) $(UTF8PROC_OBJ_HEADER) | $(build_prefix)/manifest
+	echo $(UTF8PROC_SHA1) > $@
+
 clean-utf8proc:
-	-$(MAKE) -C $(BUILDDIR)/$(UTF8PROC_SRC_DIR) clean
+	-rm -rf $(build_prefix)/manifest/utf8proc $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
 	-rm -rf $(build_libdir)/libutf8proc.a $(build_includedir)/utf8proc.h
+	-$(MAKE) -C $(BUILDDIR)/$(UTF8PROC_SRC_DIR) clean
 
 get-utf8proc: $(UTF8PROC_SRC_FILE)
-configure-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/Makefile
-compile-utf8proc: $(UTF8PROC_SRC_TARGET)
-check-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/checked
-install-utf8proc: $(UTF8PROC_OBJ_TARGET)
+extract-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/source-extracted
+configure-utf8proc: extract-utf8proc
+compile-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
+check-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-checked
+install-utf8proc: $(build_prefix)/manifest/utf8proc

--- a/deps/utf8proc.mk
+++ b/deps/utf8proc.mk
@@ -18,23 +18,23 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-$(UTF8PROC_OBJ_LIB): $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
-	cp -f $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/libutf8proc.a $@
-
-$(UTF8PROC_OBJ_HEADER): $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
-	cp -f $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/utf8proc.h $@
-
-$(build_prefix)/manifest/utf8proc : $(UTF8PROC_OBJ_LIB) $(UTF8PROC_OBJ_HEADER) | $(build_prefix)/manifest
-	echo $(UTF8PROC_SHA1) > $@
+define UTF8PROC_INSTALL
+	mkdir -p $2/$$(build_includedir) $2/$$(build_libdir)
+	cp $1/utf8proc.h $2/$$(build_includedir)
+	cp $1/libutf8proc.a $2/$$(build_libdir)
+endef
+$(eval $(call staged-install, \
+	utf8proc,$(UTF8PROC_SRC_DIR), \
+	UTF8PROC_INSTALL,,,))
 
 clean-utf8proc:
-	-rm -rf $(build_prefix)/manifest/utf8proc $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
-	-rm -rf $(build_libdir)/libutf8proc.a $(build_includedir)/utf8proc.h
+	-rm $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(UTF8PROC_SRC_DIR) clean
 
 get-utf8proc: $(UTF8PROC_SRC_FILE)
 extract-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/source-extracted
 configure-utf8proc: extract-utf8proc
 compile-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
+# utf8proc tests disabled since they require a download
+fastcheck-utf8proc: #check-utf8proc
 check-utf8proc: $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-checked
-install-utf8proc: $(build_prefix)/manifest/utf8proc

--- a/deps/virtualenv.mk
+++ b/deps/virtualenv.mk
@@ -32,5 +32,6 @@ get-virtualenv: $(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER).tar.gz
 extract-virtualenv: $(VIRTUALENV_SOURCE)
 configure-virtualenv: extract-virtualenv
 compile-virtualenv: configure-virtualenv
+fastcheck-virtualenv: check-virtualenv
 check-virtualenv: compile-virtualenv
 install-virtualenv: $(VIRTUALENV_TARGET)

--- a/deps/virtualenv.mk
+++ b/deps/virtualenv.mk
@@ -1,14 +1,19 @@
-## virtualenv
+## virtualenv ##
+
+# this target doesn't follow the same rules as the others
+# since it is so simple, and it doesn't need to be actually installed
 
 VIRTUALENV_SOURCE := $(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER)/virtualenv.py
 VIRTUALENV_TARGET := $(BUILDDIR)/julia-env
 
 $(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER).tar.gz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://pypi.python.org/packages/source/v/virtualenv/$(notdir $@)
+
 $(VIRTUALENV_SOURCE): $(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER).tar.gz
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) zxf $<
 	touch -c $@
+
 $(VIRTUALENV_TARGET): $(VIRTUALENV_SOURCE)
 	"$(shell $(SRCDIR)/tools/find_python2)" $< $@
 ifeq ($(BUILD_OS), WINNT)
@@ -18,12 +23,14 @@ endif
 
 clean-virtualenv:
 	-rm -rf $(VIRTUALENV_TARGET)
+
 distclean-virtualenv: clean-virtualenv
 	-rm -rf $(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER).tar.gz \
 		$(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER)
 
 get-virtualenv: $(SRCDIR)/srccache/virtualenv-$(VIRTUALENV_VER).tar.gz
-configure-virtualenv: get-virtualenv
-compile-virtualenv: $(VIRTUALENV_SOURCE)
+extract-virtualenv: $(VIRTUALENV_SOURCE)
+configure-virtualenv: extract-virtualenv
+compile-virtualenv: configure-virtualenv
 check-virtualenv: compile-virtualenv
 install-virtualenv: $(VIRTUALENV_TARGET)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,7 +18,7 @@ ALLSPHINXOPTS    := -d $(BUILDDIR)/_build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINX
 I18NSPHINXOPTS   := $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 ifeq ($(abspath .),$(abspath $(SRCDIR)))
-JULIA_ENV        := $(BUILDDIR)/../deps/build/julia-env
+JULIA_ENV        := $(BUILDDIR)/../deps/scratch/julia-env
 else
 JULIA_ENV        := $(BUILDDIR)/../deps/julia-env
 endif


### PR DESCRIPTION
using a consistent mapping between target names reduces the coupling between targets
and should make it easier to add features like reinstall, uninstall, etc.

and it fixes #17671 and #17282 

while the diff is large, this essentially just a mechanical change.

all targets (except get) now use secondary file targets, giving a simple mapping from the PHONY targets, and allows another target to reference the manifest file directly rather than using the OBJ_TARGET variable:
extract: srccache/LIB/source-extracted
configure: bulid/LIB/build-configured
compile: build/LIB/build-compiled
check: build/LIB/build-checked
install: usr/manifest/LIB

this allows more accurate tracking of when a build stage has completed, and a predictable way for the user to force a build stage to restart (by removing or touching the corresponding file)

(also killed of the atlas target, since it hasn't been maintained in several years)
