### PR TITLE
Fix `make -C doc linkcheck` by updating redirecting links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ First, acquire the source code by cloning the git repository:
 
 Be sure to also configure your system to use the appropriate proxy settings, e.g. by setting the `https_proxy` and `http_proxy` variables.)
 
-By default you will be building the latest unstable version of Julia. However, most users should use the most recent stable version of Julia, which is currently the `0.4` series of releases. You can get this version by changing to the Julia directory and running
+By default you will be building the latest unstable version of Julia. However, most users should use the most recent stable version of Julia, which is currently the `0.5` series of releases. You can get this version by changing to the Julia directory and running
 
-    git checkout release-0.4
+    git checkout release-0.5
 
 Now run `make` to build the `julia` executable. To perform a parallel build, use `make -j N` and supply the maximum number of concurrent processes. (See [Platform Specific Build Notes](https://github.com/JuliaLang/julia#platform-specific-build-notes) for details.)
 When compiled the first time, it will automatically download and build its [external dependencies](#Required-Build-Tools-External-Libraries).

--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -23,6 +23,8 @@ function without causing the main `julia` thread to become blocked. Concurrency
 is limited by size of the libuv thread pool, which defaults to 4 threads but
 can be increased by setting the `UV_THREADPOOL_SIZE` environment variable and
 restarting the `julia` process.
+
+Note that the called function should never call back into Julia.
 """
 macro threadcall(f, rettype, argtypes, argvals...)
     # check for usage errors

--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -56,8 +56,8 @@ cp julia-$version-win32.exe julia-$majmin-latest-win32.exe
 echo "Note: if windows code signing is not working on the buildbots, then the"
 echo "checksums need to be re-calculated after the binaries are manually signed!"
 
-shasum -a 256 julia-$version* | grep -v sha256 | grep -v md5 > julia-$version.sha256
-md5sum julia-$version* | grep -v sha256 | grep -v md5 > julia-$version.md5
+shasum -a 256 julia-$version* | grep -v -e sha256 -e md5 -e asc > julia-$version.sha256
+md5sum julia-$version* | grep -v -e sha256 -e md5 -e asc > julia-$version.md5
 
 gpg -u julia --armor --detach-sig julia-$version-full.tar.gz
 gpg -u julia --armor --detach-sig julia-$version.tar.gz

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -30,7 +30,7 @@ $(ACTIVATE):
 	touch -c $@
 
 $(SPHINX_BUILD): $(SRCDIR)/requirements.txt $(ACTIVATE)
-	. $(ACTIVATE) && pip install sphinx==1.3.1 \
+	. $(ACTIVATE) && pip install sphinx==1.4.5 \
 	              && pip install -r $<
 	touch -c $@
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,6 +96,9 @@ pygments_style = 'sphinx'
 primary_domain = 'jl'
 highlight_language = 'julia'
 
+# Flaky links to ignore in linkcheck - permissions or empty returns
+linkcheck_ignore = ['https://www.appveyor.com',
+    'https://bugs.kde.org/show_bug.cgi\?id=136779']
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/doc/devdocs/backtraces.rst
+++ b/doc/devdocs/backtraces.rst
@@ -104,4 +104,4 @@ A few terms have been used as shorthand in this guide:
 * ``<julia_root>`` refers to the root directory of the Julia source tree; e.g. it should contain folders such as ``base``, ``deps``, ``src``, ``test``, etc.....
 
 .. _gist: https://gist.github.com
-.. _issue: https://github.com/JuliaLang/julia/issues?state=open
+.. _issue: https://github.com/JuliaLang/julia/issues?q=is%3Aopen

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -41,7 +41,7 @@ functions in the Julia runtime, or functions in an application linked to
 Julia.
 
 By default, Fortran compilers `generate mangled names
-<https://en.wikipedia.org/wiki/Name_mangling#Name_mangling_in_Fortran>`_
+<https://en.wikipedia.org/wiki/Name_mangling#Fortran>`_
 (for example, converting function names to lowercase or uppercase,
 often appending an underscore), and so to call a Fortran function via
 :func:`ccall` you must pass the mangled identifier corresponding to the rule
@@ -1094,7 +1094,7 @@ More About Callbacks
 --------------------
 
 For more details on how to pass callbacks to C libraries, see this
-`blog post <http://julialang.org/blog/2013/05/callback/>`_.
+`blog post <http://julialang.org/blog/2013/05/callback>`_.
 
 C++
 ---

--- a/doc/manual/dates.rst
+++ b/doc/manual/dates.rst
@@ -238,7 +238,7 @@ Similarly for the :func:`monthname` function, a mapping of ``locale=>Dict{Int,St
 TimeType-Period Arithmetic
 --------------------------
 
-It's good practice when using any language/date framework to be familiar with how date-period arithmetic is handled as there are some `tricky issues <http://codeblog.jonskeet.uk/2010/12/01/the-joys-of-date-time-arithmetic>`_ to deal with (though much less so for day-precision types).
+It's good practice when using any language/date framework to be familiar with how date-period arithmetic is handled as there are some `tricky issues <https://codeblog.jonskeet.uk/2010/12/01/the-joys-of-date-time-arithmetic/>`_ to deal with (though much less so for day-precision types).
 
 The :mod:`Dates` module approach tries to follow the simple principle of trying to change as little as possible when doing :class:`Period` arithmetic. This approach is also often known as *calendrical* arithmetic or what you would probably guess if someone were to ask you the same calculation in a conversation. Why all the fuss about this? Let's take a classic example: add 1 month to January 31st, 2014. What's the answer? Javascript will say `March 3 <http://www.markhneedham.com/blog/2009/01/07/javascript-add-a-month-to-a-date/>`_ (assumes 31 days). PHP says `March 2 <http://stackoverflow.com/questions/5760262/php-adding-months-to-a-date-while-not-exceeding-the-last-day-of-the-month>`_ (assumes 30 days). The fact is, there is no right answer. In the :mod:`Dates` module, it gives the result of February 28th. How does it figure that out? I like to think of the classic 7-7-7 gambling game in casinos.
 

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -162,7 +162,7 @@ In addition to this manual, there are various other resources that may
 help new users get started with Julia:
 
 - `Julia and IJulia cheatsheet <http://math.mit.edu/~stevenj/Julia-cheatsheet.pdf>`_
-- `Learn Julia in a few minutes <http://learnxinyminutes.com/docs/julia/>`_
+- `Learn Julia in a few minutes <https://learnxinyminutes.com/docs/julia/>`_
 - `Learn Julia the Hard Way <https://github.com/chrisvoncsefalvay/learn-julia-the-hard-way>`_
 - `Julia by Example <http://samuelcolvin.github.io/JuliaByExample/>`_
 - `Hands-on Julia <https://github.com/dpsanders/hands_on_julia>`_

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -554,11 +554,11 @@ computation, and also in the following references:
 - For even more extensive documentation of the history of, rationale for,
   and issues with floating-point numbers, as well as discussion of many other
   topics in numerical computing, see the `collected writings
-  <http://www.cs.berkeley.edu/~wkahan/>`_ of `William Kahan
+  <https://people.eecs.berkeley.edu/~wkahan/>`_ of `William Kahan
   <https://en.wikipedia.org/wiki/William_Kahan>`_, commonly known as the "Father
   of Floating-Point". Of particular interest may be `An Interview with the Old
   Man of Floating-Point
-  <http://www.cs.berkeley.edu/~wkahan/ieee754status/754story.html>`_.
+  <https://people.eecs.berkeley.edu/~wkahan/ieee754status/754story.html>`_.
 
 .. _man-arbitrary-precision-arithmetic:
 

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -196,7 +196,7 @@ To get the latest and greatest versions of all your packages, just do :func:`Pkg
 
 The first step of updating packages is to pull new changes to ``~/.julia/v0.4/METADATA`` and see if any new registered package versions have been published.
 After this, :func:`Pkg.update` attempts to update packages that are checked out on a branch and not dirty (i.e. no changes have been made to files tracked by git) by pulling changes from the package's upstream repository.
-Upstream changes will only be applied if no merging or rebasing is necessary – i.e. if the branch can be `"fast-forwarded" <http://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging>`_.
+Upstream changes will only be applied if no merging or rebasing is necessary – i.e. if the branch can be `"fast-forwarded" <https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging>`_.
 If the branch cannot be fast-forwarded, it is assumed that you're working on it and will update the repository yourself.
 
 Finally, the update process recomputes an optimal set of package versions to have installed to satisfy your top-level requirements and the requirements of "fixed" packages.
@@ -360,7 +360,7 @@ We recommend that you create a `free account <https://github.com/join>`_ on GitH
 
 where ``USERNAME`` is your actual GitHub user name.
 Once you do this, the package manager knows your GitHub user name and can configure things accordingly.
-You should also `upload <https://github.com/settings/ssh>`_ your public SSH key to GitHub and set up an `SSH agent <http://linux.die.net/man/1/ssh-agent>`_ on your development machine so that you can push changes with minimal hassle.
+You should also `upload <https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fsettings%2Fssh>`_ your public SSH key to GitHub and set up an `SSH agent <http://linux.die.net/man/1/ssh-agent>`_ on your development machine so that you can push changes with minimal hassle.
 In the future, we will make this system extensible and support other common git hosting options like `BitBucket <https://bitbucket.org>`_ and allow developers to choose their favorite.
 Since the package development functions has been moved to the `PkgDev <https://github.com/JuliaLang/PkgDev.jl>`_ package, you need to run ``Pkg.add("PkgDev"); import PkgDev`` to access the functions starting with ``PkgDev.`` in the document below.
 
@@ -455,7 +455,7 @@ are several possible approaches, here is one that is widely used:
   ``fixbar``). By creating a branch, you ensure that you can easily go
   back and forth between your new work and the current ``master``
   branch (see
-  `<http://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell>`_).
+  `<https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell>`_).
 
   If you forget to do this step until after you've already made some
   changes, don't worry: see :ref:`more detail about branching
@@ -486,7 +486,7 @@ are several possible approaches, here is one that is widely used:
     ``src/`` folder.
 
 
-- Commit your changes: see `<http://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository>`_.
+- Commit your changes: see `<https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository>`_.
 
 - Submit your changes: From the Julia prompt, type
   :func:`PkgDev.submit("Foo") <PkgDev.submit>`. This will push your changes to your
@@ -555,7 +555,7 @@ following procedure:
   until you have resolved the problems, or you may lose your changes.
 - *Reset* ``master`` (your current branch) back to an earlier state
   with ``git reset --hard origin/master`` (see
-  `<http://git-scm.com/blog/2011/07/11/reset.html>`_).
+  `<https://git-scm.com/blog/2011/07/11/reset.html>`_).
 
 This requires a bit more familiarity with git, so it's much better to
 get in the habit of creating a branch at the outset.
@@ -583,7 +583,7 @@ quite simple but your commit history looks like this::
 
 This gets into the territory of more advanced git usage, and you're
 encouraged to do some reading
-(`<http://git-scm.com/book/en/v2/Git-Branching-Rebasing>`_).  However,
+(`<https://git-scm.com/book/en/v2/Git-Branching-Rebasing>`_).  However,
 a brief summary of the procedure is as follows:
 
 - To protect yourself from error, start from your ``fixbar`` branch
@@ -767,7 +767,7 @@ different license, you can ask us to add it to the package generator, or just pi
 
 If you created a GitHub account and configured git to know about it, :func:`PkgDev.generate` will set an appropriate origin URL
 for you.  It will also automatically generate a ``.travis.yml`` file for using the `Travis <https://travis-ci.org>`_ automated
-testing service, and an ``appveyor.yml`` file for using `AppVeyor <http://appveyor.com>`_.  You will have to enable testing on
+testing service, and an ``appveyor.yml`` file for using `AppVeyor <https://www.appveyor.com>`_.  You will have to enable testing on
 the Travis and AppVeyor websites for your package repository, but once you've done that, it will already have working tests.
 Of course, all the default testing does is verify that ``using FooBar`` in Julia works.
 
@@ -840,7 +840,7 @@ on GitHub, push your changes to your fork, and open a pull request::
     then you may have encountered an issue from using the GitHub API on
     multiple systems. The solution is to delete the "Julia Package Manager"
     personal access token `from your Github account
-    <https://github.com/settings/tokens>`_ and try again.
+    <https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fsettings%2Ftokens>`_ and try again.
 
     Other failures may require you to circumvent :func:`PkgDev.publish` by
     `creating a pull request on GitHub
@@ -915,7 +915,7 @@ that copy exists, you can push your local changes to your copy
 (just like any other GitHub project).
 
 
-1. go to `<https://github.com/JuliaLang/METADATA.jl/fork>`_ and create your own
+1. go to `<https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2FJuliaLang%2FMETADATA.jl%2Ffork>`_ and create your own
 fork.
 
 2. add your fork as a remote repository for the METADATA

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -22,7 +22,7 @@ The :func:`Pkg.status` function prints out a summary of the state of packages yo
 Initially, you'll have no packages installed::
 
     julia> Pkg.status()
-    INFO: Initializing package repository /Users/stefan/.julia/v0.4
+    INFO: Initializing package repository /Users/stefan/.julia/v0.5
     INFO: Cloning METADATA from git://github.com/JuliaLang/METADATA.jl
     No packages installed.
 
@@ -56,7 +56,7 @@ This means that you tell it what you want and it figures out what versions to in
 So rather than installing a package, you just add it to the list of requirements and then "resolve" what needs to be installed.
 In particular, this means that if some package had been installed because it was needed by a previous version of something you wanted, and a newer version doesn't have that requirement anymore, updating will actually remove that package.
 
-Your package requirements are in the file ``~/.julia/v0.4/REQUIRE``.
+Your package requirements are in the file ``~/.julia/v0.5/REQUIRE``.
 You can edit this file by hand and then call :func:`Pkg.resolve` to install, upgrade or remove packages to optimally satisfy the requirements, or you can do :func:`Pkg.edit`, which will open ``REQUIRE`` in your editor (configured via the ``EDITOR`` or ``VISUAL`` environment variables), and then automatically call :func:`Pkg.resolve` afterwards if necessary.
 If you only want to add or remove the requirement for a single package, you can also use the non-interactive :func:`Pkg.add` and :func:`Pkg.rm` commands, which add or remove a single requirement to ``REQUIRE`` and then call :func:`Pkg.resolve`.
 
@@ -81,15 +81,15 @@ You can add a package to the list of requirements with the :func:`Pkg.add` funct
      - NumericExtensions             0.2.17
      - Stats                         0.2.6
 
-What this is doing is first adding ``Distributions`` to your ``~/.julia/v0.4/REQUIRE`` file::
+What this is doing is first adding ``Distributions`` to your ``~/.julia/v0.5/REQUIRE`` file::
 
-    $ cat ~/.julia/v0.4/REQUIRE
+    $ cat ~/.julia/v0.5/REQUIRE
     Distributions
 
 It then runs :func:`Pkg.resolve` using these new requirements, which leads to the conclusion that the ``Distributions`` package should be installed since it is required but not installed.
-As stated before, you can accomplish the same thing by editing your ``~/.julia/v0.4/REQUIRE`` file by hand and then running :func:`Pkg.resolve` yourself::
+As stated before, you can accomplish the same thing by editing your ``~/.julia/v0.5/REQUIRE`` file by hand and then running :func:`Pkg.resolve` yourself::
 
-    $ echo UTF16 >> ~/.julia/v0.4/REQUIRE
+    $ echo UTF16 >> ~/.julia/v0.5/REQUIRE
 
     julia> Pkg.resolve()
     INFO: Cloning cache of UTF16 from git://github.com/nolta/UTF16.jl.git
@@ -175,7 +175,7 @@ To install an unregistered package, use :func:`Pkg.clone(url) <Pkg.clone>`, wher
     Resolving deltas: 100% (8/8), done.
 
 By convention, Julia repository names end with ``.jl`` (the additional ``.git`` indicates a "bare" git repository), which keeps them from colliding with repositories for other languages, and also makes Julia packages easy to find in search engines.
-When packages are installed in your ``.julia/v0.4`` directory, however, the extension is redundant so we leave it off.
+When packages are installed in your ``.julia/v0.5`` directory, however, the extension is redundant so we leave it off.
 
 If unregistered packages contain a ``REQUIRE`` file at the top of their source tree, that file will be used to determine which registered packages the unregistered package depends on, and they will automatically be installed.
 Unregistered packages participate in the same version resolution logic as registered packages, so installed package versions will be adjusted as necessary to satisfy the requirements of both registered and unregistered packages.
@@ -194,7 +194,7 @@ To get the latest and greatest versions of all your packages, just do :func:`Pkg
     INFO: Upgrading Distributions: v0.2.8 => v0.2.10
     INFO: Upgrading Stats: v0.2.7 => v0.2.8
 
-The first step of updating packages is to pull new changes to ``~/.julia/v0.4/METADATA`` and see if any new registered package versions have been published.
+The first step of updating packages is to pull new changes to ``~/.julia/v0.5/METADATA`` and see if any new registered package versions have been published.
 After this, :func:`Pkg.update` attempts to update packages that are checked out on a branch and not dirty (i.e. no changes have been made to files tracked by git) by pulling changes from the package's upstream repository.
 Upstream changes will only be applied if no merging or rebasing is necessary – i.e. if the branch can be `"fast-forwarded" <https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging>`_.
 If the branch cannot be fast-forwarded, it is assumed that you're working on it and will update the repository yourself.
@@ -207,7 +207,7 @@ A package is considered fixed if it is one of the following:
 3. **Dirty:** changes have been made to files in the repo.
 
 If any of these are the case, the package manager cannot freely change the installed version of the package, so its requirements must be satisfied by whatever other package versions it picks.
-The combination of top-level requirements in ``~/.julia/v0.4/REQUIRE`` and the requirement of fixed packages are used to determine what should be installed.
+The combination of top-level requirements in ``~/.julia/v0.5/REQUIRE`` and the requirement of fixed packages are used to determine what should be installed.
 
 You can also update only a subset of the installed packages, by providing arguments to the `Pkg.update` function. In that case, only the packages provided as arguments and their dependencies will be updated::
 
@@ -720,7 +720,7 @@ Suppose you want to create a new Julia package called ``FooBar``.  To get starte
 name of a license that the package generator knows about::
 
     julia> PkgDev.generate("FooBar","MIT")
-    INFO: Initializing FooBar repo: /Users/stefan/.julia/v0.4/FooBar
+    INFO: Initializing FooBar repo: /Users/stefan/.julia/v0.5/FooBar
     INFO: Origin: git://github.com/StefanKarpinski/FooBar.jl.git
     INFO: Generating LICENSE.md
     INFO: Generating README.md
@@ -732,10 +732,10 @@ name of a license that the package generator knows about::
     INFO: Generating .gitignore
     INFO: Committing FooBar generated files
 
-This creates the directory ``~/.julia/v0.4/FooBar``, initializes it as a git repository, generates a bunch of files
+This creates the directory ``~/.julia/v0.5/FooBar``, initializes it as a git repository, generates a bunch of files
 that all packages should have, and commits them to the repository::
 
-    $ cd ~/.julia/v0.4/FooBar && git show --stat
+    $ cd ~/.julia/v0.5/FooBar && git show --stat
 
     commit 84b8e266dae6de30ab9703150b3bf771ec7b6285
     Author: Stefan Karpinski <stefan@karpinski.org>
@@ -763,7 +763,7 @@ that all packages should have, and commits them to the repository::
 At the moment, the package manager knows about the MIT "Expat" License, indicated by ``"MIT"``, the Simplified BSD License,
 indicated by ``"BSD"``, and version 2.0 of the Apache Software License, indicated by ``"ASL"``.  If you want to use a
 different license, you can ask us to add it to the package generator, or just pick one of these three and then modify the
-``~/.julia/v0.4/PACKAGE/LICENSE.md`` file after it has been generated.
+``~/.julia/v0.5/PACKAGE/LICENSE.md`` file after it has been generated.
 
 If you created a GitHub account and configured git to know about it, :func:`PkgDev.generate` will set an appropriate origin URL
 for you.  It will also automatically generate a ``.travis.yml`` file for using the `Travis <https://travis-ci.org>`_ automated
@@ -799,9 +799,9 @@ of ``METADATA`` using :func:`PkgDev.register`::
     INFO: Registering FooBar at git://github.com/StefanKarpinski/FooBar.jl.git
     INFO: Committing METADATA for FooBar
 
-This creates a commit in the ``~/.julia/v0.4/METADATA`` repo::
+This creates a commit in the ``~/.julia/v0.5/METADATA`` repo::
 
-    $ cd ~/.julia/v0.4/METADATA && git show
+    $ cd ~/.julia/v0.5/METADATA && git show
 
     commit 9f71f4becb05cadacb983c54a72eed744e5c019d
     Author: Stefan Karpinski <stefan@karpinski.org>
@@ -857,12 +857,12 @@ register it with the :func:`PkgDev.tag` command::
 
 This tags ``v0.0.1`` in the ``FooBar`` repo::
 
-    $ cd ~/.julia/v0.4/FooBar && git tag
+    $ cd ~/.julia/v0.5/FooBar && git tag
     v0.0.1
 
 It also creates a new version entry in your local ``METADATA`` repo for ``FooBar``::
 
-    $ cd ~/.julia/v0.4/FooBar && git show
+    $ cd ~/.julia/v0.5/FooBar && git show
     commit de77ee4dc0689b12c5e8b574aef7f70e8b311b0e
     Author: Stefan Karpinski <stefan@karpinski.org>
     Date:   Wed Oct 16 23:06:18 2013 -0400
@@ -922,7 +922,7 @@ fork.
 repository on your local computer (in the terminal where USERNAME is
 your github username)::
 
-    cd ~/.julia/v0.4/METADATA
+    cd ~/.julia/v0.5/METADATA
     git remote add USERNAME https://github.com/USERNAME/METADATA.jl.git
 
 3. push your changes to your fork::
@@ -938,7 +938,7 @@ Fixing Package Requirements
 
 If you need to fix the registered requirements of an already-published package version, you can do so just by editing the metadata for that version, which will still have the same commit hash – the hash associated with a version is permanent::
 
-    $ cd ~/.julia/v0.4/METADATA/FooBar/versions/0.0.1 && cat requires
+    $ cd ~/.julia/v0.5/METADATA/FooBar/versions/0.0.1 && cat requires
     julia 0.3-
     $ vi requires
 
@@ -951,7 +951,7 @@ When you fix the requirements in ``METADATA`` for a previous version of a packag
 Requirements Specification
 --------------------------
 
-The ``~/.julia/v0.4/REQUIRE`` file, the ``REQUIRE`` file inside packages, and the ``METADATA`` package ``requires`` files use a simple line-based format to express the ranges of package versions which need to be installed.  Package ``REQUIRE`` and ``METADATA requires`` files should also include the range of versions of ``julia`` the package is expected to work with.
+The ``~/.julia/v0.5/REQUIRE`` file, the ``REQUIRE`` file inside packages, and the ``METADATA`` package ``requires`` files use a simple line-based format to express the ranges of package versions which need to be installed.  Package ``REQUIRE`` and ``METADATA requires`` files should also include the range of versions of ``julia`` the package is expected to work with.
 
 Here's how these files are parsed and interpreted.
 

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -22,7 +22,7 @@ The :func:`Pkg.status` function prints out a summary of the state of packages yo
 Initially, you'll have no packages installed::
 
     julia> Pkg.status()
-    INFO: Initializing package repository /Users/stefan/.julia/v0.5
+    INFO: Initializing package repository /Users/stefan/.julia/v0.6
     INFO: Cloning METADATA from git://github.com/JuliaLang/METADATA.jl
     No packages installed.
 
@@ -56,7 +56,7 @@ This means that you tell it what you want and it figures out what versions to in
 So rather than installing a package, you just add it to the list of requirements and then "resolve" what needs to be installed.
 In particular, this means that if some package had been installed because it was needed by a previous version of something you wanted, and a newer version doesn't have that requirement anymore, updating will actually remove that package.
 
-Your package requirements are in the file ``~/.julia/v0.5/REQUIRE``.
+Your package requirements are in the file ``~/.julia/v0.6/REQUIRE``.
 You can edit this file by hand and then call :func:`Pkg.resolve` to install, upgrade or remove packages to optimally satisfy the requirements, or you can do :func:`Pkg.edit`, which will open ``REQUIRE`` in your editor (configured via the ``EDITOR`` or ``VISUAL`` environment variables), and then automatically call :func:`Pkg.resolve` afterwards if necessary.
 If you only want to add or remove the requirement for a single package, you can also use the non-interactive :func:`Pkg.add` and :func:`Pkg.rm` commands, which add or remove a single requirement to ``REQUIRE`` and then call :func:`Pkg.resolve`.
 
@@ -81,15 +81,15 @@ You can add a package to the list of requirements with the :func:`Pkg.add` funct
      - NumericExtensions             0.2.17
      - Stats                         0.2.6
 
-What this is doing is first adding ``Distributions`` to your ``~/.julia/v0.5/REQUIRE`` file::
+What this is doing is first adding ``Distributions`` to your ``~/.julia/v0.6/REQUIRE`` file::
 
-    $ cat ~/.julia/v0.5/REQUIRE
+    $ cat ~/.julia/v0.6/REQUIRE
     Distributions
 
 It then runs :func:`Pkg.resolve` using these new requirements, which leads to the conclusion that the ``Distributions`` package should be installed since it is required but not installed.
-As stated before, you can accomplish the same thing by editing your ``~/.julia/v0.5/REQUIRE`` file by hand and then running :func:`Pkg.resolve` yourself::
+As stated before, you can accomplish the same thing by editing your ``~/.julia/v0.6/REQUIRE`` file by hand and then running :func:`Pkg.resolve` yourself::
 
-    $ echo UTF16 >> ~/.julia/v0.5/REQUIRE
+    $ echo UTF16 >> ~/.julia/v0.6/REQUIRE
 
     julia> Pkg.resolve()
     INFO: Cloning cache of UTF16 from git://github.com/nolta/UTF16.jl.git
@@ -175,7 +175,7 @@ To install an unregistered package, use :func:`Pkg.clone(url) <Pkg.clone>`, wher
     Resolving deltas: 100% (8/8), done.
 
 By convention, Julia repository names end with ``.jl`` (the additional ``.git`` indicates a "bare" git repository), which keeps them from colliding with repositories for other languages, and also makes Julia packages easy to find in search engines.
-When packages are installed in your ``.julia/v0.5`` directory, however, the extension is redundant so we leave it off.
+When packages are installed in your ``.julia/v0.6`` directory, however, the extension is redundant so we leave it off.
 
 If unregistered packages contain a ``REQUIRE`` file at the top of their source tree, that file will be used to determine which registered packages the unregistered package depends on, and they will automatically be installed.
 Unregistered packages participate in the same version resolution logic as registered packages, so installed package versions will be adjusted as necessary to satisfy the requirements of both registered and unregistered packages.
@@ -194,7 +194,7 @@ To get the latest and greatest versions of all your packages, just do :func:`Pkg
     INFO: Upgrading Distributions: v0.2.8 => v0.2.10
     INFO: Upgrading Stats: v0.2.7 => v0.2.8
 
-The first step of updating packages is to pull new changes to ``~/.julia/v0.5/METADATA`` and see if any new registered package versions have been published.
+The first step of updating packages is to pull new changes to ``~/.julia/v0.6/METADATA`` and see if any new registered package versions have been published.
 After this, :func:`Pkg.update` attempts to update packages that are checked out on a branch and not dirty (i.e. no changes have been made to files tracked by git) by pulling changes from the package's upstream repository.
 Upstream changes will only be applied if no merging or rebasing is necessary – i.e. if the branch can be `"fast-forwarded" <https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging>`_.
 If the branch cannot be fast-forwarded, it is assumed that you're working on it and will update the repository yourself.
@@ -207,7 +207,7 @@ A package is considered fixed if it is one of the following:
 3. **Dirty:** changes have been made to files in the repo.
 
 If any of these are the case, the package manager cannot freely change the installed version of the package, so its requirements must be satisfied by whatever other package versions it picks.
-The combination of top-level requirements in ``~/.julia/v0.5/REQUIRE`` and the requirement of fixed packages are used to determine what should be installed.
+The combination of top-level requirements in ``~/.julia/v0.6/REQUIRE`` and the requirement of fixed packages are used to determine what should be installed.
 
 You can also update only a subset of the installed packages, by providing arguments to the `Pkg.update` function. In that case, only the packages provided as arguments and their dependencies will be updated::
 
@@ -720,7 +720,7 @@ Suppose you want to create a new Julia package called ``FooBar``.  To get starte
 name of a license that the package generator knows about::
 
     julia> PkgDev.generate("FooBar","MIT")
-    INFO: Initializing FooBar repo: /Users/stefan/.julia/v0.5/FooBar
+    INFO: Initializing FooBar repo: /Users/stefan/.julia/v0.6/FooBar
     INFO: Origin: git://github.com/StefanKarpinski/FooBar.jl.git
     INFO: Generating LICENSE.md
     INFO: Generating README.md
@@ -732,10 +732,10 @@ name of a license that the package generator knows about::
     INFO: Generating .gitignore
     INFO: Committing FooBar generated files
 
-This creates the directory ``~/.julia/v0.5/FooBar``, initializes it as a git repository, generates a bunch of files
+This creates the directory ``~/.julia/v0.6/FooBar``, initializes it as a git repository, generates a bunch of files
 that all packages should have, and commits them to the repository::
 
-    $ cd ~/.julia/v0.5/FooBar && git show --stat
+    $ cd ~/.julia/v0.6/FooBar && git show --stat
 
     commit 84b8e266dae6de30ab9703150b3bf771ec7b6285
     Author: Stefan Karpinski <stefan@karpinski.org>
@@ -763,7 +763,7 @@ that all packages should have, and commits them to the repository::
 At the moment, the package manager knows about the MIT "Expat" License, indicated by ``"MIT"``, the Simplified BSD License,
 indicated by ``"BSD"``, and version 2.0 of the Apache Software License, indicated by ``"ASL"``.  If you want to use a
 different license, you can ask us to add it to the package generator, or just pick one of these three and then modify the
-``~/.julia/v0.5/PACKAGE/LICENSE.md`` file after it has been generated.
+``~/.julia/v0.6/PACKAGE/LICENSE.md`` file after it has been generated.
 
 If you created a GitHub account and configured git to know about it, :func:`PkgDev.generate` will set an appropriate origin URL
 for you.  It will also automatically generate a ``.travis.yml`` file for using the `Travis <https://travis-ci.org>`_ automated
@@ -799,9 +799,9 @@ of ``METADATA`` using :func:`PkgDev.register`::
     INFO: Registering FooBar at git://github.com/StefanKarpinski/FooBar.jl.git
     INFO: Committing METADATA for FooBar
 
-This creates a commit in the ``~/.julia/v0.5/METADATA`` repo::
+This creates a commit in the ``~/.julia/v0.6/METADATA`` repo::
 
-    $ cd ~/.julia/v0.5/METADATA && git show
+    $ cd ~/.julia/v0.6/METADATA && git show
 
     commit 9f71f4becb05cadacb983c54a72eed744e5c019d
     Author: Stefan Karpinski <stefan@karpinski.org>
@@ -857,12 +857,12 @@ register it with the :func:`PkgDev.tag` command::
 
 This tags ``v0.0.1`` in the ``FooBar`` repo::
 
-    $ cd ~/.julia/v0.5/FooBar && git tag
+    $ cd ~/.julia/v0.6/FooBar && git tag
     v0.0.1
 
 It also creates a new version entry in your local ``METADATA`` repo for ``FooBar``::
 
-    $ cd ~/.julia/v0.5/FooBar && git show
+    $ cd ~/.julia/v0.6/FooBar && git show
     commit de77ee4dc0689b12c5e8b574aef7f70e8b311b0e
     Author: Stefan Karpinski <stefan@karpinski.org>
     Date:   Wed Oct 16 23:06:18 2013 -0400
@@ -922,7 +922,7 @@ fork.
 repository on your local computer (in the terminal where USERNAME is
 your github username)::
 
-    cd ~/.julia/v0.5/METADATA
+    cd ~/.julia/v0.6/METADATA
     git remote add USERNAME https://github.com/USERNAME/METADATA.jl.git
 
 3. push your changes to your fork::
@@ -938,7 +938,7 @@ Fixing Package Requirements
 
 If you need to fix the registered requirements of an already-published package version, you can do so just by editing the metadata for that version, which will still have the same commit hash – the hash associated with a version is permanent::
 
-    $ cd ~/.julia/v0.5/METADATA/FooBar/versions/0.0.1 && cat requires
+    $ cd ~/.julia/v0.6/METADATA/FooBar/versions/0.0.1 && cat requires
     julia 0.3-
     $ vi requires
 
@@ -951,7 +951,7 @@ When you fix the requirements in ``METADATA`` for a previous version of a packag
 Requirements Specification
 --------------------------
 
-The ``~/.julia/v0.5/REQUIRE`` file, the ``REQUIRE`` file inside packages, and the ``METADATA`` package ``requires`` files use a simple line-based format to express the ranges of package versions which need to be installed.  Package ``REQUIRE`` and ``METADATA requires`` files should also include the range of versions of ``julia`` the package is expected to work with.
+The ``~/.julia/v0.6/REQUIRE`` file, the ``REQUIRE`` file inside packages, and the ``METADATA`` package ``requires`` files use a simple line-based format to express the ranges of package versions which need to be installed.  Package ``REQUIRE`` and ``METADATA requires`` files should also include the range of versions of ``julia`` the package is expected to work with.
 
 Here's how these files are parsed and interpreted.
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -15,7 +15,7 @@ it's fairly obvious that a given CPU will have fastest access to the RAM
 within the same computer (node). Perhaps more surprisingly, similar
 issues are relevant on a typical multicore laptop, due to
 differences in the speed of main memory and the
-`cache <http://www.akkadia.org/drepper/cpumemory.pdf>`_. Consequently, a
+`cache <https://www.akkadia.org/drepper/cpumemory.pdf>`_. Consequently, a
 good multiprocessing environment should allow control over the
 "ownership" of a chunk of memory by a particular CPU. Julia provides a
 multiprocessing environment based on message passing to allow programs

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -1081,21 +1081,21 @@ Note that :obj:`Threads.@threads` does not have an optional reduction parameter 
 All I/O tasks, timers, REPL commands, etc are multiplexed onto a single OS thread via an event loop.
 A patched version of libuv (http://docs.libuv.org/en/v1.x/) provides this functionality. Yield points provide
 for co-operatively scheduling multiple tasks onto the same OS thread. I/O tasks and timers yield implicitly while
-waiting for the event to occur. Calling `yield()` explicitly allows for other tasks to be scheduled.
+waiting for the event to occur. Calling ``yield()`` explicitly allows for other tasks to be scheduled.
 
 Thus, a task executing a ``ccall`` effectively prevents the Julia scheduler from executing any other
 tasks till the call returns. This is true for all calls into external libraries. Exceptions are calls into
-custom C code that call back into Julia (which may then yield) or C code that calls ``jl_yield()``(C equivalent of ``yield()``).
+custom C code that call back into Julia (which may then yield) or C code that calls ``jl_yield()`` (C equivalent of ``yield()``).
 
 Note that while Julia code runs on a single thread (by default), libraries used by Julia may launch their own internal
 threads. For example, the BLAS library may start as many threads as there are cores on a machine.
 
 The ``@threadcall`` macro addresses scenarios where we do not want a ``ccall`` to block the main Julia event loop.
 It schedules a C function for execution in a separate thread. A threadpool with a default size of 4 is used for this.
-The size of the threadpool is controlled via environment variable UV_THREADPOOL_SIZE. While waiting for a free thread,
+The size of the threadpool is controlled via environment variable ``UV_THREADPOOL_SIZE``. While waiting for a free thread,
 and during function execution once a thread is available, the requesting task (on the main Julia event loop)
 yields to other tasks. Note that ``@threadcall`` does not return till the execution is complete. From a user point of
-view, it is therefore a blocking call like other Julia API.
+view, it is therefore a blocking call like other Julia APIs.
 
 It is very important that the called function does not call back into Julia.
 

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -770,7 +770,7 @@ code.
 
 Some run-time benchmarks comparing (1) type dispatch, (2) dictionary
 lookup, and (3) a "switch" statement can be found `on the mailing list
-<https://groups.google.com/d/msg/julia-users/jUMu9A3QKQQ/qjgVWr7vAwAJ>`_.
+<https://groups.google.com/forum/#!msg/julia-users/jUMu9A3QKQQ/qjgVWr7vAwAJ>`_.
 
 Perhaps even worse than the run-time impact is the compile-time
 impact: Julia will compile specialized functions for each different

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -7,7 +7,7 @@
 All package manager functions are defined in the ``Pkg`` module. None of the ``Pkg`` module's functions are exported;
 to use them, you'll need to prefix each function call with an explicit ``Pkg.``, e.g. ``Pkg.status()`` or ``Pkg.dir()``.
 
-Functions for package development (e.g. ``tag``, ``publish``, etc.) have been moved to the `PkgDev <https://github.com/JuliaLang/PkgDev.jl>`_ package. See `PkgDev README <https://github.com/JuliaLang/PkgDev.jl/blob/master/README.md#usage>`_ for the documentation of those functions.
+Functions for package development (e.g. ``tag``, ``publish``, etc.) have been moved to the `PkgDev <https://github.com/JuliaLang/PkgDev.jl>`_ package. See `PkgDev README <https://github.com/JuliaLang/PkgDev.jl/blob/master/README.md>`_ for the documentation of those functions.
 
 .. function:: dir() -> AbstractString
 


### PR DESCRIPTION
Upgrades to a newer sphinx to deal with getting some latin-1 back from valgrind's docs, and ignores the other remaining 2 problematic ones - the kde bug page is returning empty, and https://www.appveyor.com is returning 403: Forbidden. cc @FeodorFitsner any idea why it would do that using the Sphinx doc generator's link-checking feature?

All but ~~the last commit~~ https://github.com/JuliaLang/julia/pull/17862/commits/5f95c4f5f2faf3ae0665da1609a2f8aae87becd5 should be backported to release-0.5. (and some version of the first 3 should be backported to release-0.4)
