### PR TITLE
improve heuristic for when to refresh line in the REPL

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -448,18 +448,18 @@ end
 
 function edit_insert(s::PromptState, c)
     buf = s.input_buffer
-    function line_size(s)
+    function line_size()
         p = position(buf)
         seek(buf, rsearch(buf.data, '\n', p))
-        line_size = p - position(buf)
+        ls = p - position(buf)
         seek(buf, p)
-        return line_size
+        return ls
     end
     str = string(c)
     edit_insert(buf, str)
     offset = s.ias.curs_row == 1 ? sizeof(s.p.prompt) : s.indent
     if !('\n' in str) && eof(buf) &&
-        ((line_size(s) + offset + sizeof(str) - 1) < width(terminal(s)))
+        ((line_size() + offset + sizeof(str) - 1) < width(terminal(s)))
         # Avoid full update when appending characters to the end
         # and an update of curs_row isn't necessary (conservatively estimated)
         write(terminal(s), str)

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -457,8 +457,9 @@ function edit_insert(s::PromptState, c)
     end
     str = string(c)
     edit_insert(buf, str)
+    offset = s.ias.curs_row == 1 ? sizeof(s.p.prompt) : s.indent
     if !('\n' in str) && eof(buf) &&
-        ((line_size(s) + sizeof(s.p.prompt) + sizeof(str) - 1) < width(terminal(s)))
+        ((line_size(s) + offset + sizeof(str) - 1) < width(terminal(s)))
         # Avoid full update when appending characters to the end
         # and an update of curs_row isn't necessary (conservatively estimated)
         write(terminal(s), str)

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -447,10 +447,18 @@ function edit_replace(s, from, to, str)
 end
 
 function edit_insert(s::PromptState, c)
+    buf = s.input_buffer
+    function line_size(s)
+        p = position(buf)
+        seek(buf, rsearch(buf.data, '\n', p))
+        line_size = p - position(buf)
+        seek(buf, p)
+        return line_size
+    end
     str = string(c)
-    edit_insert(s.input_buffer, str)
-    if !('\n' in str) && eof(s.input_buffer) &&
-        ((position(s.input_buffer) + sizeof(s.p.prompt) + sizeof(str) - 1) < width(terminal(s)))
+    edit_insert(buf, str)
+    if !('\n' in str) && eof(buf) && 
+        ((line_size(s) + sizeof(s.p.prompt) + sizeof(str) - 1) < width(terminal(s)))
         # Avoid full update when appending characters to the end
         # and an update of curs_row isn't necessary (conservatively estimated)
         write(terminal(s), str)

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -457,7 +457,7 @@ function edit_insert(s::PromptState, c)
     end
     str = string(c)
     edit_insert(buf, str)
-    if !('\n' in str) && eof(buf) && 
+    if !('\n' in str) && eof(buf) &&
         ((line_size(s) + sizeof(s.p.prompt) + sizeof(str) - 1) < width(terminal(s)))
         # Avoid full update when appending characters to the end
         # and an update of curs_row isn't necessary (conservatively estimated)


### PR DESCRIPTION
Comparing pasting the same long function in the REPL before PR (above) and after PR (below): https://media.giphy.com/media/3o6Ztmlq9XLVMTqDgA/giphy.gif. The before PR version was going quite a while after I turned of the recording. Still not perfect, but better.

cc @vtjnash @Keno 

Sort of fixes [no auto close] https://github.com/JuliaLang/julia/issues/15787
