### PR TITLE
Fix compilation on LLVM 4.0

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -35,7 +35,17 @@ extern PassManager *jl_globalPM;
 
 #ifdef LLVM35
 #include <llvm/Target/TargetMachine.h>
+#endif
+
+#ifdef LLVM40
+typedef JITSymbol JL_JITSymbol;
+// The type that is similar to SymbolInfo on LLVM 4.0 is actually
+// `JITEvaluatedSymbol`. However, we only use this type when a JITSymbol
+// is expected.
+typedef JITSymbol JL_SymbolInfo;
 #else
+typedef orc::JITSymbol JL_JITSymbol;
+typedef RuntimeDyld::SymbolInfo JL_SymbolInfo;
 #endif
 
 extern "C" {
@@ -184,8 +194,8 @@ public:
     void *getPointerToGlobalIfAvailable(const GlobalValue *GV);
     void addModule(std::unique_ptr<Module> M);
     void removeModule(ModuleHandleT H);
-    orc::JITSymbol findSymbol(const std::string &Name, bool ExportedSymbolsOnly);
-    orc::JITSymbol findUnmangledSymbol(const std::string Name);
+    JL_JITSymbol findSymbol(const std::string &Name, bool ExportedSymbolsOnly);
+    JL_JITSymbol findUnmangledSymbol(const std::string Name);
     uint64_t getGlobalValueAddress(const std::string &Name);
     uint64_t getFunctionAddress(const std::string &Name);
     Function *FindFunctionNamed(const std::string &Name);


### PR DESCRIPTION
Renaming of `orc::JITSymbol` and `RuntimeDyld::SymbolInfo`.

Ref https://github.com/llvm-mirror/llvm/commit/075c1e2e1aa2a1fc577cb92ab40a260e45929984
