### PR TITLE
fix less on windows

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -70,9 +70,17 @@ edit(file, line::Integer) = error("could not find source file for function")
 
 # terminal pager
 
-function less(file::AbstractString, line::Integer)
-    pager = get(ENV, "PAGER", "less")
-    run(`$pager +$(line)g $file`)
+if is_windows()
+    function less(file::AbstractString, line::Integer)
+        pager = get(ENV, "PAGER", "more")
+        g = pager == "more" ? "" : "g"
+        run(Cmd(`$pager +$(line)$(g) \"$file\"`, windows_verbatim = true))
+    end
+else
+    function less(file::AbstractString, line::Integer)
+        pager = get(ENV, "PAGER", "less")
+        run(`$pager +$(line)g $file`)
+    end
 end
 
 less(file::AbstractString) = less(file, 1)


### PR DESCRIPTION
by using `more` as the default and escaping `file`.

More concise implementation would be something like 

``` julia
function less(file::AbstractString, line::Integer)
    default = is_windows() ? "more" : "less"
    pager = get(ENV, "PAGER", default)
    g = is_windows() && pager == "more" ? "" : "g"
    run(Cmd(`$pager +$(line)$g \"$file\"`, windows_verbatim = true)
end
```

but I dunno if escaping `file` with `\"` does something bad on non-windows OSs.

Fixes #17872.
