### PR TITLE
Add Gitter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This is the GitHub repository of Julia source code, including instructions for c
 - **Source code:** <https://github.com/JuliaLang/julia>
 - **Git clone URL:** <git://github.com/JuliaLang/julia.git>
 - **Mailing lists:** <http://julialang.org/community/>
-- **IRC:** <http://webchat.freenode.net/?channels=julia>
 - **Gitter:** <https://gitter.im/JuliaLang/julia>
+- **IRC:** <http://webchat.freenode.net/?channels=julia>
 - **Code coverage:** <https://coveralls.io/r/JuliaLang/julia>
 
 The mailing list for developer discussion is
@@ -43,7 +43,6 @@ developers may find the notes in [CONTRIBUTING](https://github.com/JuliaLang/jul
 - [**StackOverflow**](https://stackoverflow.com/questions/tagged/julia-lang)
 - [**Youtube**](https://www.youtube.com/channel/UC9IuUwwE2xdjQUT_LMLONoA)
 - [**Twitter**](https://twitter.com/JuliaLanguage)
-- [**Google+**](https://plus.google.com/communities/111295162646766639102)
 - [**Meetup**](http://julia.meetup.com/)
 
 <a name="Currently-Supported-Platforms"/>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is the GitHub repository of Julia source code, including instructions for c
 - **Git clone URL:** <git://github.com/JuliaLang/julia.git>
 - **Mailing lists:** <http://julialang.org/community/>
 - **IRC:** <http://webchat.freenode.net/?channels=julia>
+- **Gitter:** <https://gitter.im/JuliaLang/julia>
 - **Code coverage:** <https://coveralls.io/r/JuliaLang/julia>
 
 The mailing list for developer discussion is


### PR DESCRIPTION
The Gitter is a large active community that new users have found lots of help at. I think it would be helpful to have the Gitter right here in the README, because some of the people went to IRC for chat only to find out about the Gitter through the Gitter/IRC bot (and then switched to Gtiter for the code highlighting). I think showing the active community and the help it gives on a README will be important to lower the new-user threshold. They can click on the link and see the current Julia help chat in a nice web interface that appeals to less programming-experienced (or more aesthetically-inclined) users more than IRC.
