### PR TITLE
MORE doc improvements for arrays, and for eigen

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -554,6 +554,22 @@ function insert!{T}(a::Array{T,1}, i::Integer, item)
     return a
 end
 
+"""
+    deleteat!(a::Vector, i::Integer)
+
+Remove the item at the given `i` and return the modified `a`. Subsequent items
+are shifted to fill the resulting gap.
+
+```jldoctest
+julia> deleteat!([6, 5, 4, 3, 2, 1], 2)
+5-element Array{Int64,1}:
+ 6
+ 4
+ 3
+ 2
+ 1
+```
+"""
 deleteat!(a::Vector, i::Integer) = (_deleteat!(a, i, 1); a)
 
 function deleteat!{T<:Integer}(a::Vector, r::UnitRange{T})
@@ -562,6 +578,25 @@ function deleteat!{T<:Integer}(a::Vector, r::UnitRange{T})
     return a
 end
 
+"""
+    deleteat!(a::Vector, inds)
+
+Remove the items at the indices given by `inds`, and return the modified `a`.
+Subsequent items are shifted to fill the resulting gap. `inds` must be sorted and unique.
+
+```jldoctest
+julia> deleteat!([6, 5, 4, 3, 2, 1], 1:2:5)
+3-element Array{Int64,1}:
+ 5
+ 3
+ 1
+
+julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
+ERROR: ArgumentError: indices must be unique and sorted
+ in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:576
+ ...
+```
+"""
 function deleteat!(a::Vector, inds)
     n = length(a)
     s = start(inds)
@@ -732,7 +767,24 @@ end
 
 ## find ##
 
-# returns the index of the next non-zero element, or 0 if all zeros
+"""
+    findnext(A, i::Integer)
+
+Find the next linear index >= `i` of a non-zero element of `A`, or `0` if not found.
+
+```jldoctest
+julia> A = [0 0; 1 0]
+2×2 Array{Int64,2}:
+ 0  0
+ 1  0
+
+julia> findnext(A,1)
+2
+
+julia> findnext(A,3)
+0
+```
+"""
 function findnext(A, start::Integer)
     for i = start:length(A)
         if A[i] != 0
@@ -741,9 +793,43 @@ function findnext(A, start::Integer)
     end
     return 0
 end
+
+"""
+    findfirst(A)
+
+Return the linear index of the first non-zero value in `A` (determined by `A[i]!=0`).
+Returns `0` if no such value is found.
+
+```jldoctest
+julia> A = [0 0; 1 0]
+2×2 Array{Int64,2}:
+ 0  0
+ 1  0
+
+julia> findfirst(A)
+2
+```
+"""
 findfirst(A) = findnext(A, 1)
 
-# returns the index of the next matching element
+"""
+    findnext(A, v, i::Integer)
+
+Find the next linear index >= `i` of an element of `A` equal to `v` (using `==`), or `0` if not found.
+
+```jldoctest
+julia> A = [1 4; 2 2]
+2×2 Array{Int64,2}:
+ 1  4
+ 2  2
+
+julia> findnext(A,4,4)
+0
+
+julia> findnext(A,4,3)
+3
+```
+"""
 function findnext(A, v, start::Integer)
     for i = start:length(A)
         if A[i] == v
@@ -752,9 +838,45 @@ function findnext(A, v, start::Integer)
     end
     return 0
 end
+"""
+    findfirst(A, v)
+
+Return the linear index of the first element equal to `v` in `A`.
+Returns `0` if `v` is not found.
+
+```jldoctest
+julia> A = [4 6; 2 2]
+2×2 Array{Int64,2}:
+ 4  6
+ 2  2
+
+julia> findfirst(A,2)
+2
+
+julia> findfirst(A,3)
+0
+```
+"""
 findfirst(A, v) = findnext(A, v, 1)
 
-# returns the index of the next element for which the function returns true
+"""
+    findnext(predicate::Function, A, i::Integer)
+
+Find the next linear index >= `i` of an element of `A` for which `predicate` returns `true`, or `0` if not found.
+
+```jldoctest
+julia> A = [1 4; 2 2]
+2×2 Array{Int64,2}:
+ 1  4
+ 2  2
+
+julia> findnext(isodd, A, 1)
+1
+
+julia> findnext(isodd, A, 2)
+0
+```
+"""
 function findnext(testf::Function, A, start::Integer)
     for i = start:length(A)
         if testf(A[i])
@@ -763,35 +885,193 @@ function findnext(testf::Function, A, start::Integer)
     end
     return 0
 end
+
+"""
+    findfirst(predicate::Function, A)
+
+Return the linear index of the first element of `A` for which `predicate` returns `true`.
+Returns `0` if there is no such element.
+
+```jldoctest
+julia> A = [1 4; 2 2]
+2×2 Array{Int64,2}:
+ 1  4
+ 2  2
+
+julia> findfirst(iseven, A)
+2
+
+julia> findfirst(x -> x>10, A)
+0
+```
+"""
 findfirst(testf::Function, A) = findnext(testf, A, 1)
 
-# returns the index of the previous non-zero element, or 0 if all zeros
+"""
+    findprev(A, i::Integer)
+
+Find the previous linear index <= `i` of a non-zero element of `A`, or `0` if not found.
+
+```jldoctest
+julia> A = [0 0; 1 2]
+2×2 Array{Int64,2}:
+ 0  0
+ 1  2
+
+julia> findprev(A,2)
+2
+
+julia> findprev(A,1)
+0
+```
+"""
 function findprev(A, start::Integer)
     for i = start:-1:1
         A[i] != 0 && return i
     end
     return 0
 end
+
+"""
+    findlast(A)
+
+Return the linear index of the last non-zero value in `A` (determined by `A[i]!=0`).
+Returns `0` if there is no non-zero value in `A`.
+
+```jldoctest
+julia> A = [1 0; 1 0]
+2×2 Array{Int64,2}:
+ 1  0
+ 1  0
+
+julia> findlast(A)
+2
+
+julia> A = zeros(2,2)
+2×2 Array{Float64,2}:
+ 0.0  0.0
+ 0.0  0.0
+
+julia> findlast(A)
+0
+```
+"""
 findlast(A) = findprev(A, length(A))
 
-# returns the index of the matching element, or 0 if no matching
+"""
+    findprev(A, v, i::Integer)
+
+Find the previous linear index <= `i` of an element of `A` equal to `v` (using `==`), or `0` if not found.
+
+```jldoctest
+julia> A = [0 0; 1 2]
+2×2 Array{Int64,2}:
+ 0  0
+ 1  2
+
+julia> findprev(A, 1, 4)
+2
+
+julia> findprev(A, 1, 1)
+0
+```
+"""
 function findprev(A, v, start::Integer)
     for i = start:-1:1
         A[i] == v && return i
     end
     return 0
 end
+
+"""
+    findlast(A, v)
+
+Return the linear index of the last element equal to `v` in `A`.
+Returns `0` if there is no element of `A` equal to `v`.
+
+```jldoctest
+julia> A = [1 2; 2 1]
+2×2 Array{Int64,2}:
+ 1  2
+ 2  1
+
+julia> findlast(A,1)
+4
+
+julia> findlast(A,2)
+3
+
+julia> findlast(A,3)
+0
+```
+"""
 findlast(A, v) = findprev(A, v, length(A))
 
-# returns the index of the previous element for which the function returns true, or zero if it never does
+"""
+    findprev(predicate::Function, A, i::Integer)
+
+Find the previous linear index <= `i` of an element of `A` for which `predicate` returns `true`, or
+`0` if not found.
+
+```jldoctest
+julia> A = [4 6; 1 2]
+2×2 Array{Int64,2}:
+ 4  6
+ 1  2
+
+julia> findprev(isodd, A, 1)
+0
+
+julia> findprev(isodd, A, 3)
+2
+```
+"""
 function findprev(testf::Function, A, start::Integer)
     for i = start:-1:1
         testf(A[i]) && return i
     end
     return 0
 end
+
+"""
+    findlast(predicate::Function, A)
+
+Return the linear index of the last element of `A` for which `predicate` returns `true`.
+Returns `0` if there is no such element.
+
+```jldoctest
+julia> A = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> findlast(isodd, A)
+2
+
+julia> findlast(x -> x > 5, A)
+0
+```
+"""
 findlast(testf::Function, A) = findprev(testf, A, length(A))
 
+"""
+    find(f::Function, A)
+
+Return a vector `I` of the linear indexes of `A` where `f(A[I])` returns `true`.
+If there are no such elements of `A`, find returns an empty array.
+
+```jldoctest
+julia> A = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> find(isodd,A)
+2-element Array{Int64,1}:
+ 1
+ 2
+```
+"""
 function find(testf::Function, A)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return
@@ -806,6 +1086,25 @@ function find(testf::Function, A)
     return I
 end
 
+"""
+    find(A)
+
+Return a vector of the linear indexes of the non-zeros in `A` (determined by `A[i]!=0`). A
+common use of this is to convert a boolean array to an array of indexes of the `true`
+elements. If there are no non-zero elements of `A`, `find` returns an empty array.
+
+```jldoctest
+julia> A = [true false; false true]
+2×2 Array{Bool,2}:
+  true  false
+ false   true
+
+julia> find(A)
+2-element Array{Int64,1}:
+ 1
+ 4
+```
+"""
 function find(A)
     nnzA = countnz(A)
     I = Vector{Int}(nnzA)
@@ -824,6 +1123,32 @@ find(testf::Function, x::Number) = !testf(x) ? Array{Int,1}(0) : [1]
 
 findn(A::AbstractVector) = find(A)
 
+"""
+    findn(A)
+
+Return a vector of indexes for each dimension giving the locations of the non-zeros in `A`
+(determined by `A[i]!=0`).
+If there are no non-zero elements of `A`, `findn` returns a 2-tuple of empty arrays.
+
+```jldoctest
+julia> A = [1 2 0; 0 0 3; 0 4 0]
+3×3 Array{Int64,2}:
+ 1  2  0
+ 0  0  3
+ 0  4  0
+
+julia> findn(A)
+([1,1,3,2],[1,2,2,3])
+
+julia> A = zeros(2,2)
+2×2 Array{Float64,2}:
+ 0.0  0.0
+ 0.0  0.0
+
+julia> findn(A)
+(Int64[],Int64[])
+```
+"""
 function findn(A::AbstractMatrix)
     nnzA = countnz(A)
     I = similar(A, Int, nnzA)
@@ -839,6 +1164,23 @@ function findn(A::AbstractMatrix)
     return (I, J)
 end
 
+"""
+    findnz(A)
+
+Return a tuple `(I, J, V)` where `I` and `J` are the row and column indexes of the non-zero
+values in matrix `A`, and `V` is a vector of the non-zero values.
+
+```jldoctest
+julia> A = [1 2 0; 0 0 3; 0 4 0]
+3×3 Array{Int64,2}:
+ 1  2  0
+ 0  0  3
+ 0  4  0
+
+julia> findnz(A)
+([1,1,3,2],[1,2,2,3],[1,2,4,3])
+```
+"""
 function findnz{T}(A::AbstractMatrix{T})
     nnzA = countnz(A)
     I = zeros(Int, nnzA)
@@ -921,6 +1263,8 @@ end
     indmax(itr) -> Integer
 
 Returns the index of the maximum element in a collection.
+The collection must not be empty.
+
 ```jldoctest
 julia> indmax([8,0.1,-9,pi])
 1
@@ -932,6 +1276,8 @@ indmax(a) = findmax(a)[2]
     indmin(itr) -> Integer
 
 Returns the index of the minimum element in a collection.
+The collection must not be empty.
+
 ```jldoctest
 julia> indmin([8,0.1,-9,pi])
 3
@@ -1091,6 +1437,22 @@ function union(vs...)
     ret
 end
 # setdiff only accepts two args
+
+"""
+    setdiff(a, b)
+
+Construct the set of elements in `a` but not `b`. Maintains order with arrays. Note that
+both arguments must be collections, and both will be iterated over. In particular,
+`setdiff(set,element)` where `element` is a potential member of `set`, will not work in
+general.
+
+```jldoctest
+julia> setdiff([1,2,3],[3,4,5])
+2-element Array{Int64,1}:
+ 1
+ 2
+```
+"""
 function setdiff(a, b)
     args_type = promote_type(eltype(a), eltype(b))
     bset = Set(b)
@@ -1111,4 +1473,18 @@ end
 # store counts with a Dict.
 symdiff(a) = a
 symdiff(a, b) = union(setdiff(a,b), setdiff(b,a))
+"""
+    symdiff(a, b, rest...)
+
+Construct the symmetric difference of elements in the passed in sets or arrays.
+Maintains order with arrays.
+
+```jldoctest
+julia> symdiff([1,2,3],[3,4,5],[4,5,6])
+3-element Array{Int64,1}:
+ 1
+ 2
+ 6
+```
+"""
 symdiff(a, b, rest...) = symdiff(a, symdiff(b, rest...))

--- a/base/collections.jl
+++ b/base/collections.jl
@@ -109,7 +109,7 @@ end
 
 # Turn an arbitrary array into a binary min-heap in linear time.
 """
-    heapify!(v, [ord])
+    heapify!(v, ord::Ordering=Forward)
 
 In-place [`heapify`](:func:`heapify`).
 """
@@ -121,16 +121,49 @@ function heapify!(xs::AbstractArray, o::Ordering=Forward)
 end
 
 """
-    heapify(v, [ord])
+    heapify(v, ord::Ordering=Forward)
 
 Returns a new vector in binary heap order, optionally using the given ordering.
+```jldoctest
+julia> a = [1,3,4,5,2];
+
+julia> Base.Collections.heapify(a)
+5-element Array{Int64,1}:
+ 1
+ 2
+ 4
+ 5
+ 3
+
+julia> Base.Collections.heapify(a, Base.Order.Reverse)
+5-element Array{Int64,1}:
+ 5
+ 3
+ 4
+ 1
+ 2
+```
 """
 heapify(xs::AbstractArray, o::Ordering=Forward) = heapify!(copymutable(xs), o)
 
 """
-    isheap(v, [ord])
+    isheap(v, ord::Ordering=Forward)
 
 Return `true` if an array is heap-ordered according to the given order.
+
+```jldoctest
+julia> a = [1,2,3]
+3-element Array{Int64,1}:
+ 1
+ 2
+ 3
+
+julia> Base.Collections.isheap(a,Base.Order.Forward)
+true
+
+julia> Base.Collections.isheap(a,Base.Order.Reverse)
+false
+```
 """
 function isheap(xs::AbstractArray, o::Ordering=Forward)
     for i in 1:div(length(xs), 2)
@@ -157,6 +190,14 @@ the default comparison for `V`.
 A `PriorityQueue` acts like a `Dict`, mapping values to their
 priorities, with the addition of a `dequeue!` function to remove the
 lowest priority element.
+
+```jldoctest
+julia> a = Base.Collections.PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+  "c" => 1
+  "b" => 3
+  "a" => 2
+```
 """
 type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
     # Binary heap of (element, priority) pairs.
@@ -304,6 +345,21 @@ end
     enqueue!(pq, k, v)
 
 Insert the a key `k` into a priority queue `pq` with priority `v`.
+
+```jldoctest
+julia> a = Base.Collections.PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+  "c" => 1
+  "b" => 3
+  "a" => 2
+
+julia> Base.Collections.enqueue!(a, "d", 4)
+Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 4 entries:
+  "c" => 1
+  "b" => 3
+  "a" => 2
+  "d" => 4
+```
 """
 function enqueue!{K,V}(pq::PriorityQueue{K,V}, key, value)
     if haskey(pq, key)
@@ -319,6 +375,22 @@ end
     dequeue!(pq)
 
 Remove and return the lowest priority key from a priority queue.
+
+```jldoctest
+julia> a = Base.Collections.PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+  "c" => 1
+  "b" => 3
+  "a" => 2
+
+julia> Base.Collections.dequeue!(a)
+"c"
+
+julia> a
+Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 2 entries:
+  "b" => 3
+  "a" => 2
+```
 """
 function dequeue!(pq::PriorityQueue)
     x = pq.xs[1]

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -690,11 +690,11 @@ function writedlm(fname::AbstractString, a, dlm; opts...)
 end
 
 """
-    writedlm(f, A, dl='\\t'; opts)
+    writedlm(f, A, delim='\\t'; opts)
 
-Write `A` (a vector, matrix or an iterable collection of iterable rows) as text to `f`
-(either a filename string or an `IO` stream) using the given delimiter `delim` (which
-defaults to tab, but can be any printable Julia object, typically a `Char` or
+Write `A` (a vector, matrix, or an iterable collection of iterable rows) as text to `f`
+(either a filename string or an [`IO`](:class:`IO`) stream) using the given delimiter
+`delim` (which defaults to tab, but can be any printable Julia object, typically a `Char` or
 `AbstractString`).
 
 For example, two vectors `x` and `y` of the same length can be written as two columns of
@@ -705,7 +705,7 @@ writedlm(io, a; opts...) = writedlm(io, a, '\t'; opts...)
 """
     writecsv(filename, A; opts)
 
-Equivalent to `writedlm` with `delim` set to comma.
+Equivalent to [`writedlm`](:func:`writedlm`) with `delim` set to comma.
 """
 writecsv(io, a; opts...) = writedlm(io, a, ','; opts...)
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -264,14 +264,6 @@ The text is assumed to be encoded in UTF-8.
 readlines
 
 """
-    findnz(A)
-
-Return a tuple `(I, J, V)` where `I` and `J` are the row and column indexes of the non-zero
-values in matrix `A`, and `V` is a vector of the non-zero values.
-"""
-findnz
-
-"""
     foldl(op, v0, itr)
 
 Like [`reduce`](:func:`reduce`), but with guaranteed left associativity. `v0` will be used
@@ -1640,13 +1632,6 @@ Bitwise and.
 &
 
 """
-    eigmax(A)
-
-Returns the largest eigenvalue of `A`.
-"""
-eigmax
-
-"""
     PipeBuffer()
 
 An IOBuffer that allows reading and performs writes by appending. Seeking and truncating are
@@ -2113,21 +2098,6 @@ themselves in another collection. The result is of the preceding example is equi
 """
 append!
 
-"""
-    find(A)
-
-Return a vector of the linear indexes of the non-zeros in `A` (determined by `A[i]!=0`). A
-common use of this is to convert a boolean array to an array of indexes of the `true`
-elements.
-"""
-find(A)
-
-"""
-    find(f,A)
-
-Return a vector of the linear indexes of `A` where `f` returns `true`.
-"""
-find(f, A)
 
 """
     ctranspose(A)
@@ -2308,24 +2278,6 @@ prod(itr)
 Multiply elements of an array over the given dimensions.
 """
 prod(A, dims)
-
-"""
-    Base.linearindexing(A)
-
-`linearindexing` defines how an AbstractArray most efficiently accesses its elements. If
-`Base.linearindexing(A)` returns `Base.LinearFast()`, this means that linear indexing with
-only one index is an efficient operation. If it instead returns `Base.LinearSlow()` (by
-default), this means that the array intrinsically accesses its elements with indices
-specified for every dimension. Since converting a linear index to multiple indexing
-subscripts is typically very expensive, this provides a traits-based mechanism to enable
-efficient generic code for all array types.
-
-An abstract array subtype `MyArray` that wishes to opt into fast linear indexing behaviors
-should define `linearindexing` in the type-domain:
-
-    Base.linearindexing{T<:MyArray}(::Type{T}) = Base.LinearFast()
-"""
-Base.linearindexing
 
 """
     isqrt(n)
@@ -3216,14 +3168,6 @@ results `A[ks...]`, where `ks` goes over the positions in the broadcast.
 broadcast_getindex
 
 """
-    findn(A)
-
-Return a vector of indexes for each dimension giving the locations of the non-zeros in `A`
-(determined by `A[i]!=0`).
-"""
-findn
-
-"""
     invoke(f, (types...), args...)
 
 Invoke a method for the given generic function matching the specified types (as a tuple), on
@@ -3379,13 +3323,6 @@ rem
 Display an informational message. Argument `msg` is a string describing the information to be displayed.
 """
 info
-
-"""
-    eigmin(A)
-
-Returns the smallest eigenvalue of `A`.
-"""
-eigmin
 
 """
     ltoh(x)
@@ -4189,13 +4126,6 @@ last argument optionally specifies a size beyond which the buffer may not be gro
 IOBuffer(data=?)
 
 """
-    findmax(A, dims) -> (maxval, index)
-
-For an array input, returns the value and index of the maximum over the given dimensions.
-"""
-findmax(A,dims)
-
-"""
     tempname()
 
 Generate a unique temporary file path.
@@ -4273,45 +4203,6 @@ send
 Compute the inverse hyperbolic tangent of `x`.
 """
 atanh
-
-"""
-    deleteat!(collection, index)
-
-Remove the item at the given `index` and return the modified `collection`. Subsequent items
-are shifted to fill the resulting gap.
-
-```jldoctest
-julia> deleteat!([6, 5, 4, 3, 2, 1], 2)
-5-element Array{Int64,1}:
- 6
- 4
- 3
- 2
- 1
-```
-"""
-deleteat!(collection, index::Integer)
-
-"""
-    deleteat!(collection, itr)
-
-Remove the items at the indices given by `itr`, and return the modified `collection`.
-Subsequent items are shifted to fill the resulting gap. `itr` must be sorted and unique.
-
-```jldoctest
-julia> deleteat!([6, 5, 4, 3, 2, 1], 1:2:5)
-3-element Array{Int64,1}:
- 5
- 3
- 1
-
-julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
-ERROR: ArgumentError: indices must be unique and sorted
- in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:575
- ...
-```
-"""
-deleteat!(collection, itr)
 
 """
     read(stream::IO, T)
@@ -4397,14 +4288,6 @@ Get the next valid string index after `i`. Returns a value greater than `endof(s
 after the end of the string.
 """
 nextind
-
-"""
-    symdiff(s1,s2...)
-
-Construct the symmetric difference of elements in the passed in sets or arrays. Maintains
-order with arrays.
-"""
-symdiff
 
 """
     eta(x)
@@ -4726,13 +4609,6 @@ modf
 Convert a hexadecimal string to the floating point number it represents.
 """
 hex2num
-
-"""
-    ndims(A) -> Integer
-
-Returns the number of dimensions of `A`.
-"""
-ndims
 
 """
     ishermitian(A) -> Bool
@@ -5060,16 +4936,6 @@ expm1
 Show a descriptive representation of an exception object.
 """
 showerror
-
-"""
-    setdiff(s1,s2)
-
-Construct the set of elements in `s1` but not `s2`. Maintains order with arrays. Note that
-both arguments must be collections, and both will be iterated over. In particular,
-`setdiff(set,element)` where `element` is a potential member of `set`, will not work in
-general.
-"""
-setdiff
 
 """
     error(message::AbstractString)
@@ -5884,28 +5750,6 @@ Return ``x^{1/3}``.  The prefix operator `∛` is equivalent to `cbrt`.
 cbrt
 
 """
-    findprev(A, i)
-
-Find the previous index <= `i` of a non-zero element of `A`, or `0` if not found.
-"""
-findprev(A,i)
-
-"""
-    findprev(predicate, A, i)
-
-Find the previous index <= `i` of an element of `A` for which `predicate` returns `true`, or
-`0` if not found.
-"""
-findprev(predicate::Function,A,i)
-
-"""
-    findprev(A, v, i)
-
-Find the previous index <= `i` of an element of `A` equal to `v` (using `==`), or `0` if not found.
-"""
-findprev(A,v,i)
-
-"""
     matchall(r::Regex, s::AbstractString[, overlap::Bool=false]) -> Vector{AbstractString}
 
 Return a vector of the matching substrings from eachmatch.
@@ -6111,30 +5955,6 @@ all elements of the string.
 ispunct
 
 """
-    size(A, [dim...])
-
-Returns a tuple containing the dimensions of `A`. Optionally you can specify the
-dimension(s) you want the length of, and get the length of that dimension, or a tuple of the
-lengths of dimensions you asked for.
-
-    julia> A = rand(2,3,4);
-
-    julia> size(A, 2)
-    3
-
-    julia> size(A,3,2)
-    (4,3)
-"""
-size
-
-"""
-    findmin(A, dims) -> (minval, index)
-
-For an array input, returns the value and index of the minimum over the given dimensions.
-"""
-findmin(A,dims)
-
-"""
     ismount(path) -> Bool
 
 Returns `true` if `path` is a mount point, `false` otherwise.
@@ -6155,13 +5975,6 @@ endswith
 Boolean not.
 """
 Base.:(!)
-
-"""
-    length(A) -> Integer
-
-Returns the number of elements in `A`.
-"""
-length(::AbstractArray)
 
 """
     length(collection) -> Integer
@@ -6301,27 +6114,6 @@ Creates a closure around an expression and runs it on an automatically-chosen pr
 returning a `Future` to the result.
 """
 :@spawn
-
-"""
-    findfirst(A)
-
-Return the index of the first non-zero value in `A` (determined by `A[i]!=0`).
-"""
-findfirst(A)
-
-"""
-    findfirst(A,v)
-
-Return the index of the first element equal to `v` in `A`.
-"""
-findfirst(A,v)
-
-"""
-    findfirst(predicate, A)
-
-Return the index of the first element of `A` for which `predicate` returns `true`.
-"""
-findfirst
 
 """
     promote_rule(type1, type2)
@@ -6822,48 +6614,6 @@ false
 isbits
 
 """
-    findlast(A)
-
-Return the index of the last non-zero value in `A` (determined by `A[i]!=0`).
-"""
-findlast(A)
-
-"""
-    findlast(A, v)
-
-Return the index of the last element equal to `v` in `A`.
-"""
-findlast(A,v)
-
-"""
-    findlast(predicate, A)
-
-Return the index of the last element of `A` for which `predicate` returns `true`.
-"""
-findlast(::Function, A)
-
-"""
-    findnext(A, i)
-
-Find the next index >= `i` of a non-zero element of `A`, or `0` if not found.
-"""
-findnext
-
-"""
-    findnext(predicate, A, i)
-
-Find the next index >= `i` of an element of `A` for which `predicate` returns `true`, or `0` if not found.
-"""
-findnext(::Function,A,i)
-
-"""
-    findnext(A, v, i)
-
-Find the next index >= `i` of an element of `A` equal to `v` (using `==`), or `0` if not found.
-"""
-findnext(A,v,i)
-
-"""
     angle(z)
 
 Compute the phase angle in radians of a complex number `z`.
@@ -6908,18 +6658,6 @@ Broadcasts the arrays `As` to a common size by expanding singleton dimensions, a
 an array of the results `f(as...)` for each position.
 """
 broadcast
-
-"""
-    eigvecs(A, [eigvals,][permute=true,][scale=true]) -> Matrix
-
-Returns a matrix `M` whose columns are the eigenvectors of `A`. (The `k`th eigenvector can
-be obtained from the slice `M[:, k]`.) The `permute` and `scale` keywords are the same as
-for [`eigfact`](:func:`eigfact`).
-
-For [`SymTridiagonal`](:class:`SymTridiagonal`) matrices, if the optional vector of
-eigenvalues `eigvals` is specified, returns the specific corresponding eigenvectors.
-"""
-eigvecs
 
 """
     ntoh(x)
@@ -7365,45 +7103,12 @@ unsigned without checking for negative values.
 unsigned
 
 """
-    eigfact(A,[irange,][vl,][vu,][permute=true,][scale=true]) -> Eigen
-
-Computes the eigenvalue decomposition of `A`, returning an `Eigen` factorization object `F`
-which contains the eigenvalues in `F[:values]` and the eigenvectors in the columns of the
-matrix `F[:vectors]`. (The `k`th eigenvector can be obtained from the slice `F[:vectors][:, k]`.)
-
-The following functions are available for `Eigen` objects: `inv`, `det`.
-
-If `A` is [`Symmetric`](:class:`Symmetric`), [`Hermitian`](:class:`Hermitian`) or
-[`SymTridiagonal`](:class:`SymTridiagonal`), it is possible to calculate only a subset of
-the eigenvalues by specifying either a [`UnitRange`](:class:`UnitRange`) `irange` covering
-indices of the sorted eigenvalues or a pair `vl` and `vu` for the lower and upper boundaries
-of the eigenvalues.
-
-For general nonsymmetric matrices it is possible to specify how the matrix is balanced
-before the eigenvector calculation. The option `permute=true` permutes the matrix to become
-closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
-make rows and columns more equal in norm. The default is `true` for both options.
-"""
-eigfact(A,?,?,?,?)
-
-"""
-    eigfact(A, B) -> GeneralizedEigen
-
-Computes the generalized eigenvalue decomposition of `A` and `B`, returning a
-`GeneralizedEigen` factorization object `F` which contains the generalized eigenvalues in
-`F[:values]` and the generalized eigenvectors in the columns of the matrix `F[:vectors]`.
-(The `k`th generalized eigenvector can be obtained from the slice `F[:vectors][:, k]`.)
-"""
-eigfact(A,B)
-
-"""
     mkdir(path, [mode])
 
 Make a new directory with name `path` and permissions `mode`. `mode` defaults to `0o777`,
 modified by the current file creation mask.
 """
 mkdir
-
 
 """
     midpoints(e)
@@ -7464,33 +7169,6 @@ a string. A character is classified as lowercase if it belongs to Unicode catego
 Letter: Lowercase.
 """
 islower
-
-"""
-    eig(A,[irange,][vl,][vu,][permute=true,][scale=true]) -> D, V
-
-Computes eigenvalues and eigenvectors of `A`. See [`eigfact`](:func:`eigfact`) for details
-on the `permute` and `scale` keyword arguments. The eigenvectors are returned columnwise.
-
-```jldoctest
-julia> eig([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
-([1.0,3.0,18.0],
-[1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
-```
-
-`eig` is a wrapper around [`eigfact`](:func:`eigfact`), extracting all parts of the
-factorization to a tuple; where possible, using [`eigfact`](:func:`eigfact`) is recommended.
-"""
-eig(A,?,?,?)
-
-"""
-    eig(A, B) -> D, V
-
-Computes generalized eigenvalues and vectors of `A` with respect to `B`.
-
-`eig` is a wrapper around [`eigfact`](:func:`eigfact`), extracting all parts of the
-factorization to a tuple; where possible, using [`eigfact`](:func:`eigfact`) is recommended.
-"""
-eig(A,B)
 
 """
     exp2(x)

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -54,6 +54,27 @@ function eigfact!{T<:BlasComplex}(A::StridedMatrix{T}; permute::Bool=true, scale
     ishermitian(A) && return eigfact!(Hermitian(A))
     return Eigen(LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)[[2,4]]...)
 end
+
+"""
+    eigfact(A,[irange,][vl,][vu,][permute=true,][scale=true]) -> Eigen
+
+Computes the eigenvalue decomposition of `A`, returning an [`Eigen`](:obj:`Eigen`) factorization object `F`
+which contains the eigenvalues in `F[:values]` and the eigenvectors in the columns of the
+matrix `F[:vectors]`. (The `k`th eigenvector can be obtained from the slice `F[:vectors][:, k]`.)
+
+The following functions are available for `Eigen` objects: [`inv`](:func:`inv`), [`det`](:func:`det`), and [`isposdef`](:func:`isposdef`).
+
+If `A` is [`Symmetric`](:class:`Symmetric`), [`Hermitian`](:class:`Hermitian`) or
+[`SymTridiagonal`](:class:`SymTridiagonal`), it is possible to calculate only a subset of
+the eigenvalues by specifying either a [`UnitRange`](:class:`UnitRange`) `irange` covering
+indices of the sorted eigenvalues or a pair `vl` and `vu` for the lower and upper boundaries
+of the eigenvalues.
+
+For general nonsymmetric matrices it is possible to specify how the matrix is balanced
+before the eigenvector calculation. The option `permute=true` permutes the matrix to become
+closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
+make rows and columns more equal in norm. The default is `true` for both options.
+"""
 function eigfact{T}(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true)
     S = promote_type(Float32, typeof(one(T)/norm(one(T))))
     eigfact!(copy_oftype(A, S), permute = permute, scale = scale)
@@ -64,12 +85,40 @@ function eig(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=tr
     F = eigfact(A, permute=permute, scale=scale)
     F.values, F.vectors
 end
+
+"""
+    eig(A,[irange,][vl,][vu,][permute=true,][scale=true]) -> D, V
+
+Computes eigenvalues (`D`) and eigenvectors (`V`) of `A`.
+See [`eigfact`](:func:`eigfact`) for details on the
+`irange`, `vl`, and `vu` arguments
+and the `permute` and `scale` keyword arguments.
+The eigenvectors are returned columnwise.
+
+```jldoctest
+julia> eig([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
+([1.0,3.0,18.0],
+[1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+```
+
+`eig` is a wrapper around [`eigfact`](:func:`eigfact`), extracting all parts of the
+factorization to a tuple; where possible, using [`eigfact`](:func:`eigfact`) is recommended.
+"""
 function eig(A::AbstractMatrix, args...)
     F = eigfact(A, args...)
     F.values, F.vectors
 end
 
-#Calculates eigenvectors
+"""
+    eigvecs(A, [eigvals,][permute=true,][scale=true]) -> Matrix
+
+Returns a matrix `M` whose columns are the eigenvectors of `A`. (The `k`th eigenvector can
+be obtained from the slice `M[:, k]`.) The `permute` and `scale` keywords are the same as
+for [`eigfact`](:func:`eigfact`).
+
+For [`SymTridiagonal`](:class:`SymTridiagonal`) matrices, if the optional vector of
+eigenvalues `eigvals` is specified, returns the specific corresponding eigenvectors.
+"""
 eigvecs(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true) =
     eigvecs(eigfact(A, permute=permute, scale=scale))
 eigvecs{T,V,S,U}(F::Union{Eigen{T,V,S,U}, GeneralizedEigen{T,V,S,U}}) = F[:vectors]::S
@@ -77,10 +126,9 @@ eigvecs{T,V,S,U}(F::Union{Eigen{T,V,S,U}, GeneralizedEigen{T,V,S,U}}) = F[:vecto
 eigvals{T,V,S,U}(F::Union{Eigen{T,V,S,U}, GeneralizedEigen{T,V,S,U}}) = F[:values]::U
 
 """
-
     eigvals!(A,[irange,][vl,][vu]) -> values
 
-Same as `eigvals`, but saves space by overwriting the input `A` (and `B`), instead of creating a copy.
+Same as [`eigvals`](:func:`eigvals`), but saves space by overwriting the input `A`, instead of creating a copy.
 """
 function eigvals!{T<:BlasReal}(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true)
     issymmetric(A) && return eigvals!(Symmetric(A))
@@ -100,8 +148,37 @@ function eigvals{T<:Number}(x::T; kwargs...)
     return imag(val) == 0 ? [real(val)] : [val]
 end
 
-# TO DO: Put message about not being able to sort complex numbers back in!
-#Computes maximum and minimum eigenvalue
+"""
+    eigmax(A; permute::Bool=true, scale::Bool=true)
+
+Returns the largest eigenvalue of `A`.
+The option `permute=true` permutes the matrix to become
+closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
+make rows and columns more equal in norm.
+Note that if the eigenvalues of `A` are complex,
+this method will fail, since complex numbers cannot
+be sorted.
+
+```jldoctest
+julia> A = [0 im; -im 0]
+2×2 Array{Complex{Int64},2}:
+ 0+0im  0+1im
+ 0-1im  0+0im
+
+julia> eigmax(A)
+1.0
+
+julia> A = [0 im; -1 0]
+2×2 Array{Complex{Int64},2}:
+  0+0im  0+1im
+ -1+0im  0+0im
+
+julia> eigmax(A)
+ERROR: DomainError:
+ in #eigmax#30(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:108
+ in eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:106
+```
+"""
 function eigmax(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=true)
     v = eigvals(A, permute = permute, scale = scale)
     if eltype(v)<:Complex
@@ -109,6 +186,38 @@ function eigmax(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool
     end
     maximum(v)
 end
+
+"""
+    eigmin(A; permute::Bool=true, scale::Bool=true)
+
+Returns the smallest eigenvalue of `A`.
+The option `permute=true` permutes the matrix to become
+closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
+make rows and columns more equal in norm.
+Note that if the eigenvalues of `A` are complex,
+this method will fail, since complex numbers cannot
+be sorted.
+
+```jldoctest
+julia> A = [0 im; -im 0]
+2×2 Array{Complex{Int64},2}:
+ 0+0im  0+1im
+ 0-1im  0+0im
+
+julia> eigmin(A)
+-1.0
+
+julia> A = [0 im; -1 0]
+2×2 Array{Complex{Int64},2}:
+  0+0im  0+1im
+ -1+0im  0+0im
+
+julia> eigmin(A)
+ERROR: DomainError:
+ in #eigmin#31(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:115
+ in eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:113
+```
+"""
 function eigmin(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=true)
     v = eigvals(A, permute = permute, scale = scale)
     if eltype(v)<:Complex
@@ -149,6 +258,15 @@ function eigfact!{T<:BlasComplex}(A::StridedMatrix{T}, B::StridedMatrix{T})
     alpha, beta, _, vr = LAPACK.ggev!('N', 'V', A, B)
     return GeneralizedEigen(alpha./beta, vr)
 end
+
+"""
+    eigfact(A, B) -> GeneralizedEigen
+
+Computes the generalized eigenvalue decomposition of `A` and `B`, returning a
+`GeneralizedEigen` factorization object `F` which contains the generalized eigenvalues in
+`F[:values]` and the generalized eigenvectors in the columns of the matrix `F[:vectors]`.
+(The `k`th generalized eigenvector can be obtained from the slice `F[:vectors][:, k]`.)
+"""
 function eigfact{TA,TB}(A::AbstractMatrix{TA}, B::AbstractMatrix{TB})
     S = promote_type(Float32, typeof(one(TA)/norm(one(TA))),TB)
     return eigfact!(copy_oftype(A, S), copy_oftype(B, S))
@@ -156,6 +274,30 @@ end
 
 eigfact(A::Number, B::Number) = eigfact(fill(A,1,1), fill(B,1,1))
 
+"""
+    eig(A, B) -> D, V
+
+Computes generalized eigenvalues (`D`) and vectors (`V`) of `A` with respect to `B`.
+
+`eig` is a wrapper around [`eigfact`](:func:`eigfact`), extracting all parts of the
+factorization to a tuple; where possible, using [`eigfact`](:func:`eigfact`) is recommended.
+
+```jldoctest
+julia> A = [1 0; 0 -1]
+2×2 Array{Int64,2}:
+ 1   0
+ 0  -1
+
+julia> B = [0 1; 1 0]
+2×2 Array{Int64,2}:
+ 0  1
+ 1  0
+
+julia> eig(A, B)
+(Complex{Float64}[0.0+1.0im,0.0-1.0im],
+Complex{Float64}[0.0-1.0im 0.0+1.0im; -1.0-0.0im -1.0+0.0im])
+```
+"""
 function eig(A::AbstractMatrix, B::AbstractMatrix)
     F = eigfact(A,B)
     F.values, F.vectors
@@ -165,6 +307,11 @@ function eig(A::Number, B::Number)
     F.values, F.vectors
 end
 
+"""
+    eigvals!(A, B) -> values
+
+Same as [`eigvals`](:func:`eigvals`), but saves space by overwriting the input `A` (and `B`), instead of creating copies.
+"""
 function eigvals!{T<:BlasReal}(A::StridedMatrix{T}, B::StridedMatrix{T})
     issymmetric(A) && isposdef(B) && return eigvals!(Symmetric(A), Symmetric(B))
     alphar, alphai, beta, vl, vr = LAPACK.ggev!('N', 'N', A, B)
@@ -175,11 +322,57 @@ function eigvals!{T<:BlasComplex}(A::StridedMatrix{T}, B::StridedMatrix{T})
     alpha, beta, vl, vr = LAPACK.ggev!('N', 'N', A, B)
     alpha./beta
 end
+
+"""
+    eigvals(A, B) -> values
+
+Computes the generalized eigenvalues of `A` and `B`.
+
+```jldoctest
+julia> A = [1 0; 0 -1]
+2×2 Array{Int64,2}:
+ 1   0
+ 0  -1
+
+julia> B = [0 1; 1 0]
+2×2 Array{Int64,2}:
+ 0  1
+ 1  0
+
+julia> eigvals(A,B)
+2-element Array{Complex{Float64},1}:
+ 0.0+1.0im
+ 0.0-1.0im
+```
+"""
 function eigvals{TA,TB}(A::AbstractMatrix{TA}, B::AbstractMatrix{TB})
     S = promote_type(Float32, typeof(one(TA)/norm(one(TA))),TB)
     return eigvals!(copy_oftype(A, S), copy_oftype(B, S))
 end
 
+"""
+    eigvecs(A, B) -> Matrix
+
+Returns a matrix `M` whose columns are the generalized eigenvectors of `A` and `B`. (The `k`th eigenvector can
+be obtained from the slice `M[:, k]`.)
+
+```jldoctest
+julia> A = [1 0; 0 -1]
+2×2 Array{Int64,2}:
+ 1   0
+ 0  -1
+
+julia> B = [0 1; 1 0]
+2×2 Array{Int64,2}:
+ 0  1
+ 1  0
+
+julia> eigvecs(A, B)
+2×2 Array{Complex{Float64},2}:
+  0.0-1.0im   0.0+1.0im
+ -1.0-0.0im  -1.0+0.0im
+```
+"""
 eigvecs(A::AbstractMatrix, B::AbstractMatrix) = eigvecs(eigfact(A, B))
 
 # Conversion methods

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -380,6 +380,11 @@ function findmin!{R}(rval::AbstractArray{R},
     findminmax!(<, initarray!(rval, scalarmin, init), rind, A)
 end
 
+"""
+    findmin(A, region) -> (minval, index)
+
+For an array input, returns the value and index of the minimum over the given region.
+"""
 function findmin{T}(A::AbstractArray{T}, region)
     if isempty(A)
         return (similar(A, reduced_dims0(A, region)),
@@ -402,6 +407,11 @@ function findmax!{R}(rval::AbstractArray{R},
     findminmax!(>, initarray!(rval, scalarmax, init), rind, A)
 end
 
+"""
+    findmax(A, region) -> (maxval, index)
+
+For an array input, returns the value and index of the maximum over the given region.
+"""
 function findmax{T}(A::AbstractArray{T}, region)
     if isempty(A)
         return (similar(A, reduced_dims0(A,region)),

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -9,21 +9,28 @@
 Basic functions
 ---------------
 
-.. function:: ndims(A) -> Integer
+.. function:: ndims(A::AbstractArray) -> Integer
 
    .. Docstring generated from Julia source
 
    Returns the number of dimensions of ``A``\ .
 
-.. function:: size(A, [dim...])
+   .. doctest::
+
+       julia> A = ones(3,4,5);
+
+       julia> ndims(A)
+       3
+
+.. function:: size(A::AbstractArray, [dim...])
 
    .. Docstring generated from Julia source
 
    Returns a tuple containing the dimensions of ``A``\ . Optionally you can specify the dimension(s) you want the length of, and get the length of that dimension, or a tuple of the lengths of dimensions you asked for.
 
-   .. code-block:: julia
+   .. doctest::
 
-       julia> A = rand(2,3,4);
+       julia> A = ones(2,3,4);
 
        julia> size(A, 2)
        3
@@ -43,11 +50,18 @@ Basic functions
 
    Returns the valid range of indices for array ``A`` along dimension ``d``\ .
 
-.. function:: length(A) -> Integer
+.. function:: length(A::AbstractArray) -> Integer
 
    .. Docstring generated from Julia source
 
    Returns the number of elements in ``A``\ .
+
+   .. doctest::
+
+       julia> A = ones(3,4,5);
+
+       julia> length(A)
+       60
 
 .. function:: eachindex(A...)
 
@@ -116,17 +130,34 @@ Basic functions
 
    Convert an array to its complex conjugate in-place.
 
-.. function:: stride(A, k)
+.. function:: stride(A, k::Integer)
 
    .. Docstring generated from Julia source
 
    Returns the distance in memory (in number of elements) between adjacent elements in dimension ``k``\ .
+
+   .. doctest::
+
+       julia> A = ones(3,4,5);
+
+       julia> stride(A,2)
+       3
+
+       julia> stride(A,3)
+       12
 
 .. function:: strides(A)
 
    .. Docstring generated from Julia source
 
    Returns a tuple of the memory strides in each dimension.
+
+   .. doctest::
+
+       julia> A = ones(3,4,5);
+
+       julia> strides(A)
+       (1,3,12)
 
 .. function:: ind2sub(dims, index) -> subscripts
 
@@ -620,19 +651,62 @@ Indexing, Assignment, and Concatenation
 
    .. Docstring generated from Julia source
 
-   Return a vector of the linear indexes of the non-zeros in ``A`` (determined by ``A[i]!=0``\ ). A common use of this is to convert a boolean array to an array of indexes of the ``true`` elements.
+   Return a vector of the linear indexes of the non-zeros in ``A`` (determined by ``A[i]!=0``\ ). A common use of this is to convert a boolean array to an array of indexes of the ``true`` elements. If there are no non-zero elements of ``A``\ , ``find`` returns an empty array.
 
-.. function:: find(f,A)
+   .. doctest::
+
+       julia> A = [true false; false true]
+       2×2 Array{Bool,2}:
+         true  false
+        false   true
+
+       julia> find(A)
+       2-element Array{Int64,1}:
+        1
+        4
+
+.. function:: find(f::Function, A)
 
    .. Docstring generated from Julia source
 
-   Return a vector of the linear indexes of ``A`` where ``f`` returns ``true``\ .
+   Return a vector ``I`` of the linear indexes of ``A`` where ``f(A[I])`` returns ``true``\ . If there are no such elements of ``A``\ , find returns an empty array.
+
+   .. doctest::
+
+       julia> A = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
+
+       julia> find(isodd,A)
+       2-element Array{Int64,1}:
+        1
+        2
 
 .. function:: findn(A)
 
    .. Docstring generated from Julia source
 
-   Return a vector of indexes for each dimension giving the locations of the non-zeros in ``A`` (determined by ``A[i]!=0``\ ).
+   Return a vector of indexes for each dimension giving the locations of the non-zeros in ``A`` (determined by ``A[i]!=0``\ ). If there are no non-zero elements of ``A``\ , ``findn`` returns a 2-tuple of empty arrays.
+
+   .. doctest::
+
+       julia> A = [1 2 0; 0 0 3; 0 4 0]
+       3×3 Array{Int64,2}:
+        1  2  0
+        0  0  3
+        0  4  0
+
+       julia> findn(A)
+       ([1,1,3,2],[1,2,2,3])
+
+       julia> A = zeros(2,2)
+       2×2 Array{Float64,2}:
+        0.0  0.0
+        0.0  0.0
+
+       julia> findn(A)
+       (Int64[],Int64[])
 
 .. function:: findnz(A)
 
@@ -640,77 +714,249 @@ Indexing, Assignment, and Concatenation
 
    Return a tuple ``(I, J, V)`` where ``I`` and ``J`` are the row and column indexes of the non-zero values in matrix ``A``\ , and ``V`` is a vector of the non-zero values.
 
+   .. doctest::
+
+       julia> A = [1 2 0; 0 0 3; 0 4 0]
+       3×3 Array{Int64,2}:
+        1  2  0
+        0  0  3
+        0  4  0
+
+       julia> findnz(A)
+       ([1,1,3,2],[1,2,2,3],[1,2,4,3])
+
 .. function:: findfirst(A)
 
    .. Docstring generated from Julia source
 
-   Return the index of the first non-zero value in ``A`` (determined by ``A[i]!=0``\ ).
+   Return the linear index of the first non-zero value in ``A`` (determined by ``A[i]!=0``\ ). Returns ``0`` if no such value is found.
 
-.. function:: findfirst(A,v)
+   .. doctest::
+
+       julia> A = [0 0; 1 0]
+       2×2 Array{Int64,2}:
+        0  0
+        1  0
+
+       julia> findfirst(A)
+       2
+
+.. function:: findfirst(A, v)
 
    .. Docstring generated from Julia source
 
-   Return the index of the first element equal to ``v`` in ``A``\ .
+   Return the linear index of the first element equal to ``v`` in ``A``\ . Returns ``0`` if ``v`` is not found.
 
-.. function:: findfirst(predicate, A)
+   .. doctest::
+
+       julia> A = [4 6; 2 2]
+       2×2 Array{Int64,2}:
+        4  6
+        2  2
+
+       julia> findfirst(A,2)
+       2
+
+       julia> findfirst(A,3)
+       0
+
+.. function:: findfirst(predicate::Function, A)
 
    .. Docstring generated from Julia source
 
-   Return the index of the first element of ``A`` for which ``predicate`` returns ``true``\ .
+   Return the linear index of the first element of ``A`` for which ``predicate`` returns ``true``\ . Returns ``0`` if there is no such element.
+
+   .. doctest::
+
+       julia> A = [1 4; 2 2]
+       2×2 Array{Int64,2}:
+        1  4
+        2  2
+
+       julia> findfirst(iseven, A)
+       2
+
+       julia> findfirst(x -> x>10, A)
+       0
 
 .. function:: findlast(A)
 
    .. Docstring generated from Julia source
 
-   Return the index of the last non-zero value in ``A`` (determined by ``A[i]!=0``\ ).
+   Return the linear index of the last non-zero value in ``A`` (determined by ``A[i]!=0``\ ). Returns ``0`` if there is no non-zero value in ``A``\ .
+
+   .. doctest::
+
+       julia> A = [1 0; 1 0]
+       2×2 Array{Int64,2}:
+        1  0
+        1  0
+
+       julia> findlast(A)
+       2
+
+       julia> A = zeros(2,2)
+       2×2 Array{Float64,2}:
+        0.0  0.0
+        0.0  0.0
+
+       julia> findlast(A)
+       0
 
 .. function:: findlast(A, v)
 
    .. Docstring generated from Julia source
 
-   Return the index of the last element equal to ``v`` in ``A``\ .
+   Return the linear index of the last element equal to ``v`` in ``A``\ . Returns ``0`` if there is no element of ``A`` equal to ``v``\ .
 
-.. function:: findlast(predicate, A)
+   .. doctest::
 
-   .. Docstring generated from Julia source
+       julia> A = [1 2; 2 1]
+       2×2 Array{Int64,2}:
+        1  2
+        2  1
 
-   Return the index of the last element of ``A`` for which ``predicate`` returns ``true``\ .
+       julia> findlast(A,1)
+       4
 
-.. function:: findnext(A, i)
+       julia> findlast(A,2)
+       3
 
-   .. Docstring generated from Julia source
+       julia> findlast(A,3)
+       0
 
-   Find the next index >= ``i`` of a non-zero element of ``A``\ , or ``0`` if not found.
-
-.. function:: findnext(predicate, A, i)
-
-   .. Docstring generated from Julia source
-
-   Find the next index >= ``i`` of an element of ``A`` for which ``predicate`` returns ``true``\ , or ``0`` if not found.
-
-.. function:: findnext(A, v, i)
+.. function:: findlast(predicate::Function, A)
 
    .. Docstring generated from Julia source
 
-   Find the next index >= ``i`` of an element of ``A`` equal to ``v`` (using ``==``\ ), or ``0`` if not found.
+   Return the linear index of the last element of ``A`` for which ``predicate`` returns ``true``\ . Returns ``0`` if there is no such element.
 
-.. function:: findprev(A, i)
+   .. doctest::
+
+       julia> A = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
+
+       julia> findlast(isodd, A)
+       2
+
+       julia> findlast(x -> x > 5, A)
+       0
+
+.. function:: findnext(A, i::Integer)
 
    .. Docstring generated from Julia source
 
-   Find the previous index <= ``i`` of a non-zero element of ``A``\ , or ``0`` if not found.
+   Find the next linear index >= ``i`` of a non-zero element of ``A``\ , or ``0`` if not found.
 
-.. function:: findprev(predicate, A, i)
+   .. doctest::
+
+       julia> A = [0 0; 1 0]
+       2×2 Array{Int64,2}:
+        0  0
+        1  0
+
+       julia> findnext(A,1)
+       2
+
+       julia> findnext(A,3)
+       0
+
+.. function:: findnext(predicate::Function, A, i::Integer)
 
    .. Docstring generated from Julia source
 
-   Find the previous index <= ``i`` of an element of ``A`` for which ``predicate`` returns ``true``\ , or ``0`` if not found.
+   Find the next linear index >= ``i`` of an element of ``A`` for which ``predicate`` returns ``true``\ , or ``0`` if not found.
 
-.. function:: findprev(A, v, i)
+   .. doctest::
+
+       julia> A = [1 4; 2 2]
+       2×2 Array{Int64,2}:
+        1  4
+        2  2
+
+       julia> findnext(isodd, A, 1)
+       1
+
+       julia> findnext(isodd, A, 2)
+       0
+
+.. function:: findnext(A, v, i::Integer)
 
    .. Docstring generated from Julia source
 
-   Find the previous index <= ``i`` of an element of ``A`` equal to ``v`` (using ``==``\ ), or ``0`` if not found.
+   Find the next linear index >= ``i`` of an element of ``A`` equal to ``v`` (using ``==``\ ), or ``0`` if not found.
+
+   .. doctest::
+
+       julia> A = [1 4; 2 2]
+       2×2 Array{Int64,2}:
+        1  4
+        2  2
+
+       julia> findnext(A,4,4)
+       0
+
+       julia> findnext(A,4,3)
+       3
+
+.. function:: findprev(A, i::Integer)
+
+   .. Docstring generated from Julia source
+
+   Find the previous linear index <= ``i`` of a non-zero element of ``A``\ , or ``0`` if not found.
+
+   .. doctest::
+
+       julia> A = [0 0; 1 2]
+       2×2 Array{Int64,2}:
+        0  0
+        1  2
+
+       julia> findprev(A,2)
+       2
+
+       julia> findprev(A,1)
+       0
+
+.. function:: findprev(predicate::Function, A, i::Integer)
+
+   .. Docstring generated from Julia source
+
+   Find the previous linear index <= ``i`` of an element of ``A`` for which ``predicate`` returns ``true``\ , or ``0`` if not found.
+
+   .. doctest::
+
+       julia> A = [4 6; 1 2]
+       2×2 Array{Int64,2}:
+        4  6
+        1  2
+
+       julia> findprev(isodd, A, 1)
+       0
+
+       julia> findprev(isodd, A, 3)
+       2
+
+.. function:: findprev(A, v, i::Integer)
+
+   .. Docstring generated from Julia source
+
+   Find the previous linear index <= ``i`` of an element of ``A`` equal to ``v`` (using ``==``\ ), or ``0`` if not found.
+
+   .. doctest::
+
+       julia> A = [0 0; 1 2]
+       2×2 Array{Int64,2}:
+        0  0
+        1  2
+
+       julia> findprev(A, 1, 4)
+       2
+
+       julia> findprev(A, 1, 1)
+       0
 
 .. function:: permutedims(A, perm)
 

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -480,7 +480,7 @@ Iterable Collections
 
    .. Docstring generated from Julia source
 
-   Returns the index of the maximum element in a collection.
+   Returns the index of the maximum element in a collection. The collection must not be empty.
 
    .. doctest::
 
@@ -491,7 +491,7 @@ Iterable Collections
 
    .. Docstring generated from Julia source
 
-   Returns the index of the minimum element in a collection.
+   Returns the index of the minimum element in a collection. The collection must not be empty.
 
    .. doctest::
 
@@ -509,11 +509,11 @@ Iterable Collections
        julia> findmax([8,0.1,-9,pi])
        (8.0,1)
 
-.. function:: findmax(A, dims) -> (maxval, index)
+.. function:: findmax(A, region) -> (maxval, index)
 
    .. Docstring generated from Julia source
 
-   For an array input, returns the value and index of the maximum over the given dimensions.
+   For an array input, returns the value and index of the maximum over the given region.
 
 .. function:: findmin(itr) -> (x, index)
 
@@ -526,11 +526,11 @@ Iterable Collections
        julia> findmin([8,0.1,-9,pi])
        (-9.0,3)
 
-.. function:: findmin(A, dims) -> (minval, index)
+.. function:: findmin(A, region) -> (minval, index)
 
    .. Docstring generated from Julia source
 
-   For an array input, returns the value and index of the minimum over the given dimensions.
+   For an array input, returns the value and index of the minimum over the given region.
 
 .. function:: findmax!(rval, rind, A, [init=true]) -> (maxval, index)
 
@@ -1162,11 +1162,18 @@ Set-Like Collections
 
    Construct the intersection of two or more sets. Maintains order and multiplicity of the first argument for arrays and ranges.
 
-.. function:: setdiff(s1,s2)
+.. function:: setdiff(a, b)
 
    .. Docstring generated from Julia source
 
-   Construct the set of elements in ``s1`` but not ``s2``\ . Maintains order with arrays. Note that both arguments must be collections, and both will be iterated over. In particular, ``setdiff(set,element)`` where ``element`` is a potential member of ``set``\ , will not work in general.
+   Construct the set of elements in ``a`` but not ``b``\ . Maintains order with arrays. Note that both arguments must be collections, and both will be iterated over. In particular, ``setdiff(set,element)`` where ``element`` is a potential member of ``set``\ , will not work in general.
+
+   .. doctest::
+
+       julia> setdiff([1,2,3],[3,4,5])
+       2-element Array{Int64,1}:
+        1
+        2
 
 .. function:: setdiff!(s, iterable)
 
@@ -1174,11 +1181,19 @@ Set-Like Collections
 
    Remove each element of ``iterable`` from set ``s`` in-place.
 
-.. function:: symdiff(s1,s2...)
+.. function:: symdiff(a, b, rest...)
 
    .. Docstring generated from Julia source
 
    Construct the symmetric difference of elements in the passed in sets or arrays. Maintains order with arrays.
+
+   .. doctest::
+
+       julia> symdiff([1,2,3],[3,4,5],[4,5,6])
+       3-element Array{Int64,1}:
+        1
+        2
+        6
 
 .. function:: symdiff!(s, n)
 
@@ -1332,11 +1347,11 @@ Dequeues
         2
         1
 
-.. function:: deleteat!(collection, index)
+.. function:: deleteat!(a::Vector, i::Integer)
 
    .. Docstring generated from Julia source
 
-   Remove the item at the given ``index`` and return the modified ``collection``\ . Subsequent items are shifted to fill the resulting gap.
+   Remove the item at the given ``i`` and return the modified ``a``\ . Subsequent items are shifted to fill the resulting gap.
 
    .. doctest::
 
@@ -1348,11 +1363,11 @@ Dequeues
         2
         1
 
-.. function:: deleteat!(collection, itr)
+.. function:: deleteat!(a::Vector, inds)
 
    .. Docstring generated from Julia source
 
-   Remove the items at the indices given by ``itr``\ , and return the modified ``collection``\ . Subsequent items are shifted to fill the resulting gap. ``itr`` must be sorted and unique.
+   Remove the items at the indices given by ``inds``\ , and return the modified ``a``\ . Subsequent items are shifted to fill the resulting gap. ``inds`` must be sorted and unique.
 
    .. doctest::
 
@@ -1364,7 +1379,7 @@ Dequeues
 
        julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
        ERROR: ArgumentError: indices must be unique and sorted
-        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:575
+        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:576
         ...
 
 .. function:: splice!(collection, index, [replacement]) -> item
@@ -1527,17 +1542,56 @@ changed efficiently.
 
    A ``PriorityQueue`` acts like a ``Dict``\ , mapping values to their priorities, with the addition of a ``dequeue!`` function to remove the lowest priority element.
 
+   .. doctest::
+
+       julia> a = Base.Collections.PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+       Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+         "c" => 1
+         "b" => 3
+         "a" => 2
+
 .. function:: enqueue!(pq, k, v)
 
    .. Docstring generated from Julia source
 
    Insert the a key ``k`` into a priority queue ``pq`` with priority ``v``\ .
 
+   .. doctest::
+
+       julia> a = Base.Collections.PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+       Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+         "c" => 1
+         "b" => 3
+         "a" => 2
+
+       julia> Base.Collections.enqueue!(a, "d", 4)
+       Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 4 entries:
+         "c" => 1
+         "b" => 3
+         "a" => 2
+         "d" => 4
+
 .. function:: dequeue!(pq)
 
    .. Docstring generated from Julia source
 
    Remove and return the lowest priority key from a priority queue.
+
+   .. doctest::
+
+       julia> a = Base.Collections.PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+       Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+         "c" => 1
+         "b" => 3
+         "a" => 2
+
+       julia> Base.Collections.dequeue!(a)
+       "c"
+
+       julia> a
+       Base.Collections.PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 2 entries:
+         "b" => 3
+         "a" => 2
 
 .. function:: peek(pq)
 
@@ -1575,23 +1629,57 @@ lower level functions for performing binary heap operations on arrays. Each
 function takes an optional ordering argument. If not given, default ordering
 is used, so that elements popped from the heap are given in ascending order.
 
-.. function:: heapify(v, [ord])
+.. function:: heapify(v, ord::Ordering=Forward)
 
    .. Docstring generated from Julia source
 
    Returns a new vector in binary heap order, optionally using the given ordering.
 
-.. function:: heapify!(v, [ord])
+   .. doctest::
+
+       julia> a = [1,3,4,5,2];
+
+       julia> Base.Collections.heapify(a)
+       5-element Array{Int64,1}:
+        1
+        2
+        4
+        5
+        3
+
+       julia> Base.Collections.heapify(a, Base.Order.Reverse)
+       5-element Array{Int64,1}:
+        5
+        3
+        4
+        1
+        2
+
+.. function:: heapify!(v, ord::Ordering=Forward)
 
    .. Docstring generated from Julia source
 
    In-place :func:`heapify`\ .
 
-.. function:: isheap(v, [ord])
+.. function:: isheap(v, ord::Ordering=Forward)
 
    .. Docstring generated from Julia source
 
    Return ``true`` if an array is heap-ordered according to the given order.
+
+   .. doctest::
+
+       julia> a = [1,2,3]
+       3-element Array{Int64,1}:
+        1
+        2
+        3
+
+       julia> Base.Collections.isheap(a,Base.Order.Forward)
+       true
+
+       julia> Base.Collections.isheap(a,Base.Order.Reverse)
+       false
 
 .. function:: heappush!(v, x, [ord])
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -624,11 +624,11 @@ Text I/O
 
    The columns are assumed to be separated by one or more whitespaces. The end of line delimiter is taken as ``\n``\ . If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a heterogeneous array of numbers and strings is returned.
 
-.. function:: writedlm(f, A, dl='\\t'; opts)
+.. function:: writedlm(f, A, delim='\\t'; opts)
 
    .. Docstring generated from Julia source
 
-   Write ``A`` (a vector, matrix or an iterable collection of iterable rows) as text to ``f`` (either a filename string or an ``IO`` stream) using the given delimiter ``delim`` (which defaults to tab, but can be any printable Julia object, typically a ``Char`` or ``AbstractString``\ ).
+   Write ``A`` (a vector, matrix, or an iterable collection of iterable rows) as text to ``f`` (either a filename string or an :class:`IO` stream) using the given delimiter ``delim`` (which defaults to tab, but can be any printable Julia object, typically a ``Char`` or ``AbstractString``\ ).
 
    For example, two vectors ``x`` and ``y`` of the same length can be written as two columns of tab-delimited text to ``f`` by either ``writedlm(f, [x y])`` or by ``writedlm(f, zip(x, y))``\ .
 
@@ -642,7 +642,7 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   Equivalent to ``writedlm`` with ``delim`` set to comma.
+   Equivalent to :func:`writedlm` with ``delim`` set to comma.
 
 .. function:: Base64EncodePipe(ostream)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -580,7 +580,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Computes eigenvalues and eigenvectors of ``A``\ . See :func:`eigfact` for details on the ``permute`` and ``scale`` keyword arguments. The eigenvectors are returned columnwise.
+   Computes eigenvalues (``D``\ ) and eigenvectors (``V``\ ) of ``A``\ . See :func:`eigfact` for details on the ``irange``\ , ``vl``\ , and ``vu`` arguments and the ``permute`` and ``scale`` keyword arguments. The eigenvectors are returned columnwise.
 
    .. doctest::
 
@@ -594,9 +594,25 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Computes generalized eigenvalues and vectors of ``A`` with respect to ``B``\ .
+   Computes generalized eigenvalues (``D``\ ) and vectors (``V``\ ) of ``A`` with respect to ``B``\ .
 
    ``eig`` is a wrapper around :func:`eigfact`\ , extracting all parts of the factorization to a tuple; where possible, using :func:`eigfact` is recommended.
+
+   .. doctest::
+
+       julia> A = [1 0; 0 -1]
+       2×2 Array{Int64,2}:
+        1   0
+        0  -1
+
+       julia> B = [0 1; 1 0]
+       2×2 Array{Int64,2}:
+        0  1
+        1  0
+
+       julia> eig(A, B)
+       (Complex{Float64}[0.0+1.0im,0.0-1.0im],
+       Complex{Float64}[0.0-1.0im 0.0+1.0im; -1.0-0.0im -1.0+0.0im])
 
 .. function:: eigvals(A,[irange,][vl,][vu]) -> values
 
@@ -610,19 +626,59 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Same as ``eigvals``\ , but saves space by overwriting the input ``A`` (and ``B``\ ), instead of creating a copy.
+   Same as :func:`eigvals`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy.
 
-.. function:: eigmax(A)
-
-   .. Docstring generated from Julia source
-
-   Returns the largest eigenvalue of ``A``\ .
-
-.. function:: eigmin(A)
+.. function:: eigmax(A; permute::Bool=true, scale::Bool=true)
 
    .. Docstring generated from Julia source
 
-   Returns the smallest eigenvalue of ``A``\ .
+   Returns the largest eigenvalue of ``A``\ . The option ``permute=true`` permutes the matrix to become closer to upper triangular, and ``scale=true`` scales the matrix by its diagonal elements to make rows and columns more equal in norm. Note that if the eigenvalues of ``A`` are complex, this method will fail, since complex numbers cannot be sorted.
+
+   .. doctest::
+
+       julia> A = [0 im; -im 0]
+       2×2 Array{Complex{Int64},2}:
+        0+0im  0+1im
+        0-1im  0+0im
+
+       julia> eigmax(A)
+       1.0
+
+       julia> A = [0 im; -1 0]
+       2×2 Array{Complex{Int64},2}:
+         0+0im  0+1im
+        -1+0im  0+0im
+
+       julia> eigmax(A)
+       ERROR: DomainError:
+        in #eigmax#30(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:108
+        in eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:106
+
+.. function:: eigmin(A; permute::Bool=true, scale::Bool=true)
+
+   .. Docstring generated from Julia source
+
+   Returns the smallest eigenvalue of ``A``\ . The option ``permute=true`` permutes the matrix to become closer to upper triangular, and ``scale=true`` scales the matrix by its diagonal elements to make rows and columns more equal in norm. Note that if the eigenvalues of ``A`` are complex, this method will fail, since complex numbers cannot be sorted.
+
+   .. doctest::
+
+       julia> A = [0 im; -im 0]
+       2×2 Array{Complex{Int64},2}:
+        0+0im  0+1im
+        0-1im  0+0im
+
+       julia> eigmin(A)
+       -1.0
+
+       julia> A = [0 im; -1 0]
+       2×2 Array{Complex{Int64},2}:
+         0+0im  0+1im
+        -1+0im  0+0im
+
+       julia> eigmin(A)
+       ERROR: DomainError:
+        in #eigmin#31(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:115
+        in eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:113
 
 .. function:: eigvecs(A, [eigvals,][permute=true,][scale=true]) -> Matrix
 
@@ -636,9 +692,9 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Computes the eigenvalue decomposition of ``A``\ , returning an ``Eigen`` factorization object ``F`` which contains the eigenvalues in ``F[:values]`` and the eigenvectors in the columns of the matrix ``F[:vectors]``\ . (The ``k``\ th eigenvector can be obtained from the slice ``F[:vectors][:, k]``\ .)
+   Computes the eigenvalue decomposition of ``A``\ , returning an :obj:`Eigen` factorization object ``F`` which contains the eigenvalues in ``F[:values]`` and the eigenvectors in the columns of the matrix ``F[:vectors]``\ . (The ``k``\ th eigenvector can be obtained from the slice ``F[:vectors][:, k]``\ .)
 
-   The following functions are available for ``Eigen`` objects: ``inv``\ , ``det``\ .
+   The following functions are available for ``Eigen`` objects: :func:`inv`\ , :func:`det`\ , and :func:`isposdef`\ .
 
    If ``A`` is :class:`Symmetric`\ , :class:`Hermitian` or :class:`SymTridiagonal`\ , it is possible to calculate only a subset of the eigenvalues by specifying either a :class:`UnitRange` ``irange`` covering indices of the sorted eigenvalues or a pair ``vl`` and ``vu`` for the lower and upper boundaries of the eigenvalues.
 


### PR DESCRIPTION
Loads more examples and wording improvements for `find{min,max,first,last,prev,next}`. `deleteat!` only has methods for arrays. Also cleaned up the docs for various `eig*` functions.

I think I got most of this into the rst (this is another 🚂  PR) but if not, please let me know!
