### PR TITLE
Fix #17684 (concatenations involving annotated sparse/special matrices)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -682,15 +682,6 @@ function reverse!(v::AbstractVector, s=1, n=length(v))
 end
 
 
-# concatenations of combinations (homogeneous, heterogeneous) of dense matrices/vectors #
-vcat{T}(A::Union{Vector{T},Matrix{T}}...) = typed_vcat(T, A...)
-vcat(A::Union{Vector,Matrix}...) = typed_vcat(promote_eltype(A...), A...)
-hcat{T}(A::Union{Vector{T},Matrix{T}}...) = typed_hcat(T, A...)
-hcat(A::Union{Vector,Matrix}...) = typed_hcat(promote_eltype(A...), A...)
-hvcat{T}(rows::Tuple{Vararg{Int}}, xs::Union{Vector{T},Matrix{T}}...) = typed_hvcat(T, rows, xs...)
-hvcat(rows::Tuple{Vararg{Int}}, xs::Union{Vector,Matrix}...) = typed_hvcat(promote_eltype(xs...), rows, xs...)
-cat{T}(catdims, xs::Union{Vector{T},Matrix{T}}...) = Base.cat_t(catdims, T, xs...)
-cat(catdims, xs::Union{Vector,Matrix}...) = Base.cat_t(catdims, promote_eltype(xs...), xs...)
 # concatenations of homogeneous combinations of vectors, horizontal and vertical
 function hcat{T}(V::Vector{T}...)
     height = length(V[1])

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -265,6 +265,8 @@ function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, S::SparseMatrixCSC)
 end
 # convert'ing from other matrix types to SparseMatrixCSC (also see sparse())
 convert(::Type{SparseMatrixCSC}, M::Matrix) = sparse(M)
+convert{Tv}(::Type{SparseMatrixCSC}, M::AbstractMatrix{Tv}) = convert(SparseMatrixCSC{Tv,Int}, M)
+convert{Tv}(::Type{SparseMatrixCSC{Tv}}, M::AbstractMatrix{Tv}) = convert(SparseMatrixCSC{Tv,Int}, M)
 function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, M::AbstractMatrix)
     (I, J, V) = findnz(M)
     eltypeTiI = convert(Vector{Ti}, I)

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -166,3 +166,89 @@ let
         end
     end
 end
+
+# Test that concatenations of annotated sparse/special matrix types with other matrix
+# types yield sparse arrays, and that the code which effects that does not make concatenations
+# strictly involving un/annotated dense matrices yield sparse arrays
+#
+# TODO: As with the associated code, these tests should be moved to a more appropriate
+# location, particularly some future equivalent of base/linalg/special.jl dedicated to
+# intereactions between a broader set of matrix types
+let
+    N = 4
+    # The tested annotation types
+    testfull = Bool(parse(Int,(get(ENV, "JULIA_TESTFULL", "0"))))
+    utriannotations = (UpperTriangular, Base.LinAlg.UnitUpperTriangular)
+    ltriannotations = (LowerTriangular, Base.LinAlg.UnitLowerTriangular)
+    triannotations = (utriannotations..., ltriannotations...)
+    symannotations = (Symmetric, Hermitian)
+    annotations = testfull ? (triannotations..., symannotations...) : (LowerTriangular, Symmetric)
+    # Concatenations involving these types, un/annotated, should yield sparse arrays
+    spvec = spzeros(N)
+    spmat = speye(N)
+    diagmat = Diagonal(ones(N))
+    bidiagmat = Bidiagonal(ones(N), ones(N-1), true)
+    tridiagmat = Tridiagonal(ones(N-1), ones(N), ones(N-1))
+    symtridiagmat = SymTridiagonal(ones(N), ones(N-1))
+    sparseconcatmats = testfull ? (spmat, diagmat, bidiagmat, tridiagmat, symtridiagmat) : (spmat, diagmat)
+    # Concatenations involving strictly these types, un/annotated, should yield dense arrays
+    densevec = ones(N)
+    densemat = ones(N, N)
+    # Annotated collections
+    annodmats = [annot(densemat) for annot in annotations]
+    annospcmats = [annot(spcmat) for annot in annotations, spcmat in sparseconcatmats]
+    # Test that concatenations of pairwise combinations of annotated sparse/special
+    # yield sparse matrices
+    for annospcmata in annospcmats, annospcmatb in annospcmats
+        @test issparse(vcat(annospcmata, annospcmatb))
+        @test issparse(hcat(annospcmata, annospcmatb))
+        @test issparse(hvcat((2,), annospcmata, annospcmatb))
+        @test issparse(cat((1,2), annospcmata, annospcmatb))
+    end
+    # Test that concatenations of pairwise combinations of annotated sparse/special
+    # matrices and other matrix/vector types yield sparse matrices
+    for annospcmat in annospcmats
+        # --> Tests applicable to pairs including only matrices
+        for othermat in (densemat, annodmats..., sparseconcatmats...)
+            @test issparse(vcat(annospcmat, othermat))
+            @test issparse(vcat(othermat, annospcmat))
+        end
+        # --> Tests applicable to pairs including other vectors or matrices
+        for other in (spvec, densevec, densemat, annodmats..., sparseconcatmats...)
+            @test issparse(hcat(annospcmat, other))
+            @test issparse(hcat(other, annospcmat))
+            @test issparse(hvcat((2,), annospcmat, other))
+            @test issparse(hvcat((2,), other, annospcmat))
+            @test issparse(cat((1,2), annospcmat, other))
+            @test issparse(cat((1,2), other, annospcmat))
+        end
+    end
+    # The preceding tests should cover multi-way combinations of those types, but for good
+    # measure test a few multi-way combinations involving those types
+    @test issparse(vcat(spmat, densemat, annospcmats[1], annodmats[2]))
+    @test issparse(vcat(densemat, spmat, annodmats[1], annospcmats[2]))
+    @test issparse(hcat(spvec, annodmats[1], annospcmats[3], densevec, diagmat))
+    @test issparse(hcat(annodmats[2], annospcmats[4], spvec, densevec, diagmat))
+    @test issparse(hvcat((5,), diagmat, densevec, spvec, annodmats[1], annospcmats[1]))
+    @test issparse(hvcat((5,), spvec, annodmats[2], diagmat, densevec, annospcmats[2]))
+    @test issparse(cat((1,2), annodmats[1], diagmat, annospcmats[3], densevec, spvec))
+    @test issparse(cat((1,2), spvec, diagmat, densevec, annospcmats[4], annodmats[2]))
+    # Test that concatenations strictly involving un/annotated dense matrices/vectors
+    # yield dense arrays
+    for densemata in (densemat, annodmats...)
+        # --> Tests applicable to pairs including only matrices
+        for densematb in (densemat, annodmats...)
+            @test !issparse(vcat(densemata, densematb))
+            @test !issparse(vcat(densematb, densemata))
+        end
+        # --> Tests applicable to pairs including vectors or matrices
+        for otherdense in (densevec, densemat, annodmats...)
+            @test !issparse(hcat(densemata, otherdense))
+            @test !issparse(hcat(otherdense, densemata))
+            @test !issparse(hvcat((2,), densemata, otherdense))
+            @test !issparse(hvcat((2,), otherdense, densemata))
+            @test !issparse(cat((1,2), densemata, otherdense))
+            @test !issparse(cat((1,2), otherdense, densemata))
+        end
+    end
+end


### PR DESCRIPTION
This pull request addresses JuliaLang/LinearAlgebra.jl#350 by making concatenations involving annotated sparse/special matrices yield sparse arrays.

The tests introduced increase linalg/special's run time from ~13s to ~465s locally. Though systematic testing is nice, testing that heavy seems a bit excessive for this functionality. Paring off a few type combinations, for example testing solely combinations involving `LowerTriangular` rather than similar combinations for all `<:AbstractTriangular` (which should exercise the same code), should reduce the test time increase substantially. Thoughts @tkelman @kshyatt?

Ref. JuliaLang/julia#17660. Best!
