### PR TITLE
Revert "Fix `@threadcall` argument passing."

### DIFF
--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -23,8 +23,6 @@ function without causing the main `julia` thread to become blocked. Concurrency
 is limited by size of the libuv thread pool, which defaults to 4 threads but
 can be increased by setting the `UV_THREADPOOL_SIZE` environment variable and
 restarting the `julia` process.
-
-Note that the called function should never call back into Julia.
 """
 macro threadcall(f, rettype, argtypes, argvals...)
     # check for usage errors
@@ -75,7 +73,6 @@ function do_threadcall(wrapper::Function, rettype::Type, argtypes::Vector, argva
         y = cconvert(T, x)
         push!(roots, y)
         unsafe_store!(convert(Ptr{T}, ptr), unsafe_convert(T, y))
-        ptr += sizeof(T)
     end
 
     # create return buffer

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -589,10 +589,6 @@ threadcall_test_func(x) =
 @test threadcall_test_func(3) == 1
 @test threadcall_test_func(259) == 1
 
-f17819(a,b) = Cint(a+b)
-cf17819 = cfunction(f17819, Cint, (Cint,Cint))
-@test @threadcall(cf17819, Cint, (Cint, Cint), 1, 2) == 3
-
 let n=3
     tids = Culong[]
     @sync for i in 1:10^n


### PR DESCRIPTION
Reverts JuliaLang/julia#17823

The test violates the very condition that the PR adds to the docs. This seems to be showing up as breakage of the Mac travis build.
