### PR TITLE
fix output of getaddrinfo in networking and streams

### DIFF
--- a/doc/manual/networking-and-streams.rst
+++ b/doc/manual/networking-and-streams.rst
@@ -260,5 +260,5 @@ allows you to do things like::
 At the base of this functionality is :func:`getaddrinfo`, which will do the appropriate address resolution::
 
     julia> getaddrinfo("google.com")
-    IPv4(74.125.226.225)
+    ip"74.125.226.225"
 


### PR DESCRIPTION
fix output of getaddrinfo in networking and streams documentation for v0.5.
