### PR TITLE
Add NCycle iterator

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -967,6 +967,7 @@ export
     take,
     drop,
     cycle,
+    ncycle,
     repeated,
 
 # object identity and equality

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -448,6 +448,36 @@ end
 
 done(it::Cycle, state) = state[2]
 
+#NCycle - cycle through an object N times
+
+immutable NCycle{I}
+    iter::I
+    n::Int
+end
+
+"""
+    ncycle(iter, n)
+
+An iterator that cycles through `iter` `n` times.
+"""
+ncycle(iter, n::Int) = NCycle(iter, n)
+
+eltype(nc::NCycle) = eltype(nc.iter)
+length(nc::NCycle) = nc.n*length(nc.iter)
+size(nc::NCycle) = (size(nc.iter)..., nc.n)
+iteratorsize{I}(::Type{NCycle{I}}) = iteratorsize(I)
+iteratoreltype{I}(::Type{NCycle{I}}) = iteratoreltype(I)
+
+start(nc::NCycle) = (start(nc.iter), 0)
+function next(nc::NCycle, state)
+    nv, ns = next(nc.iter,state[1])
+    if done(nc.iter, ns)
+        return (nv, (start(nc.iter), state[2]+1))
+    else
+        return (nv, (ns, state[2]))
+    end
+end
+done(nc::NCycle, state) = state[2] == nc.n
 
 # Repeated - repeat an object infinitely many times
 

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -163,6 +163,12 @@ type.
 
    An iterator that cycles through ``iter`` forever.
 
+.. function:: ncycle(iter, n)
+
+   .. Docstring generated from Julia source
+
+   An iterator that cycles through ``iter`` ``n`` times.
+
 .. function:: repeated(x[, n::Int])
 
    .. Docstring generated from Julia source

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -166,6 +166,16 @@ let i = 0
     end
 end
 
+# ncycle
+# ------
+
+let i = 0
+    for j = ncycle(0:3,3)
+        @test j == i % 4
+        i += 1
+    end
+end
+
 # repeated
 # --------
 


### PR DESCRIPTION
I think it is useful to be able to set how many times an iterator should be cycled over.

``` julia
julia> for i=cycle(1:2,2)
           println(i)
       end
1
2
1
2
```

The documentation should be changed but I am unsure of where to change it.
