### PR TITLE
Fix trailing whitespace in code literal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,8 @@ New language features
 ---------------------
 
   * The REPL now supports something called *prompt pasting*.
-    This activates when pasting text that starts with `julia> ` into the REPL.
-    In that case, only expressions starting with `julia> ` are parsed, the rest are removed.
+    This activates when pasting text that starts with `julia> ` into the REPL.
+    In that case, only expressions starting with `julia> ` are parsed, the rest are removed.
     This makes it possible to paste a chunk of code that has been copied from a REPL session
     without having to scrub away prompts and outputs.
     This can be disabled or enabled at will with `Base.REPL.enable_promptpaste(::Bool)`.

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -42,8 +42,8 @@ There are a number useful features unique to interactive work. In addition to sh
     julia> ans
     "12"
 
-In Julia mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL.
-In that case, only expressions starting with ``julia> `` are parsed, others are removed.
+In Julia mode, the REPL supports something called *prompt pasting*. This activates when pasting text that starts with ``julia> `` into the REPL.
+In that case, only expressions starting with ``julia> `` are parsed, others are removed.
 This makes it is possible to paste a chunk of code that has been copied from a REPL session without having to scrub away prompts and outputs.
 This feature is enabled by default but can be disabled or enabled at will with ``Base.REPL.enable_promptpaste(::Bool)``.
 If it is enabled, you can try it out by pasting the code block above this paragraph straight into the REPL.


### PR DESCRIPTION
rst apparently requires that the closing double backticks for code literals appear at the end of a "word", rather than preceded by a space as markdown allows. This means that ```julia> ``` doesn't parse correctly. The fix is to just remove the trailing space and explicitly mention the need for a space after the `>`.
