### PR TITLE
fix BigInt `ndigits` test

### DIFF
--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -278,7 +278,11 @@ ndigits_mismatch(n) = ndigits(n) != ndigits(BigInt(n))
 ndigits(rand(big(-999:999)), rand(63:typemax(Int)))
 ndigits(rand(big(-999:999)), big(2)^rand(2:999))
 
-@test_throws DomainError ndigits(rand(big(-999:999)), rand(typemin(Int):1))
+for i in big([-20:-1;1:20])
+    for b in -10:1
+        @test_throws DomainError ndigits(i, b)
+    end
+end
 
 # conversion from float
 @test BigInt(2.0) == BigInt(2.0f0) == BigInt(big(2.0)) == 2


### PR DESCRIPTION
Just ran into this one on CI.

See #16766. `ndigits(big(0),1)` doesn't raise an error, but we were sometimes (randomly, rarely) testing that it does. This change makes the test reliable. The issue of how this case should actually behave is still open.
