### PR TITLE
improve correctness of fieldtype_tfunc

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -83,7 +83,7 @@ static int jl_has_typevars__(jl_value_t *v, int incl_wildcard, jl_value_t **p, s
             jl_has_typevars__(((jl_tvar_t*)v)->lb, incl_wildcard, p, np))
             return 1;
         if (p != NULL) {
-            for(i=0; i < np; i++) {
+            for (i = 0; i < np; i++) {
                 if (v == p[i])
                     return 1;
             }
@@ -102,7 +102,7 @@ static int jl_has_typevars__(jl_value_t *v, int incl_wildcard, jl_value_t **p, s
     }
     else if (jl_is_datatype(v)) {
         if (is_unspec((jl_datatype_t*)v))
-            return 0;
+            return 0; // TODO: fix expect in this case
         if (p == NULL) {
             if (incl_wildcard)
                 expect = ((jl_datatype_t*)v)->haswildcard;
@@ -118,7 +118,7 @@ static int jl_has_typevars__(jl_value_t *v, int incl_wildcard, jl_value_t **p, s
         return 0;
     }
     size_t l = jl_svec_len(t);
-    for(i=0; i < l; i++) {
+    for (i = 0; i < l; i++) {
         jl_value_t *elt = jl_svecref(t, i);
         if (elt != v) {
             if (jl_has_typevars__(elt, incl_wildcard, p, np)) {

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -282,3 +282,27 @@ let I = Integer[]
     push!(I, 1)
     @test I == Any[1]
 end
+
+# issue #16530
+type Foo16530a{dim}
+    c::Vector{NTuple{dim, Float64}}
+    d::Vector
+end
+type Foo16530b{dim}
+    c::Vector{NTuple{dim, Float64}}
+end
+f16530a() = fieldtype(Foo16530a, :c)
+f16530a(c) = fieldtype(Foo16530a, c)
+f16530b() = fieldtype(Foo16530b, :c)
+f16530b(c) = fieldtype(Foo16530b, c)
+
+let T = Array{Tuple{Vararg{Float64,TypeVar(:dim)}},1},
+    TTlim = Type{TypeVar(:_,Array{TypeVar(:_,Tuple),1})}
+
+    @test f16530a() == T
+    @test f16530a(:c) == T
+    @test Base.return_types(f16530a, ()) == Any[TTlim]
+    @test Base.return_types(f16530b, ()) == Any[TTlim]
+    @test Base.return_types(f16530b, (Symbol,)) == Any[TTlim]
+end
+@test f16530a(:d) == Vector


### PR DESCRIPTION
it should trust the return value 'exact' that was meticulously computed for getfield_tfunc,
instead of trying to recompute it (badly)

also make getfield_tfunc monotonic for the case where the type has one field

fix #16530
