### PR TITLE
Disable openssl in curl build when building against mbedtls

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -16,7 +16,7 @@ $(SRCDIR)/srccache/curl-$(CURL_VER)/configure: $(SRCDIR)/srccache/curl-$(CURL_VE
 $(BUILDDIR)/curl-$(CURL_VER)/config.status: $(SRCDIR)/srccache/curl-$(CURL_VER)/configure
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$< $(CONFIGURE_COMMON) --includedir=$(build_includedir) --with-mbedtls=$(build_shlibdir)/.. CFLAGS="$(CFLAGS) $(CURL_CFLAGS)" LDFLAGS="$(LDFLAGS) $(CURL_LDFLAGS)"
+	$< $(CONFIGURE_COMMON) --includedir=$(build_includedir) --without-ssl --with-mbedtls=$(build_prefix) CFLAGS="$(CFLAGS) $(CURL_CFLAGS)" LDFLAGS="$(LDFLAGS) $(CURL_LDFLAGS)"
 	touch -c $@
 $(CURL_SRC_TARGET): $(BUILDDIR)/curl-$(CURL_VER)/config.status
 	$(MAKE) -C $(dir $<) $(LIBTOOL_CCLD)


### PR DESCRIPTION
Disable OpenSSL in `libcurl` build when building against MbedTLS. This should fix #17910.
