### PR TITLE
Move documentation inline for error types declared in base/base.jl.

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -1,5 +1,10 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+"""
+    SystemError(prefix::AbstractString, [errno::Int32])
+
+A system call failed with an error code (in the `errno` global variable).
+"""
 type SystemError <: Exception
     prefix::AbstractString
     errnum::Int32
@@ -9,10 +14,22 @@ type SystemError <: Exception
     SystemError(p::AbstractString) = new(p, Libc.errno())
 end
 
+"""
+    ParseError(msg)
+
+The expression passed to the `parse` function could not be interpreted as a valid Julia
+expression.
+"""
 type ParseError <: Exception
     msg::AbstractString
 end
 
+"""
+    ArgumentError(msg)
+
+The parameters to a function call do not match a valid signature. Argument `msg` is a
+descriptive error string.
+"""
 type ArgumentError <: Exception
     msg::AbstractString
 end
@@ -21,25 +38,53 @@ end
 #    var::Symbol
 #end
 
+"""
+    KeyError(key)
+
+An indexing operation into an `Associative` (`Dict`) or `Set` like object tried to access or
+delete a non-existent element.
+"""
 type KeyError <: Exception
     key
 end
 
+"""
+    MethodError(f, args)
+
+A method with the required type signature does not exist in the given generic function.
+Alternatively, there is no unique most-specific method.
+"""
 type MethodError <: Exception
     f
     args
 end
 
+"""
+    EOFError()
+
+No more data was available to read from a file or stream.
+"""
 type EOFError <: Exception end
 
+"""
+    DimensionMismatch([msg])
+
+The objects called do not have matching dimensionality. Optional argument `msg` is a
+descriptive error string.
+"""
 type DimensionMismatch <: Exception
     msg::AbstractString
 end
 DimensionMismatch() = DimensionMismatch("")
 
+"""
+    AssertionError([msg])
+
+The asserted condition did not evaluate to `true`.
+Optional argument `msg` is a descriptive error string.
+"""
 type AssertionError <: Exception
     msg::AbstractString
-
     AssertionError() = new("")
     AssertionError(msg) = new(msg)
 end
@@ -48,12 +93,24 @@ end
 #Subtypes should put the exception in an 'error' field
 abstract WrappedException <: Exception
 
+"""
+    LoadError(file::AbstractString, line::Int, error)
+
+An error occurred while `include`ing, `require`ing, or `using` a file. The error specifics
+should be available in the `.error` field.
+"""
 type LoadError <: WrappedException
     file::AbstractString
     line::Int
     error
 end
 
+"""
+    InitError(mod::Symbol, error)
+
+An error occurred when running a module's `__init__` function. The actual error thrown is
+available in the `.error` field.
+"""
 type InitError <: WrappedException
     mod::Symbol
     error

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2176,13 +2176,6 @@ Remove each element of `iterable` from set `s` in-place.
 setdiff!
 
 """
-    EOFError()
-
-No more data was available to read from a file or stream.
-"""
-EOFError
-
-"""
     isascii(c::Union{Char,AbstractString}) -> Bool
 
 Tests whether a character belongs to the ASCII character set, or whether this is true for
@@ -3016,12 +3009,6 @@ handle properly.
 """
 OutOfMemoryError
 
-"""
-    SystemError(prefix::AbstractString, [errno::Int32])
-
-A system call failed with an error code (in the `errno` global variable).
-"""
-SystemError
 
 """
     binomial(n,k)
@@ -3059,14 +3046,6 @@ Print information about the version of Julia in use. If the `verbose` argument i
 detailed system information is shown as well.
 """
 versioninfo
-
-"""
-    DimensionMismatch([msg])
-
-The objects called do not have matching dimensionality. Optional argument `msg` is a
-descriptive error string.
-"""
-DimensionMismatch
 
 """
     sort!(v, [alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
@@ -3652,13 +3631,6 @@ Like `foldr(op, v0, itr)`, but using the last element of `itr` as `v0`. In gener
 cannot be used with empty collections (see `reduce(op, itr)`).
 """
 foldr(op, itr)
-
-"""
-    ParseError(msg)
-
-The expression passed to the `parse` function could not be interpreted as a valid Julia expression.
-"""
-ParseError
 
 """
     delete!(collection, key)
@@ -4567,22 +4539,6 @@ Get the file name part of a path.
 basename
 
 """
-    ArgumentError(msg)
-
-The parameters to a function call do not match a valid signature. Argument `msg` is a
-descriptive error string.
-"""
-ArgumentError
-
-"""
-    KeyError(key)
-
-An indexing operation into an `Associative` (`Dict`) or `Set` like object tried to access or
-delete a non-existent element.
-"""
-KeyError
-
-"""
     isdiag(A) -> Bool
 
 Test whether a matrix is diagonal.
@@ -5454,13 +5410,6 @@ indexes. If the array length is insufficient, the least significant digits are f
 the array length. If the array length is excessive, the excess portion is filled with zeros.
 """
 digits!
-
-"""
-    MethodError(f, args)
-
-A method with the required type signature does not exist in the given generic function. Alternatively, there is no unique most-specific method.
-"""
-MethodError
 
 """
     cat(dims, A...)
@@ -6871,22 +6820,6 @@ Compute the phase angle in radians of a complex number `z`.
 angle
 
 """
-    LoadError(file::AbstractString, line::Int, error)
-
-An error occurred while `include`ing, `require`ing, or `using` a file. The error specifics
-should be available in the `.error` field.
-"""
-LoadError
-
-"""
-    InitError(mod::Symbol, error)
-
-An error occurred when running a module's `__init__` function. The actual error thrown is
-available in the `.error` field.
-"""
-InitError
-
-"""
     copy!(dest, src)
 
 Copy all elements from collection `src` to array `dest`. Returns `dest`.
@@ -7833,14 +7766,6 @@ seekend
 Integer division was attempted with a denominator value of 0.
 """
 DivideError
-
-"""
-    AssertionError([msg])
-
-The asserted condition did not evaluate to `true`.
-Optional argument `msg` is a descriptive error string.
-"""
-AssertionError
 
 """
     Ac_ldiv_Bc(A, B)


### PR DESCRIPTION
I've moved the documentation inline for types `SystemError`, `ParseError`, `ArgumentError`, `KeyError`, `MethodError`,  `EOFError`, `DimensionMismatch`, `AssertionError`, `LoadError`, and `InitError`. Hope that helps!
