### PR TITLE
add support for split debuginfo files

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -460,6 +460,7 @@ endif #ARCH
 LD := link
 endif #USEMSVC
 RANLIB := $(CROSS_COMPILE)ranlib
+OBJCOPY := $(CROSS_COMPILE)objcopy
 
 # file extensions
 ifeq ($(OS), WINNT)

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -56,7 +56,7 @@ immutable StackFrame # this type should be kept platform-agnostic so that profil
     "true if the code is from an inlined frame"
     inlined::Bool
     "representation of the pointer to the execution context as returned by `backtrace`"
-    pointer::Int64  # Large enough to be read losslessly on 32- and 64-bit machines.
+    pointer::UInt64  # Large enough to be read losslessly on 32- and 64-bit machines.
 end
 
 StackFrame(func, file, line) = StackFrame(func, file, line, Nullable{LambdaInfo}(), false, false, 0)
@@ -123,7 +123,7 @@ inlined at that point, innermost function first.
 """
 function lookup(pointer::Ptr{Void})
     infos = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), pointer - 1, false)
-    isempty(infos) && return [StackFrame(empty_sym, empty_sym, -1, Nullable{LambdaInfo}(), true, false, convert(Int64, pointer))]
+    isempty(infos) && return [StackFrame(empty_sym, empty_sym, -1, Nullable{LambdaInfo}(), true, false, convert(UInt64, pointer))]
     res = Array{StackFrame}(length(infos))
     for i in 1:length(infos)
         info = infos[i]

--- a/src/Makefile
+++ b/src/Makefile
@@ -124,8 +124,26 @@ $(BUILDDIR)/%.dbg.obj: $(SRCDIR)/%.cpp $(SRCDIR)/llvm-version.h $(HEADERS) $(LLV
 	@$(call PRINT_CC, $(CXX) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
 libccalltest: $(build_shlibdir)/libccalltest.$(SHLIB_EXT)
+
+ifeq ($(OS), Linux)
+JULIA_SPLITDEBUG := 1
+else
+JULIA_SPLITDEBUG := 0
+endif
 $(build_shlibdir)/libccalltest.$(SHLIB_EXT): $(SRCDIR)/ccalltest.c
-	@$(call PRINT_CC, $(CC) $(CFLAGS) $(CPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@ $(LDFLAGS))
+	@$(call PRINT_CC, $(CC) $(CFLAGS) $(CPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@.tmp $(LDFLAGS))
+ifeq ($(JULIA_SPLITDEBUG),1)
+	@# Create split debug info file for libccalltest stacktraces test
+	@# packagers should disable this by setting JULIA_SPLITDEBUG=0 if this is already done by your build system
+	$(OBJCOPY) --only-keep-debug $@.tmp $@.debug
+	$(OBJCOPY) --strip-debug $@.tmp
+	$(OBJCOPY) --add-gnu-debuglink=$@.debug $@.tmp
+endif
+	@## clang should have made the dSYM split-debug directory,
+	@## but we are intentionally not going to give it the correct name
+	@## because we want to test the non-default debug configuration
+	@#rm -r $@.dSYM && mv $@.tmp.dSYM $@.dSYM
+	mv $@.tmp $@
 
 julia_flisp.boot.inc.phony: $(BUILDDIR)/julia_flisp.boot.inc
 
@@ -221,9 +239,11 @@ ifneq ($(OS), WINNT)
 	@ln -sf libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT) $(build_shlibdir)/libjulia-debug.$(SHLIB_EXT)
 endif
 	$(DSYMUTIL) $@
+
 $(BUILDDIR)/libjulia-debug.a: $(SRCDIR)/julia.expmap $(DOBJS) $(BUILDDIR)/flisp/libflisp-debug.a $(BUILDDIR)/support/libsupport-debug.a
 	rm -f $@
 	@$(call PRINT_LINK, ar -rcs $@ $(DOBJS))
+
 libjulia-debug: $(build_shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)
 
 $(build_shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT): $(SRCDIR)/julia.expmap $(OBJS) $(BUILDDIR)/flisp/libflisp.a $(BUILDDIR)/support/libsupport.a $(LIBUV)
@@ -234,6 +254,7 @@ ifneq ($(OS), WINNT)
 	@ln -sf libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT) $(build_shlibdir)/libjulia.$(SHLIB_EXT)
 endif
 	$(DSYMUTIL) $@
+
 $(BUILDDIR)/libjulia.a: julia.expmap $(OBJS) $(BUILDDIR)/flisp/libflisp.a $(BUILDDIR)/support/libsupport.a
 	rm -f $@
 	@$(call PRINT_LINK, ar -rcs $@ $(OBJS))

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -748,6 +748,8 @@ static int lookup_pointer(DIContext *context, jl_frame_t **frames,
 
 #ifdef _OS_DARWIN_
 #include <mach-o/dyld.h>
+#else
+#define LC_UUID 0
 #endif
 #ifndef _OS_WINDOWS_
 #include <dlfcn.h>
@@ -761,11 +763,10 @@ typedef struct {
 typedef std::map<uint64_t, objfileentry_t, revcomp> obfiletype;
 static obfiletype objfilemap;
 
-#ifdef _OS_DARWIN_
 static bool getObjUUID(llvm::object::MachOObjectFile *obj, uint8_t uuid[16])
 {
 # ifdef LLVM37
-    for (auto Load : obj->load_commands ()) {
+    for (auto Load : obj->load_commands())
 # else
 #  ifdef LLVM35
     uint32_t LoadCommandCount = obj->getHeader().ncmds;
@@ -773,8 +774,9 @@ static bool getObjUUID(llvm::object::MachOObjectFile *obj, uint8_t uuid[16])
     uint32_t LoadCommandCount = obj->getHeader().NumLoadCommands;
 #  endif
     llvm::object::MachOObjectFile::LoadCommandInfo Load = obj->getFirstLoadCommandInfo();
-    for (unsigned I = 0; ; ++I) {
+    for (unsigned I = 0; ; ++I)
 # endif
+    {
         if (
 # ifdef LLVM35
             Load.C.cmd == LC_UUID
@@ -782,7 +784,7 @@ static bool getObjUUID(llvm::object::MachOObjectFile *obj, uint8_t uuid[16])
             Load.C.Type == LC_UUID
 # endif
             ) {
-            memcpy(uuid,((MachO::uuid_command*)Load.Ptr)->uuid,16);
+            memcpy(uuid, ((const MachO::uuid_command*)Load.Ptr)->uuid, 16);
             return true;
         }
 # ifndef LLVM37
@@ -795,6 +797,115 @@ static bool getObjUUID(llvm::object::MachOObjectFile *obj, uint8_t uuid[16])
 # endif
     }
     return false;
+}
+
+#ifdef LLVM36
+struct debug_link_info {
+    StringRef filename;
+    uint32_t crc32;
+};
+static debug_link_info getDebuglink(const object::ObjectFile &Obj)
+{
+    debug_link_info info = {};
+    for (const object::SectionRef &Section: Obj.sections()) {
+        StringRef sName;
+        if (!Section.getName(sName) && sName == ".gnu_debuglink") {
+            StringRef Contents;
+            if (!Section.getContents(Contents)) {
+                size_t length = Contents.find('\0');
+                info.filename = Contents.substr(0, length);
+                info.crc32 = *(const uint32_t*)Contents.substr(LLT_ALIGN(length + 1, 4), 4).data();
+                break;
+            }
+        }
+    }
+    return info;
+}
+/*
+ * crc function from http://svnweb.freebsd.org/base/head/sys/libkern/crc32.c (and lldb)
+ *
+ *   COPYRIGHT (C) 1986 Gary S. Brown. You may use this program, or
+ *   code or tables extracted from it, as desired without restriction.
+ */
+static uint32_t
+calc_gnu_debuglink_crc32(const void *buf, size_t size)
+{
+    static const uint32_t g_crc32_tab[] =
+    {
+        0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
+        0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+        0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
+        0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+        0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
+        0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+        0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
+        0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+        0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
+        0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+        0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
+        0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+        0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
+        0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+        0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+        0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+        0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
+        0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+        0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
+        0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+        0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
+        0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+        0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
+        0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+        0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
+        0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+        0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
+        0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+        0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
+        0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+        0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
+        0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+        0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
+        0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+        0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
+        0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+        0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
+        0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+        0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
+        0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+        0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
+        0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+        0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+    };
+    const uint8_t *p = (const uint8_t *)buf;
+    uint32_t crc;
+
+    crc = ~0U;
+    while (size--)
+        crc = g_crc32_tab[(crc ^ *p++) & 0xFF] ^ (crc >> 8);
+    return crc ^ ~0U;
+}
+static ErrorOr<object::OwningBinary<object::ObjectFile>> openDebugInfo(StringRef debuginfopath, const debug_link_info &info)
+{
+    auto SplitFile = MemoryBuffer::getFile(debuginfopath);
+    if (std::error_code EC = SplitFile.getError())
+        return EC;
+
+    uint32_t crc32 = calc_gnu_debuglink_crc32(
+            SplitFile.get()->getBufferStart(),
+            SplitFile.get()->getBufferSize());
+    if (crc32 != info.crc32)
+        return object::object_error::arch_not_found;
+
+    auto error_splitobj = object::ObjectFile::createObjectFile(
+            SplitFile.get().get()->getMemBufferRef(),
+            sys::fs::file_magic::unknown);
+    if (std::error_code EC = error_splitobj.getError())
+        return EC;
+
+    // successfully validated and loaded split debug info file
+    return object::OwningBinary<object::ObjectFile>(
+            std::move(error_splitobj.get()),
+            std::move(SplitFile.get()));
 }
 #endif
 
@@ -817,55 +928,57 @@ bool jl_dylib_DI_for_fptr(size_t pointer, const llvm::object::ObjectFile **obj, 
     *context = NULL;
     *slide = 0;
     *section_slide = 0;
+
 // GOAL: Determine containing Library
-// Assigning fname, fbase, msize
+// Assigning fname, fbase
 #ifdef _OS_WINDOWS_
     IMAGEHLP_MODULE64 ModuleInfo;
-    bool isvalid;
     ModuleInfo.SizeOfStruct = sizeof(IMAGEHLP_MODULE64);
     jl_in_stackwalk = 1;
-    isvalid = SymGetModuleInfo64(GetCurrentProcess(), (DWORD64)pointer, &ModuleInfo);
+    bool isvalid = SymGetModuleInfo64(GetCurrentProcess(), (DWORD64)pointer, &ModuleInfo);
     jl_in_stackwalk = 0;
-    if (isvalid) {
-        char *fname = ModuleInfo.LoadedImageName;
-        if (!fname[0]) // empirically, LoadedImageName might be missing
-            fname = ModuleInfo.ImageName;
-        DWORD64 fbase = ModuleInfo.BaseOfImage;
-        bool insysimage = (fbase == jl_sysimage_base);
-        if (isSysImg)
-            *isSysImg = insysimage;
-        if (onlySysImg && !insysimage) {
-            return false;
-        }
-        static char frame_info_func[
-            sizeof(SYMBOL_INFO) +
-            MAX_SYM_NAME * sizeof(TCHAR)];
-        DWORD64 dwDisplacement64 = 0;
-        DWORD64 dwAddress = pointer;
-        PSYMBOL_INFO pSymbol = (PSYMBOL_INFO)frame_info_func;
-        pSymbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-        pSymbol->MaxNameLen = MAX_SYM_NAME;
-        jl_in_stackwalk = 1;
-        if (SymFromAddr(GetCurrentProcess(), dwAddress, &dwDisplacement64,
-                        pSymbol)) {
-            // SymFromAddr returned success
-            // errors are ignored, but are hopefully patched up by
-            // using llvm to read the object (below)
-            if (name)
-                jl_copy_str(name, pSymbol->Name);
-            if (saddr)
-                *saddr = (void*)(uintptr_t)pSymbol->Address;
-        }
-        else if (saddr) {
-            *saddr = NULL;
-        }
+    if (!isvalid) return false;
 
-        // If we didn't find the filename before in the debug
-        // info, use the dll name
-        if (filename && !*filename)
-            jl_copy_str(filename, fname);
+    StringRef fname = ModuleInfo.LoadedImageName;
+    if (fname.empty()) // empirically, LoadedImageName might be missing
+        fname = ModuleInfo.ImageName;
+    DWORD64 fbase = ModuleInfo.BaseOfImage;
+    bool insysimage = (fbase == jl_sysimage_base);
+    if (isSysImg)
+        *isSysImg = insysimage;
+    if (onlySysImg && !insysimage) {
+        return false;
+    }
+    static char frame_info_func[
+        sizeof(SYMBOL_INFO) +
+        MAX_SYM_NAME * sizeof(TCHAR)];
+    DWORD64 dwDisplacement64 = 0;
+    DWORD64 dwAddress = pointer;
+    PSYMBOL_INFO pSymbol = (PSYMBOL_INFO)frame_info_func;
+    pSymbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+    pSymbol->MaxNameLen = MAX_SYM_NAME;
+    jl_in_stackwalk = 1;
+    if (SymFromAddr(GetCurrentProcess(), dwAddress, &dwDisplacement64,
+                    pSymbol)) {
+        // SymFromAddr returned success
+        // errors are ignored, but are hopefully patched up by
+        // using llvm to read the object (below)
+        if (name)
+            jl_copy_str(name, pSymbol->Name);
+        if (saddr)
+            *saddr = (void*)(uintptr_t)pSymbol->Address;
+    }
+    else if (saddr) {
+        *saddr = NULL;
+    }
 
-        jl_in_stackwalk = 0;
+    // If we didn't find the filename before in the debug
+    // info, use the dll name
+    if (filename && !*filename)
+        jl_copy_str(filename, fname.data());
+
+    jl_in_stackwalk = 0;
+
 #else // ifdef _OS_WINDOWS_
     Dl_info dlinfo;
     int dladdr_success;
@@ -876,201 +989,239 @@ bool jl_dylib_DI_for_fptr(size_t pointer, const llvm::object::ObjectFile **obj, 
 #else
     dladdr_success = dladdr((void*)pointer, &dlinfo) != 0;
 #endif
+    if (!dladdr_success || !dlinfo.dli_fname)
+        return false;
 
-    if (dladdr_success && dlinfo.dli_fname) {
 #ifdef __GLIBC__
-        // dlinfo.dli_fbase is not the right value for the main executable on linux
-        fbase = (uintptr_t)extra_info->l_addr;
+    // dlinfo.dli_fbase is not the right value for the main executable on linux
+    fbase = (uintptr_t)extra_info->l_addr;
 #else
-        fbase = (uintptr_t)dlinfo.dli_fbase;
+    fbase = (uintptr_t)dlinfo.dli_fbase;
 #endif
-        const char *fname;
-        if (saddr)
-            *saddr = dlinfo.dli_saddr;
-#if defined(_OS_DARWIN_)
-        size_t msize = (size_t)(((uint64_t)-1)-fbase);
-#endif
-        bool insysimage = (fbase == jl_sysimage_base);
-        if (isSysImg)
-            *isSysImg = insysimage;
-        if (onlySysImg && !insysimage) {
-            return false;
-        }
-        // In case we fail with the debug info lookup, we at least still
-        // have the function name, even if we don't have line numbers
-        if (name)
-            jl_copy_str(name, dlinfo.dli_sname);
-        if (filename)
-            jl_copy_str(filename, dlinfo.dli_fname);
-        fname = dlinfo.dli_fname;
+    StringRef fname;
+    if (saddr)
+        *saddr = dlinfo.dli_saddr;
+    bool insysimage = (fbase == jl_sysimage_base);
+    if (isSysImg)
+        *isSysImg = insysimage;
+    if (onlySysImg && !insysimage) {
+        return false;
+    }
+    // In case we fail with the debug info lookup, we at least still
+    // have the function name, even if we don't have line numbers
+    if (name)
+        jl_copy_str(name, dlinfo.dli_sname);
+    if (filename)
+        jl_copy_str(filename, dlinfo.dli_fname);
+    fname = dlinfo.dli_fname;
 #endif // ifdef _OS_WINDOWS_
 
-// GOAL: Read debuginfo from file
-#if !defined(_OS_WINDOWS_) || defined(LLVM35)
-        // TODO: need read/write lock here for objfilemap synchronization
-        obfiletype::iterator it = objfilemap.find(fbase);
-        if (it != objfilemap.end()) {
-            // Return cached value
-            *obj = it->second.obj;
-            *context = it->second.ctx;
-            *slide = it->second.slide;
-            *section_slide = it->second.section_slide;
-        }
-        else {
-// GOAL: Assign errorobj
+    int isdarwin = 0, islinux = 0, iswindows = 0;
 #if defined(_OS_DARWIN_)
-#ifdef LLVM36
-           std::unique_ptr<MemoryBuffer> membuf = MemoryBuffer::getMemBuffer(
-                    StringRef((const char *)fbase, msize), "", false);
-           auto origerrorobj = llvm::object::ObjectFile::createObjectFile(
-                membuf->getMemBufferRef(), sys::fs::file_magic::unknown);
-#elif defined(LLVM35)
-            MemoryBuffer *membuf = MemoryBuffer::getMemBuffer(
-                StringRef((const char *)fbase, msize), "", false);
-            std::unique_ptr<MemoryBuffer> buf(membuf);
-            auto origerrorobj = llvm::object::ObjectFile::createObjectFile(
-                buf, sys::fs::file_magic::unknown);
-#else
-            MemoryBuffer *membuf = MemoryBuffer::getMemBuffer(
-                StringRef((const char *)fbase, msize), "", false);
-            llvm::object::ObjectFile *origerrorobj = llvm::object::ObjectFile::createObjectFile(
-                membuf);
-#endif
-            if (!origerrorobj) {
-                objfileentry_t entry = {*obj,*context,*slide,*section_slide};
-                objfilemap[fbase] = entry;
-                return true;
-            }
-
-#ifdef LLVM36
-            *obj = (llvm::object::MachOObjectFile *)origerrorobj.get().release();
-#elif defined(LLVM35)
-            *obj = (llvm::object::MachOObjectFile *)origerrorobj.get();
-#else
-            *obj = (llvm::object::MachOObjectFile *)origerrorobj;
-#endif
-            llvm::object::MachOObjectFile *morigobj = (llvm::object::MachOObjectFile *)*obj;
-
-
-            // First find the uuid of the object file (we'll use this to make sure we find the
-            // correct debug symbol file).
-            uint8_t uuid[16], uuid2[16];
-            if (!getObjUUID(morigobj,uuid)) {
-                objfileentry_t entry = {*obj,*context,*slide,*section_slide};
-                objfilemap[fbase] = entry;
-                return true;
-            }
-
-            // On OS X debug symbols are not contained in the dynamic library and that's why
-            // we can't have nice things (easily). For now we only support .dSYM files in the same directory
-            // as the shared library. In the future we may use DBGCopyFullDSYMURLForUUID from CoreFoundation to make
-            // use of spotlight to find the .dSYM file.
-            char dsympath[PATH_MAX];
-            strlcpy(dsympath, fname, sizeof(dsympath));
-            strlcat(dsympath, ".dSYM/Contents/Resources/DWARF/", sizeof(dsympath));
-            strlcat(dsympath, strrchr(fname,'/')+1, sizeof(dsympath));
-#ifdef LLVM35
-            auto errorobj = llvm::object::ObjectFile::createObjectFile(dsympath);
-#else
-            llvm::object::ObjectFile *errorobj = llvm::object::ObjectFile::createObjectFile(dsympath);
+    isdarwin = 1;
+#elif defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
+    islinux = 1;
+#elif defined(_OS_WINDOWS_)
+    iswindows = 1;
 #endif
 
-#else // ifndef _OS_DARWIN_
-
-            // On Linux systems we need to mmap another copy because of the permissions on the mmap'ed shared library.
-            // On Windows we need to mmap another copy since reading the in-memory copy seems to return object_error:unexpected_eof
-#ifdef LLVM35
-            auto errorobj = llvm::object::ObjectFile::createObjectFile(fname);
-#else
-            llvm::object::ObjectFile *errorobj = llvm::object::ObjectFile::createObjectFile(fname);
-#endif
-#endif // ifdef _OS_DARWIN_
-
-// GOAL: Assign *obj, *context, *slide (if above succeeded)
-            if (errorobj) {
-#ifdef LLVM36
-                auto binary = errorobj.get().takeBinary();
-                *obj = binary.first.release();
-                binary.second.release();
-#elif defined(LLVM35)
-                *obj = errorobj.get();
-#else
-                *obj = errorobj;
-#endif
-#ifdef _OS_DARWIN_
-                if (getObjUUID((llvm::object::MachOObjectFile *)*obj,uuid2) &&
-                    memcmp(uuid,uuid2,sizeof(uuid)) == 0) {
-#endif
-#ifdef LLVM37
-                    *context = new DWARFContextInMemory(**obj);
-#elif defined(LLVM36)
-                    *context = DIContext::getDWARFContext(**obj);
-#else
-                    *context = DIContext::getDWARFContext(const_cast<object::ObjectFile*>(*obj));
-#endif
-                    *slide = -(int64_t)fbase;
-#ifdef _OS_DARWIN_
-                }
-                else {
-                    // If we're here the, the dsym does not match the dylib. Use the original
-                    // object instead. For consistency (and to make sure we get a sensible size
-                    // for the memory buffer), we also use a fresh copy mapped from
-                    // the file rather than reusing the one in memory. We may want to revisit
-                    // that in the future (ideally, once we support fewer LLVM versions).
-                    errorobj = llvm::object::ObjectFile::createObjectFile(fname);
-                    assert(errorobj);
-#ifdef LLVM36
-                    auto binary = errorobj.get().takeBinary();
-                    *obj = binary.first.release();
-                    binary.second.release();
-#elif defined(LLVM35)
-                    *obj = errorobj.get();
-#else
-                    *obj = errorobj;
-#endif
-                    delete morigobj;
-                }
-#endif
-#if defined(_OS_WINDOWS_)
-                assert((*obj)->isCOFF());
-                const llvm::object::COFFObjectFile *coffobj = (const llvm::object::COFFObjectFile *)*obj;
-                const llvm::object::pe32plus_header *pe32plus;
-                coffobj->getPE32PlusHeader(pe32plus);
-                if (pe32plus != NULL) {
-                    *slide = pe32plus->ImageBase - fbase;
-                    *section_slide = -(int64_t)pe32plus->ImageBase;
-                }
-                else {
-                    const llvm::object::pe32_header *pe32;
-                    coffobj->getPE32Header(pe32);
-                    if (pe32 == NULL) {
-                        *obj = NULL;
-                        *context = NULL;
-                        *slide = 0;
-                    }
-                    else {
-                        *slide = pe32->ImageBase - fbase;
-                        *section_slide = -(int64_t)pe32->ImageBase;
-                    }
-                }
-#endif
-            }
-#ifdef LLVM39
-            else {
-                // TODO: report the error instead of silently consuming it?
-                //       jl_error might run into the same error again...
-                consumeError(errorobj.takeError());
-            }
-#endif
-
-            // update cache
-            objfileentry_t entry = {*obj,*context,*slide,*section_slide};
-            objfilemap[fbase] = entry;
-        }
-#endif
+#ifndef LLVM35
+    if (iswindows) {
         return true;
     }
-    return false;
+#endif
+
+// GOAL: Read debuginfo from file
+    // TODO: need read/write lock here for objfilemap synchronization
+    obfiletype::iterator it = objfilemap.find(fbase);
+    if (it != objfilemap.end()) {
+        // Return cached value
+        *obj = it->second.obj;
+        *context = it->second.ctx;
+        *slide = it->second.slide;
+        *section_slide = it->second.section_slide;
+        return true;
+    }
+
+// GOAL: Assign errorobj
+    StringRef objpath;
+    std::string debuginfopath;
+    uint8_t uuid[16], uuid2[16];
+    if (isdarwin) {
+        size_t msize = (size_t)(((uint64_t)-1) - fbase);
+#ifdef LLVM36
+        std::unique_ptr<MemoryBuffer> membuf = MemoryBuffer::getMemBuffer(
+                StringRef((const char *)fbase, msize), "", false);
+        auto origerrorobj = llvm::object::ObjectFile::createObjectFile(
+            membuf->getMemBufferRef(), sys::fs::file_magic::unknown);
+#elif defined(LLVM35)
+        MemoryBuffer *membuf = MemoryBuffer::getMemBuffer(
+            StringRef((const char *)fbase, msize), "", false);
+        std::unique_ptr<MemoryBuffer> buf(membuf);
+        auto origerrorobj = llvm::object::ObjectFile::createObjectFile(
+            buf, sys::fs::file_magic::unknown);
+#else
+        MemoryBuffer *membuf = MemoryBuffer::getMemBuffer(
+            StringRef((const char *)fbase, msize), "", false);
+        std::unique_ptr<llvm::object::ObjectFile> origerrorobj(llvm::object::ObjectFile::createObjectFile(
+            membuf));
+#endif
+        if (!origerrorobj) {
+            objfileentry_t entry = {};
+            objfilemap[fbase] = entry;
+            return true;
+        }
+
+        llvm::object::MachOObjectFile *morigobj = (llvm::object::MachOObjectFile*)
+#ifdef LLVM36
+            origerrorobj.get().get();
+#else
+            origerrorobj.get();
+#endif
+
+        // First find the uuid of the object file (we'll use this to make sure we find the
+        // correct debug symbol file).
+        if (!getObjUUID(morigobj, uuid)) {
+            objfileentry_t entry = {};
+            objfilemap[fbase] = entry;
+            return true;
+        }
+
+        // On OS X debug symbols are not contained in the dynamic library.
+        // For now we only support .dSYM files in the same directory
+        // as the shared library. In the future we may use DBGCopyFullDSYMURLForUUID from CoreFoundation to make
+        // use of spotlight to find the .dSYM file.
+        size_t sep = fname.rfind('/');
+        debuginfopath = fname;
+        debuginfopath += ".dSYM/Contents/Resources/DWARF/";
+        debuginfopath += fname.substr(sep + 1);
+        objpath = debuginfopath;
+    }
+    else {
+        // On Linux systems we need to mmap another copy because of the permissions on the mmap'ed shared library.
+        // On Windows we need to mmap another copy since reading the in-memory copy seems to return object_error:unexpected_eof
+        objpath = fname;
+    }
+#ifdef LLVM35
+    auto errorobj = llvm::object::ObjectFile::createObjectFile(objpath);
+#else
+    std::unique_ptr<llvm::object::ObjectFile> errorobj(llvm::object::ObjectFile::createObjectFile(objpath));
+#endif
+
+// GOAL: Assign *obj, *context, *slide (if above succeeded)
+    if (errorobj) {
+#ifdef LLVM36
+        auto *debugobj = errorobj->getBinary();
+#else
+        auto *debugobj = errorobj.get();
+#endif
+
+        if (islinux) {
+#ifdef LLVM36
+            // if the file has a .gnu_debuglink section,
+            // try to load its companion file instead
+            // in the expected locations
+            // for now, we don't support the build-id method
+            debug_link_info info = getDebuglink(*debugobj);
+            if (!info.filename.empty()) {
+                size_t sep = fname.rfind('/');
+                ErrorOr<object::OwningBinary<object::ObjectFile>> DebugInfo(std::errc::no_such_file_or_directory);
+                if (fname.substr(sep + 1) != info.filename) {
+                    debuginfopath = fname.substr(0, sep + 1);
+                    debuginfopath += info.filename;
+                    DebugInfo = openDebugInfo(debuginfopath, info);
+                }
+                if (DebugInfo.getError()) {
+                    debuginfopath = fname.substr(0, sep + 1);
+                    debuginfopath += ".debug/";
+                    debuginfopath += info.filename;
+                    DebugInfo = openDebugInfo(debuginfopath, info);
+                }
+                if (DebugInfo.getError()) {
+                    debuginfopath = "/usr/lib/debug/";
+                    debuginfopath += fname.substr(0, sep + 1);
+                    debuginfopath += info.filename;
+                    DebugInfo = openDebugInfo(debuginfopath, info);
+                }
+                if (DebugInfo.getError()) {
+                    // no split debug info found
+                    // should we warn the user?
+                }
+                else {
+                    errorobj = std::move(DebugInfo);
+                    debugobj = errorobj->getBinary();
+                }
+            }
+#endif
+        }
+
+        if (isdarwin) {
+            // verify the UUID matches
+            if (!getObjUUID((llvm::object::MachOObjectFile*)debugobj, uuid2) ||
+                    memcmp(uuid, uuid2, sizeof(uuid)) != 0) {
+                objfileentry_t entry = {};
+                objfilemap[fbase] = entry;
+                return true;
+            }
+        }
+
+        if (iswindows) {
+#ifdef LLVM35
+            assert(debugobj->isCOFF());
+            const llvm::object::COFFObjectFile *coffobj = (const llvm::object::COFFObjectFile*)debugobj;
+            const llvm::object::pe32plus_header *pe32plus;
+            coffobj->getPE32PlusHeader(pe32plus);
+            if (pe32plus != NULL) {
+                *slide = pe32plus->ImageBase - fbase;
+                *section_slide = -(int64_t)pe32plus->ImageBase;
+            }
+            else {
+                const llvm::object::pe32_header *pe32;
+                coffobj->getPE32Header(pe32);
+                if (pe32 == NULL) {
+                    objfileentry_t entry = {};
+                    objfilemap[fbase] = entry;
+                    return true;
+                }
+                else {
+                    *slide = pe32->ImageBase - fbase;
+                    *section_slide = -(int64_t)pe32->ImageBase;
+                }
+            }
+#endif
+        }
+        else {
+            *slide = -(int64_t)fbase;
+        }
+
+#ifdef LLVM37
+        *context = new DWARFContextInMemory(*debugobj);
+#elif defined(LLVM36)
+        *context = DIContext::getDWARFContext(*debugobj);
+#else
+        *context = DIContext::getDWARFContext(debugobj);
+#endif
+        *obj = debugobj;
+#ifdef LLVM36
+        auto binary = errorobj->takeBinary();
+        binary.first.release();
+        binary.second.release();
+#else
+        errorobj.release();
+#endif
+    }
+#ifdef LLVM39
+    else {
+        // TODO: report the error instead of silently consuming it?
+        //       jl_error might run into the same error again...
+        consumeError(errorobj.takeError());
+    }
+#endif
+
+    // update cache
+    objfileentry_t entry = {*obj, *context, *slide, *section_slide};
+    objfilemap[fbase] = entry;
+    return true;
 }
 
 // *name and *filename should be either NULL or malloc'd pointer

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -194,17 +194,21 @@ static DWORD64 WINAPI JuliaGetModuleBase64(
 #endif
 }
 
+// Might be called from unmanaged thread.
 int needsSymRefreshModuleList;
 BOOL (WINAPI *hSymRefreshModuleList)(HANDLE);
-static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *Context)
+void jl_refresh_dbg_module_list(void)
 {
-    // Might be called from unmanaged thread.
     if (needsSymRefreshModuleList && hSymRefreshModuleList != 0 && !jl_in_stackwalk) {
         jl_in_stackwalk = 1;
         hSymRefreshModuleList(GetCurrentProcess());
         jl_in_stackwalk = 0;
         needsSymRefreshModuleList = 0;
     }
+}
+static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *Context)
+{
+    jl_refresh_dbg_module_list();
 #if !defined(_CPU_X86_64_)
     if (jl_in_stackwalk) {
         return 0;
@@ -372,7 +376,7 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
         jl_svecset(r, 3, frame.linfo != NULL ? (jl_value_t*)frame.linfo : jl_nothing);
         jl_svecset(r, 4, jl_box_bool(frame.fromC));
         jl_svecset(r, 5, jl_box_bool(frame.inlined));
-        jl_svecset(r, 6, jl_box_long((intptr_t)ip));
+        jl_svecset(r, 6, jl_box_voidpointer(ip));
     }
     free(frames);
     JL_GC_POP();

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -109,3 +109,13 @@ let li = typeof(getfield).name.mt.cache.func::LambdaInfo,
     repr = string(sf)
     @test repr == " in getfield(...) at b:3"
 end
+
+let ctestptr = cglobal((:ctest, "libccalltest")),
+    ctest = StackTraces.lookup(ctestptr + 1)
+
+    @test length(ctest) == 1
+    @test ctest[1].func === :ctest
+    @test isnull(ctest[1].linfo)
+    @test ctest[1].from_c
+    @test ctest[1].pointer === UInt64(ctestptr)
+end


### PR DESCRIPTION
There seem to be a few variations on the tools and arguments
available for creating split debuginfo files.
I used the following:

objcopy --only-keep-debug libjulia.so libjulia.so.debug
strip -g libjulia.so
objcopy --add-gnu-debuglink=libjulia.so.debug libjulia.so

fix https://github.com/JuliaLang/julia/issues/17854
