### PR TITLE
Fix StackOverflowError in zip_iteratorsize

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -61,6 +61,7 @@ zip_iteratorsize(a, b) = and_iteratorsize(a,b) # as `and_iteratorsize` but inher
 zip_iteratorsize(::HasLength, ::IsInfinite) = HasLength()
 zip_iteratorsize(::HasShape, ::IsInfinite) = HasLength()
 zip_iteratorsize(a::IsInfinite, b) = zip_iteratorsize(b,a)
+zip_iteratorsize(a::IsInfinite, b::IsInfinite) = IsInfinite()
 
 
 immutable Zip1{I} <: AbstractZipIterator

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -185,6 +185,7 @@ end
 @test Base.iteratorsize(repeated(0, 5))   == Base.HasLength()
 @test Base.iteratoreltype(repeated(0))    == Base.HasEltype()
 @test Base.iteratoreltype(repeated(0, 5)) == Base.HasEltype()
+@test Base.iteratorsize(zip(repeated(0), repeated(0))) == Base.IsInfinite()
 
 
 # product


### PR DESCRIPTION
Triggered by the PlotlyJS tests
