### PR TITLE
Provide a better error for `similar` methods with Dict

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -848,3 +848,6 @@ function similar(t::ImmutableDict)
     end
     return t
 end
+
+_similar_for{P<:Pair}(c::Dict, ::Type{P}, itr, isz) = similar(c, P)
+_similar_for(c::Associative, T, itr, isz) = throw(ArgumentError("for Associatives, similar requires an element type of Pair;\n  if calling map, consider a comprehension instead"))

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -388,6 +388,11 @@ d = Dict('a'=>1, 'b'=>1, 'c'=> 3)
 @test [d[k] for k in keys(d)] == [d[k] for k in eachindex(d)] ==
       [v for (k, v) in d] == [d[x[1]] for (i, x) in enumerate(d)]
 
+# generators, similar
+d = Dict(:a=>"a")
+@test @inferred(map(identity, d)) == d
+@test @inferred(map(p->p.first=>p.second[1], d)) == Dict(:a=>'a')
+@test_throws ArgumentError map(p->p.second, d)
 
 # Issue 12451
 @test_throws ArgumentError Dict(0)


### PR DESCRIPTION
Fixes the following error:

``` jl
julia> d = Dict(:a=>"a")
Dict{Symbol,String} with 1 entry:
  :a => "a"

julia> map(p->p.second, d) == ["a"]
ERROR: MethodError: no method matching similar(::Dict{Symbol,String}, ::Type{String})
Closest candidates are:
  similar(::SubArray{T,N,P,I,L}, ::Type{T}, ::Tuple{Vararg{Int64,N}}) at subarray.jl:52
  similar{T}(::Array{T,1}, ::Type{T}) at array.jl:122
  similar{T}(::Array{T,2}, ::Type{T}) at array.jl:123
  ...
 in _collect(::Dict{Symbol,String}, ::Base.Generator{Dict{Symbol,String},##1#2}, ::Base.EltypeUnknown, ::Base.HasLength) at ./array.jl:318
 in map(::Function, ::Dict{Symbol,String}) at ./abstractarray.jl:1673
```

Noticed from the PlotlyJS tests.
