### PR TITLE
Remove two cross-references

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2913,21 +2913,6 @@ Squared absolute value of `x`.
 abs2
 
 """
-    write(stream::IO, x)
-    write(filename::AbstractString, x)
-
-Write the canonical binary representation of a value to the given I/O stream or file.
-Returns the number of bytes written into the stream.
-
-You can write multiple values with the same :func:`write` call. i.e. the following are
-equivalent:
-
-    write(stream, x, y...)
-    write(stream, x) + write(stream, y...)
-"""
-write
-
-"""
     sizehint!(s, n)
 
 Suggest that collection `s` reserve capacity for at least `n` elements. This can improve performance.

--- a/base/io.jl
+++ b/base/io.jl
@@ -23,6 +23,20 @@ function iswritable end
 function copy end
 function eof end
 
+"""
+    write(stream::IO, x)
+    write(filename::AbstractString, x)
+
+Write the canonical binary representation of a value to the given I/O stream or file.
+Returns the number of bytes written into the stream.
+
+You can write multiple values with the same `write` call. i.e. the following are equivalent:
+
+    write(stream, x, y...)
+    write(stream, x) + write(stream, y...)
+"""
+function write end
+
 read(s::IO, ::Type{UInt8}) = error(typeof(s)," does not support byte I/O")
 write(s::IO, x::UInt8) = error(typeof(s)," does not support byte I/O")
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -230,7 +230,7 @@ end
 
 Unsigned right bit shift operator, `x >>> n`. For `n >= 0`, the result is `x`
 shifted right by `n` bits, where `n >= 0`, filling with `0`s. For `n < 0`, this
-is equivalent to `x [<<](:func:`<<`) -n`].
+is equivalent to `x << -n`.
 
 For `Unsigned` integer types, this is equivalent to [`>>`](:func:`>>`). For
 `Signed` integer types, this is equivalent to `signed(unsigned(x) >> n)`.

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -134,7 +134,7 @@ General I/O
 
    Write the canonical binary representation of a value to the given I/O stream or file. Returns the number of bytes written into the stream.
 
-   You can write multiple values with the same :func:``write`` call. i.e. the following are equivalent:
+   You can write multiple values with the same ``write`` call. i.e. the following are equivalent:
 
    .. code-block:: julia
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -284,7 +284,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Unsigned right bit shift operator, ``x >>> n``\ . For ``n >= 0``\ , the result is ``x`` shifted right by ``n`` bits, where ``n >= 0``\ , filling with ``0``\ s. For ``n < 0``\ , this is equivalent to ``x [<<](:func:``\ <<``) -n``\ ].
+   Unsigned right bit shift operator, ``x >>> n``\ . For ``n >= 0``\ , the result is ``x`` shifted right by ``n`` bits, where ``n >= 0``\ , filling with ``0``\ s. For ``n < 0``\ , this is equivalent to ``x << -n``\ .
 
    For ``Unsigned`` integer types, this is equivalent to :func:`>>`\ . For ``Signed`` integer types, this is equivalent to ``signed(unsigned(x) >> n)``\ .
 


### PR DESCRIPTION
- Replace a malformed link in `write` docstring with a literal `write` rather than a real cross-reference, since that would just cross-reference itself. Also move `write` docstring inline.
- Remove cross-reference for `<<` from inside a literal since text inside a literal can't contain a link. A cross-reference to `<<` already appears at the end of the docstring.
