### PR TITLE
Fix typo in libgit2 credentials callback

### DIFF
--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -121,8 +121,8 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
             end
             passdef
         end
-        (creds.user != username) || (creds.pass != userpass) ||
-            (creds.prvkey != privatekey) || (creds.pubkey != publickey) && reset!(creds)
+        ((creds.user != username) || (creds.pass != passphrase) ||
+            (creds.prvkey != privatekey) || (creds.pubkey != publickey)) && reset!(creds)
 
         creds.user = username # save credentials
         creds.prvkey = privatekey # save credentials


### PR DESCRIPTION
Only the typo fix for now. I tried a simple test, but mistyping the passphrase seems to be a fatal error, so that'll have to wait.
