### PR TITLE
Generalize getindex for AbstractUnitRanges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -499,10 +499,11 @@ end
 
 getindex(r::Range, ::Colon) = copy(r)
 
-function getindex{T<:Integer}(r::UnitRange, s::AbstractUnitRange{T})
+function getindex{T<:Integer}(r::AbstractUnitRange, s::AbstractUnitRange{T})
     @_inline_meta
     @boundscheck checkbounds(r, s)
-    st = oftype(r.start, r.start + first(s)-1)
+    f = first(r)
+    st = oftype(f, f + first(s)-1)
     range(st, length(s))
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -755,6 +755,7 @@ r = Base.OneTo(3)
 @test minimum(r) == 1
 @test maximum(r) == 3
 @test r[2] == 2
+@test r[2:3] === 2:3
 @test_throws BoundsError r[4]
 @test_throws BoundsError r[0]
 @test r+1 === 2:4


### PR DESCRIPTION
It turns out we were returning a `Vector{Int}` for operations that should return a Range
