### PR TITLE
Write up test for #15592

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -662,3 +662,8 @@ end
 
 # issue #17701
 @test expand(:(i==3 && i+=1)) == Expr(:error, "invalid assignment location \"==(i,3)&&i\"")
+
+# PR #15592
+let str = "[1] [2]"
+    @test_throws ParseError parse(str)
+end


### PR DESCRIPTION
parse("[1] [2]") should throw a ParseError. 

This is a test for PR #15592, which fixed issue #15590. 
