### PR TITLE
Add test for 15913 and 15896

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -669,4 +669,4 @@ let str = "[1] [2]"
 end
 
 # issue 15896 and PR 15913
-@test_throws ErrorException eval(:(macro test(d; y=0) end))
+@test_throws ErrorException eval(:(macro test15896(d; y=0) end))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -667,3 +667,6 @@ end
 let str = "[1] [2]"
     @test_throws ParseError parse(str)
 end
+
+# issue 15896 and PR 15913
+@test_throws ErrorException eval(:(macro test(d; y=0) end))


### PR DESCRIPTION
This tests that macros with kwargs throws a syntax error. 

This adds a test for #15913, which fixed #15896
