### PR TITLE
Custom parser for dates.

### DIFF
--- a/base/dates/Dates.jl
+++ b/base/dates/Dates.jl
@@ -16,6 +16,7 @@ include("ranges.jl")
 include("adjusters.jl")
 include("rounding.jl")
 include("io.jl")
+include("iofast.jl")
 
 export Period, DatePeriod, TimePeriod,
        Year, Month, Week, Day, Hour, Minute, Second, Millisecond,

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -1,26 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-# TODO: optimize this
-function Base.string(dt::DateTime)
-    y,m,d = yearmonthday(days(dt))
-    h,mi,s = hour(dt),minute(dt),second(dt)
-    yy = y < 0 ? @sprintf("%05i",y) : lpad(y,4,"0")
-    mm = lpad(m,2,"0")
-    dd = lpad(d,2,"0")
-    hh = lpad(h,2,"0")
-    mii = lpad(mi,2,"0")
-    ss = lpad(s,2,"0")
-    ms = millisecond(dt) == 0 ? "" : string(millisecond(dt)/1000.0)[2:end]
-    return "$yy-$mm-$(dd)T$hh:$mii:$ss$(ms)"
-end
+Base.string(dt::DateTime) = format(dt)
 Base.show(io::IO,x::DateTime) = print(io,string(x))
-function Base.string(dt::Date)
-    y,m,d = yearmonthday(value(dt))
-    yy = y < 0 ? @sprintf("%05i",y) : lpad(y,4,"0")
-    mm = lpad(m,2,"0")
-    dd = lpad(d,2,"0")
-    return "$yy-$mm-$dd"
-end
+Base.string(dt::Date) = format(dt)
 Base.show(io::IO,x::Date) = print(io,string(x))
 
 ### Parsing
@@ -49,11 +31,17 @@ immutable FixedWidthSlot{T<:Any} <: Slot{T}
     width::Int
 end
 
-immutable DateFormat
+abstract AbstractDateFormat
+
+immutable DateFormat <: AbstractDateFormat
     slots::Array{Slot,1}
     prefix::AbstractString # optional transition from the start of a string to the 1st slot
     locale::AbstractString
 end
+
+immutable FastDateFormat{S} <: AbstractDateFormat
+end
+
 
 abstract DayOfWeekSlot
 
@@ -223,9 +211,13 @@ function format(dt::TimeType,df::DateFormat)
 end
 
 # UI
-const ISODateTimeFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.s")
-const ISODateFormat = DateFormat("yyyy-mm-dd")
+const ISODateTimeFormat = FastDateFormat{:ISODateTime}()
+const ISODateFormat = FastDateFormat{:ISODate}()
 const RFC1123Format = DateFormat("e, dd u yyyy HH:MM:SS")
+
+format(dt::DateTime) = format(dt, ISODateTimeFormat)
+format(dt::Date) = format(dt, ISODateFormat)
+
 
 """
     DateTime(dt::AbstractString, format::AbstractString; locale="english") -> DateTime
@@ -258,14 +250,15 @@ backslash. The date "1995y01m" would have the format "y\\ym\\m".
 DateTime(dt::AbstractString,format::AbstractString;locale::AbstractString="english") = DateTime(dt,DateFormat(format,locale))
 
 """
-    DateTime(dt::AbstractString, df::DateFormat) -> DateTime
+    DateTime(dt::AbstractString, df::AbstractDateFormat) -> DateTime
 
 Construct a `DateTime` by parsing the `dt` date string following the pattern given in
 the [`DateFormat`](:func:`Dates.DateFormat`) object. Similar to
 `DateTime(::AbstractString, ::AbstractString)` but more efficient when repeatedly parsing
 similarly formatted date strings with a pre-created `DateFormat` object.
 """
-DateTime(dt::AbstractString,df::DateFormat=ISODateTimeFormat) = DateTime(parse(dt,df)...)
+DateTime(dt::AbstractString,df::DateFormat) = DateTime(parse(dt,df)...)
+DateTime(dt::AbstractString) = DateTime(dt,ISODateTimeFormat)
 
 """
     Date(dt::AbstractString, format::AbstractString; locale="english") -> Date
@@ -277,11 +270,12 @@ Construct a `Date` object by parsing a `dt` date string following the pattern gi
 Date(dt::AbstractString,format::AbstractString;locale::AbstractString="english") = Date(dt,DateFormat(format,locale))
 
 """
-    Date(dt::AbstractString, df::DateFormat) -> Date
+    Date(dt::AbstractString, df::AbstractDateFormat) -> Date
 
-Parse a date from a date string `dt` using a `DateFormat` object `df`.
+Parse a date from a date string `dt` using format `df`.
 """
-Date(dt::AbstractString,df::DateFormat=ISODateFormat) = Date(parse(dt,df)...)
+Date(dt::AbstractString,df::DateFormat) = Date(parse(dt,df)...)
+Date(str::AbstractString) = Date(str,ISODateFormat)
 
 
 """
@@ -321,18 +315,19 @@ format(dt::TimeType,f::AbstractString;locale::AbstractString="english") = format
 
 # vectorized
 DateTime{T<:AbstractString}(Y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = DateTime(Y,DateFormat(format,locale))
-function DateTime{T<:AbstractString}(Y::AbstractArray{T},df::DateFormat=ISODateTimeFormat)
-    return reshape(DateTime[DateTime(parse(y,df)...) for y in Y], size(Y))
+
+function DateTime{T<:AbstractString}(Y::AbstractArray{T},df::AbstractDateFormat=ISODateTimeFormat)
+    return reshape(DateTime[DateTime(y,df) for y in Y], size(Y))
 end
 Date{T<:AbstractString}(Y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Date(Y,DateFormat(format,locale))
-function Date{T<:AbstractString}(Y::AbstractArray{T},df::DateFormat=ISODateFormat)
-    return reshape(Date[Date(parse(y,df)...) for y in Y], size(Y))
+function Date{T<:AbstractString}(Y::AbstractArray{T},df::AbstractDateFormat=ISODateFormat)
+    return reshape(Date[Date(y,df) for y in Y], size(Y))
 end
 
 format{T<:TimeType}(Y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Dates.format(Y,DateFormat(format,locale))
-function format(Y::AbstractArray{Date},df::DateFormat=ISODateFormat)
+function format(Y::AbstractArray{Date},df::AbstractDateFormat=ISODateFormat)
     return reshape([Dates.format(y,df) for y in Y], size(Y))
 end
-function format(Y::AbstractArray{DateTime},df::DateFormat=ISODateTimeFormat)
+function format(Y::AbstractArray{DateTime},df::AbstractDateFormat=ISODateTimeFormat)
     return reshape([Dates.format(y,df) for y in Y], size(Y))
 end

--- a/base/dates/iofast.jl
+++ b/base/dates/iofast.jl
@@ -1,0 +1,171 @@
+import Base.tryparse
+
+
+function DateTime(str::AbstractString,::FastDateFormat{:ISODateTime})
+    nd = tryparse(DateTime, str)
+    isnull(nd) && throw(ArgumentError("Invalid DateTime string"))
+    get(nd)
+end
+function Date(str::AbstractString,::FastDateFormat{:ISODate})
+    nd = tryparse(Date, str)
+    isnull(nd) && throw(ArgumentError("Invalid Date string"))
+    get(nd)
+end
+
+
+macro chk1(expr,label=:error)
+    quote
+        x,i = $(esc(expr))
+        if isnull(x)
+            @goto $label
+        else
+            get(x),i
+        end
+    end
+end
+
+function tryparse{T<:Union{Date,DateTime}}(::Type{T}, str::AbstractString)
+    i = start(str)
+    i = skipwhitespace(str,i)
+    nd, i = tryparsenext(T, str, i)
+    i = skipwhitespace(str,i)
+    if !done(str,i)
+        return Nullable{T}()
+    else
+        return nd
+    end
+end
+
+@inline function skipwhitespace(str,i)
+    while !done(str,i)
+        c,ii = next(str,i)
+        if !isspace(c)
+            break
+        end
+        i = ii
+    end
+    return i
+end
+
+@inline function tryparsenext(::Type{Date},str,i)
+    R = Nullable{Date}
+    dm = dd = 1
+    dy, i = @chk1 tryparsenext_base10(str,i,10)
+    c,  i = @chk1 tryparsenext_char(str,i,'-')
+    dm, i = @chk1 tryparsenext_base10(str,i,2) done
+    c,  i = @chk1 tryparsenext_char(str,i,'-') done
+    dd, i = @chk1 tryparsenext_base10(str,i,2) done
+
+    @label done
+    d = Date(dy,dm,dd)
+    return R(d), i
+
+    @label error
+    return R(), i
+end
+
+
+@inline function tryparsenext(::Type{DateTime},str,i)
+    R = Nullable{DateTime}
+    dm = dd = 1
+    th = tm = ts = tms = 0
+    dy, i = @chk1 tryparsenext_base10(str,i,10)
+    c,  i = @chk1 tryparsenext_char(str,i,'-')
+    dm, i = @chk1 tryparsenext_base10(str,i,2) done
+    c,  i = @chk1 tryparsenext_char(str,i,'-') done
+    dd, i = @chk1 tryparsenext_base10(str,i,2) done
+    c,  i = @chk1 tryparsenext_char(str,i,'T') done
+    th, i = @chk1 tryparsenext_base10(str,i,2) done
+    c,  i = @chk1 tryparsenext_char(str,i,':') done
+    tm, i = @chk1 tryparsenext_base10(str,i,2) done
+    c,  i = @chk1 tryparsenext_char(str,i,':') done
+    ts, i = @chk1 tryparsenext_base10(str,i,2) done
+    c,  i = @chk1 tryparsenext_char(str,i,'.') done
+    tms,i = @chk1 tryparsenext_base10_frac(str,i,3) done
+
+    @label done
+    d = DateTime(dy,dm,dd,th,tm,ts,tms)
+    return R(d), i
+
+    @label error
+    return R(), i
+end
+
+@inline function tryparsenext_base10_digit(str,i)
+    R = Nullable{Int}
+    done(str,i) && @goto error
+    c,ii = next(str,i)
+    '0' <= c <= '9' || @goto error
+    return R(c-'0'), ii
+
+    @label error
+    return R(), i
+end
+
+@inline function tryparsenext_base10(str,i,maxdig)
+    R = Nullable{Int}
+    r,i = @chk1 tryparsenext_base10_digit(str,i)
+    for j = 2:maxdig
+        d,i = @chk1 tryparsenext_base10_digit(str,i) done
+        r = r*10 + d
+    end
+    @label done
+    return R(r), i
+
+    @label error
+    return R(), i
+end
+
+@inline function tryparsenext_base10_frac(str,i,maxdig)
+    R = Nullable{Int}
+    r,i = @chk1 tryparsenext_base10_digit(str,i)
+    for j = 2:maxdig
+        nd,i = tryparsenext_base10_digit(str,i)
+        if isnull(nd)
+            for k = j:maxdig
+                r *= 10
+            end
+            break
+        end
+        d = get(nd)
+        r = 10*r + d
+    end
+    return R(r), i
+
+    @label error
+    return R(), i
+end
+
+
+@inline function tryparsenext_char(str,i,cc::Char)
+    R = Nullable{Char}
+    done(str,i) && @goto error
+    c,ii = next(str,i)
+    c == cc || @goto error
+    return R(c), ii
+
+    @label error
+    return R(), i
+end
+
+# TODO: optimize this
+function format(dt::DateTime, ::FastDateFormat{:ISODateTime})
+    y,m,d = yearmonthday(days(dt))
+    h,mi,s = hour(dt),minute(dt),second(dt)
+    yy = y < 0 ? @sprintf("%05i",y) : lpad(y,4,"0")
+    mm = lpad(m,2,"0")
+    dd = lpad(d,2,"0")
+    hh = lpad(h,2,"0")
+    mii = lpad(mi,2,"0")
+    ss = lpad(s,2,"0")
+    ms = millisecond(dt) == 0 ? "" : string(millisecond(dt)/1000.0)[2:end]
+    return "$yy-$mm-$(dd)T$hh:$mii:$ss$(ms)"
+end
+
+function format(dt::Date, ::FastDateFormat{:ISODate})
+    y,m,d = yearmonthday(value(dt))
+    yy = y < 0 ? @sprintf("%05i",y) : lpad(y,4,"0")
+    mm = lpad(m,2,"0")
+    dd = lpad(d,2,"0")
+    return "$yy-$mm-$dd"
+end

--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -175,7 +175,7 @@ Alternatively, you can write ``using Base.Dates`` to bring all exported function
 
    Construct a date formatting object that can be used for parsing date strings or formatting a date object as a string. For details on the syntax for ``format`` see :ref:`parsing <man-date-parsing>` and :ref:`formatting <man-date-formatting>`\ .
 
-.. function:: DateTime(dt::AbstractString, df::DateFormat) -> DateTime
+.. function:: DateTime(dt::AbstractString, df::AbstractDateFormat) -> DateTime
 
    .. Docstring generated from Julia source
 
@@ -211,11 +211,11 @@ Alternatively, you can write ``using Base.Dates`` to bring all exported function
 
    Construct a ``Date`` object by parsing a ``dt`` date string following the pattern given in the ``format`` string. Follows the same conventions as ``DateTime(::AbstractString, ::AbstractString)``\ .
 
-.. function:: Date(dt::AbstractString, df::DateFormat) -> Date
+.. function:: Date(dt::AbstractString, df::AbstractDateFormat) -> Date
 
    .. Docstring generated from Julia source
 
-   Parse a date from a date string ``dt`` using a ``DateFormat`` object ``df``\ .
+   Parse a date from a date string ``dt`` using format ``df``\ .
 
 .. function:: now() -> DateTime
 

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -19,6 +19,37 @@ using Base.Test
 @test string(Dates.DateTime(2000,1,1,0,0,0,998)) == "2000-01-01T00:00:00.998"
 @test string(Dates.DateTime(2000,1,1,0,0,0,999)) == "2000-01-01T00:00:00.999"
 
+
+# 0.4/0.5 parsing behaviour
+@test_throws ArgumentError Date("2010")
+@test Date("2010-")      == Date(2010)
+@test Date("2010-2")     == Date(2010,2)
+@test Date("2010-02-")   == Date(2010,2)
+@test Date("2010-02-5")  == Date(2010,2,5)
+@test Date("2010-02-05") == Date(2010,2,5)
+
+@test_throws ArgumentError DateTime("2010")
+@test DateTime("2010-")                     == DateTime(2010)
+@test DateTime("2010-2")                    == DateTime(2010,2)
+@test DateTime("2010-02-")                  == DateTime(2010,2)
+@test DateTime("2010-02-5")                 == DateTime(2010,2,5)
+@test DateTime("2010-02-05")                == DateTime(2010,2,5)
+@test DateTime("2010-02-05T")               == DateTime(2010,2,5)
+@test DateTime("2010-02-05T7")              == DateTime(2010,2,5,7)
+@test DateTime("2010-02-05T07")             == DateTime(2010,2,5,7)
+@test DateTime("2010-02-05T07:")            == DateTime(2010,2,5,7)
+@test DateTime("2010-02-05T07:8")           == DateTime(2010,2,5,7,8)
+@test DateTime("2010-02-05T07:08")          == DateTime(2010,2,5,7,8)
+@test DateTime("2010-02-05T07:08:")         == DateTime(2010,2,5,7,8)
+@test DateTime("2010-02-05T07:08:3")        == DateTime(2010,2,5,7,8,3)
+@test DateTime("2010-02-05T07:08:03")       == DateTime(2010,2,5,7,8,3)
+@test DateTime("2010-02-05T07:08:03.")      == DateTime(2010,2,5,7,8,3)
+@test DateTime("2010-02-05T07:08:03.1")     == DateTime(2010,2,5,7,8,3,100)
+@test DateTime("2010-02-05T07:08:03.12")    == DateTime(2010,2,5,7,8,3,120)
+@test DateTime("2010-02-05T07:08:03.123")   == DateTime(2010,2,5,7,8,3,123)
+@test_throws ArgumentError DateTime("2010-02-05T07:08:03.1234") # was InexactError
+
+
 # DateTime parsing
 # Useful reference for different locales: http://library.princeton.edu/departments/tsd/katmandu/reference/months.html
 


### PR DESCRIPTION
This replaces the default date parser with a custom-coded version. It is approximately 50x faster on the following snippet:

``` julia
datestr = map(string,range(DateTime("2016-02-19T12:34:56"),Dates.Millisecond(123),100_000))
testDateTime(v) = map(DateTime,v)

@time testDateTime(datestr)
```
