### PR TITLE
RFC: Move i686 CI testing from Travis to CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Linux, OSX: [![Build Status](https://api.travis-ci.org/JuliaLang/julia.svg?branch=master)](https://travis-ci.org/JuliaLang/julia)
 
+Linux i686: [![CircleCI](https://circleci.com/gh/JuliaLang/julia.svg?style=shield)](https://circleci.com/gh/JuliaLang/julia)
+
 Windows: [![Build status](https://ci.appveyor.com/api/projects/status/dvial98s5vi6ealt/branch/master?svg=true)](https://ci.appveyor.com/project/JuliaLang/julia/branch/master)
 
 Code Coverage: [![Coverage Status](https://coveralls.io/repos/JuliaLang/julia/badge.svg?branch=master)](https://coveralls.io/r/JuliaLang/julia?branch=master) [![codecov.io](http://codecov.io/github/JuliaLang/julia/coverage.svg?branch=master)](http://codecov.io/github/JuliaLang/julia?branch=master)

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,11 @@ machine:
     JULIA_TEST_MAXRSS_MB: 600
     TEST_DIR: "/tmp/julia/share/julia/test"
 
-general:
-  branches:
-    only:
-      - master
-      - /release-.*/
+# general:
+#   branches:
+#     only:
+#       - master
+#       - /release-.*/
 
 checkout:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,53 @@
+machine:
+  environment:
+    ARCH: "i686"
+    BUILDOPTS: "-j3 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1"
+    TESTSTORUN: "all"
+    JULIA_CPU_CORES: 2
+    JULIA_TEST_MAXRSS_MB: 600
+    TEST_DIR: "/tmp/julia/share/julia/test"
+
+general:
+  branches:
+    only:
+      - master
+      - /release-.*/
+
+checkout:
+  post:
+    - git config --global --unset url.ssh://git@github.com:.insteadof
+    - make check-whitespace
+    - git clone -q git://git.kitenet.net/moreutils
+    - echo "override ARCH=$ARCH" >> Make.user
+
+dependencies:
+  pre:
+    - sudo dpkg --add-architecture i386
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -y
+    - sudo apt-get install -y bar:i386 binutils:i386 gcc-5:i386 gcc-5-multilib:i386 g++-5:i386 g++-5-multilib:i386 gfortran-5:i386 gfortran-5-multilib:i386 make:i386 libssl-dev:i386
+    - mkdir -p $HOME/bin
+    - ln -s /usr/bin/gcc-5 $HOME/bin/gcc
+    - ln -s /usr/bin/g++-5 $HOME/bin/g++
+    - ln -s /usr/bin/gfortran-5 $HOME/bin/gfortran
+    - gcc --version
+  override:
+    - make -C moreutils mispipe
+    - make $BUILDOPTS -C base version_git.jl.phony
+    - moreutils/mispipe "make $BUILDOPTS NO_GIT=1 -C deps" bar > deps.log || cat deps.log
+    - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
+    - make $BUILDOPTS NO_GIT=1 build-stats
+    - du -sk /tmp/julia/*
+  cache_directories:
+    - deps/srccache
+    - deps/build
+
+test:
+  override:
+    - /tmp/julia/bin/julia --precompile=no -e 'true'
+    - /tmp/julia/bin/julia-debug --precompile=no -e 'true'
+    - /tmp/julia/bin/julia -e 'versioninfo()'
+    - cd $TEST_DIR && bash ~/julia/contrib/circle_balanceload.sh:
+        parallel: true
+  post:
+    - cd $HOME && rm -rf julia/deps/build/julia-env

--- a/circle.yml
+++ b/circle.yml
@@ -44,8 +44,8 @@ dependencies:
 
 test:
   override:
-    - /tmp/julia/bin/julia --precompile=no -e 'true'
-    - /tmp/julia/bin/julia-debug --precompile=no -e 'true'
+    - /tmp/julia/bin/julia --precompiled=no -e 'true'
+    - /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
     - /tmp/julia/bin/julia -e 'versioninfo()'
     - cd $TEST_DIR && bash ~/julia/contrib/circle_balanceload.sh:
         parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ checkout:
 
 dependencies:
   pre:
+    - gem install gist # to upload a gist of the log on failure
     - sudo dpkg --add-architecture i386
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update -y
@@ -32,9 +33,10 @@ dependencies:
     - ln -s /usr/bin/gfortran-5 $HOME/bin/gfortran
     - gcc --version
   override:
+    - make -C deps distcleanall # REMOVE ME
     - make -C moreutils mispipe
     - make $BUILDOPTS -C base version_git.jl.phony
-    - moreutils/mispipe "make $BUILDOPTS NO_GIT=1 -C deps" bar > deps.log || cat deps.log
+    - make $BUILDOPTS NO_GIT=1 -C deps 1> deps.log || gist deps.log
     - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - make $BUILDOPTS NO_GIT=1 build-stats
     - du -sk /tmp/julia/*

--- a/contrib/circle_balanceload.sh
+++ b/contrib/circle_balanceload.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Balance the testing load between 2 CircleCI parallel containers
 
+set -e
+
 tests=($(/tmp/julia/bin/julia -e 'include("choosetests.jl"); t = choosetests(["all"])[1]; print(join(t, " "))'))
 
 # Command to run tests -- append names for specific tests

--- a/contrib/circle_balanceload.sh
+++ b/contrib/circle_balanceload.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Balance the testing load between 2 CircleCI parallel containers
+
+tests=($(/tmp/julia/bin/julia -e 'include("choosetests.jl"); t = choosetests(["all"])[1]; print(join(t, " "))'))
+
+# Command to run tests -- append names for specific tests
+jlcmd="/tmp/julia/bin/julia --check-bounds=yes runtests.jl"
+
+# Cut my build into pieces, this is my last resort
+cutoff=29
+
+case $CIRCLE_NODE_INDEX in
+  0) $jlcmd ${tests[@]:0:${cutoff}} libgit2-online ;;
+  1) $jlcmd ${tests[@]:${cutoff}+1} pkg ;;
+esac


### PR DESCRIPTION
This will hopefully lessen the Travis CI queue by moving the i686 Linux tests from Travis to CircleCI.

CircleCI will need to be manually enabled and configured by a JuliaLang owner, but much of the build configuration is in the circle.yml file added in this PR. I've been testing this on my fork of Julia and it seems to work okay, though the first successful run for me took about 2.5 hours because it had to build dependencies. CircleCI enables cached directories just as Travis does, so subsequent builds are shorter. ~~I should note that I'm not sure how to configure fast fails for queued commits on the same PR, though that should be possible.~~ Figured it out, it's just a project setting in CircleCI.

CircleCI gives you the option to use Ubuntu 12.04 or 14.04. I opted for the latter in my fork after reading their [documentation about the difference](https://circleci.com/docs/differences-between-trusty-and-precise/). I can't guarantee that the YAML I set up here will work with Circle's 12.04 but I don't know why it wouldn't.

cc @tkelman 
