### PR TITLE
Fix missing type parameter in _array_for

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -288,8 +288,8 @@ else
     _default_eltype(itr::ANY) = Any
 end
 
-_array_for(T, itr, ::HasLength) = Array{T,1}(Int(length(itr)::Integer))
-_array_for(T, itr, ::HasShape) = similar(Array{T}, indices(itr))
+_array_for{T}(::Type{T}, itr, ::HasLength) = Array{T,1}(Int(length(itr)::Integer))
+_array_for{T}(::Type{T}, itr, ::HasShape) = similar(Array{T}, indices(itr))
 
 function collect(itr::Generator)
     isz = iteratorsize(itr.iter)


### PR DESCRIPTION
This fixes a performance regression in the lucompletepiv benchmark triggered by generalizing `_array_for` to work with indices. Ref https://github.com/JuliaLang/julia/pull/17960#commitcomment-18612934.

This call, first introduced in b363cc70ee6f09bb4472944f8690283793c6052a, likely always triggered dynamic method dispatch. Unfortunately, the generalization to indices seemed to make that worse. This new version should be type stable and improves the performance of that benchmark by almost exactly twofold.
