### PR TITLE
Fix `@threadcall` argument passing (second try)

### DIFF
--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -75,6 +75,7 @@ function do_threadcall(wrapper::Function, rettype::Type, argtypes::Vector, argva
         y = cconvert(T, x)
         push!(roots, y)
         unsafe_store!(convert(Ptr{T}, ptr), unsafe_convert(T, y))
+        ptr += sizeof(T)
     end
 
     # create return buffer

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -21,6 +21,7 @@ int verbose = 1;
 
 int c_int = 0;
 
+
 //////////////////////////////////
 // Test for proper argument register truncation
 
@@ -520,12 +521,17 @@ JL_DLLEXPORT void finalizer_cptr(void* v)
     set_c_int(-1);
 }
 
+
 //////////////////////////////////
 // Turn off verbose for automated tests, leave on for debugging
 
 JL_DLLEXPORT void set_verbose(int level) {
     verbose = level;
 }
+
+
+//////////////////////////////////
+// Other tests
 
 JL_DLLEXPORT void *test_echo_p(void *p) {
     return p;
@@ -723,3 +729,7 @@ JL_DLLEXPORT float32x4_t test_ppc64_vec2(int64_t d1, float32x4_t a, float32x4_t 
 }
 
 #endif
+
+JL_DLLEXPORT int threadcall_args(int a, int b) {
+    return a + b;
+}

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -589,6 +589,10 @@ threadcall_test_func(x) =
 @test threadcall_test_func(3) == 1
 @test threadcall_test_func(259) == 1
 
+# issue 17819
+# NOTE: can't use cfunction or reuse ccalltest Struct methods, as those call into the runtime
+@test @threadcall((:threadcall_args, libccalltest), Cint, (Cint, Cint), 1, 2) == 3
+
 let n=3
     tids = Culong[]
     @sync for i in 1:10^n


### PR DESCRIPTION
Changed the erroneous `cfunction` with one in `ccalltest`.
Refs #17819 #17823 #17917
