### PR TITLE
fix effect_free computation over getfield

### DIFF
--- a/test/inference.jl
+++ b/test/inference.jl
@@ -68,7 +68,7 @@ end
 abstract Outer5906{T}
 
 immutable Inner5906{T}
-   a:: T
+    a:: T
 end
 
 immutable Empty5906{T} <: Outer5906{T}
@@ -306,3 +306,19 @@ let T = Array{Tuple{Vararg{Float64,TypeVar(:dim)}},1},
     @test Base.return_types(f16530b, (Symbol,)) == Any[TTlim]
 end
 @test f16530a(:d) == Vector
+
+
+# issue #18015
+type Triple18015
+    a::Int
+    b::Int
+    c::Int
+end
+a18015(tri) = tri.a
+b18015(tri) = tri.b
+c18015(tri) = tri.c
+setabc18015!(tri, a, b, c) = (tri.a = a; tri.b = b; tri.c = c)
+let tri = Triple18015(1, 2, 3)
+    setabc18015!(tri, b18015(tri), c18015(tri), a18015(tri))
+    @test tri.a === 2 && tri.b === 3 && tri.c === 1
+end


### PR DESCRIPTION
fix #18015 

@JeffBezanson this also fixes the bug you noted where inlineable was passing the wrong `sv` to `effect_free`. It would be appreciated if you could verify I've picked the right linfo to pass in each case.
