### PR TITLE
Fix a row-indexing bug with sparse matrices that have non-Int indices

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -426,8 +426,8 @@ function Base.getindex{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, i::Integer, J::Abstract
     @inbounds for j = 1:nJ
         col = J[j]
         rowI = i
-        ptrA = colptrA[col]
-        stopA = colptrA[col+1]-1
+        ptrA = Int(colptrA[col])
+        stopA = Int(colptrA[col+1]-1)
         if ptrA <= stopA
             if rowvalA[ptrA] <= rowI
                 ptrA = searchsortedfirst(rowvalA, rowI, ptrA, stopA, Base.Order.Forward)

--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -9,11 +9,7 @@ all: micro kernel cat shootout blas lapack simd sort spell sparse
 
 micro kernel cat shootout blas lapack simd sort spell sparse:
 	@$(MAKE) $(QUIET_MAKE) -C $(SRCDIR)/shootout
-ifneq ($(OS),WINNT)
-	@$(call spawn,$(JULIA_EXECUTABLE)) $(SRCDIR)/$@/perf.jl | perl -nle '@_=split/,/; printf "%-18s %8.3f %8.3f %8.3f %8.3f\n", $$_[1], $$_[2], $$_[3], $$_[4], $$_[5]'
-else
-	@$(call spawn,$(JULIA_EXECUTABLE)) $(SRCDIR)/$@/perf.jl 2> /dev/null
-endif
+	@$(call spawn,$(JULIA_EXECUTABLE)) $(call cygpath_w,$(SRCDIR)/$@/perf.jl) | perl -nle '@_=split/,/; printf "%-18s %8.3f %8.3f %8.3f %8.3f\n", $$_[1], $$_[2], $$_[3], $$_[4], $$_[5]'
 
 codespeed:
 	@$(MAKE) $(QUIET_MAKE) -C $(SRCDIR)/shootout

--- a/test/perf/shootout/fasta.jl
+++ b/test/perf/shootout/fasta.jl
@@ -22,7 +22,7 @@ const IA  =   3877.0
 const IC  =  29573.0
 
 function gen_random()
-    global rng_state::Float64 = ((rng_state::Float64 * IA + IC) % IM) / IM
+    global rng_state = ((rng_state::Float64 * IA + IC) % IM) / IM
 end
 function repeat_fasta(src, n)
     k = length(src)

--- a/test/perf/shootout/fasta.jl
+++ b/test/perf/shootout/fasta.jl
@@ -55,7 +55,7 @@ end
 
 rng_state = 42.0
 function fasta(n=25000000)
-  repeat_fasta(alu, 2n)
-  random_fasta(iub1, iub2, 3n)
-  random_fasta(homosapiens1, homosapiens2, 5n)
+    repeat_fasta(alu, 2n)
+    random_fasta(iub1, iub2, 3n)
+    random_fasta(homosapiens1, homosapiens2, 5n)
 end

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1588,3 +1588,8 @@ end
 
 # Test temporary fix for issue #16548 in PR #16979. Brittle. Expect to remove with `\` revisions.
 @test which(\, (SparseMatrixCSC, AbstractVecOrMat)).module == Base.SparseArrays
+
+# Row indexing a SparseMatrixCSC with non-Int integer type
+let A = sparse(UInt32[1,2,3], UInt32[1,2,3], [1.0,2.0,3.0])
+    @test A[1,1:3] == A[1,:] == [1,0,0]
+end


### PR DESCRIPTION
Introduced by #13612, has caused `make -C test/perf` to fail for the last 9 months

searchsortedfirst does not have methods for general Integer indices

Also a few other little deprecation and portability fixes in `test/perf`
