### PR TITLE
Remove Random.RNG from exports

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -15,7 +15,7 @@ export srand,
        randsubseq,randsubseq!,
        shuffle,shuffle!,
        randperm, randcycle,
-       AbstractRNG, RNG, MersenneTwister, RandomDevice,
+       AbstractRNG, MersenneTwister, RandomDevice,
        GLOBAL_RNG, randjump
 
 


### PR DESCRIPTION
to fix the "RNG not defined" issue https://github.com/JuliaLang/julia/issues/17983,
here are commits of the PR "WIP: RNG cleanups" https://github.com/JuliaLang/julia/pull/2070

Random.RNG has been exported with the commit (in base/random.jl)
"Move around a few names, since types and modules cannot have the same…" https://github.com/JuliaLang/julia/pull/2070/commits/786335720afa9b1fd8f533bc039f446a63969c13

and the variable has removed by (in base/random.jl)
"Decided not to have a default RNG type"  https://github.com/JuliaLang/julia/pull/2070/commits/6dc0fbfdff4ae3555aa9018a2093b5b297892615

"Removed RNG from exports" but only in base/exports.jl https://github.com/JuliaLang/julia/pull/2070/commits/21f34a91f54bbdc6ec01b1e8be78821e23979ec6

[edit by tkelman: closes #17983]
