### PR TITLE
specialize on type in getindex for types

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -126,7 +126,7 @@ similar{N}(a::Array, T::Type, dims::Dims{N}) = Array{T,N}(dims)
 similar{T,N}(a::Array{T}, dims::Dims{N})     = Array{T,N}(dims)
 
 # T[x...] constructs Array{T,1}
-function getindex(T::Type, vals...)
+function getindex{T}(::Type{T}, vals...)
     a = Array{T,1}(length(vals))
     @inbounds for i = 1:length(vals)
         a[i] = vals[i]
@@ -134,10 +134,10 @@ function getindex(T::Type, vals...)
     return a
 end
 
-getindex(T::Type) = Array{T,1}(0)
-getindex(T::Type, x) = (a = Array{T,1}(1); @inbounds a[1] = x; a)
-getindex(T::Type, x, y) = (a = Array{T,1}(2); @inbounds (a[1] = x; a[2] = y); a)
-getindex(T::Type, x, y, z) = (a = Array{T,1}(3); @inbounds (a[1] = x; a[2] = y; a[3] = z); a)
+getindex{T}(::Type{T}) = (@_inline_meta; Array{T,1}(0))
+getindex{T}(::Type{T}, x) = (@_inline_meta; a = Array{T,1}(1); @inbounds a[1] = x; a)
+getindex{T}(::Type{T}, x, y) = (@_inline_meta; a = Array{T,1}(2); @inbounds (a[1] = x; a[2] = y); a)
+getindex{T}(::Type{T}, x, y, z) = (@_inline_meta; a = Array{T,1}(3); @inbounds (a[1] = x; a[2] = y; a[3] = z); a)
 
 function getindex(::Type{Any}, vals::ANY...)
     a = Array{Any,1}(length(vals))


### PR DESCRIPTION
Fixes #18021. From 3.65 -> 0.25 seconds in the benchmark code in the linked issue.

Ref #17798 for similar correction

Fix found by eavesdropping on a discussion by @vtjnash and @yuyichao :)
