### PR TITLE
Lock libmap and use atomic load/store on library handle/symbol GVs

### DIFF
--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -133,7 +133,7 @@ extern "C" void jl_init_runtime_ccall(void)
 
 // map from user-specified lib names to handles
 static std::map<std::string, void*> libMap;
-
+static jl_mutex_t libmap_lock;
 extern "C"
 void *jl_get_library(const char *f_lib)
 {
@@ -146,21 +146,27 @@ void *jl_get_library(const char *f_lib)
 #endif
     if (f_lib == NULL)
         return jl_RTLD_DEFAULT_handle;
-    hnd = libMap[f_lib];
+    JL_LOCK_NOGC(&libmap_lock);
+    // This is the only operation we do on the map, which doesn't invalidate
+    // any references or iterators.
+    void **map_slot = &libMap[f_lib];
+    JL_UNLOCK_NOGC(&libmap_lock);
+    hnd = jl_atomic_load_acquire(map_slot);
     if (hnd != NULL)
         return hnd;
+    // We might run this concurrently on two threads but it doesn't matter.
     hnd = jl_load_dynamic_library(f_lib, JL_RTLD_DEFAULT);
     if (hnd != NULL)
-        libMap[f_lib] = hnd;
+        jl_atomic_store_release(map_slot, hnd);
     return hnd;
 }
 
 extern "C" JL_DLLEXPORT
 void *jl_load_and_lookup(const char *f_lib, const char *f_name, void **hnd)
 {
-    void *handle = *hnd;
+    void *handle = jl_atomic_load_acquire(hnd);
     if (!handle)
-        *hnd = handle = jl_get_library(f_lib);
+        jl_atomic_store_release(hnd, (handle = jl_get_library(f_lib)));
     return jl_dlsym(handle, f_name);
 }
 

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -385,3 +385,15 @@ if ccall(:jl_threading_enabled, Cint, ()) == 0
 else
     @test_throws ErrorException cglobal(:jl_tls_states)
 end
+
+# Thread safety of `jl_load_and_lookup`.
+function test_load_and_lookup_18020(n)
+    @threads for i in 1:n
+        try
+            ccall(:jl_load_and_lookup,
+                  Ptr{Void}, (Cstring, Cstring, Ref{Ptr{Void}}),
+                  "$i", :f, C_NULL)
+        end
+    end
+end
+test_load_and_lookup_18020(10000)


### PR DESCRIPTION
As [Herb Sutter pointed out](https://channel9.msdn.com/posts/C-and-Beyond-2012-Herb-Sutter-You-dont-know-blank-and-blank), const member functions in the stdlib are thread safe so we could use a rw lock and only do lookup while holding the read lock. I highly doubt we need that kind of concurrency though....

@vtjnash do you have a test case? (Calling `jl_load_and_lookup` explicitly on a large number of (non-existing) libraries?)

Fix #18020
