### PR TITLE
Add method to contains for regex needle

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3889,29 +3889,6 @@ Element-wise greater-than comparison operator.
 Base.:(.>)
 
 """
-    search(string, chars, [start])
-
-Search for the first occurrence of the given characters within the given string. The second
-argument may be a single character, a vector or a set of characters, a string, or a regular
-expression (though regular expressions are only allowed on contiguous strings, such as ASCII
-or UTF-8 strings). The third argument optionally specifies a starting index. The return
-value is a range of indexes where the matching sequence is found, such that `s[search(s,x)] == x`:
-
-`search(string, "substring")` = `start:end` such that `string[start:end] == "substring"`, or
-`0:-1` if unmatched.
-
-`search(string, 'c')` = `index` such that `string[index] == 'c'`, or `0` if unmatched.
-"""
-search
-
-"""
-    contains(haystack, needle)
-
-Determine whether the second argument is a substring of the first.
-"""
-contains
-
-"""
     flush(stream)
 
 Commit all currently buffered writes to the given stream.
@@ -4791,14 +4768,6 @@ Instances can be constructed from strings via [`parse`](:func:`parse`), or using
 string literal.
 """
 BigInt
-
-"""
-    rsearch(string, chars, [start])
-
-Similar to `search`, but returning the last occurrence of the given characters within the
-given string, searching in reverse from `start`.
-"""
-rsearch
 
 """
     isdirpath(path::AbstractString) -> Bool
@@ -5719,13 +5688,6 @@ ismatch
 Compute ``e^x``.
 """
 exp
-
-"""
-    searchindex(string, substring, [start])
-
-Similar to `search`, but return only the start index at which the substring is found, or `0` if it is not.
-"""
-searchindex
 
 """
     listenany(port_hint) -> (UInt16,TCPServer)
@@ -7078,13 +7040,6 @@ time_ns
 Get the exponent of a normalized floating-point number.
 """
 exponent
-
-"""
-    rsearchindex(string, substring, [start])
-
-Similar to `rsearch`, but return only the start index at which the substring is found, or `0` if it is not.
-"""
-rsearchindex
 
 """
     muladd(x, y, z)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -226,6 +226,11 @@ search(s::AbstractString, r::Regex, idx::Integer) = throw(ArgumentError(
 ))
 search(s::AbstractString, r::Regex) = search(s,r,start(s))
 
+function contains(haystack::Union{SubString{String}, String}, re::Regex)
+    compile(re)
+    PCRE.exec(re.regex, haystack, start(haystack)-1, re.match_options, re.match_data)
+end
+
 immutable SubstitutionString{T<:AbstractString} <: AbstractString
     string::T
 end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -1,5 +1,19 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+"""
+    search(string, chars, [start])
+
+Search for the first occurrence of the given characters within the given string. The second
+argument may be a single character, a vector or a set of characters, a string, or a regular
+expression (though regular expressions are only allowed on contiguous strings, such as ASCII
+or UTF-8 strings). The third argument optionally specifies a starting index. The return
+value is a range of indexes where the matching sequence is found, such that `s[search(s,x)] == x`:
+
+`search(string, "substring")` = `start:end` such that `string[start:end] == "substring"`, or
+`0:-1` if unmatched.
+
+`search(string, 'c')` = `index` such that `string[index] == 'c'`, or `0` if unmatched.
+"""
 function search(s::AbstractString, c::Chars, i::Integer)
     if isempty(c)
         return 1 <= i <= nextind(s,endof(s)) ? i :
@@ -123,6 +137,11 @@ searchindex(s::AbstractString, t::AbstractString) = searchindex(s,t,start(s))
 searchindex(s::AbstractString, c::Char, i::Integer) = _searchindex(s,c,i)
 searchindex(s::AbstractString, c::Char) = searchindex(s,c,start(s))
 
+"""
+    searchindex(string, substring, [start])
+
+Similar to `search`, but return only the start index at which the substring is found, or `0` if it is not.
+"""
 function searchindex(s::String, t::String, i::Integer=1)
     # Check for fast case of a single byte
     # (for multi-byte UTF-8 sequences, use searchindex on byte arrays instead)
@@ -150,7 +169,12 @@ function search(s::AbstractString, t::AbstractString, i::Integer=start(s))
         idx:(idx > 0 ? idx + endof(t) - 1 : -1)
     end
 end
+"""
+    rsearch(string, chars, [start])
 
+Similar to `search`, but returning the last occurrence of the given characters within the
+given string, searching in reverse from `start`.
+"""
 function rsearch(s::AbstractString, c::Chars)
     j = search(RevString(s), c)
     j == 0 && return 0
@@ -263,6 +287,11 @@ rsearchindex(s::ByteArray,t::ByteArray,i) = _rsearchindex(s,t,i)
 rsearchindex(s::AbstractString, t::AbstractString, i::Integer) = _rsearchindex(s,t,i)
 rsearchindex(s::AbstractString, t::AbstractString) = (isempty(s) && isempty(t)) ? 1 : rsearchindex(s,t,endof(s))
 
+"""
+    rsearchindex(string, substring, [start])
+
+Similar to `rsearch`, but return only the start index at which the substring is found, or `0` if it is not.
+"""
 function rsearchindex(s::String, t::String)
     # Check for fast case of a single byte
     # (for multi-byte UTF-8 sequences, use rsearchindex instead)
@@ -307,6 +336,11 @@ function rsearch(s::AbstractString, t::AbstractString, i::Integer=endof(s))
     end
 end
 
+"""
+    contains(haystack, needle) -> Bool
+
+Determine whether the second argument is a substring of the first.
+"""
 contains(haystack::AbstractString, needle::AbstractString) = searchindex(haystack,needle)!=0
 
 in(::AbstractString, ::AbstractString) = error("use contains(x,y) for string containment")

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -339,9 +339,11 @@ end
 """
     contains(haystack, needle) -> Bool
 
-Determine whether the second argument is a substring of the first.
+Determine whether the second argument is a substring of the first. The second
+argument may be a single character, a string, or a regular
+expression (though regular expressions are only allowed on contiguous strings, such as `String` or `SubString`)
 """
-contains(haystack::AbstractString, needle::AbstractString) = searchindex(haystack,needle)!=0
+contains(haystack::AbstractString, needle::Union{AbstractString, Char}) = searchindex(haystack, needle)!=0
 
 in(::AbstractString, ::AbstractString) = error("use contains(x,y) for string containment")
 

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -5,8 +5,8 @@
 
 Search for the first occurrence of the given characters within the given string. The second
 argument may be a single character, a vector or a set of characters, a string, or a regular
-expression (though regular expressions are only allowed on contiguous strings, such as ASCII
-or UTF-8 strings). The third argument optionally specifies a starting index. The return
+expression (though regular expressions are only allowed on contiguous strings, such as `String`
+or `SubString`). The third argument optionally specifies a starting index. The return
 value is a range of indexes where the matching sequence is found, such that `s[search(s,x)] == x`:
 
 `search(string, "substring")` = `start:end` such that `string[start:end] == "substring"`, or

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -47,3 +47,46 @@ end
 # Backcapture reference in substitution string
 @test replace("abcde", r"(..)(?P<byname>d)", s"\g<byname>xy\\\1") == "adxy\\bce"
 @test_throws ErrorException replace("a", r"(?P<x>)", s"\g<y>")
+
+# some test strings, the strings and the tests is equal to the test in test/strings/search.jl
+astr = "Hello, world.\n"
+u8str = "∀ ε > 0, ∃ δ > 0: |x-y| < δ ⇒ |f(x)-f(y)| < ε"
+
+# string search with a single-char regex
+@test search(astr, r"x") == 0:-1
+@test search(astr, r"H") == 1:1
+@test search(astr, r"H", 2) == 0:-1
+@test search(astr, r"l") == 3:3
+@test search(astr, r"l", 4) == 4:4
+@test search(astr, r"l", 5) == 11:11
+@test search(astr, r"l", 12) == 0:-1
+@test search(astr, r"\n") == 14:14
+@test search(astr, r"\n", 15) == 0:-1
+@test search(u8str, r"z") == 0:-1
+@test search(u8str, r"∄") == 0:-1
+@test search(u8str, r"∀") == 1:1
+@test search(u8str, r"∀", 4) == 0:-1
+@test search(u8str, r"∀") == search(u8str, r"\u2200")
+@test search(u8str, r"∀", 4) == search(u8str, r"\u2200", 4)
+@test search(u8str, r"∃") == 13:13
+@test search(u8str, r"∃", 16) == 0:-1
+@test search(u8str, r"x") == 26:26
+@test search(u8str, r"x", 27) == 43:43
+@test search(u8str, r"x", 44) == 0:-1
+@test search(u8str, r"ε") == 5:5
+@test search(u8str, r"ε", 7) == 54:54
+@test search(u8str, r"ε", 56) == 0:-1
+
+# string search with a two-char regex
+@test search("foo,bar,baz", r"xx") == 0:-1
+@test search("foo,bar,baz", r"fo") == 1:2
+@test search("foo,bar,baz", r"fo", 3) == 0:-1
+@test search("foo,bar,baz", r"oo") == 2:3
+@test search("foo,bar,baz", r"oo", 4) == 0:-1
+@test search("foo,bar,baz", r"o,") == 3:4
+@test search("foo,bar,baz", r"o,", 5) == 0:-1
+@test search("foo,bar,baz", r",b") == 4:5
+@test search("foo,bar,baz", r",b", 6) == 8:9
+@test search("foo,bar,baz", r",b", 10) == 0:-1
+@test search("foo,bar,baz", r"az") == 10:11
+@test search("foo,bar,baz", r"az", 12) == 0:-1

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -90,3 +90,13 @@ u8str = "∀ ε > 0, ∃ δ > 0: |x-y| < δ ⇒ |f(x)-f(y)| < ε"
 @test search("foo,bar,baz", r",b", 10) == 0:-1
 @test search("foo,bar,baz", r"az") == 10:11
 @test search("foo,bar,baz", r"az", 12) == 0:-1
+
+@test contains(astr, r"w")
+@test contains(astr, r",\sw")
+@test !contains(astr, r"x")
+
+@test contains(u8str, r"x")
+@test contains(u8str, r"∃ δ >")
+@test !contains(u8str, r"9")
+@test !contains(u8str, r"> 0:9")
+@test contains(u8str, r">\s\d:")

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -335,3 +335,16 @@ end
 # string searchindex with a two-char UTF-8 (4 byte) string literal
 @test rsearchindex("\U1f596\U1f596", "\U1f596\U1f596") == 1
 @test rsearchindex("\U1f596\U1f596", "\U1f596\U1f596", endof("\U1f596\U1f596\U1f596")) == 1
+
+@test contains(astr, "w")
+@test contains(astr, 'w')
+@test contains(astr, ", w")
+@test !contains(astr, "x")
+@test !contains(astr, 'x')
+
+@test contains(u8str, "x")
+@test contains(u8str, 'x')
+@test contains(u8str, "∃ δ >")
+@test !contains(u8str, "9")
+@test !contains(u8str, '9')
+@test !contains(u8str, "> 0:9")

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -182,30 +182,6 @@ end
 @test rsearch(u8str, "ε", 53) == 5:5
 @test rsearch(u8str, "ε", 4) == 0:-1
 
-# string search with a single-char regex
-@test search(astr, r"x") == 0:-1
-@test search(astr, r"H") == 1:1
-@test search(astr, r"H", 2) == 0:-1
-@test search(astr, r"l") == 3:3
-@test search(astr, r"l", 4) == 4:4
-@test search(astr, r"l", 5) == 11:11
-@test search(astr, r"l", 12) == 0:-1
-@test search(astr, r"\n") == 14:14
-@test search(astr, r"\n", 15) == 0:-1
-@test search(u8str, r"z") == 0:-1
-@test search(u8str, r"∄") == 0:-1
-@test search(u8str, r"∀") == 1:1
-@test search(u8str, r"∀", 4) == 0:-1
-@test search(u8str, r"∀") == search(u8str, r"\u2200")
-@test search(u8str, r"∀", 4) == search(u8str, r"\u2200", 4)
-@test search(u8str, r"∃") == 13:13
-@test search(u8str, r"∃", 16) == 0:-1
-@test search(u8str, r"x") == 26:26
-@test search(u8str, r"x", 27) == 43:43
-@test search(u8str, r"x", 44) == 0:-1
-@test search(u8str, r"ε") == 5:5
-@test search(u8str, r"ε", 7) == 54:54
-@test search(u8str, r"ε", 56) == 0:-1
 for i = 1:endof(astr)
     @test search(astr, r"."s, i) == i:i
 end
@@ -316,20 +292,6 @@ end
 # array rsearch
 @test rsearch(UInt8[1,2,3],UInt8[2,3],3) == 2:3
 @test rsearch(UInt8[1,2,3],UInt8[2,3],1) == 0:-1
-
-# string search with a two-char regex
-@test search("foo,bar,baz", r"xx") == 0:-1
-@test search("foo,bar,baz", r"fo") == 1:2
-@test search("foo,bar,baz", r"fo", 3) == 0:-1
-@test search("foo,bar,baz", r"oo") == 2:3
-@test search("foo,bar,baz", r"oo", 4) == 0:-1
-@test search("foo,bar,baz", r"o,") == 3:4
-@test search("foo,bar,baz", r"o,", 5) == 0:-1
-@test search("foo,bar,baz", r",b") == 4:5
-@test search("foo,bar,baz", r",b", 6) == 8:9
-@test search("foo,bar,baz", r",b", 10) == 0:-1
-@test search("foo,bar,baz", r"az") == 10:11
-@test search("foo,bar,baz", r"az", 12) == 0:-1
 
 @test searchindex("foo", 'o') == 2
 @test searchindex("foo", 'o', 3) == 3


### PR DESCRIPTION
This PR defines `contains` with a regex search pattern. Besides the new method I have also widen the signature of the original method to include `Char` as: `contains(haystack::AbstractString, needle::Union{AbstractString, Char})`. Besides the additions to `contains`, I have:
-  Moved the docs for the functions in `search` inline
-  Moved the test for `search(::String, ::Regex)` from  `test/strings/search` to `test/regex.jl` as the method is defined in `regex.jl`.
-  Added methods to `contains` and test for the methods plus additional tests for `contains` in general as it seemed not to be tested directly anywhere.
-  Fixed an reference to ASCII and UTF8 string.

It would be good to backport this to 0.5.1 as it increases test coverage and fixes docs. The additional methods for `contains` are probably not to be viewed as a "new" feature?
