### PR TITLE
`print(::Float32)` should use `e` instead of Julia specific `f`

### DIFF
--- a/base/grisu/grisu.jl
+++ b/base/grisu/grisu.jl
@@ -86,7 +86,7 @@ function _show(io::IO, x::AbstractFloat, mode, n::Int, typed, nanstr, infstr)
         else
             write(io, '0')
         end
-        write(io, isa(x,Float32) ? 'f' : 'e')
+        write(io, (typed && isa(x,Float32)) ? 'f' : 'e')
         write(io, dec(pt-1))
         typed && isa(x,Float16) && write(io, ")")
         return
@@ -118,7 +118,7 @@ end
 
 function Base.show(io::IO, x::Union{Float64,Float32})
     if get(io, :compact, false)
-        _show(io, x, PRECISION, 6, false)
+        _show(io, x, PRECISION, 6, true)
     else
         _show(io, x, SHORTEST, 0, true)
     end

--- a/test/show.jl
+++ b/test/show.jl
@@ -577,3 +577,6 @@ end
 @test repr(NTuple{7,Int64}) == "NTuple{7,Int64}"
 @test repr(Tuple{Float64, Float64, Float64, Float64}) == "NTuple{4,Float64}"
 @test repr(Tuple{Float32, Float32, Float32}) == "Tuple{Float32,Float32,Float32}"
+
+# Float32 printing
+@test sprint((io, x)->print(io, x), 1f-7) == "1.0e-7"


### PR DESCRIPTION
Note:

Currently, `showcompact(::Float32)` prints typed representation for `Float32` (e.g. `1.0f10`).
Although this behaviour is inconsistent with [the documentation of `showcompact`](http://docs.julialang.org/en/latest/stdlib/io-network/?highlight=showcompact),
I kept the behaviour as is, following the discussions of https://github.com/JuliaLang/julia/issues/17720.
