### PR TITLE
Clear the IRBuilder's insertion point after emitting a function

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4718,6 +4718,8 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
         }
     }
 
+    builder.ClearInsertionPoint();
+
     // step 13, Apply LLVM level inlining
     for(std::vector<CallInst*>::iterator it = ctx.to_inline.begin(); it != ctx.to_inline.end(); ++it) {
         Function *inlinef = (*it)->getCalledFunction();

--- a/test/core.jl
+++ b/test/core.jl
@@ -4469,3 +4469,10 @@ let
     k(x) = (k = x; k)
     @test k(1) == 1
 end
+
+# PR #18054: compilation of cfunction leaves IRBuilder in bad state,
+#            causing heap-use-after-free when compiling f18054
+function f18054()
+    return Cint(0)
+end
+cfunction(f18054, Cint, ())


### PR DESCRIPTION
The function might get finalized, invalidating the IP. However, in some cases this invalid IP may get saved and restored, accessing the invalid IP while doing so.

Example code path accessing an invalid IP:
- `jl_cfunction_object`: nested_compile=true, but doesn't change IP
- `gen_cfun_wrapper`
- `jl_compile_linfo`: saves and restores invalid IP

Example code:

``` julia
function foobar()
    return Cint(0)
end

cfunction(foobar, Cint, ())

# compilation of cfunction makes builder.BB point to an invalid BB
# compilation of foobar restores that invalid BB (as per code path explained above)
```
