### PR TITLE
Add a global indicating if ASAN or MSAN are enabled

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -66,6 +66,11 @@ endif
 	@echo "const DOCDIR = \"$(docdir_rel)\"" >> $@
 	@echo "const LIBDIR = \"$(libdir_rel)\"" >> $@
 	@echo "const INCLUDEDIR = \"$(includedir_rel)\"" >> $@
+ifeq ($(SANITIZE),1)
+	@echo "const SANITIZE = true" >> $@
+else
+	@echo "const SANITIZE = false" >> $@
+endif
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -221,7 +221,7 @@ module Tmp14173
     A = randn(2000, 2000)
 end
 whos(IOBuffer(), Tmp14173) # warm up
-@test @allocated(whos(IOBuffer(), Tmp14173)) < 10000
+@test @allocated(whos(IOBuffer(), Tmp14173)) < (Base.SANITIZE ? 25000 : 10000)
 
 ## test conversion from UTF-8 to UTF-16 (for Windows APIs)
 


### PR DESCRIPTION
Use it to alter a test which allocates much more memory if sanitized.
