### PR TITLE
do not catch everything in isassigned

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -177,12 +177,15 @@ function _strides{M,T,N}(out::NTuple{M}, A::AbstractArray{T,N})
 end
 
 function isassigned(a::AbstractArray, i::Int...)
-    # TODO
     try
         a[i...]
         true
-    catch
-        false
+    catch e
+        if isa(e, BoundsError) || isa(e, UndefRefError)
+            return false
+        else
+            rethrow(e)
+        end
     end
 end
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -408,6 +408,13 @@ function test_primitives{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     @test convert(Array, X) == X
 end
 
+let
+    type TestThrowNoGetindex{T} <: AbstractVector{T} end
+    Base.length(::TestThrowNoGetindex) = 2
+    Base.size(::TestThrowNoGetindex) = (2,)
+    @test_throws ErrorException isassigned(TestThrowNoGetindex{Float64}(), 1)
+end
+
 function test_in_bounds(::Type{TestAbstractArray})
     n = rand(2:5)
     sz = rand(2:5, n)


### PR DESCRIPTION
If `getindex` on an `AbstractArray` errors with `ThrowMeOrEveryoneWillPerishOhMyGodTheyAreComingException` we should probably throw it instead of just returning `false` in `isassigned`.
