### PR TITLE
Increase the allocation threshold for #14173 test

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -221,7 +221,7 @@ module Tmp14173
     A = randn(2000, 2000)
 end
 whos(IOBuffer(), Tmp14173) # warm up
-@test @allocated(whos(IOBuffer(), Tmp14173)) < 10000
+@test @allocated(whos(IOBuffer(), Tmp14173)) < 50000
 
 ## test conversion from UTF-8 to UTF-16 (for Windows APIs)
 


### PR DESCRIPTION
The test failed again in MEMDEBUG mode, allocating 19776 bytes (while only 6096 with MEMDEBUG off). Before #14173, the test allocated 1597240656 bytes, so it is safe to bump this value to 50k.

Ref: #14173 and fix #14177, #18055.
