### PR TITLE
Add 'isassigned' for RefValue

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -41,6 +41,7 @@ type RefValue{T} <: Ref{T}
     RefValue(x) = new(x)
 end
 RefValue{T}(x::T) = RefValue{T}(x)
+isassigned(x::RefValue) = isdefined(x, :x)
 
 Ref(x::Ref) = x
 Ref(x::Any) = RefValue(x)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -611,3 +611,11 @@ end
     @test Foo_19281().f[1] == ()
     @test Foo_19281().f[2] == (1, )
 end
+
+let
+    x_notdefined = Ref{String}()
+    @test !isassigned(x_notdefined)
+
+    x_defined = Ref{String}("Test")
+    @test isassigned(x_defined)
+end


### PR DESCRIPTION
Useful to avoid the need for users to break encapsulation by directly referencing the fields of `RefValue`
