### PR TITLE
In cgmemmgr, allow writing permissions on the read page for the debugger

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -435,3 +435,18 @@ let creds = Base.LibGit2.CachedCredentials()
     securezero!(creds)
     @test LibGit2.get_creds!(creds, "foo", nothing).pass == "\0\0\0"
 end
+
+# Test that we can VirtualProtect jitted code to writable
+if is_windows()
+    @noinline function WeVirtualProtectThisToRWX(x, y)
+        x+y
+    end
+
+    let addr = cfunction(WeVirtualProtectThisToRWX, UInt64, (UInt64, UInt64))
+        addr = addr-(UInt64(addr)%4096)
+        const PAGE_EXECUTE_READWRITE = 0x40
+        oldPerm = Ref{UInt32}()
+        err = ccall(:VirtualProtect,stdcall,Cint,(Ptr{Void}, Csize_t, UInt32, Ptr{UInt32}), addr, 4096, PAGE_EXECUTE_READWRITE, oldPerm)
+        err == 0 && error(Libc.GetLastError())
+    end
+end


### PR DESCRIPTION
The permissions specified in MapViewOfFile specify the maximum permissions
the file can ever have, which means that even permissions bypass by the
debugger is not allowed to write it. Instead, set the maximum permissions
to RWX and VirtualProtect down to the permissions we need. This is the same
behavior as we use on Mac/Linux.

Fixes https://github.com/Keno/Gallium.jl/issues/126
