### PR TITLE
split static-eval to its individual users

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -264,6 +264,7 @@ JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
     return jv;
 }
 
+
 extern jl_value_t *jl_builtin_getfield;
 jl_value_t *jl_resolve_globals(jl_value_t *expr, jl_lambda_info_t *lam)
 {
@@ -280,20 +281,37 @@ jl_value_t *jl_resolve_globals(jl_value_t *expr, jl_lambda_info_t *lam)
             e->head == boundscheck_sym || e->head == simdloop_sym) {
         }
         else {
-            if (e->head == call_sym && jl_expr_nargs(e) == 3 && jl_is_quotenode(jl_exprarg(e,2)) &&
+            if (e->head == call_sym && jl_expr_nargs(e) == 3 && jl_is_quotenode(jl_exprarg(e, 2)) &&
                 lam->def->module != NULL) {
                 // replace getfield(module_expr, :sym) with GlobalRef
-                jl_value_t *s = jl_fieldref(jl_exprarg(e,2),0);
-                jl_value_t *fe = jl_exprarg(e,0);
+                jl_value_t *s = jl_fieldref(jl_exprarg(e, 2), 0);
+                jl_value_t *fe = jl_exprarg(e, 0);
                 if (jl_is_symbol(s) && jl_is_globalref(fe)) {
-                    jl_value_t *f = jl_static_eval(fe, NULL, lam->def->module, lam, 0, 0);
+                    jl_binding_t *b = jl_get_binding(jl_globalref_mod(fe), jl_globalref_name(fe));
+                    jl_value_t *f = NULL;
+                    if (b && b->constp) {
+                        f = b->value;
+                    }
                     if (f == jl_builtin_getfield) {
-                        jl_value_t *me = jl_exprarg(e,1);
-                        if (jl_is_globalref(me) ||
-                            (jl_is_symbol(me) && jl_binding_resolved_p(lam->def->module, (jl_sym_t*)me))) {
-                            jl_value_t *m = jl_static_eval(me, NULL, lam->def->module, lam, 0, 0);
-                            if (m && jl_is_module(m))
-                                return jl_module_globalref((jl_module_t*)m, (jl_sym_t*)s);
+                        jl_value_t *me = jl_exprarg(e, 1);
+                        jl_module_t *me_mod = NULL;
+                        jl_sym_t *me_sym = NULL;
+                        if (jl_is_globalref(me)) {
+                            me_mod = jl_globalref_mod(me);
+                            me_sym = jl_globalref_name(me);
+                        }
+                        else if (jl_is_symbol(me) && jl_binding_resolved_p(lam->def->module, (jl_sym_t*)me)) {
+                            me_mod = lam->def->module;
+                            me_sym = (jl_sym_t*)me;
+                        }
+                        if (me_mod && me_sym) {
+                            jl_binding_t *b = jl_get_binding(me_mod, me_sym);
+                            if (b && b->constp) {
+                                jl_value_t *m = b->value;
+                                if (m && jl_is_module(m)) {
+                                    return jl_module_globalref((jl_module_t*)m, (jl_sym_t*)s);
+                                }
+                            }
                         }
                     }
                 }
@@ -303,7 +321,7 @@ jl_value_t *jl_resolve_globals(jl_value_t *expr, jl_lambda_info_t *lam)
                 e->head == bitstype_sym || e->head == module_sym)
                 i++;
             for(; i < jl_array_len(e->args); i++) {
-                jl_exprargset(e, i, jl_resolve_globals(jl_exprarg(e,i), lam));
+                jl_exprargset(e, i, jl_resolve_globals(jl_exprarg(e, i), lam));
             }
         }
     }

--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -36,12 +36,6 @@ int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int no
     return 0;
 }
 
-jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
-                           jl_lambda_info_t *li, int sparams, int allow_alloc)
-{
-    return NULL;
-}
-
 void jl_register_fptrs(uint64_t sysimage_base, void **fptrs, jl_lambda_info_t **linfos, size_t n)
 {
     (void)sysimage_base; (void)fptrs; (void)linfos; (void)n;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -305,8 +305,6 @@ jl_value_t *jl_parse_eval_all(const char *fname,
                               const char *content, size_t contentlen);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
 jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e);
-jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
-                           jl_lambda_info_t *li, int sparams, int allow_alloc);
 int jl_is_toplevel_only_expr(jl_value_t *e);
 jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr);
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -263,6 +263,67 @@ JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m)
     return jl_top_module;
 }
 
+// try to statically evaluate, NULL if not possible
+// remove this once jl_has_intrinsics is deleted
+extern jl_value_t *jl_builtin_getfield;
+static jl_value_t *jl_static_eval(jl_value_t *ex, jl_module_t *mod,
+                                  jl_lambda_info_t *linfo, int sparams)
+{
+    if (jl_is_symbol(ex)) {
+        jl_sym_t *sym = (jl_sym_t*)ex;
+        if (jl_is_const(mod, sym))
+            return jl_get_global(mod, sym);
+        return NULL;
+    }
+    if (jl_is_slot(ex))
+        return NULL;
+    if (jl_is_ssavalue(ex))
+        return NULL;
+    if (jl_is_quotenode(ex))
+        return jl_fieldref(ex, 0);
+    if (jl_is_lambda_info(ex))
+        return NULL;
+    jl_module_t *m = NULL;
+    jl_sym_t *s = NULL;
+    if (jl_is_globalref(ex)) {
+        jl_binding_t *b = jl_get_binding(jl_globalref_mod(ex), jl_globalref_name(ex));
+        if (b && b->constp) {
+            return b->value;
+        }
+        return NULL;
+    }
+    if (jl_is_expr(ex)) {
+        jl_expr_t *e = (jl_expr_t*)ex;
+        if (e->head == call_sym) {
+            jl_value_t *f = jl_static_eval(jl_exprarg(e, 0), mod, linfo, sparams);
+            if (f) {
+                if (jl_array_dim0(e->args) == 3 && f==jl_builtin_getfield) {
+                    m = (jl_module_t*)jl_static_eval(jl_exprarg(e, 1), mod, linfo, sparams);
+                    s = (jl_sym_t*)jl_static_eval(jl_exprarg(e, 2), mod, linfo, sparams);
+                    if (m && jl_is_module(m) && s && jl_is_symbol(s)) {
+                        jl_binding_t *b = jl_get_binding(m, s);
+                        if (b && b->constp) {
+                            return b->value;
+                        }
+                    }
+                }
+            }
+        }
+        else if (e->head == static_parameter_sym) {
+            size_t idx = jl_unbox_long(jl_exprarg(e, 0));
+            if (linfo && idx <= jl_svec_len(linfo->sparam_vals)) {
+                jl_value_t *e = jl_svecref(linfo->sparam_vals, idx - 1);
+                if (jl_is_typevar(e))
+                    return NULL;
+                return e;
+            }
+        }
+        return NULL;
+    }
+    return ex;
+}
+
+
 int jl_has_intrinsics(jl_lambda_info_t *li, jl_value_t *v, jl_module_t *m)
 {
     if (!jl_is_expr(v)) return 0;
@@ -273,13 +334,13 @@ int jl_has_intrinsics(jl_lambda_info_t *li, jl_value_t *v, jl_module_t *m)
         return 0;
     jl_value_t *e0 = jl_exprarg(e, 0);
     if (e->head == call_sym) {
-        jl_value_t *sv = jl_static_eval(e0, NULL, m, li, li != NULL, 0);
+        jl_value_t *sv = jl_static_eval(e0, m, li, li != NULL);
         if (sv && jl_typeis(sv, jl_intrinsic_type))
             return 1;
     }
     if (0 && e->head == assign_sym && jl_is_ssavalue(e0)) { // code branch needed for *very-linear-mode*, but not desirable otherwise
         jl_value_t *e1 = jl_exprarg(e, 1);
-        jl_value_t *sv = jl_static_eval(e1, NULL, m, li, li != NULL, 0);
+        jl_value_t *sv = jl_static_eval(e1, m, li, li != NULL);
         if (sv && jl_typeis(sv, jl_intrinsic_type))
             return 1;
     }


### PR DESCRIPTION
most users of static-eval didn't need most of it's complexity
and didn't actually want its deprecation warning behavior

this also will make it easier to delete this function as the users
of it get fixed not to need it
