### PR TITLE
Add a builtin for checking the value of compile-time options

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1601,6 +1601,34 @@ JL_DLLEXPORT void jl_breakpoint(jl_value_t *v)
     // put a breakpoint in your debugger here
 }
 
+// check whether a compile-time option is defined, returning a boolean value
+JL_DLLEXPORT int8_t jl_get_option(jl_value_t *v)
+{
+    // fragile set of macros to detect whether an option is defined.
+    // only works for non-valued definitions, ie. expanding to nothing if defined
+    #define JL_DEFINED(option) JL_DEFINED_##option
+    #define JL_DEFINED_ 1
+
+    #define JL_HANDLE_OPTION(input, option) \
+    const int8_t JL_DEFINED_##option = 0;   \
+    if (strcmp(input, #option) == 0) {      \
+        return JL_DEFINED(option);          \
+    }
+
+    if (!jl_is_symbol(v))
+        jl_error("option should be a symbol");
+    char *key = jl_symbol_name((jl_sym_t*) v);
+
+    // dummy options for testing purposes
+    #define ALWAYS_DEFINED
+    JL_HANDLE_OPTION(key, ALWAYS_DEFINED);
+    JL_HANDLE_OPTION(key, NEVER_DEFINED);
+
+    JL_HANDLE_OPTION(key, MEMDEBUG);
+
+    jl_errorf("unknown option '%s'", key);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/core.jl
+++ b/test/core.jl
@@ -4476,3 +4476,10 @@ function f18054()
     return Cint(0)
 end
 cfunction(f18054, Cint, ())
+
+# jl_get_option
+@test_throws ErrorException ccall(:jl_get_option, Bool, (Any,), "invalid")
+@test ccall(:jl_get_option, Bool, (Any,), :ALWAYS_DEFINED) == true
+@test ccall(:jl_get_option, Bool, (Any,), :NEVER_DEFINED) == false
+@test_throws ErrorException ccall(:jl_get_option, Bool, (Any,), :UNHANDLED) == true
+

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -221,7 +221,8 @@ module Tmp14173
     A = randn(2000, 2000)
 end
 whos(IOBuffer(), Tmp14173) # warm up
-@test @allocated(whos(IOBuffer(), Tmp14173)) < 10000
+const MEMDEBUG = ccall(:jl_get_option, Bool, (Any,), :MEMDEBUG)
+@test @allocated(whos(IOBuffer(), Tmp14173)) < (MEMDEBUG ? 20000 : 8000)
 
 ## test conversion from UTF-8 to UTF-16 (for Windows APIs)
 


### PR DESCRIPTION
Yet another approach for fixing the #14173 test in combination with MEMDEBUG. It's a more generic approach than adding a single purpose builtin for discovering MEMDEBUG.

This doesn't add a global (@tkelman), doesn't change the non-MEMDEBUG allocation limit (@vtjnash, I even tightened a bit, undoing 78bc312de0dc0a3792db327d7edf897c8cc98d62), and doesn't change how `jl_gc_big_alloc` counts allocations (@yuyichao).

The preprocessor magic isn't particularly clean (and only works for certain compile-time options), but being whitelist-based it shouldn't matter and we can fix or special-case other options when the need arises. Curious whether it'll work on all compilers...
