### PR TITLE
fix #18085, segfault on method add in loop

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2882,7 +2882,7 @@ f(x) = yt(x)
                         (let* ((exprs     (lift-toplevel (convert-lambda lam2 '|#anon| #t '())))
                                (top-stmts (cdr exprs))
                                (newlam    (renumber-slots-and-labels (linearize (car exprs)))))
-                          `(block
+                          `(toplevel-butlast
                             ,@top-stmts
                             ,@sp-inits
                             (method ,name ,(cl-convert sig fname lam namemap toplevel interp)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4476,3 +4476,11 @@ function f18054()
     return Cint(0)
 end
 cfunction(f18054, Cint, ())
+
+# issue #18085
+f18085(a,x...) = (0,)
+for (f,g) in ((:asin,:sin), (:acos,:cos))
+    gx = eval(g)
+    f18085(::Type{Val{f}},x...) = map(x->2gx(x), f18085(Val{g},x...))
+end
+@test f18085(Val{:asin},3) === (0.0,)


### PR DESCRIPTION
Closures that are part of out-of-scope method adds were not lifted
out of top-level loops.
