### PR TITLE
make sure .= uses Base.identity, not a local identity

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1706,7 +1706,7 @@
             (expand-forms `(call (top broadcast!) ,(from-lambda (cadr e)) ,lhs-view ,@(caddr e))))
         (if (null? lhs)
             (expand-forms e)
-            (expand-forms `(call (top broadcast!) identity ,lhs-view ,e))))))
+            (expand-forms `(call (top broadcast!) (top identity) ,lhs-view ,e))))))
 
 ;; table mapping expression head to a function expanding that form
 (define expand-table

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -284,6 +284,10 @@ let d = Dict(:foo => [1,3,7], (3,4) => [5,9])
     d[3,4] .-= 1
     @test d[3,4] == [4,8]
 end
+let identity = error, x = [1,2,3]
+    x .= 1 # make sure it goes to broadcast!(Base.identity, ...), not identity
+    @test x == [1,1,1]
+end
 
 # PR 16988
 @test Base.promote_op(+, Bool) === Int


### PR DESCRIPTION
As pointed out by @shashi in dcjones/Gadfly.jl#864, the `.=` lowering was incorrectly lowering `x .= y` to `broadcast!(identity, x, y)`, when in fact it should have used `Base.identity`.  This let to a confusing error in Gadfly, which defines a local variable named `identity`.

@tkelman, can this be backported to 0.5.0?
