### PR TITLE
disable llvm optimizations in JIT when generating output

### DIFF
--- a/src/timing.h
+++ b/src/timing.h
@@ -46,7 +46,8 @@ static inline uint64_t rdtscp(void)
         X(AST_COMPRESS),          \
         X(AST_UNCOMPRESS),        \
         X(SYSIMG_LOAD),           \
-        X(SYSIMG_DUMP),
+        X(SYSIMG_DUMP),           \
+        X(NATIVE_DUMP),
 
 enum jl_timing_owners {
 #define X(name) JL_TIMING_ ## name


### PR DESCRIPTION
When saving native code we re-run optimization on the whole module as part of object file emission, so it is not needed for JIT compiled code. We are already passing -O0 for package precompilation; this
extends that benefit to the system image. Shaves 30+ seconds off sysimg build for me.

Also adds timing for native code emission.
