### PR TITLE
provide Base.crc32c checksum and use it in checking cache staleness

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,6 +29,7 @@ for exceptions.
 
 Julia includes code from the following projects, which have their own licenses:
 
+- [crc32c.c](http://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software) (CRC-32c checksum code by Mark Adler) [[ZLib](https://opensource.org/licenses/Zlib)].
 - [LDC](https://github.com/ldc-developers/ldc/blob/master/LICENSE) (for ccall/cfunction ABI definitions) [BSD-3]. The portion of code that Julia uses from LDC is [BSD-3] licensed.
 - [LLVM](http://llvm.org/releases/3.7.0/LICENSE.TXT) (for parts of src/jitlayers.cpp and src/disasm.cpp) [BSD-3, effectively]
 - [MUSL](http://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) (for getopt implementation on Windows) [MIT]

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -212,15 +212,17 @@ end
 # to synchronize multiple tasks trying to import/using something
 const package_locks = Dict{Symbol,Condition}()
 
+cache_checksum(path) = crc32c(read(path))
+
 # used to optionally track dependencies when requiring a module:
-const _require_dependencies = Tuple{String,Float64}[]
+const _require_dependencies = Tuple{String,Float64,UInt32}[]
 const _track_dependencies = [false]
 function _include_dependency(_path::AbstractString)
     prev = source_path(nothing)
     path = (prev === nothing) ? abspath(_path) : joinpath(dirname(prev),_path)
     if myid() == 1 && _track_dependencies[1]
         apath = abspath(path)
-        push!(_require_dependencies, (apath, mtime(apath)))
+        push!(_require_dependencies, (apath, mtime(apath), cache_checksum(path)))
     end
     return path, prev
 end
@@ -513,7 +515,7 @@ isvalid_cache_header(f::IOStream) = 0 != ccall(:jl_read_verify_header, Cint, (Pt
 
 function cache_dependencies(f::IO)
     modules = Tuple{Symbol,UInt64}[]
-    files = Tuple{String,Float64}[]
+    files = Tuple{String,Float64,UInt32}[]
     while true
         n = ntoh(read(f, Int32))
         n == 0 && break
@@ -525,7 +527,7 @@ function cache_dependencies(f::IO)
     while true
         n = ntoh(read(f, Int32))
         n == 0 && break
-        push!(files, (String(read(f, n)), ntoh(read(f, Float64))))
+        push!(files, (String(read(f, n)), ntoh(read(f, Float64)), ntoh(read(f, UInt32))))
     end
     return modules, files
 end
@@ -550,9 +552,10 @@ function stale_cachefile(modpath, cachefile)
         if files[1][1] != modpath
             return true # cache file was compiled from a different path
         end
-        for (f,ftime) in files
+        for (f,ftime,checksum) in files
             # Issue #13606: compensate for Docker images rounding mtimes
-            if mtime(f) ∉ (ftime, floor(ftime))
+            if mtime(f) ∉ (ftime, floor(ftime)) &&
+               cache_checksum(f) != checksum
                 return true
             end
         end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -212,7 +212,7 @@ end
 # to synchronize multiple tasks trying to import/using something
 const package_locks = Dict{Symbol,Condition}()
 
-cache_checksum(path) = crc32c(read(path))
+cache_checksum(path) = isfile(path) ? crc32c(read(path)) : 0x00000000
 
 # used to optionally track dependencies when requiring a module:
 const _require_dependencies = Tuple{String,Float64,UInt32}[]
@@ -553,7 +553,8 @@ function stale_cachefile(modpath, cachefile)
             return true # cache file was compiled from a different path
         end
         for (f,ftime,checksum) in files
-            # Issue #13606: compensate for Docker images rounding mtimes
+            # mtime check of ftime and floor(ftime) is due to issue #13606:
+            # compensate for Docker images rounding mtimes
             if mtime(f) ∉ (ftime, floor(ftime)) &&
                cache_checksum(f) != checksum
                 return true

--- a/base/util.jl
+++ b/base/util.jl
@@ -514,3 +514,15 @@ if is_windows()
     end
 
 end
+
+"""
+    crc32c(data, crc::UInt32=0x00000000)
+
+Compute the CRC-32c checksum of the given `data`, which can be
+an `Array{UInt8}` or a `String`.  Optionally, you can pass
+a starting `crc` integer to be mixed in with the checksum.
+(Technically, a little-endian checksum is computed.)
+"""
+function crc32c end
+crc32c(a::Array{UInt8}, crc::UInt32=0x00000000) = ccall(:jl_crc32c, UInt32, (UInt32, Ptr{UInt8}, Csize_t), crc, a, sizeof(a))
+crc32c(s::String, crc::UInt32=0x00000000) = crc32c(s.data, crc)

--- a/contrib/add_license_to_files.jl
+++ b/contrib/add_license_to_files.jl
@@ -57,6 +57,7 @@ const skipfiles = [
     "../src/support/tzfile.h",
     "../src/support/utf8.c",
     "../test/perf/micro/randmtzig.c",
+    "../src/support/crc32c.c",
 ]
 
 const ext_prefix = Dict([

--- a/src/dump.c
+++ b/src/dump.c
@@ -1084,7 +1084,7 @@ static void write_mod_list(ios_t *s)
 }
 
 // "magic" string and version header of .ji file
-static const int JI_FORMAT_VERSION = 2;
+static const int JI_FORMAT_VERSION = 3;
 static const char JI_MAGIC[] = "\373jli\r\n\032\n"; // based on PNG signature
 static const uint16_t BOM = 0xFEFF; // byte-order marker
 static void write_header(ios_t *s)
@@ -1101,8 +1101,8 @@ static void write_header(ios_t *s)
     ios_write(s, commit, strlen(commit)+1);
 }
 
-// serialize the global _require_dependencies array of pathnames that
-// are include depenencies
+// serialize the global _require_dependencies array of
+// (pathname, timestamp, checksum) that are include dependencies
 static void write_dependency_list(ios_t *s)
 {
     size_t total_size = 0;
@@ -1124,7 +1124,7 @@ static void write_dependency_list(ios_t *s)
         for (size_t i=0; i < l; i++) {
             jl_value_t *dep = jl_fieldref(jl_array_ptr_ref(udeps, i), 0);
             size_t slen = jl_string_len(dep);
-            total_size += 4 + slen + 8;
+            total_size += 4 + slen + 8 + 4;
         }
         total_size += 4;
     }
@@ -1140,6 +1140,7 @@ static void write_dependency_list(ios_t *s)
             write_int32(s, slen);
             ios_write(s, jl_string_data(dep), slen);
             write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 1)));
+            write_int32(s, jl_unbox_int32(jl_fieldref(deptuple, 2)));
         }
         write_int32(s, 0); // terminator, for ease of reading
     }

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -7,7 +7,7 @@ override CXXFLAGS += $(JCXXFLAGS)
 override CPPFLAGS += $(JCPPFLAGS)
 
 SRCS := hashing timefuncs ptrhash operators utf8 ios htable bitvector \
-	int2str libsupportinit arraylist strtod
+	int2str libsupportinit arraylist strtod crc32c
 ifeq ($(OS),WINNT)
 SRCS += asprintf wsasocketpair strptime
 ifeq ($(ARCH),i686)

--- a/src/support/crc32c.c
+++ b/src/support/crc32c.c
@@ -1,0 +1,365 @@
+/* crc32c.c -- compute CRC-32C using the Intel crc32 instruction
+ * Copyright (C) 2013 Mark Adler
+ * Version 1.1  1 Aug 2013  Mark Adler
+ *
+ * Code retrieved in August 2016 from August 2013 post by Mark Adler on
+ *    http://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software
+ * Modified for use in libjulia:
+ *    - exported function renamed to jl_crc32c, DLL exports added.
+ *    - removed main() function
+ *    - changed crc32c_table initialization to a single jl_crc23_init(0) call.
+ *    - protect sse code with #ifdef __x86_64__
+ *    - added header file
+ */
+
+/*
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the author be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Mark Adler
+  madler@alumni.caltech.edu
+*/
+
+/* Use hardware CRC instruction on Intel SSE 4.2 processors.  This computes a
+   CRC-32C, *not* the CRC-32 used by Ethernet and zip, gzip, etc.  A software
+   version is provided as a fall-back, as well as for speed comparisons. */
+
+/* Version history:
+   1.0  10 Feb 2013  First version
+   1.1   1 Aug 2013  Correct comments on why three crc instructions in parallel
+*/
+
+#include "crc32c.h"
+
+/* CRC-32C (iSCSI) polynomial in reversed bit order. */
+#define POLY 0x82f63b78
+
+/* Table for a quadword-at-a-time software crc. */
+static uint32_t crc32c_table[8][256];
+
+/* Construct table for software CRC-32C calculation. */
+static void crc32c_init_sw(void)
+{
+    uint32_t n, crc, k;
+
+    for (n = 0; n < 256; n++) {
+        crc = n;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+        crc32c_table[0][n] = crc;
+    }
+    for (n = 0; n < 256; n++) {
+        crc = crc32c_table[0][n];
+        for (k = 1; k < 8; k++) {
+            crc = crc32c_table[0][crc & 0xff] ^ (crc >> 8);
+            crc32c_table[k][n] = crc;
+        }
+    }
+}
+
+/* Table-driven software version as a fall-back.  This is about 15 times slower
+   than using the hardware instructions.  This computes a little-endian
+   CRC32c, equivalent to the little-endian CRC of the Intel instructions,
+   regardless of the endianness of the machine this is running on.  */
+static uint32_t crc32c_sw(uint32_t crci, const void *buf, size_t len)
+{
+    const unsigned char *next = buf;
+    uint64_t crc;
+
+    /* pthread_once(&crc32c_once_sw, crc32c_init_sw); */
+    crc = crci ^ 0xffffffff;
+    while (len && ((uintptr_t)next & 7) != 0) {
+        crc = crc32c_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);
+        len--;
+    }
+    while (len >= 8) {
+        crc ^= *(uint64_t *)next;
+                crc = crc32c_table[7][crc & 0xff] ^
+                    crc32c_table[6][(crc >> 8) & 0xff] ^
+                    crc32c_table[5][(crc >> 16) & 0xff] ^
+                    crc32c_table[4][(crc >> 24) & 0xff] ^
+                    crc32c_table[3][(crc >> 32) & 0xff] ^
+                    crc32c_table[2][(crc >> 40) & 0xff] ^
+                    crc32c_table[1][(crc >> 48) & 0xff] ^
+                    crc32c_table[0][crc >> 56];
+                next += 8;
+                len -= 8;
+    }
+    while (len) {
+        crc = crc32c_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);
+        len--;
+    }
+    return (uint32_t)crc ^ 0xffffffff;
+}
+
+#ifdef __x86_64__
+
+/* Multiply a matrix times a vector over the Galois field of two elements,
+   GF(2).  Each element is a bit in an unsigned integer.  mat must have at
+   least as many entries as the power of two for most significant one bit in
+   vec. */
+static inline uint32_t gf2_matrix_times(uint32_t *mat, uint32_t vec)
+{
+    uint32_t sum;
+
+    sum = 0;
+    while (vec) {
+        if (vec & 1)
+            sum ^= *mat;
+        vec >>= 1;
+        mat++;
+    }
+    return sum;
+}
+
+/* Multiply a matrix by itself over GF(2).  Both mat and square must have 32
+   rows. */
+static inline void gf2_matrix_square(uint32_t *square, uint32_t *mat)
+{
+    int n;
+
+    for (n = 0; n < 32; n++)
+        square[n] = gf2_matrix_times(mat, mat[n]);
+}
+
+/* Construct an operator to apply len zeros to a crc.  len must be a power of
+   two.  If len is not a power of two, then the result is the same as for the
+   largest power of two less than len.  The result for len == 0 is the same as
+   for len == 1.  A version of this routine could be easily written for any
+   len, but that is not needed for this application. */
+static void crc32c_zeros_op(uint32_t *even, size_t len)
+{
+    int n;
+    uint32_t row;
+    uint32_t odd[32];       /* odd-power-of-two zeros operator */
+
+    /* put operator for one zero bit in odd */
+    odd[0] = POLY;              /* CRC-32C polynomial */
+    row = 1;
+    for (n = 1; n < 32; n++) {
+        odd[n] = row;
+        row <<= 1;
+    }
+
+    /* put operator for two zero bits in even */
+    gf2_matrix_square(even, odd);
+
+    /* put operator for four zero bits in odd */
+    gf2_matrix_square(odd, even);
+
+    /* first square will put the operator for one zero byte (eight zero bits),
+       in even -- next square puts operator for two zero bytes in odd, and so
+       on, until len has been rotated down to zero */
+    do {
+        gf2_matrix_square(even, odd);
+        len >>= 1;
+        if (len == 0)
+            return;
+        gf2_matrix_square(odd, even);
+        len >>= 1;
+    } while (len);
+
+    /* answer ended up in odd -- copy to even */
+    for (n = 0; n < 32; n++)
+        even[n] = odd[n];
+}
+
+/* Take a length and build four lookup tables for applying the zeros operator
+   for that length, byte-by-byte on the operand. */
+static void crc32c_zeros(uint32_t zeros[][256], size_t len)
+{
+    uint32_t n;
+    uint32_t op[32];
+
+    crc32c_zeros_op(op, len);
+    for (n = 0; n < 256; n++) {
+        zeros[0][n] = gf2_matrix_times(op, n);
+        zeros[1][n] = gf2_matrix_times(op, n << 8);
+        zeros[2][n] = gf2_matrix_times(op, n << 16);
+        zeros[3][n] = gf2_matrix_times(op, n << 24);
+    }
+}
+
+/* Apply the zeros operator table to crc. */
+static inline uint32_t crc32c_shift(uint32_t zeros[][256], uint32_t crc)
+{
+    return zeros[0][crc & 0xff] ^ zeros[1][(crc >> 8) & 0xff] ^
+        zeros[2][(crc >> 16) & 0xff] ^ zeros[3][crc >> 24];
+}
+
+/* Block sizes for three-way parallel crc computation.  LONG and SHORT must
+   both be powers of two.  The associated string constants must be set
+   accordingly, for use in constructing the assembler instructions. */
+#define LONG 8192
+#define LONGx1 "8192"
+#define LONGx2 "16384"
+#define SHORT 256
+#define SHORTx1 "256"
+#define SHORTx2 "512"
+
+/* Tables for hardware crc that shift a crc by LONG and SHORT zeros. */
+static uint32_t crc32c_long[4][256];
+static uint32_t crc32c_short[4][256];
+
+/* Initialize tables for shifting crcs. */
+static void crc32c_init_hw(void)
+{
+    crc32c_zeros(crc32c_long, LONG);
+    crc32c_zeros(crc32c_short, SHORT);
+}
+
+/* Compute CRC-32C using the Intel hardware instruction. */
+static uint32_t crc32c_hw(uint32_t crc, const void *buf, size_t len)
+{
+    const unsigned char *next = buf;
+    const unsigned char *end;
+    uint64_t crc0, crc1, crc2;      /* need to be 64 bits for crc32q */
+
+    /* populate shift tables the first time through */
+    /* pthread_once(&crc32c_once_hw, crc32c_init_hw); */
+
+    /* pre-process the crc */
+    crc0 = crc ^ 0xffffffff;
+
+    /* compute the crc for up to seven leading bytes to bring the data pointer
+       to an eight-byte boundary */
+    while (len && ((uintptr_t)next & 7) != 0) {
+        __asm__("crc32b\t" "(%1), %0"
+                : "=r"(crc0)
+                : "r"(next), "0"(crc0));
+        next++;
+        len--;
+    }
+
+    /* compute the crc on sets of LONG*3 bytes, executing three independent crc
+       instructions, each on LONG bytes -- this is optimized for the Nehalem,
+       Westmere, Sandy Bridge, and Ivy Bridge architectures, which have a
+       throughput of one crc per cycle, but a latency of three cycles */
+    while (len >= LONG*3) {
+        crc1 = 0;
+        crc2 = 0;
+        end = next + LONG;
+        do {
+            __asm__("crc32q\t" "(%3), %0\n\t"
+                                        "crc32q\t" LONGx1 "(%3), %1\n\t"
+                                        "crc32q\t" LONGx2 "(%3), %2"
+                    : "=r"(crc0), "=r"(crc1), "=r"(crc2)
+                    : "r"(next), "0"(crc0), "1"(crc1), "2"(crc2));
+            next += 8;
+        } while (next < end);
+        crc0 = crc32c_shift(crc32c_long, crc0) ^ crc1;
+        crc0 = crc32c_shift(crc32c_long, crc0) ^ crc2;
+        next += LONG*2;
+        len -= LONG*3;
+    }
+
+    /* do the same thing, but now on SHORT*3 blocks for the remaining data less
+       than a LONG*3 block */
+    while (len >= SHORT*3) {
+        crc1 = 0;
+        crc2 = 0;
+        end = next + SHORT;
+        do {
+            __asm__("crc32q\t" "(%3), %0\n\t"
+                                        "crc32q\t" SHORTx1 "(%3), %1\n\t"
+                                        "crc32q\t" SHORTx2 "(%3), %2"
+                    : "=r"(crc0), "=r"(crc1), "=r"(crc2)
+                    : "r"(next), "0"(crc0), "1"(crc1), "2"(crc2));
+            next += 8;
+        } while (next < end);
+        crc0 = crc32c_shift(crc32c_short, crc0) ^ crc1;
+        crc0 = crc32c_shift(crc32c_short, crc0) ^ crc2;
+        next += SHORT*2;
+        len -= SHORT*3;
+    }
+
+    /* compute the crc on the remaining eight-byte units less than a SHORT*3
+       block */
+    end = next + (len - (len & 7));
+    while (next < end) {
+        __asm__("crc32q\t" "(%1), %0"
+                : "=r"(crc0)
+                : "r"(next), "0"(crc0));
+        next += 8;
+    }
+    len &= 7;
+
+    /* compute the crc for up to seven trailing bytes */
+    while (len) {
+        __asm__("crc32b\t" "(%1), %0"
+                : "=r"(crc0)
+                : "r"(next), "0"(crc0));
+        next++;
+        len--;
+    }
+
+    /* return a post-processed crc */
+    return (uint32_t)crc0 ^ 0xffffffff;
+}
+
+/* Check for SSE 4.2.  SSE 4.2 was first supported in Nehalem processors
+   introduced in November, 2008.  This does not check for the existence of the
+   cpuid instruction itself, which was introduced on the 486SL in 1992, so this
+   will fail on earlier x86 processors.  cpuid works on all Pentium and later
+   processors. */
+#define SSE42(have) \
+    do { \
+        uint32_t eax, ecx; \
+        eax = 1; \
+        __asm__("cpuid" \
+                : "=c"(ecx) \
+                : "a"(eax) \
+                : "%ebx", "%edx"); \
+        (have) = (ecx >> 20) & 1; \
+    } while (0)
+
+static int sse42 = 0;
+
+#endif /* ifdef __x86_64__ */
+
+/* jl_crc32c_init must be called before jl_crc32c.  Passing 1
+   can be used to force the use of the software implementation,
+   which is useful for testing purposes. */
+JL_DLLEXPORT void jl_crc32c_init(int force_sw)
+{
+#ifdef __x86_64__
+    if (force_sw)
+        sse42 = 0; /* useful for testing purposes */
+    else
+        SSE42(sse42);
+    if (sse42)
+        crc32c_init_hw();
+    else
+#endif
+        crc32c_init_sw();
+}
+
+/* Compute a CRC-32C.  If the crc32 instruction is available, use the hardware
+   version.  Otherwise, use the software version. */
+JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const void *buf, size_t len)
+{
+    return
+#ifdef __x86_64__
+    sse42 ? crc32c_hw(crc, buf, len) :
+#endif
+    crc32c_sw(crc, buf, len);
+}

--- a/src/support/crc32c.c
+++ b/src/support/crc32c.c
@@ -44,7 +44,7 @@
 
 #include "crc32c.h"
 
-#if defined(_CPU_X86_64_) && !defined(_COMPILER_MICROSOFT_)
+#if (defined(_CPU_X86_64_) || defined(_CPU_X86_)) && !defined(_COMPILER_MICROSOFT_)
 #  define HW_CRC
 #endif
 

--- a/src/support/crc32c.c
+++ b/src/support/crc32c.c
@@ -44,6 +44,10 @@
 
 #include "crc32c.h"
 
+#if defined(_CPU_X86_64_) && !defined(_COMPILER_MICROSOFT_)
+#  define HW_CRC
+#endif
+
 /* CRC-32C (iSCSI) polynomial in reversed bit order. */
 #define POLY 0x82f63b78
 
@@ -111,7 +115,7 @@ static uint32_t crc32c_sw(uint32_t crci, const void *buf, size_t len)
     return (uint32_t)crc ^ 0xffffffff;
 }
 
-#ifdef __x86_64__
+#ifdef HW_CRC
 
 /* Multiply a matrix times a vector over the Galois field of two elements,
    GF(2).  Each element is a bit in an unsigned integer.  mat must have at
@@ -334,14 +338,14 @@ static uint32_t crc32c_hw(uint32_t crc, const void *buf, size_t len)
 
 static int sse42 = 0;
 
-#endif /* ifdef __x86_64__ */
+#endif /* ifdef HW_CRC */
 
 /* jl_crc32c_init must be called before jl_crc32c.  Passing 1
    can be used to force the use of the software implementation,
    which is useful for testing purposes. */
 JL_DLLEXPORT void jl_crc32c_init(int force_sw)
 {
-#ifdef __x86_64__
+#ifdef HW_CRC
     if (force_sw)
         sse42 = 0; /* useful for testing purposes */
     else

--- a/src/support/crc32c.c
+++ b/src/support/crc32c.c
@@ -44,7 +44,7 @@
 
 #include "crc32c.h"
 
-#if (defined(_CPU_X86_64_) || defined(_CPU_X86_)) && !defined(_COMPILER_MICROSOFT_)
+#if defined(_CPU_X86_64_) && !defined(_COMPILER_MICROSOFT_)
 #  define HW_CRC
 #endif
 

--- a/src/support/crc32c.c
+++ b/src/support/crc32c.c
@@ -8,7 +8,7 @@
  *    - exported function renamed to jl_crc32c, DLL exports added.
  *    - removed main() function
  *    - changed crc32c_table initialization to a single jl_crc23_init(0) call.
- *    - protect sse code with #ifdef __x86_64__
+ *    - protect sse code with #ifdef (correct architecture and compiler)
  *    - added header file
  */
 
@@ -362,7 +362,7 @@ JL_DLLEXPORT void jl_crc32c_init(int force_sw)
 JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const void *buf, size_t len)
 {
     return
-#ifdef __x86_64__
+#ifdef HW_CRC
     sse42 ? crc32c_hw(crc, buf, len) :
 #endif
     crc32c_sw(crc, buf, len);

--- a/src/support/crc32c.c
+++ b/src/support/crc32c.c
@@ -86,7 +86,7 @@ static void crc32c_init_sw(void)
    regardless of the endianness of the machine this is running on.  */
 static uint32_t crc32c_sw(uint32_t crci, const void *buf, size_t len)
 {
-    const unsigned char *next = buf;
+    const unsigned char *next = (const unsigned char *) buf;
     uint64_t crc;
 
     /* pthread_once(&crc32c_once_sw, crc32c_init_sw); */
@@ -234,7 +234,7 @@ static void crc32c_init_hw(void)
 /* Compute CRC-32C using the Intel hardware instruction. */
 static uint32_t crc32c_hw(uint32_t crc, const void *buf, size_t len)
 {
-    const unsigned char *next = buf;
+    const unsigned char *next = (const unsigned char *) buf;
     const unsigned char *end;
     uint64_t crc0, crc1, crc2;      /* need to be 64 bits for crc32q */
 

--- a/src/support/crc32c.h
+++ b/src/support/crc32c.h
@@ -1,0 +1,17 @@
+#ifndef CRC32C_H
+#define CRC32C_H 1
+
+#include "dtypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JL_DLLEXPORT void jl_crc32c_init(int force_sw);
+JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const void *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CRC32C_H */

--- a/src/support/libsupport.h
+++ b/src/support/libsupport.h
@@ -18,6 +18,7 @@
 #include "bitvector.h"
 #include "dirpath.h"
 #include "strtod.h"
+#include "crc32c.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/support/libsupportinit.c
+++ b/src/support/libsupportinit.c
@@ -20,6 +20,8 @@ void libsupport_init(void)
 
         ios_init_stdstreams();
 
+        jl_crc32c_init(0);
+
         isInitialized=1;
     }
 }

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -161,7 +161,7 @@ try
     Base.compilecache("FooBar")
     @test isfile(joinpath(dir, "FooBar.ji"))
 
-    sleep(2) # wait to make sure file modification date changes
+    sleep(2) # wait to make sure file modification time changes
     touch(FooBar_file)
     insert!(Base.LOAD_CACHE_PATH, 1, dir2)
     Base.recompile_stale(:FooBar, joinpath(dir, "FooBar.ji"))

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -159,16 +159,23 @@ try
           """)
 
     Base.compilecache("FooBar")
-    sleep(2)
     @test isfile(joinpath(dir, "FooBar.ji"))
 
+    sleep(2) # wait to make sure file modification date changes
     touch(FooBar_file)
     insert!(Base.LOAD_CACHE_PATH, 1, dir2)
     Base.recompile_stale(:FooBar, joinpath(dir, "FooBar.ji"))
-    sleep(2)
+    # just touching the file should not invalidate the old cachefile (#17845)
+    @test !isfile(joinpath(dir2, "FooBar.ji"))
+    @test !Base.stale_cachefile(FooBar_file, joinpath(dir, "FooBar.ji"))
+
+    open(FooBar_file, "a") do io
+        println(io) # invalidate checksum
+    end
+    Base.recompile_stale(:FooBar, joinpath(dir, "FooBar.ji"))
     @test isfile(joinpath(dir2, "FooBar.ji"))
-    @test Base.stale_cachefile(FooBar_file, joinpath(dir, "FooBar.ji"))
     @test !Base.stale_cachefile(FooBar_file, joinpath(dir2, "FooBar.ji"))
+    @test Base.stale_cachefile(FooBar_file, joinpath(dir, "FooBar.ji"))
 
     write(FooBar_file,
           """
@@ -177,6 +184,8 @@ try
           error("break me")
           end
           """)
+    @test Base.stale_cachefile(FooBar_file, joinpath(dir, "FooBar.ji"))
+    @test Base.stale_cachefile(FooBar_file, joinpath(dir2, "FooBar.ji"))
 
     try
         redirected_stderr()

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -425,3 +425,11 @@ let creds = Base.LibGit2.CachedCredentials()
     securezero!(creds)
     @test LibGit2.get_creds!(creds, "foo", nothing).pass == "\0\0\0"
 end
+
+# CRC32c checksum (test data generated from @andrewcooke's CRC.jl package)
+for force_software_crc in (1,0)
+    ccall(:jl_crc32c_init, Void, (Cint,), force_software_crc)
+    for (n,crc) in [(0,0x00000000),(1,0xa016d052),(2,0x03f89f52),(3,0xf130f21e),(4,0x29308cf4),(5,0x53518fab),(6,0x4f4dfbab),(7,0xbd3a64dc),(8,0x46891f81),(9,0x5a14b9f9),(10,0xb219db69),(11,0xd232a91f),(12,0x51a15563),(13,0x9f92de41),(14,0x4d8ae017),(15,0xc8b74611),(16,0xa0de6714),(17,0x672c992a),(18,0xe8206eb6),(19,0xc52fd285),(20,0x327b0397),(21,0x318263dd),(22,0x08485ccd),(23,0xea44d29e),(24,0xf6c0cb13),(25,0x3969bba2),(26,0x6a8810ec),(27,0x75b3d0df),(28,0x82d535b1),(29,0xbdf7fc12),(30,0x1f836b7d),(31,0xd29f33af),(32,0x8e4acb3e),(33,0x1cbee2d1),(34,0xb25f7132),(35,0xb0fa484c),(36,0xb9d262b4),(37,0x3207fe27),(38,0xa024d7ac),(39,0x49a2e7c5),(40,0x0e2c157f),(41,0x25f7427f),(42,0x368c6adc),(43,0x75efd4a5),(44,0xa84c5c31),(45,0x0fc817b2),(46,0x8d99a881),(47,0x5cc3c078),(48,0x9983d5e2),(49,0x9267c2db),(50,0xc96d4745),(51,0x058d8df3),(52,0x453f9cf3),(53,0xb714ade1),(54,0x55d3c2bc),(55,0x495710d0),(56,0x3bddf494),(57,0x4f2577d0),(58,0xdae0f604),(59,0x3c57c632),(60,0xfe39bbb0),(61,0x6f5d1d41),(62,0x7d996665),(63,0x68c738dc),(64,0x8dfea7ae)]
+        @test Base.crc32c(UInt8[1:n;]) == crc
+    end
+end


### PR DESCRIPTION
This fixes #17845: to reduce the chance of false positives when checking cache staleness, it also checks a CRC-32c checksum of the file if the timestamp doesn't match.  (That is, the file is considered stale if `timestamp mismatch && checksum mismatch`).

The performance impact seems to be negligible.  In the common case where the timestamps match, the checksum is never computed at all, and in any case the computation of a checksum seems to be orders of magnitude faster than the time to load the cache file.

I used Mark Adler's (@madler) ~~BSD-licensed~~ [zlib-licensed](https://opensource.org/licenses/Zlib) CRC-32c implementation that he [posted on StackOverflow](http://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software), which includes both software and hardware-accelerated versions (the latter for SSE4.2 hardware).   [Adler](https://en.wikipedia.org/wiki/Mark_Adler) seems to be someone who knows what he is doing with checksum algorithms, so I was happy to see he posted usable code.  His code seems to be pretty fast (well over an order of magnitude faster than @andrewcooke's implementation in CRC.jl, which Andrew said is comparable to zlib; see also andrewcooke/CRC.jl#5).  @baruch did [some benchmarking](https://github.com/baruch/crcbench) and he found that Adler's implementation was one of the fastest.   I don't see much point in re-implementing it in Julia.

Because of the existence of hardware support, [CRC-32c seems like the most sensible choice](http://www.evanjones.ca/crc32c.html) of checksum algorithm, so I didn't really look at alternatives.

It also seems like a good idea to export the `crc32c` checksum function, since this is pretty generally useful functionality to have, but I wanted to get feedback first.
