### PR TITLE
Fix incorrect code block in rounding modes docs

### DIFF
--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -505,10 +505,9 @@ Rounding modes
 If a number doesn't have an exact floating-point representation, it must be
 rounded to an appropriate representable value, however, if wanted, the manner
 in which this rounding is done can be changed according to the rounding modes
-presented in the `IEEE 754 standard <https://en.wikipedia.org/wiki/IEEE_754-2008>`_::
+presented in the `IEEE 754 standard <https://en.wikipedia.org/wiki/IEEE_754-2008>`_.
 
 .. doctest::
-
 
     julia> x = 1.1; y = 0.1;
 


### PR DESCRIPTION
The `::` syntax appearing before the `doctest::` block was causing the doctest not be rendered correctly.
