### PR TITLE
Forward-port "Bugfix #18073 (#18105)"

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -457,7 +457,7 @@ any(f::Predicate, itr) = mapreduce_sc_impl(f, |, itr)
 any(f::typeof(identity), itr) =
     eltype(itr) <: Bool ?
         mapreduce_sc_impl(f, |, itr) :
-        reduce(or_bool_only, itr)
+        reduce(or_bool_only, false, itr)
 
 """
     all(p, itr) -> Bool
@@ -474,7 +474,7 @@ all(f::Predicate, itr) = mapreduce_sc_impl(f, &, itr)
 all(f::typeof(identity), itr) =
     eltype(itr) <: Bool ?
         mapreduce_sc_impl(f, &, itr) :
-        reduce(and_bool_only, itr)
+        reduce(and_bool_only, true, itr)
 
 ## in & contains
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -173,6 +173,7 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 
 # any & all
 
+@test any([]) == false
 @test any(Bool[]) == false
 @test any([true]) == true
 @test any([false, false]) == false
@@ -183,6 +184,7 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test any([true, false, true]) == true
 @test any([false, false, false]) == false
 
+@test all([]) == true
 @test all(Bool[]) == true
 @test all([true]) == true
 @test all([false, false]) == false
@@ -193,11 +195,13 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test all([true, false, true]) == false
 @test all([false, false, false]) == false
 
+@test any(x->x>0, []) == false
 @test any(x->x>0, Int[]) == false
 @test any(x->x>0, [-3]) == false
 @test any(x->x>0, [4]) == true
 @test any(x->x>0, [-3, 4, 5]) == true
 
+@test all(x->x>0, []) == true
 @test all(x->x>0, Int[]) == true
 @test all(x->x>0, [-3]) == false
 @test all(x->x>0, [4]) == true


### PR DESCRIPTION
fix #18073: `any([])` and `all([])` (#18105)
(cherry picked from commit d259be55130f9d695262c3e528697c451cbb4e9e, against master this time)
