### PR TITLE
Adds support for String(x::Symbol) = string(x)

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -62,6 +62,7 @@ convert(::Type{Array{UInt8}}, s::AbstractString) = String(s).data
 convert(::Type{String}, s::AbstractString) = String(s)
 convert(::Type{Vector{Char}}, s::AbstractString) = collect(s)
 convert(::Type{Symbol}, s::AbstractString) = Symbol(s)
+convert(::Type{String}, s::Symbol) = unsafe_string(Cstring(s))
 
 ## generic supplied functions ##
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -55,6 +55,7 @@ let
     # make symbol with invalid char
     sym = Symbol(Char(0xdcdb))
     @test string(sym) == string(Char(0xdcdb))
+    @test String(sym) == string(Char(0xdcdb))
     @test expand(sym) === sym
     res = string(parse(string(Char(0xdcdb)," = 1"),1,raise=false)[1])
     @test res == """\$(Expr(:error, "invalid character \\\"\\udcdb\\\"\"))"""


### PR DESCRIPTION
Bug fix for #16997 
defines String(x::Symbol) = string(x)

(This one's against master!)
