### PR TITLE
Add command line option --polly={yes|no}

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -24,6 +24,7 @@ immutable JLOptions
     check_bounds::Int8
     depwarn::Int8
     can_inline::Int8
+    polly::Int8
     fast_math::Int8
     worker::Ptr{UInt8}
     handle_signals::Int8

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4111,7 +4111,7 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
 #endif
 
 #ifdef USE_POLLY
-    if (!jl_has_meta(code, polly_sym)) {
+    if (!jl_has_meta(code, polly_sym) || jl_options.polly == JL_OPTIONS_POLLY_OFF) {
         f->addFnAttr(polly::PollySkipFnAttr);
     }
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -78,6 +78,7 @@ jl_options_t jl_options = { 0,    // quiet
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
                             1,    // depwarn
                             1,    // can_inline
+                            JL_OPTIONS_POLLY_ON, // polly
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
                             JL_OPTIONS_HANDLE_SIGNALS_ON,

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -46,6 +46,9 @@ static const char opts[]  =
     " -O, --optimize={0,1,2,3}  Set the optimization level (default 2 if unspecified or 3 if specified as -O)\n"
     " --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)\n"
     " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)\n"
+#ifdef USE_POLLY
+    " --polly={yes|no}          Enable or disable the polyhedral optimizer Polly (overrides @polly declaration)\n"
+#endif
     " --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)\n\n"
 
     // error and warning options
@@ -83,6 +86,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_output_bc,
            opt_depwarn,
            opt_inline,
+           opt_polly,
            opt_math_mode,
            opt_worker,
            opt_bind_to,
@@ -125,6 +129,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "output-incremental",required_argument, 0, opt_incremental },
         { "depwarn",         required_argument, 0, opt_depwarn },
         { "inline",          required_argument, 0, opt_inline },
+        { "polly",           required_argument, 0, opt_polly },
         { "math-mode",       required_argument, 0, opt_math_mode },
         { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
@@ -396,6 +401,15 @@ restart_switch:
                 jl_options.can_inline = 0;
             else {
                 jl_errorf("julia: invalid argument to --inline (%s)", optarg);
+            }
+            break;
+       case opt_polly:
+            if (!strcmp(optarg,"yes"))
+                jl_options.polly = JL_OPTIONS_POLLY_ON;
+            else if (!strcmp(optarg,"no"))
+                jl_options.polly = JL_OPTIONS_POLLY_OFF;
+            else {
+                jl_errorf("julia: invalid argument to --polly (%s)", optarg);
             }
             break;
         case opt_math_mode:

--- a/src/julia.h
+++ b/src/julia.h
@@ -1668,6 +1668,7 @@ typedef struct {
     int8_t check_bounds;
     int8_t depwarn;
     int8_t can_inline;
+    int8_t polly;
     int8_t fast_math;
     const char *worker;
     int8_t handle_signals;
@@ -1721,6 +1722,9 @@ JL_DLLEXPORT int jl_generating_output(void);
 #define JL_OPTIONS_DEPWARN_OFF 0
 #define JL_OPTIONS_DEPWARN_ON 1
 #define JL_OPTIONS_DEPWARN_ERROR 2
+
+#define JL_OPTIONS_POLLY_ON 1
+#define JL_OPTIONS_POLLY_OFF 0
 
 #define JL_OPTIONS_FAST_MATH_ON 1
 #define JL_OPTIONS_FAST_MATH_OFF 2

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -186,6 +186,13 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     # --inline takes yes/no as argument
     @test !success(`$exename --inline=false`)
 
+    # --polly
+    @test readchomp(`$exename -E "Bool(Base.JLOptions().polly)"`) == "true"
+    @test readchomp(`$exename --polly=yes -E "Bool(Base.JLOptions().polly)"`) == "true"
+    @test readchomp(`$exename --polly=no -E "Bool(Base.JLOptions().polly)"`) == "false"
+    # --polly takes yes/no as argument
+    @test !success(`$exename --polly=false`)
+
     # --fast-math
     let JL_OPTIONS_FAST_MATH_DEFAULT = 0,
         JL_OPTIONS_FAST_MATH_ON = 1,


### PR DESCRIPTION
When this option is passed `@polly` declarations will be ignored. This facilitates debugging or evaluating performance differences between using/not using Polly without having to manually remove `@polly` declarations from functions.

I also wanted to ask you for some advice on the following issues: The `polly` field in the `JLOptions` type will also be present in a non-Polly build (`USE_POLLY := 0`) because I don't know how I could hide it in this case. Do you think that there would be a better alternative for this or would that be acceptable?

Furthermore, I also wanted to add according test cases to `test/cmdlineargs.jl`:

```
@test readchomp(`$exename -E "Bool(Base.JLOptions().polly)"`) == "true"
@test readchomp(`$exename --disable-polly -E "Bool(Base.JLOptions().polly)"`) == "false"
```

But the problem for the second test case is that in a non-Polly build `--disable-polly` would not be available which would make this test fail. A possible solution would be to add the following to the `build_h.jl.phy` target in `base/Makefile`:

```
ifeq ($(USE_POLLY), 1)
    @echo "const USE_POLLY = true" >> $@
else
    @echo "const USE_POLLY = false" >> $@
endif
```

Then it should be possible to make the above test cases conditional by adding:

```
if Base.USE_POLLY
    @test readchomp(`$exename -E "Bool(Base.JLOptions().polly)"`) == "true"
    @test readchomp(`$exename --disable-polly -E "Bool(Base.JLOptions().polly)"`) == "false"
end
```

Do you think that this would be a convenient solution?

Thank you in advance for your help!

Best,
Matthias

@tobig @vtjnash  @timholy 
