### PR TITLE
reshape(::Array, Val{N}) always returns an Array

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -51,20 +51,27 @@ end
 @pure rdims{N}(out::Tuple, inds::Tuple{}, ::Type{Val{N}}) = rdims((out..., OneTo(1)), (), Val{N})
 @pure rdims{N}(out::Tuple, inds::Tuple{Any, Vararg{Any}}, ::Type{Val{N}}) = rdims((out..., first(inds)), tail(inds), Val{N})
 
+# _reshape on Array returns an Array
+_reshape(parent::Vector, dims::Dims{1}) = parent
+_reshape(parent::Array, dims::Dims{1}) = reshape(parent, dims)
+_reshape(parent::Array, dims::Dims) = reshape(parent, dims)
+
+# When reshaping Vector->Vector, don't wrap with a ReshapedArray
+function _reshape(v::AbstractVector, dims::Dims{1})
+    len = dims[1]
+    len == length(v) || throw(DimensionMismatch("parent has $(length(v)) elements, which is incompatible with length $len"))
+    v
+end
+# General reshape
 function _reshape(parent::AbstractArray, dims::Dims)
     n = _length(parent)
     prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
     __reshape((parent, linearindexing(parent)), dims)
 end
-_reshape(R::ReshapedArray, dims::Dims) = _reshape(R.parent, dims)
 
-# When reshaping Vector->Vector, don't wrap with a ReshapedArray
-_reshape{T}(v::ReshapedArray{T,1}, dims::Tuple{Int}) = _reshape(v.parent, dims)
-function _reshape(v::AbstractVector, dims::Tuple{Int})
-    len = dims[1]
-    len == length(v) || throw(DimensionMismatch("parent has $(length(v)) elements, which is incompatible with length $len"))
-    v
-end
+# Reshaping a ReshapedArray
+_reshape{T}(v::ReshapedArray{T,1}, dims::Dims{1}) = _reshape(v.parent, dims)
+_reshape(R::ReshapedArray, dims::Dims) = _reshape(R.parent, dims)
 
 function __reshape(p::Tuple{AbstractArray,LinearSlow}, dims::Dims)
     parent = p[1]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -124,6 +124,14 @@ a = zeros(0, 5)  # an empty linearslow array
 s = view(a, :, [2,3,5])
 @test length(reshape(s, length(s))) == 0
 
+# reshape(a, Val{N})
+a = ones(Int,3,3)
+s = view(a, 1:2, 1:2)
+for N in (1,3)
+    @test isa(reshape(a, Val{N}), Array{Int,N})
+    @test isa(reshape(s, Val{N}), Base.ReshapedArray{Int,N})
+end
+
 @test reshape(1:5, (5,)) === 1:5
 @test reshape(1:5, 5) === 1:5
 


### PR DESCRIPTION
We have a convenience method, `reshape(A, Val{N})`, that reshapes to `N` dimensions, "collapsing" trailing dimensions if `ndims(A) > N`. However, one can also use this to "extend" dimensions, adding trailing 1s to the indices. When the array was an `Array`, we were returning an Array for `ndims(A) >= N` but not for `ndims(A) <= N`.

This was only a couple-line change, but I took the opportunity to move a few lines of code around to help clarify the organization.
