### PR TITLE
Do codegen in control flow order

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -4117,6 +4117,18 @@ test_metadata_matches(f4, Tuple{})
 
 end
 
+# SSA value where the assignment is after the user in syntactic order
+let f = function(a, b)
+    @goto a
+    @label b
+    return j[1] + j[2] * 2
+    @label a
+    j = (a, b)
+    @goto b
+end
+    @test f(1, 2) == 5
+end
+
 # issue #8712
 type Issue8712; end
 @test isa(invoke(Issue8712, ()), Issue8712)


### PR DESCRIPTION
- Fix codegen of `SSAValue` whose assignment appears later than the user
  in syntactic order due to backward branches.
  
    See the added test.
- Disallow more expression types in value position
- Use improved debug info metadata in coverage and allocation tracking too

Marked as WIP since one of the boundscheck test is still failing, probably because some of the inbounds handling are slightly different. Will also need to run benchmarks after that is fixed.
