### PR TITLE
Misc build fixes for win32 clang

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -445,7 +445,9 @@ export CCACHE_CPP2 := yes
 endif
 else #USECCACHE
 CC_BASE := $(shell echo $(CC) | cut -d' ' -f1)
+CC_ARG := $(shell echo $(CC) | cut -d' ' -f2-)
 CXX_BASE := $(shell echo $(CXX) | cut -d' ' -f1)
+CXX_ARG := $(shell echo $(CXX) | cut -d' ' -f2-)
 endif
 
 JFFLAGS := -O2 $(fPIC)
@@ -683,8 +685,10 @@ endif
 
 ifeq ($(OS),WINNT)
 ifneq ($(ARCH),x86_64)
+ifneq ($(USECLANG),1)
 JCFLAGS += -mincoming-stack-boundary=2
 JCXXFLAGS += -mincoming-stack-boundary=2
+endif
 endif
 endif
 

--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -54,7 +54,9 @@ OPENBLAS_BUILD_OPTS += OSNAME=$(OS) CROSS=1 HOSTCC=$(HOSTCC)
 endif
 ifeq ($(OS),WINNT)
 ifneq ($(ARCH),x86_64)
+ifneq ($(USECLANG),1)
 OPENBLAS_BUILD_OPTS += CFLAGS="$(CFLAGS) -mincoming-stack-boundary=2"
+endif
 OPENBLAS_BUILD_OPTS += FFLAGS="$(FFLAGS) -mincoming-stack-boundary=2"
 endif
 endif

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -11,7 +11,9 @@ LIBGIT2_OPTS := $(CMAKE_COMMON) -DCMAKE_BUILD_TYPE=Release -DTHREADSAFE=ON
 ifeq ($(OS),WINNT)
 LIBGIT2_OPTS += -DWIN32=ON -DMINGW=ON
 ifneq ($(ARCH),x86_64)
+ifneq ($(USECLANG),1)
 LIBGIT2_OPTS += -DCMAKE_C_FLAGS="-mincoming-stack-boundary=2"
+endif
 endif
 ifeq ($(BUILD_OS),WINNT)
 LIBGIT2_OPTS += -G"MSYS Makefiles"

--- a/src/support/ENTRY.i387.h
+++ b/src/support/ENTRY.i387.h
@@ -59,7 +59,7 @@ EXT(CNAME):
 _START_ENTRY
 .globl EXT(CNAME)
 .section .drectve
-.ascii " -export:" XSTR(CNAME)
+.ascii " -export:", XSTR(CNAME)
 .section .text
 .def EXT(CNAME)
 .scl 2


### PR DESCRIPTION
Clang doesn't support `mincoming-stack-boundary`. I would assume that's ok as long as everything is built with clang. If it comes up as a problem I'll look for a way to achieve the same result.
