### PR TITLE
Add do-block support for redirect_std[out,err,in]

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3937,14 +3937,6 @@ Convert `x` from degrees to radians.
 deg2rad
 
 """
-    redirect_stdin([stream])
-
-Like redirect_stdout, but for STDIN. Note that the order of the return tuple is still
-(rd,wr), i.e. data to be read from STDIN, may be written to wr.
-"""
-redirect_stdin
-
-"""
     mktemp([parent=tempdir()])
 
 Returns `(path, io)`, where `path` is the path of a new temporary file in `parent` and `io`
@@ -5195,13 +5187,6 @@ secd
 The result of an expression is too large for the specified type and will cause a wraparound.
 """
 OverflowError
-
-"""
-    redirect_stderr([stream])
-
-Like `redirect_stdout`, but for `STDERR`.
-"""
-redirect_stderr
 
 """
     ctranspose!(dest,src)
@@ -6758,24 +6743,6 @@ General unescaping of traditional C and Unicode escape sequences. Reverse of
 [`escape_string`](:func:`escape_string`). See also [`unescape_string`](:func:`unescape_string`).
 """
 unescape_string(s)
-
-"""
-    redirect_stdout()
-
-Create a pipe to which all C and Julia level `STDOUT` output will be redirected. Returns a
-tuple `(rd,wr)` representing the pipe ends. Data written to `STDOUT` may now be read from
-the rd end of the pipe. The wr end is given for convenience in case the old `STDOUT` object
-was cached by the user and needs to be replaced elsewhere.
-"""
-redirect_stdout
-
-"""
-    redirect_stdout(stream)
-
-Replace `STDOUT` by stream for all C and Julia level output to `STDOUT`. Note that `stream`
-must be a TTY, a `Pipe` or a `TCPSocket`.
-"""
-redirect_stdout(stream)
 
 """
     print_with_color(color::Symbol, [io], strings...)

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -350,17 +350,35 @@ General I/O
 
    Replace ``STDOUT`` by stream for all C and Julia level output to ``STDOUT``\ . Note that ``stream`` must be a TTY, a ``Pipe`` or a ``TCPSocket``\ .
 
+.. function:: redirect_stdout(f::Function, stream)
+
+   .. Docstring generated from Julia source
+
+   Run the function ``f`` while redirecting ``STDOUT`` to ``stream``\ . Upon completion, ``STDOUT`` is restored to its prior setting.
+
 .. function:: redirect_stderr([stream])
 
    .. Docstring generated from Julia source
 
    Like ``redirect_stdout``\ , but for ``STDERR``\ .
 
+.. function:: redirect_stderr(f::Function, stream)
+
+   .. Docstring generated from Julia source
+
+   Run the function ``f`` while redirecting ``STDERR`` to ``stream``\ . Upon completion, ``STDERR`` is restored to its prior setting.
+
 .. function:: redirect_stdin([stream])
 
    .. Docstring generated from Julia source
 
    Like redirect_stdout, but for STDIN. Note that the order of the return tuple is still (rd,wr), i.e. data to be read from STDIN, may be written to wr.
+
+.. function:: redirect_stdin(f::Function, stream)
+
+   .. Docstring generated from Julia source
+
+   Run the function ``f`` while redirecting ``STDIN`` to ``stream``\ . Upon completion, ``STDIN`` is restored to its prior setting.
 
 .. function:: readchomp(x)
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -318,6 +318,32 @@ let oldout = STDOUT, olderr = STDERR
     end
 end
 
+let filename = tempname()
+    ret = open(filename, "w") do f
+        redirect_stdout(f) do
+            println("hello")
+            [1,3]
+        end
+    end
+    @test ret == [1,3]
+    @test chomp(readstring(filename)) == "hello"
+    ret = open(filename, "w") do f
+        redirect_stderr(f) do
+            warn("hello")
+            [2]
+        end
+    end
+    @test ret == [2]
+    @test contains(readstring(filename), "WARNING: hello")
+    ret = open(filename) do f
+        redirect_stdin(f) do
+            readline()
+        end
+    end
+    @test contains(ret, "WARNING: hello")
+    rm(filename)
+end
+
 # issue #12960
 type T12960 end
 let


### PR DESCRIPTION
In particular, these simplify the process of safely testing for warnings, as exhibited in the tests:

``` julia
open(filename, "w") do f
    redirect_stderr(f) do
        warn("hello")
    end
end
@test contains(readstring(filename), "WARNING: hello")
```

I assume this counts as a new feature and can't be backported? If so, perhaps I will add this to Compat. (If not, please add the "backport-pending" label.)
