### PR TITLE
add isimmutabletype

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -210,6 +210,8 @@ Library improvements
 
   * New `iszero(x)` function to quickly check whether `x` is zero (or is all zeros, for an array) ([#19950]).
 
+  * New function `isimmutabletype(T)` ([#18168]).
+
   * `notify` now returns a count of tasks woken up ([#19841]).
 
 Compiler/Runtime improvements
@@ -883,6 +885,7 @@ Language tooling improvements
 [#17758]: https://github.com/JuliaLang/julia/issues/17758
 [#17785]: https://github.com/JuliaLang/julia/issues/17785
 [#18050]: https://github.com/JuliaLang/julia/issues/18050
+[#18168]: https://github.com/JuliaLang/julia/issues/18168
 [#18330]: https://github.com/JuliaLang/julia/issues/18330
 [#18339]: https://github.com/JuliaLang/julia/issues/18339
 [#18346]: https://github.com/JuliaLang/julia/issues/18346
@@ -919,4 +922,5 @@ Language tooling improvements
 [#19919]: https://github.com/JuliaLang/julia/issues/19919
 [#19944]: https://github.com/JuliaLang/julia/issues/19944
 [#19950]: https://github.com/JuliaLang/julia/issues/19950
+[#20079]: https://github.com/JuliaLang/julia/issues/20079
 [#20164]: https://github.com/JuliaLang/julia/issues/20164

--- a/NEWS.md
+++ b/NEWS.md
@@ -130,6 +130,9 @@ This section lists changes that do not have deprecation warnings.
     (since it is shorthand for `NTuple{N,T} where T`). To get the old behavior of matching
     any tuple, use `NTuple{N,Any}` ([#18457]).
 
+  * `isimmutable(T::Type)` now checks whether `T` is an immutable type,
+    rather than checking whether `typeof(T)` is an immutable type ([#18168]).
+
 Library improvements
 --------------------
 
@@ -209,8 +212,6 @@ Library improvements
     either universally or on a per-module/function basis ([#16213]).
 
   * New `iszero(x)` function to quickly check whether `x` is zero (or is all zeros, for an array) ([#19950]).
-
-  * New function `isimmutabletype(T)` ([#18168]).
 
   * `notify` now returns a count of tasks woken up ([#19841]).
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -946,6 +946,7 @@ export
     isbits,
     isequal,
     isimmutable,
+    isimmutabletype,
     isless,
     ifelse,
     lexless,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -946,7 +946,6 @@ export
     isbits,
     isequal,
     isimmutable,
-    isimmutabletype,
     isless,
     ifelse,
     lexless,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -206,6 +206,15 @@ isstructtype(t::DataType) = (@_pure_meta; nfields(t) != 0 || (t.size==0 && !t.ab
 isstructtype(x) = (@_pure_meta; false)
 
 """
+    isimmutabletype(T)
+
+Return `true` if the type `T` is immutable.  See [manual](:ref:`man-immutable-composite-types`)
+for a discussion of immutability.   See also [`isimmutable`](:func:`isimmutable`)
+for the corresponding function acting on values rather than types.
+"""
+isimmutabletype(t::ANY) = (@_pure_meta; isa(t, DataType) && !t.mutable)
+
+"""
     isbits(T)
 
 Return `true` if `T` is a "plain data" type, meaning it is immutable and contains no

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -195,24 +195,17 @@ datatype_fielddesc_type(dt::DataType) = dt.layout == C_NULL ? throw(UndefRefErro
     (unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).alignment >> 30) & 3
 
 """
-    isimmutable(v)
+    isimmutable(x)
 
-Return `true` iff value `v` is immutable.  See [Immutable Composite Types](@ref)
-for a discussion of immutability. Note that this function works on values, so if you give it
-a type, it will tell you that a value of `DataType` is mutable.
+Return `true` if the value `x` is immutable; if `x` is a type, then returns
+whether `x` is an immutable type.  See [Immutable Composite Types](@ref)
+for a discussion of immutability.
 """
 isimmutable(x::ANY) = (@_pure_meta; (isa(x,Tuple) || !typeof(x).mutable))
+isimmutable(t::DataType) = (@_pure_meta; !t.mutable)
+isimmutable(::Type) = (@_pure_meta; false)
 isstructtype(t::DataType) = (@_pure_meta; nfields(t) != 0 || (t.size==0 && !t.abstract))
 isstructtype(x) = (@_pure_meta; false)
-
-"""
-    isimmutabletype(T)
-
-Return `true` if the type `T` is immutable.  See [manual](:ref:`man-immutable-composite-types`)
-for a discussion of immutability.   See also [`isimmutable`](:func:`isimmutable`)
-for the corresponding function acting on values rather than types.
-"""
-isimmutabletype(t::ANY) = (@_pure_meta; isa(t, DataType) && !t.mutable)
 
 """
     isbits(T)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -159,12 +159,14 @@ not_const = 1
 
 @test isimmutable(1) == true
 @test isimmutable([]) == false
-@test isimmutable("abc") == true
 @test isimmutable((3,4,5)) == true
 @test isimmutable(Int) == true
 @test isimmutable(Vector{Int}) == false
-@test isimmutable(String) == true
 @test isimmutable(Tuple{Int}) == true
+
+# should String in 0.6 be immutable?
+@test_broken isimmutable("abc") == true
+@test_broken isimmutable(String) == true
 
 
 ## find bindings tests

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -161,10 +161,10 @@ not_const = 1
 @test isimmutable([]) == false
 @test isimmutable("abc") == true
 @test isimmutable((3,4,5)) == true
-@test isimmutabletype(Int) == true
-@test isimmutabletype(Vector{Int}) == false
-@test isimmutabletype(String) == true
-@test isimmutabletype(Tuple{Int}) == true
+@test isimmutable(Int) == true
+@test isimmutable(Vector{Int}) == false
+@test isimmutable(String) == true
+@test isimmutable(Tuple{Int}) == true
 
 
 ## find bindings tests

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -159,6 +159,13 @@ not_const = 1
 
 @test isimmutable(1) == true
 @test isimmutable([]) == false
+@test isimmutable("abc") == true
+@test isimmutable((3,4,5)) == true
+@test isimmutabletype(Int) == true
+@test isimmutabletype(Vector{Int}) == false
+@test isimmutabletype(String) == true
+@test isimmutabletype(Tuple{Int}) == true
+
 
 ## find bindings tests
 @test ccall(:jl_get_module_of_binding, Any, (Any, Any), Base, :sin)==Base


### PR DESCRIPTION
As discussed [on julia-users recently](https://groups.google.com/d/msg/julia-users/2hlzYxy4yIE/b9DyvKDXBgAJ), there is an `isimmutable` function to check whether a _value_ is immutable, but nothing to check whether a _type_ is immutable, which forces you to look in the internal `mutable` field of a type.  This PR adds an `isimmutabletype` function to fill this gap.

It also inlines some documentation, and removes an obsolete special-case for `Tuple` from the `isimmutable` function.
