### PR TITLE
ASAN: disable leak detection for flisp.

### DIFF
--- a/src/flisp/flmain.c
+++ b/src/flisp/flmain.c
@@ -8,6 +8,14 @@
 extern "C" {
 #endif
 
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+const char* __asan_default_options() {
+    return "detect_leaks=0";
+}
+#endif
+#endif
+
 static value_t argv_list(fl_context_t *fl_ctx, int argc, char *argv[])
 {
     int i;

--- a/src/init.c
+++ b/src/init.c
@@ -51,6 +51,7 @@ JL_DLLEXPORT const char* __asan_default_options() {
     return "allow_user_segv_handler=1:detect_leaks=0";
     // FIXME: enable LSAN after fixing leaks & defining __lsan_default_suppressions(),
     //        or defining __lsan_default_options = exitcode=0 once publicly available
+    //        (here and in flisp/flmain.c)
 }
 #endif
 


### PR DESCRIPTION
In line with #18067, makes the build & use of julia work out of the box. Proper solution of course is to fix any leaks and/or provide suppression.
