### PR TITLE
inline native Julia scalars encountered in f.(args...) AST

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -9,7 +9,7 @@
         ((string? e) (print-to-string e))
         ((eq? e #t) "true")
         ((eq? e #f) "false")
-        ((eq? (typeof e) 'julia_value)
+        ((or (eq? (typeof e) 'julia_value) (eq? (typeof e) 'julia_scalar_value))
          (let ((s (string e)))
            (if (string.find s "#<julia: ")
                ;; successfully printed as a julia value

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -2398,6 +2398,7 @@ static void lisp_init(fl_context_t *fl_ctx, size_t initial_heapsize)
 #endif
 
     fl_ctx->jl_sym = symbol(fl_ctx, "julia_value");
+    fl_ctx->jl_scalar_sym = symbol(fl_ctx, "julia_scalar_value");
 
     fl_ctx->the_empty_vector = tagptr(alloc_words(fl_ctx, 1), TAG_VECTOR);
     vector_setsize(fl_ctx->the_empty_vector, 0);

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -476,6 +476,7 @@ struct _fl_context_t {
     value_t apply_func, apply_v, apply_e;
 
     value_t jl_sym;
+    value_t jl_scalar_sym;
     // persistent buffer (avoid repeated malloc/free)
     // for julia_extensions.c: normalize
     size_t jlbuflen;

--- a/src/flisp/print.c
+++ b/src/flisp/print.c
@@ -657,7 +657,7 @@ static void cvalue_printdata(fl_context_t *fl_ctx, ios_t *f, void *data,
 #endif
                 init = 1;
             }
-            if (jl_static_print != NULL && fl_ctx->jl_sym == type) {
+            if (jl_static_print != NULL && (fl_ctx->jl_sym == type || fl_ctx->jl_scalar_sym == type)) {
                 fl_ctx->HPOS += ios_printf(f, "#<julia: ");
                 fl_ctx->HPOS += jl_static_print(f, *(void**)data);
                 fl_ctx->HPOS += ios_printf(f, ">");

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1679,7 +1679,8 @@
                                 new-fargs new-args (cons (cons (cadr farg) (cadr varfarg)) renames)
                                 varfarg vararg)
                             (error "multiple splatted args cannot be fused into a single broadcast"))))
-                   ((number? arg) ; inline numeric literals
+                   ((or (number? arg) ; inline numeric literals
+                        (eq? (typeof arg) 'julia_scalar_value)) ; & Julia scalars
                     (cf (cdr old-fargs) (cdr old-args)
                         new-fargs new-args
                         (cons (cons farg arg) renames)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -288,6 +288,8 @@ let identity = error, x = [1,2,3]
     x .= 1 # make sure it goes to broadcast!(Base.identity, ...), not identity
     @test x == [1,1,1]
 end
+# See issue #18176:
+@test ((a,b,c) -> a+b+c).(1.0:2, 3, 4) == ((a,b,c) -> a+b+c).(1.0:2, 3.0, 4.0) == [8,9]
 
 # PR 16988
 @test Base.promote_op(+, Bool) === Int


### PR DESCRIPTION
As an optimization, the "dot call" fusion does "inlining" of literal scalars, so that e.g. `f.(x,3)` turns into `broadcast(x -> f(x,3), x)` rather than `broadcast(f, x, 3)`.  This PR expands the range of scalars that are inlined to include Julia `Number` objects in the AST (and could do the same for `String` and some other types once #16966 is fixed … since it is just an optimization, it is okay if we aren't exhaustive).

(As was observed in #18176, the parser actually ends up converting things like floating-point literals into Julia objects in the AST, so without this optimization they aren't inlined.)
