### PR TITLE
inline native Julia scalars encountered in f.(args...) AST

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1679,7 +1679,7 @@
                                 new-fargs new-args (cons (cons (cadr farg) (cadr varfarg)) renames)
                                 varfarg vararg)
                             (error "multiple splatted args cannot be fused into a single broadcast"))))
-                   ((number? arg) ; inline numeric literals
+                   ((julia-scalar? arg) ; inline numeric literals etc.
                     (cf (cdr old-fargs) (cdr old-args)
                         new-fargs new-args
                         (cons (cons farg arg) renames)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -289,6 +289,13 @@ let identity = error, x = [1,2,3]
     @test x == [1,1,1]
 end
 
+# make sure scalars are inlined, which causes f.(x,scalar) to lower to a "thunk"
+import Base.Meta: isexpr
+@test isexpr(expand(:(f.(x,y))), :call)
+@test isexpr(expand(:(f.(x,1))), :thunk)
+@test isexpr(expand(:(f.(x,1.0))), :thunk)
+@test isexpr(expand(:(f.(x,$π))), :thunk)
+
 # PR 16988
 @test Base.promote_op(+, Bool) === Int
 @test isa(broadcast(+, [true]), Array{Int,1})


### PR DESCRIPTION
_This is an alternative version of #18202, following a suggestion by @JeffBezanson._

As an optimization, the "dot call" fusion does "inlining" of literal scalars, so that e.g. `f.(x,3)` turns into `broadcast(x -> f(x,3), x)` rather than `broadcast(f, x, 3)`.  This PR expands the range of scalars that are inlined to include Julia `Number` objects in the AST (and could do the same for `String` and some other types once #16966 is fixed … since it is just an optimization, it is okay if we aren't exhaustive).

(As was observed in #18176, the parser actually ends up converting things like floating-point literals into Julia objects in the AST, so without this optimization they aren't inlined.)
