### PR TITLE
RFC: Change fastmath to use dispatch instead of dictionary lookup

### DIFF
--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -144,6 +144,7 @@ end
 for T in (Complex64, Complex128, Complex{BigFloat})
     half = (1+1im)/T(2)
     third = (1-1im)/T(3)
+    println("$T")
 
     # some of these functions promote their result to double
     # precision, but we want to check equality at precision T
@@ -153,6 +154,7 @@ for T in (Complex64, Complex128, Complex{BigFloat})
               :acos, :acosh, :asin, :asinh, :atan, :atanh, :cis, :cos,
               :cosh, :exp10, :exp2, :exp, :expm1, :log10, :log1p,
               :log2, :log, :sin, :sinh, :sqrt, :tan, :tanh)
+
         @test isapprox((@eval @fastmath $f($half)), (@eval $f($half)), rtol=rtol)
         @test isapprox((@eval @fastmath $f($third)), (@eval $f($third)), rtol=rtol)
     end

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -4,11 +4,11 @@
 
 # check expansions
 
-@test macroexpand(:(@fastmath 1+2)) == :(Base.FastMath.add_fast(1,2))
-@test macroexpand(:(@fastmath +)) == :(Base.FastMath.add_fast)
-@test macroexpand(:(@fastmath min(1))) == :(Base.FastMath.min_fast(1))
-@test macroexpand(:(@fastmath min)) == :(Base.FastMath.min_fast)
-@test macroexpand(:(@fastmath x.min)) == :(x.min)
+@test macroexpand(:(@fastmath 1+2)) == :(Base.FastMath.fastmath(+)(1,2))
+@test macroexpand(:(@fastmath +)) == :(Base.FastMath.fastmath(+))
+@test macroexpand(:(@fastmath min(1))) == :(Base.FastMath.fastmath(min)(1))
+@test macroexpand(:(@fastmath min)) == :(Base.FastMath.fastmath(min))
+@test macroexpand(:(@fastmath x.min)) == :(Base.FastMath.fastmath(x.min))
 
 # basic arithmetic
 


### PR DESCRIPTION
This changes `@fastmath` to use dispatch instead of a dictionary lookup of symbols: this avoids problems whereby a user could use the symbol for another purpose locally, e.g.

``` julia
sin = 2.0
@fastmath  1.0 + sin
```

It is also easily extensible:

``` julia
Base.FastMath.fastmath(::typeof(foo)) = fast_foo
```

will define `fast_foo` as a fast version of `foo` (perhaps a macro would be a good idea here)

cc @eschnett 
