### PR TITLE
Add get(coll, key) for Associative returning Nullable

### DIFF
--- a/base/collections.jl
+++ b/base/collections.jl
@@ -323,6 +323,11 @@ function get{K,V}(pq::PriorityQueue{K,V}, key, deflt)
     i == 0 ? deflt : pq.xs[i].second
 end
 
+function get{K,V}(pq::PriorityQueue{K,V}, key)
+    i = get(pq.index, key, 0)
+    i == 0 ? Nullable{V}() : Nullable{V}(pq.xs[i].second)
+end
+
 
 # Change the priority of an existing element, or equeue it if it isn't present.
 function setindex!{K,V}(pq::PriorityQueue{K, V}, value, key)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -4015,6 +4015,14 @@ end
 get
 
 """
+    get(collection, key) -> Nullable
+
+Return the value stored for the given key as `Nullable(value)`,
+or if no mapping for the key is present, return null.
+"""
+get(collection, key)
+
+"""
     .!=(x, y)
     .≠(x,y)
 

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -40,6 +40,7 @@ end
 
 get{K}(wkh::WeakKeyDict{K}, key, default) = lock(() -> get(wkh.ht, key, default), wkh)
 get{K}(default::Callable, wkh::WeakKeyDict{K}, key) = lock(() -> get(default, wkh.ht, key), wkh)
+get{K}(wkh::WeakKeyDict{K}, key) = lock(() -> get(wkh.ht, key), wkh)
 get!{K}(wkh::WeakKeyDict{K}, key, default) = lock(() -> get!(wkh.ht, key, default), wkh)
 get!{K}(default::Callable, wkh::WeakKeyDict{K}, key) = lock(() -> get!(default, wkh.ht, key), wkh)
 pop!{K}(wkh::WeakKeyDict{K}, key) = lock(() -> pop!(wkh.ht, key), wkh)

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -987,6 +987,12 @@ Given a dictionary ``D``, the syntax ``D[x]`` returns the value of key ``x`` (if
 
    Determine whether a collection has a mapping for a given key.
 
+.. function:: get(collection, key) -> Nullable
+
+   .. Docstring generated from Julia source
+
+   Return the value stored for the given key as ``Nullable(value)``\ , or if no mapping for the key is present, return null.
+
 .. function:: get(collection, key, default)
 
    .. Docstring generated from Julia source

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -256,6 +256,10 @@ let f(x) = x^2, d = Dict(8=>19)
         f(4)
     end == 16
 
+    # get (returning Nullable)
+    @test get(get(d, 8)) == 19
+    @test isnull(get(d, 13))
+
     @test d == Dict(8=>19, 19=>2, 42=>4)
 end
 
@@ -448,6 +452,10 @@ let d = ImmutableDict{String, String}(),
     @test in(k2 => 1.0, dnum, is)
     @test !in(k2 => 1, dnum, <)
     @test in(k2 => 0, dnum, <)
+    @test get(d1, "key1") === Nullable{String}(v1)
+    @test get(d4, "key1") === Nullable{String}(v2)
+    @test get(d4, "foo") === Nullable{String}()
+    @test get(d, k1) === Nullable{String}()
     @test get(d1, "key1", :default) === v1
     @test get(d4, "key1", :default) === v2
     @test get(d4, "foo", :default) === :default

--- a/test/priorityqueue.jl
+++ b/test/priorityqueue.jl
@@ -107,3 +107,21 @@ for priority in values(priorities)
     heappush!(xs, priority)
 end
 @test issorted([heappop!(xs) for _ in length(priorities)])
+
+
+# test length, in, haskey, get
+let
+    pq = PriorityQueue(Dict(
+        i => i+5 for i in 1:5
+    ))
+    @test length(pq) == 5
+
+    for i in 1:5
+        @test haskey(pq, i)
+        @test (i=>i+5) in pq
+        @test get(pq, i, 0) == i + 5
+        @test get(get(pq, i)) == i+5
+    end
+    @test get(pq, 10, 0) == 0
+    @test isnull(get(pq, 10))
+end


### PR DESCRIPTION
This returns a Nullable value corresponding to the key (or null).
Includes specialization for dictionaries.
Fixes #13055
