### PR TITLE
Move specialized isequal definitions to avoid hitting #265

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -461,12 +461,11 @@ end
 
 @deprecate ==(x::Char, y::Integer) UInt32(x) == y
 @deprecate ==(x::Integer, y::Char) x == UInt32(y)
+# Note: when these deprecations are deleted, the specialized definitions isequal(x::Char, y::Integer)
+# and isequal(x::Integer, y::Char) in operators.jl can be deleted, too
 @deprecate isless(x::Char, y::Integer) UInt32(x) < y
 @deprecate isless(x::Integer, y::Char) x < UInt32(y)
 
-# delete these methods along with deprecations:
-isequal(x::Char, y::Integer) = false
-isequal(x::Integer, y::Char) = false
 
 #6674 and #4233
 macro windows(qm,ex)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -15,6 +15,11 @@ supertype(T::DataType) = T.super
 ==(x, y) = x === y
 isequal(x, y) = x == y
 
+# TODO: these can be deleted once the deprecations of ==(x::Char, y::Integer) and
+# ==(x::Integer, y::Char) are gone and the above returns false anyway
+isequal(x::Char, y::Integer) = false
+isequal(x::Integer, y::Char) = false
+
 ## minimally-invasive changes to test == causing NotComparableError
 # export NotComparableError
 # =={T}(x::T, y::T) = x === y


### PR DESCRIPTION
Fixes #18213.

How can I test that something does not give a deprecation warning?
