### PR TITLE
RFC hide func args in backtrace by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@ New language features
 Language changes
 ----------------
 
+ * Function definition arguments are now by default hidden in the backtrace of error messages in the REPL.
+   To re enable this, you can add `ENV["JULIA_ARGS_BACKTRACE"] = ""` to your `.juliarc` file.
+
 Breaking changes
 ----------------
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1008,8 +1008,10 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     nothing
 end
 
+# print a method signature tuple for a lambda definition
+# if ::hide_args_in_signature is true for the io the
+# arguments in the signatures will not be printed
 function show_lambda_types(io::IO, li::LambdaInfo)
-    # print a method signature tuple for a lambda definition
     if li.specTypes === Tuple
         print(io, li.def.name, "(...)")
         return
@@ -1027,14 +1029,16 @@ function show_lambda_types(io::IO, li::LambdaInfo)
     else
         print(io, "(::", ft, ")")
     end
-    first = true
-    print(io, '(')
-    for i = 2:length(sig)  # fixme (iter): `eachindex` with offset?
-        first || print(io, ", ")
-        first = false
-        print(io, "::", sig[i])
+    if !get(io, :hide_args_in_signature, false)
+        first = true
+        print(io, '(')
+        for i = 2:length(sig)  # fixme (iter): `eachindex` with offset?
+            first || print(io, ", ")
+            first = false
+            print(io, "::", sig[i])
+        end
+        print(io, ')')
     end
-    print(io, ')')
     nothing
 end
 

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -304,3 +304,13 @@ informational messages in cyan you can add the following to your ``juliarc.jl`` 
 
     ENV["JULIA_WARN_COLOR"] = :yellow
     ENV["JULIA_INFO_COLOR"] = :cyan
+
+Customizing Error Messages
+--------------------------
+
+By default Julia will not show the arguments for the functions in a backtrace since this can lead to quite large error messages.
+It is possible to activate this by adding the following to your ``juliarc.jl`` file::
+
+    ENV["JULIA_ARGS_BACKTRACE"] = ""
+
+The last error message showed in the REPL can be showed again with `Base.REPL.show_lasterror()`.


### PR DESCRIPTION
Function definition arguments in the backtrace often leads to large backtraces that might fill the whole REPL window.

This commit makes them hidden by default but adds a check for an enviromental variable "JULIA_ARGS_BACKTRACE" and shows them in case that is found.

It also adds an unexported function `Base.REPL.show_lasterror()` that reshows the last error the REPL showed.

An example with the following code:

``` jl
    type ThisisALongTypeThatWeMightNotWantToSee end
    typealias TL ThisisALongTypeThatWeMightNotWantToSee

    @noinline ff(x) = (a = rand(5); a[6])
    @noinline function g(a::TL, b::TL, c, d::Float64, e::Float64, f::TL, n)
        if n == 0
            return ff(2)
        else
            g(a, b, c, d, e, f, n-1)
        end
        return 0
    end

    @noinline h(x) = g(TL(), TL(), 2, 1.0, 2.0, TL(), 4)


    function test_it(args...)
        h(2.0)
    end

   test_it()
```

![image](https://cloud.githubusercontent.com/assets/1282691/17929084/7447261e-69fe-11e6-935a-3f5b11073354.png)

Ref #18068

Would be interesting to hear your opinions. If you think it is a crap change, say so :) I can take it.
