### PR TITLE
lufact for sparse matrix pivot option error

### DIFF
--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -157,7 +157,7 @@ lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}
     "sparse floating point LU using UMFPACK or lufact(full(A)) for generic ",
     "dense LU.")))
 lufact(A::SparseMatrixCSC) = lufact(float(A))
-lufact(A::SparseMatrixCSC, pivot::Type{Val{false}}) = lufact(A)
+lufact(A::SparseMatrixCSC, pivot::Type{Val{true}}) = lufact(A)
 
 
 size(F::UmfpackLU) = (F.m, F.n)

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -157,7 +157,6 @@ lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}
     "sparse floating point LU using UMFPACK or lufact(full(A)) for generic ",
     "dense LU.")))
 lufact(A::SparseMatrixCSC) = lufact(float(A))
-lufact(A::SparseMatrixCSC, pivot::Type{Val{true}}) = lufact(A)
 
 
 size(F::UmfpackLU) = (F.m, F.n)

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -140,8 +140,8 @@ end
 
 #18246,18244-lufact sparse pivot
 let
-  A = speye(4)
-  A[1:2,1:2] = [-.01 -200; 200 .001]
-  F = lufact(A,Val{true})
-  @test F[:p] == [3 ; 4 ; 2 ; 1]
+    A = speye(4)
+    A[1:2,1:2] = [-.01 -200; 200 .001]
+    F = lufact(A,Val{true})
+    @test F[:p] == [3 ; 4 ; 2 ; 1]
 end

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -137,3 +137,11 @@ let
     aa = complex(a)
     @test_throws ArgumentError Base.SparseArrays.UMFPACK.solve!(aa, lufact(complex(speye(5,5))), aa, Base.SparseArrays.UMFPACK.UMFPACK_A)
 end
+
+#18246,18244-lufact sparse pivot
+let
+  A = speye(4)
+  A[1:2,1:2] = [-.01 -200; 200 .001]
+  F = lufact(A,Val{true})
+  @test F[:p] == [3 ; 4 ; 2 ; 1]
+end

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -142,6 +142,6 @@ end
 let
     A = speye(4)
     A[1:2,1:2] = [-.01 -200; 200 .001]
-    F = lufact(A,Val{true})
+    F = lufact(A)
     @test F[:p] == [3 ; 4 ; 2 ; 1]
 end


### PR DESCRIPTION
base/sparse/umfpack.jl includes the following method definition for lufact

`lufact(A::SparseMatrixCSC, pivot::Type{Val{false}}) = lufact(A)`

which should be

`lufact(A::SparseMatrixCSC, pivot::Type{Val{true}}) = lufact(A)`

because in lufact pivoting is on by default.

The error is shown in the following example

```
A = speye(4)
A[1:2,1:2] = [-.01 -200; 200 .001]
F = lufact(A,Val{false})
F[:p]
```

which returns

```
julia> F[:q]
4-element Array{Int64,1}:
 3
 4
 1
 2
```

However it should return

```
julia> F[:q]
4-element Array{Int64,1}:
1
2
3
4
```

because pivoting was turned off.
