### PR TITLE
Clean up redirect_* APIs after Pipe -> PipeEndpoint rename

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -76,7 +76,8 @@ tse_str = sprint(show, Test.TestSetException(1,2,3,4))
 
 OLD_STDOUT = STDOUT
 catch_out = IOStream("")
-rd, wr = redirect_stdout()
+# Capture a reference to make sure the read end doesn't get closed
+pipe = redirect_stdout()
 
 # Check that the fallback test set throws immediately
 @test_throws ErrorException (@test 1 == 2)


### PR DESCRIPTION
These probably should have been cleaned up along side that in #12739.
Certainly the documentation was out of date, since it referred to `Pipe`,
but meant what is now called `PipeEndpoint`. Clean all of this up, by
allowing an unitinalized `Pipe` to be passed to these functions, and
also by replacing the tuple of `PipeEndpoint`s, by `Pipe`, since the
purpose of `Pipe` is precisely to hold two endpoints.
