### PR TITLE
Fix #18002: parse `typealias` args space-sensitive

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1218,11 +1218,8 @@
         (list 'bitstype (with-space-sensitive (parse-cond s))
               (parse-subtype-spec s)))
        ((typealias)
-        (let ((lhs (parse-call s)))
-          (if (and (pair? lhs) (eq? (car lhs) 'call))
-              ;; typealias X (...) is tuple type alias, not call
-              (list 'typealias (cadr lhs) (cons 'tuple (cddr lhs)))
-              (list 'typealias lhs (parse-arrow s)))))
+        (let ((lhs (with-space-sensitive (parse-call s))))
+              (list 'typealias lhs (parse-arrow s))))
        ((try)
         (let ((try-block (if (memq (require-token s) '(catch finally))
                              '(block)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -818,3 +818,8 @@ type Type
 end
 end
 @test method_exists(Mod18756.Type, ())
+
+# issue 18002
+@test parse("typealias a (Int)") == Expr(:typealias, :a, :Int)
+@test parse("typealias b (Int,)") == Expr(:typealias, :b, Expr(:tuple, :Int))
+@test parse("typealias Foo{T} Bar{T}") == Expr(:typealias, Expr(:curly, :Foo, :T), Expr(:curly, :Bar, :T))


### PR DESCRIPTION
Also removes hack for the old space-optional call syntax.
