### PR TITLE
Small build system modifications to make ppc64le compileable

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -600,27 +600,6 @@ $(error Pre-SSE2 CPU targets not supported. To create a generic 32-bit x86 binar
 pass 'MARCH=pentium4'.)
 endif
 
-ifneq ($(MARCH),)
-CC += -march=$(MARCH)
-CXX += -march=$(MARCH)
-FC += -march=$(MARCH)
-JULIA_CPU_TARGET ?= $(MARCH)
-ifeq ($(OS),Darwin)
-# on Darwin, the standalone `as` program doesn't know
-# how to handle AVX instructions, but it does know how
-# to dispatch to the clang assembler (if we ask it to)
-ifeq ($(USECLANG),1)
-CC += -integrated-as
-CXX += -integrated-as
-else
-CC += -Wa,-q
-CXX += -Wa,-q
-endif
-FC += -Wa,-q
-AS += -q
-endif
-endif
-
 JULIA_CPU_TARGET ?= native
 
 # We map amd64 to x86_64 for compatibility with systems that identify 64-bit systems as such
@@ -652,12 +631,13 @@ ISX86:=0
 endif
 
 # If we are running on powerpc64 or ppc64, set certain options automatically
-ifneq (,$(filter $(ARCH), powerpc64 ppc64le))
+ifneq (,$(filter $(ARCH), powerpc64 powerpc64le ppc64 ppc64le))
 JCFLAGS += -fsigned-char
 override LLVM_VER:=3.8.1
 override OPENBLAS_DYNAMIC_ARCH:=0
 override OPENBLAS_TARGET_ARCH:=POWER8
-
+# GCC doesn't do -march= on ppc64le
+override MARCH=
 endif
 
 # If we are running on ARM, set certain options automatically
@@ -669,7 +649,28 @@ override USE_BLAS64:=0
 override OPENBLAS_DYNAMIC_ARCH:=0
 override OPENBLAS_TARGET_ARCH:=ARMV7
 override USE_SYSTEM_LIBM:=1
+endif
 
+# Set MARCH-specific flags
+ifneq ($(MARCH),)
+CC += -march=$(MARCH)
+CXX += -march=$(MARCH)
+FC += -march=$(MARCH)
+JULIA_CPU_TARGET ?= $(MARCH)
+ifeq ($(OS),Darwin)
+# on Darwin, the standalone `as` program doesn't know
+# how to handle AVX instructions, but it does know how
+# to dispatch to the clang assembler (if we ask it to)
+ifeq ($(USECLANG),1)
+CC += -integrated-as
+CXX += -integrated-as
+else
+CC += -Wa,-q
+CXX += -Wa,-q
+endif
+FC += -Wa,-q
+AS += -q
+endif
 endif
 
 # Set some ARCH-specific flags

--- a/Make.inc
+++ b/Make.inc
@@ -630,14 +630,19 @@ else
 ISX86:=0
 endif
 
-# If we are running on powerpc64 or ppc64, set certain options automatically
-ifneq (,$(filter $(ARCH), powerpc64 powerpc64le ppc64 ppc64le))
+# If we are running on powerpc64le or ppc64le, set certain options automatically
+ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
 JCFLAGS += -fsigned-char
 override LLVM_VER:=3.8.1
 override OPENBLAS_DYNAMIC_ARCH:=0
 override OPENBLAS_TARGET_ARCH:=POWER8
 # GCC doesn't do -march= on ppc64le
 override MARCH=
+endif
+
+# If we are running on powerpc64 or ppc64, fail out dramatically
+ifneq (,$(filter $(ARCH), powerpc64 ppc64))
+$(error Big-endian PPC64 is not supported, to ignore this error, set ARCH=ppc64le)
 endif
 
 # If we are running on ARM, set certain options automatically

--- a/src/threading.c
+++ b/src/threading.c
@@ -137,7 +137,7 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
 // The general solution is to add one more indirection in the C entry point
 // (see `jl_get_ptls_states_wrapper`).
 //
-// When `ifunc` is availabe, we can use it to trick the linker to use the
+// When `ifunc` is available, we can use it to trick the linker to use the
 // real address (`jl_get_ptls_states_static`) directly as the symbol address.
 // (see `jl_get_ptls_states_resolve`).
 //
@@ -145,8 +145,7 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
 // is not guaranteed to be reliable, we still need to fallback to the wrapper
 // version as the symbol address if we didn't find the static version in `ifunc`.
 #if defined(__GLIBC__) && (defined(_CPU_X86_64_) || defined(_CPU_X86_) || \
-                           ((defined(_CPU_AARCH64_) || defined(_CPU_ARM_) || \
-                             defined(_CPU_PPC64_) || defined(_CPU_PPC_)) && \
+                          ((defined(_CPU_AARCH64_) || defined(_CPU_ARM_)) && \
                             __GNUC__ >= 6))
 // Only enable this on architectures that are tested.
 // For example, GCC doesn't seem to support the `ifunc` attribute on power yet.


### PR DESCRIPTION
This changeset:
- Adds a few new aliases for `ppc64le`, as the names change from GCC version to GCC version.
- Moves the block in `Make.inc` that takes `MARCH` values and converts them to `CC` flags and moves it past the sections where we determine which `ARCH` we are building for.
- Disables `ifunc` on `PPC` completely, because to my knowledge it is not compatible with gcc.
