### PR TITLE
Type inference opt passes clean up

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1604,6 +1604,7 @@ function typeinf_ext(linfo::LambdaInfo)
             linfo.ssavaluetypes = code.ssavaluetypes
             linfo.pure = code.pure
             linfo.inlineable = code.inlineable
+            linfo.propagate_inbounds = code.propagate_inbounds
             ccall(:jl_set_lambda_rettype, Void, (Any, Any), linfo, code.rettype)
             if code.jlcall_api == 2
                 linfo.constval = code.constval
@@ -2587,7 +2588,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
 
     body = Expr(:block)
     body.args = ast
-    propagate_inbounds, _ = popmeta!(body, :propagate_inbounds)
+    propagate_inbounds = linfo.propagate_inbounds
 
     # see if each argument occurs only once in the body expression
     stmts = Any[]

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -101,6 +101,7 @@ jl_sym_t *meta_sym; jl_sym_t *compiler_temp_sym;
 jl_sym_t *inert_sym; jl_sym_t *vararg_sym;
 jl_sym_t *unused_sym; jl_sym_t *static_parameter_sym;
 jl_sym_t *polly_sym; jl_sym_t *inline_sym;
+jl_sym_t *propagate_inbounds_sym;
 
 typedef struct {
     int64_t a;
@@ -349,6 +350,8 @@ static void jl_lambda_info_set_ast(jl_lambda_info_t *li, jl_expr_t *ast)
                     li->pure = 1;
                 else if (ma == (jl_value_t*)inline_sym)
                     li->inlineable = 1;
+                else if (ma == (jl_value_t*)propagate_inbounds_sym)
+                    li->propagate_inbounds = 1;
                 else
                     jl_array_ptr_set(meta, ins++, ma);
             }
@@ -431,6 +434,7 @@ JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info_uninit(void)
     li->constval = NULL;
     li->pure = 0;
     li->inlineable = 0;
+    li->propagate_inbounds = 0;
     return li;
 }
 
@@ -544,6 +548,7 @@ static jl_lambda_info_t *jl_copy_lambda(jl_lambda_info_t *linfo)
     new_linfo->sparam_vals = linfo->sparam_vals;
     new_linfo->pure = linfo->pure;
     new_linfo->inlineable = linfo->inlineable;
+    new_linfo->propagate_inbounds = linfo->propagate_inbounds;
     new_linfo->nargs = linfo->nargs;
     new_linfo->isva = linfo->isva;
     new_linfo->rettype = linfo->rettype;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4498,18 +4498,13 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
         DebugLoc loc;
         StringRef file;
         ssize_t line;
-        bool enabled;
         bool is_inbounds;
         bool loc_changed;
         bool is_poploc;
     };
     std::vector<StmtProp> stmtprops(stmtslen);
     std::vector<DbgState> DI_stack;
-    std::vector<bool> boundsCheck_stack{false};
     std::vector<bool> inbounds_stack{false};
-    auto is_bounds_check_block = [&] () {
-        return !boundsCheck_stack.empty() && boundsCheck_stack.back();
-    };
     auto is_inbounds = [&] () {
         // inbounds rule is either of top two values on inbounds stack are true
         size_t sz = inbounds_stack.size();
@@ -4518,7 +4513,7 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
             inbounds |= inbounds_stack[sz - 2];
         return inbounds;
     };
-    StmtProp cur_prop{topdebugloc, filename, toplineno, true, false, true, false};
+    StmtProp cur_prop{topdebugloc, filename, toplineno, false, true, false};
     for (i = 0; i < stmtslen; i++) {
         cur_prop.loc_changed = false;
         cur_prop.is_poploc = false;
@@ -4628,64 +4623,26 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
         }
         if (expr) {
             jl_value_t **args = (jl_value_t**)jl_array_data(expr->args);
-            if (expr->head == boundscheck_sym) {
-                if (jl_array_len(expr->args) > 0) {
-                    jl_value_t *arg = args[0];
-                    if (arg == jl_true) {
-                        boundsCheck_stack.push_back(true);
-                    }
-                    else if (arg == jl_false) {
-                        boundsCheck_stack.push_back(false);
-                    }
-                    else {
-                        if (!boundsCheck_stack.empty()) {
-                            boundsCheck_stack.pop_back();
-                        }
-                    }
-                }
-            }
-            else if (cur_prop.enabled && expr->head == inbounds_sym) {
+            if (expr->head == inbounds_sym) {
                 // manipulate inbounds stack
-                // note that when entering an inbounds context, we must also update
-                // the boundsCheck context to be false
                 if (jl_array_len(expr->args) > 0) {
                     jl_value_t *arg = args[0];
                     if (arg == jl_true) {
                         inbounds_stack.push_back(true);
-                        boundsCheck_stack.push_back(false);
                     }
                     else if (arg == jl_false) {
                         inbounds_stack.push_back(false);
-                        boundsCheck_stack.push_back(false);
                     }
-                    else {
-                        if (!inbounds_stack.empty())
-                            inbounds_stack.pop_back();
-                        if (!boundsCheck_stack.empty())
-                            boundsCheck_stack.pop_back();
+                    else if (!inbounds_stack.empty()) {
+                        inbounds_stack.pop_back();
                     }
                 }
             }
         }
-        bool is_ib = is_inbounds();
-        if (is_ib && is_bounds_check_block() &&
-            jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_ON) {
-            // elide bounds check blocks in inbounds context
-            cur_prop.enabled = false;
-        }
-        else if (is_bounds_check_block() &&
-                 jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_OFF) {
-            // elide bounds check blocks when turned off by options
-            cur_prop.enabled = false;
-        }
-        else {
-            cur_prop.enabled = true;
-        }
-        cur_prop.is_inbounds = is_ib;
+        cur_prop.is_inbounds = is_inbounds();
         stmtprops[i] = cur_prop;
     }
     DI_stack.clear();
-    boundsCheck_stack.clear();
     inbounds_stack.clear();
 
     // step 12. Do codegen in control flow order
@@ -4772,7 +4729,7 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
             if (ctx.debug_enabled)
                 builder.SetCurrentDebugLocation(props.loc);
             // Disable coverage for pop_loc, it doesn't start a new expression
-            if (do_coverage && props.enabled && !props.is_poploc) {
+            if (do_coverage && !props.is_poploc) {
                 coverageVisitLine(props.file, props.line);
             }
         }
@@ -4783,10 +4740,6 @@ static std::unique_ptr<Module> emit_function(jl_lambda_info_t *lam, jl_llvm_func
             // Label node
             int lname = jl_labelnode_label(stmt);
             handle_label(lname, true);
-            continue;
-        }
-        if (!props.enabled) {
-            find_next_stmt(cursor + 1);
             continue;
         }
         if (expr && expr->head == return_sym) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -949,6 +949,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v)
         jl_serialize_value(s, (jl_value_t*)li->sparam_vals);
         write_int8(s->s, li->pure);
         write_int8(s->s, li->inlineable);
+        write_int8(s->s, li->propagate_inbounds);
         write_int8(s->s, li->isva);
         write_int32(s->s, li->nargs);
         jl_serialize_value(s, (jl_value_t*)li->def);
@@ -1616,6 +1617,7 @@ static jl_value_t *jl_deserialize_value_(jl_serializer_state *s, jl_value_t *vta
         li->unspecialized_ducttape = NULL;
         li->pure = read_int8(s->s);
         li->inlineable = read_int8(s->s);
+        li->propagate_inbounds = read_int8(s->s);
         li->isva = read_int8(s->s);
         li->nargs = read_int32(s->s);
         li->def = (jl_method_t*)jl_deserialize_value(s, (jl_value_t**)&li->def);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3880,7 +3880,7 @@ void jl_init_types(void)
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaInfo"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(24,
+                        jl_svec(25,
                                 jl_symbol("rettype"),
                                 jl_symbol("sparam_syms"),
                                 jl_symbol("sparam_vals"),
@@ -3898,13 +3898,14 @@ void jl_init_types(void)
                                 jl_symbol("inferred"),
                                 jl_symbol("pure"),
                                 jl_symbol("inlineable"),
+                                jl_symbol("propagate_inbounds"),
                                 jl_symbol("inInference"),
                                 jl_symbol("inCompile"),
                                 jl_symbol("jlcall_api"),
                                 jl_symbol(""),
                                 jl_symbol("fptr"),
                                 jl_symbol(""), jl_symbol("")),
-                        jl_svec(24,
+                        jl_svec(25,
                                 jl_any_type,
                                 jl_simplevector_type,
                                 jl_simplevector_type,
@@ -3918,6 +3919,7 @@ void jl_init_types(void)
                                 jl_method_type,
                                 jl_any_type,
                                 jl_int32_type,
+                                jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type,
@@ -3991,9 +3993,9 @@ void jl_init_types(void)
     jl_svecset(jl_methtable_type->types, 6, jl_int32_type); // DWORD
 #endif
     jl_svecset(jl_methtable_type->types, 7, jl_int32_type); // uint32_t
-    jl_svecset(jl_lambda_info_type->types, 21, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 22, jl_voidpointer_type);
     jl_svecset(jl_lambda_info_type->types, 23, jl_voidpointer_type);
+    jl_svecset(jl_lambda_info_type->types, 24, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);
@@ -4071,6 +4073,7 @@ void jl_init_types(void)
     compiler_temp_sym = jl_symbol("#temp#");
     polly_sym = jl_symbol("polly");
     inline_sym = jl_symbol("inline");
+    propagate_inbounds_sym = jl_symbol("propagate_inbounds");
 
     tttvar = jl_new_typevar(jl_symbol("T"),
                                   (jl_value_t*)jl_bottom_type,

--- a/src/julia.h
+++ b/src/julia.h
@@ -258,6 +258,7 @@ typedef struct _jl_lambda_info_t {
     int8_t inferred;
     int8_t pure;
     int8_t inlineable;
+    int8_t propagate_inbounds;
     int8_t inInference; // flags to tell if inference is running on this function
     int8_t inCompile; // flag to tell if codegen is running on this function
     int8_t jlcall_api; // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t, 2 = constval
@@ -555,36 +556,7 @@ extern JL_DLLEXPORT jl_value_t *jl_false;
 extern JL_DLLEXPORT jl_value_t *jl_nothing;
 
 // some important symbols
-extern jl_sym_t *call_sym;    extern jl_sym_t *invoke_sym;
-extern jl_sym_t *empty_sym;   extern jl_sym_t *body_sym;
-extern jl_sym_t *dots_sym;    extern jl_sym_t *vararg_sym;
-extern jl_sym_t *quote_sym;   extern jl_sym_t *newvar_sym;
-extern jl_sym_t *top_sym;     extern jl_sym_t *dot_sym;
-extern jl_sym_t *line_sym;    extern jl_sym_t *toplevel_sym;
-extern jl_sym_t *core_sym;    extern jl_sym_t *globalref_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_incomplete_sym;
-extern jl_sym_t *error_sym;   extern jl_sym_t *amp_sym;
-extern jl_sym_t *module_sym;  extern jl_sym_t *colons_sym;
-extern jl_sym_t *export_sym;  extern jl_sym_t *import_sym;
-extern jl_sym_t *importall_sym; extern jl_sym_t *using_sym;
-extern jl_sym_t *goto_sym;    extern jl_sym_t *goto_ifnot_sym;
-extern jl_sym_t *label_sym;   extern jl_sym_t *return_sym;
-extern jl_sym_t *lambda_sym;  extern jl_sym_t *assign_sym;
-extern jl_sym_t *method_sym;  extern jl_sym_t *slot_sym;
-extern jl_sym_t *enter_sym;   extern jl_sym_t *leave_sym;
-extern jl_sym_t *exc_sym;     extern jl_sym_t *new_sym;
-extern jl_sym_t *compiler_temp_sym;
-extern jl_sym_t *const_sym;   extern jl_sym_t *thunk_sym;
-extern jl_sym_t *anonymous_sym;  extern jl_sym_t *underscore_sym;
-extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
-extern jl_sym_t *compositetype_sym;
-extern jl_sym_t *global_sym; extern jl_sym_t *unused_sym;
-extern jl_sym_t *boundscheck_sym; extern jl_sym_t *inbounds_sym;
-extern jl_sym_t *copyast_sym; extern jl_sym_t *fastmath_sym;
-extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
-extern jl_sym_t *meta_sym; extern jl_sym_t *list_sym;
-extern jl_sym_t *inert_sym; extern jl_sym_t *static_parameter_sym;
-extern jl_sym_t *polly_sym; extern jl_sym_t *inline_sym;
 
 // gc -------------------------------------------------------------------------
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -766,6 +766,37 @@ JL_DLLEXPORT jl_array_t *jl_array_cconvert_cstring(jl_array_t *a);
 
 int isabspath(const char *in);
 
+extern jl_sym_t *call_sym;    extern jl_sym_t *invoke_sym;
+extern jl_sym_t *empty_sym;   extern jl_sym_t *body_sym;
+extern jl_sym_t *dots_sym;    extern jl_sym_t *vararg_sym;
+extern jl_sym_t *quote_sym;   extern jl_sym_t *newvar_sym;
+extern jl_sym_t *top_sym;     extern jl_sym_t *dot_sym;
+extern jl_sym_t *line_sym;    extern jl_sym_t *toplevel_sym;
+extern jl_sym_t *core_sym;    extern jl_sym_t *globalref_sym;
+extern jl_sym_t *error_sym;   extern jl_sym_t *amp_sym;
+extern jl_sym_t *module_sym;  extern jl_sym_t *colons_sym;
+extern jl_sym_t *export_sym;  extern jl_sym_t *import_sym;
+extern jl_sym_t *importall_sym; extern jl_sym_t *using_sym;
+extern jl_sym_t *goto_sym;    extern jl_sym_t *goto_ifnot_sym;
+extern jl_sym_t *label_sym;   extern jl_sym_t *return_sym;
+extern jl_sym_t *lambda_sym;  extern jl_sym_t *assign_sym;
+extern jl_sym_t *method_sym;  extern jl_sym_t *slot_sym;
+extern jl_sym_t *enter_sym;   extern jl_sym_t *leave_sym;
+extern jl_sym_t *exc_sym;     extern jl_sym_t *new_sym;
+extern jl_sym_t *compiler_temp_sym;
+extern jl_sym_t *const_sym;   extern jl_sym_t *thunk_sym;
+extern jl_sym_t *anonymous_sym;  extern jl_sym_t *underscore_sym;
+extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
+extern jl_sym_t *compositetype_sym;
+extern jl_sym_t *global_sym; extern jl_sym_t *unused_sym;
+extern jl_sym_t *boundscheck_sym; extern jl_sym_t *inbounds_sym;
+extern jl_sym_t *copyast_sym; extern jl_sym_t *fastmath_sym;
+extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
+extern jl_sym_t *meta_sym; extern jl_sym_t *list_sym;
+extern jl_sym_t *inert_sym; extern jl_sym_t *static_parameter_sym;
+extern jl_sym_t *polly_sym; extern jl_sym_t *inline_sym;
+extern jl_sym_t *propagate_inbounds_sym;
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -151,4 +151,27 @@ end
 
 @test B2() == 0
 
+# Make sure type inference doesn't incorrectly optimize out
+# `Expr(:inbounds, false)`
+# Simply `return a[1]` doesn't work due to inlining bug
+@inline function f1(a)
+    # This has to be an arrayget / arrayset since these currently have a
+    # implicit `Expr(:boundscheck)` that's not visible to type inference
+    x = a[1]
+    return x
+end
+# second level
+@inline function g1(a)
+    x = f1(a)
+    return x
+end
+function k1(a)
+    # This `Expr(:inbounds, true)` shouldn't affect `f1`
+    @inbounds x = g1(a)
+    return x
+end
+if bc_opt != bc_off
+    @test_throws BoundsError k1(Int[])
+end
+
 end


### PR DESCRIPTION
These are the parts that are not related to coverage from https://github.com/JuliaLang/julia/pull/18196. The changes included in the PR are,
- Make sure inlining cost model is insensitive to meta nodes and closer to the toplevel model in codegen.
- Fix the cases where the label number doesn't match the statement index
- Pop `propagate_inbounds` to `LambdaInfo`
- Clean up some void use of variable to help allocation elim pass
- Move handling of custom boundscheck elimination to type inference in order to reduce the AST size
- Fix incorrect deletion of `Expr(:inbounds, false)` (This increases the AST size by a little since some of the nodes were incorrectly deleted.)

Overall this shrink the rodata size by 1-2%.

The last commit is some debugging/verifying code and will be removed before merging.

@nanosoldier `runbenchmarks(ALL, vs = ":master")`
