### PR TITLE
Faster indices for SubArray

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -45,7 +45,7 @@ function mapfoldl_impl(f, op, v0, itr, i)
         (x, i) = next(itr, i)
         v = op(r_promote(op, v0), f(x))
         while !done(itr, i)
-            (x, i) = next(itr, i)
+            @inbounds (x, i) = next(itr, i)
             v = op(v, f(x))
         end
         return v

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -273,11 +273,20 @@ end
 # they are taken from the range/vector
 # Since bounds-checking is performance-critical and uses
 # indices, it's worth optimizing these implementations thoroughly
-indices(S::SubArray) = (@_inline_pure_meta; _indices_sub(S, indices(S.parent), S.indexes...))
+indices(S::SubArray) = (@_inline_meta; _indices_sub(S, indices(S.parent), S.indexes...))
 _indices_sub(S::SubArray, pinds) = ()
-_indices_sub(S::SubArray, pinds, ::Real, I...) = _indices_sub(S, tail(pinds), I...)
-_indices_sub(S::SubArray, pinds, ::Colon, I...) = (pinds[1], _indices_sub(S, tail(pinds), I...)...)
-_indices_sub(S::SubArray, pinds, i1::AbstractArray, I...) = (unsafe_indices(i1)..., _indices_sub(S, tail(pinds), I...)...)
+function _indices_sub(S::SubArray, pinds, ::Real, I...)
+    @_inline_meta
+    _indices_sub(S, tail(pinds), I...)
+end
+function _indices_sub(S::SubArray, pinds, ::Colon, I...)
+    @_inline_meta
+    (pinds[1], _indices_sub(S, tail(pinds), I...)...)
+end
+function _indices_sub(S::SubArray, pinds, i1::AbstractArray, I...)
+    @_inline_meta
+    (unsafe_indices(i1)..., _indices_sub(S, tail(pinds), I...)...)
+end
 
 ## Compatability
 # deprecate?


### PR DESCRIPTION
Master:

``` julia
julia> A = rand(101,101,101);

julia> S = view(A, 1:100, 1:100, 1:100);

# After warmup
julia> @time sum(S)
  1.382890 seconds (23.00 M allocations: 579.835 MB, 4.14% gc time)
499407.9573498594
```

This PR:

``` julia
julia> @time sum(S)
  0.001883 seconds (8 allocations: 288 bytes)
499439.6116757188
```

The important change is going with just `@inline` for `indices`; the extra `@inbounds` annotation is the dipping sauce for the main meal.

Kind of amazing I didn't notice this previously---perhaps the behavior of `@pure` changed? Let's see if this performance improvement is caught by our benchmarks: @nanosoldier `runbenchmarks(ALL, vs = ":master")`. If not, I'll write a new benchmark.
