### PR TITLE
Add a more efficient implementation of in(::CartesianIndex, ::CartesianRange)

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -3,7 +3,7 @@
 ### Multidimensional iterators
 module IteratorsMD
 
-import Base: eltype, length, size, start, done, next, last, getindex, setindex!, linearindexing, min, max, zero, one, isless, eachindex, ndims, iteratorsize
+import Base: eltype, length, size, start, done, next, last, in, getindex, setindex!, linearindexing, min, max, zero, one, isless, eachindex, ndims, iteratorsize
 importall ..Base.Operators
 import Base: simd_outer_range, simd_inner_length, simd_index
 using Base: LinearFast, LinearSlow, AbstractCartesianIndex, fill_to_length, tail
@@ -129,6 +129,12 @@ dimlength(start, stop) = stop-start+1
 length(iter::CartesianRange) = prod(size(iter))
 
 last(iter::CartesianRange) = iter.stop
+
+@inline function in{I<:CartesianIndex}(i::I, r::CartesianRange{I})
+    _in(true, i.I, r.start.I, r.stop.I)
+end
+_in(b, ::Tuple{}, ::Tuple{}, ::Tuple{}) = b
+@inline _in(b, i, start, stop) = _in(b & (start[1] <= i[1] <= stop[1]), tail(i), tail(start), tail(stop))
 
 simd_outer_range(iter::CartesianRange{CartesianIndex{0}}) = iter
 function simd_outer_range{I}(iter::CartesianRange{I})

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1327,6 +1327,14 @@ indexes = collect(R)
 @test length(indexes) == 12
 @test length(R) == 12
 @test ndims(R) == 2
+@test in(CartesianIndex((2,3)), R)
+@test in(CartesianIndex((3,3)), R)
+@test in(CartesianIndex((3,5)), R)
+@test in(CartesianIndex((5,5)), R)
+@test !in(CartesianIndex((1,3)), R)
+@test !in(CartesianIndex((3,2)), R)
+@test !in(CartesianIndex((3,6)), R)
+@test !in(CartesianIndex((6,5)), R)
 
 @test CartesianRange((3:5,-7:7)) == CartesianRange(CartesianIndex{2}(3,-7),CartesianIndex{2}(5,7))
 @test CartesianRange((3,-7:7)) == CartesianRange(CartesianIndex{2}(3,-7),CartesianIndex{2}(3,7))


### PR DESCRIPTION
Previously this fell back to the generic implementation, requiring iteration over every element in the CartesianRange.
