### PR TITLE
added n-loops and tuple argument ability to @threads

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -397,3 +397,28 @@ function test_load_and_lookup_18020(n)
     end
 end
 test_load_and_lookup_18020(10000)
+
+
+# make sure syntax is parsed correctly and all elements are visited once
+function test_thread_nloop(size)
+    a = zeros(size,size,size)
+    @threads for i=1:size, j=1:size, k=1:size
+        a[i,j,k] += 1
+    end
+    @test all(a.==1)
+end
+test_thread_nloop(10)
+
+
+# make sure syntax is parsed correctly and all elements are visited once
+function test_thread_tupleloop()
+    idxs = [(1,2),(3,4)]
+    a = zeros(5,5)
+    @threads for (i,j) = idxs
+        a[i,j] += 1
+    end
+    for i=1:5, j=1:5
+        @test a[i,j] == ((i,j) in idxs ? 1 : 0)
+    end
+end
+test_thread_tupleloop()


### PR DESCRIPTION
This lets you use `@threads` with n-loops, 

``` julia
a = zeros(5,5)
@threads for i=1:5, j=1:5
    a[i,j] = threadid()
end
a
5×5 Array{Float64,2}:
 1.0  6.0  3.0  8.0  5.0
 2.0  7.0  4.0  1.0  6.0
 3.0  8.0  5.0  2.0  7.0
 4.0  1.0  6.0  3.0  8.0
 5.0  2.0  7.0  4.0  1.0
```

and with tuple arguments, 

``` julia
a = zeros(5,5)
@threads for (i,j) in [(1,2),(3,4)]
    a[i,j] = threadid()
end
a
5×5 Array{Float64,2}:
 0.0  1.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  2.0  0.0
 0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0
```

(or with a mixture of both). 

Note from the first example that I changed the way the data is split among threads so that if `i` and `j` index an array, the threads move through the array in memory order so that caching is improved. 

Also, the old version declared the loop indices as `local` which I removed. To me it seems that if the user didn't do this, the `@threads` macro has no reason to do it for them. But please verify I haven't missed something (cc @ArchRobison who wrote that I believe). 

I think someone that knows Julia better than I could certainly improve my `ndi` function to make it faster, maybe move more of it to compile-time.

Anyway, this'll be my first contribution to the Julia language so please let me know if there's anything that needs fixing! Thanks. 
