### PR TITLE
Rename the FooBar type in test/core.jl

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -1019,20 +1019,20 @@ let
     @test_throws InexactError unsafe_wrap(Array, pointer(a), -3)
 end
 
-immutable FooBar
+immutable FooBar2515
     foo::Int
     bar::Int
 end
 let
     local X, p
-    X = FooBar[ FooBar(3,1), FooBar(4,4) ]
+    X = FooBar2515[ FooBar2515(3,1), FooBar2515(4,4) ]
     p = pointer(X)
-    @test unsafe_load(p) == FooBar(3,1)
-    @test unsafe_load(p, 2) == FooBar(4,4)
-    unsafe_store!(p, FooBar(8,4))
-    @test X[1] == FooBar(8,4)
-    unsafe_store!(p, FooBar(7,3), 1)
-    @test X[1] == FooBar(7,3)
+    @test unsafe_load(p) == FooBar2515(3,1)
+    @test unsafe_load(p, 2) == FooBar2515(4,4)
+    unsafe_store!(p, FooBar2515(8,4))
+    @test X[1] == FooBar2515(8,4)
+    unsafe_store!(p, FooBar2515(7,3), 1)
+    @test X[1] == FooBar2515(7,3)
 end
 
 # issue #1287, combinations of try, catch, return


### PR DESCRIPTION
so `JULIA_CPU_CORES=1 ./julia test/runtests.jl core compile` passes
after #18150
