### PR TITLE
Unrevert #18259

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -80,6 +80,8 @@ end
     return Char(c), i
 end
 
+# This implementation relies on `next` returning a value past the end of the
+# String's underlying data, which is true for valid Strings
 done(s::String, state) = state > endof(s.data)
 
 @inline function next(s::String, i::Int)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -80,6 +80,8 @@ end
     return Char(c), i
 end
 
+done(s::String, state) = state > endof(s.data)
+
 @inline function next(s::String, i::Int)
     # function is split into this critical fast-path
     # for pure ascii data, such as parsing numbers,

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -427,3 +427,9 @@ foobaz(ch) = reinterpret(Char, typemax(UInt32))
 
 # issue #17624, missing getindex method for String
 @test "abc"[:] == "abc"
+
+# issue #18280: next/nextind must return past String's underlying data
+for s in ("Hello", "Σ", "こんにちは", "😊😁")
+    @test next(s, endof(s))[2] > endof(s.data)
+    @test nextind(s, endof(s)) > endof(s.data)
+end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -427,7 +427,3 @@ foobaz(ch) = reinterpret(Char, typemax(UInt32))
 
 # issue #17624, missing getindex method for String
 @test "abc"[:] == "abc"
-
-# PR #18259 reverted because failing test below
-a = [x for x in String([0xcf, 0x83, 0x83, 0x83, 0x83])]
-@test a[1] == 'σ'


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/18081 again.

The implementation of `next` for `String` returns a value past the end of the `String`'s underlying data. Even in a black box, the only way for `next` to _not_ do this is to know the `String`'s last index somehow, so any implementation that does not return a value past the end of the `String`'s underlying data is necessarily non-optimal. Thus I think it's reasonable to make this assumption.

I threw out the test on `String([0xcf, 0x83, 0x83, 0x83, 0x83])` because the case where a `String` contains invalid UTF-8 is really not worth dealing with. These strings already cause iteration problems anyway. Yes, this string now does not `collect` properly—but it wasn't really working well to begin with; since `String([0xcf, 0x83, 0x83, 0x83, 0x83]) * "x"` did not collect properly even before this change.

cc @KristofferC, @tkelman 
