### PR TITLE
RFC: make `issorted` work with non-strict orders

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -49,7 +49,7 @@ function issorted(itr, order::Ordering)
     prev, state = next(itr, state)
     while !done(itr, state)
         this, state = next(itr, state)
-        lt(order, this, prev) && return false
+        lt(order, this, prev) && !lt(order, prev, this) && return false
         prev = this
     end
     return true

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -16,6 +16,9 @@ end
 @test_throws ArgumentError sortperm!(view([1,2,3,4], 1:4), [2,3,1])
 @test !issorted([2,3,1])
 @test issorted([1,2,3])
+@test issorted([1,1,2], lt=(<=))
+@test issorted([1,1,1], lt=(==))
+@test issorted([3,2,1], lt=(>))
 @test reverse([2,3,1]) == [1,3,2]
 @test select([3,6,30,1,9],3) == 6
 @test select([3,6,30,1,9],3:4) == [6,9]


### PR DESCRIPTION
Currently we get the following answers, which I find less than ideal:

```
julia> issorted([1,1,2], lt=(<=))
false

julia> issorted([1,1,1], lt=(==))
false
```

It might also be good to have a separate strict ordering check. Or, we could make `issorted` strict (checking that the relation holds for each pair of adjacent elements), so passing `<` checks for strict ordering and passing `<=` checks for non-strict ordering, but make the default `<=` (actually `isless || isequal`).
