### PR TITLE
RFC: add cache for Pkg.Read.available

### DIFF
--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -15,7 +15,7 @@ type AvailableCache
     pkgs::Dict{String, Dict{VersionNumber, Available}}
 end
 
-PKG_AVAILABLE_CACHE = AvailableCache("", Dict{VersionNumber,Available}())
+PKG_AVAILABLE_CACHE = AvailableCache("", Dict{String, Dict{VersionNumber, Available}}())
 
 function copypkg(old_pkg)
     new_pkg = Dict{String, Dict{VersionNumber, Available}}()

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -41,7 +41,7 @@ available(pkg::AbstractString) = get(available([pkg]),pkg,Dict{VersionNumber,Ava
 function available(cache::AvailableCache = PKG_AVAILABLE_CACHE)
     names = readdir("METADATA")
     # Not a git repo so just bail on using cache
-    if in(".git", names)
+    if in(".git", names) && !haskey(ENV, "JULIA_PKG_DISABLE_CACHE")
         pkgs, usecache = LibGit2.with(LibGit2.GitRepo("METADATA")) do repo
             LibGit2.with(LibGit2.head(repo)) do head
                 sha = Base.LibGit2.Oid(head)

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -17,14 +17,6 @@ end
 
 PKG_AVAILABLE_CACHE = AvailableCache(LibGit2.Oid(), Dict{String, Dict{VersionNumber, Available}}())
 
-function copypkg(old_pkg)
-    new_pkg = Dict{String, Dict{VersionNumber, Available}}()
-    for (k, v) in old_pkg
-        new_pkg[k] = copy(old_pkg[k])
-    end
-    return new_pkg
-end
-
 function available(names)
     pkgs = Dict{String,Dict{VersionNumber,Available}}()
     for pkg in names
@@ -64,8 +56,7 @@ function available(cache::AvailableCache = PKG_AVAILABLE_CACHE)
                             cache.pkgs = available(names)
                             cache.sha = sha
                         end
-                        # Copy because some functions that use this data mutate state, like Pkg.Query.requirements
-                        return copypkg(cache.pkgs), true
+                        return cache.pkgs, true
                     end
                     nothing, false
                 end

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -42,7 +42,7 @@ function available(cache::AvailableCache = PKG_AVAILABLE_CACHE)
     names = readdir("METADATA")
     # Not a git repo so just bail on using cache
     if in(".git", names)
-        pkg, usecache = LibGit2.with(LibGit2.GitRepo("METADATA")) do repo
+        pkgs, usecache = LibGit2.with(LibGit2.GitRepo("METADATA")) do repo
             LibGit2.with(LibGit2.head(repo)) do head
                 sha = Base.LibGit2.Oid(head)
                 # Only use cache if nothing funky is going on.
@@ -62,7 +62,7 @@ function available(cache::AvailableCache = PKG_AVAILABLE_CACHE)
                 end
             end
         end
-        usecache && return pkg
+        usecache && return pkgs
     end
     return available(names)
 end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -515,6 +515,12 @@ temp_pkg_dir() do
             LibGit2.reset!(repo, LibGit2.Oid(old_commit), LibGit2.Consts.RESET_HARD)
         end
 
+        # METADATA has changed, see if cache realizes it.
+        empty!(Pkg.Read.PKG_AVAILABLE_CACHE.pkgs)
+        Pkg.available()
+        @test Pkg.Read.PKG_AVAILABLE_CACHE.sha == LibGit2.Oid(old_commit)
+        @test !isempty(Pkg.Read.PKG_AVAILABLE_CACHE.pkgs)
+
         ret, out, err = @grab_outputs Pkg.add("Colors")
         @test ret === nothing && out == ""
         @test contains(err, "INFO: Installing Colors v0.6.4")


### PR DESCRIPTION
Many of the functions in `Pkg` call out to `Pkg.Read.available()` which searches though all of METADATA and reparses all the files. This PR introduces a cache so that in case of the METADATA being in the same state as the previous call, the previous result is then used.

Unfortunately, for some reason (probably the way we structure METADATA with a huge number of files) just runnning the equivalent of `git status` in libgit2 takes ~ 0.1 - 0.3 seconds depending on computer so  even when using the cache it takes a bit of time. FWIW, the `status` command on https://github.com/KristofferC/METADATA_compressed takes 0.005 seconds.

I have more optimizations for Pkg stuff in the pipeline but let's take them one by one.
