### PR TITLE
Comments on the same line as variable declarations for make

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -4,6 +4,10 @@
 ##   It is generally preferable to change these options, for
 ##   your local machine, in a file named `Make.user` in the toplevel
 ##   and build directories
+##
+## For developers, take care to not insert comments on the same line as
+## variable declarations. The spaces between the variable value and the
+## comment will be included in the value.
 
 # OPENBLAS build options
 OPENBLAS_TARGET_ARCH:=
@@ -58,7 +62,8 @@ USE_INTEL_JITEVENTS ?= 0
 USEICC  ?= 0
 USEIFC  ?= 0
 
-JULIA_THREADS := 1 # Enable threading with one thread
+# Enable threading with one thread
+JULIA_THREADS := 1
 
 ifeq ($(USE_MKL), 1)
 $(warning "The julia make variable USE_MKL has been renamed to USE_INTEL_MKL")
@@ -427,12 +432,16 @@ endif
 
 ifeq ($(USECCACHE), 1)
 # expand CC and CXX at declaration time because we will redefine them
-CC_ARG   := $(CC)         # Expand CC and CXX here already because we want
-CXX_ARG  := $(CXX)        # the original definition and not the ccache version.
-CC_FULL  := ccache $(CC)  # Expand CC and CXX here already to avoid recursive
-CXX_FULL := ccache $(CXX) # referencing.
-CC       := $(CC_FULL)    # Add an extra indirection to make CC/CXX non-simple
-CXX      := $(CXX_FULL)   # vars (because of how -m$(BINARY) is added later on).
+# Expand CC and CXX here already because we want the original definition and not the ccache version.
+CC_ARG   := $(CC)
+CXX_ARG  := $(CXX)
+# Expand CC and CXX here already to avoid recursive referencing.
+CC_FULL  := ccache $(CC)
+CXX_FULL := ccache $(CXX)
+# Add an extra indirection to make CC/CXX non-simple vars
+# (because of how -m$(BINARY) is added later on).
+CC       := $(CC_FULL)
+CXX      := $(CXX_FULL)
 CC_BASE  := ccache
 CXX_BASE := ccache
 ifeq ($(USECLANG),1)


### PR DESCRIPTION
I was investigating building julia with threading disabled and discovered changing the value in `Make.inc` did not seem to be doing anything. After some investigation, I found out that the comment on the same line in the variable declaration was causing the variable value to have trailing whitespace characters, and so the `ifneq ($(JULIA_THREADS), 0)` just always returned true. This behavior is noted in the [GNU make manual](https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors).

I saw there were a couple other places where the same thing happened so I changed those and added a warning up top. Let me know if that's just adding noise and I can remove the warning.
