### PR TITLE
display something useful for text/plain output of invalid String

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -153,6 +153,16 @@ end
 show(io::IO, ::MIME"text/plain", X::AbstractArray) = showarray(io, X, false)
 show(io::IO, ::MIME"text/plain", r::Range) = show(io, r) # always use the compact form for printing ranges
 
+# display something useful even for strings containing arbitrary
+# (non-UTF8) binary data:
+function show(io::IO, ::MIME"text/plain", s::String)
+    if isvalid(s)
+        show(io, s)
+    else
+        println(io, sizeof(s), "-byte String of invalid UTF-8 data:")
+        showarray(io, s.data, false; header=false)
+    end
+end
 
 # showing exception objects as descriptive error messages
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -603,3 +603,6 @@ end
 @test repr(NTuple{7,Int64}) == "NTuple{7,Int64}"
 @test repr(Tuple{Float64, Float64, Float64, Float64}) == "NTuple{4,Float64}"
 @test repr(Tuple{Float32, Float32, Float32}) == "Tuple{Float32,Float32,Float32}"
+
+# Test that REPL/mime display of invalid UTF-8 data doesn't throw an exception:
+@test isa(stringmime("text/plain", String(UInt8[0x00:0xff;])), String)


### PR DESCRIPTION
Rather than throwing an exception in the REPL when it tries to show a `String` containing invalid UTF-8 data, this displays something useful.
