### PR TITLE
For running tests, use up to 32 cores if available instead of 8.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ max_worker_rss != typemax(Csize_t) && move_to_node1("parallel")
 cd(dirname(@__FILE__)) do
     n = 1
     if net_on
-        n = min(8, Sys.CPU_CORES, length(tests))
+        n = min(Sys.CPU_CORES, length(tests))
         n > 1 && addprocs(n; exeflags=`--check-bounds=yes --startup-file=no --depwarn=error`)
         BLAS.set_num_threads(1)
     end


### PR DESCRIPTION
I have tested with up to 48 cores being used simultaneously for tests. If the system has fewer cores, then the test system anyways picks up fewer. This lets us use more cores if available, which I find quite handy on larger systems.
