### PR TITLE
set JULIA_CPU_TARGET default after MARCH-dependent block

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -609,8 +609,6 @@ $(error Pre-SSE2 CPU targets not supported. To create a generic 32-bit x86 binar
 pass 'MARCH=pentium4'.)
 endif
 
-JULIA_CPU_TARGET ?= native
-
 # We map amd64 to x86_64 for compatibility with systems that identify 64-bit systems as such
 ifeq ($(ARCH),amd64)
 override ARCH := x86_64
@@ -686,6 +684,8 @@ FC += -Wa,-q
 AS += -q
 endif
 endif
+
+JULIA_CPU_TARGET ?= native
 
 # Set some ARCH-specific flags
 ifneq ($(USEICC),1)


### PR DESCRIPTION
otherwise #18258 causes "Target architecture mismatch" errors in generic linux binaries
