### PR TITLE
Make `chop` and `chomp` return `SubString`

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -64,7 +64,7 @@ startswith(a::Vector{UInt8}, b::Vector{UInt8}) =
 Remove the last character from `s`.
 
 ```jldoctest
-julia> a = string("March")
+julia> a = "March"
 "March"
 
 julia> chop(a)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -58,7 +58,6 @@ startswith(a::Vector{UInt8}, b::Vector{UInt8}) =
 
 # TODO: fast endswith
 
-
 """
     chop(s::AbstractString)
 
@@ -72,7 +71,7 @@ julia> chop(a)
 "Marc"
 ```
 """
-chop(s::AbstractString) = s[1:end-1]
+chop(s::AbstractString) = SubString(s, 1, endof(s)-1)
 
 """
     chomp(s::AbstractString)
@@ -81,14 +80,21 @@ Remove a single trailing newline from a string.
 """
 function chomp(s::AbstractString)
     i = endof(s)
-    if (i < 1 || s[i] != '\n') return s end
+    if (i < 1 || s[i] != '\n') return SubString(s, 1, i) end
     j = prevind(s,i)
-    if (j < 1 || s[j] != '\r') return s[1:i-1] end
-    return s[1:j-1]
+    if (j < 1 || s[j] != '\r') return SubString(s, 1, i-1) end
+    return SubString(s, 1, j-1)
 end
-chomp(s::String) =
-    (endof(s) < 1 || s.data[end]   != 0x0a) ? s :
-    (endof(s) < 2 || s.data[end-1] != 0x0d) ? s[1:end-1] : s[1:end-2]
+function chomp(s::String)
+    i = endof(s)
+    if i < 1 || s.data[i] != 0x0a
+        SubString(s, 1, i)
+    elseif i < 2 || s.data[i-1] != 0x0d
+        SubString(s, 1, i-1)
+    else
+        SubString(s, 1, i-2)
+    end
+end
 
 # NOTE: use with caution -- breaks the immutable string convention!
 function chomp!(s::String)

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -450,7 +450,7 @@
 
    .. doctest::
 
-       julia> a = string("March")
+       julia> a = "March"
        "March"
 
        julia> chop(a)

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -210,7 +210,9 @@ end
 
 # chomp/chop
 @test chomp("foo\n") == "foo"
-@test chop("foob") == "foo"
+@test chop("fooε") == "foo"
+@test isa(chomp("foo"), SubString)
+@test isa(chop("foo"), SubString)
 
 # bytes2hex and hex2bytes
 hex_str = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"


### PR DESCRIPTION
This is unfortunate:

``` julia
julia> const str = "x" ^ 100000 * "\n";

julia> @benchmark split(str, '\n')[1]
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     8
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  192.00 bytes
  allocs estimate:  4
  minimum time:     2.99 μs (0.00% GC)
  median time:      3.21 μs (0.00% GC)
  mean time:        3.26 μs (0.00% GC)
  maximum time:     8.44 μs (0.00% GC)

julia> @benchmark chomp(str)
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  97.78 kb
  allocs estimate:  3
  minimum time:     9.35 μs (0.00% GC)
  median time:      10.81 μs (0.00% GC)
  mean time:        13.47 μs (10.56% GC)
  maximum time:     790.80 μs (94.19% GC)
```

I suspect that the same reason that `split` returns `SubString` applies to `chop` and `chomp` also. The clear benefit of returning a view is performance and allocation avoidance; the disadvantages are that the underlying string cannot be freed, and accessing a `SubString` is slightly slower. However, in `chop` and `chomp`'s case, the disadvantage is incredibly slight—an extra byte or so that can't be freed—so I believe it would make sense to follow `split` here.

Note that Perl, the only other language I know with `chop` and `chomp`, has these as _in-place_ operations—which is even faster than creating a `SubString`, but not appropriate for Julia's conventionally immutable `String`s.

On another note, I wonder whether it might be worthwhile to make `String` into `String{T}`, so that a string's underlying data can be an array view—which would make `SubString` substantially faster.
