### PR TITLE
don't throw DomainError for negative integer powers of ±1

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -115,6 +115,8 @@ function power_by_squaring(x_, p::Integer)
     elseif p == 2
         return x*x
     elseif p < 0
+        x == 1 && return copy(x)
+        x == -1 && return iseven(p) ? one(x) : copy(x)
         throw(DomainError())
     end
     t = trailing_zeros(p) + 1
@@ -135,7 +137,7 @@ function power_by_squaring(x_, p::Integer)
 end
 power_by_squaring(x::Bool, p::Unsigned) = ((p==0) | x)
 function power_by_squaring(x::Bool, p::Integer)
-    p < 0 && throw(DomainError())
+    p < 0 && !x && throw(DomainError())
     return (p==0) | x
 end
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -824,6 +824,10 @@ end
 @test_throws DomainError 2 ^ -2
 @test_throws DomainError (-2)^(2.2)
 @test_throws DomainError (-2.0)^(2.2)
+@test_throws DomainError false ^ -2
+@test 1 ^ -2 === (-1) ^ -2 === 1
+@test (-1) ^ -3 === -1
+@test true ^ -2 === true
 
 # issue #13748
 let A = [1 2; 3 4]; B = [5 6; 7 8]; C = [9 10; 11 12]

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -257,7 +257,7 @@ immutable TypeWithIntParam{T <: Integer} end
 let undefvar
     err_str = @except_strbt sqrt(-1) DomainError
     @test contains(err_str, "Try sqrt(complex(x)).")
-    err_str = @except_strbt 1^(-1) DomainError
+    err_str = @except_strbt 2^(-1) DomainError
     @test contains(err_str, "Cannot raise an integer x to a negative power -n")
     err_str = @except_strbt (-1)^0.25 DomainError
     @test contains(err_str, "Exponentiation yielding a complex result requires a complex argument")


### PR DESCRIPTION
As discussed in #3024, #12822, we throw a `DomainError` for e.g. `2^-2`.   However, we shouldn't throw an error for `1^-2` or `(-1)^-2`, since the result is an integer.
