### PR TITLE
make sysimg compile faster

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -23,6 +23,7 @@ macro _propagate_inbounds_meta()
     Expr(:meta, :inline, :propagate_inbounds)
 end
 
+convert(::Type{Any}, x::ANY) = x
 convert{T}(::Type{T}, x::T) = x
 
 convert(::Type{Tuple{}}, ::Tuple{}) = ()


### PR DESCRIPTION
we really need a heuristic for detecting simple methods like this. this seemed to make a very large difference in the time taken for sysimg compilation (esp. when inlining is not active)
