### PR TITLE
Fix docs for isdefined

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1675,12 +1675,17 @@ eta
 """
     isdefined([m::Module,] s::Symbol)
     isdefined(object, s::Symbol)
-    isdefined(a::AbstractArray, index::Int)
+    isdefined(object, index::Int)
+    isdefined(a::Array, index::Int)
 
 Tests whether an assignable location is defined. The arguments can be a module and a symbol,
-a composite object and field name (as a symbol), or an array and index. With a single
-symbol argument, tests whether a global variable with that name is defined in
+a composite object and field name (as a symbol) or index, or an `Array` and index.
+With a single symbol argument, tests whether a global variable with that name is defined in
 `current_module()`.
+
+Note: For `AbstractArray`s other than `Array`, `isdefined` tests whether the given field
+index is defined, not the given array index. To test whether an array index is defined, use
+[`isassigned`](:func:`isassigned`).
 """
 isdefined
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -349,11 +349,14 @@ All Objects
 
 .. function:: isdefined([m::Module,] s::Symbol)
               isdefined(object, s::Symbol)
-              isdefined(a::AbstractArray, index::Int)
+              isdefined(object, index::Int)
+              isdefined(a::Array, index::Int)
 
    .. Docstring generated from Julia source
 
-   Tests whether an assignable location is defined. The arguments can be a module and a symbol, a composite object and field name (as a symbol), or an array and index. With a single symbol argument, tests whether a global variable with that name is defined in ``current_module()``\ .
+   Tests whether an assignable location is defined. The arguments can be a module and a symbol, a composite object and field name (as a symbol) or index, or an ``Array`` and index. With a single symbol argument, tests whether a global variable with that name is defined in ``current_module()``\ .
+
+   Note: For ``AbstractArray``\ s other than ``Array``\ , ``isdefined`` tests whether the given field index is defined, not the given array index. To test whether an array index is defined, use :func:`isassigned`\ .
 
 .. function:: convert(T, x)
 


### PR DESCRIPTION
- `isdefined(object, index::Int)` is implemented but was not documented
- `isdefined(a::AbstractArray, index::Int)` was wrong in the sense that `isdefined` does something different for Arrays than AbstractArrays.
- Added a note to try to convince people to use `isassigned` with arrays, since `isdefined` doesn't do the expected thing for AbstractArrays.
