### PR TITLE
meet_tvars: return bound tvar if both inputs are bound. Fixes #17648

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1242,6 +1242,7 @@ static jl_value_t *meet_tvars(jl_tvar_t *a, jl_tvar_t *b)
         return ub;
     }
     jl_value_t *res = (jl_value_t*)jl_new_typevar(underscore_sym, lb, ub);
+    ((jl_tvar_t*)res)->bound = a->bound & b->bound;
     JL_GC_POP();
     return res;
 }

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -186,4 +186,17 @@ immutable T end
 end
 @test length(detect_ambiguities(Ambig7)) == 1
 
+module Ambig17648
+immutable MyArray{T,N} <: AbstractArray{T,N}
+    data::Array{T,N}
+end
+
+foo{T,N}(::Type{Array{T,N}}, A::MyArray{T,N}) = A.data
+foo{T<:AbstractFloat,N}(::Type{Array{T,N}}, A::MyArray{T,N}) = A.data
+foo{S<:AbstractFloat,N,T<:AbstractFloat}(::Type{Array{S,N}}, A::AbstractArray{T,N}) = copy!(Array{S}(size(A)), A)
+foo{S<:AbstractFloat,N,T<:AbstractFloat}(::Type{Array{S,N}}, A::MyArray{T,N}) = copy!(Array{S}(size(A)), A.data)
+end
+
+@test isempty(detect_ambiguities(Ambig17648))
+
 nothing


### PR DESCRIPTION
Untested locally, let's see what breaks...
