### PR TITLE
add -g flag to only track debug information when the user wants it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ BASE_SRCS := $(shell find $(JULIAHOME)/base -name \*.jl)
 $(build_private_libdir)/inference.ji: $(CORE_SRCS) | $(build_private_libdir)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --output-ji $(call cygpath_w,$@) \
-		--startup-file=no coreimg.jl)
+		--startup-file=no -g0 -O0 coreimg.jl)
 
 RELBUILDROOT := $(shell $(JULIAHOME)/contrib/relative_path.sh "$(JULIAHOME)/base" "$(BUILDROOT)/base/")
 COMMA:=,

--- a/base/options.jl
+++ b/base/options.jl
@@ -21,6 +21,7 @@ immutable JLOptions
     code_coverage::Int8
     malloc_log::Int8
     opt_level::Int8
+    debug_level::Int8
     check_bounds::Int8
     depwarn::Int8
     can_inline::Int8

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -68,7 +68,7 @@ Print help message
 Start up with the given system image file
 
 .TP
--precompiled={yes|no}
+--precompiled={yes|no}
 Use precompiled code from system image if available
 
 .TP
@@ -120,16 +120,28 @@ Enable or disable color text
 Load or save history
 
 .TP
- --compile={yes|no|all}
+--compile={yes|no|all}
 Enable or disable compiler, or request exhaustive compilation
 
 .TP
--C, --cpu-target <target>
+-C, --cpu-target=<target>
 Limit usage of cpu features up to <target>
 
 .TP
 -O, --optimize
 Run time-intensive code optimizations
+
+.TP
+-O <n>, --optimize=<n>
+Set the optimization level to <n>
+
+.TP
+-g
+Enable generation of full debug info
+
+.TP
+-g <n>
+Set the level of debug info generation to <n>
 
 .TP
 --inline={yes|no}
@@ -149,19 +161,19 @@ or adhere to declarations in source code
 Enable or disable syntax and method deprecation warnings ('error' turns warnings into errors)
 
 .TP
- --output-o name
+--output-o <name>
 Generate an object file (including system image data)
 
 .TP
---output-ji name
+--output-ji <name>
 Generate a system image data file (.ji)
 
 .TP
---output-bc name
+--output-bc <name>
 Generate LLVM bitcode (.bc)
 
 .TP
- --output-incremental=no
+--output-incremental={yes|no}
 Generate an incremental output file (rather than complete)
 
 .TP

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -137,7 +137,8 @@ those available for the ``perl`` and ``ruby`` programs:
 
      --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation
      -C, --cpu-target <target> Limit usage of cpu features up to <target>
-     -O, --optimize={0,1,2,3}  Set the optimization level (default 2 if unspecified or 3 if specified as -O)
+     -O, --optimize={0,1,2,3}  Set the optimization level (default is 2 if unspecified or 3 if specified as -O)
+     -g, -g <level>            Enable / Set the level of debug info generation (default is 1 if unspecified or 2 if specified as -g)
      --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)
      --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)
      --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)

--- a/src/init.c
+++ b/src/init.c
@@ -55,44 +55,6 @@ JL_DLLEXPORT const char* __asan_default_options() {
 }
 #endif
 
-static const char system_image_path[256] = "\0" JL_SYSTEM_IMAGE_PATH;
-
-jl_options_t jl_options = { 0,    // quiet
-                            NULL, // julia_home
-                            NULL, // julia_bin
-                            NULL, // eval
-                            NULL, // print
-                            NULL, // postboot
-                            NULL, // load
-                            &system_image_path[1], // image_file
-                            NULL, // cpu_taget ("native", "core2", etc...)
-                            0,    // nprocs
-                            NULL, // machinefile
-                            0,    // isinteractive
-                            0,    // color
-                            JL_OPTIONS_HISTORYFILE_ON, // historyfile
-                            0,    // startupfile
-                            JL_OPTIONS_COMPILE_DEFAULT, // compile_enabled
-                            0,    // code_coverage
-                            0,    // malloc_log
-                            2,    // opt_level
-                            JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
-                            1,    // depwarn
-                            1,    // can_inline
-                            JL_OPTIONS_POLLY_ON, // polly
-                            JL_OPTIONS_FAST_MATH_DEFAULT,
-                            0,    // worker
-                            JL_OPTIONS_HANDLE_SIGNALS_ON,
-                            JL_OPTIONS_USE_PRECOMPILED_YES,
-                            JL_OPTIONS_USE_COMPILECACHE_YES,
-                            NULL, // bindto
-                            NULL, // outputbc
-                            NULL, // outputo
-                            NULL, // outputji
-                            0, // incremental
-                            0 // image_file_specified
-};
-
 int jl_boot_file_loaded = 0;
 size_t jl_page_size;
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -11,6 +11,49 @@
 #include "getopt.h"
 #endif
 
+static const char system_image_path[256] = "\0" JL_SYSTEM_IMAGE_PATH;
+
+jl_options_t jl_options = { 0,    // quiet
+                            NULL, // julia_home
+                            NULL, // julia_bin
+                            NULL, // eval
+                            NULL, // print
+                            NULL, // post-boot
+                            NULL, // load
+                            &system_image_path[1], // image_file
+                            NULL, // cpu_target ("native", "core2", etc...)
+                            0,    // nprocs
+                            NULL, // machinefile
+                            0,    // isinteractive
+                            0,    // color
+                            JL_OPTIONS_HISTORYFILE_ON, // history file
+                            0,    // startup file
+                            JL_OPTIONS_COMPILE_DEFAULT, // compile_enabled
+                            0,    // code_coverage
+                            0,    // malloc_log
+                            2,    // opt_level
+#ifdef JL_DEBUG_BUILD
+                            2,    // debug_level [debug build]
+#else
+                            1,    // debug_level [release build]
+#endif
+                            JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
+                            1,    // deprecation warning
+                            1,    // can_inline
+                            JL_OPTIONS_POLLY_ON, // polly
+                            JL_OPTIONS_FAST_MATH_DEFAULT,
+                            0,    // worker
+                            JL_OPTIONS_HANDLE_SIGNALS_ON,
+                            JL_OPTIONS_USE_PRECOMPILED_YES,
+                            JL_OPTIONS_USE_COMPILECACHE_YES,
+                            NULL, // bind-to
+                            NULL, // output-bc
+                            NULL, // output-o
+                            NULL, // output-ji
+                            0, // incremental
+                            0 // image_file_specified
+};
+
 static const char usage[] = "julia [switches] -- [programfile] [args...]\n";
 static const char opts[]  =
     " -v, --version             Display version information\n"
@@ -42,8 +85,14 @@ static const char opts[]  =
 
     // code generation options
     " --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation\n"
-    " -C, --cpu-target <target> Limit usage of cpu features up to <target>\n"
-    " -O, --optimize={0,1,2,3}  Set the optimization level (default 2 if unspecified or 3 if specified as -O)\n"
+    " -C, --cpu-target <target> Limit usage of cpu features up to <target>; set to \"help\" to see the available options\n"
+    " -O, --optimize={0,1,2,3}  Set the optimization level (default level is 2 if unspecified or 3 if used without a level)\n"
+    " -g, -g <level>            Enable / Set the level of debug info generation"
+#ifdef JL_DEBUG_BUILD
+        " (default level for julia-debug is 2 if unspecified or if used without a level)\n"
+#else
+        " (default level is 1 if unspecified or 2 if used without a level)\n"
+#endif
     " --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)\n"
     " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)\n"
 #ifdef USE_POLLY
@@ -97,7 +146,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_use_compilecache,
            opt_incremental
     };
-    static const char* const shortopts = "+vhqFfH:e:E:P:L:J:C:ip:O:";
+    static const char* const shortopts = "+vhqFfH:e:E:P:L:J:C:ip:O:g:";
     static const struct option longopts[] = {
         // exposed command line options
         // NOTE: This set of required arguments need to be kept in sync
@@ -172,6 +221,10 @@ restart_switch:
         case '?':
         case ':':
             if (optopt) {
+                if (optopt == 'g') {
+                    c = 'g';
+                    goto restart_switch;
+                }
                 for (const struct option *o = longopts; o->val; o++) {
                     if (optopt == o->val) {
                         if (o->has_arg == optional_argument) {
@@ -200,6 +253,22 @@ restart_switch:
             jl_exit(0);
         case 'q': // quiet
             jl_options.quiet = 1;
+            break;
+        case 'g': // debug info
+            if (optarg != NULL) {
+                if (!strcmp(optarg,"0"))
+                    jl_options.debug_level = 0;
+                else if (!strcmp(optarg,"1"))
+                    jl_options.debug_level = 1;
+                else if (!strcmp(optarg,"2"))
+                    jl_options.debug_level = 2;
+                else
+                    jl_errorf("julia: invalid argument to -g (%s)", optarg);
+                break;
+            }
+            else {
+                jl_options.debug_level = 2;
+            }
             break;
         case 'H': // home
             jl_options.julia_home = strdup(optarg);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1637,6 +1637,7 @@ typedef struct {
     int8_t code_coverage;
     int8_t malloc_log;
     int8_t opt_level;
+    int8_t debug_level;
     int8_t check_bounds;
     int8_t depwarn;
     int8_t can_inline;


### PR DESCRIPTION
This lets us save a small, but measurable, amount of compile time and memory. I also suspect it may be more effective to cache code that doesn't contain type information (less information => more likely two functions can share the same code).
