### PR TITLE
Deprecate isdefined for Arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ Compiler/Runtime improvements
 Deprecated or removed
 ---------------------
 
+  * `isdefined(a::Array, i::Int)` has been deprecated in favor of `isassigned` ([#18346]).
+
 Julia v0.5.0 Release Notes
 ==========================
 
@@ -653,3 +655,4 @@ Language tooling improvements
 [#17668]: https://github.com/JuliaLang/julia/issues/17668
 [#17785]: https://github.com/JuliaLang/julia/issues/17785
 [#18330]: https://github.com/JuliaLang/julia/issues/18330
+[#18346]: https://github.com/JuliaLang/julia/issues/18346

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -66,7 +66,7 @@ const SLOT_RULE = SlotRule(Array{Type}(256))
 
 getindex(collection::SlotRule, key::Char) = collection.rules[Int(key)]
 setindex!(collection::SlotRule, value::Type, key::Char) = collection.rules[Int(key)] = value
-keys(c::SlotRule) = map(Char, filter(el -> isdefined(c.rules, el) && c.rules[el] != Void, eachindex(c.rules)))
+keys(c::SlotRule) = map(Char, filter(el -> isassigned(c.rules, el) && c.rules[el] != Void, eachindex(c.rules)))
 
 SLOT_RULE['y'] = Year
 SLOT_RULE['Y'] = Year

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -56,7 +56,7 @@ function _deepcopy_array_t(x::ANY, T, stackdict::ObjectIdDict)
     dest = similar(x)
     stackdict[x] = dest
     for i=1:length(x)
-        if isdefined(x,i)
+        if isassigned(x,i)
             arrayset(dest, deepcopy_internal(x[i], stackdict), i)
         end
     end

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1680,16 +1680,10 @@ eta
     isdefined([m::Module,] s::Symbol)
     isdefined(object, s::Symbol)
     isdefined(object, index::Int)
-    isdefined(a::Array, index::Int)
 
-Tests whether an assignable location is defined. The arguments can be a module and a symbol,
-a composite object and field name (as a symbol) or index, or an `Array` and index.
-With a single symbol argument, tests whether a global variable with that name is defined in
-`current_module()`.
-
-Note: For `AbstractArray`s other than `Array`, `isdefined` tests whether the given field
-index is defined, not the given array index. To test whether an array index is defined, use
-[`isassigned`](:func:`isassigned`).
+Tests whether an assignable location is defined. The arguments can be a module and a symbol
+or a composite object and field name (as a symbol) or index. With a single symbol argument,
+tests whether a global variable with that name is defined in `current_module()`.
 """
 isdefined
 

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -694,7 +694,7 @@ function builtin_tfunction(f::ANY, argtypes::Array{Any,1}, sv::InferenceState)
     end
     if isa(f, IntrinsicFunction)
         iidx = Int(reinterpret(Int32, f::IntrinsicFunction))+1
-        if !isdefined(t_ifunc, iidx)
+        if !isassigned(t_ifunc, iidx)
             # unknown/unhandled intrinsic (most fall in this category since most return an unboxed value)
             return Any
         end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -440,13 +440,13 @@ function visit(f, mc::TypeMapLevel)
     if mc.targ !== nothing
         e = mc.targ::Vector{Any}
         for i in 1:length(e)
-            isdefined(e, i) && visit(f, e[i])
+            isassigned(e, i) && visit(f, e[i])
         end
     end
     if mc.arg1 !== nothing
         e = mc.arg1::Vector{Any}
         for i in 1:length(e)
-            isdefined(e, i) && visit(f, e[i])
+            isassigned(e, i) && visit(f, e[i])
         end
     end
     mc.list !== nothing && visit(f, mc.list)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -213,7 +213,7 @@ function serialize(s::AbstractSerializer, a::Array)
         serialize_array_data(s.io, a)
     else
         for i in eachindex(a)
-            if isdefined(a, i)
+            if isassigned(a, i)
                 serialize(s, a[i])
             else
                 writetag(s.io, UNDEFREF_TAG)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1130,7 +1130,7 @@ dump(io::IO, x::Union,  n::Int, indent) = print(io, x)
 function dump_elts(io::IO, x::Array, n::Int, indent, i0, i1)
     for i in i0:i1
         print(io, indent, "  ", i, ": ")
-        if !isdefined(x,i)
+        if !isassigned(x,i)
             print(io, undef_ref_str)
         else
             dump(io, x[i], n - 1, string(indent, "  "))

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -350,13 +350,10 @@ All Objects
 .. function:: isdefined([m::Module,] s::Symbol)
               isdefined(object, s::Symbol)
               isdefined(object, index::Int)
-              isdefined(a::Array, index::Int)
 
    .. Docstring generated from Julia source
 
-   Tests whether an assignable location is defined. The arguments can be a module and a symbol, a composite object and field name (as a symbol) or index, or an ``Array`` and index. With a single symbol argument, tests whether a global variable with that name is defined in ``current_module()``\ .
-
-   Note: For ``AbstractArray``\ s other than ``Array``\ , ``isdefined`` tests whether the given field index is defined, not the given array index. To test whether an array index is defined, use :func:`isassigned`\ .
+   Tests whether an assignable location is defined. The arguments can be a module and a symbol or a composite object and field name (as a symbol) or index. With a single symbol argument, tests whether a global variable with that name is defined in ``current_module()``\ .
 
 .. function:: convert(T, x)
 

--- a/src/array.c
+++ b/src/array.c
@@ -491,6 +491,14 @@ JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
 int jl_array_isdefined(jl_value_t **args0, int nargs)
 {
     assert(jl_is_array(args0[0]));
+    jl_value_t **depwarn_args;
+    JL_GC_PUSHARGS(depwarn_args, 3);
+    depwarn_args[0] = jl_get_global(jl_base_module, jl_symbol("depwarn"));
+    depwarn_args[1] = jl_cstr_to_string("isdefined(a::Array, i::Int) is deprecated, use isassigned(a, i) instead");
+    depwarn_args[2] = (jl_value_t*) jl_symbol("isdefined");
+    jl_apply(depwarn_args, 3);
+    JL_GC_POP();
+
     jl_array_t *a = (jl_array_t*)args0[0];
     jl_value_t **args = &args0[1];
     size_t nidxs = nargs-1;

--- a/test/core.jl
+++ b/test/core.jl
@@ -594,15 +594,6 @@ end
 
 let
     local a
-    a = Vector{Any}(2)
-    @test !isdefined(a,1) && !isdefined(a,2)
-    a[1] = 1
-    @test isdefined(a,1) && !isdefined(a,2)
-    a = Array{Float64}(1)
-    @test isdefined(a,1)
-    @test isdefined(a)
-    @test !isdefined(a,2)
-
     a = UndefField()
     @test !isdefined(a, :field)
     @test !isdefined(a, :foo)
@@ -3754,9 +3745,9 @@ end
 
 let ary = Vector{Any}(10)
     check_undef_and_fill(ary, rng) = for i in rng
-        @test !isdefined(ary, i)
+        @test !isassigned(ary, i)
         ary[i] = (Float64(i), i) # some non-cached content
-        @test isdefined(ary, i)
+        @test isassigned(ary, i)
     end
     # Check if the memory is initially zerod and fill it with value
     # to check if these values are not reused later.
@@ -3819,7 +3810,7 @@ let ary = Vector{Any}(10)
         len = length(ary)
         ccall(:jl_array_grow_end, Void, (Any, Csize_t), ary, 10)
         for i in (len + 1):(len + 10)
-            @test !isdefined(ary, i)
+            @test !isassigned(ary, i)
         end
     end
 
@@ -3827,7 +3818,7 @@ let ary = Vector{Any}(10)
     ary[:] = 1:length(ary)
     ccall(:jl_array_grow_at, Void, (Any, Csize_t, Csize_t), ary, 50, 10)
     for i in 51:60
-        @test !isdefined(ary, i)
+        @test !isassigned(ary, i)
     end
 end
 

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -220,8 +220,8 @@ create_serialization_stream() do s # small 1d array
     @test deserialize(s) == arr4
 
     result = deserialize(s)
-    @test !isdefined(result,1)
-    @test !isdefined(result,3)
+    @test !isassigned(result,1)
+    @test !isassigned(result,3)
     @test result[2].v == arr5[2].v
 end
 

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -107,10 +107,10 @@ let
     Base.rehash!(s)
     @test length(k) == length(s.dict.keys)
     for i in 1:length(k)
-        if isdefined(k, i)
+        if isassigned(k, i)
             @test k[i] == s.dict.keys[i]
         else
-            @test !isdefined(s.dict.keys, i)
+            @test !isassigned(s.dict.keys, i)
         end
     end
     s == Set(["a", "b", "c"])


### PR DESCRIPTION
Fixes #18346. Someone should confirm that this is the appropriate way to call `depwarn` from the C code.
