### PR TITLE
cumsum fixes (fixes #18363 and #18336)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@ This section lists changes that do not have deprecation warnings.
   * Keyword arguments are processed left-to-right: if the same keyword is specified more than
     once, the rightmost occurrence takes precedence ([#17785]).
 
+  * The `cumsum` and `cumprod` functions now use the same type promotion as `sum` and `prod`,
+    and in particular their numeric result types are now widened to at least 32 bits;
+    you can use `cumsum!` or `cumprod!` to specify a different type ([#18364]).
+
 Library improvements
 --------------------
 
@@ -648,3 +652,4 @@ Language tooling improvements
 [#17546]: https://github.com/JuliaLang/julia/issues/17546
 [#17668]: https://github.com/JuliaLang/julia/issues/17668
 [#17785]: https://github.com/JuliaLang/julia/issues/17785
+[#18364]: https://github.com/JuliaLang/julia/issues/18364

--- a/NEWS.md
+++ b/NEWS.md
@@ -648,4 +648,3 @@ Language tooling improvements
 [#17546]: https://github.com/JuliaLang/julia/issues/17546
 [#17668]: https://github.com/JuliaLang/julia/issues/17668
 [#17785]: https://github.com/JuliaLang/julia/issues/17785
-[#18364]: https://github.com/JuliaLang/julia/issues/18364

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,10 +24,6 @@ This section lists changes that do not have deprecation warnings.
   * Keyword arguments are processed left-to-right: if the same keyword is specified more than
     once, the rightmost occurrence takes precedence ([#17785]).
 
-  * The `cumsum` and `cumprod` functions now use the same type promotion as `sum` and `prod`,
-    and in particular their numeric result types are now widened to at least 32 bits;
-    you can use `cumsum!` or `cumprod!` to specify a different type ([#18364]).
-
 Library improvements
 --------------------
 

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -479,6 +479,6 @@ for (f, f!, fp, op) = ((:cumsum, :cumsum!, :cumsum_pairwise!, :+),
     end
 
     @eval function ($f){T}(v::AbstractVector{T})
-        return ($f!)(similar(v), v)
+        return ($f!)(similar(v, r_promote_type($op, T)), v)
     end
 end

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -477,7 +477,7 @@ for (f, f!, fp, op) = ((:cumsum, :cumsum!, :cumsum_pairwise!, :+),
 
     @eval function ($f!)(result::AbstractVector, v::AbstractVector)
         li = linearindices(v)
-        li != linearindices(result) && throw(BoundsError())
+        li != linearindices(result) && throw(DimensionMismatch("input and output array sizes and indices must match"))
         n = length(li)
         if n == 0; return result; end
         i1 = first(li)

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -467,10 +467,10 @@ for (f, f!, fp, op) = ((:cumsum, :cumsum!, :cumsum_pairwise!, :+),
     end
 
     @eval function ($f!)(result::AbstractVector, v::AbstractVector)
-        n = length(v)
-        if n == 0; return result; end
         li = linearindices(v)
         li != linearindices(result) && throw(BoundsError())
+        n = length(li)
+        if n == 0; return result; end
         i1 = first(li)
         @inbounds result[i1] = v1 = v[i1]
         n == 1 && return result

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -527,7 +527,7 @@ julia> cumsum(a,2)
  4  9  15
 ```
 """
-cumsum(A::AbstractArray, axis::Integer=1) =  cumsum!(similar(A), A, axis)
+cumsum{T}(A::AbstractArray{T}, axis::Integer=1) =  cumsum!(similar(A, Base.r_promote_type(+, T)), A, axis)
 cumsum!(B, A::AbstractArray) = cumsum!(B, A, 1)
 """
     cumprod(A, dim=1)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -527,7 +527,7 @@ julia> cumsum(a,2)
  4  9  15
 ```
 """
-cumsum{T}(A::AbstractArray{T}, axis::Integer=1) =  cumsum!(similar(A, Base.r_promote_type(+, T)), A, axis)
+cumsum{T}(A::AbstractArray{T}, axis::Integer=1) =  cumsum!(similar(A, Base.rcum_promote_type(+, T)), A, axis)
 cumsum!(B, A::AbstractArray) = cumsum!(B, A, 1)
 """
     cumprod(A, dim=1)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -527,7 +527,7 @@ julia> cumsum(a,2)
  4  9  15
 ```
 """
-cumsum(A::AbstractArray, axis::Integer=1) =  cumsum!(similar(A, Base._cumsum_type(A)), A, axis)
+cumsum(A::AbstractArray, axis::Integer=1) =  cumsum!(similar(A), A, axis)
 cumsum!(B, A::AbstractArray) = cumsum!(B, A, 1)
 """
     cumprod(A, dim=1)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -33,6 +33,12 @@ r_promote(::typeof(min), x::WidenReduceResult) = r_promote(scalarmin, x)
 r_promote(::typeof(max), x) = r_promote(scalarmax, x)
 r_promote(::typeof(min), x) = r_promote(scalarmin, x)
 
+# like r_promote but acting on types T rather than on values x
+r_promote_type(op, T::Type) = T
+r_promote_type{T<:WidenReduceResult}(::typeof(+), ::Type{T}) = widen(T)
+r_promote_type{T<:WidenReduceResult}(::typeof(*), ::Type{T}) = widen(T)
+r_promote_type{T<:Number}(::typeof(+), ::Type{T}) = typeof(zero(T)+zero(T))
+r_promote_type{T<:Number}(::typeof(*), ::Type{T}) = typeof(one(T)*one(T))
 
 ## foldl && mapfoldl
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -15,30 +15,21 @@ end
 typealias CommonReduceResult Union{UInt64,UInt128,Int64,Int128,Float32,Float64}
 typealias WidenReduceResult Union{SmallSigned, SmallUnsigned, Float16}
 
-# r_promote: promote x to the type of reduce(op, [x])
-r_promote(op, x::WidenReduceResult) = widen(x)
-r_promote(op, x) = x
-r_promote(::typeof(+), x::WidenReduceResult) = widen(x)
-r_promote(::typeof(*), x::WidenReduceResult) = widen(x)
-r_promote(::typeof(+), x::Number) = oftype(x + zero(x), x)
-r_promote(::typeof(*), x::Number) = oftype(x * one(x), x)
-r_promote(::typeof(+), x) = x
-r_promote(::typeof(*), x) = x
-r_promote(::typeof(scalarmax), x::WidenReduceResult) = x
-r_promote(::typeof(scalarmin), x::WidenReduceResult) = x
-r_promote(::typeof(scalarmax), x) = x
-r_promote(::typeof(scalarmin), x) = x
-r_promote(::typeof(max), x::WidenReduceResult) = r_promote(scalarmax, x)
-r_promote(::typeof(min), x::WidenReduceResult) = r_promote(scalarmin, x)
-r_promote(::typeof(max), x) = r_promote(scalarmax, x)
-r_promote(::typeof(min), x) = r_promote(scalarmin, x)
-
-# like r_promote but acting on types T rather than on values x
-r_promote_type(op, T::Type) = T
+# r_promote_type: promote T to the type of reduce(op, ::Array{T})
+# (some "extra" methods are required here to avoid ambiguity warnings)
+r_promote_type{T}(op, ::Type{T}) = T
+r_promote_type{T<:WidenReduceResult}(op, ::Type{T}) = widen(T)
 r_promote_type{T<:WidenReduceResult}(::typeof(+), ::Type{T}) = widen(T)
 r_promote_type{T<:WidenReduceResult}(::typeof(*), ::Type{T}) = widen(T)
 r_promote_type{T<:Number}(::typeof(+), ::Type{T}) = typeof(zero(T)+zero(T))
 r_promote_type{T<:Number}(::typeof(*), ::Type{T}) = typeof(one(T)*one(T))
+r_promote_type{T<:WidenReduceResult}(::typeof(scalarmax), ::Type{T}) = T
+r_promote_type{T<:WidenReduceResult}(::typeof(scalarmin), ::Type{T}) = T
+r_promote_type{T<:WidenReduceResult}(::typeof(max), ::Type{T}) = T
+r_promote_type{T<:WidenReduceResult}(::typeof(min), ::Type{T}) = T
+
+# r_promote: promote x to the type of reduce(op, [x])
+r_promote{T}(op, x::T) = convert(r_promote_type(op, T), x)
 
 ## foldl && mapfoldl
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -353,7 +353,7 @@ function sparse_IJ_sorted!{Ti<:Integer}(I::AbstractVector{Ti}, J::AbstractVector
         end
     end
 
-    colptr = cumsum(cols)
+    colptr = cumsum!(similar(cols), cols)
 
     # Allow up to 20% slack
     if ndups > 0.2*L

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1689,6 +1689,15 @@ end
 @test cumsum([1 2; 3 4], 2) == [1 3; 3 7]
 @test cumsum([1 2; 3 4], 3) == [1 2; 3 4]
 
+# issue #18363
+@test_throws BoundsError cumsum!([0,0], 1:4)
+@test cumsum(Any[]) == Any[] && isa(cumsum(Any[]), Vector{Any})
+@test cumsum(Any[1, 2.3]) == [1, 3.3]
+
+#issue #18336
+@test cumsum([-0.0, -0.0])[1] === cumsum([-0.0, -0.0])[2] === -0.0
+@test cumprod(-0.0im + (0:0))[1] === Complex(0.0, -0.0)
+
 module TestNLoops15895
 
 using Base.Cartesian

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1690,7 +1690,7 @@ end
 @test cumsum([1 2; 3 4], 3) == [1 2; 3 4]
 
 # issue #18363
-@test_throws BoundsError cumsum!([0,0], 1:4)
+@test_throws DimensionMismatch cumsum!([0,0], 1:4)
 @test cumsum(Any[])::Vector{Any} == Any[]
 @test cumsum(Any[1, 2.3])::Vector{Any} == [1, 3.3] == cumsum(Real[1, 2.3])::Vector{Real}
 @test cumsum([true,true,true]) == [1,2,3]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1691,10 +1691,11 @@ end
 
 # issue #18363
 @test_throws BoundsError cumsum!([0,0], 1:4)
-@test cumsum(Any[]) == Any[] && isa(cumsum(Any[]), Vector{Any})
-@test cumsum(Any[1, 2.3]) == [1, 3.3]
+@test cumsum(Any[])::Vector{Any} == Any[]
+@test cumsum(Any[1, 2.3])::Vector{Any} == [1, 3.3] == cumsum(Real[1, 2.3])::Vector{Real}
 @test cumsum([true,true,true]) == [1,2,3]
-@test cumsum(0x00:0xff)[end] === 0x00007f80
+@test cumsum(0x00:0xff)[end] === 0x80 # overflow
+@test cumsum([[true], [true], [false]])::Vector{Vector{Int}} == [[1], [2], [2]]
 
 #issue #18336
 @test cumsum([-0.0, -0.0])[1] === cumsum([-0.0, -0.0])[2] === -0.0

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1693,6 +1693,8 @@ end
 @test_throws BoundsError cumsum!([0,0], 1:4)
 @test cumsum(Any[]) == Any[] && isa(cumsum(Any[]), Vector{Any})
 @test cumsum(Any[1, 2.3]) == [1, 3.3]
+@test cumsum([true,true,true]) == [1,2,3]
+@test cumsum(0x00:0xff)[end] === 0x00007f80
 
 #issue #18336
 @test cumsum([-0.0, -0.0])[1] === cumsum([-0.0, -0.0])[2] === -0.0


### PR DESCRIPTION
This fixes JuliaLang/julia#18336 and JuliaLang/julia#18363 — there were an embarrassing number of problems with `cumsum` and `cumprod` for corner cases.  (My fault, I think, since I wrote this routine back in JuliaLang/julia#4039.)

The breaking change is that `cumsum(v)` now uses `similar(v, rcum_promote_type(+, eltype(v)))` rather than the broken `_cumsum_type(v)` function, where `rcum_promote_type` is a new function that calls `promote_op` for numbers but which leaves most other types alone.   I don't think this should change any working cases for `cumsum` of numeric types, but it might break some unusual user-defined types in which `+` produces a different type.

(The user can still control the result type manually by passing an array to `cumsum!`, however.)
