### PR TITLE
fix an inverted return conditional from stale_cachefile

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -383,6 +383,12 @@ warn(io::IO, err::Exception; prefix="ERROR: ", kw...) =
 warn(err::Exception; prefix="ERROR: ", kw...) =
     warn(STDERR, err, prefix=prefix; kw...)
 
+info(io::IO, err::Exception; prefix="ERROR: ", kw...) =
+    info(io, sprint(buf->showerror(buf, err)), prefix=prefix; kw...)
+
+info(err::Exception; prefix="ERROR: ", kw...) =
+    info(STDERR, err, prefix=prefix; kw...)
+
 function julia_cmd(julia=joinpath(JULIA_HOME, julia_exename()))
     opts = JLOptions()
     cpu_target = unsafe_string(opts.cpu_target)


### PR DESCRIPTION
also add plenty of helpful debugging information enabled by the environment variable:
`JULIA_DEBUG_LOADING`

this bug would cause compilation to become confused
and likely tardy at recompiling files when it should
that would up with longer dependency chains where one
of the files had been updated

this is a fix for #18150
