### PR TITLE
hook up runtime intrinsics

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -99,7 +99,11 @@ end
 function show(io::IO, ::MIME"text/plain", f::Function)
     ft = typeof(f)
     mt = ft.name.mt
-    if isa(f, Core.Builtin)
+    if isa(f, Core.IntrinsicFunction)
+        show(io, f)
+        id = Core.Intrinsics.box(Int32, f)
+        print(io, " (intrinsic function #$id)")
+    elseif isa(f, Core.Builtin)
         print(io, mt.name, " (built-in function)")
     else
         name = mt.name

--- a/base/show.jl
+++ b/base/show.jl
@@ -170,7 +170,8 @@ function show(io::IO, f::Function)
 end
 
 function show(io::IO, x::Core.IntrinsicFunction)
-    print(io, "(intrinsic function #", box(Int32, unbox(Core.IntrinsicFunction, x)), ")")
+    name = ccall(:jl_intrinsic_name, Cstring, (Core.IntrinsicFunction,), x)
+    print(io, unsafe_string(name))
 end
 
 function show(io::IO, x::Union)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1124,7 +1124,7 @@ jl_fptr_t jl_get_builtin_fptr(jl_value_t *b)
 
 static void add_builtin_func(const char *name, jl_fptr_t fptr)
 {
-    add_builtin(name, jl_mk_builtin_func(name, fptr));
+    jl_mk_builtin_func(NULL, name, fptr);
 }
 
 void jl_init_primitives(void)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5601,29 +5601,29 @@ static void init_julia_llvm_env(Module *m)
     gcroot_func =
         Function::Create(FunctionType::get(T_ppjlvalue, false),
                      Function::ExternalLinkage,
-                     "julia.gc_root_decl", m);
+                     "julia.gc_root_decl");
     add_named_global(gcroot_func, (void*)NULL, /*dllimport*/false);
 
     gckill_func =
         Function::Create(FunctionType::get(T_void, ArrayRef<Type*>(T_ppjlvalue), false),
                      Function::ExternalLinkage,
-                     "julia.gc_root_kill", m);
+                     "julia.gc_root_kill");
     add_named_global(gckill_func, (void*)NULL, /*dllimport*/false);
 
     jlcall_frame_func =
         Function::Create(FunctionType::get(T_ppjlvalue, ArrayRef<Type*>(T_int32), false),
                      Function::ExternalLinkage,
-                     "julia.jlcall_frame_decl", m);
+                     "julia.jlcall_frame_decl");
     add_named_global(jlcall_frame_func, (void*)NULL, /*dllimport*/false);
 
     gcroot_flush_func = Function::Create(FunctionType::get(T_void, false),
                                          Function::ExternalLinkage,
-                                         "julia.gcroot_flush", m);
+                                         "julia.gcroot_flush");
     add_named_global(gcroot_flush_func, (void*)NULL, /*dllimport*/false);
 
     except_enter_func = Function::Create(FunctionType::get(T_int32, false),
                                          Function::ExternalLinkage,
-                                         "julia.except_enter", m);
+                                         "julia.except_enter");
     except_enter_func->addFnAttr(Attribute::ReturnsTwice);
     add_named_global(except_enter_func, (void*)NULL, /*dllimport*/false);
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -2050,7 +2050,13 @@ static void jl_save_system_image_to_stream(ios_t *f)
     jl_serialize_value(&s, jl_main_module);
     jl_serialize_value(&s, jl_top_module);
     jl_serialize_value(&s, jl_typeinf_func);
+
+    // deserialize method tables of builtin types
     jl_serialize_value(&s, jl_type_type->name->mt);
+    jl_serialize_value(&s, jl_intrinsic_type->name->mt);
+    jl_serialize_value(&s, jl_sym_type->name->mt);
+    jl_serialize_value(&s, jl_array_type->name->mt);
+    jl_serialize_value(&s, jl_module_type->name->mt);
 
     jl_prune_type_cache(jl_tuple_typename->cache);
     jl_prune_type_cache(jl_tuple_typename->linearcache);
@@ -2146,10 +2152,17 @@ static void jl_restore_system_image_from_stream(ios_t *f)
     jl_main_module = (jl_module_t*)jl_deserialize_value(&s, NULL);
     jl_top_module = (jl_module_t*)jl_deserialize_value(&s, NULL);
     jl_internal_main_module = jl_main_module;
+
     jl_typeinf_func = (jl_function_t*)jl_deserialize_value(&s, NULL);
     jl_type_type_mt = (jl_methtable_t*)jl_deserialize_value(&s, NULL);
-    jl_type_type->name->mt = jl_typector_type->name->mt = jl_uniontype_type->name->mt = jl_datatype_type->name->mt =
-        jl_type_type_mt;
+    jl_type_type->name->mt = jl_type_type_mt;
+    jl_typector_type->name->mt = jl_type_type_mt;
+    jl_uniontype_type->name->mt = jl_type_type_mt;
+    jl_datatype_type->name->mt = jl_type_type_mt;
+    jl_intrinsic_type->name->mt = (jl_methtable_t*)jl_deserialize_value(&s, NULL);
+    jl_sym_type->name->mt = (jl_methtable_t*)jl_deserialize_value(&s, NULL);
+    jl_array_type->name->mt = (jl_methtable_t*)jl_deserialize_value(&s, NULL);
+    jl_module_type->name->mt = (jl_methtable_t*)jl_deserialize_value(&s, NULL);
 
     intptr_t i;
     for(i=0; i < builtin_types.len; i++) {

--- a/src/init.c
+++ b/src/init.c
@@ -661,6 +661,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
     jl_an_empty_vec_any = (jl_value_t*)jl_alloc_vec_any(0);
     jl_init_serializer();
+    jl_init_intrinsic_properties();
 
     if (!jl_options.image_file) {
         jl_core_module = jl_new_module(jl_symbol("Core"));

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -923,6 +923,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         f = fptoui_auto;
     if (f == fptosi && nargs == 1)
         f = fptosi_auto;
+    if (f == cglobal && nargs == 1)
+        f = cglobal_auto;
     unsigned expected_nargs = intrinsic_nargs[f];
     if (expected_nargs && expected_nargs != nargs) {
         jl_errorf("intrinsic #%d %s: wrong number of arguments", f, JL_I::jl_intrinsic_name((int)f));
@@ -930,6 +932,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 
     switch (f) {
     case ccall: return emit_ccall(args, nargs, ctx);
+    case cglobal_auto:
     case cglobal: return emit_cglobal(args, nargs, ctx);
     case llvmcall: return emit_llvmcall(args, nargs, ctx);
     case arraylen:

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3947,7 +3947,7 @@ void jl_init_types(void)
         jl_type_type->name->mt;
 
     jl_intrinsic_type = jl_new_bitstype((jl_value_t*)jl_symbol("IntrinsicFunction"),
-                                        jl_any_type, jl_emptysvec, 32);
+                                        jl_builtin_type, jl_emptysvec, 32);
 
     tv = jl_svec1(tvar("T"));
     jl_ref_type =

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -335,6 +335,7 @@ void jl_init_frontend(void);
 void jl_init_primitives(void);
 void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
+void jl_init_intrinsic_properties(void);
 void jl_init_tasks(void);
 void jl_init_stack_limits(int ismaster);
 void jl_init_root_task(void *stack, size_t ssize);
@@ -532,6 +533,8 @@ const char *jl_intrinsic_name(int f);
 JL_DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align);
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
+JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty);
+JL_DLLEXPORT jl_value_t *jl_cglobal_auto(jl_value_t *v);
 
 JL_DLLEXPORT jl_value_t *jl_neg_int(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_add_int(jl_value_t *a, jl_value_t *b);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -269,7 +269,7 @@ int jl_types_equal_generic(jl_value_t *a, jl_value_t *b, int useenv);
 jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np);
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p);
 void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
-jl_value_t *jl_mk_builtin_func(const char *name, jl_fptr_t fptr);
+void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr);
 STATIC_INLINE int jl_is_type(jl_value_t *v)
 {
     jl_value_t *t = jl_typeof(v);
@@ -528,7 +528,7 @@ extern JL_DLLEXPORT jl_value_t *jl_segv_exception;
 #endif
 
 // -- Runtime intrinsics -- //
-const char *jl_intrinsic_name(int f);
+JL_DLLEXPORT const char *jl_intrinsic_name(int f);
 
 JL_DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1,7 +1,7 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
 // This is in implementation of the Julia intrinsic functions against boxed types
-// excluding the c interface (ccall, cglobal, llvmcall)
+// excluding the native function call interface (ccall, llvmcall)
 //
 // this file assumes a little-endian processor, although that isn't too hard to fix
 // it also assumes two's complement negative numbers, which might be a bit harder to fix
@@ -74,6 +74,58 @@ JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t 
         jl_assign_bits(pp, x);
     }
     return p;
+}
+
+JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty)
+{
+    JL_TYPECHK(cglobal, type, ty);
+    jl_value_t *rt =
+        v == (jl_value_t*)jl_void_type ? (jl_value_t*)jl_voidpointer_type : // a common case
+            (jl_value_t*)jl_apply_type_((jl_value_t*)jl_pointer_type, &ty, 1);
+
+    if (!jl_is_leaf_type(rt))
+        jl_error("cglobal: type argument not a leaftype");
+
+    if (jl_is_tuple(v) && jl_nfields(v) == 1)
+        v = jl_fieldref(v, 0);
+
+    if (jl_is_pointer(v))
+        return jl_reinterpret(rt, v);
+
+    char *f_lib = NULL;
+    if (jl_is_tuple(v) && jl_nfields(v) > 1) {
+        jl_value_t *t1 = jl_fieldref(v, 1);
+        v = jl_fieldref(v, 0);
+        if (jl_is_symbol(t1))
+            f_lib = jl_symbol_name((jl_sym_t*)t1);
+        else if (jl_is_string(t1))
+            f_lib = jl_string_data(t1);
+        else
+            JL_TYPECHK(cglobal, symbol, t1)
+    }
+
+    char *f_name = NULL;
+    if (jl_is_symbol(v))
+        f_name = jl_symbol_name((jl_sym_t*)v);
+    else if (jl_is_string(v))
+        f_name = jl_string_data(v);
+    else
+        JL_TYPECHK(cglobal, symbol, v)
+
+#ifdef _OS_WINDOWS_
+    if (!f_lib)
+        f_lib = jl_dlfind_win32(f_name);
+#endif
+
+    void *ptr = jl_dlsym(jl_get_library(f_lib), f_name);
+    jl_value_t *jv = jl_gc_alloc_1w();
+    jl_set_typeof(jv, rt);
+    *(void**)jl_data_ptr(jv) = ptr;
+    return jv;
+}
+
+JL_DLLEXPORT jl_value_t *jl_cglobal_auto(jl_value_t *v) {
+    return jl_cglobal(v, (jl_value_t*)jl_void_type);
 }
 
 static inline char signbitbyte(void *a, unsigned bytes)

--- a/test/core.jl
+++ b/test/core.jl
@@ -504,6 +504,13 @@ glotest()
 @test glob_x == 88
 @test loc_x == 10
 
+# runtime intrinsics
+
+let f = Any[Core.Intrinsics.add_int, Core.Intrinsics.sub_int]
+    @test f[1](1, 1) == 2
+    @test f[2](1, 1) == 0
+end
+
 # issue #7234
 begin
     glob_x2 = 24


### PR DESCRIPTION
This long-overdue PR makes the intrinsic functions work just like normal builtin functions instead of requiring special rules in the compiler.

incorporates parts of jn/jlinterpreter and #14918
