### PR TITLE
Show replacement for module deprecation

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -486,7 +486,7 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
         else
             jl_printf(JL_STDERR, "%s is deprecated", jl_symbol_name(b->name));
         jl_value_t *v = b->value;
-        if (v && (jl_is_type(v)/* || (jl_is_function(v) && jl_is_gf(v))*/)) {
+        if (v && (jl_is_type(v) || jl_is_module(v)/* || (jl_is_function(v) && jl_is_gf(v))*/)) {
             jl_printf(JL_STDERR, ", use ");
             jl_static_show(JL_STDERR, v);
             jl_printf(JL_STDERR, " instead");


### PR DESCRIPTION
Shows the new name for a deprecated module, like it currently does for deprecated types.

``` jl
julia> module Foo
       end
Foo

julia> Base.@deprecate_binding Bar Foo

julia> Bar
WARNING: Main.Bar is deprecated, use Foo instead.
  likely near no file:0
Foo
```
