### PR TITLE
Use typed_hcat in typed_hvcat

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1425,7 +1425,7 @@ function typed_hvcat{T}(::Type{T}, rows::Tuple{Vararg{Int}}, as...)
     rs = Array{Any,1}(nbr)
     a = 1
     for i = 1:nbr
-        rs[i] = hcat(as[a:a-1+rows[i]]...)
+        rs[i] = typed_hcat(T, as[a:a-1+rows[i]]...)
         a += rows[i]
     end
     T[rs...;]

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -560,6 +560,9 @@ function test_cat(::Type{TestAbstractArray})
     # check for # of columns mismatch b/w rows
     @test_throws ArgumentError hvcat((3, 2), 1, 2, 3, 4, 5, 6)
     @test_throws ArgumentError Base.typed_hvcat(Int, (3, 2), 1, 2, 3, 4, 5, 6)
+
+    # 18395
+    @test isa(Any["a" 5; 2//3 1.0][2,1], Rational{Int})
 end
 
 function test_ind2sub(::Type{TestAbstractArray})


### PR DESCRIPTION
Fixes #18395

...unfortunately it segfaults when I run the tests.

```
➜  julia-dev git:(anj/hvcat) ./julia test/runtests.jl abstractarray
     * abstractarray
signal (11): Segmentation fault: 11
while loading /Users/andreasnoack/julia-dev/test/abstractarray.jl, in expression starting on line 696
ht_keyindex at ./dict.jl:647
get at ./dict.jl:806 [inlined]
getindex at /Users/andreasnoack/julia-dev/test/abstractarray.jl:214
convert at /Users/andreasnoack/julia-dev/test/abstractarray.jl:202
collect_to_with_first! at ./array.jl:364 [inlined]
collect at ./array.jl:346
getindex at ./tuple.jl:18
unknown function (ip: 0x31b08d1b6)
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
typed_hvcat at ./abstractarray.jl:1444
test_cat at /Users/andreasnoack/julia-dev/test/abstractarray.jl:558
unknown function (ip: 0x31b079742)
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
do_call at /Users/andreasnoack/julia-dev/src/interpreter.c:66
eval at /Users/andreasnoack/julia-dev/src/interpreter.c:205
jl_toplevel_eval_flex at /Users/andreasnoack/julia-dev/src/toplevel.c:619
jl_parse_eval_all at /Users/andreasnoack/julia-dev/src/ast.c:735
jl_load at /Users/andreasnoack/julia-dev/src/toplevel.c:657 [inlined]
jl_load_ at /Users/andreasnoack/julia-dev/src/toplevel.c:666
include_from_node1 at ./loading.jl:534
jlcall_include_from_node1_18800 at /Users/andreasnoack/julia-dev/usr/lib/julia/sys.dylib (unknown line)
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
macro expansion at ./util.jl:232 [inlined]
runtests at /Users/andreasnoack/julia-dev/test/testdefs.jl:7
#592 at ./multi.jl:1030
run_work_thunk at ./multi.jl:1001
unknown function (ip: 0x110dcc8f9)
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
#remotecall_fetch#597 at ./multi.jl:1055
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
jl_apply at /Users/andreasnoack/julia-dev/src/./julia.h:1364 [inlined]
jl_f__apply at /Users/andreasnoack/julia-dev/src/builtins.c:547
remotecall_fetch at ./multi.jl:1055
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
jl_apply at /Users/andreasnoack/julia-dev/src/./julia.h:1364 [inlined]
jl_f__apply at /Users/andreasnoack/julia-dev/src/builtins.c:547
#remotecall_fetch#601 at ./multi.jl:1080
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
jl_apply at /Users/andreasnoack/julia-dev/src/./julia.h:1364 [inlined]
jl_f__apply at /Users/andreasnoack/julia-dev/src/builtins.c:547
remotecall_fetch at ./multi.jl:1080
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
macro expansion at /Users/andreasnoack/julia-dev/test/runtests.jl:44 [inlined]
#15 at ./task.jl:363
unknown function (ip: 0x110dcc1af)
jl_call_method_internal at /Users/andreasnoack/julia-dev/src/./julia_internal.h:185 [inlined]
jl_apply_generic at /Users/andreasnoack/julia-dev/src/gf.c:1931
jl_apply at /Users/andreasnoack/julia-dev/src/./julia.h:1364 [inlined]
start_task at /Users/andreasnoack/julia-dev/src/task.c:259
Allocations: 20281836 (Pool: 20279113; Big: 2723); GC: 33
[1]    33057 segmentation fault  ./julia test/runtests.jl abstractarray
```
