### PR TITLE
Proposal for metadata-v3

### DIFF
--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -8,6 +8,9 @@ export dir, init, rm, add, available, installed, status, clone, checkout,
 
 const DEFAULT_META = "https://github.com/JuliaLang/METADATA.jl"
 const META_BRANCH = "metadata-v2"
+const DEVEL_META_BRANCH = "metadata-v3"
+
+isdevmetadata() = Dir.getmetabranch() == DEVEL_META_BRANCH
 
 type PkgError <: Exception
     msg::AbstractString

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -3,7 +3,7 @@
 module Reqs
 
 import Base: ==
-import ...Pkg.PkgError
+import ...Pkg: PkgError, isdevmetadata
 using ..Types
 
 # representing lines of REQUIRE files
@@ -113,8 +113,9 @@ parse(x) = parse(read(x))
 
 function dependents(packagename::AbstractString)
     pkgs = AbstractString[]
+    devmetadata = isdevmetadata()
     cd(Pkg.dir()) do
-        for (pkg,latest) in Pkg.Read.latest()
+        for (pkg,latest) in Pkg.Read.latest(devmetadata)
             if haskey(latest.requires, packagename)
                 push!(pkgs, pkg)
             end

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -2,11 +2,11 @@
 
 module Write
 
-import ...LibGit2, ..Cache, ..Read, ...Pkg.PkgError
+import ...LibGit2, ..Cache, ..Read, ...Pkg.PkgError, ..isdevmetadata
 importall ...LibGit2
 
 function prefetch(pkg::AbstractString, sha1::AbstractString)
-    isempty(Cache.prefetch(pkg, Read.url(pkg), sha1)) && return
+    isempty(Cache.prefetch(pkg, Read.url(pkg, isdevmetadata()), sha1)) && return
     throw(PkgError("$pkg: couldn't find commit $(sha1[1:10])"))
 end
 
@@ -27,7 +27,7 @@ function fetch(repo::GitRepo, pkg::AbstractString, sha1::AbstractString)
 end
 
 function checkout(repo::GitRepo, pkg::AbstractString, sha1::AbstractString)
-    LibGit2.set_remote_url(repo, Cache.normalize_url(Read.url(pkg)))
+    LibGit2.set_remote_url(repo, Cache.normalize_url(Read.url(pkg, isdevmetadata())))
     LibGit2.checkout!(repo, sha1)
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -57,7 +57,7 @@ macro grab_outputs(ex)
     end
 end
 
-for branch in (Pkg.META_BRANCH, Pkg.DEVEL_META_BRANCH)
+for branch in (Pkg.META_BRANCH,) # Pkg.DEVEL_META_BRANCH)
 # Test basic operations: adding or removing a package, status, free
 # Also test for the existence of REQUIRE and META_BRANCH
 temp_pkg_dir(branch) do


### PR DESCRIPTION
## Problem

The current way METADATA is structured hits the most pessimistic case in many systems that interact with it.
- Slow hard drives and slower file systems have significant overhead opening all files (currently 20k+ and increasing rapidly).
- Alignment requirements of files in certain file system means that METADATA takes an excessive amount of hard drive space
- The Github METADATA repo website takes a long time to load and is generally "laggy". Results are currently also truncated due to a 1000 file per tree limit.
- Having so many files in one folder is pessimistic when it comes to the Git model, see: https://github.com/CocoaPods/CocoaPods/issues/4989#issuecomment-193835710

I therefore propose a new file structure for METADATA, a `metadata-v3` if you wish. This new format aims to solve all of the problems above.  Note that the suggestion here is purely for performance and is not intended to change anything how `Pkg` works or how users interact with it.
## Changes
- Each package is put in a folder according to the first letter of the package name.
- All the information for each package is contained in a single file.
- The format of the file is as follows:
  - The file is named `<PACKAGE NAME>.versions`
  - The content is:
  
  ```
   url to package repo
   <BLANK LINE> <
   version n    |
   -------      |
   sha1         |
   req 1        |
   req 2        |
   ...          |
   req m ----- n+= 1
  ```
  - An example of such a file is:
  
  ```
  git://github.com/HSU-ANT/ACME.jl.git
  
  0.1.0
  -----
  bd831384dcb4435367bb1370c47d89b2f604a15a
  julia 0.3
  Compat 0.7.9
  ProgressMeter 0.2.1
  
  0.1.1
  -----
  ac5e269dde43edad43241313f5593c90aa5d7bd2
  julia 0.3
  Compat 0.7.15
  ProgressMeter 0.2.1
  ```

I currently have a METADATA fork that has this format at https://github.com/KristofferC/METADATA.jl/tree/metadata-v3. I regularly run a convert script to sync the current METADATA to it. The convert script can be seen at https://gist.github.com/KristofferC/7c101bfb896a1e719808ee9374f913e8 and it takes an input folder (the current METADATA) and an output folder (the new METADATA).
## Upgrade path.

It is important that the upgrade path is as smooth as possible for both users and package writers. It would also be preferable if developers on 0.4 (where there is no `PkgDev`) could still submit packages. One possible way to do this is to have a bidirectional mirror script that runs regularly between `metadata-v2` and `metadata-v3`. The new format is implemented in `PkgDev` which checks what branch METADATA is on and uses the correct format when using `PkgDev.tag`. 
## This PR

This PR introduces support for the `metadata-v3` format I proposed above while keeping support for `metadata-v2`, this is "dispatched" on the contents of the `META_BRANCH` file. The `pkg` tests passess sucessfully on https://github.com/KristofferC/METADATA.jl/tree/metadata-v3 but are currently disabled. Note that it is made on top of #18289. At some point we could add the `metadata-v3` branch to the JuliaLang METADATA repo and then anyone who wants to try it out can simply run `Pkg.init("https://github.com/JuliaLang/METADATA.jl", "metadata-v3")` to try it out and report bugs.

If things look good a patch could be added to `PkgDev` to add support for the new format as well as setting up a script to sync back to `metadata-v2`. 

It is worth to think about how this will fit into "pkg3" but there is little public information about it so it is difficult.
