### PR TITLE
fix jl_method_lookup_by_type disabling the wrong cache

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1422,7 +1422,7 @@ end
 # create a specialized LambdaInfo from a method
 function specialize_method(method::Method, types::ANY, sp::SimpleVector, cached)
     if cached
-        return ccall(:jl_specializations_get_linfo, Ref{LambdaInfo}, (Any, Any, Any), method, types, sp)
+        return ccall(:jl_specializations_get_linfo, Ref{LambdaInfo}, (Any, Any, Any, Cint), method, types, sp, true)
     else
         return ccall(:jl_get_specialized, Ref{LambdaInfo}, (Any, Any, Any), method, types, sp)
     end

--- a/src/dump.c
+++ b/src/dump.c
@@ -1591,7 +1591,7 @@ static jl_value_t *jl_deserialize_value_(jl_serializer_state *s, jl_value_t *vta
             if (external) {
                 jl_datatype_t *ftype = jl_first_argument_datatype((jl_value_t*)li->specTypes);
                 jl_methtable_t *mt = ftype->name->mt;
-                li = jl_method_lookup_by_type(mt, li->specTypes, 1, 0, 0);
+                li = jl_method_lookup_by_type(mt, li->specTypes, 0, 0, 0);
                 assert(li);
                 backref_list.items[pos] = li;
                 // if it can be inferred but isn't, encourage codegen to infer it
@@ -2456,7 +2456,7 @@ static void jl_recache_types(void)
             jl_datatype_t *ftype = jl_first_argument_datatype((jl_value_t*)argtypes);
             jl_methtable_t *mt = ftype->name->mt;
             jl_set_typeof(li, (void*)(intptr_t)0x30); // invalidate the old value to help catch errors
-            li = jl_method_lookup_by_type(mt, argtypes, 1, 0, 0);
+            li = jl_method_lookup_by_type(mt, argtypes, 0, 0, 0);
             assert(li);
             // if it can be inferred but isn't, encourage codegen to infer it
             if (inferred && !li->inferred) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -117,7 +117,7 @@ static int8_t jl_cachearg_offset(jl_methtable_t *mt)
 /// ----- Insertion logic for special entries ----- ///
 
 // get or create the LambdaInfo for a specialization
-JL_DLLEXPORT jl_lambda_info_t *jl_specializations_get_linfo(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams)
+JL_DLLEXPORT jl_lambda_info_t *jl_specializations_get_linfo(jl_method_t *m, jl_tupletype_t *type, jl_svec_t *sparams, int allow_exec)
 {
     JL_LOCK(&m->writelock);
     jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(m->specializations, type, NULL, 1, /*subtype*/0, /*offs*/0);
@@ -125,7 +125,7 @@ JL_DLLEXPORT jl_lambda_info_t *jl_specializations_get_linfo(jl_method_t *m, jl_t
         JL_UNLOCK(&m->writelock);
         return (jl_lambda_info_t*)sf->func.value;
     }
-    jl_lambda_info_t *li = jl_get_specialized(m, type, sparams, 1);
+    jl_lambda_info_t *li = jl_get_specialized(m, type, sparams, allow_exec);
     JL_GC_PUSH1(&li);
     // TODO: fuse lookup and insert steps
     jl_typemap_insert(&m->specializations, (jl_value_t*)m, type, jl_emptysvec, NULL, jl_emptysvec, (jl_value_t*)li, 0, &tfunc_cache, NULL);
@@ -758,7 +758,7 @@ static jl_lambda_info_t *cache_method(jl_methtable_t *mt, union jl_typemap_t *ca
     }
 
     // here we infer types and specialize the method
-    newmeth = jl_specializations_get_linfo(definition, type, sparams);
+    newmeth = jl_specializations_get_linfo(definition, type, sparams, allow_exec);
 
     if (cache_with_orig) {
         // if there is a need to cache with one of the original signatures,
@@ -827,7 +827,7 @@ static jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *
     sig = join_tsig(tt, entry->sig);
     jl_lambda_info_t *nf;
     if (!cache) {
-        nf = jl_get_specialized(m, sig, env, allow_exec);
+        nf = jl_specializations_get_linfo(m, sig, env, allow_exec);
     }
     else {
         nf = cache_method(mt, &mt->cache, (jl_value_t*)mt, sig, tt, entry, env, allow_exec);
@@ -1593,7 +1593,7 @@ static void _compile_all_deq(jl_array_t *found)
         if (m->isstaged)
             linfo = templ;
         else
-            linfo = jl_specializations_get_linfo(m, ml->sig, jl_emptysvec);
+            linfo = jl_specializations_get_linfo(m, ml->sig, jl_emptysvec, 1);
 
         if (linfo->jlcall_api == 2)
             continue;


### PR DESCRIPTION
we want cache=false to disable putting the method in mt->cache (possibly with a wider signature)
but it should still be doing the expected unique-ing through the method->specializations cache

fix #18404
