### PR TITLE
Prevent repl tests from hanging if homedir() is a symlink

### DIFF
--- a/test/repl.jl
+++ b/test/repl.jl
@@ -86,10 +86,10 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
         write(stdin_write, ";")
         readuntil(stdout_read, "shell> ")
         write(stdin_write, "cd\n")
-        readuntil(stdout_read, homedir()[max(1,end-39):end])
+        readuntil(stdout_read, realpath(homedir())[max(1,end-39):end])
         readuntil(stdout_read, "\n")
         readuntil(stdout_read, "\n")
-        @test pwd() == homedir()
+        @test pwd() == realpath(homedir())
     end
     cd(origpwd)
 


### PR DESCRIPTION
I am testing julia on a machine where my home directory is a symlink.  Unfortunately, this means the repl tests hang, as they wait for the homedir to be given at the shell prompt, but instead the `pwd()` is printed.  `pwd()` calls `uv_cwd()` which calls `getcwd()`, which [will always resolve symbolic links](http://stackoverflow.com/a/1545838/1558890), thus printing something other than `homedir()` on my system. This PR changes the repl tests to wait for `realpath(homedir())` instead of `homedir()`.

I am confident that this is the correct change for UNIX systems, but I do not know enough about Windows to know whether this might cause problems there.  That said, a few lines earlier, the tests wait for `realpath(tmpdir)`, which has caused no problems on Windows, so I expect this is the correct fix there too.

(Incidentially, [I was the original author](https://github.com/JuliaLang/julia/commit/3aa64ef1832aca239b372a9c3b8e5a32b5b22e0d) of these tests, so I have only myself to blame!)
