### PR TITLE
Remove ppc specific treatment in unwind.mk.

### DIFF
--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -28,12 +28,9 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-define LIBUNWIND_INSTALL
-	$(call MAKE_INSTALL,$1,$2,$3)
-endef
 $(eval $(call staged-install, \
 	unwind,libunwind-$(UNWIND_VER), \
-	LIBUNWIND_INSTALL,,,))
+	MAKE_INSTALL,,,))
 
 clean-unwind:
 	-rm $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -30,10 +30,6 @@ endif
 
 define LIBUNWIND_INSTALL
 	$(call MAKE_INSTALL,$1,$2,$3)
-ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
-	@# workaround for configure script bug
-	mv $2/$$(build_prefix)/lib64/libunwind*.a $2/$$(build_libdir)
-  endif
 endef
 $(eval $(call staged-install, \
 	unwind,libunwind-$(UNWIND_VER), \


### PR DESCRIPTION
libunwind on ppc64 is getting installed correctly. This fix isn't required (although in my testing, it never showed an error). 

Should fix the buildbot failure seen here:
https://build.julialang.org/builders/package_tarballppc64le/builds/26/steps/make/logs/stdio
