### PR TITLE
Disable at-simd warning.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3290,8 +3290,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
         return mark_julia_type(builder.CreateCall(prepare_call(jlcopyast_func), boxed(ast, ctx)), true, ast.typ, ctx);
     }
     else if (head == simdloop_sym) {
-        if (!llvm::annotateSimdLoop(builder.GetInsertBlock()))
-            jl_printf(JL_STDERR, "WARNING: could not attach metadata for @simd loop.\n");
+        llvm::annotateSimdLoop(builder.GetInsertBlock());
         return jl_cgval_t();
     }
     else if (head == goto_ifnot_sym) {


### PR DESCRIPTION
It's not helpful/annoy for users because,
1. It doesn't cover the majority of the cases when a loop can't be vectorized (the majority of the cases that matters anyway).
2. It makes it hard to put `@simd` on a loop that might be vectorizable without getting the warning for non builtin types.

It's not really helpful for debugging vectorization failure due to codegen issues either since
1. In it's current state (probably different before), I've never seen a single case captured by it
2. It doesn't print any useful debug info with it so you need some other ways to print the llvm ir anyway
