### PR TITLE
recompute sparams during inference after widening a method signature

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1089,6 +1089,9 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         fieldval.gcroot = strct.gcroot;
         return fieldval;
     }
+    else if (isa<UndefValue>(strct.V)) {
+        return jl_cgval_t();
+    }
     else {
         if (strct.V->getType()->isVectorTy()) {
             fldv = builder.CreateExtractElement(strct.V, ConstantInt::get(T_int32, idx));

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1159,6 +1159,16 @@ JL_DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b)
     return ti;
 }
 
+JL_DLLEXPORT jl_svec_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t *tvars)
+{
+    jl_svec_t *env = jl_emptysvec;
+    JL_GC_PUSH1(&env);
+    jl_value_t *ti = jl_type_intersection_matching(a, b, &env, tvars);
+    jl_svec_t *pair = jl_svec2(ti, env);
+    JL_GC_POP();
+    return pair;
+}
+
 /*
   constraint satisfaction algorithm:
   - keep lists of equality constraints and subtype constraints

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -336,3 +336,30 @@ f18222(x) = true
 g18222(x) = f18222(x)
 @test f18222(1) == g18222(1) == true
 @test f18222(1.0) == g18222(1.0) == false
+
+# issue #18399
+# TODO: this test is rather brittle
+type TSlow18399{T}
+    x::T
+end
+function hvcat18399(as)
+    cb = ri->as[ri]
+    g = Base.Generator(cb, 1)
+    return g.f(1)
+end
+function cat_t18399(X...)
+    for i = 2:1
+        X[i]
+        d->i
+    end
+end
+C18399 = TSlow18399{Int}(1)
+GB18399 = TSlow18399{Int}(1)
+function test18399(C)
+    B = GB18399::Union{TSlow18399{Int},TSlow18399{Any}}
+    cat_t18399()
+    cat_t18399(B, B, B)
+    hvcat18399((C,))
+    return hvcat18399(((2, 3),))
+end
+@test test18399(C18399) == (2, 3)


### PR DESCRIPTION
also avoid an expensive loop in the common case of the hotpath

fix #18399
