### PR TITLE
Fix libgit `ldd` parsing to find `libssl` and `libcrypto`

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -84,7 +84,7 @@ else
 endif
 ifeq ($$(OS),Linux)
 	@# If we're on linux, copy over libssl and libcrypto for libgit2
-	-LIBGIT_LIBS=$$$$(ldd "$$@" | tail -n +2 | awk '{print $$$$(NF-1)}'); \
+	-LIBGIT_LIBS=$$$$(ldd "$1/libgit2.$$(SHLIB_EXT)" | tail -n +2 | awk '{print $$$$(NF-1)}'); \
 	for LIB in libssl libcrypto; do \
 		LIB_PATH=$$$$(echo "$$$$LIBGIT_LIBS" | grep "$$$$LIB"); \
 		echo "LIB_PATH for $$$$LIB: $$$$LIB_PATH"; \


### PR DESCRIPTION
This used to work, back when this was invoked as part of a rule targeting `libgit2.so`, but now that it's within a function, it's better to just be more explicit and reference `libgit2.so` directly.

This should fix the breakage currently rampaging throughout the Travis-sphere due to missing `libssl` and `libcrypto` libraries.
