### PR TITLE
Fix reflection macros for keyword calls

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -347,9 +347,12 @@ function gen_call_with_extracted_types(fcn, ex0)
         if any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex0.args)
             # remove keyword args, but call the kwfunc
             args = filter(a->!(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex0.args)
-            return :($(fcn)(Core.kwfunc($(esc(args[1]))),
-                            Tuple{Vector{Any}, typeof($(esc(args[1]))),
-                                  $(typesof)($(map(esc, args[2:end])...)).parameters...}))
+            return quote
+                local arg1 = $(esc(args[1]))
+                $(fcn)(Core.kwfunc(arg1),
+                       Tuple{Vector{Any}, Core.Typeof(arg1),
+                             $(typesof)($(map(esc, args[2:end])...)).parameters...})
+            end
         elseif ex0.head == :call
             return Expr(:call, fcn, esc(ex0.args[1]),
                         Expr(:call, typesof, map(esc, ex0.args[2:end])...))

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -553,3 +553,18 @@ let
     @test length(a) == 0
     @test length(b) == 0
 end
+
+type A18434
+end
+(::Type{A18434})(x; y=1) = 1
+
+global counter18434 = 0
+function get_A18434()
+    global counter18434
+    counter18434 += 1
+    return A18434
+end
+@which get_A18434()(1; y=2)
+@test counter18434 == 1
+@which get_A18434()(1, y=2)
+@test counter18434 == 2


### PR DESCRIPTION
Do note that the returned value is the keyword wrapper so it might not be what some people want.

Fix #18434 
