### PR TITLE
Add project editor configuration file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Define and maintain consistent coding styles between different
+# editors and IDEs. See editorconfig.org for more information.
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[{Makefile,*.mk,*.make,*.inc}]
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
It seems that many common editors honor the configuration settings in .editorconfig files. As such, I figured it might be a good idea to include one here to hopefully help enforce code style guidelines for contributions. More information about the file format and supporting editors can be found at http://editorconfig.org.

Skipping CI because this should have no effect on... well, anything.
