### PR TITLE
Make application/julia a text MIME

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1011,9 +1011,9 @@ export @vectorize_1arg, @vectorize_2arg
 
 # Deprecate @textmime into the Multimedia module, #18441
 eval(Multimedia, :(macro textmime(mime)
-    Base.depwarn(string("`@textmime mime` is deprecated; use ",
-        "`Base.Multimedia.mimetypetype(::MIME{mime}) = ",
-        "Base.Multimedia.IsText` instead."), :textmime)
+    Base.depwarn(string("`@textmime \"mime\"` is deprecated; use ",
+        "`Base.Multimedia.istextmime(::MIME\"mime\") = true` instead"
+        ), :textmime)
     quote
         Base.Multimedia.istextmime(::MIME{$(Meta.quot(Symbol(mime)))}) = true
     end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1009,4 +1009,15 @@ export @vectorize_1arg, @vectorize_2arg
 @deprecate abs(M::SymTridiagonal) abs.(M)
 @deprecate abs(x::AbstractSparseVector) abs.(x)
 
+# Deprecate @textmime into the Multimedia module, #18441
+eval(Multimedia, :(macro textmime(mime)
+    Base.depwarn(string("`@textmime mime` is deprecated; use ",
+        "`Base.Multimedia.mimetypetype(::MIME{mime}) = ",
+        "Base.Multimedia.IsText` instead."), :textmime)
+    quote
+        Base.Multimedia.mimetypetype(::MIME{$(Meta.quot(Symbol(mime)))}) =
+            Base.Multimedia.IsText()
+    end
+end))
+
 # End deprecations scheduled for 0.6

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1015,8 +1015,7 @@ eval(Multimedia, :(macro textmime(mime)
         "`Base.Multimedia.mimetypetype(::MIME{mime}) = ",
         "Base.Multimedia.IsText` instead."), :textmime)
     quote
-        Base.Multimedia.mimetypetype(::MIME{$(Meta.quot(Symbol(mime)))}) =
-            Base.Multimedia.IsText()
+        Base.Multimedia.istextmime(::MIME{$(Meta.quot(Symbol(mime)))}) = true
     end
 end))
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3074,15 +3074,6 @@ type. This is similar to [`reprmime`](:func:`reprmime`) except that binary data 
 stringmime
 
 """
-    print_with_color(color::Symbol, [io], strings...)
-
-Print strings in a color specified as a symbol.
-
-`color` may take any of the values $(Base.available_text_colors_docstring).
-"""
-print_with_color
-
-"""
     zero(x)
 
 Get the additive identity element for the type of `x` (`x` can also specify the type itself).

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2632,22 +2632,6 @@ the current exception (if called within a `catch` block).
 rethrow
 
 """
-    reprmime(mime, x)
-
-Returns an `AbstractString` or `Vector{UInt8}` containing the representation of `x` in the
-requested `mime` type, as written by `show` (throwing a `MethodError` if no appropriate
-`show` is available). An `AbstractString` is returned for MIME types with textual
-representations (such as `"text/html"` or `"application/postscript"`), whereas binary data
-is returned as `Vector{UInt8}`. (The function `istextmime(mime)` returns whether or not Julia
-treats a given `mime` type as text.)
-
-As a special case, if `x` is an `AbstractString` (for textual MIME types) or a
-`Vector{UInt8}` (for binary MIME types), the `reprmime` function assumes that `x` is already
-in the requested `mime` format and simply returns `x`.
-"""
-reprmime
-
-"""
     !(x)
 
 Boolean not.
@@ -3088,6 +3072,15 @@ Returns an `AbstractString` containing the representation of `x` in the requeste
 type. This is similar to [`reprmime`](:func:`reprmime`) except that binary data is base64-encoded as an ASCII string.
 """
 stringmime
+
+"""
+    print_with_color(color::Symbol, [io], strings...)
+
+Print strings in a color specified as a symbol.
+
+`color` may take any of the values $(Base.available_text_colors_docstring).
+"""
+print_with_color
 
 """
     zero(x)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3264,13 +3264,6 @@ processes completed successfully.
 exit
 
 """
-    istextmime(m::MIME)
-
-Determine whether a MIME type is text data.
-"""
-istextmime
-
-"""
     skipchars(stream, predicate; linecomment::Char)
 
 Advance the stream until before the first character for which `predicate` returns `false`.

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -81,7 +81,7 @@ istextmime(m::AbstractString) = istextmime(MIME(m))
 reprmime(m::AbstractString, x) = reprmime(MIME(m), x)
 stringmime(m::AbstractString, x) = stringmime(MIME(m), x)
 
-for mime in ["text/vnd.graphviz", "text/latex", "text/calendar", "text/n3", "text/richtext", "text/x-setext", "text/sgml", "text/tab-separated-values", "text/x-vcalendar", "text/x-vcard", "text/cmd", "text/css", "text/csv", "text/html", "text/javascript", "text/markdown", "text/plain", "text/vcard", "text/xml", "application/atom+xml", "application/ecmascript", "application/json", "application/rdf+xml", "application/rss+xml", "application/xml-dtd", "application/postscript", "image/svg+xml", "application/x-latex", "application/xhtml+xml", "application/javascript", "application/xml", "model/x3d+xml", "model/x3d+vrml", "model/vrml"]
+for mime in ["application/atom+xml", "application/ecmascript", "application/javascript", "application/julia", "application/json", "application/postscript", "application/rdf+xml", "application/rss+xml", "application/x-latex", "application/xhtml+xml", "application/xml", "application/xml-dtd", "image/svg+xml", "model/vrml", "model/x3d+vrml", "model/x3d+xml", "text/calendar", "text/cmd", "text/css", "text/csv", "text/html", "text/javascript", "text/latex", "text/markdown", "text/n3", "text/plain", "text/richtext", "text/sgml", "text/tab-separated-values", "text/vcard", "text/vnd.graphviz", "text/x-setext", "text/x-vcalendar", "text/x-vcard", "text/xml"]
     @eval @textmime $mime
 end
 

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -33,56 +33,89 @@ mimewritable{mime}(::MIME{mime}, x) =
 show(io::IO, m::AbstractString, x) = show(io, MIME(m), x)
 mimewritable(m::AbstractString, x) = mimewritable(MIME(m), x)
 
-###########################################################################
-# MIME types are assumed to be binary data except for a set of types known
-# to be text data (possibly Unicode).  istextmime(m) returns whether
-# m::MIME is text data, and reprmime(m, x) returns x written to either
-# a string (for text m::MIME) or a Vector{UInt8} (for binary m::MIME),
-# assuming the corresponding write_mime method exists.  stringmime
-# is like reprmime except that it always returns a string, which in the
-# case of binary data is Base64-encoded.
-#
-# Also, if reprmime is passed a AbstractString for a text type or Vector{UInt8} for
-# a binary type, the argument is assumed to already be in the corresponding
-# format and is returned unmodified.  This is useful so that raw data can be
-# passed to display(m::MIME, x).
+abstract MIMETypeType
+
+immutable IsText <: MIMETypeType end
+immutable IsBytes <: MIMETypeType end
 
 verbose_show(io, m, x) = show(IOContext(io,limit=false), m, x)
 
-macro textmime(mime)
-    quote
-        mimeT = MIME{Symbol($mime)}
-        # avoid method ambiguities with the general definitions below:
-        # (Q: should we treat Vector{UInt8} as a String?)
-        Base.Multimedia.reprmime(m::mimeT, x::Vector{UInt8}) = sprint(verbose_show, m, x)
-        Base.Multimedia.stringmime(m::mimeT, x::Vector{UInt8}) = reprmime(m, x)
+"""
+MIME types are assumed to be binary data except for a set of types known to be
+text data (possibly Unicode). `mimetypetype(m)` returns `Multimedia.IsText` or
+`Multimedia.IsBytes` for text or binary data respectively.
+"""
+mimetypetype{M}(::MIME{M}) =
+    startswith(string(M), "text/") ? IsText() : IsBytes()
 
-        Base.Multimedia.istextmime(::mimeT) = true
-        if $(mime != "text/plain") # strings are shown escaped for text/plain
-            Base.Multimedia.reprmime(m::mimeT, x::AbstractString) = x
-        end
-        Base.Multimedia.reprmime(m::mimeT, x) = sprint(verbose_show, m, x)
-        Base.Multimedia.stringmime(m::mimeT, x) = reprmime(m, x)
-    end
-end
+"""
+    reprmime(mime, x)
 
-istextmime(::MIME) = false
-function reprmime(m::MIME, x)
+Returns an `AbstractString` or `Vector{UInt8}` containing the representation of
+`x` in the requested `mime` type, as written by `show` (throwing a
+`MethodError` if no appropriate `show` is available). An `AbstractString` is
+returned for MIME types with textual representations (such as `"text/html"` or
+`"application/postscript"`), whereas binary data is returned as
+`Vector{UInt8}`. (The function `istextmime(mime)` returns whether or not Julia
+treats a given `mime` type as text.)
+
+As a special case, if `x` is an `AbstractString` (for textual MIME types) or a
+`Vector{UInt8}` (for binary MIME types), the `reprmime` function assumes that
+`x` is already in the requested `mime` format and simply returns `x`. This
+special case does not apply to the `"text/plain"` MIME type. This is useful so
+that raw data can be passed to `display(m::MIME, x)`.
+"""
+reprmime(m::MIME, x) = reprmime(mimetypetype(m), m, x)
+reprmime(::IsText, m::MIME, x) = sprint(verbose_show, m, x)
+
+# strings are shown escaped for text/plain
+reprmime(::IsText, ::MIME, x::AbstractString) = x
+reprmime(::IsText, m::MIME"text/plain", x::AbstractString) =
+    sprint(verbose_show, m, x)
+
+function reprmime(::IsBytes, m::MIME, x)
     s = IOBuffer()
     verbose_show(s, m, x)
     takebuf_array(s)
 end
-reprmime(m::MIME, x::Vector{UInt8}) = x
-stringmime(m::MIME, x) = base64encode(verbose_show, m, x)
-stringmime(m::MIME, x::Vector{UInt8}) = base64encode(write, x)
+reprmime(::IsBytes, m::MIME, x::Vector{UInt8}) = x
+
+"""
+    stringmime(mime, x)
+
+Returns an `AbstractString` containing the representation of `x` in the
+requested `mime` type. This is similar to [`reprmime`](:func:`reprmime`) except
+that binary data is base64-encoded as an ASCII string.
+"""
+stringmime(m::MIME, x) = stringmime(mimetypetype(m), m, x)
+stringmime(::IsText, m::MIME, x) = reprmime(m, x)
+stringmime(::IsBytes, m::MIME, x) = base64encode(verbose_show, m, x)
+stringmime(::IsBytes, m::MIME, x::Vector{UInt8}) = base64encode(write, x)
+
+macro textmime(mime)
+    Base.depwarn(string("`@textmime mime` is deprecated; use ",
+        "`Base.Multimedia.mimetypetype(::MIME{mime}) = ",
+        "Base.Multimedia.IsText` instead."))
+    quote
+        Base.Multimedia.mimetypetype(::MIME{$(Symbol(mime))}) =
+            Base.Multimedia.IsText()
+    end
+end
+
+istextmime(m::MIME) = isa(mimetypetype(m), IsText)
 
 # it is convenient to accept strings instead of ::MIME
 istextmime(m::AbstractString) = istextmime(MIME(m))
 reprmime(m::AbstractString, x) = reprmime(MIME(m), x)
 stringmime(m::AbstractString, x) = stringmime(MIME(m), x)
 
-for mime in ["application/atom+xml", "application/ecmascript", "application/javascript", "application/julia", "application/json", "application/postscript", "application/rdf+xml", "application/rss+xml", "application/x-latex", "application/xhtml+xml", "application/xml", "application/xml-dtd", "image/svg+xml", "model/vrml", "model/x3d+vrml", "model/x3d+xml", "text/calendar", "text/cmd", "text/css", "text/csv", "text/html", "text/javascript", "text/latex", "text/markdown", "text/n3", "text/plain", "text/richtext", "text/sgml", "text/tab-separated-values", "text/vcard", "text/vnd.graphviz", "text/x-setext", "text/x-vcalendar", "text/x-vcard", "text/xml"]
-    @eval @textmime $mime
+for mime in ["application/atom+xml", "application/ecmascript",
+"application/javascript", "application/julia", "application/json",
+"application/postscript", "application/rdf+xml", "application/rss+xml",
+"application/x-latex", "application/xhtml+xml", "application/xml",
+"application/xml-dtd", "image/svg+xml", "model/vrml", "model/x3d+vrml",
+"model/x3d+xml"]
+    mimetypetype(::MIME{Symbol(mime)}) = IsText()
 end
 
 ###########################################################################

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -45,7 +45,7 @@ MIME types are assumed to be binary data except for a set of types known to be
 text data (possibly Unicode). `mimetypetype(m)` returns `Multimedia.IsText` or
 `Multimedia.IsBytes` for text or binary data respectively.
 """
-mimetypetype{M}(::MIME{M}) =
+Base.@pure mimetypetype{M}(::MIME{M}) =
     startswith(string(M), "text/") ? IsText() : IsBytes()
 
 """
@@ -102,6 +102,11 @@ macro textmime(mime)
     end
 end
 
+"""
+    istextmime(m::MIME)
+
+Determine whether a MIME type is text data.
+"""
 istextmime(m::MIME) = isa(mimetypetype(m), IsText)
 
 # it is convenient to accept strings instead of ::MIME

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -92,16 +92,6 @@ stringmime(::IsText, m::MIME, x) = reprmime(m, x)
 stringmime(::IsBytes, m::MIME, x) = base64encode(verbose_show, m, x)
 stringmime(::IsBytes, m::MIME, x::Vector{UInt8}) = base64encode(write, x)
 
-macro textmime(mime)
-    Base.depwarn(string("`@textmime mime` is deprecated; use ",
-        "`Base.Multimedia.mimetypetype(::MIME{mime}) = ",
-        "Base.Multimedia.IsText` instead."))
-    quote
-        Base.Multimedia.mimetypetype(::MIME{$(Symbol(mime))}) =
-            Base.Multimedia.IsText()
-    end
-end
-
 """
     istextmime(m::MIME)
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -782,7 +782,7 @@ Julia environments (such as the IPython-based IJulia notebook).
 
    Returns an ``AbstractString`` or ``Vector{UInt8}`` containing the representation of ``x`` in the requested ``mime`` type, as written by ``show`` (throwing a ``MethodError`` if no appropriate ``show`` is available). An ``AbstractString`` is returned for MIME types with textual representations (such as ``"text/html"`` or ``"application/postscript"``\ ), whereas binary data is returned as ``Vector{UInt8}``\ . (The function ``istextmime(mime)`` returns whether or not Julia treats a given ``mime`` type as text.)
 
-   As a special case, if ``x`` is an ``AbstractString`` (for textual MIME types) or a ``Vector{UInt8}`` (for binary MIME types), the ``reprmime`` function assumes that ``x`` is already in the requested ``mime`` format and simply returns ``x``\ .
+   As a special case, if ``x`` is an ``AbstractString`` (for textual MIME types) or a ``Vector{UInt8}`` (for binary MIME types), the ``reprmime`` function assumes that ``x`` is already in the requested ``mime`` format and simply returns ``x``\ . This special case does not apply to the ``"text/plain"`` MIME type. This is useful so that raw data can be passed to ``display(m::MIME, x)``\ .
 
 .. function:: stringmime(mime, x)
 


### PR DESCRIPTION
Add `application/julia` as a text MIME, and sort the list of text MIMEs.

I wonder if `istextmime` could be made a little more intelligent. All mime types with `text` should be text MIMEs, right?
