### PR TITLE
change default info color to cyan

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -36,7 +36,7 @@ text_colors
 
 have_color = false
 default_color_warn = :red
-default_color_info = :blue
+default_color_info = :cyan
 if is_windows()
     default_color_input = :normal
     default_color_answer = :normal


### PR DESCRIPTION
It is for me almost illegible with the standard blue on black.

Before: 
![image](https://cloud.githubusercontent.com/assets/1282691/18416380/83f4f262-7813-11e6-9a48-64b9859546f2.png)

After:

![image](https://cloud.githubusercontent.com/assets/1282691/18416379/7eecca56-7813-11e6-8591-668ad43fc8d6.png)

On white:

![image](https://cloud.githubusercontent.com/assets/1282691/18416393/c34b4d44-7813-11e6-9a44-24386dbde1a0.png)
