### PR TITLE
Inline invoke (take 3) plus a few other tweaks

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1038,9 +1038,9 @@ An indexing operation into an array, `a`, tried to access an out-of-bounds eleme
 BoundsError
 
 """
-    invoke(f, (types...), args...)
+    invoke(f, types <: Tuple, args...)
 
-Invoke a method for the given generic function matching the specified types (as a tuple), on
+Invoke a method for the given generic function matching the specified types, on
 the specified arguments. The arguments must be compatible with the specified types. This
 allows invoking a method other than the most specific matching method, which is useful when
 the behavior of a more general definition is explicitly needed (often as part of the

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -411,14 +411,14 @@ function serialize(s::AbstractSerializer, S::SharedArray)
 end
 
 function deserialize{T,N}(s::AbstractSerializer, t::Type{SharedArray{T,N}})
-    S = invoke(deserialize, Tuple{AbstractSerializer, DataType}, s, t)
+    S = invoke(deserialize, Tuple{AbstractSerializer,DataType}, s, t)
     init_loc_flds(S, true)
     S
 end
 
 function show(io::IO, S::SharedArray)
     if length(S.s) > 0
-        invoke(show, (IO, DenseArray), io, S)
+        invoke(show, Tuple{IO,DenseArray}, io, S)
     else
         show(io, remotecall_fetch(sharr->sharr.s, S.pids[1], S))
     end
@@ -426,7 +426,7 @@ end
 
 function show(io::IO, mime::MIME"text/plain", S::SharedArray)
     if length(S.s) > 0
-        invoke(show, (IO, MIME"text/plain", DenseArray), io, MIME"text/plain"(), S)
+        invoke(show, Tuple{IO,MIME"text/plain",DenseArray}, io, MIME"text/plain"(), S)
     else
         # retrieve from the first worker mapping the array.
         println(io, summary(S), ":")

--- a/examples/lru.jl
+++ b/examples/lru.jl
@@ -110,7 +110,7 @@ end
 
 # Eviction
 function setindex!{V,K}(lru::BoundedLRU, v::V, key::K)
-    invoke(setindex!, (LRU, V, K), lru, v, key)
+    invoke(setindex!, Tuple{LRU,V,K}, lru, v, key)
     nrm = length(lru) - lru.maxsize
     for i in 1:nrm
         rm = pop!(lru.q)

--- a/src/array.c
+++ b/src/array.c
@@ -529,13 +529,8 @@ JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
 int jl_array_isdefined(jl_value_t **args0, int nargs)
 {
     assert(jl_is_array(args0[0]));
-    jl_value_t **depwarn_args;
-    JL_GC_PUSHARGS(depwarn_args, 3);
-    depwarn_args[0] = jl_get_global(jl_base_module, jl_symbol("depwarn"));
-    depwarn_args[1] = jl_cstr_to_string("isdefined(a::Array, i::Int) is deprecated, use isassigned(a, i) instead");
-    depwarn_args[2] = (jl_value_t*) jl_symbol("isdefined");
-    jl_apply(depwarn_args, 3);
-    JL_GC_POP();
+    jl_depwarn("`isdefined(a::Array, i::Int)` is deprecated, "
+               "use `isassigned(a, i)` instead", jl_symbol("isdefined"));
 
     jl_array_t *a = (jl_array_t*)args0[0];
     jl_value_t **args = &args0[1];

--- a/src/gf.c
+++ b/src/gf.c
@@ -2222,11 +2222,10 @@ jl_value_t *jl_gf_invoke(jl_tupletype_t *types0, jl_value_t **args, size_t nargs
 {
     size_t world = jl_get_ptls_states()->world_age;
     jl_svec_t *tpenv = jl_emptysvec;
-    jl_tupletype_t *newsig = NULL;
     jl_tupletype_t *tt = NULL;
     jl_tupletype_t *types = NULL;
     jl_tupletype_t *sig = NULL;
-    JL_GC_PUSH5(&types, &tpenv, &newsig, &sig, &tt);
+    JL_GC_PUSH4(&types, &tpenv, &sig, &tt);
     jl_value_t *gf = args[0];
     types = (jl_datatype_t*)jl_argtype_with_function(gf, (jl_tupletype_t*)types0);
     jl_methtable_t *mt = jl_gf_mtable(gf);
@@ -2275,6 +2274,88 @@ jl_value_t *jl_gf_invoke(jl_tupletype_t *types0, jl_value_t **args, size_t nargs
     }
     JL_GC_POP();
     return jl_call_method_internal(mfunc, args, nargs);
+}
+
+typedef struct _tupletype_stack_t {
+    struct _tupletype_stack_t *parent;
+    jl_tupletype_t *tt;
+} tupletype_stack_t;
+
+static int tupletype_on_stack(jl_tupletype_t *tt, tupletype_stack_t *stack)
+{
+    while (stack) {
+        if (tt == stack->tt)
+            return 1;
+        stack = stack->parent;
+    }
+    return 0;
+}
+
+static int tupletype_has_datatype(jl_tupletype_t *tt, tupletype_stack_t *stack)
+{
+    for (int i = 0; i < jl_nparams(tt); i++) {
+        jl_value_t *ti = jl_tparam(tt, i);
+        if (ti == (jl_value_t*)jl_datatype_type)
+            return 1;
+        if (jl_is_tuple_type(ti)) {
+            jl_tupletype_t *tt1 = (jl_tupletype_t*)ti;
+            if (!tupletype_on_stack(tt1, stack) &&
+                tupletype_has_datatype(tt1, stack)) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+JL_DLLEXPORT jl_value_t *jl_get_invoke_lambda(jl_methtable_t *mt,
+                                              jl_typemap_entry_t *entry,
+                                              jl_tupletype_t *tt,
+                                              size_t world)
+{
+    if (!jl_is_leaf_type((jl_value_t*)tt) || tupletype_has_datatype(tt, NULL))
+        return jl_nothing;
+
+    jl_method_t *method = entry->func.method;
+    jl_typemap_entry_t *tm = NULL;
+    if (method->invokes.unknown != NULL) {
+        tm = jl_typemap_assoc_by_type(method->invokes, tt, NULL, 0, 1,
+                                      jl_cachearg_offset(mt), world);
+        if (tm) {
+            return (jl_value_t*)tm->func.linfo;
+        }
+    }
+
+    JL_LOCK(&method->writelock);
+    if (method->invokes.unknown != NULL) {
+        tm = jl_typemap_assoc_by_type(method->invokes, tt, NULL, 0, 1,
+                                      jl_cachearg_offset(mt), world);
+        if (tm) {
+            jl_method_instance_t *mfunc = tm->func.linfo;
+            JL_UNLOCK(&method->writelock);
+            return (jl_value_t*)mfunc;
+        }
+    }
+    jl_svec_t *tpenv = jl_emptysvec;
+    jl_tupletype_t *sig = NULL;
+    JL_GC_PUSH2(&tpenv, &sig);
+    if (entry->tvars != jl_emptysvec) {
+        jl_value_t *ti =
+            jl_lookup_match((jl_value_t*)tt, (jl_value_t*)entry->sig, &tpenv, entry->tvars);
+        assert(ti != (jl_value_t*)jl_bottom_type);
+        (void)ti;
+    }
+    sig = join_tsig(tt, entry->sig);
+    jl_method_t *func = entry->func.method;
+
+    if (func->invokes.unknown == NULL)
+        func->invokes.unknown = jl_nothing;
+
+    jl_method_instance_t *mfunc = cache_method(mt, &func->invokes, entry->func.value,
+                                               sig, tt, entry, world, tpenv, 1);
+    JL_GC_POP();
+    JL_UNLOCK(&method->writelock);
+    return (jl_value_t*)mfunc;
 }
 
 static jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *module, jl_datatype_t *st, int iskw)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -829,6 +829,7 @@ STATIC_INLINE void *jl_get_frame_addr(void)
 }
 
 JL_DLLEXPORT jl_array_t *jl_array_cconvert_cstring(jl_array_t *a);
+void jl_depwarn(const char *msg, jl_sym_t *sym);
 
 int isabspath(const char *in);
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -2224,13 +2224,6 @@ f9520c(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, args...) = 46
 @test invoke(f9520b, Tuple{Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6) == 23
 @test invoke(f9520c, Tuple{Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6) == 46
 @test invoke(f9520c, Tuple{Any, Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6, 7) == 46
-# Keep until the old signature of invoke is dropped.
-@test invoke(f9520a, (Any, Any), 1, 2) == 15
-@test invoke(f9520a, (Any, Any, Any), 1, 2, 3) == 15
-@test invoke(f9520b, (Any, Any, Any), 1, 2, 3) == 23
-@test invoke(f9520b, (Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6) == 23
-@test invoke(f9520c, (Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6) == 46
-@test invoke(f9520c, (Any, Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6, 7) == 46
 
 call_lambda1() = (()->x)(1)
 call_lambda2() = ((x)->x)()
@@ -3672,7 +3665,7 @@ f14245() = (v = []; push!(v, length(v)); v)
         return y
     end
 end
-foo9677(x::Array) = invoke(foo9677,(AbstractArray,),x)
+foo9677(x::Array) = invoke(foo9677, Tuple{AbstractArray}, x)
 @test foo9677(1:5) == foo9677(randn(3))
 
 # issue #6846
@@ -4191,7 +4184,7 @@ end
 
 # issue #8712
 type Issue8712; end
-@test isa(invoke(Issue8712, ()), Issue8712)
+@test isa(invoke(Issue8712, Tuple{}), Issue8712)
 
 # issue #16089
 f16089(args...) = typeof(args)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4652,6 +4652,21 @@ catch e
     (e::ErrorException).msg
 end == "generated function body is not pure. this likely means it contains a closure or comprehension."
 
+let x = 1
+    global g18444
+    @noinline g18444(a) = (x += 1; a[])
+    f18444_1(a) = invoke(sin, Tuple{Int}, g18444(a))
+    f18444_2(a) = invoke(sin, Tuple{Integer}, g18444(a))
+    @test_throws ErrorException f18444_1(Ref{Any}(1.0))
+    @test x == 2
+    @test_throws ErrorException f18444_2(Ref{Any}(1.0))
+    @test x == 3
+    @test f18444_1(Ref{Any}(1)) === sin(1)
+    @test x == 4
+    @test f18444_2(Ref{Any}(1)) === sin(1)
+    @test x == 5
+end
+
 # issue #10981, long argument lists
 let a = fill(["sdf"], 2*10^6), temp_vcat(x...) = vcat(x...)
     # we introduce a new function `temp_vcat` to make sure there is no existing

--- a/test/datafmt.jl
+++ b/test/datafmt.jl
@@ -248,7 +248,7 @@ end
 @test sprint(io -> show(io, "text/csv", [1 2; 3 4])) == "1,2\n3,4\n"
 
 for writefunc in ((io,x) -> show(io, "text/csv", x),
-                  (io,x) -> invoke(writedlm, (IO, Any, Any), io, x, ","))
+                  (io,x) -> invoke(writedlm, Tuple{IO,Any,Any}, io, x, ","))
     # iterable collections of iterable rows:
     let x = [(1,2), (3,4)], io = IOBuffer()
         writefunc(io, x)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -509,7 +509,7 @@ end
 # filtering
 let d = Dict(zip(1:1000,1:1000)), f = (k,v) -> iseven(k)
     @test filter(f, d) == filter!(f, copy(d)) ==
-          invoke(filter!, (Function, Associative), f, copy(d)) ==
+          invoke(filter!, Tuple{Function,Associative}, f, copy(d)) ==
           Dict(zip(2:2:1000, 2:2:1000))
 end
 

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -259,7 +259,7 @@ for elty in (Float32,Float64,Complex64,Complex128)
     @test x.'*y == convert(Vector{elty},[29.0])
 end
 
-vecdot_(x,y) = invoke(vecdot, (Any,Any), x,y) # generic vecdot
+vecdot_(x,y) = invoke(vecdot, Tuple{Any,Any}, x,y) # generic vecdot
 let AA = [1+2im 3+4im; 5+6im 7+8im], BB = [2+7im 4+1im; 3+8im 6+5im]
     for Atype = ["Array", "SubArray"],  Btype = ["Array", "SubArray"]
         A = Atype == "Array" ? AA : view(AA, 1:2, 1:2)

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -47,7 +47,7 @@ X = [2 3 1 -1; 7 4 5 -4]
 @test median!([1 2; 3 4]) == 2.5
 
 
-@test invoke(median, (AbstractVector,), 1:10) == median(1:10) == 5.5
+@test invoke(median, Tuple{AbstractVector}, 1:10) == median(1:10) == 5.5
 
 # mean
 @test_throws ArgumentError mean(())
@@ -338,14 +338,14 @@ y = [0.40003674665581906,0.4085630862624367,0.41662034698690303,0.41662034698690
 
 # variance of complex arrays (#13309)
 let z = rand(Complex128, 10)
-    @test var(z) ≈ invoke(var, (Any,), z) ≈ cov(z) ≈ var(z,1)[1] ≈ sum(abs2, z - mean(z))/9
+    @test var(z) ≈ invoke(var, Tuple{Any}, z) ≈ cov(z) ≈ var(z,1)[1] ≈ sum(abs2, z - mean(z))/9
     @test isa(var(z), Float64)
-    @test isa(invoke(var, (Any,), z), Float64)
+    @test isa(invoke(var, Tuple{Any}, z), Float64)
     @test isa(cov(z), Float64)
     @test isa(var(z,1), Vector{Float64})
-    @test varm(z, 0.0) ≈ invoke(varm, (Any,Float64), z, 0.0) ≈ sum(abs2, z)/9
+    @test varm(z, 0.0) ≈ invoke(varm, Tuple{Any,Float64}, z, 0.0) ≈ sum(abs2, z)/9
     @test isa(varm(z, 0.0), Float64)
-    @test isa(invoke(varm, (Any,Float64), z, 0.0), Float64)
+    @test isa(invoke(varm, Tuple{Any,Float64}, z, 0.0), Float64)
     @test cor(z) === 1.0
 end
 let v = varm([1.0+2.0im], 0; corrected = false)


### PR DESCRIPTION
Replaces https://github.com/JuliaLang/julia/pull/10964 (take 2). `Expr(:invoke)` makes this significantly easier to implement =)

Summary of changes,
1. Deprecate the tuple form of `invoke` and use the tuple type form instead.
   
   It's much easier to infer/optimize.
2. Inline `invoke` call.

~~Based on https://github.com/JuliaLang/julia/pull/18438 since I hit it when working on this PR.~~ (merged)

Close https://github.com/JuliaLang/julia/issues/9608
