### PR TITLE
Make embedding dirt-simple, parts 1 & 2 (#18421)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ julia-src-release julia-src-debug : julia-src-% : julia-deps julia_flisp.boot.in
 julia-ui-release julia-ui-debug : julia-ui-% : julia-src-%
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/ui julia-$*
 
+julia-embedding-release julia-embedding-debug : julia-embedding-% : julia-src-%
+	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/examples embedding-$*
+
 julia-inference : julia-base julia-ui-$(JULIA_BUILD_MODE) $(build_prefix)/.examples
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/inference.ji JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
 
@@ -101,7 +104,7 @@ julia-sysimg-release : julia-inference julia-ui-release
 julia-sysimg-debug : julia-inference julia-ui-debug
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/sys-debug.$(SHLIB_EXT) JULIA_BUILD_MODE=debug
 
-julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest
+julia-debug julia-release : julia-% : julia-ui-% julia-embedding-% julia-sysimg-% julia-symlink julia-libccalltest
 
 debug release : % : julia-%
 
@@ -334,6 +337,7 @@ install: $(build_depsbindir)/stringreplace $(BUILDROOT)/doc/_build/html
 	done
 
 	$(INSTALL_M) $(build_bindir)/julia* $(DESTDIR)$(bindir)/
+	$(INSTALL_M) $(build_bindir)/embedding* $(DESTDIR)$(bindir)/
 ifeq ($(OS),WINNT)
 	-$(INSTALL_M) $(build_bindir)/*.dll $(DESTDIR)$(bindir)/
 	-$(INSTALL_M) $(build_libdir)/libjulia.dll.a $(DESTDIR)$(libdir)/
@@ -536,6 +540,7 @@ clean: | $(CLEAN_TARGETS)
 	@-$(MAKE) -C $(BUILDROOT)/doc clean
 	@-$(MAKE) -C $(BUILDROOT)/src clean
 	@-$(MAKE) -C $(BUILDROOT)/ui clean
+	@-$(MAKE) -C $(BUILDROOT)/examples clean
 	@-$(MAKE) -C $(BUILDROOT)/test clean
 	-rm -f $(BUILDROOT)/julia
 	-rm -f $(BUILDROOT)/*.tar.gz
@@ -559,6 +564,7 @@ distcleanall: cleanall
 .PHONY: default debug release check-whitespace release-candidate \
 	julia-debug julia-release julia-deps \
 	julia-ui-release julia-ui-debug julia-src-release julia-src-debug \
+	julia-embedding-release julia-embedding-debug \
 	julia-symlink julia-base julia-inference julia-sysimg-release julia-sysimg-debug \
 	test testall testall1 test clean distcleanall cleanall clean-* \
 	run-julia run-julia-debug run-julia-release run \

--- a/base/options.jl
+++ b/base/options.jl
@@ -5,6 +5,7 @@ immutable JLOptions
     quiet::Int8
     julia_home::Ptr{UInt8}
     julia_bin::Ptr{UInt8}
+    julia_lib::Ptr{UInt8}
     eval::Ptr{UInt8}
     print::Ptr{UInt8}
     postboot::Ptr{UInt8}

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,16 @@
-JULIAHOME = $(abspath ..)
+JULIAHOME := $(abspath ..)
 include $(JULIAHOME)/Make.inc
 
-FLAGS = -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
+FLAGS := -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
 	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir) $(CFLAGS)
+
+ifeq ($(USEGCC),1)
+FLAGS += -std=gnu99
+endif
+
+ifneq ($(JULIA_THREADS), 0)
+FLAGS += -DJULIA_ENABLE_THREADING -DJULIA_NUM_THREADS=$(JULIA_THREADS)
+endif
 
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
@@ -38,4 +46,3 @@ clean: | $(CLEAN_TARGETS)
 	rm -f $(build_bindir)/embedding-debug $(build_bindir)/embedding
 
 .PHONY: clean release debug
-

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -256,6 +256,11 @@ JL_DLLEXPORT jl_value_t *jl_get_julia_bin(void)
     return jl_cstr_to_string(jl_options.julia_bin);
 }
 
+JL_DLLEXPORT jl_value_t *jl_get_julia_lib(void)
+{
+    return jl_cstr_to_string(jl_options.julia_lib);
+}
+
 JL_DLLEXPORT jl_value_t *jl_get_image_file(void)
 {
     return jl_cstr_to_string(jl_options.image_file);

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -16,6 +16,7 @@ static const char system_image_path[256] = "\0" JL_SYSTEM_IMAGE_PATH;
 jl_options_t jl_options = { 0,    // quiet
                             NULL, // julia_home
                             NULL, // julia_bin
+                            NULL, // julia_lib
                             NULL, // eval
                             NULL, // print
                             NULL, // post-boot

--- a/src/julia.h
+++ b/src/julia.h
@@ -1633,6 +1633,7 @@ typedef struct {
     int8_t quiet;
     const char *julia_home;
     const char *julia_bin;
+    const char *julia_lib;
     const char *eval;
     const char *print;
     const char *postboot;

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -87,3 +87,9 @@ end
 
 include(joinpath(dir, "clustermanager/0mq/ZMQCM.jl"))
 
+# test that the embedding example runs without error
+let
+    lines = readlines(pipeline(`$(joinpath(Base.JULIA_HOME, "embedding"))`, stderr=DevNull))
+    @test parse(Float64, lines[1]) ≈ sqrt(2)
+    @test parse(Float64, lines[2]) ≈ sqrt(2)
+end


### PR DESCRIPTION
The purpose is to make embedding "just work" in the simplest way possible, document the process for doing so accurately, and catch regressions in the embedding process.
- [x] Make guessing `JULIA_HOME` work when the embedding executable isn't in the same directory as `julia` (related to #18437).
- [x] Build, install, and test the embedding example to help prevent future regressions (#8757).
-  ~~Update the `julia-config.jl` script and embedding example accordingly. Rework the `Makefile` for the embedding example and the embedding documentation to actually correspond to each other.~~

Update: I'll continue with the third part later.
