### PR TITLE
WIP: Improve tuple subtyping in invariant position

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2670,6 +2670,8 @@ static int jl_tuple_subtype_(jl_value_t **child, size_t clenr,
             if (jl_is_vararg_type(pe)) pe = jl_tparam0(pe);
         }
 
+        if (invariant && jl_is_typevar(pe) && !((jl_tvar_t*)pe)->bound && !jl_is_typevar(ce))
+            break;
         if (!jl_subtype_le(ce, pe, ta, invariant))
             break;
 

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -363,3 +363,7 @@ function test18399(C)
     return hvcat18399(((2, 3),))
 end
 @test test18399(C18399) == (2, 3)
+
+# issue #18450
+f18450() = ifelse(true, Tuple{Vararg{Int}}, Tuple{Vararg})
+@test f18450() = Tuple{Vararg{Int}}


### PR DESCRIPTION
When computing tuple subtype in invariant position, fail early when encountering an unbound typevar. As far as I can tell, this added logic is similar to that for `jl_subtype_le` for `DataType` above. (Perhaps this logic should be put into a helper function.)

Fix https://github.com/JuliaLang/julia/issues/18450.

Currently not working; it seems to have broken `Array{Tuple} <: Array{NTuple}`.
