### PR TITLE
Work around inference bug with Vararg

### DIFF
--- a/test/inference.jl
+++ b/test/inference.jl
@@ -364,3 +364,7 @@ function test18399(C)
     return hvcat18399(((2, 3),))
 end
 @test test18399(C18399) == (2, 3)
+
+# issue #18450
+f18450() = ifelse(true, Tuple{Vararg{Int}}, Tuple{Vararg})
+@test f18450() == Tuple{Vararg{Int}}


### PR DESCRIPTION
Never inline as constant anything inferred as `Type{Tuple{Vararg}}`, as the actual type could be less specific. Works around the inference part of #18450.

If this is desired, it might be a good idea to run benchmarks in case this pessimizes something.
