### PR TITLE
Better definition of `broadcast(::Function, ::Integer)`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -380,7 +380,7 @@ end
 # expressions like f.(3) should still call broadcast for f::Function,
 # and in general broadcast should work for scalar arguments, while
 # getfield is certainly not intended for the case of f::Function.
-broadcast(f::Function, i::Integer) = invoke(broadcast, (Function, Number), f, i)
+broadcast(f::Function, i::Integer) = f(i)
 
 #16167
 macro ccallable(def)


### PR DESCRIPTION
This was actually the last motivation for https://github.com/JuliaLang/julia/pull/18444 and would not really be necessary after it's merged. Nevertheless, there's no need to go through `invoke` since the method it's invoking is actually much shorter than the `invoke` call itself..... This should also benefit 0.5 since the invoke inlining won't be backported.

@stevengj 
