### PR TITLE
Move a bunch of Linalg docs out of helpdb, improve math docs

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2385,7 +2385,7 @@ using the `<:` infix operator as `type1 <: type2`.
 julia> issubtype(Int8, Int32)
 false
 
-julia> issubtype(Int8, Integer)
+julia> Int8 <: Integer
 true
 ```
 """

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -30,6 +30,18 @@ read!
     empty!(collection) -> collection
 
 Remove all elements from a `collection`.
+
+```jldoctest
+julia> A = Dict("a" => 1, "b" => 2)
+Dict{String,Int64} with 2 entries:
+  "b" => 2
+  "a" => 1
+
+julia> empty!(A);
+
+julia> A
+Dict{String,Int64} with 0 entries
+```
 """
 empty!
 
@@ -69,7 +81,15 @@ Base.:(//)
 """
     isinteger(x) -> Bool
 
-Test whether `x` or all its elements are numerically equal to some integer
+Test whether `x` or all its elements are numerically equal to some integer.
+
+```jldoctest
+julia> isinteger(4.0)
+true
+
+julia> isinteger([1; 2; 5.5])
+false
+```
 """
 isinteger
 
@@ -215,6 +235,27 @@ getindex(::Type, elements...)
 Returns a subset of array `A` as specified by `inds`, where each `ind` may be an
 `Int`, a `Range`, or a `Vector`. See the manual section on
 [array indexing](:ref:`array indexing <man-array-indexing>`) for details.
+
+```jldoctest
+julia> A = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> getindex(A, 1)
+1
+
+julia> getindex(A, [2, 1])
+2-element Array{Int64,1}:
+ 3
+ 1
+
+julia> getindex(A, 2:4)
+3-element Array{Int64,1}:
+ 3
+ 2
+ 4
+```
 """
 getindex(::AbstractArray, inds...)
 
@@ -223,6 +264,16 @@ getindex(::AbstractArray, inds...)
 
 Retrieve the value(s) stored at the given key or index within a collection. The syntax
 `a[i,j,...]` is converted by the compiler to `getindex(a, i, j, ...)`.
+
+```jldoctest
+julia> A = Dict("a" => 1, "b" => 2)
+Dict{String,Int64} with 2 entries:
+  "b" => 2
+  "a" => 1
+
+julia> getindex(A, "a")
+1
+```
 """
 getindex(collection, key...)
 
@@ -426,6 +477,14 @@ filter!
     sizeof(T)
 
 Size, in bytes, of the canonical binary representation of the given DataType `T`, if any.
+
+```jldoctest
+julia> sizeof(Float32)
+4
+
+julia> sizeof(Complex128)
+16
+```
 """
 sizeof(::Type)
 
@@ -450,6 +509,14 @@ ReadOnlyMemoryError
 Get the last element of an ordered collection, if it can be computed in O(1) time. This is
 accomplished by calling [`endof`](:func:`endof`) to get the last index. Returns the end
 point of a [`Range`](:obj:`Range`) even if it is empty.
+
+```jldoctest
+julia> last(1:2:10)
+9
+
+julia> last([1; 2; 3; 4])
+4
+```
 """
 last
 
@@ -1021,13 +1088,6 @@ Seek a stream relative to the current position.
 skip
 
 """
-    lu(A) -> L, U, p
-
-Compute the LU factorization of `A`, such that `A[p,:] = L*U`.
-"""
-lu
-
-"""
     setdiff!(s, iterable)
 
 Remove each element of `iterable` from set `s` in-place.
@@ -1115,6 +1175,22 @@ maximum!
     prod(A, dims)
 
 Multiply elements of an array over the given dimensions.
+
+```jldoctest
+julia> A = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> prod(A, 1)
+1×2 Array{Int64,2}:
+ 3  8
+
+julia> prod(A, 2)
+2×1 Array{Int64,2}:
+  2
+ 12
+```
 """
 prod(A, dims)
 
@@ -1134,13 +1210,6 @@ log1p
 Return `x` with its sign flipped if `y` is negative. For example `abs(x) = flipsign(x,x)`.
 """
 flipsign
-
-"""
-    lbeta(x, y)
-
-Natural logarithm of the absolute value of the beta function ``\\log(|\\operatorname{B}(x,y)|)``.
-"""
-lbeta
 
 """
     randstring([rng,] len=8)
@@ -1199,6 +1268,22 @@ serialize
     sum(A, dims)
 
 Sum elements of an array over the given dimensions.
+
+```jldoctest
+julia> A = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> sum(A, 1)
+1×2 Array{Int64,2}:
+ 4  6
+
+julia> sum(A, 2)
+2×1 Array{Int64,2}:
+ 3
+ 7
+```
 """
 sum(A, dims)
 
@@ -1459,14 +1544,6 @@ floating point number. If the string does not contain a valid number, an error i
 parse(T::Type, str, base=Int)
 
 """
-    bkfact!(A) -> BunchKaufman
-
-`bkfact!` is the same as [`bkfact`](:func:`bkfact`), but saves space by overwriting the
-input `A`, instead of creating a copy.
-"""
-bkfact!
-
-"""
     ^(x, y)
 
 Exponentiation operator.
@@ -1497,10 +1574,17 @@ selectperm
 """
     reinterpret(type, A)
 
-Change the type-interpretation of a block of memory. For example,
-`reinterpret(Float32, UInt32(7))` interprets the 4 bytes corresponding to `UInt32(7)` as a
-`Float32`. For arrays, this constructs an array with the same binary data as the given
+Change the type-interpretation of a block of memory.
+For arrays, this constructs an array with the same binary data as the given
 array, but with the specified element type.
+For example,
+`reinterpret(Float32, UInt32(7))` interprets the 4 bytes corresponding to `UInt32(7)` as a
+`Float32`.
+
+```jldoctest
+julia> reinterpret(Float32, UInt32(7))
+1.0f-44
+```
 """
 reinterpret
 
@@ -1625,13 +1709,6 @@ Compute a type that contains both `T` and `S`.
 typejoin
 
 """
-    beta(x, y)
-
-Euler integral of the first kind ``\\operatorname{B}(x,y) = \\Gamma(x)\\Gamma(y)/\\Gamma(x+y)``.
-"""
-beta
-
-"""
     sin(x)
 
 Compute sine of `x`, where `x` is in radians.
@@ -1666,6 +1743,22 @@ asinh
 Compute the minimum value of an array over the given dimensions. See also the
 [`min(a,b)`](:func:`min`) function to take the minimum of two or more arguments,
 which can be applied elementwise to arrays via `min.(a,b)`.
+
+```jldoctest
+julia> A = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> minimum(A, 1)
+1×2 Array{Int64,2}:
+ 1  2
+
+julia> minimum(A, 2)
+2×1 Array{Int64,2}:
+ 1
+ 3
+```
 """
 minimum(A,dims)
 
@@ -1710,16 +1803,6 @@ end
 ```
 """
 get
-
-"""
-    lufact!(A) -> LU
-
-`lufact!` is the same as [`lufact`](:func:`lufact`), but saves space by overwriting the
-input `A`, instead of creating a copy. An `InexactError` exception is thrown if the
-factorisation produces a number not representable by the element type of `A`, e.g. for
-integer types.
-"""
-lufact!
 
 """
     Mmap.sync!(array)
@@ -1798,13 +1881,6 @@ shift!
 Run a command object asynchronously, returning the resulting [`Process`](:obj:`Process`) object.
 """
 spawn
-
-"""
-    eta(x)
-
-Dirichlet eta function ``\\eta(s) = \\sum^\\infty_{n=1}(-1)^{n-1}/n^{s}``.
-"""
-eta
 
 """
     isdefined([m::Module,] s::Symbol)
@@ -1911,6 +1987,22 @@ typemax
     all(A, dims)
 
 Test whether all values along the given dimensions of an array are `true`.
+
+```jldoctest
+julia> A = [true false; true true]
+2×2 Array{Bool,2}:
+ true  false
+ true   true
+
+julia> all(A, 1)
+1×2 Array{Bool,2}:
+ true  false
+
+julia> all(A, 2)
+2×1 Array{Bool,2}:
+ false
+  true
+```
 """
 all(A::AbstractArray, dims)
 
@@ -2114,14 +2206,6 @@ program, in the same manner as C.
 unsafe_store!
 
 """
-    hessfact!(A)
-
-`hessfact!` is the same as [`hessfact`](:func:`hessfact`), but saves space by overwriting
-the input `A`, instead of creating a copy.
-"""
-hessfact!
-
-"""
     readcsv(source, [T::Type]; options...)
 
 Equivalent to `readdlm` with `delim` set to comma, and type optionally defined by `T`.
@@ -2280,6 +2364,14 @@ Array
     isreal(x) -> Bool
 
 Test whether `x` or all its elements are numerically equal to some real number.
+
+```jldoctest
+julia> isreal(5.)
+true
+
+julia> isreal([4.; complex(0,1)])
+false
+```
 """
 isreal
 
@@ -2288,6 +2380,14 @@ isreal
 
 Return `true` if and only if all values of `type1` are also of `type2`. Can also be written
 using the `<:` infix operator as `type1 <: type2`.
+
+```jldoctest
+julia> issubtype(Int8, Int32)
+false
+
+julia> issubtype(Int8, Integer)
+true
+```
 """
 issubtype(type1, type2)
 
@@ -2350,6 +2450,33 @@ countlines
     .\\(x, y)
 
 Element-wise left division operator.
+
+```jldoctest
+julia> A = [1 0; 0 -1];
+
+julia> B = [0 1; 1 0];
+
+julia> C = [A, B]
+2-element Array{Array{Int64,2},1}:
+ [1 0; 0 -1]
+ [0 1; 1 0]
+
+julia> x = [1; 0];
+
+julia> y = [0; 1];
+
+julia> D = [x, y]
+2-element Array{Array{Int64,1},1}:
+ [1,0]
+ [0,1]
+
+julia> C .\\ D
+2-element Array{Array{Float64,1},1}:
+ [1.0,-0.0]
+ [1.0,0.0]
+```
+
+See also [`broadcast`](:func:`broadcast`).
 """
 Base.:(.\)(x,y)
 
@@ -2455,6 +2582,14 @@ deserialize
 
 Get the first element of an iterable collection. Returns the start point of a
 [`Range`](:obj:`Range`) even if it is empty.
+
+```jldoctest
+julia> first(2:2:10)
+2
+
+julia> first([1; 2; 3; 4])
+1
+```
 """
 first
 
@@ -2518,21 +2653,19 @@ Base.:(!)
 """
     length(collection) -> Integer
 
-For ordered, indexable collections, the maximum index `i` for which `getindex(collection, i)`
-is valid. For unordered collections, the number of elements.
+For ordered, indexable collections, returns the maximum index `i` for which `getindex(collection, i)`
+is valid.
+For unordered collections, returns the number of elements.
+
+```jldoctest
+julia> length(1:5)
+5
+
+julia> length([1; 2; 3; 4])
+4
+```
 """
 length(collection)
-
-"""
-    bkfact(A) -> BunchKaufman
-
-Compute the Bunch-Kaufman [^Bunch1977] factorization of a real symmetric or complex Hermitian
-matrix `A` and return a `BunchKaufman` object. The following functions are available for
-`BunchKaufman` objects: [`size`](:func:`size`), `\\`, [`inv`](:func:`inv`), [`issymmetric`](:func:`issymmetric`), [`ishermitian`](:func:`ishermitian`).
-
-[^Bunch1977]: J R Bunch and L Kaufman, Some stable methods for calculating inertia and solving symmetric linear systems, Mathematics of Computation 31:137 (1977), 163-179. [url](http://www.ams.org/journals/mcom/1977-31-137/S0025-5718-1977-0428694-0).
-
-"""
 bkfact
 
 """
@@ -3037,13 +3170,6 @@ zeros(A)
 Create a `Symbol` by concatenating the string representations of the arguments together.
 """
 Symbol
-
-"""
-    zeta(s)
-
-Riemann zeta function ``\\zeta(s)``.
-"""
-zeta(s)
 
 """
     isvalid(value) -> Bool

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -485,6 +485,15 @@ julia> sizeof(Float32)
 julia> sizeof(Complex128)
 16
 ```
+
+If `T` is not a bitstype, an error is thrown.
+
+```jldoctest
+julia> sizeof(Base.LinAlg.LU)
+ERROR: argument is an abstract type; size is indeterminate
+ in sizeof(::Type{T}) at ./essentials.jl:89
+ ...
+```
 """
 sizeof(::Type)
 
@@ -1584,6 +1593,10 @@ For example,
 ```jldoctest
 julia> reinterpret(Float32, UInt32(7))
 1.0f-44
+
+julia> reinterpret(Float32, UInt32[1 2 3 4 5])
+1×5 Array{Float32,2}:
+ 1.4013f-45  2.8026f-45  4.2039f-45  5.60519f-45  7.00649f-45
 ```
 """
 reinterpret
@@ -2452,6 +2465,18 @@ countlines
 Element-wise left division operator.
 
 ```jldoctest
+julia> A = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> A .\ [1 2]
+2×2 Array{Float64,2}:
+ 1.0       1.0
+ 0.333333  0.5
+```
+
+```jldoctest
 julia> A = [1 0; 0 -1];
 
 julia> B = [0 1; 1 0];
@@ -2666,7 +2691,6 @@ julia> length([1; 2; 3; 4])
 ```
 """
 length(collection)
-bkfact
 
 """
     searchsortedlast(a, x, [by=<transform>,] [lt=<comparison>,] [rev=false])

--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -16,6 +16,12 @@ BunchKaufman{T}(A::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::Char, symmetr
     rook::Bool, info::BlasInt) =
         BunchKaufman{T,typeof(A)}(A, ipiv, uplo, symmetric, rook, info)
 
+"""
+    bkfact!(A, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false) -> BunchKaufman
+
+`bkfact!` is the same as [`bkfact`](:func:`bkfact`), but saves space by overwriting the
+input `A`, instead of creating a copy. `uplo`
+"""
 function bkfact!{T<:BlasReal}(A::StridedMatrix{T}, uplo::Symbol = :U,
     symmetric::Bool = issymmetric(A), rook::Bool = false)
 
@@ -47,6 +53,22 @@ function bkfact!{T<:BlasComplex}(A::StridedMatrix{T}, uplo::Symbol=:U,
     end
     BunchKaufman(LD, ipiv, char_uplo(uplo), symmetric, rook, info)
 end
+
+"""
+    bkfact(A, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false) -> BunchKaufman
+
+Compute the Bunch-Kaufman [^Bunch1977] factorization of a real symmetric or complex Hermitian
+matrix `A` and return a `BunchKaufman` object.
+`uplo` indicates which triangle of matrix `A` to reference.
+If `symmetric` is `true`, `A` is assumed to be real symmetric. If `symmetric` is `false`,
+`A` is assumed to be complex Hermitian. If `rook` is `true`, rook pivoting is used. If
+`rook` is false, rook pivoting is not used.
+The following functions are available for
+`BunchKaufman` objects: [`size`](:func:`size`), `\\`, [`inv`](:func:`inv`), [`issymmetric`](:func:`issymmetric`), [`ishermitian`](:func:`ishermitian`).
+
+[^Bunch1977]: J R Bunch and L Kaufman, Some stable methods for calculating inertia and solving symmetric linear systems, Mathematics of Computation 31:137 (1977), 163-179. [url](http://www.ams.org/journals/mcom/1977-31-137/S0025-5718-1977-0428694-0).
+
+"""
 bkfact{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issymmetric(A),
     rook::Bool=false) =
         bkfact!(copy(A), uplo, symmetric, rook)

--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -20,7 +20,7 @@ BunchKaufman{T}(A::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::Char, symmetr
     bkfact!(A, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false) -> BunchKaufman
 
 `bkfact!` is the same as [`bkfact`](:func:`bkfact`), but saves space by overwriting the
-input `A`, instead of creating a copy. `uplo`
+input `A`, instead of creating a copy.
 """
 function bkfact!{T<:BlasReal}(A::StridedMatrix{T}, uplo::Symbol = :U,
     symmetric::Bool = issymmetric(A), rook::Bool = false)

--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -60,7 +60,7 @@ end
 Compute the Bunch-Kaufman [^Bunch1977] factorization of a real symmetric or complex Hermitian
 matrix `A` and return a `BunchKaufman` object.
 `uplo` indicates which triangle of matrix `A` to reference.
-If `symmetric` is `true`, `A` is assumed to be real symmetric. If `symmetric` is `false`,
+If `symmetric` is `true`, `A` is assumed to be symmetric. If `symmetric` is `false`,
 `A` is assumed to be complex Hermitian. If `rook` is `true`, rook pivoting is used. If
 `rook` is false, rook pivoting is not used.
 The following functions are available for

--- a/base/linalg/hessenberg.jl
+++ b/base/linalg/hessenberg.jl
@@ -9,24 +9,29 @@ Hessenberg{T}(factors::AbstractMatrix{T}, τ::Vector{T}) = Hessenberg{T,typeof(f
 
 Hessenberg(A::StridedMatrix) = Hessenberg(LAPACK.gehrd!(A)...)
 
+
+"""
+    hessfact!(A) -> Hessenberg
+
+`hessfact!` is the same as [`hessfact`](:func:`hessfact`), but saves space by overwriting
+the input `A`, instead of creating a copy.
+"""
 hessfact!{T<:BlasFloat}(A::StridedMatrix{T}) = Hessenberg(A)
 
 hessfact{T<:BlasFloat}(A::StridedMatrix{T}) = hessfact!(copy(A))
-function hessfact{T}(A::StridedMatrix{T})
-    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
-    return hessfact!(copy_oftype(A, S))
-end
 
 """
-    hessfact(A)
+    hessfact(A) -> Hessenberg
 
 Compute the Hessenberg decomposition of `A` and return a `Hessenberg` object. If `F` is the
 factorization object, the unitary matrix can be accessed with `F[:Q]` and the Hessenberg
 matrix with `F[:H]`. When `Q` is extracted, the resulting type is the `HessenbergQ` object,
 and may be converted to a regular matrix with [`full`](:func:`full`).
 """
-hessfact
-
+function hessfact{T}(A::StridedMatrix{T})
+    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
+    return hessfact!(copy_oftype(A, S))
+end
 
 immutable HessenbergQ{T,S<:AbstractMatrix} <: AbstractMatrix{T}
     factors::S

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -143,9 +143,12 @@ lufact(F::LU) = F
 lu(x::Number) = (one(x), x, 1)
 
 """
-    lu(A) -> L, U, p
+    lu(A, pivot=Val{true}) -> L, U, p
 
 Compute the LU factorization of `A`, such that `A[p,:] = L*U`.
+By default, pivoting is used. This can be overridden by passing
+`Val{false}` for the second argument.
+
 See also [`lufact`](:func:`lufact`).
 """
 function lu(A::AbstractMatrix, pivot::Union{Type{Val{false}}, Type{Val{true}}} = Val{true})

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -19,6 +19,15 @@ function lufact!{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Union{Type{Val{false}
     lpt = LAPACK.getrf!(A)
     return LU{T,typeof(A)}(lpt[1], lpt[2], lpt[3])
 end
+
+"""
+    lufact!(A, pivot=Val{true}) -> LU
+
+`lufact!` is the same as [`lufact`](:func:`lufact`), but saves space by overwriting the
+input `A`, instead of creating a copy. An [`InexactError`](:obj:`InexactError`)
+exception is thrown if the factorisation produces a number not representable by the
+element type of `A`, e.g. for integer types.
+"""
 lufact!(A::StridedMatrix, pivot::Union{Type{Val{false}}, Type{Val{true}}} = Val{true}) = generic_lufact!(A, pivot)
 function generic_lufact!{T,Pivot}(A::StridedMatrix{T}, ::Type{Val{Pivot}} = Val{true})
     m, n = size(A)
@@ -132,6 +141,13 @@ lufact(x::Number) = LU(fill(x, 1, 1), BlasInt[1], x == 0 ? one(BlasInt) : zero(B
 lufact(F::LU) = F
 
 lu(x::Number) = (one(x), x, 1)
+
+"""
+    lu(A) -> L, U, p
+
+Compute the LU factorization of `A`, such that `A[p,:] = L*U`.
+See also [`lufact`](:func:`lufact`).
+"""
 function lu(A::AbstractMatrix, pivot::Union{Type{Val{false}}, Type{Val{true}}} = Val{true})
     F = lufact(A, pivot)
     F[:L], F[:U], F[:p]

--- a/base/math.jl
+++ b/base/math.jl
@@ -95,6 +95,17 @@ Evaluate the polynomial ``\\sum_k c[k] z^{k-1}`` for the coefficients `c[1]`, `c
 that is, the coefficients are given in ascending order by power of `z`.  This macro expands
 to efficient inline code that uses either Horner's method or, for complex `z`, a more
 efficient Goertzel-like algorithm.
+
+```jldoctest
+julia> @evalpoly(3, 1, 0, 1)
+10
+
+julia> @evalpoly(2, 1, 0, 1)
+5
+
+julia> @evalpoly(2, 1, 1, 1)
+7
+```
 """
 macro evalpoly(z, p...)
     a = :($(esc(p[end])))
@@ -330,6 +341,11 @@ minmax{T<:AbstractFloat}(x::T, y::T) = ifelse(isnan(x-y), ifelse(isnan(x), (y, y
     ldexp(x, n)
 
 Compute ``x \\times 2^n``.
+
+```jldoctest
+julia> ldexp(5., 2)
+20.0
+```
 """
 ldexp(x::Float64,e::Integer) = ccall((:scalbn,libm),  Float64, (Float64,Int32), x, Int32(e))
 ldexp(x::Float32,e::Integer) = ccall((:scalbnf,libm), Float32, (Float32,Int32), x, Int32(e))

--- a/base/special/gamma.jl
+++ b/base/special/gamma.jl
@@ -535,16 +535,28 @@ invdigamma(x::Float32) = Float32(invdigamma(Float64(x)))
 """
     invdigamma(x)
 
-Compute the inverse digamma function of `x`.
+Compute the inverse [`digamma`](:func:`digamma`) function of `x`.
 """
 invdigamma(x::Real) = invdigamma(Float64(x))
 
+"""
+    beta(x, y)
+
+Euler integral of the first kind ``\\operatorname{B}(x,y) = \\Gamma(x)\\Gamma(y)/\\Gamma(x+y)``.
+"""
 function beta(x::Number, w::Number)
     yx, sx = lgamma_r(x)
     yw, sw = lgamma_r(w)
     yxw, sxw = lgamma_r(x+w)
     return exp(yx + yw - yxw) * (sx*sw*sxw)
 end
+
+"""
+    lbeta(x, y)
+
+Natural logarithm of the absolute value of the [`beta`](:func:`beta`)
+function ``\\log(|\\operatorname{B}(x,y)|)``.
+"""
 lbeta(x::Number, w::Number) = lgamma(x)+lgamma(w)-lgamma(x+w)
 
 # Riemann zeta function; algorithm is based on specializing the Hurwitz
@@ -596,6 +608,12 @@ end
 
 zeta(x::Integer) = zeta(Float64(x))
 zeta(x::Real)    = oftype(float(x),zeta(Float64(x)))
+
+"""
+    zeta(s)
+
+Riemann zeta function ``\\zeta(s)``.
+"""
 zeta(z::Complex) = oftype(float(z),zeta(Complex128(z)))
 
 function eta(z::Union{Float64,Complex{Float64}})
@@ -614,4 +632,10 @@ function eta(z::Union{Float64,Complex{Float64}})
 end
 eta(x::Integer) = eta(Float64(x))
 eta(x::Real)    = oftype(float(x),eta(Float64(x)))
+
+"""
+    eta(x)
+
+Dirichlet eta function ``\\eta(s) = \\sum^\\infty_{n=1}(-1)^{n-1}/n^{s}``.
+"""
 eta(z::Complex) = oftype(float(z),eta(Complex128(z)))

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -531,6 +531,10 @@ Constructors
        julia> reinterpret(Float32, UInt32(7))
        1.0f-44
 
+       julia> reinterpret(Float32, UInt32[1 2 3 4 5])
+       1×5 Array{Float32,2}:
+        1.4013f-45  2.8026f-45  4.2039f-45  5.60519f-45  7.00649f-45
+
 .. function:: eye([T::Type=Float64,] n::Integer)
 
    .. Docstring generated from Julia source

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -524,7 +524,12 @@ Constructors
 
    .. Docstring generated from Julia source
 
-   Change the type-interpretation of a block of memory. For example, ``reinterpret(Float32, UInt32(7))`` interprets the 4 bytes corresponding to ``UInt32(7)`` as a ``Float32``\ . For arrays, this constructs an array with the same binary data as the given array, but with the specified element type.
+   Change the type-interpretation of a block of memory. For arrays, this constructs an array with the same binary data as the given array, but with the specified element type. For example, ``reinterpret(Float32, UInt32(7))`` interprets the 4 bytes corresponding to ``UInt32(7)`` as a ``Float32``\ .
+
+   .. doctest::
+
+       julia> reinterpret(Float32, UInt32(7))
+       1.0f-44
 
 .. function:: eye([T::Type=Float64,] n::Integer)
 
@@ -655,6 +660,27 @@ Indexing, Assignment, and Concatenation
    .. Docstring generated from Julia source
 
    Returns a subset of array ``A`` as specified by ``inds``\ , where each ``ind`` may be an ``Int``\ , a ``Range``\ , or a ``Vector``\ . See the manual section on :ref:`array indexing <man-array-indexing>` for details.
+
+   .. doctest::
+
+       julia> A = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
+
+       julia> getindex(A, 1)
+       1
+
+       julia> getindex(A, [2, 1])
+       2-element Array{Int64,1}:
+        3
+        1
+
+       julia> getindex(A, 2:4)
+       3-element Array{Int64,1}:
+        3
+        2
+        4
 
 .. function:: view(A, inds...)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -547,6 +547,15 @@ Types
        julia> sizeof(Complex128)
        16
 
+   If ``T`` is not a bitstype, an error is thrown.
+
+   .. doctest::
+
+       julia> sizeof(Base.LinAlg.LU)
+       ERROR: argument is an abstract type; size is indeterminate
+        in sizeof(::Type{T}) at ./essentials.jl:89
+        ...
+
 .. function:: eps(T)
 
    .. Docstring generated from Julia source

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -474,6 +474,14 @@ Types
 
    Return ``true`` if and only if all values of ``type1`` are also of ``type2``\ . Can also be written using the ``<:`` infix operator as ``type1 <: type2``\ .
 
+   .. doctest::
+
+       julia> issubtype(Int8, Int32)
+       false
+
+       julia> issubtype(Int8, Integer)
+       true
+
 .. function:: <:(T1, T2)
 
    .. Docstring generated from Julia source
@@ -530,6 +538,14 @@ Types
    .. Docstring generated from Julia source
 
    Size, in bytes, of the canonical binary representation of the given DataType ``T``\ , if any.
+
+   .. doctest::
+
+       julia> sizeof(Float32)
+       4
+
+       julia> sizeof(Complex128)
+       16
 
 .. function:: eps(T)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -479,7 +479,7 @@ Types
        julia> issubtype(Int8, Int32)
        false
 
-       julia> issubtype(Int8, Integer)
+       julia> Int8 <: Integer
        true
 
 .. function:: <:(T1, T2)

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -247,11 +247,31 @@ General Collections
 
    Remove all elements from a ``collection``\ .
 
+   .. doctest::
+
+       julia> A = Dict("a" => 1, "b" => 2)
+       Dict{String,Int64} with 2 entries:
+         "b" => 2
+         "a" => 1
+
+       julia> empty!(A);
+
+       julia> A
+       Dict{String,Int64} with 0 entries
+
 .. function:: length(collection) -> Integer
 
    .. Docstring generated from Julia source
 
-   For ordered, indexable collections, the maximum index ``i`` for which ``getindex(collection, i)`` is valid. For unordered collections, the number of elements.
+   For ordered, indexable collections, returns the maximum index ``i`` for which ``getindex(collection, i)`` is valid. For unordered collections, returns the number of elements.
+
+   .. doctest::
+
+       julia> length(1:5)
+       5
+
+       julia> length([1; 2; 3; 4])
+       4
 
 .. function:: endof(collection) -> Integer
 
@@ -472,6 +492,22 @@ Iterable Collections
 
    Compute the minimum value of an array over the given dimensions. See also the :func:`min` function to take the minimum of two or more arguments, which can be applied elementwise to arrays via ``min.(a,b)``\ .
 
+   .. doctest::
+
+       julia> A = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
+
+       julia> minimum(A, 1)
+       1×2 Array{Int64,2}:
+        1  2
+
+       julia> minimum(A, 2)
+       2×1 Array{Int64,2}:
+        1
+        3
+
 .. function:: minimum!(r, A)
 
    .. Docstring generated from Julia source
@@ -624,6 +660,22 @@ Iterable Collections
 
    Sum elements of an array over the given dimensions.
 
+   .. doctest::
+
+       julia> A = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
+
+       julia> sum(A, 1)
+       1×2 Array{Int64,2}:
+        4  6
+
+       julia> sum(A, 2)
+       2×1 Array{Int64,2}:
+        3
+        7
+
 .. function:: sum!(r, A)
 
    .. Docstring generated from Julia source
@@ -684,6 +736,22 @@ Iterable Collections
 
    Multiply elements of an array over the given dimensions.
 
+   .. doctest::
+
+       julia> A = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
+
+       julia> prod(A, 1)
+       1×2 Array{Int64,2}:
+        3  8
+
+       julia> prod(A, 2)
+       2×1 Array{Int64,2}:
+         2
+        12
+
 .. function:: prod!(r, A)
 
    .. Docstring generated from Julia source
@@ -743,6 +811,22 @@ Iterable Collections
    .. Docstring generated from Julia source
 
    Test whether all values along the given dimensions of an array are ``true``\ .
+
+   .. doctest::
+
+       julia> A = [true false; true true]
+       2×2 Array{Bool,2}:
+        true  false
+        true   true
+
+       julia> all(A, 1)
+       1×2 Array{Bool,2}:
+        true  false
+
+       julia> all(A, 2)
+       2×1 Array{Bool,2}:
+        false
+         true
 
 .. function:: all!(r, A)
 
@@ -881,11 +965,27 @@ Iterable Collections
 
    Get the first element of an iterable collection. Returns the start point of a :obj:`Range` even if it is empty.
 
+   .. doctest::
+
+       julia> first(2:2:10)
+       2
+
+       julia> first([1; 2; 3; 4])
+       1
+
 .. function:: last(coll)
 
    .. Docstring generated from Julia source
 
    Get the last element of an ordered collection, if it can be computed in O(1) time. This is accomplished by calling :func:`endof` to get the last index. Returns the end point of a :obj:`Range` even if it is empty.
+
+   .. doctest::
+
+       julia> last(1:2:10)
+       9
+
+       julia> last([1; 2; 3; 4])
+       4
 
 .. function:: step(r)
 
@@ -983,6 +1083,16 @@ Indexable Collections
    .. Docstring generated from Julia source
 
    Retrieve the value(s) stored at the given key or index within a collection. The syntax ``a[i,j,...]`` is converted by the compiler to ``getindex(a, i, j, ...)``\ .
+
+   .. doctest::
+
+       julia> A = Dict("a" => 1, "b" => 2)
+       Dict{String,Int64} with 2 entries:
+         "b" => 2
+         "a" => 1
+
+       julia> getindex(A, "a")
+       1
 
 .. function:: setindex!(collection, value, key...)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -218,11 +218,13 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    ``eigfact`` will use a method specialized for matrices known to be Hermitian. Note that ``Hupper`` will not be equal to ``Hlower`` unless ``A`` is itself Hermitian (e.g. if ``A == A'``\ ).
 
-.. function:: lu(A) -> L, U, p
+.. function:: lu(A, pivot=Val{true}) -> L, U, p
 
    .. Docstring generated from Julia source
 
-   Compute the LU factorization of ``A``\ , such that ``A[p,:] = L*U``\ . See also :func:`lufact`\ .
+   Compute the LU factorization of ``A``\ , such that ``A[p,:] = L*U``\ . By default, pivoting is used. This can be overridden by passing ``Val{false}`` for the second argument.
+
+   See also :func:`lufact`\ .
 
 .. function:: lufact(A [,pivot=Val{true}]) -> F::LU
 
@@ -586,7 +588,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Compute the Bunch-Kaufman [Bunch1977]_ factorization of a real symmetric or complex Hermitian matrix ``A`` and return a ``BunchKaufman`` object. ``uplo`` indicates which triangle of matrix ``A`` to reference. If ``symmetric`` is ``true``\ , ``A`` is assumed to be real symmetric. If ``symmetric`` is ``false``\ , ``A`` is assumed to be complex Hermitian. If ``rook`` is ``true``\ , rook pivoting is used. If ``rook`` is false, rook pivoting is not used. The following functions are available for ``BunchKaufman`` objects: :func:`size`\ , ``\``\ , :func:`inv`\ , :func:`issymmetric`\ , :func:`ishermitian`\ .
+   Compute the Bunch-Kaufman [Bunch1977]_ factorization of a real symmetric or complex Hermitian matrix ``A`` and return a ``BunchKaufman`` object. ``uplo`` indicates which triangle of matrix ``A`` to reference. If ``symmetric`` is ``true``\ , ``A`` is assumed to be symmetric. If ``symmetric`` is ``false``\ , ``A`` is assumed to be complex Hermitian. If ``rook`` is ``true``\ , rook pivoting is used. If ``rook`` is false, rook pivoting is not used. The following functions are available for ``BunchKaufman`` objects: :func:`size`\ , ``\``\ , :func:`inv`\ , :func:`issymmetric`\ , :func:`ishermitian`\ .
 
    .. [Bunch1977] J R Bunch and L Kaufman, Some stable methods for calculating inertia and solving symmetric linear systems, Mathematics of Computation 31:137 (1977), 163-179. `url <http://www.ams.org/journals/mcom/1977-31-137/S0025-5718-1977-0428694-0>`_\ .
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -594,7 +594,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   ``bkfact!`` is the same as :func:`bkfact`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy. ``uplo``
+   ``bkfact!`` is the same as :func:`bkfact`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy.
 
 .. function:: eig(A,[irange,][vl,][vu,][permute=true,][scale=true]) -> D, V
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -222,7 +222,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Compute the LU factorization of ``A``\ , such that ``A[p,:] = L*U``\ .
+   Compute the LU factorization of ``A``\ , such that ``A[p,:] = L*U``\ . See also :func:`lufact`\ .
 
 .. function:: lufact(A [,pivot=Val{true}]) -> F::LU
 
@@ -310,11 +310,11 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    ``lufact(A::SparseMatrixCSC)`` uses the UMFPACK library that is part of SuiteSparse. As this library only supports sparse matrices with ``Float64`` or ``Complex128`` elements, ``lufact`` converts ``A`` into a copy that is of type ``SparseMatrixCSC{Float64}`` or ``SparseMatrixCSC{Complex128}`` as appropriate.
 
-.. function:: lufact!(A) -> LU
+.. function:: lufact!(A, pivot=Val{true}) -> LU
 
    .. Docstring generated from Julia source
 
-   ``lufact!`` is the same as :func:`lufact`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy. An ``InexactError`` exception is thrown if the factorisation produces a number not representable by the element type of ``A``\ , e.g. for integer types.
+   ``lufact!`` is the same as :func:`lufact`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy. An :obj:`InexactError` exception is thrown if the factorisation produces a number not representable by the element type of ``A``\ , e.g. for integer types.
 
 .. function:: chol(A) -> U
 
@@ -582,19 +582,19 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Perform an LQ factorization of ``A`` such that ``A = L*Q``\ . The default is to compute a thin factorization. The LQ factorization is the QR factorization of ``A.'``\ . ``L`` is not extended with zeros if the full ``Q`` is requested.
 
-.. function:: bkfact(A) -> BunchKaufman
+.. function:: bkfact(A, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false) -> BunchKaufman
 
    .. Docstring generated from Julia source
 
-   Compute the Bunch-Kaufman [Bunch1977]_ factorization of a real symmetric or complex Hermitian matrix ``A`` and return a ``BunchKaufman`` object. The following functions are available for ``BunchKaufman`` objects: :func:`size`\ , ``\``\ , :func:`inv`\ , :func:`issymmetric`\ , :func:`ishermitian`\ .
+   Compute the Bunch-Kaufman [Bunch1977]_ factorization of a real symmetric or complex Hermitian matrix ``A`` and return a ``BunchKaufman`` object. ``uplo`` indicates which triangle of matrix ``A`` to reference. If ``symmetric`` is ``true``\ , ``A`` is assumed to be real symmetric. If ``symmetric`` is ``false``\ , ``A`` is assumed to be complex Hermitian. If ``rook`` is ``true``\ , rook pivoting is used. If ``rook`` is false, rook pivoting is not used. The following functions are available for ``BunchKaufman`` objects: :func:`size`\ , ``\``\ , :func:`inv`\ , :func:`issymmetric`\ , :func:`ishermitian`\ .
 
    .. [Bunch1977] J R Bunch and L Kaufman, Some stable methods for calculating inertia and solving symmetric linear systems, Mathematics of Computation 31:137 (1977), 163-179. `url <http://www.ams.org/journals/mcom/1977-31-137/S0025-5718-1977-0428694-0>`_\ .
 
-.. function:: bkfact!(A) -> BunchKaufman
+.. function:: bkfact!(A, uplo::Symbol=:U, symmetric::Bool=issymmetric(A), rook::Bool=false) -> BunchKaufman
 
    .. Docstring generated from Julia source
 
-   ``bkfact!`` is the same as :func:`bkfact`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy.
+   ``bkfact!`` is the same as :func:`bkfact`\ , but saves space by overwriting the input ``A``\ , instead of creating a copy. ``uplo``
 
 .. function:: eig(A,[irange,][vl,][vu,][permute=true,][scale=true]) -> D, V
 
@@ -734,13 +734,13 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Same as :func:`eigfact`\ , but saves space by overwriting the input ``A`` (and ``B``\ ), instead of creating a copy.
 
-.. function:: hessfact(A)
+.. function:: hessfact(A) -> Hessenberg
 
    .. Docstring generated from Julia source
 
    Compute the Hessenberg decomposition of ``A`` and return a ``Hessenberg`` object. If ``F`` is the factorization object, the unitary matrix can be accessed with ``F[:Q]`` and the Hessenberg matrix with ``F[:H]``\ . When ``Q`` is extracted, the resulting type is the ``HessenbergQ`` object, and may be converted to a regular matrix with :func:`full`\ .
 
-.. function:: hessfact!(A)
+.. function:: hessfact!(A) -> Hessenberg
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -132,6 +132,18 @@ Mathematical Operators
 
    .. doctest::
 
+       julia> A = [1 2; 3 4]
+       2×2 Array{Int64,2}:
+        1  2
+        3  4
+
+       julia> A . [1 2]
+       2×2 Array{Float64,2}:
+        1.0       1.0
+        0.333333  0.5
+
+   .. doctest::
+
        julia> A = [1 0; 0 -1];
 
        julia> B = [0 1; 1 0];

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -130,6 +130,33 @@ Mathematical Operators
 
    Element-wise left division operator.
 
+   .. doctest::
+
+       julia> A = [1 0; 0 -1];
+
+       julia> B = [0 1; 1 0];
+
+       julia> C = [A, B]
+       2-element Array{Array{Int64,2},1}:
+        [1 0; 0 -1]
+        [0 1; 1 0]
+
+       julia> x = [1; 0];
+
+       julia> y = [0; 1];
+
+       julia> D = [x, y]
+       2-element Array{Array{Int64,1},1}:
+        [1,0]
+        [0,1]
+
+       julia> C .\ D
+       2-element Array{Array{Float64,1},1}:
+        [1.0,-0.0]
+        [1.0,0.0]
+
+   See also :func:`broadcast`\ .
+
 .. _.^:
 .. function:: .^(x, y)
 
@@ -1023,6 +1050,11 @@ Mathematical Functions
 
    Compute :math:`x \times 2^n`\ .
 
+   .. doctest::
+
+       julia> ldexp(5., 2)
+       20.0
+
 .. function:: modf(x)
 
    .. Docstring generated from Julia source
@@ -1646,7 +1678,7 @@ Mathematical Functions
 
    .. Docstring generated from Julia source
 
-   Compute the inverse digamma function of ``x``\ .
+   Compute the inverse :func:`digamma` function of ``x``\ .
 
 .. function:: trigamma(x)
 
@@ -1822,7 +1854,7 @@ Mathematical Functions
 
    .. Docstring generated from Julia source
 
-   Natural logarithm of the absolute value of the beta function :math:`\log(|\operatorname{B}(x,y)|)`\ .
+   Natural logarithm of the absolute value of the :func:`beta` function :math:`\log(|\operatorname{B}(x,y)|)`\ .
 
 .. function:: eta(x)
 
@@ -1864,6 +1896,17 @@ Mathematical Functions
    .. Docstring generated from Julia source
 
    Evaluate the polynomial :math:`\sum_k c[k] z^{k-1}` for the coefficients ``c[1]``\ , ``c[2]``\ , ...; that is, the coefficients are given in ascending order by power of ``z``\ .  This macro expands to efficient inline code that uses either Horner's method or, for complex ``z``\ , a more efficient Goertzel-like algorithm.
+
+   .. doctest::
+
+       julia> @evalpoly(3, 1, 0, 1)
+       10
+
+       julia> @evalpoly(2, 1, 0, 1)
+       5
+
+       julia> @evalpoly(2, 1, 1, 1)
+       7
 
 Statistics
 ----------

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -349,13 +349,29 @@ General Number Functions and Constants
 
    .. Docstring generated from Julia source
 
-   Test whether ``x`` or all its elements are numerically equal to some integer
+   Test whether ``x`` or all its elements are numerically equal to some integer.
+
+   .. doctest::
+
+       julia> isinteger(4.0)
+       true
+
+       julia> isinteger([1; 2; 5.5])
+       false
 
 .. function:: isreal(x) -> Bool
 
    .. Docstring generated from Julia source
 
    Test whether ``x`` or all its elements are numerically equal to some real number.
+
+   .. doctest::
+
+       julia> isreal(5.)
+       true
+
+       julia> isreal([4.; complex(0,1)])
+       false
 
 .. function:: isimag(z) -> Bool
 


### PR DESCRIPTION
Made docs for `bkfact`, `hessenberg`, `lu` more accurate.
Added examples for more functions.
Moved some special functions out of helpdb as well.
