### PR TITLE
[RFC/WIP] Intrinsics for `NTuple{N, VecElement}`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -119,7 +119,8 @@ function show_default(io::IO, x::ANY)
     show(io, t)
     print(io, '(')
     nf = nfields(t)
-    if nf != 0 || t.size==0
+    nb = sizeof(x)
+    if nf != 0 || nb==0
         if !show_circular(io, x)
             recur_io = IOContext(io, :SHOWN_SET => x)
             for i=1:nf
@@ -135,7 +136,6 @@ function show_default(io::IO, x::ANY)
             end
         end
     else
-        nb = t.size
         print(io, "0x")
         p = data_pointer_from_objref(x)
         for i=nb-1:-1:0

--- a/src/abi_ppc64le.cpp
+++ b/src/abi_ppc64le.cpp
@@ -97,7 +97,7 @@ bool use_sret(AbiState *state, jl_datatype_t *dt)
 {
     jl_datatype_t *ty0 = NULL;
     bool hva = false;
-    if (dt->size > 16 && isHFA(dt, &ty0, &hva) > 8)
+    if (jl_datatype_size(dt) > 16 && isHFA(dt, &ty0, &hva) > 8)
         return true;
     return false;
 }
@@ -106,14 +106,14 @@ void needPassByRef(AbiState *state, jl_datatype_t *dt, bool *byRef, bool *inReg)
 {
     jl_datatype_t *ty0 = NULL;
     bool hva = false;
-    if (dt->size > 64 && isHFA(dt, &ty0, &hva) > 8)
+    if (jl_datatype_size(dt) > 64 && isHFA(dt, &ty0, &hva) > 8)
         *byRef = true;
 }
 
 Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
 {
     // Arguments are either scalar or passed by value
-    size_t size = dt->size;
+    size_t size = jl_datatype_size(dt);
     // don't need to change bitstypes
     if (!jl_datatype_nfields(dt))
         return NULL;

--- a/src/abi_win32.cpp
+++ b/src/abi_win32.cpp
@@ -44,7 +44,7 @@ bool use_sret(AbiState *state, jl_datatype_t *dt)
 {
     // Use sret if the size of the argument is not one of 1, 2, 4, 8 bytes
     // This covers the special case of Complex64
-    size_t size = dt->size;
+    size_t size = jl_datatype_size(dt);
     if (size == 1 || size == 2 || size == 4 || size == 8)
         return false;
     return true;
@@ -62,7 +62,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
     // rewrite integer sized (non-sret) struct to the corresponding integer
     if (!dt->layout->nfields)
         return NULL;
-    return Type::getIntNTy(jl_LLVMContext, dt->size * 8);
+    return Type::getIntNTy(jl_LLVMContext, jl_datatype_nbits(dt));
 }
 
 bool need_private_copy(jl_value_t *ty, bool byRef)

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -63,7 +63,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
 {
     size_t size = jl_datatype_size(dt);
     if (size > 0 && size <= 8 && !jl_is_bitstype(dt))
-        return Type::getIntNTy(jl_LLVMContext, size*8);
+        return Type::getIntNTy(jl_LLVMContext, jl_datatype_nbits(dt));
     return NULL;
 }
 

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -207,7 +207,8 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
     if (is_native_simd_type(dt))
         return NULL;
 
-    int size = jl_datatype_size(dt);
+    size_t size = jl_datatype_size(dt);
+    size_t nbits = jl_datatype_nbits(dt);
     if (size > 16 || size == 0)
         return NULL;
 
@@ -221,7 +222,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
             if (size >= 8)
                 types[0] = T_int64;
             else
-                types[0] = Type::getIntNTy(jl_LLVMContext, size*8);
+                types[0] = Type::getIntNTy(jl_LLVMContext, nbits);
             break;
         case Sse:
             if (size <= 4)
@@ -237,7 +238,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
             return types[0];
         case Integer:
             assert(size > 8);
-            types[1] = Type::getIntNTy(jl_LLVMContext, (size-8)*8);
+            types[1] = Type::getIntNTy(jl_LLVMContext, (nbits-64));
             return StructType::get(jl_LLVMContext,ArrayRef<Type*>(&types[0],2));
         case Sse:
             if (size <= 12)

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -229,7 +229,7 @@ JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
     va_list args;
     size_t nf = jl_datatype_nfields(type);
     va_start(args, type);
-    jl_value_t *jv = jl_gc_alloc(ptls, type->size, type);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
     for(size_t i=0; i < nf; i++) {
         jl_set_nth_field(jv, i, va_arg(args, jl_value_t*));
     }
@@ -243,7 +243,7 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
     jl_ptls_t ptls = jl_get_ptls_states();
     if (type->instance != NULL) return type->instance;
     size_t nf = jl_datatype_nfields(type);
-    jl_value_t *jv = jl_gc_alloc(ptls, type->size, type);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
     for(size_t i=0; i < na; i++) {
         jl_set_nth_field(jv, i, args[i]);
     }
@@ -259,7 +259,7 @@ JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (type->instance != NULL) return type->instance;
-    size_t size = type->size;
+    size_t size = jl_datatype_size(type);
     jl_value_t *jv = jl_gc_alloc(ptls, size, type);
     if (size > 0)
         memset(jl_data_ptr(jv), 0, size);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -329,7 +329,7 @@ JL_DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b)
         return dta->name == dtb->name && compare_svec(dta->parameters, dtb->parameters);
     }
     if (dt->mutabl) return 0;
-    size_t sz = dt->size;
+    size_t sz = jl_datatype_size(dt);
     if (sz == 0) return 1;
     size_t nf = jl_datatype_nfields(dt);
     if (nf == 0)
@@ -359,7 +359,7 @@ JL_CALLABLE(jl_f_sizeof)
         jl_datatype_t *dx = (jl_datatype_t*)x;
         if (dx->name == jl_array_typename || dx == jl_symbol_type || dx == jl_simplevector_type)
             jl_error("type does not have a canonical binary representation");
-        if (!(dx->name->names == jl_emptysvec && dx->size > 0)) {
+        if (!(dx->name->names == jl_emptysvec && jl_datatype_size(dx) > 0)) {
             // names===() and size > 0  =>  bitstype, size always known
             if (dx->abstract || !jl_is_leaf_type(x))
                 jl_error("argument is an abstract type; size is indeterminate");

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1157,7 +1157,7 @@ static std::string generate_func_sig(
                 // see pull req #978. need to annotate signext/zeroext for
                 // small integer arguments.
                 jl_datatype_t *bt = (jl_datatype_t*)tti;
-                if (bt->size < 4) {
+                if (jl_datatype_size(bt) < 4) {
                     if (jl_signed_type && jl_subtype(tti, (jl_value_t*)jl_signed_type, 0))
                         av = Attribute::SExt;
                     else

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2499,7 +2499,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     size_t nd = jl_is_long(ndp) ? jl_unbox_long(ndp) : 1;
                     Value *idx = emit_array_nd_index(ary, args[1], nd, &args[2], nargs-1, ctx);
                     if (jl_array_store_unboxed(ety) &&
-                        ((jl_datatype_t*)ety)->size == 0) {
+                        jl_datatype_size(ety) == 0) {
                         assert(jl_is_datatype(ety));
                         assert(((jl_datatype_t*)ety)->instance != NULL);
                         *ret = ghostValue(ety);
@@ -2534,7 +2534,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     size_t nd = jl_is_long(ndp) ? jl_unbox_long(ndp) : 1;
                     Value *idx = emit_array_nd_index(ary, args[1], nd, &args[3], nargs-2, ctx);
                     bool isboxed = !jl_array_store_unboxed(ety);
-                    if (!isboxed && ((jl_datatype_t*)ety)->size == 0) {
+                    if (!isboxed && jl_datatype_size(ety) == 0) {
                         // no-op, but emit expr for possible effects
                         assert(jl_is_datatype(ety));
                         emit_expr(args[2], ctx);
@@ -2739,8 +2739,8 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             // this is issue #8798
             sty != jl_datatype_type) {
             if (jl_is_leaf_type((jl_value_t*)sty) ||
-                (sty->name->names == jl_emptysvec && sty->size > 0)) {
-                *ret = mark_julia_type(ConstantInt::get(T_size, sty->size), false, jl_long_type, ctx);
+                (sty->name->names == jl_emptysvec && jl_datatype_size(sty) > 0)) {
+                *ret = mark_julia_type(ConstantInt::get(T_size, jl_datatype_size(sty)), false, jl_long_type, ctx);
                 JL_GC_POP();
                 return true;
             }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -91,6 +91,12 @@ static Type *FT(Type *t)
 {
     if (t->isFloatingPointTy())
         return t;
+    if (auto vt = dyn_cast<VectorType>(t)) {
+        if (vt->getElementType()->isFloatingPointTy())
+            return t;
+        Type *et = FTnbits(vt->getElementType()->getPrimitiveSizeInBits());
+        return VectorType::get(et, vt->getNumElements());
+    }
     return FTnbits(t->getPrimitiveSizeInBits());
 }
 
@@ -99,6 +105,9 @@ static Value *FP(Value *v)
 {
     if (v->getType()->isFloatingPointTy())
         return v;
+    if (auto vt = dyn_cast<VectorType>(v->getType()))
+        if (vt->getElementType()->isFloatingPointTy())
+            return v;
     return emit_bitcast(v, FT(v->getType()));
 }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -969,6 +969,18 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
             r = builder.CreateCall3(func, x, y, z);
 #endif
         }
+        else if (nargs == 4) {
+            Value *x = boxed(emit_expr(args[1], ctx), ctx);
+            Value *y = boxed(emit_expr(args[2], ctx), ctx);
+            Value *z = boxed(emit_expr(args[3], ctx), ctx);
+            Value *w = boxed(emit_expr(args[4], ctx), ctx);
+
+#ifdef LLVM37
+            r = builder.CreateCall(func, {x, y, z, w});
+#else
+            r = builder.CreateCall4(func, x, y, z, w);
+#endif
+        }
         else {
             assert(0);
         }

--- a/src/julia.h
+++ b/src/julia.h
@@ -953,6 +953,27 @@ STATIC_INLINE int jl_is_vecelement_type(jl_value_t* t)
             ((jl_datatype_t*)(t))->name == jl_vecelement_typename);
 }
 
+STATIC_INLINE int jl_is_vec_type(jl_value_t* t)
+{
+    if (!jl_is_tuple_type(t))
+        return 0;
+
+    jl_value_t* ft0 = jl_field_type(t, 0);
+    if (!jl_is_vecelement_type(ft0))
+        return 0;
+
+    if (!jl_is_bitstype(jl_field_type(ft0, 0)))
+        return 0;
+
+    size_t nf = jl_datatype_nfields(t);
+    for (size_t i = 1; i < nf; ++i)
+        if (jl_field_type(t, i) != ft0)
+            // Not homogeneous
+            return 0;
+
+    return 1;
+}
+
 STATIC_INLINE int jl_is_type_type(jl_value_t *v)
 {
     return (jl_is_datatype(v) &&

--- a/src/julia.h
+++ b/src/julia.h
@@ -767,6 +767,7 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x)
 #define jl_field_type(st,i)    jl_svecref(((jl_datatype_t*)st)->types, (i))
 #define jl_field_count(st)     jl_svec_len(((jl_datatype_t*)st)->types)
 #define jl_datatype_size(t)    (((jl_datatype_t*)t)->size)
+#define jl_datatype_nbits(t)   ((((jl_datatype_t*)t)->size)*8)
 #define jl_datatype_nfields(t) (((jl_datatype_t*)(t))->layout->nfields)
 
 // inline version with strong type check to detect typos in a `->name` chain
@@ -871,14 +872,14 @@ STATIC_INLINE int jl_is_bitstype(void *v)
     return (jl_is_datatype(v) && jl_is_immutable(v) &&
             ((jl_datatype_t*)(v))->layout &&
             jl_datatype_nfields(v) == 0 &&
-            ((jl_datatype_t*)(v))->size > 0);
+            jl_datatype_size(v) > 0);
 }
 
 STATIC_INLINE int jl_is_structtype(void *v)
 {
     return (jl_is_datatype(v) &&
             (jl_field_count(v) > 0 ||
-             ((jl_datatype_t*)(v))->size == 0) &&
+             jl_datatype_size(v) == 0) &&
             !((jl_datatype_t*)(v))->abstract);
 }
 
@@ -895,7 +896,7 @@ STATIC_INLINE int jl_is_datatype_singleton(jl_datatype_t *d)
 
 STATIC_INLINE int jl_is_datatype_make_singleton(jl_datatype_t *d)
 {
-    return (!d->abstract && d->size == 0 && d != jl_sym_type && d->name != jl_array_typename &&
+    return (!d->abstract && jl_datatype_size(d) == 0 && d != jl_sym_type && d->name != jl_array_typename &&
             d->uid != 0 && (d->name->names == jl_emptysvec || !d->mutabl));
 }
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -322,12 +322,13 @@ jl_value_t *jl_iintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name,
                             char (*getsign)(void*, unsigned),
                             jl_value_t *(*lambda1)(jl_value_t*, void*, unsigned, unsigned, const void*), const void *list)
 {
-    if (!jl_is_bitstype(jl_typeof(a)))
+    jl_value_t *aty = jl_typeof(a);
+    if (!(jl_is_bitstype(aty) || jl_is_vec_type(aty)))
         jl_errorf("%s: value is not a bitstype", name);
-    if (!jl_is_bitstype(ty))
+    if (!(jl_is_bitstype(ty) || jl_is_vec_type(ty)))
         jl_errorf("%s: type is not a bitstype", name);
     void *pa = jl_data_ptr(a);
-    unsigned isize = jl_datatype_size(jl_typeof(a));
+    unsigned isize = jl_datatype_size(aty);
     unsigned isize2 = next_power_of_two(isize);
     unsigned osize = jl_datatype_size(ty);
     unsigned osize2 = next_power_of_two(osize);
@@ -391,9 +392,9 @@ static inline jl_value_t *jl_intrinsic_cvt(jl_value_t *ty, jl_value_t *a, const 
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *aty = jl_typeof(a);
-    if (!jl_is_bitstype(aty))
+    if (!(jl_is_bitstype(aty) || jl_is_vec_type(aty)))
         jl_errorf("%s: value is not a bitstype", name);
-    if (!jl_is_bitstype(ty))
+    if (!(jl_is_bitstype(ty) || jl_is_vec_type(aty)))
         jl_errorf("%s: type is not a bitstype", name);
     void *pa = jl_data_ptr(a);
     unsigned isize = jl_datatype_size(aty);
@@ -430,14 +431,15 @@ typedef void (fintrinsic_op1)(unsigned, void*, void*);
 static inline jl_value_t *jl_fintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name, fintrinsic_op1 *floatop, fintrinsic_op1 *doubleop)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    if (!jl_is_bitstype(jl_typeof(a)))
+    jl_value_t *aty = jl_typeof(a);
+    if (!(jl_is_bitstype(aty) || jl_is_vec_type(aty)))
         jl_errorf("%s: value is not a bitstype", name);
-    if (!jl_is_bitstype(ty))
+    if (!(jl_is_bitstype(ty) || jl_is_vec_type(ty)))
         jl_errorf("%s: type is not a bitstype", name);
     unsigned sz2 = jl_datatype_size(ty);
     jl_value_t *newv = jl_gc_alloc(ptls, sz2, ty);
     void *pa = jl_data_ptr(a), *pr = jl_data_ptr(newv);
-    unsigned sz = jl_datatype_size(jl_typeof(a));
+    unsigned sz = jl_datatype_size(aty);
     switch (sz) {
     /* choose the right size c-type operation based on the input */
     case 4:
@@ -889,7 +891,7 @@ un_fintrinsic_withtype(checked_fptoui, checked_fptoui)
 JL_DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a)
 {
     jl_value_t *ty = jl_typeof(a);
-    if (!jl_is_bitstype(ty))
+    if (!(jl_is_bitstype(ty) || jl_is_vec_type(ty)))
         jl_error("check_top_bit: value is not a bitstype");
     if (signbitbyte(jl_data_ptr(a), jl_datatype_size(ty)))
         jl_throw(jl_inexact_exception);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -351,7 +351,7 @@ jl_value_t *jl_iintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name,
 static inline jl_value_t *jl_intrinsiclambda_ty1(jl_value_t *ty, void *pa, unsigned osize, unsigned osize2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_1_t op = select_intrinsic_1(osize2, (const intrinsic_1_t*)voidlist);
     op(osize * host_char_bit, pa, jl_data_ptr(newv));
     return newv;
@@ -360,7 +360,7 @@ static inline jl_value_t *jl_intrinsiclambda_ty1(jl_value_t *ty, void *pa, unsig
 static inline jl_value_t *jl_intrinsiclambda_u1(jl_value_t *ty, void *pa, unsigned osize, unsigned osize2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_u1_t op = select_intrinsic_u1(osize2, (const intrinsic_u1_t*)voidlist);
     unsigned cnt = op(osize * host_char_bit, pa);
     // TODO: the following memset/memcpy assumes little-endian
@@ -399,7 +399,7 @@ static inline jl_value_t *jl_intrinsic_cvt(jl_value_t *ty, jl_value_t *a, const 
     unsigned osize = jl_datatype_size(ty);
     if (check_op && check_op(isize, osize, pa))
         jl_throw(jl_inexact_exception);
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     op(aty == (jl_value_t*)jl_bool_type ? 1 : isize * host_char_bit, pa,
             osize * host_char_bit, jl_data_ptr(newv));
     if (ty == (jl_value_t*)jl_bool_type)
@@ -566,7 +566,7 @@ jl_value_t *jl_iintrinsic_2(jl_value_t *a, jl_value_t *b, const char *name,
 static inline jl_value_t *jl_intrinsiclambda_2(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_2_t op = select_intrinsic_2(sz2, (const intrinsic_2_t*)voidlist);
     op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
     if (ty == (jl_value_t*)jl_bool_type)
@@ -584,7 +584,7 @@ static inline jl_value_t *jl_intrinsiclambda_cmp(jl_value_t *ty, void *pa, void 
 static inline jl_value_t *jl_intrinsiclambda_checked(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_checked_t op = select_intrinsic_checked(sz2, (const intrinsic_checked_t*)voidlist);
     int ovflw = op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
     if (ovflw)

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -18,13 +18,14 @@ const unsigned int host_char_bit = 8;
 JL_DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v)
 {
     JL_TYPECHK(reinterpret, datatype, ty);
-    if (!jl_is_leaf_type(ty) || !jl_is_bitstype(ty))
+    if (!jl_is_leaf_type(ty) || !(jl_is_bitstype(ty) || jl_is_vec_type(ty)))
         jl_error("reinterpret: target type not a leaf bitstype");
-    if (!jl_is_bitstype(jl_typeof(v)))
+    jl_value_t* dt = jl_typeof(v);
+    if (!(jl_is_bitstype(dt) || jl_is_vec_type(dt)))
         jl_error("reinterpret: value not a bitstype");
-    if (jl_datatype_size(jl_typeof(v)) != jl_datatype_size(ty))
+    if (jl_datatype_size(dt) != jl_datatype_size(ty))
         jl_error("reinterpret: argument size does not match size of target type");
-    if (ty == jl_typeof(v))
+    if (ty == dt)
         return v;
     if (ty == (jl_value_t*)jl_bool_type)
         return *(uint8_t*)jl_data_ptr(v) & 1 ? jl_true : jl_false;

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -65,3 +65,16 @@ a[1] = Gr(5.0, Bunch((VecElement(6.0), VecElement(7.0))), 8.0)
 @test a[2] == Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
 
 @test isa(VecElement((1,2)), VecElement{Tuple{Int,Int}})
+
+import Core.Intrinsics
+# Test intrinsics for #18445
+# Explicit form
+function trunc_vec{T1 <: Vec, T2 <: Vec}(::Type{T1}, x :: T2)
+    Intrinsics.box(T1, Intrinsics.trunc_int(T1, Intrinsics.unbox(T2, x)))
+end
+
+@test trunc_vec(Vec{4, UInt8}, Vec((0xff00, 0xff01, 0x00ff, 0xf0f0))) == Vec((0x00, 0x01, 0xff, 0xf0))
+@test Intrinsics.zext_int(Vec{4, UInt16}, Vec((0x00, 0x01, 0xff, 0xf0))) == Vec((0x0000, 0x0001, 0x00ff, 0x00f0))
+@test Intrinsics.sext_int(Vec{4, UInt16}, Vec((0x00, 0x01, 0xff, 0xf0))) == Vec((0x0000, 0x0001, 0xffff, 0xfff0))
+@test Intrinsics.add_int(Vec((1,2,3,4)), Vec((1,2,3,4))) == Vec((2,4,6,8))
+# @test Intrinsics.mul_float(Vec((1.0, 2.0, 1.0, 2.0)), Vec((0.5, 0.5, 1.5, 1.5))) == Vec((0.5, 1.0, 1.5, 3.0))

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -77,4 +77,4 @@ end
 @test Intrinsics.zext_int(Vec{4, UInt16}, Vec((0x00, 0x01, 0xff, 0xf0))) == Vec((0x0000, 0x0001, 0x00ff, 0x00f0))
 @test Intrinsics.sext_int(Vec{4, UInt16}, Vec((0x00, 0x01, 0xff, 0xf0))) == Vec((0x0000, 0x0001, 0xffff, 0xfff0))
 @test Intrinsics.add_int(Vec((1,2,3,4)), Vec((1,2,3,4))) == Vec((2,4,6,8))
-# @test Intrinsics.mul_float(Vec((1.0, 2.0, 1.0, 2.0)), Vec((0.5, 0.5, 1.5, 1.5))) == Vec((0.5, 1.0, 1.5, 3.0))
+@test Intrinsics.mul_float(Vec((1.0, 2.0, 1.0, 2.0)), Vec((0.5, 0.5, 1.5, 1.5))) == Vec((0.5, 1.0, 1.5, 3.0))


### PR DESCRIPTION
This fixes #18445 by handling `NTuple{N, VecElement}` in the lowering of our intrinsics. This should make it easier to implement the fundamentals of `SIMD.jl` without `llvmcall` and maybe in the long-term enable us to have SIMD types in base julia. 
## Todo:
- [ ] Runtime intrinsics (right now they return nonsense.)
- [x] Floats handling
- [x] in `jl_is_vec_type` check that `VecElement` contains a `jl_is_bitstype`

If needed I can separate out b2f6b1b and fb12337 into a separate PR.

cc @eschnett 
