### PR TITLE
support 256 colors in print_with_color and env variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@ New language features
     without having to scrub away prompts and outputs.
     This can be disabled or enabled at will with `Base.REPL.enable_promptpaste(::Bool)`.
 
+  * The function `print_with_color` can now take a color represented by an integer between 0 and 255 inclusive as its first argument.
+    For a number to color mapping please refer to [this chart](https://upload.wikimedia.org/wikipedia/en/1/15/Xterm_256color_chart.svg).
+    It is also possible to use numbers as colors in environment variables that customizes colors in the REPL.
+    For example, to get orange warning messages, simply set `ENV["JULIA_WARN_COLOR"] = 208`.
+    Please note that not all terminals support 256 colors.
+
 Language changes
 ----------------
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -16,10 +16,14 @@ const text_colors = AnyDict(
     :bold    => "\033[1m",
 )
 
+for i in 0:256
+    text_colors[i] = "\033[1m\033[38;5;$(i)m"
+end
+
 # Create a docstring with an automatically generated list
 # of colors.
 const possible_formatting_symbols = [:normal, :bold]
-available_text_colors = collect(keys(text_colors))
+available_text_colors = collect(filter(x -> !isa(x, Integer), keys(text_colors)))
 available_text_colors = cat(1,
     sort(intersect(available_text_colors, possible_formatting_symbols), rev=true),
     sort(setdiff(  available_text_colors, possible_formatting_symbols)))
@@ -30,7 +34,7 @@ const available_text_colors_docstring =
 
 """Dictionary of color codes for the terminal.
 
-Available colors are: $available_text_colors_docstring.
+Available colors are: $available_text_colors_docstring as well as the integers 0 to 256 inclusive.
 """
 text_colors
 
@@ -47,8 +51,10 @@ end
 color_normal = text_colors[:normal]
 
 function repl_color(key, default)
-    c = Symbol(get(ENV, key, ""))
-    haskey(text_colors, c) ? c : default
+    env_str = get(ENV, key, "")
+    c = tryparse(Int, env_str)
+    c_conv = isnull(c) ? Symbol(env_str) : get(c)
+    haskey(text_colors, c_conv) ? c_conv : default
 end
 
 warn_color()   = repl_color("JULIA_WARN_COLOR", default_color_warn)

--- a/base/client.jl
+++ b/base/client.jl
@@ -16,7 +16,7 @@ const text_colors = AnyDict(
     :bold    => "\033[1m",
 )
 
-for i in 0:256
+for i in 0:255
     text_colors[i] = "\033[1m\033[38;5;$(i)m"
 end
 
@@ -34,7 +34,7 @@ const available_text_colors_docstring =
 
 """Dictionary of color codes for the terminal.
 
-Available colors are: $available_text_colors_docstring as well as the integers 0 to 256 inclusive.
+Available colors are: $available_text_colors_docstring as well as the integers 0 to 255 inclusive.
 """
 text_colors
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2967,15 +2967,6 @@ Return `true` if `A` is a subset of or equal to `S`.
 issubset
 
 """
-    print_with_color(color::Symbol, [io], strings...)
-
-Print strings in a color specified as a symbol.
-
-`color` may take any of the values $(Base.available_text_colors_docstring).
-"""
-print_with_color
-
-"""
     stringmime(mime, x)
 
 Returns an `AbstractString` containing the representation of `x` in the requested `mime`

--- a/base/util.jl
+++ b/base/util.jl
@@ -316,7 +316,7 @@ end
 Print strings in a color specified as a symbol.
 
 `color` may take any of the values $(Base.available_text_colors_docstring)
-or an integer between 0 and 256 inclusive. Note that not all terminals support 256 colors.
+or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
 """
 print_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...) =
     with_output_color(print, color, io, msg...)

--- a/base/util.jl
+++ b/base/util.jl
@@ -301,7 +301,6 @@ end
 
 function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args...)
     buf = IOBuffer()
-
     have_color && print(buf, get(text_colors, color, color_normal))
     try f(buf, args...)
     finally

--- a/base/util.jl
+++ b/base/util.jl
@@ -299,8 +299,9 @@ end
 
 ## printing with color ##
 
-function with_output_color(f::Function, color::Symbol, io::IO, args...)
+function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args...)
     buf = IOBuffer()
+
     have_color && print(buf, get(text_colors, color, color_normal))
     try f(buf, args...)
     finally
@@ -309,13 +310,21 @@ function with_output_color(f::Function, color::Symbol, io::IO, args...)
     end
 end
 
-print_with_color(color::Symbol, io::IO, msg::AbstractString...) =
+"""
+    print_with_color(color::Union{Symbol, Int}, [io], strings...)
+
+Print strings in a color specified as a symbol.
+
+`color` may take any of the values $(Base.available_text_colors_docstring)
+or an integer between 0 and 256 inclusive. Note that not all terminals support 256 colors.
+"""
+print_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...) =
     with_output_color(print, color, io, msg...)
-print_with_color(color::Symbol, msg::AbstractString...) =
+print_with_color(color::Union{Int, Symbol}, msg::AbstractString...) =
     print_with_color(color, STDOUT, msg...)
-println_with_color(color::Symbol, io::IO, msg::AbstractString...) =
+println_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...) =
     with_output_color(println, color, io, msg...)
-println_with_color(color::Symbol, msg::AbstractString...) =
+println_with_color(color::Union{Int, Symbol}, msg::AbstractString...) =
     println_with_color(color, STDOUT, msg...)
 
 ## warnings and messages ##

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -292,7 +292,7 @@ prompt you can add something like the following to your ``juliarc.jl`` file::
     Base.active_repl.prompt_color = Base.text_colors[:cyan]
 
 The available color keys in ``Base.text_colors`` are ``:black``, ``:red``, ``:green``, ``:yellow``,
-``:blue``, ``:magenta``, ``:cyan``, ``:white``, ``:normal``, and ``:bold`` as well as the integers 0 to 256 for terminals with 256 color support. Similarly, you can
+``:blue``, ``:magenta``, ``:cyan``, ``:white``, ``:normal``, and ``:bold`` as well as the integers 0 to 255 for terminals with 256 color support. Similarly, you can
 change the colors for the help and shell prompts and input and answer text by setting the
 appropriate member of ``Base.active_repl`` (respectively, ``help_color``, ``shell_color``,
 ``input_color``, and ``answer_color``). For the latter two, be sure that the ``envcolors`` member

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -292,7 +292,7 @@ prompt you can add something like the following to your ``juliarc.jl`` file::
     Base.active_repl.prompt_color = Base.text_colors[:cyan]
 
 The available color keys in ``Base.text_colors`` are ``:black``, ``:red``, ``:green``, ``:yellow``,
-``:blue``, ``:magenta``, ``:cyan``, ``:white``, ``:normal``, and ``:bold``. Similarly, you can
+``:blue``, ``:magenta``, ``:cyan``, ``:white``, ``:normal``, and ``:bold`` as well as the integers 0 to 256 for terminals with 256 color support. Similarly, you can
 change the colors for the help and shell prompts and input and answer text by setting the
 appropriate member of ``Base.active_repl`` (respectively, ``help_color``, ``shell_color``,
 ``input_color``, and ``answer_color``). For the latter two, be sure that the ``envcolors`` member

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -502,13 +502,13 @@ Text I/O
 
    Print (using :func:`print`\ ) ``xs`` followed by a newline. If ``io`` is not supplied, prints to :obj:`STDOUT`\ .
 
-.. function:: print_with_color(color::Symbol, [io], strings...)
+.. function:: print_with_color(color::Union{Symbol, Int}, [io], strings...)
 
    .. Docstring generated from Julia source
 
    Print strings in a color specified as a symbol.
 
-   ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:magenta``\ , ``:red``\ , ``:white``\ , or  ``:yellow``\ .
+   ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:magenta``\ , ``:red``\ , ``:white``\ , or  ``:yellow`` or an integer between 0 and 256 inclusive. Note that not all terminals support 256 colors.
 
 .. function:: info(msg...; prefix="INFO: ")
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -508,7 +508,7 @@ Text I/O
 
    Print strings in a color specified as a symbol.
 
-   ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:magenta``\ , ``:red``\ , ``:white``\ , or  ``:yellow`` or an integer between 0 and 256 inclusive. Note that not all terminals support 256 colors.
+   ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:magenta``\ , ``:red``\ , ``:white``\ , or  ``:yellow`` or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
 
 .. function:: info(msg...; prefix="INFO: ")
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1282691/18465795/efac8d86-7998-11e6-9b85-6d786881f642.png)

Now people can have their orange warning messages:

![image](https://cloud.githubusercontent.com/assets/1282691/18465803/fa89aa68-7998-11e6-8f06-55eac535471b.png)
