### PR TITLE
Fix a couple of inferrability issues

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -420,7 +420,7 @@ function vecnorm(itr, p::Real=2)
         vecnormp(itr,p)
     end
 end
-@inline vecnorm(x::Number, p::Real=2) = p == 0 ? real(x==0 ? zero(x) : one(x)) : abs(x)
+@inline vecnorm(x::Number, p::Real=2) = p == 0 ? (x==0 ? zero(abs(x)) : one(abs(x))) : abs(x)
 
 norm(x::AbstractVector, p::Real=2) = vecnorm(x, p)
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -108,7 +108,7 @@ julia> typeof(num(a))
 BigInt
 ```
 """
-function rationalize{T<:Integer}(::Type{T}, x::AbstractFloat; tol::Real=eps(x))
+function rationalize{T<:Integer}(::Type{T}, x::AbstractFloat, tol::Real)
     if tol < 0
         throw(ArgumentError("negative tolerance $tol"))
     end
@@ -123,7 +123,9 @@ function rationalize{T<:Integer}(::Type{T}, x::AbstractFloat; tol::Real=eps(x))
     r = x-a
     y = one(x)
 
-    nt, t, tt = tol, zero(tol), tol
+    tolx = oftype(x, tol)
+    nt, t, tt = tolx, zero(tolx), tolx
+    ia = np = nq = zero(T)
 
     # compute the successive convergents of the continued fraction
     #  np // nq = (p*a + pp) // (q*a + qq)
@@ -165,6 +167,7 @@ function rationalize{T<:Integer}(::Type{T}, x::AbstractFloat; tol::Real=eps(x))
         return p // q
     end
 end
+rationalize{T<:Integer}(::Type{T}, x::AbstractFloat; tol::Real=eps(x)) = rationalize(T, x, tol)::Rational{T}
 rationalize(x::AbstractFloat; kvs...) = rationalize(Int, x; kvs...)
 
 num(x::Integer) = x

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -913,4 +913,6 @@ end
 let x = 1+im
     @inferred sin(x)
     @inferred cos(x)
+    @inferred norm(x)
+    @inferred vecnorm(x)
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1012,6 +1012,9 @@ f9085() = typemax(UInt64) != 2.0^64
 @test (1//typemax(Int)) / (1//typemax(Int)) == 1
 @test_throws OverflowError (1//2)^63
 
+@test @inferred(rationalize(Int, 3.0, 0.0)) === 3//1
+@test @inferred(rationalize(Int, 3.0, 0)) === 3//1
+
 for a = -5:5, b = -5:5
     if a == b == 0; continue; end
     if ispow2(b)


### PR DESCRIPTION
Discovered while kicking the tires on Unitful. I'm not sure whether there's a concern about making `tol` a positional argument for `rationalize`, but the solution I adopted seems reasonable to me. Even when you rely on the keyword argument for `tol`, this still makes the function faster:

Julia 0.5:

``` jl
julia> @benchmark rationalize(3.2)
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     195
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  224.00 bytes
  allocs estimate:  5
  minimum time:     494.00 ns (0.00% GC)
  median time:      499.00 ns (0.00% GC)
  mean time:        556.76 ns (7.63% GC)
  maximum time:     31.35 μs (97.69% GC)
```

This branch:

``` jl
julia> @benchmark rationalize(3.2)
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     525
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  192.00 bytes
  allocs estimate:  3
  minimum time:     213.00 ns (0.00% GC)
  median time:      215.00 ns (0.00% GC)
  mean time:        233.26 ns (3.46% GC)
  maximum time:     2.98 μs (87.50% GC)
```

and

``` jl
julia> @benchmark rationalize(Int, 3.2, $(eps(3.2)))
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     861
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     140.00 ns (0.00% GC)
  median time:      141.00 ns (0.00% GC)
  mean time:        146.25 ns (0.00% GC)
  maximum time:     319.00 ns (0.00% GC)
```
