### PR TITLE
Do not print in bold in print_with_color + other color tweaks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ Language changes
     One way of doing this is by adding `ENV["JULIA_INFO_COLOR"] = :blue` to the `.juliarc.jl` file.
     For more information regarding customizing colors in the REPL, see this [manual section]( http://docs.julialang.org/en/latest/manual/interacting-with-julia/#customizing-colors).
 
+  * The function `print_with_color` no longer prints text in bold by default.
+
 Breaking changes
 ----------------
 

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -626,6 +626,7 @@ default_enter_cb(_) = true
 
 write_prompt(terminal, s::PromptState) = write_prompt(terminal, s.p)
 function write_prompt(terminal, p::Prompt)
+    write(terminal, Base.text_colors[:bold])
     prefix = isa(p.prompt_prefix,Function) ? p.prompt_prefix() : p.prompt_prefix
     suffix = isa(p.prompt_suffix,Function) ? p.prompt_suffix() : p.prompt_suffix
     write(terminal, prefix)

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -111,8 +111,10 @@ function ip_matches_func(ip, func::Symbol)
 end
 
 function display_error(io::IO, er, bt)
-    Base.with_output_color(:red, io) do io
-        print(io, "ERROR: ")
+    Base.with_output_color(:light_red, io) do io
+        Base.with_output_color(:bold, io) do io
+            print(io, "ERROR: ")
+        end
         # remove REPL-related frames from interactive printing
         eval_ind = findlast(addr->ip_matches_func(addr, :eval), bt)
         if eval_ind != 0
@@ -281,7 +283,7 @@ LineEditREPL(t::TextTerminal, envcolors = false) =  LineEditREPL(t,
                                               julia_green,
                                               Base.input_color(),
                                               Base.answer_color(),
-                                              Base.text_colors[:red],
+                                              Base.text_colors[:light_red],
                                               Base.text_colors[:yellow],
                                               false, false, false, envcolors)
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -4,16 +4,24 @@
 ##             and REPL
 
 const text_colors = AnyDict(
-    :black   => "\033[1m\033[30m",
-    :red     => "\033[1m\033[31m",
-    :green   => "\033[1m\033[32m",
-    :yellow  => "\033[1m\033[33m",
-    :blue    => "\033[1m\033[34m",
-    :magenta => "\033[1m\033[35m",
-    :cyan    => "\033[1m\033[36m",
-    :white   => "\033[1m\033[37m",
-    :normal  => "\033[0m",
-    :bold    => "\033[1m",
+    :black     => "\033[1m\033[30m",
+    :red       => "\033[1m\033[31m",
+    :green     => "\033[1m\033[32m",
+    :yellow    => "\033[1m\033[33m",
+    :blue      => "\033[1m\033[34m",
+    :magenta   => "\033[1m\033[35m",
+    :cyan      => "\033[1m\033[36m",
+    :white     => "\033[1m\033[37m",
+    :normal    => "\033[0m",
+    :bold      => "\033[1m",
+    :italics   => "\033[3m",
+    :underline => "\033[4m",
+)
+
+const disable_text_style = AnyDict(
+    :bold => "\033[22m",
+    :italics => "\033[23m",
+    :underline => "\033[24m",
 )
 
 for i in 0:255

--- a/base/client.jl
+++ b/base/client.jl
@@ -4,24 +4,28 @@
 ##             and REPL
 
 const text_colors = AnyDict(
-    :black     => "\033[1m\033[30m",
-    :red       => "\033[1m\033[31m",
-    :green     => "\033[1m\033[32m",
-    :yellow    => "\033[1m\033[33m",
-    :blue      => "\033[1m\033[34m",
-    :magenta   => "\033[1m\033[35m",
-    :cyan      => "\033[1m\033[36m",
-    :white     => "\033[1m\033[37m",
-    :normal    => "\033[0m",
-    :bold      => "\033[1m",
-    :italics   => "\033[3m",
-    :underline => "\033[4m",
+    :black         => "\033[30m",
+    :red           => "\033[31m",
+    :green         => "\033[32m",
+    :yellow        => "\033[33m",
+    :blue          => "\033[34m",
+    :magenta       => "\033[35m",
+    :cyan          => "\033[36m",
+    :white         => "\033[37m",
+    :dark_gray     => "\033[90m",
+    :light_red     => "\033[91m",
+    :light_green   => "\033[92m",
+    :light_yellow  => "\033[93m",
+    :light_blue    => "\033[94m",
+    :light_magenta => "\033[95m",
+    :light_cyan    => "\033[96m",
+    :normal        => "\033[0m",
+    :default       => "\033[39m",
+    :bold          => "\033[1m",
 )
 
 const disable_text_style = AnyDict(
     :bold => "\033[22m",
-    :italics => "\033[23m",
-    :underline => "\033[24m",
 )
 
 for i in 0:255
@@ -30,7 +34,7 @@ end
 
 # Create a docstring with an automatically generated list
 # of colors.
-const possible_formatting_symbols = [:normal, :bold]
+const possible_formatting_symbols = [:normal, :bold, :default]
 available_text_colors = collect(filter(x -> !isa(x, Integer), keys(text_colors)))
 available_text_colors = cat(1,
     sort(intersect(available_text_colors, possible_formatting_symbols), rev=true),
@@ -43,11 +47,14 @@ const available_text_colors_docstring =
 """Dictionary of color codes for the terminal.
 
 Available colors are: $available_text_colors_docstring as well as the integers 0 to 255 inclusive.
+
+The color `:default` will print text in the default color while the color `:normal`
+will print text with all properties reset to normal (including boldness, italics etc.).
 """
 text_colors
 
 have_color = false
-default_color_warn = :red
+default_color_warn = :light_red
 default_color_info = :cyan
 if is_windows()
     default_color_input = :normal
@@ -67,8 +74,10 @@ end
 
 warn_color()   = repl_color("JULIA_WARN_COLOR", default_color_warn)
 info_color()   = repl_color("JULIA_INFO_COLOR", default_color_info)
-input_color()  = text_colors[repl_color("JULIA_INPUT_COLOR", default_color_input)]
-answer_color() = text_colors[repl_color("JULIA_ANSWER_COLOR", default_color_answer)]
+
+# Print input and answer in bold unless the user specifies :default in the ENV var.
+input_color()  = text_colors[:bold] * text_colors[repl_color("JULIA_INPUT_COLOR", default_color_input)]
+answer_color() = text_colors[:bold] * text_colors[repl_color("JULIA_ANSWER_COLOR", default_color_answer)]
 
 function repl_cmd(cmd, out)
     shell = shell_split(get(ENV,"JULIA_SHELL",get(ENV,"SHELL","/bin/sh")))
@@ -109,8 +118,10 @@ end
 
 display_error(er) = display_error(er, [])
 function display_error(er, bt)
-    with_output_color(:red, STDERR) do io
-        print(io, "ERROR: ")
+    with_output_color(:light_red, STDERR) do io
+        with_output_color(:bold, STDERR) do io_bold
+            print(io_bold, "ERROR: ")
+        end
         showerror(io, er, bt)
         println(io)
     end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -174,7 +174,7 @@ function status(io::IO, pkg::AbstractString, ver::VersionNumber, fix::Bool)
             LibGit2.isdirty(prepo) && push!(attrs,"dirty")
             isempty(attrs) || print(io, " (",join(attrs,", "),")")
         catch err
-            print_with_color(:red, io, " broken-repo (unregistered)")
+            print_with_color(:light_red, io, " broken-repo (unregistered)")
         finally
             finalize(prepo)
         end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -462,7 +462,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                 t_in === Union{} && special && i == 1 && break
                 if t_in === Union{}
                     if Base.have_color
-                        Base.with_output_color(:red, buf) do buf
+                        Base.with_output_color(:light_red, buf) do buf
                             print(buf, "::$sigstr")
                         end
                     else
@@ -503,7 +503,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                             print(buf, ", ")
                         end
                         if Base.have_color
-                            Base.with_output_color(:red, buf) do buf
+                            Base.with_output_color(:light_red, buf) do buf
                                 print(buf, "::$sigstr")
                             end
                         else
@@ -529,7 +529,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                         end
                     end
                     if !isempty(unexpected)
-                        Base.with_output_color(:red, buf) do buf
+                        Base.with_output_color(:light_red, buf) do buf
                             plur = length(unexpected) > 1 ? "s" : ""
                             print(buf, " got unsupported keyword argument$plur \"", join(unexpected, "\", \""), "\"")
                         end

--- a/base/show.jl
+++ b/base/show.jl
@@ -527,7 +527,7 @@ function show_expr_type(io::IO, ty, emph)
     end
 end
 
-emphasize(io, str::AbstractString) = have_color ? print_with_color(:red, io, str) : print(io, uppercase(str))
+emphasize(io, str::AbstractString) = have_color ? print_with_color(:light_red, io, str) : print(io, uppercase(str))
 
 show_linenumber(io::IO, line)       = print(io," # line ",line,':')
 show_linenumber(io::IO, line, file) = print(io," # ", file,", line ",line,':')

--- a/base/task.jl
+++ b/base/task.jl
@@ -181,7 +181,7 @@ function task_done_hook(t::Task)
         if !suppress_excp_printing(t)
             let bt = t.backtrace
                 # run a new task to print the error for us
-                @schedule with_output_color(:red, STDERR) do io
+                @schedule with_output_color(:light_red, STDERR) do io
                     print(io, "ERROR (unhandled task failure): ")
                     showerror(io, result, bt)
                     println(io)

--- a/base/test.jl
+++ b/base/test.jl
@@ -68,7 +68,7 @@ type Fail <: Result
     value
 end
 function Base.show(io::IO, t::Fail)
-    print_with_color(:red, io, "Test Failed\n")
+    print_with_color(:light_red, io, "Test Failed\n")
     print(io, "  Expression: ", t.orig_expr)
     if t.test_type == :test_throws_wrong
         # An exception was thrown, but it was of the wrong type
@@ -100,7 +100,7 @@ type Error <: Result
     backtrace
 end
 function Base.show(io::IO, t::Error)
-    print_with_color(:red, io, "Error During Test\n")
+    print_with_color(:light_red, io, "Error During Test\n")
     if t.test_type == :test_nonbool
         println(io, "  Expression evaluated to non-Boolean")
         println(io, "  Expression: ", t.orig_expr)
@@ -476,10 +476,10 @@ function finish(ts::DefaultTestSet)
         print_with_color(:green, lpad("Pass",pass_width," "), "  ")
     end
     if fail_width > 0
-        print_with_color(:red, lpad("Fail",fail_width," "), "  ")
+        print_with_color(:light_red, lpad("Fail",fail_width," "), "  ")
     end
     if error_width > 0
-        print_with_color(:red, lpad("Error",error_width," "), "  ")
+        print_with_color(:light_red, lpad("Error",error_width," "), "  ")
     end
     if broken_width > 0
         print_with_color(:yellow, lpad("Broken",broken_width," "), "  ")
@@ -562,7 +562,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     nf = fails + c_fails
     if nf > 0
-        print_with_color(:red, lpad(string(nf), fail_width, " "), "  ")
+        print_with_color(:light_red, lpad(string(nf), fail_width, " "), "  ")
     elseif fail_width > 0
         # No fails at this level, but some at another level
         print(lpad(" ", fail_width), "  ")
@@ -570,7 +570,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     ne = errors + c_errors
     if ne > 0
-        print_with_color(:red, lpad(string(ne), error_width, " "), "  ")
+        print_with_color(:light_red, lpad(string(ne), error_width, " "), "  ")
     elseif error_width > 0
         # No errors at this level, but some at another level
         print(lpad(" ", error_width), "  ")

--- a/base/util.jl
+++ b/base/util.jl
@@ -304,7 +304,7 @@ function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args.
     have_color && print(buf, get(text_colors, color, color_normal))
     try f(buf, args...)
     finally
-        have_color && print(buf, color_normal)
+        have_color && print(buf, get(disable_text_style, color, "\033[0m"))
         print(io, takebuf_string(buf))
     end
 end

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -295,8 +295,7 @@ prompt you can add something like the following to your ``juliarc.jl`` file::
 
     atreplinit(customize_colors)
 
-The available color keys in ``Base.text_colors`` are ``:black``, ``:red``, ``:green``, ``:yellow``,
-``:blue``, ``:magenta``, ``:cyan``, ``:white``, ``:normal``, and ``:bold`` as well as the integers 0 to 255 for terminals with 256 color support. Similarly, you can
+The available color keys can be seen by typing ``Base.text_colors`` in the help mode of the REPL. Similarly, you can
 change the colors for the help and shell prompts and input and answer text by setting the
 appropriate field of ``repl`` in the ``customize_colors`` function above (respectively, ``help_color``, ``shell_color``,
 ``input_color``, and ``answer_color``). For the latter two, be sure that the ``envcolors`` field

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -508,9 +508,7 @@ Text I/O
 
    Print strings in a color specified as a symbol.
 
-   ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:italics``\ , ``:magenta``\ , ``:red``\ , ``:underline``\ , ``:white``\ , or  ``:yellow`` or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
-
-    ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:italics``\ , ``:magenta``\ , ``:red``\ , ``:underline``\ , ``:white``\ , or  ``:yellow``\ . or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
+   ``color`` may take any of the values ``:normal``\ , ``:default``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:dark_gray``\ , ``:green``\ , ``:light_blue``\ , ``:light_cyan``\ , ``:light_green``\ , ``:light_magenta``\ , ``:light_red``\ , ``:light_yellow``\ , ``:magenta``\ , ``:red``\ , ``:white``\ , or  ``:yellow`` or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
 
 .. function:: info(msg...; prefix="INFO: ")
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -508,7 +508,9 @@ Text I/O
 
    Print strings in a color specified as a symbol.
 
-   ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:magenta``\ , ``:red``\ , ``:white``\ , or  ``:yellow`` or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
+   ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:italics``\ , ``:magenta``\ , ``:red``\ , ``:underline``\ , ``:white``\ , or  ``:yellow`` or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
+
+    ``color`` may take any of the values ``:normal``\ , ``:bold``\ , ``:black``\ , ``:blue``\ , ``:cyan``\ , ``:green``\ , ``:italics``\ , ``:magenta``\ , ``:red``\ , ``:underline``\ , ``:white``\ , or  ``:yellow``\ . or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
 
 .. function:: info(msg...; prefix="INFO: ")
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -452,3 +452,21 @@ if is_windows()
         err18083 == 0 && error(Libc.GetLastError())
     end
 end
+
+let
+    old_have_color = Base.have_color
+    try
+        eval(Base, :(have_color = true))
+        io = IOBuffer()
+        Base.with_output_color(:red, io) do io
+            Base.with_output_color(:bold, io) do io
+                print(io, " boldred ")
+            end
+            print(io, " just red ")
+        end
+        print(io, " normal")
+        @test takebuf_string(io) == "\e[31m\e[1m boldred \e[22m just red \e[39m normal"
+    finally
+        eval(Base, :(have_color = $(old_have_color)))
+    end
+end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -67,7 +67,7 @@ end
 pos_stable(x) = x > 0 ? x : zero(x)
 pos_unstable(x) = x > 0 ? x : 0
 
-tag = Base.have_color ? Base.text_colors[:red] : "UNION"
+tag = Base.have_color ? Base.text_colors[:light_red] : "UNION"
 @test warntype_hastag(pos_unstable, Tuple{Float64}, tag)
 @test !warntype_hastag(pos_stable, Tuple{Float64}, tag)
 
@@ -80,13 +80,13 @@ end
 Base.getindex(A::Stable, i) = A.A[i]
 Base.getindex(A::Unstable, i) = A.A[i]
 
-tag = Base.have_color ? Base.text_colors[:red] : "ARRAY{FLOAT64,N}"
+tag = Base.have_color ? Base.text_colors[:light_red] : "ARRAY{FLOAT64,N}"
 @test warntype_hastag(getindex, Tuple{Unstable{Float64},Int}, tag)
 @test !warntype_hastag(getindex, Tuple{Stable{Float64,2},Int}, tag)
 @test warntype_hastag(getindex, Tuple{Stable{Float64},Int}, tag)
 
 # Make sure emphasis is not used for other functions
-tag = Base.have_color ? Base.text_colors[:red] : "ANY"
+tag = Base.have_color ? Base.text_colors[:light_red] : "ANY"
 iob = IOBuffer()
 show(iob, expand(:(x->x^2)))
 str = takebuf_string(iob)


### PR DESCRIPTION
- Changes print_with_color and company to not print things in bold by default.
- As a consequence of above, changes the default color for warnings and error printing to use `light_red` which is the same color as bold + red previously was on most terminals.
- `with_output_color` does no longer reset all the color state (does not print a `\e[0m` in the end) but instead "pops" off the last one. This means you can nest a bold style and a color style in `with_output_color`.
- Makes the "ERROR", "INFO", "WARNING" part bold.

![image](https://cloud.githubusercontent.com/assets/1282691/18476191/5ea6cb5e-79c9-11e6-8a03-304d97a16521.png)

![image](https://cloud.githubusercontent.com/assets/1282691/18476130/2f79a72a-79c9-11e6-8c6f-63845215abd6.png)
