### PR TITLE
Equivalency between function calls, abspath(p1, p2..) and abspath(joinpath(p1, p2..))

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -238,6 +238,10 @@ normpath(a::AbstractString, b::AbstractString...) = normpath(joinpath(a,b...))
     abspath(path::AbstractString) -> AbstractString
 
 Convert a path to an absolute path by adding the current directory if necessary.
+
+!!! note
+    The function calls `abspath(p1, p2..)` and `abspath(joinpath(p1, p2..))`
+    are equivalent.
 """
 abspath(a::String) = normpath(isabspath(a) ? a : joinpath(pwd(),a))
 abspath(a::AbstractString, b::AbstractString...) = abspath(joinpath(a,b...))

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -412,6 +412,9 @@
 
    Convert a path to an absolute path by adding the current directory if necessary.
 
+   .. note::
+       The function calls ``abspath(p1, p2...)`` and ``abspath(joinpath(p1, p2...))`` are equivalent.
+
 .. function:: normpath(path::AbstractString) -> AbstractString
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
This PR solves #18406.
## What does this PR do ?

This PR is a doc-fix. As mentioned in #18406, this PR documents the fact that the two function calls `abspath(p1, p2...)` and `abspath(joinpath(p1, p2...))` are equivalent.

@stevengj: Kindly review. The docs compile properly on my local system.
