### PR TITLE
Add generic isnull and unsafe_get methods

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1467,13 +1467,6 @@ julia> log2(10)
 log2
 
 """
-    isnull(x)
-
-Is the `Nullable` object `x` null, i.e. missing a value?
-"""
-isnull
-
-"""
     abs2(x)
 
 Squared absolute value of `x`.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1324,6 +1324,7 @@ export
 
 # nullable types
     isnull,
+    unsafe_get,
 
 # Macros
     # parser internal

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -61,6 +61,68 @@ end
 
 get(x::Nullable) = isnull(x) ? throw(NullException()) : x.value
 
+"""
+    unsafe_get(x)
+
+Return the value of `x` for [`Nullable`](:obj:`Nullable`) `x`; return `x` for
+all other `x`.
+
+This method does not check whether or not `x` is null before attempting to
+access the value of `x` for `x::Nullable` (hence "unsafe").
+
+```jldoctest
+julia> x = Nullable(1)
+Nullable{Int64}(1)
+
+julia> unsafe_get(x)
+1
+
+julia> x = Nullable{String}()
+Nullable{String}()
+
+julia> unsafe_get(x)
+ERROR: UndefRefError: access to undefined reference
+ in unsafe_get(::Nullable{String}) at ./REPL[4]:1
+
+julia> x = 1
+1
+
+julia> unsafe_get(x)
+1
+```
+"""
+unsafe_get(x::Nullable) = x.value
+unsafe_get(x) = x
+
+"""
+    isnull(x)
+
+Return whether or not `x` is null for [`Nullable`](:obj:`Nullable`) `x`; return
+`false` for all other `x`.
+
+```jldoctest
+julia> x = Nullable(1, false)
+Nullable{Int64}(1)
+
+julia> isnull(x)
+false
+
+julia> x = Nullable(1, true)
+Nullable{Int64}()
+
+julia> isnull(x)
+true
+
+julia> x = 1
+1
+
+julia> isnull(x)
+false
+```
+"""
+isnull(x::Nullable) = x.isnull
+isnull(x) = false
+
 isnull(x::Nullable) = !x.hasvalue
 
 ## Operators

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -161,13 +161,49 @@ for T in types
     @test get(x3, zero(T)) === one(T)
 end
 
-# isnull(x::Nullable)
 for T in types
+    # unsafe_get(x::Nullable)
+    x1 = Nullable{T}()
+    x2 = Nullable(zero(T))
+    x3 = Nullable(one(T))
+    a = rand(T)
+    x4 = Nullable(a)
+
+    @test isa(unsafe_get(x1), T)
+    @test unsafe_get(x2) === zero(T)
+    @test unsafe_get(x3) === one(T)
+    @test unsafe_get(x4) === a
+
+    # unsafe_get(x)
+    x2 = zero(T)
+    x3 = one(T)
+    x4 = rand(T)
+
+    @test unsafe_get(x2) === zero(T)
+    @test unsafe_get(x3) === one(T)
+    @test unsafe_get(x4) === x4
+end
+
+@test_throws UndefRefError unsafe_get(Nullable())
+@test_throws UndefRefError unsafe_get(Nullable{String}())
+@test_throws UndefRefError unsafe_get(Nullable{Array}())
+
+for T in types
+    # isnull(x::Nullable)
     x1 = Nullable{T}()
     x2 = Nullable(zero(T))
     x3 = Nullable(one(T))
 
     @test isnull(x1) === true
+    @test isnull(x2) === false
+    @test isnull(x3) === false
+
+    # isnull(x)
+    x1 = zero(T)
+    x2 = one(T)
+    x3 = rand(T)
+
+    @test isnull(x1) === false
     @test isnull(x2) === false
     @test isnull(x3) === false
 end


### PR DESCRIPTION
It would be useful to have a generic fallback for `isnull` when operating on iterators (usually tuples) of both `Nullable` and non-`Nullable` objects. Is there anything else we need to do here to make sure this is optimized away in the case of non-`Nullable` arguments? What should tests look like?

cc: @johnmyleswhite @nalimilan @quinnj 
