### PR TITLE
Attach eval docstring in the appropriate module

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -70,7 +70,7 @@ Evaluate an expression in the given module and return the result. Every `Module`
 those defined with `baremodule`) has its own 1-argument definition of `eval`, which
 evaluates expressions in that module.
 """
-eval
+Core.eval
 
 """
     @eval


### PR DESCRIPTION
The issue, on master:

``` julia
help?> eval
search: eval evalfile @eval @evalpoly eigvals eigvals! readavailable TypeVar NewvarNode

  No documentation found.

  Core.eval is a Function.

  #2 methods for generic function "eval":
  eval(m::Module, e::ANY<:Any) at boot.jl:234
  eval(e::ANY<:Any) at boot.jl:233

help?> Core.eval
  No documentation found.

  Core.eval is a Function.

  #2 methods for generic function "eval":
  eval(m::Module, e::ANY<:Any) at boot.jl:234
  eval(e::ANY<:Any) at boot.jl:233

help?> Base.eval
  eval([m::Module], expr::Expr)

  Evaluate an expression in the given module and return the result. Every Module (except
  those defined with baremodule) has its own 1-argument definition of eval, which evaluates
  expressions in that module.
```

With this PR:

``` julia
help?> eval
search: eval evalfile @eval @evalpoly eigvals eigvals! readavailable TypeVar NewvarNode

  eval([m::Module], expr::Expr)

  Evaluate an expression in the given module and return the result. Every Module (except
  those defined with baremodule) has its own 1-argument definition of eval, which evaluates
  expressions in that module.
```

Best!
