### PR TITLE
Add support for views with arrays of CartesianIndex

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -346,6 +346,7 @@ function checkbounds_indices(::Type{Bool}, IA::Tuple, I::Tuple{Any})
     @_inline_meta
     checkindex(Bool, OneTo(trailingsize(IA)), I[1])  # linear indexing
 end
+checkbounds_indices(::Type{Bool}, ::Tuple, ::Tuple{}) = true
 
 throw_boundserror(A, I) = (@_noinline_meta; throw(BoundsError(A, I)))
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -3,7 +3,10 @@
 ### Multidimensional iterators
 module IteratorsMD
 
-import Base: eltype, length, size, start, done, next, last, in, getindex, setindex!, linearindexing, min, max, zero, one, isless, eachindex, ndims, iteratorsize, to_index
+import Base: eltype, length, size, start, done, next, last, in, getindex,
+             setindex!, linearindexing, min, max, zero, one, isless, eachindex,
+             ndims, iteratorsize, to_index
+
 importall ..Base.Operators
 import Base: simd_outer_range, simd_inner_length, simd_index
 using Base: LinearFast, LinearSlow, AbstractCartesianIndex, fill_to_length, tail

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -88,6 +88,9 @@ unsafe_view(V::SubArray, I::Union{Real, NonSliceIndex}...) = (@_inline_meta; _ma
 _maybe_reindex(V, I) = (@_inline_meta; _maybe_reindex(V, I, I))
 _maybe_reindex{C<:AbstractCartesianIndex}(V, I, ::Tuple{AbstractArray{C}, Vararg{Any}}) =
     (@_inline_meta; SubArray(V, I, map(unsafe_length, index_shape(V, I...))))
+# But allow arrays of CartesianIndex{1}; they behave just like arrays of Ints
+_maybe_reindex{C<:AbstractCartesianIndex{1}}(V, I, A::Tuple{AbstractArray{C}, Vararg{Any}}) =
+    (@_inline_meta; _maybe_reindex(V, I, tail(A)))
 _maybe_reindex(V, I, A::Tuple{Any, Vararg{Any}}) = (@_inline_meta; _maybe_reindex(V, I, tail(A)))
 function _maybe_reindex(V, I, ::Tuple{})
     @_inline_meta

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -31,7 +31,8 @@ end
 
 check_parent_index_match(parent, indexes) = check_parent_index_match(parent, index_ndims(indexes...))
 check_parent_index_match{T,N}(parent::AbstractArray{T,N}, ::NTuple{N, Bool}) = nothing
-check_parent_index_match{N}(parent, ::NTuple{N, Bool}) = throw(ArgumentError("number of indices ($N) must match the parent dimensionality ($(ndims(parent)))"))
+check_parent_index_match{N}(parent, ::NTuple{N, Bool}) =
+    throw(ArgumentError("number of indices ($N) must match the parent dimensionality ($(ndims(parent)))"))
 
 # This computes the linear indexing compatability for a given tuple of indices
 viewindexing() = LinearFast()

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1257,7 +1257,9 @@ b = view(a, :, :)
 @test mdsum(b) == 0
 
 for a in (copy(reshape(1:60, 3, 4, 5)),
-          view(copy(reshape(1:60, 3, 4, 5)), 1:3, :, :))
+          view(copy(reshape(1:60, 3, 4, 5)), 1:3, :, :),
+          view(copy(reshape(1:60, 3, 4, 5)), CartesianIndex.(1:3, (1:4)'), :),
+          view(copy(reshape(1:60, 3, 4, 5)), :, CartesianIndex.(1:4, (1:5)')))
     @test a[CartesianIndex{3}(2,3,4)] == 44
     a[CartesianIndex{3}(2,3,3)] = -1
     @test a[CartesianIndex{3}(2,3,3)] == -1
@@ -1267,12 +1269,26 @@ for a in (copy(reshape(1:60, 3, 4, 5)),
     @test a[CartesianIndex{1}(2),3,CartesianIndex{1}(4)] == 44
     a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] = -3
     @test a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] == -3
-    @test a[:, :, CartesianIndex((1,))] == a[:,:,1]
-    @test a[CartesianIndex((1,)), [1,2], :] == a[1,[1,2],:]
-    @test a[CartesianIndex((2,)), 3:4, :] == a[2,3:4,:]
-    @test a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3] == reshape([a[1,3,3]; a[2,4,3]], 2, 1)
+
+    @test a[:, :, CartesianIndex((1,))] == (@view a[:, :, CartesianIndex((1,))]) == a[:,:,1]
+    @test a[CartesianIndex((1,)), [1,2], :] == (@view a[CartesianIndex((1,)), [1,2], :]) == a[1,[1,2],:]
+    @test a[CartesianIndex((2,)), 3:4, :] == (@view a[CartesianIndex((2,)), 3:4, :]) == a[2,3:4,:]
+    @test a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3] == (@view a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3]) == reshape([a[1,3,3]; a[2,4,3]], 2, 1)
+
+    @test a[[CartesianIndex()], :, :, :] == (@view a[[CartesianIndex()], :, :, :]) == reshape(a, 1, 3, 4, 5)
+    @test a[:, [CartesianIndex()], :, :] == (@view a[:, [CartesianIndex()], :, :]) == reshape(a, 3, 1, 4, 5)
+    @test a[:, :, [CartesianIndex()], :] == (@view a[:, :, [CartesianIndex()], :]) == reshape(a, 3, 4, 1, 5)
+    @test a[:, :, :, [CartesianIndex()]] == (@view a[:, :, :, [CartesianIndex()]]) == reshape(a, 3, 4, 5, 1)
+    @test a[[CartesianIndex()], :, :]    == (@view a[[CartesianIndex()], :, :])    == reshape(a, 1, 3, 20)
+    @test a[:, [CartesianIndex()], :]    == (@view a[:, [CartesianIndex()], :])    == reshape(a, 3, 1, 20)
+    @test a[:, :, [CartesianIndex()]]    == (@view a[:, :, [CartesianIndex()]])    == reshape(a, 3, 20, 1)
+    @test a[[CartesianIndex()], :]       == (@view a[[CartesianIndex()], :])       == reshape(a, 1, 60)
+    @test a[:, [CartesianIndex()]]       == (@view a[:, [CartesianIndex()]])       == reshape(a, 60, 1)
+
     @test_throws BoundsError a[[CartesianIndex(1,5),CartesianIndex(2,4)],3:3]
     @test_throws BoundsError a[1:4, [CartesianIndex(1,3),CartesianIndex(2,4)]]
+    @test_throws BoundsError @view a[[CartesianIndex(1,5),CartesianIndex(2,4)],3:3]
+    @test_throws BoundsError @view a[1:4, [CartesianIndex(1,3),CartesianIndex(2,4)]]
 end
 
 for a in (view(zeros(3, 4, 5), :, :, :),

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1273,7 +1273,8 @@ for a in (copy(reshape(1:60, 3, 4, 5)),
     @test a[:, :, CartesianIndex((1,))] == (@view a[:, :, CartesianIndex((1,))]) == a[:,:,1]
     @test a[CartesianIndex((1,)), [1,2], :] == (@view a[CartesianIndex((1,)), [1,2], :]) == a[1,[1,2],:]
     @test a[CartesianIndex((2,)), 3:4, :] == (@view a[CartesianIndex((2,)), 3:4, :]) == a[2,3:4,:]
-    @test a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3] == (@view a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3]) == reshape([a[1,3,3]; a[2,4,3]], 2, 1)
+    @test a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3] ==
+          (@view a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3]) == reshape([a[1,3,3]; a[2,4,3]], 2, 1)
 
     @test a[[CartesianIndex()], :, :, :] == (@view a[[CartesianIndex()], :, :, :]) == reshape(a, 1, 3, 4, 5)
     @test a[:, [CartesianIndex()], :, :] == (@view a[:, [CartesianIndex()], :, :]) == reshape(a, 3, 1, 4, 5)


### PR DESCRIPTION
The first commit here simply allows using arrays of `CartesianIndex{0}` as trailing indices.  Whereas they previously would throw an error during bounds checking, this commit enables their use.

Allowing arrays of CartesianIndex for SubArray, however, is more challenging.  Enabling the creation of views with an index of type `AbstractArray{CartesianIndex{N}}` is relatively simple. The disastrously difficult part, however, is reindexing a view with arrays of CartesianIndex.  Here's a good example of why that's hard:

``` jl
julia> A = copy(reshape(1:16, 4, 4))
       V = view(A, [1 2; 3 4], [4 2; 3 1])
       view(V, :, map(CartesianIndex, [(1,1), (2, 2)]), [CartesianIndex()], :)
2×2×1×2 SubArray{Int64,4,SubArray{Int64,4,Array{Int64,2},Tuple{Array{Int64,2},Array{Int64,2}},false},Tuple{Colon,Array{CartesianIndex{2},1},Array{CartesianIndex{0},1},Colon},false}:
[:, :, 1, 1] =
 13  10
 15  12

[:, :, 1, 2] =
 5  2
 7  4
```

The ~~2-dimensional array~~ vector of CartesianIndex{2} spans the two parent indices, and the second parent index gets further split up by the addition of a dimension right in the middle.  I believe the only index type this could possibly be recomputed to is a `Array{CartesianIndex{2}, 4}`.  Doing that sort of indexing arithmetic is crazy-making, and it's likely to allocate large arrays.  So I punt and simply rely on a second level of indirection, just like subarrays of reshaped arrays do.

The fun part that led to this rabbit hole is that we now have a completely first-class equivalent to [`np.newaxis`](http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#numpy.newaxis):

``` jl
julia> const newaxis = [CartesianIndex()];

julia> A = 1:3
       A[:, newaxis] * A[newaxis, :]
3×3 Array{Int64,2}:
 1  2  3
 2  4  6
 3  6  9

julia> A = copy(reshape(1:6, 3, 2))
       A[:, newaxis, :]
3×1×2 Array{Int64,3}:
[:, :, 1] =
 1
 2
 3

[:, :, 2] =
 4
 5
 6
```
