### PR TITLE
Deprecate vectorized float methods in favor of compact broadcast syntax

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,8 @@ module Broadcast
 using Base.Cartesian
 using Base: promote_eltype_op, @get!, _msk_end, unsafe_bitgetindex, linearindices, tail, OneTo, to_shape
 import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^
-export broadcast, broadcast!, bitbroadcast, dotview
+import Base: broadcast
+export broadcast!, bitbroadcast, dotview
 export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -813,6 +813,7 @@ end
 
 float{T<:AbstractFloat}(z::Complex{T}) = z
 float(z::Complex) = Complex(float(real(z)), float(imag(z)))
+broadcast{T<:AbstractFloat}(::typeof(float), A::AbstractArray{Complex{T}}) = A
 
 big{T<:AbstractFloat}(z::Complex{T}) = Complex{BigFloat}(z)
 big{T<:Integer}(z::Complex{T}) = Complex{BigInt}(z)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -995,4 +995,16 @@ macro vectorize_2arg(S,f)
 end
 export @vectorize_1arg, @vectorize_2arg
 
+# Deprecate manually-vectorized float methods in favor of compact broadcast syntax
+@deprecate float(r::UnitRange) float.(r)
+@deprecate float(r::StepRange) float.(r)
+@deprecate float(r::FloatRange) float.(r)
+@deprecate float(r::LinSpace) float.(r)
+@deprecate float{T}(A::AbstractArray{T}) float.(A)
+@deprecate float{T<:AbstractFloat}(A::AbstractArray{T}) float.(A)
+@deprecate float{S<:AbstractString}(a::AbstractArray{S}) float.(a)
+@deprecate float(S::SparseMatrixCSC) float.(S)
+@deprecate float(x::AbstractSparseVector) float.(x)
+@deprecate float{Tv<:AbstractFloat}(x::AbstractSparseVector{Tv}) float.(x)
+
 # End deprecations scheduled for 0.6

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3113,14 +3113,6 @@ Unicode string.)
 reverseind
 
 """
-    float(x)
-
-Convert a number, array, or string to a `AbstractFloat` data type. For numeric data, the
-smallest suitable `AbstractFloat` type is used. Converts strings to `Float64`.
-"""
-float
-
-"""
     signbit(x)
 
 Returns `true` if the value of the sign of `x` is negative, otherwise `false`.

--- a/base/dsp.jl
+++ b/base/dsp.jl
@@ -141,9 +141,9 @@ function conv{T<:Base.LinAlg.BlasFloat}(u::StridedVector{T}, v::StridedVector{T}
     end
     return y[1:n]
 end
-conv{T<:Integer}(u::StridedVector{T}, v::StridedVector{T}) = round(Int,conv(float(u), float(v)))
-conv{T<:Integer, S<:Base.LinAlg.BlasFloat}(u::StridedVector{T}, v::StridedVector{S}) = conv(float(u), v)
-conv{T<:Integer, S<:Base.LinAlg.BlasFloat}(u::StridedVector{S}, v::StridedVector{T}) = conv(u, float(v))
+conv{T<:Integer}(u::StridedVector{T}, v::StridedVector{T}) = round(Int,conv(float.(u), float.(v)))
+conv{T<:Integer, S<:Base.LinAlg.BlasFloat}(u::StridedVector{T}, v::StridedVector{S}) = conv(float.(u), v)
+conv{T<:Integer, S<:Base.LinAlg.BlasFloat}(u::StridedVector{S}, v::StridedVector{T}) = conv(u, float.(v))
 
 """
     conv2(u,v,A)
@@ -184,8 +184,8 @@ function conv2{T}(A::StridedMatrix{T}, B::StridedMatrix{T})
     end
     return C
 end
-conv2{T<:Integer}(A::StridedMatrix{T}, B::StridedMatrix{T}) = round(Int,conv2(float(A), float(B)))
-conv2{T<:Integer}(u::StridedVector{T}, v::StridedVector{T}, A::StridedMatrix{T}) = round(Int,conv2(float(u), float(v), float(A)))
+conv2{T<:Integer}(A::StridedMatrix{T}, B::StridedMatrix{T}) = round(Int,conv2(float.(A), float.(B)))
+conv2{T<:Integer}(u::StridedVector{T}, v::StridedVector{T}, A::StridedMatrix{T}) = round(Int,conv2(float.(u), float.(v), float.(A)))
 
 """
     xcorr(u,v)

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -98,8 +98,8 @@ end
 
 ## norm and rank
 
-svd(A::BitMatrix) = svd(float(A))
-qr(A::BitMatrix) = qr(float(A))
+svd(A::BitMatrix) = svd(float.(A))
+qr(A::BitMatrix) = qr(float.(A))
 
 ## kron
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -262,7 +262,7 @@ used, otherwise the scaling and squaring algorithm (see [^H05]) is chosen.
 
 """
 expm{T<:BlasFloat}(A::StridedMatrix{T}) = expm!(copy(A))
-expm{T<:Integer}(A::StridedMatrix{T}) = expm!(float(A))
+expm{T<:Integer}(A::StridedMatrix{T}) = expm!(float.(A))
 expm(x::Number) = exp(x)
 
 ## Destructive matrix exponential using algorithm from Higham, 2008,
@@ -686,7 +686,7 @@ function sylvester{T<:BlasFloat}(A::StridedMatrix{T},B::StridedMatrix{T},C::Stri
     Y, scale = LAPACK.trsyl!('N','N', RA, RB, D)
     scale!(QA*A_mul_Bc(Y,QB), inv(scale))
 end
-sylvester{T<:Integer}(A::StridedMatrix{T},B::StridedMatrix{T},C::StridedMatrix{T}) = sylvester(float(A), float(B), float(C))
+sylvester{T<:Integer}(A::StridedMatrix{T},B::StridedMatrix{T},C::StridedMatrix{T}) = sylvester(float.(A), float.(B), float.(C))
 
 # AX + XA' + C = 0
 
@@ -704,5 +704,5 @@ function lyap{T<:BlasFloat}(A::StridedMatrix{T},C::StridedMatrix{T})
     Y, scale = LAPACK.trsyl!('N', T <: Complex ? 'C' : 'T', R, R, D)
     scale!(Q*A_mul_Bc(Y,Q), inv(scale))
 end
-lyap{T<:Integer}(A::StridedMatrix{T},C::StridedMatrix{T}) = lyap(float(A), float(C))
+lyap{T<:Integer}(A::StridedMatrix{T},C::StridedMatrix{T}) = lyap(float.(A), float.(C))
 lyap{T<:Number}(a::T, c::T) = -c/(2a)

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -168,8 +168,7 @@ function parse{T<:AbstractFloat}(::Type{T}, s::AbstractString)
 end
 
 float(x::AbstractString) = parse(Float64,x)
-
-float{S<:AbstractString}(a::AbstractArray{S}) = map!(float, similar(a,typeof(float(0))), a)
+broadcast{S<:AbstractString}(::typeof(float), a::AbstractArray{S}) = map!(float, similar(a,typeof(float(0))), a)
 
 ## interface to parser ##
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -348,7 +348,7 @@ julia> full(A)
 """
 full
 
-float(S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), float.(S.nzval))
+broadcast(::typeof(float), S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), float.(S.nzval))
 
 complex(S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), complex(copy(S.nzval)))
 

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -758,9 +758,9 @@ function reinterpret{T,Tv}(::Type{T}, x::AbstractSparseVector{Tv})
     SparseVector(length(x), copy(nonzeroinds(x)), reinterpret(T, nonzeros(x)))
 end
 
-float{Tv<:AbstractFloat}(x::AbstractSparseVector{Tv}) = x
-float(x::AbstractSparseVector) =
-    SparseVector(length(x), copy(nonzeroinds(x)), float(nonzeros(x)))
+broadcast{Tv<:AbstractFloat}(::typeof(float), x::AbstractSparseVector{Tv}) = x
+broadcast(::typeof(float), x::AbstractSparseVector) =
+    SparseVector(length(x), copy(nonzeroinds(x)), float.(nonzeros(x)))
 
 complex{Tv<:Complex}(x::AbstractSparseVector{Tv}) = x
 complex(x::AbstractSparseVector) =

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -156,7 +156,7 @@ lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}
     "Try lufact(convert(SparseMatrixCSC{Float64/Complex128,Int}, A)) for ",
     "sparse floating point LU using UMFPACK or lufact(full(A)) for generic ",
     "dense LU.")))
-lufact(A::SparseMatrixCSC) = lufact(float(A))
+lufact(A::SparseMatrixCSC) = lufact(float.(A))
 
 
 size(F::UmfpackLU) = (F.m, F.n)

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -118,7 +118,7 @@ Data Formats
 
    .. Docstring generated from Julia source
 
-   Convert a number, array, or string to a ``AbstractFloat`` data type. For numeric data, the smallest suitable ``AbstractFloat`` type is used. Converts strings to ``Float64``\ .
+   Convert a number or string to a ``AbstractFloat`` data type. For numeric data, the smallest suitable ``AbstractFloat`` type is used. Converts strings to ``Float64``\ .
 
 .. function:: significand(x)
 

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -58,11 +58,11 @@ if Base.fftw_vendor() != :mkl
         4.0  -2.071929829606556   4.0  -2.388955165168770; 12.  -0.765366864730179   4.0  -1.847759065022573 ]
 
     Xdct = dct(X)
-    Xdct! = float(X); dct!(Xdct!)
+    Xdct! = float.(X); dct!(Xdct!)
     Xdct_1 = dct(X,1)
-    Xdct!_1 = float(X); dct!(Xdct!_1,1)
+    Xdct!_1 = float.(X); dct!(Xdct!_1,1)
     Xdct_2 = dct(X,2)
-    Xdct!_2 = float(X); dct!(Xdct!_2,2)
+    Xdct!_2 = float.(X); dct!(Xdct!_2,2)
 
     Xidct = idct(true_Xdct)
     Xidct! = copy(true_Xdct); idct!(Xidct!)
@@ -72,11 +72,11 @@ if Base.fftw_vendor() != :mkl
     Xidct!_2 = copy(true_Xdct_2); idct!(Xidct!_2,2)
 
     pXdct = plan_dct(X)*(X)
-    pXdct! = float(X); plan_dct!(pXdct!)*(pXdct!)
+    pXdct! = float.(X); plan_dct!(pXdct!)*(pXdct!)
     pXdct_1 = plan_dct(X,1)*(X)
-    pXdct!_1 = float(X); plan_dct!(pXdct!_1,1)*(pXdct!_1)
+    pXdct!_1 = float.(X); plan_dct!(pXdct!_1,1)*(pXdct!_1)
     pXdct_2 = plan_dct(X,2)*(X)
-    pXdct!_2 = float(X); plan_dct!(pXdct!_2,2)*(pXdct!_2)
+    pXdct!_2 = float.(X); plan_dct!(pXdct!_2,2)*(pXdct!_2)
 
     pXidct = plan_idct(true_Xdct)*(true_Xdct)
     pXidct! = copy(true_Xdct); plan_idct!(pXidct!)*(pXidct!)

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -170,7 +170,7 @@ H = Rational{BigInt}[1//(i+j-1) for i = 1:nHilbert,j = 1:nHilbert]
 Hinv = Rational{BigInt}[(-1)^(i+j)*(i+j-1)*binomial(nHilbert+i-1,nHilbert-j)*binomial(nHilbert+j-1,nHilbert-i)*binomial(i+j-2,i-1)^2 for i = big(1):nHilbert,j=big(1):nHilbert]
 @test inv(H) == Hinv
 setprecision(2^10) do
-    @test norm(Array{Float64}(inv(float(H)) - float(Hinv))) < 1e-100
+    @test norm(Array{Float64}(inv(float.(H)) - float.(Hinv))) < 1e-100
 end
 
 # Test balancing in eigenvector calculations

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -658,7 +658,7 @@ test_linspace_identity(linspace(1f0, 1f0, 1), linspace(-1f0, -1f0, 1))
 # PR 12200 and related
 for _r in (1:2:100, 1:100, 1f0:2f0:100f0, 1.0:2.0:100.0,
            linspace(1, 100, 10), linspace(1f0, 100f0, 10))
-    float_r = float(_r)
+    float_r = float.(_r)
     big_r = big(_r)
     @test typeof(big_r).name === typeof(_r).name
     if eltype(_r) <: AbstractFloat

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -46,7 +46,7 @@
 @test sum([3.0]) === 3.0
 
 z = reshape(1:16, (2,2,2,2))
-fz = float(z)
+fz = float.(z)
 @test sum(z) === 136
 @test sum(fz) === 136.0
 
@@ -58,7 +58,7 @@ a = sum(sin, z)
 @test a ≈ sum(sin.(fz))
 
 z = [-4, -3, 2, 5]
-fz = float(z)
+fz = float.(z)
 a = randn(32) # need >16 elements to trigger BLAS code path
 b = complex(randn(32), randn(32))
 @test sumabs(Float64[]) === 0.0

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -230,7 +230,7 @@ for n in [0:10; 100; 101; 1000; 1001]
     for rev in [false,true]
         # insertion sort (stable) as reference
         pi = sortperm(v, alg=InsertionSort, rev=rev)
-        @test pi == sortperm(float(v), alg=InsertionSort, rev=rev)
+        @test pi == sortperm(float.(v), alg=InsertionSort, rev=rev)
         @test isperm(pi)
         si = v[pi]
         @test [sum(si .== x) for x in r] == h
@@ -245,7 +245,7 @@ for n in [0:10; 100; 101; 1000; 1001]
         # stable algorithms
         for alg in [MergeSort]
             p = sortperm(v, alg=alg, rev=rev)
-            @test p == sortperm(float(v), alg=alg, rev=rev)
+            @test p == sortperm(float.(v), alg=alg, rev=rev)
             @test p == pi
             s = copy(v)
             permute!(s, p)
@@ -257,7 +257,7 @@ for n in [0:10; 100; 101; 1000; 1001]
         # unstable algorithms
         for alg in [QuickSort, PartialQuickSort(n)]
             p = sortperm(v, alg=alg, rev=rev)
-            @test p == sortperm(float(v), alg=alg, rev=rev)
+            @test p == sortperm(float.(v), alg=alg, rev=rev)
             @test isperm(p)
             @test v[p] == si
             s = copy(v)

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -470,12 +470,12 @@ for elty in (Float64, Complex{Float64})
     @test CHOLMOD.Sparse(CHOLMOD.Dense(A1Sparse)) == A1Sparse
 end
 
-Af = float([4 12 -16; 12 37 -43; -16 -43 98])
+Af = float.([4 12 -16; 12 37 -43; -16 -43 98])
 As = sparse(Af)
-Lf = float([2 0 0; 6 1 0; -8 5 3])
-LDf = float([4 0 0; 3 1 0; -4 5 9])  # D is stored along the diagonal
-L_f = float([1 0 0; 3 1 0; -4 5 1])  # L by itself in LDLt of Af
-D_f = float([4 0 0; 0 1 0; 0 0 9])
+Lf = float.([2 0 0; 6 1 0; -8 5 3])
+LDf = float.([4 0 0; 3 1 0; -4 5 9])  # D is stored along the diagonal
+L_f = float.([1 0 0; 3 1 0; -4 5 1])  # L by itself in LDLt of Af
+D_f = float.([4 0 0; 0 1 0; 0 0 9])
 
 # cholfact, no permutation
 Fs = cholfact(As, perm=[1:3;])

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1189,9 +1189,9 @@ A = speye(5)
 
 # test float
 A = sprand(Bool, 5,5,0.0)
-@test eltype(float(A)) == Float64  # issue #11658
+@test eltype(float.(A)) == Float64  # issue #11658
 A = sprand(Bool, 5,5,0.2)
-@test float(A) == float(full(A))
+@test float.(A) == float.(full(A))
 
 # test sparsevec
 A = sparse(ones(5,5))

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -255,8 +255,8 @@ let a = SparseVector(8, [2, 5, 6], Int32[12, 35, 72])
     @test exact_equal(au, SparseVector(8, [2, 5, 6], UInt32[12, 35, 72]))
 
     # float
-    af = float(a)
-    @test float(af) == af
+    af = float.(a)
+    @test float.(af) == af
     @test isa(af, SparseVector{Float64,Int})
     @test exact_equal(af, SparseVector(8, [2, 5, 6], [12., 35., 72.]))
     @test sparsevec(transpose(transpose(af))) == af

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -27,12 +27,12 @@ for Tv in (Float64, Complex128)
 
         b = [8., 45., -3., 3., 19.]
         x = lua\b
-        @test x ≈ float([1:5;])
+        @test x ≈ float.([1:5;])
 
         @test norm(A*x-b,1) < eps(1e4)
         z = complex(b,zeros(b))
         x = Base.SparseArrays.A_ldiv_B!(lua, z)
-        @test x ≈ float([1:5;])
+        @test x ≈ float.([1:5;])
         @test z === x
         y = similar(z)
         A_ldiv_B!(y, lua, complex(b,zeros(b)))
@@ -42,12 +42,12 @@ for Tv in (Float64, Complex128)
 
         b = [8., 20., 13., 6., 17.]
         x = lua'\b
-        @test x ≈ float([1:5;])
+        @test x ≈ float.([1:5;])
 
         @test norm(A'*x-b,1) < eps(1e4)
         z = complex(b,zeros(b))
         x = Base.SparseArrays.Ac_ldiv_B!(lua, z)
-        @test x ≈ float([1:5;])
+        @test x ≈ float.([1:5;])
         @test x === z
         y = similar(x)
         Base.SparseArrays.Ac_ldiv_B!(y, lua, complex(b,zeros(b)))
@@ -55,11 +55,11 @@ for Tv in (Float64, Complex128)
 
         @test norm(A'*x-b,1) < eps(1e4)
         x = lua.'\b
-        @test x ≈ float([1:5;])
+        @test x ≈ float.([1:5;])
 
         @test norm(A.'*x-b,1) < eps(1e4)
         x = Base.SparseArrays.At_ldiv_B!(lua,complex(b,zeros(b)))
-        @test x ≈ float([1:5;])
+        @test x ≈ float.([1:5;])
         y = similar(x)
         Base.SparseArrays.At_ldiv_B!(y, lua,complex(b,zeros(b)))
         @test y ≈ x


### PR DESCRIPTION
This PR deprecates all (?) remaining vectorized `float` methods in favor of compact broadcast syntax. Ref. #16285 and #17302. Best!

To work around #18462, I made the `Broadcast` module `import` rather than `export` `broadcast`. I will correct this if / when a better solution for #18462 appears.
