### PR TITLE
Put inference parameters in a dedicated object

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -285,7 +285,8 @@ function get_type_call(expr::Expr)
     length(mt) == 1 || return (Any, false)
     m = first(mt)
     # Typeinference
-    return_type = Core.Inference.typeinf_type(m[3], m[1], m[2])
+    params = Core.Inference.InferenceParams()
+    return_type = Core.Inference.typeinf_type(m[3], m[1], m[2], true, params)
     return_type === nothing && return (Any, false)
     return (return_type, true)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -587,9 +587,10 @@ function code_typed(f::ANY, types::ANY=Tuple; optimize=true)
     end
     types = to_tuple_type(types)
     asts = []
+    params = Core.Inference.InferenceParams()
     for x in _methods(f, types, -1)
         meth = func_for_method_checked(x[3], types)
-        (code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, optimize)
+        (code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, optimize, params)
         code === nothing && error("inference not successful") # Inference disabled?
         push!(asts, uncompressed_ast(meth, code) => ty)
     end
@@ -603,9 +604,10 @@ function return_types(f::ANY, types::ANY=Tuple)
     end
     types = to_tuple_type(types)
     rt = []
+    params = Core.Inference.InferenceParams()
     for x in _methods(f, types, -1)
         meth = func_for_method_checked(x[3], types)
-        ty = Core.Inference.typeinf_type(meth, x[1], x[2])
+        ty = Core.Inference.typeinf_type(meth, x[1], x[2], true, params)
         ty === nothing && error("inference not successful") # Inference disabled?
         push!(rt, ty)
     end


### PR DESCRIPTION
Part of #18338, based on #18396 for now because it uses kwargs in inference.

Entry-point function parameters to type inference (`needtree`, `optimize`, `cached`) are now saved in the `InferenceState`, which makes them available in more places. However, using `cached` that way [breaks `abstract_call_gf_by_type`](https://github.com/JuliaLang/julia/blob/tb/inference_params/base/inference.jl#L923-L925). Any reason this should always be saving its results?

Performance difference in loading `base/inference.jl` seems undetectable. Suggestions for better testing of type inference performance?

cc @JeffBezanson @vtjnash
