### PR TITLE
Make include a function

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -519,15 +519,6 @@ evaluated by `julia -e <expr>`.
 """
 macro __DIR__() source_dir() end
 
-"""
-    include(path::AbstractString)
-
-Evaluate the contents of a source file in the current context. During including, a
-task-local include path is set to the directory containing the file. Nested calls to
-`include` will search relative to that path. All paths refer to files on node 1 when running
-in parallel, and files will be fetched from node 1. This function is typically used to load
-source interactively, or to combine files in packages that are broken into multiple source files.
-"""
 include_from_node1(path::AbstractString) = include_from_node1(String(path))
 function include_from_node1(_path::String)
     path, prev = _include_dependency(_path)
@@ -549,6 +540,24 @@ function include_from_node1(_path::String)
         else
             tls[:SOURCE_PATH] = prev
         end
+    end
+    result
+end
+
+"""
+    include(path::AbstractString...)
+
+Evaluate the contents of the input source file(s) in the current context. Returns the result
+of the last evaluated argument (of the last input file). During including, a
+task-local include path is set to the directory containing the file. Nested calls to
+`include` will search relative to that path. All paths refer to files on node 1 when running
+in parallel, and files will be fetched from node 1. This function is typically used to load
+source interactively, or to combine files in packages that are broken into multiple source files.
+"""
+function include(_path::AbstractString...)
+    local result
+    for path in _path
+        result = include(path)
     end
     result
 end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -144,11 +144,11 @@ Getting Around
 
    ``__precompile__()`` should *not* be used in a module unless all of its dependencies are also using ``__precompile__()``\ . Failure to do so can result in a runtime error when loading the module.
 
-.. function:: include(path::AbstractString)
+.. function:: include(path::AbstractString...)
 
    .. Docstring generated from Julia source
 
-   Evaluate the contents of a source file in the current context. During including, a task-local include path is set to the directory containing the file. Nested calls to ``include`` will search relative to that path. All paths refer to files on node 1 when running in parallel, and files will be fetched from node 1. This function is typically used to load source interactively, or to combine files in packages that are broken into multiple source files.
+   Evaluate the contents of the input source file(s) in the current context. Returns the result of the last evaluated argument (of the last input file). During including, a task-local include path is set to the directory containing the file. Nested calls to ``include`` will search relative to that path. All paths refer to files on node 1 when running in parallel, and files will be fetched from node 1. This function is typically used to load source interactively, or to combine files in packages that are broken into multiple source files.
 
 .. function:: include_string(code::AbstractString, filename::AbstractString="string")
 


### PR DESCRIPTION
This defines the `include` function. Currently `include` is just a variable pointing at different variants of `include` functions during the building process, and for end users points at [`include_from_node1`](https://github.com/JuliaLang/julia/blob/master/base/loading.jl#L531).

The motivation for this is to overload `include` to allow for several input files in the same call. And in the meantime it would also fix #9959

Currently this PR defines the `include` function at the top of `sysimg.jl` and overloads in in `loading.jl`. Ideally it would have been nice to define a multiple argument variant at the top of `sysimg.jl`, to allow for multiple inputs during building as well. (for instance [here](https://github.com/JuliaLang/julia/blob/master/base/pkg/pkg.jl#L33) it could be nice, instead of looping.) However, I couldn't manage to iterate through the input using only `Core` stuff. Is there a better way to solve this?

TLDR: Make include work with several input files

``` jl
include("file1.jl","file2.jl")
```
