### PR TITLE
Deprecate vectorized real methods in favor of compact broadcast syntax

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -85,7 +85,7 @@ squeeze(A::AbstractArray, dim::Integer) = squeeze(A, (Int(dim),))
 conj{T<:Real}(x::AbstractArray{T}) = x
 conj!{T<:Real}(x::AbstractArray{T}) = x
 
-real{T<:Real}(x::AbstractArray{T}) = x
+broadcast{T<:Real}(::typeof(real), x::AbstractArray{T}) = x
 imag{T<:Real}(x::AbstractArray{T}) = zero(x)
 
 +{T<:Number}(x::AbstractArray{T}) = x

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -30,7 +30,6 @@ end
 
 (-)(A::AbstractArray{Bool}) = reshape([ -A[i] for i in eachindex(A) ], size(A))
 
-real(A::AbstractArray) = reshape([ real(x) for x in A ], size(A))
 imag(A::AbstractArray) = reshape([ imag(x) for x in A ], size(A))
 
 function !(A::AbstractArray{Bool})

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,8 @@ module Broadcast
 using Base.Cartesian
 using Base: promote_eltype_op, @get!, _msk_end, unsafe_bitgetindex, linearindices, tail, OneTo, to_shape
 import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^
-export broadcast, broadcast!, bitbroadcast, dotview
+import Base: broadcast
+export broadcast!, bitbroadcast, dotview
 export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1000,4 +1000,7 @@ macro vectorize_2arg(S,f)
 end
 export @vectorize_1arg, @vectorize_2arg
 
+# Deprecate manually vectorized real methods in favor of compact broadcast syntax
+@deprecate real(A::AbstractArray) real.(A)
+
 # End deprecations scheduled for 0.6

--- a/base/dsp.jl
+++ b/base/dsp.jl
@@ -161,7 +161,7 @@ function conv2{T}(u::StridedVector{T}, v::StridedVector{T}, A::StridedMatrix{T})
     v = fft([v;zeros(T,n-length(v))])
     C = ifft(fft(B) .* (u * v.'))
     if T <: Real
-        return real(C)
+        return real.(C)
     end
     return C
 end
@@ -180,7 +180,7 @@ function conv2{T}(A::StridedMatrix{T}, B::StridedMatrix{T})
     p = plan_fft(At)
     C = ifft((p*At).*(p*Bt))
     if T <: Real
-        return real(C)
+        return real.(C)
     end
     return C
 end

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -120,7 +120,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
     elseif which == "LR" || which == "LA" || which == "BE"
         dmap = real
     elseif which == "SR" || which == "SA"
-        dmap = x->-real(x)
+        dmap = x->-real.(x)
     elseif which == "LI"
         dmap = imag
     elseif which == "SI"

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -189,7 +189,8 @@ function size(M::Bidiagonal, d::Integer)
 end
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag, :abs)
+broadcast(::typeof(real), M::Bidiagonal) = Bidiagonal(real.(M.dv), real.(M.ev), M.isupper)
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :imag, :abs)
     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.isupper)
 end
 for func in (:round, :trunc, :floor, :ceil)

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -406,7 +406,7 @@ function logm(A::StridedMatrix)
     end
 
     if isreal(A) && ~np_real_eigs
-        return real(retmat)
+        return real.(retmat)
     else
         return retmat
     end

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -71,14 +71,14 @@ end
 parent(D::Diagonal) = D.diag
 
 ishermitian{T<:Real}(D::Diagonal{T}) = true
-ishermitian(D::Diagonal) = all(D.diag .== real(D.diag))
+ishermitian(D::Diagonal) = all(D.diag .== real.(D.diag))
 issymmetric(D::Diagonal) = true
 isposdef(D::Diagonal) = all(D.diag .> 0)
 
 factorize(D::Diagonal) = D
 
 abs(D::Diagonal) = Diagonal(abs(D.diag))
-real(D::Diagonal) = Diagonal(real(D.diag))
+broadcast(::typeof(real), D::Diagonal) = Diagonal(real.(D.diag))
 imag(D::Diagonal) = Diagonal(imag(D.diag))
 
 istriu(D::Diagonal) = true

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -12,7 +12,7 @@ SVD{T,Tr}(U::AbstractArray{T}, S::Vector{Tr}, Vt::AbstractArray{T}) = SVD{T,Tr,t
 function svdfact!{T<:BlasFloat}(A::StridedMatrix{T}; thin::Bool=true)
     m,n = size(A)
     if m == 0 || n == 0
-        u,s,vt = (eye(T, m, thin ? n : m), real(zeros(T,0)), eye(T,n,n))
+        u,s,vt = (eye(T, m, thin ? n : m), real.(zeros(T,0)), eye(T,n,n)) # shuold real.(zeros(T,0)) be zeros(real(T),0)?
     else
         u,s,vt = LAPACK.gesdd!(thin ? 'S' : 'A', A)
     end

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -250,7 +250,7 @@ function expm{T}(A::Hermitian{T})
     F = eigfact(A)
     retmat = (F.vectors * Diagonal(exp.(F.values))) * F.vectors'
     if T <: Real
-        return real(Hermitian(retmat))
+        return real.(Hermitian(retmat))
     else
         for i = 1:n
             retmat[i,i] = real(retmat[i,i])

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -34,8 +34,8 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
 
         big(A::$t) = $t(big(A.data))
 
-        real{T<:Real}(A::$t{T}) = A
-        real{T<:Complex}(A::$t{T}) = (B = real(A.data); $t(B))
+        broadcast{T<:Real}(::typeof(real), A::$t{T}) = A
+        broadcast{T<:Complex}(::typeof(real), A::$t{T}) = $t(real.(A.data))
         broadcast(::typeof(abs), A::$t) = $t(abs.(A.data))
     end
 end

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -71,7 +71,8 @@ end
 similar{T}(S::SymTridiagonal, ::Type{T}) = SymTridiagonal{T}(similar(S.dv, T), similar(S.ev, T))
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real, :imag)
+broadcast(::typeof(real), M::SymTridiagonal) = SymTridiagonal(real.(M.dv), real.(M.ev))
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :imag)
     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
 end
 for func in (:round, :trunc, :floor, :ceil)
@@ -388,7 +389,8 @@ end
 copy!(dest::Tridiagonal, src::Tridiagonal) = Tridiagonal(copy!(dest.dl, src.dl), copy!(dest.d, src.d), copy!(dest.du, src.du), copy!(dest.du2, src.du2))
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real, :imag)
+broadcast(::typeof(real), M::Tridiagonal) = Tridiagonal(real.(M.dl), real.(M.d), real.(M.du), real.(M.du2))
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :imag)
     @eval function ($func)(M::Tridiagonal)
         Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du), ($func)(M.du2))
     end

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1485,7 +1485,7 @@ end
 Ac_ldiv_B(L::FactorComponent, B) = ctranspose(L)\B
 
 (\){T<:VTypes}(L::Factor{T}, B::Dense{T}) = solve(CHOLMOD_A, L, B)
-(\)(L::Factor{Float64}, B::VecOrMat{Complex{Float64}}) = complex(L\real(B), L\imag(B))
+(\)(L::Factor{Float64}, B::VecOrMat{Complex{Float64}}) = complex(L\real.(B), L\imag(B))
 # First explicit TypeVars are necessary to avoid ambiguity errors with definition in
 # linalg/factorizations.jl
 (\){T<:VTypes}(L::Factor{T}, b::StridedVector) = Vector(L\convert(Dense{T}, b))

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -213,7 +213,7 @@ for itype in UmfpackIndexTypes
             @isok ccall(($sym_c, :libumfpack), $itype,
                         ($itype, $itype, Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Float64}, Ptr{Void},
                          Ptr{Float64}, Ptr{Float64}),
-                        U.m, U.n, U.colptr, U.rowval, real(U.nzval), imag(U.nzval), tmp,
+                        U.m, U.n, U.colptr, U.rowval, real.(U.nzval), imag(U.nzval), tmp,
                         umf_ctrl, umf_info)
             U.symbolic = tmp[1]
             return U
@@ -240,7 +240,7 @@ for itype in UmfpackIndexTypes
             status = ccall(($num_c, :libumfpack), $itype,
                            (Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Float64}, Ptr{Void}, Ptr{Void},
                             Ptr{Float64}, Ptr{Float64}),
-                           U.colptr, U.rowval, real(U.nzval), imag(U.nzval), U.symbolic, tmp,
+                           U.colptr, U.rowval, real.(U.nzval), imag(U.nzval), U.symbolic, tmp,
                            umf_ctrl, umf_info)
             if status != UMFPACK_WARNING_singular_matrix
                 umferror(status)
@@ -395,7 +395,7 @@ for (f!, umfpack) in ((:A_ldiv_B!, :UMFPACK_A),
             # TODO: Optionally let user allocate these and pass in somehow
             r = similar(b, Float64)
             i = similar(b, Float64)
-            solve!(r, lu, convert(Vector{Float64}, real(b)), $umfpack)
+            solve!(r, lu, convert(Vector{Float64}, real.(b)), $umfpack)
             solve!(i, lu, convert(Vector{Float64}, imag(b)), $umfpack)
             # We have checked size in solve!
             @inbounds for k in eachindex(x)

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -106,7 +106,7 @@ for elty in [Float32, Float64, Complex64, Complex128]
             @test BLAS.asum(b) ≈ sum(abs.(b))
             @test BLAS.iamax(b) ≈ indmax(abs.(b))
         else
-            @test BLAS.asum(b) ≈ sum(abs.(real(b))) + sum(abs.(imag(b)))
+            @test BLAS.asum(b) ≈ sum(abs.(real.(b))) + sum(abs.(imag(b)))
             @test BLAS.iamax(b) == indmax(map(x -> abs(real(x)) + abs(imag(x)), b))
         end
 
@@ -214,7 +214,7 @@ for elty in [Float32, Float64, Complex64, Complex128]
             fST[2,:] = ST.dv
             @test BLAS.sbmv('U',1,fST,x) ≈ ST*x
         else
-            dv = real(rand(elty,n))
+            dv = real.(rand(elty,n))
             ev = rand(elty,n-1)
             bH = zeros(elty,2,n)
             bH[1,2:n] = ev

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -134,7 +134,7 @@ let
     v=reshape(v,(50,50)) # reshape to matrix
     v/=trace(v) # factor out arbitrary phase
     @test isapprox(vecnorm(imag(v)),0.) # it should be real
-    v=real(v)
+    v=real.(v)
     # @test isapprox(vecnorm(v-v')/2,0.) # it should be Hermitian
     # Since this fails sometimes (numerical precision error),this test is commented out
     v=(v+v')/2

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -66,7 +66,7 @@ for relty in (Int, Float32, Float64, BigFloat), elty in (relty, Complex{relty})
         @test Bidiagonal(full(T), isupper) == T
         @test big(T) == T
         @test full(abs.(T)) == abs.(diagm(dv)) + abs.(diagm(ev, isupper?1:-1))
-        @test full(real(T)) == real(diagm(dv)) + real(diagm(ev, isupper?1:-1))
+        @test full(real.(T)) == real.(diagm(dv)) + real.(diagm(ev, isupper?1:-1))
         @test full(imag(T)) == imag(diagm(dv)) + imag(diagm(ev, isupper?1:-1))
         z = zeros(elty, n)
 

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -114,7 +114,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         @test_throws Base.LinAlg.RankDeficientException Base.LinAlg.chkfullrank(cz)
         cpapd = cholfact(apd, :U, Val{true})
         @test rank(cpapd) == n
-        @test all(diff(diag(real(cpapd.factors))).<=0.) # diagonal should be non-increasing
+        @test all(diff(diag(real.(cpapd.factors))).<=0.) # diagonal should be non-increasing
         if isreal(apd)
             @test apd*inv(cpapd) ≈ eye(n)
         end

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -27,7 +27,7 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
     @test typeof(convert(Diagonal{Complex64},D)) == Diagonal{Complex64}
     @test typeof(convert(AbstractMatrix{Complex64},D))   == Diagonal{Complex64}
 
-    @test full(real(D)) == real(DM)
+    @test full(real.(D)) == real.(DM)
     @test full(abs.(D)) == abs.(DM)
     @test full(imag(D)) == imag(DM)
 

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -414,7 +414,7 @@ end
 
 #ptsv
 for elty in (Float32, Float64, Complex64, Complex128)
-    dv = real(ones(elty,10))
+    dv = real.(ones(elty,10))
     ev = zeros(elty,9)
     A = SymTridiagonal(dv,ev)
     if elty <: Complex
@@ -429,7 +429,7 @@ end
 
 #pttrf and pttrs
 for elty in (Float32, Float64, Complex64, Complex128)
-    dv = real(ones(elty,10))
+    dv = real.(ones(elty,10))
     ev = zeros(elty,9)
     A = SymTridiagonal(dv,ev)
     if elty <: Complex
@@ -453,7 +453,7 @@ end
 #posv and some errors for friends
 for elty in (Float32, Float64, Complex64, Complex128)
     A = 0.01*rand(elty,10,10)
-    A += real(diagm(10*real(rand(elty,10))))
+    A += real.(diagm(10*real.(rand(elty,10))))
     if elty <: Complex
         A = A + A'
     else

--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -35,7 +35,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
         d,v = eig(a)
         f   = schurfact(a)
         @test f[:vectors]*f[:Schur]*f[:vectors]' ≈ a
-        @test sort(real(f[:values])) ≈ sort(real(d))
+        @test sort(real.(f[:values])) ≈ sort(real.(d))
         @test sort(imag(f[:values])) ≈ sort(imag(d))
         @test istriu(f[:Schur]) || eltype(a)<:Real
         @test full(f) ≈ a

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -48,7 +48,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
         if eltya <: BlasFloat
             svdz = svdfact!(ones(eltya,0,0))
             @test svdz[:U] ≈ eye(eltya,0,0)
-            @test svdz[:S] ≈ real(zeros(eltya,0))
+            @test svdz[:S] ≈ real.(zeros(eltya,0))
             @test svdz[:Vt] ≈ eye(eltya,0,0)
         end
 

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -142,7 +142,7 @@ for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloa
         @test diag(A1) == diag(full(A1))
 
         # real
-        @test full(real(A1)) == real(full(A1))
+        @test full(real.(A1)) == real.(full(A1))
         @test full(imag(A1)) == imag(full(A1))
         @test full(abs.(A1)) == abs.(full(A1))
 
@@ -302,7 +302,7 @@ for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloa
         end
 
         for eltyB in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat})
-            B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
+            B = convert(Matrix{eltyB}, elty1 <: Complex ? real.(A1)*ones(n, n) : A1*ones(n, n))
 
             debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
 
@@ -402,7 +402,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         debug && println("\ntype of A: ", eltya, " type of b: ", eltyb, "\n")
 
         debug && println("Solve upper triangular system")
-        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real.(t) : t # Here the triangular matrix can't be too badly conditioned
         b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
         x = full(Atri) \ b
 
@@ -430,7 +430,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         end
 
         debug && println("Solve lower triangular system")
-        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real.(t) : t # Here the triangular matrix can't be too badly conditioned
         b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
         x = full(Atri)\b
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -50,10 +50,10 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     @test ctranspose(T) == Tridiagonal(conj(du), conj(d), conj(dl))
 
     @test abs.(T) == Tridiagonal(abs.(dl),abs.(d),abs.(du))
-    @test real(T) == Tridiagonal(real(dl),real(d),real(du))
+    @test real.(T) == Tridiagonal(real.(dl),real.(d),real.(du))
     @test imag(T) == Tridiagonal(imag(dl),imag(d),imag(du))
     @test abs.(Ts) == SymTridiagonal(abs.(d),abs.(dl))
-    @test real(Ts) == SymTridiagonal(real(d),real(dl))
+    @test real.(Ts) == SymTridiagonal(real.(d),real.(dl))
     @test imag(Ts) == SymTridiagonal(imag(d),imag(dl))
 
     # test interconversion of Tridiagonal and SymTridiagonal


### PR DESCRIPTION
This PR deprecates all (?) remaining vectorized `real` methods (excepting those for `SparseVector`s, separate PR) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, and #18512. Best!

As with earlier PRs in this series, to work around #18462 I made the `Broadcast` module `import` rather than `export` `broadcast`. Will correct this if / when a better solution for #18462 appears.
