### PR TITLE
RFC: Make `take` and `drop` for `String` return `SubString`

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -348,6 +348,20 @@ length(t::Take) = _min_length(t.xs, 1:t.n, iteratorsize(t.xs), HasLength())
 
 start(it::Take) = (it.n, start(it.xs))
 
+"""
+    take(s::String, n)
+
+Return a `SubString` with at most `n` of the first `Char`s contained in `s`.
+"""
+function take(s::String, n::Int)
+    i = 1
+    while n > 1 && i < endof(s.data)
+        n -= 1
+        i = nextind(s, i)
+    end
+    SubString(s, 1, i)
+end
+
 function next(it::Take, state)
     n, xs_state = state
     v, xs_state = next(it.xs, xs_state)

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -348,21 +348,6 @@ length(t::Take) = _min_length(t.xs, 1:t.n, iteratorsize(t.xs), HasLength())
 
 start(it::Take) = (it.n, start(it.xs))
 
-"""
-    take(s::String, n)
-
-Return a `SubString` with at most `n` of the first characters of `s`.  A
-character is defined as a Unicode scalar value.
-"""
-function take(s::String, n::Int)
-    i = 1
-    while n > 1 && i < endof(s.data)
-        n -= 1
-        i = nextind(s, i)
-    end
-    SubString(s, 1, i)
-end
-
 function next(it::Take, state)
     n, xs_state = state
     v, xs_state = next(it.xs, xs_state)

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -351,7 +351,8 @@ start(it::Take) = (it.n, start(it.xs))
 """
     take(s::String, n)
 
-Return a `SubString` with at most `n` of the first `Char`s contained in `s`.
+Return a `SubString` with at most `n` of the first characters of `s`.  A
+character is defined as a Unicode scalar value.
 """
 function take(s::String, n::Int)
     i = 1

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -453,3 +453,31 @@ Convert a string to `String` type and check that it contains only ASCII data, ot
 throwing an `ArgumentError` indicating the position of the first non-ASCII byte.
 """
 ascii(x::AbstractString) = ascii(convert(String, x))
+
+"""
+    take(s::AbstractString, n)
+
+Return a `SubString` with at most the first `n` characters of `s`. A character
+is defined as a Unicode scalar value.
+"""
+function take(s::AbstractString, n::Int)
+    for i in eachindex(s)
+        n -= 1
+        n == 0 && return SubString(s, 1, i)
+    end
+    SubString(s, 1)
+end
+
+"""
+    drop(s::AbstractString, n)
+
+Return a `SubString` without the first `n` characters of `s`. A character is
+defined as a Unicode scalar value.
+"""
+function drop(s::AbstractString, n::Int)
+    for i in eachindex(s)
+        n == 0 && return SubString(s, i)
+        n -= 1
+    end
+    SubString(s, endof(s)+1)
+end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -238,4 +238,12 @@ bin_val = hex2bytes("07bf")
 @test take("Hello, World!", 5) == "Hello"
 @test take("Hello, World!", 100) == "Hello, World!"
 @test take("שלום לך עולם", 4) == "שלום"
-@test take("हैलो वर्ल्ड", 20) == "हैलो वर्ल्ड"
+@test take("你好，世界！", 20) == "你好，世界！"
+
+# drop first characters from `String`
+@test drop("Hello, World!", 5) == ", World!"
+@test drop("Hello, World!", 100) == ""
+@test drop("שלום לך עולם", 4) == " לך עולם"
+@test drop("你好，世界！", 0) == "你好，世界！"
+
+@test drop(take("Hello, World!", 10), 5) == ", Wor"

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -233,3 +233,9 @@ bin_val = hex2bytes("07bf")
 
 #non-hex characters
 @test_throws ArgumentError hex2bytes("0123456789abcdefABCDEFGH")
+
+# take first characters from `String`
+@test take("Hello, World!", 5) == "Hello"
+@test take("Hello, World!", 100) == "Hello, World!"
+@test take("שלום לך עולם", 4) == "שלום"
+@test take("हैलो वर्ल्ड", 20) == "हैलो वर्ल्ड"


### PR DESCRIPTION
This came up on Stack Overflow: http://stackoverflow.com/questions/39501900/truncate-string-in-julia

Stuff isn't very inlined in this implementation, so it could definitely be made faster, but this was the clearest implementation I could do without bringing in internal-ish string functions like `is_valid_continuation`. If it turns out this needs to be fast, it can be fixed later.

As `Base.Take` supports only the iteration protocol, `SubString` is a strict superset of its functionality. Thus, I don't expect this to be a breaking change. (I don't know if it would technically be considered one.)

The Hebrew line of code in the tests displays rather unfortunately on GitHub. If this is a concern, I can add an LTR override, or maybe replace it with a non-RTL language.

Technically, this is not a faster version of `take`, since `take` is lazy, while this does an iteration. However, I suspect it is more useful in all situations.
