### PR TITLE
non-x86: ensure cgmemmgr caches are consistent

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -462,11 +462,12 @@ public:
     virtual ~ROAllocator() {}
     virtual void finalize()
     {
-        if (exec) {
-            for (auto &alloc: allocations) {
-                sys::Memory::InvalidateInstructionCache(alloc.rt_addr,
-                                                        alloc.sz);
-            }
+        for (auto &alloc: allocations) {
+            // ensure the mapped pages are consistent
+            sys::Memory::InvalidateInstructionCache(alloc.wr_addr,
+                                                    alloc.sz);
+            sys::Memory::InvalidateInstructionCache(alloc.rt_addr,
+                                                    alloc.sz);
         }
         completed.clear();
         allocations.clear();


### PR DESCRIPTION
this ensures that the writes are completed before flushing the icache
otherwise, platforms like ARM would potentially fail to see some of the writes
and were especially likely to miss the relocations applied to the JIT code

fix #17577
