### PR TITLE
18267 1x1 NaN matrix eigenvalue

### DIFF
--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -27,13 +27,8 @@ isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(A.values .>
 
 function eigfact!{T<:BlasReal}(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true)
     n = size(A, 2)
-    n==0 && return Eigen(zeros(T, 0), zeros(T, 0, 0))
-    print("abcdefg")
-    """
-    so its somewhere here, need to find out where this eigfact! is located then I can fix it
-    """
-    issymmetric(A) && return eigfact!(Symmetric(A))
-    print("zzzzzzz")
+    n == 0 && return Eigen(zeros(T, 0), zeros(T, 0, 0))
+    (issymmetric(A) && !((size(A) == (1, 1)) && isnan(A[1]))) && return eigfact!(Symmetric(A))
     A, WR, WI, VL, VR, _ = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)
     all(WI .== 0.) && return Eigen(WR, VR)
     evec = zeros(Complex{T}, n, n)

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -28,7 +28,12 @@ isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(A.values .>
 function eigfact!{T<:BlasReal}(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true)
     n = size(A, 2)
     n==0 && return Eigen(zeros(T, 0), zeros(T, 0, 0))
+    print("abcdefg")
+    """
+    so its somewhere here, need to find out where this eigfact! is located then I can fix it
+    """
     issymmetric(A) && return eigfact!(Symmetric(A))
+    print("zzzzzzz")
     A, WR, WI, VL, VR, _ = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)
     all(WI .== 0.) && return Eigen(WR, VR)
     evec = zeros(Complex{T}, n, n)

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -28,7 +28,7 @@ isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(A.values .>
 function eigfact!{T<:BlasReal}(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true)
     n = size(A, 2)
     n == 0 && return Eigen(zeros(T, 0), zeros(T, 0, 0))
-    (issymmetric(A) && !((size(A) == (1, 1)) && isnan(A[1]))) && return eigfact!(Symmetric(A))
+    issymmetric(A) && return eigfact!(Symmetric(A))
     A, WR, WI, VL, VR, _ = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)
     all(WI .== 0.) && return Eigen(WR, VR)
     evec = zeros(Complex{T}, n, n)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -704,13 +704,7 @@ function issymmetric(A::AbstractMatrix)
     if indsm != indsn
         return false
     end
-    if indsm == Base.OneTo(1)
-        if isnan(A[1,1])
-            return false
-        end
-        return true
-    end
-    for i = first(indsn):last(indsn)-1, j = (i+1):last(indsn)
+    for i = first(indsn):last(indsn), j = (i):last(indsn)
         if A[i,j] != transpose(A[j,i])
             return false
         end

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -704,6 +704,12 @@ function issymmetric(A::AbstractMatrix)
     if indsm != indsn
         return false
     end
+    if indsm == Base.OneTo(1)
+        if isnan(A[1,1])
+            return false
+        end
+        return true
+    end
     for i = first(indsn):last(indsn)-1, j = (i+1):last(indsn)
         if A[i,j] != transpose(A[j,i])
             return false

--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -100,7 +100,7 @@ end
 for eltya in (NaN16, NaN32, NaN)
     @test_throws(ArgumentError, eig(fill(eltya, 1, 1)))
     @test_throws(ArgumentError, eig(fill(eltya, 2, 2)))
-    test_matrix = rand(typeof(eltya,3,3)
+    test_matrix = rand(typeof(eltya,3,3))
     test_matrix[2,2] = eltya
     @test_throws(ArgumentError, eig(test_matrix))
 end

--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -95,6 +95,16 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
         @test v == f[:vectors]
     end
 end
+
+#test eigenvalue computations with NaNs
+for eltya in (NaN16, NaN32, NaN)
+    @test_throws(ArgumentError, eig(fill(eltya, 1, 1)))
+    @test_throws(ArgumentError, eig(fill(eltya, 2, 2)))
+    test_matrix = rand(3,3)
+    test_matrix[2,2] = eltya
+    @test_throws(ArgumentError, eig(test_matrix))
+end
+
 # test a matrix larger than 140-by-140 for #14174
 let aa = rand(200, 200)
     for atype in ("Array", "SubArray")

--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -100,7 +100,7 @@ end
 for eltya in (NaN16, NaN32, NaN)
     @test_throws(ArgumentError, eig(fill(eltya, 1, 1)))
     @test_throws(ArgumentError, eig(fill(eltya, 2, 2)))
-    test_matrix = rand(3,3)
+    test_matrix = rand(typeof(eltya,3,3)
     test_matrix[2,2] = eltya
     @test_throws(ArgumentError, eig(test_matrix))
 end

--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -100,7 +100,7 @@ end
 for eltya in (NaN16, NaN32, NaN)
     @test_throws(ArgumentError, eig(fill(eltya, 1, 1)))
     @test_throws(ArgumentError, eig(fill(eltya, 2, 2)))
-    test_matrix = rand(typeof(eltya,3,3))
+    test_matrix = rand(typeof(eltya),3,3)
     test_matrix[2,2] = eltya
     @test_throws(ArgumentError, eig(test_matrix))
 end


### PR DESCRIPTION
Added a check when computing the eigenvalue of a matrix for if the matrix is a 1x1 matrix with NaN elements. Previously this case incorrectly returned a value (not NaN) while the 2x2 and larger dimensional cases threw an error.

This is my first contribution to Julia, so any help or feedback is greatly appreciated.

https://github.com/JuliaLang/LinearAlgebra.jl/issues/365
