### PR TITLE
Changed the test for symmetry of a Number.

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -712,7 +712,7 @@ function issymmetric(A::AbstractMatrix)
     return true
 end
 
-issymmetric(x::Number) = true
+issymmetric(x::Number) = x == x
 
 """
     ishermitian(A) -> Bool

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -223,6 +223,10 @@ for elty in [Float32,Float64,Complex64,Complex128]
     @test det(a) == a
 end
 
+@test !issymmetric(NaN16)
+@test !issymmetric(NaN32)
+@test !issymmetric(NaN)
+
 @test rank([1.0 0.0; 0.0 0.9],0.95) == 1
 @test qr(big([0 1; 0 0]))[2] == [0 1; 0 0]
 


### PR DESCRIPTION
Changed the symmetry test for Numbers. Previously it always returned true. Now it tests whether the argument passed in is equal to itself. This causes `issymmetric(NaN)` to return false when previously it returned true.
