### PR TITLE
Make take and drop type-idempotent, and canonicalize their order

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -338,6 +338,7 @@ julia> collect(take(a,3))
 ```
 """
 take(xs, n::Int) = Take(xs, n)
+take(xs::Take, n::Int) = Take(xs.xs, min(n, xs.n))
 
 eltype{I}(::Type{Take{I}}) = eltype(I)
 iteratoreltype{I}(::Type{Take{I}}) = iteratoreltype(I)
@@ -391,6 +392,7 @@ julia> collect(drop(a,4))
 ```
 """
 drop(xs, n::Int) = Drop(xs, n)
+drop(xs::Drop, n::Int) = Drop(xs.xs, n + xs.n)
 
 eltype{I}(::Type{Drop{I}}) = eltype(I)
 iteratoreltype{I}(::Type{Drop{I}}) = iteratoreltype(I)

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -392,6 +392,7 @@ julia> collect(drop(a,4))
 ```
 """
 drop(xs, n::Int) = Drop(xs, n)
+drop(xs::Take, n::Int) = Take(drop(xs.xs, n), max(0, xs.n - n))
 drop(xs::Drop, n::Int) = Drop(xs.xs, n + xs.n)
 
 eltype{I}(::Type{Drop{I}}) = eltype(I)

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -156,13 +156,18 @@ end
 @test_throws MethodError length(drop(countfrom(1), 3))
 
 # double take
+# and take/drop canonicalization
 # -----------
 
 for xs in Any["abc", [1, 2, 3]]
-    @test take(take(xs, 2), 3) == take(xs, 2)
-    @test take(take(xs, 4), 2) == take(xs, 2)
-    @test drop(drop(xs, 1), 1) == drop(xs, 2)
+    @test take(take(xs, 2), 3) === take(xs, 2)
+    @test take(take(xs, 4), 2) === take(xs, 2)
+    @test drop(drop(xs, 1), 1) === drop(xs, 2)
+    @test take(drop(xs, 1), 1) === drop(take(xs, 2), 1)
+    @test take(drop(xs, 3), 0) === drop(take(xs, 2), 3)
     @test isempty(drop(drop(xs, 2), 2))
+    @test drop(take(drop(xs, 1), 2), 1) === take(drop(xs, 2), 1)
+    @test take(drop(take(xs, 3), 1), 1) === take(drop(xs, 1), 1)
 end
 
 # cycle

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -155,6 +155,16 @@ end
 @test Base.iteratorsize(drop(countfrom(1),3)) == Base.IsInfinite()
 @test_throws MethodError length(drop(countfrom(1), 3))
 
+# double take
+# -----------
+
+for xs in Any["abc", [1, 2, 3]]
+    @test take(take(xs, 2), 3) == take(xs, 2)
+    @test take(take(xs, 4), 2) == take(xs, 2)
+    @test drop(drop(xs, 1), 1) == drop(xs, 2)
+    @test isempty(drop(drop(xs, 2), 2))
+end
+
 # cycle
 # -----
 


### PR DESCRIPTION
Guarantees `typeof(take(take(itr, n), m)) == typeof(take(itr, n))`. Related to #18515, but this should be less significant of a change. We already do this for `SubString` and `view`.
