### PR TITLE
RFC: Use `view` in `take`, `drop` of `AbstractArray`

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -378,3 +378,27 @@ macro view(ex)
         throw(ArgumentError("Invalid use of @view macro: argument must be a reference expression A[...]."))
     end
 end
+
+"""
+    take(A::AbstractArray, n)
+
+Return a one-dimensional array view over at most the first `n` elements of `A`.
+See also [`view`](:func:`view`). Resizing `A` afterward is not allowed.
+"""
+function take(A::AbstractArray, n::Int)
+    inds = linearindices(A)
+    i, j = first(inds), last(inds)
+    view(A, i:min(i+n-1, j))
+end
+
+"""
+    drop(A::AbstractArray, n)
+
+Return a one-dimensional array view over all elements of `A` except the first
+`n`. See also [`view`](:func:`view`). Resizing `A` afterward is not allowed.
+"""
+function drop(A::Array, n::Int)
+    inds = linearindices(A)
+    i, j = first(inds), last(inds)
+    view(A, min(last(inds)+1, i+n):j)
+end

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -140,6 +140,12 @@ end
 @test length(take(countfrom(1),3)) == 3
 @test length(take(1:6,3)) == 3
 
+# take on arrays
+for itr in Any[[1:10;], [1 3 5 7 9; 2 4 6 8 10]]
+    @test take(itr, 5) == view(itr, 1:5)
+    @test take(itr, 15) == view(itr, 1:10)
+end
+
 # drop
 # ----
 
@@ -154,6 +160,14 @@ end
 @test length(drop(1:3,typemax(Int))) == 0
 @test Base.iteratorsize(drop(countfrom(1),3)) == Base.IsInfinite()
 @test_throws MethodError length(drop(countfrom(1), 3))
+
+# drop on arrays
+for itr in Any[[1:10;], [1 3 5 7 9; 2 4 6 8 10]]
+    @test drop(itr, 5) == view(itr, 6:10)
+    @test isempty(drop(itr, 15))
+    @test take(drop(itr, 3), 3) == view(itr, 4:6)
+    @test take(drop(itr, 3), 100) == view(itr, 4:10)
+end
 
 # cycle
 # -----
@@ -346,7 +360,7 @@ end
 @test Base.iteratorsize(Base.product(1:2))                        == Base.HasShape()
 @test Base.iteratorsize(Base.product(1:2, 1:2))                   == Base.HasShape()
 @test Base.iteratorsize(Base.product(take(1:2, 1), take(1:2, 1))) == Base.HasShape()
-@test Base.iteratorsize(Base.product(take(1:2, 2)))               == Base.HasLength()
+@test Base.iteratorsize(Base.product(take(1:2, 2)))               == Base.HasShape()
 @test Base.iteratorsize(Base.product([1 2; 3 4]))                 == Base.HasShape()
 
 # iteratoreltype trait business


### PR DESCRIPTION
Since we already have a `SubArray` type, which is substantially more powerful (and indeed _almost_ a strict superset of the functionality of) the `Take` and `Drop` types, I wonder if we should use those for `take` and `drop` of `AbstractArray`.

The only limitations of `SubArray` that `Take` and `Drop` are not susceptible to, that I know of, are:
- `Take` and `Drop` can be used on vectors that are later resized, and so their emptiness is a function of the underlying vector's size. `view`'s emptiness is determined on construction.
- `Take` and `Drop` have no problem dealing with `typemax(Int)` and values close to it; `view` can run into issues if the underlying array has large underlying index.

Otherwise, I think it's useful to have `take` and `drop` return the most useful possible result, and `SubArray` is certainly more useful than `Take{Array}`.

Related: #18515
