### PR TITLE
Fix #18544, cmdlineargs test failing in Mac binary due to default jul…

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -301,9 +301,11 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes`
     # --startup-file
     let JL_OPTIONS_STARTUPFILE_ON = 1,
         JL_OPTIONS_STARTUPFILE_OFF = 2
-        # `HOME=/tmp` to avoid errors in the user .juliarc.jl, which hangs the tests.  Issue #17642
-        @test parse(Int,readchomp(setenv(`$exename -E "Base.JLOptions().startupfile" --startup-file=yes`,
-            ["HOME=/tmp", "PATH="*ENV["PATH"]]))) == JL_OPTIONS_STARTUPFILE_ON
+        # `HOME=$tmpdir` to avoid errors in the user .juliarc.jl, which hangs the tests.  Issue #17642
+        mktempdir() do tmpdir
+            @test parse(Int,readchomp(setenv(`$exename -E "Base.JLOptions().startupfile" --startup-file=yes`,
+                ["HOME="*tmpdir, "PATH="*ENV["PATH"]]))) == JL_OPTIONS_STARTUPFILE_ON
+        end
         @test parse(Int,readchomp(`$exename -E "Base.JLOptions().startupfile" --startup-file=no`)) == JL_OPTIONS_STARTUPFILE_OFF
     end
     @test !success(`$exename --startup-file=false`)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -302,7 +302,8 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes`
     let JL_OPTIONS_STARTUPFILE_ON = 1,
         JL_OPTIONS_STARTUPFILE_OFF = 2
         # `HOME=/tmp` to avoid errors in the user .juliarc.jl, which hangs the tests.  Issue #17642
-        @test parse(Int,readchomp(setenv(`$exename -E "Base.JLOptions().startupfile" --startup-file=yes`, ["HOME=/tmp"]))) == JL_OPTIONS_STARTUPFILE_ON
+        @test parse(Int,readchomp(setenv(`$exename -E "Base.JLOptions().startupfile" --startup-file=yes`,
+            ["HOME=/tmp", "PATH="*ENV["PATH"]]))) == JL_OPTIONS_STARTUPFILE_ON
         @test parse(Int,readchomp(`$exename -E "Base.JLOptions().startupfile" --startup-file=no`)) == JL_OPTIONS_STARTUPFILE_OFF
     end
     @test !success(`$exename --startup-file=false`)


### PR DESCRIPTION
…iarc

Pass through `ENV["PATH"]` in the `setenv` call since it is read from in
https://github.com/JuliaLang/julia/blob/v0.5.0-rc4/contrib/mac/juliarc.jl

@scottsallberg can you test if making this change to `/Applications/Julia-0.5.app/Contents/Resources/julia/share/julia/test/cmdlineargs.jl` fixes #18544 for you?
