### PR TITLE
[RFC] Normalize `make binary-dist` filenames

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -692,6 +692,32 @@ ifneq (,$(filter $(ARCH), powerpc64 ppc64))
 $(error Big-endian PPC64 is not supported, to ignore this error, set ARCH=ppc64le)
 endif
 
+# File name of make binary-dist result
+ifeq ($(JULIA_BINARYDIST_FILENAME),)
+DIST_OS:=$(OS)
+ifeq (WINNT,$(OS))
+DIST_OS:=win
+endif
+ifeq (Linux,$(OS))
+DIST_OS:=linux
+endif
+ifeq (Darwin,$(OS))
+DIST_OS:=mac
+endif
+DIST_ARCH:=$(ARCH)
+ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
+DIST_ARCH:=ppc64le
+endif
+ifeq (1,$(ISX86))
+DIST_ARCH:=$(BINARY)
+endif
+ifneq (,$(findstring arm,$(ARCH)))
+DIST_ARCH:=arm
+endif
+
+JULIA_BINARYDIST_FILENAME := julia-$(JULIA_COMMIT)-$(DIST_OS)$(DIST_ARCH)
+endif
+
 # If we are running on ARM, set certain options automatically
 ifneq (,$(findstring arm,$(ARCH)))
 JCFLAGS += -fsigned-char

--- a/Make.inc
+++ b/Make.inc
@@ -694,7 +694,7 @@ endif
 
 # File name of make binary-dist result
 ifeq ($(JULIA_BINARYDIST_FILENAME),)
-DIST_OS:=$(OS)
+DIST_OS:=$(shell echo $(OS) | tr '[:upper:]' '[:lower:]')
 ifeq (WINNT,$(OS))
 DIST_OS:=win
 endif

--- a/Makefile
+++ b/Makefile
@@ -474,6 +474,10 @@ else
 endif
 	rm -fr $(BUILDROOT)/julia-$(JULIA_COMMIT)
 
+app:
+	$(MAKE) -C contrib/mac/app
+	-mv contrib/mac/app/$(JULIA_BINARYDIST_FILENAME).dmg $(BUILDROOT)
+
 light-source-dist.tmp: $(BUILDROOT)/doc/_build/html/en/index.html
 ifneq ($(BUILDROOT),$(JULIAHOME))
 	$(error make light-source-dist does not work in out-of-tree builds)

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,6 @@ include $(JULIAHOME)/Make.inc
 # third-party code).
 VERSDIR := v`cut -d. -f1-2 < $(JULIAHOME)/VERSION`
 
-#file name of make binary-dist result
-ifeq ($(JULIA_BINARYDIST_TARNAME),)
-	JULIA_BINARYDIST_TARNAME := julia-$(JULIA_COMMIT)-$(OS)-$(ARCH)
-endif
-
 default: $(JULIA_BUILD_MODE) # contains either "debug" or "release"
 all: debug release
 
@@ -472,10 +467,10 @@ endif
 
 	# compress nsis installer and combine with 7zip self-extracting header
 	cd $(BUILDROOT) && $(JULIAHOME)/dist-extras/7z a -mx9 "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" julia-installer.exe
-	cd $(BUILDROOT) && cat $(JULIAHOME)/contrib/windows/7zS.sfx $(JULIAHOME)/contrib/windows/7zSFX-config.txt "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" > "julia-${JULIA_VERSION}-${ARCH}.exe"
+	cd $(BUILDROOT) && cat $(JULIAHOME)/contrib/windows/7zS.sfx $(JULIAHOME)/contrib/windows/7zSFX-config.txt "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" > "$(JULIA_BINARYDIST_FILENAME).exe"
 	-rm -f $(BUILDROOT)/julia-installer.exe
 else
-	cd $(BUILDROOT) && $(TAR) zcvf $(JULIA_BINARYDIST_TARNAME).tar.gz julia-$(JULIA_COMMIT)
+	cd $(BUILDROOT) && $(TAR) zcvf $(JULIA_BINARYDIST_FILENAME).tar.gz julia-$(JULIA_COMMIT)
 endif
 	rm -fr $(BUILDROOT)/julia-$(JULIA_COMMIT)
 

--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ endif
 
 app:
 	$(MAKE) -C contrib/mac/app
-	-mv contrib/mac/app/$(JULIA_BINARYDIST_FILENAME).dmg $(BUILDROOT)
+	@mv contrib/mac/app/$(JULIA_BINARYDIST_FILENAME).dmg $(BUILDROOT)
 
 light-source-dist.tmp: $(BUILDROOT)/doc/_build/html/en/index.html
 ifneq ($(BUILDROOT),$(JULIAHOME))

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -48,7 +48,7 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	plutil -insert  NSHumanReadableCopyright   -string "$(APP_COPYRIGHT)" $@/Contents/Info.plist
 	-mkdir -p $@/Contents/Resources/julia
 	make -C $(JULIAHOME) binary-dist
-	tar zxf $(JULIAHOME)/julia-*.tar.gz -C $@/Contents/Resources/julia --strip-components 1
+	tar zxf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
 	-codesign -s "AFB379C0B4CBD9DB9A762797FC2AB5460A2B0DBE" --deep $@
 
 ROOTFILES := $(shell ls -ld dmg/*.app *.dmg 2> /dev/null | awk '{print $$3}')

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -12,7 +12,7 @@ JULIA_VERSION_OPT_COMMIT:=$(shell [ $$(git describe --tags --exact-match 2>/dev/
 JULIA_VERSION_MAJOR_MINOR:=$(shell echo $(JULIA_VERSION) | grep -o '^[0-9]\+.[0-9]\+')
 JULIA_VERSION_MAJOR_MINOR_PATCH:=$(shell echo $(JULIA_VERSION) | grep -o '^[0-9]\+.[0-9]\+.[0-9]\+')
 
-DMG_NAME:=Julia-$(JULIA_VERSION_OPT_COMMIT).dmg
+DMG_NAME:=$(JULIA_BINARYDIST_FILENAME).dmg
 APP_NAME:=Julia-$(JULIA_VERSION_MAJOR_MINOR).app
 VOL_NAME:=Julia-$(JULIA_VERSION_OPT_COMMIT)
 

--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -44,11 +44,11 @@ curl -L -o julia-$version-linux-arm.tar.gz \
   $julianightlies/linux/arm/$majmin/julia-$majminpatch-$shashort-linuxarm.tar.gz
 cp julia-$version-linux-arm.tar.gz julia-$majmin-latest-linux-arm.tar.gz
 curl -L -o julia-$version-linux-ppc64le.tar.gz \
-  $julianightlies/linux/ppc64le/$majmin/julia-$majminpatch-$shashort-linuxppc64.tar.gz
+  $julianightlies/linux/ppc64le/$majmin/julia-$majminpatch-$shashort-linuxppc64le.tar.gz
 cp julia-$version-linux-ppc64le.tar.gz julia-$majmin-latest-linux-ppc64le.tar.gz
-curl -L -o "julia-$version-osx10.7 .dmg" \
-  $julianightlies/osx/x64/$majmin/julia-$majminpatch-$shashort-osx.dmg
-cp "julia-$version-osx10.7 .dmg" "julia-$majmin-latest-osx10.7 .dmg"
+curl -L -o "julia-$version-mac64.dmg" \
+  $julianightlies/mac/x64/$majmin/julia-$majminpatch-$shashort-mac64.dmg
+cp "julia-$version-mac64.dmg" "julia-$majmin-latest-mac64.dmg"
 curl -L -o julia-$version-win64.exe \
   $julianightlies/winnt/x64/$majmin/julia-$majminpatch-$shashort-win64.exe
 cp julia-$version-win64.exe julia-$majmin-latest-win64.exe
@@ -85,12 +85,11 @@ for plat in x86_64 i686 arm ppc64le; do
     s3://julialang/bin/linux/$platshort/$majmin/
   curl -X PURGE -L "https://julialang-s3.julialang.org/bin/linux/$platshort/$majmin/julia-$majmin-latest-linux-$plat.tar.gz"
 done
-aws s3 cp --acl public-read "julia-$version-osx10.7 .dmg" \
-  s3://julialang/bin/osx/x64/$majmin/
-aws s3 cp --acl public-read "julia-$majmin-latest-osx10.7 .dmg" \
-  s3://julialang/bin/osx/x64/$majmin/
-curl -X PURGE -L "https://julialang-s3.julialang.org/bin/osx/x64/$majmin/julia-$majmin-latest-osx10.7 .dmg"
-curl -X PURGE -L "https://julialang-s3.julialang.org/bin/osx/x64/$majmin/julia-$majmin-latest-osx10.7+.dmg"
+aws s3 cp --acl public-read "julia-$version-mac64 .dmg" \
+  s3://julialang/bin/mac/x64/$majmin/
+aws s3 cp --acl public-read "julia-$majmin-latest-mac64.dmg" \
+  s3://julialang/bin/mac/x64/$majmin/
+curl -X PURGE -L "https://julialang-s3.julialang.org/bin/mac/x64/$majmin/julia-$majmin-latest-mac64.dmg"
 aws s3 cp --acl public-read "julia-$version-win64.exe" \
   s3://julialang/bin/winnt/x64/$majmin/
 aws s3 cp --acl public-read "julia-$majmin-latest-win64.exe" \


### PR DESCRIPTION
With this change, the output of `make binary-dist` filenames are nicely normalized across platforms.  Running this branch through the buildbots results in the following set of files:

```
julia-19d61d20ff-linux32.tar.gz
julia-19d61d20ff-linux64.tar.gz
julia-19d61d20ff-linuxarm.tar.gz
julia-19d61d20ff-linuxppc64le.tar.gz
julia-19d61d20ff-mac64.dmg
julia-19d61d20ff-win64.exe *
julia-19d61d20ff-win32.exe *
```

We should get the two windows ones (that have a `*` after them) as well, but I'm running into weird windows errors while trying to build llvm, so I can't _actually_ verify that works.
