### PR TITLE
Deprecate vectorized abs methods in favor of compact broadcast syntax

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -996,7 +996,7 @@ function empty!(B::BitVector)
 end
 
 ## Misc functions
-abs(B::BitArray) = copy(B)
+broadcast(::typeof(abs), B::BitArray) = copy(B)
 
 ## Unary operators ##
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,8 @@ module Broadcast
 using Base.Cartesian
 using Base: promote_eltype_op, @get!, _msk_end, unsafe_bitgetindex, linearindices, tail, OneTo, to_shape
 import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^
-export broadcast, broadcast!, bitbroadcast, dotview
+import Base: broadcast
+export broadcast!, bitbroadcast, dotview
 export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1000,4 +1000,13 @@ macro vectorize_2arg(S,f)
 end
 export @vectorize_1arg, @vectorize_2arg
 
+# Devectorize manually vectorized abs methods in favor of compact broadcast syntax
+@deprecate abs(f::Base.Pkg.Resolve.MaxSum.Field) abs.(f)
+@deprecate abs(B::BitArray) abs.(B)
+@deprecate abs(M::Bidiagonal) abs.(M)
+@deprecate abs(D::Diagonal) abs.(D)
+@deprecate abs(M::Tridiagonal) abs.(M)
+@deprecate abs(M::SymTridiagonal) abs.(M)
+@deprecate abs(x::AbstractSparseVector) abs.(x)
+
 # End deprecations scheduled for 0.6

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -189,7 +189,8 @@ function size(M::Bidiagonal, d::Integer)
 end
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag, :abs)
+broadcast(::typeof(abs), M::Bidiagonal) = Bidiagonal(abs.(M.dv), abs.(M.ev), abs.(M.isupper))
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.isupper)
 end
 for func in (:round, :trunc, :floor, :ceil)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -77,7 +77,7 @@ isposdef(D::Diagonal) = all(D.diag .> 0)
 
 factorize(D::Diagonal) = D
 
-abs(D::Diagonal) = Diagonal(abs(D.diag))
+broadcast(::typeof(abs), D::Diagonal) = Diagonal(abs.(D.diag))
 real(D::Diagonal) = Diagonal(real(D.diag))
 imag(D::Diagonal) = Diagonal(imag(D.diag))
 

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -71,7 +71,8 @@ end
 similar{T}(S::SymTridiagonal, ::Type{T}) = SymTridiagonal{T}(similar(S.dv, T), similar(S.ev, T))
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real, :imag)
+broadcast(::typeof(abs), M::SymTridiagonal) = SymTridiagonal(abs.(M.dv), abs.(M.ev))
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
 end
 for func in (:round, :trunc, :floor, :ceil)
@@ -388,7 +389,8 @@ end
 copy!(dest::Tridiagonal, src::Tridiagonal) = Tridiagonal(copy!(dest.dl, src.dl), copy!(dest.d, src.d), copy!(dest.du, src.du), copy!(dest.du2, src.du2))
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real, :imag)
+broadcast(::typeof(abs), M::Tridiagonal) = Tridiagonal(abs.(M.dl), abs.(M.d), abs.(M.du), abs.(M.du2))
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
     @eval function ($func)(M::Tridiagonal)
         Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du), ($func)(M.du2))
     end

--- a/base/pkg/resolve/fieldvalue.jl
+++ b/base/pkg/resolve/fieldvalue.jl
@@ -62,7 +62,6 @@ end
     a.l0 == b.l0 && a.l1 == b.l1 && a.l2 == b.l2 && a.l3 == b.l3 && a.l4 == b.l4
 
 Base.abs(a::FieldValue) = FieldValue(abs(a.l0), abs(a.l1), abs(a.l2), abs(a.l3), abs(a.l4))
-Base.abs(f::Field) = FieldValue[abs(a) for a in f]
 
 # if the maximum field has l0 < 0, it means that
 # some hard constraint is being violated

--- a/base/pkg/resolve/maxsum.jl
+++ b/base/pkg/resolve/maxsum.jl
@@ -329,7 +329,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
         end
 
         diff = newmsg - oldmsg
-        maxdiff = max(maxdiff, maximum(abs(diff)))
+        maxdiff = max(maxdiff, maximum(abs.(diff)))
 
         # update the field of p1
         fld1 = fld[p1]

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -912,7 +912,8 @@ hvcat{T}(rows::Tuple{Vararg{Int}}, xs::_TypedDenseConcatGroup{T}...) = Base.type
 ### Unary Map
 
 # zero-preserving functions (z->z, nz->nz)
-for op in [:abs, :abs2, :conj]
+broadcast(::typeof(abs), x::AbstractSparseVector) = SparseVector(length(x), copy(nonzeroinds(x)), abs.(nonzeros(x)))
+for op in [:abs2, :conj]
     @eval begin
         $(op)(x::AbstractSparseVector) =
             SparseVector(length(x), copy(nonzeroinds(x)), $(op).(nonzeros(x)))

--- a/test/perf/kernel/gk.jl
+++ b/test/perf/kernel/gk.jl
@@ -123,7 +123,7 @@ function gk(n, myeps)
 
         AX=A*X
         Ax = A*x
-        error=abs(AX)-abs(U)
+        error=abs.(AX)-abs.(U)
         #print(Ax)
 
         Axepse=0

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -559,7 +559,7 @@ let x = spv_x1, x2 = x2 = spv_x2
     @test exact_equal(-x, SparseVector(8, [2, 5, 6], [-1.25, 0.75, -3.5]))
 
     # abs and abs2
-    @test exact_equal(abs(x), SparseVector(8, [2, 5, 6], abs.([1.25, -0.75, 3.5])))
+    @test exact_equal(abs.(x), SparseVector(8, [2, 5, 6], abs.([1.25, -0.75, 3.5])))
     @test exact_equal(abs2(x), SparseVector(8, [2, 5, 6], abs2.([1.25, -0.75, 3.5])))
 
     # plus and minus
@@ -683,12 +683,12 @@ let x = spv_x1
     @test minabs(x) == 0.0
 end
 
-let x = abs(spv_x1)
+let x = abs.(spv_x1)
     @test maximum(x) == 3.5
     @test minimum(x) == 0.0
 end
 
-let x = -abs(spv_x1)
+let x = -abs.(spv_x1)
     @test maximum(x) == 0.0
     @test minimum(x) == -3.5
 end


### PR DESCRIPTION
This PR deprecates all (?) remaining vectorized `abs` methods in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, and #18513. Best!
