### PR TITLE
Attempt to fix osx travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ before_install:
         contrib/travis_fastfail.sh || exit 1;
         brew tap staticfloat/julia;
         brew rm --force $(brew deps --HEAD julia);
-        brew install -v staticfloat/juliadeps/libgfortran;
+        brew install -v cmake staticfloat/juliadeps/libgfortran;
         brew install -v --only-dependencies --HEAD julia;
         BUILDOPTS="-j3 USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm37-julia)/bin/llvm-config-3.7 LLVM_SIZE=$(brew --prefix llvm37-julia)/bin/llvm-size-3.7";
         BUILDOPTS="$BUILDOPTS VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse-julia)/include FORCE_ASSERTIONS=1";

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
             - gfortran-5
     - os: osx
       env: ARCH="x86_64"
+      osx_image: xcode7
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/deps/srccache


### PR DESCRIPTION
We're now getting

> Error: You must `brew link autoconf` before staticfloat/julia/julia can be installed

Probably because Homebrew officially started supporting 10.12 Sierra, and that broke something.
Try to use the 10.10 Travis OSX image instead of the default 10.9 (https://docs.travis-ci.com/user/osx-ci-environment/)
[av skip]
