### PR TITLE
Deprecate vectorized abs2 methods in favor of compact broadcast syntax

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1347,4 +1347,7 @@ function quadgk(args...)
 end
 export quadgk
 
+# Deprecate manually vectorized abs2 methods in favor of compact broadcast syntax
+@deprecate abs2(x::AbstractSparseVector) abs2.(x)
+
 # End deprecations scheduled for 0.6

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -919,7 +919,8 @@ hvcat{T}(rows::Tuple{Vararg{Int}}, xs::_TypedDenseConcatGroup{T}...) = Base.type
 
 # zero-preserving functions (z->z, nz->nz)
 broadcast(::typeof(abs), x::AbstractSparseVector) = SparseVector(length(x), copy(nonzeroinds(x)), abs.(nonzeros(x)))
-for op in [:abs2, :conj]
+broadcast(::typeof(abs2), x::AbstractSparseVector) = SparseVector(length(x), copy(nonzeroinds(x)), abs2.(nonzeros(x)))
+for op in [:conj]
     @eval begin
         $(op)(x::AbstractSparseVector) =
             SparseVector(length(x), copy(nonzeroinds(x)), $(op).(nonzeros(x)))

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -588,7 +588,7 @@ let x = spv_x1, x2 = spv_x2
 
     # abs and abs2
     @test exact_equal(abs.(x), SparseVector(8, [2, 5, 6], abs.([1.25, -0.75, 3.5])))
-    @test exact_equal(abs2(x), SparseVector(8, [2, 5, 6], abs2.([1.25, -0.75, 3.5])))
+    @test exact_equal(abs2.(x), SparseVector(8, [2, 5, 6], abs2.([1.25, -0.75, 3.5])))
 
     # plus and minus
     xa = SparseVector(8, [1,2,5,6,7], [3.25,5.25,-0.75,-2.0,-6.0])
@@ -610,7 +610,7 @@ let x = spv_x1, x2 = spv_x2
     # multiplies
     xm = SparseVector(8, [2, 6], [5.0, -19.25])
     let y=x # workaround for broadcast not preserving sparsity in general
-        @test exact_equal(x .* y, abs2(x))
+        @test exact_equal(x .* y, abs2.(x))
     end
     @test exact_equal(x .* x2, xm)
     @test exact_equal(x2 .* x, xm)


### PR DESCRIPTION
This PR deprecates the last remaining vectorized `abs2` method in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, and #18558. Best!

(Unlike with `float`, `real`, etc., the remaining vectorized `abs2` method never aliases its input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
