### PR TITLE
Fix for 17139

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -488,7 +488,7 @@ function uncompressed_ast(m::Method, s::CodeInfo)
 end
 
 # Printing code representations in IR and assembly
-function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant::String=:att)
+function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant::Symbol=:att)
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -506,9 +506,9 @@ function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_me
     return _dump_function(linfo, native, wrapper, strip_ir_metadata, dump_module, asmvariant)
 end
 
-function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant::String=:att)
-    if asmvariant != :att || asmvariant != :intel
-       error("asmvariant must be set to 'intel' or 'att'")
+function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant::Symbol=:att)
+    if asmvariant != :att && asmvariant != :intel
+       throw(ErrorException("asmvariant must be either :intel or :att"))
     end
     if native
         llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, Bool), linfo, wrapper)
@@ -549,11 +549,11 @@ code_llvm_raw(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types, false)
     code_native([io], f, types, [asm_variant])
 
 Prints the native assembly instructions generated for running the method matching the given
-generic function and type signature to `io` which defaults to `STDOUT`.Switch assembly syntax using asm_variant:[att|intel].Output is AT&T syntax by default.
+generic function and type signature to `io` which defaults to `STDOUT`.Switch assembly syntax using `asmvariant` symbol parameter set to `:att` for AT&T syntax or `:intel` for Intel syntax. Output is AT&T syntax by default.
 """
-code_native(io::IO, f::ANY, types::ANY=Tuple, asmvariant::String=:att) =
+code_native(io::IO, f::ANY, types::ANY=Tuple, asmvariant::Symbol=:att) =
     print(io, _dump_function(f, types, true, false, false, false, asmvariant))
-code_native(f::ANY, types::ANY=Tuple, asmvariant::String=:att) = code_native(STDOUT, f, types, asmvariant)
+code_native(f::ANY, types::ANY=Tuple, asmvariant::Symbol=:att) = code_native(STDOUT, f, types, asmvariant)
 
 # give a decent error message if we try to instantiate a staged function on non-leaf types
 function func_for_method_checked(m::Method, types::ANY)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -488,7 +488,7 @@ function uncompressed_ast(m::Method, s::CodeInfo)
 end
 
 # Printing code representations in IR and assembly
-function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant=0)
+function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant::String=:att)
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -506,7 +506,10 @@ function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_me
     return _dump_function(linfo, native, wrapper, strip_ir_metadata, dump_module, asmvariant)
 end
 
-function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant="att")
+function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant::String=:att)
+    if asmvariant != :att || asmvariant != :intel
+       error("asmvariant must be set to 'intel' or 'att'")
+    end
     if native
         llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, Bool), linfo, wrapper)
     else
@@ -548,9 +551,9 @@ code_llvm_raw(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types, false)
 Prints the native assembly instructions generated for running the method matching the given
 generic function and type signature to `io` which defaults to `STDOUT`.Switch assembly syntax using asm_variant:[att|intel].Output is AT&T syntax by default.
 """
-code_native(io::IO, f::ANY, types::ANY=Tuple, asmvariant="att") =
+code_native(io::IO, f::ANY, types::ANY=Tuple, asmvariant::String=:att) =
     print(io, _dump_function(f, types, true, false, false, false, asmvariant))
-code_native(f::ANY, types::ANY=Tuple, asmvariant="att") = code_native(STDOUT, f, types, asmvariant)
+code_native(f::ANY, types::ANY=Tuple, asmvariant::String=:att) = code_native(STDOUT, f, types, asmvariant)
 
 # give a decent error message if we try to instantiate a staged function on non-leaf types
 function func_for_method_checked(m::Method, types::ANY)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -488,7 +488,7 @@ function uncompressed_ast(m::Method, s::CodeInfo)
 end
 
 # Printing code representations in IR and assembly
-function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool)
+function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant=0)
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -503,10 +503,10 @@ function _dump_function(f::ANY, t::ANY, native::Bool, wrapper::Bool, strip_ir_me
     meth = func_for_method_checked(meth, tt)
     linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any), meth, tt, env)
     # get the code for it
-    return _dump_function(linfo, native, wrapper, strip_ir_metadata, dump_module)
+    return _dump_function(linfo, native, wrapper, strip_ir_metadata, dump_module, asmvariant)
 end
 
-function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool)
+function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, asmvariant="att")
     if native
         llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, Bool), linfo, wrapper)
     else
@@ -517,7 +517,8 @@ function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool,
     end
 
     if native
-        str = ccall(:jl_dump_function_asm, Ref{String}, (Ptr{Void}, Cint), llvmf, 0)
+        str = ccall(:jl_dump_function_asm, Ref{String},
+                    (Ptr{Void}, Cint, Cstring), llvmf, 0, asmvariant)
     else
         str = ccall(:jl_dump_function_ir, Ref{String},
                     (Ptr{Void}, Bool, Bool), llvmf, strip_ir_metadata, dump_module)
@@ -542,14 +543,14 @@ code_llvm(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types)
 code_llvm_raw(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types, false)
 
 """
-    code_native([io], f, types)
+    code_native([io], f, types, [asm_variant])
 
 Prints the native assembly instructions generated for running the method matching the given
-generic function and type signature to `io` which defaults to `STDOUT`.
+generic function and type signature to `io` which defaults to `STDOUT`.Switch assembly syntax using asm_variant:[att|intel].Output is AT&T syntax by default.
 """
-code_native(io::IO, f::ANY, types::ANY=Tuple) =
-    print(io, _dump_function(f, types, true, false, false, false))
-code_native(f::ANY, types::ANY=Tuple) = code_native(STDOUT, f, types)
+code_native(io::IO, f::ANY, types::ANY=Tuple, asmvariant="att") =
+    print(io, _dump_function(f, types, true, false, false, false, asmvariant))
+code_native(f::ANY, types::ANY=Tuple, asmvariant="att") = code_native(STDOUT, f, types, asmvariant)
 
 # give a decent error message if we try to instantiate a staged function on non-leaf types
 function func_for_method_checked(m::Method, types::ANY)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -508,7 +508,7 @@ end
 
 function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, syntax::Symbol=:att)
     if syntax != :att && syntax != :intel
-       throw(ArgumentError("'syntax' must be either :intel or :att"))
+        throw(ArgumentError("'syntax' must be either :intel or :att"))
     end
     if native
         llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, Bool), linfo, wrapper)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -508,7 +508,7 @@ end
 
 function _dump_function(linfo::Core.MethodInstance, native::Bool, wrapper::Bool, strip_ir_metadata::Bool, dump_module::Bool, syntax::Symbol=:att)
     if syntax != :att && syntax != :intel
-       throw(ErrorException("'syntax' must be either :intel or :att"))
+       throw(ArgumentError("'syntax' must be either :intel or :att"))
     end
     if native
         llvmf = ccall(:jl_get_llvmf_decl, Ptr{Void}, (Any, Bool), linfo, wrapper)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -549,11 +549,15 @@ code_llvm_raw(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types, false)
     code_native([io], f, types, [asm_variant])
 
 Prints the native assembly instructions generated for running the method matching the given
-generic function and type signature to `io` which defaults to `STDOUT`.Switch assembly syntax using `asmvariant` symbol parameter set to `:att` for AT&T syntax or `:intel` for Intel syntax. Output is AT&T syntax by default.
+generic function and type signature to `io` which defaults to `STDOUT`.Switch assembly syntax using `asmvariant` symbol parameter set to `:att` for AT&T syntax or `:intel` for Intel syntax. Output is AT&T syntax by default .
 """
+
+
 code_native(io::IO, f::ANY, types::ANY=Tuple, asmvariant::Symbol=:att) =
     print(io, _dump_function(f, types, true, false, false, false, asmvariant))
-code_native(f::ANY, types::ANY=Tuple, asmvariant::Symbol=:att) = code_native(STDOUT, f, types, asmvariant)
+
+code_native(f::ANY, types::ANY=Tuple) = code_native(STDOUT, f, types, :att)
+
 
 # give a decent error message if we try to instantiate a staged function on non-leaf types
 function func_for_method_checked(m::Method, types::ANY)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1561,11 +1561,11 @@ Internals
 
    Evaluates the arguments to the function or macro call, determines their types, and calls :func:`code_llvm` on the resulting expression.
 
-.. function:: code_native([io], f, types)
+.. function:: code_native([io], f, types, [syntax])
 
    .. Docstring generated from Julia source
 
-   Prints the native assembly instructions generated for running the method matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ .
+   Prints the native assembly instructions generated for running the method matching the given generic function and type signature to ``io`` which defaults to ``STDOUT``\ . Switch assembly syntax using ``syntax`` symbol parameter set to ``:att`` for AT&T syntax or ``:intel`` for Intel syntax. Output is AT&T syntax by default.
 
 .. function:: @code_native
 

--- a/doc/stdlib/stacktraces.rst
+++ b/doc/stdlib/stacktraces.rst
@@ -17,7 +17,7 @@
    * ``func::Symbol``
 
      The name of the function containing the execution context.
-   * ``linfo::Nullable{MethodInstance}``
+   * ``linfo::Nullable{Core.MethodInstance}``
 
      The MethodInstance containing the execution context (if it could be found).
    * ``file::Symbol``

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1505,7 +1505,7 @@ static uint64_t compute_obj_symsize(const object::ObjectFile *obj, uint64_t offs
 
 // print a native disassembly for f (an LLVM function)
 extern "C" JL_DLLEXPORT
-const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
+const jl_value_t *jl_dump_function_asm(void *f, int raw_mc, const char* asm_variant="att")
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     std::string code;
@@ -1559,10 +1559,11 @@ const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
 #endif
             object, objcontext,
 #if JL_LLVM_VERSION >= 30700
-            stream
+            stream,
 #else
-            fstream
+            fstream,
 #endif
+            asm_variant
             );
 
 #if JL_LLVM_VERSION < 30700

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -15,10 +15,11 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
                           const object::ObjectFile *object,
                           llvm::DIContext *context,
 #if JL_LLVM_VERSION >= 30700
-                          raw_ostream &rstream
+                          raw_ostream &rstream,
 #else
-                          formatted_raw_ostream &stream
+                          formatted_raw_ostream &stream,
 #endif
+                          const char* asm_variant="att"
                           );
 
 // Declarations for debuginfo.cpp

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -366,7 +366,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 #else
                           formatted_raw_ostream &stream,
 #endif
-						  const char* asm_variant="att"
+                          const char* asm_variant="att"
                           )
 {
     // GC safe
@@ -447,7 +447,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
     }
     unsigned OutputAsmVariant = 0; // ATT or Intel-style assembly
 
-    if( strcmp(asm_variant, "intel")==0){
+    if (strcmp(asm_variant, "intel")==0) {
         OutputAsmVariant = 1;
     }
     bool ShowEncoding = false;

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -448,9 +448,9 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
     unsigned OutputAsmVariant = 0; // ATT or Intel-style assembly
 
     if( strcmp(asm_variant, "intel")==0){
-       OutputAsmVariant = 1;
+        OutputAsmVariant = 1;
     }
-	bool ShowEncoding = false;
+    bool ShowEncoding = false;
 
 #if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -362,10 +362,11 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
                           const object::ObjectFile *object,
                           DIContext *di_ctx,
 #if JL_LLVM_VERSION >= 30700
-                          raw_ostream &rstream
+                          raw_ostream &rstream,
 #else
-                          formatted_raw_ostream &stream
+                          formatted_raw_ostream &stream,
 #endif
+						  const char* asm_variant="att"
                           )
 {
     // GC safe
@@ -444,9 +445,12 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
                   TripleName.c_str());
         return;
     }
-
     unsigned OutputAsmVariant = 0; // ATT or Intel-style assembly
-    bool ShowEncoding = false;
+
+    if( strcmp(asm_variant, "intel")==0){
+       OutputAsmVariant = 1;
+    }
+	bool ShowEncoding = false;
 
 #if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -4,7 +4,7 @@ using Base.Test
 
 ix86 = r"i[356]86"
 
-if Sys.ARCH === :x86_64 || ismatch(Sys.ARCH, ix86)
+if Sys.ARCH === :x86_64 || ismatch(ix86, string(Sys.ARCH))
   let
     function linear_foo()
          x = 4

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -1,0 +1,28 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+using Base.Test
+
+
+function linear_foo()
+         x = 4
+         y = 5
+end
+
+rgx = r"%"
+buf = IOBuffer()
+output=""
+
+code_native(buf,linear_foo,(),"att")
+output=takebuf_string(buf)
+
+@test ismatch(rgx,output)
+
+code_native(buf,linear_foo,(),"intel")
+output=takebuf_string(buf)
+
+@test !(ismatch(rgx,output))
+
+code_native(buf,linear_foo,())
+output=takebuf_string(buf)
+
+@test ismatch(rgx, output)

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -2,29 +2,31 @@
 
 using Base.Test
 
-
-function linear_foo()
+if Sys.ARCH === :x86_64 || Sys.Arch == :i386
+  let
+    function linear_foo()
          x = 4
          y = 5
-end
+    end
 
-let 
-  rgx = r"%"
-  buf = IOBuffer()
-  output=""
 
-  code_native(buf,linear_foo,(),"att")
-  output=takebuf_string(buf)
+    rgx = r"%"
+    buf = IOBuffer()
+    output=""
 
-  @test ismatch(rgx,output)
+    code_native(buf,linear_foo,(),"att")
+    output=takebuf_string(buf)
 
-  code_native(buf,linear_foo,(),"intel")
-  output=takebuf_string(buf)
+    @test ismatch(rgx,output)
 
-  @test !(ismatch(rgx,output))
+    code_native(buf,linear_foo,(),"intel")
+    output=takebuf_string(buf)
 
-  code_native(buf,linear_foo,())
-  output=takebuf_string(buf)
+    @test !(ismatch(rgx,output))
 
-  @test ismatch(rgx, output)
+    code_native(buf,linear_foo,())
+    output=takebuf_string(buf)
+
+    @test ismatch(rgx, output)
+  end
 end

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -5,12 +5,10 @@ using Base.Test
 ix86 = r"i[356]86"
 
 if Sys.ARCH === :x86_64 || ismatch(ix86, string(Sys.ARCH))
-  let
     function linear_foo()
-         x = 4
-         y = 5
+        x = 4
+        y = 5
     end
-
 
     rgx = r"%"
     buf = IOBuffer()
@@ -31,5 +29,4 @@ if Sys.ARCH === :x86_64 || ismatch(ix86, string(Sys.ARCH))
     output=takebuf_string(buf)
 
     @test ismatch(rgx, output)
-  end
 end

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -8,21 +8,23 @@ function linear_foo()
          y = 5
 end
 
-rgx = r"%"
-buf = IOBuffer()
-output=""
+let 
+  rgx = r"%"
+  buf = IOBuffer()
+  output=""
 
-code_native(buf,linear_foo,(),"att")
-output=takebuf_string(buf)
+  code_native(buf,linear_foo,(),"att")
+  output=takebuf_string(buf)
 
-@test ismatch(rgx,output)
+  @test ismatch(rgx,output)
 
-code_native(buf,linear_foo,(),"intel")
-output=takebuf_string(buf)
+  code_native(buf,linear_foo,(),"intel")
+  output=takebuf_string(buf)
 
-@test !(ismatch(rgx,output))
+  @test !(ismatch(rgx,output))
 
-code_native(buf,linear_foo,())
-output=takebuf_string(buf)
+  code_native(buf,linear_foo,())
+  output=takebuf_string(buf)
 
-@test ismatch(rgx, output)
+  @test ismatch(rgx, output)
+end

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -16,9 +16,9 @@ if Sys.ARCH === :x86_64 || Sys.Arch === :i386
     #test that the string output is at&t syntax by checking for occurrences of '%'s
     code_native(buf,linear_foo,(),:att)
     output=takebuf_string(buf)
-     
+
     @test ismatch(rgx,output)
-    
+
     #test that the code output is intel syntax by checking it has no occurrences of '%'
     code_native(buf,linear_foo,(),:intel)
     output=takebuf_string(buf)

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -2,7 +2,7 @@
 
 using Base.Test
 
-if Sys.ARCH === :x86_64 || Sys.Arch == :i386
+if Sys.ARCH === :x86_64 || Sys.Arch === :i386
   let
     function linear_foo()
          x = 4
@@ -13,13 +13,14 @@ if Sys.ARCH === :x86_64 || Sys.Arch == :i386
     rgx = r"%"
     buf = IOBuffer()
     output=""
-
-    code_native(buf,linear_foo,(),"att")
+    #test that the string output is at&t syntax by checking for occurrences of '%'s
+    code_native(buf,linear_foo,(),:att)
     output=takebuf_string(buf)
-
+     
     @test ismatch(rgx,output)
-
-    code_native(buf,linear_foo,(),"intel")
+    
+    #test that the code output is intel syntax by checking it has no occurrences of '%'
+    code_native(buf,linear_foo,(),:intel)
     output=takebuf_string(buf)
 
     @test !(ismatch(rgx,output))

--- a/test/asmvariant.jl
+++ b/test/asmvariant.jl
@@ -2,7 +2,9 @@
 
 using Base.Test
 
-if Sys.ARCH === :x86_64 || Sys.Arch === :i386
+ix86 = r"i[356]86"
+
+if Sys.ARCH === :x86_64 || ismatch(Sys.ARCH, ix86)
   let
     function linear_foo()
          x = 4

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -33,7 +33,7 @@ function choosetests(choices = [])
         "markdown", "base64", "serialize", "misc", "threads",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
-        "boundscheck", "error", "ambiguous", "cartesian"
+        "boundscheck", "error", "ambiguous", "cartesian", "asmvariant"
     ]
 
     if Base.USE_GPL_LIBS


### PR DESCRIPTION
Update from previously closed PR solving issue 17139 enabling support for specifying the flavour of syntax desired for native code dump (code_native)
