### PR TITLE
Deprecate vectorized imag methods in favor of compact broadcast syntax

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -86,7 +86,7 @@ conj{T<:Real}(x::AbstractArray{T}) = x
 conj!{T<:Real}(x::AbstractArray{T}) = x
 
 real{T<:Real}(x::AbstractArray{T}) = x
-imag{T<:Real}(x::AbstractArray{T}) = zero(x)
+broadcast{T<:Real}(::typeof(imag), x::AbstractArray{T}) = zero(x)
 
 +{T<:Number}(x::AbstractArray{T}) = x
 *{T<:Number}(x::AbstractArray{T,2}) = x

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -31,7 +31,6 @@ end
 (-)(A::AbstractArray{Bool}) = reshape([ -A[i] for i in eachindex(A) ], size(A))
 
 real(A::AbstractArray) = reshape([ real(x) for x in A ], size(A))
-imag(A::AbstractArray) = reshape([ imag(x) for x in A ], size(A))
 
 function !(A::AbstractArray{Bool})
     F = similar(A)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,8 @@ module Broadcast
 using Base.Cartesian
 using Base: promote_eltype_op, @get!, _msk_end, unsafe_bitgetindex, linearindices, tail, OneTo, to_shape
 import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^
-export broadcast, broadcast!, bitbroadcast, dotview
+import Base: broadcast
+export broadcast!, bitbroadcast, dotview
 export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1000,4 +1000,7 @@ macro vectorize_2arg(S,f)
 end
 export @vectorize_1arg, @vectorize_2arg
 
+# Deprecate manually vectorized imag methods in favor of compact broadcast syntax
+@deprecate imag(A::AbstractArray) imag.(A)
+
 # End deprecations scheduled for 0.6

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -122,9 +122,9 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
     elseif which == "SR" || which == "SA"
         dmap = x->-real(x)
     elseif which == "LI"
-        dmap = imag
+        dmap = x -> imag.(x)
     elseif which == "SI"
-        dmap = x->-imag(x)
+        dmap = x -> map(t -> -imag(t), x)
     end
 
     if cmplx

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -189,7 +189,8 @@ function size(M::Bidiagonal, d::Integer)
 end
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag, :abs)
+broadcast(::typeof(imag), M::Bidiagonal) = Bidiagonal(imag.(M.dv), imag.(M.ev), M.isupper)
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :abs)
     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.isupper)
 end
 for func in (:round, :trunc, :floor, :ceil)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -79,7 +79,7 @@ factorize(D::Diagonal) = D
 
 abs(D::Diagonal) = Diagonal(abs(D.diag))
 real(D::Diagonal) = Diagonal(real(D.diag))
-imag(D::Diagonal) = Diagonal(imag(D.diag))
+broadcast(::typeof(imag), D::Diagonal) = Diagonal(imag.(D.diag))
 
 istriu(D::Diagonal) = true
 istril(D::Diagonal) = true

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -97,9 +97,9 @@ copy{T,S}(A::Symmetric{T,S}) = (B = copy(A.data); Symmetric{T,typeof(B)}(B,A.upl
 copy{T,S}(A::Hermitian{T,S}) = (B = copy(A.data); Hermitian{T,typeof(B)}(B,A.uplo))
 ishermitian(A::Hermitian) = true
 ishermitian{T<:Real,S}(A::Symmetric{T,S}) = true
-ishermitian{T<:Complex,S}(A::Symmetric{T,S}) = all(imag(A.data) .== 0)
+ishermitian{T<:Complex,S}(A::Symmetric{T,S}) = all(imag.(A.data) .== 0)
 issymmetric{T<:Real,S}(A::Hermitian{T,S}) = true
-issymmetric{T<:Complex,S}(A::Hermitian{T,S}) = all(imag(A.data) .== 0)
+issymmetric{T<:Complex,S}(A::Hermitian{T,S}) = all(imag.(A.data) .== 0)
 issymmetric(A::Symmetric) = true
 transpose(A::Symmetric) = A
 ctranspose{T<:Real}(A::Symmetric{T}) = A

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -43,10 +43,10 @@ end
 LowerTriangular(U::UpperTriangular) = throw(ArgumentError("cannot create a LowerTriangular matrix from an UpperTriangular input"))
 UpperTriangular(U::LowerTriangular) = throw(ArgumentError("cannot create an UpperTriangular matrix from a LowerTriangular input"))
 
-imag(A::UpperTriangular) = UpperTriangular(imag(A.data))
-imag(A::LowerTriangular) = LowerTriangular(imag(A.data))
-imag(A::UnitLowerTriangular) = LowerTriangular(tril!(imag(A.data),-1))
-imag(A::UnitUpperTriangular) = UpperTriangular(triu!(imag(A.data),1))
+broadcast(::typeof(imag), A::UpperTriangular) = UpperTriangular(imag.(A.data))
+broadcast(::typeof(imag), A::LowerTriangular) = LowerTriangular(imag.(A.data))
+broadcast(::typeof(imag), A::UnitLowerTriangular) = LowerTriangular(tril!(imag.(A.data), -1))
+broadcast(::typeof(imag), A::UnitUpperTriangular) = UpperTriangular(triu!(imag.(A.data), 1))
 
 convert(::Type{Array}, A::AbstractTriangular) = convert(Matrix, A)
 full(A::AbstractTriangular) = convert(Array, A)

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -71,7 +71,8 @@ end
 similar{T}(S::SymTridiagonal, ::Type{T}) = SymTridiagonal{T}(similar(S.dv, T), similar(S.ev, T))
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real, :imag)
+broadcast(::typeof(imag), M::SymTridiagonal) = SymTridiagonal(imag.(M.dv), imag.(M.ev))
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real)
     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
 end
 for func in (:round, :trunc, :floor, :ceil)
@@ -388,7 +389,8 @@ end
 copy!(dest::Tridiagonal, src::Tridiagonal) = Tridiagonal(copy!(dest.dl, src.dl), copy!(dest.d, src.d), copy!(dest.du, src.du), copy!(dest.du2, src.du2))
 
 #Elementary operations
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real, :imag)
+broadcast(::typeof(imag), M::Tridiagonal) = Tridiagonal(imag.(M.dl), imag.(M.d), imag.(M.du), imag.(M.du2))
+for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :abs, :real)
     @eval function ($func)(M::Tridiagonal)
         Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du), ($func)(M.du2))
     end

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1491,7 +1491,7 @@ end
 Ac_ldiv_B(L::FactorComponent, B) = ctranspose(L)\B
 
 (\){T<:VTypes}(L::Factor{T}, B::Dense{T}) = solve(CHOLMOD_A, L, B)
-(\)(L::Factor{Float64}, B::VecOrMat{Complex{Float64}}) = complex(L\real(B), L\imag(B))
+(\)(L::Factor{Float64}, B::VecOrMat{Complex{Float64}}) = complex(L\real(B), L\imag.(B))
 # First explicit TypeVars are necessary to avoid ambiguity errors with definition in
 # linalg/factorizations.jl
 (\){T<:VTypes}(L::Factor{T}, b::StridedVector) = Vector(L\convert(Dense{T}, b))

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -213,7 +213,7 @@ for itype in UmfpackIndexTypes
             @isok ccall(($sym_c, :libumfpack), $itype,
                         ($itype, $itype, Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Float64}, Ptr{Void},
                          Ptr{Float64}, Ptr{Float64}),
-                        U.m, U.n, U.colptr, U.rowval, real(U.nzval), imag(U.nzval), tmp,
+                        U.m, U.n, U.colptr, U.rowval, real(U.nzval), imag.(U.nzval), tmp,
                         umf_ctrl, umf_info)
             U.symbolic = tmp[1]
             return U
@@ -240,7 +240,7 @@ for itype in UmfpackIndexTypes
             status = ccall(($num_c, :libumfpack), $itype,
                            (Ptr{$itype}, Ptr{$itype}, Ptr{Float64}, Ptr{Float64}, Ptr{Void}, Ptr{Void},
                             Ptr{Float64}, Ptr{Float64}),
-                           U.colptr, U.rowval, real(U.nzval), imag(U.nzval), U.symbolic, tmp,
+                           U.colptr, U.rowval, real(U.nzval), imag.(U.nzval), U.symbolic, tmp,
                            umf_ctrl, umf_info)
             if status != UMFPACK_WARNING_singular_matrix
                 umferror(status)
@@ -396,7 +396,7 @@ for (f!, umfpack) in ((:A_ldiv_B!, :UMFPACK_A),
             r = similar(b, Float64)
             i = similar(b, Float64)
             solve!(r, lu, convert(Vector{Float64}, real(b)), $umfpack)
-            solve!(i, lu, convert(Vector{Float64}, imag(b)), $umfpack)
+            solve!(i, lu, convert(Vector{Float64}, imag.(b)), $umfpack)
             # We have checked size in solve!
             @inbounds for k in eachindex(x)
                 x[k] = Tb(r[k] + im*i[k])

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -10,18 +10,30 @@ tc(r1,r2) = false
 bitcheck(b::BitArray) = length(b.chunks) == 0 || (b.chunks[end] == b.chunks[end] & Base._msk_end(b))
 bitcheck(x) = true
 
-function check_bitop(ret_type, func, args...)
+function check_bitop_call(ret_type, func, args...)
     r1 = func(args...)
     r2 = func(map(x->(isa(x, BitArray) ? Array(x) : x), args)...)
+    check_bitop_tests(ret_type, r1, r2)
+end
+function check_bitop_dotcall(ret_type, func, args...)
+    r1 = func.(args...)
+    r2 = func.(map(x->(isa(x, BitArray) ? Array(x) : x), args)...)
+    check_bitop_tests(ret_type, r1, r2)
+end
+function check_bitop_tests(ret_type, r1, r2)
     @test isa(r1, ret_type)
     @test tc(r1, r2)
     @test isequal(r1, convert(ret_type, r2))
     @test bitcheck(r1)
 end
-
 macro check_bit_operation(ex, ret_type)
-    @assert Meta.isexpr(ex, :call)
-    Expr(:call, :check_bitop, esc(ret_type), map(esc,ex.args)...)
+    if Meta.isexpr(ex, :call)
+        Expr(:call, :check_bitop_call, esc(ret_type), map(esc, ex.args)...)
+    elseif Meta.isexpr(ex, :.)
+        Expr(:call, :check_bitop_dotcall, esc(ret_type), esc(ex.args[1]), map(esc, ex.args[2].args)...)
+    else
+        throw(ArgumentError("first argument to @check_bit_operation must be an expression with head either :call or :. !"))
+    end
 end
 
 let t0 = time()
@@ -583,7 +595,7 @@ b1 = bitrand(n1, n2)
 @check_bit_operation (-)(b1)  Matrix{Int}
 @check_bit_operation sign(b1) BitMatrix
 @check_bit_operation real(b1) BitMatrix
-@check_bit_operation imag(b1) BitMatrix
+@check_bit_operation imag.(b1) BitMatrix
 @check_bit_operation conj(b1) BitMatrix
 
 b0 = falses(0)

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -106,7 +106,7 @@ for elty in [Float32, Float64, Complex64, Complex128]
             @test BLAS.asum(b) ≈ sum(abs.(b))
             @test BLAS.iamax(b) ≈ indmax(abs.(b))
         else
-            @test BLAS.asum(b) ≈ sum(abs.(real(b))) + sum(abs.(imag(b)))
+            @test BLAS.asum(b) ≈ sum(abs.(real(b))) + sum(abs.(imag.(b)))
             @test BLAS.iamax(b) == indmax(map(x -> abs(real(x)) + abs(imag(x)), b))
         end
 

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -133,7 +133,7 @@ let
     @test d[1] ≈ 1. # largest eigenvalue should be 1.
     v=reshape(v,(50,50)) # reshape to matrix
     v/=trace(v) # factor out arbitrary phase
-    @test isapprox(vecnorm(imag(v)),0.) # it should be real
+    @test isapprox(vecnorm(imag.(v)),0.) # it should be real
     v=real(v)
     # @test isapprox(vecnorm(v-v')/2,0.) # it should be Hermitian
     # Since this fails sometimes (numerical precision error),this test is commented out

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -67,7 +67,7 @@ for relty in (Int, Float32, Float64, BigFloat), elty in (relty, Complex{relty})
         @test big(T) == T
         @test full(abs.(T)) == abs.(diagm(dv)) + abs.(diagm(ev, isupper?1:-1))
         @test full(real(T)) == real(diagm(dv)) + real(diagm(ev, isupper?1:-1))
-        @test full(imag(T)) == imag(diagm(dv)) + imag(diagm(ev, isupper?1:-1))
+        @test full(imag.(T)) == imag.(diagm(dv)) + imag.(diagm(ev, isupper?1:-1))
         z = zeros(elty, n)
 
         debug && println("Idempotent tests")

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -29,7 +29,7 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
 
     @test full(real(D)) == real(DM)
     @test full(abs.(D)) == abs.(DM)
-    @test full(imag(D)) == imag(DM)
+    @test full(imag.(D)) == imag.(DM)
 
     @test parent(D) == d
     @test diag(D) == d

--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -36,7 +36,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, Int)
         f   = schurfact(a)
         @test f[:vectors]*f[:Schur]*f[:vectors]' ≈ a
         @test sort(real(f[:values])) ≈ sort(real(d))
-        @test sort(imag(f[:values])) ≈ sort(imag(d))
+        @test sort(imag.(f[:values])) ≈ sort(imag.(d))
         @test istriu(f[:Schur]) || eltype(a)<:Real
         @test full(f) ≈ a
         @test_throws KeyError f[:A]

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -143,7 +143,7 @@ for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloa
 
         # real
         @test full(real(A1)) == real(full(A1))
-        @test full(imag(A1)) == imag(full(A1))
+        @test full(imag.(A1)) == imag.(full(A1))
         @test full(abs.(A1)) == abs.(full(A1))
 
         # Unary operations

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -51,10 +51,10 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
 
     @test abs.(T) == Tridiagonal(abs.(dl),abs.(d),abs.(du))
     @test real(T) == Tridiagonal(real(dl),real(d),real(du))
-    @test imag(T) == Tridiagonal(imag(dl),imag(d),imag(du))
+    @test imag.(T) == Tridiagonal(imag.(dl),imag.(d),imag.(du))
     @test abs.(Ts) == SymTridiagonal(abs.(d),abs.(dl))
     @test real(Ts) == SymTridiagonal(real(d),real(dl))
-    @test imag(Ts) == SymTridiagonal(imag(d),imag(dl))
+    @test imag.(Ts) == SymTridiagonal(imag.(d),imag.(dl))
 
     # test interconversion of Tridiagonal and SymTridiagonal
     @test Tridiagonal(dl, d, dl) == SymTridiagonal(d, dl)


### PR DESCRIPTION
This PR deprecates all remaining vectorized `imag` methods (apart from those for `SparseVector`s, separate PR) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, #18558, and #18564. Best!

(Unlike with `float`, `real`, etc., the remaining vectorized `imag` methods never alias their input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
