### PR TITLE
Deprecate vectorized methods for trigonometric and hyperbolic functions in favor of compact broadcast syntax

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,4 +1168,11 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# Deprecate manually vectorized trigonometric and hyperbolic functions in favor of compact broadcast syntax
+for f in (:sec, :sech, :secd, :asec, :asech,
+            :csc, :csch, :cscd, :acsc, :acsch,
+            :cot, :coth, :cotd, :acot, :acoth)
+    @eval @deprecate $f{T<:Number}(A::AbstractArray{T}) $f.(A)
+end
+
 # End deprecations scheduled for 0.6

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -311,7 +311,6 @@ for (finv, f) in ((:sec, :cos), (:csc, :sin), (:cot, :tan),
                   (:secd, :cosd), (:cscd, :sind), (:cotd, :tand))
     @eval begin
         ($finv){T<:Number}(z::T) = one(T) / (($f)(z))
-        ($finv){T<:Number}(z::AbstractArray{T}) = one(T) ./ (($f)(z))
     end
 end
 
@@ -324,11 +323,9 @@ for (tfa, tfainv, hfa, hfainv, fn) in ((:asec, :acos, :asech, :acosh, "secant"),
         @doc """
             $($tname)(x)
         Compute the inverse $($fn) of `x`, where the output is in radians. """ ($tfa){T<:Number}(y::T) = ($tfainv)(one(T) / y)
-        ($tfa){T<:Number}(y::AbstractArray{T}) = ($tfainv)(one(T) ./ y)
         @doc """
             $($hname)(x)
         Compute the inverse hyperbolic $($fn) of `x`. """ ($hfa){T<:Number}(y::T) = ($hfainv)(one(T) / y)
-        ($hfa){T<:Number}(y::AbstractArray{T}) = ($hfainv)(one(T) ./ y)
     end
 end
 


### PR DESCRIPTION
This PR deprecates all (?) remaining vectorized methods for trigonometric and hyperbolic functions (less those for `SparseVector`s, separate PR) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, #18558, #18564, and #18566. Best!

(Unlike with `float`, `real`, etc., the remaining vectorized methods for trigonometic and hyperbolic functions never alias their input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
