### PR TITLE
Fix Tuple inference regression from #18467

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -245,7 +245,7 @@ isType(t::ANY) = isa(t,DataType) && is((t::DataType).name,Type.name)
 # true if Type is inlineable as constant
 isconstType(t::ANY,b::Bool) =
     isType(t) && !has_typevars(t.parameters[1],b) &&
-    !issubtype(Tuple{Vararg}, t.parameters[1])  # work around inference bug #18450
+    !issubtype(Type{Tuple{Vararg}}, t)  # work around inference bug #18450
 
 const IInf = typemax(Int) # integer infinity
 const n_ifunc = reinterpret(Int32,arraylen)+1

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -368,3 +368,6 @@ end
 # issue #18450
 f18450() = ifelse(true, Tuple{Vararg{Int}}, Tuple{Vararg})
 @test f18450() == Tuple{Vararg{Int}}
+
+# issue #18569
+@test Core.Inference.isconstType(Type{Tuple},true)


### PR DESCRIPTION
This fixes the `cat` regressions from #18467 (seen in #18569) on my machine. Haven't tested the other ones yet, but I suspect they will be similar. Could someone run nanosoldier?

I wasn't able to come up with a shorter test. I can remove the current one if it's a bad thing to test internal functions.

cc @tkelman @KristofferC @Sacha0 
