### PR TITLE
Re-tighten logical indexing bounds checks

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -375,18 +375,7 @@ function checkindex(::Type{Bool}, inds::AbstractUnitRange, r::Range)
     isempty(r) | (checkindex(Bool, inds, first(r)) & checkindex(Bool, inds, last(r)))
 end
 checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractVector{Bool}) = indx == indices1(I)
-# Logical indexing is an exception to the "output dimensionality is the sum of
-# the dimensionality of the indices" rule; `A[A.<0]` always returns a vector,
-# regardless of the dimensionalities of `A and `A.<0`. This method goes one step
-# further and ignores singleton dimensions for logical mask indices. While a
-# little strange, it enables idioms like `A[:, sum(A, 1) .< 0]`. Ref #18271.
-function checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractArray{Bool})
-    # Ensure that there's no more than one non-singleton dimension and that it
-    # matches the source array's index. Note that there's an ambiguity at length
-    # 1, since we cannot tell which dimension should be the non-singleton one.
-    @_inline_meta
-    length(indx) == prod(map(length, indices(I))) && any(x->x==indx, indices(I))
-end
+checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractArray{Bool}) = false
 function checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractArray)
     @_inline_meta
     b = true

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -82,10 +82,10 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, trues(5, 4, 3)) == true
 @test checkbounds(Bool, A, trues(5, 4, 2)) == false
 @test checkbounds(Bool, A, trues(5, 12)) == false
-@test checkbounds(Bool, A, trues(1, 5), trues(1, 4, 1), trues(1, 1, 3)) == true
+@test checkbounds(Bool, A, trues(1, 5), trues(1, 4, 1), trues(1, 1, 3)) == false
 @test checkbounds(Bool, A, trues(1, 5), trues(1, 4, 1), trues(1, 1, 2)) == false
 @test checkbounds(Bool, A, trues(1, 5), trues(1, 5, 1), trues(1, 1, 3)) == false
-@test checkbounds(Bool, A, trues(1, 5), :, 2) == true
+@test checkbounds(Bool, A, trues(1, 5), :, 2) == false
 
 # array of CartesianIndex
 @test checkbounds(Bool, A, [CartesianIndex((1, 1, 1))]) == true


### PR DESCRIPTION
If #18401 doesn't make it into 0.5, there's no point in keeping the change in behavior for 0.6.  As I said there, this behavior isn't where we want to end up anyways. It's not a straight reversion because the simplification is still a good change.
