### PR TITLE
Deprecate vectorized floor methods in favor of compact broadcast syntax

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,4 +1168,11 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# Deprecate manually vectorized floor methods in favor of compact broadcast syntax
+@deprecate floor(M::Bidiagonal) floor.(M)
+@deprecate floor(M::Tridiagonal) floor.(M)
+@deprecate floor(M::SymTridiagonal) floor.(M)
+@deprecate floor{T<:Integer}(::Type{T}, A::AbstractArray) floor.(T, A)
+@deprecate floor(A::AbstractArray, digits::Integer, base::Integer = 10) floor.(A, digits, base)
+
 # End deprecations scheduled for 0.6

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -112,7 +112,7 @@ function round(x::AbstractFloat, ::RoundingMode{:NearestTiesUp})
 end
 round{T<:Integer}(::Type{T}, x::AbstractFloat, r::RoundingMode) = trunc(T,round(x,r))
 
-for f in (:trunc,:floor,:ceil,:round)
+for f in (:trunc,:ceil,:round)
     @eval begin
         function ($f){T,R}(::Type{T}, x::AbstractArray{R,1})
             [ ($f)(T, y)::T for y in x ]

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -253,10 +253,12 @@ end
 
 #Elementary operations
 broadcast(::typeof(abs), M::Bidiagonal) = Bidiagonal(abs.(M.dv), abs.(M.ev), abs.(M.isupper))
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
+broadcast(::typeof(floor), M::Bidiagonal) = Bidiagonal(floor.(M.dv), floor.(M.ev), M.isupper)
+for func in (:conj, :copy, :round, :trunc, :ceil, :real, :imag)
     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.isupper)
 end
-for func in (:round, :trunc, :floor, :ceil)
+broadcast{T<:Integer}(::typeof(floor), ::Type{T}, M::Bidiagonal) = Bidiagonal(floor.(T, M.dv), floor.(T, M.ev), M.isupper)
+for func in (:round, :trunc, :ceil)
     @eval ($func){T<:Integer}(::Type{T}, M::Bidiagonal) = Bidiagonal(($func)(T,M.dv), ($func)(T,M.ev), M.isupper)
 end
 

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -97,10 +97,12 @@ similar{T}(S::SymTridiagonal, ::Type{T}) = SymTridiagonal{T}(similar(S.dv, T), s
 
 #Elementary operations
 broadcast(::typeof(abs), M::SymTridiagonal) = SymTridiagonal(abs.(M.dv), abs.(M.ev))
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
+broadcast(::typeof(floor), M::SymTridiagonal) = SymTridiagonal(floor.(M.dv), floor.(M.ev))
+for func in (:conj, :copy, :round, :trunc, :ceil, :real, :imag)
     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
 end
-for func in (:round, :trunc, :floor, :ceil)
+broadcast{T<:Integer}(::typeof(floor), ::Type{T}, M::SymTridiagonal) = SymTridiagonal(floor.(T, M.dv), floor.(T, M.ev))
+for func in (:round, :trunc, :ceil)
     @eval ($func){T<:Integer}(::Type{T},M::SymTridiagonal) = SymTridiagonal(($func)(T,M.dv), ($func)(T,M.ev))
 end
 transpose(M::SymTridiagonal) = M #Identity operation
@@ -464,12 +466,15 @@ copy!(dest::Tridiagonal, src::Tridiagonal) = Tridiagonal(copy!(dest.dl, src.dl),
 
 #Elementary operations
 broadcast(::typeof(abs), M::Tridiagonal) = Tridiagonal(abs.(M.dl), abs.(M.d), abs.(M.du), abs.(M.du2))
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
+broadcast(::typeof(floor), M::Tridiagonal) = Tridiagonal(floor.(M.dl), floor.(M.d), floor.(M.du), floor.(M.du2))
+for func in (:conj, :copy, :round, :trunc, :ceil, :real, :imag)
     @eval function ($func)(M::Tridiagonal)
         Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du), ($func)(M.du2))
     end
 end
-for func in (:round, :trunc, :floor, :ceil)
+broadcast{T<:Integer}(::typeof(floor), ::Type{T}, M::Tridiagonal) =
+    Tridiagonal(floor.(T, M.dl), floor.(T, M.d), floor.(T, M.du), floor.(T, M.du2))
+for func in (:round, :trunc, :ceil)
     @eval function ($func){T<:Integer}(::Type{T},M::Tridiagonal)
         Tridiagonal(($func)(T,M.dl), ($func)(T,M.d), ($func)(T,M.du), ($func)(T,M.du2))
     end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2277,7 +2277,6 @@ conj!(A::SparseMatrixCSC) = (broadcast!(conj, A.nzval, A.nzval); A)
 
 # TODO: The following definitions should be deprecated.
 ceil{To}(::Type{To}, A::SparseMatrixCSC) = ceil.(To, A)
-floor{To}(::Type{To}, A::SparseMatrixCSC) = floor.(To, A)
 trunc{To}(::Type{To}, A::SparseMatrixCSC) = trunc.(To, A)
 round{To}(::Type{To}, A::SparseMatrixCSC) = round.(To, A)
 

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -160,8 +160,8 @@ srand(1)
 
         @testset "Round,float,trunc,ceil" begin
             if elty <: BlasReal
-                @test floor(Int,T) == Bidiagonal(floor(Int,T.dv),floor(Int,T.ev),T.isupper)
-                @test isa(floor(Int,T), Bidiagonal)
+                @test floor.(Int, T) == Bidiagonal(floor.(Int, T.dv), floor.(Int, T.ev), T.isupper)
+                @test isa(floor.(Int, T), Bidiagonal)
                 @test trunc(Int,T) == Bidiagonal(trunc(Int,T.dv),trunc(Int,T.ev),T.isupper)
                 @test isa(trunc(Int,T), Bidiagonal)
                 @test round(Int,T) == Bidiagonal(round(Int,T.dv),round(Int,T.ev),T.isupper)

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -278,8 +278,8 @@ let n = 12 #Size of matrix problem to test
             @test isa(trunc(Int,A), SymTridiagonal)
             @test ceil(Int,A) == ceil(Int,fA)
             @test isa(ceil(Int,A), SymTridiagonal)
-            @test floor(Int,A) == floor(Int,fA)
-            @test isa(floor(Int,A), SymTridiagonal)
+            @test floor.(Int,A) == floor.(Int,fA)
+            @test isa(floor.(Int,A), SymTridiagonal)
         end
 
         debug && println("Tridiagonal/SymTridiagonal mixing ops")
@@ -396,8 +396,8 @@ let n = 12 #Size of matrix problem to test
             @test isa(trunc(Int,A), Tridiagonal)
             @test ceil(Int,A) == ceil(Int,fA)
             @test isa(ceil(Int,A), Tridiagonal)
-            @test floor(Int,A) == floor(Int,fA)
-            @test isa(floor(Int,A), Tridiagonal)
+            @test floor.(Int,A) == floor.(Int,fA)
+            @test isa(floor.(Int,A), Tridiagonal)
         end
 
         debug && println("Binary operations")

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2026,7 +2026,7 @@ x = 0.0
 @test approx_eq(round(pi,3,5), 3.144)
 # vectorized trunc/round/floor/ceil with digits/base argument
 a = rand(2, 2, 2)
-for f in (trunc, round, floor, ceil)
+for f in (trunc, round, ceil)
     @test f(a[:, 1, 1], 2) == map(x->f(x, 2), a[:, 1, 1])
     @test f(a[:, :, 1], 2) == map(x->f(x, 2), a[:, :, 1])
     @test f(a, 9, 2) == map(x->f(x, 9, 2), a)
@@ -2034,6 +2034,14 @@ for f in (trunc, round, floor, ceil)
     @test f(a[:, :, 1], 9, 2) == map(x->f(x, 9, 2), a[:, :, 1])
     @test f(a, 9, 2) == map(x->f(x, 9, 2), a)
  end
+for f in (floor,)
+    @test f.(a[:, 1, 1], 2) == map(x->f(x, 2), a[:, 1, 1])
+    @test f.(a[:, :, 1], 2) == map(x->f(x, 2), a[:, :, 1])
+    @test f.(a, 9, 2) == map(x->f(x, 9, 2), a)
+    @test f.(a[:, 1, 1], 9, 2) == map(x->f(x, 9, 2), a[:, 1, 1])
+    @test f.(a[:, :, 1], 9, 2) == map(x->f(x, 9, 2), a[:, :, 1])
+    @test f.(a, 9, 2) == map(x->f(x, 9, 2), a)
+end
 # significant digits (would be nice to have a smart vectorized
 # version of signif)
 @test approx_eq(signif(123.456,1), 100.)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -500,7 +500,7 @@ end
     @test cos.(Afull) == Array(cos.(A))
     # Test representatives of remaining vectorized-nonbroadcast unary functions
     @test ceil(Int, Afull) == Array(ceil(Int, A))
-    @test floor(Int, Afull) == Array(floor(Int, A))
+    @test floor.(Int, Afull) == Array(floor.(Int, A))
     # Tests of real, imag, abs, and abs2 for SparseMatrixCSC{Int,X}s previously elsewhere
     for T in (Int, Float16, Float32, Float64, BigInt, BigFloat)
         R = rand(T[1:100;], 2, 2)


### PR DESCRIPTION
This PR deprecates all remaining vectorized `floor` methods (less those for SparseVectors, separate PR) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, #18558, #18564, #18566, #18571 and #18575. Best!

(Unlike with `float`, `real`, etc., the remaining vectorized `floor` methods never alias their input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
