### PR TITLE
Deprecate vectorized ceil methods in favor of compact broadcast syntax

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,4 +1168,11 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# Deprecate manually vectorized ceil methods in favor of compact broadcast syntax
+@deprecate ceil(M::Bidiagonal) ceil.(M)
+@deprecate ceil(M::Tridiagonal) ceil.(M)
+@deprecate ceil(M::SymTridiagonal) ceil.(M)
+@deprecate ceil{T<:Integer}(::Type{T}, x::AbstractArray) ceil.(T, x)
+@deprecate ceil(x::AbstractArray, digits::Integer, base::Integer = 10) ceil.(x, digits, base)
+
 # End deprecations scheduled for 0.6

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -112,7 +112,7 @@ function round(x::AbstractFloat, ::RoundingMode{:NearestTiesUp})
 end
 round{T<:Integer}(::Type{T}, x::AbstractFloat, r::RoundingMode) = trunc(T,round(x,r))
 
-for f in (:trunc,:floor,:ceil,:round)
+for f in (:trunc,:floor,:round)
     @eval begin
         function ($f){T,R}(::Type{T}, x::AbstractArray{R,1})
             [ ($f)(T, y)::T for y in x ]

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -253,10 +253,12 @@ end
 
 #Elementary operations
 broadcast(::typeof(abs), M::Bidiagonal) = Bidiagonal(abs.(M.dv), abs.(M.ev), abs.(M.isupper))
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
+broadcast(::typeof(ceil), M::Bidiagonal) = Bidiagonal(ceil.(M.dv), ceil.(M.ev), M.isupper)
+for func in (:conj, :copy, :round, :trunc, :floor, :real, :imag)
     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.isupper)
 end
-for func in (:round, :trunc, :floor, :ceil)
+broadcast{T<:Integer}(::typeof(ceil), ::Type{T}, M::Bidiagonal) = Bidiagonal(ceil.(T, M.dv), ceil.(T, M.ev), M.isupper)
+for func in (:round, :trunc, :floor)
     @eval ($func){T<:Integer}(::Type{T}, M::Bidiagonal) = Bidiagonal(($func)(T,M.dv), ($func)(T,M.ev), M.isupper)
 end
 

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -97,10 +97,12 @@ similar{T}(S::SymTridiagonal, ::Type{T}) = SymTridiagonal{T}(similar(S.dv, T), s
 
 #Elementary operations
 broadcast(::typeof(abs), M::SymTridiagonal) = SymTridiagonal(abs.(M.dv), abs.(M.ev))
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
+broadcast(::typeof(ceil), M::SymTridiagonal) = SymTridiagonal(ceil.(M.dv), ceil.(M.ev))
+for func in (:conj, :copy, :round, :trunc, :floor, :real, :imag)
     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
 end
-for func in (:round, :trunc, :floor, :ceil)
+broadcast{T<:Integer}(::typeof(ceil), ::Type{T}, M::SymTridiagonal) = SymTridiagonal(ceil.(T, M.dv), ceil.(T, M.ev))
+for func in (:round, :trunc, :floor)
     @eval ($func){T<:Integer}(::Type{T},M::SymTridiagonal) = SymTridiagonal(($func)(T,M.dv), ($func)(T,M.ev))
 end
 transpose(M::SymTridiagonal) = M #Identity operation
@@ -464,12 +466,15 @@ copy!(dest::Tridiagonal, src::Tridiagonal) = Tridiagonal(copy!(dest.dl, src.dl),
 
 #Elementary operations
 broadcast(::typeof(abs), M::Tridiagonal) = Tridiagonal(abs.(M.dl), abs.(M.d), abs.(M.du), abs.(M.du2))
-for func in (:conj, :copy, :round, :trunc, :floor, :ceil, :real, :imag)
+broadcast(::typeof(ceil), M::Tridiagonal) = Tridiagonal(ceil.(M.dl), ceil.(M.d), ceil.(M.du), ceil.(M.du2))
+for func in (:conj, :copy, :round, :trunc, :floor, :real, :imag)
     @eval function ($func)(M::Tridiagonal)
         Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du), ($func)(M.du2))
     end
 end
-for func in (:round, :trunc, :floor, :ceil)
+broadcast{T<:Integer}(::typeof(ceil), ::Type{T}, M::Tridiagonal) =
+    Tridiagonal(ceil.(T, M.dl), ceil.(T, M.d), ceil.(T, M.du), ceil.(T, M.du2))
+for func in (:round, :trunc, :floor)
     @eval function ($func){T<:Integer}(::Type{T},M::Tridiagonal)
         Tridiagonal(($func)(T,M.dl), ($func)(T,M.d), ($func)(T,M.du), ($func)(T,M.du2))
     end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2276,7 +2276,6 @@ conj!(A::SparseMatrixCSC) = (broadcast!(conj, A.nzval, A.nzval); A)
 (-)(A::SparseMatrixCSC) = SparseMatrixCSC(A.m, A.n, copy(A.colptr), copy(A.rowval), map(-, A.nzval))
 
 # TODO: The following definitions should be deprecated.
-ceil{To}(::Type{To}, A::SparseMatrixCSC) = ceil.(To, A)
 floor{To}(::Type{To}, A::SparseMatrixCSC) = floor.(To, A)
 trunc{To}(::Type{To}, A::SparseMatrixCSC) = trunc.(To, A)
 round{To}(::Type{To}, A::SparseMatrixCSC) = round.(To, A)

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -166,8 +166,8 @@ srand(1)
                 @test isa(trunc(Int,T), Bidiagonal)
                 @test round(Int,T) == Bidiagonal(round(Int,T.dv),round(Int,T.ev),T.isupper)
                 @test isa(round(Int,T), Bidiagonal)
-                @test ceil(Int,T) == Bidiagonal(ceil(Int,T.dv),ceil(Int,T.ev),T.isupper)
-                @test isa(ceil(Int,T), Bidiagonal)
+                @test ceil.(Int,T) == Bidiagonal(ceil.(Int,T.dv), ceil.(Int,T.ev), T.isupper)
+                @test isa(ceil.(Int,T), Bidiagonal)
             end
         end
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -276,8 +276,8 @@ let n = 12 #Size of matrix problem to test
             @test isa(round(Int,A), SymTridiagonal)
             @test trunc(Int,A) == trunc(Int,fA)
             @test isa(trunc(Int,A), SymTridiagonal)
-            @test ceil(Int,A) == ceil(Int,fA)
-            @test isa(ceil(Int,A), SymTridiagonal)
+            @test ceil.(Int,A) == ceil.(Int,fA)
+            @test isa(ceil.(Int,A), SymTridiagonal)
             @test floor(Int,A) == floor(Int,fA)
             @test isa(floor(Int,A), SymTridiagonal)
         end
@@ -394,8 +394,8 @@ let n = 12 #Size of matrix problem to test
             @test isa(round(Int,A), Tridiagonal)
             @test trunc(Int,A) == trunc(Int,fA)
             @test isa(trunc(Int,A), Tridiagonal)
-            @test ceil(Int,A) == ceil(Int,fA)
-            @test isa(ceil(Int,A), Tridiagonal)
+            @test ceil.(Int,A) == ceil.(Int,fA)
+            @test isa(ceil.(Int,A), Tridiagonal)
             @test floor(Int,A) == floor(Int,fA)
             @test isa(floor(Int,A), Tridiagonal)
         end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2026,14 +2026,22 @@ x = 0.0
 @test approx_eq(round(pi,3,5), 3.144)
 # vectorized trunc/round/floor/ceil with digits/base argument
 a = rand(2, 2, 2)
-for f in (trunc, round, floor, ceil)
+for f in (trunc, round, floor)
     @test f(a[:, 1, 1], 2) == map(x->f(x, 2), a[:, 1, 1])
     @test f(a[:, :, 1], 2) == map(x->f(x, 2), a[:, :, 1])
     @test f(a, 9, 2) == map(x->f(x, 9, 2), a)
     @test f(a[:, 1, 1], 9, 2) == map(x->f(x, 9, 2), a[:, 1, 1])
     @test f(a[:, :, 1], 9, 2) == map(x->f(x, 9, 2), a[:, :, 1])
     @test f(a, 9, 2) == map(x->f(x, 9, 2), a)
- end
+end
+for f in (ceil,)
+    @test f.(a[:, 1, 1], 2) == map(x->f(x, 2), a[:, 1, 1])
+    @test f.(a[:, :, 1], 2) == map(x->f(x, 2), a[:, :, 1])
+    @test f.(a, 9, 2) == map(x->f(x, 9, 2), a)
+    @test f.(a[:, 1, 1], 9, 2) == map(x->f(x, 9, 2), a[:, 1, 1])
+    @test f.(a[:, :, 1], 9, 2) == map(x->f(x, 9, 2), a[:, :, 1])
+    @test f.(a, 9, 2) == map(x->f(x, 9, 2), a)
+end
 # significant digits (would be nice to have a smart vectorized
 # version of signif)
 @test approx_eq(signif(123.456,1), 100.)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -499,7 +499,7 @@ end
     # Test representatives of [unary functions that map both zeros and nonzeros to nonzeros]
     @test cos.(Afull) == Array(cos.(A))
     # Test representatives of remaining vectorized-nonbroadcast unary functions
-    @test ceil(Int, Afull) == Array(ceil(Int, A))
+    @test ceil.(Int, Afull) == Array(ceil.(Int, A))
     @test floor(Int, Afull) == Array(floor(Int, A))
     # Tests of real, imag, abs, and abs2 for SparseMatrixCSC{Int,X}s previously elsewhere
     for T in (Int, Float16, Float32, Float64, BigInt, BigFloat)
@@ -1437,7 +1437,7 @@ end
 # test sparse matrix norms
 Ac = sprandn(10,10,.1) + im* sprandn(10,10,.1)
 Ar = sprandn(10,10,.1)
-Ai = ceil(Int,Ar*100)
+Ai = ceil.(Int,Ar*100)
 @test norm(Ac,1) ≈ norm(Array(Ac),1)
 @test norm(Ac,Inf) ≈ norm(Array(Ac),Inf)
 @test vecnorm(Ac) ≈ vecnorm(Array(Ac))
@@ -1478,9 +1478,9 @@ end
 
 # test sparse matrix normestinv
 Ac = sprandn(20,20,.5) + im* sprandn(20,20,.5)
-Aci = ceil(Int64,100*sprand(20,20,.5))+ im*ceil(Int64,sprand(20,20,.5))
+Aci = ceil.(Int64,100*sprand(20,20,.5))+ im*ceil.(Int64,sprand(20,20,.5))
 Ar = sprandn(20,20,.5)
-Ari = ceil(Int64,100*Ar)
+Ari = ceil.(Int64,100*Ar)
 if Base.USE_GPL_LIBS
     @test_approx_eq_eps Base.SparseArrays.normestinv(Ac,3) norm(inv(Array(Ac)),1) 1e-4
     @test_approx_eq_eps Base.SparseArrays.normestinv(Aci,3) norm(inv(Array(Aci)),1) 1e-4


### PR DESCRIPTION
This PR deprecates all remaining vectorized `ceil` methods (less those for SparseVectors, separate PR) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, #18558, #18564, #18566, #18571 #18575, and #18576. Best!

(Unlike with `float`, `real`, etc., the remaining vectorized `ceil` methods never alias their input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
