### PR TITLE
Add power binaries to prepare_release.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,7 @@ script:
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
     - cd `dirname $TRAVIS_BUILD_DIR` && mv julia2 julia &&
-        rm -rf julia/deps/scratch/julia-env
+        rm -rf julia/deps/scratch/julia-env &&
+        rm -f julia/deps/scratch/libgit2-*/CMakeFiles/CMakeOutput.log
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg

--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -43,6 +43,9 @@ cp julia-$version-linux-i686.tar.gz julia-$majmin-latest-linux-i686.tar.gz
 curl -L -o julia-$version-linux-arm.tar.gz \
   $julianightlies/linux/arm/$majmin/julia-$majminpatch-$shashort-linuxarm.tar.gz
 cp julia-$version-linux-arm.tar.gz julia-$majmin-latest-linux-arm.tar.gz
+curl -L -o julia-$version-linux-ppc64le.tar.gz \
+  $julianightlies/linux/ppc64le/$majmin/julia-$majminpatch-$shashort-linuxppc64.tar.gz
+cp julia-$version-linux-ppc64le.tar.gz julia-$majmin-latest-linux-ppc64le.tar.gz
 curl -L -o "julia-$version-osx10.7 .dmg" \
   $julianightlies/osx/x64/$majmin/julia-$majminpatch-$shashort-osx.dmg
 cp "julia-$version-osx10.7 .dmg" "julia-$majmin-latest-osx10.7 .dmg"
@@ -64,6 +67,7 @@ gpg -u julia --armor --detach-sig julia-$version.tar.gz
 gpg -u julia --armor --detach-sig julia-$version-linux-x86_64.tar.gz
 gpg -u julia --armor --detach-sig julia-$version-linux-i686.tar.gz
 gpg -u julia --armor --detach-sig julia-$version-linux-arm.tar.gz
+gpg -u julia --armor --detach-sig julia-$version-linux-ppc64le.tar.gz
 
 echo "All files prepared. Attach julia-$version.tar.gz and julia-$version-full.tar.gz"
 echo "to github releases, upload all binaries and checksums to julialang S3. Be sure"


### PR DESCRIPTION
and delete a file on travis that keeps changing, making each pr update a redundant copy of the cache

(travis timed out https://gist.github.com/6cf533cf6c4372e7928c57064a44aa8d, restarted)
