### PR TITLE
simplify entry points to type inference

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -575,14 +575,10 @@ function code_typed(f::ANY, types::ANY=Tuple; optimize=true)
     end
     types = to_tuple_type(types)
     asts = []
-    for x in _methods(f,types,-1)
+    for x in _methods(f, types, -1)
         meth = func_for_method_checked(x[3], types)
-        if optimize
-            (code, ty, inf) = Core.Inference.typeinf(meth, x[1], x[2], true)
-        else
-            (code, ty, inf) = Core.Inference.typeinf_uncached(meth, x[1], x[2], optimize=false)
-        end
-        inf || error("inference not successful") # Inference disabled
+        (code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, !optimize)
+        code === nothing && error("inference not successful") # Inference disabled?
         push!(asts, uncompressed_ast(meth, code) => ty)
     end
     return asts
@@ -595,10 +591,10 @@ function return_types(f::ANY, types::ANY=Tuple)
     end
     types = to_tuple_type(types)
     rt = []
-    for x in _methods(f,types,-1)
+    for x in _methods(f, types, -1)
         meth = func_for_method_checked(x[3], types)
-        (code, ty, inf) = Core.Inference.typeinf(meth, x[1], x[2])
-        inf || error("inference not successful") # Inference disabled
+        ty = Core.Inference.typeinf_type(meth, x[1], x[2])
+        ty === nothing && error("inference not successful") # Inference disabled?
         push!(rt, ty)
     end
     return rt

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4193,7 +4193,7 @@ static std::unique_ptr<Module> emit_function(jl_method_instance_t *lam, jl_code_
 #endif
 
 #ifdef USE_POLLY
-    if (!jl_has_meta(code, polly_sym) || jl_options.polly == JL_OPTIONS_POLLY_OFF) {
+    if (!jl_has_meta(stmts, polly_sym) || jl_options.polly == JL_OPTIONS_POLLY_OFF) {
         f->addFnAttr(polly::PollySkipFnAttr);
     }
 #endif

--- a/src/dump.c
+++ b/src/dump.c
@@ -676,6 +676,7 @@ static void jl_serialize_module(jl_serializer_state *s, jl_module_t *m)
 
 static int is_ast_node(jl_value_t *v)
 {
+    // TODO: this accidentally copies QuoteNode(Expr(...)) and QuoteNode(svec(...))
     return jl_is_symbol(v) || jl_is_slot(v) || jl_is_ssavalue(v) ||
         jl_is_expr(v) || jl_is_newvarnode(v) || jl_is_svec(v) || jl_is_tuple(v) ||
         jl_is_uniontype(v) || jl_is_int32(v) || jl_is_int64(v) ||

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3946,7 +3946,7 @@ void jl_init_types(void)
                                 jl_any_type, // void*
                                 jl_any_type, // void*
                                 jl_any_type, jl_any_type), // void*, void*
-                        0, 1, 4);
+                        0, 1, 3);
 
     jl_typector_type =
         jl_new_datatype(jl_symbol("TypeConstructor"),

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -2,6 +2,10 @@
 
 #include <llvm/Config/llvm-config.h>
 
+#ifndef LLVM_VERSION_PATCH // for LLVM 3.3
+#define LLVM_VERSION_PATCH 0
+#endif
+
 // The LLVM version used, JL_LLVM_VERSION, is represented as a 5-digit integer
 // of the form ABBCC, where A is the major version, B is minor, and C is patch.
 // So for example, LLVM 3.7.0 is 30700.


### PR DESCRIPTION
this breaks up the typeinf_edge function into its subcomponents,
allowing callers to exercise only the pieces they care about
rather than returning all possible values the caller might care
about in a Tuple

also fixes missing test-and-lock-and-test for threaded inference

(backporting from https://github.com/JuliaLang/julia/pull/17057 WIP)
