### PR TITLE
Deprecate vectorized mod methods in favor of compact broadcast syntax

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -66,7 +66,7 @@ promote_array_type{S<:Integer}(::typeof(/), ::Type{S}, ::Type{Bool}, T::Type) = 
 promote_array_type{S<:Integer}(::typeof(\), ::Type{S}, ::Type{Bool}, T::Type) = T
 promote_array_type{S<:Integer}(F, ::Type{S}, ::Type{Bool}, T::Type) = T
 
-for f in (:+, :-, :div, :mod, :&, :|, :xor)
+for f in (:+, :-, :div, :&, :|, :xor)
     @eval ($f)(A::AbstractArray, B::AbstractArray) =
         _elementwise($f, promote_eltype_op($f, A, B), A, B)
 end
@@ -89,7 +89,7 @@ function _elementwise{T}(op, ::Type{T}, A::AbstractArray, B::AbstractArray)
     return F
 end
 
-for f in (:div, :mod, :rem, :&, :|, :xor, :/, :\, :*, :+, :-)
+for f in (:div, :rem, :&, :|, :xor, :/, :\, :*, :+, :-)
     if f != :/
         @eval function ($f){T}(A::Number, B::AbstractArray{T})
             R = promote_op($f, typeof(A), T)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1257,27 +1257,7 @@ function div(x::Number, B::BitArray)
     return fill(y, size(B))
 end
 
-function mod(A::BitArray, B::BitArray)
-    shp = promote_shape(size(A), size(B))
-    all(B) || throw(DivideError())
-    return falses(shp)
-end
-mod(A::BitArray, B::Array{Bool}) = mod(A, BitArray(B))
-mod(A::Array{Bool}, B::BitArray) = mod(BitArray(A), B)
-function mod(B::BitArray, x::Bool)
-    return x ? falses(size(B)) : throw(DivideError())
-end
-function mod(x::Bool, B::BitArray)
-    all(B) || throw(DivideError())
-    return falses(size(B))
-end
-function mod(x::Number, B::BitArray)
-    all(B) || throw(DivideError())
-    y = mod(x, true)
-    return fill(y, size(B))
-end
-
-for f in (:div, :mod)
+for f in (:div,)
     @eval begin
         function ($f)(B::BitArray, x::Number)
             T = promote_op($f, Bool, typeof(x))

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,4 +1168,11 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# Deprecate manually vectorized mod methods in favor of compact broadcast syntax
+@deprecate mod(B::BitArray, x::Bool) mod.(B, x)
+@deprecate mod(x::Bool, B::BitArray) mod.(x, B)
+@deprecate mod(A::AbstractArray, B::AbstractArray) mod.(A, B)
+@deprecate mod{T}(x::Number, A::AbstractArray{T}) mod.(x, A)
+@deprecate mod{T}(A::AbstractArray{T}, x::Number) mod.(A, x)
+
 # End deprecations scheduled for 0.6


### PR DESCRIPTION
This PR deprecates (almost) all remaining vectorized `mod` methods (less those for SparseVectors and one related to dates, separate PRs) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, #18558, #18564, #18566, #18571 #18575, #18576, #18586, and #18590. Best!

Edit: Added a couple questions for reviewers via comments in the code.

(Unlike with `float`, `real`, etc., the remaining vectorized `mod` methods never alias their input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
