### PR TITLE
detect errors in generated function declarations early

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1047,9 +1047,10 @@ the order that the first of each set of equivalent elements originally appears.
 If `dim` is specified, returns unique regions of the array `itr` along `dim`.
 """
 @generated function unique{T,N}(A::AbstractArray{T,N}, dim::Int)
+    inds = inds -> zeros(UInt, inds)
     quote
         1 <= dim <= $N || return copy(A)
-        hashes = similar(inds->zeros(UInt, inds), indices(A, dim))
+        hashes = similar($inds, indices(A, dim))
 
         # Compute hash for each row
         k = 0

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -324,8 +324,6 @@ jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
 jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded);
-jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex,
-                                     int delay_warn);
 
 jl_code_info_t *jl_wrap_expr(jl_value_t *expr);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);

--- a/test/core.jl
+++ b/test/core.jl
@@ -4578,3 +4578,12 @@ end
 fVararg(x) = Vararg{x}
 gVararg(a::fVararg(Int)) = length(a)
 @test gVararg(1,2,3,4,5) == 5
+
+# issue #18577
+@generated f18577() = quote ()->1 end
+@test try
+    f18577()
+    false
+catch e
+    (e::ErrorException).msg
+end == "generated function body is not pure. this likely means it contains a closure or comprehension."

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -156,7 +156,7 @@ end
 @generated function _g_f_with_inner(x)
     :(y->y)
 end
-@test (_g_f_with_inner(1))(8) == 8
+@test_throws ErrorException _g_f_with_inner(1)
 
 # @generated functions errors
 global gf_err_ref = Ref{Int}()


### PR DESCRIPTION
this would have detected #18577 before it was merged
