### PR TITLE
Deprecate vectorized div methods in favor of compact broadcast syntax

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -66,7 +66,7 @@ promote_array_type{S<:Integer}(::typeof(/), ::Type{S}, ::Type{Bool}, T::Type) = 
 promote_array_type{S<:Integer}(::typeof(\), ::Type{S}, ::Type{Bool}, T::Type) = T
 promote_array_type{S<:Integer}(F, ::Type{S}, ::Type{Bool}, T::Type) = T
 
-for f in (:+, :-, :div, :mod, :&, :|, :xor)
+for f in (:+, :-, :mod, :&, :|, :xor)
     @eval ($f)(A::AbstractArray, B::AbstractArray) =
         _elementwise($f, promote_eltype_op($f, A, B), A, B)
 end
@@ -89,7 +89,7 @@ function _elementwise{T}(op, ::Type{T}, A::AbstractArray, B::AbstractArray)
     return F
 end
 
-for f in (:div, :mod, :rem, :&, :|, :xor, :/, :\, :*, :+, :-)
+for f in (:mod, :rem, :&, :|, :xor, :/, :\, :*, :+, :-)
     if f != :/
         @eval function ($f){T}(A::Number, B::AbstractArray{T})
             R = promote_op($f, typeof(A), T)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1237,26 +1237,6 @@ end
 (/)(B::BitArray, x::Number) = (/)(Array(B), x)
 (/)(x::Number, B::BitArray) = (/)(x, Array(B))
 
-function div(A::BitArray, B::BitArray)
-    shp = promote_shape(size(A), size(B))
-    all(B) || throw(DivideError())
-    return reshape(copy(A), shp)
-end
-div(A::BitArray, B::Array{Bool}) = div(A, BitArray(B))
-div(A::Array{Bool}, B::BitArray) = div(BitArray(A), B)
-function div(B::BitArray, x::Bool)
-    return x ? copy(B) : throw(DivideError())
-end
-function div(x::Bool, B::BitArray)
-    all(B) || throw(DivideError())
-    return x ? trues(size(B)) : falses(size(B))
-end
-function div(x::Number, B::BitArray)
-    all(B) || throw(DivideError())
-    y = div(x, true)
-    return fill(y, size(B))
-end
-
 function mod(A::BitArray, B::BitArray)
     shp = promote_shape(size(A), size(B))
     all(B) || throw(DivideError())
@@ -1277,7 +1257,7 @@ function mod(x::Number, B::BitArray)
     return fill(y, size(B))
 end
 
-for f in (:div, :mod)
+for f in (:mod,)
     @eval begin
         function ($f)(B::BitArray, x::Number)
             T = promote_op($f, Bool, typeof(x))

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,4 +1168,9 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# Deprecate manually vectorized div methods in favor of compact broadcast syntax
+@deprecate div(A::Number, B::AbstractArray) div.(A, B)
+@deprecate div(A::AbstractArray, B::Number) div.(A, B)
+@deprecate div(A::AbstractArray, B::AbstractArray) div.(A, B)
+
 # End deprecations scheduled for 0.6

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -354,7 +354,7 @@ plan_irfft
 
 export fftshift, ifftshift
 
-fftshift(x) = circshift(x, div([size(x)...],2))
+fftshift(x) = circshift(x, div.([size(x)...],2))
 
 """
     fftshift(x)
@@ -376,7 +376,7 @@ Swap the first and second halves of the given dimension of array `x`.
 """
 fftshift(x,dim)
 
-ifftshift(x) = circshift(x, div([size(x)...],-2))
+ifftshift(x) = circshift(x, div.([size(x)...],-2))
 
 """
     ifftshift(x, [dim])


### PR DESCRIPTION
This PR deprecates (almost) all remaining vectorized `div` methods (less a couple related to dates, separate PR) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, #18558, #18564, #18566, #18571 #18575, #18576, #18586, #18590, and #18593. Best!

(Unlike with `float`, `real`, etc., the remaining vectorized `div` methods never alias their input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
