### PR TITLE
Deprecate vectorized rem methods in favor of compact broadcast syntax

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -89,7 +89,7 @@ function _elementwise{T}(op, ::Type{T}, A::AbstractArray, B::AbstractArray)
     return F
 end
 
-for f in (:div, :mod, :rem, :&, :|, :xor, :/, :\, :*, :+, :-)
+for f in (:div, :mod, :&, :|, :xor, :/, :\, :*, :+, :-)
     if f != :/
         @eval function ($f){T}(A::Number, B::AbstractArray{T})
             R = promote_op($f, typeof(A), T)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,4 +1168,8 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# Deprecate manually vectorized rem methods in favor of compact broadcast syntax
+@deprecate rem(A::Number, B::AbstractArray) rem.(A, B)
+@deprecate rem(A::AbstractArray, B::Number) rem.(A, B)
+
 # End deprecations scheduled for 0.6


### PR DESCRIPTION
This PR deprecates (almost) all remaining vectorized `rem` methods (less a couple related to dates, separate PR) in favor of compact broadcast syntax. Ref. #16285, #17302, #18495, #18512, #18513, #18558, #18564, #18566, #18571 #18575, #18576, #18586, #18590, #18593, and #18607. Best!

(Unlike with `float`, `real`, etc., the remaining vectorized `rem` methods never alias their input. This PR should be less controversial than #18495, #18512, and #18513 as a result.)
