### PR TITLE
Improve promotion for constructors...

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -224,7 +224,16 @@ if isdefined(Core, :Inference)
         G = Tuple{Generator{Tuple{T},typeof(op)}}
         return Core.Inference.return_type(first, G)
     end
+    function _promote_op{op}(::Type{op}, T::ANY)
+        G = Tuple{Generator{Tuple{T},Type{op}}}
+        return Core.Inference.return_type(first, G)
+    end
     function _promote_op(op, R::ANY, S::ANY)
+        F = typeof(a -> op(a...))
+        G = Tuple{Generator{Zip2{Tuple{R},Tuple{S}},F}}
+        return Core.Inference.return_type(first, G)
+    end
+    function _promote_op{op}(::Type{op}, R::ANY, S::ANY)
         F = typeof(a -> op(a...))
         G = Tuple{Generator{Zip2{Tuple{R},Tuple{S}},F}}
         return Core.Inference.return_type(first, G)
@@ -235,8 +244,6 @@ end
 _default_type(T::Type) = (@_pure_meta; T)
 
 promote_op(::Any...) = (@_pure_meta; Any)
-promote_op(T::Type, ::Any) = (@_pure_meta; T)
-promote_op(T::Type, ::Type) = (@_pure_meta; T) # To handle ambiguities
 # Promotion that tries to preserve non-concrete types
 function promote_op{S}(f, ::Type{S})
     T = _promote_op(f, _default_type(S))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -337,3 +337,15 @@ end
 @test broadcast(+, 1.0, (0, -2.0)) == (1.0,-1.0)
 @test broadcast(+, 1.0, (0, -2.0), [1]) == [2.0, 0.0]
 @test broadcast(*, ["Hello"], ", ", ["World"], "!") == ["Hello, World!"]
+
+# Ensure that even strange constructors that break `T(x)::T` work with broadcast
+immutable StrangeType18623 end
+StrangeType18623(x) = x
+StrangeType18623(x,y) = (x,y)
+@test @inferred broadcast(StrangeType18623, 1:3) == [1,2,3]
+@test @inferred broadcast(StrangeType18623, 1:3, 4:6) == [(1,4),(2,5),(3,6)]
+
+@test typeof(Int.(Number[1, 2, 3])) === typeof((x->Int(x)).(Number[1, 2, 3]))
+
+@test @inferred broadcast(CartesianIndex, 1:2) == [CartesianIndex(1), CartesianIndex(2)]
+@test @inferred broadcast(CartesianIndex, 1:2,3:4) == [CartesianIndex(1,3), CartesianIndex(2,4)]


### PR DESCRIPTION
by enabling `Type{}` specialization in the `promote_op` methods that request return information from Inference. Notably, this makes constructors behave in exactly the same manner as normal functions... even in cases where that behavior may be controversial:

``` jl
julia> Int.(Number[1,2])
2-element Array{Number,1}:
 1
 2

julia> (x->Int(x)).(Number[1,2])
2-element Array{Number,1}:
 1
 2
```
