### PR TITLE
Export AbstractSet.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -27,6 +27,7 @@ export
 # Types
     AbstractChannel,
     AbstractMatrix,
+    AbstractSet,
     AbstractUnitRange,
     AbstractVector,
     AbstractVecOrMat,


### PR DESCRIPTION
The discussion in https://github.com/JuliaLang/julia/issues/5533 led to the PR in https://github.com/JuliaLang/julia/pull/12816 where `AbstractSet` was added. I think it would only be appropriate to export `AbstractSet`. It was brought up at https://github.com/JuliaML/LearnBase.jl/pull/11, and also in https://github.com/JuliaLang/julia/pull/12816#issuecomment-226680647.
