### PR TITLE
make print_with_color not default to bold take 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,12 @@ Library improvements
     For example, to get orange warning messages, simply set `ENV["JULIA_WARN_COLOR"] = 208`.
     Please note that not all terminals support 256 colors.
 
+  * The function `print_with_color` no longer prints text in bold by default ([#18628]).
+    Instead, the function now take a keyword argument `bold::Bool` which determines whether to print in bold or not.
+    On some terminals, printing a color in non bold results in slightly darker colors being printed than when printing in bold.
+    Therefore, light versions of the colors are now supported.
+    For the available colors see the help entry on `print_with_color`.
+
   * The default color for info messages has been changed from blue to cyan ([#18442]).
     This can be changed back to the original color by setting the environment variable `JULIA_INFO_COLOR` to `"blue"`.
     One way of doing this is by adding `ENV["JULIA_INFO_COLOR"] = :blue` to the `.juliarc.jl` file.
@@ -719,6 +725,7 @@ Language tooling improvements
 [#18473]: https://github.com/JuliaLang/julia/issues/18473
 [#18644]: https://github.com/JuliaLang/julia/issues/18644
 [#18690]: https://github.com/JuliaLang/julia/issues/18690
+[#18628]: https://github.com/JuliaLang/julia/issues/18628
 [#18839]: https://github.com/JuliaLang/julia/issues/18839
 [#18931]: https://github.com/JuliaLang/julia/issues/18931
 [#18977]: https://github.com/JuliaLang/julia/issues/18977

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -629,6 +629,7 @@ function write_prompt(terminal, p::Prompt)
     prefix = isa(p.prompt_prefix,Function) ? p.prompt_prefix() : p.prompt_prefix
     suffix = isa(p.prompt_suffix,Function) ? p.prompt_suffix() : p.prompt_suffix
     write(terminal, prefix)
+    write(terminal, Base.text_colors[:bold])
     write(terminal, p.prompt)
     write(terminal, Base.text_colors[:normal])
     write(terminal, suffix)

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -111,7 +111,7 @@ function ip_matches_func(ip, func::Symbol)
 end
 
 function display_error(io::IO, er, bt)
-    Base.with_output_color(:red, io) do io
+    Base.with_output_color(Base.error_color(), io) do io
         print(io, "ERROR: ")
         # remove REPL-related frames from interactive printing
         eval_ind = findlast(addr->ip_matches_func(addr, :eval), bt)

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -111,8 +111,8 @@ function ip_matches_func(ip, func::Symbol)
 end
 
 function display_error(io::IO, er, bt)
+    print_with_color(Base.error_color(), io, "ERROR: "; bold = true)
     Base.with_output_color(Base.error_color(), io) do io
-        print(io, "ERROR: ")
         # remove REPL-related frames from interactive printing
         eval_ind = findlast(addr->ip_matches_func(addr, :eval), bt)
         if eval_ind != 0

--- a/base/client.jl
+++ b/base/client.jl
@@ -40,6 +40,7 @@ text_colors
 
 have_color = false
 default_color_warn = :red
+default_color_error = :red
 default_color_info = :cyan
 if is_windows()
     default_color_input = :normal
@@ -57,6 +58,7 @@ function repl_color(key, default)
     haskey(text_colors, c_conv) ? c_conv : default
 end
 
+error_color() = repl_color("JULIA_ERROR_COLOR", default_color_error)
 warn_color()   = repl_color("JULIA_WARN_COLOR", default_color_warn)
 info_color()   = repl_color("JULIA_INFO_COLOR", default_color_info)
 input_color()  = text_colors[repl_color("JULIA_INPUT_COLOR", default_color_input)]
@@ -101,7 +103,7 @@ end
 
 display_error(er) = display_error(er, [])
 function display_error(er, bt)
-    with_output_color(:red, STDERR) do io
+    with_output_color(Base.error_color(), STDERR) do io
         print(io, "ERROR: ")
         showerror(io, er, bt)
         println(io)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -174,7 +174,7 @@ function status(io::IO, pkg::AbstractString, ver::VersionNumber, fix::Bool)
             LibGit2.isdirty(prepo) && push!(attrs,"dirty")
             isempty(attrs) || print(io, " (",join(attrs,", "),")")
         catch err
-            print_with_color(:red, io, " broken-repo (unregistered)")
+            print_with_color(Base.error_color(), io, " broken-repo (unregistered)")
         finally
             finalize(prepo)
         end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -462,7 +462,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                 t_in === Union{} && special && i == 1 && break
                 if t_in === Union{}
                     if Base.have_color
-                        Base.with_output_color(:red, buf) do buf
+                        Base.with_output_color(Base.error_color(), buf) do buf
                             print(buf, "::$sigstr")
                         end
                     else
@@ -503,7 +503,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                             print(buf, ", ")
                         end
                         if Base.have_color
-                            Base.with_output_color(:red, buf) do buf
+                            Base.with_output_color(Base.error_color(), buf) do buf
                                 print(buf, "::$sigstr")
                             end
                         else
@@ -529,7 +529,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                         end
                     end
                     if !isempty(unexpected)
-                        Base.with_output_color(:red, buf) do buf
+                        Base.with_output_color(Base.error_color(), buf) do buf
                             plur = length(unexpected) > 1 ? "s" : ""
                             print(buf, " got unsupported keyword argument$plur \"", join(unexpected, "\", \""), "\"")
                         end

--- a/base/show.jl
+++ b/base/show.jl
@@ -527,7 +527,7 @@ function show_expr_type(io::IO, ty, emph)
     end
 end
 
-emphasize(io, str::AbstractString) = have_color ? print_with_color(Base.error_color(), io, str) : print(io, uppercase(str))
+emphasize(io, str::AbstractString) = have_color ? print_with_color(Base.error_color(), io, str; bold = true) : print(io, uppercase(str))
 
 show_linenumber(io::IO, line)       = print(io," # line ",line,':')
 show_linenumber(io::IO, line, file) = print(io," # ", file,", line ",line,':')

--- a/base/show.jl
+++ b/base/show.jl
@@ -527,7 +527,7 @@ function show_expr_type(io::IO, ty, emph)
     end
 end
 
-emphasize(io, str::AbstractString) = have_color ? print_with_color(:red, io, str) : print(io, uppercase(str))
+emphasize(io, str::AbstractString) = have_color ? print_with_color(Base.error_color(), io, str) : print(io, uppercase(str))
 
 show_linenumber(io::IO, line)       = print(io," # line ",line,':')
 show_linenumber(io::IO, line, file) = print(io," # ", file,", line ",line,':')

--- a/base/task.jl
+++ b/base/task.jl
@@ -222,7 +222,7 @@ function task_done_hook(t::Task)
         if !suppress_excp_printing(t)
             let bt = t.backtrace
                 # run a new task to print the error for us
-                @schedule with_output_color(:red, STDERR) do io
+                @schedule with_output_color(Base.error_color(), STDERR) do io
                     print(io, "ERROR (unhandled task failure): ")
                     showerror(io, result, bt)
                     println(io)

--- a/base/test.jl
+++ b/base/test.jl
@@ -70,7 +70,7 @@ type Fail <: Result
     value
 end
 function Base.show(io::IO, t::Fail)
-    print_with_color(:light_red, io, "Test Failed\n"; bold = true)
+    print_with_color(Base.error_color(), io, "Test Failed\n"; bold = true)
     print(io, "  Expression: ", t.orig_expr)
     if t.test_type == :test_throws_wrong
         # An exception was thrown, but it was of the wrong type
@@ -102,7 +102,7 @@ type Error <: Result
     backtrace
 end
 function Base.show(io::IO, t::Error)
-    print_with_color(:light_red, io, "Error During Test\n"; bold = true)
+    print_with_color(Base.error_color(), io, "Error During Test\n"; bold = true)
     if t.test_type == :test_nonbool
         println(io, "  Expression evaluated to non-Boolean")
         println(io, "  Expression: ", t.orig_expr)
@@ -483,16 +483,16 @@ function print_test_results(ts::DefaultTestSet, depth_pad=0)
         print_with_color(:green, lpad("Pass",pass_width," "), "  "; bold = true)
     end
     if fail_width > 0
-        print_with_color(:light_red, lpad("Fail",fail_width," "), "  "; bold = true)
+        print_with_color(Base.error_color(), lpad("Fail",fail_width," "), "  "; bold = true)
     end
     if error_width > 0
-        print_with_color(:light_red, lpad("Error",error_width," "), "  "; bold = true)
+        print_with_color(Base.error_color(), lpad("Error",error_width," "), "  "; bold = true)
     end
     if broken_width > 0
         print_with_color(:yellow, lpad("Broken",broken_width," "), "  "; bold = true)
     end
     if total_width > 0
-        print_with_color(:blue, lpad("Total",total_width, " "); bold = true)
+        print_with_color(Base.info_color(), lpad("Total",total_width, " "); bold = true)
     end
     println()
     # Recursively print a summary at every level
@@ -595,7 +595,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     np = passes + c_passes
     if np > 0
-        print_with_color(:green, lpad(string(np), pass_width, " "), "  "; bold = true)
+        print_with_color(:green, lpad(string(np), pass_width, " "), "  ")
     elseif pass_width > 0
         # No passes at this level, but some at another level
         print(lpad(" ", pass_width), "  ")
@@ -603,7 +603,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     nf = fails + c_fails
     if nf > 0
-        print_with_color(:light_red, lpad(string(nf), fail_width, " "), "  "; bold = true)
+        print_with_color(Base.error_color(), lpad(string(nf), fail_width, " "), "  ")
     elseif fail_width > 0
         # No fails at this level, but some at another level
         print(lpad(" ", fail_width), "  ")
@@ -611,7 +611,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     ne = errors + c_errors
     if ne > 0
-        print_with_color(:light_red, lpad(string(ne), error_width, " "), "  "; bold = true)
+        print_with_color(Base.error_color(), lpad(string(ne), error_width, " "), "  ")
     elseif error_width > 0
         # No errors at this level, but some at another level
         print(lpad(" ", error_width), "  ")
@@ -619,16 +619,16 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     nb = broken + c_broken
     if nb > 0
-        print_with_color(:yellow, lpad(string(nb), broken_width, " "), "  "; bold = true)
+        print_with_color(:yellow, lpad(string(nb), broken_width, " "), "  ")
     elseif broken_width > 0
         # None broken at this level, but some at another level
         print(lpad(" ", broken_width), "  ")
     end
 
     if np == 0 && nf == 0 && ne == 0 && nb == 0
-        print_with_color(:blue, "No tests"; bold = true)
+        print_with_color(Base.info_color(), "No tests")
     else
-        print_with_color(:blue, lpad(string(subtotal), total_width, " "); bold = true)
+        print_with_color(Base.info_color(), lpad(string(subtotal), total_width, " "))
     end
     println()
 

--- a/base/test.jl
+++ b/base/test.jl
@@ -43,7 +43,7 @@ immutable Pass <: Result
     value
 end
 function Base.show(io::IO, t::Pass)
-    print_with_color(:green, io, "Test Passed\n")
+    print_with_color(:green, io, "Test Passed\n"; bold = true)
     if !(t.orig_expr === nothing)
         print(io, "  Expression: ", t.orig_expr)
     end
@@ -70,7 +70,7 @@ type Fail <: Result
     value
 end
 function Base.show(io::IO, t::Fail)
-    print_with_color(:red, io, "Test Failed\n")
+    print_with_color(:light_red, io, "Test Failed\n"; bold = true)
     print(io, "  Expression: ", t.orig_expr)
     if t.test_type == :test_throws_wrong
         # An exception was thrown, but it was of the wrong type
@@ -102,7 +102,7 @@ type Error <: Result
     backtrace
 end
 function Base.show(io::IO, t::Error)
-    print_with_color(:red, io, "Error During Test\n")
+    print_with_color(:light_red, io, "Error During Test\n"; bold = true)
     if t.test_type == :test_nonbool
         println(io, "  Expression evaluated to non-Boolean")
         println(io, "  Expression: ", t.orig_expr)
@@ -140,7 +140,7 @@ type Broken <: Result
     orig_expr
 end
 function Base.show(io::IO, t::Broken)
-    print_with_color(:yellow, io, "Test Broken\n")
+    print_with_color(:yellow, io, "Test Broken\n"; bold = true)
     if t.test_type == :skipped && !(t.orig_expr === nothing)
         println(io, "  Skipped: ", t.orig_expr)
     elseif !(t.orig_expr === nothing)
@@ -478,21 +478,21 @@ function print_test_results(ts::DefaultTestSet, depth_pad=0)
     # recursively walking the tree of test sets
     align = max(get_alignment(ts, 0), length("Test Summary:"))
     # Print the outer test set header once
-    print_with_color(:white, rpad("Test Summary:",align," "), " | ")
+    print_with_color(:white, rpad("Test Summary:",align," "), " | "; bold = true)
     if pass_width > 0
-        print_with_color(:green, lpad("Pass",pass_width," "), "  ")
+        print_with_color(:green, lpad("Pass",pass_width," "), "  "; bold = true)
     end
     if fail_width > 0
-        print_with_color(:red, lpad("Fail",fail_width," "), "  ")
+        print_with_color(:light_red, lpad("Fail",fail_width," "), "  "; bold = true)
     end
     if error_width > 0
-        print_with_color(:red, lpad("Error",error_width," "), "  ")
+        print_with_color(:light_red, lpad("Error",error_width," "), "  "; bold = true)
     end
     if broken_width > 0
-        print_with_color(:yellow, lpad("Broken",broken_width," "), "  ")
+        print_with_color(:yellow, lpad("Broken",broken_width," "), "  "; bold = true)
     end
     if total_width > 0
-        print_with_color(:blue, lpad("Total",total_width, " "))
+        print_with_color(:blue, lpad("Total",total_width, " "); bold = true)
     end
     println()
     # Recursively print a summary at every level
@@ -595,7 +595,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     np = passes + c_passes
     if np > 0
-        print_with_color(:green, lpad(string(np), pass_width, " "), "  ")
+        print_with_color(:green, lpad(string(np), pass_width, " "), "  "; bold = true)
     elseif pass_width > 0
         # No passes at this level, but some at another level
         print(lpad(" ", pass_width), "  ")
@@ -603,7 +603,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     nf = fails + c_fails
     if nf > 0
-        print_with_color(:red, lpad(string(nf), fail_width, " "), "  ")
+        print_with_color(:light_red, lpad(string(nf), fail_width, " "), "  "; bold = true)
     elseif fail_width > 0
         # No fails at this level, but some at another level
         print(lpad(" ", fail_width), "  ")
@@ -611,7 +611,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     ne = errors + c_errors
     if ne > 0
-        print_with_color(:red, lpad(string(ne), error_width, " "), "  ")
+        print_with_color(:light_red, lpad(string(ne), error_width, " "), "  "; bold = true)
     elseif error_width > 0
         # No errors at this level, but some at another level
         print(lpad(" ", error_width), "  ")
@@ -619,16 +619,16 @@ function print_counts(ts::DefaultTestSet, depth, align,
 
     nb = broken + c_broken
     if nb > 0
-        print_with_color(:yellow, lpad(string(nb), broken_width, " "), "  ")
+        print_with_color(:yellow, lpad(string(nb), broken_width, " "), "  "; bold = true)
     elseif broken_width > 0
         # None broken at this level, but some at another level
         print(lpad(" ", broken_width), "  ")
     end
 
     if np == 0 && nf == 0 && ne == 0 && nb == 0
-        print_with_color(:blue, "No tests")
+        print_with_color(:blue, "No tests"; bold = true)
     else
-        print_with_color(:blue, lpad(string(subtotal), total_width, " "))
+        print_with_color(:blue, lpad(string(subtotal), total_width, " "); bold = true)
     end
     println()
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -303,34 +303,38 @@ end
 
 ## printing with color ##
 
-function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args...)
+function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args...; bold::Bool = false)
     buf = IOBuffer()
+    have_color && bold && print(buf, text_colors[:bold])
     have_color && print(buf, get(text_colors, color, color_normal))
     try f(IOContext(buf, io), args...)
     finally
-        have_color && print(buf, color_normal)
+        have_color && print(buf, get(disable_text_style, color, text_colors[:default]))
+        have_color && (bold || color == :bold) && print(buf, disable_text_style[:bold])
         print(io, String(take!(buf)))
     end
 end
 
 """
-    print_with_color(color::Union{Symbol, Int}, [io], strings...)
+    print_with_color(color::Union{Symbol, Int}, [io], strings...; bold::Bool = false)
 
 Print strings in a color specified as a symbol.
 
 `color` may take any of the values $(Base.available_text_colors_docstring)
 or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
+If the keyword `bold` is given as `true`, the result will be printed in bold.
 """
-print_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...) =
-    with_output_color(print, color, io, msg...)
-print_with_color(color::Union{Int, Symbol}, msg::AbstractString...) =
-    print_with_color(color, STDOUT, msg...)
-println_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...) =
-    with_output_color(println, color, io, msg...)
-println_with_color(color::Union{Int, Symbol}, msg::AbstractString...) =
-    println_with_color(color, STDOUT, msg...)
+print_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...; bold::Bool = false) =
+    with_output_color(print, color, io, msg...; bold = bold)
+print_with_color(color::Union{Int, Symbol}, msg::AbstractString...; bold::Bool = false) =
+    print_with_color(color, STDOUT, msg...; bold = bold)
+println_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...; bold::Bool = false) =
+    with_output_color(println, color, io, msg...; bold = bold)
+println_with_color(color::Union{Int, Symbol}, msg::AbstractString...; bold::Bool = false) =
+    println_with_color(color, STDOUT, msg...; bold = bold)
 
 ## warnings and messages ##
+
 
 """
     info(msg...; prefix="INFO: ")
@@ -349,7 +353,8 @@ MY INFO: hello world
 ```
 """
 function info(io::IO, msg...; prefix="INFO: ")
-    println_with_color(info_color(), io, prefix, chomp(string(msg...)))
+    print_with_color(info_color(), io, prefix; bold = true)
+    println_with_color(info_color(), io, chomp(string(msg...)))
 end
 info(msg...; prefix="INFO: ") = info(STDERR, msg..., prefix=prefix)
 
@@ -371,7 +376,8 @@ function warn(io::IO, msg...;
         (key in have_warned) && return
         push!(have_warned, key)
     end
-    print_with_color(warn_color(), io, prefix, str)
+    print_with_color(warn_color(), io, prefix; bold = true)
+    print_with_color(warn_color(), io, str)
     if bt !== nothing
         show_backtrace(io, bt)
     end

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -310,18 +310,21 @@ end
 atreplinit(customize_colors)
 ```
 
-The available color keys in `Base.text_colors` are `:black`, `:red`, `:green`, `:yellow`, `:blue`,
-`:magenta`, `:cyan`, `:white`, `:normal`, and `:bold` as well as the integers 0 to 255 for terminals
-with 256 color support. Similarly, you can change the colors for the help and shell prompts and
+The available color keys can be seen by typing `Base.text_colors` in the help mode of the REPL.
+In addition, the integers 0 to 255 can be used as color keys for terminals
+with 256 color support.
+
+You can also change the colors for the help and shell prompts and
 input and answer text by setting the appropriate field of `repl` in the `customize_colors` function
 above (respectively, `help_color`, `shell_color`, `input_color`, and `answer_color`). For the
 latter two, be sure that the `envcolors` field is also set to false.
 
-You can also customize the color used to render warning and informational messages by setting
-the appropriate environment variable. For instance, to render warning messages in yellow and informational
-messages in cyan you can add the following to your `juliarc.jl` file:
+You can also customize the color used to render warning and informational messages by
+setting the appropriate environment variables. For instance, to render error, warning, and informational
+messages respectively in magenta, yellow, and cyan you can add the following to your `juliarc.jl` file:
 
 ```julia
+ENV["JULIA_ERROR_COLOR"] = :magenta
 ENV["JULIA_WARN_COLOR"] = :yellow
 ENV["JULIA_INFO_COLOR"] = :cyan
 ```

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -483,3 +483,20 @@ let
     end
     @test c_18711 == 1
 end
+
+let
+    old_have_color = Base.have_color
+    try
+        eval(Base, :(have_color = true))
+        buf = IOBuffer()
+        print_with_color(:red, buf, "foo")
+        # Check that we get back to normal text color in the end
+        @test String(take!(buf)) == "\e[31mfoo\e[39m"
+
+        # Check that boldness is turned off
+        print_with_color(:red, buf, "foo"; bold = true)
+        @test String(take!(buf)) == "\e[1m\e[31mfoo\e[39m\e[22m"
+    finally
+        eval(Base, :(have_color = $(old_have_color)))
+    end
+end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -67,7 +67,7 @@ end
 pos_stable(x) = x > 0 ? x : zero(x)
 pos_unstable(x) = x > 0 ? x : 0
 
-tag = Base.have_color ? Base.text_colors[:red] : "UNION"
+tag = Base.have_color ? Base.error_color() : "UNION"
 @test warntype_hastag(pos_unstable, Tuple{Float64}, tag)
 @test !warntype_hastag(pos_stable, Tuple{Float64}, tag)
 
@@ -80,13 +80,13 @@ end
 Base.getindex(A::Stable, i) = A.A[i]
 Base.getindex(A::Unstable, i) = A.A[i]
 
-tag = Base.have_color ? Base.text_colors[:red] : "ARRAY{FLOAT64,N}"
+tag = Base.have_color ? Base.error_color() : "ARRAY{FLOAT64,N}"
 @test warntype_hastag(getindex, Tuple{Unstable{Float64},Int}, tag)
 @test !warntype_hastag(getindex, Tuple{Stable{Float64,2},Int}, tag)
 @test warntype_hastag(getindex, Tuple{Stable{Float64},Int}, tag)
 
 # Make sure emphasis is not used for other functions
-tag = Base.have_color ? Base.text_colors[:red] : "ANY"
+tag = Base.have_color ? Base.error_color() : "ANY"
 iob = IOBuffer()
 show(iob, expand(:(x->x^2)))
 str = String(take!(iob))


### PR DESCRIPTION
This is take 2 of #18480.
- First commit introduces an ENV var for changing the color errors are printed in.
- Second commit remove the default boldness in `print_with_color`. Instead a kwarg `bold` is added which determines if the result should be printed in bold. For backwards compatability, the `:bold` key is still left in the `text_colors` dict. This also sets the default color for errors and warnings to `light_red` instead of `red` because on most terminals this is the color it used to be when printing `red` + `bold`. This is also the reason for the first commit because for example Jupyter notebook does not support the light versions of the color so `IJulia` can if it wants set the ENV variable to just be `red`. Edit: However, 16 color support in notebook is merged, just not in release: https://github.com/jupyter/notebook/pull/1230
- Third commit hooks up the test framework to use corresponding ENV variables in a few places. The reason for this is that the blue used is not very visible on many terminals (same problem as with the previous info messages) and it is good to keep the users chosen "colorscheme".

Note, this is not meant to change any input color / boldness, output color / boldness, repl color / boldness etc and not change any of the possible settings that are available now. 

![image](https://cloud.githubusercontent.com/assets/1282691/18747086/8a0ad0a2-80cb-11e6-8d3f-680a71febcb0.png)
