### PR TITLE
Support unsafe_trunc(T, ::Integer)

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -327,6 +327,8 @@ rem{T<:Integer}(x::T, ::Type{T}) = x
 rem(x::Integer, ::Type{Bool}) = ((x&1)!=0)
 mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)
 
+unsafe_trunc{T<:Integer}(::Type{T}, x::Integer) = rem(x, T)
+
 convert{Tf<:Union{Float32,Float64}}(T::BitSigned64T, x::Tf) =
     box(T,checked_fptosi(T,unbox(Tf,x)))
 convert{Tf<:Union{Float32,Float64}}(T::BitUnsigned64T, x::Tf) =

--- a/test/int.jl
+++ b/test/int.jl
@@ -195,3 +195,9 @@ end
 @test true << 2 === 1 << 2
 @test true >> 2 === 1 >> 2
 @test true >>> 2 === 1 >>> 2
+
+@test @inferred(unsafe_trunc(Int8, 127)) === Int8(127)
+@test unsafe_trunc(Int8, 128) === Int8(-128)
+@test unsafe_trunc(Int8, -127) === Int8(-127)
+@test unsafe_trunc(Int8, -128) === Int8(-128)
+@test unsafe_trunc(Int8, -129) === Int8(127)


### PR DESCRIPTION
The input types supported by `unsafe_trunc` and `rem` are currently disjoint:

``` julia
julia> unsafe_trunc(Int32, 3.2)
3

julia> 3.2 % Int32
ERROR: MethodError: no method matching rem(::Float64, ::Type{Int32})
Closest candidates are:
  rem(::Bool, ::Type{Int32}) at int.jl:221
  rem(::Int16, ::Type{Int32}) at int.jl:218
  rem(::Int64, ::Type{Int32}) at int.jl:208
  ...

julia> unsafe_trunc(Int32, 3)
ERROR: MethodError: no method matching unsafe_trunc(::Type{Int32}, ::Int64)
Closest candidates are:
  unsafe_trunc(::Type{Int32}, ::Float32) at float.jl:159
  unsafe_trunc(::Type{Int32}, ::Float64) at float.jl:160
  unsafe_trunc{T<:Integer}(::Type{T<:Integer}, ::BigFloat) at mpfr.jl:130

julia> 3 % Int32
3
```

I'm not sure this is a bug, but it seems a bit inconvenient. Since `trunc(Int32, 3)` works, I thought it would be best to define `unsafe_trunc` for integer inputs.
