### PR TITLE
WIP/RFC unbox more immutables

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -26,8 +26,10 @@ end
 
 asize_from(a::Array, n) = n > ndims(a) ? () : (arraysize(a,n), asize_from(a, n+1)...)
 
+is_stored_unboxed(T) = isleaftype(T) && !T.mutable
+
 length(a::Array) = arraylen(a)
-elsize{T}(a::Array{T}) = isbits(T) ? sizeof(T) : sizeof(Ptr)
+elsize{T}(a::Array{T}) = is_stored_unboxed(T) ? sizeof(T) : sizeof(Ptr)
 sizeof(a::Array) = elsize(a) * length(a)
 
 function isassigned{T}(a::Array{T}, i::Int...)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -209,7 +209,12 @@ immutable OutOfMemoryError   <: Exception end
 immutable ReadOnlyMemoryError<: Exception end
 immutable SegmentationFault  <: Exception end
 immutable StackOverflowError <: Exception end
-immutable UndefRefError      <: Exception end
+immutable UndefRefError      <: Exception
+    a::Any
+    i::Any
+    UndefRefError() = new()
+end
+const empty_undefref_error = UndefRefError()
 immutable UndefVarError      <: Exception
     var::Symbol
 end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -183,7 +183,7 @@ if is(Int,Int64)
 else
     typealias UInt UInt32
 end
-
+abstract ValueType
 abstract AbstractString
 
 function Typeof end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1175,7 +1175,7 @@ function abstract_eval(e::ANY, vtypes::VarTable, sv::InferenceState)
         t = abstract_eval_call(e, vtypes, sv)
     elseif is(e.head,:null)
         t = Void
-    elseif is(e.head,:new)
+    elseif is(e.head,:new) || is(e.head,:stack_new)
         t = abstract_eval(e.args[1], vtypes, sv)
         if isType(t)
             t = t.parameters[1]
@@ -2316,7 +2316,7 @@ function effect_free(e::ANY, src::CodeInfo, mod::Module, allow_volatile::Bool)
             else
                 return false
             end
-        elseif head === :new
+        elseif head === :new || head === :stack_new
             if !allow_volatile
                 a = ea[1]
                 typ = widenconst(exprtype(a, src, mod))
@@ -3597,7 +3597,7 @@ function is_allocation(e::ANY, sv::InferenceState)
     isa(e, Expr) || return false
     if is_known_call(e, tuple, sv.src, sv.mod)
         return (length(e.args)-1,())
-    elseif e.head === :new
+    elseif e.head === :new || e.head === :stack_new
         typ = widenconst(exprtype(e, sv.src, sv.mod))
         if isleaftype(typ)
             @assert(isa(typ,DataType))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -165,6 +165,7 @@ object_id(x::ANY) = ccall(:jl_object_id, UInt, (Any,), x)
 
 immutable DataTypeLayout
     nfields::UInt32
+    npointers::UInt32
     alignment::UInt32
     # alignment : 28;
     # haspadding : 1;

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -246,7 +246,18 @@ function showerror(io::IO, ex::SystemError)
 end
 showerror(io::IO, ::DivideError) = print(io, "DivideError: integer division error")
 showerror(io::IO, ::StackOverflowError) = print(io, "StackOverflowError:")
-showerror(io::IO, ::UndefRefError) = print(io, "UndefRefError: access to undefined reference")
+function showerror(io::IO, e::UndefRefError)
+    print(io, "UndefRefError: ")
+    if isdefined(e, :a)
+        if isa(e.a, Array)
+            print(io, "access to undefined element ", e.i, " of ", summary(e.a))
+        else
+            print(io, "access to undefined field `", fieldname(typeof(e.a), e.i), "` of ", e.a)
+        end
+    else
+        print(io, "access to undefined reference")
+    end
+end
 showerror(io::IO, ::EOFError) = print(io, "EOFError: read end of file")
 showerror(io::IO, ex::ErrorException) = print(io, ex.msg)
 showerror(io::IO, ex::KeyError) = print(io, "KeyError: key $(repr(ex.key)) not found")

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -68,6 +68,7 @@ JL_DLLEXPORT jl_value_t *jl_inexact_exception;
 JL_DLLEXPORT jl_value_t *jl_undefref_exception;
 jl_value_t *jl_interrupt_exception;
 jl_datatype_t *jl_boundserror_type;
+jl_datatype_t *jl_undefreferror_type;
 jl_value_t *jl_memory_exception;
 jl_value_t *jl_readonlymemory_exception;
 union jl_typemap_t jl_cfunction_list;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -103,6 +103,7 @@ jl_sym_t *inert_sym; jl_sym_t *vararg_sym;
 jl_sym_t *unused_sym; jl_sym_t *static_parameter_sym;
 jl_sym_t *polly_sym; jl_sym_t *inline_sym;
 jl_sym_t *propagate_inbounds_sym;
+jl_sym_t *stack_new_sym;
 
 typedef struct {
     int64_t a;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -890,9 +890,9 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t nfields,
             if (desc[i].size > max_size)
                 max_size = desc[i].size;
         }
-        jl_fielddesc8_t maxdesc8 = { 0, max_size, max_offset };
-        jl_fielddesc16_t maxdesc16 = { 0, max_size, max_offset };
-        jl_fielddesc32_t maxdesc32 = { 0, max_size, max_offset };
+        jl_fielddesc8_t maxdesc8 = { 0, 0, max_size, max_offset };
+        jl_fielddesc16_t maxdesc16 = { 0, 0, max_size, max_offset };
+        jl_fielddesc32_t maxdesc32 = { 0, 0, max_size, max_offset };
         if (maxdesc8.size != max_size || maxdesc8.offset != max_offset) {
             fielddesc_type = 1;
             if (maxdesc16.size != max_size || maxdesc16.offset != max_offset) {
@@ -923,18 +923,21 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t nfields,
             desc8[i].offset = desc[i].offset;
             desc8[i].size = desc[i].size;
             desc8[i].isptr = desc[i].isptr;
+            desc8[i].hasptr = desc[i].hasptr;
         }
         else if (fielddesc_type == 1) {
             desc16[i].offset = desc[i].offset;
             desc16[i].size = desc[i].size;
             desc16[i].isptr = desc[i].isptr;
+            desc16[i].hasptr = desc[i].hasptr;
         }
         else {
             desc32[i].offset = desc[i].offset;
             desc32[i].size = desc[i].size;
             desc32[i].isptr = desc[i].isptr;
+            desc32[i].hasptr = desc[i].hasptr;
         }
-        if (desc[i].isptr)
+        if (desc[i].isptr || desc[i].hasptr)
             ptrfree = 0;
     }
     flddesc->pointerfree = ptrfree;
@@ -1010,6 +1013,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
                 jl_throw(jl_overflow_exception);
             al = ((jl_datatype_t*)ty)->layout->alignment;
             desc[i].isptr = 0;
+            desc[i].hasptr = !((jl_datatype_t*)ty)->layout->pointerfree;
             if (((jl_datatype_t*)ty)->layout->haspadding)
                 haspadding = 1;
         }
@@ -1019,6 +1023,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
                 fsz = MAX_ALIGN;
             al = fsz;
             desc[i].isptr = 1;
+            desc[i].hasptr = 0;
         }
         if (al != 0) {
             size_t alsz = LLT_ALIGN(sz, al);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -71,7 +71,6 @@ jl_datatype_t *jl_boundserror_type;
 jl_value_t *jl_memory_exception;
 jl_value_t *jl_readonlymemory_exception;
 union jl_typemap_t jl_cfunction_list;
-
 jl_sym_t *call_sym;    jl_sym_t *invoke_sym;
 jl_sym_t *dots_sym;    jl_sym_t *empty_sym;
 jl_sym_t *module_sym;  jl_sym_t *slot_sym;
@@ -1004,7 +1003,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
     for (size_t i = 0; i < nfields; i++) {
         jl_value_t *ty = jl_field_type(st, i);
         size_t fsz, al;
-        if (jl_isbits(ty) && jl_is_leaf_type(ty) && ((jl_datatype_t*)ty)->layout) {
+        if ((jl_isbits(ty) || jl_is_vt(ty)) && jl_is_leaf_type(ty) && ((jl_datatype_t*)ty)->layout) {
             fsz = jl_datatype_size(ty);
             // Should never happen
             if (__unlikely(fsz > max_size))

--- a/src/array.c
+++ b/src/array.c
@@ -25,7 +25,7 @@ extern "C" {
 static inline int store_unboxed(jl_value_t *el_type) // jl_isbits
 {
     return jl_is_leaf_type(el_type) && jl_is_immutable(el_type) &&
-        ((jl_datatype_t*)el_type)->layout && ((jl_datatype_t*)el_type)->layout->pointerfree;
+        ((jl_datatype_t*)el_type)->layout && (((jl_datatype_t*)el_type)->layout->pointerfree || jl_is_vt(el_type));
 }
 
 int jl_array_store_unboxed(jl_value_t *el_type)

--- a/src/array.c
+++ b/src/array.c
@@ -24,8 +24,7 @@ extern "C" {
 
 static inline int store_unboxed(jl_value_t *el_type) // jl_isbits
 {
-    return jl_is_leaf_type(el_type) && jl_is_immutable(el_type) &&
-        ((jl_datatype_t*)el_type)->layout && (((jl_datatype_t*)el_type)->layout->pointerfree || jl_is_vt(el_type));
+    return jl_is_leaf_type(el_type) && jl_is_unboxed(el_type);
 }
 
 int jl_array_store_unboxed(jl_value_t *el_type)

--- a/src/array.c
+++ b/src/array.c
@@ -548,8 +548,10 @@ JL_DLLEXPORT void jl_arrayset_nothrow(jl_array_t *a, jl_value_t *rhs, size_t i)
     assert(i < jl_array_len(a));
     if (!a->flags.ptrarray) {
         assert(rhs);
-        //TODO multiwb
         jl_assign_bits(&((char*)a->data)[i*a->elsize], rhs);
+        if (a->flags.hasptr) {
+            jl_gc_multi_wb(jl_array_owner(a), rhs);
+        }
     }
     else {
         ((jl_value_t**)a->data)[i] = rhs;

--- a/src/array.c
+++ b/src/array.c
@@ -498,8 +498,13 @@ JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
 {
     if (a->flags.ptrarray)
         return ((jl_value_t**)jl_array_data(a))[i] != NULL;
+    else if (a->flags.hasptr)
+        return value_isdefined(jl_tparam0(jl_typeof(a)),
+                               &((char*)a->data)[i*a->elsize]);
     return 1;
 }
+
+int value_isdefined(jl_datatype_t *st, char *v);
 
 int jl_array_isdefined(jl_value_t **args0, int nargs)
 {
@@ -533,9 +538,7 @@ int jl_array_isdefined(jl_value_t **args0, int nargs)
     if (i >= stride)
         return 0;
 
-    if (a->flags.ptrarray)
-        return ((jl_value_t**)jl_array_data(a))[i] != NULL;
-    return 1;
+    return jl_array_isassigned(a, i);
 }
 
 JL_DLLEXPORT void jl_arrayset_nothrow(jl_array_t *a, jl_value_t *rhs, size_t i)

--- a/src/array.c
+++ b/src/array.c
@@ -457,7 +457,7 @@ JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
 {
     jl_value_t *e = jl_arrayref_nothrow(a, i);
     if (e == NULL) {
-        jl_throw(jl_undefref_exception);
+        jl_undefref_error_int(a, i);
     }
     return e;
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -183,6 +183,27 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v, size_t *idxs, 
     jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
 }
 
+JL_DLLEXPORT void JL_NORETURN jl_undefref_error_unboxed_int(void *data, jl_value_t *vt, size_t field)
+{
+    // data is expected to be gc-safe (either gc-rooted, or alloca)
+    // vt is expected to be gc-rooted (in a linfo-root probably)
+    jl_value_t *v = NULL, *boxed = NULL;
+    JL_GC_PUSH2(&v, &boxed);
+    v = jl_new_bits(vt, data);
+    boxed = jl_box_long(field+1);
+    jl_throw(jl_new_struct((jl_datatype_t*)jl_undefreferror_type, v, boxed));
+}
+
+JL_DLLEXPORT void JL_NORETURN jl_undefref_error_int(jl_value_t *v, size_t field)
+{
+    jl_value_t *boxed = NULL;
+    JL_GC_PUSH2(&v, &boxed); // root arguments so the caller doesn't need to
+    boxed = jl_box_long(field+1);
+    jl_throw(jl_new_struct((jl_datatype_t*)jl_undefreferror_type, v, boxed));
+}
+
+
+
 JL_DLLEXPORT void JL_NORETURN jl_eof_error(void)
 {
     jl_datatype_t *eof_error =

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -732,7 +732,7 @@ JL_CALLABLE(jl_f_getfield)
     }
     jl_value_t *fval = jl_get_nth_field(v, idx);
     if (fval == NULL)
-        jl_throw(jl_undefref_exception);
+        jl_undefref_error_int(v, idx);
     return fval;
 }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -878,11 +878,11 @@ static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
     if (!isboxed) {
         emit_unbox(elty, rhs, jltype, addr);
         assert(jl_is_datatype(jltype));
-        jl_datatype_layout_t *ly = (jl_datatype_layout_t*)((jl_datatype_t*)jltype)->layout;
+        const jl_datatype_layout_t *ly = ((jl_datatype_t*)jltype)->layout;
         uint32_t npointers = ly->npointers;
         if (npointers > 0 && !rhs.constant && parent) {
             assert(rhs.ispointer());
-            uint32_t *pointers = jl_dt_layout_pointers(ly);
+            const uint32_t *pointers = jl_dt_layout_pointers(ly);
             Value **pointersV = (Value**)alloca(npointers * sizeof(Value*));
             Value *rhs_i8 = emit_bitcast(rhs.V, T_pint8);
             for (size_t i = 0; i < npointers; i++) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1696,8 +1696,12 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             Value *strct;
             if (init_as_value)
                 strct = UndefValue::get(lt == T_void ? NoopType : lt);
-            else
-                strct = emit_static_alloca(lt);
+            else {
+                if (sty->pointerfree)
+                    strct = emit_static_alloca(lt);
+                else
+                    strct = emit_static_alloca(lt, (jl_value_t*)sty, ctx);
+            }
 
             unsigned idx = 0;
             for (size_t i=0; i < na; i++) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -985,7 +985,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
             idx = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
             Value *fld = tbaa_decorate(strct.tbaa, builder.CreateLoad(
                         builder.CreateGEP(data_pointer(strct, ctx), idx)));
-            if ((unsigned)stt->ninitialized != nfields)
+            if (1 || (unsigned)stt->ninitialized != nfields)
                 null_pointer_check(fld, ctx);
             *ret = mark_julia_type(fld, true, jl_any_type, ctx, strct.gcroot || !strct.isimmutable);
             return true;
@@ -1062,7 +1062,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
                               ConstantInt::get(T_size, jl_field_offset(jt,idx)));
         if (jl_field_isptr(jt, idx)) {
             Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
-            if (idx >= (unsigned)jt->ninitialized)
+            if (1 || idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
             jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx, strct.gcroot || !strct.isimmutable);
             return ret;
@@ -1086,7 +1086,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         assert(!jt->mutabl);
         if (jl_field_isptr(jt, idx)) {
             Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(builder.CreateBitCast(addr, T_ppjlvalue)));
-            if (idx >= (unsigned)jt->ninitialized)
+            if (1 || idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
             jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx, true);
             return ret;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -999,7 +999,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
                 // just compute the pointer and let user load it when necessary
                 Type *fty = julia_type_to_llvm(jt);
                 Value *addr = builder.CreateGEP(builder.CreatePointerCast(ptr, PointerType::get(fty,0)), idx);
-                *ret = mark_julia_slot(addr, jt, strct.tbaa, ctx);
+                *ret = mark_julia_slot(addr, jt, strct.tbaa, ctx, false);
                 ret->gcroot = strct.gcroot;
                 ret->isimmutable = strct.isimmutable;
                 return true;
@@ -1093,7 +1093,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
 
             //            return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, strct.tbaa, 0);
         } else {
-            jl_cgval_t fieldval = mark_julia_slot(addr, jfty, strct.tbaa, ctx);
+            jl_cgval_t fieldval = mark_julia_slot(addr, jfty, strct.tbaa, ctx, false);
             fieldval.isimmutable = strct.isimmutable;
             fieldval.gcroot = strct.gcroot;
             return fieldval;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1717,7 +1717,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                 if (sty->layout->pointerfree)
                     strct = emit_static_alloca(lt);
                 else
-                    strct = emit_static_alloca(lt, (jl_value_t*)sty, ctx);
+                    strct = emit_rooted_static_alloca(lt, (jl_value_t*)sty, ctx);
             }
 
             unsigned idx = 0;
@@ -1778,7 +1778,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             if (sty->layout->pointerfree)
                 strct = emit_static_alloca(lt);
             else
-                strct = emit_static_alloca(lt, (jl_value_t*)sty, ctx);
+                strct = emit_rooted_static_alloca(lt, (jl_value_t*)sty, ctx);
             strctinfo = mark_julia_slot(strct, ty, tbaa_stack, ctx, !sty->layout->pointerfree);
         }
         if (f1) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1004,7 +1004,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, V
             idx = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
             Value *fld = tbaa_decorate(strct.tbaa, builder.CreateLoad(
                         builder.CreateGEP(data_pointer(strct, ctx), idx)));
-            if (1 || (unsigned)stt->ninitialized != nfields)
+            if ((unsigned)stt->ninitialized != nfields) // TODO ptrfree
                 null_pointer_check(fld, ctx);
             *ret = mark_julia_type(fld, true, jl_any_type, ctx, strct.gcroot || !strct.isimmutable);
             return true;
@@ -1081,7 +1081,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
                               ConstantInt::get(T_size, jl_field_offset(jt,idx)));
         if (jl_field_isptr(jt, idx)) {
             Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
-            if (1 || idx >= (unsigned)jt->ninitialized)
+            if (idx >= (unsigned)jt->ninitialized) // TODO ptrfree
                 null_pointer_check(fldv, ctx);
             jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx, strct.gcroot || !strct.isimmutable);
             return ret;
@@ -1106,7 +1106,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         assert(!jt->mutabl);
         if (jl_field_isptr(jt, idx)) {
             Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(builder.CreateBitCast(addr, T_ppjlvalue)));
-            if (1 || idx >= (unsigned)jt->ninitialized)
+            if (idx >= (unsigned)jt->ninitialized) // TODO ptrfree
                 null_pointer_check(fldv, ctx);
             jl_cgval_t ret = mark_julia_type(fldv, true, jfty, ctx, true);
             return ret;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4035,7 +4035,7 @@ static Function *gen_jlcall_wrapper(jl_method_instance_t *lam, Function *f, bool
     if (sret) {
         Type *llvm_retty = f->getFunctionType()->getParamType(0)->getContainedType(0);
         if (ret_needsroot)
-            result = emit_static_alloca(llvm_retty, jlretty, &ctx);
+            result = emit_rooted_static_alloca(llvm_retty, jlretty, &ctx);
         else
             result = emit_static_alloca(llvm_retty);//builder.CreateAlloca();
         args[idx] = result;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2889,7 +2889,12 @@ static jl_cgval_t emit_call_function_object(jl_method_instance_t *li, const jl_c
         unsigned idx = 0;
         Value *result;
         if (sret) {
-            result = emit_static_alloca(cft->getParamType(0)->getContainedType(0), ctx);
+            bool ret_needsroot = !((jl_datatype_t*)jlretty)->layout->pointerfree;
+            Type *llvm_retty = cft->getParamType(0)->getContainedType(0);
+            if (ret_needsroot)
+                result = emit_static_alloca(llvm_retty, jlretty, ctx);
+            else
+                result = emit_static_alloca(llvm_retty);//builder.CreateAlloca();
             argvals[idx] = result;
             idx++;
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -338,6 +338,8 @@ static Function *jlboundserror_func;
 static Function *jluboundserror_func;
 static Function *jlvboundserror_func;
 static Function *jlboundserrorv_func;
+static Function *jlundefreferror_func;
+static Function *jluundefreferror_func;
 static Function *jlcheckassign_func;
 static Function *jldeclareconst_func;
 static Function *jlgetbindingorerror_func;
@@ -2574,7 +2576,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                         *ret = ghostValue(ety);
                     }
                     else {
-                        *ret = typed_load(emit_arrayptr(ary, args[1], ctx), idx, ety, ctx, tbaa_arraybuf);
+                        *ret = typed_load(emit_arrayptr(ary, args[1], ctx), idx, ety, ctx, tbaa_arraybuf, 0, ary);
                     }
                     JL_GC_POP();
                     return true;
@@ -5559,6 +5561,28 @@ static void init_julia_llvm_env(Module *m)
                          "jl_bounds_error_unboxed_int", m);
     jluboundserror_func->setDoesNotReturn();
     add_named_global(jluboundserror_func, &jl_bounds_error_unboxed_int);
+
+    std::vector<Type*> args2_undefreferror;
+    args2_undefreferror.push_back(T_pjlvalue);
+    args2_undefreferror.push_back(T_size);
+    jlundefreferror_func =
+        Function::Create(FunctionType::get(T_void, args2_undefreferror, false),
+                         Function::ExternalLinkage,
+                         "jl_undefref_error_int", m);
+    jlundefreferror_func->setDoesNotReturn();
+    add_named_global(jlundefreferror_func, &jl_undefref_error_int);
+
+    std::vector<Type*> args3_uundefreferror;
+    args3_uundefreferror.push_back(T_pint8);
+    args3_uundefreferror.push_back(T_pjlvalue);
+    args3_uundefreferror.push_back(T_size);
+    jluundefreferror_func =
+        Function::Create(FunctionType::get(T_void, args3_uundefreferror, false),
+                         Function::ExternalLinkage,
+                         "jl_undefref_error_unboxed_int", m);
+    jluundefreferror_func->setDoesNotReturn();
+    add_named_global(jluundefreferror_func, &jl_undefref_error_unboxed_int);
+
 
     jlnew_func =
         Function::Create(jl_func_sig, Function::ExternalLinkage,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -724,6 +724,7 @@ static inline jl_cgval_t mark_julia_const(jl_value_t *jv)
 // --- utilities ---
 
 static void emit_write_barrier(jl_codectx_t*, Value*, Value*);
+static void emit_write_barrier(jl_codectx_t*, Value*, ArrayRef<Value*>);
 
 #include "cgutils.cpp"
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2576,7 +2576,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                         *ret = ghostValue(ety);
                     }
                     else {
-                        *ret = typed_load(emit_arrayptr(ary, args[1], ctx), idx, ety, ctx, tbaa_arraybuf, 0, ary);
+                        *ret = typed_load(emit_arrayptr(ary, args[1], ctx), idx, ety, ctx, tbaa_arraybuf, 0, ary, idx);
                     }
                     JL_GC_POP();
                     return true;
@@ -3507,14 +3507,14 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
                                literal_pointer_val(bnd));
         }
     }
-    else if (head == new_sym) {
+    else if (head == new_sym || head == stack_new_sym) {
         jl_value_t *ty = expr_type(args[0], ctx);
         size_t nargs = jl_array_len(ex->args);
         if (jl_is_type_type(ty) &&
             jl_is_datatype(jl_tparam0(ty)) &&
             jl_is_leaf_type(jl_tparam0(ty))) {
             assert(nargs <= jl_datatype_nfields(jl_tparam0(ty))+1);
-            return emit_new_struct(jl_tparam0(ty),nargs,args,ctx);
+            return emit_new_struct(jl_tparam0(ty),nargs,args,ctx,head == stack_new_sym);
         }
         Value *typ = boxed(emit_expr(args[0], ctx), ctx);
         Value *val = emit_jlcall(jlnew_func, typ, &args[1], nargs-1, ctx);

--- a/src/dump.c
+++ b/src/dump.c
@@ -966,7 +966,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v)
             write_int32(s->s, (int32_t)*(int32_t*)data);
         }
         else {
-            if (v == t->instance) {
+            if (jl_is_datatype_singleton(t)) {//v == t->instance) {
                 if (s->mode == MODE_MODULE && !type_in_worklist(t)) {
                     // also flag this in the backref table as special
                     // if it might not be unique (is external)

--- a/src/dump.c
+++ b/src/dump.c
@@ -596,6 +596,7 @@ static void jl_serialize_datatype(jl_serializer_state *s, jl_datatype_t *dt)
     write_uint8(s->s, dt->abstract | (dt->mutabl<<1) | (has_layout<<2) | (has_instance<<3) |
                 (dt->hastypevars<<4) | (dt->haswildcard<<5) | (dt->isleaftype<<6) | (dt->boxed<<7));
     write_int32(s->s, dt->depth);
+    write_int32(s->s, dt->first_init_ptr);
     if (!dt->abstract) {
         write_uint16(s->s, dt->ninitialized);
         if (s->mode != MODE_MODULE && s->mode != MODE_MODULE_POSTWORK) {
@@ -1239,6 +1240,7 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
     size_t size = read_int32(s->s);
     uint8_t flags = read_uint8(s->s);
     uint8_t depth = read_int32(s->s);
+    int32_t first_init_ptr = read_int32(s->s);
     jl_datatype_t *dt = NULL;
     if (tag == 2)
         dt = jl_int32_type;
@@ -1266,6 +1268,7 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
     dt->haswildcard = (flags>>5)&1;
     dt->isleaftype = (flags>>6)&1;
     dt->boxed = (flags>>7)&1;
+    dt->first_init_ptr = first_init_ptr;
     dt->depth = depth;
     dt->types = NULL;
     dt->parameters = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -594,7 +594,7 @@ static void jl_serialize_datatype(jl_serializer_state *s, jl_datatype_t *dt)
     int has_instance = (dt->instance != NULL);
     int has_layout = (dt->layout != NULL);
     write_uint8(s->s, dt->abstract | (dt->mutabl<<1) | (has_layout<<2) | (has_instance<<3) |
-        (dt->hastypevars<<4) | (dt->haswildcard<<5) | (dt->isleaftype<<6));
+                (dt->hastypevars<<4) | (dt->haswildcard<<5) | (dt->isleaftype<<6) | (dt->boxed<<7));
     write_int32(s->s, dt->depth);
     if (!dt->abstract) {
         write_uint16(s->s, dt->ninitialized);
@@ -1265,6 +1265,7 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
     dt->hastypevars = (flags>>4)&1;
     dt->haswildcard = (flags>>5)&1;
     dt->isleaftype = (flags>>6)&1;
+    dt->boxed = (flags>>7)&1;
     dt->depth = depth;
     dt->types = NULL;
     dt->parameters = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1477,8 +1477,16 @@ static jl_value_t *jl_deserialize_value_(jl_serializer_state *s, jl_value_t *vta
         }
         else {
             jl_value_t **data = (jl_value_t**)jl_array_data(a);
-            for(i=0; i < jl_array_len(a); i++) {
-                jl_arrayset_nothrow(a, jl_deserialize_value(s, NULL), i);
+            if (a->flags.ptrarray) {
+                for(i=0; i < jl_array_len(a); i++) {
+                    data[i] = jl_deserialize_value(s, &data[i]);
+                    if (data[i]) jl_gc_wb(a, data[i]);
+                }
+            }
+            else {
+                for(i=0; i < jl_array_len(a); i++) {
+                    jl_arrayset_nothrow(a, jl_deserialize_value(s, NULL), i);
+                }
             }
         }
         return (jl_value_t*)a;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1823,7 +1823,7 @@ static void _jl_gc_collect(jl_ptls_t ptls, int full)
         gc_num.interval = default_collect_interval / 2;
         sweep_full = gc_sweep_always_full;
     }
-    sweep_full = 1;
+
     if (sweep_full)
         perm_scanned_bytes = 0;
     scanned_bytes = 0;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1874,6 +1874,7 @@ static void _jl_gc_collect(jl_ptls_t ptls, int full)
 
 JL_DLLEXPORT void jl_gc_collect(int full)
 {
+    char dummy;
     jl_ptls_t ptls = jl_get_ptls_states();
     if (jl_gc_disable_counter) {
         gc_num.deferred_alloc += (gc_num.allocd + gc_num.interval);
@@ -1891,6 +1892,7 @@ JL_DLLEXPORT void jl_gc_collect(int full)
         jl_gc_state_set(ptls, old_state, JL_GC_STATE_WAITING);
         return;
     }
+    ptls->stack_lo = &dummy;
     // no-op for non-threading
     jl_gc_wait_for_the_world();
 

--- a/src/init.c
+++ b/src/init.c
@@ -834,7 +834,6 @@ void jl_get_builtin_hooks(void)
     jl_string_type = (jl_datatype_t*)core("String");
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
     jl_vecelement_typename = ((jl_datatype_t*)core("VecElement"))->name;
-    jl_valuetype_type = (jl_datatype_t*)core("ValueType");
 }
 
 JL_DLLEXPORT void jl_get_system_hooks(void)

--- a/src/init.c
+++ b/src/init.c
@@ -834,6 +834,7 @@ void jl_get_builtin_hooks(void)
     jl_string_type = (jl_datatype_t*)core("String");
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");
     jl_vecelement_typename = ((jl_datatype_t*)core("VecElement"))->name;
+    jl_valuetype_type = (jl_datatype_t*)core("ValueType");
 }
 
 JL_DLLEXPORT void jl_get_system_hooks(void)

--- a/src/init.c
+++ b/src/init.c
@@ -819,7 +819,8 @@ void jl_get_builtin_hooks(void)
     jl_domain_exception    = jl_new_struct_uninit((jl_datatype_t*)core("DomainError"));
     jl_overflow_exception  = jl_new_struct_uninit((jl_datatype_t*)core("OverflowError"));
     jl_inexact_exception   = jl_new_struct_uninit((jl_datatype_t*)core("InexactError"));
-    jl_undefref_exception  = jl_new_struct_uninit((jl_datatype_t*)core("UndefRefError"));
+    jl_undefref_exception  = core("empty_undefref_error");
+    jl_undefreferror_type  = (jl_datatype_t*)core("UndefRefError");
     jl_undefvarerror_type  = (jl_datatype_t*)core("UndefVarError");
     jl_interrupt_exception = jl_new_struct_uninit((jl_datatype_t*)core("InterruptException"));
     jl_boundserror_type    = (jl_datatype_t*)core("BoundsError");

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -60,8 +60,8 @@ JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_
     assert(v);
     return v;
 }
-jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt, int cache, int inexact);
- jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int include_ambiguous);
+
+jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int include_ambiguous);
 
 static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s)
 {

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -60,6 +60,8 @@ JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_
     assert(v);
     return v;
 }
+jl_lambda_info_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt, int cache, int inexact);
+ jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int include_ambiguous);
 
 static jl_value_t *do_call(jl_value_t **args, size_t nargs, interpreter_state *s)
 {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -301,7 +301,9 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
         builder.CreateStore(unboxed, dest, volatile_store);
         return NULL;
     }
-    if (!((jl_datatype_t*)x.typ)->layout->pointerfree && !dest && needsroot) {
+    if (!dest && needsroot &&
+        (jt && jl_is_unboxed(jt) && !((jl_datatype_t*)jt)->layout->pointerfree ||
+         x.typ && jl_is_unboxed(x.typ) && !((jl_datatype_t*)x.typ)->layout->pointerfree)) {
         assert(0 && "Should never actually unbox !ptrfree");
         abort();
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -262,7 +262,7 @@ static Constant *julia_const_to_llvm(jl_value_t *e)
 static jl_cgval_t ghostValue(jl_value_t *ty);
 
 // emit code to unpack a raw value from a box into registers or a stack slot
-static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *dest, bool volatile_store)
+static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *dest, bool volatile_store, bool needsroot)
 {
     assert(to != T_pjlvalue);
     // TODO: fully validate that x.typ == jt?
@@ -301,7 +301,7 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
         builder.CreateStore(unboxed, dest, volatile_store);
         return NULL;
     }
-    if (jl_is_vt(x.typ) && !dest) {
+    if (jl_is_vt(x.typ) && !dest && needsroot) {
         assert(0 && "Should never actually unbox !ptrfree");
         abort();
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -301,7 +301,7 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
         builder.CreateStore(unboxed, dest, volatile_store);
         return NULL;
     }
-    if (jl_is_vt(x.typ) && !dest && needsroot) {
+    if (!((jl_datatype_t*)x.typ)->layout->pointerfree && !dest && needsroot) {
         assert(0 && "Should never actually unbox !ptrfree");
         abort();
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -301,6 +301,10 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
         builder.CreateStore(unboxed, dest, volatile_store);
         return NULL;
     }
+    if (jl_is_vt(x.typ) && !dest) {
+        assert(0 && "Should never actually unbox !ptrfree");
+        abort();
+    }
 
     // bools stored as int8, so an extra Trunc is needed to get an int1
     Value *p = x.constant ? literal_pointer_val(x.constant) : x.V;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1104,8 +1104,8 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
             if (type_is_ghost(llt1))
                 return x;
             ifelse_result = builder.CreateSelect(isfalse,
-                    emit_unbox(llt1, y, t1),
-                    emit_unbox(llt1, x, t1));
+                                                 emit_unbox(llt1, y, t1, NULL, false, false),
+                                                 emit_unbox(llt1, x, t1, NULL, false, false));
         }
         else {
             ifelse_result = builder.CreateSelect(isfalse,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2298,6 +2298,12 @@ static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **i
             jl_gc_wb(ndt, ndt->instance);
         }
     }
+
+    if (istuple)
+        ndt->ninitialized = ntp;
+    else
+        ndt->ninitialized = dt->ninitialized;
+
     if (ftypes == NULL || dt->super == NULL) {
         // in the process of creating this type definition:
         // need to instantiate the super and types fields later
@@ -2324,10 +2330,6 @@ static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **i
             assert(ndt->name->names == jl_emptysvec);
         }
     }
-    if (istuple)
-        ndt->ninitialized = ntp;
-    else
-        ndt->ninitialized = dt->ninitialized;
 
     if (cacheable) {
         jl_cache_type_(ndt);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3954,7 +3954,7 @@ void jl_init_types(void)
                         jl_svec(2, jl_symbol("parameters"),
                                 jl_symbol("body")),
                         jl_svec(2, jl_simplevector_type, jl_any_type),
-                        0, 0, 2);
+                        0, 1, 2);
 
     // all kinds of types share a method table
     jl_typector_type->name->mt = jl_uniontype_type->name->mt = jl_datatype_type->name->mt =

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -4102,6 +4102,7 @@ void jl_init_types(void)
     polly_sym = jl_symbol("polly");
     inline_sym = jl_symbol("inline");
     propagate_inbounds_sym = jl_symbol("propagate_inbounds");
+    stack_new_sym = jl_symbol("stack_new");
 
     tttvar = jl_new_typevar(jl_symbol("T"),
                                   (jl_value_t*)jl_bottom_type,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3469,7 +3469,7 @@ jl_value_t *jl_type_match(jl_value_t *a, jl_value_t *b)
     return jl_type_match_(a, b, 0);
 }
 
-jl_value_t *jl_type_match_morespecific(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT jl_value_t *jl_type_match_morespecific(jl_value_t *a, jl_value_t *b)
 {
     return jl_type_match_(a, b, 1);
 }
@@ -3649,7 +3649,7 @@ void jl_init_types(void)
                                         jl_type_type, jl_emptysvec,
                                         jl_svec(1, jl_symbol("types")),
                                         jl_svec(1, jl_simplevector_type),
-                                        0, 0, 1);
+                                        0, 1, 1);
 
     jl_bottom_type = (jl_value_t*)jl_new_struct(jl_uniontype_type, jl_emptysvec);
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3793,7 +3793,14 @@ void jl_init_types(void)
                         jl_emptysvec, jl_emptysvec, 0, 1, 0);
     jl_array_typename = jl_array_type->name;
     jl_array_type->ninitialized = 0;
-    static const jl_datatype_layout_t _jl_array_layout = { 0, sizeof(void*), 0, 0, 0 };
+    static const jl_datatype_layout_t _jl_array_layout =
+        {
+            .nfields = 0,
+            .npointers = 0,
+            .alignment = sizeof(void*),
+            .haspadding = 0,
+            .pointerfree = 0,
+            .fielddesc_type = 0 };
     jl_array_type->layout = &_jl_array_layout;
 
     jl_array_any_type =

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3645,11 +3645,14 @@ void jl_init_types(void)
     jl_set_typeof(jl_nothing, jl_void_type);
     jl_void_type->instance = jl_nothing;
 
-    jl_uniontype_type = jl_new_datatype(jl_symbol("Union"),
-                                        jl_type_type, jl_emptysvec,
-                                        jl_svec(1, jl_symbol("types")),
-                                        jl_svec(1, jl_simplevector_type),
-                                        0, 1, 1);
+    jl_uniontype_type = jl_new_datatype_(jl_symbol("Union"),
+                                         jl_type_type, jl_emptysvec,
+                                         jl_svec(1, jl_symbol("types")),
+                                         jl_svec(1, jl_simplevector_type),
+                                         0, 0, 1, 1 /* force boxing */);
+    // we force boxing for uniontypes while keeping them immutable because
+    // 1. making them mutable breaks object_id and ObjectIdDict are used in several places to index types
+    // 2. making them immutables breaks Bottom uniquing which is assumed in a lot of places
 
     jl_bottom_type = (jl_value_t*)jl_new_struct(jl_uniontype_type, jl_emptysvec);
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3154,7 +3154,7 @@ f(x) = yt(x)
                   ((symbol? e) (emit e) #f)  ;; keep symbols for undefined-var checking
                   (else #f)))
           (case (car e)
-            ((call new)
+            ((call new stack_new)
              (let* ((ccall? (and (eq? (car e) 'call) (equal? (cadr e) '(core ccall))))
                     (args (if ccall?
                               ;; NOTE: 2nd and 3rd arguments of ccall must be left in place
@@ -3168,7 +3168,7 @@ f(x) = yt(x)
                     (callex (cons (car e) args)))
                (cond (tail (emit-return callex))
                      (value callex)
-                     ((eq? (car e) 'new) #f)
+                     ((or (eq? (car e) 'new) (eq? (car e) 'stack_new)) #f)
                      (else (emit callex)))))
             ((=)
              (let* ((rhs (compile (caddr e) break-labels #t #f))

--- a/src/julia.h
+++ b/src/julia.h
@@ -133,7 +133,8 @@ typedef struct {
       3 = has a pointer to the Array that owns the data
     */
     uint16_t how:2;
-    uint16_t ndims:10;
+    uint16_t ndims:9;
+    uint16_t hasptr:1;
     uint16_t pooled:1;
     uint16_t ptrarray:1;  // representation is pointer array
     uint16_t isshared:1;  // data is shared by multiple Arrays
@@ -959,7 +960,8 @@ STATIC_INLINE int jl_is_tuple_type(void *t)
 STATIC_INLINE int jl_is_vecelement_type(jl_value_t* t)
 {
     return (jl_is_datatype(t) &&
-            ((jl_datatype_t*)(t))->name == jl_vecelement_typename);
+            ((jl_datatype_t*)(t))->name == jl_vecelement_typename &&
+            jl_isbits(jl_tparam0(t)));
 }
 
 STATIC_INLINE int jl_is_type_type(jl_value_t *v)
@@ -1159,7 +1161,9 @@ JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str);
 JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a);
 JL_DLLEXPORT jl_array_t *jl_alloc_vec_any(size_t n);
 JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
+JL_DLLEXPORT jl_value_t *jl_arrayref_nothrow(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
+JL_DLLEXPORT void jl_arrayset_nothrow(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc);
 JL_DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);

--- a/src/julia.h
+++ b/src/julia.h
@@ -382,6 +382,7 @@ typedef struct _jl_datatype_t {
     int8_t isleaftype;
     //
     int8_t boxed; // if true, we box instances of this even if they are immutable
+    int32_t first_init_ptr; // offset in bytes or -1
 } jl_datatype_t;
 
 typedef struct {

--- a/src/julia.h
+++ b/src/julia.h
@@ -809,7 +809,7 @@ static inline int jl_field_isptr(jl_datatype_t *st, int i)
 
 static inline int jl_field_hasptr(jl_datatype_t *st, int i)
 {
-    const struct _jl_datatype_layout_t *ly = st->layout;
+    const jl_datatype_layout_t *ly = st->layout;
     assert(i >= 0 && (size_t)i < ly->nfields);
     return ((const jl_fielddesc8_t*)(jl_dt_layout_fields(ly) + (i << (ly->fielddesc_type + 1))))->hasptr;
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -533,6 +533,7 @@ extern JL_DLLEXPORT jl_value_t *jl_inexact_exception;
 extern JL_DLLEXPORT jl_value_t *jl_undefref_exception;
 extern JL_DLLEXPORT jl_value_t *jl_interrupt_exception;
 extern JL_DLLEXPORT jl_datatype_t *jl_boundserror_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_undefreferror_type;
 extern JL_DLLEXPORT jl_value_t *jl_an_empty_vec_any;
 
 extern JL_DLLEXPORT jl_datatype_t *jl_bool_type;
@@ -1292,6 +1293,8 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_tuple_int(jl_value_t **v,
                                                         size_t nv, size_t i);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_unboxed_int(void *v, jl_value_t *vt, size_t i);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v, size_t *idxs, size_t nidxs);
+JL_DLLEXPORT void JL_NORETURN jl_undefref_error_unboxed_int(void *data, jl_value_t *vt, size_t field);
+JL_DLLEXPORT void JL_NORETURN jl_undefref_error_int(jl_value_t *v, size_t field);
 JL_DLLEXPORT void JL_NORETURN jl_eof_error(void);
 JL_DLLEXPORT jl_value_t *jl_exception_occurred(void);
 JL_DLLEXPORT void jl_exception_clear(void);

--- a/src/julia.h
+++ b/src/julia.h
@@ -327,19 +327,22 @@ typedef struct {
 // in little-endian, isptr is always the first bit, avoiding the need for a branch in computing isptr
 typedef struct {
     uint8_t isptr:1;
-    uint8_t size:7;
+    uint8_t hasptr:1;
+    uint8_t size:6;
     uint8_t offset;   // offset relative to data start, excluding type tag
 } jl_fielddesc8_t;
 
 typedef struct {
     uint16_t isptr:1;
-    uint16_t size:15;
+    uint16_t hasptr:1;
+    uint16_t size:14;
     uint16_t offset;   // offset relative to data start, excluding type tag
 } jl_fielddesc16_t;
 
 typedef struct {
     uint32_t isptr:1;
-    uint32_t size:31;
+    uint32_t hasptr:1;
+    uint32_t size:30;
     uint32_t offset;   // offset relative to data start, excluding type tag
 } jl_fielddesc32_t;
 
@@ -801,6 +804,13 @@ static inline int jl_field_isptr(jl_datatype_t *st, int i)
     const jl_datatype_layout_t *ly = st->layout;
     assert(i >= 0 && (size_t)i < ly->nfields);
     return ((const jl_fielddesc8_t*)(jl_dt_layout_fields(ly) + (i << (ly->fielddesc_type + 1))))->isptr;
+}
+
+static inline int jl_field_hasptr(jl_datatype_t *st, int i)
+{
+    const struct _jl_datatype_layout_t *ly = st->layout;
+    assert(i >= 0 && (size_t)i < ly->nfields);
+    return ((const jl_fielddesc8_t*)(jl_dt_layout_fields(ly) + (i << (ly->fielddesc_type + 1))))->hasptr;
 }
 
 static inline uint32_t jl_fielddesc_size(int8_t fielddesc_type)
@@ -1754,7 +1764,8 @@ typedef struct {
 
 static inline int jl_is_vt(void* t)
 {
-    return ((jl_datatype_t*)t)->super == jl_valuetype_type;
+    //return ((jl_datatype_t*)t)->super == jl_valuetype_type;
+    return jl_is_datatype(t) && !((jl_datatype_t*)t)->mutabl && ((jl_datatype_t*)t)->layout && !((jl_datatype_t*)t)->layout->pointerfree;
 }
 
 #ifdef __cplusplus

--- a/src/julia.h
+++ b/src/julia.h
@@ -493,7 +493,7 @@ extern JL_DLLEXPORT jl_datatype_t *jl_tvar_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_task_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_function_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_builtin_type;
-
+extern JL_DLLEXPORT jl_datatype_t *jl_valuetype_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_uniontype_type;
 extern JL_DLLEXPORT jl_datatype_t *jl_datatype_type;
 
@@ -1751,6 +1751,11 @@ typedef struct {
 #define jl_root_task (jl_get_ptls_states()->root_task)
 #define jl_exception_in_transit (jl_get_ptls_states()->exception_in_transit)
 #define jl_task_arg_in_transit (jl_get_ptls_states()->task_arg_in_transit)
+
+static inline int jl_is_vt(void* t)
+{
+    return ((jl_datatype_t*)t)->super == jl_valuetype_type;
+}
 
 #ifdef __cplusplus
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -349,15 +349,17 @@ typedef struct {
 
 typedef struct {
     uint32_t nfields;
+    uint32_t npointers; // number of pointers (including inlined ones)
     uint32_t alignment : 28;  // strictest alignment over all fields
     uint32_t haspadding : 1;  // has internal undefined bytes
     uint32_t pointerfree : 1; // has any julia gc pointers
     uint32_t fielddesc_type : 2; // 0 -> 8, 1 -> 16, 2 -> 32
     // union {
-    //     jl_fielddesc8_t field8[];
-    //     jl_fielddesc16_t field16[];
-    //     jl_fielddesc32_t field32[];
+    //     jl_fielddesc8_t field8[nfields];
+    //     jl_fielddesc16_t field16[nfields];
+    //     jl_fielddesc32_t field32[nfields];
     // };
+    // uint32_t pointers[npointers];
 } jl_datatype_layout_t;
 
 typedef struct _jl_datatype_t {
@@ -658,6 +660,24 @@ STATIC_INLINE void jl_gc_wb(void *parent, void *ptr)
         jl_gc_queue_root((jl_value_t*)parent);
 }
 
+STATIC_INLINE uint32_t *jl_dt_layout_pointers(jl_datatype_layout_t*);
+
+STATIC_INLINE void jl_gc_multi_wb(void *parent, void *ptr) {
+    if (__likely(jl_astaggedvalue(parent)->bits.gc != 3))
+        return;
+    jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(ptr);
+    jl_datatype_layout_t *ly = (jl_datatype_layout_t*)dt->layout;
+    uint32_t npointers = ly->npointers;
+    uint32_t *pointers = jl_dt_layout_pointers(ly);
+    for (size_t i = 0; i < npointers; i++) {
+        void *ptrf = *(void**)((char*)ptr + pointers[i]);
+        if ((jl_astaggedvalue(ptrf)->bits.gc & 1) == 0) {
+            jl_gc_queue_root((jl_value_t*)parent);
+            return;
+        }
+    }
+}
+
 STATIC_INLINE void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
 {
     // if ptr is old
@@ -783,6 +803,19 @@ STATIC_INLINE char *jl_symbol_name_(jl_sym_t *s)
 #define jl_symbol_name(s) jl_symbol_name_(s)
 
 #define jl_dt_layout_fields(d) ((const char*)(d) + sizeof(jl_datatype_layout_t))
+
+STATIC_INLINE uint32_t *jl_dt_layout_pointers(jl_datatype_layout_t *l)
+{
+    if (l->fielddesc_type == 0)
+        return (uint32_t*)(jl_dt_layout_fields(l) +
+                           sizeof(jl_fielddesc8_t)*l->nfields);
+    if (l->fielddesc_type == 1)
+        return (uint32_t*)(jl_dt_layout_fields(l) +
+                           sizeof(jl_fielddesc16_t)*l->nfields);
+    if (l->fielddesc_type == 2)
+        return (uint32_t*)(jl_dt_layout_fields(l) +
+                           sizeof(jl_fielddesc32_t)*l->nfields);
+}
 
 #define DEFINE_FIELD_ACCESSORS(f)                                             \
     static inline uint32_t jl_field_##f(jl_datatype_t *st, int i)             \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -443,10 +443,12 @@ void jl_wake_libuv(void);
 jl_get_ptls_states_func jl_get_ptls_states_getter(void);
 static inline void jl_set_gc_and_wait(void)
 {
+    char dummy;
     jl_ptls_t ptls = jl_get_ptls_states();
     // reading own gc state doesn't need atomic ops since no one else
     // should store to it.
     int8_t state = jl_gc_state(ptls);
+    ptls->stack_lo = &dummy;
     jl_atomic_store_release(&ptls->gc_state, JL_GC_STATE_WAITING);
     jl_safepoint_wait_gc();
     jl_atomic_store_release(&ptls->gc_state, state);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -839,7 +839,7 @@ extern jl_sym_t *meta_sym; extern jl_sym_t *list_sym;
 extern jl_sym_t *inert_sym; extern jl_sym_t *static_parameter_sym;
 extern jl_sym_t *polly_sym; extern jl_sym_t *inline_sym;
 extern jl_sym_t *propagate_inbounds_sym;
-
+extern jl_sym_t *stack_new_sym;
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -312,6 +312,12 @@ jl_value_t *jl_type_intersection_matching(jl_value_t *a, jl_value_t *b,
 jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
 jl_datatype_t *jl_new_uninitialized_datatype(void);
+jl_datatype_t *jl_new_datatype_(jl_sym_t *name, jl_datatype_t *super,
+                                jl_svec_t *parameters,
+                                jl_svec_t *fnames, jl_svec_t *ftypes,
+                                int abstract, int mutabl,
+                                int ninitialized, int boxed);
+
 jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
                                    jl_svec_t *parameters);
 void jl_precompute_memoized_dt(jl_datatype_t *dt);

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -1008,13 +1008,13 @@ void JuliaGCAllocator::allocate_frame()
             if (callInst->getCalledValue() == gcroot_func) {
                 unsigned offset = 2 + argSpaceSize++;
                 if (callInst->getArgOperand(0) != V_null) {
-                    Instruction *tagaddr = GetElementPtrInst::Create(LLVM37_param(NULL) gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, offset)));
+                    /*Instruction *tagaddr = GetElementPtrInst::Create(LLVM37_param(NULL) gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, offset)));
                     offset++;
                     tagaddr->insertAfter(last_gcframe_inst);
                     StoreInst *tagstore = new StoreInst(callInst->getArgOperand(0), tagaddr);
                     tagstore->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_gcframe);
                     tagstore->insertAfter(tagaddr);
-                    argSpaceSize++;
+                    argSpaceSize++;*/
                 }
                 Instruction *argTempi = GetElementPtrInst::Create(LLVM37_param(NULL) gcframe, ArrayRef<Value*>(ConstantInt::get(T_int32, offset)));
                 argTempi->insertAfter(last_gcframe_inst);

--- a/src/options.h
+++ b/src/options.h
@@ -34,7 +34,7 @@
 // with MEMDEBUG, every object is allocated explicitly with malloc, and
 // filled with 0xbb before being freed. this helps tools like valgrind
 // catch invalid accesses.
-#define MEMDEBUG
+//#define MEMDEBUG
 
 // with MEMFENCE, the object pool headers are verified during sweep
 // to help detect corruption due to fence-post write errors

--- a/src/options.h
+++ b/src/options.h
@@ -34,7 +34,7 @@
 // with MEMDEBUG, every object is allocated explicitly with malloc, and
 // filled with 0xbb before being freed. this helps tools like valgrind
 // catch invalid accesses.
-// #define MEMDEBUG
+#define MEMDEBUG
 
 // with MEMFENCE, the object pool headers are verified during sweep
 // to help detect corruption due to fence-post write errors

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -518,6 +518,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast, int expanded)
     jl_ptls_t ptls = jl_get_ptls_states();
     //jl_show(ex);
     //jl_printf(JL_STDOUT, "\n");
+
     if (!jl_is_expr(e)) {
         if (jl_is_linenode(e)) {
             jl_lineno = jl_linenode_line(e);


### PR DESCRIPTION
The codegen/gc part of this is basically working.
I'm now wondering about semantics and I'd like us to discuss the following issues a bit before I clean up the code and we start the review (there is a bunch of duplicate paths in codegen that can be merged together/simplified and some things are plain wrong and/or inefficient).

This patch allows us to unbox most immutables. By unbox I mean : allocate/store them on the stack, inline them in other objects and inline them in arrays.
Why most ? There are (for now) two problems : cycles and #undef.

Cycles are a fundamental problem, if A has a field of type B and B of type A, we obviously can't inline them into each other. The cycle needs to be broken, the annoying part is that it should be done in a predictable way. For now, on this PR, it's done in DFS order which means that for example the layout of B will differ if we ever instantiated an A before. Not good. Proposal I remember about that (Jameson @ juliacon iirc) was to make types boxed iff they are part of any field cycle.
`#undef` is annoying because it makes a difference at the julia level between `isbits` types and other immutables. To minimize breakage I've gone the route of preserving the current behavior.

So if A has a pointer field and we make, e.g., an uninitialized array of A, this branch uses the nullity of the field of A as a marker that the corresponding slot in the array is #undef. This only works if the field of a valid instance of A can never be null, i.e., if `A.ninitialized >= field_index_of_the_ptr_field`.

This makes most code (at least all the test suite :-)) work but I think the following rules are really weird :

A type `T` will be inlined into fields/arrays and stack allocated if
- it is immutable
- it is not possible to reach itself through a sequence of field access
- it has at least one never-#undef pointer field or no pointer fields at all

The only difference between a type that is boxed or not is memory layout, but I'd assume that we want that to be easily predictable since for example people routinely interface with C.

A proposed alternative by Yichao was to make it entierly opt-in and error out if inlining was not possible. I'm worried this will lead to yet-another-annotation that people will sprinkle everywhere.

For performance, specially crafted tests (like summing lines of a very skinny matrix using subarrays) show some improvements by avoiding gc allocation. Not super satisfying for now and casual inspection of generated asm shows a lot of stack movement. We can work on that though, probably by improving llvm's visibility of our rooting mechanism and/or just using statepoints.

(to sweeten the deal I've thrown in improved undef ref errors)
