### PR TITLE
document how to pretty-print objects

### DIFF
--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -706,6 +706,8 @@ Text I/O
 
    Return the nominal size of the screen that may be used for rendering output to this io object
 
+.. _man-multimedia-io:
+
 Multimedia I/O
 --------------
 
@@ -1076,4 +1078,3 @@ Network I/O
    .. Docstring generated from Julia source
 
    The 32-bit byte-order-mark indicates the native byte order of the host machine. Little-endian machines will contain the value ``0x04030201``\ . Big-endian machines will contain the value ``0x01020304``\ .
-


### PR DESCRIPTION
This fixes #9458.

This has come up a zillion times on julia-users ([here](https://groups.google.com/d/msg/julia-users/_CO-2XHKNQA/xjGFF5Grmu8J), [here](https://groups.google.com/d/msg/julia-users/eudLjjKiNP0/TU60_fqGnjYJ), [here](https://groups.google.com/d/msg/julia-users/eRQh51PR7Tg/bpvanIoMBQAJ), [here](https://groups.google.com/d/msg/julia-users/nYtZE7mj8qg/52sDls0iCAAJ), [here](https://groups.google.com/d/msg/julia-users/QwFzU_PbtF8/VFkm2ZFMNVgJ), [here](https://groups.google.com/d/msg/julia-users/TTuZ_UKNpPo/fLzXQTRboQUJ), [here](https://groups.google.com/d/msg/julia-users/9B8lgy24EtY/lIlTq-4zI3wJ), ....).  I can't believe we've gone this long without a manual section on it.
