### PR TITLE
Bugfix and tests for sparse

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -1358,8 +1358,8 @@ end
 
 scale!(x::AbstractSparseVector, a::Real) = (scale!(nonzeros(x), a); x)
 scale!(x::AbstractSparseVector, a::Complex) = (scale!(nonzeros(x), a); x)
-scale!(a::Real, x::AbstractSparseVector) = scale!(nonzeros(x), a)
-scale!(a::Complex, x::AbstractSparseVector) = scale!(nonzeros(x), a)
+scale!(a::Real, x::AbstractSparseVector) = (scale!(nonzeros(x), a); x)
+scale!(a::Complex, x::AbstractSparseVector) = (scale!(nonzeros(x), a); x)
 
 
 .*(x::AbstractSparseVector, a::Number) = SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) * a)

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -120,6 +120,8 @@ for i = 1:5
     @test (maximum(abs.(a*b - full(a)*b)) < 100*eps())
     @test (maximum(abs.(A_mul_B!(similar(b), a, b) - full(a)*b)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
     @test (maximum(abs.(A_mul_B!(similar(c), a, c) - full(a)*c)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
+    @test (maximum(abs.(At_mul_B!(similar(b), a, b) - full(a).'*b)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
+    @test (maximum(abs.(At_mul_B!(similar(c), a, c) - full(a).'*c)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
     @test (maximum(abs.(a'b - full(a)'b)) < 100*eps())
     @test (maximum(abs.(a.'b - full(a).'b)) < 100*eps())
     @test (maximum(abs.(a\b - full(a)\b)) < 1000*eps())

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -738,6 +738,9 @@ let x = sprand(16, 0.5), x2 = sprand(16, 0.4)
         xc = copy(x)
         @test is(scale!(xc, 2.5), xc)
         @test exact_equal(xc, sx)
+        xc = copy(x)
+        @test is(scale!(2.5, xc), xc)
+        @test exact_equal(xc, sx)
     end
 
     # dot


### PR DESCRIPTION
`scale!` for sparse vectors would return the nonzero elements of the vector, not the sparse vector itself; very bad!

Also added a test for `At_mul_B!` since this was missing.
