### PR TITLE
Use string parsing for command literals

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -783,4 +783,27 @@ else
     @test count_meta_loc(f2_exprs) == 1
 end
 
+# Check that string and command literals are parsed to the appropriate macros
+@test :(x"s") == :(@x_str "s")
+@test :(x"s"flag) == :(@x_str "s" "flag")
+@test :(x"s\"`\x\$\\") == :(@x_str "s\"`\\x\\\$\\\\")
+@test :(x`s`) == :(@x_cmd "s")
+@test :(x`s`flag) == :(@x_cmd "s" "flag")
+@test :(x`s\`"\x\$\\`) == :(@x_cmd "s`\"\\x\\\$\\\\")
+
+# Check multiline command literals
+@test :```
+multiline
+command
+``` == :(@cmd "multiline\ncommand\n")
+
+macro julia_cmd(s)
+    Meta.quot(parse(s))
+end
+@test julia```
+if test + test == test
+    println(test)
+end
+```.head == :if
+
 end


### PR DESCRIPTION
This changes command literals to be parsed the same way (raw) string literals are.

Consequences:
- Multiline command literals with <code>```</code> now supported
- <code>x`cmd`</code> parsing to `@x_cmd "cmd"` now supported
- `\r\n` within command literals translated to `\n`
- <s>`\\` within command literals now means two backslashes, instead of one. Note that this means it is no longer possible to end a command literal with a single backslash. I don't think this is a big deal, since it can just be quoted.</s> never mind, this is actually the same behaviour as before. the `Cmd` constructor just special-cased it.

This implements the less breaking and less controversial (I think) part of https://github.com/JuliaLang/julia/issues/12139.
