### PR TITLE
Make versioninfo() display the OS name on Windows and Mac

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -251,7 +251,8 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
         println(io, "DEBUG build")
     end
     println(io,             "Platform Info:")
-    println(io,             "  System: ", Sys.KERNEL, " (", Sys.MACHINE, ")")
+    println(io,             "  OS: ", is_windows() ? "Windows" : is_apple() ?
+        "macOS" : Sys.KERNEL, " (", Sys.MACHINE, ")")
 
     cpu = Sys.cpu_info()
     println(io,         "  CPU: ", cpu[1].model)

--- a/doc/devdocs/backtraces.rst
+++ b/doc/devdocs/backtraces.rst
@@ -23,7 +23,7 @@ No matter the error, we will always need to know what version of Julia you are r
  Julia Version 0.3.3-pre+25
  Commit 417b50a* (2014-11-03 11:32 UTC)
  Platform Info:
-   System: Linux (x86_64-linux-gnu)
+   OS: Linux (x86_64-linux-gnu)
    CPU: Intel(R) Core(TM) i7 CPU       L 640  @ 2.13GHz
    WORD_SIZE: 64
    BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Nehalem)


### PR DESCRIPTION
I'm already tired of seeing bug reports with the output of `versioninfo()`
that don't say Windows anywhere. Many users don't know what NT or Darwin mean.
