### PR TITLE
_subtype should use a typed Set

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -280,7 +280,7 @@ enumerated types (see `@enum`).
 function instances end
 
 # subtypes
-function _subtypes(m::Module, x::DataType, sts=Set(), visited=Set())
+function _subtypes(m::Module, x::DataType, sts=Set{DataType}(), visited=Set{Module}())
     push!(visited, m)
     for s in names(m, true)
         if isdefined(m, s) && !isdeprecated(m, s)


### PR DESCRIPTION
Like this, `subtype` returns a `Vector{DataType}` instead of `Vector{Any}` and speed is improved tenfold.
Are there corner cases where this won't work (`Type`?), or is this an oversight?
