### PR TITLE
Use withenv in test/cmdlineargs.jl

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -303,8 +303,9 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes`
         JL_OPTIONS_STARTUPFILE_OFF = 2
         # `HOME=$tmpdir` to avoid errors in the user .juliarc.jl, which hangs the tests.  Issue #17642
         mktempdir() do tmpdir
-            @test parse(Int,readchomp(setenv(`$exename -E "Base.JLOptions().startupfile" --startup-file=yes`,
-                ["HOME="*tmpdir, "PATH="*ENV["PATH"]]))) == JL_OPTIONS_STARTUPFILE_ON
+            withenv("HOME"=>tmpdir) do
+                @test parse(Int,readchomp(`$exename -E "Base.JLOptions().startupfile" --startup-file=yes`)) == JL_OPTIONS_STARTUPFILE_ON
+            end
         end
         @test parse(Int,readchomp(`$exename -E "Base.JLOptions().startupfile" --startup-file=no`)) == JL_OPTIONS_STARTUPFILE_OFF
     end


### PR DESCRIPTION
One of the `cmdlineargs` tests currently uses `setenv` to set `HOME` to a temporary directory to avoid loading `~/.juliarc.jl`.  db01a8fd already fixed a corner case by including the current `PATH` in the new environment, and at the moment `LD_LIBRARY_PATH` is not passed, which can cause the test to fail on systems where `LD_LIBRARY_PATH` is needed to run julia.  (Note that julia's README mentions using `LD_LIBRARY_PATH` at both compile and run time as an alternative to `LDFLAGS`.)  Also, the current code fails if `ENV["PATH"]` is unset -- a very unlikely occurrence, admittedly, but a possible one.

For the above reasons I think `setenv` is overkill, so this pull request modifies the test to use `withenv`, which minimally modifies the environment, thus changing only `ENV["HOME"]`.
