### PR TITLE
Fix backtrace test with inlining off

### DIFF
--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -118,7 +118,11 @@ for sfs in lkup
     end
 end
 @test hasbt
-@test_broken hasbt2
+if Base.JLOptions().can_inline != 0
+    @test_broken hasbt2
+else
+    @test hasbt2
+end
 
 function btmacro()
     ret = @timed backtrace()

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -6,6 +6,8 @@ module MetaTest
 
 using Base.Test
 
+const inlining_on = Base.JLOptions().can_inline != 0
+
 function f(x)
     y = x+5
     z = y*y
@@ -42,7 +44,9 @@ function foundfunc(bt, funcname)
     end
     false
 end
-@test !foundfunc(h_inlined(), :g_inlined)
+if inlining_on
+    @test !foundfunc(h_inlined(), :g_inlined)
+end
 @test foundfunc(h_noinlined(), :g_noinlined)
 
 using Base.pushmeta!, Base.popmeta!


### PR DESCRIPTION
Otherwise the test complains that the backtrace is too good with inlining off.
