### PR TITLE
make findnext work for utf8 strings (and other iterators)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -665,8 +665,8 @@ start(A::AbstractArray) = (@_inline_meta; itr = eachindex(A); (itr, start(itr)))
 next(A::AbstractArray,i) = (@_propagate_inbounds_meta; (idx, s) = next(i[1], i[2]); (A[idx], (i[1], s)))
 done(A::AbstractArray,i) = (@_propagate_inbounds_meta; done(i[1], i[2]))
 
-nextind(s, i::Integer) = Int(i)+1
-prevind(s, i::Integer) = Int(i)-1
+nextind{T<:Integer}(s, i::T) = i+T(1)
+prevind{T<:Integer}(s, i::T) = i-T(1)
 
 # eachindex iterates over all indices. LinearSlow definitions are later.
 eachindex(A::AbstractVector) = (@_inline_meta(); indices1(A))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -665,6 +665,9 @@ start(A::AbstractArray) = (@_inline_meta; itr = eachindex(A); (itr, start(itr)))
 next(A::AbstractArray,i) = (@_propagate_inbounds_meta; (idx, s) = next(i[1], i[2]); (A[idx], (i[1], s)))
 done(A::AbstractArray,i) = (@_propagate_inbounds_meta; done(i[1], i[2]))
 
+nextind(s::AbstractArray    , i::Integer) = Int(i)+1
+prevind(s::AbstractArray    , i::Integer) = Int(i)-1
+
 # eachindex iterates over all indices. LinearSlow definitions are later.
 eachindex(A::AbstractVector) = (@_inline_meta(); indices1(A))
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -665,8 +665,8 @@ start(A::AbstractArray) = (@_inline_meta; itr = eachindex(A); (itr, start(itr)))
 next(A::AbstractArray,i) = (@_propagate_inbounds_meta; (idx, s) = next(i[1], i[2]); (A[idx], (i[1], s)))
 done(A::AbstractArray,i) = (@_propagate_inbounds_meta; done(i[1], i[2]))
 
-nextind(s::AbstractArray    , i::Integer) = Int(i)+1
-prevind(s::AbstractArray    , i::Integer) = Int(i)-1
+nextind(s, i::Integer) = Int(i)+1
+prevind(s, i::Integer) = Int(i)-1
 
 # eachindex iterates over all indices. LinearSlow definitions are later.
 eachindex(A::AbstractVector) = (@_inline_meta(); indices1(A))

--- a/base/array.jl
+++ b/base/array.jl
@@ -1075,7 +1075,7 @@ function findnext(testf::Function, A, idx::Integer)
         elem, idx = next(A, idx)
         testf(elem) && return lastidx
     end
-    0
+    zero(idx)
 end
 
 """
@@ -1165,7 +1165,6 @@ julia> findprev(A, 1, 1)
 """
 findprev(A, v, start::Integer) = findprev(x-> x==v, A, start)
 
-
 """
     findlast(A, v)
 
@@ -1210,12 +1209,12 @@ julia> findprev(isodd, A, 3)
 ```
 """
 function findprev(testf::Function, A, idx::Integer)
-    while idx > 0
+    while idx > zero(idx)
         elem, _ = next(A, idx)
         testf(elem) && return idx
         idx = prevind(A, idx)
     end
-    0
+    zero(idx)
 end
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -990,9 +990,7 @@ julia> findnext(A,3)
 0
 ```
 """
-function findnext(A, start::Integer)
-    findnext(x->x!=0, A, start)
-end
+findnext(A, start::Integer) = findnext(x->x!=0, A, start)
 
 """
     findfirst(A)
@@ -1030,9 +1028,8 @@ julia> findnext(A,4,3)
 3
 ```
 """
-function findnext(A, v, start::Integer)
-    findnext(x->x==v, A, start)
-end
+findnext(A, v, start::Integer) = findnext(x->x==v, A, start)
+
 """
     findfirst(A, v)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -991,12 +991,7 @@ julia> findnext(A,3)
 ```
 """
 function findnext(A, start::Integer)
-    for i = start:length(A)
-        if A[i] != 0
-            return i
-        end
-    end
-    return 0
+    findnext(x->x!=0, A, start)
 end
 
 """
@@ -1036,12 +1031,7 @@ julia> findnext(A,4,3)
 ```
 """
 function findnext(A, v, start::Integer)
-    for i = start:length(A)
-        if A[i] == v
-            return i
-        end
-    end
-    return 0
+    findnext(x->x==v, A, start)
 end
 """
     findfirst(A, v)
@@ -1082,13 +1072,13 @@ julia> findnext(isodd, A, 2)
 0
 ```
 """
-function findnext(testf::Function, A, start::Integer)
-    for i = start:length(A)
-        if testf(A[i])
-            return i
-        end
+function findnext(testf::Function, A, idx::Integer)
+    while !done(A, idx)
+        lastidx = idx
+        elem, idx = next(A, idx)
+        testf(elem) && return lastidx
     end
-    return 0
+    0
 end
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -990,7 +990,7 @@ julia> findnext(A,3)
 0
 ```
 """
-findnext(A, start::Integer) = findnext(x->x!=0, A, start)
+findnext(A, start::Integer) = findnext(x-> x!=0, A, start)
 
 """
     findfirst(A)
@@ -1028,7 +1028,7 @@ julia> findnext(A,4,3)
 3
 ```
 """
-findnext(A, v, start::Integer) = findnext(x->x==v, A, start)
+findnext(A, v, start::Integer) = findnext(x-> x==v, A, start)
 
 """
     findfirst(A, v)
@@ -1117,12 +1117,7 @@ julia> findprev(A,1)
 0
 ```
 """
-function findprev(A, start::Integer)
-    for i = start:-1:1
-        A[i] != 0 && return i
-    end
-    return 0
-end
+findprev(A, start::Integer) = findprev(x-> x!=0, A, start)
 
 """
     findlast(A)
@@ -1168,12 +1163,8 @@ julia> findprev(A, 1, 1)
 0
 ```
 """
-function findprev(A, v, start::Integer)
-    for i = start:-1:1
-        A[i] == v && return i
-    end
-    return 0
-end
+findprev(A, v, start::Integer) = findprev(x-> x==v, A, start)
+
 
 """
     findlast(A, v)
@@ -1218,11 +1209,13 @@ julia> findprev(isodd, A, 3)
 2
 ```
 """
-function findprev(testf::Function, A, start::Integer)
-    for i = start:-1:1
-        testf(A[i]) && return i
+function findprev(testf::Function, A, idx::Integer)
+    while idx > 0
+        elem, _ = next(A, idx)
+        testf(elem) && return idx
+        idx = prevind(A, idx)
     end
-    return 0
+    0
 end
 
 """

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -190,7 +190,6 @@ end
 prevind(s::DirectIndexString, i::Integer) = Int(i)-1
 nextind(s::DirectIndexString, i::Integer) = Int(i)+1
 
-
 function prevind(s::String, i::Integer)
     j = Int(i)
     e = endof(s.data)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -188,9 +188,8 @@ end
 ## Generic indexing functions ##
 
 prevind(s::DirectIndexString, i::Integer) = Int(i)-1
-prevind(s::AbstractArray    , i::Integer) = Int(i)-1
 nextind(s::DirectIndexString, i::Integer) = Int(i)+1
-nextind(s::AbstractArray    , i::Integer) = Int(i)+1
+
 
 function prevind(s::String, i::Integer)
     j = Int(i)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -394,6 +394,13 @@ end
     @test findprev(a,1,8) == 6
     @test findprev(isodd, [2,4,5,3,9,2,0], 7) == 5
     @test findprev(isodd, [2,4,5,3,9,2,0], 2) == 0
+    utf8str = "𝐴 ∈ ℝⁿˣⁿ, 𝐯 ∈ ℝⁿ, λᵢ ∈ ℝ: 𝐯"
+    idx = findnext(str, 'λ', 1)
+    @test str[idx] == 'λ'
+    idx = findnext(str,'ᵢ', idx)
+    @test str[idx] == 'ᵢ'
+    idx = findnext(str,'𝐯', endof(str))
+    @test idx == endof(str)
 end
 @testset "find with general iterables" begin
     s = "julia"
@@ -506,7 +513,6 @@ end
     @test Base.circshift!(b, a, 1) == [5,1,2,3,4]
 end
 
-# unique across dim
 
 # All rows and columns unique
 A = ones(10, 10)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -519,6 +519,7 @@ end
     @test Base.circshift!(b, a, 1) == [5,1,2,3,4]
 end
 
+# unique across dim
 
 # All rows and columns unique
 A = ones(10, 10)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -374,6 +374,7 @@ end
     @test findfirst(a.==0) == 1
     @test findfirst(a.==5) == 0
     @test findfirst([1,2,4,1,2,3,4], 3) == 6
+    @test findfirst(isodd, (2,4,6,3,9,2,0)) == 4
     @test findfirst(isodd, [2,4,6,3,9,2,0]) == 4
     @test findfirst(isodd, [2,4,6,2,0]) == 0
     @test findnext(a,4) == 4
@@ -394,6 +395,7 @@ end
     @test findprev(a,1,8) == 6
     @test findprev(isodd, [2,4,5,3,9,2,0], 7) == 5
     @test findprev(isodd, [2,4,5,3,9,2,0], 2) == 0
+    @test findprev(isodd, (2,4,5,3,9,2,0), 2) == 0
     str = "𝐴 ∈ ℝⁿˣⁿ, 𝐯 ∈ ℝⁿ, λᵢ ∈ ℝ: 𝐯"
     idx = findnext(str, 'λ', 1)
     @test str[idx] == 'λ'

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -394,13 +394,19 @@ end
     @test findprev(a,1,8) == 6
     @test findprev(isodd, [2,4,5,3,9,2,0], 7) == 5
     @test findprev(isodd, [2,4,5,3,9,2,0], 2) == 0
-    utf8str = "𝐴 ∈ ℝⁿˣⁿ, 𝐯 ∈ ℝⁿ, λᵢ ∈ ℝ: 𝐯"
+    str = "𝐴 ∈ ℝⁿˣⁿ, 𝐯 ∈ ℝⁿ, λᵢ ∈ ℝ: 𝐯"
     idx = findnext(str, 'λ', 1)
     @test str[idx] == 'λ'
     idx = findnext(str,'ᵢ', idx)
     @test str[idx] == 'ᵢ'
     idx = findnext(str,'𝐯', endof(str))
     @test idx == endof(str)
+    idx = findprev(str, 'λ', endof(str))
+    @test str[idx] == 'λ'
+    idx = findprev(str,'ⁿ', idx)
+    @test str[idx] == 'ⁿ'
+    idx = findprev(str,'𝐴', 1)
+    @test idx == 1
 end
 @testset "find with general iterables" begin
     s = "julia"

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -397,15 +397,15 @@ end
     str = "𝐴 ∈ ℝⁿˣⁿ, 𝐯 ∈ ℝⁿ, λᵢ ∈ ℝ: 𝐯"
     idx = findnext(str, 'λ', 1)
     @test str[idx] == 'λ'
-    idx = findnext(str,'ᵢ', idx)
+    idx = findnext(str, 'ᵢ', idx)
     @test str[idx] == 'ᵢ'
-    idx = findnext(str,'𝐯', endof(str))
+    idx = findnext(str, '𝐯', endof(str))
     @test idx == endof(str)
     idx = findprev(str, 'λ', endof(str))
     @test str[idx] == 'λ'
-    idx = findprev(str,'ⁿ', idx)
+    idx = findprev(str, 'ⁿ', idx)
     @test str[idx] == 'ⁿ'
-    idx = findprev(str,'𝐴', 1)
+    idx = findprev(str, '𝐴', 1)
     @test idx == 1
 end
 @testset "find with general iterables" begin


### PR DESCRIPTION
... and why not use closures on 0.6, so that there is actually only one real implementation of findnext.
A simple benchmark suggests that there are no speed regression:

``` Julia
using BenchmarkTools
a = rand(10000)
v = 42.0
a[end] == v
b1 = @benchmark simon.findnext($a, $v, $(1))
b2 = @benchmark master.findnext($a, $v, $(1))
judge(minimum(b1), minimum(b2))
-> invariant
```
