### PR TITLE
Fix compilation on LLVM 4.0

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -35,6 +35,9 @@
 #if JL_LLVM_VERSION >= 30900
 #include <llvm/Transforms/Scalar/GVN.h>
 #endif
+#if JL_LLVM_VERSION >= 40000
+#include <llvm/Transforms/IPO/AlwaysInliner.h>
+#endif
 
 namespace llvm {
     extern Pass *createLowerSimdLoopPass();
@@ -142,7 +145,11 @@ void addOptimizationPasses(PassManager *PM)
     // list of passes from vmkit
     PM->add(createCFGSimplificationPass()); // Clean up disgusting code
     PM->add(createPromoteMemoryToRegisterPass());// Kill useless allocas
+#if JL_LLVM_VERSION >= 40000
+    PM->add(createAlwaysInlinerLegacyPass()); // Respect always_inline
+#else
     PM->add(createAlwaysInlinerPass()); // Respect always_inline
+#endif
 
 #ifndef INSTCOMBINE_BUG
     PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.


### PR DESCRIPTION
AlwaysInlinerPass is ported to the new pass manager and the creation function
is renamed.

Ref https://reviews.llvm.org/D23299
Ref https://github.com/llvm-mirror/llvm/commit/b699f7b88fcfbddfb4d7f98a85cbf3373c32049d
