### PR TITLE
backport of changes in #17057 that don't require new worlds

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1,31 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-## Type aliases for convenience ##
-
-typealias AbstractVector{T} AbstractArray{T,1}
-typealias AbstractMatrix{T} AbstractArray{T,2}
-typealias AbstractVecOrMat{T} Union{AbstractVector{T}, AbstractMatrix{T}}
-typealias RangeIndex Union{Int, Range{Int}, AbstractUnitRange{Int}, Colon}
-typealias DimOrInd Union{Integer, AbstractUnitRange}
-typealias IntOrInd Union{Int, AbstractUnitRange}
-typealias DimsOrInds{N} NTuple{N,DimOrInd}
-typealias NeedsShaping Union{Tuple{Integer,Vararg{Integer}}, Tuple{OneTo,Vararg{OneTo}}}
-
-macro _inline_pure_meta()
-    Expr(:meta, :inline, :pure)
-end
-
 ## Basic functions ##
-
-vect() = Array{Any,1}(0)
-vect{T}(X::T...) = T[ X[i] for i=1:length(X) ]
-
-function vect(X...)
-    T = promote_typeof(X...)
-    #T[ X[i] for i=1:length(X) ]
-    # TODO: this is currently much faster. should figure out why. not clear.
-    copy!(Array{T,1}(length(X)), X)
-end
 
 """
     size(A::AbstractArray, [dim...])

--- a/base/array.jl
+++ b/base/array.jl
@@ -2,6 +2,17 @@
 
 ## array.jl: Dense arrays
 
+## Type aliases for convenience ##
+
+typealias AbstractVector{T} AbstractArray{T,1}
+typealias AbstractMatrix{T} AbstractArray{T,2}
+typealias AbstractVecOrMat{T} Union{AbstractVector{T}, AbstractMatrix{T}}
+typealias RangeIndex Union{Int, Range{Int}, AbstractUnitRange{Int}, Colon}
+typealias DimOrInd Union{Integer, AbstractUnitRange}
+typealias IntOrInd Union{Int, AbstractUnitRange}
+typealias DimsOrInds{N} NTuple{N,DimOrInd}
+typealias NeedsShaping Union{Tuple{Integer,Vararg{Integer}}, Tuple{OneTo,Vararg{OneTo}}}
+
 typealias Vector{T} Array{T,1}
 typealias Matrix{T} Array{T,2}
 typealias VecOrMat{T} Union{Vector{T}, Matrix{T}}
@@ -13,6 +24,16 @@ typealias DenseVecOrMat{T} Union{DenseVector{T}, DenseMatrix{T}}
 ## Basic functions ##
 
 import Core: arraysize, arrayset, arrayref
+
+vect() = Array{Any,1}(0)
+vect{T}(X::T...) = T[ X[i] for i=1:length(X) ]
+
+function vect(X...)
+    T = promote_typeof(X...)
+    #T[ X[i] for i=1:length(X) ]
+    # TODO: this is currently much faster. should figure out why. not clear.
+    return copy!(Array{T,1}(length(X)), X)
+end
 
 size(a::Array, d) = arraysize(a, d)
 size(a::Vector) = (arraysize(a,1),)

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -45,8 +45,8 @@ Symbol(a::Array{UInt8,1}) =
     ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int32), a, length(a))
 
 # core array operations
-include("abstractarray.jl")
 include("array.jl")
+include("abstractarray.jl")
 
 #TODO: eliminate Dict from inference
 include("hashing.jl")

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -239,12 +239,12 @@ tupletype_tail(t::ANY, n) = Tuple{t.parameters[n:end]...}
 
 #### type-functions for builtins / intrinsics ####
 
-cmp_tfunc = (x,y)->Bool
+cmp_tfunc = (x::ANY, y::ANY) -> Bool
 
 isType(t::ANY) = isa(t,DataType) && is((t::DataType).name,Type.name)
 
 # true if Type is inlineable as constant
-isconstType(t::ANY,b::Bool) =
+isconstType(t::ANY, b::Bool) =
     isType(t) && !has_typevars(t.parameters[1],b) &&
     !issubtype(Type{Tuple{Vararg}}, t)  # work around inference bug #18450
 
@@ -275,7 +275,7 @@ add_tfunc(le_float, 2, 2, cmp_tfunc)
 add_tfunc(fpiseq, 2, 2, cmp_tfunc)
 add_tfunc(fpislt, 2, 2, cmp_tfunc)
 add_tfunc(Core.Intrinsics.ccall, 3, IInf,
-    function(fptr, rt, at, a...)
+    function(fptr::ANY, rt::ANY, at::ANY, a...)
         if !isType(rt)
             return Any
         end
@@ -290,12 +290,12 @@ add_tfunc(Core.Intrinsics.ccall, 3, IInf,
         return t
     end)
 add_tfunc(Core.Intrinsics.llvmcall, 3, IInf,
-    (fptr, rt, at, a...)->(isType(rt) ? rt.parameters[1] : Any))
+    (fptr::ANY, rt::ANY, at::ANY, a...)->(isType(rt) ? rt.parameters[1] : Any))
 add_tfunc(Core.Intrinsics.cglobal, 1, 2,
-    (fptr, t...)->(isempty(t) ? Ptr{Void} :
+    (fptr::ANY, t::ANY...)->(isempty(t) ? Ptr{Void} :
                    isType(t[1]) ? Ptr{t[1].parameters[1]} : Ptr))
 add_tfunc(Core.Intrinsics.select_value, 3, 3,
-    function (cnd, x, y)
+    function (cnd::ANY, x::ANY, y::ANY)
         if isa(cnd, Const)
             if cnd.val === true
                 return x
@@ -306,7 +306,7 @@ add_tfunc(Core.Intrinsics.select_value, 3, 3,
             end
         end
         (Bool ⊑ cnd) || return Bottom
-        tmerge(x, y)
+        return tmerge(x, y)
     end)
 add_tfunc(is, 2, 2,
     function (x::ANY, y::ANY)
@@ -325,23 +325,23 @@ add_tfunc(is, 2, 2,
     end)
 add_tfunc(isdefined, 1, IInf, (args...)->Bool)
 add_tfunc(Core.sizeof, 1, 1, x->Int)
-add_tfunc(nfields, 1, 1, x->(isa(x,Const) ? Const(nfields(x.val)) :
+add_tfunc(nfields, 1, 1, (x::ANY)->(isa(x,Const) ? Const(nfields(x.val)) :
                              isType(x) && isleaftype(x.parameters[1]) ? Const(nfields(x.parameters[1])) :
                              Int))
 add_tfunc(Core._expr, 1, IInf, (args...)->Expr)
-add_tfunc(applicable, 1, IInf, (f, args...)->Bool)
+add_tfunc(applicable, 1, IInf, (f::ANY, args...)->Bool)
 add_tfunc(Core.Intrinsics.arraylen, 1, 1, x->Int)
-add_tfunc(arraysize, 2, 2, (a,d)->Int)
+add_tfunc(arraysize, 2, 2, (a::ANY, d::ANY)->Int)
 add_tfunc(pointerref, 3, 3,
-          function (a,i,align)
+          function (a::ANY, i::ANY, align::ANY)
               a = widenconst(a)
-              isa(a,DataType) && a<:Ptr && isa(a.parameters[1],Union{Type,TypeVar}) ? a.parameters[1] : Any
+              return isa(a,DataType) && a<:Ptr && isa(a.parameters[1],Union{Type,TypeVar}) ? a.parameters[1] : Any
           end)
-add_tfunc(pointerset, 4, 4, (a,v,i,align)->a)
+add_tfunc(pointerset, 4, 4, (a::ANY, v::ANY, i::ANY, align::ANY) -> a)
 
 function typeof_tfunc(t::ANY)
-    if isa(t,Const)
-        return Type{typeof(t.val)}
+    return if isa(t,Const)
+        Type{typeof(t.val)}
     elseif isType(t)
         t = t.parameters[1]
         if isa(t,TypeVar)
@@ -367,7 +367,7 @@ function typeof_tfunc(t::ANY)
 end
 add_tfunc(typeof, 1, 1, typeof_tfunc)
 add_tfunc(typeassert, 2, 2,
-          function (v, t)
+          function (v::ANY, t::ANY)
               if isType(t)
                   if isa(v,Const)
                       if isleaftype(t) && !isa(v.val, t.parameters[1])
@@ -380,7 +380,7 @@ add_tfunc(typeassert, 2, 2,
               return v
           end)
 add_tfunc(isa, 2, 2,
-          function (v, t)
+          function (v::ANY, t::ANY)
               if isType(t) && isleaftype(t)
                   if v ⊑ t.parameters[1]
                       return Const(true)
@@ -391,7 +391,7 @@ add_tfunc(isa, 2, 2,
               return Bool
           end)
 add_tfunc(issubtype, 2, 2,
-          function (a, b)
+          function (a::ANY, b::ANY)
               if isType(a) && isType(b) && isleaftype(a) && isleaftype(b)
                   return Const(issubtype(a.parameters[1], b.parameters[1]))
               end
@@ -408,7 +408,7 @@ function type_depth(t::ANY)
     return 0
 end
 
-function limit_type_depth(t::ANY, d::Int, cov::Bool, vars)
+function limit_type_depth(t::ANY, d::Int, cov::Bool, vars::Vector{Any})
     if isa(t,TypeVar) || isa(t,TypeConstructor)
         return t
     end
@@ -543,9 +543,9 @@ function getfield_tfunc(s0::ANY, name)
         end
     end
 end
-add_tfunc(getfield, 2, 2, (s,name)->getfield_tfunc(s,name)[1])
-add_tfunc(setfield!, 3, 3, (o, f, v)->v)
-function fieldtype_tfunc(s::ANY, name)
+add_tfunc(getfield, 2, 2, (s::ANY, name::ANY) -> getfield_tfunc(s, name)[1])
+add_tfunc(setfield!, 3, 3, (o::ANY, f::ANY, v::ANY) -> v)
+function fieldtype_tfunc(s::ANY, name::ANY)
     if isType(s)
         s = s.parameters[1]
     else
@@ -555,7 +555,7 @@ function fieldtype_tfunc(s::ANY, name)
     if is(t,Bottom)
         return t
     end
-    Type{exact || isleaftype(t) || isa(t,TypeVar) || isvarargtype(t) ? t : TypeVar(:_, t)}
+    return Type{exact || isleaftype(t) || isa(t,TypeVar) || isvarargtype(t) ? t : TypeVar(:_, t)}
 end
 add_tfunc(fieldtype, 2, 2, fieldtype_tfunc)
 
@@ -994,7 +994,7 @@ function abstract_apply(af::ANY, fargs, aargtypes::Vector{Any}, vtypes::VarTable
     return abstract_call(af, (), Any[type_typeof(af), Vararg{Any}], vtypes, sv)
 end
 
-function pure_eval_call(f::ANY, argtypes::ANY, atype, vtypes, sv)
+function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv::InferenceState)
     for a in drop(argtypes,1)
         if !(isa(a,Const) || isconstType(a,false))
             return false
@@ -2040,7 +2040,7 @@ function record_slot_type!(id, vt::ANY, slottypes)
     end
 end
 
-function eval_annotate(e::ANY, vtypes::ANY, sv::InferenceState, undefs, pass)
+function eval_annotate(e::ANY, vtypes::ANY, sv::InferenceState, undefs::Array{Bool,1}, pass::Int)
     if isa(e, Slot)
         id = (e::Slot).id
         s = vtypes[id]
@@ -3168,14 +3168,14 @@ function delete_var!(src::CodeInfo, id, T)
     return src
 end
 
-function slot_replace!(src::CodeInfo, id, rhs, T)
+function slot_replace!(src::CodeInfo, id::Int, rhs::ANY, T::ANY)
     for i = 1:length(src.code)
         src.code[i] = _slot_replace!(src.code[i], id, rhs, T)
     end
     return src
 end
 
-function _slot_replace!(e, id, rhs, T::ANY)
+function _slot_replace!(e, id::Int, rhs::ANY, T::ANY)
     if isa(e,T) && e.id == id
         return rhs
     end
@@ -3255,7 +3255,7 @@ symequal(x::Slot    , y::Slot)     = is(x.id,y.id)
 symequal(x::ANY     , y::ANY)      = is(x,y)
 
 function occurs_outside_getfield(e::ANY, sym::ANY,
-                                 sv::InferenceState, field_count, field_names)
+                                 sv::InferenceState, field_count::Int, field_names::ANY)
     if e===sym || (isa(e,Slot) && isa(sym,Slot) && (e::Slot).id == (sym::Slot).id)
         return true
     end
@@ -3361,7 +3361,7 @@ function meta_elim_pass!(code::Array{Any,1}, propagate_inbounds::Bool, do_covera
     #    not too common.
     check_bounds = JLOptions().check_bounds
 
-    inbounds_stack = propagate_inbounds ? Bool[] : [false]
+    inbounds_stack = propagate_inbounds ? Bool[] : Bool[false]
     # Whether the push is deleted (therefore if the pop has to be too)
     # Shared for `Expr(:boundscheck)` and `Expr(:inbounds)`
     bounds_elim_stack = Bool[]
@@ -3370,7 +3370,7 @@ function meta_elim_pass!(code::Array{Any,1}, propagate_inbounds::Bool, do_covera
     # The clearing needs to be propagated up during pop
     # This is not pushed to if the push is already eliminated
     # Also shared for `Expr(:boundscheck)` and `Expr(:inbounds)`
-    bounds_push_pos_stack = [0] # always non-empty
+    bounds_push_pos_stack = Int[0] # always non-empty
     # Number of boundscheck pushes in a eliminated boundscheck block
     void_boundscheck_depth = 0
     is_inbounds = check_bounds == 2
@@ -3378,9 +3378,9 @@ function meta_elim_pass!(code::Array{Any,1}, propagate_inbounds::Bool, do_covera
 
     # Position of the last line number node without any non-meta expressions
     # in between.
-    prev_dbg_stack = [0] # always non-empty
+    prev_dbg_stack = Int[0] # always non-empty
     # Whether there's any non-meta exprs after the enclosing `push_loc`
-    push_loc_pos_stack = [0] # always non-empty
+    push_loc_pos_stack = Int[0] # always non-empty
 
     for i in 1:length(code)
         ex = code[i]
@@ -3923,10 +3923,29 @@ end
 
 # make sure that typeinf is executed before turning on typeinf_ext
 # this ensures that typeinf_ext doesn't recurse before it can add the item to the workq
+# especially try to make sure any recursive and leaf functions have concrete signatures,
+# since we won't be able to specialize & infer them at runtime
 
-for m in _methods_by_ftype(Tuple{typeof(typeinf_loop), Vararg{Any}}, 10)
-    typeinf_type(m[3], m[1], m[2])
-end
-for m in _methods_by_ftype(Tuple{typeof(typeinf_edge), Vararg{Any}}, 10)
-    typeinf_type(m[3], m[1], m[2])
+let fs = Any[typeinf_ext, typeinf_loop, typeinf_edge, occurs_outside_getfield, eval_annotate, pure_eval_call]
+    for x in t_ffunc_val
+        push!(fs, x[3])
+    end
+    for i = 1:length(t_ifunc)
+        if isassigned(t_ifunc, i)
+            x = t_ifunc[i]
+            push!(fs, x[3])
+        end
+    end
+    for f in fs
+        for m in _methods_by_ftype(Tuple{typeof(f), Vararg{Any}}, 10)
+            # remove any TypeVars from the intersection
+            typ = Any[m[1].parameters...]
+            for i = 1:length(typ)
+                if isa(typ[i], TypeVar)
+                    typ[i] = typ[i].ub
+                end
+            end
+            typeinf_type(m[3], Tuple{typ...}, m[2])
+        end
+    end
 end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2490,7 +2490,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
                 end
                 local ret_var, merge
                 if spec_miss !== nothing
-                    ret_var = add_slot!(sv.src, ex.typ, false)
+                    ret_var = add_slot!(sv.src, widenconst(ex.typ), false)
                     merge = genlabel(sv)
                     push!(stmts, spec_miss)
                     push!(stmts, Expr(:(=), ret_var, ex))
@@ -3140,7 +3140,7 @@ const compiler_temp_sym = Symbol("#temp#")
 function add_slot!(src::CodeInfo, typ::ANY, is_sa::Bool, name::Symbol=compiler_temp_sym)
     id = length(src.slotnames) + 1
     push!(src.slotnames, name)
-    push!(src.slottypes, typ)
+    push!(src.slottypes, typ); @assert !isa(typ, Const)
     push!(src.slotflags, Slot_Assigned + is_sa * Slot_AssignedOnce)
     return SlotNumber(id)
 end
@@ -3753,7 +3753,7 @@ function alloc_elim_pass!(sv::InferenceState)
                             tmpv = newvar!(sv, elty)
                         else
                             var = var::Slot
-                            tmpv = add_slot!(sv.src, elty, false,
+                            tmpv = add_slot!(sv.src, widenconst(elty), false,
                                              sv.src.slotnames[var.id])
                             slot_id = tmpv.id
                             new_slots[j] = slot_id

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -64,9 +64,6 @@ end
 @pure function rationalize{T<:Integer}(::Type{T}, x::Irrational; tol::Real=0)
     return rationalize(T, big(x), tol=tol)
 end
-@pure function rationalize{T<:Integer}(::Type{T}, x::Irrational)
-    return rationalize(T, big(x), tol=0)
-end
 @pure function lessrational{T<:Integer}(rx::Rational{T}, x::Irrational)
     # an @pure version of `<` for determining if the rationalization of
     # an irrational number required rounding up or down

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -57,27 +57,44 @@ end
     x < big(y)
 end
 
-<=(x::Irrational,y::AbstractFloat) = x < y
-<=(x::AbstractFloat,y::Irrational) = x < y
+<=(x::Irrational, y::AbstractFloat) = x < y
+<=(x::AbstractFloat, y::Irrational) = x < y
 
 # Irrational vs Rational
-@generated function <{T}(x::Irrational, y::Rational{T})
-    bx = big(x())
-    bx < 0 && T <: Unsigned && return true
-    rx = rationalize(T,bx,tol=0)
-    rx < bx ? :($rx < y) : :($rx <= y)
+@pure function rationalize{T<:Integer}(::Type{T}, x::Irrational; tol::Real=0)
+    return rationalize(T, big(x), tol=tol)
 end
-@generated function <{T}(x::Rational{T}, y::Irrational)
-    by = big(y())
-    by < 0 && T <: Unsigned && return false
-    ry = rationalize(T,by,tol=0)
-    ry < by ? :(x <= $ry) : :(x < $ry)
+@pure function rationalize{T<:Integer}(::Type{T}, x::Irrational)
+    return rationalize(T, big(x), tol=0)
+end
+@pure function lessrational{T<:Integer}(rx::Rational{T}, x::Irrational)
+    # an @pure version of `<` for determining if the rationalization of
+    # an irrational number required rounding up or down
+    return rx < big(x)
+end
+function <{T}(x::Irrational, y::Rational{T})
+    T <: Unsigned && x < 0.0 && return true
+    rx = rationalize(T, x)
+    if lessrational(rx, x)
+        return rx < y
+    else
+        return rx <= y
+    end
+end
+function <{T}(x::Rational{T}, y::Irrational)
+    T <: Unsigned && y < 0.0 && return false
+    ry = rationalize(T, y)
+    if lessrational(ry, y)
+        return x <= ry
+    else
+        return x < ry
+    end
 end
 <(x::Irrational, y::Rational{BigInt}) = big(x) < y
 <(x::Rational{BigInt}, y::Irrational) = x < big(y)
 
-<=(x::Irrational,y::Rational) = x < y
-<=(x::Rational,y::Irrational) = x < y
+<=(x::Irrational, y::Rational) = x < y
+<=(x::Rational, y::Irrational) = x < y
 
 isfinite(::Irrational) = true
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -2,169 +2,168 @@
 
 ### Multidimensional iterators
 module IteratorsMD
+    import Base: eltype, length, size, start, done, next, last, in, getindex,
+                 setindex!, linearindexing, min, max, zero, one, isless, eachindex,
+                 ndims, iteratorsize, to_index
 
-import Base: eltype, length, size, start, done, next, last, in, getindex,
-             setindex!, linearindexing, min, max, zero, one, isless, eachindex,
-             ndims, iteratorsize, to_index
+    importall ..Base.Operators
+    import Base: simd_outer_range, simd_inner_length, simd_index
+    using Base: LinearFast, LinearSlow, AbstractCartesianIndex, fill_to_length, tail
 
-importall ..Base.Operators
-import Base: simd_outer_range, simd_inner_length, simd_index
-using Base: LinearFast, LinearSlow, AbstractCartesianIndex, fill_to_length, tail
+    export CartesianIndex, CartesianRange
 
-export CartesianIndex, CartesianRange
-
-# CartesianIndex
-immutable CartesianIndex{N} <: AbstractCartesianIndex{N}
-    I::NTuple{N,Int}
-    CartesianIndex(index::NTuple{N,Integer}) = new(index)
-end
-
-CartesianIndex{N}(index::NTuple{N,Integer}) = CartesianIndex{N}(index)
-(::Type{CartesianIndex})(index::Integer...) = CartesianIndex(index)
-(::Type{CartesianIndex{N}}){N}(index::Vararg{Integer,N}) = CartesianIndex{N}(index)
-# Allow passing tuples smaller than N
-(::Type{CartesianIndex{N}}){N}(index::Tuple) = CartesianIndex{N}(fill_to_length(index, 1, Val{N}))
-(::Type{CartesianIndex{N}}){N}(index::Integer...) = CartesianIndex{N}(index)
-(::Type{CartesianIndex{N}}){N}() = CartesianIndex{N}(())
-# Un-nest passed CartesianIndexes
-CartesianIndex(index::Union{Integer, CartesianIndex}...) = CartesianIndex(flatten(index))
-flatten(I::Tuple{}) = I
-flatten(I::Tuple{Any}) = I
-flatten{N}(I::Tuple{CartesianIndex{N}}) = I[1].I
-@inline flatten(I) = _flatten(I...)
-@inline _flatten() = ()
-@inline _flatten(i, I...)                 = (i, _flatten(I...)...)
-@inline _flatten(i::CartesianIndex, I...) = (i.I..., _flatten(I...)...)
-CartesianIndex(index::Tuple{Vararg{Union{Integer, CartesianIndex}}}) = CartesianIndex(index...)
-
-# length
-length{N}(::CartesianIndex{N})=N
-length{N}(::Type{CartesianIndex{N}})=N
-
-# indexing
-getindex(index::CartesianIndex, i::Integer) = index.I[i]
-
-# zeros and ones
-zero{N}(::CartesianIndex{N}) = zero(CartesianIndex{N})
-zero{N}(::Type{CartesianIndex{N}}) = CartesianIndex(ntuple(x -> 0, Val{N}))
-one{N}(::CartesianIndex{N}) = one(CartesianIndex{N})
-one{N}(::Type{CartesianIndex{N}}) = CartesianIndex(ntuple(x -> 1, Val{N}))
-
-# arithmetic, min/max
-(-){N}(index::CartesianIndex{N}) = CartesianIndex{N}(map(-, index.I))
-(+){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(+, index1.I, index2.I))
-(-){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(-, index1.I, index2.I))
-min{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(min, index1.I, index2.I))
-max{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(max, index1.I, index2.I))
-
-(+){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x+i, index.I))
-(+){N}(i::Integer, index::CartesianIndex{N}) = index+i
-(-){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x-i, index.I))
-(-){N}(i::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->i-x, index.I))
-(*){N}(a::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->a*x, index.I))
-(*)(index::CartesianIndex,a::Integer)=*(a,index)
-
-# comparison
-@inline isless{N}(I1::CartesianIndex{N}, I2::CartesianIndex{N}) = _isless(0, I1.I, I2.I)
-@inline function _isless{N}(ret, I1::NTuple{N,Int}, I2::NTuple{N,Int})
-    newret = ifelse(ret==0, icmp(I1[N], I2[N]), ret)
-    _isless(newret, Base.front(I1), Base.front(I2))
-end
-_isless(ret, ::Tuple{}, ::Tuple{}) = ifelse(ret==1, true, false)
-icmp(a, b) = ifelse(isless(a,b), 1, ifelse(a==b, 0, -1))
-
-# Iteration
-immutable CartesianRange{I<:CartesianIndex}
-    start::I
-    stop::I
-end
-
-CartesianRange{N}(index::CartesianIndex{N}) = CartesianRange(one(index), index)
-CartesianRange(::Tuple{}) = CartesianRange{CartesianIndex{0}}(CartesianIndex{0}(()),CartesianIndex{0}(()))
-CartesianRange{N}(sz::NTuple{N,Int}) = CartesianRange(CartesianIndex(sz))
-CartesianRange{N}(rngs::NTuple{N,Union{Integer,AbstractUnitRange}}) = CartesianRange(CartesianIndex(map(first, rngs)), CartesianIndex(map(last, rngs)))
-
-ndims(R::CartesianRange) = length(R.start)
-ndims{I<:CartesianIndex}(::Type{CartesianRange{I}}) = length(I)
-
-eachindex(::LinearSlow, A::AbstractArray) = CartesianRange(indices(A))
-
-@inline eachindex(::LinearSlow, A::AbstractArray, B::AbstractArray...) = CartesianRange(maxsize((), A, B...))
-maxsize(sz) = sz
-@inline maxsize(sz, A, B...) = maxsize(maxt(sz, size(A)), B...)
-@inline maxt(a::Tuple{}, b::Tuple{}) = ()
-@inline maxt(a::Tuple{}, b::Tuple)   = b
-@inline maxt(a::Tuple,   b::Tuple{}) = a
-@inline maxt(a::Tuple,   b::Tuple)   = (max(a[1], b[1]), maxt(tail(a), tail(b))...)
-
-eltype{I}(::Type{CartesianRange{I}}) = I
-iteratorsize{I}(::Type{CartesianRange{I}}) = Base.HasShape()
-
-@inline function start{I<:CartesianIndex}(iter::CartesianRange{I})
-    if any(map(>, iter.start.I, iter.stop.I))
-        return iter.stop+1
+    # CartesianIndex
+    immutable CartesianIndex{N} <: AbstractCartesianIndex{N}
+        I::NTuple{N,Int}
+        CartesianIndex(index::NTuple{N,Integer}) = new(index)
     end
-    iter.start
-end
-@inline function next{I<:CartesianIndex}(iter::CartesianRange{I}, state)
-    state, I(inc(state.I, iter.start.I, iter.stop.I))
-end
-# increment & carry
-@inline inc(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
-@inline inc(state::Tuple{Int}, start::Tuple{Int}, stop::Tuple{Int}) = (state[1]+1,)
-@inline function inc(state, start, stop)
-    if state[1] < stop[1]
-        return (state[1]+1,tail(state)...)
+
+    CartesianIndex{N}(index::NTuple{N,Integer}) = CartesianIndex{N}(index)
+    (::Type{CartesianIndex})(index::Integer...) = CartesianIndex(index)
+    (::Type{CartesianIndex{N}}){N}(index::Vararg{Integer,N}) = CartesianIndex{N}(index)
+    # Allow passing tuples smaller than N
+    (::Type{CartesianIndex{N}}){N}(index::Tuple) = CartesianIndex{N}(fill_to_length(index, 1, Val{N}))
+    (::Type{CartesianIndex{N}}){N}(index::Integer...) = CartesianIndex{N}(index)
+    (::Type{CartesianIndex{N}}){N}() = CartesianIndex{N}(())
+    # Un-nest passed CartesianIndexes
+    CartesianIndex(index::Union{Integer, CartesianIndex}...) = CartesianIndex(flatten(index))
+    flatten(I::Tuple{}) = I
+    flatten(I::Tuple{Any}) = I
+    flatten{N}(I::Tuple{CartesianIndex{N}}) = I[1].I
+    @inline flatten(I) = _flatten(I...)
+    @inline _flatten() = ()
+    @inline _flatten(i, I...)                 = (i, _flatten(I...)...)
+    @inline _flatten(i::CartesianIndex, I...) = (i.I..., _flatten(I...)...)
+    CartesianIndex(index::Tuple{Vararg{Union{Integer, CartesianIndex}}}) = CartesianIndex(index...)
+
+    # length
+    length{N}(::CartesianIndex{N})=N
+    length{N}(::Type{CartesianIndex{N}})=N
+
+    # indexing
+    getindex(index::CartesianIndex, i::Integer) = index.I[i]
+
+    # zeros and ones
+    zero{N}(::CartesianIndex{N}) = zero(CartesianIndex{N})
+    zero{N}(::Type{CartesianIndex{N}}) = CartesianIndex(ntuple(x -> 0, Val{N}))
+    one{N}(::CartesianIndex{N}) = one(CartesianIndex{N})
+    one{N}(::Type{CartesianIndex{N}}) = CartesianIndex(ntuple(x -> 1, Val{N}))
+
+    # arithmetic, min/max
+    (-){N}(index::CartesianIndex{N}) = CartesianIndex{N}(map(-, index.I))
+    (+){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(+, index1.I, index2.I))
+    (-){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(-, index1.I, index2.I))
+    min{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(min, index1.I, index2.I))
+    max{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(max, index1.I, index2.I))
+
+    (+){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x+i, index.I))
+    (+){N}(i::Integer, index::CartesianIndex{N}) = index+i
+    (-){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x-i, index.I))
+    (-){N}(i::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->i-x, index.I))
+    (*){N}(a::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->a*x, index.I))
+    (*)(index::CartesianIndex,a::Integer)=*(a,index)
+
+    # comparison
+    @inline isless{N}(I1::CartesianIndex{N}, I2::CartesianIndex{N}) = _isless(0, I1.I, I2.I)
+    @inline function _isless{N}(ret, I1::NTuple{N,Int}, I2::NTuple{N,Int})
+        newret = ifelse(ret==0, icmp(I1[N], I2[N]), ret)
+        _isless(newret, Base.front(I1), Base.front(I2))
     end
-    newtail = inc(tail(state), tail(start), tail(stop))
-    (start[1], newtail...)
-end
-@inline done{I<:CartesianIndex}(iter::CartesianRange{I}, state) = state.I[end] > iter.stop.I[end]
+    _isless(ret, ::Tuple{}, ::Tuple{}) = ifelse(ret==1, true, false)
+    icmp(a, b) = ifelse(isless(a,b), 1, ifelse(a==b, 0, -1))
 
-# 0-d cartesian ranges are special-cased to iterate once and only once
-start{I<:CartesianIndex{0}}(iter::CartesianRange{I}) = false
-next{I<:CartesianIndex{0}}(iter::CartesianRange{I}, state) = iter.start, true
-done{I<:CartesianIndex{0}}(iter::CartesianRange{I}, state) = state
+    # Iteration
+    immutable CartesianRange{I<:CartesianIndex}
+        start::I
+        stop::I
+    end
 
-size{I<:CartesianIndex}(iter::CartesianRange{I}) = map(dimlength, iter.start.I, iter.stop.I)
-dimlength(start, stop) = stop-start+1
+    CartesianRange{N}(index::CartesianIndex{N}) = CartesianRange(one(index), index)
+    CartesianRange(::Tuple{}) = CartesianRange{CartesianIndex{0}}(CartesianIndex{0}(()),CartesianIndex{0}(()))
+    CartesianRange{N}(sz::NTuple{N,Int}) = CartesianRange(CartesianIndex(sz))
+    CartesianRange{N}(rngs::NTuple{N,Union{Integer,AbstractUnitRange}}) = CartesianRange(CartesianIndex(map(first, rngs)), CartesianIndex(map(last, rngs)))
 
-length(iter::CartesianRange) = prod(size(iter))
+    ndims(R::CartesianRange) = length(R.start)
+    ndims{I<:CartesianIndex}(::Type{CartesianRange{I}}) = length(I)
 
-last(iter::CartesianRange) = iter.stop
+    eachindex(::LinearSlow, A::AbstractArray) = CartesianRange(indices(A))
 
-to_index(c::CartesianIndex) = c
+    @inline eachindex(::LinearSlow, A::AbstractArray, B::AbstractArray...) = CartesianRange(maxsize((), A, B...))
+    maxsize(sz) = sz
+    @inline maxsize(sz, A, B...) = maxsize(maxt(sz, size(A)), B...)
+    @inline maxt(a::Tuple{}, b::Tuple{}) = ()
+    @inline maxt(a::Tuple{}, b::Tuple)   = b
+    @inline maxt(a::Tuple,   b::Tuple{}) = a
+    @inline maxt(a::Tuple,   b::Tuple)   = (max(a[1], b[1]), maxt(tail(a), tail(b))...)
 
-@inline function in{I<:CartesianIndex}(i::I, r::CartesianRange{I})
-    _in(true, i.I, r.start.I, r.stop.I)
-end
-_in(b, ::Tuple{}, ::Tuple{}, ::Tuple{}) = b
-@inline _in(b, i, start, stop) = _in(b & (start[1] <= i[1] <= stop[1]), tail(i), tail(start), tail(stop))
+    eltype{I}(::Type{CartesianRange{I}}) = I
+    iteratorsize{I}(::Type{CartesianRange{I}}) = Base.HasShape()
 
-simd_outer_range(iter::CartesianRange{CartesianIndex{0}}) = iter
-function simd_outer_range{I}(iter::CartesianRange{I})
-    start = CartesianIndex(tail(iter.start.I))
-    stop  = CartesianIndex(tail(iter.stop.I))
-    CartesianRange(start, stop)
-end
+    @inline function start{I<:CartesianIndex}(iter::CartesianRange{I})
+        if any(map(>, iter.start.I, iter.stop.I))
+            return iter.stop+1
+        end
+        iter.start
+    end
+    @inline function next{I<:CartesianIndex}(iter::CartesianRange{I}, state)
+        state, I(inc(state.I, iter.start.I, iter.stop.I))
+    end
+    # increment & carry
+    @inline inc(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
+    @inline inc(state::Tuple{Int}, start::Tuple{Int}, stop::Tuple{Int}) = (state[1]+1,)
+    @inline function inc(state, start, stop)
+        if state[1] < stop[1]
+            return (state[1]+1,tail(state)...)
+        end
+        newtail = inc(tail(state), tail(start), tail(stop))
+        (start[1], newtail...)
+    end
+    @inline done{I<:CartesianIndex}(iter::CartesianRange{I}, state) = state.I[end] > iter.stop.I[end]
 
-simd_inner_length{I<:CartesianIndex{0}}(iter::CartesianRange{I}, ::CartesianIndex) = 1
-simd_inner_length(iter::CartesianRange, I::CartesianIndex) = iter.stop[1]-iter.start[1]+1
+    # 0-d cartesian ranges are special-cased to iterate once and only once
+    start{I<:CartesianIndex{0}}(iter::CartesianRange{I}) = false
+    next{I<:CartesianIndex{0}}(iter::CartesianRange{I}, state) = iter.start, true
+    done{I<:CartesianIndex{0}}(iter::CartesianRange{I}, state) = state
 
-simd_index{I<:CartesianIndex{0}}(iter::CartesianRange{I}, ::CartesianIndex, I1::Int) = iter.start
-@inline function simd_index{N}(iter::CartesianRange, Ilast::CartesianIndex{N}, I1::Int)
-    CartesianIndex((I1+iter.start[1], Ilast.I...))
-end
+    size{I<:CartesianIndex}(iter::CartesianRange{I}) = map(dimlength, iter.start.I, iter.stop.I)
+    dimlength(start, stop) = stop-start+1
 
-# Split out the first N elements of a tuple
-@inline split{N}(t, V::Type{Val{N}}) = _split((), t, V)
-@inline _split(tN, trest, V) = _split((tN..., trest[1]), tail(trest), V)
-# exit either when we've exhausted the input tuple or when tN has length N
-@inline _split{N}(tN::NTuple{N}, ::Tuple{}, ::Type{Val{N}}) = tN, ()  # ambig.
-@inline _split{N}(tN,            ::Tuple{}, ::Type{Val{N}}) = tN, ()
-@inline _split{N}(tN::NTuple{N},  trest,    ::Type{Val{N}}) = tN, trest
+    length(iter::CartesianRange) = prod(size(iter))
 
+    last(iter::CartesianRange) = iter.stop
+
+    to_index(c::CartesianIndex) = c
+
+    @inline function in{I<:CartesianIndex}(i::I, r::CartesianRange{I})
+        _in(true, i.I, r.start.I, r.stop.I)
+    end
+    _in(b, ::Tuple{}, ::Tuple{}, ::Tuple{}) = b
+    @inline _in(b, i, start, stop) = _in(b & (start[1] <= i[1] <= stop[1]), tail(i), tail(start), tail(stop))
+
+    simd_outer_range(iter::CartesianRange{CartesianIndex{0}}) = iter
+    function simd_outer_range{I}(iter::CartesianRange{I})
+        start = CartesianIndex(tail(iter.start.I))
+        stop  = CartesianIndex(tail(iter.stop.I))
+        CartesianRange(start, stop)
+    end
+
+    simd_inner_length{I<:CartesianIndex{0}}(iter::CartesianRange{I}, ::CartesianIndex) = 1
+    simd_inner_length(iter::CartesianRange, I::CartesianIndex) = iter.stop[1]-iter.start[1]+1
+
+    simd_index{I<:CartesianIndex{0}}(iter::CartesianRange{I}, ::CartesianIndex, I1::Int) = iter.start
+    @inline function simd_index{N}(iter::CartesianRange, Ilast::CartesianIndex{N}, I1::Int)
+        CartesianIndex((I1+iter.start[1], Ilast.I...))
+    end
+
+    # Split out the first N elements of a tuple
+    @inline split{N}(t, V::Type{Val{N}}) = _split((), t, V)
+    @inline _split(tN, trest, V) = _split((tN..., trest[1]), tail(trest), V)
+    # exit either when we've exhausted the input tuple or when tN has length N
+    @inline _split{N}(tN::NTuple{N}, ::Tuple{}, ::Type{Val{N}}) = tN, ()  # ambig.
+    @inline _split{N}(tN,            ::Tuple{}, ::Type{Val{N}}) = tN, ()
+    @inline _split{N}(tN::NTuple{N},  trest,    ::Type{Val{N}}) = tN, trest
 end  # IteratorsMD
+
 
 using .IteratorsMD
 
@@ -1119,3 +1118,41 @@ end
 
 indexoffset(i) = first(i)-1
 indexoffset(::Colon) = 0
+
+
+"""
+    extrema(A,dims) -> Array{Tuple}
+
+Compute the minimum and maximum elements of an array over the given dimensions.
+"""
+function extrema(A::AbstractArray, dims)
+    sz = [size(A)...]
+    sz[[dims...]] = 1
+    B = Array{Tuple{eltype(A),eltype(A)}}(sz...)
+    return extrema!(B, A)
+end
+
+@generated function extrema!{T,N}(B, A::AbstractArray{T,N})
+    return quote
+        sA = size(A)
+        sB = size(B)
+        @nloops $N i B begin
+            AI = @nref $N A i
+            (@nref $N B i) = (AI, AI)
+        end
+        Bmax = sB
+        Istart = ones(Int,ndims(A))
+        Istart[([sB...].==1) & ([sA...].!=1)] = 2
+        @inbounds @nloops $N i d->(Istart[d]:size(A,d)) begin
+            AI = @nref $N A i
+            @nexprs $N d->(j_d = min(Bmax[d], i_{d}))
+            BJ = @nref $N B j
+            if AI < BJ[1]
+                (@nref $N B j) = (AI, BJ[2])
+            elseif AI > BJ[2]
+                (@nref $N B j) = (BJ[1], AI)
+            end
+        end
+        return B
+    end
+end

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -512,43 +512,6 @@ function extrema(itr)
     return (vmin, vmax)
 end
 
-"""
-    extrema(A,dims) -> Array{Tuple}
-
-Compute the minimum and maximum elements of an array over the given dimensions.
-"""
-function extrema(A::AbstractArray, dims)
-    sz = [size(A)...]
-    sz[[dims...]] = 1
-    B = Array{Tuple{eltype(A),eltype(A)}}(sz...)
-    extrema!(B, A)
-end
-
-@generated function extrema!{T,N}(B, A::AbstractArray{T,N})
-    quote
-        sA = size(A)
-        sB = size(B)
-        @nloops $N i B begin
-            AI = @nref $N A i
-            (@nref $N B i) = (AI, AI)
-        end
-        Bmax = sB
-        Istart = ones(Int,ndims(A))
-        Istart[([sB...].==1) & ([sA...].!=1)] = 2
-        @inbounds @nloops $N i d->(Istart[d]:size(A,d)) begin
-            AI = @nref $N A i
-            @nexprs $N d->(j_d = min(Bmax[d], i_{d}))
-            BJ = @nref $N B j
-            if AI < BJ[1]
-                (@nref $N B j) = (AI, BJ[2])
-            elseif AI > BJ[2]
-                (@nref $N B j) = (BJ[1], AI)
-            end
-        end
-        B
-    end
-end
-
 ## all & any
 
 """

--- a/base/show.jl
+++ b/base/show.jl
@@ -616,7 +616,9 @@ function show_unquoted(io::IO, ex::Slot, ::Int, ::Int)
         if isa(slottypes, Array) && slotid <= length(slottypes::Array)
             slottype = slottypes[slotid]
             # The Slot in assignment can somehow have an Any type
-            slottype <: typ && (typ = slottype)
+            if slottype <: typ
+                typ = slottype
+            end
         end
     end
     slotnames = get(io, :SOURCE_SLOTNAMES, false)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -79,9 +79,9 @@ end
 Symbol(x...) = Symbol(string(x...))
 
 # array structures
+include("array.jl")
 include("abstractarray.jl")
 include("subarray.jl")
-include("array.jl")
 
 # Array convenience converting constructors
 (::Type{Array{T}}){T}(m::Integer) = Array{T,1}(Int(m))

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -893,12 +893,14 @@ the arguments are known, but the function is not yet compiled.
 Instead of performing some calculation or action, a generated function
 declaration returns a quoted expression which then forms the body for the
 method corresponding to the types of the arguments. When called, the body
-expression is compiled (or fetched from a cache, on subsequent calls) and
-only the returned expression - not the code that generated it - is evaluated.
+expression is first evaluated and compiled,
+then the returned expression is compiled and run.
+To make this efficient, the result is often cached.
+And to make this inferable, only a limited subset of the language is usable.
 Thus, generated functions provide a flexible framework to move work from
-run-time to compile-time.
+run-time to compile-time, at the expense of greater restrictions on the allowable constructs.
 
-When defining generated functions, there are three main differences to
+When defining generated functions, there are four main differences to
 ordinary functions:
 
 1. You annotate the function declaration with the ``@generated`` macro.
@@ -906,10 +908,17 @@ ordinary functions:
    this is a generated function.
 
 2. In the body of the generated function you only have access to the
-   *types* of the arguments, not their values.
+   *types* of the arguments -- not their values -- and any function that
+   was defined *before* the definition of the generated function.
 
 3. Instead of calculating something or performing some action, you return
    a *quoted expression* which, when evaluated, does what you want.
+
+4. Generated functions must not have any side-effects or examine any non-constant
+   global state (including, for example, IO, locks, or non-local dictionaries).
+   In other words, they must be completely pure.
+   Due to an implementation limitation,
+   this also means that they currently cannot define a closure or untyped generator.
 
 It's easiest to illustrate this with an example. We can declare a generated
 function ``foo`` as
@@ -917,13 +926,13 @@ function ``foo`` as
 .. doctest::
 
     julia> @generated function foo(x)
-               println(x)
-               return :(x*x)
+               Core.println(x)
+               return :(x * x)
            end
     foo (generic function with 1 method)
 
-Note that the body returns a quoted expression, namely ``:(x*x)``, rather
-than just the value of ``x*x``.
+Note that the body returns a quoted expression, namely ``:(x * x)``, rather
+than just the value of ``x * x``.
 
 From the caller's perspective, they are very similar to regular functions;
 in fact, you don't have to know if you're calling a regular or generated
@@ -958,31 +967,35 @@ used?
     julia> foo(4)
     16
 
-Note that there is no printout of :obj:`Int64`. The body of the generated
-function is only executed *once* (not entirely true, see note below) when
-the method for that specific set of argument types is compiled. After that,
-the expression returned from the generated function on the first invocation
-is re-used as the method body.
+Note that there is no printout of :obj:`Int64`. We can see that the body
+of the generated function was only executed once here,
+for the specific set of argument types, and the result was cached.
+After that, for this example, the expression returned from the generated
+function on the first invocation was re-used as the method body.
+However, the actual caching behavior is an implementation-defined performance optimization,
+so it is invalid to depend too closely on this behavior.
 
-The reason for the disclaimer above is that the number of times a generated
-function is generated is really an implementation detail; it *might* be only
-once, but it *might* also be more often. As a consequence, you should
-*never* write a generated function with side effects - when, and how often,
-the side effects occur is undefined. (This is true for macros too - and just
-like for macros, the use of :func:`eval` in a generated function is a sign that
+The number of times a generated function is generated *might* be only once,
+but it *might* also be more often, or appear to not happen at all.
+As a consequence, you should *never* write a generated function with side effects - when,
+and how often, the side effects occur is undefined.
+(This is true for macros too - and just like for macros,
+the use of :func:`eval` in a generated function is a sign that
 you're doing something the wrong way.)
+However, unlike macros, the runtime system cannot correctly handle a call to
+:func:`eval`, so it is disallowed.
 
 The example generated function ``foo`` above did not do anything a normal
-function ``foo(x)=x*x`` could not do, except printing the type on the
-first invocation (and incurring a higher compile-time cost). However, the
-power of a generated function lies in its ability to compute different quoted
-expression depending on the types passed to it:
+function ``foo(x) = x * x`` could not do (except printing the type on the
+first invocation, and incurring higher overhead).
+However, the power of a generated function lies in its ability to compute
+different quoted expressions depending on the types passed to it:
 
 .. doctest::
 
    julia> @generated function bar(x)
               if x <: Integer
-                  return :(x^2)
+                  return :(x ^ 2)
               else
                   return :(x)
               end
@@ -991,13 +1004,14 @@ expression depending on the types passed to it:
 
    julia> bar(4)
    16
+
    julia> bar("baz")
    "baz"
 
-(although of course this contrived example is easily implemented using
-multiple dispatch...)
+(although of course this contrived example would be more easily implemented
+using multiple dispatch...)
 
-We can, of course, abuse this to produce some interesting behavior:
+Abusing this will corrupt the runtime system and cause undefined behavior:
 
 .. doctest::
 
@@ -1011,13 +1025,8 @@ We can, of course, abuse this to produce some interesting behavior:
    baz (generic function with 1 method)
 
 
-Since the body of the generated function is non-deterministic, its behavior
-is undefined; the expression returned on the *first* invocation will be
-used for *all* subsequent invocations with the same type (again, with the
-exception covered by the disclaimer above). When we call the generated
-function with ``x`` of a new type, :func:`rand` will be called again to
-see which method body to use for the new type. In this case, for one
-*type* out of ten, ``baz(x)`` will return the string ``"boo!"``.
+Since the body of the generated function is non-deterministic, its behavior,
+*and the behavior of all subsequent code* is undefined.
 
 *Don't copy these examples!*
 
@@ -1025,15 +1034,43 @@ These examples are hopefully helpful to illustrate how generated functions
 work, both in the definition end and at the call site; however, *don't
 copy them*, for the following reasons:
 
-* the ``foo`` function has side-effects, and it is undefined exactly when,
+* the ``foo`` function has side-effects (the call to ``Core.println``), and it is undefined exactly when,
   how often or how many times these side-effects will occur
 * the ``bar`` function solves a problem that is better solved with multiple
-  dispatch - defining ``bar(x) = x`` and ``bar(x::Integer) = x^2`` will do
+  dispatch - defining ``bar(x) = x`` and ``bar(x::Integer) = x ^ 2`` will do
   the same thing, but it is both simpler and faster.
 * the ``baz`` function is pathologically insane
 
-Instead, now that we have a better understanding for how generated functions
-work, let's use them to build some more advanced functionality...
+Note that the set of operations that should not be attempted in a generated function
+is unbounded, and the runtime system can currently only detect a subset of
+the invalid operations. There are many other operations that will simply
+corrupt the runtime system without notification, usually in subtle
+ways not obviously connected to the bad definition.
+Because the function generator is run during inference,
+it must respect all of the limitations of that code.
+
+Some operations that should not be attempted include:
+
+  1. Caching of native pointers.
+
+  2. Interacting with the contents or methods of Core.Inference in any way.
+
+  3. Observing any mutable state.
+
+     - Inference on the generated function may be run at *any* time,
+       including while your code is attempting to observe or mutate this state.
+
+  4. Taking any locks: C code you call out to may use locks internally,
+     (for example, it is not problematic to call ``malloc``,
+     even though most implementations require locks internally)
+     but don't attempt to hold or acquire any while executing Julia code.
+
+  5. Calling any function that is defined after the body of the generated function.
+     This condition is relaxed for incrementally-loaded precompiled modules to
+     allow calling any function in the module.
+
+Alright, now that we have a better understanding of how generated functions
+work, let's use them to build some more advanced (and valid) functionality...
 
 An advanced example
 ~~~~~~~~~~~~~~~~~~~
@@ -1055,11 +1092,11 @@ possible implementation is the following::
 The same thing can be done using recursion::
 
     sub2ind_rec(dims::Tuple{}) = 1
-    sub2ind_rec(dims::Tuple{},i1::Integer, I::Integer...) =
-        i1==1 ? sub2ind_rec(dims,I...) : throw(BoundsError())
-    sub2ind_rec(dims::Tuple{Integer,Vararg{Integer}}, i1::Integer) = i1
-    sub2ind_rec(dims::Tuple{Integer,Vararg{Integer}}, i1::Integer, I::Integer...) =
-        i1 + dims[1]*(sub2ind_rec(tail(dims),I...)-1)
+    sub2ind_rec(dims::Tuple{}, i1::Integer, I::Integer...) =
+        i1 == 1 ? sub2ind_rec(dims, I...) : throw(BoundsError())
+    sub2ind_rec(dims::Tuple{Integer, Vararg{Integer}}, i1::Integer) = i1
+    sub2ind_rec(dims::Tuple{Integer, Vararg{Integer}}, i1::Integer, I::Integer...) =
+        i1 + dims[1] * (sub2ind_rec(tail(dims), I...) - 1)
 
 Both these implementations, although different, do essentially the same
 thing: a runtime loop over the dimensions of the array, collecting the
@@ -1076,8 +1113,8 @@ that calculates the index:
 
     @generated function sub2ind_gen{N}(dims::NTuple{N}, I::Integer...)
         ex = :(I[$N] - 1)
-        for i = N-1:-1:1
-            ex = :(I[$i] - 1 + dims[$i]*$ex)
+        for i = (N - 1):-1:1
+            ex = :(I[$i] - 1 + dims[$i] * $ex)
         end
         return :($ex + 1)
     end
@@ -1090,15 +1127,15 @@ function:
 .. doctest::
 
    julia> @generated function sub2ind_gen{N}(dims::NTuple{N}, I::Integer...)
-              sub2ind_gen_impl(dims, I...)
+              return sub2ind_gen_impl(dims, I...)
           end
    sub2ind_gen (generic function with 1 method)
 
    julia> function sub2ind_gen_impl{N}(dims::Type{NTuple{N}}, I...)
               length(I) == N || return :(error("partial indexing is unsupported"))
               ex = :(I[$N] - 1)
-              for i = N-1:-1:1
-                  ex = :(I[$i] - 1 + dims[$i]*$ex)
+              for i = (N - 1):-1:1
+                  ex = :(I[$i] - 1 + dims[$i] * $ex)
               end
               return :($ex + 1)
           end

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -529,8 +529,11 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         }
 
         func = (jl_code_info_t*)jl_expand((jl_value_t*)ex);
-        if (!jl_is_code_info(func))
+        if (!jl_is_code_info(func)) {
+            if (jl_is_expr(func) && ((jl_expr_t*)func)->head == error_sym)
+                jl_interpret_toplevel_expr((jl_value_t*)func);
             jl_error("generated function body is not pure. this likely means it contains a closure or comprehension.");
+        }
 
         jl_array_t *stmts = (jl_array_t*)func->code;
         for (i = 0, l = jl_array_len(stmts); i < l; i++) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -432,7 +432,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t
     return ret;
 }
 
-static jl_function_t *jl_append_any_func;
+jl_function_t *jl_append_any_func;
 
 JL_CALLABLE(jl_f__apply)
 {
@@ -468,7 +468,7 @@ JL_CALLABLE(jl_f__apply)
         else {
             if (jl_append_any_func == NULL) {
                 jl_append_any_func =
-                    (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("append_any"));
+                    (jl_function_t*)jl_get_global(jl_top_module, jl_symbol("append_any"));
                 if (jl_append_any_func == NULL) {
                     // error if append_any not available
                     JL_TYPECHK(apply, tuple, jl_typeof(args[i]));

--- a/src/gf.c
+++ b/src/gf.c
@@ -829,7 +829,7 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype
     sig = join_tsig(tt, entry->sig);
     jl_method_instance_t *nf;
     if (!cache) {
-        nf = jl_get_specialized(m, sig, env); // TODO: should be jl_specializations_get_linfo
+        nf = jl_specializations_get_linfo(m, sig, env);
     }
     else {
         nf = cache_method(mt, &mt->cache, (jl_value_t*)mt, sig, tt, entry, env, allow_exec);

--- a/src/module.c
+++ b/src/module.c
@@ -11,10 +11,11 @@
 extern "C" {
 #endif
 
-jl_module_t *jl_main_module=NULL;
-jl_module_t *jl_core_module=NULL;
-jl_module_t *jl_base_module=NULL;
-jl_module_t *jl_top_module=NULL;
+jl_module_t *jl_main_module = NULL;
+jl_module_t *jl_core_module = NULL;
+jl_module_t *jl_base_module = NULL;
+jl_module_t *jl_top_module = NULL;
+extern jl_function_t *jl_append_any_func;
 
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 {
@@ -62,8 +63,10 @@ JL_DLLEXPORT void jl_set_istopmod(uint8_t isprimary)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     ptls->current_module->istopmod = 1;
-    if (isprimary)
+    if (isprimary) {
         jl_top_module = ptls->current_module;
+        jl_append_any_func = NULL;
+    }
 }
 
 JL_DLLEXPORT uint8_t jl_istopmod(jl_module_t *mod)


### PR DESCRIPTION
Fixes some method definition orderings, and other `@generated` functions, that will be broken by PR #17057
