### PR TITLE
Fix another failing test with inlining off

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -231,7 +231,7 @@ module Tmp14173
 end
 whos(IOBuffer(), Tmp14173) # warm up
 const MEMDEBUG = ccall(:jl_is_memdebug, Bool, ())
-@test @allocated(whos(IOBuffer(), Tmp14173)) < (MEMDEBUG ? 30000 : 8000)
+@test @allocated(whos(IOBuffer(), Tmp14173)) < (MEMDEBUG ? 30000 : 10000)
 
 ## test conversion from UTF-8 to UTF-16 (for Windows APIs)
 


### PR DESCRIPTION
I've increased the limit even for inline cases since the number is actually really close (for me ~7**\* with inlining and 8**\* without).
