### PR TITLE
don't use `f` in `print` of Float32s

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -606,3 +606,6 @@ end
 
 # Test that REPL/mime display of invalid UTF-8 data doesn't throw an exception:
 @test isa(stringmime("text/plain", String(UInt8[0x00:0xff;])), String)
+
+# don't use julia-specific `f` in Float32 printing (PR #18053)
+@test sprint(print, 1f-7) == "1.0e-7"


### PR DESCRIPTION
This is intended to take the place of #18053. The change is minimal, only changing the `f` to an `e` in `print` or `string` of a `Float32`.
