### PR TITLE
Permit using string macro with "qualified" name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,10 +11,11 @@ Language changes
     nonstandard command literal is like a nonstandard string literal, but the
     syntax uses backquotes (``` ` ```) instead of double quotes, and the
     resulting macro called is suffixed with `_cmd`. For instance, the syntax
-    ``` q`xyz` ``` is equivalent to `@q_cmd "xyz"`.
+    ``` q`xyz` ``` is equivalent to `@q_cmd "xyz"`. ([#18644])
+    
   * Nonstandard string and command literals can now be qualified with their
     module. For instance, `Base.r"x"` is now parsed as `Base.@r_str "x"`.
-    Previously, this syntax parsed as an implicit multiplication.
+    Previously, this syntax parsed as an implicit multiplication. ([#18690])
 
 Breaking changes
 ----------------
@@ -716,6 +717,8 @@ Language tooling improvements
 [#18346]: https://github.com/JuliaLang/julia/issues/18346
 [#18442]: https://github.com/JuliaLang/julia/issues/18442
 [#18473]: https://github.com/JuliaLang/julia/issues/18473
+[#18644]: https://github.com/JuliaLang/julia/issues/18644
+[#18690]: https://github.com/JuliaLang/julia/issues/18690
 [#18839]: https://github.com/JuliaLang/julia/issues/18839
 [#18931]: https://github.com/JuliaLang/julia/issues/18931
 [#18977]: https://github.com/JuliaLang/julia/issues/18977

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,10 +7,6 @@ New language features
 Language changes
 ----------------
 
-  * The default color for info messages has been changed from blue to cyan.
-    This can be changed back to the original color by setting the environment variable `JULIA_INFO_COLOR` to `"blue"`.
-    One way of doing this is by adding `ENV["JULIA_INFO_COLOR"] = :blue` to the `.juliarc.jl` file.
-    For more information regarding customizing colors in the REPL, see this [manual section]( http://docs.julialang.org/en/latest/manual/interacting-with-julia/#customizing-colors).
   * Multiline and singleline nonstandard command literals have been added. A
     nonstandard command literal is like a nonstandard string literal, but the
     syntax uses backquotes (``` ` ```) instead of double quotes, and the

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,19 @@ New language features
 Language changes
 ----------------
 
+  * The default color for info messages has been changed from blue to cyan.
+    This can be changed back to the original color by setting the environment variable `JULIA_INFO_COLOR` to `"blue"`.
+    One way of doing this is by adding `ENV["JULIA_INFO_COLOR"] = :blue` to the `.juliarc.jl` file.
+    For more information regarding customizing colors in the REPL, see this [manual section]( http://docs.julialang.org/en/latest/manual/interacting-with-julia/#customizing-colors).
+  * Multiline and singleline command macros have been added. A command macro is
+    like a string macro, but the syntax uses backquotes (<code>\`</code>)
+    instead of double quotes, and the resulting macro called is suffixed with
+    `_cmd`. For instance, the syntax <code>q\`xyz\`</code> is equivalent to
+    `@q_cmd "xyz"`.
+  * String and command macros can now be qualified with their module. For
+    instance, `Base.r"x"` is now parsed as `Base.@r_str "x"`. Previously, this
+    syntax parsed as an implicit multiplication.
+
 Breaking changes
 ----------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,14 +11,14 @@ Language changes
     This can be changed back to the original color by setting the environment variable `JULIA_INFO_COLOR` to `"blue"`.
     One way of doing this is by adding `ENV["JULIA_INFO_COLOR"] = :blue` to the `.juliarc.jl` file.
     For more information regarding customizing colors in the REPL, see this [manual section]( http://docs.julialang.org/en/latest/manual/interacting-with-julia/#customizing-colors).
-  * Multiline and singleline command macros have been added. A command macro is
-    like a string macro, but the syntax uses backquotes (<code>\`</code>)
-    instead of double quotes, and the resulting macro called is suffixed with
-    `_cmd`. For instance, the syntax <code>q\`xyz\`</code> is equivalent to
-    `@q_cmd "xyz"`.
-  * String and command macros can now be qualified with their module. For
-    instance, `Base.r"x"` is now parsed as `Base.@r_str "x"`. Previously, this
-    syntax parsed as an implicit multiplication.
+  * Multiline and singleline nonstandard command literals have been added. A
+    nonstandard command literal is like a nonstandard string literal, but the
+    syntax uses backquotes (``` ` ```) instead of double quotes, and the
+    resulting macro called is suffixed with `_cmd`. For instance, the syntax
+    ``` q`xyz` ``` is equivalent to `@q_cmd "xyz"`.
+  * Nonstandard string and command literals can now be qualified with their
+    module. For instance, `Base.r"x"` is now parsed as `Base.@r_str "x"`.
+    Previously, this syntax parsed as an implicit multiplication.
 
 Breaking changes
 ----------------

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -864,13 +864,27 @@ majority of use cases, however, regular expressions are not constructed
 based on run-time data. In this majority of cases, the ability to write
 regular expressions as compile-time values is invaluable.
 
+Like non-standard string literals, non-standard command literals exist using a
+prefixed variant of the command literal syntax. The command literal
+``custom`literal``` is parsed as ``@custom_cmd "literal"``. Julia itself does
+not contain any non-standard command literals, but packages can make use of
+this syntax. Aside from the different syntax and the ``_cmd`` suffix instead of
+the ``_str`` suffix, non-standard command literals behave exactly like
+non-standard string literals.
+
+In the event that two modules provide non-standard string or command literals
+with the same name, it is possible to qualify the string or command literal
+with a module name. For instance, if both ``Foo`` and ``Bar`` provide
+non-standard string literal ``@x_str``, then one can write ``Foo.x"literal"``
+or ``Bar.x"literal"`` to disambiguate between the two.
+
 The mechanism for user-defined string literals is deeply, profoundly
 powerful. Not only are Julia's non-standard literals implemented using
 it, but also the command literal syntax (```echo "Hello, $person"```)
 is implemented with the following innocuous-looking macro::
 
     macro cmd(str)
-      :(cmd_gen($shell_parse(str)))
+      :(cmd_gen($(shell_parse(str)[1])))
     end
 
 Of course, a large amount of complexity is hidden in the functions used

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -845,3 +845,20 @@ begin
 end"""))
     @test !any(x->(x == Expr(:meta, :push_loc, :none)), ex.args)
 end
+
+# Check qualified string macros
+Base.r"regex" == r"regex"
+
+module QualifiedStringMacro
+module SubModule
+macro x_str(x)
+    1
+end
+macro y_cmd(x)
+    2
+end
+end
+end
+
+@test QualifiedStringMacro.SubModule.x"" === 1
+@test QualifiedStringMacro.SubModule.y`` === 2


### PR DESCRIPTION
@JeffBezanson raised some concerns in https://github.com/JuliaLang/julia/issues/14208#issuecomment-161090248, but I think that overall this change is fairly intuitive. Being able to call string macros that happen to have the same name in different modules is a big plus in my opinion.

Close #6970.
Close #14208.
