### PR TITLE
workers should ignore startupfile

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -218,13 +218,12 @@ function process_options(opts::JLOptions)
     global have_color     = (opts.color == 1)
     global is_interactive = (opts.isinteractive != 0)
     while true
-        # load ~/.juliarc file
-        startup && load_juliarc()
-
-        # startup worker
+        # startup worker.
+        # opts.startupfile, opts.load, etc should should not be processed for workers.
         if opts.worker != C_NULL
             start_worker(unsafe_string(opts.worker)) # does not return
         end
+
         # add processors
         if opts.nprocs > 0
             addprocs(opts.nprocs)
@@ -233,6 +232,10 @@ function process_options(opts::JLOptions)
         if opts.machinefile != C_NULL
             addprocs(load_machine_file(unsafe_string(opts.machinefile)))
         end
+
+        # load ~/.juliarc file
+        startup && load_juliarc()
+
         # load file immediately on all processors
         if opts.load != C_NULL
             @sync for p in procs()


### PR DESCRIPTION
Appears this is a regression that crept in during the 0.5 cycle. 

From http://docs.julialang.org/en/latest/manual/parallel-computing/#code-availability-and-loading-packages

```
Note that workers do not run a .juliarc.jl startup script, nor do they synchronize their 
global state (such as global variables, new method definitions, and loaded modules) 
with any of the other running processes.
```

Closes https://github.com/JuliaLang/julia/issues/17726
