### PR TITLE
Cleanup the usage of `jl_datatype_size`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -119,7 +119,8 @@ function show_default(io::IO, x::ANY)
     show(io, t)
     print(io, '(')
     nf = nfields(t)
-    if nf != 0 || t.size==0
+    nb = sizeof(x)
+    if nf != 0 || nb==0
         if !show_circular(io, x)
             recur_io = IOContext(io, :SHOWN_SET => x)
             for i=1:nf
@@ -135,7 +136,6 @@ function show_default(io::IO, x::ANY)
             end
         end
     else
-        nb = t.size
         print(io, "0x")
         p = data_pointer_from_objref(x)
         for i=nb-1:-1:0

--- a/src/abi_ppc64le.cpp
+++ b/src/abi_ppc64le.cpp
@@ -97,7 +97,7 @@ bool use_sret(AbiState *state, jl_datatype_t *dt)
 {
     jl_datatype_t *ty0 = NULL;
     bool hva = false;
-    if (dt->size > 16 && isHFA(dt, &ty0, &hva) > 8)
+    if (jl_datatype_size(dt) > 16 && isHFA(dt, &ty0, &hva) > 8)
         return true;
     return false;
 }
@@ -106,14 +106,14 @@ void needPassByRef(AbiState *state, jl_datatype_t *dt, bool *byRef, bool *inReg)
 {
     jl_datatype_t *ty0 = NULL;
     bool hva = false;
-    if (dt->size > 64 && isHFA(dt, &ty0, &hva) > 8)
+    if (jl_datatype_size(dt) > 64 && isHFA(dt, &ty0, &hva) > 8)
         *byRef = true;
 }
 
 Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
 {
     // Arguments are either scalar or passed by value
-    size_t size = dt->size;
+    size_t size = jl_datatype_size(dt);
     // don't need to change bitstypes
     if (!jl_datatype_nfields(dt))
         return NULL;

--- a/src/abi_win32.cpp
+++ b/src/abi_win32.cpp
@@ -44,7 +44,7 @@ bool use_sret(AbiState *state, jl_datatype_t *dt)
 {
     // Use sret if the size of the argument is not one of 1, 2, 4, 8 bytes
     // This covers the special case of Complex64
-    size_t size = dt->size;
+    size_t size = jl_datatype_size(dt);
     if (size == 1 || size == 2 || size == 4 || size == 8)
         return false;
     return true;
@@ -62,7 +62,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
     // rewrite integer sized (non-sret) struct to the corresponding integer
     if (!dt->layout->nfields)
         return NULL;
-    return Type::getIntNTy(jl_LLVMContext, dt->size * 8);
+    return Type::getIntNTy(jl_LLVMContext, jl_datatype_nbits(dt));
 }
 
 bool need_private_copy(jl_value_t *ty, bool byRef)

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -68,7 +68,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
 {
     size_t size = jl_datatype_size(dt);
     if (size > 0 && win64_reg_size(size) && !jl_is_bitstype(dt))
-        return Type::getIntNTy(jl_LLVMContext, size*8);
+        return Type::getIntNTy(jl_LLVMContext, jl_datatype_nbits(dt));
     return NULL;
 }
 

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -207,7 +207,8 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
     if (is_native_simd_type(dt))
         return NULL;
 
-    int size = jl_datatype_size(dt);
+    size_t size = jl_datatype_size(dt);
+    size_t nbits = jl_datatype_nbits(dt);
     if (size > 16 || size == 0)
         return NULL;
 
@@ -221,7 +222,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
             if (size >= 8)
                 types[0] = T_int64;
             else
-                types[0] = Type::getIntNTy(jl_LLVMContext, size*8);
+                types[0] = Type::getIntNTy(jl_LLVMContext, nbits);
             break;
         case Sse:
             if (size <= 4)
@@ -237,7 +238,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret)
             return types[0];
         case Integer:
             assert(size > 8);
-            types[1] = Type::getIntNTy(jl_LLVMContext, (size-8)*8);
+            types[1] = Type::getIntNTy(jl_LLVMContext, (nbits-64));
             return StructType::get(jl_LLVMContext,ArrayRef<Type*>(&types[0],2));
         case Sse:
             if (size <= 12)

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -229,7 +229,7 @@ JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
     va_list args;
     size_t nf = jl_datatype_nfields(type);
     va_start(args, type);
-    jl_value_t *jv = jl_gc_alloc(ptls, type->size, type);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
     for(size_t i=0; i < nf; i++) {
         jl_set_nth_field(jv, i, va_arg(args, jl_value_t*));
     }
@@ -243,7 +243,7 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
     jl_ptls_t ptls = jl_get_ptls_states();
     if (type->instance != NULL) return type->instance;
     size_t nf = jl_datatype_nfields(type);
-    jl_value_t *jv = jl_gc_alloc(ptls, type->size, type);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
     for(size_t i=0; i < na; i++) {
         jl_set_nth_field(jv, i, args[i]);
     }
@@ -259,7 +259,7 @@ JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (type->instance != NULL) return type->instance;
-    size_t size = type->size;
+    size_t size = jl_datatype_size(type);
     jl_value_t *jv = jl_gc_alloc(ptls, size, type);
     if (size > 0)
         memset(jl_data_ptr(jv), 0, size);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -329,7 +329,7 @@ JL_DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b)
         return dta->name == dtb->name && compare_svec(dta->parameters, dtb->parameters);
     }
     if (dt->mutabl) return 0;
-    size_t sz = dt->size;
+    size_t sz = jl_datatype_size(dt);
     if (sz == 0) return 1;
     size_t nf = jl_datatype_nfields(dt);
     if (nf == 0)
@@ -359,7 +359,7 @@ JL_CALLABLE(jl_f_sizeof)
         jl_datatype_t *dx = (jl_datatype_t*)x;
         if (dx->name == jl_array_typename || dx == jl_symbol_type || dx == jl_simplevector_type)
             jl_error("type does not have a canonical binary representation");
-        if (!(dx->name->names == jl_emptysvec && dx->size > 0)) {
+        if (!(dx->name->names == jl_emptysvec && jl_datatype_size(dx) > 0)) {
             // names===() and size > 0  =>  bitstype, size always known
             if (dx->abstract || !jl_is_leaf_type(x))
                 jl_error("argument is an abstract type; size is indeterminate");

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1172,7 +1172,7 @@ static std::string generate_func_sig(
                 // see pull req #978. need to annotate signext/zeroext for
                 // small integer arguments.
                 jl_datatype_t *bt = (jl_datatype_t*)tti;
-                if (bt->size < 4) {
+                if (jl_datatype_size(bt) < 4) {
                     if (jl_signed_type && jl_subtype(tti, (jl_value_t*)jl_signed_type, 0))
                         av = Attribute::SExt;
                     else

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2499,7 +2499,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     size_t nd = jl_is_long(ndp) ? jl_unbox_long(ndp) : 1;
                     Value *idx = emit_array_nd_index(ary, args[1], nd, &args[2], nargs-1, ctx);
                     if (jl_array_store_unboxed(ety) &&
-                        ((jl_datatype_t*)ety)->size == 0) {
+                        jl_datatype_size(ety) == 0) {
                         assert(jl_is_datatype(ety));
                         assert(((jl_datatype_t*)ety)->instance != NULL);
                         *ret = ghostValue(ety);
@@ -2534,7 +2534,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     size_t nd = jl_is_long(ndp) ? jl_unbox_long(ndp) : 1;
                     Value *idx = emit_array_nd_index(ary, args[1], nd, &args[3], nargs-2, ctx);
                     bool isboxed = !jl_array_store_unboxed(ety);
-                    if (!isboxed && ((jl_datatype_t*)ety)->size == 0) {
+                    if (!isboxed && jl_datatype_size(ety) == 0) {
                         // no-op, but emit expr for possible effects
                         assert(jl_is_datatype(ety));
                         emit_expr(args[2], ctx);
@@ -2739,8 +2739,8 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             // this is issue #8798
             sty != jl_datatype_type) {
             if (jl_is_leaf_type((jl_value_t*)sty) ||
-                (sty->name->names == jl_emptysvec && sty->size > 0)) {
-                *ret = mark_julia_type(ConstantInt::get(T_size, sty->size), false, jl_long_type, ctx);
+                (sty->name->names == jl_emptysvec && jl_datatype_size(sty) > 0)) {
+                *ret = mark_julia_type(ConstantInt::get(T_size, jl_datatype_size(sty)), false, jl_long_type, ctx);
                 JL_GC_POP();
                 return true;
             }

--- a/src/julia.h
+++ b/src/julia.h
@@ -767,6 +767,7 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x)
 #define jl_field_type(st,i)    jl_svecref(((jl_datatype_t*)st)->types, (i))
 #define jl_field_count(st)     jl_svec_len(((jl_datatype_t*)st)->types)
 #define jl_datatype_size(t)    (((jl_datatype_t*)t)->size)
+#define jl_datatype_nbits(t)   ((((jl_datatype_t*)t)->size)*8)
 #define jl_datatype_nfields(t) (((jl_datatype_t*)(t))->layout->nfields)
 
 // inline version with strong type check to detect typos in a `->name` chain
@@ -871,14 +872,14 @@ STATIC_INLINE int jl_is_bitstype(void *v)
     return (jl_is_datatype(v) && jl_is_immutable(v) &&
             ((jl_datatype_t*)(v))->layout &&
             jl_datatype_nfields(v) == 0 &&
-            ((jl_datatype_t*)(v))->size > 0);
+            jl_datatype_size(v) > 0);
 }
 
 STATIC_INLINE int jl_is_structtype(void *v)
 {
     return (jl_is_datatype(v) &&
             (jl_field_count(v) > 0 ||
-             ((jl_datatype_t*)(v))->size == 0) &&
+             jl_datatype_size(v) == 0) &&
             !((jl_datatype_t*)(v))->abstract);
 }
 
@@ -895,7 +896,7 @@ STATIC_INLINE int jl_is_datatype_singleton(jl_datatype_t *d)
 
 STATIC_INLINE int jl_is_datatype_make_singleton(jl_datatype_t *d)
 {
-    return (!d->abstract && d->size == 0 && d != jl_sym_type && d->name != jl_array_typename &&
+    return (!d->abstract && jl_datatype_size(d) == 0 && d != jl_sym_type && d->name != jl_array_typename &&
             d->uid != 0 && (d->name->names == jl_emptysvec || !d->mutabl));
 }
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -351,7 +351,7 @@ jl_value_t *jl_iintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name,
 static inline jl_value_t *jl_intrinsiclambda_ty1(jl_value_t *ty, void *pa, unsigned osize, unsigned osize2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_1_t op = select_intrinsic_1(osize2, (const intrinsic_1_t*)voidlist);
     op(osize * host_char_bit, pa, jl_data_ptr(newv));
     return newv;
@@ -360,7 +360,7 @@ static inline jl_value_t *jl_intrinsiclambda_ty1(jl_value_t *ty, void *pa, unsig
 static inline jl_value_t *jl_intrinsiclambda_u1(jl_value_t *ty, void *pa, unsigned osize, unsigned osize2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_u1_t op = select_intrinsic_u1(osize2, (const intrinsic_u1_t*)voidlist);
     unsigned cnt = op(osize * host_char_bit, pa);
     // TODO: the following memset/memcpy assumes little-endian
@@ -399,7 +399,7 @@ static inline jl_value_t *jl_intrinsic_cvt(jl_value_t *ty, jl_value_t *a, const 
     unsigned osize = jl_datatype_size(ty);
     if (check_op && check_op(isize, osize, pa))
         jl_throw(jl_inexact_exception);
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     op(aty == (jl_value_t*)jl_bool_type ? 1 : isize * host_char_bit, pa,
             osize * host_char_bit, jl_data_ptr(newv));
     if (ty == (jl_value_t*)jl_bool_type)
@@ -566,7 +566,7 @@ jl_value_t *jl_iintrinsic_2(jl_value_t *a, jl_value_t *b, const char *name,
 static inline jl_value_t *jl_intrinsiclambda_2(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_2_t op = select_intrinsic_2(sz2, (const intrinsic_2_t*)voidlist);
     op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
     if (ty == (jl_value_t*)jl_bool_type)
@@ -584,7 +584,7 @@ static inline jl_value_t *jl_intrinsiclambda_cmp(jl_value_t *ty, void *pa, void 
 static inline jl_value_t *jl_intrinsiclambda_checked(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, const void *voidlist)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)ty)->size, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(ty), ty);
     intrinsic_checked_t op = select_intrinsic_checked(sz2, (const intrinsic_checked_t*)voidlist);
     int ovflw = op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
     if (ovflw)


### PR DESCRIPTION
- Use `jl_datatype_size` instead of `dt->size`.
  `jl_datatype_size` is always in bytes, whereas the underlying
  implementation of `dt->size` might change.
- do not use .size directly (that is just asking for trouble)
- Introduce `jl_datatype_nbits` that gives nbits
  Instead of calculating it per hand everywhere. This allows for
  interesting experiments (and eventually not restricting `bitstype` to
  multiplies of 8).

This is the part of #18470 that is just cleanup
