### PR TITLE
Fix sparse broadcast macro hygiene issue

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1397,7 +1397,7 @@ such that `broadcast(::typeof(fc), A::SparseMatrixCSC) = fp(fc, A)`.
 macro _enumerate_childmethods(fp, fcs...)
     fcexps = Expr(:block)
     for fc in fcs
-        push!(fcexps.args, :( broadcast(::typeof($(esc(fc))), A::SparseMatrixCSC) = $(esc(fp))($(esc(fc)), A) ) )
+        push!(fcexps.args, :( $(esc(:broadcast))(::typeof($(esc(fc))), A::SparseMatrixCSC) = $(esc(fp))($(esc(fc)), A) ) )
     end
     return fcexps
 end

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1624,3 +1624,12 @@ end
 let A = sparse(UInt32[1,2,3], UInt32[1,2,3], [1.0,2.0,3.0])
     @test A[1,1:3] == A[1,:] == [1,0,0]
 end
+
+# Check that `broadcast` methods specialized for unary operations over
+# `SparseMatrixCSC`s are called. (Issue #18705.)
+let
+    A = spdiagm(1.0:5.0)
+    @test isa(sin.(A), SparseMatrixCSC) # representative for _unary_nz2z_z2z class
+    @test isa(abs.(A), SparseMatrixCSC) # representative for _unary_nz2nz_z2z class
+    @test isa(exp.(A), Array) # representative for _unary_nz2nz_z2nz class
+end


### PR DESCRIPTION
Due to a macro hygiene issue introduced in #17302, `broadcast` methods specialized for unary operations over `SparseMatrixCSC`s are not being called:

``` julia
julia> versioninfo()
Julia Version 0.6.0-dev.804
Commit 182f4b3* (2016-09-27 03:28 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin15.5.0)
  CPU: Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.7.1 (ORCJIT, ivybridge)

julia> sin.(spdiagm(1.0:5.0))
5×5 Array{Float64,2}:
 0.841471  0.0       0.0       0.0        0.0
 0.0       0.909297  0.0       0.0        0.0
 0.0       0.0       0.14112   0.0        0.0
 0.0       0.0       0.0      -0.756802   0.0
 0.0       0.0       0.0       0.0       -0.958924
```

This PR fixes that issue,

``` julia
julia> sin.(spdiagm(1.0:5.0))
5×5 sparse matrix with 5 Float64 nonzero entries:
        [1, 1]  =  0.841471
        [2, 2]  =  0.909297
        [3, 3]  =  0.14112
        [4, 4]  =  -0.756802
        [5, 5]  =  -0.958924
```

and introduces tests to guard against regression. Best!
