### PR TITLE
fix #10981, splatting very long argument lists

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -4598,3 +4598,13 @@ gVararg(a::fVararg(Int)) = length(a)
 catch e
     (e::ErrorException).msg
 end == "generated function body is not pure. this likely means it contains a closure or comprehension."
+
+# issue #10981, long argument lists
+let a = fill(["sdf"], 2*10^6), temp_vcat(x...) = vcat(x...)
+    # we introduce a new function `temp_vcat` to make sure there is no existing
+    # method cache match, leading to a path that allocates a large tuple type.
+    b = temp_vcat(a...)
+    @test isa(b, Vector{String})
+    @test length(b) == 2*10^6
+    @test b[1] == b[end] == "sdf"
+end


### PR DESCRIPTION
It's a bit tricky to get a reliable test for this. For some reason, when I run e.g. `../julia runtests.jl core` it segfaults reliably, but `make test-core` succeeds. Anybody know why that might be?
