### PR TITLE
RFC: use limit true IOContext when showing errors in the REPL

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -118,7 +118,7 @@ function display_error(io::IO, er, bt)
         if eval_ind != 0
             bt = bt[1:eval_ind-1]
         end
-        Base.showerror(io, er, bt)
+        Base.showerror(IOContext(io, :limit => true), er, bt)
     end
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -532,3 +532,13 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     @test readstring(outs) == "1\n"
 end
 end # let exename
+
+# Test containers in error messages are limited #18726
+let io = IOBuffer()
+    REPL.display_error(io,
+        try [][trues(6000)]
+        catch e
+            e
+        end, [])
+    @test length(takebuf_string(io)) < 1500
+end


### PR DESCRIPTION
Makes the example in https://groups.google.com/forum/#!topic/julia-users/ahxFyM082MQ not generate 10 pages of errors in the REPL.

Fixes #14734.

Is this too drastic?
