### PR TITLE
Implement rounding in length(::StepRange)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -402,8 +402,12 @@ step{T}(r::LinSpace{T}) = ifelse(r.len <= 0, convert(T,NaN), (r.stop-r.start)/r.
 
 unsafe_length(r::Range) = length(r)  # generic fallback
 
-function unsafe_length(r::StepRange)
+function unsafe_length{T<:Integer,S<:Integer}(r::StepRange{T,S})
     n = Integer(div(r.stop+r.step - r.start, r.step))
+    isempty(r) ? zero(n) : n
+end
+function unsafe_length(r::StepRange)
+    n = round(Integer, (r.stop - r.start)/r.step + 1)
     isempty(r) ? zero(n) : n
 end
 length(r::StepRange) = unsafe_length(r)

--- a/base/range.jl
+++ b/base/range.jl
@@ -135,7 +135,16 @@ colon{T}(start::T, step, stop::T) = StepRange(start, step, stop)
 
 Construct a range by length, given a starting value and optional step (defaults to 1).
 """
-range{T,S}(a::T, step::S, len::Integer) = StepRange{T,S}(a, step, convert(T, a+step*(len-1)))
+function range{T,S}(a::T, step::S, len::Integer)
+    r = StepRange{T,S}(a, step, convert(T, a+step*(len-1)))
+    if length(r) < len
+        r = StepRange{T,S}(a, step, convert(T, a+step*len))
+        if length(r) > len
+            throw(InexactError())
+        end
+    end
+    r
+end
 
 ## floating point ranges
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -794,8 +794,9 @@ Base.isless(x::FloatLike, y::FloatLike) = isless(x.val, y.val)
 Base.:+(x::FloatLike, y::FloatLike) = FloatLike(x.val+y.val)
 Base.:-(x::FloatLike, y::FloatLike) = FloatLike(x.val-y.val)
 Base.:/(x::FloatLike, y::FloatLike) = x.val / y.val
-# Base.div(x::FloatLike, y::FloatLike) = div(x.val, y.val)
 Base.rem(x::FloatLike, y::FloatLike) = FloatLike(rem(x.val, y.val))
+Base.:*(x::FloatLike, y::Int) = FloatLike(x.val * y)
+Base.:/(x::FloatLike, y::Int) = FloatLike(x.val / y)
 
 rf = 0.8:0.8:640.0
 rs = StepRange(FloatLike(0.8), FloatLike(0.8), FloatLike(640))
@@ -807,3 +808,6 @@ rs = StepRange(FloatLike(640), FloatLike(-0.8), FloatLike(0.8))
 @test first(rs) == FloatLike(640)
 @test last(rs).val ≈ 0.8
 @test length(rf) == length(rs) == 800
+rs = range(FloatLike(0), FloatLike(0.1), 10)
+@test length(rs) == 10
+@test last(rs).val ≈ 0.9


### PR DESCRIPTION
`StepRange` is the only range object currently in Base that's suitable for non-`Integer`, non-`AbstractFloat` objects; among possibly-other places, it's used to construct ranges with physical units in `Unitful`. I noticed an off-by-one bug in `length` with such ranges, which this fixes. CC @ajkeller34.
