### PR TITLE
disable method overwrite warnings if both functions are in Main

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -973,16 +973,18 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
     jl_method_t *method = (jl_method_t*)newentry->func.method;
     jl_module_t *newmod = method->module;
     jl_module_t *oldmod = oldvalue->module;
-    JL_STREAM *s = JL_STDERR;
-    jl_printf(s, "WARNING: Method definition ");
-    jl_static_show_func_sig(s, (jl_value_t*)newentry->sig);
-    jl_printf(s, " in module %s", jl_symbol_name(oldmod->name));
-    print_func_loc(s, oldvalue);
-    jl_printf(s, " overwritten");
-    if (oldmod != newmod)
-        jl_printf(s, " in module %s", jl_symbol_name(newmod->name));
-    print_func_loc(s, method);
-    jl_printf(s, ".\n");
+    if (!(newmod == jl_main_module && oldmod == jl_main_module)) {
+        JL_STREAM *s = JL_STDERR;
+        jl_printf(s, "WARNING: Method definition ");
+        jl_static_show_func_sig(s, (jl_value_t*)newentry->sig);
+        jl_printf(s, " in module %s", jl_symbol_name(oldmod->name));
+        print_func_loc(s, oldvalue);
+        jl_printf(s, " overwritten");
+        if (oldmod != newmod)
+            jl_printf(s, " in module %s", jl_symbol_name(newmod->name));
+        print_func_loc(s, method);
+        jl_printf(s, ".\n");
+    }
 }
 
 // invalidate cached methods that overlap this definition

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -366,4 +366,30 @@ let module_name = string("a",randstring())
     rm(file_name)
 end
 
+let
+    t = redirected_stderr("")
+    try
+        f_overwrite_main(x) = x
+        f_overwrite_main(x) = x
+    finally
+        close(STDERR)
+        redirect_stderr(olderr)
+    end
+    wait(t)
+
+    t = redirected_stderr("WARNING: Method definition f_overwrite_module(Any) in module F18725")
+    mktemp() do path, stream
+        try
+        include_string("""module F18725
+                f_overwrite_module(x) = x
+                f_overwrite_module(x) = x
+            end""")
+        finally
+            close(STDERR)
+            redirect_stderr(olderr)
+        end
+    end
+    wait(t)
+end
+
 end # !withenv

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -378,16 +378,15 @@ let
     wait(t)
 
     t = redirected_stderr("WARNING: Method definition f_overwrite_module(Any) in module F18725")
-    mktemp() do path, stream
-        try
-        include_string("""module F18725
+    try
+        include_string("""
+            module F18725
                 f_overwrite_module(x) = x
                 f_overwrite_module(x) = x
             end""")
-        finally
-            close(STDERR)
-            redirect_stderr(olderr)
-        end
+    finally
+        close(STDERR)
+        redirect_stderr(olderr)
     end
     wait(t)
 end


### PR DESCRIPTION
Implements @vtjnash suggestion in https://github.com/JuliaLang/julia/issues/18725#issuecomment-250502825

``` jl
julia> f(x) = 3;

julia> f(x) = 3;

julia> module F
       f(x) = 3
       f(x) = 3
       end;
WARNING: Method definition f(Any) in module F at REPL[2]:2 overwritten at REPL[2]:3.
```

fixes #18725

Stuff like https://github.com/tbreloff/Plots.jl/issues/508 or

``` jl

julia> f(g) = g();

julia> g() = 1;

julia> f(g)
1

julia> g() = 2

julia> f(g)
1
```

are of course a little bit scary to happen without a warning.
