### PR TITLE
RFC: Fix skipchars inexact error/hanging (#16892)

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -334,4 +334,3 @@ function skipchars(io::IOStream, pred; linecomment=nothing)
     return io
 end
 
-

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -309,6 +309,14 @@ function read(s::IOStream, nb::Integer; all::Bool=true)
 end
 
 ## Character streams ##
+const _chtmp = Array{Char}(1)
+function peekchar(s::IOStream)
+    if ccall(:ios_peekutf8, Cint, (Ptr{Void}, Ptr{Char}), s, _chtmp) < 0
+      return typemax(Char)
+    end
+    return _chtmp[1]
+end
+
 function peek(s::IOStream)
     ccall(:ios_peekc, Cint, (Ptr{Void},), s)
 end
@@ -325,4 +333,5 @@ function skipchars(io::IO, pred; linecomment=nothing)
     end
     return io
 end
+
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -321,7 +321,7 @@ function peek(s::IOStream)
     ccall(:ios_peekc, Cint, (Ptr{Void},), s)
 end
 
-function skipchars(io::IO, pred; linecomment=nothing)
+function skipchars(io::IOStream, pred; linecomment=nothing)
     while !eof(io)
         c = read(io, Char)
         if c === linecomment

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -312,7 +312,7 @@ end
 const _chtmp = Array{Char}(1)
 function peekchar(s::IOStream)
     if ccall(:ios_peekutf8, Cint, (Ptr{Void}, Ptr{Char}), s, _chtmp) < 0
-      return typemax(Char)
+        return typemax(Char)
     end
     return _chtmp[1]
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -337,10 +337,10 @@ function skipchars(io::IO, pred; linecomment::Char=Char(0xffffffff))
     end
 end
 
-function _skipchars_impl(action, io::IO, pred)
+function _skipchars_impl(skipcomment, io::IO, pred)
     while !eof(io)
         c = read(io, Char)
-        if !action(c) && !pred(c)
+        if !skipcomment(c) && !pred(c)
             seek(io,position(io)-sizeof(string(c)))
             break
         end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -309,14 +309,6 @@ function read(s::IOStream, nb::Integer; all::Bool=true)
 end
 
 ## Character streams ##
-const _chtmp = Array{Char}(1)
-function peekchar(s::IOStream)
-    if ccall(:ios_peekutf8, Cint, (Ptr{Void}, Ptr{Char}), s, _chtmp) < 0
-        return Char(-1)
-    end
-    return _chtmp[1]
-end
-
 function peek(s::IOStream)
     ccall(:ios_peekc, Cint, (Ptr{Void},), s)
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -314,24 +314,11 @@ function peek(s::IOStream)
 end
 
 function skipchars(io::IO, pred; linecomment=nothing)
-    _skipchars_impl(_get_comment_skipper(io, linecomment), io, pred)
-end
-
-_get_comment_skipper(io, linecomment::Void) = c->false
-_get_comment_skipper(io, linecomment::Char) =
-    function(c)
-        if c == linecomment
-            readline(io)
-            return true
-        else
-            return false
-        end
-    end
-
-@noinline function _skipchars_impl(skipcomment, io::IO, pred)
     while !eof(io)
         c = read(io, Char)
-        if !skipcomment(c) && !pred(c)
+        if c === linecomment
+            readline(io)
+        elseif !pred(c)
             seek(io,position(io)-sizeof(string(c)))
             break
         end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -344,7 +344,7 @@ function _skipchars_impl(action, io::IO, pred)
             seek(io,position(io)-sizeof(string(c)))
             break
         end
-     end
+    end
     return io
 end
 

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,7 +35,7 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "distributed", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
-        "channels"
+        "channels", "iostream"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -13,7 +13,7 @@ macro test_skipchars(str, expected_char, lnc=Char(0xffffffff))
     end
 end
 
-@test_skipchars "abc" 'a'
-@test_skipchars "   bac" 'b'
-@test_skipchars "  #cm \n   cab" 'c' '#'
+@test_skipchars("abc", 'a')
+@test_skipchars("   bac", 'b')
+@test_skipchars("  #cm \n   cab", 'c', '#')
 

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -10,14 +10,14 @@ mktemp() do path, file
     # test it doesn't error on eof
     @test skipchars(file, isspace) == file
 
-    # test it does it correctly skips
+    # test if it correctly skips
     append_to_file("    ")
     @test eof(skipchars(file, isspace))
 
     # test it correctly detects comment lines
     append_to_file("#    \n   ")
     @test eof(skipchars(file, isspace, linecomment='#'))
-    
+
     # test it stops at the appropriate time
     append_to_file("   not a space")
     @test skipchars(file, isspace) == file
@@ -26,6 +26,6 @@ mktemp() do path, file
     # test it correctly ignores the contents of comment lines
     append_to_file("  #not a space \n   not a space")
     @test skipchars(file, isspace, linecomment='#') == file
-    @test !eof(file) && read(file, Char) == 'n'  
+    @test !eof(file) && read(file, Char) == 'n'
 end
 

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -7,10 +7,10 @@ end
 @test eof(skipchars(IOBuffer("#    \n   "), isspace, linecomment='#'))
 
 macro test_skipchars(str, expected_char, lnc=Char(0xffffffff))
-  quote
-    io = skipchars(IOBuffer($str), isspace, linecomment=$lnc)
-    @test !eof(io) && read(io, Char) == $expected_char
-  end
+    quote
+        io = skipchars(IOBuffer($str), isspace, linecomment=$lnc)
+        @test !eof(io) && read(io, Char) == $expected_char
+    end
 end
 
 @test_skipchars "abc" 'a'

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -1,0 +1,19 @@
+@test mktemp() do _, file
+    skipchars(file, isspace)
+    true
+end
+
+@test eof(skipchars(IOBuffer("    "), isspace))
+@test eof(skipchars(IOBuffer("#    \n   "), isspace, linecomment='#'))
+
+macro test_skipchars(str, expected_char, lnc=Char(0xffffffff))
+  quote
+    io = skipchars(IOBuffer($str), isspace, linecomment=$lnc)
+    @test !eof(io) && read(io, Char) == $expected_char
+  end
+end
+
+@test_skipchars "abc" 'a'
+@test_skipchars "   bac" 'b'
+@test_skipchars "  #cm \n   cab" 'c' '#'
+


### PR DESCRIPTION
Hey-ho. I completely forgot about this until I decided to check my issued issues.

This fixes the inexact error raised when using the `skipchars` function. It's also faster for inputs larger than a few characters when you don't use the `linecomment` argument, because it doesn't test each character for it.

I had to change a lot since the function was broken even before that error started to show up (hangs on 0.3), but do tell if this is over-complicating the problem, I am terrible at telling what the line for that is.

Questions:
- This is no longer exclusive to `IOStream`s (works for e.g. `IOBuffer`), should I move it somewhere else? (where?) (actually it doesn't work for `Pipe`s, so maybe I should use a `Union{IOStream,IOBuffer}`?)
- [`peekchar`](https://github.com/JuliaLang/julia/blob/b728145b713e07b60854ad6b81da62c04804a83e/base/iostream.jl#L313), an unexported function only used by the current `skipchars`, is broken. (and I don't know any good way to fix it [I don't think it ever worked as intended, actually]) <s>Should I remove it?</s> I removed it, but please tell me if I should reintroduce it and try to fix it (in this or in another PR).
