### PR TITLE
Enable unwinding on ARM

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -433,6 +433,7 @@ $(eval $(call LLVM_PATCH,llvm-nodllalias))
 $(eval $(call LLVM_PATCH,llvm-D21271-instcombine-tbaa-3.7))
 $(eval $(call LLVM_PATCH,llvm-win64-reloc-dwarf))
 $(eval $(call LLVM_PATCH,llvm-3.7.1_destsharedlibdir))
+$(eval $(call LLVM_PATCH,llvm-arm-fix-prel31))
 else ifeq ($(LLVM_VER_SHORT),3.8)
 ifeq ($(LLVM_VER),3.8.0)
 $(eval $(call LLVM_PATCH,llvm-D17326_unpack_load))
@@ -456,11 +457,13 @@ $(eval $(call LLVM_PATCH,llvm-PR27046)) # Remove for 3.9
 $(eval $(call LLVM_PATCH,llvm-3.8.0_ppc64_SUBFC8)) # Remove for 3.9
 $(eval $(call LLVM_PATCH,llvm-D21271-instcombine-tbaa-3.8)) # Remove for 3.9
 $(eval $(call LLVM_PATCH,llvm-win64-reloc-dwarf))
+$(eval $(call LLVM_PATCH,llvm-arm-fix-prel31))
 else ifeq ($(LLVM_VER_SHORT),3.9)
 # fix lowering for atomics on ppc
 $(eval $(call LLVM_PATCH,llvm-rL279933-ppc-atomicrmw-lowering)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-PR22923)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-r282182)) # Remove for 4.0
+$(eval $(call LLVM_PATCH,llvm-arm-fix-prel31))
 endif # LLVM_VER
 
 ifeq ($(LLVM_VER),3.7.1)

--- a/deps/patches/libunwind-arm-dyn.patch
+++ b/deps/patches/libunwind-arm-dyn.patch
@@ -1,0 +1,46 @@
+From 8475f898b7f47b6e9f7193597dadb959dc5a02d2 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Fri, 30 Sep 2016 04:11:03 +0000
+Subject: [PATCH 1/3] Support dynamic unwind info on ARM
+
+---
+ src/arm/Gstep.c       | 10 ++++++++--
+ src/mi/Gdyn-extract.c |  1 +
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/arm/Gstep.c b/src/arm/Gstep.c
+index 79f2dd2..5b2b329 100644
+--- a/src/arm/Gstep.c
++++ b/src/arm/Gstep.c
+@@ -45,8 +45,14 @@ arm_exidx_step (struct cursor *c)
+   /* mark PC unsaved */
+   c->dwarf.loc[UNW_ARM_R15] = DWARF_NULL_LOC;
+ 
+-  if ((ret = tdep_find_proc_info (&c->dwarf, c->dwarf.ip, 1)) < 0)
+-     return ret;
++  /* check dynamic info first --- it overrides everything else */
++  ret = unwi_find_dynamic_proc_info (c->dwarf.as, c->dwarf.ip, &c->dwarf.pi, 1,
++                                     c->dwarf.as_arg);
++  if (ret == -UNW_ENOINFO)
++    {
++      if ((ret = tdep_find_proc_info (&c->dwarf, c->dwarf.ip, 1)) < 0)
++        return ret;
++    }
+ 
+   if (c->dwarf.pi.format != UNW_INFO_FORMAT_ARM_EXIDX)
+     return -UNW_ENOINFO;
+diff --git a/src/mi/Gdyn-extract.c b/src/mi/Gdyn-extract.c
+index c8ae7a0..5f7682e 100644
+--- a/src/mi/Gdyn-extract.c
++++ b/src/mi/Gdyn-extract.c
+@@ -49,6 +49,7 @@ unwi_extract_dynamic_proc_info (unw_addr_space_t as, unw_word_t ip,
+ 
+     case UNW_INFO_FORMAT_TABLE:
+     case UNW_INFO_FORMAT_REMOTE_TABLE:
++    case UNW_INFO_FORMAT_ARM_EXIDX:
+     case UNW_INFO_FORMAT_IP_OFFSET:
+ #ifdef tdep_search_unwind_table
+       /* call platform-specific search routine: */
+-- 
+2.10.0
+

--- a/deps/patches/libunwind-arm-pc-offset.patch
+++ b/deps/patches/libunwind-arm-pc-offset.patch
@@ -1,0 +1,43 @@
+From 320973722157e09c6139b016aa31012d5ea75f68 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sun, 2 Oct 2016 03:19:19 +0000
+Subject: [PATCH] Handle non-signal frame unwind info lookup in ARM exidx
+ unwinder
+
+---
+ src/arm/Gstep.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/src/arm/Gstep.c b/src/arm/Gstep.c
+index 449419b..76ced8e 100644
+--- a/src/arm/Gstep.c
++++ b/src/arm/Gstep.c
+@@ -44,19 +44,22 @@ arm_exidx_step (struct cursor *c)
+ 
+   /* mark PC unsaved */
+   c->dwarf.loc[UNW_ARM_R15] = DWARF_NULL_LOC;
++  unw_word_t ip = c->dwarf.ip;
++  if (c->dwarf.use_prev_instr)
++    --ip;
+ 
+   /* check dynamic info first --- it overrides everything else */
+-  ret = unwi_find_dynamic_proc_info (c->dwarf.as, c->dwarf.ip, &c->dwarf.pi, 1,
++  ret = unwi_find_dynamic_proc_info (c->dwarf.as, ip, &c->dwarf.pi, 1,
+                                      c->dwarf.as_arg);
+   if (ret == -UNW_ENOINFO)
+     {
+ #ifdef UNW_LOCAL_ONLY
+-        if ((ret = arm_find_proc_info2 (c->dwarf.as, c->dwarf.ip, &c->dwarf.pi,
++        if ((ret = arm_find_proc_info2 (c->dwarf.as, ip, &c->dwarf.pi,
+                                         1, c->dwarf.as_arg,
+                                         UNW_ARM_METHOD_EXIDX)) < 0)
+         return ret;
+ #else
+-      if ((ret = tdep_find_proc_info (&c->dwarf, c->dwarf.ip, 1)) < 0)
++      if ((ret = tdep_find_proc_info (&c->dwarf, ip, 1)) < 0)
+         return ret;
+ #endif
+     }
+-- 
+2.10.0
+

--- a/deps/patches/libunwind-dwarf-ver.patch
+++ b/deps/patches/libunwind-dwarf-ver.patch
@@ -1,0 +1,26 @@
+From 155540bf1b1b57bd73ba1e7c1c77f3e4467bf253 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sat, 1 Oct 2016 15:24:09 +0000
+Subject: [PATCH 2/3] Allow DWARF version 4
+
+---
+ src/dwarf/Gfde.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/dwarf/Gfde.c b/src/dwarf/Gfde.c
+index dc973fe..c1d6e1c 100644
+--- a/src/dwarf/Gfde.c
++++ b/src/dwarf/Gfde.c
+@@ -116,7 +116,8 @@ parse_cie (unw_addr_space_t as, unw_accessors_t *a, unw_word_t addr,
+   if ((ret = dwarf_readu8 (as, a, &addr, &version, arg)) < 0)
+     return ret;
+ 
+-  if (version != 1 && version != DWARF_CIE_VERSION)
++  if (version != 1 && version != DWARF_CIE_VERSION &&
++      !(version == 4 && DWARF_CIE_VERSION))
+     {
+       Debug (1, "Got CIE version %u, expected version 1 or "
+              STR (DWARF_CIE_VERSION) "\n", version);
+-- 
+2.10.0
+

--- a/deps/patches/libunwind-prefer-extbl.patch
+++ b/deps/patches/libunwind-prefer-extbl.patch
@@ -1,0 +1,143 @@
+From 6b6d4b1ce3dcfdc87a84ee276947d473e84cd39e Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sat, 1 Oct 2016 16:55:40 +0000
+Subject: [PATCH 3/3] Prefer EXTBL unwinding on ARM since it seems to be more
+ reliable
+
+---
+ include/tdep-arm/libunwind_i.h |  4 ++++
+ src/arm/Gex_tables.c           | 18 ++++++++++++++----
+ src/arm/Gstep.c                | 29 ++++++++++++++++++-----------
+ 3 files changed, 36 insertions(+), 15 deletions(-)
+
+diff --git a/include/tdep-arm/libunwind_i.h b/include/tdep-arm/libunwind_i.h
+index d3a279c..89a0b72 100644
+--- a/include/tdep-arm/libunwind_i.h
++++ b/include/tdep-arm/libunwind_i.h
+@@ -250,6 +250,7 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
+ #define tdep_init_done                  UNW_OBJ(init_done)
+ #define tdep_init                       UNW_OBJ(init)
+ #define arm_find_proc_info              UNW_OBJ(find_proc_info)
++#define arm_find_proc_info2             UNW_OBJ(find_proc_info2)
+ #define arm_put_unwind_info             UNW_OBJ(put_unwind_info)
+ /* Platforms that support UNW_INFO_FORMAT_TABLE need to define
+    tdep_search_unwind_table.  */
+@@ -290,6 +291,9 @@ extern void tdep_init (void);
+ extern int arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+                                unw_proc_info_t *pi, int need_unwind_info,
+                                void *arg);
++extern int arm_find_proc_info2 (unw_addr_space_t as, unw_word_t ip,
++                                unw_proc_info_t *pi, int need_unwind_info,
++                                void *arg, int methods);
+ extern void arm_put_unwind_info (unw_addr_space_t as,
+                                   unw_proc_info_t *pi, void *arg);
+ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
+diff --git a/src/arm/Gex_tables.c b/src/arm/Gex_tables.c
+index 34706cf..379859a 100644
+--- a/src/arm/Gex_tables.c
++++ b/src/arm/Gex_tables.c
+@@ -500,15 +500,16 @@ arm_phdr_cb (struct dl_phdr_info *info, size_t size, void *data)
+ }
+ 
+ HIDDEN int
+-arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+-                    unw_proc_info_t *pi, int need_unwind_info, void *arg)
++arm_find_proc_info2 (unw_addr_space_t as, unw_word_t ip,
++                     unw_proc_info_t *pi, int need_unwind_info, void *arg,
++                     int methods)
+ {
+   int ret = -1;
+   intrmask_t saved_mask;
+ 
+   Debug (14, "looking for IP=0x%lx\n", (long) ip);
+ 
+-  if (UNW_TRY_METHOD(UNW_ARM_METHOD_DWARF))
++  if (UNW_TRY_METHOD(UNW_ARM_METHOD_DWARF) && (methods & UNW_ARM_METHOD_DWARF))
+     {
+       struct dwarf_callback_data cb_data;
+ 
+@@ -534,7 +535,8 @@ arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+         ret = -UNW_ENOINFO;
+     }
+ 
+-  if (ret < 0 && UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX))
++  if (ret < 0 && UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX) &&
++      (methods & UNW_ARM_METHOD_EXIDX))
+     {
+       struct arm_cb_data cb_data;
+ 
+@@ -560,6 +562,14 @@ arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+   return ret;
+ }
+ 
++HIDDEN int
++arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
++                    unw_proc_info_t *pi, int need_unwind_info, void *arg)
++{
++    return arm_find_proc_info2 (as, ip, pi, need_unwind_info, arg,
++                                UNW_ARM_METHOD_ALL);
++}
++
+ HIDDEN void
+ arm_put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
+ {
+diff --git a/src/arm/Gstep.c b/src/arm/Gstep.c
+index 5b2b329..449419b 100644
+--- a/src/arm/Gstep.c
++++ b/src/arm/Gstep.c
+@@ -50,8 +50,15 @@ arm_exidx_step (struct cursor *c)
+                                      c->dwarf.as_arg);
+   if (ret == -UNW_ENOINFO)
+     {
++#ifdef UNW_LOCAL_ONLY
++        if ((ret = arm_find_proc_info2 (c->dwarf.as, c->dwarf.ip, &c->dwarf.pi,
++                                        1, c->dwarf.as_arg,
++                                        UNW_ARM_METHOD_EXIDX)) < 0)
++        return ret;
++#else
+       if ((ret = tdep_find_proc_info (&c->dwarf, c->dwarf.ip, 1)) < 0)
+         return ret;
++#endif
+     }
+ 
+   if (c->dwarf.pi.format != UNW_INFO_FORMAT_ARM_EXIDX)
+@@ -184,8 +191,18 @@ unw_step (unw_cursor_t *cursor)
+   if (unw_is_signal_frame (cursor))
+      return unw_handle_signal_frame (cursor);
+ 
++  /* First, try extbl-based unwinding. */
++  if (UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX))
++    {
++      ret = arm_exidx_step (c);
++      if (ret > 0)
++        return 1;
++      if (ret == -UNW_ESTOPUNWIND || ret == 0)
++        return ret;
++    }
++
+ #ifdef CONFIG_DEBUG_FRAME
+-  /* First, try DWARF-based unwinding. */
++  /* Second, try DWARF-based unwinding. */
+   if (UNW_TRY_METHOD(UNW_ARM_METHOD_DWARF))
+     {
+       ret = dwarf_step (&c->dwarf);
+@@ -204,16 +221,6 @@ unw_step (unw_cursor_t *cursor)
+     }
+ #endif /* CONFIG_DEBUG_FRAME */
+ 
+-  /* Next, try extbl-based unwinding. */
+-  if (UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX))
+-    {
+-      ret = arm_exidx_step (c);
+-      if (ret > 0)
+-        return 1;
+-      if (ret == -UNW_ESTOPUNWIND || ret == 0)
+-        return ret;
+-    }
+-
+   /* Fall back on APCS frame parsing.
+      Note: This won't work in case the ARM EABI is used. */
+   if (unlikely (ret < 0))
+-- 
+2.10.0
+

--- a/deps/patches/llvm-arm-fix-prel31.patch
+++ b/deps/patches/llvm-arm-fix-prel31.patch
@@ -1,0 +1,60 @@
+From 6cef9adffcf9af3c632e58e0d7d4d6e1d0525980 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Thu, 29 Sep 2016 22:41:57 -0400
+Subject: [PATCH] Fix PREL31 relocation on ARM
+
+This is a 31bits relative relocation instead of a 32bits absolute relocation.
+---
+ lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp |  4 ++++
+ .../RuntimeDyld/ARM/ELF_ARM_EXIDX_relocations.s    | 23 ++++++++++++++++++++++
+ 2 files changed, 27 insertions(+)
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/ARM/ELF_ARM_EXIDX_relocations.s
+
+diff --git a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+index 6929732..2e0d168 100644
+--- a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
++++ b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+@@ -463,7 +463,11 @@ void RuntimeDyldELF::resolveARMRelocation(const SectionEntry &Section,
+ 
+   case ELF::R_ARM_NONE:
+     break;
++    // Write a 31bit signed offset
+   case ELF::R_ARM_PREL31:
++    *TargetPtr &= 0x80000000;
++    *TargetPtr |= (Value - FinalAddress) & ~0x80000000;
++    break;
+   case ELF::R_ARM_TARGET1:
+   case ELF::R_ARM_ABS32:
+     *TargetPtr = Value;
+diff --git a/test/ExecutionEngine/RuntimeDyld/ARM/ELF_ARM_EXIDX_relocations.s b/test/ExecutionEngine/RuntimeDyld/ARM/ELF_ARM_EXIDX_relocations.s
+new file mode 100644
+index 0000000..eb07b00
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/ARM/ELF_ARM_EXIDX_relocations.s
+@@ -0,0 +1,23 @@
++# RUN: llvm-mc -triple=arm-linux-gnueabihf -filetype=obj -o %T/reloc.o %s
++# RUN: llvm-rtdyld -triple=arm-linux-gnueabihf -verify -map-section reloc.o,.ARM.exidx=0x6000 -map-section reloc.o,.text=0x4000  -dummy-extern __aeabi_unwind_cpp_pr0=0x1234 -check=%s %T/reloc.o
++
++        .text
++        .syntax unified
++        .eabi_attribute 67, "2.09"      @ Tag_conformance
++        .cpu    cortex-a8
++        .fpu    neon
++        .file   "reloc.c"
++        .globl  g
++        .align  2
++        .type   g,%function
++g:
++        .fnstart
++        movw    r0, #1
++        bx      lr
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++        .fnend
++
++# rtdyld-check: *{4}(section_addr(reloc.o, .ARM.exidx)) = (g - (section_addr(reloc.o, .ARM.exidx))) & 0x7fffffff
++# Compat unwind info: finish(0xb0), finish(0xb0), finish(0xb0)
++# rtdyld-check: *{4}(section_addr(reloc.o, .ARM.exidx) + 0x4) = 0x80b0b0b0
+-- 
+2.10.0
+

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -12,7 +12,23 @@ $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted: $(SRCDIR)/srccache/
 	touch -c $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/configure # old target
 	echo 1 > $@
 
-$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted
+$(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-arm-dyn.patch-applied: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted
+	cd $(SRCDIR)/srccache/libunwind-$(UNWIND_VER) && patch -p1 -f < $(SRCDIR)/patches/libunwind-arm-dyn.patch
+	echo 1 > $@
+
+$(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-dwarf-ver.patch-applied: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-arm-dyn.patch-applied
+	cd $(SRCDIR)/srccache/libunwind-$(UNWIND_VER) && patch -p1 -f < $(SRCDIR)/patches/libunwind-dwarf-ver.patch
+	echo 1 > $@
+
+$(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-prefer-extbl.patch-applied: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-dwarf-ver.patch-applied
+	cd $(SRCDIR)/srccache/libunwind-$(UNWIND_VER) && patch -p1 -f < $(SRCDIR)/patches/libunwind-prefer-extbl.patch
+	echo 1 > $@
+
+$(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-arm-pc-offset.patch-applied: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-prefer-extbl.patch-applied
+	cd $(SRCDIR)/srccache/libunwind-$(UNWIND_VER) && patch -p1 -f < $(SRCDIR)/patches/libunwind-arm-pc-offset.patch
+	echo 1 > $@
+
+$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-arm-pc-offset.patch-applied
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CONFIGURE_COMMON) CPPFLAGS="$(CPPFLAGS) $(LIBUNWIND_CPPFLAGS)" CFLAGS="$(CFLAGS) $(LIBUNWIND_CFLAGS)" --disable-shared --disable-minidebuginfo

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -338,6 +338,58 @@ public:
         };
 #endif
 
+#ifdef _CPU_ARM_
+        // ARM does not have/use .eh_frame
+        uint64_t arm_exidx_addr = 0;
+        size_t arm_exidx_len = 0;
+        uint64_t arm_text_addr = 0;
+        size_t arm_text_len = 0;
+        for (auto &section: obj.sections()) {
+            bool istext = false;
+            if (section.isText()) {
+                istext = true;
+            }
+            else {
+                StringRef sName;
+                if (section.getName(sName))
+                    continue;
+                if (sName != ".ARM.exidx") {
+                    continue;
+                }
+            }
+#if JL_LLVM_VERSION >= 30800
+            uint64_t loadaddr = L.getSectionLoadAddress(section);
+#else
+            uint64_t loadaddr = L.getSectionLoadAddress(sName);
+#endif
+            size_t seclen = section.getSize();
+            if (istext) {
+                arm_text_addr = loadaddr;
+                arm_text_len = seclen;
+                if (!arm_exidx_addr) {
+                    continue;
+                }
+            }
+            else {
+                arm_exidx_addr = loadaddr;
+                arm_exidx_len = seclen;
+                if (!arm_text_addr) {
+                    continue;
+                }
+            }
+            unw_dyn_info_t *di = new unw_dyn_info_t;
+            di->gp = 0;
+            di->format = UNW_INFO_FORMAT_ARM_EXIDX;
+            di->start_ip = (uintptr_t)arm_text_addr;
+            di->end_ip = (uintptr_t)(arm_text_addr + arm_text_len);
+            di->u.rti.name_ptr = 0;
+            di->u.rti.table_data = arm_exidx_addr;
+            di->u.rti.table_len = arm_exidx_len;
+            _U_dyn_register(di);
+            break;
+        }
+#endif
+
 #if defined(_OS_WINDOWS_)
         uint64_t SectionAddrCheck = 0; // assert that all of the Sections are at the same location
         uint8_t *UnwindData = NULL;
@@ -1645,7 +1697,8 @@ void deregister_eh_frames(uint8_t *Addr, size_t Size)
     });
 }
 
-#elif defined(_OS_LINUX_) && JL_LLVM_VERSION >= 30700 && defined(JL_UNW_HAS_FORMAT_IP)
+#elif defined(_OS_LINUX_) && JL_LLVM_VERSION >= 30700 && \
+    defined(JL_UNW_HAS_FORMAT_IP) && !defined(_CPU_ARM_)
 #include <type_traits>
 
 struct unw_table_entry
@@ -1830,11 +1883,8 @@ static DW_EH_PE parseCIE(const uint8_t *Addr, const uint8_t *End)
 
 void register_eh_frames(uint8_t *Addr, size_t Size)
 {
-#ifndef _CPU_ARM_
     // System unwinder
-    // Linux uses setjmp/longjmp exception handling on ARM.
     __register_frame(Addr);
-#endif
     // Our unwinder
     unw_dyn_info_t *di = new unw_dyn_info_t;
     // In a shared library, this is set to the address of the PLT.
@@ -1961,12 +2011,20 @@ void register_eh_frames(uint8_t *Addr, size_t Size)
 
 void deregister_eh_frames(uint8_t *Addr, size_t Size)
 {
-#ifndef _CPU_ARM_
     __deregister_frame(Addr);
-#endif
     // Deregistering with our unwinder requires a lookup table to find the
     // the allocated entry above (or we could look in libunwind's internal
     // data structures).
+}
+
+#elif defined(_CPU_ARM_)
+
+void register_eh_frames(uint8_t *Addr, size_t Size)
+{
+}
+
+void deregister_eh_frames(uint8_t *Addr, size_t Size)
+{
 }
 
 #else

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -37,6 +37,12 @@ static bt_context_t *jl_to_bt_context(void *sigctx)
 {
 #ifdef __APPLE__
     return (bt_context_t*)&((ucontext64_t*)sigctx)->uc_mcontext64->__ss;
+#elif defined(_CPU_ARM_)
+    // libunwind does not use `ucontext_t` on ARM.
+    // `unw_context_t` is a struct of 16 `unsigned long` which should
+    // have the same layout as the `arm_r0` to `arm_pc` fields in `sigcontext`
+    ucontext_t *ctx = (ucontext_t*)sigctx;
+    return (bt_context_t*)&ctx->uc_mcontext.arm_r0;
 #else
     return (bt_context_t*)sigctx;
 #endif

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -305,12 +305,6 @@ static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp)
 #endif
 }
 
-#elif defined(_CPU_ARM_)
-// platforms on which libunwind may be broken
-
-static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *context) { return 0; }
-static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp) { return 0; }
-
 #else
 // stacktrace using libunwind
 


### PR DESCRIPTION
There are multiple issues that hold this back, most of them from upstream.
1. GCC 5.0+ miscompiles LLVM on ARM (i.e. https://github.com/JuliaLang/julia/issues/14550)
   
   Now that I've found a workaround, I can finally start playing with unwinding on ARM.
   (In another word, users of LLVM compiled with GCC 5.0+ without LTO and with optimization will break.)
2. ARM use a special format other than DWARF for unwind info.
   
   The first commit makes sure the unwind info for JIT code is registered with libunwind. This is the only change we need to make to our code.
3. LLVM emit incorrect unwind info (wrong relocation).
   
   Fixed by the LLVM patch. Submitted upstream at https://reviews.llvm.org/D25069. Should be the right approach but needs to be approved and I probably need to figure out how to write a test for it....
4. libunwind doesn't accept dynamic unwind info registration on ARM, messes up unwind info lookup of different formats, and doesn't like DWARF 4 debug info....
   
   The first patch is submitted to the libunwind-devel list, the second and the third are a tiny bit more hacky and we'll probably not wait for upstream to accept this anyway.....

Local test shows that the unwinding is pretty reliable now and the tests this fixes are `backtrace`, `replutil`, `meta`, `stacktraces`, `cmdlineargs`, `compile`. The ones that are still failing are `profile` and `parallel`. I'll check why those are still failing later but the PR should be good to go without that.
