### PR TITLE
Allow x[] for get(x::Nullable)

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -46,10 +46,10 @@ function show{T}(io::IO, x::Nullable{T})
 end
 
 """
-    get(x::Nullable[, y])
+    get(x::Nullable, y)
 
 Attempt to access the value of `x`. Returns the value if it is present;
-otherwise, returns `y` if provided, or throws a `NullException` if not.
+otherwise, returns `y` if provided.
 """
 @inline function get{S,T}(x::Nullable{S}, y::T)
     if isbits(S)
@@ -59,7 +59,20 @@ otherwise, returns `y` if provided, or throws a `NullException` if not.
     end
 end
 
-get(x::Nullable) = isnull(x) ? throw(NullException()) : x.value
+"""
+    getindex(x::Nullable)
+
+Attempt to access the value of `x`. Throw a `NullException` if the value is not
+present. Usually, this is written as `x[]`.
+"""
+getindex(x::Nullable) = isnull(x) ? throw(NullException()) : x.value
+
+"""
+    get(x::Nullable)
+
+Alias for `getindex(x::Nullable)`.
+"""
+get(x::Nullable) = x[]
 
 """
     unsafe_get(x)

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -71,7 +71,7 @@ getindex(x::Nullable) = isnull(x) ? throw(NullException()) : x.value
     get(x::Nullable)
 
 Attempt to access the value of `x`. Throw a `NullException` if the value is not
-present.
+present. Equivalent to `getindex(x::Nullable)`.
 """
 get(x::Nullable) = x[]
 

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -70,7 +70,8 @@ getindex(x::Nullable) = isnull(x) ? throw(NullException()) : x.value
 """
     get(x::Nullable)
 
-Alias for `getindex(x::Nullable)`.
+Attempt to access the value of `x`. Throw a `NullException` if the value is not
+present.
 """
 get(x::Nullable) = x[]
 

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -49,7 +49,7 @@ end
     get(x::Nullable, y)
 
 Attempt to access the value of `x`. Returns the value if it is present;
-otherwise, returns `y` if provided.
+otherwise, returns `y`.
 """
 @inline function get{S,T}(x::Nullable{S}, y::T)
     if isbits(S)

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -71,7 +71,8 @@ getindex(x::Nullable) = isnull(x) ? throw(NullException()) : x.value
     get(x::Nullable)
 
 Attempt to access the value of `x`. Throw a `NullException` if the value is not
-present. Equivalent to `getindex(x::Nullable)`, which can be spelt `x[]`.
+present. Equivalent to `getindex(x::Nullable)`, which can alternatively be
+written as `x[]`.
 """
 get(x::Nullable) = x[]
 

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -71,7 +71,7 @@ getindex(x::Nullable) = isnull(x) ? throw(NullException()) : x.value
     get(x::Nullable)
 
 Attempt to access the value of `x`. Throw a `NullException` if the value is not
-present. Equivalent to `getindex(x::Nullable)`.
+present. Equivalent to `getindex(x::Nullable)`, which can be spelt `x[]`.
 """
 get(x::Nullable) = x[]
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -826,7 +826,7 @@ Nullables
 
    .. Docstring generated from Julia source
 
-   Attempt to access the value of ``x``\ . Returns the value if it is present; otherwise, returns ``y`` if provided.
+   Attempt to access the value of ``x``\ . Returns the value if it is present; otherwise, returns ``y``\ .
 
 .. function:: getindex(x::Nullable)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -822,11 +822,17 @@ Nullables
 
    Wrap value ``x`` in an object of type ``Nullable``\ , which indicates whether a value is present. ``Nullable(x)`` yields a non-empty wrapper, and ``Nullable{T}()`` yields an empty instance of a wrapper that might contain a value of type ``T``\ .
 
-.. function:: get(x::Nullable[, y])
+.. function:: get(x::Nullable, y)
 
    .. Docstring generated from Julia source
 
-   Attempt to access the value of ``x``\ . Returns the value if it is present; otherwise, returns ``y`` if provided, or throws a ``NullException`` if not.
+   Attempt to access the value of ``x``\ . Returns the value if it is present; otherwise, returns ``y`` if provided.
+
+.. function:: getindex(x::Nullable)
+
+   .. Docstring generated from Julia source
+
+   Attempt to access the value of ``x``\ . Throw a ``NullException`` if the value is not present. Usually, this is written as ``x[]``\ .
 
 .. function:: isnull(x)
 

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -140,11 +140,13 @@ for T in types
     x3 = Nullable(one(T))
 
     @test_throws NullException get(x1)
-    @test get(x2) === zero(T)
-    @test get(x3) === one(T)
+    @test_throws NullException x1[]
+    @test get(x2) === x2[] === zero(T)
+    @test get(x3) === x3[] === one(T)
 end
 
 @test_throws NullException get(Nullable())
+@test_throws NullException Nullable()[]
 
 # get{S, T}(x::Nullable{S}, y::T)
 for T in types


### PR DESCRIPTION
No other `get` function has these semantics, and the `x[]` is better syntax anyway.

Note that parallel from

``` julia
dict[key]
```

to

``` julia
get(dict, key, default)
```

versus

``` julia
nullable[]
```

to

``` julia
get(nullable, default)
```
