### PR TITLE
Add fallback sparse and sparsevec methods that convert Vector{Any} to Vector{Int}

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -499,6 +499,9 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V:
     end
 end
 
+sparse(I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Integer, n::Integer, combine) =
+    sparse(AbstractVector{Int}(I), AbstractVector{Int}(J), V, m, n, combine)
+
 """
     sparse!{Tv,Ti<:Integer}(
         I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::AbstractVector{Tv},

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -96,7 +96,7 @@ Duplicates are combined using the `combine` function, which defaults to
 `+` if no `combine` argument is provided, unless the elements of `V` are Booleans
 in which case `combine` defaults to `|`.
 """
-function sparsevec{Tv,Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector{Tv}, combine::Function)
+function sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector, combine::Function)
     length(I) == length(V) ||
         throw(ArgumentError("index and value vectors must be the same length"))
     len = 0
@@ -106,37 +106,37 @@ function sparsevec{Tv,Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector{Tv},
             len = i
         end
     end
-    _sparsevector!(collect(Ti, I), collect(Tv, V), len, combine)
+    _sparsevector!(collect(I), collect(V), len, combine)
 end
 
-function sparsevec{Tv,Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector{Tv}, len::Integer, combine::Function)
+function sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::AbstractVector, len::Integer, combine::Function)
     length(I) == length(V) ||
         throw(ArgumentError("index and value vectors must be the same length"))
-    maxi = convert(Ti, len)
     for i in I
-        1 <= i <= maxi || throw(ArgumentError("An index is out of bound."))
+        1 <= i <= len || throw(ArgumentError("An index is out of bound."))
     end
-    _sparsevector!(collect(Ti, I), collect(Tv, V), len, combine)
+    _sparsevector!(collect(I), collect(V), len, combine)
 end
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Number, AbstractVector}) =
+sparsevec(I::AbstractVector, V::Union{Number, AbstractVector}, args...) =
+    sparsevec(Vector{Int}(I), V, args...)
+
+sparsevec(I::AbstractVector, V::Union{Number, AbstractVector}) =
     sparsevec(I, V, +)
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Number, AbstractVector},
-    len::Integer) =
+sparsevec(I::AbstractVector, V::Union{Number, AbstractVector}, len::Integer) =
     sparsevec(I, V, len, +)
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Bool, AbstractVector{Bool}}) =
+sparsevec(I::AbstractVector, V::Union{Bool, AbstractVector{Bool}}) =
     sparsevec(I, V, |)
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, V::Union{Bool, AbstractVector{Bool}},
-    len::Integer) =
+sparsevec(I::AbstractVector, V::Union{Bool, AbstractVector{Bool}}, len::Integer) =
     sparsevec(I, V, len, |)
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, v::Number, combine::Function) =
+sparsevec(I::AbstractVector, v::Number, combine::Function) =
     sparsevec(I, fill(v, length(I)), combine)
 
-sparsevec{Ti<:Integer}(I::AbstractVector{Ti}, v::Number, len::Integer, combine::Function) =
+sparsevec(I::AbstractVector, v::Number, len::Integer, combine::Function) =
     sparsevec(I, fill(v, length(I)), len, combine)
 
 

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -13,6 +13,8 @@
 @test_throws ArgumentError sparse([1,2,4], [1,2,3], [1,2,3], 3, 3)
 @test_throws ArgumentError sparse([1,2,3], [1,2,4], [1,2,3], 3, 3)
 @test isequal(sparse(Int[], Int[], Int[], 0, 0), SparseMatrixCSC(0, 0, Int[1], Int[], Int[]))
+@test sparse(Any[1,2,3], Any[1,2,3], Any[1,1,1]) == sparse([1,2,3], [1,2,3], [1,1,1])
+@test sparse(Any[1,2,3], Any[1,2,3], Any[1,1,1], 5, 4) == sparse([1,2,3], [1,2,3], [1,1,1], 5, 4)
 
 # check matrix operations
 se33 = speye(3)

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -92,6 +92,14 @@ let x0 = SparseVector(8, [2, 3, 6], [12.0, 18.0, 25.0])
         SparseVector(8, [2, 3, 6, 7], [12.0, 18.0, 25.0, 0.0]))
 end
 
+@test exact_equal(
+    sparsevec(Any[1, 3], [1, 1]),
+    sparsevec([1, 3], [1, 1]))
+
+@test exact_equal(
+    sparsevec(Any[1, 3], [1, 1], 5),
+    sparsevec([1, 3], [1, 1], 5))
+
 # from dictionary
 
 function my_intmap(x)


### PR DESCRIPTION
This change makes it possible to do something like

``` jl
julia> is, js, vs = [], [], []
(Any[],Any[],Any[])

julia> for i = 1:3
           push!(is, i)
           push!(js, i)
           push!(vs, 1)
       end

julia> sparse(is,js,vs)
3×3 sparse matrix with 3 Any nonzero entries:
    [1, 1]  =  1
    [2, 2]  =  1
    [3, 3]  =  1
```

cc: @alanedelman 
