### PR TITLE
fast sorting of integer vectors with few uniques

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -430,7 +430,41 @@ function sort!(v::AbstractVector;
                by=identity,
                rev::Bool=false,
                order::Ordering=Forward)
-    sort!(v, alg, ord(lt,by,rev,order))
+    ordr = ord(lt,by,rev,order)
+    if ordr === Forward && isa(v,Vector) && eltype(v)<:Integer
+        n = length(v)
+        if n > 1
+            min, max = extrema(v)
+            rangelen = max - min + 1
+            if rangelen < div(n,2)
+                return sort_int_range!(v, rangelen, min)
+            end
+        end
+    end
+    sort!(v, alg, ordr)
+end
+
+# sort! for vectors of few unique integers
+function sort_int_range!{T<:Integer}(x::Vector{T}, rangelen, minval)
+    offs = 1 - minval
+    n = length(x)
+
+    where = fill(0, rangelen)
+    @inbounds for i = 1:n
+        where[x[i] + offs] += 1
+    end
+
+    idx = 1
+    @inbounds for i = 1:rangelen
+        lastidx = idx + where[i] - 1
+        val = i-offs
+        for j = idx:lastidx
+            x[j] = val
+        end
+        idx = lastidx + 1
+    end
+
+    return x
 end
 
 """
@@ -439,7 +473,6 @@ end
 Variant of [`sort!`](:func:`sort!`) that returns a sorted copy of `v` leaving `v` itself unmodified.
 """
 sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...)
-
 
 ## selectperm: the permutation to sort the first k elements of an array ##
 
@@ -485,11 +518,22 @@ function sortperm(v::AbstractVector;
                   by=identity,
                   rev::Bool=false,
                   order::Ordering=Forward)
+    ordr = ord(lt,by,rev,order)
+    if ordr === Forward && isa(v,Vector) && eltype(v)<:Integer
+        n = length(v)
+        if n > 1
+            min, max = extrema(v)
+            rangelen = max - min + 1
+            if rangelen < div(n,2)
+                return sortperm_int_range(v, rangelen, min)
+            end
+        end
+    end
     p = similar(Vector{Int}, indices(v, 1))
     for (i,ind) in zip(eachindex(p), indices(v, 1))
         p[i] = ind
     end
-    sort!(p, alg, Perm(ord(lt,by,rev,order),v))
+    sort!(p, alg, Perm(ordr,v))
 end
 
 
@@ -515,6 +559,28 @@ function sortperm!{I<:Integer}(x::AbstractVector{I}, v::AbstractVector;
         end
     end
     sort!(x, alg, Perm(ord(lt,by,rev,order),v))
+end
+
+# sortperm for vectors of few unique integers
+function sortperm_int_range{T<:Integer}(x::Vector{T}, rangelen, minval)
+    offs = 1 - minval
+    n = length(x)
+
+    where = fill(0, rangelen+1)
+    where[1] = 1
+    @inbounds for i = 1:n
+        where[x[i] + offs + 1] += 1
+    end
+    cumsum!(where, where)
+
+    P = Vector{Int}(n)
+    @inbounds for i = 1:n
+        label = x[i] + offs
+        P[where[label]] = i
+        where[label] += 1
+    end
+
+    return P
 end
 
 ## sorting multi-dimensional arrays ##

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -318,7 +318,7 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, a::MergeSortAlg, o::Ordering
         hi-lo <= SMALL_THRESHOLD && return sort!(v, lo, hi, SMALL_ALGORITHM, o)
 
         m = (lo+hi)>>>1
-        isempty(t) && resize!(t, m-lo+1)
+        (length(t) < m-lo+1) && resize!(t, m-lo+1)
 
         sort!(v, lo,  m,  a, o, t)
         sort!(v, m+1, hi, a, o, t)


### PR DESCRIPTION
The first commit is a quasi-bugfix: the mergesort code only resized its temp vector if it was empty, but should do so more generally if the vector is too short. I discovered this while irresponsibly calling this internal function in order to reuse a temp vector in a loop.

The next commit implements the O(n) counting sort algorithm for integer vectors with a narrow range of values, which is very common in practice. Example:

```
x = rand(1:100000, 10000000)

# before
julia> @time sort(x);
  0.862170 seconds (8 allocations: 76.294 MB, 2.12% gc time)

julia> @time sortperm(x);
  2.869195 seconds (8 allocations: 76.294 MB, 2.48% gc time)

# after
julia> @time sort(x);
  0.090334 seconds (8 allocations: 77.057 MB, 4.81% gc time)

julia> @time sortperm(x);
  0.626009 seconds (8 allocations: 77.057 MB, 10.69% gc time)
```
