### PR TITLE
Do more constant propagation at type inference time

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -14,7 +14,11 @@ typemax(::Type{Bool}) = true
 
 ## boolean operations ##
 
-!(x::Bool) = box(Bool,not_int(unbox(Bool,x)))
+function !(x::Bool)
+    ## We need a better heuristic to detect this automatically
+    @_pure_meta
+    return box(Bool,not_int(unbox(Bool,x)))
+end
 
 (~)(x::Bool) = !x
 (&)(x::Bool, y::Bool) = box(Bool,and_int(unbox(Bool,x),unbox(Bool,y)))

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -404,8 +404,9 @@ JL_DLLEXPORT jl_method_instance_t *jl_new_method_instance_uninit(void)
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_method_instance_t *li =
         (jl_method_instance_t*)jl_gc_alloc(ptls, sizeof(jl_method_instance_t),
-                                       jl_method_instance_type);
+                                           jl_method_instance_type);
     li->inferred = NULL;
+    li->inferred_const = NULL;
     li->rettype = (jl_value_t*)jl_any_type;
     li->sparam_vals = jl_emptysvec;
     li->fptr = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -920,6 +920,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v)
             }
         }
         jl_serialize_value(s, li->inferred);
+        jl_serialize_value(s, li->inferred_const);
         jl_serialize_value(s, li->rettype);
         jl_serialize_value(s, (jl_value_t*)li->sparam_vals);
         jl_serialize_value(s, (jl_value_t*)li->def);
@@ -1563,6 +1564,9 @@ static jl_value_t *jl_deserialize_value_method_instance(jl_serializer_state *s, 
 
     li->inferred = jl_deserialize_value(s, &li->inferred);
     jl_gc_wb(li, li->inferred);
+    li->inferred_const = jl_deserialize_value(s, &li->inferred_const);
+    if (li->inferred_const)
+        jl_gc_wb(li, li->inferred_const);
     li->rettype = jl_deserialize_value(s, &li->rettype);
     jl_gc_wb(li, li->rettype);
     li->sparam_vals = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&li->sparam_vals);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1219,8 +1219,11 @@ jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t *li)
                 li->functionObjectsDecls.functionObject = NULL;
                 li->functionObjectsDecls.specFunctionObject = NULL;
                 li->inferred = def->unspecialized->inferred;
-                li->jlcall_api = 2;
                 jl_gc_wb(li, li->inferred);
+                li->inferred_const = def->unspecialized->inferred_const;
+                if (li->inferred_const)
+                    jl_gc_wb(li, li->inferred_const);
+                li->jlcall_api = 2;
                 return li->functionObjectsDecls;
             }
             if (def->unspecialized->fptr) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -218,7 +218,7 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *li, int force)
     return src;
 }
 
-JL_DLLEXPORT void jl_set_lambda_rettype(jl_method_instance_t *li, jl_value_t *rettype, jl_value_t *const_api, jl_value_t *inferred)
+JL_DLLEXPORT void jl_set_lambda_rettype(jl_method_instance_t *li, jl_value_t *rettype, int32_t const_flags, jl_value_t *inferred_const, jl_value_t *inferred)
 {
     // changing rettype changes the llvm signature,
     // so clear all of the llvm state at the same time
@@ -230,8 +230,14 @@ JL_DLLEXPORT void jl_set_lambda_rettype(jl_method_instance_t *li, jl_value_t *re
     jl_gc_wb(li, rettype);
     li->inferred = inferred;
     jl_gc_wb(li, inferred);
-    if (const_api == jl_true)
+    if (const_flags & 1) {
+        assert(const_flags & 2);
         li->jlcall_api = 2;
+    }
+    if (const_flags & 2) {
+        li->inferred_const = inferred_const;
+        jl_gc_wb(li, inferred_const);
+    }
 }
 
 static int jl_is_uninferred(jl_method_instance_t *li)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3922,11 +3922,12 @@ void jl_init_types(void)
     jl_method_instance_type =
         jl_new_datatype(jl_symbol("MethodInstance"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(12,
+                        jl_svec(13,
                                 jl_symbol("specTypes"),
                                 jl_symbol("rettype"),
                                 jl_symbol("sparam_vals"),
                                 jl_symbol("inferred"),
+                                jl_symbol("inferred_const"),
                                 jl_symbol("def"),
                                 jl_symbol("inInference"),
                                 jl_symbol("jlcall_api"),
@@ -3934,10 +3935,11 @@ void jl_init_types(void)
                                 jl_symbol("fptr"),
                                 jl_symbol("unspecialized_ducttape"),
                                 jl_symbol(""), jl_symbol("")),
-                        jl_svec(12,
+                        jl_svec(13,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_simplevector_type,
+                                jl_any_type,
                                 jl_any_type,
                                 jl_method_type,
                                 jl_bool_type,
@@ -4008,10 +4010,10 @@ void jl_init_types(void)
 #endif
     jl_svecset(jl_methtable_type->types, 7, jl_int32_type); // uint32_t
     jl_svecset(jl_method_type->types, 10, jl_method_instance_type);
-    jl_svecset(jl_method_instance_type->types, 8, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 9, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 10, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 11, jl_voidpointer_type);
+    jl_svecset(jl_method_instance_type->types, 12, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -273,6 +273,7 @@ typedef struct _jl_method_instance_t {
     jl_value_t *rettype; // return type for fptr
     jl_svec_t *sparam_vals; // the values for the tvars, indexed by def->sparam_syms
     jl_value_t *inferred;  // inferred jl_code_info_t, or value of the function if jlcall_api == 2, or null
+    jl_value_t *inferred_const; // inferred constant return value, or null
     jl_method_t *def; // method this is specialized from, null if this is a toplevel thunk
     uint8_t inInference; // flags to tell if inference is running on this function
     uint8_t jlcall_api; // the c-abi for fptr; 0 = jl_fptr_t, 1 = jl_fptr_sparam_t, 2 = constval

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -951,3 +951,11 @@ end
         @inferred vecnorm(x)
     end
 end
+
+@testset "issue #18785" begin
+    # type stability for exp, expm1 for Complex{Int64}
+    let x = 2*im
+        @inferred exp(x)
+        @inferred expm1(x)
+    end
+end


### PR DESCRIPTION
This also fix #18785

@nanosoldier `runbenchmarks(ALL, vs=":master")` (edit: nanosoldier was triggered before I did a force push to fix the test name)
