### PR TITLE
Fix cbrt(Float16(-1)) throwing DomainError

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -204,16 +204,19 @@ end
 # fallback definitions to prevent infinite loop from $f(x::Real) def above
 
 """
-    cbrt(x)
+    cbrt(x::Real)
 
-Return ``x^{1/3}``.  The prefix operator `∛` is equivalent to `cbrt`.
+Return the cube root of `x`, i.e. ``x^{1/3}``. Negative values are accepted
+(returning the negative real root when ``x < 0``).
+
+The prefix operator `∛` is equivalent to `cbrt`.
 
 ```jldoctest
 julia> cbrt(big(27))
 3.000000000000000000000000000000000000000000000000000000000000000000000000000000
 ```
 """
-cbrt(x::AbstractFloat) = x^(1//3)
+cbrt(x::AbstractFloat) = x < 0 ? -(-x)^(1//3) : x^(1//3)
 
 """
     exp2(x)
@@ -611,6 +614,7 @@ for func in (:atan2,:hypot)
 end
 
 ldexp(a::Float16, b::Integer) = Float16(ldexp(Float32(a), b))
+cbrt(a::Float16) = Float16(cbrt(Float32(a)))
 
 # More special functions
 include("special/trig.jl")

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1640,3 +1640,4 @@ Internals
    .. Docstring generated from Julia source
 
    Compile the given function ``f`` for the argument tuple (of types) ``args``\ , but do not execute it.
+

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1433,11 +1433,13 @@ Mathematical Functions
        julia> isqrt(5)
        2
 
-.. function:: cbrt(x)
+.. function:: cbrt(x::Real)
 
    .. Docstring generated from Julia source
 
-   Return :math:`x^{1/3}`\ .  The prefix operator ``∛`` is equivalent to ``cbrt``\ .
+   Return the cube root of ``x``\ , i.e. :math:`x^{1/3}`\ . Negative values are accepted (returning the negative real root when :math:`x < 0`\ ).
+
+   The prefix operator ``∛`` is equivalent to ``cbrt``\ .
 
    .. doctest::
 

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -146,3 +146,6 @@ end
 
 # issue #17148
 @test rem(Float16(1.2), Float16(one(1.2))) == 0.20019531f0
+
+# no domain error is thrown for negative values
+@test cbrt(Float16(-1.0)) == -1.0

--- a/test/math.jl
+++ b/test/math.jl
@@ -938,3 +938,6 @@ end
 
 @test Base.Math.f32(complex(1.0,1.0)) == complex(Float32(1.),Float32(1.))
 @test Base.Math.f16(complex(1.0,1.0)) == complex(Float16(1.),Float16(1.))
+
+# no domain error is thrown for negative values
+@test invoke(cbrt, Tuple{AbstractFloat}, -1.0) == -1.0


### PR DESCRIPTION
This function needed special casing to be consistent with Float32 and Float64.

This was the problem at the root of https://github.com/JuliaStats/NullableArrays.jl/issues/154.
