### PR TITLE
Check freshness of doc/stdlib on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,15 +121,20 @@ script:
             install -pm755 usr/lib/lib${name}*.dylib* /tmp/julia/lib/julia/;
         done;
       fi
+    - GENSTDLIB_OUTPUT=`make -s $BUILDOPTS julia-genstdlib 2>&1`; GENSTDLIB_EXITCODE=$?; test $GENSTDLIB_EXITCODE -eq 0
+    - STDLIBDOC_DIFF=`git diff --stat --exit-code doc/stdlib`
     - cd .. && mv julia julia2
     - /tmp/julia/bin/julia --precompiled=no -e 'true' &&
         /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
     - /tmp/julia/bin/julia -e 'versioninfo()'
-    - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 && cd /tmp/julia/share/julia/test &&
+    - test \! \( $GENSTDLIB_EXITCODE -eq 0 -a -z "$STDLIBDOC_DIFF" \) || (export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 &&
+        cd /tmp/julia/share/julia/test &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
-        /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
+        /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg)
     - cd `dirname $TRAVIS_BUILD_DIR` && mv julia2 julia &&
         rm -rf julia/deps/scratch/julia-env &&
         rm -f julia/deps/scratch/libgit2-*/CMakeFiles/CMakeOutput.log
+    - test $GENSTDLIB_EXITCODE -eq 0 || (echo 'make julia-genstdlib failed:'; echo "${GENSTDLIB_OUTPUT}"; false)
+    - test -z "$STDLIBDOC_DIFF" || (echo "Outdated files in doc/stdlib:"; echo "${STDLIBDOC_DIFF}"; echo "Please run make julia-genstdlib locally!"; false)
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg

--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -44,7 +44,7 @@ function translate(dirs::Vector; root = dirname(@__FILE__))
                 end
             end
         else
-            warn("errors found while generating documentation. Aborting file writing.")
+            error("errors found while generating documentation. Aborting file writing.")
         end
         # Report statistics about 'Base' docs.
         summarise(state)


### PR DESCRIPTION
Will be obsoleted by #18588 but hopefully is useful until then by catching the common mistake of modifying docstrings and not updating the corresponding RST files.
