### PR TITLE
RFC: Avoid overwriting isnull method

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -120,10 +120,8 @@ julia> isnull(x)
 false
 ```
 """
-isnull(x::Nullable) = x.isnull
-isnull(x) = false
-
 isnull(x::Nullable) = !x.hasvalue
+isnull(x) = false
 
 ## Operators
 


### PR DESCRIPTION
The `Nullable` type no longer has an `isnull` field--it's now `hasvalue`. `isnull(::Nullable)` was still referencing the `isnull` field, but the method was overwritten, so it ended up not actually causing user-facing issues. I only noticed by building from source and seeing the method overwritten warning. This PR simply removes the incorrect method.
