### PR TITLE
Non-32-bit enums / "Typed" enums

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -5,12 +5,14 @@ module Enums
 import Core.Intrinsics.box
 export Enum, @enum
 
-abstract Enum
+function basetype end
 
-Base.convert{T<:Integer}(::Type{T}, x::Enum) = convert(T, box(Int32, x))
+abstract Enum{T<:Integer}
 
-Base.write(io::IO, x::Enum) = write(io, Int32(x))
-Base.read{T<:Enum}(io::IO, ::Type{T}) = T(read(io, Int32))
+Base.convert{T<:Integer}(::Type{Integer}, x::Enum{T}) = box(T, x)
+Base.convert{T<:Integer,T2<:Integer}(::Type{T}, x::Enum{T2}) = convert(T, box(T2, x))
+Base.write{T<:Integer}(io::IO, x::Enum{T}) = write(io, T(x))
+Base.read{T<:Enum}(io::IO, ::Type{T}) = T(read(io, Enums.basetype(T)))
 
 # generate code to test whether expr is in the given set of values
 function membershiptest(expr, values)
@@ -47,20 +49,26 @@ macro enum(T,syms...)
     if isempty(syms)
         throw(ArgumentError("no arguments given for Enum $T"))
     end
-    if !isa(T,Symbol)
+    basetype = Int32
+    typename = T
+    if isa(T,Expr) && T.head == :(::) && length(T.args) == 2 && isa(T.args[1], Symbol)
+        typename = T.args[1]
+        basetype = eval(current_module(),T.args[2])
+        if !isa(basetype, DataType) || !(basetype <: Integer) || !isbits(basetype)
+            throw(ArgumentError("invalid base type for Enum $typename, $T=::$basetype; base type must be an integer bitstype"))
+        end
+    elseif !isa(T,Symbol)
         throw(ArgumentError("invalid type expression for enum $T"))
     end
-    typename = T
     vals = Array{Tuple{Symbol,Integer}}(0)
     lo = hi = 0
-    i = Int32(-1)
+    i = zero(basetype)
     hasexpr = false
     for s in syms
         if isa(s,Symbol)
-            if i == typemax(typeof(i))
+            if i == typemin(basetype) && !isempty(vals)
                 throw(ArgumentError("overflow in value \"$s\" of Enum $typename"))
             end
-            i += one(i)
         elseif isa(s,Expr) &&
                (s.head == :(=) || s.head == :kw) &&
                length(s.args) == 2 && isa(s.args[1],Symbol)
@@ -68,7 +76,7 @@ macro enum(T,syms...)
             if !isa(i, Integer)
                 throw(ArgumentError("invalid value for Enum $typename, $s=$i; values must be integers"))
             end
-            i = convert(Int32, i)
+            i = convert(basetype, i)
             s = s.args[1]
             hasexpr = true
         else
@@ -84,27 +92,29 @@ macro enum(T,syms...)
             lo = min(lo, i)
             hi = max(hi, i)
         end
+        i += one(i)
     end
-    values = Int32[i[2] for i in vals]
+    values = basetype[i[2] for i in vals]
     if hasexpr && values != unique(values)
         throw(ArgumentError("values for Enum $typename are not unique"))
     end
     blk = quote
         # enum definition
-        Base.@__doc__(bitstype 32 $(esc(T)) <: Enum)
+        Base.@__doc__(bitstype $(basetype.size * 8) $(esc(typename)) <: Enum{$(basetype)})
         function Base.convert(::Type{$(esc(typename))}, x::Integer)
             $(membershiptest(:x, values)) || enum_argument_error($(Expr(:quote, typename)), x)
-            box($(esc(typename)), convert(Int32, x))
+            box($(esc(typename)), convert($(basetype), x))
         end
+        Enums.basetype(::Type{$(esc(typename))}) = $(esc(basetype))
         Base.typemin(x::Type{$(esc(typename))}) = $(esc(typename))($lo)
         Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)
-        Base.isless(x::$(esc(typename)), y::$(esc(typename))) = isless(Int32(x), Int32(y))
+        Base.isless(x::$(esc(typename)), y::$(esc(typename))) = isless($basetype(x), $basetype(y))
         let insts = ntuple(i->$(esc(typename))($values[i]), $(length(vals)))
             Base.instances(::Type{$(esc(typename))}) = insts
         end
         function Base.print(io::IO, x::$(esc(typename)))
             for (sym, i) in $vals
-                if i == Int32(x)
+                if i == $(basetype)(x)
                     print(io, sym); break
                 end
             end
@@ -115,7 +125,7 @@ macro enum(T,syms...)
             else
                 print(io, x, "::")
                 showcompact(io, typeof(x))
-                print(io, " = ", Int(x))
+                print(io, " = ", $basetype(x))
             end
         end
         function Base.show(io::IO, t::Type{$(esc(typename))})
@@ -130,9 +140,9 @@ macro enum(T,syms...)
             end
         end
     end
-    if isa(T,Symbol)
+    if isa(typename,Symbol)
         for (sym,i) in vals
-            push!(blk.args, :(const $(esc(sym)) = $(esc(T))($i)))
+            push!(blk.args, :(const $(esc(sym)) = $(esc(typename))($i)))
         end
     end
     push!(blk.args, :nothing)

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -103,7 +103,7 @@ macro enum(T,syms...)
     end
     blk = quote
         # enum definition
-        Base.@__doc__(bitstype $(basetype.size * 8) $(esc(typename)) <: Enum{$(basetype)})
+        Base.@__doc__(bitstype $(sizeof(basetype) * 8) $(esc(typename)) <: Enum{$(basetype)})
         function Base.convert(::Type{$(esc(typename))}, x::Integer)
             $(membershiptest(:x, values)) || enum_argument_error($(Expr(:quote, typename)), x)
             box($(esc(typename)), convert($(basetype), x))

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -29,9 +29,9 @@ end
 @noinline enum_argument_error(typename, x) = throw(ArgumentError(string("invalid value for Enum $(typename): $x")))
 
 """
-    @enum EnumName EnumValue1[=x] EnumValue2[=y]
+    @enum EnumName[::BaseType] EnumValue1[=x] EnumValue2[=y]
 
-Create an `Enum` type with name `EnumName` and enum member values of
+Create an [`Enum`]{`BaseType`} subtype with name `EnumName` and enum member values of
 `EnumValue1` and `EnumValue2` with optional assigned values of `x` and `y`, respectively.
 `EnumName` can be used just like other types and enum member values as regular values, such as
 
@@ -44,6 +44,9 @@ f (generic function with 1 method)
 julia> f(apple)
 "I'm a FRUIT with value: 1"
 ```
+
+`BaseType`, which defaults to `Int32`, must be a bitstype subtype of Integer. Member values can be converted between
+the enum type and `BaseType`. `read` and and `write` perform these conversions automatically.
 """
 macro enum(T,syms...)
     if isempty(syms)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -83,59 +83,20 @@ end
 @test_throws ArgumentError eval(:(@enum Test22 1=2))
 
 # other Integer types of enum members
-# TODO - not yet supported
-#=
-@enum Test3 _one_Test3=0x01 _two_Test3=0x02 _three_Test3=0x03
-@test typeof(_one_Test3.val) <: UInt8
-@test _one_Test3.val === 0x01
+@enum Test3::UInt8 _one_Test3=0x01 _two_Test3=0x02 _three_Test3=0x03
+@test Test3.size == 1
+@test convert(UInt8, _one_Test3) === 0x01
 @test length(instances(Test3)) == 3
 
-@enum Test4 _one_Test4=0x01 _two_Test4=0x0002 _three_Test4=0x03
-@test _one_Test4.val === 0x0001
-@test _two_Test4.val === 0x0002
-@test _three_Test4.val === 0x0003
-@test typeof(_one_Test4.val) <: UInt16
+@enum Test4::UInt16 _one_Test4=0x01 _two_Test4=0x0002 _three_Test4=0x03
+@test Test4.size == 2
 
-@enum Test5 _one_Test5=0x01 _two_Test5=0x00000002 _three_Test5=0x00000003
-@test _one_Test5.val === 0x00000001
-@test _two_Test5.val === 0x00000002
-@test _three_Test5.val === 0x00000003
-@test typeof(_one_Test5.val) <: UInt32
+@enum Test5::UInt32 _one_Test5=0x01 _two_Test5=0x00000002 _three_Test5=0x00000003
+@test Test5.size == 4
 
-@enum Test6 _one_Test6=0x00000000000000000000000000000001 _two_Test6=0x00000000000000000000000000000002
-@test _one_Test6.val === 0x00000000000000000000000000000001
-@test _two_Test6.val === 0x00000000000000000000000000000002
-@test typeof(_one_Test6.val) <: UInt128
-
-@enum Test7 _zero_Test7=0b0 _one_Test7=0b1 _two_Test7=0b10
-@test _zero_Test7.val === 0x00
-@test _one_Test7.val === 0x01
-@test _two_Test7.val === 0x02
-@test typeof(_zero_Test7.val) <: UInt8
-
-@test_throws ArgumentError eval(:(@enum Test8 _zero="zero"))
-@test_throws ArgumentError eval(:(@enum Test9 _zero='0'))
-
-@enum Test8 _zero_Test8=zero(Int64)
-@test typeof(_zero_Test8.val) <: Int64
-@test _zero_Test8.val === Int64(0)
-
-@enum Test9 _zero_Test9 _one_Test9=0x01 _two_Test9
-@test typeof(_zero_Test9.val) <: Int
-@test _zero_Test9.val === 0
-@test typeof(_one_Test9.val) <: Int
-@test _one_Test9.val === 1
-@test typeof(_two_Test9.val) <: Int
-@test _two_Test9.val === 2
-
-@enum Test10 _zero_Test10=0x00 _one_Test10 _two_Test10
-@test typeof(_zero_Test10.val) <: UInt8
-@test _zero_Test10.val === 0x00
-@test typeof(_one_Test10.val) <: UInt8
-@test _one_Test10.val === 0x01
-@test typeof(_two_Test10.val) <: UInt8
-@test _two_Test10.val === 0x02
-=#
+@enum Test6::UInt128 _one_Test6=0x00000000000000000000000000000001 _two_Test6=0x00000000000000000000000000000002
+@test Test6.size == 16
+@test typeof(convert(Integer, _one_Test6)) == UInt128
 
 # test macro handles keyword arguments
 @enum(Test11, _zero_Test11=2,


### PR DESCRIPTION
Adds `@enum Foo::*IntegerType*` to specify to use a bitstype with the same size as the specified integer type. The default type remains `Int32`.

Use case: I want to use an enum for a field in a structure passed to a C function, and I don't get to decide the field size.

Summary:
- The type must be an integer bitstype.
- `read` and `write` read/write the right number of bytes.
- `convert(Integer, value)` converts into the type specified in the `@enum`. Converting to a specific integer types works the same way as before.
- There's no accessor to determine the specified type, but `typeof(convert(Integer, value))` will do.
- Some of the old typed enums tests have been updated, but many of them relate to the `val` field, which isn't really meaningful now.

Tangentally related changes:
- `names` is overloaded for enums, and returns the names of the enumerants. Not totally sure that is the right function for the concept, though.

Not done (yet):
- Updating documentation for `@enum`.

Unanswered questions:
- What should this be called? "Typed enum" seems clear, but enums already have types.
