### PR TITLE
Channel constructor requires an explicit size. Also implements 0-sized channels

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -2,25 +2,48 @@
 
 abstract AbstractChannel
 
-const DEF_CHANNEL_SZ=32
-
 type Channel{T} <: AbstractChannel
     cond_take::Condition    # waiting for data to become available
     cond_put::Condition     # waiting for a writeable slot
     state::Symbol
 
     data::Array{T,1}
-    sz_max::Int             # maximum size of channel
+    sz_max::Int            # maximum size of channel
 
-    function Channel(sz)
-        sz_max = sz == typemax(Int) ? typemax(Int) - 1 : sz
-        new(Condition(), Condition(), :open, Array{T}(0), sz_max)
+    # Used when sz_max == 0, i.e., an unbuffered channel.
+    takers::Array{Condition}
+
+    function Channel(sz::Float64)
+        if sz == Inf
+            Channel{T}(typemax(Int))
+        else
+            Channel{T}(convert(Int, sz))
+        end
+    end
+    function Channel(sz::Integer)
+        if sz < 0
+            throw(ArgumentError("Channel size must be either 0, a positive integer or Inf"))
+        end
+        new(Condition(), Condition(), :open, Array{T}(0), sz, Array{Condition}(0))
+    end
+
+    # deprecated empty constructor
+    function Channel()
+        depwarn(string("The empty constructor Channel() is deprecated. ",
+                        "The channel size needs to be specified explictly. ",
+                        "Defaulting to Channel{$T}(32)."), :Channel)
+        Channel(32)
     end
 end
 
-Channel(sz::Int = DEF_CHANNEL_SZ) = Channel{Any}(sz)
+Channel(sz) = Channel{Any}(sz)
+
+# deprecated empty constructor
+Channel() = Channel{Any}()
 
 closed_exception() = InvalidStateException("Channel is closed.", :closed)
+
+isbuffered(c::Channel) = c.sz_max==0 ? false : true
 
 """
     close(c::Channel)
@@ -46,9 +69,16 @@ end
     put!(c::Channel, v)
 
 Appends an item `v` to the channel `c`. Blocks if the channel is full.
+
+For unbuffered channels, blocks until a `take!` is performed by a different
+task.
 """
 function put!(c::Channel, v)
     !isopen(c) && throw(closed_exception())
+    isbuffered(c) ? put_buffered(c,v) : put_unbuffered(c,v)
+end
+
+function put_buffered(c::Channel, v)
     while length(c.data) == c.sz_max
         wait(c.cond_put)
     end
@@ -57,19 +87,42 @@ function put!(c::Channel, v)
     v
 end
 
+function put_unbuffered(c::Channel, v)
+    while length(c.takers) == 0
+        notify(c.cond_take, nothing, true, false)  # Required to handle wait() on 0-sized channels
+        wait(c.cond_put)
+    end
+    cond_taker = shift!(c.takers)
+    notify(cond_taker, v, false, false)
+    v
+end
+
 push!(c::Channel, v) = put!(c, v)
 
-function fetch(c::Channel)
+"""
+    fetch(c::Channel)
+
+Waits for and gets the first available item from the channel. Does not
+remove the item. `fetch` is unsupported on an unbuffered (0-size) channel.
+"""
+fetch(c::Channel) = isbuffered(c) ? fetch_buffered(c) : fetch_unbuffered(c)
+function fetch_buffered(c::Channel)
     wait(c)
     c.data[1]
 end
+fetch_unbuffered(c::Channel) = throw(ErrorException("`fetch` is not supported on an unbuffered Channel."))
+
 
 """
     take!(c::Channel)
 
-Removes and returns a value from a `Channel`. Blocks till data is available.
+Removes and returns a value from a `Channel`. Blocks until data is available.
+
+For unbuffered channels, blocks until a `put!` is performed by a different
+task.
 """
-function take!(c::Channel)
+take!(c::Channel) = isbuffered(c) ? take_buffered(c) : take_unbuffered(c)
+function take_buffered(c::Channel)
     wait(c)
     v = shift!(c.data)
     notify(c.cond_put, nothing, false, false) # notify only one, since only one slot has become available for a put!.
@@ -78,13 +131,35 @@ end
 
 shift!(c::Channel) = take!(c)
 
+# 0-size channel
+function take_unbuffered(c::Channel)
+    !isopen(c) && throw(closed_exception())
+    cond_taker = Condition()
+    push!(c.takers, cond_taker)
+    notify(c.cond_put, nothing, false, false)
+    try
+        return wait(cond_taker)
+    catch e
+        if isa(e, InterruptException)
+            # remove self from the list of takers
+            filter!(x -> x != cond_taker, c.takers)
+        else
+            rethrow(e)
+        end
+    end
+end
+
 """
     isready(c::Channel)
 
-Determine whether a `Channel` has a value stored to it.
-`isready` on `Channel`s is non-blocking.
+Determine whether a `Channel` has a value stored to it. Returns
+immediately, does not block.
+
+For unbuffered channels returns `true` if there are tasks waiting
+on a `put!`.
 """
 isready(c::Channel) = n_avail(c) > 0
+n_avail(c::Channel) = isbuffered(c) ? length(c.data) : n_waiters(c.cond_put)
 
 function wait(c::Channel)
     while !isready(c)
@@ -97,11 +172,10 @@ end
 function notify_error(c::Channel, err)
     notify_error(c.cond_take, err)
     notify_error(c.cond_put, err)
+    foreach(x->notify_error(x, err), c.takers)
 end
 
 eltype{T}(::Type{Channel{T}}) = T
-
-n_avail(c::Channel) = length(c.data)
 
 show(io::IO, c::Channel) = print(io, "$(typeof(c))(sz_max:$(c.sz_max),sz_curr:$(n_avail(c)))")
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1033,4 +1033,7 @@ end))
 @deprecate_binding cycle     Iterators.cycle
 @deprecate_binding repeated  Iterators.repeated
 
+# NOTE: Deprecation of Channel{T}() is implemented in channels.jl.
+# To be removed from there when 0.6 deprecations are removed.
+
 # End deprecations scheduled for 0.6

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1426,13 +1426,16 @@ endof
 """
     Channel{T}(sz::Int)
 
-Constructs a `Channel` that can hold a maximum of `sz` objects of type `T`. `put!` calls on
-a full channel block till an object is removed with `take!`.
+Constructs a `Channel` with an internal buffer that can hold a maximum of `sz` objects
+of type `T`. `put!` calls on a full channel block until an object is removed with `take!`.
+
+`Channel(0)` constructs an unbuffered channel. `put!` blocks until a matching `take!` is called.
+And vice-versa.
 
 Other constructors:
 
-- `Channel()` - equivalent to `Channel{Any}(32)`
-- `Channel(sz::Int)` equivalent to `Channel{Any}(sz)`
+- `Channel(Inf)` - equivalent to `Channel{Any}(typemax(Int))`
+- `Channel(sz)` equivalent to `Channel{Any}(sz)`
 """
 Channel
 

--- a/base/event.jl
+++ b/base/event.jl
@@ -54,6 +54,7 @@ end
 
 notify_error(c::Condition, err) = notify(c, err, true, true)
 
+n_waiters(c::Condition) = length(c.waitq)
 
 # schedule an expression to run asynchronously, with minimal ceremony
 """

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1175,7 +1175,6 @@ Waits and fetches a value from `x` depending on the type of `x`. Does not remove
   is an exception, throws a `RemoteException` which captures the remote exception and backtrace.
 * `RemoteChannel`: Wait for and get the value of a remote reference. Exceptions raised are
   same as for a `Future` .
-* `Channel` : Wait for and get the first available item from the channel.
 """
 fetch(x::ANY) = x
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -1,0 +1,90 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+# Test various constructors
+c=Channel(1)
+@test eltype(c) == Any
+@test put!(c, 1) == 1
+@test isready(c) == true
+@test take!(c) == 1
+@test isready(c) == false
+
+@test eltype(Channel(1.0)) == Any
+
+c=Channel{Int}(1)
+@test eltype(c) == Int
+@test_throws MethodError put!(c, "Hello")
+
+c=Channel{Int}(Inf)
+@test eltype(c) == Int
+pvals = map(i->put!(c,i), 1:10^6)
+tvals = Int[take!(c) for i in 1:10^6]
+@test pvals == tvals
+
+# Uncomment line below once deprecation support has been removed.
+# @test_throws MethodError Channel()
+
+@test_throws ArgumentError Channel(-1)
+@test_throws InexactError Channel(1.5)
+
+# Test multiple concurrent put!/take! on a channel for different sizes
+function testcpt(sz)
+    c = Channel{Int}(sz)
+    size = 0
+    inc() = size += 1
+    dec() = size -= 1
+    @sync for i = 1:10^4
+        @async (sleep(rand()); put!(c, i); inc())
+        @async (sleep(rand()); take!(c); dec())
+    end
+    @test size == 0
+end
+testcpt(0)
+testcpt(1)
+testcpt(32)
+testcpt(Inf)
+
+# Test multiple "for" loops waiting on the same channel which
+# is closed after adding a few elements.
+c=Channel(32)
+results=[]
+@sync begin
+    for i in 1:20
+        @async for i in c
+            push!(results, i)
+        end
+    end
+    sleep(1.0)
+    for i in 1:5
+        put!(c,i)
+    end
+    close(c)
+end
+@test sum(results) == 15
+
+# Testing timedwait on multiple channels
+@sync begin
+    rr1 = Channel(1)
+    rr2 = Channel(1)
+    rr3 = Channel(1)
+
+    callback() = all(map(isready, [rr1, rr2, rr3]))
+    # precompile functions which will be tested for execution time
+    @test !callback()
+    @test timedwait(callback, 0.0) === :timed_out
+
+    @async begin sleep(0.5); put!(rr1, :ok) end
+    @async begin sleep(1.0); put!(rr2, :ok) end
+    @async begin sleep(2.0); put!(rr3, :ok) end
+
+    tic()
+    timedwait(callback, 1.0)
+    et=toq()
+    # assuming that 0.5 seconds is a good enough buffer on a typical modern CPU
+    try
+        @test (et >= 1.0) && (et <= 1.5)
+        @test !isready(rr3)
+    catch
+        warn("timedwait tests delayed. et=$et, isready(rr3)=$(isready(rr3))")
+    end
+    @test isready(rr1)
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -33,7 +33,8 @@ function choosetests(choices = [])
         "markdown", "base64", "serialize", "misc", "threads",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
-        "boundscheck", "error", "ambiguous", "cartesian", "asmvariant"
+        "boundscheck", "error", "ambiguous", "cartesian", "asmvariant",
+        "channels"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/julia/pull/17698#issuecomment-237317413, the default channel size of 32 has been removed. The size needs to be specified explicitly. `Channel(Inf)` is an unlimited channel, a shorter way of writing `Channel(typemax(UInt))`

Channel tests have been moved into its own file.

Added support for 0-sized channels (as mentioned in https://github.com/JuliaLang/julia/issues/17699). This provides the same behavior as `produce`/ `consume` which can be deprecated in a separate PR.
