### PR TITLE
Fix relocation verification code

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -508,7 +508,7 @@ void JuliaOJIT::addModule(std::unique_ptr<Module> M)
             else if (!(isIntrinsicFunction(F) ||
                        findUnmangledSymbol(F->getName()) ||
                        SectionMemoryManager::getSymbolAddressInProcess(
-                           F->getName()))) {
+                           getMangledName(F->getName())))) {
                 std::cerr << "FATAL ERROR: "
                           << "Symbol \"" << F->getName().str() << "\""
                           << "not found";

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -143,6 +143,16 @@ function confuse_declname_parsing()
 end
 confuse_declname_parsing()
 
+# Test for proper mangling of external (C) functions
+function call_jl_errno()
+    llvmcall(
+    (""" declare i32 @jl_errno()""",
+    """
+    %r = call i32 @jl_errno()
+    ret i32 %r
+    """),Int32,Tuple{})
+end
+call_jl_errno()
 
 module ObjLoadTest
     using Base: Test, llvmcall, @ccallable


### PR DESCRIPTION
The code needs to use the mangled name in order to find symbols. On OS X,
mangling adds an underscore, while on linux mangling does nothing. Since
this verification code only exists when assertions are turned on, not
many people have run into this (since it's a bug in the verification,
not actually indicative of a problem).

Nevertheless, fixes https://github.com/Keno/Cxx.jl/issues/296.
