### PR TITLE
Doctests examples for Linear Algebra library as suggested in #18799

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -131,7 +131,7 @@ The following keyword arguments are supported:
 iterations `niter` and the number of matrix vector multiplications `nmult`, as well as the
 final residual vector `resid`.
 
-**Example**
+# Example
 
 ```julia
 X = sprand(10, 5, 0.2)
@@ -342,7 +342,7 @@ iterations derived from [`eigs`](:func:`eigs`).
 * `nmult`: Number of matrix--vector products used.
 * `resid`: Final residual vector.
 
-**Example**
+# Example
 
 ```julia
 X = sprand(10, 5, 0.2)

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -23,11 +23,33 @@ must be one less than the length of `dv`.
 
 **Example**
 
-```julia
-dv = rand(5)
-ev = rand(4)
-Bu = Bidiagonal(dv, ev, true) #e is on the first superdiagonal
-Bl = Bidiagonal(dv, ev, false) #e is on the first subdiagonal
+```jldoctest
+julia> dv = [1; 2; 3; 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> ev = [7; 8; 9]
+3-element Array{Int64,1}:
+ 7
+ 8
+ 9
+
+ julia> Bu = Bidiagonal(dv, ev, true) #e is on the first superdiagonal
+ 4×4 Bidiagonal{Int64}:
+  1  7  ⋅  ⋅
+  ⋅  2  8  ⋅
+  ⋅  ⋅  3  9
+  ⋅  ⋅  ⋅  4
+
+ julia> Bl = Bidiagonal(dv, ev, false) #e is on the first subdiagonal
+ 4×4 Bidiagonal{Int64}:
+  1  ⋅  ⋅  ⋅
+  7  2  ⋅  ⋅
+  ⋅  8  3  ⋅
+  ⋅  ⋅  9  4
 ```
 """
 Bidiagonal{T}(dv::AbstractVector{T}, ev::AbstractVector{T}, isupper::Bool) = Bidiagonal{T}(collect(dv), collect(ev), isupper)
@@ -44,11 +66,33 @@ length must be one less than the length of `dv`.
 
 **Example**
 
-```julia
-dv = rand(5)
-ev = rand(4)
-Bu = Bidiagonal(dv, ev, 'U') #e is on the first superdiagonal
-Bl = Bidiagonal(dv, ev, 'L') #e is on the first subdiagonal
+```jldoctest
+julia> dv = [1; 2; 3; 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> ev = [7; 8; 9]
+3-element Array{Int64,1}:
+ 7
+ 8
+ 9
+
+julia> Bu = Bidiagonal(dv, ev, 'U') #e is on the first superdiagonal
+4×4 Bidiagonal{Int64}:
+ 1  7  ⋅  ⋅
+ ⋅  2  8  ⋅
+ ⋅  ⋅  3  9
+ ⋅  ⋅  ⋅  4
+
+julia> Bl = Bidiagonal(dv, ev, 'L') #e is on the first subdiagonal
+4×4 Bidiagonal{Int64}:
+ 1  ⋅  ⋅  ⋅
+ 7  2  ⋅  ⋅
+ ⋅  8  3  ⋅
+ ⋅  ⋅  9  4
 ```
 """
 #Convert from BLAS uplo flag to boolean internal
@@ -75,10 +119,27 @@ its first super- (if `isupper=true`) or sub-diagonal (if `isupper=false`).
 
 **Example**
 
-```julia
-A = rand(5,5)
-Bu = Bidiagonal(A, true) #contains the main diagonal and first superdiagonal of A
-Bl = Bidiagonal(A, false) #contains the main diagonal and first subdiagonal of A
+```jldoctest
+julia> A = [1 1 1 1; 2 2 2 2; 3 3 3 3; 4 4 4 4]
+4×4 Array{Int64,2}:
+ 1  1  1  1
+ 2  2  2  2
+ 3  3  3  3
+ 4  4  4  4
+
+julia> Bidiagonal(A, true) #contains the main diagonal and first superdiagonal of A
+4×4 Bidiagonal{Int64}:
+ 1  1  ⋅  ⋅
+ ⋅  2  2  ⋅
+ ⋅  ⋅  3  3
+ ⋅  ⋅  ⋅  4
+
+julia> Bidiagonal(A, false) #contains the main diagonal and first subdiagonal of A
+4×4 Bidiagonal{Int64}:
+ 1  ⋅  ⋅  ⋅
+ 2  2  ⋅  ⋅
+ ⋅  3  3  ⋅
+ ⋅  ⋅  4  4
 ```
 """
 Bidiagonal(A::AbstractMatrix, isupper::Bool)=Bidiagonal(diag(A), diag(A, isupper?1:-1), isupper)

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -21,7 +21,7 @@ and provides efficient specialized linear solvers, but may be converted into a r
 matrix with [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short). `ev`'s length
 must be one less than the length of `dv`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> dv = [1; 2; 3; 4]
@@ -64,7 +64,7 @@ and provides efficient specialized linear solvers, but may be converted into a r
 matrix with [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short). `ev`'s
 length must be one less than the length of `dv`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> dv = [1; 2; 3; 4]
@@ -117,7 +117,7 @@ end
 Construct a `Bidiagonal` matrix from the main diagonal of `A` and
 its first super- (if `isupper=true`) or sub-diagonal (if `isupper=false`).
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 1 1 1; 2 2 2 2; 3 3 3 3; 4 4 4 4]

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -37,14 +37,14 @@ julia> ev = [7; 8; 9]
  8
  9
 
- julia> Bu = Bidiagonal(dv, ev, true) #e is on the first superdiagonal
+ julia> Bu = Bidiagonal(dv, ev, true) # ev is on the first superdiagonal
  4×4 Bidiagonal{Int64}:
   1  7  ⋅  ⋅
   ⋅  2  8  ⋅
   ⋅  ⋅  3  9
   ⋅  ⋅  ⋅  4
 
- julia> Bl = Bidiagonal(dv, ev, false) #e is on the first subdiagonal
+ julia> Bl = Bidiagonal(dv, ev, false) # ev is on the first subdiagonal
  4×4 Bidiagonal{Int64}:
   1  ⋅  ⋅  ⋅
   7  2  ⋅  ⋅

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -162,7 +162,7 @@ end
 Compute the Cholesky factorization of a positive definite matrix `A`
 and return the UpperTriangular matrix `U` such that `A = U'U`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1. 2.; 2. 50.]
@@ -192,7 +192,7 @@ end
 
 Compute the square root of a non-negative number `x`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> chol(16)
@@ -230,7 +230,7 @@ of creating a copy. An `InexactError` exception is thrown if the factorisation
 produces a number not representable by the element type of `A`, e.g. for
 integer types.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2; 2 50]
@@ -307,7 +307,7 @@ The triangular Cholesky factor can be obtained from the factorization `F` with: 
 The following functions are available for `Cholesky` objects: `size`, `\\`, `inv`, `det`.
 A `PosDefException` exception is thrown in case the matrix is not positive definite.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -161,6 +161,25 @@ end
 
 Compute the Cholesky factorization of a positive definite matrix `A`
 and return the UpperTriangular matrix `U` such that `A = U'U`.
+
+**Example**
+
+```jldoctest
+julia> A = [1. 2.; 2. 50.]
+2×2 Array{Float64,2}:
+ 1.0   2.0
+ 2.0  50.0
+
+julia> U = chol(A)
+2×2 UpperTriangular{Float64,Array{Float64,2}}:
+ 1.0  2.0
+  ⋅   6.78233
+
+julia> U'U
+2×2 Array{Float64,2}:
+ 1.0   2.0
+ 2.0  50.0
+```
 """
 function chol(A::AbstractMatrix)
     ishermitian(A) || non_hermitian_error("chol")
@@ -172,6 +191,13 @@ end
     chol(x::Number) -> y
 
 Compute the square root of a non-negative number `x`.
+
+**Example**
+
+```jldoctest
+julia> chol(16)
+4.0
+```
 """
 chol(x::Number, args...) = _chol!(x, nothing)
 
@@ -203,6 +229,19 @@ The same as `cholfact`, but saves space by overwriting the input `A`, instead
 of creating a copy. An `InexactError` exception is thrown if the factorisation
 produces a number not representable by the element type of `A`, e.g. for
 integer types.
+
+**Example**
+
+```jldoctest
+julia> A = [1 2; 2 50]
+2×2 Array{Int64,2}:
+ 1   2
+ 2  50
+
+ julia> cholfact!(A)
+ ERROR: InexactError()
+  ...
+```
 """
 function cholfact!(A::StridedMatrix, uplo::Symbol, ::Type{Val{false}})
     ishermitian(A) || non_hermitian_error("cholfact!")
@@ -267,6 +306,8 @@ The default is to use `:U`.
 The triangular Cholesky factor can be obtained from the factorization `F` with: `F[:L]` and `F[:U]`.
 The following functions are available for `Cholesky` objects: `size`, `\\`, `inv`, `det`.
 A `PosDefException` exception is thrown in case the matrix is not positive definite.
+
+**Example**
 
 ```jldoctest
 julia> A = [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -267,6 +267,33 @@ The default is to use `:U`.
 The triangular Cholesky factor can be obtained from the factorization `F` with: `F[:L]` and `F[:U]`.
 The following functions are available for `Cholesky` objects: `size`, `\\`, `inv`, `det`.
 A `PosDefException` exception is thrown in case the matrix is not positive definite.
+
+```jldoctest
+julia> A = [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]
+3×3 Array{Float64,2}:
+   4.0   12.0  -16.0
+  12.0   37.0  -43.0
+ -16.0  -43.0   98.0
+
+julia> C = cholfact(A)
+Base.LinAlg.Cholesky{Float64,Array{Float64,2}} with factor:
+[2.0 6.0 -8.0; 0.0 1.0 5.0; 0.0 0.0 3.0]
+
+julia> C[:U]
+3×3 UpperTriangular{Float64,Array{Float64,2}}:
+ 2.0  6.0  -8.0
+  ⋅   1.0   5.0
+  ⋅    ⋅    3.0
+
+julia> C[:L]
+3×3 LowerTriangular{Float64,Array{Float64,2}}:
+  2.0   ⋅    ⋅
+  6.0  1.0   ⋅
+ -8.0  5.0  3.0
+
+julia> C[:L] * C[:U] == A
+true
+```
 """
 function cholfact(A::StridedMatrix, uplo::Symbol, ::Type{Val{false}})
     ishermitian(A) || non_hermitian_error("cholfact")

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -505,9 +505,22 @@ If `factorize` is called on a Hermitian positive-definite matrix, for instance, 
 will return a Cholesky factorization.
 
 Example:
-```julia
-A = diagm(rand(5)) + diagm(rand(4),1); #A is really bidiagonal
-factorize(A) #factorize will check to see that A is already factorized
+```jldoctest
+julia> A = Bidiagonal(ones(5, 5), true) #A is really bidiagonal
+5×5 Bidiagonal{Float64}:
+ 1.0  1.0   ⋅    ⋅    ⋅
+  ⋅   1.0  1.0   ⋅    ⋅
+  ⋅    ⋅   1.0  1.0   ⋅
+  ⋅    ⋅    ⋅   1.0  1.0
+  ⋅    ⋅    ⋅    ⋅   1.0
+
+julia> factorize(A) #factorize will check to see that A is already factorized
+5×5 Bidiagonal{Float64}:
+ 1.0  1.0   ⋅    ⋅    ⋅
+  ⋅   1.0  1.0   ⋅    ⋅
+  ⋅    ⋅   1.0  1.0   ⋅
+  ⋅    ⋅    ⋅   1.0  1.0
+  ⋅    ⋅    ⋅    ⋅   1.0
 ```
 This returns a `5×5 Bidiagonal{Float64}`, which can now be passed to other linear algebra functions
 (e.g. eigensolvers) which will use specialized methods for `Bidiagonal` types.

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -213,22 +213,22 @@ end
 Kronecker tensor product of two vectors or two matrices.
 
 ```jldoctest
-julia> A = [1 2; 1 0]
+julia> A = [1 2; 3 4]
 2×2 Array{Int64,2}:
  1  2
- 1  0
+ 3  4
 
-julia> B = [2 0; 0 1]
+julia> B = [1 1; 1 1]
 2×2 Array{Int64,2}:
- 2  0
- 0  1
+ 1  1
+ 1  1
 
 julia> kron(A, B)
 4×4 Array{Int64,2}:
- 2  0  4  0
- 0  1  0  2
- 2  0  0  0
- 0  1  0  0
+ 1  1  2  2
+ 1  1  2  2
+ 3  3  4  4
+ 3  3  4  4
 ```
 """
 function kron{T,S}(a::AbstractMatrix{T}, b::AbstractMatrix{S})
@@ -504,17 +504,16 @@ systems. For example: `A=factorize(A); x=A\\b; y=A\\C`.
 If `factorize` is called on a Hermitian positive-definite matrix, for instance, then `factorize`
 will return a Cholesky factorization.
 
-Example:
 ```jldoctest
-julia> A = Bidiagonal(ones(5, 5), true) #A is really bidiagonal
-5×5 Bidiagonal{Float64}:
- 1.0  1.0   ⋅    ⋅    ⋅
-  ⋅   1.0  1.0   ⋅    ⋅
-  ⋅    ⋅   1.0  1.0   ⋅
-  ⋅    ⋅    ⋅   1.0  1.0
-  ⋅    ⋅    ⋅    ⋅   1.0
+julia> A = Array(Bidiagonal(ones(5, 5), true))
+5×5 Array{Float64,2}:
+ 1.0  1.0  0.0  0.0  0.0
+ 0.0  1.0  1.0  0.0  0.0
+ 0.0  0.0  1.0  1.0  0.0
+ 0.0  0.0  0.0  1.0  1.0
+ 0.0  0.0  0.0  0.0  1.0
 
-julia> factorize(A) #factorize will check to see that A is already factorized
+julia> factorize(A) # factorize will check to see that A is already factorized
 5×5 Bidiagonal{Float64}:
  1.0  1.0   ⋅    ⋅    ⋅
   ⋅   1.0  1.0   ⋅    ⋅

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -211,6 +211,25 @@ end
     kron(A, B)
 
 Kronecker tensor product of two vectors or two matrices.
+
+```jldoctest
+julia> A = [1 2; 1 0]
+2×2 Array{Int64,2}:
+ 1  2
+ 1  0
+
+julia> B = [2 0; 0 1]
+2×2 Array{Int64,2}:
+ 2  0
+ 0  1
+
+julia> kron(A, B)
+4×4 Array{Int64,2}:
+ 2  0  4  0
+ 0  1  0  2
+ 2  0  0  0
+ 0  1  0  0
+```
 """
 function kron{T,S}(a::AbstractMatrix{T}, b::AbstractMatrix{S})
     R = Array{promote_type(T,S)}(size(a,1)*size(b,1), size(a,2)*size(b,2))
@@ -587,6 +606,23 @@ inverting dense ill-conditioned matrices in a least-squares sense,
 
 For more information, see [^issue8859], [^B96], [^S84], [^KY88].
 
+```jldoctest
+julia> M = [1.5 1.3; 1.2 1.9]
+2×2 Array{Float64,2}:
+ 1.5  1.3
+ 1.2  1.9
+
+julia> N = pinv(M)
+2×2 Array{Float64,2}:
+  1.47287   -1.00775
+ -0.930233   1.16279
+
+julia> M * N
+2×2 Array{Float64,2}:
+ 1.0          -2.22045e-16
+ 4.44089e-16   1.0
+```
+
 [^issue8859]: Issue 8859, "Fix least squares", https://github.com/JuliaLang/julia/pull/8859
 
 [^B96]: Åke Björck, "Numerical Methods for Least Squares Problems",  SIAM Press, Philadelphia, 1996, "Other Titles in Applied Mathematics", Vol. 51. [doi:10.1137/1.9781611971484](http://epubs.siam.org/doi/book/10.1137/1.9781611971484)
@@ -640,6 +676,20 @@ end
     nullspace(M)
 
 Basis for nullspace of `M`.
+
+```jldoctest
+julia> M = [1 0 0; 0 1 0; 0 0 0]
+3×3 Array{Int64,2}:
+ 1  0  0
+ 0  1  0
+ 0  0  0
+
+julia> nullspace(M)
+3×1 Array{Float64,2}:
+ 0.0
+ 0.0
+ 1.0
+```
 """
 function nullspace{T}(A::StridedMatrix{T})
     m, n = size(A)

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -46,7 +46,7 @@ isposdef{T}(A::AbstractMatrix{T}, UL::Symbol) = (S = typeof(sqrt(one(T))); ispos
 
 Test whether a matrix is positive definite.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2; 2 50]
@@ -83,7 +83,7 @@ vecnorm2{T<:BlasFloat}(x::Union{Array{T},StridedVector{T}}) =
 Returns the upper triangle of `M` starting from the `k`th superdiagonal,
 overwriting `M` in the process.
 
-**Example**
+# Example
 ```jldoctest
 julia> M = [1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5]
 5×5 Array{Int64,2}:
@@ -126,7 +126,7 @@ triu(M::Matrix, k::Integer) = triu!(copy(M), k)
 Returns the lower triangle of `M` starting from the `k`th superdiagonal, overwriting `M` in
 the process.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> M = [1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5]
@@ -192,7 +192,7 @@ end
 
 A [`Range`](:class:`Range`) giving the indices of the `k`th diagonal of the matrix `M`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]
@@ -213,7 +213,7 @@ diagind(A::AbstractMatrix, k::Integer=0) = diagind(size(A,1), size(A,2), k)
 The `k`th diagonal of a matrix, as a vector.
 Use [`diagm`](:func:`diagm`) to construct a diagonal matrix.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]
@@ -235,7 +235,7 @@ diag(A::AbstractMatrix, k::Integer=0) = A[diagind(A,k)]
 
 Construct a matrix by placing `v` on the `k`th diagonal.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> diagm([1,2,3],1)
@@ -269,7 +269,7 @@ end
 
 Kronecker tensor product of two vectors or two matrices.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2; 3 4]
@@ -277,17 +277,17 @@ julia> A = [1 2; 3 4]
  1  2
  3  4
 
-julia> B = [1 1; 1 1]
-2×2 Array{Int64,2}:
- 1  1
- 1  1
+julia> B = [im 1; 1 -im]
+2×2 Array{Complex{Int64},2}:
+ 0+1im  1+0im
+ 1+0im  0-1im
 
 julia> kron(A, B)
-4×4 Array{Int64,2}:
- 1  1  2  2
- 1  1  2  2
- 3  3  4  4
- 3  3  4  4
+4×4 Array{Complex{Int64},2}:
+ 0+1im  1+0im  0+2im  2+0im
+ 1+0im  0-1im  2+0im  0-2im
+ 0+3im  3+0im  0+4im  4+0im
+ 3+0im  0-3im  4+0im  0-4im
 ```
 """
 function kron{T,S}(a::AbstractMatrix{T}, b::AbstractMatrix{S})
@@ -338,7 +338,7 @@ used, otherwise the scaling and squaring algorithm (see [^H05]) is chosen.
 
 [^H05]: Nicholas J. Higham, "The squaring and scaling method for the matrix exponential revisited", SIAM Journal on Matrix Analysis and Applications, 26(4), 2005, 1179-1193. [doi:10.1137/090768539](http://dx.doi.org/10.1137/090768539)
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = eye(2, 2)
@@ -576,7 +576,7 @@ systems. For example: `A=factorize(A); x=A\\b; y=A\\C`.
 If `factorize` is called on a Hermitian positive-definite matrix, for instance, then `factorize`
 will return a Cholesky factorization.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = Array(Bidiagonal(ones(5, 5), true))
@@ -692,7 +692,7 @@ inverting dense ill-conditioned matrices in a least-squares sense,
 
 For more information, see [^issue8859], [^B96], [^S84], [^KY88].
 
-**Example**
+# Example
 
 ```jldoctest
 julia> M = [1.5 1.3; 1.2 1.9]
@@ -765,7 +765,7 @@ end
 
 Basis for nullspace of `M`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> M = [1 0 0; 0 1 0; 0 0 0]

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -45,6 +45,18 @@ isposdef{T}(A::AbstractMatrix{T}, UL::Symbol) = (S = typeof(sqrt(one(T))); ispos
     isposdef(A) -> Bool
 
 Test whether a matrix is positive definite.
+
+**Example**
+
+```jldoctest
+julia> A = [1 2; 2 50]
+2×2 Array{Int64,2}:
+ 1   2
+ 2  50
+
+julia> isposdef(A)
+true
+```
 """
 isposdef{T}(A::AbstractMatrix{T}) = (S = typeof(sqrt(one(T))); isposdef!(S == T ? copy(A) : convert(AbstractMatrix{S}, A)))
 isposdef(x::Number) = imag(x)==0 && real(x) > 0
@@ -70,6 +82,25 @@ vecnorm2{T<:BlasFloat}(x::Union{Array{T},StridedVector{T}}) =
 
 Returns the upper triangle of `M` starting from the `k`th superdiagonal,
 overwriting `M` in the process.
+
+**Example**
+```jldoctest
+julia> M = [1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5]
+5×5 Array{Int64,2}:
+ 1  2  3  4  5
+ 1  2  3  4  5
+ 1  2  3  4  5
+ 1  2  3  4  5
+ 1  2  3  4  5
+
+julia> triu!(M, 1)
+5×5 Array{Int64,2}:
+ 0  2  3  4  5
+ 0  0  3  4  5
+ 0  0  0  4  5
+ 0  0  0  0  5
+ 0  0  0  0  0
+```
 """
 function triu!(M::AbstractMatrix, k::Integer)
     m, n = size(M)
@@ -94,6 +125,26 @@ triu(M::Matrix, k::Integer) = triu!(copy(M), k)
 
 Returns the lower triangle of `M` starting from the `k`th superdiagonal, overwriting `M` in
 the process.
+
+**Example**
+
+```jldoctest
+julia> M = [1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5]
+5×5 Array{Int64,2}:
+ 1  2  3  4  5
+ 1  2  3  4  5
+ 1  2  3  4  5
+ 1  2  3  4  5
+ 1  2  3  4  5
+
+julia> tril!(M, 2)
+5×5 Array{Int64,2}:
+ 1  2  3  0  0
+ 1  2  3  4  0
+ 1  2  3  4  5
+ 1  2  3  4  5
+ 1  2  3  4  5
+```
 """
 function tril!(M::AbstractMatrix, k::Integer)
     m, n = size(M)
@@ -141,6 +192,8 @@ end
 
 A [`Range`](:class:`Range`) giving the indices of the `k`th diagonal of the matrix `M`.
 
+**Example**
+
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]
 3×3 Array{Int64,2}:
@@ -159,6 +212,8 @@ diagind(A::AbstractMatrix, k::Integer=0) = diagind(size(A,1), size(A,2), k)
 
 The `k`th diagonal of a matrix, as a vector.
 Use [`diagm`](:func:`diagm`) to construct a diagonal matrix.
+
+**Example**
 
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]
@@ -179,6 +234,8 @@ diag(A::AbstractMatrix, k::Integer=0) = A[diagind(A,k)]
     diagm(v, k::Integer=0)
 
 Construct a matrix by placing `v` on the `k`th diagonal.
+
+**Example**
 
 ```jldoctest
 julia> diagm([1,2,3],1)
@@ -211,6 +268,8 @@ end
     kron(A, B)
 
 Kronecker tensor product of two vectors or two matrices.
+
+**Example**
 
 ```jldoctest
 julia> A = [1 2; 3 4]
@@ -279,6 +338,19 @@ used, otherwise the scaling and squaring algorithm (see [^H05]) is chosen.
 
 [^H05]: Nicholas J. Higham, "The squaring and scaling method for the matrix exponential revisited", SIAM Journal on Matrix Analysis and Applications, 26(4), 2005, 1179-1193. [doi:10.1137/090768539](http://dx.doi.org/10.1137/090768539)
 
+**Example**
+
+```jldoctest
+julia> A = eye(2, 2)
+2×2 Array{Float64,2}:
+ 1.0  0.0
+ 0.0  1.0
+
+julia> expm(A)
+2×2 Array{Float64,2}:
+ 2.71828  0.0
+ 0.0      2.71828
+```
 """
 expm{T<:BlasFloat}(A::StridedMatrix{T}) = expm!(copy(A))
 expm{T<:Integer}(A::StridedMatrix{T}) = expm!(float(A))
@@ -504,6 +576,8 @@ systems. For example: `A=factorize(A); x=A\\b; y=A\\C`.
 If `factorize` is called on a Hermitian positive-definite matrix, for instance, then `factorize`
 will return a Cholesky factorization.
 
+**Example**
+
 ```jldoctest
 julia> A = Array(Bidiagonal(ones(5, 5), true))
 5×5 Array{Float64,2}:
@@ -618,6 +692,8 @@ inverting dense ill-conditioned matrices in a least-squares sense,
 
 For more information, see [^issue8859], [^B96], [^S84], [^KY88].
 
+**Example**
+
 ```jldoctest
 julia> M = [1.5 1.3; 1.2 1.9]
 2×2 Array{Float64,2}:
@@ -688,6 +764,8 @@ end
     nullspace(M)
 
 Basis for nullspace of `M`.
+
+**Example**
 
 ```jldoctest
 julia> M = [1 0 0; 0 1 0; 0 0 0]

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -9,12 +9,38 @@ end
     Diagonal(A::AbstractMatrix)
 
 Constructs a matrix from the diagonal of `A`.
+
+```jldoctest
+julia> A = [1 2 3; 4 5 6; 7 8 9]
+3×3 Array{Int64,2}:
+ 1  2  3
+ 4  5  6
+ 7  8  9
+
+julia> Diagonal(A)
+3×3 Diagonal{Int64}:
+ 1  ⋅  ⋅
+ ⋅  5  ⋅
+ ⋅  ⋅  9
+```
 """
 Diagonal(A::AbstractMatrix) = Diagonal(diag(A))
 """
     Diagonal(V::AbstractVector)
 
 Constructs a matrix with `V` as its diagonal.
+
+```jldoctest
+julia> V = [1; 2]
+2-element Array{Int64,1}:
+ 1
+ 2
+
+julia> Diagonal(V)
+2×2 Diagonal{Int64}:
+ 1  ⋅
+ ⋅  2
+```
 """
 Diagonal(V::AbstractVector) = Diagonal(collect(V))
 

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -10,7 +10,7 @@ end
 
 Constructs a matrix from the diagonal of `A`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]
@@ -32,7 +32,7 @@ Diagonal(A::AbstractMatrix) = Diagonal(diag(A))
 
 Constructs a matrix with `V` as its diagonal.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> V = [1; 2]

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -10,6 +10,8 @@ end
 
 Constructs a matrix from the diagonal of `A`.
 
+**Example**
+
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]
 3×3 Array{Int64,2}:
@@ -29,6 +31,8 @@ Diagonal(A::AbstractMatrix) = Diagonal(diag(A))
     Diagonal(V::AbstractVector)
 
 Constructs a matrix with `V` as its diagonal.
+
+**Example**
 
 ```jldoctest
 julia> V = [1; 2]

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -74,6 +74,25 @@ For general nonsymmetric matrices it is possible to specify how the matrix is ba
 before the eigenvector calculation. The option `permute=true` permutes the matrix to become
 closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
 make rows and columns more equal in norm. The default is `true` for both options.
+
+**Example**
+
+```jldoctest
+julia> F = eigfact([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
+Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([1.0,3.0,18.0],[1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+
+julia> F[:values]
+3-element Array{Float64,1}:
+  1.0
+  3.0
+ 18.0
+
+julia> F[:vectors]
+3×3 Array{Float64,2}:
+ 1.0  0.0  0.0
+ 0.0  1.0  0.0
+ 0.0  0.0  1.0
+```
 """
 function eigfact{T}(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true)
     S = promote_type(Float32, typeof(one(T)/norm(one(T))))
@@ -94,6 +113,8 @@ See [`eigfact`](:func:`eigfact`) for details on the
 `irange`, `vl`, and `vu` arguments
 and the `permute` and `scale` keyword arguments.
 The eigenvectors are returned columnwise.
+
+**Example**
 
 ```jldoctest
 julia> eig([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
@@ -118,6 +139,16 @@ for [`eigfact`](:func:`eigfact`).
 
 For [`SymTridiagonal`](:class:`SymTridiagonal`) matrices, if the optional vector of
 eigenvalues `eigvals` is specified, returns the specific corresponding eigenvectors.
+
+**Example**
+
+```jldoctest
+julia> eigvecs([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
+3×3 Array{Float64,2}:
+ 1.0  0.0  0.0
+ 0.0  1.0  0.0
+ 0.0  0.0  1.0
+```
 """
 eigvecs(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true) =
     eigvecs(eigfact(A, permute=permute, scale=scale))
@@ -159,6 +190,8 @@ Note that if the eigenvalues of `A` are complex,
 this method will fail, since complex numbers cannot
 be sorted.
 
+**Example**
+
 ```jldoctest
 julia> A = [0 im; -im 0]
 2×2 Array{Complex{Int64},2}:
@@ -175,8 +208,8 @@ julia> A = [0 im; -1 0]
 
 julia> eigmax(A)
 ERROR: DomainError:
- in #eigmax#30(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:186
- in eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:184
+ in #eigmax#30(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:219
+ in eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:217
  ...
 ```
 """
@@ -199,6 +232,8 @@ Note that if the eigenvalues of `A` are complex,
 this method will fail, since complex numbers cannot
 be sorted.
 
+**Example**
+
 ```jldoctest
 julia> A = [0 im; -im 0]
 2×2 Array{Complex{Int64},2}:
@@ -215,8 +250,8 @@ julia> A = [0 im; -1 0]
 
 julia> eigmin(A)
 ERROR: DomainError:
- in #eigmin#31(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:226
- in eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:224
+ in #eigmin#31(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:261
+ in eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:259
  ...
 ```
 """
@@ -284,6 +319,8 @@ Computes generalized eigenvalues (`D`) and vectors (`V`) of `A` with respect to 
 `eig` is a wrapper around [`eigfact`](:func:`eigfact`), extracting all parts of the
 factorization to a tuple; where possible, using [`eigfact`](:func:`eigfact`) is recommended.
 
+**Example**
+
 ```jldoctest
 julia> A = [1 0; 0 -1]
 2×2 Array{Int64,2}:
@@ -330,6 +367,8 @@ end
 
 Computes the generalized eigenvalues of `A` and `B`.
 
+**Example**
+
 ```jldoctest
 julia> A = [1 0; 0 -1]
 2×2 Array{Int64,2}:
@@ -357,6 +396,8 @@ end
 
 Returns a matrix `M` whose columns are the generalized eigenvectors of `A` and `B`. (The `k`th eigenvector can
 be obtained from the slice `M[:, k]`.)
+
+**Example**
 
 ```jldoctest
 julia> A = [1 0; 0 -1]

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -75,7 +75,7 @@ before the eigenvector calculation. The option `permute=true` permutes the matri
 closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
 make rows and columns more equal in norm. The default is `true` for both options.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> F = eigfact([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
@@ -114,7 +114,7 @@ See [`eigfact`](:func:`eigfact`) for details on the
 and the `permute` and `scale` keyword arguments.
 The eigenvectors are returned columnwise.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> eig([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
@@ -140,7 +140,7 @@ for [`eigfact`](:func:`eigfact`).
 For [`SymTridiagonal`](:class:`SymTridiagonal`) matrices, if the optional vector of
 eigenvalues `eigvals` is specified, returns the specific corresponding eigenvectors.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> eigvecs([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
@@ -190,7 +190,7 @@ Note that if the eigenvalues of `A` are complex,
 this method will fail, since complex numbers cannot
 be sorted.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [0 im; -im 0]
@@ -232,7 +232,7 @@ Note that if the eigenvalues of `A` are complex,
 this method will fail, since complex numbers cannot
 be sorted.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [0 im; -im 0]
@@ -319,7 +319,7 @@ Computes generalized eigenvalues (`D`) and vectors (`V`) of `A` with respect to 
 `eig` is a wrapper around [`eigfact`](:func:`eigfact`), extracting all parts of the
 factorization to a tuple; where possible, using [`eigfact`](:func:`eigfact`) is recommended.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 0; 0 -1]
@@ -367,7 +367,7 @@ end
 
 Computes the generalized eigenvalues of `A` and `B`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 0; 0 -1]
@@ -397,7 +397,7 @@ end
 Returns a matrix `M` whose columns are the generalized eigenvectors of `A` and `B`. (The `k`th eigenvector can
 be obtained from the slice `M[:, k]`.)
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 0; 0 -1]

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -472,9 +472,33 @@ For vectors, `p` can assume any numeric value (even though not all values produc
 mathematically valid vector norm). In particular, `norm(A, Inf)` returns the largest value
 in `abs(A)`, whereas `norm(A, -Inf)` returns the smallest.
 
+```jldoctest
+julia> v = [3;-2;6]
+3-element Array{Int64,1}:
+  3
+ -2
+  6
+
+julia> norm(v)
+7.0
+
+julia> norm(v, Inf)
+6.0
+```
+
 For matrices, the matrix norm induced by the vector `p`-norm is used, where valid values of
 `p` are `1`, `2`, or `Inf`. (Note that for sparse matrices, `p=2` is currently not
 implemented.) Use [`vecnorm`](:func:`vecnorm`) to compute the Frobenius norm.
+
+```jldoctest
+julia> A = [1 -2 -3; 2 3 -1]
+2×3 Array{Int64,2}:
+ 1  -2  -3
+ 2   3  -1
+
+julia> norm(A, Inf)
+6.0
+```
 """
 function norm{T}(A::AbstractMatrix{T}, p::Real=2)
     if p == 2
@@ -550,6 +574,21 @@ dot(x::Number, y::Number) = vecdot(x, y)
     ⋅(x,y)
 
 Compute the dot product. For complex vectors, the first vector is conjugated.
+
+```jldoctest
+julia> a = [1; 1]
+2-element Array{Int64,1}:
+ 1
+ 1
+
+julia> b = [2; 3]
+2-element Array{Int64,1}:
+ 2
+ 3
+
+julia> dot(a, b)
+5
+```
 """
 dot(x::AbstractVector, y::AbstractVector) = vecdot(x, y)
 
@@ -608,6 +647,21 @@ Matrix inverse. Computes matrix `N` such that
 `M * N = I`, where `I` is the identity matrix.
 Computed by solving the left-division
 `N = M \\ I`.
+
+```jldoctest
+julia> M = [2 5; 1 3]
+2×2 Array{Int64,2}:
+ 2  5
+ 1  3
+
+julia> N = inv(M)
+2×2 Array{Float64,2}:
+  3.0  -5.0
+ -1.0   2.0
+
+julia> M*N == N*M == eye(2)
+true
+```
 """
 function inv{T}(A::AbstractMatrix{T})
     S = typeof(zero(T)/one(T))
@@ -1002,6 +1056,16 @@ end
     det(M)
 
 Matrix determinant.
+
+```jldoctest
+julia> M = [1 0; 2 2]
+2×2 Array{Int64,2}:
+ 1  0
+ 2  2
+
+julia> det(M)
+2.0
+```
 """
 function det{T}(A::AbstractMatrix{T})
     if istriu(A) || istril(A)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -576,18 +576,11 @@ dot(x::Number, y::Number) = vecdot(x, y)
 Compute the dot product. For complex vectors, the first vector is conjugated.
 
 ```jldoctest
-julia> a = [1; 1]
-2-element Array{Int64,1}:
- 1
- 1
-
-julia> b = [2; 3]
-2-element Array{Int64,1}:
- 2
- 3
-
-julia> dot(a, b)
+julia> dot([1; 1], [2; 3])
 5
+
+julia> dot([im; im], [1; 1])
+0 - 2im
 ```
 """
 dot(x::AbstractVector, y::AbstractVector) = vecdot(x, y)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -54,6 +54,8 @@ If `A` is a matrix and `b` is a vector, then `scale!(A,b)` scales each column `i
 thrown if the scaling produces a number not representable by the element type of `A`,
 e.g. for integer types.
 
+**Example**
+
 ```jldoctest
 julia> a = [1 2; 3 4]
 2×2 Array{Int64,2}:
@@ -89,6 +91,8 @@ scale!(s::Number, X::AbstractArray) = generic_scale!(s, X)
 
 Compute the cross product of two 3-vectors.
 
+**Example**
+
 ```jldoctest
 julia> a = [0;1;0]
 3-element Array{Int64,1}:
@@ -116,6 +120,8 @@ cross(a::AbstractVector, b::AbstractVector) = [a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[
 
 Upper triangle of a matrix.
 
+**Example**
+
 ```jldoctest
 julia> a = ones(4,4)
 4×4 Array{Float64,2}:
@@ -139,6 +145,8 @@ triu(M::AbstractMatrix) = triu!(copy(M))
 
 Lower triangle of a matrix.
 
+**Example**
+
 ```jldoctest
 julia> a = ones(4,4)
 4×4 Array{Float64,2}:
@@ -161,6 +169,8 @@ tril(M::AbstractMatrix) = tril!(copy(M))
     triu(M, k::Integer)
 
 Returns the upper triangle of `M` starting from the `k`th superdiagonal.
+
+**Example**
 
 ```jldoctest
 julia> a = ones(4,4)
@@ -191,6 +201,8 @@ triu(M::AbstractMatrix,k::Integer) = triu!(copy(M),k)
     tril(M, k::Integer)
 
 Returns the lower triangle of `M` starting from the `k`th superdiagonal.
+
+**Example**
 
 ```jldoctest
 julia> a = ones(4,4)
@@ -241,6 +253,8 @@ diff(a::AbstractVector) = [ a[i+1] - a[i] for i=1:length(a)-1 ]
 Finite difference operator of matrix or vector `A`. If `A` is a matrix,
 compute the finite difference over a dimension `dim` (default `1`).
 
+**Example**
+
 ```jldoctest
 julia> a = [2 4; 6 16]
 2×2 Array{Int64,2}:
@@ -271,6 +285,8 @@ gradient(F::AbstractVector) = gradient(F, [1:length(F);])
 
 Compute differences along vector `F`, using `h` as the spacing between points. The default
 spacing is one.
+
+**Example**
 
 ```jldoctest
 julia> a = [2,4,6,8];
@@ -472,6 +488,8 @@ For vectors, `p` can assume any numeric value (even though not all values produc
 mathematically valid vector norm). In particular, `norm(A, Inf)` returns the largest value
 in `abs(A)`, whereas `norm(A, -Inf)` returns the smallest.
 
+**Example**
+
 ```jldoctest
 julia> v = [3;-2;6]
 3-element Array{Int64,1}:
@@ -489,6 +507,8 @@ julia> norm(v, Inf)
 For matrices, the matrix norm induced by the vector `p`-norm is used, where valid values of
 `p` are `1`, `2`, or `Inf`. (Note that for sparse matrices, `p=2` is currently not
 implemented.) Use [`vecnorm`](:func:`vecnorm`) to compute the Frobenius norm.
+
+**Example**
 
 ```jldoctest
 julia> A = [1 -2 -3; 2 3 -1]
@@ -575,6 +595,8 @@ dot(x::Number, y::Number) = vecdot(x, y)
 
 Compute the dot product. For complex vectors, the first vector is conjugated.
 
+**Example**
+
 ```jldoctest
 julia> dot([1; 1], [2; 3])
 5
@@ -610,6 +632,8 @@ rank(x::Number) = x==0 ? 0 : 1
 
 Matrix trace. Sums the diagonal elements of `M`.
 
+**Example**
+
 ```jldoctest
 julia> A = [1 2; 3 4]
 2×2 Array{Int64,2}:
@@ -640,6 +664,8 @@ Matrix inverse. Computes matrix `N` such that
 `M * N = I`, where `I` is the identity matrix.
 Computed by solving the left-division
 `N = M \\ I`.
+
+**Example**
 
 ```jldoctest
 julia> M = [2 5; 1 3]
@@ -676,6 +702,20 @@ pivoted QR factorization of `A` and a rank estimate of `A` based on the R factor
 When `A` is sparse, a similar polyalgorithm is used. For indefinite matrices, the `LDLt`
 factorization does not use pivoting during the numerical factorization and therefore the
 procedure can fail even for invertible matrices.
+
+**Example**
+
+```jldoctest
+julia> A = [1 0; 1 -2]; B = [32; -4];
+
+julia> X = A \\ B
+2-element Array{Float64,1}:
+ 32.0
+ 18.0
+
+julia> A * X == B
+true
+```
 """
 function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
     m, n = size(A)
@@ -728,6 +768,8 @@ condskeel(A::AbstractMatrix, x::AbstractVector, p::Real=Inf) = norm(abs.(inv(A))
 
 Test whether a matrix is symmetric.
 
+**Example**
+
 ```jldoctest
 julia> a = [1 2; 2 -1]
 2×2 Array{Int64,2}:
@@ -765,6 +807,8 @@ issymmetric(x::Number) = x == x
     ishermitian(A) -> Bool
 
 Test whether a matrix is Hermitian.
+
+**Example**
 
 ```jldoctest
 julia> a = [1 2; 2 -1]
@@ -804,6 +848,8 @@ ishermitian(x::Number) = (x == conj(x))
 
 Test whether a matrix is upper triangular.
 
+**Example**
+
 ```jldoctest
 julia> a = [1 2; 2 -1]
 2×2 Array{Int64,2}:
@@ -837,6 +883,8 @@ end
 
 Test whether a matrix is lower triangular.
 
+**Example**
+
 ```jldoctest
 julia> a = [1 2; 2 -1]
 2×2 Array{Int64,2}:
@@ -869,6 +917,8 @@ end
     isdiag(A) -> Bool
 
 Test whether a matrix is diagonal.
+
+**Example**
 
 ```jldoctest
 julia> a = [1 2; 2 -1]
@@ -1050,6 +1100,8 @@ end
 
 Matrix determinant.
 
+**Example**
+
 ```jldoctest
 julia> M = [1 0; 2 2]
 2×2 Array{Int64,2}:
@@ -1133,6 +1185,8 @@ end
 
 Normalize the vector `v` with respect to the `p`-norm.
 See also [`normalize!`](:func:`normalize!`) and [`vecnorm`](:func:`vecnorm`).
+
+**Example**
 
 ```jldoctest
 julia> a = [1,2,4];

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -54,7 +54,7 @@ If `A` is a matrix and `b` is a vector, then `scale!(A,b)` scales each column `i
 thrown if the scaling produces a number not representable by the element type of `A`,
 e.g. for integer types.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [1 2; 3 4]
@@ -91,7 +91,7 @@ scale!(s::Number, X::AbstractArray) = generic_scale!(s, X)
 
 Compute the cross product of two 3-vectors.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [0;1;0]
@@ -120,7 +120,7 @@ cross(a::AbstractVector, b::AbstractVector) = [a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[
 
 Upper triangle of a matrix.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = ones(4,4)
@@ -145,7 +145,7 @@ triu(M::AbstractMatrix) = triu!(copy(M))
 
 Lower triangle of a matrix.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = ones(4,4)
@@ -170,7 +170,7 @@ tril(M::AbstractMatrix) = tril!(copy(M))
 
 Returns the upper triangle of `M` starting from the `k`th superdiagonal.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = ones(4,4)
@@ -202,7 +202,7 @@ triu(M::AbstractMatrix,k::Integer) = triu!(copy(M),k)
 
 Returns the lower triangle of `M` starting from the `k`th superdiagonal.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = ones(4,4)
@@ -253,7 +253,7 @@ diff(a::AbstractVector) = [ a[i+1] - a[i] for i=1:length(a)-1 ]
 Finite difference operator of matrix or vector `A`. If `A` is a matrix,
 compute the finite difference over a dimension `dim` (default `1`).
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [2 4; 6 16]
@@ -286,7 +286,7 @@ gradient(F::AbstractVector) = gradient(F, [1:length(F);])
 Compute differences along vector `F`, using `h` as the spacing between points. The default
 spacing is one.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [2,4,6,8];
@@ -488,7 +488,7 @@ For vectors, `p` can assume any numeric value (even though not all values produc
 mathematically valid vector norm). In particular, `norm(A, Inf)` returns the largest value
 in `abs(A)`, whereas `norm(A, -Inf)` returns the smallest.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> v = [3;-2;6]
@@ -508,7 +508,7 @@ For matrices, the matrix norm induced by the vector `p`-norm is used, where vali
 `p` are `1`, `2`, or `Inf`. (Note that for sparse matrices, `p=2` is currently not
 implemented.) Use [`vecnorm`](:func:`vecnorm`) to compute the Frobenius norm.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 -2 -3; 2 3 -1]
@@ -595,7 +595,7 @@ dot(x::Number, y::Number) = vecdot(x, y)
 
 Compute the dot product. For complex vectors, the first vector is conjugated.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> dot([1; 1], [2; 3])
@@ -632,7 +632,7 @@ rank(x::Number) = x==0 ? 0 : 1
 
 Matrix trace. Sums the diagonal elements of `M`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2; 3 4]
@@ -665,7 +665,7 @@ Matrix inverse. Computes matrix `N` such that
 Computed by solving the left-division
 `N = M \\ I`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> M = [2 5; 1 3]
@@ -703,7 +703,7 @@ When `A` is sparse, a similar polyalgorithm is used. For indefinite matrices, th
 factorization does not use pivoting during the numerical factorization and therefore the
 procedure can fail even for invertible matrices.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 0; 1 -2]; B = [32; -4];
@@ -768,7 +768,7 @@ condskeel(A::AbstractMatrix, x::AbstractVector, p::Real=Inf) = norm(abs.(inv(A))
 
 Test whether a matrix is symmetric.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [1 2; 2 -1]
@@ -808,7 +808,7 @@ issymmetric(x::Number) = x == x
 
 Test whether a matrix is Hermitian.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [1 2; 2 -1]
@@ -848,7 +848,7 @@ ishermitian(x::Number) = (x == conj(x))
 
 Test whether a matrix is upper triangular.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [1 2; 2 -1]
@@ -883,7 +883,7 @@ end
 
 Test whether a matrix is lower triangular.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [1 2; 2 -1]
@@ -918,7 +918,7 @@ end
 
 Test whether a matrix is diagonal.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [1 2; 2 -1]
@@ -1100,7 +1100,7 @@ end
 
 Matrix determinant.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> M = [1 0; 2 2]
@@ -1186,7 +1186,7 @@ end
 Normalize the vector `v` with respect to the `p`-norm.
 See also [`normalize!`](:func:`normalize!`) and [`vecnorm`](:func:`vecnorm`).
 
-**Example**
+# Example
 
 ```jldoctest
 julia> a = [1,2,4];

--- a/base/linalg/linalg.jl
+++ b/base/linalg/linalg.jl
@@ -192,7 +192,7 @@ end
 Check that a matrix is square, then return its common dimension.
 For multiple arguments, return a vector.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = ones(4,4); B = zeros(5,5);

--- a/base/linalg/linalg.jl
+++ b/base/linalg/linalg.jl
@@ -192,6 +192,8 @@ end
 Check that a matrix is square, then return its common dimension.
 For multiple arguments, return a vector.
 
+**Example**
+
 ```jldoctest
 julia> A = ones(4,4); B = zeros(5,5);
 

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -115,6 +115,24 @@ The relationship between `F` and `A` is
 | [`logdet`](:func:`logdet`)       | ✓    | ✓                      |
 | [`logabsdet`](:func:`logabsdet`) | ✓    | ✓                      |
 | [`size`](:func:`size`)           | ✓    | ✓                      |
+
+**Example**
+
+```jldoctest
+julia> A = [4 3; 6 3]
+2×2 Array{Int64,2}:
+ 4  3
+ 6  3
+
+julia> lufact(A)
+Base.LinAlg.LU{Float64,Array{Float64,2}}([4.0 3.0; 1.5 -1.5],[1,2],0)
+
+julia> F = lufact(A)
+Base.LinAlg.LU{Float64,Array{Float64,2}}([4.0 3.0; 1.5 -1.5],[1,2],0)
+
+julia> F[:L] * F[:U] == A[F[:p], :]
+true
+```
 """
 function lufact{T}(A::AbstractMatrix{T}, pivot::Union{Type{Val{false}}, Type{Val{true}}})
     S = typeof(zero(T)/one(T))
@@ -150,6 +168,26 @@ By default, pivoting is used. This can be overridden by passing
 `Val{false}` for the second argument.
 
 See also [`lufact`](:func:`lufact`).
+
+**Example**
+
+```jldoctest
+julia> A = [4. 3.; 6. 3.]
+2×2 Array{Float64,2}:
+ 4.0  3.0
+ 6.0  3.0
+
+julia> L, U, p = lu(A)
+(
+[1.0 0.0; 0.666667 1.0],
+<BLANKLINE>
+[6.0 3.0; 0.0 1.0],
+<BLANKLINE>
+[2,1])
+
+julia> A[p, :] == L * U
+true
+```
 """
 function lu(A::AbstractMatrix, pivot::Union{Type{Val{false}}, Type{Val{true}}} = Val{true})
     F = lufact(A, pivot)

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -116,16 +116,13 @@ The relationship between `F` and `A` is
 | [`logabsdet`](:func:`logabsdet`) | ✓    | ✓                      |
 | [`size`](:func:`size`)           | ✓    | ✓                      |
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [4 3; 6 3]
 2×2 Array{Int64,2}:
  4  3
  6  3
-
-julia> lufact(A)
-Base.LinAlg.LU{Float64,Array{Float64,2}}([4.0 3.0; 1.5 -1.5],[1,2],0)
 
 julia> F = lufact(A)
 Base.LinAlg.LU{Float64,Array{Float64,2}}([4.0 3.0; 1.5 -1.5],[1,2],0)
@@ -169,7 +166,7 @@ By default, pivoting is used. This can be overridden by passing
 
 See also [`lufact`](:func:`lufact`).
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [4. 3.; 6. 3.]

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -130,6 +130,15 @@ Ac_mul_B!(y::AbstractVector, A::AbstractVecOrMat, x::AbstractVector) = generic_m
 ```
 
 Matrix multiplication.
+
+**Example**
+
+```jldoctest
+julia> [1 1; 0 1] * [1 0; 1 1]
+2×2 Array{Int64,2}:
+ 2  1
+ 1  1
+```
 """
 function (*){T,S}(A::AbstractMatrix{T}, B::AbstractMatrix{S})
     TS = promote_op(*, arithtype(T), arithtype(S))
@@ -153,6 +162,8 @@ end
 Calculates the matrix-matrix or matrix-vector product ``A⋅B`` and stores the result in `Y`,
 overwriting the existing value of `Y`. Note that `Y` must not be aliased with either `A` or
 `B`.
+
+**Example**
 
 ```jldoctest
 julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; Y = similar(B); A_mul_B!(Y, A, B);

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -131,7 +131,7 @@ Ac_mul_B!(y::AbstractVector, A::AbstractVecOrMat, x::AbstractVector) = generic_m
 
 Matrix multiplication.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> [1 1; 0 1] * [1 0; 1 1]
@@ -163,7 +163,7 @@ Calculates the matrix-matrix or matrix-vector product ``A⋅B`` and stores the r
 overwriting the existing value of `Y`. Note that `Y` must not be aliased with either `A` or
 `B`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; Y = similar(B); A_mul_B!(Y, A, B);

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -208,6 +208,8 @@ Returns `w`, a unit vector in the direction of `v`, and
 See also [`normalize`](:func:`normalize`), [`normalize!`](:func:`normalize!`),
 and [`LinAlg.qr!](:func:`LinAlg.qr!`).
 
+**Example**
+
 ```jldoctest
 julia> v = [1; 2]
 2-element Array{Int64,1}:

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -208,7 +208,7 @@ Returns `w`, a unit vector in the direction of `v`, and
 See also [`normalize`](:func:`normalize`), [`normalize!`](:func:`normalize!`),
 and [`LinAlg.qr!](:func:`LinAlg.qr!`).
 
-**Example**
+# Example
 
 ```jldoctest
 julia> v = [1; 2]

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -207,6 +207,19 @@ Returns `w`, a unit vector in the direction of `v`, and
 
 See also [`normalize`](:func:`normalize`), [`normalize!`](:func:`normalize!`),
 and [`LinAlg.qr!](:func:`LinAlg.qr!`).
+
+```jldoctest
+julia> v = [1; 2]
+2-element Array{Int64,1}:
+ 1
+ 2
+
+julia> w, r = qr(v)
+([0.447214,0.894427],2.23606797749979)
+
+julia> w*r == v
+true
+```
 """
 function qr(v::AbstractVector)
     nrm = norm(v)

--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -24,7 +24,7 @@ be obtained from the `Schur` object `F` with either `F[:Schur]` or `F[:T]` and t
 orthogonal/unitary Schur vectors can be obtained with `F[:vectors]` or `F[:Z]` such that
 `A = F[:vectors]*F[:Schur]*F[:vectors]'`. The eigenvalues of `A` can be obtained with `F[:values]`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [-2. 1. 3.; 2. 1. -1.; -7. 2. 7.]
@@ -70,7 +70,7 @@ triangular Schur factor `T` and the orthogonal/unitary Schur vectors `Z` such th
 
 See `schurfact`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [-2. 1. 3.; 2. 1. -1.; -7. 2. 7.]

--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -23,6 +23,25 @@ Computes the Schur factorization of the matrix `A`. The (quasi) triangular Schur
 be obtained from the `Schur` object `F` with either `F[:Schur]` or `F[:T]` and the
 orthogonal/unitary Schur vectors can be obtained with `F[:vectors]` or `F[:Z]` such that
 `A = F[:vectors]*F[:Schur]*F[:vectors]'`. The eigenvalues of `A` can be obtained with `F[:values]`.
+
+**Example**
+
+```jldoctest
+julia> A = [-2. 1. 3.; 2. 1. -1.; -7. 2. 7.]
+3×3 Array{Float64,2}:
+ -2.0  1.0   3.0
+  2.0  1.0  -1.0
+ -7.0  2.0   7.0
+
+julia> F = schurfact(A)
+Base.LinAlg.Schur{Float64,Array{Float64,2}}([2.0 0.801792 6.63509; -8.55988e-11 2.0 8.08286; 0.0 0.0 1.99999],[0.577351 0.154299 -0.801784; 0.577346 -0.77152 0.267262; 0.577354 0.617211 0.534522],Complex{Float64}[2.0+8.28447e-6im,2.0-8.28447e-6im,1.99999+0.0im])
+
+julia> F[:vectors] * F[:Schur] * F[:vectors]'
+3×3 Array{Float64,2}:
+ -2.0  1.0   3.0
+  2.0  1.0  -1.0
+ -7.0  2.0   7.0
+```
 """
 schurfact{T<:BlasFloat}(A::StridedMatrix{T}) = schurfact!(copy(A))
 function schurfact{T}(A::StridedMatrix{T})
@@ -50,6 +69,30 @@ triangular Schur factor `T` and the orthogonal/unitary Schur vectors `Z` such th
 `A = Z*T*Z'`. The eigenvalues of `A` are returned in the vector `λ`.
 
 See `schurfact`.
+
+**Example**
+
+```jldoctest
+julia> A = [-2. 1. 3.; 2. 1. -1.; -7. 2. 7.]
+3×3 Array{Float64,2}:
+ -2.0  1.0   3.0
+  2.0  1.0  -1.0
+ -7.0  2.0   7.0
+
+julia> T, Z, lambda = schur(A)
+(
+[2.0 0.801792 6.63509; -8.55988e-11 2.0 8.08286; 0.0 0.0 1.99999],
+<BLANKLINE>
+[0.577351 0.154299 -0.801784; 0.577346 -0.77152 0.267262; 0.577354 0.617211 0.534522],
+<BLANKLINE>
+Complex{Float64}[2.0+8.28447e-6im,2.0-8.28447e-6im,1.99999+0.0im])
+
+julia> Z * T * Z'
+3×3 Array{Float64,2}:
+ -2.0  1.0   3.0
+  2.0  1.0  -1.0
+ -7.0  2.0   7.0
+```
 """
 function schur(A::StridedMatrix)
     SchurF = schurfact(A)

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -52,6 +52,29 @@ If `thin=true` (default), a thin SVD is returned. For a ``M \\times N`` matrix
 `svd` is a wrapper around [`svdfact`](:func:`svdfact(A)`), extracting all parts
 of the `SVD` factorization to a tuple. Direct use of `svdfact` is therefore more
 efficient.
+
+```jldoctest
+julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
+4×5 Array{Float64,2}:
+ 1.0  0.0  0.0  0.0  2.0
+ 0.0  0.0  3.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  2.0  0.0  0.0  0.0
+
+julia> U, S, V = svd(A)
+(
+[0.0 1.0 0.0 0.0; 1.0 0.0 0.0 0.0; 0.0 0.0 0.0 -1.0; 0.0 0.0 1.0 0.0],
+<BLANKLINE>
+[3.0,2.23607,2.0,0.0],
+[-0.0 0.447214 -0.0 0.0; 0.0 0.0 1.0 0.0; … ; -0.0 0.0 -0.0 1.0; 0.0 0.894427 0.0 0.0])
+
+julia> U*diagm(S)*V'
+4×5 Array{Float64,2}:
+ 1.0  0.0  0.0  0.0  2.0
+ 0.0  0.0  3.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  2.0  0.0  0.0  0.0
+```
 """
 function svd(A::Union{Number, AbstractArray}; thin::Bool=true)
     F = svdfact(A, thin=thin)
@@ -84,6 +107,22 @@ svdvals{T<:BlasFloat}(A::AbstractMatrix{T}) = svdvals!(copy(A))
     svdvals(A)
 
 Returns the singular values of `A`.
+
+```jldoctest
+julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
+4×5 Array{Float64,2}:
+ 1.0  0.0  0.0  0.0  2.0
+ 0.0  0.0  3.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  2.0  0.0  0.0  0.0
+
+julia> svdvals(A)
+4-element Array{Float64,1}:
+ 3.0
+ 2.23607
+ 2.0
+ 0.0
+```
 """
 function svdvals{T}(A::AbstractMatrix{T})
     S = promote_type(Float32, typeof(one(T)/norm(one(T))))

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -31,6 +31,26 @@ The algorithm produces `Vt` and hence `Vt` is more efficient to extract than `V`
 If `thin=true` (default), a thin SVD is returned. For a ``M \\times N`` matrix
 `A`, `U` is ``M \\times M`` for a full SVD (`thin=false`) and
 ``M \\times \\min(M, N)`` for a thin SVD.
+
+**Example**
+```jldoctest
+julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
+4×5 Array{Float64,2}:
+ 1.0  0.0  0.0  0.0  2.0
+ 0.0  0.0  3.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  2.0  0.0  0.0  0.0
+
+julia> F = svdfact(A)
+Base.LinAlg.SVD{Float64,Float64,Array{Float64,2}}([0.0 1.0 0.0 0.0; 1.0 0.0 0.0 0.0; 0.0 0.0 0.0 -1.0; 0.0 0.0 1.0 0.0],[3.0,2.23607,2.0,0.0],[-0.0 0.0 … -0.0 0.0; 0.447214 0.0 … 0.0 0.894427; -0.0 1.0 … -0.0 0.0; 0.0 0.0 … 1.0 0.0])
+
+julia> F[:U] * diagm(F[:S]) * F[:Vt]
+4×5 Array{Float64,2}:
+ 1.0  0.0  0.0  0.0  2.0
+ 0.0  0.0  3.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  2.0  0.0  0.0  0.0
+```
 """
 function svdfact{T}(A::StridedVecOrMat{T}; thin::Bool = true)
     S = promote_type(Float32, typeof(one(T)/norm(one(T))))
@@ -52,6 +72,8 @@ If `thin=true` (default), a thin SVD is returned. For a ``M \\times N`` matrix
 `svd` is a wrapper around [`svdfact`](:func:`svdfact(A)`), extracting all parts
 of the `SVD` factorization to a tuple. Direct use of `svdfact` is therefore more
 efficient.
+
+**Example**
 
 ```jldoctest
 julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
@@ -107,6 +129,8 @@ svdvals{T<:BlasFloat}(A::AbstractMatrix{T}) = svdvals!(copy(A))
     svdvals(A)
 
 Returns the singular values of `A`.
+
+**Example**
 
 ```jldoctest
 julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -32,7 +32,7 @@ If `thin=true` (default), a thin SVD is returned. For a ``M \\times N`` matrix
 `A`, `U` is ``M \\times M`` for a full SVD (`thin=false`) and
 ``M \\times \\min(M, N)`` for a thin SVD.
 
-**Example**
+# Example
 ```jldoctest
 julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
 4×5 Array{Float64,2}:
@@ -73,7 +73,7 @@ If `thin=true` (default), a thin SVD is returned. For a ``M \\times N`` matrix
 of the `SVD` factorization to a tuple. Direct use of `svdfact` is therefore more
 efficient.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
@@ -130,7 +130,7 @@ svdvals{T<:BlasFloat}(A::AbstractMatrix{T}) = svdvals!(copy(A))
 
 Returns the singular values of `A`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -57,32 +57,26 @@ Construct a `Hermitian` matrix from the upper (if `uplo = :U`) or lower (if `upl
 # Example
 
 ```jldoctest
-julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]
-5×5 Array{Int64,2}:
- 1  0  2  0  3
- 0  4  0  5  0
- 6  0  7  0  8
- 0  9  0  1  0
- 2  0  3  0  4
+julia> A = [1 0 2+2im 0 3-3im; 0 4 0 5 0; 6-6im 0 7 0 8+8im; 0 9 0 1 0; 2+2im 0 3-3im 0 4];
 
 julia> Hupper = Hermitian(A)
-5×5 Hermitian{Int64,Array{Int64,2}}:
- 1  0  2  0  3
- 0  4  0  5  0
- 2  0  7  0  8
- 0  5  0  1  0
- 3  0  8  0  4
+5×5 Hermitian{Complex{Int64},Array{Complex{Int64},2}}:
+ 1+0im  0+0im  2+2im  0+0im  3-3im
+ 0+0im  4+0im  0+0im  5+0im  0+0im
+ 2-2im  0+0im  7+0im  0+0im  8+8im
+ 0+0im  5+0im  0+0im  1+0im  0+0im
+ 3+3im  0+0im  8-8im  0+0im  4+0im
 
 julia> Hlower = Hermitian(A, :L)
-5×5 Hermitian{Int64,Array{Int64,2}}:
- 1  0  6  0  2
- 0  4  0  9  0
- 6  0  7  0  3
- 0  9  0  1  0
- 2  0  3  0  4
+5×5 Hermitian{Complex{Int64},Array{Complex{Int64},2}}:
+ 1+0im  0+0im  6+6im  0+0im  2-2im
+ 0+0im  4+0im  0+0im  9+0im  0+0im
+ 6-6im  0+0im  7+0im  0+0im  3+3im
+ 0+0im  9+0im  0+0im  1+0im  0+0im
+ 2+2im  0+0im  3-3im  0+0im  4+0im
 
 julia> eigfact(Hupper)
-Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([-2.96684,-2.72015,0.440875,7.72015,14.526],[-0.302016 -2.22045e-16 … 1.11022e-16 0.248524; -6.67755e-16 0.596931 … -0.802293 1.93069e-17; … ; 8.88178e-16 -0.802293 … -0.596931 0.0; 0.772108 8.93933e-16 … 0.0 0.630015])
+Base.LinAlg.Eigen{Complex{Float64},Float64,Array{Complex{Float64},2},Array{Float64,1}}([-8.32069,-2.72015,3.1496,7.72015,17.1711],Complex{Float64}[-0.231509+0.392692im -4.16334e-17+5.55112e-17im … -2.77556e-17-1.11022e-16im -0.129023-0.00628656im; 0.0+0.0im -0.532524+0.269711im … -0.521035+0.610079im 0.0+0.0im; … ; 0.0-1.38778e-17im 0.715729-0.362501im … -0.387666+0.453917im 0.0-6.93889e-18im; 0.67898-0.0im 0.0+0.0im … 0.0+0.0im -0.661651-0.0im])
 ```
 
 `eigfact` will use a method specialized for matrices known to be Hermitian.

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -12,11 +12,33 @@ Construct a `Symmetric` matrix from the upper (if `uplo = :U`) or lower (if `upl
 
 **Example**
 
-```julia
-A = randn(10,10)
-Supper = Symmetric(A)
-Slower = Symmetric(A,:L)
-eigfact(Supper)
+```jldoctest
+julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]
+5×5 Array{Int64,2}:
+ 1  0  2  0  3
+ 0  4  0  5  0
+ 6  0  7  0  8
+ 0  9  0  1  0
+ 2  0  3  0  4
+
+julia> Supper = Symmetric(A)
+5×5 Symmetric{Int64,Array{Int64,2}}:
+ 1  0  2  0  3
+ 0  4  0  5  0
+ 2  0  7  0  8
+ 0  5  0  1  0
+ 3  0  8  0  4
+
+julia> Slower = Symmetric(A, :L)
+5×5 Symmetric{Int64,Array{Int64,2}}:
+ 1  0  6  0  2
+ 0  4  0  9  0
+ 6  0  7  0  3
+ 0  9  0  1  0
+ 2  0  3  0  4
+
+julia> eigfact(Supper)
+Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([-2.96684,-2.72015,0.440875,7.72015,14.526],[-0.302016 -2.22045e-16 … 1.11022e-16 0.248524; -6.67755e-16 0.596931 … -0.802293 1.93069e-17; … ; 8.88178e-16 -0.802293 … -0.596931 0.0; 0.772108 8.93933e-16 … 0.0 0.630015])
 ```
 
 `eigfact` will use a method specialized for matrices known to be symmetric.
@@ -34,11 +56,33 @@ Construct a `Hermitian` matrix from the upper (if `uplo = :U`) or lower (if `upl
 
 **Example**
 
-```julia
-A = randn(10,10)
-Hupper = Hermitian(A)
-Hlower = Hermitian(A,:L)
-eigfact(Hupper)
+```jldoctest
+julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]
+5×5 Array{Int64,2}:
+ 1  0  2  0  3
+ 0  4  0  5  0
+ 6  0  7  0  8
+ 0  9  0  1  0
+ 2  0  3  0  4
+
+julia> Hupper = Hermitian(A)
+5×5 Hermitian{Int64,Array{Int64,2}}:
+ 1  0  2  0  3
+ 0  4  0  5  0
+ 2  0  7  0  8
+ 0  5  0  1  0
+ 3  0  8  0  4
+
+julia> Hlower = Hermitian(A, :L)
+5×5 Hermitian{Int64,Array{Int64,2}}:
+ 1  0  6  0  2
+ 0  4  0  9  0
+ 6  0  7  0  3
+ 0  9  0  1  0
+ 2  0  3  0  4
+
+julia> eigfact(Hupper)
+Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([-2.96684,-2.72015,0.440875,7.72015,14.526],[-0.302016 -2.22045e-16 … 1.11022e-16 0.248524; -6.67755e-16 0.596931 … -0.802293 1.93069e-17; … ; 8.88178e-16 -0.802293 … -0.596931 0.0; 0.772108 8.93933e-16 … 0.0 0.630015])
 ```
 
 `eigfact` will use a method specialized for matrices known to be Hermitian.

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -10,7 +10,7 @@ end
 
 Construct a `Symmetric` matrix from the upper (if `uplo = :U`) or lower (if `uplo = :L`) triangle of `A`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]
@@ -54,7 +54,7 @@ end
 
 Construct a `Hermitian` matrix from the upper (if `uplo = :U`) or lower (if `uplo = :L`) triangle of `A`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -21,6 +21,28 @@ Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-d
 respectively. The result is of type `SymTridiagonal` and provides efficient specialized
 eigensolvers, but may be converted into a regular matrix with
 [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
+
+```jldoctest
+julia> dv = [1; 2; 3; 4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> ev = [7; 8; 9]
+3-element Array{Int64,1}:
+ 7
+ 8
+ 9
+
+julia> SymTridiagonal(dv, ev)
+4×4 SymTridiagonal{Int64}:
+ 1  7  ⋅  ⋅
+ 7  2  8  ⋅
+ ⋅  8  3  9
+ ⋅  ⋅  9  4
+```
 """
 SymTridiagonal{T}(dv::Vector{T}, ev::Vector{T}) = SymTridiagonal{T}(dv, ev)
 
@@ -332,6 +354,34 @@ respectively.  The result is of type `Tridiagonal` and provides efficient specia
 solvers, but may be converted into a regular matrix with
 [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
 The lengths of `dl` and `du` must be one less than the length of `d`.
+
+```jldoctest
+julia> dl = [1; 2; 3]
+3-element Array{Int64,1}:
+ 1
+ 2
+ 3
+
+julia> du = [4; 5; 6]
+3-element Array{Int64,1}:
+ 4
+ 5
+ 6
+
+julia> d = [7; 8; 9; 0]
+4-element Array{Int64,1}:
+ 7
+ 8
+ 9
+ 0
+
+julia> Tridiagonal(dl, d, du)
+4×4 Tridiagonal{Int64}:
+ 7  4  ⋅  ⋅
+ 1  8  5  ⋅
+ ⋅  2  9  6
+ ⋅  ⋅  3  0
+```
 """
 # Basic constructor takes in three dense vectors of same type
 function Tridiagonal{T}(dl::Vector{T}, d::Vector{T}, du::Vector{T})
@@ -353,6 +403,22 @@ end
 
 returns a `Tridiagonal` array based on (abstract) matrix `A`, using its first lower diagonal,
 main diagonal, and first upper diagonal.
+
+```jldoctest
+julia> A = [1 2 3 4; 1 2 3 4; 1 2 3 4; 1 2 3 4]
+4×4 Array{Int64,2}:
+ 1  2  3  4
+ 1  2  3  4
+ 1  2  3  4
+ 1  2  3  4
+
+julia> Tridiagonal(A)
+4×4 Tridiagonal{Int64}:
+ 1  2  ⋅  ⋅
+ 1  2  3  ⋅
+ ⋅  2  3  4
+ ⋅  ⋅  3  4
+```
 """
 function Tridiagonal(A::AbstractMatrix)
     return Tridiagonal(diag(A,-1), diag(A), diag(A,+1))

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -22,7 +22,7 @@ respectively. The result is of type `SymTridiagonal` and provides efficient spec
 eigensolvers, but may be converted into a regular matrix with
 [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
 
-**Example**
+# Example
 
 ```jldoctest
 julia> dv = [1; 2; 3; 4]
@@ -357,7 +357,7 @@ solvers, but may be converted into a regular matrix with
 [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
 The lengths of `dl` and `du` must be one less than the length of `d`.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> dl = [1; 2; 3]
@@ -408,7 +408,7 @@ end
 returns a `Tridiagonal` array based on (abstract) matrix `A`, using its first lower diagonal,
 main diagonal, and first upper diagonal.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> A = [1 2 3 4; 1 2 3 4; 1 2 3 4; 1 2 3 4]

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -22,6 +22,8 @@ respectively. The result is of type `SymTridiagonal` and provides efficient spec
 eigensolvers, but may be converted into a regular matrix with
 [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
 
+**Example**
+
 ```jldoctest
 julia> dv = [1; 2; 3; 4]
 4-element Array{Int64,1}:
@@ -355,6 +357,8 @@ solvers, but may be converted into a regular matrix with
 [`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
 The lengths of `dl` and `du` must be one less than the length of `d`.
 
+**Example**
+
 ```jldoctest
 julia> dl = [1; 2; 3]
 3-element Array{Int64,1}:
@@ -403,6 +407,8 @@ end
 
 returns a `Tridiagonal` array based on (abstract) matrix `A`, using its first lower diagonal,
 main diagonal, and first upper diagonal.
+
+**Example**
 
 ```jldoctest
 julia> A = [1 2 3 4; 1 2 3 4; 1 2 3 4; 1 2 3 4]

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -12,7 +12,7 @@ end
 
 An object of type `UniformScaling`, representing an identity matrix of any size.
 
-**Example**
+# Example
 
 ```jldoctest
 julia> ones(5, 6) * I == ones(5, 6)

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -11,6 +11,18 @@ end
     I
 
 An object of type `UniformScaling`, representing an identity matrix of any size.
+
+**Example**
+
+```jldoctest
+julia> ones(5, 6) * I == ones(5, 6)
+true
+
+julia> [1 2im 3; 1im 2 3] * I
+2×3 Array{Complex{Int64},2}:
+ 1+0im  0+2im  3+0im
+ 0+1im  2+0im  3+0im
+```
 """
 const I = UniformScaling(1)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -36,6 +36,21 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the dot product. For complex vectors, the first vector is conjugated.
 
+   .. doctest::
+
+       julia> a = [1; 1]
+       2-element Array{Int64,1}:
+        1
+        1
+
+       julia> b = [2; 3]
+       2-element Array{Int64,1}:
+        2
+        3
+
+       julia> dot(a, b)
+       5
+
 .. function:: vecdot(x, y)
 
    .. Docstring generated from Julia source
@@ -122,11 +137,37 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Constructs a matrix from the diagonal of ``A``\ .
 
+   .. doctest::
+
+       julia> A = [1 2 3; 4 5 6; 7 8 9]
+       3×3 Array{Int64,2}:
+        1  2  3
+        4  5  6
+        7  8  9
+
+       julia> Diagonal(A)
+       3×3 Diagonal{Int64}:
+        1  ⋅  ⋅
+        ⋅  5  ⋅
+        ⋅  ⋅  9
+
 .. function:: Diagonal(V::AbstractVector)
 
    .. Docstring generated from Julia source
 
    Constructs a matrix with ``V`` as its diagonal.
+
+   .. doctest::
+
+       julia> V = [1; 2]
+       2-element Array{Int64,1}:
+        1
+        2
+
+       julia> Diagonal(V)
+       2×2 Diagonal{Int64}:
+        1  ⋅
+        ⋅  2
 
 .. function:: Bidiagonal(dv, ev, isupper::Bool)
 
@@ -178,11 +219,61 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal, respectively. The result is of type ``SymTridiagonal`` and provides efficient specialized eigensolvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short).
 
+   .. doctest::
+
+       julia> dv = [1; 2; 3; 4]
+       4-element Array{Int64,1}:
+        1
+        2
+        3
+        4
+
+       julia> ev = [7; 8; 9]
+       3-element Array{Int64,1}:
+        7
+        8
+        9
+
+       julia> SymTridiagonal(dv, ev)
+       4×4 SymTridiagonal{Int64}:
+        1  7  ⋅  ⋅
+        7  2  8  ⋅
+        ⋅  8  3  9
+        ⋅  ⋅  9  4
+
 .. function:: Tridiagonal(dl, d, du)
 
    .. Docstring generated from Julia source
 
    Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
+
+   .. doctest::
+
+       julia> dl = [1; 2; 3]
+       3-element Array{Int64,1}:
+        1
+        2
+        3
+
+       julia> du = [4; 5; 6]
+       3-element Array{Int64,1}:
+        4
+        5
+        6
+
+       julia> d = [7; 8; 9; 0]
+       4-element Array{Int64,1}:
+        7
+        8
+        9
+        0
+
+       julia> Tridiagonal(dl, d, du)
+       4×4 Tridiagonal{Int64}:
+        7  4  ⋅  ⋅
+        1  8  5  ⋅
+        ⋅  2  9  6
+        ⋅  ⋅  3  0
 
 .. function:: Symmetric(A, uplo=:U)
 
@@ -336,6 +427,33 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the Cholesky factorization of a dense symmetric positive definite matrix ``A`` and return a ``Cholesky`` factorization. The matrix ``A`` can either be a ``Symmetric`` or ``Hermitian`` ``StridedMatrix`` or a *perfectly* symmetric or Hermitian ``StridedMatrix``\ . In the latter case, the optional argument ``uplo`` may be ``:L`` for using the lower part or ``:U`` for the upper part of ``A``\ . The default is to use ``:U``\ . The triangular Cholesky factor can be obtained from the factorization ``F`` with: ``F[:L]`` and ``F[:U]``\ . The following functions are available for ``Cholesky`` objects: ``size``\ , ``\``\ , ``inv``\ , ``det``\ . A ``PosDefException`` exception is thrown in case the matrix is not positive definite.
 
+   .. doctest::
+
+       julia> A = [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]
+       3×3 Array{Float64,2}:
+          4.0   12.0  -16.0
+         12.0   37.0  -43.0
+        -16.0  -43.0   98.0
+
+       julia> C = cholfact(A)
+       Base.LinAlg.Cholesky{Float64,Array{Float64,2}} with factor:
+       [2.0 6.0 -8.0; 0.0 1.0 5.0; 0.0 0.0 3.0]
+
+       julia> C[:U]
+       3×3 UpperTriangular{Float64,Array{Float64,2}}:
+        2.0  6.0  -8.0
+         ⋅   1.0   5.0
+         ⋅    ⋅    3.0
+
+       julia> C[:L]
+       3×3 LowerTriangular{Float64,Array{Float64,2}}:
+         2.0   ⋅    ⋅
+         6.0  1.0   ⋅
+        -8.0  5.0  3.0
+
+       julia> C[:L] * C[:U] == A
+       true
+
 .. function:: cholfact(A, [uplo::Symbol,] Val{true}; tol = 0.0) -> CholeskyPivoted
 
    .. Docstring generated from Julia source
@@ -453,6 +571,19 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    Computes the polar decomposition of a vector. Returns ``w``\ , a unit vector in the direction of ``v``\ , and ``r``\ , the norm of ``v``\ .
 
    See also :func:`normalize`\ , :func:`normalize!`\ , and :func:`LinAlg.qr!`\ .
+
+   .. doctest::
+
+       julia> v = [1; 2]
+       2-element Array{Int64,1}:
+        1
+        2
+
+       julia> w, r = qr(v)
+       ([0.447214,0.894427],2.23606797749979)
+
+       julia> w*r == v
+       true
 
 .. function:: LinAlg.qr!(v::AbstractVector) -> w, r
 
@@ -844,11 +975,50 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    ``svd`` is a wrapper around :func:`svdfact(A)`\ , extracting all parts of the ``SVD`` factorization to a tuple. Direct use of ``svdfact`` is therefore more efficient.
 
+   .. doctest::
+
+       julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
+       4×5 Array{Float64,2}:
+        1.0  0.0  0.0  0.0  2.0
+        0.0  0.0  3.0  0.0  0.0
+        0.0  0.0  0.0  0.0  0.0
+        0.0  2.0  0.0  0.0  0.0
+
+       julia> U, S, V = svd(A)
+       (
+       [0.0 1.0 0.0 0.0; 1.0 0.0 0.0 0.0; 0.0 0.0 0.0 -1.0; 0.0 0.0 1.0 0.0],
+       <BLANKLINE>
+       [3.0,2.23607,2.0,0.0],
+       [-0.0 0.447214 -0.0 0.0; 0.0 0.0 1.0 0.0; … ; -0.0 0.0 -0.0 1.0; 0.0 0.894427 0.0 0.0])
+
+       julia> U*diagm(S)*V'
+       4×5 Array{Float64,2}:
+        1.0  0.0  0.0  0.0  2.0
+        0.0  0.0  3.0  0.0  0.0
+        0.0  0.0  0.0  0.0  0.0
+        0.0  2.0  0.0  0.0  0.0
+
 .. function:: svdvals(A)
 
    .. Docstring generated from Julia source
 
    Returns the singular values of ``A``\ .
+
+   .. doctest::
+
+       julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
+       4×5 Array{Float64,2}:
+        1.0  0.0  0.0  0.0  2.0
+        0.0  0.0  3.0  0.0  0.0
+        0.0  0.0  0.0  0.0  0.0
+        0.0  2.0  0.0  0.0  0.0
+
+       julia> svdvals(A)
+       4-element Array{Float64,1}:
+        3.0
+        2.23607
+        2.0
+        0.0
 
 .. function:: svdvals!(A)
 
@@ -1177,6 +1347,34 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
 
+   .. doctest::
+
+       julia> dl = [1; 2; 3]
+       3-element Array{Int64,1}:
+        1
+        2
+        3
+
+       julia> du = [4; 5; 6]
+       3-element Array{Int64,1}:
+        4
+        5
+        6
+
+       julia> d = [7; 8; 9; 0]
+       4-element Array{Int64,1}:
+        7
+        8
+        9
+        0
+
+       julia> Tridiagonal(dl, d, du)
+       4×4 Tridiagonal{Int64}:
+        7  4  ⋅  ⋅
+        1  8  5  ⋅
+        ⋅  2  9  6
+        ⋅  ⋅  3  0
+
 .. function:: rank(M[, tol::Real])
 
    .. Docstring generated from Julia source
@@ -1191,7 +1389,31 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    For vectors, ``p`` can assume any numeric value (even though not all values produce a mathematically valid vector norm). In particular, ``norm(A, Inf)`` returns the largest value in ``abs(A)``\ , whereas ``norm(A, -Inf)`` returns the smallest.
 
+   .. doctest::
+
+       julia> v = [3;-2;6]
+       3-element Array{Int64,1}:
+         3
+        -2
+         6
+
+       julia> norm(v)
+       7.0
+
+       julia> norm(v, Inf)
+       6.0
+
    For matrices, the matrix norm induced by the vector ``p``\ -norm is used, where valid values of ``p`` are ``1``\ , ``2``\ , or ``Inf``\ . (Note that for sparse matrices, ``p=2`` is currently not implemented.) Use :func:`vecnorm` to compute the Frobenius norm.
+
+   .. doctest::
+
+       julia> A = [1 -2 -3; 2 3 -1]
+       2×3 Array{Int64,2}:
+        1  -2  -3
+        2   3  -1
+
+       julia> norm(A, Inf)
+       6.0
 
 .. function:: vecnorm(A, [p::Real=2])
 
@@ -1270,6 +1492,16 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Matrix determinant.
 
+   .. doctest::
+
+       julia> M = [1 0; 2 2]
+       2×2 Array{Int64,2}:
+        1  0
+        2  2
+
+       julia> det(M)
+       2.0
+
 .. function:: logdet(M)
 
    .. Docstring generated from Julia source
@@ -1288,6 +1520,21 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Matrix inverse. Computes matrix ``N`` such that ``M * N = I``\ , where ``I`` is the identity matrix. Computed by solving the left-division ``N = M \ I``\ .
 
+   .. doctest::
+
+       julia> M = [2 5; 1 3]
+       2×2 Array{Int64,2}:
+        2  5
+        1  3
+
+       julia> N = inv(M)
+       2×2 Array{Float64,2}:
+         3.0  -5.0
+        -1.0   2.0
+
+       julia> M*N == N*M == eye(2)
+       true
+
 .. function:: pinv(M[, tol::Real])
 
    .. Docstring generated from Julia source
@@ -1299,6 +1546,23 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    The optimal choice of ``tol`` varies both with the value of ``M`` and the intended application of the pseudoinverse. The default value of ``tol`` is ``eps(real(float(one(eltype(M)))))*maximum(size(A))``\ , which is essentially machine epsilon for the real part of a matrix element multiplied by the larger matrix dimension. For inverting dense ill-conditioned matrices in a least-squares sense, ``tol = sqrt(eps(real(float(one(eltype(M))))))`` is recommended.
 
    For more information, see [issue8859]_, [B96]_, [S84]_, [KY88]_.
+
+   .. doctest::
+
+       julia> M = [1.5 1.3; 1.2 1.9]
+       2×2 Array{Float64,2}:
+        1.5  1.3
+        1.2  1.9
+
+       julia> N = pinv(M)
+       2×2 Array{Float64,2}:
+         1.47287   -1.00775
+        -0.930233   1.16279
+
+       julia> M * N
+       2×2 Array{Float64,2}:
+        1.0          -2.22045e-16
+        4.44089e-16   1.0
 
    .. [issue8859] Issue 8859, "Fix least squares", https://github.com/JuliaLang/julia/pull/8859
 
@@ -1313,6 +1577,20 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Basis for nullspace of ``M``\ .
+
+   .. doctest::
+
+       julia> M = [1 0 0; 0 1 0; 0 0 0]
+       3×3 Array{Int64,2}:
+        1  0  0
+        0  1  0
+        0  0  0
+
+       julia> nullspace(M)
+       3×1 Array{Float64,2}:
+        0.0
+        0.0
+        1.0
 
 .. function:: repmat(A, m::Int, n::Int=1)
 
@@ -1374,6 +1652,25 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Kronecker tensor product of two vectors or two matrices.
+
+   .. doctest::
+
+       julia> A = [1 2; 1 0]
+       2×2 Array{Int64,2}:
+        1  2
+        1  0
+
+       julia> B = [2 0; 0 1]
+       2×2 Array{Int64,2}:
+        2  0
+        0  1
+
+       julia> kron(A, B)
+       4×4 Array{Int64,2}:
+        2  0  4  0
+        0  1  0  2
+        2  0  0  0
+        0  1  0  0
 
 .. function:: blkdiag(A...)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -38,18 +38,11 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. doctest::
 
-       julia> a = [1; 1]
-       2-element Array{Int64,1}:
-        1
-        1
-
-       julia> b = [2; 3]
-       2-element Array{Int64,1}:
-        2
-        3
-
-       julia> dot(a, b)
+       julia> dot([1; 1], [2; 3])
        5
+
+       julia> dot([im; im], [1; 1])
+       0 - 2im
 
 .. function:: vecdot(x, y)
 
@@ -116,19 +109,17 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    If ``factorize`` is called on a Hermitian positive-definite matrix, for instance, then ``factorize`` will return a Cholesky factorization.
 
-   Example:
-
    .. doctest::
 
-       julia> A = Bidiagonal(ones(5, 5), true) #A is really bidiagonal
-       5×5 Bidiagonal{Float64}:
-        1.0  1.0   ⋅    ⋅    ⋅
-         ⋅   1.0  1.0   ⋅    ⋅
-         ⋅    ⋅   1.0  1.0   ⋅
-         ⋅    ⋅    ⋅   1.0  1.0
-         ⋅    ⋅    ⋅    ⋅   1.0
+       julia> A = Array(Bidiagonal(ones(5, 5), true))
+       5×5 Array{Float64,2}:
+        1.0  1.0  0.0  0.0  0.0
+        0.0  1.0  1.0  0.0  0.0
+        0.0  0.0  1.0  1.0  0.0
+        0.0  0.0  0.0  1.0  1.0
+        0.0  0.0  0.0  0.0  1.0
 
-       julia> factorize(A) #factorize will check to see that A is already factorized
+       julia> factorize(A) # factorize will check to see that A is already factorized
        5×5 Bidiagonal{Float64}:
         1.0  1.0   ⋅    ⋅    ⋅
          ⋅   1.0  1.0   ⋅    ⋅
@@ -205,14 +196,14 @@ Linear algebra functions in Julia are largely implemented by calling functions f
         8
         9
 
-        julia> Bu = Bidiagonal(dv, ev, true) #e is on the first superdiagonal
+        julia> Bu = Bidiagonal(dv, ev, true) # ev is on the first superdiagonal
         4×4 Bidiagonal{Int64}:
          1  7  ⋅  ⋅
          ⋅  2  8  ⋅
          ⋅  ⋅  3  9
          ⋅  ⋅  ⋅  4
 
-        julia> Bl = Bidiagonal(dv, ev, false) #e is on the first subdiagonal
+        julia> Bl = Bidiagonal(dv, ev, false) # ev is on the first subdiagonal
         4×4 Bidiagonal{Int64}:
          1  ⋅  ⋅  ⋅
          7  2  ⋅  ⋅
@@ -1773,22 +1764,22 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. doctest::
 
-       julia> A = [1 2; 1 0]
+       julia> A = [1 2; 3 4]
        2×2 Array{Int64,2}:
         1  2
-        1  0
+        3  4
 
-       julia> B = [2 0; 0 1]
+       julia> B = [1 1; 1 1]
        2×2 Array{Int64,2}:
-        2  0
-        0  1
+        1  1
+        1  1
 
        julia> kron(A, B)
        4×4 Array{Int64,2}:
-        2  0  4  0
-        0  1  0  2
-        2  0  0  0
-        0  1  0  0
+        1  1  2  2
+        1  1  2  2
+        3  3  4  4
+        3  3  4  4
 
 .. function:: blkdiag(A...)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -19,6 +19,15 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Matrix multiplication.
 
+   **Example**
+
+   .. doctest::
+
+       julia> [1 1; 0 1] * [1 0; 1 1]
+       2×2 Array{Int64,2}:
+        2  1
+        1  1
+
 .. function:: \\(A, B)
 
    .. Docstring generated from Julia source
@@ -29,12 +38,28 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    When ``A`` is sparse, a similar polyalgorithm is used. For indefinite matrices, the ``LDLt`` factorization does not use pivoting during the numerical factorization and therefore the procedure can fail even for invertible matrices.
 
+   **Example**
+
+   .. doctest::
+
+       julia> A = [1 0; 1 -2]; B = [32; -4];
+
+       julia> X = A \ B
+       2-element Array{Float64,1}:
+        32.0
+        18.0
+
+       julia> A * X == B
+       true
+
 .. function:: dot(x, y)
               ⋅(x,y)
 
    .. Docstring generated from Julia source
 
    Compute the dot product. For complex vectors, the first vector is conjugated.
+
+   **Example**
 
    .. doctest::
 
@@ -56,6 +81,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Compute the cross product of two 3-vectors.
+
+   **Example**
 
    .. doctest::
 
@@ -109,6 +136,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    If ``factorize`` is called on a Hermitian positive-definite matrix, for instance, then ``factorize`` will return a Cholesky factorization.
 
+   **Example**
+
    .. doctest::
 
        julia> A = Array(Bidiagonal(ones(5, 5), true))
@@ -141,6 +170,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Constructs a matrix from the diagonal of ``A``\ .
 
+   **Example**
+
    .. doctest::
 
        julia> A = [1 2 3; 4 5 6; 7 8 9]
@@ -160,6 +191,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Constructs a matrix with ``V`` as its diagonal.
+
+   **Example**
 
    .. doctest::
 
@@ -284,6 +317,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal, respectively. The result is of type ``SymTridiagonal`` and provides efficient specialized eigensolvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short).
 
+   **Example**
+
    .. doctest::
 
        julia> dv = [1; 2; 3; 4]
@@ -311,6 +346,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
+
+   **Example**
 
    .. doctest::
 
@@ -389,32 +426,26 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. doctest::
 
-       julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]
-       5×5 Array{Int64,2}:
-        1  0  2  0  3
-        0  4  0  5  0
-        6  0  7  0  8
-        0  9  0  1  0
-        2  0  3  0  4
+       julia> A = [1 0 2+2im 0 3-3im; 0 4 0 5 0; 6-6im 0 7 0 8+8im; 0 9 0 1 0; 2+2im 0 3-3im 0 4];
 
        julia> Hupper = Hermitian(A)
-       5×5 Hermitian{Int64,Array{Int64,2}}:
-        1  0  2  0  3
-        0  4  0  5  0
-        2  0  7  0  8
-        0  5  0  1  0
-        3  0  8  0  4
+       5×5 Hermitian{Complex{Int64},Array{Complex{Int64},2}}:
+        1+0im  0+0im  2+2im  0+0im  3-3im
+        0+0im  4+0im  0+0im  5+0im  0+0im
+        2-2im  0+0im  7+0im  0+0im  8+8im
+        0+0im  5+0im  0+0im  1+0im  0+0im
+        3+3im  0+0im  8-8im  0+0im  4+0im
 
        julia> Hlower = Hermitian(A, :L)
-       5×5 Hermitian{Int64,Array{Int64,2}}:
-        1  0  6  0  2
-        0  4  0  9  0
-        6  0  7  0  3
-        0  9  0  1  0
-        2  0  3  0  4
+       5×5 Hermitian{Complex{Int64},Array{Complex{Int64},2}}:
+        1+0im  0+0im  6+6im  0+0im  2-2im
+        0+0im  4+0im  0+0im  9+0im  0+0im
+        6-6im  0+0im  7+0im  0+0im  3+3im
+        0+0im  9+0im  0+0im  1+0im  0+0im
+        2+2im  0+0im  3-3im  0+0im  4+0im
 
        julia> eigfact(Hupper)
-       Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([-2.96684,-2.72015,0.440875,7.72015,14.526],[-0.302016 -2.22045e-16 … 1.11022e-16 0.248524; -6.67755e-16 0.596931 … -0.802293 1.93069e-17; … ; 8.88178e-16 -0.802293 … -0.596931 0.0; 0.772108 8.93933e-16 … 0.0 0.630015])
+       Base.LinAlg.Eigen{Complex{Float64},Float64,Array{Complex{Float64},2},Array{Float64,1}}([-8.32069,-2.72015,3.1496,7.72015,17.1711],Complex{Float64}[-0.231509+0.392692im -4.16334e-17+5.55112e-17im … -2.77556e-17-1.11022e-16im -0.129023-0.00628656im; 0.0+0.0im -0.532524+0.269711im … -0.521035+0.610079im 0.0+0.0im; … ; 0.0-1.38778e-17im 0.715729-0.362501im … -0.387666+0.453917im 0.0-6.93889e-18im; 0.67898-0.0im 0.0+0.0im … 0.0+0.0im -0.661651-0.0im])
 
    ``eigfact`` will use a method specialized for matrices known to be Hermitian. Note that ``Hupper`` will not be equal to ``Hlower`` unless ``A`` is itself Hermitian (e.g. if ``A == A'``\ ).
 
@@ -425,6 +456,26 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    Compute the LU factorization of ``A``\ , such that ``A[p,:] = L*U``\ . By default, pivoting is used. This can be overridden by passing ``Val{false}`` for the second argument.
 
    See also :func:`lufact`\ .
+
+   **Example**
+
+   .. doctest::
+
+       julia> A = [4. 3.; 6. 3.]
+       2×2 Array{Float64,2}:
+        4.0  3.0
+        6.0  3.0
+
+       julia> L, U, p = lu(A)
+       (
+       [1.0 0.0; 0.666667 1.0],
+       <BLANKLINE>
+       [6.0 3.0; 0.0 1.0],
+       <BLANKLINE>
+       [2,1])
+
+       julia> A[p, :] == L * U
+       true
 
 .. function:: lufact(A [,pivot=Val{true}]) -> F::LU
 
@@ -471,6 +522,21 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    +--------------------+--------+--------------------------+
    | :func:`size`       | ✓      | ✓                        |
    +--------------------+--------+--------------------------+
+
+   **Example**
+
+   .. doctest::
+
+       julia> A = [4 3; 6 3]
+       2×2 Array{Int64,2}:
+        4  3
+        6  3
+
+       julia> F = lufact(A)
+       Base.LinAlg.LU{Float64,Array{Float64,2}}([4.0 3.0; 1.5 -1.5],[1,2],0)
+
+       julia> F[:L] * F[:U] == A[F[:p], :]
+       true
 
 .. function:: lufact(A::SparseMatrixCSC) -> F::UmfpackLU
 
@@ -524,17 +590,45 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the Cholesky factorization of a positive definite matrix ``A`` and return the UpperTriangular matrix ``U`` such that ``A = U'U``\ .
 
+   **Example**
+
+   .. doctest::
+
+       julia> A = [1. 2.; 2. 50.]
+       2×2 Array{Float64,2}:
+        1.0   2.0
+        2.0  50.0
+
+       julia> U = chol(A)
+       2×2 UpperTriangular{Float64,Array{Float64,2}}:
+        1.0  2.0
+         ⋅   6.78233
+
+       julia> U'U
+       2×2 Array{Float64,2}:
+        1.0   2.0
+        2.0  50.0
+
 .. function:: chol(x::Number) -> y
 
    .. Docstring generated from Julia source
 
    Compute the square root of a non-negative number ``x``\ .
 
+   **Example**
+
+   .. doctest::
+
+       julia> chol(16)
+       4.0
+
 .. function:: cholfact(A, [uplo::Symbol,] Val{false}) -> Cholesky
 
    .. Docstring generated from Julia source
 
    Compute the Cholesky factorization of a dense symmetric positive definite matrix ``A`` and return a ``Cholesky`` factorization. The matrix ``A`` can either be a ``Symmetric`` or ``Hermitian`` ``StridedMatrix`` or a *perfectly* symmetric or Hermitian ``StridedMatrix``\ . In the latter case, the optional argument ``uplo`` may be ``:L`` for using the lower part or ``:U`` for the upper part of ``A``\ . The default is to use ``:U``\ . The triangular Cholesky factor can be obtained from the factorization ``F`` with: ``F[:L]`` and ``F[:U]``\ . The following functions are available for ``Cholesky`` objects: ``size``\ , ``\``\ , ``inv``\ , ``det``\ . A ``PosDefException`` exception is thrown in case the matrix is not positive definite.
+
+   **Example**
 
    .. doctest::
 
@@ -600,6 +694,19 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    The same as ``cholfact``\ , but saves space by overwriting the input ``A``\ , instead of creating a copy. An ``InexactError`` exception is thrown if the factorisation produces a number not representable by the element type of ``A``\ , e.g. for integer types.
+
+   **Example**
+
+   .. doctest::
+
+       julia> A = [1 2; 2 50]
+       2×2 Array{Int64,2}:
+        1   2
+        2  50
+
+        julia> cholfact!(A)
+        ERROR: InexactError()
+         ...
 
 .. function:: cholfact!(A, [uplo::Symbol,] Val{true}; tol = 0.0) -> CholeskyPivoted
 
@@ -680,6 +787,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    Computes the polar decomposition of a vector. Returns ``w``\ , a unit vector in the direction of ``v``\ , and ``r``\ , the norm of ``v``\ .
 
    See also :func:`normalize`\ , :func:`normalize!`\ , and :func:`LinAlg.qr!`\ .
+
+   **Example**
 
    .. doctest::
 
@@ -826,6 +935,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Computes eigenvalues (``D``\ ) and eigenvectors (``V``\ ) of ``A``\ . See :func:`eigfact` for details on the ``irange``\ , ``vl``\ , and ``vu`` arguments and the ``permute`` and ``scale`` keyword arguments. The eigenvectors are returned columnwise.
 
+   **Example**
+
    .. doctest::
 
        julia> eig([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
@@ -841,6 +952,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    Computes generalized eigenvalues (``D``\ ) and vectors (``V``\ ) of ``A`` with respect to ``B``\ .
 
    ``eig`` is a wrapper around :func:`eigfact`\ , extracting all parts of the factorization to a tuple; where possible, using :func:`eigfact` is recommended.
+
+   **Example**
 
    .. doctest::
 
@@ -878,6 +991,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Returns the largest eigenvalue of ``A``\ . The option ``permute=true`` permutes the matrix to become closer to upper triangular, and ``scale=true`` scales the matrix by its diagonal elements to make rows and columns more equal in norm. Note that if the eigenvalues of ``A`` are complex, this method will fail, since complex numbers cannot be sorted.
 
+   **Example**
+
    .. doctest::
 
        julia> A = [0 im; -im 0]
@@ -895,8 +1010,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
        julia> eigmax(A)
        ERROR: DomainError:
-        in #eigmax#30(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:186
-        in eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:184
+        in #eigmax#30(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:219
+        in eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:217
         ...
 
 .. function:: eigmin(A; permute::Bool=true, scale::Bool=true)
@@ -904,6 +1019,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Returns the smallest eigenvalue of ``A``\ . The option ``permute=true`` permutes the matrix to become closer to upper triangular, and ``scale=true`` scales the matrix by its diagonal elements to make rows and columns more equal in norm. Note that if the eigenvalues of ``A`` are complex, this method will fail, since complex numbers cannot be sorted.
+
+   **Example**
 
    .. doctest::
 
@@ -922,8 +1039,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
        julia> eigmin(A)
        ERROR: DomainError:
-        in #eigmin#31(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:226
-        in eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:224
+        in #eigmin#31(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:261
+        in eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:259
         ...
 
 .. function:: eigvecs(A, [eigvals,][permute=true,][scale=true]) -> Matrix
@@ -933,6 +1050,16 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    Returns a matrix ``M`` whose columns are the eigenvectors of ``A``\ . (The ``k``\ th eigenvector can be obtained from the slice ``M[:, k]``\ .) The ``permute`` and ``scale`` keywords are the same as for :func:`eigfact`\ .
 
    For :class:`SymTridiagonal` matrices, if the optional vector of eigenvalues ``eigvals`` is specified, returns the specific corresponding eigenvectors.
+
+   **Example**
+
+   .. doctest::
+
+       julia> eigvecs([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
+       3×3 Array{Float64,2}:
+        1.0  0.0  0.0
+        0.0  1.0  0.0
+        0.0  0.0  1.0
 
 .. function:: eigfact(A,[irange,][vl,][vu,][permute=true,][scale=true]) -> Eigen
 
@@ -945,6 +1072,25 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    If ``A`` is :class:`Symmetric`\ , :class:`Hermitian` or :class:`SymTridiagonal`\ , it is possible to calculate only a subset of the eigenvalues by specifying either a :class:`UnitRange` ``irange`` covering indices of the sorted eigenvalues or a pair ``vl`` and ``vu`` for the lower and upper boundaries of the eigenvalues.
 
    For general nonsymmetric matrices it is possible to specify how the matrix is balanced before the eigenvector calculation. The option ``permute=true`` permutes the matrix to become closer to upper triangular, and ``scale=true`` scales the matrix by its diagonal elements to make rows and columns more equal in norm. The default is ``true`` for both options.
+
+   **Example**
+
+   .. doctest::
+
+       julia> F = eigfact([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
+       Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([1.0,3.0,18.0],[1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+
+       julia> F[:values]
+       3-element Array{Float64,1}:
+         1.0
+         3.0
+        18.0
+
+       julia> F[:vectors]
+       3×3 Array{Float64,2}:
+        1.0  0.0  0.0
+        0.0  1.0  0.0
+        0.0  0.0  1.0
 
 .. function:: eigfact(A, B) -> GeneralizedEigen
 
@@ -976,6 +1122,25 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Computes the Schur factorization of the matrix ``A``\ . The (quasi) triangular Schur factor can be obtained from the ``Schur`` object ``F`` with either ``F[:Schur]`` or ``F[:T]`` and the orthogonal/unitary Schur vectors can be obtained with ``F[:vectors]`` or ``F[:Z]`` such that ``A = F[:vectors]*F[:Schur]*F[:vectors]'``\ . The eigenvalues of ``A`` can be obtained with ``F[:values]``\ .
 
+   **Example**
+
+   .. doctest::
+
+       julia> A = [-2. 1. 3.; 2. 1. -1.; -7. 2. 7.]
+       3×3 Array{Float64,2}:
+        -2.0  1.0   3.0
+         2.0  1.0  -1.0
+        -7.0  2.0   7.0
+
+       julia> F = schurfact(A)
+       Base.LinAlg.Schur{Float64,Array{Float64,2}}([2.0 0.801792 6.63509; -8.55988e-11 2.0 8.08286; 0.0 0.0 1.99999],[0.577351 0.154299 -0.801784; 0.577346 -0.77152 0.267262; 0.577354 0.617211 0.534522],Complex{Float64}[2.0+8.28447e-6im,2.0-8.28447e-6im,1.99999+0.0im])
+
+       julia> F[:vectors] * F[:Schur] * F[:vectors]'
+       3×3 Array{Float64,2}:
+        -2.0  1.0   3.0
+         2.0  1.0  -1.0
+        -7.0  2.0   7.0
+
 .. function:: schurfact!(A::StridedMatrix) -> F::Schur
 
    .. Docstring generated from Julia source
@@ -989,6 +1154,30 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    Computes the Schur factorization of the matrix ``A``\ . The methods return the (quasi) triangular Schur factor ``T`` and the orthogonal/unitary Schur vectors ``Z`` such that ``A = Z*T*Z'``\ . The eigenvalues of ``A`` are returned in the vector ``λ``\ .
 
    See ``schurfact``\ .
+
+   **Example**
+
+   .. doctest::
+
+       julia> A = [-2. 1. 3.; 2. 1. -1.; -7. 2. 7.]
+       3×3 Array{Float64,2}:
+        -2.0  1.0   3.0
+         2.0  1.0  -1.0
+        -7.0  2.0   7.0
+
+       julia> T, Z, lambda = schur(A)
+       (
+       [2.0 0.801792 6.63509; -8.55988e-11 2.0 8.08286; 0.0 0.0 1.99999],
+       <BLANKLINE>
+       [0.577351 0.154299 -0.801784; 0.577346 -0.77152 0.267262; 0.577354 0.617211 0.534522],
+       <BLANKLINE>
+       Complex{Float64}[2.0+8.28447e-6im,2.0-8.28447e-6im,1.99999+0.0im])
+
+       julia> Z * T * Z'
+       3×3 Array{Float64,2}:
+        -2.0  1.0   3.0
+         2.0  1.0  -1.0
+        -7.0  2.0   7.0
 
 .. function:: ordschur(F::Schur, select::Union{Vector{Bool},BitVector}) -> F::Schur
 
@@ -1066,6 +1255,27 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    If ``thin=true`` (default), a thin SVD is returned. For a :math:`M \times N` matrix ``A``\ , ``U`` is :math:`M \times M` for a full SVD (``thin=false``\ ) and :math:`M \times \min(M, N)` for a thin SVD.
 
+   **Example**
+
+   .. doctest::
+
+       julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
+       4×5 Array{Float64,2}:
+        1.0  0.0  0.0  0.0  2.0
+        0.0  0.0  3.0  0.0  0.0
+        0.0  0.0  0.0  0.0  0.0
+        0.0  2.0  0.0  0.0  0.0
+
+       julia> F = svdfact(A)
+       Base.LinAlg.SVD{Float64,Float64,Array{Float64,2}}([0.0 1.0 0.0 0.0; 1.0 0.0 0.0 0.0; 0.0 0.0 0.0 -1.0; 0.0 0.0 1.0 0.0],[3.0,2.23607,2.0,0.0],[-0.0 0.0 … -0.0 0.0; 0.447214 0.0 … 0.0 0.894427; -0.0 1.0 … -0.0 0.0; 0.0 0.0 … 1.0 0.0])
+
+       julia> F[:U] * diagm(F[:S]) * F[:Vt]
+       4×5 Array{Float64,2}:
+        1.0  0.0  0.0  0.0  2.0
+        0.0  0.0  3.0  0.0  0.0
+        0.0  0.0  0.0  0.0  0.0
+        0.0  2.0  0.0  0.0  0.0
+
 .. function:: svdfact!(A, [thin=true]) -> SVD
 
    .. Docstring generated from Julia source
@@ -1083,6 +1293,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    If ``thin=true`` (default), a thin SVD is returned. For a :math:`M \times N` matrix ``A``\ , ``U`` is :math:`M \times M` for a full SVD (``thin=false``\ ) and :math:`M \times \min(M, N)` for a thin SVD.
 
    ``svd`` is a wrapper around :func:`svdfact(A)`\ , extracting all parts of the ``SVD`` factorization to a tuple. Direct use of ``svdfact`` is therefore more efficient.
+
+   **Example**
 
    .. doctest::
 
@@ -1112,6 +1324,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Returns the singular values of ``A``\ .
+
+   **Example**
 
    .. doctest::
 
@@ -1244,6 +1458,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Upper triangle of a matrix.
 
+   **Example**
+
    .. doctest::
 
        julia> a = ones(4,4)
@@ -1265,6 +1481,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Returns the upper triangle of ``M`` starting from the ``k``\ th superdiagonal.
+
+   **Example**
 
    .. doctest::
 
@@ -1301,11 +1519,33 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Returns the upper triangle of ``M`` starting from the ``k``\ th superdiagonal, overwriting ``M`` in the process.
 
+   **Example**
+
+   .. doctest::
+
+       julia> M = [1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5]
+       5×5 Array{Int64,2}:
+        1  2  3  4  5
+        1  2  3  4  5
+        1  2  3  4  5
+        1  2  3  4  5
+        1  2  3  4  5
+
+       julia> triu!(M, 1)
+       5×5 Array{Int64,2}:
+        0  2  3  4  5
+        0  0  3  4  5
+        0  0  0  4  5
+        0  0  0  0  5
+        0  0  0  0  0
+
 .. function:: tril(M)
 
    .. Docstring generated from Julia source
 
    Lower triangle of a matrix.
+
+   **Example**
 
    .. doctest::
 
@@ -1328,6 +1568,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Returns the lower triangle of ``M`` starting from the ``k``\ th superdiagonal.
+
+   **Example**
 
    .. doctest::
 
@@ -1364,11 +1606,33 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Returns the lower triangle of ``M`` starting from the ``k``\ th superdiagonal, overwriting ``M`` in the process.
 
+   **Example**
+
+   .. doctest::
+
+       julia> M = [1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5; 1 2 3 4 5]
+       5×5 Array{Int64,2}:
+        1  2  3  4  5
+        1  2  3  4  5
+        1  2  3  4  5
+        1  2  3  4  5
+        1  2  3  4  5
+
+       julia> tril!(M, 2)
+       5×5 Array{Int64,2}:
+        1  2  3  0  0
+        1  2  3  4  0
+        1  2  3  4  5
+        1  2  3  4  5
+        1  2  3  4  5
+
 .. function:: diagind(M, k::Integer=0)
 
    .. Docstring generated from Julia source
 
    A :class:`Range` giving the indices of the ``k``\ th diagonal of the matrix ``M``\ .
+
+   **Example**
 
    .. doctest::
 
@@ -1386,6 +1650,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    The ``k``\ th diagonal of a matrix, as a vector. Use :func:`diagm` to construct a diagonal matrix.
+
+   **Example**
 
    .. doctest::
 
@@ -1406,6 +1672,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Construct a matrix by placing ``v`` on the ``k``\ th diagonal.
 
+   **Example**
+
    .. doctest::
 
        julia> diagm([1,2,3],1)
@@ -1423,6 +1691,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    Scale an array ``A`` by a scalar ``b`` overwriting ``A`` in-place.
 
    If ``A`` is a matrix and ``b`` is a vector, then ``scale!(A,b)`` scales each column ``i`` of ``A`` by ``b[i]`` (similar to ``A*Diagonal(b)``\ ), while ``scale!(b,A)`` scales each row ``i`` of ``A`` by ``b[i]`` (similar to ``Diagonal(b)*A``\ ), again operating in-place on ``A``\ . An ``InexactError`` exception is thrown if the scaling produces a number not representable by the element type of ``A``\ , e.g. for integer types.
+
+   **Example**
 
    .. doctest::
 
@@ -1455,6 +1725,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
+
+   **Example**
 
    .. doctest::
 
@@ -1498,6 +1770,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    For vectors, ``p`` can assume any numeric value (even though not all values produce a mathematically valid vector norm). In particular, ``norm(A, Inf)`` returns the largest value in ``abs(A)``\ , whereas ``norm(A, -Inf)`` returns the smallest.
 
+   **Example**
+
    .. doctest::
 
        julia> v = [3;-2;6]
@@ -1513,6 +1787,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
        6.0
 
    For matrices, the matrix norm induced by the vector ``p``\ -norm is used, where valid values of ``p`` are ``1``\ , ``2``\ , or ``Inf``\ . (Note that for sparse matrices, ``p=2`` is currently not implemented.) Use :func:`vecnorm` to compute the Frobenius norm.
+
+   **Example**
 
    .. doctest::
 
@@ -1543,6 +1819,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Normalize the vector ``v`` with respect to the ``p``\ -norm. See also :func:`normalize!` and :func:`vecnorm`\ .
+
+   **Example**
 
    .. doctest::
 
@@ -1585,6 +1863,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Matrix trace. Sums the diagonal elements of ``M``\ .
 
+   **Example**
+
    .. doctest::
 
        julia> A = [1 2; 3 4]
@@ -1600,6 +1880,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Matrix determinant.
+
+   **Example**
 
    .. doctest::
 
@@ -1629,6 +1911,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Matrix inverse. Computes matrix ``N`` such that ``M * N = I``\ , where ``I`` is the identity matrix. Computed by solving the left-division ``N = M \ I``\ .
 
+   **Example**
+
    .. doctest::
 
        julia> M = [2 5; 1 3]
@@ -1655,6 +1939,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    The optimal choice of ``tol`` varies both with the value of ``M`` and the intended application of the pseudoinverse. The default value of ``tol`` is ``eps(real(float(one(eltype(M)))))*maximum(size(A))``\ , which is essentially machine epsilon for the real part of a matrix element multiplied by the larger matrix dimension. For inverting dense ill-conditioned matrices in a least-squares sense, ``tol = sqrt(eps(real(float(one(eltype(M))))))`` is recommended.
 
    For more information, see [issue8859]_, [B96]_, [S84]_, [KY88]_.
+
+   **Example**
 
    .. doctest::
 
@@ -1686,6 +1972,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Basis for nullspace of ``M``\ .
+
+   **Example**
 
    .. doctest::
 
@@ -1762,6 +2050,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Kronecker tensor product of two vectors or two matrices.
 
+   **Example**
+
    .. doctest::
 
        julia> A = [1 2; 3 4]
@@ -1769,17 +2059,17 @@ Linear algebra functions in Julia are largely implemented by calling functions f
         1  2
         3  4
 
-       julia> B = [1 1; 1 1]
-       2×2 Array{Int64,2}:
-        1  1
-        1  1
+       julia> B = [im 1; 1 -im]
+       2×2 Array{Complex{Int64},2}:
+        0+1im  1+0im
+        1+0im  0-1im
 
        julia> kron(A, B)
-       4×4 Array{Int64,2}:
-        1  1  2  2
-        1  1  2  2
-        3  3  4  4
-        3  3  4  4
+       4×4 Array{Complex{Int64},2}:
+        0+1im  1+0im  0+2im  2+0im
+        1+0im  0-1im  2+0im  0-2im
+        0+3im  3+0im  0+4im  4+0im
+        3+0im  0-3im  4+0im  0-4im
 
 .. function:: blkdiag(A...)
 
@@ -1822,6 +2112,20 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. [H05] Nicholas J. Higham, "The squaring and scaling method for the matrix exponential revisited", SIAM Journal on Matrix Analysis and Applications, 26(4), 2005, 1179-1193. `doi:10.1137/090768539 <http://dx.doi.org/10.1137/090768539>`_
 
+   **Example**
+
+   .. doctest::
+
+       julia> A = eye(2, 2)
+       2×2 Array{Float64,2}:
+        1.0  0.0
+        0.0  1.0
+
+       julia> expm(A)
+       2×2 Array{Float64,2}:
+        2.71828  0.0
+        0.0      2.71828
+
 .. function:: logm(A::StridedMatrix)
 
    .. Docstring generated from Julia source
@@ -1862,6 +2166,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Test whether a matrix is symmetric.
 
+   **Example**
+
    .. doctest::
 
        julia> a = [1 2; 2 -1]
@@ -1886,6 +2192,18 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Test whether a matrix is positive definite.
 
+   **Example**
+
+   .. doctest::
+
+       julia> A = [1 2; 2 50]
+       2×2 Array{Int64,2}:
+        1   2
+        2  50
+
+       julia> isposdef(A)
+       true
+
 .. function:: isposdef!(A) -> Bool
 
    .. Docstring generated from Julia source
@@ -1897,6 +2215,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Test whether a matrix is lower triangular.
+
+   **Example**
 
    .. doctest::
 
@@ -1922,6 +2242,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Test whether a matrix is upper triangular.
 
+   **Example**
+
    .. doctest::
 
        julia> a = [1 2; 2 -1]
@@ -1946,6 +2268,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Test whether a matrix is diagonal.
 
+   **Example**
+
    .. doctest::
 
        julia> a = [1 2; 2 -1]
@@ -1969,6 +2293,8 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    .. Docstring generated from Julia source
 
    Test whether a matrix is Hermitian.
+
+   **Example**
 
    .. doctest::
 
@@ -2211,6 +2537,8 @@ according to the usual Julia convention.
    .. Docstring generated from Julia source
 
    Calculates the matrix-matrix or matrix-vector product :math:`A⋅B` and stores the result in ``Y``\ , overwriting the existing value of ``Y``\ . Note that ``Y`` must not be aliased with either ``A`` or ``B``\ .
+
+   **Example**
 
    .. doctest::
 
@@ -2614,6 +2942,18 @@ for ``Float64``, ``Float32``, ``Complex128``, and ``Complex64`` arrays.
    .. Docstring generated from Julia source
 
    An object of type ``UniformScaling``\ , representing an identity matrix of any size.
+
+   **Example**
+
+   .. doctest::
+
+       julia> ones(5, 6) * I == ones(5, 6)
+       true
+
+       julia> [1 2im 3; 1im 2 3] * I
+       2×3 Array{Complex{Int64},2}:
+        1+0im  0+2im  3+0im
+        0+1im  2+0im  3+0im
 
 LAPACK Functions
 ----------------

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -118,10 +118,23 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Example:
 
-   .. code-block:: julia
+   .. doctest::
 
-       A = diagm(rand(5)) + diagm(rand(4),1); #A is really bidiagonal
-       factorize(A) #factorize will check to see that A is already factorized
+       julia> A = Bidiagonal(ones(5, 5), true) #A is really bidiagonal
+       5×5 Bidiagonal{Float64}:
+        1.0  1.0   ⋅    ⋅    ⋅
+         ⋅   1.0  1.0   ⋅    ⋅
+         ⋅    ⋅   1.0  1.0   ⋅
+         ⋅    ⋅    ⋅   1.0  1.0
+         ⋅    ⋅    ⋅    ⋅   1.0
+
+       julia> factorize(A) #factorize will check to see that A is already factorized
+       5×5 Bidiagonal{Float64}:
+        1.0  1.0   ⋅    ⋅    ⋅
+         ⋅   1.0  1.0   ⋅    ⋅
+         ⋅    ⋅   1.0  1.0   ⋅
+         ⋅    ⋅    ⋅   1.0  1.0
+         ⋅    ⋅    ⋅    ⋅   1.0
 
    This returns a ``5×5 Bidiagonal{Float64}``\ , which can now be passed to other linear algebra functions (e.g. eigensolvers) which will use specialized methods for ``Bidiagonal`` types.
 
@@ -177,12 +190,34 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    **Example**
 
-   .. code-block:: julia
+   .. doctest::
 
-       dv = rand(5)
-       ev = rand(4)
-       Bu = Bidiagonal(dv, ev, true) #e is on the first superdiagonal
-       Bl = Bidiagonal(dv, ev, false) #e is on the first subdiagonal
+       julia> dv = [1; 2; 3; 4]
+       4-element Array{Int64,1}:
+        1
+        2
+        3
+        4
+
+       julia> ev = [7; 8; 9]
+       3-element Array{Int64,1}:
+        7
+        8
+        9
+
+        julia> Bu = Bidiagonal(dv, ev, true) #e is on the first superdiagonal
+        4×4 Bidiagonal{Int64}:
+         1  7  ⋅  ⋅
+         ⋅  2  8  ⋅
+         ⋅  ⋅  3  9
+         ⋅  ⋅  ⋅  4
+
+        julia> Bl = Bidiagonal(dv, ev, false) #e is on the first subdiagonal
+        4×4 Bidiagonal{Int64}:
+         1  ⋅  ⋅  ⋅
+         7  2  ⋅  ⋅
+         ⋅  8  3  ⋅
+         ⋅  ⋅  9  4
 
 .. function:: Bidiagonal(dv, ev, uplo::Char)
 
@@ -192,12 +227,34 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    **Example**
 
-   .. code-block:: julia
+   .. doctest::
 
-       dv = rand(5)
-       ev = rand(4)
-       Bu = Bidiagonal(dv, ev, 'U') #e is on the first superdiagonal
-       Bl = Bidiagonal(dv, ev, 'L') #e is on the first subdiagonal
+       julia> dv = [1; 2; 3; 4]
+       4-element Array{Int64,1}:
+        1
+        2
+        3
+        4
+
+       julia> ev = [7; 8; 9]
+       3-element Array{Int64,1}:
+        7
+        8
+        9
+
+       julia> Bu = Bidiagonal(dv, ev, 'U') #e is on the first superdiagonal
+       4×4 Bidiagonal{Int64}:
+        1  7  ⋅  ⋅
+        ⋅  2  8  ⋅
+        ⋅  ⋅  3  9
+        ⋅  ⋅  ⋅  4
+
+       julia> Bl = Bidiagonal(dv, ev, 'L') #e is on the first subdiagonal
+       4×4 Bidiagonal{Int64}:
+        1  ⋅  ⋅  ⋅
+        7  2  ⋅  ⋅
+        ⋅  8  3  ⋅
+        ⋅  ⋅  9  4
 
 .. function:: Bidiagonal(A, isupper::Bool)
 
@@ -207,11 +264,28 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    **Example**
 
-   .. code-block:: julia
+   .. doctest::
 
-       A = rand(5,5)
-       Bu = Bidiagonal(A, true) #contains the main diagonal and first superdiagonal of A
-       Bl = Bidiagonal(A, false) #contains the main diagonal and first subdiagonal of A
+       julia> A = [1 1 1 1; 2 2 2 2; 3 3 3 3; 4 4 4 4]
+       4×4 Array{Int64,2}:
+        1  1  1  1
+        2  2  2  2
+        3  3  3  3
+        4  4  4  4
+
+       julia> Bidiagonal(A, true) #contains the main diagonal and first superdiagonal of A
+       4×4 Bidiagonal{Int64}:
+        1  1  ⋅  ⋅
+        ⋅  2  2  ⋅
+        ⋅  ⋅  3  3
+        ⋅  ⋅  ⋅  4
+
+       julia> Bidiagonal(A, false) #contains the main diagonal and first subdiagonal of A
+       4×4 Bidiagonal{Int64}:
+        1  ⋅  ⋅  ⋅
+        2  2  ⋅  ⋅
+        ⋅  3  3  ⋅
+        ⋅  ⋅  4  4
 
 .. function:: SymTridiagonal(dv, ev)
 
@@ -283,12 +357,34 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    **Example**
 
-   .. code-block:: julia
+   .. doctest::
 
-       A = randn(10,10)
-       Supper = Symmetric(A)
-       Slower = Symmetric(A,:L)
-       eigfact(Supper)
+       julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]
+       5×5 Array{Int64,2}:
+        1  0  2  0  3
+        0  4  0  5  0
+        6  0  7  0  8
+        0  9  0  1  0
+        2  0  3  0  4
+
+       julia> Supper = Symmetric(A)
+       5×5 Symmetric{Int64,Array{Int64,2}}:
+        1  0  2  0  3
+        0  4  0  5  0
+        2  0  7  0  8
+        0  5  0  1  0
+        3  0  8  0  4
+
+       julia> Slower = Symmetric(A, :L)
+       5×5 Symmetric{Int64,Array{Int64,2}}:
+        1  0  6  0  2
+        0  4  0  9  0
+        6  0  7  0  3
+        0  9  0  1  0
+        2  0  3  0  4
+
+       julia> eigfact(Supper)
+       Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([-2.96684,-2.72015,0.440875,7.72015,14.526],[-0.302016 -2.22045e-16 … 1.11022e-16 0.248524; -6.67755e-16 0.596931 … -0.802293 1.93069e-17; … ; 8.88178e-16 -0.802293 … -0.596931 0.0; 0.772108 8.93933e-16 … 0.0 0.630015])
 
    ``eigfact`` will use a method specialized for matrices known to be symmetric. Note that ``Supper`` will not be equal to ``Slower`` unless ``A`` is itself symmetric (e.g. if ``A == A.'``\ ).
 
@@ -300,12 +396,34 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    **Example**
 
-   .. code-block:: julia
+   .. doctest::
 
-       A = randn(10,10)
-       Hupper = Hermitian(A)
-       Hlower = Hermitian(A,:L)
-       eigfact(Hupper)
+       julia> A = [1 0 2 0 3; 0 4 0 5 0; 6 0 7 0 8; 0 9 0 1 0; 2 0 3 0 4]
+       5×5 Array{Int64,2}:
+        1  0  2  0  3
+        0  4  0  5  0
+        6  0  7  0  8
+        0  9  0  1  0
+        2  0  3  0  4
+
+       julia> Hupper = Hermitian(A)
+       5×5 Hermitian{Int64,Array{Int64,2}}:
+        1  0  2  0  3
+        0  4  0  5  0
+        2  0  7  0  8
+        0  5  0  1  0
+        3  0  8  0  4
+
+       julia> Hlower = Hermitian(A, :L)
+       5×5 Hermitian{Int64,Array{Int64,2}}:
+        1  0  6  0  2
+        0  4  0  9  0
+        6  0  7  0  3
+        0  9  0  1  0
+        2  0  3  0  4
+
+       julia> eigfact(Hupper)
+       Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([-2.96684,-2.72015,0.440875,7.72015,14.526],[-0.302016 -2.22045e-16 … 1.11022e-16 0.248524; -6.67755e-16 0.596931 … -0.802293 1.93069e-17; … ; 8.88178e-16 -0.802293 … -0.596931 0.0; 0.772108 8.93933e-16 … 0.0 0.630015])
 
    ``eigfact`` will use a method specialized for matrices known to be Hermitian. Note that ``Hupper`` will not be equal to ``Hlower`` unless ``A`` is itself Hermitian (e.g. if ``A == A'``\ ).
 


### PR DESCRIPTION
Issue JuliaLang/LinearAlgebra.jl#371 
### Added Doctests
- `cholfact(A)`
- `kron(A, B)`
- `pinv(M)`
- `nullspace(M)`
- `Diagonal(A::AbstractMatrix), Diagonal(V::AbstractVector)`
- `norm(v), norm(v, Inf), norm(A, Inf)`
- `dot(a, b)`
- `inv(M)`
- `qr(v)`
- `svd(A), svdvals(A)`
- `SymTridiagonal(dv, ev), Tridiagonal(dl, d, du)`, `Tridiagonal(A)`
### Rewritten examples
- `Bidiagonal()`
- `Symmetric()`
- `Hermitian()`

I have rewritten these existing examples to be easier to understand without having to run the code.

`make docs && make -C doc doctest` runs fine, no failures for `stdlib/linalg`. The failures it shows are identical to the ones on the master branch.

First PR, so please let me know if I did something wrong :)
