### PR TITLE
added isapprox method for UniformScaling and tests

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -33,8 +33,6 @@ istriu(::UniformScaling) = true
 istril(::UniformScaling) = true
 issymmetric(::UniformScaling) = true
 ishermitian(J::UniformScaling) = isreal(J.λ)
-isapprox{T<:Number,S<:Number}(J1::UniformScaling{T}, J2::UniformScaling{S};
-                              rtol::Real=Base.rtoldefault(T,S), atol::Real=0) = isapprox(J1.λ, J2.λ, rtol=rtol, atol=atol)
 
 (+)(J1::UniformScaling, J2::UniformScaling) = UniformScaling(J1.λ+J2.λ)
 (+){T}(B::BitArray{2},J::UniformScaling{T}) = Array(B) + J
@@ -153,3 +151,6 @@ inv(J::UniformScaling) = UniformScaling(inv(J.λ))
 ./(J::UniformScaling,x::Number) = UniformScaling(J.λ/x)
 
 ==(J1::UniformScaling,J2::UniformScaling) = (J1.λ == J2.λ)
+
+isapprox{T<:Number,S<:Number}(J1::UniformScaling{T}, J2::UniformScaling{S};
+                              rtol::Real=Base.rtoldefault(T,S), atol::Real=0) = isapprox(J1.λ, J2.λ, rtol=rtol, atol=atol)

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -33,6 +33,8 @@ istriu(::UniformScaling) = true
 istril(::UniformScaling) = true
 issymmetric(::UniformScaling) = true
 ishermitian(J::UniformScaling) = isreal(J.λ)
+isapprox{T<:Number,S<:Number}(J1::UniformScaling{T}, J2::UniformScaling{S};
+                              rtol::Real=Base.rtoldefault(T,S), atol::Real=0) = isapprox(J1.λ, J2.λ, rtol=rtol, atol=atol)
 
 (+)(J1::UniformScaling, J2::UniformScaling) = UniformScaling(J1.λ+J2.λ)
 (+){T}(B::BitArray{2},J::UniformScaling{T}) = Array(B) + J

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -18,13 +18,15 @@ srand(123)
     @test -one(UniformScaling(2)) == UniformScaling(-1)
 end
 
-@testset "istriu, istril, issymmetric, ishermitian" begin
+@testset "istriu, istril, issymmetric, ishermitian, isapprox" begin
     @test istriu(I)
     @test istril(I)
     @test issymmetric(I)
     @test issymmetric(UniformScaling(complex(1.0,1.0)))
     @test ishermitian(I)
     @test !ishermitian(UniformScaling(complex(1.0,1.0)))
+    @test isapprox(UniformScaling(4.00000000000001), UniformScaling(4.0))
+    @test isapprox(UniformScaling(4.32), UniformScaling(4.3); rtol=0.1, atol=0.01)
 end
 
 @testset "* and / with number" begin


### PR DESCRIPTION
Referencing [#18858](https://github.com/JuliaLang/LinearAlgebra.jl/issues/372)
