### PR TITLE
Move most C type aliases to early in core/sysimg generation

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -6,28 +6,6 @@ import Core.Intrinsics: cglobal, box
 
 cfunction(f::Function, r, a) = ccall(:jl_function_ptr, Ptr{Void}, (Any, Any, Any), f, r, a)
 
-"""
-    Ptr{T}
-
-A memory address referring to data of type `T`.  However, there is no guarantee that the
-memory is actually valid, or that it actually represents data of the specified type.
-"""
-Ptr
-
-"""
-    Ref{T}
-
-An object that safely references data of type `T`. This type is guaranteed to point to
-valid, Julia-allocated memory of the correct type. The underlying data is protected from
-freeing by the garbage collector as long as the `Ref` itself is referenced.
-
-When passed as a `ccall` argument (either as a `Ptr` or `Ref` type), a `Ref` object will be
-converted to a native pointer to the data it references.
-
-There is no invalid (NULL) `Ref`.
-"""
-Ref
-
 if ccall(:jl_is_char_signed, Ref{Bool}, ())
     typealias Cchar Int8
 else

--- a/base/c.jl
+++ b/base/c.jl
@@ -18,36 +18,6 @@ Equivalent to the native `char` c-type.
 """
 Cchar
 
-"""
-    Cuchar
-
-Equivalent to the native `unsigned char` c-type (`UInt8`).
-"""
-typealias Cuchar UInt8
-"""
-    Cshort
-
-Equivalent to the native `signed short` c-type (`Int16`).
-"""
-typealias Cshort Int16
-"""
-    Cushort
-
-Equivalent to the native `unsigned short` c-type (`UInt16`).
-"""
-typealias Cushort UInt16
-"""
-    Cint
-
-Equivalent to the native `signed int` c-type (`Int32`).
-"""
-typealias Cint Int32
-"""
-    Cuint
-
-Equivalent to the native `unsigned int` c-type (`UInt32`).
-"""
-typealias Cuint UInt32
 if is_windows()
     typealias Clong Int32
     typealias Culong UInt32
@@ -75,61 +45,6 @@ Culong
 Equivalent to the native `wchar_t` c-type (`Int32`).
 """
 Cwchar_t
-
-"""
-    Cptrdiff_t
-
-Equivalent to the native `ptrdiff_t` c-type (`Int`).
-"""
-typealias Cptrdiff_t Int
-"""
-    Csize_t
-
-Equivalent to the native `size_t` c-type (`UInt`).
-"""
-typealias Csize_t UInt
-"""
-    Cssize_t
-
-Equivalent to the native `ssize_t` c-type.
-"""
-typealias Cssize_t Int
-"""
-    Cintmax_t
-
-Equivalent to the native `intmax_t` c-type (`Int64`).
-"""
-typealias Cintmax_t Int64
-"""
-    Cuintmax_t
-
-Equivalent to the native `uintmax_t` c-type (`UInt64`).
-"""
-typealias Cuintmax_t UInt64
-"""
-    Clonglong
-
-Equivalent to the native `signed long long` c-type (`Int64`).
-"""
-typealias Clonglong Int64
-"""
-    Culonglong
-
-Equivalent to the native `unsigned long long` c-type (`UInt64`).
-"""
-typealias Culonglong UInt64
-"""
-    Cfloat
-
-Equivalent to the native `float` c-type (`Float32`).
-"""
-typealias Cfloat Float32
-"""
-    Cdouble
-
-Equivalent to the native `double` c-type (`Float64`).
-"""
-typealias Cdouble Float64
 
 if !is_windows()
     const sizeof_mode_t = ccall(:jl_sizeof_mode_t, Cint, ())

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -12,8 +12,7 @@ eval(m,x) = Core.eval(m,x)
 include = Core.include
 
 ## Load essential files and libraries
-typealias Cint Int32
-typealias Csize_t UInt
+include("ctypes.jl")
 include("essentials.jl")
 include("generator.jl")
 include("reflection.jl")

--- a/base/ctypes.jl
+++ b/base/ctypes.jl
@@ -1,0 +1,89 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+# essential type definitions for interacting with C code
+# (platform- or OS-dependent types are defined in c.jl)
+
+"""
+    Cuchar
+
+Equivalent to the native `unsigned char` c-type (`UInt8`).
+"""
+typealias Cuchar UInt8
+"""
+    Cshort
+
+Equivalent to the native `signed short` c-type (`Int16`).
+"""
+typealias Cshort Int16
+"""
+    Cushort
+
+Equivalent to the native `unsigned short` c-type (`UInt16`).
+"""
+typealias Cushort UInt16
+"""
+    Cint
+
+Equivalent to the native `signed int` c-type (`Int32`).
+"""
+typealias Cint Int32
+"""
+    Cuint
+
+Equivalent to the native `unsigned int` c-type (`UInt32`).
+"""
+typealias Cuint UInt32
+"""
+    Cptrdiff_t
+
+Equivalent to the native `ptrdiff_t` c-type (`Int`).
+"""
+typealias Cptrdiff_t Int
+"""
+    Csize_t
+
+Equivalent to the native `size_t` c-type (`UInt`).
+"""
+typealias Csize_t UInt
+"""
+    Cssize_t
+
+Equivalent to the native `ssize_t` c-type.
+"""
+typealias Cssize_t Int
+"""
+    Cintmax_t
+
+Equivalent to the native `intmax_t` c-type (`Int64`).
+"""
+typealias Cintmax_t Int64
+"""
+    Cuintmax_t
+
+Equivalent to the native `uintmax_t` c-type (`UInt64`).
+"""
+typealias Cuintmax_t UInt64
+"""
+    Clonglong
+
+Equivalent to the native `signed long long` c-type (`Int64`).
+"""
+typealias Clonglong Int64
+"""
+    Culonglong
+
+Equivalent to the native `unsigned long long` c-type (`UInt64`).
+"""
+typealias Culonglong UInt64
+"""
+    Cfloat
+
+Equivalent to the native `float` c-type (`Float32`).
+"""
+typealias Cfloat Float32
+"""
+    Cdouble
+
+Equivalent to the native `double` c-type (`Float64`).
+"""
+typealias Cdouble Float64

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -1,5 +1,13 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+"""
+    Ptr{T}
+
+A memory address referring to data of type `T`.  However, there is no guarantee that the
+memory is actually valid, or that it actually represents data of the specified type.
+"""
+Ptr
+
 ## converting pointers to an appropriate unsigned ##
 
 """

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -1,5 +1,19 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+"""
+    Ref{T}
+
+An object that safely references data of type `T`. This type is guaranteed to point to
+valid, Julia-allocated memory of the correct type. The underlying data is protected from
+freeing by the garbage collector as long as the `Ref` itself is referenced.
+
+When passed as a `ccall` argument (either as a `Ptr` or `Ref` type), a `Ref` object will be
+converted to a native pointer to the data it references.
+
+There is no invalid (NULL) `Ref`.
+"""
+Ref
+
 # C NUL-terminated string pointers; these can be used in ccall
 # instead of Ptr{Cchar} and Ptr{Cwchar_t}, respectively, to enforce
 # a check for embedded NUL chars in the string (to avoid silent truncation).

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -42,6 +42,7 @@ if false
 end
 
 ## Load essential files and libraries
+include("ctypes.jl")
 include("essentials.jl")
 include("base.jl")
 include("generator.jl")


### PR DESCRIPTION
This PR extracts all plain, non-conditional typealiases from `c.jl` into a dedicated file, `ctypes.jl`, and loads them as early as possible during core- and sysimg generation. This makes it possible to use these aliases everywhere.

My earlier attempt in #18802 didn't suffice, as I missed how for the system image `c.jl` is being loaded pretty late.

The only similar types left in `c.jl` depend on either `osutils` or `refpointer`.
