### PR TITLE
fix #18695, inferred type of `sum(::Generator)`

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -66,7 +66,7 @@ this cannot be used with empty collections (see `reduce(op, itr)`).
 function mapfoldl(f, op, itr)
     i = start(itr)
     if done(itr, i)
-        return Base.mr_empty(f, op, eltype(itr))
+        return Base.mr_empty_iter(f, op, itr, iteratoreltype(itr))
     end
     (x, i) = next(itr, i)
     v0 = f(x)
@@ -201,7 +201,8 @@ pairwise_blocksize(::typeof(abs2), ::typeof(+)) = 4096
 
 
 # handling empty arrays
-mr_empty(f, op, T) = throw(ArgumentError("reducing over an empty collection is not allowed"))
+_empty_reduce_error() = throw(ArgumentError("reducing over an empty collection is not allowed"))
+mr_empty(f, op, T) = _empty_reduce_error()
 # use zero(T)::T to improve type information when zero(T) is not defined
 mr_empty(::typeof(identity), op::typeof(+), T) = r_promote(op, zero(T)::T)
 mr_empty(::typeof(abs), op::typeof(+), T) = r_promote(op, abs(zero(T)::T))
@@ -213,6 +214,11 @@ mr_empty(::typeof(abs), op::typeof(max), T) = mr_empty(abs, scalarmax, T)
 mr_empty(::typeof(abs2), op::typeof(max), T) = mr_empty(abs2, scalarmax, T)
 mr_empty(f, op::typeof(&), T) = true
 mr_empty(f, op::typeof(|), T) = false
+
+mr_empty_iter(f, op, itr, ::HasEltype) = mr_empty(f, op, eltype(itr))
+mr_empty_iter(f, op::typeof(&), itr, ::EltypeUnknown) = true
+mr_empty_iter(f, op::typeof(|), itr, ::EltypeUnknown) = false
+mr_empty_iter(f, op, itr, ::EltypeUnknown) = _empty_reduce_error()
 
 _mapreduce(f, op, A::AbstractArray) = _mapreduce(f, op, linearindexing(A), A)
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -298,3 +298,8 @@ let A = collect(1:10)
     @test A ∌ 11
     @test contains(==,A,6)
 end
+
+# issue #18695
+test18695(r) = sum( t^2 for t in r )
+@test @inferred(test18695([1.0,2.0,3.0,4.0])) == 30.0
+@test_throws ArgumentError test18695(Any[])


### PR DESCRIPTION
This is more than just a type inference workaround, since it lets us get the more useful "reducing over an empty collection is not allowed" error in more cases, instead of a method error on `zero(Any)` when the eltype is not known.
