### PR TITLE
Don't cache inference results if not optimizing.

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -583,7 +583,7 @@ function code_typed(f::ANY, types::ANY=Tuple; optimize=true)
     asts = []
     for x in _methods(f, types, -1)
         meth = func_for_method_checked(x[3], types)
-        (code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, !optimize)
+        (code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, optimize)
         code === nothing && error("inference not successful") # Inference disabled?
         push!(asts, uncompressed_ast(meth, code) => ty)
     end


### PR DESCRIPTION
The logic had been switched since #18591:

``` patch
@@ -575,14 +575,10 @@ function code_typed(f::ANY, types::ANY=Tuple; optimize=true)
     end
     types = to_tuple_type(types)
     asts = []
-    for x in _methods(f,types,-1)
+    for x in _methods(f, types, -1)
         meth = func_for_method_checked(x[3], types)
-        if optimize
-            (code, ty, inf) = Core.Inference.typeinf(meth, x[1], x[2], true)
-        else
-            (code, ty, inf) = Core.Inference.typeinf_uncached(meth, x[1], x[2], optimize=false)
-        end
-        inf || error("inference not successful") # Inference disabled
+        (code, ty) = Core.Inference.typeinf_code(meth, x[1], x[2], optimize, !optimize)
+        code === nothing && error("inference not successful") # Inference disabled?
         push!(asts, uncompressed_ast(meth, code) => ty)
     end
     return asts
```

~~I have a test, but it still fails after this fix (works on 0.5)...~~

``` julia
fXXX() = return nothing
m = first(methods(fXXX, Tuple{}))
@test m.specializations == nothing

code_typed(fXXX, Tuple{}; optimize=false)
@test m.specializations == nothing

code_typed(fXXX, Tuple{}; optimize=true)
@test m.specializations != nothing
```

Has the behavior changed, or is there another caching issue out there? cc @vtjnash
