### PR TITLE
deprecate `ipermutedims`

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -283,43 +283,6 @@ function cumsum_kbn{T<:AbstractFloat}(A::AbstractArray{T}, axis::Integer=1)
     return B + C
 end
 
-## ipermutedims in terms of permutedims ##
-
-"""
-    ipermutedims(A, perm)
-
-Like [`permutedims`](:func:`permutedims`), except the inverse of the given permutation is applied.
-
-```jldoctest
-julia> A = reshape(collect(1:8), (2,2,2))
-2×2×2 Array{Int64,3}:
-[:, :, 1] =
- 1  3
- 2  4
-<BLANKLINE>
-[:, :, 2] =
- 5  7
- 6  8
-
-julia> ipermutedims(A, [3, 2, 1])
-2×2×2 Array{Int64,3}:
-[:, :, 1] =
- 1  3
- 5  7
-<BLANKLINE>
-[:, :, 2] =
- 2  4
- 6  8
-```
-"""
-function ipermutedims(A::AbstractArray,perm)
-    iperm = Array{Int}(length(perm))
-    for (i,p) = enumerate(perm)
-        iperm[p] = i
-    end
-    return permutedims(A,iperm)
-end
-
 ## Other array functions ##
 
 """

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1019,4 +1019,6 @@ eval(Multimedia, :(macro textmime(mime)
     end
 end))
 
+@deprecate ipermutedims(A::AbstractArray,p) permutedims(A, invperm(p))
+
 # End deprecations scheduled for 0.6

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -532,7 +532,6 @@ export
     indmin,
     invperm,
     ipermute!,
-    ipermutedims,
     isassigned,
     isperm,
     issorted,

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -608,7 +608,7 @@ function sort(A::AbstractArray, dim::Integer;
         Ap = permutedims(A, pdims)
         Av = vec(Ap)
         sort_chunks!(Av, n, alg, order)
-        ipermutedims(Ap, pdims)
+        permutedims(Ap, invperm(pdims))
     else
         Av = A[:]
         sort_chunks!(Av, n, alg, order)

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1354,34 +1354,6 @@ Indexing, Assignment, and Concatenation
         2  4
         6  8
 
-.. function:: ipermutedims(A, perm)
-
-   .. Docstring generated from Julia source
-
-   Like :func:`permutedims`\ , except the inverse of the given permutation is applied.
-
-   .. doctest::
-
-       julia> A = reshape(collect(1:8), (2,2,2))
-       2×2×2 Array{Int64,3}:
-       [:, :, 1] =
-        1  3
-        2  4
-       <BLANKLINE>
-       [:, :, 2] =
-        5  7
-        6  8
-
-       julia> ipermutedims(A, [3, 2, 1])
-       2×2×2 Array{Int64,3}:
-       [:, :, 1] =
-        1  3
-        5  7
-       <BLANKLINE>
-       [:, :, 2] =
-        2  4
-        6  8
-
 .. function:: permutedims!(dest, src, perm)
 
    .. Docstring generated from Julia source

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -486,14 +486,11 @@ end
     @test_throws ArgumentError permutedims(s, (1,1,1))
     @test_throws ArgumentError Base.PermutedDimsArrays.PermutedDimsArray(a, (1,1,1))
     @test_throws ArgumentError Base.PermutedDimsArrays.PermutedDimsArray(s, (1,1,1))
-end
 
-@testset "ipermutedims" begin
-    tensors = Any[rand(1,2,3,4),rand(2,2,2,2),rand(5,6,5,6),rand(1,1,1,1)]
-    for i = tensors
+    for A in [rand(1,2,3,4),rand(2,2,2,2),rand(5,6,5,6),rand(1,1,1,1)]
         perm = randperm(4)
-        @test isequal(i,ipermutedims(permutedims(i,perm),perm))
-        @test isequal(i,permutedims(ipermutedims(i,perm),perm))
+        @test isequal(A,permutedims(permutedims(A,perm),invperm(perm)))
+        @test isequal(A,permutedims(permutedims(A,invperm(perm)),perm))
     end
 end
 


### PR DESCRIPTION
It seems pretty unnecessary to have a separate function for this, plus it duplicates the implementation of `invperm`.
