### PR TITLE
some small optimizations to setting up and notifying async conditions

### DIFF
--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -49,6 +49,7 @@ disassociate_julia_struct(handle::Ptr{Void}) =
 # and should thus not be garbage collected
 const uvhandles = ObjectIdDict()
 preserve_handle(x) = uvhandles[x] = get(uvhandles,x,0)::Int+1
+preserve_handle_new(x) = uvhandles[x] = 1
 unpreserve_handle(x) = (v = uvhandles[x]::Int; v == 1 ? pop!(uvhandles,x) : (uvhandles[x] = v-1); nothing)
 
 ## Libuv error handling ##

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1070,8 +1070,8 @@ end
 isopen(s::BufferStream) = s.is_open
 function close(s::BufferStream)
     s.is_open = false
-    notify(s.r_c; all=true)
-    notify(s.close_c; all=true)
+    notify(s.r_c)
+    notify(s.close_c)
     nothing
 end
 uvfinalize(s::BufferStream) = nothing
@@ -1103,7 +1103,7 @@ start_reading(s::BufferStream) = nothing
 write(s::BufferStream, b::UInt8) = write(s, Ref{UInt8}(b))
 function unsafe_write(s::BufferStream, p::Ptr{UInt8}, nb::UInt)
     rv = unsafe_write(s.buffer, p, nb)
-    !(s.buffer_writes) && notify(s.r_c; all=true)
+    !(s.buffer_writes) && notify(s.r_c)
     return rv
 end
 
@@ -1114,4 +1114,4 @@ end
 
 # If buffer_writes is called, it will delay notifying waiters till a flush is called.
 buffer_writes(s::BufferStream, bufsize=0) = (s.buffer_writes=true; s)
-flush(s::BufferStream) = (notify(s.r_c; all=true); nothing)
+flush(s::BufferStream) = (notify(s.r_c); nothing)


### PR DESCRIPTION
Before:

```
julia> @time @sync begin
                for i in 1:10^6
                  @async sleep(0.01)
                end
              end
 15.648525 seconds (13.05 M allocations: 3.528 GB, 16.95% gc time)
```

after:

```
julia> @time @sync begin
                for i in 1:10^6
                  @async sleep(0.01)
                end
              end
 10.365588 seconds (11.00 M allocations: 3.302 GB, 27.12% gc time)
```
