### PR TITLE
use `convert(T,x)::T` for all declared return types

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -185,8 +185,8 @@
                                                                 val))))
                          `(,(car body) ,@meta
                            ,(if (return? val)
-                                `(return (call (top convert) ,rett ,(cadr val)))
-                                `(call (top convert) ,rett ,val)))
+                                `(return ,(convert-for-type-decl (cadr val) rett))
+                                (convert-for-type-decl val rett)))
                          (let ((R (make-ssavalue)))
                            `(,(car body) ,@meta
                              (= ,R ,rett)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4404,6 +4404,11 @@ function f17613_2(x)::Float64
 end
 @test isa(f17613_2(1), Float64)
 
+type A1090 end
+Base.convert(::Type{Int}, ::A1090) = "hey"
+f1090()::Int = A1090()
+@test_throws TypeError f1090()
+
 # issue #16783
 function f16783()
     T = UInt32


### PR DESCRIPTION
before, the type assert was not included for short functions
