### PR TITLE
remove duplicate documentation for ===

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -498,14 +498,6 @@ ERROR: argument is an abstract type; size is indeterminate
 sizeof(::Type)
 
 """
-    ===(x, y)
-    ≡(x,y)
-
-See the [`is`](:func:`is`) operator.
-"""
-Base.:(===)
-
-"""
     ReadOnlyMemoryError()
 
 An operation tried to write to memory that is read-only.

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -455,14 +455,6 @@ Mathematical Operators
 
    Not-equals comparison operator. Always gives the opposite answer as ``==``\ . New types should generally not implement this, and rely on the fallback definition ``!=(x,y) = !(x==y)`` instead.
 
-.. _===:
-.. function:: ===(x, y)
-              ≡(x,y)
-
-   .. Docstring generated from Julia source
-
-   See the :func:`is` operator.
-
 .. _!==:
 .. function:: !==(x, y)
               ≢(x,y)


### PR DESCRIPTION
`===`/`is`/`≡` is already documented in operators.jl, so this is
redundant (and not all that helpful).
