### PR TITLE
Add a virtual destructor to the AbiLayout base class.

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -766,7 +766,7 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
 }
 
 #ifdef USE_MCJIT
-class FunctionMover : public ValueMaterializer
+class FunctionMover final : public ValueMaterializer
 {
 public:
     FunctionMover(llvm::Module *dest,llvm::Module *src) :
@@ -842,11 +842,11 @@ public:
     }
 
 #if JL_LLVM_VERSION >= 30900
-    virtual Value *materialize(Value *V) override
+    Value *materialize(Value *V) override
 #elif JL_LLVM_VERSION >= 30800
-    virtual Value *materializeDeclFor(Value *V) override
+    Value *materializeDeclFor(Value *V) override
 #else
-    virtual Value *materializeValueFor (Value *V) override
+    Value *materializeValueFor (Value *V) override
 #endif
     {
         Function *F = dyn_cast<Function>(V);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -336,6 +336,7 @@ static Value *emit_plt(FunctionType *functype, const AttributeSet &attrs,
 
 class AbiLayout {
 public:
+    virtual ~AbiLayout() {}
     virtual bool use_sret(jl_datatype_t *ty) = 0;
     virtual void needPassByRef(jl_datatype_t *ty, bool *byRef, bool *inReg) = 0;
     virtual Type *preferred_llvm_type(jl_datatype_t *ty, bool isret) const = 0;


### PR DESCRIPTION
Since we're using ABI layout objects polymorphically (via `std::unique_ptr<AbiLayout> abi`), the base class needs a virtual destructor or the derived class' destructor will never trigger (it might even be UB).

This also squelches compile-time warnings:

```
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
src/ccall.cpp:337:7: warning: 'AbiLayout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
class AbiLayout {
      ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:363:
src/abi_llvm.cpp:41:8: warning: 'ABI_LLVMLayout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_LLVMLayout : AbiLayout {
       ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:365:
src/abi_arm.cpp:24:8: warning: 'ABI_ARMLayout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_ARMLayout : AbiLayout {
       ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:366:
src/abi_aarch64.cpp:14:8: warning: 'ABI_AArch64Layout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_AArch64Layout : AbiLayout {
       ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:367:
src/abi_ppc64le.cpp:42:8: warning: 'ABI_PPC64leLayout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_PPC64leLayout : AbiLayout {
       ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:368:
src/abi_win32.cpp:40:8: warning: 'ABI_Win32Layout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_Win32Layout : AbiLayout {
       ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:369:
src/abi_win64.cpp:46:8: warning: 'ABI_Win64Layout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_Win64Layout : AbiLayout {
       ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:370:
src/abi_x86_64.cpp:41:8: warning: 'ABI_x86_64Layout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_x86_64Layout : AbiLayout {
       ^
In file included from src/codegen.cpp:1870:
In file included from src/intrinsics.cpp:7:
In file included from src/ccall.cpp:371:
src/abi_x86.cpp:40:8: warning: 'ABI_x86Layout' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
struct ABI_x86Layout : AbiLayout {
       ^
```
