### PR TITLE
fix specificity of sigs that are strict subtypes of vararg sigs

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3132,7 +3132,9 @@ int jl_args_morespecific_fix1(jl_value_t *a, jl_value_t *b, int swap)
     if (changed) {
         JL_GC_PUSH1(&newtta);
         int ret;
-        if (swap)
+        if (type_eqv_(b, newtta))
+            ret = swap;
+        else if (swap)
             ret = jl_args_morespecific_(b, (jl_value_t*)newtta);
         else
             ret = jl_args_morespecific_((jl_value_t*)newtta, b);

--- a/test/core.jl
+++ b/test/core.jl
@@ -219,6 +219,11 @@ end
 
 # with bound varargs
 
+_bound_vararg_specificity_1{T,N}(::Type{Array{T,N}}, d::Vararg{Int, N}) = 0
+_bound_vararg_specificity_1{T}(::Type{Array{T,1}}, d::Int) = 1
+@test _bound_vararg_specificity_1(Array{Int,1}, 1) == 1
+@test _bound_vararg_specificity_1(Array{Int,2}, 1, 1) == 0
+
 # issue #11840
 typealias TT11840{T} Tuple{T,T}
 f11840(::Type) = "Type"


### PR DESCRIPTION
I noticed that the Array constructor

```
(::Type{Array{T,N}}){T,N}(d::Vararg{Int, N})
```

was getting called in preference to

```
(::Type{Array{T,1}}){T}(m::Int)
```

which cased extra tuple allocations. The problem seems to be method specificity when one signature is Vararg, and the other is a specialization of it (e.g. for the case N==1 as here). This patch should fix it.

Fix #18922 
