### PR TITLE
avoid more tuple allocations in Array constructors

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -313,6 +313,9 @@ typealias NTuple{N,T} Tuple{Vararg{T,N}}
 # primitive array constructors
 (::Type{Array{T,N}}){T,N}(d::NTuple{N,Int}) =
     ccall(:jl_new_array, Array{T,N}, (Any,Any), Array{T,N}, d)
+(::Type{Array{T,1}}){T}(d::NTuple{1,Int}) = Array{T,1}(getfield(d,1))
+(::Type{Array{T,2}}){T}(d::NTuple{2,Int}) = Array{T,2}(getfield(d,1), getfield(d,2))
+(::Type{Array{T,3}}){T}(d::NTuple{3,Int}) = Array{T,3}(getfield(d,1), getfield(d,2), getfield(d,3))
 (::Type{Array{T,N}}){T,N}(d::Vararg{Int, N}) = ccall(:jl_new_array, Array{T,N}, (Any,Any), Array{T,N}, d)
 (::Type{Array{T,1}}){T}(m::Int) =
     ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, m)


### PR DESCRIPTION
The problem here is that `Array{...}((n,))` passes the tuple to C as `Any`, requiring it to be heap allocated. This is a quick fix that gets around that by unpacking the tuple from julia first.

Issues like this can potentially be eliminated once and for all by #12447. Another approach to explore is passing the tuple to C as `Ptr{Int}`, allowing it to remain stack allocated. @vtjnash Is that possible?
