### PR TITLE
Add patch for LLVM-3.9+Clang+macOS Sierra

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -493,6 +493,13 @@ $(eval $(call LLVM_PATCH,llvm-D34078-vectorize-fdiv))
 $(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 endif # LLVM_VER
 
+# Remove hardcoded OS X requirements in compilter-rt cmake build
+ifeq ($(LLVM_VER_SHORT),3.9)
+ifeq ($(BUILD_LLVM_CLANG),1)
+$(eval $(call LLVM_PATCH,llvm-3.9-osx-10.12))
+endif
+endif
+
 $(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_PATCH_PREV)
 
 $(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_SRC_DIR)/source-extracted | $(llvm_python_workaround) $(LIBCXX_DEPENDENCY)

--- a/deps/patches/llvm-3.9-osx-10.12.patch
+++ b/deps/patches/llvm-3.9-osx-10.12.patch
@@ -1,0 +1,33 @@
+--- a/projects/compiler-rt/cmake/builtin-config-ix.cmake
++++ b/projects/compiler-rt/cmake/builtin-config-ix.cmake
+@@ -57,9 +57,6 @@
+   find_darwin_sdk_dir(DARWIN_tvos_SYSROOT appletvos)
+ 
+   set(DARWIN_EMBEDDED_PLATFORMS)
+-  set(DARWIN_osx_BUILTIN_MIN_VER 10.5)
+-  set(DARWIN_osx_BUILTIN_MIN_VER_FLAG
+-      -mmacosx-version-min=${DARWIN_osx_BUILTIN_MIN_VER})
+ 
+   if(COMPILER_RT_ENABLE_IOS)
+     list(APPEND DARWIN_EMBEDDED_PLATFORMS ios)
+@@ -101,20 +98,6 @@
+     set(CAN_TARGET_${arch} 1)
+   endforeach()
+ 
+-  # Need to build a 10.4 compatible libclang_rt
+-  set(DARWIN_10.4_SYSROOT ${DARWIN_osx_SYSROOT})
+-  set(DARWIN_10.4_BUILTIN_MIN_VER 10.4)
+-  set(DARWIN_10.4_BUILTIN_MIN_VER_FLAG
+-      -mmacosx-version-min=${DARWIN_10.4_BUILTIN_MIN_VER})
+-  set(DARWIN_10.4_SKIP_CC_KEXT On)
+-  darwin_test_archs(10.4 DARWIN_10.4_ARCHS i386 x86_64)
+-  message(STATUS "OSX 10.4 supported builtin arches: ${DARWIN_10.4_ARCHS}")
+-  if(DARWIN_10.4_ARCHS)
+-    # don't include the Haswell slice in the 10.4 compatibility library
+-    list(REMOVE_ITEM DARWIN_10.4_ARCHS x86_64h)
+-    list(APPEND BUILTIN_SUPPORTED_OS 10.4)
+-  endif()
+-
+   foreach(platform ${DARWIN_EMBEDDED_PLATFORMS})
+     if(DARWIN_${platform}sim_SYSROOT)
+       set(DARWIN_${platform}sim_BUILTIN_MIN_VER


### PR DESCRIPTION
Removes hardcoded lower version bounds incompatible with Sierra
in CMake file for compiler-rt

This seems to necessary to build Clang on Sierra with LLVM 3.9.

cc: @vchuravy who diagnosed the issue.
