### PR TITLE
RFC: revert back to one index for some elementwise operations

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -20,8 +20,15 @@ for f in (:-, :~, :conj, :sign)
     @eval begin
         function ($f)(A::AbstractArray)
             F = similar(A)
-            for (iF, iA) in zip(eachindex(F), eachindex(A))
-                F[iF] = ($f)(A[iA])
+            RF, RA = eachindex(F), eachindex(A)
+            if RF == RA
+                for i in RA
+                    F[i] = ($f)(A[i])
+                end
+            else
+                for (iF, iA) in zip(RF, RA)
+                   F[iF] = ($f)(A[iA])
+                end
             end
             return F
         end
@@ -35,8 +42,15 @@ imag(A::AbstractArray) = reshape([ imag(x) for x in A ], size(A))
 
 function !(A::AbstractArray{Bool})
     F = similar(A)
-    for (iF, iA) in zip(eachindex(F), eachindex(A))
-        F[iF] = !A[iA]
+    RF, RA = eachindex(F), eachindex(A)
+    if RF == RA
+        for i in RA
+            F[i] = !A[i]
+        end
+    else
+        for (iF, iA) in zip(RF, RA)
+            F[iF] = !A[iA]
+        end
     end
     return F
 end
@@ -62,8 +76,15 @@ function _elementwise(op, ::Type{Any}, A::AbstractArray, B::AbstractArray)
 end
 function _elementwise{T}(op, ::Type{T}, A::AbstractArray, B::AbstractArray)
     F = similar(A, T, promote_shape(A, B))
-    for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
-        @inbounds F[iF] = op(A[iA], B[iB])
+    RF, RA, RB  = eachindex(F), eachindex(A), eachindex(B)
+    if RF == RA == RB
+        for i in RA
+            @inbounds F[i] = op(A[i], B[i])
+        end
+    else
+        for (iF, iA, iB) in zip(RF, RA, RB)
+            @inbounds F[iF] = op(A[iA], B[iB])
+        end
     end
     return F
 end
@@ -75,8 +96,15 @@ for f in (:.+, :.-, :.*, :./, :.\, :.^, :.÷, :.%, :.<<, :.>>, :div, :mod, :rem,
             S = promote_array_type($f, typeof(A), T, R)
             S === Any && return [($f)(A, b) for b in B]
             F = similar(B, S)
-            for (iF, iB) in zip(eachindex(F), eachindex(B))
-                @inbounds F[iF] = ($f)(A, B[iB])
+            RF, RB = eachindex(F), eachindex(B)
+            if RF == RB
+                for i in RB
+                    @inbounds F[i] = ($f)(A, B[i])
+                end
+            else
+                for (iF, iB) in zip(RF, RB)
+                    @inbounds F[iF] = ($f)(A, B[iB])
+                end
             end
             return F
         end
@@ -85,8 +113,15 @@ for f in (:.+, :.-, :.*, :./, :.\, :.^, :.÷, :.%, :.<<, :.>>, :div, :mod, :rem,
             S = promote_array_type($f, typeof(B), T, R)
             S === Any && return [($f)(a, B) for a in A]
             F = similar(A, S)
-            for (iF, iA) in zip(eachindex(F), eachindex(A))
-                @inbounds F[iF] = ($f)(A[iA], B)
+            RF, RA = eachindex(F), eachindex(A)
+            if RF == RA
+                for i in RA
+                    @inbounds F[i] = ($f)(A[i], B)
+                end
+            else
+                for (iF, iA) in zip(RF, RA)
+                    @inbounds F[iF] = ($f)(A[iA], B)
+                end
             end
             return F
         end
@@ -420,9 +455,17 @@ function transposeblock!(f,B::AbstractMatrix,A::AbstractMatrix,m::Int,n::Int,off
     end
     return B
 end
+
 function ccopy!(B, A)
-    for (i,j) = zip(eachindex(B),eachindex(A))
-        B[i] = ctranspose(A[j])
+    RB, RA = eachindex(B), eachindex(A)
+    if RB == RA
+        for i = RB
+            B[i] = ctranspose(A[i])
+        end
+    else
+        for (i,j) = zip(RB, RA)
+            B[i] = ctranspose(A[j])
+        end
     end
 end
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -839,24 +839,45 @@ promote_array_type{S<:Union{Complex, Real}, T<:AbstractFloat}(F, ::Type{S}, ::Ty
 function complex{S<:Real,T<:Real}(A::AbstractArray{S}, B::AbstractArray{T})
     if size(A) != size(B); throw(DimensionMismatch()); end
     F = similar(A, typeof(complex(zero(S),zero(T))))
-    for (iF, iA, iB) in zip(eachindex(F), eachindex(A), eachindex(B))
-        @inbounds F[iF] = complex(A[iA], B[iB])
+    RF, RA, RB = eachindex(F), eachindex(A), eachindex(B)
+    if RF == RA == RB
+        for i in RA
+            @inbounds F[i] = complex(A[i], B[i])
+        end
+    else
+        for (iF, iA, iB) in zip(RF, RA, RB)
+            @inbounds F[iF] = complex(A[iA], B[iB])
+        end
     end
     return F
 end
 
 function complex{T<:Real}(A::Real, B::AbstractArray{T})
     F = similar(B, typeof(complex(A,zero(T))))
-    for (iF, iB) in zip(eachindex(F), eachindex(B))
-        @inbounds F[iF] = complex(A, B[iB])
+    RF, RB = eachindex(F), eachindex(B)
+    if RF == RB
+        for i in RB
+            @inbounds F[i] = complex(A, B[i])
+        end
+    else
+        for (iF, iB) in zip(RF, RB)
+            @inbounds F[iF] = complex(A, B[iB])
+        end
     end
     return F
 end
 
 function complex{T<:Real}(A::AbstractArray{T}, B::Real)
     F = similar(A, typeof(complex(zero(T),B)))
-    for (iF, iA) in zip(eachindex(F), eachindex(A))
-        @inbounds F[iF] = complex(A[iA], B)
+    RF, RA = eachindex(F), eachindex(A)
+    if RF == RA
+        for i in RA
+            @inbounds F[i] = complex(A[i], B)
+        end
+    else
+        for (iF, iA) in zip(RF, RA)
+            @inbounds F[iF] = complex(A[iA], B)
+        end
     end
     return F
 end


### PR DESCRIPTION
This reenables SIMD to work for a few elementwise operations that I think regressed with https://github.com/JuliaLang/julia/pull/16498

Benchmark run:
https://github.com/JuliaCI/BaseBenchmarkReports/blob/a6f6f33385f31746c2294f8d10e42caedc09db85/5f550ea_vs_4ba21aa/report.md

Ref: https://github.com/JuliaLang/julia/pull/15356#issuecomment-247841350

What are your opinions about this @timholy?

Backport? 
