### PR TITLE
remove `iterator.jl` from coreimg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,6 @@ CORE_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/inference.jl \
 		base/int.jl \
 		base/intset.jl \
-		base/iterator.jl \
 		base/nofloat_hashing.jl \
 		base/number.jl \
 		base/operators.jl \

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -59,7 +59,6 @@ include("reduce.jl")
 ## core structures
 include("intset.jl")
 include("associative.jl")
-include("iterator.jl")
 
 # core docsystem
 include("docs/core.jl")

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -63,6 +63,12 @@ function tuple_type_tail(T::DataType)
     return Tuple{argtail(T.parameters...)...}
 end
 
+tuple_type_cons{S}(::Type{S}, ::Type{Union{}}) = Union{}
+function tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
+    @_pure_meta
+    Tuple{S, T.parameters...}
+end
+
 isvarargtype(t::ANY) = isa(t, DataType) && is((t::DataType).name, Vararg.name)
 isvatuple(t::DataType) = (n = length(t.parameters); n > 0 && isvarargtype(t.parameters[n]))
 unwrapva(t::ANY) = isvarargtype(t) ? t.parameters[1] : t
@@ -231,3 +237,5 @@ function vector_any(xs::ANY...)
     end
     a
 end
+
+isempty(itr) = done(itr, start(itr))

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1019,7 +1019,8 @@ function abstract_apply(af::ANY, fargs, aargtypes::Vector{Any}, vtypes::VarTable
 end
 
 function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv::InferenceState)
-    for a in drop(argtypes,1)
+    for i = 2:length(argtypes)
+        a = argtypes[i]
         if !(isa(a,Const) || isconstType(a,false))
             return false
         end
@@ -1055,7 +1056,7 @@ function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv:
         return false
     end
 
-    args = Any[ isa(a,Const) ? a.val : a.parameters[1] for a in drop(argtypes,1) ]
+    args = Any[ (a=argtypes[i]; isa(a,Const) ? a.val : a.parameters[1]) for i in 2:length(argtypes) ]
     try
         return abstract_eval_constant(f(args...))
     catch

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-isempty(itr) = done(itr, start(itr))
-
 _min_length(a, b, ::IsInfinite, ::IsInfinite) = min(length(a),length(b)) # inherit behaviour, error
 _min_length(a, b, A, ::IsInfinite) = length(a)
 _min_length(a, b, ::IsInfinite, B) = length(b)
@@ -143,11 +141,6 @@ zip(a, b, c...) = Zip(a, zip(b, c...))
 length(z::Zip) = _min_length(z.a, z.z, iteratorsize(z.a), iteratorsize(z.z))
 size(z::Zip) = promote_shape(size(z.a), size(z.z))
 indices(z::Zip) = promote_shape(indices(z.a), indices(z.z))
-tuple_type_cons{S}(::Type{S}, ::Type{Union{}}) = Union{}
-function tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
-    @_pure_meta
-    Tuple{S, T.parameters...}
-end
 eltype{I,Z}(::Type{Zip{I,Z}}) = tuple_type_cons(eltype(I), eltype(Z))
 @inline start(z::Zip) = tuple(start(z.a), start(z.z))
 @inline function next(z::Zip, st)


### PR DESCRIPTION
After very minor changes it's no longer used. This is a small subset of #18839 that can be merged separately.
