### PR TITLE
Fix libgit2 SSL certificate searching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,10 +453,9 @@ ifneq ($(OS), WINNT)
 endif
 ifeq ($(OS), Linux)
 	-$(JULIAHOME)/contrib/fixup-libstdc++.sh $(DESTDIR)$(libdir) $(DESTDIR)$(private_libdir)
-	# We need to bundle ca certs on linux now that we're using libgit2 with ssl
-ifeq ($(shell [ -e $(shell openssl version -d | cut -d '"' -f 2)/cert.pem ] && echo exists),exists)
-	-cp $(shell openssl version -d | cut -d '"' -f 2)/cert.pem $(DESTDIR)$(datarootdir)/julia/
-endif
+
+	# Copy over any bundled ca certs we picked up from the system during buildi
+	-cp $(build_datarootdir)/julia/cert.pem $(DESTDIR)$(datarootdir)/julia/
 endif
 	# Copy in juliarc.jl files per-platform for binary distributions as well
 	# Note that we don't install to sysconfdir: we always install to $(DESTDIR)$(prefix)/etc.

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -65,7 +65,6 @@ $(SRCDIR)/srccache/$(LIBGIT2_SRC_DIR)/libgit2-openssl-hang.patch-applied: $(SRCD
 
 $(build_datarootdir)/julia/cert.pem: $(CERTFILE)
 	mkdir -p $(build_datarootdir)/julia
-	echo "NABIL: Copying over certfile $(CERTFILE)"
 	-cp $(CERTFILE) $@
 
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: \


### PR DESCRIPTION
This PR contains two pieces:
- Makefile fixes to grab OS-provided SSL certificates on Linux during `libgit2` compile time, so that from-source builds and `make binary-dist` builds have a more consistent environment
- Reordering `libgit2` initialization logic and disabling calling `git_libgit2_opts()` in favor of setting environment variables so as to workaround https://github.com/libgit2/libgit2/pull/3935#issuecomment-253910017.

This is a somewhat ugly solution to the problem, but until we hear back from that libgit2 PR on the proper way to fix this, this is the best solution I've got.
