### PR TITLE
Move error.jl docs inline; add example to catch_backtrace()

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3,13 +3,6 @@
 # Base
 
 """
-    systemerror(sysfunc, iftrue)
-
-Raises a `SystemError` for `errno` with the descriptive string `sysfunc` if `iftrue` is `true`
-"""
-systemerror
-
-"""
     fill!(A, x)
 
 Fill array `A` with the value `x`. If `x` is an object reference, all elements will refer to
@@ -177,13 +170,6 @@ julia> [1 2 3] .* [1 2 3]
 Base.:(.*)
 
 """
-    backtrace()
-
-Get a backtrace object for the current program point.
-"""
-backtrace
-
-"""
     -(x)
 
 Unary minus operator.
@@ -289,14 +275,6 @@ return an object of a type different from `T`, which however is suitable for
 Neither `convert` nor `cconvert` should take a Julia object and turn it into a `Ptr`.
 """
 cconvert
-
-"""
-    assert(cond)
-
-Throw an [`AssertionError`](:obj:`AssertionError`) if `cond` is `false`.
-Also available as the macro `@assert expr`.
-"""
-assert
 
 """
     sech(x)
@@ -2156,13 +2134,6 @@ Show a descriptive representation of an exception object.
 showerror
 
 """
-    error(message::AbstractString)
-
-Raise an `ErrorException` with the given message.
-"""
-error
-
-"""
     sqrtm(A)
 
 If `A` has no negative real eigenvalues, compute the principal matrix square root of `A`,
@@ -2539,14 +2510,6 @@ This is intended to be called using `do` block syntax:
 get!(f::Function,collection,key)
 
 """
-    @assert cond [text]
-
-Throw an `AssertionError` if `cond` is `false`. Preferred syntax for writing assertions.
-Message `text` is optionally displayed upon assertion failure.
-"""
-:@assert
-
-"""
     deserialize(stream)
 
 Read a value written by [`serialize`](:func:`serialize`). `deserialize` assumes the binary data read from
@@ -2586,14 +2549,6 @@ median!
 Cumulative product of `A` along a dimension, storing the result in `B`. The dimension defaults to 1.
 """
 cumprod!
-
-"""
-    rethrow([e])
-
-Throw an object without changing the current exception backtrace. The default argument is
-the current exception (if called within a `catch` block).
-"""
-rethrow
 
 """
     !(x)
@@ -2798,13 +2753,6 @@ pointer `p` to ensure that it is valid. Incorrect usage may segfault your progra
 garbage answers, in the same manner as C.
 """
 unsafe_load
-
-"""
-    catch_backtrace()
-
-Get the backtrace of the current exception, for use within `catch` blocks.
-"""
-catch_backtrace
 
 """
     cos(x)

--- a/base/error.jl
+++ b/base/error.jl
@@ -51,13 +51,19 @@ may be helpful for displaying the backtrace in a human-readable format.
 
 # Example
 
-```
-f(x) = try
-    sqrt(x)
-catch y
-    bt = catch_backtrace()
-    showerror(STDOUT, y, bt)
-end
+```jldoctest
+julia> f(x) = try
+           sqrt(x)
+       catch y
+           bt = catch_backtrace()
+           showerror(STDOUT, y, bt)
+       end;
+
+julia> f(-1)
+DomainError:
+ in f(::Int64) at ./REPL[24]:2
+ in eval(::Module, ::Any) at ./boot.jl:236
+ ...
 ```
 """
 catch_backtrace() = ccall(:jl_get_backtrace, Array{Ptr{Void},1}, ())

--- a/base/error.jl
+++ b/base/error.jl
@@ -18,24 +18,77 @@
 
 ## native julia error handling ##
 
+"""
+    error(message::AbstractString)
+
+Raise an `ErrorException` with the given message.
+"""
 error(s::AbstractString) = throw(ErrorException(s))
 error(s...) = throw(ErrorException(Main.Base.string(s...)))
 
+"""
+    rethrow([e])
+
+Throw an object without changing the current exception backtrace. The default argument is
+the current exception (if called within a `catch` block).
+"""
 rethrow() = ccall(:jl_rethrow, Bottom, ())
 rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
+
+"""
+    backtrace()
+
+Get a backtrace object for the current program point.
+"""
 backtrace() = ccall(:jl_backtrace_from_here, Array{Ptr{Void},1}, (Int32,), false)
+
+"""
+    catch_backtrace()
+
+Get the backtrace of the current exception, for use within `catch` blocks.
+The backtrace is represented as an `Array{Ptr{Void}}` of addresses, so [`showerror`](:func:`showerror`)
+may be helpful for displaying the backtrace in a human-readable format.
+
+# Example
+
+```
+f(x) = try
+    sqrt(x)
+catch y
+    bt = catch_backtrace()
+    showerror(STDOUT, y, bt)
+end
+```
+"""
 catch_backtrace() = ccall(:jl_get_backtrace, Array{Ptr{Void},1}, ())
 
 ## keyword arg lowering generates calls to this ##
 kwerr(kw, args...) = throw(MethodError(typeof(args[1]).name.mt.kwsorter, (kw,args...)))
 
 ## system error handling ##
+"""
+    systemerror(sysfunc, iftrue)
 
+Raises a `SystemError` for `errno` with the descriptive string `sysfunc` if `iftrue` is `true`.
+"""
 systemerror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), extrainfo)) : nothing
 
 ## assertion functions and macros ##
 
+"""
+    assert(cond)
+
+Throw an [`AssertionError`](:obj:`AssertionError`) if `cond` is `false`.
+Also available as the macro `@assert expr`.
+"""
 assert(x) = x ? nothing : throw(Main.Base.AssertionError())
+
+"""
+    @assert cond [text]
+
+Throw an `AssertionError` if `cond` is `false`. Preferred syntax for writing assertions.
+Message `text` is optionally displayed upon assertion failure.
+"""
 macro assert(ex, msgs...)
     msg = isempty(msgs) ? ex : msgs[1]
     if !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))

--- a/base/test.jl
+++ b/base/test.jl
@@ -964,7 +964,7 @@ Body:
 
 julia> @inferred f(1,2,3)
 ERROR: return type Int64 does not match inferred return type Union{Float64,Int64}
- in error(::String) at ./error.jl:21
+ in error(::String) at ./error.jl:26
  ...
 
 julia> @inferred max(1,2)

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -807,7 +807,7 @@ execution:
 
     julia> error("Hi"); 1+1
     ERROR: Hi
-     in error(::String) at ./error.jl:21
+     in error(::String) at ./error.jl:26
      ...
 
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1197,7 +1197,18 @@ Errors
 
    .. Docstring generated from Julia source
 
-   Get the backtrace of the current exception, for use within ``catch`` blocks.
+   Get the backtrace of the current exception, for use within ``catch`` blocks. The backtrace is represented as an ``Array{Ptr{Void}}`` of addresses, so :func:`showerror` may be helpful for displaying the backtrace in a human-readable format.
+
+   **Example**
+
+   .. code-block:: julia
+
+       f(x) = try
+           sqrt(x)
+       catch y
+           bt = catch_backtrace()
+           showerror(STDOUT, y, bt)
+       end
 
 .. function:: assert(cond)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1201,14 +1201,20 @@ Errors
 
    **Example**
 
-   .. code-block:: julia
+   .. doctest::
 
-       f(x) = try
-           sqrt(x)
-       catch y
-           bt = catch_backtrace()
-           showerror(STDOUT, y, bt)
-       end
+       julia> f(x) = try
+                  sqrt(x)
+              catch y
+                  bt = catch_backtrace()
+                  showerror(STDOUT, y, bt)
+              end;
+
+       julia> f(-1)
+       DomainError:
+        in f(::Int64) at ./REPL[24]:2
+        in eval(::Module, ::Any) at ./boot.jl:236
+        ...
 
 .. function:: assert(cond)
 

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -157,7 +157,7 @@
 
    .. Docstring generated from Julia source
 
-   Raises a ``SystemError`` for ``errno`` with the descriptive string ``sysfunc`` if ``iftrue`` is ``true``
+   Raises a ``SystemError`` for ``errno`` with the descriptive string ``sysfunc`` if ``iftrue`` is ``true``\ .
 
 .. data:: Ptr{T}
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -461,7 +461,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Equivalent to ``!is(x, y)``\ .
+   Equivalent to ``!(x === y)``\ .
 
 .. _<:
 .. function:: <(x, y)

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -274,7 +274,7 @@ writing new tests.
 
        julia> @inferred f(1,2,3)
        ERROR: return type Int64 does not match inferred return type Union{Float64,Int64}
-        in error(::String) at ./error.jl:21
+        in error(::String) at ./error.jl:26
         ...
 
        julia> @inferred max(1,2)


### PR DESCRIPTION
I moved docstrings inline for a few functions declared in error.jl and augmented the docs slightly for `catch_backtrace()`. ref #7283

Thanks in advance and happy Saturday!
