### PR TITLE
Documented @printf's differences from C; moved docs inline

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1620,18 +1620,6 @@ write results to `r`.
 sumabs2!
 
 """
-    @sprintf("%Fmt", args...)
-
-Return `@printf` formatted output as string.
-
-    julia> s = @sprintf "this is a %s %15.1f" "test" 34.567;
-
-    julia> println(s)
-    this is a test            34.6
-"""
-:@sprintf
-
-"""
     tanh(x)
 
 Compute hyperbolic tangent of `x`.
@@ -2425,15 +2413,6 @@ Assign `x` to a named field in `value` of composite type. The syntax `a.b = c` c
 `setfield!(a, :b, c)`.
 """
 setfield!
-
-"""
-    @printf([io::IOStream], "%Fmt", args...)
-
-Print `args` using C `printf()` style format specification string.
-Optionally, an [`IOStream`](:obj:`IOStream`)
-may be passed as the first argument to redirect output.
-"""
-:@printf
 
 """
     countlines(io,[eol::Char])

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -1174,6 +1174,21 @@ function _printf(macroname, io, fmt, args)
     Expr(:let, blk)
 end
 
+"""
+    @printf([io::IOStream], "%Fmt", args...)
+
+Print `args` using C `printf()` style format specification string, with some caveats:
+`Inf` and `NaN` are printed consistently as 'Inf' and 'NaN' for flags %a, %A,
+%e, %E, %f, %F, %g, and %G.
+
+Optionally, an [`IOStream`](:obj:`IOStream`)
+may be passed as the first argument to redirect output.
+
+# Examples
+
+    julia> @printf( "%f %F %f %F", Inf, Inf, NaN, NaN )
+    Inf Inf NaN NaN
+"""
 macro printf(args...)
     isempty(args) && throw(ArgumentError("@printf: called with no arguments"))
     if isa(args[1], AbstractString) || is_str_expr(args[1])
@@ -1185,6 +1200,18 @@ macro printf(args...)
     end
 end
 
+"""
+    @sprintf("%Fmt", args...)
+
+Return `@printf` formatted output as string.
+
+# Examples
+
+    julia> s = @sprintf "this is a %s %15.1f" "test" 34.567;
+
+    julia> println(s)
+    this is a test            34.6
+"""
 macro sprintf(args...)
     isempty(args) && throw(ArgumentError("@sprintf: called with zero arguments"))
     isa(args[1], AbstractString) || is_str_expr(args[1]) ||

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -534,13 +534,24 @@ Text I/O
 
    .. Docstring generated from Julia source
 
-   Print ``args`` using C ``printf()`` style format specification string. Optionally, an :obj:`IOStream` may be passed as the first argument to redirect output.
+   Print ``args`` using C ``printf()`` style format specification string, with some caveats: ``Inf`` and ``NaN`` are printed consistently as 'Inf' and 'NaN' for flags %a, %A, %e, %E, %f, %F, %g, and %G.
+
+   Optionally, an :obj:`IOStream` may be passed as the first argument to redirect output.
+
+   **Examples**
+
+   .. code-block:: julia
+
+       julia> @printf( "%f %F %f %F", Inf, Inf, NaN, NaN )
+       Inf Inf NaN NaN
 
 .. function:: @sprintf("%Fmt", args...)
 
    .. Docstring generated from Julia source
 
    Return ``@printf`` formatted output as string.
+
+   **Examples**
 
    .. code-block:: julia
 


### PR DESCRIPTION
Documented how output for [`@printf`](:ref:`@printf`) differs from that of C's `printf()` for `Inf` and `NaN` given flags %a, %A, %e, %E, %f, %F, %g, and %G. ref #11942 

Also moved docstrings for [`@printf`](:ref:`@printf`) and [`@sprintf`](:ref:`@sprintf`) inline.

Thanks!!
