### PR TITLE
Remove duplicate mention of Interacting with Julia in manual index

### DIFF
--- a/doc/manual/index.rst
+++ b/doc/manual/index.rst
@@ -31,7 +31,6 @@
    networking-and-streams
    parallel-computing
    dates
-   interacting-with-julia
    running-external-programs
    calling-c-and-fortran-code
    handling-operating-system-variation


### PR DESCRIPTION
Introduced when syncing two variants of the index.
