### PR TITLE
Fix #18974 (promotion in sparse unary broadcast methods)

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1433,7 +1433,7 @@ function _broadcast_unary_nz2z_z2z_T{TvA,TiA,TvB}(f::Function, A::SparseMatrixCS
     return SparseMatrixCSC(A.m, A.n, Bcolptr, Browval, Bnzval)
 end
 function _broadcast_unary_nz2z_z2z{Tv}(f::Function, A::SparseMatrixCSC{Tv})
-    _broadcast_unary_nz2z_z2z_T(f, A, Tv)
+    _broadcast_unary_nz2z_z2z_T(f, A, promote_op(f, Tv))
 end
 @_enumerate_childmethods(_broadcast_unary_nz2z_z2z,
     sin, sinh, sind, asin, asinh, asind,
@@ -1465,7 +1465,7 @@ function _broadcast_unary_nz2nz_z2z_T{TvA,TiA,TvB}(f::Function, A::SparseMatrixC
     return SparseMatrixCSC(A.m, A.n, Bcolptr, Browval, Bnzval)
 end
 function _broadcast_unary_nz2nz_z2z{Tv}(f::Function, A::SparseMatrixCSC{Tv})
-    _broadcast_unary_nz2nz_z2z_T(f, A, Tv)
+    _broadcast_unary_nz2nz_z2z_T(f, A, promote_op(f, Tv))
 end
 @_enumerate_childmethods(_broadcast_unary_nz2nz_z2z,
     log1p, expm1, abs, abs2, conj)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1635,3 +1635,12 @@ let
     @test isa(abs.(A), SparseMatrixCSC) # representative for _unary_nz2nz_z2z class
     @test isa(exp.(A), Array) # representative for _unary_nz2nz_z2nz class
 end
+
+# Check that `broadcast` methods specialized for unary operations over
+# `SparseMatrixCSC`s determine a reasonable return element type. (Issue #18974.)
+let
+    A = spdiagm(Int64(1):Int64(4))
+    @test isa(eltype(expm1.(A)), Float64) # representative for _unary_nz2nz_z2z class
+    @test isa(eltype(exp.(A)), Float64) # representative for _unary_nz2nz_z2nz class
+    @test isa(eltype(sin.(A)), Float64) # representative for _unary_nz2z_z2z class
+end


### PR DESCRIPTION
Without this PR

``` julia
julia> sin.(spdiagm(1:4))
ERROR: InexactError()
 in convert(::Type{Int64}, ::Float64) at ./float.jl:637
 in _broadcast_unary_nz2z_z2z_T(::Base.#sin, ::SparseMatrixCSC{Int64,Int64}, ::Type{Int64}) at ./sparse/sparsematrix.jl:1425
 in broadcast(::Base.#sin, ::SparseMatrixCSC{Int64,Int64}) at ./sparse/sparsematrix.jl:1403
```

whereas with this PR

``` julia
julia> sin.(spdiagm(1:4))
4×4 sparse matrix with 4 Float64 nonzero entries:
        [1, 1]  =  0.841471
        [2, 2]  =  0.909297
        [3, 3]  =  0.14112
        [4, 4]  =  -0.756802
```

Best!
