### PR TITLE
Fix another IRBuilder InsertionPoint leak.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3854,6 +3854,9 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     else
         builder.CreateRet(r);
 
+    builder.SetCurrentDebugLocation(noDbg);
+    builder.ClearInsertionPoint();
+
     jl_finalize_module(M, true);
 
     return cw_proto;


### PR DESCRIPTION
Similar to #18054. The `builder` used in `gen_cfun_wrapper` sets but doesn't clear its insertion point, which can get destroyed during finalization. When doing `old = builder.GetInsertionPoint(); emit_whatever(); builder.SetInsertionPoint(old)` later on, LLVM reads from that invalid memory.
