### PR TITLE
Automatically detect ifunc support in the compiler

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -893,6 +893,11 @@ endif
 
 ifeq ($(OS), Linux)
 OSLIBS += -Wl,--no-as-needed -ldl -lrt -lpthread -Wl,--export-dynamic,--as-needed,--no-whole-archive $(LIBUNWIND)
+# Detect if ifunc is supported
+IFUNC_DETECT_SRC := 'void (*f0(void))(void) { return (void(*)(void))0L; }; void f(void) __attribute__((ifunc("f0")));'
+ifeq (supported, $(shell echo $(IFUNC_DETECT_SRC) | $(CC) -Werror -x c - -S -o /dev/null > /dev/null 2>&1 && echo supported))
+JCPPFLAGS += -DJULIA_HAS_IFUNC_SUPPORT=1
+endif
 ifneq ($(SANITIZE),1)
 ifneq ($(SANITIZE_MEMORY),1)
 ifneq ($(LLVM_SANITIZE),1)


### PR DESCRIPTION
Apparently this can be enabled or disabled at gcc compile time and there's no obvious way to detect this in the C code. glibc 2.13 also doesn't seem to support it on ARM while 2.18 does.

This effectively implements a `try_compile`.... Oh well...
