### PR TITLE
Disable profile test on ARM by default

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,6 +35,13 @@ function choosetests(choices = [])
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant"
     ]
+    profile_skipped = false
+    if startswith(string(Sys.ARCH), "arm")
+        # Remove profile from default tests on ARM since it currently segfaults
+        # Allow explicitly adding it for testing
+        filter!(x -> (x != "profile"), testnames)
+        profile_skipped = true
+    end
 
     if Base.USE_GPL_LIBS
         testnames = [testnames, "fft", "dsp"; ]
@@ -58,6 +65,9 @@ function choosetests(choices = [])
 
     if tests == ["all"] || isempty(tests)
         tests = testnames
+        if profile_skipped
+            warn("profile test skipped")
+        end
     end
 
     datestests = ["dates/accessors", "dates/adjusters", "dates/query",

--- a/test/core.jl
+++ b/test/core.jl
@@ -3739,7 +3739,8 @@ end
 
 # issue #13229
 module I13229
-    using Base.Test
+using Base.Test
+if !startswith(string(Sys.ARCH), "arm")
     global z = 0
     @timed @profile for i = 1:5
         function f(x)
@@ -3748,6 +3749,9 @@ module I13229
         global z = f(i)
     end
     @test z == 10
+else
+    warn("@profile test skipped")
+end
 end
 
 # issue #15186


### PR DESCRIPTION
It's known to SegFault sometimes. All other tests should pass on ARM now.
