### PR TITLE
Implement BitArray construction from iterables

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -265,7 +265,7 @@ end
 Broadcasts the arrays, tuples and/or scalars `As` to a container of the
 appropriate type and dimensions. In this context, anything that is not a
 subtype of `AbstractArray` or `Tuple` is considered a scalar. The resulting
-container is stablished by the following rules:
+container is established by the following rules:
 
  - If all the arguments are scalars, it returns a scalar.
  - If the arguments are tuples and zero or more scalars, it returns a tuple.

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -3,7 +3,8 @@
 module Broadcast
 
 using Base.Cartesian
-using Base: promote_eltype_op, @get!, _msk_end, unsafe_bitgetindex, linearindices, tail, OneTo, to_shape
+using Base: promote_eltype_op, linearindices, tail, OneTo, to_shape,
+            _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache
 import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^
 import Base: broadcast
 export broadcast!, bitbroadcast, dotview
@@ -118,13 +119,6 @@ map_newindexer(shape, ::Tuple{}) = (), ()
     keep, Idefault = newindexer(shape, A1)
     (keep, keeps...), (Idefault, Idefaults...)
 end
-
-# For output BitArrays
-const bitcache_chunks = 64 # this can be changed
-const bitcache_size = 64 * bitcache_chunks # do not change this
-
-dumpbitcache(Bc::Vector{UInt64}, bind::Int, C::Vector{Bool}) =
-    Base.copy_to_bitarray_chunks!(Bc, ((bind - 1) << 6) + 1, C, 1, min(bitcache_size, (length(Bc)-bind+1) << 6))
 
 @inline _broadcast_getindex(A, I) = _broadcast_getindex(containertype(A), A, I)
 @inline _broadcast_getindex(::Type{Any}, A, I) = A

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -606,7 +606,7 @@ All mathematical operations and functions are supported for arrays
 
    .. Docstring generated from Julia source
 
-   Broadcasts the arrays, tuples and/or scalars ``As`` to a container of the appropriate type and dimensions. In this context, anything that is not a subtype of ``AbstractArray`` or ``Tuple`` is considered a scalar. The resulting container is stablished by the following rules:
+   Broadcasts the arrays, tuples and/or scalars ``As`` to a container of the appropriate type and dimensions. In this context, anything that is not a subtype of ``AbstractArray`` or ``Tuple`` is considered a scalar. The resulting container is established by the following rules:
 
    * If all the arguments are scalars, it returns a scalar.
    * If the arguments are tuples and zero or more scalars, it returns a tuple.

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -461,7 +461,7 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Equivalent to ``!is(x, y)``\ .
+   Equivalent to ``!(x === y)``\ .
 
 .. _<:
 .. function:: <(x, y)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -132,6 +132,18 @@ end
 
 timesofar("utils")
 
+## Constructors from iterables ##
+
+for g in ((x%7==3 for x = 1:v1),
+          (x%7==3 for x = 1:v1 if x>5),
+          ((x+y)%5==2 for x = 1:n1, y = 1:n2),
+          ((x+y+z+t)%5==2 for x = 1:s2, y = 1:s2, z = 1:s3, t = 1:s4),
+          ((x+y)%5==2 for x = 1:n1 for y = 1:n2))
+    @test BitArray(g) == BitArray(collect(g))
+end
+
+timesofar("constructors")
+
 ## Indexing ##
 
 # 0d


### PR DESCRIPTION
In particular, can now use generators, e.g. `BitArray(isodd(x) for x = 1:20)` and similar.
Fixes #3166.
