### PR TITLE
Show deprecation warning module when lineinfo n/a

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-JULIAHOME = $(abspath ..)
+JULIAHOME := $(abspath ..)
 include $(JULIAHOME)/Make.inc
 
 FLAGS = -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -534,7 +534,7 @@
                   #\newline
                   (if *deperror* "ERROR:" "WARNING:") " deprecated syntax \"" what "\""
                   (if (or (not s) (eq? current-filename 'none))
-                      ""
+                      (string " in module: " (deparse (current-julia-module)))
                       (string " at " current-filename ":" (input-port-line (if (port? s) s (ts:port s)))))
                   "."
                   (if (equal? instead "")


### PR DESCRIPTION
> [Showing the module name is a good idea. That should be much easier.](https://github.com/JuliaLang/julia/issues/16967#issuecomment-238298982)

For #16967: show module name with syntax deprecation warning if lineinfo is not available.

Second commit fixes the embedding `Makefile` to get rid of a `cowardly refusing ...` build error.
