### PR TITLE
remove redundant assignments in generated function bodies

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2999,9 +2999,9 @@ f(x) = yt(x)
                      ,(if exists
                           '(null)
                           (convert-assignment name mk-closure fname lam interp)))))))
-          ((lambda)  ;; should only happen inside (thunk ...)
+          ((lambda)  ;; happens inside (thunk ...) and generated function bodies
 	   (for-each (lambda (vi) (vinfo:set-asgn! vi #t))
-		     (car (lam:vinfo e)))
+		     (list-tail (car (lam:vinfo e)) (length (lam:args e))))
            `(lambda ,(cadr e)
               (,(clear-capture-bits (car (lam:vinfo e)))
                () ,@(cddr (lam:vinfo e)))


### PR DESCRIPTION
This was causing us to emit a copy+assignment for each argument of a generated function, `x=x; y=y; ...`.  It doesn't really matter, except when one of these functions is compiled without optimizations, causing us to access and assign a variable that the front end thought was unused.
