### PR TITLE
fetch is a noop when on the same worker

### DIFF
--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -80,8 +80,16 @@ you read from a remote object to obtain data needed by the next local operation.
 but is more efficient.
 
 ```julia-repl
-julia> remotecall_fetch(getindex, 2, r, 1, 1)
+julia> remotecall_fetch(r-> fetch(r)[1, 1], 2, r)
 0.18526337335308085
+```
+
+This fetches the array on worker 2 and returns the first value. Note, that `fetch` doesn't move any data in
+this case, since it's executed on the worker that owns the array. One can also write:
+
+```julia-repl
+julia> remotecall_fetch(getindex, 2, r, 1, 1)
+0.10824216411304866
 ```
 
 Remember that [`getindex(r,1,1)`](@ref) is [equivalent](@ref man-array-indexing) to `r[1,1]`, so this call fetches


### PR DESCRIPTION
I was quite confused by this example, since I didn't realize that there is a `getindex(f::Future, args...) = getindex(fetch(f), args...)`. 
Because of this I misinterpreted the example (my first conclusion: `remote_call` must magically unpack the `Future`). 
Also, it didn't really make clear, that fetch turns into a noop if applied to a `Future` from the same worker.
I tried to add this information in a concise way. 
If I failed at this, it'd be nice if someone else could rewrite this text ;)
