### PR TITLE
Make sparse ldltfact work for larger indefinite matrices

### DIFF
--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1340,14 +1340,8 @@ cholfact{T<:Real}(A::Union{SparseMatrixCSC{T}, SparseMatrixCSC{Complex{T}},
 function ldltfact!{Tv}(F::Factor{Tv}, A::Sparse{Tv}; shift::Real=0.0)
     cm = common()
 
-    # Makes it an LDLt
-    unsafe_store!(common_final_ll, 0)
-
     # Compute the numerical factorization
     factorize_p!(A, shift, F, cm)
-
-    # Really make sure it's an LDLt by avoiding supernodal factorisation
-    unsafe_store!(common_supernodal, 0)
 
     s = unsafe_load(get(F.p))
     s.minor < size(A, 1) && throw(Base.LinAlg.ArgumentError("matrix has one or more zero pivots"))
@@ -1383,6 +1377,11 @@ function ldltfact(A::Sparse; shift::Real=0.0,
 
     cm = defaults(common())
     set_print_level(cm, 0)
+
+    # Makes it an LDLt
+    unsafe_store!(common_final_ll, 0)
+    # Really make sure it's an LDLt by avoiding supernodal factorisation
+    unsafe_store!(common_supernodal, 0)
 
     # Compute the symbolic factorization
     F = fact_(A, cm; perm = perm)

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -660,3 +660,13 @@ A = sprandn(5,5,0.4) |> t -> t't + I
 B = complex(randn(5,2), randn(5,2))
 @test cholfact(A)\B ≈ A\B
 
+# Make sure that ldltfact performs an LDLt (Issue #19032)
+let m = 400, n = 500
+    A = sprandn(m, n, .2)
+    M = [speye(n) A'; A -speye(m)]
+    b = M*ones(m + n)
+    F = ldltfact(M)
+    s = unsafe_load(get(F.p))
+    @test s.is_super == 0
+    @test F\b ≈ ones(m + n)
+end


### PR DESCRIPTION
The setting for LDLt had ended up right before the numerical factorization
instead of the symbolic so CHOLMOD tried to do a supernodal factorization
on indefinite matrices which fails. Problem discovered in JuliaLang/LinearAlgebra.jl#378
