### PR TITLE
RFC: CodegenParams for external language implementations

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -457,7 +457,7 @@ STATIC_INLINE jl_value_t *jl_call_staged(jl_svec_t *sparam_vals, jl_method_insta
     fptr.fptr = generator->fptr;
     fptr.jlcall_api = generator->jlcall_api;
     if (__unlikely(fptr.fptr == NULL || fptr.jlcall_api == 0)) {
-        void *F = jl_compile_linfo(generator, (jl_code_info_t*)generator->inferred).functionObject;
+        void *F = jl_compile_linfo(generator, (jl_code_info_t*)generator->inferred, &jl_default_cgparams).functionObject;
         fptr = jl_generate_fptr(generator, F);
     }
     assert(jl_svec_len(generator->def->sparam_syms) == jl_svec_len(sparam_vals));

--- a/src/gf.c
+++ b/src/gf.c
@@ -1261,7 +1261,7 @@ jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t *li)
     decls = li->functionObjectsDecls;
     if (decls.functionObject != NULL || li->jlcall_api == 2)
         return decls;
-    return jl_compile_linfo(li, src);
+    return jl_compile_linfo(li, src, &jl_default_cgparams);
 }
 
 // compile-time method lookup
@@ -1310,7 +1310,7 @@ JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
     if (jl_is_uninferred(li))
         src = jl_type_infer(li, 0);
     if (li->jlcall_api != 2)
-        jl_compile_linfo(li, src);
+        jl_compile_linfo(li, src, &jl_default_cgparams);
     return 1;
 }
 
@@ -1550,7 +1550,7 @@ static void _compile_all_deq(jl_array_t *found)
                 linfo->fptr = (jl_fptr_t)(uintptr_t)-1;
         }
         else {
-            jl_compile_linfo(linfo, src);
+            jl_compile_linfo(linfo, src, &jl_default_cgparams);
             assert(linfo->functionObjectsDecls.functionObject != NULL);
         }
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -68,6 +68,8 @@ JL_DLLEXPORT jl_value_t *jl_emptytuple=NULL;
 jl_svec_t *jl_emptysvec;
 jl_value_t *jl_nothing;
 
+jl_cgparams_t jl_default_cgparams;
+
 // --- type properties and predicates ---
 
 STATIC_INLINE int is_unspec(jl_datatype_t *dt)
@@ -3530,6 +3532,8 @@ void jl_init_types(void)
     jl_type_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Type"), jl_any_type, jl_emptysvec);
     jl_type_type_mt = jl_new_method_table(jl_type_type->name->name, ptls->current_module);
     jl_type_type->name->mt = jl_type_type_mt;
+
+    jl_default_cgparams = (jl_cgparams_t){1, 1, 1, 1, 1, 1, 1};
 
     // initialize them. lots of cycles.
     jl_datatype_type->name = jl_new_typename(jl_symbol("DataType"));

--- a/src/julia.h
+++ b/src/julia.h
@@ -1754,6 +1754,22 @@ typedef struct {
 #define jl_exception_in_transit (jl_get_ptls_states()->exception_in_transit)
 #define jl_task_arg_in_transit (jl_get_ptls_states()->task_arg_in_transit)
 
+
+// codegen interface ----------------------------------------------------------
+
+typedef struct {
+    int cached;             // can the compiler use/populate the compilation cache?
+
+    // language features (C-style integer booleans)
+    int runtime;            // can we call into the runtime?
+    int exceptions;         // are exceptions supported (requires runtime)?
+    int track_allocations;  // can we track allocations (don't if disallowed)?
+    int code_coverage;      // can we measure coverage (don't if disallowed)?
+    int static_alloc;       // is the compiler allowed to allocate statically?
+    int dynamic_alloc;      // is the compiler allowed to allocate dynamically (requires runtime)?
+} jl_cgparams_t;
+extern JL_DLLEXPORT jl_cgparams_t jl_default_cgparams;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -188,7 +188,7 @@ STATIC_INLINE void *jl_gc_alloc_buf(jl_ptls_t ptls, size_t sz)
 
 jl_code_info_t *jl_type_infer(jl_method_instance_t *li, int force);
 jl_generic_fptr_t jl_generate_fptr(jl_method_instance_t *li, void *F);
-jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t *li, jl_code_info_t *src);
+jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t *li, jl_code_info_t *src, jl_cgparams_t *params);
 jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t *li);
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
 jl_code_info_t *jl_new_code_info_from_ast(jl_expr_t *ast);


### PR DESCRIPTION
Part of #18338, codegen counterpart to #18496. Used in [CUDAnative.jl](https://github.com/JuliaGPU/CUDAnative.jl/blob/38e819c41d2e8b7cf72fb6344fe922f82ca90fb9/src/jit.jl#L67-L75).


## What

This PR adds a `CodegenParams` struct containing parameters influencing how code is generated (surprise surprise). For now, it is only accepted as an argument to reflection entry-points (ie. `_dump_function`). The struct contains two types of fields:
- 'regular' parameters, for now only `cached`
- language feature parameters, enabling/disabling parts of the language

In addition, this PR also adds an `optimized` flag to `_dump_function` to dump IR, and adds a reference to the current line number for better error reporting (still need to rethink this one).


## Why

The goal of the `cached` parameter is not to reuse from / pollute the cache with functions that have previously been compiled, because those functions might have been compiled with different parameters, or might already be registered with the Host EE in which case we'll just get a pointer.

The language feature parameters make sure we generate valid, GPU compatible IR, and generate a somewhat useful error message if we don't.


## How

For us to use this functionality, there's some missing pieces still: codegen hooks (again, cfr. the inference hooks I've proposed in #18338). These allow overriding certain codegen functionality, eg. `module_setup` (create module with data layout, DWARF version) or `module_activation` (CPU: register with EE, active DI; GPU: collect IR, link and mcgen afterwards).

We could also generalize these hooks to replace the language features struct, eg. `hooks.dynamic_alloc = throw()`.


## Plan

Everything in this PR is up for discussion, but it's kind of the functionality I think I need to support GPU compilation. Nonetheless, I'd prefer to have it part of `master` (albeit undocumented/unsupported) and iterate on it from there on. This makes it much easier for people to try and use our GPU support, at which point we'll probably get to understand how to improve CUDAnative.jl and its interface with the compiler.

Also, keeping up with `master` is [annoying](https://github.com/JuliaLang/julia/compare/master...JuliaGPU:master).

cc @JeffBezanson @vtjnash @Keno @yuyichao @vchuravy
