### PR TITLE
asyncmap retains shape. Closes #18500  

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -209,8 +209,8 @@ function next(itr::AsyncGenerator, state::AsyncGeneratorState)
     return (r, state)
 end
 
-iteratorsize(::Type{AsyncGenerator}) = SizeUnknown()
-
+iteratorsize(itr::AsyncGenerator) = iteratorsize(itr.collector.enumerator)
+size(itr::AsyncGenerator) = size(itr.collector.enumerator)
 
 """
     asyncmap(f, c...) -> collection

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -61,6 +61,21 @@ results=[]
 end
 @test sum(results) == 15
 
+# Test channel iterator with done() being called multiple times
+# This needs to be explicitly tested since `take!` is called
+# in `done()` and not `next()`
+c=Channel(32); foreach(i->put!(c,i), 1:10); close(c)
+s=start(c)
+@test done(c,s) == false
+res = Int[]
+while !done(c,s)
+    @test done(c,s) == false
+    v,s = next(c,s)
+    push!(res,v)
+end
+@test res == Int[1:10...]
+
+
 # Testing timedwait on multiple channels
 @sync begin
     rr1 = Channel(1)

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -777,6 +777,18 @@ end
 # Test asyncmap
 @test allunique(asyncmap(x->(sleep(1.0);object_id(current_task())), 1:10))
 
+# check whether shape is retained
+a=rand(2,2)
+b=asyncmap(identity, a)
+@test a == b
+@test size(a) == size(b)
+
+# check with an iterator that does not implement size()
+c=Channel(32); foreach(i->put!(c,i), 1:10); close(c)
+b=asyncmap(identity, c)
+@test Int[1:10...] == b
+@test size(b) == (10,)
+
 # CachingPool tests
 wp = CachingPool(workers())
 @test [1:100...] == pmap(wp, x->x, 1:100)


### PR DESCRIPTION
Also fixes a bug in the channel iterator that was triggered by `asyncmap` on a channel.
