### PR TITLE
Fix shlib build of llvm with cmake

### DIFF
--- a/deps/llvm-ver.make
+++ b/deps/llvm-ver.make
@@ -11,7 +11,7 @@ ifeq ($(LLVM_VER_PATCH),)
 LLVM_VER_PATCH := 0
 endif
 
-ifeq ($(LLVM_VER_SHORT),$(filter $(LLVM_VER_SHORT),3.3 3.4 3.5 3.6 3.7 3.8))
+ifeq ($(LLVM_VER_SHORT),$(filter $(LLVM_VER_SHORT),3.3 3.4 3.5 3.6 3.7))
 LLVM_USE_CMAKE := 0
 else
 LLVM_USE_CMAKE := 1

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -450,6 +450,7 @@ $(eval $(call LLVM_PATCH,llvm-3.7.1_3)) # Remove for 3.9
 $(eval $(call LLVM_PATCH,llvm-D14260))
 $(eval $(call LLVM_PATCH,llvm-3.8.0_bindir)) # Remove for 3.9
 $(eval $(call LLVM_PATCH,llvm-3.8.0_winshlib)) # Remove for 3.9
+$(eval $(call LLVM_PATCH,llvm-D25865-cmakeshlib))
 $(eval $(call LLVM_PATCH,llvm-nodllalias)) # Remove for 3.9
 # Cygwin and openSUSE still use win32-threads mingw, https://llvm.org/bugs/show_bug.cgi?id=26365
 $(eval $(call LLVM_PATCH,llvm-3.8.0_threads))
@@ -469,6 +470,7 @@ $(eval $(call LLVM_PATCH,llvm-rL279933-ppc-atomicrmw-lowering)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-PR22923)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-r282182)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-arm-fix-prel31))
+$(eval $(call LLVM_PATCH,llvm-D25865-cmakeshlib))
 endif # LLVM_VER
 
 ifeq ($(LLVM_VER),3.7.1)

--- a/deps/patches/llvm-D25865-cmakeshlib.patch
+++ b/deps/patches/llvm-D25865-cmakeshlib.patch
@@ -1,0 +1,83 @@
+From 417001588d232151050db2d32df443e2d073ebbf Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 21 Oct 2016 17:25:04 +0900
+Subject: [PATCH] Fix llvm-shlib cmake build
+
+Summary:
+This fixes a few things that used to work with a Makefile build, but were broken in cmake.
+
+1. Treat MINGW like a Linux system.
+2. The shlib should never contain other shared libraries.
+
+Subscribers: beanz, mgorny
+
+Differential Revision: https://reviews.llvm.org/D25865
+---
+ tools/llvm-shlib/CMakeLists.txt | 42 ++++++++++++++++++++---------------------
+ 1 file changed, 20 insertions(+), 22 deletions(-)
+
+diff --git a/tools/llvm-shlib/CMakeLists.txt b/tools/llvm-shlib/CMakeLists.txt
+index 3fe672d..edadb82 100644
+--- a/tools/llvm-shlib/CMakeLists.txt
++++ b/tools/llvm-shlib/CMakeLists.txt
+@@ -8,29 +8,27 @@ set(SOURCES
+ 
+ llvm_map_components_to_libnames(LIB_NAMES ${LLVM_DYLIB_COMPONENTS})
+ 
+-if(LLVM_LINK_LLVM_DYLIB)
+-  if(LLVM_DYLIB_EXPORTED_SYMBOL_FILE)
+-    message(WARNING "Using LLVM_LINK_LLVM_DYLIB with LLVM_DYLIB_EXPORTED_SYMBOL_FILE may not work. Use at your own risk.")
+-  endif()
+-
+-  # libLLVM.so should not have any dependencies on any other LLVM
+-  # shared libraries. When using the "all" pseudo-component,
+-  # LLVM_AVAILABLE_LIBS is added to the dependencies, which may
+-  # contain shared libraries (e.g. libLTO).
+-  #
+-  # Also exclude libLLVMTableGen for the following reasons:
+-  #  - it is only used by internal *-tblgen utilities;
+-  #  - it pollutes the global options space.
+-  foreach(lib ${LIB_NAMES})
+-    get_target_property(t ${lib} TYPE)
+-    if("${lib}" STREQUAL "LLVMTableGen")
+-    elseif("x${t}" STREQUAL "xSTATIC_LIBRARY")
+-      list(APPEND FILTERED_LIB_NAMES ${lib})
+-    endif()
+-  endforeach()
+-  set(LIB_NAMES ${FILTERED_LIB_NAMES})
++if(LLVM_LINK_LLVM_DYLIB AND LLVM_DYLIB_EXPORTED_SYMBOL_FILE)
++  message(WARNING "Using LLVM_LINK_LLVM_DYLIB with LLVM_DYLIB_EXPORTED_SYMBOL_FILE may not work. Use at your own risk.")
+ endif()
+ 
++# libLLVM.so should not have any dependencies on any other LLVM
++# shared libraries. When using the "all" pseudo-component,
++# LLVM_AVAILABLE_LIBS is added to the dependencies, which may
++# contain shared libraries (e.g. libLTO).
++#
++# Also exclude libLLVMTableGen for the following reasons:
++#  - it is only used by internal *-tblgen utilities;
++#  - it pollutes the global options space.
++foreach(lib ${LIB_NAMES})
++  get_target_property(t ${lib} TYPE)
++  if("${lib}" STREQUAL "LLVMTableGen")
++  elseif("x${t}" STREQUAL "xSTATIC_LIBRARY")
++    list(APPEND FILTERED_LIB_NAMES ${lib})
++  endif()
++endforeach()
++set(LIB_NAMES ${FILTERED_LIB_NAMES})
++
+ if(LLVM_DYLIB_EXPORTED_SYMBOL_FILE)
+   set(LLVM_EXPORTED_SYMBOL_FILE ${LLVM_DYLIB_EXPORTED_SYMBOL_FILE})
+   add_custom_target(libLLVMExports DEPENDS ${LLVM_EXPORTED_SYMBOL_FILE})
+@@ -39,7 +37,7 @@ endif()
+ add_llvm_library(LLVM SHARED DISABLE_LLVM_LINK_LLVM_DYLIB SONAME ${SOURCES})
+ 
+ list(REMOVE_DUPLICATES LIB_NAMES)
+-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") # FIXME: It should be "GNU ld for elf"
++if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR MINGW) # FIXME: It should be "GNU ld for elf"
+   # GNU ld doesn't resolve symbols in the version script.
+   set(LIB_NAMES -Wl,--whole-archive ${LIB_NAMES} -Wl,--no-whole-archive)
+ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+-- 
+2.10.1
+


### PR DESCRIPTION
This addresses the first two bullet-points of #19051. The difference to #18863 is that it doesn't require the `LLVM_LINK_LLVM_DYLIB` option (which would cause the tools to be linked against `libLLVM.so`, thanks to @maleadt  to pointing this out to me). The llvm patch is submitted as https://reviews.llvm.org/D25865. 
