### PR TITLE
Reattach filter's docstring

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1637,7 +1637,25 @@ end
 
 ## Filter ##
 
-# given a function returning a boolean and an array, return matching elements
+"""
+    filter(function, collection)
+
+Return a copy of `collection`, removing elements for which `function` is `false`. For
+associative collections, the function is passed two arguments (key and value).
+
+```jldocttest
+julia> a = 1:10
+1:10
+
+julia> filter(isodd, a)
+5-element Array{Int64,1}:
+ 1
+ 3
+ 5
+ 7
+ 9
+```
+"""
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
 function filter!(f, a::Vector)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -176,25 +176,6 @@ immutable Filter{F,I}
     itr::I
 end
 
-"""
-    filter(function, collection)
-
-Return a copy of `collection`, removing elements for which `function` is `false`. For
-associative collections, the function is passed two arguments (key and value).
-
-```jldocttest
-julia> a = 1:10
-1:10
-
-julia> filter(isodd, a)
-5-element Array{Int64,1}:
- 1
- 3
- 5
- 7
- 9
-```
-"""
 filter(flt, itr) = Filter(flt, itr)
 
 start(f::Filter) = start_filter(f.flt, f.itr)


### PR DESCRIPTION
#18839 moved the docstring-bearing `filter` method into module `Iterators`. Module `Iterators` does not `import` `filter` from `Base`, so `filter`'s docstring no longer attaches to `Base.filter`:

``` julia
julia> VERSION
v"0.6.0-dev.1054"

help?> filter
search: filter filter! PollingFileWatcher fieldtype

  No documentation found.

  Base.filter is a Function.

  #7 methods for generic function "filter":
  filter(f, a::Array{T<:Any,1}) at array.jl:1656
  filter(f, Bs::BitArray) at bitarray.jl:2014
  filter(f, As::AbstractArray) at array.jl:1641
  filter(f, d::Associative) at associative.jl:211
  filter(f, s::Set) at set.jl:171
  filter(f, s::AbstractString) at strings/basic.jl:449
  filter(flt, itr) at deprecated.jl:49
```

This pull request attaches `filter`'s docstring to `filter`'s `AbstractArray` fallback in base/array.jl. Best!
