### PR TITLE
Improve(?) deprecation warnings for deprecated iterators

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1025,12 +1025,15 @@ end))
 
 @deprecate_binding Filter    Iterators.Filter
 @deprecate_binding Zip       Iterators.Zip
-@deprecate filter(flt, itr)  Iterators.filter(flt, itr)
-@deprecate_binding rest      Iterators.rest
-@deprecate_binding countfrom Iterators.countfrom
-@deprecate_binding take      Iterators.take
-@deprecate_binding drop      Iterators.drop
-@deprecate_binding cycle     Iterators.cycle
-@deprecate_binding repeated  Iterators.repeated
+@deprecate take(iter, n)        Iterators.take(iter, n)
+@deprecate drop(iter, n)        Iterators.drop(iter, n)
+@deprecate cycle(iter)          Iterators.cycle(iter)
+@deprecate rest(iter, state)    Iterators.rest(iter, state)
+@deprecate filter(flt, itr)     Iterators.filter(flt, itr)
+@deprecate repeated(x)          Iterators.repeated(x)
+@deprecate repeated(x, n)       Iterators.repeated(x, n)
+@deprecate countfrom()              Iterators.countfrom()
+@deprecate countfrom(start)         Iterators.countfrom(start)
+@deprecate countfrom(start, step)   Iterators.countfrom(start, step)
 
 # End deprecations scheduled for 0.6


### PR DESCRIPTION
The deprecation warnings for `rest`, `take`, `drop`, `cycle`, `repeated`, and `countfrom` (#18839) do not point to their replacements,

``` julia
julia> VERSION
v"0.6.0-dev.1054"

julia> rest
WARNING: Base.rest is deprecated.
  likely near no file:0
rest (generic function with 1 method)

julia> countfrom
WARNING: Base.countfrom is deprecated.
  likely near no file:0
countfrom (generic function with 3 methods)

julia> take
WARNING: Base.take is deprecated.
  likely near no file:0
take (generic function with 2 methods)

julia> drop
WARNING: Base.drop is deprecated.
  likely near no file:0
drop (generic function with 3 methods)

julia> cycle
WARNING: Base.cycle is deprecated.
  likely near no file:0
cycle (generic function with 1 method)

julia> repeated
WARNING: Base.repeated is deprecated.
  likely near no file:0
repeated (generic function with 2 methods)
```

due to the relevant deprecations being `@deprecate_binding`s rather than `@deprecate`s. This pull request replaces those `@deprecate_binding`s with an expanded set of `@deprecate`s such that e.g.

``` julia
julia> repeated(3, 4)
WARNING: repeated(x,n) is deprecated, use Iterators.repeated(x,n) instead.
 in depwarn(::String, ::Symbol) at ./deprecated.jl:64
 in repeated(::Int64, ::Int64) at ./deprecated.jl:50
 in eval(::Module, ::Any) at ./boot.jl:236
 in eval(::Module, ::Any) at /Users/sacha/pkg/julia/usr/lib/julia/sys.dylib:?
 in eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 in macro expansion at ./REPL.jl:97 [inlined]
 in (::Base.REPL.##3#4{Base.REPL.REPLBackend})() at ./event.jl:65
while loading no file, in expression starting on line 0
Base.Iterators.Take{Base.Iterators.Repeated{Int64}}(Base.Iterators.Repeated{Int64}(3),4)
```

If use of `@deprecate_binding` rather than `@deprecate` was intentional, please close this pull request. Best!
