### PR TITLE
Correct line numbers in doctests

### DIFF
--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -159,7 +159,7 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``:
     julia> sqrt(-1)
     ERROR: DomainError:
     sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
-     in sqrt(::Int64) at ./math.jl:252
+     in sqrt(::Int64) at ./math.jl:278
      ...
 
     julia> sqrt(-1 + 0im)

--- a/doc/manual/constructors.rst
+++ b/doc/manual/constructors.rst
@@ -328,7 +328,7 @@ types of the arguments given to the constructor. Here are some examples:
     ERROR: MethodError: no method matching Point{T<:Real}(::Int64, ::Float64)
     Closest candidates are:
       Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real) at none:2
-      Point{T<:Real}{T}(::Any) at sysimg.jl:53
+      Point{T<:Real}{T}(::Any) at sysimg.jl:66
      ...
 
     ## explicit T ##
@@ -427,7 +427,7 @@ However, other similar calls still don't work:
     ERROR: MethodError: no method matching Point{T<:Real}(::Float64, ::Int64)
     Closest candidates are:
       Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real) at none:2
-      Point{T<:Real}{T}(::Any) at sysimg.jl:53
+      Point{T<:Real}{T}(::Any) at sysimg.jl:66
      ...
 
 For a much more general way of making all such calls work sensibly, see

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -666,7 +666,7 @@ negative real value:
     julia> sqrt(-1)
     ERROR: DomainError:
     sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
-     in sqrt(::Int64) at ./math.jl:252
+     in sqrt(::Int64) at ./math.jl:278
      ...
 
 You may define your own exceptions in the following way:

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -400,7 +400,7 @@ The following examples show the different forms.
 
     julia> Int8(128)
     ERROR: InexactError()
-     in Int8(::Int64) at ./sysimg.jl:53
+     in Int8(::Int64) at ./sysimg.jl:66
      ...
 
     julia> Int8(127.0)
@@ -408,12 +408,12 @@ The following examples show the different forms.
 
     julia> Int8(3.14)
     ERROR: InexactError()
-     in Int8(::Float64) at ./sysimg.jl:53
+     in Int8(::Float64) at ./sysimg.jl:66
      ...
 
     julia> Int8(128.0)
     ERROR: InexactError()
-     in Int8(::Float64) at ./sysimg.jl:53
+     in Int8(::Float64) at ./sysimg.jl:66
      ...
 
     julia> 127 % Int8
@@ -427,8 +427,8 @@ The following examples show the different forms.
 
     julia> round(Int8,127.6)
     ERROR: InexactError()
-     in trunc(::Type{Int8}, ::Float64) at ./float.jl:464
-     in round(::Type{Int8}, ::Float64) at ./float.jl:211
+     in trunc(::Type{Int8}, ::Float64) at ./float.jl:609
+     in round(::Type{Int8}, ::Float64) at ./float.jl:313
      ...
 
 See :ref:`man-conversion-and-promotion` for how to define your own

--- a/doc/manual/stacktraces.rst
+++ b/doc/manual/stacktraces.rst
@@ -32,7 +32,7 @@ alias :obj:`StackTrace` can be used in place of ``Vector{StackFrame}``. (Example
     julia> example()
     11-element Array{StackFrame,1}:
       in example() at none:1
-      in eval(::Module, ::Any) at boot.jl:234
+      in eval(::Module, ::Any) at boot.jl:236
       ...
 
     julia> @noinline child() = stacktrace()
@@ -74,7 +74,7 @@ Each :obj:`StackFrame` contains the function name, file name, line number, lambd
 .. doctest::
 
     julia> top_frame = stacktrace()[1]
-     in eval(::Module, ::Any) at boot.jl:234
+     in eval(::Module, ::Any) at boot.jl:236
 
     julia> top_frame.func
     :eval
@@ -83,7 +83,7 @@ Each :obj:`StackFrame` contains the function name, file name, line number, lambd
     Symbol("./boot.jl")
 
     julia> top_frame.line
-    234
+    236
 
     julia> top_frame.linfo
     Nullable{MethodInstance}(MethodInstance for eval(::Module, ::Any))
@@ -123,7 +123,7 @@ helpful in many places, the most obvious application is in error handling and de
     julia> example()
     11-element Array{StackFrame,1}:
       in example() at none:4
-      in eval(::Module, ::Any) at boot.jl:234
+      in eval(::Module, ::Any) at boot.jl:236
       ...
 
 You may notice that in the example above the first stack frame points points at line 4,

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -291,14 +291,14 @@ such an invalid byte index, an error is thrown:
     ERROR: UnicodeError: invalid character index
      in slow_utf8_next(::Array{UInt8,1}, ::UInt8, ::Int64) at ./strings/string.jl:67
      in next at ./strings/string.jl:92 [inlined]
-     in getindex(::String, ::Int64) at ./strings/basic.jl:70
+     in getindex(::String, ::Int64) at ./strings/basic.jl:71
      ...
 
     julia> s[3]
     ERROR: UnicodeError: invalid character index
      in slow_utf8_next(::Array{UInt8,1}, ::UInt8, ::Int64) at ./strings/string.jl:67
      in next at ./strings/string.jl:92 [inlined]
-     in getindex(::String, ::Int64) at ./strings/basic.jl:70
+     in getindex(::String, ::Int64) at ./strings/basic.jl:71
      ...
 
     julia> s[4]
@@ -554,7 +554,7 @@ contained in a string:
     julia> contains("Xylophon", 'o')
     ERROR: MethodError: no method matching contains(::String, ::Char)
     Closest candidates are:
-      contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:682
+      contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:640
       contains(::AbstractString, !Matched::AbstractString) at strings/search.jl:366
      ...
 

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -765,14 +765,14 @@ each field:
     ERROR: MethodError: Cannot `convert` an object of type Float64 to an object of type Point{Float64}
     This may have arisen from a call to the constructor Point{Float64}(...),
     since type constructors fall back to convert methods.
-     in Point{Float64}(::Float64) at ./sysimg.jl:53
+     in Point{Float64}(::Float64) at ./sysimg.jl:66
      ...
 
     julia> Point{Float64}(1.0,2.0,3.0)
     ERROR: MethodError: no method matching Point{Float64}(::Float64, ::Float64, ::Float64)
     Closest candidates are:
       Point{Float64}{T}(::Any, ::Any) at none:3
-      Point{Float64}{T}(::Any) at sysimg.jl:53
+      Point{Float64}{T}(::Any) at sysimg.jl:66
      ...
 
 Only one default constructor is generated for parametric types, since

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -564,7 +564,7 @@ Types
 
        julia> sizeof(Base.LinAlg.LU)
        ERROR: argument is an abstract type; size is indeterminate
-        in sizeof(::Type{T}) at ./essentials.jl:89
+        in sizeof(::Type{T}) at ./essentials.jl:99
         ...
 
 .. function:: eps(T)

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -1506,7 +1506,7 @@ Dequeues
 
        julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
        ERROR: ArgumentError: indices must be unique and sorted
-        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:727
+        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:748
         ...
 
 .. function:: splice!(a::Vector, index::Integer, [replacement]) -> item


### PR DESCRIPTION
Several doctests fail because they reference functions at incorrect line numbers. I updated line numbers to fix some of the failing doctests. Thanks!
