### PR TITLE
Better error message when URL is wrong

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -197,7 +197,11 @@ function clone(url::AbstractString, pkg::AbstractString)
         end
     catch err
         isdir(pkg) && Base.rm(pkg, recursive=true)
-        rethrow(err)
+        if isa(err, Base.LibGit2.Error.GitError) && err.msg == "Unexpected HTTP status code: 404"
+            throw(PkgError("Provided url $url is invalid"))
+        else
+            rethrow(err)
+        end
     end
     info("Computing changes...")
     if !edit(Reqs.add, pkg)


### PR DESCRIPTION
I changed the error message returned by `Pkg.clone()` when the provided url doesn't work. Thanks!

Fix #18185
