### PR TITLE
Fix compilation on LLVM 4.0

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -123,7 +123,14 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
     }
     if (jl_is_bitstype(jt)) {
         uint64_t SizeInBits = jl_datatype_nbits(jdt);
-    #if JL_LLVM_VERSION >= 30700
+    #if JL_LLVM_VERSION >= 40000
+        llvm::DIType *t = dbuilder->createBasicType(
+                jl_symbol_name(jdt->name->name),
+                SizeInBits,
+                llvm::dwarf::DW_ATE_unsigned);
+        jdt->ditype = t;
+        return t;
+    #elif JL_LLVM_VERSION >= 30700
         llvm::DIType *t = dbuilder->createBasicType(
                 jl_symbol_name(jdt->name->name),
                 SizeInBits,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4429,6 +4429,7 @@ static std::unique_ptr<Module> emit_function(jl_method_instance_t *lam, jl_code_
             jl_varinfo_t &varinfo = ctx.slots[i];
             if (varinfo.isArgument || s == compiler_temp_sym || s == unused_sym)
                 continue;
+            // LLVM 4.0: Assume the variable has default alignment
 #if JL_LLVM_VERSION >= 30800
             varinfo.dinfo = dbuilder.createAutoVariable(
 #else


### PR DESCRIPTION
The alignment attribute is removed from the type.
We should always use the default alignment for now.

Ref https://github.com/llvm-mirror/llvm/commit/e69c459a6e9756ca1ff3acb1dcfc434843aee80f

@Keno (Sorry `@Ken` that was a typo)
