### PR TITLE
Removed array of Any to improve style

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -398,7 +398,7 @@ has been introduced. Therefore it makes sense to write something like
 ``let x = x`` since the two ``x`` variables are distinct and have separate
 storage. Here is an example where the behavior of ``let`` is needed::
 
-    Fs = Array{Any}(2)
+    Fs = Array{Function}(2)
     i = 1
     while i <= 2
         Fs[i] = ()->i
@@ -416,7 +416,7 @@ However, it is always the same variable ``i``, so the two closures
 behave identically. We can use ``let`` to create a new binding for
 ``i``::
 
-    Fs = Array{Any}(2)
+    Fs = Array{Function}(2)
     i = 1
     while i <= 2
         let i = i
@@ -463,7 +463,7 @@ are freshly allocated for each loop iteration.  This is in contrast to
 iterations. Therefore these constructs are similar to ``while`` loops
 with ``let`` blocks inside::
 
-    Fs = Array{Any}(2)
+    Fs = Array{Function}(2)
     for i = 1:2
         Fs[i] = ()->i
     end


### PR DESCRIPTION
Following introduction of the `Function` type in 0.5, it is pointless to have an array of `Any`.
