### PR TITLE
Replace full(X) with Array(X)/AbstractArray(X) in (base|test)/linalg/tridiag.jl

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -19,7 +19,8 @@ end
 
 Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal,
 respectively. The result is of type `SymTridiagonal` and provides efficient specialized
-eigensolvers, but may be converted into a regular matrix with [`full`](:func:`full`).
+eigensolvers, but may be converted into a regular matrix with
+[`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
 """
 SymTridiagonal{T}(dv::Vector{T}, ev::Vector{T}) = SymTridiagonal{T}(dv, ev)
 
@@ -328,7 +329,8 @@ end
 
 Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal,
 respectively.  The result is of type `Tridiagonal` and provides efficient specialized linear
-solvers, but may be converted into a regular matrix with [`full`](:func:`full`).
+solvers, but may be converted into a regular matrix with
+[`convert(Array, _)`](:func:`convert`) (or `Array(_)` for short).
 The lengths of `dl` and `du` must be one less than the length of `d`.
 """
 # Basic constructor takes in three dense vectors of same type

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -132,7 +132,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Constructs an upper (``isupper=true``\ ) or lower (``isupper=false``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . ``ev``\ 's length must be one less than the length of ``dv``\ .
+   Constructs an upper (``isupper=true``\ ) or lower (``isupper=false``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). ``ev``\ 's length must be one less than the length of ``dv``\ .
 
    **Example**
 
@@ -147,7 +147,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Constructs an upper (``uplo='U'``\ ) or lower (``uplo='L'``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . ``ev``\ 's length must be one less than the length of ``dv``\ .
+   Constructs an upper (``uplo='U'``\ ) or lower (``uplo='L'``\ ) bidiagonal matrix using the given diagonal (``dv``\ ) and off-diagonal (``ev``\ ) vectors.  The result is of type ``Bidiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). ``ev``\ 's length must be one less than the length of ``dv``\ .
 
    **Example**
 
@@ -176,13 +176,13 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal, respectively. The result is of type ``SymTridiagonal`` and provides efficient specialized eigensolvers, but may be converted into a regular matrix with :func:`full`\ .
+   Construct a symmetric tridiagonal matrix from the diagonal and first sub/super-diagonal, respectively. The result is of type ``SymTridiagonal`` and provides efficient specialized eigensolvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short).
 
 .. function:: Tridiagonal(dl, d, du)
 
    .. Docstring generated from Julia source
 
-   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
+   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
 
 .. function:: Symmetric(A, uplo=:U)
 
@@ -1175,7 +1175,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    .. Docstring generated from Julia source
 
-   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`full`\ . The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
+   Construct a tridiagonal matrix from the first subdiagonal, diagonal, and first superdiagonal, respectively.  The result is of type ``Tridiagonal`` and provides efficient specialized linear solvers, but may be converted into a regular matrix with :func:`convert` (or ``Array(_)`` for short). The lengths of ``dl`` and ``du`` must be one less than the length of ``d``\ .
 
 .. function:: rank(M[, tol::Real])
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -42,7 +42,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
         F[i,i+1] = du[i]
         F[i+1,i] = dl[i]
     end
-    @test full(T) == F
+    @test Array(T) == F
 
     # elementary operations on tridiagonals
     @test conj(T) == Tridiagonal(conj(dl), conj(d), conj(du))
@@ -62,7 +62,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     @test Tridiagonal(dl, d, du) + Tridiagonal(du, d, dl) == SymTridiagonal(2d, dl+du)
     @test SymTridiagonal(d, dl) + Tridiagonal(dl, d, du) == Tridiagonal(dl + dl, d+d, dl+du)
     @test convert(SymTridiagonal,Tridiagonal(Ts)) == Ts
-    @test full(convert(SymTridiagonal{Complex64},Tridiagonal(Ts))) == convert(Matrix{Complex64},full(Ts))
+    @test Array(convert(SymTridiagonal{Complex64},Tridiagonal(Ts))) == convert(Matrix{Complex64}, Ts)
     if elty == Int
         vv = rand(1:100, n)
         BB = rand(1:100, n, 2)
@@ -101,7 +101,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     # symmetric tridiagonal
     if elty <: Real
         Ts = SymTridiagonal(d, dl)
-        Fs = full(Ts)
+        Fs = Array(Ts)
         Tldlt = factorize(Ts)
         @test_throws DimensionMismatch Tldlt\rand(elty,n+1)
         @test size(Tldlt) == size(Ts)
@@ -119,7 +119,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
             invFsv = Fs\vv
             x = Ts\vv
             @test x ≈ invFsv
-            @test full(full(Tldlt)) ≈ Fs
+            @test Array(AbstractArray(Tldlt)) ≈ Fs
         end
 
         # similar
@@ -237,7 +237,7 @@ let n = 12 #Size of matrix problem to test
         @test_throws ArgumentError SymTridiagonal(rand(n,n))
 
         A = SymTridiagonal(a, b)
-        fA = map(elty <: Complex ? Complex128 : Float64, full(A))
+        fA = map(elty <: Complex ? Complex128 : Float64, Array(A))
 
         debug && println("getindex")
         @test_throws BoundsError A[n+1,1]
@@ -289,10 +289,10 @@ let n = 12 #Size of matrix problem to test
         @test B - A == A - B
 
         debug && println("Multiplication with strided vector")
-        @test A*ones(n) ≈ full(A)*ones(n)
+        @test A*ones(n) ≈ Array(A)*ones(n)
 
         debug && println("Multiplication with strided matrix")
-        @test A*ones(n, 2) ≈ full(A)*ones(n, 2)
+        @test A*ones(n, 2) ≈ Array(A)*ones(n, 2)
 
         debug && println("Eigensystems")
         if elty <: Real
@@ -312,13 +312,13 @@ let n = 12 #Size of matrix problem to test
 
             debug && println("stegr! call with index range")
             F = eigfact(SymTridiagonal(a, b),1:2)
-            fF = eigfact(Symmetric(full(SymTridiagonal(a, b))),1:2)
+            fF = eigfact(Symmetric(Array(SymTridiagonal(a, b))),1:2)
             Test.test_approx_eq_modphase(F[:vectors], fF[:vectors])
             @test F[:values] ≈ fF[:values]
 
             debug && println("stegr! call with value range")
             F = eigfact(SymTridiagonal(a, b),0.0,1.0)
-            fF = eigfact(Symmetric(full(SymTridiagonal(a, b))),0.0,1.0)
+            fF = eigfact(Symmetric(Array(SymTridiagonal(a, b))),0.0,1.0)
             Test.test_approx_eq_modphase(F[:vectors], fF[:vectors])
             @test F[:values] ≈ fF[:values]
         end
@@ -332,15 +332,15 @@ let n = 12 #Size of matrix problem to test
         end
 
         B = SymTridiagonal(a, b)
-        fB = map(elty <: Complex ? Complex128 : Float64, full(B))
+        fB = map(elty <: Complex ? Complex128 : Float64, Array(B))
 
         for op in (+, -, *)
-            @test full(op(A, B)) ≈ op(fA, fB)
+            @test Array(op(A, B)) ≈ op(fA, fB)
         end
         α = rand(elty)
-        @test full(α*A) ≈ α*full(A)
-        @test full(A*α) ≈ full(A)*α
-        @test full(A/α) ≈ full(A)/α
+        @test Array(α*A) ≈ α*Array(A)
+        @test Array(A*α) ≈ Array(A)*α
+        @test Array(A/α) ≈ Array(A)/α
 
         debug && println("A_mul_B!")
         @test_throws DimensionMismatch A_mul_B!(zeros(elty,n,n),B,ones(elty,n+1,n))
@@ -363,7 +363,7 @@ let n = 12 #Size of matrix problem to test
 
         @test_throws ArgumentError Tridiagonal(a,a,a)
         A = Tridiagonal(a, b, c)
-        fA = map(elty <: Complex ? Complex128 : Float64, full(A))
+        fA = map(elty <: Complex ? Complex128 : Float64, Array(A))
 
         debug && println("Similar, size, and copy!")
         B = similar(A)
@@ -411,22 +411,22 @@ let n = 12 #Size of matrix problem to test
         end
 
         debug && println("Multiplication with strided vector")
-        @test A*ones(n) ≈ full(A)*ones(n)
+        @test A*ones(n) ≈ Array(A)*ones(n)
 
         debug && println("Multiplication with strided matrix")
-        @test A*ones(n, 2) ≈ full(A)*ones(n, 2)
+        @test A*ones(n, 2) ≈ Array(A)*ones(n, 2)
 
 
         B = Tridiagonal(a, b, c)
-        fB = map(elty <: Complex ? Complex128 : Float64, full(B))
+        fB = map(elty <: Complex ? Complex128 : Float64, Array(B))
 
         for op in (+, -, *)
-            @test full(op(A, B)) ≈ op(fA, fB)
+            @test Array(op(A, B)) ≈ op(fA, fB)
         end
         α = rand(elty)
-        @test full(α*A) ≈ α*full(A)
-        @test full(A*α) ≈ full(A)*α
-        @test full(A/α) ≈ full(A)/α
+        @test Array(α*A) ≈ α*Array(A)
+        @test Array(A*α) ≈ Array(A)*α
+        @test Array(A/α) ≈ Array(A)/α
 
         @test_throws ArgumentError convert(SymTridiagonal{elty},A)
 


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/pull/18850#issuecomment-254922199. This pull request replaces `full(X)` with `Array(X)`/`AbstractArray(X)` as appropriate in base/linalg/tridiag.jl and test/linalg/tridiag.jl. None of these replacements should be controversial. Best!
