### PR TITLE
Replace full(X) with Array(X)/AbstractArray(X) in lapack, matmul, and spqr tests

### DIFF
--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -52,7 +52,7 @@ end
             d, e = convert(Vector{elty}, randn(n)), convert(Vector{elty}, randn(n - 1))
             U, Vt, C = eye(elty, n), eye(elty, n), eye(elty, n)
             s, _ = LAPACK.bdsqr!('U', copy(d), copy(e), Vt, U, C)
-            @test full(Bidiagonal(d, e, true)) ≈ U*Diagonal(s)*Vt
+            @test Array(Bidiagonal(d, e, true)) ≈ U*Diagonal(s)*Vt
 
             @test_throws ArgumentError LAPACK.bdsqr!('A', d, e, Vt, U, C)
             @test_throws DimensionMismatch LAPACK.bdsqr!('U', d, [e; 1], Vt, U, C)

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -336,7 +336,7 @@ A = [RootInt(3) RootInt(5)]
 
 function test_mul(C, A, B)
     A_mul_B!(C, A, B)
-    @test full(A) * full(B) ≈ C
+    @test Array(A) * Array(B) ≈ C
     @test A*B ≈ C
 end
 

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -23,8 +23,8 @@ for eltyA in (Float64, Complex{Float64})
         end
 
         @inferred A\B
-        @test A\B[:,1] ≈ full(A)\B[:,1]
-        @test A\B ≈ full(A)\B
+        @test A\B[:,1] ≈ Array(A)\B[:,1]
+        @test A\B ≈ Array(A)\B
         @test_throws DimensionMismatch A\B[1:m-1,:]
         @test A[1:9,:]*(A[1:9,:]\ones(eltyB, 9)) ≈ ones(9) # Underdetermined system
 


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/pull/18850#issuecomment-254922199. This pull request replaces `full(X)` with `Array(X)`/`AbstractArray(X)` as appropriate in test/linalg/lapack.jl, test/linalg/matmul.jl, and test/sparse/spqr.jl. None of these replacements should be controversial. Best!
