### PR TITLE
Replace full(X) with AbstractArray(X) in test/linalg/(schur|svd).jl

### DIFF
--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -35,7 +35,7 @@ aimg  = randn(n,n)/2
         @test sort(real(f[:values])) ≈ sort(real(d))
         @test sort(imag(f[:values])) ≈ sort(imag(d))
         @test istriu(f[:Schur]) || eltype(a)<:Real
-        @test full(f) ≈ a
+        @test AbstractArray(f) ≈ a
         @test_throws KeyError f[:A]
 
         @testset "Reorder Schur" begin

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -36,7 +36,7 @@ a2img  = randn(n,n)/2
         @testset "singular value decomposition" begin
             @test usv[:S] === svdvals(usv)
             @test usv[:U] * (Diagonal(usv[:S]) * usv[:Vt]) ≈ a
-            @test full(usv) ≈ a
+            @test AbstractArray(usv) ≈ a
             @test usv[:Vt]' ≈ usv[:V]
             @test_throws KeyError usv[:Z]
             b = rand(eltya,n)


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/pull/18850#issuecomment-254922199. This pull request replaces `full(X)` with `AbstractArray(X)` in test/linalg/schur.jl and test/linalg/svd.jl. These replacements should not be controversial. Best!
