### PR TITLE
Rename internal reduced_dims->reduced_indices to reflect new output type

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -193,7 +193,7 @@ function isassigned(a::AbstractArray, i::Int...)
 end
 
 # used to compute "end" for last index
-function trailingsize(A::AbstractArray, n)
+function trailingsize(A, n)
     s = 1
     for i=n:ndims(A)
         s *= size(A,i)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1044,7 +1044,7 @@ function reduced_dims(::Tuple{}, d::Int)
 end
 reduced_dims(::Tuple{}, region) = ()
 function reduced_dims(dims::Dims, region)
-    Base.depwarn("`reduced_dims` is deprecated for Dims-tuples; pass `indices` instead", :reduced_dims)
+    Base.depwarn("`reduced_dims` is deprecated for Dims-tuples; pass `indices` to `reduced_indices` instead", :reduced_dims)
     map(last, reduced_dims(map(n->OneTo(n), dims), region))
 end
 
@@ -1054,8 +1054,18 @@ function reduced_dims0(::Tuple{}, d::Int)
 end
 reduced_dims0(::Tuple{}, region) = ()
 function reduced_dims0(dims::Dims, region)
-    Base.depwarn("`reduced_dims0` is deprecated for Dims-tuples; pass `indices` instead", :reduced_dims0)
+    Base.depwarn("`reduced_dims0` is deprecated for Dims-tuples; pass `indices` to `reduced_indices0` instead", :reduced_dims0)
     map(last, reduced_dims0(map(n->OneTo(n), dims), region))
+end
+
+function reduced_dims(a::AbstractArray, region)
+    Base.depwarn("`reduced_dims` is deprecated in favor of `reduced_indices`", :reduced_dims)
+    to_shape(reduced_indices(a, region))  # to_shape keeps the return-type consistent, when it's possible to do so
+end
+
+function reduced_dims0(a::AbstractArray, region)
+    Base.depwarn("`reduced_dims0` is deprecated in favor of `reduced_indices0`", :reduced_dims)
+    to_shape(reduced_indices0(a, region))
 end
 
 # #18218

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -3,12 +3,12 @@
 ## Functions to compute the reduced shape
 
 # for reductions that expand 0 dims to 1
-reduced_dims(a::AbstractArray, region) = reduced_dims(indices(a), region)
+reduced_indices(a::AbstractArray, region) = reduced_indices(indices(a), region)
 
 # for reductions that keep 0 dims as 0
-reduced_dims0(a::AbstractArray, region) = reduced_dims0(indices(a), region)
+reduced_indices0(a::AbstractArray, region) = reduced_indices0(indices(a), region)
 
-function reduced_dims{N}(inds::Indices{N}, d::Int, rd::AbstractUnitRange)
+function reduced_indices{N}(inds::Indices{N}, d::Int, rd::AbstractUnitRange)
     d < 1 && throw(ArgumentError("dimension must be ≥ 1, got $d"))
     if d == 1
         return (oftype(inds[1], rd), tail(inds)...)
@@ -18,18 +18,18 @@ function reduced_dims{N}(inds::Indices{N}, d::Int, rd::AbstractUnitRange)
         return inds
     end
 end
-reduced_dims{N}(inds::Indices{N}, d::Int) = reduced_dims(inds, d, OneTo(1))
+reduced_indices{N}(inds::Indices{N}, d::Int) = reduced_indices(inds, d, OneTo(1))
 
-function reduced_dims0{N}(inds::Indices{N}, d::Int)
+function reduced_indices0{N}(inds::Indices{N}, d::Int)
     d < 1 && throw(ArgumentError("dimension must be ≥ 1, got $d"))
     if d <= N
-        return reduced_dims(inds, d, (inds[d] == OneTo(0) ? OneTo(0) : OneTo(1)))
+        return reduced_indices(inds, d, (inds[d] == OneTo(0) ? OneTo(0) : OneTo(1)))
     else
         return inds
     end
 end
 
-function reduced_dims{N}(inds::Indices{N}, region)
+function reduced_indices{N}(inds::Indices{N}, region)
     rinds = [inds...]
     for i in region
         isa(i, Integer) || throw(ArgumentError("reduced dimension(s) must be integers"))
@@ -43,7 +43,7 @@ function reduced_dims{N}(inds::Indices{N}, region)
     tuple(rinds...)::typeof(inds)
 end
 
-function reduced_dims0{N}(inds::Indices{N}, region)
+function reduced_indices0{N}(inds::Indices{N}, region)
     rinds = [inds...]
     for i in region
         isa(i, Integer) || throw(ArgumentError("reduced dimension(s) must be integers"))
@@ -70,10 +70,10 @@ for (Op, initval) in ((:(typeof(&)), true), (:(typeof(|)), false))
     @eval initarray!(a::AbstractArray, ::$(Op), init::Bool) = (init && fill!(a, $initval); a)
 end
 
-reducedim_initarray{R}(A::AbstractArray, region, v0, ::Type{R}) = fill!(similar(A,R,reduced_dims(A,region)), v0)
+reducedim_initarray{R}(A::AbstractArray, region, v0, ::Type{R}) = fill!(similar(A,R,reduced_indices(A,region)), v0)
 reducedim_initarray{T}(A::AbstractArray, region, v0::T) = reducedim_initarray(A, region, v0, T)
 
-reducedim_initarray0{R}(A::AbstractArray, region, v0, ::Type{R}) = fill!(similar(A,R,reduced_dims0(A,region)), v0)
+reducedim_initarray0{R}(A::AbstractArray, region, v0, ::Type{R}) = fill!(similar(A,R,reduced_indices0(A,region)), v0)
 reducedim_initarray0{T}(A::AbstractArray, region, v0::T) = reducedim_initarray0(A, region, v0, T)
 
 # TODO: better way to handle reducedim initialization
@@ -375,11 +375,11 @@ For an array input, returns the value and index of the minimum over the given re
 """
 function findmin{T}(A::AbstractArray{T}, region)
     if isempty(A)
-        return (similar(A, reduced_dims0(A, region)),
-                similar(dims->zeros(Int, dims), reduced_dims0(A, region)))
+        return (similar(A, reduced_indices0(A, region)),
+                similar(dims->zeros(Int, dims), reduced_indices0(A, region)))
     end
     return findminmax!(<, reducedim_initarray0(A, region, typemax(T)),
-            similar(dims->zeros(Int, dims), reduced_dims0(A, region)), A)
+            similar(dims->zeros(Int, dims), reduced_indices0(A, region)), A)
 end
 
 """
@@ -402,11 +402,11 @@ For an array input, returns the value and index of the maximum over the given re
 """
 function findmax{T}(A::AbstractArray{T}, region)
     if isempty(A)
-        return (similar(A, reduced_dims0(A,region)),
-                similar(dims->zeros(Int, dims), reduced_dims0(A,region)))
+        return (similar(A, reduced_indices0(A,region)),
+                similar(dims->zeros(Int, dims), reduced_indices0(A,region)))
     end
     return findminmax!(>, reducedim_initarray0(A, region, typemin(T)),
-            similar(dims->zeros(Int, dims), reduced_dims0(A, region)), A)
+            similar(dims->zeros(Int, dims), reduced_indices0(A, region)), A)
 end
 
 reducedim1(R, A) = length(indices1(R)) == 1

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1864,9 +1864,9 @@ end
 # and computing reductions along columns into SparseMatrixCSC is
 # non-trivial, so use Arrays for output
 Base.reducedim_initarray{R}(A::SparseMatrixCSC, region, v0, ::Type{R}) =
-    fill!(similar(dims->Array{R}(dims), Base.reduced_dims(A,region)), v0)
+    fill!(similar(dims->Array{R}(dims), Base.reduced_indices(A,region)), v0)
 Base.reducedim_initarray0{R}(A::SparseMatrixCSC, region, v0, ::Type{R}) =
-    fill!(similar(dims->Array{R}(dims), Base.reduced_dims0(A,region)), v0)
+    fill!(similar(dims->Array{R}(dims), Base.reduced_indices0(A,region)), v0)
 
 # General mapreduce
 function _mapreducezeros(f, op, T::Type, nzeros::Int, v0)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -20,7 +20,7 @@ for region in Any[
     1, 2, 3, 4, 5, (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4),
     (1, 2, 3), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)]
     # println("region = $region")
-    r = fill(NaN, map(length, Base.reduced_dims(indices(Areduc), region)))
+    r = fill(NaN, map(length, Base.reduced_indices(indices(Areduc), region)))
     @test sum!(r, Areduc) ≈ safe_sum(Areduc, region)
     @test prod!(r, Areduc) ≈ safe_prod(Areduc, region)
     @test maximum!(r, Areduc) ≈ safe_maximum(Areduc, region)
@@ -62,7 +62,7 @@ end
 # Test reduction along first dimension; this is special-cased for
 # size(A, 1) >= 16
 Breduc = rand(64, 3)
-r = fill(NaN, map(length, Base.reduced_dims(indices(Breduc), 1)))
+r = fill(NaN, map(length, Base.reduced_indices(indices(Breduc), 1)))
 @test sum!(r, Breduc) ≈ safe_sum(Breduc, 1)
 @test sumabs!(r, Breduc) ≈ safe_sumabs(Breduc, 1)
 @test sumabs2!(r, Breduc) ≈ safe_sumabs2(Breduc, 1)


### PR DESCRIPTION
This may also make backporting to julia-0.5 safer. Ref https://github.com/JuliaLang/julia/pull/19100#issuecomment-256087668.
