### PR TITLE
prevent creation of Box for simple let-block variables

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -227,6 +227,7 @@
 
 (define (vinfo:capt v) (< 0 (logand (caddr v) 1)))
 (define (vinfo:asgn v) (< 0 (logand (caddr v) 2)))
+(define (vinfo:never-undef v) (< 0 (logand (caddr v) 4)))
 (define (vinfo:const v) (< 0 (logand (caddr v) 8)))
 (define (vinfo:sa v) (< 0 (logand (caddr v) 16)))
 (define (set-bit x b val) (if val (logior x b) (logand x (lognot b))))
@@ -234,6 +235,8 @@
 (define (vinfo:set-capt! v c)  (set-car! (cddr v) (set-bit (caddr v) 1 c)))
 ;; whether var is assigned
 (define (vinfo:set-asgn! v a)  (set-car! (cddr v) (set-bit (caddr v) 2 a)))
+;; whether the assignments to var are known to dominate its usages
+(define (vinfo:set-never-undef! v a) (set-car! (cddr v) (set-bit (caddr v) 4 a)))
 ;; whether var is const
 (define (vinfo:set-const! v a) (set-car! (cddr v) (set-bit (caddr v) 8 a)))
 ;; whether var is assigned once

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1001,12 +1001,12 @@
                                 (block (= ,tmp ,(caddar binds))
                                        (scope-block
                                         (block
-                                         (local ,(cadar binds))
+                                         (local-def ,(cadar binds))
                                          (= ,vname ,tmp)
                                          ,blk)))))
                             `(scope-block
                               (block
-                               (local ,(cadar binds))
+                               (local-def ,(cadar binds))
                                (= ,vname ,(caddar binds))
                                ,blk))))))
                ((and (pair? (cadar binds))
@@ -1023,7 +1023,7 @@
                   (loop (cdr binds)
                         `(scope-block
                           (block
-                           (local ,name)
+                           (local-def ,name)
                            ,asgn
                            ,blk)))))
                ;; (a, b, c, ...) = rhs
@@ -1033,7 +1033,7 @@
                   (loop (cdr binds)
                         `(scope-block
                           (block
-                           ,@(map (lambda (v) `(local ,v)) vars)
+                           ,@(map (lambda (v) `(local-def ,v)) vars)
                            ,(car binds)
                            ,blk)))))
                (else (error "invalid let syntax"))))
@@ -1208,7 +1208,7 @@
   (if (atom? (cadr e))
       e
       (case (car (cadr e))
-        ((global local)
+        ((global local local-def)
          (expand-forms
           (qualified-const-expr (cdr (cadr e)) e)))
         ((=)
@@ -2250,11 +2250,11 @@
 
 ;; pass 2: identify and rename local vars
 
-(define (check-dups locals)
-  (if (and (pair? locals) (pair? (cdr locals)))
-      (or (and (memq (car locals) (cdr locals))
-               (error (string "local \"" (car locals) "\" declared twice")))
-          (check-dups (cdr locals))))
+(define (check-dups locals others)
+  (if (pair? locals)
+      (if (or (memq (car locals) (cdr locals)) (memq (car locals) others))
+          (error (string "local \"" (car locals) "\" declared twice"))
+          (check-dups (cdr locals) others)))
   locals)
 
 (define (find-assigned-vars e env)
@@ -2290,15 +2290,14 @@
              (apply append! (map (lambda (x) (find-decls kind x))
                                  e))))))
 
-(define (find-local-decls  e) (find-decls 'local  e))
+(define (find-local-decls e) (find-decls 'local e))
+(define (find-local-def-decls e) (find-decls 'local-def e))
 (define (find-global-decls e) (find-decls 'global e))
 
-(define (find-locals e env glob)
-  (delete-duplicates
-   (append! (check-dups (find-local-decls e))
-            ;; const decls on non-globals also introduce locals
-            (diff (find-decls 'const e) glob)
-            (find-assigned-vars e env))))
+(define (implicit-locals e env glob)
+  ;; const decls on non-globals introduce locals
+  (append! (diff (find-decls 'const e) glob)
+           (find-assigned-vars e env)))
 
 (define (occurs-outside? sym e excl)
   (cond ((eq? e sym) #t)
@@ -2316,9 +2315,10 @@
 ;; returns lambdas in the form (lambda (args...) (locals...) body)
 (define (resolve-scopes- e env implicitglobals lam renames newlam)
   (cond ((symbol? e) (let ((r (assq e renames)))
-                       (if r (cdr r) e)))
+                       (if r (cdr r) e))) ;; return the renaming for e, or e
         ((or (not (pair? e)) (quoted? e) (eq? (car e) 'toplevel)) e)
         ((eq? (car e) 'local) '(null)) ;; remove local decls
+        ((eq? (car e) 'local-def) '(null)) ;; remove local decls
         ((eq? (car e) 'lambda)
          (let* ((lv (lam:vars e))
                 (env (append lv env))
@@ -2332,48 +2332,65 @@
                                        #t)))
            `(lambda ,(cadr e) ,(caddr e) ,body)))
         ((eq? (car e) 'scope-block)
-         (let* ((blok (cadr e))
-                (other-locals (if lam (caddr lam) '()))
-                (iglo (find-decls 'implicit-global blok))
-                (glob (diff (find-global-decls blok) iglo))
-                (vars (find-locals
-                       blok
-                       ;; being declared global prevents a variable
-                       ;; assignment from introducing a local
-                       (append env glob implicitglobals iglo)
-                       (append glob iglo)))
-                (need-rename
-                 (if (or newlam (not lam)) '()
-                     (receive
-                      (conflicted unknown)
-                      (separate (lambda (v) (or (memq v env) (memq v other-locals)))
-                                vars)
-                      (append
-                       conflicted
-                       (let ((lbod (lam:body lam)))
-                         (filter (lambda (v) (occurs-outside? v lbod e))
-                                 unknown))))))
+         (let* ((blok (cadr e)) ;; body of scope-block expression
+                (other-locals (if lam (caddr lam) '())) ;; locals that are explicitly part of containing lambda expression
+                (iglo (find-decls 'implicit-global blok)) ;; implicitly defined globals used in blok
+                (glob (diff (find-global-decls blok) iglo)) ;; all globals declared in blok
+                (vars-def (check-dups (find-local-def-decls blok) '()))
+                (locals-declared (check-dups (find-local-decls blok) vars-def))
+                (locals-implicit (diff (implicit-locals
+                                         blok
+                                         ;; being declared global prevents a variable
+                                         ;; assignment from introducing a local
+                                         (append env glob implicitglobals iglo)
+                                         (append glob iglo))
+                                       vars-def))
+                (vars (delete-duplicates (append! locals-declared locals-implicit)))
+                (all-vars (append vars vars-def))
+                (need-rename?
+                 (lambda (vars)
+                  ;; compute the set of locals introduced by this scope which
+                  ;; have the same name as a variable used in an outer scope
+                  (if (or newlam (not lam))
+                      '()
+                      (receive
+                       (conflicted unknown)
+                       (separate (lambda (v) (or (memq v env) (memq v other-locals)))
+                                 vars)
+                       (append
+                        conflicted
+                        (let ((lbod (lam:body lam)))
+                          (filter (lambda (v) (occurs-outside? v lbod e))
+                                  unknown)))))))
+                (need-rename (need-rename? vars))
+                (need-rename-def (need-rename? vars-def))
+                ;; new gensym names for conflicting variables
                 (renamed (map named-gensy need-rename))
-                (new-ren (append (map cons need-rename renamed)
-                                 (filter (lambda (ren)
-                                           (not (memq (car ren) vars)))
-                                         renames)))
-                (new-env (append vars glob env))
+                (renamed-def (map named-gensy need-rename-def))
+                ;; combine the list of new renamings with the inherited list
+                (new-renames (append (map cons need-rename renamed) ;; map from definition name -> gensym name
+                                     (map cons need-rename-def renamed-def)
+                                     (filter (lambda (ren) ;; old renames list, with anything in vars removed
+                                               (not (memq (car ren) all-vars)))
+                                             renames)))
+                (new-env (append all-vars glob env))
                 (new-iglo (append iglo implicitglobals))
-                (body (resolve-scopes- blok new-env new-iglo lam new-ren #f))
-                (real-new-vars (append (diff vars need-rename) renamed)))
+                (body (resolve-scopes- blok new-env new-iglo lam new-renames #f))
+                (real-new-vars (append (diff vars need-rename) renamed))
+                (real-new-vars-def (append (diff vars-def need-rename-def) renamed-def)))
            (for-each (lambda (v)
-                       (if (memq v vars)
+                       (if (memq v all-vars)
                            (error (string "variable \"" v "\" declared both local and global"))))
                      glob)
-           (if lam
+           (if lam ;; update in-place the list of local variables in lam
                (set-car! (cddr lam)
-                         (append real-new-vars (caddr lam))))
-           (insert-after-meta
+                         (append real-new-vars real-new-vars-def (caddr lam))))
+           (insert-after-meta ;; return the new, expanded scope-block
             (if (and (pair? body) (eq? (car body) 'block))
                 body
                 `(block ,body))
-            (map (lambda (v) `(local ,v)) real-new-vars))))
+            (append! (map (lambda (v) `(local ,v)) real-new-vars)
+                     (map (lambda (v) `(local-def ,v)) real-new-vars-def)))))
         ((eq? (car e) 'module)
          (error "module expression not at top level"))
         (else
@@ -2460,6 +2477,9 @@
   (if (or (atom? e) (quoted? e))
       e
       (case (car e)
+        ((local-def) ;; a local that we know has an assignment that dominates all usages
+         (let ((vi (var-info-for (cadr e) env)))
+              (vinfo:set-never-undef! vi #t)))
         ((=)
          (let ((vi (var-info-for (cadr e) env)))
            (if vi
@@ -2737,26 +2757,26 @@ f(x) = yt(x)
                         (take-statements-while
                          (lambda (e)
                            (or (atom? e)
-                               (memq (car e) '(quote top core line inert local unnecessary
+                               (memq (car e) '(quote top core line inert local local-def unnecessary
                                                meta inbounds boundscheck simdloop
                                                implicit-global global globalref
                                                const = null method call))))
                          (lam:body lam))))
                (unused (map cadr (filter (lambda (x) (memq (car x) '(method =)))
-                                         leading)))
-               (def (table)))
-          ;; TODO: reorder leading statements to put assignments where the RHS is
-          ;; `simple-atom?` at the top.
-          (for-each (lambda (e)
-                      (set! unused (filter (lambda (v) (not (expr-uses-var e v)))
-                                           unused))
-                      (if (and (memq (car e) '(method =)) (memq (cadr e) unused))
-                          (put! def (cadr e) #t)))
-                    leading)
-          (for-each (lambda (v)
-                      (if (and (vinfo:sa v) (has? def (car v)))
-                          (set-car! (cddr v) (logand (caddr v) (lognot 5)))))
-                    vi)))
+                                         leading))))
+              ;; TODO: reorder leading statements to put assignments where the RHS is
+              ;; `simple-atom?` at the top.
+              (for-each (lambda (e)
+                          (set! unused (filter (lambda (v) (not (expr-uses-var e v)))
+                                               unused))
+                          (if (and (memq (car e) '(method =)) (memq (cadr e) unused))
+                              (let ((v (assq (cadr e) vi)))
+                                   (if v (vinfo:set-never-undef! v #t)))))
+                        leading)))
+    (for-each (lambda (v)
+                (if (and (vinfo:sa v) (vinfo:never-undef v))
+                    (set-car! (cddr v) (logand (caddr v) (lognot 5)))))
+              vi)
     lam))
 
 (define (is-var-boxed? v lam)
@@ -2821,11 +2841,18 @@ f(x) = yt(x)
              (if (ssavalue? var)
                  `(= ,var ,rhs)
                  (convert-assignment var rhs fname lam interp))))
+          ((local-def) ;; make new Box for local declaration of defined variable
+           (let ((vi (assq (cadr e) (car (lam:vinfo lam)))))
+             (if (and vi (vinfo:asgn vi) (vinfo:capt vi))
+                 `(= ,(cadr e) (call (core Box)))
+                 '(null))))
           ((local) ;; convert local declarations to newvar statements
            (let ((vi (assq (cadr e) (car (lam:vinfo lam)))))
              (if (and vi (vinfo:asgn vi) (vinfo:capt vi))
                  `(= ,(cadr e) (call (core Box)))
-                 `(newvar ,(cadr e)))))
+                 (if (vinfo:never-undef vi)
+                     '(null)
+                     `(newvar ,(cadr e))))))
           ((const)
            (if (or (assq (cadr e) (car  (lam:vinfo lam)))
                    (assq (cadr e) (cadr (lam:vinfo lam))))
@@ -3346,6 +3373,7 @@ f(x) = yt(x)
                    ;; issue #7264
                    (error (string "`global " vname "`: " vname " is local variable in the enclosing scope"))
                    #f)))
+            ((local-def) #f)
             ((local) #f)
             ((implicit-global) #f)
             ((const) (emit e))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -909,9 +909,9 @@
          (rett (if dcl (caddr name) 'Any))
          (name (if dcl (cadr name) name)))
     (cond ((and (length= e 2) (symbol? name))
-	   (if (or (eq? name 'true) (eq? name 'false))
-	       (error (string "invalid function name \"" name "\"")))
-	   `(method ,name))
+           (if (or (eq? name 'true) (eq? name 'false))
+               (error (string "invalid function name \"" name "\"")))
+           `(method ,name))
           ((not (pair? name))                  e)
           ((eq? (car name) 'tuple)
            (expand-forms `(-> ,name ,(caddr e))))
@@ -2869,12 +2869,12 @@ f(x) = yt(x)
                         (if (eqv? (string.char (string name) 0) #\@)
                             (error "macro definition not allowed inside a local scope"))))
              (if lam2
-		 (begin
-		   ;; mark all non-arguments as assigned, since locals that are never assigned
-		   ;; need to be handled the same as those that are (i.e., boxed).
-		   (for-each (lambda (vi) (vinfo:set-asgn! vi #t))
-			     (list-tail (car (lam:vinfo lam2)) (length (lam:args lam2))))
-		   (lambda-optimize-vars! lam2)))
+                 (begin
+                   ;; mark all non-arguments as assigned, since locals that are never assigned
+                   ;; need to be handled the same as those that are (i.e., boxed).
+                   (for-each (lambda (vi) (vinfo:set-asgn! vi #t))
+                             (list-tail (car (lam:vinfo lam2)) (length (lam:args lam2))))
+                   (lambda-optimize-vars! lam2)))
              (if (not local) ;; not a local function; will not be closure converted to a new type
                  (cond (short e)
                        ((null? cvs)
@@ -3000,8 +3000,8 @@ f(x) = yt(x)
                           '(null)
                           (convert-assignment name mk-closure fname lam interp)))))))
           ((lambda)  ;; happens inside (thunk ...) and generated function bodies
-	   (for-each (lambda (vi) (vinfo:set-asgn! vi #t))
-		     (list-tail (car (lam:vinfo e)) (length (lam:args e))))
+           (for-each (lambda (vi) (vinfo:set-asgn! vi #t))
+                     (list-tail (car (lam:vinfo e)) (length (lam:args e))))
            `(lambda ,(cadr e)
               (,(clear-capture-bits (car (lam:vinfo e)))
                () ,@(cddr (lam:vinfo e)))
@@ -3366,9 +3366,9 @@ f(x) = yt(x)
 
             ;; top level expressions returning values
             ((abstract_type bits_type composite_type thunk toplevel module)
-	     (emit e)
+             (emit e)
              (if tail (emit-return '(null)))
-	     '(null))
+             '(null))
 
             ;; other top level expressions and metadata
             ((import importall using export line meta inbounds boundscheck simdloop)

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -11,7 +11,11 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Intrinsics.h>
+#if JL_LLVM_VERSION >= 30700
 #include <llvm/IR/LegacyPassManager.h>
+#else
+#include <llvm/PassManager.h>
+#endif
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #if JL_LLVM_VERSION >= 30600

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -15,7 +15,11 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/LLVMContext.h>
+#if JL_LLVM_VERSION >= 30700
 #include <llvm/IR/LegacyPassManager.h>
+#else
+#include <llvm/PassManager.h>
+#endif
 #include <llvm/IR/MDBuilder.h>
 
 #include "julia.h"

--- a/test/core.jl
+++ b/test/core.jl
@@ -404,7 +404,7 @@ let
         function bar()
             x = 100
         end
-    bar()
+        bar()
         x
     end
     @test foo() === convert(Int8,100)
@@ -4654,3 +4654,101 @@ gc_enable(true)
 bad_tvars{T}() = 1
 @test isa(@which(bad_tvars()), Method)
 @test_throws MethodError bad_tvars()
+
+# issue #19059 - test for lowering of `let` with assignment not adding Box in simple cases
+contains_Box(e::GlobalRef) = (e.name === :Box)
+contains_Box(e::ANY) = false
+contains_Box(e::Expr) = any(contains_Box, e.args)
+
+function let_noBox()
+    local x
+    for i = 1:2
+        if i == 1
+            x = 21
+        end
+        let x = x
+            return () -> x
+        end
+    end
+end
+function let_Box1()
+    local x
+    for i = 1:2
+        if i == 1
+            x = 22
+        end
+        let y = x
+            return () -> x
+        end
+    end
+end
+function let_Box2()
+    local x
+    for i = 1:2
+        if i == 1
+            x = 23
+        end
+        let x = x
+            # In the future, this may change to no-Box if lowering improves
+            return () -> x
+            x = 43
+        end
+    end
+end
+function let_Box3()
+    local x
+    for i = 1:2
+        if i == 1
+            x = 24
+        end
+        let y
+            # In the future, this may change to no-Box if lowering improves
+            y = x
+            return () -> x
+        end
+    end
+end
+function let_Box4()
+    local x, g
+    for i = 1:2
+        if i == 1
+            x = 25
+        end
+        let x = x
+            g = () -> x
+            x = 44
+        end
+        @test x == 25
+        return g
+    end
+end
+function let_Box5()
+    local x, g, h
+    for i = 1:2
+        if i == 1
+            x = 25
+        end
+        let x = x
+            g = () -> (x = 46)
+            h = () -> x
+        end
+        @test x == 25
+        @test h() == 25
+        @test g() == 46
+        @test h() == 46
+        @test x == 25
+        return g
+    end
+end
+@test any(contains_Box, (@code_lowered let_Box1()).code)
+@test any(contains_Box, (@code_lowered let_Box2()).code)
+@test any(contains_Box, (@code_lowered let_Box3()).code)
+@test any(contains_Box, (@code_lowered let_Box4()).code)
+@test any(contains_Box, (@code_lowered let_Box5()).code)
+@test !any(contains_Box, (@code_lowered let_noBox()).code)
+@test let_Box1()() == 22
+@test let_Box2()() == 23
+@test let_Box3()() == 24
+@test let_Box4()() == 44
+@test let_Box5()() == 46
+@test let_noBox()() == 21

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -598,6 +598,20 @@ end
               local x = 1
               end")) == Expr(:error, "variable \"x\" declared both local and global")
 
+@test expand(parse("let
+              local x = 2
+              local x = 1
+              end")) == Expr(:error, "local \"x\" declared twice")
+
+@test expand(parse("let x
+                  local x = 1
+              end")) == Expr(:error, "local \"x\" declared twice")
+
+@test expand(parse("let x = 2
+                  local x = 1
+              end")) == Expr(:error, "local \"x\" declared twice")
+
+
 # make sure front end can correctly print values to error messages
 let ex = expand(parse("\"a\"=1"))
     @test ex == Expr(:error, "invalid assignment location \"\"a\"\"")


### PR DESCRIPTION
This is just another easy case where we can remove Box trivially, where a variable is declared and assigned exactly once in the head of a let block.

This means that the performance issue caused by the current closure conversion introducing a Box can be addressed by wrapping that code in a let block. (edit: provided none of the variables are undefined and are expecting to not be used)
