### PR TITLE
allow `@everywhere` to be called from modules not loaded on workers

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1973,7 +1973,7 @@ Unlike `@spawn` and `@spawnat`, `@everywhere` does not capture any local variabl
     foo = 1
     @eval @everywhere bar=\$foo
 
-The expression is only evaluated under `Main` irrespective of where `@everywhere` is called from.
+The expression is evaluated under `Main` irrespective of where `@everywhere` is called from.
 For example :
 
     module FooBar

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1957,14 +1957,15 @@ macro fetchfrom(p, expr)
 end
 
 """
-    @everywhere
+    @everywhere expr
 
-Execute an expression on all processes. Errors on any of the processes are collected into a
+Execute an expression under Main everywhere. Equivalent to calling
+`eval(Main, expr)` on all processes. Errors on any of the processes are collected into a
 `CompositeException` and thrown. For example :
 
     @everywhere bar=1
 
-will define `bar` under module `Main` on all processes.
+will define `Main.bar` on all processes.
 
 Unlike `@spawn` and `@spawnat`, `@everywhere` does not capture any local variables. Prefixing
 `@everywhere` with `@eval` allows us to broadcast local variables using interpolation :
@@ -1972,25 +1973,35 @@ Unlike `@spawn` and `@spawnat`, `@everywhere` does not capture any local variabl
     foo = 1
     @eval @everywhere bar=\$foo
 
+The expression is only evaluated under `Main` irrespective of where `@everywhere` is called from.
+For example :
 
+    module FooBar
+        foo() = @everywhere bar()=myid()
+    end
+    FooBar.foo()
+
+will result in `Main.bar` being defined on all processes and not `FooBar.bar`.
 """
 macro everywhere(ex)
     quote
         sync_begin()
-        thunk = ()->(eval(Main,$(Expr(:quote,ex))); nothing)
         for pid in workers()
-            async_run_thunk(()->remotecall_fetch(thunk, pid))
+            async_run_thunk(()->remotecall_fetch(eval_ew_expr, pid, $(Expr(:quote,ex))))
             yield() # ensure that the remotecall_fetch has been started
         end
 
-        # execute locally last.
+        # execute locally last as we do not want local execution to block serialization
+        # of the request to remote nodes.
         if nprocs() > 1
-            async_run_thunk(thunk)
+            async_run_thunk(()->eval_ew_expr($(Expr(:quote,ex))))
         end
 
         sync_end()
     end
 end
+
+eval_ew_expr(ex) = (eval(Main, ex); nothing)
 
 # Statically split range [1,N] into equal sized chunks for np processors
 function splitrange(N::Int, np::Int)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -564,7 +564,7 @@ Types
 
        julia> sizeof(Base.LinAlg.LU)
        ERROR: argument is an abstract type; size is indeterminate
-        in sizeof(::Type{T}) at ./essentials.jl:99
+        in sizeof(::Type{T}) at ./essentials.jl:89
         ...
 
 .. function:: eps(T)

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -1506,7 +1506,7 @@ Dequeues
 
        julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
        ERROR: ArgumentError: indices must be unique and sorted
-        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:748
+        in deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:727
         ...
 
 .. function:: splice!(a::Vector, index::Integer, [replacement]) -> item

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -564,17 +564,17 @@ General Parallel Computing Support
            body
        end
 
-.. function:: @everywhere
+.. function:: @everywhere expr
 
    .. Docstring generated from Julia source
 
-   Execute an expression on all processes. Errors on any of the processes are collected into a ``CompositeException`` and thrown. For example :
+   Execute an expression under Main everywhere. Equivalent to calling ``eval(Main, expr)`` on all processes. Errors on any of the processes are collected into a ``CompositeException`` and thrown. For example :
 
    .. code-block:: julia
 
        @everywhere bar=1
 
-   will define ``bar`` under module ``Main`` on all processes.
+   will define ``Main.bar`` on all processes.
 
    Unlike ``@spawn`` and ``@spawnat``\ , ``@everywhere`` does not capture any local variables. Prefixing ``@everywhere`` with ``@eval`` allows us to broadcast local variables using interpolation :
 
@@ -582,6 +582,17 @@ General Parallel Computing Support
 
        foo = 1
        @eval @everywhere bar=$foo
+
+   The expression is only evaluated under ``Main`` irrespective of where ``@everywhere`` is called from. For example :
+
+   .. code-block:: julia
+
+       module FooBar
+           foo() = @everywhere bar()=myid()
+       end
+       FooBar.foo()
+
+   will result in ``Main.bar`` being defined on all processes and not ``FooBar.bar``\ .
 
 .. function:: clear!(pool::CachingPool) -> pool
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -583,7 +583,7 @@ General Parallel Computing Support
        foo = 1
        @eval @everywhere bar=$foo
 
-   The expression is only evaluated under ``Main`` irrespective of where ``@everywhere`` is called from. For example :
+   The expression is evaluated under ``Main`` irrespective of where ``@everywhere`` is called from. For example :
 
    .. code-block:: julia
 

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -1067,6 +1067,15 @@ let
     @test_throws RemoteException fetch(ref)
 end
 
+# Test calling @everywhere from a module not defined on the workers
+module LocalBar
+    bar() = @everywhere new_bar()=myid()
+end
+LocalBar.bar()
+for p in procs()
+    @test p == remotecall_fetch(new_bar, p)
+end
+
 # Test addprocs enable_threaded_blas parameter
 
 const get_num_threads = function() # anonymous so it will be serialized when called


### PR DESCRIPTION
Currently it results in an `UndefVar` error on the remote since we were wrapping the expression in a local closure which referenced the enclosing module. 
