### PR TITLE
Added more descriptive error to run(``) (Fixes #19094)

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -507,6 +507,9 @@ function setup_stdio(anon::Function, stdio::StdIOSet)
 end
 
 function spawn(cmd::Cmd, stdios::StdIOSet; chain::Nullable{ProcessChain}=Nullable{ProcessChain}())
+    if isempty(cmd.exec)
+        throw(ArgumentError("cannot spawn empty command"))
+    end
     loop = eventloop()
     pp = Process(cmd, C_NULL, stdios[1], stdios[2], stdios[3])
     setup_stdio(stdios) do in, out, err
@@ -647,15 +650,8 @@ Run a command object, constructed with backticks. Throws an error if anything go
 including the process exiting with a non-zero status.
 """
 function run(cmds::AbstractCmd, args...)
-    try
-        ps = spawn(cmds, spawn_opts_inherit(args...)...)
-        success(ps) ? nothing : pipeline_error(ps)
-    catch exc
-        if isa(exc, BoundsError)
-            throw(ArgumentError("Empty command cannot be run"))
-        end
-        rethrow()
-    end
+    ps = spawn(cmds, spawn_opts_inherit(args...)...)
+    success(ps) ? nothing : pipeline_error(ps)
 end
 
 const SIGPIPE = 13

--- a/base/process.jl
+++ b/base/process.jl
@@ -647,6 +647,9 @@ Run a command object, constructed with backticks. Throws an error if anything go
 including the process exiting with a non-zero status.
 """
 function run(cmds::AbstractCmd, args...)
+    if isempty(cmds.exec) # Issue 19094
+        throw(ArgumentError("Empty command cannot be run"))
+    end
     ps = spawn(cmds, spawn_opts_inherit(args...)...)
     success(ps) ? nothing : pipeline_error(ps)
 end

--- a/base/process.jl
+++ b/base/process.jl
@@ -647,11 +647,15 @@ Run a command object, constructed with backticks. Throws an error if anything go
 including the process exiting with a non-zero status.
 """
 function run(cmds::AbstractCmd, args...)
-    if isempty(cmds.exec) # Issue 19094
-        throw(ArgumentError("Empty command cannot be run"))
+    try
+        ps = spawn(cmds, spawn_opts_inherit(args...)...)
+        success(ps) ? nothing : pipeline_error(ps)
+    catch exc
+        if isa(exc, BoundsError)
+            throw(ArgumentError("Empty command cannot be run"))
+        end
+        rethrow()
     end
-    ps = spawn(cmds, spawn_opts_inherit(args...)...)
-    success(ps) ? nothing : pipeline_error(ps)
 end
 
 const SIGPIPE = 13

--- a/test/process.jl
+++ b/test/process.jl
@@ -1,7 +1,0 @@
-# This file is a part of Julia. License is MIT: http://julialang.org/license
-
-@testset "run(``) tests" begin
-    @test_throws ArgumentError run(Base.Cmd(``))
-    @test_throws ArgumentError run(Base.AndCmds(``, ``))
-    @test_throws ArgumentError run(Base.AndCmds(``, `echo "test"`))
-end

--- a/test/process.jl
+++ b/test/process.jl
@@ -1,0 +1,7 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+@testset "run(``) tests" begin
+    @test_throws ArgumentError run(Base.Cmd(``))
+    @test_throws ArgumentError run(Base.AndCmds(``, ``))
+    @test_throws ArgumentError run(Base.AndCmds(``, `echo "test"`))
+end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -406,6 +406,17 @@ end
 @test Base.AndCmds(`$echo abc`, `$echo def`) == Base.AndCmds(`$echo abc`, `$echo def`)
 @test Base.AndCmds(`$echo abc`, `$echo def`) != Base.AndCmds(`$echo abc`, `$echo xyz`)
 
+# test for correct error when an empty command is spawned (Issue 19094)
+@test_throws ArgumentError run(Base.Cmd(``))
+@test_throws ArgumentError run(Base.AndCmds(``, ``))
+@test_throws ArgumentError run(Base.AndCmds(``, `$echo test`))
+@test_throws ArgumentError run(Base.AndCmds(`$echo test`, ``))
+
+@test_throws ArgumentError spawn(Base.Cmd(``))
+@test_throws ArgumentError spawn(Base.AndCmds(``, ``))
+@test_throws ArgumentError spawn(Base.AndCmds(``, `$echo test`))
+@test_throws ArgumentError spawn(Base.AndCmds(`$echo test`, ``))
+
 # tests for reducing over collection of Cmd
 @test_throws ArgumentError reduce(&, Base.AbstractCmd[])
 @test_throws ArgumentError reduce(&, Base.Cmd[])


### PR DESCRIPTION
As discussed in #19094 This PR adds a more descriptive error message when `run()` is called with an empty command:

``` julia
julia> run(``)
ERROR: ArgumentError: Empty command cannot be run
 in run(::Cmd) at ./process.jl:651
```
