### PR TITLE
Fix #19129, type inference for Mmap.mmap

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -93,7 +93,7 @@ else
     error("mmap not defined for this OS")
 end # os-test
 
-# core impelementation of mmap
+# core implementation of mmap
 function mmap{T,N}(io::IO,
                    ::Type{Array{T,N}}=Vector{UInt8},
                    dims::NTuple{N,Integer}=(div(filesize(io)-position(io),sizeof(T)),),
@@ -104,7 +104,7 @@ function mmap{T,N}(io::IO,
 
     len = prod(dims) * sizeof(T)
     len >= 0 || throw(ArgumentError("requested size must be ≥ 0, got $len"))
-    len == 0 && return Array{T}(ntuple(x->0,N))
+    len == 0 && return Array{T}(ntuple(x->0,Val{N}))
     len < typemax(Int) - PAGESIZE || throw(ArgumentError("requested size must be < $(typemax(Int)-PAGESIZE), got $len"))
 
     offset >= 0 || throw(ArgumentError("requested offset must be ≥ 0, got $offset"))
@@ -179,7 +179,7 @@ function mmap{T<:BitArray,N}(io::IOStream,
             throw(ArgumentError("the given file does not contain a valid BitArray of size $(join(dims, 'x')) (open with \"r+\" mode to override)"))
         end
     end
-    B = BitArray{N}(ntuple(i->0,N)...)
+    B = BitArray{N}(ntuple(i->0,Val{N})...)
     B.chunks = chunks
     B.len = n
     if N != 1

--- a/base/test.jl
+++ b/base/test.jl
@@ -978,26 +978,28 @@ macro inferred(ex)
     Meta.isexpr(ex, :call)|| error("@inferred requires a call expression")
 
     Base.remove_linenums!(quote
-        $(if any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex.args)
-            # Has keywords
-            args = gensym()
-            kwargs = gensym()
-            quote
-                $(esc(args)), $(esc(kwargs)), result = $(esc(Expr(:call, _args_and_call, ex.args[2:end]..., ex.args[1])))
-                inftypes = $(Base.gen_call_with_extracted_types(Base.return_types, :($(ex.args[1])($(args)...; $(kwargs)...))))
-            end
-        else
-            # No keywords
-            quote
-                args = ($([esc(ex.args[i]) for i = 2:length(ex.args)]...),)
-                result = $(esc(ex.args[1]))(args...)
-                inftypes = Base.return_types($(esc(ex.args[1])), Base.typesof(args...))
-            end
-        end)
-        @assert length(inftypes) == 1
-        rettype = isa(result, Type) ? Type{result} : typeof(result)
-        rettype == inftypes[1] || error("return type $rettype does not match inferred return type $(inftypes[1])")
-        result
+        let
+            $(if any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex.args)
+                # Has keywords
+                args = gensym()
+                kwargs = gensym()
+                quote
+                    $(esc(args)), $(esc(kwargs)), result = $(esc(Expr(:call, _args_and_call, ex.args[2:end]..., ex.args[1])))
+                    inftypes = $(Base.gen_call_with_extracted_types(Base.return_types, :($(ex.args[1])($(args)...; $(kwargs)...))))
+                end
+            else
+                # No keywords
+                quote
+                    args = ($([esc(ex.args[i]) for i = 2:length(ex.args)]...),)
+                    result = $(esc(ex.args[1]))(args...)
+                    inftypes = Base.return_types($(esc(ex.args[1])), Base.typesof(args...))
+                end
+            end)
+            @assert length(inftypes) == 1
+            rettype = isa(result, Type) ? Type{result} : typeof(result)
+            rettype == inftypes[1] || error("return type $rettype does not match inferred return type $(inftypes[1])")
+            result
+        end
     end)
 end
 

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -20,27 +20,27 @@ m = Mmap.mmap(file, Array{UInt8,3}, (1,2,1))
 finalize(m); m=nothing; gc()
 
 # constructors
-@test length(Mmap.mmap(file)) == 12
-@test length(Mmap.mmap(file, Vector{Int8})) == 12
-@test length(Mmap.mmap(file, Matrix{Int8}, (12,1))) == 12
-@test length(Mmap.mmap(file, Matrix{Int8}, (12,1), 0)) == 12
-@test length(Mmap.mmap(file, Matrix{Int8}, (12,1), 0; grow=false)) == 12
-@test length(Mmap.mmap(file, Matrix{Int8}, (12,1), 0; shared=false)) == 12
-@test length(Mmap.mmap(file, Vector{Int8}, 12)) == 12
-@test length(Mmap.mmap(file, Vector{Int8}, 12, 0)) == 12
-@test length(Mmap.mmap(file, Vector{Int8}, 12, 0; grow=false)) == 12
-@test length(Mmap.mmap(file, Vector{Int8}, 12, 0; shared=false)) == 12
+@test length(@inferred Mmap.mmap(file)) == 12
+@test length(@inferred Mmap.mmap(file, Vector{Int8})) == 12
+@test length(@inferred Mmap.mmap(file, Matrix{Int8}, (12,1))) == 12
+@test length(@inferred Mmap.mmap(file, Matrix{Int8}, (12,1), 0)) == 12
+@test length(@inferred Mmap.mmap(file, Matrix{Int8}, (12,1), 0; grow=false)) == 12
+@test length(@inferred Mmap.mmap(file, Matrix{Int8}, (12,1), 0; shared=false)) == 12
+@test length(@inferred Mmap.mmap(file, Vector{Int8}, 12)) == 12
+@test length(@inferred Mmap.mmap(file, Vector{Int8}, 12, 0)) == 12
+@test length(@inferred Mmap.mmap(file, Vector{Int8}, 12, 0; grow=false)) == 12
+@test length(@inferred Mmap.mmap(file, Vector{Int8}, 12, 0; shared=false)) == 12
 s = open(file)
-@test length(Mmap.mmap(s)) == 12
-@test length(Mmap.mmap(s, Vector{Int8})) == 12
-@test length(Mmap.mmap(s, Matrix{Int8}, (12,1))) == 12
-@test length(Mmap.mmap(s, Matrix{Int8}, (12,1), 0)) == 12
-@test length(Mmap.mmap(s, Matrix{Int8}, (12,1), 0; grow=false)) == 12
-@test length(Mmap.mmap(s, Matrix{Int8}, (12,1), 0; shared=false)) == 12
-@test length(Mmap.mmap(s, Vector{Int8}, 12)) == 12
-@test length(Mmap.mmap(s, Vector{Int8}, 12, 0)) == 12
-@test length(Mmap.mmap(s, Vector{Int8}, 12, 0; grow=false)) == 12
-@test length(Mmap.mmap(s, Vector{Int8}, 12, 0; shared=false)) == 12
+@test length(@inferred Mmap.mmap(s)) == 12
+@test length(@inferred Mmap.mmap(s, Vector{Int8})) == 12
+@test length(@inferred Mmap.mmap(s, Matrix{Int8}, (12,1))) == 12
+@test length(@inferred Mmap.mmap(s, Matrix{Int8}, (12,1), 0)) == 12
+@test length(@inferred Mmap.mmap(s, Matrix{Int8}, (12,1), 0; grow=false)) == 12
+@test length(@inferred Mmap.mmap(s, Matrix{Int8}, (12,1), 0; shared=false)) == 12
+@test length(@inferred Mmap.mmap(s, Vector{Int8}, 12)) == 12
+@test length(@inferred Mmap.mmap(s, Vector{Int8}, 12, 0)) == 12
+@test length(@inferred Mmap.mmap(s, Vector{Int8}, 12, 0; grow=false)) == 12
+@test length(@inferred Mmap.mmap(s, Vector{Int8}, 12, 0; shared=false)) == 12
 close(s)
 @test_throws ErrorException Mmap.mmap(file, Vector{Ref}) # must be bit-type
 gc(); gc()
@@ -187,7 +187,7 @@ write(s, [0xffffffffffffffff,
 close(s)
 s = open(file, "r")
 @test isreadonly(s)
-b = Mmap.mmap(s, BitArray, (17,13))
+b = @inferred Mmap.mmap(s, BitArray, (17,13))
 @test Base._check_bitarray_consistency(b)
 @test b == trues(17,13)
 @test_throws ArgumentError Mmap.mmap(s, BitArray, (7,3))


### PR DESCRIPTION
Unfortunately `mmaplen` and `ptr` still get boxed inside the function due to the finalizer closure (#15276) but at least the return type can now be inferred.
