### PR TITLE
Pass `MARCH` as `REAL_ARCH` in additional to `ARCH` to openlibm

### DIFF
--- a/deps/openlibm.mk
+++ b/deps/openlibm.mk
@@ -3,7 +3,7 @@ OPENLIBM_GIT_URL := git://github.com/JuliaLang/openlibm.git
 OPENLIBM_TAR_URL = https://api.github.com/repos/JuliaLang/openlibm/tarball/$1
 $(eval $(call git-external,openlibm,OPENLIBM,,,$(BUILDDIR)))
 
-OPENLIBM_FLAGS := ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
+OPENLIBM_FLAGS := ARCH="$(ARCH)" REAL_ARCH="$(MARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
 
 $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/source-extracted
 	$(MAKE) -C $(dir $<) $(OPENLIBM_FLAGS) $(MAKE_COMMON)


### PR DESCRIPTION
This cause trouble on ARM since `arm` is not a legal march name. This also means that we'll compile openlibm for `pentium4` instead of `i686` on 32bits x86.

Fix #18174

Previous attempt was at https://github.com/JuliaLang/julia/pull/18195

@tkelman for testing. I was able to compile openlibm locally with the right arch using

``` bash
make ARCH=i686 CC='gcc -m32' CXX='g++ -m32' -C deps compile-openlibm
```

Which should be what we are doing on travis?
