### PR TITLE
Install `libLTO` next to `libLLVM`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ endif
 endif
 ifeq ($(USE_SYSTEM_LLVM),0)
 ifeq ($(USE_LLVM_SHLIB),1)
-JL_PRIVATE_LIBS += LLVM
+JL_PRIVATE_LIBS += LLVM LTO
 endif
 endif
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
At least for LLVM `3.9.0` we need to install `libLTO` as well as `libLLVM` otherwise `libLTO` is going to be picked up from the environment leading for several versions of LLVM to be loaded. It isn't needed for LLVM `3.7` but it also doesn't hurt.
