### PR TITLE
replace calls to libuv stop with faster deferred operations

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -70,6 +70,7 @@ function depwarn(msg, funcsym)
             throw(ErrorException(msg))
         end
     end
+    nothing
 end
 
 function firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol)
@@ -1101,5 +1102,7 @@ end)
 # #19246
 @deprecate den denominator
 @deprecate num numerator
+
+Filesystem.stop_watching(stream::Filesystem._FDWatcher) = depwarn("stop_watching(::_FDWatcher) should not be used", :stop_watching)
 
 # End deprecations scheduled for 0.6

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -54,7 +54,7 @@ function eof(s::LibuvStream)
         return nb_available(s) <= 0
     end
     wait_readnb(s,1)
-    !isopen(s) && nb_available(s) <= 0
+    return !isopen(s) && nb_available(s) <= 0
 end
 
 const DEFAULT_READ_BUFFER_SZ = 10485760           # 10 MB
@@ -67,6 +67,7 @@ const StatusActive      = 4 # handle is listening for read/write/connect events
 const StatusClosing     = 5 # handle is closing / being closed
 const StatusClosed      = 6 # handle is closed
 const StatusEOF         = 7 # handle is a TTY that has seen an EOF event
+const StatusPaused      = 8 # handle is Active, but not consuming events, and will transition to Open if it receives an event
 function uv_status_string(x)
     s = x.status
     if x.handle == C_NULL
@@ -86,6 +87,8 @@ function uv_status_string(x)
         return "open"
     elseif s == StatusActive
         return "active"
+    elseif s == StatusPaused
+        return "paused"
     elseif s == StatusClosing
         return "closing"
     elseif s == StatusClosed
@@ -289,11 +292,11 @@ function wait_readnb(x::LibuvStream, nb::Int)
             wait(x.readnotify)
         end
     finally
-        if oldthrottle <= x.throttle <= nb
-            x.throttle = oldthrottle
-        end
         if isempty(x.readnotify.waitq)
             stop_reading(x) # stop reading iff there are currently no other read clients of the stream
+        end
+        if oldthrottle <= x.throttle <= nb
+            x.throttle = oldthrottle
         end
         unpreserve_handle(x)
     end
@@ -409,12 +412,25 @@ function uv_connectioncb(stream::Ptr{Void}, status::Cint)
 end
 
 ## BUFFER ##
-## Allocate a simple buffer
+## Allocate space in buffer (for immediate use)
 function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, Int(recommended_size))
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
-    return (pointer(buffer.data, ptr), length(buffer.data) - ptr + 1)
+    nb = length(buffer.data) - ptr + 1
+    return (pointer(buffer.data, ptr), nb)
 end
+
+notify_filled(buffer::IOBuffer, nread::Int, base::Ptr{Void}, len::UInt) = notify_filled(buffer, nread)
+
+function notify_filled(buffer::IOBuffer, nread::Int)
+    if buffer.append
+        buffer.size += nread
+    else
+        buffer.ptr += nread
+    end
+end
+
+alloc_buf_hook(stream::LibuvStream, size::UInt) = alloc_request(stream.buffer, UInt(size))
 
 function uv_alloc_buf(handle::Ptr{Void}, size::Csize_t, buf::Ptr{Void})
     hd = uv_handle_data(handle)
@@ -424,62 +440,66 @@ function uv_alloc_buf(handle::Ptr{Void}, size::Csize_t, buf::Ptr{Void})
     end
     stream = unsafe_pointer_to_objref(hd)::LibuvStream
 
-    (data, newsize) = alloc_buf_hook(stream, UInt(size))
+    local data::Ptr{Void}, newsize::Csize_t
+    if stream.status != StatusActive
+        data = C_NULL
+        newsize = 0
+    else
+        (data, newsize) = alloc_buf_hook(stream, UInt(size))
+        if data == C_NULL
+            newsize = 0
+        end
+    end
 
     ccall(:jl_uv_buf_set_base, Void, (Ptr{Void}, Ptr{Void}), buf, data)
     ccall(:jl_uv_buf_set_len, Void, (Ptr{Void}, Csize_t), buf, newsize)
-
     nothing
-end
-
-alloc_buf_hook(stream::LibuvStream, size::UInt) = alloc_request(stream.buffer, UInt(size))
-function notify_filled(buffer::IOBuffer, nread::Int, base::Ptr{Void}, len::UInt)
-    if buffer.append
-        buffer.size += nread
-    else
-        buffer.ptr += nread
-    end
 end
 
 function uv_readcb(handle::Ptr{Void}, nread::Cssize_t, buf::Ptr{Void})
-    stream = @handle_as handle LibuvStream
-    nread = Int(nread)
-    base = ccall(:jl_uv_buf_base, Ptr{Void}, (Ptr{Void},), buf)
-    len = UInt(ccall(:jl_uv_buf_len, Csize_t, (Ptr{Void},), buf))
-
-    if nread < 0
-        if nread == UV_ENOBUFS && len == 0
-            # remind the client that stream.buffer is full
-            notify(stream.readnotify)
-        elseif nread == UV_EOF
-            if isa(stream, TTY)
-                stream.status = StatusEOF # libuv called stop_reading already
+    stream_unknown_type = @handle_as handle LibuvStream
+    nrequested = ccall(:jl_uv_buf_len, Csize_t, (Ptr{Void},), buf)
+    function readcb_specialized(stream::LibuvStream, nread::Int, nrequested::UInt)
+        if nread < 0
+            if nread == UV_ENOBUFS && nrequested == 0
+                # remind the client that stream.buffer is full
                 notify(stream.readnotify)
-                notify(stream.closenotify)
-            elseif stream.status != StatusClosing
-                # begin shutdown of the stream
-                ccall(:jl_close_uv, Void, (Ptr{Void},), stream.handle)
-                stream.status = StatusClosing
+            elseif nread == UV_EOF
+                if isa(stream, TTY)
+                    stream.status = StatusEOF # libuv called uv_stop_reading already
+                    notify(stream.readnotify)
+                    notify(stream.closenotify)
+                elseif stream.status != StatusClosing
+                    # begin shutdown of the stream
+                    ccall(:jl_close_uv, Void, (Ptr{Void},), stream.handle)
+                    stream.status = StatusClosing
+                end
+            else
+                # This is a fatal connection error. Shutdown requests as per the usual
+                # close function won't work and libuv will fail with an assertion failure
+                ccall(:jl_forceclose_uv, Void, (Ptr{Void},), stream)
+                notify_error(stream.readnotify, UVError("read", nread))
             end
         else
-            # This is a fatal connection error. Shutdown requests as per the usual
-            # close function won't work and libuv will fail with an assertion failure
-            ccall(:jl_forceclose_uv, Void, (Ptr{Void},), stream)
-            notify_error(stream.readnotify, UVError("read", nread))
+            notify_filled(stream.buffer, nread)
+            notify(stream.readnotify)
         end
-    else
-        notify_filled(stream.buffer, nread, base, len)
-        notify(stream.readnotify)
-    end
 
-    # Stop background reading when
-    # 1) we have accumulated a lot of unread data OR
-    # 2) we have an alternate buffer that has reached its limit.
-    if (nb_available(stream.buffer) >= stream.throttle) ||
-       (nb_available(stream.buffer) >= stream.buffer.maxsize)
-        stop_reading(stream)
+        # Stop background reading when
+        # 1) there's nobody paying attention to the data we are reading
+        # 2) we have accumulated a lot of unread data OR
+        # 3) we have an alternate buffer that has reached its limit.
+        if stream.status == StatusPaused ||
+           (stream.status == StatusActive &&
+            ((nb_available(stream.buffer) >= stream.throttle) ||
+             (nb_available(stream.buffer) >= stream.buffer.maxsize)))
+            # save cycles by stopping kernel notifications from arriving
+            ccall(:uv_read_stop, Cint, (Ptr{Void},), stream)
+            stream.status = StatusOpen
+        end
+        nothing
     end
-    nothing
+    readcb_specialized(stream_unknown_type, Int(nread), UInt(nrequested))
 end
 
 function reseteof(x::TTY)
@@ -627,6 +647,8 @@ end
 
 ## Functions for any LibuvStream ##
 
+# flow control
+
 function start_reading(stream::LibuvStream)
     if stream.status == StatusOpen
         if !isreadable(stream)
@@ -636,6 +658,9 @@ function start_reading(stream::LibuvStream)
                     stream, uv_jl_alloc_buf::Ptr{Void}, uv_jl_readcb::Ptr{Void})
         stream.status = StatusActive
         return ret
+    elseif stream.status == StatusPaused
+        stream.status = StatusActive
+        return Int32(0)
     elseif stream.status == StatusActive
         return Int32(0)
     else
@@ -643,17 +668,29 @@ function start_reading(stream::LibuvStream)
     end
 end
 
-function stop_reading(stream::LibuvStream)
-    if stream.status == StatusActive
-        ret = ccall(:uv_read_stop, Cint, (Ptr{Void},), stream)
-        stream.status = StatusOpen
-        return ret
-    elseif stream.status == StatusOpen
-        return Int32(0)
-    else
-        return Int32(-1)
+if is_windows()
+    # the low performance version of stop_reading is required
+    # on Windows due to a NT kernel bug that we can't use a blocking
+    # stream for non-blocking (overlapped) calls,
+    # and a ReadFile call blocking on one thread
+    # causes all other operations on that stream to lockup
+    function stop_reading(stream::LibuvStream)
+        if stream.status == StatusActive
+            ccall(:uv_read_stop, Cint, (Ptr{Void},), stream)
+            stream.status = StatusOpen
+        end
+        nothing
+    end
+else
+    function stop_reading(stream::LibuvStream)
+        if stream.status == StatusActive
+            stream.status = StatusPaused
+        end
+        nothing
     end
 end
+
+# bulk read / write
 
 readbytes!(s::LibuvStream, a::Vector{UInt8}, nb = length(a)) = readbytes!(s, a, Int(nb))
 function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
@@ -1098,7 +1135,8 @@ function wait_readbyte(s::BufferStream, c::UInt8)
 end
 
 wait_close(s::BufferStream) = if isopen(s); wait(s.close_c); end
-start_reading(s::BufferStream) = nothing
+start_reading(s::BufferStream) = Int32(0)
+stop_reading(s::BufferStream) = nothing
 
 write(s::BufferStream, b::UInt8) = write(s, Ref{UInt8}(b))
 function unsafe_write(s::BufferStream, p::Ptr{UInt8}, nb::UInt)

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -30,7 +30,7 @@ function pfd_tst_reads(idx, intvl)
     t_elapsed = toq()
     @test !evt.timedout
     @test evt.readable
-    @test is_windows() ? evt.writable : !evt.writable
+    @test evt.writable
 
     # println("Expected ", intvl, ", actual ", t_elapsed, ", diff ", t_elapsed - intvl)
     # Disabled since this assertion fails randomly, notably on build VMs (issue #12824)

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -26,11 +26,11 @@ function pfd_tst_reads(idx, intvl)
     global ready += 1
     wait(ready_c)
     tic()
-    evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=true)
+    evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false)
     t_elapsed = toq()
     @test !evt.timedout
     @test evt.readable
-    @test evt.writable
+    @test !evt.writable
 
     # println("Expected ", intvl, ", actual ", t_elapsed, ", diff ", t_elapsed - intvl)
     # Disabled since this assertion fails randomly, notably on build VMs (issue #12824)


### PR DESCRIPTION
This avoids a Libuv bug in the Win32 handling of Polling on Sockets when a outdated firewall is installed. Plus, it should be faster.

~~TODO: A few of the tests for Pipe close likely need to be updated.~~
~~TODO: I forgot that the old setup for stop_reading was required in order to work around several NT kernel bugs. I'll keep it low performance on Windows and just make it faster on Unix (thus widening the gap between them even further).~~