### PR TITLE
Add module name to method show output

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -110,7 +110,7 @@ function show(io::IO, m::Method; kwtype::Nullable{DataType}=Nullable{DataType}()
             join(io, kwargs, ", ", ", ")
         end
     end
-    print(io, ")")
+    print(io, ") in ", m.module)
     if line > 0
         print(io, " at ", file, ":", line)
     end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -52,8 +52,8 @@ let err = try
     io = IOBuffer()
     Base.showerror(io, err)
     lines = split(takebuf_string(io), '\n')
-    ambig_checkline(str) = startswith(str, "  ambig(x, y::Integer) at") ||
-                           startswith(str, "  ambig(x::Integer, y) at")
+    ambig_checkline(str) = startswith(str, "  ambig(x, y::Integer) in Main at") ||
+                           startswith(str, "  ambig(x::Integer, y) in Main at")
     @test ambig_checkline(lines[2])
     @test ambig_checkline(lines[3])
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -442,7 +442,7 @@ let li = typeof(getfield).name.mt.cache.func::Core.MethodInstance,
     mmime = stringmime("text/plain", li.def)
 
     @test lrepr == lmime == "MethodInstance for getfield(...)"
-    @test mrepr == mmime == "getfield(...)"
+    @test mrepr == mmime == "getfield(...) in Core"
 end
 
 

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -363,15 +363,15 @@ let err_str,
     sp = Base.source_path()
     sn = basename(sp)
 
-    @test sprint(show, which(Symbol, Tuple{})) == "Symbol() at $sp:$(method_defs_lineno + 0)"
-    @test sprint(show, which(:a, Tuple{})) == "(::Symbol)() at $sp:$(method_defs_lineno + 1)"
-    @test sprint(show, which(EightBitType, Tuple{})) == "EightBitType() at $sp:$(method_defs_lineno + 2)"
-    @test sprint(show, which(reinterpret(EightBitType, 0x54), Tuple{})) == "(::EightBitType)() at $sp:$(method_defs_lineno + 3)"
-    @test sprint(show, which(EightBitTypeT, Tuple{})) == "(::Type{EightBitTypeT})() at $sp:$(method_defs_lineno + 4)"
-    @test sprint(show, which(EightBitTypeT{Int32}, Tuple{})) == "(::Type{EightBitTypeT{T}}){T}() at $sp:$(method_defs_lineno + 5)"
-    @test sprint(show, which(reinterpret(EightBitTypeT{Int32}, 0x54), Tuple{})) == "(::EightBitTypeT)() at $sp:$(method_defs_lineno + 6)"
-    @test startswith(sprint(show, which(getfield(Base, Symbol("@doc")), Tuple{Vararg{Any}})), "@doc(x...) at boot.jl:")
-    @test startswith(sprint(show, which(FunctionLike(), Tuple{})), "(::FunctionLike)() at $sp:$(method_defs_lineno + 7)")
+    @test sprint(show, which(Symbol, Tuple{})) == "Symbol() in Main at $sp:$(method_defs_lineno + 0)"
+    @test sprint(show, which(:a, Tuple{})) == "(::Symbol)() in Main at $sp:$(method_defs_lineno + 1)"
+    @test sprint(show, which(EightBitType, Tuple{})) == "EightBitType() in Main at $sp:$(method_defs_lineno + 2)"
+    @test sprint(show, which(reinterpret(EightBitType, 0x54), Tuple{})) == "(::EightBitType)() in Main at $sp:$(method_defs_lineno + 3)"
+    @test sprint(show, which(EightBitTypeT, Tuple{})) == "(::Type{EightBitTypeT})() in Main at $sp:$(method_defs_lineno + 4)"
+    @test sprint(show, which(EightBitTypeT{Int32}, Tuple{})) == "(::Type{EightBitTypeT{T}}){T}() in Main at $sp:$(method_defs_lineno + 5)"
+    @test sprint(show, which(reinterpret(EightBitTypeT{Int32}, 0x54), Tuple{})) == "(::EightBitTypeT)() in Main at $sp:$(method_defs_lineno + 6)"
+    @test startswith(sprint(show, which(getfield(Base, Symbol("@doc")), Tuple{Vararg{Any}})), "@doc(x...) in Core at boot.jl:")
+    @test startswith(sprint(show, which(FunctionLike(), Tuple{})), "(::FunctionLike)() in Main at $sp:$(method_defs_lineno + 7)")
     @test stringmime("text/plain", FunctionLike()) == "(::FunctionLike) (generic function with 1 method)"
     @test stringmime("text/plain", Core.arraysize) == "arraysize (built-in function)"
 


### PR DESCRIPTION
This came up in the discussion over in #18745.  The general point of the issue was that it is hard to find where things are defined.

While `which` will tell you the module in which a generic function was defined, there didn't seem to be an easy way to find the module in which a specific method was defined.  This pull request adds the module name to the method show output.  For example:

```
julia> @which big(1.0) + big(2.0)
+(x::BigFloat, y::BigFloat) in Base.MPFR at mpfr.jl:224
```

There will probably be a few different changes proposed out of that issue.  This was just an easy one to start with (assuming people like it).
