### PR TITLE
Tell user to run `using Primes` in migration message. ref #18831

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -209,7 +209,7 @@ for deprecatedfunc in [:isprime, :primes, :primesmask, :factor]
     @eval begin
         $deprecatedfunc(args...) = error(string($deprecatedfunc, args,
             " has been moved to the package Primes.jl.\n",
-            "Run Pkg.add(\"Primes\") to install Primes on Julia v0.5-"))
+            "Run Pkg.add(\"Primes\") to install Primes on Julia v0.5- and then run `using Primes`."))
         export $deprecatedfunc
     end
 end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -199,7 +199,7 @@ for deprecatedfunc in [:combinations, :factorial, :prevprod, :levicivita,
     @eval begin
         $deprecatedfunc(args...) = error(string($deprecatedfunc, args,
             " has been moved to the package Combinatorics.jl.\n",
-            "Run Pkg.add(\"Combinatorics\") to install Combinatorics on Julia v0.5-"))
+            "Run Pkg.add(\"Combinatorics\") to install Combinatorics on Julia v0.5 and later."))
         export $deprecatedfunc
     end
 end
@@ -209,7 +209,7 @@ for deprecatedfunc in [:isprime, :primes, :primesmask, :factor]
     @eval begin
         $deprecatedfunc(args...) = error(string($deprecatedfunc, args,
             " has been moved to the package Primes.jl.\n",
-            "Run Pkg.add(\"Primes\") to install Primes on Julia v0.5- and then run `using Primes`."))
+            "Run Pkg.add(\"Primes\") to install Primes on Julia v0.5 and later, and then run `using Primes`."))
         export $deprecatedfunc
     end
 end


### PR DESCRIPTION
I updated the migration message in `deprecated.jl` to tell the user to run `using Primes` after running `Pkg.add("Primes")`. Thank you!

ref #18831 
