### PR TITLE
`float`, `real`, `complex`: impove docs, move docs inline, and add doctest examples

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -56,11 +56,24 @@ Return both the real and imaginary parts of the complex number `z`.
 """
 reim(z) = (real(z), imag(z))
 
+"""
+    real(T::Type)
+
+Returns the type that represents the real part of a value of type `T`.
+e.g: for `T == Complex{R}`, returns `R`.
+Equivalent to `typeof(real(zero(T)))`.
+
+```jldoctest
+julia> real(Complex{Int})
+Int64
+
+julia> real(Float64)
+Float64
+```
+"""
+real(T::Type) = typeof(real(zero(T)))
 real{T<:Real}(::Type{T}) = T
 real{T<:Real}(::Type{Complex{T}}) = T
-
-complex{T<:Real}(::Type{T}) = Complex{T}
-complex{T<:Real}(::Type{Complex{T}}) = Complex{T}
 
 isreal(x::Real) = true
 isreal(z::Complex) = imag(z) == 0
@@ -75,9 +88,31 @@ isfinite(z::Complex) = isfinite(real(z)) & isfinite(imag(z))
 isnan(z::Complex) = isnan(real(z)) | isnan(imag(z))
 isinf(z::Complex) = isinf(real(z)) | isinf(imag(z))
 
-complex(x::Real, y::Real) = Complex(x, y)
-complex(x::Real) = Complex(x)
+"""
+    complex(r, [i])
+
+Convert real numbers or arrays to complex. `i` defaults to zero.
+"""
 complex(z::Complex) = z
+complex(x::Real) = Complex(x)
+complex(x::Real, y::Real) = Complex(x, y)
+
+"""
+    complex(T::Type)
+
+Returns an appropriate type which can represent a value of type `T` as a complex number.
+Equivalent to `typeof(complex(zero(T)))`.
+
+```jldoctest
+julia> complex(Complex{Int})
+Complex{Int64}
+
+julia> complex(Int)
+Complex{Int64}
+```
+"""
+complex{T<:Real}(::Type{T}) = Complex{T}
+complex{T<:Real}(::Type{Complex{T}}) = Complex{T}
 
 flipsign(x::Complex, y::Real) = ifelse(signbit(y), -x, x)
 

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -951,13 +951,6 @@ The text is assumed to be encoded in UTF-8.
 eachline
 
 """
-    complex(r, [i])
-
-Convert real numbers or arrays to complex. `i` defaults to zero.
-"""
-complex
-
-"""
     Mmap.Anonymous(name, readonly, create)
 
 Create an `IO`-like object for creating zeroed-out mmapped-memory that is not tied to a file
@@ -3128,14 +3121,6 @@ Given an index `i` in `reverse(v)`, return the corresponding index in `v` so tha
 Unicode string.)
 """
 reverseind
-
-"""
-    float(x)
-
-Convert a number, array, or string to a `AbstractFloat` data type. For numeric data, the
-smallest suitable `AbstractFloat` type is used. Converts strings to `Float64`.
-"""
-float
 
 """
     signbit(x)

--- a/base/float.jl
+++ b/base/float.jl
@@ -248,9 +248,28 @@ convert(::Type{AbstractFloat}, x::UInt32)  = convert(Float64, x)
 convert(::Type{AbstractFloat}, x::UInt64)  = convert(Float64, x) # LOSSY
 convert(::Type{AbstractFloat}, x::UInt128) = convert(Float64, x) # LOSSY
 
+"""
+    float(x)
+
+Convert a number or array to a floating point data type.
+When passed a string, this function is equivalent to `parse(Float64, x)`.
+"""
 float(x) = convert(AbstractFloat, x)
 
-# for constructing arrays
+"""
+    float(T::Type)
+
+Returns an appropriate type to represent a value of type `T` as a floating point value.
+Equivalent to `typeof(float(zero(T)))`.
+
+```jldoctest
+julia> float(Complex{Int})
+Complex{Float64}
+
+julia> float(Int)
+Float64
+```
+"""
 float{T<:Number}(::Type{T}) = typeof(float(zero(T)))
 
 for Ti in (Int8, Int16, Int32, Int64)

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -118,7 +118,7 @@ Data Formats
 
    .. Docstring generated from Julia source
 
-   Convert a number, array, or string to a ``AbstractFloat`` data type. For numeric data, the smallest suitable ``AbstractFloat`` type is used. Converts strings to ``Float64``\ .
+   Convert a number or array to a floating point data type. When passed a string, this function is equivalent to ``parse(Float64, x)``\ .
 
 .. function:: significand(x)
 


### PR DESCRIPTION
Fixes #18596 and #19113.

This PR:
- adds documentation to these functions for when passing a `Type`, which was absent before.
    - and `jldoctest` examples
- moves the docs for `float` and `complex` inline from `base/docs/helpdb/Base.jl` into `base/float.jl` and `base/complex.jl`--where the functions are defined--respectively.

**N.B:** I haven't been able to verify that the doctests actually work...

```
$ make -C doc doctest
make: Entering directory '/home/dwight/julia/doc'
PATH=":/usr/local/bin:/usr/bin:/cygdrive/c/Users/dwight/cmder_mini/vendor/conemu-maximus5/ConEmu/Scripts:/cygdrive/c/Users/dwight/cmder_mini/vendor/conemu-maximus5:/cygdrive/c/Users/dwight/cmder_mini/vendor/conemu-maximus5/ConEmu:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/WINDOWS/system32:/cygdrive/c/WINDOWS:/cygdrive/c/WINDOWS/System32/Wbem:/cygdrive/c/WINDOWS/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/Microsoft SQL Server/110/Tools/Binn:/cygdrive/c/Program Files (x86)/Microsoft SDKs/TypeScript/1.0:/cygdrive/c/Program Files/Microsoft SQL Server/120/Tools/Binn:/cygdrive/c/Program Files/WIDCOMM/Bluetooth Software:/cygdrive/c/Program Files/WIDCOMM/Bluetooth Software/syswow64:/cygdrive/c/Program Files/Sublime Text 3:/cygdrive/c/Program Files (x86)/Windows Kits/8.1/Windows Performance Toolkit:/cygdrive/c/Program Files (x86)/Microsoft SDKs/F#/3.1/Framework/v4.0:/cygdrive/c/Program Files/Boo/bin:/cygdrive/c/clojure-1.6.0:/cygdrive/c/Program Files (x86)/IronPython 2.7:/cygdrive/c/Python27:/cygdrive/c/Program Files (x86)/scala/bin:/cygdrive/c/Program Files (x86)/NVIDIA Corporation/PhysX/Common:/cygdrive/c/Program Files/TortoiseHg:/cygdrive/c/Program Files (x86)/erl7.0/bin:/cygdrive/c/Program Files (x86)/Elixir/bin:/cygdrive/c/Program Files/Microsoft/Web Platform Installer:/cygdrive/c/WINDOWS/System32/WindowsPowerShell/v1.0:/cygdrive/c/Perl/perl/bin:/cygdrive/c/Program Files/nodejs:/cygdrive/c/Go/bin:/cygdrive/c/D/dmd2/windows/bin:/cygdrive/c/Program Files/Mercurial:/cygdrive/c/Program Files/Git/cmd:/cygdrive/c/WINDOWS/system32:/cygdrive/c/WINDOWS:/cygdrive/c/WINDOWS/System32/Wbem:/cygdrive/c/Program Files (x86)/Vim/vim80:/cygdrive/c/Users/dwight/.cargo/bin:/cygdrive/c/Users/dwight/bin:/cygdrive/c/Users/dwight/AppData/Local/scoop/shims:/cygdrive/c/Users/dwight/.symlink:/cygdrive/c/Users/dwight/AppData/Local/atom/bin:/cygdrive/c/Users/dwight/Dropbox/Projects/Go/bin:/cygdrive/c/Users/dwight/AppData/Roaming/npm:/cygdrive/c/Users/dwight/AppData/Local/Microsoft/WindowsApps:/cygdrive/c/Nim/dist/mingw:/cygdrive/c/Nim/dist/mingw/bin:/cygdrive/c/Nim/bin:/cygdrive/c/Nim/dist/babel" . ./../deps/scratch/julia-env/bin/activate && sphinx-build -b doctest -d ./_build/doctrees   /home/dwight/julia/doc ./_build/doctest
Running Sphinx v1.4.5
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [doctest]: targets for 87 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
running tests...

Document: manual/interfaces
---------------------------

Exception occurred:
  File "/usr/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
The full traceback has been saved in /tmp/sphinx-err-30n_ir.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:176: doctest] Error 1
make: Leaving directory '/home/dwight/julia/doc'
```