### PR TITLE
Fix convert() and add promotion rules for Pair

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -965,8 +965,11 @@ length(p::Pair) = 2
 
 convert{A,B}(::Type{Pair{A,B}}, x::Pair{A,B}) = x
 function convert{A,B}(::Type{Pair{A,B}}, x::Pair)
-    convert(A, x[1]) => convert(B, x[2])
+    Pair{A, B}(convert(A, x[1]), convert(B, x[2]))
 end
+
+promote_rule{A1, B1, A2, B2}(::Type{Pair{A1, B1}}, ::Type{Pair{A2, B2}}) =
+    Pair{promote_type(A1, A2), promote_type(B1, B2)}
 
 # some operators not defined yet
 global //, >:, <|, hcat, hvcat, ⋅, ×, ∈, ∉, ∋, ∌, ⊆, ⊈, ⊊, ∩, ∪, √, ∛

--- a/test/core.jl
+++ b/test/core.jl
@@ -3020,9 +3020,13 @@ function func8283 end
 @test_throws MethodError func8283()
 
 # issue #11243
-let a = [Pair(1,2), Pair("a","b")]
-    @test typeof(a) == Vector{Pair}
-    @test typeof(a) <: Vector{Pair}
+type Type11243{A, B}
+    x::A
+    y::B
+end
+let a = [Type11243(1,2), Type11243("a","b")]
+    @test typeof(a) == Vector{Type11243}
+    @test typeof(a) <: Vector{Type11243}
 end
 
 # issue #11065, #1571

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -24,6 +24,15 @@ B = [true true false]
 @test convert(Pair{Float64,Float64}, 17 => 4711) === (17.0 => 4711.0)
 @test convert(Pair{Int,Float64}, 17 => 4711) === (17 => 4711.0)
 @test convert(Pair{Float64,Int}, 17 => 4711) === (17.0 => 4711)
+@test convert(Pair{Any,Any}, 17 => 4711) === Pair{Any,Any}(17, 4711)
+@test convert(Pair{Number,Number}, 17 => 4711) === Pair{Number,Number}(17, 4711)
+@test promote(1=>1, 2=>2.0) === (1=>1.0, 2=>2.0)
+@test promote(1=>1, 2.0=>2) === (1.0=>1, 2.0=>2)
+@test promote(1=>1.0, 2.0=>2) === (1.0=>1.0, 2.0=>2.0)
+@test promote(1=>1, :b=>2.0) === (Pair{Any,Float64}(1,1.0),Pair{Any,Float64}(:b,2.0))
+@test isa([:a=>1, :b=>2], Vector{Pair{Symbol,Int}})
+@test isa([:a=>1, :b=>2.0], Vector{Pair{Symbol,Float64}})
+@test isa(["a"=>1, :b=>2.0], Vector{Pair{Any,Float64}})
 
 p = 1=>:foo
 @test first(p) == 1


### PR DESCRIPTION
Existing method was incorrect when converting to Pair with Abstract element
types. No promotion rules existed.

Fixes https://github.com/JuliaLang/julia/issues/19139.