### PR TITLE
Broadcast shouldn't use inbounds when calling f

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -140,7 +140,8 @@ end
             # extract array values
             @nexprs $nargs i->(@inbounds val_i = _broadcast_getindex(A_i, I_i))
             # call the function and store the result
-            @inbounds B[I] = @ncall $nargs f val
+            result = @ncall $nargs f val
+            @inbounds B[I] = result
         end
     end
 end

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -120,9 +120,9 @@ map_newindexer(shape, ::Tuple{}) = (), ()
     (keep, keeps...), (Idefault, Idefaults...)
 end
 
-@inline _broadcast_getindex(A, I) = _broadcast_getindex(containertype(A), A, I)
-@inline _broadcast_getindex(::Type{Any}, A, I) = A
-@inline _broadcast_getindex(::Any, A, I) = A[I]
+Base.@propagate_inbounds _broadcast_getindex(A, I) = _broadcast_getindex(containertype(A), A, I)
+Base.@propagate_inbounds _broadcast_getindex(::Type{Any}, A, I) = A
+Base.@propagate_inbounds _broadcast_getindex(::Any, A, I) = A[I]
 
 ## Broadcasting core
 # nargs encodes the number of As arguments (which matches the number

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -174,4 +174,11 @@ if bc_opt != bc_off
     @test_throws BoundsError k1(Int[])
 end
 
+# Ensure that broadcast doesn't use @inbounds when calling the function
+if bc_opt != bc_off
+    let A = zeros(3,3)
+        @test_throws BoundsError broadcast(getindex, A, 1:3, 1:3)
+    end
+end
+
 end


### PR DESCRIPTION
Previously, `broadcast(getindex, A, I...)` would call `getindex` within an
at-inbounds context. This patch simply moves the function call so that it
will throw a BoundsError appropriately.

Fixes #19203.