### PR TITLE
Fix `bin`, `oct`, `dec` and `hex` when padding negative `BigInt`s

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -536,10 +536,8 @@ function base(b::Integer, n::BigInt, pad::Integer)
         s = s[2:end]
         write(buf, '-')
     end
-    if length(s) < pad
-        for i in 1:pad-length(s)
-            write(buf, '0')
-        end
+    for i in 1:pad-sizeof(s) # `s` is known to be ASCII, and `length` is slower
+        write(buf, '0')
     end
     write(buf, s)
     String(buf)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -518,21 +518,10 @@ oct(n::BigInt) = base( 8, n)
 dec(n::BigInt) = base(10, n)
 hex(n::BigInt) = base(16, n)
 
-for f in (:bin, :oct, :dec, :hex)
-    @eval function ($f)(n::BigInt, pad::Int)
-        b = IOBuffer()
-        res = ($f)(abs(n))
-        diff = pad - length(res)
-        if n < 0
-            write(b, "-")
-        end
-        for _ in 1:diff
-            write(b, "0")
-        end
-        write(b, res)
-        String(b)
-    end
-end
+bin(n::BigInt, pad::Int) = base( 2, n, pad)
+oct(n::BigInt, pad::Int) = base( 8, n, pad)
+dec(n::BigInt, pad::Int) = base(10, n, pad)
+hex(n::BigInt, pad::Int) = base(16, n, pad)
 
 function base(b::Integer, n::BigInt)
     2 <= b <= 62 || throw(ArgumentError("base must be 2 ≤ base ≤ 62, got $b"))

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -521,8 +521,11 @@ hex(n::BigInt) = base(16, n)
 for f in (:bin, :oct, :dec, :hex)
     @eval function ($f)(n::BigInt, pad::Int)
         b = IOBuffer()
-        res = ($f)(n)
+        res = ($f)(abs(n))
         diff = pad - length(res)
+        if n < 0
+            write(b, "-")
+        end
         for _ in 1:diff
             write(b, "0")
         end

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -540,6 +540,22 @@ function base(b::Integer, n::BigInt)
     unsafe_wrap(String, p, true)
 end
 
+function base(b::Integer, n::BigInt, pad::Integer)
+    s = base(b, n)
+    buf = IOBuffer()
+    if n < 0
+        s = s[2:end]
+        write(buf, '-')
+    end
+    if length(s) < pad
+        for i in 1:pad-length(s)
+            write(buf, '0')
+        end
+    end
+    write(buf, s)
+    String(buf)
+end
+
 function ndigits0z(x::BigInt, b::Integer=10)
     b < 2 && throw(DomainError())
     if ispow2(b) && 2 <= b <= 62 # GMP assumes b is in this range

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -322,6 +322,16 @@ let padding = 4, low = big(4), high = big(2^20)
     @test oct(high, padding) == "4000000"
     @test dec(high, padding) == "1048576"
     @test hex(high, padding) == "100000"
+
+    @test bin(-low, padding) == "-0100" # handle negative numbers correctly
+    @test oct(-low, padding) == "-0004"
+    @test dec(-low, padding) == "-0004"
+    @test hex(-low, padding) == "-0004"
+
+    @test bin(-high, padding) == "-100000000000000000000"
+    @test oct(-high, padding) == "-4000000"
+    @test dec(-high, padding) == "-1048576"
+    @test hex(-high, padding) == "-100000"
 end
 
 @test isqrt(big(4)) == 2


### PR DESCRIPTION
As brought to my attention via @KlausC, there was a bug in my previous PR involving these functions, #18855, where negative numbers had the minus sign display after the padding and before the number.
~~This PR fixes that issue by printing an minus sign if appropriate, followed by printing out the absolute value of the number, and adds some more tests.~~
This PR adds a special method for padding `BigInt`s and then refactors `bin`, `oct`, `dec` and `hex` to simply call this new method. This replaces what I did #18855.
This new method simply calls the non-padding version of `base` with the same radix, handles the possible minus-sign, and pads the result.

Before this PR: `hex(-big(0x123), 5) == "0-123"`

After this PR: `hex(-big(0x123), 5) == "-00123"`

~~I also didn't remove some old tests that are more than covered by the tests from #18855. So I threw that into this PR as well - let me know if you'd rather have them in a different PR.~~