### PR TITLE
More fair equivalent for pisum() function in R

### DIFF
--- a/test/perf/micro/perf.R
+++ b/test/perf/micro/perf.R
@@ -110,14 +110,12 @@ timeit("mandel", mandelperf)
 
 pisum = function() {
     t = 0.0
+    a = 1:10000
     for (j in 1:500) {
-        t = 0.0
-        for (k in 1:10000) {
-            t = t + 1.0/(k*k)
-        }
+        t = sum(1/a^2)
     }
     return(t)
-}
+}	
 
 assert(abs(pisum()-1.644834071848065) < 1e-12);
 timeit("pi_sum", pisum, times=1)


### PR DESCRIPTION
The `pisum` function in the Julia benchmarks uses a vectorized squaring & reciprocal operation on its indices, so it seems fair that R should also.  It's also shorter and more idiomatic of what a typical R programmer would do.