### PR TITLE
Check output dimensions for 2x2 and 3x3 in-place matmuls

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -656,6 +656,9 @@ function matmul2x2{T,S}(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S})
 end
 
 function matmul2x2!{T,S,R}(C::AbstractMatrix{R}, tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S})
+    if !(size(A) == size(B) == size(C) == (2,2))
+        throw(DimensionMismatch("A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
+    end
     @inbounds begin
     if tA == 'T'
         A11 = transpose(A[1,1]); A12 = transpose(A[2,1]); A21 = transpose(A[1,2]); A22 = transpose(A[2,2])
@@ -685,6 +688,9 @@ function matmul3x3{T,S}(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S})
 end
 
 function matmul3x3!{T,S,R}(C::AbstractMatrix{R}, tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S})
+    if !(size(A) == size(B) == size(C) == (3,3))
+        throw(DimensionMismatch("A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
+    end
     @inbounds begin
     if tA == 'T'
         A11 = transpose(A[1,1]); A12 = transpose(A[2,1]); A13 = transpose(A[3,1])

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -39,6 +39,8 @@ let
         @test Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
         @test_throws DimensionMismatch [1 2; 0 0; 0 0] * [1 2]
     end
+    CC = ones(3, 3)
+    @test_throws DimensionMismatch A_mul_B!(CC, AA, BB)
 end
 # 3x3
 let
@@ -62,6 +64,8 @@ let
         @test Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
         @test_throws DimensionMismatch [1 2 3; 0 0 0; 0 0 0] * [1 2 3]
     end
+    CC = ones(4, 4)
+    @test_throws DimensionMismatch A_mul_B!(CC, AA, BB)
 end
 # Generic integer matrix multiplication
 # Generic AbstractArrays


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#382

`matmul2x2!` and `matmul3x3!` currently don't check whether the destination array is actually 2x2 or 3x3, respectively. Larger matrices go through `Base.BLAS.gemm!`, which performs such a check. This makes the behavior consistent, thereby fixing the linked issue.