### PR TITLE
Define copy!, setindex!, and arithmetic for Symmetric and Hermitian

### DIFF
--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -266,10 +266,16 @@ let X = sparse([1 -1; -1 1])
 
         W[1,1] = 4
         @test W == T(sparse([4 -1; -1 1]))
+        @test_throws ArgumentError (W[1,2] = 2)
 
         @test Y + I == T(sparse([2 -1; -1 2]))
         @test Y - I == T(sparse([0 -1; -1 0]))
+        @test Y * I == Y
+
         @test Y + 1 == T(sparse([2 0; 0 2]))
+        @test Y - 1 == T(sparse([0 -2; -2 0]))
+        @test Y * 2 == T(sparse([2 -2; -2 2]))
+        @test Y / 1 == Y
     end
 
     @test_throws ArgumentError Hermitian(X) + 2im*I

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -250,3 +250,28 @@ let a = randn(2,2)
     cc = copy(c)
     @test conj!(c) == conj(Array(c))
 end
+
+# 19225
+let X = sparse([1 -1; -1 1])
+    for T in (Symmetric, Hermitian)
+        Y = T(copy(X))
+        _Y = similar(Y)
+        copy!(_Y, Y)
+        @test _Y == Y
+
+        W = T(copy(X), :L)
+        copy!(W, Y)
+        @test W.data == Y.data
+        @test W.uplo != Y.uplo
+
+        W[1,1] = 4
+        @test W == T(sparse([4 -1; -1 1]))
+
+        @test Y + I == T(sparse([2 -1; -1 2]))
+        @test Y - I == T(sparse([0 -1; -1 0]))
+        @test Y + 1 == T(sparse([2 0; 0 2]))
+    end
+
+    @test_throws ArgumentError Hermitian(X) + 2im*I
+    @test_throws ArgumentError Hermitian(X) - 2im*I
+end

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -276,6 +276,8 @@ let X = sparse([1 -1; -1 1])
         @test Y - 1 == T(sparse([0 -2; -2 0]))
         @test Y * 2 == T(sparse([2 -2; -2 2]))
         @test Y / 1 == Y
+
+        @test T([true false; false true]) + true == T([2 1; 1 2])
     end
 
     @test_throws ArgumentError Hermitian(X) + 2im*I

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -252,7 +252,7 @@ let a = randn(2,2)
 end
 
 # 19225
-let X = sparse([1 -1; -1 1])
+let X = [1 -1; -1 1]
     for T in (Symmetric, Hermitian)
         Y = T(copy(X))
         _Y = similar(Y)
@@ -265,16 +265,16 @@ let X = sparse([1 -1; -1 1])
         @test W.uplo != Y.uplo
 
         W[1,1] = 4
-        @test W == T(sparse([4 -1; -1 1]))
+        @test W == T([4 -1; -1 1])
         @test_throws ArgumentError (W[1,2] = 2)
 
-        @test Y + I == T(sparse([2 -1; -1 2]))
-        @test Y - I == T(sparse([0 -1; -1 0]))
+        @test Y + I == T([2 -1; -1 2])
+        @test Y - I == T([0 -1; -1 0])
         @test Y * I == Y
 
-        @test Y + 1 == T(sparse([2 0; 0 2]))
-        @test Y - 1 == T(sparse([0 -2; -2 0]))
-        @test Y * 2 == T(sparse([2 -2; -2 2]))
+        @test Y + 1 == T([2 0; 0 2])
+        @test Y - 1 == T([0 -2; -2 0])
+        @test Y * 2 == T([2 -2; -2 2])
         @test Y / 1 == Y
 
         @test T([true false; false true]) + true == T([2 1; 1 2])

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1635,3 +1635,31 @@ let
     @test isa(abs.(A), SparseMatrixCSC) # representative for _unary_nz2nz_z2z class
     @test isa(exp.(A), Array) # representative for _unary_nz2nz_z2nz class
 end
+
+# 19225
+let X = sparse([1 -1; -1 1])
+    for T in (Symmetric, Hermitian)
+        Y = T(copy(X))
+        _Y = similar(Y)
+        copy!(_Y, Y)
+        @test _Y == Y
+
+        W = T(copy(X), :L)
+        copy!(W, Y)
+        @test W.data == Y.data
+        @test W.uplo != Y.uplo
+
+        W[1,1] = 4
+        @test W == T(sparse([4 -1; -1 1]))
+        @test_throws ArgumentError (W[1,2] = 2)
+
+        @test Y + I == T(sparse([2 -1; -1 2]))
+        @test Y - I == T(sparse([0 -1; -1 0]))
+        @test Y * I == Y
+
+        @test Y + 1 == T(sparse([2 0; 0 2]))
+        @test Y - 1 == T(sparse([0 -2; -2 0]))
+        @test Y * 2 == T(sparse([2 -2; -2 2]))
+        @test Y / 1 == Y
+    end
+end


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#383

This implements `copy!` for `Symmetric` and `Hermitian` types, as well as `+` and `-` for `Symmetric` and `Hermitian` with `UniformScaling`.