### PR TITLE
Fix \ and .'\ for Symmetric and Hermitian sparse matrices.

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -855,7 +855,7 @@ end
 for f in (:sin, :sinh, :sind, :asin, :asinh, :asind,
         :tan, :tanh, :tand, :atan, :atanh, :atand,
         :sinpi, :cosc, :ceil, :floor, :trunc, :round, :real, :imag,
-        :log1p, :expm1, :abs, :abs2, :conj,
+        :log1p, :expm1, :abs, :abs2,
         :log, :log2, :log10, :exp, :exp2, :exp10, :sinc, :cospi,
         :cos, :cosh, :cosd, :acos, :acosd,
         :cot, :coth, :cotd, :acot, :acotd,

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -39,8 +39,7 @@ function (\){T<:BlasReal}(F::Factorization{T}, B::VecOrMat{Complex{T}})
 end
 
 for (f1, f2) in ((:\, :A_ldiv_B!),
-                 (:Ac_ldiv_B, :Ac_ldiv_B!),
-                 (:At_ldiv_B, :At_ldiv_B!))
+                 (:Ac_ldiv_B, :Ac_ldiv_B!))
     @eval begin
         function $f1(F::Factorization, B::AbstractVecOrMat)
             TFB = typeof(one(eltype(F)) / one(eltype(B)))
@@ -56,6 +55,10 @@ for f in (:A_ldiv_B!, :Ac_ldiv_B!, :At_ldiv_B!)
     @eval $f(Y::AbstractVecOrMat, A::Factorization, B::AbstractVecOrMat) =
         $f(A, copy!(Y, B))
 end
+
+# fallback methods for transposed solves
+At_ldiv_B{T<:Real}(F::Factorization{T}, B::AbstractVecOrMat) = Ac_ldiv_B(F, B)
+At_ldiv_B(F::Factorization, B) = conj.(Ac_ldiv_B(F, conj.(B)))
 
 """
     A_ldiv_B!([Y,] A, B) -> Y

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -864,12 +864,7 @@ function (\)(A::SparseMatrixCSC, B::AbstractVecOrMat)
             return UpperTriangular(A) \ B
         end
         if ishermitian(A)
-            try
-                return cholfact(Hermitian(A)) \ B
-            catch e
-                isa(e, PosDefException) || rethrow(e)
-                return ldltfact(Hermitian(A)) \ B
-            end
+            Hermitian(A) \ B
         end
         return lufact(A) \ B
     else

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -44,7 +44,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         εb = eps(abs(float(one(eltyb))))
         ε = max(εa,εb)
 
-debug && println("(Automatic) Square LU decomposition")
+debug && println("(Automatic) Square LU decomposition. eltya: $eltya, eltyb: $eltyb")
         κ     = cond(a,1)
         lua   = factorize(a)
         @test_throws KeyError lua[:Z]

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -381,6 +381,7 @@ for elty in (Float64, Complex{Float64})
     @test_throws DimensionMismatch F\CHOLMOD.Sparse(sparse(ones(elty, 4)))
     @test F'\ones(elty, 5) ≈ Array(A1pd)'\ones(5)
     @test F'\sparse(ones(elty, 5)) ≈ Array(A1pd)'\ones(5)
+    @test F.'\ones(elty, 5) ≈ conj(A1pd)'\ones(elty, 5)
     @test logdet(F) ≈ logdet(Array(A1pd))
     @test det(F) == exp(logdet(F))
     let # to test supernodal, we must use a larger matrix
@@ -670,3 +671,19 @@ let m = 400, n = 500
     @test s.is_super == 0
     @test F\b ≈ ones(m + n)
 end
+
+# Test that \ and '\ and .'\ work for Symmetric and Hermitian. This is just
+# a dispatch exercise so it doesn't matter that the complex matrix has
+# zero imaginary parts
+let Apre = sprandn(10, 10, 0.2) - I
+    for A in (Symmetric(Apre), Hermitian(Apre),
+              Symmetric(Apre + 10I), Hermitian(Apre + 10I),
+              Hermitian(complex(Apre)), Hermitian(complex(Apre) + 10I))
+
+        x = ones(10)
+        b = A*x
+        @test x ≈ A\b
+        @test A.'\b ≈ A'\b
+    end
+end
+


### PR DESCRIPTION
Apparently, we were not testing `\` for `Symmetric` and `Hermitian` sparse matrices. We also didn't have a fallback method for `A.'\b`. See also https://github.com/JuliaLang/LinearAlgebra.jl/issues/384