### PR TITLE
Fix mapreduce for arrays with negative indexes

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -154,7 +154,7 @@ function mapreduce_impl(f, op, A::AbstractArray, ifirst::Integer, ilast::Integer
         return v
     else
         # pairwise portion
-        imid = (ifirst + ilast) >>> 1
+        imid = (ifirst + ilast) >> 1
         v1 = mapreduce_impl(f, op, A, ifirst, imid, blksize)
         v2 = mapreduce_impl(f, op, A, imid+1, ilast, blksize)
         return op(v1, v2)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -317,6 +317,7 @@ I,J,N = findnz(z)
 @test var(A_3_3) == 7.5
 @test std(A_3_3, 1) == OffsetArray([1 1 1], (0,A_3_3.offsets[2]))
 @test std(A_3_3, 2) == OffsetArray([3,3,3]'', (A_3_3.offsets[1],0))
+@test sum(OffsetArray(ones(Int,3000), -1000)) == 3000
 
 @test_approx_eq vecnorm(v) vecnorm(parent(v))
 @test_approx_eq vecnorm(A) vecnorm(parent(A))


### PR DESCRIPTION
On 0.5 and master, the following recurses infinitely:
```Julia
using OffsetArrays
sum(OffsetArray(ones(Int,3000), -1000))
```