### PR TITLE
Use LLVM 3.9.0 on ARM by default

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -656,7 +656,7 @@ endif
 ifneq (,$(findstring arm,$(ARCH)))
 JCFLAGS += -fsigned-char
 
-LLVM_VER:=3.8.1
+LLVM_VER:=3.9.0
 USE_BLAS64:=0
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV7


### PR DESCRIPTION
This is the first known LLVM version that passes all the tests on ARM.

Build passes on the buildbot https://build.julialang.org/builders/package_tarballarm/builds/940. The executable runs on scaleway. The default triple (by checking the files on the buildbot) is changed to armv7l.
