### PR TITLE
Explicit canonicalization of `CompoundPeriod`s

### DIFF
--- a/base/dates/Dates.jl
+++ b/base/dates/Dates.jl
@@ -20,6 +20,8 @@ include("io.jl")
 export Period, DatePeriod, TimePeriod,
        Year, Month, Week, Day, Hour, Minute, Second, Millisecond,
        TimeZone, UTC, TimeType, DateTime, Date,
+       # periods.jl
+       canonicalize,
        # accessors.jl
        yearmonthday, yearmonth, monthday, year, month, week, day,
        hour, minute, second, millisecond, dayofmonth,

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -190,36 +190,52 @@ end
 """
     CompoundPeriod(periods) -> CompoundPeriod
 
-Construct a `CompoundPeriod` from a `Vector` of `Period`s. The constructor will
-automatically simplify the periods into a canonical form according to the following rules:
-
-* All `Period`s of the same type will be added together
-* Any `Period` large enough be partially representable by a coarser `Period` will be broken
-  into multiple `Period`s (eg. `Hour(30)` becomes `Day(1) + Hour(6)`)
-* `Period`s with opposite signs will be combined when possible
-  (eg. `Hour(1) - Day(1)` becomes `-Hour(23)`)
-
-Due to the canonicalization, `CompoundPeriod` is also useful for converting time periods
-into more human-comprehensible forms.
+Construct a `CompoundPeriod` from a `Vector` of `Period`s. All `Period`s of the same type
+will be added together.
 
 # Examples
 ```julia
 julia> Dates.CompoundPeriod([Dates.Hour(12), Dates.Hour(13)])
-1 day, 1 hour
+25 hours
 
 julia> Dates.CompoundPeriod([Dates.Hour(-1), Dates.Minute(1)])
--59 minutes
+-1 hour, 1 minute
 
 julia> Dates.CompoundPeriod([Dates.Month(1), Dates.Week(-2)])
 1 month, -2 weeks
 
-julia> Dates.CompoundPeriod(Dates.Minute(50000)))
-4 weeks, 6 days, 17 hours, 20 minutes
+julia> Dates.CompoundPeriod(Dates.Minute(50000))
+50000 minutes
 ```
 """
 CompoundPeriod{P<:Period}(p::Vector{P}) = CompoundPeriod(Array{Period}(p))
 
 
+"""
+    canonicalize(::CompoundPeriod) -> CompoundPeriod
+
+Reduces the `CompoundPeriod` into its canonical form by applying the following rules:
+
+* Any `Period` large enough be partially representable by a coarser `Period` will be broken
+  into multiple `Period`s (eg. `Hour(30)` becomes `Day(1) + Hour(6)`)
+* `Period`s with opposite signs will be combined when possible
+  (eg. `Hour(1) - Day(1)` becomes `-Hour(23)`)
+
+# Examples
+```julia
+julia> Dates.canonicalize(Dates.CompoundPeriod([Dates.Hour(12), Dates.Hour(13)]))
+1 day, 1 hour
+
+julia> Dates.canonicalize(Dates.CompoundPeriod([Dates.Hour(-1), Dates.Minute(1)]))
+-59 minutes
+
+julia> Dates.canonicalize(Dates.CompoundPeriod([Dates.Month(1), Dates.Week(-2)]))
+1 month, -2 weeks
+
+julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Minute(50000)))
+4 weeks, 6 days, 17 hours, 20 minutes
+```
+"""
 function canonicalize(x::CompoundPeriod)
     # canonicalize Periods by pushing "overflow" into a coarser period.
     p = x.periods

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -187,6 +187,8 @@ type CompoundPeriod <: AbstractTime
     end
 end
 
+CompoundPeriod{P<:Period}(p::Vector{P}) = CompoundPeriod(Array{Period}(p))
+
 """
     CompoundPeriod(periods) -> CompoundPeriod
 
@@ -195,20 +197,20 @@ will be added together.
 
 # Examples
 ```julia
-julia> Dates.CompoundPeriod([Dates.Hour(12), Dates.Hour(13)])
+julia> Dates.CompoundPeriod(Dates.Hour(12), Dates.Hour(13))
 25 hours
 
-julia> Dates.CompoundPeriod([Dates.Hour(-1), Dates.Minute(1)])
+julia> Dates.CompoundPeriod(Dates.Hour(-1), Dates.Minute(1))
 -1 hour, 1 minute
 
-julia> Dates.CompoundPeriod([Dates.Month(1), Dates.Week(-2)])
+julia> Dates.CompoundPeriod(Dates.Month(1), Dates.Week(-2))
 1 month, -2 weeks
 
 julia> Dates.CompoundPeriod(Dates.Minute(50000))
 50000 minutes
 ```
 """
-CompoundPeriod{P<:Period}(p::Vector{P}) = CompoundPeriod(Array{Period}(p))
+CompoundPeriod(p::Period...) = CompoundPeriod(Period[p...])
 
 
 """
@@ -223,13 +225,13 @@ Reduces the `CompoundPeriod` into its canonical form by applying the following r
 
 # Examples
 ```julia
-julia> Dates.canonicalize(Dates.CompoundPeriod([Dates.Hour(12), Dates.Hour(13)]))
+julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Hour(12), Dates.Hour(13)))
 1 day, 1 hour
 
-julia> Dates.canonicalize(Dates.CompoundPeriod([Dates.Hour(-1), Dates.Minute(1)]))
+julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Hour(-1), Dates.Minute(1)))
 -59 minutes
 
-julia> Dates.canonicalize(Dates.CompoundPeriod([Dates.Month(1), Dates.Week(-2)]))
+julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Month(1), Dates.Week(-2)))
 1 month, -2 weeks
 
 julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Minute(50000)))

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -316,13 +316,13 @@ emptyperiod = ((y + d) - d) - y
 @test y - m == 11m
 
 # reduce compound periods into the most basic form
-@test (h - mi).periods == Dates.Period[59mi]
-@test (-h + mi).periods == Dates.Period[-59mi]
-@test (-y + d).periods == Dates.Period[-y, d]
-@test (-y + m - w + d).periods == Dates.Period[-11m, -6d]
-@test (-y + m - w + ms).periods == Dates.Period[-11m, -6d, -23h, -59mi, -59s, -999ms]
-@test (y - m + w - d + h - mi + s - ms).periods == Dates.Period[11m, 6d, 59mi, 999ms]
-@test (-y + m - w + d - h + mi - s + ms).periods == Dates.Period[-11m, -6d, -59mi, -999ms]
+@test Dates.canonicalize(h - mi).periods == Dates.Period[59mi]
+@test Dates.canonicalize(-h + mi).periods == Dates.Period[-59mi]
+@test Dates.canonicalize(-y + d).periods == Dates.Period[-y, d]
+@test Dates.canonicalize(-y + m - w + d).periods == Dates.Period[-11m, -6d]
+@test Dates.canonicalize(-y + m - w + ms).periods == Dates.Period[-11m, -6d, -23h, -59mi, -59s, -999ms]
+@test Dates.canonicalize(y - m + w - d + h - mi + s - ms).periods == Dates.Period[11m, 6d, 59mi, 999ms]
+@test Dates.canonicalize(-y + m - w + d - h + mi - s + ms).periods == Dates.Period[-11m, -6d, -59mi, -999ms]
 
 @test Dates.Date(2009,2,1) - (Dates.Month(1) + Dates.Day(1)) == Dates.Date(2008,12,31)
 @test (Dates.Month(1) + Dates.Day(1)) - Dates.Date(2009,2,1) == Dates.Date(2008,12,31)

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -315,6 +315,12 @@ emptyperiod = ((y + d) - d) - y
 @test h + 3mi == 63mi
 @test y - m == 11m
 
+# compound periods should avoid automatically converting period types
+@test (d - h).periods == Dates.Period[d, -h]
+@test d - h == 23h
+@test !isequal(d - h, 23h)
+@test isequal(d - h, 2d - 2h - 1d + 1h)
+
 # reduce compound periods into the most basic form
 @test Dates.canonicalize(h - mi).periods == Dates.Period[59mi]
 @test Dates.canonicalize(-h + mi).periods == Dates.Period[-59mi]


### PR DESCRIPTION
Changes the behaviour of `CompoundPeriod` such that canonicalization no longer happens automatically. The change is to improve support with `ZonedDateTime`s (from TimeZones.jl) for which the concept of adding a `Hour(24)` or a `Day(1)` can result in different answers (see TimeZones.jl [arithmetic documentation](http://timezonesjl.readthedocs.io/en/stable/arithmetic/)).

