### PR TITLE
Include `EDITOR` env var in `edit` docs

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -6,8 +6,8 @@
     editor()
 
 Determines the editor to use when running functions like `edit`. Returns an Array compatible
-for use within backticks. You can change the editor by setting JULIA_EDITOR, VISUAL, or
-EDITOR as an environmental variable.
+for use within backticks. You can change the editor by setting `JULIA_EDITOR`, `VISUAL` or
+`EDITOR` as an environmental variable.
 """
 function editor()
     if is_windows() || is_apple()
@@ -27,7 +27,8 @@ end
     edit(path::AbstractString, line::Integer=0)
 
 Edit a file or directory optionally providing a line number to edit the file at.
-Returns to the `julia` prompt when you quit the editor.
+Returns to the `julia` prompt when you quit the editor. The editor can be changed
+by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environmental variable.
 """
 function edit(path::AbstractString, line::Integer=0)
     command = editor()
@@ -74,7 +75,8 @@ end
     edit(function, [types])
 
 Edit the definition of a function, optionally specifying a tuple of types to
-indicate which method to edit.
+indicate which method to edit. The editor can be changed by setting `JULIA_EDITOR`,
+`VISUAL` or `EDITOR` as an environmental variable.
 """
 edit(f)          = edit(functionloc(f)...)
 edit(f, t::ANY)  = edit(functionloc(f,t)...)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -68,13 +68,13 @@ Getting Around
 
    .. Docstring generated from Julia source
 
-   Edit a file or directory optionally providing a line number to edit the file at. Returns to the ``julia`` prompt when you quit the editor.
+   Edit a file or directory optionally providing a line number to edit the file at. Returns to the ``julia`` prompt when you quit the editor. The editor can be changed by setting ``JULIA_EDITOR``\ , ``VISUAL`` or ``EDITOR`` as an environmental variable.
 
 .. function:: edit(function, [types])
 
    .. Docstring generated from Julia source
 
-   Edit the definition of a function, optionally specifying a tuple of types to indicate which method to edit.
+   Edit the definition of a function, optionally specifying a tuple of types to indicate which method to edit. The editor can be changed by setting ``JULIA_EDITOR``\ , ``VISUAL`` or ``EDITOR`` as an environmental variable.
 
 .. function:: @edit
 


### PR DESCRIPTION
Fix #19277 

Copied the sentence from `Base.editor` doc string.

Maybe sufficient like this since the docs for `@edit` refers to `edit`? Although most users probably use `@edit` so maybe include the information there as well?