### PR TITLE
RFC: CodegenHooks for external language implementations

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -501,6 +501,18 @@ function uncompressed_ast(m::Method, s::CodeInfo)
     return s
 end
 
+# this type mirrors jl_cghooks_t (documented in julia.h)
+immutable CodegenHooks
+    module_setup::Ptr{Void}
+    module_activation::Ptr{Void}
+    raise_exception::Ptr{Void}
+
+    CodegenHooks(;module_setup=nothing, module_activation=nothing, raise_exception=nothing) =
+        new(pointer_from_objref(module_setup),
+            pointer_from_objref(module_activation),
+            pointer_from_objref(raise_exception))
+end
+
 # this type mirrors jl_cgparams_t (documented in julia.h)
 immutable CodegenParams
     cached::Cint
@@ -512,14 +524,18 @@ immutable CodegenParams
     static_alloc::Cint
     dynamic_alloc::Cint
 
+    hooks::CodegenHooks
+
     CodegenParams(;cached::Bool=true,
                    runtime::Bool=true, exceptions::Bool=true,
                    track_allocations::Bool=true, code_coverage::Bool=true,
-                   static_alloc::Bool=true, dynamic_alloc::Bool=true) =
+                   static_alloc::Bool=true, dynamic_alloc::Bool=true,
+                   hooks::CodegenHooks=CodegenHooks()) =
         new(Cint(cached),
             Cint(runtime), Cint(exceptions),
             Cint(track_allocations), Cint(code_coverage),
-            Cint(static_alloc), Cint(dynamic_alloc))
+            Cint(static_alloc), Cint(dynamic_alloc),
+            hooks)
 end
 
 # Printing code representations in IR and assembly

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -68,7 +68,7 @@ JL_DLLEXPORT jl_value_t *jl_emptytuple=NULL;
 jl_svec_t *jl_emptysvec;
 jl_value_t *jl_nothing;
 
-const jl_cgparams_t jl_default_cgparams = {1, 1, 1, 1, 1, 1, 1};
+jl_cgparams_t jl_default_cgparams = {1, 1, 1, 1, 1, 1, 1, {NULL, NULL, NULL}};
 
 // --- type properties and predicates ---
 
@@ -3522,6 +3522,10 @@ void jl_init_types(void)
     jl_simplevector_type = jl_new_uninitialized_datatype();
     jl_methtable_type = jl_new_uninitialized_datatype();
     jl_nothing = jl_gc_alloc(ptls, 0, NULL);
+
+    jl_default_cgparams.hooks.module_setup = jl_nothing;
+    jl_default_cgparams.hooks.module_activation = jl_nothing;
+    jl_default_cgparams.hooks.raise_exception = jl_nothing;
 
     jl_emptysvec = (jl_svec_t*)jl_gc_alloc(ptls, sizeof(void*),
                                            jl_simplevector_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1771,6 +1771,25 @@ typedef struct {
 // codegen interface ----------------------------------------------------------
 
 typedef struct {
+    // to disable a hook: set to NULL or nothing
+
+    // module setup: prepare a module for code emission (data layout, DWARF version, ...)
+    // parameters: LLVMModuleRef as Ptr{Void}
+    // return value: none
+    jl_value_t *module_setup;
+
+    // module activation: registers debug info, adds module to JIT
+    // parameters: LLVMModuleRef as Ptr{Void}
+    // return value: none
+    jl_value_t *module_activation;
+
+    // exception raising: emit LLVM instructions to raise an exception
+    // parameters: LLVMBasicBlockRef as Ptr{Void}, LLVMValueRef as Ptr{Void}
+    // return value: none
+    jl_value_t *raise_exception;
+} jl_cghooks_t;
+
+typedef struct {
     int cached;             // can the compiler use/populate the compilation cache?
 
     // language features (C-style integer booleans)
@@ -1780,8 +1799,10 @@ typedef struct {
     int code_coverage;      // can we measure coverage (don't if disallowed)?
     int static_alloc;       // is the compiler allowed to allocate statically?
     int dynamic_alloc;      // is the compiler allowed to allocate dynamically (requires runtime)?
+
+    jl_cghooks_t hooks;
 } jl_cgparams_t;
-extern JL_DLLEXPORT const jl_cgparams_t jl_default_cgparams;
+extern JL_DLLEXPORT jl_cgparams_t jl_default_cgparams;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Summary**: extends the codegen parameters from #19046, adding a `hooks` struct for users to put callback routines in. If any of the hooks is set, the compiler will call said method instead of emitting code. By using a package like LLVM.jl, those callback routines can then emit code themselves.
[See here for example use of this functionality](https://github.com/JuliaGPU/CUDAnative.jl/blob/master/src/jit.jl#L61-L94).

Similar to the codegen hooks, this functionality might not be top-notch yet, but I'd prefer to be developing on top of master instead of maintaining my own forks. I'll keep on improving this interface, figuring out exactly which hooks are important, and what the parameters should be (eg. how much of `jl_codectx_t` should be exposed?). Tests and proper documentation are to follow after that, I don't want to set anything in stone for now.

Except for some patches to LLVM (and a bump to 3.9, see my [tb/cuda](https://github.com/JuliaLang/julia/commits/tb/cuda) branch), this is the last required part of functionality for CUDAnative.jl to work on vanilla master.

cc @vchuravy