### PR TITLE
make isfile_casesensitive only check case of the basename on Windows

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -11,7 +11,7 @@ elseif is_windows()
     # GetLongPathName Win32 function returns the case-preserved filename on NTFS.
     function isfile_casesensitive(path)
         isfile(path) || return false  # Fail fast
-        Filesystem.longpath(path) == path
+        basename(Filesystem.longpath(path)) == basename(path)
     end
 elseif is_apple()
     # HFS+ filesystem is case-preserving. The getattrlist API returns

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -15,18 +15,26 @@ thefname = "the fname!//\\&\1*"
 @test @__DIR__() == dirname(@__FILE__)
 
 # Issue #5789 and PR #13542:
-let true_filename = "cAsEtEsT.jl", lowered_filename="casetest.jl"
-    touch(true_filename)
-    @test Base.isfile_casesensitive(true_filename)
-    @test !Base.isfile_casesensitive(lowered_filename)
-    rm(true_filename)
-end
+cd(mktempdir()) do
+    let true_filename = "cAsEtEsT.jl", lowered_filename="casetest.jl"
+        touch(true_filename)
+        @test Base.isfile_casesensitive(true_filename)
+        @test !Base.isfile_casesensitive(lowered_filename)
 
-# Test Unicode normalization; pertinent for OS X
-let nfc_name = "\U00F4.jl"
-    touch(nfc_name)
-    @test Base.isfile_casesensitive(nfc_name)
-    rm(nfc_name)
+        # check that case-sensitivity only applies to basename of a path:
+        if isfile(lowered_filename) # case-insensitive filesystem
+            mkdir("cAsEtEsT")
+            touch(joinpath("cAsEtEsT", true_filename))
+            @test Base.isfile_casesensitive(joinpath("casetest", true_filename))
+            @test !Base.isfile_casesensitive(joinpath("casetest", lowered_filename))
+        end
+    end
+
+    # Test Unicode normalization; pertinent for OS X
+    let nfc_name = "\U00F4.jl"
+        touch(nfc_name)
+        @test Base.isfile_casesensitive(nfc_name)
+    end
 end
 
 let paddedname = "Ztest_sourcepath.jl"

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -15,25 +15,27 @@ thefname = "the fname!//\\&\1*"
 @test @__DIR__() == dirname(@__FILE__)
 
 # Issue #5789 and PR #13542:
-cd(mktempdir()) do
-    let true_filename = "cAsEtEsT.jl", lowered_filename="casetest.jl"
-        touch(true_filename)
-        @test Base.isfile_casesensitive(true_filename)
-        @test !Base.isfile_casesensitive(lowered_filename)
+mktempdir() do dir
+    cd(dir) do
+        let true_filename = "cAsEtEsT.jl", lowered_filename="casetest.jl"
+            touch(true_filename)
+            @test Base.isfile_casesensitive(true_filename)
+            @test !Base.isfile_casesensitive(lowered_filename)
 
-        # check that case-sensitivity only applies to basename of a path:
-        if isfile(lowered_filename) # case-insensitive filesystem
-            mkdir("cAsEtEsT")
-            touch(joinpath("cAsEtEsT", true_filename))
-            @test Base.isfile_casesensitive(joinpath("casetest", true_filename))
-            @test !Base.isfile_casesensitive(joinpath("casetest", lowered_filename))
+            # check that case-sensitivity only applies to basename of a path:
+            if isfile(lowered_filename) # case-insensitive filesystem
+                mkdir("cAsEtEsT")
+                touch(joinpath("cAsEtEsT", true_filename))
+                @test Base.isfile_casesensitive(joinpath("casetest", true_filename))
+                @test !Base.isfile_casesensitive(joinpath("casetest", lowered_filename))
+            end
         end
-    end
 
-    # Test Unicode normalization; pertinent for OS X
-    let nfc_name = "\U00F4.jl"
-        touch(nfc_name)
-        @test Base.isfile_casesensitive(nfc_name)
+        # Test Unicode normalization; pertinent for OS X
+        let nfc_name = "\U00F4.jl"
+            touch(nfc_name)
+            @test Base.isfile_casesensitive(nfc_name)
+        end
     end
 end
 


### PR DESCRIPTION
This modifies the `Base.isfile_casesensitive` function of #13542, which is used to implement a case-sensitive `require` (for `using` and `import`) to only check the case of the `basename` of the path on Windows.  Rationale:

* This is consistent with what is done on MacOS and in the fallback (`readdir`-based) routine.

* This way, the `using` statement is case-sensitive, but things like `LOAD_PATH` are not, as one would probably expect on a case-insensitive filesystem.  (See also [this discussion](https://discourse.julialang.org/t/windows-capitalization-of-the-home-environment-variable/200?u=stevengj).)

Also relevant for #18210.  cc @malmaud and @jakebolewski.