### PR TITLE
Allow arbitrary integers in take, drop, repeated, and partition

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -291,8 +291,8 @@ julia> collect(Iterators.take(a,3))
  5
 ```
 """
-take(xs, n::Int) = Take(xs, n)
-take(xs::Take, n::Int) = Take(xs.xs, min(n, xs.n))
+take(xs, n::Integer) = Take(xs, Int(n))
+take(xs::Take, n::Integer) = Take(xs.xs, min(Int(n), xs.n))
 
 eltype{I}(::Type{Take{I}}) = eltype(I)
 iteratoreltype{I}(::Type{Take{I}}) = iteratoreltype(I)
@@ -345,9 +345,9 @@ julia> collect(Iterators.drop(a,4))
  11
 ```
 """
-drop(xs, n::Int) = Drop(xs, n)
-drop(xs::Take, n::Int) = Take(drop(xs.xs, n), max(0, xs.n - n))
-drop(xs::Drop, n::Int) = Drop(xs.xs, n + xs.n)
+drop(xs, n::Integer) = Drop(xs, Int(n))
+drop(xs::Take, n::Integer) = Take(drop(xs.xs, Int(n)), max(0, xs.n - Int(n)))
+drop(xs::Drop, n::Integer) = Drop(xs.xs, Int(n) + xs.n)
 
 eltype{I}(::Type{Drop{I}}) = eltype(I)
 iteratoreltype{I}(::Type{Drop{I}}) = iteratoreltype(I)
@@ -430,7 +430,7 @@ julia> collect(a)
  [1 2]
 ```
 """
-repeated(x, n::Int) = take(repeated(x), n)
+repeated(x, n::Integer) = take(repeated(x), Int(n))
 
 eltype{O}(::Type{Repeated{O}}) = O
 
@@ -646,7 +646,7 @@ julia> collect(Iterators.partition([1,2,3,4,5], 2))
  [5]
 ```
 """
-partition{T}(c::T, n::Int) = PartitionIterator{T}(c, n)
+partition{T}(c::T, n::Integer) = PartitionIterator{T}(c, Int(n))
 
 
 type PartitionIterator{T}

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -391,3 +391,11 @@ let s = "Monkey 🙈🙊🙊"
     @test tf(2) == "Mo|nk|ey| 🙈|🙊🙊"
     @test tf(1) == "M|o|n|k|e|y| |🙈|🙊|🙊"
 end
+
+# take and friends with arbitrary integers (#19214)
+for T in (UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int128, BigInt)
+    @test length(take(1:6, T(3))) == 3
+    @test length(drop(1:6, T(3))) == 3
+    @test length(repeated(1, T(5))) == 5
+    @test collect(partition(1:5, T(5)))[1] == collect(1:5)
+end


### PR DESCRIPTION
Fixes #19214

Previously `take`, `drop`, `repeated`, and `partition` only allowed `Int` arguments. This widens the signatures to permit any `Integer` type.