### PR TITLE
add a list of common parametric method patterns to the manual

### DIFF
--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -536,7 +536,7 @@ This dispatching branching can be observed, for example, in the logic to sum two
 A natural extension to the iterated dispatch above is to add a layer to
 method selection that identifies classes of types.
 We could do this by writing out a ``Union`` of the types with similar characteristics.
-But then this would list then would not be extensible.
+But then this list would not be extensible.
 However, by expressing the property as a "trait",
 it is possible to express type behaviors in the abstract
 in a way that is flexible to new additions, but which has no performance impact.


### PR DESCRIPTION
this section will hopefully be helpful to new users both as motivational examples
demonstrating the usefulness of the ideas behind dispatch

as well as design patterns for more advanced users to refer to
when developing generic library code

(`make check-whitespace` and `make -C doc` run locally)