### PR TITLE
Correction for the FreeBSD building instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Note that Julia is community-supported and we have little control over our upstr
  - libunwind needs a small patch to its tests to compile.
  - OpenBLAS patches in pkg haven't been upstreamed.
  - gfortran can't link binaries. Set `FFLAGS=-Wl,-rpath,/usr/local/lib/gcc6` to work around this (upstream bug submitted to FreeBSD pkg maintainers).
- - System libraries installed by pkg are not on the compiler path by default. You may need to add `LDFLAGS=/usr/local/lib` and `CPPFLAGS=/usr/local/include` to your environment or `Make.user` file to build successfully.
+ - System libraries installed by pkg are not on the compiler path by default. You may need to add `LDFLAGS=-L/usr/local/lib` and `CPPFLAGS=-I/usr/local/include` to your environment or `Make.user` file to build successfully.
 
 
 ### Windows


### PR DESCRIPTION
Currently the README says that the following variables may need to be set either in the environment or in the Make.user file:
```
LDFLAGS=/usr/local/lib
CPPFLAGS=/usr/local/include
```
This syntax isn't quite right and causes the build to fail. This PR corrects the recommendation to:
```
LDFLAGS=-L/usr/local/lib
CPPFLAGS=-I/usr/local/include
```
That allows the build to succeed.

cc @vtjnash, who introduced the original text in #18063.