### PR TITLE
RFC: deprecate hard/soft scope distinction

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -13,15 +13,34 @@ set of source lines; instead, it will always line up with one of these blocks. T
 main types of scopes in Julia, *global scope* and *local scope*, the latter can be nested. The
 constructs introducing scope blocks are:
 
-| Scope name           | block/construct introducing this kind of scope                                                           |
-|:-------------------- |:-------------------------------------------------------------------------------------------------------- |
-| [Global Scope](@ref) | `module`, `baremodule`, at interactive prompt (REPL)                                                     |
-| [Local Scope](@ref)  | [Soft Local Scope](@ref): `for`, `while`, comprehensions, try-catch-finally, `let`                       |
-| [Local Scope](@ref)  | [Hard Local Scope](@ref): functions (either syntax, anonymous & do-blocks), `struct`, `macro`            |
+# [](@id man-scope-table)
 
-Notably missing from this table are [begin blocks](@ref man-compound-expressions) and [if blocks](@ref man-conditional-evaluation), which do *not*
-introduce new scope blocks. All three types of scopes follow somewhat different rules which will
-be explained below as well as some extra rules for certain blocks.
+  * Scope blocks that may nest only in other global scope blocks:
+
+    - global scope
+
+      + module, baremodule
+
+      + at interactive prompt (REPL)
+
+    - local scope (don't allow nesting)
+
+      + type, immutable, macro
+
+  * Scope blocks which may nest anywhere (in global or local scope):
+
+    - local scope
+
+      + for, while, try-catch-finally, let
+
+      + functions (either syntax, anonymous & do-blocks)
+
+      + comprehensions, broadcast-fusing
+
+Notably missing from this table are
+[begin blocks](@ref man-compound-expressions) and [if blocks](@ref man-conditional-evaluation)
+which do *not* introduce new scope blocks.
+Both types of scopes follow somewhat different rules which will be explained below.
 
 Julia uses [lexical scoping](https://en.wikipedia.org/wiki/Scope_%28computer_science%29#Lexical_scoping_vs._dynamic_scoping),
 meaning that a function's scope does not inherit from its caller's scope, but from the scope in
@@ -50,7 +69,7 @@ Thus *lexical scope* means that the scope of variables can be inferred from the 
 
 ## Global Scope
 
-*Each module introduces a new global scope*, separate from the global scope of all other modules;
+Each module introduces a new global scope, separate from the global scope of all other modules;
 there is no all-encompassing global scope. Modules can introduce variables of other modules into
 their scope through the [using or import](@ref modules) statements or through qualified access using the
 dot-notation, i.e. each module is a so-called *namespace*. Note that variable bindings can only
@@ -87,16 +106,20 @@ Note that the interactive prompt (aka REPL) is in the global scope of the module
 
 ## Local Scope
 
-A new local scope is introduced by most code-blocks, see above table for a complete list.
- A local scope *usually* inherits all the variables from its parent scope, both for reading and
-writing. There are two subtypes of local scopes, hard and soft, with slightly different rules
-concerning what variables are inherited. Unlike global scopes, local scopes are not namespaces,
+A new local scope is introduced by most code blocks (see above
+[table](@ref man-scope-table) for a complete list).
+A local scope inherits all the variables from a parent local scope,
+both for reading and writing.
+Additionally, the local scope inherits all globals that are assigned
+to in its parent global scope block (if it is surrounded by a global `if` or `begin` scope).
+Unlike global scopes, local scopes are not namespaces,
 thus variables in an inner scope cannot be retrieved from the parent scope through some sort of
 qualified access.
 
-The following rules and examples pertain to both hard and soft local scopes. A newly introduced
-variable in a local scope does not back-propagate to its parent scope. For example, here the
-`z` is not introduced into the top-level scope:
+The following rules and examples pertain to local scopes.
+A newly introduced variable in a local scope does not
+back-propagate to its parent scope.
+For example, here the ``z`` is not introduced into the top-level scope:
 
 ```jldoctest
 julia> for i = 1:10
@@ -110,13 +133,13 @@ ERROR: UndefVarError: z not defined
 (Note, in this and all following examples it is assumed that their top-level is a global scope
 with a clean workspace, for instance a newly started REPL.)
 
-Inside a local scope a variable can be forced to be a local variable using the `local` keyword:
+Inside a local scope a variable can be forced to be a new local variable using the `local` keyword:
 
 ```jldoctest
 julia> x = 0;
 
 julia> for i = 1:10
-           local x
+           local x # this is also the default
            x = i + 1
        end
 
@@ -124,7 +147,7 @@ julia> x
 0
 ```
 
-Inside a local scope a new global variable can be defined using the keyword `global`:
+Inside a local scope a global variable can be assigned to by using the keyword `global`:
 
 ```jldoctest
 julia> for i = 1:10
@@ -152,37 +175,14 @@ julia> z
 The `local` and `global` keywords can also be applied to destructuring assignments, e.g.
 `local x, y = 1, 2`. In this case the keyword affects all listed variables.
 
-### Soft Local Scope
+Local scopes are introduced by most block keywords,
+with notable exceptions of `begin` and `if`.
 
-> In a soft local scope, all variables are inherited from its parent scope unless a variable is
-> specifically marked with the keyword `local`.
+In a local scope, all variables are inherited from its parent
+global scope block unless:
 
-Soft local scopes are introduced by for-loops, while-loops, comprehensions, try-catch-finally-blocks,
-and let-blocks. There are some extra rules for [Let Blocks](@ref) and for [For Loops and Comprehensions](@ref).
-
-In the following example the `x` and `y` refer always to the same variables as the soft local
-scope inherits both read and write variables:
-
-```jldoctest
-julia> x, y = 0, 1;
-
-julia> for i = 1:10
-           x = i + y + 1
-       end
-
-julia> x
-12
-```
-
-### Hard Local Scope
-
-Hard local scopes are introduced by function definitions (in all their forms), struct type definition blocks,
-and macro-definitions.
-
-> In a hard local scope, all variables are inherited from its parent scope unless:
->
->   * an assignment would result in a modified *global* variable, or
->   * a variable is specifically marked with the keyword `local`.
+  * an assignment would result in a modified *global* variable, or
+  * a variable is specifically marked with the keyword `local`.
 
 Thus global variables are only inherited for reading but not for writing:
 
@@ -203,6 +203,14 @@ julia> x
 
 An explicit `global` is needed to assign to a global variable:
 
+!!! sidebar "Avoiding globals"
+    Avoiding changing the value of global variables is considered by many
+    to be a programming best-practice.
+    One reason for this is that remotely changing the state of global variables in other
+    modules should be done with care as it makes the local behavior of the program hard to reason about.
+    This is why the scope blocks that introduce local scope require the ``global``
+    keyword to declare the intent to modify a global variable.
+
 ```jldoctest
 julia> x = 1;
 
@@ -216,8 +224,7 @@ julia> x
 2
 ```
 
-Note that *nested functions* can behave differently to functions defined in the global scope as
-they can modify their parent scope's *local* variables:
+Note that *nested functions* can modify their parent scope's *local* variables:
 
 ```jldoctest
 julia> x, y = 1, 2;
@@ -234,19 +241,40 @@ julia> function baz()
 julia> baz()
 22
 
-julia> x, y
+julia> x, y # verify that global x and y are unchanged
 (1, 2)
 ```
 
-The distinction between inheriting global and local variables for assignment can lead to some
-slight differences between functions defined in local vs. global scopes. Consider the modification
-of the last example by moving `bar` to the global scope:
+The reason to allow *modifying local* variables of parent scopes in
+nested functions is to allow constructing `closures
+<https://en.wikipedia.org/wiki/Closure_%28computer_programming%29>`_
+which have a private state, for instance the ``state`` variable in the
+following example:
+
+```jldoctest
+    julia> let state = 0
+               global counter() = (state += 1)
+           end;
+
+    julia> counter()
+    1
+
+    julia> counter()
+    2
+```
+
+See also the closures in the examples in the next two sections.
+
+The distinction between inheriting global scope and nesting local scope
+can lead to some slight differences between functions
+defined in local vs. global scopes for variable assignments.
+Consider the modification of the last example by moving `bar` to the global scope:
 
 ```jldoctest
 julia> x, y = 1, 2;
 
 julia> function bar()
-           x = 10 # local
+           x = 10 # local, no longer a closure variable
            return x + y
        end;
 
@@ -258,11 +286,11 @@ julia> function quz()
 julia> quz()
 14
 
-julia> x, y
+julia> x, y # verify that global x and y are unchanged
 (1, 2)
 ```
 
-Note that above subtlety does not pertain to type and macro definitions as they can only appear
+Note that the above nesting rules do not pertain to type and macro definitions as they can only appear
 at the global scope. There are special scoping rules concerning the evaluation of default and
 keyword function arguments which are described in the [Function section](@ref man-functions).
 
@@ -292,9 +320,9 @@ they are actually called. As an example, here is an inefficient, mutually recurs
 if positive integers are even or odd:
 
 ```jldoctest
-julia> even(n) = n == 0 ? true : odd(n-1);
+julia> even(n) = (n == 0) ? true : odd(n - 1);
 
-julia> odd(n) = n == 0 ? false : even(n-1);
+julia> odd(n) = (n == 0) ? false : even(n - 1);
 
 julia> even(3)
 false
@@ -304,37 +332,8 @@ true
 ```
 
 Julia provides built-in, efficient functions to test for oddness and evenness called [`iseven`](@ref)
-and [`isodd`](@ref) so the above definitions should only be taken as examples.
-
-### Hard vs. Soft Local Scope
-
-Blocks which introduce a soft local scope, such as loops, are generally used to manipulate the
-variables in their parent scope. Thus their default is to fully access all variables in their
-parent scope.
-
-Conversely, the code inside blocks which introduce a hard local scope (function, type, and macro
-definitions) can be executed at any place in a program. Remotely changing the state of global
-variables in other modules should be done with care and thus this is an opt-in feature requiring
-the `global` keyword.
-
-The reason to allow *modifying local* variables of parent scopes in nested functions is to allow
-constructing [closures](https://en.wikipedia.org/wiki/Closure_%28computer_programming%29) which
-have a private state, for instance the `state` variable in the following example:
-
-```jldoctest
-julia> let state = 0
-           global counter
-           counter() = state += 1
-       end;
-
-julia> counter()
-1
-
-julia> counter()
-2
-```
-
-See also the closures in the examples in the next two sections.
+and [`isodd`](@ref) so the above definitions should only be considered to be examples of scope,
+not efficient design.
 
 ### Let Blocks
 

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -576,41 +576,41 @@ end
     @test !contains(str, "backtrace()")
 end
 
-msg = read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
-using Test
+let msg = read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
+        using Test
 
-foo(x) = length(x)^2
+        foo(x) = length(x)^2
 
-@testset "Foo Tests" begin
-    @testset "Animals" begin
-        @testset "Felines" begin
-            @test foo("cat") == 9
-        end
-        @testset "Canines" begin
-            @test foo("dog") == 11
-        end
-    end
-    @testset "Arrays" begin
-        @test foo(zeros(2)) == 4
-        @test foo(ones(4)) == 15
-    end
-end'`), stderr=DevNull), String)
-
-@test contains(msg,
-"""
-Test Summary: | Pass  Fail  Total
-Foo Tests     |    2     2      4
-  Animals     |    1     1      2
-    Felines   |    1            1
-    Canines   |          1      1
-  Arrays      |    1     1      2
-""")
+        @testset "Foo Tests" begin
+            @testset "Animals" begin
+                @testset "Felines" begin
+                    @test foo("cat") == 9
+                end
+                @testset "Canines" begin
+                    @test foo("dog") == 11
+                end
+            end
+            @testset "Arrays" begin
+                @test foo(zeros(2)) == 4
+                @test foo(ones(4)) == 15
+            end
+        end'`), stderr=DevNull), String)
+    @test contains(msg,
+        """
+        Test Summary: | Pass  Fail  Total
+        Foo Tests     |    2     2      4
+          Animals     |    1     1      2
+            Felines   |    1            1
+            Canines   |          1      1
+          Arrays      |    1     1      2
+        """)
+end
 
 # 20489
-msg = split(read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
-Test.print_test_results(Test.DefaultTestSet(""))'`), stderr=DevNull), String), "\n")[1]
-
-@test msg == rstrip(msg)
+let msg = split(read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
+        Test.print_test_results(Test.DefaultTestSet(""))'`), stderr=DevNull), String), "\n")[1]
+    @test msg == rstrip(msg)
+end
 
 @testset "test guarded srand" begin
     seed = rand(UInt)

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -196,11 +196,14 @@ end
     @test binomial(BigInt(-53), 42) == parse(BigInt,"959509335087854414441273718")
     @test binomial(BigInt(113), BigInt(42)) == parse(BigInt,"18672199984318438125634054194360")
 end
-a = rand(1:100, 10000)
-b = map(BigInt, a)
-@test sum(a) == sum(b)
+let a, b
+    a = rand(1:100, 10000)
+    b = map(BigInt, a)
+    @test sum(a) == sum(b)
+end
 
 @testset "Iterated arithmetic" begin
+    local a, b, c, d, f, g
     a = parse(BigInt,"315135")
     b = parse(BigInt,"12412")
     c = parse(BigInt,"3426495623485904783478347")

--- a/test/dates/types.jl
+++ b/test/dates/types.jl
@@ -190,6 +190,7 @@ c = Dates.Time(0)
     @test isfinite(Dates.Time)
 end
 @testset "Date-DateTime conversion/promotion" begin
+    global a, b, c, d
     @test Dates.DateTime(a) == a
     @test Dates.Date(a) == b
     @test Dates.DateTime(b) == a

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -151,11 +151,11 @@ end
         @test abs(f32 - f16) < abs(f32 - prevfloat(f16))
     end
     # halfway between and last bit is 1
-    f = reinterpret(Float32,                           0b00111110101010100011000000000000)
-    @test Float32(Float16(f)) === reinterpret(Float32, 0b00111110101010100100000000000000)
+    ff = reinterpret(Float32,                           0b00111110101010100011000000000000)
+    @test Float32(Float16(ff)) === reinterpret(Float32, 0b00111110101010100100000000000000)
     # halfway between and last bit is 0
-    f = reinterpret(Float32,                           0b00111110101010100001000000000000)
-    @test Float32(Float16(f)) === reinterpret(Float32, 0b00111110101010100000000000000000)
+    ff = reinterpret(Float32,                           0b00111110101010100001000000000000)
+    @test Float32(Float16(ff)) === reinterpret(Float32, 0b00111110101010100000000000000000)
 end
 
 # issue #5948

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -139,7 +139,7 @@ bimg  = randn(n,2)/2
 end # for eltya
 
 @testset "test triu/tril bounds checking" begin
-    m, n = 5, 7
+    local m, n = 5, 7
     ainit = rand(m, n)
     for a in (copy(ainit), view(ainit, 1:m, 1:n))
         @test_throws ArgumentError triu(a, -m)

--- a/test/linalg/lq.jl
+++ b/test/linalg/lq.jl
@@ -115,7 +115,7 @@ end
     # orthogonal factor (say Q) should be a square matrix of order of A's number of
     # columns independent of factorization form (truncated, square), and L and Q
     # should have multiplication-compatible shapes.
-    m, n = 4, 2
+    local m, n = 4, 2
     A = randn(m, n)
     for thin in (true, false)
         L, Q = lq(A, thin = thin)
@@ -146,6 +146,7 @@ end
 end
 
 @testset "getindex on LQPackedQ (#23733)" begin
+    local m, n
     function getqs(F::Base.LinAlg.LQ)
         implicitQ = F[:Q]
         explicitQ = A_mul_B!(implicitQ, eye(eltype(implicitQ), size(implicitQ.factors, 2)))

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -523,7 +523,7 @@ let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
 end
 
 @testset "similar should preserve underlying storage type" begin
-    m, n = 4, 3
+    local m, n = 4, 3
     sparsemat = sprand(m, m, 0.5)
     for TriType in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
         trisparsemat = TriType(sparsemat)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -524,6 +524,7 @@ try
     touch(joinpath(Pack_folder2, "Test_pack2.jl"))
 
     # Test it completes on folders
+    local c, r, res # workaround for issue #24331
     c, r, res = test_complete("using Test_p")
     @test !("Test_pack" in c)
     @test "Test_pack2" in c

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -2044,7 +2044,7 @@ end
 end
 
 @testset "similar for SparseMatrixCSC" begin
-    A = speye(5)
+    local A = speye(5)
     # test similar without specifications (preserves stored-entry structure)
     simA = similar(A)
     @test typeof(simA) == typeof(A)


### PR DESCRIPTION
This PR examines the impact of deprecating (much of?) the distinction between hard/soft scope. Instead it simply distinguishes between global and local scope. This means that all scope-blocks introduce the same type of scope (local), rather than distinguishing that toplevel functions have special, hard scope rules. I've updated the manual to try to show how this change would impact the user. The main change is that there would no longer be the concept of implicit globals computed from examining the module bindings. Instead the global/local computation would be purely syntactic. For example, take the following code snippet:

```julia
global x = 0
for x = 1:10 end
@show x
```

Under the current, this shows `10`, because `x` had a value before the for-loop.
Under the new rules, this shows `0`, since the for-loop introduce a new local scope.

Making this code work as before would requiring declaring `x` to be a global inside the for-loop scope block:
```julia
for x = 1:10; global x; end
```

Another option that this PR still permits is to make an assignment to x inside a begin/end block:
```julia
begin
  x = 0
  for x = 1:10 end
end
@show x
```

The impact to base is small (two corrections to code that will be broken anyways when #265 is fixed).

The impact to tests is larger, as it takes a large number of unintentionally-global variables and causes them to emit a deprecation warning. I think the resulting changes are arguably beneficial, even if we don't decide to change the scoping rules, since they reduce the number of objects being kept around in global variables.