### PR TITLE
Fix mapreduce_impl() for 1-element range

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -169,11 +169,11 @@ foldr(op, itr) = mapfoldr(identity, op, itr)
 
 function mapreduce_impl(f, op, A::AbstractArray, ifirst::Integer, ilast::Integer, blksize::Int=pairwise_blocksize(f, op))
     if ifirst == ilast
-        return r_promote(op, f(A[ifirst]))
+        @inbounds return r_promote(op, f(A[ifirst]))
     elseif ifirst + blksize > ilast
         # sequential portion
-        fx1 = r_promote(op, f(A[ifirst]))
-        fx2 = r_promote(op, f(A[ifirst + 1]))
+        @inbounds fx1 = r_promote(op, f(A[ifirst]))
+        @inbounds fx2 = r_promote(op, f(A[ifirst + 1]))
         v = op(fx1, fx2)
         @simd for i = ifirst + 2 : ilast
             @inbounds Ai = A[i]
@@ -417,7 +417,7 @@ function mapreduce_impl(f, op::Union{typeof(scalarmax),
                                      typeof(min)},
                         A::AbstractArray, first::Int, last::Int)
     # locate the first non NaN number
-    v = f(A[first])
+    @inbounds v = f(A[first])
     i = first + 1
     while v != v && i <= last
         @inbounds Ai = A[i]
@@ -426,8 +426,7 @@ function mapreduce_impl(f, op::Union{typeof(scalarmax),
     end
     while i <= last
         @inbounds Ai = A[i]
-        x = f(Ai)
-        v = op(v, x)
+        v = op(v, f(Ai))
         i += 1
     end
     v

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -167,6 +167,13 @@ foldr(op, itr) = mapfoldr(identity, op, itr)
 
 ## reduce & mapreduce
 
+# `mapreduce_impl()` is called by `mapreduce()` (via `_mapreduce()`, when `A`
+# supports linear indexing) and does actual calculations (for `A[ifirst:ilast]` subset).
+# For efficiency, no parameter validity checks are done, it's the caller responsibility.
+# `ifirst:ilast` range is assumed to be a valid non-empty subset of `A` indices.
+
+# This is a generic implementation of `mapreduce_impl()`,
+# certain `op` (e.g. `min` and `max`) may have their own specialized versions.
 function mapreduce_impl(f, op, A::AbstractArray, ifirst::Integer, ilast::Integer, blksize::Int=pairwise_blocksize(f, op))
     if ifirst == ilast
         @inbounds a1 = A[ifirst]

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -401,12 +401,7 @@ function mapreduce_impl(f, op::Union{typeof(scalarmax),
     # locate the first non NaN number
     @inbounds v = f(A[first])
     i = first + 1
-    while v != v && i <= last
-        @inbounds Ai = A[i]
-        v = f(Ai)
-        i += 1
-    end
-    while i <= last
+    while (v == v) && (i <= last)
         @inbounds Ai = A[i]
         v = op(v, f(Ai))
         i += 1

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -168,7 +168,9 @@ foldr(op, itr) = mapfoldr(identity, op, itr)
 ## reduce & mapreduce
 
 function mapreduce_impl(f, op, A::AbstractArray, ifirst::Integer, ilast::Integer, blksize::Int=pairwise_blocksize(f, op))
-    if ifirst + blksize > ilast
+    if ifirst == ilast
+        return r_promote(op, f(A[ifirst]))
+    elseif ifirst + blksize > ilast
         # sequential portion
         fx1 = r_promote(op, f(A[ifirst]))
         fx2 = r_promote(op, f(A[ifirst + 1]))

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -252,26 +252,8 @@ _mapreduce(f, op, A::AbstractArray) = _mapreduce(f, op, IndexStyle(A), A)
 
 function _mapreduce{T}(f, op, ::IndexLinear, A::AbstractArray{T})
     inds = linearindices(A)
-    n = length(inds)
-    @inbounds begin
-        if n == 0
-            return mr_empty(f, op, T)
-        elseif n == 1
-            return r_promote(op, f(A[inds[1]]))
-        elseif n < 16
-            fx1 = r_promote(op, f(A[inds[1]]))
-            fx2 = r_promote(op, f(A[inds[2]]))
-            s = op(fx1, fx2)
-            i = inds[2]
-            while i < last(inds)
-                Ai = A[i+=1]
-                s = op(s, f(Ai))
-            end
-            return s
-        else
-            return mapreduce_impl(f, op, A, first(inds), last(inds))
-        end
-    end
+    length(inds) > 0 ? mapreduce_impl(f, op, A, first(inds), last(inds)) :
+                       mr_empty(f, op, T)
 end
 
 _mapreduce(f, op, ::IndexCartesian, A::AbstractArray) = mapfoldl(f, op, A)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -169,6 +169,10 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test isnan(minimum([NaN]))
 @test isequal(extrema([NaN]), (NaN, NaN))
 
+@test isnan(maximum([NaN, 2.]))
+@test isnan(minimum([NaN, 2.]))
+@test isequal(extrema([NaN, 2.]), (NaN,NaN))
+
 @test isnan(maximum([NaN, 2., 3.]))
 @test isnan(minimum([NaN, 2., 3.]))
 @test isequal(extrema([NaN, 2., 3.]), (NaN,NaN))
@@ -176,6 +180,14 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test isnan(maximum([4., 3., NaN, 5., 2.]))
 @test isnan(minimum([4., 3., NaN, 5., 2.]))
 @test isequal(extrema([4., 3., NaN, 5., 2.]), (NaN,NaN))
+
+ # test long arrays
+@test isnan(maximum([NaN; 1.:10000.]))
+@test isnan(maximum([1.:10000.; NaN]))
+@test isnan(minimum([NaN; 1.:10000.]))
+@test isnan(minimum([1.:10000.; NaN]))
+@test isequal(extrema([1.:10000.; NaN]), (NaN,NaN))
+@test isequal(extrema([NaN; 1.:10000.]), (NaN,NaN))
 
 @test maximum(abs2, 3:7) == 49
 @test minimum(abs2, 3:7) == 9

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -37,10 +37,14 @@
 @test mapreduce(-, +, [-10 -9 -3]) == ((10 + 9) + 3)
 @test mapreduce((x)->x[1:3], (x,y)->"($x+$y)", ["abcd", "efgh", "01234"]) == "((abc+efg)+012)"
 
-# mapreduce_impl() correctly works with 1- and n-sized blocks (PR #19325)
+# mapreduce_impl()
+#   correctly works with 1- and n-sized blocks (PR #19325)
 @test Base.mapreduce_impl(-, +, [-10, -9, -3], 2, 2) == 9
 @test Base.mapreduce_impl(abs2, +, [-10, -9, -3], 2, 3) == 81 + 9
 @test Base.mapreduce_impl(-, +, [-10, -9, -3, -4, -8, -2, -7], 2, 6, 2) == (9 + 3 + 4 + 8 + 2)
+#   type stability
+@test typeof(Base.mapreduce_impl(*, +, Int8[10], 1, 1)) === typeof(Base.mapreduce_impl(*, +, Int8[10, 11], 1, 2)) === typeof(Base.mapreduce_impl(*, +, Int8[10, 11, 12, 13], 1, 4))
+@test typeof(Base.mapreduce_impl(*, +, Float32[10.0], 1, 1)) === typeof(Base.mapreduce_impl(*, +, Float32[10, 11], 1, 2)) === typeof(Base.mapreduce_impl(*, +, Float32[10, 11, 12, 13], 1, 4))
 
 # sum
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -43,8 +43,12 @@
 @test Base.mapreduce_impl(abs2, +, [-10, -9, -3], 2, 3) == 81 + 9
 @test Base.mapreduce_impl(-, +, [-10, -9, -3, -4, -8, -2, -7], 2, 6, 2) == (9 + 3 + 4 + 8 + 2)
 #   type stability
-@test typeof(Base.mapreduce_impl(*, +, Int8[10], 1, 1)) === typeof(Base.mapreduce_impl(*, +, Int8[10, 11], 1, 2)) === typeof(Base.mapreduce_impl(*, +, Int8[10, 11, 12, 13], 1, 4))
-@test typeof(Base.mapreduce_impl(*, +, Float32[10.0], 1, 1)) === typeof(Base.mapreduce_impl(*, +, Float32[10, 11], 1, 2)) === typeof(Base.mapreduce_impl(*, +, Float32[10, 11, 12, 13], 1, 4))
+@test typeof(Base.mapreduce_impl(*, +, Int8[10], 1, 1)) ===
+    typeof(Base.mapreduce_impl(*, +, Int8[10, 11], 1, 2)) ===
+    typeof(Base.mapreduce_impl(*, +, Int8[10, 11, 12, 13], 1, 4))
+@test typeof(Base.mapreduce_impl(*, +, Float32[10.0], 1, 1)) ===
+    typeof(Base.mapreduce_impl(*, +, Float32[10, 11], 1, 2)) ===
+    typeof(Base.mapreduce_impl(*, +, Float32[10, 11, 12, 13], 1, 4))
 
 # sum
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -37,6 +37,11 @@
 @test mapreduce(-, +, [-10 -9 -3]) == ((10 + 9) + 3)
 @test mapreduce((x)->x[1:3], (x,y)->"($x+$y)", ["abcd", "efgh", "01234"]) == "((abc+efg)+012)"
 
+# mapreduce_impl() correctly works with 1- and n-sized blocks (PR #19325)
+@test Base.mapreduce_impl(-, +, [-10, -9, -3], 2, 2) == 9
+@test Base.mapreduce_impl(abs2, +, [-10, -9, -3], 2, 3) == 81 + 9
+@test Base.mapreduce_impl(-, +, [-10, -9, -3, -4, -8, -2, -7], 2, 6, 2) == (9 + 3 + 4 + 8 + 2)
+
 # sum
 
 @test sum(Int8[]) === Int32(0)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -26,7 +26,7 @@
 @test Base.mapfoldr(abs2, -, 2:5) == -14
 @test Base.mapfoldr(abs2, -, 10, 2:5) == -4
 
-# reduce & mapreduce
+# reduce
 @test reduce(+, Int64[]) === Int64(0) # In reference to issue #20144 (PR #20160)
 @test reduce(+, Int16[]) === Int32(0)
 @test reduce((x,y)->"($x+$y)", 9:11) == "((9+10)+11)"
@@ -34,21 +34,31 @@
 @test reduce(+, 1000, 1:5) == (1000 + 1 + 2 + 3 + 4 + 5)
 @test reduce(+,1) == 1
 
+# mapreduce
 @test mapreduce(-, +, [-10 -9 -3]) == ((10 + 9) + 3)
 @test mapreduce((x)->x[1:3], (x,y)->"($x+$y)", ["abcd", "efgh", "01234"]) == "((abc+efg)+012)"
 
-# mapreduce_impl()
-#   correctly works with 1- and n-sized blocks (PR #19325)
-@test Base.mapreduce_impl(-, +, [-10, -9, -3], 2, 2) == 9
-@test Base.mapreduce_impl(abs2, +, [-10, -9, -3], 2, 3) == 81 + 9
-@test Base.mapreduce_impl(-, +, [-10, -9, -3, -4, -8, -2, -7], 2, 6, 2) == (9 + 3 + 4 + 8 + 2)
-#   type stability
-@test typeof(Base.mapreduce_impl(*, +, Int8[10], 1, 1)) ===
-    typeof(Base.mapreduce_impl(*, +, Int8[10, 11], 1, 2)) ===
-    typeof(Base.mapreduce_impl(*, +, Int8[10, 11, 12, 13], 1, 4))
-@test typeof(Base.mapreduce_impl(*, +, Float32[10.0], 1, 1)) ===
-    typeof(Base.mapreduce_impl(*, +, Float32[10, 11], 1, 2)) ===
-    typeof(Base.mapreduce_impl(*, +, Float32[10, 11, 12, 13], 1, 4))
+# mapreduce() for 1- 2- and n-sized blocks (PR #19325)
+@test mapreduce(-, +, [-10]) == 10
+@test mapreduce(abs2, +, [-9, -3]) == 81 + 9
+@test mapreduce(-, +, [-9, -3, -4, 8, -2]) == (9 + 3 + 4 - 8 + 2)
+@test mapreduce(-, +, collect(linspace(1.0, 10000.0, 10000))) == -50005000.0
+# mapreduce() type stability
+@test typeof(mapreduce(*, +, Int8[10])) ===
+      typeof(mapreduce(*, +, Int8[10, 11])) ===
+      typeof(mapreduce(*, +, Int8[10, 11, 12, 13]))
+@test typeof(mapreduce(*, +, Float32[10.0])) ===
+      typeof(mapreduce(*, +, Float32[10, 11])) ===
+      typeof(mapreduce(*, +, Float32[10, 11, 12, 13]))
+# mapreduce() type stability when f supports empty collections
+@test typeof(mapreduce(abs, +, Int8[])) ===
+      typeof(mapreduce(abs, +, Int8[10])) ===
+      typeof(mapreduce(abs, +, Int8[10, 11])) ===
+      typeof(mapreduce(abs, +, Int8[10, 11, 12, 13]))
+@test typeof(mapreduce(abs, +, Float32[])) ===
+      typeof(mapreduce(abs, +, Float32[10])) ===
+      typeof(mapreduce(abs, +, Float32[10, 11])) ===
+      typeof(mapreduce(abs, +, Float32[10, 11, 12, 13]))
 
 # sum
 


### PR DESCRIPTION
IIUC, 1-element case is handled by `Base._mapreduce()`, so Base never calls `mapreduce_impl()` for 1-element ranges, but it gets exposed by  `NullableArrays`:
```julia
mean(NullableArray([1]), skipnull=true)
```
```
ERROR: BoundsError: attempt to access 1-element Array{Int64,1} at index [2]
```

Also affects 0.5.