### PR TITLE
Patch the libunwind tests on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ You must use the `gmake` command on FreeBSD instead of `make`.
 Note that Julia is community-supported and we have little control over our upstream dependencies, you may still run into issues with dependencies and YMMV. Current known issues include:
 
  - The x86 arch doesn't support threading due to lack of compiler runtime library support (set `JULIA_THREADS=0`).
- - libunwind needs a small patch to its tests to compile.
  - OpenBLAS patches in pkg haven't been upstreamed.
  - gfortran can't link binaries. Set `FFLAGS=-Wl,-rpath,/usr/local/lib/gcc6` to work around this (upstream bug submitted to FreeBSD pkg maintainers).
  - System libraries installed by pkg are not on the compiler path by default. You may need to add `LDFLAGS=-L/usr/local/lib` and `CPPFLAGS=-I/usr/local/include` to your environment or `Make.user` file to build successfully.

--- a/deps/patches/libunwind-freebsd-mapper.patch
+++ b/deps/patches/libunwind-freebsd-mapper.patch
@@ -1,0 +1,12 @@
+--- tests/mapper.c	2014-10-06 14:46:27.000000000 -0400
++++ tests/mapper.c	2014-10-06 14:47:00.000000000 -0400
+@@ -39,6 +39,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DE
+ #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+ # define MAP_ANONYMOUS MAP_ANON
+ #endif
++#if !defined(MAP_NORESERVE)
++# define MAP_NORESERVE 0
++#endif
+ 
+ int
+ main (void)

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -28,7 +28,11 @@ $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-arm-pc-offset.patch-applied
 	cd $(SRCDIR)/srccache/libunwind-$(UNWIND_VER) && patch -p1 -f < $(SRCDIR)/patches/libunwind-arm-pc-offset.patch
 	echo 1 > $@
 
-$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-arm-pc-offset.patch-applied
+$(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-freebsd-mapper.patch-applied: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-arm-pc-offset.patch-applied
+	cd $(SRCDIR)/srccache/libunwind-$(UNWIND_VER) && patch -p0 -f < $(SRCDIR)/patches/libunwind-freebsd-mapper.patch
+	echo 1 > $@
+
+$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/source-extracted $(SRCDIR)/srccache/libunwind-$(UNWIND_VER)/libunwind-freebsd-mapper.patch-applied
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CONFIGURE_COMMON) CPPFLAGS="$(CPPFLAGS) $(LIBUNWIND_CPPFLAGS)" CFLAGS="$(CFLAGS) $(LIBUNWIND_CFLAGS)" --disable-shared --disable-minidebuginfo


### PR DESCRIPTION
Currently libunwind won't build as-is on FreeBSD; this PR incorporates John Baldwin's upstream patch for the libunwind tests that allows them to build. The issue is that the `MAP_NORESERVE` flag for `mmap` is used, but that flag was never implemented on FreeBSD. The patch just defines `MAP_NORESERVE` to be 0 if it's not defined, so it shouldn't adversely affect other systems.