### PR TITLE
make retry() more flexible

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -82,45 +82,70 @@ macro assert(ex, msgs...)
     return :($(esc(ex)) ? $(nothing) : throw(Main.Base.AssertionError($msg)))
 end
 
-# NOTE: Please keep the constant values specified below in sync with the doc string
-const DEFAULT_RETRY_N = 1
-const DEFAULT_RETRY_ON = e->true
-const DEFAULT_RETRY_MAX_DELAY = 10.0
+immutable ExponentialBackOff
+    n::Int
+    first_delay::Float64
+    max_delay::Float64
+    factor::Float64
+    jitter::Float64
 
-"""
-    retry(f, [retry_on]; n=1, max_delay=10.0) -> Function
-
-Returns a lambda that retries function `f` up to `n` times in the
-event of an exception. If `retry_on` is a `Type` then retry only
-for exceptions of that type. If `retry_on` is a function
-`test_error(::Exception) -> Bool` then retry only if it is true.
-
-The first retry happens after a gap of 50 milliseconds or `max_delay`,
-whichever is lower. Subsequently, the delays between retries are
-exponentially increased with a random factor up to `max_delay`.
-
-**Examples**
-```julia
-retry(http_get, e -> e.status == "503")(url)
-retry(read, UVError)(io)
-```
-"""
-function retry(f::Function, retry_on::Function=DEFAULT_RETRY_ON; n=DEFAULT_RETRY_N, max_delay=DEFAULT_RETRY_MAX_DELAY)
-    (args...) -> begin
-        delay = min(0.05, max_delay)
-        for i = 1:n+1
-            try
-                return f(args...)
-            catch e
-                if i > n || try retry_on(e) end !== true
-                    rethrow(e)
-                end
-            end
-            delay = min(max_delay, delay)
-            sleep(delay * (0.8 + (rand() * 0.2)))
-            delay = delay * 5
-        end
+    function ExponentialBackOff(n, first_delay, max_delay, factor, jitter)
+        all(x->x>=0, (n, first_delay, max_delay, factor, jitter)) || error("all inputs must be non-negative")
+        new(n, first_delay, max_delay, factor, jitter)
     end
 end
 
-retry(f::Function, t::Type; kw...) = retry(f, e->isa(e, t); kw...)
+"""
+    ExponentialBackOff(; n=1, first_delay=0.05, max_delay=10.0, factor=5.0, jitter=0.1)
+
+A `Float64` iterator of length `n` whose elements exponentially increase at a
+rate in the interval `factor` * (1 ± `jitter`).  The first element is
+`first_delay` and all elements are clamped to `max_delay`.
+"""
+ExponentialBackOff(; n=1, first_delay=0.05, max_delay=10.0, factor=5.0, jitter=0.1) =
+    ExponentialBackOff(n, first_delay, max_delay, factor, jitter)
+start(ebo::ExponentialBackOff) = (ebo.n, min(ebo.first_delay, ebo.max_delay))
+function next(ebo::ExponentialBackOff, state)
+    next_n = state[1]-1
+    curr_delay = state[2]
+    next_delay = min(ebo.max_delay, state[2] * ebo.factor * (1.0 - ebo.jitter + (rand() * 2.0 * ebo.jitter)))
+    (curr_delay, (next_n, next_delay))
+end
+done(ebo::ExponentialBackOff, state) = state[1]<1
+length(ebo::ExponentialBackOff) = ebo.n
+
+"""
+    retry(f::Function;  delays=Base.ExponentialBackOff(), check=nothing) -> Function
+
+Returns an anonymous function that calls function `f`.  If an exception arises,
+`f` is repeatedly called again, each time `check` returns `true`, after waiting the
+number of seconds specified in `delays`.  `check` should input `delays`'s
+current state and the `Exception`.
+
+# Examples
+```julia
+retry(f, delays=fill(5.0, 3))
+retry(f, delays=rand(5:10, 2))
+retry(f, delays=Base.ExponentialBackOff(n=3, first_delay=5, max_delay=1000))
+retry(http_get, check=(s,e)->e.status == "503")(url)
+retry(read, check=(s,e)->isa(e, UVError))(io)
+```
+"""
+function retry(f::Function;  delays=ExponentialBackOff(), check=nothing)
+    (args...) -> begin
+        state = start(delays)
+        while true
+            try
+                return f(args...)
+            catch e
+                done(delays, state) && rethrow(e)
+                if check !== nothing
+                    state, retry_or_not = check(state, e)
+                    retry_or_not || rethrow(e)
+                end
+            end
+            (delay, state) = next(delays, state)
+            sleep(delay)
+        end
+    end
+end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -59,6 +59,7 @@ export
     EachLine,
     Enum,
     Enumerate,
+    ExponentialBackOff,
     Factorization,
     FileMonitor,
     FloatRange,

--- a/base/workerpool.jl
+++ b/base/workerpool.jl
@@ -208,7 +208,7 @@ end
 """
     remote([::AbstractWorkerPool], f) -> Function
 
-Returns a lambda that executes function `f` on an available worker
+Returns an anonymous function that executes function `f` on an available worker
 using [`remotecall_fetch`](@ref).
 """
 remote(f) = (args...; kwargs...)->remotecall_fetch(f, default_worker_pool(), args...; kwargs...)

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -231,6 +231,7 @@ Core.UndefRefError
 Core.UndefVarError
 Base.InitError
 Base.retry
+Base.ExponentialBackOff
 ```
 
 ## Events

--- a/test/error.jl
+++ b/test/error.jl
@@ -1,5 +1,14 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+@test length(ExponentialBackOff(n=10)) == 10
+@test collect(ExponentialBackOff(n=10, first_delay=0.01))[1] == 0.01
+@test maximum(ExponentialBackOff(n=10, max_delay=0.06)) == 0.06
+ratio(x) = x[2:end]./x[1:end-1]
+@test all(x->isapprox(x,10.0), ratio(collect(
+            ExponentialBackOff(n=10, max_delay=Inf, factor=10, jitter=0.0))))
+srand(12345)
+@test (mean(ratio(collect(ExponentialBackOff(n=100, max_delay=Inf, factor=1, jitter=0.1)))) - 1.0) < 1e-4
+
 let
     function foo_error(c, n)
         c[1] += 1
@@ -16,42 +25,42 @@ let
 
     # Success on second attempt
     c = [0]
-    @test retry(foo_error;n=1)(c,1) == 7
+    @test retry(foo_error)(c,1) == 7
     @test c[1] == 2
 
     # 2 failed retry attempts, so exception is raised
     c = [0]
-    ex = try retry(foo_error;n=2)(c,3) catch e; e end
+    ex = try retry(foo_error, delays=ExponentialBackOff(n=2))(c,3) catch e; e end
     @test ex.msg == "foo"
     @test c[1] == 3
 
     c = [0]
-    ex = try retry(foo_error, ErrorException)(c,2) catch e; e end
+    ex = try retry(foo_error, check=(s,e)->(s,isa(e, ErrorException)))(c,2) catch e; e end
     @test typeof(ex) == ErrorException
     @test ex.msg == "foo"
     @test c[1] == 2
 
     c = [0]
-    ex = try retry(foo_error, e->e.msg == "foo")(c,2) catch e; e end
+    ex = try retry(foo_error, check=(s,e)->(s,e.msg == "foo"))(c,2) catch e; e end
     @test typeof(ex) == ErrorException
     @test ex.msg == "foo"
     @test c[1] == 2
 
     # No retry if condition does not match
     c = [0]
-    ex = try retry(foo_error, e->e.msg == "bar"; n=3)(c,2) catch e; e end
+    ex = try retry(foo_error, check=(s,e)->(s,e.msg == "bar"))(c,2) catch e; e end
     @test typeof(ex) == ErrorException
     @test ex.msg == "foo"
     @test c[1] == 1
 
     c = [0]
-    ex = try retry(foo_error, e->e.http_status_code == "503")(c,2) catch e; e end
+    ex = try retry(foo_error, check=(s,e)->(s,try e.http_status_code == "503" end != true))(c,2) catch e; e end
     @test typeof(ex) == ErrorException
     @test ex.msg == "foo"
-    @test c[1] == 1
+    @test c[1] == 2
 
     c = [0]
-    ex = try retry(foo_error, SystemError)(c,2) catch e; e end
+    ex = try retry(foo_error, check=(s,e)->(s,isa(e,SystemError)))(c,2) catch e; e end
     @test typeof(ex) == ErrorException
     @test ex.msg == "foo"
     @test c[1] == 1


### PR DESCRIPTION
retry as it is is GREAT!  however, it's not flexible enough for my needs.  this PR simply hoists all of the arbitrary hard-coded constants up to keyword arguments.  it also add the ability to display a custom message at each retry.  lastly it interpolates the global default values into the docstring so the two don't get out of sync.

@amitmurthy @samoconnor 