### PR TITLE
prevent lowering from renaming globals nested in renamed locals variables

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2373,7 +2373,9 @@
                 (new-renames (append (map cons need-rename renamed) ;; map from definition name -> gensym name
                                      (map cons need-rename-def renamed-def)
                                      (filter (lambda (ren) ;; old renames list, with anything in vars removed
-                                               (not (memq (car ren) all-vars)))
+                                               (not (or (memq (car ren) all-vars)
+                                                        (memq (car ren) iglo)
+                                                        (memq (car ren) glob))))
                                              renames)))
                 (new-env (append all-vars glob env))
                 (new-iglo (append iglo implicitglobals))

--- a/test/core.jl
+++ b/test/core.jl
@@ -548,6 +548,18 @@ let
 end
 @test glob_x3 == 12
 
+# interaction between local variable renaming and nested globals (#19333)
+x19333 = 1
+function f19333(x19333)
+    return let x19333 = x19333
+        g19333() = (global x19333 += 2)
+        g19333() + (x19333 += 1)
+    end + (x19333 += 1)
+end
+@test f19333(0) == 5
+@test f19333(0) == 7
+@test x19333 == 5
+
 # let - new variables, including undefinedness
 function let_undef()
     first = true


### PR DESCRIPTION
fix #19333

(note for backporting: I think the `all-vars` variable was simply `vars` in release-0.5, but that otherwise the code is fairly similar)