### PR TITLE
Correct not working examples in differences from R section

### DIFF
--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -142,7 +142,12 @@ noteworthy differences:
   index range.  For example, ``c(1, 2, 3, 4) + c(1, 2)`` is valid R but the
   equivalent ``[1, 2, 3, 4] + [1, 2]`` will throw an error in Julia.
 - Julia's :func:`map` takes the function first, then its arguments, unlike
-  ``lapply(<structure>, function, ...)`` in R.
+  ``lapply(<structure>, function, ...)`` in R. Similarly Julia's equivalent of
+  ``apply(X, MARGIN, FUN, ...)`` in R is :func:`mapslices` where function is a
+  first argument.
+- Multivariate apply in R, e.g. ``mapply(choose, 11:13, 1:3)``, can be written as
+  ``broadcast(binomial, 11:13, 1:3)`` in Julia. Equivalently Julia offers a shorter
+  dot syntax for vectorizing functions ``binomial.(11:13, 1:3)``.
 - Julia uses ``end`` to denote the end of conditional blocks, like ``if``,
   loop blocks, like ``while``/``for``, and functions. In lieu of the one-line
   ``if ( cond ) statement``, Julia allows statements of the form

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -140,9 +140,9 @@ noteworthy differences:
 - Like many languages, Julia does not always allow operations on vectors of
   different lengths, unlike R where the vectors only need to share a common
   index range.  For example, ``c(1,2,3,4) + c(1,2)`` is valid R but the
-  equivalent ``[1:4] + [1:2]`` will throw an error in Julia.
-- Julia's :func:`apply` takes the function first, then its arguments, unlike
-  ``lapply(<structure>, function, arg2, ...)`` in R.
+  equivalent ``[1,2,3,4] + [1,2]`` will throw an error in Julia.
+- Julia's :func:`map` takes the function first, then its arguments, unlike
+  ``lapply(<structure>, function, ...)`` in R.
 - Julia uses ``end`` to denote the end of conditional blocks, like ``if``,
   loop blocks, like ``while``/``for``, and functions. In lieu of the one-line
   ``if ( cond ) statement``, Julia allows statements of the form

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -133,14 +133,14 @@ noteworthy differences:
 - In Julia, not all data structures support logical indexing. Furthermore,
   logical indexing in Julia is supported only with vectors of length equal to
   the object being indexed. For example:
-  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE)]`` is equivalent to ``c(1,3)``.
-  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE, TRUE, FALSE)]`` is equivalent to ``c(1,3)``.
+  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE)]`` is equivalent to ``c(1, 3)``.
+  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE, TRUE, FALSE)]`` is equivalent to ``c(1, 3)``.
   - In Julia, ``[1, 2, 3, 4][[true, false]]`` throws a :exc:`BoundsError`.
   - In Julia, ``[1, 2, 3, 4][[true, false, true, false]]`` produces ``[1, 3]``.
 - Like many languages, Julia does not always allow operations on vectors of
   different lengths, unlike R where the vectors only need to share a common
-  index range.  For example, ``c(1,2,3,4) + c(1,2)`` is valid R but the
-  equivalent ``[1,2,3,4] + [1,2]`` will throw an error in Julia.
+  index range.  For example, ``c(1, 2, 3, 4) + c(1, 2)`` is valid R but the
+  equivalent ``[1, 2, 3, 4] + [1, 2]`` will throw an error in Julia.
 - Julia's :func:`map` takes the function first, then its arguments, unlike
   ``lapply(<structure>, function, ...)`` in R.
 - Julia uses ``end`` to denote the end of conditional blocks, like ``if``,


### PR DESCRIPTION
1. `[1:4]+[1:2]` in Julia is not equivalent of `c(1,2,3,4)+c(1,2)` in R.
2. I am not aware of `apply` function in base Julia. I would say that the closest equivalent of `lapply` is `map`.