### PR TITLE
Don't require write permissions in readdlm

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -115,7 +115,9 @@ function readdlm_auto(input::AbstractString, dlm::Char, T::Type, eol::Char, auto
     use_mmap = get(optsd, :use_mmap, is_windows() ? false : true)
     fsz = filesize(input)
     if use_mmap && fsz > 0 && fsz < typemax(Int)
-        a = Mmap.mmap(input, Vector{UInt8}, (Int(fsz),))
+        a = open(input, "r") do f
+            Mmap.mmap(f, Vector{UInt8}, (Int(fsz),))
+        end
         # TODO: It would be nicer to use String(a) without making a copy,
         # but because the mmap'ed array is not NUL-terminated this causes
         # jl_try_substrtod to segfault below.

--- a/test/datafmt.jl
+++ b/test/datafmt.jl
@@ -262,3 +262,13 @@ for writefunc in ((io,x) -> show(io, "text/csv", x),
         @test vec(readcsv(io)) == x
     end
 end
+
+# Test that we can read a write protected file
+let fn = tempname()
+    open(fn, "w") do f
+        write(f, "Julia")
+    end
+    chmod(fn, 0o444)
+    readdlm(fn)[] == "Julia"
+    rm(fn)
+end


### PR DESCRIPTION
Right now `readdlm` fails when trying to read a read-only file because `Mmap.mmap` requires write permissions. In any case, I don't think that `readdlm` should ask for write permissions but I'm wondering if `mmap`'s default should be changed such that it doesn't ask for write permissions.