### PR TITLE
Patch LibSSH2 for missing macro definition on FreeBSD

### DIFF
--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -28,7 +28,11 @@ $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: $(SRCD
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-encryptedpem.patch
 	echo 1 > $@
 
-$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied
+$(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-netinet-in.patch-applied: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied
+	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p0 -f < $(SRCDIR)/patches/libssh2-netinet-in.patch
+	echo 1 > $@
+
+$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-netinet-in.patch-applied
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(CMAKE) $(dir $<) $(LIBSSH2_OPTS)

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -28,6 +28,8 @@ $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: $(SRCD
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-encryptedpem.patch
 	echo 1 > $@
 
+# Patch submitted upstream: https://github.com/libssh2/libssh2/pull/148
+# Remove the patch here once we're using a version of libssh2 that includes the upstream patch
 $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-netinet-in.patch-applied: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p0 -f < $(SRCDIR)/patches/libssh2-netinet-in.patch
 	echo 1 > $@

--- a/deps/patches/libssh2-netinet-in.patch
+++ b/deps/patches/libssh2-netinet-in.patch
@@ -1,0 +1,10 @@
+--- tests/CMakeLists.txt	2016-10-24 23:43:39.000000000 -0700
++++ tests/CMakeLists.txt	2016-11-15 20:44:32.132344000 -0800
+@@ -47,6 +47,7 @@
+ check_include_files(arpa/inet.h HAVE_ARPA_INET_H)
+ check_include_files(windows.h HAVE_WINDOWS_H)
+ check_include_files(winsock2.h HAVE_WINSOCK2_H)
++check_include_files(netinet/in.h HAVE_NETINET_IN_H)
+ configure_file(
+   "${CMAKE_CURRENT_SOURCE_DIR}/libssh2_config_cmake.h.in"
+   "${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h")


### PR DESCRIPTION
The CMakeLists.txt file in the tests directory doesn't define the C preprocessor macro `HAVE_NETINET_IN_H` to indicate the presence of the system header file netinet/in.h, but the macro gets referenced in one of the files. On FreeBSD this causes the build to error, since netinet/in.h defines types used in the file.

This PR includes a patch to define the macro and a corresponding update to the LibSSH2 makefile.