### PR TITLE
IDEA: patch LLVM to make 'code_llvm_ display source location information 

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -481,6 +481,11 @@ $(eval $(call LLVM_PATCH,llvm-arm-fix-prel31))
 $(eval $(call LLVM_PATCH,llvm-D25865-cmakeshlib))
 endif # LLVM_VER
 
+# patch the AsmWriter to print debug info comments
+ifeq ($(LLVM_VER_SHORT),3.9)
+$(eval $(call LLVM_PATCH,llvm-3.9-asmwriter-di))
+endif
+
 ifeq ($(LLVM_VER),3.7.1)
 ifeq ($(BUILD_LLDB),1)
 $(eval $(call LLVM_PATCH,lldb-3.7.1))

--- a/deps/patches/llvm-3.9-asmwriter-di.patch
+++ b/deps/patches/llvm-3.9-asmwriter-di.patch
@@ -1,0 +1,43 @@
+diff --git a/lib/IR/AsmWriter.cpp b/lib/IR/AsmWriter.cpp
+index 9b2399d..e7bb1ad 100644
+--- a/lib/IR/AsmWriter.cpp
++++ b/lib/IR/AsmWriter.cpp
+@@ -2115,6 +2115,8 @@ private:
+   // printGCRelocateComment - print comment after call to the gc.relocate
+   // intrinsic indicating base and derived pointer names.
+   void printGCRelocateComment(const GCRelocateInst &Relocate);
++
++  DILocation *InstrLoc = nullptr;
+ };
+ } // namespace
+ 
+@@ -2710,6 +2712,7 @@ void AssemblyWriter::printFunction(const Function *F) {
+ 
+     Out << " {";
+     // Output all of the function's basic blocks.
++    InstrLoc = nullptr;
+     for (const BasicBlock &BB : *F)
+       printBasicBlock(&BB);
+ 
+@@ -2792,6 +2795,21 @@ void AssemblyWriter::printBasicBlock(const BasicBlock *BB) {
+ 
+ /// printInstructionLine - Print an instruction and a newline character.
+ void AssemblyWriter::printInstructionLine(const Instruction &I) {
++  DILocation *NewInstrLoc = I.getDebugLoc();
++  if (NewInstrLoc != nullptr && NewInstrLoc != InstrLoc) {
++    bool NewFile = false;
++    if (!NewInstrLoc->getFilename().empty() &&
++        (InstrLoc == nullptr || NewInstrLoc->getFilename() != InstrLoc->getFilename())) {
++      Out << "; Filename: " << NewInstrLoc->getFilename() << '\n';
++      NewFile = true;
++    }
++
++    if (NewInstrLoc->getLine() != UINT_MAX &&
++        (NewFile || NewInstrLoc->getLine() != InstrLoc->getLine()))
++      Out << "; Source line: " << NewInstrLoc->getLine() << '\n';
++  }
++  InstrLoc = NewInstrLoc;
++
+   printInstruction(I);
+   Out << '\n';
+ }


### PR DESCRIPTION
This is a debugging patch I had floating around, which multiple people have mentioned would be very useful to have by default. It patches LLVM's `AssemblyWriter` to make it emit source location information:
```julia
julia> code_llvm(STDOUT, sin, Tuple{Int}, false)

define double @julia_sin_61930(i64) #0 !dbg !5 {
top:
; Filename: math.jl
; Source line: 265
  %1 = sitofp i64 %0 to double, !dbg !7
  %2 = call double @julia_sin_61931(double %1) #0, !dbg !7
  ret double %2, !dbg !7
}
```

Not sure if this is worth patching LLVM for, but it has helped me greatly when hunting down the origin of runtime calls in LLVM IR output. If there's interest, I could clean this up (make sure it works on all supported LLVM versions, make sure it works with `@code_llvm`, maybe try to still have it strip `!dbg` metadata, etc).

cc @andreasnoack, @jrevels