### PR TITLE
RFC: Use super script T as tranpose operator instead of .'

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1116,4 +1116,8 @@ Filesystem.stop_watching(stream::Filesystem._FDWatcher) = depwarn("stop_watching
 @deprecate takebuf_array take!
 @deprecate takebuf_string(b) String(take!(b))
 
+# Deprecate .' syntax for transpose
+matlabtranspose(x) = depwarn(string(".' is now depreacted in favor of ᵀ, i.e. superscipt T which ",
+    "you can type \\^T[tab] in the REPL, Jupyter, and most editors"), :matlabtranspose)
+
 # End deprecations scheduled for 0.6

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -662,6 +662,7 @@ export
     lufact!,
     lufact,
     lyap,
+    matlabtranspose,
     norm,
     normalize,
     normalize!,

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -21,7 +21,7 @@
                  (if (and (pair? (caddr e)) (memq (caaddr e) '(quote inert)))
                      (deparse (cadr (caddr e)))
                      (string #\( (deparse (caddr e)) #\)))))
-        ((memq (car e) '(... |'| |.'|))
+        ((memq (car e) '(... |'| |.'| ᵀ))
          (string (deparse (cadr e)) (car e)))
         ((or (syntactic-op? (car e)) (eq? (car e) '|<:|) (eq? (car e) '|>:|))
          (string (deparse (cadr e)) (car e) (deparse (caddr e))))
@@ -206,7 +206,8 @@
                            (pair? (caddr x))
                            (length> (caddr x) 1)
                            (eq? (cadr (caddr x)) 'Vararg)))))
-(define (trans?  x) (and (pair? x) (eq? (car x) '|.'|)))
+(define (trans? x) (and (pair? x) (eq? (car x) 'ᵀ)))
+(define (matlabtrans?  x) (and (pair? x) (eq? (car x) '|.'|)))
 (define (ctrans? x) (and (pair? x) (eq? (car x) '|'|)))
 
 (define (make-assignment l r) `(= ,l ,r))

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -120,6 +120,8 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
         return 1;
     if (wc < 0xA1 || wc > 0x10ffff)
         return 0;
+    if (wc == 0x1d40)   // superscript transpose
+        return 0;
     utf8proc_category_t cat = utf8proc_category((utf8proc_int32_t) wc);
     if (is_wc_cat_id_start(wc, cat)) return 1;
     if (cat == UTF8PROC_CATEGORY_MN || cat == UTF8PROC_CATEGORY_MC ||

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -89,11 +89,12 @@
       (and (pair? ex)
            (eq? '$ (car ex)))))
 
-(define trans-op (string->symbol ".'"))
+(define trans-op (string->symbol "ᵀ"))
 (define ctrans-op (string->symbol "'"))
+(define matlabtrans-op (string->symbol ".'"))
 (define vararg-op (string->symbol "..."))
 
-(define operators (list* '~ '! '¬ '-> '√ '∛ '∜ ctrans-op trans-op vararg-op
+(define operators (list* '~ '! '¬ '-> '√ '∛ '∜ ctrans-op trans-op matlabtrans-op vararg-op
                          (delete-duplicates
                           (apply append (map eval prec-names)))))
 
@@ -842,7 +843,7 @@
            (large-number? expr)
            (not (number? t))    ;; disallow "x.3" and "sqrt(2)2"
            ;; to allow x'y as a special case
-           #;(and (pair? expr) (memq (car expr) '(|'| |.'|))
+           #;(and (pair? expr) (memq (car expr) '(|'| |.'| ᵀ))
                 (not (memv t '(#\( #\[ #\{))))
            )
        (not (ts:space? s))
@@ -1057,7 +1058,7 @@
                            `(macrocall (|.| ,ex (quote ,(cadr name)))
                                        ,@(cddr name))
                            `(|.| ,ex (quote ,name))))))))
-            ((|.'| |'|)
+            ((|.'| |'| ᵀ)
              (if (ts:space? s)
                  (error (string "space not allowed before \"" t "\"")))
              (take-token s)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2122,8 +2122,9 @@
                      ,.(apply append rows)))
             `(call (top typed_vcat) ,t ,@a)))))
 
-   '|'|  (lambda (e) `(call ctranspose ,(expand-forms (cadr e))))
-   '|.'| (lambda (e) `(call  transpose ,(expand-forms (cadr e))))
+   'ᵀ    (lambda (e) `(call       transpose ,(expand-forms (cadr e))))
+   '|'|  (lambda (e) `(call      ctranspose ,(expand-forms (cadr e))))
+   '|.'| (lambda (e) `(call matlabtranspose ,(expand-forms (cadr e))))
 
    'ccall
    (lambda (e)


### PR DESCRIPTION
Now that we have gotten used to the nice dot broadcast syntax, our `.'` transpose seems like an odd inheritance from Matlab. Therefore in this PR, I'm trying out `ᵀ` as the symbol for (non-conjugate) transpose of a matrix, i.e.
```
julia> A = randn(4,3)
A4×3 Array{Float64,2}:
 -0.440397   -1.4602      -0.28655
 -1.20043     1.15012     -0.908555
  0.455838   -0.00121238   0.101605
 -0.0430458   0.411735    -1.88737

julia> Aᵀ
3×4 Array{Float64,2}:
 -0.440397  -1.20043    0.455838    -0.0430458
 -1.4602     1.15012   -0.00121238   0.411735
 -0.28655   -0.908555   0.101605    -1.88737
```
For most of us, it is ~~two~~three keystrokes more (`\^T[tab]`) but I think it reads so much nicer that it is worth it. Only minor problem is if `Aᵀ` is used as an identified but it will error and it will probably be a minor inconvenience to change the name.