### PR TITLE
Ensure greater resilience when dealing with possible testing errors

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,7 +155,7 @@ cd(dirname(@__FILE__)) do
     print_with_color(:white, rpad("Test:",name_align," "), " | ")
     print_with_color(:white, "Total time (s): | GC time (s): | Percent in gc: | Allocated (MB): | RSS (MB):\n")
     for res in results
-        if !isa(res[2][1], RemoteException)
+        if !isa(res[2][1], Exception)
             print_with_color(:white, rpad("$(res[1])",name_align," "), " | ")
             time_str = @sprintf("%7.2f",res[2][2])
             print_with_color(:white, rpad(time_str,elapsed_align," "), " | ")


### PR DESCRIPTION
While trying to track down testing errors, it's annoying that segfaults in the remote julia processes cause exceptions that are not caught by this if statement, causing the parent julia process to fail.  This should hopefully make things a little more resilient.