### PR TITLE
Patch OpenBLAS to build on FreeBSD

### DIFF
--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -74,6 +74,8 @@ endif
 # Do not overwrite the "-j" flag
 OPENBLAS_BUILD_OPTS += MAKE_NB_JOBS=0
 
+# Patch submitted upstream: https://github.com/xianyi/OpenBLAS/pull/1015
+# Remove the patch here once we're using a version of OpenBLAS that includes the upstream patch
 $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-freebsd.patch-applied: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/source-extracted
 	cd $(BUILDDIR)/$(OPENBLAS_SRC_DIR) && patch -p0 -f < $(SRCDIR)/patches/openblas-freebsd.patch
 	echo 1 > $@

--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -74,7 +74,11 @@ endif
 # Do not overwrite the "-j" flag
 OPENBLAS_BUILD_OPTS += MAKE_NB_JOBS=0
 
-$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/source-extracted
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-freebsd.patch-applied: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/source-extracted
+	cd $(BUILDDIR)/$(OPENBLAS_SRC_DIR) && patch -p0 -f < $(SRCDIR)/patches/openblas-freebsd.patch
+	echo 1 > $@
+
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-freebsd.patch-applied
 	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' $(dir $<)/Makefile.system
 	echo 1 > $@
 

--- a/deps/patches/openblas-freebsd.patch
+++ b/deps/patches/openblas-freebsd.patch
@@ -1,0 +1,11 @@
+--- driver/others/blas_server.c	2016-08-31 20:58:42.000000000 -0700
++++ driver/others/blas_server.c	2016-11-16 21:24:52.282666000 -0800
+@@ -70,7 +70,7 @@
+ /*********************************************************************/
+ 
+ #include "common.h"
+-#if defined(OS_LINUX) || defined(OS_NETBSD) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_SUNOS)
++#if defined(OS_LINUX) || defined(OS_NETBSD) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_SUNOS) || defined(OS_FREEBSD)
+ #include <dlfcn.h>
+ #include <signal.h>
+ #include <sys/resource.h>


### PR DESCRIPTION
This PR provides a minimal patch to OpenBLAS that allows it to build on FreeBSD. The issue was that certain header files weren't being included because FreeBSD was omitted from the OS conditional that includes them. The change should have no effect at all on other systems.

The patch has been submitted upstream: https://github.com/xianyi/OpenBLAS/pull/1015