### PR TITLE
fix dispatch loop introduced by #19305

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1293,10 +1293,10 @@ julia> hvcat((2,2,2), a,b,c,d,e,f)
 If the first argument is a single integer `n`, then all block rows are assumed to have `n`
 block columns.
 """
-hvcat(rows::Tuple{Vararg{Int}}, xs::AbstractMatrix...) = typed_hvcat(promote_eltype(xs...), rows, xs...)
-hvcat{T}(rows::Tuple{Vararg{Int}}, xs::AbstractMatrix{T}...) = typed_hvcat(T, rows, xs...)
+hvcat(rows::Tuple{Vararg{Int}}, xs::AbstractVecOrMat...) = typed_hvcat(promote_eltype(xs...), rows, xs...)
+hvcat{T}(rows::Tuple{Vararg{Int}}, xs::AbstractVecOrMat{T}...) = typed_hvcat(T, rows, xs...)
 
-function typed_hvcat{T}(::Type{T}, rows::Tuple{Vararg{Int}}, as::AbstractMatrix...)
+function typed_hvcat{T}(::Type{T}, rows::Tuple{Vararg{Int}}, as::AbstractVecOrMat...)
     nbr = length(rows)  # number of block rows
 
     nc = 0

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -785,3 +785,6 @@ end
 @test ndims((1:3)[:,:,1:1,:]) == 4
 @test ndims((1:3)[:,:,1:1]) == 3
 @test ndims((1:3)[:,:,1:1,:,:,[1]]) == 6
+
+# dispatch loop introduced in #19305
+@test [(1:2) zeros(2,2); ones(3,3)] == [[1,2] zeros(2,2); ones(3,3)] == [reshape([1,2],2,1) zeros(2,2); ones(3,3)]


### PR DESCRIPTION
This fixes a dispatch loop in `hvcat` introduced by #19305, pointed out by @tkelman, which broke the tests in ImageFiltering.jl (cc @timholy).

It also makes `hvcat` significantly faster for concatenating 1d arrays or combinations of 1d and 2d arrays.  e.g. `@benchmark [(1:10^4) (1:10^4) (1:10^4) (1:10^4); (1:10^4) (1:10^4) (1:10^4) (1:10^4); (1:10^4) (1:10^4) (1:10^4) (1:10^4); (1:10^4) (1:10^4) (1:10^4) (1:10^4)]` is 2-6x faster than in 0.5.