### PR TITLE
Add function `enumerate_countfrom` to mirror Python's `enumerate(x, n)`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -961,7 +961,10 @@ export
     next,
     start,
 
-    enumerate,  # re-exported from Iterators
+    # re-exported from Iterators
+    enumerate,
+    enumerate_countfrom,
+
     zip,
 
 # object identity and equality

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -6,7 +6,7 @@ import Base: start, done, next, isempty, length, size, eltype, iteratorsize, ite
 
 using Base: tuple_type_cons, SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo
 
-export enumerate, zip, rest, countfrom, take, drop, cycle, repeated, product, flatten, partition
+export enumerate, enumerate_countfrom, zip, rest, countfrom, take, drop, cycle, repeated, product, flatten, partition
 
 _min_length(a, b, ::IsInfinite, ::IsInfinite) = min(length(a),length(b)) # inherit behaviour, error
 _min_length(a, b, A, ::IsInfinite) = length(a)
@@ -54,6 +54,23 @@ julia> for (index, value) in enumerate(a)
 ```
 """
 enumerate(iter) = Enumerate(iter)
+
+"""
+    enumerate_countfrom(iter, n)
+
+Returns an iterator that yields `(i + n, e)` where `i` is a counter starting
+at `n`, and `e` is the `i - n + 1`-th element from the iterator.
+
+```jldoctest
+julia> for (i, e) in enumerate_countfrom(1:3, 5)
+           println(i, " ", e)
+       end
+5 1
+6 2
+7 3
+```
+"""
+enumerate_countfrom(iter, n::Integer) = ((i+n-1, e) for (i,e) in enumerate(iter))
 
 length(e::Enumerate) = length(e.itr)
 size(e::Enumerate) = size(e.itr)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -130,7 +130,7 @@ include("associative.jl")
 include("dict.jl")
 include("set.jl")
 include("iterators.jl")
-using .Iterators: zip, enumerate
+using .Iterators: zip, enumerate, enumerate_countfrom
 using .Iterators: Flatten, product  # for generators
 
 # Definition of StridedArray

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -399,3 +399,19 @@ for T in (UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int128, BigInt)
     @test length(repeated(1, T(5))) == 5
     @test collect(partition(1:5, T(5)))[1] == collect(1:5)
 end
+
+# Issue #19332: enumerate from a specific counting-index
+#               (like Python's `enumerate(x, n)`)
+let i = 1:5
+    @test collect(enumerate_countfrom(i, 5)) == [(5,1),
+                                                 (6,2),
+                                                 (7,3),
+                                                 (8,4),
+                                                 (9,5)]
+
+    @test collect(enumerate_countfrom(i, 10)) == [(10,1),
+                                                  (11,2),
+                                                  (12,3),
+                                                  (13,4),
+                                                  (14,5)]
+end


### PR DESCRIPTION
~~Adds methods to `enumerate` so that we can specify a subset of an iterator that we wish to iterate over.~~

Addresses #19332.

Adds, and exports, function `enumerate_countfrom` which behaves exactly like `enumerate(iter, n)` in Python.