### PR TITLE
RFC: Disable GC state assertion when threading is disabled

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -818,7 +818,9 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
     // to workaround a llvm bug.
     // Ref https://llvm.org/bugs/show_bug.cgi?id=27190
     jl_gc_pool_t *p = (jl_gc_pool_t*)((char*)ptls + pool_offset);
+#ifdef JULIA_ENABLE_THREADING
     assert(ptls->gc_state == 0);
+#endif
 #ifdef MEMDEBUG
     return jl_gc_big_alloc(ptls, osize);
 #endif


### PR DESCRIPTION
Addresses #19328

This PR implements @yuyichao's suggestion of simply disabling the assertion when building with `JULIA_THREADS=0`. I don't know whether this is the best solution, but it'll be here if folks think it is. To be frank, I've no idea why the assertion fails now when it didn't before.