### PR TITLE
ignore/remove *.dwo files generated by gcc fission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 *.exe
 *.dll
+*.dwo
 *.do
 *.o
 *.obj

--- a/src/Makefile
+++ b/src/Makefile
@@ -283,7 +283,7 @@ libjulia-release: $(build_shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT) $(PUBLI
 clean:
 	-rm -fr $(build_shlibdir)/libjulia* $(build_shlibdir)/libccalltest*
 	-rm -f $(BUILDDIR)/julia_flisp.boot $(BUILDDIR)/julia_flisp.boot.inc
-	-rm -f $(BUILDDIR)/*.dbg.obj $(BUILDDIR)/*.o $(BUILDDIR)/*.$(SHLIB_EXT) $(BUILDDIR)/*.a
+	-rm -f $(BUILDDIR)/*.dbg.obj $(BUILDDIR)/*.o $(BUILDDIR)/*.dwo $(BUILDDIR)/*.$(SHLIB_EXT) $(BUILDDIR)/*.a
 	-rm -f $(BUILDDIR)/julia_version.h
 
 clean-flisp:

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -156,7 +156,7 @@ static inline unsigned long JL_CONST_FUNC jl_thread_self(void)
  * we use only a compiler (signal) barrier and use the signal handler to do the
  * synchronization in order to lower the mutator overhead as much as possible.
  *
- * We use the compiler instrinsics to implement a similar API to the c11/c++11
+ * We use the compiler intrinsics to implement a similar API to the c11/c++11
  * one instead of using it directly because,
  *
  *     1. We support GCC 4.7 and GCC add support for c11 atomics in 4.9.


### PR DESCRIPTION
- ignore/remove *.dwo files generated by gcc fission
- typo fix

----
I did a commit about how Make.inc includes Make.user, and I realize I wrong: I did notice I should use `override` keyword in Make.user to set CC/CXX. Sorry for that, now I removed the wrong commit.
