### PR TITLE
Integrate test segfaults with the Testset scaffolding

### DIFF
--- a/test/util/segfault.jl
+++ b/test/util/segfault.jl
@@ -1,0 +1,1 @@
+unsafe_load(convert(Ptr{UInt8},C_NULL))

--- a/test/util/throw_error_exception.jl
+++ b/test/util/throw_error_exception.jl
@@ -1,0 +1,1 @@
+error("This purposefully dies")


### PR DESCRIPTION
Fixes #19376

Also add utility tests `segfault` and `throw_error_exception` that do exactly
what they sound like.

I am most likely abusing the testset framework here, specifically [this line](https://github.com/JuliaLang/julia/blob/fe2f271520aa36c2029cce3ba65194ff3fdf890b/test/runtests.jl#L156) is particularly bad, I think, where I'm co-opting the `Base.Test.Error` type and doing things like passing in an empty list instead of a backtrace, the testset name instead of the original expression, etc...

I would have marked the test as `Broken` instead of `Error` and set `o_ts.anynonpass` to `true`, but this gets clobbered by `Base.Test.print_test_results()` because that recalculates `o_ts.anynonpass`.  This makes me think that we shouldn't be setting `o_ts.anynonpass` anywhere inside `test/runtests.jl`.

Pinging @kshyatt as you're the last person to touch this stuff and you probably know the "right" way to fix this.  To test, run something like `./julia test/runtests.jl keywordargs inference dates/arithmetic util/segfault`