### PR TITLE
Use zero in istriu, istril methods

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -263,8 +263,8 @@ end
 transpose(M::Bidiagonal) = Bidiagonal(M.dv, M.ev, !M.isupper)
 ctranspose(M::Bidiagonal) = Bidiagonal(conj(M.dv), conj(M.ev), !M.isupper)
 
-istriu(M::Bidiagonal) = M.isupper || all(M.ev .== 0)
-istril(M::Bidiagonal) = !M.isupper || all(M.ev .== 0)
+istriu(M::Bidiagonal) = M.isupper || all(M.ev .== zero(eltype(M)))
+istril(M::Bidiagonal) = !M.isupper || all(M.ev .== zero(eltype(M)))
 
 function tril!(M::Bidiagonal, k::Integer=0)
     n = length(M.dv)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -870,8 +870,9 @@ true
 """
 function istriu(A::AbstractMatrix)
     m, n = size(A)
+    z = zero(eltype(A))
     for j = 1:min(n,m-1), i = j+1:m
-        if A[i,j] != 0
+        if A[i,j] != z
             return false
         end
     end
@@ -905,8 +906,9 @@ true
 """
 function istril(A::AbstractMatrix)
     m, n = size(A)
+    z = zero(eltype(A))
     for j = 2:n, i = 1:min(j-1,m)
-        if A[i,j] != 0
+        if A[i,j] != z
             return false
         end
     end

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -206,8 +206,8 @@ eigvecs{T<:BlasFloat,Eigenvalue<:Real}(A::SymTridiagonal{T}, eigvals::Vector{Eig
 
 #tril and triu
 
-istriu(M::SymTridiagonal) = all(M.ev .== 0)
-istril(M::SymTridiagonal) = all(M.ev .== 0)
+istriu(M::SymTridiagonal) = all(M.ev .== zero(eltype(M)))
+istril(M::SymTridiagonal) = all(M.ev .== zero(eltype(M)))
 
 function tril!(M::SymTridiagonal, k::Integer=0)
     n = length(M.dv)
@@ -526,8 +526,8 @@ end
 
 #tril and triu
 
-istriu(M::Tridiagonal) = all(M.dl .== 0)
-istril(M::Tridiagonal) = all(M.du .== 0)
+istriu(M::Tridiagonal) = all(M.dl .== zero(eltype(M)))
+istril(M::Tridiagonal) = all(M.du .== zero(eltype(M)))
 
 function tril!(M::Tridiagonal, k::Integer=0)
     n = length(M.d)


### PR DESCRIPTION
This PR replaces `0` with `zero(T)` for appropriate `T` in methods of `istriu` and `istril`. I'm not sure what tests to add if any since the behavior is unchanged for subtypes of `Number` found in Base, and there are already some tests for these methods. I'm happy to add some if there are suggestions. I was unable to detect any regressions from these changes using BaseBenchmarks and BenchmarkTools. 

For context, I noticed this when playing around with matrices of [Unitful](https://github.com/ajkeller34/Unitful.jl) numbers, where comparisons with `0` are problematic.