### PR TITLE
Generalized CartesianRange

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -118,7 +118,7 @@ function _copy!{T,N,perm}(P::PermutedDimsArray{T,N,perm}, src)
     return P
 end
 
-@noinline function _permutedims!(P::PermutedDimsArray, src, R1::CartesianRange{CartesianIndex{0}}, R2, R3, ds, dp)
+@noinline function _permutedims!(P::PermutedDimsArray, src, R1::CartesianRange{0}, R2, R3, ds, dp)
     ip, is = indices(src, dp), indices(src, ds)
     for jo in first(ip):8:last(ip), io in first(is):8:last(is)
         for I3 in R3, I2 in R2


### PR DESCRIPTION
This PR provides a different implementation of CartesianRange which is more general in that it also allows `StepRange`s. I have been conservative in restricting everything to subtypes of `OrdinalRange{Int,Int}`, though most of the implementation is completely general up to one or two lines. I think a completely general implementation is possible, though for this it would be helpful if `next` is split into `nextval` and `nextstate` as was suggested in a different context some time ago.

I have not been able to detect a noticeable slowdown using some quick tests with BenchmarkTools. If there is one, it cannot be more than a few percent. I would of course like some thoughts and comments, e.g. from @timholy .