### PR TITLE
docfixes.

### DIFF
--- a/base/workerpool.jl
+++ b/base/workerpool.jl
@@ -20,27 +20,28 @@ type WorkerPool <: AbstractWorkerPool
     workers::Set{Int}
     ref::RemoteChannel
 
-    function WorkerPool()
-        wp = WorkerPool(Channel{Int}(typemax(Int)), RemoteChannel())
-        put!(wp.ref, wp)
-        wp
-    end
-
-    """
-        WorkerPool(workers)
-
-    Create a WorkerPool from a vector of worker ids.
-    """
-    function WorkerPool(workers::Vector{Int})
-        pool = WorkerPool()
-        foreach(w->push!(pool, w), workers)
-        return pool
-    end
-
-    # On workers where this pool has been serialized to, instantiate with a dummy local channel.
-    WorkerPool(ref::RemoteChannel) = WorkerPool(Channel{Int}(1), ref)
     WorkerPool(c::Channel, ref::RemoteChannel) = new(c, Set{Int}(), ref)
 end
+
+function WorkerPool()
+    wp = WorkerPool(Channel{Int}(typemax(Int)), RemoteChannel())
+    put!(wp.ref, wp)
+    wp
+end
+
+"""
+    WorkerPool(workers::Vector{Int})
+
+Create a WorkerPool from a vector of worker ids.
+"""
+function WorkerPool(workers::Vector{Int})
+    pool = WorkerPool()
+    foreach(w->push!(pool, w), workers)
+    return pool
+end
+
+# On workers where this pool has been serialized to, instantiate with a dummy local channel.
+WorkerPool(ref::RemoteChannel) = WorkerPool(Channel{Int}(1), ref)
 
 function Base.serialize(S::AbstractSerializer, pool::WorkerPool)
     # Allow accessing a worker pool from other processors. When serialized,

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -1503,7 +1503,7 @@ Array functions
 
    .. Docstring generated from Julia source
 
-   Cumulative operation ``op`` along a dimension ``dim`` (defaults to 1). See also :func:`accumulate!` to use a preallocated output array, both for performance and to control the precision of the output (e.g. to avoid overflow). For common operations there are specialized variants of accumulate, see: :func:`cumsum`\ , :func:`cumprod`
+   Cumulative operation ``op`` along a dimension ``dim`` (defaults to 1). See also :func:`accumulate!` to use a preallocated output array, both for performance and to control the precision of the output (e.g. to avoid overflow). For common operations there are specialized variants of ``accumulate``\ , see: :func:`cumsum`\ , :func:`cumprod`
 
    .. doctest::
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -438,7 +438,7 @@ General Parallel Computing Support
        @async put!(c, remotecall_fetch(long_computation, p))
        isready(c)  # will not block
 
-.. function:: WorkerPool(workers)
+.. function:: WorkerPool(workers::Vector{Int})
 
    .. Docstring generated from Julia source
 
@@ -470,7 +470,7 @@ General Parallel Computing Support
 
    .. Docstring generated from Julia source
 
-   WorkerPool containing idle ``workers()`` (used by ``remote(f)``\ ).
+   WorkerPool containing idle ``workers()`` - used by ``remote(f)`` and ``pmap`` (by default).
 
 .. function:: remote([::AbstractWorkerPool], f) -> Function
 


### PR DESCRIPTION
Moved a few of the constructors outside the `type` definition as it appears that docstrings within a `type` definition are not recognized. 