### PR TITLE
Add test coverage for SubArray to linalg/dense.jl

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -163,10 +163,10 @@ function tril!(M::AbstractMatrix, k::Integer)
 end
 tril(M::Matrix, k::Integer) = tril!(copy(M), k)
 
-function gradient(F::Vector, h::Vector)
+function gradient(F::AbstractVector, h::Vector)
     n = length(F)
     T = typeof(one(eltype(F))/one(eltype(h)))
-    g = Array{T}(n)
+    g = similar(F, T)
     if n == 1
         g[1] = zero(T)
     elseif n > 1
@@ -309,9 +309,9 @@ kron(a::AbstractVector, b::AbstractVector)=vec(kron(reshape(a,length(a),1),resha
 kron(a::AbstractMatrix, b::AbstractVector)=kron(a,reshape(b,length(b),1))
 kron(a::AbstractVector, b::AbstractMatrix)=kron(reshape(a,length(a),1),b)
 
-^(A::Matrix, p::Integer) = p < 0 ? inv(A^-p) : Base.power_by_squaring(A,p)
+^(A::AbstractMatrix, p::Integer) = p < 0 ? inv(A^-p) : Base.power_by_squaring(A,p)
 
-function ^(A::Matrix, p::Number)
+function ^(A::AbstractMatrix, p::Number)
     if isinteger(p)
         return A^Integer(real(p))
     end


### PR DESCRIPTION
I extended the systematic test coverage in `test/linalg/dense.jl` to include `SubArray` testing in the style of JuliaLang/julia#14731. Previously `gradient` and `^` were not defined for SubArray arguments, so I also modified the signatures of these functions (in `base/linalg/dense.jl`) to make all tests pass.

To note --- I did not edit the spot testing associated with particular issues at the end of `test/linalg/dense.jl` as I was not sure whether this would be useful.

Thanks in advance for reviewing!

ref JuliaLang/LinearAlgebra.jl#299