### PR TITLE
Add detail to installed(pkg) doc

### DIFF
--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -124,7 +124,8 @@ installed() = cd(Entry.installed)
 """
     installed(pkg) -> Void | VersionNumber
 
-If `pkg` is installed, return the installed version number, otherwise return `nothing`.
+If `pkg` is installed, return the installed version number. If `pkg` is registered,
+but not installed, return `nothing`.
 """
 installed(pkg::AbstractString) = cd(Entry.installed,pkg)
 

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -91,7 +91,7 @@ Functions for package development (e.g. ``tag``, ``publish``, etc.) have been mo
 
    .. Docstring generated from Julia source
 
-   If ``pkg`` is installed, return the installed version number, otherwise return ``nothing``\ .
+   If ``pkg`` is installed, return the installed version number. If ``pkg`` is registered, but not installed, return ``nothing``\ .
 
 .. function:: status()
 


### PR DESCRIPTION
Could be some confusion to this ... see e.g. [SO question](http://stackoverflow.com/questions/40826701/pkg-installedaninvalidpackage-should-return-nothing-or-throw-an-error/40832080#40832080)