### PR TITLE
Support partially copied stack in the GC

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -147,7 +147,8 @@ static void NOINLINE save_stack(jl_ptls_t ptls, jl_task_t *t)
     if (t->state == done_sym || t->state == failed_sym)
         return;
     char *frame_addr = (char*)jl_get_frame_addr();
-    size_t nb = (char*)ptls->stackbase - frame_addr;
+    char *stackbase = (char*)ptls->stackbase;
+    size_t nb = stackbase > frame_addr ? stackbase - frame_addr : 0;
     char *buf;
     if (t->stkbuf == NULL || t->bufsz < nb) {
         buf = (char*)jl_gc_alloc_buf(ptls, nb);


### PR DESCRIPTION
This does no really fix a bug but should make embedding in scripting languages a little easier. Copying only part of the stack should be less problematic than copying stack frames that do not expect it so I think we could support that. Bottom line is that I don't really like this but this shouldn't introduce any new segfault.

Doing a stack switch with an stack address higher than `stackbase` can probably still do sth weird (it'll request a unreasonably big buffer to old the stack for example).

This fixes https://github.com/JuliaPy/pyjulia/issues/71 for me and will likely fix https://github.com/JuliaLang/julia/issues/19401 although I have no way to verify the second one.

Apparently people are hitting this as early as 0.3 but I'm not sure how backportable this actually this.....
