### PR TITLE
map/map! for sparse matrices

### DIFF
--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -2,7 +2,7 @@
 
 module SparseArrays
 
-using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape
+using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail
 using Base.Sort: Forward
 using Base.LinAlg: AbstractTriangular, PosDefException
 
@@ -24,7 +24,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     vcat, hcat, hvcat, cat, imag, indmax, ishermitian, kron, length, log, log1p, max, min,
     maximum, minimum, norm, one, promote_eltype, real, reinterpret, reshape, rot180,
     rotl90, rotr90, round, scale!, setindex!, similar, size, transpose, tril,
-    triu, vec, permute!
+    triu, vec, permute!, map, map!
 
 import Base.Broadcast: broadcast_indices
 


### PR DESCRIPTION
This pull request provides (1) a `map`/`map!` implementation specialized for a single (input) sparse matrix, (2) a `map`/`map!` implementation specialized for a pair of (input) sparse matrices, and (3) a general `map`/`map!` implementation capable of efficiently handling an arbitrary number of sparse matrices (within compiler limits). `broadcast`/`broadcast!` over a single (input) sparse matrix being identical to `map`/`map!` over the same, this pull request also reimplements `broadcast`/`broadcast!` over a single (input) sparse matrix as short children of `map`/`map!`.

The semantics of these `map!`/`broadcast!` methods are those discussed in #19372. Notably these `map!`/`broadcast!` methods only allocate when strictly necessary, so for example
```julia
julia> C = spzeros(5,5); A = speye(5); B = sparse(Bidiagonal(zeros(5), ones(4), true));

julia> @allocated map!(*, C, A, B) # after warmup
0
```
Additionally, where these `map!`/`broadcast!` methods do allocate, they do so less pessimistically than the existing `broadcast!` methods.

The specialized `map`/`map!` methods achieve performance similar to corresponding existing `broadcast`/`broadcast!` methods (despite performing slightly more work to enable the more precise allocation behavior). The former win in some cases and the latter in others, with runtime differences usually ~10% or less in (hopefully realistic) tests.

The general `map`/`map!` methods achieve performance not too far behind the methods specialized for pairs of (input) sparse matrices. The latter typically best the former by only 10-35% runtime, though in some cases they're on par and in others the gap stretches to 45%.

Fixes (the `SparseMatrixCSC` part of) #19363. Also relevant to #16285 and friends as a step in the sparse `broadcast`/`broadcast!` overhaul. Best!

(Realized this PR lacks a `map!(f, A)` method. Punting to a followup PR.)
