### PR TITLE
Fix completion on custom (non-Dict) Associatives

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -414,6 +414,16 @@ function dict_identifier_key(str,tag)
     return (obj, partial_key, begin_of_key)
 end
 
+# This needs to be a separate non-inlined function, see #19441
+@noinline function find_dict_matches(identifier, partial_key)
+    matches = []
+    for key in keys(identifier)
+        rkey = repr(key)
+        startswith(rkey,partial_key) && push!(matches,rkey)
+    end
+    return matches
+end
+
 function completions(string, pos)
     # First parse everything up to the current position
     partial = string[1:pos]
@@ -425,11 +435,7 @@ function completions(string, pos)
     identifier, partial_key, loc = dict_identifier_key(partial,inc_tag)
     if identifier !== nothing
         if partial_key !== nothing
-            matches = []
-            for key in keys(identifier)
-                rkey = repr(key)
-                startswith(rkey,partial_key) && push!(matches,rkey)
-            end
+            matches = find_dict_matches(identifier, partial_key)
             length(matches)==1 && (length(string) <= pos || string[pos+1] != ']') && (matches[1]*="]")
             length(matches)>0 && return sort(matches), loc:pos, true
         else

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -21,6 +21,14 @@ ex = quote
         :()
     end
 
+    # Support non-Dict Associatives, #19441
+    type CustomDict{K, V} <: Associative{K, V}
+        mydict::Dict{K, V}
+    end
+
+    Base.keys(d::CustomDict) = collect(keys(d.mydict))
+    Base.length(d::CustomDict) = length(d.mydict)
+
     test{T<:Real}(x::T, y::T) = pass
     test(x::Real, y::Real) = pass
     test{T<:Real}(x::AbstractArray{T}, y) = pass
@@ -55,8 +63,10 @@ ex = quote
     test_dict = Dict("abc"=>1, "abcd"=>10, :bar=>2, :bar2=>9, Base=>3,
                      contains=>4, `ls`=>5, 66=>7, 67=>8, ("q",3)=>11,
                      "α"=>12, :α=>13)
+    test_customdict = CustomDict(test_dict)
     end
     test_repl_comp_dict = CompletionFoo.test_dict
+    test_repl_comp_customdict = CompletionFoo.test_customdict
 end
 ex.head = :toplevel
 eval(Main, ex)
@@ -732,4 +742,6 @@ function test_dict_completion(dict_name)
     @test c == Any[":α]"]
 end
 test_dict_completion("CompletionFoo.test_dict")
+test_dict_completion("CompletionFoo.test_customdict")
 test_dict_completion("test_repl_comp_dict")
+test_dict_completion("test_repl_comp_customdict")


### PR DESCRIPTION
Inference is confused by dict_identifier_key(), which is inherently type
unstable since it calls getfield based on the name of the object
(passed as a string). When completions() is first compiled,
there is only one start() method for Associative objects, so its return type
is assumed for all Associative. This breaks when introducing a custom
Associative like SortedDict, since completions() isn't recompiled because
its input types do not include the dictionary type, and the new start()
methods do not trigger its recompilation (issue #265).

As a temporary solution, move the offending code to a separate function which
takes the dictionary as an argument, so that a specialized version is compiled
and calls the correct methods.

Fixes #19441.