### PR TITLE
Consistently return IO in `Base.buffer_writes` methods

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -7,7 +7,7 @@ unlock(::IO) = nothing
 reseteof(x::IO) = nothing
 
 const SZ_UNBUFFERED_IO = 65536
-buffer_writes(x::IO, bufsize=SZ_UNBUFFERED_IO) = nothing
+buffer_writes(x::IO, bufsize=SZ_UNBUFFERED_IO) = x
 
 """
     isopen(object) -> Bool

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -213,3 +213,8 @@ let bstream = BufferStream()
 end
 
 @test flush(IOBuffer()) === nothing # should be a no-op
+
+# pr #19461
+let io = IOBuffer()
+    @test Base.buffer_writes(io) === io
+end


### PR DESCRIPTION
The `Base.buffer_writes` methods in "stream.jl" all return the IO objects. This change updates a `buffer_writes` to also return its IO object.