### PR TITLE
Update metaprogramming.rst

### DIFF
--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -57,10 +57,9 @@ each string into an object called an expression, represented by the Julia type
      :args
      :typ 
 
-- `head` -- a ``Symbol`` identifying the 
-  `kind of expression <http://docs.julialang.org/en/release-0.5/devdocs/ast/#expr-types>`_. 
-  A symbol is an `interned string <https://en.wikipedia.org/wiki/String_interning>`_
-  identifier (more discussion below).
+- `head` -- a ``Symbol`` identifying the :ref:`kind of expression <expr-types>`. 
+  A symbol is used to represent a variable in metaprogramming (`discussion 
+  <http://stackoverflow.com/questions/23480722/what-is-a-symbol-in-julia/23482257#23482257>`_). 
 
 .. doctest::
 

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -167,8 +167,8 @@ the value bound to that symbol in the appropriate :ref:`scope
 <man-variables-and-scoping>`.
 
 Sometimes extra parentheses around the argument to ``:`` are needed to avoid
-ambiguity in parsing, e.g. Distinguishing between the token `:` as in `1:5` 
-and the token `::` as in `x::Int`:
+ambiguity in parsing, e.g. distinguishing between the token ``:`` as in ``1:5`` 
+and the token ``::`` as in ``x::Int``:
 
 .. doctest::
 

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -57,8 +57,8 @@ each string into an object called an expression, represented by the Julia type
      :args
      :typ 
 
-- `head` -- a ``Symbol`` identifying the :ref:`kind of expression <expr-types>`. 
-  A symbol is used to represent a variable in metaprogramming (`discussion 
+- ``head`` -- a ``Symbol`` identifying the :ref:`kind of expression <expr-types>`. 
+  A symbol is used to represent a variable in metaprogramming (discussion `here  
   <http://stackoverflow.com/questions/23480722/what-is-a-symbol-in-julia/23482257#23482257>`_). 
 
 .. doctest::
@@ -66,7 +66,7 @@ each string into an object called an expression, represented by the Julia type
     julia> ex1.head
     :call
 
-- `args` -- the expression arguments, which may be symbols, other expressions, or literal values:
+- ``args`` -- the expression arguments, which may be symbols, other expressions, or literal values:
 
 .. doctest::
 
@@ -76,7 +76,7 @@ each string into an object called an expression, represented by the Julia type
      1
      1
 
-- `typ` -- the expression result type, which may be annotated by the user or inferred
+- ``typ`` -- the expression result type, which may be annotated by the user or inferred
   by the compiler (and may be ignored completely for the purposes of this chapter):
 
 .. doctest::

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -45,11 +45,21 @@ each string into an object called an expression, represented by the Julia type
 
     julia> typeof(ex1)
     Expr
+    
 
 :obj:`Expr` objects contain three parts:
 
-- a ``Symbol`` identifying the kind of expression. A symbol is an
-  `interned string <https://en.wikipedia.org/wiki/String_interning>`_
+.. doctest::
+
+    julia> fieldnames(Expr)
+    3-element Array{Symbol,1}:
+     :head
+     :args
+     :typ 
+
+- `head` -- a ``Symbol`` identifying the 
+  `kind of expression <http://docs.julialang.org/en/release-0.5/devdocs/ast/#expr-types>`_. 
+  A symbol is an `interned string <https://en.wikipedia.org/wiki/String_interning>`_
   identifier (more discussion below).
 
 .. doctest::
@@ -57,7 +67,7 @@ each string into an object called an expression, represented by the Julia type
     julia> ex1.head
     :call
 
-- the expression arguments, which may be symbols, other expressions, or literal values:
+- `args` -- the expression arguments, which may be symbols, other expressions, or literal values:
 
 .. doctest::
 
@@ -67,7 +77,7 @@ each string into an object called an expression, represented by the Julia type
      1
      1
 
-- finally, the expression result type, which may be annotated by the user or inferred
+- `typ` -- the expression result type, which may be annotated by the user or inferred
   by the compiler (and may be ignored completely for the purposes of this chapter):
 
 .. doctest::
@@ -158,7 +168,8 @@ the value bound to that symbol in the appropriate :ref:`scope
 <man-variables-and-scoping>`.
 
 Sometimes extra parentheses around the argument to ``:`` are needed to avoid
-ambiguity in parsing.:
+ambiguity in parsing, e.g. Distinguishing between the token `:` as in `1:5` 
+and the token `::` as in `x::Int`:
 
 .. doctest::
 


### PR DESCRIPTION
I've added a missing logical step in the exposition of `Expr`. 
Further down I've added a few words of explanation to the `:(:)` vs `:(::)` example which currently risks stalling the reader.

PS I wonder if the code sections under each bullet point can be indented so as to fall within that bullet point. Unfortunately the GitHub "preview" option hangs (i.e. fails to render a preview) so I haven't tried using spaces to do the indentation.