### PR TITLE
Fixes for LLVM 3.9 and Win64

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -485,6 +485,7 @@ $(eval $(call LLVM_PATCH,llvm-D25865-cmakeshlib))
 $(eval $(call LLVM_PATCH,llvm-3.9.0_threads))
 $(eval $(call LLVM_PATCH,llvm-3.9.0_cygwin)) # R283427, Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-3.9.0_win64-reloc-dwarf))
+$(eval $(call LLVM_PATCH,llvm-3.9.0_D27296-libssp))
 endif # LLVM_VER
 
 ifeq ($(LLVM_VER),3.7.1)

--- a/deps/patches/llvm-3.9.0_D27296-libssp.patch
+++ b/deps/patches/llvm-3.9.0_D27296-libssp.patch
@@ -1,0 +1,47 @@
+From e95516f77127ca534775d5f8d8cbb6e2e9c3f993 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Thu, 1 Dec 2016 18:48:30 +0900
+Subject: [PATCH] Don't assume mingw is providing SSP functions
+
+Summary:
+Mingw is indirectly targeting msvcrt*.dll and we can't guarantee that
+these functions will be available during JIT'ing.
+
+Differential Revision: https://reviews.llvm.org/D27296
+---
+ lib/Target/X86/X86ISelLowering.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/Target/X86/X86ISelLowering.cpp b/lib/Target/X86/X86ISelLowering.cpp
+index 44eae35..a932792 100644
+--- a/lib/Target/X86/X86ISelLowering.cpp
++++ b/lib/Target/X86/X86ISelLowering.cpp
+@@ -2016,7 +2016,7 @@ Value *X86TargetLowering::getIRStackGuard(IRBuilder<> &IRB) const {
+ 
+ void X86TargetLowering::insertSSPDeclarations(Module &M) const {
+   // MSVC CRT provides functionalities for stack protection.
+-  if (Subtarget.getTargetTriple().isOSMSVCRT()) {
++  if (Subtarget.getTargetTriple().isWindowsMSVCEnvironment()) {
+     // MSVC CRT has a global variable holding security cookie.
+     M.getOrInsertGlobal("__security_cookie",
+                         Type::getInt8PtrTy(M.getContext()));
+@@ -2038,14 +2038,14 @@ void X86TargetLowering::insertSSPDeclarations(Module &M) const {
+ 
+ Value *X86TargetLowering::getSDagStackGuard(const Module &M) const {
+   // MSVC CRT has a global variable holding security cookie.
+-  if (Subtarget.getTargetTriple().isOSMSVCRT())
++  if (Subtarget.getTargetTriple().isWindowsMSVCEnvironment())
+     return M.getGlobalVariable("__security_cookie");
+   return TargetLowering::getSDagStackGuard(M);
+ }
+ 
+ Value *X86TargetLowering::getSSPStackGuardCheck(const Module &M) const {
+   // MSVC CRT has a function to validate security cookie.
+-  if (Subtarget.getTargetTriple().isOSMSVCRT())
++  if (Subtarget.getTargetTriple().isWindowsMSVCEnvironment())
+     return M.getFunction("__security_check_cookie");
+   return TargetLowering::getSSPStackGuardCheck(M);
+ }
+-- 
+2.10.2
+


### PR DESCRIPTION
This fixes the issue with LLVM trying to link against MSVC instead of `libssp` for stack protection, submitted upstream as https://reviews.llvm.org/D27296.
It also disables 128bit atomics on Windows until we can use `libatomic` (cc. @yuyichao)

The only remaining issue is in `test/reflection` https://gist.github.com/vchuravy/cff71dc331974d3162526ccbec90f553 and that issue is for another day.
