### PR TITLE
RFC: Add a GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+Welcome to the Julia project!
+
+We use the GitHub issue tracker for bug reports and feature requests.
+If you have a question or are unsure if the behavior you're experiencing is a bug,
+please search or post to [our Discourse site](https://discourse.julialang.org).
+
+If you're submitting a bug report, be sure to include as much relevant information as
+possible, including a minimal reproducible example and the output of `versioninfo()`.
+Consider using a [GitHub Gist](https://gist.github.com) if you have a lot of code or output
+to include in the report.
+If you're experiencing a problem with a particular package, open an issue on that
+package's repository instead.
+
+Please delete this message before posting, and thanks for your contribution to Julia!


### PR DESCRIPTION
This PR adds a template that will appear whenever someone goes to submit a new issue. My intention with this is primarily to direct people to Discourse for their questions, though I've also included a blurb about bug reports.

cc @StefanKarpinski 