### PR TITLE
Correct alignment of atomic load and stores

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -312,7 +312,7 @@ void NotifyDebugger(jit_code_entry *JITCodeEntry)
 }
 // ------------------------ END OF TEMPORARY COPY FROM LLVM -----------------
 
-#ifdef _OS_LINUX_
+#if defined(_OS_LINUX_)
 // Resolve non-lock free atomic functions in the libatomic library.
 // This is the library that provides support for c11/c++11 atomic operations.
 static uint64_t resolve_atomic(const char *name)
@@ -542,7 +542,7 @@ void JuliaOJIT::addModule(std::unique_ptr<Module> M)
                         // Step 2: Search the program symbols
                         if (uint64_t addr = SectionMemoryManager::getSymbolAddressInProcess(Name))
                             return JL_SymbolInfo(addr, JITSymbolFlags::Exported);
-#ifdef _OS_LINUX_
+#if defined(_OS_LINUX_)
                         if (uint64_t addr = resolve_atomic(Name.c_str()))
                             return JL_SymbolInfo(addr, JITSymbolFlags::Exported);
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -112,6 +112,7 @@ STATIC_INLINE int jl_gc_alignment(size_t sz)
     return 16;
 #endif
 }
+JL_DLLEXPORT int jl_alignment(size_t sz);
 
 STATIC_INLINE int JL_CONST_FUNC jl_gc_szclass(size_t sz)
 {

--- a/src/threading.c
+++ b/src/threading.c
@@ -779,6 +779,13 @@ void jl_start_threads(void) { }
 
 #endif // !JULIA_ENABLE_THREADING
 
+// Make gc alignment available for threading
+// see threads.jl alignment
+JL_DLLEXPORT int jl_alignment(size_t sz)
+{
+    return jl_gc_alignment(sz);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -273,7 +273,8 @@ let atomic_types = [Int8, Int16, Int32, Int64, Int128,
                     Float16, Float32, Float64]
     # Temporarily omit 128-bit types on 32bit x86
     # 128-bit atomics do not exist on AArch32.
-    # And we don't support them yet on power.
+    # And we don't support them yet on power, because they are lowered
+    # to `__sync_lock_test_and_set_16`.
     if Sys.ARCH === :i686 || startswith(string(Sys.ARCH), "arm") ||
        Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
         filter!(T -> sizeof(T)<=8, atomic_types)


### PR DESCRIPTION
While updating LLVM from 3.7 to 3.9 on windows, I noticed that for 128bit atomics a libcall was issued,
instead of resolving to the hardware instruction (that we forcefully enable with the subtarget feature on X86 `cx16`).
Disabling the `libatomic` support in `jitlayers.cpp` revealed the same regression on Linux.

After discussion with @yuyichao (thank you again) we realized that the X86 ABI of atomic types requires an alignment of `sizeof(T)`
instead of the current `WORD_SIZE/8` (see the libatomic ABI draft https://gcc.gnu.org/ml/gcc/2016-11/txt6ZlA_JS27i.txt).

Load and stores should follow the alignment guarantees of the GC. 

@tkelman this fixes the issue in #19472 properly and after merging this we will only need the SSP patch, from that PR.