### PR TITLE
updates enum capitalization to be more consistent with Julia style

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -36,13 +36,13 @@ Create an `Enum{BaseType}` subtype with name `EnumName` and enum member values o
 `EnumName` can be used just like other types and enum member values as regular values, such as
 
 ```jldoctest
-julia> @enum FRUIT apple=1 orange=2 kiwi=3
+julia> @enum Fruit apple=1 orange=2 kiwi=3
 
-julia> f(x::FRUIT) = "I'm a FRUIT with value: \$(Int(x))"
+julia> f(x::Fruit) = "I'm a Fruit with value: \$(Int(x))"
 f (generic function with 1 method)
 
 julia> f(apple)
-"I'm a FRUIT with value: 1"
+"I'm a Fruit with value: 1"
 ```
 
 `BaseType`, which defaults to `Int32`, must be a bitstype subtype of Integer. Member values can be converted between

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -293,7 +293,7 @@ For users coming to Julia from R, these are some noteworthy differences:
     form is often used to annotate blocks, as in the parallel `for` construct: `@parallel for i in 1:n; #= body =#; end`.
     Where the end of the macro construct may be unclear, use the function-like form.
   * Julia now has an enumeration type, expressed using the macro `@enum(name, value1, value2, ...)`
-    For example: `@enum(Fruit, Banana=1, Apple, Pear)`
+    For example: `@enum(Fruit, banana=1, apple, pear)`
   * By convention, functions that modify their arguments have a `!` at the end of the name, for example
     `push!`.
   * In C++, by default, you have static dispatch, i.e. you need to annotate a function as virtual,


### PR DESCRIPTION
I don't think there's anywhere else where we use all-caps for a type name. Also in one place we had the enum values capitalized. This brings the docs in-line with what's used in the tests.