### PR TITLE
explicitly track unbound variables during lowering

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -53,6 +53,7 @@
                 ((top)        (deparse (cadr e)))
                 ((core)       (string "Core." (deparse (cadr e))))
                 ((globalref)  (string (deparse (cadr e)) "." (deparse (caddr e))))
+                ((outerref)   (string (deparse (cadr e))))
                 ((:)
                  (string (deparse (cadr e)) ': (deparse (caddr e))
                          (if (length> e 3)
@@ -105,7 +106,7 @@
 
 ;; predicates and accessors
 
-(define (quoted? e) (memq (car e) '(quote top core globalref line break inert)))
+(define (quoted? e) (memq (car e) '(quote top core globalref outerref line break inert meta)))
 
 (define (lam:args x) (cadr x))
 (define (lam:vars x) (llist-vars (lam:args x)))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3210,6 +3210,7 @@ f(x) = yt(x)
                   ((or (eq? e 'true) (eq? e 'false)) #f)
                   ((symbol? e) (emit e) #f)  ;; keep symbols for undefined-var checking
                   ((and (pair? e) (eq? (car e) 'outerref)) (emit e) #f)  ;; keep globals for undefined-var checking
+                  ((and (pair? e) (eq? (car e) 'globalref)) (emit e) #f) ;; keep globals for undefined-var checking
                   (else #f)))
           (case (car e)
             ((call new)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -225,7 +225,12 @@
         (else
          (error "malformed type parameter list"))))
 
-(define (method-expr-name m) (cadr m))
+(define (method-expr-name m)
+  (let ((name (cadr m)))
+       (cond ((not (pair? name)) name)
+             ((eq? (car name) 'outerref) (cadr name))
+             ;((eq? (car name) 'globalref) (caddr name))
+             (else name))))
 
 ;; extract static parameter names from a (method ...) expression
 (define (method-expr-static-parameters m)
@@ -243,6 +248,7 @@
 (define (sym-ref? e)
   (or (symbol? e)
       (and (length= e 3) (eq? (car e) 'globalref))
+      (and (length= e 2) (eq? (car e) 'outerref))
       (and (length= e 3) (eq? (car e) '|.|)
            (or (atom? (cadr e)) (sym-ref? (cadr e)))
            (pair? (caddr e)) (memq (car (caddr e)) '(quote inert))
@@ -290,6 +296,15 @@
         (else
          (cons (car e)
                (map (lambda (x) (replace-vars x renames))
+                    (cdr e))))))
+
+(define (replace-outer-vars e renames)
+  (cond ((and (pair? e) (eq? (car e) 'outerref)) (lookup (cadr e) renames e))
+        ((or (not (pair? e)) (quoted? e))  e)
+        ((memq (car e) '(-> function scope-block)) e)
+        (else
+         (cons (car e)
+               (map (lambda (x) (replace-outer-vars x renames))
                     (cdr e))))))
 
 ;; construct the (method ...) expression for one primitive method definition,
@@ -675,8 +690,8 @@
   (if (length> params (length type-params))
       (error "too few type parameters specified in \"new{...}\""))
   (let ((Texpr (if (null? type-params)
-                   `(globalref ,(current-julia-module) ,Tname)
-                   `(curly (globalref ,(current-julia-module) ,Tname)
+                   `(outerref ,Tname)
+                   `(curly (outerref ,Tname)
                            ,@type-params))))
     (cond ((length> args (length field-names))
            `(call (top error) "new: too many arguments"))
@@ -1516,7 +1531,7 @@
                                 ,(loop (cdr tail)))))))))))
 
 (define (expand-forms e)
-  (if (or (atom? e) (memq (car e) '(quote inert top core globalref line module toplevel ssavalue null meta)))
+  (if (or (atom? e) (memq (car e) '(quote inert top core globalref outerref line module toplevel ssavalue null meta)))
       e
       (let ((ex (get expand-table (car e) #f)))
         (if ex
@@ -2306,6 +2321,8 @@
         ((symbol? e) (if (not (memq e bound)) (put! tab e #t)) tab)
         ((or (not (pair? e)) (quoted? e)) tab)
         ((memq (car e) '(lambda scope-block module toplevel)) tab)
+        ((eq? (car e) 'break-block) (unbound-vars (caddr e) bound tab))
+        ((eq? (car e) 'with-static-parameters) (unbound-vars (cadr e) bound tab))
         (else (for-each (lambda (x) (unbound-vars x bound tab))
                             (cdr e))
               tab)))
@@ -2319,9 +2336,10 @@
 (define (resolve-scopes- e env implicitglobals lam renames newlam)
   (cond ((symbol? e) (let ((r (assq e renames)))
                        (if r (cdr r) e))) ;; return the renaming for e, or e
-        ((or (not (pair? e)) (quoted? e) (eq? (car e) 'toplevel)) e)
+        ((or (not (pair? e)) (quoted? e) (memq (car e) '(toplevel global))) e)
         ((eq? (car e) 'local) '(null)) ;; remove local decls
         ((eq? (car e) 'local-def) '(null)) ;; remove local decls
+        ((eq? (car e) 'implicit-global) '(null)) ;; remove implicit-global decls
         ((eq? (car e) 'lambda)
          (let* ((lv (lam:vars e))
                 (env (append lv env))
@@ -2358,7 +2376,6 @@
                       '()
                        (filter (lambda (v) (or (memq v env)
                                                (memq v other-locals)
-                                               (memq v implicitglobals)
                                                (memq v (caddr lam))))
                                vars))))
                 (need-rename (need-rename? vars))
@@ -2366,24 +2383,26 @@
                 ;; new gensym names for conflicting variables
                 (renamed (map named-gensy need-rename))
                 (renamed-def (map named-gensy need-rename-def))
-                ;; combine the list of new renamings with the inherited list
-                (new-renames (append (map cons need-rename renamed) ;; map from definition name -> gensym name
-                                     (map cons need-rename-def renamed-def)
-                                     (filter (lambda (ren) ;; old renames list, with anything in vars removed
-                                               (not (or (memq (car ren) all-vars)
-                                                        (memq (car ren) iglo)
-                                                        (memq (car ren) glob))))
-                                             renames)))
                 (new-env (append all-vars glob env)) ;; all variables declared in or outside blok
-                (new-iglo-table ;; initial list of implicit globals from outside blok
+                (new-iglo-table ;; initial list of implicit globals from outside blok which aren't part of the local vars
                   (let ((tab (table)))
-                    (for-each (lambda (v) (put! tab v #t)) iglo)
-                    (for-each (lambda (v) (put! tab v #t)) implicitglobals)
+                    (for-each (lambda (v) (if (not (memq v all-vars)) (put! tab v #t))) iglo)
+                    (for-each (lambda (v) (if (not (memq v all-vars)) (put! tab v #t))) implicitglobals)
                     tab))
                 (new-iglo (table.keys ;; compute list of all globals used implicitly in blok
                             (unbound-vars blok
                                           new-env ;; list of everything else
                                           new-iglo-table)))
+                ;; combine the list of new renamings with the inherited list
+                (new-renames (append (map cons need-rename renamed) ;; map from definition name -> gensym name
+                                     (map cons need-rename-def renamed-def)
+                                     (map (lambda (g) (cons g `(outerref ,g))) new-iglo)
+                                     (filter (lambda (ren) ;; old renames list, with anything in vars removed
+                                               (not (or (memq (car ren) all-vars)
+                                                        (memq (car ren) iglo)
+                                                        (memq (car ren) implicitglobals)
+                                                        (memq (car ren) glob))))
+                                             renames)))
                 (body (resolve-scopes- blok new-env new-iglo lam new-renames #f))
                 (real-new-vars (append (diff vars need-rename) renamed))
                 (real-new-vars-def (append (diff vars-def need-rename-def) renamed-def)))
@@ -2402,6 +2421,13 @@
                          (map (lambda (v) `(local-def ,v)) real-new-vars-def)))))
         ((eq? (car e) 'module)
          (error "module expression not at top level"))
+        ((eq? (car e) 'break-block)
+         `(break-block ,(cadr e) ;; ignore type symbol of break-block expression
+                       ,(resolve-scopes- (caddr e) env implicitglobals lam renames #f))) ;; body of break-block expression
+        ((eq? (car e) 'with-static-parameters)
+         `(with-static-parameters ;; ignore list of sparams in break-block expression
+            ,(resolve-scopes- (cadr e) env implicitglobals lam renames #f)
+            ,@(cddr e))) ;; body of break-block expression
         (else
          (cons (car e)
                (map (lambda (x)
@@ -2420,6 +2446,9 @@
 (define (free-vars- e tab)
   (cond ((or (eq? e 'true) (eq? e 'false) (eq? e UNUSED)) tab)
         ((symbol? e) (put! tab e #t))
+        ((and (pair? e) (eq? (car e) 'outerref)) (put! tab (cadr e) #t))
+        ((and (pair? e) (eq? (car e) 'break-block)) (free-vars- (caddr e) tab))
+        ((and (pair? e) (eq? (car e) 'with-static-parameters)) (free-vars- (cadr e) tab))
         ((or (atom? e) (quoted? e)) tab)
         ((eq? (car e) 'lambda)
          (let ((bound (lambda-all-vars e)))
@@ -2768,7 +2797,7 @@ f(x) = yt(x)
                            (or (atom? e)
                                (memq (car e) '(quote top core line inert local local-def unnecessary
                                                meta inbounds boundscheck simdloop
-                                               implicit-global global globalref
+                                               implicit-global global globalref outerref
                                                const = null method call))))
                          (lam:body lam))))
                (unused (map cadr (filter (lambda (x) (memq (car x) '(method =)))
@@ -2843,7 +2872,7 @@ f(x) = yt(x)
        ((atom? e) e)
        (else
         (case (car e)
-          ((quote top core globalref line break inert module toplevel null meta) e)
+          ((quote top core globalref outerref line break inert module toplevel null meta) e)
           ((=)
            (let ((var (cadr e))
                  (rhs (cl-convert (caddr e) fname lam namemap toplevel interp)))
@@ -2948,12 +2977,15 @@ f(x) = yt(x)
                         (capt-vars (diff all-capt-vars capt-sp)) ; remove capt-sp from capt-vars
                         (find-locals-in-method-sig (lambda (methdef)
                                                      (expr-find-all
-                                                      (lambda (s) (and (not (eq? name s))
-                                                                       (not (memq s capt-sp))
-                                                                       (or ;(local? s) ; TODO: make this work for local variables too?
-                                                                         (memq s (lam:sp lam)))))
+                                                      (lambda (e) (and (pair? e) (eq? (car e) 'outerref)
+                                                                       (let ((s (cadr e)))
+                                                                            (and (symbol? s)
+                                                                                 (not (eq? name s))
+                                                                                 (not (memq s capt-sp))
+                                                                                 (or ;(local? s) ; TODO: make this work for local variables too?
+                                                                                   (memq s (lam:sp lam)))))))
                                                       (caddr methdef)
-                                                      identity)))
+                                                      (lambda (e) (cadr e)))))
                         (sig-locals (simple-sort
                                      (delete-duplicates  ;; locals used in sig from all definitions
                                       (apply append      ;; will convert these into sparams for dispatch
@@ -2978,7 +3010,7 @@ f(x) = yt(x)
                               (let* ((iskw ;; TODO jb/functions need more robust version of this
                                       (contains (lambda (x) (eq? x 'kwftype)) sig))
                                      (renamemap (map cons closure-param-names closure-param-syms))
-                                     (arg-defs (replace-vars
+                                     (arg-defs (replace-outer-vars
                                                 (fix-function-arg-type sig type-name iskw namemap closure-param-syms)
                                                 renamemap)))
                                     (append (map (lambda (gs tvar)
@@ -3001,7 +3033,7 @@ f(x) = yt(x)
                                                         v)))
                                                 capt-vars))
                                 (P (append
-                                    closure-param-names
+                                    (map (lambda (n) `(outerref ,n)) closure-param-names)
                                     (filter identity (map (lambda (v ve)
                                                             (if (is-var-boxed? v lam)
                                                                 #f
@@ -3131,7 +3163,7 @@ f(x) = yt(x)
                                  (cdr lst))))
                 (simple? (every (lambda (x) (or (simple-atom? x) (symbol? x) (ssavalue? x)
                                                 (and (pair? x)
-                                                     (memq (car x) '(quote inert top core globalref copyast)))))
+                                                     (memq (car x) '(quote inert top core globalref outerref copyast)))))
                                 lst)))
             (let loop ((lst  lst)
                        (vals '()))
@@ -3144,7 +3176,7 @@ f(x) = yt(x)
                                          (not (simple-atom? arg))  (not (ssavalue? arg))
                                          (not (simple-atom? aval)) (not (ssavalue? aval))
                                          (not (and (pair? arg)
-                                                   (memq (car arg) '(& quote inert top core globalref copyast))))
+                                                   (memq (car arg) '(& quote inert top core globalref outerref copyast))))
                                          (not (and (symbol? arg)
                                                    (or (null? (cdr lst))
                                                        (null? vals)))))
@@ -3169,7 +3201,7 @@ f(x) = yt(x)
     ;; from the current function.
     (define (compile e break-labels value tail)
       (if (or (not (pair? e)) (memq (car e) '(null ssavalue quote inert top core copyast the_exception $
-                                                   globalref cdecl stdcall fastcall thiscall)))
+                                                   globalref outerref cdecl stdcall fastcall thiscall)))
           (let ((e (if (and arg-map (symbol? e))
                        (get arg-map e e)
                        e)))
@@ -3177,6 +3209,7 @@ f(x) = yt(x)
                   (value e)
                   ((or (eq? e 'true) (eq? e 'false)) #f)
                   ((symbol? e) (emit e) #f)  ;; keep symbols for undefined-var checking
+                  ((and (pair? e) (eq? (car e) 'outerref)) (emit e) #f)  ;; keep globals for undefined-var checking
                   (else #f)))
           (case (car e)
             ((call new)
@@ -3538,10 +3571,10 @@ f(x) = yt(x)
   (define (renumber-slots e)
     (cond ((symbol? e)
            (let ((idx (get slot-table e #f)))
-             (or (and idx `(slot ,idx))
-                 (let ((idx (get sp-table e #f)))
-                   (or (and idx `(static_parameter ,idx))
-                       e)))))
+             (if idx `(slot ,idx) e)))
+          ((and (pair? e) (eq? (car e) 'outerref))
+           (let ((idx (get sp-table (cadr e) #f)))
+                (if idx `(static_parameter ,idx) (cadr e))))
           ((or (atom? e) (quoted? e)) e)
           ((ssavalue? e)
            (let ((idx (or (get ssavalue-table (cadr e) #f)

--- a/test/core.jl
+++ b/test/core.jl
@@ -560,6 +560,18 @@ end
 @test f19333(0) == 7
 @test x19333 == 5
 
+function h19333()
+    s = 0
+    for (i, j) in ((1, 2),)
+        s += i + j # use + as a global
+    end
+    for (k, +) in ((3, 4),)
+        s -= (k - +) # use + as a local
+    end
+    return s
+end
+@test h19333() == 4
+
 # let - new variables, including undefinedness
 function let_undef()
     first = true

--- a/test/core.jl
+++ b/test/core.jl
@@ -3683,6 +3683,13 @@ foo9677(x::Array) = invoke(foo9677,(AbstractArray,),x)
 f6846() = (please6846; 2)
 @test_throws UndefVarError f6846()
 
+module M6846
+    macro f()
+        return :(please6846; 2)
+    end
+end
+@test_throws UndefVarError @M6846.f()
+
 # issue #14758
 @test isa(eval(:(f14758(; $([]...)) = ())), Function)
 


### PR DESCRIPTION
rather than renaming conflicting locals,
it is easier to explicitly track the free symbols that may be global or sparams
by marking that they came from the outer scope

fixes https://github.com/JuliaLang/julia/pull/19346's incorrect handling of the test-case here