### PR TITLE
Improve exponent function

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -361,7 +361,7 @@ function exponent{T<:AbstractFloat}(x::T)
     xs = reinterpret(Unsigned, x) & ~sign_mask(T)
     xs >= exponent_mask(T) && return throw(DomainError()) # NaN or Inf
     k = Int(xs >> significand_bits(T))
-    if xs <= (~exponent_mask(T) & ~sign_mask(T)) # x is subnormal
+    if k == 0 # x is subnormal
         xs == 0 && throw(DomainError())
         m = leading_zeros(xs) - exponent_bits(T)
         k = 1 - m
@@ -412,12 +412,12 @@ function frexp{T<:AbstractFloat}(x::T)
     xs = xu & ~sign_mask(T)
     xs >= exponent_mask(T) && return x, 0 # NaN or Inf
     k = Int(xs >> significand_bits(T))
-    if xs <= (~exponent_mask(T) & ~sign_mask(T)) # x is subnormal
+    if k == 0 # x is subnormal
         xs == 0 && return x, 0 # +-0
-        m = unsigned(leading_zeros(xs) - exponent_bits(T))
-        xs <<= m
+        m = leading_zeros(xs) - exponent_bits(T)
+        xs <<= unsigned(m)
         xu = xs | (xu & sign_mask(T))
-        k = 1 - signed(m)
+        k = 1 - m
     end
     k -= (exponent_bias(T) - 1)
     xu = (xu & ~exponent_mask(T)) | exponent_half(T)


### PR DESCRIPTION
Remove unnecessary branch/better perf



```julia
julia> @code_llvm my_exponent(-10.1)

; Function Attrs: uwtable
define i64 @julia__exponent_72099(double) #0 {
top:
  %1 = bitcast double %0 to i64
  %2 = and i64 %1, 9223372036854775807
  %3 = icmp ult i64 %2, 9218868437227405312
  br i1 %3, label %pass, label %if

L2:                                               ; preds = %pass.8, %pass
  %k.0 = phi i64 [ %5, %pass ], [ %9, %pass.8 ]
  %4 = add nsw i64 %k.0, -1023
  ret i64 %4

if:                                               ; preds = %top
  call void @jl_throw(%jl_value_t* inttoptr (i64 2153013112 to %jl_value_t*))
  unreachable

pass:                                             ; preds = %top
  %5 = lshr i64 %2, 52
  %6 = icmp ugt i64 %2, 4503599627370495
  br i1 %6, label %L2, label %if3

if3:                                              ; preds = %pass
  %7 = icmp eq i64 %2, 0
  br i1 %7, label %if4, label %pass.8

if4:                                              ; preds = %if3
  call void @jl_throw(%jl_value_t* inttoptr (i64 2153013112 to %jl_value_t*))
  unreachable

pass.8:                                           ; preds = %if3
  %8 = call i64 @llvm.ctlz.i64(i64 %2, i1 false)
  %9 = sub nsw i64 12, %8
  br label %L2
}

julia> @code_llvm exponent(-10.1)



; Function Attrs: uwtable
define i64 @julia_exponent_72000(double) #0 {
pass:
  %1 = bitcast double %0 to i64
  %2 = and i64 %1, 9218868437227405312
  %3 = icmp eq i64 %2, 0
  br i1 %3, label %if, label %L1

L1:                                               ; preds = %pass
  %4 = lshr exact i64 %2, 52
  %5 = icmp eq i64 %2, 9218868437227405312
  br i1 %5, label %if6, label %L2

L2:                                               ; preds = %L1, %pass.5
  %k.0 = phi i64 [ %4, %L1 ], [ %10, %pass.5 ]
  %6 = add nsw i64 %k.0, -1023
  ret i64 %6

if:                                               ; preds = %pass
  %7 = fcmp une double %0, 0.000000e+00
  br i1 %7, label %pass.5, label %if3

if3:                                              ; preds = %if
  call void @jl_throw(%jl_value_t* inttoptr (i64 2153013112 to %jl_value_t*))
  unreachable

pass.5:                                           ; preds = %if
  %8 = and i64 %1, 4503599627370495
  %9 = call i64 @llvm.ctlz.i64(i64 %8, i1 false)
  %10 = sub nsw i64 12, %9
  br label %L2

if6:                                              ; preds = %L1
  call void @jl_throw(%jl_value_t* inttoptr (i64 2153013112 to %jl_value_t*))
  unreachable
```