### PR TITLE
WIP: Further improving fast date parsing

### DIFF
--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -252,11 +252,7 @@ function DateFormat(f::AbstractString, locale::DateLocale=ENGLISH)
             letter, width = prev
             typ = SLOT_RULE[letter]
 
-            if isempty(tran)
-                push!(tokens, DatePart{letter}(width, true))
-            else
-                push!(tokens, DatePart{letter}(width, false))
-            end
+            push!(tokens, DatePart{letter}(width, isempty(tran)))
         end
 
         if !isempty(tran)

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -25,7 +25,7 @@ end
 """
 Information for parsing and formatting date time values.
 """
-immutable DateFormat{T<:Tuple}
+immutable DateFormat{S,T<:Tuple}
     tokens::T
     locale::DateLocale
 end
@@ -279,7 +279,8 @@ function DateFormat(f::AbstractString, locale::DateLocale=ENGLISH)
         push!(tokens, Delim(length(tran) == 1 ? first(tran) : tran))
     end
 
-    return DateFormat((tokens...), locale)
+    tokens_tuple = (tokens...)
+    return DateFormat{Symbol(f),typeof(tokens_tuple)}(tokens_tuple, locale)
 end
 
 function DateFormat(f::AbstractString, locale::AbstractString)
@@ -307,7 +308,7 @@ macro dateformat_str(str)
 end
 
 # Standard formats
-const ISODateTimeFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.sss")
+const ISODateTimeFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.s")
 const ISODateFormat = DateFormat("yyyy-mm-dd")
 const RFC1123Format = DateFormat("e, dd u yyyy HH:MM:SS")
 

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -68,12 +68,14 @@ b3 = "96/2/15"
 @test_throws ArgumentError Dates.DateTime(b3,f)
 try
     Dates.tryparse_internal(DateTime, "2012-02-20T09:09:3.43i9", Dates.ISODateTimeFormat, true)
+    @test false
 catch err
     @test isa(err, ArgumentError)
     @test err.msg == "Found extra characters at the end of date time string"
 end
 try
     Dates.tryparse_internal(DateTime, "2012-02-20T09:09:3i439", Dates.ISODateTimeFormat, true)
+    @test false
 catch err
     @test isa(err, ArgumentError)
     @test err.msg == "Unable to parse date time. Expected token Delim(.) at char 19"

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -67,13 +67,13 @@ b2 = "96/Feb/1"
 b3 = "96/2/15"
 @test_throws ArgumentError Dates.DateTime(b3,f)
 try
-    DateTime("2012-02-20T09:09:3.43i9")
+    Dates.tryparse_internal(DateTime, "2012-02-20T09:09:3.43i9", Dates.ISODateTimeFormat, true)
 catch err
     @test isa(err, ArgumentError)
     @test err.msg == "Found extra characters at the end of date time string"
 end
 try
-    DateTime("2012-02-20T09:09:3i439")
+    Dates.tryparse_internal(DateTime, "2012-02-20T09:09:3i439", Dates.ISODateTimeFormat, true)
 catch err
     @test isa(err, ArgumentError)
     @test err.msg == "Unable to parse date time. Expected token Delim(.) at char 19"

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -66,11 +66,15 @@ b2 = "96/Feb/1"
 # Here we've specifed a text month name, but given a number
 b3 = "96/2/15"
 @test_throws ArgumentError Dates.DateTime(b3,f)
-let err = try DateTime("2012-02-20T09:09:3.43i9") catch err; err end
+try
+    DateTime("2012-02-20T09:09:3.43i9")
+catch err
     @test isa(err, ArgumentError)
     @test err.msg == "Found extra characters at the end of date time string"
 end
-let err = try DateTime("2012-02-20T09:09:3i439") catch err; err end
+try
+    DateTime("2012-02-20T09:09:3i439")
+catch err
     @test isa(err, ArgumentError)
     @test err.msg == "Unable to parse date time. Expected token Delim(.) at char 19"
 end

--- a/test/dates/query.jl
+++ b/test/dates/query.jl
@@ -37,12 +37,12 @@ end
 
 # Customizing locale
 Dates.LOCALES["french"] = Dates.DateLocale(
-    ["janvier", "février", "mars", "avril", "mai", "juin", "juillet",
-     "août", "septembre", "octobre", "novembre", "décembre"],
-    ["janv","févr","mars","avril","mai","juin","juil","août",
-     "sept","oct","nov","déc"],
-    ["Lundi","Mardi","Mercredi","Jeudi",
-     "Vendredi","Samedi","Dimanche"],[""]
+    ["janvier", "février", "mars", "avril", "mai", "juin",
+     "juillet", "août", "septembre", "octobre", "novembre", "décembre"],
+    ["janv","févr","mars","avril","mai","juin",
+     "juil","août","sept","oct","nov","déc"],
+    ["Lundi","Mardi","Mercredi","Jeudi","Vendredi","Samedi","Dimanche"],
+    [""],
 )
 @test Dates.dayname(Nov;locale="french") == "Lundi"
 @test Dates.dayname(Jan;locale="french") == "Mardi"


### PR DESCRIPTION
Iterating on #18000 and #19545. Speed up is currently 140x.

before:

```julia
julia> @benchmark DateTime("2010-10-10T10:10:10.10")
BenchmarkTools.Trial: 
  memory estimate:  3.11 kb
  allocs estimate:  85
  --------------
  minimum time:     16.768 μs (0.00% GC)
  median time:      17.943 μs (0.00% GC)
  mean time:        20.198 μs (1.78% GC)
  maximum time:     3.734 ms (96.53% GC)
  --------------
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

Shashi's update #19545

```julia
julia> @benchmark DateTime("2010-10-10T10:10:10.10")
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     138.344 ns (0.00% GC)
  median time:      140.283 ns (0.00% GC)
  mean time:        157.004 ns (0.00% GC)
  maximum time:     1.683 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     861
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

This PR:
```julia
julia> @benchmark DateTime("2010-10-10T10:10:10.10")
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     118.559 ns (0.00% GC)
  median time:      125.402 ns (0.00% GC)
  mean time:        138.223 ns (0.00% GC)
  maximum time:     2.867 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     907
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

fixes #15888, #13644
supersedes #18000, #19545