### PR TITLE
Always inline ith_all()

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1835,8 +1835,8 @@ end
 
 ## N argument
 
-ith_all(i, ::Tuple{}) = ()
-ith_all(i, as) = (as[1][i], ith_all(i, tail(as))...)
+@inline ith_all(i, ::Tuple{}) = ()
+@inline ith_all(i, as) = (as[1][i], ith_all(i, tail(as))...)
 
 function map_n!{F}(f::F, dest::AbstractArray, As)
     for i = linearindices(As[1])


### PR DESCRIPTION
For some custom arrays like NullableArray, it was not inlined, which triggered
allocations in map_n!().