### PR TITLE
RFC: Specialize promotion for concatenations

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -92,6 +92,7 @@ linearindices(A::AbstractVector) = (@_inline_meta; indices1(A))
 eltype{T}(::Type{AbstractArray{T}}) = T
 eltype{T,N}(::Type{AbstractArray{T,N}}) = T
 elsize{T}(::AbstractArray{T}) = sizeof(T)
+
 """
     ndims(A::AbstractArray) -> Integer
 
@@ -991,6 +992,11 @@ replace_in_print_matrix(A::AbstractMatrix,i::Integer,j::Integer,s::AbstractStrin
 replace_in_print_matrix(A::AbstractVector,i::Integer,j::Integer,s::AbstractString) = s
 
 ## Concatenation ##
+eltypeof(x) = typeof(x)
+eltypeof(x::AbstractArray) = eltype(x)
+
+promote_eltypeof() = Bottom
+promote_eltypeof(v1, vs...) = promote_type(eltypeof(v1), promote_eltypeof(vs...))
 
 promote_eltype() = Bottom
 promote_eltype(v1, vs...) = promote_type(eltype(v1), promote_eltype(vs...))
@@ -1136,7 +1142,7 @@ _cs(d, concat, a, b) = concat ? (a + b) : (a == b ? a : throw(DimensionMismatch(
 dims2cat{n}(::Type{Val{n}}) = ntuple(i -> (i == n), Val{n})
 dims2cat(dims) = ntuple(i -> (i in dims), maximum(dims))
 
-cat(dims, X...) = cat_t(dims, promote_eltype(X...), X...)
+cat(dims, X...) = cat_t(dims, promote_eltypeof(X...), X...)
 
 function cat_t(dims, T::Type, X...)
     catdims = dims2cat(dims)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -567,6 +567,9 @@ function test_cat(::Type{TestAbstractArray})
     # 13665, 19038
     @test @inferred(hcat([1.0 2.0], 3))::Array{Float64,2} == [1.0 2.0 3.0]
     @test @inferred(vcat([1.0, 2.0], 3))::Array{Float64,1} == [1.0, 2.0, 3.0]
+
+    @test @inferred(vcat(["a"], "b"))::Vector{String} == ["a", "b"]
+    @test @inferred(vcat((1,), (2.0,)))::Vector{Tuple{Real}} == [(1,), (2.0,)]
 end
 
 function test_ind2sub(::Type{TestAbstractArray})


### PR DESCRIPTION
Currently for concatenation purposes, we need promotion mechanism that takes `eltype`s of `AbstractArray`s and `typeof` of anything else and promotes these (see https://github.com/JuliaLang/julia/pull/19387#issuecomment-265458567).

There are two proposals that occur to me to handle this:

1. Define a `eltypeof` (or `eltype_or_typeof`) method that gives the appropriate type depending on the argument and pass that to `promote_eltype` ~~(this PR)~~
2. Or define a new `promote_eltypeof` that handles properly mixtures of `AbstractArray`s and scalars leaving `promote_eltype` alone (this PR).

The first approach shouldn't change the behavior of `promote_eltype` when called over `AbstractArray`s only, ~~that's why I'm inclined to go that route~~ but a proper interface would have to be decided given how things like strings are both scalar and collection under different circumstances. Anyway, it'd be useful to see what other people think.