### PR TITLE
replace broadcast with map in sparse binary op definitions

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2278,17 +2278,14 @@ round{To}(::Type{To}, A::SparseMatrixCSC) = round.(To, A)
 
 ## Binary arithmetic and boolean operators
 
-# TODO: These seven functions should probably be reimplemented in terms of sparse map
-# when a better sparse map exists. (And vectorized min, max, &, |, and xor should be
-# deprecated in favor of compact-broadcast syntax.)
-_checksameshape(A, B) = size(A) == size(B) || throw(DimensionMismatch("size(A) must match size(B)"))
-(+)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (_checksameshape(A, B); broadcast(+, A, B))
-(-)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (_checksameshape(A, B); broadcast(-, A, B))
-min(A::SparseMatrixCSC, B::SparseMatrixCSC) = (_checksameshape(A, B); broadcast(min, A, B))
-max(A::SparseMatrixCSC, B::SparseMatrixCSC) = (_checksameshape(A, B); broadcast(max, A, B))
-(&)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (_checksameshape(A, B); broadcast(&, A, B))
-(|)(A::SparseMatrixCSC, B::SparseMatrixCSC) = (_checksameshape(A, B); broadcast(|, A, B))
-xor(A::SparseMatrixCSC, B::SparseMatrixCSC) = (_checksameshape(A, B); broadcast(xor, A, B))
+(+)(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(+, A, B)
+(-)(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(-, A, B)
+# TODO: Vectorized min, max, |, and xor should be deprecated in favor of compact-broadcast syntax.
+min(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(min, A, B)
+max(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(max, A, B)
+(&)(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(&, A, B)
+(|)(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(|, A, B)
+xor(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(xor, A, B)
 
 (.+)(A::SparseMatrixCSC, B::Number) = Array(A) .+ B
 ( +)(A::SparseMatrixCSC, B::Array ) = Array(A)  + B

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -24,6 +24,17 @@ do33 = ones(3)
 # check sparse binary op
 @test all(Array(se33 + convert(SparseMatrixCSC{Float32,Int32}, se33)) == 2*eye(3))
 @test all(Array(se33 * convert(SparseMatrixCSC{Float32,Int32}, se33)) == eye(3))
+@testset "Shape checks for sparse elementwise binary operations equivalent to map" begin
+    sqrfloatmat, colfloatmat = sprand(4, 4, 0.5), sprand(4, 1, 0.5)
+    @test_throws DimensionMismatch (+)(sqrfloatmat, colfloatmat)
+    @test_throws DimensionMismatch (-)(sqrfloatmat, colfloatmat)
+    @test_throws DimensionMismatch min(sqrfloatmat, colfloatmat)
+    @test_throws DimensionMismatch max(sqrfloatmat, colfloatmat)
+    sqrboolmat, colboolmat = sprand(Bool, 4, 4, 0.5), sprand(Bool, 4, 1, 0.5)
+    @test_throws DimensionMismatch (&)(sqrboolmat, colboolmat)
+    @test_throws DimensionMismatch (|)(sqrboolmat, colboolmat)
+    @test_throws DimensionMismatch xor(sqrboolmat, colboolmat)
+end
 
 # check horiz concatenation
 @test all([se33 se33] == sparse([1, 2, 3, 1, 2, 3], [1, 2, 3, 4, 5, 6], ones(6)))


### PR DESCRIPTION
A few elementwise operations over pairs of sparse matrices (e.g. `+`, `min`) are implemented as short children of `broadcast` preceded by a (same-)shape check. This pull request reimplements those operations in terms of `map`. Best!

~~Note: This pull request should not pass CI prior to rebasing on #19518.~~