### PR TITLE
Fix #19503 (provide a unary minus method specialized for sparse matrices)

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2267,12 +2267,14 @@ broadcast_zpreserving{Tv,Ti}(f::Function, A_1::Union{Array,BitArray,Number}, A_2
 
 # TODO: More appropriate location?
 conj!(A::SparseMatrixCSC) = (broadcast!(conj, A.nzval, A.nzval); A)
+(-)(A::SparseMatrixCSC) = SparseMatrixCSC(A.m, A.n, copy(A.colptr), copy(A.rowval), map(-, A.nzval))
 
 # TODO: The following definitions should be deprecated.
 ceil{To}(::Type{To}, A::SparseMatrixCSC) = ceil.(To, A)
 floor{To}(::Type{To}, A::SparseMatrixCSC) = floor.(To, A)
 trunc{To}(::Type{To}, A::SparseMatrixCSC) = trunc.(To, A)
 round{To}(::Type{To}, A::SparseMatrixCSC) = round.(To, A)
+
 
 ## Binary arithmetic and boolean operators
 

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1692,6 +1692,9 @@ end
 # `SparseMatrixCSC`s determine a reasonable return type. (Issue #18974.)
 @test eltype(sin.(spdiagm(Int64(1):Int64(4)))) == Float64
 
+# Check calling of unary minus method specialized for SparseMatrixCSCs. (Issue #19503.)
+@test which(-, (SparseMatrixCSC,)).module == Base.SparseArrays
+
 # Test map/map! over sparse matrices
 let
     N, M = 10, 12


### PR DESCRIPTION
As @StephenVavasis caught in #19503 (thanks!), I accidentally removed the unary minus method specialized for sparse matrices in #17265. This pull request provides a replacement method. Fixes #19503. Best!