### PR TITLE
Fix #18739, Make testset results printing better

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -44,7 +44,9 @@ immutable Pass <: Result
 end
 function Base.show(io::IO, t::Pass)
     print_with_color(:green, io, "Test Passed\n")
-    print(io, "  Expression: ", t.orig_expr)
+    if !(t.orig_expr === nothing)
+        print(io, "  Expression: ", t.orig_expr)
+    end
     if t.test_type == :test_throws
         # The correct type of exception was thrown
         print(io, "\n      Thrown: ", typeof(t.value))
@@ -139,9 +141,9 @@ type Broken <: Result
 end
 function Base.show(io::IO, t::Broken)
     print_with_color(:yellow, io, "Test Broken\n")
-    if t.test_type == :skipped
+    if t.test_type == :skipped && !(t.orig_expr === nothing)
         println(io, "  Skipped: ", t.orig_expr)
-    else
+    elseif !(t.orig_expr === nothing)
         println(io, "Expression: ", t.orig_expr)
     end
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -457,7 +457,7 @@ end
 # @macroexpand tests
 macro seven_dollar(ex)
     # simonbyrne example 18240
-    isa(ex,Expr) && ex.head == :$ ? 7 : ex
+    isa(ex,Expr) && ex.head == :$ ? 7 : esc(ex)
 end
 
 let

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -8,7 +8,6 @@ function runtests(name, isolate=true)
         m = Main
     end
     eval(m, :(using Base.Test))
-    @printf("     \033[1m*\033[0m \033[31m%-21s\033[0m", name)
     ex = quote
         @timed @testset $"$name" begin
             include($"$name.jl")
@@ -16,7 +15,6 @@ function runtests(name, isolate=true)
     end
     res_and_time_data = eval(m, ex)
     rss = Sys.maxrss()
-    @printf(" maxrss %7.2f MB\n", rss / 2^20)
     #res_and_time_data[1] is the testset
     passes,fails,error,broken,c_passes,c_fails,c_errors,c_broken = Base.Test.get_test_counts(res_and_time_data[1])
     if res_and_time_data[1].anynonpass == false


### PR DESCRIPTION
Now results come in one by one and print their memory/timing data
as they come in. We will no longer print rss results twice. Also,
each test now prints which worker it ran on.

Here are some screencaps:
![screen shot 2016-12-07 at 14 55 47](https://cloud.githubusercontent.com/assets/828643/20990464/c766676a-bc8d-11e6-93e3-7521c44e8d66.png)
![screen shot 2016-12-07 at 14 46 30](https://cloud.githubusercontent.com/assets/828643/20990467/c969fc2a-bc8d-11e6-85f4-ed07a7ad4b29.png)
