### PR TITLE
type stable last for heterogeneous tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -10,7 +10,7 @@ NTuple
 
 ## indexing ##
 
-length(t::Tuple) = nfields(t)
+length{T<:Tuple}(t::T) = nfields(T)
 endof(t::Tuple) = length(t)
 size(t::Tuple, d) = d==1 ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
 getindex(t::Tuple, i::Int) = getfield(t, i)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -170,3 +170,6 @@ for n = 0:20
         @test t[i] == i
     end
 end
+
+# Check type stability of last for tuples
+@inferred last((1, 2.0))


### PR DESCRIPTION
`last` is not type stable for heterogeneous tuples. This pull request provides a specialization of `last` that is type stable for heterogeneous tuples. (Should something like [the trick used to limit code growth in the definition of `map` for tuples](https://github.com/JuliaLang/julia/blob/374c3d6b3c3e15c00f7d3df8b5cb7c8a763aa746/base/tuple.jl#L110) limit inlining here as well?). Best!