### PR TITLE
Docstring for `contains(fun,itr,x) -> Bool`

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -630,6 +630,31 @@ const ∈ = in
 ∋(itr, x)= ∈(x, itr)
 ∌(itr, x)=!∋(itr, x)
 
+"""
+    contains(fun, itr, x) -> Bool
+
+Returns `true` if there is at least one element `y` in `itr` such that `fun(y,x)` is `true`.
+
+```jldoctest
+julia> vec = [ 10, 100, 200 ]
+3-element Array{Int64,1}:
+  10
+ 100
+ 200
+
+julia> contains(==, vec, 200)
+true
+
+julia> contains(==, vec, 300)
+false
+
+julia> contains(>, vec, 100)
+true
+
+julia> contains(>, vec, 200)
+false
+```
+"""
 function contains(eq::Function, itr, x)
     for y in itr
         eq(y, x) && return true

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -78,6 +78,7 @@ Base.flipdim
 Base.circshift
 Base.circshift!
 Base.circcopy!
+Base.contains(::Function, ::Any, ::Any)
 Base.find(::Any)
 Base.find(::Function, ::Any)
 Base.findn

--- a/doc/src/stdlib/strings.md
+++ b/doc/src/stdlib/strings.md
@@ -31,7 +31,7 @@ Base.search
 Base.rsearch
 Base.searchindex
 Base.rsearchindex
-Base.contains
+Base.contains(::AbstractString, ::AbstractString)
 Base.reverse(::AbstractString)
 Base.replace
 Base.split


### PR DESCRIPTION
Regarding method `contains(fun, itr, x) -> Bool`