### PR TITLE
RFC: Make `any` and `all` always short-circuit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,10 @@ Library improvements
 
   * New `titlecase` function, which capitalizes the first character of each word within a string ([#19469]).
 
+  * `any` and `all` now always short-circuit, and `mapreduce` never short-circuits ([#19543]).
+    That is, not every member of the input iterable will be visited if a `true` (in the case of `any`) or
+    `false` (in the case of `all`) value is found, and `mapreduce` will visit all members of the iterable.
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/char.jl
+++ b/base/char.jl
@@ -18,7 +18,7 @@ length(c::Char) = 1
 endof(c::Char) = 1
 getindex(c::Char) = c
 getindex(c::Char, i::Integer) = i == 1 ? c : throw(BoundsError())
-getindex(c::Char, I::Integer...) = all(Predicate(x -> x == 1), I) ? c : throw(BoundsError())
+getindex(c::Char, I::Integer...) = all(x -> x == 1, I) ? c : throw(BoundsError())
 first(c::Char) = c
 last(c::Char) = c
 eltype(::Type{Char}) = Char

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -579,11 +579,12 @@ true
 ```
 """
 any(f::Any, itr) = any(Predicate(f), itr)
-any(f::Predicate, itr) = mapreduce_sc_impl(f, |, itr)
-any(f::typeof(identity), itr) =
-    eltype(itr) <: Bool ?
-        mapreduce_sc_impl(f, |, itr) :
-        reduce(or_bool_only, false, itr)
+function any(f::Predicate, itr)
+    for x in itr
+        f(x) && return true
+    end
+    return false
+end
 
 """
     all(p, itr) -> Bool
@@ -596,11 +597,12 @@ true
 ```
 """
 all(f::Any, itr) = all(Predicate(f), itr)
-all(f::Predicate, itr) = mapreduce_sc_impl(f, &, itr)
-all(f::typeof(identity), itr) =
-    eltype(itr) <: Bool ?
-        mapreduce_sc_impl(f, &, itr) :
-        reduce(and_bool_only, true, itr)
+function all(f::Predicate, itr)
+    for x in itr
+        f(x) || return false
+    end
+    return true
+end
 
 ## in & contains
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -476,6 +476,7 @@ end
     any(itr) -> Bool
 
 Test whether any elements of a boolean collection are `true`.
+Not all items in `itr` will be visited if a `true` value is found.
 
 ```jldoctest
 julia> a = [true,false,false,true]
@@ -487,6 +488,10 @@ julia> a = [true,false,false,true]
 
 julia> any(a)
 true
+
+julia> any((println(i); v) for (i, v) in enumerate(a))
+1
+true
 ```
 """
 any(itr) = any(identity, itr)
@@ -495,6 +500,7 @@ any(itr) = any(identity, itr)
     all(itr) -> Bool
 
 Test whether all elements of a boolean collection are `true`.
+Not all items in `itr` will be visited if a `false` value is found.
 
 ```jldoctest
 julia> a = [true,false,false,true]
@@ -506,6 +512,11 @@ julia> a = [true,false,false,true]
 
 julia> all(a)
 false
+
+julia> all((println(i); v) for (i, v) in enumerate(a))
+1
+2
+false
 ```
 """
 all(itr) = all(identity, itr)
@@ -514,9 +525,17 @@ all(itr) = all(identity, itr)
     any(p, itr) -> Bool
 
 Determine whether predicate `p` returns `true` for any elements of `itr`.
+Not all items in `itr` will be visited if a `true` value is found.
 
 ```jldoctest
 julia> any(i->(4<=i<=6), [3,5,7])
+true
+
+julia> any(i -> (println(i); i > 3), 1:10)
+1
+2
+3
+4
 true
 ```
 """
@@ -531,10 +550,17 @@ end
     all(p, itr) -> Bool
 
 Determine whether predicate `p` returns `true` for all elements of `itr`.
+Not all items in `itr` will be visited if a `false` value is found.
 
 ```jldoctest
 julia> all(i->(4<=i<=6), [4,5,6])
 true
+
+julia> all(i -> (println(i); i < 3), 1:10)
+1
+2
+3
+false
 ```
 """
 function all(f, itr)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -475,8 +475,8 @@ end
 """
     any(itr) -> Bool
 
-Test whether any elements of a boolean collection are `true`.
-Not all items in `itr` will be visited if a `true` value is found.
+Test whether any elements of a boolean collection are `true`, returning `true` as
+soon as the first `true` value in `itr` is encountered (short-circuiting).
 
 ```jldoctest
 julia> a = [true,false,false,true]
@@ -499,8 +499,8 @@ any(itr) = any(identity, itr)
 """
     all(itr) -> Bool
 
-Test whether all elements of a boolean collection are `true`.
-Not all items in `itr` will be visited if a `false` value is found.
+Test whether all elements of a boolean collection are `true`, returning `false` as
+soon as the first `false` value in `itr` is encountered (short-circuiting).
 
 ```jldoctest
 julia> a = [true,false,false,true]
@@ -524,8 +524,9 @@ all(itr) = all(identity, itr)
 """
     any(p, itr) -> Bool
 
-Determine whether predicate `p` returns `true` for any elements of `itr`.
-Not all items in `itr` will be visited if a `true` value is found.
+Determine whether predicate `p` returns `true` for any elements of `itr`, returning
+`true` as soon as the first item in `itr` for which `p` returns `true` is encountered
+(short-circuiting).
 
 ```jldoctest
 julia> any(i->(4<=i<=6), [3,5,7])
@@ -549,8 +550,9 @@ end
 """
     all(p, itr) -> Bool
 
-Determine whether predicate `p` returns `true` for all elements of `itr`.
-Not all items in `itr` will be visited if a `false` value is found.
+Determine whether predicate `p` returns `true` for all elements of `itr`, returning
+`false` as soon as the first item in `itr` for which `p` returns `false` is encountered
+(short-circuiting).
 
 ```jldoctest
 julia> all(i->(4<=i<=6), [4,5,6])

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -224,6 +224,15 @@ let c = [0, 0], A = 1:1000
     @test c == [10,10]
 end
 
+# 19151 - always short circuit
+let c = Int[], d = Int[], A = 1:9
+    all((push!(c, x); x < 5) for x in A)
+    @test c == collect(1:5)
+
+    any((push!(d, x); x > 4) for x in A)
+    @test d == collect(1:5)
+end
+
 # any and all with functors
 
 immutable SomeFunctor end


### PR DESCRIPTION
Fixes #19151

This implements @JeffBezanson's suggested simplification. With this change, `any` and `all` will short circuit in _all_ circumstances. Currently they short circuit for arrays (we even have a test for that) but not for generators.