### PR TITLE
Add LLVM patches to fix compilation on AArch64

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -489,6 +489,8 @@ $(eval $(call LLVM_PATCH,llvm-D25865-cmakeshlib))
 $(eval $(call LLVM_PATCH,llvm-3.9.0_threads))
 $(eval $(call LLVM_PATCH,llvm-3.9.0_win64-reloc-dwarf))
 $(eval $(call LLVM_PATCH,llvm-3.9.0_D27296-libssp))
+$(eval $(call LLVM_PATCH,llvm-D27609-AArch64-UABS_G3))
+$(eval $(call LLVM_PATCH,llvm-D27629-AArch64-large_model))
 endif # LLVM_VER
 
 ifeq ($(LLVM_VER),3.7.1)

--- a/deps/patches/llvm-D27609-AArch64-UABS_G3.patch
+++ b/deps/patches/llvm-D27609-AArch64-UABS_G3.patch
@@ -1,0 +1,311 @@
+From df0ce05530fd3a0e4c283af817f4446d439647ea Mon Sep 17 00:00:00 2001
+From: yuyichao <yuyichao@91177308-0d34-0410-b5e6-96231b3b80d8>
+Date: Thu, 15 Dec 2016 22:36:53 +0000
+Subject: [PATCH 1/2] Fix R_AARCH64_MOVW_UABS_G3 relocation
+
+Summary: The relocation is missing mask so an address that has non-zero bits in 47:43 may overwrite the register number. (Frequently shows up as target register changed to `xzr`....)
+
+Reviewers: t.p.northover, lhames
+
+Subscribers: davide, aemerson, rengolin, llvm-commits
+
+Differential Revision: https://reviews.llvm.org/D27609
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@289880 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ include/llvm/Object/ELFObjectFile.h                |  2 +-
+ include/llvm/Object/RelocVisitor.h                 |  1 +
+ lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp | 72 +++++++++++++++-------
+ .../RuntimeDyld/AArch64/ELF_ARM64_BE-relocations.s | 34 ++++++++++
+ .../RuntimeDyld/AArch64/ELF_ARM64_relocations.s    | 33 ++++++++++
+ 5 files changed, 118 insertions(+), 24 deletions(-)
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-relocations.s
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_relocations.s
+
+diff --git a/include/llvm/Object/ELFObjectFile.h b/include/llvm/Object/ELFObjectFile.h
+index 4209da8..69987d4 100644
+--- a/include/llvm/Object/ELFObjectFile.h
++++ b/include/llvm/Object/ELFObjectFile.h
+@@ -972,7 +972,7 @@ unsigned ELFObjectFile<ELFT>::getArch() const {
+   case ELF::EM_X86_64:
+     return Triple::x86_64;
+   case ELF::EM_AARCH64:
+-    return Triple::aarch64;
++    return IsLittleEndian ? Triple::aarch64 : Triple::aarch64_be;
+   case ELF::EM_ARM:
+     return Triple::arm;
+   case ELF::EM_AVR:
+diff --git a/include/llvm/Object/RelocVisitor.h b/include/llvm/Object/RelocVisitor.h
+index e1926aa..3510d29 100644
+--- a/include/llvm/Object/RelocVisitor.h
++++ b/include/llvm/Object/RelocVisitor.h
+@@ -86,6 +86,7 @@ private:
+           return RelocToApply();
+         }
+       case Triple::aarch64:
++      case Triple::aarch64_be:
+         switch (RelocType) {
+         case llvm::ELF::R_AARCH64_ABS32:
+           return visitELF_AARCH64_ABS32(R, Value);
+diff --git a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+index c70e81a..a977dce 100644
+--- a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
++++ b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+@@ -325,6 +325,8 @@ void RuntimeDyldELF::resolveAArch64Relocation(const SectionEntry &Section,
+   uint32_t *TargetPtr =
+       reinterpret_cast<uint32_t *>(Section.getAddressWithOffset(Offset));
+   uint64_t FinalAddress = Section.getLoadAddressWithOffset(Offset);
++  // Data should use target endian. Code should always use little endian.
++  bool isBE = Arch == Triple::aarch64_be;
+ 
+   DEBUG(dbgs() << "resolveAArch64Relocation, LocalAddress: 0x"
+                << format("%llx", Section.getAddressWithOffset(Offset))
+@@ -340,14 +342,22 @@ void RuntimeDyldELF::resolveAArch64Relocation(const SectionEntry &Section,
+   case ELF::R_AARCH64_ABS64: {
+     uint64_t *TargetPtr =
+         reinterpret_cast<uint64_t *>(Section.getAddressWithOffset(Offset));
+-    *TargetPtr = Value + Addend;
++    if (isBE)
++      support::ubig64_t::ref{TargetPtr} = Value + Addend;
++    else
++      support::ulittle64_t::ref{TargetPtr} = Value + Addend;
+     break;
+   }
+   case ELF::R_AARCH64_PREL32: {
+     uint64_t Result = Value + Addend - FinalAddress;
+     assert(static_cast<int64_t>(Result) >= INT32_MIN &&
+            static_cast<int64_t>(Result) <= UINT32_MAX);
+-    *TargetPtr = static_cast<uint32_t>(Result & 0xffffffffU);
++    if (isBE)
++      support::ubig32_t::ref{TargetPtr} =
++        static_cast<uint32_t>(Result & 0xffffffffU);
++    else
++      support::ulittle32_t::ref{TargetPtr} =
++        static_cast<uint32_t>(Result & 0xffffffffU);
+     break;
+   }
+   case ELF::R_AARCH64_CALL26: // fallthrough
+@@ -355,104 +365,120 @@ void RuntimeDyldELF::resolveAArch64Relocation(const SectionEntry &Section,
+     // Operation: S+A-P. Set Call or B immediate value to bits fff_fffc of the
+     // calculation.
+     uint64_t BranchImm = Value + Addend - FinalAddress;
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // "Check that -2^27 <= result < 2^27".
+     assert(isInt<28>(BranchImm));
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0xfc000000U;
++    TargetValue &= 0xfc000000U;
+     // Immediate goes in bits 25:0 of B and BL.
+-    *TargetPtr |= static_cast<uint32_t>(BranchImm & 0xffffffcU) >> 2;
++    TargetValue |= static_cast<uint32_t>(BranchImm & 0xffffffcU) >> 2;
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   case ELF::R_AARCH64_MOVW_UABS_G3: {
+     uint64_t Result = Value + Addend;
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0xffe0001fU;
++    TargetValue &= 0xffe0001fU;
+     // Immediate goes in bits 20:5 of MOVZ/MOVK instruction
+-    *TargetPtr |= Result >> (48 - 5);
++    TargetValue |= ((Result & 0xffff000000000000ULL) >> (48 - 5));
+     // Shift must be "lsl #48", in bits 22:21
+-    assert((*TargetPtr >> 21 & 0x3) == 3 && "invalid shift for relocation");
++    assert((TargetValue >> 21 & 0x3) == 3 && "invalid shift for relocation");
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   case ELF::R_AARCH64_MOVW_UABS_G2_NC: {
+     uint64_t Result = Value + Addend;
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0xffe0001fU;
++    TargetValue &= 0xffe0001fU;
+     // Immediate goes in bits 20:5 of MOVZ/MOVK instruction
+-    *TargetPtr |= ((Result & 0xffff00000000ULL) >> (32 - 5));
++    TargetValue |= ((Result & 0xffff00000000ULL) >> (32 - 5));
+     // Shift must be "lsl #32", in bits 22:21
+-    assert((*TargetPtr >> 21 & 0x3) == 2 && "invalid shift for relocation");
++    assert((TargetValue >> 21 & 0x3) == 2 && "invalid shift for relocation");
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   case ELF::R_AARCH64_MOVW_UABS_G1_NC: {
+     uint64_t Result = Value + Addend;
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0xffe0001fU;
++    TargetValue &= 0xffe0001fU;
+     // Immediate goes in bits 20:5 of MOVZ/MOVK instruction
+-    *TargetPtr |= ((Result & 0xffff0000U) >> (16 - 5));
++    TargetValue |= ((Result & 0xffff0000U) >> (16 - 5));
+     // Shift must be "lsl #16", in bits 22:2
+-    assert((*TargetPtr >> 21 & 0x3) == 1 && "invalid shift for relocation");
++    assert((TargetValue >> 21 & 0x3) == 1 && "invalid shift for relocation");
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   case ELF::R_AARCH64_MOVW_UABS_G0_NC: {
+     uint64_t Result = Value + Addend;
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0xffe0001fU;
++    TargetValue &= 0xffe0001fU;
+     // Immediate goes in bits 20:5 of MOVZ/MOVK instruction
+-    *TargetPtr |= ((Result & 0xffffU) << 5);
++    TargetValue |= ((Result & 0xffffU) << 5);
+     // Shift must be "lsl #0", in bits 22:21.
+-    assert((*TargetPtr >> 21 & 0x3) == 0 && "invalid shift for relocation");
++    assert((TargetValue >> 21 & 0x3) == 0 && "invalid shift for relocation");
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   case ELF::R_AARCH64_ADR_PREL_PG_HI21: {
+     // Operation: Page(S+A) - Page(P)
+     uint64_t Result =
+         ((Value + Addend) & ~0xfffULL) - (FinalAddress & ~0xfffULL);
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // Check that -2^32 <= X < 2^32
+     assert(isInt<33>(Result) && "overflow check failed for relocation");
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0x9f00001fU;
++    TargetValue &= 0x9f00001fU;
+     // Immediate goes in bits 30:29 + 5:23 of ADRP instruction, taken
+     // from bits 32:12 of X.
+-    *TargetPtr |= ((Result & 0x3000U) << (29 - 12));
+-    *TargetPtr |= ((Result & 0x1ffffc000ULL) >> (14 - 5));
++    TargetValue |= ((Result & 0x3000U) << (29 - 12));
++    TargetValue |= ((Result & 0x1ffffc000ULL) >> (14 - 5));
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   case ELF::R_AARCH64_LDST32_ABS_LO12_NC: {
+     // Operation: S + A
+     uint64_t Result = Value + Addend;
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0xffc003ffU;
++    TargetValue &= 0xffc003ffU;
+     // Immediate goes in bits 21:10 of LD/ST instruction, taken
+     // from bits 11:2 of X
+-    *TargetPtr |= ((Result & 0xffc) << (10 - 2));
++    TargetValue |= ((Result & 0xffc) << (10 - 2));
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   case ELF::R_AARCH64_LDST64_ABS_LO12_NC: {
+     // Operation: S + A
+     uint64_t Result = Value + Addend;
++    uint32_t TargetValue = support::ulittle32_t::ref{TargetPtr};
+ 
+     // AArch64 code is emitted with .rela relocations. The data already in any
+     // bits affected by the relocation on entry is garbage.
+-    *TargetPtr &= 0xffc003ffU;
++    TargetValue &= 0xffc003ffU;
+     // Immediate goes in bits 21:10 of LD/ST instruction, taken
+     // from bits 11:3 of X
+-    *TargetPtr |= ((Result & 0xff8) << (10 - 3));
++    TargetValue |= ((Result & 0xff8) << (10 - 3));
++    support::ulittle32_t::ref{TargetPtr} = TargetValue;
+     break;
+   }
+   }
+diff --git a/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-relocations.s b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-relocations.s
+new file mode 100644
+index 0000000..3ba95e4
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-relocations.s
+@@ -0,0 +1,34 @@
++# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -filetype=obj -o %T/be-reloc.o %s
++# RUN: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -dummy-extern f=0x0123456789abcdef -check=%s %T/be-reloc.o
++
++        .text
++        .globl  g
++        .p2align        2
++        .type   g,@function
++g:
++# R_AARCH64_MOVW_UABS_G3
++        movz    x0, #:abs_g3:f
++# R_AARCH64_MOVW_UABS_G2_NC
++        movk    x0, #:abs_g2_nc:f
++# R_AARCH64_MOVW_UABS_G1_NC
++        movk    x0, #:abs_g1_nc:f
++# R_AARCH64_MOVW_UABS_G0_NC
++        movk    x0, #:abs_g0_nc:f
++        ret
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++
++        .type   k,@object
++        .data
++        .globl  k
++        .p2align        3
++k:
++        .xword  f
++        .size   k, 8
++
++# LE instructions read as BE
++# rtdyld-check: *{4}(g) = 0x6024e0d2
++# rtdyld-check: *{4}(g + 4) = 0xe0acc8f2
++# rtdyld-check: *{4}(g + 8) = 0x6035b1f2
++# rtdyld-check: *{4}(g + 12) = 0xe0bd99f2
++# rtdyld-check: *{8}k = f
+diff --git a/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_relocations.s b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_relocations.s
+new file mode 100644
+index 0000000..f83f6bf
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_relocations.s
+@@ -0,0 +1,33 @@
++# RUN: llvm-mc -triple=arm64-none-linux-gnu -filetype=obj -o %T/reloc.o %s
++# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -dummy-extern f=0x0123456789abcdef -check=%s %T/reloc.o
++
++        .text
++        .globl  g
++        .p2align        2
++        .type   g,@function
++g:
++# R_AARCH64_MOVW_UABS_G3
++        movz    x0, #:abs_g3:f
++# R_AARCH64_MOVW_UABS_G2_NC
++        movk    x0, #:abs_g2_nc:f
++# R_AARCH64_MOVW_UABS_G1_NC
++        movk    x0, #:abs_g1_nc:f
++# R_AARCH64_MOVW_UABS_G0_NC
++        movk    x0, #:abs_g0_nc:f
++        ret
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++
++        .type   k,@object
++        .data
++        .globl  k
++        .p2align        3
++k:
++        .xword  f
++        .size   k, 8
++
++# rtdyld-check: *{4}(g) = 0xd2e02460
++# rtdyld-check: *{4}(g + 4) = 0xf2c8ace0
++# rtdyld-check: *{4}(g + 8) = 0xf2b13560
++# rtdyld-check: *{4}(g + 12) = 0xf299bde0
++# rtdyld-check: *{8}k = f
+-- 
+2.10.2
+

--- a/deps/patches/llvm-D27629-AArch64-large_model.patch
+++ b/deps/patches/llvm-D27629-AArch64-large_model.patch
@@ -1,0 +1,100 @@
+From 073a3b4c0e422396016ddea15181411e45c96af5 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Fri, 9 Dec 2016 15:59:46 -0500
+Subject: [PATCH 2/2] Fix unwind info relocation with large code model on
+ AArch64
+
+---
+ lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp     | 10 ++++++++++
+ lib/MC/MCObjectFileInfo.cpp                            |  2 ++
+ .../AArch64/ELF_ARM64_BE-large-relocations.s           | 18 ++++++++++++++++++
+ .../RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s  | 18 ++++++++++++++++++
+ 4 files changed, 48 insertions(+)
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-large-relocations.s
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+
+diff --git a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+index a977dce..2a832f8 100644
+--- a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
++++ b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+@@ -360,6 +360,16 @@ void RuntimeDyldELF::resolveAArch64Relocation(const SectionEntry &Section,
+         static_cast<uint32_t>(Result & 0xffffffffU);
+     break;
+   }
++  case ELF::R_AARCH64_PREL64: {
++    uint64_t *TargetPtr =
++        reinterpret_cast<uint64_t *>(Section.getAddressWithOffset(Offset));
++    uint64_t Result = Value + Addend - FinalAddress;
++    if (isBE)
++      support::ubig64_t::ref{TargetPtr} = Result;
++    else
++      support::ulittle64_t::ref{TargetPtr} = Result;
++    break;
++  }
+   case ELF::R_AARCH64_CALL26: // fallthrough
+   case ELF::R_AARCH64_JUMP26: {
+     // Operation: S+A-P. Set Call or B immediate value to bits fff_fffc of the
+diff --git a/lib/MC/MCObjectFileInfo.cpp b/lib/MC/MCObjectFileInfo.cpp
+index 8fd71f6..bcf774e 100644
+--- a/lib/MC/MCObjectFileInfo.cpp
++++ b/lib/MC/MCObjectFileInfo.cpp
+@@ -279,6 +279,8 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T) {
+   case Triple::mips64el:
+     FDECFIEncoding = dwarf::DW_EH_PE_sdata8;
+     break;
++  case Triple::aarch64:
++  case Triple::aarch64_be:
+   case Triple::x86_64:
+     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
+                      ((CMModel == CodeModel::Large) ? dwarf::DW_EH_PE_sdata8
+diff --git a/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-large-relocations.s b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-large-relocations.s
+new file mode 100644
+index 0000000..e3eeb02
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-large-relocations.s
+@@ -0,0 +1,18 @@
++# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -code-model=large -filetype=obj -o %T/be-large-reloc.o %s
++# RUN: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section be-large-reloc.o,.eh_frame=0x10000 -map-section be-large-reloc.o,.text=0xffff000000000000 -check=%s %T/be-large-reloc.o
++
++        .text
++        .globl  g
++        .p2align        2
++        .type   g,@function
++g:
++        .cfi_startproc
++        mov      x0, xzr
++        ret
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++        .cfi_endproc
++
++# Skip the CIE and load the 8 bytes PC begin pointer.
++# Assuming the CIE and the FDE length are both 4 bytes.
++# rtdyld-check: *{8}(section_addr(be-large-reloc.o, .eh_frame) + (*{4}(section_addr(be-large-reloc.o, .eh_frame))) + 0xc) = g - (section_addr(be-large-reloc.o, .eh_frame) + (*{4}(section_addr(be-large-reloc.o, .eh_frame))) + 0xc)
+diff --git a/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+new file mode 100644
+index 0000000..ec30f19
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+@@ -0,0 +1,18 @@
++# RUN: llvm-mc -triple=arm64-none-linux-gnu -code-model=large -filetype=obj -o %T/large-reloc.o %s
++# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %T/large-reloc.o
++
++        .text
++        .globl  g
++        .p2align        2
++        .type   g,@function
++g:
++        .cfi_startproc
++        mov      x0, xzr
++        ret
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++        .cfi_endproc
++
++# Skip the CIE and load the 8 bytes PC begin pointer.
++# Assuming the CIE and the FDE length are both 4 bytes.
++# rtdyld-check: *{8}(section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc) = g - (section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc)
+-- 
+2.10.2
+


### PR DESCRIPTION
The AArch64 and ARM buildbot were brought down for the past few days to investigate what I suspected to be a llvm or kernel issue and it seems to be two bugs in LLVM. I've updated the kernel with the configuration that triggers these issues so that we can test these.

The failure looks like https://buildtest.e.ip.saba.us/#/builders/69/builds/31/steps/4/logs/stdio, which is reproducible on the ArchLinux stock kernel and the kernel on Packet Type 2A. I've triggered a build on the buildbot on this commit and it should hopefully pass the tests and cache a working LLVM build before this is merged.
