### PR TITLE
Maintain a more obvious ordering of SSL certificate locations

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -43,23 +43,20 @@ endif
 # We need to bundle ca certs on linux now that we're using libgit2 with ssl
 ifeq ($(OS),Linux)
 OPENSSL_DIR=$(shell openssl version -d | cut -d '"' -f 2)
-# This certfile location observed on Ubuntu 14.04
-ifeq ($(shell [ -e $(OPENSSL_DIR)/cert.pem ] && echo exists),exists)
-CERTFILE=$(OPENSSL_DIR)/cert.pem
-endif
 # This certfile location observed on Ubuntu 16.04
 ifeq ($(shell [ -e $(OPENSSL_DIR)/certs/ca-certificates.crt ] && echo exists),exists)
 CERTFILE=$(OPENSSL_DIR)/certs/ca-certificates.crt
-endif
+# This certfile location observed on openSUSE Leap 42.1
+else ifeq ($(shell [ -e $(OPENSSL_DIR)/ca-bundle.pem ] && echo exists),exists)
+CERTFILE=$(OPENSSL_DIR)/ca-bundle.pem
+# This certfile location observed on Ubuntu 14.04
+else ifeq ($(shell [ -e $(OPENSSL_DIR)/cert.pem ] && echo exists),exists)
+CERTFILE=$(OPENSSL_DIR)/cert.pem
 # This certfile location observed on Debian 7
-ifeq ($(shell [ -e $(OPENSSL_DIR)/certs/ca.pem ] && echo exists),exists)
+else ifeq ($(shell [ -e $(OPENSSL_DIR)/certs/ca.pem ] && echo exists),exists)
 CERTFILE=$(OPENSSL_DIR)/certs/ca.pem
 endif
-# This certfile location observed on openSUSE Leap 42.1
-ifeq ($(shell [ -e $(OPENSSL_DIR)/ca-bundle.pem ] && echo exists),exists)
-CERTFILE=$(OPENSSL_DIR)/ca-bundle.pem
-endif
-endif
+endif # Linux
 
 LIBGIT2_SRC_PATH := $(SRCDIR)/srccache/$(LIBGIT2_SRC_DIR)
 


### PR DESCRIPTION
This creates a more well-defined ordering of SSL certificate locations that we search, and permutes the ordering a bit to look for certificates that are more explicitly named first.  This is necessary because, on some older Debian systems, the file `<openssl dir>/certs/ca.pem` is actually the certificate for the `debconf.org` site, and not the list of certificate authorities ([Debian bug about this](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=693405)).

With this patch, we pick up the more explicitly named `ca-certificates.crt` first which fixes the issue on the machine I discovered this issue on.