### PR TITLE
Upgrade doc deps

### DIFF
--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
 Compat 0.9.5 0.9.5+
 DocStringExtensions 0.3.0 0.3.0+
-Documenter 0.8.2 0.8.2+
+Documenter 0.8.3 0.8.3+


### PR DESCRIPTION
Bump Documenter to version 0.8.3 which contains a fix for jb/subtype.