### PR TITLE
expand xor documentation [skip ci]

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3212,8 +3212,8 @@ dawson
 
 Bitwise exclusive or of `x` and `y`.  The infix operation
 `a ⊻ b` is a synonym for `xor(a,b)`, and
-`⊻` can be typed by tab-completing `\xor`
-or `\veebar` in the Julia REPL.
+`⊻` can be typed by tab-completing `\\xor`
+or `\\veebar` in the Julia REPL.
 
 ```jldoctest
 julia> [true; true; false] ⊻ [true; false; false]

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3213,7 +3213,7 @@ dawson
 Bitwise exclusive or of `x` and `y`.  The infix operation
 `a ⊻ b` is a synonym for `xor(a,b)`, and
 `⊻` can be typed by tab-completing `\xor`
-or `\vbar` in the Julia REPL.
+or `\veebar` in the Julia REPL.
 
 ```jldoctest
 julia> [true; true; false] ⊻ [true; false; false]

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -3210,7 +3210,10 @@ dawson
     xor(x, y)
     ⊻(x, y)
 
-Bitwise exclusive or.
+Bitwise exclusive or of `x` and `y`.  The infix operation
+`a ⊻ b` is a synonym for `xor(a,b)`, and
+`⊻` can be typed by tab-completing `\xor`
+or `\vbar` in the Julia REPL.
 
 ```jldoctest
 julia> [true; true; false] ⊻ [true; false; false]


### PR DESCRIPTION
The `xor` documentation was a bit terse, and in particular a note on how to type `⊻` would be helpful.