### PR TITLE
Remove localize_vars. Serialize global values under Main.

### DIFF
--- a/base/event.jl
+++ b/base/event.jl
@@ -66,10 +66,12 @@ n_waiters(c::Condition) = length(c.waitq)
     @schedule
 
 Wrap an expression in a [`Task`](@ref) and add it to the local machine's scheduler queue.
+Similar to [`@async`](@ref) except that an enclosing `@sync` does NOT wait for tasks
+started with an `@schedule`.
 """
 macro schedule(expr)
-    expr = :(()->($expr))
-    :(enq_work(Task($(esc(expr)))))
+    thunk = esc(:(()->($expr)))
+    :(enq_work(Task($thunk)))
 end
 
 ## scheduler and work queue

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -188,37 +188,6 @@ end
 
 ## some macro utilities ##
 
-find_vars(e) = find_vars(e, [])
-function find_vars(e, lst)
-    if isa(e,Symbol)
-        if current_module()===Main && isdefined(e)
-            # Main runs on process 1, so send globals from there, excluding
-            # things defined in Base.
-            if !isdefined(Base,e) || eval(Base,e)!==eval(current_module(),e)
-                push!(lst, e)
-            end
-        end
-    elseif isa(e,Expr) && e.head !== :quote && e.head !== :top && e.head !== :core
-        for x in e.args
-            find_vars(x,lst)
-        end
-    end
-    lst
-end
-
-# wrap an expression in "let a=a,b=b,..." for each var it references
-localize_vars(expr) = localize_vars(expr, true)
-function localize_vars(expr, esca)
-    v = find_vars(expr)
-    # requires a special feature of the front end that knows how to insert
-    # the correct variables. the list of free variables cannot be computed
-    # from a macro.
-    if esca
-        v = map(esc,v)
-    end
-    Expr(:localize, expr, v...)
-end
-
 function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
     if isempty(args)
         tag = sym

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1937,8 +1937,8 @@ end
 ## higher-level functions: spawn, pmap, pfor, etc. ##
 
 let nextidx = 0
-    global chooseproc
-    function chooseproc(thunk::Function)
+    global nextproc
+    function nextproc()
         p = -1
         if p == -1
             p = workers()[(nextidx % nworkers()) + 1]
@@ -1950,16 +1950,16 @@ end
 
 spawnat(p, thunk) = sync_add(remotecall(thunk, p))
 
-spawn_somewhere(thunk) = spawnat(chooseproc(thunk),thunk)
+spawn_somewhere(thunk) = spawnat(nextproc(),thunk)
 
 macro spawn(expr)
-    expr = localize_vars(esc(:(()->($expr))), false)
-    :(spawn_somewhere($expr))
+    thunk = esc(:(()->($expr)))
+    :(spawn_somewhere($thunk))
 end
 
 macro spawnat(p, expr)
-    expr = localize_vars(esc(:(()->($expr))), false)
-    :(spawnat($(esc(p)), $expr))
+    thunk = esc(:(()->($expr)))
+    :(spawnat($(esc(p)), $thunk))
 end
 
 """
@@ -1969,11 +1969,8 @@ Equivalent to `fetch(@spawn expr)`.
 See [`fetch`](@ref) and [`@spawn`](@ref).
 """
 macro fetch(expr)
-    expr = localize_vars(esc(:(()->($expr))), false)
-    quote
-        thunk = $expr
-        remotecall_fetch(thunk, chooseproc(thunk))
-    end
+    thunk = esc(:(()->($expr)))
+    :(remotecall_fetch($thunk, nextproc()))
 end
 
 """
@@ -1983,8 +1980,8 @@ Equivalent to `fetch(@spawnat p expr)`.
 See [`fetch`](@ref) and [`@spawnat`](@ref).
 """
 macro fetchfrom(p, expr)
-    expr = localize_vars(esc(:(()->($expr))), false)
-    :(remotecall_fetch($expr, $(esc(p))))
+    thunk = esc(:(()->($expr)))
+    :(remotecall_fetch($thunk, $(esc(p))))
 end
 
 """
@@ -2140,7 +2137,7 @@ macro parallel(args...)
     else
         thecall = :(preduce($(esc(reducer)), $(make_preduce_body(var, body)), $(esc(r))))
     end
-    localize_vars(thecall)
+    thecall
 end
 
 
@@ -2286,3 +2283,25 @@ function getindex(r::RemoteChannel, args...)
     end
     return remotecall_fetch(getindex, r.where, r, args...)
 end
+
+"""
+    clear!(syms, pids=workers(); mod=Main)
+
+Clears global bindings in modules by initializing them to `nothing`.
+`syms` should be of type `Symbol` or a collection of `Symbol`s . `pids` and `mod`
+identify the processes and the module in which global variables are to be
+reinitialized. Only those names found to be defined under `mod` are cleared.
+
+An exception is raised if a global constant is requested to be cleared.
+"""
+function clear!(syms, pids=workers(); mod=Main)
+    @sync for p in pids
+        @async remotecall_wait(clear_impl!, p, syms, mod)
+    end
+end
+clear!(sym::Symbol, pid::Int; mod=Main) = clear!([sym], [pid]; mod=mod)
+clear!(sym::Symbol, pids=workers(); mod=Main) = clear!([sym], pids; mod=mod)
+clear!(syms, pid::Int; mod=Main) = clear!(syms, [pid]; mod=mod)
+
+clear_impl!(syms, mod::Module) = foreach(x->clear_impl!(x,mod), syms)
+clear_impl!(sym::Symbol, mod::Module) = isdefined(mod, sym) && eval(mod, :(global $sym = nothing))

--- a/base/task.jl
+++ b/base/task.jl
@@ -325,10 +325,9 @@ end
 
 Like `@schedule`, `@async` wraps an expression in a `Task` and adds it to the local
 machine's scheduler queue. Additionally it adds the task to the set of items that the
-nearest enclosing `@sync` waits for. `@async` also wraps the expression in a `let x=x, y=y, ...`
-block to create a new scope with copies of all variables referenced in the expression.
+nearest enclosing `@sync` waits for.
 """
 macro async(expr)
-    expr = localize_vars(esc(:(()->($expr))), false)
-    :(async_run_thunk($expr))
+    thunk = esc(:(()->($expr)))
+    :(async_run_thunk($thunk))
 end

--- a/doc/src/stdlib/parallel.md
+++ b/doc/src/stdlib/parallel.md
@@ -60,6 +60,7 @@ Base.isready(::Future)
 Base.WorkerPool
 Base.CachingPool
 Base.default_worker_pool
+Base.clear!(::CachingPool)
 Base.remote
 Base.remotecall(::Any, ::Base.AbstractWorkerPool, ::Any...)
 Base.remotecall_wait(::Any, ::Base.AbstractWorkerPool, ::Any...)
@@ -74,7 +75,7 @@ Base.@async
 Base.@sync
 Base.@parallel
 Base.@everywhere
-Base.clear!
+Base.clear!(::Any, ::Any; ::Any)
 Base.remoteref_id
 Base.channel_from_id
 Base.worker_id_from_socket

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -278,17 +278,6 @@
                           (cadr e))
                      ,(resolve-expansion-vars- (caddr e) env m inarg))))
 
-           ((localize)
-            (let ((expr (cadr e))
-                  (lvars (map unescape (cddr e))))
-              (let ((vs (delete-duplicates
-                         (expr-find-all (lambda (v)
-                                          (and (symbol? v) (or (memq v lvars)
-                                                               (assq v env))))
-                                        expr identity)))
-                    (e2 (resolve-expansion-vars-with-new-env expr env m inarg)))
-                `(call (-> (tuple ,@vs) ,e2) ,@vs))))
-
            ((let)
             (let* ((newenv (new-expansion-env-for e env))
                    (body   (resolve-expansion-vars- (cadr e) newenv m inarg)))
@@ -329,7 +318,6 @@
 (define (find-declared-vars-in-expansion e decl (outer #t))
   (cond ((or (not (pair? e)) (quoted? e)) '())
         ((eq? (car e) 'escape)  '())
-        ((eq? (car e) 'localize) '())
         ((eq? (car e) decl)     (map decl-var* (cdr e)))
         ((and (not outer) (function-def? e)) '())
         (else
@@ -340,7 +328,6 @@
 (define (find-assigned-vars-in-expansion e (outer #t))
   (cond ((or (not (pair? e)) (quoted? e))  '())
         ((eq? (car e) 'escape)  '())
-        ((eq? (car e) 'localize) '())
         ((and (not outer) (function-def? e))
          ;; pick up only function name
          (let ((fname (cond ((eq? (car e) '=) (cadr (cadr e)))

--- a/test/core.jl
+++ b/test/core.jl
@@ -3222,16 +3222,6 @@ abstract B11327 <: A11327
 f11327{T}(::Type{T},x::T) = x
 @test_throws MethodError f11327(Type{A11327},B11327)
 
-# issue 13855
-macro m13855()
-    Expr(:localize, :(() -> $(esc(:x))))
-end
-@noinline function foo13855(x)
-    @m13855()
-end
-@test foo13855(+)() == +
-@test foo13855(*)() == *
-
 # issue #8487
 @test [x for x in 1:3] == [x for x ∈ 1:3] == [x for x = 1:3]
 let A = Array{Int}(4,3)


### PR DESCRIPTION
Closes:
https://github.com/JuliaLang/julia/issues/11228
https://github.com/JuliaLang/julia/issues/8591

Fixes https://github.com/JuliaLang/julia/issues/2669#issuecomment-15378474

The following can now be fixed by automatic serialization of globals (as mentioned in issue https://github.com/JuliaLang/julia/issues/19000) :
https://github.com/JuliaLang/julia/issues/5930
https://github.com/JuliaLang/julia/issues/12367
https://github.com/JuliaLang/julia/issues/14399
https://github.com/JuliaLang/julia/issues/6760

This helps in removing some of the scoping issues w.r.t. parallel macros. A strategy to track and automatic serialization of globals should help in removing the rest.

Till automatic serialization of globals is in place, this will break existing code that would work with globals due to the transparent `localize_vars` call.

We can discuss and merge this now or wait till we have a strategy to deal with globals and merge them together. A reason for delaying a merge would be to preempt issues being reported of globals not being serialized. 