### PR TITLE
call `julia_init` before entering `--lisp` prompt

### DIFF
--- a/ui/repl.c
+++ b/ui/repl.c
@@ -239,12 +239,17 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
     }
 #endif
     libsupport_init();
-    if (argc >= 2 && strcmp((char*)argv[1],"--lisp") == 0) {
-        jl_lisp_prompt();
-        return 0;
+    int lisp_prompt = (argc >= 2 && strcmp((char*)argv[1],"--lisp") == 0);
+    if (lisp_prompt) {
+        memmove(&argv[1], &argv[2], (argc-2)*sizeof(void*));
+        argc--;
     }
     jl_parse_opts(&argc, (char***)&argv);
     julia_init(jl_options.image_file_specified ? JL_IMAGE_CWD : JL_IMAGE_JULIA_HOME);
+    if (lisp_prompt) {
+        jl_lisp_prompt();
+        return 0;
+    }
     int ret = true_main(argc, (char**)argv);
     jl_atexit_hook(ret);
     return ret;


### PR DESCRIPTION
Since 173cc40858eca65c2a66b7dd8746a53717bb0d74, many things crash in `--lisp` mode. This is because `defined-julia-global` was changed to call `scm_to_julia`, which uses `JL_TRY`, which needs more of the runtime initialized. This fixes it, plus allows more to be done from the lisp prompt, which is probably a good idea anyway.