### PR TITLE
Correct expression for vcat

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -150,7 +150,7 @@ A few special expressions correspond to calls to functions with non-obvious name
 | Expression        | Calls                  |
 |:----------------- |:---------------------- |
 | `[A B C ...]`     | [`hcat()`](@ref)       |
-| `[A, B, C, ...]`  | [`vcat()`](@ref)       |
+| `[A; B; C; ...]`  | [`vcat()`](@ref)       |
 | `[A B; C D; ...]` | [`hvcat()`](@ref)      |
 | `A'`              | [`ctranspose()`](@ref) |
 | `A.'`             | [`transpose()`](@ref)  |


### PR DESCRIPTION
Related to https://discourse.julialang.org/t/whats-the-meaning-of-the-array-syntax/938.
I understand that the expression for `vcat` is `[A; B; C; ...]` not `[A, B, C, ...]`.