### PR TITLE
Docs fixes for jb/subtype

### DIFF
--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
 Compat 0.9.5 0.9.5+
-DocStringExtensions 0.3.0 0.3.0+
-Documenter 0.8.3 0.8.3+
+DocStringExtensions 0.3.1 0.3.1+
+Documenter 0.8.4 0.8.4+

--- a/doc/src/stdlib/c.md
+++ b/doc/src/stdlib/c.md
@@ -8,7 +8,7 @@ Base.unsafe_convert
 Base.cconvert
 Base.unsafe_load
 Base.unsafe_store!
-Base.unsafe_copy!(::Ptr, ::Ptr, ::Any)
+Base.unsafe_copy!{T}(::Ptr{T}, ::Ptr{T}, ::Any)
 Base.unsafe_copy!(::Array, ::Any, ::Array, ::Any, ::Any)
 Base.copy!(::Any, ::Any)
 Base.copy!(::Any, ::Any, ::Any, ::Any, ::Any)

--- a/doc/src/stdlib/math.md
+++ b/doc/src/stdlib/math.md
@@ -36,8 +36,7 @@ Base.denominator
 Base.:(<<)
 Base.:(>>)
 Base.:(>>>)
-Base.colon(::Real, ::Real, ::Real)
-Base.colon(::Real, ::Any, ::Real)
+Base.colon
 Base.range
 Base.OneTo
 Base.:(==)


### PR DESCRIPTION
This includes some adjustments to doc signatures to work correctly with the changes on jb/subtype. Also bumps the doc dep versions.