### PR TITLE
WIP: cat for vectors, vcat for matrices & arrays

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -918,7 +918,7 @@ function keymap{D<:Dict}(keymaps::Array{D})
 end
 
 const escape_defaults = merge!(
-    AnyDict(Char(i) => nothing for i=vcat(1:26, 28:31)), # Ignore control characters by default
+    AnyDict(Char(i) => nothing for i=cat(1:26, 28:31)), # Ignore control characters by default
     AnyDict( # And ignore other escape sequences by default
         "\e*" => nothing,
         "\e[*" => nothing,

--- a/base/array.jl
+++ b/base/array.jl
@@ -954,7 +954,7 @@ function hcat{T}(V::Vector{T}...)
     return [ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]
 end
 
-function vcat{T}(arrays::Vector{T}...)
+function cat{T}(arrays::Vector{T}...)
     n = 0
     for a in arrays
         n += length(a)
@@ -981,8 +981,12 @@ function vcat{T}(arrays::Vector{T}...)
     return arr
 end
 
-cat(n::Integer, x::Integer...) = reshape([x...], (ntuple(x->1, n-1)..., length(x)))
+function vcat{T}(arrays::Vector{T}...)
+    arr = cat(arrays...)
+    return reshape(arr,length(arr),1)
+end
 
+cat(n::Integer, x::Integer...) = reshape([x...], (ntuple(x->1, n-1)..., length(x)))
 
 ## find ##
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -2154,7 +2154,7 @@ function hcat(B::BitVector...)
     return M
 end
 
-function vcat(V::BitVector...)
+function cat(V::BitVector...)
     n = 0
     for Vk in V
         n += length(Vk)

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -180,7 +180,7 @@ function parse(x::AbstractString,df::DateFormat)
     if isempty(extra)
         return periods
     else
-        return vcat(periods, extra)
+        return cat(periods, extra)
     end
 end
 

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -309,12 +309,12 @@ Base.show(io::IO,x::CompoundPeriod) = print(io,string(x))
 
 # E.g. Year(1) + Day(1)
 (+)(x::Period,y::Period) = CompoundPeriod(Period[x,y])
-(+)(x::CompoundPeriod,y::Period) = CompoundPeriod(vcat(x.periods,y))
+(+)(x::CompoundPeriod,y::Period) = CompoundPeriod(cat(x.periods,y))
 (+)(y::Period,x::CompoundPeriod) = x + y
-(+)(x::CompoundPeriod,y::CompoundPeriod) = CompoundPeriod(vcat(x.periods,y.periods))
+(+)(x::CompoundPeriod,y::CompoundPeriod) = CompoundPeriod(cat(x.periods,y.periods))
 # E.g. Year(1) - Month(1)
 (-)(x::Period,y::Period) = CompoundPeriod(Period[x,-y])
-(-)(x::CompoundPeriod,y::Period) = CompoundPeriod(vcat(x.periods,-y))
+(-)(x::CompoundPeriod,y::Period) = CompoundPeriod(cat(x.periods,-y))
 (-)(x::CompoundPeriod) = CompoundPeriod(-x.periods)
 (-)(y::Union{Period,CompoundPeriod},x::CompoundPeriod) = (-x) + y
 

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -388,7 +388,7 @@ end
 `catdoc(xs...)`: Combine the documentation metadata `xs` into a single meta object.
 """
 catdoc() = nothing
-catdoc(xs...) = vcat(xs...)
+catdoc(xs...) = cat(xs...)
 
 const keywords = Dict{Symbol, DocStr}()
 

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1030,7 +1030,7 @@ function abstract_apply(af::ANY, fargs, aargtypes::Vector{Any}, vtypes::VarTable
         n = length(at)
         if n-1 > sv.params.MAX_TUPLETYPE_LEN
             tail = foldl((a,b)->tmerge(a,unwrapva(b)), Bottom, at[sv.params.MAX_TUPLETYPE_LEN+1:n])
-            at = vcat(at[1:sv.params.MAX_TUPLETYPE_LEN], Any[Vararg{widenconst(tail)}])
+            at = cat(at[1:sv.params.MAX_TUPLETYPE_LEN], Any[Vararg{widenconst(tail)}])
         end
         return abstract_call(af, (), at, vtypes, sv)
     end

--- a/base/markdown/Common/block.jl
+++ b/base/markdown/Common/block.jl
@@ -256,7 +256,7 @@ type List
     List(b::Integer) = new(Any[], b)
 end
 
-List(xs...) = List(vcat(xs...))
+List(xs...) = List(cat(xs...))
 
 isordered(list::List) = list.ordered >= 0
 

--- a/base/markdown/parse/parse.jl
+++ b/base/markdown/parse/parse.jl
@@ -8,7 +8,7 @@ type MD
         new(content, meta)
 end
 
-MD(xs...) = MD(vcat(xs...))
+MD(xs...) = MD(cat(xs...))
 
 function MD(cfg::Config, xs...)
     md = MD(xs...)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -523,7 +523,7 @@ function rmprocs(pids...; waitfor = 0.0)
     lock(worker_lock)
     try
         rmprocset = []
-        for i in vcat(pids...)
+        for i in cat(pids...)
             if i == 1
                 warn("rmprocs: process 1 not removed")
             else

--- a/base/range.jl
+++ b/base/range.jl
@@ -861,7 +861,7 @@ convert{T<:AbstractFloat}(::Type{LinSpace}, r::FloatRange{T}) =
 
 ## concatenation ##
 
-function vcat{T}(rs::Range{T}...)
+function cat{T}(rs::Range{T}...)
     n::Int = 0
     for ra in rs
         n += length(ra)
@@ -875,8 +875,8 @@ function vcat{T}(rs::Range{T}...)
     return a
 end
 
-convert{T}(::Type{Array{T,1}}, r::Range{T}) = vcat(r)
-collect(r::Range) = vcat(r)
+convert{T}(::Type{Array{T,1}}, r::Range{T}) = cat(r)
+collect(r::Range) = cat(r)
 
 reverse(r::OrdinalRange) = colon(last(r), -step(r), first(r))
 reverse(r::FloatRange)   = FloatRange(r.start + (r.len-1)*r.step, -r.step, r.len, r.divisor)

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -144,7 +144,7 @@ doesn't return C functions, but this can be enabled.) When called without specif
 trace, `stacktrace` first calls `backtrace`.
 """
 function stacktrace(trace::Vector{Ptr{Void}}, c_funcs::Bool=false)
-    stack = vcat(map(lookup, trace)...)::StackTrace
+    stack = cat(map(lookup, trace)...)::StackTrace
 
     # Remove frames that come from C calls.
     if !c_funcs

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -150,7 +150,7 @@ A few special expressions correspond to calls to functions with non-obvious name
 | Expression        | Calls                  |
 |:----------------- |:---------------------- |
 | `[A B C ...]`     | [`hcat()`](@ref)       |
-| `[A, B, C, ...]`  | [`vcat()`](@ref)       |
+| `[A; B; C; ...]`  | [`vcat()`](@ref)       |
 | `[A B; C D; ...]` | [`hvcat()`](@ref)      |
 | `A'`              | [`ctranspose()`](@ref) |
 | `A.'`             | [`transpose()`](@ref)  |

--- a/examples/lru_test.jl
+++ b/examples/lru_test.jl
@@ -5,7 +5,7 @@ using .LRUExample
 TestLRU = LRUExample.UnboundedLRU{String, String}()
 TestBLRU = LRUExample.BoundedLRU{String, String}(1000)
 
-get_str(i) = String(vcat(map(x->[x>>4; x&0x0F], reinterpret(UInt8, [Int32(i)]))...))
+get_str(i) = String(cat(map(x->[x>>4; x&0x0F], reinterpret(UInt8, [Int32(i)]))...))
 
 isbounded{L<:LRUExample.LRU}(::Type{L}) = any(map(n->n==:maxsize, fieldnames(L)))
 isbounded{L<:LRUExample.LRU}(l::L) = isbounded(L)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -523,6 +523,7 @@ function test_cat(::Type{TestAbstractArray})
     D = [1:24...]
     i = rand(1:10)
 
+    @test cat() == Any[]
     @test cat(i) == Any[]
     @test vcat() == Any[]
     @test hcat() == Any[]
@@ -536,7 +537,7 @@ function test_cat(::Type{TestAbstractArray})
     @test Base.typed_hcat(Float64, B, B) == TSlow(b2hcat)
     @test Base.typed_hcat(Float64, B, B, B) == TSlow(b3hcat)
 
-    @test vcat(B1, B2) == TSlow(vcat([1:24...], [1:25...]))
+    @test cat(B1, B2) == TSlow(cat([1:24...], [1:25...]))
     @test hcat(C1, C2) == TSlow([1 2 1 2 3; 3 4 4 5 6])
     @test hcat(C1, C2, C1) == TSlow([1 2 1 2 3 1 2; 3 4 4 5 6 3 4])
 
@@ -566,7 +567,7 @@ function test_cat(::Type{TestAbstractArray})
 
     # 13665, 19038
     @test @inferred(hcat([1.0 2.0], 3))::Array{Float64,2} == [1.0 2.0 3.0]
-    @test @inferred(vcat([1.0, 2.0], 3))::Array{Float64,1} == [1.0, 2.0, 3.0]
+    @test @inferred(vcat([1.0, 2.0], 3))::Array{Float64,2} == [1.0; 2.0; 3.0]
 end
 
 function test_ind2sub(::Type{TestAbstractArray})
@@ -732,7 +733,7 @@ let
     M = rand(n, n)
     # vector of vectors
     v = [[M]; [M]] # using vcat
-    @test size(v) == (2,)
+    @test size(v) == (2,1)
     @test !issparse(v)
     # matrix of vectors
     m1 = [[M] [M]] # using hcat

--- a/test/core.jl
+++ b/test/core.jl
@@ -4664,10 +4664,10 @@ catch e
 end == "generated function body is not pure. this likely means it contains a closure or comprehension."
 
 # issue #10981, long argument lists
-let a = fill(["sdf"], 2*10^6), temp_vcat(x...) = vcat(x...)
-    # we introduce a new function `temp_vcat` to make sure there is no existing
+let a = fill(["sdf"], 2*10^6), temp_cat(x...) = cat(x...)
+    # we introduce a new function `temp_cat` to make sure there is no existing
     # method cache match, leading to a path that allocates a large tuple type.
-    b = temp_vcat(a...)
+    b = temp_cat(a...)
     @test isa(b, Vector{String})
     @test length(b) == 2*10^6
     @test b[1] == b[end] == "sdf"

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -6,7 +6,7 @@ types = Any[
     Rational{Int8}, Rational{UInt8}, Rational{Int16}, Rational{UInt16},
     Rational{Int32}, Rational{UInt32}, Rational{Int64}, Rational{UInt64}
 ]
-vals = vcat(
+vals = cat(
     typemin(Int64),
     -Int64(maxintfloat(Float64))+Int64[-4:1;],
     typemin(Int32),

--- a/test/perf/sort/perf.jl
+++ b/test/perf/sort/perf.jl
@@ -90,7 +90,7 @@ else
                 name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_qsortkiller"
                 data = data[1:size>>1]
                 data = sort!(data, alg=s)
-                data = vcat(reverse(data), data)
+                data = cat(reverse(data), data)
                 @timeit_init(sort!(qdata, alg=s), begin qdata=copy(data) end, name, "")
             end
         end

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -412,7 +412,7 @@ let m = 80, n = 100
     end
     @test Array(H) == Hr
 
-    V = vcat(A...)
+    V = cat(A...)
     @test isa(V, SparseVector{Float64,Int})
     @test length(V) == m * n
     Vr = vec(Hr)

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -25,7 +25,7 @@ function runtests(name, isolate=true)
                              res_and_time_data[4],
                              res_and_time_data[5])
     end
-    vcat(collect(res_and_time_data), rss)
+    cat(collect(res_and_time_data), rss)
 end
 
 # looking in . messes things up badly

--- a/test/unicode/utf8proc.jl
+++ b/test/unicode/utf8proc.jl
@@ -79,7 +79,7 @@ end
 let
     alower=['a', 'd', 'j', 'y', 'z']
     ulower=['α', 'β', 'γ', 'δ', 'ф', 'я']
-    for c in vcat(alower,ulower)
+    for c in cat(alower,ulower)
         @test islower(c) == true
         @test isupper(c) == false
         @test isdigit(c) == false
@@ -89,7 +89,7 @@ let
     aupper=['A', 'D', 'J', 'Y', 'Z']
     uupper= ['Δ', 'Γ', 'Π', 'Ψ', 'ǅ', 'Ж', 'Д']
 
-    for c in vcat(aupper,uupper)
+    for c in cat(aupper,uupper)
         @test islower(c) == false
         @test isupper(c) == true
         @test isdigit(c) == false
@@ -97,7 +97,7 @@ let
     end
 
     nocase=['א','ﺵ']
-    alphas=vcat(alower,ulower,aupper,uupper,nocase)
+    alphas=cat(alower,ulower,aupper,uupper,nocase)
 
     for c in alphas
          @test isalpha(c) == true
@@ -117,7 +117,7 @@ let
          @test isnumber(c) == true
     end
 
-    alnums=vcat(alphas,anumber,unumber)
+    alnums=cat(alphas,anumber,unumber)
     for c in alnums
          @test isalnum(c) == true
          @test ispunct(c) == false
@@ -129,12 +129,12 @@ let
     apunct =['.',',',';',':','&']
     upunct =['‡', '؟', '჻' ]
 
-    for c in vcat(apunct,upunct)
+    for c in cat(apunct,upunct)
          @test ispunct(c) == true
          @test isalnum(c) == false
     end
 
-    for c in vcat(alnums,asymbol,usymbol,apunct,upunct)
+    for c in cat(alnums,asymbol,usymbol,apunct,upunct)
         @test isprint(c) == true
         @test isgraph(c) == true
         @test isspace(c) == false
@@ -150,13 +150,13 @@ let
     uspace = [ENSPACE, EMSPACE, THINSPACE]
     aspace = [' ']
     acntrl_space = ['\t', '\n', '\v', '\f', '\r']
-    for c in vcat(aspace,uspace)
+    for c in cat(aspace,uspace)
         @test isspace(c) == true
         @test isprint(c) == true
         @test isgraph(c) == false
     end
 
-    for c in vcat(acntrl_space)
+    for c in cat(acntrl_space)
         @test isspace(c) == true
         @test isprint(c) == false
         @test isgraph(c) == false
@@ -168,7 +168,7 @@ let
     latincontrol = [ Char(0x0080), Char(0x0085) ]
     ucontrol = [ Char(0x200E), Char(0x202E) ]
 
-    for c in vcat(acontrol, acntrl_space, latincontrol)
+    for c in cat(acontrol, acntrl_space, latincontrol)
         @test iscntrl(c) == true
         @test isalnum(c) == false
         @test isprint(c) == false


### PR DESCRIPTION
[*this is a very unfinished pull request*. I considered making an issue based on [the discourse thread about semicolons](https://discourse.julialang.org/t/whats-the-meaning-of-the-array-syntax/938), wanted to contribute, started making changes, realised how many ramifications this change has, realised that I can't build julia on my machine, and almost scrapped it. It's now a PR 1) to raise the issue, 2) in case someone else wants to improve on this, 3) to sit here until I can finish it.]

Suggestion part-implemented but not tested here:
* add methods to `cat` to concatenate vectors
* change `vcat` to always return an array of dim at least 2 (in particular, `vcat` of vectors is a `1xn` matrix)

Implications:
* the semicolon operator `;` now always returns a matrix, for consistency
* it's easier to instantiate `1xn` matrices
* lots of instances of using `vcat` to concatenate vectors into another vector should be changed to `cat`

Motivation:
* [commas do vectors, semicolons and spaces concatenate and produce matrices](https://discourse.julialang.org/t/whats-the-meaning-of-the-array-syntax/938) or higher-dimensionals
* consistency in separating vectors and matrices

I would really welcome any comments, advice, or anyone taking this further. (One thing I would definitely change in future is try to modify several files in a single commit...) If someone has a beginner's guide to contributing to core, that would be great. Hope this PR is ok