### PR TITLE
Make sparse operations less dependent on inference

### DIFF
--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1828,3 +1828,8 @@ let
     @test_throws DimensionMismatch broadcast(+, A, B, speye(N))
     @test_throws DimensionMismatch broadcast!(+, X, A, B, speye(N))
 end
+
+let A = sparse(Real[1 1])
+    @test (A + A)::SparseMatrixCSC{Int,Int} == [2 2] #19595
+    @test_throws DimensionMismatch A + A'
+end


### PR DESCRIPTION
This should address #19595 and also fix the examples in #19561, although it might still be worth to have something like #19589.

This falls back, when the return type cannot be inferred, to treating the `SparseMatrixCSC`s as `Array`s and then calls `sparse` over the result. Granted, this is not the most efficient fallback, but since it applies to type-unstable functions, it shouldn't be much of a problem. We could eventually improve the performance if it seems necessary.