### PR TITLE
Document prod(f, itr) method

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -382,7 +382,11 @@ end
 
 
 ## prod
+"""
+    prod(f, itr)
 
+Returns the product of `f` applied to each element of `itr`.
+"""
 prod(f::Callable, a) = mapreduce(f, *, a)
 
 """

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -104,8 +104,7 @@ Base.findmax!
 Base.findmin!
 Base.sum(::Any)
 Base.sum!
-Base.prod(::Any)
-Base.prod(::Any, ::Any)
+Base.prod
 Base.prod!
 Base.any(::Any)
 Base.any(::AbstractArray, ::Any)

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -102,7 +102,7 @@ Base.findmin(::Any)
 Base.findmin(::AbstractArray, ::Any)
 Base.findmax!
 Base.findmin!
-Base.sum(::Any)
+Base.sum
 Base.sum!
 Base.prod
 Base.prod!


### PR DESCRIPTION
Fixes #19146

The methods for `sum` and `mean` with function arguments are documented but the corresponding method for `prod` is not. This PR simply adds the appropriate docs.