### PR TITLE
fix #19599, crash with vararg type containing closure in method def

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -156,15 +156,7 @@
 ;; GF method does not need to keep decl expressions on lambda args
 ;; except for rest arg
 (define (method-lambda-expr argl body rett)
-  (let ((argl (map (lambda (x)
-                     (if (vararg? x)
-                         (make-decl (arg-name x) (arg-type x))
-                         (if (varargexpr? x)
-                             (if (pair? (caddr x))
-                                 x
-                                 `(|::| ,(arg-name x) (curly Vararg Any)))
-                             (arg-name x))))
-                   argl))
+  (let ((argl (map arg-name argl))
         (body (if (and (pair? body) (eq? (car body) 'block))
                   (if (null? (cdr body))
                       `(block (null))

--- a/test/core.jl
+++ b/test/core.jl
@@ -4821,3 +4821,8 @@ end
 
 @test f14893() == 14893
 @test M14893.f14893() == 14893
+
+# issue #19599
+f19599{T}(x::((S)->Vector{S})(T)...) = 1
+@test f19599([1],[1]) == 1
+@test_throws MethodError f19599([1],[1.0])


### PR DESCRIPTION
This is kind of silly --- I believe @vtjnash already did most of the work to fix this a little while back, and this is just sweeping away the sawdust.