### PR TITLE
fix the deprecations for cummin and cummax

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1131,7 +1131,7 @@ eval(Base.Dates, quote
 end)
 
 # #18931
-@deprecate cummin(A, dim=1) accumulate(min, A, dim=1)
-@deprecate cummax(A, dim=1) accumulate(max, A, dim=1)
+@deprecate cummin(A, dim=1) accumulate(min, A, dim)
+@deprecate cummax(A, dim=1) accumulate(max, A, dim)
 
 # End deprecations scheduled for 0.6


### PR DESCRIPTION
was giving `function accumulate does not accept keyword arguments`

we should really come up with an automated way of testing deprecations...