### PR TITLE
Work around redirection issue on windows buildbots

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,14 +19,19 @@ help:
 	@echo "  check     to run linkcheck and doctests"
 
 clean:
-	-rm -rf _build/* deps/*
+	-rm -rf _build/* deps/* docbuild.log
 
 cleanall: clean
 
 html:
 	@echo "Building HTML documentation."
-# pipe to cat to work around issue #11727, redirection breaking on windows buildbot
-	$(JULIA_EXECUTABLE) make.jl -- deploy | cat 2>&1
+ifneq ($(OS),WINNT)
+	$(JULIA_EXECUTABLE) make.jl -- deploy
+else
+# work around issue #11727, windows output redirection breaking on buildbot
+	$(JULIA_EXECUTABLE) make.jl -- deploy > docbuild.log 2>&1
+	@cat docbuild.log
+endif
 	@echo "Build finished. The HTML pages are in _build/html."
 
 pdf:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,19 +19,14 @@ help:
 	@echo "  check     to run linkcheck and doctests"
 
 clean:
-	-rm -rf _build/* deps/* docbuild.log
+	-rm -rf _build/* deps/*
 
 cleanall: clean
 
 html:
 	@echo "Building HTML documentation."
-ifneq ($(OS),WINNT)
-	$(JULIA_EXECUTABLE) make.jl -- deploy
-else
-# work around issue #11727, windows output redirection breaking on buildbot
-	$(JULIA_EXECUTABLE) make.jl -- deploy > docbuild.log 2>&1
-	@cat docbuild.log
-endif
+# pipe to cat to work around issue #11727, redirection breaking on windows buildbot
+	$(JULIA_EXECUTABLE) make.jl -- deploy | cat 2>&1
 	@echo "Build finished. The HTML pages are in _build/html."
 
 pdf:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,13 +19,19 @@ help:
 	@echo "  check     to run linkcheck and doctests"
 
 clean:
-	-rm -rf _build/* deps/*
+	-rm -rf _build/* deps/* docbuild.log
 
 cleanall: clean
 
 html:
 	@echo "Building HTML documentation."
+ifneq ($(OS),WINNT)
 	$(JULIA_EXECUTABLE) make.jl -- deploy
+else
+# work around issue #11727, windows output redirection breaking on buildbot
+	$(JULIA_EXECUTABLE) make.jl -- deploy > docbuild.log 2>&1
+	@cat docbuild.log
+endif
 	@echo "Build finished. The HTML pages are in _build/html."
 
 pdf:


### PR DESCRIPTION
with documentation build, ref https://github.com/JuliaLang/julia/pull/18588#issuecomment-265779669
redirecting to a file should work, but redirecting to a cygwin pipe
or driving application like perl or python (in the buildbot case) doesn't

test builds from this branch:
https://build.julialang.org/builders/package_win6.2-x64/builds/1049
https://build.julialang.org/builders/package_win6.2-x86/builds/984

vs master:
https://build.julialang.org/builders/package_win6.2-x64/builds/1045
https://build.julialang.org/builders/package_win6.2-x86/builds/980
