### PR TITLE
Make spawn test depend on current ulimit value instead of changing it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,6 @@ script:
         /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
     - /tmp/julia/bin/julia -e 'versioninfo()'
     - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 &&
-        ulimit -n 128 &&
         cd /tmp/julia/share/julia/test &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,16 +8,8 @@ TESTS = all linalg sparse unicode strings dates $(filter-out TestHelpers runtest
 
 default: all
 
-# set hard and soft limits for spawn fd-exhaustion test
-ifeq ($(OS),WINNT)
-ULIMIT_TEST=
-else
-ULIMIT_TEST=ulimit -n 128 &&
-endif
-
 $(TESTS):
 	@cd $(SRCDIR) && \
-	$(ULIMIT_TEST) \
 	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no ./runtests.jl $@)
 
 perf:

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -430,7 +430,7 @@ end
 if is_unix()
     let ps = Pipe[]
         try
-            for i = 1:100_000
+            for i = 1 : 100 * parse(Int, readchomp(`sh -c 'ulimit -n'`))
                 p = Pipe()
                 Base.link_pipe(p)
                 push!(ps, p)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -429,8 +429,9 @@ end
 # test for proper handling of FD exhaustion
 if is_unix()
     let ps = Pipe[]
+        ulimit_n = tryparse(Int, readchomp(`sh -c 'ulimit -n'`))
         try
-            for i = 1 : 100 * parse(Int, readchomp(`sh -c 'ulimit -n'`))
+            for i = 1 : 100 * get(ulimit_n, 1000)
                 p = Pipe()
                 Base.link_pipe(p)
                 push!(ps, p)
@@ -440,7 +441,12 @@ if is_unix()
             for p in ps
                 close(p)
             end
-            @test (ex::Base.UVError).code == Base.UV_EMFILE
+            if isnull(ulimit_n)
+                warn("`ulimit -n` is set to unlimited, fd exhaustion cannot be tested")
+                @test_broken (ex::Base.UVError).code == Base.UV_EMFILE
+            else
+                @test (ex::Base.UVError).code == Base.UV_EMFILE
+            end
         end
     end
 end


### PR DESCRIPTION
this should allow `Base.runtests("spawn")` to pass on travis

ref https://github.com/JuliaLang/julia/pull/19307#issuecomment-260755789