### PR TITLE
Remove explicit dependence of sparse broadcast on type inference

### DIFF
--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1828,3 +1828,16 @@ let
     @test_throws DimensionMismatch broadcast(+, A, B, speye(N))
     @test_throws DimensionMismatch broadcast!(+, X, A, B, speye(N))
 end
+
+# Issue #19595 - broadcasting over sparse matrices with abstract eltype
+let x = sparse(eye(Real,3,3))
+    @test eltype(x) === Real
+    @test eltype(x + x) <: Real
+    @test eltype(x .+ x) <: Real
+    @test eltype(map(+, x, x)) <: Real
+    @test eltype(broadcast(+, x, x)) <: Real
+    @test eltype(x + x + x) <: Real
+    @test eltype(x .+ x .+ x) <: Real
+    @test eltype(map(+, map(+, x, x), x)) <: Real
+    @test eltype(broadcast(+, broadcast(+, x, x), x)) <: Real
+end


### PR DESCRIPTION
For the type-stable case (i.e. the function `f` being `broadcast`/`map`ped can be inferred to give a leaf type), the compiler should be able to elide any overhead introduced by this, so I expect performance not to suffer.

For the type-unstable case, improvements are certainly possible performance-wise, but this should at least get things in a working state again.

Replaces #19611, closes #19595.
Note that #19589 is still needed in principle, although  this PR also makes it less likely to hit #19561. I.e. the examples therein work with this PR, but the underlying problem is only solved in #19589.