### PR TITLE
Fixes broken LibGit2.rebase!

### DIFF
--- a/base/libgit2/error.jl
+++ b/base/libgit2/error.jl
@@ -2,7 +2,7 @@
 
 module Error
 
-export GitError
+export GitError, @check
 
 @enum(Code, GIT_OK          = Cint(0),   # no error
             ERROR           = Cint(-01), # generic error
@@ -60,7 +60,7 @@ export GitError
 
 immutable ErrorStruct
     message::Ptr{UInt8}
-    class::Cint
+    class::Class
 end
 
 immutable GitError <: Exception
@@ -74,30 +74,30 @@ function last_error()
     err = ccall((:giterr_last, :libgit2), Ptr{ErrorStruct}, ())
     if err != C_NULL
         err_obj   = unsafe_load(err)
-        err_class = Class[err_obj.class][]
+        err_class = err_obj.class
         err_msg   = unsafe_string(err_obj.message)
     else
-        err_class = Class[0][]
+        err_class = Class(0)
         err_msg = "No errors"
     end
     return (err_class, err_msg)
 end
 
-function GitError(code::Integer)
-    err_code = Code[code][]
+GitError(err::Integer) = GitError(Code(err))
+function GitError(err_code::Code)
     err_class, err_msg = last_error()
     return GitError(err_class, err_code, err_msg)
 end
 
-end # Error module
-
 macro check(git_func)
     quote
-        local err::Cint
+        local err::Code
         err = $(esc(git_func::Expr))
-        if err < 0
-            throw(Error.GitError(err))
+        if err != GIT_OK
+            throw(GitError(err))
         end
         err
     end
 end
+
+end # Error module

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -13,8 +13,6 @@ include("utils.jl")
 include("consts.jl")
 include("types.jl")
 include("error.jl")
-using .Error
-
 include("signature.jl")
 include("oid.jl")
 include("reference.jl")
@@ -34,6 +32,7 @@ include("status.jl")
 include("tree.jl")
 include("callbacks.jl")
 
+using .Error
 
 immutable State
     head::Oid

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -13,6 +13,8 @@ include("utils.jl")
 include("consts.jl")
 include("types.jl")
 include("error.jl")
+using .Error
+
 include("signature.jl")
 include("oid.jl")
 include("reference.jl")
@@ -32,7 +34,6 @@ include("status.jl")
 include("tree.jl")
 include("callbacks.jl")
 
-using .Error
 
 immutable State
     head::Oid
@@ -434,7 +435,7 @@ function rebase!(repo::GitRepo, upstream::AbstractString="", newbase::AbstractSt
     with(head(repo)) do head_ref
         head_ann = GitAnnotated(repo, head_ref)
         upst_ann  = if isempty(upstream)
-            with(upstream(head_ref)) do brn_ref
+            with(LibGit2.upstream(head_ref)) do brn_ref
                 if brn_ref === nothing
                     throw(GitError(Error.Rebase, Error.ERROR,
                                    "There is no tracking information for the current branch."))
@@ -467,6 +468,7 @@ function rebase!(repo::GitRepo, upstream::AbstractString="", newbase::AbstractSt
             finalize(head_ann)
         end
     end
+    return nothing
 end
 
 

--- a/base/libgit2/rebase.jl
+++ b/base/libgit2/rebase.jl
@@ -41,6 +41,13 @@ function Base.next(rb::GitRebase)
     return unsafe_load(convert(Ptr{RebaseOperation}, rb_op_ptr_ptr[]), 1)
 end
 
+
+"""
+    LibGit2.commit(rb::GitRebase, sig::GitSignature)
+
+Commits the current patch to the rebase `rb`, using `sig` as the committer. Is silent if
+the commit has already been applied.
+"""
 function commit(rb::GitRebase, sig::GitSignature)
     oid_ptr = Ref(Oid())
     try

--- a/base/libgit2/rebase.jl
+++ b/base/libgit2/rebase.jl
@@ -43,9 +43,12 @@ end
 
 function commit(rb::GitRebase, sig::GitSignature)
     oid_ptr = Ref(Oid())
-    @check ccall((:git_rebase_commit, :libgit2), Cint,
+    err = ccall((:git_rebase_commit, :libgit2), Error.Code,
                   (Ptr{Oid}, Ptr{Void}, Ptr{SignatureStruct}, Ptr{SignatureStruct}, Ptr{UInt8}, Ptr{UInt8}),
-                   oid_ptr, rb.ptr, C_NULL, sig.ptr, C_NULL, C_NULL)
+                oid_ptr, rb.ptr, C_NULL, sig.ptr, C_NULL, C_NULL)
+    if err != Error.GIT_OK && err != Error.EAPPLIED
+        throw(Error.GitError(err))
+    end
     return oid_ptr[]
 end
 

--- a/base/libgit2/rebase.jl
+++ b/base/libgit2/rebase.jl
@@ -55,6 +55,7 @@ function commit(rb::GitRebase, sig::GitSignature)
                      (Ptr{Oid}, Ptr{Void}, Ptr{SignatureStruct}, Ptr{SignatureStruct}, Ptr{UInt8}, Ptr{UInt8}),
                       oid_ptr, rb.ptr, C_NULL, sig.ptr, C_NULL, C_NULL)
     catch err
+        # TODO: return current HEAD instead
         err.code == Error.EAPPLIED && return nothing
         rethrow(err)
     end

--- a/base/libgit2/rebase.jl
+++ b/base/libgit2/rebase.jl
@@ -45,7 +45,7 @@ function commit(rb::GitRebase, sig::GitSignature)
     oid_ptr = Ref(Oid())
     err = ccall((:git_rebase_commit, :libgit2), Error.Code,
                   (Ptr{Oid}, Ptr{Void}, Ptr{SignatureStruct}, Ptr{SignatureStruct}, Ptr{UInt8}, Ptr{UInt8}),
-                oid_ptr, rb.ptr, C_NULL, sig.ptr, C_NULL, C_NULL)
+                   oid_ptr, rb.ptr, C_NULL, sig.ptr, C_NULL, C_NULL)
     if err != Error.GIT_OK && err != Error.EAPPLIED
         throw(Error.GitError(err))
     end


### PR DESCRIPTION
`LibGit2.rebase!` is broken, causing problems with `Pkg.update()`
after `PkgDev.tag()`, see
https://discourse.julialang.org/t/how-to-properly-add-releases-with-pkgdev/961/15?u=simonbyrne

There were two problems:
- `upstream` was used as a variable name and a function call
- if the patch was redundant (`EAPPLIED` return code), `rebase!` would
throw an error.