### PR TITLE
Inferable broadcast and promote_op of closures

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -223,21 +223,23 @@ minmax(x::Real, y::Real) = minmax(promote(x, y)...)
 _default_type(T::Type) = (@_pure_meta; T)
 
 if isdefined(Core, :Inference)
-    _promote_op(f::ANY, t::ANY) = Core.Inference.return_type(f, t)
+    _return_type(f::ANY, t::ANY) = Core.Inference.return_type(f, t)
 else
-    _promote_op(f::ANY, t::ANY) = Any
+    _return_type(f::ANY, t::ANY) = Any
 end
 
 promote_op(::Any...) = (@_pure_meta; Any)
 function promote_op{S}(f, ::Type{S})
     @_inline_meta
-    T = _promote_op(f, Tuple{_default_type(S)})
+    Z = Tuple{_default_type(S)}
+    T = _default_eltype(Generator{Z, typeof(f)})
     isleaftype(S) && return isleaftype(T) ? T : Any
     return typejoin(S, T)
 end
 function promote_op{R,S}(f, ::Type{R}, ::Type{S})
     @_inline_meta
-    T = _promote_op(f, Tuple{_default_type(R), _default_type(S)})
+    Z = Iterators.Zip2{Tuple{_default_type(R)}, Tuple{_default_type(S)}}
+    T = _default_eltype(Generator{Z, typeof(a -> f(a...))})
     isleaftype(R) && isleaftype(S) && return isleaftype(T) ? T : Any
     return typejoin(R, S, T)
 end

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -26,7 +26,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     rotl90, rotr90, round, scale!, setindex!, similar, size, transpose, tril,
     triu, vec, permute!, map, map!
 
-import Base.Broadcast: broadcast_indices
+import Base.Broadcast: _broadcast_type, broadcast_indices
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, dropzeros,

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1464,7 +1464,6 @@ _maxnnzfrom(Cm, Cn, A) = nnz(A) * div(Cm, A.m) * div(Cn, A.n)
 @inline _maxnnzfrom_each(Cm, Cn, As) = (_maxnnzfrom(Cm, Cn, first(As)), _maxnnzfrom_each(Cm, Cn, tail(As))...)
 @inline _unchecked_maxnnzbcres(Cm, Cn, As) = min(Cm * Cn, sum(_maxnnzfrom_each(Cm, Cn, As)))
 @inline _checked_maxnnzbcres(Cm, Cn, As...) = Cm != 0 && Cn != 0 ? _unchecked_maxnnzbcres(Cm, Cn, As) : 0
-_broadcast_type(f, As...) = Base._promote_op(f, Base.Broadcast.typestuple(As...))
 
 # _map_zeropres!/_map_notzeropres! specialized for a single sparse matrix
 "Stores only the nonzero entries of `map(f, Matrix(A))` in `C`."

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -355,3 +355,11 @@ StrangeType18623(x,y) = (x,y)
 
 # 19419
 @test @inferred(broadcast(round, Int, [1])) == [1]
+
+# https://discourse.julialang.org/t/towards-broadcast-over-combinations-of-sparse-matrices-and-scalars/910
+let
+    f(A, n) = broadcast(x -> +(x, n), A)
+    @test @inferred(f([1.0], 1)) == [2.0]
+    g() = (a = 1; Base.Broadcast._broadcast_type(x -> x + a, 1.0))
+    @test @inferred(g()) === Float64
+end


### PR DESCRIPTION
Restoring some of the behavior before #19421 as it seems to be needed by some packages, e.g. https://github.com/JuliaArrays/StaticArrays.jl/issues/88

Also, should help with the problem in [this discourse thread](https://discourse.julialang.org/t/towards-broadcast-over-combinations-of-sparse-matrices-and-scalars/910)