### PR TITLE
Reduce allocations in broadcast

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -129,7 +129,7 @@ Base.@propagate_inbounds _broadcast_getindex(::Any, A, I) = A[I]
 # of keeps). The first two type parameters are to ensure specialization.
 @generated function _broadcast!{K,ID,AT,nargs}(f, B::AbstractArray, keeps::K, Idefaults::ID, As::AT, ::Type{Val{nargs}}, iter)
     quote
-        $(Expr(:meta, :noinline))
+        $(Expr(:meta, :inline))
         # destructure the keeps and As tuples
         @nexprs $nargs i->(A_i = As[i])
         @nexprs $nargs i->(keep_i = keeps[i])
@@ -150,7 +150,7 @@ end
 # and then copy in chunks into the output
 @generated function _broadcast!{K,ID,AT,nargs}(f, B::BitArray, keeps::K, Idefaults::ID, As::AT, ::Type{Val{nargs}}, iter)
     quote
-        $(Expr(:meta, :noinline))
+        $(Expr(:meta, :inline))
         # destructure the keeps and As tuples
         @nexprs $nargs i->(A_i = As[i])
         @nexprs $nargs i->(keep_i = keeps[i])
@@ -244,9 +244,8 @@ function broadcast_t(f, ::Type{Any}, shape, iter, As...)
     B[I] = val
     return _broadcast!(f, B, keeps, Idefaults, As, Val{nargs}, iter, st, 1)
 end
-@inline function broadcast_t(f, T, shape, iter, As...)
+@inline function broadcast_t{nargs}(f, T, shape, iter, As::Vararg{Any,nargs})
     B = similar(Array{T}, shape)
-    nargs = length(As)
     keeps, Idefaults = map_newindexer(shape, As)
     _broadcast!(f, B, keeps, Idefaults, As, Val{nargs}, iter)
     return B

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -559,23 +559,30 @@ function eigvecs{T}(M::Bidiagonal{T})
     n = length(M.dv)
     Q = Array{T}(n, n)
     blks = [0; find(x -> x == 0, M.ev); n]
+    v = zeros(T, n)
     if M.isupper
         for idx_block = 1:length(blks) - 1, i = blks[idx_block] + 1:blks[idx_block + 1] #index of eigenvector
-            v=zeros(T, n)
+            fill!(v, zero(T))
             v[blks[idx_block] + 1] = one(T)
             for j = blks[idx_block] + 1:i - 1 #Starting from j=i, eigenvector elements will be 0
                 v[j+1] = (M.dv[i] - M.dv[j])/M.ev[j] * v[j]
             end
-            Q[:, i] = v/norm(v)
+            c = norm(v)
+            for j = 1:n
+                Q[j, i] = v[j] / c
+            end
         end
     else
         for idx_block = 1:length(blks) - 1, i = blks[idx_block + 1]:-1:blks[idx_block] + 1 #index of eigenvector
-            v = zeros(T, n)
+            fill!(v, zero(T))
             v[blks[idx_block+1]] = one(T)
             for j = (blks[idx_block+1] - 1):-1:max(1, (i - 1)) #Starting from j=i, eigenvector elements will be 0
                 v[j] = (M.dv[i] - M.dv[j+1])/M.ev[j] * v[j+1]
             end
-            Q[:,i] = v/norm(v)
+            c = norm(v)
+            for j = 1:n
+                Q[j, i] = v[j] / c
+            end
         end
     end
     Q #Actually Triangular

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -338,9 +338,9 @@ svdvals(D::Diagonal) = [svdvals(v) for v in D.diag]
 function svd{T<:Number}(D::Diagonal{T})
     S   = abs.(D.diag)
     piv = sortperm(S, rev = true)
-    U   = Array(Diagonal(D.diag ./ S))
+    U   = Diagonal(D.diag ./ S)
     Up  = hcat([U[:,i] for i = 1:length(D.diag)][piv]...)
-    V   = eye(D)
+    V   = Diagonal(ones(D.diag))
     Vp  = hcat([V[:,i] for i = 1:length(D.diag)][piv]...)
     return (Up, S[piv], Vp)
 end


### PR DESCRIPTION
With this PR
```julia
julia> function foo(x, n)
           for i = 1:n
               broadcast!(x -> 2x+1, x, x)
           end
           return x
       end
foo (generic function with 1 method)

julia> @time foo([0,0,0], 10^4);
  0.027883 seconds (25.78 k allocations: 1.108 MB)

julia> @time foo([0,0,0], 10^4);
  0.000121 seconds (6 allocations: 288 bytes)

julia> using BenchmarkTools

julia> @benchmark [1,2,3] .+ 1
BenchmarkTools.Trial: 
  memory estimate:  224.00 bytes
  allocs estimate:  2
  --------------
  minimum time:     63.186 ns (0.00% GC)
  median time:      67.704 ns (0.00% GC)
  mean time:        74.881 ns (7.55% GC)
  maximum time:     841.374 ns (89.36% GC)
  --------------
  samples:          10000
  evals/sample:     982
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark broadcast(+, [1,2,3], 1)
BenchmarkTools.Trial: 
  memory estimate:  224.00 bytes
  allocs estimate:  2
  --------------
  minimum time:     65.979 ns (0.00% GC)
  median time:      71.068 ns (0.00% GC)
  mean time:        78.431 ns (7.44% GC)
  maximum time:     1.139 μs (92.01% GC)
  --------------
  samples:          10000
  evals/sample:     982
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

Compare this with https://github.com/JuliaLang/julia/issues/19608#issue-195814777 and https://github.com/JuliaLang/julia/issues/16285#issuecomment-267522849