### PR TITLE
RFC: Revise the issue template to be more concise

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,10 @@
-Welcome to the Julia project!
-
-We use the GitHub issue tracker for bug reports and feature requests.
 If you have a question or are unsure if the behavior you're experiencing is a bug,
-please search or post to [our Discourse site](https://discourse.julialang.org).
+please search or post to our Discourse site: https://discourse.julialang.org. We use
+the GitHub issue tracker for bug reports and feature requests only.
 
 If you're submitting a bug report, be sure to include as much relevant information as
 possible, including a minimal reproducible example and the output of `versioninfo()`.
-Consider using a [GitHub Gist](https://gist.github.com) if you have a lot of code or output
-to include in the report.
 If you're experiencing a problem with a particular package, open an issue on that
 package's repository instead.
 
-Please delete this message before posting, and thanks for your contribution to Julia!
+Thanks for contributing to the Julia project!


### PR DESCRIPTION
It's been pointed out that the current issue template, introduced in #19478, is a bit verbose and contains Markdown-specific formatting that doesn't show up in the default new issue view. This PR simplifies the template a bit to be more readable and concise, while (hopefully!) maintaining an overall welcoming attitude.

cc @Sacha0 and @vtjnash 