### PR TITLE
RFC: Document the rationale behind * for strings

### DIFF
--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -318,7 +318,7 @@ further discussion of UTF-8 encoding issues, see the section below on [byte arra
 The [`transcode()`](@ref) function is provided to convert data between the various UTF-xx encodings,
 primarily for working with external data and libraries.
 
-## [Interpolation](@id string-interpolation)
+## Concatenation
 
 One of the most common and useful string operations is concatenation:
 
@@ -333,9 +333,35 @@ julia> string(greet, ", ", whom, ".\n")
 "Hello, world.\n"
 ```
 
-Constructing strings like this can become a bit cumbersome, however. To reduce the need for these
-verbose calls to [`string()`](@ref), Julia allows interpolation into string literals using `$`,
-as in Perl:
+Julia also provides `*` for string concatenation:
+
+```julia
+julia> greet * ", " * whom * ".\n"
+"Hello, world.\n"
+```
+
+While `*` may seem like a surprising choice to users of languages that provide `+` for string
+concatenation, this use of `*` has precedent in mathematics, particularly in abstract algebra.
+
+In mathematics, `+` usually denotes a *commutative* operation, where the order of the operands does
+not matter. An example of this is matrix addition, where `A + B == B + A` for any matrices `A` and `B`
+that have the same shape. In contrast, `*` typically denotes a *noncommutative* operation, where the
+order of the operands *does* matter. An example of this is matrix multiplication, where in general
+`A * B != B * A`. As with matrix multiplication, string concatenation is noncommutative:
+`greet * whom != whom * greet`. As such, `*` is a more natural choice for an infix string concatenation
+operator, consistent with common mathematical use.
+
+More precisely, the set of all finite-length strings *S* together with the string concatenation operator
+`*` forms a [free monoid](https://en.wikipedia.org/wiki/Free_monoid) (*S*, `*`). The identity element
+of this set is the empty string, `""`. Whenever a free monoid is not commutative, the operation is
+typically represented as `\cdot`, `*`, or a similar symbol, rather than `+`, which as stated usually
+implies commutativity.
+
+## [Interpolation](@id string-interpolation)
+
+Constructing strings using concatenation can become a bit cumbersome, however. To reduce the need for these
+verbose calls to [`string()`](@ref) or repeated multiplications, Julia allows interpolation into string literals
+using `$`, as in Perl:
 
 ```julia
 julia> "$greet, $whom.\n"

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -322,7 +322,7 @@ primarily for working with external data and libraries.
 
 One of the most common and useful string operations is concatenation:
 
-```julia
+```jldoctest stringconcat
 julia> greet = "Hello"
 "Hello"
 
@@ -335,7 +335,7 @@ julia> string(greet, ", ", whom, ".\n")
 
 Julia also provides `*` for string concatenation:
 
-```julia
+```jldoctest stringconcat
 julia> greet * ", " * whom * ".\n"
 "Hello, world.\n"
 ```
@@ -363,7 +363,7 @@ Constructing strings using concatenation can become a bit cumbersome, however. T
 verbose calls to [`string()`](@ref) or repeated multiplications, Julia allows interpolation into string literals
 using `$`, as in Perl:
 
-```julia
+```jldoctest stringconcat
 julia> "$greet, $whom.\n"
 "Hello, world.\n"
 ```


### PR DESCRIPTION
I figured as long as `*` is used for string concatenation, we should be transparent about _why_ it's used for string concatenation. Currently it's not even mentioned in the manual, only in the standard library documentation. This PR adds a subsection on concatenation to the Strings section of the manual. In it I've tried to express why `*` isn't just some arbitrary choice. In its current form, the text here was built collaboratively by @Sacha0 and me. Any comments are quite welcome.

As an aside, since this only touches a Markdown file in the manual source, I've skipped CI. If CI should not have been skipped then let me know and I can undo that.

cc @stevengj and @StefanKarpinski 