### PR TITLE
Disable szclass 12 for i686 systems.

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -61,9 +61,12 @@ void *jl_gc_perm_alloc(size_t sz);
 static const int jl_gc_sizeclasses[JL_GC_N_POOLS] = {
 #ifdef _P64
     8,
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
     // ARM and PowerPC have max alignment of 8,
     // make sure allocation of size 8 has that alignment.
+    // for x86 alignment is important for atomic ops and
+    // the corresponding platform ABI. Once we can use
+    // libatomic on Windows this is no longer necessary.
     4, 8,
 #else
     4, 8, 12,
@@ -99,7 +102,7 @@ STATIC_INLINE int jl_gc_alignment(size_t sz)
 #ifdef _P64
     (void)sz;
     return 16;
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
     return sz <= 4 ? 8 : 16;
 #else
     // szclass 8
@@ -120,7 +123,7 @@ STATIC_INLINE int JL_CONST_FUNC jl_gc_szclass(size_t sz)
     if (sz <=    8)
         return 0;
     const int N = 0;
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
     if (sz <=    8)
         return (sz + 3) / 4 - 1;
     const int N = 1;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -56,7 +56,7 @@ typedef struct {
     // variables for allocating objects from pools
 #ifdef _P64
 #  define JL_GC_N_POOLS 41
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
 #  define JL_GC_N_POOLS 42
 #else
 #  define JL_GC_N_POOLS 43


### PR DESCRIPTION
The interplay between platform ABI and alignment for atomic ops is
tricky. This disables szclass 12 on i686 until we can use libatomic on all 32bit platforms (Windows support is currently missing).