### PR TITLE
Throw error on aborted rebase

### DIFF
--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -424,9 +424,11 @@ function merge!(repo::GitRepo;
                 remotename = with(GitConfig, repo) do cfg
                     LibGit2.get(String, cfg, "branch.$branchname.remote")
                 end
-                with(GitReference(repo, "refs/remotes/$remotename/$branchname")) do ref
-                    obj = LibGit2.Oid(ref)
-                    LibGit2.create_branch(repo, branchname, get(GitCommit, repo, obj))
+                obj = with(GitReference(repo, "refs/remotes/$remotename/$branchname")) do ref
+                    LibGit2.Oid(ref)
+                end
+                with(get(GitCommit, repo, obj)) do cmt
+                    LibGit2.create_branch(repo, branchname, cmt)
                 end
                 return true
             else

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -416,7 +416,7 @@ function merge!(repo::GitRepo;
                 m = with(GitReference(repo, Consts.HEAD_FILE)) do head_sym_ref
                     match(r"refs/heads/(.*)", fullname(head_sym_ref))
                 end
-                if m == nothing
+                if m === nothing
                     throw(GitError(Error.Merge, Error.ERROR,
                                    "Unable to determine name of unborn branch."))
                 end

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -455,6 +455,7 @@ function rebase!(repo::GitRepo, upstream::AbstractString="", newbase::AbstractSt
                     finish(rbs, sig)
                 catch err
                     abort(rbs)
+                    rethrow(err)
                 finally
                     finalize(rbs)
                 end

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -424,9 +424,10 @@ function merge!(repo::GitRepo;
                 remotename = with(GitConfig, repo) do cfg
                     LibGit2.get(String, cfg, "branch.$branchname.remote")
                 end
-                ref = GitReference(repo, "refs/remotes/$remotename/$branchname")
-                obj = LibGit2.Oid(ref)
-                LibGit2.create_branch(repo, "master", get(GitCommit, repo, obj))
+                with(GitReference(repo, "refs/remotes/$remotename/$branchname")) do ref
+                    obj = LibGit2.Oid(ref)
+                    LibGit2.create_branch(repo, branchname, get(GitCommit, repo, obj))
+                end
                 return true
             else
                 with(head(repo)) do head_ref

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -386,46 +386,68 @@ function merge!(repo::GitRepo;
                 merge_opts::MergeOptions = MergeOptions(),
                 checkout_opts::CheckoutOptions = CheckoutOptions())
     # merge into head branch
-    with(head(repo)) do head_ref
-        upst_anns = if !isempty(committish) # merge committish into HEAD
-            if committish == Consts.FETCH_HEAD # merge FETCH_HEAD
-                fheads = fetchheads(repo)
-                filter!(fh->fh.ismerge, fheads)
-                if isempty(fheads)
-                    throw(GitError(Error.Merge, Error.ERROR,
-                                   "There is no fetch reference for this branch."))
-                end
-                map(fh->GitAnnotated(repo,fh), fheads)
-            else # merge commitish
-                [GitAnnotated(repo, committish)]
+    upst_anns = if !isempty(committish) # merge committish into HEAD
+        if committish == Consts.FETCH_HEAD # merge FETCH_HEAD
+            fheads = fetchheads(repo)
+            filter!(fh->fh.ismerge, fheads)
+            if isempty(fheads)
+                throw(GitError(Error.Merge, Error.ERROR,
+                               "There is no fetch reference for this branch."))
             end
-        else
-            if !isempty(branch) # merge provided branch into HEAD
-                with(GitReference(repo, branch)) do brn_ref
-                    [GitAnnotated(repo, brn_ref)]
-                end
-            else # try to get tracking remote branch for the head
-                if !isattached(repo)
-                    throw(GitError(Error.Merge, Error.ERROR,
-                                   "Repository HEAD is detached. Remote tracking branch cannot be used."))
-                end
-                with(upstream(head_ref)) do tr_brn_ref
-                    if tr_brn_ref === nothing
-                        throw(GitError(Error.Merge, Error.ERROR,
-                                       "There is no tracking information for the current branch."))
-                    end
-                    [GitAnnotated(repo, tr_brn_ref)]
-                end
-            end
+            map(fh->GitAnnotated(repo,fh), fheads)
+        else # merge commitish
+            [GitAnnotated(repo, committish)]
         end
+    else
+        if !isempty(branch) # merge provided branch into HEAD
+            with(GitReference(repo, branch)) do brn_ref
+                [GitAnnotated(repo, brn_ref)]
+            end
+        else # try to get tracking remote branch for the head
+            if !isattached(repo)
+                throw(GitError(Error.Merge, Error.ERROR,
+                               "Repository HEAD is detached. Remote tracking branch cannot be used."))
+            end
+            if isunborn(repo)
+                # this isn't really a merge, but really moving HEAD
+                # https://github.com/libgit2/libgit2/issues/2135#issuecomment-35997764
+                # try to figure out remote tracking of unborn head
 
-        try
-            merge!(repo, upst_anns, fastforward,
-                   merge_opts=merge_opts,
-                   checkout_opts=checkout_opts)
-        finally
-            map(finalize, upst_anns)
+                m = with(GitReference(repo, Consts.HEAD_FILE)) do head_sym_ref
+                    match(r"refs/heads/(.*)", fullname(head_sym_ref))
+                end
+                if m == nothing
+                    throw(GitError(Error.Merge, Error.ERROR,
+                                   "Unable to determine name of unborn branch."))
+                end
+                branchname = m.captures[1]
+                remotename = with(GitConfig, repo) do cfg
+                    LibGit2.get(String, cfg, "branch.$branchname.remote")
+                end
+                ref = GitReference(repo, "refs/remotes/$remotename/$branchname")
+                obj = LibGit2.Oid(ref)
+                LibGit2.create_branch(repo, "master", get(GitCommit, repo, obj))
+                return true
+            else
+                with(head(repo)) do head_ref
+                    with(upstream(head_ref)) do tr_brn_ref
+                        if tr_brn_ref === nothing
+                            throw(GitError(Error.Merge, Error.ERROR,
+                                           "There is no tracking information for the current branch."))
+                        end
+                        [GitAnnotated(repo, tr_brn_ref)]
+                    end
+                end
+            end
         end
+    end
+
+    try
+        merge!(repo, upst_anns, fastforward,
+               merge_opts=merge_opts,
+               checkout_opts=checkout_opts)
+    finally
+        map(finalize, upst_anns)
     end
 end
 

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -18,6 +18,12 @@ function GitReference(repo::GitRepo, obj_oid::Oid, refname::AbstractString = Con
     return GitReference(ref_ptr_ptr[])
 end
 
+function isunborn(repo::GitRepo)
+    r = @check ccall((:git_repository_head_unborn, :libgit2), Cint,
+                     (Ptr{Void},), repo.ptr)
+    r != 0
+end
+
 function head(repo::GitRepo)
     head_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
     @check ccall((:git_repository_head, :libgit2), Cint,

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -18,7 +18,13 @@ function GitReference(repo::GitRepo, obj_oid::Oid, refname::AbstractString = Con
     return GitReference(ref_ptr_ptr[])
 end
 
-function isunborn(repo::GitRepo)
+"""
+    LibGit2.isorphan(repo::GitRepo)
+
+Checks if the current branch is an "orphan" branch, i.e. has no commits. The first commit
+to this branch will have no parents.
+"""
+function isorphan(repo::GitRepo)
     r = @check ccall((:git_repository_head_unborn, :libgit2), Cint,
                      (Ptr{Void},), repo.ptr)
     r != 0

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -460,8 +460,6 @@ mktempdir() do dir
             LibGit2.set!(cfg, "user.email", "BBBB@BBBB.COM")
 
             # Try rebasing on master instead
-            # this currently throws an error (wanting a manual merge)
-            # however CLI git can do this automatically without any problems
             LibGit2.rebase!(repo, master_branch)
             @test LibGit2.head_oid(repo) == head_oid
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -242,11 +242,12 @@ mktempdir() do dir
             end
         end
         @testset "normal" begin
-            repo = LibGit2.clone(cache_repo, test_repo, remote_cb = LibGit2.mirror_cb())
+            repo = LibGit2.clone(cache_repo, test_repo)
             try
                 @test isdir(test_repo)
                 @test isdir(joinpath(test_repo, ".git"))
                 @test LibGit2.isattached(repo)
+                @test LibGit2.isunborn(repo)
             finally
                 finalize(repo)
             end
@@ -461,7 +462,8 @@ mktempdir() do dir
             # Try rebasing on master instead
             # this currently throws an error (wanting a manual merge)
             # however CLI git can do this automatically without any problems
-            @test_throws LibGit2.Error.GitError LibGit2.rebase!(repo, master_branch)
+            LibGit2.rebase!(repo, master_branch)
+            @test LibGit2.head_oid(repo) == head_oid
 
             # Switch to the master branch
             LibGit2.branch!(repo, master_branch)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -247,7 +247,7 @@ mktempdir() do dir
                 @test isdir(test_repo)
                 @test isdir(joinpath(test_repo, ".git"))
                 @test LibGit2.isattached(repo)
-                @test LibGit2.isunborn(repo)
+                @test LibGit2.isorphan(repo)
             finally
                 finalize(repo)
             end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -459,7 +459,9 @@ mktempdir() do dir
             LibGit2.set!(cfg, "user.email", "BBBB@BBBB.COM")
 
             # Try rebasing on master instead
-            LibGit2.rebase!(repo, master_branch)
+            # this currently throws an error (wanting a manual merge)
+            # however CLI git can do this automatically without any problems
+            @test_throws LibGit2.Error.GitError LibGit2.rebase!(repo, master_branch)
 
             # Switch to the master branch
             LibGit2.branch!(repo, master_branch)


### PR DESCRIPTION
`LibGit2.rebase!` will no longer silently abort if an error occurs.

This changes the behaviour of one of the tests: for some reason LibGit2 is unable to automatically rebase this branch (previously it would silently abort).

follows on from #19624