### PR TITLE
Remove printing of an unnecessary backtrace when running tests

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -422,14 +422,11 @@ DefaultTestSet(desc) = DefaultTestSet(desc, [], false)
 record(ts::DefaultTestSet, t::Union{Pass,Broken}) = (push!(ts.results, t); t)
 
 # For the other result types, immediately print the error message
-# but do not terminate. Print a backtrace.
+# but do not terminate.
 function record(ts::DefaultTestSet, t::Union{Fail, Error})
     if myid() == 1
         print_with_color(:white, ts.description, ": ")
         print(t)
-        # don't print the backtrace for Errors because it gets printed in the show
-        # method
-        isa(t, Error) || Base.show_backtrace(STDOUT, backtrace())
         println()
     end
     push!(ts.results, t)


### PR DESCRIPTION
Does someone understand why this backtrace is printed?

As an example, this is what you get from `Pkg.test()` when a test fails in a testset:

![image](https://cloud.githubusercontent.com/assets/1282691/21326197/dd7393ac-c629-11e6-83fa-654856b7913a.png)

What information does it bring?

cc @kshyatt

