### PR TITLE
Fix #19655 (TypeError on empty stacktrace)

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -144,7 +144,7 @@ doesn't return C functions, but this can be enabled.) When called without specif
 trace, `stacktrace` first calls `backtrace`.
 """
 function stacktrace(trace::Vector{Ptr{Void}}, c_funcs::Bool=false)
-    stack = vcat(map(lookup, trace)...)::StackTrace
+    stack = vcat(StackTrace(), map(lookup, trace)...)::StackTrace
 
     # Remove frames that come from C calls.
     if !c_funcs

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -124,3 +124,12 @@ let ctestptr = cglobal((:ctest, "libccalltest")),
     @test ctest[1].from_c
     @test ctest[1].pointer === UInt64(ctestptr)
 end
+
+# #19655
+let
+    # not in a `catch`, so should return an empty StackTrace
+    st = stacktrace(empty!(backtrace()))
+
+    @test isempty(st)
+    @test isa(st, StackTrace)
+end


### PR DESCRIPTION
The issue was that `vcat(StackFrame[]...)` gives `Any[]`, not `StackFrame[]`. 