### PR TITLE
Avoid adding extension again when looking for library from versioned name

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -40,7 +40,14 @@ static int endswith_extension(const char *path)
     for (size_t i = 1;i < N_EXTENSIONS;i++) {
         const char *ext = extensions[i];
         size_t extlen = strlen(ext);
-        if (len >= extlen && memcmp(ext, path + len - extlen, extlen) == 0) {
+        if (len < extlen) return 0;
+        // Skip version extensions if present
+        size_t j = len-1;
+        while (j > 0) {
+            if (path[j] == '.' || (path[j] >= '0' && path[j] <= '9')) j--;
+            else break;
+        }
+        if ((j == len-1 || path[j+1] == '.') && memcmp(ext, path + j - extlen + 1, extlen) == 0) {
             return 1;
         }
     }

--- a/test/libdl.jl
+++ b/test/libdl.jl
@@ -160,6 +160,12 @@ end
 # opening a library that does not exist throws an ErrorException
 @test_throws ErrorException Libdl.dlopen("./foo")
 
+# opening a versioned library that does not exist does not result in adding extension twice
+err = @test_throws ErrorException Libdl.dlopen("./foo.$(Libdl.dlext).0")
+@test !contains(err.value.msg, "foo.$(Libdl.dlext).0.$(Libdl.dlext)")
+err = @test_throws ErrorException Libdl.dlopen("./foo.$(Libdl.dlext).0.22.1")
+@test !contains(err.value.msg, "foo.$(Libdl.dlext).0.22.1.$(Libdl.dlext)")
+
 # test dlsym
 let dl = C_NULL
     try


### PR DESCRIPTION
Improve detection of extension by first skipping trailing numbers and dots.
Previously, looking for a library via its versioned name (including extension)
would try with the extension added twice if loading using the raw name failed.
This would mask any errors from that step (e.g. due to missing symbols),
printing instead the "file not found" error from the second attempt with the
extension added.