### PR TITLE
Improves path handling in LibGit2, also defines show method for GitRepo.

### DIFF
--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -145,7 +145,7 @@ repositories.
 
     This will typically be the parent directory of `gitdir(repo)`, but can be different in
     some cases: e.g. if either the `core.worktree` configuration variable or the
-    `GIT_WORK_TREE` environmental variable is set.
+    `GIT_WORK_TREE` environment variable is set.
 
 See also `gitdir`, `path`
 """

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -44,3 +44,15 @@ function features()
     end
     return res
 end
+
+"""
+    LibGit2.posixpath(path)
+
+Standardise the path string `path` to use POSIX separators.
+"""
+function posixpath end
+if is_windows()
+    posixpath(path) = replace(path,'\\','/')
+else is_unix()
+    posixpath(path) = path
+end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -168,6 +168,7 @@ mktempdir() do dir
             repo = LibGit2.init(cache_repo)
             try
                 @test isdir(cache_repo)
+                @test LibGit2.path(repo) == realpath(cache_repo)
                 @test isdir(joinpath(cache_repo, ".git"))
 
                 # set a remote branch
@@ -192,6 +193,7 @@ mktempdir() do dir
             repo = LibGit2.init(path, true)
             try
                 @test isdir(path)
+                @test LibGit2.path(repo) == realpath(path)
                 @test isfile(joinpath(path, LibGit2.Consts.HEAD_FILE))
                 @test LibGit2.isattached(repo)
             finally
@@ -216,6 +218,7 @@ mktempdir() do dir
             repo = LibGit2.clone(cache_repo, repo_path, isbare = true)
             try
                 @test isdir(repo_path)
+                @test LibGit2.path(repo) == realpath(repo_path)
                 @test isfile(joinpath(repo_path, LibGit2.Consts.HEAD_FILE))
                 @test LibGit2.isattached(repo)
                 @test LibGit2.remotes(repo) == ["origin"]
@@ -228,6 +231,7 @@ mktempdir() do dir
             repo = LibGit2.clone(cache_repo, repo_path, isbare = true, remote_cb = LibGit2.mirror_cb())
             try
                 @test isdir(repo_path)
+                @test LibGit2.path(repo) == realpath(repo_path)
                 @test isfile(joinpath(repo_path, LibGit2.Consts.HEAD_FILE))
                 rmt = LibGit2.get(LibGit2.GitRemote, repo, "origin")
                 try
@@ -245,6 +249,7 @@ mktempdir() do dir
             repo = LibGit2.clone(cache_repo, test_repo)
             try
                 @test isdir(test_repo)
+                @test LibGit2.path(repo) == realpath(test_repo)
                 @test isdir(joinpath(test_repo, ".git"))
                 @test LibGit2.isattached(repo)
                 @test LibGit2.isorphan(repo)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -168,7 +168,7 @@ mktempdir() do dir
             repo = LibGit2.init(cache_repo)
             try
                 @test isdir(cache_repo)
-                @test LibGit2.path(repo) == realpath(cache_repo)
+                @test LibGit2.path(repo) == LibGit2.posixpath(realpath(cache_repo))
                 @test isdir(joinpath(cache_repo, ".git"))
 
                 # set a remote branch
@@ -193,7 +193,7 @@ mktempdir() do dir
             repo = LibGit2.init(path, true)
             try
                 @test isdir(path)
-                @test LibGit2.path(repo) == realpath(path)
+                @test LibGit2.path(repo) == LibGit2.posixpath(realpath(path))
                 @test isfile(joinpath(path, LibGit2.Consts.HEAD_FILE))
                 @test LibGit2.isattached(repo)
             finally
@@ -218,7 +218,7 @@ mktempdir() do dir
             repo = LibGit2.clone(cache_repo, repo_path, isbare = true)
             try
                 @test isdir(repo_path)
-                @test LibGit2.path(repo) == realpath(repo_path)
+                @test LibGit2.path(repo) == LibGit2.posixpath(realpath(repo_path))
                 @test isfile(joinpath(repo_path, LibGit2.Consts.HEAD_FILE))
                 @test LibGit2.isattached(repo)
                 @test LibGit2.remotes(repo) == ["origin"]
@@ -231,7 +231,7 @@ mktempdir() do dir
             repo = LibGit2.clone(cache_repo, repo_path, isbare = true, remote_cb = LibGit2.mirror_cb())
             try
                 @test isdir(repo_path)
-                @test LibGit2.path(repo) == realpath(repo_path)
+                @test LibGit2.path(repo) == LibGit2.posixpath(realpath(repo_path))
                 @test isfile(joinpath(repo_path, LibGit2.Consts.HEAD_FILE))
                 rmt = LibGit2.get(LibGit2.GitRemote, repo, "origin")
                 try
@@ -249,7 +249,7 @@ mktempdir() do dir
             repo = LibGit2.clone(cache_repo, test_repo)
             try
                 @test isdir(test_repo)
-                @test LibGit2.path(repo) == realpath(test_repo)
+                @test LibGit2.path(repo) == LibGit2.posixpath(realpath(test_repo))
                 @test isdir(joinpath(test_repo, ".git"))
                 @test LibGit2.isattached(repo)
                 @test LibGit2.isorphan(repo)


### PR DESCRIPTION
Defines a `workdir` function, uses this to define `path` in a more principled way, and a show method.