### PR TITLE
Make Travis build deps in parallel again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
     # capture the log, but only print it if `make deps` fails
     # try to show the end of the log first, because this log might be very long (> 4MB)
     # and thus be truncated by travis
-    - moreutils/mispipe "make \$BUILDOPTS VERBOSE=0 -C deps 2> deps-err.log" "$BAR" > deps.log ||
+    - moreutils/mispipe "make $BUILDOPTS VERBOSE=0 -C deps 2> deps-err.log" "$BAR" > deps.log ||
         { echo "-- deps build log stderr tail 100 --------------------------------------";
           tail -n 100 deps-err.log;
           echo "-- deps build log stdout tail 100 --------------------------------------";

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
           packages:
-            - cmake
             - bar
             - time
             - binutils
@@ -30,9 +28,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
           packages:
-            - cmake
             - bar
             - time
             - g++-5
@@ -82,7 +78,7 @@ before_install:
         contrib/travis_fastfail.sh || exit 1;
         brew tap staticfloat/julia;
         brew rm --force $(brew deps --HEAD julia);
-        brew install -v cmake staticfloat/juliadeps/libgfortran;
+        brew install -v staticfloat/juliadeps/libgfortran;
         brew install -v --only-dependencies --HEAD julia;
         BUILDOPTS="-j3 USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm37-julia)/bin/llvm-config-3.7 LLVM_SIZE=$(brew --prefix llvm37-julia)/bin/llvm-size-3.7";
         BUILDOPTS="$BUILDOPTS VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse-julia)/include FORCE_ASSERTIONS=1";
@@ -100,6 +96,7 @@ before_install:
     - git clone -q git://git.kitenet.net/moreutils
 script:
     - echo $BUILDOPTS
+    - contrib/download_cmake.sh
     - make -C moreutils mispipe
     - make $BUILDOPTS -C base version_git.jl.phony
     # capture the log, but only print it if `make deps` fails

--- a/contrib/download_cmake.sh
+++ b/contrib/download_cmake.sh
@@ -24,11 +24,11 @@ FULLNAME=cmake-$CMAKE_VERSION-$PLATFORM
 case $PLATFORM in
   Darwin-x86_64)
     ../tools/jldownload https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/$FULLNAME.tar.gz
-    echo "$CMAKE_SHA256_DARWIN $FULLNAME.tar.gz" | shasum -a 256 -c -
+    echo "$CMAKE_SHA256_DARWIN  $FULLNAME.tar.gz" | shasum -a 256 -c -
     CMAKE_EXTRACTED_PATH=$FULLNAME/CMake.app/Contents/bin/cmake;;
   Linux-x86_64)
     ../tools/jldownload https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/$FULLNAME.tar.gz
-    echo "$CMAKE_SHA256_LINUX $FULLNAME.tar.gz" | sha256sum -c -
+    echo "$CMAKE_SHA256_LINUX  $FULLNAME.tar.gz" | sha256sum -c -
     CMAKE_EXTRACTED_PATH=$FULLNAME/bin/cmake;;
   *)
     echo "This script only supports x86_64 Mac and Linux. For other platforms," >&2


### PR DESCRIPTION
unnecessary change from https://github.com/JuliaLang/julia/pull/19475/files#r93611089,
causes linux builds from a clean cache to time out but was not noticed when building
from an already-populated cache

(and build llvm twice, once with assertions and once without)