### PR TITLE
Make op(Array, Scalar) use broadcast

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,9 @@ This section lists changes that do not have deprecation warnings.
     The flip-side of this is that new method definitions should now reliably actually
     take effect, and be called when evaluating new code ([#265]).
 
+  * The array-scalar operations `div`, `mod`, `rem`, `&`, `|`, `xor`, `/`, `\`, `*`, `+`, and `-`
+    now follow broadcast promotion rules ([#19692]).
+
 Library improvements
 --------------------
 

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -91,42 +91,10 @@ end
 
 for f in (:div, :mod, :rem, :&, :|, :xor, :/, :\, :*, :+, :-)
     if f != :/
-        @eval function ($f){T}(A::Number, B::AbstractArray{T})
-            R = promote_op($f, typeof(A), T)
-            S = promote_array_type($f, typeof(A), T, R)
-            S === Any && return [($f)(A, b) for b in B]
-            F = similar(B, S)
-            RF, RB = eachindex(F), eachindex(B)
-            if RF == RB
-                for i in RB
-                    @inbounds F[i] = ($f)(A, B[i])
-                end
-            else
-                for (iF, iB) in zip(RF, RB)
-                    @inbounds F[iF] = ($f)(A, B[iB])
-                end
-            end
-            return F
-        end
+        @eval ($f){T}(A::Number, B::AbstractArray{T}) = broadcast($f, A, B)
     end
     if f != :\
-        @eval function ($f){T}(A::AbstractArray{T}, B::Number)
-            R = promote_op($f, T, typeof(B))
-            S = promote_array_type($f, typeof(B), T, R)
-            S === Any && return [($f)(a, B) for a in A]
-            F = similar(A, S)
-            RF, RA = eachindex(F), eachindex(A)
-            if RF == RA
-                for i in RA
-                    @inbounds F[i] = ($f)(A[i], B)
-                end
-            else
-                for (iF, iA) in zip(RF, RA)
-                    @inbounds F[iF] = ($f)(A[iA], B)
-                end
-            end
-            return F
-        end
+        @eval ($f){T}(A::AbstractArray{T}, B::Number) = broadcast($f, A, B)
     end
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -186,7 +186,7 @@ let a = Real[2, 2.0, 4//2] / 2
     @test eltype(a) == Real
 end
 let a = Real[2, 2.0, 4//2] / 2.0
-    @test eltype(a) == Real
+    @test eltype(a) == Float64
 end
 
 # issue 16164

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -488,7 +488,7 @@ end
 
 @testset "posv and some errors for friends" begin
     @testset for elty in (Float32, Float64, Complex64, Complex128)
-        A = 0.01*rand(elty,10,10)
+        A = rand(elty,10,10)/100
         A += real(diagm(10*real(rand(elty,10))))
         if elty <: Complex
             A = A + A'


### PR DESCRIPTION
These are broadcast operations and could therefore just use the broadcast functionality. @martinholters I had to tighten a single type test that you added but I believe that this can just be considered an improvement.