### PR TITLE
splitdrive under windows

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -34,7 +34,7 @@ elseif is_windows()
     const path_ext_splitter = r"^((?:.*[/\\])?(?:\.|[^/\\\.])[^/\\]*?)(\.[^/\\\.]*|)$"
 
     function splitdrive(path::String)
-        m = match(r"^(\w+:|\\\\\w+\\\w+|\\\\\?\\UNC\\\w+\\\w+|\\\\\?\\\w+:|)(.*)$", path)
+        m = match(r"^([^\\]+:|\\\\[^\\]+\\[^\\]+|\\\\\?\\UNC\\[^\\]+\\[^\\]+|\\\\\?\\[^\\]+:|)(.*)$", path)
         String(m.captures[1]), String(m.captures[2])
     end
 else

--- a/test/path.jl
+++ b/test/path.jl
@@ -67,6 +67,11 @@ for S in (String, GenericString)
 
     @test joinpath(splitdir(S(homedir()))...) == homedir()
     @test string(splitdrive(S(homedir()))...) == homedir()
+    
+    if is_windows()
+        @test splitdrive("\\\\servername\\hello.world\\filename.ext") == ("\\\\servername\\hello.world","\\filename.ext")
+        @test splitdrive("\\\\servername.com\\hello.world\\filename.ext") == ("\\\\servername.com\\hello.world","\\filename.ext")
+    end
 
     @test splitext(S("")) == ("", "")
     @test splitext(S(".")) == (".", "")


### PR DESCRIPTION
windows paths can contain non alphanumeric characters
[https://discourse.julialang.org/t/splitdrive-under-windows/1083](url)
@vtjnash suggested i tried a PR