### PR TITLE
use Ref in getipaddr and improve type stability

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -656,12 +656,11 @@ const _sizeof_uv_interface_address = ccall(:jl_uv_sizeof_interface_address,Int32
 Get the IP address of the local machine.
 """
 function getipaddr()
-    addr = Array{Ptr{UInt8}}(1)
-    addr[1] = C_NULL
-    count = zeros(Int32,1)
+    addr_ref = Ref{Ptr{UInt8}}(C_NULL)
+    count_ref = Ref{Int32}(1)
     lo_present = false
-    err = ccall(:jl_uv_interface_addresses, Int32, (Ptr{Ptr{UInt8}}, Ptr{Int32}), addr, count)
-    addr,  count = addr[1], count[1]
+    err = ccall(:jl_uv_interface_addresses, Int32, (Ref{Ptr{UInt8}}, Ref{Int32}), addr_ref, count_ref)
+    addr, count = addr_ref[], count_ref[]
     if err != 0
         ccall(:uv_free_interface_addresses, Void, (Ptr{UInt8}, Int32), addr, count)
         throw(UVError("getlocalip", err))


### PR DESCRIPTION
Just a slight improvement I noticed when I was doing something else.