### PR TITLE
RFC: eliminate getindex(::Number)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -138,6 +138,10 @@ Compiler/Runtime improvements
 Deprecated or removed
 ---------------------
 
+  * `getindex(x::Number)` and similar functions (`ndims`, `size`) that treat
+    numbers as 0-dimensional arrays have been removed, although they are
+    still iterable ([#19700]).
+
   * `isdefined(a::Array, i::Int)` has been deprecated in favor of `isassigned` ([#18346]).
 
   * `is` has been deprecated in favor of `===` (which used to be an alias for `is`) ([#17758]).

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,6 +1168,29 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# #19700:
+function depnumberindex(x)
+    depwarn("treating numbers as 0-dimensional arrays is deprecated", :depnumberindex)
+    return x
+end
+size(x::Number) = depnumberindex(())
+size(x::Number,d) = depnumberindex(convert(Int,d)<1 ? throw(BoundsError()) : 1)
+indices(x::Number) = depnumberindex(())
+indices(x::Number,d) = depnumberindex(convert(Int,d)<1 ? throw(BoundsError()) : OneTo(1))
+ndims(x::Number) = depnumberindex(0)
+ndims{T<:Number}(::Type{T}) = depnumberindex(0)
+endof(x::Number) = depnumberindex(1)
+getindex(x::Number) = depnumberindex(x)
+function getindex(x::Number, i::Integer)
+    @boundscheck i == 1 || throw(BoundsError())
+    depnumberindex(x)
+end
+function getindex(x::Number, I::Integer...)
+    @boundscheck all([i == 1 for i in I]) || throw(BoundsError())
+    depnumberindex(x)
+end
+getindex(x::Number, I::Real...) = getindex(x, to_indexes(I...)...)
+
 # Deprecate vectorized xor in favor of compact broadcast syntax
 @deprecate xor(a::Bool, B::BitArray)                xor.(a, B)
 @deprecate xor(A::BitArray, b::Bool)                xor.(A, b)

--- a/base/dsp.jl
+++ b/base/dsp.jl
@@ -32,7 +32,7 @@ function filt!{T,S,N}(out::AbstractArray, b::Union{AbstractVector, Number}, a::U
                       x::AbstractArray{T}, si::AbstractArray{S,N}=_zerosi(b,a,T))
     isempty(b) && throw(ArgumentError("filter vector b must be non-empty"))
     isempty(a) && throw(ArgumentError("filter vector a must be non-empty"))
-    a[1] == 0  && throw(ArgumentError("filter vector a[1] must be nonzero"))
+    first(a) == 0  && throw(ArgumentError("filter vector first(a) must be nonzero"))
     if size(x) != size(out)
         throw(ArgumentError("output size $(size(out)) must match input size $(size(x))"))
     end
@@ -51,11 +51,11 @@ function filt!{T,S,N}(out::AbstractArray, b::Union{AbstractVector, Number}, a::U
     end
 
     size(x,1) == 0 && return out
-    sz == 1 && return scale!(out, x, b[1]/a[1]) # Simple scaling without memory
+    sz == 1 && return scale!(out, x, first(b)/first(a)) # Simple scaling without memory
 
     # Filter coefficient normalization
-    if a[1] != 1
-        norml = a[1]
+    if first(a) != 1
+        norml = first(a)
         a ./= norml
         b ./= norml
     end
@@ -66,11 +66,11 @@ function filt!{T,S,N}(out::AbstractArray, b::Union{AbstractVector, Number}, a::U
     initial_si = si
     for col = 1:ncols
         # Reset the filter state
-        si = initial_si[:, N > 1 ? col : 1]
+        si_col = initial_si[:, N > 1 ? col : 1]
         if as > 1
-            _filt_iir!(out, b, a, x, si, col)
+            _filt_iir!(out, b, a, x, si_col, col)
         else
-            _filt_fir!(out, b, x, si, col)
+            _filt_fir!(out, b, x, si_col, col)
         end
     end
     return out

--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -433,20 +433,19 @@ function fix_kinds(region, kinds)
             if isempty(kinds)
                 throw(ArgumentError("must supply a transform kind"))
             end
-            k = Array{Int32}(length(region))
-            k[1:length(kinds)] = [kinds...]
-            k[length(kinds)+1:end] = kinds[end]
-            kinds = k
+            fixedkinds = Array{Int32}(length(region))
+            copy!(fixedkinds, 1, kinds, 1, length(kinds))
+            fixedkinds[length(kinds)+1:end] = last(kinds)
         end
     else
-        kinds = Int32[kinds...]
+        fixedkinds = Int32[kinds...]
     end
-    for i = 1:length(kinds)
-        if kinds[i] < 0 || kinds[i] > 10
+    for k in fixedkinds
+        if k < 0 || k > 10
             throw(ArgumentError("invalid transform kind"))
         end
     end
-    return kinds
+    return fixedkinds
 end
 
 # low-level FFTWPlan creation (for internal use in FFTW module)

--- a/base/fft/dct.jl
+++ b/base/fft/dct.jl
@@ -34,7 +34,7 @@ for (pf, pfr, K, inplace) in ((:plan_dct, :plan_r2r, REDFT10, false),
         r = [1:n for n in size(X)]
         nrm = sqrt(0.5^length(region) * normalization(X,region))
         DCTPlan{T,$K,$inplace}($pfr(X, $K, region; kws...), r, nrm,
-                               ntuple(i -> Int(region[i]), length(region)))
+                               tuple(collect(Int,region)...))
     end
 end
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -932,7 +932,7 @@ end
         ind = 0
         Xc, Bc = X.chunks, B.chunks
         idxlens = @ncall $N index_lengths B d->I[d]
-        @nloops $N i d->(1:idxlens[d]) d->(@inbounds offset_{d-1} = offset_d + (I[d][i_d]-1)*stride_d) begin
+        @nloops $N i d->(1:idxlens[d]) d->(@inbounds offset_{d-1} = offset_d + ((let Id = I[d]; isa(Id,Number)?Id:Id[i_d];end)-1)*stride_d) begin
             ind += 1
             unsafe_bitsetindex!(Xc, unsafe_bitgetindex(Bc, offset_0), ind)
         end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -931,8 +931,10 @@ end
         $(Symbol(:offset_, N)) = 1
         ind = 0
         Xc, Bc = X.chunks, B.chunks
-        idxlens = @ncall $N index_lengths B d->I[d]
-        @nloops $N i d->(1:idxlens[d]) d->(@inbounds offset_{d-1} = offset_d + ((let Id = I[d]; isa(Id,Number)?Id:Id[i_d];end)-1)*stride_d) begin
+        @nexprs $N d->(I_d = I[d])
+        J = @ncall $N decolon B I
+        @nexprs $N d->(J_d = J[d])
+        @nloops $N j d->J_d d->(@inbounds offset_{d-1} = offset_d + (j_d-1)*stride_d) begin
             ind += 1
             unsafe_bitsetindex!(Xc, unsafe_bitgetindex(Bc, offset_0), ind)
         end

--- a/base/number.jl
+++ b/base/number.jl
@@ -12,32 +12,19 @@ all of the elements of `x` are zero.
 """
 iszero(x) = x == zero(x) # fallback method
 
-size(x::Number) = ()
-size(x::Number,d) = convert(Int,d)<1 ? throw(BoundsError()) : 1
-indices(x::Number) = ()
-indices(x::Number,d) = convert(Int,d)<1 ? throw(BoundsError()) : OneTo(1)
-eltype{T<:Number}(::Type{T}) = T
-ndims(x::Number) = 0
-ndims{T<:Number}(::Type{T}) = 0
-length(x::Number) = 1
-endof(x::Number) = 1
-iteratorsize{T<:Number}(::Type{T}) = HasShape()
-
-getindex(x::Number) = x
-function getindex(x::Number, i::Integer)
-    @_inline_meta
-    @boundscheck i == 1 || throw(BoundsError())
-    x
-end
-function getindex(x::Number, I::Integer...)
-    @_inline_meta
-    @boundscheck all([i == 1 for i in I]) || throw(BoundsError())
-    x
-end
-getindex(x::Number, I::Real...) = getindex(x, to_indexes(I...)...)
+# it is sometimes convenient, when writing generic code,
+# to be able to iterate over numbers as 1-element collections (#7903)
 first(x::Number) = x
 last(x::Number) = x
-copy(x::Number) = x  # some code treats numbers as collection-like
+start(::Number) = false
+next(x::Number, state) = (x, true)
+done(::Number, state) = state
+isempty(::Number) = false
+in(x::Number, y::Number) = x == y
+length(::Number) = 1
+eltype{T<:Number}(::Type{T}) = T
+iteratorsize{T<:Number}(::Type{T}) = HasLength()
+copy(x::Number) = x
 
 """
     divrem(x, y)
@@ -93,12 +80,6 @@ julia> widemul(Float32(3.), 4.)
 ```
 """
 widemul(x::Number, y::Number) = widen(x)*widen(y)
-
-start(x::Number) = false
-next(x::Number, state) = (x, true)
-done(x::Number, state) = state
-isempty(x::Number) = false
-in(x::Number, y::Number) = x == y
 
 map(f, x::Number, ys::Number...) = f(x, ys...)
 

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -176,9 +176,8 @@ end
 
 # Ensure that broadcast doesn't use @inbounds when calling the function
 if bc_opt != bc_off
-    let A = zeros(3,3)
-        @test_throws BoundsError broadcast(getindex, A, 1:3, 1:3)
-    end
+    @test broadcast(getindex, Ref{UnitRange{Int}}(4:6), [1,1,3,2]) == [4,4,6,5]
+    @test_throws BoundsError broadcast(getindex, Ref{UnitRange{Int}}(4:6), [1,0])
 end
 
 # issue #19554

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -43,7 +43,7 @@ end
 @test isequal(filter((ss)->length(ss)==3, ["abcd", "efg", "hij", "klmn", "opq"]), ["efg", "hij", "opq"])
 
 # numbers
-@test size(collect(1)) == size(1)
+@test size(collect(1)) == (1,)
 
 @test isa(collect(Any, [1,2]), Vector{Any})
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2521,33 +2521,15 @@ let number_types = Set()
     for T in number_types
         @test eltype(T) == T
     end
-
-    #ndims{T<:Number}(::Type{T}) = 0
-    for x in number_types
-        @test ndims(x) == 0
-    end
 end
 
-#getindex(x::Number) = x
-for x in [1.23, 7, e, 4//5] #[FP, Int, Irrational, Rat]
-    @test getindex(x) == x
-    @test getindex(x, 1, 1) == x
-end
-
-#getindex(x::Number,-1) throws BoundsError
-#getindex(x::Number,0) throws BoundsError
-#getindex(x::Number,2) throws BoundsError
 #getindex(x::Array,-1) throws BoundsError
 #getindex(x::Array,0 throws BoundsError
 #getindex(x::Array,length(x::Array)+1) throws BoundsError
 for x in [1.23, 7, e, 4//5] #[FP, Int, Irrational, Rat]
-    @test_throws BoundsError getindex(x,-1)
-    @test_throws BoundsError getindex(x,0)
-    @test_throws BoundsError getindex(x,2)
     @test_throws BoundsError getindex([x x],-1)
     @test_throws BoundsError getindex([x x],0)
     @test_throws BoundsError getindex([x x],length([x,x])+1)
-    @test_throws BoundsError getindex(x, 1, 0)
 end
 
 # copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, x)
@@ -2794,17 +2776,7 @@ testmi(typemin(Int)+1:typemin(Int)+1000, -100:100)
 testmi(map(UInt32, 0:1000), map(UInt32, 1:100))
 testmi(typemax(UInt32)-UInt32(1000):typemax(UInt32), map(UInt32, 1:100))
 
-@test ndims(1) == 0
-@test ndims(Integer) == 0
-@test size(1,1) == 1
-@test_throws BoundsError size(1,-1)
-@test indices(1) == ()
-@test indices(1,1) == 1:1
-@test_throws BoundsError indices(1,-1)
-@test isinteger(Integer(2)) == true
-@test size(1) == ()
 @test length(1) == 1
-@test endof(1) == 1
 @test eltype(Integer) == Integer
 
 # issue #15920

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -488,7 +488,7 @@ end
     for i=1:5
         sprb45 = sprand(Bool, 4, 5, 0.5)
         @test length(sprb45) == 20
-        sprb45nnzs[i] = sum(sprb45)[1]
+        sprb45nnzs[i] = sum(sprb45)
     end
     @test 4 <= mean(sprb45nnzs) <= 16
 end


### PR DESCRIPTION
This PR partially addresses #7903: it makes numbers non-indexable, so that they no longer act like 0-dimensional arrays (no `size`, `getindex`, `ndims`, etc).  (`broadcast` is unaffected.)

* Pro: being able to do `1[1]` was always a bit odd, and it doesn't seem to gain us much.  Eliminating this functionality seems to require minimal changes to Base.  Also, the `f.(x)` syntax removes some of the impetus to write functions where scalars can be treated like arrays.

* Con: eliminating this functionality doesn't actually save us much code in Base, and it might make some kinds of generic functions more annoying to write, especially since numbers are still iterable.   Is it worth it?

I initially also tried making numbers non-iterable (removing `start` etc.).  However, I quickly found that there is a *lot* of code in Base that is affected, and would seem to become much uglier without this capability (see https://github.com/JuliaLang/julia/issues/7903#issuecomment-269015974).  My conclusion is that making numbers iterable is more likely something we want to retain.