### PR TITLE
Avoid rebuilding docs from 'make install' when they are already there (cont.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ julia_flisp.boot.inc.phony: julia-deps
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/src julia_flisp.boot.inc.phony
 
 # Build the HTML docs (skipped if already exists, notably in tarballs)
-$(BUILDROOT)/doc/_build/html/en/index.html: $(shell find $(BUILDROOT)/base $(BUILDROOT)/doc -path $(BUILDROOT)/doc/_build -prune -o -print)
+$(BUILDROOT)/doc/_build/html/en/index.html: $(shell find $(BUILDROOT)/base $(BUILDROOT)/doc \( -path $(BUILDROOT)/doc/_build -o -path $(BUILDROOT)/doc/deps -o -name *_constants.jl -o -name *_h.jl \) -prune -o -type f -print)
 	@$(MAKE) docs
 
 # doc needs to live under $(build_docdir), not under $(build_datarootdir)/julia/


### PR DESCRIPTION
Turns out we need to exclude directories (whose timestamps change when
building the tarball) and some files generated during the build.

Continuation of https://github.com/JuliaLang/julia/pull/19539.