### PR TITLE
Deprecate vectorized | in favor of compact broadcast syntax

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -66,7 +66,7 @@ promote_array_type{S<:Integer}(::typeof(/), ::Type{S}, ::Type{Bool}, T::Type) = 
 promote_array_type{S<:Integer}(::typeof(\), ::Type{S}, ::Type{Bool}, T::Type) = T
 promote_array_type{S<:Integer}(F, ::Type{S}, ::Type{Bool}, T::Type) = T
 
-for f in (:+, :-, :div, :mod, :&, :|, :xor)
+for f in (:+, :-, :div, :mod, :&, :xor)
     @eval ($f)(A::AbstractArray, B::AbstractArray) =
         _elementwise($f, promote_eltype_op($f, A, B), A, B)
 end
@@ -89,7 +89,7 @@ function _elementwise{T}(op, ::Type{T}, A::AbstractArray, B::AbstractArray)
     return F
 end
 
-for f in (:div, :mod, :rem, :&, :|, :xor, :/, :\, :*, :+, :-)
+for f in (:div, :mod, :rem, :&, :xor, :/, :\, :*, :+, :-)
     if f != :/
         @eval function ($f){T}(A::Number, B::AbstractArray{T})
             R = promote_op($f, typeof(A), T)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1296,17 +1296,12 @@ function (&)(B::BitArray, x::Bool)
 end
 (&)(x::Bool, B::BitArray) = B & x
 
-function (|)(B::BitArray, x::Bool)
-    x ? trues(size(B)) : copy(B)
-end
-(|)(x::Bool, B::BitArray) = B | x
-
 function xor(B::BitArray, x::Bool)
     x ? ~B : copy(B)
 end
 xor(x::Bool, B::BitArray) = xor(B, x)
 
-for f in (:&, :|, :xor)
+for f in (:&, :xor)
     @eval begin
         function ($f)(A::BitArray, B::BitArray)
             F = BitArray(promote_shape(size(A),size(B))...)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1168,4 +1168,11 @@ for (dep, f, op) in [(:sumabs!, :sum!, :abs),
     end
 end
 
+# Deprecate vectorized | in favor of compact broadcast syntax
+@deprecate (|)(a::Bool, B::BitArray)                a .| B
+@deprecate (|)(A::BitArray, b::Bool)                A .| b
+@deprecate (|)(a::Number, B::AbstractArray)         a .| B
+@deprecate (|)(A::AbstractArray, b::Number)         A .| b
+@deprecate (|)(A::AbstractArray, B::AbstractArray)  A .| B
+
 # End deprecations scheduled for 0.6

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2289,7 +2289,6 @@ round{To}(::Type{To}, A::SparseMatrixCSC) = round.(To, A)
 min(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(min, A, B)
 max(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(max, A, B)
 (&)(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(&, A, B)
-(|)(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(|, A, B)
 xor(A::SparseMatrixCSC, B::SparseMatrixCSC) = map(xor, A, B)
 
 ( +)(A::SparseMatrixCSC, B::Array ) = Array(A)  + B

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -783,7 +783,7 @@ timesofar("unary arithmetic")
 let b1 = bitrand(n1, n2)
     b2 = bitrand(n1, n2)
     @check_bit_operation (&)(b1, b2)  BitMatrix
-    @check_bit_operation (|)(b1, b2)  BitMatrix
+    @check_bit_operation broadcast(|, b1, b2)  BitMatrix
     @check_bit_operation xor(b1, b2)  BitMatrix
     @check_bit_operation (+)(b1, b2)  Matrix{Int}
     @check_bit_operation (-)(b1, b2)  Matrix{Int}
@@ -814,7 +814,7 @@ end
 
 let b0 = falses(0)
     @check_bit_operation (&)(b0, b0)  BitVector
-    @check_bit_operation (|)(b0, b0)  BitVector
+    @check_bit_operation broadcast(|, b0, b0)  BitVector
     @check_bit_operation xor(b0, b0)  BitVector
     @check_bit_operation broadcast(*, b0, b0) BitVector
     @check_bit_operation (*)(b0, b0') Matrix{Int}
@@ -825,7 +825,7 @@ end
 let b1 = bitrand(n1, n2)
     i2 = rand(1:10, n1, n2)
     @check_bit_operation (&)(b1, i2)  Matrix{Int}
-    @check_bit_operation (|)(b1, i2)  Matrix{Int}
+    @check_bit_operation broadcast(|, b1, i2)  Matrix{Int}
     @check_bit_operation xor(b1, i2)  Matrix{Int}
     @check_bit_operation (+)(b1, i2)  Matrix{Int}
     @check_bit_operation (-)(b1, i2)  Matrix{Int}
@@ -858,14 +858,14 @@ let b2 = bitrand(n1, n2)
     cf1 = complex(f1)
 
     @check_bit_operation (&)(i1, b2)  Matrix{Int}
-    @check_bit_operation (|)(i1, b2)  Matrix{Int}
+    @check_bit_operation broadcast(|, i1, b2)  Matrix{Int}
     @check_bit_operation xor(i1, b2)  Matrix{Int}
     @check_bit_operation broadcast(+, i1, b2)  Matrix{Int}
     @check_bit_operation broadcast(-, i1, b2)  Matrix{Int}
     @check_bit_operation broadcast(*, i1, b2) Matrix{Int}
 
     @check_bit_operation (&)(u1, b2)  Matrix{UInt8}
-    @check_bit_operation (|)(u1, b2)  Matrix{UInt8}
+    @check_bit_operation broadcast(|, u1, b2)  Matrix{UInt8}
     @check_bit_operation xor(u1, b2)  Matrix{UInt8}
     @check_bit_operation broadcast(+, u1, b2)  Matrix{UInt8}
     @check_bit_operation broadcast(-, u1, b2)  Matrix{UInt8}
@@ -937,10 +937,10 @@ let b1 = bitrand(n1, n2)
     @check_bit_operation (&)(b1, false)  BitMatrix
     @check_bit_operation (&)(true, b1)   BitMatrix
     @check_bit_operation (&)(false, b1)  BitMatrix
-    @check_bit_operation (|)(b1, true)   BitMatrix
-    @check_bit_operation (|)(b1, false)  BitMatrix
-    @check_bit_operation (|)(true, b1)   BitMatrix
-    @check_bit_operation (|)(false, b1)  BitMatrix
+    @check_bit_operation broadcast(|, b1, true)   BitMatrix
+    @check_bit_operation broadcast(|, b1, false)  BitMatrix
+    @check_bit_operation broadcast(|, true, b1)   BitMatrix
+    @check_bit_operation broadcast(|, false, b1)  BitMatrix
     @check_bit_operation xor(b1, true)   BitMatrix
     @check_bit_operation xor(b1, false)  BitMatrix
     @check_bit_operation xor(true, b1)   BitMatrix
@@ -959,13 +959,13 @@ let b1 = bitrand(n1, n2)
     @check_bit_operation mod(b1, true)   BitMatrix
 
     @check_bit_operation (&)(b1, b2)  BitMatrix
-    @check_bit_operation (|)(b1, b2)  BitMatrix
+    @check_bit_operation broadcast(|, b1, b2)  BitMatrix
     @check_bit_operation xor(b1, b2)  BitMatrix
     @check_bit_operation (&)(b2, b1)  BitMatrix
-    @check_bit_operation (|)(b2, b1)  BitMatrix
+    @check_bit_operation broadcast(|, b2, b1)  BitMatrix
     @check_bit_operation xor(b2, b1)  BitMatrix
     @check_bit_operation (&)(b1, i2)  Matrix{Int}
-    @check_bit_operation (|)(b1, i2)  Matrix{Int}
+    @check_bit_operation broadcast(|, b1, i2)  Matrix{Int}
     @check_bit_operation xor(b1, i2)  Matrix{Int}
     @check_bit_operation broadcast(+, b1, i2)  Matrix{Int}
     @check_bit_operation broadcast(-, b1, i2)  Matrix{Int}
@@ -975,7 +975,7 @@ let b1 = bitrand(n1, n2)
     @check_bit_operation mod(b1, i2)  Matrix{Int}
 
     @check_bit_operation (&)(b1, u2)  Matrix{UInt8}
-    @check_bit_operation (|)(b1, u2)  Matrix{UInt8}
+    @check_bit_operation broadcast(|, b1, u2)  Matrix{UInt8}
     @check_bit_operation xor(b1, u2)  Matrix{UInt8}
     @check_bit_operation broadcast(+, b1, u2)  Matrix{UInt8}
     @check_bit_operation broadcast(-, b1, u2)  Matrix{UInt8}
@@ -1118,7 +1118,7 @@ let b1 = trues(v1)
 
     for i = 3:(v1-1), j = 2:i
         submask = b1 << (v1-j+1)
-        @test findnext((b1 >> i) | submask, j) == i+1
+        @test findnext((b1 >> i) .| submask, j) == i+1
         @test findnextnot((~(b1 >> i)) ⊻ submask, j) == i+1
     end
 end
@@ -1275,7 +1275,7 @@ for l = [0, 1, 63, 64, 65, 127, 128, 129, 255, 256, 257, 6399, 6400, 6401]
     @test map(identity, b1) == map(x->x, b1) == b1
 
     @test map(&, b1, b2) == map((x,y)->x&y, b1, b2) == b1 & b2
-    @test map(|, b1, b2) == map((x,y)->x|y, b1, b2) == b1 | b2
+    @test map(|, b1, b2) == map((x,y)->x|y, b1, b2) == broadcast(|, b1, b2)
     @test map(⊻, b1, b2) == map((x,y)->x⊻y, b1, b2) == b1 ⊻ b2 == xor(b1, b2)
 
     @test map(^, b1, b2) == map((x,y)->x^y, b1, b2) == b1 .^ b2
@@ -1300,7 +1300,7 @@ for l = [0, 1, 63, 64, 65, 127, 128, 129, 255, 256, 257, 6399, 6400, 6401]
     @test map!(one, b, b1) == map!(x->true, b, b1) == trues(l) == b
 
     @test map!(&, b, b1, b2) == map!((x,y)->x&y, b, b1, b2) == b1 & b2 == b
-    @test map!(|, b, b1, b2) == map!((x,y)->x|y, b, b1, b2) == b1 | b2 == b
+    @test map!(|, b, b1, b2) == map!((x,y)->x|y, b, b1, b2) == broadcast(|, b1, b2) == b
     @test map!(⊻, b, b1, b2) == map!((x,y)->x⊻y, b, b1, b2) == b1 ⊻ b2 == xor(b1, b2) == b
 
     @test map!(^, b, b1, b2) == map!((x,y)->x^y, b, b1, b2) == b1 .^ b2 == b
@@ -1409,7 +1409,7 @@ for sz = [(n1,n1), (n1,n2), (n2,n1)], (f,isf) = [(tril,istril), (triu,istriu)]
 end
 
 let b1 = bitrand(n1,n1)
-    b1 |= b1.'
+    b1 .|= b1.'
     @check_bit_operation issymmetric(b1) Bool
     @check_bit_operation ishermitian(b1) Bool
 end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -186,8 +186,8 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test all(x->x>0, [4]) == true
 @test all(x->x>0, [-3, 4, 5]) == false
 
-@test reduce(|, fill(trues(5), 24))  == trues(5)
-@test reduce(|, fill(falses(5), 24)) == falses(5)
+@test reduce((a, b) -> a .| b, fill(trues(5), 24))  == trues(5)
+@test reduce((a, b) -> a .| b, fill(falses(5), 24)) == falses(5)
 @test reduce(&, fill(trues(5), 24))  == trues(5)
 @test reduce(&, fill(falses(5), 24)) == falses(5)
 

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -39,7 +39,7 @@ do33 = ones(3)
         @test_throws DimensionMismatch max(sqrfloatmat, colfloatmat)
         sqrboolmat, colboolmat = sprand(Bool, 4, 4, 0.5), sprand(Bool, 4, 1, 0.5)
         @test_throws DimensionMismatch (&)(sqrboolmat, colboolmat)
-        @test_throws DimensionMismatch (|)(sqrboolmat, colboolmat)
+        # @test_throws DimensionMismatch (|)(sqrboolmat, colboolmat) # vectorized | no longer exists
         @test_throws DimensionMismatch xor(sqrboolmat, colboolmat)
     end
 end
@@ -1592,8 +1592,8 @@ end
     @test A13024 & B13024 == sparse([1,2,5], [1,2,5], fill(true,3))
     @test typeof(A13024 & B13024) == SparseMatrixCSC{Bool,Int}
 
-    @test A13024 | B13024 == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], fill(true,6))
-    @test typeof(A13024 | B13024) == SparseMatrixCSC{Bool,Int}
+    @test broadcast(|, A13024, B13024) == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], fill(true,6))
+    @test typeof(broadcast(|, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
 
     @test A13024 ⊻ B13024 == sparse([3,4,4], [3,3,4], fill(true,3), 5, 5)
     @test typeof(A13024 ⊻ B13024) == SparseMatrixCSC{Bool,Int}
@@ -1604,7 +1604,8 @@ end
     @test min(A13024, B13024) == sparse([1,2,5], [1,2,5], fill(true,3))
     @test typeof(min(A13024, B13024)) == SparseMatrixCSC{Bool,Int}
 
-    for op in (+, -, &, |, xor)
+    @test broadcast(|, A13024, B13024) == broadcast(|, Array(A13024), Array(B13024))
+    for op in (+, -, &, xor)
         @test op(A13024, B13024) == op(Array(A13024), Array(B13024))
     end
     for op in (max, min)


### PR DESCRIPTION
This pull request deprecates all remaining vectorized `|` methods in favor of compact broadcast syntax. Best!