### PR TITLE
Re-quine quine.jl

### DIFF
--- a/examples/quine.jl
+++ b/examples/quine.jl
@@ -1,4 +1,4 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-x="println(\"x=\$(repr(x))\\n\$x\")"
-println("x=$(repr(x))\n$x")
+x="println(\"# This file is a part of Julia. License is MIT: http://julialang.org/license\\n\\nx=\$(repr(x))\\n\$x\")"
+println("# This file is a part of Julia. License is MIT: http://julialang.org/license\n\nx=$(repr(x))\n$x")


### PR DESCRIPTION
In May 2015, a sweeping [license header change](https://github.com/JuliaLang/julia/commit/fde191ecc9199aa48feb8fed08f9dde7bb699aed) added a standard license comment to the top of each of Julia's source files.

This had the side effect of making quine.jl no longer a true [quine](http://www.madore.org/~david/computers/quine.html), since its printed output was no longer identical to the original source file.

This pull request restores quine.jl's quine-ness.