### PR TITLE
Deprecate map!(f, A) (and asyncmap!(f, A)) for a cycle

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1798,12 +1798,6 @@ promote_eltype_op(op, A, B, C, D...) = (@_inline_meta; promote_eltype_op(op, elt
 
 ## 1 argument
 
-"""
-    map!(function, collection)
-
-In-place version of [`map`](@ref).
-"""
-map!{F}(f::F, A::AbstractArray) = map!(f, A, A)
 function map!{F}(f::F, dest::AbstractArray, A::AbstractArray)
     for (i,j) in zip(eachindex(dest),eachindex(A))
         dest[i] = f(A[j])

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -413,16 +413,6 @@ size(itr::AsyncGenerator) = size(itr.collector.enumerator)
 length(itr::AsyncGenerator) = length(itr.collector.enumerator)
 
 """
-    asyncmap!(f, c; ntasks=0, batch_size=nothing)
-
-In-place version of [`asyncmap()`](@ref).
-"""
-function asyncmap!(f, c; ntasks=0, batch_size=nothing)
-    foreach(identity, AsyncCollector(f, c, c; ntasks=ntasks, batch_size=batch_size))
-    c
-end
-
-"""
     asyncmap!(f, results, c...; ntasks=0, batch_size=nothing)
 
 Like [`asyncmap()`](@ref), but stores output in `results` rather than

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1895,8 +1895,6 @@ map(::typeof(zero), A::BitArray) = fill!(similar(A), false)
 map(::typeof(one), A::BitArray) = fill!(similar(A), true)
 map(::typeof(identity), A::BitArray) = copy(A)
 
-map!(f, A::BitArray) = map!(f, A, A)
-map!(::typeof(identity), A::BitArray) = A
 map!(::Union{typeof(~), typeof(!)}, dest::BitArray, A::BitArray) = bit_map!(~, dest, A)
 map!(::typeof(zero), dest::BitArray, A::BitArray) = fill!(dest, false)
 map!(::typeof(one), dest::BitArray, A::BitArray) = fill!(dest, true)

--- a/base/client.jl
+++ b/base/client.jl
@@ -317,7 +317,8 @@ end
 function load_machine_file(path::AbstractString)
     machines = []
     for line in split(readstring(path),'\n'; keep=false)
-        s = map!(strip, split(line,'*'; keep=false))
+        s = split(line, '*'; keep = false)
+        map!(strip, s, s)
         if length(s) > 1
             cnt = isnumber(s[1]) ? parse(Int,s[1]) : Symbol(s[1])
             push!(machines,(s[2], cnt))

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1347,4 +1347,8 @@ function quadgk(args...)
 end
 export quadgk
 
+# Deprecate two-argument map! (map!(f, A)) for a cycle in anticipation of semantic change
+@deprecate map!{F}(f::F, A::AbstractArray) map!(f, A, A)
+@deprecate asyncmap!(f, c; ntasks=0, batch_size=nothing) asyncmap!(f, c, c; ntasks=ntasks, batch_size=batch_size)
+
 # End deprecations scheduled for 0.6

--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -11,7 +11,7 @@ function parserow(stream::IO)
         row = split(line, r"(?<!\\)\|")
         length(row) == 1 && return
         row[1] == "" && shift!(row)
-        map!(x -> strip(replace(x, "\\|", "|")), row)
+        map!(x -> strip(replace(x, "\\|", "|")), row, row)
         row[end] == "" && pop!(row)
         return row
     end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -646,10 +646,10 @@ function test_map(::Type{TestAbstractArray})
 
     # In-place map
     A = Float64[1:10...]
-    map!(x->x*x, A)
-    @test A == map(x->x*x, Float64[1:10...])
+    map!(x -> x*x, A, A)
+    @test A == map(x -> x*x, Float64[1:10...])
     B = Float64[1:10...]
-    Base.asyncmap!(x->x*x, B)
+    Base.asyncmap!(x->x*x, B, B)
     @test A == B
 
     # Map to destination collection

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -6,7 +6,7 @@
 @test isequal(map((x)->"$x"[end:end], 9:11), ["9", "0", "1"])
 # TODO: @test map!() much more thoroughly
 let a = [1.0, 2.0]
-    map!(sin, a)
+    map!(sin, a, a)
     @test isequal(a, sin.([1.0, 2.0]))
 end
 # map -- ranges.jl

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -443,7 +443,7 @@ d2 = map(x->1, d)
 @test reduce(+, d2) == 100
 
 @test reduce(+, d) == ((50*id_me) + (50*id_other))
-map!(x->1, d)
+map!(x->1, d, d)
 @test reduce(+, d) == 100
 
 @test fill!(d, 1) == ones(10, 10)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1330,9 +1330,9 @@ end
         Aposzeros = setindex!(copy(A), 2, poszerosinds)
         Anegzeros = setindex!(copy(A), -2, negzerosinds)
         Abothsigns = setindex!(copy(Aposzeros), -2, negzerosinds)
-        map!(x -> x == 2 ? 0.0 : x, Aposzeros.nzval)
-        map!(x -> x == -2 ? -0.0 : x, Anegzeros.nzval)
-        map!(x -> x == 2 ? 0.0 : x == -2 ? -0.0 : x, Abothsigns.nzval)
+        map!(x -> x == 2 ? 0.0 : x, Aposzeros.nzval, Aposzeros.nzval)
+        map!(x -> x == -2 ? -0.0 : x, Anegzeros.nzval, Anegzeros.nzval)
+        map!(x -> x == 2 ? 0.0 : x == -2 ? -0.0 : x, Abothsigns.nzval, Abothsigns.nzval)
         for Awithzeros in (Aposzeros, Anegzeros, Abothsigns)
             # Basic functionality / dropzeros!
             @test dropzeros!(copy(Awithzeros)) == A

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -1017,9 +1017,9 @@ let testdims = (10, 20, 30), nzprob = 0.4, targetnumposzeros = 5, targetnumnegze
         vposzeros = setindex!(copy(v), 2, poszerosinds)
         vnegzeros = setindex!(copy(v), -2, negzerosinds)
         vbothsigns = setindex!(copy(vposzeros), -2, negzerosinds)
-        map!(x -> x == 2 ? 0.0 : x, vposzeros.nzval)
-        map!(x -> x == -2 ? -0.0 : x, vnegzeros.nzval)
-        map!(x -> x == 2 ? 0.0 : x == -2 ? -0.0 : x, vbothsigns.nzval)
+        map!(x -> x == 2 ? 0.0 : x, vposzeros.nzval, vposzeros.nzval)
+        map!(x -> x == -2 ? -0.0 : x, vnegzeros.nzval, vnegzeros.nzval)
+        map!(x -> x == 2 ? 0.0 : x == -2 ? -0.0 : x, vbothsigns.nzval, vbothsigns.nzval)
         for vwithzeros in (vposzeros, vnegzeros, vbothsigns)
             # Basic functionality / dropzeros!
             @test dropzeros!(copy(vwithzeros)) == v


### PR DESCRIPTION
#12277 discusses the discrepancy between `map!(f, A)` `(= map!(f, A, A))` and `broadcast!(f, A)` `= (A <- [f() for a in A]`. Sentiment in #12277 leans towards `map!(f, A)` and `broadcast!(f, A)` having consistent semantics, specifically `broadcast!(f, A)`'s semantics for consistency with `map!`/`broadcast!` methods accepting more arguments.

As an experiment, this pull request deprecates `map!(f, A)` (and analog `asyncmap!(f, A)`) in favor of `map!(f, A, A)` (`asyncmap!(f, A, A)`) such that `map!(f, A)`'s (`asyncmap!(f, A)`'s) semantics can change in a future release without silent breakage.

Thoughts? Best!

(I expect the modification of `map!(f, A::SharedArray)` isn't quite correct. Someone with knowledge of `SharedArray`s should have a look at that.)