### PR TITLE
Make broadcast!(f, A) populate A via independent f() calls

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -78,7 +78,7 @@ Symbol(x...) = Symbol(string(x...))
 # specific array types etc.
 #  --Here, just define fallback routines for broadcasting with no arguments
 broadcast(f) = f()
-broadcast!(f, X::AbstractArray) = fill!(X, f())
+broadcast!(f, X::AbstractArray) = (@inbounds for I in eachindex(X); X[I] = f(); end; X)
 
 # array structures
 include("array.jl")

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -373,3 +373,6 @@ end
 @test (+).(Ref(1), Ref(2)) == fill(3)
 @test (+).([[0,2], [1,3]], [1,-1]) == [[1,3], [0,2]]
 @test (+).([[0,2], [1,3]], Ref{Vector{Int}}([1,-1])) == [[1,1], [2,2]]
+
+# Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722).
+@test let z = 1; A = broadcast!(() -> z += 1, zeros(2)); A[1] != A[2]; end


### PR DESCRIPTION
`broadcast!(f, A)` presently yields `fill!(A, f())`. #12277 discusses making `broadcast!(f, A)` instead populate `A` via independent `f()` calls. This pull request realizes that change. Best!