### PR TITLE
Simplify and extend broadcast eltype promotion mechanism

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -231,15 +231,13 @@ end
 promote_op(::Any...) = (@_pure_meta; Any)
 function promote_op{S}(f, ::Type{S})
     @_inline_meta
-    Z = Tuple{_default_type(S)}
-    T = _default_eltype(Generator{Z, typeof(f)})
+    T = _return_type(f, Tuple{_default_type(S)})
     isleaftype(S) && return isleaftype(T) ? T : Any
     return typejoin(S, T)
 end
 function promote_op{R,S}(f, ::Type{R}, ::Type{S})
     @_inline_meta
-    Z = Iterators.Zip2{Tuple{_default_type(R)}, Tuple{_default_type(S)}}
-    T = _default_eltype(Generator{Z, typeof(a -> f(a...))})
+    T = _return_type(f, Tuple{_default_type(R), _default_type(S)})
     isleaftype(R) && isleaftype(S) && return isleaftype(T) ? T : Any
     return typejoin(R, S, T)
 end

--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -73,7 +73,7 @@ function _noshapecheck_map{Tf,N}(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseVecO
     fofzeros = f(_zeros_eltypes(A, Bs...)...)
     fpreszeros = _iszero(fofzeros)
     maxnnzC = fpreszeros ? min(length(A), _sumnnzs(A, Bs...)) : length(A)
-    entrytypeC = Base.Broadcast._broadcast_type(f, A, Bs...)
+    entrytypeC = Base.Broadcast._broadcast_eltype(f, A, Bs...)
     indextypeC = _promote_indtype(A, Bs...)
     C = _allocres(size(A), indextypeC, entrytypeC, maxnnzC)
     return fpreszeros ? _map_zeropres!(f, C, A, Bs...) :
@@ -101,7 +101,7 @@ function _diffshape_broadcast{Tf,N}(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseV
     fofzeros = f(_zeros_eltypes(A, Bs...)...)
     fpreszeros = _iszero(fofzeros)
     indextypeC = _promote_indtype(A, Bs...)
-    entrytypeC = Base.Broadcast._broadcast_type(f, A, Bs...)
+    entrytypeC = Base.Broadcast._broadcast_eltype(f, A, Bs...)
     shapeC = to_shape(Base.Broadcast.broadcast_indices(A, Bs...))
     maxnnzC = fpreszeros ? _checked_maxnnzbcres(shapeC, A, Bs...) : _densennz(shapeC)
     C = _allocres(shapeC, indextypeC, entrytypeC, maxnnzC)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -363,7 +363,7 @@ StrangeType18623(x,y) = (x,y)
 let
     f(A, n) = broadcast(x -> +(x, n), A)
     @test @inferred(f([1.0], 1)) == [2.0]
-    g() = (a = 1; Base.Broadcast._broadcast_type(x -> x + a, 1.0))
+    g() = (a = 1; Base.Broadcast._broadcast_eltype(x -> x + a, 1.0))
     @test @inferred(g()) === Float64
 end
 
@@ -417,4 +417,10 @@ end
 let io = IOBuffer()
     broadcast(x -> print(io, x), [Nullable(1.0)])
     @test String(take!(io)) == "Nullable{Float64}(1.0)"
+end
+
+# Test that broadcast's promotion mechanism handles closures accepting more than one argument.
+# (See issue #19641 and referenced issues and pull requests.)
+let f() = (a = 1; Base.Broadcast._broadcast_eltype((x, y) -> x + y + a, 1.0, 1.0))
+    @test @inferred(f()) == Float64
 end


### PR DESCRIPTION
(Requires #19667.) This pull request restores the simplification of `broadcast`'s eltype promotion mechanism in #19421. With benefit of #19667 (thanks `@yuyichao`!), that simplification handles more cases (e.g. closures accepting more than two arguments) than the present mechanism (`_default_eltype`-`first`-`Generator`-`zip`). This pull request also gives `broadcast`'s eltype promotion mechanism a more precise name (`_broadcast_type` -> `_broadcast_eltype`). Best!
