### PR TITLE
expr.jl: Doc for inline and inbounds

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -148,6 +148,26 @@ macro boundscheck(blk)
       $(Expr(:boundscheck,:pop)))
 end
 
+"""
+    @inbounds(blk)
+
+Eliminates array bounds checking within expressions.
+
+In the example below the bound check of array A is skipped to improve performance.
+```julia
+function sum(A::AbstractArray)
+    r = zero(eltype(A))
+    for i = 1:length(A)
+        @inbounds r += A[i]
+    end
+    return r
+end
+```
+!!! Warning
+
+    Using `@inbounds` may return incorrect results/crashes/corruption
+    for out-of-bounds indices. The user is responsible for checking it manually.
+"""
 macro inbounds(blk)
     :($(Expr(:inbounds,true));
       $(esc(blk));

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -118,10 +118,43 @@ macro eval(x)
     :($(esc(:eval))($(Expr(:quote,x))))
 end
 
+"""
+    @inline
+
+Give a hint to the compiler that this function is worth inlining.
+
+Small functions typically do not need the `@inline` annotation,
+as the compiler does it automatically. By using `@inline` on bigger functions,
+an extra nudge can be given to the compiler to inline it.
+This is shown in the following example:
+```julia
+@inline function bigfunction(x)
+    #=
+        Function Definition
+    =#
+end
+```
+"""
 macro inline(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :inline) : ex)
 end
 
+"""
+    @noinline
+
+Prevents the compiler from inlining a function.
+
+Small functions are typically inlined automatically.
+By using `@noinline` on small functions, auto-inlining can be
+prevented. This is shown in the following example:
+```julia
+@noinline function smallfunction(x)
+    #=
+        Function Definition
+    =#
+end
+```
+"""
 macro noinline(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :noinline) : ex)
 end

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -131,6 +131,9 @@ Core.eval
 Base.@eval
 Base.evalfile
 Base.esc
+Base.@inbounds
+Base.@inline
+Base.@noinline
 Base.gensym
 Base.@gensym
 Base.@polly


### PR DESCRIPTION
The documents were added for `@inline` and `@inbounds`

Closes #19276 