### PR TITLE
RFC: Speedier, simpler and more systematic index conversions

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1171,7 +1171,6 @@ function cat_t(dims, T::Type, X...)
 end
 
 function _cat{N}(A, shape::NTuple{N}, catdims, X...)
-    N = length(shape)
     offsets = zeros(Int, N)
     inds = Vector{UnitRange{Int}}(N)
     concat = copy!(zeros(Bool, N), catdims)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1170,7 +1170,7 @@ function cat_t(dims, T::Type, X...)
     return _cat(A, shape, catdims, X...)
 end
 
-function _cat(A, shape, catdims, X...)
+function _cat{N}(A, shape::NTuple{N}, catdims, X...)
     N = length(shape)
     offsets = zeros(Int, N)
     inds = Vector{UnitRange{Int}}(N)
@@ -1184,7 +1184,8 @@ function _cat(A, shape, catdims, X...)
                 inds[i] = 1:shape[i]
             end
         end
-        A[inds...] = x
+        I::NTuple{N, UnitRange{Int}} = (inds...,)
+        A[I...] = x
     end
     return A
 end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1170,23 +1170,29 @@ function cat_t(dims, T::Type, X...)
     return _cat(A, shape, catdims, X...)
 end
 
+_cat_inds(i, x, ::Tuple{}, offsets, concat) = ()
+@inline function _cat_inds(i, x, shape, offsets, concat)
+    if concat[i]
+        val = offsets[i] + cat_indices(x, i)
+        offsets[i] += cat_size(x, i)
+    else
+        val = 1:shape[1]
+    end
+    return (val, _cat_inds(i+1, x, tail(shape), offsets, concat)...)
+end
+
 function _cat(A, shape, catdims, X...)
     N = length(shape)
     offsets = zeros(Int, N)
-    inds = Vector{UnitRange{Int}}(N)
     concat = copy!(zeros(Bool, N), catdims)
-    for x in X
-        for i = 1:N
-            if concat[i]
-                inds[i] = offsets[i] + cat_indices(x, i)
-                offsets[i] += cat_size(x, i)
-            else
-                inds[i] = 1:shape[i]
-            end
-        end
-        A[inds...] = x
-    end
-    return A
+    return _catloop(A, shape, offsets, concat, X...)
+end
+
+_catloop{N}(A, shape::NTuple{N}, offsets, concat) = A
+function _catloop{N}(A, shape::NTuple{N}, offsets, concat, x, X...)
+    I = _cat_inds(1, x, shape, offsets, concat)
+    A[I...] = x
+    return _catloop(A, shape, offsets, concat, X...)
 end
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -7,7 +7,7 @@
 typealias AbstractVector{T} AbstractArray{T,1}
 typealias AbstractMatrix{T} AbstractArray{T,2}
 typealias AbstractVecOrMat{T} Union{AbstractVector{T}, AbstractMatrix{T}}
-typealias RangeIndex Union{Int, Range{Int}, AbstractUnitRange{Int}, Colon}
+typealias RangeIndex Union{Int, Range{Int}, AbstractUnitRange{Int}}
 typealias DimOrInd Union{Integer, AbstractUnitRange}
 typealias IntOrInd Union{Int, AbstractUnitRange}
 typealias DimsOrInds{N} NTuple{N,DimOrInd}
@@ -448,8 +448,8 @@ done(a::Array,i) = (@_inline_meta; i == length(a)+1)
 ## Indexing: getindex ##
 
 # This is more complicated than it needs to be in order to get Win64 through bootstrap
-getindex(A::Array, i1::Real) = arrayref(A, to_index(i1))
-getindex(A::Array, i1::Real, i2::Real, I::Real...) = (@_inline_meta; arrayref(A, to_index(i1), to_index(i2), to_indexes(I...)...)) # TODO: REMOVE FOR #14770
+getindex(A::Array, i1::Int) = arrayref(A, i1)
+getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayref(A, i1, i2, I...)) # TODO: REMOVE FOR #14770
 
 # Faster contiguous indexing using copy! for UnitRange and Colon
 function getindex(A::Array, I::UnitRange{Int})
@@ -472,13 +472,13 @@ function getindex(A::Array, c::Colon)
 end
 
 # This is redundant with the abstract fallbacks, but needed for bootstrap
-function getindex{S,T<:Real}(A::Array{S}, I::Range{T})
-    return S[ A[to_index(i)] for i in I ]
+function getindex{S}(A::Array{S}, I::Range{Int})
+    return S[ A[i] for i in I ]
 end
 
 ## Indexing: setindex! ##
-setindex!{T}(A::Array{T}, x, i1::Real) = arrayset(A, convert(T,x)::T, to_index(i1))
-setindex!{T}(A::Array{T}, x, i1::Real, i2::Real, I::Real...) = (@_inline_meta; arrayset(A, convert(T,x)::T, to_index(i1), to_index(i2), to_indexes(I...)...)) # TODO: REMOVE FOR #14770
+setindex!{T}(A::Array{T}, x, i1::Int) = arrayset(A, convert(T,x)::T, i1)
+setindex!{T}(A::Array{T}, x, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayset(A, convert(T,x)::T, i1, i2, I...)) # TODO: REMOVE FOR #14770
 
 # These are redundant with the abstract fallbacks but needed for bootstrap
 function setindex!(A::Array, x, I::AbstractVector{Int})
@@ -1313,7 +1313,7 @@ function find(testf::Function, A)
     return I
 end
 _index_remapper(A::AbstractArray) = linearindices(A)
-_index_remapper(iter) = Colon()  # safe for objects that don't implement length
+_index_remapper(iter) = OneTo(typemax(Int))  # safe for objects that don't implement length
 
 """
     find(A)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1125,6 +1125,39 @@ eval(Base.Dates, quote
      recur{T<:TimeType}(fun::Function, start::T, stop::T; step::Period=Day(1), negate::Bool=false, limit::Int=10000) = recur(fun, start:step:stop; negate=negate)
 end)
 
+# Index conversions revamp; #19730
+function getindex(A::LogicalIndex, i::Int)
+    depwarn("indexing into logical indices is deprecated; use iteration or collect the indices into an array instead.", :getindex)
+    checkbounds(A, i)
+    first(Iterators.drop(A, i-1))
+end
+function to_indexes(I...)
+    depwarn("to_indexes is deprecated; pass both the source array and tuple of indices to `to_indices(A, I)` instead.", :to_indexes)
+    map(_to_index, I)
+end
+_to_index(i) = to_index(I)
+_to_index(c::Colon) = c
+function getindex(::Colon, i)
+    depwarn("indexing into Colons is deprecated; convert Colons to Slices with to_indices", :getindex)
+    to_index(i)
+end
+function unsafe_getindex(::Colon, i::Integer)
+    depwarn("indexing into Colons is deprecated; convert Colons to Slices with to_indices", :unsafe_getindex)
+    to_index(i)
+end
+function step(::Colon)
+    depwarn("step(::Colon) is deprecated; convert Colons to Slices with to_indices", :step)
+    1
+end
+function isempty(::Colon)
+    depwarn("isempty(::Colon) is deprecated; convert Colons to Slices with to_indices", :isempty)
+    false
+end
+function in(::Integer, ::Colon)
+    depwarn("in(::Integer, ::Colon) is deprecated; convert Colons to Slices with to_indices", :in)
+    true
+end
+
 # #18931
 @deprecate cummin(A, dim=1) accumulate(min, A, dim)
 @deprecate cummax(A, dim=1) accumulate(max, A, dim)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1127,34 +1127,35 @@ end)
 
 # Index conversions revamp; #19730
 function getindex(A::LogicalIndex, i::Int)
-    depwarn("indexing into logical indices is deprecated; use iteration or collect the indices into an array instead.", :getindex)
+    depwarn("getindex(A::LogicalIndex, i) is deprecated; use iteration or index into the result of `collect(A)` instead.", :getindex)
     checkbounds(A, i)
     first(Iterators.drop(A, i-1))
 end
 function to_indexes(I...)
-    depwarn("to_indexes is deprecated; pass both the source array and tuple of indices to `to_indices(A, I)` instead.", :to_indexes)
+    depwarn("to_indexes is deprecated; pass both the source array `A` and indices as `to_indices(A, $(I...))` instead.", :to_indexes)
     map(_to_index, I)
 end
 _to_index(i) = to_index(I)
 _to_index(c::Colon) = c
+const _colon_usage_msg = "convert Colons to a set of indices for indexing into array `A` by passing them in a complete tuple of indices `I` to `to_indices(A, I)`"
 function getindex(::Colon, i)
-    depwarn("indexing into Colons is deprecated; convert Colons to Slices with to_indices", :getindex)
+    depwarn("getindex(::Colon, i) is deprecated; $_colon_usage_msg", :getindex)
     to_index(i)
 end
 function unsafe_getindex(::Colon, i::Integer)
-    depwarn("indexing into Colons is deprecated; convert Colons to Slices with to_indices", :unsafe_getindex)
+    depwarn("getindex(::Colon, i) is deprecated; $_colon_usage_msg", :unsafe_getindex)
     to_index(i)
 end
 function step(::Colon)
-    depwarn("step(::Colon) is deprecated; convert Colons to Slices with to_indices", :step)
+    depwarn("step(::Colon) is deprecated; $_colon_usage_msg", :step)
     1
 end
 function isempty(::Colon)
-    depwarn("isempty(::Colon) is deprecated; convert Colons to Slices with to_indices", :isempty)
+    depwarn("isempty(::Colon) is deprecated; $_colon_usage_msg", :isempty)
     false
 end
 function in(::Integer, ::Colon)
-    depwarn("in(::Integer, ::Colon) is deprecated; convert Colons to Slices with to_indices", :in)
+    depwarn("in(::Integer, ::Colon) is deprecated; $_colon_usage_msg", :in)
     true
 end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -229,13 +229,14 @@ function isassigned(v::SimpleVector, i::Int)
     return x != C_NULL
 end
 
-# index colon
 """
     Colon()
 
 Colons (:) are used to signify indexing entire objects or dimensions at once.
+
 Very few operations are defined on Colons directly; instead they are converted
-to `Slice`s upon indexing (within `to_indices`).
+by `to_indices` to an internal vector type (`Base.Slice`) to represent the
+collection of indices they span before being used.
 """
 immutable Colon
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -230,6 +230,13 @@ function isassigned(v::SimpleVector, i::Int)
 end
 
 # index colon
+"""
+    Colon()
+
+Colons (:) are used to signify indexing entire objects or dimensions at once.
+Very few operations are defined on Colons directly; instead they are converted
+to `Slice`s upon indexing (within `to_indices`).
+"""
 immutable Colon
 end
 const (:) = Colon()

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -578,6 +578,7 @@ export
     sum!,
     sum,
     sum_kbn,
+    to_indices,
     vcat,
     vec,
     view,

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -173,6 +173,14 @@ using .IteratorsMD
 @inline checkbounds_indices(::Type{Bool}, IA::Tuple, I::Tuple{CartesianIndex,Vararg{Any}}) =
     checkbounds_indices(Bool, IA, (I[1].I..., tail(I)...))
 
+# Indexing into Array with mixtures of Integers and CartesianIndices is
+# extremely performance-sensitive. While the abstract fallbacks support this,
+# codegen has extra support for SIMDification that sub2ind doesn't (yet) support
+@propagate_inbounds getindex(A::Array, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...) =
+    A[to_indices(A, (i1, I...))...]
+@propagate_inbounds setindex!(A::Array, v, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...) =
+    (A[to_indices(A, (i1, I...))...] = v; A)
+
 # Support indexing with an array of CartesianIndex{N}s
 # Here we try to consume N of the indices (if there are that many available)
 # The first two simply handle ambiguities

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -295,7 +295,7 @@ checkbounds(::Type{Bool}, A::AbstractArray, I::LogicalIndex) = checkbounds(Bool,
 checkindex(::Type{Bool}, indx::AbstractUnitRange, I::LogicalIndex) = checkindex(Bool, indx, I.mask)
 ensure_indexable(I::Tuple{}) = ()
 ensure_indexable(I::Tuple{Any, Vararg{Any}}) = (I[1], ensure_indexable(tail(I))...)
-ensure_indexable(I::Tuple{LogicalIndex, Vararg{Any}}) = (collect(I), ensure_indexable(tail(I))...)
+ensure_indexable(I::Tuple{LogicalIndex, Vararg{Any}}) = (collect(I[1]), ensure_indexable(tail(I))...)
 
 # In simple cases, we know that we don't need to use indices(A). Optimize those
 # until Julia gets smart enough to elide the call on its own:

--- a/base/number.jl
+++ b/base/number.jl
@@ -46,7 +46,6 @@ function getindex(x::Number, I::Integer...)
     @boundscheck all([i == 1 for i in I]) || throw(BoundsError())
     x
 end
-getindex(x::Number, I::Real...) = getindex(x, to_indexes(I...)...)
 first(x::Number) = x
 last(x::Number) = x
 copy(x::Number) = x  # some code treats numbers as collection-like

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -872,7 +872,7 @@ setindex_shape_check(X, I...) = nothing # Non-arrays broadcast to all idxs
 """
     to_index(A, i)
 
-Convert index `i` for use into indexing into array `A`. Custom array types
+Convert index `i` for use in indexing into array `A`. Custom array types
 should specialize `to_index(::CustomArray, i)` to provide special indexing
 behaviors. Note that some index types (like `Colon`) require more context in
 order to transform them into an array of indices; those get converted in the
@@ -909,7 +909,7 @@ For simple index types, this simply ends up calling `to_index(A, i)` for each
 index `i`. More complicated index types, however, require more context about
 the dimension into which they index. To support those cases, `to_indices(A, I)`
 calls `to_indices(A, indices(A), I)`, which then recursively walks through both
-the given tuple of indices and the indices in `A` in tandem.
+the given tuple of indices and the dimensional indices of `A` in tandem.
 """
 to_indices(A, I::Tuple) = (@_inline_meta; to_indices(A, indices(A), I))
 to_indices(A, inds, ::Tuple{}) = ()

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -868,19 +868,83 @@ function setindex_shape_check{T}(X::AbstractArray{T,2}, i::Integer, j::Integer)
 end
 setindex_shape_check(X, I...) = nothing # Non-arrays broadcast to all idxs
 
-# convert to a supported index type (Array, Colon, or Int)
-to_index(i::Int) = i
+# convert to a supported index type (array or Int)
+"""
+    to_index(A, i)
+
+Convert index `i` for use into indexing into array `A`. Custom array types
+should specialize `to_index(::CustomArray, i)` to provide special indexing
+behaviors. Note that some index types (like `Colon`) require more context in
+order to transform them into an array of indices; those get converted in the
+more complicated `to_indices` function. By default, this simply calls the
+generic `to_index(i)`.
+"""
+to_index(A, i) = to_index(i)
+
+"""
+    to_index(i)
+
+Convert index `i` to an `Int` or array of indices to be used as an index for all
+arrays.  Custom index types should specialize `to_index(::CustomIndex)` to
+provide special indexing behaviors.
+"""
 to_index(i::Integer) = convert(Int,i)::Int
-to_index(c::Colon) = c
-to_index(I::AbstractArray{Bool}) = find(I)
-to_index(A::AbstractArray) = A
-to_index{T<:AbstractArray}(A::AbstractArray{T}) = throw(ArgumentError("invalid index: $A"))
-to_index(A::AbstractArray{Colon}) = throw(ArgumentError("invalid index: $A"))
+to_index(I::AbstractArray{Bool}) = LogicalIndex(I)
+to_index(I::AbstractArray) = I
+to_index{T<:Union{AbstractArray, Colon}}(I::AbstractArray{T}) = throw(ArgumentError("invalid index: $I"))
+to_index(::Colon) = throw(ArgumentError("colons must be converted by to_indices(...)"))
 to_index(i) = throw(ArgumentError("invalid index: $i"))
 
-to_indexes() = ()
-to_indexes(i1) = (to_index(i1),)
-to_indexes(i1, I...) = (@_inline_meta; (to_index(i1), to_indexes(I...)...))
+# The general to_indices is mostly defined in multidimensional.jl, but this
+# definition is required for bootstrap:
+"""
+    to_indices(A, I::Tuple)
+
+Convert a tuple of indices `I` for use in indexing into array `A`, where the
+returned indices are either `Int`s or `AbstractArray`s of `Int` or
+`CartesianIndex`. This function accepts any index types and must return a tuple
+containing `Int`s and `AbstractArray`s.
+
+For simple index types, this simply ends up calling `to_index(A, i)` for each
+index `i`. More complicated index types, however, require more context about
+the dimension into which they index. To support those cases, `to_indices(A, I)`
+calls `to_indices(A, indices(A), I)`, which then recursively walks through both
+the given tuple of indices and the indices in `A` in tandem.
+"""
+to_indices(A, I::Tuple) = (@_inline_meta; to_indices(A, indices(A), I))
+to_indices(A, inds, ::Tuple{}) = ()
+to_indices(A, inds, I::Tuple{Any, Vararg{Any}}) =
+    (@_inline_meta; (to_index(A, I[1]), to_indices(A, _maybetail(inds), tail(I))...))
+
+_maybetail(::Tuple{}) = ()
+_maybetail(t::Tuple) = tail(t)
+
+"""
+   Slice(indices)
+
+Upon calling to_indices(), colons are converted to Slice objects that wrap the
+indices over which the colon spans. Slice objects are themselves unit ranges
+with the same indices as those they wrap. This means that indexing into
+a Slice object with an integer always returns that exact integer, but they
+iterate over all indices in the array, even supporting OffsetArrays.
+"""
+immutable Slice{T<:AbstractUnitRange} <: AbstractUnitRange{Int}
+    indices::T
+end
+indices(S::Slice) = (S.indices,)
+unsafe_indices(S::Slice) = (S.indices,)
+indices1(S::Slice) = S.indices
+first(S::Slice) = first(S.indices)
+last(S::Slice) = last(S.indices)
+errmsg(A) = error("size not supported for arrays with indices $(indices(A)); see http://docs.julialang.org/en/latest/devdocs/offset-arrays/")
+size(S::Slice) = first(S.indices) == 1 ? (length(S.indices),) : errmsg(S)
+length(S::Slice) = first(S.indices) == 1 ? length(S.indices) : errmsg(S)
+unsafe_length(S::Slice) = first(S.indices) == 1 ? unsafe_length(S.indices) : errmsg(S)
+getindex(S::Slice, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
+show(io::IO, r::Slice) = print(io, "Base.Slice(", r.indices, ")")
+start(S::Slice) = start(S.indices)
+next(S::Slice, s) = next(S.indices, s)
+done(S::Slice, s) = done(S.indices, s)
 
 # Addition/subtraction of ranges
 for f in (:+, :-)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -4,7 +4,7 @@ module Serializer
 
 import Base: GMP, Bottom, unsafe_convert, uncompressed_ast, datatype_pointerfree
 import Core: svec
-using Base: ViewIndex, index_lengths
+using Base: ViewIndex, Slice, index_lengths
 
 export serialize, deserialize, SerializationState
 
@@ -233,7 +233,7 @@ function trimmedsubarray{T,N,A<:Array}(V::SubArray{T,N,A})
     _trimmedsubarray(dest, V, (), V.indexes...)
 end
 
-trimmedsize(V) = index_lengths(V.parent, V.indexes...)
+trimmedsize(V) = index_lengths(V.indexes...)
 
 function _trimmedsubarray{T,N,P,I,LD}(A, V::SubArray{T,N,P,I,LD}, newindexes)
     LD && return SubArray{T,N,P,I,LD}(A, newindexes, Base.compute_offset1(A, 1, newindexes), 1)
@@ -243,6 +243,7 @@ _trimmedsubarray(A, V, newindexes, index::ViewIndex, indexes...) = _trimmedsubar
 
 trimmedindex(P, d, i::Real) = oftype(i, 1)
 trimmedindex(P, d, i::Colon) = i
+trimmedindex(P, d, i::Slice) = i
 trimmedindex(P, d, i::AbstractArray) = oftype(i, reshape(linearindices(i), indices(i)))
 
 function serialize{T<:AbstractString}(s::AbstractSerializer, ss::SubString{T})

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -8,7 +8,9 @@ import
     Base.sort,
     Base.sort!,
     Base.issorted,
-    Base.sortperm
+    Base.sortperm,
+    Base.Slice,
+    Base.to_indices
 
 export # also exported by Base
     # order-only:
@@ -669,11 +671,11 @@ function sortcols(A::AbstractMatrix; kws...)
 end
 
 function slicetypeof{T,N}(A::AbstractArray{T,N}, i1, i2)
-    I = (slice_dummy(i1),slice_dummy(i2))
+    I = map(slice_dummy, to_indices(A, (i1, i2)))
     fast = isa(linearindexing(viewindexing(I), linearindexing(A)), LinearFast)
     SubArray{T,1,typeof(A),typeof(I),fast}
 end
-slice_dummy(::Colon) = Colon()
+slice_dummy(S::Slice) = S
 slice_dummy{T}(::AbstractUnitRange{T}) = one(T)
 
 ## fast clever sorting for floats ##

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -1,9 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 abstract AbstractCartesianIndex{N} # This is a hacky forward declaration for CartesianIndex
-typealias NonSliceIndex Union{Colon, AbstractArray}
-typealias ViewIndex Union{Real, NonSliceIndex}
-typealias ScalarIndex Union{Real, AbstractCartesianIndex}
+typealias ViewIndex Union{Real, AbstractArray}
+typealias ScalarIndex Real
 
 # L is true if the view itself supports fast linear indexing
 immutable SubArray{T,N,P,I,L} <: AbstractArray{T,N}
@@ -14,7 +13,7 @@ immutable SubArray{T,N,P,I,L} <: AbstractArray{T,N}
     function SubArray(parent, indexes, offset1, stride1)
         @_inline_meta
         check_parent_index_match(parent, indexes)
-        new(parent, indexes, offset1, stride1)
+        new(parent, ensure_indexable(indexes), offset1, stride1)
     end
 end
 # Compute the linear indexability of the indices, and combine it with the linear indexing of the parent
@@ -42,12 +41,12 @@ check_parent_index_match{N}(parent, ::NTuple{N, Bool}) =
 viewindexing() = LinearFast()
 # Leading scalar indexes simply increase the stride
 viewindexing(I::Tuple{ScalarIndex, Vararg{Any}}) = (@_inline_meta; viewindexing(tail(I)))
-# Colons may begin a section which may be followed by any number of Colons
-viewindexing(I::Tuple{Colon, Colon, Vararg{Any}}) = (@_inline_meta; viewindexing(tail(I)))
-# A UnitRange can follow Colons, but only if all other indices are scalar
-viewindexing(I::Tuple{Colon, UnitRange, Vararg{ScalarIndex}}) = LinearFast()
+# Slices may begin a section which may be followed by any number of Slices
+viewindexing(I::Tuple{Slice, Slice, Vararg{Any}}) = (@_inline_meta; viewindexing(tail(I)))
+# A UnitRange can follow Slices, but only if all other indices are scalar
+viewindexing(I::Tuple{Slice, UnitRange, Vararg{ScalarIndex}}) = LinearFast()
 # In general, ranges are only fast if all other indices are scalar
-viewindexing(I::Tuple{Union{Range, Colon}, Vararg{ScalarIndex}}) = LinearFast()
+viewindexing(I::Tuple{Union{Range, Slice}, Vararg{ScalarIndex}}) = LinearFast()
 # All other index combinations are slow
 viewindexing(I::Tuple{Vararg{Any}}) = LinearSlow()
 # Of course, all other array types are slow
@@ -85,18 +84,16 @@ given indices instead of making a copy.  Calling [`getindex`](@ref) or
 [`setindex!`](@ref) on the returned `SubArray` computes the
 indices to the parent array on the fly without checking bounds.
 """
-function view(A::AbstractArray, I::ViewIndex...)
+function view(A::AbstractArray, I...)
     @_inline_meta
-    @boundscheck checkbounds(A, I...)
-    unsafe_view(_maybe_reshape_parent(A, index_ndims(I...)), I...)
+    J = to_indices(A, I)
+    @boundscheck checkbounds(A, J...)
+    unsafe_view(_maybe_reshape_parent(A, index_ndims(J...)), J...)
 end
-# But we can simply flatten scalar `CartesianIndex`s first to make life easier
-view(A::AbstractArray, I::Union{ViewIndex, AbstractCartesianIndex}...) = view(A, IteratorsMD.flatten(I)...)
 
 function unsafe_view(A::AbstractArray, I::ViewIndex...)
     @_inline_meta
-    J = to_indexes(I...)
-    SubArray(A, J)
+    SubArray(A, I)
 end
 # When we take the view of a view, it's often possible to "reindex" the parent
 # view's indices such that we can "pop" the parent view and keep just one layer
@@ -104,7 +101,7 @@ end
 # might span multiple parent indices, making the reindex calculation very hard.
 # So we use _maybe_reindex to figure out if there are any arrays of
 # `CartesianIndex`, and if so, we punt and keep two layers of indirection.
-unsafe_view(V::SubArray, I::ViewIndex...) = (@_inline_meta; _maybe_reindex(V, to_indexes(I...)))
+unsafe_view(V::SubArray, I::ViewIndex...) = (@_inline_meta; _maybe_reindex(V, I))
 _maybe_reindex(V, I) = (@_inline_meta; _maybe_reindex(V, I, I))
 _maybe_reindex{C<:AbstractCartesianIndex}(V, I, ::Tuple{AbstractArray{C}, Vararg{Any}}) =
     (@_inline_meta; SubArray(V, I))
@@ -114,7 +111,7 @@ _maybe_reindex{C<:AbstractCartesianIndex{1}}(V, I, A::Tuple{AbstractArray{C}, Va
 _maybe_reindex(V, I, A::Tuple{Any, Vararg{Any}}) = (@_inline_meta; _maybe_reindex(V, I, tail(A)))
 function _maybe_reindex(V, I, ::Tuple{})
     @_inline_meta
-    idxs = reindex(V, V.indexes, to_indexes(I...))
+    idxs = to_indices(V.parent, reindex(V, V.indexes, I))
     SubArray(V.parent, idxs)
 end
 
@@ -134,8 +131,8 @@ reindex(V, ::Tuple{}, ::Tuple{}) = ()
 reindex(V, idxs::Tuple{ScalarIndex, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) =
     (@_propagate_inbounds_meta; (idxs[1], reindex(V, tail(idxs), subidxs)...))
 
-# Colons simply pass their subindexes straight through
-reindex(V, idxs::Tuple{Colon, Vararg{Any}}, subidxs::Tuple{Any, Vararg{Any}}) =
+# Slices simply pass their subindexes straight through
+reindex(V, idxs::Tuple{Slice, Vararg{Any}}, subidxs::Tuple{Any, Vararg{Any}}) =
     (@_propagate_inbounds_meta; (subidxs[1], reindex(V, tail(idxs), tail(subidxs))...))
 
 # Re-index into parent vectors with one subindex
@@ -159,57 +156,50 @@ end
 
 # In general, we simply re-index the parent indices by the provided ones
 typealias SlowSubArray{T,N,P,I} SubArray{T,N,P,I,false}
-function getindex{T,N}(V::SlowSubArray{T,N}, I::Vararg{Real,N})
+function getindex{T,N}(V::SlowSubArray{T,N}, I::Vararg{Int,N})
     @_inline_meta
     @boundscheck checkbounds(V, I...)
-    @inbounds r = V.parent[reindex(V, V.indexes, to_indexes(I...))...]
+    @inbounds r = V.parent[reindex(V, V.indexes, I)...]
     r
 end
 
 typealias FastSubArray{T,N,P,I} SubArray{T,N,P,I,true}
-function getindex(V::FastSubArray, i::Real)
+function getindex(V::FastSubArray, i::Int)
     @_inline_meta
     @boundscheck checkbounds(V, i)
-    @inbounds r = V.parent[V.offset1 + V.stride1*to_index(i)]
+    @inbounds r = V.parent[V.offset1 + V.stride1*i]
     r
 end
 # We can avoid a multiplication if the first parent index is a Colon or UnitRange
-typealias FastContiguousSubArray{T,N,P,I<:Tuple{Union{Colon, UnitRange}, Vararg{Any}}} SubArray{T,N,P,I,true}
-function getindex(V::FastContiguousSubArray, i::Real)
+typealias FastContiguousSubArray{T,N,P,I<:Tuple{Union{Slice, UnitRange}, Vararg{Any}}} SubArray{T,N,P,I,true}
+function getindex(V::FastContiguousSubArray, i::Int)
     @_inline_meta
     @boundscheck checkbounds(V, i)
-    @inbounds r = V.parent[V.offset1 + to_index(i)]
+    @inbounds r = V.parent[V.offset1 + i]
     r
 end
 
-function setindex!{T,N}(V::SlowSubArray{T,N}, x, I::Vararg{Real,N})
+function setindex!{T,N}(V::SlowSubArray{T,N}, x, I::Vararg{Int,N})
     @_inline_meta
     @boundscheck checkbounds(V, I...)
-    @inbounds V.parent[reindex(V, V.indexes, to_indexes(I...))...] = x
+    @inbounds V.parent[reindex(V, V.indexes, I)...] = x
     V
 end
-function setindex!(V::FastSubArray, x, i::Real)
+function setindex!(V::FastSubArray, x, i::Int)
     @_inline_meta
     @boundscheck checkbounds(V, i)
-    @inbounds V.parent[V.offset1 + V.stride1*to_index(i)] = x
+    @inbounds V.parent[V.offset1 + V.stride1*i] = x
     V
 end
-function setindex!(V::FastContiguousSubArray, x, i::Real)
+function setindex!(V::FastContiguousSubArray, x, i::Int)
     @_inline_meta
     @boundscheck checkbounds(V, i)
-    @inbounds V.parent[V.offset1 + to_index(i)] = x
+    @inbounds V.parent[V.offset1 + i] = x
     V
 end
 
 linearindexing{T<:FastSubArray}(::Type{T}) = LinearFast()
 linearindexing{T<:SubArray}(::Type{T}) = LinearSlow()
-
-getindex(::Colon, i) = to_index(i)
-unsafe_getindex(::Colon, i) = to_index(i)
-
-step(::Colon) = 1
-isempty(::Colon) = false
-in(::Integer, ::Colon) = true
 
 # Strides are the distance between adjacent elements in a given dimension,
 # so they are well-defined even for non-linear memory layouts
@@ -217,9 +207,8 @@ strides{T,N,P,I}(V::SubArray{T,N,P,I}) = substrides(V.parent, V.indexes)
 
 substrides(parent, I::Tuple) = substrides(1, parent, 1, I)
 substrides(s, parent, dim, ::Tuple{}) = ()
-substrides(s, parent, dim, I::Tuple{Real, Vararg{Any}}) = (substrides(s*size(parent, dim), parent, dim+1, tail(I))...)
-substrides(s, parent, dim, I::Tuple{AbstractCartesianIndex, Vararg{Any}}) = substrides(s, parent, dim, (I[1].I..., tail(I)...))
-substrides(s, parent, dim, I::Tuple{Colon, Vararg{Any}}) = (s, substrides(s*size(parent, dim), parent, dim+1, tail(I))...)
+substrides(s, parent, dim, I::Tuple{ScalarIndex, Vararg{Any}}) = (substrides(s*size(parent, dim), parent, dim+1, tail(I))...)
+substrides(s, parent, dim, I::Tuple{Slice, Vararg{Any}}) = (s, substrides(s*size(parent, dim), parent, dim+1, tail(I))...)
 substrides(s, parent, dim, I::Tuple{Range, Vararg{Any}}) = (s*step(I[1]), substrides(s*size(parent, dim), parent, dim+1, tail(I))...)
 substrides(s, parent, dim, I::Tuple{Any, Vararg{Any}}) = throw(ArgumentError("strides is invalid for SubArrays with indices of type $(typeof(I[1]))"))
 
@@ -228,15 +217,10 @@ stride(V::SubArray, d::Integer) = d <= ndims(V) ? strides(V)[d] : strides(V)[end
 compute_stride1{N}(parent::AbstractArray, I::NTuple{N}) =
     (@_inline_meta; compute_stride1(1, fill_to_length(indices(parent), OneTo(1), Val{N}), I))
 compute_stride1(s, inds, I::Tuple{}) = s
-compute_stride1(s, inds, I::Tuple{Real, Vararg{Any}}) =
+compute_stride1(s, inds, I::Tuple{ScalarIndex, Vararg{Any}}) =
     (@_inline_meta; compute_stride1(s*unsafe_length(inds[1]), tail(inds), tail(I)))
 compute_stride1(s, inds, I::Tuple{Range, Vararg{Any}}) = s*step(I[1])
-compute_stride1(s, inds, I::Tuple{Colon, Vararg{Any}}) = s
-function compute_stride1{N}(s, inds, I::Tuple{AbstractCartesianIndex{N}, Vararg{Any}})
-    @_inline_meta
-    h, t = IteratorsMD.split(inds, Val{N})
-    compute_stride1(s*prod(map(unsafe_length, h)), t, tail(I))
-end
+compute_stride1(s, inds, I::Tuple{Slice, Vararg{Any}}) = s
 compute_stride1(s, inds, I::Tuple{Any, Vararg{Any}}) = throw(ArgumentError("invalid strided index type $(typeof(I[1]))"))
 
 iscontiguous(A::SubArray) = iscontiguous(typeof(A))
@@ -258,7 +242,7 @@ end
 # linear indexing always starts with 1.
 compute_offset1(parent, stride1::Integer, I::Tuple) =
     (@_inline_meta; compute_offset1(parent, stride1, find_extended_dims(I)..., I))
-compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{Colon}, I::Tuple) =
+compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{Slice}, I::Tuple) =
     (@_inline_meta; compute_linindex(parent, I) - stride1*first(indices(parent, dims[1])))  # index-preserving case
 compute_offset1(parent, stride1::Integer, dims, inds, I::Tuple) =
     (@_inline_meta; compute_linindex(parent, I) - stride1)  # linear indexing starts with 1
@@ -268,16 +252,11 @@ function compute_linindex{N}(parent, I::NTuple{N})
     IP = fill_to_length(indices(parent), OneTo(1), Val{N})
     compute_linindex(1, 1, IP, I)
 end
-function compute_linindex(f, s, IP::Tuple, I::Tuple{Real, Vararg{Any}})
+function compute_linindex(f, s, IP::Tuple, I::Tuple{ScalarIndex, Vararg{Any}})
     @_inline_meta
     Δi = I[1]-first(IP[1])
     compute_linindex(f + Δi*s, s*unsafe_length(IP[1]), tail(IP), tail(I))
 end
-# Just splat out the cartesian indices and continue
-compute_linindex(f, s, IP::Tuple, I::Tuple{AbstractCartesianIndex, Vararg{Any}}) =
-    (@_inline_meta; compute_linindex(f, s, IP, (I[1].I..., tail(I)...)))
-compute_linindex(f, s, IP::Tuple, I::Tuple{Colon, Vararg{Any}}) =
-    (@_inline_meta; compute_linindex(f, s*unsafe_length(IP[1]), tail(IP), tail(I)))
 function compute_linindex(f, s, IP::Tuple, I::Tuple{Any, Vararg{Any}})
     @_inline_meta
     Δi = first(I[1])-first(IP[1])
@@ -286,11 +265,9 @@ end
 compute_linindex(f, s, IP::Tuple, I::Tuple{}) = f
 
 find_extended_dims(I) = (@_inline_meta; _find_extended_dims((), (), 1, I...))
-_find_extended_dims(dims, inds, dim) = (@_inline_meta; return (dims, inds))
-_find_extended_dims(dims, inds, dim, ::Real, I...) =
+_find_extended_dims(dims, inds, dim) = dims, inds
+_find_extended_dims(dims, inds, dim, ::ScalarIndex, I...) =
     (@_inline_meta; _find_extended_dims(dims, inds, dim+1, I...))
-_find_extended_dims(dims, inds, dim, i1::AbstractCartesianIndex, I...) =
-    (@_inline_meta; _find_extended_dims(dims, inds, dim, i1.I..., I...))
 _find_extended_dims(dims, inds, dim, i1, I...) =
     (@_inline_meta; _find_extended_dims((dims..., dim), (inds..., i1), dim+1, I...))
 
@@ -312,29 +289,16 @@ function pointer{T,N,P<:Array,I<:Tuple{Vararg{RangeIndex}}}(V::SubArray{T,N,P,I}
     return pointer(V.parent, index)
 end
 
-# indices of the parent are preserved for ::Colon indices, otherwise
-# they are taken from the range/vector
+# indices are taken from the range/vector
 # Since bounds-checking is performance-critical and uses
 # indices, it's worth optimizing these implementations thoroughly
-indices(S::SubArray) = (@_inline_meta; _indices_sub(S, indices(S.parent), S.indexes...))
-_indices_sub(S::SubArray, pinds) = ()
-function _indices_sub(S::SubArray, pinds, ::Real, I...)
+indices(S::SubArray) = (@_inline_meta; _indices_sub(S, S.indexes...))
+_indices_sub(S::SubArray) = ()
+_indices_sub(S::SubArray, ::Real, I...) = (@_inline_meta; _indices_sub(S, I...))
+function _indices_sub(S::SubArray, i1::AbstractArray, I...)
     @_inline_meta
-    _indices_sub(S, tail(pinds), I...)
+    (unsafe_indices(i1)..., _indices_sub(S, I...)...)
 end
-function _indices_sub(S::SubArray, pinds, ::Colon, I...)
-    @_inline_meta
-    (pinds[1], _indices_sub(S, tail(pinds), I...)...)
-end
-function _indices_sub(S::SubArray, pinds, i1::AbstractArray, I...)
-    @_inline_meta
-    (unsafe_indices(i1)..., _indices_sub(S, tail(pinds), I...)...)
-end
-function _indices_sub{N}(S::SubArray, pinds, ::AbstractCartesianIndex{N}, I...)
-    @_inline_meta
-    _indices_sub(S, IteratorsMD.split(pinds, Val{N})[2], I...)
-end
-# _indices_sub for arrays of CartesianIndex is defined in multidimensional.jl
 
 ## Compatability
 # deprecate?
@@ -346,7 +310,7 @@ function parentdims(s::SubArray)
     j = 1
     for i = 1:ndims(s.parent)
         r = s.indexes[i]
-        if j <= nd && (isa(r,Union{Colon,Range}) ? sp[i]*step(r) : sp[i]) == sv[j]
+        if j <= nd && (isa(r,Union{Slice,Range}) ? sp[i]*step(r) : sp[i]) == sv[j]
             dimindex[j] = i
             j += 1
         end

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -13,13 +13,13 @@ immutable SubArray{T,N,P,I,L} <: AbstractArray{T,N}
     function SubArray(parent, indexes, offset1, stride1)
         @_inline_meta
         check_parent_index_match(parent, indexes)
-        new(parent, ensure_indexable(indexes), offset1, stride1)
+        new(parent, indexes, offset1, stride1)
     end
 end
 # Compute the linear indexability of the indices, and combine it with the linear indexing of the parent
 function SubArray(parent::AbstractArray, indexes::Tuple)
     @_inline_meta
-    SubArray(linearindexing(viewindexing(indexes), linearindexing(parent)), parent, indexes, index_dimsum(indexes...))
+    SubArray(linearindexing(viewindexing(indexes), linearindexing(parent)), parent, ensure_indexable(indexes), index_dimsum(indexes...))
 end
 function SubArray{P, I, N}(::LinearSlow, parent::P, indexes::I, ::NTuple{N})
     @_inline_meta

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -56,6 +56,7 @@ Base.Broadcast.broadcast!
 Base.getindex(::AbstractArray, ::Any...)
 Base.view
 Base.@view
+Base.to_indices
 Base.parent
 Base.parentindexes
 Base.slicedim

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -57,6 +57,7 @@ Base.getindex(::AbstractArray, ::Any...)
 Base.view
 Base.@view
 Base.to_indices
+Base.Colon
 Base.parent
 Base.parentindexes
 Base.slicedim

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -104,12 +104,14 @@ Base.reshape(A::AbstractArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) = Offse
     @inbounds ret = parent(A)[offset(A.offsets, I)...]
     ret
 end
-@inline function Base._getindex(::LinearFast, A::OffsetVector, i::Int)
+# Vectors don't support one-based linear indexing; they always use the offsets
+@inline function Base.getindex(A::OffsetVector, i::Int)
     checkbounds(A, i)
     @inbounds ret = parent(A)[offset(A.offsets, (i,))[1]]
     ret
 end
-@inline function Base._getindex(::LinearFast, A::OffsetArray, i::Int)
+# But multidimensional arrays allow one-based linear indexing
+@inline function Base.getindex(A::OffsetArray, i::Int)
     checkbounds(A, i)
     @inbounds ret = parent(A)[i]
     ret
@@ -119,12 +121,12 @@ end
     @inbounds parent(A)[offset(A.offsets, I)...] = val
     val
 end
-@inline function Base._setindex!(::LinearFast, A::OffsetVector, val, i::Int)
+@inline function Base.setindex!(A::OffsetVector, val, i::Int)
     checkbounds(A, i)
     @inbounds parent(A)[offset(A.offsets, (i,))[1]] = val
     val
 end
-@inline function Base._setindex!(::LinearFast, A::OffsetArray, val, i::Int)
+@inline function Base.setindex!(A::OffsetArray, val, i::Int)
     checkbounds(A, i)
     @inbounds parent(A)[i] = val
     val

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -365,11 +365,11 @@ sA = view(A, 1:2, 3, [1 3; 4 2])
 
 # logical indexing #4763
 A = view([1:10;], 5:8)
-@test A[A.<7] == [5, 6]
+@test A[A.<7] == view(A, A.<7) == [5, 6]
 @test Base.unsafe_getindex(A, A.<7) == [5, 6]
 B = reshape(1:16, 4, 4)
 sB = view(B, 2:3, 2:3)
-@test sB[sB.>8] == [10, 11]
+@test sB[sB.>8] == view(sB, sB.>8) == [10, 11]
 @test Base.unsafe_getindex(sB, sB.>8) == [10, 11]
 
 # Tests where dimensions are dropped

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -320,7 +320,7 @@ A = copy(reshape(1:120, 3, 5, 8))
 sA = view(A, 2:2, 1:5, :)
 @test strides(sA) == (1, 3, 15)
 @test parent(sA) == A
-@test parentindexes(sA) == (2:2, 1:5, :)
+@test parentindexes(sA) == (2:2, 1:5, Base.Slice(1:8))
 @test Base.parentdims(sA) == [1:3;]
 @test size(sA) == (1, 5, 8)
 @test indices(sA) === (Base.OneTo(1), Base.OneTo(5), Base.OneTo(8))
@@ -376,7 +376,7 @@ sB = view(B, 2:3, 2:3)
 A = copy(reshape(1:120, 3, 5, 8))
 sA = view(A, 2, :, 1:8)
 @test parent(sA) == A
-@test parentindexes(sA) == (2, :, 1:8)
+@test parentindexes(sA) == (2, Base.Slice(1:5), 1:8)
 @test Base.parentdims(sA) == [2:3;]
 @test size(sA) == (5, 8)
 @test indices(sA) === (Base.OneTo(5), Base.OneTo(8))


### PR DESCRIPTION
This patch dramatically simplifies the fallback indexing algorithms for arrays
by standardizing the way in which the passed indices are converted `to_index`
and by rigorously defining what a supported index type is.

The very first thing that occurs within the fallback indexing methods is that
the passed indices are converted to a supported indexing type by
`to_indices(...)`. A supported index type is either `Int` or an `AbstractArray`
of indices. This means that it is at this point that both `Colon` and arrays of
booleans get converted to collections of indices (as specialized array types:
`Slice` and `LogicalIndex`, respectively). This *drastically* simplifies much
of the internal logic. Whereas we had previously encoded the special behaviors
of `:` indexing in about four places, this patch does it once and then stores
the result in a `Slice` AbstractVector. Similarly, `CartesianIndex` is now
converted within `to_indices`, as well.

In addition to simplifying the internal definitions, this patch also makes it
easier for both external packages and Base to add new behaviors in a systematic
fashion. Simple extensions would include things like `Not` indices and
[EndpointRanges.jl](https://github.com/JuliaArrays/EndpointRanges.jl).

Additionally, logical indexing is now represented by a specialized
`LogicalIndex` type that enables fast iteration over the boolean mask without
allocations. This allows index conversions to occur before checking bounds,
and should enable further optimizations for LinearSlow arrays.

 ### Breaking Behaviors:

* The stored type of indices in SubArrays change from `Colon` to `Slice`.

### Non-breaking behavior changes:

* Fully deprecates using `Colon` as pseudo-collections of integers.
* Logical indices are converted to a lazy, iterative collection of indices that doesn't support indexing.  A deprecation provides indexing with O(n) search.

### TODO:

* [x] CI pass
* [x] @nanosoldier `runbenchmarks(ALL, vs = ":master")`
* [x] Decide: should we export and formally document `to_indices`? **YES**. I think I'd be inclined to continue to *not* export `to_index`, particularly now that it's not the entire story.  You *must* call `to_indices` to get the complete conversion, but you can extend `to_index` to provide simpler customizations. **Exported to_indices**.