### PR TITLE
fix ability to use .. as an infix operator

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -195,7 +195,9 @@
       (cadr (caddr e))
       e))
 
-(define (dotop? o) (and (symbol? o) (eqv? (string.char (string o) 0) #\.)))
+(define (dotop? o) (and (symbol? o) (eqv? (string.char (string o) 0) #\.)
+                        (not (eq? o '|.|))
+                        (not (eqv? (string.char (string o) 1) #\.))))
 
 ; convert '.xx to 'xx
 (define (undotop op)
@@ -207,7 +209,9 @@
 (define (maybe-undotop e)
   (if (symbol? e)
       (let ((str (string e)))
-        (if (eqv? (string.char str 0) #\.)
+        (if (and (eqv? (string.char str 0) #\.)
+                 (not (eq? e '|.|))
+                 (not (eqv? (string.char str 1) #\.)))
             (symbol (string.sub str 1 (length str)))
             #f))
       (if (pair? e)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -108,8 +108,7 @@
 (define dot-opchar? (Set
                      (delete-duplicates
                       (map (lambda (op) (string.char (string op) 1))
-                           (filter (lambda (op) (and (dotop? op) (not (eq? op '|.|))))
-                                   operators)))))
+                           (cons `|..| (filter dotop? operators))))))
 (define operator? (Set operators))
 
 (define initial-reserved-words '(begin while if for try return break continue

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -863,3 +863,6 @@ end
 
 @test QualifiedStringMacro.SubModule.x"" === 1
 @test QualifiedStringMacro.SubModule.y`` === 2
+
+..(x,y) = x + y
+@test 3 .. 4 === 7

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -864,5 +864,6 @@ end
 @test QualifiedStringMacro.SubModule.x"" === 1
 @test QualifiedStringMacro.SubModule.y`` === 2
 
-..(x,y) = x + y
-@test 3 .. 4 === 7
+let ..(x,y) = x + y
+    @test 3 .. 4 === 7
+end


### PR DESCRIPTION
As noted by @tkelman, the ability to define `..` as an infix operator was accidentally removed in #17623.  This restores that capability, and adds a test.