### PR TITLE
Update doc deps

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -46,10 +46,10 @@ linkcheck:
 
 doctest:
 	@echo "Running all embedded 'doctests'."
-	$(JULIA_EXECUTABLE) make.jl -- doctest
+	$(JULIA_EXECUTABLE) --color=yes make.jl -- doctest
 	@echo "Checks finished."
 
 check:
 	@echo "Running all embedded 'doctests' and checking external links."
-	$(JULIA_EXECUTABLE) make.jl -- doctest linkcheck
+	$(JULIA_EXECUTABLE) --color=yes make.jl -- doctest linkcheck
 	@echo "Checks finished."

--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
 Compat 0.9.5 0.9.5+
 DocStringExtensions 0.3.1 0.3.1+
-Documenter 0.8.5 0.8.5+
+Documenter 0.8.7 0.8.7+

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -123,6 +123,7 @@ makedocs(
     format    = "pdf" in ARGS ? :latex : :html,
     sitename  = "The Julia Language",
     authors   = "Jeff Bezanson, Stefan Karpinski, Viral Shah, Alan Edelman, et al.",
+    analytics = "UA-28835595-1",
     pages     = PAGES,
 )
 


### PR DESCRIPTION
This updates Documenter to ~~0.8.6~~ 0.8.7 which includes:

- Google Analytics support (@ViralBShah, if you (or anyone else) knows the GA tracking ID that's used for the site I'll add that to this PR to enable analytics for the docs); (edit: second commit uses the tracking ID found in the main site, presumably it's the same one?)
- Color diffs of failed doctests;
- Fix for missing highlighting of `jldoctest` blocks;
- Fix for `@ref` issue mentioned in https://github.com/JuliaLang/julia/pull/19691#discussion_r94005194.