### PR TITLE
Resolve ambiguity in math test

### DIFF
--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -133,7 +133,8 @@ ambs = detect_ambiguities(Ambig5)
 @test length(ambs) == 2
 
 # Test that Core and Base are free of ambiguities
-@test (x->(isempty(x) || println(x)))(detect_ambiguities(Core, Base; imported=true))
+@test detect_ambiguities(Core, Base; imported=true) == []
+# not using isempty so this prints more information when it fails
 
 amb_1(::Int8, ::Int) = 1
 amb_1(::Integer, x) = 2

--- a/test/math.jl
+++ b/test/math.jl
@@ -773,6 +773,7 @@ module Test19626
     +(a::MockQuantity, b::MockQuantity) = MockQuantity(a.val+b.val)
     -(a::MockQuantity, b::MockQuantity) = MockQuantity(a.val-b.val)
     *(a::MockQuantity, b::Number) = MockQuantity(a.val*b)
+    *(a::MockQuantity, b::Bool) = MockQuantity(a.val*b) # resolve ambiguity
     abs(a::MockQuantity) = MockQuantity(abs(a.val))
     isnan(a::MockQuantity) = isnan(a.val)
     isinf(a::MockQuantity) = isinf(a.val)


### PR DESCRIPTION
when it runs on the same worker as test/ambiguous.jl

Clean up printing of ambiguities when the test fails

This was mentioned in https://github.com/JuliaLang/julia/issues/19707, but the more interesting part of that issue with the stack overflow is still open.