### PR TITLE
Add CxxWrap as recommendation

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -900,4 +900,4 @@ For more details on how to pass callbacks to C libraries, see this [blog post](h
 
 ## C++
 
-Support for C++ is provided by the [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl) or [Cxx](https://github.com/Keno/Cxx.jl); and [Clang](https://github.com/ihnorton/Clang.jl) packages.
+For direct C++ interfacing, see the [Cxx](https://github.com/Keno/Cxx.jl) package. For tools to create C++ bindings, see the [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl) package.

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -900,5 +900,4 @@ For more details on how to pass callbacks to C libraries, see this [blog post](h
 
 ## C++
 
-Limited support for C++ is provided by the [Cpp](https://github.com/timholy/Cpp.jl), [Clang](https://github.com/ihnorton/Clang.jl),
-and [Cxx](https://github.com/Keno/Cxx.jl) packages.
+Support for C++ is provided by the [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl) or [Cxx](https://github.com/Keno/Cxx.jl); and [Clang](https://github.com/ihnorton/Clang.jl) packages.


### PR DESCRIPTION
Cpp seems to be old (will not run in supported Julia). Drop it; I guess redundant to others (CxxWrap).

`@cpp` macro implemented by both, say "or"?

Really limited support by now (Cxx) or best in class? Maybe its docs just outdated, but even CxxWrap, seems as good a support as from any other language(?).

Include (ObjC.jl and) Rust.jl support also?

[skip ci]