### PR TITLE
RFC: do not print backtrace for TestSetExceptions and Pkg.test() exception.

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -731,6 +731,14 @@ function test!(pkg::AbstractString,
     isfile(reqs_path) && resolve()
 end
 
+type PkgTestError <: Exception
+    msg::String
+end
+
+function Base.showerror(io::IO, ex::PkgTestError, bt; backtrace=true)
+    print_with_color(Base.error_color(), io, ex.msg)
+end
+
 function test(pkgs::Vector{AbstractString}; coverage::Bool=false)
     errs = AbstractString[]
     nopkgs = AbstractString[]
@@ -751,7 +759,7 @@ function test(pkgs::Vector{AbstractString}; coverage::Bool=false)
         if !isempty(notests)
             push!(messages, "$(join(notests,", "," and ")) did not provide a test/runtests.jl file")
         end
-        throw(PkgError(join(messages, "and")))
+        throw(PkgTestError(join(messages, "and")))
     end
 end
 

--- a/base/test.jl
+++ b/base/test.jl
@@ -406,6 +406,10 @@ function Base.show(io::IO, ex::TestSetException)
     print(io, ex.broken, " broken.")
 end
 
+function Base.showerror(io::IO, ex::TestSetException, bt; backtrace=true)
+    print_with_color(Base.error_color(), io, string(ex))
+end
+
 #-----------------------------------------------------------------------
 
 """
@@ -417,12 +421,20 @@ immutable FallbackTestSet <: AbstractTestSet
 end
 fallback_testset = FallbackTestSet()
 
+type FallbackTestSetException <: Exception
+    msg::String
+end
+
+function Base.showerror(io::IO, ex::FallbackTestSetException, bt; backtrace=true)
+    print_with_color(Base.error_color(), io, ex.msg)
+end
+
 # Records nothing, and throws an error immediately whenever a Fail or
 # Error occurs. Takes no action in the event of a Pass or Broken result
 record(ts::FallbackTestSet, t::Union{Pass,Broken}) = t
 function record(ts::FallbackTestSet, t::Union{Fail,Error})
     println(t)
-    error("There was an error during testing")
+    throw(FallbackTestSetException("There was an error during testing"))
 end
 # We don't need to do anything as we don't record anything
 finish(ts::FallbackTestSet) = ts

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -273,7 +273,7 @@ temp_pkg_dir() do
             Pkg.test("IDoNotExist")
             error("unexpected")
         catch ex
-            @test isa(ex,Pkg.PkgError)
+            @test isa(ex,Pkg.Entry.PkgTestError)
             @test ex.msg == "IDoNotExist is not an installed package"
         end
 
@@ -281,7 +281,7 @@ temp_pkg_dir() do
             Pkg.test("IDoNotExist1", "IDoNotExist2")
             error("unexpected")
         catch ex
-            @test isa(ex,Pkg.PkgError)
+            @test isa(ex,Pkg.Entry.PkgTestError)
             @test ex.msg == "IDoNotExist1 and IDoNotExist2 are not installed packages"
         end
     end
@@ -560,4 +560,10 @@ temp_pkg_dir() do
             "redirect_stderr(STDOUT); using Example; Pkg.update(\"$package\")"`))
         @test contains(msg, "- $package\nRestart Julia to use the updated versions.")
     end
+end
+
+let
+    io = IOBuffer()
+    Base.showerror(io, Base.Pkg.Entry.PkgTestError("ppp"), backtrace())
+    @test !contains(String(take!(io)), "backtrace()")
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -401,3 +401,24 @@ io = IOBuffer()
 str = String(take!(io))
 @test contains(str, "test.jl")
 @test !contains(str, "boot.jl")
+
+let
+    io = IOBuffer()
+    exc = Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}())
+    Base.showerror(io, exc, backtrace())
+    @test !contains(String(take!(io)), "backtrace()")
+end
+
+# 19750
+let
+    io = IOBuffer()
+    exc = Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}())
+    Base.showerror(io, exc, backtrace())
+    @test !contains(String(take!(io)), "backtrace()")
+
+    exc = Test.FallbackTestSetException("msg")
+    Base.showerror(io, exc, backtrace())
+    str = String(take!(io))
+    @test contains(str, "msg")
+    @test !contains(str, "backtrace()")
+end


### PR DESCRIPTION
Removes the backtraces that points to internal functions that are running tests when these test runners run as expected.

Difference between master and PR

## PR:

![image](https://cloud.githubusercontent.com/assets/1282691/21626487/a7ea5696-d211-11e6-8e81-169077948b02.png)

## Master

![image](https://cloud.githubusercontent.com/assets/1282691/21626475/943a3c56-d211-11e6-8a1d-269018c5aeb7.png)
