### PR TITLE
Scrub backtraces being printed when a test in a testset fails.

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -23,23 +23,23 @@ export GenericString
 #-----------------------------------------------------------------------
 
 # Backtrace utility functions
-function ip_matches_name(ip, dir::String, file::String)
+function ip_matches_func_and_name(ip, func::Symbol, dir::String, file::String)
     for fr in StackTraces.lookup(ip)
         if fr === StackTraces.UNKNOWN || fr.from_c
             return false
         end
         path = string(fr.file)
-        dirname(path) == dir && basename(path) == file && return true
+        fr.func == func && dirname(path) == dir && basename(path) == file && return true
     end
     return false
 end
 
 function scrub_backtrace(bt)
-    do_test_ind = findfirst(addr->Base.REPL.ip_matches_func(addr, :do_test), bt)
+    do_test_ind = findfirst(addr->ip_matches_func_and_name(addr, :do_test, ".", "test.jl"), bt)
     if do_test_ind != 0 && length(bt) > do_test_ind
         bt = bt[do_test_ind + 1:end]
     end
-    name_ind = findfirst(addr->ip_matches_name(addr, ".", "test.jl"), bt)
+    name_ind = findfirst(addr->ip_matches_func_and_name(addr, Symbol("macro expansion;"), ".", "test.jl"), bt)
     if name_ind != 0 && length(bt) != 0
         bt = bt[1:name_ind]
     end

--- a/test/test.jl
+++ b/test/test.jl
@@ -395,3 +395,9 @@ end
 end
 @test_throws ErrorException @testset "$(error())" begin
 end
+
+io = IOBuffer()
+@test (print(io, Base.Test.Error(:test_error, "woot", 5, backtrace())); 1) == 1
+str = String(take!(io))
+@test contains(str, "test.jl")
+@test !contains(str, "boot.jl")


### PR DESCRIPTION
Removes the frames above the "do_test" function and below where the test expression is interpolated.
Some examples of output difference between the PR and master.

##### PR
```jl
julia> Pkg.test("Testpkg")
INFO: Testing Testpkg
testing: Test Failed
  Expression: Testpkg.g() == 2
   Evaluated: 1 == 2
 in macro expansion; at /home/kristoffer/.julia/v0.6/Testpkg/test/runtests.jl:11 [inlined]
 in macro expansion; at ./test.jl:752 [inlined]
 in anonymous at ./<missing>:?
```

##### Master
```jl
julia> Pkg.test("Testpkg")
INFO: Testing Testpkg
testing: Test Failed
  Expression: Testpkg.g() == 2
   Evaluated: 1 == 2
 in record(::Base.Test.DefaultTestSet, ::Base.Test.Fail) at ./test.jl:428
 in do_test(::Base.Test.Returned, ::Expr) at ./test.jl:281
 in macro expansion; at /home/kristoffer/.julia/v0.5/Testpkg/test/runtests.jl:11 [inlined]
 in macro expansion; at ./test.jl:672 [inlined]
 in anonymous at ./<missing>:?
 in include_from_node1(::String) at ./loading.jl:488
 in process_options(::Base.JLOptions) at ./client.jl:262
 in _start() at ./client.jl:318
```


##### PR
```jl
julia> @testset "test" begin
       @test 2 == 1
       end
test: Test Failed
  Expression: 2 == 1
   Evaluated: 2 == 1
 in macro expansion; at ./REPL[3]:2 [inlined]
 in macro expansion; at ./test.jl:752 [inlined]
 in anonymous at ./<missing>:?

```

##### Master

```jl
julia> @testset "test" begin
       @test 2 == 1
       end
test: Test Failed
  Expression: 2 == 1
   Evaluated: 2 == 1
 in record(::Base.Test.DefaultTestSet, ::Base.Test.Fail) at ./test.jl:428
 in do_test(::Base.Test.Returned, ::Expr) at ./test.jl:281
 in macro expansion; at ./REPL[4]:2 [inlined]
 in macro expansion; at ./test.jl:672 [inlined]
 in anonymous at ./<missing>:?
 in eval(::Module, ::Any) at ./boot.jl:234
 in eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:64
 in macro expansion at ./REPL.jl:95 [inlined]
 in (::Base.REPL.##3#4{Base.REPL.REPLBackend})() at ./event.jl:68
```


##### PR
```julia
julia> @testset "test" begin
       @test [][1]
       end
test: Error During Test
  Test threw an exception of type BoundsError
  Expression: ([])[1]
  BoundsError: attempt to access 0-element Array{Any,1} at index [1]
   in macro expansion; at ./REPL[4]:2 [inlined]
   in macro expansion; at ./test.jl:752 [inlined]
   in anonymous at ./<missing>:?
```

##### Master
```jl
julia> @testset "test" begin
       @test [][1]
       end
test: Error During Test
  Test threw an exception of type BoundsError
  Expression: ([])[1]
  BoundsError: attempt to access 0-element Array{Any,1} at index [1]
   in macro expansion; at ./REPL[5]:2 [inlined]
   in macro expansion; at ./test.jl:672 [inlined]
   in anonymous at ./<missing>:?
   in eval(::Module, ::Any) at ./boot.jl:234
   in eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:64
   in macro expansion at ./REPL.jl:95 [inlined]
   in (::Base.REPL.##3#4{Base.REPL.REPLBackend})() at ./event.jl:68
```