### PR TITLE
add newline to warning in codegen.cpp

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3710,7 +3710,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
                 // occasionally required by the C API (typically error callbacks)
                 // and doesn't capture the majority of the case when a function
                 // may throw.
-                jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match", name);
+                jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name);
             }
         }
     }


### PR DESCRIPTION
Added missing newline to warning message when cfunction is called with wrong return type.