### PR TITLE
RFC: add `<-` as an assignment-like operator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Julia v0.6.0 Release Notes
 New language features
 ---------------------
 
+  * `<-` is now a valid operator that can be defined for custom purposes.
+    It has assignment precedence. ([#19765])
+
 Language changes
 ----------------
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -8,7 +8,7 @@
 ;; be an operator.
 (define prec-assignment
   (append! (add-dots '(= += -= *= /= //= |\\=| ^= ÷= %= <<= >>= >>>= |\|=| &= ⊻=))
-           '(:= => ~ $=)))
+           '(:= => ~ $= <-)))
 (define prec-conditional '(?))
 (define prec-arrow       (append!
                           '(-- -->)
@@ -729,7 +729,9 @@
                        (let ((args (parse-chain s down '~)))
                          `(macrocall @~ ,ex ,@(butlast args)
                                      ,(loop (last args) (peek-token s)))))
-                   (list t ex (parse-assignment s down)))))))
+                   (if (syntactic-op? t)
+                       (list t ex (parse-assignment s down))
+                       (list 'call t ex (parse-assignment s down))))))))
 
 (define (parse-eq s)
   (let ((lno (input-port-line (ts:port s))))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -384,6 +384,12 @@ end
 @test parse("x<:y<:z").head === :comparison
 @test parse("x>:y<:z").head === :comparison
 
+# PR #19765
+let <-(x,y) = 2x + y
+    @test (3<-10) == 16
+end
+@test parse("x<-y<-z") == Expr(:call, :(<-), :x, Expr(:call, :(<-), :y, :z))
+
 # issue #11169
 uncalled(x) = @test false
 fret() = uncalled(return true)


### PR DESCRIPTION
We currently don't parse this at all. This might be useful to define on objects that support some kind of insertion or assignment operation. One motivation is that I've seen `<=` used for that purpose.

This change parses `<-` with assignment-level precedence but as an ordinary function call.