### PR TITLE
Integer /: restrict fallback to same-type case (fix #19714)

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -260,6 +260,8 @@ for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
     end
 end
 
+/(x::BigInt, y::BigInt) = float(x)/float(y)
+
 function invmod(x::BigInt, y::BigInt)
     z = zero(BigInt)
     ya = abs(y)
@@ -341,6 +343,9 @@ function *(x::BigInt, c::ClongMax)
     return z
 end
 *(c::ClongMax, x::BigInt) = x * c
+
+/(x::BigInt, y::Union{ClongMax,CulongMax}) = float(x)/y
+/(x::Union{ClongMax,CulongMax}, y::BigInt) = x/float(y)
 
 # unary ops
 for (fJ, fC) in ((:-, :neg), (:~, :com))

--- a/base/int.jl
+++ b/base/int.jl
@@ -32,8 +32,10 @@ typealias BitUnsigned64T Union{Type{UInt8},Type{UInt16},Type{UInt32},Type{UInt64
 +{T<:BitInteger}(x::T, y::T) = box(T, add_int(unbox(T,x),unbox(T,y)))
 *{T<:BitInteger}(x::T, y::T) = box(T, mul_int(unbox(T,x),unbox(T,y)))
 
-/(x::Integer, y::Integer) = float(x)/float(y)
 inv(x::Integer) = float(one(x))/float(x)
+/{T<:Integer}(x::T, y::T) = float(x)/float(y)
+# skip promotion for system integer types
+/(x::BitInteger, y::BitInteger) = float(x)/float(y)
 
 """
     isodd(x::Integer) -> Bool

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -71,3 +71,11 @@ let xs = [[i:i+4;] for i in 1:10]
         @test max.(xs[1:n]...) == [n:n+4;]
     end
 end
+
+# issue #19714
+immutable T19714 <: Integer end
+Base.float(::T19714) = 19714.0
+Base.:/(::T19714, ::T19714) = T19714()
+Base.convert(::Type{T19714}, ::Int) = T19714()
+Base.promote_rule(::Type{T19714}, ::Type{Int}) = T19714
+@test T19714()/1 === 1/T19714() === T19714()


### PR DESCRIPTION
The principle here is that if there's an implementation of a promoted operator for some type and promotions for that type, unless other methods are defined, the operation should always be "funnelled" through the core operator definition for that type. The method for `/(::Integer, ::Integer)` violated that principle since it would take precedence in mixed-integer-type division cases even in the presence of a same-type method definition for a custom integer type and the appropriate promotion rules.