### PR TITLE
Fix some tests and documentation in "typed enums" code

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -31,7 +31,7 @@ end
 """
     @enum EnumName[::BaseType] EnumValue1[=x] EnumValue2[=y]
 
-Create an `Enum`{`BaseType`} subtype with name `EnumName` and enum member values of
+Create an `Enum{BaseType}` subtype with name `EnumName` and enum member values of
 `EnumValue1` and `EnumValue2` with optional assigned values of `x` and `y`, respectively.
 `EnumName` can be used just like other types and enum member values as regular values, such as
 

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -31,7 +31,7 @@ end
 """
     @enum EnumName[::BaseType] EnumValue1[=x] EnumValue2[=y]
 
-Create an [`Enum`]{`BaseType`} subtype with name `EnumName` and enum member values of
+Create an `Enum`{`BaseType`} subtype with name `EnumName` and enum member values of
 `EnumValue1` and `EnumValue2` with optional assigned values of `x` and `y`, respectively.
 `EnumName` can be used just like other types and enum member values as regular values, such as
 
@@ -46,7 +46,7 @@ julia> f(apple)
 ```
 
 `BaseType`, which defaults to `Int32`, must be a bitstype subtype of Integer. Member values can be converted between
-the enum type and `BaseType`. `read` and and `write` perform these conversions automatically.
+the enum type and `BaseType`. `read` and `write` perform these conversions automatically.
 """
 macro enum(T,syms...)
     if isempty(syms)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -98,6 +98,11 @@ end
 @test Test6.size == 16
 @test typeof(convert(Integer, _one_Test6)) == UInt128
 
+# enum values must be integers
+@test_throws ArgumentError eval(:(@enum Test7 _zero="zero"))
+@test_throws ArgumentError eval(:(@enum Test8 _zero='0'))
+@test_throws ArgumentError eval(:(@enum Test9 _zero=0.5))
+
 # test macro handles keyword arguments
 @enum(Test11, _zero_Test11=2,
               _one_Test11,


### PR DESCRIPTION
I inadvertently removed these when clearing out the tests that used an enum's no longer present `.val` field.

This restores the lost two, plus another that checks that the value type isn't a float.