### PR TITLE
Only download UnicodeData.txt once

### DIFF
--- a/deps/tools/jlchecksum
+++ b/deps/tools/jlchecksum
@@ -37,7 +37,8 @@ checksum_error()
     echo "  But \`$CHECKSUM_PROG\` results in:" >&2
     print_hash "$CURR_CHECKSUM"
     echo "  This can happen due to bad downloads or network proxies, please check your" >&2
-    echo "  network proxy/firewall settings and delete deps/srccache/$BASENAME" >&2
+    echo "  network proxy/firewall settings and delete" >&2
+    echo "  $(realpath $ARG1)" >&2
     echo "  to force a redownload when you are ready" >&2
     echo "===============================================================================" >&2
     exit 2

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,8 +18,10 @@ help:
 	@echo "  doctest   to run all doctests embedded in the documentation"
 	@echo "  check     to run linkcheck and doctests"
 
-deps:
+UnicodeData.txt:
 	$(JLDOWNLOAD) http://www.unicode.org/Public/9.0.0/ucd/UnicodeData.txt
+
+deps: UnicodeData.txt
 	$(JLCHECKSUM) UnicodeData.txt
 
 clean:


### PR DESCRIPTION
Verify the checksums on every run, but only download the file if missing.
Also fix path in error message when checksum doesn't match by tweaking
jlchecksum a bit so that it doesn't assume all files are saved into
deps/srccache.