### PR TITLE
broadcast!(f, A, x::Number...) should call f(x...) independently for each A[i]

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -16,7 +16,7 @@ export broadcast_getindex, broadcast_setindex!, dotview
 
 # special cases for "X .= ..." (broadcast!) assignments
 broadcast!(::typeof(identity), X::AbstractArray, x::Number) = fill!(X, x)
-broadcast!(f, X::AbstractArray, x::Number...) = fill!(X, f(x...))
+broadcast!(f, X::AbstractArray, x::Number...) = (@inbounds for I in eachindex(X); X[I] = f(x...); end; X)
 function broadcast!{T,S,N}(::typeof(identity), x::AbstractArray{T,N}, y::AbstractArray{S,N})
     check_broadcast_shape(broadcast_indices(x), broadcast_indices(y))
     copy!(x, y)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -376,6 +376,7 @@ end
 
 # Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722).
 @test let z = 1; A = broadcast!(() -> z += 1, zeros(2)); A[1] != A[2]; end
+@test let z = 1; A = broadcast!(x -> z += x, zeros(2), 1); A[1] != A[2]; end
 
 # broadcasting for custom AbstractArray
 immutable Array19745{T,N} <: AbstractArray{T,N}

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -374,7 +374,8 @@ end
 @test (+).([[0,2], [1,3]], [1,-1]) == [[1,3], [0,2]]
 @test (+).([[0,2], [1,3]], Ref{Vector{Int}}([1,-1])) == [[1,1], [2,2]]
 
-# Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722).
+# Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722),
+# and similarly for broadcast!(f, A, numbers...) (#19799).
 @test let z = 1; A = broadcast!(() -> z += 1, zeros(2)); A[1] != A[2]; end
 @test let z = 1; A = broadcast!(x -> z += x, zeros(2), 1); A[1] != A[2]; end
 


### PR DESCRIPTION
This corrects for an omission in #19722.

Technically, this is a breaking change compared to 0.5.  However, it can also be viewed as a restoration of Julia-0.4 behavior that was unintentionally changed in 0.5, and which so far no one has noticed.  (However, this will become much more important nowadays given dot-call syntax, e.g. if someone does `x .= rand.() .+ 1` ala #19796.)