### PR TITLE
Make cfunction optmization in codegen valid

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1210,6 +1210,10 @@ function abstract_call(f::ANY, fargs, argtypes::Vector{Any}, vtypes::VarTable, s
             end
         end
     end
+    if istopfunction(tm, f, :cfunction) && length(fargs) == 4
+        # This can be skipped if codegen cannot inline the call
+        update_valid_age!(sv.params.world, sv.params.world, sv)
+    end
 
     atype = argtypes_to_type(argtypes)
     t = pure_eval_call(f, argtypes, atype, vtypes, sv)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1635,7 +1635,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                 frt = jl_tparam0(frt);
                 Value *llvmf = NULL;
                 JL_TRY {
-                    llvmf = jl_cfunction_object((jl_function_t*)f, frt, (jl_tupletype_t*)fargt);
+                    llvmf = jl_cfunction_object((jl_function_t*)f, frt, (jl_tupletype_t*)fargt, ctx->world);
                 }
                 JL_CATCH {
                     llvmf = NULL;

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -466,6 +466,29 @@ let
     @test c_18711 == 1
 end
 
+g19801(a) = a
+f19801() = cfunction(g19801, Int, (Int,))
+f19801_dynamic = f19801
+# Run a single function twice to make sure the function is recompiled
+function test19801(first, ptr0=f19801())
+    if first
+        @test ccall(ptr0, Int, (Int,), 1) == 1
+        @eval g19801(a::Int) = a + 1
+        # Check that both static and dynamic version returns the old pointer
+        @test f19801() == ptr0
+        @test f19801_dynamic() == ptr0
+        @test ccall(f19801(), Int, (Int,), 1) == 1
+    else
+        @test ccall(ptr0, Int, (Int,), 1) == 1
+        @test f19801() != ptr0
+        @test f19801_dynamic() == f19801()
+        @test ccall(f19801(), Int, (Int,), 1) == 2
+    end
+    return ptr0
+end
+ptr19801 = test19801(true)
+test19801(false, ptr19801)
+
 let
     old_have_color = Base.have_color
     try


### PR DESCRIPTION
The backedge in inference if obviously very pessimistic but I doubt it will cause too much trouble. Also need tests.

This makes sure that `cfunction` (or `jl_function_ptr`) always returns a function pointer that captures the calling world and makes sure that both the runtime implementation and codegen agrees on this.

Add to 0.6 milestone since this should be ready as is (missing tests and further optimizations) and should make it easier to handle cases like https://github.com/JuliaLang/julia/issues/19790 in packages.
