### PR TITLE
Deprecate vectorized div, rem/%, and mod methods for Dates.Periods

### DIFF
--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -87,10 +87,7 @@ end
 *{P<:Period}(x::P,y::Real) = P(value(x) * Int64(y))
 *(y::Real,x::Period) = x * y
 for (op,Ty,Tz) in ((:*,Real,:P),
-                   (:/,:P,Float64), (:/,Real,:P),
-                   (:div,:P,Int64), (:div,Integer,:P),
-                   (:%,:P,:P),
-                   (:mod,:P,:P))
+                   (:/,:P,Float64), (:/,Real,:P))
     @eval begin
         function ($op){P<:Period}(X::StridedArray{P},y::$Ty)
             Z = similar(X, $Tz)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1421,6 +1421,12 @@ end
 @deprecate rem(A::Number, B::AbstractArray) rem.(A, B)
 @deprecate rem(A::AbstractArray, B::Number) rem.(A, B)
 
+# Deprecate manually vectorized div, mod, and % methods for dates
+@deprecate div{P<:Dates.Period}(X::StridedArray{P}, y::P)         div.(X, y)
+@deprecate div{P<:Dates.Period}(X::StridedArray{P}, y::Integer)   div.(X, y)
+@deprecate (%){P<:Dates.Period}(X::StridedArray{P}, y::P)         X .% y
+@deprecate mod{P<:Dates.Period}(X::StridedArray{P}, y::P)         mod.(X, y)
+
 # Deprecate manually vectorized mod methods in favor of compact broadcast syntax
 @deprecate mod(B::BitArray, x::Bool) mod.(B, x)
 @deprecate mod(x::Bool, B::BitArray) mod.(x, B)

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -35,8 +35,8 @@ t2 = Dates.Year(2)
 @test_throws MethodError ([t,t,t,t,t] .* Dates.Year(1)) == ([t,t,t,t,t])
 @test ([t,t,t,t,t] * 1) == ([t,t,t,t,t])
 @test ([t,t,t,t,t] .% t2) == ([t,t,t,t,t])
-@test div([t,t,t,t,t],Dates.Year(1)) == ([1,1,1,1,1])
-@test mod([t,t,t,t,t],Dates.Year(2)) == ([t,t,t,t,t])
+@test div.([t,t,t,t,t],Dates.Year(1)) == ([1,1,1,1,1])
+@test mod.([t,t,t,t,t],Dates.Year(2)) == ([t,t,t,t,t])
 @test [t,t,t] / t2 == [0.5,0.5,0.5]
 @test abs(-t) == t
 


### PR DESCRIPTION
This pull request deprecates the remaining vectorized `div`, `rem`/`%`, and `mod` methods for `Dates.Period`s mentioned in https://github.com/JuliaLang/julia/pull/18608#issuecomment-269858148. Best!