### PR TITLE
Remove broadcast_elwise_op and deprecate promote_eltype_op

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1790,12 +1790,6 @@ function mapslices(f, A::AbstractArray, dims::AbstractVector)
     return R
 end
 
-# These are needed because map(eltype, As) is not inferrable
-promote_eltype_op(::Any) = Any
-promote_eltype_op(op, A) = (@_inline_meta; promote_op(op, eltype(A)))
-promote_eltype_op(op, A, B) = (@_inline_meta; promote_op(op, eltype(A), eltype(B)))
-promote_eltype_op(op, A, B, C, D...) = (@_inline_meta; promote_eltype_op(op, eltype(A), promote_eltype_op(op, B, C, D...)))
-
 ## 1 argument
 
 function map!{F}(f::F, dest::AbstractArray, A::AbstractArray)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -3,7 +3,7 @@
 module Broadcast
 
 using Base.Cartesian
-using Base: promote_eltype_op, linearindices, tail, OneTo, to_shape,
+using Base: linearindices, tail, OneTo, to_shape,
             _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache,
             nullable_returntype, null_safe_eltype_op, hasvalue
 import Base: broadcast, broadcast!
@@ -266,11 +266,6 @@ function broadcast_t(f, ::Type{Bool}, shape, iter, As...)
     _broadcast!(f, B, keeps, Idefaults, As, Val{nargs}, iter)
     return B
 end
-
-# broadcast method that uses inference to find the type, but preserves abstract
-# container types when possible (used by binary elementwise operators)
-@inline broadcast_elwise_op(f, As...) =
-    broadcast!(f, similar(Array{promote_eltype_op(f, As...)}, broadcast_indices(As...)), As...)
 
 eltypestuple(a) = (Base.@_pure_meta; Tuple{eltype(a)})
 eltypestuple(T::Type) = (Base.@_pure_meta; Tuple{Type{T}})

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1470,7 +1470,7 @@ end
 @deprecate (|)(A::AbstractArray, b::Number)         A .| b
 @deprecate (|)(A::AbstractArray, B::AbstractArray)  A .| B
 
-# Calling promote_op is likely a bad idea, so deprecate to its convenience wrapper promote_eltype_op
+# Calling promote_op is likely a bad idea, so deprecate its convenience wrapper promote_eltype_op
 @deprecate promote_eltype_op(op, As...) promote_op(op, map(eltype, As)...)
 
 # End deprecations scheduled for 0.6

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1239,7 +1239,7 @@ for (Bsig, A1sig, A2sig, gbb, funcname) in
     end  # let broadcast_cache
 end
 _broadcast_zpreserving!(args...) = broadcast!(args...)
-_broadcast_zpreserving(args...) = Base.Broadcast.broadcast_elwise_op(args...)
+_broadcast_zpreserving(f, As...) = broadcast!(f, similar(Array{promote_op(f, map(eltype, As)...)}, Base.Broadcast.broadcast_indices(As...)), As...)
 _broadcast_zpreserving{Tv1,Ti1,Tv2,Ti2}(f::Function, A_1::SparseMatrixCSC{Tv1,Ti1}, A_2::SparseMatrixCSC{Tv2,Ti2}) =
     _broadcast_zpreserving!(f, spzeros(promote_type(Tv1, Tv2), promote_type(Ti1, Ti2), Base.to_shape(Base.Broadcast.broadcast_indices(A_1, A_2))), A_1, A_2)
 _broadcast_zpreserving{Tv,Ti}(f::Function, A_1::SparseMatrixCSC{Tv,Ti}, A_2::Union{Array,BitArray,Number}) =
@@ -1469,5 +1469,8 @@ end
 @deprecate (|)(a::Number, B::AbstractArray)         a .| B
 @deprecate (|)(A::AbstractArray, b::Number)         A .| b
 @deprecate (|)(A::AbstractArray, B::AbstractArray)  A .| B
+
+# Calling promote_op is likely a bad idea, so deprecate to its convenience wrapper promote_eltype_op
+@deprecate promote_eltype_op(op, As...) promote_op(op, map(eltype, As)...)
 
 # End deprecations scheduled for 0.6


### PR DESCRIPTION
AFAICT, `broadcast_elwise_op` was only used in the deprecation of `_broadcast_zpreserving`.

I've found the following uses of `promote_eltype_op`:
* ImageFiltering - only adds methods, should be no problem.
* DataArrays - actually uses `Compat.promote_eltype_op`.
* Compat - Defines its own version or re-exports the one from Base if it exists.

Probably the cleanest thing would be to update DataArrays not to rely on `promote_eltype_op` and also deprecate it in Compat. Or Compat could just use the definition from the deprecation directly.