### PR TITLE
add a caution to avoid spaces in Julia path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ By default you will be building the latest unstable version of Julia. However, m
 
     git checkout release-0.5
 
-Now run `make` to build the `julia` executable. To perform a parallel build, use `make -j N` and supply the maximum number of concurrent processes. (See [Platform Specific Build Notes](https://github.com/JuliaLang/julia#platform-specific-build-notes) for details.)
+Ensure that you do not have any whitespaces in your Julia path, as `make` is not known to work well with them. Now run `make` to build the `julia` executable. To perform a parallel build, use `make -j N` and supply the maximum number of concurrent processes. (See [Platform Specific Build Notes](https://github.com/JuliaLang/julia#platform-specific-build-notes) for details.)
 When compiled the first time, it will automatically download and build its [external dependencies](#Required-Build-Tools-External-Libraries).
 This takes a while, but only has to be done once. If the defaults in the build do not work for you, and you need to set specific make parameters, you can save them in `Make.user`. The build will automatically check for the existence of `Make.user` and use it if it exists.
 Building Julia requires 1.5GiB of disk space and approximately 700MiB of virtual memory.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ By default you will be building the latest unstable version of Julia. However, m
 
     git checkout release-0.5
 
-Ensure that you do not have any whitespaces in your Julia path, as `make` is not known to work well with them. Now run `make` to build the `julia` executable. To perform a parallel build, use `make -j N` and supply the maximum number of concurrent processes. (See [Platform Specific Build Notes](https://github.com/JuliaLang/julia#platform-specific-build-notes) for details.)
+Ensure that you do not have any whitespaces in your Julia path, as `make` is known to work poorly with them. Now run `make` to build the `julia` executable. To perform a parallel build, use `make -j N` and supply the maximum number of concurrent processes. (See [Platform Specific Build Notes](https://github.com/JuliaLang/julia#platform-specific-build-notes) for details.)
 When compiled the first time, it will automatically download and build its [external dependencies](#Required-Build-Tools-External-Libraries).
 This takes a while, but only has to be done once. If the defaults in the build do not work for you, and you need to set specific make parameters, you can save them in `Make.user`. The build will automatically check for the existence of `Make.user` and use it if it exists.
 Building Julia requires 1.5GiB of disk space and approximately 700MiB of virtual memory.


### PR DESCRIPTION
As one of the reasons of `make` statement to fail is path with spaces, it is better to put this knowledge up in the README.md file. WRT https://github.com/JuliaLang/julia/issues/19806