### PR TITLE
Revert "Add an option to add CPUID tag to sysimg and .ji files"

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -83,11 +83,6 @@ HAVE_SSP := 0
 WITH_GC_VERIFY := 0
 WITH_GC_DEBUG_ENV := 0
 
-# When set, give julia binaries CPUID specific names. This is useful in cluster environments
-# with heterogeneous architectures. N.B.: will not be automatically rebuilt for all
-# architectures if julia is updated.
-CPUID_SPECIFIC_BINARIES ?= 0
-
 # Prevent picking up $ARCH from the environment variables
 ARCH:=
 

--- a/Makefile
+++ b/Makefile
@@ -95,17 +95,11 @@ julia-ui-release julia-ui-debug : julia-ui-% : julia-src-%
 julia-inference : julia-base julia-ui-$(JULIA_BUILD_MODE) $(build_prefix)/.examples
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/inference.ji JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
 
-ifneq ($(CPUID_SPECIFIC_BINARIES), 0)
-CPUID_TAG = _$(call spawn,$(JULIA_EXECUTABLE) --cpuid)
-else
-CPUID_TAG =
-endif
-
 julia-sysimg-release : julia-inference julia-ui-release
-	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/sys$(CPUID_TAG).$(SHLIB_EXT) JULIA_BUILD_MODE=release
+	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/sys.$(SHLIB_EXT) JULIA_BUILD_MODE=release
 
 julia-sysimg-debug : julia-inference julia-ui-debug
-	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/sys-debug$(CPUID_TAG).$(SHLIB_EXT) JULIA_BUILD_MODE=debug
+	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/sys-debug.$(SHLIB_EXT) JULIA_BUILD_MODE=debug
 
 julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest
 
@@ -175,7 +169,7 @@ $(build_datarootdir)/julia/julia-config.jl : $(JULIAHOME)/contrib/julia-config.j
 
 $(build_private_libdir)/%.$(SHLIB_EXT): $(build_private_libdir)/%.o
 	@$(call PRINT_LINK, $(CXX) $(LDFLAGS) -shared $(fPIC) -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ $< \
-		$(if $(findstring -debug,$(notdir $@)),-ljulia-debug,-ljulia) \
+		$(if $(findstring -debug.$(SHLIB_EXT),$(notdir $@)),-ljulia-debug,-ljulia) \
 		$$([ $(OS) = WINNT ] && echo '' -lssp))
 	@$(INSTALL_NAME_CMD)$(notdir $@) $@
 	@$(DSYMUTIL) $@
@@ -221,13 +215,8 @@ $$(build_private_libdir)/sys$1.o: $$(build_private_libdir)/inference.ji $$(JULIA
 		|| { echo '*** This error is usually fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***' && false; } )
 .SECONDARY: $(build_private_libdir)/sys$1.o
 endef
-ifneq ($(CPUID_SPECIFIC_BINARIES),0)
-$(eval $(call sysimg_builder,_%,-O3,$(JULIA_EXECUTABLE_release)))
-$(eval $(call sysimg_builder,-debug_%,-O0,$(JULIA_EXECUTABLE_debug)))
-else
 $(eval $(call sysimg_builder,,-O3,$(JULIA_EXECUTABLE_release)))
 $(eval $(call sysimg_builder,-debug,-O0,$(JULIA_EXECUTABLE_debug)))
-endif
 
 $(build_depsbindir)/stringreplace: $(JULIAHOME)/contrib/stringreplace.c | $(build_depsbindir)
 	@$(call PRINT_CC, $(HOSTCC) -o $(build_depsbindir)/stringreplace $(JULIAHOME)/contrib/stringreplace.c)

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -71,8 +71,6 @@ init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRANCH) = Di
 
 function __init__()
     vers = "v$(VERSION.major).$(VERSION.minor)"
-    vers = ccall(:jl_uses_cpuid_tag, Cint, ()) == 0 ? vers :
-        joinpath(vers,hex(ccall(:jl_cpuid_tag, UInt64, ()), 2*sizeof(UInt64)))
     unshift!(Base.LOAD_CACHE_PATH, abspath(Dir._pkgroot(), "lib", vers))
 end
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -103,12 +103,8 @@ DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 
 # if not absolute, then relative to the directory of the julia executable
-SHIPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys\""
-DEBUGFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys-debug\""
-
-ifneq ($(CPUID_SPECIFIC_BINARIES), 0)
-override CPPFLAGS += "-DCPUID_SPECIFIC_BINARIES=1"
-endif
+SHIPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\""
+DEBUGFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys-debug.$(SHLIB_EXT)\""
 
 FLISP_EXECUTABLE_debug := $(BUILDDIR)/flisp/flisp-debug
 FLISP_EXECUTABLE_release := $(BUILDDIR)/flisp/flisp

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -11,25 +11,7 @@
 #include "getopt.h"
 #endif
 
-#ifdef _OS_WINDOWS_
-char *shlib_ext = ".dll";
-#elif defined(_OS_DARWIN_)
-char *shlib_ext = ".dylib";
-#else
-char *shlib_ext = ".so";
-#endif
-
-static char default_sysimg_path[512];
-static const char *get_default_sysimg_path()
-{
-#ifndef CPUID_SPECIFIC_BINARIES
-    snprintf(default_sysimg_path, 512, "%s%s", JL_SYSTEM_IMAGE_PATH, shlib_ext);
-#else
-    snprintf(default_sysimg_path, 512, "%s_%llx%s", JL_SYSTEM_IMAGE_PATH, jl_cpuid_tag(), shlib_ext);
-#endif
-    return default_sysimg_path;
-}
-
+static const char system_image_path[256] = "\0" JL_SYSTEM_IMAGE_PATH;
 
 jl_options_t jl_options = { 0,    // quiet
                             NULL, // julia_home
@@ -38,7 +20,7 @@ jl_options_t jl_options = { 0,    // quiet
                             NULL, // print
                             NULL, // post-boot
                             NULL, // load
-                            NULL, // image_file (will be filled in below)
+                            &system_image_path[1], // image_file
                             NULL, // cpu_target ("native", "core2", etc...)
                             0,    // nprocs
                             NULL, // machinefile
@@ -209,10 +191,6 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "no-startup",      no_argument,       0, 'f' },                 // deprecated
         { 0, 0, 0, 0 }
     };
-
-    // If CPUID specific binaries are enabled, this varies between runs, so initialize
-    // it here, rather than as part of the static initialization above.
-    jl_options.image_file = get_default_sysimg_path();
 
     int codecov  = JL_LOG_NONE;
     int malloclog= JL_LOG_NONE;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1234,8 +1234,6 @@ JL_DLLEXPORT long jl_getallocationgranularity(void);
 JL_DLLEXPORT int jl_is_debugbuild(void);
 JL_DLLEXPORT jl_sym_t *jl_get_UNAME(void);
 JL_DLLEXPORT jl_sym_t *jl_get_ARCH(void);
-JL_DLLEXPORT uint64_t jl_cpuid_tag(void);
-JL_DLLEXPORT int jl_uses_cpuid_tag(void);
 
 // environment entries
 JL_DLLEXPORT jl_value_t *jl_environ(int i);

--- a/src/sys.c
+++ b/src/sys.c
@@ -366,7 +366,6 @@ JL_DLLEXPORT int jl_cpu_cores(void)
 #endif
 }
 
-
 // -- high resolution timers --
 // Returns time in nanosec
 JL_DLLEXPORT uint64_t jl_hrtime(void)
@@ -452,24 +451,7 @@ JL_DLLEXPORT void jl_cpuid(int32_t CPUInfo[4], int32_t InfoType)
     );
 #endif
 }
-JL_DLLEXPORT uint64_t jl_cpuid_tag(void)
-{
-    uint32_t info[4];
-    jl_cpuid((int32_t *)info, 1);
-    return (((uint64_t)info[2]) | (((uint64_t)info[3]) << 32));
-}
-#elif defined(CPUID_SPECIFIC_BINARIES)
-#error "CPUID not available on this CPU. Turn off CPUID_SPECIFIC_BINARIES"
 #endif
-
-JL_DLLEXPORT int jl_uses_cpuid_tag()
-{
-#ifdef CPUID_SPECIFIC_BINARIES
-    return 1;
-#else
-    return 0;
-#endif
-}
 
 // -- set/clear the FZ/DAZ flags on x86 & x86-64 --
 #ifdef __SSE__

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -177,8 +177,6 @@ static NOINLINE int true_main(int argc, char *argv[])
     return 0;
 }
 
-extern uint64_t jl_cpuid_tag();
-
 #ifndef _OS_WINDOWS_
 int main(int argc, char *argv[])
 {
@@ -243,11 +241,6 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
         argv[i] = (wchar_t*)arg;
     }
 #endif
-    if (argc >= 2 && strcmp((char *)argv[1], "--cpuid") == 0) {
-        /* Used by the build system to name CPUID-specific binaries */
-        printf("%llx", jl_cpuid_tag());
-        return 0;
-    }
     libsupport_init();
     int lisp_prompt = (argc >= 2 && strcmp((char*)argv[1],"--lisp") == 0);
     if (lisp_prompt) {


### PR DESCRIPTION
Reverts JuliaLang/julia#19486

Precompile will get confused by this. One of the assumptions it needs is that all clients must use the same sysimg as on node one to prevent the nodes from throwing "out-of-sync" errors when trying to load packages.