### PR TITLE
drop special support in the parser for deprecating f.(1) getfield syntax

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1704,9 +1704,7 @@
                    (else
                     (cf (cdr old-fargs) (cdr old-args)
                         (cons farg new-fargs) (cons arg new-args) renames varfarg vararg))))))
-          (if (and (= (length args) 1) (integer? (car args)))
-              e ; hack: don't compress e.g. f.(1) so that deprecation for getfield works
-              (cf (cdadr f) args '() '() '() '() '())))
+          (cf (cdadr f) args '() '() '() '() '()))
         e)) ; (not (fuse? e))
   (let ((e (compress-fuse (dot-to-fuse rhs))) ; an expression '(fuse func args) if expr is a dot call
         (lhs-view (ref-to-view lhs))) ; x[...] expressions on lhs turn in to view(x, ...) to update x in-place


### PR DESCRIPTION
This drops a hack in the parser code (specifically, in the argument-simplification code for lowering fusion operations) that was required to propertly deprecate 0.4-style `f.(1)` code to `getfield(f,1)`.  Since this was deprecated in 0.5, presumably support will be removed entirely in 0.6.