### PR TITLE
inline string literals in dot calls

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -200,15 +200,14 @@ value_t fl_invoke_julia_macro(fl_context_t *fl_ctx, value_t *args, uint32_t narg
 // Check whether v is a scalar for purposes of inlining fused-broadcast
 // arguments when lowering; should agree with broadcast.jl on what is a
 // scalar.  When in doubt, return false, since this is only an optimization.
-// (TODO: update after #16966 is resolved.)
 value_t fl_julia_scalar(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "julia-scalar?", nargs, 1);
-    if (fl_isnumber(fl_ctx, args[0]))
+    if (fl_isnumber(fl_ctx, args[0]) || fl_isstring(fl_ctx, args[0]))
         return fl_ctx->T;
     else if (iscvalue(args[0]) && fl_ctx->jl_sym == cv_type((cvalue_t*)ptr(args[0]))) {
         jl_value_t *v = *(jl_value_t**)cptr(args[0]);
-        if (jl_subtype(v,(jl_value_t*)jl_number_type,1))
+        if (jl_subtype(v,(jl_value_t*)jl_number_type,1) || jl_is_string(v))
             return fl_ctx->T;
     }
     return fl_ctx->F;

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -340,7 +340,7 @@ end
 @test broadcast(+, 1.0, (0, -2.0), [1]) == [2.0, 0.0]
 @test broadcast(*, ["Hello"], ", ", ["World"], "!") == ["Hello, World!"]
 let s = "foo"
-    @test s .* ["bar", "baz"] == ["foobar", "foobaz"]
+    @test s .* ["bar", "baz"] == ["foobar", "foobaz"] == "foo" .* ["bar", "baz"]
 end
 
 # Ensure that even strange constructors that break `T(x)::T` work with broadcast

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -291,6 +291,8 @@ import Base.Meta: isexpr
 @test isexpr(expand(:(f.(x,1))), :thunk)
 @test isexpr(expand(:(f.(x,1.0))), :thunk)
 @test isexpr(expand(:(f.(x,$π))), :thunk)
+@test isexpr(expand(:(f.(x,"hello"))), :thunk)
+@test isexpr(expand(:(f.(x,$("hello")))), :thunk)
 
 # PR #17623: Fused binary operators
 @test [true] .* [true] == [true]

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -339,6 +339,9 @@ end
 @test broadcast(+, 1.0, (0, -2.0)) == (1.0,-1.0)
 @test broadcast(+, 1.0, (0, -2.0), [1]) == [2.0, 0.0]
 @test broadcast(*, ["Hello"], ", ", ["World"], "!") == ["Hello, World!"]
+let s = "foo"
+    @test s .* ["bar", "baz"] == ["foobar", "foobaz"]
+end
 
 # Ensure that even strange constructors that break `T(x)::T` work with broadcast
 immutable StrangeType18623 end

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -319,11 +319,11 @@ c, r, res = test_complete(s)
 # (As discussed in #19829, the Base.REPLCompletions.get_type function isn't
 #  powerful enough to analyze general dot calls because it can't handle
 #  anonymous-function evaluation.)
-# s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
-# c, r, res = test_complete(s)
-# @test !res
-# @test length(c) == 1
-# @test c[1] == string(first(methods(Main.CompletionFoo.test5, Tuple{BitArray{1}})))
+s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
+c, r, res = test_complete(s)
+@test !res
+@test_broken length(c) == 1
+@test_broken c[1] == string(first(methods(Main.CompletionFoo.test5, Tuple{BitArray{1}})))
 
 s = "CompletionFoo.test4(CompletionFoo.test_y_array[1]()[1], CompletionFoo.test_y_array[1]()[2], "
 c, r, res = test_complete(s)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -316,11 +316,14 @@ c, r, res = test_complete(s)
 @test length(c) == 1
 @test s[r] == "CompletionFoo.test4"
 
-s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 1
-@test c[1] == string(first(methods(Main.CompletionFoo.test5, Tuple{BitArray{1}})))
+# (As discussed in #19829, the Base.REPLCompletions.get_type function isn't
+#  powerful enough to analyze general dot calls because it can't handle
+#  anonymous-function evaluation.)
+# s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
+# c, r, res = test_complete(s)
+# @test !res
+# @test length(c) == 1
+# @test c[1] == string(first(methods(Main.CompletionFoo.test5, Tuple{BitArray{1}})))
 
 s = "CompletionFoo.test4(CompletionFoo.test_y_array[1]()[1], CompletionFoo.test_y_array[1]()[2], "
 c, r, res = test_complete(s)


### PR DESCRIPTION
This adds a small optimization to inline string literals in dot calls.  i.e. `f.("foo", bar)` becomes `broadcast(x -> f("foo", x), bar)` rather than `broadcast((y,x) -> f(y, x), "foo", bar)`.   In a small benchmark of `["a" for i = 1:1000] .* "b"`, it led to about a 50% speedup.