### PR TITLE
Fix getting started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ the `julia` source directory, type `make testall`. You should see output
 that lists a series of tests being run; if they complete without
 error, you should be in good shape to start using Julia.
 
-You can read about [getting started](http://julialang.org/manual/getting-started) in the manual.
+You can read about [getting started](http://docs.julialang.org/en/stable/manual/getting-started/) in the manual.
 
 If you are building a Julia package for distribution on Linux, OS X,
 or Windows, take a look at the detailed notes in


### PR DESCRIPTION
The current "Getting Started" link in README is broken.