### PR TITLE
Fix nullpointer dereference if compiling with cached=false.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -934,7 +934,7 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
         else
             pdecls = &decls;
         m = emit_function(li, src, world, pdecls, params);
-        if (world)
+        if (params->cached && world)
             decls = li->functionObjectsDecls;
         //n_emit++;
     }


### PR DESCRIPTION
In the case of `cached=false`, `decls` shouldn't point to the cached entries (which are `NULL`, triggering a segfault in a call to `decls.functionObject.getName` below).

As this interface is likely to disappear over time (pure codegen), I've just added tests over at [CUDAnative.jl](https://github.com/JuliaGPU/CUDAnative.jl/commit/e30e1020b7f89ec7d56a1df0f853ce467096e36e).