### PR TITLE
fix #18838, populate `source` field of generated functions

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1297,9 +1297,7 @@ void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name)
 extern "C" JL_DLLEXPORT
 void *jl_get_llvmf_defn(jl_method_instance_t *linfo, size_t world, bool getwrapper, bool optimize, const jl_cgparams_t params)
 {
-    // `source` is `NULL` for generated functions.
-    // The `isstaged` check can be removed if that is not the case anymore.
-    if (linfo->def && linfo->def->source == NULL && !linfo->def->isstaged) {
+    if (linfo->def && linfo->def->source == NULL) {
         // not a generic function
         return NULL;
     }
@@ -1376,9 +1374,7 @@ void *jl_get_llvmf_defn(jl_method_instance_t *linfo, size_t world, bool getwrapp
 extern "C" JL_DLLEXPORT
 void *jl_get_llvmf_decl(jl_method_instance_t *linfo, size_t world, bool getwrapper, const jl_cgparams_t params)
 {
-    // `source` is `NULL` for generated functions.
-    // The `isstaged` check can be removed if that is not the case anymore.
-    if (linfo->def && linfo->def->source == NULL && !linfo->def->isstaged) {
+    if (linfo->def && linfo->def->source == NULL) {
         // not a generic function
         return NULL;
     }

--- a/src/dump.c
+++ b/src/dump.c
@@ -920,6 +920,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v)
         jl_serialize_value(s, (jl_value_t*)m->roots);
         jl_serialize_value(s, (jl_value_t*)m->source);
         jl_serialize_value(s, (jl_value_t*)m->unspecialized);
+        jl_serialize_value(s, (jl_value_t*)m->generator);
         jl_serialize_value(s, (jl_value_t*)m->invokes.unknown);
         write_int8(s->s, m->needs_sparam_vals_ducttape);
     }
@@ -1625,6 +1626,9 @@ static jl_value_t *jl_deserialize_value_method(jl_serializer_state *s, jl_value_
     m->unspecialized = (jl_method_instance_t*)jl_deserialize_value(s, (jl_value_t**)&m->unspecialized);
     if (m->unspecialized)
         jl_gc_wb(m, m->unspecialized);
+    m->generator = (jl_method_instance_t*)jl_deserialize_value(s, (jl_value_t**)&m->generator);
+    if (m->generator)
+        jl_gc_wb(m, m->generator);
     m->invokes.unknown = jl_deserialize_value(s, (jl_value_t**)&m->invokes);
     jl_gc_wb(m, m->invokes.unknown);
     m->needs_sparam_vals_ducttape = read_int8(s->s);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3893,7 +3893,7 @@ void jl_init_types(void)
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(20,
+                        jl_svec(21,
                                 jl_symbol("name"),
                                 jl_symbol("module"),
                                 jl_symbol("file"),
@@ -3907,6 +3907,7 @@ void jl_init_types(void)
                                 jl_symbol("sparam_syms"),
                                 jl_symbol("source"),
                                 jl_symbol("unspecialized"),
+                                jl_symbol("generator"),
                                 jl_symbol("roots"),
                                 jl_symbol("invokes"),
                                 jl_symbol("nargs"),
@@ -3914,7 +3915,7 @@ void jl_init_types(void)
                                 jl_symbol("isva"),
                                 jl_symbol("isstaged"),
                                 jl_symbol("needs_sparam_vals_ducttape")),
-                        jl_svec(20,
+                        jl_svec(21,
                                 jl_sym_type,
                                 jl_module_type,
                                 jl_sym_type,
@@ -3927,6 +3928,7 @@ void jl_init_types(void)
                                 jl_any_type, // TypeMap
                                 jl_simplevector_type,
                                 jl_code_info_type,
+                                jl_any_type, // jl_method_instance_type
                                 jl_any_type, // jl_method_instance_type
                                 jl_array_any_type,
                                 jl_any_type,
@@ -4037,6 +4039,7 @@ void jl_init_types(void)
 #endif
     jl_svecset(jl_methtable_type->types, 8, jl_int32_type); // uint32_t
     jl_svecset(jl_method_type->types, 12, jl_method_instance_type);
+    jl_svecset(jl_method_type->types, 13, jl_method_instance_type);
     jl_svecset(jl_method_instance_type->types, 12, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 13, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 14, jl_voidpointer_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -241,12 +241,10 @@ typedef struct _jl_method_t {
     // table of all argument types for which we've inferred or compiled this code
     union jl_typemap_t specializations;
 
-    // sparams are the symbols in the tvars vector
-    jl_svec_t *sparam_syms;
-    // the code AST template
-    jl_code_info_t *source; // null for builtins and staged functions
-    // unspecialized executable thunk (for isstaged, code for the generator), or null
-    struct _jl_method_instance_t *unspecialized;
+    jl_svec_t *sparam_syms;  // symbols corresponding to the tvars vector
+    jl_code_info_t *source;  // original code template, null for builtins
+    struct _jl_method_instance_t *unspecialized;  // unspecialized executable method instance, or null
+    struct _jl_method_instance_t *generator;  // executable code-generating function if isstaged
     jl_array_t *roots;  // pointers in generated code (shared to reduce memory), or null
 
     // cache of specializations of this method for invoke(), i.e.

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -717,7 +717,7 @@ void print_func_loc(JL_STREAM *s, jl_method_t *m);
 
 void jl_check_static_parameter_conflicts(jl_method_t *m, jl_svec_t *t)
 {
-    jl_code_info_t *src = m->isstaged ? (jl_code_info_t*)m->unspecialized->inferred : m->source;
+    jl_code_info_t *src = m->source;
     size_t nvars = jl_array_len(src->slotnames);
 
     size_t i, n = jl_svec_len(t);


### PR DESCRIPTION
This puts the code for the generator in .source, an executable version of it in a new field called `generator`, and leaves `unspecialized` un-set, so that we can hopefully eventually put a genuine generic implementation there.