### PR TITLE
more verbose multi-line display(c) for Char

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -82,6 +82,6 @@ using UTF8proc: category_abbrev, category_string
 function show(io::IO, ::MIME"text/plain", c::Char)
     show(io, c)
     u = UInt32(c)
-    print(io, ": ", isascii(c) ? "ASCII/" : "", "Unicode U+", hex(u, u > 0xffff ? 8 : 4))
+    print(io, ": ", isascii(c) ? "ASCII/" : "", "Unicode U+", hex(u, u > 0xffff ? 6 : 4))
     print(io, " (category ", category_abbrev(c), ": ", category_string(c), ")")
 end

--- a/base/char.jl
+++ b/base/char.jl
@@ -78,10 +78,9 @@ function show(io::IO, c::Char)
     return
 end
 
-using UTF8proc: category_abbrev, category_string
 function show(io::IO, ::MIME"text/plain", c::Char)
     show(io, c)
     u = UInt32(c)
     print(io, ": ", isascii(c) ? "ASCII/" : "", "Unicode U+", hex(u, u > 0xffff ? 6 : 4))
-    print(io, " (category ", category_abbrev(c), ": ", category_string(c), ")")
+    print(io, " (category ", UTF8proc.category_abbrev(c), ": ", UTF8proc.category_string(c), ")")
 end

--- a/base/char.jl
+++ b/base/char.jl
@@ -77,3 +77,11 @@ function show(io::IO, c::Char)
     end
     return
 end
+
+using UTF8proc: category_abbrev, category_string
+function show(io::IO, ::MIME"text/plain", c::Char)
+    show(io, c)
+    u = UInt32(c)
+    print(io, ": ", isascii(c) ? "ASCII/" : "", "Unicode U+", hex(u, u > 0xffff ? 8 : 4))
+    print(io, " (category ", category_abbrev(c), ": ", category_string(c), ")")
+end

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -11,16 +11,15 @@ export Display, display, pushdisplay, popdisplay, displayable, redisplay,
 # that Julia's dispatch and overloading mechanisms can be used to
 # dispatch show and to add conversions for new types.
 
-immutable MIME{mime} end
+# defined in sysimg.jl for bootstrapping:
+# immutable MIME{mime} end
+# macro MIME_str(s)
+import Base: MIME, @MIME_str
 
 import Base: show, print, string, convert
 MIME(s) = MIME{Symbol(s)}()
 show{mime}(io::IO, ::MIME{mime}) = print(io, "MIME type ", string(mime))
 print{mime}(io::IO, ::MIME{mime}) = print(io, mime)
-
-macro MIME_str(s)
-    :(MIME{$(Expr(:quote, Symbol(s)))})
-end
 
 ###########################################################################
 # For any type T one can define show(io, ::MIME"type", x::T) = ...

--- a/base/strings/utf8proc.jl
+++ b/base/strings/utf8proc.jl
@@ -5,7 +5,7 @@ module UTF8proc
 
 import Base: show, ==, hash, string, Symbol, isless, length, eltype, start, next, done, convert, isvalid, lowercase, uppercase, titlecase
 
-export isgraphemebreak, category_abbrev, category_string
+export isgraphemebreak, category_code, category_abbrev, category_string
 
 # also exported by Base:
 export normalize_string, graphemes, is_assigned_char, charwidth, isvalid,
@@ -51,7 +51,7 @@ const UTF8PROC_CATEGORY_CF = 27
 const UTF8PROC_CATEGORY_CS = 28
 const UTF8PROC_CATEGORY_CO = 29
 
-# strings corresponding to the category constants"
+# strings corresponding to the category constants
 const category_strings = [
     "Other, not assigned",
     "Letter, uppercase",
@@ -200,6 +200,7 @@ titlecase(c::Char) = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) : Char(ccall(
 # returns UTF8PROC_CATEGORY code in 0:30 giving Unicode category
 category_code(c) = ccall(:utf8proc_category, Cint, (UInt32,), c)
 
+# more human-readable representations of the category code
 category_abbrev(c) = unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))
 category_string(c) = category_strings[category_code(c)+1]
 

--- a/base/strings/utf8proc.jl
+++ b/base/strings/utf8proc.jl
@@ -5,7 +5,7 @@ module UTF8proc
 
 import Base: show, ==, hash, string, Symbol, isless, length, eltype, start, next, done, convert, isvalid, lowercase, uppercase, titlecase
 
-export isgraphemebreak
+export isgraphemebreak, category_abbrev, category_string
 
 # also exported by Base:
 export normalize_string, graphemes, is_assigned_char, charwidth, isvalid,
@@ -50,6 +50,40 @@ const UTF8PROC_CATEGORY_CC = 26
 const UTF8PROC_CATEGORY_CF = 27
 const UTF8PROC_CATEGORY_CS = 28
 const UTF8PROC_CATEGORY_CO = 29
+
+# strings corresponding to the category constants"
+const category_strings = [
+    "Other, not assigned",
+    "Letter, uppercase",
+    "Letter, lowercase",
+    "Letter, titlecase",
+    "Letter, modifier",
+    "Letter, other",
+    "Mark, nonspacing",
+    "Mark, spacing combining",
+    "Mark, enclosing",
+    "Number, decimal digit",
+    "Number, letter",
+    "Number, other",
+    "Punctuation, connector",
+    "Punctuation, dash",
+    "Punctuation, open",
+    "Punctuation, close",
+    "Punctuation, initial quote",
+    "Punctuation, final quote",
+    "Punctuation, other",
+    "Symbol, math",
+    "Symbol, currency",
+    "Symbol, modifier",
+    "Symbol, other",
+    "Separator, space",
+    "Separator, line",
+    "Separator, paragraph",
+    "Other, control",
+    "Other, format",
+    "Other, surrogate",
+    "Other, private use"
+]
 
 const UTF8PROC_STABLE    = (1<<1)
 const UTF8PROC_COMPAT    = (1<<2)
@@ -164,9 +198,10 @@ titlecase(c::Char) = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) : Char(ccall(
 ############################################################################
 
 # returns UTF8PROC_CATEGORY code in 0:30 giving Unicode category
-function category_code(c)
-    return ccall(:utf8proc_category, Cint, (UInt32,), c)
-end
+category_code(c) = ccall(:utf8proc_category, Cint, (UInt32,), c)
+
+category_abbrev(c) = unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))
+category_string(c) = category_strings[category_code(c)+1]
 
 """
     is_assigned_char(c) -> Bool

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -158,6 +158,12 @@ include("io.jl")
 include("iostream.jl")
 include("iobuffer.jl")
 
+# define MIME"foo/bar" early so that we can overload 3-arg show
+immutable MIME{mime} end
+macro MIME_str(s)
+    :(MIME{$(Expr(:quote, Symbol(s)))})
+end
+
 # strings & printing
 include("char.jl")
 include("intfuncs.jl")

--- a/test/char.jl
+++ b/test/char.jl
@@ -197,3 +197,4 @@ end
 @test !isequal('x', 120)
 
 @test sprint(show, "text/plain", '$') == "'\$': ASCII/Unicode U+0024 (category Sc: Symbol, currency)"
+@test repr('$') == "'\$'"

--- a/test/char.jl
+++ b/test/char.jl
@@ -195,3 +195,5 @@ let
 end
 
 @test !isequal('x', 120)
+
+@test sprint(show, "text/plain", '$') == "'\$': ASCII/Unicode U+0024 (category Sc: Symbol, currency)"


### PR DESCRIPTION
`show('$')` prints a terse representation like `'$'`.   I've been thinking it would be nice to have a more informative display in the REPL (and in other things like IJulia that use the 3-argument `show` via `display`).  This PR does so, giving output like:
```
julia> '$'
'$': ASCII/Unicode U+0024 (category Sc: Symbol, currency)

julia> '⊗'
'⊗': Unicode U+2297 (category Sm: Symbol, math)
```