### PR TITLE
WIP: Use calloc for zeros

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -254,6 +254,15 @@ for (fname, felt) in ((:zeros,:zero), (:ones,:one))
     end
 end
 
+zero_memory_array{T, N}(::Type{T}, dims::NTuple{N, Int}) = ccall(:jl_new_array, Array{T,N}, (Any, Any, Int32), Array{T,N}, dims, Int32(1))
+zero_memory_array{T}(::Type{T}, dims::NTuple{1, Int}) = ccall(:jl_alloc_array_1d, Array{T,1}, (Any, Int, Int32), Array{T,1}, getfield(dims, 1), Int32(1))
+zero_memory_array{T}(::Type{T}, dims::NTuple{2, Int}) = ccall(:jl_alloc_array_2d, Array{T,2}, (Any, Int, Int, Int32), Array{T,2}, getfield(dims, 1), getfield(dims, 2), Int32(1))
+zero_memory_array{T}(::Type{T}, dims::NTuple{3, Int}) = ccall(:jl_alloc_array_3d, Array{T,3}, (Any, Int, Int, Int, Int32), Array{T,3}, getfield(dims, 1), getfield(dims, 2), getfield(dims, 3), Int32(1))
+
+zero_memory_array{T}(::Type{T}, dims::Tuple) = zero_memory_array(T, map((x)->convert(Int, x), dims))
+
+zeros(::Type{Float64}, dims::Tuple) = zero_memory_array(Float64, dims)
+
 """
     eye([T::Type=Float64,] m::Integer, n::Integer)
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -303,17 +303,17 @@ NTuple{N,T} = Tuple{Vararg{T,N}}
 
 # primitive array constructors
 (::Type{Array{T,N}}){T,N}(d::NTuple{N,Int}) =
-    ccall(:jl_new_array, Array{T,N}, (Any,Any), Array{T,N}, d)
+    ccall(:jl_new_array, Array{T,N}, (Any,Any,Int32), Array{T,N}, d, Int32(0))
 (::Type{Array{T,1}}){T}(d::NTuple{1,Int}) = Array{T,1}(getfield(d,1))
 (::Type{Array{T,2}}){T}(d::NTuple{2,Int}) = Array{T,2}(getfield(d,1), getfield(d,2))
 (::Type{Array{T,3}}){T}(d::NTuple{3,Int}) = Array{T,3}(getfield(d,1), getfield(d,2), getfield(d,3))
-(::Type{Array{T,N}}){T,N}(d::Vararg{Int, N}) = ccall(:jl_new_array, Array{T,N}, (Any,Any), Array{T,N}, d)
+(::Type{Array{T,N}}){T,N}(d::Vararg{Int, N}) = ccall(:jl_new_array, Array{T,N}, (Any,Any,Int32), Array{T,N}, d, Int32(0))
 (::Type{Array{T,1}}){T}(m::Int) =
-    ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, m)
+    ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int,Int32), Array{T,1}, m, Int32(0))
 (::Type{Array{T,2}}){T}(m::Int, n::Int) =
-    ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int), Array{T,2}, m, n)
+    ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int,Int32), Array{T,2}, m, n, Int32(0))
 (::Type{Array{T,3}}){T}(m::Int, n::Int, o::Int) =
-    ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, m, n, o)
+    ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int,Int32), Array{T,3}, m, n, o, Int32(0))
 
 (::Type{Array{T}}){T,N}(d::NTuple{N,Int}) = Array{T,N}(d)
 (::Type{Array{T}}){T}(m::Int) = Array{T,1}(m)

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -154,10 +154,10 @@ function __init__()
         # Register gc tracked allocator if CHOLMOD is new enough
         if current_version >= v"3.0.0"
             cnfg = cglobal((:SuiteSparse_config, :libsuitesparseconfig), Ptr{Void})
-            unsafe_store!(cnfg, cglobal(:jl_malloc, Ptr{Void}), 1)
-            unsafe_store!(cnfg, cglobal(:jl_calloc, Ptr{Void}), 2)
-            unsafe_store!(cnfg, cglobal(:jl_realloc, Ptr{Void}), 3)
-            unsafe_store!(cnfg, cglobal(:jl_free, Ptr{Void}), 4)
+            unsafe_store!(cnfg, cglobal(:jl_gc_malloc, Ptr{Void}), 1)
+            unsafe_store!(cnfg, cglobal(:jl_gc_calloc, Ptr{Void}), 2)
+            unsafe_store!(cnfg, cglobal(:jl_gc_realloc, Ptr{Void}), 3)
+            unsafe_store!(cnfg, cglobal(:jl_gc_free, Ptr{Void}), 4)
         end
 
     catch ex

--- a/src/array.c
+++ b/src/array.c
@@ -102,13 +102,13 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
     }
     else {
         tsz = JL_ARRAY_ALIGN(tsz, JL_CACHE_BYTE_ALIGNMENT); // align whole object
-        data = jl_gc_managed_malloc(tot);
+        data = jl_gc_malloc_aligned(tot, JL_CACHE_BYTE_ALIGNMENT);
         // Allocate the Array **after** allocating the data
         // to make sure the array is still young
         a = (jl_array_t*)jl_gc_alloc(ptls, tsz, atype);
         // No allocation or safepoint allowed after this
         a->flags.how = 2;
-        jl_gc_track_malloced_array(ptls, a);
+        jl_gc_track_malloced_array(ptls, a, 1);
         if (!isunboxed)
             memset(data, 0, tot);
     }
@@ -292,7 +292,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
     a->flags.isaligned = 0;  // TODO: allow passing memalign'd buffers
     if (own_buffer) {
         a->flags.how = 2;
-        jl_gc_track_malloced_array(ptls, a);
+        jl_gc_track_malloced_array(ptls, a, 0);
         jl_gc_count_allocd(nel*elsz + (elsz == 1 ? 1 : 0));
     }
     else {
@@ -348,7 +348,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
     a->flags.isaligned = 0;
     if (own_buffer) {
         a->flags.how = 2;
-        jl_gc_track_malloced_array(ptls, a);
+        jl_gc_track_malloced_array(ptls, a, 0);
         jl_gc_count_allocd(nel*elsz + (elsz == 1 ? 1 : 0));
     }
     else {
@@ -566,8 +566,7 @@ static int NOINLINE array_resize_buffer(jl_array_t *a, size_t newlen)
     if (a->flags.how == 2) {
         // already malloc'd - use realloc
         char *olddata = (char*)a->data - oldoffsnb;
-        a->data = jl_gc_managed_realloc(olddata, nbytes, oldnbytes,
-                                        a->flags.isaligned, (jl_value_t*)a);
+        a->data = jl_gc_realloc_aligned(olddata, nbytes);
     }
     else if (a->flags.how == 3 && jl_is_string(jl_array_data_owner(a))) {
         // if data is in a String, keep it that way
@@ -592,8 +591,8 @@ static int NOINLINE array_resize_buffer(jl_array_t *a, size_t newlen)
             elsz > 4
 #endif
             ) {
-            a->data = jl_gc_managed_malloc(nbytes);
-            jl_gc_track_malloced_array(ptls, a);
+            a->data = jl_gc_malloc_aligned(nbytes, JL_CACHE_BYTE_ALIGNMENT);
+            jl_gc_track_malloced_array(ptls, a, 1);
             a->flags.how = 2;
             a->flags.isaligned = 1;
         }

--- a/src/array.c
+++ b/src/array.c
@@ -124,7 +124,6 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
     a->flags.ptrarray = !isunboxed;
     a->elsize = elsz;
     a->flags.isshared = 0;
-    a->flags.isaligned = 1;
     a->offset = 0;
     if (ndims == 1) {
         a->nrows = nel;
@@ -187,7 +186,6 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
     a->flags.ndims = ndims;
     a->offset = 0;
     a->data = NULL;
-    a->flags.isaligned = data->flags.isaligned;
     jl_value_t *el_type = jl_tparam0(atype);
     assert(store_unboxed(el_type) == !data->flags.ptrarray);
     if (!data->flags.ptrarray) {
@@ -247,7 +245,6 @@ JL_DLLEXPORT jl_array_t *jl_string_to_array(jl_value_t *str)
     a->flags.ndims = 1;
     a->offset = 0;
     a->data = jl_string_data(str);
-    a->flags.isaligned = 0;
     a->elsize = 1;
     a->flags.ptrarray = 0;
     jl_array_data_owner(a) = str;
@@ -289,7 +286,6 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
     a->flags.ptrarray = !isunboxed;
     a->flags.ndims = 1;
     a->flags.isshared = 1;
-    a->flags.isaligned = 0;  // TODO: allow passing memalign'd buffers
     if (own_buffer) {
         a->flags.how = 2;
         jl_gc_track_malloced_array(ptls, a, 0);
@@ -345,7 +341,6 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
     a->flags.ndims = ndims;
     a->offset = 0;
     a->flags.isshared = 1;
-    a->flags.isaligned = 0;
     if (own_buffer) {
         a->flags.how = 2;
         jl_gc_track_malloced_array(ptls, a, 0);
@@ -594,7 +589,6 @@ static int NOINLINE array_resize_buffer(jl_array_t *a, size_t newlen)
             a->data = jl_gc_malloc_aligned(nbytes, JL_CACHE_BYTE_ALIGNMENT);
             jl_gc_track_malloced_array(ptls, a, 1);
             a->flags.how = 2;
-            a->flags.isaligned = 1;
         }
         else {
             a->data = jl_gc_alloc_buf(ptls, nbytes);

--- a/src/gc.c
+++ b/src/gc.c
@@ -2156,14 +2156,14 @@ JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size
     return b;
 }
 
-JL_DLLEXPORT void *jl_malloc(size_t sz)
+JL_DLLEXPORT void *jl_gc_malloc(size_t sz)
 {
     int64_t *p = (int64_t *)jl_gc_counted_malloc(sz);
     p[0] = sz;
     return (void *)(p + 2);
 }
 
-JL_DLLEXPORT void *jl_calloc(size_t nm, size_t sz)
+JL_DLLEXPORT void *jl_gc_calloc(size_t nm, size_t sz)
 {
     int64_t *p;
     size_t nmsz = nm*sz;
@@ -2172,7 +2172,7 @@ JL_DLLEXPORT void *jl_calloc(size_t nm, size_t sz)
     return (void *)(p + 2);
 }
 
-JL_DLLEXPORT void jl_free(void *p)
+JL_DLLEXPORT void jl_gc_free(void *p)
 {
     if (p != NULL) {
         int64_t *pp = (int64_t *)p - 2;
@@ -2181,7 +2181,7 @@ JL_DLLEXPORT void jl_free(void *p)
     }
 }
 
-JL_DLLEXPORT void *jl_realloc(void *p, size_t sz)
+JL_DLLEXPORT void *jl_gc_realloc(void *p, size_t sz)
 {
     int64_t *pp;
     size_t szold;

--- a/src/gc.h
+++ b/src/gc.h
@@ -109,6 +109,12 @@ typedef struct _bigval_t {
 typedef struct _mallocarray_t {
     jl_array_t *a;
     struct _mallocarray_t *next;
+    /*
+      how - how to free the array's data
+      0 = free
+      1 = jl_gc_free_aligned
+    */
+    uint16_t how:1;
 } mallocarray_t;
 
 // pool page metadata

--- a/src/julia.h
+++ b/src/julia.h
@@ -662,6 +662,11 @@ STATIC_INLINE void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
     }
 }
 
+void *jl_gc_malloc_aligned(size_t sz, size_t align);
+void *jl_gc_calloc_aligned(size_t nm, size_t sz, size_t align);
+void *jl_gc_realloc_aligned(void *p, size_t sz);
+void jl_gc_free_aligned(void *p);
+
 JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
 JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
                                          int isaligned, jl_value_t *owner);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1162,7 +1162,7 @@ JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld);
 JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a);
 
 // arrays
-JL_DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims);
+JL_DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims, int iszeros);
 JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
                                           jl_value_t *dims);
 JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
@@ -1170,11 +1170,11 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
 JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
                                          jl_value_t *dims, int own_buffer);
 
-JL_DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr, int iszeros);
 JL_DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr,
-                                           size_t nc);
+                                           size_t nc, int iszeros);
 JL_DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr,
-                                           size_t nc, size_t z);
+                                           size_t nc, size_t z, int iszeros);
 JL_DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str);

--- a/src/julia.h
+++ b/src/julia.h
@@ -137,7 +137,7 @@ typedef struct {
     uint16_t pooled:1;
     uint16_t ptrarray:1;  // representation is pointer array
     uint16_t isshared:1;  // data is shared by multiple Arrays
-    uint16_t isaligned:1; // data allocated with memalign
+    uint16_t _unused:1;
 } jl_array_flags_t;
 
 typedef struct {

--- a/src/julia.h
+++ b/src/julia.h
@@ -667,10 +667,6 @@ void *jl_gc_calloc_aligned(size_t nm, size_t sz, size_t align);
 void *jl_gc_realloc_aligned(void *p, size_t sz);
 void jl_gc_free_aligned(void *p);
 
-JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
-JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
-                                         int isaligned, jl_value_t *owner);
-
 // object accessors -----------------------------------------------------------
 
 #define jl_svec_len(t)              (((jl_svec_t*)(t))->length)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -260,7 +260,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t
 
 void jl_gc_setmark(jl_ptls_t ptls, jl_value_t *v);
 void jl_gc_sync_total_bytes(void);
-void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a);
+void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a, uint16_t how);
 void jl_gc_count_allocd(size_t sz);
 void jl_gc_run_all_finalizers(jl_ptls_t ptls);
 

--- a/src/method.c
+++ b/src/method.c
@@ -150,7 +150,7 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
     li->slotnames = jl_alloc_vec_any(nslots);
     jl_gc_wb(li, li->slotnames);
     li->slottypes = jl_nothing;
-    li->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
+    li->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots, 0);
     jl_gc_wb(li, li->slotflags);
     li->ssavaluetypes = jl_box_long(nssavalue);
     jl_gc_wb(li, li->ssavaluetypes);

--- a/src/module.c
+++ b/src/module.c
@@ -553,7 +553,7 @@ JL_DLLEXPORT void jl_set_current_module(jl_value_t *m)
 
 JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
 {
-    jl_array_t *a = jl_alloc_array_1d(jl_array_any_type, 0);
+    jl_array_t *a = jl_alloc_array_1d(jl_array_any_type, 0, 0);
     JL_GC_PUSH1(&a);
     for(int i=(int)m->usings.len-1; i >= 0; --i) {
         jl_array_grow_end(a, 1);
@@ -566,7 +566,7 @@ JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
 
 JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
 {
-    jl_array_t *a = jl_alloc_array_1d(jl_array_symbol_type, 0);
+    jl_array_t *a = jl_alloc_array_1d(jl_array_symbol_type, 0, 0);
     JL_GC_PUSH1(&a);
     size_t i;
     void **table = m->bindings.table;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -94,8 +94,8 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp)
     if (array_ptr_void_type == NULL) {
         array_ptr_void_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_voidpointer_type, jl_box_long(1));
     }
-    ip = jl_alloc_array_1d(array_ptr_void_type, 0);
-    sp = returnsp ? jl_alloc_array_1d(array_ptr_void_type, 0) : NULL;
+    ip = jl_alloc_array_1d(array_ptr_void_type, 0, 0);
+    sp = returnsp ? jl_alloc_array_1d(array_ptr_void_type, 0, 0) : NULL;
     const size_t maxincr = 1000;
     bt_context_t context;
     bt_cursor_t cursor;
@@ -126,7 +126,7 @@ JL_DLLEXPORT jl_value_t *jl_get_backtrace(void)
     if (array_ptr_void_type == NULL) {
         array_ptr_void_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_voidpointer_type, jl_box_long(1));
     }
-    bt = jl_alloc_array_1d(array_ptr_void_type, ptls->bt_size);
+    bt = jl_alloc_array_1d(array_ptr_void_type, ptls->bt_size, 0);
     memcpy(bt->data, ptls->bt_data, ptls->bt_size * sizeof(void*));
     JL_GC_POP();
     return (jl_value_t*)bt;

--- a/src/sys.c
+++ b/src/sys.c
@@ -266,12 +266,12 @@ JL_DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim, uint8_t str, uint
             s->bpos += n;
             return str;
         }
-        a = jl_alloc_array_1d(jl_array_uint8_type, n);
+        a = jl_alloc_array_1d(jl_array_uint8_type, n, 0);
         memcpy(jl_array_data(a), s->buf + s->bpos, n);
         s->bpos += n;
     }
     else {
-        a = jl_alloc_array_1d(jl_array_uint8_type, 80);
+        a = jl_alloc_array_1d(jl_array_uint8_type, 80, 0);
         ios_t dest;
         ios_mem(&dest, 0);
         ios_setbuf(&dest, (char*)a->data, 80, 0);

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -228,7 +228,7 @@ static jl_array_t *jl_alloc_int_1d(size_t np, size_t len)
             int32 = jl_apply_array_type((jl_value_t*)jl_uint32_type, 1);
         ty = int32;
     }
-    jl_array_t *a = jl_alloc_array_1d(ty, len);
+    jl_array_t *a = jl_alloc_array_1d(ty, len, 0);
     memset(a->data, 0, len * a->elsize);
     return a;
 }

--- a/test/core.jl
+++ b/test/core.jl
@@ -4643,12 +4643,12 @@ end # module SOE
 # issue #15240
 @test_nowarn begin
     local p15240
-    p15240 = ccall(:jl_realloc, Ptr{Void}, (Ptr{Void}, Csize_t), C_NULL, 10)
-    ccall(:jl_free, Void, (Ptr{Void}, ), p15240)
+    p15240 = ccall(:jl_gc_realloc, Ptr{Void}, (Ptr{Void}, Csize_t), C_NULL, 10)
+    ccall(:jl_gc_free, Void, (Ptr{Void}, ), p15240)
 end
 
 # issue #19963
-@test_nowarn ccall(:jl_free, Void, (Ptr{Void}, ), C_NULL)
+@test_nowarn ccall(:jl_gc_free, Void, (Ptr{Void}, ), C_NULL)
 
 # Wrong string size on 64bits for large string.
 if Sys.WORD_SIZE == 64


### PR DESCRIPTION
This resolves #130.  The main goal is to use calloc when creating large arrays of zeros (only opting in to this behavior for appropriate eltypes).  But I had to make a number of other changes along the way:

- Small arrays of zeros are allocated as before, but zeroed using `memset`
- Renamed `jl_malloc` (and friends) to `jl_gc_malloc` to disambiguate from `jl_malloc_aligned`, which allocates memory that isn't gc counted
- Added `jl_gc_malloc_aligned` (and friends)
- Removed `jl_gc_managed_malloc`, the old gc counted, aligned `malloc`, which didn't have a matching `calloc`
- Freed up a bit in `jl_array_flags_t` by tracking whether the memory is aligned or not in `mallocarray_t` instead

Before I submit this, I'd still like to do the following:

- [ ] Check that these changes do indeed make things faster! (need to check both large and small arrays)
- [ ] Add special casing to `jl_gc_malloc_aligned` and `jl_gc_calloc_aligned`
- [ ] Add checks on the alignment argument (?)
- [ ] When using `jl_gc_realloc_aligned`, be smarter and only `memcpy` the memory being used by the array
- [ ] Double check the `zeros` tests
- [ ] Use calloc for more eltypes

