### PR TITLE
Make broadcast return BitArray even if it cannot be inferred

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -244,7 +244,11 @@ function broadcast_t(f, ::Type{Any}, shape, iter, As...)
     st = start(iter)
     I, st = next(iter, st)
     val = f([ _broadcast_getindex(As[i], newindex(I, keeps[i], Idefaults[i])) for i=1:nargs ]...)
-    B = similar(Array{typeof(val)}, shape)
+    if val isa Bool
+        B = similar(BitArray, shape)
+    else
+        B = similar(Array{typeof(val)}, shape)
+    end
     B[I] = val
     return _broadcast!(f, B, keeps, Idefaults, As, Val{nargs}, iter, st, 1)
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -433,8 +433,6 @@ end
         a = f.([false])
         @test a isa Array{String}
         @test a == ["false"]
-        a = f.([true, false])
-        @test a isa Array
-        @test a == [true, "false"]
+        @test f.([true, false]) == [true, "false"]
     end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -424,3 +424,17 @@ end
 let f() = (a = 1; Base.Broadcast._broadcast_eltype((x, y) -> x + y + a, 1.0, 1.0))
     @test @inferred(f()) == Float64
 end
+
+@testset "broadcast resulting in BitArray" begin
+    let f(x) = x ? true : "false"
+        ba = f.([true])
+        @test ba isa BitArray
+        @test ba == [true]
+        a = f.([false])
+        @test a isa Array{String}
+        @test a == ["false"]
+        a = f.([true, false])
+        @test a isa Array
+        @test a == [true, "false"]
+    end
+end


### PR DESCRIPTION
Thanks to #17623 broadcast returns `BitArray` instead of `Array{Bool}` _if this can be decided based on inference_:
```Julia
julia> foo(x::Bool) = (x,"bla")[1] # can be inferred
foo (generic function with 1 method)

julia> foo.(trues(2))
2-element BitArray{1}:
 true
 true

julia> bar(x::Bool) = (x,"bla")[length([x])] # cannot be inferred
bar (generic function with 1 method)

julia> bar.(trues(2))
2-element Array{Bool,1}:
 true
 true
```

Reliance on inference should be avoided, so with this PR:
```Julia
julia> bar.(trues(2))
2-element BitArray{1}:
 true
 true
```

