### PR TITLE
REPL help for LaTeX tab completion

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -175,7 +175,8 @@ function repl_latex(io::IO, s::String)
 end
 repl_latex(s::String) = repl_latex(STDOUT, s)
 
-macro repl(ex...) length(ex) == 2 ? repl(ex[1], ex[2]) : repl(ex[1]) end
+macro repl(ex) repl(ex) end
+macro repl(io, ex) repl(io, ex) end
 
 function repl(io::IO, s::Symbol)
     str = string(s)

--- a/doc/src/manual/unicode-input.md
+++ b/doc/src/manual/unicode-input.md
@@ -3,8 +3,9 @@
 The following table lists Unicode characters that can be entered via
 tab completion of LaTeX-like abbreviations in the Julia REPL (and
 in various other editing environments).  You can also get information on how to
-type a symbol by entering it in the REPL help, i.e. by typing `?` and then the
-symbol in the REPL.
+type a symbol by entering it in the REPL help, i.e. by typing `?` and then
+entering the symbol in the REPL (e.g., by copy-paste from somewhere you saw
+the symbol).
 
 !!! warning
 

--- a/doc/src/manual/unicode-input.md
+++ b/doc/src/manual/unicode-input.md
@@ -1,5 +1,11 @@
 # Unicode Input
 
+The following table lists Unicode characters that can be entered via
+tab completion of LaTeX-like abbreviations in the Julia REPL (and
+in various other editing environments).  You can also get information on how to
+type a symbol by entering it in the REPL help, i.e. by typing `?` and then the
+symbol in the REPL.
+
 !!! warning
 
     This table may appear to contain missing characters in the second column, or even
@@ -28,7 +34,7 @@ function unicode_data()
         for line in readlines(unidata)
             id, name, desc = split(line, ";")[[1, 2, 11]]
             codepoint = parse(UInt32, "0x$id")
-            names[codepoint] = name == "" ? desc : desc == "" ? name : "$name / $desc"
+            names[codepoint] = titlecase(lowercase(name == "" ? desc : desc == "" ? name : "$name / $desc"))
         end
     end
     return names

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -55,8 +55,9 @@ julia> 안녕하세요 = "Hello"
 In the Julia REPL and several other Julia editing environments, you can type many Unicode math
 symbols by typing the backslashed LaTeX symbol name followed by tab.  For example, the variable
 name `δ` can be entered by typing `\delta`-*tab*, or even `α̂₂` by `\alpha`-*tab*-`\hat`-
-*tab*-`\_2`-*tab*.  (You can get information on how to type a symbol via tab completion
-by entering it in the REPL help, i.e. typing `?` and then the symbol in the REPL.)
+*tab*-`\_2`-*tab*.  (If you find a symbol somewhere, e.g. in someone else's code,
+that you don't know how to type, the REPL help will tell you: just type `?` and
+then paste the symbol.)
 
 Julia will even let you redefine built-in constants and functions if needed:
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -55,7 +55,8 @@ julia> 안녕하세요 = "Hello"
 In the Julia REPL and several other Julia editing environments, you can type many Unicode math
 symbols by typing the backslashed LaTeX symbol name followed by tab.  For example, the variable
 name `δ` can be entered by typing `\delta`-*tab*, or even `α̂₂` by `\alpha`-*tab*-`\hat`-
-*tab*-`\_2`-*tab*.
+*tab*-`\_2`-*tab*.  (You can get information on how to type a symbol via tab completion
+by entering it in the REPL help, i.e. typing `?` and then the symbol in the REPL.)
 
 Julia will even let you redefine built-in constants and functions if needed:
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -908,5 +908,7 @@ for (line, expr) in Pair[
     "\"...\""      => "...",
     "r\"...\""     => :(r"..."),
     ]
-    @test Docs.helpmode(line) == :(Base.Docs.@repl($expr))
+    @test Docs.helpmode(line) == :(Base.Docs.@repl($STDOUT, $expr))
+    buf = IOBuffer()
+    @test eval(Base, Docs.helpmode(buf, line)) isa Union{Base.Markdown.MD,Void}
 end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -912,3 +912,13 @@ for (line, expr) in Pair[
     buf = IOBuffer()
     @test eval(Base, Docs.helpmode(buf, line)) isa Union{Base.Markdown.MD,Void}
 end
+
+let save_color = Base.have_color
+    try
+        eval(Base, :(have_color = false))
+        @test sprint(Base.Docs.repl_latex, "√") == "\"√\" can be typed by \\sqrt<tab>\n\n"
+        @test sprint(Base.Docs.repl_latex, "x̂₂") == "\"x̂₂\" can be typed by x\\hat<tab>\\_2<tab>\n\n"
+    finally
+        eval(Base, :(have_color = $save_color))
+    end
+end


### PR DESCRIPTION
In this PR, typing a Unicode symbol into the REPL help now prints information about how to type it using the LaTeX tab completion, if possible:
```
help?> √
"√" can be typed by \sqrt<tab>

search: √

  sqrt(x)

  Return \sqrt{x}. Throws DomainError for negative Real arguments. Use complex
  negative arguments instead. The prefix operator √ is equivalent to sqrt.

help?> x̂₂
"x̂₂" can be typed by x\hat<tab>\_2<tab>

search:

Couldn't find x̂₂
Perhaps you meant xor, exit, exp, exp2, expm, Expr, hex, max, !, !=, !==, $, % or &
  No documentation found.

  Binding x̂₂ does not exist.
```

While I was editing this code, I also made it possible to get the help text in a user-supplied `io` stream rather than `STDOUT`, which will help with IJulia and similar enviroments.