### PR TITLE
add repr for empty multidimensional arrays

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1630,6 +1630,9 @@ end
 
 show(io::IO, X::AbstractArray) = showarray(io, X, true)
 
+repremptyarray{T}(io::IO, X::Array{T}) = print(io, "Array{$T}(", join(size(X),','), ')')
+repremptyarray(io, X) = nothing # by default, we don't know this constructor
+
 function showarray(io::IO, X::AbstractArray, repr::Bool = true; header = true)
     if repr && ndims(X) == 1
         return show_vector(io, X, "[", "]")
@@ -1667,6 +1670,8 @@ function showarray(io::IO, X::AbstractArray, repr::Bool = true; header = true)
                         !repr)
             end
         end
+    elseif repr
+        repremptyarray(io, X)
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -211,6 +211,13 @@ export A, B, C
 export D, E, F
 end"
 
+# issue #19840
+@test_repr "Array{Int}(0)"
+@test_repr "Array{Int}(0,0)"
+@test_repr "Array{Int}(0,0,0)"
+@test_repr "Array{Int}(0,1)"
+@test_repr "Array{Int}(0,0,1)"
+
 # issue #8994
 @test_repr "get! => 2"
 @test_repr "(<) : 2"


### PR DESCRIPTION
Fixes #19840.

```jl
julia> print(Array{Int}(0))
Int64[]
julia> print(Array{Int}(0,0))
Array{Int64}(0,0)
julia> print(Array{Int}(0,5))
Array{Int64}(0,5)
```