### PR TITLE
Fix inference of fastmath floating point comparisons

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -330,6 +330,10 @@ add_tfunc(lt_float, 2, 2, cmp_tfunc)
 add_tfunc(le_float, 2, 2, cmp_tfunc)
 add_tfunc(fpiseq, 2, 2, cmp_tfunc)
 add_tfunc(fpislt, 2, 2, cmp_tfunc)
+add_tfunc(eq_float_fast, 2, 2, cmp_tfunc)
+add_tfunc(ne_float_fast, 2, 2, cmp_tfunc)
+add_tfunc(lt_float_fast, 2, 2, cmp_tfunc)
+add_tfunc(le_float_fast, 2, 2, cmp_tfunc)
 
 chk_tfunc = (x,y) -> Tuple{widenconst(x),Bool}
 add_tfunc(checked_sadd_int, 2, 2, chk_tfunc)

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -471,3 +471,16 @@ foo19641() = let a = 1.0
     Core.Inference.return_type(x -> x + a, Tuple{Float64})
 end
 @inferred foo19641()
+
+test_fast_eq(a, b) = @fastmath a == b
+test_fast_ne(a, b) = @fastmath a != b
+test_fast_lt(a, b) = @fastmath a < b
+test_fast_le(a, b) = @fastmath a <= b
+@inferred test_fast_eq(1f0, 1f0)
+@inferred test_fast_ne(1f0, 1f0)
+@inferred test_fast_lt(1f0, 1f0)
+@inferred test_fast_le(1f0, 1f0)
+@inferred test_fast_eq(1.0, 1.0)
+@inferred test_fast_ne(1.0, 1.0)
+@inferred test_fast_lt(1.0, 1.0)
+@inferred test_fast_le(1.0, 1.0)


### PR DESCRIPTION
See the test cases.

Tentatively add backport label since this should be non-breaking (the test will probably have some trivial conflicts)
