### PR TITLE
Add ORIGIN to rpath for libgit2, libssh2, and mbedtls on FreeBSD

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -40,6 +40,10 @@ ifeq ($(OS),Linux)
 LIBGIT2_OPTS += -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
+ifeq ($(OS),FreeBSD)
+LIBGIT2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
+
 # We need to bundle ca certs on linux now that we're using libgit2 with ssl
 ifeq ($(OS),Linux)
 OPENSSL_DIR=$(shell openssl version -d | cut -d '"' -f 2)

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -24,6 +24,10 @@ ifeq ($(OS),Linux)
 LIBSSH2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
+ifeq ($(OS),FreeBSD)
+LIBSSH2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
+
 $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-encryptedpem.patch
 	echo 1 > $@

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -19,6 +19,10 @@ ifeq ($(OS),Linux)
 MBEDTLS_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
+ifeq ($(OS),FreeBSD)
+MBEDTLS_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
+
 $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ $(MBEDTLS_URL)
 


### PR DESCRIPTION
Currently we add the flag `-DCMAKE_INSTALL_RPATH="\$$ORIGIN"` to the build options on Linux for libgit2, libssh2, and mbedtls. This option is similarly required on FreeBSD; without it, none of the resulting shared libraries can find each other. This PR simply adds the option on FreeBSD.