### PR TITLE
add string precision to @printf

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -626,12 +626,18 @@ function gen_c(flags::String, width::Int, precision::Int, c::Char)
     :(($x)::Integer), blk
 end
 
+function _limit(s, prec)
+    prec >= sizeof(s) && return s
+    p = prevind(s, prec+1)
+    n = nextind(s, p)-1
+    s[1:(prec>=n?n:prevind(s,p))]
+end
+
 function gen_s(flags::String, width::Int, precision::Int, c::Char)
     # print a string:
     #  [sS]: both the same for us (Unicode)
     #
     # flags:
-    #  (0): pad left with zeros
     #  (-): left justify
     #
     @gensym x
@@ -642,6 +648,9 @@ function gen_s(flags::String, width::Int, precision::Int, c::Char)
         else
             push!(blk.args, :($x = repr($x)))
         end
+        if precision!=-1
+            push!(blk.args, :($x = _limit($x, $precision)))
+        end
         if !('-' in flags)
             push!(blk.args, pad(width, :($width-strwidth($x)), ' '))
         end
@@ -650,10 +659,18 @@ function gen_s(flags::String, width::Int, precision::Int, c::Char)
             push!(blk.args, pad(width, :($width-strwidth($x)), ' '))
         end
     else
-        if !('#' in flags)
-            push!(blk.args, :(print(out, $x)))
+        if precision!=-1
+            push!(blk.args, :(io = IOBuffer()))
         else
-            push!(blk.args, :(show(out, $x)))
+            push!(blk.args, :(io = out))
+        end
+        if !('#' in flags)
+            push!(blk.args, :(print(io, $x)))
+        else
+            push!(blk.args, :(show(io, $x)))
+        end
+        if precision!=-1
+            push!(blk.args, :(write(out, _limit(String(take!(io)), $precision))))
         end
     end
     :(($x)::Any), blk

--- a/test/printf.jl
+++ b/test/printf.jl
@@ -223,6 +223,15 @@ end
 @test (@sprintf "%#8s" :test) == "   :test"
 @test (@sprintf "%#-8s" :test) == ":test   "
 
+@test (@sprintf "%8.3s" "test") == "     tes"
+@test (@sprintf "%#8.3s" "test") == "     \"te"
+@test (@sprintf "%-8.3s" "test") == "tes     "
+@test (@sprintf "%#-8.3s" "test") == "\"te     "
+@test (@sprintf "%.3s" "test") == "tes"
+@test (@sprintf "%#.3s" "test") == "\"te"
+@test (@sprintf "%-.3s" "test") == "tes"
+@test (@sprintf "%#-.3s" "test") == "\"te"
+
 # reasonably complex
 @test (@sprintf "Test: %s%c%C%c%#-.0f." "t" 65 66 67 -42) == "Test: tABC-42.."
 


### PR DESCRIPTION
closes https://github.com/JuliaLang/julia/issues/14908

thanks to Scott Jones for the solution:

> Date: Tue, 20 Dec 2016 11:49:35 -0500
> From: Scott Jones 
> To: arthurb
> CC: Milan Bouchet-Valat
> Subject: Re: [JuliaLang/julia] @printf string precision truncate (#14908)
> X-Mailer: Apple Mail (2.3256)
> 
> Unfortunately, it's not really that straightforward.
> 
> [1:precision], on a String(), will give you a bounds error if precision is > sizeof the string.
> It won't limit it by the number of characters either, because String is indexed by bytes, not character positions.
> Also, it won't help in preventing buffer overruns (which is the rationale behind the C spec), because Julia will output all of a character if the end range is anywhere within the character
> (so 1:11 may get 13 bytes, for example).
> 
> Here is a function that will correctly limit the string to the number of bytes given with precision, as per C spec.
> (as you can see, it doesn't need to iteratively call nextind either, it takes advantage of the fact that String is in UTF-8, and you can (relatively) efficiently go backwards with prevind)
> 
> function _limit(s, prec)
>            prec >= sizeof(s) && return s
>            p = prevind(s, prec+1)
>            n = nextind(s, p)-1
>            s[1:(prec>=n?n:prevind(s,p))]
> end
> 
> I hope this helps!
> 
> Scott Jones
> 