### PR TITLE
RFC: Make EOL handling more general

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -187,7 +187,7 @@ end
     readlines(stream::IO, chomp::Bool=false)
     readlines(filename::AbstractString, chomp::Bool=false)
 
-Read all lines (delimited ) of an I/O stream or a file as a vector of strings.
+Read all lines of an I/O stream or a file as a vector of strings.
 Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`.
 The text is assumed to be encoded in UTF-8. If `chomp=false` 
 trailing newline character(s) will be included in the output;

--- a/base/io.jl
+++ b/base/io.jl
@@ -542,10 +542,10 @@ readstring(filename::AbstractString) = open(readstring, filename)
 
 type EachLine
     stream::IO
-    ondone::Function
     chomp::Bool
-    EachLine(stream, chomp) = EachLine(stream, ()->nothing, chomp)
-    EachLine(stream, ondone, chomp) = new(stream, ondone, chomp)
+    ondone::Function
+    EachLine(stream, chomp) = EachLine(stream, chomp, ()->nothing)
+    EachLine(stream, chomp, ondone) = new(stream, chomp, ondone)
 end
 
 """
@@ -555,12 +555,12 @@ end
 Create an iterable object that will yield each line from an I/O stream or a file.
 The text is assumed to be encoded in UTF-8.
 """
-eachline(stream::IO, chomp::Bool = false) = EachLine(stream, chomp)
+eachline(stream::IO, chomp::Bool=false) = EachLine(stream, chomp)
 
 
-function eachline(filename::AbstractString, chomp::Bool = false)
+function eachline(filename::AbstractString, chomp::Bool=false)
     s = open(filename)
-    EachLine(s, ()->close(s), chomp)
+    EachLine(s, chomp, ()->close(s))
 end
 
 start(itr::EachLine) = nothing
@@ -575,7 +575,7 @@ end
 next(itr::EachLine, nada) = (readline(itr.stream, itr.chomp), nothing)
 eltype(::Type{EachLine}) = String
 
-readlines(s=STDIN, chomp = false) = collect(eachline(s, chomp))
+readlines(s=STDIN, chomp::Bool=false) = collect(eachline(s, chomp))
 
 iteratorsize(::Type{EachLine}) = SizeUnknown()
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -166,14 +166,12 @@ The text is assumed to be encoded in UTF-8.
 """
 readuntil(filename::AbstractString, args...) = open(io->readuntil(io, args...), filename)
 
-If true, newline characters and character combinations are stripped from the result; otherwise, newline characters or character combinations are preserved.
-
 """
     readline(stream::IO=STDIN, chomp::Bool=false)
     readline(filename::AbstractString, chomp::Bool=false)
 
 Read a single line of text including from the given I/O stream or file (defaults to `STDIN`).
-Lines in the input can end in '\n', '\r', or '\r\n'. When reading from a file, the text is 
+Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`. When reading from a file, the text is 
 assumed to be encoded in UTF-8. If `chomp=false` trailing newline character(s) will be included
 in the output (if reached before the end of the input); otherwise newline characters(s) 
 are stripped from result.
@@ -190,7 +188,7 @@ end
     readlines(filename::AbstractString, chomp::Bool=false)
 
 Read all lines (delimited ) of an I/O stream or a file as a vector of strings.
-Lines in the input can end in '\n', '\r', or '\r\n'.
+Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`.
 The text is assumed to be encoded in UTF-8. If `chomp=false` 
 trailing newline character(s) will be included in the output;
 otherwise newline characters(s) are stripped from result.
@@ -560,7 +558,7 @@ end
     eachline(filename::AbstractString,  chomp::Bool=false)
 
 Create an iterable object that will yield each line from an I/O stream or a file.
-Lines in the input can end in '\n', '\r', or '\r\n'.
+Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`.
 The text is assumed to be encoded in UTF-8. If `chomp=false` 
 trailing newline character(s) will be included in the output;
 otherwise newline characters(s) are stripped from result.

--- a/base/io.jl
+++ b/base/io.jl
@@ -166,13 +166,17 @@ The text is assumed to be encoded in UTF-8.
 """
 readuntil(filename::AbstractString, args...) = open(io->readuntil(io, args...), filename)
 
-"""
-    readline(stream::IO=STDIN)
-    readline(filename::AbstractString)
+If true, newline characters and character combinations are stripped from the result; otherwise, newline characters or character combinations are preserved.
 
-Read a single line of text, including a trailing newline character (if one is reached before
-the end of the input), from the given I/O stream or file (defaults to `STDIN`).
-When reading from a file, the text is assumed to be encoded in UTF-8.
+"""
+    readline(stream::IO=STDIN, chomp::Bool=false)
+    readline(filename::AbstractString, chomp::Bool=false)
+
+Read a single line of text including from the given I/O stream or file (defaults to `STDIN`).
+Lines in the input can end in '\n', '\r', or '\r\n'. When reading from a file, the text is 
+assumed to be encoded in UTF-8. If `chomp=false` trailing newline character(s) will be included
+in the output (if reached before the end of the input); otherwise newline characters(s) 
+are stripped from result.
 """
 function readline(filename::AbstractString, chomp = false)
     open(filename) do f
@@ -182,13 +186,16 @@ end
 
 
 """
-    readlines(stream::IO)
-    readlines(filename::AbstractString)
+    readlines(stream::IO, chomp::Bool=false)
+    readlines(filename::AbstractString, chomp::Bool=false)
 
-Read all lines of an I/O stream or a file as a vector of strings.
-The text is assumed to be encoded in UTF-8.
+Read all lines (delimited ) of an I/O stream or a file as a vector of strings.
+Lines in the input can end in '\n', '\r', or '\r\n'.
+The text is assumed to be encoded in UTF-8. If `chomp=false` 
+trailing newline character(s) will be included in the output;
+otherwise newline characters(s) are stripped from result.
 """
-function readlines(filename::AbstractString, chomp = false)
+function readlines(filename::AbstractString, chomp::Bool=false)
     open(filename) do f
           readlines(f, chomp)
     end
@@ -549,11 +556,14 @@ type EachLine
 end
 
 """
-    eachline(stream::IO)
-    eachline(filename::AbstractString)
+    eachline(stream::IO,  chomp::Bool=false)
+    eachline(filename::AbstractString,  chomp::Bool=false)
 
 Create an iterable object that will yield each line from an I/O stream or a file.
-The text is assumed to be encoded in UTF-8.
+Lines in the input can end in '\n', '\r', or '\r\n'.
+The text is assumed to be encoded in UTF-8. If `chomp=false` 
+trailing newline character(s) will be included in the output;
+otherwise newline characters(s) are stripped from result.
 """
 eachline(stream::IO, chomp::Bool=false) = EachLine(stream, chomp)
 
@@ -575,7 +585,7 @@ end
 next(itr::EachLine, nada) = (readline(itr.stream, itr.chomp), nothing)
 eltype(::Type{EachLine}) = String
 
-readlines(s=STDIN, chomp::Bool=false) = collect(eachline(s, chomp))
+readlines(s::IO=STDIN, chomp::Bool=false) = collect(eachline(s, chomp))
 
 iteratorsize(::Type{EachLine}) = SizeUnknown()
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -171,9 +171,9 @@ readuntil(filename::AbstractString, args...) = open(io->readuntil(io, args...), 
     readline(filename::AbstractString, chomp::Bool=false)
 
 Read a single line of text including from the given I/O stream or file (defaults to `STDIN`).
-Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`. When reading from a file, the text is 
+Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`. When reading from a file, the text is
 assumed to be encoded in UTF-8. If `chomp=false` trailing newline character(s) will be included
-in the output (if reached before the end of the input); otherwise newline characters(s) 
+in the output (if reached before the end of the input); otherwise newline characters(s)
 are stripped from result.
 """
 function readline(filename::AbstractString, chomp = false)
@@ -189,7 +189,7 @@ end
 
 Read all lines of an I/O stream or a file as a vector of strings.
 Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`.
-The text is assumed to be encoded in UTF-8. If `chomp=false` 
+The text is assumed to be encoded in UTF-8. If `chomp=false`
 trailing newline character(s) will be included in the output;
 otherwise newline characters(s) are stripped from result.
 """
@@ -466,7 +466,7 @@ function readline(s::IO, chomp::Bool=false)
     out = UInt8[]
     while !eof(s)
         c = read(s, UInt8)
-        if c == 0x0d 
+        if c == 0x0d
             !chomp && push!(out, c)
             if !eof(s) && Base.peek(s) == 0x0a
                 c = read(s, UInt8)
@@ -559,7 +559,7 @@ end
 
 Create an iterable object that will yield each line from an I/O stream or a file.
 Lines in the input can end in `'\\n'`, `'\\r'`, or `'\\r\\n'`.
-The text is assumed to be encoded in UTF-8. If `chomp=false` 
+The text is assumed to be encoded in UTF-8. If `chomp=false`
 trailing newline character(s) will be included in the output;
 otherwise newline characters(s) are stripped from result.
 """

--- a/base/io.jl
+++ b/base/io.jl
@@ -457,14 +457,17 @@ end
 
 readline() = readline(STDIN)
 
-function readline(s::IO, chomp::Bool = false)
+function readline(s::IO, chomp::Bool=false)
     out = UInt8[]
     while !eof(s)
         c = read(s, UInt8)
-        if c == 0x0d && !eof(s) && Base.peek(s) == 0x0a
+        if c == 0x0d 
             !chomp && push!(out, c)
-            c = read(s, UInt8)
-            !chomp && push!(out, c)
+            if !eof(s) && Base.peek(s) == 0x0a
+                c = read(s, UInt8)
+                !chomp && push!(out, c)
+            end
+
             break
         elseif c == 0x0a
             !chomp && push!(out, c)
@@ -475,30 +478,6 @@ function readline(s::IO, chomp::Bool = false)
     end
 
     return String(out)
-end
-
-const linefeeds = ['\n', '\r', '\u85', '\u0B', '\u0c', '\u2028', '\u2029']
-
-function readline(s::IO, chomp = false, newlines::Vector{Char}=linefeeds)
-    out = IOBuffer()
-    while !eof(s)
-        c = read(s, Char)
-        if c in newlines
-            if c == '\r' && !eof(s) && Base.peek(s) == 0x0a
-                !chomp && write(out, c)
-                c = read(s, Char)
-                !chomp && write(out, c)
-            else
-                !chomp && write(out, c)
-            end
-
-            break
-        else
-            write(out, c)
-        end
-    end
-
-    return String(take!(out))
 end
 
 """

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -225,6 +225,10 @@ function readuntil(s::IOStream, delim::UInt8)
     ccall(:jl_readuntil, Array{UInt8,1}, (Ptr{Void}, UInt8), s.ios, delim)
 end
 
+function readline(s::IOStream, chomp::Bool=false)
+    String(ccall(:jl_readline, Array{UInt8,1}, (Ptr{Void}, Cint), s.ios, chomp))
+end
+
 function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)
     olb = lb = length(b)
     nr = 0

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -92,7 +92,7 @@ function chomp(s::String)
     i = endof(s)
     if i < 1 || (s.data[i] != 0x0a && s.data[i] != 0x0d)
         SubString(s, 1, i)
-    elseif s.data[i] == 0x0d 
+    elseif s.data[i] == 0x0d
         SubString(s, 1, i-1)
     elseif i < 2 || s.data[i-1] != 0x0d
         SubString(s, 1, i-1)
@@ -103,7 +103,7 @@ end
 
 # NOTE: use with caution -- breaks the immutable string convention!
 function chomp!(s::String)
-    if !isempty(s) && s.data[end] == 0x0a 
+    if !isempty(s) && s.data[end] == 0x0a
         n = (endof(s) < 2 || s.data[end-1] != 0x0d) ? 1 : 2
         ccall(:jl_array_del_end, Void, (Any, UInt), s.data, n)
     elseif s.data[end] == 0x0d

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -831,7 +831,7 @@ size_t ios_copyuntil(ios_t *to, ios_t *from, char delim)
     return total;
 }
 
-//Copy until '\r', '\n' or '\r\n'
+// Copy until '\r', '\n' or '\r\n'
 size_t ios_copyline(ios_t *to, ios_t *from, int chomp)
 {
     size_t nchomp = 0;
@@ -851,7 +851,7 @@ size_t ios_copyline(ios_t *to, ios_t *from, int chomp)
         for (size_t i = 0; i < avail; i++){
             char *p = (char*)from->buf+from->bpos+i;
             char ch = from->buf[from->bpos+i];
-            
+
             if (ch == '\n'){
                 n = p;
                 if (chomp) nchomp = 1;
@@ -861,8 +861,8 @@ size_t ios_copyline(ios_t *to, ios_t *from, int chomp)
             if (ch == '\r'){
                 r = p;
                 if (chomp) nchomp = 1;
-                ntowrite = r - (from->buf+from->bpos) + 1 - nchomp;    
-                if (i <= avail){
+                ntowrite = r - (from->buf+from->bpos) + 1 - nchomp;
+                if (i < avail){
                     char ch2 = from->buf[from->bpos+i+1];
                     if (ch2 == '\n'){
                         if (chomp) nchomp = 2;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -95,6 +95,7 @@ JL_DLLEXPORT void ios_set_readonly(ios_t *s);
 JL_DLLEXPORT size_t ios_copy(ios_t *to, ios_t *from, size_t nbytes);
 JL_DLLEXPORT size_t ios_copyall(ios_t *to, ios_t *from);
 JL_DLLEXPORT size_t ios_copyuntil(ios_t *to, ios_t *from, char delim);
+JL_DLLEXPORT size_t ios_copyline(ios_t *to, ios_t *from, int chomp);
 // ensure at least n bytes are buffered if possible. returns # available.
 JL_DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -281,6 +281,27 @@ JL_DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
     return (jl_value_t*)a;
 }
 
+JL_DLLEXPORT jl_value_t *jl_readline(ios_t *s, int chomp)
+{
+    jl_array_t *a;
+    a = jl_alloc_array_1d(jl_array_uint8_type, 80);
+    ios_t dest;
+    ios_mem(&dest, 0);
+    ios_setbuf(&dest, (char*)a->data, 80, 0);
+    size_t n = ios_copyline(&dest, s, chomp);
+    if (dest.buf != a->data) {
+        a = jl_take_buffer(&dest);
+    }
+    else {
+#ifdef STORE_ARRAY_LEN
+        a->length = n;
+#endif
+        a->nrows = n;
+        ((char*)a->data)[n] = '\0';
+    }
+    return (jl_value_t*)a;
+}
+
 JL_DLLEXPORT uint64_t jl_ios_get_nbyte_int(ios_t *s, const size_t n)
 {
     assert(n <= 8);

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -74,6 +74,20 @@ Base.compact(io)
 @test_throws ArgumentError seek(io,0)
 @test_throws ArgumentError truncate(io,0)
 @test readline(io) == "whipped cream\n"
+@test write(io,"pancakes\r\nwaffles\n\rblueberries\r") > 0
+@test readline(io) == "pancakes\r\n"
+@test readline(io) == "waffles\n"
+@test readline(io) == "\r"
+@test readline(io) == "blueberries\r"
+write(io,"pancakes\r\nwaffles\n\rblueberries\r")
+@test readline(io, true) == "pancakes"
+@test readline(io, true) == "waffles"
+@test readline(io, true) == ""
+@test readline(io, true) == "blueberries"
+write(io,"pancakes\r\nwaffles\n\rblueberries\r")
+@test readlines(io) == String["pancakes\r\n","waffles\n","\r","blueberries\r"]
+write(io,"pancakes\r\nwaffles\n\rblueberries\r")
+@test readlines(io, true) == String["pancakes","waffles","","blueberries"]
 Base.compact(io)
 @test position(io) == 0
 @test ioslength(io) == 0

--- a/test/read.jl
+++ b/test/read.jl
@@ -256,7 +256,7 @@ for (name, f) in l
         @test readlines(io()) == readlines(filename)
         @test readlines(io(), true) == readlines(IOBuffer(text), true)
         @test readlines(io(), true) == readlines(filename, true)
-        
+
         @test collect(eachline(io())) == collect(eachline(IOBuffer(text)))
         @test collect(eachline(io())) == collect(eachline(filename))
         @test collect(eachline(io(), true)) == collect(eachline(IOBuffer(text), true))

--- a/test/read.jl
+++ b/test/read.jl
@@ -7,6 +7,7 @@ tasks = []
 # Create test file
 filename = joinpath(dir, "file.txt")
 text = "C1,C2\n1,2\na,b\n"
+text2 = "line1\rline2\nline\r\nline4"
 
 # List of IO producers
 l = Vector{Tuple{AbstractString,Function}}()
@@ -44,6 +45,10 @@ s = io(text)
 close(s)
 push!(l, ("IOBuffer", io))
 
+# Readlines
+write(filename, text2)
+readlines(filename) == String["line1\r","line2\n","line\r\n","line4"]
+readlines(filename, true) == String["line1","line2","line","line4"]
 
 function run_test_server(srv, text)
     push!(tasks, @async begin
@@ -243,12 +248,19 @@ for (name, f) in l
         verbose && println("$name readline...")
         @test readline(io()) == readline(IOBuffer(text))
         @test readline(io()) == readline(filename)
+        @test readline(io(), true) == readline(IOBuffer(text), true)
+        @test readline(io(), true) == readline(filename, true)
 
         verbose && println("$name readlines...")
         @test readlines(io()) == readlines(IOBuffer(text))
         @test readlines(io()) == readlines(filename)
+        @test readlines(io(), true) == readlines(IOBuffer(text), true)
+        @test readlines(io(), true) == readlines(filename, true)
+        
         @test collect(eachline(io())) == collect(eachline(IOBuffer(text)))
         @test collect(eachline(io())) == collect(eachline(filename))
+        @test collect(eachline(io(), true)) == collect(eachline(IOBuffer(text), true))
+        @test collect(eachline(io(), true)) == collect(eachline(filename, true))
 
         cleanup()
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -213,6 +213,12 @@ end
 @test chop("fooε") == "foo"
 @test isa(chomp("foo"), SubString)
 @test isa(chop("foo"), SubString)
+@test chomp("foo\r\n") == "foo"
+@test chomp("foo\r") == "foo"
+@test chomp("foo\r\r") == "foo\r"
+@test Base.chomp!("foo\r\n") == "foo"
+@test Base.chomp!("foo\r") == "foo"
+@test Base.chomp!("foo\r\r") == "foo\r"
 
 # bytes2hex and hex2bytes
 hex_str = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"


### PR DESCRIPTION
This aims to solve #19785. I would like to get feedback if this is going to the right direction and can be merged when ready before working further on this.

- [x] Consider `['\n', '\r', '\r\n']` as line ends in `readline`, `readlines` and `eachline`
- [x] Add option to `readline` etc. to omit EOL (`chomp::Bool=false`)
- [x] Make chomp to remove any of the above line feeds 
- [x] Update documentation
- [x] Add tests

