### PR TITLE
RFC: Rename LibGit2.Oid to LibGit2.GitHash

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1499,6 +1499,9 @@ end
 # Calling promote_op is likely a bad idea, so deprecate its convenience wrapper promote_eltype_op
 @deprecate promote_eltype_op(op, As...) promote_op(op, map(eltype, As)...)
 
+# Rename LibGit2.Oid to LibGit2.GitHash (part of #19839)
+eval(Base.LibGit2, :(Base.@deprecate_binding Oid GitHash))
+
 function unsafe_wrap(::Type{String}, p::Union{Ptr{UInt8},Ptr{Int8}}, len::Integer, own::Bool=false)
     Base.depwarn("unsafe_wrap(String, ...) is deprecated; use `unsafe_string` instead.", :unsafe_wrap)
     #ccall(:jl_array_to_string, Ref{String}, (Any,),

--- a/base/libgit2/blob.jl
+++ b/base/libgit2/blob.jl
@@ -8,10 +8,10 @@ function Base.length(blob::GitBlob)
     return ccall((:git_blob_rawsize, :libgit2), Int64, (Ptr{Void},), blob.ptr)
 end
 
-function lookup(repo::GitRepo, oid::Oid)
+function lookup(repo::GitRepo, oid::GitHash)
     blob_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
     @check ccall((:git_blob_lookup, :libgit2), Cint,
-                  (Ptr{Ptr{Void}}, Ptr{Void}, Ref{Oid}),
+                  (Ptr{Ptr{Void}}, Ptr{Void}, Ref{GitHash}),
                    blob_ptr_ptr, repo.ptr, Ref(oid))
     return GitBlob(blob_ptr_ptr[])
 end

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -255,9 +255,9 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
 end
 
 function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
-                        oid::Ptr{Oid}, is_merge::Cuint, payload::Ptr{Void})
+                        oid::Ptr{GitHash}, is_merge::Cuint, payload::Ptr{Void})
     fhead_vec = unsafe_pointer_to_objref(payload)::Vector{FetchHead}
-    push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url), Oid(oid), is_merge == 1))
+    push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url), GitHash(oid), is_merge == 1))
     return Cint(0)
 end
 
@@ -266,4 +266,4 @@ mirror_cb() = cfunction(mirror_callback, Cint, (Ptr{Ptr{Void}}, Ptr{Void}, Cstri
 "C function pointer for `credentials_callback`"
 credentials_cb() = cfunction(credentials_callback, Cint, (Ptr{Ptr{Void}}, Cstring, Cstring, Cuint, Ptr{Void}))
 "C function pointer for `fetchhead_foreach_callback`"
-fetchhead_foreach_cb() = cfunction(fetchhead_foreach_callback, Cint, (Cstring, Cstring, Ptr{Oid}, Cuint, Ptr{Void}))
+fetchhead_foreach_cb() = cfunction(fetchhead_foreach_callback, Cint, (Cstring, Cstring, Ptr{GitHash}, Cuint, Ptr{Void}))

--- a/base/libgit2/commit.jl
+++ b/base/libgit2/commit.jl
@@ -30,11 +30,11 @@ function commit(repo::GitRepo,
                 committer::GitSignature,
                 tree::GitTree,
                 parents::GitCommit...)
-    commit_id_ptr = Ref(Oid())
+    commit_id_ptr = Ref(GitHash())
     nparents = length(parents)
     parentptrs = Ptr{Void}[c.ptr for c in parents]
     @check ccall((:git_commit_create, :libgit2), Cint,
-                 (Ptr{Oid}, Ptr{Void}, Ptr{UInt8},
+                 (Ptr{GitHash}, Ptr{Void}, Ptr{UInt8},
                   Ptr{SignatureStruct}, Ptr{SignatureStruct},
                   Ptr{UInt8}, Ptr{UInt8}, Ptr{Void},
                   Csize_t, Ptr{Ptr{Void}}),
@@ -50,8 +50,8 @@ function commit(repo::GitRepo, msg::AbstractString;
                 refname::AbstractString=Consts.HEAD_FILE,
                 author::Signature = Signature(repo),
                 committer::Signature = Signature(repo),
-                tree_id::Oid = Oid(),
-                parent_ids::Vector{Oid}=Oid[])
+                tree_id::GitHash = GitHash(),
+                parent_ids::Vector{GitHash}=GitHash[])
     # Retrieve tree identifier
     if iszero(tree_id)
         tree_id = with(GitIndex, repo) do idx; write_tree!(idx) end
@@ -60,12 +60,12 @@ function commit(repo::GitRepo, msg::AbstractString;
     # Retrieve parents from HEAD
     if isempty(parent_ids)
         try # if throws then HEAD not found -> empty repo
-            push!(parent_ids, Oid(repo, refname))
+            push!(parent_ids, GitHash(repo, refname))
         end
     end
 
     # return commit id
-    commit_id  = Oid()
+    commit_id  = GitHash()
 
     # get necessary objects
     tree = get(GitTree, repo, tree_id)

--- a/base/libgit2/index.jl
+++ b/base/libgit2/index.jl
@@ -18,9 +18,9 @@ function write!(idx::GitIndex)
 end
 
 function write_tree!(idx::GitIndex)
-    oid_ptr = Ref(Oid())
+    oid_ptr = Ref(GitHash())
     @check ccall((:git_index_write_tree, :libgit2), Cint,
-                 (Ptr{Oid}, Ptr{Void}), oid_ptr, idx.ptr)
+                 (Ptr{GitHash}, Ptr{Void}), oid_ptr, idx.ptr)
     return oid_ptr[]
 end
 
@@ -30,7 +30,7 @@ function owner(idx::GitIndex)
     return GitRepo(repo_ptr)
 end
 
-function read_tree!(idx::GitIndex, tree_id::Oid)
+function read_tree!(idx::GitIndex, tree_id::GitHash)
     repo = owner(idx)
     tree = get(GitTree, repo, tree_id)
     try

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -35,12 +35,12 @@ include("callbacks.jl")
 using .Error
 
 immutable State
-    head::Oid
-    index::Oid
-    work::Oid
+    head::GitHash
+    index::GitHash
+    work::GitHash
 end
 
-"""Return HEAD Oid as string"""
+"""Return HEAD GitHash as string"""
 function head(pkg::AbstractString)
     with(GitRepo, pkg) do repo
         string(head_oid(repo))
@@ -213,18 +213,18 @@ function branch!(repo::GitRepo, branch_name::AbstractString,
             if branch_rmt_ref === nothing
                 with(head(repo)) do head_ref
                     with(peel(GitCommit, head_ref)) do hrc
-                        Oid(hrc)
+                        GitHash(hrc)
                     end
                 end
             else
                 tmpcmt = with(peel(GitCommit, branch_rmt_ref)) do hrc
-                    Oid(hrc)
+                    GitHash(hrc)
                 end
                 finalize(branch_rmt_ref)
                 tmpcmt
             end
         else
-            Oid(commit)
+            GitHash(commit)
         end
         iszero(commit_id) && return
         cmt =  get(GitCommit, repo, commit_id)
@@ -278,13 +278,13 @@ function checkout!(repo::GitRepo, commit::AbstractString = "";
             head_name = shortname(head_ref)
             # if it is HEAD use short OID instead
             if head_name == Consts.HEAD_FILE
-                head_name = string(Oid(head_ref))
+                head_name = string(GitHash(head_ref))
             end
         end
     end
 
     # search for commit to get a commit object
-    obj = get(GitAnyObject, repo, Oid(commit))
+    obj = get(GitAnyObject, repo, GitHash(commit))
     obj === nothing && return
     try
         peeled = peel(obj, Consts.OBJ_COMMIT)
@@ -293,7 +293,7 @@ function checkout!(repo::GitRepo, commit::AbstractString = "";
                        CheckoutOptions()
         try
             # detach commit
-            obj_oid = Oid(peeled)
+            obj_oid = GitHash(peeled)
             ref = GitReference(repo, obj_oid, force=force,
                 msg="libgit2.checkout: moving from $head_name to $(string(obj_oid))")
             finalize(ref)
@@ -340,7 +340,7 @@ function reset!(repo::GitRepo, committish::AbstractString, pathspecs::AbstractSt
 end
 
 """ git reset [--soft | --mixed | --hard] <commit> """
-function reset!(repo::GitRepo, commit::Oid, mode::Cint = Consts.RESET_MIXED)
+function reset!(repo::GitRepo, commit::GitHash, mode::Cint = Consts.RESET_MIXED)
     obj = get(GitAnyObject, repo, commit)
     # object must exist for reset
     obj === nothing && throw(GitError(Error.Object, Error.ERROR, "Commit `$(string(commit))` object not found"))
@@ -425,7 +425,7 @@ function merge!(repo::GitRepo;
                     LibGit2.get(String, cfg, "branch.$branchname.remote")
                 end
                 obj = with(GitReference(repo, "refs/remotes/$remotename/$branchname")) do ref
-                    LibGit2.Oid(ref)
+                    LibGit2.GitHash(ref)
                 end
                 with(get(GitCommit, repo, obj)) do cmt
                     LibGit2.create_branch(repo, branchname, cmt)
@@ -523,7 +523,7 @@ function authors(repo::GitRepo)
 end
 
 function snapshot(repo::GitRepo)
-    head = Oid(repo, Consts.HEAD_FILE)
+    head = GitHash(repo, Consts.HEAD_FILE)
     index = with(GitIndex, repo) do idx; write_tree!(idx) end
     work = try
         with(GitIndex, repo) do idx

--- a/base/libgit2/merge.jl
+++ b/base/libgit2/merge.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-function GitAnnotated(repo::GitRepo, commit_id::Oid)
+function GitAnnotated(repo::GitRepo, commit_id::GitHash)
     ann_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
     @check ccall((:git_annotated_commit_lookup, :libgit2), Cint,
-                  (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{Oid}),
+                  (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{GitHash}),
                    ann_ptr_ptr, repo.ptr, Ref(commit_id))
     return GitAnnotated(ann_ptr_ptr[])
 end
@@ -19,7 +19,7 @@ end
 function GitAnnotated(repo::GitRepo, fh::FetchHead)
     ann_ref_ref = Ref{Ptr{Void}}(C_NULL)
     @check ccall((:git_annotated_commit_from_fetchhead, :libgit2), Cint,
-                  (Ptr{Ptr{Void}}, Ptr{Void}, Cstring, Cstring, Ptr{Oid}),
+                  (Ptr{Ptr{Void}}, Ptr{Void}, Cstring, Cstring, Ptr{GitHash}),
                    ann_ref_ref, repo.ptr, fh.name, fh.url, Ref(fh.oid))
     return GitAnnotated(ann_ref_ref[])
 end
@@ -29,14 +29,14 @@ function GitAnnotated(repo::GitRepo, comittish::AbstractString)
     try
         cmt = peel(obj, Consts.OBJ_COMMIT)
         cmt === nothing && return nothing
-        return GitAnnotated(repo, Oid(cmt))
+        return GitAnnotated(repo, GitHash(cmt))
     finally
         finalize(obj)
     end
 end
 
 function commit(ann::GitAnnotated)
-    return Oid(ccall((:git_annotated_commit_id, :libgit2), Ptr{Oid}, (Ptr{Void},), ann.ptr))
+    return GitHash(ccall((:git_annotated_commit_id, :libgit2), Ptr{GitHash}, (Ptr{Void},), ann.ptr))
 end
 
 function merge_analysis(repo::GitRepo, anns::Vector{GitAnnotated})
@@ -58,7 +58,7 @@ function ffmerge!(repo::GitRepo, ann::GitAnnotated)
     try
         checkout_tree(repo, cmt)
         with(head(repo)) do head_ref
-            cmt_oid = Oid(cmt)
+            cmt_oid = GitHash(cmt)
             msg = "libgit2.merge: fastforward $(string(cmt_oid)) into $(name(head_ref))"
             new_head_ref = if reftype(head_ref) == Consts.REF_OID
                 target!(head_ref, cmt_oid, msg=msg)
@@ -148,17 +148,17 @@ function merge!(repo::GitRepo, anns::Vector{GitAnnotated}, fastforward::Bool;
 end
 
 function merge_base(repo::GitRepo, one::AbstractString, two::AbstractString)
-    oid1_ptr = Ref(Oid(one))
-    oid2_ptr = Ref(Oid(two))
-    moid_ptr = Ref(Oid())
+    oid1_ptr = Ref(GitHash(one))
+    oid2_ptr = Ref(GitHash(two))
+    moid_ptr = Ref(GitHash())
     moid = try
         @check ccall((:git_merge_base, :libgit2), Cint,
-                (Ptr{Oid}, Ptr{Void}, Ptr{Oid}, Ptr{Oid}),
+                (Ptr{GitHash}, Ptr{Void}, Ptr{GitHash}, Ptr{GitHash}),
                 moid_ptr, repo.ptr, oid1_ptr, oid2_ptr)
         moid_ptr[]
     catch e
         #warn("Pkg:",path(repo),"=>",e.msg)
-        Oid()
+        GitHash()
     end
     return moid
 end

--- a/base/libgit2/oid.jl
+++ b/base/libgit2/oid.jl
@@ -1,88 +1,88 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-Oid(id::Oid) = id
-Oid(ptr::Ptr{Oid}) = unsafe_load(ptr)::Oid
+GitHash(id::GitHash) = id
+GitHash(ptr::Ptr{GitHash}) = unsafe_load(ptr)::GitHash
 
-function Oid(ptr::Ptr{UInt8})
+function GitHash(ptr::Ptr{UInt8})
     if ptr == C_NULL
-        throw(ArgumentError("NULL pointer passed to Oid() constructor"))
+        throw(ArgumentError("NULL pointer passed to GitHash() constructor"))
     end
-    oid_ptr = Ref(Oid())
-    ccall((:git_oid_fromraw, :libgit2), Void, (Ptr{Oid}, Ptr{UInt8}), oid_ptr, ptr)
+    oid_ptr = Ref(GitHash())
+    ccall((:git_oid_fromraw, :libgit2), Void, (Ptr{GitHash}, Ptr{UInt8}), oid_ptr, ptr)
     return oid_ptr[]
 end
 
-function Oid(id::Array{UInt8,1})
+function GitHash(id::Array{UInt8,1})
     if length(id) != OID_RAWSZ
         throw(ArgumentError("invalid raw buffer size"))
     end
-    return Oid(pointer(id))
+    return GitHash(pointer(id))
 end
 
-function Oid(id::AbstractString)
+function GitHash(id::AbstractString)
     bstr = String(id)
     len = sizeof(bstr)
-    oid_ptr  = Ref(Oid())
+    oid_ptr  = Ref(GitHash())
     err = if len < OID_HEXSZ
         ccall((:git_oid_fromstrn, :libgit2), Cint,
-              (Ptr{Oid}, Ptr{UInt8}, Csize_t), oid_ptr, bstr, len)
+              (Ptr{GitHash}, Ptr{UInt8}, Csize_t), oid_ptr, bstr, len)
     else
         ccall((:git_oid_fromstrp, :libgit2), Cint,
-              (Ptr{Oid}, Cstring), oid_ptr, bstr)
+              (Ptr{GitHash}, Cstring), oid_ptr, bstr)
     end
-    err != 0 && return Oid()
+    err != 0 && return GitHash()
     return oid_ptr[]
 end
 
-function Oid(ref::GitReference)
-    isempty(ref) && return Oid()
-    reftype(ref) != Consts.REF_OID && return Oid()
+function GitHash(ref::GitReference)
+    isempty(ref) && return GitHash()
+    reftype(ref) != Consts.REF_OID && return GitHash()
     oid_ptr = ccall((:git_reference_target, :libgit2), Ptr{UInt8}, (Ptr{Void},), ref.ptr)
-    oid_ptr == C_NULL && return Oid()
-    return Oid(oid_ptr)
+    oid_ptr == C_NULL && return GitHash()
+    return GitHash(oid_ptr)
 end
 
-function Oid(repo::GitRepo, ref_name::AbstractString)
-    isempty(repo) && return Oid()
-    oid_ptr  = Ref(Oid())
+function GitHash(repo::GitRepo, ref_name::AbstractString)
+    isempty(repo) && return GitHash()
+    oid_ptr  = Ref(GitHash())
     @check ccall((:git_reference_name_to_id, :libgit2), Cint,
-                    (Ptr{Oid}, Ptr{Void}, Cstring),
+                    (Ptr{GitHash}, Ptr{Void}, Cstring),
                      oid_ptr, repo.ptr, ref_name)
     return oid_ptr[]
 end
 
-function Oid(obj::Ptr{Void})
+function GitHash(obj::Ptr{Void})
     oid_ptr = ccall((:git_object_id, :libgit2), Ptr{UInt8}, (Ptr{Void},), obj)
-    oid_ptr == C_NULL && return Oid()
-    return Oid(oid_ptr)
+    oid_ptr == C_NULL && return GitHash()
+    return GitHash(oid_ptr)
 end
 
-function Oid{T<:GitObject}(obj::T)
-    obj === nothing && return Oid()
-    return Oid(obj.ptr)
+function GitHash{T<:GitObject}(obj::T)
+    obj === nothing && return GitHash()
+    return GitHash(obj.ptr)
 end
 
-Base.hex(id::Oid) = join([hex(i,2) for i in id.val])
+Base.hex(id::GitHash) = join([hex(i,2) for i in id.val])
 
-raw(id::Oid) = collect(id.val)
+raw(id::GitHash) = collect(id.val)
 
-Base.string(id::Oid) = hex(id)
+Base.string(id::GitHash) = hex(id)
 
-Base.show(io::IO, id::Oid) = print(io, "Oid($(string(id)))")
+Base.show(io::IO, id::GitHash) = print(io, "GitHash($(string(id)))")
 
-Base.hash(id::Oid, h::UInt) = hash(id.val, h)
+Base.hash(id::GitHash, h::UInt) = hash(id.val, h)
 
-cmp(id1::Oid, id2::Oid) = Int(ccall((:git_oid_cmp, :libgit2), Cint,
-                                    (Ptr{Oid}, Ptr{Oid}), Ref(id1), Ref(id2)))
+cmp(id1::GitHash, id2::GitHash) = Int(ccall((:git_oid_cmp, :libgit2), Cint,
+                                    (Ptr{GitHash}, Ptr{GitHash}), Ref(id1), Ref(id2)))
 
-==(id1::Oid, id2::Oid) = cmp(id1, id2) == 0
-Base.isless(id1::Oid, id2::Oid)  = cmp(id1, id2) < 0
+==(id1::GitHash, id2::GitHash) = cmp(id1, id2) == 0
+Base.isless(id1::GitHash, id2::GitHash)  = cmp(id1, id2) < 0
 
-function iszero(id::Oid)
+function iszero(id::GitHash)
     for i in 1:OID_RAWSZ
         id.val[i] != zero(UInt8) && return false
     end
     return true
 end
 
-Base.zero(::Type{Oid}) = Oid()
+Base.zero(::Type{GitHash}) = GitHash()

--- a/base/libgit2/rebase.jl
+++ b/base/libgit2/rebase.jl
@@ -49,10 +49,10 @@ Commits the current patch to the rebase `rb`, using `sig` as the committer. Is s
 the commit has already been applied.
 """
 function commit(rb::GitRebase, sig::GitSignature)
-    oid_ptr = Ref(Oid())
+    oid_ptr = Ref(GitHash())
     try
         @check ccall((:git_rebase_commit, :libgit2), Error.Code,
-                     (Ptr{Oid}, Ptr{Void}, Ptr{SignatureStruct}, Ptr{SignatureStruct}, Ptr{UInt8}, Ptr{UInt8}),
+                     (Ptr{GitHash}, Ptr{Void}, Ptr{SignatureStruct}, Ptr{SignatureStruct}, Ptr{UInt8}, Ptr{UInt8}),
                       oid_ptr, rb.ptr, C_NULL, sig.ptr, C_NULL, C_NULL)
     catch err
         # TODO: return current HEAD instead

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -44,7 +44,7 @@ end
 function head_oid(repo::GitRepo)
     head_ref = head(repo)
     try
-        return Oid(head_ref)
+        return GitHash(head_ref)
     finally
         finalize(head_ref)
     end
@@ -55,7 +55,7 @@ function headname(repo::GitRepo)
         if isattached(repo)
             shortname(href)
         else
-            "(detached from $(string(Oid(href))[1:7]))"
+            "(detached from $(string(GitHash(href))[1:7]))"
         end
     end
 end
@@ -80,24 +80,24 @@ end
 """ Returns id of a found object """
 function revparseid(repo::GitRepo, objname::AbstractString)
     obj = revparse(repo, objname)
-    obj === nothing && return Oid()
-    oid = Oid(obj.ptr)
+    obj === nothing && return GitHash()
+    oid = GitHash(obj.ptr)
     finalize(obj)
     return oid
 end
 
-function get{T <: GitObject}(::Type{T}, r::GitRepo, oid::Oid, oid_size::Int=OID_HEXSZ)
+function get{T <: GitObject}(::Type{T}, r::GitRepo, oid::GitHash, oid_size::Int=OID_HEXSZ)
     id_ptr  = Ref(oid)
     obj_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
     git_otype = getobjecttype(T)
 
     err = if oid_size != OID_HEXSZ
         ccall((:git_object_lookup_prefix, :libgit2), Cint,
-              (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{Oid}, Csize_t, Cint),
+              (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{GitHash}, Csize_t, Cint),
               obj_ptr_ptr, r.ptr, id_ptr, Csize_t(oid_size), git_otype)
     else
         ccall((:git_object_lookup, :libgit2), Cint,
-              (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{Oid}, Cint),
+              (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{GitHash}, Cint),
               obj_ptr_ptr, r.ptr, id_ptr, git_otype)
     end
     if err == Int(Error.ENOTFOUND)
@@ -112,7 +112,7 @@ function get{T <: GitObject}(::Type{T}, r::GitRepo, oid::Oid, oid_size::Int=OID_
 end
 
 function get{T <: GitObject}(::Type{T}, r::GitRepo, oid::AbstractString)
-    return get(T, r, Oid(oid), length(oid))
+    return get(T, r, GitHash(oid), length(oid))
 end
 
 function gitdir(repo::GitRepo)
@@ -131,7 +131,7 @@ function peel(obj::GitObject, obj_type::Cint)
     err = ccall((:git_object_peel, :libgit2), Cint,
                 (Ptr{Ptr{Void}}, Ptr{Void}, Cint), peeled_ptr_ptr, obj.ptr, obj_type)
     if err == Int(Error.ENOTFOUND)
-        return Oid()
+        return GitHash()
     elseif err != Int(Error.GIT_OK)
         if peeled_ptr_ptr[] != C_NULL
             finalize(GitAnyObject(peeled_ptr_ptr[]))

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -112,7 +112,7 @@ function get{T <: GitObject}(::Type{T}, repo::GitRepo, oid::GitHash, oid_size::I
 end
 
 function get{T <: GitObject}(::Type{T}, repo::GitRepo, oid::AbstractString)
-    return get(T, r, GitHash(oid), length(oid))
+    return get(T, repo, GitHash(oid), length(oid))
 end
 
 function gitdir(repo::GitRepo)

--- a/base/libgit2/tag.jl
+++ b/base/libgit2/tag.jl
@@ -14,16 +14,16 @@ function tag_delete(repo::GitRepo, tag::AbstractString)
                   (Ptr{Void}, Cstring, ), repo.ptr, tag)
 end
 
-function tag_create(repo::GitRepo, tag::AbstractString, commit::Union{AbstractString,Oid};
+function tag_create(repo::GitRepo, tag::AbstractString, commit::Union{AbstractString,GitHash};
                     msg::AbstractString = "",
                     force::Bool = false,
                     sig::Signature = Signature(repo))
-    oid_ptr = Ref(Oid())
+    oid_ptr = Ref(GitHash())
     with(get(GitCommit, repo, commit)) do commit_obj
         commit_obj === nothing && return oid_ptr[] # return empty oid
         with(convert(GitSignature, sig)) do git_sig
             @check ccall((:git_tag_create, :libgit2), Cint,
-                 (Ptr{Oid}, Ptr{Void}, Cstring, Ptr{Void}, Ptr{SignatureStruct}, Cstring, Cint),
+                 (Ptr{GitHash}, Ptr{Void}, Cstring, Ptr{Void}, Ptr{SignatureStruct}, Cstring, Cint),
                   oid_ptr, repo.ptr, tag, commit_obj.ptr, git_sig.ptr, msg, Cint(force))
         end
     end
@@ -37,7 +37,7 @@ function name(tag::GitTag)
 end
 
 function target(tag::GitTag)
-    oid_ptr = ccall((:git_tag_target_id, :libgit2), Ptr{Oid}, (Ptr{Void}, ), tag.ptr)
+    oid_ptr = ccall((:git_tag_target_id, :libgit2), Ptr{GitHash}, (Ptr{Void}, ), tag.ptr)
     oid_ptr == C_NULL && throw(Error.GitError(Error.ERROR))
-    return Oid(oid_ptr)
+    return GitHash(oid_ptr)
 end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -6,11 +6,11 @@ const OID_RAWSZ = 20
 const OID_HEXSZ = OID_RAWSZ * 2
 const OID_MINPREFIXLEN = 4
 
-immutable Oid
+immutable GitHash
     val::NTuple{OID_RAWSZ, UInt8}
-    Oid(val::NTuple{OID_RAWSZ, UInt8}) = new(val)
+    GitHash(val::NTuple{OID_RAWSZ, UInt8}) = new(val)
 end
-Oid() = Oid(ntuple(i->zero(UInt8), OID_RAWSZ))
+GitHash() = GitHash(ntuple(i->zero(UInt8), OID_RAWSZ))
 
 """
     LibGit2.TimeStruct
@@ -227,7 +227,7 @@ Description of one side of a delta.
 Matches the [`git_diff_file`](https://libgit2.github.com/libgit2/#HEAD/type/git_diff_file) struct.
 """
 immutable DiffFile
-    id::Oid
+    id::GitHash
     path::Cstring
     size::Int64
     flags::UInt32
@@ -317,7 +317,7 @@ immutable IndexEntry
     gid::UInt32
     file_size::Int64
 
-    id::Oid
+    id::GitHash
 
     flags::UInt16
     flags_extended::UInt16
@@ -352,7 +352,7 @@ Matches the `git_rebase_operation` struct.
 """
 immutable RebaseOperation
     optype::Cint
-    id::Oid
+    id::GitHash
     exec::Cstring
 end
 Base.show(io::IO, rbo::RebaseOperation) = print(io, "RebaseOperation($(string(rbo.id)))")
@@ -389,7 +389,7 @@ end
 immutable FetchHead
     name::String
     url::String
-    oid::Oid
+    oid::GitHash
     ismerge::Bool
 end
 

--- a/base/libgit2/walker.jl
+++ b/base/libgit2/walker.jl
@@ -8,9 +8,9 @@ function GitRevWalker(r::GitRepo)
 end
 
 function Base.start(w::GitRevWalker)
-    id_ptr = Ref(Oid())
+    id_ptr = Ref(GitHash())
     err = ccall((:git_revwalk_next, :libgit2), Cint,
-                (Ptr{Oid}, Ptr{Void}), id_ptr, w.ptr)
+                (Ptr{GitHash}, Ptr{Void}), id_ptr, w.ptr)
     err != Int(Error.GIT_OK) && return (nothing, true)
     return (id_ptr[], false)
 end
@@ -18,9 +18,9 @@ end
 Base.done(w::GitRevWalker, state) = Bool(state[2])
 
 function Base.next(w::GitRevWalker, state)
-    id_ptr = Ref(Oid())
+    id_ptr = Ref(GitHash())
     err = ccall((:git_revwalk_next, :libgit2), Cint,
-                (Ptr{Oid}, Ptr{Void}), id_ptr, w.ptr)
+                (Ptr{GitHash}, Ptr{Void}), id_ptr, w.ptr)
     err != Int(Error.GIT_OK) && return (state[1], (nothing, true))
     return (state[1], (id_ptr[], false))
 end
@@ -32,8 +32,8 @@ function push_head!(w::GitRevWalker)
     return w
 end
 
-function Base.push!(w::GitRevWalker, cid::Oid)
-    @check ccall((:git_revwalk_push, :libgit2), Cint, (Ptr{Void}, Ptr{Oid}), w.ptr, Ref(cid))
+function Base.push!(w::GitRevWalker, cid::GitHash)
+    @check ccall((:git_revwalk_push, :libgit2), Cint, (Ptr{Void}, Ptr{GitHash}), w.ptr, Ref(cid))
     return w
 end
 
@@ -55,7 +55,7 @@ function repository(w::GitRevWalker)
 end
 
 function Base.map(f::Function, walker::GitRevWalker;
-                  oid::Oid=Oid(),
+                  oid::GitHash=GitHash(),
                   range::AbstractString="",
                   by::Cint = Consts.SORT_NONE,
                   rev::Bool=false,
@@ -84,7 +84,7 @@ function Base.map(f::Function, walker::GitRevWalker;
 end
 
 function Base.count(f::Function, walker::GitRevWalker;
-                  oid::Oid=Oid(),
+                  oid::GitHash=GitHash(),
                   by::Cint = Consts.SORT_NONE,
                   rev::Bool=false)
     c = 0

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -166,7 +166,7 @@ function status(io::IO, pkg::AbstractString, ver::VersionNumber, fix::Bool)
                 if LibGit2.isattached(prepo)
                     print(io, LibGit2.shortname(phead))
                 else
-                    print(io, string(LibGit2.Oid(phead))[1:8])
+                    print(io, string(LibGit2.GitHash(phead))[1:8])
                 end
             end
             attrs = AbstractString[]

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -21,18 +21,18 @@ end
 end
 
 @testset "OID" begin
-    z = LibGit2.Oid()
+    z = LibGit2.GitHash()
     @test LibGit2.iszero(z)
-    @test z == zero(LibGit2.Oid)
-    @test z == LibGit2.Oid(z)
+    @test z == zero(LibGit2.GitHash)
+    @test z == LibGit2.GitHash(z)
     rs = string(z)
     rr = LibGit2.raw(z)
-    @test z == LibGit2.Oid(rr)
-    @test z == LibGit2.Oid(rs)
-    @test z == LibGit2.Oid(pointer(rr))
+    @test z == LibGit2.GitHash(rr)
+    @test z == LibGit2.GitHash(rs)
+    @test z == LibGit2.GitHash(pointer(rr))
     for i in 11:length(rr); rr[i] = 0; end
-    @test LibGit2.Oid(rr) == LibGit2.Oid(rs[1:20])
-    @test_throws ArgumentError LibGit2.Oid(Ptr{UInt8}(C_NULL))
+    @test LibGit2.GitHash(rr) == LibGit2.GitHash(rs[1:20])
+    @test_throws ArgumentError LibGit2.GitHash(Ptr{UInt8}(C_NULL))
 end
 
 @testset "StrArrayStruct" begin
@@ -135,9 +135,9 @@ mktempdir() do dir
     config_file = "testconfig"
     commit_msg1 = randstring(10)
     commit_msg2 = randstring(10)
-    commit_oid1 = LibGit2.Oid()
-    commit_oid2 = LibGit2.Oid()
-    commit_oid3 = LibGit2.Oid()
+    commit_oid1 = LibGit2.GitHash()
+    commit_oid2 = LibGit2.GitHash()
+    commit_oid3 = LibGit2.GitHash()
     master_branch = "master"
     test_branch = "test_branch"
     tag1 = "tag1"
@@ -290,7 +290,7 @@ mktempdir() do dir
                 # lookup commits
                 cmt = LibGit2.get(LibGit2.GitCommit, repo, commit_oid1)
                 try
-                    @test commit_oid1 == LibGit2.Oid(cmt)
+                    @test commit_oid1 == LibGit2.GitHash(cmt)
                     auth = LibGit2.author(cmt)
                     @test isa(auth, LibGit2.Signature)
                     @test auth.name == test_sig.name
@@ -577,7 +577,7 @@ mktempdir() do dir
             @test get(st_uns) == get(st_mod)
 
             # reset repo
-            @test_throws LibGit2.Error.GitError LibGit2.reset!(repo, LibGit2.Oid(), LibGit2.Consts.RESET_HARD)
+            @test_throws LibGit2.Error.GitError LibGit2.reset!(repo, LibGit2.GitHash(), LibGit2.Consts.RESET_HARD)
 
             LibGit2.reset!(repo, LibGit2.head_oid(repo), LibGit2.Consts.RESET_HARD)
             open(joinpath(test_repo, test_file), "r") do io

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -150,10 +150,10 @@ temp_pkg_dir() do
         Pkg.checkout("Example3", branch_name)
 
         LibGit2.with(LibGit2.GitRepo, Pkg.dir("Example2")) do repo
-            @test LibGit2.head_oid(repo) == LibGit2.Oid(branch_commit)
+            @test LibGit2.head_oid(repo) == LibGit2.GitHash(branch_commit)
         end
         LibGit2.with(LibGit2.GitRepo, Pkg.dir("Example3")) do repo
-            @test LibGit2.head_oid(repo) == LibGit2.Oid(branch_commit)
+            @test LibGit2.head_oid(repo) == LibGit2.GitHash(branch_commit)
         end
     end
 
@@ -459,7 +459,7 @@ temp_pkg_dir() do
         # (note that the following Pkg.update calls will update METADATA to the
         # latest version even though they don't update all packages)
         LibGit2.with(LibGit2.GitRepo, metadata_dir) do repo
-            LibGit2.reset!(repo, LibGit2.Oid(old_commit), LibGit2.Consts.RESET_HARD)
+            LibGit2.reset!(repo, LibGit2.GitHash(old_commit), LibGit2.Consts.RESET_HARD)
         end
 
         @test_warn ("INFO: Installing Colors v0.6.4",
@@ -486,7 +486,7 @@ temp_pkg_dir() do
 
         # Reset METADATA to the second to last update of Example.jl
         LibGit2.with(LibGit2.GitRepo, metadata_dir) do repo
-            LibGit2.reset!(repo, LibGit2.Oid(old_commit), LibGit2.Consts.RESET_HARD)
+            LibGit2.reset!(repo, LibGit2.GitHash(old_commit), LibGit2.Consts.RESET_HARD)
         end
 
         Pkg.add(package)


### PR DESCRIPTION
This addresses one of the points in #19839: renaming `Oid` to `GitHash` in LibGit2. I only did this one rename in this PR, since the diff is fairly large as it is.

cc @simonbyrne 