### PR TITLE
Some broadcast performance tweaks

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -9,7 +9,7 @@ Transform an array to its complex conjugate in-place.
 
 See also [`conj`](@ref).
 """
-conj!{T<:Number}(A::AbstractArray{T}) = broadcast!(conj, A, A)
+conj!{T<:Number}(A::AbstractArray{T}) = (@inbounds broadcast!(conj, A, A); A)
 
 for f in (:-, :~, :conj, :sign, :real, :imag)
     @eval ($f)(A::AbstractArray) = broadcast($f, A)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1400,7 +1400,7 @@ sparse(S::UniformScaling, m::Integer, n::Integer=m) = speye_scaled(S.λ, m, n)
 
 
 # TODO: More appropriate location?
-conj!(A::SparseMatrixCSC) = (broadcast!(conj, A.nzval, A.nzval); A)
+conj!(A::SparseMatrixCSC) = (@inbounds broadcast!(conj, A.nzval, A.nzval); A)
 (-)(A::SparseMatrixCSC) = SparseMatrixCSC(A.m, A.n, copy(A.colptr), copy(A.rowval), map(-, A.nzval))
 
 


### PR DESCRIPTION
This allows dot-calls to fully specialize on the first argument when it is a type. The solution here does not extend to type arguments in other positions. For that, something like #19829 for type arguments would be needed, but I'm not sure that is possible in general (except for built-in types).

This PR also allows to remove shape checking in `broadcast!` when applying an `@inbounds` to it.

Should fix #19849