### PR TITLE
Include world age in thread work

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -399,10 +399,13 @@ void ti_threadfun(void *arg)
                 int8_t gc_state = jl_gc_unsafe_enter(ptls);
                 // This is probably always NULL for now
                 jl_module_t *last_m = ptls->current_module;
+                size_t last_age = ptls->world_age;
                 JL_GC_PUSH1(&last_m);
                 ptls->current_module = work->current_module;
+                ptls->world_age = work->world_age;
                 ti_run_fun(work->args);
                 ptls->current_module = last_m;
+                ptls->world_age = last_age;
                 JL_GC_POP();
                 jl_gc_unsafe_leave(ptls, gc_state);
             }
@@ -666,6 +669,7 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_svec_t *args)
     threadwork.args = args;
     threadwork.ret = jl_nothing;
     threadwork.current_module = ptls->current_module;
+    threadwork.world_age = ptls->world_age;
 
 #if PROFILE_JL_THREADING
     uint64_t tcompile = uv_hrtime();

--- a/src/threading.h
+++ b/src/threading.h
@@ -43,6 +43,7 @@ typedef struct {
     jl_svec_t     *args;
     jl_value_t    *ret;
     jl_module_t   *current_module;
+    size_t        world_age;
 } ti_threadwork_t;
 
 // thread function


### PR DESCRIPTION
Similar to how we deal with `current_module`.

Fix #19876
