### PR TITLE
Without DirtyCOW, julia causes penguins to freeze

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -15,6 +15,7 @@
 #endif
 #ifdef _OS_LINUX_
 #  include <sys/syscall.h>
+#  include <sys/utsname.h>
 #endif
 #ifndef _OS_WINDOWS_
 #  include <sys/mman.h>
@@ -265,6 +266,16 @@ static int self_mem_fd = -1;
 
 static int init_self_mem()
 {
+    struct utsname kernel;
+    uname(&kernel);
+    int major, minor;
+    if (-1 == sscanf(kernel.release, "%d.%d", &major, &minor))
+        return -1;
+    // Can't risk getting a memory block backed by transparent huge pages,
+    // which cause the kernel to freeze on systems that have the DirtyCOW
+    // mitigation patch, but are < 4.10.
+    if (!(major > 4 || (major == 4 && minor >= 10)))
+        return -1;
 #ifdef O_CLOEXEC
     int fd = open("/proc/self/mem", O_RDWR | O_SYNC | O_CLOEXEC);
     if (fd == -1)


### PR DESCRIPTION
The DirtyCOW exploit mitigation patch in Linux (torvalds/linux@19be0eaff),
introduced a kernel bug, that would cause the kernel to hang if an
application tries to use /proc/<pid>/mem (or ptrace) to bypass page
protections on pages that are backed by transparent huge pages (though only
if the write causes a COW resolution). We make use of this feature in our
cg memory manager on Linux, but since we can't predict whether or not our
mappings will be backed by transparent huge pages, the only safe thing
to do is to fall back to dual maps on kernels that potentially have this
issue. Since the problematic commit is a fix for a high-profile exploit,
it is quite likely that it is included in most stable kernels by now.
I have a patch pending at http://marc.info/?l=linux-mm&m=148359462417378&w=2,
which I expect will fix this in the kernel for 4.10. However, we'll have
to disable the use of /proc/self/mem for all prior kernel versions to
avoid locking up the kernel.