### PR TITLE
don't warn about redefining methods in Main

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1181,16 +1181,18 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
     jl_method_t *method = (jl_method_t*)newentry->func.method;
     jl_module_t *newmod = method->module;
     jl_module_t *oldmod = oldvalue->module;
-    JL_STREAM *s = JL_STDERR;
-    jl_printf(s, "WARNING: Method definition ");
-    jl_static_show_func_sig(s, (jl_value_t*)newentry->sig);
-    jl_printf(s, " in module %s", jl_symbol_name(oldmod->name));
-    print_func_loc(s, oldvalue);
-    jl_printf(s, " overwritten");
-    if (oldmod != newmod)
-        jl_printf(s, " in module %s", jl_symbol_name(newmod->name));
-    print_func_loc(s, method);
-    jl_printf(s, ".\n");
+    if (newmod != jl_main_module || oldmod != jl_main_module) {
+        JL_STREAM *s = JL_STDERR;
+        jl_printf(s, "WARNING: Method definition ");
+        jl_static_show_func_sig(s, (jl_value_t*)newentry->sig);
+        jl_printf(s, " in module %s", jl_symbol_name(oldmod->name));
+        print_func_loc(s, oldvalue);
+        jl_printf(s, " overwritten");
+        if (oldmod != newmod)
+            jl_printf(s, " in module %s", jl_symbol_name(newmod->name));
+        print_func_loc(s, method);
+        jl_printf(s, ".\n");
+    }
 }
 
 static void update_max_args(jl_methtable_t *mt, jl_tupletype_t *type)


### PR DESCRIPTION
This PR closes #18725 by silencing the "Method definition overwritten" warnings when both the new and old methods are in `Main`.

The warnings are useful for modules, where overwritten methods are usually an error, but are incredibly annoying and confusing during interactive work in the REPL (or IJulia etc.).  (Now that #265 is fixed, redefining functions is much less dangerous, so most of the concerns raised in #18725 should now be moot.)

With this PR:
```jl
julia> f(x) = 3
f (generic function with 1 method)

julia> f(x) = 12
f (generic function with 2 methods)

julia> f(4)
12

julia> module Foo
           f(x) = 3
           f(x) = 4
       end
WARNING: Method definition f(Any) in module Foo at REPL[7]:2 overwritten at REPL[7]:3.
Foo
```