### PR TITLE
show current-world number of methods for display(::Function)

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -109,7 +109,7 @@ function show(io::IO, ::MIME"text/plain", f::Function)
         name = mt.name
         isself = isdefined(ft.name.module, name) &&
                  ft == typeof(getfield(ft.name.module, name))
-        n = length(mt)
+        n = length(methods(f))
         m = n==1 ? "method" : "methods"
         ns = isself ? string(name) : string("(::", name, ")")
         what = startswith(ns, '@') ? "macro" : "generic function"


### PR DESCRIPTION
Functions are displayed in the REPL as `foo (generic function with N methods)`.  Before this PR, `N` was the number of methods *ever* defined, even methods that have been overwritten.  After this PR, `N` is the number in the current world, matching the number displayed by `methods(foo)`.

Before this PR:
```jl
julia> f(x) = 3
f (generic function with 1 method)

julia> f(x) = 4
WARNING: Method definition f(Any) in module Main at REPL[1]:1 overwritten at REPL[2]:1.
f (generic function with 2 methods)
```
After this PR:
```jl
julia> f(x) = 3
f (generic function with 1 method)

julia> f(x) = 4
WARNING: Method definition f(Any) in module Main at REPL[1]:1 overwritten at REPL[2]:1.
f (generic function with 1 method)
```

(Note that #19888 eliminates the warning.)