### PR TITLE
Avoid error if temp_dir acquires .DS_Store file (#19873)

### DIFF
--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -57,7 +57,7 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
         Base.mv(joinpath(temp_dir,"METADATA"), metadata_dir)
         Base.mv(joinpath(temp_dir,"REQUIRE"), joinpath(dir,"REQUIRE"))
         Base.mv(joinpath(temp_dir,"META_BRANCH"), joinpath(dir,"META_BRANCH"))
-        rm(temp_dir)
+        rm(temp_dir, recursive=true)
     catch err
         ispath(metadata_dir) && rm(metadata_dir, recursive=true)
         ispath(temp_dir) && rm(temp_dir, recursive=true)


### PR DESCRIPTION
Issue #19873. If the macOS Finder inserts a .DS_Store file while Pkg.update/Pkg.add operation is in progress, a plain `rm(temp_dir)` will not succeed.