### PR TITLE
Fix ambiguity of broadcast!(identity, ::SparseVector, ::SparseVector)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -19,10 +19,6 @@ typealias ScalarType Union{Type{Any}, Type{Nullable}}
 # special cases for "X .= ..." (broadcast!) assignments
 broadcast!(::typeof(identity), X::AbstractArray, x::Number) = fill!(X, x)
 broadcast!(f, X::AbstractArray, x::Number...) = (@inbounds for I in eachindex(X); X[I] = f(x...); end; X)
-function broadcast!{T,S,N}(::typeof(identity), x::AbstractArray{T,N}, y::AbstractArray{S,N})
-    @boundscheck check_broadcast_shape(broadcast_indices(x), broadcast_indices(y))
-    copy!(x, y)
-end
 
 # logic for deciding the resulting container type
 containertype(x) = containertype(typeof(x))

--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -148,9 +148,6 @@ ambiguityfunnel{Tf}(f::Tf, x, y) = _aresameshape(x, y) ? _noshapecheck_map(f, x,
 broadcast(::typeof(+), x::SparseVector, y::SparseVector) = ambiguityfunnel(+, x, y) # base/sparse/sparsevectors.jl:1266
 broadcast(::typeof(-), x::SparseVector, y::SparseVector) = ambiguityfunnel(-, x, y) # base/sparse/sparsevectors.jl:1266
 broadcast(::typeof(*), x::SparseVector, y::SparseVector) = ambiguityfunnel(*, x, y) # base/sparse/sparsevectors.jl:1266
-function broadcast!(::typeof(identity), C::SparseMatrixCSC, A::SparseMatrixCSC) # from #17623, loc?
-    _checksameshape(C, A); return copy!(C, A)
-end
 
 
 # (4) _map_zeropres!/_map_notzeropres! specialized for a single sparse vector/matrix

--- a/test/sparse/higherorderfns.jl
+++ b/test/sparse/higherorderfns.jl
@@ -86,6 +86,8 @@ end
     @test broadcast(sin, A) == sparse(broadcast(sin, fA))
     @test broadcast!(sin, copy(a), a) == sparse(broadcast!(sin, copy(fa), fa))
     @test broadcast!(sin, copy(A), A) == sparse(broadcast!(sin, copy(fA), fA))
+    @test broadcast!(identity, copy(a), a) == sparse(broadcast!(identity, copy(fa), fa))
+    @test broadcast!(identity, copy(A), A) == sparse(broadcast!(identity, copy(fA), fA))
 end
 
 @testset "broadcast[!] implementation specialized for pairs of (input) sparse vectors/matrices" begin


### PR DESCRIPTION
Without this:
```Julia
julia> a=spzeros(10); a.=a
ERROR: MethodError: broadcast!(::Base.#identity, ::SparseVector{Float64,Int64}, ::SparseVector{Float64,Int64}) is ambiguous. Candidates:
  broadcast!{Tf}(f::Tf, C::Union{SparseMatrixCSC,SparseVector}, A::Union{SparseMatrixCSC,SparseVector}) in Base.SparseArrays.HigherOrderFns at sparse/higherorderfns.jl:84
  broadcast!{Tf,N}(f::Tf, C::Union{SparseMatrixCSC,SparseVector}, A::Union{SparseMatrixCSC,SparseVector}, Bs::Vararg{Union{SparseMatrixCSC,SparseVector},N}) in Base.SparseArrays.HigherOrderFns at sparse/higherorderfns.jl:86
  broadcast!{T,S,N}(::Base.#identity, x::AbstractArray{T,N}, y::AbstractArray{S,N}) in Base.Broadcast at broadcast.jl:23
```

BTW, should `test/ambiguous.jl` have caught this?