### PR TITLE
RFC: add raw_str macro for strings with no interpolation/unescaping

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1303,10 +1303,11 @@ export
     @cmd,    # `commands`
 
     # notation for certain types
-    @b_str,  # byte vector
-    @r_str,  # regex
-    @s_str,  # regex substitution string
-    @v_str,  # version number
+    @b_str,    # byte vector
+    @r_str,    # regex
+    @s_str,    # regex substitution string
+    @v_str,    # version number
+    @raw_str,  # raw string with no interpolation/unescaping
 
     # documentation
     @text_str,

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -310,6 +310,8 @@ unescape_string(s::AbstractString) = sprint(endof(s), unescape_string, s)
 
 macro b_str(s); :($(unescape_string(s)).data); end
 
+macro raw_str(s); s; end
+
 ## multiline strings ##
 
 """

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -883,3 +883,11 @@ scheme.
 
 Besides being used for the [`VERSION`](@ref) constant, `VersionNumber` objects are widely used
 in the `Pkg` module, to specify packages versions and their dependencies.
+
+## [Raw String Literals](@id man-raw-string-literals)
+
+Raw strings without interpolation or unescaping can be expressed with
+non-standard string literals of the form `raw"..."`. Raw string literals
+create ordinary `String` objects which contain the enclosed contents exactly
+as entered with no interpolation or unescaping. This is useful for strings which
+contain code or markup in other languages which use `$` or `\` as special characters.

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -183,3 +183,20 @@ join(myio, "", "", 1)
 @test Base.unindent("\n    \tfoo",4) == "\n    foo"
 @test Base.unindent("\n\t\n    \tfoo",4) == "\n    \n    foo"
 @test Base.unindent("\n\tfoo\tbar",4) == "\n    foo     bar"
+
+# Tests of raw_str macro
+@test raw"$" == "\$"
+@test raw"\n" == "\\n"
+@test raw"\t" == "\\t"
+
+s1 = raw"""
+     lorem ipsum\n
+     $x = 1$
+     """
+
+s2 = """
+     lorem ipsum\\n
+     \$x = 1\$
+     """
+
+@test s1 == s2


### PR DESCRIPTION
This implements a raw_str macro that allows input of strings with no interpolation/unescaping as discussed in issue #11567 and #11764. I understand this functionality (as `L_str`) was removed by commit 7123ad3112cf73fb1e53b3e0585697e30a73cfe1 following discussion in issue #107. However, I think this merits reconsideration for a couple reasons.

1) This feature is useful as a base for working with strings that represent code/markup in other languages. This is reimplemented in packages that deal with these situations, e.g. LaTeXStrings, but the core functionality seems sufficiently general to merit inclusion in base.

2) Although the implementation of raw_str is basically trivial, it has very low discoverability to new users, especially people coming from python who expect to have the functionality builtin. Users wanting to use raw strings shouldn't have to go through [stack overflow](http://stackoverflow.com/questions/21882353/raw-literal-strings-in-julia) to implement this functionality themselves. 
 
3) raw_str is clear, concise and provides a useful base for more complicated use cases. Because raw_str doesn't unescape anything, it is possible to define exactly what you want to unescape in julia, e.g. `unescape(raw"...")` will unescape traditional c/unicode escape sequences but leave $ escaped and avoid interpolation. This seems much cleaner than some proposals for using string macro suffixes to specify exactly what to unescape. Also to me `raw"..."` seems more self-documenting than `L"..."` or `'''...'''` and adds the minimal amount of additional complexity to the strings ecosystem. 

Apologies in advanced if this has already been hashed out beyond the discussions I was able to find, but given the two open issues I thought it was worth submitting a PR to see if we can figure out something that can be merged into master. 

This duplicates PR #19254 which I closed/deleted because there was no response so I assumed there wasn't interest. However, since closing that PR it seems that there is at least some interest so I am creating this new PR. Unfortunately I can't reopen the old one because the branch is deleted. Apologies for the clutter.