### PR TITLE
Run non-Julia finalizers at exit

### DIFF
--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -973,3 +973,7 @@ JL_DLLEXPORT float32x4_t test_ppc64_vec2(int64_t d1, float32x4_t a, float32x4_t 
 JL_DLLEXPORT int threadcall_args(int a, int b) {
     return a + b;
 }
+
+JL_DLLEXPORT void c_exit_finalizer(void* v) {
+    printf("c_exit_finalizer: %d, %u", *(int*)v, (unsigned)((uintptr_t)v & (uintptr_t)1));
+}

--- a/src/gc.c
+++ b/src/gc.c
@@ -246,6 +246,9 @@ static void schedule_all_finalizers(arraylist_t *flist)
         if (!gc_ptr_tag(v, 1)) {
             schedule_finalization(v, f);
         }
+        else {
+            ((void (*)(void*))f)(gc_ptr_clear_tag(v, 1));
+        }
     }
     flist->len = 0;
 }

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -798,6 +798,11 @@ let A = [1]
     @test ccall((:get_c_int, libccalltest), Cint, ()) == -1
 end
 
+# Pointer finalizer at exit (PR #19911)
+let result = readstring(`$(Base.julia_cmd()) --startup-file=no -e "A = Ref{Cint}(42); finalizer(A, cglobal((:c_exit_finalizer, \"$libccalltest\"), Void))"`)
+    @test result == "c_exit_finalizer: 42, 0"
+end
+
 # SIMD Registers
 
 typealias VecReg{N,T} NTuple{N,VecElement{T}}


### PR DESCRIPTION
It seems function-pointer finalizers are not run at exit. The example at the bottom of this comment illustrates the problem, the proposed fix here makes that work but crashes on an MPFR test in make test-all:

```
signal (11): Segmentation fault
while loading no file, in expression starting on line 0
mpfr_clear at /usr/lib/libmpfr.so (unknown line)
jl_gc_run_finalizers_in_list at /home/bjanssens/src/julia/julia/src/gc.c:199 [inlined]
run_finalizers at /home/bjanssens/src/julia/julia/src/gc.c:229 [inlined]
jl_gc_run_all_finalizers at /home/bjanssens/src/julia/julia/src/gc.c:266
jl_atexit_hook at /home/bjanssens/src/julia/julia/src/init.c:223
jl_exit at /home/bjanssens/src/julia/julia/src/jl_uv.c:554
exit at ./initdefs.jl:22
unknown function (ip: 0x7f4d3eda2c08)
jl_call_method_internal at /home/bjanssens/src/julia/julia/src/julia_internal.h:246 [inlined]
jl_apply_generic at /home/bjanssens/src/julia/julia/src/gf.c:2198
jl_apply at /home/bjanssens/src/julia/julia/src/julia.h:1388 [inlined]
jl_f__apply at /home/bjanssens/src/julia/julia/src/builtins.c:548
#512 at ./multi.jl:1488
run_work_thunk at ./multi.jl:1024
#511 at ./event.jl:66
jl_call_method_internal at /home/bjanssens/src/julia/julia/src/julia_internal.h:246 [inlined]
jl_apply_generic at /home/bjanssens/src/julia/julia/src/gf.c:2198
jl_apply at /home/bjanssens/src/julia/julia/src/julia.h:1388 [inlined]
start_task at /home/bjanssens/src/julia/julia/src/task.c:261
```

Clearly I did something wrong, but I'm out of ideas, so there goes my great plan to fix this myself :)

Example C code:
```c++
#include <iostream>

extern "C"
{

int c_int = 0;

}

struct PrintDestruction
{
  ~PrintDestruction()
  {
    std::cout << "final c_int is " << c_int << std::endl;
  }

  static PrintDestruction& instance()
  {
    static PrintDestruction m_instance;
    return m_instance;
  }

private:
  PrintDestruction()
  {
    std::cout << "initial c_int is " << c_int << std::endl;
  }
};

extern "C"
{

int get_c_int(void)
{
    return c_int;
}

void set_c_int(int i)
{
    c_int = i;
    PrintDestruction::instance();
}

void finalizer_cptr(void* v)
{
  std::cout << "Running C finalizer" << std::endl;
  set_c_int(-1);
}

}

```

Example Julia code:
```julia
using Base.Test

const libccalltest = joinpath(dirname(@__FILE__),"finalizers")

let A = [1]
    ccall((:set_c_int, libccalltest), Void, (Cint,), 1)
    @test ccall((:get_c_int, libccalltest), Cint, ()) == 1
    finalizer(A, cglobal((:finalizer_cptr, libccalltest), Void))
end

```