### PR TITLE
Implement `zero!` for arrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -683,6 +683,25 @@ copymutable(itr) = collect(itr)
 
 zero{T}(x::AbstractArray{T}) = fill!(similar(x), zero(T))
 
+"""
+    zero!(x::AbstractArray)
+
+Sets all elements of array `x` to 0. Equivalent to `fill!(x, 0)`.
+
+```jldoctest
+julia> A = ones(2,2)
+2×2 Array{Float64,2}:
+ 1.0  1.0
+ 1.0  1.0
+
+julia> zero!(A)
+2×2 Array{Float64,2}:
+ 0.0  0.0
+ 0.0  0.0
+```
+"""
+zero!{T}(x::AbstractArray{T}) = fill!(x, zero(T))
+
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both LinearFast and LinearSlow arrays
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -580,6 +580,7 @@ export
     vcat,
     vec,
     view,
+    zero!,
     zeros,
 
 # linear algebra

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -32,6 +32,7 @@ Base.trues
 Base.falses
 Base.fill
 Base.fill!
+Base.zero!
 Base.reshape
 Base.similar(::AbstractArray)
 Base.similar(::Any, ::Tuple)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1978,6 +1978,13 @@ end
     test_zeros(oarr.parent, Matrix{UInt16}, (3, 2))
 end
 
+@testset "zero!" begin
+    A = ones(2,2)
+    B = zero(A)
+    zero!(A)
+    @test A == B
+end
+
 # issue #11053
 type T11053
     a::Float64


### PR DESCRIPTION
Implements `zero!` to set all elements of an array to 0.

I was really surprised this wasn't a thing already, and since it is a very common thing to do I think it might be nice to have a special version of `fill!` for this purpose. I think it makes the code very readable and it is obvious what the function does.

```jl
julia> A = rand(2,2)
2×2 Array{Float64,2}:
 0.885381  0.234   
 0.943264  0.777748

julia> zero!(A)
2×2 Array{Float64,2}:
 0.0  0.0
 0.0  0.0
```

(I also really like in-place `!` functions :smile: )

Comments?