### PR TITLE
Use view more in dot calls

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1658,7 +1658,7 @@
                       (nargs (if (null? vararg) new-args (cons vararg new-args))))
                   `(fuse (-> (tuple ,@(reverse nfargs)) ,(replace-vars (caddr f) renames))
                          ,(reverse nargs)))
-                (let ((farg (car old-fargs)) (arg (car old-args)))
+                (let ((farg (car old-fargs)) (arg (ref-to-view (car old-args))))
                   (cond
                    ((and (vararg? farg) (vararg? arg)) ; arg... must be the last argument
                     (if (null? varfarg)


### PR DESCRIPTION
I'm not sure whether we want this, but this would allow us to write

```julia
tmp = rand(1000)
a = rand(1000)
b = rand(1000)

r = 1:4:1000
tmp[r] .= a[r] .* b[r]
```

and have the last line lowered to `broadcast!(*, Base.dotview(tmp, r), Base.dotview(a, r), Base.dotview(a, r))` as proposed [here](https://discourse.julialang.org/t/is-there-a-way-to-choose-the-indices-for-broadcasting/1317). In this particular case, that is equivalent to `broadcast!(*, view(tmp, r), view(a, r), view(b, r))`.

cc @stevengj 