### PR TITLE
silence innocuous -Wsign-compare warning about comparing size_t & int

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4450,7 +4450,7 @@ static std::unique_ptr<Module> emit_function(
             std::vector<Value*> ditypes(0);
 #endif
             for (size_t i = 0; i < jl_nparams(lam->specTypes); i++) { // assumes !va
-                if (i < ctx.nargs && ctx.slots[i].value.isghost)
+                if (i < (size_t)(ctx.nargs) && ctx.slots[i].value.isghost)
                     continue;
                 ditypes.push_back(julia_type_to_di(jl_tparam(lam->specTypes,i),&dbuilder,false));
             }


### PR DESCRIPTION
Silences 
```
    CC src/codegen.o
/Users/stevenj/Documents/Code/julia/src/codegen.cpp:4453:23: warning: 
      comparison of integers of different signs: 'size_t' (aka 'unsigned long')
      and 'int' [-Wsign-compare]
                if (i < ctx.nargs && ctx.slots[i].value.isghost)
                    ~ ^ ~~~~~~~~~
```
warning.

(Could also redefine `i` as an `int`, but then you need a cast elsewhere.)