### PR TITLE
display_error should call latest showerror

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -134,7 +134,8 @@ function print_response(errio::IO, val::ANY, bt, show_value::Bool, have_color::B
         try
             Base.sigatomic_end()
             if bt !== nothing
-                Base.display_error(errio, val, bt)
+                eval(Main, Expr(:body, Expr(:return, Expr(:call, Base.display_error,
+                                                          errio, QuoteNode(val), bt))))
                 iserr, lasterr = false, ()
             else
                 if val !== nothing && show_value

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -539,6 +539,16 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
 end
 end # let exename
 
+# issue #19864:
+type Error19864 <: Exception; end
+function test19864()
+    eval(current_module(), :(Base.showerror(io::IO, e::Error19864) = print(io, "correct19864")))
+    buf = IOBuffer()
+    REPL.print_response(buf, Error19864(), [], false, false, nothing)
+    return String(take!(buf))
+end
+@test contains(test19864(), "correct19864")
+
 # Test containers in error messages are limited #18726
 let io = IOBuffer()
     Base.display_error(io,


### PR DESCRIPTION
This  fixes #19864.   The REPL now calls `display_error` in the latest world, similar to how it calls `display`, in order to pick up user modifications to `showerror`.