### PR TITLE
Make it easier to avoid StackOverflowErrors with promotion and convert

### DIFF
--- a/base/dates/types.jl
+++ b/base/dates/types.jl
@@ -239,7 +239,7 @@ Base.eltype{T<:Period}(::Type{T}) = T
 Base.promote_rule(::Type{Date},x::Type{DateTime}) = DateTime
 Base.isless(x::Date,y::Date) = isless(value(x),value(y))
 Base.isless(x::DateTime,y::DateTime) = isless(value(x),value(y))
-Base.isless(x::TimeType,y::TimeType) = isless(promote(x,y)...)
+Base.isless(x::TimeType,y::TimeType) = isless(Base.promote_noncircular(x,y)...)
 ==(x::TimeType,y::TimeType) = ===(promote(x,y)...)
 
 import Base: sleep,Timer,timedwait

--- a/base/int.jl
+++ b/base/int.jl
@@ -72,7 +72,7 @@ signbit(x::Unsigned) = false
 
 flipsign{T<:BitSigned}(x::T, y::T) = box(T,flipsign_int(unbox(T,x),unbox(T,y)))
 
-flipsign(x::Signed, y::Signed)  = convert(typeof(x), flipsign(promote(x,y)...))
+flipsign(x::Signed, y::Signed)  = convert(typeof(x), flipsign(promote_noncircular(x,y)...))
 flipsign(x::Signed, y::Float16) = flipsign(x, reinterpret(Int16,y))
 flipsign(x::Signed, y::Float32) = flipsign(x, reinterpret(Int32,y))
 flipsign(x::Signed, y::Float64) = flipsign(x, reinterpret(Int64,y))

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -927,7 +927,7 @@ for f in (:+, :-)
 
         $f(r1::Union{FloatRange, OrdinalRange, LinSpace},
            r2::Union{FloatRange, OrdinalRange, LinSpace}) =
-               $f(promote(r1, r2)...)
+               $f(promote_noncircular(r1, r2)...)
     end
 end
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -23,6 +23,7 @@ eval(x) = Core.eval(Base, x)
 eval(m, x) = Core.eval(m, x)
 (::Type{T}){T}(arg) = convert(T, arg)::T
 (::Type{VecElement{T}}){T}(arg) = VecElement{T}(convert(T, arg))
+(::Type{Union{}})(arg) = error("cannot convert type ", typeof(arg), " to Union{}")
 convert{T<:VecElement}(::Type{T}, arg) = T(arg)
 convert{T<:VecElement}(::Type{T}, arg::T) = arg
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -4826,3 +4826,24 @@ end
 f19599{T}(x::((S)->Vector{S})(T)...) = 1
 @test f19599([1],[1]) == 1
 @test_throws MethodError f19599([1],[1.0])
+
+# avoiding StackOverflowErrors (issues #12007, #10326, #15736)
+module SOE
+type Sgnd <: Signed
+    v::Int
+end
+using Base.Test
+@test_throws ErrorException abs(Sgnd(1))       #12007
+io = IOBuffer()
+@test_throws ErrorException show(io, Sgnd(1))  #12007
+
+@test_throws ErrorException convert(Union{}, 1) #10326
+
+@test_throws ErrorException permutedims(rand(()), ()) #15736
+
+immutable MyTime <: Dates.TimeType
+    value::Int
+end
+@test_throws ErrorException isless(MyTime(1), now())
+
+end


### PR DESCRIPTION
This guards against errors that can lead to stack overflows. It resolves a mutually-recursive interaction between `T(x)` and `convert(T, x)` for `T==Union{}`, and more significantly introduces a new function, `promote_noncircular(x, y, z...)`, that throws an error if promotion didn't change at least one of the types. That prevents stack overflows for definitions like
```jl
foo{T}(x::T, y::T) = # "real" definition of foo
foo(x, y) = foo(promote_noncircular(x, y)...)
```

`promote_noncircular` is somewhat similar to (but more general than) `promote_to_supertype`. It is not quite as `@pure`, so the existing mechanism is also retained. At some point we may want to think about exporting this (or a variant), but for now this is a purely internal method.

Fixes #12007, fixes #10326, fixes #15736
