### PR TITLE
make broadcast treat all type arguments as scalars (fix DataArrays.jl#229)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -25,13 +25,13 @@ function broadcast!{T,S,N}(::typeof(identity), x::AbstractArray{T,N}, y::Abstrac
 end
 
 # logic for deciding the resulting container type
-containertype(x) = containertype(typeof(x))
-containertype(::Type) = Any
-containertype{T<:Ptr}(::Type{T}) = Any
-containertype{T<:Tuple}(::Type{T}) = Tuple
-containertype{T<:Ref}(::Type{T}) = Array
-containertype{T<:AbstractArray}(::Type{T}) = Array
-containertype{T<:Nullable}(::Type{T}) = Nullable
+_containertype(::Type) = Any
+_containertype{T<:Ptr}(::Type{T}) = Any
+_containertype{T<:Tuple}(::Type{T}) = Tuple
+_containertype{T<:Ref}(::Type{T}) = Array
+_containertype{T<:AbstractArray}(::Type{T}) = Array
+_containertype{T<:Nullable}(::Type{T}) = Nullable
+containertype(x) = _containertype(typeof(x))
 containertype(ct1, ct2) = promote_containertype(containertype(ct1), containertype(ct2))
 @inline containertype(ct1, ct2, cts...) = promote_containertype(containertype(ct1), containertype(ct2, cts...))
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -386,7 +386,7 @@ end
 Base.getindex(A::Array19745, i::Integer...) = A.data[i...]
 Base.size(A::Array19745) = size(A.data)
 
-Base.Broadcast.containertype{T<:Array19745}(::Type{T}) = Array19745
+Base.Broadcast._containertype{T<:Array19745}(::Type{T}) = Array19745
 
 Base.Broadcast.promote_containertype(::Type{Array19745}, ::Type{Array19745}) = Array19745
 Base.Broadcast.promote_containertype(::Type{Array19745}, ::Type{Array})      = Array19745
@@ -435,4 +435,12 @@ end
         @test a == ["false"]
         @test f.([true, false]) == [true, "false"]
     end
+end
+
+# Test that broadcast treats type arguments as scalars, i.e. containertype yields Any,
+# even for subtypes of abstract array. (https://github.com/JuliaStats/DataArrays.jl/issues/229)
+let
+    @test Base.Broadcast.containertype(AbstractArray) == Any
+    @test broadcast(==, [1], AbstractArray) == BitArray([false])
+    @test broadcast(==, 1, AbstractArray) == false
 end


### PR DESCRIPTION
`Base.Broadcast.broadcast_containertype` is incorrect for `::Type{T}` arguments to upstream `broadcast` where `T <: Union{Tuple, Ref, AbstractArray, Nullable}`, e.g. `Base.Broadcast.broadcast_containertype(AbstractArray)` yields `Array` rather than `Any`. That incorrect return causes, e.g.,
```julia
julia> broadcast(==, [1], AbstractArray)
ERROR: MethodError: no method matching size(::Type{AbstractArray})
Closest candidates are:
  size{N}(::Any, ::Integer, ::Integer, ::Integer...) at abstractarray.jl:23
  size(::BitArray{1}) at bitarray.jl:49
  size(::BitArray{1}, ::Any) at bitarray.jl:53
  ...
Stacktrace:
 [1] broadcast_indices(::Type{Array}, ::Type{T}) at ./broadcast.jl:54
 [2] broadcast_c at ./broadcast.jl:290 [inlined]
 [3] broadcast(::Function, ::Array{Int64,1}, ::Type{T}) at ./broadcast.jl:406
```
This pull request addresses the above issue. Thanks to @ararslan for catching this issue in https://github.com/JuliaStats/DataArrays.jl/issues/229!