### PR TITLE
fix REPL callbacks to use eval so newest world function is executed

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -626,8 +626,8 @@ default_enter_cb(_) = true
 
 write_prompt(terminal, s::PromptState) = write_prompt(terminal, s.p)
 function write_prompt(terminal, p::Prompt)
-    prefix = isa(p.prompt_prefix,Function) ? p.prompt_prefix() : p.prompt_prefix
-    suffix = isa(p.prompt_suffix,Function) ? p.prompt_suffix() : p.prompt_suffix
+    prefix = isa(p.prompt_prefix,Function) ? eval(Expr(:call, p.prompt_prefix)) : p.prompt_prefix
+    suffix = isa(p.prompt_suffix,Function) ? eval(Expr(:call, p.prompt_suffix)) : p.prompt_suffix
     write(terminal, prefix)
     write(terminal, Base.text_colors[:bold])
     write(terminal, p.prompt)
@@ -734,7 +734,7 @@ end
 keymap_fcn(f::Void, c) = (s, p) -> return :ok
 function keymap_fcn(f::Function, c)
     return function (s, p)
-        r = f(s, p, c)
+        r = eval(Expr(:call,f,s, p, c))
         if isa(r, Symbol)
             return r
         else


### PR DESCRIPTION
Implements the suggestions by @luchr to get the REPL callbacks work again. (This also makes the syntax highlighting in OhMyREPL work again.)

