### PR TITLE
deprecate array-reducing isinteger

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -2,11 +2,10 @@
 
  ## Basic functions ##
 
-isinteger(x::AbstractArray) = all(isinteger,x)
-isinteger{T<:Integer,n}(x::AbstractArray{T,n}) = true
 isreal(x::AbstractArray) = all(isreal,x)
 iszero(x::AbstractArray) = all(iszero,x)
 isreal{T<:Real,n}(x::AbstractArray{T,n}) = true
+all{T<:Integer}(::typeof(isinteger), ::AbstractArray{T}) = true
 
 ## Constructors ##
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1541,6 +1541,9 @@ function frexp{T<:AbstractFloat}(A::Array{T})
     return (F, E)
 end
 
+# Deprecate reducing isinteger over arrays
+@deprecate isinteger(A::AbstractArray) all(isinteger, A)
+
 # Deprecate promote_eltype_op (#19814, #19937)
 _promote_eltype_op(::Any) = Any
 _promote_eltype_op(op, A) = (@_inline_meta; promote_op(op, eltype(A)))

--- a/base/number.jl
+++ b/base/number.jl
@@ -4,14 +4,11 @@
 """
     isinteger(x) -> Bool
 
-Test whether `x` or all its elements are numerically equal to some integer.
+Test whether `x` is numerically equal to some integer.
 
 ```jldoctest
 julia> isinteger(4.0)
 true
-
-julia> isinteger([1; 2; 5.5])
-false
 ```
 """
 isinteger(x::Integer) = true

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -747,7 +747,7 @@ let
 end
 
 # isinteger and isreal
-@test isinteger(Diagonal(rand(1:5,5)))
+@test all(isinteger, Diagonal(rand(1:5, 5))) # reducing isinteger(...) deprecated
 @test isreal(Diagonal(rand(5)))
 
 # unary ops

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -277,7 +277,7 @@ end
         X = get(A, -5:5, NaN32)
         @test eltype(X) == Float32
         @test Base.elsize(X) == sizeof(Float32)
-        @test !isinteger(X)
+        @test !all(isinteger, X)
         @test isnan.(X) == [trues(6);falses(5)]
         @test X[7:11] == [1:5;]
         X = get(A, (2:4, 9:-2:-13), 0)


### PR DESCRIPTION
This pull request deprecates array-reducing `isinteger(A::AbstractArray)` in favor of `all(isinteger, A)` (edit: likewise `isreal`). Discussion: https://github.com/JuliaLang/julia/pull/19674#discussion_r93943286, https://github.com/JuliaLang/julia/issues/19598#issuecomment-267408376, and https://github.com/JuliaLang/julia/issues/19598#issuecomment-270032732. (Edit: Also fixes `isimag` for real numbers that are zero.) Best!