### PR TITLE
add first,last,eltype methods for Pair

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -961,6 +961,7 @@ const => = Pair
 start(p::Pair) = 1
 done(p::Pair, i) = i>2
 next(p::Pair, i) = (getfield(p,i), i+1)
+eltype{A,B}(p::Pair{A,B}) = Union{A,B}
 
 indexed_next(p::Pair, i::Int, state) = (getfield(p,i), i+1)
 
@@ -977,6 +978,8 @@ reverse{A,B}(p::Pair{A,B}) = Pair{B,A}(p.second, p.first)
 
 endof(p::Pair) = 2
 length(p::Pair) = 2
+first(p::Pair) = p.first
+last(p::Pair) = p.second
 
 convert{A,B}(::Type{Pair{A,B}}, x::Pair{A,B}) = x
 function convert{A,B}(::Type{Pair{A,B}}, x::Pair)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1,31 +1,35 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # Pair
-p = Pair(1,2)
-@test p == (1=>2)
-@test isequal(p,1=>2)
+p = Pair(10,20)
+@test p == (10=>20)
+@test isequal(p,10=>20)
 @test start(p) == 1
-@test next(p, 1) == (1,2)
+@test next(p, 1) == (10,2)
 @test !done(p, 1)
 @test !done(p,2)
 @test done(p,3)
 @test !done(p,0)
 @test endof(p) == length(p) == 2
-@test Base.indexed_next(p, 1, (1,2)) == (1,2)
-@test Base.indexed_next(p, 2, (1,2)) == (2,3)
+@test Base.indexed_next(p, 1, (1,2)) == (10,2)
+@test Base.indexed_next(p, 2, (1,2)) == (20,3)
 @test (1=>2) < (2=>3)
 @test (2=>2) < (2=>3)
 @test !((2=>3) < (2=>3))
 @test (2=>3) < (4=>3)
 @test (1=>100) < (4=>1)
-@test p[1] == 1
-@test p[2] == 2
+@test p[1] == 10
+@test p[2] == 20
 @test_throws BoundsError p[3]
 @test_throws BoundsError p[false]
-@test p[true] == 1
-@test p[2.0] == 2
-@test p[0x01] == 1
+@test p[true] == 10
+@test p[2.0] == 20
+@test p[0x01] == 10
 @test_throws InexactError p[2.3]
+@test first(p) == 10
+@test last(p) == 20
+@test eltype(p) == Int
+@test eltype(4 => 5.6) == Union{Int,Float64}
 
 # Dict
 h = Dict()


### PR DESCRIPTION
Since `Pair` is iterable, I figured we might as well have an `eltype` function for it (previously, the eltype was `Any`).   And people using `first` and `last` to access the components of the `Pair` has come up a couple of times on the mailing list, so I figured it would be nice to have specialized methods.  The `first(p::Pair)` function is now more than 2x faster, in particular.

(In addition to testing these methods, I modified the tests for `Pair` a bit: it was testing on a `1=>2` pair, which was really confusing because `1` and `2` are also the indices of first and second components, so I changed it to `10=>20`.)