### PR TITLE
julia-syntax.scm: Remove deprecation warning

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -80,7 +80,7 @@
 ;; && sequences.
 (define (expand-vector-compare e)
   (comp-accum e
-              (lambda (a b) `(call & ,a ,b))
+              (lambda (a b) `(call .& ,a ,b))
               (lambda (x) (not (length> x 2)))
               (lambda (e)
                 (if (dotop? (cadr e))

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -89,3 +89,11 @@ end
     @test filter(!isupper, str) == replace(str, r"[A-Z]", "")
     @test filter(!islower, str) == replace(str, r"[a-z]", "")
 end
+
+# issue #19891
+@testset "chained comparison" begin
+    B = 0 .< [1 -1 5] .< 3
+    @test B == [true false false]
+    B = 3 .> [1 -1 5] .> 0
+    @test B == [true false false]
+end


### PR DESCRIPTION
Changed & to .& to remove 0 .< A .< 1
deprecation warning

Fixes #19891