### PR TITLE
Deprecate vectorized ifelse in favor of dot syntax

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1486,6 +1486,12 @@ end
 @deprecate (|)(A::AbstractArray, b::Number)         A .| b
 @deprecate (|)(A::AbstractArray, B::AbstractArray)  A .| B
 
+# Deprecate vectorized ifelse
+@deprecate ifelse(c::AbstractArray{Bool}, x, y) ifelse.(c, x, y)
+@deprecate ifelse(c::AbstractArray{Bool}, x, y::AbstractArray) ifelse.(c, x, y)
+@deprecate ifelse(c::AbstractArray{Bool}, x::AbstractArray, y) ifelse.(c, x, y)
+@deprecate ifelse(c::AbstractArray{Bool}, x::AbstractArray, y::AbstractArray) ifelse.(c, x, y)
+
 function frexp{T<:AbstractFloat}(A::Array{T})
     depwarn("`frexp(x::Array)` is discontinued.", :frexp)
     F = similar(A)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -931,24 +931,6 @@ for f in (:+, :-)
     end
 end
 
-# vectorized ifelse
-
-function ifelse(c::AbstractArray{Bool}, x, y)
-    [ifelse(ci, x, y) for ci in c]
-end
-
-function ifelse(c::AbstractArray{Bool}, x::AbstractArray, y::AbstractArray)
-    [ifelse(c_elem, x_elem, y_elem) for (c_elem, x_elem, y_elem) in zip(c, x, y)]
-end
-
-function ifelse(c::AbstractArray{Bool}, x::AbstractArray, y)
-    [ifelse(c_elem, x_elem, y) for (c_elem, x_elem) in zip(c, x)]
-end
-
-function ifelse(c::AbstractArray{Bool}, x, y::AbstractArray)
-    [ifelse(c_elem, x, y_elem) for (c_elem, y_elem) in zip(c, y)]
-end
-
 # Pair
 
 immutable Pair{A,B}

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -13,10 +13,10 @@ false ? push!(s, 3) : push!(s, 4)
 @test s == Set([1, 4])
 
 B = [true true false]
-@test ifelse(B, 1, 2) == [1 1 2]
-@test ifelse(B, 1, [2 3 4]) == [1 1 4]
-@test ifelse(B, [2 3 4], 1) == [2 3 1]
-@test ifelse(B, [2 3 4], [5 6 7]) == [2 3 7]
+@test ifelse.(B, 1, 2) == [1 1 2]
+@test ifelse.(B, 1, [2 3 4]) == [1 1 4]
+@test ifelse.(B, [2 3 4], 1) == [2 3 1]
+@test ifelse.(B, [2 3 4], [5 6 7]) == [2 3 7]
 
 @test reverse(Pair(1,2)) == Pair(2,1)
 @test reverse(Pair("13","24")) == Pair("24","13")


### PR DESCRIPTION
This pull request deprecates vectorized `ifelse` methods in favor of dot syntax. Ref. https://github.com/JuliaLang/julia/issues/19598#issuecomment-271144184. Best!