### PR TITLE
Change string output for BigFloat Inf and NaN

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -919,6 +919,11 @@ end
 setprecision(f::Function, precision::Integer) = setprecision(f, BigFloat, precision)
 
 function string(x::BigFloat)
+
+    if isnan(x) || isinf(x)
+        return string("BigFloat(", Float64(x), ", ", precision(x), ")")
+    end
+
     # In general, the number of decimal places needed to read back the number exactly
     # is, excluding the most significant, ceil(log(10, 2^precision(x)))
     k = ceil(Int32, precision(x) * 0.3010299956639812)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -919,7 +919,6 @@ end
 setprecision(f::Function, precision::Integer) = setprecision(f, BigFloat, precision)
 
 function string(x::BigFloat)
-
     if isnan(x) || isinf(x)
         return string("BigFloat(", Float64(x), ", ", precision(x), ")")
     end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -896,3 +896,9 @@ for prec in (10, 100, 1000)
         end
     end
 end
+
+setprecision(256) do
+    @test string(big(Inf)) == "BigFloat(Inf, 256)"
+    @test string(big(-Inf)) == "BigFloat(-Inf, 256)"
+    @test string(big(NaN)) == "BigFloat(Inf, 256)"
+end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -900,5 +900,5 @@ end
 setprecision(256) do
     @test string(big(Inf)) == "BigFloat(Inf, 256)"
     @test string(big(-Inf)) == "BigFloat(-Inf, 256)"
-    @test string(big(NaN)) == "BigFloat(Inf, 256)"
+    @test string(big(NaN)) == "BigFloat(NaN, 256)"
 end


### PR DESCRIPTION
Currently:

``` julia
julia> BigFloat(Inf)
inf
```

After this PR:

``` julia
julia> BigFloat(Inf)
BigFloat(Inf, 256)

julia> BigFloat(-Inf)
BigFloat(-Inf, 256)

julia> BigFloat(NaN)
BigFloat(NaN, 256)
```

See #13843 for previous discussion, where it was suggested to differentiate the output for `BigFloat(Inf)` from `Inf` (the output for `Float64(Inf)`).

After #17217, it also makes sense to add the precision in this way.

