### PR TITLE
avoid a copy in readuntil

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -389,7 +389,7 @@ end
 
 function readuntil(s::IO, delim::Char)
     if delim < Char(0x80)
-        return readuntil_string(s::IO, delim % UInt8)
+        return readuntil_string(s, delim % UInt8)
     end
     out = IOBuffer()
     while !eof(s)

--- a/base/io.jl
+++ b/base/io.jl
@@ -389,7 +389,7 @@ end
 
 function readuntil(s::IO, delim::Char)
     if delim < Char(0x80)
-        return String(readuntil(s, delim % UInt8))
+        return readuntil_string(s::IO, delim % UInt8)
     end
     out = IOBuffer()
     while !eof(s)

--- a/base/io.jl
+++ b/base/io.jl
@@ -387,6 +387,10 @@ function read(s::IO, ::Type{Char})
     return Char(c)
 end
 
+# readuntil_string is useful below since it has
+# an optimized method for s::IOStream
+readuntil_string(s::IO, delim::UInt8) = String(readuntil(s, delim))
+
 function readuntil(s::IO, delim::Char)
     if delim < Char(0x80)
         return readuntil_string(s, delim % UInt8)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -229,6 +229,17 @@ function readline(s::IOStream)
     ccall(:jl_readuntil, Ref{String}, (Ptr{Void}, UInt8, UInt8), s.ios, '\n', 1)
 end
 
+"""
+    readuntil_string(s::IO, delim::UInt8)
+
+Like `readuntil(s, delim)`, but returns a `String` rather than
+a `Vector{UInt8}`.
+"""
+readuntil_string(s::IO, delim::UInt8) = String(readuntil(s, delim))
+function readuntil_string(s::IOStream, delim::UInt8)
+    ccall(:jl_readuntil, Ref{String}, (Ptr{Void}, UInt8, UInt8), s.ios, delim, 1)
+end
+
 function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)
     olb = lb = length(b)
     nr = 0

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -225,19 +225,13 @@ function readuntil(s::IOStream, delim::UInt8)
     ccall(:jl_readuntil, Array{UInt8,1}, (Ptr{Void}, UInt8, UInt8), s.ios, delim, 0)
 end
 
-function readline(s::IOStream)
-    ccall(:jl_readuntil, Ref{String}, (Ptr{Void}, UInt8, UInt8), s.ios, '\n', 1)
-end
-
-"""
-    readuntil_string(s::IO, delim::UInt8)
-
-Like `readuntil(s, delim)`, but returns a `String` rather than
-a `Vector{UInt8}`.
-"""
-readuntil_string(s::IO, delim::UInt8) = String(readuntil(s, delim))
+# like readuntil, above, but returns a String without requiring a copy
 function readuntil_string(s::IOStream, delim::UInt8)
     ccall(:jl_readuntil, Ref{String}, (Ptr{Void}, UInt8, UInt8), s.ios, delim, 1)
+end
+
+function readline(s::IOStream)
+    ccall(:jl_readuntil, Ref{String}, (Ptr{Void}, UInt8, UInt8), s.ios, '\n', 1)
 end
 
 function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)


### PR DESCRIPTION
This avoids a copy of the string data in `readuntil(s::IO, delim::Char)` when `delim` is ASCII and `s` is a file.