### PR TITLE
nextfloat(x), prevfloat(x), eps(x) respect precision of BigFloat

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -708,7 +708,7 @@ end
 function eps(x::AbstractFloat)
     if isfinite(x)
         if abs(x) >= realmin(x)  # normal
-            oftype(x, ldexp(2.0, exponent(x) - precision(x)))
+            oftype(x, ldexp(one(x), exponent(x) - precision(x) + 1))
         else
             oftype(x, nextfloat(zero(x)))   # subnormal
         end

--- a/base/float.jl
+++ b/base/float.jl
@@ -703,32 +703,22 @@ end
     realmin() = realmin(Float64)
     realmax() = realmax(Float64)
 
-    #eps(x::AbstractFloat) = isfinite(x) ? abs(x) >= realmin(x) ? ldexp(eps(typeof(x)),exponent(x)) : nextfloat(zero(x)) : oftype(x,NaN)
-    # eps(::Type{Float16}) = $(box(Float16,unbox(UInt16,0x1400)))
-    # eps(::Type{Float32}) = $(box(Float32,unbox(UInt32,0x34000000)))
-    # eps(::Type{Float64}) = $(box(Float64,unbox(UInt64,0x3cb0000000000000)))
+end
 
-    function myeps(x::AbstractFloat)
+function eps(x::AbstractFloat)
     if isfinite(x)
-
-        if abs(x) >= realmin(x)
-            # ldexp(eps(typeof(x)), exponent(x))
-
-            ldexp(2.0, -precision(x) + exponent(x))
-
+        if abs(x) >= realmin(x)  # normal
+            oftype(x, ldexp(2.0, exponent(x) - precision(x)))
         else
-            nextfloat(zero(x))
+            oftype(x, nextfloat(zero(x)))   # subnormal
         end
-
     else
         oftype(x, NaN)
-
     end
 end
 
-
-    eps() = eps(Float64)
-end
+eps{T<:AbstractFloat}(::Type{T}) = eps(one(T))
+eps() = eps(Float64)
 
 ## byte order swaps for arbitrary-endianness serialization/deserialization ##
 bswap(x::Float32) = box(Float32,bswap_int(unbox(Float32,x)))

--- a/base/float.jl
+++ b/base/float.jl
@@ -703,10 +703,30 @@ end
     realmin() = realmin(Float64)
     realmax() = realmax(Float64)
 
-    eps(x::AbstractFloat) = isfinite(x) ? abs(x) >= realmin(x) ? ldexp(eps(typeof(x)),exponent(x)) : nextfloat(zero(x)) : oftype(x,NaN)
-    eps(::Type{Float16}) = $(box(Float16,unbox(UInt16,0x1400)))
-    eps(::Type{Float32}) = $(box(Float32,unbox(UInt32,0x34000000)))
-    eps(::Type{Float64}) = $(box(Float64,unbox(UInt64,0x3cb0000000000000)))
+    #eps(x::AbstractFloat) = isfinite(x) ? abs(x) >= realmin(x) ? ldexp(eps(typeof(x)),exponent(x)) : nextfloat(zero(x)) : oftype(x,NaN)
+    # eps(::Type{Float16}) = $(box(Float16,unbox(UInt16,0x1400)))
+    # eps(::Type{Float32}) = $(box(Float32,unbox(UInt32,0x34000000)))
+    # eps(::Type{Float64}) = $(box(Float64,unbox(UInt64,0x3cb0000000000000)))
+
+    function myeps(x::AbstractFloat)
+    if isfinite(x)
+
+        if abs(x) >= realmin(x)
+            # ldexp(eps(typeof(x)), exponent(x))
+
+            ldexp(2.0, -precision(x) + exponent(x))
+
+        else
+            nextfloat(zero(x))
+        end
+
+    else
+        oftype(x, NaN)
+
+    end
+end
+
+
     eps() = eps(Float64)
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -119,6 +119,19 @@ end
 convert(::Type{Rational}, x::BigFloat) = convert(Rational{BigInt}, x)
 convert(::Type{AbstractFloat}, x::BigInt) = BigFloat(x)
 
+"""
+    BigFloat(x::BigFloat)
+
+Create a `BigFloat` with the current global precision from the `BigFloat` `x`.
+
+Note that `convert(BigFloat, x)` still just returns `x`.
+"""
+function BigFloat(x::BigFloat)
+    z = BigFloat()  # global precision
+    ccall((:mpfr_set, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32), &z, &x, ROUNDING_MODE[])
+    return z
+end
+
 # generic constructor with arbitrary precision:
 """
     BigFloat(x, prec::Int)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -900,8 +900,6 @@ function prevfloat(x::BigFloat)
     return z
 end
 
-eps(::Type{BigFloat}) = nextfloat(BigFloat(1)) - BigFloat(1)
-
 realmin(::Type{BigFloat}) = nextfloat(zero(BigFloat))
 realmax(::Type{BigFloat}) = prevfloat(BigFloat(Inf))
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -67,8 +67,7 @@ type BigFloat <: AbstractFloat
     exp::Clong
     d::Ptr{Limb}
 
-    function BigFloat()
-        prec = precision(BigFloat)
+    function BigFloat(; prec=precision(BigFloat))
         z = new(zero(Clong), zero(Cint), zero(Clong), C_NULL)
         ccall((:mpfr_init2,:libmpfr), Void, (Ptr{BigFloat}, Clong), &z, prec)
         finalizer(z, cglobal((:mpfr_clear, :libmpfr)))
@@ -873,7 +872,7 @@ iszero(x::BigFloat) = x == Clong(0)
 @eval typemin(::Type{BigFloat}) = $(BigFloat(-Inf))
 
 function nextfloat(x::BigFloat)
-    z = BigFloat()
+    z = BigFloat(prec=precision(x))
     ccall((:mpfr_set, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32),
           &z, &x, ROUNDING_MODE[])
     ccall((:mpfr_nextabove, :libmpfr), Int32, (Ptr{BigFloat},), &z) != 0
@@ -881,7 +880,7 @@ function nextfloat(x::BigFloat)
 end
 
 function prevfloat(x::BigFloat)
-    z = BigFloat()
+    z = BigFloat(prec=precision(x))
     ccall((:mpfr_set, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32),
           &z, &x, ROUNDING_MODE[])
     ccall((:mpfr_nextbelow, :libmpfr), Int32, (Ptr{BigFloat},), &z) != 0


### PR DESCRIPTION
`nextfloat(x)`, `prevfloat(x)` and `eps(x)` now respect the precision of the `BigFloat` `x`, rather than using the global `BigFloat` precision.

This includes a rewritten generic `eps` function.

Part of #13155 