### PR TITLE
deprecate isimag

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -90,12 +90,6 @@ false
 """
 isreal(x::Real) = true
 isreal(z::Complex) = iszero(imag(z))
-"""
-    isimag(z) -> Bool
-
-Test whether `z` is purely imaginary, i.e. has a real part equal to 0.
-"""
-isimag(z::Number) = iszero(real(z))
 isinteger(z::Complex) = isreal(z) & isinteger(real(z))
 isfinite(z::Complex) = isfinite(real(z)) & isfinite(imag(z))
 isnan(z::Complex) = isnan(real(z)) | isnan(imag(z))

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1278,6 +1278,9 @@ eval(SparseArrays, :(broadcast_zpreserving!(f, C::SparseMatrixCSC, A::Union{Arra
 @deprecate getindex(t::Tuple, r::AbstractArray)       getindex(t, vec(r))
 @deprecate getindex(t::Tuple, b::AbstractArray{Bool}) getindex(t, vec(b))
 
+# Deprecate isimag (#19947).
+@deprecate isimag(z::Number) iszero(real(z))
+
 @deprecate airy(z::Number) airyai(z)
 @deprecate airyx(z::Number) airyaix(z)
 @deprecate airyprime(z::Number) airyaiprime(z)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -358,7 +358,6 @@ export
     ispow2,
     isqrt,
     isreal,
-    isimag,
     issubnormal,
     iszero,
     lcm,

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -72,7 +72,6 @@ Base.nextfloat
 Base.prevfloat
 Base.isinteger
 Base.isreal
-Base.isimag
 Core.Float32
 Core.Float64
 Base.GMP.BigInt

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -147,9 +147,9 @@ end
     end
 end
 
-@testset "isimag and isinf" begin
-    @test isimag(complex(0.0,1.0))
-    @test !isimag(complex(1.0,1.0))
+@testset "isinf" begin
+    @test iszero(real(complex(0.0,1.0))) # isimag deprecated
+    @test !iszero(real(complex(1.0,1.0))) # isimag deprecated
     @test isinf(complex(Inf,0))
     @test isinf(complex(-Inf,0))
     @test isinf(complex(0,Inf))


### PR DESCRIPTION
This pull request deprecates `isimag` (presently (tentatively) in favor of `Base.iszero(real(z))`). See discussion in #19947. Best!