### PR TITLE
Show methods for Signatures and Commits

### DIFF
--- a/base/libgit2/commit.jl
+++ b/base/libgit2/commit.jl
@@ -22,6 +22,12 @@ function committer(c::GitCommit)
     return Signature(ptr)
 end
 
+function Base.show(io::IO, c::GitCommit)
+    authstr = sprint(show, author(c))
+    cmtrstr = sprint(show, committer(c))
+    print(io, "Git Commit:\nCommit Author: $authstr\nCommitter: $cmtrstr\nSHA: $(GitHash(c))\nMessage:\n$(message(c))")
+end
+
 """ Wrapper around `git_commit_create` """
 function commit(repo::GitRepo,
                 refname::AbstractString,

--- a/base/libgit2/signature.jl
+++ b/base/libgit2/signature.jl
@@ -35,6 +35,8 @@ function Base.convert(::Type{GitSignature}, sig::Signature)
     return GitSignature(sig_ptr_ptr[])
 end
 
+Base.show(io::IO, sig::Signature) = print(io, "Name: $(sig.name), Email: $(sig.email), Time: $(Dates.unix2datetime(sig.time + sig.time_offset))")
+
 """Return signature object. Free it after use."""
 function default_signature(repo::GitRepo)
     sig_ptr_ptr = Ref{Ptr{SignatureStruct}}(C_NULL)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -302,6 +302,14 @@ mktempdir() do dir
                     @test cmtr.time == test_sig.time
                     @test cmtr.email == test_sig.email
                     @test LibGit2.message(cmt) == commit_msg1
+                    showstr = split(sprint(show, cmt), "\n")
+                    # the time of the commit will vary so just test the first two parts
+                    @test contains(showstr[1], "Git Commit:")
+                    @test contains(showstr[2], "Commit Author: Name: TEST, Email: TEST@TEST.COM, Time:")
+                    @test contains(showstr[3], "Committer: Name: TEST, Email: TEST@TEST.COM, Time:")
+                    @test contains(showstr[4], "SHA:")
+                    @test showstr[5] == "Message:"
+                    @test showstr[6] == commit_msg1
                 finally
                     close(cmt)
                 end


### PR DESCRIPTION
Add `show` methods for `Signature` and `Commit`s in LibGit2.
Display the time of the commit using Julia's built-in date handling.

Re: #19839