### PR TITLE
Fix simultaneous merge issue between #19724 and #19922

### DIFF
--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -5,7 +5,7 @@ module HigherOrderFns
 # This module provides higher order functions specialized for sparse arrays,
 # particularly map[!]/broadcast[!] for SparseVectors and SparseMatrixCSCs at present.
 import Base: map, map!, broadcast, broadcast!
-import Base.Broadcast: containertype, promote_containertype,
+import Base.Broadcast: _containertype, promote_containertype,
     broadcast_indices, broadcast_c, broadcast_c!
 
 using Base: front, tail, to_shape
@@ -843,7 +843,7 @@ end
 # broadcast shape promotion for combinations of sparse arrays and other types
 broadcast_indices(::Type{AbstractSparseArray}, A) = indices(A)
 # broadcast container type promotion for combinations of sparse arrays and other types
-containertype{T<:SparseVecOrMat}(::Type{T}) = AbstractSparseArray
+_containertype{T<:SparseVecOrMat}(::Type{T}) = AbstractSparseArray
 # combinations of sparse arrays with broadcast scalars should yield sparse arrays
 promote_containertype(::Type{Any}, ::Type{AbstractSparseArray}) = AbstractSparseArray
 promote_containertype(::Type{AbstractSparseArray}, ::Type{Any}) = AbstractSparseArray


### PR DESCRIPTION
#19922 changed `broadcast`'s `containertype` (-> `_containertype`), while #19724 extended `containertype`, introducing silent conflicts. #19724's last CI run predated #19922's merge, so merging #19724 seemed safe yet master began failing tests post-merge. This pull request fixes the silent conflicts such that master should pass tests again. Ref. https://github.com/JuliaLang/julia/pull/19724#issuecomment-271398323. Best!