### PR TITLE
Add show methods for remotes and tags

### DIFF
--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -35,7 +35,13 @@ end
 function url(rmt::GitRemote)
     url_ptr = ccall((:git_remote_url, :libgit2), Cstring, (Ptr{Void}, ), rmt.ptr)
     url_ptr == C_NULL && return ""
-    return  unsafe_string(url_ptr)
+    return unsafe_string(url_ptr)
+end
+
+function name(rmt::GitRemote)
+    name_ptr = ccall((:git_remote_name, :libgit2), Cstring, (Ptr{Void}, ), rmt.ptr)
+    name_ptr == C_NULL && return ""
+    return unsafe_string(name_ptr)
 end
 
 function fetch_refspecs(rmt::GitRemote)
@@ -88,3 +94,5 @@ function push{T<:AbstractString}(rmt::GitRemote, refspecs::Vector{T};
         !no_refs && close(sa)
     end
 end
+
+Base.show(io::IO, rmt::GitRemote) = print(io, "GitRemote:\nRemote name: ", name(rmt), " url: ", url(rmt))

--- a/base/libgit2/tag.jl
+++ b/base/libgit2/tag.jl
@@ -41,3 +41,5 @@ function target(tag::GitTag)
     oid_ptr == C_NULL && throw(Error.GitError(Error.ERROR))
     return GitHash(oid_ptr)
 end
+
+Base.show(io::IO, tag::GitTag) = print(io, "GitTag:\nTag name: $(name(tag)) target: $(target(tag))")

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -180,6 +180,9 @@ mktempdir() do dir
 
                 remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
                 @test LibGit2.url(remote) == repo_url
+                @test LibGit2.name(remote) == "upstream"
+                @test isa(remote, LibGit2.GitRemote)
+                @test sprint(show, remote) == "GitRemote:\nRemote name: upstream url: $repo_url"
                 @test LibGit2.isattached(repo)
                 close(remote)
             finally
@@ -394,7 +397,7 @@ mktempdir() do dir
                 tag1tag = LibGit2.peel(LibGit2.GitTag,tag1ref)
                 @test LibGit2.name(tag1tag) == tag1
                 @test LibGit2.target(tag1tag) == commit_oid1
-
+                @test sprint(show, tag1tag) == "GitTag:\nTag name: $tag1 target: $commit_oid1"
                 tag_oid2 = LibGit2.tag_create(repo, tag2, commit_oid2)
                 @test !LibGit2.iszero(tag_oid2)
                 tags = LibGit2.tag_list(repo)


### PR DESCRIPTION
Re: #19839

Oh, I added a `name` function for `remote` since we didn't have that and it seems useful to know.