### PR TITLE
Use standard Julia mechanisms for LibGit2 StrArrayStruct and Buffer types.

### DIFF
--- a/base/libgit2/config.jl
+++ b/base/libgit2/config.jl
@@ -52,12 +52,13 @@ function addfile(cfg::GitConfig, path::AbstractString,
 end
 
 function get{T<:AbstractString}(::Type{T}, c::GitConfig, name::AbstractString)
-    buf_ptr = Ref(Buffer())
+    buf_ref = Ref(Buffer())
     @check ccall((:git_config_get_string_buf, :libgit2), Cint,
-                (Ptr{Buffer}, Ptr{Void}, Cstring), buf_ptr, c.ptr, name)
-    return with(buf_ptr[]) do buf
-        unsafe_string(buf.ptr, buf.size)
-    end
+                 (Ptr{Buffer}, Ptr{Void}, Cstring), buf_ref, c.ptr, name)
+    buf = buf_ref[]
+    str = unsafe_string(buf.ptr, buf.size)
+    free(buf_ref)
+    str
 end
 
 function get(::Type{Bool}, c::GitConfig, name::AbstractString)

--- a/base/libgit2/diff.jl
+++ b/base/libgit2/diff.jl
@@ -2,17 +2,14 @@
 
 # TODO: make this a general purpose solution
 function Base.cconvert(::Type{Ptr{DiffOptionsStruct}}, pathspecs::AbstractString)
-    cs = Base.cconvert(Cstring, pathspecs)
-    data = [Base.unsafe_convert(Cstring, cs)]
-    sa = StrArrayStruct(pointer(data), 1)
+    str_ref = Base.cconvert(Ref{Cstring}, [pathspecs])
+    sa = StrArrayStruct(Base.unsafe_convert(Ref{Cstring}, str_ref), 1)
     do_ref = Ref(DiffOptions(pathspec = sa))
-    return do_ref, data, cs
+    do_ref, str_ref
 end
-function Base.unsafe_convert(::Type{Ptr{DiffOptionsStruct}}, tup::Tuple)
-    Base.unsafe_convert(Ptr{DiffOptionStruct}, first(tup))
+function Base.unsafe_convert(::Type{Ptr{DiffOptionsStruct}}, rr::Tuple{Ref{DiffOptionsStruct}, Ref{Cstring}})
+    Base.unsafe_convert(Ptr{DiffOptionStruct}, first(rr))
 end
-
-
 
 
 function diff_tree(repo::GitRepo, tree::GitTree, pathspecs::AbstractString=""; cached::Bool=false)

--- a/base/libgit2/diff.jl
+++ b/base/libgit2/diff.jl
@@ -13,6 +13,7 @@ end
 
 
 function diff_tree(repo::GitRepo, tree::GitTree, pathspecs::AbstractString=""; cached::Bool=false)
+    diff_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
     if cached
         @check ccall((:git_diff_tree_to_index, :libgit2), Cint,
                      (Ptr{Ptr{Void}}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{DiffOptionsStruct}),

--- a/base/libgit2/index.jl
+++ b/base/libgit2/index.jl
@@ -42,36 +42,21 @@ end
 
 function add!{T<:AbstractString}(idx::GitIndex, files::T...;
              flags::Cuint = Consts.INDEX_ADD_DEFAULT)
-    sa = StrArrayStruct(files...)
-    try
-        @check ccall((:git_index_add_all, :libgit2), Cint,
-                     (Ptr{Void}, Ptr{StrArrayStruct}, Cuint, Ptr{Void}, Ptr{Void}),
-                      idx.ptr, Ref(sa), flags, C_NULL, C_NULL)
-    finally
-        close(sa)
-    end
+    @check ccall((:git_index_add_all, :libgit2), Cint,
+                 (Ptr{Void}, Ptr{StrArrayStruct}, Cuint, Ptr{Void}, Ptr{Void}),
+                 idx.ptr, collect(files), flags, C_NULL, C_NULL)
 end
 
 function update!{T<:AbstractString}(idx::GitIndex, files::T...)
-    sa = StrArrayStruct(files...)
-    try
-        @check ccall((:git_index_update_all, :libgit2), Cint,
-                     (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{Void}, Ptr{Void}),
-                      idx.ptr, Ref(sa), C_NULL, C_NULL)
-    finally
-        close(sa)
-    end
+    @check ccall((:git_index_update_all, :libgit2), Cint,
+                 (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{Void}, Ptr{Void}),
+                 idx.ptr, collect(files), C_NULL, C_NULL)
 end
 
 function remove!{T<:AbstractString}(idx::GitIndex, files::T...)
-    sa = StrArrayStruct(files...)
-    try
-        @check ccall((:git_index_remove_all, :libgit2), Cint,
-                     (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{Void}, Ptr{Void}),
-                      idx.ptr, Ref(sa), C_NULL, C_NULL)
-    finally
-        close(sa)
-    end
+    @check ccall((:git_index_remove_all, :libgit2), Cint,
+                 (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{Void}, Ptr{Void}),
+                 idx.ptr, collect(files), C_NULL, C_NULL)
 end
 
 function add!{T<:AbstractString}(repo::GitRepo, files::T...;

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -116,12 +116,12 @@ function peel{T <: GitObject}(::Type{T}, ref::GitReference)
 end
 
 function ref_list(repo::GitRepo)
-    with(StrArrayStruct()) do sa
-        sa_ref = Ref(sa)
-        @check ccall((:git_reference_list, :libgit2), Cint,
+    sa_ref = Ref(StrArrayStruct())
+    @check ccall((:git_reference_list, :libgit2), Cint,
                       (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, repo.ptr)
-        convert(Vector{AbstractString}, sa_ref[])
-    end
+    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    free(sa_ref)
+    res
 end
 
 function create_branch(repo::GitRepo,

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -119,7 +119,7 @@ function ref_list(repo::GitRepo)
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_reference_list, :libgit2), Cint,
                       (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, repo.ptr)
-    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
 end

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -42,7 +42,7 @@ function fetch_refspecs(rmt::GitRemote)
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_remote_get_fetch_refspecs, :libgit2), Cint,
                  (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
-    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
 end
@@ -51,7 +51,7 @@ function push_refspecs(rmt::GitRemote)
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_remote_get_push_refspecs, :libgit2), Cint,
                  (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
-    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
 end

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -39,52 +39,36 @@ function url(rmt::GitRemote)
 end
 
 function fetch_refspecs(rmt::GitRemote)
-    sa_ref = Ref{StrArrayStruct}()
-    try
-        @check ccall((:git_remote_get_fetch_refspecs, :libgit2), Cint,
-                      (Ptr{LibGit2.StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
-        convert(Vector{AbstractString}, sa_ref[])
-    finally
-        close(sa_ref[])
-    end
+    sa_ref = Ref(StrArrayStruct())
+    @check ccall((:git_remote_get_fetch_refspecs, :libgit2), Cint,
+                 (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
+    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    free(sa_ref)
+    res
 end
 
 function push_refspecs(rmt::GitRemote)
-    sa_ref = Ref{StrArrayStruct}()
-    try
-        @check ccall((:git_remote_get_push_refspecs, :libgit2), Cint,
-                      (Ptr{LibGit2.StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
-        convert(Vector{AbstractString}, sa_ref[])
-    finally
-        close(sa_ref[])
-    end
+    sa_ref = Ref(StrArrayStruct())
+    @check ccall((:git_remote_get_push_refspecs, :libgit2), Cint,
+                 (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
+    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    free(sa_ref)
+    res
 end
 
 function fetch{T<:AbstractString}(rmt::GitRemote, refspecs::Vector{T};
                options::FetchOptions = FetchOptions(),
                msg::AbstractString="")
     msg = "libgit2.fetch: $msg"
-    no_refs = isempty(refspecs)
-    !no_refs && (sa = StrArrayStruct(refspecs...))
-    try
-        @check ccall((:git_remote_fetch, :libgit2), Cint,
-            (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{FetchOptions}, Cstring),
-            rmt.ptr, no_refs ? C_NULL : Ref(sa), Ref(options), msg)
-    finally
-        !no_refs && close(sa)
-    end
+    @check ccall((:git_remote_fetch, :libgit2), Cint,
+                 (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{FetchOptions}, Cstring),
+                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, Ref(options), msg)
 end
 
 function push{T<:AbstractString}(rmt::GitRemote, refspecs::Vector{T};
                                  force::Bool = false,
                                  options::PushOptions = PushOptions())
-    no_refs = isempty(refspecs)
-    !no_refs && (sa = StrArrayStruct(refspecs...))
-    try
-        @check ccall((:git_remote_push, :libgit2), Cint,
-                      (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{PushOptions}),
-                       rmt.ptr, no_refs ? C_NULL : Ref(sa), Ref(options))
-    finally
-        !no_refs && close(sa)
-    end
+    @check ccall((:git_remote_push, :libgit2), Cint,
+                 (Ptr{Void}, Ptr{StrArrayStruct}, Ptr{PushOptions}),
+                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, Ref(options))
 end

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -210,7 +210,7 @@ function remotes(repo::GitRepo)
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_remote_list, :libgit2), Cint,
                   (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, repo.ptr)
-    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     return res
 end

--- a/base/libgit2/strarray.jl
+++ b/base/libgit2/strarray.jl
@@ -1,37 +1,15 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-function StrArrayStruct{T<:AbstractString}(strs::T...)
-    strcount = length(strs)
-    for s in strs
-        if Base.containsnul(s)
-            throw("embedded NULs are not allowed in C strings: $(repr(s))")
-        end
-    end
-    sa_strings = convert(Ptr{Cstring}, Libc.malloc(sizeof(Cstring) * strcount))
-    for i=1:strcount
-        len = length(strs[i])
-        in_ptr  = pointer(String(strs[i]))
-        out_ptr = convert(Ptr{UInt8}, Libc.malloc(sizeof(UInt8) * (len + 1)))
-        unsafe_copy!(out_ptr, in_ptr, len)
-        unsafe_store!(out_ptr, zero(UInt8), len + 1) # NULL byte
-        unsafe_store!(sa_strings, convert(Cstring, out_ptr), i)
-    end
-    return StrArrayStruct(sa_strings, strcount)
+function Base.cconvert{T<:AbstractString}(::Type{Ptr{StrArrayStruct}}, strs::Vector{T})
+    data = [Base.cconvert(Cstring, s) for s in strs]
+    ptrs = [Base.unsafe_convert(Cstring, d) for d in data]
+    sa = Ref(StrArrayStruct(pointer(ptrs), length(ptrs)))
+    sa, data, ptrs
 end
-StrArrayStruct{T<:AbstractString}(strs::Vector{T}) = StrArrayStruct(strs...)
-
-function Base.convert(::Type{Vector{AbstractString}}, sa::StrArrayStruct)
-    arr = Array{AbstractString}(sa.count)
-    for i=1:sa.count
-        arr[i] = unsafe_string(unsafe_load(sa.strings, i))
-    end
-    return arr
+function Base.unsafe_convert(::Type{Ptr{StrArrayStruct}}, tup::Tuple)
+    Base.unsafe_convert(Ptr{StrArrayStruct}, first(tup))
 end
 
-function Base.copy(src::StrArrayStruct)
-    dst_ptr = Ref(StrArrayStruct())
-    @check ccall((:git_strarray_copy, :libgit2), Cint,
-                  (Ptr{StrArrayStruct}, Ptr{StrArrayStruct}),
-                   dst_ptr, Ref(src))
-    return dst_ptr[]
+function Base.unsafe_convert(::Type{Vector{String}}, sa::StrArrayStruct)
+    [unsafe_string(unsafe_load(sa.strings, i)) for i = 1:sa.count]
 end

--- a/base/libgit2/strarray.jl
+++ b/base/libgit2/strarray.jl
@@ -10,6 +10,6 @@ function Base.unsafe_convert(::Type{Ptr{StrArrayStruct}}, rr::Tuple{Ref{StrArray
     Base.unsafe_convert(Ptr{StrArrayStruct}, first(rr))
 end
 
-function Base.unsafe_convert(::Type{Vector{String}}, sa::StrArrayStruct)
+function Base.convert(::Type{Vector{String}}, sa::StrArrayStruct)
     [unsafe_string(unsafe_load(sa.strings, i)) for i = 1:sa.count]
 end

--- a/base/libgit2/strarray.jl
+++ b/base/libgit2/strarray.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-function Base.cconvert{T<:AbstractString}(::Type{Ptr{StrArrayStruct}}, strs::Vector{T})
-    data = [Base.cconvert(Cstring, s) for s in strs]
-    ptrs = [Base.unsafe_convert(Cstring, d) for d in data]
-    sa = Ref(StrArrayStruct(pointer(ptrs), length(ptrs)))
-    sa, data, ptrs
+
+function Base.cconvert(::Type{Ptr{StrArrayStruct}}, x::Vector)
+    str_ref = Base.cconvert(Ref{Cstring}, x)
+    sa_ref = Ref(StrArrayStruct(Base.unsafe_convert(Ref{Cstring}, str_ref), length(x)))
+    sa_ref, str_ref
 end
-function Base.unsafe_convert(::Type{Ptr{StrArrayStruct}}, tup::Tuple)
-    Base.unsafe_convert(Ptr{StrArrayStruct}, first(tup))
+function Base.unsafe_convert(::Type{Ptr{StrArrayStruct}}, rr::Tuple{Ref{StrArrayStruct}, Ref{Cstring}})
+    Base.unsafe_convert(Ptr{StrArrayStruct}, first(rr))
 end
 
 function Base.unsafe_convert(::Type{Vector{String}}, sa::StrArrayStruct)

--- a/base/libgit2/tag.jl
+++ b/base/libgit2/tag.jl
@@ -4,7 +4,7 @@ function tag_list(repo::GitRepo)
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_tag_list, :libgit2), Cint,
                  (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, repo.ptr)
-    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
 end

--- a/base/libgit2/tag.jl
+++ b/base/libgit2/tag.jl
@@ -1,12 +1,12 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 function tag_list(repo::GitRepo)
-    with(StrArrayStruct()) do sa
-        sa_ref = Ref(sa)
-        @check ccall((:git_tag_list, :libgit2), Cint,
-                      (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, repo.ptr)
-        convert(Vector{AbstractString}, sa_ref[])
-    end
+    sa_ref = Ref(StrArrayStruct())
+    @check ccall((:git_tag_list, :libgit2), Cint,
+                 (Ptr{StrArrayStruct}, Ptr{Void}), sa_ref, repo.ptr)
+    res = Base.unsafe_convert(Vector{String}, sa_ref[])
+    free(sa_ref)
+    res
 end
 
 function tag_delete(repo::GitRepo, tag::AbstractString)

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -45,7 +45,7 @@ When fetching data from LibGit2, a typical usage would look like:
 ```julia
 sa_ref = Ref(StrArrayStruct())
 @check ccall(..., (Ptr{StrArrayStruct},), sa_ref)
-res = Base.unsafe_convert(Vector{String}, sa_ref[])
+res = convert(Vector{String}, sa_ref[])
 free(sa_ref)
 ```
 In particular, note that `LibGit2.free` should be called afterward on the `Ref` object.

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -92,7 +92,7 @@ end
 Buffer() = Buffer(C_NULL, 0, 0)
 
 function free(buf_ref::Base.Ref{Buffer})
-    ccall((:git_buf_free, :libgit2), Void, (Ptr{Buffer},), buf_ptr)
+    ccall((:git_buf_free, :libgit2), Void, (Ptr{Buffer},), buf_ref)
 end
 
 "Abstract credentials payload"

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -42,7 +42,7 @@ A LibGit2 representation of an array of strings.
 Matches the [`git_strarray`](https://libgit2.github.com/libgit2/#HEAD/type/git_strarray) struct.
 
 When fetching data from LibGit2, a typical usage would look like:
-```
+```julia
 sa_ref = Ref(StrArrayStruct())
 @check ccall(..., (Ptr{StrArrayStruct},), sa_ref)
 res = Base.unsafe_convert(Vector{String}, sa_ref[])
@@ -52,7 +52,7 @@ In particular, note that `LibGit2.free` should be called afterward on the `Ref` 
 
 Conversely, when a vector of strings to LibGit2, it is generally simplest to rely on
 implicit conversion:
-```
+```julia
 strs = String[...]
 @check ccall(..., (Ptr{StrArrayStruct},), strs)
 ```
@@ -75,7 +75,7 @@ A data buffer for exporting data from libgit2.
 Matches the [`git_buf`](https://libgit2.github.com/libgit2/#HEAD/type/git_buf) struct.
 
 When fetching data from LibGit2, a typical usage would look like:
-```
+```julia
 buf_ref = Ref(Buffer())
 @check ccall(..., (Ptr{Buffer},), buf_ref)
 # operation on buf_ref

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -64,7 +64,7 @@ immutable StrArrayStruct
 end
 StrArrayStruct() = StrArrayStruct(C_NULL, 0)
 
-function free(sa_ref::Base.RefValue{StrArrayStruct})
+function free(sa_ref::Base.Ref{StrArrayStruct})
     ccall((:git_strarray_free, :libgit2), Void, (Ptr{StrArrayStruct},), sa_ref)
 end
 
@@ -73,16 +73,26 @@ end
 
 A data buffer for exporting data from libgit2.
 Matches the [`git_buf`](https://libgit2.github.com/libgit2/#HEAD/type/git_buf) struct.
+
+When fetching data from LibGit2, a typical usage would look like:
+```
+buf_ref = Ref(Buffer())
+@check ccall(..., (Ptr{Buffer},), buf_ref)
+# operation on buf_ref
+free(buf_ref)
+```
+In particular, note that `LibGit2.free` should be called afterward on the `Ref` object.
+
 """
-@kwdef immutable Buffer
+immutable Buffer
     ptr::Ptr{Cchar}
     asize::Csize_t
     size::Csize_t
 end
-function Base.close(buf::Buffer)
-    buf_ptr = Ref(buf)
+Buffer() = Buffer(C_NULL, 0, 0)
+
+function free(buf_ref::Base.Ref{Buffer})
     ccall((:git_buf_free, :libgit2), Void, (Ptr{Buffer},), buf_ptr)
-    return buf_ptr[]
 end
 
 "Abstract credentials payload"

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -50,8 +50,8 @@ free(sa_ref)
 ```
 In particular, note that `LibGit2.free` should be called afterward on the `Ref` object.
 
-Conversely, when a vector of strings to LibGit2, it is generally simplest to rely on
-implicit conversion:
+Conversely, when passing a vector of strings to LibGit2, it is generally simplest to rely
+on implicit conversion:
 ```julia
 strs = String[...]
 @check ccall(..., (Ptr{StrArrayStruct},), strs)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -39,7 +39,7 @@ end
     p = ["XXX","YYY"]
     a = Base.cconvert(Ptr{LibGit2.StrArrayStruct}, p)
     b = Base.unsafe_convert(Ptr{LibGit2.StrArrayStruct}, a)
-    @test p == Base.unsafe_convert(Vector{String}, unsafe_load(b))
+    @test p == convert(Vector{String}, unsafe_load(b))
 end
 
 @testset "Signature" begin

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -36,29 +36,10 @@ end
 end
 
 @testset "StrArrayStruct" begin
-    p1 = "XXX"
-    p2 = "YYY"
-    sa1 = LibGit2.StrArrayStruct(p1)
-    try
-        arr = convert(Vector{AbstractString}, sa1)
-        @test arr[1] == p1
-    finally
-        close(sa1)
-    end
-
-    sa2 = LibGit2.StrArrayStruct(p1, p2)
-    try
-        arr1 = convert(Vector{AbstractString}, sa2)
-        @test arr1[1] == p1
-        @test arr1[2] == p2
-        sa3 = copy(sa2)
-        arr2 = convert(Vector{AbstractString}, sa3)
-        @test arr1[1] == arr2[1]
-        @test arr1[2] == arr2[2]
-        close(sa3)
-    finally
-        close(sa2)
-    end
+    p = ["XXX","YYY"]
+    a = Base.cconvert(Ptr{LibGit2.StrArrayStruct}, p)
+    b = Base.unsafe_convert(Ptr{LibGit2.StrArrayStruct}, a)
+    @test p == Base.unsafe_convert(Vector{String}, unsafe_load(b))
 end
 
 @testset "Signature" begin


### PR DESCRIPTION
The code currently calls `Libc.malloc`, and then relies on the library
function to free the data. This seems slightly dubious, so I rejigged it
to use `cconvert` and `unsafe_convert`.