### PR TITLE
remove `subtypes` search for concrete types

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -301,7 +301,7 @@ function _subtypes(m::Module, x::DataType, sts=Set{DataType}(), visited=Set{Modu
     end
     return sts
 end
-subtypes(m::Module, x::DataType) = sort(collect(_subtypes(m, x)), by=string)
+subtypes(m::Module, x::DataType) = x.abstract ? sort(collect(_subtypes(m, x)), by=string) : DataType[]
 
 """
     subtypes(T::DataType)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -301,7 +301,7 @@ function _subtypes(m::Module, x::DataType, sts=Set{DataType}(), visited=Set{Modu
     end
     return sts
 end
-subtypes(m::Module, x::DataType) = x.abstract ? sort(collect(_subtypes(m, x)), by=string) : DataType[]
+subtypes(m::Module, x::DataType) = x.abstract ? sort!(collect(_subtypes(m, x)), by=string) : DataType[]
 
 """
     subtypes(T::DataType)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -610,3 +610,6 @@ end
 @generated f18883() = nothing
 @test !isempty(sprint(io->code_llvm(io, f18883, Tuple{})))
 @test !isempty(sprint(io->code_native(io, f18883, Tuple{})))
+
+# PR #19964
+@test isempty(subtypes(Float64))


### PR DESCRIPTION
This prevents an unnecessary/expensive call to `_subtypes` when `subtypes` is called on a concrete type.