### PR TITLE
Use sort! where possible

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -438,7 +438,7 @@ function completions(string, pos)
         if partial_key !== nothing
             matches = find_dict_matches(identifier, partial_key)
             length(matches)==1 && (length(string) <= pos || string[pos+1] != ']') && (matches[1]*="]")
-            length(matches)>0 && return sort(matches), loc:pos, true
+            length(matches)>0 && return sort!(matches), loc:pos, true
         else
             return String[], 0:-1, false
         end
@@ -457,7 +457,7 @@ function completions(string, pos)
             paths[1] *= "\""
         end
         #Latex symbols can be completed for strings
-        (success || inc_tag==:cmd) && return sort(paths), r, success
+        (success || inc_tag==:cmd) && return sort!(paths), r, success
     end
 
     ok, ret = bslash_completions(string, pos)
@@ -550,7 +550,7 @@ function completions(string, pos)
         end
     end
     append!(suggestions, complete_symbol(s, ffunc))
-    return sort(unique(suggestions)), (dotpos+1):pos, true
+    return sort!(unique(suggestions)), (dotpos+1):pos, true
 end
 
 function shell_completions(string, pos)

--- a/base/client.jl
+++ b/base/client.jl
@@ -40,8 +40,8 @@ const disable_text_style = AnyDict(
 available_text_colors = collect(Iterators.filter(x -> !isa(x, Integer), keys(text_colors)))
 const possible_formatting_symbols = [:normal, :bold, :default]
 available_text_colors = cat(1,
-    sort(intersect(available_text_colors, possible_formatting_symbols), rev=true),
-    sort(setdiff(  available_text_colors, possible_formatting_symbols)))
+    sort!(intersect(available_text_colors, possible_formatting_symbols), rev=true),
+    sort!(setdiff(  available_text_colors, possible_formatting_symbols)))
 
 const available_text_colors_docstring =
     string(join([string("`:", key,"`")

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -186,7 +186,7 @@ function check_requirements(reqs::Requires, deps::Dict{String,Dict{VersionNumber
         if !any(vn->(vn in vs), keys(deps[p]))
             remaining_vs = VersionSet()
             err_msg = "fixed packages introduce conflicting requirements for $p: \n"
-            available_list = sort(collect(keys(deps[p])))
+            available_list = sort!(collect(keys(deps[p])))
             for (p1,f1) in fix
                 f1r = f1.requires
                 haskey(f1r, p) || continue

--- a/test/perf/shootout/k_nucleotide.jl
+++ b/test/perf/shootout/k_nucleotide.jl
@@ -46,7 +46,7 @@ function sorted_array(m::Dict{AbstractString, Int})
         kn[i] = KNuc(elem...)
         i += 1
     end
-    sort(kn)
+    sort!(kn)
 end
 
 function print_knucs(a::Array{KNuc, 1})

--- a/test/perf/shootout/k_nucleotide.jl
+++ b/test/perf/shootout/k_nucleotide.jl
@@ -46,7 +46,7 @@ function sorted_array(m::Dict{AbstractString, Int})
         kn[i] = KNuc(elem...)
         i += 1
     end
-    sort!(kn)
+    sort(kn)
 end
 
 function print_knucs(a::Array{KNuc, 1})


### PR DESCRIPTION
I noticed [here](https://github.com/JuliaLang/julia/pull/19964#discussion_r95409462) that there are a few places where we are using `sort` instead of `sort!`. There are just a handful of them and they are not performance-critical, but the changes were easy enough that I decided to do them anyway.