### PR TITLE
fix and then specialize sparse broadcast!(f, C, A), strengthen tests

### DIFF
--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -102,7 +102,6 @@ function broadcast!{Tf}(f::Tf, C::SparseVecOrMat)
     end
     return C
 end
-broadcast!{Tf}(f::Tf, C::SparseVecOrMat, A::SparseVecOrMat) = map!(f, C, A)
 function broadcast!{Tf,N}(f::Tf, C::SparseVecOrMat, A::SparseVecOrMat, Bs::Vararg{SparseVecOrMat,N})
     _aresameshape(C, A, Bs...) && return _noshapecheck_map!(f, C, A, Bs...)
     Base.Broadcast.check_broadcast_indices(indices(C), A, Bs...)

--- a/test/sparse/higherorderfns.jl
+++ b/test/sparse/higherorderfns.jl
@@ -119,14 +119,7 @@ end
         # --> test broadcast! entry point / not-zero-preserving op
         broadcast!(cos, fZ, fX); Z = sparse(fZ)
         broadcast!(cos, Z, X); Z = sparse(fZ) # warmup for @allocated
-        if Xo === first(mats)
-            @test (@allocated broadcast!(cos, Z, X)) == 0
-        else
-            @test_broken (@allocated broadcast!(cos, Z, X)) == 0
-            # broken: allocates 16 bytes in calling generic _broadcast_notzeropres!
-            # see note in the related tests for broadcast[!] over >2 input arrays below
-            # only allocates those 16 bytes when Z and X are not the same shape
-        end
+        @test (@allocated broadcast!(cos, Z, X)) == 0
         @test broadcast!(cos, Z, X) == sparse(broadcast!(cos, fZ, fX))
         # --> test shape checks for broadcast! entry point
         # TODO strengthen this test, avoiding dependence on checking whether
@@ -150,14 +143,7 @@ end
         # --> test broadcast! entry point / not-zero-preserving
         broadcast!(cos, fV, fX); V = sparse(fV)
         broadcast!(cos, V, X); V = sparse(fV) # warmup for @allocated
-        if Xo === first(vecs)
-            @test (@allocated broadcast!(cos, V, X)) == 0
-        else
-            @test_broken (@allocated broadcast!(cos, V, X)) == 0
-            # broken: allocates 16 bytes in calling generic _broadcast_notzeropres!
-            # see note in the related tests for broadcast[!] over >2 input arrays below
-            # only allocates those 16 bytes when V and X are not the same shape
-        end
+        @test (@allocated broadcast!(cos, V, X)) == 0
         @test broadcast!(cos, V, X) == sparse(broadcast!(cos, fV, fX))
         # --> test shape checks for broadcast! entry point
         # TODO strengthen this test, avoiding dependence on checking whether

--- a/test/sparse/higherorderfns.jl
+++ b/test/sparse/higherorderfns.jl
@@ -94,11 +94,6 @@ end
     fa, fA = Array(a), Array(A)
     @test broadcast(sin, a) == sparse(broadcast(sin, fa))
     @test broadcast(sin, A) == sparse(broadcast(sin, fA))
-    # The two following tests are from #19895, and check the absence of an ambiguity
-    # between a pair of specializations, but #19895 removed both of those specializations,
-    # so perhaps these tests should be nixed?
-    @test broadcast!(identity, copy(a), a) == sparse(broadcast!(identity, copy(fa), fa))
-    @test broadcast!(identity, copy(A), A) == sparse(broadcast!(identity, copy(fA), fA))
 end
 
 @testset "broadcast! implementation specialized for a single (input) sparse vector/matrix" begin
@@ -153,6 +148,13 @@ end
         catch
             @test_throws DimensionMismatch broadcast!(sin, V, spzeros((shapeX .- 1)...))
         end
+    end
+    # Tests specific to #19895, i.e. for broadcast!(identity, C, A) specializations
+    Z = copy(first(mats)); fZ = Array(Z)
+    V = copy(first(vecs)); fV = Array(V)
+    for X in (mats..., vecs...)
+        @test broadcast!(identity, Z, X) == sparse(broadcast!(identity, fZ, Array(X)))
+        X isa SparseVector && @test broadcast!(identity, V, X) == sparse(broadcast!(identity, fV, Array(X)))
     end
 end
 

--- a/test/sparse/higherorderfns.jl
+++ b/test/sparse/higherorderfns.jl
@@ -6,7 +6,6 @@
 
 @testset "map[!] implementation specialized for a single (input) sparse vector/matrix" begin
     N, M = 10, 12
-    # (also the implementation for broadcast[!] over a single (input) sparse vector/matrix)
     for shapeA in ((N,), (N, M))
         A = sprand(shapeA..., 0.4); fA = Array(A)
         # --> test map entry point
@@ -86,18 +85,89 @@ end
     @test let z = 0, fz = 0; broadcast!(() -> z += 1, C) == broadcast!(() -> fz += 1, fC); end
 end
 
-@testset "broadcast[!] implementation specialized for a single (input) sparse vector/matrix" begin
-    # broadcast[!] for a single sparse vector/matrix falls back to map[!], tested extensively
-    # above. here we simply lightly exercise the relevant broadcast[!] entry points.
+@testset "broadcast implementation specialized for a single (input) sparse vector/matrix" begin
+    # broadcast for a single (input) sparse vector/matrix falls back to map, tested
+    # extensively above. here we simply lightly exercise the relevant broadcast entry
+    # point.
     N, M, p = 10, 12, 0.4
     a, A = sprand(N, p), sprand(N, M, p)
     fa, fA = Array(a), Array(A)
     @test broadcast(sin, a) == sparse(broadcast(sin, fa))
     @test broadcast(sin, A) == sparse(broadcast(sin, fA))
-    @test broadcast!(sin, copy(a), a) == sparse(broadcast!(sin, copy(fa), fa))
-    @test broadcast!(sin, copy(A), A) == sparse(broadcast!(sin, copy(fA), fA))
+    # The two following tests are from #19895, and check the absence of an ambiguity
+    # between a pair of specializations, but #19895 removed both of those specializations,
+    # so perhaps these tests should be nixed?
     @test broadcast!(identity, copy(a), a) == sparse(broadcast!(identity, copy(fa), fa))
     @test broadcast!(identity, copy(A), A) == sparse(broadcast!(identity, copy(fA), fA))
+end
+
+@testset "broadcast! implementation specialized for a single (input) sparse vector/matrix" begin
+    N, M, p = 10, 12, 0.3
+    f(x, y) = x + y + 1
+    mats = (sprand(N, M, p), sprand(N, 1, p), sprand(1, M, p), sprand(1, 1, 1.0), spzeros(1, 1))
+    vecs = (sprand(N, p), sprand(1, 1.0), spzeros(1))
+    # --> test with matrix destination (Z/fZ)
+    fZ = Array(first(mats))
+    for Xo in (mats..., vecs...)
+        X = ndims(Xo) == 1 ? SparseVector{Float32,Int32}(Xo) : SparseMatrixCSC{Float32,Int32}(Xo)
+        shapeX, fX = size(X), Array(X)
+        # --> test broadcast! entry point / zero-preserving op
+        broadcast!(sin, fZ, fX); Z = sparse(fZ)
+        broadcast!(sin, Z, X); Z = sparse(fZ) # warmup for @allocated
+        @test (@allocated broadcast!(sin, Z, X)) == 0
+        @test broadcast!(sin, Z, X) == sparse(broadcast!(sin, fZ, fX))
+        # --> test broadcast! entry point / not-zero-preserving op
+        broadcast!(cos, fZ, fX); Z = sparse(fZ)
+        broadcast!(cos, Z, X); Z = sparse(fZ) # warmup for @allocated
+        if Xo === first(mats)
+            @test (@allocated broadcast!(cos, Z, X)) == 0
+        else
+            @test_broken (@allocated broadcast!(cos, Z, X)) == 0
+            # broken: allocates 16 bytes in calling generic _broadcast_notzeropres!
+            # see note in the related tests for broadcast[!] over >2 input arrays below
+            # only allocates those 16 bytes when Z and X are not the same shape
+        end
+        @test broadcast!(cos, Z, X) == sparse(broadcast!(cos, fZ, fX))
+        # --> test shape checks for broadcast! entry point
+        # TODO strengthen this test, avoiding dependence on checking whether
+        # broadcast_indices throws to determine whether sparse broadcast should throw
+        try
+            Base.Broadcast.check_broadcast_indices(indices(Z), spzeros((shapeX .- 1)...))
+        catch
+            @test_throws DimensionMismatch broadcast!(sin, Z, spzeros((shapeX .- 1)...))
+        end
+    end
+    # --> test with vector destination (V/fV)
+    fV = Array(first(vecs))
+    for Xo in vecs # vector target
+        X = SparseVector{Float32,Int32}(Xo)
+        shapeX, fX = size(X), Array(X)
+        # --> test broadcast! entry point / zero-preserving op
+        broadcast!(sin, fV, fX); V = sparse(fV)
+        broadcast!(sin, V, X); V = sparse(fV) # warmup for @allocated
+        @test (@allocated broadcast!(sin, V, X)) == 0
+        @test broadcast!(sin, V, X) == sparse(broadcast!(sin, fV, fX))
+        # --> test broadcast! entry point / not-zero-preserving
+        broadcast!(cos, fV, fX); V = sparse(fV)
+        broadcast!(cos, V, X); V = sparse(fV) # warmup for @allocated
+        if Xo === first(vecs)
+            @test (@allocated broadcast!(cos, V, X)) == 0
+        else
+            @test_broken (@allocated broadcast!(cos, V, X)) == 0
+            # broken: allocates 16 bytes in calling generic _broadcast_notzeropres!
+            # see note in the related tests for broadcast[!] over >2 input arrays below
+            # only allocates those 16 bytes when V and X are not the same shape
+        end
+        @test broadcast!(cos, V, X) == sparse(broadcast!(cos, fV, fX))
+        # --> test shape checks for broadcast! entry point
+        # TODO strengthen this test, avoiding dependence on checking whether
+        # broadcast_indices throws to determine whether sparse broadcast should throw
+        try
+            Base.Broadcast.check_broadcast_indices(indices(V), spzeros((shapeX .- 1)...))
+        catch
+            @test_throws DimensionMismatch broadcast!(sin, V, spzeros((shapeX .- 1)...))
+        end
+    end
 end
 
 @testset "broadcast[!] implementation specialized for pairs of (input) sparse vectors/matrices" begin
@@ -192,6 +262,8 @@ end
             # up with --track-allocation=user. allocation shows up on the first line of the
             # entry point for broadcast! with --track-allocation=all, but that first line
             # almost certainly should not allocate. so not certain what's going on.
+            # additional info: occurs for broadcast!(f, Z, X) for Z and X of different
+            # shape, but not for Z and X of the same shape.
             @test broadcast!(f, Q, X, Y, Z) == sparse(broadcast!(f, fQ, fX, fY, fZ))
             # --> test shape checks for both broadcast and broadcast! entry points
             # TODO strengthen this test, avoiding dependence on checking whether


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/19895#issuecomment-271230830, @martinholters (thanks!) noticed that the existing sparse `broadcast!(f, C, A)` specialization does not handle cases where the shapes of destination `C` and source `A` differ.

This pull request's first commit removes the incorrect sparse `broadcast!(f, C, A)` specialization (falling back to the argument-number-generic sparse `broadcast!` code, which does not suffer from the above issue) and strengthens associated tests. The argument-number-generic code leaves some performance on the table, so the second commit provides a corrected sparse `broadcast!(f, C, A)` specialization for zero-preserving `f`, and the third commit likewise for not-zero-preserving `f`.

While writing this pull request I realized that the sparse `broadcast!(f, C, A, B)` specializations suffer from the same issue. A fix for that code is in the works. Best!