### PR TITLE
tbd: deprecate array-reducing isreal

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -4,9 +4,8 @@
 
 isinteger(x::AbstractArray) = all(isinteger,x)
 isinteger{T<:Integer,n}(x::AbstractArray{T,n}) = true
-isreal(x::AbstractArray) = all(isreal,x)
 iszero(x::AbstractArray) = all(iszero,x)
-isreal{T<:Real,n}(x::AbstractArray{T,n}) = true
+all{T<:Real}(::typeof(isreal), ::AbstractArray{T}) = true
 ctranspose(a::AbstractArray) = error("ctranspose not implemented for $(typeof(a)). Consider adding parentheses, e.g. A*(B*C') instead of A*B*C' to avoid explicit calculation of the transposed matrix.")
 transpose(a::AbstractArray) = error("transpose not implemented for $(typeof(a)). Consider adding parentheses, e.g. A*(B*C.') instead of A*B*C' to avoid explicit calculation of the transposed matrix.")
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -78,14 +78,11 @@ real{T<:Real}(::Type{Complex{T}}) = T
 """
     isreal(x) -> Bool
 
-Test whether `x` or all its elements are numerically equal to some real number.
+Test whether `x` is numerically equal to some real number.
 
 ```jldoctest
 julia> isreal(5.)
 true
-
-julia> isreal([4.; complex(0,1)])
-false
 ```
 """
 isreal(x::Real) = true

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1507,6 +1507,9 @@ function frexp{T<:AbstractFloat}(A::Array{T})
     return (F, E)
 end
 
+# Deprecate array-reducing isreal
+@deprecate isreal(A::AbstractArray) all(isreal, A)
+
 # Deprecate promote_eltype_op (#19814, #19937)
 _promote_eltype_op(::Any) = Any
 _promote_eltype_op(op, A) = (@_inline_meta; promote_op(op, eltype(A)))

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -509,7 +509,7 @@ function logm(A::StridedMatrix)
         end
     end
 
-    if isreal(A) && ~np_real_eigs
+    if all(isreal, A) && ~np_real_eigs
         return real(retmat)
     else
         return retmat

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -101,7 +101,7 @@ end
 parent(D::Diagonal) = D.diag
 
 ishermitian{T<:Real}(D::Diagonal{T}) = true
-ishermitian(D::Diagonal) = isreal(D.diag)
+ishermitian(D::Diagonal) = all(isreal, D.diag)
 issymmetric(D::Diagonal) = true
 isposdef(D::Diagonal) = all(x -> x > 0, D.diag)
 

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -23,7 +23,7 @@ function getindex(A::Union{Eigen,GeneralizedEigen}, d::Symbol)
     throw(KeyError(d))
 end
 
-isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0, A.values)
+isposdef(A::Union{Eigen,GeneralizedEigen}) = all(isreal, A.values) && all(x -> x > 0, A.values)
 
 """
     eigfact!(A, [B])

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -169,9 +169,9 @@ end
 
 ishermitian(A::Hermitian) = true
 ishermitian{T<:Real,S}(A::Symmetric{T,S}) = true
-ishermitian{T<:Complex,S}(A::Symmetric{T,S}) = isreal(A.data)
+ishermitian{T<:Complex,S}(A::Symmetric{T,S}) = all(isreal, A.data)
 issymmetric{T<:Real,S}(A::Hermitian{T,S}) = true
-issymmetric{T<:Complex,S}(A::Hermitian{T,S}) = isreal(A.data)
+issymmetric{T<:Complex,S}(A::Hermitian{T,S}) = all(isreal, A.data)
 issymmetric(A::Symmetric) = true
 transpose(A::Symmetric) = A
 ctranspose{T<:Real}(A::Symmetric{T}) = A

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1828,7 +1828,7 @@ logm(A::LowerTriangular) = logm(A.').'
 function sqrtm{T}(A::UpperTriangular{T})
     n = checksquare(A)
     realmatrix = false
-    if isreal(A)
+    if all(isreal, A)
         realmatrix = true
         for i = 1:n
             if real(A[i,i]) < 0

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -748,7 +748,7 @@ end
 
 # isinteger and isreal
 @test isinteger(Diagonal(rand(1:5,5)))
-@test isreal(Diagonal(rand(5)))
+@test all(isreal, Diagonal(rand(5))) # reducing isreal(...) deprecated
 
 # unary ops
 let A = Diagonal(rand(1:5,5))

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -129,7 +129,7 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         cpapd = cholfact(apd, :U, Val{true})
         @test rank(cpapd) == n
         @test all(diff(diag(real(cpapd.factors))).<=0.) # diagonal should be non-increasing
-        if isreal(apd)
+        if all(isreal, apd)
             @test apd*inv(cpapd) ≈ eye(n)
         end
         @test full(cpapd) ≈ apd


### PR DESCRIPTION
Deprecation of array-reducing `isreal(A::AbstractArray)` in favor of `all(isinteger, A)` sparked debate in #19925, so I've separated that deprecation (into this pull request) from #19925's uncontroversial `isinteger` deprecation. `isreal(A::AbstractArray)`: keep or nix? Best!