### PR TITLE
fix warning that Base.cond cannot be imported into LinAlg

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-import Base: cond, copy, ctranspose, getindex, show, transpose, one, zero, inv,
+import Base: copy, ctranspose, getindex, show, transpose, one, zero, inv,
              @_pure_meta, hcat, vcat, hvcat
 import Base.LinAlg: SingularException
 


### PR DESCRIPTION
#19906 added `import cond` to `base/linalg/uniformscaling.jl`, which is part of the `LinAlg` module. But the `LinAlg` module defines and exports `cond`, so this `import` results in a warning that `Base.cond` cannot be imported `LinAlg` when building julia. This pull request removes the relevant `import`. Best!