### PR TITLE
Don't show built-in modules in whos()

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -667,7 +667,7 @@ Print information about exported global variables in a module, optionally restri
 
 The memory consumption estimate is an approximate lower bound on the size of the internal structure of the object.
 """
-function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"")
+function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"^(?!.*(Base|Main|Core)).*$")
     maxline = displaysize(io)[2]
     line = zeros(UInt8, maxline)
     head = PipeBuffer(maxline + 1)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -677,7 +677,7 @@ function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"")
             value = getfield(m, v)
             @printf head "%30s " s
             try
-                if s ∈ ("Base", "Main", "Core")
+                if value ∈ (Base, Main, Core)
                     print(head, "              ")
                 else
                     bytes = summarysize(value)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -667,7 +667,7 @@ Print information about exported global variables in a module, optionally restri
 
 The memory consumption estimate is an approximate lower bound on the size of the internal structure of the object.
 """
-function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"^(?!.*(Base|Main|Core)).*$")
+function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"")
     maxline = displaysize(io)[2]
     line = zeros(UInt8, maxline)
     head = PipeBuffer(maxline + 1)
@@ -677,17 +677,20 @@ function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"^(?!.*
             value = getfield(m, v)
             @printf head "%30s " s
             try
-                bytes = summarysize(value)
-                if bytes < 10_000
-                    @printf(head, "%6d bytes  ", bytes)
+                if s ∈ ("Base", "Main", "Core")
+                    print(head, "              ")
                 else
-                    @printf(head, "%6d KB     ", bytes ÷ (1024))
+                    bytes = summarysize(value)
+                    if bytes < 10_000
+                        @printf(head, "%6d bytes  ", bytes)
+                    else
+                        @printf(head, "%6d KB     ", bytes ÷ (1024))
+                    end
                 end
                 print(head, summary(value))
             catch e
                 print(head, "#=ERROR: unable to show value=#")
             end
-
             newline = search(head, UInt8('\n')) - 1
             if newline < 0
                 newline = nb_available(head)


### PR DESCRIPTION
It's very time-consuming (almost 10 seconds on my machine) to compute the `summarysize` of `Base`, `Core`, and `Main`, making `whos()` an impractical tool for quickly seeing my custom workspace variables. It also seems like unnecessary information, since those modules are always available at the REPL and almost never need to be explicitly accessed.

Thus, I propose not showing those by default.  They're still available with `whos(r".*")`. 