### PR TITLE
Add a few new reflection methods (after type system merge)

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -111,6 +111,15 @@ function unwrapva(t::ANY)
     isvarargtype(t2) ? t2.parameters[1] : t
 end
 
+typename(a) = error("typename does not apply to this type")
+typename(a::DataType) = a.name
+function typename(a::Union)
+    ta = typename(a.a)
+    tb = typename(a.b)
+    ta === tb ? tb : error("typename does not apply to unions whose components have different typenames")
+end
+typename(union::UnionAll) = typename(union.body)
+
 convert{T<:Tuple{Any,Vararg{Any}}}(::Type{T}, x::Tuple{Any, Vararg{Any}}) =
     tuple(convert(tuple_type_head(T),x[1]), convert(tuple_type_tail(T), tail(x))...)
 convert{T<:Tuple{Any,Vararg{Any}}}(::Type{T}, x::T) = x

--- a/base/test.jl
+++ b/base/test.jl
@@ -1123,7 +1123,7 @@ defined in the specified modules. Use `imported=true` if you wish to
 also test functions that were imported into these modules from
 elsewhere.
 """
-function detect_ambiguities(mods...; imported::Bool=false)
+function detect_ambiguities(mods...; imported::Bool=false, allow_bottom::Bool=true)
     function sortdefs(m1, m2)
         ord12 = m1.file < m2.file
         if !ord12 && (m1.file == m2.file)
@@ -1145,7 +1145,7 @@ function detect_ambiguities(mods...; imported::Bool=false)
                 for m in mt
                     if m.ambig !== nothing
                         for m2 in m.ambig
-                            if Base.isambiguous(m, m2)
+                            if Base.isambiguous(m, m2, allow_bottom)
                                 push!(ambs, sortdefs(m, m2))
                             end
                         end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -588,3 +588,14 @@ f11015(a::AT11015) = g11015(Base.fieldtype(typeof(a), :f), true)
 g11015(::Type{Bool}, ::Bool) = 2.0
 @test Int <: Base.return_types(f11015, (AT11015,))[1]
 @test f11015(AT11015(true)) === 1
+
+# Inference for some type-level computation
+fUnionAll{T}(::Type{T}) = Type{S} where S <: T
+@inferred fUnionAll(Real) == Type{T} where T <: Real
+@inferred fUnionAll(Rational{T} where T <: AbstractFloat) == Type{T} where T<:(Rational{S} where S <: AbstractFloat)
+
+fComplicatedUnionAll{T}(::Type{T}) = Type{Tuple{S,rand() >= 0.5 ? Int : Float64}} where S <: T
+let pub = Base.parameter_upper_bound, x = fComplicatedUnionAll(Real)
+    @test pub(pub(x, 1), 1) == Real
+    @test pub(pub(x, 1), 2) == Int || pub(pub(x, 1), 2) == Float64
+end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -615,3 +615,23 @@ end
 
 # PR #19964
 @test isempty(subtypes(Float64))
+
+# New reflection methods in 0.6
+immutable ReflectionExample{T<:AbstractFloat, N}
+    x::Tuple{T, N}
+end
+
+@test Base.isabstract(AbstractArray)
+@test !Base.isabstract(ReflectionExample)
+@test !Base.isabstract(Int)
+
+@test Base.parameter_upper_bound(ReflectionExample, 1) === AbstractFloat
+@test Base.parameter_upper_bound(ReflectionExample, 2) === Any
+@test Base.parameter_upper_bound(ReflectionExample{T, N} where T where N <: Real, 2) === Real
+
+@test Base.typename(ReflectionExample{Float64, Int64}).wrapper === ReflectionExample
+@test Base.typename(ReflectionExample{Float64, N} where N).wrapper === ReflectionExample
+@test Base.typename(ReflectionExample{T, Int64} where T).wrapper === ReflectionExample
+@test Base.typename(ReflectionExample).wrapper === ReflectionExample
+@test Base.typename(Union{ReflectionExample{Union{},1},ReflectionExample{Float64,1}}).wrapper === ReflectionExample
+@test_throws ErrorException Base.typename(Union{Int, Float64})

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -629,9 +629,12 @@ end
 @test Base.parameter_upper_bound(ReflectionExample, 2) === Any
 @test Base.parameter_upper_bound(ReflectionExample{T, N} where T where N <: Real, 2) === Real
 
-@test Base.typename(ReflectionExample{Float64, Int64}).wrapper === ReflectionExample
-@test Base.typename(ReflectionExample{Float64, N} where N).wrapper === ReflectionExample
-@test Base.typename(ReflectionExample{T, Int64} where T).wrapper === ReflectionExample
-@test Base.typename(ReflectionExample).wrapper === ReflectionExample
-@test Base.typename(Union{ReflectionExample{Union{},1},ReflectionExample{Float64,1}}).wrapper === ReflectionExample
-@test_throws ErrorException Base.typename(Union{Int, Float64})
+let
+    wrapperT(T) = Base.typename(T).wrapper
+    @test @inferred wrapperT(ReflectionExample{Float64, Int64}) == ReflectionExample
+    @test @inferred wrapperT(ReflectionExample{Float64, N} where N) == ReflectionExample
+    @test @inferred wrapperT(ReflectionExample{T, Int64} where T) == ReflectionExample
+    @test @inferred wrapperT(ReflectionExample) == ReflectionExample
+    @test @inferred wrapperT(Union{ReflectionExample{Union{},1},ReflectionExample{Float64,1}}) == ReflectionExample
+    @test_throws ErrorException Base.typename(Union{Int, Float64})
+end


### PR DESCRIPTION
This is informed by attempting to port some packages to the new type system.
I have abstracted out the functionality required by those packages into
documented/tested functions. The hope is to avoid introducing too many
implementation details to packages. These functions can also be implemented
in Compat for older julia versions, such that packages can immediate replace
their use of internal APIs with these functions.