### PR TITLE
minimal hook into loading necessary for Pkg3

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -32,9 +32,9 @@ isinteractive() = (is_interactive::Bool)
 
 An array of paths (as strings) where the `require` function looks for code.
 """
-const LOAD_PATH = String[]
-
+const LOAD_PATH = Any[]
 const LOAD_CACHE_PATH = String[]
+
 function init_load_path()
     vers = "v$(VERSION.major).$(VERSION.minor)"
     if haskey(ENV, "JULIA_LOAD_PATH")

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -80,7 +80,7 @@ else
     end
 end
 
-function load_hook(prefix::String, name::String, found::Void=nothing)
+function load_hook(prefix::String, name::String, found::Void)
     name_jl = "$name.jl"
     path = joinpath(prefix, name_jl)
     isfile_casesensitive(path) && return abspath(path)
@@ -91,9 +91,12 @@ function load_hook(prefix::String, name::String, found::Void=nothing)
     return nothing
 end
 load_hook(prefix::String, name::String, found::String) = found
+load_hook(prefix, name::String, found) =
+    throw(ArgumentError("unrecognized custom loader in LOAD_PATH: $prefix"))
 
 function find_in_path(name::String)
-    path = load_hook(Pkg.dir(), name)
+    path = nothing
+    path = load_hook(Pkg.dir(), name, path)
     for dir in LOAD_PATH
         path = load_hook(dir, name, path)
     end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -94,11 +94,14 @@ load_hook(prefix::String, name::String, found::String) = found
 load_hook(prefix, name::String, found) =
     throw(ArgumentError("unrecognized custom loader in LOAD_PATH: $prefix"))
 
+_str(x::AbstractString) = String(x)
+_str(x) = x
+
 function find_in_path(name::String)
     path = nothing
-    path = load_hook(Pkg.dir(), name, path)
+    path = _str(load_hook(_str(Pkg.dir()), name, path))
     for dir in LOAD_PATH
-        path = load_hook(dir, name, path)
+        path = _str(load_hook(_str(dir), name, path))
     end
     return path
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -80,54 +80,30 @@ else
     end
 end
 
-function try_path(prefix::String, base::String, name::String)
-    path = joinpath(prefix, name)
+function load_hook(prefix::String, name::String, found::Void=nothing)
+    name_jl = "$name.jl"
+    path = joinpath(prefix, name_jl)
     isfile_casesensitive(path) && return abspath(path)
-    path = joinpath(prefix, base, "src", name)
+    path = joinpath(prefix, name_jl, "src", name_jl)
     isfile_casesensitive(path) && return abspath(path)
-    path = joinpath(prefix, name, "src", name)
+    path = joinpath(prefix, name, "src", name_jl)
     isfile_casesensitive(path) && return abspath(path)
     return nothing
 end
+load_hook(prefix::String, name::String, found::String) = found
 
-# `wd` is a working directory to search. defaults to current working directory.
-# if `wd === nothing`, no extra path is searched.
-function find_in_path(name::String, wd)
-    isabspath(name) && return name
-    base = name
-    if endswith(name,".jl")
-        base = name[1:end-3]
-    else
-        name = string(base,".jl")
+function find_in_path(name::String)
+    path = load_hook(Pkg.dir(), name)
+    for dir in LOAD_PATH
+        path = load_hook(dir, name, path)
     end
-    if wd !== nothing
-        isfile_casesensitive(joinpath(wd,name)) && return joinpath(wd,name)
-    end
-    p = try_path(Pkg.dir(), base, name)
-    p !== nothing && return p
-    for prefix in LOAD_PATH
-        p = try_path(prefix, base, name)
-        p !== nothing && return p
-    end
-    return nothing
+    return path
 end
-find_in_path(name::AbstractString, wd = pwd()) = find_in_path(String(name), wd)
+find_in_path(name::AbstractString) = find_in_path(String(name))
 
-function find_in_node_path(name::String, srcpath, node::Int=1)
-    if myid() == node
-        return find_in_path(name, srcpath)
-    else
-        return remotecall_fetch(find_in_path, node, name, srcpath)
-    end
-end
-
-function find_source_file(file::String)
-    (isabspath(file) || isfile(file)) && return file
-    file2 = find_in_path(file)
-    file2 !== nothing && return file2
-    file2 = joinpath(JULIA_HOME, DATAROOTDIR, "julia", "base", file)
-    return isfile(file2) ? file2 : nothing
-end
+find_in_node_path(name::String, node::Int=1) =
+    myid() == node ? find_in_path(name) :
+    remotecall_fetch(find_in_path, node, name)
 
 function find_all_in_cache_path(mod::Symbol)
     name = string(mod)
@@ -391,7 +367,7 @@ function require(mod::Symbol)
         toplevel_load = false
         # perform the search operation to select the module file require intends to load
         name = string(mod)
-        path = find_in_node_path(name, nothing, 1)
+        path = find_in_node_path(name, 1)
         if path === nothing
             throw(ArgumentError("Module $name not found in current path.\nRun `Pkg.add(\"$name\")` to install the $name package."))
         end
@@ -632,7 +608,7 @@ for important notes.
 function compilecache(name::String)
     myid() == 1 || error("can only precompile from node 1")
     # decide where to get the source file from
-    path = find_in_path(name, nothing)
+    path = find_in_path(name)
     path === nothing && throw(ArgumentError("$name not found in path"))
     path = String(path)
     # decide where to put the resulting cache file

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -740,6 +740,12 @@ Get the name of a generic `Function` as a symbol, or `:anonymous`.
 """
 function_name(f::Function) = typeof(f).name.mt.name
 
+function find_source_file(file::String)
+    (isabspath(file) || isfile(file)) && return file
+    file = joinpath(JULIA_HOME, DATAROOTDIR, "julia", "base", file)
+    return isfile(file) ? file : nothing
+end
+
 functionloc(m::Core.MethodInstance) = functionloc(m.def)
 
 """

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -42,10 +42,12 @@ end
 
 SAVED_LOAD_PATH = copy(LOAD_PATH)
 empty!(LOAD_PATH)
-push!(LOAD_PATH, @__DIR__)
 let paddedname = "Atest_sourcepathZ"
+    push!(LOAD_PATH, @__DIR__)
     filename = SubString(paddedname, 2, length(paddedname)-1)
-    @test Base.find_in_path(filename) == abspath("$(paddedname[2:end-1]).jl")
+    @test Base.find_in_path(filename) == abspath("test_sourcepath.jl")
+    LOAD_PATH[end] = GenericString(LOAD_PATH[end])
+    @test Base.find_in_path(filename) == abspath("test_sourcepath.jl")
 end
 
 immutable CustomLoader

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -40,6 +40,7 @@ mktempdir() do dir
     end
 end
 
+SAVED_LOAD_PATH = copy(LOAD_PATH)
 empty!(LOAD_PATH)
 push!(LOAD_PATH, @__DIR__)
 let paddedname = "Atest_sourcepathZ"
@@ -60,3 +61,5 @@ end
 Base.load_hook(prefix::CustomLoader, name::String, found::String) = found
 @test Base.find_in_path("test_sourcepath") == abspath("test_sourcepath.jl")
 empty!(LOAD_PATH)
+append!(LOAD_PATH, SAVED_LOAD_PATH)
+@test LOAD_PATH == SAVED_LOAD_PATH

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -40,7 +40,9 @@ mktempdir() do dir
     end
 end
 
-let paddedname = "Ztest_sourcepath.jl"
-    filename = SubString(paddedname, 2, length(paddedname))
-    @test Base.find_in_path(filename) == abspath(paddedname[2:end])
+push!(LOAD_PATH, @__DIR__)
+let paddedname = "Atest_sourcepathZ"
+    filename = SubString(paddedname, 2, length(paddedname)-1)
+    @test Base.find_in_path(filename) == abspath("$(paddedname[2:end-1]).jl")
 end
+pop!(LOAD_PATH)


### PR DESCRIPTION
This is a less disruptive alternative to https://github.com/JuliaLang/julia/pull/19910 and https://github.com/JuliaLang/julia/pull/19866. Doesn't really change anything, just makes how code gets loaded extensible via putting things that aren't Strings in `LOAD_PATH` and defining appropriate methods for `Base.load_hook`.

It does also remove searching for files relative to the current directory behavior, but I don't think that was used by anything except for the reflection code, I've now factored out.