### PR TITLE
Fix #19995, improve hashing algorithm for Associative types

### DIFF
--- a/base/associative.jl
+++ b/base/associative.jl
@@ -249,11 +249,11 @@ end
 
 const hasha_seed = UInt === UInt64 ? 0x6d35bb51952d5539 : 0x952d5539
 function hash(a::Associative, h::UInt)
-    h = hash(hasha_seed, h)
+    hv = hasha_seed
     for (k,v) in a
-        h ⊻= hash(k, hash(v))
+        hv ⊻= hash(k, hash(v))
     end
-    return h
+    hash(hv, h)
 end
 
 function getindex(t::Associative, key)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -649,3 +649,11 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     @test isempty(wkd)
     @test isa(wkd, WeakKeyDict)
 end
+
+# issue 19995
+
+@test hash(Dict(Dict(1=>2) => 3, Dict(4=>5) => 6)) != hash(Dict(Dict(4=>5) => 3, Dict(1=>2) => 6))
+let a = Dict(Dict(3 => 4, 2 => 3) => 2, Dict(1 => 2, 5 => 6) => 1)
+    b = Dict(Dict(1 => 2, 2 => 3, 5 => 6) => 1, Dict(3 => 4) => 2)
+    @test hash(a) != hash(b)
+end


### PR DESCRIPTION
This fixes #19995 via a minor modification to `hash(::Associative)` that seems otherwise reasonable.