### PR TITLE
Explicitly list types in iszero test

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -398,3 +398,5 @@ end
 function ^{T<:Rational}(z::Complex{T}, n::Integer)
     n >= 0 ? power_by_squaring(z,n) : power_by_squaring(inv(z),-n)
 end
+
+iszero(x::Rational) = iszero(numerator(x))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2867,14 +2867,19 @@ end
 
 @testset "iszero" begin
     # Numeric scalars
-    for T in Iterators.flatten(subtypes.([AbstractFloat, Signed, Unsigned]))
+    for T in [Float16, Float32, Float64, BigFloat,
+              Int8, Int16, Int32, Int64, Int128, BigInt,
+              UInt8, UInt16, UInt32, UInt64, UInt128]
         @test iszero(T(0))
         @test iszero(Complex{T}(0))
+        if T <: Integer
+            @test iszero(Rational{T}(0))
+        elseif T <: AbstractFloat
+            @test iszero(T(-0.0))
+            @test iszero(Complex{T}(-0.0))
+        end
     end
-    @test iszero(BigFloat(0))
     @test !iszero(nextfloat(BigFloat(0)))
-    @test iszero(BigInt(0))
-    @test iszero(0//1)
 
     # Array reduction
     @test !iszero([0, 1, 2, 3])


### PR DESCRIPTION
This addresses @tkelman's comment in https://github.com/JuliaLang/julia/pull/19950#discussion_r96108525. I've restructured the `iszero` tests such that the types are explicitly listed out. I've also consolidated more of the other tests into the loop.