### PR TITLE
Minor cleanups, style tweaks

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -328,7 +328,7 @@ the following rules:
  - If the arguments are tuples and zero or more scalars, it returns a tuple.
  - If the arguments contain at least one array or `Ref`, it returns an array
    (expanding singleton dimensions), and treats `Ref`s as 0-dimensional arrays,
-   and tuples as a 1-dimensional arrays.
+   and tuples as 1-dimensional arrays.
 
 The following additional rule applies to `Nullable` arguments: If there is at
 least one `Nullable`, and all the arguments are scalars or `Nullable`, it

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -81,7 +81,6 @@ i = 1
 i = 2
 i = 3
 i = 4
-
 ```
 
 An example of referencing the created task:
@@ -99,7 +98,6 @@ take!(c) = "Hello"
 
 julia> istaskdone(taskref[])
 true
-
 ```
 """
 function Channel(func::Function; ctype=Any, csize=0, taskref=nothing)
@@ -175,7 +173,6 @@ i = 4
 
 julia> isopen(c)
 false
-
 ```
 
 ```jldoctest
@@ -193,7 +190,6 @@ ERROR: foo
 Stacktrace:
  [1] check_channel_state(::Channel{Any}) at ./channels.jl:129
  [2] put!(::Channel{Any}, ::Int64) at ./channels.jl:247
-
 ```
 """
 function bind(c::Channel, task::Task)

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -88,7 +88,7 @@ function deepcopy_internal(x::Dict, stackdict::ObjectIdDict)
     dest = similar(x)
     stackdict[x] = dest
     for (k, v) in x
-        dest[Base.deepcopy_internal(k, stackdict)] = Base.deepcopy_internal(v, stackdict)
+        dest[deepcopy_internal(k, stackdict)] = deepcopy_internal(v, stackdict)
     end
     dest
 end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1677,72 +1677,72 @@ iteratoreltype(::Type{Task}) = EltypeUnknown()
 
 isempty(::Task) = error("isempty not defined for Tasks")
 
-# BEGIN code from base/test.jl
-approx_full(x::AbstractArray) = x
-approx_full(x::Number) = x
-approx_full(x) = full(x)
+eval(Base.Test, quote
+    approx_full(x::AbstractArray) = x
+    approx_full(x::Number) = x
+    approx_full(x) = full(x)
 
-function test_approx_eq(va, vb, Eps, astr, bstr)
-    va = approx_full(va)
-    vb = approx_full(vb)
-    la, lb = length(linearindices(va)), length(linearindices(vb))
-    if la != lb
-        error("lengths of ", astr, " and ", bstr, " do not match: ",
-              "\n  ", astr, " (length $la) = ", va,
-              "\n  ", bstr, " (length $lb) = ", vb)
-    end
-    diff = real(zero(eltype(va)))
-    for (xa, xb) = zip(va, vb)
-        if isfinite(xa) && isfinite(xb)
-            diff = max(diff, abs(xa-xb))
-        elseif !isequal(xa,xb)
-            error("mismatch of non-finite elements: ",
-                  "\n  ", astr, " = ", va,
-                  "\n  ", bstr, " = ", vb)
+    function test_approx_eq(va, vb, Eps, astr, bstr)
+        va = approx_full(va)
+        vb = approx_full(vb)
+        la, lb = length(linearindices(va)), length(linearindices(vb))
+        if la != lb
+            error("lengths of ", astr, " and ", bstr, " do not match: ",
+                "\n  ", astr, " (length $la) = ", va,
+                "\n  ", bstr, " (length $lb) = ", vb)
+        end
+        diff = real(zero(eltype(va)))
+        for (xa, xb) = zip(va, vb)
+            if isfinite(xa) && isfinite(xb)
+                diff = max(diff, abs(xa-xb))
+            elseif !isequal(xa,xb)
+                error("mismatch of non-finite elements: ",
+                    "\n  ", astr, " = ", va,
+                    "\n  ", bstr, " = ", vb)
+            end
+        end
+
+        if !isnan(Eps) && !(diff <= Eps)
+            sdiff = string("|", astr, " - ", bstr, "| <= ", Eps)
+            error("assertion failed: ", sdiff,
+                "\n  ", astr, " = ", va,
+                "\n  ", bstr, " = ", vb,
+                "\n  difference = ", diff, " > ", Eps)
         end
     end
 
-    if !isnan(Eps) && !(diff <= Eps)
-        sdiff = string("|", astr, " - ", bstr, "| <= ", Eps)
-        error("assertion failed: ", sdiff,
-              "\n  ", astr, " = ", va,
-              "\n  ", bstr, " = ", vb,
-              "\n  difference = ", diff, " > ", Eps)
+    array_eps{T}(a::AbstractArray{Complex{T}}) = eps(float(maximum(x->(isfinite(x) ? abs(x) : T(NaN)), a)))
+    array_eps(a) = eps(float(maximum(x->(isfinite(x) ? abs(x) : oftype(x,NaN)), a)))
+
+    test_approx_eq(va, vb, astr, bstr) =
+        test_approx_eq(va, vb, 1E4*length(linearindices(va))*max(array_eps(va), array_eps(vb)), astr, bstr)
+
+    """
+        @test_approx_eq_eps(a, b, tol)
+
+    Test two floating point numbers `a` and `b` for equality taking into account
+    a margin of tolerance given by `tol`.
+    """
+    macro test_approx_eq_eps(a, b, c)
+        Base.depwarn(string("@test_approx_eq_eps is deprecated, use `@test ", a, " ≈ ", b, " atol=", c, "` instead"),
+                    Symbol("@test_approx_eq_eps"))
+        :(test_approx_eq($(esc(a)), $(esc(b)), $(esc(c)), $(string(a)), $(string(b))))
     end
-end
+    export @test_approx_eq_eps
 
-array_eps{T}(a::AbstractArray{Complex{T}}) = eps(float(maximum(x->(isfinite(x) ? abs(x) : T(NaN)), a)))
-array_eps(a) = eps(float(maximum(x->(isfinite(x) ? abs(x) : oftype(x,NaN)), a)))
+    """
+        @test_approx_eq(a, b)
 
-test_approx_eq(va, vb, astr, bstr) =
-    test_approx_eq(va, vb, 1E4*length(linearindices(va))*max(array_eps(va), array_eps(vb)), astr, bstr)
-
-"""
-    @test_approx_eq_eps(a, b, tol)
-
-Test two floating point numbers `a` and `b` for equality taking into account
-a margin of tolerance given by `tol`.
-"""
-macro test_approx_eq_eps(a, b, c)
-    Base.depwarn(string("@test_approx_eq_eps is deprecated, use `@test ", a, " ≈ ", b, " atol=", c, "` instead"),
-                 Symbol("@test_approx_eq_eps"))
-    :(test_approx_eq($(esc(a)), $(esc(b)), $(esc(c)), $(string(a)), $(string(b))))
-end
-export @test_approx_eq_eps
-
-"""
-    @test_approx_eq(a, b)
-
-Deprecated. Test two floating point numbers `a` and `b` for equality taking into
-account small numerical errors.
-"""
-macro test_approx_eq(a, b)
-    Base.depwarn(string("@test_approx_eq is deprecated, use `@test ", a, " ≈ ", b, "` instead"),
-                 Symbol("@test_approx_eq"))
-    :(test_approx_eq($(esc(a)), $(esc(b)), $(string(a)), $(string(b))))
-end
-export @test_approx_eq
-# END code from base/test.jl
+    Deprecated. Test two floating point numbers `a` and `b` for equality taking into
+    account small numerical errors.
+    """
+    macro test_approx_eq(a, b)
+        Base.depwarn(string("@test_approx_eq is deprecated, use `@test ", a, " ≈ ", b, "` instead"),
+                    Symbol("@test_approx_eq"))
+        :(test_approx_eq($(esc(a)), $(esc(b)), $(string(a)), $(string(b))))
+    end
+    export @test_approx_eq
+end)
 
 # Deprecate Array(T, dims...) in favor of proper type constructors
 @deprecate Array{T,N}(::Type{T}, d::NTuple{N,Int})               Array{T,N}(d)

--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -456,7 +456,6 @@ end
 
 for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
                          (:Float32,:Complex64,"fftwf",libfftwf))
-
     @eval function (::Type{cFFTWPlan{$Tc,K,inplace,N}}){K,inplace,N}(X::StridedArray{$Tc,N},
                                                                      Y::StridedArray{$Tc,N},
                                                                      region, flags::Integer, timelimit::Real)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -7,7 +7,7 @@
 
 Determines the editor to use when running functions like `edit`. Returns an Array compatible
 for use within backticks. You can change the editor by setting `JULIA_EDITOR`, `VISUAL` or
-`EDITOR` as an environmental variable.
+`EDITOR` as an environment variable.
 """
 function editor()
     if is_windows() || is_apple()
@@ -28,7 +28,7 @@ end
 
 Edit a file or directory optionally providing a line number to edit the file at.
 Returns to the `julia` prompt when you quit the editor. The editor can be changed
-by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environmental variable.
+by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environment variable.
 """
 function edit(path::AbstractString, line::Integer=0)
     command = editor()
@@ -76,7 +76,7 @@ end
 
 Edit the definition of a function, optionally specifying a tuple of types to
 indicate which method to edit. The editor can be changed by setting `JULIA_EDITOR`,
-`VISUAL` or `EDITOR` as an environmental variable.
+`VISUAL` or `EDITOR` as an environment variable.
 """
 edit(f)          = edit(functionloc(f)...)
 edit(f, t::ANY)  = edit(functionloc(f,t)...)

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -10,7 +10,6 @@ function aupd_wrapper(T, matvecA!::Function, matvecB::Function, solveSI::Functio
                       sym::Bool, cmplx::Bool, bmat::String,
                       nev::Integer, ncv::Integer, which::String,
                       tol::Real, maxiter::Integer, mode::Integer, v0::Vector)
-
     lworkl = cmplx ? ncv * (3*ncv + 5) : (sym ? ncv * (ncv + 8) :  ncv * (3*ncv + 6) )
     TR = cmplx ? T.types[1] : T
     TOL = Array{TR}(1)
@@ -109,7 +108,6 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
                       nev::Integer, which::String, ritzvec::Bool,
                       TOL::Array, resid, ncv::Integer, v, ldv, sigma, iparam, ipntr,
                       workd, workl, lworkl, rwork)
-
     howmny = "A"
     select = Array{BlasInt}(ncv)
     info   = zeros(BlasInt, 1)
@@ -128,7 +126,6 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
     end
 
     if cmplx
-
         d = Array{T}(nev+1)
         sigmar = ones(T, 1)*sigma
         workev = Array{T}(2ncv)
@@ -141,9 +138,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
 
         p = sortperm(dmap(d[1:nev]), rev=true)
         return ritzvec ? (d[p], v[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d[p],iparam[5],iparam[3],iparam[9],resid)
-
     elseif sym
-
         d = Array{T}(nev)
         sigmar = ones(T, 1)*sigma
         seupd(ritzvec, howmny, select, d, v, ldv, sigmar,
@@ -155,9 +150,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
 
         p = sortperm(dmap(d), rev=true)
         return ritzvec ? (d[p], v[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d,iparam[5],iparam[3],iparam[9],resid)
-
     else
-
         dr     = Array{T}(nev+1)
         di     = Array{T}(nev+1)
         fill!(dr,NaN)
@@ -204,17 +197,14 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
 
         return ritzvec ? (d[p], evec[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d[p],iparam[5],iparam[3],iparam[9],resid)
     end
-
 end
 
 for (T, saupd_name, seupd_name, naupd_name, neupd_name) in
     ((:Float64, :dsaupd_, :dseupd_, :dnaupd_, :dneupd_),
      (:Float32, :ssaupd_, :sseupd_, :snaupd_, :sneupd_))
     @eval begin
-
         function naupd(ido, bmat, n, evtype, nev, TOL::Array{$T}, resid::Array{$T}, ncv, v::Array{$T}, ldv,
                        iparam, ipntr, workd::Array{$T}, workl::Array{$T}, lworkl, info)
-
             ccall(($(string(naupd_name)), :libarpack), Void,
                   (Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt},
                    Ptr{$T}, Ptr{$T}, Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt},
@@ -226,7 +216,6 @@ for (T, saupd_name, seupd_name, naupd_name, neupd_name) in
         function neupd(rvec, howmny, select, dr, di, z, ldz, sigmar, sigmai,
                   workev::Array{$T}, bmat, n, evtype, nev, TOL::Array{$T}, resid::Array{$T}, ncv, v, ldv,
                   iparam, ipntr, workd::Array{$T}, workl::Array{$T}, lworkl, info)
-
             ccall(($(string(neupd_name)), :libarpack), Void,
                   (Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{$T},
                    Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{$T}, Ptr{UInt8}, Ptr{BlasInt},
@@ -241,20 +230,17 @@ for (T, saupd_name, seupd_name, naupd_name, neupd_name) in
 
         function saupd(ido, bmat, n, which, nev, TOL::Array{$T}, resid::Array{$T}, ncv, v::Array{$T}, ldv,
                        iparam, ipntr, workd::Array{$T}, workl::Array{$T}, lworkl, info)
-
             ccall(($(string(saupd_name)), :libarpack), Void,
                   (Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt},
                    Ptr{$T}, Ptr{$T}, Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt}, Clong, Clong),
                   ido, bmat, &n, which, &nev, TOL, resid, &ncv, v, &ldv,
                   iparam, ipntr, workd, workl, &lworkl, info, sizeof(bmat), sizeof(which))
-
         end
 
         function seupd(rvec, howmny, select, d, z, ldz, sigma,
                        bmat, n, evtype, nev, TOL::Array{$T}, resid::Array{$T}, ncv, v::Array{$T}, ldv,
                        iparam, ipntr, workd::Array{$T}, workl::Array{$T}, lworkl, info)
-
             ccall(($(string(seupd_name)), :libarpack), Void,
                   (Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{BlasInt}, Ptr{$T},
                    Ptr{UInt8}, Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt},
@@ -264,7 +250,6 @@ for (T, saupd_name, seupd_name, naupd_name, neupd_name) in
                   bmat, &n, evtype, &nev, TOL, resid, &ncv, v, &ldv,
                   iparam, ipntr, workd, workl, &lworkl, info, sizeof(howmny), sizeof(bmat), sizeof(evtype))
         end
-
     end
 end
 
@@ -272,11 +257,9 @@ for (T, TR, naupd_name, neupd_name) in
     ((:Complex128, :Float64, :znaupd_, :zneupd_),
      (:Complex64,  :Float32, :cnaupd_, :cneupd_))
     @eval begin
-
         function naupd(ido, bmat, n, evtype, nev, TOL::Array{$TR}, resid::Array{$T}, ncv, v::Array{$T}, ldv,
                        iparam, ipntr, workd::Array{$T}, workl::Array{$T}, lworkl,
                        rwork::Array{$TR}, info)
-
             ccall(($(string(naupd_name)), :libarpack), Void,
                   (Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt},
                    Ptr{$TR}, Ptr{$T}, Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt},
@@ -284,14 +267,12 @@ for (T, TR, naupd_name, neupd_name) in
                    Ptr{$TR}, Ptr{BlasInt}),
                   ido, bmat, &n, evtype, &nev, TOL, resid, &ncv, v, &ldv,
                   iparam, ipntr, workd, workl, &lworkl, rwork, info)
-
         end
 
         function neupd(rvec, howmny, select, d, z, ldz, sigma, workev::Array{$T},
                        bmat, n, evtype, nev, TOL::Array{$TR}, resid::Array{$T}, ncv, v::Array{$T}, ldv,
                        iparam, ipntr, workd::Array{$T}, workl::Array{$T}, lworkl,
                        rwork::Array{$TR}, info)
-
             ccall(($(string(neupd_name)), :libarpack), Void,
                   (Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{BlasInt},
                    Ptr{$T}, Ptr{$T}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{UInt8}, Ptr{BlasInt},
@@ -300,9 +281,7 @@ for (T, TR, naupd_name, neupd_name) in
                   &rvec, howmny, select, d, z, &ldz, sigma, workev,
                   bmat, &n, evtype, &nev, TOL, resid, &ncv, v, &ldv,
                   iparam, ipntr, workd, workl, &lworkl, rwork, info)
-
         end
-
     end
 end
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -509,7 +509,7 @@ function logm(A::StridedMatrix)
         end
     end
 
-    if isreal(A) && ~np_real_eigs
+    if isreal(A) && !np_real_eigs
         return real(retmat)
     else
         return retmat

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1731,7 +1731,7 @@ function logm{T<:Union{Float64,Complex{Float64}}}(A0::UpperTriangular{T})
         foundm = true
     end
 
-    while ~foundm
+    while !foundm
         more = false
         if s > s0
             d3 = cbrt(norm(AmI^3, 1))
@@ -1753,7 +1753,7 @@ function logm{T<:Union{Float64,Complex{Float64}}}(A0::UpperTriangular{T})
            end
         end
 
-        if ~more
+        if !more
             d5 = norm(AmI^5, 1)^(1/5)
             alpha4 = max(d4, d5)
             eta = min(alpha3, alpha4)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -51,10 +51,14 @@ module IteratorsMD
 
     # arithmetic, min/max
     (-){N}(index::CartesianIndex{N}) = CartesianIndex{N}(map(-, index.I))
-    (+){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(+, index1.I, index2.I))
-    (-){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(-, index1.I, index2.I))
-    min{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(min, index1.I, index2.I))
-    max{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) = CartesianIndex{N}(map(max, index1.I, index2.I))
+    (+){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+        CartesianIndex{N}(map(+, index1.I, index2.I))
+    (-){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+        CartesianIndex{N}(map(-, index1.I, index2.I))
+    min{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+        CartesianIndex{N}(map(min, index1.I, index2.I))
+    max{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+        CartesianIndex{N}(map(max, index1.I, index2.I))
 
     (+){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x+i, index.I))
     (+){N}(i::Integer, index::CartesianIndex{N}) = index+i
@@ -81,14 +85,16 @@ module IteratorsMD
     CartesianRange{N}(index::CartesianIndex{N}) = CartesianRange(one(index), index)
     CartesianRange(::Tuple{}) = CartesianRange{CartesianIndex{0}}(CartesianIndex{0}(()),CartesianIndex{0}(()))
     CartesianRange{N}(sz::NTuple{N,Int}) = CartesianRange(CartesianIndex(sz))
-    CartesianRange{N}(rngs::NTuple{N,Union{Integer,AbstractUnitRange}}) = CartesianRange(CartesianIndex(map(first, rngs)), CartesianIndex(map(last, rngs)))
+    CartesianRange{N}(rngs::NTuple{N,Union{Integer,AbstractUnitRange}}) =
+        CartesianRange(CartesianIndex(map(first, rngs)), CartesianIndex(map(last, rngs)))
 
     ndims(R::CartesianRange) = length(R.start)
     ndims{I<:CartesianIndex}(::Type{CartesianRange{I}}) = length(I)
 
     eachindex(::LinearSlow, A::AbstractArray) = CartesianRange(indices(A))
 
-    @inline eachindex(::LinearSlow, A::AbstractArray, B::AbstractArray...) = CartesianRange(maxsize((), A, B...))
+    @inline eachindex(::LinearSlow, A::AbstractArray, B::AbstractArray...) =
+        CartesianRange(maxsize((), A, B...))
     maxsize(sz) = sz
     @inline maxsize(sz, A, B...) = maxsize(maxt(sz, size(A)), B...)
     @inline maxt(a::Tuple{}, b::Tuple{}) = ()
@@ -184,16 +190,20 @@ using .IteratorsMD
 # Support indexing with an array of CartesianIndex{N}s
 # Here we try to consume N of the indices (if there are that many available)
 # The first two simply handle ambiguities
-@inline function checkbounds_indices{N}(::Type{Bool}, ::Tuple{}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+@inline function checkbounds_indices{N}(::Type{Bool}, ::Tuple{},
+        I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
     checkindex(Bool, (), I[1]) & checkbounds_indices(Bool, (), tail(I))
 end
-@inline function checkbounds_indices(::Type{Bool}, IA::Tuple{Any}, I::Tuple{AbstractArray{CartesianIndex{0}},Vararg{Any}})
+@inline function checkbounds_indices(::Type{Bool}, IA::Tuple{Any},
+        I::Tuple{AbstractArray{CartesianIndex{0}},Vararg{Any}})
     checkbounds_indices(Bool, IA, tail(I))
 end
-@inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple{Any}, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+@inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple{Any},
+        I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
     checkindex(Bool, IA, I[1]) & checkbounds_indices(Bool, (), tail(I))
 end
-@inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
+@inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple,
+        I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
     IA1, IArest = IteratorsMD.split(IA, Val{N})
     checkindex(Bool, IA1, I[1]) & checkbounds_indices(Bool, IArest, tail(I))
 end
@@ -308,7 +318,8 @@ end
     IA1, IArest = IteratorsMD.split(IA, Val{N})
     checkindex(Bool, IA1, I[1])
 end
-@inline checkbounds{T,B<:AbstractArray{Bool,1}}(::Type{Bool}, A::AbstractArray, I::LogicalIndex{T,B}) = linearindices(A) == linearindices(I.mask)
+@inline checkbounds{T,B<:AbstractArray{Bool,1}}(::Type{Bool}, A::AbstractArray, I::LogicalIndex{T,B}) =
+    linearindices(A) == linearindices(I.mask)
 @inline checkbounds(::Type{Bool}, A::AbstractArray, I::LogicalIndex) = indices(A) == indices(I.mask)
 @inline checkindex(::Type{Bool}, indx::AbstractUnitRange, I::LogicalIndex) = (indx,) == indices(I.mask)
 checkindex(::Type{Bool}, inds::Tuple, I::LogicalIndex) = false
@@ -669,8 +680,8 @@ end
 """
     accumulate!(op, B, A, dim=1)
 
-Cumulative operation `op` on `A` along a dimension, storing the result in `B`. The dimension defaults to 1.
-See also [`accumulate`](@ref).
+Cumulative operation `op` on `A` along a dimension, storing the result in `B`.
+The dimension defaults to 1. See also [`accumulate`](@ref).
 """
 function accumulate!(op, B, A, axis::Integer=1)
     axis > 0 || throw(ArgumentError("axis must be a positive integer"))
@@ -731,7 +742,9 @@ end
 
 function copy!(dest::AbstractArray, Rdest::CartesianRange, src::AbstractArray, Rsrc::CartesianRange)
     isempty(Rdest) && return dest
-    size(Rdest) == size(Rsrc) || throw(ArgumentError("source and destination must have same size (got $(size(Rsrc)) and $(size(Rdest)))"))
+    if size(Rdest) != size(Rsrc)
+        throw(ArgumentError("source and destination must have same size (got $(size(Rsrc)) and $(size(Rdest)))"))
+    end
     @boundscheck checkbounds(dest, Rdest.start)
     @boundscheck checkbounds(dest, Rdest.stop)
     @boundscheck checkbounds(src, Rsrc.start)
@@ -871,7 +884,8 @@ end
 end
 
 # Optimization where the inner dimension is contiguous improves perf dramatically
-@generated function _unsafe_getindex!(X::BitArray, B::BitArray, I0::Union{Slice,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Slice}...)
+@generated function _unsafe_getindex!(X::BitArray, B::BitArray,
+        I0::Union{Slice,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Slice}...)
     N = length(I)
     quote
         $(Expr(:meta, :inline))
@@ -953,12 +967,14 @@ end
     return B
 end
 
-@inline function setindex!(B::BitArray, X::Union{BitArray,Array}, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
+@inline function setindex!(B::BitArray, X::Union{BitArray,Array},
+        I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     J = to_indices(B, (I0, I...))
     @boundscheck checkbounds(B, J...)
     _unsafe_setindex!(B, X, J...)
 end
-@generated function _unsafe_setindex!(B::BitArray, X::Union{BitArray,Array}, I0::Union{Slice,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Slice}...)
+@generated function _unsafe_setindex!(B::BitArray, X::Union{BitArray,Array},
+        I0::Union{Slice,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Slice}...)
     N = length(I)
     quote
         idxlens = @ncall $N index_lengths I0 d->I[d]
@@ -992,12 +1008,14 @@ end
     end
 end
 
-@inline function setindex!(B::BitArray, x, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
+@inline function setindex!(B::BitArray, x,
+        I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
     J = to_indices(B, (I0, I...))
     @boundscheck checkbounds(B, J...)
     _unsafe_setindex!(B, x, J...)
 end
-@generated function _unsafe_setindex!(B::BitArray, x, I0::Union{Slice,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Slice}...)
+@generated function _unsafe_setindex!(B::BitArray, x,
+        I0::Union{Slice,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Slice}...)
     N = length(I)
     quote
         y = Bool(x)

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -88,7 +88,6 @@ function normalize_url(url::AbstractString)
     m = match(GITHUB_REGEX,url)
     (m === nothing || rewrite_url_to === nothing) ?
         url : "$rewrite_url_to://github.com/$(m.captures[1]).git"
-
 end
 
 end # module

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -117,8 +117,7 @@ function sanity_check(deps::Dict{String,Dict{VersionNumber,Available}},
             end
         end
         if ok
-            let
-                p0 = interface.pdict[p]
+            let p0 = interface.pdict[p]
                 svn = red_pvers[p0][sol[p0]]
                 @assert svn == vn
             end

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -433,7 +433,6 @@ any!(r, A)
 for (fname, op) in [(:sum, :+), (:prod, :*),
                     (:maximum, :scalarmax), (:minimum, :scalarmin),
                     (:all, :&), (:any, :|)]
-
     fname! = Symbol(fname, '!')
     @eval begin
         $(fname!)(f::Function, r::AbstractArray, A::AbstractArray; init::Bool=true) =

--- a/base/special/bessel.jl
+++ b/base/special/bessel.jl
@@ -118,7 +118,6 @@ for afn in (:airyai, :airyaiprime, :airybi, :airybiprime,
     else
         @eval $afn(x::Real) = real($afn(complex(float(x))))
     end
-
 end
 
 ## Bessel functions

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -271,7 +271,7 @@ for important details on how to modify these fields safely.
 
     The ABI to use when calling `fptr`. Some significant ones include:
 
-      * 0 - Not compiled yet.
+      * 0 - Not compiled yet
       * 1 - JL_CALLABLE `jl_value_t *(*)(jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`
       * 2 - Constant (value stored in `inferred`)
       * 3 - With Static-parameters forwarded `jl_value_t *(*)(jl_svec_t *sparams, jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -24,9 +24,9 @@ is that of the last subexpression. Here's an example of a `begin` block:
 
 ```julia
 julia> z = begin
-         x = 1
-         y = 2
-         x + y
+           x = 1
+           y = 2
+           x + y
        end
 3
 ```
@@ -74,13 +74,13 @@ evaluated; if neither expression is true, the `else` block is evaluated. Here it
 
 ```julia
 julia> function test(x, y)
-         if x < y
-           println("x is less than y")
-         elseif x > y
-           println("x is greater than y")
-         else
-           println("x is equal to y")
-         end
+           if x < y
+               println("x is less than y")
+           elseif x > y
+               println("x is greater than y")
+           else
+               println("x is equal to y")
+           end
        end
 test (generic function with 1 method)
 
@@ -105,14 +105,14 @@ before. So, we could have defined the `test` function above as
 
 ```julia
 julia> function test(x,y)
-         if x < y
-           relation = "less than"
-         elseif x == y
-           relation = "equal to"
-         else
-           relation = "greater than"
-         end
-         println("x is ", relation, " y.")
+           if x < y
+               relation = "less than"
+           elseif x == y
+               relation = "equal to"
+           else
+               relation = "greater than"
+           end
+           println("x is ", relation, " y.")
        end
 test (generic function with 1 method)
 ```
@@ -123,12 +123,12 @@ change to the above function results in a runtime error
 
 ```julia
 julia> function test(x,y)
-         if x < y
-           relation = "less than"
-         elseif x == y
-           relation = "equal to"
-         end
-         println("x is ", relation, " y.")
+           if x < y
+               relation = "less than"
+           elseif x == y
+               relation = "equal to"
+           end
+           println("x is ", relation, " y.")
        end
 test (generic function with 1 method)
 
@@ -165,7 +165,7 @@ Unlike C, MATLAB, Perl, Python, and Ruby -- but like Java, and a few other stric
 
 ```julia
 julia> if 1
-         println("true")
+           println("true")
        end
 ERROR: TypeError: non-boolean (Int64) used in boolean context
  ...
@@ -379,8 +379,8 @@ loop. Here is an example of a `while` loop:
 julia> i = 1;
 
 julia> while i <= 5
-         println(i)
-         i += 1
+           println(i)
+           i += 1
        end
 1
 2
@@ -399,7 +399,7 @@ down like the above `while` loop does is so common, it can be expressed more con
 
 ```julia
 julia> for i = 1:5
-         println(i)
+           println(i)
        end
 1
 2
@@ -417,7 +417,7 @@ You'll either need a new interactive session instance or a different variable na
 
 ```julia
 julia> for j = 1:5
-         println(j)
+           println(j)
        end
 1
 2
@@ -439,14 +439,14 @@ the code read more clearly:
 
 ```julia
 julia> for i in [1,4,0]
-         println(i)
+           println(i)
        end
 1
 4
 0
 
 julia> for s ∈ ["foo","bar","baz"]
-         println(s)
+           println(s)
        end
 foo
 bar
@@ -464,11 +464,11 @@ This can be accomplished with the `break` keyword:
 julia> i = 1;
 
 julia> while true
-         println(i)
-         if i >= 5
-           break
-         end
-         i += 1
+           println(i)
+           if i >= 5
+               break
+           end
+           i += 1
        end
 1
 2
@@ -477,10 +477,10 @@ julia> while true
 5
 
 julia> for i = 1:1000
-         println(i)
-         if i >= 5
-           break
-         end
+           println(i)
+           if i >= 5
+               break
+           end
        end
 1
 2
@@ -495,10 +495,10 @@ immediately. The `continue` keyword accomplishes this:
 
 ```julia
 julia> for i = 1:10
-         if i % 3 != 0
-           continue
-         end
-         println(i)
+           if i % 3 != 0
+               continue
+           end
+           println(i)
        end
 3
 6
@@ -515,7 +515,7 @@ of its iterables:
 
 ```julia
 julia> for i = 1:2, j = 3:4
-         println((i, j))
+           println((i, j))
        end
 (1,3)
 (1,4)
@@ -668,10 +668,10 @@ interactive session:
 
 ```julia
 julia> function verbose_fussy_sqrt(x)
-         println("before fussy_sqrt")
-         r = fussy_sqrt(x)
-         println("after fussy_sqrt")
-         return r
+           println("before fussy_sqrt")
+           r = fussy_sqrt(x)
+           println("after fussy_sqrt")
+           return r
        end
 verbose_fussy_sqrt (generic function with 1 method)
 
@@ -716,9 +716,9 @@ method on demand using `Exception`s :
 
 ```julia
 julia> f(x) = try
-         sqrt(x)
+           sqrt(x)
        catch
-         sqrt(complex(x, 0))
+           sqrt(complex(x, 0))
        end
 f (generic function with 1 method)
 
@@ -738,13 +738,13 @@ is indexable, otherwise assumes `x` is a real number and returns its square root
 
 ```julia
 julia> sqrt_second(x) = try
-         sqrt(x[2])
+           sqrt(x[2])
        catch y
-         if isa(y, DomainError)
-           sqrt(complex(x[2], 0))
-         elseif isa(y, BoundsError)
-           sqrt(x)
-         end
+           if isa(y, DomainError)
+               sqrt(complex(x[2], 0))
+           elseif isa(y, BoundsError)
+               sqrt(x)
+           end
        end
 sqrt_second (generic function with 1 method)
 
@@ -851,11 +851,11 @@ We can then [`take!()`](@ref) values repeatedly from the channel object:
 
 ```jldoctest
 julia> function producer(c::Channel)
-         put!(c, "start")
-         for n=1:4
-           put!(c, 2n)
-         end
-         put!(c, "stop")
+           put!(c, "start")
+           for n=1:4
+               put!(c, 2n)
+           end
+           put!(c, "stop")
        end;
 
 julia> chnl = Channel(producer);
@@ -887,7 +887,7 @@ loop variable takes on all the produced values. The loop is terminated when the 
 
 ```jldoctest
 julia> for x in Channel(producer)
-         println(x)
+           println(x)
        end
 start
 2

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -842,7 +842,7 @@ and consumer can both run as long as they need to, passing values back and forth
 
 Julia provides a [`Channel`](@ref) mechanism for solving this problem.
 A [`Channel`](@ref) is a waitable first-in first-out queue which can have
-multiple tasks reading and writing to it.
+multiple tasks reading from and writing to it.
 
 Let's define a producer task, which produces values via the [`put!`](@ref) call.
 To consume values, we need to schedule the producer to run in a new task. A special [`Channel`](@ref)

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -841,7 +841,8 @@ may have more values to generate and so might not yet be ready to return. With t
 and consumer can both run as long as they need to, passing values back and forth as necessary.
 
 Julia provides a [`Channel`](@ref) mechanism for solving this problem.
-A [`Channel`](@ref) is a waitable FIFO queue which can have multiple tasks reading and writing to it.
+A [`Channel`](@ref) is a waitable first-in first-out queue which can have
+multiple tasks reading and writing to it.
 
 Let's define a producer task, which produces values via the [`put!`](@ref) call.
 To consume values, we need to schedule the producer to run in a new task. A special [`Channel`](@ref)

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -104,17 +104,13 @@ The `BigFloat` type implements arbitrary-precision floating-point arithmetic usi
 Base.precision
 Base.MPFR.precision(::Type{BigFloat})
 Base.MPFR.setprecision
-```
-
-### Additional constructors for `BigFloat`
-```@docs
 Base.MPFR.BigFloat(x, prec::Int)
 BigFloat(x::Union{Integer, AbstractFloat, String}, rounding::RoundingMode)
 Base.MPFR.BigFloat(x, prec::Int, rounding::RoundingMode)
 Base.MPFR.BigFloat(x::String)
 ```
-## Random Numbers
 
+## Random Numbers
 
 Random number generation in Julia uses the [Mersenne Twister library](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/#dSFMT)
 via `MersenneTwister` objects. Julia has a global RNG, which is used by default. Other RNG types

--- a/doc/src/stdlib/test.md
+++ b/doc/src/stdlib/test.md
@@ -169,6 +169,17 @@ As calculations on floating-point values can be imprecise, you can perform appro
 checks using either `@test a ≈ b` (where `≈`, typed via tab completion of `\approx`, is the
 [`isapprox()`](@ref) function) or use [`isapprox()`](@ref) directly.
 
+```julia
+julia> @test 1 ≈ 0.999999999
+
+julia> @test 1 ≈ 0.999999
+ERROR: test failed: 1 isapprox 0.999999
+ in expression: 1 ≈ 0.999999
+ in error at error.jl:21
+ in default_handler at test.jl:30
+ in do_test at test.jl:53
+```
+
 ```@docs
 Base.Test.@inferred
 Base.Test.@test_warn

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -962,11 +962,11 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
         bool toplevel = li->def == NULL;
         if (!toplevel) {
             const DataLayout &DL =
-    #if JL_LLVM_VERSION >= 30500
+#if JL_LLVM_VERSION >= 30500
                 m->getDataLayout();
-    #else
+#else
                 *jl_data_layout;
-    #endif
+#endif
             // but don't remember toplevel thunks because
             // they may not be rooted in the gc for the life of the program,
             // and the runtime doesn't notify us when the code becomes unreachable :(
@@ -4467,11 +4467,11 @@ static std::unique_ptr<Module> emit_function(
         }
 
         topfile = dbuilder.createFile(filename, ".");
-        #if JL_LLVM_VERSION < 30400
+#if JL_LLVM_VERSION < 30400
         SP = dbuilder.createFunction((DIDescriptor)dbuilder.getCU(),
-        #else
+#else
         SP = dbuilder.createFunction(CU,
-        #endif
+#endif
                                     dbgFuncName,      // Name
                                     f->getName(),     // LinkageName
                                     topfile,          // File
@@ -4482,18 +4482,18 @@ static std::unique_ptr<Module> emit_function(
                                     0,                // ScopeLine
                                     DIFlagZero,       // Flags
                                     true,             // isOptimized
-        #if JL_LLVM_VERSION >= 30800
+#if JL_LLVM_VERSION >= 30800
                                     nullptr);         // Template Parameters
-        #else
+#else
                                     f);               // Function
-        #endif
+#endif
         topdebugloc = DebugLoc::get(toplineno, 0, SP, NULL);
-        #if JL_LLVM_VERSION >= 30800
+#if JL_LLVM_VERSION >= 30800
         f->setSubprogram(SP);
-        #endif
-        #if JL_LLVM_VERSION < 30700
+#endif
+#if JL_LLVM_VERSION < 30700
         assert(SP.Verify() && SP.describes(f) && SP.getFunction() == f);
-        #endif
+#endif
     }
     builder.SetCurrentDebugLocation(noDbg);
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -1396,7 +1396,7 @@ JL_DLLEXPORT void jl_gc_lookfor(jl_value_t *v) { lookforme = v; }
 */
 
 #define MAX_MARK_DEPTH 400
-// Scan an marked object `v` and recursively mark its children.
+// Scan a marked object `v` and recursively mark its children.
 // The object will be queued on the mark stack when recursion depth
 // becomes too high.
 // It does so assuming that the tag of the (marked) object is `tag`.

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -730,8 +730,7 @@ A = TSlowNIndexes(rand(2,2))
 @test @inferred(indices(rand(3,2), 3)) == 1:1
 
 #17088
-let
-    n = 10
+let n = 10
     M = rand(n, n)
     # vector of vectors
     v = [[M]; [M]] # using vcat

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -264,28 +264,27 @@ end
     @test size(Matrix()) == (0,0)
 end
 @testset "get" begin
-    let A = reshape(1:24, 3, 8)
-        x = get(A, 32, -12)
-        @test x == -12
-        x = get(A, 14, -12)
-        @test x == 14
-        x = get(A, (2,4), -12)
-        @test x == 11
-        x = get(A, (4,4), -12)
-        @test x == -12
-        X = get(A, -5:5, NaN32)
-        @test eltype(X) == Float32
-        @test Base.elsize(X) == sizeof(Float32)
-        @test !all(isinteger, X)
-        @test isnan.(X) == [trues(6);falses(5)]
-        @test X[7:11] == [1:5;]
-        X = get(A, (2:4, 9:-2:-13), 0)
-        Xv = zeros(Int, 3, 12)
-        Xv[1:2, 2:5] = A[2:3, 7:-2:1]
-        @test X == Xv
-        X2 = get(A, Vector{Int}[[2:4;], [9:-2:-13;]], 0)
-        @test X == X2
-    end
+    A = reshape(1:24, 3, 8)
+    x = get(A, 32, -12)
+    @test x == -12
+    x = get(A, 14, -12)
+    @test x == 14
+    x = get(A, (2,4), -12)
+    @test x == 11
+    x = get(A, (4,4), -12)
+    @test x == -12
+    X = get(A, -5:5, NaN32)
+    @test eltype(X) == Float32
+    @test Base.elsize(X) == sizeof(Float32)
+    @test !all(isinteger, X)
+    @test isnan.(X) == [trues(6);falses(5)]
+    @test X[7:11] == [1:5;]
+    X = get(A, (2:4, 9:-2:-13), 0)
+    Xv = zeros(Int, 3, 12)
+    Xv[1:2, 2:5] = A[2:3, 7:-2:1]
+    @test X == Xv
+    X2 = get(A, Vector{Int}[[2:4;], [9:-2:-13;]], 0)
+    @test X == X2
 end
 @testset "arrays as dequeues" begin
     l = Any[1]
@@ -345,12 +344,11 @@ end
 end
 
 @testset "typed hvcat" begin
-    let X = Float64[1 2 3; 4 5 6]
-        X32 = Float32[X X; X X]
-        @test eltype(X32) <: Float32
-        for i=[1,3], j=[1,4]
-            @test X32[i:(i+1), j:(j+2)] == X
-        end
+    X = Float64[1 2 3; 4 5 6]
+    X32 = Float32[X X; X X]
+    @test eltype(X32) <: Float32
+    for i=[1,3], j=[1,4]
+        @test X32[i:(i+1), j:(j+2)] == X
     end
 end
 @testset "end" begin
@@ -535,252 +533,250 @@ Base.hash(::HashCollision, h::UInt) = h
 end
 
 @testset "repmat and repeat" begin
-    let
-        local A, A1, A2, A3, v, v2, cv, cv2, c, R, T
-        A = ones(Int,2,3,4)
-        A1 = reshape(repmat([1,2],1,12),2,3,4)
-        A2 = reshape(repmat([1 2 3],2,4),2,3,4)
-        A3 = reshape(repmat([1 2 3 4],6,1),2,3,4)
-        @test isequal(cumsum(A),A1)
-        @test isequal(cumsum(A,1),A1)
-        @test isequal(cumsum(A,2),A2)
-        @test isequal(cumsum(A,3),A3)
+    local A, A1, A2, A3, v, v2, cv, cv2, c, R, T
+    A = ones(Int,2,3,4)
+    A1 = reshape(repmat([1,2],1,12),2,3,4)
+    A2 = reshape(repmat([1 2 3],2,4),2,3,4)
+    A3 = reshape(repmat([1 2 3 4],6,1),2,3,4)
+    @test isequal(cumsum(A),A1)
+    @test isequal(cumsum(A,1),A1)
+    @test isequal(cumsum(A,2),A2)
+    @test isequal(cumsum(A,3),A3)
 
-        R = repeat([1, 2])
-        @test R == [1, 2]
-        R = repeat([1, 2], inner=1)
-        @test R == [1, 2]
-        R = repeat([1, 2], outer=1)
-        @test R == [1, 2]
-        R = repeat([1, 2], inner=(1,))
-        @test R == [1, 2]
-        R = repeat([1, 2], outer=(1,))
-        @test R == [1, 2]
-        R = repeat([1, 2], inner=[1])
-        @test R == [1, 2]
-        R = repeat([1, 2], outer=[1])
-        @test R == [1, 2]
-        R = repeat([1, 2], inner=1, outer=1)
-        @test R == [1, 2]
-        R = repeat([1, 2], inner=(1,), outer=(1,))
-        @test R == [1, 2]
-        R = repeat([1, 2], inner=[1], outer=[1])
-        @test R == [1, 2]
+    R = repeat([1, 2])
+    @test R == [1, 2]
+    R = repeat([1, 2], inner=1)
+    @test R == [1, 2]
+    R = repeat([1, 2], outer=1)
+    @test R == [1, 2]
+    R = repeat([1, 2], inner=(1,))
+    @test R == [1, 2]
+    R = repeat([1, 2], outer=(1,))
+    @test R == [1, 2]
+    R = repeat([1, 2], inner=[1])
+    @test R == [1, 2]
+    R = repeat([1, 2], outer=[1])
+    @test R == [1, 2]
+    R = repeat([1, 2], inner=1, outer=1)
+    @test R == [1, 2]
+    R = repeat([1, 2], inner=(1,), outer=(1,))
+    @test R == [1, 2]
+    R = repeat([1, 2], inner=[1], outer=[1])
+    @test R == [1, 2]
 
-        R = repeat([1, 2], inner=2)
-        @test R == [1, 1, 2, 2]
-        R = repeat([1, 2], outer=2)
-        @test R == [1, 2, 1, 2]
-        R = repeat([1, 2], inner=(2,))
-        @test R == [1, 1, 2, 2]
-        R = repeat([1, 2], outer=(2,))
-        @test R == [1, 2, 1, 2]
-        R = repeat([1, 2], inner=[2])
-        @test R == [1, 1, 2, 2]
-        R = repeat([1, 2], outer=[2])
-        @test R == [1, 2, 1, 2]
+    R = repeat([1, 2], inner=2)
+    @test R == [1, 1, 2, 2]
+    R = repeat([1, 2], outer=2)
+    @test R == [1, 2, 1, 2]
+    R = repeat([1, 2], inner=(2,))
+    @test R == [1, 1, 2, 2]
+    R = repeat([1, 2], outer=(2,))
+    @test R == [1, 2, 1, 2]
+    R = repeat([1, 2], inner=[2])
+    @test R == [1, 1, 2, 2]
+    R = repeat([1, 2], outer=[2])
+    @test R == [1, 2, 1, 2]
 
-        R = repeat([1, 2], inner=2, outer=2)
-        @test R == [1, 1, 2, 2, 1, 1, 2, 2]
-        R = repeat([1, 2], inner=(2,), outer=(2,))
-        @test R == [1, 1, 2, 2, 1, 1, 2, 2]
-        R = repeat([1, 2], inner=[2], outer=[2])
-        @test R == [1, 1, 2, 2, 1, 1, 2, 2]
+    R = repeat([1, 2], inner=2, outer=2)
+    @test R == [1, 1, 2, 2, 1, 1, 2, 2]
+    R = repeat([1, 2], inner=(2,), outer=(2,))
+    @test R == [1, 1, 2, 2, 1, 1, 2, 2]
+    R = repeat([1, 2], inner=[2], outer=[2])
+    @test R == [1, 1, 2, 2, 1, 1, 2, 2]
 
-        R = repeat([1, 2], inner = (1, 1), outer = (1, 1))
-        @test R == reshape([1, 2], (2,1))
-        R = repeat([1, 2], inner = (2, 1), outer = (1, 1))
-        @test R == reshape([1, 1, 2, 2], (4,1))
-        R = repeat([1, 2], inner = (1, 2), outer = (1, 1))
-        @test R == [1 1; 2 2]
-        R = repeat([1, 2], inner = (1, 1), outer = (2, 1))
-        @test R == reshape([1, 2, 1, 2], (4,1))
-        R = repeat([1, 2], inner = (1, 1), outer = (1, 2))
-        @test R == [1 1; 2 2]
+    R = repeat([1, 2], inner = (1, 1), outer = (1, 1))
+    @test R == reshape([1, 2], (2,1))
+    R = repeat([1, 2], inner = (2, 1), outer = (1, 1))
+    @test R == reshape([1, 1, 2, 2], (4,1))
+    R = repeat([1, 2], inner = (1, 2), outer = (1, 1))
+    @test R == [1 1; 2 2]
+    R = repeat([1, 2], inner = (1, 1), outer = (2, 1))
+    @test R == reshape([1, 2, 1, 2], (4,1))
+    R = repeat([1, 2], inner = (1, 1), outer = (1, 2))
+    @test R == [1 1; 2 2]
 
-        R = repeat([1 2;
-                    3 4], inner = (1, 1), outer = (1, 1))
-        @test R == [1 2;
-                      3 4]
-        R = repeat([1 2;
-                    3 4], inner = (1, 1), outer = (2, 1))
-        @test R == [1 2;
-                      3 4;
-                      1 2;
-                      3 4]
-        R = repeat([1 2;
-                    3 4], inner = (1, 1), outer = (1, 2))
-        @test R == [1 2 1 2;
-                      3 4 3 4]
-        R = repeat([1 2;
-                    3 4], inner = (1, 1), outer = (2, 2))
-        @test R == [1 2 1 2;
-                      3 4 3 4;
-                      1 2 1 2;
-                      3 4 3 4]
-        R = repeat([1 2;
-                    3 4], inner = (2, 1), outer = (1, 1))
-        @test R == [1 2;
-                      1 2;
-                      3 4;
-                      3 4]
-        R = repeat([1 2;
-                    3 4], inner = (2, 1), outer = (2, 1))
-        @test R == [1 2;
-                      1 2;
-                      3 4;
-                      3 4;
-                      1 2;
-                      1 2;
-                      3 4;
-                      3 4]
-        R = repeat([1 2;
-                    3 4], inner = (2, 1), outer = (1, 2))
-        @test R == [1 2 1 2;
-                      1 2 1 2;
-                      3 4 3 4;
-                      3 4 3 4;]
-        R = repeat([1 2;
-                    3 4], inner = (2, 1), outer = (2, 2))
-        @test R == [1 2 1 2;
-                      1 2 1 2;
-                      3 4 3 4;
-                      3 4 3 4;
-                      1 2 1 2;
-                      1 2 1 2;
-                      3 4 3 4;
-                      3 4 3 4]
-        R = repeat([1 2;
-                    3 4], inner = (1, 2), outer = (1, 1))
-        @test R == [1 1 2 2;
-                      3 3 4 4]
-        R = repeat([1 2;
-                    3 4], inner = (1, 2), outer = (2, 1))
-        @test R == [1 1 2 2;
-                      3 3 4 4;
-                      1 1 2 2;
-                      3 3 4 4]
-        R = repeat([1 2;
-                    3 4], inner = (1, 2), outer = (1, 2))
-        @test R == [1 1 2 2 1 1 2 2;
-                      3 3 4 4 3 3 4 4]
-        R = repeat([1 2;
-                    3 4], inner = (1, 2), outer = (2, 2))
-        @test R == [1 1 2 2 1 1 2 2;
-                      3 3 4 4 3 3 4 4;
-                      1 1 2 2 1 1 2 2;
-                      3 3 4 4 3 3 4 4]
-        R = repeat([1 2;
-                    3 4], inner = (2, 2), outer = [1, 1])
-        @test R == [1 1 2 2;
-                      1 1 2 2;
-                      3 3 4 4;
-                      3 3 4 4]
-        R = repeat([1 2;
-                    3 4], inner = (2, 2), outer = (2, 1))
-        @test R == [1 1 2 2;
-                      1 1 2 2;
-                      3 3 4 4;
-                      3 3 4 4;
-                      1 1 2 2;
-                      1 1 2 2;
-                      3 3 4 4;
-                      3 3 4 4]
-        R = repeat([1 2;
-                    3 4], inner = (2, 2), outer = (1, 2))
-        @test R == [1 1 2 2 1 1 2 2;
-                      1 1 2 2 1 1 2 2;
-                      3 3 4 4 3 3 4 4;
-                      3 3 4 4 3 3 4 4]
-        R = repeat([1 2;
-                    3 4], inner = (2, 2), outer = (2, 2))
-        @test R == [1 1 2 2 1 1 2 2;
-                      1 1 2 2 1 1 2 2;
-                      3 3 4 4 3 3 4 4;
-                      3 3 4 4 3 3 4 4;
-                      1 1 2 2 1 1 2 2;
-                      1 1 2 2 1 1 2 2;
-                      3 3 4 4 3 3 4 4;
-                      3 3 4 4 3 3 4 4]
-        @test_throws ArgumentError repeat([1 2;
-                                           3 4], inner=2, outer=(2, 2))
-        @test_throws ArgumentError repeat([1 2;
-                                           3 4], inner=(2, 2), outer=2)
-        @test_throws ArgumentError repeat([1 2;
-                                           3 4], inner=(2,), outer=(2, 2))
-        @test_throws ArgumentError repeat([1 2;
-                                           3 4], inner=(2, 2), outer=(2,))
+    R = repeat([1 2;
+                3 4], inner = (1, 1), outer = (1, 1))
+    @test R == [1 2;
+                    3 4]
+    R = repeat([1 2;
+                3 4], inner = (1, 1), outer = (2, 1))
+    @test R == [1 2;
+                    3 4;
+                    1 2;
+                    3 4]
+    R = repeat([1 2;
+                3 4], inner = (1, 1), outer = (1, 2))
+    @test R == [1 2 1 2;
+                    3 4 3 4]
+    R = repeat([1 2;
+                3 4], inner = (1, 1), outer = (2, 2))
+    @test R == [1 2 1 2;
+                    3 4 3 4;
+                    1 2 1 2;
+                    3 4 3 4]
+    R = repeat([1 2;
+                3 4], inner = (2, 1), outer = (1, 1))
+    @test R == [1 2;
+                    1 2;
+                    3 4;
+                    3 4]
+    R = repeat([1 2;
+                3 4], inner = (2, 1), outer = (2, 1))
+    @test R == [1 2;
+                    1 2;
+                    3 4;
+                    3 4;
+                    1 2;
+                    1 2;
+                    3 4;
+                    3 4]
+    R = repeat([1 2;
+                3 4], inner = (2, 1), outer = (1, 2))
+    @test R == [1 2 1 2;
+                    1 2 1 2;
+                    3 4 3 4;
+                    3 4 3 4;]
+    R = repeat([1 2;
+                3 4], inner = (2, 1), outer = (2, 2))
+    @test R == [1 2 1 2;
+                    1 2 1 2;
+                    3 4 3 4;
+                    3 4 3 4;
+                    1 2 1 2;
+                    1 2 1 2;
+                    3 4 3 4;
+                    3 4 3 4]
+    R = repeat([1 2;
+                3 4], inner = (1, 2), outer = (1, 1))
+    @test R == [1 1 2 2;
+                    3 3 4 4]
+    R = repeat([1 2;
+                3 4], inner = (1, 2), outer = (2, 1))
+    @test R == [1 1 2 2;
+                    3 3 4 4;
+                    1 1 2 2;
+                    3 3 4 4]
+    R = repeat([1 2;
+                3 4], inner = (1, 2), outer = (1, 2))
+    @test R == [1 1 2 2 1 1 2 2;
+                    3 3 4 4 3 3 4 4]
+    R = repeat([1 2;
+                3 4], inner = (1, 2), outer = (2, 2))
+    @test R == [1 1 2 2 1 1 2 2;
+                    3 3 4 4 3 3 4 4;
+                    1 1 2 2 1 1 2 2;
+                    3 3 4 4 3 3 4 4]
+    R = repeat([1 2;
+                3 4], inner = (2, 2), outer = [1, 1])
+    @test R == [1 1 2 2;
+                    1 1 2 2;
+                    3 3 4 4;
+                    3 3 4 4]
+    R = repeat([1 2;
+                3 4], inner = (2, 2), outer = (2, 1))
+    @test R == [1 1 2 2;
+                    1 1 2 2;
+                    3 3 4 4;
+                    3 3 4 4;
+                    1 1 2 2;
+                    1 1 2 2;
+                    3 3 4 4;
+                    3 3 4 4]
+    R = repeat([1 2;
+                3 4], inner = (2, 2), outer = (1, 2))
+    @test R == [1 1 2 2 1 1 2 2;
+                    1 1 2 2 1 1 2 2;
+                    3 3 4 4 3 3 4 4;
+                    3 3 4 4 3 3 4 4]
+    R = repeat([1 2;
+                3 4], inner = (2, 2), outer = (2, 2))
+    @test R == [1 1 2 2 1 1 2 2;
+                    1 1 2 2 1 1 2 2;
+                    3 3 4 4 3 3 4 4;
+                    3 3 4 4 3 3 4 4;
+                    1 1 2 2 1 1 2 2;
+                    1 1 2 2 1 1 2 2;
+                    3 3 4 4 3 3 4 4;
+                    3 3 4 4 3 3 4 4]
+    @test_throws ArgumentError repeat([1 2;
+                                        3 4], inner=2, outer=(2, 2))
+    @test_throws ArgumentError repeat([1 2;
+                                        3 4], inner=(2, 2), outer=2)
+    @test_throws ArgumentError repeat([1 2;
+                                        3 4], inner=(2,), outer=(2, 2))
+    @test_throws ArgumentError repeat([1 2;
+                                        3 4], inner=(2, 2), outer=(2,))
 
-        A = reshape(1:8, 2, 2, 2)
-        R = repeat(A, inner = (1, 1, 2), outer = (1, 1, 1))
-        T = reshape([1:4; 1:4; 5:8; 5:8], 2, 2, 4)
-        @test R == T
-        A = Array{Int}(2, 2, 2)
-        A[:, :, 1] = [1 2;
-                      3 4]
-        A[:, :, 2] = [5 6;
-                      7 8]
-        R = repeat(A, inner = (2, 2, 2), outer = (2, 2, 2))
-        @test R[1, 1, 1] == 1
-        @test R[2, 2, 2] == 1
-        @test R[3, 3, 3] == 8
-        @test R[4, 4, 4] == 8
-        @test R[5, 5, 5] == 1
-        @test R[6, 6, 6] == 1
-        @test R[7, 7, 7] == 8
-        @test R[8, 8, 8] == 8
+    A = reshape(1:8, 2, 2, 2)
+    R = repeat(A, inner = (1, 1, 2), outer = (1, 1, 1))
+    T = reshape([1:4; 1:4; 5:8; 5:8], 2, 2, 4)
+    @test R == T
+    A = Array{Int}(2, 2, 2)
+    A[:, :, 1] = [1 2;
+                    3 4]
+    A[:, :, 2] = [5 6;
+                    7 8]
+    R = repeat(A, inner = (2, 2, 2), outer = (2, 2, 2))
+    @test R[1, 1, 1] == 1
+    @test R[2, 2, 2] == 1
+    @test R[3, 3, 3] == 8
+    @test R[4, 4, 4] == 8
+    @test R[5, 5, 5] == 1
+    @test R[6, 6, 6] == 1
+    @test R[7, 7, 7] == 8
+    @test R[8, 8, 8] == 8
 
-        R = repeat(1:2)
-        @test R == [1, 2]
-        R = repeat(1:2, inner=1)
-        @test R == [1, 2]
-        R = repeat(1:2, inner=2)
-        @test R == [1, 1, 2, 2]
-        R = repeat(1:2, outer=1)
-        @test R == [1, 2]
-        R = repeat(1:2, outer=2)
-        @test R == [1, 2, 1, 2]
-        R = repeat(1:2, inner=(3,), outer=(2,))
-        @test R == [1, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2]
+    R = repeat(1:2)
+    @test R == [1, 2]
+    R = repeat(1:2, inner=1)
+    @test R == [1, 2]
+    R = repeat(1:2, inner=2)
+    @test R == [1, 1, 2, 2]
+    R = repeat(1:2, outer=1)
+    @test R == [1, 2]
+    R = repeat(1:2, outer=2)
+    @test R == [1, 2, 1, 2]
+    R = repeat(1:2, inner=(3,), outer=(2,))
+    @test R == [1, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2]
 
-        A = rand(4,4)
-        for s in Any[A[1:2:4, 1:2:4], view(A, 1:2:4, 1:2:4)]
-            c = cumsum(s, 1)
-            @test c[1,1] == A[1,1]
-            @test c[2,1] == A[1,1]+A[3,1]
-            @test c[1,2] == A[1,3]
-            @test c[2,2] == A[1,3]+A[3,3]
+    A = rand(4,4)
+    for s in Any[A[1:2:4, 1:2:4], view(A, 1:2:4, 1:2:4)]
+        c = cumsum(s, 1)
+        @test c[1,1] == A[1,1]
+        @test c[2,1] == A[1,1]+A[3,1]
+        @test c[1,2] == A[1,3]
+        @test c[2,2] == A[1,3]+A[3,3]
 
-            c = cumsum(s, 2)
-            @test c[1,1] == A[1,1]
-            @test c[2,1] == A[3,1]
-            @test c[1,2] == A[1,1]+A[1,3]
-            @test c[2,2] == A[3,1]+A[3,3]
-        end
-
-        v   = [1,1e100,1,-1e100]*1000
-        v2  = [1,-1e100,1,1e100]*1000
-
-        cv  = [1,1e100,1e100,2]*1000
-        cv2 = [1,-1e100,-1e100,2]*1000
-
-        @test isequal(cumsum_kbn(v), cv)
-        @test isequal(cumsum_kbn(v2), cv2)
-
-        A = [v reverse(v) v2 reverse(v2)]
-
-        c = cumsum_kbn(A, 1)
-
-        @test isequal(c[:,1], cv)
-        @test isequal(c[:,3], cv2)
-        @test isequal(c[4,:], [2.0, 2.0, 2.0, 2.0]*1000)
-
-        c = cumsum_kbn(A, 2)
-
-        @test isequal(c[1,:], cv2)
-        @test isequal(c[3,:], cv)
-        @test isequal(c[:,4], [2.0,2.0,2.0,2.0]*1000)
+        c = cumsum(s, 2)
+        @test c[1,1] == A[1,1]
+        @test c[2,1] == A[3,1]
+        @test c[1,2] == A[1,1]+A[1,3]
+        @test c[2,2] == A[3,1]+A[3,3]
     end
+
+    v   = [1,1e100,1,-1e100]*1000
+    v2  = [1,-1e100,1,1e100]*1000
+
+    cv  = [1,1e100,1e100,2]*1000
+    cv2 = [1,-1e100,-1e100,2]*1000
+
+    @test isequal(cumsum_kbn(v), cv)
+    @test isequal(cumsum_kbn(v2), cv2)
+
+    A = [v reverse(v) v2 reverse(v2)]
+
+    c = cumsum_kbn(A, 1)
+
+    @test isequal(c[:,1], cv)
+    @test isequal(c[:,3], cv2)
+    @test isequal(c[4,:], [2.0, 2.0, 2.0, 2.0]*1000)
+
+    c = cumsum_kbn(A, 2)
+
+    @test isequal(c[1,:], cv2)
+    @test isequal(c[3,:], cv)
+    @test isequal(c[:,4], [2.0,2.0,2.0,2.0]*1000)
 end
 
 @testset "indexing with bools" begin
@@ -851,68 +847,65 @@ end
 end
 
 @testset "mapslices" begin
-    let
-        local a,h,i
-        a = rand(5,5)
-        s = mapslices(sort, a, [1])
-        S = mapslices(sort, a, [2])
-        for i = 1:5
-            @test s[:,i] == sort(a[:,i])
-            @test vec(S[i,:]) == sort(vec(a[i,:]))
-        end
-
-        # issue #3613
-        b = mapslices(sum, ones(2,3,4), [1,2])
-        @test size(b) === (1,1,4)
-        @test all(b.==6)
-
-        # issue #5141
-        ## Update Removed the version that removes the dimensions when dims==1:ndims(A)
-        c1 = mapslices(x-> maximum(-x), a, [])
-        @test c1 == -a
-
-        # other types than Number
-        @test mapslices(prod,["1" "2"; "3" "4"],1) == ["13" "24"]
-        @test mapslices(prod,["1"],1) == ["1"]
-
-        # issue #5177
-
-        c = ones(2,3,4)
-        m1 = mapslices(x-> ones(2,3), c, [1,2])
-        m2 = mapslices(x-> ones(2,4), c, [1,3])
-        m3 = mapslices(x-> ones(3,4), c, [2,3])
-        @test size(m1) == size(m2) == size(m3) == size(c)
-
-        n1 = mapslices(x-> ones(6), c, [1,2])
-        n2 = mapslices(x-> ones(6), c, [1,3])
-        n3 = mapslices(x-> ones(6), c, [2,3])
-        n1a = mapslices(x-> ones(1,6), c, [1,2])
-        n2a = mapslices(x-> ones(1,6), c, [1,3])
-        n3a = mapslices(x-> ones(1,6), c, [2,3])
-        @test size(n1a) == (1,6,4) && size(n2a) == (1,3,6)  && size(n3a) == (2,1,6)
-        @test size(n1) == (6,1,4) && size(n2) == (6,3,1)  && size(n3) == (2,6,1)
-
-        # mutating functions
-        o = ones(3, 4)
-        m = mapslices(x->fill!(x, 0), o, 2)
-        @test m == zeros(3, 4)
-        @test o == ones(3, 4)
+    local a,h,i
+    a = rand(5,5)
+    s = mapslices(sort, a, [1])
+    S = mapslices(sort, a, [2])
+    for i = 1:5
+        @test s[:,i] == sort(a[:,i])
+        @test vec(S[i,:]) == sort(vec(a[i,:]))
     end
+
+    # issue #3613
+    b = mapslices(sum, ones(2,3,4), [1,2])
+    @test size(b) === (1,1,4)
+    @test all(b.==6)
+
+    # issue #5141
+    ## Update Removed the version that removes the dimensions when dims==1:ndims(A)
+    c1 = mapslices(x-> maximum(-x), a, [])
+    @test c1 == -a
+
+    # other types than Number
+    @test mapslices(prod,["1" "2"; "3" "4"],1) == ["13" "24"]
+    @test mapslices(prod,["1"],1) == ["1"]
+
+    # issue #5177
+
+    c = ones(2,3,4)
+    m1 = mapslices(x-> ones(2,3), c, [1,2])
+    m2 = mapslices(x-> ones(2,4), c, [1,3])
+    m3 = mapslices(x-> ones(3,4), c, [2,3])
+    @test size(m1) == size(m2) == size(m3) == size(c)
+
+    n1 = mapslices(x-> ones(6), c, [1,2])
+    n2 = mapslices(x-> ones(6), c, [1,3])
+    n3 = mapslices(x-> ones(6), c, [2,3])
+    n1a = mapslices(x-> ones(1,6), c, [1,2])
+    n2a = mapslices(x-> ones(1,6), c, [1,3])
+    n3a = mapslices(x-> ones(1,6), c, [2,3])
+    @test size(n1a) == (1,6,4) && size(n2a) == (1,3,6)  && size(n3a) == (2,1,6)
+    @test size(n1) == (6,1,4) && size(n2) == (6,3,1)  && size(n3) == (2,6,1)
+
+    # mutating functions
+    o = ones(3, 4)
+    m = mapslices(x->fill!(x, 0), o, 2)
+    @test m == zeros(3, 4)
+    @test o == ones(3, 4)
 end
 
 @testset "single multidimensional index" begin
-    let a = rand(6,6)
-        I = [1 4 5; 4 2 6; 5 6 3]
-        a2 = a[I]
-        @test size(a2) == size(I)
-        for i = 1:length(a2)
-            @test a2[i] == a[I[i]]
-        end
-        a = [1,3,5]
-        b = [1 3]
-        a[b] = 8
-        @test a == [8,3,8]
+    a = rand(6,6)
+    I = [1 4 5; 4 2 6; 5 6 3]
+    a2 = a[I]
+    @test size(a2) == size(I)
+    for i = 1:length(a2)
+        @test a2[i] == a[I[i]]
     end
+    a = [1,3,5]
+    b = [1 3]
+    a[b] = 8
+    @test a == [8,3,8]
 end
 
 @testset "assigning an array into itself" begin
@@ -938,63 +931,61 @@ end
 end
 
 @testset "sort on arrays" begin
-    let
-        local a = rand(3,3)
+    local a = rand(3,3)
 
-        asr = sortrows(a)
-        @test lexless(asr[1,:],asr[2,:])
-        @test lexless(asr[2,:],asr[3,:])
+    asr = sortrows(a)
+    @test lexless(asr[1,:],asr[2,:])
+    @test lexless(asr[2,:],asr[3,:])
 
-        asc = sortcols(a)
-        @test lexless(asc[:,1],asc[:,2])
-        @test lexless(asc[:,2],asc[:,3])
+    asc = sortcols(a)
+    @test lexless(asc[:,1],asc[:,2])
+    @test lexless(asc[:,2],asc[:,3])
 
-        # mutating functions
-        o = ones(3, 4)
-        m = mapslices(x->fill!(x, 0), o, 2)
-        @test m == zeros(3, 4)
-        @test o == ones(3, 4)
+    # mutating functions
+    o = ones(3, 4)
+    m = mapslices(x->fill!(x, 0), o, 2)
+    @test m == zeros(3, 4)
+    @test o == ones(3, 4)
 
-        # issue #18524
-        m = mapslices(x->tuple(x), [1 2; 3 4], 1)
-        @test m[1,1] == ([1,3],)
-        @test m[1,2] == ([2,4],)
+    # issue #18524
+    m = mapslices(x->tuple(x), [1 2; 3 4], 1)
+    @test m[1,1] == ([1,3],)
+    @test m[1,2] == ([2,4],)
 
-        asr = sortrows(a, rev=true)
-        @test lexless(asr[2,:],asr[1,:])
-        @test lexless(asr[3,:],asr[2,:])
+    asr = sortrows(a, rev=true)
+    @test lexless(asr[2,:],asr[1,:])
+    @test lexless(asr[3,:],asr[2,:])
 
-        asc = sortcols(a, rev=true)
-        @test lexless(asc[:,2],asc[:,1])
-        @test lexless(asc[:,3],asc[:,2])
+    asc = sortcols(a, rev=true)
+    @test lexless(asc[:,2],asc[:,1])
+    @test lexless(asc[:,3],asc[:,2])
 
-        as = sort(a, 1)
-        @test issorted(as[:,1])
-        @test issorted(as[:,2])
-        @test issorted(as[:,3])
+    as = sort(a, 1)
+    @test issorted(as[:,1])
+    @test issorted(as[:,2])
+    @test issorted(as[:,3])
 
-        as = sort(a, 2)
-        @test issorted(as[1,:])
-        @test issorted(as[2,:])
-        @test issorted(as[3,:])
+    as = sort(a, 2)
+    @test issorted(as[1,:])
+    @test issorted(as[2,:])
+    @test issorted(as[3,:])
 
-        local b = rand(21,21,2)
+    local b = rand(21,21,2)
 
-        bs = sort(b, 1)
-        for i in 1:21
-            @test issorted(bs[:,i,1])
-            @test issorted(bs[:,i,2])
-        end
-
-        bs = sort(b, 2)
-        for i in 1:21
-            @test issorted(bs[i,:,1])
-            @test issorted(bs[i,:,2])
-        end
-
-        bs = sort(b, 3)
-        @test all(bs[:,:,1] .<= bs[:,:,2])
+    bs = sort(b, 1)
+    for i in 1:21
+        @test issorted(bs[:,i,1])
+        @test issorted(bs[:,i,2])
     end
+
+    bs = sort(b, 2)
+    for i in 1:21
+        @test issorted(bs[i,:,1])
+        @test issorted(bs[i,:,2])
+    end
+
+    bs = sort(b, 3)
+    @test all(bs[:,:,1] .<= bs[:,:,2])
 end
 
 @testset "fill" begin
@@ -1805,26 +1796,28 @@ end
 end
 
 @testset "sign, conj, ~" begin
-    let A = [-10,0,3], B = [-10.0,0.0,3.0], C = [1,im,0]
-        @test sign(A) == [-1,0,1]
-        @test sign(B) == [-1,0,1]
-        @test typeof(sign(A)) == Vector{Int}
-        @test typeof(sign(B)) == Vector{Float64}
+    A = [-10,0,3]
+    B = [-10.0,0.0,3.0]
+    C = [1,im,0]
 
-        @test conj(A) == A
-        @test conj(B) == A
-        @test conj(C) == [1,-im,0]
-        @test typeof(conj(A)) == Vector{Int}
-        @test typeof(conj(B)) == Vector{Float64}
-        @test typeof(conj(C)) == Vector{Complex{Int}}
+    @test sign(A) == [-1,0,1]
+    @test sign(B) == [-1,0,1]
+    @test typeof(sign(A)) == Vector{Int}
+    @test typeof(sign(B)) == Vector{Float64}
 
-        @test ~A == [9,-1,-4]
-        @test typeof(~A) == Vector{Int}
-    end
+    @test conj(A) == A
+    @test conj(B) == A
+    @test conj(C) == [1,-im,0]
+    @test typeof(conj(A)) == Vector{Int}
+    @test typeof(conj(B)) == Vector{Float64}
+    @test typeof(conj(C)) == Vector{Complex{Int}}
+
+    @test ~A == [9,-1,-4]
+    @test typeof(~A) == Vector{Int}
 end
 
-# issue #16247
-let A = zeros(3,3)
+@testset "issue #16247" begin
+    A = zeros(3,3)
     @test size(A[:,0x1:0x2]) == (3, 2)
     @test size(A[:,UInt(1):UInt(2)]) == (3,2)
     @test size(similar(A, UInt(3), 0x3)) == size(similar(A, (UInt(3), 0x3))) == (3,3)
@@ -1850,47 +1843,45 @@ end
 end # module AutoRetType
 
 @testset "concatenations of dense matrices/vectors yield dense matrices/vectors" begin
-    let N = 4
-        densevec = ones(N)
-        densemat = diagm(ones(N))
-        # Test that concatenations of homogeneous pairs of either dense matrices or dense vectors
-        # (i.e., Matrix-Matrix concatenations, and Vector-Vector concatenations) yield dense arrays
-        for densearray in (densevec, densemat)
-            @test isa(vcat(densearray, densearray), Array)
-            @test isa(hcat(densearray, densearray), Array)
-            @test isa(hvcat((2,), densearray, densearray), Array)
-            @test isa(cat((1,2), densearray, densearray), Array)
-        end
-        # Test that concatenations of heterogeneous Matrix-Vector pairs yield dense matrices
-        @test isa(hcat(densemat, densevec), Array)
-        @test isa(hcat(densevec, densemat), Array)
-        @test isa(hvcat((2,), densemat, densevec), Array)
-        @test isa(hvcat((2,), densevec, densemat), Array)
-        @test isa(cat((1,2), densemat, densevec), Array)
-        @test isa(cat((1,2), densevec, densemat), Array)
+    N = 4
+    densevec = ones(N)
+    densemat = diagm(ones(N))
+    # Test that concatenations of homogeneous pairs of either dense matrices or dense vectors
+    # (i.e., Matrix-Matrix concatenations, and Vector-Vector concatenations) yield dense arrays
+    for densearray in (densevec, densemat)
+        @test isa(vcat(densearray, densearray), Array)
+        @test isa(hcat(densearray, densearray), Array)
+        @test isa(hvcat((2,), densearray, densearray), Array)
+        @test isa(cat((1,2), densearray, densearray), Array)
     end
+    # Test that concatenations of heterogeneous Matrix-Vector pairs yield dense matrices
+    @test isa(hcat(densemat, densevec), Array)
+    @test isa(hcat(densevec, densemat), Array)
+    @test isa(hvcat((2,), densemat, densevec), Array)
+    @test isa(hvcat((2,), densevec, densemat), Array)
+    @test isa(cat((1,2), densemat, densevec), Array)
+    @test isa(cat((1,2), densevec, densemat), Array)
 end
 
 @testset "type constructor Array{T, N}(d...) works (especially for N>3)" begin
-    let a = Array{Float64}(10)
-        b = Array{Float64, 1}(10)
-        @test size(a) == (10,)
-        @test size(a, 1) == 10
-        @test size(a,2,1) == (1,10)
-        @test size(a) == size(b)
-        a = Array{Float64}(2,3)
-        b = Array{Float64, 2}(2,3)
-        @test size(a) == (2,3)
-        @test size(a,4,3,2,1) == (1,1,3,2)
-        @test size(a,1,2) == (2,3)
-        @test size(a) == size(b)
-        a = Array{Float64}(9,8,7,6,5,4,3,2,1)
-        b = Array{Float64, 9}(9,8,7,6,5,4,3,2,1)
-        @test size(a,1,1) == (9,9)
-        @test size(a,4) == 6
-        @test size(a,9,8,7,6,5,4,3,2,19,8,7,6,5,4,3,2,1) == (1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,9)
-        @test size(a) == size(b)
-    end
+    a = Array{Float64}(10)
+    b = Array{Float64, 1}(10)
+    @test size(a) == (10,)
+    @test size(a, 1) == 10
+    @test size(a,2,1) == (1,10)
+    @test size(a) == size(b)
+    a = Array{Float64}(2,3)
+    b = Array{Float64, 2}(2,3)
+    @test size(a) == (2,3)
+    @test size(a,4,3,2,1) == (1,1,3,2)
+    @test size(a,1,2) == (2,3)
+    @test size(a) == size(b)
+    a = Array{Float64}(9,8,7,6,5,4,3,2,1)
+    b = Array{Float64, 9}(9,8,7,6,5,4,3,2,1)
+    @test size(a,1,1) == (9,9)
+    @test size(a,4) == 6
+    @test size(a,9,8,7,6,5,4,3,2,19,8,7,6,5,4,3,2,1) == (1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,9)
+    @test size(a) == size(b)
 end
 
 @testset "accumulate, accumulate!" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -405,7 +405,6 @@ end
     @test find(isascii, g) == Int[]
 end
 @testset "findn" begin
-
     b = findn(ones(2,2,2,2))
     @test (length(b[1]) == 16)
     @test (length(b[2]) == 16)
@@ -443,7 +442,6 @@ end
 end
 
 @testset "permutedims" begin
-
     # keeps the num of dim
     p = randperm(5)
     q = randperm(5)
@@ -1902,7 +1900,6 @@ end
 end
 
 @testset "accumulate, accumulate!" begin
-
     @test accumulate(+, [1,2,3]) == [1, 3, 6]
     @test accumulate(min, [1 2; 3 4], 1) == [1 2; 1 2]
     @test accumulate(max, [1 2; 3 0], 2) == [1 2; 3 3]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -264,8 +264,7 @@ end
     @test size(Matrix()) == (0,0)
 end
 @testset "get" begin
-    let
-        A = reshape(1:24, 3, 8)
+    let A = reshape(1:24, 3, 8)
         x = get(A, 32, -12)
         @test x == -12
         x = get(A, 14, -12)
@@ -902,8 +901,7 @@ end
 end
 
 @testset "single multidimensional index" begin
-    let
-        a = rand(6,6)
+    let a = rand(6,6)
         I = [1 4 5; 4 2 6; 5 6 3]
         a2 = a[I]
         @test size(a2) == size(I)
@@ -1184,8 +1182,7 @@ for N = 1:Nmax
 end
 
 # issue #6645 (32-bit)
-let
-    x = Float64[]
+let x = Float64[]
     for i=1:5; push!(x, 1.0); end
     @test dot(zeros(5),x) == 0.0
 end
@@ -1221,8 +1218,7 @@ end
 @test pr8622() == [0,3,1,0]
 
 #6828 - size of specific dimensions
-let
-    a = Array{Float64}(10)
+let a = Array{Float64}(10)
     @test size(a) == (10,)
     @test size(a, 1) == 10
     @test size(a,2,1) == (1,10)
@@ -1851,11 +1847,10 @@ for op in (:.+, :.*, :.÷, :.%, :.<<, :.>>, :.-, :./, :.\, :.//, :.^)
     @eval @test typeof($(op)(A,A)) == Matrix{Foo}
 end
 
-end
+end # module AutoRetType
 
 @testset "concatenations of dense matrices/vectors yield dense matrices/vectors" begin
-    let
-        N = 4
+    let N = 4
         densevec = ones(N)
         densemat = diagm(ones(N))
         # Test that concatenations of homogeneous pairs of either dense matrices or dense vectors
@@ -1877,8 +1872,7 @@ end
 end
 
 @testset "type constructor Array{T, N}(d...) works (especially for N>3)" begin
-    let
-        a = Array{Float64}(10)
+    let a = Array{Float64}(10)
         b = Array{Float64, 1}(10)
         @test size(a) == (10,)
         @test size(a, 1) == 10

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -257,8 +257,7 @@ s = string(n)
 @test startswith(s, "316047687386689")
 
 # serialization (#5133)
-let
-    n = parse(BigInt,"359334085968622831041960188598043661065388726959079837")
+let n = parse(BigInt,"359334085968622831041960188598043661065388726959079837")
     b = IOBuffer()
     serialize(b,n)
     seek(b,0)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -444,7 +444,7 @@ end
 
 # Test that broadcast treats type arguments as scalars, i.e. containertype yields Any,
 # even for subtypes of abstract array. (https://github.com/JuliaStats/DataArrays.jl/issues/229)
-let
+@testset "treat type arguments as scalars, DataArrays issue 229" begin
     @test Base.Broadcast.containertype(AbstractArray) == Any
     @test broadcast(==, [1], AbstractArray) == BitArray([false])
     @test broadcast(==, 1, AbstractArray) == false

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -207,8 +207,7 @@ end
     @test isequal(sqrt(complex( NaN,-Inf)), complex( Inf,-Inf))
 end
 
-@testset "log" begin
-    # log(conj(z)) = conj(log(z))
+@testset "log(conj(z)) == conj(log(z))" begin
     @test isequal(log(complex( 0.0, 0.0)), complex(-Inf, 0.0))
     @test isequal(log(complex( 0.0,-0.0)), complex(-Inf,-0.0))
     @test isequal(log(complex( 0.0, 1.0)), complex( 0.0, pi/2))
@@ -240,8 +239,7 @@ end
     @test isequal(log(complex( NaN, NaN)), complex( NaN, NaN))
 end
 
-@testset "exp" begin
-    # exp(conj(z)) = conj(exp(z))
+@testset "exp(conj(z)) == conj(exp(z))" begin
     @test isequal(exp(complex( 0.0, 0.0)), complex(1.0, 0.0))
     @test isequal(exp(complex( 0.0,-0.0)), complex(1.0,-0.0))
     @test isequal(exp(complex( 0.0, Inf)), complex(NaN, NaN))
@@ -275,8 +273,7 @@ end
     @test isequal(exp(complex( NaN, NaN)), complex( NaN, NaN))
 end
 
-@testset "expm1" begin
-    # expm1(conj(z)) = conj(expm1(z))
+@testset "expm1(conj(z)) == conj(expm1(z))" begin
     @test isequal(expm1(complex( 0.0, 0.0)), complex(0.0, 0.0))
     @test isequal(expm1(complex( 0.0,-0.0)), complex(0.0,-0.0))
     @test isequal(expm1(complex( 0.0, Inf)), complex(NaN, NaN))
@@ -392,7 +389,6 @@ end
 
     # @test isequal(sin(complex( 0, 10000)),complex( 0.0, Inf))
     # @test isequal(sin(complex( 0,-10000)),complex( 0.0,-Inf))
-
     for (x,y) in [(complex( 0.0, 0.0), complex( 0.0, 0.0)),
                   (complex( 0.0, Inf), complex( 0.0, NaN)),
                   (complex( 0.0, NaN), complex( 0.0, NaN)),
@@ -408,7 +404,6 @@ end
                   (complex( NaN, 7.2), complex( NaN, NaN)),
                   (complex( NaN, NaN), complex( NaN, NaN)),
                   ]
-
         @test isequal(sinh(x), y)
         @test isequal(sinh(conj(x)), conj(y))
         @test isequal(sinh(-x), -y)
@@ -441,7 +436,6 @@ end
     #   and cos(b+ia) = cosh(a-ib)
     #  cos(conj(z)) = conj(cos(z))
     #  cos(-z) = cos(z)
-
     for (x,y) in [(complex( 0.0, 0.0), complex( 1.0, 0.0)),
                   (complex( 0.0, Inf), complex( NaN, 0.0)),
                   (complex( 0.0, NaN), complex( NaN, 0.0)),
@@ -485,9 +479,7 @@ end
     end
 end
 
-@testset "tanh" begin
-    # tanh(conj(z)) = conj(tanh(z))
-    # tanh(-z) = -tanh(z)
+@testset "tanh(op(z)) == op(tanh(z)) for op in (conj, -)" begin
     @test isequal(tanh(complex( 0, 0)),complex(0.0,0.0)) #integer fallback
     @test isequal(tanh(complex( 0.0, 0.0)),complex(0.0,0.0))
     @test isequal(tanh(complex( 0.0,-0.0)),complex(0.0,-0.0))
@@ -524,8 +516,7 @@ end
     @test isequal(tanh(complex( NaN, NaN)),complex(NaN, NaN))
 end
 
-@testset "tan" begin
-    # tan(z) = -i tanh(iz)
+@testset "tan(z) == -i tanh(iz)" begin
     @test isequal(tan(complex( 0.0, Inf)),complex( 0.0, 1.0))
     @test isequal(tan(complex( 0.0,-Inf)),complex( 0.0,-1.0))
     @test isequal(tan(complex( 0.0, NaN)),complex( 0.0, NaN))
@@ -552,8 +543,7 @@ end
     @test isequal(tan(complex( NaN, NaN)),complex( NaN, NaN))
 end
 
-@testset "acosh" begin
-    # acosh(conj(z)) = conj(acosh(z))
+@testset "acosh(conj(z)) == conj(acosh(z))" begin
     @test isequal(acosh(complex( 0.0, 0.0)), complex( 0.0, pi/2))
     @test isequal(acosh(complex( 0.0,-0.0)), complex( 0.0,-pi/2))
     @test isequal(acosh(complex( 0.0, Inf)), complex( Inf, pi/2))
@@ -585,8 +575,7 @@ end
     @test isequal(acosh(complex( NaN, NaN)), complex( NaN, NaN))
 end
 
-@testset "acos" begin
-    # acos(conj(z)) = conj(acos(z))
+@testset "acos(conj(z)) == conj(acos(z))" begin
     @test isequal(acos(complex( 0, 0)),complex(pi/2,-0.0)) #integer fallback
     @test isequal(acos(complex( 0.0, 0.0)),complex(pi/2,-0.0))
     @test isequal(acos(complex( 0.0,-0.0)),complex(pi/2, 0.0))
@@ -625,9 +614,7 @@ end
     @test isequal(acos(complex( NaN, NaN)),complex( NaN, NaN))
 end
 
-@testset "asinh" begin
-    # asinh(conj(z)) = conj(asinh(z))
-    # asinh(-z) = -asinh(z)
+@testset "asinh(op(z)) == op(asinh(z)) for op in (conj, -)" begin
     @test isequal(asinh(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(asinh(complex( 0.0,-0.0)),complex( 0.0,-0.0))
     @test isequal(asinh(complex( 0.0, Inf)),complex( Inf, pi/2))
@@ -660,8 +647,7 @@ end
     @test isequal(asinh(complex( NaN, NaN)),complex( NaN, NaN))
 end
 
-@testset "asin" begin
-    # asin(z) = -i*asinh(iz)
+@testset "asin(z) == -i*asinh(iz)" begin
     @test isequal(asin(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(asin(complex( 0.0,-0.0)),complex( 0.0,-0.0))
     @test isequal(asin(complex(-0.0, 0.0)),complex(-0.0, 0.0))
@@ -693,9 +679,7 @@ end
     @test isequal(asin(complex( NaN, NaN)),complex( NaN, NaN))
 end
 
-@testset "atanh" begin
-    # atanh(conj(z)) = conj(atanh(z))
-    # atanh(-z) = -atanh(z)
+@testset "atanh(op(z)) == op(atanh(z)) for op in (conj, -)" begin
     @test isequal(atanh(complex( 0, 0)),complex( 0.0, 0.0)) #integer fallback
     @test isequal(atanh(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(atanh(complex( 0.0,-0.0)),complex( 0.0,-0.0))
@@ -743,8 +727,7 @@ end
     @test isequal(atanh(complex( NaN, NaN)),complex( NaN, NaN))
 end
 
-@testset "atan" begin
-    # atan(z) = -i*atanh(iz)
+@testset "atan(z) == -i*atanh(iz)" begin
     @test isequal(atan(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(atan(complex( 0.0,-0.0)),complex( 0.0,-0.0))
     @test isequal(atan(complex( 0.0, 1.0)),complex( 0.0, Inf))
@@ -941,7 +924,7 @@ end
 end
 
 @testset "issue #11839" begin
-    #type stability for Complex{Int64}
+    # type stability for Complex{Int64}
     let x = 1+im
         @inferred sin(x)
         @inferred cos(x)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -208,8 +208,7 @@ end
 end
 
 @testset "log" begin
-    #  log(conj(z)) = conj(log(z))
-
+    # log(conj(z)) = conj(log(z))
     @test isequal(log(complex( 0.0, 0.0)), complex(-Inf, 0.0))
     @test isequal(log(complex( 0.0,-0.0)), complex(-Inf,-0.0))
     @test isequal(log(complex( 0.0, 1.0)), complex( 0.0, pi/2))
@@ -242,8 +241,7 @@ end
 end
 
 @testset "exp" begin
-    #  exp(conj(z)) = conj(exp(z))
-
+    # exp(conj(z)) = conj(exp(z))
     @test isequal(exp(complex( 0.0, 0.0)), complex(1.0, 0.0))
     @test isequal(exp(complex( 0.0,-0.0)), complex(1.0,-0.0))
     @test isequal(exp(complex( 0.0, Inf)), complex(NaN, NaN))
@@ -278,8 +276,7 @@ end
 end
 
 @testset "expm1" begin
-    #  expm1(conj(z)) = conj(expm1(z))
-
+    # expm1(conj(z)) = conj(expm1(z))
     @test isequal(expm1(complex( 0.0, 0.0)), complex(0.0, 0.0))
     @test isequal(expm1(complex( 0.0,-0.0)), complex(0.0,-0.0))
     @test isequal(expm1(complex( 0.0, Inf)), complex(NaN, NaN))
@@ -351,9 +348,9 @@ end
 
 
 @testset "^ (cpow)" begin
-    #  equivalent to exp(y*log(x))
-    #    except for 0^0?
-    #  conj(x)^conj(y) = conj(x^y)
+    # equivalent to exp(y*log(x))
+    #   except for 0^0?
+    # conj(x)^conj(y) = conj(x^y)
     @test isequal(complex( 0.0, 0.0)^complex( 0.0, 0.0), complex(1.0, 0.0))
     @test isequal(complex( 0.0, 0.0)^complex( 0.0,-0.0), complex(1.0, 0.0))
     @test isequal(complex( 0.0, 0.0)^complex(-0.0, 0.0), complex(1.0,-0.0))
@@ -489,8 +486,8 @@ end
 end
 
 @testset "tanh" begin
-    #  tanh(conj(z)) = conj(tanh(z))
-    #  tanh(-z) = -tanh(z)
+    # tanh(conj(z)) = conj(tanh(z))
+    # tanh(-z) = -tanh(z)
     @test isequal(tanh(complex( 0, 0)),complex(0.0,0.0)) #integer fallback
     @test isequal(tanh(complex( 0.0, 0.0)),complex(0.0,0.0))
     @test isequal(tanh(complex( 0.0,-0.0)),complex(0.0,-0.0))
@@ -528,8 +525,7 @@ end
 end
 
 @testset "tan" begin
-    #  tan(z) = -i tanh(iz)
-
+    # tan(z) = -i tanh(iz)
     @test isequal(tan(complex( 0.0, Inf)),complex( 0.0, 1.0))
     @test isequal(tan(complex( 0.0,-Inf)),complex( 0.0,-1.0))
     @test isequal(tan(complex( 0.0, NaN)),complex( 0.0, NaN))
@@ -557,8 +553,7 @@ end
 end
 
 @testset "acosh" begin
-    #  acosh(conj(z)) = conj(acosh(z))
-
+    # acosh(conj(z)) = conj(acosh(z))
     @test isequal(acosh(complex( 0.0, 0.0)), complex( 0.0, pi/2))
     @test isequal(acosh(complex( 0.0,-0.0)), complex( 0.0,-pi/2))
     @test isequal(acosh(complex( 0.0, Inf)), complex( Inf, pi/2))
@@ -591,8 +586,7 @@ end
 end
 
 @testset "acos" begin
-    ##  acos(conj(z)) = conj(acos(z))
-
+    # acos(conj(z)) = conj(acos(z))
     @test isequal(acos(complex( 0, 0)),complex(pi/2,-0.0)) #integer fallback
     @test isequal(acos(complex( 0.0, 0.0)),complex(pi/2,-0.0))
     @test isequal(acos(complex( 0.0,-0.0)),complex(pi/2, 0.0))
@@ -632,8 +626,8 @@ end
 end
 
 @testset "asinh" begin
-    ##  asinh(conj(z)) = conj(asinh(z))
-    ##  asinh(-z) = -asinh(z)
+    # asinh(conj(z)) = conj(asinh(z))
+    # asinh(-z) = -asinh(z)
     @test isequal(asinh(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(asinh(complex( 0.0,-0.0)),complex( 0.0,-0.0))
     @test isequal(asinh(complex( 0.0, Inf)),complex( Inf, pi/2))
@@ -667,8 +661,7 @@ end
 end
 
 @testset "asin" begin
-    #  asin(z) = -i*asinh(iz)
-
+    # asin(z) = -i*asinh(iz)
     @test isequal(asin(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(asin(complex( 0.0,-0.0)),complex( 0.0,-0.0))
     @test isequal(asin(complex(-0.0, 0.0)),complex(-0.0, 0.0))
@@ -701,9 +694,8 @@ end
 end
 
 @testset "atanh" begin
-    #  atanh(conj(z)) = conj(atanh(z))
-    #  atanh(-z) = -atanh(z)
-
+    # atanh(conj(z)) = conj(atanh(z))
+    # atanh(-z) = -atanh(z)
     @test isequal(atanh(complex( 0, 0)),complex( 0.0, 0.0)) #integer fallback
     @test isequal(atanh(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(atanh(complex( 0.0,-0.0)),complex( 0.0,-0.0))
@@ -752,8 +744,7 @@ end
 end
 
 @testset "atan" begin
-    #  atan(z) = -i*atanh(iz)
-
+    # atan(z) = -i*atanh(iz)
     @test isequal(atan(complex( 0.0, 0.0)),complex( 0.0, 0.0))
     @test isequal(atan(complex( 0.0,-0.0)),complex( 0.0,-0.0))
     @test isequal(atan(complex( 0.0, 1.0)),complex( 0.0, Inf))

--- a/test/core.jl
+++ b/test/core.jl
@@ -4861,10 +4861,9 @@ immutable MyTime <: Dates.TimeType
 end
 @test_throws ErrorException isless(MyTime(1), now())
 
-end
+end # module SOE
 
 # issue #15240
-
 @test_nowarn begin
     local p15240
     p15240 = ccall(:jl_realloc, Ptr{Void}, (Ptr{Void}, Csize_t), C_NULL, 10)
@@ -4872,5 +4871,4 @@ end
 end
 
 # issue #19963
-
 @test_nowarn ccall(:jl_free, Void, (Ptr{Void}, ), C_NULL)

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -332,8 +332,7 @@ let f = "YY"
 end
 
 # Issue: https://github.com/quinnj/TimeZones.jl/issues/19
-let
-    ds = "2015-07-24T05:38:19.591Z"
+let ds = "2015-07-24T05:38:19.591Z"
     dt = Dates.DateTime(2015,7,24,5,38,19,591)
 
     format = "yyyy-mm-ddTHH:MM:SS.sssZ"

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -639,9 +639,9 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     @test isa(wkd, WeakKeyDict)
 end
 
-# issue 19995
-@test hash(Dict(Dict(1=>2) => 3, Dict(4=>5) => 6)) != hash(Dict(Dict(4=>5) => 3, Dict(1=>2) => 6))
-let a = Dict(Dict(3 => 4, 2 => 3) => 2, Dict(1 => 2, 5 => 6) => 1)
+@testset "issue #19995, hash of dicts" begin
+    @test hash(Dict(Dict(1=>2) => 3, Dict(4=>5) => 6)) != hash(Dict(Dict(4=>5) => 3, Dict(1=>2) => 6))
+    a = Dict(Dict(3 => 4, 2 => 3) => 2, Dict(1 => 2, 5 => 6) => 1)
     b = Dict(Dict(1 => 2, 2 => 3, 5 => 6) => 1, Dict(3 => 4) => 2)
     @test hash(a) != hash(b)
 end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -244,9 +244,7 @@ d4[1001] = randstring(3)
 @test isequal(Dict{Int,Int}(), Dict{AbstractString,AbstractString}())
 
 # get! (get with default values assigned to the given location)
-
 let f(x) = x^2, d = Dict(8=>19)
-
     @test get!(d, 8, 5) == 19
     @test get!(d, 19, 2) == 2
 
@@ -518,7 +516,6 @@ let d = Dict(zip(1:1000,1:1000)), f = (k,v) -> iseven(k)
 end
 
 # issue #15077
-
 immutable MyString <: AbstractString
     str::String
 end
@@ -585,7 +582,6 @@ let badKeys = UInt16[0xb800,0xa501,0xcdff,0x6303,0xe40a,0xcf0e,0xf3df,0xae99,0x9
                      0xd02c,0x862d,0x8f34,0xe529,0xf938,0x4f39,0xd03a,0x473b,0x1e3b,0x1d3a,
                      0xcc39,0x7339,0xcf40,0x8740,0x813d,0xe640,0xc443,0x6344,0x3744,0x2c3d,
                      0x8c48,0xdf49,0x5743]
-
     # Walk through all possible hash values (mod size of hash table)
     for offset = 0:1023
         d2 = Dict{MyInt, Int}()
@@ -651,7 +647,6 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
 end
 
 # issue 19995
-
 @test hash(Dict(Dict(1=>2) => 3, Dict(4=>5) => 6)) != hash(Dict(Dict(4=>5) => 3, Dict(1=>2) => 6))
 let a = Dict(Dict(3 => 4, 2 => 3) => 2, Dict(1 => 2, 5 => 6) => 1)
     b = Dict(Dict(1 => 2, 2 => 3, 5 => 6) => 1, Dict(3 => 4) => 2)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -81,8 +81,7 @@ h["a","b","c"] = 4
 @test keytype(h) == Any
 @test valtype(h) == Any
 
-let
-    td = Dict{AbstractString,Float64}()
+let td = Dict{AbstractString,Float64}()
     @test eltype(td) == Pair{AbstractString,Float64}
     @test keytype(td) == AbstractString
     @test valtype(td) == Float64
@@ -90,8 +89,7 @@ let
     @test valtype(Dict{AbstractString,Float64}) === Float64
 end
 
-let
-    z = Dict()
+let z = Dict()
     get_KeyError = false
     try
         z["a"]
@@ -104,8 +102,7 @@ end
 _d = Dict("a"=>0)
 @test isa([k for k in filter(x->length(x)==1, collect(keys(_d)))], Vector{String})
 
-let
-    d = Dict(((1, 2), (3, 4)))
+let d = Dict(((1, 2), (3, 4)))
     @test d[1] === 2
     @test d[3] === 4
     d2 = Dict(1 => 2, 3 => 4)
@@ -154,8 +151,7 @@ end
 @test_throws KeyError Dict("a"=>2)[Base.secret_table_token]
 
 # issue #1821
-let
-    d = Dict{String, Vector{Int}}()
+let d = Dict{String, Vector{Int}}()
     d["a"] = [1, 2]
     @test_throws MethodError d["b"] = 1
     @test isa(repr(d), AbstractString)  # check that printable without error
@@ -343,15 +339,13 @@ for k5886 in keys(d5886)
 end
 
 # issue #8877
-let
-    a = Dict("foo"  => 0.0, "bar" => 42.0)
-    b = Dict("フー" => 17, "バー" => 4711)
+let a = Dict("foo"  => 0.0, "bar" => 42.0),
+        b = Dict("フー" => 17, "バー" => 4711)
     @test typeof(merge(a, b)) === Dict{String,Float64}
 end
 
 # issue 9295
-let
-    d = Dict()
+let d = Dict()
     @test push!(d, 'a' => 1) === d
     @test d['a'] == 1
     @test push!(d, 'b' => 2, 'c' => 3) === d
@@ -366,8 +360,7 @@ end
 
 # issue #10647
 type T10647{T}; x::T; end
-let
-    a = ObjectIdDict()
+let a = ObjectIdDict()
     a[1] = a
     a[a] = 2
     a[3] = T10647(a)

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -48,8 +48,7 @@ end
 @test isa(collect(Any, [1,2]), Vector{Any})
 
 # foreach
-let
-    a = []
+let a = []
     foreach(()->push!(a,0))
     @test a == [0]
     a = []

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -61,7 +61,6 @@ let
 end
 
 # generators (#4470, #14848)
-
 @test sum(i/2 for i=1:2) == 1.5
 @test collect(2i for i=2:5) == [4,6,8,10]
 @test collect((i+10j for i=1:2,j=3:4)) == [31 41; 32 42]
@@ -104,7 +103,6 @@ let i = 1
 end
 
 # generators and guards
-
 let gen = (x for x in 1:10)
     @test gen.iter == 1:10
     @test gen.f(first(1:10)) == next(gen, start(gen))[1]
@@ -135,7 +133,6 @@ let gen = ((x,y) for x in 1:10, y in 1:10 if x % 2 == 0 && y % 2 == 0),
 end
 
 # generators with nested loops (#4867)
-
 @test [(i,j) for i=1:3 for j=1:i] == [(1,1), (2,1), (2,2), (3,1), (3,2), (3,3)]
 
 @test [(i,j) for i=1:3 for j=1:i if j>1] == [(2,2), (3,2), (3,3)]

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -59,7 +59,6 @@ end
 
 # countfrom
 # ---------
-
 let i = 0
     for j = countfrom(0, 2)
         @test j == i*2
@@ -70,7 +69,6 @@ end
 
 # take
 # ----
-
 let t = take(0:2:8, 10), i = 0
     @test length(collect(t)) == 5
 
@@ -95,7 +93,6 @@ end
 
 # drop
 # ----
-
 let i = 0
     for j = drop(0:2:10, 2)
         @test j == (i+2)*2
@@ -111,7 +108,6 @@ end
 # double take
 # and take/drop canonicalization
 # -----------
-
 for xs in Any["abc", [1, 2, 3]]
     @test take(take(xs, 2), 3) === take(xs, 2)
     @test take(take(xs, 4), 2) === take(xs, 2)
@@ -125,7 +121,6 @@ end
 
 # cycle
 # -----
-
 let i = 0
     for j = cycle(0:3)
         @test j == i % 4
@@ -136,7 +131,6 @@ end
 
 # repeated
 # --------
-
 let i = 0
     for j = repeated(1, 10)
         @test j == 1
@@ -341,7 +335,6 @@ end
 
 # flatten
 # -------
-
 @test collect(flatten(Any[1:2, 4:5])) == Any[1,2,4,5]
 @test collect(flatten(Any[flatten(Any[1:2, 6:5]), flatten(Any[10:7, 10:9])])) == Any[1,2]
 @test collect(flatten(Any[flatten(Any[1:2, 4:5]), flatten(Any[6:7, 8:9])])) == Any[1,2,4,5,6,7,8,9]

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -34,7 +34,7 @@ let b = IOBuffer("1\n2\n3\n"), a = []
 end
 
 # zip eachline (issue #7369)
-let zeb     = IOBuffer("1\n2\n3\n4\n5\n"),
+let zeb = IOBuffer("1\n2\n3\n4\n5\n"),
     letters = ['a', 'b', 'c', 'd', 'e'],
     res     = []
     for (number, letter) in zip(eachline(zeb), letters)
@@ -174,8 +174,7 @@ end
 @test collect(product(1:2, 3:4, 5:6)) == [(i, j, k) for i=1:2, j=3:4, k=5:6]
 
 # iteration order
-let
-    expected = [(1,3,5), (2,3,5), (1,4,5), (2,4,5), (1,3,6), (2,3,6), (1,4,6), (2,4,6)]
+let expected = [(1,3,5), (2,3,5), (1,4,5), (2,4,5), (1,3,6), (2,3,6), (1,4,6), (2,4,6)]
     actual = product(1:2, 3:4, 5:6)
     for (exp, act) in zip(expected, actual)
         @test exp == act
@@ -183,9 +182,8 @@ let
 end
 
 # collect multidimensional array
-let
-    a, b = 1:3, [4 6;
-                 5 7]
+let (a, b) = (1:3, [4 6;
+                    5 7])
     p = product(a, b)
     @test size(p)    == (3, 2, 2)
     @test length(p)  == 12
@@ -199,9 +197,7 @@ let
 end
 
 # with 1D inputs
-let
-    a, b, c = 1:2, 1.0:10.0, Int32(1):Int32(0)
-
+let (a, b, c) = (1:2, 1.0:10.0, Int32(1):Int32(0))
     # length
     @test length(product(a))       == 2
     @test length(product(a, b))    == 20
@@ -224,8 +220,7 @@ let
 end
 
 # with multidimensional inputs
-let
-    a, b, c = randn(4, 4), randn(3, 3, 3), randn(2, 2, 2, 2)
+let (a, b, c) = (randn(4, 4), randn(3, 3, 3), randn(2, 2, 2, 2))
     args = Any[(a,),
                (a, a),
                (a, b),
@@ -244,8 +239,7 @@ let
 end
 
 # more tests on product with iterators of various type
-let
-    iters = (1:2,
+let iters = (1:2,
              rand(2, 2, 2),
              take(1:4, 2),
              product(1:2, 1:3),
@@ -268,8 +262,7 @@ let
 end
 
 # product of finite length and infinite length iterators
-let
-    a = 1:2
+let a = 1:2
     b = countfrom(1)
     ab = product(a, b)
     ba = product(b, a)

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -153,8 +153,7 @@ let
 end
 
 @testset "real svds" begin
-    let # svds test
-        A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
+    let A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
         S1 = svds(A, nsv = 2)
         S2 = svd(Array(A))
 
@@ -198,8 +197,7 @@ end
 end
 
 @testset "complex svds" begin
-    let # complex svds test
-        A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp.(im*[2.0:2:10;]))
+    let A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp.(im*[2.0:2:10;]))
         S1 = svds(A, nsv = 2)
         S2 = svd(Array(A))
 
@@ -242,8 +240,7 @@ end
 end
 
 # Symmetric generalized with singular B
-let
-    n = 10
+let n = 10
     k = 3
     A = randn(n,n); A = A'A
     B = randn(n,k);  B = B*B'

--- a/test/linalg/bunchkaufman.jl
+++ b/test/linalg/bunchkaufman.jl
@@ -87,8 +87,7 @@ end
 
 
 @testset "Bunch-Kaufman factors of a singular matrix" begin
-    let
-        As1 = ones(n, n)
+    let As1 = ones(n, n)
         As2 = complex(ones(n, n))
         As3 = complex(ones(n, n))
         As3[end, 1] += im

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -7,7 +7,6 @@ n=12 #Size of matrix problem to test
 srand(1)
 
 @testset for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
-
     d=convert(Vector{elty}, randn(n))
     v=convert(Vector{elty}, randn(n))
     U=convert(Matrix{elty}, randn(n,n))

--- a/test/linalg/givens.jl
+++ b/test/linalg/givens.jl
@@ -7,7 +7,6 @@ debug = false
 
 # Test givens rotations
 for elty in (Float32, Float64, Complex64, Complex128)
-
     debug && println("elty is $elty")
 
     if elty <: Real

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -29,8 +29,12 @@ dreal = randn(n)/2
 dimg  = randn(n)/2
 
 for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
-    a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
-    d = eltya == Int ? Tridiagonal(rand(1:7, n-1), rand(1:7, n), rand(1:7, n-1)) : convert(Tridiagonal{eltya}, eltya <: Complex ? Tridiagonal(complex.(dlreal, dlimg), complex.(dreal, dimg), complex.(dureal, duimg)) : Tridiagonal(dlreal, dreal, dureal))
+    a = eltya == Int ? rand(1:7, n, n) :
+        convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
+    d = eltya == Int ? Tridiagonal(rand(1:7, n-1), rand(1:7, n), rand(1:7, n-1)) :
+        convert(Tridiagonal{eltya}, eltya <: Complex ?
+        Tridiagonal(complex.(dlreal, dlimg), complex.(dreal, dimg), complex.(dureal, duimg)) :
+        Tridiagonal(dlreal, dreal, dureal))
     ε = εa = eps(abs(float(one(eltya))))
 
     if eltya <: BlasFloat
@@ -39,8 +43,10 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         @test AbstractArray(lufact(num)) ≈ eltya[num]
     end
     for eltyb in (Float32, Float64, Complex64, Complex128, Int)
-        b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex.(breal, bimg) : breal)
-        c = eltyb == Int ? rand(1:5, n) : convert(Vector{eltyb}, eltyb <: Complex ? complex.(creal, cimg) : creal)
+        b = eltyb == Int ? rand(1:5, n, 2) :
+            convert(Matrix{eltyb}, eltyb <: Complex ? complex.(breal, bimg) : breal)
+        c = eltyb == Int ? rand(1:5, n) :
+            convert(Vector{eltyb}, eltyb <: Complex ? complex.(creal, cimg) : creal)
         εb = eps(abs(float(one(eltyb))))
         ε = max(εa,εb)
 
@@ -167,7 +173,9 @@ end
 ## Testing Rational{BigInt} and BigFloat version
 nHilbert = 50
 H = Rational{BigInt}[1//(i+j-1) for i = 1:nHilbert,j = 1:nHilbert]
-Hinv = Rational{BigInt}[(-1)^(i+j)*(i+j-1)*binomial(nHilbert+i-1,nHilbert-j)*binomial(nHilbert+j-1,nHilbert-i)*binomial(i+j-2,i-1)^2 for i = big(1):nHilbert,j=big(1):nHilbert]
+Hinv = Rational{BigInt}[(-1)^(i+j)*(i+j-1)*binomial(nHilbert+i-1,nHilbert-j)*
+    binomial(nHilbert+j-1,nHilbert-i)*binomial(i+j-2,i-1)^2
+    for i = big(1):nHilbert,j=big(1):nHilbert]
 @test inv(H) == Hinv
 setprecision(2^10) do
     @test norm(Array{Float64}(inv(float(H)) - float(Hinv))) < 1e-100

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -31,10 +31,14 @@ dimg  = randn(n)/2
 for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     a = eltya == Int ? rand(1:7, n, n) :
         convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
-    d = eltya == Int ? Tridiagonal(rand(1:7, n-1), rand(1:7, n), rand(1:7, n-1)) :
-        convert(Tridiagonal{eltya}, eltya <: Complex ?
-        Tridiagonal(complex.(dlreal, dlimg), complex.(dreal, dimg), complex.(dureal, duimg)) :
-        Tridiagonal(dlreal, dreal, dureal))
+    d = if eltya == Int
+        Tridiagonal(rand(1:7, n-1), rand(1:7, n), rand(1:7, n-1))
+    elseif eltya <: Complex
+        convert(Tridiagonal{eltya}, Tridiagonal(
+            complex.(dlreal, dlimg), complex.(dreal, dimg), complex.(dureal, duimg)))
+    else
+        convert(Tridiagonal{eltya}, Tridiagonal(dlreal, dreal, dureal))
+    end
     ε = εa = eps(abs(float(one(eltya))))
 
     if eltya <: BlasFloat

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -72,7 +72,6 @@ end
     @test (rv/d)::RowVector ≈ [2/1  3/2  4/3]
 
     @test_throws Exception d \ rv
-
 end
 
 @testset "Bidiagonal ambiguity methods" begin
@@ -164,7 +163,6 @@ end
     @test_throws Exception z'*cz
     @test z'*z === 15 + 0im
     @test_throws Exception mat'*cz
-
 end
 
 @testset "norm" begin
@@ -238,7 +236,6 @@ end
     @test (rv/ut')::RowVector ≈ [2/1  3/2  4/3]
 
     @test_throws Exception ut\rv
-
 end
 
 

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -126,8 +126,7 @@ for typ in [UpperTriangular,LowerTriangular,Base.LinAlg.UnitUpperTriangular,Base
 end
 
 # Test that concatenations of combinations of special and other matrix types yield sparse arrays
-let
-    N = 4
+let N = 4
     # Test concatenating pairwise combinations of special matrices
     diagmat = Diagonal(ones(N))
     bidiagmat = Bidiagonal(ones(N), ones(N-1), true)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -180,7 +180,6 @@ let doc = Markdown.parse(
         ... another paragraph.
         """
     )
-
     @test length(doc.content) === 3
     @test isa(doc.content[1], Markdown.Paragraph)
     @test isa(doc.content[2], Markdown.List)
@@ -202,7 +201,6 @@ end
 @test md"Foo \[bar](baz)" == MD(Paragraph("Foo [bar](baz)"))
 
 # Basic plain (markdown) output
-
 @test md"foo" |> plain == "foo\n"
 @test md"foo *bar* baz" |> plain == "foo *bar* baz\n"
 @test md"# title" |> plain == "# title\n"
@@ -242,7 +240,6 @@ let doc = Markdown.parse(
 end
 
 # HTML output
-
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"
 @test md"something ***" |> html == "<p>something ***</p>\n"
 @test md"# h1## " |> html == "<h1>h1##</h1>\n"
@@ -295,7 +292,6 @@ Some **bolded**
 """
 @test latex(book) == "\\section{Title}\nSome discussion\n\n\\begin{quote}\nA quote\n\n\\end{quote}\n\\subsection{Section \\emph{important}}\nSome \\textbf{bolded}\n\n\\begin{itemize}\n\\item list1\n\n\n\\item list2\n\n\\end{itemize}\n"
 # mime output
-
 let out =
     """
     # Title
@@ -379,7 +375,6 @@ let out =
 end
 
 # rst rendering
-
 for (input, output) in (
         md"foo *bar* baz"     => "foo *bar* baz\n",
         md"something ***"     => "something ***\n",
@@ -407,7 +402,6 @@ for (input, output) in (
 end
 
 # Interpolation / Custom types
-
 type Reference
     ref
 end
@@ -494,7 +488,6 @@ let text =
 end
 
 # LaTeX extension
-
 let in_dollars =
     """
     We have \$x^2 < x\$ whenever:
@@ -563,7 +556,6 @@ let in_dollars =
 end
 
 # Nested backticks for inline code and math.
-
 let t_1 = "`code` ``math`` ```code``` ````math```` `````code`````",
     t_2 = "`` `math` `` ``` `code` ``code`` ``` ```` `math` ``math`` ```math``` ````",
     t_3 = "`` ` `` ``` `` ` `` ` ` ```",
@@ -617,7 +609,6 @@ let t_1 = "`code` ``math`` ```code``` ````math```` `````code`````",
 end
 
 # Admonitions.
-
 let t_1 =
         """
         # Foo
@@ -695,7 +686,6 @@ let t_1 =
     @test isa(m_2.content[3].content[3], Markdown.Header{1})
 
     # Rendering Tests.
-
     let out = Markdown.plain(m_1),
         expected =
             """
@@ -833,7 +823,6 @@ let t_1 =
 end
 
 # Nested Lists.
-
 let text =
         """
         1. A paragraph
@@ -887,7 +876,6 @@ let text =
     @test md.content[6].items[3][1].content[1] == "baz"
 
     # Rendering tests.
-
     let expected =
             """
             1. A paragraph with two lines.
@@ -988,7 +976,6 @@ let text =
 end
 
 # Ordered list starting number.
-
 let text =
         """
         42. foo

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -875,9 +875,7 @@ end
 @test isnan(sqrt(BigFloat(NaN)))
 
 # PR 17217 -- BigFloat constructors with given precision and rounding mode
-
 # test constructors and `big` with additional precision and rounding mode:
-
 for prec in (10, 100, 1000)
     for val in ("3.1", pi, "-1.3", 3.1)
         let

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -384,6 +384,9 @@ end
 @test parse("x<:y<:z").head === :comparison
 @test parse("x>:y<:z").head === :comparison
 
+# reason PR #19765, <- operator, was reverted
+@test -2<-1 # DO NOT ADD SPACES
+
 # issue #11169
 uncalled(x) = @test false
 fret() = uncalled(return true)

--- a/test/perf/micro/perf.go
+++ b/test/perf/micro/perf.go
@@ -1,6 +1,6 @@
 // Implementation of the Julia benchmark suite in Go.
 //
-// Three gonum packages must be installed, and then an additional environmental
+// Three gonum packages must be installed, and then an additional environment
 // variable must be set to use the BLAS installation.
 // To install the gonum packages, run:
 // 		go get github.com/gonum/blas

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -496,8 +496,7 @@ temp_pkg_dir() do
     end
 end
 
-let
-    io = IOBuffer()
+let io = IOBuffer()
     Base.showerror(io, Base.Pkg.Entry.PkgTestError("ppp"), backtrace())
     @test !contains(String(take!(io)), "backtrace()")
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -180,7 +180,7 @@ foo7648(x) = x
 function foo7648_nomethods end
 type Foo7648 end
 
-    module TestModSub9475
+module TestModSub9475
     using Base.Test
     using ..TestMod7648
     import ..curmod_name
@@ -196,7 +196,7 @@ type Foo7648 end
                                                   :TestModSub9475)
         @test Base.module_parent(current_module()) == TestMod7648
     end
-    end # module TestModSub9475
+end # module TestModSub9475
 
 using .TestModSub9475
 
@@ -552,8 +552,7 @@ else
 end
 
 # Adds test for PR #17636
-let
-    a = @code_typed 1 + 1
+let a = @code_typed 1 + 1
     b = @code_lowered 1 + 1
     @test isa(a, Pair{CodeInfo, DataType})
     @test isa(b, CodeInfo)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -550,7 +550,8 @@ end
 # Test containers in error messages are limited #18726
 let io = IOBuffer()
     Base.display_error(io,
-        try [][trues(6000)]
+        try
+            [][trues(6000)]
         catch e
             e
         end, [])

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -511,7 +511,6 @@ let exename = Base.julia_cmd()
 # Test REPL in dumb mode
 if !is_windows()
     TestHelpers.with_fake_pty() do slave, master
-
         nENV = copy(ENV)
         nENV["TERM"] = "dumb"
         p = spawn(setenv(`$exename --startup-file=no --quiet`,nENV),slave,slave,slave)
@@ -527,7 +526,6 @@ if !is_windows()
         output = readuntil(master,' ')
         @test output == "1\r\nquit()\r\n1\r\n\r\njulia> "
         @test nb_available(master) == 0
-
     end
 end
 

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -421,8 +421,7 @@ let b = IOBuffer()
 end
 
 # issue #1770
-let
-    a = ['T', 'e', 's', 't']
+let a = ['T', 'e', 's', 't']
     f = IOBuffer()
     serialize(f, a)
     seek(f, 0)

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -149,7 +149,6 @@ pred = afiro'*sol
 @test norm(afiro * (convert(Matrix, y) - convert(Matrix, pred))) < 1e-8
 
 let # Issue 9160
-
     A = sprand(10, 10, 0.1)
     A = convert(SparseMatrixCSC{Float64,CHOLMOD.SuiteSparse_long}, A)
     cmA = CHOLMOD.Sparse(A)
@@ -174,7 +173,6 @@ let # Issue 9160
     A = 0.5*(A + A')
     cmA = CHOLMOD.Sparse(A)
     @test sparse(cmA*cmA') ≈ A*A'
-
 end
 
 # Issue #9915
@@ -675,7 +673,6 @@ let Apre = sprandn(10, 10, 0.2) - I
     for A in (Symmetric(Apre), Hermitian(Apre),
               Symmetric(Apre + 10I), Hermitian(Apre + 10I),
               Hermitian(complex(Apre)), Hermitian(complex(Apre) + 10I))
-
         x = ones(10)
         b = A*x
         @test x ≈ A\b

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -441,8 +441,7 @@ end
 
 # Test that concatenations of combinations of sparse vectors with various other
 # matrix/vector types yield sparse arrays
-let
-    N = 4
+let N = 4
     spvec = spzeros(N)
     spmat = spzeros(N, 1)
     densevec = ones(N)
@@ -967,8 +966,7 @@ let m = 10
     end
 end
 # The preceding tests miss the edge case where the sparse vector is empty (#16716)
-let
-    origmat = [-1.5 -0.7; 0.0 1.0]
+let origmat = [-1.5 -0.7; 0.0 1.0]
     transmat = transpose(origmat)
     utmat = UpperTriangular(origmat)
     ltmat = LowerTriangular(transmat)

--- a/test/sparse/umfpack.jl
+++ b/test/sparse/umfpack.jl
@@ -137,8 +137,7 @@ let
 end
 
 #18246,18244-lufact sparse pivot
-let
-    A = speye(4)
+let A = speye(4)
     A[1:2,1:2] = [-.01 -200; 200 .001]
     F = lufact(A)
     @test F[:p] == [3 ; 4 ; 2 ; 1]

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -38,9 +38,8 @@ let
     @test isnull(frame2.linfo)
 end
 
-let
-    # Test from_c
-    default, with_c, without_c = stacktrace(), stacktrace(true), stacktrace(false)
+# Test from_c
+let (default, with_c, without_c) = (stacktrace(), stacktrace(true), stacktrace(false))
     @test default == without_c
     @test length(with_c) > length(without_c)
     @test !isempty(filter(frame -> frame.from_c, with_c))
@@ -125,11 +124,9 @@ let ctestptr = cglobal((:ctest, "libccalltest")),
     @test ctest[1].pointer === UInt64(ctestptr)
 end
 
-# #19655
-let
+# issue #19655
+let st = stacktrace(empty!(backtrace()))
     # not in a `catch`, so should return an empty StackTrace
-    st = stacktrace(empty!(backtrace()))
-
     @test isempty(st)
     @test isa(st, StackTrace)
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -408,16 +408,14 @@ str = String(take!(io))
 @test contains(str, "test.jl")
 @test !contains(str, "boot.jl")
 
-let
-    io = IOBuffer()
+let io = IOBuffer()
     exc = Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}())
     Base.showerror(io, exc, backtrace())
     @test !contains(String(take!(io)), "backtrace()")
 end
 
 # 19750
-let
-    io = IOBuffer()
+let io = IOBuffer()
     exc = Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}())
     Base.showerror(io, exc, backtrace())
     @test !contains(String(take!(io)), "backtrace()")

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -147,12 +147,12 @@ let ex = t265.exception
     @test ex.world == wc265
     str = sprint(showerror, ex)
     wc = world_counter()
-    cmp = """
+    cmps = """
         MethodError: no method matching h265()
         The applicable method may be too new: running in world age $wc265, while current world is $wc."""
-    @test startswith(str, cmp)
-    cmp = "\n  h265() at $loc_h265 (method too new to be called from this world context.)"
-    @test contains(str, cmp)
+    @test startswith(str, cmps)
+    cmps = "\n  h265() at $loc_h265 (method too new to be called from this world context.)"
+    @test contains(str, cmps)
 end
 
 # test for generated function correctness


### PR DESCRIPTION
Mostly removing empty lines right at the start of a block or right before end, consolidating zero-arg `let`s in many of the tests to save a few lines, and eval-ing a deprecation from https://github.com/JuliaLang/julia/pull/19901 into the right module (that commit is best viewed as https://github.com/JuliaLang/julia/pull/20031/commits/f397cad6b2441658bb90ff0a277de6ad6122f2b8?w=1, as is the last commit https://github.com/JuliaLang/julia/pull/20031/commits/d5ea34842b1cb47dab4c2e603fd781bb805f0d6f?w=1 - or overall, https://github.com/JuliaLang/julia/pull/20031/files?w=1).