### PR TITLE
pmap docstring update, hook exception input changes.

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,10 +268,6 @@ export call
 # #12872
 @deprecate istext istextmime
 
-#15409
-# Deprecated definition of pmap with keyword arguments.
-# deprecation warnings are in pmap.jl
-
 # 15692
 typealias Func{N} Function
 deprecate(:Func)


### PR DESCRIPTION
This PR

- Updates docstring for pmap
- Cleans up exception input in the hooks. Previously hooks were input the wrapped `RemoteException`, now they are input the actual root exception.
- deprecated keyword args have been removed

Please provide feedback on the updated docstring.
Also a good time to bikeshed keyword arg names.

Closes #19652 