### PR TITLE
WIP/RFH: Deprecate generalized linear indexing

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1547,12 +1547,11 @@ for (f, g) in ((:A_mul_Bc, :A_mul_Bc!), (:A_mul_Bt, :A_mul_Bt!))
     end
 end
 
-for mat in (:AbstractVector, :AbstractMatrix)
-
 ### Multiplication with triangle to the left and hence rhs cannot be transposed.
 for (f, g) in ((:*, :A_mul_B!), (:Ac_mul_B, :Ac_mul_B!), (:At_mul_B, :At_mul_B!))
     @eval begin
-        function ($f)(A::AbstractTriangular, B::$mat)
+        ($f)(A::AbstractTriangular, B::AbstractVector) = ($f)(A, reshape(B, Val{2}))
+        function ($f)(A::AbstractTriangular, B::AbstractMatrix)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
             copy!(BB, B)
@@ -1563,7 +1562,8 @@ end
 ### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
 for (f, g) in ((:\, :A_ldiv_B!), (:Ac_ldiv_B, :Ac_ldiv_B!), (:At_ldiv_B, :At_ldiv_B!))
     @eval begin
-        function ($f)(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
+        ($f)(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::AbstractVector) = ($f)(A, reshape(B, Val{2}))
+        function ($f)(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::AbstractMatrix)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
             copy!(BB, B)
@@ -1574,7 +1574,8 @@ end
 ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
 for (f, g) in ((:\, :A_ldiv_B!), (:Ac_ldiv_B, :Ac_ldiv_B!), (:At_ldiv_B, :At_ldiv_B!))
     @eval begin
-        function ($f)(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
+        ($f)(A::Union{UpperTriangular,LowerTriangular}, B::AbstractVector) = ($f)(A, reshape(B, Val{2}))
+        function ($f)(A::Union{UpperTriangular,LowerTriangular}, B::AbstractMatrix)
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             BB = similar(B, TAB, size(B))
             copy!(BB, B)
@@ -1585,7 +1586,8 @@ end
 ### Multiplication with triangle to the rigth and hence lhs cannot be transposed.
 for (f, g) in ((:*, :A_mul_B!), (:A_mul_Bc, :A_mul_Bc!), (:A_mul_Bt, :A_mul_Bt!))
     @eval begin
-        function ($f)(A::$mat, B::AbstractTriangular)
+        ($f)(A::AbstractVector, B::AbstractTriangular) = ($f)(reshape(A, Val{2}), B)
+        function ($f)(A::AbstractMatrix, B::AbstractTriangular)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
             copy!(AA, A)
@@ -1596,7 +1598,8 @@ end
 ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
 for (f, g) in ((:/, :A_rdiv_B!), (:A_rdiv_Bc, :A_rdiv_Bc!), (:A_rdiv_Bt, :A_rdiv_Bt!))
     @eval begin
-        function ($f)(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
+        ($f)(A::AbstractVector, B::Union{UnitUpperTriangular, UnitLowerTriangular}) = ($f)(reshape(A, Val{2}), B)
+        function ($f)(A::AbstractMatrix, B::Union{UnitUpperTriangular, UnitLowerTriangular})
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
             copy!(AA, A)
@@ -1608,14 +1611,14 @@ end
 ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
 for (f, g) in ((:/, :A_rdiv_B!), (:A_rdiv_Bc, :A_rdiv_Bc!), (:A_rdiv_Bt, :A_rdiv_Bt!))
     @eval begin
-        function ($f)(A::$mat, B::Union{UpperTriangular,LowerTriangular})
+        ($f)(A::AbstractVector, B::Union{UpperTriangular,LowerTriangular}) = ($f)(reshape(A, Val{2}), B)
+        function ($f)(A::AbstractMatrix, B::Union{UpperTriangular,LowerTriangular})
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             AA = similar(A, TAB, size(A))
             copy!(AA, A)
             ($g)(AA, convert(AbstractArray{TAB}, B))
         end
     end
-end
 end
 
 # If these are not defined, they will fallback to the versions in matmul.jl

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -180,6 +180,11 @@ using .IteratorsMD
     A[to_indices(A, (i1, I...))...]
 @propagate_inbounds setindex!(A::Array, v, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...) =
     (A[to_indices(A, (i1, I...))...] = v; A)
+# But they may not expand to 1 or N indices; ensure the above doesn't shadow the general indexing fallbacks
+@propagate_inbounds getindex{T}(A::Array{T}, i1::Int, I::Int...) =
+    _getindex(LinearFast(), A, i1, I...)
+@propagate_inbounds setindex!{T}(A::Array{T}, v, i1::Int, I::Int...) =
+    _setindex!(LinearFast(), A, v, i1, I...)
 
 # Support indexing with an array of CartesianIndex{N}s
 # Here we try to consume N of the indices (if there are that many available)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -376,11 +376,10 @@ getindex(t::Tuple, I...) = getindex(t, IteratorsMD.flatten(I)...)
     end
 end
 # But we can speed up LinearSlow arrays by reshaping them to the appropriate dimensionality:
-_maybe_reshape(::LinearFast, A::AbstractArray, I...) = A
-_maybe_reshape(::LinearSlow, A::AbstractVector, I...) = A
-@inline _maybe_reshape(::LinearSlow, A::AbstractArray, I...) = __maybe_reshape(A, index_ndims(I...))
-@inline __maybe_reshape{T,N}(A::AbstractArray{T,N}, ::NTuple{N}) = A
-@inline __maybe_reshape{N}(A::AbstractArray, ::NTuple{N}) = reshape(A, Val{N})
+@inline _maybe_reshape(l::LinearIndexing, A::AbstractArray, I...) = __maybe_reshape(l, A, index_ndims(I...))
+@inline __maybe_reshape{T,N}(::LinearSlow, A::AbstractArray{T,N}, ::NTuple{N}) = A
+@inline __maybe_reshape{T,N}(::LinearSlow, A::AbstractArray{T,N}, ::NTuple{1}) = reshape(A, Val{1})
+@inline __maybe_reshape{T,N}(::LinearFast, A::AbstractArray{T,N}, ::Any) = A
 
 @generated function _unsafe_getindex(::LinearIndexing, A::AbstractArray, I::Union{Real, AbstractArray}...)
     N = length(I)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -75,7 +75,6 @@ parentindexes(a::AbstractArray) = ntuple(i->OneTo(size(a,i)), ndims(a))
 # can make the number of effective indices not equal to length(I).
 _maybe_reshape_parent(A::AbstractArray, ::NTuple{1, Bool}) = reshape(A, Val{1})
 _maybe_reshape_parent{_,N}(A::AbstractArray{_,N}, ::NTuple{N, Bool}) = A
-_maybe_reshape_parent{N}(A::AbstractArray, ::NTuple{N, Bool}) = reshape(A, Val{N}) # TODO: DEPRECATE FOR #14770
 """
     view(A, inds...)
 

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -132,6 +132,11 @@ end
     val
 end
 
+# Add support for indexing into OffsetVectors with trailing 1s
+# These are required because OffsetVectors don't support sub2ind
+Base._to_linear_index(A::OffsetVector, I::Int...) = I[1] # TODO: REMOVE FOR #14770
+Base._to_linear_index(A::OffsetVector) = error("linear indexing is not defined for one-dimensional arrays")
+
 # Computing a shifted index (subtracting the offset)
 offset{N}(offsets::NTuple{N,Int}, inds::NTuple{N,Int}) = _offset((), offsets, inds)
 _offset(out, ::Tuple{}, ::Tuple{}) = out

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -526,7 +526,7 @@ import Base.==
 
 const global hashoffset = [UInt(190)]
 
-Base.hash(s::MyString) = hash(s.str) + hashoffset[]
+Base.hash(s::MyString) = hash(s.str) + hashoffset[1]
 Base.endof(s::MyString) = endof(s.str)
 Base.next(s::MyString, v::Int) = next(s.str, v)
 Base.isequal(a::MyString, b::MyString) = isequal(a.str, b.str)
@@ -559,7 +559,7 @@ let badKeys = [
     # Walk through all possible hash values (mod size of hash table)
     for offset = 0:1023
         d2 = Dict{MyString,Int}()
-        hashoffset[] = offset
+        hashoffset[1] = offset
         for i = 1:length(badKeys)
             d2[MyString(badKeys[i])] = i
         end
@@ -574,7 +574,7 @@ immutable MyInt <: Integer
     val::UInt
 end
 
-Base.hash(v::MyInt) = v.val + hashoffset[]
+Base.hash(v::MyInt) = v.val + hashoffset[1]
 Base.endof(v::MyInt) = endof(v.val)
 Base.next(v::MyInt, i::Int) = next(v.val, i)
 Base.isequal(a::MyInt, b::MyInt) = isequal(a.val, b.val)
@@ -589,7 +589,7 @@ let badKeys = UInt16[0xb800,0xa501,0xcdff,0x6303,0xe40a,0xcf0e,0xf3df,0xae99,0x9
     # Walk through all possible hash values (mod size of hash table)
     for offset = 0:1023
         d2 = Dict{MyInt, Int}()
-        hashoffset[] = offset
+        hashoffset[1] = offset
         for i = 1:length(badKeys)
             d2[MyInt(badKeys[i])] = i
         end


### PR DESCRIPTION
This deprecates generalized linear indexing, meaning that after this patch, the only two ways to index into an `AbstractArray{T,N}` is either with one index or with `N` indices.  This removes support for what I've called "partial linear indexing" (e.g., `rand(2,3,4)[1, 7]`) as well as trailing `1` indices (e.g., `(1:10)[2,1,1]`).

Note that until #18457 is merged, these deprecated definitions need to occur *before* the real definitions in order to get the method sorting right.

There are tons of deprecation warnings, and I need help in chasing them all down. Please feel free to push to this branch or open PRs targeted at it.  My computer is slowly chugging through the test suite and saving the warnings, but here's an initial list:

* [ ] **test/subarray.jl**: Many of these tests are explicitly designed to test this behavior; needs significant refactor or lots of reshapes.
* [ ] **test/abstractarray.jl**: Same as subarray.

-----

And then there are a bunch of places within the standard library that need refactored.  ~~I'll post the full depwarn log once I finally get to the end of the test suite, but here's an initial list~~.  [Here is the full log from make test](https://gist.github.com/mbauman/b25b1fb8fdc1e539265514c29e5a60ec). I modified depwarn to try and print where it thought the deprecation was coming from in an easy-to-grep-for way; that's how I've populated the list below.  So if something there doesn't make sense, you can refer to the full log and find the full stack trace for it. While there are thousands of warnings, it's not as bad as I thought it might be… It seems like many come from the same areas:

* [ ] .../test/arrayops.jl at 171
* [ ] .../test/dsp.jl at 10
* [ ] .../test/linalg/diagonal.jl at 9
* [ ] .../test/linalg/generic.jl at 148
* [ ] .../test/linalg/lu.jl at 31
* [ ] .../test/show.jl at 12
* [ ] .../test/show.jl at 422
* [ ] .../test/show.jl at 512
* [ ] .../test/show.jl at 539
* [ ] .../test/show.jl at 619
* [ ] .../test/sparse/umfpack.jl at 15
* [ ] abstractarray.jl:995
* [ ] arnoldi.jl:302
* [ ] arnoldi.jl:303
* [ ] arrayops.jl:328 [inlined]
* [ ] dsp.jl:19
* [ ] dsp.jl:71
* [ ] dsp.jl:73
* [ ] error.jl:88
* [ ] error.jl:99 [inlined] (may be libgit/error.jl)
* [ ] factorization.jl:48
* [ ] factorization.jl:60
* [ ] generic.jl:757
* [ ] givens.jl:10
* [x] linalg.jl:85
* [ ] linalg.jl:869
* [x] linalg.jl:96
* [ ] matmul.jl:200
* [ ] matmul.jl:225
* [ ] matmul.jl:379
* [ ] matmul.jl:387
* [ ] matmul.jl:83
* [ ] qr.jl:367
* [ ] qr.jl:409
* [ ] reference.jl:179
* [ ] repository.jl:11
* [x] sparse.jl:1127 [inlined]
* [x] sparse.jl:155 [inlined]
* [ ] sparse.jl:1565 [inlined]
* [ ] sparse.jl:1567 [inlined]
* [x] sparse.jl:157 [inlined]
* [x] sparse.jl:163 [inlined]
* [x] sparse.jl:165 [inlined]
* [x] triangular.jl:1559
* [x] umfpack.jl:400
* [x] umfpack.jl:419