### PR TITLE
Fix A[c|t]_ldiv_B!{T<:Complex}(X::StridedMatrix{T}, lu::UmfpackLU{Float64}, B::StridedMatrix{T}) (and similar) method error

### DIFF
--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -397,10 +397,9 @@ for (f!, umfpack) in ((:A_ldiv_B!, :UMFPACK_A),
             end
             return x
         end
-        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::StridedVector{T}) = $f!(b, lu, copy(b))
-        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::StridedMatrix{T}) = $f!(b, lu, copy(b))
+        $f!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::StridedVecOrMat{T}) = $f!(b, lu, copy(b))
 
-        function $f!{Tb<:Complex}(x::StridedVector{Tb}, lu::UmfpackLU{Float64}, b::StridedVector{Tb})
+        function $f!{Tb<:Complex}(x::StridedVecOrMat{Tb}, lu::UmfpackLU{Float64}, b::StridedVecOrMat{Tb})
             m, n = size(x, 1), size(x, 2)
             if n != size(b, 2)
                 throw(DimensionMismatch("in and output arrays must have the same number of columns"))
@@ -416,7 +415,7 @@ for (f!, umfpack) in ((:A_ldiv_B!, :UMFPACK_A),
             end
             return x
         end
-        $f!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::StridedVector{Tb}) = $f!(b, lu, copy(b))
+        $f!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::StridedVecOrMat{Tb}) = $f!(b, lu, copy(b))
     end
 end
 

--- a/test/sparse/umfpack.jl
+++ b/test/sparse/umfpack.jl
@@ -143,3 +143,15 @@ let
     F = lufact(A)
     @test F[:p] == [3 ; 4 ; 2 ; 1]
 end
+
+# Test that A[c|t]_ldiv_B!{T<:Complex}(X::StridedMatrix{T}, lu::UmfpackLU{Float64},
+# B::StridedMatrix{T}) works as expected.
+let N = 10, p = 0.5
+    A = N*speye(N) + sprand(N, N, p)
+    X = zeros(Complex{Float64}, N, N)
+    B = complex.(rand(N, N), rand(N, N))
+    luA, lufA = lufact(A), lufact(Array(A))
+    @test A_ldiv_B!(copy(X), luA, B) ≈ A_ldiv_B!(copy(X), lufA, B)
+    @test At_ldiv_B!(copy(X), luA, B) ≈ At_ldiv_B!(copy(X), lufA, B)
+    @test Ac_ldiv_B!(copy(X), luA, B) ≈ Ac_ldiv_B!(copy(X), lufA, B)
+end


### PR DESCRIPTION
Calling `A[c|t]_ldiv_B!{T<:Complex}(X::StridedMatrix{T}, lu::UmfpackLU{Float64}, B::StridedMatrix{T})` fails due to [the relevant signature](https://github.com/JuliaLang/julia/blob/cf997039a4dfeb866fad162a2d58463f94658bfd/base/sparse/umfpack.jl#L403) being too tight:
```julia
julia> versioninfo()
Julia Version 0.6.0-dev.2102
Commit cf99703 (2017-01-15 04:45 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin15.6.0)
  CPU: Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, ivybridge)

julia> begin
                  N, p = 100, 0.1
                  A = N*speye(N) + sprand(N, N, p)
                  X = zeros(Complex{Float64}, N, N)
                  B = complex.(rand(N, N), rand(N, N))
                  luA = lufact(A)
              end;

julia> @which A_ldiv_B!(X, luA, B)
A_ldiv_B!(Y::Union{AbstractArray{T<:Any,1},AbstractArray{T<:Any,2}}, A::Factorization, B::Union{AbstractArray{T<:Any,1},AbstractArray{T<:Any,2}}) in Base.LinAlg at linalg/factorization.jl:55

julia> A_ldiv_B!(X, luA, B)
ERROR: MethodError: no method matching A_ldiv_B!(::Base.SparseArrays.UMFPACK.UmfpackLU{Float64,Int64}, ::Array{Complex{Float64},2})
Closest candidates are:
  A_ldiv_B!{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},S<:Union{Base.ReshapedArray{T,2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T,2},SubArray{T,2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}}(::LowerTriangular{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},S<:Union{Base.ReshapedArray{T,2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T,2},SubArray{T,2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}}, ::Union{Base.ReshapedArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},Base.ReshapedArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1},DenseArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2},SubArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L},SubArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}) at linalg/triangular.jl:443
  A_ldiv_B!{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},S<:Union{Base.ReshapedArray{T,2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T,2},SubArray{T,2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}}(::Base.LinAlg.UnitLowerTriangular{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},S<:Union{Base.ReshapedArray{T,2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T,2},SubArray{T,2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}}, ::Union{Base.ReshapedArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},Base.ReshapedArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1},DenseArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2},SubArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L},SubArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}) at linalg/triangular.jl:443
  A_ldiv_B!{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},S<:Union{Base.ReshapedArray{T,2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T,2},SubArray{T,2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}}(::UpperTriangular{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},S<:Union{Base.ReshapedArray{T,2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T,2},SubArray{T,2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}}, ::Union{Base.ReshapedArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},Base.ReshapedArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1},DenseArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2},SubArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},1,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L},SubArray{T<:Union{Complex{Float32},Complex{Float64},Float32,Float64},2,A<:Union{Base.ReshapedArray{T,N,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Int64,Range{Int64}},N}},L}}) at linalg/triangular.jl:443
  ...
Stacktrace:
 [1] A_ldiv_B!(::Array{Complex{Float64},2}, ::Base.SparseArrays.UMFPACK.UmfpackLU{Float64,Int64}, ::Array{Complex{Float64},2}) at ./linalg/factorization.jl:55
```
The same holds for the two-argument form `A[c|t]_ldiv_B!(luA, B)`. This pull request resolves the above issue. Best!