### PR TITLE
Return Any[] from broadcast() for empty input when no method applies

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -280,7 +280,10 @@ end
 eltypestuple(a) = (Base.@_pure_meta; Tuple{eltype(a)})
 eltypestuple(T::Type) = (Base.@_pure_meta; Tuple{Type{T}})
 eltypestuple(a, b...) = (Base.@_pure_meta; Tuple{eltypestuple(a).types..., eltypestuple(b...).types...})
-_broadcast_eltype(f, A, Bs...) = Base._return_type(f, eltypestuple(A, Bs...))
+function _broadcast_eltype(f, A, Bs...)
+    T = Base._return_type(f, eltypestuple(A, Bs...))
+    return T === Union{} ? Any : T
+end
 
 # broadcast methods that dispatch on the type of the final container
 @inline function broadcast_c(f, ::Type{Array}, A, Bs...)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -449,3 +449,14 @@ let
     @test broadcast(==, [1], AbstractArray) == BitArray([false])
     @test broadcast(==, 1, AbstractArray) == false
 end
+
+# Test that an Array{Any} is returned when an empty array is passed
+# and no function applies to the element type (#20033)
+let f(x::Float64) = true, f(x::Float64, y::Float64) = 2
+    @test isa(broadcast(f, Int[]), Vector{Any})
+    @test isa(map(f, Int[]), Vector{Any})
+
+    @test isa(broadcast(f, Int[], Int[]), Vector{Any})
+    @test isa(map(f, Int[], Int[]), Vector{Any})
+end
+


### PR DESCRIPTION
This is consistent with map().

This is one way of fixing https://github.com/JuliaLang/julia/issues/20033.