### PR TITLE
Move the deprecation of midpoints to 0.6 section,

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -592,10 +592,6 @@ function histrange{T<:Integer,N}(v::AbstractArray{T,N}, n::Integer)
     start:step:(start + nm1*step)
 end
 
-## midpoints of intervals
-midpoints(r::Range) = r[1:length(r)-1] + 0.5*step(r)
-midpoints(v::AbstractVector) = [0.5*(v[i] + v[i+1]) for i in 1:length(v)-1]
-
 ## hist ##
 function sturges(n)  # Sturges' formula
     depwarn("sturges(n) is deprecated, use StatsBase.sturges(n) instead.",:sturges)
@@ -1028,6 +1024,9 @@ export $
 
 @deprecate is (===)
 
+# midpoints of intervals
+@deprecate midpoints(r::Range) r[1:length(r)-1] + 0.5*step(r)
+@deprecate midpoints(v::AbstractVector) [0.5*(v[i] + v[i+1]) for i in 1:length(v)-1]
 
 @deprecate_binding Filter    Iterators.Filter
 @deprecate_binding Zip       Iterators.Zip

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2220,14 +2220,6 @@ unsigned without checking for negative values.
 unsigned
 
 """
-    midpoints(e)
-
-Compute the midpoints of the bins with edges `e`. The result is a vector/range of length
-`length(e) - 1`. Note: Julia does not ignore `NaN` values in the computation.
-"""
-midpoints
-
-"""
     reverseind(v, i)
 
 Given an index `i` in `reverse(v)`, return the corresponding index in `v` so that

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -886,7 +886,6 @@ export
     median!,
     median,
     middle,
-    midpoints,
     quantile!,
     quantile,
     std,

--- a/doc/src/stdlib/math.md
+++ b/doc/src/stdlib/math.md
@@ -232,7 +232,6 @@ Base.varm
 Base.middle
 Base.median
 Base.median!
-Base.midpoints
 Base.quantile
 Base.quantile!
 Base.cov

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -317,11 +317,6 @@ let tmp = linspace(1, 85, 100)
     @test cor(tmp, tmp2) <= 1.0
 end
 
-
-@test midpoints(1.0:1.0:10.0) == 1.5:1.0:9.5
-@test midpoints(1:10) == 1.5:9.5
-@test midpoints(Float64[1.0:1.0:10.0;]) == Float64[1.5:1.0:9.5;]
-
 @test quantile([1,2,3,4],0.5) == 2.5
 @test quantile([1,2,3,4],[0.5]) == [2.5]
 @test quantile([1., 3],[.25,.5,.75])[2] == median([1., 3])


### PR DESCRIPTION
and actually deprecate it - this was moved to deprecated.jl
in #16450, but not actually deprecated