### PR TITLE
fix return value of `typeinf_code` for `code == nothing`

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1936,7 +1936,7 @@ end
 function typeinf_code(method::Method, atypes::ANY, sparams::SimpleVector,
                       optimize::Bool, cached::Bool, params::InferenceParams)
     code = code_for_method(method, atypes, sparams, params.world)
-    code === nothing && return (nothing, Any)
+    code === nothing && return (nothing, nothing, Any)
     return typeinf_code(code::MethodInstance, optimize, cached, params)
 end
 function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -494,3 +494,9 @@ immutable MyType18457{T,F,G}<:AbstractMyType18457{T,F,G} end
 tpara18457{I}(::Type{AbstractMyType18457{I}}) = I
 tpara18457{A<:AbstractMyType18457}(::Type{A}) = tpara18457(supertype(A))
 @test tpara18457(MyType18457{true}) === true
+
+# Issue 20067
+@generated function foo20067{T <: Tuple}(::Type{T}, elements::Tuple)
+           :(T)
+end
+code_typed(DevNull, foo20067, (DataType, Tuple{Int, Int}))


### PR DESCRIPTION
Fixes #20067

@SimonDanisch what was the example that triggered this? Would be good as a test case.