### PR TITLE
change order of exponent for neg. matrix powers

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -309,7 +309,7 @@ kron(a::AbstractVector, b::AbstractVector)=vec(kron(reshape(a,length(a),1),resha
 kron(a::AbstractMatrix, b::AbstractVector)=kron(a,reshape(b,length(b),1))
 kron(a::AbstractVector, b::AbstractMatrix)=kron(reshape(a,length(a),1),b)
 
-^(A::AbstractMatrix, p::Integer) = p < 0 ? inv(A^-p) : Base.power_by_squaring(A,p)
+^(A::AbstractMatrix, p::Integer) = p < 0 ? inv(A)^-p : Base.power_by_squaring(A,p)
 
 function ^(A::AbstractMatrix, p::Number)
     if isinteger(p)


### PR DESCRIPTION
According to Higham-Lin [1], numerical accuracy is higher for the calculation `A^-k`, when `A` is a matrix and `k` a positive integer, if it is calculated as `(A^-1)^k`.

[1] [A Schur-Pade algorithm for fractional powers of a matrix](http://eprints.ma.man.ac.uk/1589/01/covered/MIMS_ep2010_91.pdf), SIAM J. Matrix Anal. & Appl., Vol 32/3 1056-1078
Section 6:
"Algorithm 6.1 [`A^-k = (A^k)^-1`] inverts `A^k`, which is potentially a much more ill conditioned matrix than `A`. Intuitively, Algorithm 6.2 [`A^-k = (A^-1)^k`] should therefore be preferred.
Section 9, Experiment 7: "Algorithms 6.2 ... clearly produce much more accurate results than Algorithm 6.1, as we expected."