### PR TITLE
Update code that detects short form function definitions to allow `where`

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -274,8 +274,18 @@ function findmetaarg(metaargs, sym)
     return 0
 end
 
+function is_short_function_def(ex)
+    ex.head == :(=) || return false
+    while length(ex.args) >= 1 && isa(ex.args[1], Expr)
+        (ex.args[1].head == :call) && return true
+        (ex.args[1].head == :where) || return false
+        ex = ex.args[1]
+    end
+    return false
+end
+
 function findmeta(ex::Expr)
-    if ex.head == :function || (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
+    if ex.head == :function || is_short_function_def(ex)
         body::Expr = ex.args[2]
         body.head == :block || error(body, " is not a block expression")
         return findmeta_block(ex.args)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -604,12 +604,20 @@
 (define (line-number-node s)
   `(line ,(input-port-line (ts:port s)) ,current-filename))
 
+(define (eventually-call ex)
+  (if (pair? ex)
+    (if (eq? (car ex) 'call)
+      #t
+      (if (eq? (car ex) 'where)
+        (eventually-call (cadr ex))
+        #f))
+    #f))
+
 ;; insert line/file for short-form function defs, otherwise leave alone
 (define (short-form-function-loc ex lno)
   (if (and (pair? ex)
            (eq? (car ex) '=)
-           (pair? (cadr ex))
-           (eq? (caadr ex) 'call))
+           (eventually-call (cadr ex)))
       `(= ,(cadr ex) (block (line ,lno ,current-filename) ,(caddr ex)))
       ex))
 

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -422,6 +422,10 @@ gpure(x::Irrational) = fpure(x)
 @test gpure() == gpure() == gpure()
 @test gpure(π) == gpure(π) == gpure(π)
 
+# Make sure @pure works for functions using the new syntax
+Base.@pure (fpure2(x::T) where T) = T
+@test which(fpure2, (Int64,)).source.pure
+
 # issue #10880
 function cat10880(a, b)
     Tuple{a.parameters..., b.parameters...}

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -928,3 +928,8 @@ end
 # issue #18754: parse ccall as a regular function
 @test parse("ccall([1], 2)[3]") == Expr(:ref, Expr(:call, :ccall, Expr(:vect, 1), 2), 3)
 @test parse("ccall(a).member") == Expr(:., Expr(:call, :ccall, :a), QuoteNode(:member))
+
+# Check that the body of a `where`-qualified short form function definition gets
+# a :block for its body
+short_where_call = :(f(x::T) where T = T)
+@test short_where_call.args[2].head == :block


### PR DESCRIPTION
Fixes #20075