### PR TITLE
RFC: Deprecate partial linear indexing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -224,6 +224,13 @@ Compiler/Runtime improvements
 Deprecated or removed
 ---------------------
 
+  * Linear indexing is now only supported when there is exactly one
+    non-cartesian index provided. Allowing a trailing index at dimension `d` to
+    linearly access the higher dimensions from array `A` (beyond `size(A, d)`)
+    has been deprecated as a stricter constraint during bounds checking.
+    Instead, `reshape` the array such that its dimensionality matches the
+    number of indices ([#20079]).
+
   * `isdefined(a::Array, i::Int)` has been deprecated in favor of `isassigned` ([#18346]).
 
   * `is` has been deprecated in favor of `===` (which used to be an alias for `is`) ([#17758]).

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -120,10 +120,10 @@ julia> length(A)
 60
 ```
 """
-length(t::AbstractArray) = prod(size(t))
-_length(A::AbstractArray) = prod(map(unsafe_length, indices(A))) # circumvent missing size
-_length(A) = length(A)
-endof(a::AbstractArray) = length(a)
+length(t::AbstractArray) = (@_inline_meta; prod(size(t)))
+_length(A::AbstractArray) = (@_inline_meta; prod(map(unsafe_length, indices(A)))) # circumvent missing size
+_length(A) = (@_inline_meta; length(A))
+endof(a::AbstractArray) = (@_inline_meta; length(a))
 first(a::AbstractArray) = a[first(eachindex(a))]
 
 """

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -73,7 +73,8 @@ function depwarn(msg, funcsym)
     nothing
 end
 
-function firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol)
+firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol) = firstcaller(bt, (funcsym,))
+function firstcaller(bt::Array{Ptr{Void},1}, funcsyms)
     # Identify the calling line
     i = 1
     while i <= length(bt)
@@ -83,7 +84,7 @@ function firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol)
             if lkup === StackTraces.UNKNOWN
                 continue
             end
-            if lkup.func == funcsym
+            if lkup.func in funcsyms
                 @goto found
             end
         end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -172,6 +172,12 @@ end  # IteratorsMD
 using .IteratorsMD
 
 ## Bounds-checking with CartesianIndex
+# Disallow linear indexing with CartesianIndex
+function checkbounds(::Type{Bool}, A::AbstractArray, i::Union{CartesianIndex, AbstractArray{C} where C <: CartesianIndex})
+    @_inline_meta
+    checkbounds_indices(Bool, indices(A), (i,))
+end
+
 @inline checkbounds_indices(::Type{Bool}, ::Tuple{}, I::Tuple{CartesianIndex,Vararg{Any}}) =
     checkbounds_indices(Bool, (), (I[1].I..., tail(I)...))
 @inline checkbounds_indices(::Type{Bool}, IA::Tuple{Any}, I::Tuple{CartesianIndex,Vararg{Any}}) =

--- a/src/array.c
+++ b/src/array.c
@@ -530,7 +530,7 @@ int jl_array_isdefined(jl_value_t **args0, int nargs)
 {
     assert(jl_is_array(args0[0]));
     jl_depwarn("`isdefined(a::Array, i::Int)` is deprecated, "
-               "use `isassigned(a, i)` instead", jl_symbol("isdefined"));
+               "use `isassigned(a, i)` instead", (jl_value_t*)jl_symbol("isdefined"));
 
     jl_array_t *a = (jl_array_t*)args0[0];
     jl_value_t **args = &args0[1];

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -394,6 +394,7 @@ static Function *expect_func;
 static Function *jldlsym_func;
 static Function *jlnewbits_func;
 static Function *jltypeassert_func;
+static Function *jldepwarnpi_func;
 #if JL_LLVM_VERSION < 30600
 static Function *jlpow_func;
 static Function *jlpowf_func;
@@ -5773,6 +5774,13 @@ static void init_julia_llvm_env(Module *m)
                                         Function::ExternalLinkage,
                                         "jl_typeassert", m);
     add_named_global(jltypeassert_func, &jl_typeassert);
+
+    std::vector<Type*> argsdepwarnpi(0);
+    argsdepwarnpi.push_back(T_size);
+    jldepwarnpi_func = Function::Create(FunctionType::get(T_void, argsdepwarnpi, false),
+                                        Function::ExternalLinkage,
+                                        "jl_depwarn_partial_indexing", m);
+    add_named_global(jldepwarnpi_func, &jl_depwarn_partial_indexing);
 
     queuerootfun = Function::Create(FunctionType::get(T_void, args_1ptr, false),
                                     Function::ExternalLinkage,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -817,7 +817,8 @@ STATIC_INLINE void *jl_get_frame_addr(void)
 }
 
 JL_DLLEXPORT jl_array_t *jl_array_cconvert_cstring(jl_array_t *a);
-void jl_depwarn(const char *msg, jl_sym_t *sym);
+void jl_depwarn(const char *msg, jl_value_t *sym);
+void jl_depwarn_partial_indexing(size_t n);
 
 int isabspath(const char *in);
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -16,10 +16,10 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, 2, 2, 2, 1) == true  # extra indices
 @test checkbounds(Bool, A, 2, 2, 2, 2) == false
 @test checkbounds(Bool, A, 1, 1)  == true       # partial linear indexing (PLI)
-@test checkbounds(Bool, A, 1, 12) == true       # PLI
-@test checkbounds(Bool, A, 5, 12) == true       # PLI
+# @test checkbounds(Bool, A, 1, 12) == true       # PLI
+# @test checkbounds(Bool, A, 5, 12) == true       # PLI
 @test checkbounds(Bool, A, 1, 13) == false      # PLI
-@test checkbounds(Bool, A, 6, 12) == false      # PLI
+# @test checkbounds(Bool, A, 6, 12) == false      # PLI
 
 # single CartesianIndex
 @test checkbounds(Bool, A, CartesianIndex((1, 1, 1))) == true
@@ -31,15 +31,15 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, CartesianIndex((5, 5, 3))) == false
 @test checkbounds(Bool, A, CartesianIndex((5, 4, 4))) == false
 @test checkbounds(Bool, A, CartesianIndex((1,))) == true
-@test checkbounds(Bool, A, CartesianIndex((60,))) == true
+# @test checkbounds(Bool, A, CartesianIndex((60,))) == true
 @test checkbounds(Bool, A, CartesianIndex((61,))) == false
 @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 1,))) == true
 @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 2,))) == false
 @test checkbounds(Bool, A, CartesianIndex((1, 1,)))  == true
-@test checkbounds(Bool, A, CartesianIndex((1, 12,))) == true
-@test checkbounds(Bool, A, CartesianIndex((5, 12,))) == true
+# @test checkbounds(Bool, A, CartesianIndex((1, 12,))) == true
+# @test checkbounds(Bool, A, CartesianIndex((5, 12,))) == true
 @test checkbounds(Bool, A, CartesianIndex((1, 13,))) == false
-@test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false
+# @test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false
 
 # mix of CartesianIndex and Int
 @test checkbounds(Bool, A, CartesianIndex((1,)), 1, CartesianIndex((1,))) == true
@@ -63,9 +63,10 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, 1:61) == false
 @test checkbounds(Bool, A, 2, 2, 2, 1:1) == true  # extra indices
 @test checkbounds(Bool, A, 2, 2, 2, 1:2) == false
-@test checkbounds(Bool, A, 1:5, 1:12) == true
+@test checkbounds(Bool, A, 1:5, 1:4) == true
+# @test checkbounds(Bool, A, 1:5, 1:12) == true
 @test checkbounds(Bool, A, 1:5, 1:13) == false
-@test checkbounds(Bool, A, 1:6, 1:12) == false
+# @test checkbounds(Bool, A, 1:6, 1:12) == false
 
 # logical
 @test checkbounds(Bool, A, trues(5), trues(4), trues(3)) == true
@@ -76,9 +77,9 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, trues(61)) == false
 @test checkbounds(Bool, A, 2, 2, 2, trues(1)) == true  # extra indices
 @test checkbounds(Bool, A, 2, 2, 2, trues(2)) == false
-@test checkbounds(Bool, A, trues(5), trues(12)) == true
+# @test checkbounds(Bool, A, trues(5), trues(12)) == true
 @test checkbounds(Bool, A, trues(5), trues(13)) == false
-@test checkbounds(Bool, A, trues(6), trues(12)) == false
+# @test checkbounds(Bool, A, trues(6), trues(12)) == false
 @test checkbounds(Bool, A, trues(5, 4, 3)) == true
 @test checkbounds(Bool, A, trues(5, 4, 2)) == false
 @test checkbounds(Bool, A, trues(5, 12)) == false
@@ -201,6 +202,7 @@ end
 TSlow{T}(::Type{T}, dims::Int...) = TSlow(T, dims)
 TSlow{T,N}(::Type{T}, dims::NTuple{N,Int}) = TSlow{T,N}(Dict{NTuple{N,Int}, T}(), dims)
 
+Base.convert{T,N  }(::Type{TSlow{T,N}}, X::TSlow{T,N}) = X
 Base.convert{T,N  }(::Type{TSlow     }, X::AbstractArray{T,N}) = convert(TSlow{T,N}, X)
 Base.convert{T,N,_}(::Type{TSlow{T  }}, X::AbstractArray{_,N}) = convert(TSlow{T,N}, X)
 Base.convert{T,N  }(::Type{TSlow{T,N}}, X::AbstractArray     ) = begin
@@ -236,7 +238,6 @@ Base.setindex!{T}(A::TSlow{T,4}, v, i1::Int, i2::Int, i3::Int, i4::Int) =
 Base.setindex!{T}(A::TSlow{T,5}, v, i1::Int, i2::Int, i3::Int, i4::Int, i5::Int) =
     (A.data[(i1,i2,i3,i4,i5)] = v)
 
-import Base: trailingsize
 const can_inline = Base.JLOptions().can_inline != 0
 function test_scalar_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     N = prod(shape)
@@ -245,7 +246,7 @@ function test_scalar_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     @test A == B
     # Test indexing up to 5 dimensions
     i=0
-    for i5 = 1:trailingsize(B, 5)
+    for i5 = 1:size(B, 5)
         for i4 = 1:size(B, 4)
             for i3 = 1:size(B, 3)
                 for i2 = 1:size(B, 2)
@@ -266,7 +267,7 @@ function test_scalar_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
         @test A[i1] == B[i1] == i
     end
     i=0
-    for i2 = 1:trailingsize(B, 2)
+    for i2 = 1:size(B, 2)
         for i1 = 1:size(B, 1)
             i += 1
             @test A[i1,i2] == B[i1,i2] == i
@@ -274,7 +275,7 @@ function test_scalar_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     end
     @test A == B
     i=0
-    for i3 = 1:trailingsize(B, 3)
+    for i3 = 1:size(B, 3)
         for i2 = 1:size(B, 2)
             for i1 = 1:size(B, 1)
                 i += 1
@@ -290,7 +291,7 @@ function test_scalar_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     D2 = T(Int, shape)
     D3 = T(Int, shape)
     i=0
-    for i5 = 1:trailingsize(B, 5)
+    for i5 = 1:size(B, 5)
         for i4 = 1:size(B, 4)
             for i3 = 1:size(B, 3)
                 for i2 = 1:size(B, 2)
@@ -322,20 +323,22 @@ function test_scalar_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     @test C == B == A
     C = T(Int, shape)
     i=0
-    for i2 = 1:trailingsize(C, 2)
-        for i1 = 1:size(C, 1)
+    C2 = reshape(C, Val{2})
+    for i2 = 1:size(C2, 2)
+        for i1 = 1:size(C2, 1)
             i += 1
-            C[i1,i2] = i
+            C2[i1,i2] = i
         end
     end
     @test C == B == A
     C = T(Int, shape)
     i=0
-    for i3 = 1:trailingsize(C, 3)
-        for i2 = 1:size(C, 2)
-            for i1 = 1:size(C, 1)
+    C3 = reshape(C, Val{3})
+    for i3 = 1:size(C3, 3)
+        for i2 = 1:size(C3, 2)
+            for i1 = 1:size(C3, 1)
                 i += 1
-                C[i1,i2,i3] = i
+                C3[i1,i2,i3] = i
             end
         end
     end
@@ -355,29 +358,29 @@ function test_vector_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     @test B[vec(idxs)] == A[vec(idxs)] == vec(idxs)
     @test B[:] == A[:] == collect(1:N)
     @test B[1:end] == A[1:end] == collect(1:N)
-    @test B[:,:] == A[:,:] == reshape(1:N, shape[1], prod(shape[2:end]))
-    @test B[1:end,1:end] == A[1:end,1:end] == reshape(1:N, shape[1], prod(shape[2:end]))
+    # @test B[:,:] == A[:,:] == reshape(1:N, shape[1], prod(shape[2:end]))
+    # @test B[1:end,1:end] == A[1:end,1:end] == reshape(1:N, shape[1], prod(shape[2:end]))
     # Test with containers that aren't Int[]
     @test B[[]] == A[[]] == []
     @test B[convert(Array{Any}, idxs)] == A[convert(Array{Any}, idxs)] == idxs
 
     # Test adding dimensions with matrices
     idx1 = rand(1:size(A, 1), 3)
-    idx2 = rand(1:Base.trailingsize(A, 2), 4, 5)
+    idx2 = rand(1:size(A, 2), 4, 5)
     @test B[idx1, idx2] == A[idx1, idx2] == reshape(A[idx1, vec(idx2)], 3, 4, 5) == reshape(B[idx1, vec(idx2)], 3, 4, 5)
     @test B[1, idx2] == A[1, idx2] == reshape(A[1, vec(idx2)], 4, 5) == reshape(B[1, vec(idx2)], 4, 5)
 
     # test removing dimensions with 0-d arrays
     idx0 = reshape([rand(1:size(A, 1))])
     @test B[idx0, idx2] == A[idx0, idx2] == reshape(A[idx0[], vec(idx2)], 4, 5) == reshape(B[idx0[], vec(idx2)], 4, 5)
-    @test B[reshape([end]), reshape([end])] == A[reshape([end]), reshape([end])] == reshape([A[end,end]]) == reshape([B[end,end]])
+    # @test B[reshape([end]), reshape([end])] == A[reshape([end]), reshape([end])] == reshape([A[end,end]]) == reshape([B[end,end]])
 
     # test logical indexing
     mask = bitrand(shape)
     @test B[mask] == A[mask] == B[find(mask)] == A[find(mask)] == find(mask)
     @test B[vec(mask)] == A[vec(mask)] == find(mask)
     mask1 = bitrand(size(A, 1))
-    mask2 = bitrand(Base.trailingsize(A, 2))
+    mask2 = bitrand(size(A, 2))
     @test B[mask1, mask2] == A[mask1, mask2] == B[find(mask1), find(mask2)]
     @test B[mask1, 1] == A[mask1, 1] == find(mask1)
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -16,10 +16,10 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, 2, 2, 2, 1) == true  # extra indices
 @test checkbounds(Bool, A, 2, 2, 2, 2) == false
 @test checkbounds(Bool, A, 1, 1)  == true       # partial linear indexing (PLI)
-# @test checkbounds(Bool, A, 1, 12) == true       # PLI
-# @test checkbounds(Bool, A, 5, 12) == true       # PLI
+# @test checkbounds(Bool, A, 1, 12) == false       # PLI TODO: Re-enable after partial linear indexing deprecation
+# @test checkbounds(Bool, A, 5, 12) == false       # PLI TODO: Re-enable after partial linear indexing deprecation
 @test checkbounds(Bool, A, 1, 13) == false      # PLI
-# @test checkbounds(Bool, A, 6, 12) == false      # PLI
+# @test checkbounds(Bool, A, 6, 12) == false      # PLI TODO: Re-enable after partial linear indexing deprecation
 
 # single CartesianIndex
 @test checkbounds(Bool, A, CartesianIndex((1, 1, 1))) == true
@@ -31,15 +31,15 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, CartesianIndex((5, 5, 3))) == false
 @test checkbounds(Bool, A, CartesianIndex((5, 4, 4))) == false
 @test checkbounds(Bool, A, CartesianIndex((1,))) == true
-# @test checkbounds(Bool, A, CartesianIndex((60,))) == true
+# @test checkbounds(Bool, A, CartesianIndex((60,))) == false # TODO: Re-enable after partial linear indexing deprecation
 @test checkbounds(Bool, A, CartesianIndex((61,))) == false
 @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 1,))) == true
 @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 2,))) == false
 @test checkbounds(Bool, A, CartesianIndex((1, 1,)))  == true
-# @test checkbounds(Bool, A, CartesianIndex((1, 12,))) == true
-# @test checkbounds(Bool, A, CartesianIndex((5, 12,))) == true
+# @test checkbounds(Bool, A, CartesianIndex((1, 12,))) == false # TODO: Re-enable after partial linear indexing deprecation
+# @test checkbounds(Bool, A, CartesianIndex((5, 12,))) == false # TODO: Re-enable after partial linear indexing deprecation
 @test checkbounds(Bool, A, CartesianIndex((1, 13,))) == false
-# @test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false
+# @test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false # TODO: Re-enable after partial linear indexing deprecation
 
 # mix of CartesianIndex and Int
 @test checkbounds(Bool, A, CartesianIndex((1,)), 1, CartesianIndex((1,))) == true
@@ -64,9 +64,9 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, 2, 2, 2, 1:1) == true  # extra indices
 @test checkbounds(Bool, A, 2, 2, 2, 1:2) == false
 @test checkbounds(Bool, A, 1:5, 1:4) == true
-# @test checkbounds(Bool, A, 1:5, 1:12) == true
+# @test checkbounds(Bool, A, 1:5, 1:12) == false # TODO: Re-enable after partial linear indexing deprecation
 @test checkbounds(Bool, A, 1:5, 1:13) == false
-# @test checkbounds(Bool, A, 1:6, 1:12) == false
+# @test checkbounds(Bool, A, 1:6, 1:12) == false # TODO: Re-enable after partial linear indexing deprecation
 
 # logical
 @test checkbounds(Bool, A, trues(5), trues(4), trues(3)) == true
@@ -77,9 +77,9 @@ A = rand(5,4,3)
 @test checkbounds(Bool, A, trues(61)) == false
 @test checkbounds(Bool, A, 2, 2, 2, trues(1)) == true  # extra indices
 @test checkbounds(Bool, A, 2, 2, 2, trues(2)) == false
-# @test checkbounds(Bool, A, trues(5), trues(12)) == true
+# @test checkbounds(Bool, A, trues(5), trues(12)) == false # TODO: Re-enable after partial linear indexing deprecation
 @test checkbounds(Bool, A, trues(5), trues(13)) == false
-# @test checkbounds(Bool, A, trues(6), trues(12)) == false
+# @test checkbounds(Bool, A, trues(6), trues(12)) == false # TODO: Re-enable after partial linear indexing deprecation
 @test checkbounds(Bool, A, trues(5, 4, 3)) == true
 @test checkbounds(Bool, A, trues(5, 4, 2)) == false
 @test checkbounds(Bool, A, trues(5, 12)) == false
@@ -358,8 +358,8 @@ function test_vector_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     @test B[vec(idxs)] == A[vec(idxs)] == vec(idxs)
     @test B[:] == A[:] == collect(1:N)
     @test B[1:end] == A[1:end] == collect(1:N)
-    # @test B[:,:] == A[:,:] == reshape(1:N, shape[1], prod(shape[2:end]))
-    # @test B[1:end,1:end] == A[1:end,1:end] == reshape(1:N, shape[1], prod(shape[2:end]))
+    # @test B[:,:] == A[:,:] == reshape(1:N, shape[1], prod(shape[2:end])) # TODO: Re-enable after partial linear indexing deprecation
+    # @test B[1:end,1:end] == A[1:end,1:end] == reshape(1:N, shape[1], prod(shape[2:end])) # TODO: Re-enable after partial linear indexing deprecation
     # Test with containers that aren't Int[]
     @test B[[]] == A[[]] == []
     @test B[convert(Array{Any}, idxs)] == A[convert(Array{Any}, idxs)] == idxs
@@ -373,7 +373,7 @@ function test_vector_indexing{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     # test removing dimensions with 0-d arrays
     idx0 = reshape([rand(1:size(A, 1))])
     @test B[idx0, idx2] == A[idx0, idx2] == reshape(A[idx0[], vec(idx2)], 4, 5) == reshape(B[idx0[], vec(idx2)], 4, 5)
-    # @test B[reshape([end]), reshape([end])] == A[reshape([end]), reshape([end])] == reshape([A[end,end]]) == reshape([B[end,end]])
+    # @test B[reshape([end]), reshape([end])] == A[reshape([end]), reshape([end])] == reshape([A[end,end]]) == reshape([B[end,end]]) # TODO: Re-enable after partial linear indexing deprecation
 
     # test logical indexing
     mask = bitrand(shape)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -221,7 +221,7 @@ end
     @test A[2:6] == [2:6;]
     @test A[1:3,2,2:4] == cat(2,46:48,86:88,126:128)
     @test A[:,7:-3:1,5] == [191 176 161; 192 177 162; 193 178 163; 194 179 164; 195 180 165]
-    @test A[:,3:9] == reshape(11:45,5,7)
+    @test reshape(A, Val{2})[:,3:9] == reshape(11:45,5,7)
     rng = (2,2:3,2:2:5)
     tmp = zeros(Int,map(maximum,rng)...)
     tmp[rng...] = A[rng...]
@@ -255,7 +255,7 @@ end
     B[4,[2,3]] = 7
     @test B == [0 23 1 24 0; 11 12 13 14 15; 0 21 3 22 0; 0 7 7 0 0]
 
-    @test isequal(reshape(1:27, 3, 3, 3)[1,:], [1,  4,  7,  10,  13,  16,  19,  22,  25])
+    @test isequal(reshape(reshape(1:27, 3, 3, 3), Val{2})[1,:], [1,  4,  7,  10,  13,  16,  19,  22,  25])
 
     a = [3, 5, -7, 6]
     b = [4, 6, 2, -7, 1]
@@ -1360,11 +1360,13 @@ end
         @test a[:, [CartesianIndex()], :, :] == (@view a[:, [CartesianIndex()], :, :]) == reshape(a, 3, 1, 4, 5)
         @test a[:, :, [CartesianIndex()], :] == (@view a[:, :, [CartesianIndex()], :]) == reshape(a, 3, 4, 1, 5)
         @test a[:, :, :, [CartesianIndex()]] == (@view a[:, :, :, [CartesianIndex()]]) == reshape(a, 3, 4, 5, 1)
-        @test a[[CartesianIndex()], :, :]    == (@view a[[CartesianIndex()], :, :])    == reshape(a, 1, 3, 20)
-        @test a[:, [CartesianIndex()], :]    == (@view a[:, [CartesianIndex()], :])    == reshape(a, 3, 1, 20)
-        @test a[:, :, [CartesianIndex()]]    == (@view a[:, :, [CartesianIndex()]])    == reshape(a, 3, 20, 1)
-        @test a[[CartesianIndex()], :]       == (@view a[[CartesianIndex()], :])       == reshape(a, 1, 60)
-        @test a[:, [CartesianIndex()]]       == (@view a[:, [CartesianIndex()]])       == reshape(a, 60, 1)
+        a2 = reshape(a, Val{2})
+        @test a2[[CartesianIndex()], :, :]   == (@view a2[[CartesianIndex()], :, :])   == reshape(a, 1, 3, 20)
+        @test a2[:, [CartesianIndex()], :]   == (@view a2[:, [CartesianIndex()], :])   == reshape(a, 3, 1, 20)
+        @test a2[:, :, [CartesianIndex()]]   == (@view a2[:, :, [CartesianIndex()]])   == reshape(a, 3, 20, 1)
+        a1 = reshape(a, Val{1})
+        @test a1[[CartesianIndex()], :]      == (@view a1[[CartesianIndex()], :])      == reshape(a, 1, 60)
+        @test a1[:, [CartesianIndex()]]      == (@view a1[:, [CartesianIndex()]])      == reshape(a, 60, 1)
 
         @test_throws BoundsError a[[CartesianIndex(1,5),CartesianIndex(2,4)],3:3]
         @test_throws BoundsError a[1:4, [CartesianIndex(1,3),CartesianIndex(2,4)]]

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -485,7 +485,7 @@ Y = 4:-1:1
 @test X[1:end] == @view X[1:end]
 @test X[1:end-3] == @view X[1:end-3]
 @test X[1:end,2,2] == @view X[1:end,2,2]
-# @test X[1,1:end-2] == @view X[1,1:end-2]
+# @test X[1,1:end-2] == @view X[1,1:end-2] # TODO: Re-enable after partial linear indexing deprecation
 @test X[1,2,1:end-2] == @view X[1,2,1:end-2]
 @test X[1,2,Y[2:end]] == @view X[1,2,Y[2:end]]
 @test X[1:end,2,Y[2:end]] == @view X[1:end,2,Y[2:end]]

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -46,6 +46,9 @@ ensure_iterable(::Tuple{}) = ()
 ensure_iterable(t::Tuple{Union{Number, CartesianIndex}, Vararg{Any}}) = ((t[1],), ensure_iterable(Base.tail(t))...)
 ensure_iterable(t::Tuple{Any, Vararg{Any}}) = (t[1], ensure_iterable(Base.tail(t))...)
 
+index_ndims(t::Tuple) = tup2val(Base.index_ndims(t))
+tup2val{N}(::NTuple{N}) = Val{N}
+
 # To avoid getting confused by manipulations that are implemented for SubArrays,
 # it's good to copy the contents to an Array. This version protects against
 # `similar` ever changing its meaning.
@@ -127,9 +130,8 @@ test_mixed{T}(::AbstractArray{T,1}, ::Array) = nothing
 test_mixed{T}(::AbstractArray{T,2}, ::Array) = nothing
 test_mixed(A, B::Array) = _test_mixed(A, reshape(B, size(A)))
 function _test_mixed(A::ANY, B::ANY)
-    L = length(A)
     m = size(A, 1)
-    n = div(L, m)
+    n = size(A, 2)
     isgood = true
     for j = 1:n, i = 1:m
         if A[i,j] != B[i,j]
@@ -224,9 +226,11 @@ end
 function runviews(SB::AbstractArray, indexN, indexNN, indexNNN)
     @assert ndims(SB) > 2
     for i3 in indexN, i2 in indexN, i1 in indexN
+        ndims(SB) > 3 && i3 isa Colon && continue # TODO: Re-enable once Colon no longer spans partial trailing dimensions
         runsubarraytests(SB, i1, i2, i3)
     end
-    for i2 in indexNN, i1 in indexN
+    for i2 in indexN, i1 in indexN
+        i2 isa Colon && continue # TODO: Re-enable once Colon no longer spans partial trailing dimensions
         runsubarraytests(SB, i1, i2)
     end
     for i1 in indexNNN
@@ -272,9 +276,15 @@ end
 # with the exception of Int-slicing
 oindex = (:, 6, 3:7, reshape([12]), [8,4,6,12,5,7], [3:7 1:5 2:6 4:8 5:9])
 
+_ndims{T,N}(::AbstractArray{T,N}) = N
+_ndims(x) = 1
+
 if testfull
     let B = copy(reshape(1:13^3, 13, 13, 13))
         for o3 in oindex, o2 in oindex, o1 in oindex
+            if (o3 isa Colon && (_ndims(o1) + _ndims(o2) != 2))
+                continue # TODO: remove once Colon no longer spans partial trailing dimensions
+            end
             viewB = view(B, o1, o2, o3)
             runviews(viewB, index5, index25, index125)
         end
@@ -298,8 +308,7 @@ if !testfull
                      (CartesianIndex(13,6),[8,4,6,12,5,7]),
                      (1,:,view(1:13,[9,12,4,13,1])),
                      (view(1:13,[9,12,4,13,1]),2:6,4),
-                     ([1:5 2:6 3:7 4:8 5:9], :, 3),
-                     (:, [46:-1:42 88:-1:84 22:-1:18 49:-1:45 8:-1:4]))
+                     ([1:5 2:6 3:7 4:8 5:9], :, 3))
             runsubarraytests(B, oind...)
             viewB = view(B, oind...)
             runviews(viewB, index5, index25, index125)
@@ -476,7 +485,7 @@ Y = 4:-1:1
 @test X[1:end] == @view X[1:end]
 @test X[1:end-3] == @view X[1:end-3]
 @test X[1:end,2,2] == @view X[1:end,2,2]
-@test X[1,1:end-2] == @view X[1,1:end-2]
+# @test X[1,1:end-2] == @view X[1,1:end-2]
 @test X[1,2,1:end-2] == @view X[1,2,1:end-2]
 @test X[1,2,Y[2:end]] == @view X[1,2,Y[2:end]]
 @test X[1:end,2,Y[2:end]] == @view X[1:end,2,Y[2:end]]


### PR DESCRIPTION
This is the tiniest of scalpels compared to the chainsaw that was #20040.  This *only* deprecates the most offensive behavior, that is, the "linearization" of dimensions beyond the first.  To be more specific, this means that it's still ok to index a three dimensional array with two indices.  That second index, though, now cannot exceed `size(A, 2)`.  For indices between `size(A, 2)` and `trailingsize(A, 2)`, this will now throw a warning.

After this deprecation goes through, we'll be able to change the behavior of `end` and `:` such that they no longer call `trailingsize`. But for now, indexing `rand(2,3,4)[1, end]` and `rand(2,3,4)[1, :]` will throw a warning.

This is rather inline with allowing trailing singleton dimensions.  When you index a three-dimensional array with only two indices, you're implicitly treating it as a matrix, with an implicit `1` in the third dimension.  This is not terribly unlike indexing a one-dimensional array with a trailing singleton dimension to treat it as a matrix.

I don't have much more time to spend on this, but the deprecation fixes required here are much more contained.  In fact, I believe they're entirely limited to `test/subarray.jl`, `test/arrayops.jl` and `test/abstractarray.jl`.