### PR TITLE
RFC/WIP: "for-loop" compliant @parallel for [ci skip]

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -80,6 +80,7 @@ export
     ObjectIdDict,
     OrdinalRange,
     Pair,
+    ParallelAccumulator,
     PartialQuickSort,
     PollingFileWatcher,
     QuickSort,
@@ -1359,6 +1360,7 @@ export
     @threadcall,
 
     # multiprocessing
+    @accumulate,
     @spawn,
     @spawnat,
     @fetch,


### PR DESCRIPTION
This addresses some of the concerns with `@parallel` as discussed at https://github.com/JuliaLang/julia/issues/19578 in a different manner.

`@parallel for` differs from a regular for-loop by
- implementing a reducer functionality
- treating the last line in the body as the value to be reduced
- returning before the loop completes execution (non-reducer case)
- folks are used to looping over local arrays and expect them to be updated. This only works with shared arrays.   

This PR:
- deprecates the reducer mode of `@parallel for`
- provides a way for the user to explicitly specify accumulators and use them in the main body
- can wait on the accumulator(s)

The syntax is a bit more verbose, but there is much lesser scope for confusion or misplaced expectations.

```
@parallel reducer for x in unit_range
  body
end
```

will now be written as 

```
acc = ParallelAccumulator(reducer, length)
@accumulate acc @parallel for x in unit_range
  body
  push!(acc, iteration_value)
end
result = wait(acc)
```

Multiple accumulators can also be specified as a vector  
```
a1 = ParallelAccumulator{Int}(+, 10)
a2 = ParallelAccumulator{Int}(*, 10)
@accumulate [a1,a2] @parallel for i in 1:10
  push!(a1, i)
  push!(a2, i)
end
results = [wait(a1), wait(a2)]
```

Updating shared arrays work as before, there is no need for ParallelAccumulators. However, ParallelAccumulators can be used in multi-node scenarios which shared memory cannot address.

As before the input range is partitioned across workers, local reductions performed with a final reduction on the caller.

I feel this syntax and loop behavior is more in-line with a regular for-loop. Updating arrays from the body is still not allowed (except if they are shared of course). ParallelAccumulators does cover that need.

- New exports : `ParallelAccumulator`, `@accumulate`
- `wait(::ParallelAccumulator)` - waits for and returns value of distributed computation
- `ParallelAccumulator(reducer, length)` - reducer function, count of values to be reduced over
- `push!(accumulator, value)` - applies reducer over value, stores the result. Local `ParallelAccumulator` push results to the caller only once (when local range iteration is complete).

Feedback on the overall API and suggestions towards syntax, bikeshedding names are welcome.

Note that with this final result of both 
`@accumulate acc for-loop` and `@accumulate acc @parallel for-loop` is the same as long as the loop only returns data via accumulators
    