### PR TITLE
Misc tests for issues fixed by jb/subtype

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -78,15 +78,16 @@ g11840{T<:Tuple}(sig::Type{T}) = 3
 
 g11840b(::DataType) = 1
 g11840b(::Type) = 2
-# FIXME: how to compute that the guard entry is still required,
-# even though Type{Vector} ∩ DataType = Bottom and this method would set cache_with_orig = true
-#g11840b{T<:Tuple}(sig::Type{T}) = 3
+# FIXME (needs a test): how to compute that the guard entry is still required,
+# even though Type{Vector} ∩ DataType = Bottom and this method would set
+# cache_with_orig = true
+g11840b{T<:Tuple}(sig::Type{T}) = 3
 @test g11840b(Vector) == 2
 @test g11840b(Vector.body) == 1
 @test g11840b(Vector) == 2
 @test g11840b(Vector.body) == 1
-#@test g11840b(Tuple) == 3
-#@test g11840b(TT11840) == 3
+@test g11840b(Tuple) == 3
+@test g11840b(TT11840) == 3
 
 h11840(::DataType) = '1'
 h11840(::Type) = '2'

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -827,5 +827,27 @@ test_intersection()
 test_properties()
 test_intersection_properties()
 
+
 # issue #20121
 @test NTuple{170,Matrix{Int}} <: (Tuple{Vararg{Union{Array{T,1},Array{T,2},Array{T,3}}}} where T)
+
+# Issue #12580
+abstract AbstractMyType12580{T}
+immutable MyType12580{T}<:AbstractMyType12580{T} end
+tpara{A<:AbstractMyType12580}(::Type{A}) = tpara(supertype(A))
+tpara{I}(::Type{AbstractMyType12580{I}}) = I
+@test tpara(MyType12580{true})
+
+# Issue #18348
+f18348{T<:Any}(::Type{T}, x) = 1
+f18348{T<:Any}(::Type{T}, x::T) = 2
+@test length(methods(f18348, Tuple{Type{Any},Any})) == 1
+
+# Issue #13165
+@test Symmetric{Float64,Matrix{Float64}} <: LinAlg.RealHermSymComplexHerm
+@test Hermitian{Float64,Matrix{Float64}} <: LinAlg.RealHermSymComplexHerm
+@test Hermitian{Complex{Float64},Matrix{Complex{Float64}}} <: LinAlg.RealHermSymComplexHerm
+
+# Issue #12721
+f12721{T<:Type{Int}}(::T) = true
+@test_throws MethodError f12721(Float64)


### PR DESCRIPTION
Added misc tests referenced in #19998

Added tests for issues #12580, #18348, #13165, #11803, #12721.  I placed those in `inference.jl`, is that correct or should I move them?

Enabled tests for #11840 (cc: @vtjnash)