### PR TITLE
fix some inference and method lookup issues

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -83,6 +83,22 @@ function rewrap_unionall(t::ANY, u::ANY)
     return UnionAll(u.var, rewrap_unionall(t, u.body))
 end
 
+# replace TypeVars in all enclosing UnionAlls with fresh TypeVars
+function rename_unionall(u::ANY)
+    if !isa(u,UnionAll)
+        return u
+    end
+    body = rename_unionall(u.body)
+    if body === u.body
+        body = u
+    else
+        body = UnionAll(u.var, body)
+    end
+    var = u.var::TypeVar
+    nv = TypeVar(var.name, var.lb, var.ub)
+    return UnionAll(nv, body{nv})
+end
+
 const _va_typename = Vararg.body.body.name
 function isvarargtype(t::ANY)
     t = unwrap_unionall(t)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -784,7 +784,13 @@ static jl_value_t *get_fieldtype(jl_value_t *t, jl_value_t *f)
     int field_index;
     if (jl_is_long(f)) {
         field_index = jl_unbox_long(f) - 1;
-        if (field_index < 0 || field_index >= jl_field_count(st))
+        int nf = jl_field_count(st);
+        if (nf > 0 && field_index >= nf-1 && st->name == jl_tuple_typename) {
+            jl_value_t *ft = jl_field_type(st, nf-1);
+            if (jl_is_vararg_type(ft))
+                return jl_unwrap_vararg(ft);
+        }
+        if (field_index < 0 || field_index >= nf)
             jl_bounds_error(t, f);
     }
     else {

--- a/src/dump.c
+++ b/src/dump.c
@@ -2885,7 +2885,7 @@ jl_method_instance_t *jl_recache_method_instance(jl_method_instance_t *li, size_
     jl_datatype_t *argtypes = (jl_datatype_t*)li->specTypes;
     jl_set_typeof(li, (void*)(intptr_t)0x40); // invalidate the old value to help catch errors
     jl_svec_t *env = jl_emptysvec;
-    jl_value_t *ti = jl_type_intersection_matching((jl_value_t*)argtypes, (jl_value_t*)m->sig, &env);
+    jl_value_t *ti = jl_type_intersection_env((jl_value_t*)argtypes, (jl_value_t*)m->sig, &env);
     //assert(ti != jl_bottom_type); (void)ti;
     if (ti == jl_bottom_type)
         env = jl_emptysvec; // the intersection may fail now if the type system had made an incorrect subtype env in the past

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -335,7 +335,8 @@ jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np);
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p);
 JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
 void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr);
-jl_value_t *jl_type_intersection_matching(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
+jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, int *issubty);
+jl_value_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
 JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals);
 jl_value_t *jl_substitute_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val);
@@ -794,10 +795,9 @@ struct typemap_intersection_env {
     // output values
     jl_value_t *ti; // intersection type
     jl_svec_t *env; // intersection env (initialize to null to perform intersection without an environment)
+    int issubty;    // if `a <: b` is true in `intersect(a,b)`
 };
 int jl_typemap_intersection_visitor(union jl_typemap_t a, int offs, struct typemap_intersection_env *closure);
-
-jl_value_t *jl_lookup_match(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
 
 unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *field_type);
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1358,6 +1358,11 @@ end
 import Base: promote_rule
 promote_rule{T,T2,S,S2}(A::Type{SIQ{T,T2}},B::Type{SIQ{S,S2}}) = SIQ{promote_type(T,S)}
 @test_throws ErrorException promote_type(SIQ{Int},SIQ{Float64})
+f4731{T}(x::T...) = 0
+f4731(x...) = ""
+g4731() = f4731()
+@test f4731() == ""
+@test g4731() == ""
 
 # issue #4675
 f4675(x::StridedArray...) = 1
@@ -4428,7 +4433,7 @@ gc_enable(true)
 
 # issue #18710
 bad_tvars{T}() = 1
-@test isa(@which(bad_tvars()), Method)
+@test_throws ErrorException @which(bad_tvars())
 @test_throws MethodError bad_tvars()
 
 # issue #19059 - test for lowering of `let` with assignment not adding Box in simple cases

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -322,14 +322,12 @@ f16530a(c) = fieldtype(Foo16530a, c)
 f16530b() = fieldtype(Foo16530b, :c)
 f16530b(c) = fieldtype(Foo16530b, c)
 
-let T = Array{Tuple{Vararg{Float64,dim}}, 1} where dim,
-    TTlim = Type{_} where _<:T
-
+let T = Vector{Tuple{Vararg{Float64,dim}}} where dim
     @test f16530a() == T
     @test f16530a(:c) == T
-    @test Base.return_types(f16530a, ()) == Any[TTlim]
-    @test Base.return_types(f16530b, ()) == Any[TTlim]
-    @test Base.return_types(f16530b, (Symbol,)) == Any[TTlim]
+    @test Base.return_types(f16530a, ()) == Any[Type{T}]
+    @test Base.return_types(f16530b, ()) == Any[Type{T}]
+    @test Base.return_types(f16530b, (Symbol,)) == Any[Type{T}]
 end
 @test f16530a(:d) == Vector
 
@@ -346,7 +344,7 @@ let T1 = Tuple{Int, Float64},
     @test f18037(2) === T2
 
     @test Base.return_types(f18037, ()) == Any[Type{T1}]
-    @test Base.return_types(f18037, (Int,)) == Any[Type{T} where T<:Tuple{Int, AbstractFloat}]
+    @test Base.return_types(f18037, (Int,)) == Any[Union{Type{T1},Type{T2}}]
 end
 
 # issue #18015
@@ -485,6 +483,20 @@ function maybe_vararg_tuple_2()
     Tuple{x}
 end
 @test Type{Tuple{Vararg{Int}}} <: Base.return_types(maybe_vararg_tuple_2, ())[1]
+
+# inference of `fieldtype`
+type UndefField__
+    x::Union{}
+end
+f_infer_undef_field() = fieldtype(UndefField__, :x)
+@test Base.return_types(f_infer_undef_field, ()) == Any[Type{Union{}}]
+@test f_infer_undef_field() === Union{}
+
+type HasAbstractlyTypedField
+    x::Union{Int,String}
+end
+f_infer_abstract_fieldtype() = fieldtype(HasAbstractlyTypedField, :x)
+@test Base.return_types(f_infer_abstract_fieldtype, ()) == Any[Type{Union{Int,String}}]
 
 # Issue 19641
 foo19641() = let a = 1.0

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -470,6 +470,22 @@ function g19348(x)
 end
 test_inferred_static(@code_typed g19348((1, 2.0)))
 
+# issue #5575
+f5575() = zeros(Type[Float64][1], 1)
+@test Base.return_types(f5575, ())[1] == Vector
+
+# make sure Tuple{unknown} handles the possibility that `unknown` is a Vararg
+function maybe_vararg_tuple_1()
+    x = Any[Vararg{Int}][1]
+    Tuple{x}
+end
+@test Type{Tuple{Vararg{Int}}} <: Base.return_types(maybe_vararg_tuple_1, ())[1]
+function maybe_vararg_tuple_2()
+    x = Type[Vararg{Int}][1]
+    Tuple{x}
+end
+@test Type{Tuple{Vararg{Int}}} <: Base.return_types(maybe_vararg_tuple_2, ())[1]
+
 # Issue 19641
 foo19641() = let a = 1.0
     Core.Inference.return_type(x -> x + a, Tuple{Float64})

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -300,6 +300,10 @@ tlayout = TLayout(5,7,11)
 @test_throws BoundsError fieldname(TLayout, 4)
 @test_throws BoundsError fieldoffset(TLayout, 4)
 
+@test fieldtype(Tuple{Vararg{Int8}}, 1) === Int8
+@test fieldtype(Tuple{Vararg{Int8}}, 10) === Int8
+@test_throws BoundsError fieldtype(Tuple{Vararg{Int8}}, 0)
+
 @test fieldnames((1,2,3)) == fieldnames(NTuple{3, Int}) == [fieldname(NTuple{3, Int}, i) for i = 1:3] == [1, 2, 3]
 @test_throws BoundsError fieldname(NTuple{3, Int}, 0)
 @test_throws BoundsError fieldname(NTuple{3, Int}, 4)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -72,6 +72,9 @@ function test_2()
     @test issub_strict(Tuple{Int,Int}, Tuple{E,E,Vararg{E,N}} where E where N)
 
     @test issub(Type{Tuple{VecElement{Bool}}}, (Type{Tuple{Vararg{VecElement{T},N}}} where T where N))
+
+    @test isequal_type(Type{Tuple{Vararg{Int,N}} where N}, Type{Tuple{Vararg{Int,N} where N}})
+    @test Type{Tuple{Vararg{Int,N}} where N} !== Type{Tuple{Vararg{Int,N} where N}}
 end
 
 function test_diagonal()
@@ -791,6 +794,9 @@ function test_intersection()
     # test typeintersect wrapper as well as _type_intersect
     @test typeintersect(Union{DataType,Int}, Type) === DataType
     @test typeintersect(Union{DataType,Int}, Type{T} where T) === DataType
+
+    # since BottomType is a singleton we can deduce its intersection with Type{...}
+    @testintersect(Core.BottomType, (Type{T} where T<:Tuple), Type{Union{}})
 
     @testintersect((Type{Tuple{Vararg{T}}} where T), Type{Tuple}, Bottom)
     @testintersect(Tuple{Type{S}, Tuple{Any, Vararg{Any}}} where S<:Tuple{Any, Vararg{Any}},


### PR DESCRIPTION
1. Given something like `Array{Any[Int][1]}`, we can now infer `Type{Array{_,N} where N} where _` instead of `Type{_} where _<:Array`.

2. Given `Tuple{x::Any}` we didn't take into account the possibility that `x` could be `Vararg` at run time. This is fixed.

3. *All* versions of julia seem to have this bug:

```
julia> f{T}(x::T...) = 0

julia> f(x...) = ""

julia> f()
""

julia> @code_typed f()
LambdaInfo for f()
:(begin 
        return 0
    end::Int64)
```

Another manifestation:

```
julia> g{T}() = 0
WARNING: static parameter T does not occur in signature for g at none:1.
The method will not be callable.
g (generic function with 1 method)

julia> g()
ERROR: MethodError: `g` has no method matching g()

julia> @which g()
g{T}() at none:1
```

We were actually testing for this behavior! Test fixed.

4. In `ml_matches_visitor`, after computing a type intersection, we also computed subtype. I added a flag to intersection to avoid this redundant call, which will hopefully save a little compile time.

5. Deleted some code that's not needed with the new subtyping algorithm.

6. Inference of `ccall` was returning types with free variables. Fixes #20305

7. Improve/fix t-func for `fieldtype`.

Fixes #20096
