### PR TITLE
Fix #20108 fix #20111: method display errors

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -87,7 +87,7 @@ end
 function show(io::IO, m::Method; kwtype::Nullable{DataType}=Nullable{DataType}())
     tv, decls, file, line = arg_decl_parts(m)
     sig = unwrap_unionall(m.sig)
-    ft = sig.parameters[1]
+    ft = unwrap_unionall(sig.parameters[1])
     d1 = decls[1]
     if sig === Tuple
         print(io, m.name)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -515,6 +515,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                     # If the methods args is longer than input then the method
                     # arguments is printed as not a match
                     for (k, sigtype) in enumerate(sig[length(t_i)+1:end])
+                        sigtype = isvarargtype(sigtype) ? unwrap_unionall(sigtype) : sigtype
                         if Base.isvarargtype(sigtype)
                             sigstr = string(sigtype.parameters[1], "...")
                         else

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -463,8 +463,8 @@ end
 
 # Issue 20111
 let K20111(x) = y -> x, buf = IOBuffer()
-  show(buf, methods(K20111(1)))
-  @test contains(String(buf), " 1 method for generic function")
+    show(buf, methods(K20111(1)))
+    @test contains(String(buf), " 1 method for generic function")
 end
 
 # @macroexpand tests

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -453,6 +453,19 @@ let d = Dict(1 => 2, 3 => 45)
     end
 end
 
+# Issue #20108
+let err, buf = IOBuffer()
+    try Array() catch err end
+    Base.show_method_candidates(buf,err)
+    @test isa(err, MethodError)
+    @test contains(String(buf), "Closest candidates are:")
+end
+
+# Issue 20111
+let K20111(x) = y -> x, buf = IOBuffer()
+  show(buf, methods(K20111(1)))
+  @test contains(String(buf), " 1 method for generic function")
+end
 
 # @macroexpand tests
 macro seven_dollar(ex)


### PR DESCRIPTION
Both errors from trying to access fields of `::UnionAll` objects.
replutil seems to be reasonably well-tested already, but hit some corner cases here.