### PR TITLE
Add reference count to LibGit2 objects

### DIFF
--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -605,7 +605,7 @@ function __init__()
 
     err = ccall((:git_libgit2_init, :libgit2), Cint, ())
     err > 0 || throw(ErrorException("error initializing LibGit2 module"))
-    REFCOUNT[] += 1
+    REFCOUNT[] = 1
 
     atexit() do
         REFCOUNT[] -= 1


### PR DESCRIPTION
Fixes segfault from calling `git_libgit2_shutdown` before finalizers (#20109).