### PR TITLE
Change type docs use of `is` to `===`

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1021,7 +1021,7 @@ UInt64
 This is accomplished via the following code in `base/boot.jl`:
 
 ```julia
-if is(Int,Int64)
+if Int === Int64
     typealias UInt UInt64
 else
     typealias UInt UInt32


### PR DESCRIPTION
In the type system docs, an example of type aliases is given that mimics the code in Base for defining `UInt`. The example still uses `is`, which is now deprecated in favor of `===`.