### PR TITLE
RFC: Add support for dynamic doc strings

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -241,7 +241,8 @@ end
 """
     getdoc(x::T, sig) -> String
 
-Return the dynamic docstring associated with object `x`, or `nothing` to use the binding's documentation.
+Return the dynamic docstring associated with object `x`, or `nothing` to use
+the binding's documentation.
 """
 getdoc(x, sig) = getdoc(x)
 getdoc(x) = nothing
@@ -251,7 +252,8 @@ getdoc(x) = nothing
 
 Returns all documentation that matches both `binding` and `sig`.
 
-If `getdoc` returns a non-`nothing` result on the value of the binding, then a dynamic docstring is returned instead of one based on the binding itself.
+If `getdoc` returns a non-`nothing` result on the value of the binding, then a
+dynamic docstring is returned instead of one based on the binding itself.
 """
 function doc(binding::Binding, sig::Type = Union{})
     if defined(binding)

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -258,7 +258,7 @@ dynamic docstring is returned instead of one based on the binding itself.
 function doc(binding::Binding, sig::Type = Union{})
     if defined(binding)
         result = getdoc(resolve(binding), sig)
-        result === nothing || return Markdown.parse(result)
+        result === nothing || return result
     end
     results, groups = DocStr[], MultiDoc[]
     # Lookup `binding` and `sig` for matches in all modules of the docsystem.

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -930,7 +930,7 @@ type DynamicDocType
     x
 end
 
-Base.Docs.getdoc(d::DynamicDocType) = d.x
+Base.Docs.getdoc(d::DynamicDocType) = Base.Markdown.parse(d.x)
 
 dynamic_test = DynamicDocType("test 1")
 @test docstrings_equal(@doc(dynamic_test), doc"test 1")

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -922,3 +922,17 @@ let save_color = Base.have_color
         eval(Base, :(have_color = $save_color))
     end
 end
+
+
+# Dynamic docstrings
+
+type DynamicDocType
+    x
+end
+
+Base.Docs.getdoc(d::DynamicDocType) = d.x
+
+dynamic_test = DynamicDocType("test 1")
+@test docstrings_equal(@doc(dynamic_test), doc"test 1")
+dynamic_test.x = "test 2"
+@test docstrings_equal(@doc(dynamic_test), doc"test 2")


### PR DESCRIPTION
Useful for eg https://github.com/JuliaPy/PyCall.jl/issues/46.

Allows instances of the same type to have different docstrings which can only be determined at runtime. Useful for interlanguage support where the same Julia type (eg `PyObject`) corresponds to different types in the guest language that might have different docstrings. 