### PR TITLE
basic inference support for conditional back-propagation

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -752,11 +752,9 @@ static bool store_unboxed_p(jl_value_t *jt)
 static bool store_unboxed_p(int s, jl_codectx_t *ctx)
 {
     jl_varinfo_t &vi = ctx->slots[s];
-    // only store a variable unboxed if type inference has run, which
-    // checks that the variable is not referenced undefined.
-    return (ctx->source->inferred &&
-            // don't unbox vararg tuples
-            s != ctx->vaSlot && store_unboxed_p(vi.value.typ));
+    if (s == ctx->vaSlot) // don't unbox vararg tuples
+        return false;
+    return store_unboxed_p(vi.value.typ);
 }
 
 static jl_sym_t *slot_symbol(int s, jl_codectx_t *ctx)

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -491,3 +491,21 @@ tpara18457{I}(::Type{AbstractMyType18457{I}}) = I
 tpara18457{A<:AbstractMyType18457}(::Type{A}) = tpara18457(supertype(A))
 @test tpara18457(MyType18457{true}) === true
 
+randT_inferred_union() = rand(Bool) ? rand(Bool) ? 1 : 2.0 : nothing
+function f_inferred_union()
+    b = randT_inferred_union()
+    if !(nothing !== b) === true
+        return f_inferred_union_nothing(b)
+    elseif (isa(b, Float64) === true) !== false
+        return f_inferred_union_float(b)
+    else
+        return f_inferred_union_int(b)
+    end
+end
+f_inferred_union_nothing(::Void) = 1
+f_inferred_union_nothing(::Any) = "broken"
+f_inferred_union_float(::Float64) = 2
+f_inferred_union_float(::Any) = "broken"
+f_inferred_union_int(::Int) = 3
+f_inferred_union_int(::Any) = "broken"
+@test @inferred(f_inferred_union()) in (1, 2, 3)


### PR DESCRIPTION
Following the general principle of `Const`, this adds support to inference to pattern-match a few useful boolean conditions, such that we can make use of a branch resulting from an `isa` or `is` test to improve the type information later for that slot.