### PR TITLE
remove erroneous test for #20068

### DIFF
--- a/test/inference.jl
+++ b/test/inference.jl
@@ -491,8 +491,3 @@ tpara18457{I}(::Type{AbstractMyType18457{I}}) = I
 tpara18457{A<:AbstractMyType18457}(::Type{A}) = tpara18457(supertype(A))
 @test tpara18457(MyType18457{true}) === true
 
-# Issue 20067
-@generated function foo20067{T <: Tuple}(::Type{T}, elements::Tuple)
-           :(T)
-end
-code_typed(DevNull, foo20067, (DataType, Tuple{Int, Int}))


### PR DESCRIPTION
This test exercises a seldom used codepath and is not correct in its current form (see https://github.com/JuliaLang/julia/pull/20068#discussion_r97014905).
In my opinion the best thing is to remove it for now.