### PR TITLE
A few fixes to make the marking more parallel friendly

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -176,7 +176,7 @@ static void gc_verify_track(jl_ptls_t ptls)
         arraylist_push(&lostval_parents_done, lostval);
         jl_printf(JL_STDERR, "Now looking for %p =======\n", lostval);
         clear_mark(GC_CLEAN);
-        pre_mark(ptls);
+        mark_all_roots(ptls);
         gc_mark_object_list(ptls, &to_finalize, 0);
         for (int i = 0;i < jl_n_threads;i++) {
             jl_ptls_t ptls2 = jl_all_tls_states[i];
@@ -222,7 +222,7 @@ void gc_verify(jl_ptls_t ptls)
     lostval_parents_done.len = 0;
     clear_mark(GC_CLEAN);
     gc_verifying = 1;
-    pre_mark(ptls);
+    mark_all_roots(ptls);
     gc_mark_object_list(ptls, &to_finalize, 0);
     for (int i = 0;i < jl_n_threads;i++) {
         jl_ptls_t ptls2 = jl_all_tls_states[i];

--- a/src/gc.c
+++ b/src/gc.c
@@ -1152,18 +1152,6 @@ static void grow_mark_stack(void)
     mark_stack_size = newsz;
 }
 
-static void reset_remset(void)
-{
-    for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_ptls_t ptls2 = jl_all_tls_states[t_i];
-        arraylist_t *tmp = ptls2->heap.remset;
-        ptls2->heap.remset = ptls2->heap.last_remset;
-        ptls2->heap.last_remset = tmp;
-        ptls2->heap.remset->len = 0;
-        ptls2->heap.remset_nptr = 0;
-    }
-}
-
 JL_DLLEXPORT void jl_gc_queue_root(jl_value_t *ptr)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
@@ -1592,25 +1580,24 @@ extern jl_array_t *jl_module_init_order;
 extern jl_typemap_entry_t *call_cache[N_CALL_CACHE];
 extern jl_array_t *jl_all_methods;
 
+static void jl_gc_mark_thread_local(jl_ptls_t ptls, jl_ptls_t ptls2)
+{
+    // `current_module` might not have a value when the thread is not
+    // running.
+    if (ptls2->current_module)
+        gc_push_root(ptls, ptls2->current_module, 0);
+    gc_push_root(ptls, ptls2->current_task, 0);
+    gc_push_root(ptls, ptls2->root_task, 0);
+    gc_push_root(ptls, ptls2->exception_in_transit, 0);
+    gc_push_root(ptls, ptls2->task_arg_in_transit, 0);
+}
+
 // mark the initial root set
-void pre_mark(jl_ptls_t ptls)
+static void mark_roots(jl_ptls_t ptls)
 {
     // modules
     gc_push_root(ptls, jl_main_module, 0);
     gc_push_root(ptls, jl_internal_main_module, 0);
-
-    size_t i;
-    for(i=0; i < jl_n_threads; i++) {
-        jl_ptls_t ptls2 = jl_all_tls_states[i];
-        // current_module might not have a value when the thread is not
-        // running.
-        if (ptls2->current_module)
-            gc_push_root(ptls, ptls2->current_module, 0);
-        gc_push_root(ptls, ptls2->current_task, 0);
-        gc_push_root(ptls, ptls2->root_task, 0);
-        gc_push_root(ptls, ptls2->exception_in_transit, 0);
-        gc_push_root(ptls, ptls2->task_arg_in_transit, 0);
-    }
 
     // invisible builtin values
     if (jl_an_empty_vec_any != NULL)
@@ -1620,27 +1607,22 @@ void pre_mark(jl_ptls_t ptls)
     gc_push_root(ptls, jl_cfunction_list.unknown, 0);
     gc_push_root(ptls, jl_anytuple_type_type, 0);
     gc_push_root(ptls, jl_ANY_flag, 0);
-    for (i = 0; i < N_CALL_CACHE; i++)
+    for (size_t i = 0; i < N_CALL_CACHE; i++)
         if (call_cache[i])
             gc_push_root(ptls, call_cache[i], 0);
     if (jl_all_methods != NULL)
         gc_push_root(ptls, jl_all_methods, 0);
 
-    jl_mark_box_caches(ptls);
-    //gc_push_root(ptls, jl_unprotect_stack_func, 0);
-    gc_push_root(ptls, jl_typetype_type, 0);
+    // gc_push_root(ptls, jl_unprotect_stack_func, 0);
 
     // constants
-    gc_push_root(ptls, jl_emptysvec, 0);
-    gc_push_root(ptls, jl_emptytuple, 0);
+    gc_push_root(ptls, jl_typetype_type, 0);
     gc_push_root(ptls, jl_emptytuple_type, 0);
-    gc_push_root(ptls, jl_true, 0);
-    gc_push_root(ptls, jl_false, 0);
 }
 
 // find unmarked objects that need to be finalized from the finalizer list "list".
 // this must happen last in the mark phase.
-static void post_mark(arraylist_t *list)
+static void sweep_finalizer_list(arraylist_t *list)
 {
     void **items = list->items;
     size_t len = list->len;
@@ -1744,74 +1726,106 @@ JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void)
 }
 void jl_gc_sync_total_bytes(void) {last_gc_total_bytes = jl_gc_total_bytes();}
 
-#define MIN_SCAN_BYTES 1024*1024
+static void jl_gc_premark(jl_ptls_t ptls2)
+{
+    arraylist_t *remset = ptls2->heap.remset;
+    ptls2->heap.remset = ptls2->heap.last_remset;
+    ptls2->heap.last_remset = remset;
+    ptls2->heap.remset->len = 0;
+    ptls2->heap.remset_nptr = 0;
+
+    // avoid counting remembered objects & bindings twice
+    // in `perm_scanned_bytes`
+    size_t len = remset->len;
+    void **items = remset->items;
+    for (size_t i = 0; i < len; i++) {
+        jl_value_t *item = (jl_value_t*)items[i];
+        objprofile_count(jl_typeof(item), 2, 0);
+        jl_astaggedvalue(item)->bits.gc = GC_OLD_MARKED;
+    }
+    len = ptls2->heap.rem_bindings.len;
+    items = ptls2->heap.rem_bindings.items;
+    for (size_t i = 0; i < len; i++) {
+        void *ptr = items[i];
+        jl_astaggedvalue(ptr)->bits.gc = GC_OLD_MARKED;
+    }
+}
+
+static void jl_gc_mark_remset(jl_ptls_t ptls, jl_ptls_t ptls2)
+{
+    size_t len = ptls2->heap.last_remset->len;
+    void **items = ptls2->heap.last_remset->items;
+    for (size_t i = 0; i < len; i++) {
+        jl_value_t *item = (jl_value_t*)items[i];
+        gc_scan_obj(ptls, item, 0, jl_astaggedvalue(item)->header);
+    }
+    int n_bnd_refyoung = 0;
+    len = ptls2->heap.rem_bindings.len;
+    items = ptls2->heap.rem_bindings.items;
+    for (size_t i = 0; i < len; i++) {
+        jl_binding_t *ptr = (jl_binding_t*)items[i];
+        // A null pointer can happen here when the binding is cleaned up
+        // as an exception is thrown after it was already queued (#10221)
+        if (!ptr->value) continue;
+        if (gc_push_root(ptls, ptr->value, 0)) {
+            items[n_bnd_refyoung] = ptr;
+            n_bnd_refyoung++;
+        }
+    }
+    ptls2->heap.rem_bindings.len = n_bnd_refyoung;
+}
+
+static void jl_gc_mark_ptrfree(jl_ptls_t ptls)
+{
+    // Pointer-free objects, can be marked concurrently
+    jl_mark_box_caches(ptls);
+    jl_gc_setmark(ptls, (jl_value_t*)jl_emptysvec);
+    jl_gc_setmark(ptls, jl_emptytuple);
+    jl_gc_setmark(ptls, jl_true);
+    jl_gc_setmark(ptls, jl_false);
+}
 
 // Only one thread should be running in this function
 static void _jl_gc_collect(jl_ptls_t ptls, int full)
 {
-    JL_TIMING(GC);
     uint64_t t0 = jl_hrtime();
     int64_t last_perm_scanned_bytes = perm_scanned_bytes;
     assert(mark_sp == 0);
 
+    jl_gc_mark_ptrfree(ptls);
+
     // 1. fix GC bits of objects in the remset.
-    reset_remset();
-    for (int t_i = 0;t_i < jl_n_threads;t_i++) {
+    for (int t_i = 0; t_i < jl_n_threads; t_i++)
+        jl_gc_premark(jl_all_tls_states[t_i]);
+
+    for (int t_i = 0; t_i < jl_n_threads; t_i++) {
         jl_ptls_t ptls2 = jl_all_tls_states[t_i];
-        // avoid counting remembered objects & bindings twice in perm_scanned_bytes
-        for (int i = 0; i < ptls2->heap.last_remset->len; i++) {
-            jl_value_t *item = (jl_value_t*)ptls2->heap.last_remset->items[i];
-            objprofile_count(jl_typeof(item), 2, 0);
-            jl_astaggedvalue(item)->bits.gc = GC_OLD_MARKED;
-        }
-        for (int i = 0; i < ptls2->heap.rem_bindings.len; i++) {
-            void *ptr = ptls2->heap.rem_bindings.items[i];
-            jl_astaggedvalue(ptr)->bits.gc = GC_OLD_MARKED;
-        }
-    }
-
-    // 2. mark every object in the remsets and rem_binding
-    for (int t_i = 0;t_i < jl_n_threads;t_i++) {
-        jl_ptls_t ptls2 = jl_all_tls_states[t_i];
-
-        for (int i = 0; i < ptls2->heap.last_remset->len; i++) {
-            jl_value_t *item = (jl_value_t*)ptls2->heap.last_remset->items[i];
-            gc_scan_obj(ptls, item, 0, jl_astaggedvalue(item)->header);
-        }
-
-        int n_bnd_refyoung = 0;
-        for (int i = 0; i < ptls2->heap.rem_bindings.len; i++) {
-            jl_binding_t *ptr = (jl_binding_t*)ptls2->heap.rem_bindings.items[i];
-            // A null pointer can happen here when the binding is cleaned up
-            // as an exception is thrown after it was already queued (#10221)
-            if (!ptr->value) continue;
-            if (gc_push_root(ptls, ptr->value, 0)) {
-                ptls2->heap.rem_bindings.items[n_bnd_refyoung] = ptr;
-                n_bnd_refyoung++;
-            }
-        }
-        ptls2->heap.rem_bindings.len = n_bnd_refyoung;
+        // 2.1. mark every object in the `last_remsets` and `rem_binding`
+        jl_gc_mark_remset(ptls, ptls2);
+        // 2.2. mark every thread local root
+        jl_gc_mark_thread_local(ptls, ptls2);
     }
 
     // 3. walk roots
-    pre_mark(ptls);
+    mark_roots(ptls);
     visit_mark_stack(ptls);
     gc_num.since_sweep += gc_num.allocd + (int64_t)gc_num.interval;
     gc_settime_premark_end();
     gc_time_mark_pause(t0, scanned_bytes, perm_scanned_bytes);
     int64_t actual_allocd = gc_num.since_sweep;
     // marking is over
+
     // 4. check for objects to finalize
     // Record the length of the marked list since we need to
     // mark the object moved to the marked list from the
-    // `finalizer_list` by `post_mark`
+    // `finalizer_list` by `sweep_finalizer_list`
     size_t orig_marked_len = finalizer_list_marked.len;
     for (int i = 0;i < jl_n_threads;i++) {
         jl_ptls_t ptls2 = jl_all_tls_states[i];
-        post_mark(&ptls2->finalizers);
+        sweep_finalizer_list(&ptls2->finalizers);
     }
     if (prev_sweep_full) {
-        post_mark(&finalizer_list_marked);
+        sweep_finalizer_list(&finalizer_list_marked);
         orig_marked_len = 0;
     }
     for (int i = 0;i < jl_n_threads;i++) {
@@ -1945,6 +1959,7 @@ JL_DLLEXPORT void jl_gc_collect(int full)
         jl_gc_state_set(ptls, old_state, JL_GC_STATE_WAITING);
         return;
     }
+    JL_TIMING(GC);
     // no-op for non-threading
     jl_gc_wait_for_the_world();
 
@@ -1967,6 +1982,14 @@ JL_DLLEXPORT void jl_gc_collect(int full)
         run_finalizers(ptls);
         ptls->in_finalizer = was_in_finalizer;
     }
+}
+
+void mark_all_roots(jl_ptls_t ptls)
+{
+    for (size_t i = 0; i < jl_n_threads; i++)
+        jl_gc_mark_thread_local(ptls, jl_all_tls_states[i]);
+    mark_roots(ptls);
+    jl_gc_mark_ptrfree(ptls);
 }
 
 // allocator entry points

--- a/src/gc.h
+++ b/src/gc.h
@@ -113,27 +113,25 @@ typedef struct _mallocarray_t {
 
 // pool page metadata
 typedef struct {
-    struct {
-        // index of pool that owns this page
-        uint16_t pool_n : 8;
-        // Whether any cell in the page is marked
-        // This bit is set before sweeping iff there's live cells in the page.
-        // Note that before marking or after sweeping there can be live
-        // (and young) cells in the page for `!has_marked`.
-        uint16_t has_marked: 1;
-        // Whether any cell was live and young **before sweeping**.
-        // For a normal sweep (quick sweep that is NOT preceded by a
-        // full sweep) this bit is set iff there are young or newly dead
-        // objects in the page and the page needs to be swept.
-        //
-        // For a full sweep, this bit should be ignored.
-        //
-        // For a quick sweep preceded by a full sweep. If this bit is set,
-        // the page needs to be swept. If this bit is not set, there could
-        // still be old dead objects in the page and `nold` and `prev_nold`
-        // should be used to determine if the page needs to be swept.
-        uint16_t has_young: 1;
-    };
+    // index of pool that owns this page
+    uint8_t pool_n;
+    // Whether any cell in the page is marked
+    // This bit is set before sweeping iff there's live cells in the page.
+    // Note that before marking or after sweeping there can be live
+    // (and young) cells in the page for `!has_marked`.
+    uint8_t has_marked;
+    // Whether any cell was live and young **before sweeping**.
+    // For a normal sweep (quick sweep that is NOT preceded by a
+    // full sweep) this bit is set iff there are young or newly dead
+    // objects in the page and the page needs to be swept.
+    //
+    // For a full sweep, this bit should be ignored.
+    //
+    // For a quick sweep preceded by a full sweep. If this bit is set,
+    // the page needs to be swept. If this bit is not set, there could
+    // still be old dead objects in the page and `nold` and `prev_nold`
+    // should be used to determine if the page needs to be swept.
+    uint8_t has_young;
     // number of old objects in this page
     uint16_t nold;
     // number of old objects in this page during the previous full sweep

--- a/src/gc.h
+++ b/src/gc.h
@@ -277,7 +277,7 @@ STATIC_INLINE void gc_big_object_link(bigval_t *hdr, bigval_t **list)
     *list = hdr;
 }
 
-void pre_mark(jl_ptls_t ptls);
+void mark_all_roots(jl_ptls_t ptls);
 void gc_mark_object_list(jl_ptls_t ptls, arraylist_t *list, size_t start);
 void visit_mark_stack(jl_ptls_t ptls);
 void gc_debug_init(void);

--- a/src/threadgroup.h
+++ b/src/threadgroup.h
@@ -8,7 +8,7 @@
 
 // for the barrier
 typedef struct {
-    volatile int sense;
+    int sense;
 } ti_thread_sense_t;
 
 // thread group
@@ -17,7 +17,7 @@ typedef struct {
     uint8_t num_sockets, num_cores, num_threads_per_core;
 
     // fork/join/barrier
-    volatile uint8_t  group_sense;
+    uint8_t group_sense; // Written only be master thread
     ti_thread_sense_t **thread_sense;
     void              *envelope;
 

--- a/src/threadgroup.h
+++ b/src/threadgroup.h
@@ -17,7 +17,7 @@ typedef struct {
     uint8_t num_sockets, num_cores, num_threads_per_core;
 
     // fork/join/barrier
-    uint8_t group_sense; // Written only be master thread
+    uint8_t group_sense; // Written only by master thread
     ti_thread_sense_t **thread_sense;
     void              *envelope;
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -693,10 +693,8 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_svec_t *args)
     user_ns[ptls->tid] += (trun - tfork);
 #endif
 
-    jl_gc_state_set(ptls, JL_GC_STATE_SAFE, 0);
     // wait for completion (TODO: nowait?)
     ti_threadgroup_join(tgworld, ptls->tid);
-    jl_gc_state_set(ptls, 0, JL_GC_STATE_SAFE);
 
 #if PROFILE_JL_THREADING
     uint64_t tjoin = uv_hrtime();


### PR DESCRIPTION
This is a follow up of https://github.com/JuliaLang/julia/pull/19940. Still doesn't make the marking thread safe but is one step closer. A summary of the changes:

* Reorder marking and split out different marking phases. (first commit)

    Also renames a few functions....

* Use normal fields instead of bitfields in page metadata.

    So that the fields can be modified concurrently.

* Use atomic operation instead of volatile for thread synchronization.

* Use safepoint instead of state transitions for the join.

    So that it's easier to branch into the GC.

* Only access global data in setmark if the tag is changed.

    So that only one thread will update the data for an object.

* Pass `ptls` to `gc_managed_realloc_`.

* Make `_jl_gc_collect` non-recursive.

@nanosoldier `runbenchmarks(ALL, vs=":master")`