### PR TITLE
use a counter for passed tests instead of storing the Result object

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -548,7 +548,7 @@ type DefaultTestSet <: AbstractTestSet
 end
 DefaultTestSet(desc) = DefaultTestSet(desc, [], 0, false)
 
-# For a a broken result, simply store the result
+# For a broken result, simply store the result
 record(ts::DefaultTestSet, t::Broken) = (push!(ts.results, t); t)
 # For a passed result, do not store the result since it uses a lot of memory
 record(ts::DefaultTestSet, t::Pass) = (ts.n_passed += 1; t)

--- a/test/test.jl
+++ b/test/test.jl
@@ -107,13 +107,13 @@ end
         @test true
     end
     @test typeof(ts) == Base.Test.DefaultTestSet
-    @test typeof(ts.results[1]) == Base.Test.Pass
+    @test ts.n_passed == 1
     tss = @testset "@testset/for should return an array of testsets: $i" for i in 1:3
         @test true
     end
     @test length(tss) == 3
     @test typeof(tss[1]) == Base.Test.DefaultTestSet
-    @test typeof(tss[1].results[1]) == Base.Test.Pass
+    @test tss[1].n_passed == 1
 end
 @testset "accounting" begin
     local ts
@@ -205,14 +205,14 @@ ts = @testset "@testset should return the testset" begin
     @test true
 end
 @test typeof(ts) == Base.Test.DefaultTestSet
-@test typeof(ts.results[1]) == Base.Test.Pass
+@test ts.n_passed == 1
 
 tss = @testset "@testset/for should return an array of testsets: $i" for i in 1:3
     @test true
 end
 @test length(tss) == 3
 @test typeof(tss[1]) == Base.Test.DefaultTestSet
-@test typeof(tss[1].results[1]) == Base.Test.Pass
+@test tss[1].n_passed == 1
 
 # Issue #17908 (return)
 testset_depth17908 = Test.get_testset_depth()


### PR DESCRIPTION
Should fix #20137. cc @Keno