### PR TITLE
Fix behavior of `foldr` on empty arrays (#20144)

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -104,7 +104,7 @@ foldl(op, itr) = mapfoldl(identity, op, itr)
 function mapfoldr_impl(f, op, v0, itr, i::Integer)
     # Unroll the while loop once; if v0 is known, the call to op may
     # be evaluated at compile time
-    if i == 0
+    if isempty(itr)
         return r_promote(op, v0)
     else
         x = itr[i]
@@ -133,7 +133,7 @@ this cannot be used with empty collections (see `reduce(op, itr)`).
 """
 function mapfoldr(f, op, itr)
     i = endof(itr)
-    if i == 0
+    if isempty(itr)
         return Base.mr_empty_iter(f, op, itr, iteratoreltype(itr))
     end
     return mapfoldr_impl(f, op, f(itr[i]), itr, i-1)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -131,7 +131,13 @@ mapfoldr(f, op, v0, itr) = mapfoldr_impl(f, op, v0, itr, endof(itr))
 Like `mapfoldr(f, op, v0, itr)`, but using the first element of `itr` as `v0`. In general,
 this cannot be used with empty collections (see `reduce(op, itr)`).
 """
-mapfoldr(f, op, itr) = (i = endof(itr); mapfoldr_impl(f, op, f(itr[i]), itr, i-1))
+function mapfoldr(f, op, itr)
+    i = endof(itr);
+    if i == 0
+        return Base.mr_empty_iter(f, op, itr, iteratoreltype(itr))
+    end
+    return mapfoldr_impl(f, op, f(itr[i]), itr, i-1)
+end
 
 """
     foldr(op, v0, itr)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -132,7 +132,7 @@ Like `mapfoldr(f, op, v0, itr)`, but using the first element of `itr` as `v0`. I
 this cannot be used with empty collections (see `reduce(op, itr)`).
 """
 function mapfoldr(f, op, itr)
-    i = endof(itr);
+    i = endof(itr)
     if i == 0
         return Base.mr_empty_iter(f, op, itr, iteratoreltype(itr))
     end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # fold(l|r) & mapfold(l|r)
+@test foldl(+, Int64[]) == 0
 @test foldl(-, 1:5) == -13
 @test foldl(-, 10, 1:5) == -5
 
@@ -16,6 +17,7 @@
 @test Base.mapfoldl((x)-> x ⊻ true, |, [true false true false false]) == true
 @test Base.mapfoldl((x)-> x ⊻ true, |, false, [true false true false false]) == true
 
+@test foldr(+, Int64[]) == 0
 @test foldr(-, 1:5) == 3
 @test foldr(-, 10, 1:5) == -7
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # fold(l|r) & mapfold(l|r)
-@test foldl(+, Int64[]) == 0 # In reference to issues #7465/#20144 (PR #20160)
+@test foldl(+, Int64[]) === Int64(0) # In reference to issues #7465/#20144 (PR #20160)
+@test foldl(+, Int16[]) === Int32(0)
 @test foldl(-, 1:5) == -13
 @test foldl(-, 10, 1:5) == -5
 
@@ -17,7 +18,8 @@
 @test Base.mapfoldl((x)-> x ⊻ true, |, [true false true false false]) == true
 @test Base.mapfoldl((x)-> x ⊻ true, |, false, [true false true false false]) == true
 
-@test foldr(+, Int64[]) == 0 # In reference to issue #20144 (PR #20160)
+@test foldr(+, Int64[]) === Int64(0) # In reference to issue #20144 (PR #20160)
+@test foldr(+, Int16[]) === Int32(0)
 @test foldr(-, 1:5) == 3
 @test foldr(-, 10, 1:5) == -7
 
@@ -25,6 +27,8 @@
 @test Base.mapfoldr(abs2, -, 10, 2:5) == -4
 
 # reduce & mapreduce
+@test reduce(+, Int64[]) === Int64(0) # In reference to issue #20144 (PR #20160)
+@test reduce(+, Int16[]) === Int32(0)
 @test reduce((x,y)->"($x+$y)", 9:11) == "((9+10)+11)"
 @test reduce(max, [8 6 7 5 3 0 9]) == 9
 @test reduce(+, 1000, 1:5) == (1000 + 1 + 2 + 3 + 4 + 5)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # fold(l|r) & mapfold(l|r)
-@test foldl(+, Int64[]) == 0
+@test foldl(+, Int64[]) == 0 # In reference to issues #7465/#20144 (PR #20160)
 @test foldl(-, 1:5) == -13
 @test foldl(-, 10, 1:5) == -5
 
@@ -17,7 +17,7 @@
 @test Base.mapfoldl((x)-> x ⊻ true, |, [true false true false false]) == true
 @test Base.mapfoldl((x)-> x ⊻ true, |, false, [true false true false false]) == true
 
-@test foldr(+, Int64[]) == 0
+@test foldr(+, Int64[]) == 0 # In reference to issue #20144 (PR #20160)
 @test foldr(-, 1:5) == 3
 @test foldr(-, 10, 1:5) == -7
 


### PR DESCRIPTION
This is a fix for #20144.

When fixing #7465, a check was added based on `mr_empty` to `mapfoldl`, which is called by both `foldl` and `reduce`, so they would have better behavior with empty arrays.

This implements an equivalent check on `foldr` so that it will have the same behavior as `foldl` and `reduce`.

I also added tests to make sure "folding" an operator such as `+` on an empty array gives the expected result.

This is my first PR, so sorry for any mistakes.