### PR TITLE
Add patch to set `-O2` for suitesparse build

### DIFF
--- a/deps/patches/SuiteSparse-O2.patch
+++ b/deps/patches/SuiteSparse-O2.patch
@@ -1,0 +1,11 @@
+--- SuiteSparse_config/SuiteSparse_config.mk    2014-12-22 14:21:00.000000000 -0800
++++ SuiteSparse_config/SuiteSparse_config.mk    2017-01-20 15:17:43.000000000 -0800
+@@ -69,7 +69,7 @@
+ # C and C++ compiler flags.  The first three are standard for *.c and *.cpp
+ # Add -DNTIMER if you do use any timing routines (otherwise -lrt is required).
+ # CF = $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -O3 -fexceptions -fPIC -DNTIMER
+-  CF = $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -O3 -fexceptions -fPIC
++  CF = $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -O2 -fexceptions -fPIC
+ # for the MKL BLAS:
+ # CF = $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -O3 -fexceptions -fPIC -I$(MKLROOT)/include -D_GNU_SOURCE
+ # with no optimization:

--- a/deps/suitesparse.mk
+++ b/deps/suitesparse.mk
@@ -37,12 +37,17 @@ $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-winclang.patch-applied: $
 	cd $(dir $@) && patch -p0 < $(SRCDIR)/patches/SuiteSparse-winclang.patch
 	echo 1 > $@
 
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-O2.patch-applied: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-winclang.patch-applied
+	cd $(dir $@) && patch -p0 < $(SRCDIR)/patches/SuiteSparse-O2.patch
+	echo 1 > $@
+
+
 ifeq ($(USE_SYSTEM_BLAS), 0)
 $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: | $(build_prefix)/manifest/openblas
 else ifeq ($(USE_SYSTEM_LAPACK), 0)
 $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: | $(build_prefix)/manifest/lapack
 endif
-$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/source-extracted $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-winclang.patch-applied
+$(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/source-extracted $(BUILDDIR)/SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse-O2.patch-applied
 	$(MAKE) -C $(dir $<) library $(SUITESPARSE_MFLAGS)
 	echo 1 > $@
 


### PR DESCRIPTION
This fixes the compiler regression noticed in GCC 6.3.0 in https://github.com/JuliaLang/julia/issues/20123 by disabling `-ftree-slp-vectorize` as a side-effect of moving from `-O3` to `-O2`.  We prefer to compile with `-O2` by default anyway, so let's do so.