### PR TITLE
minimal pass at getting cfunction to always run in the newest world

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-size_t jl_world_counter = 1;
+JL_DLLEXPORT size_t jl_world_counter = 1;
 JL_DLLEXPORT size_t jl_get_world_counter(void)
 {
     return jl_world_counter;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -39,7 +39,7 @@ extern "C" {
 
 // useful constants
 extern jl_methtable_t *jl_type_type_mt;
-extern size_t jl_world_counter;
+JL_DLLEXPORT extern size_t jl_world_counter;
 
 typedef void (*tracer_cb)(jl_value_t *tracee);
 void jl_call_tracer(tracer_cb callback, jl_value_t *tracee);


### PR DESCRIPTION
We are not really striving for accuracy or speed here (on the method invalidation path), just validity. That's also why there's no tests added here. I'm just trying to get some packages working again as quickly as possible, then will need to go back and make this much better.