### PR TITLE
use ISQ abbreviations (KiB etc.) for power-of-1024 memory units

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -118,7 +118,7 @@ function toc()
 end
 
 # print elapsed time, return expression value
-const _mem_units = ["byte", "KB", "MB", "GB", "TB", "PB"]
+const _mem_units = ["byte", "KiB", "MiB", "GiB", "TiB", "PiB"]
 const _cnt_units = ["", " k", " M", " G", " T", " P"]
 function prettyprint_getunits(value, numunits, factor)
     if value == 0 || value == 1


### PR DESCRIPTION
This PR changes the memory pretty-printing (for `@time` etc) to use ISQ abbreviations like KiB ([kibibytes](https://en.wikipedia.org/wiki/Kibibyte)) for power-of-1024 units.   Previously, it used units of "KB" etc, which follows [JEDEC](https://en.wikipedia.org/wiki/JEDEC_memory_standards#Unit_prefixes_for_semiconductor_storage_capacity) but is easily confused with the SI "kB" (1000 bytes).