### PR TITLE
Guard against broadcast!(identity, A, B) regressions

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -449,3 +449,11 @@ end
     @test broadcast(==, [1], AbstractArray) == BitArray([false])
     @test broadcast(==, 1, AbstractArray) == false
 end
+
+# Test that broadcasting identity where the input and output Array shapes do not match
+# yields the correct result, not merely a partial copy. See pull request #19895 for discussion.
+let N = 5
+    @test iszero(ones(N, N) .= zeros(N, 1))
+    @test iszero(ones(N, N) .= zeros(1, N))
+    @test iszero(ones(N, N) .= zeros(1, 1))
+end


### PR DESCRIPTION
This pull request adds tests guarding against regression of `broadcast!(identity, A::AbstractArray, B::AbstractArray)` where `A` and `B` have different shapes. Ref. #19895. Best!