### PR TITLE
Doctests for the manual, part 1

### DIFF
--- a/doc/src/manual/complex-and-rational-numbers.md
+++ b/doc/src/manual/complex-and-rational-numbers.md
@@ -13,14 +13,14 @@ is such a popular index variable name. Since Julia allows numeric literals to be
 this binding suffices to provide convenient syntax for complex numbers, similar to the traditional
 mathematical notation:
 
-```julia
+```jldoctest
 julia> 1 + 2im
 1 + 2im
 ```
 
 You can perform all the standard arithmetic operations with complex numbers:
 
-```julia
+```jldoctest
 julia> (1 + 2im)*(2 - 3im)
 8 + 1im
 
@@ -54,7 +54,7 @@ julia> 3(2 - 5im)^-1.0
 
 The promotion mechanism ensures that combinations of operands of different types just work:
 
-```julia
+```jldoctest
 julia> 2(1 - 1im)
 2 - 2im
 
@@ -88,23 +88,26 @@ division.
 
 Standard functions to manipulate complex values are provided:
 
-```julia
-julia> real(1 + 2im)
+```jldoctest
+julia> z = 1 + 2im
+1 + 2im
+
+julia> real(1 + 2im) # real part of z
 1
 
-julia> imag(1 + 2im)
+julia> imag(1 + 2im) # imaginary part of z
 2
 
-julia> conj(1 + 2im)
+julia> conj(1 + 2im) # complex conjugate of z
 1 - 2im
 
-julia> abs(1 + 2im)
+julia> abs(1 + 2im) # absolute value of z
 2.23606797749979
 
-julia> abs2(1 + 2im)
+julia> abs2(1 + 2im) # squared absolute value
 5
 
-julia> angle(1 + 2im)
+julia> angle(1 + 2im) # phase angle in radians
 1.1071487177940904
 ```
 
@@ -114,7 +117,7 @@ numbers where it avoids taking a square root. [`angle()`](@ref) returns the phas
 (also known as the *argument* or *arg* function). The full gamut of other [Elementary Functions](@ref)
 is also defined for complex numbers:
 
-```julia
+```jldoctest
 julia> sqrt(1im)
 0.7071067811865476 + 0.7071067811865475im
 
@@ -135,12 +138,12 @@ Note that mathematical functions typically return real values when applied to re
 complex values when applied to complex numbers. For example, [`sqrt()`](@ref) behaves differently
 when applied to `-1` versus `-1 + 0im` even though `-1 == -1 + 0im`:
 
-```julia
+```jldoctest
 julia> sqrt(-1)
 ERROR: DomainError:
 sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
- in sqrt(::Int64) at ./math.jl:278
- ...
+Stacktrace:
+ [1] sqrt(::Int64) at ./math.jl:432
 
 julia> sqrt(-1 + 0im)
 0.0 + 1.0im
@@ -149,7 +152,7 @@ julia> sqrt(-1 + 0im)
 The [literal numeric coefficient notation](@ref man-numeric-literal-coefficients) does not work when constructing complex number
 from variables. Instead, the multiplication must be explicitly written out:
 
-```julia
+```jldoctest
 julia> a = 1; b = 2; a + b*im
 1 + 2im
 ```
@@ -157,8 +160,8 @@ julia> a = 1; b = 2; a + b*im
 However, this is *not* recommended; Use the [`complex()`](@ref) function instead to construct
 a complex value directly from its real and imaginary parts.:
 
-```julia
-julia> complex(a,b)
+```jldoctest
+julia> a = 1; b = 2; complex(a, b)
 1 + 2im
 ```
 
@@ -167,7 +170,7 @@ This construction avoids the multiplication and addition operations.
 [`Inf`](@ref) and [`NaN`](@ref) propagate through complex numbers in the real and imaginary parts
 of a complex number as described in the [Special floating-point values](@ref) section:
 
-```julia
+```jldoctest
 julia> 1 + Inf*im
 1.0 + Inf*im
 
@@ -180,7 +183,7 @@ julia> 1 + NaN*im
 Julia has a rational number type to represent exact ratios of integers. Rationals are constructed
 using the [`//`](@ref) operator:
 
-```julia
+```jldoctest
 julia> 2//3
 2//3
 ```
@@ -188,7 +191,7 @@ julia> 2//3
 If the numerator and denominator of a rational have common factors, they are reduced to lowest
 terms such that the denominator is non-negative:
 
-```julia
+```jldoctest
 julia> 6//9
 2//3
 
@@ -207,7 +210,7 @@ tested by checking for equality of the numerator and denominator. The standardiz
 denominator of a rational value can be extracted using the [`numerator()`](@ref) and [`denominator()`](@ref)
 functions:
 
-```julia
+```jldoctest
 julia> numerator(2//3)
 2
 
@@ -218,7 +221,7 @@ julia> denominator(2//3)
 Direct comparison of the numerator and denominator is generally not necessary, since the standard
 arithmetic and comparison operations are defined for rational values:
 
-```julia
+```jldoctest
 julia> 2//3 == 6//9
 true
 
@@ -246,7 +249,7 @@ julia> 6//5 / 10//7
 
 Rationals can be easily converted to floating-point numbers:
 
-```julia
+```jldoctest
 julia> float(3//4)
 0.75
 ```
@@ -254,14 +257,16 @@ julia> float(3//4)
 Conversion from rational to floating-point respects the following identity for any integral values
 of `a` and `b`, with the exception of the case `a == 0` and `b == 0`:
 
-```julia
+```jldoctest
+julia> a = 1; b = 2;
+
 julia> isequal(float(a//b), a/b)
 true
 ```
 
 Constructing infinite rational values is acceptable:
 
-```julia
+```jldoctest
 julia> 5//0
 1//0
 
@@ -274,17 +279,17 @@ Rational{Int64}
 
 Trying to construct a [`NaN`](@ref) rational value, however, is not:
 
-```julia
+```jldoctest
 julia> 0//0
 ERROR: ArgumentError: invalid rational: zero(Int64)//zero(Int64)
- in Rational{Int64}(::Int64, ::Int64) at ./rational.jl:8
- in //(::Int64, ::Int64) at ./rational.jl:22
- ...
+Stacktrace:
+ [1] Rational{Int64}(::Int64, ::Int64) at ./rational.jl:8
+ [2] //(::Int64, ::Int64) at ./rational.jl:27
 ```
 
 As usual, the promotion system makes interactions with other numeric types effortless:
 
-```julia
+```jldoctest
 julia> 3//5 + 1
 8//5
 

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -48,7 +48,7 @@ flexible, user-extensible [type promotion system](@ref conversion-and-promotion)
 
 Literal integers are represented in the standard manner:
 
-```julia
+```jldoctest
 julia> 1
 1
 
@@ -102,7 +102,7 @@ UInt64
 Larger integer literals that cannot be represented using only 32 bits but can be represented in
 64 bits always create 64-bit integers, regardless of the system type:
 
-```julia
+```jldoctest
 # 32-bit or 64-bit system:
 julia> typeof(3000000000)
 Int64
@@ -112,7 +112,7 @@ Unsigned integers are input and output using the `0x` prefix and hexadecimal (ba
 `0-9a-f` (the capitalized digits `A-F` also work for input). The size of the unsigned value is
 determined by the number of hex digits used:
 
-```julia
+```jldoctest
 julia> 0x1
 0x01
 
@@ -147,7 +147,7 @@ an interactive session. This does not occur when Julia code is run in other ways
 
 Binary and octal literals are also supported:
 
-```julia
+```jldoctest
 julia> 0b10
 0x02
 
@@ -164,12 +164,12 @@ UInt8
 The minimum and maximum representable values of primitive numeric types such as integers are given
 by the [`typemin()`](@ref) and [`typemax()`](@ref) functions:
 
-```julia
+```jldoctest
 julia> (typemin(Int32), typemax(Int32))
 (-2147483648,2147483647)
 
 julia> for T in [Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128]
-         println("$(lpad(T,7)): [$(typemin(T)),$(typemax(T))]")
+           println("$(lpad(T,7)): [$(typemin(T)),$(typemax(T))]")
        end
    Int8: [-128,127]
   Int16: [-32768,32767]
@@ -192,7 +192,7 @@ with some existing programming experience.)
 
 In Julia, exceeding the maximum representable value of a given type results in a wraparound behavior:
 
-```julia
+```jldoctest
 julia> x = typemax(Int64)
 9223372036854775807
 
@@ -220,7 +220,7 @@ second argument is zero.
 
 Literal floating-point numbers are represented in the standard formats:
 
-```julia
+```jldoctest
 julia> 1.0
 1.0
 
@@ -246,7 +246,7 @@ julia> 2.5e-4
 The above results are all `Float64` values. Literal `Float32` values can be entered by writing
 an `f` in place of `e`:
 
-```julia
+```jldoctest
 julia> 0.5f0
 0.5f0
 
@@ -259,7 +259,7 @@ julia> 2.5f-4
 
 Values can be converted to `Float32` easily:
 
-```julia
+```jldoctest
 julia> Float32(-1.5)
 -1.5f0
 
@@ -269,7 +269,7 @@ Float32
 
 Hexadecimal floating-point literals are also valid, but only as `Float64` values:
 
-```julia
+```jldoctest
 julia> 0x1p0
 1.0
 
@@ -283,10 +283,10 @@ julia> typeof(ans)
 Float64
 ```
 
-Half-precision floating-point numbers are also supported (`Float16`), but only as a storage format.
-In calculations they'll be converted to `Float32`:
+Half-precision floating-point numbers are also supported (`Float16`), but they are
+implemented in software and use `Float32` for calculations.
 
-```julia
+```jldoctest
 julia> sizeof(Float16(4.))
 2
 
@@ -296,7 +296,7 @@ Float16(8.0)
 
 The underscore `_` can be used as digit separator:
 
-```julia
+```jldoctest
 julia> 10_000, 0.000_000_005, 0xdead_beef, 0b1011_0010
 (10000,5.0e-9,0xdeadbeef,0xb2)
 ```
@@ -307,7 +307,7 @@ Floating-point numbers have [two zeros](https://en.wikipedia.org/wiki/Signed_zer
 and negative zero. They are equal to each other but have different binary representations, as
 can be seen using the `bits` function: :
 
-```julia
+```jldoctest
 julia> 0.0 == -0.0
 true
 
@@ -333,7 +333,7 @@ For further discussion of how these non-finite floating-point values are ordered
 to each other and other floats, see [Numeric Comparisons](@ref). By the [IEEE 754 standard](https://en.wikipedia.org/wiki/IEEE_754-2008),
 these floating-point values are the results of certain arithmetic operations:
 
-```julia
+```jldoctest
 julia> 1/Inf
 0.0
 
@@ -373,7 +373,7 @@ NaN
 
 The [`typemin()`](@ref) and [`typemax()`](@ref) functions also apply to floating-point types:
 
-```julia
+```jldoctest
 julia> (typemin(Float16),typemax(Float16))
 (-Inf16,Inf16)
 
@@ -393,7 +393,7 @@ which is often known as [machine epsilon](https://en.wikipedia.org/wiki/Machine_
 Julia provides [`eps()`](@ref), which gives the distance between `1.0` and the next larger representable
 floating-point value:
 
-```julia
+```jldoctest
 julia> eps(Float32)
 1.1920929f-7
 
@@ -410,7 +410,7 @@ difference between that value and the next representable floating point value. T
 yields a value of the same type as `x` such that `x + eps(x)` is the next representable floating-point
 value larger than `x`:
 
-```julia
+```jldoctest
 julia> eps(1.0)
 2.220446049250313e-16
 
@@ -432,9 +432,8 @@ a 64-bit floating-point value.
 
 Julia also provides the [`nextfloat()`](@ref) and [`prevfloat()`](@ref) functions which return
 the next largest or smallest representable floating-point number to the argument respectively:
-:
 
-```julia
+```jldoctest
 julia> x = 1.25f0
 1.25f0
 
@@ -463,7 +462,7 @@ If a number doesn't have an exact floating-point representation, it must be roun
 representable value, however, if wanted, the manner in which this rounding is done can be changed
 according to the rounding modes presented in the [IEEE 754 standard](https://en.wikipedia.org/wiki/IEEE_754-2008).
 
-```julia
+```jldoctest
 julia> x = 1.1; y = 0.1;
 
 julia> x + y
@@ -516,7 +515,7 @@ Constructors exist to create these types from primitive numerical types, and [`p
 can be use to construct them from `AbstractString`s.  Once created, they participate in arithmetic
 with all other numeric types thanks to Julia's [type promotion and conversion mechanism](@ref conversion-and-promotion):
 
-```julia
+```jldoctest
 julia> BigInt(typemax(Int64)) + 1
 9223372036854775808
 
@@ -536,7 +535,7 @@ julia> factorial(BigInt(40))
 However, type promotion between the primitive types above and [`BigInt`](@ref)/[`BigFloat`](@ref)
 is not automatic and must be explicitly stated.
 
-```julia
+```jldoctest
 julia> x = typemin(Int64)
 -9223372036854775808
 
@@ -562,19 +561,19 @@ and all further calculations will take these changes in account.  Alternatively,
 or the rounding can be changed only within the execution of a particular block of code by using
 the same functions with a `do` block:
 
-```julia
+```jldoctest
 julia> setrounding(BigFloat, RoundUp) do
-       BigFloat(1) + parse(BigFloat, "0.1")
+           BigFloat(1) + parse(BigFloat, "0.1")
        end
 1.100000000000000000000000000000000000000000000000000000000000000000000000000003
 
 julia> setrounding(BigFloat, RoundDown) do
-       BigFloat(1) + parse(BigFloat, "0.1")
+           BigFloat(1) + parse(BigFloat, "0.1")
        end
 1.099999999999999999999999999999999999999999999999999999999999999999999999999986
 
 julia> setprecision(40) do
-       BigFloat(1) + parse(BigFloat, "0.1")
+           BigFloat(1) + parse(BigFloat, "0.1")
        end
 1.1000000000004
 ```
@@ -585,7 +584,7 @@ To make common numeric formulas and expressions clearer, Julia allows variables 
 preceded by a numeric literal, implying multiplication. This makes writing polynomial expressions
 much cleaner:
 
-```julia
+```jldoctest
 julia> x = 3
 3
 
@@ -627,11 +626,9 @@ expression, however, can be used to imply multiplication:
 ```julia
 julia> (x-1)(x+1)
 ERROR: MethodError: objects of type Int64 are not callable
-...
 
 julia> x(x+1)
 ERROR: MethodError: objects of type Int64 are not callable
-...
 ```
 
 Both expressions are interpreted as function application: any expression that is not a numeric
@@ -674,7 +671,7 @@ These functions are useful in [Numeric Comparisons](@ref) to avoid overhead from
 
 Examples:
 
-```julia
+```jldoctest
 julia> zero(Float32)
 0.0f0
 

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -33,7 +33,7 @@ system.
 
 Here are some simple examples using arithmetic operators:
 
-```julia
+```jldoctest
 julia> 1 + 2 + 3
 6
 
@@ -65,7 +65,7 @@ are supported on all primitive integer types:
 
 Here are some examples with bitwise operators:
 
-```julia
+```jldoctest
 julia> ~123
 -124
 
@@ -95,7 +95,7 @@ of the operation back into its left operand. The updating version of the binary 
 by placing a `=` immediately after the operator. For example, writing `x += 3` is equivalent to
 writing `x = x + 3`:
 
-```julia
+```jldoctest
 julia> x = 1
 1
 
@@ -116,36 +116,44 @@ The updating versions of all the binary arithmetic and bitwise operators are:
     An updating operator rebinds the variable on the left-hand side. As a result, the type of the
     variable may change.
 
-    ```julia
+    ```jldoctest
     julia> x = 0x01; typeof(x)
     UInt8
 
-    julia> x *= 2 #Same as x = x * 2
+    julia> x *= 2 # Same as x = x * 2
     2
 
-    julia> isa(x, Int)
-    true
+    julia> typeof(x)
+    Int64
     ```
 
 ## [Vectorized "dot" operators](@id man-dot-operators)
 
 For *every* binary operation like `^`, there is a corresponding
 "dot" operation `.^` that is *automatically* defined
-to perform `^` element-by-element on arrays.   For example,
+to perform `^` element-by-element on arrays. For example,
 `[1,2,3] ^ 3` is not defined, since there is no standard
 mathematical meaning to "cubing" an array, but `[1,2,3] .^ 3`
 is defined as computing the elementwise
 (or "vectorized") result `[1^3, 2^3, 3^3]`.
 
+```jldoctest
+julia> [1,2,3] .^ 3
+3-element Array{Int64,1}:
+  1
+  8
+ 27
+```
+
 More specifically, `a .^ b` is parsed as the ["dot" call](@ref man-vectorized)
 `(^).(a,b)`, which performs a [broadcast](@ref Broadcasting) operation:
 it can combine arrays and scalars, arrays of the same size (performing
 the operation elementwise), and even arrays of different shapes (e.g.
-combining row and column vectors to produce a matrix).   Moreover, like
+combining row and column vectors to produce a matrix). Moreover, like
 all vectorized "dot calls," these "dot operators" are
-*fusing*.  For example, if you compute `2 .* A.^2 .+ sin.(A)` for an
+*fusing*. For example, if you compute `2 .* A.^2 .+ sin.(A)` for an
 array `A`, it performs a *single* loop over `A`, computing `2a^2 + sin(a)`
-for each element of `A`.  In particular, nested dot calls like `f.(g.(x))`
+for each element of `A`. In particular, nested dot calls like `f.(g.(x))`
 are fused, and "adjacent" binary operators like `x .+ 3 .* x.^2` are
 equivalent to nested dot calls `(+).(x, (*).(3, (^).(x, 2)))`.
 
@@ -173,7 +181,7 @@ Standard comparison operations are defined for all the primitive numeric types:
 
 Here are some simple examples:
 
-```julia
+```jldoctest
 julia> 1 == 1
 true
 
@@ -219,7 +227,7 @@ are compared according to the [IEEE 754 standard](https://en.wikipedia.org/wiki/
 
 The last point is potentially surprising and thus worth noting:
 
-```julia
+```jldoctest
 julia> NaN == NaN
 false
 
@@ -235,7 +243,7 @@ false
 
 and can cause especial headaches with [Arrays](@ref):
 
-```julia
+```jldoctest
 julia> [1 NaN] == [1 NaN]
 false
 ```
@@ -252,20 +260,20 @@ situations like hash key comparisons:
 
 [`isequal()`](@ref) considers `NaN`s equal to each other:
 
-```julia
-julia> isequal(NaN,NaN)
+```jldoctest
+julia> isequal(NaN, NaN)
 true
 
 julia> isequal([1 NaN], [1 NaN])
 true
 
-julia> isequal(NaN,NaN32)
+julia> isequal(NaN, NaN32)
 true
 ```
 
-[`isequal()`](@ref) can also be used to distinguish signed zeros:
+`isequal()` can also be used to distinguish signed zeros:
 
-```julia
+```jldoctest
 julia> -0.0 == 0.0
 true
 
@@ -276,7 +284,7 @@ false
 Mixed-type comparisons between signed integers, unsigned integers, and floats can be tricky. A
 great deal of care has been taken to ensure that Julia does them correctly.
 
-For other types, [`isequal()`](@ref) defaults to calling [`==()`](@ref), so if you want to define
+For other types, `isequal()` defaults to calling [`==()`](@ref), so if you want to define
 equality for your own types then you only need to add a [`==()`](@ref) method.  If you define
 your own equality function, you should probably define a corresponding [`hash()`](@ref) method
 to ensure that `isequal(x,y)` implies `hash(x) == hash(y)`.
@@ -286,7 +294,7 @@ to ensure that `isequal(x,y)` implies `hash(x) == hash(y)`.
 Unlike most languages, with the [notable exception of Python](https://en.wikipedia.org/wiki/Python_syntax_and_semantics#Comparison_operators),
 comparisons can be arbitrarily chained:
 
-```julia
+```jldoctest
 julia> 1 < 2 <= 2 < 3 == 3 > 2 >= 1 == 1 < 3 != 5
 true
 ```
@@ -298,7 +306,7 @@ are true where the corresponding elements of `A` are between 0 and 1.
 
 Note the evaluation behavior of chained comparisons:
 
-```julia
+```jldoctest
 julia> v(x) = (println(x); x)
 v (generic function with 1 method)
 
@@ -366,29 +374,29 @@ conversions.
 
 The following examples show the different forms.
 
-```julia
+```jldoctest
 julia> Int8(127)
 127
 
 julia> Int8(128)
 ERROR: InexactError()
- in Int8(::Int64) at ./sysimg.jl:66
- ...
+Stacktrace:
+ [1] Int8(::Int64) at ./sysimg.jl:24
 
 julia> Int8(127.0)
 127
 
 julia> Int8(3.14)
 ERROR: InexactError()
- in convert(::Type{Int8}, ::Float64) at ./float.jl:635
- in Int8(::Float64) at ./sysimg.jl:66
- ...
+Stacktrace:
+ [1] convert(::Type{Int8}, ::Float64) at ./float.jl:654
+ [2] Int8(::Float64) at ./sysimg.jl:24
 
 julia> Int8(128.0)
 ERROR: InexactError()
- in convert(::Type{Int8}, ::Float64) at ./float.jl:635
- in Int8(::Float64) at ./sysimg.jl:66
- ...
+Stacktrace:
+ [1] convert(::Type{Int8}, ::Float64) at ./float.jl:654
+ [2] Int8(::Float64) at ./sysimg.jl:24
 
 julia> 127 % Int8
 127
@@ -401,9 +409,9 @@ julia> round(Int8,127.4)
 
 julia> round(Int8,127.6)
 ERROR: InexactError()
- in trunc(::Type{Int8}, ::Float64) at ./float.jl:628
- in round(::Type{Int8}, ::Float64) at ./float.jl:332
- ...
+Stacktrace:
+ [1] trunc(::Type{Int8}, ::Float64) at ./float.jl:647
+ [2] round(::Type{Int8}, ::Float64) at ./float.jl:333
 ```
 
 See [Conversion and Promotion](@ref conversion-and-promotion) for how to define your own conversions and promotions.

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -46,9 +46,9 @@ representation and appropriate arithmetic behaviors, whose numeric value is inte
 [Unicode code point](https://en.wikipedia.org/wiki/Code_point). Here is how `Char` values are
 input and shown:
 
-```julia
+```jldoctest
 julia> 'x'
-'x'
+'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 
 julia> typeof(ans)
 Char
@@ -56,7 +56,7 @@ Char
 
 You can convert a `Char` to its integer value, i.e. code point, easily:
 
-```julia
+```jldoctest
 julia> Int('x')
 120
 
@@ -67,18 +67,18 @@ Int64
 On 32-bit architectures, [`typeof(ans)`](@ref) will be `Int32`. You can convert an integer value
 back to a `Char` just as easily:
 
-```julia
+```jldoctest
 julia> Char(120)
-'x'
+'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 ```
 
 Not all integer values are valid Unicode code points, but for performance, the `Char()` conversion
 does not check that every character value is valid. If you want to check that each converted value
 is a valid code point, use the [`isvalid()`](@ref) function:
 
-```julia
+```jldoctest
 julia> Char(0x110000)
-'\U110000'
+'\U110000': Unicode U+110000 (category Cn: Other, not assigned)
 
 julia> isvalid(Char, 0x110000)
 false
@@ -92,18 +92,18 @@ You can input any Unicode character in single quotes using `\u` followed by up t
 digits or `\U` followed by up to eight hexadecimal digits (the longest valid value only requires
 six):
 
-```julia
+```jldoctest
 julia> '\u0'
-'\0'
+'\0': ASCII/Unicode U+0000 (category Cc: Other, control)
 
 julia> '\u78'
-'x'
+'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 
 julia> '\u2200'
-'∀'
+'∀': Unicode U+2200 (category Sm: Symbol, math)
 
 julia> '\U10ffff'
-'\U10ffff'
+'\U10ffff': Unicode U+10ffff (category Cn: Other, not assigned)
 ```
 
 Julia uses your system's locale and language settings to determine which characters can be printed
@@ -111,7 +111,7 @@ as-is and which must be output using the generic, escaped `\u` or `\U` input for
 to these Unicode escape forms, all of [C's traditional escaped input forms](https://en.wikipedia.org/wiki/C_syntax#Backslash_escapes)
 can also be used:
 
-```julia
+```jldoctest
 julia> Int('\0')
 0
 
@@ -136,7 +136,7 @@ julia> Int('\xff')
 
 You can do comparisons and a limited amount of arithmetic with `Char` values:
 
-```julia
+```jldoctest
 julia> 'A' < 'a'
 true
 
@@ -150,14 +150,14 @@ julia> 'x' - 'a'
 23
 
 julia> 'A' + 1
-'B'
+'B': ASCII/Unicode U+0042 (category Lu: Letter, uppercase)
 ```
 
 ## String Basics
 
 String literals are delimited by double quotes or triple double quotes:
 
-```julia
+```jldoctest helloworldstring
 julia> str = "Hello, world.\n"
 "Hello, world.\n"
 
@@ -167,15 +167,15 @@ julia> """Contains "quote" characters"""
 
 If you want to extract a character from a string, you index into it:
 
-```julia
+```jldoctest helloworldstring
 julia> str[1]
-'H'
+'H': ASCII/Unicode U+0048 (category Lu: Letter, uppercase)
 
 julia> str[6]
-','
+',': ASCII/Unicode U+002c (category Po: Punctuation, other)
 
 julia> str[end]
-'\n'
+'\n': ASCII/Unicode U+000a (category Cc: Other, control)
 ```
 
 All indexing in Julia is 1-based: the first element of any integer-indexed object is found at
@@ -185,36 +185,40 @@ In any indexing expression, the keyword `end` can be used as a shorthand for the
 by [`endof(str)`](@ref)). You can perform arithmetic and other operations with `end`, just like
 a normal value:
 
-```julia
+```jldoctest helloworldstring
 julia> str[end-1]
-'.'
+'.': ASCII/Unicode U+002e (category Po: Punctuation, other)
 
 julia> str[end÷2]
-' '
+' ': ASCII/Unicode U+0020 (category Zs: Separator, space)
 ```
 
 Using an index less than 1 or greater than `end` raises an error:
 
-```julia
+```jldoctest helloworldstring
 julia> str[0]
-ERROR: BoundsError: attempt to access 14-element Array{UInt8,1} at index [0]
+ERROR: BoundsError: attempt to access "Hello, world.\n"
+  at index [0]
+[...]
 
 julia> str[end+1]
-ERROR: BoundsError: attempt to access 14-element Array{UInt8,1} at index [15]
+ERROR: BoundsError: attempt to access "Hello, world.\n"
+  at index [15]
+[...]
 ```
 
 You can also extract a substring using range indexing:
 
-```julia
+```jldoctest helloworldstring
 julia> str[4:9]
 "lo, wo"
 ```
 
 Notice that the expressions `str[k]` and `str[k:k]` do not give the same result:
 
-```julia
+```jldoctest helloworldstring
 julia> str[6]
-','
+',': ASCII/Unicode U+002c (category Po: Punctuation, other)
 
 julia> str[6:6]
 ","
@@ -229,7 +233,7 @@ Julia fully supports Unicode characters and strings. As [discussed above](@ref m
 literals, Unicode code points can be represented using Unicode `\u` and `\U` escape sequences,
 as well as all the standard C escape sequences. These can likewise be used to write string literals:
 
-```julia
+```jldoctest unicodestring
 julia> s = "\u2200 x \u2203 y"
 "∀ x ∃ y"
 ```
@@ -243,26 +247,20 @@ above are encoded using multiple bytes -- up to four per character. This means t
 byte index into a UTF-8 string is necessarily a valid index for a character. If you index into
 a string at such an invalid byte index, an error is thrown:
 
-```julia
+```jldoctest unicodestring
 julia> s[1]
-'∀'
+'∀': Unicode U+2200 (category Sm: Symbol, math)
 
 julia> s[2]
 ERROR: UnicodeError: invalid character index
- in slow_utf8_next(::Array{UInt8,1}, ::UInt8, ::Int64) at ./strings/string.jl:67
- in next at ./strings/string.jl:92 [inlined]
- in getindex(::String, ::Int64) at ./strings/basic.jl:71
- ...
+[...]
 
 julia> s[3]
 ERROR: UnicodeError: invalid character index
- in slow_utf8_next(::Array{UInt8,1}, ::UInt8, ::Int64) at ./strings/string.jl:67
- in next at ./strings/string.jl:92 [inlined]
- in getindex(::String, ::Int64) at ./strings/basic.jl:71
- ...
+[...]
 
 julia> s[4]
-' '
+' ': ASCII/Unicode U+0020 (category Zs: Separator, space)
 ```
 
 In this case, the character `∀` is a three-byte character, so the indices 2 and 3 are invalid
@@ -276,7 +274,7 @@ of characters comprising the string `s`. Thus we have the identity that `length(
 since each character in a string must have its own index. The following is an inefficient and
 verbose way to iterate through the characters of `s`:
 
-```julia
+```jldoctest unicodestring
 julia> for i = 1:endof(s)
            try
                println(s[i])
@@ -297,7 +295,7 @@ The blank lines actually have spaces on them. Fortunately, the above awkward idi
 for iterating through the characters in a string, since you can just use the string as an iterable
 object, no exception handling required:
 
-```julia
+```jldoctest unicodestring
 julia> for c in s
            println(c)
        end
@@ -374,7 +372,7 @@ rewrites this apparent single string literal into a concatenation of string lite
 The shortest complete expression after the `$` is taken as the expression whose value is to be
 interpolated into the string. Thus, you can interpolate any expression into a string using parentheses:
 
-```julia
+```jldoctest
 julia> "1 + 2 = $(1 + 2)"
 "1 + 2 = 3"
 ```
@@ -383,7 +381,7 @@ Both concatenation and string interpolation call [`string()`](@ref) to convert o
 form. Most non-`AbstractString` objects are converted to strings closely corresponding to how
 they are entered as literal expressions:
 
-```julia
+```jldoctest
 julia> v = [1,2,3]
 3-element Array{Int64,1}:
  1
@@ -397,9 +395,9 @@ julia> "v: $v"
 [`string()`](@ref) is the identity for `AbstractString` and `Char` values, so these are interpolated
 into strings as themselves, unquoted and unescaped:
 
-```julia
+```jldoctest
 julia> c = 'x'
-'x'
+'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 
 julia> "hi, $c"
 "hi, x"
@@ -407,7 +405,7 @@ julia> "hi, $c"
 
 To include a literal `$` in a string literal, escape it with a backslash:
 
-```julia
+```jldoctest
 julia> print("I have \$100 in my account.\n")
 I have $100 in my account.
 ```
@@ -442,7 +440,7 @@ contain `"` symbols without escaping. Triple-quoted strings are also dedented to
 the least-indented line. This is useful for defining strings within code that is indented. For
 example:
 
-```julia
+```jldoctest
 julia> str = """
            Hello,
            world.
@@ -461,7 +459,7 @@ you can enter the literal string `"a CRLF line ending\r\n"`.
 
 You can lexicographically compare strings using the standard comparison operators:
 
-```julia
+```jldoctest
 julia> "abracadabra" < "xylophone"
 true
 
@@ -477,7 +475,7 @@ true
 
 You can search for the index of a particular character using the [`search()`](@ref) function:
 
-```julia
+```jldoctest
 julia> search("xylophone", 'x')
 1
 
@@ -490,7 +488,7 @@ julia> search("xylophone", 'z')
 
 You can start the search for a character at a given offset by providing a third argument:
 
-```julia
+```jldoctest
 julia> search("xylophone", 'o')
 4
 
@@ -503,7 +501,7 @@ julia> search("xylophone", 'o', 8)
 
 You can use the [`contains()`](@ref) function to check if a substring is contained in a string:
 
-```julia
+```jldoctest
 julia> contains("Hello, world.", "world")
 true
 
@@ -516,9 +514,8 @@ false
 julia> contains("Xylophon", 'o')
 ERROR: MethodError: no method matching contains(::String, ::Char)
 Closest candidates are:
-  contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:640
-  contains(::AbstractString, !Matched::AbstractString) at strings/search.jl:366
- ...
+  contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:634
+  contains(::AbstractString, !Matched::AbstractString) at strings/search.jl:359
 ```
 
 The last error is because `'o'` is a character literal, and [`contains()`](@ref) is a generic
@@ -527,7 +524,7 @@ instead.
 
 Two other handy string functions are [`repeat()`](@ref) and [`join()`](@ref):
 
-```julia
+```jldoctest
 julia> repeat(".:Z:.", 10)
 ".:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:."
 
@@ -568,7 +565,7 @@ can be used to efficiently search for patterns in strings. In Julia, regular exp
 using non-standard string literals prefixed with various identifiers beginning with `r`. The most
 basic regular expression literal without any options turned on just uses `r"..."`:
 
-```julia
+```jldoctest
 julia> r"^\s*(?:#|$)"
 r"^\s*(?:#|$)"
 
@@ -578,7 +575,7 @@ Regex
 
 To check if a regex matches a string, use [`ismatch()`](@ref):
 
-```julia
+```jldoctest
 julia> ismatch(r"^\s*(?:#|$)", "not a comment")
 false
 
@@ -591,7 +588,7 @@ given regex matches the string or not. Commonly, however, one wants to know not 
 string matched, but also *how* it matched. To capture this information about a match, use the
 [`match()`](@ref) function instead:
 
-```julia
+```jldoctest
 julia> match(r"^\s*(?:#|$)", "not a comment")
 
 julia> match(r"^\s*(?:#|$)", "# a comment")
@@ -617,7 +614,7 @@ matches and any captured substrings, if there are any. This example only capture
 of the substring that matches, but perhaps we want to capture any non-blank text after the comment
 character. We could do the following:
 
-```julia
+```jldoctest
 julia> m = match(r"^\s*(?:#\s*(.*?)\s*$|$)", "# a comment ")
 RegexMatch("# a comment ", 1="a comment")
 ```
@@ -625,7 +622,7 @@ RegexMatch("# a comment ", 1="a comment")
 When calling [`match()`](@ref), you have the option to specify an index at which to start the
 search. For example:
 
-```julia
+```jldoctest
 julia> m = match(r"[0-9]","aaaa1aaaa2aaaa3",1)
 RegexMatch("1")
 
@@ -647,7 +644,7 @@ For when a capture doesn't match, instead of a substring, `m.captures` contains 
 position, and `m.offsets` has a zero offset (recall that indices in Julia are 1-based, so a zero
 offset into a string is invalid). Here is a pair of somewhat contrived examples:
 
-```julia
+```jldoctest
 julia> m = match(r"(a|b)(c)?(d)", "acd")
 RegexMatch("acd", 1="a", 2="c", 3="d")
 
@@ -702,11 +699,13 @@ julia> first, second, third = m.captures; first
 Captures can also be accessed by indexing the `RegexMatch` object with the number or name of the
 capture group:
 
-```julia
+```jldoctest
 julia> m=match(r"(?<hour>\d+):(?<minute>\d+)","12:45")
 RegexMatch("12:45", hour="12", minute="45")
+
 julia> m[:minute]
 "45"
+
 julia> m[2]
 "45"
 ```
@@ -716,14 +715,14 @@ to refer to the nth capture group and prefixing the subsitution string with `s`.
 0 refers to the entire match object. Named capture groups can be referenced in the substitution
 with `g<groupname>`. For example:
 
-```julia
+```jldoctest
 julia> replace("first second", r"(\w+) (?<agroup>\w+)", s"\g<agroup> \1")
 "second first"
 ```
 
 Numbered capture groups can also be referenced as `\g<n>` for disambiguation, as in:
 
-```julia
+```jldoctest
 julia> replace("a", r".", s"\g<0>1")
 "a1"
 ```
@@ -764,7 +763,7 @@ x   Tells the regular expression parser to ignore most whitespace
 
 For example, the following regex has all three flags turned on:
 
-```julia
+```jldoctest
 julia> r"a+.*b+.*?d$"ism
 r"a+.*b+.*?d$"ims
 
@@ -790,7 +789,7 @@ There is some overlap between these rules since the behavior of `\x` and octal e
 rules allow one to easily use ASCII characters, arbitrary byte values, and UTF-8 sequences to
 produce arrays of bytes. Here is an example using all three:
 
-```julia
+```jldoctest
 julia> b"DATA\xff\u2200"
 8-element Array{UInt8,1}:
  0x44
@@ -811,14 +810,13 @@ a regular string literal, you will get a syntax error:
 ```julia
 julia> "DATA\xff\u2200"
 ERROR: syntax: invalid UTF-8 sequence
- ...
 ```
 
 Also observe the significant distinction between `\xff` and `\uff`: the former escape sequence
 encodes the *byte 255*, whereas the latter escape sequence represents the *code point 255*, which
 is encoded as two bytes in UTF-8:
 
-```julia
+```jldoctest
 julia> b"\xff"
 1-element Array{UInt8,1}:
  0xff

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -25,7 +25,7 @@ Julia provides an extremely flexible system for naming variables. Variable names
 and have no semantic meaning (that is, the language will not treat variables differently based
 on their names).
 
-```julia
+```jldoctest
 julia> x = 1.0
 1.0
 
@@ -44,7 +44,7 @@ julia> UniversalDeclarationOfHumanRightsStart = "人人生而自由，在尊严�
 
 Unicode names (in UTF-8 encoding) are allowed:
 
-```julia
+```jldoctest
 julia> δ = 0.00001
 1.0e-5
 
@@ -53,15 +53,15 @@ julia> 안녕하세요 = "Hello"
 ```
 
 In the Julia REPL and several other Julia editing environments, you can type many Unicode math
-symbols by typing the backslashed LaTeX symbol name followed by tab.  For example, the variable
+symbols by typing the backslashed LaTeX symbol name followed by tab. For example, the variable
 name `δ` can be entered by typing `\delta`-*tab*, or even `α̂₂` by `\alpha`-*tab*-`\hat`-
-*tab*-`\_2`-*tab*.  (If you find a symbol somewhere, e.g. in someone else's code,
+*tab*-`\_2`-*tab*. (If you find a symbol somewhere, e.g. in someone else's code,
 that you don't know how to type, the REPL help will tell you: just type `?` and
 then paste the symbol.)
 
 Julia will even let you redefine built-in constants and functions if needed:
 
-```julia
+```jldoctest
 julia> pi
 π = 3.1415926535897...
 
@@ -94,7 +94,7 @@ primes, and a few other characters.
 
 Operators like `+` are also valid identifiers, but are parsed specially. In some contexts, operators
 can be used just like variables; for example `(+)` refers to the addition function, and `(+) = f`
-will reassign it.  Most of the Unicode infix operators (in category Sm), such as `⊕`, are parsed
+will reassign it. Most of the Unicode infix operators (in category Sm), such as `⊕`, are parsed
 as infix operators and are available for user-defined methods (e.g. you can use `const ⊗ = kron`
 to define `⊗` as an infix Kronecker product).
 
@@ -103,11 +103,9 @@ The only explicitly disallowed names for variables are the names of built-in sta
 ```julia
 julia> else = false
 ERROR: syntax: unexpected "else"
- ...
 
 julia> try = "No"
 ERROR: syntax: unexpected "="
- ...
 ```
 
 Some Unicode characters are considered to be equivalent in identifiers.


### PR DESCRIPTION
Started from the top of the manual: this PR converts to (and updates) the examples in the first 5 markdown files to use doctests. Some of them are trivial, but the doctests run really fast so there is no reason not to add it IMO.

(all the added doctests pass locally, and `make check-whitespace` passes so i `[ci skip]`'d, remove this if/when this is merged)