### PR TITLE
doctests for manual/functions.md (part 2)

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -4,17 +4,19 @@ In Julia, a function is an object that maps a tuple of argument values to a retu
 functions are not pure mathematical functions, in the sense that functions can alter and be affected
 by the global state of the program. The basic syntax for defining functions in Julia is:
 
-```julia
-function f(x,y)
-  x + y
-end
+```jldoctest
+julia> function f(x,y)
+           x + y
+       end
+f (generic function with 1 method)
 ```
 
 There is a second, more terse syntax for defining a function in Julia. The traditional function
 declaration syntax demonstrated above is equivalent to the following compact "assignment form":
 
-```julia
-f(x,y) = x + y
+```jldoctest fofxy
+julia> f(x,y) = x + y
+f (generic function with 1 method)
 ```
 
 In the assignment form, the body of the function must be a single expression, although it can
@@ -24,7 +26,7 @@ both typing and visual noise.
 
 A function is called using the traditional parenthesis syntax:
 
-```julia
+```jldoctest fofxy
 julia> f(2,3)
 5
 ```
@@ -32,7 +34,7 @@ julia> f(2,3)
 Without parentheses, the expression `f` refers to the function object, and can be passed around
 like any value:
 
-```julia
+```jldoctest fofxy
 julia> g = f;
 
 julia> g(2,3)
@@ -41,9 +43,12 @@ julia> g(2,3)
 
 As with variables, Unicode can also be used for function names:
 
-```julia
+```jldoctest
 julia> ∑(x,y) = x + y
 ∑ (generic function with 1 method)
+
+julia> ∑(2, 3)
+5
 ```
 
 ## Argument Passing Behavior
@@ -65,21 +70,23 @@ an expression whose value is returned:
 
 ```julia
 function g(x,y)
-  return x * y
-  x + y
+    return x * y
+    x + y
 end
 ```
 
 Since function definitions can be entered into interactive sessions, it is easy to compare these
 definitions:
 
-```julia
-f(x,y) = x + y
+```jldoctest
+julia> f(x,y) = x + y
+f (generic function with 1 method)
 
-function g(x,y)
-  return x * y
-  x + y
-end
+julia> function g(x,y)
+           return x * y
+           x + y
+       end
+g (generic function with 1 method)
 
 julia> f(2,3)
 5
@@ -94,20 +101,24 @@ in the function and omit the `return`. In conjunction with other control flow, h
 is of real use. Here, for example, is a function that computes the hypotenuse length of a right
 triangle with sides of length `x` and `y`, avoiding overflow:
 
-```julia
-function hypot(x,y)
-  x = abs(x)
-  y = abs(y)
-  if x > y
-    r = y/x
-    return x*sqrt(1+r*r)
-  end
-  if y == 0
-    return zero(x)
-  end
-  r = x/y
-  return y*sqrt(1+r*r)
-end
+```jldoctest
+julia> function hypot(x,y)
+           x = abs(x)
+           y = abs(y)
+           if x > y
+               r = y/x
+               return x*sqrt(1+r*r)
+           end
+           if y == 0
+               return zero(x)
+           end
+           r = x/y
+           return y*sqrt(1+r*r)
+       end
+hypot (generic function with 1 method)
+
+julia> hypot(3, 4)
+5.0
 ```
 
 There are three possible points of return from this function, returning the values of three different
@@ -122,7 +133,7 @@ since [Short-Circuit Evaluation](@ref) requires that their operands are not eval
 of the operator.) Accordingly, you can also apply them using parenthesized argument lists, just
 as you would any other function:
 
-```julia
+```jldoctest
 julia> 1 + 2 + 3
 6
 
@@ -134,7 +145,7 @@ The infix form is exactly equivalent to the function application form -- in fact
 parsed to produce the function call internally. This also means that you can assign and pass around
 operators such as [`+()`](@ref) and [`*()`](@ref) just like you would with other function values:
 
-```julia
+```jldoctest
 julia> f = +;
 
 julia> f(1,2,3)
@@ -169,7 +180,7 @@ variable they have been assigned to. They can be used as arguments, and they can
 values. They can also be created anonymously, without being given a name, using either of these
 syntaxes:
 
-```julia
+```jldoctest
 julia> x -> x^2 + 2x - 1
 (::#1) (generic function with 1 method)
 
@@ -187,7 +198,7 @@ The primary use for anonymous functions is passing them to functions which take 
 as arguments. A classic example is [`map()`](@ref), which applies a function to each value of
 an array and returns a new array containing the resulting values:
 
-```julia
+```jldoctest
 julia> map(round, [1.2,3.5,1.7])
 3-element Array{Float64,1}:
  1.0
@@ -200,7 +211,7 @@ first argument to [`map()`](@ref). Often, however, a ready-to-use, named functio
 In these situations, the anonymous function construct allows easy creation of a single-use function
 object without needing a name:
 
-```julia
+```jldoctest
 julia> map(x -> x^2 + 2x - 1, [1,3,-1])
 3-element Array{Int64,1}:
   2
@@ -220,16 +231,17 @@ can be created and destructured without needing parentheses, thereby providing a
 multiple values are being returned, rather than a single tuple value. For example, the following
 function returns a pair of values:
 
-```julia
+```jldoctest foofunc
 julia> function foo(a,b)
-         a+b, a*b
-       end;
+           a+b, a*b
+       end
+foo (generic function with 1 method)
 ```
 
 If you call it in an interactive session without assigning the return value anywhere, you will
 see the tuple returned:
 
-```julia
+```jldoctest foofunc
 julia> foo(2,3)
 (5,6)
 ```
@@ -237,8 +249,9 @@ julia> foo(2,3)
 A typical usage of such a pair of return values, however, extracts each value into a variable.
 Julia supports simple tuple "destructuring" that facilitates this:
 
-```julia
-julia> x, y = foo(2,3);
+```jldoctest foofunc
+julia> x, y = foo(2,3)
+(5,6)
 
 julia> x
 5
@@ -251,7 +264,7 @@ You can also return multiple values via an explicit usage of the `return` keywor
 
 ```julia
 function foo(a,b)
-  return a+b, a*b
+    return a+b, a*b
 end
 ```
 
@@ -263,7 +276,7 @@ It is often convenient to be able to write functions taking an arbitrary number 
 Such functions are traditionally known as "varargs" functions, which is short for "variable number
 of arguments". You can define a varargs function by following the last argument with an ellipsis:
 
-```julia
+```jldoctest barfunc
 julia> bar(a,b,x...) = (a,b,x)
 bar (generic function with 1 method)
 ```
@@ -272,7 +285,7 @@ The variables `a` and `b` are bound to the first two argument values as usual, a
 `x` is bound to an iterable collection of the zero or more values passed to `bar` after its first
 two arguments:
 
-```julia
+```jldoctest barfunc
 julia> bar(1,2)
 (1,2,())
 
@@ -295,7 +308,7 @@ On the flip side, it is often handy to "splice" the values contained in an itera
 into a function call as individual arguments. To do this, one also uses `...` but in the function
 call instead:
 
-```julia
+```jldoctest barfunc
 julia> x = (3,4)
 (3,4)
 
@@ -306,7 +319,7 @@ julia> bar(1,2,x...)
 In this case a tuple of values is spliced into a varargs call precisely where the variable number
 of arguments go. This need not be the case, however:
 
-```julia
+```jldoctest barfunc
 julia> x = (2,3,4)
 (2,3,4)
 
@@ -322,7 +335,7 @@ julia> bar(x...)
 
 Furthermore, the iterable object spliced into a function call need not be a tuple:
 
-```julia
+```jldoctest barfunc
 julia> x = [3,4]
 2-element Array{Int64,1}:
  3
@@ -345,7 +358,7 @@ julia> bar(x...)
 Also, the function that arguments are spliced into need not be a varargs function (although it
 often is):
 
-```julia
+```jldoctest
 julia> baz(a,b) = a + b;
 
 julia> args = [1,2]
@@ -366,7 +379,6 @@ julia> baz(args...)
 ERROR: MethodError: no method matching baz(::Int64, ::Int64, ::Int64)
 Closest candidates are:
   baz(::Any, ::Any) at none:1
-...
 ```
 
 As you can see, if the wrong number of elements are in the spliced container, then the function
@@ -379,7 +391,7 @@ be passed explicitly in every call. For example, the library function [`parse(T,
 interprets a string as a number in some base. The `base` argument defaults to `10`. This behavior
 can be expressed concisely as:
 
-```
+```julia
 function parse(type, num, base=10)
     ###
 end
@@ -388,7 +400,7 @@ end
 With this definition, the function can be called with either two or three arguments, and `10`
 is automatically passed when a third argument is not specified:
 
-```julia
+```jldoctest
 julia> parse(Int,"12",10)
 12
 
@@ -424,7 +436,7 @@ end
 ```
 
 When the function is called, the semicolon is optional: one can either call `plot(x, y, width=2)`
-or `plot(x, y; width=2)`, but the former style is more common.  An explicit semicolon is required
+or `plot(x, y; width=2)`, but the former style is more common. An explicit semicolon is required
 only for passing varargs or computed keywords as described below.
 
 Keyword argument default values are evaluated only when necessary (when a corresponding keyword
@@ -452,8 +464,8 @@ Such collections can be passed as keyword arguments using a semicolon in a call,
 Dictionaries can also be used for this purpose.
 
 One can also pass `(key,value)` tuples, or any iterable expression (such as a `=>` pair) that
-can be assigned to such a tuple, explicitly after a semicolon.  For example, `plot(x, y; (:width,2))`
-and `plot(x, y; :width => 2)` are equivalent to `plot(x, y, width=2)`.  This is useful in situations
+can be assigned to such a tuple, explicitly after a semicolon. For example, `plot(x, y; (:width,2))`
+and `plot(x, y; :width => 2)` are equivalent to `plot(x, y, width=2)`. This is useful in situations
 where the keyword name is computed at runtime.
 
 The nature of keyword arguments makes it possible to specify the same argument more than once.
@@ -558,42 +570,90 @@ the arguments of the user function are initialized.
 
 In technical-computing languages, it is common to have "vectorized" versions of functions, which
 simply apply a given function `f(x)` to each element of an array `A` to yield a new array via
-`f(A)`.   This kind of syntax is convenient for data processing, but in other languages vectorization
+`f(A)`. This kind of syntax is convenient for data processing, but in other languages vectorization
 is also often required for performance: if loops are slow, the "vectorized" version of a function
-can call fast library code written in a low-level language.   In Julia, vectorized functions are
+can call fast library code written in a low-level language. In Julia, vectorized functions are
 *not* required for performance, and indeed it is often beneficial to write your own loops (see
-[Performance Tips](@ref man-performance-tips)), but they can still be convenient.  Therefore, *any* Julia function
+[Performance Tips](@ref man-performance-tips)), but they can still be convenient. Therefore, *any* Julia function
 `f` can be applied elementwise to any array (or other collection) with the syntax `f.(A)`.
+For example `sin` can be applied to all elements in the vector `A`, like so:
+
+```jldoctest
+julia> A = [1.0, 2.0, 3.0]
+3-element Array{Float64,1}:
+ 1.0
+ 2.0
+ 3.0
+
+julia> sin.(A)
+3-element Array{Float64,1}:
+ 0.841471
+ 0.909297
+ 0.14112
+```
 
 Of course, you can omit the dot if you write a specialized "vector" method of `f`, e.g. via `f(A::AbstractArray) = map(f, A)`,
-and this is just as efficient as `f.(A)`.   But that approach requires you to decide in advance
+and this is just as efficient as `f.(A)`. But that approach requires you to decide in advance
 which functions you want to vectorize.
 
 More generally, `f.(args...)` is actually equivalent to `broadcast(f, args...)`, which allows
 you to operate on multiple arrays (even of different shapes), or a mix of arrays and scalars (see
-[Broadcasting](@ref)).  For example, if you have `f(x,y) = 3x + 4y`, then `f.(pi,A)` will return
+[Broadcasting](@ref)). For example, if you have `f(x,y) = 3x + 4y`, then `f.(pi,A)` will return
 a new array consisting of `f(pi,a)` for each `a` in `A`, and `f.(vector1,vector2)` will return
 a new vector consisting of `f(vector1[i],vector2[i])` for each index `i` (throwing an exception
 if the vectors have different length).
 
-Moreover, *nested*`f.(args...)` calls are *fused* into a single `broadcast` loop.  For example,
+```jldoctest
+julia> f(x,y) = 3x + 4y;
+
+julia> A = [1.0, 2.0, 3.0];
+
+julia> B = [4.0, 5.0, 6.0];
+
+julia> f.(pi, A)
+3-element Array{Float64,1}:
+ 13.4248
+ 17.4248
+ 21.4248
+
+julia> f.(A, B)
+3-element Array{Float64,1}:
+ 19.0
+ 26.0
+ 33.0
+```
+
+Moreover, *nested* `f.(args...)` calls are *fused* into a single `broadcast` loop. For example,
 `sin.(cos.(X))` is equivalent to `broadcast(x -> sin(cos(x)), X)`, similar to `[sin(cos(x)) for x in X]`:
-there is only a single loop over `X`, and a single array is allocated for the result.   [In contrast,
+there is only a single loop over `X`, and a single array is allocated for the result. [In contrast,
 `sin(cos(X))` in a typical "vectorized" language would first allocate one temporary array for
 `tmp=cos(X)`, and then compute `sin(tmp)` in a separate loop, allocating a second array.] This
 loop fusion is not a compiler optimization that may or may not occur, it is a *syntactic guarantee*
-whenever nested `f.(args...)` calls are encountered.  Technically, the fusion stops as soon as
+whenever nested `f.(args...)` calls are encountered. Technically, the fusion stops as soon as
 a "non-dot" function call is encountered; for example, in `sin.(sort(cos.(X)))` the `sin` and `cos`
 loops cannot be merged because of the intervening `sort` function.
 
 Finally, the maximum efficiency is typically achieved when the output array of a vectorized operation
 is *pre-allocated*, so that repeated calls do not allocate new arrays over and over again for
-the results ([Pre-allocating outputs](@ref):).   A convenient syntax for this is `X .= ...`, which
+the results ([Pre-allocating outputs](@ref):). A convenient syntax for this is `X .= ...`, which
 is equivalent to `broadcast!(identity, X, ...)` except that, as above, the `broadcast!` loop is
-fused with any nested "dot" calls.  For example, `X .= sin.(Y)` is equivalent to `broadcast!(sin, X, Y)`,
+fused with any nested "dot" calls. For example, `X .= sin.(Y)` is equivalent to `broadcast!(sin, X, Y)`,
 overwriting `X` with `sin.(Y)` in-place. If the left-hand side is an array-indexing expression,
 e.g. `X[2:end] .= sin.(Y)`, then it translates to `broadcast!` on a `view`, e.g. `broadcast!(sin, view(X, 2:endof(X)), Y)`,
 so that the left-hand side is updated in-place.
+
+```jldoctest
+julia> Y = [1.0, 2.0, 3.0, 4.0];
+
+julia> X = similar(Y); # pre-allocate output array
+
+julia> X .= sin.(cos.(Y))
+4-element Array{Float64,1}:
+  0.514395
+ -0.404239
+ -0.836022
+ -0.608083
+```
 
 Operators like `.*` are handled with the same mechanism:
 they are equivalent to `broadcast` calls and are fused with other nested "dot" calls.


### PR DESCRIPTION
add doctests, and add some examples to break up the quite compact section about vectorizing functions
also some whitespace and indentation fixes

(`make check-whitespace` and the doctests pass locally, remove `[ci skip]` from commit message if/when this is merged)