### PR TITLE
doctests for the manual, part 3

### DIFF
--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -22,7 +22,7 @@ in order, returning the value of the last subexpression as its value. There are 
 that accomplish this: `begin` blocks and `(;)` chains. The value of both compound expression constructs
 is that of the last subexpression. Here's an example of a `begin` block:
 
-```julia
+```jldoctest
 julia> z = begin
            x = 1
            y = 2
@@ -34,7 +34,7 @@ julia> z = begin
 Since these are fairly small, simple expressions, they could easily be placed onto a single line,
 which is where the `(;)` chain syntax comes in handy:
 
-```julia
+```jldoctest
 julia> z = (x = 1; y = 2; x + y)
 3
 ```
@@ -43,7 +43,7 @@ This syntax is particularly useful with the terse single-line function definitio
 in [Functions](@ref). Although it is typical, there is no requirement that `begin` blocks be multiline
 or that `(;)` chains be single-line:
 
-```julia
+```jldoctest
 julia> begin x = 1; y = 2; x + y end
 3
 
@@ -72,7 +72,7 @@ If the condition expression `x < y` is `true`, then the corresponding block is e
 the condition expression `x > y` is evaluated, and if it is `true`, the corresponding block is
 evaluated; if neither expression is true, the `else` block is evaluated. Here it is in action:
 
-```julia
+```jldoctest
 julia> function test(x, y)
            if x < y
                println("x is less than y")
@@ -100,10 +100,10 @@ one evaluates to `true`, after which the associated block is evaluated, and no f
 expressions or blocks are evaluated.
 
 `if` blocks are "leaky", i.e. they do not introduce a local scope. This means that new variables
-defined inside the `ìf` clauses can be used after the `if` block, even if they weren't defined
+defined inside the `if` clauses can be used after the `if` block, even if they weren't defined
 before. So, we could have defined the `test` function above as
 
-```julia
+```jldoctest
 julia> function test(x,y)
            if x < y
                relation = "less than"
@@ -115,13 +115,16 @@ julia> function test(x,y)
            println("x is ", relation, " y.")
        end
 test (generic function with 1 method)
+
+julia> test(2, 1)
+x is greater than y.
 ```
 
 The variable `relation` is declared inside the `if` block, but used outside. However, when depending
 on this behavior, make sure all possible code paths define a value for the variable. The following
 change to the above function results in a runtime error
 
-```julia
+```jldoctest
 julia> function test(x,y)
            if x < y
                relation = "less than"
@@ -137,15 +140,15 @@ x is less than y.
 
 julia> test(2,1)
 ERROR: UndefVarError: relation not defined
- in test(::Int64, ::Int64) at ./none:7
- ...
+Stacktrace:
+ [1] test(::Int64, ::Int64) at ./none:7
 ```
 
 `if` blocks also return a value, which may seem unintuitive to users coming from many other languages.
 This value is simply the return value of the last executed statement in the branch that was chosen,
 so
 
-```julia
+```jldoctest
 julia> x = 3
 3
 
@@ -163,12 +166,11 @@ Evaluation in Julia, as outlined in the next section.
 Unlike C, MATLAB, Perl, Python, and Ruby -- but like Java, and a few other stricter, typed languages
 -- it is an error if the value of a conditional expression is anything but `true` or `false`:
 
-```julia
+```jldoctest
 julia> if 1
            println("true")
        end
 ERROR: TypeError: non-boolean (Int64) used in boolean context
- ...
 ```
 
 This error indicates that the conditional was of the wrong type: `Int64` rather than the required
@@ -192,7 +194,7 @@ The easiest way to understand this behavior is to see an example. In the previou
 print. This could be written more concisely using the ternary operator. For the sake of clarity,
 let's try a two-way version first:
 
-```julia
+```jldoctest
 julia> x = 1; y = 2;
 
 julia> println(x < y ? "less than" : "not less than")
@@ -208,7 +210,7 @@ If the expression `x < y` is true, the entire ternary operator expression evalua
 `"less than"` and otherwise it evaluates to the string `"not less than"`. The original three-way
 example requires chaining multiple uses of the ternary operator together:
 
-```julia
+```jldoctest
 julia> test(x, y) = println(x < y ? "x is less than y"    :
                             x > y ? "x is greater than y" : "x is equal to y")
 test (generic function with 1 method)
@@ -228,7 +230,7 @@ To facilitate chaining, the operator associates from right to left.
 It is significant that like `if`-`elseif`-`else`, the expressions before and after the `:` are
 only evaluated if the condition expression evaluates to `true` or `false`, respectively:
 
-```julia
+```jldoctest
 julia> v(x) = (println(x); x)
 v (generic function with 1 method)
 
@@ -257,7 +259,7 @@ The reasoning is that `a && b` must be `false` if `a` is `false`, regardless of 
 of `b`. Both `&&` and `||` associate to the right, but `&&` has higher precedence than `||` does.
 It's easy to experiment with this behavior:
 
-```julia
+```jldoctest tandf
 julia> t(x) = (println(x); true)
 t (generic function with 1 method)
 
@@ -311,7 +313,7 @@ one can write `<cond> || <statement>` (which could be read as: <cond> *or else* 
 
 For example, a recursive factorial routine could be defined like this:
 
-```julia
+```jldoctest
 julia> function fact(n::Int)
            n >= 0 || error("n must be non-negative")
            n == 0 && return 1
@@ -327,15 +329,15 @@ julia> fact(0)
 
 julia> fact(-1)
 ERROR: n must be non-negative
- in fact(::Int64) at ./none:2
- ...
+Stacktrace:
+ [1] fact(::Int64) at ./none:2
 ```
 
 Boolean operations *without* short-circuit evaluation can be done with the bitwise boolean operators
 introduced in [Mathematical Operations and Elementary Functions](@ref): `&` and `|`. These are
 normal functions, which happen to support infix operator syntax, but always evaluate their arguments:
 
-```julia
+```jldoctest tandf
 julia> f(1) & t(2)
 1
 2
@@ -351,22 +353,19 @@ Just like condition expressions used in `if`, `elseif` or the ternary operator, 
 `&&` or `||` must be boolean values (`true` or `false`). Using a non-boolean value anywhere except
 for the last entry in a conditional chain is an error:
 
-```julia
+```jldoctest
 julia> 1 && true
 ERROR: TypeError: non-boolean (Int64) used in boolean context
- ...
 ```
 
 On the other hand, any type of expression can be used at the end of a conditional chain. It will
 be evaluated and returned depending on the preceding conditionals:
 
-```julia
-julia> true && (x = rand(2,2))
-2×2 Array{Float64,2}:
- 0.768448  0.673959
- 0.940515  0.395453
+```jldoctest
+julia> true && (x = (1, 2, 3))
+(1,2,3)
 
-julia> false && (x = rand(2,2))
+julia> false && (x = (1, 2, 3))
 false
 ```
 
@@ -375,7 +374,7 @@ false
 There are two constructs for repeated evaluation of expressions: the `while` loop and the `for`
 loop. Here is an example of a `while` loop:
 
-```julia
+```jldoctest
 julia> i = 1;
 
 julia> while i <= 5
@@ -397,7 +396,7 @@ The `for` loop makes common repeated evaluation idioms easier to write. Since co
 down like the above `while` loop does is so common, it can be expressed more concisely with a
 `for` loop:
 
-```julia
+```jldoctest
 julia> for i = 1:5
            println(i)
        end
@@ -415,7 +414,7 @@ during which the variable is visible. If the variable `i` has not been introduce
 scope, in the `for` loop form, it is visible only inside of the `for` loop, and not afterwards.
 You'll either need a new interactive session instance or a different variable name to test this:
 
-```julia
+```jldoctest
 julia> for j = 1:5
            println(j)
        end
@@ -427,7 +426,6 @@ julia> for j = 1:5
 
 julia> j
 ERROR: UndefVarError: j not defined
- ...
 ```
 
 See [Scope of Variables](@ref scope-of-variables) for a detailed explanation of variable scope and how it works in
@@ -437,7 +435,7 @@ In general, the `for` loop construct can iterate over any container. In these ca
 (but fully equivalent) keyword `in` or `∈` is typically used instead of `=`, since it makes
 the code read more clearly:
 
-```julia
+```jldoctest
 julia> for i in [1,4,0]
            println(i)
        end
@@ -460,7 +458,7 @@ It is sometimes convenient to terminate the repetition of a `while` before the t
 is falsified or stop iterating in a `for` loop before the end of the iterable object is reached.
 This can be accomplished with the `break` keyword:
 
-```julia
+```jldoctest
 julia> i = 1;
 
 julia> while true
@@ -488,12 +486,13 @@ julia> for i = 1:1000
 4
 5
 ```
+
 Without the `break` keyword, the above `while` loop would never terminate on its own, and the `for` loop would iterate up to 1000. These loops are both exited early by using `break`.
 
 In other circumstances, it is handy to be able to stop an iteration and move on to the next one
 immediately. The `continue` keyword accomplishes this:
 
-```julia
+```jldoctest
 julia> for i = 1:10
            if i % 3 != 0
                continue
@@ -513,7 +512,7 @@ which one calls `continue`.
 Multiple nested `for` loops can be combined into a single outer loop, forming the cartesian product
 of its iterables:
 
-```julia
+```jldoctest
 julia> for i = 1:2, j = 3:4
            println((i, j))
        end
@@ -567,17 +566,17 @@ below all interrupt the normal flow of control.
 For example, the [`sqrt()`](@ref) function throws a [`DomainError`](@ref) if applied to a negative
 real value:
 
-```julia
+```jldoctest
 julia> sqrt(-1)
 ERROR: DomainError:
 sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
- in sqrt(::Int64) at ./math.jl:278
- ...
+Stacktrace:
+ [1] sqrt(::Int64) at ./math.jl:432
 ```
 
 You may define your own exceptions in the following way:
 
-```julia
+```jldoctest
 julia> type MyCustomException <: Exception end
 ```
 
@@ -587,7 +586,7 @@ Exceptions can be created explicitly with [`throw()`](@ref). For example, a func
 for nonnegative numbers could be written to [`throw()`](@ref) a [`DomainError`](@ref) if the argument
 is negative:
 
-```julia
+```jldoctest
 julia> f(x) = x>=0 ? exp(-x) : throw(DomainError())
 f (generic function with 1 method)
 
@@ -596,14 +595,14 @@ julia> f(1)
 
 julia> f(-1)
 ERROR: DomainError:
- in f(::Int64) at ./none:1
- ...
+Stacktrace:
+ [1] f(::Int64) at ./none:1
 ```
 
 Note that [`DomainError`](@ref) without parentheses is not an exception, but a type of exception.
 It needs to be called to obtain an `Exception` object:
 
-```julia
+```jldoctest
 julia> typeof(DomainError()) <: Exception
 true
 
@@ -613,20 +612,20 @@ false
 
 Additionally, some exception types take one or more arguments that are used for error reporting:
 
-```julia
+```jldoctest
 julia> throw(UndefVarError(:x))
 ERROR: UndefVarError: x not defined
- ...
 ```
 
 This mechanism can be implemented easily by custom exception types following the way [`UndefVarError`](@ref)
 is written:
 
-```julia
+```jldoctest
 julia> type MyUndefVarError <: Exception
            var::Symbol
        end
-julia> Base.showerror(io::IO, e::MyUndefVarError) = print(io, e.var, " not defined");
+
+julia> Base.showerror(io::IO, e::MyUndefVarError) = print(io, e.var, " not defined")
 ```
 
 !!! note
@@ -649,7 +648,7 @@ Suppose we want to stop execution immediately if the square root of a negative n
 To do this, we can define a fussy version of the [`sqrt()`](@ref) function that raises an error
 if its argument is negative:
 
-```julia
+```jldoctest fussy_sqrt
 julia> fussy_sqrt(x) = x >= 0 ? sqrt(x) : error("negative x not allowed")
 fussy_sqrt (generic function with 1 method)
 
@@ -658,15 +657,15 @@ julia> fussy_sqrt(2)
 
 julia> fussy_sqrt(-1)
 ERROR: negative x not allowed
- in fussy_sqrt(::Int64) at ./none:1
- ...
+Stacktrace:
+ [1] fussy_sqrt(::Int64) at ./none:1
 ```
 
 If `fussy_sqrt` is called with a negative value from another function, instead of trying to continue
 execution of the calling function, it returns immediately, displaying the error message in the
 interactive session:
 
-```julia
+```jldoctest fussy_sqrt
 julia> function verbose_fussy_sqrt(x)
            println("before fussy_sqrt")
            r = fussy_sqrt(x)
@@ -683,9 +682,9 @@ after fussy_sqrt
 julia> verbose_fussy_sqrt(-1)
 before fussy_sqrt
 ERROR: negative x not allowed
- in fussy_sqrt at ./none:1 [inlined]
- in verbose_fussy_sqrt(::Int64) at ./none:3
- ...
+Stacktrace:
+ [1] fussy_sqrt at ./none:1 [inlined]
+ [2] verbose_fussy_sqrt(::Int64) at ./none:3
 ```
 
 ### Warnings and informational messages
@@ -693,7 +692,7 @@ ERROR: negative x not allowed
 Julia also provides other functions that write messages to the standard error I/O, but do not
 throw any `Exception`s and hence do not interrupt execution:
 
-```julia
+```jldoctest
 julia> info("Hi"); 1+1
 INFO: Hi
 2
@@ -704,8 +703,8 @@ WARNING: Hi
 
 julia> error("Hi"); 1+1
 ERROR: Hi
- in error(::String) at ./error.jl:21
- ...
+Stacktrace:
+ [1] error(::String) at ./error.jl:21
 ```
 
 ### The `try/catch` statement
@@ -714,7 +713,7 @@ The `try/catch` statement allows for `Exception`s to be tested for. For example,
 square root function can be written to automatically call either the real or complex square root
 method on demand using `Exception`s :
 
-```julia
+```jldoctest
 julia> f(x) = try
            sqrt(x)
        catch
@@ -736,7 +735,7 @@ instead of catching an exception. The exception is much slower than simply compa
 example, the following example calculates the square root of the second element of `x` if `x`
 is indexable, otherwise assumes `x` is a real number and returns its square root:
 
-```julia
+```jldoctest
 julia> sqrt_second(x) = try
            sqrt(x[2])
        catch y
@@ -759,8 +758,8 @@ julia> sqrt_second(9)
 
 julia> sqrt_second(-9)
 ERROR: DomainError:
- in sqrt_second(::Int64) at ./none:7
- ...
+Stacktrace:
+ [1] sqrt_second(::Int64) at ./none:7
 ```
 
 Note that the symbol following `catch` will always be interpreted as a name for the exception,
@@ -784,8 +783,8 @@ end
 
 The `catch` clause is not strictly necessary; when omitted, the default return value is `nothing`.
 
-```julia
-julia> try error() end #Returns nothing
+```jldoctest
+julia> try error() end # Returns nothing
 ```
 
 The power of the `try/catch` construct lies in the ability to unwind a deeply nested computation
@@ -794,7 +793,7 @@ no error has occurred, but the ability to unwind the stack and pass a value to a
 is desirable. Julia provides the [`rethrow()`](@ref), [`backtrace()`](@ref) and [`catch_backtrace()`](@ref)
 functions for more advanced error handling.
 
-### finally Clauses
+### `finally` Clauses
 
 In code that performs state changes or uses resources like files, there is typically clean-up
 work (such as closing files) that needs to be done when the code is finished. Exceptions potentially
@@ -849,7 +848,7 @@ To consume values, we need to schedule the producer to run in a new task. A spec
 constructor which accepts a 1-arg function as an argument can be used to run a task bound to a channel.
 We can then [`take!()`](@ref) values repeatedly from the channel object:
 
-```jldoctest
+```jldoctest producer
 julia> function producer(c::Channel)
            put!(c, "start")
            for n=1:4
@@ -885,7 +884,7 @@ calls to [`put!()`](@ref), the producer's execution is suspended and the consume
 The returned [`Channel`](@ref) can be used as an iterable object in a `for` loop, in which case the
 loop variable takes on all the produced values. The loop is terminated when the channel is closed.
 
-```jldoctest
+```jldoctest producer
 julia> for x in Channel(producer)
            println(x)
        end
@@ -909,7 +908,7 @@ function application is needed to create a 0 or 1 argument [anonymous function](
 
 For [`Task()`](@ref) objects this can be done either directly or by use of a convenience macro:
 
-```
+```julia
 function mytask(myarg)
     ...
 end

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -9,8 +9,8 @@ rules; this section spells them out in detail.
 
 Certain constructs in the language introduce *scope blocks*, which are regions of code that are
 eligible to be the scope of some set of variables. The scope of a variable cannot be an arbitrary
-set of source lines; instead, it will always line up with one of these blocks.  There are two
-main types of scopes in Julia, *global scope* and *local scope*, the latter can be nested.  The
+set of source lines; instead, it will always line up with one of these blocks. There are two
+main types of scopes in Julia, *global scope* and *local scope*, the latter can be nested. The
 constructs introducing scope blocks are:
 
 | Scope name           | block/construct introducing this kind of scope                                                           |
@@ -20,7 +20,7 @@ constructs introducing scope blocks are:
 | [Local Scope](@ref)  | [Hard Local Scope](@ref): functions (either syntax, anonymous & do-blocks), `type`, `immutable`, `macro` |
 
 Notably missing from this table are [begin blocks](@ref man-compound-expressions) and [if blocks](@ref man-conditional-evaluation), which do *not*
-introduce new scope blocks.  All three types of scopes follow somewhat different rules which will
+introduce new scope blocks. All three types of scopes follow somewhat different rules which will
 be explained below as well as some extra rules for certain blocks.
 
 Julia uses [lexical scoping](https://en.wikipedia.org/wiki/Scope_%28computer_science%29#Lexical_scoping_vs._dynamic_scoping),
@@ -28,17 +28,17 @@ meaning that a function's scope does not inherit from its caller's scope, but fr
 which the function was defined. For example, in the following code the `x` inside `foo` refers
 to the `x` in the global scope of its module `Bar`:
 
-```julia
+```jldoctest moduleBar
 julia> module Bar
-       x = 1
-       foo() = x
+           x = 1
+           foo() = x
        end;
 ```
 
 and not a `x` in the scope where `foo` is used:
 
-```julia
-julia> import Bar
+```jldoctest moduleBar
+julia> import .Bar
 
 julia> x = -1;
 
@@ -53,36 +53,34 @@ Thus *lexical scope* means that the scope of variables can be inferred from the 
 *Each module introduces a new global scope*, separate from the global scope of all other modules;
 there is no all-encompassing global scope. Modules can introduce variables of other modules into
 their scope through the [using or import](@ref modules) statements or through qualified access using the
-dot-notation, i.e. each module is a so-called *namespace*.  Note that variable bindings can only
+dot-notation, i.e. each module is a so-called *namespace*. Note that variable bindings can only
 be changed within their global scope and not from an outside module.
 
-```julia
+```jldoctest
 julia> module A
-       a = 1 # a global in A's scope
+           a = 1 # a global in A's scope
        end;
 
 julia> module B
            module C
-           c = 2
+               c = 2
            end
-       b = C.c # can access the namespace of a nested global scope
-               # through a qualified access
-       import A # makes module A available
-       d = A.a
+           b = C.c    # can access the namespace of a nested global scope
+                      # through a qualified access
+           import ..A # makes module A available
+           d = A.a
        end;
 
 julia> module D
            b = a # errors as D's global scope is separate from A's
        end;
 ERROR: UndefVarError: a not defined
-...
 
 julia> module E
-           import A # make module A available
-           A.a = 2 # throws below error
+           import ..A # make module A available
+           A.a = 2    # throws below error
        end;
 ERROR: cannot assign variables in other modules
-...
 ```
 
 Note that the interactive prompt (aka REPL) is in the global scope of the module `Main`.
@@ -91,23 +89,22 @@ Note that the interactive prompt (aka REPL) is in the global scope of the module
 
 A new local scope is introduced by most code-blocks, see above table for a complete list.
  A local scope *usually* inherits all the variables from its parent scope, both for reading and
-writing.  There are two subtypes of local scopes, hard and soft, with slightly different rules
-concerning what variables are inherited.  Unlike global scopes, local scopes are not namespaces,
+writing. There are two subtypes of local scopes, hard and soft, with slightly different rules
+concerning what variables are inherited. Unlike global scopes, local scopes are not namespaces,
 thus variables in an inner scope cannot be retrieved from the parent scope through some sort of
 qualified access.
 
-The following rules and examples pertain to both hard and soft local scopes.  A newly introduced
-variable in a local scope does not back-propagate to its parent scope.  For example, here the
+The following rules and examples pertain to both hard and soft local scopes. A newly introduced
+variable in a local scope does not back-propagate to its parent scope. For example, here the
 `z` is not introduced into the top-level scope:
 
-```julia
+```jldoctest
 julia> for i = 1:10
            z = i
        end
 
 julia> z
 ERROR: UndefVarError: z not defined
-...
 ```
 
 (Note, in this and all following examples it is assumed that their top-level is a global scope
@@ -115,7 +112,7 @@ with a clean workspace, for instance a newly started REPL.)
 
 Inside a local scope a variable can be forced to be a local variable using the `local` keyword:
 
-```julia
+```jldoctest
 julia> x = 0;
 
 julia> for i = 1:10
@@ -129,7 +126,7 @@ julia> x
 
 Inside a local scope a new global variable can be defined using the keyword `global`:
 
-```julia
+```jldoctest
 julia> for i = 1:10
            global z
            z = i
@@ -142,7 +139,7 @@ julia> z
 The location of both the `local` and `global` keywords within the scope block is irrelevant.
 The following is equivalent to the last example (although stylistically worse):
 
-```julia
+```jldoctest
 julia> for i = 1:10
            z = i
            global z
@@ -152,27 +149,18 @@ julia> z
 10
 ```
 
-Multiple global or local definitions can be on one line and can also be paired with assignments:
-
-```julia
-julia> for i = 1:10
-           global x = i, y, z
-           local a = 4, b, c = 1
-       end
-```
-
 ### Soft Local Scope
 
 > In a soft local scope, all variables are inherited from its parent scope unless a variable is
 > specifically marked with the keyword `local`.
 
 Soft local scopes are introduced by for-loops, while-loops, comprehensions, try-catch-finally-blocks,
-and let-blocks.  There are some extra rules for [Let Blocks](@ref) and for [For Loops and Comprehensions](@ref).
+and let-blocks. There are some extra rules for [Let Blocks](@ref) and for [For Loops and Comprehensions](@ref).
 
 In the following example the `x` and `y` refer always to the same variables as the soft local
 scope inherits both read and write variables:
 
-```julia
+```jldoctest
 julia> x, y = 0, 1;
 
 julia> for i = 1:10
@@ -183,7 +171,7 @@ julia> x
 12
 ```
 
-Within soft scopes, the *global* keyword is never necessary, although allowed.  The only case
+Within soft scopes, the *global* keyword is never necessary, although allowed. The only case
 when it would change the semantics is (currently) a syntax error:
 
 ```julia
@@ -194,7 +182,6 @@ julia> let
            end
        end
 ERROR: syntax: `global j`: j is local variable in the enclosing scope
-...
 ```
 
 ### Hard Local Scope
@@ -209,11 +196,11 @@ and macro-definitions.
 
 Thus global variables are only inherited for reading but not for writing:
 
-```julia
+```jldoctest
 julia> x, y = 1, 2;
 
 julia> function foo()
-           x = 2 # assignment introduces a new local
+           x = 2        # assignment introduces a new local
            return x + y # y refers to the global
        end;
 
@@ -226,7 +213,7 @@ julia> x
 
 An explicit `global` is needed to assign to a global variable:
 
-```julia
+```jldoctest
 julia> x = 1;
 
 julia> function foobar()
@@ -242,13 +229,13 @@ julia> x
 Note that *nested functions* can behave differently to functions defined in the global scope as
 they can modify their parent scope's *local* variables:
 
-```julia
+```jldoctest
 julia> x, y = 1, 2;
 
 julia> function baz()
            x = 2 # introduces a new local
            function bar()
-               x = 10 # modifies the parent's x
+               x = 10       # modifies the parent's x
                return x + y # y is global
            end
            return bar() + x # 12 + 10 (x is modified in call of bar())
@@ -262,10 +249,10 @@ julia> x, y
 ```
 
 The distinction between inheriting global and local variables for assignment can lead to some
-slight differences between functions defined in local vs. global scopes.  Consider the modification
+slight differences between functions defined in local vs. global scopes. Consider the modification
 of the last example by moving `bar` to the global scope:
 
-```julia
+```jldoctest
 julia> x, y = 1, 2;
 
 julia> function bar()
@@ -292,14 +279,14 @@ keyword function arguments which are described in the [Function section](@ref ma
 An assignment introducing a variable used inside a function, type or macro definition need not
 come before its inner usage:
 
-```julia
+```jldoctest
 julia> f = y -> y + a
-(::#2) (generic function with 1 method)
+(::#1) (generic function with 1 method)
 
 julia> f(3)
 ERROR: UndefVarError: a not defined
- in (::##2#3)(::Int64) at ./none:1
- ...
+Stacktrace:
+ [1] (::##1#2)(::Int64) at ./none:1
 
 julia> a = 1
 1
@@ -312,10 +299,10 @@ This behavior may seem slightly odd for a normal variable, but allows for named 
 are just normal variables holding function objects -- to be used before they are defined. This
 allows functions to be defined in whatever order is intuitive and convenient, rather than forcing
 bottom up ordering or requiring forward declarations, as long as they are defined by the time
-they are actually called.  As an example, here is an inefficient, mutually recursive way to test
+they are actually called. As an example, here is an inefficient, mutually recursive way to test
 if positive integers are even or odd:
 
-```julia
+```jldoctest
 julia> even(n) = n == 0 ? true : odd(n-1);
 
 julia> odd(n) = n == 0 ? false : even(n-1);
@@ -337,7 +324,7 @@ variables in their parent scope. Thus their default is to fully access all varia
 parent scope.
 
 Conversely, the code inside blocks which introduce a hard local scope (function, type, and macro
-definitions) can be executed at any place in a program.  Remotely changing the state of global
+definitions) can be executed at any place in a program. Remotely changing the state of global
 variables in other modules should be done with care and thus this is an opt-in feature requiring
 the `global` keyword.
 
@@ -369,7 +356,7 @@ This difference is usually not important, and is only detectable in the case of 
 outlive their scope via closures. The `let` syntax accepts a comma-separated series of assignments
 and variable names:
 
-```julia
+```jldoctest
 julia> x, y, z = -1, -1, -1;
 
 julia> let x = 1, z
@@ -378,7 +365,6 @@ julia> let x = 1, z
        end
 x: 1, y: -1
 ERROR: UndefVarError: z not defined
-...
 ```
 
 The assignments are evaluated in order, with each right-hand side evaluated in the scope before
@@ -386,7 +372,7 @@ the new variable on the left-hand side has been introduced. Therefore it makes s
 something like `let x = x` since the two `x` variables are distinct and have separate storage.
 Here is an example where the behavior of `let` is needed:
 
-```julia
+```jldoctest
 julia> Fs = Array{Any}(2); i = 1;
 
 julia> while i <= 2
@@ -405,7 +391,7 @@ Here we create and store two closures that return variable `i`. However, it is a
 variable `i`, so the two closures behave identically. We can use `let` to create a new binding
 for `i`:
 
-```julia
+```jldoctest
 julia> Fs = Array{Any}(2); i = 1;
 
 julia> while i <= 2
@@ -442,11 +428,11 @@ outer local `x`.
 ### For Loops and Comprehensions
 
 `for` loops and [Comprehensions](@ref) have the following behavior: any new variables introduced
-in their body scopes are freshly allocated for each loop iteration.  This is in contrast to `while`
+in their body scopes are freshly allocated for each loop iteration. This is in contrast to `while`
 loops which reuse the variables for all iterations. Therefore these constructs are similar to
 `while` loops with `let` blocks inside:
 
-```julia
+```jldoctest
 julia> Fs = Array{Any}(2);
 
 julia> for j = 1:2
@@ -462,7 +448,7 @@ julia> Fs[2]()
 
 `for` loops will reuse existing variables for its iteration variable:
 
-```julia
+```jldoctest
 julia> i = 0;
 
 julia> for i = 1:3
@@ -474,7 +460,7 @@ julia> i
 
 However, comprehensions do not do this, and always freshly allocate their iteration variables:
 
-```julia
+```jldoctest
 julia> x = 0;
 
 julia> [ x for x = 1:3 ];
@@ -488,7 +474,7 @@ julia> x
 A common use of variables is giving names to specific, unchanging values. Such variables are only
 assigned once. This intent can be conveyed to the compiler using the `const` keyword:
 
-```julia
+```jldoctest
 julia> const e  = 2.71828182845904523536;
 
 julia> const pi = 3.14159265358979323846;


### PR DESCRIPTION
nothing exciting here, just plain conversion to doctests and some whitespace fixes

(`make check-whitespace` and the doctests pass locally, remove `[ci skip]` from commit message if/when this is merged)