### PR TITLE
fix some issues with `Vararg`

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -900,6 +900,9 @@ function apply_type_tfunc(headtypetype::ANY, args::ANY...)
         uncertain = true
     end
     !uncertain && return Const(appl)
+    if isvarargtype(headtype)
+        return Type
+    end
     if type_too_complex(appl,0)
         return Type{_} where _<:headtype
     end
@@ -1821,8 +1824,17 @@ function ⊑(a::ANY, b::ANY)
     end
 end
 
-widenconst(c::Const) = isa(c.val, Type) ? Type{c.val} : typeof(c.val)
 widenconst(c::Conditional) = Bool
+function widenconst(c::Const)
+    if isa(c.val, Type)
+        if isvarargtype(c.val)
+            return Type
+        end
+        return Type{c.val}
+    else
+        return typeof(c.val)
+    end
+end
 widenconst(t::ANY) = t
 
 issubstate(a::VarState, b::VarState) = (a.typ ⊑ b.typ && a.undef <= b.undef)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -878,7 +878,11 @@ function apply_type_tfunc(headtypetype::ANY, args::ANY...)
             #end
             uncertain = true
             if istuple
-                push!(tparams, Any)
+                if i == largs
+                    push!(tparams, Vararg)
+                else
+                    push!(tparams, Any)
+                end
             else
                 # TODO: use rewrap_unionall to skip only the unknown parameters
                 #push!(tparams, headtype.parameters[i-1])

--- a/test/core.jl
+++ b/test/core.jl
@@ -15,6 +15,10 @@ f47{T}(x::Vector{Vector{T}}) = 0
 @test_throws TypeError ([T] where T)
 @test_throws TypeError (Array{T} where T<:[])
 @test_throws TypeError (Array{T} where T>:[])
+@test_throws TypeError (Array{T} where T<:Vararg)
+@test_throws TypeError (Array{T} where T>:Vararg)
+@test_throws TypeError (Array{T} where T<:Vararg{Int})
+@test_throws TypeError (Array{T} where T<:Vararg{Int,2})
 
 # issue #8652
 args_morespecific(a, b) = ccall(:jl_type_morespecific, Cint, (Any,Any), a, b) != 0
@@ -3086,10 +3090,12 @@ end
 
 # don't allow Vararg{} in Union{} type constructor
 @test_throws TypeError Union{Int,Vararg{Int}}
+@test_throws TypeError Union{Vararg{Int}}
 
-# don't allow Vararg{} in Tuple{} type constructor in non-trailing position
+# only allow Vararg{} in last position of Tuple{ }
 @test_throws TypeError Tuple{Vararg{Int32},Int64,Float64}
 @test_throws TypeError Tuple{Int64,Vararg{Int32},Float64}
+@test_throws TypeError Array{Vararg}
 
 # don't allow non-types in Union
 @test_throws TypeError Union{1}

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -478,6 +478,17 @@ function maybe_vararg_tuple_2()
 end
 @test Type{Tuple{Vararg{Int}}} <: Base.return_types(maybe_vararg_tuple_2, ())[1]
 
+# issue #11480
+@noinline f11480(x,y) = x
+let A = Ref
+    function h11480(x::A{A{A{A{A{A{A{A{A{Int}}}}}}}}}) # enough for type_too_complex
+        y :: Tuple{Vararg{typeof(x)}} = (x,) # apply_type(Vararg, too_complex) => TypeVar(_,Vararg)
+        f(y[1], # fool getfield logic : Tuple{_<:Vararg}[1] => Vararg
+          1) # make it crash by construction of the signature Tuple{Vararg,Int}
+    end
+    @test !Base.isvarargtype(Base.return_types(h11480, (Any,))[1])
+end
+
 # Issue 19641
 foo19641() = let a = 1.0
     Core.Inference.return_type(x -> x + a, Tuple{Float64})

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -466,6 +466,18 @@ function g19348(x)
 end
 test_inferred_static(@code_typed g19348((1, 2.0)))
 
+# make sure Tuple{unknown} handles the possibility that `unknown` is a Vararg
+function maybe_vararg_tuple_1()
+    x = Any[Vararg{Int}][1]
+    Tuple{x}
+end
+@test Type{Tuple{Vararg{Int}}} <: Base.return_types(maybe_vararg_tuple_1, ())[1]
+function maybe_vararg_tuple_2()
+    x = Type[Vararg{Int}][1]
+    Tuple{x}
+end
+@test Type{Tuple{Vararg{Int}}} <: Base.return_types(maybe_vararg_tuple_2, ())[1]
+
 # Issue 19641
 foo19641() = let a = 1.0
     Core.Inference.return_type(x -> x + a, Tuple{Float64})


### PR DESCRIPTION
- fix #11480, don't use `Type{_} where _<:Vararg` in inference
- disallow `Vararg` in type var bounds (fixes #19400)
- disallow `Vararg` as a type parameter in general
- move some checks from lower-level functions to apply_type
