### PR TITLE
Re-fix ccall tests

### DIFF
--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -15,37 +15,55 @@ ccall_test_func(x) = ccall((:testUcharX, libccalltest), Int32, (UInt8,), x % UIn
 
 
 # Test for proper round-trip of Ref{T} type
-function ccall_echo_func(x::ANY, T::Type, U::Type)
-    f = (@eval (x) -> ccall((:test_echo_p, libccalltest), $T, ($U,), x))
-    return @eval $f($x)
+function gen_ccall_echo(x, T, U, ret=nothing)
+    # Construct a noninline function to do all the work, this is necessary
+    # to make sure object x is still valid (rooted as argument)
+    # when loading the pointer.
+    # This works as long as we still keep the argument
+    # rooted but might fail if we are smarter about eliminating dead root.
+
+    # `eval` in global scope to make sure the function is not a closure
+    func_ex = :(ccall((:test_echo_p, libccalltest), $T, ($U,), x))
+    # It is not allowed to allocate after the ccall returns
+    # and before calling `ret`.
+    if ret !== nothing
+        func_ex = :($ret($func_ex))
+    end
+    @gensym func_name
+    @eval @noinline $func_name(x) = $func_ex
+    :($func_name($(esc(x))))
 end
-# Make sure object x is still valid (rooted as argument)
-# when loading the pointer. This works as long as we still keep the argument
-# rooted but might fail if we are smarter about eliminating dead root.
-@noinline ccall_echo_load{T,U}(x, ::Type{T}, ::Type{U}) =
-    unsafe_load(ccall_echo_func(x, T, U))
-@noinline ccall_echo_objref{T,U}(x, ::Type{T}, ::Type{U}) =
-    unsafe_pointer_to_objref(ccall_echo_func(x, Ptr{T}, U))
+
+macro ccall_echo_func(x, T, U)
+    gen_ccall_echo(x, T, U)
+end
+macro ccall_echo_load(x, T, U)
+    gen_ccall_echo(x, T, U, :unsafe_load)
+end
+macro ccall_echo_objref(x, T, U)
+    gen_ccall_echo(x, :(Ptr{$T}), U, :unsafe_pointer_to_objref)
+end
+
 type IntLike
     x::Int
 end
-@test ccall_echo_load(132, Ptr{Int}, Ref{Int}) === 132
-@test ccall_echo_load(Ref(921), Ptr{Int}, Ref{Int}) === 921
-@test ccall_echo_load(IntLike(993), Ptr{Int}, Ref{IntLike}) === 993
-@test ccall_echo_load(IntLike(881), Ptr{IntLike}, Ref{IntLike}).x === 881
-@test ccall_echo_func(532, Int, Int) === 532
+@test @ccall_echo_load(132, Ptr{Int}, Ref{Int}) === 132
+@test @ccall_echo_load(Ref(921), Ptr{Int}, Ref{Int}) === 921
+@test @ccall_echo_load(IntLike(993), Ptr{Int}, Ref{IntLike}) === 993
+@test @ccall_echo_load(IntLike(881), Ptr{IntLike}, Ref{IntLike}).x === 881
+@test @ccall_echo_func(532, Int, Int) === 532
 if Sys.WORD_SIZE == 64
     # this test is valid only for x86_64 and win64
-    @test ccall_echo_func(164, IntLike, Int).x === 164
+    @test @ccall_echo_func(164, IntLike, Int).x === 164
 end
-@test ccall_echo_func(IntLike(828), Int, IntLike) === 828
-@test ccall_echo_func(913, Any, Any) === 913
-@test ccall_echo_objref(553, Ptr{Any}, Any) === 553
-@test ccall_echo_func(124, Ref{Int}, Any) === 124
-@test ccall_echo_load(422, Ptr{Any}, Ref{Any}) === 422
-@test ccall_echo_load([383], Ptr{Int}, Ref{Int}) === 383
-@test ccall_echo_load(Ref([144,172],2), Ptr{Int}, Ref{Int}) === 172
-# @test ccall_echo_load(Ref([8],1,1), Ptr{Int}, Ref{Int}) === 8
+@test @ccall_echo_func(IntLike(828), Int, IntLike) === 828
+@test @ccall_echo_func(913, Any, Any) === 913
+@test @ccall_echo_objref(553, Ptr{Any}, Any) === 553
+@test @ccall_echo_func(124, Ref{Int}, Any) === 124
+@test @ccall_echo_load(422, Ptr{Any}, Ref{Any}) === 422
+@test @ccall_echo_load([383], Ptr{Int}, Ref{Int}) === 383
+@test @ccall_echo_load(Ref([144,172],2), Ptr{Int}, Ref{Int}) === 172
+# @test @ccall_echo_load(Ref([8],1,1), Ptr{Int}, Ref{Int}) === 8
 
 
 ## Tests for passing and returning structs


### PR DESCRIPTION
The ccall_echo wrapper is not allowed to allocate.

Alternative is to use a `@generated` function although it seems that this is more likely to work for longer.....

Ref https://github.com/JuliaLang/julia/pull/12185 (Re-fix #12122)
