### PR TITLE
change Array(T, dims...) deprecation message to Array{T}(dims)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -27,11 +27,12 @@ import Core: arraysize, arrayset, arrayref
 
 """
     Array{T}(dims)
+    Array{T,N}(dims)
 
 Construct an uninitialized `N`-dimensional dense array with element type `T`,
 where `N` is determined from the length or number of `dims`.  `dims` may
-be a tuple or a series of `Int` arguments corresponding to the lengths in each dimension.
-If the rank `N` is supplied explicitly, e.g. `Array{T,N}(dims)`, then it must
+be a tuple or a series of integer arguments corresponding to the lengths in each dimension.
+If the rank `N` is supplied explicitly as in `Array{T,N}(dims)`, then it must
 match the length or number of `dims`.
 """
 Array

--- a/base/array.jl
+++ b/base/array.jl
@@ -26,11 +26,13 @@ typealias DenseVecOrMat{T} Union{DenseVector{T}, DenseMatrix{T}}
 import Core: arraysize, arrayset, arrayref
 
 """
-    Array{T,N}(dims)
+    Array{T}(dims)
 
-Construct an uninitialized `N`-dimensional dense array with element type `T`. `dims` may
-be a tuple or a series of integer arguments corresponding to the length in each dimension.
-If the rank `N` is omitted, i.e. `Array{T}(dims)`, the rank is determined based on `dims`.
+Construct an uninitialized `N`-dimensional dense array with element type `T`,
+where `N` is determined from the length or number of `dims`.  `dims` may
+be a tuple or a series of `Int` arguments corresponding to the lengths in each dimension.
+If the rank `N` is supplied explicitly, e.g. `Array{T,N}(dims)`, then it must
+match the length or number of `dims`.
 """
 Array
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1740,23 +1740,23 @@ eval(Base.Test, quote
 end)
 
 # Deprecate Array(T, dims...) in favor of proper type constructors
-@deprecate Array{T,N}(::Type{T}, d::NTuple{N,Int})               Array{T,N}(d)
-@deprecate Array{T}(::Type{T}, d::Int...)                        Array{T,length(d)}(d...)
-@deprecate Array{T}(::Type{T}, m::Int)                           Array{T,1}(m)
-@deprecate Array{T}(::Type{T}, m::Int,n::Int)                    Array{T,2}(m,n)
-@deprecate Array{T}(::Type{T}, m::Int,n::Int,o::Int)             Array{T,3}(m,n,o)
-@deprecate Array{T}(::Type{T}, d::Integer...)                    Array{T,length(d)}(convert(Tuple{Vararg{Int}}, d))
-@deprecate Array{T}(::Type{T}, m::Integer)                       Array{T,1}(Int(m))
-@deprecate Array{T}(::Type{T}, m::Integer,n::Integer)            Array{T,2}(Int(m),Int(n))
-@deprecate Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) Array{T,3}(Int(m),Int(n),Int(o))
+@deprecate Array{T,N}(::Type{T}, d::NTuple{N,Int})               Array{T}(d)
+@deprecate Array{T}(::Type{T}, d::Int...)                        Array{T}(d...)
+@deprecate Array{T}(::Type{T}, m::Int)                           Array{T}(m)
+@deprecate Array{T}(::Type{T}, m::Int,n::Int)                    Array{T}(m,n)
+@deprecate Array{T}(::Type{T}, m::Int,n::Int,o::Int)             Array{T}(m,n,o)
+@deprecate Array{T}(::Type{T}, d::Integer...)                    Array{T}(convert(Tuple{Vararg{Int}}, d))
+@deprecate Array{T}(::Type{T}, m::Integer)                       Array{T}(Int(m))
+@deprecate Array{T}(::Type{T}, m::Integer,n::Integer)            Array{T}(Int(m),Int(n))
+@deprecate Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) Array{T}(Int(m),Int(n),Int(o))
 
 # Likewise for SharedArrays
-@deprecate SharedArray{T,N}(::Type{T}, dims::Dims{N}; kwargs...) SharedArray{T,N}(dims; kwargs...)
-@deprecate SharedArray{T}(::Type{T}, dims::Int...; kwargs...)    SharedArray{T,length(dims)}(dims...; kwargs...)
+@deprecate SharedArray{T,N}(::Type{T}, dims::Dims{N}; kwargs...) SharedArray{T}(dims; kwargs...)
+@deprecate SharedArray{T}(::Type{T}, dims::Int...; kwargs...)    SharedArray{T}(dims...; kwargs...)
 @deprecate(SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,Int}, offset; kwargs...),
-           SharedArray{T,N}(filename, dims, offset; kwargs...))
+           SharedArray{T}(filename, dims, offset; kwargs...))
 @deprecate(SharedArray{T}(filename::AbstractString, ::Type{T}, dims::NTuple, offset; kwargs...),
-           SharedArray{T,length(dims)}(filename, dims, offset; kwargs...))
+           SharedArray{T}(filename, dims, offset; kwargs...))
 
 @noinline function is_intrinsic_expr(x::ANY)
     Base.depwarn("is_intrinsic_expr is deprecated. There are no intrinsic functions anymore.", :is_intrinsic_expr)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -29,10 +29,12 @@ type SharedArray{T,N} <: DenseArray{T,N}
 end
 
 """
-    SharedArray{T,N}(dims::NTuple; init=false, pids=Int[])
+    SharedArray{T[,N]}(dims::NTuple; init=false, pids=Int[])
 
-Construct a `SharedArray` of a bitstype `T` and size `dims` across the processes specified
-by `pids` - all of which have to be on the same host.
+Construct a `SharedArray` of a bitstype `T` and size `dims` across the
+processes specified by `pids` - all of which have to be on the same
+host.  If `N` is specified by calling `SharedArray{T,N}(dims)`, then
+`N` must match the length of `dims`.
 
 If `pids` is left unspecified, the shared array will be mapped across all processes on the
 current host, including the master. But, `localindexes` and `indexpids` will only refer to
@@ -42,7 +44,7 @@ computation with the master process acting as a driver.
 If an `init` function of the type `initfn(S::SharedArray)` is specified, it is called on all
 the participating workers.
 
-    SharedArray{T,N}(filename::AbstractString, dims::NTuple, [offset=0]; mode=nothing, init=false, pids=Int[])
+    SharedArray{T[,N]}(filename::AbstractString, dims::NTuple, [offset=0]; mode=nothing, init=false, pids=Int[])
 
 Construct a `SharedArray` backed by the file `filename`, with element
 type `T` (must be a `bitstype`) and size `dims`, across the processes

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -29,7 +29,8 @@ type SharedArray{T,N} <: DenseArray{T,N}
 end
 
 """
-    SharedArray{T[,N]}(dims::NTuple; init=false, pids=Int[])
+    SharedArray{T}(dims::NTuple; init=false, pids=Int[])
+    SharedArray{T,N}(...)
 
 Construct a `SharedArray` of a bitstype `T` and size `dims` across the
 processes specified by `pids` - all of which have to be on the same
@@ -44,7 +45,8 @@ computation with the master process acting as a driver.
 If an `init` function of the type `initfn(S::SharedArray)` is specified, it is called on all
 the participating workers.
 
-    SharedArray{T[,N]}(filename::AbstractString, dims::NTuple, [offset=0]; mode=nothing, init=false, pids=Int[])
+    SharedArray{T}(filename::AbstractString, dims::NTuple, [offset=0]; mode=nothing, init=false, pids=Int[])
+    SharedArray{T,N}(...)
 
 Construct a `SharedArray` backed by the file `filename`, with element
 type `T` (must be a `bitstype`) and size `dims`, across the processes


### PR DESCRIPTION
This modifies the deprecation message and docstring from #19989 to recommend `Array{T}(dims)` and not `Array{T,N}(dims...)`.   Supplying `N` explicitly is unnecessary, and I don't think that we should recommend typing redundant information by default.  (Also, it may mislead people into thinking that the `N` is required.)