### PR TITLE
bring back testset printing

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -631,6 +631,9 @@ function print_test_results(ts::DefaultTestSet, depth_pad=0)
     print_counts(ts, depth_pad, align, pass_width, fail_width, error_width, broken_width, total_width)
 end
 
+
+const TESTSET_PRINT_ENABLE = Ref(true)
+
 # Called at the end of a @testset, behaviour depends on whether
 # this is a child of another testset, or the "root" testset
 function finish(ts::DefaultTestSet)
@@ -648,6 +651,11 @@ function finish(ts::DefaultTestSet)
     total_error  = errors + c_errors
     total_broken = broken + c_broken
     total = total_pass + total_fail + total_error + total_broken
+
+    if TESTSET_PRINT_ENABLE[]
+        print_test_results(ts)
+    end
+
     # Finally throw an error as we are the outermost test set
     if total != total_pass + total_broken
         # Get all the error/failures and bring them along for the ride

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -1,31 +1,37 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 function runtests(name, isolate=true)
-    if isolate
-        mod_name = Symbol("TestMain_", replace(name, '/', '_'))
-        m = eval(Main, :(module $mod_name end))
-    else
-        m = Main
-    end
-    eval(m, :(using Base.Test))
-    ex = quote
-        @timed @testset $"$name" begin
-            include($"$name.jl")
+    old_print_setting = Base.Test.TESTSET_PRINT_ENABLE[]
+    Base.Test.TESTSET_PRINT_ENABLE[] = false
+    try
+        if isolate
+            mod_name = Symbol("TestMain_", replace(name, '/', '_'))
+            m = eval(Main, :(module $mod_name end))
+        else
+            m = Main
         end
+        eval(m, :(using Base.Test))
+        ex = quote
+            @timed @testset $"$name" begin
+                include($"$name.jl")
+            end
+        end
+        res_and_time_data = eval(m, ex)
+        rss = Sys.maxrss()
+        #res_and_time_data[1] is the testset
+        passes,fails,error,broken,c_passes,c_fails,c_errors,c_broken = Base.Test.get_test_counts(res_and_time_data[1])
+        if res_and_time_data[1].anynonpass == false
+            res_and_time_data = (
+                                 (passes+c_passes,broken+c_broken),
+                                 res_and_time_data[2],
+                                 res_and_time_data[3],
+                                 res_and_time_data[4],
+                                 res_and_time_data[5])
+        end
+        vcat(collect(res_and_time_data), rss)
+    finally
+        Base.Test.TESTSET_PRINT_ENABLE[] = old_print_setting
     end
-    res_and_time_data = eval(m, ex)
-    rss = Sys.maxrss()
-    #res_and_time_data[1] is the testset
-    passes,fails,error,broken,c_passes,c_fails,c_errors,c_broken = Base.Test.get_test_counts(res_and_time_data[1])
-    if res_and_time_data[1].anynonpass == false
-        res_and_time_data = (
-                             (passes+c_passes,broken+c_broken),
-                             res_and_time_data[2],
-                             res_and_time_data[3],
-                             res_and_time_data[4],
-                             res_and_time_data[5])
-    end
-    vcat(collect(res_and_time_data), rss)
 end
 
 # looking in . messes things up badly


### PR DESCRIPTION
Should restore things like they were on 0.5 while keeping things like they are for Base tests (no testset printing).

Review with https://github.com/JuliaLang/julia/pull/20221/files?w=1