### PR TITLE
Manual doctests (part 4)

### DIFF
--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -53,41 +53,38 @@ and count.
 When defining a function, one can optionally constrain the types of parameters it is applicable
 to, using the `::` type-assertion operator, introduced in the section on [Composite Types](@ref):
 
-```julia
-julia> f(x::Float64, y::Float64) = 2x + y;
+```jldoctest fofxy
+julia> f(x::Float64, y::Float64) = 2x + y
+f (generic function with 1 method)
 ```
 
 This function definition applies only to calls where `x` and `y` are both values of type `Float64`:
 
-```julia
+```jldoctest fofxy
 julia> f(2.0, 3.0)
 7.0
 ```
 
 Applying it to any other types of arguments will result in a [`MethodError`](@ref):
 
-```julia
+```jldoctest fofxy
 julia> f(2.0, 3)
 ERROR: MethodError: no method matching f(::Float64, ::Int64)
 Closest candidates are:
   f(::Float64, !Matched::Float64) at none:1
-...
 
 julia> f(Float32(2.0), 3.0)
 ERROR: MethodError: no method matching f(::Float32, ::Float64)
 Closest candidates are:
   f(!Matched::Float64, ::Float64) at none:1
-...
 
 julia> f(2.0, "3.0")
 ERROR: MethodError: no method matching f(::Float64, ::String)
 Closest candidates are:
   f(::Float64, !Matched::Float64) at none:1
-...
 
 julia> f("2.0", "3.0")
 ERROR: MethodError: no method matching f(::String, ::String)
-...
 ```
 
 As you can see, the arguments must be precisely of type `Float64`. Other numeric types, such as
@@ -97,8 +94,9 @@ be subclassed in Julia, such a definition can only be applied to arguments that 
 type `Float64`. It may often be useful, however, to write more general methods where the declared
 parameter types are abstract:
 
-```julia
-julia> f(x::Number, y::Number) = 2x - y;
+```jldoctest fofxy
+julia> f(x::Number, y::Number) = 2x - y
+f (generic function with 2 methods)
 
 julia> f(2.0, 3)
 1.0
@@ -118,7 +116,7 @@ behavior specific to pairs of `Float64` values. If one of the arguments is a 64-
 the other one is not, then the `f(Float64,Float64)` method cannot be called and the more general
 `f(Number,Number)` method must be used:
 
-```julia
+```jldoctest fofxy
 julia> f(2.0, 3.0)
 7.0
 
@@ -141,25 +139,23 @@ from magic. [^Clarke61]
 For non-numeric values, and for fewer or more than two arguments, the function `f` remains undefined,
 and applying it will still result in a [`MethodError`](@ref):
 
-```julia
+```jldoctest fofxy
 julia> f("foo", 3)
 ERROR: MethodError: no method matching f(::String, ::Int64)
 Closest candidates are:
   f(!Matched::Number, ::Number) at none:1
-...
 
 julia> f()
 ERROR: MethodError: no method matching f()
 Closest candidates are:
   f(!Matched::Float64, !Matched::Float64) at none:1
   f(!Matched::Number, !Matched::Number) at none:1
-...
 ```
 
 You can easily see which methods exist for a function by entering the function object itself in
 an interactive session:
 
-```julia
+```jldoctest fofxy
 julia> f
 f (generic function with 2 methods)
 ```
@@ -182,8 +178,9 @@ In the absence of a type declaration with `::`, the type of a method parameter i
 meaning that it is unconstrained since all values in Julia are instances of the abstract type
 `Any`. Thus, we can define a catch-all method for `f` like so:
 
-```julia
-julia> f(x,y) = println("Whoa there, Nelly.");
+```jldoctest fofxy
+julia> f(x,y) = println("Whoa there, Nelly.")
+f (generic function with 3 methods)
 
 julia> f("foo", 1)
 Whoa there, Nelly.
@@ -229,10 +226,12 @@ specialized code to handle each case at run time.
 It is possible to define a set of function methods such that there is no unique most specific
 method applicable to some combinations of arguments:
 
-```julia
-julia> g(x::Float64, y) = 2x + y;
+```jldoctest gofxy
+julia> g(x::Float64, y) = 2x + y
+g (generic function with 1 method)
 
-julia> g(x, y::Float64) = x + 2y;
+julia> g(x, y::Float64) = x + 2y
+g (generic function with 2 methods)
 
 julia> g(2.0, 3)
 7.0
@@ -241,10 +240,8 @@ julia> g(2, 3.0)
 8.0
 
 julia> g(2.0, 3.0)
-ERROR: MethodError: g(::Float64, ::Float64) is ambiguous. Candidates:
-  g(x, y::Float64) in Main at none:1
-  g(x::Float64, y) in Main at none:1
- ...
+ERROR: MethodError: g(::Float64, ::Float64) is ambiguous.
+[...]
 ```
 
 Here the call `g(2.0, 3.0)` could be handled by either the `g(Float64, Any)` or the `g(Any, Float64)`
@@ -252,12 +249,9 @@ method, and neither is more specific than the other. In such cases, Julia raises
 rather than arbitrarily picking a method. You can avoid method ambiguities by specifying an appropriate
 method for the intersection case:
 
-```julia
-julia> g(x::Float64, y::Float64) = 2x + 2y;
-
-julia> g(x::Float64, y) = 2x + y;
-
-julia> g(x, y::Float64) = x + 2y;
+```jldoctest gofxy
+julia> g(x::Float64, y::Float64) = 2x + 2y
+g (generic function with 3 methods)
 
 julia> g(2.0, 3)
 7.0
@@ -277,10 +271,12 @@ exists, if transiently, until the more specific method is defined.
 Method definitions can optionally have type parameters immediately after the method name and before
 the parameter tuple:
 
-```julia
-julia> same_type{T}(x::T, y::T) = true;
+```jldoctest same_typefunc
+julia> same_type{T}(x::T, y::T) = true
+same_type (generic function with 1 method)
 
-julia> same_type(x,y) = false;
+julia> same_type(x,y) = false
+same_type (generic function with 2 methods)
 ```
 
 The first method applies whenever both arguments are of the same concrete type, regardless of
@@ -288,7 +284,7 @@ what type that is, while the second method acts as a catch-all, covering all oth
 overall, this defines a boolean function that checks whether its two arguments are of the same
 type:
 
-```julia
+```jldoctest same_typefunc
 julia> same_type(1, 2)
 true
 
@@ -314,7 +310,7 @@ they can be used anywhere a value would be in the signature of the function or b
 Here's an example where the method type parameter `T` is used as the type parameter to the parametric
 type `Vector{T}` in the method signature:
 
-```julia
+```jldoctest
 julia> myappend{T}(v::Vector{T}, x::T) = [v..., x]
 myappend (generic function with 1 method)
 
@@ -329,7 +325,6 @@ julia> myappend([1,2,3],2.5)
 ERROR: MethodError: no method matching myappend(::Array{Int64,1}, ::Float64)
 Closest candidates are:
   myappend{T}(::Array{T,1}, !Matched::T) at none:1
-...
 
 julia> myappend([1.0,2.0,3.0],4.0)
 4-element Array{Float64,1}:
@@ -342,14 +337,13 @@ julia> myappend([1.0,2.0,3.0],4)
 ERROR: MethodError: no method matching myappend(::Array{Float64,1}, ::Int64)
 Closest candidates are:
   myappend{T}(::Array{T,1}, !Matched::T) at none:1
-...
 ```
 
 As you can see, the type of the appended element must match the element type of the vector it
 is appended to, or else a [`MethodError`](@ref) is raised. In the following example, the method type parameter
 `T` is used as the return value:
 
-```julia
+```jldoctest
 julia> mytypeof{T}(x::T) = T
 mytypeof (generic function with 1 method)
 
@@ -363,9 +357,12 @@ Float64
 Just as you can put subtype constraints on type parameters in type declarations (see [Parametric Types](@ref)),
 you can also constrain type parameters of methods:
 
-```julia
-same_type_numeric{T<:Number}(x::T, y::T) = true
-same_type_numeric(x::Number, y::Number) = false
+```jldoctest
+julia> same_type_numeric{T<:Number}(x::T, y::T) = true
+same_type_numeric (generic function with 1 method)
+
+julia> same_type_numeric(x::Number, y::Number) = false
+same_type_numeric (generic function with 2 methods)
 
 julia> same_type_numeric(1, 2)
 true
@@ -377,10 +374,13 @@ julia> same_type_numeric(1.0, 2.0)
 true
 
 julia> same_type_numeric("foo", 2.0)
-no method same_type_numeric(String,Float64)
+ERROR: MethodError: no method matching same_type_numeric(::String, ::Float64)
+Closest candidates are:
+  same_type_numeric{T<:Number}(!Matched::T<:Number, ::T<:Number) at none:1
+  same_type_numeric(!Matched::Number, ::Number) at none:1
 
 julia> same_type_numeric("foo", "bar")
-no method same_type_numeric(String,String)
+ERROR: MethodError: no method matching same_type_numeric(::String, ::String)
 
 julia> same_type_numeric(Int32(1), Int64(2))
 false
@@ -446,55 +446,64 @@ Sometimes it is necessary to get around this (for example, if you are implementi
 Well, don't despair, since there's an easy solution: just call `eval` a second time.
 For example, here we create a zero-argument closure over `ans` and `eval` a call to it:
 
-```julia
-    julia> function tryeval2()
-               ans = (@eval newfun2() = 1)
-               res = eval(Expr(:call,
-                   function()
-                       return ans() + 1
-                   end))
-                return res
-           end
-    tryeval2 (generic function with 1 method)
+```jldoctest
+julia> function tryeval2()
+           ans = (@eval newfun2() = 1)
+           res = eval(Expr(:call,
+               function()
+                   return ans() + 1
+               end))
+           return res
+       end
+tryeval2 (generic function with 1 method)
 
-    julia> tryeval2()
-    2
+julia> tryeval2()
+2
 ```
 
 Finally, let's take a look at some more complex examples where this rule comes into play.
+Define a function `f(x)`, which initially has one method:
 
-```julia
-    julia> # initially f(x) has one definition:
+```jldoctest redefinemethod
+julia> f(x) = "original definition"
+f (generic function with 1 method)
+```
 
-    julia> f(x) = "original definition";
+Start some other operations that use `f(x)`:
 
-    julia> # start some other operations that use f(x):
+```jldoctest redefinemethod
+julia> g(x) = f(x)
+g (generic function with 1 method)
 
-    julia> g(x) = f(x);
+julia> t = @async f(wait()); yield();
+```
 
-    julia> t = @async f(wait()); yield();
+Now we add some new methods to `f(x)`:
 
-    julia> # now we add some new definitions for f(x):
+```jldoctest redefinemethod
+julia> f(x::Int) = "definition for Int"
+f (generic function with 2 methods)
 
-    julia> f(x::Int) = "definition for Int";
+julia> f(x::Type{Int}) = "definition for Type{Int}"
+f (generic function with 3 methods)
+```
 
-    julia> f(x::Type{Int}) = "definition for Type{Int}";
+Compare how these results differ:
 
-    julia> # and compare how these results differ:
+```jldoctest redefinemethod
+julia> f(1)
+"definition for Int"
 
-    julia> f(1)
-    "definition for Int"
+julia> g(1)
+"definition for Int"
 
-    julia> g(1)
-    "definition for Int"
+julia> wait(schedule(t, 1))
+"original definition"
 
-    julia> wait(schedule(t, 1))
-    "original definition"
+julia> t = @async f(wait()); yield();
 
-    julia> t = @async f(wait()); yield();
-
-    julia> wait(schedule(t, 1))
-    "definition for Int"
+julia> wait(schedule(t, 1))
+"definition for Int"
 ```
 
 ## Parametrically-constrained Varargs methods
@@ -503,22 +512,25 @@ Function parameters can also be used to constrain the number of arguments that m
 to a "varargs" function ([Varargs Functions](@ref)).  The notation `Vararg{T,N}` is used to indicate
 such a constraint.  For example:
 
-```julia
-julia> bar(a,b,x::Vararg{Any,2}) = (a,b,x);
+```jldoctest
+julia> bar(a,b,x::Vararg{Any,2}) = (a,b,x)
+bar (generic function with 1 method)
 
 julia> bar(1,2,3)
 ERROR: MethodError: no method matching bar(::Int64, ::Int64, ::Int64)
-...
+Closest candidates are:
+  bar(::Any, ::Any, ::Any, !Matched::Any) at none:1
 
 julia> bar(1,2,3,4)
 (1,2,(3,4))
 
 julia> bar(1,2,3,4,5)
 ERROR: MethodError: no method matching bar(::Int64, ::Int64, ::Int64, ::Int64, ::Int64)
-...
+Closest candidates are:
+  bar(::Any, ::Any, ::Any, ::Any) at none:1
 ```
 
-More usefully, it is possible to constrain varargs methods by a parameter.  For example:
+More usefully, it is possible to constrain varargs methods by a parameter. For example:
 
 ```julia
 function getindex{T,N}(A::AbstractArray{T,N}, indexes::Vararg{Number,N})
@@ -568,24 +580,24 @@ by adding methods to its type. (Such "callable" objects are sometimes called "fu
 For example, you can define a type that stores the coefficients of a polynomial, but behaves like
 a function evaluating the polynomial:
 
-```julia
-immutable Polynomial{R}
-    coeffs::Vector{R}
-end
+```jldoctest polynomial
+julia> immutable Polynomial{R}
+           coeffs::Vector{R}
+       end
 
-function (p::Polynomial)(x)
-    v = p.coeffs[end]
-    for i = (length(p.coeffs)-1):-1:1
-        v = v*x + p.coeffs[i]
-    end
-    return v
-end
+julia> function (p::Polynomial)(x)
+           v = p.coeffs[end]
+           for i = (length(p.coeffs)-1):-1:1
+               v = v*x + p.coeffs[i]
+           end
+           return v
+       end
 ```
 
 Notice that the function is specified by type instead of by name. In the function body, `p` will
 refer to the object that was called. A `Polynomial` can be used as follows:
 
-```julia
+```jldoctest polynomial
 julia> p = Polynomial([1,10,100])
 Polynomial{Int64}([1,10,100])
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -67,10 +67,9 @@ is a subtype of any other. When the type is abstract, it suffices for the value 
 by a concrete type that is a subtype of the abstract type. If the type assertion is not true,
 an exception is thrown, otherwise, the left-hand value is returned:
 
-```julia
+```jldoctest
 julia> (1+2)::AbstractFloat
 ERROR: TypeError: typeassert: expected AbstractFloat, got Int64
- ...
 
 julia> (1+2)::Int
 3
@@ -83,7 +82,7 @@ the `::` operator means something a bit different: it declares the variable to a
 specified type, like a type declaration in a statically-typed language such as C. Every value
 assigned to the variable will be converted to the declared type using [`convert()`](@ref):
 
-```julia
+```jldoctest
 julia> function foo()
            x::Int8 = 100
            x
@@ -189,7 +188,7 @@ the right-hand type to be an immediate supertype of the newly declared type. It 
 in expressions as a subtype operator which returns `true` when its left operand is a subtype of
 its right operand:
 
-```julia
+```jldoctest
 julia> Integer <: Number
 true
 
@@ -309,7 +308,7 @@ Since composite types are the most common form of user-defined concrete type, th
 introduced with the `type` keyword followed by a block of field names, optionally annotated with
 types using the `::` operator:
 
-```julia
+```jldoctest footype
 julia> type Foo
            bar
            baz::Int
@@ -322,7 +321,7 @@ Fields with no type annotation default to `Any`, and can accordingly hold any ty
 New objects of composite type `Foo` are created by applying the `Foo` type object like a function
 to values for its fields:
 
-```julia
+```jldoctest footype
 julia> foo = Foo("Hello, world.", 23, 1.5)
 Foo("Hello, world.",23,1.5)
 
@@ -339,17 +338,17 @@ it easier to add new definitions without inadvertently replacing a default const
 Since the `bar` field is unconstrained in type, any value will do. However, the value for `baz`
 must be convertible to `Int`:
 
-```julia
+```jldoctest footype
 julia> Foo((), 23.5, 1)
 ERROR: InexactError()
- in convert(::Type{Int64}, ::Float64) at ./float.jl:656
- in Foo(::Tuple{}, ::Float64, ::Int64) at ./none:2
- ...
+Stacktrace:
+ [1] convert(::Type{Int64}, ::Float64) at ./float.jl:675
+ [2] Foo(::Tuple{}, ::Float64, ::Int64) at ./none:2
 ```
 
 You may find a list of field names using the `fieldnames` function.
 
-```julia
+```jldoctest footype
 julia> fieldnames(foo)
 3-element Array{Symbol,1}:
  :bar
@@ -359,7 +358,7 @@ julia> fieldnames(foo)
 
 You can access the field values of a composite object using the traditional `foo.bar` notation:
 
-```julia
+```jldoctest footype
 julia> foo.bar
 "Hello, world."
 
@@ -372,7 +371,7 @@ julia> foo.qux
 
 You can also change the values as one would expect:
 
-```julia
+```jldoctest footype
 julia> foo.qux = 2
 2
 
@@ -382,9 +381,9 @@ julia> foo.bar = 1//2
 
 Composite types with no fields are singletons; there can be only one instance of such types:
 
-```julia
-type NoFields
-end
+```jldoctest
+julia> type NoFields
+       end
 
 julia> NoFields() === NoFields()
 true
@@ -456,7 +455,7 @@ They share the same key properties:
 Because of these shared properties, these types are internally represented as instances of the
 same concept, `DataType`, which is the type of any of these types:
 
-```julia
+```jldoctest
 julia> typeof(Real)
 DataType
 
@@ -475,7 +474,7 @@ Every concrete value in the system is an instance of some `DataType`.
 A type union is a special abstract type which includes as objects all instances of any of its
 argument types, constructed using the special `Union` function:
 
-```julia
+```jldoctest
 julia> IntOrString = Union{Int,AbstractString}
 Union{AbstractString,Int64}
 
@@ -486,7 +485,7 @@ julia> "Hello!" :: IntOrString
 "Hello!"
 
 julia> 1.0 :: IntOrString
-ERROR: type: typeassert: expected Union{AbstractString,Int64}, got Float64
+ERROR: TypeError: typeassert: expected Union{AbstractString,Int64}, got Float64
 ```
 
 The compilers for many languages have an internal union construct for reasoning about types; Julia
@@ -517,11 +516,11 @@ abstract types, and finally parametric bits types.
 
 Type parameters are introduced immediately after the type name, surrounded by curly braces:
 
-```julia
-type Point{T}
-    x::T
-    y::T
-end
+```jldoctest pointtype
+julia> type Point{T}
+           x::T
+           y::T
+       end
 ```
 
 This declaration defines a new parametric type, `Point{T}`, holding two "coordinates" of type
@@ -532,7 +531,7 @@ of `Point` with [`Float64`](@ref). Thus, this single declaration actually declar
 number of types: `Point{Float64}`, `Point{AbstractString}`, `Point{Int64}`, etc. Each of these
 is now a usable concrete type:
 
-```julia
+```jldoctest pointtype
 julia> Point{Float64}
 Point{Float64}
 
@@ -546,7 +545,7 @@ the type `Point{AbstractString}` is a "point" whose "coordinates" are string obj
 `Point` itself is also a valid type object, containing all instances `Point{Float64}`, `Point{AbstractString}`,
 etc. as subtypes:
 
-```julia
+```jldoctest pointtype
 julia> Point{Float64} <: Point
 true
 
@@ -556,7 +555,7 @@ true
 
 Other types, of course, are not subtypes of it:
 
-```julia
+```jldoctest pointtype
 julia> Float64 <: Point
 false
 
@@ -566,7 +565,7 @@ false
 
 Concrete `Point` types with different values of `T` are never subtypes of each other:
 
-```julia
+```jldoctest pointtype
 julia> Point{Float64} <: Point{Int64}
 false
 
@@ -600,7 +599,7 @@ to arguments of type `Point{Float64}`:
 
 ```julia
 function norm(p::Point{Real})
-   sqrt(p.x^2 + p.y^2)
+    sqrt(p.x^2 + p.y^2)
 end
 ```
 
@@ -609,7 +608,7 @@ a subtype of `Real` is:
 
 ```julia
 function norm{T<:Real}(p::Point{T})
-   sqrt(p.x^2 + p.y^2)
+    sqrt(p.x^2 + p.y^2)
 end
 ```
 
@@ -624,7 +623,7 @@ arguments to the object constructor.
 Since the type `Point{Float64}` is a concrete type equivalent to `Point` declared with [`Float64`](@ref)
 in place of `T`, it can be applied as a constructor accordingly:
 
-```julia
+```jldoctest pointtype
 julia> Point{Float64}(1.0,2.0)
 Point{Float64}(1.0,2.0)
 
@@ -634,20 +633,16 @@ Point{Float64}
 
 For the default constructor, exactly one argument must be supplied for each field:
 
-```julia
+```jldoctest pointtype
 julia> Point{Float64}(1.0)
 ERROR: MethodError: Cannot `convert` an object of type Float64 to an object of type Point{Float64}
 This may have arisen from a call to the constructor Point{Float64}(...),
 since type constructors fall back to convert methods.
- in Point{Float64}(::Float64) at ./sysimg.jl:66
- ...
+Stacktrace:
+ [1] Point{Float64}(::Float64) at ./sysimg.jl:24
 
 julia> Point{Float64}(1.0,2.0,3.0)
 ERROR: MethodError: no method matching Point{Float64}(::Float64, ::Float64, ::Float64)
-Closest candidates are:
-  Point{Float64}{T}(::Any, ::Any) at none:3
-  Point{Float64}{T}(::Any) at sysimg.jl:66
- ...
 ```
 
 Only one default constructor is generated for parametric types, since overriding it is not possible.
@@ -658,7 +653,7 @@ the types of arguments to the constructor call already implicitly provide type i
 that reason, you can also apply `Point` itself as a constructor, provided that the implied value
 of the parameter type `T` is unambiguous:
 
-```julia
+```jldoctest pointtype
 julia> Point(1.0,2.0)
 Point{Float64}(1.0,2.0)
 
@@ -675,10 +670,12 @@ Point{Int64}
 In the case of `Point`, the type of `T` is unambiguously implied if and only if the two arguments
 to `Point` have the same type. When this isn't the case, the constructor will fail with a [`MethodError`](@ref):
 
-```julia
+```jldoctest pointtype
 julia> Point(1,2.5)
-ERROR: MethodError: no method matching Point{T}(::Int64, ::Float64)
-...
+ERROR: MethodError: no method matching Point(::Int64, ::Float64)
+Closest candidates are:
+  Point{T}(::Any) at sysimg.jl:24
+  Point{T}(::T, !Matched::T) at none:2
 ```
 
 Constructor methods to appropriately handle such mixed cases can be defined, but that will not
@@ -689,14 +686,14 @@ be discussed until later on in [Constructors](@ref man-constructors).
 Parametric abstract type declarations declare a collection of abstract types, in much the same
 way:
 
-```julia
-abstract Pointy{T}
+```jldoctest pointytype
+julia> abstract Pointy{T}
 ```
 
 With this declaration, `Pointy{T}` is a distinct abstract type for each type or integer value
 of `T`. As with parametric composite types, each such instance is a subtype of `Pointy`:
 
-```julia
+```jldoctest pointytype
 julia> Pointy{Int64} <: Pointy
 true
 
@@ -706,7 +703,7 @@ true
 
 Parametric abstract types are invariant, much as parametric composite types are:
 
-```julia
+```jldoctest pointytype
 julia> Pointy{Float64} <: Pointy{Real}
 false
 
@@ -718,16 +715,16 @@ Much as plain old abstract types serve to create a useful hierarchy of types ove
 parametric abstract types serve the same purpose with respect to parametric composite types. We
 could, for example, have declared `Point{T}` to be a subtype of `Pointy{T}` as follows:
 
-```julia
-type Point{T} <: Pointy{T}
-    x::T
-    y::T
-end
+```jldoctest pointytype
+julia> type Point{T} <: Pointy{T}
+           x::T
+           y::T
+       end
 ```
 
 Given such a declaration, for each choice of `T`, we have `Point{T}` as a subtype of `Pointy{T}`:
 
-```julia
+```jldoctest pointytype
 julia> Point{Float64} <: Pointy{Float64}
 true
 
@@ -740,7 +737,7 @@ true
 
 This relationship is also invariant:
 
-```julia
+```jldoctest pointytype
 julia> Point{Float64} <: Pointy{Real}
 false
 ```
@@ -749,10 +746,10 @@ What purpose do parametric abstract types like `Pointy` serve? Consider if we cr
 implementation that only requires a single coordinate because the point is on the diagonal line
 *x = y*:
 
-```julia
-type DiagPoint{T} <: Pointy{T}
-    x::T
-end
+```jldoctest pointytype
+julia> type DiagPoint{T} <: Pointy{T}
+           x::T
+       end
 ```
 
 Now both `Point{Float64}` and `DiagPoint{Float64}` are implementations of the `Pointy{Float64}`
@@ -764,14 +761,14 @@ next section, [Methods](@ref).
 There are situations where it may not make sense for type parameters to range freely over all
 possible types. In such situations, one can constrain the range of `T` like so:
 
-```julia
-abstract Pointy{T<:Real}
+```jldoctest realpointytype
+julia> abstract Pointy{T<:Real}
 ```
 
 With such a declaration, it is acceptable to use any type that is a subtype of `Real` in place
 of `T`, but not types that are not subtypes of `Real`:
 
-```julia
+```jldoctest realpointytype
 julia> Pointy{Float64}
 Pointy{Float64}
 
@@ -780,11 +777,9 @@ Pointy{Real}
 
 julia> Pointy{AbstractString}
 ERROR: TypeError: Pointy: in T, expected T<:Real, got Type{AbstractString}
- ...
 
 julia> Pointy{1}
 ERROR: TypeError: Pointy: in T, expected T<:Real, got Int64
- ...
 ```
 
 Type parameters for parametric composite types can be restricted in the same manner:
@@ -836,14 +831,14 @@ However, there are three key differences:
 Tuple values are written with parentheses and commas. When a tuple is constructed, an appropriate
 tuple type is generated on demand:
 
-```julia
+```jldoctest
 julia> typeof((1,"foo",2.5))
 Tuple{Int64,String,Float64}
 ```
 
 Note the implications of covariance:
 
-```julia
+```jldoctest
 julia> Tuple{Int,AbstractString} <: Tuple{Real,Any}
 true
 
@@ -862,17 +857,20 @@ signature (when the signature matches).
 The last parameter of a tuple type can be the special type `Vararg`, which denotes any number
 of trailing elements:
 
-```julia
-julia> isa(("1",), Tuple{AbstractString,Vararg{Int}})
+```jldoctest
+julia> mytupletype = Tuple{AbstractString,Vararg{Int}}
+Tuple{AbstractString,Vararg{Int64,N} where N}
+
+julia> isa(("1",), mytupletype)
 true
 
-julia> isa(("1",1), Tuple{AbstractString,Vararg{Int}})
+julia> isa(("1",1), mytupletype)
 true
 
-julia> isa(("1",1,2), Tuple{AbstractString,Vararg{Int}})
+julia> isa(("1",1,2), mytupletype)
 true
 
-julia> isa(("1",1,2,3.0), Tuple{AbstractString,Vararg{Int}})
+julia> isa(("1",1,2,3.0), mytupletype)
 false
 ```
 
@@ -888,7 +886,7 @@ There is a special kind of abstract parametric type that must be mentioned here:
 For each type, `T`, the "singleton type" `Type{T}` is an abstract type whose only instance is
 the object `T`. Since the definition is a little difficult to parse, let's look at some examples:
 
-```julia
+```jldoctest
 julia> isa(Float64, Type{Float64})
 true
 
@@ -906,24 +904,24 @@ In other words, [`isa(A,Type{B})`](@ref) is true if and only if `A` and `B` are 
 and that object is a type. Without the parameter, `Type` is simply an abstract type which has
 all type objects as its instances, including, of course, singleton types:
 
-```julia
-julia> isa(Type{Float64},Type)
+```jldoctest
+julia> isa(Type{Float64}, Type)
 true
 
-julia> isa(Float64,Type)
+julia> isa(Float64, Type)
 true
 
-julia> isa(Real,Type)
+julia> isa(Real, Type)
 true
 ```
 
 Any object that is not a type is not an instance of `Type`:
 
-```julia
-julia> isa(1,Type)
+```jldoctest
+julia> isa(1, Type)
 false
 
-julia> isa("foo",Type)
+julia> isa("foo", Type)
 false
 ```
 
@@ -958,7 +956,7 @@ only by their type parameter. Thus, `Ptr{Float64}` and `Ptr{Int64}` are distinct
 they have identical representations. And of course, all specific pointer types are subtype of
 the umbrella `Ptr` type:
 
-```julia
+```jldoctest
 julia> Ptr{Float64} <: Ptr
 true
 
@@ -1004,13 +1002,15 @@ contains the type of the first tuple element.
 
 The `where` keyword itself can be nested inside a more complex declaration.  For example, consider the
 two types created by the following declarations:
-```julia
+
+```jldoctest
 julia> const T1 = Array{Array{T,1} where T, 1}
 Array{Array{T,1} where T,1}
 
 julia> const T2 = Array{Array{T,1}, 1} where T
 Array{Array{T,1},1} where T
 ```
+
 Type `T1` defines a 1-dimensional array of 1-dimensional arrays; each
 of the inner arrays consists of objects of the same type, but this type may vary from one inner array to the next.
 On the other hand, type `T2` defines a 1-dimensional array of 1-dimensional arrays all of whose inner arrays must have the
@@ -1067,13 +1067,13 @@ that are particularly useful for working with or exploring types have already be
 such as the `<:` operator, which indicates whether its left hand operand is a subtype of its right
 hand operand.
 
-The `isa` function tests if an object is of a given type and returns true or false:
+The [`isa`](@ref) function tests if an object is of a given type and returns true or false:
 
-```julia
-julia> isa(1,Int)
+```jldoctest
+julia> isa(1, Int)
 true
 
-julia> isa(1,AbstractFloat)
+julia> isa(1, AbstractFloat)
 false
 ```
 
@@ -1081,7 +1081,7 @@ The [`typeof()`](@ref) function, already used throughout the manual in examples,
 of its argument. Since, as noted above, types are objects, they also have types, and we can ask
 what their types are:
 
-```julia
+```jldoctest
 julia> typeof(Rational{Int})
 DataType
 
@@ -1095,7 +1095,7 @@ Union
 What if we repeat the process? What is the type of a type of a type? As it happens, types are
 all composite values and thus all have a type of `DataType`:
 
-```julia
+```jldoctest
 julia> typeof(DataType)
 DataType
 
@@ -1108,7 +1108,7 @@ DataType
 Another operation that applies to some types is [`supertype()`](@ref), which reveals a type's
 supertype. Only declared types (`DataType`) have unambiguous supertypes:
 
-```julia
+```jldoctest
 julia> supertype(Float64)
 AbstractFloat
 
@@ -1125,9 +1125,12 @@ Any
 If you apply [`supertype()`](@ref) to other type objects (or non-type objects), a [`MethodError`](@ref)
 is raised:
 
-```julia
+```jldoctest
 julia> supertype(Union{Float64,Int64})
-ERROR: `supertype` has no method matching supertype(::Type{Union{Float64,Int64}})
+ERROR: MethodError: no method matching supertype(::Type{Union{Float64,Int64}})
+Closest candidates are:
+  supertype(!Matched::DataType) at operators.jl:27
+  supertype(!Matched::UnionAll) at operators.jl:32
 ```
 
 ## Custom pretty-printing
@@ -1136,16 +1139,18 @@ Often, one wants to customize how instances of a type are displayed.  This is ac
 overloading the [`show()`](@ref) function.  For example, suppose we define a type to represent
 complex numbers in polar form:
 
-```julia
-type Polar{T<:Real} <: Number
-    r::T
-    Θ::T
-end
-Polar(r::Real,Θ::Real) = Polar(promote(r,Θ)...)
+```jldoctest polartype
+julia> type Polar{T<:Real} <: Number
+           r::T
+           Θ::T
+       end
+
+julia> Polar(r::Real,Θ::Real) = Polar(promote(r,Θ)...)
+Polar
 ```
 
 Here, we've added a custom constructor function so that it can take arguments of different `Real`
-types and promote them to a commmon type (see [Constructors](@ref man-constructors) and [Conversion and Promotion](@ref conversion-and-promotion)).
+types and promote them to a common type (see [Constructors](@ref man-constructors) and [Conversion and Promotion](@ref conversion-and-promotion)).
 (Of course, we would have to define lots of other methods, too, to make it act like a `Number`,
 e.g. `+`, `*`, `one`, `zero`, promotion rules and so on.) By default, instances of this type display
 rather simply, with information about the type name and the field values, as e.g. `Polar{Float64}(3.0,4.0)`.
@@ -1154,8 +1159,8 @@ If we want it to display instead as `3.0 * exp(4.0im)`, we would define the foll
 print the object to a given output object `io` (representing a file, terminal, buffer, etcetera;
 see [Networking and Streams](@ref)):
 
-```julia
-Base.show(io::IO, z::Polar) = print(io, z.r, " * exp(", z.Θ, "im)")
+```jldoctest polartype
+julia> Base.show(io::IO, z::Polar) = print(io, z.r, " * exp(", z.Θ, "im)")
 ```
 
 More fine-grained control over display of `Polar` objects is possible. In particular, sometimes
@@ -1166,14 +1171,14 @@ by default the `show(io, z)` function is called in both cases, you can define a 
 format for displaying an object by overloading a three-argument form of `show` that takes the
 `text/plain` MIME type as its second argument (see [Multimedia I/O](@ref)), for example:
 
-```julia
-Base.show{T}(io::IO, ::MIME"text/plain", z::Polar{T}) =
-    print(io, "Polar{$T} complex number:\n   ", z)
+```jldoctest polartype
+julia> Base.show{T}(io::IO, ::MIME"text/plain", z::Polar{T}) =
+           print(io, "Polar{$T} complex number:\n   ", z)
 ```
 
 (Note that `print(..., z)` here will call the 2-argument `show(io, z)` method.) This results in:
 
-```julia
+```jldoctest polartype
 julia> Polar(3, 4.0)
 Polar{Float64} complex number:
    3.0 * exp(4.0im)
@@ -1193,16 +1198,16 @@ Moreover, you can also define `show` methods for other MIME types in order to en
 (HTML, images, etcetera) of objects in environments that support this (e.g. IJulia).   For example,
 we can define formatted HTML display of `Polar` objects, with superscripts and italics, via:
 
-```julia
-Base.show{T}(io::IO, ::MIME"text/html", z::Polar{T}) =
-    println(io, "<code>Polar{$T}</code> complex number: ",
-            z.r, " <i>e</i><sup>", z.Θ, " <i>i</i></sup>")
+```jldoctest polartype
+julia> Base.show{T}(io::IO, ::MIME"text/html", z::Polar{T}) =
+           println(io, "<code>Polar{$T}</code> complex number: ",
+                   z.r, " <i>e</i><sup>", z.Θ, " <i>i</i></sup>")
 ```
 
 A `Polar` object will then display automatically using HTML in an environment that supports HTML
 display, but you can call `show` manually to get HTML output if you want:
 
-```julia
+```jldoctest polartype
 julia> show(STDOUT, "text/html", Polar(3.0,4.0))
 <code>Polar{Float64}</code> complex number: 3.0 <i>e</i><sup>4.0 <i>i</i></sup>
 ```
@@ -1225,18 +1230,21 @@ elaborate hierarchy.
 
 `Val` is defined as:
 
-```julia
-immutable Val{T}
-end
+```jldoctest valtype
+julia> immutable Val{T}
+       end
 ```
 
 There is no more to the implementation of `Val` than this.  Some functions in Julia's standard
 library accept `Val` types as arguments, and you can also use it to write your own functions.
  For example:
 
-```julia
-firstlast(::Type{Val{true}}) = "First"
-firstlast(::Type{Val{false}}) = "Last"
+```jldoctest valtype
+julia> firstlast(::Type{Val{true}}) = "First"
+firstlast (generic function with 1 method)
+
+julia> firstlast(::Type{Val{false}}) = "Last"
+firstlast (generic function with 2 methods)
 
 julia> firstlast(Val{true})
 "First"
@@ -1278,7 +1286,7 @@ the interface consists of several possible interactions:
 
 To construct an object representing a missing value of type `T`, use the `Nullable{T}()` function:
 
-```julia
+```jldoctest
 julia> x1 = Nullable{Int64}()
 Nullable{Int64}()
 
@@ -1292,7 +1300,7 @@ Nullable{Array{Int64,1}}()
 To construct an object representing a non-missing value of type `T`, use the `Nullable(x::T)`
 function:
 
-```julia
+```jldoctest
 julia> x1 = Nullable(1)
 Nullable{Int64}(1)
 
@@ -1311,7 +1319,7 @@ a single value of type `T` as an argument.
 
 You can check if a `Nullable` object has any value using [`isnull()`](@ref):
 
-```julia
+```jldoctest
 julia> isnull(Nullable{Float64}())
 true
 
@@ -1323,11 +1331,11 @@ false
 
 You can safely access the value of a `Nullable` object using [`get()`](@ref):
 
-```julia
+```jldoctest
 julia> get(Nullable{Float64}())
 ERROR: NullException()
- in get(::Nullable{Float64}) at ./nullable.jl:91
- ...
+Stacktrace:
+ [1] get(::Nullable{Float64}) at ./nullable.jl:92
 
 julia> get(Nullable(1.0))
 1.0
@@ -1341,7 +1349,7 @@ In cases for which a reasonable default value exists that could be used when a `
 object's value turns out to be missing, you can provide this default value as a second argument
 to `get()`:
 
-```julia
+```jldoctest
 julia> get(Nullable{Float64}(), 0.0)
 0.0
 
@@ -1389,11 +1397,9 @@ including making existing operations work and propagate `Nullable`s. An example
 will motivate the need for `broadcast`. Suppose we have a function that computes the
 greater of two real roots of a quadratic equation, using the quadratic formula:
 
-```julia
-"""
-Compute the positive real root of ``ax^2 + bx + c = 0``.
-"""
-root(a::Real, b::Real, c::Real) = (-b + √(b^2 - 4a*c)) / 2a
+```jldoctest nullableroot
+julia> root(a::Real, b::Real, c::Real) = (-b + √(b^2 - 4a*c)) / 2a
+root (generic function with 1 method)
 ```
 
 We may verify that the result of `root(1, -9, 20)` is `5.0`, as we expect,
@@ -1412,7 +1418,7 @@ output.
 The `broadcast()` function makes this task easy; we can simply pass the
 `root` function we wrote to `broadcast`:
 
-```julia
+```jldoctest nullableroot
 julia> broadcast(root, Nullable(1), Nullable(-9), Nullable(20))
 Nullable{Float64}(5.0)
 
@@ -1429,7 +1435,7 @@ If one or more of the inputs is missing, then the output of
 There exists special syntactic sugar for the `broadcast()` function
 using a dot notation:
 
-```julia
+```jldoctest nullableroot
 julia> root.(Nullable(1), Nullable(-9), Nullable(20))
 Nullable{Float64}(5.0)
 ```
@@ -1437,7 +1443,7 @@ Nullable{Float64}(5.0)
 In particular, the regular arithmetic operators can be `broadcast()`
 conveniently using `.`-prefixed operators:
 
-```julia
+```jldoctest
 julia> Nullable(2) ./ Nullable(3) .+ Nullable(1.0)
 Nullable{Float64}(1.66667)
 ```


### PR DESCRIPTION
Pretty straight forward commits, with a reservation on what is decided regarding showing backtraces (ref. https://github.com/JuliaLang/julia/pull/20202#discussion_r97447735)

(`make check-whitespace` and the doctests pass locally, remove `[ci skip]` from commit message if/when this is merged)