### PR TITLE
deprecate vectorized sign methods in favor of dot syntax

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -11,7 +11,7 @@ See also [`conj`](@ref).
 """
 conj!{T<:Number}(A::AbstractArray{T}) = (@inbounds broadcast!(conj, A, A); A)
 
-for f in (:-, :~, :conj, :sign, :real, :imag)
+for f in (:-, :~, :conj, :real, :imag)
     @eval ($f)(A::AbstractArray) = broadcast($f, A)
 end
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1166,7 +1166,7 @@ function (-)(B::BitArray)
     end
     return A
 end
-sign(B::BitArray) = copy(B)
+broadcast(::typeof(sign), B::BitArray) = copy(B)
 
 function (~)(B::BitArray)
     C = similar(B)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1423,6 +1423,9 @@ end
 # Deprecate manually vectorized abs2 methods in favor of compact broadcast syntax
 @deprecate abs2(x::AbstractSparseVector) abs2.(x)
 
+# Deprecate manually vectorized sign methods in favor of compact broadcast syntax
+@deprecate sign(A::AbstractArray) sign.(A)
+
 # Deprecate manually vectorized trigonometric and hyperbolic functions in favor of compact broadcast syntax
 for f in (:sec, :sech, :secd, :asec, :asech,
             :csc, :csch, :cscd, :acsc, :acsch,

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -386,7 +386,7 @@ function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxite
 
     if ritzvec
         # calculating singular vectors
-        left_sv  = sqrt(2) * ex[2][ 1:size(X,1),     ind ] .* sign(ex[1][ind]')
+        left_sv  = sqrt(2) * ex[2][ 1:size(X,1),     ind ] .* sign.(ex[1][ind]')
         right_sv = sqrt(2) * ex[2][ size(X,1)+1:end, ind ]
         return (SVD(left_sv, sval, right_sv'), ex[3], ex[4], ex[5], ex[6])
     else

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1824,10 +1824,10 @@ end
     B = [-10.0,0.0,3.0]
     C = [1,im,0]
 
-    @test sign(A) == [-1,0,1]
-    @test sign(B) == [-1,0,1]
-    @test typeof(sign(A)) == Vector{Int}
-    @test typeof(sign(B)) == Vector{Float64}
+    @test sign.(A) == [-1,0,1]
+    @test sign.(B) == [-1,0,1]
+    @test typeof(sign.(A)) == Vector{Int}
+    @test typeof(sign.(B)) == Vector{Float64}
 
     @test conj(A) == A
     @test conj(B) == A

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -724,7 +724,7 @@ timesofar("dequeue")
     @check_bit_operation (~)(b1)  BitMatrix
     @check_bit_operation (!)(b1)  BitMatrix
     @check_bit_operation (-)(b1)  Matrix{Int}
-    @check_bit_operation sign(b1) BitMatrix
+    @check_bit_operation broadcast(sign, b1) BitMatrix
     @check_bit_operation real(b1) BitMatrix
     @check_bit_operation imag(b1) BitMatrix
     @check_bit_operation conj(b1) BitMatrix
@@ -733,7 +733,7 @@ timesofar("dequeue")
     @check_bit_operation (~)(b0)  BitVector
     @check_bit_operation (!)(b0)  BitVector
     @check_bit_operation (-)(b0)  Vector{Int}
-    @check_bit_operation sign(b0) BitVector
+    @check_bit_operation broadcast(sign, b0) BitVector
 
     @testset "flipbits!" begin
         b1 = bitrand(n1, n2)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -729,10 +729,10 @@ end
 
 # sign, conj, ~ (Issue #16067)
 let A = -1:1, B = -1.0:1.0
-    @test sign(A) == [-1,0,1]
-    @test sign(B) == [-1,0,1]
-    @test typeof(sign(A)) === Vector{Int}
-    @test typeof(sign(B)) === Vector{Float64}
+    @test sign.(A) == [-1,0,1]
+    @test sign.(B) == [-1,0,1]
+    @test typeof(sign.(A)) === Vector{Int}
+    @test typeof(sign.(B)) === Vector{Float64}
 
     @test conj(A) === A
     @test conj(B) === B


### PR DESCRIPTION
This pull request deprecates all remaining vectorized `sign` methods in favor of dot syntax. Best!