### PR TITLE
fix testset printing and add test

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -730,7 +730,7 @@ function print_counts(ts::DefaultTestSet, depth, align,
     subtotal = passes + fails + errors + broken + c_passes + c_fails + c_errors + c_broken
     # Print test set header, with an alignment that ensures all
     # the test results appear above each other
-    print(rpad(string(lpad("  ",depth), ts.description), align, " "), " | ")
+    print(rpad(string("  "^depth, ts.description), align, " "), " | ")
 
     np = passes + c_passes
     if np > 0

--- a/base/test.jl
+++ b/base/test.jl
@@ -631,6 +631,9 @@ function print_test_results(ts::DefaultTestSet, depth_pad=0)
     print_counts(ts, depth_pad, align, pass_width, fail_width, error_width, broken_width, total_width)
 end
 
+
+const TESTSET_PRINT_ENABLE = Ref(true)
+
 # Called at the end of a @testset, behaviour depends on whether
 # this is a child of another testset, or the "root" testset
 function finish(ts::DefaultTestSet)
@@ -648,6 +651,11 @@ function finish(ts::DefaultTestSet)
     total_error  = errors + c_errors
     total_broken = broken + c_broken
     total = total_pass + total_fail + total_error + total_broken
+
+    if TESTSET_PRINT_ENABLE[]
+        print_test_results(ts)
+    end
+
     # Finally throw an error as we are the outermost test set
     if total != total_pass + total_broken
         # Get all the error/failures and bring them along for the ride

--- a/test/test.jl
+++ b/test/test.jl
@@ -426,3 +426,33 @@ let io = IOBuffer()
     @test contains(str, "msg")
     @test !contains(str, "backtrace()")
 end
+
+msg = readstring(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
+using Base.Test
+
+foo(x) = length(x)^2
+
+@testset "Foo Tests" begin
+    @testset "Animals" begin
+        @testset "Felines" begin
+            @test foo("cat") == 9
+        end
+        @testset "Canines" begin
+            @test foo("dog") == 11
+        end
+    end
+    @testset "Arrays" begin
+        @test foo(zeros(2)) == 4
+        @test foo(ones(4)) == 15
+    end
+end'`))
+
+@test contains(msg,
+"""
+Test Summary: | Pass  Fail  Total
+Foo Tests     |    2     2      4
+  Animals     |    1     1      2
+    Felines   |    1            1
+    Canines   |          1      1
+  Arrays      |    1     1      2
+""")

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -1,31 +1,37 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 function runtests(name, isolate=true)
-    if isolate
-        mod_name = Symbol("TestMain_", replace(name, '/', '_'))
-        m = eval(Main, :(module $mod_name end))
-    else
-        m = Main
-    end
-    eval(m, :(using Base.Test))
-    ex = quote
-        @timed @testset $"$name" begin
-            include($"$name.jl")
+    old_print_setting = Base.Test.TESTSET_PRINT_ENABLE[]
+    Base.Test.TESTSET_PRINT_ENABLE[] = false
+    try
+        if isolate
+            mod_name = Symbol("TestMain_", replace(name, '/', '_'))
+            m = eval(Main, :(module $mod_name end))
+        else
+            m = Main
         end
+        eval(m, :(using Base.Test))
+        ex = quote
+            @timed @testset $"$name" begin
+                include($"$name.jl")
+            end
+        end
+        res_and_time_data = eval(m, ex)
+        rss = Sys.maxrss()
+        #res_and_time_data[1] is the testset
+        passes,fails,error,broken,c_passes,c_fails,c_errors,c_broken = Base.Test.get_test_counts(res_and_time_data[1])
+        if res_and_time_data[1].anynonpass == false
+            res_and_time_data = (
+                                 (passes+c_passes,broken+c_broken),
+                                 res_and_time_data[2],
+                                 res_and_time_data[3],
+                                 res_and_time_data[4],
+                                 res_and_time_data[5])
+        end
+        vcat(collect(res_and_time_data), rss)
+    finally
+        Base.Test.TESTSET_PRINT_ENABLE[] = old_print_setting
     end
-    res_and_time_data = eval(m, ex)
-    rss = Sys.maxrss()
-    #res_and_time_data[1] is the testset
-    passes,fails,error,broken,c_passes,c_fails,c_errors,c_broken = Base.Test.get_test_counts(res_and_time_data[1])
-    if res_and_time_data[1].anynonpass == false
-        res_and_time_data = (
-                             (passes+c_passes,broken+c_broken),
-                             res_and_time_data[2],
-                             res_and_time_data[3],
-                             res_and_time_data[4],
-                             res_and_time_data[5])
-    end
-    vcat(collect(res_and_time_data), rss)
 end
 
 # looking in . messes things up badly


### PR DESCRIPTION
It is currently bugged (on 0.5 as well) in that it is not indenting nested testets. I had to put this on top of https://github.com/JuliaLang/julia/pull/20221 to test it (because testsets were not printed at all before that). I just took the old implementation from BaseTestNext where it works as it should.

Now:

```
Test Summary: | Pass  Fail  Total
Foo Tests     |    2     2      4
  Animals     |    1     1      2
    Felines   |    1            1
    Canines   |          1      1
  Arrays      |    1     1      2
```

Previously:

```
Test Summary: | Pass  Fail  Total
  Foo Tests   |    2     2      4
  Animals     |    1     1      2
  Felines     |    1            1
  Canines     |          1      1
  Arrays      |    1     1      2
```