### PR TITLE
Add `broadcast!(identity, ::Array, ::Array)` specialization

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -15,6 +15,8 @@ typealias ScalarType Union{Type{Any}, Type{Nullable}}
 # fallbacks for some special cases
 @inline broadcast(f, x::Number...) = f(x...)
 @inline broadcast{N}(f, t::NTuple{N,Any}, ts::Vararg{NTuple{N,Any}}) = map(f, t, ts...)
+broadcast!{T,S,N}(::typeof(identity), x::Array{T,N}, y::Array{S,N}) =
+    size(x) == size(y) ? copy!(x, y) : broadcast_c!(identity, Array, Array, x, y)
 
 # special cases for "X .= ..." (broadcast!) assignments
 broadcast!(::typeof(identity), X::AbstractArray, x::Number) = fill!(X, x)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -453,6 +453,7 @@ end
 # Test that broadcasting identity where the input and output Array shapes do not match
 # yields the correct result, not merely a partial copy. See pull request #19895 for discussion.
 let N = 5
+    @test iszero(ones(N, N) .= zeros(N, N))
     @test iszero(ones(N, N) .= zeros(N, 1))
     @test iszero(ones(N, N) .= zeros(1, N))
     @test iszero(ones(N, N) .= zeros(1, 1))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -449,3 +449,11 @@ end
     @test broadcast(==, [1], AbstractArray) == BitArray([false])
     @test broadcast(==, 1, AbstractArray) == false
 end
+
+# Test that broadcasting identity where the input and output Array shapes do not match
+# yields the correct result, not merely a partial copy. See pull request #19895 for discussion.
+let N = 5
+    @test iszero(ones(N, N) .= zeros(N, 1))
+    @test iszero(ones(N, N) .= zeros(1, N))
+    @test iszero(ones(N, N) .= zeros(1, 1))
+end


### PR DESCRIPTION
Closes #20227.

Performance improvement is most prominent for small element size:
```julia
x=rand(Int8,50,50); y=similar(x); @benchmark $y .= $x

# master
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     9
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     2.20 μs (0.00% GC)
  median time:      2.21 μs (0.00% GC)
  mean time:        2.22 μs (0.00% GC)
  maximum time:     3.38 μs (0.00% GC)

# this PR
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     976
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     70.00 ns (0.00% GC)
  median time:      70.00 ns (0.00% GC)
  mean time:        70.19 ns (0.00% GC)
  maximum time:     130.00 ns (0.00% GC)
```

There is a little bit of overhead though, becoming significant for very small arrays:
```julia
x=rand(Int64,1); y=similar(x); @benchmark $y .= $x

# master
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     999
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     9.00 ns (0.00% GC)
  median time:      10.00 ns (0.00% GC)
  mean time:        9.96 ns (0.00% GC)
  maximum time:     19.00 ns (0.00% GC)

# this PR
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     998
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     15.00 ns (0.00% GC)
  median time:      15.00 ns (0.00% GC)
  mean time:        15.21 ns (0.00% GC)
  maximum time:     34.00 ns (0.00% GC)
```