### PR TITLE
RFC: make julia prompt non bold

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -629,7 +629,6 @@ function write_prompt(terminal, p::Prompt)
     prefix = isa(p.prompt_prefix,Function) ? eval(Expr(:call, p.prompt_prefix)) : p.prompt_prefix
     suffix = isa(p.prompt_suffix,Function) ? eval(Expr(:call, p.prompt_suffix)) : p.prompt_suffix
     write(terminal, prefix)
-    write(terminal, Base.text_colors[:bold])
     write(terminal, p.prompt)
     write(terminal, Base.text_colors[:normal])
     write(terminal, suffix)


### PR DESCRIPTION
Makes the julia prompt (`julia>`) non bold since the input and answer text now is non bold.

![image](https://cloud.githubusercontent.com/assets/1282691/22311339/59a411a4-e353-11e6-9fde-9fedd675cc2a.png)

Lemme see some thumbs.