### PR TITLE
fix failing subarray test on master (partial linear indexing depwarn)

### DIFF
--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -517,7 +517,7 @@ end
 @test X[1:end] == @views X[1:end]
 @test X[1:end-3] == @views X[1:end-3]
 @test X[1:end,2,2] == @views X[1:end,2,2]
-@test X[1,1:end-2] == @views X[1,1:end-2]
+# @test X[1,1:end-2] == @views X[1,1:end-2] # TODO: Re-enable after partial linear indexing deprecation
 @test X[1,2,1:end-2] == @views X[1,2,1:end-2]
 @test X[1,2,Y[2:end]] == @views X[1,2,Y[2:end]]
 @test X[1:end,2,Y[2:end]] == @views X[1:end,2,Y[2:end]]


### PR DESCRIPTION
The at-views PR (#20164) and partial linear indexing deprecation PR (#20079) each last passed CI prior to the other being merged, so CI missed an interaction between them that causes the subarray tests to fail (throwing a depwarn from an at-views test). This pull request disables the offending at-views test, following [the approach applied to the equivalent tests for at-view](https://github.com/JuliaLang/julia/blob/876549f63e5dabd69366608c0c668d058a944921/test/subarray.jl#L487). (Should these instead be `@test_broken`? Similar todos exist in the subarray tests regarding `Colon`.) Best!