### PR TITLE
Restrict signature for getindex(::AbstractString, ::AbstractVector}

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -34,8 +34,10 @@ getindex(s::AbstractString, i::Integer) = s[Int(i)]
 getindex(s::AbstractString, i::Colon) = s
 getindex{T<:Integer}(s::AbstractString, r::UnitRange{T}) = s[Int(first(r)):Int(last(r))]
 # TODO: handle other ranges with stride ±1 specially?
-getindex(s::AbstractString, v::AbstractVector) =
+getindex{T<:Integer}(s::AbstractString, v::AbstractVector{T}) =
     sprint(length(v), io->(for i in v; write(io,s[i]) end))
+getindex(s::AbstractString, v::AbstractVector{Bool}) =
+    throw(ArgumentError("logical indexing not supported for strings"))
 
 Symbol(s::AbstractString) = Symbol(String(s))
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -172,9 +172,9 @@ gstr = GenericString("12")
 @test convert(Array{Char,1}, gstr) ==['1';'2']
 @test convert(Symbol, gstr)==Symbol("12")
 
-@test getindex(gstr, Bool(1))=='1'
-@test getindex(gstr,Bool(1):Bool(1))=="1"
-@test getindex(gstr,AbstractVector([Bool(1):Bool(1);]))=="1"
+@test gstr[1] == '1'
+@test gstr[1:1] == "1"
+@test gstr[[1]] == "1"
 
 @test done(eachindex("foobar"),7)
 @test eltype(Base.EachStringIndex) == Int
@@ -187,9 +187,8 @@ gstr = GenericString("12")
 
 @test length(GenericString(""))==0
 
-@test getindex(gstr,AbstractVector([Bool(1):Bool(1);]))=="1"
-
-@test nextind(AbstractArray([Bool(1):Bool(1);]),1)==2
+@test nextind(1:1, 1) == 2
+@test nextind([1], 1) == 2
 
 @test ind2chr(gstr,2)==2
 
@@ -461,3 +460,7 @@ Base.endof(x::CharStr) = endof(x.chars)
 # Case with Unicode characters
 @test cmp("\U1f596\U1f596", CharStr("\U1f596")) == 1   # Gives BoundsError with bug
 @test cmp(CharStr("\U1f596"), "\U1f596\U1f596") == -1
+
+# issue #12495: check that logical indexing attempt raises ArgumentError
+@test_throws ArgumentError "abc"[[true, false, true]]
+@test_throws ArgumentError "abc"[BitArray([true, false, true])]


### PR DESCRIPTION
Only integer indices are supported by the generic interface, so better
raise a MethodError for other element types rather than failing later.
Ideally the Bool-specific method would not be needed, but it is required
as long as Bool<:Integer.

Fixes https://github.com/JuliaLang/julia/issues/12495.


(Some of the tests that needed modifications look really weird to me.)