### PR TITLE
WIP: Implement alias scopes

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -23,7 +23,7 @@ typealias DenseVecOrMat{T} Union{DenseVector{T}, DenseMatrix{T}}
 
 ## Basic functions ##
 
-import Core: arraysize, arrayset, arrayref
+import Core: arraysize, arrayset, arrayref, const_arrayref
 
 """
     Array{T,N}(dims)

--- a/src/array.c
+++ b/src/array.c
@@ -519,6 +519,13 @@ JL_CALLABLE(jl_f_arrayref)
     return jl_arrayref(a, i);
 }
 
+JL_CALLABLE(jl_f_const_arrayref)
+{
+    // The constness of the array matters during codegen for alias analysis
+    // purposes, but we don't particularly care here.
+    return jl_f_arrayref(F, args, nargs);
+}
+
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
 {
     if (a->flags.ptrarray)

--- a/src/ast.c
+++ b/src/ast.c
@@ -56,6 +56,7 @@ jl_sym_t *inert_sym; jl_sym_t *vararg_sym;
 jl_sym_t *unused_sym; jl_sym_t *static_parameter_sym;
 jl_sym_t *polly_sym; jl_sym_t *inline_sym;
 jl_sym_t *propagate_inbounds_sym;
+jl_sym_t *aliasscope_sym; jl_sym_t *popaliasscope_sym;
 
 static uint8_t flisp_system_image[] = {
 #include <julia_flisp.boot.inc>
@@ -413,6 +414,8 @@ void jl_init_frontend(void)
     polly_sym = jl_symbol("polly");
     inline_sym = jl_symbol("inline");
     propagate_inbounds_sym = jl_symbol("propagate_inbounds");
+    aliasscope_sym = jl_symbol("aliasscope");
+    popaliasscope_sym = jl_symbol("popaliasscope");
 }
 
 JL_DLLEXPORT void jl_lisp_prompt(void)

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -27,6 +27,7 @@ DECLARE_BUILTIN(isdefined);  DECLARE_BUILTIN(nfields);
 DECLARE_BUILTIN(tuple);      DECLARE_BUILTIN(svec);
 DECLARE_BUILTIN(getfield);   DECLARE_BUILTIN(setfield);
 DECLARE_BUILTIN(fieldtype);  DECLARE_BUILTIN(arrayref);
+DECLARE_BUILTIN(const_arrayref);
 DECLARE_BUILTIN(arrayset);   DECLARE_BUILTIN(arraysize);
 DECLARE_BUILTIN(apply_type); DECLARE_BUILTIN(applicable);
 DECLARE_BUILTIN(invoke);     DECLARE_BUILTIN(_expr);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1226,6 +1226,7 @@ void jl_init_primitives(void)
 
     // array primitives
     add_builtin_func("arrayref", jl_f_arrayref);
+    add_builtin_func("const_arrayref", jl_f_const_arrayref);
     add_builtin_func("arrayset", jl_f_arrayset);
     add_builtin_func("arraysize", jl_f_arraysize);
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -924,7 +924,7 @@ static unsigned julia_alignment(Value* /*ptr*/, jl_value_t *jltype, unsigned ali
 static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value* dest = NULL, bool volatile_store = false);
 
 static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
-                             jl_codectx_t *ctx, MDNode *tbaa, unsigned alignment = 0)
+                             jl_codectx_t *ctx, MDNode *tbaa, MDNode *aliasscope, unsigned alignment = 0)
 {
     bool isboxed;
     Type *elty = julia_type_to_llvm(jltype, &isboxed);
@@ -946,6 +946,9 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
     //else {
         Instruction *load = builder.CreateAlignedLoad(data, isboxed ?
             alignment : julia_alignment(data, jltype, alignment), false);
+        if (aliasscope) {
+            load->setMetadata("alias.scope", aliasscope);
+        }
         if (tbaa) {
             elt = tbaa_decorate(tbaa, load);
         }
@@ -961,6 +964,7 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
 
 static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
                         jl_value_t *jltype, jl_codectx_t *ctx, MDNode *tbaa,
+                        MDNode *aliasscope,
                         Value *parent,  // for the write barrier, NULL if no barrier needed
                         unsigned alignment = 0, bool root_box = true) // if the value to store needs a box, should we root it ?
 {
@@ -983,6 +987,8 @@ static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
         data = ptr;
     Instruction *store = builder.CreateAlignedStore(r, builder.CreateGEP(data,
         idx_0based), isboxed ? alignment : julia_alignment(r, jltype, alignment));
+    if (aliasscope)
+        store->setMetadata("noalias", aliasscope);
     if (tbaa)
         tbaa_decorate(tbaa, store);
 }
@@ -1105,7 +1111,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct,
                 ret->isimmutable = strct.isimmutable;
                 return true;
             }
-            *ret = typed_load(ptr, idx, jt, ctx, strct.tbaa);
+            *ret = typed_load(ptr, idx, jt, ctx, strct.tbaa, nullptr);
             return true;
         }
         else if (strct.isboxed) {
@@ -1176,7 +1182,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         int align = jl_field_offset(jt, idx);
         align |= 16;
         align &= -align;
-        return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, strct.tbaa, align);
+        return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, strct.tbaa, nullptr, align);
     }
     else if (isa<UndefValue>(strct.V)) {
         return jl_cgval_t();
@@ -1741,7 +1747,7 @@ static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t id
             align |= 16;
             align &= -align;
             typed_store(addr, ConstantInt::get(T_size, 0), rhs, jfty, ctx,
-                strct.tbaa, data_pointer(strct, ctx, T_pjlvalue), align);
+                strct.tbaa, nullptr, data_pointer(strct, ctx, T_pjlvalue), align);
         }
     }
     else {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -557,6 +557,7 @@ public:
     Value *spvals_ptr;
     Value *argArray;
     Value *argCount;
+    MDNode *aliasscope;
     std::string funcName;
     int vaSlot;        // name of vararg argument
     bool vaStack;      // varargs stack-allocated
@@ -2512,7 +2513,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
         }
     }
 
-    else if (f==jl_builtin_arrayref && nargs>=2) {
+    else if ((f==jl_builtin_arrayref || f == jl_builtin_const_arrayref) && nargs>=2) {
         jl_value_t *aty = expr_type(args[1], ctx); rt1 = aty;
         bool indexes_ok = true;
         for (size_t i=2; i <= nargs; i++) {
@@ -2539,7 +2540,8 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                         *ret = ghostValue(ety);
                     }
                     else {
-                        *ret = typed_load(emit_arrayptr(ary, args[1], ctx), idx, ety, ctx, tbaa_arraybuf);
+                        MDNode *aliasscope = (f == jl_builtin_const_arrayref) ? ctx->aliasscope : nullptr;
+                        *ret = typed_load(emit_arrayptr(ary, args[1], ctx), idx, ety, ctx, tbaa_arraybuf, aliasscope);
                     }
                     JL_GC_POP();
                     return true;
@@ -2618,7 +2620,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                             data_owner->addIncoming(own_ptr, ownedBB);
                         }
                         typed_store(emit_arrayptr(ary,args[1],ctx), idx, v,
-                                    ety, ctx, tbaa_arraybuf, data_owner, 0,
+                                    ety, ctx, tbaa_arraybuf, ctx->aliasscope, data_owner, 0,
                                     false); // don't need to root the box if we had to make one since it's being stored in the array immediatly
                     }
                     *ret = ary;
@@ -3380,7 +3382,7 @@ static void emit_stmtpos(jl_value_t *expr, jl_codectx_t *ctx)
     jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
     jl_sym_t *head = ex->head;
     if (head == line_sym || head == meta_sym || head == boundscheck_sym ||
-        head == inbounds_sym) {
+        head == inbounds_sym || head == aliasscope_sym || head == popaliasscope_sym) {
         // some expression types are metadata and can be ignored
         // in statement position
         return;
@@ -3602,6 +3604,12 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
     }
     else if (head == inbounds_sym) {
         jl_error("Expr(:inbounds) in value position");
+    }
+    else if (head == aliasscope_sym) {
+        jl_error("Expr(:aliasscope) in value position");
+    }
+    else if (head == popaliasscope_sym) {
+        jl_error("Expr(:popaliasscope) in value position");
     }
     else if (head == boundscheck_sym) {
         jl_error("Expr(:boundscheck) in value position");
@@ -4842,6 +4850,7 @@ static std::unique_ptr<Module> emit_function(
         bool in_user_code;
     };
     struct StmtProp {
+        MDNode *scope_list;
         DebugLoc loc;
         StringRef file;
         ssize_t line;
@@ -4852,6 +4861,8 @@ static std::unique_ptr<Module> emit_function(
     };
     std::vector<StmtProp> stmtprops(stmtslen);
     std::vector<DbgState> DI_stack;
+    std::vector<Metadata*> scope_stack;
+    std::vector<MDNode*> scope_list_stack;
     std::vector<bool> inbounds_stack{false};
     auto is_inbounds = [&] () {
         // inbounds rule is either of top two values on inbounds stack are true
@@ -4861,7 +4872,9 @@ static std::unique_ptr<Module> emit_function(
             inbounds |= inbounds_stack[sz - 2];
         return inbounds;
     };
-    StmtProp cur_prop{topdebugloc, filename, toplineno,
+    static MDBuilder *mbuilder = new MDBuilder(jl_LLVMContext);
+    MDNode *alias_domain = mbuilder->createAliasScopeDomain(ctx.name);
+    StmtProp cur_prop{nullptr, topdebugloc, filename, toplineno,
             false, true, false, false};
     ctx.line = &cur_prop.line;
     if (coverage_mode != JL_LOG_NONE || malloc_log_mode) {
@@ -4997,6 +5010,20 @@ static std::unique_ptr<Module> emit_function(
                         inbounds_stack.pop_back();
                     }
                 }
+            } else if (expr->head == aliasscope_sym) {
+                MDNode *scope = mbuilder->createAliasScope("aliasscope", alias_domain);
+                scope_stack.push_back(scope);
+                MDNode *scope_list = MDNode::get(jl_LLVMContext, ArrayRef<Metadata*>(scope_stack)
+#if JL_LLVM_VERSION >= 40000
+                    , MDNode::FL_Yes
+#endif
+                );
+                scope_list_stack.push_back(scope_list);
+                cur_prop.scope_list = scope_list;
+            } else if (expr->head == popaliasscope_sym) {
+                scope_stack.pop_back();
+                scope_list_stack.pop_back();
+                cur_prop.scope_list = scope_list_stack.back();
             }
         }
         cur_prop.is_inbounds = is_inbounds();
@@ -5107,6 +5134,7 @@ static std::unique_ptr<Module> emit_function(
             coverageVisitLine(props.file, props.line);
         }
         ctx.is_inbounds = props.is_inbounds;
+        ctx.aliasscope = props.scope_list;
         jl_value_t *stmt = jl_array_ptr_ref(stmts, cursor);
         jl_expr_t *expr = jl_is_expr(stmt) ? (jl_expr_t*)stmt : nullptr;
         if (jl_is_labelnode(stmt)) {
@@ -5764,6 +5792,7 @@ static void init_julia_llvm_env(Module *m)
     builtin_func_map[jl_f_nfields] = jlcall_func_to_llvm("jl_f_nfields", &jl_f_nfields, m);
     builtin_func_map[jl_f__expr] = jlcall_func_to_llvm("jl_f__expr", &jl_f__expr, m);
     builtin_func_map[jl_f_arrayref] = jlcall_func_to_llvm("jl_f_arrayref", &jl_f_arrayref, m);
+    builtin_func_map[jl_f_const_arrayref] = jlcall_func_to_llvm("jl_f_const_arrayref", &jl_f_arrayref, m);
     builtin_func_map[jl_f_arrayset] = jlcall_func_to_llvm("jl_f_arrayset", &jl_f_arrayset, m);
     builtin_func_map[jl_f_arraysize] = jlcall_func_to_llvm("jl_f_arraysize", &jl_f_arraysize, m);
     builtin_func_map[jl_f_apply_type] = jlcall_func_to_llvm("jl_f_apply_type", &jl_f_apply_type, m);

--- a/src/dump.c
+++ b/src/dump.c
@@ -76,7 +76,7 @@ static const jl_fptr_t id_to_fptrs[] = {
   jl_f_typeassert, jl_f__apply, jl_f__apply_pure, jl_f_isdefined,
   jl_f_tuple, jl_f_svec, jl_f_intrinsic_call,
   jl_f_getfield, jl_f_setfield, jl_f_fieldtype, jl_f_nfields,
-  jl_f_arrayref, jl_f_arrayset, jl_f_arraysize, jl_f_apply_type,
+  jl_f_arrayref, jl_f_const_arrayref, jl_f_arrayset, jl_f_arraysize, jl_f_apply_type,
   jl_f_applicable, jl_f_invoke, jl_unprotect_stack, jl_f_sizeof, jl_f__expr,
   NULL };
 

--- a/src/init.c
+++ b/src/init.c
@@ -858,6 +858,7 @@ void jl_get_builtins(void)
     jl_builtin_tuple = core("tuple");           jl_builtin_svec = core("svec");
     jl_builtin_getfield = core("getfield");     jl_builtin_setfield = core("setfield!");
     jl_builtin_fieldtype = core("fieldtype");   jl_builtin_arrayref = core("arrayref");
+    jl_builtin_const_arrayref = core("const_arrayref");
     jl_builtin_arrayset = core("arrayset");     jl_builtin_arraysize = core("arraysize");
     jl_builtin_apply_type = core("apply_type"); jl_builtin_applicable = core("applicable");
     jl_builtin_invoke = core("invoke");         jl_builtin__expr = core("_expr");

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -656,7 +656,7 @@ static jl_cgval_t emit_pointerref(jl_cgval_t *argv, jl_codectx_t *ctx)
     Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
     assert(!isboxed);
     Value *thePtr = emit_unbox(ptrty, e, e.typ);
-    return typed_load(thePtr, im1, ety, ctx, tbaa_data, align_nb);
+    return typed_load(thePtr, im1, ety, ctx, tbaa_data, nullptr, align_nb);
 }
 
 static jl_cgval_t emit_runtime_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
@@ -713,7 +713,7 @@ static jl_cgval_t emit_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
         Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
         assert(!isboxed);
         thePtr = emit_unbox(ptrty, e, e.typ);
-        typed_store(thePtr, im1, x, ety, ctx, tbaa_data, NULL, align_nb);
+        typed_store(thePtr, im1, x, ety, ctx, tbaa_data, nullptr, NULL, align_nb);
     }
     return mark_julia_type(thePtr, false, aty, ctx);
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -11,6 +11,7 @@
 #if JL_LLVM_VERSION >= 30800
 #include <llvm/Analysis/BasicAliasAnalysis.h>
 #include <llvm/Analysis/TypeBasedAliasAnalysis.h>
+#include <llvm/Analysis/ScopedNoAliasAA.h>
 #endif
 #if JL_LLVM_VERSION >= 30700
 #include <llvm/Analysis/TargetTransformInfo.h>
@@ -134,6 +135,7 @@ void addOptimizationPasses(PassManager *PM)
 #else
     jl_TargetMachine->addAnalysisPasses(*PM);
 #endif
+    PM->add(createScopedNoAliasAAWrapperPass());
 #if JL_LLVM_VERSION >= 30800
     PM->add(createTypeBasedAAWrapperPass());
 #else

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2859,6 +2859,7 @@ f(x) = yt(x)
                                (memq (car e) '(quote top core line inert local local-def unnecessary
                                                meta inbounds boundscheck simdloop
                                                implicit-global global globalref outerref
+                                               aliasscope popaliasscope
                                                const = null method call))))
                          (lam:body lam))))
                (unused (map cadr (filter (lambda (x) (memq (car x) '(method =)))
@@ -3503,7 +3504,7 @@ f(x) = yt(x)
              '(null))
 
             ;; other top level expressions and metadata
-            ((import importall using export line meta inbounds boundscheck simdloop)
+            ((import importall using export line meta inbounds boundscheck simdloop aliasscope popaliasscope)
              (let ((have-ret? (and (pair? code) (pair? (car code)) (eq? (caar code) 'return))))
                (cond ((eq? (car e) 'line)
                       (if first-line

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -851,6 +851,7 @@ extern jl_sym_t *meta_sym; extern jl_sym_t *list_sym;
 extern jl_sym_t *inert_sym; extern jl_sym_t *static_parameter_sym;
 extern jl_sym_t *polly_sym; extern jl_sym_t *inline_sym;
 extern jl_sym_t *propagate_inbounds_sym;
+extern jl_sym_t *aliasscope_sym; extern jl_sym_t *popaliasscope_sym;
 
 #ifdef __cplusplus
 }

--- a/src/method.c
+++ b/src/method.c
@@ -28,7 +28,8 @@ jl_value_t *jl_resolve_globals(jl_value_t *expr, jl_module_t *module, jl_svec_t 
         if (jl_is_toplevel_only_expr(expr) || e->head == const_sym || e->head == copyast_sym ||
             e->head == global_sym || e->head == quote_sym || e->head == inert_sym ||
             e->head == line_sym || e->head == meta_sym || e->head == inbounds_sym ||
-            e->head == boundscheck_sym || e->head == simdloop_sym) {
+            e->head == boundscheck_sym || e->head == simdloop_sym || e->head == aliasscope_sym ||
+            e->head == popaliasscope_sym) {
             // ignore these
         }
         else {


### PR DESCRIPTION
Usage example:
```
immutable Const{T<:Array}
    a::T
end

Base.getindex(A::Const, i1::Int) = Core.const_arrayref(A.a, i1)
@inline Base.getindex(A::Const, i1::Int, i2::Int, I::Int...) =  Core.const_arrayref(A.a, i1, i2, I...)

macro aliasscope(body)
    sym = gensym()
    esc(quote
        $(Expr(:aliasscope))
        $sym = $body
        $(Expr(:popaliasscope))
        $sym
    end)
end


function foo(a,b)
    @inbounds @aliasscope for i = 1:4, j=1:3
        a[i] += Const(b)[i,j]
    end
end

function foo2(a,b)
    @inbounds for i = 1:4, j=1:3
        a[i] += b[i,j]
    end
end

a = rand(4)
b = rand(3,3)
```

```
julia> @code_llvm foo(a,b)

define void @julia_foo_65980(i8**, i8**) #0 !dbg !5 {
top:
  %2 = bitcast i8** %1 to double**
  %3 = load double*, double** %2, align 8
  %4 = getelementptr i8*, i8** %1, i64 3
  %5 = bitcast i8** %4 to i64*
  %6 = load i64, i64* %5, align 8
  %7 = bitcast i8** %0 to double**
  %8 = load double*, double** %7, align 8
  %9 = getelementptr double, double* %3, i64 %6
  %10 = shl i64 %6, 1
  %11 = getelementptr double, double* %3, i64 %10
  %12 = bitcast double* %8 to <4 x double>*
  %13 = load <4 x double>, <4 x double>* %12, align 8
  %14 = bitcast double* %3 to <4 x double>*
  %15 = load <4 x double>, <4 x double>* %14, align 8
  %16 = fadd <4 x double> %13, %15
  %17 = bitcast double* %9 to <4 x double>*
  %18 = load <4 x double>, <4 x double>* %17, align 8
  %19 = fadd <4 x double> %16, %18
  %20 = bitcast double* %11 to <4 x double>*
  %21 = load <4 x double>, <4 x double>* %20, align 8
  %22 = fadd <4 x double> %19, %21
  %23 = bitcast double* %8 to <4 x double>*
  store <4 x double> %22, <4 x double>* %23, align 8
  ret void
}

julia> @code_llvm foo2(a,b)

define void @julia_foo2_65983(i8**, i8**) #0 !dbg !5 {
top:
  %2 = bitcast i8** %1 to double**
  %3 = load double*, double** %2, align 8
  %4 = getelementptr i8*, i8** %1, i64 3
  %5 = bitcast i8** %4 to i64*
  %6 = load i64, i64* %5, align 8
  %7 = bitcast i8** %0 to double**
  %8 = load double*, double** %7, align 8
  %9 = load double, double* %8, align 8
  %10 = load double, double* %3, align 8
  %11 = fadd double %9, %10
  store double %11, double* %8, align 8
  %12 = getelementptr double, double* %3, i64 %6
  %13 = load double, double* %12, align 8
  %14 = fadd double %11, %13
  store double %14, double* %8, align 8
  %15 = shl i64 %6, 1
  %16 = getelementptr double, double* %3, i64 %15
  %17 = load double, double* %16, align 8
  %18 = fadd double %14, %17
  store double %18, double* %8, align 8
  %19 = getelementptr double, double* %8, i64 1
  %20 = load double, double* %19, align 8
  %21 = getelementptr double, double* %3, i64 1
  %22 = load double, double* %21, align 8
  %23 = fadd double %20, %22
  store double %23, double* %19, align 8
  %24 = add i64 %6, 1
  %25 = getelementptr double, double* %3, i64 %24
  %26 = load double, double* %25, align 8
  %27 = fadd double %23, %26
  store double %27, double* %19, align 8
  %28 = or i64 %15, 1
  %29 = getelementptr double, double* %3, i64 %28
  %30 = load double, double* %29, align 8
  %31 = fadd double %27, %30
  store double %31, double* %19, align 8
  %32 = getelementptr double, double* %8, i64 2
  %33 = load double, double* %32, align 8
  %34 = getelementptr double, double* %3, i64 2
  %35 = load double, double* %34, align 8
  %36 = fadd double %33, %35
  store double %36, double* %32, align 8
  %37 = add i64 %6, 2
  %38 = getelementptr double, double* %3, i64 %37
  %39 = load double, double* %38, align 8
  %40 = fadd double %36, %39
  store double %40, double* %32, align 8
  %41 = add i64 %15, 2
  %42 = getelementptr double, double* %3, i64 %41
  %43 = load double, double* %42, align 8
  %44 = fadd double %40, %43
  store double %44, double* %32, align 8
  %45 = getelementptr double, double* %8, i64 3
  %46 = load double, double* %45, align 8
  %47 = getelementptr double, double* %3, i64 3
  %48 = load double, double* %47, align 8
  %49 = fadd double %46, %48
  store double %49, double* %45, align 8
  %50 = add i64 %6, 3
  %51 = getelementptr double, double* %3, i64 %50
  %52 = load double, double* %51, align 8
  %53 = fadd double %49, %52
  store double %53, double* %45, align 8
  %54 = add i64 %15, 3
  %55 = getelementptr double, double* %3, i64 %54
  %56 = load double, double* %55, align 8
  %57 = fadd double %53, %56
  store double %57, double* %45, align 8
  ret void
}
```

This is intended to be the basis for the `@constant` macro discussed in #19658, but our allocation elision is not smart enough to get rid of const. We'll either have to do that better or add a copyprop step before (it doesn't look through assignments).