### PR TITLE
Workaround GDB JIT debugging bug with shared linked LLVM

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -287,6 +287,13 @@ extern "C" {
 
 namespace {
 
+// Use a local variable to hold the addresses to avoid generating a PLT
+// on the function call.
+// It messes up the GDB lookup logic with dynamically linked LLVM.
+// (Ref https://sourceware.org/bugzilla/show_bug.cgi?id=20633)
+// Use `volatile` to make sure the call always loads this slot.
+void (*volatile jit_debug_register_code)() = __jit_debug_register_code;
+
 using namespace llvm;
 using namespace llvm::object;
 using namespace llvm::orc;
@@ -305,7 +312,7 @@ void NotifyDebugger(jit_code_entry *JITCodeEntry)
     }
     __jit_debug_descriptor.first_entry = JITCodeEntry;
     __jit_debug_descriptor.relevant_entry = JITCodeEntry;
-    __jit_debug_register_code();
+    jit_debug_register_code();
 }
 }
 // ------------------------ END OF TEMPORARY COPY FROM LLVM -----------------


### PR DESCRIPTION
This is of course still a GDB bug but I think the issue can be closed since this is a reliable/well defined enough workaround. The gdb bug can probably also be fixed by reversing the lookup order since the global variable doesn't have any PLT. I'll try that on GDB later.

Fix #17856
@Keno 
