### PR TITLE
Raise timeout when calling rmprocs() from runtests()

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ cd(dirname(@__FILE__)) do
                     push!(results, (test, resp))
                     if (isa(resp[end], Integer) && (resp[end] > max_worker_rss)) || isa(resp, Exception)
                         if n > 1
-                            rmprocs(p, waitfor=5.0)
+                            rmprocs(p, waitfor=30)
                             p = addprocs(1; exename=test_exename, exeflags=test_exeflags)[1]
                             remotecall_fetch(()->include("testdefs.jl"), p)
                         else
@@ -98,7 +98,7 @@ cd(dirname(@__FILE__)) do
         end
     end
     # Free up memory =)
-    n > 1 && rmprocs(workers(), waitfor=5.0)
+    n > 1 && rmprocs(workers(), waitfor=30)
     for t in node1_tests
         # As above, try to run each test
         # which must run on node 1. If


### PR DESCRIPTION
The short timeout causes occasional failures when building RPM nightlies.

Fixes https://github.com/JuliaLang/julia/issues/20195.


I'm not sure why `5.0` was chosen in the first place. If one minute is too long, I can use an intermediate value like `30`.