### PR TITLE
Fix return type of git_blob_is_binary()

### DIFF
--- a/base/libgit2/blob.jl
+++ b/base/libgit2/blob.jl
@@ -14,7 +14,7 @@ looking for a reasonable ratio of printable to non-printable characters among
 the first 8000 bytes.
 """
 function isbinary(blob::GitBlob)
-    bin_flag = ccall((:git_blob_is_binary, :libgit2), Int64, (Ptr{Void},), blob.ptr)
+    bin_flag = ccall((:git_blob_is_binary, :libgit2), Cint, (Ptr{Void},), blob.ptr)
     return bin_flag == 1
 end
 


### PR DESCRIPTION
This triggered a failure in the libgit2 blobs test on i686 when building
RPM nightlies. I don't understand why this error does not happen on CI.

This code was introduced in 78133def0e493ae3c40c38d53a9b7634254d78fd.

Cc: @kshyatt