### PR TITLE
remove duplicate and unecessary information printing in runtests.jl

### DIFF
--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -1476,6 +1476,6 @@ try
     error("unexpected")
 catch ex
     @test isa(ex.captured.ex.exceptions[1].ex, ErrorException)
-    @test endswith(ex.captured.ex.exceptions[1].ex.msg, "BoundsError")
+    @test contains(ex.captured.ex.exceptions[1].ex.msg, "BoundsError")
     @test ex.captured.ex.exceptions[2].ex == UndefVarError(:DontExistOn1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,7 +156,6 @@ cd(dirname(@__FILE__)) do
             Base.Test.pop_testset()
         elseif isa(res[2][1], RemoteException) && isa(res[2][1].captured.ex, Base.Test.TestSetException)
             println("Worker $(res[2][1].pid) failed running test $(res[1]):")
-            Base.showerror(STDOUT,res[2][1].captured)
             fake = Base.Test.DefaultTestSet(res[1])
             for i in 1:res[2][1].captured.ex.pass
                 Base.Test.record(fake, Base.Test.Pass(:test, nothing, nothing, nothing))
@@ -190,7 +189,6 @@ cd(dirname(@__FILE__)) do
         println("    \033[32;1mSUCCESS\033[0m")
     else
         println("    \033[31;1mFAILURE\033[0m")
-        Base.Test.print_test_errors(o_ts)
         isinteractive() ? error() : exit(-1)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,6 +191,6 @@ cd(dirname(@__FILE__)) do
     else
         println("    \033[31;1mFAILURE\033[0m")
         Base.Test.print_test_errors(o_ts)
-        error()
+        isinteractive() ? error() : exit(-1)
     end
 end


### PR DESCRIPTION
I found this patch coupled with the second commit from #20276 resulting in a much saner output from runtests.jl

Largely addresses https://github.com/JuliaLang/julia/issues/18647