### PR TITLE
Fix misc broken doctests

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -707,7 +707,7 @@ Example for a sparse 2-d array:
 
 ```jldoctest
 julia> A = sparse([1, 1, 2], [1, 3, 1], [1, 2, -5])
-2×3 sparse matrix with 3 Int64 nonzero entries:
+2×3 sparse matrix with 3 Int64 stored entries:
   [1, 1]  =  1
   [2, 1]  =  -5
   [1, 3]  =  2

--- a/base/array.jl
+++ b/base/array.jl
@@ -792,7 +792,7 @@ julia> deleteat!([6, 5, 4, 3, 2, 1], 1:2:5)
 julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
 ERROR: ArgumentError: indices must be unique and sorted
 Stacktrace:
- [1] deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:748
+ [1] deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:808
 ```
 """
 function deleteat!(a::Vector, inds)

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -27,7 +27,7 @@ julia> !false
 true
 
 julia> ![true false true]
-1×3 Array{Bool,2}:
+1×3 BitArray{2}:
  false  true  false
 ```
 """
@@ -51,8 +51,8 @@ Bitwise exclusive or of `x` and `y`.  The infix operation
 or `\\veebar` in the Julia REPL.
 
 ```jldoctest
-julia> [true; true; false] ⊻ [true; false; false]
-3-element Array{Bool,1}:
+julia> [true; true; false] .⊻ [true; false; false]
+3-element BitArray{1}:
  false
   true
  false

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -188,8 +188,8 @@ julia> take!(c)
 julia> put!(c,1);
 ERROR: foo
 Stacktrace:
- [1] check_channel_state(::Channel{Any}) at ./channels.jl:129
- [2] put!(::Channel{Any}, ::Int64) at ./channels.jl:247
+ [1] check_channel_state(::Channel{Any}) at ./channels.jl:125
+ [2] put!(::Channel{Any}, ::Int64) at ./channels.jl:256
 ```
 """
 function bind(c::Channel, task::Task)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -517,10 +517,10 @@ Dict{Char,Int64} with 2 entries:
   'a' => 2
 
 julia> getkey(a,'a',1)
-'a'
+'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
 
 julia> getkey(a,'d','a')
-'a'
+'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
 ```
 """
 function getkey{K,V}(h::Dict{K,V}, key, default)

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -225,8 +225,8 @@ julia> A = [0 im; -1 0]
 julia> eigmax(A)
 ERROR: DomainError:
 Stacktrace:
- [1] #eigmax#36(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:234
- [2] eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:232
+ [1] #eigmax#38(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:235
+ [2] eigmax(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:233
 ```
 """
 function eigmax(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=true)
@@ -267,8 +267,8 @@ julia> A = [0 im; -1 0]
 julia> eigmin(A)
 ERROR: DomainError:
 Stacktrace:
- [1] #eigmin#37(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:275
- [2] eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:273
+ [1] #eigmin#39(::Bool, ::Bool, ::Function, ::Array{Complex{Int64},2}) at ./linalg/eigen.jl:277
+ [2] eigmin(::Array{Complex{Int64},2}) at ./linalg/eigen.jl:275
 ```
 """
 function eigmin(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=true)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -36,12 +36,8 @@ julia> Slower = Symmetric(A, :L)
  6  0  7  0  3
  0  9  0  1  0
  2  0  3  0  4
-
-julia> eigfact(Supper)
-Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([-2.96684,-2.72015,0.440875,7.72015,14.526],[-0.302016 -2.22045e-16 … 1.11022e-16 0.248524; -6.67755e-16 0.596931 … -0.802293 1.93069e-17; … ; 8.88178e-16 -0.802293 … -0.596931 0.0; 0.772108 8.93933e-16 … 0.0 0.630015])
 ```
 
-[`eigfact`](@ref) will use a method specialized for matrices known to be symmetric.
 Note that `Supper` will not be equal to `Slower` unless `A` is itself symmetric (e.g. if `A == A.'`).
 """
 Symmetric(A::AbstractMatrix, uplo::Symbol=:U) = (checksquare(A);Symmetric{eltype(A),typeof(A)}(A, char_uplo(uplo)))
@@ -74,12 +70,8 @@ julia> Hlower = Hermitian(A, :L)
  6-6im  0+0im  7+0im  0+0im  3+3im
  0+0im  9+0im  0+0im  1+0im  0+0im
  2+2im  0+0im  3-3im  0+0im  4+0im
-
-julia> eigfact(Hupper)
-Base.LinAlg.Eigen{Complex{Float64},Float64,Array{Complex{Float64},2},Array{Float64,1}}([-8.32069,-2.72015,3.1496,7.72015,17.1711],Complex{Float64}[-0.231509+0.392692im -2.77556e-17+1.11022e-16im … -4.16334e-17-4.16334e-17im -0.129023-0.00628656im; 0.0+0.0im -0.523844+0.286205im … -0.521629+0.609571im 0.0+0.0im; … ; 0.0-6.93889e-18im 0.704063-0.384669im … -0.388108+0.45354im 0.0-1.38778e-17im; 0.67898+0.0im 0.0+0.0im … 0.0+0.0im -0.661651-0.0im])
 ```
 
-[`eigfact`](@ref) will use a method specialized for matrices known to be Hermitian.
 Note that `Hupper` will not be equal to `Hlower` unless `A` is itself Hermitian (e.g. if `A == A'`).
 """
 function Hermitian(A::AbstractMatrix, uplo::Symbol=:U)

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -113,7 +113,7 @@ Nullable{String}()
 julia> unsafe_get(x)
 ERROR: UndefRefError: access to undefined reference
 Stacktrace:
- [1] unsafe_get(::Nullable{String}) at ./nullable.jl:124
+ [1] unsafe_get(::Nullable{String}) at ./nullable.jl:125
 
 julia> x = 1
 1

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2933,7 +2933,7 @@ Concatenate matrices block-diagonally. Currently only implemented for sparse mat
 # Example
 ```jldoctest
 julia> blkdiag(speye(3), 2*speye(2))
-5×5 sparse matrix with 5 Float64 nonzero entries:
+5×5 sparse matrix with 5 Float64 stored entries:
   [1, 1]  =  1.0
   [2, 2]  =  1.0
   [3, 3]  =  1.0


### PR DESCRIPTION
I turned off printing for the `eigfact` stuff in `linalg/symmetric` because it was super verbose and not super instructive.