### PR TITLE
support `where` syntax in constructors

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -69,7 +69,7 @@ immutable StepRange{T,S} <: OrdinalRange{T,S}
     step::S
     stop::T
 
-    function StepRange(start::T, step::S, stop::T)
+    function StepRange{T,S}(start::T, step::S, stop::T) where (T,S)
         new(start, step, steprange_last(start,step,stop))
     end
 end
@@ -122,14 +122,14 @@ steprange_last_empty(start, step, stop) = start - step
 
 steprem(start,stop,step) = (stop-start) % step
 
-StepRange{T,S}(start::T, step::S, stop::T) = StepRange{T,S}(start, step, stop)
+StepRange(start::T, step::S, stop::T) where (T,S) = StepRange{T,S}(start, step, stop)
 
 immutable UnitRange{T<:Real} <: AbstractUnitRange{T}
     start::T
     stop::T
-    UnitRange(start, stop) = new(start, unitrange_last(start,stop))
+    UnitRange{T}(start, stop) where T<:Real = new(start, unitrange_last(start,stop))
 end
-UnitRange{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
+UnitRange(start::T, stop::T) where T<:Real = UnitRange{T}(start, stop)
 
 unitrange_last(::Bool, stop::Bool) = stop
 unitrange_last{T<:Integer}(start::T, stop::T) =
@@ -147,9 +147,9 @@ be 1.
 """
 immutable OneTo{T<:Integer} <: AbstractUnitRange{T}
     stop::T
-    OneTo(stop) = new(max(zero(T), stop))
+    OneTo{T}(stop) where T<:Integer = new(max(zero(T), stop))
 end
-OneTo{T<:Integer}(stop::T) = OneTo{T}(stop)
+OneTo(stop::T) where T<:Integer = OneTo{T}(stop)
 
 ## Step ranges parametrized by length
 
@@ -169,14 +169,14 @@ immutable StepRangeLen{T,R,S} <: Range{T}
     len::Int     # length of the range
     offset::Int  # the index of ref
 
-    function StepRangeLen(ref::R, step::S, len::Integer, offset::Integer = 1)
+    function StepRangeLen{T,R,S}(ref::R, step::S, len::Integer, offset::Integer = 1) where (T,R,S)
         len >= 0 || throw(ArgumentError("length cannot be negative, got $len"))
         1 <= offset <= max(1,len) || throw(ArgumentError("StepRangeLen: offset must be in [1,$len], got $offset"))
         new(ref, step, len, offset)
     end
 end
 
-StepRangeLen{R,S}(ref::R, step::S, len::Integer, offset::Integer = 1) =
+StepRangeLen(ref::R, step::S, len::Integer, offset::Integer = 1) where (R,S) =
     StepRangeLen{typeof(ref+0*step),R,S}(ref, step, len, offset)
 
 ## linspace and logspace
@@ -187,7 +187,7 @@ immutable LinSpace{T} <: Range{T}
     len::Int
     lendiv::Int
 
-    function LinSpace(start,stop,len)
+    function LinSpace{T}(start,stop,len) where T
         len >= 0 || throw(ArgumentError("linspace($start, $stop, $len): negative length"))
         if len == 1
             start == stop || throw(ArgumentError("linspace($start, $stop, $len): endpoints differ"))

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -4,13 +4,13 @@ immutable Rational{T<:Integer} <: Real
     num::T
     den::T
 
-    function Rational(num::Integer, den::Integer)
+    function Rational{T}(num::Integer, den::Integer) where T<:Integer
         num == den == zero(T) && throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
         g = den < 0 ? -gcd(den, num) : gcd(den, num)
         new(div(num, g), div(den, g))
     end
 end
-Rational{T<:Integer}(n::T, d::T) = Rational{T}(n,d)
+Rational(n::T, d::T) where T<:Integer = Rational{T}(n,d)
 Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 Rational(n::Integer) = Rational(n,one(n))
 

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -9,7 +9,7 @@ immutable SubString{T<:AbstractString} <: AbstractString
     offset::Int
     endof::Int
 
-    function SubString(s::T, i::Int, j::Int)
+    function SubString{T}(s::T, i::Int, j::Int) where T<:AbstractString
         if i > endof(s) || j<i
             return new(s, i-1, 0)
         else
@@ -26,7 +26,7 @@ immutable SubString{T<:AbstractString} <: AbstractString
         end
     end
 end
-SubString{T<:AbstractString}(s::T, i::Int, j::Int) = SubString{T}(s, i, j)
+SubString(s::T, i::Int, j::Int) where T<:AbstractString = SubString{T}(s, i, j)
 SubString(s::SubString, i::Int, j::Int) = SubString(s.string, s.offset+i, s.offset+j)
 SubString(s::AbstractString, i::Integer, j::Integer) = SubString(s, Int(i), Int(j))
 SubString(s::AbstractString, i::Integer) = SubString(s, i, endof(s))


### PR DESCRIPTION
This is the first part of #11310. After this, all we need to do is flip the switch to give a deprecation warning, and rewrite all uses in Base. This commit has examples.