### PR TITLE
Doctests for manual/constructors

### DIFF
--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -5,11 +5,11 @@ In Julia, type objects also serve as constructor functions: they create new inst
 when applied to an argument tuple as a function. This much was already mentioned briefly when
 composite types were introduced. For example:
 
-```julia
-type Foo
-  bar
-  baz
-end
+```jldoctest footype
+julia> type Foo
+           bar
+           baz
+       end
 
 julia> foo = Foo(1,2)
 Foo(1,2)
@@ -46,8 +46,9 @@ by simply defining new methods. For example, let's say you want to add a constru
 `Foo` objects that takes only one argument and uses the given value for both the `bar` and `baz`
 fields. This is simple:
 
-```julia
-Foo(x) = Foo(x,x)
+```jldoctest footype
+julia> Foo(x) = Foo(x,x)
+Foo
 
 julia> Foo(1)
 Foo(1,1)
@@ -56,8 +57,9 @@ Foo(1,1)
 You could also add a zero-argument `Foo` constructor method that supplies default values for both
 of the `bar` and `baz` fields:
 
-```julia
-Foo() = Foo(0)
+```jldoctest footype
+julia> Foo() = Foo(0)
+Foo
 
 julia> Foo()
 Foo(0,0)
@@ -85,25 +87,25 @@ For example, suppose one wants to declare a type that holds a pair of real numbe
 the constraint that the first number is not greater than the second one. One could declare it
 like this:
 
-```julia
-type OrderedPair
-  x::Real
-  y::Real
+```jldoctest pairtype
+julia> type OrderedPair
+           x::Real
+           y::Real
+           OrderedPair(x,y) = x > y ? error("out of order") : new(x,y)
+       end
 
-  OrderedPair(x,y) = x > y ? error("out of order") : new(x,y)
-end
 ```
 
 Now `OrderedPair` objects can only be constructed such that `x <= y`:
 
-```julia
+```jldoctest pairtype
 julia> OrderedPair(1,2)
 OrderedPair(1,2)
 
 julia> OrderedPair(2,1)
 ERROR: out of order
- in OrderedPair(::Int64, ::Int64) at ./none:5
- ...
+Stacktrace:
+ [1] OrderedPair(::Int64, ::Int64) at ./none:4
 ```
 
 You can still reach in and directly change the field values to violate this invariant, but messing
@@ -124,28 +126,28 @@ is equivalent to writing your own inner constructor method that takes all of the
 as parameters (constrained to be of the correct type, if the corresponding field has a type),
 and passes them to `new`, returning the resulting object:
 
-```julia
-type Foo
-  bar
-  baz
+```jldoctest
+julia> type Foo
+           bar
+           baz
+           Foo(bar,baz) = new(bar,baz)
+       end
 
-  Foo(bar,baz) = new(bar,baz)
-end
 ```
 
 This declaration has the same effect as the earlier definition of the `Foo` type without an explicit
 inner constructor method. The following two types are equivalent -- one with a default constructor,
 the other with an explicit constructor:
 
-```julia
-type T1
-  x::Int64
-end
+```jldoctest
+julia> type T1
+           x::Int64
+       end
 
-type T2
-  x::Int64
-  T2(x) = new(x)
-end
+julia> type T2
+           x::Int64
+           T2(x) = new(x)
+       end
 
 julia> T1(1)
 T1(1)
@@ -172,17 +174,18 @@ The final problem which has still not been addressed is construction of self-ref
 or more generally, recursive data structures. Since the fundamental difficulty may not be immediately
 obvious, let us briefly explain it. Consider the following recursive type declaration:
 
-```julia
-type SelfReferential
-  obj::SelfReferential
-end
+```jldoctest selfrefer
+julia> type SelfReferential
+           obj::SelfReferential
+       end
+
 ```
 
 This type may appear innocuous enough, until one considers how to construct an instance of it.
 If `a` is an instance of `SelfReferential`, then a second instance can be created by the call:
 
 ```julia
-b = SelfReferential(a)
+julia> b = SelfReferential(a)
 ```
 
 But how does one construct the first instance when no instance exists to provide as a valid value
@@ -197,17 +200,17 @@ object, finishing its initialization before returning it. Here, for example, we 
 at defining the `SelfReferential` type, with a zero-argument inner constructor returning instances
 having `obj` fields pointing to themselves:
 
-```julia
-type SelfReferential
-  obj::SelfReferential
+```jldoctest selfrefer2
+julia> type SelfReferential
+           obj::SelfReferential
+           SelfReferential() = (x = new(); x.obj = x)
+       end
 
-  SelfReferential() = (x = new(); x.obj = x)
-end
 ```
 
 We can verify that this constructor works and constructs objects that are, in fact, self-referential:
 
-```julia
+```jldoctest selfrefer2
 julia> x = SelfReferential();
 
 julia> x === x
@@ -223,10 +226,10 @@ true
 Although it is generally a good idea to return a fully initialized object from an inner constructor,
 incompletely initialized objects can be returned:
 
-```julia
+```jldoctest incomplete
 julia> type Incomplete
-         xx
-         Incomplete() = new()
+           xx
+           Incomplete() = new()
        end
 
 julia> z = Incomplete();
@@ -235,10 +238,9 @@ julia> z = Incomplete();
 While you are allowed to create objects with uninitialized fields, any access to an uninitialized
 reference is an immediate error:
 
-```julia
+```jldoctest incomplete
 julia> z.xx
 ERROR: UndefRefError: access to undefined reference
- ...
 ```
 
 This avoids the need to continually check for `null` values. However, not all object fields are
@@ -249,8 +251,8 @@ undefined:
 
 ```julia
 julia> type HasPlain
-         n::Int
-         HasPlain() = new()
+           n::Int
+           HasPlain() = new()
        end
 
 julia> HasPlain()
@@ -261,12 +263,11 @@ Arrays of plain data types exhibit the same behavior.
 
 You can pass incomplete objects to other functions from inner constructors to delegate their completion:
 
-```julia
-type Lazy
-  xx
-
-  Lazy(v) = complete_me(new(), v)
-end
+```jldoctest
+julia> type Lazy
+           xx
+           Lazy(v) = complete_me(new(), v)
+       end
 ```
 
 As with incomplete objects returned from constructors, if `complete_me` or any of its callees
@@ -280,48 +281,43 @@ that, by default, instances of parametric composite types can be constructed eit
 given type parameters or with type parameters implied by the types of the arguments given to the
 constructor. Here are some examples:
 
-```julia
+```jldoctest parametric
 julia> type Point{T<:Real}
-         x::T
-         y::T
+           x::T
+           y::T
        end
 
-## implicit T ##
-
-julia> Point(1,2)
+julia> Point(1,2) ## implicit T ##
 Point{Int64}(1,2)
 
-julia> Point(1.0,2.5)
+julia> Point(1.0,2.5) ## implicit T ##
 Point{Float64}(1.0,2.5)
 
-julia> Point(1,2.5)
-ERROR: MethodError: no method matching Point{T<:Real}(::Int64, ::Float64)
+julia> Point(1,2.5) ## implicit T ##
+ERROR: MethodError: no method matching Point(::Int64, ::Float64)
 Closest candidates are:
-  Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real) at none:2
-  Point{T<:Real}{T}(::Any) at sysimg.jl:66
- ...
+  Point{T}(::Any) at sysimg.jl:24
+  Point{T<:Real}(::T<:Real, ::T<:Real) at none:2
 
-## explicit T ##
-
-julia> Point{Int64}(1,2)
+julia> Point{Int64}(1,2) ## explicit T ##
 Point{Int64}(1,2)
 
-julia> Point{Int64}(1.0,2.5)
+julia> Point{Int64}(1.0,2.5) ## explicit T ##
 ERROR: InexactError()
- in convert(::Type{Int64}, ::Float64) at ./float.jl:656
- in Point{Int64}(::Float64, ::Float64) at ./none:2
- ...
+Stacktrace:
+ [1] convert(::Type{Int64}, ::Float64) at ./float.jl:675
+ [2] Point{Int64}(::Float64, ::Float64) at ./none:2
 
-julia> Point{Float64}(1.0,2.5)
+julia> Point{Float64}(1.0,2.5) ## explicit T ##
 Point{Float64}(1.0,2.5)
 
-julia> Point{Float64}(1,2)
+julia> Point{Float64}(1,2) ## explicit T ##
 Point{Float64}(1.0,2.0)
 ```
 
 As you can see, for constructor calls with explicit type parameters, the arguments are converted
 to the implied field types: `Point{Int64}(1,2)` works, but `Point{Int64}(1.0,2.5)` raises an
-`InexactError` when converting `2.5` to `Int64`. When the type is implied by the arguments to
+[`InexactError`](@ref) when converting `2.5` to `Int64`. When the type is implied by the arguments to
 the constructor call, as in `Point(1,2)`, then the types of the arguments must agree -- otherwise
 the `T` cannot be determined -- but any pair of real arguments with matching type may be given
 to the generic `Point` constructor.
@@ -334,15 +330,14 @@ behaves just like non-parametric default inner constructors do. It also provides
 outer `Point` constructor that takes pairs of real arguments, which must be of the same type.
 This automatic provision of constructors is equivalent to the following explicit declaration:
 
-```julia
-type Point{T<:Real}
-  x::T
-  y::T
+```jldoctest parametric2
+julia> type Point{T<:Real}
+           x::T
+           y::T
+           Point(x,y) = new(x,y)
+       end
 
-  Point(x,y) = new(x,y)
-end
-
-Point{T<:Real}(x::T, y::T) = Point{T}(x,y)
+julia> Point{T<:Real}(x::T, y::T) = Point{T}(x,y);
 ```
 
 Some features of parametric constructor definitions at work here deserve comment. First, inner
@@ -362,7 +357,7 @@ Suppose we wanted to make the constructor call `Point(1,2.5)` work by "promoting
 value `1` to the floating-point value `1.0`. The simplest way to achieve this is to define the
 following additional outer constructor method:
 
-```julia
+```jldoctest parametric2
 julia> Point(x::Int64, y::Float64) = Point(convert(Float64,x),y);
 ```
 
@@ -371,7 +366,7 @@ and then delegates construction to the general constructor for the case where bo
 [`Float64`](@ref). With this method definition what was previously a [`MethodError`](@ref) now
 successfully creates a point of type `Point{Float64}`:
 
-```julia
+```jldoctest parametric2
 julia> Point(1,2.5)
 Point{Float64}(1.0,2.5)
 
@@ -381,20 +376,19 @@ Point{Float64}
 
 However, other similar calls still don't work:
 
-```julia
+```jldoctest parametric2
 julia> Point(1.5,2)
-ERROR: MethodError: no method matching Point{T<:Real}(::Float64, ::Int64)
+ERROR: MethodError: no method matching Point(::Float64, ::Int64)
 Closest candidates are:
-  Point{T<:Real}{T<:Real}(::T<:Real, !Matched::T<:Real) at none:2
-  Point{T<:Real}{T}(::Any) at sysimg.jl:66
- ...
+  Point{T}(::Any) at sysimg.jl:24
+  Point{T<:Real}(::T<:Real, ::T<:Real) at none:1
 ```
 
 For a much more general way of making all such calls work sensibly, see [Conversion and Promotion](@ref conversion-and-promotion).
 At the risk of spoiling the suspense, we can reveal here that all it takes is the following outer
 method definition to make all calls to the general `Point` constructor work as one would expect:
 
-```julia
+```jldoctest parametric2
 julia> Point(x::Real, y::Real) = Point(promote(x,y)...);
 ```
 
@@ -402,7 +396,7 @@ The `promote` function converts all its arguments to a common type -- in this ca
 With this method definition, the `Point` constructor promotes its arguments the same way that
 numeric operators like [`+`](@ref) do, and works for all kinds of real numbers:
 
-```julia
+```jldoctest parametric2
 julia> Point(1.5,2)
 Point{Float64}(1.5,2.0)
 
@@ -421,56 +415,71 @@ defining sophisticated behavior is typically quite simple.
 ## Case Study: Rational
 
 Perhaps the best way to tie all these pieces together is to present a real world example of a
-parametric composite type and its constructor methods. To that end, here is beginning of [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
+parametric composite type and its constructor methods. To that end, here is the (slightly modified) beginning of [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
 which implements Julia's [Rational Numbers](@ref):
 
-```julia
-immutable Rational{T<:Integer} <: Real
-    num::T
-    den::T
+```jldoctest rational
+julia> immutable OurRational{T<:Integer} <: Real
+           num::T
+           den::T
+           function OurRational(num::T, den::T)
+               if num == 0 && den == 0
+                    error("invalid rational: 0//0")
+               end
+               g = gcd(den, num)
+               num = div(num, g)
+               den = div(den, g)
+               new(num, den)
+           end
+       end
 
-    function Rational(num::T, den::T)
-        if num == 0 && den == 0
-            error("invalid rational: 0//0")
-        end
-        g = gcd(den, num)
-        num = div(num, g)
-        den = div(den, g)
-        new(num, den)
-    end
-end
-Rational{T<:Integer}(n::T, d::T) = Rational{T}(n,d)
-Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
-Rational(n::Integer) = Rational(n,one(n))
+julia> OurRational{T<:Integer}(n::T, d::T) = OurRational{T}(n,d)
+OurRational
 
-//(n::Integer, d::Integer) = Rational(n,d)
-//(x::Rational, y::Integer) = x.num // (x.den*y)
-//(x::Integer, y::Rational) = (x*y.den) // y.num
-//(x::Complex, y::Real) = complex(real(x)//y, imag(x)//y)
-//(x::Real, y::Complex) = x*y'//real(y*y')
+julia> OurRational(n::Integer, d::Integer) = OurRational(promote(n,d)...)
+OurRational
 
-function //(x::Complex, y::Complex)
-    xy = x*y'
-    yy = real(y*y')
-    complex(real(xy)//yy, imag(xy)//yy)
-end
+julia> OurRational(n::Integer) = OurRational(n,one(n))
+OurRational
+
+julia> //(n::Integer, d::Integer) = OurRational(n,d)
+// (generic function with 1 method)
+
+julia> //(x::OurRational, y::Integer) = x.num // (x.den*y)
+// (generic function with 2 methods)
+
+julia> //(x::Integer, y::OurRational) = (x*y.den) // y.num
+// (generic function with 3 methods)
+
+julia> //(x::Complex, y::Real) = complex(real(x)//y, imag(x)//y)
+// (generic function with 4 methods)
+
+julia> //(x::Real, y::Complex) = x*y'//real(y*y')
+// (generic function with 5 methods)
+
+julia> function //(x::Complex, y::Complex)
+           xy = x*y'
+           yy = real(y*y')
+           complex(real(xy)//yy, imag(xy)//yy)
+       end
+// (generic function with 6 methods)
 ```
 
-The first line -- `immutable Rational{T<:Integer} <: Real` -- declares that `Rational` takes one
+The first line -- `immutable OurRational{T<:Integer} <: Real` -- declares that `OurRational` takes one
 type parameter of an integer type, and is itself a real type. The field declarations `num::T`
-and `den::T` indicate that the data held in a `Rational{T}` object are a pair of integers of type
+and `den::T` indicate that the data held in a `OurRational{T}` object are a pair of integers of type
 `T`, one representing the rational value's numerator and the other representing its denominator.
 
-Now things get interesting. `Rational` has a single inner constructor method which checks that
+Now things get interesting. `OurRational` has a single inner constructor method which checks that
 both of `num` and `den` aren't zero and ensures that every rational is constructed in "lowest
 terms" with a non-negative denominator. This is accomplished by dividing the given numerator and
 denominator values by their greatest common divisor, computed using the `gcd` function. Since
 `gcd` returns the greatest common divisor of its arguments with sign matching the first argument
 (`den` here), after this division the new value of `den` is guaranteed to be non-negative. Because
-this is the only inner constructor for `Rational`, we can be certain that `Rational` objects are
+this is the only inner constructor for `OurRational`, we can be certain that `OurRational` objects are
 always constructed in this normalized form.
 
-`Rational` also provides several outer constructor methods for convenience. The first is the "standard"
+`OurRational` also provides several outer constructor methods for convenience. The first is the "standard"
 general constructor that infers the type parameter `T` from the type of the numerator and denominator
 when they have the same type. The second applies when the given numerator and denominator values
 have different types: it promotes them to a common type and then delegates construction to the
@@ -481,26 +490,26 @@ Following the outer constructor definitions, we have a number of methods for the
 operator, which provides a syntax for writing rationals. Before these definitions, [`//`](@ref)
 is a completely undefined operator with only syntax and no meaning. Afterwards, it behaves just
 as described in [Rational Numbers](@ref) -- its entire behavior is defined in these few lines.
-The first and most basic definition just makes `a//b` construct a `Rational` by applying the
-`Rational` constructor to `a` and `b` when they are integers. When one of the operands of [`//`](@ref)
+The first and most basic definition just makes `a//b` construct a `OurRational` by applying the
+`OurRational` constructor to `a` and `b` when they are integers. When one of the operands of [`//`](@ref)
 is already a rational number, we construct a new rational for the resulting ratio slightly differently;
-this behavior is actually identical to division of a rational with an integer. Finally, applying
-[`//`](@ref) to complex integral values creates an instance of `Complex{Rational}` -- a complex
+this behavior is actually identical to division of a rational with an integer.
+Finally, applying
+[`//`](@ref) to complex integral values creates an instance of `Complex{OurRational}` -- a complex
 number whose real and imaginary parts are rationals:
 
-```julia
-julia> (1 + 2im)//(1 - 2im)
--3//5 + 4//5*im
+```jldoctest rational
+julia> ans = (1 + 2im)//(1 - 2im);
 
 julia> typeof(ans)
-Complex{Rational{Int64}}
+Complex{OurRational{Int64}}
 
-julia> ans <: Complex{Rational}
+julia> ans <: Complex{OurRational}
 false
 ```
 
-Thus, although the [`//`](@ref) operator usually returns an instance of `Rational`, if either
-of its arguments are complex integers, it will return an instance of `Complex{Rational}` instead.
+Thus, although the [`//`](@ref) operator usually returns an instance of `OurRational`, if either
+of its arguments are complex integers, it will return an instance of `Complex{OurRational}` instead.
 The interested reader should consider perusing the rest of [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl):
 it is short, self-contained, and implements an entire basic Julia type.
 
@@ -511,13 +520,13 @@ to their types. The type of a type is `Type`, so all constructor methods are sto
 table for the `Type` type. This means that you can declare more flexible constructors, e.g. constructors
 for abstract types, by explicitly defining methods for the appropriate types.
 
-However, in some cases you could consider adding methods to `Base.convert`*instead* of defining
+However, in some cases you could consider adding methods to `Base.convert` *instead* of defining
 a constructor, because Julia falls back to calling [`convert()`](@ref) if no matching constructor
 is found. For example, if no constructor `T(args...) = ...` exists `Base.convert(::Type{T}, args...) = ...`
 is called.
 
 `convert` is used extensively throughout Julia whenever one type needs to be converted to another
-(e.g. in assignment, `ccall`, etcetera), and should generally only be defined (or successful)
+(e.g. in assignment, [`ccall`](@ref), etcetera), and should generally only be defined (or successful)
 if the conversion is lossless.  For example, `convert(Int, 3.0)` produces `3`, but `convert(Int, 3.2)`
 throws an `InexactError`.  If you want to define a constructor for a lossless conversion from
 one type to another, you should probably define a `convert` method instead.
@@ -539,11 +548,14 @@ that specific type parameters cannot be requested manually.
 For example, say we define a type that stores a vector along with an accurate representation of
 its sum:
 
-```julia
-type SummedArray{T<:Number,S<:Number}
-    data::Vector{T}
-    sum::S
-end
+```jldoctest
+julia> type SummedArray{T<:Number,S<:Number}
+           data::Vector{T}
+           sum::S
+       end
+
+julia> SummedArray(Int32[1; 2; 3], Int8(6))
+SummedArray{Int32,Int8}(Int32[1,2,3],6)
 ```
 
 The problem is that we want `S` to be a larger type than `T`, so that we can sum many elements
@@ -552,16 +564,15 @@ Therefore we want to avoid an interface that allows the user to construct instan
 `SummedArray{Int32,Int32}`. One way to do this is to provide only an outer constructor for `SummedArray`.
 This can be done using method definition by type:
 
-```julia
-type SummedArray{T<:Number,S<:Number}
-    data::Vector{T}
-    sum::S
-
-    function (::Type{SummedArray}){T}(a::Vector{T})
-        S = widen(T)
-        new{T,S}(a, sum(S, a))
-    end
-end
+```jldoctest
+julia> type SummedArray{T<:Number,S<:Number}
+           data::Vector{T}
+           sum::S
+           function (::Type{SummedArray}){T}(a::Vector{T})
+               S = widen(T)
+               new{T,S}(a, sum(S, a))
+           end
+       end
 ```
 
 This constructor will be invoked by the syntax `SummedArray(a)`. The syntax `new{T,S}` allows


### PR DESCRIPTION
Didn't know how to handle the un-initialized type. Renamed
`Rational` -> `OurRational` to avoid horrible over-written
method warnings and similar problems.