### PR TITLE
Remove unnecessary return type annotation in _accumulate_pairwise!.

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -489,7 +489,7 @@ rcum_promote_type{T,N}(op, ::Type{Array{T,N}}) = Array{rcum_promote_type(op,T), 
 # stable in certain situations (e.g. sums).
 # it does double the number of operations compared to accumulate,
 # though for cheap operations like + this does not have much impact (20%)
-function _accumulate_pairwise!{T, Op}(op::Op, c::AbstractVector{T}, v::AbstractVector, s, i1, n)::T
+function _accumulate_pairwise!{T, Op}(op::Op, c::AbstractVector{T}, v::AbstractVector, s, i1, n)
     @inbounds if n < 128
         s_ = v[i1]
         c[i1] = op(s, s_)


### PR DESCRIPTION
The annotation makes it impossible to pass a DataArray since the return
might be an NA.