### PR TITLE
Fix package resolver score

### DIFF
--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -42,6 +42,7 @@ function resolve(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}
         # verify solution (debug code) and enforce its optimality
         @assert verify_solution(sol, interface)
         enforce_optimality!(sol, interface)
+        @assert verify_solution(sol, interface)
     end
 
     # return the solution as a Dict mapping package_name => sha1

--- a/base/pkg/resolve/fieldvalue.jl
+++ b/base/pkg/resolve/fieldvalue.jl
@@ -27,10 +27,10 @@ immutable FieldValue
     l4::Int
     l5::Int128
 end
-FieldValue(l0::Integer,l1::VersionWeight,l2::VersionWeight,l3::Integer,l4::Integer) = FieldValue(l0, l1, l2, l3, l4, Int128(0))
-FieldValue(l0::Integer,l1::VersionWeight,l2::VersionWeight,l3::Integer) = FieldValue(l0, l1, l2, l3, 0)
-FieldValue(l0::Integer,l1::VersionWeight,l2::VersionWeight) = FieldValue(l0, l1, l2, 0)
-FieldValue(l0::Integer,l1::VersionWeight) = FieldValue(l0, l1, zero(VersionWeight))
+FieldValue(l0::Integer, l1::VersionWeight, l2::VersionWeight, l3::Integer, l4::Integer) = FieldValue(l0, l1, l2, l3, l4, Int128(0))
+FieldValue(l0::Integer, l1::VersionWeight, l2::VersionWeight, l3::Integer) = FieldValue(l0, l1, l2, l3, 0)
+FieldValue(l0::Integer, l1::VersionWeight, l2::VersionWeight) = FieldValue(l0, l1, l2, 0)
+FieldValue(l0::Integer, l1::VersionWeight) = FieldValue(l0, l1, zero(VersionWeight))
 FieldValue(l0::Integer) = FieldValue(l0, zero(VersionWeight))
 FieldValue() = FieldValue(0)
 
@@ -38,7 +38,7 @@ typealias Field Vector{FieldValue}
 
 Base.zero(::Type{FieldValue}) = FieldValue()
 
-Base.typemin(::Type{FieldValue}) = (x=typemin(Int); y=typemin(VersionWeight); FieldValue(x,y,y,x,x,typemin(Int128)))
+Base.typemin(::Type{FieldValue}) = (x=typemin(Int); y=typemin(VersionWeight); FieldValue(x, y, y, x, x, typemin(Int128)))
 
 Base.:-(a::FieldValue, b::FieldValue) = FieldValue(a.l0-b.l0, a.l1-b.l1, a.l2-b.l2, a.l3-b.l3, a.l4-b.l4, a.l5-b.l5)
 Base.:+(a::FieldValue, b::FieldValue) = FieldValue(a.l0+b.l0, a.l1+b.l1, a.l2+b.l2, a.l3+b.l3, a.l4+b.l4, a.l5+b.l5)

--- a/base/pkg/resolve/fieldvalue.jl
+++ b/base/pkg/resolve/fieldvalue.jl
@@ -7,41 +7,41 @@ importall .....Base.Operators
 
 export FieldValue, Field, validmax, secondmax
 
-# FieldValue is a numeric type which helps dealing with
-# infinities. It holds 5 numbers l0,l1,l2,l3,l4. It can
-# be interpreted as a polynomial
-#  x = a^4 * l0 + a^3 * l1 + a^2 + l2 + a^1 * l3 + l4
-# where a -> Inf
+# FieldValue is a hierarchical numeric type with 6 levels.
+# When summing two FieldValues, the levels are summed independently.
+# When comparing them, lower levels take precedence.
 # The levels are used as such:
 #  l0 : for hard constraints (dependencies and requirements)
 #  l1 : for favoring higher versions of the explicitly required
 #       packages
-#  l2 : for favoring higher versions of all other packages (and
-#       favoring uninstallation of non-needed packages)
-#  l3 : for favoring dependants over dependencies
-#  l4 : for symmetry-breaking random noise
+#  l2 : for favoring higher versions of all other packages
+#  l3 : for favoring uninstallation of non-needed packages
+#  l4 : for favoring dependants over dependencies
+#  l5 : for symmetry-breaking random noise
 #
 immutable FieldValue
     l0::Int
     l1::VersionWeight
     l2::VersionWeight
     l3::Int
-    l4::Int128
+    l4::Int
+    l5::Int128
 end
-FieldValue(l0::Int,l1::VersionWeight,l2::VersionWeight,l3::Int) = FieldValue(l0, l1, l2, l3, Int128(0))
-FieldValue(l0::Int,l1::VersionWeight,l2::VersionWeight) = FieldValue(l0, l1, l2, 0)
-FieldValue(l0::Int,l1::VersionWeight) = FieldValue(l0, l1, zero(VersionWeight))
-FieldValue(l0::Int) = FieldValue(l0, zero(VersionWeight))
+FieldValue(l0::Integer,l1::VersionWeight,l2::VersionWeight,l3::Integer,l4::Integer) = FieldValue(l0, l1, l2, l3, l4, Int128(0))
+FieldValue(l0::Integer,l1::VersionWeight,l2::VersionWeight,l3::Integer) = FieldValue(l0, l1, l2, l3, 0)
+FieldValue(l0::Integer,l1::VersionWeight,l2::VersionWeight) = FieldValue(l0, l1, l2, 0)
+FieldValue(l0::Integer,l1::VersionWeight) = FieldValue(l0, l1, zero(VersionWeight))
+FieldValue(l0::Integer) = FieldValue(l0, zero(VersionWeight))
 FieldValue() = FieldValue(0)
 
 typealias Field Vector{FieldValue}
 
 Base.zero(::Type{FieldValue}) = FieldValue()
 
-Base.typemin(::Type{FieldValue}) = (x=typemin(Int); y=typemin(VersionWeight); FieldValue(x,y,y,x,typemin(Int128)))
+Base.typemin(::Type{FieldValue}) = (x=typemin(Int); y=typemin(VersionWeight); FieldValue(x,y,y,x,x,typemin(Int128)))
 
-Base.:-(a::FieldValue, b::FieldValue) = FieldValue(a.l0-b.l0, a.l1-b.l1, a.l2-b.l2, a.l3-b.l3, a.l4-b.l4)
-Base.:+(a::FieldValue, b::FieldValue) = FieldValue(a.l0+b.l0, a.l1+b.l1, a.l2+b.l2, a.l3+b.l3, a.l4+b.l4)
+Base.:-(a::FieldValue, b::FieldValue) = FieldValue(a.l0-b.l0, a.l1-b.l1, a.l2-b.l2, a.l3-b.l3, a.l4-b.l4, a.l5-b.l5)
+Base.:+(a::FieldValue, b::FieldValue) = FieldValue(a.l0+b.l0, a.l1+b.l1, a.l2+b.l2, a.l3+b.l3, a.l4+b.l4, a.l5+b.l5)
 
 function Base.isless(a::FieldValue, b::FieldValue)
     a.l0 < b.l0 && return true
@@ -55,13 +55,15 @@ function Base.isless(a::FieldValue, b::FieldValue)
     a.l3 < b.l3 && return true
     a.l3 > b.l3 && return false
     a.l4 < b.l4 && return true
+    a.l4 > b.l4 && return false
+    a.l5 < b.l5 && return true
     return false
 end
 
 Base.:(==)(a::FieldValue, b::FieldValue) =
-    a.l0 == b.l0 && a.l1 == b.l1 && a.l2 == b.l2 && a.l3 == b.l3 && a.l4 == b.l4
+    a.l0 == b.l0 && a.l1 == b.l1 && a.l2 == b.l2 && a.l3 == b.l3 && a.l4 == b.l4 && a.l5 == b.l5
 
-Base.abs(a::FieldValue) = FieldValue(abs(a.l0), abs(a.l1), abs(a.l2), abs(a.l3), abs(a.l4))
+Base.abs(a::FieldValue) = FieldValue(abs(a.l0), abs(a.l1), abs(a.l2), abs(a.l3), abs(a.l4), abs(a.l5))
 
 # if the maximum field has l0 < 0, it means that
 # some hard constraint is being violated

--- a/base/pkg/resolve/fieldvalue.jl
+++ b/base/pkg/resolve/fieldvalue.jl
@@ -58,7 +58,7 @@ function Base.isless(a::FieldValue, b::FieldValue)
     return false
 end
 
-==(a::FieldValue, b::FieldValue) =
+Base.:(==)(a::FieldValue, b::FieldValue) =
     a.l0 == b.l0 && a.l1 == b.l1 && a.l2 == b.l2 && a.l3 == b.l3 && a.l4 == b.l4
 
 Base.abs(a::FieldValue) = FieldValue(abs(a.l0), abs(a.l1), abs(a.l2), abs(a.l3), abs(a.l4))

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -90,7 +90,7 @@ type Interface
             for v0 = 1:spp0-1
                 vweight0[v0] = VersionWeight(pvers0[v0])
             end
-            vweight0[spp0] = VersionWeight(v"0", true)
+            vweight0[spp0] = VersionWeight(v"0") # last version means uninstalled
         end
 
         return new(reqs, deps, pkgs, np, spp, pdict, pvers, vdict, vweight)

--- a/base/pkg/resolve/maxsum.jl
+++ b/base/pkg/resolve/maxsum.jl
@@ -23,7 +23,7 @@ type MaxSumParams
                  # step
 
     function MaxSumParams()
-        accuracy = parse(Int,get(ENV, "JULIA_PKGRESOLVE_ACCURACY", "1"))
+        accuracy = parse(Int, get(ENV, "JULIA_PKGRESOLVE_ACCURACY", "1"))
         if accuracy <= 0
             error("JULIA_PKGRESOLVE_ACCURACY must be > 0")
         end
@@ -87,10 +87,10 @@ type Graph
         pvers = interface.pvers
         vdict = interface.vdict
 
-        gadj = [ Int[] for i = 1:np ]
-        gmsk = [ BitMatrix[] for i = 1:np ]
-        gdir = [ Int[] for i = 1:np ]
-        adjdict = [ Dict{Int,Int}() for i = 1:np ]
+        gadj = [Int[] for i = 1:np]
+        gmsk = [BitMatrix[] for i = 1:np]
+        gdir = [Int[] for i = 1:np]
+        adjdict = [Dict{Int,Int}() for i = 1:np]
 
         for (p,d) in deps
             p0 = pdict[p]
@@ -138,7 +138,7 @@ type Graph
                     end
 
                     for v1 = 1:length(pvers[p1])
-                        if !in(pvers[p1][v1], rvs)
+                        if pvers[p1][v1] ∉ rvs
                             bm[v1, v0] = false
                             bmt[v0, v1] = false
                         end
@@ -191,7 +191,7 @@ type Messages
 
         # external fields: there are 2 terms, a noise to break potential symmetries
         #                  and one to favor newest versions over older, and no-version over all
-        fld = [ [ FieldValue(0,zero(VersionWeight),vweight[p0][v0],(v0==spp[p0]),0,noise(p0,v0)) for v0 = 1:spp[p0] ] for p0 = 1:np]
+        fld = [[FieldValue(0, zero(VersionWeight), vweight[p0][v0], (v0==spp[p0]), 0, noise(p0,v0)) for v0 = 1:spp[p0]] for p0 = 1:np]
 
         # enforce requirements
         for (rp, rvs) in reqs
@@ -207,7 +207,7 @@ type Messages
                     # the state is one of those explicitly requested:
                     # favor it at a higer level than normal (upgrade
                     # FieldValue from l2 to l1)
-                    fld0[v0] += FieldValue(0,vweight[p0][v0],-vweight[p0][v0])
+                    fld0[v0] += FieldValue(0, vweight[p0][v0], -vweight[p0][v0])
                 end
             end
             # the uninstalled state is forbidden by requirements
@@ -223,7 +223,7 @@ type Messages
 
         # initialize cavity messages to 0
         gadj = graph.gadj
-        msg = [ [ zeros(FieldValue,spp[p0]) for p1 = 1:length(gadj[p0])] for p0 = 1:np]
+        msg = [[zeros(FieldValue, spp[p0]) for p1 = 1:length(gadj[p0])] for p0 = 1:np]
 
         return new(msg, fld, falses(np), np)
     end
@@ -273,9 +273,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
     for j0 in 1:length(gadj0)
 
         p1 = gadj0[j0]
-        if decimated[p1]
-            continue
-        end
+        decimated[p1] && continue
         j1 = adjdict0[p1]
         #@assert j0 == adjdict[p1][p0]
         bm1 = gmsk[p1][j1]
@@ -289,7 +287,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
         if dir1 == -1
             # p0 depends on p1
             for v0 = 1:spp0-1
-                cavmsg[v0] += FieldValue(0,VersionWeight(0),VersionWeight(0),0,v0)
+                cavmsg[v0] += FieldValue(0, VersionWeight(0), VersionWeight(0), 0, v0)
             end
         end
 
@@ -297,12 +295,12 @@ function update(p0::Int, graph::Graph, msgs::Messages)
         oldmsg = msg1[j1]
 
         # init the new message to minus infinity
-        newmsg = [ FieldValue(-1) for v1 = 1:spp1 ]
+        newmsg = [FieldValue(-1) for v1 = 1:spp1]
 
         # compute the new message by passing cavmsg
         # through the constraint encoded in the bitmask
         # (nearly equivalent to:
-        #    newmsg = [ maximum(cavmsg[bm1[:,v1]]) for v1 = 1:spp1 ]
+        #    newmsg = [maximum(cavmsg[bm1[:,v1]]) for v1 = 1:spp1]
         #  except for the gnrg term)
         m = FieldValue(-1)
         for v1 = 1:spp1
@@ -313,7 +311,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
             end
             if dir1 == 1 && v1 != spp1
                 # p1 depends on p0
-                newmsg[v1] += FieldValue(0,VersionWeight(0),VersionWeight(0),0,v1)
+                newmsg[v1] += FieldValue(0, VersionWeight(0), VersionWeight(0), 0, v1)
             end
             m = max(m, newmsg[v1])
         end
@@ -399,14 +397,10 @@ function decimate(n::Int, graph::Graph, msgs::Messages)
     decimated = msgs.decimated
     fldorder = sortperm(fld, by=secondmax)
     for p0 in fldorder
-        if decimated[p0]
-            continue
-        end
+        decimated[p0] && continue
         decimate1(p0, graph, msgs)
         n -= 1
-        if n == 0
-            break
-        end
+        n == 0 && break
     end
     @assert n == 0
     return
@@ -450,19 +444,14 @@ function maxsum(graph::Graph, msgs::Messages)
         #println("it = $it maxdiff = $maxdiff")
 
         if maxdiff == zero(FieldValue)
-            if break_ties(msgs)
-                break
-            else
-                continue
-            end
+            break_ties(msgs) && break
+            continue
         end
         if it >= params.nondec_iterations &&
            (it - params.nondec_iterations) % params.dec_interval == 0
-            numdec = clamp(floor(Int,params.dec_fraction * graph.np),  1, msgs.num_nondecimated)
+            numdec = clamp(floor(Int, params.dec_fraction * graph.np),  1, msgs.num_nondecimated)
             decimate(numdec, graph, msgs)
-            if msgs.num_nondecimated == 0
-                break
-            end
+            msgs.num_nondecimated == 0 && break
         end
     end
 

--- a/base/pkg/resolve/maxsum.jl
+++ b/base/pkg/resolve/maxsum.jl
@@ -191,7 +191,7 @@ type Messages
 
         # external fields: there are 2 terms, a noise to break potential symmetries
         #                  and one to favor newest versions over older, and no-version over all
-        fld = [ [ FieldValue(0,zero(VersionWeight),vweight[p0][v0],0,noise(p0,v0)) for v0 = 1:spp[p0] ] for p0 = 1:np]
+        fld = [ [ FieldValue(0,zero(VersionWeight),vweight[p0][v0],(v0==spp[p0]),0,noise(p0,v0)) for v0 = 1:spp[p0] ] for p0 = 1:np]
 
         # enforce requirements
         for (rp, rvs) in reqs
@@ -289,7 +289,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
         if dir1 == -1
             # p0 depends on p1
             for v0 = 1:spp0-1
-                cavmsg[v0] += FieldValue(0,VersionWeight(0),VersionWeight(0),v0)
+                cavmsg[v0] += FieldValue(0,VersionWeight(0),VersionWeight(0),0,v0)
             end
         end
 
@@ -313,7 +313,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
             end
             if dir1 == 1 && v1 != spp1
                 # p1 depends on p0
-                newmsg[v1] += FieldValue(0,VersionWeight(0),VersionWeight(0),v1)
+                newmsg[v1] += FieldValue(0,VersionWeight(0),VersionWeight(0),0,v1)
             end
             m = max(m, newmsg[v1])
         end

--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -64,7 +64,7 @@ function Base.cmp{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T})
     return cmp(a.rest, b.rest)
 end
 Base.isless{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = cmp(a,b) < 0
-=={T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = cmp(a,b) == 0
+Base.:(==){T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = cmp(a,b) == 0
 
 Base.abs{T}(a::HierarchicalValue{T}) = HierarchicalValue(T[abs(x) for x in a.v], abs(a.rest))
 
@@ -92,7 +92,7 @@ function Base.cmp(a::VWPreBuildItem, b::VWPreBuildItem)
     return cmp(a.i, b.i)
 end
 Base.isless(a::VWPreBuildItem, b::VWPreBuildItem) = cmp(a,b) < 0
-==(a::VWPreBuildItem, b::VWPreBuildItem) = cmp(a,b) == 0
+Base.:(==)(a::VWPreBuildItem, b::VWPreBuildItem) = cmp(a,b) == 0
 
 Base.abs(a::VWPreBuildItem) = VWPreBuildItem(abs(a.nonempty), abs(a.s), abs(a.i))
 
@@ -144,7 +144,7 @@ end
     return cmp(a.w, b.w)
 end
 Base.isless(a::VWPreBuild, b::VWPreBuild) = cmp(a,b) < 0
-==(a::VWPreBuild, b::VWPreBuild) = cmp(a,b) == 0
+Base.:(==)(a::VWPreBuild, b::VWPreBuild) = cmp(a,b) == 0
 
 function Base.abs(a::VWPreBuild)
     a === _vwprebuild_zero && return a
@@ -159,53 +159,45 @@ immutable VersionWeight
     patch::Int
     prerelease::VWPreBuild
     build::VWPreBuild
-    uninstall::Int
 end
-VersionWeight(major::Int,minor::Int,patch::Int,prerelease::VWPreBuild,build::VWPreBuild) = VersionWeight(major, minor, patch, prerelease, build, 0)
 VersionWeight(major::Int,minor::Int,patch::Int,prerelease::VWPreBuild) = VersionWeight(major, minor, patch, prerelease, zero(VWPreBuild))
 VersionWeight(major::Int,minor::Int,patch::Int) = VersionWeight(major, minor, patch, zero(VWPreBuild))
 VersionWeight(major::Int,minor::Int) = VersionWeight(major, minor, 0)
 VersionWeight(major::Int) = VersionWeight(major, 0)
 VersionWeight() = VersionWeight(0)
 
-VersionWeight(vn::VersionNumber, uninstall=false) =
+VersionWeight(vn::VersionNumber) =
     VersionWeight(vn.major, vn.minor, vn.patch,
-                  VWPreBuild(true, vn.prerelease), VWPreBuild(false, vn.build),
-                  Int(uninstall))
+                  VWPreBuild(true, vn.prerelease), VWPreBuild(false, vn.build))
 
 Base.zero(::Type{VersionWeight}) = VersionWeight()
 
-Base.typemin(::Type{VersionWeight}) = (x=typemin(Int); y=typemin(VWPreBuild); VersionWeight(x,x,x,y,y,x))
+Base.typemin(::Type{VersionWeight}) = (x=typemin(Int); y=typemin(VWPreBuild); VersionWeight(x,x,x,y,y))
 
 Base.:-(a::VersionWeight, b::VersionWeight) =
     VersionWeight(a.major-b.major, a.minor-b.minor, a.patch-b.patch,
-                  a.prerelease-b.prerelease, a.build-b.build,
-                  a.uninstall-b.uninstall)
+                  a.prerelease-b.prerelease, a.build-b.build)
 
 Base.:+(a::VersionWeight, b::VersionWeight) =
     VersionWeight(a.major+b.major, a.minor+b.minor, a.patch+b.patch,
-                  a.prerelease+b.prerelease, a.build+b.build,
-                  a.uninstall+b.uninstall)
+                  a.prerelease+b.prerelease, a.build+b.build)
 
 Base.:-(a::VersionWeight) =
     VersionWeight(-a.major, -a.minor, -a.patch,
-                  -a.prerelease, -a.build,
-                  -a.uninstall)
+                  -a.prerelease, -a.build)
 
 function Base.cmp(a::VersionWeight, b::VersionWeight)
     c = cmp(a.major, b.major); c != 0 && return c
     c = cmp(a.minor, b.minor); c != 0 && return c
     c = cmp(a.patch, b.patch); c != 0 && return c
     c = cmp(a.prerelease, b.prerelease); c != 0 && return c
-    c = cmp(a.build, b.build); c != 0 && return c
-    return cmp(a.uninstall, b.uninstall)
+    return cmp(a.build, b.build)
 end
 Base.isless(a::VersionWeight, b::VersionWeight) = cmp(a,b) < 0
-==(a::VersionWeight, b::VersionWeight) = cmp(a,b) == 0
+Base.:(==)(a::VersionWeight, b::VersionWeight) = cmp(a,b) == 0
 
 Base.abs(a::VersionWeight) =
     VersionWeight(abs(a.major), abs(a.minor), abs(a.patch),
-                  abs(a.prerelease), abs(a.build),
-                  abs(a.uninstall))
+                  abs(a.prerelease), abs(a.build))
 
 end

--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -160,9 +160,9 @@ immutable VersionWeight
     prerelease::VWPreBuild
     build::VWPreBuild
 end
-VersionWeight(major::Int,minor::Int,patch::Int,prerelease::VWPreBuild) = VersionWeight(major, minor, patch, prerelease, zero(VWPreBuild))
-VersionWeight(major::Int,minor::Int,patch::Int) = VersionWeight(major, minor, patch, zero(VWPreBuild))
-VersionWeight(major::Int,minor::Int) = VersionWeight(major, minor, 0)
+VersionWeight(major::Int, minor::Int, patch::Int, prerelease::VWPreBuild) = VersionWeight(major, minor, patch, prerelease, zero(VWPreBuild))
+VersionWeight(major::Int, minor::Int, patch::Int) = VersionWeight(major, minor, patch, zero(VWPreBuild))
+VersionWeight(major::Int, minor::Int) = VersionWeight(major, minor, 0)
 VersionWeight(major::Int) = VersionWeight(major, 0)
 VersionWeight() = VersionWeight(0)
 
@@ -172,7 +172,7 @@ VersionWeight(vn::VersionNumber) =
 
 Base.zero(::Type{VersionWeight}) = VersionWeight()
 
-Base.typemin(::Type{VersionWeight}) = (x=typemin(Int); y=typemin(VWPreBuild); VersionWeight(x,x,x,y,y))
+Base.typemin(::Type{VersionWeight}) = (x=typemin(Int); y=typemin(VWPreBuild); VersionWeight(x, x, x, y, y))
 
 Base.:-(a::VersionWeight, b::VersionWeight) =
     VersionWeight(a.major-b.major, a.minor-b.minor, a.patch-b.patch,


### PR DESCRIPTION
This fixes the first part of #20313, by allowing for packages to be installed without penalizing other packages. In other words: previously, installing a package could have an unintended "cost" under some particular circumstances. This could have happened when the solver had to choose between installing an earlier version of a package "A" by itself, or a newer version of "A" with a dependency "B", and when the candidate version for "B" was not the highest possible. The first commit in this PR fixes that. The other commits are a bit of housekeeping.
cc @tkelman