### PR TITLE
Fix compilation on LLVM svn

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1124,13 +1124,17 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
 #endif
 
         //f->dump();
-        #if JL_LLVM_VERSION < 30500
+#if JL_LLVM_VERSION < 30500
         if (verifyFunction(*f,PrintMessageAction)) {
-        #else
+#else
         llvm::raw_fd_ostream out(1,false);
         if (verifyFunction(*f,&out)) {
-        #endif
+#endif
+#if JL_LLVM_VERSION >= 50000
+            f->print(llvm::dbgs(), nullptr, false, true);
+#else
             f->dump();
+#endif
             jl_error("Malformed LLVM Function");
         }
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6590,9 +6590,18 @@ extern "C" void jl_init_codegen(void)
 // for debugging from gdb
 extern "C" void jl_dump_llvm_value(void *v)
 {
+#if JL_LLVM_VERSION >= 50000
+    ((Value*)v)->print(llvm::dbgs(), true);
+#else
     ((Value*)v)->dump();
+#endif
 }
 extern "C" void jl_dump_llvm_type(void *v)
 {
-    ((Type*)v)->dump(); putchar('\n');
+#if JL_LLVM_VERSION >= 50000
+    ((Type*)v)->print(llvm::dbgs(), true);
+#else
+    ((Type*)v)->dump();
+#endif
+    putchar('\n');
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -444,7 +444,11 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM)
                 auto Obj = object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef());
 
                 if (!Obj) {
+#if JL_LLVM_VERSION >= 50000
+                    M.print(llvm::dbgs(), nullptr, false, true);
+#else
                     M.dump();
+#endif
 #if JL_LLVM_VERSION >= 30900
                     std::string Buf;
                     raw_string_ostream OS(Buf);


### PR DESCRIPTION
Ref https://github.com/llvm-mirror/llvm/commit/88d207542b618ca6054b24491ddd67f8ca397540 https://github.com/llvm-mirror/llvm/commit/d6da5dbf7bc0029ddfe3e528b619e904b0f05029 https://github.com/llvm-mirror/llvm/commit/0439ed6e3d9fb3b9bac170985d8d95867d7a7fd5

Apparently it is a good idea to disable the simpler debug functions by default (conditional on `LLVM_ENABLE_DUMP`) and makes it impossible to detect if they are defined at compile time (no def in headers) because obviously no one should access them outside a debugger.....
