### PR TITLE
Allow arrays to customize nonscalar indexing return type

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -23,13 +23,13 @@ function SubArray(parent::AbstractArray, indexes::Tuple)
 end
 function SubArray{P, I, N}(::LinearSlow, parent::P, indexes::I, ::NTuple{N,Any})
     @_inline_meta
-    SubArray{eltype(P), N, P, I, false}(parent, indexes, 0, 0)
+    SubArray{indexed_eltype(parent, indexes...), N, P, I, false}(parent, indexes, 0, 0)
 end
 function SubArray{P, I, N}(::LinearFast, parent::P, indexes::I, ::NTuple{N,Any})
     @_inline_meta
     # Compute the stride and offset
     stride1 = compute_stride1(parent, indexes)
-    SubArray{eltype(P), N, P, I, true}(parent, indexes, compute_offset1(parent, stride1, indexes), stride1)
+    SubArray{indexed_eltype(parent, indexes...), N, P, I, true}(parent, indexes, compute_offset1(parent, stride1, indexes), stride1)
 end
 
 check_parent_index_match(parent, indexes) = check_parent_index_match(parent, index_ndims(indexes...))


### PR DESCRIPTION
This is a very small change (really only ±5 LOC) that adds a hook for custom arrays to customize the array storage that gets used for non-scalar indexing based upon the indices. There is no functional change to Base here; but the extensibility here is quite powerful.  I've added a very basic Interpolations.jl-like array to the AbstractArray tests.  With just a few extra definitions, it's able to fully participate with non-scalar indexing and views.

```julia
julia> v = InterpolatedVector([2^i for i=0:10])
11-element InterpolatedVector{Int64,Array{Int64,1}}:
    1
    2
    4
    ⋮

julia> v[2.5:5.5]
4-element Array{Float64,1}:
  3.0
  6.0
 12.0
 24.0

julia> @view v[2.5:5.5]
4-element SubArray{Float64,1,InterpolatedVector{Int64,Array{Int64,1}},Tuple{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}},false}:
  3.0
  6.0
 12.0
 24.0

julia> using DualNumbers

julia> v[[Dual(2.5,1),Dual(3.5,1),Dual(5.1,1)]]
3-element Array{DualNumbers.Dual{Float64},1}:
   3.0 + 2.0ɛ
   6.0 + 4.0ɛ
 17.6 + 16.0ɛ

julia> @view v[[Dual(2.5,1),Dual(3.5,1),Dual(5.1,1)]]
3-element SubArray{DualNumbers.Dual{Float64},1,InterpolatedVector{Int64,Array{Int64,1}},Tuple{Array{DualNumbers.Dual{Float64},1}},false}:
   3.0 + 2.0ɛ
   6.0 + 4.0ɛ
 17.6 + 16.0ɛ
```

cc: @tlycken 