### PR TITLE
runtests.jl: remove unecessary final call stack when run in script mode

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,6 +192,6 @@ cd(dirname(@__FILE__)) do
     else
         println("    \033[31;1mFAILURE\033[0m")
         Base.Test.print_test_errors(o_ts)
-        error()
+        throw(Test.FallbackTestSetException("Test run finished with errors"))
     end
 end


### PR DESCRIPTION
@tkelman / @kshyatt, I believe this is the cleaner thing to do in the multitude of cases where runtests.jl is run in script mode.

Feel free to merge if OK or close if not desired.