### PR TITLE
RFC: Better inference of `_apply()` (splatting)

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -17,6 +17,7 @@ immutable InferenceParams
     MAX_TUPLE_DEPTH::Int
     MAX_TUPLE_SPLAT::Int
     MAX_UNION_SPLITTING::Int
+    MAX_APPLY_UNION_ENUM::Int
 
     # reasonable defaults
     function InferenceParams(world::UInt;
@@ -24,9 +25,10 @@ immutable InferenceParams
                     tupletype_len::Int = 15,
                     tuple_depth::Int = 4,
                     tuple_splat::Int = 16,
-                    union_splitting::Int = 4)
+                    union_splitting::Int = 4,
+                    apply_union_enum::Int = 8)
         return new(world, inlining, tupletype_len,
-            tuple_depth, tuple_splat, union_splitting)
+            tuple_depth, tuple_splat, union_splitting, apply_union_enum)
     end
 end
 
@@ -1403,7 +1405,19 @@ function precise_container_types(args, types, vtypes::VarTable, sv)
                 return nothing
             end
         elseif isa(tti, Union)
-            return nothing
+            utis = uniontypes(tti)
+            if _any(t -> !isa(t,DataType) || !(t <: Tuple) || !isknownlength(t), utis)
+                return nothing
+            end
+            result[i] = Any[Union{} for j in 1:length(utis[1].parameters)]
+            for t in utis
+                if length(t.parameters) != length(result[i])
+                    return nothing
+                end
+                for j in 1:length(t.parameters)
+                    result[i][j] = tmerge(result[i][j], t.parameters[j])
+                end
+            end
         elseif isa(tti,DataType) && tti <: Tuple
             if i == n
                 if isvatuple(tti) && length(tti.parameters) == 1
@@ -1425,22 +1439,43 @@ function precise_container_types(args, types, vtypes::VarTable, sv)
     return result
 end
 
+function uniontypes_prod(types::Vector{Any}, sv)
+    if countunionsplit(types) > sv.params.MAX_APPLY_UNION_ENUM
+        return [types]
+    end
+    tp = [Any[]]
+    for i = 1:length(types)
+        uts = uniontypes(types[i])
+        tpnew = Vector{Any}[]
+        for tv in tp, t in uts
+            push!(tpnew, push!(copy(tv), t))
+        end
+        tp = tpnew
+    end
+    return tp
+end
+
 # do apply(af, fargs...), where af is a function value
 function abstract_apply(af::ANY, fargs, aargtypes::Vector{Any}, vtypes::VarTable, sv)
-    ctypes = precise_container_types(fargs, aargtypes, vtypes, sv)
-    if ctypes !== nothing
-        # apply with known func with known tuple types
-        # can be collapsed to a call to the applied func
-        at = append_any(Any[Const(af)], ctypes...)
-        n = length(at)
-        if n-1 > sv.params.MAX_TUPLETYPE_LEN
-            tail = foldl((a,b)->tmerge(a,unwrapva(b)), Bottom, at[sv.params.MAX_TUPLETYPE_LEN+1:n])
-            at = vcat(at[1:sv.params.MAX_TUPLETYPE_LEN], Any[Vararg{widenconst(tail)}])
+    res = Union{}
+    for eaargtypes in uniontypes_prod(aargtypes, sv)
+        ctypes = precise_container_types(fargs, eaargtypes, vtypes, sv)
+        if ctypes === nothing
+            # apply known function with unknown args => f(Any...)
+            res = tmerge(res, abstract_call(af, (), Any[Const(af), Vararg{Any}], vtypes, sv))
+        else
+            # apply with known func with known tuple types
+            # can be collapsed to a call to the applied func
+            at = append_any(Any[Const(af)], ctypes...)
+            n = length(at)
+            if n-1 > sv.params.MAX_TUPLETYPE_LEN
+                tail = foldl((a,b)->tmerge(a,unwrapva(b)), Bottom, at[sv.params.MAX_TUPLETYPE_LEN+1:n])
+                at = vcat(at[1:sv.params.MAX_TUPLETYPE_LEN], Any[Vararg{widenconst(tail)}])
+            end
+            res = tmerge(res, abstract_call(af, (), at, vtypes, sv))
         end
-        return abstract_call(af, (), at, vtypes, sv)
     end
-    # apply known function with unknown args => f(Any...)
-    return abstract_call(af, (), Any[Const(af), Vararg{Any}], vtypes, sv)
+    return res
 end
 
 function return_type_tfunc(argtypes::ANY, vtypes::VarTable, sv::InferenceState)

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -589,7 +589,7 @@ g11015(::Type{Bool}, ::Bool) = 2.0
 @test Int <: Base.return_types(f11015, (AT11015,))[1]
 @test f11015(AT11015(true)) === 1
 
-# splatting a Union of Tuple's (#20343)
+# better inference of apply (#20343)
 f20343(::String, ::Int) = 1
 f20343(::Int, ::String, ::Int, ::Int) = 1
 f20343(::Int, ::Int, ::String, ::Int, ::Int, ::Int) = 1
@@ -607,6 +607,10 @@ function h20343()
     f20343(i..., i...)
 end
 @test all(t -> t<:Integer, Base.return_types(h20343, ()))
+function i20343()
+    f20343([1,2,3]..., 4)
+end
+@test Base.return_types(i20343, ()) == [Int8]
 
 # Inference for some type-level computation
 fUnionAll{T}(::Type{T}) = Type{S} where S <: T

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -589,6 +589,25 @@ g11015(::Type{Bool}, ::Bool) = 2.0
 @test Int <: Base.return_types(f11015, (AT11015,))[1]
 @test f11015(AT11015(true)) === 1
 
+# splatting a Union of Tuple's (#20343)
+f20343(::String, ::Int) = 1
+f20343(::Int, ::String, ::Int, ::Int) = 1
+f20343(::Int, ::Int, ::String, ::Int, ::Int, ::Int) = 1
+f20343(::Union{Int,String}...) = Int8(1)
+f20343(::Any...) = "no"
+function g20343()
+    n = rand(1:3)
+    i = ntuple(i->n==i ? "" : 0, 2n)::Union{Tuple{String,Int},Tuple{Int,String,Int,Int},Tuple{Int,Int,String,Int,Int,Int}}
+    f20343(i...)
+end
+@test Base.return_types(g20343, ()) == [Int]
+function h20343()
+    n = rand(1:3)
+    i = ntuple(i->n==i ? "" : 0, 3)::Union{Tuple{String,Int,Int},Tuple{Int,String,Int},Tuple{Int,Int,String}}
+    f20343(i..., i...)
+end
+@test all(t -> t<:Integer, Base.return_types(h20343, ()))
+
 # Inference for some type-level computation
 fUnionAll{T}(::Type{T}) = Type{S} where S <: T
 @inferred fUnionAll(Real) == Type{T} where T <: Real

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -611,6 +611,18 @@ function i20343()
     f20343([1,2,3]..., 4)
 end
 @test Base.return_types(i20343, ()) == [Int8]
+immutable Foo20518 <: AbstractVector{Int}; end # issue #20518; inference assumed AbstractArrays
+Base.getindex(::Foo20518, ::Int) = "oops"      # not to lie about their element type
+Base.indices(::Foo20518) = (Base.OneTo(4),)
+foo20518(xs::Any...) = -1
+foo20518(xs::Int...) = [0]
+bar20518(xs) = sum(foo20518(xs...))
+@test bar20518(Foo20518()) == -1
+f19957(::Int) = Int8(1)            # issue #19957, inference failure when splatting a number
+f19957(::Int...) = Int16(1)
+f19957(::Any...) = "no"
+g19957(x) = f19957(x...)
+@test all(t -> t<:Union{Int8,Int16}, Base.return_types(g19957, (Int,))) # with a full fix, this should just be Int8
 
 # Inference for some type-level computation
 fUnionAll{T}(::Type{T}) = Type{S} where S <: T


### PR DESCRIPTION
Presently, something like
```julia
x::Union{Tuple{Foo,Bar},Tuple{Bork,Baz}}
f(x...)
```
will be inferred as `f(::Any...)`, which is likely suboptimal. This PR tries to improve the situation in two ways:
1 If a `Union` is splatted, inference tries the individual types. In case multiple `Union`s are splatted, this would result in many possible combinations; I just limit to an arbitrarily chosen maximum of 7. Otherwise...
2. a `Union` of several `Tuple`s of the same length is rewritten to a `Tuple` of `Union`s, e.g. `Tuple{Union{Foo, Bork}, Union{Bar, Baz}}` for the example above, if it wasn't handled by 1. already.

As an example, I have asserted the return type of `setindex(::Tuple, ...)` to be a large `Union`. This allows 
```julia
julia> @code_warntype slicedim(ones(1,1), 1, 1)
[...]
  end::Union{Array{Float64,1},Array{Float64,2}}

julia> @code_warntype slicedim(ones(1,1,1,1,1,1), 1, 1)
[...]
  end::Union{Array{Float64,5},Array{Float64,6}}
```
which are the tightest bounds as `slicedim` is actually not type-stable. On master, the first one gives `Union{Array{Float64,1},Array{Float64,2},Float64}`, while for more than 2 dimensions it's just `Any`. (The modification to `setindex` on master would just always give `Any` here).

The code certainly needs some revising, but as I'm completely new to inference, I'd like some feedback on the general idea first. (Blame @vtjnash for encouraging me to even try this!)

**Edit:** This PR has evolved and grown a bit. It now further enhances cases where
* a splatted argument of unknown length does not appear last. A call like `f(1, ones(n::Int)..., "bar")` is now treated like `f(::Int, ::Union{Float64,String}...)`, while on master it is treated like `f(::Any...)`.
* a general iterable is passed. The iteration protocol is simulated to determine the element type produced by the iterable, instead of just always treating it as `Any`.