### PR TITLE
fix #20332, `MethodInstance` display error

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1039,12 +1039,12 @@ function show_lambda_types(io::IO, li::Core.MethodInstance)
             returned_from_do = true
             return
         end
-        sig = li.specTypes.parameters
-        ft = sig[1]
-        if ft <: Function && isempty(ft.parameters) &&
-                isdefined(ft.name.module, ft.name.mt.name) &&
-                ft == typeof(getfield(ft.name.module, ft.name.mt.name))
-            print(io, ft.name.mt.name)
+        sig = unwrap_unionall(li.specTypes).parameters
+        ft = sig[1]; uw = unwrap_unionall(ft)
+        if ft <: Function && isa(uw,DataType) && isempty(uw.parameters) &&
+                isdefined(uw.name.module, uw.name.mt.name) &&
+                ft == typeof(getfield(uw.name.module, uw.name.mt.name))
+            print(io, uw.name.mt.name)
         elseif isa(ft, DataType) && ft.name === Type.body.name && isleaftype(ft)
             f = ft.parameters[1]
             print(io, f)

--- a/test/show.jl
+++ b/test/show.jl
@@ -650,3 +650,16 @@ end
 struct TypeWith4Params{a,b,c,d}
 end
 @test endswith(string(TypeWith4Params{Int8,Int8,Int8,Int8}), "TypeWith4Params{Int8,Int8,Int8,Int8}")
+
+# issues #20332 and #20781
+struct T20332{T}
+end
+
+(::T20332{T})(x) where T = 0
+
+let m = which(T20332{Int}(), (Int,)),
+    mi = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any, UInt),
+               m, Tuple{T20332{T}, Int} where T, Core.svec(), typemax(UInt))
+    # test that this doesn't throw an error
+    @test contains(repr(mi), "MethodInstance for")
+end


### PR DESCRIPTION
This should fix it, but I haven't been able to come up with a test case. This case occurs when we generate a specialization with a UnionAll type in the first slot, which doesn't happen very often.