### PR TITLE
"doctests" for some more manual files

### DIFF
--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -1,9 +1,9 @@
 # Interacting With Julia
 
 Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into
-the `julia` executable.  In addition to allowing quick and easy evaluation of Julia statements,
+the `julia` executable. In addition to allowing quick and easy evaluation of Julia statements,
 it has a searchable history, tab-completion, many helpful keybindings, and dedicated help and
-shell modes.  The REPL can be started by simply calling `julia` with no arguments or double-clicking
+shell modes. The REPL can be started by simply calling `julia` with no arguments or double-clicking
 on the executable:
 
 ```
@@ -11,11 +11,11 @@ $ julia
                _
    _       _ _(_)_     |  A fresh approach to technical computing
   (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
-   _ _   _| |_  __ _   |  Type "help()" to list help topics
+   _ _   _| |_  __ _   |  Type "?help" for help.
   | | | | | | |/ _` |  |
-  | | |_| | | | (_| |  |  Version 0.3.0-prerelease+2834 (2014-04-30 03:13 UTC)
- _/ |\__'_|_|_|\__'_|  |  Commit 64f437b (0 days old master)
-|__/                   |  x86_64-apple-darwin13.1.0
+  | | |_| | | | (_| |  |  Version 0.6.0-dev.2493 (2017-01-31 18:53 UTC)
+ _/ |\__'_|_|_|\__'_|  |  Commit c99e12c* (0 days old master)
+|__/                   |  x86_64-linux-gnu
 
 julia>
 ```
@@ -28,21 +28,21 @@ and a `julia>` prompt.
 
 ### The Julian mode
 
-The REPL has four main modes of operation.  The first and most common is the Julian prompt.  It
-is the default mode of operation; each new line initially starts with `julia>`.  It is here that
-you can enter Julia expressions.  Hitting return or enter after a complete expression has been
+The REPL has four main modes of operation. The first and most common is the Julian prompt. It
+is the default mode of operation; each new line initially starts with `julia>`. It is here that
+you can enter Julia expressions. Hitting return or enter after a complete expression has been
 entered will evaluate the entry and show the result of the last expression.
 
-```julia
+```jldoctest
 julia> string(1 + 2)
 "3"
 ```
 
 There are a number useful features unique to interactive work. In addition to showing the result,
-the REPL also binds the result to the variable `ans`.  A trailing semicolon on the line can be
+the REPL also binds the result to the variable `ans`. A trailing semicolon on the line can be
 used as a flag to suppress showing the result.
 
-```julia
+```jldoctest
 julia> string(3 * 4);
 
 julia> ans
@@ -61,35 +61,45 @@ at detecting when a paste occurs.
 ### Help mode
 
 When the cursor is at the beginning of the line, the prompt can be changed to a help mode by typing
-`?`.  Julia will attempt to print help or documentation for anything entered in help mode:
+`?`. Julia will attempt to print help or documentation for anything entered in help mode:
 
 ```julia
-julia> ? # upon typing ?, the prompt changes (in place) to: help>
+julia> ? # upon typing ?, the prompt changes (in place) to: help?>
 
-help> string
-Base.string(xs...)
+help?> string
+search: string String stringmime Cstring Cwstring RevString readstring randstring bytestring SubString
 
-   Create a string from any values using the "print" function.
+  string(xs...)
+
+  Create a string from any values using the print function.
 ```
 
-In addition to function names, complete function calls may be entered to see which method is called
-for the given argument(s).  Macros, types and variables can also be queried:
+Macros, types and variables can also be queried:
 
 ```
-help> string(1)
-string(x::Union{Int16,Int128,Int8,Int32,Int64}) at string.jl:1553
+help?> @time
+  @time
 
-help> @printf
-Base.@printf([io::IOStream], "%Fmt", args...)
+  A macro to execute an expression, printing the time it took to execute, the number of allocations,
+  and the total number of bytes its execution caused to be allocated, before returning the value of the
+  expression.
 
-   Print arg(s) using C "printf()" style format specification
-   string. Optionally, an IOStream may be passed as the first argument
-   to redirect output.
+  See also @timev, @timed, @elapsed, and @allocated.
 
-help> AbstractString
-DataType   : AbstractString
-  supertype: Any
-  subtypes : Any[DirectIndexString,RevString{T<:AbstractString},SubString{T<:AbstractString},String]
+help?> AbstractString
+search: AbstractString AbstractSparseMatrix AbstractSparseVector AbstractSet
+
+  No documentation found.
+
+  Summary:
+
+  abstract AbstractString <: Any
+
+  Subtypes:
+
+  Base.Test.GenericString
+  DirectIndexString
+  String
 ```
 
 Help mode can be exited by pressing backspace at the beginning of the line.
@@ -97,8 +107,8 @@ Help mode can be exited by pressing backspace at the beginning of the line.
 ### [Shell mode](@id man-shell-mode)
 
 Just as help mode is useful for quick access to documentation, another common task is to use the
-system shell to execute system commands.  Just as `?` entered help mode when at the beginning
-of the line, a semicolon (`;`) will enter the shell mode.  And it can be exited by pressing backspace
+system shell to execute system commands. Just as `?` entered help mode when at the beginning
+of the line, a semicolon (`;`) will enter the shell mode. And it can be exited by pressing backspace
 at the beginning of the line.
 
 ```julia
@@ -112,9 +122,9 @@ hello
 
 In all of the above modes, the executed lines get saved to a history file, which can be searched.
  To initiate an incremental search through the previous history, type `^R` -- the control key
-together with the `r` key.  The prompt will change to ```(reverse-i-search)`':```, and as you
-type the search query will appear in the quotes.  The most recent result that matches the query
-will dynamically update to the right of the colon as more is typed.  To find an older result using
+together with the `r` key. The prompt will change to ```(reverse-i-search)`':```, and as you
+type the search query will appear in the quotes. The most recent result that matches the query
+will dynamically update to the right of the colon as more is typed. To find an older result using
 the same query, simply type `^R` again.
 
 Just as `^R` is a reverse search, `^S` is a forward search, with the prompt ```(i-search)`':```.
@@ -123,10 +133,10 @@ results, respectively.
 
 ## Key bindings
 
-The Julia REPL makes great use of key bindings.  Several control-key bindings were already introduced
-above (`^D` to exit, `^R` and `^S` for searching), but there are many more.  In addition to the
-control-key, there are also meta-key bindings.  These vary more by platform, but most terminals
- default to using alt- or option- held down with a key to send the meta-key (or can be configured
+The Julia REPL makes great use of key bindings. Several control-key bindings were already introduced
+above (`^D` to exit, `^R` and `^S` for searching), but there are many more. In addition to the
+control-key, there are also meta-key bindings. These vary more by platform, but most terminals
+default to using alt- or option- held down with a key to send the meta-key (or can be configured
 to do so).
 
 | Keybinding          | Description                                                                      |
@@ -200,12 +210,11 @@ In both the Julian and help modes of the REPL, one can enter the first few chara
 or type and then press the tab key to get a list all matches:
 
 ```julia
-julia> stri
+julia> stri[TAB]
 stride     strides     string      stringmime  strip
 
-julia> Stri
-StridedArray    StridedVecOrMat  AbstractString
-StridedMatrix   StridedVector
+julia> Stri[TAB]
+StridedArray    StridedMatrix    StridedVecOrMat  StridedVector    String
 ```
 
 The tab key can also be used to substitute LaTeX math symbols with their Unicode equivalents,
@@ -236,8 +245,10 @@ julia> ħ(h) = h / 2π
 ħ (generic function with 1 method)
 
 julia> \h[TAB]
-\hat              \heartsuit         \hksearow          \hookleftarrow     \hslash
-\hbar             \hermitconjmatrix  \hkswarow          \hookrightarrow    \hspace
+\hat              \hermitconjmatrix  \hkswarow          \hrectangle
+\hatapprox        \hexagon           \hookleftarrow     \hrectangleblack
+\hbar             \hexagonblack      \hookrightarrow    \hslash
+\heartsuit        \hksearow          \house             \hspace
 
 julia> α="\alpha[TAB]"   # LaTeX completion also works in strings
 julia> α="α"
@@ -261,21 +272,22 @@ Tab completion can help with investigation of the available methods matching the
 ```julia
 julia> max([TAB] # All methods are displayed, not shown here due to size of the list
 
-julia> max([1,2],[TAB] # All methods where `Vector{Int}` matches as first argument
-max{T1<:Real,T2<:Real}(x::AbstractArray{T1,N<:Any}, y::T2) at operators.jl:544
-max{Tx<:Real,Ty<:Real}(x::Union{Base.ReshapedArray{Tx,1,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N<:Any}}},DenseArray{Tx,1},SubArray{Tx,1,A<:Union{Base.ReshapedArray{T<:Any,N<:Any,A<:DenseArray,MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N<:Any}}},DenseArray},I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex,Colon,Int64,Range{Int64}},N<:Any}},L<:Any}}, y::AbstractSparseArray{Ty,Ti<:Any,1}) at sparse\sparsevector.jl:1127
-max{T1<:Real,T2<:Real}(x::AbstractArray{T1,N<:Any}, y::AbstractArray{T2,N<:Any}) at operators.jl:548
-max(x, y) at operators.jl:78
-max(a, b, c, xs...) at operators.jl:119
+julia> max([1, 2], [TAB] # All methods where `Vector{Int}` matches as first argument
+max(x, y) in Base at operators.jl:215
+max(a, b, c, xs...) in Base at operators.jl:281
 
-julia> max([1,2], max(1,2),[TAB] # All methods matching the arguments.
-max{T1<:Real,T2<:Real}(x::AbstractArray{T1,N<:Any}, y::T2) at operators.jl:544
-max(x, y) at operators.jl:78
-max(a, b, c, xs...) at operators.jl:119
+julia> max([1, 2], max(1, 2), [TAB] # All methods matching the arguments.
+max(x, y) in Base at operators.jl:215
+max(a, b, c, xs...) in Base at operators.jl:281
+```
 
-julia> split("1 1 1", # Keywords are also displayed in the suggested methods, see second line after `;` where `limit` and `keep` are keyword arguments
-split(str::AbstractString) at strings/util.jl:151
-split{T<:AbstractString}(str::T, splitter; limit, keep) at strings/util.jl:127
+Keywords are also displayed in the suggested methods, see second line after `;` where `limit`
+and `keep` are keyword arguments:
+
+```julia
+julia> split("1 1 1", [TAB]
+split(str::AbstractString) in Base at strings/util.jl:278
+split{T<:AbstractString}(str::T, splitter; limit, keep) in Base at strings/util.jl:254
 ```
 
 The completion of the methods uses type inference and can therefore see if the arguments match
@@ -285,7 +297,7 @@ completion to be able to remove non-matching methods.
 Tab completion can also help completing fields:
 
 ```julia
-julia> Pkg.a
+julia> Pkg.a[TAB]
 add       available
 ```
 

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -9,14 +9,15 @@ The primary function used to obtain a stack trace is [`stacktrace()`](@ref):
 
 ```julia
 julia> stacktrace()
-3-element Array{StackFrame,1}:
- eval at boot.jl:265
- [inlined code from REPL.jl:3] eval_user_input at REPL.jl:62
- [inlined code from REPL.jl:92] anonymous at task.jl:63
+4-element Array{StackFrame,1}:
+  in eval(::Module, ::Any) at boot.jl:236
+  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+  in macro expansion at REPL.jl:97 [inlined]
+  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
 Calling [`stacktrace()`](@ref) returns a vector of [`StackFrame`](@ref) s. For ease of use, the
-alias [`StackTrace`](@ref) can be used in place of `Vector{StackFrame}`. (Examples with `...`
+alias [`StackTrace`](@ref) can be used in place of `Vector{StackFrame}`. (Examples with `[...]`
 indicate that output may vary depending on how the code is run.)
 
 ```julia
@@ -24,10 +25,10 @@ julia> example() = stacktrace()
 example (generic function with 1 method)
 
 julia> example()
-11-element Array{StackFrame,1}:
-  in example() at none:1
+5-element Array{StackFrame,1}:
+  in example() at REPL[0]:1
   in eval(::Module, ::Any) at boot.jl:236
-  ...
+[...]
 
 julia> @noinline child() = stacktrace()
 child (generic function with 1 method)
@@ -39,11 +40,11 @@ julia> grandparent() = parent()
 grandparent (generic function with 1 method)
 
 julia> grandparent()
-13-element Array{StackFrame,1}:
-  in child() at none:1
-  in parent() at none:1
-  in grandparent() at none:1
-  ...
+7-element Array{StackFrame,1}:
+  in child() at REPL[2]:1
+  in parent() at REPL[3]:1
+  in grandparent() at REPL[4]:1
+[...]
 ```
 
 Note that when calling [`stacktrace()`](@ref) you'll typically see a frame with `eval(...) at boot.jl`.
@@ -57,10 +58,10 @@ example (generic function with 1 method)
 julia> example()
 5-element Array{StackFrame,1}:
   in example() at REPL[1]:1
-  in eval(::Module, ::Any) at boot.jl:234
-  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:62
-  in macro expansion at REPL.jl:92 [inlined]
-  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:46
+  in eval(::Module, ::Any) at boot.jl:236
+  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+  in macro expansion at REPL.jl:97 [inlined]
+  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
 ## Extracting useful information
@@ -95,7 +96,7 @@ false
 
 ```julia
 julia> top_frame.pointer
-13203085684
+0x00007f390d152a59
 ```
 
 This makes stack trace information available programmatically for logging, error handling, and
@@ -118,10 +119,10 @@ julia> @noinline example() = try
 example (generic function with 1 method)
 
 julia> example()
-11-element Array{StackFrame,1}:
-  in example() at none:4
+5-element Array{StackFrame,1}:
+  in example() at REPL[2]:4
   in eval(::Module, ::Any) at boot.jl:236
-  ...
+[...]
 ```
 
 You may notice that in the example above the first stack frame points points at line 4, where
@@ -146,10 +147,10 @@ julia> @noinline example() = try
 example (generic function with 1 method)
 
 julia> example()
-12-element Array{StackFrame,1}:
-  in bad_function() at none:1
-  in example() at none:2
-  ...
+6-element Array{StackFrame,1}:
+  in bad_function() at REPL[1]:1
+  in example() at REPL[2]:2
+[...]
 ```
 
 Notice that the stack trace now indicates the appropriate line number and the missing frame.
@@ -173,11 +174,11 @@ grandparent (generic function with 1 method)
 
 julia> grandparent()
 ERROR: Whoops!
-13-element Array{StackFrame,1}:
-  in child() at none:1
-  in parent() at none:1
-  in grandparent() at none:3
-  ...
+7-element Array{StackFrame,1}:
+  in child() at REPL[1]:1
+  in parent() at REPL[2]:1
+  in grandparent() at REPL[3]:3
+[...]
 ```
 
 ## Comparison with [`backtrace()`](@ref)
@@ -187,71 +188,72 @@ A call to [`backtrace()`](@ref) returns a vector of `Ptr{Void}`, which may then 
 
 ```julia
 julia> trace = backtrace()
-20-element Array{Ptr{Void},1}:
- Ptr{Void} @0x0000000100a26fc2
- Ptr{Void} @0x00000001029435df
- Ptr{Void} @0x0000000102943635
- Ptr{Void} @0x00000001009e9620
- Ptr{Void} @0x00000001009fe1e8
- Ptr{Void} @0x00000001009fc7b6
- Ptr{Void} @0x00000001009fdae3
- Ptr{Void} @0x00000001009fe0d2
- Ptr{Void} @0x0000000100a1321b
- Ptr{Void} @0x00000001009f64e7
- Ptr{Void} @0x000000010265ac5d
- Ptr{Void} @0x000000010265acc1
- Ptr{Void} @0x00000001009e9620
- Ptr{Void} @0x000000031007744b
- Ptr{Void} @0x0000000310077537
- Ptr{Void} @0x00000001009e9620
- Ptr{Void} @0x000000031006feec
- Ptr{Void} @0x00000003100701b0
- Ptr{Void} @0x00000001009e9635
- Ptr{Void} @0x0000000100a06418
+21-element Array{Ptr{Void},1}:
+ Ptr{Void} @0x00007f10049d5b2f
+ Ptr{Void} @0x00007f0ffeb4d29c
+ Ptr{Void} @0x00007f0ffeb4d2a9
+ Ptr{Void} @0x00007f1004993fe7
+ Ptr{Void} @0x00007f10049a92be
+ Ptr{Void} @0x00007f10049a823a
+ Ptr{Void} @0x00007f10049a9fb0
+ Ptr{Void} @0x00007f10049aa718
+ Ptr{Void} @0x00007f10049c0d5e
+ Ptr{Void} @0x00007f10049a3286
+ Ptr{Void} @0x00007f0ffe9ba3ba
+ Ptr{Void} @0x00007f0ffe9ba3d0
+ Ptr{Void} @0x00007f1004993fe7
+ Ptr{Void} @0x00007f0ded34583d
+ Ptr{Void} @0x00007f0ded345a87
+ Ptr{Void} @0x00007f1004993fe7
+ Ptr{Void} @0x00007f0ded34308f
+ Ptr{Void} @0x00007f0ded343320
+ Ptr{Void} @0x00007f1004993fe7
+ Ptr{Void} @0x00007f10049aeb67
+ Ptr{Void} @0x0000000000000000
 
 julia> stacktrace(trace)
 5-element Array{StackFrame,1}:
-  in backtrace() at error.jl:26
-  in eval(::Module, ::Any) at boot.jl:231
-  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:62
-  in macro expansion at REPL.jl:92 [inlined]
-  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:46
+  in backtrace() at error.jl:46
+  in eval(::Module, ::Any) at boot.jl:236
+  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+  in macro expansion at REPL.jl:97 [inlined]
+  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
-Notice that the vector returned by [`backtrace()`](@ref) had 15 pointers, while the vector returned
-by [`stacktrace()`](@ref) only has 4. This is because, by default, [`stacktrace()`](@ref) removes
+Notice that the vector returned by [`backtrace()`](@ref) had 21 pointers, while the vector returned
+by [`stacktrace()`](@ref) only has 5. This is because, by default, [`stacktrace()`](@ref) removes
 any lower-level C functions from the stack. If you want to include stack frames from C calls,
 you can do it like this:
 
 ```julia
 julia> stacktrace(trace, true)
 26-element Array{StackFrame,1}:
-  in jl_backtrace_from_here at stackwalk.c:104
-  in backtrace() at error.jl:26
-  in ip:0x102943635
-  in jl_call_method_internal at julia_internal.h:86 [inlined]
-  in jl_apply_generic at gf.c:1805
-  in do_call at interpreter.c:65
-  in eval at interpreter.c:188
-  in eval_body at interpreter.c:469
-  in jl_interpret_call at interpreter.c:573
-  in jl_toplevel_eval_flex at toplevel.c:543
-  in jl_toplevel_eval_in_warn at builtins.c:571
-  in eval(::Module, ::Any) at boot.jl:231
-  in ip:0x10265acc1
-  in jl_call_method_internal at julia_internal.h:86 [inlined]
-  in jl_apply_generic at gf.c:1805
-  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:62
-  in ip:0x310077537
-  in jl_call_method_internal at julia_internal.h:86 [inlined]
-  in jl_apply_generic at gf.c:1805
-  in macro expansion at REPL.jl:92 [inlined]
-  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:46
-  in ip:0x3100701b0
-  in jl_call_method_internal at julia_internal.h:86 [inlined]
-  in jl_apply_generic at gf.c:1795
-  in jl_apply at julia.h:1388 [inlined]
-  in start_task at task.c:247
+  in jl_backtrace_from_here at stackwalk.c:103
+  in backtrace() at error.jl:46
+  in backtrace() at sys.so:?
+  in jl_call_method_internal at julia_internal.h:248 [inlined]
+  in jl_apply_generic at gf.c:2217
+  in do_call at interpreter.c:75
+  in eval at interpreter.c:215
+  in eval_body at interpreter.c:519
+  in jl_interpret_toplevel_thunk at interpreter.c:664
+  in jl_toplevel_eval_flex at toplevel.c:592
+  in jl_toplevel_eval_in at builtins.c:614
+  in eval(::Module, ::Any) at boot.jl:236
+  in eval(::Module, ::Any) at sys.so:?
+  in jl_call_method_internal at julia_internal.h:248 [inlined]
+  in jl_apply_generic at gf.c:2217
+  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+  in ip:0x7f0ded345a86
+  in jl_call_method_internal at julia_internal.h:248 [inlined]
+  in jl_apply_generic at gf.c:2217
+  in macro expansion at REPL.jl:97 [inlined]
+  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
+  in ip:0x7f0ded34331f
+  in jl_call_method_internal at julia_internal.h:248 [inlined]
+  in jl_apply_generic at gf.c:2217
+  in jl_apply at julia.h:1411 [inlined]
+  in start_task at task.c:261
 ```
 
 Individual pointers returned by [`backtrace()`](@ref) can be translated into [`StackFrame`](@ref)
@@ -262,7 +264,7 @@ julia> pointer = backtrace()[1];
 
 julia> frame = StackTraces.lookup(pointer)
 1-element Array{StackFrame,1}:
-  in jl_backtrace_from_here at stackwalk.c:105
+  in jl_backtrace_from_here at stackwalk.c:103
 
 julia> println("The top frame is from $(frame[1].func)!")
 The top frame is from jl_backtrace_from_here!

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -33,7 +33,7 @@ The second version will convert `x` to an appropriate type, instead of always th
 
 This style point is especially relevant to function arguments. For example, don't declare an argument
 to be of type `Int` or `Int32` if it really could be any integer, expressed with the abstract
-type `Integer`.  In fact, in many cases you can omit the argument type altogether, unless it is
+type `Integer`. In fact, in many cases you can omit the argument type altogether, unless it is
 needed to disambiguate from other method definitions, since a [`MethodError`](@ref) will be thrown
 anyway if a type is passed that does not support any of the requisite operations. (This is known
 as [duck typing](https://en.wikipedia.org/wiki/Duck_typing).)
@@ -50,18 +50,18 @@ addone(x) = x + one(x)             # any type supporting + and one
 
 The last definition of `addone` handles any type supporting [`one()`](@ref) (which returns 1 in
 the same type as `x`, which avoids unwanted type promotion) and the [`+`](@ref) function with
-those arguments.  The key thing to realize is that there is *no performance penalty* to defining
+those arguments. The key thing to realize is that there is *no performance penalty* to defining
 *only* the general `addone(x) = x + one(x)`, because Julia will automatically compile specialized
-versions as needed.  For example, the first time you call `addone(12)`, Julia will automatically
+versions as needed. For example, the first time you call `addone(12)`, Julia will automatically
 compile a specialized `addone` function for `x::Int` arguments, with the call to [`one()`](@ref)
-replaced by its inlined value `1`.  Therefore, the first three definitions of `addone` above are
+replaced by its inlined value `1`. Therefore, the first three definitions of `addone` above are
 completely redundant.
 
 ## Handle excess argument diversity in the caller
 
 Instead of:
 
-```
+```julia
 function foo(x, y)
     x = Int(x); y = Int(y)
     ...
@@ -71,7 +71,7 @@ foo(x, y)
 
 use:
 
-```
+```julia
 function foo(x::Int, y::Int)
     ...
 end
@@ -91,8 +91,10 @@ Instead of:
 
 ```julia
 function double{T<:Number}(a::AbstractArray{T})
-    for i = 1:endof(a); a[i] *= 2; end
-    a
+    for i = 1:endof(a)
+        a[i] *= 2
+    end
+    return a
 end
 ```
 
@@ -100,8 +102,10 @@ use:
 
 ```julia
 function double!{T<:Number}(a::AbstractArray{T})
-    for i = 1:endof(a); a[i] *= 2; end
-    a
+    for i = 1:endof(a)
+        a[i] *= 2
+    end
+    return a
 end
 ```
 
@@ -110,7 +114,7 @@ with both copying and modifying forms (e.g., [`sort()`](@ref) and [`sort!()`](@r
 which are just modifying (e.g., [`push!()`](@ref), [`pop!()`](@ref), [`splice!()`](@ref)).  It
 is typical for such functions to also return the modified array for convenience.
 
-## Avoid strange type Unions
+## Avoid strange type `Union`s
 
 Types such as `Union{Function,AbstractString}` are often a sign that some design could be cleaner.
 
@@ -118,7 +122,7 @@ Types such as `Union{Function,AbstractString}` are often a sign that some design
 
 When creating a type such as:
 
-```
+```julia
 type MyType
     ...
     x::Union{Void,T}
@@ -150,7 +154,7 @@ uses (e.g. `a[i]::Int`) than to try to pack many alternatives into one type.
 
 ## Use naming conventions consistent with Julia's `base/`
 
-  * modules and type names use capitalization and camel case: `module SparseArrays`,  `immutable UnitRange`.
+  * modules and type names use capitalization and camel case: `module SparseArrays`, `immutable UnitRange`.
   * functions are lowercase ([`maximum()`](@ref), [`convert()`](@ref)) and, when readable, with multiple
     words squashed together ([`isequal()`](@ref), [`haskey()`](@ref)). When necessary, use underscores
     as word separators. Underscores are also used to indicate a combination of concepts ([`remotecall_fetch()`](@ref)
@@ -179,7 +183,7 @@ instead of:
 if (a == b)
 ```
 
-## Don't overuse ...
+## Don't overuse `...`
 
 Splicing function arguments can be addictive. Instead of `[a..., b...]`, use simply `[a; b]`,
 which already concatenates arrays. [`collect(a)`](@ref) is better than `[a...]`, but since `a`
@@ -189,13 +193,13 @@ is already iterable it is often even better to leave it alone, and not convert i
 
 A function signature:
 
-```
+```julia
 foo{T<:Real}(x::T) = ...
 ```
 
 should be written as:
 
-```
+```julia
 foo(x::Real) = ...
 ```
 
@@ -210,7 +214,7 @@ FAQ [Avoid fields with abstract containers](@ref) for more information.
 
 Sets of definitions like the following are confusing:
 
-```
+```julia
 foo(::Type{MyType}) = ...
 foo(::MyType) = foo(MyType)
 ```
@@ -238,7 +242,7 @@ it will naturally have access to the run-time values it needs.
 
 If you have a type that uses a native pointer:
 
-```
+```julia
 type NativeType
     p::Ptr{UInt8}
     ...
@@ -261,7 +265,7 @@ in its name to alert callers.
 
 It is possible to write definitions like the following:
 
-```
+```julia
 show(io::IO, v::Vector{MyType}) = ...
 ```
 
@@ -289,7 +293,7 @@ little as possible through promotion.
 
 For example,
 
-```julia
+```jldoctest
 julia> f(x) = 2.0 * x
 f (generic function with 1 method)
 
@@ -305,7 +309,7 @@ julia> f(1)
 
 while
 
-```julia
+```jldoctest
 julia> g(x) = 2 * x
 g (generic function with 1 method)
 
@@ -315,8 +319,8 @@ julia> g(1//2)
 julia> g(1/2)
 1.0
 
-julia> g(2)
-4
+julia> g(1)
+2
 ```
 
 As you can see, the second version, where we used an `Int` literal, preserved the type of the
@@ -324,7 +328,7 @@ input argument, while the first didn't. This is because e.g. `promote_type(Int, 
 and promotion happens with the multiplication. Similarly, `Rational` literals are less type disruptive
 than [`Float64`](@ref) literals, but more disruptive than `Int`s:
 
-```julia
+```jldoctest
 julia> h(x) = 2//1 * x
 h (generic function with 1 method)
 


### PR DESCRIPTION
Trying to finish up https://github.com/JuliaLang/julia/issues/20274

These files did not really include any doctestable examples, but I updated them to how it currently looks.

(`make check-whitespace` and the doctests pass locally, remove `[ci skip]` from commit message if/when this is merged)