### PR TITLE
Fix gc_setmark size for strings

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -607,7 +607,7 @@ static inline uint16_t gc_setmark_pool(jl_ptls_t ptls, jl_taggedvalue_t *o,
 }
 
 static inline uint16_t gc_setmark(jl_ptls_t ptls, jl_value_t *v,
-                                  int sz, uintptr_t tag)
+                                  size_t sz, uintptr_t tag)
 {
     assert(!gc_marked(tag));
     jl_taggedvalue_t *o = jl_astaggedvalue(v);


### PR DESCRIPTION
This is only an issue for strings since normal object cannot be this big.

Fix #20360
