### PR TITLE
RFC: exportable tuple-manipulation utilities

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -86,6 +86,8 @@ export
     Range,
     RangeIndex,
     Rational,
+    ReferenceBack,
+    ReferenceFront,
     Regex,
     RegexMatch,
     RemoteChannel,

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -76,6 +76,42 @@ function _front(out, v, t...)
     _front((out..., v), t...)
 end
 
+abstract ReferenceTuple
+immutable ReferenceFront{TT<:Tuple} <: ReferenceTuple
+    t::TT
+end
+immutable ReferenceBack{TT<:Tuple} <: ReferenceTuple
+    t::TT
+end
+
+"""
+    split(t, ReferenceFront(ref)) -> front, back
+
+Splits a tuple or CartesianIndex `t` into two pieces, `front` and
+`back`, such that `t == (front..., back...)`. `front` has the same
+length as the reference `ref`.
+"""
+split(t::Tuple, ref::ReferenceFront) = _splitfront((), t, ref.t)
+_splitfront{N}(out::NTuple{N}, t, ref::NTuple{N}) = out, t
+_splitfront(out, ::Tuple{}, ref) =
+    (@_noinline_meta; throw(DimensionMismatch("front reference had $(length(ref)) elements, but input had only $(length(out))")))
+_splitfront(out, t, ref) =
+    (@_inline_meta; _splitfront((out..., t[1]), tail(t), ref))
+
+"""
+    split(t, ReferenceBack(ref)) -> front, back
+
+Splits a tuple or CartesianIndex `t` into two pieces, `front` and
+`back`, such that `t == (front..., back...)`. `front` has the same
+length as the reference `ref`.
+"""
+split(t::Tuple, ref::ReferenceBack) = _splitback((), t, ref.t)
+_splitback{N}(out, t::NTuple{N}, ref::NTuple{N}) = out, t
+_splitback(out, ::Tuple{}, ref) =
+    (@_noinline_meta; throw(DimensionMismatch("back reference had $(length(ref)) elements, but input had only $(length(out))")))
+_splitback(out, t, ref) =
+    (@_inline_meta; _splitback((out..., t[1]), tail(t), ref))
+
 ## mapping ##
 
 """

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -231,3 +231,6 @@ end
 @test Tuple{Int,Vararg{Any}}(Float64[1,2,3]) === (1, 2.0, 3.0)
 @test Tuple(ones(5)) === (1.0,1.0,1.0,1.0,1.0)
 @test_throws MethodError convert(Tuple, ones(5))
+
+@test @inferred(split((1,2,3), ReferenceFront((5,5)))) === ((1,2), (3,))
+@test @inferred(split((1,2,3), ReferenceBack((5,5))))  === ((1,), (2,3))


### PR DESCRIPTION
Fancy indexing almost invariably involves manipulation of tuples. Currently we either force users to exploit the unexported `Base.tail` and `Base.front`, or isolate type-unstable code in separate functions using `@noinline`. This proposes the following syntax:
```julia
t = (1,2,3)
rf = ReferenceFront((5,5))
front, back = split(t, rf)  # front == (1,2), back == (3,) (front has the same length as the reference)
rb = ReferenceBack((5,5))
front, back = split(t, rb)  # front == (1,), back == (2,3) (back has the same length as the reference)
```
It uses a reference-tuple to make the output inferrable. These operations are composable to implement all sorts of fancy indexing. For example, if you want to perform an operation along dimension `d`, and you have a "reference slice index" `ipost` for dimensions `d+1, ..., n`, then
```julia
indstmp, indsback = split(indices(A), ReferenceBack(ipost))
indsfront, indsd = split(indstmp, ReferenceBack((true,))
```
will allow iteration
```julia
for i in indsd
    for ipre in CartesianRange(indsfront)
        # do something with A[ipre, i, ipost]
    end
end
```

This is incomplete (I'd add support for `CartesianIndex` and `CartesianRange`). If folks like this or something similar to it, perhaps the central question is whether one should throw an error if the tuple is shorter than the reference, or whether we should return what's available so that `t == (front..., back...)`.
