### PR TITLE
Optional module argument to `@eval` passed to `eval`

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1306,7 +1306,7 @@ end
 """
 `Base.LineEdit.tabwidth` controls the presumed tab width of code pasted into the REPL.
 
-You can modify it by doing `eval(Base.LineEdit, :(tabwidth = 4))`, for example.
+You can modify it by doing `@eval Base.LineEdit tabwidth = 4`, for example.
 
 Must satisfy `0 < tabwidth <= 16`.
 """

--- a/base/client.jl
+++ b/base/client.jl
@@ -360,7 +360,7 @@ function __atreplinit(repl)
         end
     end
 end
-_atreplinit(repl) = eval(Main, :($__atreplinit($repl)))
+_atreplinit(repl) = @eval Main $__atreplinit($repl)
 
 function _start()
     empty!(ARGS)

--- a/base/clusterserialize.jl
+++ b/base/clusterserialize.jl
@@ -136,9 +136,9 @@ function deserialize_global_from_main(s::ClusterSerializer, sym)
     sym_isconst = deserialize(s)
     v = deserialize(s)
     if sym_isconst
-        eval(Main, :(const $sym = $v))
+        @eval Main const $sym = $v
     else
-        eval(Main, :($sym = $v))
+        @eval Main $sym = $v
     end
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -249,7 +249,7 @@ for f in ( :acos_fast, :acosh_fast, :angle_fast, :asin_fast, :asinh_fast,
             :cosh_fast, :exp10_fast, :exp2_fast, :exp_fast, :expm1_fast,
             :lgamma_fast, :log10_fast, :log1p_fast, :log2_fast, :log_fast,
             :sin_fast, :sinh_fast, :sqrt_fast, :tan_fast, :tanh_fast )
-    eval(FastMath, :(Base.@dep_vectorize_1arg Number $f))
+    @eval FastMath Base.@dep_vectorize_1arg Number $f
 end
 for f in (
         :invdigamma, # base/special/gamma.jl
@@ -265,7 +265,7 @@ end
 @dep_vectorize_1arg Complex float
 # base/dates/*.jl
 for f in (:unix2datetime, :rata2datetime, :julian2datetime)  # base/dates/conversions.jl
-    eval(Dates, :(Base.@dep_vectorize_1arg Real $f))
+    @eval Dates Base.@dep_vectorize_1arg Real $f
 end
 for f in (
         # base/dates/accessors.jl
@@ -279,15 +279,15 @@ for f in (
         :daysofweekinmonth, :monthname, :monthabbr, :daysinmonth,
         :isleapyear, :dayofyear, :daysinyear, :quarterofyear, :dayofquarter,
     )
-    eval(Dates, :(Base.@dep_vectorize_1arg Dates.TimeType $f))
+    @eval Dates Base.@dep_vectorize_1arg Dates.TimeType $f
 end
 for f in (
     :hour, :minute, :second, :millisecond, # base/dates/accessors.jl
     :Date, :datetime2unix, :datetime2rata, :datetime2julian, # base/dates/conversions.jl
     )
-    eval(Dates, :(Base.@dep_vectorize_1arg Dates.DateTime $f))
+    @eval Dates Base.@dep_vectorize_1arg Dates.DateTime $f
 end
-eval(Dates, :(Base.@dep_vectorize_1arg Dates.Date Datetime)) # base/dates/conversions.jl
+@eval Dates Base.@dep_vectorize_1arg Dates.Date Datetime # base/dates/conversions.jl
 
 # Deprecate @vectorize_2arg-vectorized functions from...
 for f in (
@@ -304,7 +304,7 @@ for f in (
 end
 # base/fastmath.jl
 for f in (:pow_fast, :atan2_fast, :hypot_fast, :max_fast, :min_fast, :minmax_fast)
-    eval(FastMath, :(Base.@dep_vectorize_2arg Number $f))
+    @eval FastMath Base.@dep_vectorize_2arg Number $f
 end
 for f in (
         :max, :min, # base/math.jl
@@ -356,14 +356,14 @@ end
 @deprecate abs(x::AbstractSparseVector) abs.(x)
 
 # Deprecate @textmime into the Multimedia module, #18441
-eval(Multimedia, :(macro textmime(mime)
+@eval Multimedia macro textmime(mime)
     Base.depwarn(string("`@textmime \"mime\"` is deprecated; use ",
         "`Base.Multimedia.istextmime(::MIME\"mime\") = true` instead"
         ), :textmime)
     quote
         Base.Multimedia.istextmime(::MIME{$(Meta.quot(Symbol(mime)))}) = true
     end
-end))
+end
 
 @deprecate ipermutedims(A::AbstractArray,p) permutedims(A, invperm(p))
 
@@ -436,7 +436,7 @@ function reduced_dims0(a::AbstractArray, region)
 end
 
 # #18218
-eval(Base.LinAlg, quote
+@eval Base.LinAlg begin
     function arithtype(T)
         Base.depwarn(string("arithtype is now deprecated. If you were using it inside a ",
             "promote_op call, use promote_op(LinAlg.matprod, Ts...) instead. Otherwise, ",
@@ -451,7 +451,7 @@ eval(Base.LinAlg, quote
             :arithtype)
         Int
     end
-end)
+end
 
 # #19246
 @deprecate den denominator
@@ -464,7 +464,7 @@ Filesystem.stop_watching(stream::Filesystem._FDWatcher) = depwarn("stop_watching
 @deprecate takebuf_string(b) String(take!(b))
 
 # #19288
-eval(Base.Dates, quote
+@eval Base.Dates begin
     function recur{T<:TimeType}(fun::Function, dr::StepRange{T}; negate::Bool=false, limit::Int=10000)
         Base.depwarn("Dates.recur is deprecated, use filter instead.",:recur)
         if negate
@@ -474,7 +474,7 @@ eval(Base.Dates, quote
         end
      end
      recur{T<:TimeType}(fun::Function, start::T, stop::T; step::Period=Day(1), negate::Bool=false, limit::Int=10000) = recur(fun, start:step:stop; negate=negate)
-end)
+end
 
 # Index conversions revamp; #19730
 function getindex(A::LogicalIndex, i::Int)
@@ -651,13 +651,15 @@ function _depwarn_bczpres!(f, args...)
     depwarn(_depstring_bczpres(), :broadcast_zpreserving!)
     return _broadcast_zpreserving!(f, args...)
 end
-eval(SparseArrays, :(broadcast_zpreserving(f, args...) = Base._depwarn_bczpres(f, args...)))
-eval(SparseArrays, :(broadcast_zpreserving(f, A::SparseMatrixCSC, B::SparseMatrixCSC) = Base._depwarn_bczpres(f, A, B)))
-eval(SparseArrays, :(broadcast_zpreserving(f, A::SparseMatrixCSC, B::Union{Array,BitArray,Number}) = Base._depwarn_bczpres(f, A, B)))
-eval(SparseArrays, :(broadcast_zpreserving(f, A::Union{Array,BitArray,Number}, B::SparseMatrixCSC) = Base._depwarn_bczpres(f, A, B)))
-eval(SparseArrays, :(broadcast_zpreserving!(f, args...) = Base._depwarn_bczpres!(f, args...)))
-eval(SparseArrays, :(broadcast_zpreserving!(f, C::SparseMatrixCSC, A::SparseMatrixCSC, B::Union{Array,BitArray,Number}) = Base._depwarn_bczpres!(f, C, A, B)))
-eval(SparseArrays, :(broadcast_zpreserving!(f, C::SparseMatrixCSC, A::Union{Array,BitArray,Number}, B::SparseMatrixCSC) = Base._depwarn_bczpres!(f, C, A, B)))
+@eval SparseArrays begin
+    broadcast_zpreserving(f, args...) = Base._depwarn_bczpres(f, args...)
+    broadcast_zpreserving(f, A::SparseMatrixCSC, B::SparseMatrixCSC) = Base._depwarn_bczpres(f, A, B)
+    broadcast_zpreserving(f, A::SparseMatrixCSC, B::Union{Array,BitArray,Number}) = Base._depwarn_bczpres(f, A, B)
+    broadcast_zpreserving(f, A::Union{Array,BitArray,Number}, B::SparseMatrixCSC) = Base._depwarn_bczpres(f, A, B)
+    broadcast_zpreserving!(f, args...) = Base._depwarn_bczpres!(f, args...)
+    broadcast_zpreserving!(f, C::SparseMatrixCSC, A::SparseMatrixCSC, B::Union{Array,BitArray,Number}) = Base._depwarn_bczpres!(f, C, A, B)
+    broadcast_zpreserving!(f, C::SparseMatrixCSC, A::Union{Array,BitArray,Number}, B::SparseMatrixCSC) = Base._depwarn_bczpres!(f, C, A, B)
+end
 
 # #19719
 @deprecate getindex(t::Tuple, r::AbstractArray)       getindex(t, vec(r))
@@ -1026,7 +1028,7 @@ iteratoreltype(::Type{Task}) = EltypeUnknown()
 
 isempty(::Task) = error("isempty not defined for Tasks")
 
-eval(Base.Test, quote
+@eval Base.Test begin
     approx_full(x::AbstractArray) = x
     approx_full(x::Number) = x
     approx_full(x) = full(x)
@@ -1091,7 +1093,7 @@ eval(Base.Test, quote
         :(test_approx_eq($(esc(a)), $(esc(b)), $(string(a)), $(string(b))))
     end
     export @test_approx_eq
-end)
+end
 
 # Deprecate partial linear indexing
 function partial_linear_indexing_warning_lookup(nidxs_remaining)
@@ -1158,12 +1160,10 @@ end
 end
 
 # Not exported
-eval(LibGit2, quote
-    function owner(x)
-        Base.depwarn("owner(x) is deprecated, use repository(x) instead.", :owner)
-        repository(x)
-    end
-end)
+@eval LibGit2 function owner(x)
+    Base.depwarn("owner(x) is deprecated, use repository(x) instead.", :owner)
+    repository(x)
+end
 
 @deprecate EachLine(stream, ondone) EachLine(stream, ondone=ondone)
 
@@ -1181,7 +1181,7 @@ function colon{T<:Dates.Period}(start::T, stop::T)
 end
 
 # LibGit2 refactor (#19839)
-eval(Base.LibGit2, quote
+@eval Base.LibGit2 begin
      Base.@deprecate_binding Oid GitHash
      Base.@deprecate_binding GitAnyObject GitUnknownObject
 
@@ -1191,23 +1191,21 @@ eval(Base.LibGit2, quote
      @deprecate revparse(repo::GitRepo, objname::AbstractString) GitObject(repo, objname) false
      @deprecate object(repo::GitRepo, te::GitTreeEntry) GitObject(repo, te) false
      @deprecate commit(ann::GitAnnotated) GitHash(ann) false
-end)
+end
 
 # when this deprecation is deleted, remove all calls to it, and all
 # negate=nothing keyword arguments, from base/dates/adjusters.jl
-eval(Dates, quote
-    function deprecate_negate(f, func, sig, negate)
-        if negate === nothing
-            return func
-        else
-            msg = "$f($sig; negate=$negate) is deprecated, use $f("
-            negate && (msg *= "!")
-            msg *= "$sig) instead."
-            Base.depwarn(msg, f)
-            return negate ? !func : func
-        end
+@eval Dates function deprecate_negate(f, func, sig, negate)
+    if negate === nothing
+        return func
+    else
+        msg = "$f($sig; negate=$negate) is deprecated, use $f("
+        negate && (msg *= "!")
+        msg *= "$sig) instead."
+        Base.depwarn(msg, f)
+        return negate ? !func : func
     end
-end)
+end
 
 # FloatRange replaced by StepRangeLen
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -109,12 +109,16 @@ evaluates expressions in that module.
 Core.eval
 
 """
-    @eval
+    @eval [m,] ex
 
-Evaluate an expression and return the value.
+Evaluate an expression with values interpolated into it using `eval`.
+If two arguments are provided, the first is the module to evaluate in.
 """
 macro eval(x)
     :($(esc(:eval))($(Expr(:quote,x))))
+end
+macro eval(m, x)
+    :($(esc(:eval))($(esc(m)),$(Expr(:quote,x))))
 end
 
 """

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -109,16 +109,16 @@ evaluates expressions in that module.
 Core.eval
 
 """
-    @eval [m,] ex
+    @eval [mod,] ex
 
 Evaluate an expression with values interpolated into it using `eval`.
 If two arguments are provided, the first is the module to evaluate in.
 """
-macro eval(x)
-    :($(esc(:eval))($(Expr(:quote,x))))
+macro eval(ex)
+    :(eval($(current_module()), $(Expr(:quote,ex))))
 end
-macro eval(m, x)
-    :($(esc(:eval))($(esc(m)),$(Expr(:quote,x))))
+macro eval(mod, ex)
+    :(eval($(esc(mod)), $(Expr(:quote,ex))))
 end
 
 """

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -2371,4 +2371,4 @@ clear!(sym::Symbol, pids=workers(); mod=Main) = clear!([sym], pids; mod=mod)
 clear!(syms, pid::Int; mod=Main) = clear!(syms, [pid]; mod=mod)
 
 clear_impl!(syms, mod::Module) = foreach(x->clear_impl!(x,mod), syms)
-clear_impl!(sym::Symbol, mod::Module) = isdefined(mod, sym) && eval(mod, :(global $sym = nothing))
+clear_impl!(sym::Symbol, mod::Module) = isdefined(mod, sym) && @eval(mod, global $sym = nothing)

--- a/base/test.jl
+++ b/base/test.jl
@@ -420,7 +420,7 @@ macro test_warn(msg, expr)
     quote
         let fname = tempname(), have_color = Base.have_color
             try
-                eval(Base, :(have_color = false))
+                @eval Base have_color = false
                 ret = open(fname, "w") do f
                     redirect_stderr(f) do
                         $(esc(expr))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1136,7 +1136,7 @@ A = [[i i; i i] for i=1:2]
 @test cumsum(A) == Any[[1 1; 1 1], [3 3; 3 3]]
 @test cumprod(A) == Any[[1 1; 1 1], [4 4; 4 4]]
 
-isdefined(Main, :TestHelpers) || eval(Main, :(include("TestHelpers.jl")))
+isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using TestHelpers.OAs
 
 @testset "prepend/append" begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -179,7 +179,7 @@ type Circ_{T} x::Circ_{T} end
 
 abstract Sup2a_
 abstract Sup2b_{A <: Sup2a_, B} <: Sup2a_
-@test_throws ErrorException eval(:(abstract Qux2_{T} <: Sup2b_{Qux2_{Int}, T})) # wrapped in eval to avoid #16793
+@test_throws ErrorException @eval abstract Qux2_{T} <: Sup2b_{Qux2_{Int}, T} # wrapped in eval to avoid #16793
 
 # issue #3890
 type A3890{T1}
@@ -3351,7 +3351,7 @@ macro m8846(a, b=0)
 end
 @test @m8846(a) === (:a, 0)
 @test @m8846(a,1) === (:a, 1)
-@test_throws MethodError eval(:(@m8846(a,b,c)))
+@test_throws MethodError @eval @m8846(a,b,c)
 
 # a simple case of parametric dispatch with unions
 let foo{T}(x::Union{T,Void},y::Union{T,Void}) = 1
@@ -3420,7 +3420,7 @@ end
 @test_throws UndefVarError @M6846.f()
 
 # issue #14758
-@test isa(eval(:(f14758(; $([]...)) = ())), Function)
+@test isa(@eval(f14758(; $([]...)) = ()), Function)
 
 # issue #14767
 @inline f14767(x) = x ? A14767 : ()
@@ -4575,15 +4575,15 @@ end
 @test M14893.f14893() == 14893
 
 # issue #18725
-@test_nowarn eval(Main, :(begin
+@test_nowarn @eval Main begin
     f18725(x) = 1
     f18725(x) = 2
-end))
+end
 @test Main.f18725(0) == 2
-@test_warn "WARNING: Method definition f18725(Any) in module Module18725" eval(Main, :(module Module18725
+@test_warn "WARNING: Method definition f18725(Any) in module Module18725" @eval Main module Module18725
     f18725(x) = 1
     f18725(x) = 2
-end))
+end
 
 # issue #19599
 f19599{T}(x::((S)->Vector{S})(T)...) = 1

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -915,11 +915,11 @@ end
 
 let save_color = Base.have_color
     try
-        eval(Base, :(have_color = false))
+        @eval Base have_color = false
         @test sprint(Base.Docs.repl_latex, "√") == "\"√\" can be typed by \\sqrt<tab>\n\n"
         @test sprint(Base.Docs.repl_latex, "x̂₂") == "\"x̂₂\" can be typed by x\\hat<tab>\\_2<tab>\n\n"
     finally
-        eval(Base, :(have_color = $save_color))
+        @eval Base have_color = $save_color
     end
 end
 

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -235,10 +235,10 @@ let opts = (:a=>3, :b=>4)
 end
 
 # pr #18396, kwargs before Base is defined
-eval(Core.Inference, quote
+@eval Core.Inference begin
     f18396(;kwargs...) = g18396(;kwargs...)
     g18396(;x=1,y=2) = x+y
-end)
+end
 @test Core.Inference.f18396() == 3
 
 # issue #7045, `invoke` with keyword args

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-isdefined(Main, :TestHelpers) || eval(Main, :(include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))))
+isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using TestHelpers
 
 const LIBGIT2_MIN_VER = v"0.23.0"

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 using Base.LineEdit
-isdefined(Main, :TestHelpers) || eval(Main, :(include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))))
+isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using TestHelpers
 
 function run_test(d,buf)

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -140,3 +140,15 @@ show_sexpr(ioB,:(1+1))
 show_sexpr(ioB,QuoteNode(1),1)
 
 end
+
+# test base/expr.jl
+baremodule B
+    eval = 0
+    x = 1
+    module M; x = 2; end
+    import Base
+    @Base.eval x = 3
+    @Base.eval M x = 4
+end
+@test B.x == 3
+@test B.M.x == 4

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -563,12 +563,12 @@ end
 let
     old_have_color = Base.have_color
     try
-        eval(Base, :(have_color = true))
+        @eval Base have_color = true
         buf = IOBuffer()
         print_with_color(:red, buf, "foo")
         @test startswith(String(take!(buf)), Base.text_colors[:red])
     finally
-        eval(Base, :(have_color = $(old_have_color)))
+        @eval Base have_color = $(old_have_color)
     end
 end
 
@@ -585,7 +585,7 @@ end
 let
     old_have_color = Base.have_color
     try
-        eval(Base, :(have_color = true))
+        @eval Base have_color = true
         buf = IOBuffer()
         print_with_color(:red, buf, "foo")
         # Check that we get back to normal text color in the end
@@ -595,7 +595,7 @@ let
         print_with_color(:red, buf, "foo"; bold = true)
         @test String(take!(buf)) == "\e[1m\e[31mfoo\e[39m\e[22m"
     finally
-        eval(Base, :(have_color = $(old_have_color)))
+        @eval Base have_color = $(old_have_color)
     end
 end
 

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-isdefined(Main, :TestHelpers) || eval(Main, :(include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))))
+isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using TestHelpers.OAs
 
 const OAs_name = join(fullname(OAs), ".")

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -5,7 +5,7 @@ const curmod_name = fullname(curmod)
 const curmod_prefix = "$(["$m." for m in curmod_name]...)"
 
 # REPL tests
-isdefined(Main, :TestHelpers) || eval(Main, :(include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))))
+isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using TestHelpers
 import Base: REPL, LineEdit
 
@@ -540,7 +540,7 @@ end # let exename
 # issue #19864:
 type Error19864 <: Exception; end
 function test19864()
-    eval(current_module(), :(Base.showerror(io::IO, e::Error19864) = print(io, "correct19864")))
+    @eval current_module() Base.showerror(io::IO, e::Error19864) = print(io, "correct19864")
     buf = IOBuffer()
     REPL.print_response(buf, Error19864(), [], false, false, nothing)
     return String(take!(buf))
@@ -566,7 +566,7 @@ function test_replinit()
     slot = Ref(false)
     # Create a closure from a newer world to check if `_atreplinit`
     # can run it correctly
-    atreplinit(eval(:(repl::Base.REPL.LineEditREPL->($slot[] = true))))
+    atreplinit(@eval(repl::Base.REPL.LineEditREPL->($slot[] = true)))
     Base._atreplinit(repl)
     @test slot[]
     @test_throws MethodError Base.repl_hooks[1](repl)

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -6,11 +6,11 @@ function runtests(name, isolate=true)
     try
         if isolate
             mod_name = Symbol("TestMain_", replace(name, '/', '_'))
-            m = eval(Main, :(module $mod_name end))
+            m = @eval(Main, module $mod_name end)
         else
             m = Main
         end
-        eval(m, :(using Base.Test))
+        @eval(m, using Base.Test)
         ex = quote
             @timed @testset $"$name" begin
                 include($"$name.jl")

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -144,7 +144,7 @@ end
 
 @threads for i in 1:100
     for j in 1:100
-        eval(M14726, :(module_var14726 = $j))
+        @eval M14726 module_var14726 = $j
     end
 end
 @test isdefined(:orig_curmodule14726)


### PR DESCRIPTION
Useful for evaluating definitions in modules, which is especially handy now that #265 is fixed, e.g.:

```jl
julia> @eval Base function f(args...)
    # ...
end
```

Much nicer since you can paste the definition and just hit enter.