### PR TITLE
fix function syntax using both `where` and return type

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -954,7 +954,7 @@
          (where (if (and (pair? name) (eq? (car name) 'where))
                     (let ((w (flatten-where-expr name)))
                       (begin0 (cddr w)
-                              (if (not (and (pair? (cadr w)) (eq? (caadr w) 'call)))
+                              (if (not (and (pair? (cadr w)) (memq (caadr w) '(call |::|))))
                                   (error (string "invalid assignment location \"" (deparse name) "\"")))
                               (set! name (cadr w))))
                     #f))
@@ -1000,7 +1000,8 @@
                                #f name)))
              (expand-forms
               (method-def-expr name sparams argl (caddr e) isstaged rett))))
-          (else e))))
+          (else
+           (error (string "invalid assignment location \"" (deparse name) "\""))))))
 
 ;; handle ( )->( ) function expressions. blocks `(a;b=1)` on the left need to be
 ;; converted to argument lists with kwargs.
@@ -3553,7 +3554,7 @@ f(x) = yt(x)
             ((...)
              (error "\"...\" expression outside call"))
             (else
-             (error (string "unhandled expr " e))))))
+             (error (string "invalid syntax " (deparse e)))))))
     ;; introduce new slots for assigned arguments
     (for-each (lambda (v)
                 (if (vinfo:asgn v)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4179,6 +4179,13 @@ function f17613_2(x)::Float64
 end
 @test isa(f17613_2(1), Float64)
 
+# return type decl with `where`
+function where1090(x::Array{T})::T where T<:Real
+    return x[1] + 2.0
+end
+@test where1090([4]) === 6
+@test_throws MethodError where1090(String[])
+
 type A1090 end
 Base.convert(::Type{Int}, ::A1090) = "hey"
 f1090()::Int = A1090()


### PR DESCRIPTION
`function f(x::T)::T where T` already parsed how we want but hit a small hiccup in lowering. Fixed, along with #20172.