### PR TITLE
Make .= work for arrays of arrays by returning a view from Base.dotview

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -507,6 +507,6 @@ end
 
 Base.@propagate_inbounds dotview(args...) = getindex(args...)
 Base.@propagate_inbounds dotview(A::AbstractArray, args...) = view(A, args...)
-Base.@propagate_inbounds dotview{T<:AbstractArray}(A::AbstractArray{T}, args...) = getindex(A, args...)
+Base.@propagate_inbounds dotview{T<:AbstractArray}(A::AbstractArray{T}, args::Integer...) = getindex(A, args...)
 
 end # module

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -458,3 +458,9 @@ let N = 5
     @test iszero(ones(N, N) .= zeros(1, N))
     @test iszero(ones(N, N) .= zeros(1, 1))
 end
+
+@testset "test broadcast for matrix of matrices" begin
+    A = fill(zeros(2,2), 4, 4)
+    A[1:3,1:3] .= [ones(2,2)]
+    @test all(A[1:3,1:3] .== [ones(2,2)])
+end


### PR DESCRIPTION
This was motivated by the example I've added as a test. This also changes the behavior of `a[1] .=` when the left-hand side is an array of arrays as can be seen from the tests I've commented out. I'm not sure about the behavior in this case. Part of me can see the point in the old behavior and part of me thinks it is wrong to let the broadcast behavior go one level down in the scalar case instead of considering the element a unit. One idea was I had was to restrict the definition I've now removed to
```julia
dotview{T<:AbstractArray}(A::AbstractArray{T}, args::Integer...) = getindex(A, args...)
```
but this wouldn't be correct for arrays with custom indices. Alternatively, I wondered if `(a[1]) .=` should parse differently such that the `getindex` is applied before the `broadcast!`.