### PR TITLE
Ensure range-indexing LinSpace returns LinSpace (fixes #20380)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -532,7 +532,7 @@ function getindex{T<:Integer}(r::LinSpace, s::OrdinalRange{T})
     @boundscheck checkbounds(r, s)
     vfirst = unsafe_getindex(r, first(s))
     vlast  = unsafe_getindex(r, last(s))
-    return linspace(vfirst, vlast, length(s))
+    return LinSpace(vfirst, vlast, length(s))
 end
 
 show(io::IO, r::Range) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -390,6 +390,10 @@ for T = (Float32, Float64)
     end
 end
 
+# issue #20380
+r = LinSpace(1,4,4)
+@test isa(r[1:4], LinSpace)
+
 # linspace with 1 or 0 elements (whose step length is NaN)
 @test issorted(linspace(1,1,0))
 @test issorted(linspace(1,1,1))


### PR DESCRIPTION
aka, try using the shift key sometimes, so it doesn't feel so neglected