### PR TITLE
Remove the .postboot field of JLOptions

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -288,10 +288,6 @@ function process_options(opts::JLOptions)
             println()
             break
         end
-        # eval expression but don't disable interactive mode
-        if opts.postboot != C_NULL
-            eval(Main, parse_input_line(unsafe_string(opts.postboot)))
-        end
         # load file
         if !isempty(ARGS) && !isempty(ARGS[1])
             # program

--- a/base/options.jl
+++ b/base/options.jl
@@ -7,7 +7,6 @@ immutable JLOptions
     julia_bin::Ptr{UInt8}
     eval::Ptr{UInt8}
     print::Ptr{UInt8}
-    postboot::Ptr{UInt8}
     load::Ptr{UInt8}
     image_file::Ptr{UInt8}
     cpu_target::Ptr{UInt8}

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -38,7 +38,6 @@ jl_options_t jl_options = { 0,    // quiet
                             NULL, // julia_bin
                             NULL, // eval
                             NULL, // print
-                            NULL, // post-boot
                             NULL, // load
                             NULL, // image_file (will be filled in below)
                             NULL, // cpu_target ("native", "core2", etc...)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1673,7 +1673,6 @@ typedef struct {
     const char *julia_bin;
     const char *eval;
     const char *print;
-    const char *postboot;
     const char *load;
     const char *image_file;
     const char *cpu_target;


### PR DESCRIPTION
This is no longer used now that the -P option is gone.