### PR TITLE
add count(itr) and throw and error in count if non-boolean values are encountered

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -161,6 +161,8 @@ This section lists changes that do not have deprecation warnings.
       that internally uses twice-precision arithmetic.  These two
       outcomes exhibit differences in both precision and speed.
 
+  * The `count` function no longer sums non-boolean values ([#20404])
+
 Library improvements
 --------------------
 
@@ -230,6 +232,8 @@ Library improvements
     `false` (in the case of `all`) value is found, and `mapreduce` will visit all members of the iterable.
 
   * Additional methods for `ones` and `zeros` functions to support the same signature as the `similar` function ([#19635]).
+
+  * `count` now has a `count(itr)` method equivalent to `count(identity, itr)` ([#20403]).
 
   * Methods for `map` and `filter` with `Nullable` arguments have been
     implemented; the semantics are as if the `Nullable` were a container with

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1575,6 +1575,7 @@ function countnz(B::BitArray)
     end
     return n
 end
+count(B::BitArray) = countnz(B)
 
 # returns the index of the next non-zero element, or 0 if all zeros
 function findnext(B::BitArray, start::Integer)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -662,7 +662,7 @@ end
 start(t::ImmutableDict) = t
 next{K,V}(::ImmutableDict{K,V}, t) = (Pair{K,V}(t.key, t.value), t.parent)
 done(::ImmutableDict, t) = !isdefined(t, :parent)
-length(t::ImmutableDict) = count(x->1, t)
+length(t::ImmutableDict) = count(x->true, t)
 isempty(t::ImmutableDict) = done(t, start(t))
 function similar(t::ImmutableDict)
     while isdefined(t, :parent)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -642,21 +642,35 @@ end
 
 """
     count(p, itr) -> Integer
+    count(itr) -> Integer
 
 Count the number of elements in `itr` for which predicate `p` returns `true`.
+If `p` is omitted, counts the number of `true` elements in `itr` (which
+should be a collection of boolean values).
 
 ```jldoctest
 julia> count(i->(4<=i<=6), [2,3,4,5,6])
+3
+
+julia> count([true, false, true, true])
 3
 ```
 """
 function count(pred, itr)
     n = 0
     for x in itr
-        n += pred(x)
+        n += pred(x)::Bool
     end
     return n
 end
+function count(pred, a::AbstractArray)
+    n = 0
+    for i in eachindex(a)
+        @inbounds n += pred(a[i])::Bool
+    end
+    return n
+end
+count(itr) = count(identity, itr)
 
 """
     countnz(A) -> Integer

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -44,6 +44,7 @@ julia> nnz(A)
 """
 nnz(S::SparseMatrixCSC) = Int(S.colptr[end]-1)
 countnz(S::SparseMatrixCSC) = countnz(S.nzval)
+count(S::SparseMatrixCSC) = count(S.nzval)
 
 """
     nonzeros(A)

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -31,6 +31,7 @@ length(x::SparseVector) = x.n
 size(x::SparseVector) = (x.n,)
 nnz(x::SparseVector) = length(x.nzval)
 countnz(x::SparseVector) = countnz(x.nzval)
+count(x::SparseVector) = count(x.nzval)
 nonzeros(x::SparseVector) = x.nzval
 nonzeroinds(x::SparseVector) = x.nzind
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -260,8 +260,18 @@ immutable SomeFunctor end
 
 # count & countnz
 
-@test count(x->x>0, Int[]) == 0
-@test count(x->x>0, -3:5) == 5
+@test count(x->x>0, Int[]) == count(Bool[]) == 0
+@test count(x->x>0, -3:5) == count((-3:5) .> 0) == 5
+@test count([true, true, false, true]) == count(BitVector([true, true, false, true])) == 3
+@test_throws TypeError count(sqrt, [1])
+@test_throws TypeError count([1])
+let itr = (x for x in 1:10 if x < 7)
+    @test count(iseven, itr) == 3
+    @test_throws TypeError count(itr)
+    @test_throws TypeError count(sqrt, itr)
+end
+@test count(iseven(x) for x in 1:10 if x < 7) == 3
+@test count(iseven(x) for x in 1:10 if x < -7) == 0
 
 @test countnz(Int[]) == 0
 @test countnz(Int[0]) == 0

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -806,6 +806,7 @@ end
     FI = Array(I)
     @test sparse(FS[FI]) == S[I] == S[FI]
     @test sum(S[FI]) + sum(S[!FI]) == sum(S)
+    @test countnz(I) == count(I)
 
     sumS1 = sum(S)
     sumFI = sum(S[FI])

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -26,6 +26,8 @@ let x = spv_x1
     @test nonzeros(x) == [1.25, -0.75, 3.5]
 end
 
+@test count(SparseVector(8, [2, 5, 6], [true,false,true])) == 2
+
 # full
 
 for (x, xf) in [(spv_x1, x1_full)]


### PR DESCRIPTION
Fixes #20403 and #20404.  Since changing `countnz` was controversial, I left that function alone.