### PR TITLE
Include deprecated methods for vector * matrix

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1222,6 +1222,16 @@ for name in ("alnum", "alpha", "cntrl", "digit", "number", "graph",
     @eval @deprecate ($f)(s::AbstractString) all($f, s)
 end
 
+# Vector-matrix multiplication deprecated in favor of vector-rowvector multiplication (outer product)
+function *(A::AbstractVector, B::AbstractMatrix)
+    depwarn("Vector-matrix multiplication `v*M` is being deprecated in favor of broadcasting `v.*M`, or else use the vector-rowvector (outer) product `v1*v2'`", :*)
+    if size(B,1) != 1
+        throw(DimensionMismatch(""))
+    end
+    reshape(A, (size(A,1), 1)) * B
+end
+
+
 # END 0.6 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -260,11 +260,11 @@ end
 
 @inline A_mul_Bt(D::Diagonal, rowvec::RowVector) = D*transpose(rowvec)
 
-At_mul_B(rowvec::RowVector, ::Diagonal) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+At_mul_B(rowvec::RowVector, d::Diagonal) = transpose(rowvec) * d # deprecated
 
 @inline A_mul_Bc(D::Diagonal, rowvec::RowVector) = D*ctranspose(rowvec)
 
-Ac_mul_B(rowvec::RowVector, ::Diagonal) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+Ac_mul_B(rowvec::RowVector, d::Diagonal) = ctranspose(rowvec) * d # deprecated
 
 conj(D::Diagonal) = Diagonal(conj(D.diag))
 transpose(D::Diagonal) = D

--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -154,8 +154,7 @@ end
     sum(@inbounds(return rowvec[i]*vec[i]) for i = 1:length(vec))
 end
 @inline *(rowvec::RowVector, mat::AbstractMatrix) = transpose(mat.' * transpose(rowvec))
-*(vec::AbstractVector, mat::AbstractMatrix) = throw(DimensionMismatch(
-    "Cannot left-multiply a matrix by a vector")) # Should become a deprecation
+#*(vec::AbstractVector, mat::AbstractMatrix) is deprecated
 *(::RowVector, ::RowVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))
 @inline *(vec::AbstractVector, rowvec::RowVector) = vec .* rowvec
 *(vec::AbstractVector, rowvec::AbstractVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
@@ -164,16 +163,14 @@ end
 # Transposed forms
 A_mul_Bt(::RowVector, ::AbstractVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))
 @inline A_mul_Bt(rowvec::RowVector, mat::AbstractMatrix) = transpose(mat * transpose(rowvec))
-A_mul_Bt(vec::AbstractVector, mat::AbstractMatrix) = throw(DimensionMismatch(
-    "Cannot left-multiply a matrix by a vector"))
+A_mul_Bt(vec::AbstractVector, mat::AbstractMatrix) = vec * transpose(mat) # deprecated
 @inline A_mul_Bt(rowvec1::RowVector, rowvec2::RowVector) = rowvec1*transpose(rowvec2)
 A_mul_Bt(vec::AbstractVector, rowvec::RowVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
 @inline A_mul_Bt(vec1::AbstractVector, vec2::AbstractVector) = vec1 * transpose(vec2)
 @inline A_mul_Bt(mat::AbstractMatrix, rowvec::RowVector) = mat * transpose(rowvec)
 
 @inline At_mul_Bt(rowvec::RowVector, vec::AbstractVector) = transpose(rowvec) * transpose(vec)
-At_mul_Bt(rowvec::RowVector, mat::AbstractMatrix) = throw(DimensionMismatch(
-    "Cannot left-multiply matrix by vector"))
+At_mul_Bt(rowvec::RowVector, mat::AbstractMatrix) = transpose(rowvec) * transpose(mat) # deprecated
 @inline At_mul_Bt(vec::AbstractVector, mat::AbstractMatrix) = transpose(mat * vec)
 At_mul_Bt(rowvec1::RowVector, rowvec2::RowVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
 @inline At_mul_Bt(vec::AbstractVector, rowvec::RowVector) = transpose(vec)*transpose(rowvec)
@@ -182,8 +179,7 @@ At_mul_Bt(vec::AbstractVector, rowvec::AbstractVector) = throw(DimensionMismatch
 @inline At_mul_Bt(mat::AbstractMatrix, rowvec::RowVector) = mat.' * transpose(rowvec)
 
 At_mul_B(::RowVector, ::AbstractVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
-At_mul_B(rowvec::RowVector, mat::AbstractMatrix) = throw(DimensionMismatch(
-    "Cannot left-multiply matrix by vector"))
+At_mul_B(rowvec::RowVector, mat::AbstractMatrix) = transpose(rowvec) * mat # deprecated
 @inline At_mul_B(vec::AbstractVector, mat::AbstractMatrix) = transpose(At_mul_B(mat,vec))
 @inline At_mul_B(rowvec1::RowVector, rowvec2::RowVector) = transpose(rowvec1) * rowvec2
 At_mul_B(vec::AbstractVector, rowvec::RowVector) = throw(DimensionMismatch(
@@ -197,14 +193,14 @@ At_mul_B(mat::AbstractMatrix, rowvec::RowVector) = throw(DimensionMismatch(
 # Conjugated forms
 A_mul_Bc(::RowVector, ::AbstractVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))
 @inline A_mul_Bc(rowvec::RowVector, mat::AbstractMatrix) = ctranspose(mat * ctranspose(rowvec))
-A_mul_Bc(vec::AbstractVector, mat::AbstractMatrix) = throw(DimensionMismatch("Cannot left-multiply a matrix by a vector"))
+A_mul_Bc(vec::AbstractVector, mat::AbstractMatrix) = vec * ctranspose(mat) # deprecated
 @inline A_mul_Bc(rowvec1::RowVector, rowvec2::RowVector) = rowvec1 * ctranspose(rowvec2)
 A_mul_Bc(vec::AbstractVector, rowvec::RowVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
 @inline A_mul_Bc(vec1::AbstractVector, vec2::AbstractVector) = vec1 * ctranspose(vec2)
 @inline A_mul_Bc(mat::AbstractMatrix, rowvec::RowVector) = mat * ctranspose(rowvec)
 
 @inline Ac_mul_Bc(rowvec::RowVector, vec::AbstractVector) = ctranspose(rowvec) * ctranspose(vec)
-Ac_mul_Bc(rowvec::RowVector, mat::AbstractMatrix) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+Ac_mul_Bc(rowvec::RowVector, mat::AbstractMatrix) = ctranspose(rowvec) * ctranspose(mat) # deprecated
 @inline Ac_mul_Bc(vec::AbstractVector, mat::AbstractMatrix) = ctranspose(mat * vec)
 Ac_mul_Bc(rowvec1::RowVector, rowvec2::RowVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
 @inline Ac_mul_Bc(vec::AbstractVector, rowvec::RowVector) = ctranspose(vec)*ctranspose(rowvec)
@@ -212,7 +208,7 @@ Ac_mul_Bc(vec::AbstractVector, rowvec::AbstractVector) = throw(DimensionMismatch
 @inline Ac_mul_Bc(mat::AbstractMatrix, rowvec::RowVector) = mat' * ctranspose(rowvec)
 
 Ac_mul_B(::RowVector, ::AbstractVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
-Ac_mul_B(rowvec::RowVector, mat::AbstractMatrix) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+Ac_mul_B(rowvec::RowVector, mat::AbstractMatrix) = ctranspose(rowvec) * mat
 @inline Ac_mul_B(vec::AbstractVector, mat::AbstractMatrix) = ctranspose(Ac_mul_B(mat,vec))
 @inline Ac_mul_B(rowvec1::RowVector, rowvec2::RowVector) = ctranspose(rowvec1) * rowvec2
 Ac_mul_B(vec::AbstractVector, rowvec::RowVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1643,19 +1643,19 @@ At_mul_Bt(A::AbstractMatrix, B::AbstractTriangular) = A_mul_Bt(A.', B)
 @inline A_mul_Bt(A::AbstractTriangular, rowvec::RowVector) = A * transpose(rowvec)
 
 @inline At_mul_Bt(A::AbstractTriangular, rowvec::RowVector) = A.' * transpose(rowvec)
-At_mul_Bt(::RowVector, ::AbstractTriangular) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+At_mul_Bt(rowvec::RowVector, A::AbstractTriangular) = transpose(rowvec) * transpose(A) # deprecated
 
 At_mul_B(::AbstractTriangular, ::RowVector) = throw(DimensionMismatch("Cannot right-multiply matrix by transposed vector"))
-At_mul_B(::RowVector, ::AbstractTriangular) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+At_mul_B(rowvec::RowVector, A::AbstractTriangular) = transpose(rowvec) * A # deprecated
 
 @inline A_mul_Bc(rowvec::RowVector, A::AbstractTriangular) = ctranspose(A * ctranspose(rowvec))
 @inline A_mul_Bc(A::AbstractTriangular, rowvec::RowVector) = A * ctranspose(rowvec)
 
 @inline Ac_mul_Bc(A::AbstractTriangular, rowvec::RowVector) = A' * ctranspose(rowvec)
-Ac_mul_Bc(::RowVector, ::AbstractTriangular) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+Ac_mul_Bc(rowvec::RowVector, A::AbstractTriangular) = ctranspose(rowvec) * ctranspose(A) # deprecated
 
 Ac_mul_B(::AbstractTriangular, ::RowVector) = throw(DimensionMismatch("Cannot right-multiply matrix by transposed vector"))
-Ac_mul_B(::RowVector, ::AbstractTriangular) = throw(DimensionMismatch("Cannot left-multiply matrix by vector"))
+Ac_mul_B(rowvec::RowVector, A::AbstractTriangular) = ctranspose(rowvec) * A # deprecated
 
 @inline /(rowvec::RowVector, A::Union{UpperTriangular,LowerTriangular}) = transpose(transpose(A) \ transpose(rowvec))
 @inline /(rowvec::RowVector, A::Union{UnitUpperTriangular,UnitLowerTriangular}) = transpose(transpose(A) \ transpose(rowvec))

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -104,7 +104,7 @@ end
 
     @test (rv*v) === 14
     @test (rv*mat)::RowVector == [1 4 9]
-    @test_throws DimensionMismatch [1]*reshape([1],(1,1)) # no longer permitted
+    @test [1]*reshape([1],(1,1)) == reshape([1], (1,1)) # deprecated
     @test_throws DimensionMismatch rv*rv
     @test (v*rv)::Matrix == [1 2 3; 2 4 6; 3 6 9]
     @test_throws DimensionMismatch v*v # Was previously a missing method error, now an error message
@@ -112,7 +112,7 @@ end
 
     @test_throws DimensionMismatch rv*v.'
     @test (rv*mat.')::RowVector == [1 4 9]
-    @test_throws DimensionMismatch [1]*reshape([1],(1,1)).' # no longer permitted
+    @test [1]*reshape([1],(1,1)).' == reshape([1], (1,1)) # deprecated
     @test rv*rv.' === 14
     @test_throws DimensionMismatch v*rv.'
     @test (v*v.')::Matrix == [1 2 3; 2 4 6; 3 6 9]
@@ -142,7 +142,7 @@ end
 
     @test_throws DimensionMismatch cz*z'
     @test (cz*mat')::RowVector == [-2im 4 9]
-    @test_throws DimensionMismatch [1]*reshape([1],(1,1))' # no longer permitted
+    @test [1]*reshape([1],(1,1))' == reshape([1], (1,1)) # deprecated
     @test cz*cz' === 15 + 0im
     @test_throws DimensionMismatch z*cz'
     @test (z*z')::Matrix == [2 2+2im 3+3im; 2-2im 4 6; 3-3im 6 9]
@@ -217,19 +217,19 @@ end
     @test (ut*rv.')::Vector == [2,6,12]
 
     @test (ut.'*rv.')::Vector == [2,6,12]
-    @test_throws DimensionMismatch rv.'*ut.'
+    @test_throws MethodError rv.'*ut.'
 
     @test_throws DimensionMismatch ut.'*rv
-    @test_throws DimensionMismatch rv.'*ut
+    @test_throws MethodError rv.'*ut
 
     @test (rv*ut')::RowVector == [2 6 12]
     @test (ut*rv')::Vector == [2,6,12]
 
-    @test_throws DimensionMismatch rv'*ut'
+    @test_throws MethodError rv'*ut'
     @test (ut'*rv')::Vector == [2,6,12]
 
     @test_throws DimensionMismatch ut'*rv
-    @test_throws DimensionMismatch rv'*ut
+    @test_throws MethodError rv'*ut
 
     @test (rv/ut)::RowVector ≈ [2/1  3/2  4/3]
     @test (rv/ut.')::RowVector ≈ [2/1  3/2  4/3]


### PR DESCRIPTION
This used to be the outer product but was removed by JuliaLang/julia#19670 in favor of allowing only vector * rowvector as the outer product. It makes much more sense to deprecate this than make it a breaking change.

Please see PR JuliaLang/julia#20423 for the alternative route of restoring this completely, and the discussion for which route to take at issue JuliaLang/LinearAlgebra.jl#400.