### PR TITLE
Make sure flisp.boot is copied to an existing directory.

### DIFF
--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -83,7 +83,7 @@ $(BUILDDIR)/$(EXENAME): $(OBJS) $(LIBFILES_release) $(BUILDDIR)/$(LIBTARGET).a $
 	@$(call PRINT_LINK, $(CCLD) $(SHIPFLAGS) $(LDFLAGS) $(OBJS) $(BUILDDIR)/flmain.o -o $@ $(BUILDDIR)/$(LIBTARGET).a $(LIBFILES_release) $(LIBS) $(OSLIBS))
 
 ifneq ($(BUILDDIR),.)
-$(BUILDDIR)/flisp.boot: flisp.boot
+$(BUILDDIR)/flisp.boot: flisp.boot | $(BUILDDIR)
 	cp $< $@
 endif
 


### PR DESCRIPTION
Had been seeing multiple CI failures after switching my bots to build with `-j8`:

```
make[2]: Entering directory 'julia/src/flisp'
mkdir -p julia/build/src/flisp
make -C ../support BUILDDIR='julia/build/src/support'
cp flisp.boot julia/build/src/flisp/flisp.boot
cp: cannot create regular file ‘julia/build/src/flisp/flisp.boot’: No such file or directory
```

The `mkdir` probably happens at the same time of the `cp`.