### PR TITLE
Fix `summary` for cases of mixed indices-types

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1533,8 +1533,8 @@ dims2string(d::Dims) = isempty(d) ? "0-dimensional" :
 inds2string(inds::Indices) = join(map(string,inds), '×')
 
 # anything array-like gets summarized e.g. 10-element Array{Int64,1}
-summary(a::AbstractArray) = _summary(a, to_shape(indices(a)))
-_summary(a, dims::Dims) = string(dims2string(dims), " ", typeof(a))
+summary(a::AbstractArray) = _summary(a, indices(a))
+_summary(a, inds::Tuple{Vararg{OneTo}}) = string(dims2string(length.(inds)), " ", typeof(a))
 _summary(a, inds) = string(typeof(a), " with indices ", inds2string(inds))
 
 # n-dimensional arrays

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -167,6 +167,9 @@ for n = 0:4
     show(IOContext(io, limit=true), MIME("text/plain"), (a,a))
     @test String(take!(io)) == targets2[n+1]
 end
+P = OffsetArray(rand(8,8), (1,1))
+PV = view(P, 2:3, :)
+@test endswith(summary(PV), "with indices Base.OneTo(2)×2:9")
 
 # Similar
 B = similar(A, Float32)


### PR DESCRIPTION
Fixes the following error:
```julia
julia> using OffsetArrays

julia> A = OffsetArray(rand(8,8), 2:9, 2:9)
OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:9×2:9:
 0.59856   0.434083   0.022313  0.843017   0.662765  0.979731  0.799594   0.546849
 0.823333  0.647455   0.785434  0.518239   0.184666  0.372712  0.421522   0.747545
 0.481929  0.710678   0.850665  0.42117    0.896602  0.456684  0.656202   0.205752
 0.554909  0.688436   0.555525  0.0713352  0.421323  0.733525  0.583583   0.642215
 0.363932  0.497752   0.388032  0.388487   0.919134  0.849249  0.0560365  0.960816
 0.538841  0.191339   0.236292  0.501244   0.87405   0.47807   0.109504   0.494278
 0.514059  0.621262   0.979369  0.958913   0.828713  0.16438   0.284372   0.270563
 0.810203  0.0258329  0.146011  0.345866   0.215814  0.912965  0.433246   0.31008 

julia> V = view(A, 2:3, :)
Error showing value of type SubArray{Float64,2,OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}},Tuple{UnitRange{Int64},Colon},false}:
ERROR: MethodError: no method matching inds2string(::Tuple{Int64,UnitRange{Int64}})
Closest candidates are:
  inds2string(::Tuple{Vararg{AbstractUnitRange,N}}) at show.jl:1485
 in _summary(::SubArray{Float64,2,OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}},Tuple{UnitRange{Int64},Colon},false}, ::Tuple{Int64,UnitRange{Int64}}) at ./show.jl:1490
 in summary(::SubArray{Float64,2,OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}},Tuple{UnitRange{Int64},Colon},false}) at ./show.jl:1488
 in #showarray#330(::Bool, ::Function, ::IOContext{Base.Terminals.TTYTerminal}, ::SubArray{Float64,2,OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}},Tuple{UnitRange{Int64},Colon},false}, ::Bool) at ./show.jl:1599
 in display(::Base.REPL.REPLDisplay{Base.REPL.LineEditREPL}, ::MIME{Symbol("text/plain")}, ::SubArray{Float64,2,OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}},Tuple{UnitRange{Int64},Colon},false}) at ./REPL.jl:132
 in display(::Base.REPL.REPLDisplay{Base.REPL.LineEditREPL}, ::SubArray{Float64,2,OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}},Tuple{UnitRange{Int64},Colon},false}) at ./REPL.jl:135
 in display(::SubArray{Float64,2,OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}},Tuple{UnitRange{Int64},Colon},false}) at ./multimedia.jl:143
 in print_response(::Base.Terminals.TTYTerminal, ::Any, ::Void, ::Bool, ::Bool, ::Void) at ./REPL.jl:154
 in print_response(::Base.REPL.LineEditREPL, ::Any, ::Void, ::Bool, ::Bool) at ./REPL.jl:139
 in (::Base.REPL.##22#23{Bool,Base.REPL.##33#42{Base.REPL.LineEditREPL,Base.REPL.REPLHistoryProvider},Base.REPL.LineEditREPL,Base.LineEdit.Prompt})(::Base.LineEdit.MIState, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Bool) at ./REPL.jl:652
 in run_interface(::Base.Terminals.TTYTerminal, ::Base.LineEdit.ModalInterface) at ./LineEdit.jl:1579
 in run_frontend(::Base.REPL.LineEditREPL, ::Base.REPL.REPLBackendRef) at ./REPL.jl:903
 in run_repl(::Base.REPL.LineEditREPL, ::Base.##942#943) at ./REPL.jl:188
 in _start() at ./client.jl:360
```
