### PR TITLE
a way to enable polly's parallelizer

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -237,6 +237,7 @@ BUILD_LLVM_CLANG := 0
 # see http://lldb.llvm.org/build.html for dependencies
 BUILD_LLDB := 0
 USE_POLLY := 0
+USE_POLLY_OPENMP := 0
 
 # Cross-compile
 #XC_HOST := i686-w64-mingw32

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,6 +57,9 @@ LLVMLINK += -lPolly -lPollyISL
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --src-root)/tools/polly/include
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --obj-root)/tools/polly/include
 FLAGS += -DUSE_POLLY
+ifeq ($(USE_POLLY_OPENMP),1)
+FLAGS += -fopenmp
+endif
 endif
 else
 SRCS += anticodegen

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6418,7 +6418,7 @@ extern "C" void jl_init_codegen(void)
     const char *const argv_copyprop[] = {"", "-disable-copyprop"}; // llvm bug 21743
     cl::ParseCommandLineOptions(sizeof(argv_copyprop)/sizeof(argv_copyprop[0]), argv_copyprop, "disable-copyprop\n");
 #endif
-#ifdef JL_DEBUG_BUILD
+#if defined(JL_DEBUG_BUILD) || defined(USE_POLLY)
     cl::ParseEnvironmentOptions("Julia", "JULIA_LLVM_ARGS");
 #endif
 


### PR DESCRIPTION
The current inclusion of polly is quite bare-bone and mainly oriented towards using the optimizer to increase IPC. This is all well, but I would like to have the possibility to pass arguments to the polly optimization rotines. This way the polly vectorizer can be set and the automatic SMP-mechanism (using OpenMP) can be activated.
The latter needs the `-fopenmp` flag activated.