### PR TITLE
use llvm-config --libs for llvm-library files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -87,7 +87,7 @@ else
 ifeq ($(OS),WINNT)
 LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM-$(LLVM_VER_SHORT)
 else
-LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM-$(shell $(LLVM_CONFIG_HOST) --version)
+LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --libs)
 endif # OS == WINNT
 endif # LLVM_USE_CMAKE == 1
 FLAGS += -DLLVM_SHLIB


### PR DESCRIPTION
The construct `-lLLVM-$(shell $(LLVM_CONFIG_HOST) --version)` is wrong for my install (in Gentoo). While this can be fudge-patched to work, I don't see a reason not to rely on llvm-config. Or is there?