### PR TITLE
Use mbedTLS hostname verification for LibGit2

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -84,7 +84,7 @@ $(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied: $(LIBGIT2_SRC_PATH
 		patch -p1 -f < $(SRCDIR)/patches/libgit2-mbedtls-writer-fix.patch
 	echo 1 > $@
 
-$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied: $(LIBGIT2_SRC_PATH)/source-extracted
+$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied: $(LIBGIT2_SRC_PATH)/source-extracted | $(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied
 	cd $(LIBGIT2_SRC_PATH) && \
 		patch -p1 -f < $(SRCDIR)/patches/libgit2-mbedtls-verify.patch
 	echo 1 > $@

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -84,6 +84,11 @@ $(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied: $(LIBGIT2_SRC_PATH
 		patch -p1 -f < $(SRCDIR)/patches/libgit2-mbedtls-writer-fix.patch
 	echo 1 > $@
 
+$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied: $(LIBGIT2_SRC_PATH)/source-extracted
+	cd $(LIBGIT2_SRC_PATH) && \
+		patch -p1 -f < $(SRCDIR)/patches/libgit2-mbedtls-verify.patch
+	echo 1 > $@
+
 $(build_datarootdir)/julia/cert.pem: $(CERTFILE)
 	mkdir -p $(build_datarootdir)/julia
 	-cp $(CERTFILE) $@
@@ -92,7 +97,8 @@ $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: \
 	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-ssh.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-agent-nonfatal.patch-applied \
-	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied
+	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied \
+	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied
 
 ifneq ($(CERTFILE),)
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: $(build_datarootdir)/julia/cert.pem

--- a/deps/patches/libgit2-mbedtls-verify.patch
+++ b/deps/patches/libgit2-mbedtls-verify.patch
@@ -1,0 +1,99 @@
+diff --git a/src/mbedtls_stream.c b/src/mbedtls_stream.c
+index bcc2e8b..4706102 100644
+--- a/src/mbedtls_stream.c
++++ b/src/mbedtls_stream.c
+@@ -221,82 +221,34 @@ static int ssl_teardown(mbedtls_ssl_context *ssl)
+     return ret;
+ }
+ 
+-static int check_host_name(const char *name, const char *host)
+-{
+-    if (!strcasecmp(name, host))
+-        return 0;
+-
+-    if (gitno__match_host(name, host) < 0)
+-        return -1;
+-
+-    return 0;
+-}
+-
+ static int verify_server_cert(mbedtls_ssl_context *ssl, const char *host)
+ {
+-    const mbedtls_x509_crt *cert;
+-    const mbedtls_x509_sequence *alts;
+-    int ret, matched = -1;
++    mbedtls_x509_crt *cert;
++    uint32_t flags;
++    int ret = -1;
+     size_t sn_size = 512;
+-    char subject_name[sn_size], alt_name[sn_size];
+-
++    char buf[sn_size];
+ 
+     if (( ret = mbedtls_ssl_get_verify_result(ssl) ) != 0) {
+-        char vrfy_buf[512];
+-        mbedtls_x509_crt_verify_info( vrfy_buf, sizeof( vrfy_buf ), "  ! ", ret );
+-        giterr_set(GITERR_SSL, "The SSL certificate is invalid: %s", vrfy_buf);
++        mbedtls_x509_crt_verify_info(buf, sn_size, "  ! ", ret);
++        giterr_set(GITERR_SSL, "The SSL certificate is invalid: %s", buf);
+         return GIT_ECERTIFICATE;
+     }
+ 
+-    cert = mbedtls_ssl_get_peer_cert(ssl);
++    cert = (mbedtls_x509_crt*) mbedtls_ssl_get_peer_cert(ssl);
+     if (!cert) {
+         giterr_set(GITERR_SSL, "the server did not provide a certificate");
+         return -1;
+     }
+ 
+-    /* Check the alternative names */
+-    alts = &cert->subject_alt_names;
+-    while (alts != NULL && matched != 1) {
+-        // Buffer is too small
+-        if( alts->buf.len >= sn_size )
+-            goto on_error;
+-
+-        memcpy(alt_name, alts->buf.p, alts->buf.len);
+-        alt_name[alts->buf.len] = '\0';
+-
+-        if (!memchr(alt_name, '\0', alts->buf.len)) {
+-            if (check_host_name(alt_name, host) < 0)
+-                matched = 0;
+-            else
+-                matched = 1;
+-        }
+-
+-        alts = alts->next;
++    if (mbedtls_x509_crt_verify(cert, git__ssl_conf->ca_chain, NULL, host, &flags, NULL, NULL) != 0) {
++        mbedtls_x509_crt_verify_info(buf, sn_size, "", flags);
++        buf[strlen(buf) - 1] = '\0';  // Remove trailing newline
++        giterr_set(GITERR_SSL, buf);
++        return GIT_ECERTIFICATE;
+     }
+-    if (matched == 0)
+-        goto cert_fail_name;
+-
+-    if (matched == 1)
+-        return 0;
+-
+-    /* If no alternative names are available, check the common name */
+-    ret = mbedtls_x509_dn_gets(subject_name, sn_size, &cert->subject);
+-    if (ret == 0)
+-        goto on_error;
+-    if (memchr(subject_name, '\0', ret))
+-        goto cert_fail_name;
+-
+-    if (check_host_name(subject_name, host) < 0)
+-        goto cert_fail_name;
+ 
+     return 0;
+-
+-on_error:
+-    return ssl_set_error(ssl, 0);
+-
+-cert_fail_name:
+-    giterr_set(GITERR_SSL, "hostname does not match certificate");
+-    return GIT_ECERTIFICATE;
+ }
+ 
+ typedef struct {

--- a/deps/patches/libgit2-mbedtls.patch
+++ b/deps/patches/libgit2-mbedtls.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4e1104f..8110489 100644
+index f26f468..c246687 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -113,6 +113,10 @@ IF (HAVE_STRUCT_STAT_NSEC OR WIN32)
@@ -13,7 +13,7 @@ index 4e1104f..8110489 100644
  # This variable will contain the libraries we need to put into
  # libgit2.pc's Requires.private. That is, what we're linking to or
  # what someone who's statically linking us needs to link to.
-@@ -283,6 +287,10 @@ ELSE ()
+@@ -284,6 +288,10 @@ ELSE ()
  		FIND_PACKAGE(OpenSSL)
  	ENDIF ()
  
@@ -24,7 +24,7 @@ index 4e1104f..8110489 100644
  	IF (CURL_FOUND)
  		ADD_DEFINITIONS(-DGIT_CURL)
  		INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
-@@ -316,6 +324,9 @@ ELSEIF (OPENSSL_FOUND AND NOT SHA1_TYPE STREQUAL "builtin")
+@@ -317,6 +325,9 @@ ELSEIF (OPENSSL_FOUND AND NOT SHA1_TYPE STREQUAL "builtin")
  	ELSE()
  		SET(LIBGIT2_PC_REQUIRES "${LIBGIT2_PC_REQUIRES} openssl")
  	ENDIF ()
@@ -34,7 +34,7 @@ index 4e1104f..8110489 100644
  ELSE()
  	FILE(GLOB SRC_SHA1 src/hash/hash_generic.c)
  ENDIF()
-@@ -543,6 +554,11 @@ IF (OPENSSL_FOUND)
+@@ -549,6 +560,11 @@ IF (OPENSSL_FOUND)
    SET(SSL_LIBRARIES ${OPENSSL_LIBRARIES})
  ENDIF()
  
@@ -46,7 +46,7 @@ index 4e1104f..8110489 100644
  
  
  IF (THREADSAFE)
-@@ -688,7 +704,7 @@ IF (BUILD_CLAR)
+@@ -696,7 +712,7 @@ IF (BUILD_CLAR)
  	ENDIF ()
  
  	ENABLE_TESTING()
@@ -158,10 +158,10 @@ index e2ad8fe..c5b4269 100644
  
  	GIT_MEMORY_BARRIER;
 diff --git a/src/global.h b/src/global.h
-index 2199515..adadcd9 100644
+index 88f40aa..139630c 100644
 --- a/src/global.h
 +++ b/src/global.h
-@@ -23,6 +23,12 @@ typedef struct {
+@@ -29,6 +29,12 @@ typedef struct {
  extern SSL_CTX *git__ssl_ctx;
  #endif
  
@@ -260,10 +260,10 @@ index 0000000..e50d295
 \ No newline at end of file
 diff --git a/src/mbedtls_stream.c b/src/mbedtls_stream.c
 new file mode 100644
-index 0000000..98ff808
+index 0000000..f88eeb0
 --- /dev/null
 +++ b/src/mbedtls_stream.c
-@@ -0,0 +1,483 @@
+@@ -0,0 +1,435 @@
 +/*
 + * Copyright (C) the libgit2 contributors. All rights reserved.
 + *
@@ -487,82 +487,34 @@ index 0000000..98ff808
 +    return ret;
 +}
 +
-+static int check_host_name(const char *name, const char *host)
-+{
-+    if (!strcasecmp(name, host))
-+        return 0;
-+
-+    if (gitno__match_host(name, host) < 0)
-+        return -1;
-+
-+    return 0;
-+}
-+
 +static int verify_server_cert(mbedtls_ssl_context *ssl, const char *host)
 +{
-+    const mbedtls_x509_crt *cert;
-+    const mbedtls_x509_sequence *alts;
-+    int ret, matched = -1;
++    mbedtls_x509_crt *cert;
++    uint32_t flags;
++    int ret = -1;
 +    size_t sn_size = 512;
-+    char subject_name[sn_size], alt_name[sn_size];
-+
++    char buf[sn_size];
 +
 +    if (( ret = mbedtls_ssl_get_verify_result(ssl) ) != 0) {
-+        char vrfy_buf[512];
-+        mbedtls_x509_crt_verify_info( vrfy_buf, sizeof( vrfy_buf ), "  ! ", ret );
-+        giterr_set(GITERR_SSL, "The SSL certificate is invalid: %s", vrfy_buf);
++        mbedtls_x509_crt_verify_info(buf, sn_size, "  ! ", ret);
++        giterr_set(GITERR_SSL, "The SSL certificate is invalid: %s", buf);
 +        return GIT_ECERTIFICATE;
 +    }
 +
-+    cert = mbedtls_ssl_get_peer_cert(ssl);
++    cert = (mbedtls_x509_crt*) mbedtls_ssl_get_peer_cert(ssl);
 +    if (!cert) {
 +        giterr_set(GITERR_SSL, "the server did not provide a certificate");
 +        return -1;
 +    }
 +
-+    /* Check the alternative names */
-+    alts = &cert->subject_alt_names;
-+    while (alts != NULL && matched != 1) {
-+        // Buffer is too small
-+        if( alts->buf.len >= sn_size )
-+            goto on_error;
-+
-+        memcpy(alt_name, alts->buf.p, alts->buf.len);
-+        alt_name[alts->buf.len] = '\0';
-+
-+        if (!memchr(alt_name, '\0', alts->buf.len)) {
-+            if (check_host_name(alt_name, host) < 0)
-+                matched = 0;
-+            else
-+                matched = 1;
-+        }
-+
-+        alts = alts->next;
++    if (mbedtls_x509_crt_verify(cert, git__ssl_conf->ca_chain, NULL, host, &flags, NULL, NULL) != 0) {
++        mbedtls_x509_crt_verify_info(buf, sn_size, "", flags);
++        buf[strlen(buf) - 1] = '\0';  // Remove trailing newline
++        giterr_set(GITERR_SSL, buf);
++        return GIT_ECERTIFICATE;
 +    }
-+    if (matched == 0)
-+        goto cert_fail_name;
-+
-+    if (matched == 1)
-+        return 0;
-+
-+    /* If no alternative names are available, check the common name */
-+    ret = mbedtls_x509_dn_gets(subject_name, sn_size, &cert->subject);
-+    if (ret == 0)
-+        goto on_error;
-+    if (memchr(subject_name, '\0', ret))
-+        goto cert_fail_name;
-+
-+    if (check_host_name(subject_name, host) < 0)
-+        goto cert_fail_name;
 +
 +    return 0;
-+
-+on_error:
-+    return ssl_set_error(ssl, 0);
-+
-+cert_fail_name:
-+    giterr_set(GITERR_SSL, "hostname does not match certificate");
-+    return GIT_ECERTIFICATE;
 +}
 +
 +typedef struct {
@@ -770,7 +722,7 @@ index 0000000..5cb1071
 +
 +#endif
 diff --git a/src/settings.c b/src/settings.c
-index 0da19ea..65bbb41 100644
+index 4a6e0f3..9ebcd78 100644
 --- a/src/settings.c
 +++ b/src/settings.c
 @@ -9,6 +9,10 @@
@@ -784,7 +736,7 @@ index 0da19ea..65bbb41 100644
  #include <git2.h>
  #include "common.h"
  #include "sysdir.h"
-@@ -29,7 +33,7 @@ int git_libgit2_features()
+@@ -29,7 +33,7 @@ int git_libgit2_features(void)
  #ifdef GIT_THREADS
  		| GIT_FEATURE_THREADS
  #endif

--- a/deps/patches/libgit2-mbedtls.patch
+++ b/deps/patches/libgit2-mbedtls.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f26f468..c246687 100644
+index 4e1104f..8110489 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -113,6 +113,10 @@ IF (HAVE_STRUCT_STAT_NSEC OR WIN32)
@@ -13,7 +13,7 @@ index f26f468..c246687 100644
  # This variable will contain the libraries we need to put into
  # libgit2.pc's Requires.private. That is, what we're linking to or
  # what someone who's statically linking us needs to link to.
-@@ -284,6 +288,10 @@ ELSE ()
+@@ -283,6 +287,10 @@ ELSE ()
  		FIND_PACKAGE(OpenSSL)
  	ENDIF ()
  
@@ -24,7 +24,7 @@ index f26f468..c246687 100644
  	IF (CURL_FOUND)
  		ADD_DEFINITIONS(-DGIT_CURL)
  		INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
-@@ -317,6 +325,9 @@ ELSEIF (OPENSSL_FOUND AND NOT SHA1_TYPE STREQUAL "builtin")
+@@ -316,6 +324,9 @@ ELSEIF (OPENSSL_FOUND AND NOT SHA1_TYPE STREQUAL "builtin")
  	ELSE()
  		SET(LIBGIT2_PC_REQUIRES "${LIBGIT2_PC_REQUIRES} openssl")
  	ENDIF ()
@@ -34,7 +34,7 @@ index f26f468..c246687 100644
  ELSE()
  	FILE(GLOB SRC_SHA1 src/hash/hash_generic.c)
  ENDIF()
-@@ -549,6 +560,11 @@ IF (OPENSSL_FOUND)
+@@ -543,6 +554,11 @@ IF (OPENSSL_FOUND)
    SET(SSL_LIBRARIES ${OPENSSL_LIBRARIES})
  ENDIF()
  
@@ -46,7 +46,7 @@ index f26f468..c246687 100644
  
  
  IF (THREADSAFE)
-@@ -696,7 +712,7 @@ IF (BUILD_CLAR)
+@@ -688,7 +704,7 @@ IF (BUILD_CLAR)
  	ENDIF ()
  
  	ENABLE_TESTING()
@@ -158,10 +158,10 @@ index e2ad8fe..c5b4269 100644
  
  	GIT_MEMORY_BARRIER;
 diff --git a/src/global.h b/src/global.h
-index 88f40aa..139630c 100644
+index 2199515..adadcd9 100644
 --- a/src/global.h
 +++ b/src/global.h
-@@ -29,6 +29,12 @@ typedef struct {
+@@ -23,6 +23,12 @@ typedef struct {
  extern SSL_CTX *git__ssl_ctx;
  #endif
  
@@ -260,10 +260,10 @@ index 0000000..e50d295
 \ No newline at end of file
 diff --git a/src/mbedtls_stream.c b/src/mbedtls_stream.c
 new file mode 100644
-index 0000000..f88eeb0
+index 0000000..98ff808
 --- /dev/null
 +++ b/src/mbedtls_stream.c
-@@ -0,0 +1,435 @@
+@@ -0,0 +1,483 @@
 +/*
 + * Copyright (C) the libgit2 contributors. All rights reserved.
 + *
@@ -487,34 +487,82 @@ index 0000000..f88eeb0
 +    return ret;
 +}
 +
++static int check_host_name(const char *name, const char *host)
++{
++    if (!strcasecmp(name, host))
++        return 0;
++
++    if (gitno__match_host(name, host) < 0)
++        return -1;
++
++    return 0;
++}
++
 +static int verify_server_cert(mbedtls_ssl_context *ssl, const char *host)
 +{
-+    mbedtls_x509_crt *cert;
-+    uint32_t flags;
-+    int ret = -1;
++    const mbedtls_x509_crt *cert;
++    const mbedtls_x509_sequence *alts;
++    int ret, matched = -1;
 +    size_t sn_size = 512;
-+    char buf[sn_size];
++    char subject_name[sn_size], alt_name[sn_size];
++
 +
 +    if (( ret = mbedtls_ssl_get_verify_result(ssl) ) != 0) {
-+        mbedtls_x509_crt_verify_info(buf, sn_size, "  ! ", ret);
-+        giterr_set(GITERR_SSL, "The SSL certificate is invalid: %s", buf);
++        char vrfy_buf[512];
++        mbedtls_x509_crt_verify_info( vrfy_buf, sizeof( vrfy_buf ), "  ! ", ret );
++        giterr_set(GITERR_SSL, "The SSL certificate is invalid: %s", vrfy_buf);
 +        return GIT_ECERTIFICATE;
 +    }
 +
-+    cert = (mbedtls_x509_crt*) mbedtls_ssl_get_peer_cert(ssl);
++    cert = mbedtls_ssl_get_peer_cert(ssl);
 +    if (!cert) {
 +        giterr_set(GITERR_SSL, "the server did not provide a certificate");
 +        return -1;
 +    }
 +
-+    if (mbedtls_x509_crt_verify(cert, git__ssl_conf->ca_chain, NULL, host, &flags, NULL, NULL) != 0) {
-+        mbedtls_x509_crt_verify_info(buf, sn_size, "", flags);
-+        buf[strlen(buf) - 1] = '\0';  // Remove trailing newline
-+        giterr_set(GITERR_SSL, buf);
-+        return GIT_ECERTIFICATE;
++    /* Check the alternative names */
++    alts = &cert->subject_alt_names;
++    while (alts != NULL && matched != 1) {
++        // Buffer is too small
++        if( alts->buf.len >= sn_size )
++            goto on_error;
++
++        memcpy(alt_name, alts->buf.p, alts->buf.len);
++        alt_name[alts->buf.len] = '\0';
++
++        if (!memchr(alt_name, '\0', alts->buf.len)) {
++            if (check_host_name(alt_name, host) < 0)
++                matched = 0;
++            else
++                matched = 1;
++        }
++
++        alts = alts->next;
 +    }
++    if (matched == 0)
++        goto cert_fail_name;
++
++    if (matched == 1)
++        return 0;
++
++    /* If no alternative names are available, check the common name */
++    ret = mbedtls_x509_dn_gets(subject_name, sn_size, &cert->subject);
++    if (ret == 0)
++        goto on_error;
++    if (memchr(subject_name, '\0', ret))
++        goto cert_fail_name;
++
++    if (check_host_name(subject_name, host) < 0)
++        goto cert_fail_name;
 +
 +    return 0;
++
++on_error:
++    return ssl_set_error(ssl, 0);
++
++cert_fail_name:
++    giterr_set(GITERR_SSL, "hostname does not match certificate");
++    return GIT_ECERTIFICATE;
 +}
 +
 +typedef struct {
@@ -722,7 +770,7 @@ index 0000000..5cb1071
 +
 +#endif
 diff --git a/src/settings.c b/src/settings.c
-index 4a6e0f3..9ebcd78 100644
+index 0da19ea..65bbb41 100644
 --- a/src/settings.c
 +++ b/src/settings.c
 @@ -9,6 +9,10 @@
@@ -736,7 +784,7 @@ index 4a6e0f3..9ebcd78 100644
  #include <git2.h>
  #include "common.h"
  #include "sysdir.h"
-@@ -29,7 +33,7 @@ int git_libgit2_features(void)
+@@ -29,7 +33,7 @@ int git_libgit2_features()
  #ifdef GIT_THREADS
  		| GIT_FEATURE_THREADS
  #endif

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -946,7 +946,7 @@ mktempdir() do dir
             end
 
             if isempty(common_name)
-                warn("Unable to determine hostname that maps to the loopback address")
+                warn("Skipping hostname verification tests. Unable to determine a hostname which maps to the loopback address")
             end
         end
         if openssl_installed && !isempty(common_name)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -928,15 +928,24 @@ mktempdir() do dir
                 warn("Skipping hostname verification tests. Is `openssl` on the path?")
             end
 
-            # Find a hostname that is mapped to the loopback address
+            # Find a hostname that maps to the loopback address
             hostname = replace(readchomp(`hostname`), r"\..*$", "")
             loopback = ip"127.0.0.1"
 
-            if getaddrinfo(hostname) == loopback
-                common_name = hostname
-            elseif getaddrinfo("localhost") == loopback
-                common_name = "localhost"
-            else
+            for host in (hostname, "localhost")
+                try
+                    addr = getaddrinfo(host)
+                catch
+                    continue
+                end
+
+                if addr == loopback
+                    common_name = host
+                    break
+                end
+            end
+
+            if isempty(common_name)
                 warn("Unable to determine hostname that maps to the loopback address")
             end
         end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -958,10 +958,11 @@ mktempdir() do dir
                         end
                     end
                 """
+                cmd = `$(Base.julia_cmd()) --startup-file=no -e $code`
 
                 try
                     # The generated certificate is normally invalid
-                    run(`$(Base.julia_cmd()) -e $code`)
+                    run(cmd)
                     err = open(errfile, "r") do f
                         deserialize(f)
                     end
@@ -972,7 +973,7 @@ mktempdir() do dir
                     # Specify that Julia use onl the custom certificate. Note: we need to
                     # spawn a new Julia process in order for this ENV variable to take effect.
                     withenv("SSL_CERT_FILE" => pem) do
-                        run(`$(Base.julia_cmd()) -e $code`)
+                        run(cmd)
                         err = open(errfile, "r") do f
                             deserialize(f)
                         end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -946,16 +946,17 @@ mktempdir() do dir
                 end
 
                 errfile = joinpath(root, "error")
-                reponame = "https://$hostname:4433/Example.jl"
+                repo_url = "https://$hostname:4433/Example.jl"
+                repo_dir = joinpath(root, "dest")
                 code = """
-                    dest = tempname()
+                    dest_dir = "$repo_dir"
                     open("$errfile", "w+") do f
                         try
-                            repo = LibGit2.clone("$reponame", dest)
+                            repo = LibGit2.clone("$repo_url", dest_dir)
                         catch err
                             serialize(f, err)
                         finally
-                            isdir(dest) && rm(dest, recursive=true)
+                            isdir(dest_dir) && rm(dest_dir, recursive=true)
                         end
                     end
                 """
@@ -971,7 +972,7 @@ mktempdir() do dir
 
                     rm(errfile)
 
-                    # Specify that Julia use onl the custom certificate. Note: we need to
+                    # Specify that Julia use only the custom certificate. Note: we need to
                     # spawn a new Julia process in order for this ENV variable to take effect.
                     withenv("SSL_CERT_FILE" => pem) do
                         run(cmd)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -916,17 +916,18 @@ mktempdir() do dir
     end
     =#
 
+    # Note: Tests only work on linux as SSL_CERT_FILE is only respected on linux systems.
     @testset "Hostname verification" begin
-        openssl_command = ""
+        openssl_installed = false
         if is_linux()
             try
                 # OpenSSL needs to be on the path
-                openssl_command = strip(readstring(`which openssl`))
+                openssl_installed = !isempty(readstring(`openssl version`))
             catch
-                warn("Skipping hostname verification tests (Are `which` and `openssl` installed?)")
+                warn("Skipping hostname verification tests. Is `openssl` on the path?")
             end
         end
-        if !isempty(openssl_command)
+        if openssl_installed
             mktempdir() do root
                 hostname = replace(readchomp(`hostname`), r"\..*$", "")
                 key = joinpath(root, hostname * ".key")


### PR DESCRIPTION
Corrects issues with hostname verification failing when the SSL subjectAltName is not specified and the CN should be used. Specifically the original `verify_server_cert` [check of the subjectAltName](https://github.com/JuliaLang/julia/compare/cv/libgit2-ssl-verify?expand=1#diff-7b94fb465bb67b40e70933b8f97f7d65L523) would fail since `cert->subject_alt_names` would return a single empty string. Additionally the [CN check](https://github.com/JuliaLang/julia/compare/cv/libgit2-ssl-verify?expand=1#diff-7b94fb465bb67b40e70933b8f97f7d65L548) would perform a string comparison against the entire subject line which would cause to always fail.

The fix was to use the built in mbedTLS verification which should be much more reliable.

I ended up correcting the original patch instead of creating a new patch. Let me know if a new patch is preferred.