### PR TITLE
add a fast path to typeintersect that works around #20450

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1356,11 +1356,14 @@ static jl_value_t *intersect_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_sten
     size_t lx = jl_nparams(xd), ly = jl_nparams(yd);
     if (lx == 0 && ly == 0)
         return (jl_value_t*)yd;
+    int vx=0, vy=0, vvx = (lx > 0 && jl_is_vararg_type(jl_tparam(xd, lx-1)));
+    int vvy = (ly > 0 && jl_is_vararg_type(jl_tparam(yd, ly-1)));
+    if (!vvx && !vvy && lx != ly)
+        return jl_bottom_type;
     jl_svec_t *params = jl_alloc_svec(lx > ly ? lx : ly);
     jl_value_t *res=NULL;
     JL_GC_PUSH1(&params);
     size_t i=0, j=0;
-    int vx=0, vy=0;
     jl_value_t *xi, *yi;
     while (1) {
         xi = i < lx ? jl_tparam(xd, i) : NULL;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -803,6 +803,20 @@ function test_intersection()
                    Tuple{Type{T}, T} where T,
                    Tuple{Type{S},S} where S<:Tuple{Any,Vararg{Any,N} where N})
 
+    # part of issue #20450
+    @testintersect(Tuple{Array{Ref{T}, 1}, Array{Pair{M, V}, 1}} where V where T where M,
+                   Tuple{Array{Ref{T}, 1}, Array{Pair{M, T}, 1}, SS} where T where M where SS,
+                   Union{})
+
+    # TODO: these test cases currently hang
+    @test_skip typeintersect(Tuple{Array{Ref{T}, 1}, Array{Pair{M, V}, 1}, Int} where V where T where M,
+                             Tuple{Array{Ref{T}, 1}, Array{Pair{M, T}, 1}, Any} where T where M) ==
+                                 Tuple{Array{Ref{T}, 1}, Array{Pair{M, T}, 1}, Int}
+
+    @test_skip typeintersect(Tuple{Int, Ref{Pair{K,V}}} where V where K,
+                             Tuple{Any, Ref{Pair{T,T}} where T }) ==
+                                 Tuple{Int, Ref{Pair{T,T}} where T }
+
     @test_broken isequal_type(_type_intersect(Tuple{T,T} where T,
                                               Union{Tuple{S,Array{Int64,1}},Tuple{S,Array{S,1}}} where S),
                               Union{Tuple{Vector{Int64},Vector{Int64}},


### PR DESCRIPTION
This does not fix the actual type intersection issue, but at least lets us avoid it when the tricky case occurs as part of an easy problem (in this case, different-length tuples). Sufficient to fix the specific problem in #20450. I added a skipped test for the full version of the problem (since it hangs).