### PR TITLE
fix poll_fd ArgumentError ordering

### DIFF
--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -26,11 +26,15 @@ function pfd_tst_reads(idx, intvl)
     global ready += 1
     wait(ready_c)
     tic()
+    start_evt2 = Condition()
+    evt2 = @async (notify(start_evt2); poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false))
+    wait(start_evt2); yield() # make sure the async poll_fd is pumping events
     evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false)
     t_elapsed = toq()
     @test !evt.timedout
     @test evt.readable
     @test !evt.writable
+    @test evt === wait(evt2)
 
     # println("Expected ", intvl, ", actual ", t_elapsed, ", diff ", t_elapsed - intvl)
     # Disabled since this assertion fails randomly, notably on build VMs (issue #12824)
@@ -50,10 +54,14 @@ function pfd_tst_timeout(idx, intvl)
     global ready += 1
     wait(ready_c)
     tic()
+    start_evt2 = Condition()
+    evt2 = @async (notify(start_evt2); poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false))
+    wait(start_evt2); yield() # make sure the async poll_fd is pumping events
     evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false)
     @test evt.timedout
     @test !evt.readable
     @test !evt.writable
+    @test evt === wait(evt2)
     t_elapsed = toq()
 
     # Disabled since these assertions fail randomly, notably on build VMs (issue #12824)


### PR DESCRIPTION
When reusing a _FDWatcher, the check for whether it is already in use needs to happen after we check if there's already an existing _FDWatcher. In refactoring for c0f824699177af6cfe2c71390400777a3febccf3, I got this backwards. Now added a test to make sure it works correctly in this case.

(noticed in https://discourse.julialang.org/t/waiting-on-a-file-poll-fd-and-rawfd/1876/2)