### PR TITLE
only colorize stackframes when used in backtraces

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -607,7 +607,7 @@ function show_backtrace(io::IO, t::Vector)
     n_frames != 0 && print(io, "\nStacktrace:")
     process_entry = (last_frame, n) -> begin
         frame_counter += 1
-        show_trace_entry(io, last_frame, n, prefix = string(" [", frame_counter, "] "))
+        show_trace_entry(IOContext(io, :backtrace => true), last_frame, n, prefix = string(" [", frame_counter, "] "))
         push!(LAST_BACKTRACE_LINE_INFOS, (string(last_frame.file), last_frame.line))
     end
     process_backtrace(process_entry, t)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1025,7 +1025,7 @@ function show_lambda_types(io::IO, li::Core.MethodInstance)
     # print a method signature tuple for a lambda definition
     local sig
     returned_from_do = false
-    Base.with_output_color(have_color ? stackframe_function_color() : :nothing, io) do io
+    Base.with_output_color(have_color && get(io, :backtrace, false) ? stackframe_function_color() : :nothing, io) do io
         if li.specTypes === Tuple
             print(io, li.def.name, "(...)")
             returned_from_do = true

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -195,7 +195,7 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         if frame.func === empty_sym
             @printf(io, "ip:%#x", frame.pointer)
         else
-            print_with_color(Base.have_color ? Base.stackframe_function_color() : :nothing, io, string(frame.func))
+            print_with_color(Base.have_color && get(io, :backtrace, false) ? Base.stackframe_function_color() : :nothing, io, string(frame.func))
         end
     else
         linfo = get(frame.linfo)
@@ -214,7 +214,7 @@ function show(io::IO, frame::StackFrame; full_path::Bool=false,
     if frame.file !== empty_sym
         file_info = full_path ? string(frame.file) : basename(string(frame.file))
         print(io, " at ")
-        Base.with_output_color(Base.have_color ? Base.stackframe_lineinfo_color() : :nothing, io) do io
+        Base.with_output_color(Base.have_color && get(io, :backtrace, false) ? Base.stackframe_lineinfo_color() : :nothing, io) do io
             print(io, file_info, ":")
             if frame.line >= 0
                 print(io, frame.line)


### PR DESCRIPTION
Otherwise for example `Profile.print()` tries to print the colorized versions of the stackframes. However, `Profile.print` truncates output meaning that ANSI end tokens get disregarded and the terminal gets sad.