### PR TITLE
Add logical indexing in deleteat!()

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -853,7 +853,7 @@ end
 # Simpler and more efficient version for logical indexing
 function deleteat!(a::Vector, inds::AbstractVector{Bool})
     n = length(a)
-    @boundscheck length(inds) == n || throw(BoundsError(a, inds))
+    length(inds) == n || throw(BoundsError(a, inds))
     p = 1
     for (q, i) in enumerate(inds)
         @inbounds a[p] = a[q]

--- a/base/array.jl
+++ b/base/array.jl
@@ -818,7 +818,10 @@ Stacktrace:
  [1] deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:808
 ```
 """
-function deleteat!(a::Vector, inds)
+deleteat!(a::Vector, inds) = _deleteat!(a, inds)
+deleteat!(a::Vector, inds::AbstractVector) = _deleteat!(a, to_indices(a, (inds,))[1])
+
+function _deleteat!(a::Vector, inds)
     n = length(a)
     s = start(inds)
     done(inds, s) && return a
@@ -847,9 +850,10 @@ function deleteat!(a::Vector, inds)
     return a
 end
 
+# Simpler and more efficient version for logical indexing
 function deleteat!(a::Vector, inds::AbstractVector{Bool})
     n = length(a)
-    length(inds) == n || throw(BoundsError(a, inds))
+    @boundscheck length(inds) == n || throw(BoundsError(a, inds))
     p = 1
     for (q, i) in enumerate(inds)
         @inbounds a[p] = a[q]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1067,9 +1067,13 @@ end
 @testset "deleteat!" begin
     for idx in Any[1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:10,
                    8:9, 9:10, 6:9, 7:10]
-        # integer indexing
+        # integer indexing with AbstractArray
         a = [1:10;]; acopy = copy(a)
         @test deleteat!(a, idx) == [acopy[1:(first(idx)-1)]; acopy[(last(idx)+1):end]]
+
+        # integer indexing with non-AbstractArray iterable
+        a = [1:10;]; acopy = copy(a)
+        @test deleteat!(a, (i for i in idx)) == [acopy[1:(first(idx)-1)]; acopy[(last(idx)+1):end]]
 
         # logical indexing
         a = [1:10;]; acopy = copy(a)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1067,8 +1067,13 @@ end
 @testset "deleteat!" begin
     for idx in Any[1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:10,
                    8:9, 9:10, 6:9, 7:10]
+        # integer indexing
         a = [1:10;]; acopy = copy(a)
         @test deleteat!(a, idx) == [acopy[1:(first(idx)-1)]; acopy[(last(idx)+1):end]]
+
+        # logical indexing
+        a = [1:10;]; acopy = copy(a)
+        @test deleteat!(a, map(i -> i in idx, 1:length(a))) == [acopy[1:(first(idx)-1)]; acopy[(last(idx)+1):end]]
     end
     a = [1:10;]
     @test deleteat!(a, 11:10) == [1:10;]
@@ -1077,6 +1082,9 @@ end
     @test_throws BoundsError deleteat!(a, [1,13])
     @test_throws ArgumentError deleteat!(a, [5,3])
     @test_throws BoundsError deleteat!(a, 5:20)
+    @test_throws BoundsError deleteat!(a, Bool[])
+    @test_throws BoundsError deleteat!(a, [true])
+    @test_throws BoundsError deleteat!(a, falses(11))
 end
 
 @testset "comprehensions" begin


### PR DESCRIPTION
More consistent with what getindex() supports. This can allow
avoiding an allocation when the caller already has a boolean vector of
logical indices.

-----

Turned out it could be useful for dropping null values in NullableArrays without calling `find` and allocating a new array of indices (https://github.com/JuliaStats/NullableArrays.jl/pull/179), so I figured it would make sense to have this in general.

Unfortunately, we cannot define a separate method for boolean *iterators*, only for `AbstractVector{Bool}`. The only way to support any boolean iterator is to add an `eltype(a) <: Bool` branch to the most generic method. Which approach is better?

Also, it would be great to allow passing a predicate just like e.g. to `find`, but since there's no specific predicate type, the method would be ambiguous. Should we add a separate function just like [the Find & Search Julep](https://github.com/JuliaLang/Juleps/blob/master/Find.md) has several functions for `find*` variants?

I realize one can already write `deleteat!(a, (i for i in eachindex(a) if pred(i)))` with `pred` an arbitrary predicate, so maybe that's not needed. OTOH, this form is harder to discover, and does more computations in each iteration than the simple implementation checking only `pred` for each entry.