### PR TITLE
Remove multidimensional indexing of tuples

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -384,7 +384,7 @@ uncolon(inds::Tuple,      I::Tuple{Colon, Vararg{CI0}}) = Slice(OneTo(trailingsi
 
 ### From abstractarray.jl: Internal multidimensional indexing definitions ###
 getindex(x::Number, i::CartesianIndex{0}) = x
-getindex(t::Tuple, I...) = getindex(t, IteratorsMD.flatten(I)...)
+getindex(t::Tuple,  i::CartesianIndex{1}) = getindex(t, i.I[1])
 
 # These are not defined on directly on getindex to avoid
 # ambiguities for AbstractArray subtypes. See the note in abstractarray.jl

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -231,3 +231,8 @@ end
 @test Tuple{Int,Vararg{Any}}(Float64[1,2,3]) === (1, 2.0, 3.0)
 @test Tuple(ones(5)) === (1.0,1.0,1.0,1.0,1.0)
 @test_throws MethodError convert(Tuple, ones(5))
+
+@testset "Multidimensional indexing (issue #20453)" begin
+    @test_throws MethodError (1,)[]
+    @test_throws MethodError (1,1,1)[1,1]
+end


### PR DESCRIPTION
Currently a method for tuples exists which permits multidimensional indexing (see #20453). The method merely splats the dimensions and ends up inadvertently calling itself recursively, as there's no more specific method for it to use. This PR simply removes the method and adds tests to ensure the behavior doesn't return.

Fixes #20453