### PR TITLE
RFC: no longer prefix showed stackframes by "in"

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -588,9 +588,9 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
     end
 end
 
-function show_trace_entry(io, frame, n; prefix = " in ")
-    print(io, "\n")
-    show(io, frame, full_path=true; prefix = prefix)
+function show_trace_entry(io, frame, n; prefix = "")
+    print(io, "\n", prefix)
+    show(io, frame, full_path=true)
     n > 1 && print(io, " (repeats ", n, " times)")
 end
 

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -207,9 +207,7 @@ function show_spec_linfo(io::IO, frame::StackFrame)
     end
 end
 
-function show(io::IO, frame::StackFrame; full_path::Bool=false,
-              prefix = " in ")
-    print(io, prefix)
+function show(io::IO, frame::StackFrame; full_path::Bool=false)
     show_spec_linfo(io, frame)
     if frame.file !== empty_sym
         file_info = full_path ? string(frame.file) : basename(string(frame.file))

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -10,10 +10,10 @@ The primary function used to obtain a stack trace is [`stacktrace()`](@ref):
 ```julia
 julia> stacktrace()
 4-element Array{StackFrame,1}:
-  in eval(::Module, ::Any) at boot.jl:236
-  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
-  in macro expansion at REPL.jl:97 [inlined]
-  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
+ eval(::Module, ::Any) at boot.jl:236
+ eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+ macro expansion at REPL.jl:97 [inlined]
+ (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
 Calling [`stacktrace()`](@ref) returns a vector of [`StackFrame`](@ref) s. For ease of use, the
@@ -26,8 +26,8 @@ example (generic function with 1 method)
 
 julia> example()
 5-element Array{StackFrame,1}:
-  in example() at REPL[0]:1
-  in eval(::Module, ::Any) at boot.jl:236
+ example() at REPL[1]:1
+ eval(::Module, ::Any) at boot.jl:236
 [...]
 
 julia> @noinline child() = stacktrace()
@@ -41,9 +41,9 @@ grandparent (generic function with 1 method)
 
 julia> grandparent()
 7-element Array{StackFrame,1}:
-  in child() at REPL[2]:1
-  in parent() at REPL[3]:1
-  in grandparent() at REPL[4]:1
+ child() at REPL[3]:1
+ parent() at REPL[4]:1
+ grandparent() at REPL[5]:1
 [...]
 ```
 
@@ -57,11 +57,11 @@ example (generic function with 1 method)
 
 julia> example()
 5-element Array{StackFrame,1}:
-  in example() at REPL[1]:1
-  in eval(::Module, ::Any) at boot.jl:236
-  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
-  in macro expansion at REPL.jl:97 [inlined]
-  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
+ example() at REPL[1]:1
+ eval(::Module, ::Any) at boot.jl:236
+ eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+ macro expansion at REPL.jl:97 [inlined]
+ (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
 ## Extracting useful information
@@ -73,7 +73,7 @@ returned by [`backtrace()`](@ref):
 
 ```julia
 julia> top_frame = stacktrace()[1]
- in eval(::Module, ::Any) at boot.jl:236
+eval(::Module, ::Any) at boot.jl:236
 
 julia> top_frame.func
 :eval
@@ -120,8 +120,8 @@ example (generic function with 1 method)
 
 julia> example()
 5-element Array{StackFrame,1}:
-  in example() at REPL[2]:4
-  in eval(::Module, ::Any) at boot.jl:236
+ example() at REPL[2]:4
+ eval(::Module, ::Any) at boot.jl:236
 [...]
 ```
 
@@ -148,8 +148,8 @@ example (generic function with 1 method)
 
 julia> example()
 6-element Array{StackFrame,1}:
-  in bad_function() at REPL[1]:1
-  in example() at REPL[2]:2
+ bad_function() at REPL[1]:1
+ example() at REPL[2]:2
 [...]
 ```
 
@@ -175,9 +175,9 @@ grandparent (generic function with 1 method)
 julia> grandparent()
 ERROR: Whoops!
 7-element Array{StackFrame,1}:
-  in child() at REPL[1]:1
-  in parent() at REPL[2]:1
-  in grandparent() at REPL[3]:3
+ child() at REPL[1]:1
+ parent() at REPL[2]:1
+ grandparent() at REPL[3]:3
 [...]
 ```
 
@@ -213,11 +213,11 @@ julia> trace = backtrace()
 
 julia> stacktrace(trace)
 5-element Array{StackFrame,1}:
-  in backtrace() at error.jl:46
-  in eval(::Module, ::Any) at boot.jl:236
-  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
-  in macro expansion at REPL.jl:97 [inlined]
-  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
+ backtrace() at error.jl:46
+ eval(::Module, ::Any) at boot.jl:236
+ eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+ macro expansion at REPL.jl:97 [inlined]
+ (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
 Notice that the vector returned by [`backtrace()`](@ref) had 21 pointers, while the vector returned
@@ -227,33 +227,34 @@ you can do it like this:
 
 ```julia
 julia> stacktrace(trace, true)
-26-element Array{StackFrame,1}:
-  in jl_backtrace_from_here at stackwalk.c:103
-  in backtrace() at error.jl:46
-  in backtrace() at sys.so:?
-  in jl_call_method_internal at julia_internal.h:248 [inlined]
-  in jl_apply_generic at gf.c:2217
-  in do_call at interpreter.c:75
-  in eval at interpreter.c:215
-  in eval_body at interpreter.c:519
-  in jl_interpret_toplevel_thunk at interpreter.c:664
-  in jl_toplevel_eval_flex at toplevel.c:592
-  in jl_toplevel_eval_in at builtins.c:614
-  in eval(::Module, ::Any) at boot.jl:236
-  in eval(::Module, ::Any) at sys.so:?
-  in jl_call_method_internal at julia_internal.h:248 [inlined]
-  in jl_apply_generic at gf.c:2217
-  in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
-  in ip:0x7f0ded345a86
-  in jl_call_method_internal at julia_internal.h:248 [inlined]
-  in jl_apply_generic at gf.c:2217
-  in macro expansion at REPL.jl:97 [inlined]
-  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
-  in ip:0x7f0ded34331f
-  in jl_call_method_internal at julia_internal.h:248 [inlined]
-  in jl_apply_generic at gf.c:2217
-  in jl_apply at julia.h:1411 [inlined]
-  in start_task at task.c:261
+27-element Array{StackFrame,1}:
+ jl_backtrace_from_here at stackwalk.c:103
+ backtrace() at error.jl:46
+ backtrace() at sys.so:?
+ jl_call_method_internal at julia_internal.h:248 [inlined]
+ jl_apply_generic at gf.c:2215
+ do_call at interpreter.c:75
+ eval at interpreter.c:215
+ eval_body at interpreter.c:519
+ jl_interpret_toplevel_thunk at interpreter.c:664
+ jl_toplevel_eval_flex at toplevel.c:592
+ jl_toplevel_eval_in at builtins.c:614
+ eval(::Module, ::Any) at boot.jl:236
+ eval(::Module, ::Any) at sys.so:?
+ jl_call_method_internal at julia_internal.h:248 [inlined]
+ jl_apply_generic at gf.c:2215
+ eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:66
+ ip:0x7f1c707f1846
+ jl_call_method_internal at julia_internal.h:248 [inlined]
+ jl_apply_generic at gf.c:2215
+ macro expansion at REPL.jl:97 [inlined]
+ (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
+ ip:0x7f1c707ea1ef
+ jl_call_method_internal at julia_internal.h:248 [inlined]
+ jl_apply_generic at gf.c:2215
+ jl_apply at julia.h:1411 [inlined]
+ start_task at task.c:261
+ ip:0xffffffffffffffff
 ```
 
 Individual pointers returned by [`backtrace()`](@ref) can be translated into [`StackFrame`](@ref)
@@ -264,7 +265,7 @@ julia> pointer = backtrace()[1];
 
 julia> frame = StackTraces.lookup(pointer)
 1-element Array{StackFrame,1}:
-  in jl_backtrace_from_here at stackwalk.c:103
+ jl_backtrace_from_here at stackwalk.c:103
 
 julia> println("The top frame is from $(frame[1].func)!")
 The top frame is from jl_backtrace_from_here!

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -381,21 +381,21 @@ let err_str,
     @test stringmime("text/plain", Core.arraysize) == "arraysize (built-in function)"
 
     err_str = @except_stackframe Symbol() ErrorException
-    @test err_str == " in Symbol() at $sn:$(method_defs_lineno + 0)"
+    @test err_str == "Symbol() at $sn:$(method_defs_lineno + 0)"
     err_str = @except_stackframe :a() ErrorException
-    @test err_str == " in (::Symbol)() at $sn:$(method_defs_lineno + 1)"
+    @test err_str == "(::Symbol)() at $sn:$(method_defs_lineno + 1)"
     err_str = @except_stackframe EightBitType() ErrorException
-    @test err_str == " in $(curmod_prefix)EightBitType() at $sn:$(method_defs_lineno + 2)"
+    @test err_str == "$(curmod_prefix)EightBitType() at $sn:$(method_defs_lineno + 2)"
     err_str = @except_stackframe i() ErrorException
-    @test err_str == " in (::$(curmod_prefix)EightBitType)() at $sn:$(method_defs_lineno + 3)"
+    @test err_str == "(::$(curmod_prefix)EightBitType)() at $sn:$(method_defs_lineno + 3)"
     err_str = @except_stackframe EightBitTypeT() ErrorException
-    @test err_str == " in $(curmod_prefix)EightBitTypeT() at $sn:$(method_defs_lineno + 4)"
+    @test err_str == "$(curmod_prefix)EightBitTypeT() at $sn:$(method_defs_lineno + 4)"
     err_str = @except_stackframe EightBitTypeT{Int32}() ErrorException
-    @test err_str == " in $(curmod_prefix)EightBitTypeT{Int32}() at $sn:$(method_defs_lineno + 5)"
+    @test err_str == "$(curmod_prefix)EightBitTypeT{Int32}() at $sn:$(method_defs_lineno + 5)"
     err_str = @except_stackframe j() ErrorException
-    @test err_str == " in (::$(curmod_prefix)EightBitTypeT{Int32})() at $sn:$(method_defs_lineno + 6)"
+    @test err_str == "(::$(curmod_prefix)EightBitTypeT{Int32})() at $sn:$(method_defs_lineno + 6)"
     err_str = @except_stackframe FunctionLike()() ErrorException
-    @test err_str == " in (::$(curmod_prefix)FunctionLike)() at $sn:$(method_defs_lineno + 7)"
+    @test err_str == "(::$(curmod_prefix)FunctionLike)() at $sn:$(method_defs_lineno + 7)"
 end
 
 # Issue #13032

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -106,12 +106,12 @@ let src = expand(quote let x = 1 end end).args[1]::CodeInfo,
     li.specTypes = Tuple{}
     sf = StackFrame(:a, :b, 3, li, false, false, 0)
     repr = string(sf)
-    @test repr == " in Toplevel MethodInstance thunk at b:3"
+    @test repr == "Toplevel MethodInstance thunk at b:3"
 end
 let li = typeof(getfield).name.mt.cache.func::Core.MethodInstance,
     sf = StackFrame(:a, :b, 3, li, false, false, 0),
     repr = string(sf)
-    @test repr == " in getfield(...) at b:3"
+    @test repr == "getfield(...) at b:3"
 end
 
 let ctestptr = cglobal((:ctest, "libccalltest")),


### PR DESCRIPTION
After the change to how stacktraces are shown, I feel that prefixing stackframes with "in"  doesn't make much sense any more. Instead, it is up to showers of collections of stackframes to take care of prefixing the output however they want. For example, the `show_backtrace` prints numbered `[#]` in front of each stackframe.

