### PR TITLE
Julep/WIP Added ability to have anonymous field names

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -74,7 +74,7 @@ function complete_symbol(sym, ffunc)
         fields = fieldnames(t)
         for field in fields
             s = string(field)
-            if startswith(s, name)
+            if startswith(s, name) && !contains(s, "#")
                 push!(suggestions, s)
             end
         end

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -195,8 +195,13 @@
 (define (decl-var v)
   (if (decl? v) (cadr v) v))
 
+;; like above, except create a "hidden" name of the form #i
+(define (decl-var-or-invent v i)
+  (if (decl? v) (if (= (length v) 3) (cadr v) (symbol (string "#" i))) v))
+
+;; allows for the possibilities of x::T or ::T => T
 (define (decl-type v)
-  (if (decl? v) (caddr v) 'Any))
+  (if (decl? v) (if (= (length v) 3) (caddr v) (cadr v)) 'Any))
 
 (define (sym-dot? e)
   (and (length= e 3) (eq? (car e) '|.|)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -809,6 +809,13 @@
         (ctors-min-initialized (car expr))
         (ctors-min-initialized (cdr expr)))))
 
+(define (sequence- lst n)
+  (if (zero? n)
+    lst
+    (append (sequence- lst (- n 1))(list n))))
+
+(define (sequence n) (sequence- () n))
+
 (define (struct-def-expr- name params bounds super fields0 mut)
   (receive
    (fields defs) (separate (lambda (x) (or (symbol? x) (decl? x)))
@@ -817,7 +824,7 @@
           (locs        (if (and (pair? fields0) (pair? (car fields0)) (eq? (caar fields0) 'line))
                            (list (car fields0))
                            '()))
-          (field-names (map decl-var fields))
+          (field-names (map decl-var-or-invent fields (sequence (length fields))))
           (field-types (map decl-type fields))
           (defs2 (if (null? defs)
                      (default-inner-ctors name field-names field-types params bounds locs)


### PR DESCRIPTION
The idea to have anonymous fields comes from [this comment](https://github.com/JuliaLang/julia/pull/20418#issuecomment-277644953). In short, it could be useful for two things: padding structs like this:
```julia
immutable RGB24  # A specific layout of a 8-bit-per-channel RGB color
    ::UInt8
    r::UInt8
    g::UInt8
    b::UInt8
end
```
and potentially for a different take on how we define primitive types (currently `bitstype`), though this requires a new built-in type like this:
```julia
immutable Int64
    ::Bits{64}
end
```

The parser will automatically insert field names of the form `#i` for the `i`th field, similar to how it inserts the equivalent to `::Any` when there is no type specified.

This is still WIP, e.g. the lisp code needs cleaning up and ~~the REPL needs to be taught not to show field names starting with `#` (it hides other thing starting with `#`, or at least it used to...)~~, ~~the default constructors shouldn't take account of unnamed fields~~ (punting), and I haven't run/written any tests yet.