### PR TITLE
Pkg resolution improvements: propagate requirements (with backtrace)

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -478,7 +478,7 @@ function resolve(
     upkgs :: Set{String} = Set{String}()
 )
     orig_reqs = reqs
-    reqs = Query.requirements(reqs,fixed,avail)
+    reqs, bktrc = Query.requirements(reqs,fixed,avail)
     deps, conflicts = Query.dependencies(avail,fixed)
 
     for pkg in keys(reqs)
@@ -496,7 +496,7 @@ function resolve(
 
     Query.check_requirements(reqs,deps,fixed)
 
-    deps = Query.prune_dependencies(reqs,deps)
+    deps = Query.prune_dependencies(reqs,deps,bktrc)
     want = Resolve.resolve(reqs,deps)
 
     if !isempty(upkgs)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -473,13 +473,13 @@ function resolve(
     reqs  :: Dict = Reqs.parse("REQUIRE"),
     avail :: Dict = Read.available(),
     instd :: Dict = Read.installed(avail),
-    fixed :: Dict = Read.fixed(avail,instd),
+    fixed :: Dict = Read.fixed(avail, instd),
     have  :: Dict = Read.free(instd),
     upkgs :: Set{String} = Set{String}()
 )
     orig_reqs = reqs
-    reqs, bktrc = Query.requirements(reqs,fixed,avail)
-    deps, conflicts = Query.dependencies(avail,fixed)
+    reqs, bktrc = Query.requirements(reqs, fixed, avail)
+    deps, conflicts = Query.dependencies(avail, fixed)
 
     for pkg in keys(reqs)
         if !haskey(deps,pkg)
@@ -494,14 +494,14 @@ function resolve(
         end
     end
 
-    Query.check_requirements(reqs,deps,fixed)
+    Query.check_requirements(reqs, deps, fixed)
 
-    deps = Query.prune_dependencies(reqs,deps,bktrc)
-    want = Resolve.resolve(reqs,deps)
+    deps = Query.prune_dependencies(reqs, deps, bktrc)
+    want = Resolve.resolve(reqs, deps)
 
     if !isempty(upkgs)
         orig_deps, _ = Query.dependencies(avail)
-        Query.check_partial_updates(orig_reqs,orig_deps,want,fixed,upkgs)
+        Query.check_partial_updates(orig_reqs, orig_deps, want, fixed, upkgs)
     end
 
     # compare what is installed with what should be

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -111,15 +111,19 @@ function partial_update_mask(instd::Dict{String,Tuple{VersionNumber,Bool}},
     for p in keys(avail)
         !haskey(avail_new, p) && push!(dont_update, p)
     end
-    for (p,_) in instd
-        !haskey(avail_new, p) && !(p in upkgs) && push!(dont_update, p)
+    for p in keys(instd)
+        !haskey(avail_new, p) && p ∉ upkgs && push!(dont_update, p)
     end
     return dont_update
 end
 
 # Try to produce some helpful message in case of a partial update which does not go all the way
 # (Does not do a full analysis, it only checks requirements and direct dependents.)
-function check_partial_updates(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}}, want::Dict{String,VersionNumber}, fixed::Dict{String,Fixed}, upkgs::Set{String})
+function check_partial_updates(reqs::Requires,
+                               deps::Dict{String,Dict{VersionNumber,Available}},
+                               want::Dict{String,VersionNumber},
+                               fixed::Dict{String,Fixed},
+                               upkgs::Set{String})
     for p in upkgs
         if !haskey(want, p)
             if !haskey(fixed, p)
@@ -305,9 +309,7 @@ function filter_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Av
         allowedp = get(allowed, p, Dict{VersionNumber,Bool}())
         fdepsp = filtered_deps[p]
         for (vn,a) in depsp
-            if !isempty(allowedp) && !allowedp[vn]
-                continue
-            end
+            get(allowedp, vn, true) || continue
             fdepsp[vn] = a
         end
     end
@@ -334,22 +336,19 @@ function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Ava
     # and put together those which are equal.
     # While we're at it, we also collect all dependencies into alldeps
     alldeps = Dict{String,Set{VersionSet}}()
-    for (p, fdepsp) in filtered_deps
-
+    for (p,fdepsp) in filtered_deps
         # Extract unique dependencies lists (aka classes), thereby
         # assigning an index to each class.
         uniqdepssets = unique(a.requires for a in values(fdepsp))
 
         # Store all dependencies seen so far for later use
         for r in uniqdepssets, (rp,rvs) in r
-            haskey(alldeps, rp) || (alldeps[rp] = Set{VersionSet}())
+            get!(alldeps, rp) do; Set{VersionSet}() end
             push!(alldeps[rp], rvs)
         end
 
         # If the package has just one version, it's uninteresting
-        if length(deps[p]) == 1
-            continue
-        end
+        length(deps[p]) == 1 && continue
 
         # Grow the pattern by the number of classes
         luds = length(uniqdepssets)
@@ -372,14 +371,11 @@ function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Ava
         # packages with just one version, or dependencies
         # which do not distiguish between versions, are not
         # interesting
-        if length(deps[p]) == 1 || vs == VersionSet()
-            continue
-        end
+        (length(deps[p]) == 1 || vs == VersionSet()) && continue
 
         # Store the dependency info in the patterns
         @assert haskey(vmask, p)
-        vmaskp = vmask[p]
-        for (vn,vm) in vmaskp
+        for (vn,vm) in vmask[p]
             push!(vm, vn in vs)
         end
     end
@@ -445,7 +441,7 @@ function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Ava
         new_deps[p] = Dict{VersionNumber,Available}()
         pruned_versp = pruned_vers[p]
         for (vn,a) in depsp
-            in(vn, pruned_versp) || continue
+            vn ∈ pruned_versp || continue
             new_deps[p][vn] = a
         end
     end
@@ -484,7 +480,7 @@ function subdeps(deps::Dict{String,Dict{VersionNumber,Available}}, pkgs::Set{Str
     for p in pkgs
         haskey(sub_deps, p) || (sub_deps[p] = Dict{VersionNumber,Available}())
         sub_depsp = sub_deps[p]
-        for (vn, a) in deps[p]
+        for (vn,a) in deps[p]
             sub_depsp[vn] = a
         end
     end
@@ -500,9 +496,7 @@ function dependencies_subset(deps::Dict{String,Dict{VersionNumber,Available}}, p
     while !isempty(staged)
         staged_next = Set{String}()
         for p in staged, a in values(get(deps, p, Dict{VersionNumber,Available}())), rp in keys(a.requires)
-            if !(rp in allpkgs) && rp ≠ "julia"
-                push!(staged_next, rp)
-            end
+            rp ∉ allpkgs && rp ≠ "julia" && push!(staged_next, rp)
         end
         union!(allpkgs, staged_next)
         staged = staged_next
@@ -530,9 +524,7 @@ function undirected_dependencies_subset(deps::Dict{String,Dict{VersionNumber,Ava
     while !isempty(staged)
         staged_next = Set{String}()
         for p in staged, rp in graph[p]
-            if !(rp in allpkgs)
-                push!(staged_next, rp)
-            end
+            rp ∉ allpkgs && push!(staged_next, rp)
         end
         union!(allpkgs, staged_next)
         staged = staged_next

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -255,7 +255,7 @@ function filter_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Av
             if !any(values(allowedp))
                 err_msg = "Unsatisfiable requirements detected for package $p:\n"
                 err_msg *= string(bktrc[p])
-                err_msg *= """The intersection of the requirements is $(bktrc[p].versionset).
+                err_msg *= """The intersection of the requirements is $(bktrc[p].versionreq).
                               None of the available versions can satisfy this requirement."""
                 throw(PkgError(err_msg))
             end
@@ -292,7 +292,7 @@ function filter_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Av
                 isreq[rp] || continue
                 bktrcp = get!(bktrc, rp) do; ResolveBacktraceItem(); end
                 push!(bktrcp, p=>bktrc[p], srvs)
-                if isa(bktrcp.versionset, VersionSet) && isempty(bktrcp.versionset)
+                if isa(bktrcp.versionreq, VersionSet) && isempty(bktrcp.versionreq)
                     err_msg = "Unsatisfiable requirements detected for package $rp:\n"
                     err_msg *= string(bktrcp)
                     err_msg *= "The intersection of the requirements is empty."

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -533,13 +533,6 @@ function undirected_dependencies_subset(deps::Dict{String,Dict{VersionNumber,Ava
     return subdeps(deps, allpkgs)
 end
 
-function filter_dependencies(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}})
-    deps = dependencies_subset(deps, Set{String}(keys(reqs)))
-    deps, _ = filter_versions(reqs, deps)
-
-    return deps
-end
-
 function prune_dependencies(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}})
     bktrc = ResolveBacktrace()
     for (p,vs) in reqs

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -6,6 +6,15 @@ import ...Pkg.PkgError
 using ..Types
 
 function requirements(reqs::Dict, fix::Dict, avail::Dict)
+    bktrc = ResolveBacktrace()
+    for (p,f) in fix
+        bktrc[p] = ResolveBacktraceItem(:fixed, f.version)
+    end
+    for (p,vs) in reqs
+        bktrcp = get!(bktrc, p) do; ResolveBacktraceItem() end
+        push!(bktrcp, :required, vs)
+    end
+
     for (p1,f1) in fix
         for p2 in keys(f1.requires)
             haskey(avail, p2) || haskey(fix, p2) || throw(PkgError("unknown package $p2 required by $p1"))
@@ -18,13 +27,17 @@ function requirements(reqs::Dict, fix::Dict, avail::Dict)
         end
     end
     reqs = deepcopy(reqs)
-    for (p1,f1) in fix
-        merge_requires!(reqs, f1.requires)
+    for (p,f) in fix
+        merge_requires!(reqs, f.requires)
+        for (rp,rvs) in f.requires
+            bktrcp = get!(bktrc, rp) do; ResolveBacktraceItem() end
+            push!(bktrcp, p=>bktrc[p], rvs)
+        end
     end
     for (p,f) in fix
         delete!(reqs, p)
     end
-    reqs
+    reqs, bktrc
 end
 
 # Specialized copy for the avail argument below because the deepcopy is slow
@@ -208,20 +221,82 @@ function check_requirements(reqs::Requires, deps::Dict{String,Dict{VersionNumber
 end
 
 # If there are explicitly required packages, dicards all versions outside
-# the allowed range (checking for impossible ranges while at it).
+# the allowed range.
+# It also propagates requirements: when all allowed versions of a required package
+# require some other package, this creates a new implicit requirement.
+# The propagation is tracked so that in case a contradiction is detected the error
+# message allows to determine the cause.
 # This is a pre-pruning step, so it also creates some structures which are later used by pruning
-function filter_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}})
-    # Parse requirements and store allowed versions.
-    allowed = Dict{String,Dict{VersionNumber, Bool}}()
-    for (p,vs) in reqs
-        @assert !haskey(allowed, p)
-        allowed[p] = Dict{VersionNumber,Bool}()
-        allowedp = allowed[p]
-        for vn in keys(deps[p])
-            allowedp[vn] = vn in vs
+function filter_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}}, bktrc::ResolveBacktrace)
+    allowed = Dict{String,Dict{VersionNumber,Bool}}()
+    staged = copy(reqs)
+    while !isempty(staged)
+        staged_next = Requires()
+        for (p,vs) in staged
+            # Parse requirements and store allowed versions.
+            depsp = deps[p]
+            if !haskey(allowed, p)
+                allowedp = Dict{VersionNumber,Bool}(vn=>true for vn in keys(depsp))
+                allowed[p] = allowedp
+                seen = false
+            else
+                allowedp = allowed[p]
+                oldallowedp = copy(allowedp)
+                seen = true
+            end
+            for vn in keys(depsp)
+                allowedp[vn] &= vn ∈ vs
+            end
+            @assert !isempty(allowedp)
+            if !any(values(allowedp))
+                err_msg = "Unsatisfiable requirements detected for package $p:\n"
+                err_msg *= string(bktrc[p])
+                err_msg *= """The intersection of the requirements is $(bktrc[p].versionset).
+                              None of the available versions can satisfy this requirement."""
+                throw(PkgError(err_msg))
+            end
+
+            # If we've seen this package already and nothing has changed since
+            # the last time, we stop here.
+            seen && allowedp == oldallowedp && continue
+
+            # Propagate requirements:
+            # if all allowed versions of a required package require some other package,
+            # then compute the union of the allowed versions for that other package, and
+            # treat that as a new requirement.
+            # Start by filtering out the non-allowed versions
+            fdepsp = Dict{VersionNumber,Available}(vn=>depsp[vn] for vn in keys(depsp) if allowedp[vn])
+            # Collect all required packages
+            isreq = Dict{String,Bool}(rp=>true for a in values(fdepsp) for rp in keys(a.requires))
+            # Compute whether a required package appears in all requirements
+            for a in values(fdepsp), rp in keys(isreq)
+                haskey(a.requires, rp) || (isreq[rp] = false)
+            end
+            staged_new = Set{String}()
+            for a in values(fdepsp)
+                for (rp,rvs) in a.requires
+                    # Skip packages that may not be required
+                    isreq[rp] || continue
+                    # Compute the union of the version sets
+                    snvs = get!(staged_next, rp, copy(rvs))
+                    union!(snvs, rvs)
+                    push!(staged_new, rp)
+                end
+            end
+            for rp in staged_new
+                srvs = staged_next[rp]
+                isreq[rp] || continue
+                bktrcp = get!(bktrc, rp) do; ResolveBacktraceItem(); end
+                push!(bktrcp, p=>bktrc[p], srvs)
+                if isa(bktrcp.versionset, VersionSet) && isempty(bktrcp.versionset)
+                    err_msg = "Unsatisfiable requirements detected for package $rp:\n"
+                    err_msg *= string(bktrcp)
+                    err_msg *= "The intersection of the requirements is empty."
+                    throw(PkgError(err_msg))
+                end
+            end
         end
-        @assert !isempty(allowedp)
-        @assert any(values(allowedp))
+        staged = staged_next
     end
 
     filtered_deps = Dict{String,Dict{VersionNumber,Available}}()
@@ -247,8 +322,8 @@ end
 #      dependency relation, they are both required or both not required)
 #   2) They have the same dependencies
 # Preliminarily calls filter_versions.
-function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}})
-    filtered_deps, allowed = filter_versions(reqs, deps)
+function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}}, bktrc::ResolveBacktrace)
+    filtered_deps, allowed = filter_versions(reqs, deps, bktrc)
 
     # To each version in each package, we associate a BitVector.
     # It is going to hold a pattern such that all versions with
@@ -399,7 +474,9 @@ function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Ava
     return new_deps, eq_classes
 end
 prune_versions(deps::Dict{String,Dict{VersionNumber,Available}}) =
-    prune_versions(Dict{String,VersionSet}(), deps)
+    prune_versions(Dict{String,VersionSet}(), deps, ResolveBacktrace())
+prune_versions(deps::Dict{String,Dict{VersionNumber,Available}}, bktrc::ResolveBacktrace) =
+    prune_versions(Dict{String,VersionSet}(), deps, bktrc)
 
 # Build a graph restricted to a subset of the packages
 function subdeps(deps::Dict{String,Dict{VersionNumber,Available}}, pkgs::Set{String})
@@ -472,8 +549,16 @@ function filter_dependencies(reqs::Requires, deps::Dict{String,Dict{VersionNumbe
 end
 
 function prune_dependencies(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}})
+    bktrc = ResolveBacktrace()
+    for (p,vs) in reqs
+        bktrc[p] = ResolveBacktraceItem(:required, vs)
+    end
+    return prune_dependencies(reqs, deps, bktrc)
+end
+
+function prune_dependencies(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}}, bktrc::ResolveBacktrace)
     deps = dependencies_subset(deps, Set{String}(keys(reqs)))
-    deps, _ = prune_versions(reqs, deps)
+    deps, _ = prune_versions(reqs, deps, bktrc)
 
     return deps
 end

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -83,13 +83,8 @@ function sanity_check(deps::Dict{String,Dict{VersionNumber,Available}},
     i = 1
     psl = 0
     for (p,vn,nvn) in vers
-        if ndeps[p][vn] == 0
-            break
-        end
-        if checked[i]
-            i += 1
-            continue
-        end
+        ndeps[p][vn] == 0 && break
+        checked[i] && (i += 1; continue)
 
         sub_reqs = Dict{String,VersionSet}(p=>VersionSet([vn, nvn]))
         local sub_deps::Dict{String,Dict{VersionNumber,Available}}

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -92,7 +92,18 @@ function sanity_check(deps::Dict{String,Dict{VersionNumber,Available}},
         end
 
         sub_reqs = Dict{String,VersionSet}(p=>VersionSet([vn, nvn]))
-        sub_deps = Query.prune_dependencies(sub_reqs, deps)
+        local sub_deps::Dict{String,Dict{VersionNumber,Available}}
+        try
+            sub_deps = Query.prune_dependencies(sub_reqs, deps)
+        catch err
+            isa(err, PkgError) || rethrow(err)
+            ## info("ERROR MESSAGE:\n" * err.msg)
+            for vneq in eq_classes[p][vn]
+                push!(problematic, (p, vneq, ""))
+            end
+            i += 1
+            continue
+        end
         interface = Interface(sub_reqs, sub_deps)
 
         red_pkgs = interface.pkgs

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -2,7 +2,8 @@
 
 module Types
 
-export VersionInterval, VersionSet, Requires, Available, Fixed, merge_requires!, satisfies
+export VersionInterval, VersionSet, Requires, Available, Fixed, merge_requires!, satisfies,
+       ResolveBacktraceItem, ResolveBacktrace
 import Base: show, isempty, in, intersect, union!, union, ==, hash, copy, deepcopy_internal, push!
 
 immutable VersionInterval
@@ -149,5 +150,94 @@ show(io::IO, f::Fixed) = isempty(f.requires) ?
 # TODO: Available & Fixed are almost the same – merge them?
 # Free could include the same information too, it just isn't
 # required by anything that processes these things.
+
+
+# This is used to keep track of dependency relations when propagating
+# requirements, so as to emit useful information in case of unsatisfiable
+# conditions.
+# The `versionset` field keeps track of the remaining allowed versions,
+# intersecting all requirements.
+# The `why` field is a Vector which keeps track of the requirements. Each
+# entry is a Tuple of two elements:
+# 1) the first element is the version requirement (can be a single VersionNumber
+#    or a VersionSet.
+# 2) the second element can be either :fixed (for requirements induced by
+#    fixed packages), :required (for requirements induced by explicitly
+#    required packages), or a Pair p=>backtrace_item (for requirements induced
+#    indirectly, where `p` is the package name and `backtrace_item` is
+#    another ResolveBacktraceItem.
+type ResolveBacktraceItem
+    versionset::Union{VersionNumber,VersionSet}
+    why::Vector
+    ResolveBacktraceItem() = new(VersionSet(), Any[])
+    ResolveBacktraceItem(reason, versionset::VersionSet) = new(versionset, Any[(versionset,reason)])
+    ResolveBacktraceItem(reason, version::VersionNumber) = new(version, Any[(version,reason)])
+end
+
+const empty_versionset = VersionSet([v"0.0",v"0.0"])
+
+function push!(ritem::ResolveBacktraceItem, reason, versionset::VersionSet)
+    if isa(ritem.versionset, VersionSet)
+        ritem.versionset = ritem.versionset ∩ versionset
+    elseif ritem.versionset ∉ versionset
+        ritem.versionset = empty_versionset
+    end
+    push!(ritem.why, (versionset,reason))
+end
+
+function push!(ritem::ResolveBacktraceItem, reason, version::VersionNumber)
+    if isa(ritem.versionset, VersionSet)
+        if version ∈ ritem.versionset
+            ritem.versionset = version
+        else
+            ritem.versionset = empty_versionset
+        end
+    elseif ritem.versionset ≠ version
+        ritem.versionset = empty_versionset
+    end
+    push!(ritem.why, (version,reason))
+end
+
+
+show(io::IO, ritem::ResolveBacktraceItem) = _show(io, ritem, "", Set{ResolveBacktraceItem}([ritem]))
+
+function _show(io::IO, ritem::ResolveBacktraceItem, indent::String, seen::Set{ResolveBacktraceItem})
+    l = length(ritem.why)
+    for (i,(vs,w)) in enumerate(ritem.why)
+        print(io, indent, (i==l ? '└' : '├'), '─')
+        if w ≡ :fixed
+            @assert isa(vs, VersionNumber)
+            println(io, "version $vs set by fixed requirement (package is checked out, dirty or pinned)")
+        elseif w ≡ :required
+            @assert isa(vs, VersionSet)
+            println(io, "version range $vs set by an explicit requirement")
+        else
+            @assert isa(w, Pair{<:AbstractString,ResolveBacktraceItem})
+            if isa(vs, VersionNumber)
+                print(io, "version $vs ")
+            else
+                print(io, "version range $vs ")
+            end
+            print(io, "required by package $(w[1]), ")
+            if isa(w[2].versionset, VersionSet)
+                if !isempty(w[2].versionset)
+                    println(io, "whose allowed version range is $(w[2].versionset):")
+                else
+                    println(io, "whose allowed version range is empty:")
+                end
+            else
+                println(io, "whose only allowed version is $(w[2].versionset):")
+            end
+            if w[2] ∈ seen
+                println(io, (i==l ? "  " : "│ ") * indent, "└─[see above for $(w[1]) backtrace]")
+                continue
+            end
+            push!(seen, w[2])
+            _show(io, w[2], (i==l ? "  " : "│ ") * indent, seen)
+        end
+    end
+end
+
+typealias ResolveBacktrace Dict{AbstractString,ResolveBacktraceItem}
 
 end # module

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -70,12 +70,12 @@ function normalize!(A::VersionSet)
             lo = lo1
             continue
         end
-        fuse && splice!(ivals, (k+1):k0, [VersionInterval(lo, up),])
+        fuse && splice!(ivals, (k+1):k0, (VersionInterval(lo, up),))
         fuse = false
         lo, up = lo1, up1
         k0 = k
     end
-    fuse && splice!(ivals, 1:k0, [VersionInterval(lo, up),])
+    fuse && splice!(ivals, 1:k0, (VersionInterval(lo, up),))
     return A
 end
 
@@ -94,10 +94,10 @@ function union!(A::VersionSet, B::VersionSet)
         for k1 = k0:length(ivals)
             intA = ivals[k1]
             if uB < intA.lower
-                splice!(ivals, k0:(k1-1), [VersionInterval(lB, uB),])
+                splice!(ivals, k0:(k1-1), (VersionInterval(lB, uB),))
                 break
             elseif uB ∈ intA || k1 == length(ivals)
-                splice!(ivals, k0:k1, [VersionInterval(lB, max(uB, intA.upper)),])
+                splice!(ivals, k0:k1, (VersionInterval(lB, max(uB, intA.upper)),))
                 break
             end
         end
@@ -152,48 +152,50 @@ show(io::IO, f::Fixed) = isempty(f.requires) ?
 # required by anything that processes these things.
 
 
+typealias VersionReq Union{VersionNumber,VersionSet}
+typealias WhyReq Tuple{VersionReq,Any}
+
 # This is used to keep track of dependency relations when propagating
 # requirements, so as to emit useful information in case of unsatisfiable
 # conditions.
-# The `versionset` field keeps track of the remaining allowed versions,
+# The `versionreq` field keeps track of the remaining allowed versions,
 # intersecting all requirements.
 # The `why` field is a Vector which keeps track of the requirements. Each
 # entry is a Tuple of two elements:
 # 1) the first element is the version requirement (can be a single VersionNumber
-#    or a VersionSet.
+#    or a VersionSet).
 # 2) the second element can be either :fixed (for requirements induced by
 #    fixed packages), :required (for requirements induced by explicitly
 #    required packages), or a Pair p=>backtrace_item (for requirements induced
 #    indirectly, where `p` is the package name and `backtrace_item` is
 #    another ResolveBacktraceItem.
 type ResolveBacktraceItem
-    versionset::Union{VersionNumber,VersionSet}
-    why::Vector
-    ResolveBacktraceItem() = new(VersionSet(), Any[])
-    ResolveBacktraceItem(reason, versionset::VersionSet) = new(versionset, Any[(versionset,reason)])
-    ResolveBacktraceItem(reason, version::VersionNumber) = new(version, Any[(version,reason)])
+    versionreq::VersionReq
+    why::Vector{WhyReq}
+    ResolveBacktraceItem() = new(VersionSet(), WhyReq[])
+    ResolveBacktraceItem(reason, versionreq::VersionReq) = new(versionreq, WhyReq[(versionreq,reason)])
 end
 
 const empty_versionset = VersionSet([v"0.0",v"0.0"])
 
 function push!(ritem::ResolveBacktraceItem, reason, versionset::VersionSet)
-    if isa(ritem.versionset, VersionSet)
-        ritem.versionset = ritem.versionset ∩ versionset
-    elseif ritem.versionset ∉ versionset
-        ritem.versionset = empty_versionset
+    if isa(ritem.versionreq, VersionSet)
+        ritem.versionreq = ritem.versionreq ∩ versionset
+    elseif ritem.versionreq ∉ versionset
+        ritem.versionreq = empty_versionset
     end
     push!(ritem.why, (versionset,reason))
 end
 
 function push!(ritem::ResolveBacktraceItem, reason, version::VersionNumber)
-    if isa(ritem.versionset, VersionSet)
-        if version ∈ ritem.versionset
-            ritem.versionset = version
+    if isa(ritem.versionreq, VersionSet)
+        if version ∈ ritem.versionreq
+            ritem.versionreq = version
         else
-            ritem.versionset = empty_versionset
+            ritem.versionreq = empty_versionset
         end
-    elseif ritem.versionset ≠ version
-        ritem.versionset = empty_versionset
+    elseif ritem.versionreq ≠ version
+        ritem.versionreq = empty_versionset
     end
     push!(ritem.why, (version,reason))
 end
@@ -219,14 +221,14 @@ function _show(io::IO, ritem::ResolveBacktraceItem, indent::String, seen::Set{Re
                 print(io, "version range $vs ")
             end
             print(io, "required by package $(w[1]), ")
-            if isa(w[2].versionset, VersionSet)
-                if !isempty(w[2].versionset)
-                    println(io, "whose allowed version range is $(w[2].versionset):")
+            if isa(w[2].versionreq, VersionSet)
+                if !isempty(w[2].versionreq)
+                    println(io, "whose allowed version range is $(w[2].versionreq):")
                 else
                     println(io, "whose allowed version range is empty:")
                 end
             else
-                println(io, "whose only allowed version is $(w[2].versionset):")
+                println(io, "whose only allowed version is $(w[2].versionreq):")
             end
             if w[2] ∈ seen
                 println(io, (i==l ? "  " : "│ ") * indent, "└─[see above for $(w[1]) backtrace]")

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -3,7 +3,7 @@
 module Types
 
 export VersionInterval, VersionSet, Requires, Available, Fixed, merge_requires!, satisfies
-import Base: show, isempty, in, intersect, ==, hash, copy, deepcopy_internal
+import Base: show, isempty, in, intersect, union!, union, ==, hash, copy, deepcopy_internal, push!
 
 immutable VersionInterval
     lower::VersionNumber
@@ -40,15 +40,73 @@ show(io::IO, s::VersionSet) = join(io, s.intervals, " ∪ ")
 isempty(s::VersionSet) = all(isempty, s.intervals)
 in(v::VersionNumber, s::VersionSet) = any(i->in(v,i), s.intervals)
 function intersect(A::VersionSet, B::VersionSet)
-    ivals = vec([ intersect(a,b) for a in A.intervals, b in B.intervals ])
-    ivals = copy(ivals) # temporary bandaid for issue #4592
+    ivals = [intersect(a,b) for a in A.intervals for b in B.intervals]
     filter!(i->!isempty(i), ivals)
     sort!(ivals, by=i->i.lower)
     VersionSet(ivals)
 end
+copy(A::VersionSet) = VersionSet(copy(A.intervals))
+
+function normalize!(A::VersionSet)
+    # removes empty intervals and fuses intervals without gaps
+    # e.g.:
+    #     [0.0.0,1.0.0) ∪ [1.0.0,1.5.0) ∪ [1.6.0,1.6.0) ∪ [2.0.0,∞)
+    # becomes:
+    #     [0.0.0,1.5.0) ∪ [2.0.0,∞)
+    # (still assumes that intervals are properly sorted)
+    ivals = A.intervals
+    l = length(ivals)
+    for k = l:-1:1
+        isempty(ivals[k]) && (splice!(ivals, k); l -= 1)
+    end
+    l > 1 || return A
+    lo, up, k0 = ivals[l].lower, ivals[l].upper, l
+    fuse = false
+    for k = (l-1):-1:1
+        lo1, up1 = ivals[k].lower, ivals[k].upper
+        if up1 == lo
+            fuse = true
+            lo = lo1
+            continue
+        end
+        fuse && splice!(ivals, (k+1):k0, [VersionInterval(lo, up),])
+        fuse = false
+        lo, up = lo1, up1
+        k0 = k
+    end
+    fuse && splice!(ivals, 1:k0, [VersionInterval(lo, up),])
+    return A
+end
+
+union(A::VersionSet, B::VersionSet) = union!(copy(A), B)
+function union!(A::VersionSet, B::VersionSet)
+    A == B && return normalize!(A)
+    ivals = A.intervals
+    for intB in B.intervals
+        lB, uB = intB.lower, intB.upper
+        k0 = findfirst(i->(i.upper > lB), ivals)
+        if k0 == 0
+            push!(ivals, intB)
+            continue
+        end
+        lB = min(lB, ivals[k0].lower)
+        for k1 = k0:length(ivals)
+            intA = ivals[k1]
+            if uB < intA.lower
+                splice!(ivals, k0:(k1-1), [VersionInterval(lB, uB),])
+                break
+            elseif uB ∈ intA || k1 == length(ivals)
+                splice!(ivals, k0:k1, [VersionInterval(lB, max(uB, intA.upper)),])
+                break
+            end
+        end
+    end
+    return normalize!(VersionSet(ivals))
+end
+
 ==(A::VersionSet, B::VersionSet) = A.intervals == B.intervals
 hash(s::VersionSet, h::UInt) = hash(s.intervals, h + (0x2fd2ca6efa023f44 % UInt))
-deepcopy_internal(vs::VersionSet, ::ObjectIdDict) = VersionSet(copy(vs.intervals))
+deepcopy_internal(vs::VersionSet, ::ObjectIdDict) = copy(vs)
 
 typealias Requires Dict{String,VersionSet}
 

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -94,7 +94,7 @@ function sanity_tst(deps_data, expected_result; pkgs=[])
     result = sanity_check(deps, Set(String[pkgs...]))
     length(result) == length(expected_result) || return false
     for (p, vn, pp) in result
-        in((p, vn), expected_result) || return  false
+        (p, vn) ∈ expected_result || return  false
     end
     return true
 end


### PR DESCRIPTION
This adds a pre-pruning step in which requirements are propagated along the dependency graph, keeping a backtrace of the process. The logic is explained [here](https://github.com/JuliaLang/julia/blob/41f9d6b3301d65a291870a096ce56e941599a4a7/base/pkg/query.jl#L266-L269): if all allowed versions of a required package require some other package, then compute the union of all the allowed versions for that other package, and treat that as a new requirement. At the end, versions outside the allowed ranges are pruned.

This has two benefits:
1. It makes things easier for the solver, by simplifying the graph and reducing the number of versions
2. It should detect most common problems with requirements that introduce implicit contradictions, and (since it keeps track of the process) it provides a useful error message to fix the situation.

Take for example the second issue reported in #20313. The previous code used to produce this:

```
julia> Pkg.pin("ColorTypes",v"0.3.0") ### the error message below is blaming the wrong package!!!
INFO: Creating ColorTypes branch pinned.a846a532.tmp
ERROR: unsatisfiable package requirements detected: no feasible version could be found for package: ImageRegistration
```
(the solver detected a problem, but the error message was unhelpful and actually misleading.)

With this PR the problem is detected before invoking the solver, and it produces this instead:

```
julia> Pkg.pin("ColorTypes", v"0.3.0")
INFO: Package ColorTypes: checking out existing branch pinned.a846a532.tmp
ERROR: Unsatisfiable requirements detected for package FixedPointNumbers:
├─version range [0.3.0,∞) required by package ColorTypes, whose only allowed version is 0.3.0:
│ └─version 0.3.0 set by fixed requirement (package is checked out, dirty or pinned)
├─version range [0.0.0-,∞) required by package ImageRegistration, whose allowed version range is [0.0.0-,∞):
│ └─version range [0.0.0-,∞) set by an explicit requirement
└─version range [0.0.0-,0.3.0) required by package Images, whose allowed version range is [0.0.0-,∞):
  └─version range [0.0.0-,∞) required by package ImageRegistration, whose allowed version range is [0.0.0-,∞):
    └─[see above for ImageRegistration backtrace]
The intersection of the requirements is empty.
```

cc @tkelman

I suppose that in the future some of this code could be reused and be relevant for addressing #13340 too.

Edit: I have also just changed the error message in case of failure of the solver, to at least improve the situation in cases like the one of #20313. Now it prints something like this:

```
ERROR: resolve is unable to satisfy package requirements.
  The problem was detected when trying to find a feasible version
  for package X.
  However, this only means that package X is involved in an
  unsatifiable or difficult dependency relation, and the root of
  the problem may be elsewhere.
```
