### PR TITLE
update comment for icc17-cmake patch.

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -505,7 +505,7 @@ $(eval $(call LLVM_PATCH,llvm-D27397)) # Julia issue #19792, Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D28009)) # Julia issue #19792, Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D28215_FreeBSD_shlib))
 $(eval $(call LLVM_PATCH,llvm-D28221-avx512)) # mentioned in issue #19797
-$(eval $(call LLVM_PATCH,llvm-rL293230-icc17-cmake)) # Remove for 5.0
+$(eval $(call LLVM_PATCH,llvm-rL293230-icc17-cmake)) # Remove for 4.0
 endif # LLVM_VER
 
 ifeq ($(LLVM_VER),3.7.1)


### PR DESCRIPTION
Before I forget that the patch got backported to `release-40`.

I did run `make check-whitespace` locally.