### PR TITLE
RFC: tests for dimensional correctness of Base

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1859,7 +1859,8 @@ function sqrtm(A::UpperTriangular)
     if isreal(A)
         realmatrix = true
         for i = 1:checksquare(A)
-            if real(A[i,i]) < 0
+            x = real(A[i,i])
+            if x < zero(x)
                 realmatrix = false
                 break
             end

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1880,7 +1880,7 @@ function sqrtm{T,realmatrix}(A::UpperTriangular{T},::Type{Val{realmatrix}})
             @simd for k = i+1:j-1
                 r -= R[i,k]*R[k,j]
             end
-            r==0 || (R[i,j] = sylvester(R[i,i],R[j,j],-r))
+            iszero(r) || (R[i,j] = sylvester(R[i,i],R[j,j],-r))
         end
     end
     return UpperTriangular(R)

--- a/base/range.jl
+++ b/base/range.jl
@@ -33,7 +33,10 @@ Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1, 
 is similar but uses a step size of `s`. These syntaxes call the function `colon`. The colon
 is also used in indexing to select whole dimensions.
 """
-colon{T}(start::T, step, stop::T) = StepRange(start, step, stop)
+function colon{T}(start::T, step, stop::T)
+    T′ = typeof(start+step)
+    StepRange(convert(T′,start), step, convert(T′,stop))
+end
 
 """
     range(start, [step], length)

--- a/base/range.jl
+++ b/base/range.jl
@@ -6,7 +6,7 @@ colon{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
 
 range(a::Real, len::Integer) = UnitRange{typeof(a)}(a, oftype(a, a+len-1))
 
-colon{T}(start::T, stop::T) = colon(start, oneunit(stop-start), stop)
+colon{T}(start::T, stop::T) = colon(start, oftype(stop-start, 1), stop)
 
 range(a, len::Integer) = range(a, oneunit(a-a), len)
 
@@ -49,7 +49,7 @@ _range{T,S}(::Any, ::Any, a::T, step::S, len::Integer) = StepRangeLen{typeof(a+0
 
 # AbstractFloat specializations
 colon{T<:AbstractFloat}(a::T, b::T) = colon(a, T(1), b)
-range(a::AbstractFloat, len::Integer) = range(a, oneunit(a), len)
+range(a::AbstractFloat, len::Integer) = range(a, oftype(a, 1), len)
 
 colon{T<:Real}(a::T, b::AbstractFloat, c::T) = colon(promote(a,b,c)...)
 colon{T<:AbstractFloat}(a::T, b::AbstractFloat, c::T) = colon(promote(a,b,c)...)

--- a/base/range.jl
+++ b/base/range.jl
@@ -6,9 +6,9 @@ colon{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
 
 range(a::Real, len::Integer) = UnitRange{typeof(a)}(a, oftype(a, a+len-1))
 
-colon{T}(start::T, stop::T) = colon(start, oftype(stop-start, 1), stop)
+colon{T}(start::T, stop::T) = colon(start, oneunit(stop-start), stop)
 
-range(a, len::Integer) = range(a, oftype(a-a, 1), len)
+range(a, len::Integer) = range(a, oneunit(a-a), len)
 
 # first promote start and stop, leaving step alone
 colon{A<:Real,C<:Real}(start::A, step, stop::C) = colon(convert(promote_type(A,C),start), step, convert(promote_type(A,C),stop))
@@ -46,7 +46,7 @@ _range{T,S}(::Any, ::Any, a::T, step::S, len::Integer) = StepRangeLen{typeof(a+0
 
 # AbstractFloat specializations
 colon{T<:AbstractFloat}(a::T, b::T) = colon(a, T(1), b)
-range(a::AbstractFloat, len::Integer) = range(a, oftype(a, 1), len)
+range(a::AbstractFloat, len::Integer) = range(a, oneunit(a), len)
 
 colon{T<:Real}(a::T, b::AbstractFloat, c::T) = colon(promote(a,b,c)...)
 colon{T<:AbstractFloat}(a::T, b::AbstractFloat, c::T) = colon(promote(a,b,c)...)

--- a/base/range.jl
+++ b/base/range.jl
@@ -8,7 +8,7 @@ range(a::Real, len::Integer) = UnitRange{typeof(a)}(a, oftype(a, a+len-1))
 
 colon{T}(start::T, stop::T) = colon(start, oftype(stop-start, 1), stop)
 
-range(a, len::Integer) = range(a, oneunit(a-a), len)
+range(a, len::Integer) = range(a, oftype(a-a, 1), len)
 
 # first promote start and stop, leaving step alone
 colon{A<:Real,C<:Real}(start::A, step, stop::C) = colon(convert(promote_type(A,C),start), step, convert(promote_type(A,C),stop))

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -41,7 +41,7 @@ function mean!(R::AbstractArray, A::AbstractArray)
     return R
 end
 
-momenttype{T}(::Type{T}) = typeof((zero(T) + zero(T)) / 2)
+momenttype{T}(::Type{T}) = typeof((zero(T)*zero(T) + zero(T)*zero(T)) / 2)
 momenttype(::Type{Float32}) = Float32
 momenttype(::Type{<:Union{Float64,Int32,Int64,UInt32,UInt64}}) = Float64
 

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -2,6 +2,9 @@
 
 module TestHelpers
 
+include("dimensionful.jl")
+export Furlong
+
 mutable struct FakeTerminal <: Base.Terminals.UnixTerminal
     in_stream::Base.IO
     out_stream::Base.IO

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,7 +35,7 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
-        "channels"
+        "channels", "dimensionful"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,7 +35,7 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "parallel", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
-        "channels", "dimensionful"
+        "channels"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -25,10 +25,10 @@ Base.zero{p,T}(::Type{Furlong{p,T}}) = Furlong{p,T}(zero(T))
 Base.abs{p,T}(x::Furlong{p,T}) = Furlong{p,T}(abs(x.val))
 
 for f in (:isfinite, :isnan, :isreal)
-    @eval Base.$f(x::Furlong) = isfinite(x.val)
+    @eval Base.$f(x::Furlong) = $f(x.val)
 end
 for f in (:real,:imag,:complex)
-    @eval Base.$f{p,T}(x::Furlong{p,T}) = Furlong{p}(f(x.val))
+    @eval Base.$f{p,T}(x::Furlong{p,T}) = Furlong{p}($f(x.val))
 end
 
 import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -27,11 +27,13 @@ Base.zero{p,T}(::Type{Furlong{p,T}}) = Furlong{p,T}(zero(T))
 Base.iszero(x::Furlong) = iszero(x.val)
 
 Base.abs{p,T}(x::Furlong{p,T}) = Furlong{p,T}(abs(x.val))
+@generated Base.inv{p,T}(x::Furlong{p,T}) = :(Furlong{$(-p)}(inv(x.val)))
+Base.sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 
 for f in (:isfinite, :isnan, :isreal)
     @eval Base.$f(x::Furlong) = $f(x.val)
 end
-for f in (:real,:imag,:complex)
+for f in (:real,:imag,:complex,:+,:-)
     @eval Base.$f{p,T}(x::Furlong{p,T}) = Furlong{p}($f(x.val))
 end
 
@@ -72,3 +74,7 @@ Base.sqrt{p,T}(x::Furlong{p,T}) = _div(sqrt(x.val), x, Val{2})
 @test collect(Furlong(2):Furlong(10)) == collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong.(2:10)
 @test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
       collect(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)
+
+let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
+    @test sqrtm(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))
+end

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -24,6 +24,7 @@ Base.one{p,T}(x::Furlong{p,T}) = one(T)
 Base.one{p,T}(::Type{Furlong{p,T}}) = one(T)
 Base.zero{p,T}(x::Furlong{p,T}) = Furlong{p,T}(zero(T))
 Base.zero{p,T}(::Type{Furlong{p,T}}) = Furlong{p,T}(zero(T))
+Base.iszero(x::Furlong) = iszero(x.val)
 
 Base.abs{p,T}(x::Furlong{p,T}) = Furlong{p,T}(abs(x.val))
 
@@ -41,6 +42,7 @@ for op in (:+, :-)
         Furlong{p}(v)
     end
 end
+<(x::Furlong,r::Real) = iszero(r) ? x.val < 0 : error("can't compare Furlongs to nonzero real")
 for op in (:(==), :(!=), :<, :<=, :isless, :isequal)
     @eval $op{T,p,S}(x::Furlong{p,T}, y::Furlong{p,S}) = $op(x.val, y.val)
 end
@@ -48,7 +50,7 @@ end
 for (f,op) in ((:_plus,:+),(:_minus,:-),(:_times,:*),(:_div,://))
     @eval @generated function $f{T,p,q}(v::T, ::Furlong{p}, ::Union{Furlong{q},Type{Val{q}}})
         s = $op(p, q)
-        :(Furlong{$s,$T}(v))
+        isinteger(s) ? :(Furlong{$(Int(s)),$T}(v)) : :(Furlong{$s,$T}(v))
     end
 end
 for (op,eop) in ((:*, :_plus), (:/, :_minus), (://, :_minus), (:div, :_minus))
@@ -68,4 +70,5 @@ end
 Base.sqrt{p,T}(x::Furlong{p,T}) = _div(sqrt(x.val), x, Val{2})
 
 @test collect(Furlong(2):Furlong(10)) == collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong.(2:10)
-@test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) == Furlong.(1:0.5:10)
+@test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
+      collect(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -5,8 +5,8 @@
 # represents a quantity in furlongs^p
 struct Furlong{p,T<:Number} <: Number
     val::T
-    Furlong(v::Number) = new(v)
-    Furlong(x::Furlong{p}) = new(x.val)
+    Furlong{p,T}(v::Number) where {p,T} = new(v)
+    Furlong{p,T}(x::Furlong{p}) where {p,T} = new(x.val)
 end
 Furlong{T<:Number}(x::T) = Furlong{1,T}(x)
 (::Type{T}){p,T}(x::Furlong{p,T}) = x.val

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -27,6 +27,7 @@ Base.zero{p,T}(::Type{Furlong{p,T}}) = Furlong{p,T}(zero(T))
 Base.iszero(x::Furlong) = iszero(x.val)
 
 Base.abs{p,T}(x::Furlong{p,T}) = Furlong{p,T}(abs(x.val))
+@generated Base.abs2{p,T}(x::Furlong{p,T}) = :(Furlong{$(2p),T}(abs2(x.val)))
 @generated Base.inv{p,T}(x::Furlong{p,T}) = :(Furlong{$(-p)}(inv(x.val)))
 Base.sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 
@@ -74,6 +75,12 @@ Base.sqrt{p,T}(x::Furlong{p,T}) = _div(sqrt(x.val), x, Val{2})
 @test collect(Furlong(2):Furlong(10)) == collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong.(2:10)
 @test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
       collect(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)
+
+@test sum(Furlong(1):Furlong(10)) == sum(collect(Furlong(1):Furlong(10))) == Furlong(55)
+@test cumsum(Furlong(1):Furlong(3)) == Furlong.([1,3,6])
+@test mean([Furlong(1), Furlong(2)]) == Furlong(1.5)
+@test var([Furlong(1), Furlong(2)]) == Furlong{2}(0.5)
+@test std([Furlong(1), Furlong(2)]) == Furlong{1}(sqrt(0.5))
 
 let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
     @test sqrtm(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -1,12 +1,9 @@
-# Tests to make sure that Julia functions work with types representing
-# dimensionful quantities, like in the Unitful.jl package.  Here
-# we implement a minimal dimensionful type and use it to test various
-# functions in Base.
-
-using Base.Test
+# Here we implement a minimal dimensionful type Furlong, which is used
+# to test dimensional correctness of various functions in Base.  Furlong
+# is exported by the TestHelpers module.
 
 # represents a quantity in furlongs^p
-immutable Furlong{p,T<:Number} <: Number
+struct Furlong{p,T<:Number} <: Number
     val::T
 end
 Furlong{T<:Number}(x::T) = Furlong{1,T}(x)
@@ -26,62 +23,53 @@ Base.zero{p,T}(x::Furlong{p,T}) = Furlong{p,T}(zero(T))
 Base.zero{p,T}(::Type{Furlong{p,T}}) = Furlong{p,T}(zero(T))
 Base.iszero(x::Furlong) = iszero(x.val)
 
-Base.abs{p,T}(x::Furlong{p,T}) = Furlong{p,T}(abs(x.val))
-@generated Base.abs2{p,T}(x::Furlong{p,T}) = :(Furlong{$(2p),T}(abs2(x.val)))
-@generated Base.inv{p,T}(x::Furlong{p,T}) = :(Furlong{$(-p)}(inv(x.val)))
+# convert Furlong exponent p to a canonical form.  This
+# is not type stable, but it doesn't matter since it is used
+# at compile time (in generated functions), not runtime
+canonical_p(p) = isinteger(p) ? Int(p) : Rational{Int}(p)
+
+Base.abs{p}(x::Furlong{p}) = Furlong{p}(abs(x.val))
+@generated Base.abs2{p}(x::Furlong{p}) = :(Furlong{$(canonical_p(2p))}(abs2(x.val)))
+@generated Base.inv{p}(x::Furlong{p}) = :(Furlong{$(canonical_p(-p))}(inv(x.val)))
 Base.sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 
 for f in (:isfinite, :isnan, :isreal)
     @eval Base.$f(x::Furlong) = $f(x.val)
 end
-for f in (:real,:imag,:complex,:+,:-)
-    @eval Base.$f{p,T}(x::Furlong{p,T}) = Furlong{p}($f(x.val))
+for f in (:real,:imag,:complex,:middle,:+,:-)
+    @eval Base.$f{p}(x::Furlong{p}) = Furlong{p}($f(x.val))
 end
 
-import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^
-for op in (:+, :-)
-    @eval function $op{T,p,S}(x::Furlong{p,T}, y::Furlong{p,S})
+import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^,
+             middle, hypot
+for op in (:+, :-, :middle, :hypot)
+    @eval function $op{p}(x::Furlong{p}, y::Furlong{p})
         v = $op(x.val, y.val)
         Furlong{p}(v)
     end
 end
-<(x::Furlong,r::Real) = iszero(r) ? x.val < 0 : error("can't compare Furlongs to nonzero real")
 for op in (:(==), :(!=), :<, :<=, :isless, :isequal)
-    @eval $op{T,p,S}(x::Furlong{p,T}, y::Furlong{p,S}) = $op(x.val, y.val)
+    @eval $op{p}(x::Furlong{p}, y::Furlong{p}) = $op(x.val, y.val)
 end
 # generated functions to allow type inference of the value of the exponent:
 for (f,op) in ((:_plus,:+),(:_minus,:-),(:_times,:*),(:_div,://))
     @eval @generated function $f{T,p,q}(v::T, ::Furlong{p}, ::Union{Furlong{q},Type{Val{q}}})
         s = $op(p, q)
-        isinteger(s) ? :(Furlong{$(Int(s)),$T}(v)) : :(Furlong{$s,$T}(v))
+        :(Furlong{$(canonical_p(s)),$T}(v))
     end
 end
 for (op,eop) in ((:*, :_plus), (:/, :_minus), (://, :_minus), (:div, :_minus))
     @eval begin
-        $op{T,p,q,S}(x::Furlong{p,T}, y::Furlong{q,S}) =
+        $op{p,q}(x::Furlong{p}, y::Furlong{q}) =
             $eop($op(x.val, y.val),x,y)
-        $op{p,T,S<:Number}(x::Furlong{p,T}, y::S) = $op(x,Furlong{0,S}(y))
-        $op{p,T,S<:Number}(x::S, y::Furlong{p,T}) = $op(Furlong{0,S}(x),y)
+        $op{p,S<:Number}(x::Furlong{p}, y::S) = $op(x,Furlong{0,S}(y))
+        $op{p,S<:Number}(x::S, y::Furlong{p}) = $op(Furlong{0,S}(x),y)
     end
 end
 for op in (:rem, :mod)
     @eval begin
-        $op{p,T}(x::Furlong{p,T}, y::Furlong) = Furlong{p}($op(x.val, y.val))
-        $op{p,T}(x::Furlong{p,T}, y::Number) = Furlong{p}($op(x.val, y))
+        $op{p}(x::Furlong{p}, y::Furlong) = Furlong{p}($op(x.val, y.val))
+        $op{p}(x::Furlong{p}, y::Number) = Furlong{p}($op(x.val, y))
     end
 end
-Base.sqrt{p,T}(x::Furlong{p,T}) = _div(sqrt(x.val), x, Val{2})
-
-@test collect(Furlong(2):Furlong(10)) == collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong.(2:10)
-@test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
-      collect(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)
-
-@test sum(Furlong(1):Furlong(10)) == sum(collect(Furlong(1):Furlong(10))) == Furlong(55)
-@test cumsum(Furlong(1):Furlong(3)) == Furlong.([1,3,6])
-@test mean([Furlong(1), Furlong(2)]) == Furlong(1.5)
-@test var([Furlong(1), Furlong(2)]) == Furlong{2}(0.5)
-@test std([Furlong(1), Furlong(2)]) == Furlong{1}(sqrt(0.5))
-
-let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
-    @test sqrtm(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))
-end
+Base.sqrt(x::Furlong) = _div(sqrt(x.val), x, Val{2})

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -5,6 +5,8 @@
 # represents a quantity in furlongs^p
 struct Furlong{p,T<:Number} <: Number
     val::T
+    Furlong(v::Number) = new(v)
+    Furlong(x::Furlong{p}) = new(x.val)
 end
 Furlong{T<:Number}(x::T) = Furlong{1,T}(x)
 (::Type{T}){p,T}(x::Furlong{p,T}) = x.val

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -17,6 +17,9 @@ Base.convert{T}(::Type{Furlong{0,T}}, x::Furlong{0}) = Furlong{0,T}(convert(T, x
 Base.convert{T<:Number}(::Type{T}, x::Furlong{0}) = convert(T, x.val)
 Base.convert{T}(::Type{Furlong{0,T}}, x::Number) = Furlong{0,T}(convert(T, x))
 
+Base.promote_type{p,T,S}(::Type{Furlong{p,T}}, ::Type{Furlong{p,S}}) =
+    (Base.@_pure_meta; Furlong{p,promote_type(T,S)})
+
 Base.one{p,T}(x::Furlong{p,T}) = one(T)
 Base.one{p,T}(::Type{Furlong{p,T}}) = one(T)
 Base.zero{p,T}(x::Furlong{p,T}) = Furlong{p,T}(zero(T))
@@ -64,4 +67,5 @@ for op in (:rem, :mod)
 end
 Base.sqrt{p,T}(x::Furlong{p,T}) = _div(sqrt(x.val), x, Val{2})
 
-@test collect(Furlong(2):Furlong(10)) == collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong{1}.(2:10)
+@test collect(Furlong(2):Furlong(10)) == collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong.(2:10)
+@test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) == Furlong.(1:0.5:10)

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -1,0 +1,67 @@
+# Tests to make sure that Julia functions work with types representing
+# dimensionful quantities, like in the Unitful.jl package.  Here
+# we implement a minimal dimensionful type and use it to test various
+# functions in Base.
+
+using Base.Test
+
+# represents a quantity in furlongs^p
+immutable Furlong{p,T<:Number} <: Number
+    val::T
+end
+Furlong{T<:Number}(x::T) = Furlong{1,T}(x)
+(::Type{T}){p,T}(x::Furlong{p,T}) = x.val
+(::Type{Furlong{p}}){p}(v::Number) = Furlong{p,typeof(v)}(v)
+Base.convert{T,p,S}(::Type{Furlong{p,T}}, x::Furlong{p,S}) = Furlong{p,T}(convert(T,x.val))
+Base.convert{T}(::Type{Furlong{0,T}}, x::Furlong{0}) = Furlong{0,T}(convert(T, x.val))
+Base.convert{T<:Number}(::Type{T}, x::Furlong{0}) = convert(T, x.val)
+Base.convert{T}(::Type{Furlong{0,T}}, x::Number) = Furlong{0,T}(convert(T, x))
+
+Base.one{p,T}(x::Furlong{p,T}) = one(T)
+Base.one{p,T}(::Type{Furlong{p,T}}) = one(T)
+Base.zero{p,T}(x::Furlong{p,T}) = Furlong{p,T}(zero(T))
+Base.zero{p,T}(::Type{Furlong{p,T}}) = Furlong{p,T}(zero(T))
+
+Base.abs{p,T}(x::Furlong{p,T}) = Furlong{p,T}(abs(x.val))
+
+for f in (:isfinite, :isnan, :isreal)
+    @eval Base.$f(x::Furlong) = isfinite(x.val)
+end
+for f in (:real,:imag,:complex)
+    @eval Base.$f{p,T}(x::Furlong{p,T}) = Furlong{p}(f(x.val))
+end
+
+import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^
+for op in (:+, :-)
+    @eval function $op{T,p,S}(x::Furlong{p,T}, y::Furlong{p,S})
+        v = $op(x.val, y.val)
+        Furlong{p}(v)
+    end
+end
+for op in (:(==), :(!=), :<, :<=, :isless, :isequal)
+    @eval $op{T,p,S}(x::Furlong{p,T}, y::Furlong{p,S}) = $op(x.val, y.val)
+end
+# generated functions to allow type inference of the value of the exponent:
+for (f,op) in ((:_plus,:+),(:_minus,:-),(:_times,:*),(:_div,://))
+    @eval @generated function $f{T,p,q}(v::T, ::Furlong{p}, ::Union{Furlong{q},Type{Val{q}}})
+        s = $op(p, q)
+        :(Furlong{$s,$T}(v))
+    end
+end
+for (op,eop) in ((:*, :_plus), (:/, :_minus), (://, :_minus), (:div, :_minus))
+    @eval begin
+        $op{T,p,q,S}(x::Furlong{p,T}, y::Furlong{q,S}) =
+            $eop($op(x.val, y.val),x,y)
+        $op{p,T,S<:Number}(x::Furlong{p,T}, y::S) = $op(x,Furlong{0,S}(y))
+        $op{p,T,S<:Number}(x::S, y::Furlong{p,T}) = $op(Furlong{0,S}(x),y)
+    end
+end
+for op in (:rem, :mod)
+    @eval begin
+        $op{p,T}(x::Furlong{p,T}, y::Furlong) = Furlong{p}($op(x.val, y.val))
+        $op{p,T}(x::Furlong{p,T}, y::Number) = Furlong{p}($op(x.val, y))
+    end
+end
+Base.sqrt{p,T}(x::Furlong{p,T}) = _div(sqrt(x.val), x, Val{2})
+
+@test collect(Furlong(2):Furlong(10)) == collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong{1}.(2:10)

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -495,3 +495,10 @@ end
 
 # Issue 16196
 @test UpperTriangular(eye(3)) \ view(ones(3), [1,2,3]) == ones(3)
+
+# dimensional correctness:
+isdefined(Main, :TestHelpers) || @eval Main include("../TestHelpers.jl")
+using TestHelpers.Furlong
+let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
+    @test sqrtm(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))
+end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -890,6 +890,6 @@ isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using TestHelpers.Furlong
 @test_throws MethodError collect(Furlong(2):Furlong(10)) # step size is ambiguous
 @test_throws MethodError range(Furlong(2), 9) # step size is ambiguous
-@test collect(Furlong(2):Furlong(1):Furlong(10)) == range(Furlong(2),Furlong(1),9) == Furlong.(2:10)
+@test collect(Furlong(2):Furlong(1):Furlong(10)) == collect(range(Furlong(2),Furlong(1),9)) == Furlong.(2:10)
 @test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
       collect(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -889,6 +889,7 @@ end
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using TestHelpers.Furlong
 @test_throws MethodError collect(Furlong(2):Furlong(10)) # step size is ambiguous
-@test collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong.(2:10)
+@test_throws MethodError range(Furlong(2), 9) # step size is ambiguous
+@test collect(Furlong(2):Furlong(1):Furlong(10)) == range(Furlong(2),Furlong(1),9) == Furlong.(2:10)
 @test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
       collect(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -884,3 +884,11 @@ let r = linspace(1.0, 3+im, 4)
     @test r[3] ≈ (7/3)+(2/3)im
     @test r[4] === 3.0+im
 end
+
+# dimensional correctness:
+isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
+using TestHelpers.Furlong
+@test_throws MethodError collect(Furlong(2):Furlong(10)) # step size is ambiguous
+@test collect(Furlong(2):Furlong(1):Furlong(10)) == Furlong.(2:10)
+@test collect(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
+      collect(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -368,3 +368,14 @@ let a = rand(10,10)
     x = std(a, 2)
     @test b == a
 end
+
+# dimensional correctness
+isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
+using TestHelpers.Furlong
+let r = Furlong(1):Furlong(1):Furlong(2), a = collect(r)
+    @test sum(r) == sum(a) == Furlong(3)
+    @test cumsum(r) == Furlong.([1,3])
+    @test mean(r) == mean(a) == median(a) == median(r) == Furlong(1.5)
+    @test var(r) == var(a) == Furlong{2}(0.5)
+    @test std(r) == std(a) == Furlong{1}(sqrt(0.5))
+end


### PR DESCRIPTION
This PR (currently very incomplete) adds a test suite `dimensionful.jl` that implements a small dimensionful number type `Furlong` that can be used to test the dimensional correctness of Base functions.

I already caught an bug in `range`, and there are probably lots more problems.

cc @timholy