### PR TITLE
Try using "native" boundschecking for Array

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -144,6 +144,7 @@ julia> length([1 2; 3 4])
 """
 length(t::AbstractArray) = (@_inline_meta; prod(size(t)))
 _length(A::AbstractArray) = (@_inline_meta; prod(map(unsafe_length, indices(A)))) # circumvent missing size
+_length(A::Array) = (@_inline_meta; length(A))
 _length(A) = (@_inline_meta; length(A))
 
 """
@@ -389,7 +390,7 @@ Throw an error if the specified indices `I` are not in bounds for the given arra
 """
 function checkbounds(A::AbstractArray, I...)
     @_inline_meta
-    checkbounds(Bool, A, I...) || throw_boundserror(A, I)
+    checkbounds(Bool, A, I...) || throw_boundserror(A, I...)
     nothing
 end
 checkbounds(A::AbstractArray) = checkbounds(A, 1) # 0-d case
@@ -460,7 +461,13 @@ function checkbounds_linear_indices(::Type{Bool},
 end
 checkbounds_indices(::Type{Bool}, ::Tuple, ::Tuple{}) = true
 
-throw_boundserror(A, I) = (@_noinline_meta; throw(BoundsError(A, I)))
+# Avoiding spurious allocations, GC frames, or extra work is tricky here
+# We must use `@noinline` to prevent the GC frame from allocating the BoundsError
+# But then we must define methods with discrete arguments to get call-site specialization
+throw_boundserror(A, I...)   = (@_noinline_meta; throw(BoundsError(A, I)))
+throw_boundserror(A, i1)     = (@_noinline_meta; throw(BoundsError(A, (i1,))))
+throw_boundserror(A, i1, i2) = (@_noinline_meta; throw(BoundsError(A, (i1, i2))))
+# More methods are defined programmatically in multidimensional.jl
 
 # check along a single dimension
 """
@@ -483,6 +490,7 @@ false
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i) =
     throw(ArgumentError("unable to check bounds for indices of type $(typeof(i))"))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Real) = (first(inds) <= i) & (i <= last(inds))
+checkindex(::Type{Bool}, inds::OneTo{Int}, i::Integer) = (Int(i)-1) % UInt < last(inds) % UInt
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
 function checkindex(::Type{Bool}, inds::AbstractUnitRange, r::Range)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -242,7 +242,7 @@ julia> strides(A)
 ```
 """
 strides(A::AbstractArray) = size_to_strides(1, size(A)...)
-@inline size_to_strides(s, d, sz...) = (s, size_to_strides(s * d, sz...)...)
+size_to_strides(s, d, sz...) = (@_inline_meta; (s, size_to_strides(s * d, sz...)...))
 size_to_strides(s, d) = (s,)
 size_to_strides(s) = ()
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -119,7 +119,7 @@ julia> slicedim(A,2,3)
 function slicedim(A::AbstractArray, d::Integer, i)
     d >= 1 || throw(ArgumentError("dimension must be ≥ 1"))
     nd = ndims(A)
-    d > nd && (i == 1 || throw_boundserror(A, (ntuple(k->Colon(),nd)..., ntuple(k->1,d-1-nd)..., i)))
+    d > nd && (i == 1 || throw_boundserror(A, ntuple(k->Colon(),nd)..., ntuple(k->1,d-1-nd)..., i))
     A[setindex(indices(A), i, d)...]
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -741,9 +741,9 @@ done(a::Array,i) = (@_inline_meta; i == length(a)+1)
 ## Boundscheck micro-optimization: Avoid calling max(0,sz) within OneTo's constructor
 checkbounds(::Type{Bool}, A::Array, i::Int) = (i-1) % UInt < length(A) % UInt
 checkbounds(::Type{Bool}, A::Array, i::Int, I::Int...) = (@_inline_meta; _checkarrayindex(size(A), i, I...))
-_checkarrayindex(::Tuple{}, i, I...) = (@_inline_meta; (i == 1) & _checkarrayindex((), I...))
-_checkarrayindex(sz::Tuple{Int}, i, I...) = (@_inline_meta; ((i-1) % UInt < sz[1] % UInt) & _checkarrayindex(tail(sz), I...))
-_checkarrayindex(sz::Tuple{Int, Vararg{Int}}, i, I...) = (@_inline_meta; ((i-1) % UInt < sz[1] % UInt) & _checkarrayindex(tail(sz), I...))
+_checkarrayindex(::Tuple{}, i, I...) = (@_inline_meta; (i == 1) && _checkarrayindex((), I...))
+_checkarrayindex(sz::Tuple{Int}, i, I...) = (@_inline_meta; ((i-1) % UInt < sz[1] % UInt) && _checkarrayindex(tail(sz), I...))
+_checkarrayindex(sz::Tuple{Int, Vararg{Int}}, i, I...) = (@_inline_meta; ((i-1) % UInt < sz[1] % UInt) && _checkarrayindex(tail(sz), I...))
 _checkarrayindex(::Tuple{}, i) = (i == 1)
 _checkarrayindex(sz::Tuple{Int}, i) = (i-1) % UInt < sz[1] % UInt
 function _checkarrayindex(sz::Tuple{Int, Vararg{Int}}, i)

--- a/base/array.jl
+++ b/base/array.jl
@@ -738,6 +738,25 @@ start(A::Array) = 1
 next(a::Array,i) = (@_propagate_inbounds_meta; (a[i],i+1))
 done(a::Array,i) = (@_inline_meta; i == length(a)+1)
 
+## Boundscheck micro-optimization: Avoid calling max(0,sz) within OneTo's constructor
+checkbounds(::Type{Bool}, A::Array, i::Int) = (i-1) % UInt < length(A) % UInt
+checkbounds(::Type{Bool}, A::Array, i::Int, I::Int...) = (@_inline_meta; _checkarrayindex(size(A), i, I...))
+_checkarrayindex(::Tuple{}, i, I...) = (@_inline_meta; (i == 1) & _checkarrayindex((), I...))
+_checkarrayindex(sz::Tuple{Int}, i, I...) = (@_inline_meta; ((i-1) % UInt < sz[1] % UInt) & _checkarrayindex(tail(sz), I...))
+_checkarrayindex(sz::Tuple{Int, Vararg{Int}}, i, I...) = (@_inline_meta; ((i-1) % UInt < sz[1] % UInt) & _checkarrayindex(tail(sz), I...))
+_checkarrayindex(::Tuple{}, i) = (i == 1)
+_checkarrayindex(sz::Tuple{Int}, i) = (i-1) % UInt < sz[1] % UInt
+function _checkarrayindex(sz::Tuple{Int, Vararg{Int}}, i)
+    @_inline_meta
+    if (i-1) % UInt < sz[1] % UInt
+        return true
+    elseif (i-1) % UInt < prod(sz) % UInt
+        partial_linear_indexing_warning_lookup(length(sz))
+        return true
+    end
+    return false
+end
+
 ## Indexing: getindex ##
 
 """
@@ -760,8 +779,18 @@ julia> getindex(A, "a")
 function getindex end
 
 # This is more complicated than it needs to be in order to get Win64 through bootstrap
-getindex(A::Array, i1::Int) = arrayref(A, i1)
-getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayref(A, i1, i2, I...)) # TODO: REMOVE FOR #14770
+function getindex(A::Array, i1::Int)
+    @_inline_meta
+    @boundscheck checkbounds(A, i1)
+    @inbounds r = arrayref(A, i1)
+    r
+end
+function getindex(A::Array, i1::Int, i2::Int, I::Int...)
+    @_inline_meta
+    @boundscheck checkbounds(A, i1, i2, I...)
+    @inbounds r = arrayref(A, i1, i2, I...)
+    r
+end
 
 # Faster contiguous indexing using copy! for UnitRange and Colon
 function getindex(A::Array, I::UnitRange{Int})
@@ -789,7 +818,6 @@ function getindex(A::Array{S}, I::Range{Int}) where S
 end
 
 ## Indexing: setindex! ##
-
 """
     setindex!(collection, value, key...)
 
@@ -798,8 +826,18 @@ x` is converted by the compiler to `(setindex!(a, x, i, j, ...); x)`.
 """
 function setindex! end
 
-setindex!(A::Array{T}, x, i1::Int) where {T} = arrayset(A, convert(T,x)::T, i1)
-setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T} = (@_inline_meta; arrayset(A, convert(T,x)::T, i1, i2, I...)) # TODO: REMOVE FOR #14770
+function setindex!(A::Array{T}, x, i1::Int) where {T}
+    @_inline_meta
+    @boundscheck checkbounds(A, i1)
+    @inbounds r = arrayset(A, convert(T,x)::T, i1)
+    r
+end
+function setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T}
+    @_inline_meta
+    @boundscheck checkbounds(A, i1, i2, I...)
+    @inbounds r = arrayset(A, convert(T,x)::T, i1, i2, I...)
+    r
+end
 
 # These are redundant with the abstract fallbacks but needed for bootstrap
 function setindex!(A::Array, x, I::AbstractVector{Int})

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1252,7 +1252,7 @@ end
 function slicedim(A::BitVector, d::Integer, i::Integer)
     d >= 1 || throw(ArgumentError("dimension must be ≥ 1"))
     if d > 1
-        i == 1 || throw_boundserror(A, (:, ntuple(k->1,d-2)..., i))
+        i == 1 || throw_boundserror(A, :, ntuple(k->1,d-2)..., i)
         A[:]
     else
         fill!(BitArray{0}(), A[i]) # generic slicedim would return A[i] here

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -349,6 +349,16 @@ function checkindex(::Type{Bool}, inds::Tuple, I::AbstractArray{<:CartesianIndex
     b
 end
 
+## Go back and define a few more discrete signatures for throw_boundserror
+let args = Symbol[:i1, :i2] # One and two args are defined in abstractarray.jl
+    global throw_boundserror
+    for i=3:15
+        push!(args, Symbol(:i,i))
+        @eval @noinline throw_boundserror(A, $(args...)) = throw(BoundsError(A, ($(args...),)))
+    end
+end
+
+
 # combined count of all indices, including CartesianIndex and
 # AbstractArray{CartesianIndex}
 # rather than returning N, it returns an NTuple{N,Bool} so the result is inferrable


### PR DESCRIPTION
Just a trial balloon.  The LLVM looks pretty good, but it's semantically different as it uses `&` instead of `&&` for each dimension.  Let's try this.  @nanosoldier `runbenchmarks(ALL, vs = ":master")`

Fixes #20469.