### PR TITLE
remove trailing space when there are no tests

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -610,7 +610,8 @@ function print_test_results(ts::DefaultTestSet, depth_pad=0)
     # recursively walking the tree of test sets
     align = max(get_alignment(ts, 0), length("Test Summary:"))
     # Print the outer test set header once
-    print_with_color(:white, rpad("Test Summary:",align," "), " | "; bold = true)
+    pad = total == 0 ? "" : " "
+    print_with_color(:white, rpad("Test Summary:",align," "), " |", pad; bold = true)
     if pass_width > 0
         print_with_color(:green, lpad("Pass",pass_width," "), "  "; bold = true)
     end

--- a/test/test.jl
+++ b/test/test.jl
@@ -455,3 +455,9 @@ Foo Tests     |    2     2      4
     Canines   |          1      1
   Arrays      |    1     1      2
 """)
+
+# 20489
+msg = split(readstring(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
+Test.print_test_results(Test.DefaultTestSet(""))'`), stderr=DevNull)), "\n")[1]
+
+@test msg == rstrip(msg)


### PR DESCRIPTION
currently, there's an extra space which is not good-looking in some editor (like figure below).

![screenshot_2017-02-07_17-24-55](https://cloud.githubusercontent.com/assets/9464825/22685297/bc3772d2-ed5a-11e6-96e6-6fdf08cf4c29.png)
