### PR TITLE
 display_error should call latest showerror, pt 2

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -414,7 +414,8 @@ function _start()
             end
         end
     catch err
-        display_error(err,catch_backtrace())
+        eval(Main, Expr(:body, Expr(:return, Expr(:call, Base.display_error,
+                                                  QuoteNode(err), catch_backtrace()))))
         exit(1)
     end
     if is_interactive && have_color

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -458,3 +458,11 @@ end
 
 # readlines(::Cmd), accidentally broken in #20203
 @test sort(readlines(`$lscmd -A`)) == sort(readdir())
+
+# issue #19864 (PR #20497)
+@test readchomp(pipeline(ignorestatus(
+        `$exename --startup-file=no -e '
+            struct Error19864 <: Exception; end
+            Base.showerror(io::IO, e::Error19864) = print(io, "correct19864")
+            throw(Error19864())'`),
+    stderr=catcmd)) == "ERROR: correct19864"


### PR DESCRIPTION
Ref https://discourse.julialang.org/t/custom-showerror-doesnt-always-trigger/1937 #19916 #19864

Does this warrant a test that spawns a new Julia process? Can't replicate it otherwise.

Also, @stevengj, is there a reason you used the following syntax:
```julia
eval(Main, Expr(:body, Expr(:return, Expr(:call, Base.display_error,
                                          errio, QuoteNode(val), bt))))
```
while `eval(Expr(:call, display_error, errio, val, bt))` seems to work as well?