### PR TITLE
fix missing backticks in doctests

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -21,6 +21,7 @@ julia> print(io, "Hello World!")
 
 julia> String(take!(io))
 "Hello World!"
+```
 """
 function print(io::IO, x)
     lock(io)
@@ -114,6 +115,7 @@ Create a string from any values using the [`print`](@ref) function.
 ```jldoctest
 julia> string("a", 1, true)
 "a1true"
+```
 """
 string(xs...) = print_to_string(xs...)
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -86,6 +86,7 @@ Remove a single trailing newline from a string.
 ```jldoctest
 julia> chomp("Hello\n")
 "Hello"
+```
 """
 function chomp(s::AbstractString)
     i = endof(s)
@@ -187,6 +188,7 @@ instead remove characters contained in it.
 ```jldoctest
 julia> strip("{3, 5}\n", ['{', '}', '\n'])
 "3, 5"
+```
 """
 strip(s::AbstractString) = lstrip(rstrip(s))
 strip(s::AbstractString, chars::Chars) = lstrip(rstrip(s, chars), chars)


### PR DESCRIPTION
By searching `jldoctest` in the generated HTML manual