### PR TITLE
fix #20511, segfault showing a `UnionAll`

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -956,7 +956,8 @@ static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **i
             }
             // normalize types equal to wrappers
             jl_value_t *tw = extract_wrapper(pi);
-            if (tw && tw != pi && jl_types_equal(pi, tw)) {
+            if (tw && tw != pi && (tn != jl_type_typename || jl_typeof(pi) == jl_typeof(tw)) &&
+                jl_types_equal(pi, tw)) {
                 iparams[i] = tw;
                 if (p) jl_gc_wb(p, tw);
             }

--- a/test/core.jl
+++ b/test/core.jl
@@ -105,6 +105,12 @@ h11840{T<:Tuple}(::Type{T}) = '4'
 @test h11840(Tuple) == '4'
 @test h11840(TT11840) == '4'
 
+# issue #20511
+f20511(x::DataType) = 0
+f20511(x) = 1
+Type{Integer}  # cache this
+@test f20511(Union{Integer,T} where T <: Unsigned) == 1
+
 # join
 @test typejoin(Int8,Int16) === Signed
 @test typejoin(Int,AbstractString) === Any


### PR DESCRIPTION
This is a band-aid that fixes the symptom here by making the logic in inst_datatype consistent with the matching logic in the type cache for `Type` (in `typekey_eq`).

More generally, this is of course the perennial dispatch key ambiguity problem, where given a type `X` it's not clear if the key for method lookup is `Type{X}` or `typeof(X)`. One way to fix it for good would be to represent every type with the same concrete type, which could contain a secondary tag specifying which kind of type is actually there. Or we could have types like `DataType{T}`, meaning a `DataType` that's type-equal to `T`. These are pretty drastic but we'll have to consider it at some point.