### PR TITLE
Provide fallback for FloatRange(a,st,len,div). Fixes #20506.

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -106,6 +106,10 @@ end
 
 function floatrange(a::AbstractFloat, st::AbstractFloat, len::Real, divisor::AbstractFloat)
     T = promote_type(typeof(a), typeof(st), typeof(divisor))
+    floatrange(T, a, st, len, divisor)
+end
+
+function floatrange{T}(::Type{T}, a::AbstractFloat, st::AbstractFloat, len::Real, divisor::AbstractFloat)
     m = maxintfloat(T)
     if abs(a) <= m && abs(st) <= m && abs(divisor) <= m
         ia, ist, idivisor = round(Int, a), round(Int, st), round(Int, divisor)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -861,3 +861,18 @@ let r = linspace(-big(1.0),big(1.0),4)
     @test isa(@inferred(r[2]), BigFloat)
     @test r[2] ≈ big(-1.0)/3
 end
+
+# issue #20506
+let filename = tempname()
+    open(filename, "w") do f
+        redirect_stderr(f) do
+            r = FloatRange(10.0, 1.0, 11.0, 10.0)
+            @test first(r) == 1.0
+            @test step(r) == 0.1
+            @test length(r) == 11
+            @test last(r) == 2.0
+        end
+    end
+    @test contains(readstring(filename), "deprecated")
+    rm(filename)
+end


### PR DESCRIPTION
This is the "minimal" fix, which I personally think is the safer course. See discussion in #20506.