### PR TITLE
make `_` by itself emit a deprecation warning

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -93,6 +93,8 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
 
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
 {
+    if (e == underscore_sym)
+        jl_depwarn("deprecated syntax \"_ as an rvalue\".", (jl_value_t*)jl_symbol("eval"));
     jl_value_t *v = jl_get_global(m, e);
     if (v == NULL)
         jl_undefined_var_error(e);


### PR DESCRIPTION
Handle missing case in #20328. This change makes the way deprecation warnings get printed a bit inconsistent:

```jl
julia> _ = 1
1

julia> _
WARNING: deprecated syntax "_ as an rvalue".
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:62
 [2] eval(::Module, ::Any) at ./boot.jl:236
 [3] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [4] macro expansion at ./REPL.jl:97 [inlined]
 [5] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
while loading no file, in expression starting on line 0
1

julia> _
1

julia> _,

WARNING: deprecated syntax "_ as an rvalue".
(1,)

julia> _,

WARNING: deprecated syntax "_ as an rvalue".
(1,)
```

This path calls `depwarn` which prints a proper backtrace and only prints the first time. The other path just prints the warning with no backtrace or color and prints every time.