### PR TITLE
improve two deprecations

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -204,8 +204,13 @@ function parse_input_line(s::String; filename::String="none")
     #     throw(ParseError("extra input after end of expression"))
     # end
     # expr
-    ccall(:jl_parse_input_line, Any, (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t),
-        s, sizeof(s), filename, sizeof(filename))
+    ex = ccall(:jl_parse_input_line, Any, (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t),
+               s, sizeof(s), filename, sizeof(filename))
+    if ex === :_
+        # remove with 0.6 deprecation
+        expand(ex)  # to get possible warning about using _ as an rvalue
+    end
+    return ex
 end
 parse_input_line(s::AbstractString) = parse_input_line(String(s))
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1227,6 +1227,8 @@ for name in ("alnum", "alpha", "cntrl", "digit", "number", "graph",
     @eval @deprecate ($f)(s::AbstractString) all($f, s)
 end
 
+# TODO: remove warning for using `_` in parse_input_line in base/client.jl
+
 # END 0.6 deprecations
 
 # BEGIN 1.0 deprecations

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -756,8 +756,15 @@
                   (sig    (car temp))
                   (params (cdr temp)))
              (if (pair? params)
-                 (syntax-deprecation #f (string "inner constructor " name "(...)")
-                                     (deparse `(where (call (curly ,name ,@params) ...) ,@params))))
+                 (let* ((lnos (filter (lambda (e) (and (pair? e) (eq? (car e) 'line)))
+                                      body))
+                        (lno (if (null? lnos) '() (car lnos))))
+                   (syntax-deprecation #f
+                                       (string "inner constructor " name "(...)"
+                                               (cond ((length= lno 2) (string " around line " (cadr lno)))
+                                                     ((length= lno 3) (string " around " (caddr lno) ":" (cadr lno)))
+                                                     (else "")))
+                                       (deparse `(where (call (curly ,name ,@params) ...) ,@params)))))
              `(,keyword ,sig ,(ctor-body body params)))))))
 
 ;; rewrite calls to `new( ... )` to `new` expressions on the appropriate


### PR DESCRIPTION
- for `_` by itself at the prompt
- add location info to inner constructor deprecation
