### PR TITLE
RFC: lower x^literal as x^Val{literal} for integer literals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@ New language features
 Language changes
 ----------------
 
+  * `x^n` for integer literals `n` (e.g. `x^3` or `x^-3`) is now
+    lowered to `x^Val{n}`, to enable compile-time specialization
+    for literal integer exponents ([#20530]).
+
   * "Inner constructor" syntax for parametric types is deprecated. For example,
     in this definition:
     ```

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,10 +22,6 @@ New language features
 Language changes
 ----------------
 
-  * `x^n` for integer literals `n` (e.g. `x^3` or `x^-3`) is now
-    lowered to `x^Val{n}`, to enable compile-time specialization
-    for literal integer exponents ([#20530]).
-
   * "Inner constructor" syntax for parametric types is deprecated. For example,
     in this definition:
     ```
@@ -76,6 +72,10 @@ Language changes
 
   * The `typealias` keyword is deprecated, and should be replaced with
     `Vector{T} = Array{T,1}` or a `const` assignment.
+
+  * Experimental feature: `x^n` for integer literals `n` (e.g. `x^3`
+    or `x^-3`) is now lowered to `x^Val{n}`, to enable compile-time
+    specialization for literal integer exponents ([#20530]).
 
 Breaking changes
 ----------------

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -195,6 +195,11 @@ end
 ^(x::Number, p::Integer)  = power_by_squaring(x,p)
 ^(x, p::Integer)          = power_by_squaring(x,p)
 
+# x^p for small literal p is lowered to x^Val{p},
+# to enable compile-time optimizations specialized to p.
+# However, we still need a fallback that calls the general ^:
+^{p}(x, ::Type{Val{p}}) = x^p
+
 # b^p mod m
 
 """

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -195,7 +195,7 @@ end
 ^(x::Number, p::Integer)  = power_by_squaring(x,p)
 ^(x, p::Integer)          = power_by_squaring(x,p)
 
-# x^p for small literal p is lowered to x^Val{p},
+# x^p for any literal integer p is lowered to x^Val{p},
 # to enable compile-time optimizations specialized to p.
 # However, we still need a fallback that calls the general ^:
 ^{p}(x, ::Type{Val{p}}) = x^p

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -253,8 +253,8 @@ end
 
 Exponentiation operator. If `x` is a matrix, computes matrix exponentiation.
 
-If `y` is an `Int` literal (e.g. `x^2` or `x^-3`), the Julia code
-`x^y` is transformed to `x^Val{y}`, to enable compile-time
+If `y` is an `Int` literal (e.g. `2` in `x^2` or `-3` in `x^-3`), the Julia code
+`x^y` is transformed by the compiler to `x^Val{y}`, to enable compile-time
 specialization on the value of the exponent.  (As a default fallback,
 however, `x^Val{y}` simply calls the `^(x,y)` function.)
 

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -253,6 +253,11 @@ end
 
 Exponentiation operator. If `x` is a matrix, computes matrix exponentiation.
 
+If `y` is an `Int` literal (e.g. `x^2` or `x^-3`), the Julia code
+`x^y` is transformed to `x^Val{y}`, to enable compile-time
+specialization on the value of the exponent.  (As a default fallback,
+however, `x^Val{y}` simply calls the `^(x,y)` function.)
+
 ```jldoctest
 julia> 3^5
 243

--- a/src/ast.c
+++ b/src/ast.c
@@ -245,26 +245,12 @@ value_t fl_julia_scalar(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     return fl_ctx->F;
 }
 
-value_t fl_julia_smallnum(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
-{
-    argcount(fl_ctx, "julia-smallnum?", nargs, 1);
-    if (isfixnum(args[0]) && numval(args[0]) < 32 && numval(args[0]) > -32)
-        return fl_ctx->T;
-    else if (iscvalue(args[0]) && fl_ctx->jl_sym == cv_type((cvalue_t*)ptr(args[0]))) {
-        jl_value_t *v = *(jl_value_t**)cptr(args[0]);
-        if (jl_is_long(v) && jl_unbox_long(v) < 32 && jl_unbox_long(v) > -32)
-            return fl_ctx->T;
-    }
-    return fl_ctx->F;
-}
-
 static const builtinspec_t julia_flisp_ast_ext[] = {
     { "defined-julia-global", fl_defined_julia_global },
     { "invoke-julia-macro", fl_invoke_julia_macro },
     { "current-julia-module", fl_current_julia_module },
     { "current-julia-module-counter", fl_current_module_counter },
     { "julia-scalar?", fl_julia_scalar },
-    { "julia-smallnum?", fl_julia_smallnum },
     { NULL, NULL }
 };
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -245,12 +245,26 @@ value_t fl_julia_scalar(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     return fl_ctx->F;
 }
 
+value_t fl_julia_smallnum(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
+{
+    argcount(fl_ctx, "julia-smallnum?", nargs, 1);
+    if (isfixnum(args[0]) && numval(args[0]) < 32 && numval(args[0]) > -32)
+        return fl_ctx->T;
+    else if (iscvalue(args[0]) && fl_ctx->jl_sym == cv_type((cvalue_t*)ptr(args[0]))) {
+        jl_value_t *v = *(jl_value_t**)cptr(args[0]);
+        if (jl_is_long(v) && jl_unbox_long(v) < 32 && jl_unbox_long(v) > -32)
+            return fl_ctx->T;
+    }
+    return fl_ctx->F;
+}
+
 static const builtinspec_t julia_flisp_ast_ext[] = {
     { "defined-julia-global", fl_defined_julia_global },
     { "invoke-julia-macro", fl_invoke_julia_macro },
     { "current-julia-module", fl_current_julia_module },
     { "current-julia-module-counter", fl_current_module_counter },
     { "julia-scalar?", fl_julia_scalar },
+    { "julia-smallnum?", fl_julia_smallnum },
     { NULL, NULL }
 };
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1771,8 +1771,6 @@
               (extract (cdr params) (cons p newparams) whereparams)))))
   (extract (cddr e) '() '()))
 
-(define (smallnum? x) (and (integer? x) (< x 32) (> x -32)))
-
 ;; table mapping expression head to a function expanding that form
 (define expand-table
   (table
@@ -2059,7 +2057,7 @@
                     (expand-forms
                      `(call (core _apply) ,f ,@(tuple-wrap argl '())))))
 
-                 ((and (eq? f '^) (length= e 4) (smallnum? (cadddr e)))
+                 ((and (eq? f '^) (length= e 4) (integer? (cadddr e)))
                   (expand-forms
                    `(call ^ ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)))))
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1771,6 +1771,8 @@
               (extract (cdr params) (cons p newparams) whereparams)))))
   (extract (cddr e) '() '()))
 
+(define (smallnum? x) (and (integer? x) (< x 32) (> x -32)))
+
 ;; table mapping expression head to a function expanding that form
 (define expand-table
   (table
@@ -2057,7 +2059,7 @@
                     (expand-forms
                      `(call (core _apply) ,f ,@(tuple-wrap argl '())))))
 
-                 ((and (eq? f '^) (length= e 4) (julia-smallnum? (cadddr e)))
+                 ((and (eq? f '^) (length= e 4) (smallnum? (cadddr e)))
                   (expand-forms
                    `(call ^ ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)))))
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2057,6 +2057,10 @@
                     (expand-forms
                      `(call (core _apply) ,f ,@(tuple-wrap argl '())))))
 
+                 ((and (eq? f '^) (length= e 4) (julia-smallnum? (cadddr e)))
+                  (expand-forms
+                   `(call ^ ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)))))
+
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op
                    e

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2902,6 +2902,18 @@ end
     @test rem2pi(T(-4), RoundUp)      == -4
 end
 
+import Base.^
+immutable PR20530; end
+^(::PR20530, p::Int) = 1
+^{p}(::PR20530, ::Type{Val{p}}) = 2
+@testset "literal powers" begin
+    x = PR20530()
+    p = 2
+    @test x^p == 1
+    @test x^2 == 2
+    @test [x,x,x].^2 == [2,2,2]
+end
+
 @testset "iszero" begin
     # Numeric scalars
     for T in [Float16, Float32, Float64, BigFloat,


### PR DESCRIPTION
As discussed in #20527.

This PR doesn't change any behaviors or implement any optimizations for small powers yet — it just falls through to the generic `^` for now — but there are a number of improvements that would be easy to add (in separate PRs, probably) if this is merged.