### PR TITLE
disambiguating ambiguous-length float ranges

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -155,6 +155,7 @@ function colon{T<:Union{Float16,Float32,Float64}}(start::T, step::T, stop::T)
     else
         len = round(Int, lf) + 1
         stop′ = start + (len-1)*step
+        # if we've overshot the end, subtract one:
         len -= (start < stop < stop′) + (start > stop > stop′)
     end
     StepRangeLen(TwicePrecision(start, zero(T)), twiceprecision(step, nbitslen(T, len, 1)), len)

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -147,9 +147,16 @@ function colon{T<:Union{Float16,Float32,Float64}}(start::T, step::T, stop::T)
         end
     end
     # Fallback, taking start and step literally
-    len = max(0, floor(Int, (stop-start)/step) + 1)
-    stop′ = start + len*step
-    len += (start < stop′ <= stop) + (start > stop′ >= stop)
+    lf = (stop-start)/step
+    if lf < 0
+        len = 0
+    elseif lf == 0
+        len = 1
+    else
+        len = round(Int, lf) + 1
+        stop′ = start + (len-1)*step
+        len -= (start < stop < stop′) + (start > stop > stop′)
+    end
     StepRangeLen(TwicePrecision(start, zero(T)), twiceprecision(step, nbitslen(T, len, 1)), len)
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -341,9 +341,13 @@ end
 
 for T = (Float32, Float64,), i = 1:2^15, n = 1:5
     start, step = randn(T), randn(T)
+    step == 0 && continue
     stop = start + (n-1)*step
+    lo = hi = n
+    while start + (lo-1)*step == stop; lo -= 1; end
+    while start + (hi-1)*step == stop; hi += 1; end
     r = start:step:stop
-    @test n == length(r)
+    @test lo < length(r) < hi
     # FIXME: these fail some small portion of the time
     @test_skip start == first(r)
     @test_skip stop  == last(r)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -346,8 +346,9 @@ for T = (Float32, Float64,), i = 1:2^15, n = 1:5
     lo = hi = n
     while start + (lo-1)*step == stop; lo -= 1; end
     while start + (hi-1)*step == stop; hi += 1; end
+    m = clamp(round(Int, (stop-start)/step) + 1, lo+1, hi-1)
     r = start:step:stop
-    @test lo < length(r) < hi
+    @test m == length(r)
     # FIXME: these fail some small portion of the time
     @test_skip start == first(r)
     @test_skip stop  == last(r)


### PR DESCRIPTION
This test was occasionally failing (~1 in 10 million times) since there are cases where the length of such a range is ambiguous, i.e. there is more than one `n` such that `start + (n-1)*step == stop`. This adjusts the test to allow any such choice of range length. We should still explicitly disambiguate this case by defining what the length of a range should be in such cases.