### PR TITLE
make queens more regal

### DIFF
--- a/examples/queens.jl
+++ b/examples/queens.jl
@@ -1,21 +1,28 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-addqueen(queens::Array{Vector{Int}}, queen::Vector{Int}) = push!(copy(queens), queen)
+# n-queens (nqueens) solver, for nsquaresx-by-nsquaresy board
 
-hitsany(queen::Vector{Int}, queens::Array{Vector{Int}}) = any(x->hits(queen, x), queens)
-hits(a::Array{Int}, b::Array{Int}) = any(a .== b) || abs.(a-b)[1] == abs.(a-b)[2]
+immutable Queen
+    x::Int
+    y::Int
+end
+hitshorz(queena, queenb) = queena.x == queenb.x
+hitsvert(queena, queenb) = queena.y == queenb.y
+hitsdiag(queena, queenb) = abs(queena.x - queenb.x) == abs(queena.y - queenb.y)
+hitshvd(qa, qb) = hitshorz(qa, qb) || hitsvert(qa, qb) || hitsdiag(qa, qb)
+hitsany(testqueen, queens) = any(q -> hitshvd(testqueen, q), queens)
 
-function solve(x, y, n, d=Array{Vector{Int}}(0))
-  if n == 0
-    return d
-  end
-  for px = 1:x
-    for py = 1:y
-      if !hitsany([px, py], d)
-        s = solve(x, y, n-1, addqueen(d, [px, py]))
-        s !== nothing && return s
-      end
+function trysolve(nsquaresx, nsquaresy, nqueens, presqueens = ())
+    nqueens == 0 && return presqueens
+    for xsquare in 1:nsquaresx
+        for ysquare in 1:nsquaresy
+            testqueen = Queen(xsquare, ysquare)
+            if !hitsany(testqueen, presqueens)
+                tryqueens = (presqueens..., testqueen)
+                maybesol = trysolve(nsquaresx, nsquaresy, nqueens - 1, tryqueens)
+                maybesol !== nothing && return maybesol
+            end
+        end
     end
-  end
-  return nothing
+    return nothing
 end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -30,8 +30,9 @@ r3, r4 = meshgrid(1:10,1:10)
 @test r4 == r
 
 include(joinpath(dir, "queens.jl"))
-@test solve(8, 8, 1) == Array{Int,1}[[1,1]]
-@test solve(8, 8, 7) == Array{Int,1}[[1,1],[2,3],[3,5],[4,2],[5,8],[7,4],[8,7]]
+@test trysolve(8, 8, 1) == (Queen(1,1),)
+@test trysolve(8, 8, 7) ==
+    (Queen(1,1), Queen(2,3), Queen(3,5), Queen(4,2), Queen(5,8), Queen(7,4), Queen(8,7))
 
 # Different cluster managers do not play well together. Since
 # the test infrastructure already uses LocalManager, we will test the simple


### PR DESCRIPTION
This pull request makes the n-queens example more idiomatic and explicit. As a side effect performance improves dramatically too: Before
```julia
julia> @benchmark solve(6, 5, 4)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  253.67 kb
  allocs estimate:  423
  minimum time:     161.63 μs (0.00% GC)
  median time:      175.10 μs (0.00% GC)
  mean time:        231.68 μs (13.38% GC)
  maximum time:     4.11 ms (94.43% GC)
```
and after
```julia
julia> @benchmark trysolve(6, 5, 4)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     215
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  80.00 bytes
  allocs estimate:  1
  minimum time:     344.00 ns (0.00% GC)
  median time:      348.00 ns (0.00% GC)
  mean time:        386.53 ns (0.75% GC)
  maximum time:     7.59 μs (92.66% GC)
```
Best!