### PR TITLE
Quick return for linspace when start == stop. Fixes #20520.

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -310,6 +310,9 @@ end
 # For Float16, Float32, and Float64, linspace returns a StepRangeLen
 function linspace{T<:Union{Float16,Float32,Float64}}(start::T, stop::T, len::Integer)
     len < 2 && return _linspace1(T, start, stop, len)
+    if start == stop
+        return StepRangeLen(TwicePrecision(start,zero(T)), TwicePrecision(zero(T),zero(T)), len)
+    end
     # Attempt to find exact rational approximations
     start_n, start_d = rat(start)
     stop_n, stop_d = rat(stop)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -861,3 +861,11 @@ let r = linspace(-big(1.0),big(1.0),4)
     @test isa(@inferred(r[2]), BigFloat)
     @test r[2] ≈ big(-1.0)/3
 end
+
+# issue #20520
+let r = linspace(1.3173739f0, 1.3173739f0, 3)
+    @test length(r) == 3
+    @test first(r) === 1.3173739f0
+    @test last(r)  === 1.3173739f0
+    @test r[2]     === 1.3173739f0
+end


### PR DESCRIPTION
The old code worked in the case where the inputs are expressible as rationals, but when that fails we were getting an InexactError.

CC @StefanKarpinski.