### PR TITLE
parse dots everywhere

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1,7 +1,7 @@
 ;; Operator precedence table, lowest at top
 
 ; for most operators X there is a .X "elementwise" equivalent
-(define (add-dots ops) (append! ops (map (lambda (op) (symbol (string "." op))) ops)))
+(define (add-dots ops) (append! ops (map (lambda (op) (symbol (string "." op))) ops) (map (lambda (op) (symbol (string op "."))) ops)))
 
 ;; note: there are some strange-looking things in here because
 ;; the way the lexer works, every prefix of an operator must also

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -122,7 +122,7 @@ end
 
 # rounding in conversions
 let
-    for f in [.3325f0, -.3325f0]
+    for f in [0.3325f0, -0.3325f0]
         f16 = Float16(f)
         # need to round away from 0. make sure we picked closest number.
         @test abs(f-f16) < abs(f-nextfloat(f16))

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -153,7 +153,7 @@ end
 
 # Issue 7304
 let
-    A = [-√.5 -√.5; -√.5 √.5]
+    A = [-√0.5 -√0.5; -√0.5 √0.5]
     Q = full(qrfact(A)[:Q])
     @test vecnorm(A-Q) < eps()
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1132,7 +1132,7 @@ end
 @test isa(convert(Complex{Int16},1), Complex{Int16})
 @test Complex(1,2)+1 == Complex(2,2)
 @test Complex(1,2)+1.5 == Complex(2.5,2.0)
-@test 1/Complex(2,2) == Complex(.25,-.25)
+@test 1/Complex(2,2) == Complex(.25,-0.25)
 @test Complex(1.5,1.0) + 1//2 == Complex(2.0,1.0)
 @test real(Complex(1//2,2//3)) == 1//2
 @test imag(Complex(1//2,2//3)) == 2//3
@@ -1676,10 +1676,10 @@ end
 @test isnan(eps(Inf))
 @test isnan(eps(-Inf))
 
-@test .1+.1+.1 != .3
-@test .1+.1+.1 ≈ .3
-@test .1+.1+.1-.3 ≉ 0
-@test .1+.1+.1-.3 ≈ 0 atol=eps(.3)
+@test 0.1 + 0.1 + 0.1 != 0.3
+@test 0.1 + 0.1 + 0.1 ≈ 0.3
+@test 0.1 + 0.1 + 0.1 - 0.3 ≉ 0
+@test 0.1 + 0.1 + 0.1 - 0.3 ≈ 0 atol=eps(0.3)
 @test 1.1 ≈ 1.1f0
 
 @test div(1e50,1) == 1e50
@@ -1982,8 +1982,8 @@ approx_eq(a, b) = approx_eq(a, b, 1e-6)
 @test approx_eq(round(pi,0), 3.)
 @test approx_eq(round(pi,1), 3.1)
 @test approx_eq(round(10*pi,-1), 30.)
-@test round(.1,0) == 0.
-@test round(-.1,0) == -0.
+@test round(0.1, 0) == 0.
+@test round(-0.1, 0) == -0.
 @test isnan(round(NaN, 2))
 @test isinf(round(Inf,2))
 @test isinf(round(-Inf,2))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -4,15 +4,15 @@
 @test size(10:1:0) == (0,)
 @test length(1:.2:2) == 6
 @test length(1.:.2:2.) == 6
-@test length(2:-.2:1) == 6
-@test length(2.:-.2:1.) == 6
+@test length(2:-0.2:1) == 6
+@test length(2.:-0.2:1.) == 6
 @test length(2:.2:1) == 0
 @test length(2.:.2:1.) == 0
 
 @inferred(colon(10, 1, 0))
 @inferred(colon(1, .2, 2))
 @inferred(colon(1., .2, 2.))
-@inferred(colon(2, -.2, 1))
+@inferred(colon(2, -0.2, 1))
 @inferred(colon(1, 0))
 @inferred(colon(0.0, -0.5))
 

--- a/test/sparse/umfpack.jl
+++ b/test/sparse/umfpack.jl
@@ -138,7 +138,7 @@ end
 
 #18246,18244-lufact sparse pivot
 let A = speye(4)
-    A[1:2,1:2] = [-.01 -200; 200 .001]
+    A[1:2,1:2] = [-0.01 -200; 200 .001]
     F = lufact(A)
     @test F[:p] == [3 ; 4 ; 2 ; 1]
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -197,8 +197,8 @@ end
     deleteat!(Base.Test.get_testset().results,1)
 end
 
-@test .1+.1+.1 ≈ .3
-@test .1+.1+.1 ≉ .4
+@test 0.1 + 0.1 + 0.1 ≈ 0.3
+@test 0.1 + 0.1 + 0.1 ≉ 0.4
 
 ts = @testset "@testset should return the testset" begin
     @test true


### PR DESCRIPTION
This pull request makes `op.` parse like `.op`, enabling backwards compatibility (as pointed out in https://github.com/JuliaLang/julia/pull/20249#issuecomment-275797612) in case we revisit the dot position consistency question. Best!