### PR TITLE
deprecate vectorized ! and ~ in favor of dot syntax

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -25,7 +25,7 @@ julia> A
 """
 conj!(A::AbstractArray{<:Number}) = (@inbounds broadcast!(conj, A, A); A)
 
-for f in (:-, :~, :conj, :real, :imag)
+for f in (:-, :conj, :real, :imag)
     @eval ($f)(A::AbstractArray) = broadcast($f, A)
 end
 

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -29,7 +29,6 @@ for f in (:-, :~, :conj, :real, :imag)
     @eval ($f)(A::AbstractArray) = broadcast($f, A)
 end
 
-!(A::AbstractArray{Bool}) = broadcast(!, A)
 
 ## Binary arithmetic operators ##
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1195,7 +1195,6 @@ function (-)(B::BitArray)
 end
 broadcast(::typeof(sign), B::BitArray) = copy(B)
 
-(~)(B::BitArray) = broadcast(~, B)
 function broadcast(::typeof(~), B::BitArray)
     C = similar(B)
     Bc = B.chunks
@@ -1269,7 +1268,7 @@ broadcast(::typeof(&), B::BitArray, x::Bool) = x ? copy(B) : falses(size(B))
 broadcast(::typeof(&), x::Bool, B::BitArray) = broadcast(&, B, x)
 broadcast(::typeof(|), B::BitArray, x::Bool) = x ? trues(size(B)) : copy(B)
 broadcast(::typeof(|), x::Bool, B::BitArray) = broadcast(|, B, x)
-broadcast(::typeof(xor), B::BitArray, x::Bool) = x ? ~B : copy(B)
+broadcast(::typeof(xor), B::BitArray, x::Bool) = x ? .~B : copy(B)
 broadcast(::typeof(xor), x::Bool, B::BitArray) = broadcast(xor, B, x)
 for f in (:&, :|, :xor)
     @eval begin

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1195,7 +1195,8 @@ function (-)(B::BitArray)
 end
 broadcast(::typeof(sign), B::BitArray) = copy(B)
 
-function (~)(B::BitArray)
+(~)(B::BitArray) = broadcast(~, B)
+function broadcast(::typeof(~), B::BitArray)
     C = similar(B)
     Bc = B.chunks
     if !isempty(Bc)
@@ -1236,7 +1237,6 @@ function flipbits!(B::BitArray)
     return B
 end
 
-!(B::BitArray) = ~B
 
 ## Binary arithmetic operators ##
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -827,6 +827,10 @@ end
 @deprecate(!(A::AbstractArray{Bool}), .!A) # parens for #20541
 @deprecate(!(B::BitArray), .!B) # parens for #20541
 
+# Deprecate vectorized ~
+@deprecate ~(A::AbstractArray) .~A
+@deprecate ~(B::BitArray) .~B
+
 function frexp(A::Array{<:AbstractFloat})
     depwarn("`frexp(x::Array)` is discontinued.", :frexp)
     F = similar(A)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -823,6 +823,10 @@ end
 @deprecate ifelse(c::AbstractArray{Bool}, x::AbstractArray, y) ifelse.(c, x, y)
 @deprecate ifelse(c::AbstractArray{Bool}, x::AbstractArray, y::AbstractArray) ifelse.(c, x, y)
 
+# Deprecate vectorized !
+@deprecate(!(A::AbstractArray{Bool}), .!A) # parens for #20541
+@deprecate(!(B::BitArray), .!B) # parens for #20541
+
 function frexp(A::Array{<:AbstractFloat})
     depwarn("`frexp(x::Array)` is discontinued.", :frexp)
     F = similar(A)

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -791,7 +791,7 @@ function pinv{T}(A::StridedMatrix{T}, tol::Real)
     Sinv        = zeros(Stype, length(SVD.S))
     index       = SVD.S .> tol*maximum(SVD.S)
     Sinv[index] = one(Stype) ./ SVD.S[index]
-    Sinv[find(!isfinite.(Sinv))] = zero(Stype)
+    Sinv[find(.!isfinite.(Sinv))] = zero(Stype)
     return SVD.Vt' * (Diagonal(Sinv) * SVD.U')
 end
 function pinv{T}(A::StridedMatrix{T})

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -64,7 +64,7 @@ function prefetch(pkg::AbstractString, url::AbstractString, sha1s::Vector)
             LibGit2.fetch(repo)
             in_cache = BitArray(map(sha1->LibGit2.iscommit(sha1, repo), sha1s))
         end
-        sha1s[!in_cache]
+        sha1s[.!in_cache]
     finally
         close(repo) # closing repo opened/created above
     end

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -346,7 +346,7 @@ function parse_flat(iplist, n, lidict::LineInfoFlatDict, C::Bool)
     # The ones with no line number might appear multiple times in a single
     # backtrace, giving the wrong impression about the total number of backtraces.
     # Delete them too.
-    keep = !Bool[x == UNKNOWN || x.line == 0 || (x.from_c && !C) for x in lilist]
+    keep = .!Bool[x == UNKNOWN || x.line == 0 || (x.from_c && !C) for x in lilist]
     n = n[keep]
     lilist = lilist[keep]
     return (lilist, n)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -65,8 +65,8 @@
                      t))
 (define (operator-precedence op) (get prec-table op 0))
 
-(define unary-ops (append! '(|<:| |>:| ~)
-                           (add-dots '(+ - ! ¬ √ ∛ ∜))))
+(define unary-ops (append! '(|<:| |>:|)
+                           (add-dots '(+ - ! ~ ¬ √ ∛ ∜))))
 
 ; operators that are both unary and binary
 (define unary-and-binary-ops '(+ - $ & ~ |.+| |.-|))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1863,8 +1863,8 @@ end
     @test typeof(conj(B)) == Vector{Float64}
     @test typeof(conj(C)) == Vector{Complex{Int}}
 
-    @test ~A == [9,-1,-4]
-    @test typeof(~A) == Vector{Int}
+    @test .~A == [9,-1,-4]
+    @test typeof(.~A) == Vector{Int}
 end
 
 @testset "issue #16247" begin

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -722,7 +722,7 @@ timesofar("dequeue")
 @testset "Unary operators" begin
     b1 = bitrand(n1, n2)
     @check_bit_operation (~)(b1)  BitMatrix
-    @check_bit_operation (!)(b1)  BitMatrix
+    @check_bit_operation broadcast(!, b1)  BitMatrix
     @check_bit_operation (-)(b1)  Matrix{Int}
     @check_bit_operation broadcast(sign, b1) BitMatrix
     @check_bit_operation real(b1) BitMatrix
@@ -731,7 +731,7 @@ timesofar("dequeue")
 
     b0 = falses(0)
     @check_bit_operation (~)(b0)  BitVector
-    @check_bit_operation (!)(b0)  BitVector
+    @check_bit_operation broadcast(!, b0)  BitVector
     @check_bit_operation (-)(b0)  Vector{Int}
     @check_bit_operation broadcast(sign, b0) BitVector
 
@@ -1116,7 +1116,7 @@ timesofar("nnz&find")
     n = maximum(elts)
     for c = [falses, trues]
         b1 = c(n)
-        b1[elts] = !b1[elts]
+        b1[elts] = .!b1[elts]
         b2 = ~b1
         i1 = Array(b1)
         for i = 1:n

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -721,7 +721,7 @@ timesofar("dequeue")
 
 @testset "Unary operators" begin
     b1 = bitrand(n1, n2)
-    @check_bit_operation (~)(b1)  BitMatrix
+    @check_bit_operation broadcast(~, b1)  BitMatrix
     @check_bit_operation broadcast(!, b1)  BitMatrix
     @check_bit_operation (-)(b1)  Matrix{Int}
     @check_bit_operation broadcast(sign, b1) BitMatrix
@@ -730,7 +730,7 @@ timesofar("dequeue")
     @check_bit_operation conj(b1) BitMatrix
 
     b0 = falses(0)
-    @check_bit_operation (~)(b0)  BitVector
+    @check_bit_operation broadcast(~, b0)  BitVector
     @check_bit_operation broadcast(!, b0)  BitVector
     @check_bit_operation (-)(b0)  Vector{Int}
     @check_bit_operation broadcast(sign, b0) BitVector
@@ -738,7 +738,7 @@ timesofar("dequeue")
     @testset "flipbits!" begin
         b1 = bitrand(n1, n2)
         i1 = Array(b1)
-        @test flipbits!(b1) == ~i1
+        @test flipbits!(b1) == .~i1
         @test bitcheck(b1)
     end
 end
@@ -1072,13 +1072,13 @@ timesofar("datamove")
     b1 = trues(v1)
     for i = 0:(v1-1)
         @test findfirst(b1 >> i) == i+1
-        @test Base.findfirstnot(~(b1 >> i)) == i+1
+        @test Base.findfirstnot(.~(b1 >> i)) == i+1
     end
 
     for i = 3:(v1-1), j = 2:i
         submask = b1 << (v1-j+1)
         @test findnext((b1 >> i) .| submask, j) == i+1
-        @test findnextnot((~(b1 >> i)) .⊻ submask, j) == i+1
+        @test findnextnot((.~(b1 >> i)) .⊻ submask, j) == i+1
     end
 
     b1 = bitrand(n1, n2)
@@ -1117,7 +1117,7 @@ timesofar("nnz&find")
     for c = [falses, trues]
         b1 = c(n)
         b1[elts] = .!b1[elts]
-        b2 = ~b1
+        b2 = .~b1
         i1 = Array(b1)
         for i = 1:n
             @test findprev(b1, i) == findprev(i1, i) == findprevnot(b2, i) == findprev(!, b2, i)
@@ -1128,7 +1128,7 @@ timesofar("nnz&find")
     b1 = falses(1000)
     b1[77] = true
     b1[777] = true
-    b2 = ~b1
+    b2 = .~b1
     @test_throws BoundsError findprev(b1, 1001)
     @test_throws BoundsError findprevnot(b2, 1001)
     @test_throws BoundsError findprev(!, b2, 1001)
@@ -1184,13 +1184,13 @@ timesofar("nnz&find")
         @test findprev(t, l) == findprevnot(f, l) == l
         b1 = falses(l)
         b1[end] = true
-        b2 = ~b1
+        b2 = .~b1
         @test findprev(b1, l) == findprevnot(b2, l) == l
         @test findprevnot(b1, l) == findprev(b2, l) == l-1
         if l > 1
             b1 = falses(l)
             b1[end-1] = true
-            b2 = ~b1
+            b2 = .~b1
             @test findprev(b1, l) == findprevnot(b2, l) == l-1
             @test findprevnot(b1, l) == findprev(b2, l) == l
         end
@@ -1223,7 +1223,7 @@ timesofar("reductions")
     for l = [0, 1, 63, 64, 65, 127, 128, 129, 255, 256, 257, 6399, 6400, 6401]
         b1 = bitrand(l)
         b2 = bitrand(l)
-        @test map(~, b1) == map(x->~x, b1) == ~b1
+        @test map(~, b1) == map(x->~x, b1) == broadcast(~, b1)
         @test map(identity, b1) == map(x->x, b1) == b1
 
         @test map(&, b1, b2) == map((x,y)->x&y, b1, b2) == broadcast(&, b1, b2)
@@ -1245,8 +1245,8 @@ timesofar("reductions")
 
         @testset "map! for length $l" begin
             b = BitArray(l)
-            @test map!(~, b, b1) == map!(x->~x, b, b1) == ~b1 == b
-            @test map!(!, b, b1) == map!(x->!x, b, b1) == ~b1 == b
+            @test map!(~, b, b1) == map!(x->~x, b, b1) == broadcast(~, b1) == b
+            @test map!(!, b, b1) == map!(x->!x, b, b1) == broadcast(~, b1) == b
             @test map!(identity, b, b1) == map!(x->x, b, b1) == b1 == b
             @test map!(zero, b, b1) == map!(x->false, b, b1) == falses(l) == b
             @test map!(one, b, b1) == map!(x->true, b, b1) == trues(l) == b

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -784,8 +784,8 @@ let A = -1:1, B = -1.0:1.0
     @test conj(A) === A
     @test conj(B) === B
 
-    @test ~A == [0,-1,-2]
-    @test typeof(~A) == Vector{Int}
+    @test .~A == [0,-1,-2]
+    @test typeof(.~A) == Vector{Int}
 end
 
 # conversion to Array

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -805,7 +805,7 @@ end
     FS = Array(S)
     FI = Array(I)
     @test sparse(FS[FI]) == S[I] == S[FI]
-    @test sum(S[FI]) + sum(S[!FI]) == sum(S)
+    @test sum(S[FI]) + sum(S[.!FI]) == sum(S)
     @test countnz(I) == count(I)
 
     sumS1 = sum(S)


### PR DESCRIPTION
With benefit of #20249, this pull request deprecates all remaining vectorized `!`  and `~` methods in favor of dot syntax (`.!`, `.~`). (`.~` does not parse as a unary operator; the second commit changes that.) Best!