### PR TITLE
Two REPL fixes

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -633,7 +633,7 @@ function respond(f, repl, main; pass_empty = false)
         line = String(take!(buf))
         if !isempty(line) || pass_empty
             reset(repl)
-            val, bt = send_to_backend(f(line), backend(repl))
+            val, bt = send_to_backend(eval(:(($f)($line))), backend(repl))
             if !ends_with_semicolon(line) || bt !== nothing
                 print_response(repl, val, bt, true, Base.have_color)
             end

--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -147,7 +147,7 @@ function Base.displaysize(t::UnixTerminal)
 end
 
 clear(t::UnixTerminal) = write(t.out_stream, "\x1b[H\x1b[2J")
-clear_line(t::UnixTerminal) = write(t.out_stream, "\x1b[0G\x1b[0K")
+clear_line(t::UnixTerminal) = write(t.out_stream, "\x1b[1G\x1b[0K")
 #beep(t::UnixTerminal) = write(t.err_stream,"\x7")
 
 if is_windows()


### PR DESCRIPTION
1. Use `eval` in REPL.respond, to fix external REPL modes (world age problem)
2. Another instance of 0-indexed terminal columns that should be
   1 indexed.