### PR TITLE
remove redundant `tvars` fields

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -43,11 +43,11 @@ function argtype_decl(env, n, sig::DataType, i::Int, nargs, isva::Bool) # -> (ar
 end
 
 function arg_decl_parts(m::Method)
-    tv = m.tvars
-    if !isa(tv,SimpleVector)
-        tv = Any[tv]
-    else
-        tv = Any[tv...]
+    tv = Any[]
+    sig = m.sig
+    while isa(sig, UnionAll)
+        push!(tv, sig.var)
+        sig = sig.body
     end
     if isdefined(m, :source)
         src = m.source
@@ -58,11 +58,10 @@ function arg_decl_parts(m::Method)
     line = m.line
     if src !== nothing && src.slotnames !== nothing
         argnames = src.slotnames[1:m.nargs]
-        sig = unwrap_unionall(m.sig)
         decls = Any[argtype_decl(:tvar_env => tv, argnames[i], sig, i, m.nargs, m.isva)
                     for i = 1:m.nargs]
     else
-        decls = Any[("", "") for i = 1:length(unwrap_unionall(m.sig).parameters)]
+        decls = Any[("", "") for i = 1:length(sig.parameters)]
     end
     return tv, decls, file, line
 end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -442,7 +442,12 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
     for (func,arg_types_param) in funcs
         for method in methods(func)
             buf = IOBuffer()
-            sig0 = unwrap_unionall(method.sig)
+            tv = Any[]
+            sig0 = method.sig
+            while isa(sig0, UnionAll)
+                push!(tv, sig0.var)
+                sig0 = sig0.body
+            end
             s1 = sig0.parameters[1]
             sig = sig0.parameters[2:end]
             print(buf, "  ")
@@ -453,10 +458,6 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                 # TODO: use the methodshow logic here
                 use_constructor_syntax = isa(func, Type)
                 print(buf, use_constructor_syntax ? func : typeof(func).name.mt.name)
-            end
-            tv = method.tvars
-            if !isa(tv,SimpleVector)
-                tv = Any[tv]
             end
             print(buf, "(")
             t_i = copy(arg_types_param)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -347,7 +347,6 @@ function serialize(s::AbstractSerializer, meth::Method)
     serialize(s, meth.file)
     serialize(s, meth.line)
     serialize(s, meth.sig)
-    serialize(s, meth.tvars)
     serialize(s, meth.sparam_syms)
     serialize(s, meth.ambig)
     serialize(s, meth.nargs)
@@ -632,7 +631,6 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
     file = deserialize(s)::Symbol
     line = deserialize(s)::Int32
     sig = deserialize(s)::DataType
-    tvars = deserialize(s)::Union{SimpleVector, TypeVar}
     sparam_syms = deserialize(s)::SimpleVector
     ambig = deserialize(s)::Union{Array{Any,1}, Void}
     nargs = deserialize(s)::Int32
@@ -645,7 +643,6 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
         meth.file = file
         meth.line = line
         meth.sig = sig
-        meth.tvars = tvars
         meth.sparam_syms = sparam_syms
         meth.ambig = ambig
         meth.isstaged = isstaged

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4185,7 +4185,7 @@ static Function *jl_cfunction_object(jl_function_t *ff, jl_value_t *declrt, jl_t
     }
     if (sf == NULL) {
         sf = jl_typemap_insert(&jl_cfunction_list, (jl_value_t*)jl_cfunction_list.unknown, (jl_tupletype_t*)cfunc_sig,
-            jl_emptysvec, NULL, jl_emptysvec, NULL, /*offs*/0, &cfunction_cache, 1, ~(size_t)0, NULL);
+            NULL, jl_emptysvec, NULL, /*offs*/0, &cfunction_cache, 1, ~(size_t)0, NULL);
     }
 
     // Backup the info for the nested compile

--- a/src/dump.c
+++ b/src/dump.c
@@ -922,7 +922,6 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v)
         else {
             assert(m->max_world == ~(size_t)0 && "method replacement cannot be handled by incremental serializer");
         }
-        jl_serialize_value(s, (jl_value_t*)m->tvars);
         if (external_mt)
             jl_serialize_value(s, jl_nothing);
         else
@@ -1659,8 +1658,6 @@ static jl_value_t *jl_deserialize_value_method(jl_serializer_state *s, jl_value_
         m->min_world = jl_world_counter;
         m->max_world = ~(size_t)0;
     }
-    m->tvars = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&m->tvars);
-    jl_gc_wb(m, m->tvars);
     m->ambig = jl_deserialize_value(s, (jl_value_t**)&m->ambig);
     jl_gc_wb(m, m->ambig);
     m->called = read_int8(s->s);

--- a/src/gf.c
+++ b/src/gf.c
@@ -169,7 +169,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m, 
     else {
         li->max_world = world;
     }
-    jl_typemap_insert(&m->specializations, (jl_value_t*)m, (jl_tupletype_t*)type, jl_emptysvec,
+    jl_typemap_insert(&m->specializations, (jl_value_t*)m, (jl_tupletype_t*)type,
             NULL, jl_emptysvec, (jl_value_t*)li, 0, &tfunc_cache,
             li->min_world, li->max_world, NULL);
     JL_UNLOCK(&m->writelock);
@@ -221,11 +221,10 @@ void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr)
     li->def->isva = 1;
     li->def->nargs = 2;
     li->def->sig = (jl_value_t*)jl_anytuple_type;
-    li->def->tvars = jl_emptysvec;
     li->def->sparam_syms = jl_emptysvec;
 
     jl_methtable_t *mt = dt->name->mt;
-    jl_typemap_insert(&mt->cache, (jl_value_t*)mt, jl_anytuple_type, jl_emptysvec,
+    jl_typemap_insert(&mt->cache, (jl_value_t*)mt, jl_anytuple_type,
         NULL, jl_emptysvec, (jl_value_t*)li, 0, &lambda_cache, 1, ~(size_t)0, NULL);
     JL_GC_POP();
 }
@@ -398,7 +397,7 @@ JL_DLLEXPORT jl_method_instance_t* jl_set_method_inferred(
                 li->min_world = min_world;
                 li->max_world = max_world;
                 jl_typemap_insert(&li->def->specializations, (jl_value_t*)li->def,
-                        (jl_tupletype_t*)li->specTypes, jl_emptysvec, NULL, jl_emptysvec,
+                        (jl_tupletype_t*)li->specTypes, NULL, jl_emptysvec,
                         (jl_value_t*)li, 0, &tfunc_cache,
                         li->min_world, li->max_world, NULL);
             }
@@ -878,12 +877,12 @@ static jl_method_instance_t *cache_method(jl_methtable_t *mt, union jl_typemap_t
             if (nsp > 0) {
                 jl_svec_t *env = jl_alloc_svec_uninit(2 * nsp);
                 temp2 = (jl_value_t*)env;
+                jl_unionall_t *ua = (jl_unionall_t*)m->sig;
                 for (j = 0; j < nsp; j++) {
-                    if (j == 0 && jl_is_typevar(m->tvars))
-                        jl_svecset(env, 0, m->tvars);
-                    else
-                        jl_svecset(env, j * 2, jl_svecref(m->tvars, j));
+                    assert(jl_is_unionall(ua));
+                    jl_svecset(env, j * 2, ua->var);
                     jl_svecset(env, j * 2 + 1, jl_svecref(sparams, j));
+                    ua = (jl_unionall_t*)ua->body;
                 }
                 lastdeclt = (jl_value_t*)jl_instantiate_type_with((jl_value_t*)lastdeclt,
                                                                   jl_svec_data(env), nsp);
@@ -957,7 +956,7 @@ static jl_method_instance_t *cache_method(jl_methtable_t *mt, union jl_typemap_t
                     jl_svecset(guardsigs, guards, (jl_tupletype_t*)jl_svecref(m, 0));
                     guards++;
                     //jl_typemap_insert(cache, parent, (jl_tupletype_t*)jl_svecref(m, 0),
-                    //        jl_emptysvec, NULL, jl_emptysvec, /*guard*/NULL, jl_cachearg_offset(mt), &lambda_cache, other->min_world, other->max_world, NULL);
+                    //        NULL, jl_emptysvec, /*guard*/NULL, jl_cachearg_offset(mt), &lambda_cache, other->min_world, other->max_world, NULL);
                 }
             }
         }
@@ -1006,7 +1005,7 @@ static jl_method_instance_t *cache_method(jl_methtable_t *mt, union jl_typemap_t
         }
     }
 
-    jl_typemap_insert(cache, parent, origtype, jl_emptysvec, type, guardsigs,
+    jl_typemap_insert(cache, parent, origtype, type, guardsigs,
             (jl_value_t*)newmeth, jl_cachearg_offset(mt), &lambda_cache,
             min_valid, max_valid, NULL);
 
@@ -1337,14 +1336,13 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
     assert(jl_is_method(method));
     assert(jl_is_mtable(mt));
     jl_value_t *type = method->sig;
-    jl_svec_t *tvars = method->tvars;
     jl_value_t *oldvalue = NULL;
     struct invalidate_conflicting_env env;
     env.max_world = method->min_world - 1;
     JL_GC_PUSH1(&oldvalue);
     JL_LOCK(&mt->writelock);
     jl_typemap_entry_t *newentry = jl_typemap_insert(&mt->defs, (jl_value_t*)mt,
-            (jl_tupletype_t*)type, tvars, simpletype, jl_emptysvec, (jl_value_t*)method, 0, &method_defs,
+            (jl_tupletype_t*)type, simpletype, jl_emptysvec, (jl_value_t*)method, 0, &method_defs,
             method->min_world, method->max_world, &oldvalue);
     if (oldvalue) {
         method->ambig = ((jl_method_t*)oldvalue)->ambig;
@@ -2273,7 +2271,7 @@ jl_value_t *jl_gf_invoke(jl_tupletype_t *types0, jl_value_t **args, size_t nargs
         }
         else {
             tt = arg_type_tuple(args, nargs);
-            if (entry->tvars != jl_emptysvec) {
+            if (jl_is_unionall(entry->sig)) {
                 jl_value_t *ti = jl_type_intersection_env((jl_value_t*)tt, (jl_value_t*)entry->sig, &tpenv);
                 assert(ti != (jl_value_t*)jl_bottom_type);
                 (void)ti;
@@ -2355,7 +2353,7 @@ JL_DLLEXPORT jl_value_t *jl_get_invoke_lambda(jl_methtable_t *mt,
     jl_svec_t *tpenv = jl_emptysvec;
     jl_tupletype_t *sig = NULL;
     JL_GC_PUSH2(&tpenv, &sig);
-    if (entry->tvars != jl_emptysvec) {
+    if (jl_is_unionall(entry->sig)) {
         jl_value_t *ti =
             jl_type_intersection_env((jl_value_t*)tt, (jl_value_t*)entry->sig, &tpenv);
         assert(ti != (jl_value_t*)jl_bottom_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1722,10 +1722,9 @@ void jl_init_types(void)
 
     jl_typemap_entry_type =
         jl_new_datatype(jl_symbol("TypeMapEntry"), jl_any_type, jl_emptysvec,
-                        jl_svec(11,
+                        jl_svec(10,
                             jl_symbol("next"),
                             jl_symbol("sig"),
-                            jl_symbol("tvars"),
                             jl_symbol("simplesig"),
                             jl_symbol("guardsigs"),
                             jl_symbol("min_world"),
@@ -1734,10 +1733,9 @@ void jl_init_types(void)
                             jl_symbol("isleafsig"),
                             jl_symbol("issimplesig"),
                             jl_symbol("va")),
-                        jl_svec(11,
+                        jl_svec(10,
                             jl_any_type, // Union{TypeMapEntry, Void}
                             jl_type_type, // TupleType
-                            jl_any_type, // Union{SimpleVector{TypeVar}, TypeVar}
                             jl_any_type, // TupleType
                             jl_any_type, // SimpleVector{TupleType}
                             jl_long_type, // Int
@@ -1746,7 +1744,7 @@ void jl_init_types(void)
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type),
-                        0, 1, 5);
+                        0, 1, 4);
 
     jl_function_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Function"), jl_any_type, jl_emptysvec);
     jl_builtin_type  = jl_new_abstracttype((jl_value_t*)jl_symbol("Builtin"), jl_function_type, jl_emptysvec);
@@ -1851,13 +1849,12 @@ void jl_init_types(void)
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(21,
+                        jl_svec(20,
                                 jl_symbol("name"),
                                 jl_symbol("module"),
                                 jl_symbol("file"),
                                 jl_symbol("line"),
                                 jl_symbol("sig"),
-                                jl_symbol("tvars"),
                                 jl_symbol("min_world"),
                                 jl_symbol("max_world"),
                                 jl_symbol("ambig"),
@@ -1873,13 +1870,12 @@ void jl_init_types(void)
                                 jl_symbol("isva"),
                                 jl_symbol("isstaged"),
                                 jl_symbol("needs_sparam_vals_ducttape")),
-                        jl_svec(21,
+                        jl_svec(20,
                                 jl_sym_type,
                                 jl_module_type,
                                 jl_sym_type,
                                 jl_int32_type,
                                 jl_type_type,
-                                jl_any_type, // Union{TypeVar, SimpleVector}
                                 jl_long_type,
                                 jl_long_type,
                                 jl_any_type, // Union{Array, Void}
@@ -1895,7 +1891,7 @@ void jl_init_types(void)
                                 jl_bool_type,
                                 jl_bool_type,
                                 jl_bool_type),
-                        0, 1, 11);
+                        0, 1, 10);
 
     jl_method_instance_type =
         jl_new_datatype(jl_symbol("MethodInstance"),
@@ -1999,8 +1995,8 @@ void jl_init_types(void)
     jl_svecset(jl_methtable_type->types, 7, jl_int32_type); // DWORD
 #endif
     jl_svecset(jl_methtable_type->types, 8, jl_int32_type); // uint32_t
+    jl_svecset(jl_method_type->types, 11, jl_method_instance_type);
     jl_svecset(jl_method_type->types, 12, jl_method_instance_type);
-    jl_svecset(jl_method_type->types, 13, jl_method_instance_type);
     jl_svecset(jl_method_instance_type->types, 12, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 13, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 14, jl_voidpointer_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -230,8 +230,6 @@ typedef struct _jl_method_t {
 
     // method's type signature. redundant with TypeMapEntry->specTypes
     jl_value_t *sig;
-    // bound type variables (static parameters)
-    jl_svec_t *tvars;
     size_t min_world;
     size_t max_world;
 
@@ -241,7 +239,7 @@ typedef struct _jl_method_t {
     // table of all argument types for which we've inferred or compiled this code
     union jl_typemap_t specializations;
 
-    jl_svec_t *sparam_syms;  // symbols corresponding to the tvars vector
+    jl_svec_t *sparam_syms;  // symbols giving static parameter names
     jl_code_info_t *source;  // original code template, null for builtins
     struct _jl_method_instance_t *unspecialized;  // unspecialized executable method instance, or null
     struct _jl_method_instance_t *generator;  // executable code-generating function if isstaged
@@ -268,7 +266,7 @@ typedef struct _jl_method_instance_t {
     JL_DATA_TYPE
     jl_value_t *specTypes;  // argument types this was specialized for
     jl_value_t *rettype; // return type for fptr
-    jl_svec_t *sparam_vals; // the values for the tvars, indexed by def->sparam_syms
+    jl_svec_t *sparam_vals; // static parameter values, indexed by def->sparam_syms
     jl_array_t *backedges;
     jl_value_t *inferred;  // inferred jl_code_info_t, or value of the function if jlcall_api == 2, or null
     jl_value_t *inferred_const; // inferred constant return value, or null
@@ -415,7 +413,6 @@ typedef struct _jl_typemap_entry_t {
     JL_DATA_TYPE
     struct _jl_typemap_entry_t *next; // invasive linked list
     jl_tupletype_t *sig; // the type signature for this entry
-    jl_svec_t *tvars; // the bound type variables for sig
     jl_tupletype_t *simplesig; // a simple signature for fast rejection
     jl_svec_t *guardsigs;
     size_t min_world;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -340,6 +340,7 @@ jl_value_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t **p
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
 JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals);
 jl_value_t *jl_substitute_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val);
+jl_svec_t *jl_outer_unionall_vars(jl_value_t *u);
 jl_datatype_t *jl_new_uninitialized_datatype(void);
 jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
                                    jl_svec_t *parameters);
@@ -757,7 +758,7 @@ struct jl_typemap_info {
 };
 
 jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *parent,
-                                      jl_tupletype_t *type, jl_svec_t *tvars,
+                                      jl_tupletype_t *type,
                                       jl_tupletype_t *simpletype, jl_svec_t *guardsigs,
                                       jl_value_t *newvalue, int8_t offs,
                                       const struct jl_typemap_info *tparams,

--- a/src/method.c
+++ b/src/method.c
@@ -377,9 +377,7 @@ static void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
     m->called = called;
 
     jl_array_t *copy = NULL;
-    jl_svec_t *sparam_vars = m->tvars;
-    if (!jl_is_svec(sparam_vars))
-        sparam_vars = jl_svec1(sparam_vars);
+    jl_svec_t *sparam_vars = jl_outer_unionall_vars(m->sig);
     JL_GC_PUSH2(&copy, &sparam_vars);
     assert(jl_typeis(src->code, jl_array_any_type));
     jl_array_t *stmts = (jl_array_t*)src->code;
@@ -415,7 +413,6 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(void)
         (jl_method_t*)jl_gc_alloc(ptls, sizeof(jl_method_t), jl_method_type);
     m->specializations.unknown = jl_nothing;
     m->sig = NULL;
-    m->tvars = NULL;
     m->sparam_syms = NULL;
     m->ambig = jl_nothing;
     m->roots = NULL;
@@ -465,10 +462,6 @@ jl_method_t *jl_new_method(jl_code_info_t *definition,
     m->sig = (jl_value_t*)sig;
     m->isva = isva;
     m->nargs = nargs;
-    if (jl_svec_len(tvars) == 1)
-        m->tvars = (jl_svec_t*)jl_svecref(tvars, 0);
-    else
-        m->tvars = tvars;
     jl_method_set_source(m, definition);
     if (isstaged) {
         // create and store generator for generated functions

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1821,6 +1821,23 @@ JL_DLLEXPORT jl_value_t *jl_intersect_types(jl_value_t *x, jl_value_t *y)
     return intersect_all(x, y, &e);
 }
 
+// return a SimpleVector of all vars from UnionAlls wrapping a given type
+jl_svec_t *jl_outer_unionall_vars(jl_value_t *u)
+{
+    int ntvars = jl_subtype_env_size((jl_value_t*)u);
+    jl_svec_t *vec = jl_alloc_svec_uninit(ntvars);
+    JL_GC_PUSH1(&vec);
+    jl_unionall_t *ua = (jl_unionall_t*)u;
+    int i;
+    for(i=0; i < ntvars; i++) {
+        assert(jl_is_unionall(ua));
+        jl_svecset(vec, i, ua->var);
+        ua = (jl_unionall_t*)ua->body;
+    }
+    JL_GC_POP();
+    return vec;
+}
+
 // sets *issubty to 1 iff `a` is a subtype of `b`
 jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, int *issubty)
 {


### PR DESCRIPTION
This removes `tvars` fields from `Method` and `TypeMapEntry` that duplicate information that's now also in the type (signature) field.