### PR TITLE
Fix misc test to not hard code test module name

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -52,12 +52,12 @@ end
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
 
-logging(DevNull, TestMain_misc.Logging, :bar;  kind=:info)
+logging(DevNull, Logging, :bar;  kind=:info)
 @test all(contains.(sprint(Logging.bar), ["WARNING: barwarn", "ERROR: \"barerror\""]))
 @test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
-logging(DevNull, TestMain_misc.Logging;  kind=:info)
+logging(DevNull, Logging;  kind=:info)
 @test all(contains.(sprint(Logging.bar), ["WARNING: barwarn", "ERROR: \"barerror\""]))
 @test all(contains.(sprint(Logging.pooh), ["WARNING: poohwarn", "ERROR: \"pooherror\""]))
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
@@ -73,12 +73,12 @@ logging(kind=:info)
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
 
-logging(DevNull, TestMain_misc.Logging, :bar;  kind=:warn)
+logging(DevNull, Logging, :bar;  kind=:warn)
 @test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "ERROR: \"barerror\""]))
 @test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
-logging(DevNull, TestMain_misc.Logging;  kind=:warn)
+logging(DevNull, Logging;  kind=:warn)
 @test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "ERROR: \"barerror\""]))
 @test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "ERROR: \"pooherror\""]))
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
@@ -94,12 +94,12 @@ logging(kind=:warn)
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
 
-logging(DevNull, TestMain_misc.Logging, :bar;  kind=:error)
+logging(DevNull, Logging, :bar;  kind=:error)
 @test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn"]))
 @test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
-logging(DevNull, TestMain_misc.Logging;  kind=:error)
+logging(DevNull, Logging;  kind=:error)
 @test all(contains.(sprint(Logging.bar), ["INFO: barinfo", "WARNING: barwarn"]))
 @test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn"]))
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
@@ -115,12 +115,12 @@ logging(kind=:error)
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
 
-logging(DevNull, TestMain_misc.Logging, :bar)
+logging(DevNull, Logging, :bar)
 @test sprint(Logging.bar) == ""
 @test all(contains.(sprint(Logging.pooh), ["INFO: poohinfo", "WARNING: poohwarn", "ERROR: \"pooherror\""]))
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))
 
-logging(DevNull, TestMain_misc.Logging)
+logging(DevNull, Logging)
 @test sprint(Logging.bar) == ""
 @test sprint(Logging.pooh) == ""
 @test all(contains.(sprint(foo), ["INFO: fooinfo", "WARNING: foowarn", "ERROR: \"fooerror\""]))

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -5,7 +5,9 @@ function runtests(name, isolate=true)
     Base.Test.TESTSET_PRINT_ENABLE[] = false
     try
         if isolate
-            mod_name = Symbol("TestMain_", replace(name, '/', '_'))
+            # Simple enough to type and random enough so that no one will hard
+            # code it in the test
+            mod_name = Symbol("Test", rand(1:100), "Main_", replace(name, '/', '_'))
             m = @eval(Main, module $mod_name end)
         else
             m = Main


### PR DESCRIPTION
Use randomized test module name to prevent this from happening again.

Pointed out by @vtjnash . I originally didn't use a random number because I thought it's obvious enough that the module name is not meant to be used directly.... Obviously that doesn't work.
