### PR TITLE
give `sum(T::Type, xs) = zero(T)` when xs is empy

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -232,7 +232,7 @@ mr_empty(f, op, T) = _empty_reduce_error()
 # use zero(T)::T to improve type information when zero(T) is not defined
 # f::Callable = Union{Type, Function}; when f::Type, we can do better
 mr_empty(S::Type, op::typeof(+), T) = r_promote(op, zero(S)::S)
-mr_empty(s::Type, op::typeof(*), T) = r_promote(op, one(S)::S)
+mr_empty(S::Type, op::typeof(*), T) = r_promote(op, one(S)::S)
 mr_empty(::typeof(identity), op::typeof(+), T) = r_promote(op, zero(T)::T)
 mr_empty(::typeof(abs), op::typeof(+), T) = r_promote(op, abs(zero(T)::T))
 mr_empty(::typeof(abs2), op::typeof(+), T) = r_promote(op, abs2(zero(T)::T))

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -230,6 +230,9 @@ pairwise_blocksize(::typeof(abs2), ::typeof(+)) = 4096
 _empty_reduce_error() = throw(ArgumentError("reducing over an empty collection is not allowed"))
 mr_empty(f, op, T) = _empty_reduce_error()
 # use zero(T)::T to improve type information when zero(T) is not defined
+# f::Callable = Union{Type, Function}; when f::Type, we can do better
+mr_empty(S::Type, op::typeof(+), T) = r_promote(op, zero(S)::S)
+mr_empty(s::Type, op::typeof(*), T) = r_promote(op, one(S)::S)
 mr_empty(::typeof(identity), op::typeof(+), T) = r_promote(op, zero(T)::T)
 mr_empty(::typeof(abs), op::typeof(+), T) = r_promote(op, abs(zero(T)::T))
 mr_empty(::typeof(abs2), op::typeof(+), T) = r_promote(op, abs2(zero(T)::T))


### PR DESCRIPTION
From https://github.com/JuliaLang/julia/issues/5311, we allow notation like `sum(T::Type, xs)` to cast the return type of the sum. Currently
```
julia> sum(Float64, [])
ERROR: ArgumentError: reducing over an empty collection is not allowed
```
With this PR:
```
julia> sum(Float64, [])
0.0
```
This lets you avoid writing boilerplate `if isempty(xs) ... else ...` code around what should be a simple `sum(T, xs)`, by handling the case when `xs` is empty in the natural way.

This is achieved by extending `mr_empty`, which dispatches on `f::Callable, op, T::Type`. Here `Callable = Union{Type, Function}`. When `f::Function`, there is currently nothing we can say in general (some special cases are defined, like `identity` and `abs2`). When `f::Type`, however, the user has indicated what resulting type he would like: therefore, when `op = +`, return `zero(f)`, and when `op = *`, return `one(f)`. This also enhances the behaviour of `sum(T::Type, xs)` and `prod(T::Type, xs)`.

Note this introduces a new error possibility:
```
julia> sum(String, [])
ERROR: MethodError: no method matching zero(::Type{String})
```
but I feel like anyone who tries to sum strings or any type `T` without a `zero(T)` has only himself to blame. And of course
```
julia> prod(String, [])
""
```