### PR TITLE
Fix real Hermitian inverse error

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -261,8 +261,8 @@ det(A::Symmetric) = det(bkfact(A))
 
 \(A::HermOrSym{<:Any,<:StridedMatrix}, B::StridedVecOrMat) = \(bkfact(A.data, Symbol(A.uplo), issymmetric(A)), B)
 
-inv{T<:BlasFloat,S<:StridedMatrix}(A::Hermitian{T,S}) = Hermitian{T,S}(inv(bkfact(A.data, Symbol(A.uplo))), A.uplo)
-inv{T<:BlasFloat,S<:StridedMatrix}(A::Symmetric{T,S}) = Symmetric{T,S}(inv(bkfact(A.data, Symbol(A.uplo), true)), A.uplo)
+inv{T<:BlasFloat,S<:StridedMatrix}(A::Hermitian{T,S}) = Hermitian{T,S}(inv(bkfact(A)), A.uplo)
+inv{T<:BlasFloat,S<:StridedMatrix}(A::Symmetric{T,S}) = Symmetric{T,S}(inv(bkfact(A)), A.uplo)
 
 eigfact!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)...)
 # Because of #6721 it is necessary to specify the parameters explicitly here.

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -174,6 +174,8 @@ let n=10
         @test inv(Hermitian(asym)) ≈ inv(asym)
         if eltya <: Real && eltya != Int
             @test inv(Symmetric(asym)) ≈ inv(asym)
+            @test inv(Hermitian(a)) ≈ inv(full(Hermitian(a)))
+            @test inv(Symmetric(a)) ≈ inv(full(Symmetric(a)))
         end
 
         # conversion


### PR DESCRIPTION
Fixed an error thrown when calling `inv(H)` with a Hermitian matrix `H` constructed from data that is real but not symmetric (in which case `bkfact` would end up testing symmetry on the non-symmetric `H.data` rather than `H` itself). `bkfact(A::HermOrSym)` is already defined and does the right thing, so I just use that.