### PR TITLE
Throw informative error for `eltype(Union{})`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -861,6 +861,7 @@ Int8
 """
 eltype(::Type) = Any
 eltype(::Type{Any}) = Any
+eltype(::Type{Bottom}) = throw(ArgumentError("Union{} does not have elements"))
 eltype(t::DataType) = eltype(supertype(t))
 eltype(x) = eltype(typeof(x))
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -4676,3 +4676,5 @@ if Sys.WORD_SIZE == 64
     end
     @test_nowarn tester20360()
 end
+
+@test_throws ArgumentError eltype(Bottom)


### PR DESCRIPTION
EDIT: originally this resolved the ambiguity by returning `Union{}`.