### PR TITLE
use ShellExecuteW rather than cmd for edit function on Windows 

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -64,7 +64,6 @@ function edit(path::AbstractString, line::Integer=0)
         systemerror(:edit, ccall((:ShellExecuteW,"shell32"), stdcall, Int,
                                  (Ptr{Void}, Cwstring, Cwstring, Ptr{Void}, Ptr{Void}, Cint),
                                  C_NULL, "open", path, C_NULL, C_NULL, 10) ≤ 32)
-        line_unsupported = true
     elseif background
         spawn(pipeline(cmd, stderr=STDERR))
     else


### PR DESCRIPTION
Closes #20364.  Updated version of #20478, and on JuliaLang so that buildbot can be used.  Supersedes #20479.