### PR TITLE
rename bitstype to primitivetype in internal functions

### DIFF
--- a/src/abi_arm.cpp
+++ b/src/abi_arm.cpp
@@ -166,8 +166,8 @@ void classify_return_arg(jl_datatype_t *dt, bool *reg,
     // - A double-word sized Fundamental Data Type (e.g., long long, double and
     //   64-bit containerized vectors) is returned in r0 and r1.
     // - A word-sized Fundamental Data Type (eg., int, float) is returned in r0.
-    // NOTE: assuming "fundamental type" == jl_is_bitstype, might need exact def
-    if (jl_is_bitstype(dt) && jl_datatype_size(dt) <= 8) {
+    // NOTE: assuming "fundamental type" == jl_is_primitivetype, might need exact def
+    if (jl_is_primitivetype(dt) && jl_datatype_size(dt) <= 8) {
         *reg = true;
         return;
     }
@@ -229,7 +229,7 @@ void classify_arg(jl_datatype_t *dt, bool *reg,
         return;
 
     // Handle fundamental types
-    if (jl_is_bitstype(dt) && jl_datatype_size(dt) <= 8) {
+    if (jl_is_primitivetype(dt) && jl_datatype_size(dt) <= 8) {
         *reg = true;
         return;
     }

--- a/src/abi_ppc64le.cpp
+++ b/src/abi_ppc64le.cpp
@@ -62,7 +62,7 @@ unsigned isHFA(jl_datatype_t *ty, jl_datatype_t **ty0, bool *hva) const
     if (!jl_is_datatype(fld0) || ty->name == jl_vecelement_typename)
         return 9;
     if (fld0->name == jl_vecelement_typename) {
-        if (!jl_is_bitstype(jl_tparam0(fld0)) || jl_datatype_size(ty) > 16)
+        if (!jl_is_primitivetype(jl_tparam0(fld0)) || jl_datatype_size(ty) > 16)
             return 9;
         if (l != 1 && l != 2 && l != 4 && l != 8 && l != 16)
             return 9;
@@ -134,7 +134,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret) const override
             jl_datatype_t *vecty = (jl_datatype_t*)jl_field_type(ty0, 0);
             assert(jl_is_datatype(vecty) && vecty->name == jl_vecelement_typename);
             jl_value_t *elemty = jl_tparam0(vecty);
-            assert(jl_is_bitstype(elemty));
+            assert(jl_is_primitivetype(elemty));
 
             Type *ety = julia_type_to_llvm(elemty);
             Type *vty = VectorType::get(ety, jl_datatype_nfields(ty0));

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -70,7 +70,7 @@ bool needPassByRef(jl_datatype_t *dt, AttrBuilder &ab) override
 Type *preferred_llvm_type(jl_datatype_t *dt, bool isret) const override
 {
     size_t size = jl_datatype_size(dt);
-    if (size > 0 && win64_reg_size(size) && !jl_is_bitstype(dt))
+    if (size > 0 && win64_reg_size(size) && !jl_is_primitivetype(dt))
         return Type::getIntNTy(jl_LLVMContext, jl_datatype_nbits(dt));
     return NULL;
 }

--- a/src/abi_x86.cpp
+++ b/src/abi_x86.cpp
@@ -58,7 +58,7 @@ bool use_sret(jl_datatype_t *dt) override
     size_t size = jl_datatype_size(dt);
     if (size == 0)
         return false;
-    if (is_complex64(dt) || (jl_is_bitstype(dt) && size <= 8))
+    if (is_complex64(dt) || (jl_is_primitivetype(dt) && size <= 8))
         return false;
     return true;
 }
@@ -66,7 +66,7 @@ bool use_sret(jl_datatype_t *dt) override
 bool needPassByRef(jl_datatype_t *dt, AttrBuilder &ab) override
 {
     size_t size = jl_datatype_size(dt);
-    if (is_complex64(dt) || is_complex128(dt) || (jl_is_bitstype(dt) && size <= 8))
+    if (is_complex64(dt) || is_complex128(dt) || (jl_is_primitivetype(dt) && size <= 8))
         return false;
     ab.addAttribute(Attribute::ByVal);
     return true;

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -129,7 +129,7 @@ void classifyType(Classification& accum, jl_datatype_t *dt, uint64_t offset) con
     else if (jl_datatype_size(dt) == 0) {
     }
     // BitsTypes and not float, write as Integers
-    else if (jl_is_bitstype(dt)) {
+    else if (jl_is_primitivetype(dt)) {
         if (jl_datatype_size(dt) <= 8) {
             accum.addField(offset, Integer);
         }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -549,7 +549,7 @@ static Value *julia_to_address(Type *to, jl_value_t *jlto, jl_unionall_t *jlto_e
                 // yes copy
                 Value *nbytes;
                 AllocaInst *ai;
-                if (jl_is_leaf_type(ety) || jl_is_bitstype(ety)) {
+                if (jl_is_leaf_type(ety) || jl_is_primitivetype(ety)) {
                     int nb = jl_datatype_size(ety);
                     nbytes = ConstantInt::get(T_int32, nb);
                     ai = emit_static_alloca(T_int8, nb, ctx);
@@ -1306,7 +1306,7 @@ std::string generate_func_sig()
             isboxed = false;
         }
         else {
-            if (jl_is_bitstype(tti)) {
+            if (jl_is_primitivetype(tti)) {
                 // see pull req #978. need to annotate signext/zeroext for
                 // small integer arguments.
                 jl_datatype_t *bt = (jl_datatype_t*)tti;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -151,7 +151,7 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
         return DIType((llvm::MDNode*)jdt->ditype);
 #endif
     }
-    if (jl_is_bitstype(jt)) {
+    if (jl_is_primitivetype(jt)) {
         uint64_t SizeInBits = jl_datatype_nbits(jdt);
     #if JL_LLVM_VERSION >= 40000
         llvm::DIType *t = dbuilder->createBasicType(
@@ -365,7 +365,7 @@ JL_DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt, bool *isboxed)
     if (jt == (jl_value_t*)jl_bottom_type)
         return T_void;
     if (jl_is_leaf_type(jt)) {
-        if ((jl_is_bitstype(jt) || jl_isbits(jt))) {
+        if ((jl_is_primitivetype(jt) || jl_isbits(jt))) {
             if (jl_datatype_nbits(jt) == 0)
                 return T_void;
             Type *t = julia_struct_to_llvm(jt, NULL, isboxed);
@@ -381,7 +381,7 @@ JL_DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt, bool *isboxed)
 // converts a julia bitstype into the equivalent LLVM bitstype
 static Type *bitstype_to_llvm(jl_value_t *bt)
 {
-    assert(jl_is_bitstype(bt));
+    assert(jl_is_primitivetype(bt));
     if (bt == (jl_value_t*)jl_bool_type)
         return T_int8;
     if (bt == (jl_value_t*)jl_long_type)
@@ -414,7 +414,7 @@ static Type *bitstype_to_llvm(jl_value_t *bt)
 // fields depend on any of the parameters of the containing type)
 static bool julia_struct_has_layout(jl_datatype_t *dt, jl_unionall_t *ua)
 {
-    if (dt->layout || dt->struct_decl || jl_is_bitstype(dt) || jl_isbits(dt))
+    if (dt->layout || dt->struct_decl || jl_is_primitivetype(dt) || jl_isbits(dt))
         return true;
     if (ua) {
         size_t i, ntypes = jl_datatype_nfields(dt);
@@ -435,7 +435,7 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, jl_unionall_t *ua, bool *isbox
     if (isboxed) *isboxed = false;
     if (jt == (jl_value_t*)jl_bottom_type)
         return T_void;
-    if (jl_is_bitstype(jt))
+    if (jl_is_primitivetype(jt))
         return bitstype_to_llvm(jt);
     bool isTuple = jl_is_tuple_type(jt);
     if ((isTuple || jl_is_structtype(jt)) && !jl_is_array_type(jt)) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -738,7 +738,7 @@ static void CreateTrap(IRBuilder<> &builder)
 static bool isbits_spec(jl_value_t *jt, bool allow_unsized = true)
 {
     return jl_isbits(jt) && jl_is_leaf_type(jt) && (allow_unsized ||
-        ((jl_is_bitstype(jt) && jl_datatype_size(jt) > 0) ||
+        ((jl_is_primitivetype(jt) && jl_datatype_size(jt) > 0) ||
          (jl_is_datatype(jt) && jl_datatype_nfields(jt)>0)));
 }
 

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -179,7 +179,7 @@ unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *t)
         return 0;               // nfields has more than two 1s
     assert(jl_datatype_nfields(t)==1);
     jl_value_t *ty = jl_field_type(t, 0);
-    if (!jl_is_bitstype(ty))
+    if (!jl_is_primitivetype(ty))
         // LLVM requires that a vector element be a primitive type.
         // LLVM allows pointer types as vector elements, but until a
         // motivating use case comes up for Julia, we reject pointers.
@@ -364,8 +364,8 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super
     return t;
 }
 
-JL_DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
-                                            jl_svec_t *parameters, size_t nbits)
+JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_datatype_t *super,
+                                                 jl_svec_t *parameters, size_t nbits)
 {
     jl_datatype_t *bt = jl_new_datatype((jl_sym_t*)name, super, parameters,
                                         jl_emptysvec, jl_emptysvec, 0, 0, 0);
@@ -457,7 +457,7 @@ BOXN_FUNC(64, 2)
 #define UNBOX_FUNC(j_type,c_type)                                       \
     JL_DLLEXPORT c_type jl_unbox_##j_type(jl_value_t *v)                \
     {                                                                   \
-        assert(jl_is_bitstype(jl_typeof(v)));                           \
+        assert(jl_is_primitivetype(jl_typeof(v)));                           \
         assert(jl_datatype_size(jl_typeof(v)) == sizeof(c_type));       \
         return *(c_type*)jl_data_ptr(v);                                \
     }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -368,7 +368,7 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
         if (nb < 1 || nb>=(1<<23) || (nb&7) != 0)
             jl_errorf("invalid number of bits in type %s",
                       jl_symbol_name((jl_sym_t*)name));
-        dt = jl_new_bitstype(name, NULL, (jl_svec_t*)para, nb);
+        dt = jl_new_primitivetype(name, NULL, (jl_svec_t*)para, nb);
         w = dt->name->wrapper;
         jl_binding_t *b = jl_get_binding_wr(modu, (jl_sym_t*)name);
         temp = b->value;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -168,7 +168,7 @@ static Constant *julia_const_to_llvm(void *ptr, jl_value_t *bt)
 
     if (jl_is_cpointer_type(bt))
         return ConstantExpr::getIntToPtr(ConstantInt::get(T_size, *(uintptr_t*)ptr), julia_type_to_llvm(bt));
-    if (jl_is_bitstype(bt)) {
+    if (jl_is_primitivetype(bt)) {
         int nb = jl_datatype_size(bt);
         // TODO: non-power-of-2 size datatypes may not be interpreted correctly on big-endian systems
         switch (nb) {
@@ -368,7 +368,7 @@ static jl_value_t *staticeval_bitstype(const jl_cgval_t &targ)
     // evaluate an argument at compile time to determine what type it is
     if (jl_is_type_type(targ.typ)) {
         jl_value_t *bt = jl_tparam0(targ.typ);
-        if (jl_is_bitstype(bt))
+        if (jl_is_primitivetype(bt))
             return bt;
     }
     return NULL;
@@ -404,9 +404,9 @@ static jl_cgval_t generic_bitcast(const jl_cgval_t *argv, jl_codectx_t *ctx)
     bool isboxed;
     Type *vxt = julia_type_to_llvm(v.typ, &isboxed);
 
-    if (!jl_is_bitstype(v.typ) || jl_datatype_size(v.typ) != nb) {
+    if (!jl_is_primitivetype(v.typ) || jl_datatype_size(v.typ) != nb) {
         Value *typ = emit_typeof_boxed(v, ctx);
-        if (!jl_is_bitstype(v.typ)) {
+        if (!jl_is_primitivetype(v.typ)) {
             if (isboxed) {
                 Value *isbits = emit_datatype_isbitstype(typ);
                 error_unless(isbits, "bitcast: expected primitive type value for second argument", ctx);
@@ -475,7 +475,7 @@ static jl_cgval_t generic_cast(
     const jl_cgval_t &targ = argv[0];
     const jl_cgval_t &v = argv[1];
     jl_value_t *jlto = staticeval_bitstype(targ);
-    if (!jlto || !jl_is_bitstype(v.typ))
+    if (!jlto || !jl_is_primitivetype(v.typ))
         return emit_runtime_call(f, argv, 2, ctx);
     Type *to = bitstype_to_llvm(jlto);
     Type *vt = bitstype_to_llvm(v.typ);
@@ -838,7 +838,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 
     case not_int: {
         const jl_cgval_t &x = argv[0];
-        if (!jl_is_bitstype(x.typ))
+        if (!jl_is_primitivetype(x.typ))
             return emit_runtime_call(f, argv, nargs, ctx);
         Type *xt = INTT(bitstype_to_llvm(x.typ));
         Value *from = emit_unbox(xt, x, x.typ);
@@ -853,7 +853,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     case powi_llvm: {
         const jl_cgval_t &x = argv[0];
         const jl_cgval_t &y = argv[1];
-        if (!jl_is_bitstype(x.typ) || !jl_is_bitstype(y.typ) || jl_datatype_size(y.typ) != 4)
+        if (!jl_is_primitivetype(x.typ) || !jl_is_primitivetype(y.typ) || jl_datatype_size(y.typ) != 4)
             return emit_runtime_call(f, argv, nargs, ctx);
         Type *xt = FLOATT(bitstype_to_llvm(x.typ));
         Type *yt = T_int32;
@@ -882,7 +882,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         const jl_cgval_t &xinfo = argv[0];
 
         // verify argument types
-        if (!jl_is_bitstype(xinfo.typ))
+        if (!jl_is_primitivetype(xinfo.typ))
             return emit_runtime_call(f, argv, nargs, ctx);
         Type *xtyp = bitstype_to_llvm(xinfo.typ);
         if (float_func[f])
@@ -896,7 +896,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         argt[0] = xtyp;
 
         if (f == shl_int || f == lshr_int || f == ashr_int) {
-            if (!jl_is_bitstype(argv[1].typ))
+            if (!jl_is_primitivetype(argv[1].typ))
                 return emit_runtime_call(f, argv, nargs, ctx);
             argt[1] = INTT(bitstype_to_llvm(argv[1].typ));
         }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1667,15 +1667,15 @@ void jl_init_types(void)
 
     // non-primitive definitions follow
     jl_int32_type = NULL;
-    jl_int32_type = jl_new_bitstype((jl_value_t*)jl_symbol("Int32"),
-                                    jl_any_type, jl_emptysvec, 32);
+    jl_int32_type = jl_new_primitivetype((jl_value_t*)jl_symbol("Int32"),
+                                         jl_any_type, jl_emptysvec, 32);
     jl_int64_type = NULL;
-    jl_int64_type = jl_new_bitstype((jl_value_t*)jl_symbol("Int64"),
-                                    jl_any_type, jl_emptysvec, 64);
+    jl_int64_type = jl_new_primitivetype((jl_value_t*)jl_symbol("Int64"),
+                                         jl_any_type, jl_emptysvec, 64);
 
     jl_uint8_type = NULL;
-    jl_uint8_type = jl_new_bitstype((jl_value_t*)jl_symbol("UInt8"),
-                                    jl_any_type, jl_emptysvec, 8);
+    jl_uint8_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt8"),
+                                         jl_any_type, jl_emptysvec, 8);
 
     jl_ssavalue_type = jl_new_datatype(jl_symbol("SSAValue"), jl_any_type, jl_emptysvec,
                                        jl_svec1(jl_symbol("id")),
@@ -1695,8 +1695,8 @@ void jl_init_types(void)
     jl_init_int32_int64_cache();
 
     jl_bool_type = NULL;
-    jl_bool_type = jl_new_bitstype((jl_value_t*)jl_symbol("Bool"),
-                                   jl_any_type, jl_emptysvec, 8);
+    jl_bool_type = jl_new_primitivetype((jl_value_t*)jl_symbol("Bool"),
+                                        jl_any_type, jl_emptysvec, 8);
     jl_false = jl_box8(jl_bool_type, 0);
     jl_true  = jl_box8(jl_bool_type, 1);
 
@@ -1934,8 +1934,8 @@ void jl_init_types(void)
     jl_unionall_type->name->mt = jl_uniontype_type->name->mt = jl_datatype_type->name->mt =
         jl_type_typename->mt;
 
-    jl_intrinsic_type = jl_new_bitstype((jl_value_t*)jl_symbol("IntrinsicFunction"),
-                                        jl_builtin_type, jl_emptysvec, 32);
+    jl_intrinsic_type = jl_new_primitivetype((jl_value_t*)jl_symbol("IntrinsicFunction"),
+                                             jl_builtin_type, jl_emptysvec, 32);
 
     tv = jl_svec1(tvar("T"));
     jl_ref_type = (jl_unionall_t*)
@@ -1943,9 +1943,9 @@ void jl_init_types(void)
 
     tv = jl_svec1(tvar("T"));
     jl_pointer_type = (jl_unionall_t*)
-        jl_new_bitstype((jl_value_t*)jl_symbol("Ptr"),
-                        (jl_datatype_t*)jl_apply_type((jl_value_t*)jl_ref_type, jl_svec_data(tv), 1), tv,
-                        sizeof(void*)*8)->name->wrapper;
+        jl_new_primitivetype((jl_value_t*)jl_symbol("Ptr"),
+                             (jl_datatype_t*)jl_apply_type((jl_value_t*)jl_ref_type, jl_svec_data(tv), 1), tv,
+                             sizeof(void*)*8)->name->wrapper;
     jl_pointer_typename = ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_pointer_type))->name;
 
     // Type{T} where T<:Tuple

--- a/src/julia.h
+++ b/src/julia.h
@@ -880,7 +880,7 @@ STATIC_INLINE int jl_is_type(jl_value_t *v)
     return jl_is_kind(jl_typeof(v));
 }
 
-STATIC_INLINE int jl_is_bitstype(void *v)
+STATIC_INLINE int jl_is_primitivetype(void *v)
 {
     return (jl_is_datatype(v) && jl_is_immutable(v) &&
             ((jl_datatype_t*)(v))->layout &&
@@ -1004,9 +1004,9 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super
                                             jl_svec_t *fnames, jl_svec_t *ftypes,
                                             int abstract, int mutabl,
                                             int ninitialized);
-JL_DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name,
-                                            jl_datatype_t *super,
-                                            jl_svec_t *parameters, size_t nbits);
+JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name,
+                                                 jl_datatype_t *super,
+                                                 jl_svec_t *parameters, size_t nbits);
 
 // constructors
 JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -18,9 +18,9 @@ const unsigned int host_char_bit = 8;
 JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v)
 {
     JL_TYPECHK(bitcast, datatype, ty);
-    if (!jl_is_leaf_type(ty) || !jl_is_bitstype(ty))
+    if (!jl_is_leaf_type(ty) || !jl_is_primitivetype(ty))
         jl_error("bitcast: target type not a leaf primitive type");
-    if (!jl_is_bitstype(jl_typeof(v)))
+    if (!jl_is_primitivetype(jl_typeof(v)))
         jl_error("bitcast: value not a primitive type");
     if (jl_datatype_size(jl_typeof(v)) != jl_datatype_size(ty))
         jl_error("bitcast: argument size does not match size of target type");
@@ -321,9 +321,9 @@ jl_value_t *jl_iintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name,
                             char (*getsign)(void*, unsigned),
                             jl_value_t *(*lambda1)(jl_value_t*, void*, unsigned, unsigned, const void*), const void *list)
 {
-    if (!jl_is_bitstype(jl_typeof(a)))
+    if (!jl_is_primitivetype(jl_typeof(a)))
         jl_errorf("%s: value is not a primitive type", name);
-    if (!jl_is_bitstype(ty))
+    if (!jl_is_primitivetype(ty))
         jl_errorf("%s: type is not a primitive type", name);
     void *pa = jl_data_ptr(a);
     unsigned isize = jl_datatype_size(jl_typeof(a));
@@ -390,9 +390,9 @@ static inline jl_value_t *jl_intrinsic_cvt(jl_value_t *ty, jl_value_t *a, const 
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *aty = jl_typeof(a);
-    if (!jl_is_bitstype(aty))
+    if (!jl_is_primitivetype(aty))
         jl_errorf("%s: value is not a primitive type", name);
-    if (!jl_is_bitstype(ty))
+    if (!jl_is_primitivetype(ty))
         jl_errorf("%s: type is not a primitive type", name);
     void *pa = jl_data_ptr(a);
     unsigned isize = jl_datatype_size(aty);
@@ -429,9 +429,9 @@ typedef void (fintrinsic_op1)(unsigned, void*, void*);
 static inline jl_value_t *jl_fintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name, fintrinsic_op1 *floatop, fintrinsic_op1 *doubleop)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    if (!jl_is_bitstype(jl_typeof(a)))
+    if (!jl_is_primitivetype(jl_typeof(a)))
         jl_errorf("%s: value is not a primitive type", name);
-    if (!jl_is_bitstype(ty))
+    if (!jl_is_primitivetype(ty))
         jl_errorf("%s: type is not a primitive type", name);
     unsigned sz2 = jl_datatype_size(ty);
     jl_value_t *newv = jl_gc_alloc(ptls, sz2, ty);
@@ -541,10 +541,10 @@ jl_value_t *jl_iintrinsic_2(jl_value_t *a, jl_value_t *b, const char *name,
     if (tyb != ty) {
         if (!cvtb)
             jl_errorf("%s: types of a and b must match", name);
-        if (!jl_is_bitstype(tyb))
+        if (!jl_is_primitivetype(tyb))
             jl_errorf("%s: b is not a primitive type", name);
     }
-    if (!jl_is_bitstype(ty))
+    if (!jl_is_primitivetype(ty))
         jl_errorf("%s: a is not a primitive type", name);
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b);
     unsigned sz = jl_datatype_size(ty);
@@ -627,7 +627,7 @@ JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
     jl_value_t *ty = jl_typeof(a); \
     if (jl_typeof(b) != ty) \
         jl_error(#name ": types of a and b must match"); \
-    if (!jl_is_bitstype(ty)) \
+    if (!jl_is_primitivetype(ty)) \
         jl_error(#name ": values are not primitive types"); \
     int sz = jl_datatype_size(ty); \
     jl_value_t *newv = jl_gc_alloc(ptls, sz, ty);          \
@@ -654,7 +654,7 @@ JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
     jl_value_t *ty = jl_typeof(a); \
     if (jl_typeof(b) != ty) \
         jl_error(#name ": types of a and b must match"); \
-    if (!jl_is_bitstype(ty)) \
+    if (!jl_is_primitivetype(ty)) \
         jl_error(#name ": values are not primitive types"); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b); \
     int sz = jl_datatype_size(ty); \
@@ -682,7 +682,7 @@ JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b, jl_value_t *c) 
     jl_value_t *ty = jl_typeof(a); \
     if (jl_typeof(b) != ty || jl_typeof(c) != ty) \
         jl_error(#name ": types of a, b, and c must match"); \
-    if (!jl_is_bitstype(ty)) \
+    if (!jl_is_primitivetype(ty)) \
         jl_error(#name ": values are not primitive types"); \
     int sz = jl_datatype_size(ty);                                      \
     jl_value_t *newv = jl_gc_alloc(ptls, sz, ty);                       \
@@ -870,7 +870,7 @@ cvt_iintrinsic_checked(LLVMTrunc, check_trunc_uint, checked_trunc_uint)
 JL_DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a)
 {
     jl_value_t *ty = jl_typeof(a);
-    if (!jl_is_bitstype(ty))
+    if (!jl_is_primitivetype(ty))
         jl_error("check_top_bit: value is not a primitive type");
     if (signbitbyte(jl_data_ptr(a), jl_datatype_size(ty)))
         jl_throw(jl_inexact_exception);
@@ -929,9 +929,9 @@ JL_DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *ty = jl_typeof(a);
-    if (!jl_is_bitstype(ty))
+    if (!jl_is_primitivetype(ty))
         jl_error("powi_llvm: a is not a primitive type");
-    if (!jl_is_bitstype(jl_typeof(b)) || jl_datatype_size(jl_typeof(b)) != 4)
+    if (!jl_is_primitivetype(jl_typeof(b)) || jl_datatype_size(jl_typeof(b)) != 4)
         jl_error("powi_llvm: b is not a 32-bit primitive type");
     int sz = jl_datatype_size(ty);
     jl_value_t *newv = jl_gc_alloc(ptls, sz, ty);


### PR DESCRIPTION
This helps distinguish `jl_isbits` and `jl_is_bitstype`. Renaming only.