### PR TITLE
Call constructor instead of `oftype(..., nothing)` to construct a null Nullable.

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -539,7 +539,7 @@ end
     end
 
     if done(p.a, s1)
-        return (v1,v2), (start(p.a), s2, oftype(nv2,nothing), done(p.b,s2))
+        return (v1,v2), (start(p.a), s2, Nullable{eltype(nv2)}(), done(p.b,s2))
     end
     return (v1,v2), (s1, s2, Nullable(v2), false)
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -400,3 +400,7 @@ end
 @testset "collect finite iterators issue #12009" begin
     @test eltype(collect(enumerate(Iterators.Filter(x -> x>0, randn(10))))) == Tuple{Int, Float64}
 end
+
+@testset "product iterator infinite loop" begin
+    @test collect(product(1:1, (1, "2"))) == [(1, 1) (1, "2")]
+end


### PR DESCRIPTION
Fix #20078