### PR TITLE
remove `map` method for `Vector{Any}`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -183,8 +183,6 @@ end
 # simple Array{Any} operations needed for bootstrap
 setindex!(A::Array{Any}, x::ANY, i::Int) = Core.arrayset(A, x, i)
 
-map(f::Function, a::Array{Any,1}) = Any[ f(a[i]) for i=1:length(a) ]
-
 function precompile(f::ANY, args::Tuple)
     ccall(:jl_compile_hint, Int32, (Any,), Tuple{Core.Typeof(f), args...}) != 0
 end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -322,6 +322,8 @@ function contains_is(itr, x::ANY)
     return false
 end
 
+anymap(f::Function, a::Array{Any,1}) = Any[ f(a[i]) for i=1:length(a) ]
+
 _topmod(sv::InferenceState) = _topmod(sv.mod)
 _topmod(m::Module) = ccall(:jl_base_relative_to, Any, (Any,), m)::Module
 
@@ -670,7 +672,8 @@ function limit_type_depth(t::ANY, d::Int, cov::Bool, vars::Vector{TypeVar}=TypeV
         if d > MAX_TYPE_DEPTH
             return Any
         end
-        return Union{map(x->limit_type_depth(x, d+1, cov, vars), (t.a,t.b))...}
+        return Union{limit_type_depth(t.a, d+1, cov, vars),
+                     limit_type_depth(t.b, d+1, cov, vars)}
     elseif isa(t,UnionAll)
         v = t.var
         if v.ub === Any
@@ -1084,7 +1087,7 @@ function builtin_tfunction(f::ANY, argtypes::Array{Any,1}, sv::InferenceState)
                 return tuple_tfunc(limit_tuple_depth(sv.params, argtypes_to_type(argtypes)))
             end
         end
-        return Const(tuple(map(a->a.val, argtypes)...))
+        return Const(tuple(anymap(a->a.val, argtypes)...))
     elseif f === svec
         return SimpleVector
     elseif f === arrayset
@@ -1574,7 +1577,7 @@ function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv:
     end
 end
 
-argtypes_to_type(argtypes::Array{Any,1}) = Tuple{map(widenconst, argtypes)...}
+argtypes_to_type(argtypes::Array{Any,1}) = Tuple{anymap(widenconst, argtypes)...}
 
 _Pair_name = nothing
 function Pair_name()


### PR DESCRIPTION
`map` on a `Vector{Any}` should no longer be a special case. The definition is only needed as a code size optimization in inference, but that can be handled easily in the inference code itself.