### PR TITLE
Make `parse(T, "")` and `parse(T, " ")` etc, more specific regarding whitespace and empty strings

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -58,6 +58,10 @@ end
 
 function tryparse_internal{T<:Integer}(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
     _n = Nullable{T}()
+    if isempty(strip(s))
+        raise && throw(ArgumentError("input string is empty or only contains whitespace"))
+        return _n
+    end
     sgn, base, i = parseint_preamble(T<:Signed, Int(base_), s, startpos, endpos)
     if !(2 <= base <= 62)
         raise && throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
@@ -132,21 +136,35 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
         p, "true", 4)) && (return Nullable(true))
     (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
         p, "false", 5)) && (return Nullable(false))
-    raise && throw(ArgumentError("invalid Bool representation: " *
-        repr(SubString(sbuff, startpos, endpos))))
-    Nullable{Bool}()
+    _n = Nullable{Bool}()
+    if isempty(strip(sbuff))
+        raise && throw(ArgumentError("input string is empty or only contains whitespace"))
+        return _n
+    end
+    raise && throw(ArgumentError("invalid Bool representation: $(repr(SubString(sbuff, startpos, endpos)))"))
+    return _n
 end
 
-check_valid_base(base) = 2 <= base <= 62 ? base :
+@inline function check_valid_base(base)
+    if 2 <= base <= 62
+        return base
+    end
     throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
+end
+
 tryparse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer) =
     tryparse_internal(T, s, start(s), endof(s), check_valid_base(base), false)
 tryparse{T<:Integer}(::Type{T}, s::AbstractString) =
     tryparse_internal(T, s, start(s), endof(s), 0, false)
-parse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer) =
+
+function parse{T<:Integer}(::Type{T}, s::AbstractString, base::Integer)
     get(tryparse_internal(T, s, start(s), endof(s), check_valid_base(base), true))
-parse{T<:Integer}(::Type{T}, s::AbstractString) =
-    get(tryparse_internal(T, s, start(s), endof(s), 0, true))
+end
+
+function parse{T<:Integer}(::Type{T}, s::AbstractString)
+    get(tryparse_internal(T, s, start(s), endof(s), 0, true)) # Zero means, "figure it out"
+end
+
 
 ## string to float functions ##
 
@@ -159,8 +177,11 @@ tryparse(::Type{Float32}, s::SubString{String}) = ccall(:jl_try_substrtof, Nulla
 tryparse{T<:Union{Float32,Float64}}(::Type{T}, s::AbstractString) = tryparse(T, String(s))
 
 function parse{T<:AbstractFloat}(::Type{T}, s::AbstractString)
-    nf = tryparse(T, s)
-    isnull(nf) ? throw(ArgumentError("invalid number format $(repr(s)) for $T")) : get(nf)
+    result = tryparse(T, s)
+    if isnull(result)
+        throw(ArgumentError("cannot parse $(repr(s)) as $T"))
+    end
+    return get(result)
 end
 
 float(x::AbstractString) = parse(Float64,x)

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -145,7 +145,7 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
         p, "false", 5)) && (return Nullable(false))
 
     substr = SubString(sbuff, startpos, endpos)
-    if count(isspace, sbuff) == len # all chars were whitespace
+    if count(isspace, substr) == len # all chars were whitespace
         raise && throw(ArgumentError("input string only contains whitespace"))
     else
         raise && throw(ArgumentError("invalid Bool representation: $(repr(substr))"))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -200,22 +200,32 @@ macro f(args...) end; @f ""
 @test parse(Int,'3', 8) == 3
 
 # Issue 20587
-let input_strings = ["", " ", "  "]
-    # Without a base (handles things like "0x00001111", etc)
-    for T in vcat(subtypes(Signed), subtypes(Unsigned))
-        for s in input_strings
-            result = @test_throws ArgumentError parse(T, s)
-            the_exception = result.value
-            @test the_exception.msg == "input string is empty or only contains whitespace"
+for T in vcat(subtypes(Signed), subtypes(Unsigned))
+    for s in ["", " ", "  "]
+         # Without a base (handles things like "0x00001111", etc)
+        result = @test_throws ArgumentError parse(T, s)
+        exception_without_base = result.value
+        if T == Bool
+            if s == ""
+                @test exception_without_base.msg == "input string is empty"
+            else
+                @test exception_without_base.msg == "input string only contains whitespace"
+            end
+        else
+            @test exception_without_base.msg == "input string is empty or only contains whitespace"
         end
-    end
 
-    # With a base
-    for T in vcat(subtypes(Signed), subtypes(Unsigned))
-        for s in input_strings
-            result = @test_throws ArgumentError parse(T, s, 16)
-            the_exception = result.value
-            @test the_exception.msg == "input string is empty or only contains whitespace"
+        # With a base
+        result = @test_throws ArgumentError parse(T, s, 16)
+        exception_with_base = result.value
+        if T == Bool
+            if s == ""
+                @test exception_with_base.msg == "input string is empty"
+            else
+                @test exception_with_base.msg == "input string only contains whitespace"
+            end
+        else
+            @test exception_with_base.msg == "input string is empty or only contains whitespace"
         end
     end
 end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -231,15 +231,15 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned))
 
     # Test `tryparse_internal` with part of a string
     let b = "                   "
-        result = @test_throws ArgumentError get(Base.tryparse_internal(Bool, b, 7, 11, 0, true)) == true
+        result = @test_throws ArgumentError get(Base.tryparse_internal(Bool, b, 7, 11, 0, true))
         exception_bool = result.value
         @test exception_bool.msg == "input string only contains whitespace"
 
-        result = @test_throws ArgumentError get(Base.tryparse_internal(Int, b, 7, 11, 0, true)) == true
+        result = @test_throws ArgumentError get(Base.tryparse_internal(Int, b, 7, 11, 0, true))
         exception_int = result.value
         @test exception_int.msg == "input string is empty or only contains whitespace"
 
-        result = @test_throws ArgumentError get(Base.tryparse_internal(UInt128, b, 7, 11, 0, true)) == true
+        result = @test_throws ArgumentError get(Base.tryparse_internal(UInt128, b, 7, 11, 0, true))
         exception_uint = result.value
         @test exception_uint.msg == "input string is empty or only contains whitespace"
     end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -228,6 +228,21 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned))
             @test exception_with_base.msg == "input string is empty or only contains whitespace"
         end
     end
+
+    # Test `tryparse_internal` with part of a string
+    let b = "                   "
+        result = @test_throws ArgumentError get(Base.tryparse_internal(Bool, b, 7, 11, 0, true)) == true
+        exception_bool = result.value
+        @test exception_bool.msg == "input string only contains whitespace"
+
+        result = @test_throws ArgumentError get(Base.tryparse_internal(Int, b, 7, 11, 0, true)) == true
+        exception_int = result.value
+        @test exception_int.msg == "input string is empty or only contains whitespace"
+
+        result = @test_throws ArgumentError get(Base.tryparse_internal(UInt128, b, 7, 11, 0, true)) == true
+        exception_uint = result.value
+        @test exception_uint.msg == "input string is empty or only contains whitespace"
+    end
 end
 
 parsebin(s) = parse(Int,s,2)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -202,7 +202,7 @@ macro f(args...) end; @f ""
 # Issue 20587
 for T in vcat(subtypes(Signed), subtypes(Unsigned))
     for s in ["", " ", "  "]
-         # Without a base (handles things like "0x00001111", etc)
+        # Without a base (handles things like "0x00001111", etc)
         result = @test_throws ArgumentError parse(T, s)
         exception_without_base = result.value
         if T == Bool

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -199,6 +199,27 @@ macro f(args...) end; @f ""
 @test parse(Int,'3') == 3
 @test parse(Int,'3', 8) == 3
 
+# Issue 20587
+let input_strings = ["", " ", "  "]
+    # Without a base (handles things like "0x00001111", etc)
+    for T in vcat(subtypes(Signed), subtypes(Unsigned))
+        for s in input_strings
+            result = @test_throws ArgumentError parse(T, s)
+            the_exception = result.value
+            @test the_exception.msg == "input string is empty or only contains whitespace"
+        end
+    end
+
+    # With a base
+    for T in vcat(subtypes(Signed), subtypes(Unsigned))
+        for s in input_strings
+            result = @test_throws ArgumentError parse(T, s, 16)
+            the_exception = result.value
+            @test the_exception.msg == "input string is empty or only contains whitespace"
+        end
+    end
+end
+
 parsebin(s) = parse(Int,s,2)
 parseoct(s) = parse(Int,s,8)
 parsehex(s) = parse(Int,s,16)


### PR DESCRIPTION
Fixes #20587.

Before this PR:
```
julia> parse(Int, "", 16)
ERROR: ArgumentError: invalid base: base must be 2 ≤ base ≤ 62, got 0
Stacktrace:
 [1] tryparse_internal(::Type{Int64}, ::String, ::Int64, ::Int64, ::Int64, ::Bool) at ./parse.jl:63
 [2] parse(::Type{Int64}, ::String, ::Int64) at ./parse.jl:146
```

After this PR:
```
julia> parse(Int, "", 16)
ERROR: ArgumentError: input string is empty or only contains whitespace
Stacktrace:
 [1] tryparse_internal(::Type{Int64}, ::String, ::Int64, ::Int64, ::Int64, ::Bool) at .\parse.jl:62
 [2] parse(::Type{Int64}, ::String, ::Int64) at .\parse.jl:161
```

This message will also appear for `parse(T, "")` and `parse(T, " ")`, etc.