### PR TITLE
Improve UX of calling abstract-type constructors

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -332,9 +332,8 @@ function complete_methods(ex_org::Expr)
     for method in ml
         ms = method.sig
 
-        # Do not complete the "Type{T}(::Any) where T" constructor from sysimg.jl
-        # Note that we must check if it is a Type, and not a DataType since we eval'd this.
-        if method.module == Base && method.file == Symbol("sysimg.jl") && method.sig == Tuple{Type{T},Any} where T # @Hardcoded
+        # Do not suggest the default method from sysimg.jl.
+        if Base.is_default_method(method)
             continue
         end
 

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -672,7 +672,5 @@ Determines whether a method is the default method which is provided to all types
 Such a method is usually undesirable to be displayed to the user in the REPL.
 """
 function is_default_method(m::Method)
-    return m.module == Base 
-        &&   m.file == Symbol("sysimg.jl") 
-        &&    m.sig == Tuple{Type{T},Any} where T
+    return m.module == Base && m.file == Symbol("sysimg.jl") && m.sig == Tuple{Type{T},Any} where T
 end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -322,6 +322,18 @@ function showerror(io::IO, ex::MethodError)
             f_is_function = true
             print(io, "no method matching ", name)
         elseif isa(f, Type)
+            if isa(f, DataType) && f.abstract
+                ms = methods(f)
+                if length(ms) == 1
+                    m = first(ms)
+                    if m.module == Base && m.file == Symbol("sysimg.jl") && m.sig == Tuple{Type{T},Any} where T # @Hardcoded
+                        # This is the sysimg automatic constructor: "Type{T}(::Any) where T"
+                        # If this is the only method on this type, we have not defined any other constructors.
+                        print(io, "no constructors have been defined for $f")
+                        return
+                    end
+                end
+            end
             print(io, "no method matching ", f)
         else
             print(io, "no method matching (::", ft, ")")

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -456,6 +456,10 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
             buf = IOBuffer()
             tv = Any[]
             sig0 = method.sig
+            # @Hardcoded: don't display the sysimg.jl method
+            if sig0 == Tuple{Type{T},Any} where T && method.module == Base && method.file == Symbol("sysimg.jl")
+                continue
+            end
             while isa(sig0, UnionAll)
                 push!(tv, sig0.var)
                 sig0 = sig0.body

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -672,8 +672,7 @@ Determines whether a method is the default method which is provided to all types
 Such a method is usually undesirable to be displayed to the user in the REPL.
 """
 function is_default_method(m::Method)
-    if m.module == Base && m.file == Symbol("sysimg.jl") && m.sig == Tuple{Type{T},Any} where T
-        return true
-    end
-    return false
+    return m.module == Base 
+        &&   m.file == Symbol("sysimg.jl") 
+        &&    m.sig == Tuple{Type{T},Any} where T
 end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -456,8 +456,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
             buf = IOBuffer()
             tv = Any[]
             sig0 = method.sig
-            #HARDCODED #REFACTOR: don't display the sysimg.jl method
-            if sig0 == Tuple{Type{T},Any} where T && method.module == Base && method.file == Symbol("sysimg.jl")
+            if Base.is_default_method(method)
                 continue
             end
             while isa(sig0, UnionAll)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -21,7 +21,7 @@ include("coreio.jl")
 
 eval(x) = Core.eval(Base, x)
 eval(m, x) = Core.eval(m, x)
-(::Type{T}){T}(arg) = convert(T, arg)::T
+(::Type{T}){T}(arg) = convert(T, arg)::T # Hidden from the REPL.
 (::Type{VecElement{T}}){T}(arg) = VecElement{T}(convert(T, arg))
 convert{T<:VecElement}(::Type{T}, arg) = T(arg)
 convert{T<:VecElement}(::Type{T}, arg::T) = arg

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -293,7 +293,6 @@ Point{Float64}(1.0, 2.5)
 julia> Point(1,2.5) ## implicit T ##
 ERROR: MethodError: no method matching Point(::Int64, ::Float64)
 Closest candidates are:
-  Point(::Any) where T at sysimg.jl:24
   Point(::T<:Real, !Matched::T<:Real) where T<:Real at none:2
 
 julia> Point{Int64}(1, 2) ## explicit T ##
@@ -374,7 +373,6 @@ However, other similar calls still don't work:
 julia> Point(1.5,2)
 ERROR: MethodError: no method matching Point(::Float64, ::Int64)
 Closest candidates are:
-  Point(::Any) where T at sysimg.jl:24
   Point(::T<:Real, !Matched::T<:Real) where T<:Real at none:1
 ```
 
@@ -572,7 +570,6 @@ julia> SummedArray(Int32[1; 2; 3], Int32(6))
 ERROR: MethodError: no method matching SummedArray(::Array{Int32,1}, ::Int32)
 Closest candidates are:
   SummedArray(::Array{T,1}) where T at none:5
-  SummedArray(::Any) where T at sysimg.jl:24
 ```
 
 This constructor will be invoked by the syntax `SummedArray(a)`. The syntax `new{T,S}` allows

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -680,7 +680,6 @@ to `Point` have the same type. When this isn't the case, the constructor will fa
 julia> Point(1,2.5)
 ERROR: MethodError: no method matching Point(::Int64, ::Float64)
 Closest candidates are:
-  Point(::Any) where T at sysimg.jl:24
   Point(::T, !Matched::T) where T at none:2
 ```
 

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -504,10 +504,29 @@ end
 module EnclosingModule
     abstract type AbstractTypeNoConstructors end
 end
-@test sprint(showerror, (MethodError(EnclosingModule.AbstractTypeNoConstructors, ()))) == "MethodError: no constructors have been defined for $(EnclosingModule.AbstractTypeNoConstructors)"
-EnclosingModule.AbstractTypeNoConstructors(x, y) = x + y
-@test startswith(sprint(showerror, (MethodError(EnclosingModule.AbstractTypeNoConstructors, ()))), "MethodError: no method matching $(EnclosingModule.AbstractTypeNoConstructors)()")
-@test !contains(sprint(showerror, (MethodError(EnclosingModule.AbstractTypeNoConstructors, ()))), "where T at sysimg.jl")
-for method_string in Base.REPLCompletions.complete_methods(:(EnclosingModule.AbstractTypeNoConstructors()))
-    @test method_string != "(::Type{T})(arg) where T in Base at sysimg.jl"
+let
+    method_error = MethodError(EnclosingModule.AbstractTypeNoConstructors, ())
+
+    @test sprint(
+        showerror,
+        method_error
+    ) == "MethodError: no constructors have been defined for $(EnclosingModule.AbstractTypeNoConstructors)"
+
+    EnclosingModule.AbstractTypeNoConstructors(x, y) = x + y
+
+    @test startswith(sprint(
+            showerror,
+            method_error
+        ), "MethodError: no method matching $(EnclosingModule.AbstractTypeNoConstructors)()"
+    )
+    @test !contains(sprint(
+            showerror,
+            method_error
+        ),
+        "where T at sysimg.jl"
+    )
+
+    for method_string in Base.REPLCompletions.complete_methods(:(EnclosingModule.AbstractTypeNoConstructors()))
+        @test !startswith(method_string, "(::Type{T})(arg) where T in Base at sysimg.jl")
+    end
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -501,11 +501,13 @@ foo_9965(x::Int) = 2x
 end
 
 # Issue #20556
-abstract type AbstractTypeNoConstructors end
-@test sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))) == "MethodError: no constructors have been defined for $AbstractTypeNoConstructors"
-AbstractTypeNoConstructors(x, y) = x + y
-@test startswith(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "MethodError: no method matching $AbstractTypeNoConstructors()")
-@test !contains(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "where T at sysimg.jl")
-for method_string in Base.REPLCompletions.complete_methods(:(AbstractTypeNoConstructors()))
+module EnclosingModule
+    abstract type AbstractTypeNoConstructors end
+end
+@test sprint(showerror, (MethodError(EnclosingModule.AbstractTypeNoConstructors, ()))) == "MethodError: no constructors have been defined for $(EnclosingModule.AbstractTypeNoConstructors)"
+EnclosingModule.AbstractTypeNoConstructors(x, y) = x + y
+@test startswith(sprint(showerror, (MethodError(EnclosingModule.AbstractTypeNoConstructors, ()))), "MethodError: no method matching $(EnclosingModule.AbstractTypeNoConstructors)()")
+@test !contains(sprint(showerror, (MethodError(EnclosingModule.AbstractTypeNoConstructors, ()))), "where T at sysimg.jl")
+for method_string in Base.REPLCompletions.complete_methods(:(EnclosingModule.AbstractTypeNoConstructors()))
     @test method_string != "(::Type{T})(arg) where T in Base at sysimg.jl"
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -506,3 +506,6 @@ abstract type X end
 X(x, y) = x + y
 @test startswith(sprint(showerror, (MethodError(X, ()))), "MethodError: no method matching X()")
 @test !contains(sprint(showerror, (MethodError(X, ()))), "where T at sysimg.jl:24")
+for method_string in Base.REPLCompletions.complete_methods(:(X()))
+    @test method_string != "(::Type{T})(arg) where T in Base at sysimg.jl:24"
+end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -20,6 +20,7 @@ method_c1(x::Float64, s::AbstractString...) = true
 buf = IOBuffer()
 Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, "")))
 no_color = "\nClosest candidates are:\n  method_c1(!Matched::Float64, !Matched::AbstractString...)$cfile$c1line"
+@assert length(methods(method_c1)) <= 3
 test_have_color(buf,
                 "\e[0m\nClosest candidates are:\n  method_c1(\e[1m\e[31m::Float64\e[0m, \e[1m\e[31m::AbstractString...\e[0m)$cfile$c1line\e[0m",
                 no_color)
@@ -102,12 +103,12 @@ PR16155line2 = @__LINE__ + 1
 (::Type{T}){T<:PR16155}(arg::Any) = "replace call-to-convert method from sysimg"
 
 Base.show_method_candidates(buf, MethodError(PR16155,(1.0, 2.0, Int64(3))))
-test_have_color(buf, "\e[0m\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(\e[1m\e[31m::Int64\e[0m, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2\n  ...\e[0m",
-                     "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(!Matched::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2\n  ...")
+test_have_color(buf, "\e[0m\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(\e[1m\e[31m::Int64\e[0m, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2\e[0m",
+                     "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(!Matched::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2")
 
 Base.show_method_candidates(buf, MethodError(PR16155,(Int64(3), 2.0, Int64(3))))
-test_have_color(buf, "\e[0m\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2\n  ...\e[0m",
-                     "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2\n  ...")
+test_have_color(buf, "\e[0m\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2\e[0m",
+                     "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2")
 
 c6line = @__LINE__
 method_c6(; x=1) = x
@@ -250,12 +251,6 @@ let
     err_str = @except_str g11007([[1] [1]]) MethodError
     @test contains(err_str, "row vector")
     @test contains(err_str, "column vector")
-end
-
-abstract type T11007 end
-let
-    err_str = @except_str T11007() MethodError
-    @test contains(err_str, "no method matching $(curmod_prefix)T11007()")
 end
 
 struct TypeWithIntParam{T <: Integer} end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -502,9 +502,9 @@ end
 
 # Issue #20556
 abstract type AbstractTypeNoConstructors end
-@test sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))) == "MethodError: no constructors have been defined for AbstractTypeNoConstructors"
+@test sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))) == "MethodError: no constructors have been defined for $AbstractTypeNoConstructors"
 AbstractTypeNoConstructors(x, y) = x + y
-@test startswith(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "MethodError: no method matching AbstractTypeNoConstructors()")
+@test startswith(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "MethodError: no method matching $AbstractTypeNoConstructors()")
 @test !contains(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "where T at sysimg.jl")
 for method_string in Base.REPLCompletions.complete_methods(:(AbstractTypeNoConstructors()))
     @test method_string != "(::Type{T})(arg) where T in Base at sysimg.jl"

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -502,18 +502,22 @@ end
 let
     method_error = MethodError(EnclosingModule.AbstractTypeNoConstructors, ())
 
+    # Test that it shows a special message when no constructors have been defined by the user.
     @test sprint(
         showerror,
         method_error
     ) == "MethodError: no constructors have been defined for $(EnclosingModule.AbstractTypeNoConstructors)"
 
+    # Does it go back to previous behaviour when there *is* at least
+    # one constructor defined?
     EnclosingModule.AbstractTypeNoConstructors(x, y) = x + y
-
     @test startswith(sprint(
             showerror,
             method_error
         ), "MethodError: no method matching $(EnclosingModule.AbstractTypeNoConstructors)()"
     )
+
+    # Test that the 'default' sysimg.jl method is not displayed.
     @test !contains(sprint(
             showerror,
             method_error
@@ -521,6 +525,7 @@ let
         "where T at sysimg.jl"
     )
 
+    # Test that tab-completion will not show the 'default' sysimg.jl method.
     for method_string in Base.REPLCompletions.complete_methods(:(EnclosingModule.AbstractTypeNoConstructors()))
         @test !startswith(method_string, "(::Type{T})(arg) where T in Base at sysimg.jl")
     end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -20,7 +20,7 @@ method_c1(x::Float64, s::AbstractString...) = true
 buf = IOBuffer()
 Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, "")))
 no_color = "\nClosest candidates are:\n  method_c1(!Matched::Float64, !Matched::AbstractString...)$cfile$c1line"
-@assert length(methods(method_c1)) <= 3
+@test length(methods(method_c1)) <= 3 # because of '...' in candidate printing
 test_have_color(buf,
                 "\e[0m\nClosest candidates are:\n  method_c1(\e[1m\e[31m::Float64\e[0m, \e[1m\e[31m::AbstractString...\e[0m)$cfile$c1line\e[0m",
                 no_color)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -505,7 +505,7 @@ abstract type AbstractTypeNoConstructors end
 @test sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))) == "MethodError: no constructors have been defined for AbstractTypeNoConstructors"
 AbstractTypeNoConstructors(x, y) = x + y
 @test startswith(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "MethodError: no method matching AbstractTypeNoConstructors()")
-@test !contains(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "where T at sysimg.jl:24")
+@test !contains(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "where T at sysimg.jl")
 for method_string in Base.REPLCompletions.complete_methods(:(AbstractTypeNoConstructors()))
-    @test method_string != "(::Type{T})(arg) where T in Base at sysimg.jl:24"
+    @test method_string != "(::Type{T})(arg) where T in Base at sysimg.jl"
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -505,3 +505,4 @@ abstract type X end
 @test sprint(showerror, (MethodError(X, ()))) == "MethodError: no constructors have been defined for X"
 X(x, y) = x + y
 @test startswith(sprint(showerror, (MethodError(X, ()))), "MethodError: no method matching X()")
+@test !contains(sprint(showerror, (MethodError(X, ()))), "where T at sysimg.jl:24")

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -501,11 +501,11 @@ foo_9965(x::Int) = 2x
 end
 
 # Issue #20556
-abstract type X end
-@test sprint(showerror, (MethodError(X, ()))) == "MethodError: no constructors have been defined for X"
-X(x, y) = x + y
-@test startswith(sprint(showerror, (MethodError(X, ()))), "MethodError: no method matching X()")
-@test !contains(sprint(showerror, (MethodError(X, ()))), "where T at sysimg.jl:24")
-for method_string in Base.REPLCompletions.complete_methods(:(X()))
+abstract type AbstractTypeNoConstructors end
+@test sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))) == "MethodError: no constructors have been defined for AbstractTypeNoConstructors"
+AbstractTypeNoConstructors(x, y) = x + y
+@test startswith(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "MethodError: no method matching AbstractTypeNoConstructors()")
+@test !contains(sprint(showerror, (MethodError(AbstractTypeNoConstructors, ()))), "where T at sysimg.jl:24")
+for method_string in Base.REPLCompletions.complete_methods(:(AbstractTypeNoConstructors()))
     @test method_string != "(::Type{T})(arg) where T in Base at sysimg.jl:24"
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -499,3 +499,9 @@ foo_9965(x::Int) = 2x
     Base.show_method_candidates(io, ex, [(:w,true)])
     @test contains(String(take!(io)), "got unsupported keyword argument \"w\"")
 end
+
+# Issue #20556
+abstract type X end
+@test sprint(showerror, (MethodError(X, ()))) == "MethodError: no constructors have been defined for X"
+X(x, y) = x + y
+@test startswith(sprint(showerror, (MethodError(X, ()))), "MethodError: no method matching X()")


### PR DESCRIPTION
Fixes #20556.

Also hides the `sysimg.jl` method from both the closest-candidates and tab-completion to make things less potentially confusing.

Unless I am missing something, you never intend to call the `sysimg.jl` method directly, if at all, anyway.
And, as can be seen in #20556, it can be an understandable (I think) source of confusion.

Before this PR:

```julia
julia> abstract type X end

julia> X()
ERROR: MethodError: no method matching X()
Closest candidates are:
  X(::Any) where T at sysimg.jl:24

julia> X(x,y) = x+y
X

julia> X()
ERROR: MethodError: no method matching X()
Closest candidates are:
  X(::Any) where T at sysimg.jl:24
  X(::Any, ::Any) at REPL[3]:1

julia> X(<TAB>
(::Type{T})(arg) where T in Base at sysimg.jl:24 X(x, y) in Main at REPL[3]:1
julia> X(
```

After this PR:

```julia
julia> abstract type X end

julia> X()
ERROR: MethodError: no constructors have been defined for X

julia> X(x,y) = x+y
X

julia> X()
ERROR: MethodError: no method matching X()
Closest candidates are:
  X(::Any, ::Any) at REPL[3]:1

julia> X(<TAB>
X(x, y) in Main at REPL[3]:1
julia> X(
```