### PR TITLE
RFC/WIP: fully deprecate partial indexing. Fixes #14770.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -471,8 +471,9 @@ done(a::Array,i) = (@_inline_meta; i == length(a)+1)
 ## Indexing: getindex ##
 
 # This is more complicated than it needs to be in order to get Win64 through bootstrap
+getindex{T}(A::Array{T,0}) = arrayref(A, 1)
 getindex(A::Array, i1::Int) = arrayref(A, i1)
-getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayref(A, i1, i2, I...)) # TODO: REMOVE FOR #14770
+getindex{T,N}(A::Array{T,N}, I::Vararg{Int,N}) = (@_inline_meta; arrayref(A, I...))
 
 # Faster contiguous indexing using copy! for UnitRange and Colon
 function getindex(A::Array, I::UnitRange{Int})
@@ -500,8 +501,9 @@ function getindex{S}(A::Array{S}, I::Range{Int})
 end
 
 ## Indexing: setindex! ##
+setindex!{T}(A::Array{T,0}, x) = arrayset(A, convert(T,x)::T, 1)
 setindex!{T}(A::Array{T}, x, i1::Int) = arrayset(A, convert(T,x)::T, i1)
-setindex!{T}(A::Array{T}, x, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayset(A, convert(T,x)::T, i1, i2, I...)) # TODO: REMOVE FOR #14770
+setindex!{T,N}(A::Array{T,N}, x, I::Vararg{Int,N}) = (@_inline_meta; arrayset(A, convert(T,x)::T, I...))
 
 # These are redundant with the abstract fallbacks but needed for bootstrap
 function setindex!(A::Array, x, I::AbstractVector{Int})
@@ -548,6 +550,7 @@ function setindex!{T}(A::Array{T}, X::Array{T}, c::Colon)
 end
 
 setindex!(A::Array, x::Number, ::Colon) = fill!(A, x)
+setindex!{T}(A::Array{T,0}, x::Number)  = fill!(A, x)  # ambiguity resolution
 setindex!{T, N}(A::Array{T, N}, x::Number, ::Vararg{Colon, N}) = fill!(A, x)
 
 # efficiently grow an array

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -197,8 +197,10 @@ end
 # Indexing into Array with mixtures of Integers and CartesianIndices is
 # extremely performance-sensitive. While the abstract fallbacks support this,
 # codegen has extra support for SIMDification that sub2ind doesn't (yet) support
+@propagate_inbounds getindex(A::Array, I::Integer...) = _getindex(LinearFast(), A, to_indices(A, I)...)
 @propagate_inbounds getindex(A::Array, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...) =
     A[to_indices(A, (i1, I...))...]
+@propagate_inbounds setindex!(A::Array, v, I::Integer...) = _setindex!(LinearFast(), A, v, to_indices(A, I)...)
 @propagate_inbounds setindex!(A::Array, v, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...) =
     (A[to_indices(A, (i1, I...))...] = v; A)
 


### PR DESCRIPTION
This is an alternative to the direction that #20573 was heading in, and a more aggressive version of #20079. #20079 deprecated partial linear indexing only when an index goes beyond the range of the last provided dimension:
```julia
julia> A = reshape(collect(1:8), 2, 2, 2)
2×2×2 Array{Int64,3}:
[:, :, 1] =
 1  3
 2  4

[:, :, 2] =
 5  7
 6  8

julia> A[1,1]
1

julia> A[1,2]
3

julia> A[1,3]
WARNING: Partial linear indexing is deprecated. Use `reshape(A, Val{2})` to make the dimensionality of the array match the number of indices.
Stacktrace:
 [1] depwarn(::String, ::Tuple{Symbol,Symbol,Symbol}) at ./deprecated.jl:64
 [2] partial_linear_indexing_warning(::Int64) at ./deprecated.jl:1071
 [3] getindex(::Array{Int64,3}, ::Int64, ::Int64) at ./array.jl:475
 [4] eval(::Module, ::Any) at ./boot.jl:235
 [5] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [6] macro expansion at ./REPL.jl:97 [inlined]
 [7] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
while loading no file, in expression starting on line 0
5
```
whereas this issues the warning even for `A[1,1]`. However, it doesn't touch trailing 1s:
```julia
julia> A[2,2,2,1]
8
```

The WIP part of this is to decide what to do about `A[:,:]`. Do we want to deprecate that too? Currently, this does so. There may be a couple of other loose ends, too. But I think it's mostly complete.

@nanosoldier `runbenchmarks(ALL, vs = ":master")`
