### PR TITLE
Silence Clang warning about mismatched types in comparison

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4764,7 +4764,7 @@ static std::unique_ptr<Module> emit_function(
         }
         else if (varinfo.isArgument) {
             // if we can unbox it, just use the input pointer
-            if (i != ctx.vaSlot && isbits_spec(jt, false))
+            if (i != (size_t)ctx.vaSlot && isbits_spec(jt, false))
                 continue;
         }
         else if (isbits_spec(jt, false)) {


### PR DESCRIPTION
The changes in #20374 introduced a Clang warning about the types of variables in a comparison. In this case, `i` is a `size_t` and `ctx.vaSlot` is an `int`, so this PR casts `ctx.vaSlot` to `size_t` for the comparison.