### PR TITLE
Be equally forgiving of leading & trailing whitespace in number parsing

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -135,6 +135,14 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
         return Nullable{Bool}()
     end
 
+    # Ignore leading and trailing whitespace
+    while isspace(sbuff[startpos]) && startpos <= endpos
+        startpos += 1
+    end
+    while isspace(sbuff[endpos]) && endpos >= startpos
+        endpos -= 1
+    end
+
     len = endpos - startpos + 1
     p   = pointer(sbuff) + startpos - 1
     (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -135,6 +135,9 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
         return Nullable{Bool}()
     end
 
+    orig_start = startpos
+    orig_end   = endpos
+
     # Ignore leading and trailing whitespace
     while isspace(sbuff[startpos]) && startpos <= endpos
         startpos += 1
@@ -151,7 +154,7 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
         p, "false", 5)) && (return Nullable(false))
 
     if raise
-        substr = SubString(sbuff, startpos, endpos)
+        substr = SubString(sbuff, orig_start, orig_end) # show input string in the error to avoid confusion
         if all(isspace, substr)
             throw(ArgumentError("input string only contains whitespace"))
         else

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -252,22 +252,22 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned))
 
     # Test that leading and trailing whitespace is ignored.
     for v in (1, 2, 3)
-         @test parse(Int, "    $v"    ) == v
-         @test parse(Int, "    $v\n"  ) == v
-         @test parse(Int, "$v    "    ) == v
-         @test parse(Int, "    $v    ") == v
+        @test parse(Int, "    $v"    ) == v
+        @test parse(Int, "    $v\n"  ) == v
+        @test parse(Int, "$v    "    ) == v
+        @test parse(Int, "    $v    ") == v
     end
     for v in (true, false)
-         @test parse(Bool, "    $v"    ) == v
-         @test parse(Bool, "    $v\n"  ) == v
-         @test parse(Bool, "$v    "    ) == v
-         @test parse(Bool, "    $v    ") == v
+        @test parse(Bool, "    $v"    ) == v
+        @test parse(Bool, "    $v\n"  ) == v
+        @test parse(Bool, "$v    "    ) == v
+        @test parse(Bool, "    $v    ") == v
     end
     for v in (0.05, -0.05, 2.5, -2.5)
-         @test parse(Float64, "    $v"    ) == v
-         @test parse(Float64, "    $v\n"  ) == v
-         @test parse(Float64, "$v    "    ) == v
-         @test parse(Float64, "    $v    ") == v
+        @test parse(Float64, "    $v"    ) == v
+        @test parse(Float64, "    $v\n"  ) == v
+        @test parse(Float64, "$v    "    ) == v
+        @test parse(Float64, "    $v    ") == v
     end
     @test parse(Float64, "    .5"    ) == 0.5
     @test parse(Float64, "    .5\n"  ) == 0.5

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -244,6 +244,12 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned))
         @test exception_uint.msg == "input string is empty or only contains whitespace"
     end
 
+    # Test that the entire input string appears in error messages
+    let s = "     false    true     "
+        result = @test_throws ArgumentError get(Base.tryparse_internal(Bool, s, start(s), endof(s), 0, true))
+        @test result.value.msg == "invalid Bool representation: $(repr(s))"
+    end
+
     # Test that leading and trailing whitespace is ignored.
     for v in (1, 2, 3)
          @test parse(Int, "    $v"    ) == v
@@ -263,8 +269,9 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned))
          @test parse(Float64, "$v    "    ) == v
          @test parse(Float64, "    $v    ") == v
     end
-    @test parse(Float64, "    .5    ") == 0.5
     @test parse(Float64, "    .5"    ) == 0.5
+    @test parse(Float64, "    .5\n"  ) == 0.5
+    @test parse(Float64, "    .5    ") == 0.5
     @test parse(Float64, ".5    "    ) == 0.5
 end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -243,6 +243,29 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned))
         exception_uint = result.value
         @test exception_uint.msg == "input string is empty or only contains whitespace"
     end
+
+    # Test that leading and trailing whitespace is ignored.
+    for v in (1, 2, 3)
+         @test parse(Int, "    $v"    ) == v
+         @test parse(Int, "    $v\n"  ) == v
+         @test parse(Int, "$v    "    ) == v
+         @test parse(Int, "    $v    ") == v
+    end
+    for v in (true, false)
+         @test parse(Bool, "    $v"    ) == v
+         @test parse(Bool, "    $v\n"  ) == v
+         @test parse(Bool, "$v    "    ) == v
+         @test parse(Bool, "    $v    ") == v
+    end
+    for v in (0.05, -0.05, 2.5, -2.5)
+         @test parse(Float64, "    $v"    ) == v
+         @test parse(Float64, "    $v\n"  ) == v
+         @test parse(Float64, "$v    "    ) == v
+         @test parse(Float64, "    $v    ") == v
+    end
+    @test parse(Float64, "    .5    ") == 0.5
+    @test parse(Float64, "    .5"    ) == 0.5
+    @test parse(Float64, ".5    "    ) == 0.5
 end
 
 parsebin(s) = parse(Int,s,2)


### PR DESCRIPTION
Follow-up from #20588.

Before #20588, the parsing code for integers was forgiving of leading and trailing whitespace.
The boolean parsing code was not.

After #20588, the integer parsing code _was still_ forgiving of whitespace.
The boolean parsing code was _still not_.

This PR makes all three _forgiving_ of _all_ leading and trailing whitespace, as determined by `isspace`.

cc @tkelman 