### PR TITLE
make write/unsafe_write on iobuffer return signed like other io

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -209,6 +209,9 @@ This section lists changes that do not have deprecation warnings.
     [SpecialFunctions.jl package](https://github.com/JuliaMath/SpecialFunctions.jl)
     ([#20427]).
 
+  * `write` on an `IOBuffer` now returns a signed integer in order to be
+    consistent with other buffers ([#20609]).
+
 Library improvements
 --------------------
 

--- a/base/base64.jl
+++ b/base/base64.jl
@@ -213,7 +213,7 @@ julia> io = IOBuffer();
 julia> iob64_decode = Base64DecodePipe(io);
 
 julia> write(io, "SGVsbG8h")
-0x0000000000000008
+8
 
 julia> seekstart(io);
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -322,7 +322,7 @@ end
 function unsafe_write(to::AbstractIOBuffer, p::Ptr{UInt8}, nb::UInt)
     ensureroom(to, nb)
     ptr = (to.append ? to.size+1 : to.ptr)
-    written = min(nb, length(to.data) - ptr + 1)
+    written = Int(min(nb, length(to.data) - ptr + 1))
     towrite = written
     d = to.data
     while towrite > 0

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -5,7 +5,7 @@ ioslength(io::IOBuffer) = (io.seekable ? io.size : nb_available(io))
 let io = IOBuffer()
 @test eof(io)
 @test_throws EOFError read(io,UInt8)
-@test write(io,"abc") == 3
+@test write(io,"abc") === 3
 @test isreadable(io)
 @test iswritable(io)
 @test isopen(io)
@@ -29,7 +29,7 @@ truncate(io, 0)
 truncate(io, 10)
 @test position(io) == 0
 @test all(io.data .== 0)
-@test write(io,Int16[1,2,3,4,5,6]) == 12
+@test write(io,Int16[1,2,3,4,5,6]) === 12
 seek(io, 2)
 truncate(io, 10)
 @test ioslength(io) == 10
@@ -39,8 +39,8 @@ truncate(io, 0)
 @test write(io,"boston\ncambridge\n") > 0
 @test String(take!(io)) == "boston\ncambridge\n"
 @test String(take!(io)) == ""
-@test write(io, Complex{Float64}(0)) == 16
-@test write(io, Rational{Int64}(1//2)) == 16
+@test write(io, Complex{Float64}(0)) === 16
+@test write(io, Rational{Int64}(1//2)) === 16
 close(io)
 @test_throws ArgumentError write(io,UInt8[0])
 @test_throws ArgumentError seek(io,0)
@@ -115,11 +115,11 @@ write(io,[1,2,3])
 @test ioslength(io) == 75
 @test length(io.data) == 75
 skip(io,1)
-@test write(io,UInt8(104)) == 1
+@test write(io,UInt8(104)) === 1
 skip(io,3)
-@test write(io,b"apples") == 3
+@test write(io,b"apples") === 3
 skip(io,71)
-@test write(io,'y') == 1
+@test write(io,'y') === 1
 @test readstring(io) == "happy"
 @test eof(io)
 write(io,zeros(UInt8,73))


### PR DESCRIPTION
Noticed by `@tkelman` in https://github.com/JuliaLang/julia/pull/20608#discussion_r101070679.

Before:

```
julia> io = IOBuffer()
IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1)

julia> write(io, "SGVsbG8h")
0x0000000000000008

julia> write(Base64EncodePipe(io), "SGVsbG8h")
8

julia> write(open("bla", "w"), "SGVsbG8h")
8
```
