### PR TITLE
Manual read through/example updates

### DIFF
--- a/doc/src/manual/packages.md
+++ b/doc/src/manual/packages.md
@@ -24,7 +24,7 @@ No packages installed.
 ```
 
 Your package directory is automatically initialized the first time you run a `Pkg` command
-that expects it to exist – which includes  [`Pkg.status()`](@ref). Here's an example non-trivial
+that expects it to exist – which includes [`Pkg.status()`](@ref). Here's an example non-trivial
 set of required and additional packages:
 
 ```julia
@@ -161,7 +161,7 @@ have to run [`Pkg.edit()`](@ref) again to fix the files contents yourself.
 Because the package manager uses libgit2 internally to manage the package git repositories, users
 may run into protocol issues (if behind a firewall, for example), when running [`Pkg.add()`](@ref).
 By default, all GitHub-hosted packages wil be accessed via 'https'; this default can be modified
-by calling [`Pkg.setprotocol!()`](@ref).  The following command can be run from the command line
+by calling [`Pkg.setprotocol!()`](@ref). The following command can be run from the command line
 in order to tell git to use 'https' instead of the 'git' protocol when cloning all repositories,
 wherever they are hosted:
 
@@ -473,7 +473,7 @@ GitHub "home page," find the file (e.g., `README.md`) within the repository's fo
 and click on it. You'll see the contents displayed, along with a small "pencil" icon in the upper
 right hand corner. Clicking that icon opens the file in edit mode. Make your changes, write a
 brief summary describing the changes you want to make (this is your *commit message*), and then
-hit "Propose file change."  Your changes will be submitted for consideration by the package owner(s)
+hit "Propose file change." Your changes will be submitted for consideration by the package owner(s)
 and collaborators.
 
 For larger documentation changes--and especially ones that you expect to have to update in response
@@ -484,7 +484,7 @@ to feedback--you might find it easier to use the procedure for code changes desc
 #### Executive summary
 
 Here we assume you've already set up git on your local machine and have a GitHub account (see
-above).  Let's imagine you're fixing a bug in the Images package:
+above). Let's imagine you're fixing a bug in the Images package:
 
 ```
 Pkg.checkout("Images")           # check out the master branch
@@ -511,10 +511,10 @@ project's main repository. Because the online repository can't see the code on y
 you first *push* your changes to a publicly-visible location, your own online *fork* of the package
 (hosted on your own personal GitHub account).
 
-Let's assume you already have the `Foo` package installed.  In the description below, anything
+Let's assume you already have the `Foo` package installed. In the description below, anything
 starting with `Pkg.` or `PkgDev.` is meant to be typed at the Julia prompt; anything starting
 with `git` is meant to be typed in [julia's shell mode](@ref man-shell-mode) (or using the shell that comes with
-your operating system).  Within Julia, you can combine these two modes:
+your operating system). Within Julia, you can combine these two modes:
 
 ```julia
 julia> cd(Pkg.dir("Foo"))          # go to Foo's folder
@@ -522,7 +522,7 @@ julia> cd(Pkg.dir("Foo"))          # go to Foo's folder
 shell> git command arguments...    # command will apply to Foo
 ```
 
-Now suppose you're ready to make some changes to `Foo`.  While there are several possible approaches,
+Now suppose you're ready to make some changes to `Foo`. While there are several possible approaches,
 here is one that is widely used:
 
   * From the Julia prompt, type [`Pkg.checkout("Foo")`](@ref). This ensures you're running the latest
@@ -540,10 +540,10 @@ here is one that is widely used:
     If you forget to do this step until after you've already made some changes, don't worry: see
     [more detail about branching](@ref man-branch-post-hoc) below.
   * Make your changes. Whether it's fixing a bug or adding new functionality, in most cases your change
-    should include updates to both the `src/` and `test/` folders.  If you're fixing a bug, add your
+    should include updates to both the `src/` and `test/` folders. If you're fixing a bug, add your
     minimal example demonstrating the bug (on the current code) to the test suite; by contributing
     a test for the bug, you ensure that the bug won't accidentally reappear at some later time due
-    to other changes.  If you're adding new functionality, creating tests demonstrates to the package
+    to other changes. If you're adding new functionality, creating tests demonstrates to the package
     owner that you've made sure your code works as intended.
   * Run the package's tests and make sure they pass. There are several ways to run the tests:
 
@@ -571,7 +571,7 @@ here is one that is widely used:
       * From the shell, type `git push`.  This will add your new commit(s) to the same pull request; you
         should see them appear automatically on the page holding the discussion of your pull request.
 
-    One potential type of change the owner may request is that you squash your commits.  See [Squashing](@ref man-squashing-and-rebasing)
+    One potential type of change the owner may request is that you squash your commits. See [Squashing](@ref man-squashing-and-rebasing)
     below.
 
 ### Dirty packages
@@ -586,9 +586,9 @@ Naturally, this deletes any changes you've made.
 ### [Making a branch *post hoc*](@id man-branch-post-hoc)
 
 Especially for newcomers to git, one often forgets to create a new branch until after some changes
-have already been made.  If you haven't yet staged or committed your changes, you can create a
+have already been made. If you haven't yet staged or committed your changes, you can create a
 new branch with `git checkout -b <newbranch>` just as usual--git will kindly show you that some
-files have been modified and create the new branch for you.  *Your changes have not yet been committed to this new branch*,
+files have been modified and create the new branch for you. *Your changes have not yet been committed to this new branch*,
 so the normal work rules still apply.
 
 However, if you've already made a commit to `master` but wish to go back to the official `master`
@@ -671,7 +671,7 @@ of what your package supports.
 
 You might also have no interest in supporting the development version of Julia. Just as you can
 add a floor to the version you expect your users to be on, you can set an upper bound. In this
-case, you would put `julia 0.x 0.y-` in your `REQUIRE` file.  The `-` at the end of the version
+case, you would put `julia 0.x 0.y-` in your `REQUIRE` file. The `-` at the end of the version
 number means pre-release versions of that specific version from the very first commit. By setting
 it as the ceiling, you mean the code supports everything up to but not including the ceiling version.
 
@@ -680,7 +680,7 @@ and do not want to support the current stable version of Julia. If you choose to
 add `julia 0.y-` to your `REQUIRE`. Just remember to change the `julia 0.y-` to `julia 0.y` in
 your `REQUIRE` file once `0.y` is officially released. If you don't edit the dash cruft you are
 suggesting that you support both the development and stable versions of the same version number!
-That would be madness.  See the [Requirements Specification](@ref) for the full format of `REQUIRE`.
+That would be madness. See the [Requirements Specification](@ref) for the full format of `REQUIRE`.
 
 Lastly, in many cases you may need extra packages for testing. Additional packages which
 are only required for tests should be specified in the `test/REQUIRE` file. This `REQUIRE`
@@ -730,7 +730,7 @@ to follow in naming your package:
 
 ### Generating the package
 
-Suppose you want to create a new Julia package called `FooBar`.  To get started, do `PkgDev.generate(pkg,license)`
+Suppose you want to create a new Julia package called `FooBar`. To get started, do `PkgDev.generate(pkg,license)`
 where `pkg` is the new package name and `license` is the name of a license that the package generator
 knows about:
 
@@ -781,14 +781,14 @@ Date:   Wed Oct 16 17:57:58 2013 -0400
 
 At the moment, the package manager knows about the MIT "Expat" License, indicated by `"MIT"`,
 the Simplified BSD License, indicated by `"BSD"`, and version 2.0 of the Apache Software License,
-indicated by `"ASL"`.  If you want to use a different license, you can ask us to add it to the
+indicated by `"ASL"`. If you want to use a different license, you can ask us to add it to the
 package generator, or just pick one of these three and then modify the `~/.julia/v0.6/PACKAGE/LICENSE.md`
 file after it has been generated.
 
 If you created a GitHub account and configured git to know about it, `PkgDev.generate()` will
-set an appropriate origin URL for you.  It will also automatically generate a `.travis.yml` file
+set an appropriate origin URL for you. It will also automatically generate a `.travis.yml` file
 for using the [Travis](https://travis-ci.org) automated testing service, and an `appveyor.yml`
-file for using [AppVeyor](https://www.appveyor.com).  You will have to enable testing on the Travis
+file for using [AppVeyor](https://www.appveyor.com). You will have to enable testing on the Travis
 and AppVeyor websites for your package repository, but once you've done that, it will already
 have working tests. Of course, all the default testing does is verify that `using FooBar` in Julia
 works.
@@ -808,9 +808,9 @@ foo = readcsv(joinpath(datapath, "foo.csv"))
 ### Making Your Package Available
 
 Once you've made some commits and you're happy with how `FooBar` is working, you may want to get
-some other people to try it out.  First you'll need to create the remote repository and push your
+some other people to try it out. First you'll need to create the remote repository and push your
 code to it; we don't yet automatically do this for you, but we will in the future and it's not
-too hard to figure out [^3].  Once you've done this, letting people try out your code is as simple
+too hard to figure out [^3]. Once you've done this, letting people try out your code is as simple
 as sending them the URL of the published repo – in this case:
 
 ```
@@ -866,8 +866,8 @@ index 0000000..30e525e
 +git://github.com/StefanKarpinski/FooBar.jl.git
 ```
 
-This commit is only locally visible, however.  To make it visible to the Julia community, you
-need to merge your local `METADATA` upstream into the official repo.  The `PkgDev.publish()` command
+This commit is only locally visible, however. To make it visible to the Julia community, you
+need to merge your local `METADATA` upstream into the official repo. The `PkgDev.publish()` command
 will fork the `METADATA` repository on GitHub, push your changes to your fork, and open a pull
 request:
 
@@ -934,7 +934,7 @@ index 0000000..c1cb1c1
 ```
 
 The `PkgDev.tag()` command takes an optional second argument that is either an explicit version
-number object like `v"0.0.1"` or one of the symbols `:patch`, `:minor` or `:major`.  These increment
+number object like `v"0.0.1"` or one of the symbols `:patch`, `:minor` or `:major`. These increment
 the patch, minor or major version number of your package intelligently.
 
 Adding a tagged version of your package will expedite the official registration into METADATA.jl
@@ -1010,7 +1010,7 @@ however, you should also fix the `REQUIRE` file in the current version of the pa
 
 The `~/.julia/v0.6/REQUIRE` file, the `REQUIRE` file inside packages, and the `METADATA` package
 `requires` files use a simple line-based format to express the ranges of package versions which
-need to be installed.  Package `REQUIRE` and `METADATA requires` files should also include the
+need to be installed. Package `REQUIRE` and `METADATA requires` files should also include the
 range of versions of `julia` the package is expected to work with. Additionally, packages can
 include a `test/REQUIRE` file to specify additional packages which are only required for testing.
 

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -2,7 +2,7 @@
 
 The `Profile` module provides tools to help developers improve the performance of their
 code. When used, it takes measurements on running code, and produces output that helps you understand
-how much time is spent on individual line(s).  The most common usage is to identify "bottlenecks"
+how much time is spent on individual line(s). The most common usage is to identify "bottlenecks"
 as targets for optimization.
 
 `Profile` implements what is known as a "sampling" or [statistical profiler](https://en.wikipedia.org/wiki/Profiling_(computer_programming)).
@@ -11,7 +11,7 @@ captures the currently-running function and line number, plus the complete chain
 that led to this line, and hence is a "snapshot" of the current state of execution.
 
 If much of your run time is spent executing a particular line of code, this line will show up
-frequently in the set of all backtraces.  In other words, the "cost" of a given line--or really,
+frequently in the set of all backtraces. In other words, the "cost" of a given line--or really,
 the cost of the sequence of function calls up to and including this line--is proportional to how
 often it appears in the set of all backtraces.
 
@@ -37,17 +37,17 @@ any alternatives.
 Let's work with a simple test case:
 
 ```julia
-function myfunc()
-    A = rand(100, 100, 200)
-    maximum(A)
-end
+julia> function myfunc()
+           A = rand(100, 100, 200)
+           maximum(A)
+       end
 ```
 
 It's a good idea to first run the code you intend to profile at least once (unless you want to
 profile Julia's JIT-compiler):
 
 ```julia
-julia> myfunc()  # run once to force compilation
+julia> myfunc() # run once to force compilation
 ```
 
 Now we're ready to profile this function:
@@ -73,20 +73,20 @@ julia> Profile.print()
                   11 reduce.jl; max; line: 37
 ```
 
-Each line of this display represents a particular spot (line number) in the code.  Indentation
+Each line of this display represents a particular spot (line number) in the code. Indentation
 is used to indicate the nested sequence of function calls, with more-indented lines being deeper
-in the sequence of calls.  In each line, the first "field" indicates the number of backtraces
+in the sequence of calls. In each line, the first "field" indicates the number of backtraces
 (samples) taken *at this line or in any functions executed by this line*. The second field is
 the file name, followed by a semicolon; the third is the function name followed by a semicolon,
-and the fourth is the line number.  Note that the specific line numbers may change as Julia's
+and the fourth is the line number. Note that the specific line numbers may change as Julia's
 code changes; if you want to follow along, it's best to run this example yourself.
 
 In this example, we can see that the top level is `client.jl`'s `_start` function. This is the
-first Julia function that gets called when you launch Julia.  If you examine line 373 of `client.jl`,
+first Julia function that gets called when you launch Julia. If you examine line 373 of `client.jl`,
 you'll see that (at the time of this writing) it calls `run_repl()`, mentioned on the second line.
 This in turn calls `eval_user_input()`. These are the functions in `client.jl` that interpret
 what you type at the REPL, and since we're working interactively these functions were invoked
-when we entered `@profile myfunc()`.  The next line reflects actions taken in the [`@profile`](@ref)
+when we entered `@profile myfunc()`. The next line reflects actions taken in the [`@profile`](@ref)
 macro.
 
 The first line shows that 23 backtraces were taken at line 373 of `client.jl`, but it's not that
@@ -179,7 +179,7 @@ dumbsum3
             dumbsum(1)
 ```
 
-Consequently, this child function gets 3 counts, even though the parent only gets one.  The "tree"
+Consequently, this child function gets 3 counts, even though the parent only gets one. The "tree"
 representation makes this much clearer, and for this reason (among others) is probably the most
 useful way to view the results.
 
@@ -213,16 +213,16 @@ Let's discuss these arguments in order:
     ```
   * The first keyword argument, `format`, was introduced above. The possible choices are `:tree` and
     `:flat`.
-  * `C`, if set to `true`, allows you to see even the calls to C code.  Try running the introductory
+  * `C`, if set to `true`, allows you to see even the calls to C code. Try running the introductory
     example with `Profile.print(C = true)`. This can be extremely helpful in deciding whether it's
     Julia code or C code that is causing a bottleneck; setting `C=true` also improves the interpretability
     of the nesting, at the cost of longer profile dumps.
   * Some lines of code contain multiple operations; for example, `s += A[i]` contains both an array
-    reference (`A[i]`) and a sum operation.  These correspond to different lines in the generated
+    reference (`A[i]`) and a sum operation. These correspond to different lines in the generated
     machine code, and hence there may be two or more different addresses captured during backtraces
-    on this line.  `combine=true` lumps them together, and is probably what you typically want, but
+    on this line. `combine=true` lumps them together, and is probably what you typically want, but
     you can generate an output separately for each unique instruction pointer with `combine=false`.
-  * `cols` allows you to control the number of columns that you are willing to use for display.  When
+  * `cols` allows you to control the number of columns that you are willing to use for display. When
     the text would be wider than the display, you might see output like this:
 
     ```
@@ -279,26 +279,26 @@ on the author's laptop).
 
 # Memory allocation analysis
 
-One of the most common techniques to improve performance is to reduce memory allocation.  The
+One of the most common techniques to improve performance is to reduce memory allocation. The
 total amount of allocation can be measured with [`@time`](@ref) and [`@allocated`](@ref), and
 specific lines triggering allocation can often be inferred from profiling via the cost of garbage
-collection that these lines incur.  However, sometimes it is more efficient to directly measure
+collection that these lines incur. However, sometimes it is more efficient to directly measure
 the amount of memory allocated by each line of code.
 
 To measure allocation line-by-line, start Julia with the `--track-allocation=<setting>` command-line
 option, for which you can choose `none` (the default, do not measure allocation), `user` (measure
 memory allocation everywhere except Julia's core code), or `all` (measure memory allocation at
-each line of Julia code). Allocation gets measured for each line of compiled code.  When you quit
+each line of Julia code). Allocation gets measured for each line of compiled code. When you quit
 Julia, the cumulative results are written to text files with `.mem` appended after the file name,
-residing in the same directory as the source file.  Each line lists the total number of bytes
+residing in the same directory as the source file. Each line lists the total number of bytes
 allocated. The `Coverage` package contains some elementary analysis tools, for example to sort
 the lines in order of number of bytes allocated.
 
-In interpreting the results, there are a few important details.  Under the `user` setting, the
+In interpreting the results, there are a few important details. Under the `user` setting, the
 first line of any function directly called from the REPL will exhibit allocation due to events
-that happen in the REPL code itself.  More significantly, JIT-compilation also adds to allocation
+that happen in the REPL code itself. More significantly, JIT-compilation also adds to allocation
 counts, because much of Julia's compiler is written in Julia (and compilation usually requires
-memory allocation).  The recommended procedure is to force compilation by executing all the commands
+memory allocation). The recommended procedure is to force compilation by executing all the commands
 you want to analyze, then call [`Profile.clear_malloc_data()`](@ref) to reset all allocation counters.
  Finally, execute the desired commands and quit Julia to trigger the generation of the `.mem`
 files.


### PR DESCRIPTION
This is some small fixes in the last three files in https://github.com/JuliaLang/julia/issues/20274 and then all (?) of the examples in the manual have been tested. (Thanks `@kshyatt` and` @KristofferC` for the help :tada:)

Updates are mostly whitespace and formatting. These examples can not really be doctested (?).

close https://github.com/JuliaLang/julia/issues/20274

(`make check-whitespace` and the doctests pass locally, remove `[ci skip]` from commit message if/when this is merged)