### PR TITLE
Speed-up repeat for AbstractArrays

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -402,9 +402,9 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
         for c in CartesianRange(indices(A))
             for i in 1:ndims(A)
                 n = inner[i]
-                inner_indices[i] = (1:n) + ((c.I[i] - 1) * n)
+                inner_indices[i] = (1:n) + ((c[i] - 1) * n)
             end
-            R[inner_indices...] = A[c.I...]
+            R[inner_indices...] = A[c]
         end
     end
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -360,40 +360,68 @@ julia> repeat([1 2; 3 4], inner=(2, 1), outer=(1, 3))
 ```
 """
 function repeat(A::AbstractArray;
-                inner=ntuple(x->1, ndims(A)),
-                outer=ntuple(x->1, ndims(A)))
-    ndims_in = ndims(A)
-    length_inner = length(inner)
-    length_outer = length(outer)
+                inner=ntuple(n->1, Val{ndims(A)}),
+                outer=ntuple(n->1, Val{ndims(A)}))
+    return _repeat(A, rep_kw2tup(inner), rep_kw2tup(outer))
+end
 
-    length_inner >= ndims_in || throw(ArgumentError("number of inner repetitions ($(length(inner))) cannot be less than number of dimensions of input ($(ndims(A)))"))
-    length_outer >= ndims_in || throw(ArgumentError("number of outer repetitions ($(length(outer))) cannot be less than number of dimensions of input ($(ndims(A)))"))
+rep_kw2tup(n::Integer) = (n,)
+rep_kw2tup(v::AbstractArray{<:Integer}) = (v...)
+rep_kw2tup(t::Tuple) = t
 
-    ndims_out = max(ndims_in, length_inner, length_outer)
+rep_shapes(A, i, o) = _rshps((), (), size(A), i, o)
 
-    inner = vcat(collect(inner), ones(Int,ndims_out-length_inner))
-    outer = vcat(collect(outer), ones(Int,ndims_out-length_outer))
+_rshps(shp, shp_i, ::Tuple{}, ::Tuple{}, ::Tuple{}) = (shp, shp_i)
+@inline _rshps(shp, shp_i, ::Tuple{}, ::Tuple{}, o) =
+    _rshps((shp..., o[1]), (shp_i..., 1), (), (), tail(o))
+@inline _rshps(shp, shp_i, ::Tuple{}, i, ::Tuple{}) = (n = i[1];
+    _rshps((shp..., n), (shp_i..., n), (), tail(i), ()))
+@inline _rshps(shp, shp_i, ::Tuple{}, i, o) = (n = i[1];
+    _rshps((shp..., n * o[1]), (shp_i..., n), (), tail(i), tail(o)))
+@inline _rshps(shp, shp_i, sz, i, o) = (n = sz[1] * i[1];
+    _rshps((shp..., n * o[1]), (shp_i..., n), tail(sz), tail(i), tail(o)))
+_rshps(shp, shp_i, sz, ::Tuple{}, ::Tuple{}) =
+    (n = length(shp); N = n + length(sz); _reperr("inner", n, N))
+_rshps(shp, shp_i, sz, ::Tuple{}, o) =
+    (n = length(shp); N = n + length(sz); _reperr("inner", n, N))
+_rshps(shp, shp_i, sz, i, ::Tuple{}) =
+    (n = length(shp); N = n + length(sz); _reperr("outer", n, N))
+_reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
+    "($n) cannot be less than number of dimensions of input ($N)"))
 
-    size_in = size(A)
-    size_out = ntuple(i->inner[i]*size(A,i)*outer[i],ndims_out)::Dims
-    inner_size_out = ntuple(i->inner[i]*size(A,i),ndims_out)::Dims
+@propagate_inbounds function _repeat(A::AbstractArray, inner, outer)
+    shape, inner_shape = rep_shapes(A, inner, outer)
 
-    indices_in = Vector{Int}(ndims_in)
-    indices_out = Vector{Int}(ndims_out)
+    R = similar(A, shape)
 
-    length_out = prod(size_out)
-    R = similar(A, size_out)
-
-    for index_out in 1:length_out
-        ind2sub!(indices_out, size_out, index_out)
-        for t in 1:ndims_in
-            # "Project" outer repetitions into inner repetitions
-            indices_in[t] = mod1(indices_out[t], inner_size_out[t])
-            # Find inner repetitions using flooring division
-            indices_in[t] = fld1(indices_in[t], inner[t])
+    # fill the first inner block
+    if all(x -> x == 1, inner)
+        R[indices(A)...] = A
+    else
+        inner_indices = [1:n for n in inner]
+        for c in CartesianRange(indices(A))
+            for i in 1:ndims(A)
+                n = inner[i]
+                inner_indices[i] = (1:n) + ((c.I[i] - 1) * n)
+            end
+            R[inner_indices...] = A[c.I...]
         end
-        index_in = sub2ind(size_in, indices_in...)
-        R[index_out] = A[index_in]
+    end
+
+    # fill the outer blocks along each dimension
+    if all(x -> x == 1, outer)
+        return R
+    end
+    src_indices  = [1:n for n in inner_shape]
+    dest_indices = copy(src_indices)
+    for i in 1:length(outer)
+        B = view(R, src_indices...)
+        for j in 2:outer[i]
+            dest_indices[i] += inner_shape[i]
+            R[dest_indices...] = B
+        end
+        src_indices[i] = 1:dest_indices[i][end]
+        copy!(dest_indices, src_indices)
     end
 
     return R


### PR DESCRIPTION
I'd say this should fix JuliaLang/julia#15553. Compared to the OP in that issue I get times of ~3ms vs ~600ms on master.

Also, compared to this https://github.com/JuliaLang/LinearAlgebra.jl/issues/402, I get
```julia
julia> for N in (10, 50, 100)
           A = rand(N, N)
           outer = (N, N)
           @btime repmat($A, $N, $N);
           @btime repeat($A, outer=$outer);
       end
  12.424 μs (202 allocations: 84.45 KiB)
  40.933 μs (130 allocations: 82.39 KiB)
  8.456 ms (5002 allocations: 47.84 MiB)
  12.419 ms (370 allocations: 47.70 MiB)
  169.579 ms (20002 allocations: 763.55 MiB)
  200.986 ms (670 allocations: 762.96 MiB)
```

This `repeat` is still type-unstable, but that should improve when inference and keyword arguments improve.