### PR TITLE
`ismatch(rm)` now takes RegexMatch or Void as args

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -153,6 +153,9 @@ function ismatch(r::Regex, s::SubString, offset::Integer=0)
                      r.match_data)
 end
 
+ismatch(rm::RegexMatch) = true
+ismatch(rm::Void) = false
+
 (r::Regex)(s) = ismatch(r, s)
 
 function match(re::Regex, str::Union{SubString{String}, String}, idx::Integer, add_opts::UInt32=UInt32(0))


### PR DESCRIPTION
This way one can store the result into a variable before checking the matching. I don't know about any clear example to explain. But I think it is coherent to implement them this way.