### PR TITLE
Fix bug in GitBlob lookup and add test

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1130,6 +1130,7 @@ end
      @deprecate object(repo::GitRepo, te::GitTreeEntry) GitObject(repo, te) false
      @deprecate commit(ann::GitAnnotated) GitHash(ann) false
      @deprecate cat{T<:GitObject}(repo::GitRepo, ::Type{T}, object::AbstractString) cat(repo, object)
+     @deprecate lookup(repo::GitRepo, oid::GitHash) GitBlob(repo, oid) false
 end
 
 # when this deprecation is deleted, remove all calls to it, and all

--- a/base/libgit2/blob.jl
+++ b/base/libgit2/blob.jl
@@ -25,14 +25,6 @@ function isbinary(blob::GitBlob)
     return bin_flag == 1
 end
 
-function lookup(repo::GitRepo, oid::GitHash)
-    blob_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
-    @check ccall((:git_blob_lookup, :libgit2), Cint,
-                  (Ptr{Ptr{Void}}, Ptr{Void}, Ref{GitHash}),
-                   blob_ptr_ptr, repo.ptr, Ref(oid))
-    return GitBlob(blob_ptr_ptr[])
-end
-
 """
     LibGit2.addblob!(repo::GitRepo, path::AbstractString)
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -446,10 +446,15 @@ mktempdir() do dir
                 id = LibGit2.addblob!(repo, blob_file)
                 blob = LibGit2.GitBlob(repo, id)
                 @test LibGit2.isbinary(blob)
+                len1 = length(blob)
                 blob_show_strs = split(sprint(show, blob), "\n")
                 @test blob_show_strs[1] == "GitBlob:"
                 @test contains(blob_show_strs[2], "Blob id:")
                 @test blob_show_strs[3] == "Contents are binary."
+
+                blob2 = LibGit2.GitBlob(repo, LibGit2.GitHash(blob))
+                @test LibGit2.isbinary(blob2)
+                @test length(blob2) == len1
             finally
                 close(repo)
             end


### PR DESCRIPTION
The constructor for `GitBlob` requires a `repo` argument.