### PR TITLE
Add module name "Base" when calling "shell_escape"

### DIFF
--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -185,7 +185,7 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     cmd = `cd $dir '&&' $tval $exename $exeflags`
 
     # shell login (-l) with string command (-c) to launch julia process
-    cmd = `sh -l -c $(shell_escape(cmd))`
+    cmd = `sh -l -c $(Base.shell_escape(cmd))`
 
     # remote launch with ssh with given ssh flags / host / port information
     # -T → disable pseudo-terminal allocation
@@ -195,7 +195,7 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     #                          forwarded connections are causing collisions
     # -n → Redirects stdin from /dev/null (actually, prevents reading from stdin).
     #      Used when running ssh in the background.
-    cmd = `ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host $(shell_escape(cmd))`
+    cmd = `ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host $(Base.shell_escape(cmd))`
 
     # launch the remote Julia process
 


### PR DESCRIPTION
solve problem:
`exception launching on machine <remote_ip> : UndefVarError(:shell_escape)`
when calling `addprocs([<remote_ip>])` in Julia v0.6