### PR TITLE
minimal inlining of x^Val{p} for p=0,1,2,3 and x::Number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,8 @@ Language changes
   * Experimental feature: `x^n` for integer literals `n` (e.g. `x^3`
     or `x^-3`) is now lowered to `x^Val{n}`, to enable compile-time
     specialization for literal integer exponents ([#20530]).
+    `x^p` for `x::Number` and `p=0,1,2,3` is now lowered to
+    `one(x)`, `x`, `x*x`, and `x*x*x`, respectively ([#20648]).
 
 Breaking changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,7 +76,7 @@ Language changes
   * Experimental feature: `x^n` for integer literals `n` (e.g. `x^3`
     or `x^-3`) is now lowered to `x^Val{n}`, to enable compile-time
     specialization for literal integer exponents ([#20530]).
-    `x^p` for `x::Number` and `p=0,1,2,3` is now lowered to
+    `x^p` for `x::Number` and a literal `p=0,1,2,3` is now lowered to
     `one(x)`, `x`, `x*x`, and `x*x*x`, respectively ([#20648]).
 
 Breaking changes

--- a/base/float.jl
+++ b/base/float.jl
@@ -367,6 +367,7 @@ _default_type(T::Union{Type{Real},Type{AbstractFloat}}) = Float64
 for op in (:+, :-, :*, :/, :\, :^)
     @eval ($op)(a::Float16, b::Float16) = Float16(($op)(Float32(a), Float32(b)))
 end
+^{p}(x::Float16, ::Type{Val{p}}) = Float16(Float32(x)^Val{p})
 +(x::Float32, y::Float32) = add_float(x, y)
 +(x::Float64, y::Float64) = add_float(x, y)
 -(x::Float32, y::Float32) = sub_float(x, y)

--- a/base/float.jl
+++ b/base/float.jl
@@ -367,7 +367,6 @@ _default_type(T::Union{Type{Real},Type{AbstractFloat}}) = Float64
 for op in (:+, :-, :*, :/, :\, :^)
     @eval ($op)(a::Float16, b::Float16) = Float16(($op)(Float32(a), Float32(b)))
 end
-^{p}(x::Float16, ::Type{Val{p}}) = Float16(Float32(x)^Val{p})
 +(x::Float32, y::Float32) = add_float(x, y)
 +(x::Float64, y::Float64) = add_float(x, y)
 -(x::Float32, y::Float32) = sub_float(x, y)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -443,9 +443,8 @@ end
 ^(x::Integer, y::BigInt ) = bigint_pow(BigInt(x), y)
 ^(x::Bool   , y::BigInt ) = Base.power_by_squaring(x, y)
 
-# override default inlining of x^2 and x^3 as x*x and x*x*x
-^(x::BigInt, ::Type{Val{2}}) = x^convert(Culong, 2)
-^(x::BigInt, ::Type{Val{3}}) = x^convert(Culong, 3)
+# override default inlining of x^2 and x^3 etc.
+^{p}(x::BigInt, ::Type{Val{p}}) = x^Culong(p)
 
 function powermod(x::BigInt, p::BigInt, m::BigInt)
     r = BigInt()

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -443,6 +443,10 @@ end
 ^(x::Integer, y::BigInt ) = bigint_pow(BigInt(x), y)
 ^(x::Bool   , y::BigInt ) = Base.power_by_squaring(x, y)
 
+# override default inlining of x^2 and x^3 as x*x and x*x*x
+^(x::BigInt, ::Type{Val{2}}) = x^convert(Culong, 2)
+^(x::BigInt, ::Type{Val{3}}) = x^convert(Culong, 3)
+
 function powermod(x::BigInt, p::BigInt, m::BigInt)
     r = BigInt()
     ccall((:__gmpz_powm, :libgmp), Void,

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -200,6 +200,13 @@ end
 # However, we still need a fallback that calls the general ^:
 ^{p}(x, ::Type{Val{p}}) = x^p
 
+# inference.jl has complicated logic to inline x^2 and x^3 for
+# numeric types.  In terms of Val we can do it much more simply:
+^(x::Number, ::Type{Val{0}}) = one(x)
+^(x::Number, ::Type{Val{1}}) = x
+^(x::Number, ::Type{Val{2}}) = x*x
+^(x::Number, ::Type{Val{3}}) = x*x*x
+
 # b^p mod m
 
 """

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -197,15 +197,18 @@ end
 
 # x^p for any literal integer p is lowered to x^Val{p},
 # to enable compile-time optimizations specialized to p.
-# However, we still need a fallback that calls the general ^:
-^{p}(x, ::Type{Val{p}}) = x^p
+# However, we still need a fallback that calls the general ^.
+# To avoid ambiguities for methods that dispatch on the
+# first argument, we dispatch the fallback via internal_pow:
+^(x, p) = internal_pow(x, p)
+internal_pow{p}(x, ::Type{Val{p}}) = x^p
 
 # inference.jl has complicated logic to inline x^2 and x^3 for
 # numeric types.  In terms of Val we can do it much more simply:
-^(x::Number, ::Type{Val{0}}) = one(x)
-^(x::Number, ::Type{Val{1}}) = x
-^(x::Number, ::Type{Val{2}}) = x*x
-^(x::Number, ::Type{Val{3}}) = x*x*x
+internal_pow(x::Number, ::Type{Val{0}}) = one(x)
+internal_pow(x::Number, ::Type{Val{1}}) = x
+internal_pow(x::Number, ::Type{Val{2}}) = x*x
+internal_pow(x::Number, ::Type{Val{3}}) = x*x*x
 
 # b^p mod m
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -212,6 +212,7 @@ catalan
 for T in (Irrational, Rational, Integer, Number)
     ^(::Irrational{:e}, x::T) = exp(x)
 end
+^{p}(::Irrational{:e}, ::Type{Val{p}}) = exp(p)
 
 log(::Irrational{:e}) = 1 # use 1 to correctly promote expressions like log(x)/log(e)
 log(::Irrational{:e}, x::Number) = log(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -676,6 +676,7 @@ end
 ^(x::Float32, y::Integer) = x^Int32(y)
 ^(x::Float32, y::Int32) = powi_llvm(x, y)
 ^(x::Float16, y::Integer) = Float16(Float32(x)^y)
+^{p}(x::Float16, ::Type{Val{p}}) = Float16(Float32(x)^Val{p})
 
 function angle_restrict_symm(theta)
     const P1 = 4 * 7.8539812564849853515625e-01

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -504,6 +504,11 @@ end
 ^(x::BigFloat, y::Integer)  = typemin(Clong)  <= y <= typemax(Clong)  ? x^Clong(y)  : x^BigInt(y)
 ^(x::BigFloat, y::Unsigned) = typemin(Culong) <= y <= typemax(Culong) ? x^Culong(y) : x^BigInt(y)
 
+# override default inlining of x^2 and x^3 as x*x and x*x*x
+^(x::BigFloat, ::Type{Val{2}}) = x^convert(Culong, 2)
+^(x::BigFloat, ::Type{Val{3}}) = x^convert(Culong, 3)
+^(x::BigFloat, ::Type{Val{1}}) = x^convert(Culong, 1) # might change precision
+
 for f in (:exp, :exp2, :exp10, :expm1, :cosh, :sinh, :tanh, :sech, :csch, :coth, :cbrt)
     @eval function $f(x::BigFloat)
         z = BigFloat()

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -504,10 +504,8 @@ end
 ^(x::BigFloat, y::Integer)  = typemin(Clong)  <= y <= typemax(Clong)  ? x^Clong(y)  : x^BigInt(y)
 ^(x::BigFloat, y::Unsigned) = typemin(Culong) <= y <= typemax(Culong) ? x^Culong(y) : x^BigInt(y)
 
-# override default inlining of x^2 and x^3 as x*x and x*x*x
-^(x::BigFloat, ::Type{Val{2}}) = x^convert(Culong, 2)
-^(x::BigFloat, ::Type{Val{3}}) = x^convert(Culong, 3)
-^(x::BigFloat, ::Type{Val{1}}) = x^convert(Culong, 1) # might change precision
+# override default inlining of x^2 etc.
+^{p}(x::BigFloat, ::Type{Val{p}}) = x^Culong(p)
 
 for f in (:exp, :exp2, :exp10, :expm1, :cosh, :sinh, :tanh, :sech, :csch, :coth, :cbrt)
     @eval function $f(x::BigFloat)


### PR DESCRIPTION
This PR does very basic inlining of `x^Val{p}` for `p=0,1,2,3` and `x::Number` (a much more restrictive version of #20637).

It should fix the performance regression of #20530.

It also dispatches `^(x,p) = internal_pow(x,p)` and defines `internal_pow(x, Val{p})` as suggested by @timholy, in order to avoid dispatch ambiguities for code that specializes `^` on the first argument.