### PR TITLE
fix some specificity and intersection issues

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -204,7 +204,7 @@ julia> strides(A)
 """
 strides(A::AbstractArray) = _strides((1,), A)
 _strides{T,N}(out::NTuple{N,Any}, A::AbstractArray{T,N}) = out
-function _strides{M}(out::NTuple{M}, A::AbstractArray)
+function _strides{M}(out::NTuple{M,Any}, A::AbstractArray)
     @_inline_meta
     _strides((out..., out[M]*size(A, M)), A)
 end

--- a/base/linalg/transpose.jl
+++ b/base/linalg/transpose.jl
@@ -126,7 +126,8 @@ function ctranspose(A::AbstractMatrix)
     ctranspose!(B, A)
 end
 
-@inline ctranspose(A::AbstractVecOrMat{<:Real}) = transpose(A)
+@inline ctranspose(A::AbstractVector{<:Real}) = transpose(A)
+@inline ctranspose(A::AbstractMatrix{<:Real}) = transpose(A)
 
 function copy_transpose!(B::AbstractVecOrMat, ir_dest::Range{Int}, jr_dest::Range{Int},
                          A::AbstractVecOrMat, ir_src::Range{Int}, jr_src::Range{Int})

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -31,6 +31,7 @@ eltype{T}(x::Type{Ref{T}}) = T
 convert{T}(::Type{Ref{T}}, x::Ref{T}) = x
 
 # create Ref objects for general object conversion
+unsafe_convert{T}(::Type{Ref{T}}, x::Ref{T}) = unsafe_convert(Ptr{T}, x)
 unsafe_convert{T}(::Type{Ref{T}}, x) = unsafe_convert(Ptr{T}, x)
 
 ### Methods for a Ref object that can store a single value of any type
@@ -107,8 +108,10 @@ function (::Type{Ref{P}}){P<:Union{Ptr,Cwstring,Cstring},T}(a::Array{T}) # Ref{P
         return RefArray(ptrs,1,roots)
     end
 end
-cconvert{P<:Ptr}(::Union{Type{Ptr{P}},Type{Ref{P}}}, a::Array{<:Ptr}) = a
-cconvert{P<:Union{Ptr,Cwstring,Cstring}}(::Union{Type{Ptr{P}},Type{Ref{P}}}, a::Array) = Ref{P}(a)
+cconvert{P<:Ptr}(::Type{Ptr{P}}, a::Array{<:Ptr}) = a
+cconvert{P<:Ptr}(::Type{Ref{P}}, a::Array{<:Ptr}) = a
+cconvert{P<:Union{Ptr,Cwstring,Cstring}}(::Type{Ptr{P}}, a::Array) = Ref{P}(a)
+cconvert{P<:Union{Ptr,Cwstring,Cstring}}(::Type{Ref{P}}, a::Array) = Ref{P}(a)
 
 ###
 

--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -64,7 +64,8 @@ end
 
 
 # (2) map[!] entry points
-map{Tf}(f::Tf, A::SparseVecOrMat) = _noshapecheck_map(f, A)
+map{Tf}(f::Tf, A::SparseVector) = _noshapecheck_map(f, A)
+map{Tf}(f::Tf, A::SparseMatrixCSC) = _noshapecheck_map(f, A)
 map{Tf,N}(f::Tf, A::SparseMatrixCSC, Bs::Vararg{SparseMatrixCSC,N}) =
     (_checksameshape(A, Bs...); _noshapecheck_map(f, A, Bs...))
 map{Tf,N}(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseVecOrMat,N}) =
@@ -90,7 +91,8 @@ function _noshapecheck_map{Tf,N}(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseVecO
                         _map_notzeropres!(f, fofzeros, C, A, Bs...)
 end
 # (3) broadcast[!] entry points
-broadcast{Tf}(f::Tf, A::SparseVecOrMat) = _noshapecheck_map(f, A)
+broadcast{Tf}(f::Tf, A::SparseVector) = _noshapecheck_map(f, A)
+broadcast{Tf}(f::Tf, A::SparseMatrixCSC) = _noshapecheck_map(f, A)
 function broadcast!{Tf}(f::Tf, C::SparseVecOrMat)
     isempty(C) && return _finishempty!(C)
     fofnoargs = f()

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -114,7 +114,7 @@ end
 
 # Build up the output until it has length N
 _ntuple{F,N}(out::NTuple{N,Any}, f::F, ::Type{Val{N}}) = out
-function _ntuple{F,N,M}(out::NTuple{M}, f::F, ::Type{Val{N}})
+function _ntuple{F,N,M}(out::NTuple{M,Any}, f::F, ::Type{Val{N}})
     @_inline_meta
     _ntuple((out..., f(M+1)), f, Val{N})
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -23,11 +23,11 @@ f47{T}(x::Vector{Vector{T}}) = 0
 # issue #8652
 args_morespecific(a, b) = ccall(:jl_type_morespecific, Cint, (Any,Any), a, b) != 0
 let
-    a = Tuple{Type{T1}, T1} where T1<:Integer
+    a  = Tuple{Type{T1}, T1} where T1<:Integer
     b2 = Tuple{Type{T2}, Integer} where T2<:Integer
     @test args_morespecific(a, b2)
     @test !args_morespecific(b2, a)
-    a = Tuple{Type{T1}, Ptr{T1}} where T1<:Integer
+    a  = Tuple{Type{T1}, Ptr{T1}} where T1<:Integer
     b2 = Tuple{Type{T2}, Ptr{Integer}} where T2<:Integer
     @test args_morespecific(a, b2)
     @test !args_morespecific(b2, a)
@@ -50,6 +50,18 @@ let
     @test !args_morespecific(a, b)
     @test  args_morespecific(b, a)
 end
+
+# another specificity issue
+_z_z_z_(x, y) = 1
+_z_z_z_(::Int, ::Int, ::Vector) = 2
+_z_z_z_(::Int, c...) = 3
+@test _z_z_z_(1, 1, []) == 2
+
+@test  args_morespecific(Tuple{T,Vararg{T}} where T<:Number,  Tuple{Number,Number,Vararg{Number}})
+@test !args_morespecific(Tuple{Number,Number,Vararg{Number}}, Tuple{T,Vararg{T}} where T<:Number)
+
+@test args_morespecific(Tuple{Array{T} where T<:Union{Float32,Float64,Complex64,Complex128}, Any},
+                        Tuple{Array{T} where T<:Real, Any})
 
 # with bound varargs
 


### PR DESCRIPTION
This began as an attempt to fix the dispatch issue identified here: https://github.com/JuliaComputing/IndexedTables.jl/pull/30#issuecomment-279982528

Fixing that case led to a chain of related bugs, all of which needed to be fixed to get both that case and the rest of the tests passing. This entailed a minor overhaul of the specificity code, fixing a couple todo items and making the logic clearer overall. In particular we should now have the property that at most one of `more_specific(a,b)` and `more_specific(b,a)` can be true, which makes it much easier to reason about the code and was not always true before.