### PR TITLE
Fix fetchheads callback and add tests

### DIFF
--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -258,7 +258,7 @@ end
 function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
                         oid::Ptr{GitHash}, is_merge::Cuint, payload::Ptr{Void})
     fhead_vec = unsafe_pointer_to_objref(payload)::Vector{FetchHead}
-    push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url), GitHash(oid), is_merge == 1))
+    push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url), unsafe_load(oid), is_merge == 1))
     return Cint(0)
 end
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -556,6 +556,16 @@ mktempdir() do dir
             # Switch to the master branch
             LibGit2.branch!(repo, master_branch)
 
+            fetch_heads = LibGit2.fetchheads(repo)
+            @test fetch_heads[1].name == "refs/heads/master"
+            @test fetch_heads[1].ismerge == true #we just merged master
+            @test fetch_heads[2].name == "refs/heads/test_branch"
+            @test fetch_heads[2].ismerge == false
+            @test fetch_heads[3].name == "refs/tags/tag2"
+            @test fetch_heads[3].ismerge == false
+            for fh in fetch_heads
+                @test fh.url == cache_repo
+            end
         finally
             close(repo)
         end


### PR DESCRIPTION
Previously this callback would die because you were trying to make a `GitHash` out of a `Ptr{GitHash}`. @Keno I asked for your review because I think you're familiar with our CB infrastructure. I hope I did this correctly!