### PR TITLE
Fix FileMonitor test case on FreeBSD

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -236,7 +236,11 @@ function test_monitor_wait(tval)
     end
     fname, events = wait(fm)
     close(fm)
-    @test fname == basename(file)
+    if is_linux() || is_windows() || is_apple()
+        @test fname == basename(file)
+    else
+        @test fname == ""  # platforms where F_GETPATH is not available
+    end
     @test events.changed
 end
 


### PR DESCRIPTION
close #8078

On FreeBSD, the F_GETPATH is not available in fcntl.
The path returned by libuv will be NULL.

Ref:
https://github.com/libuv/libuv/blob/309d603382159eacdf52cbf0fa936deb60552d32/src/unix/kqueue.c#L353-L361

And the test case in libuv:
https://github.com/libuv/libuv/blob/309d603382159eacdf52cbf0fa936deb60552d32/test/test-fs-event.c#L315-L318