### PR TITLE
Fix Terminals.hascolor checking on FreeBSD

### DIFF
--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -156,7 +156,11 @@ else
     function hascolor(t::TTYTerminal)
         startswith(t.term_type, "xterm") && return true
         try
-            return success(`tput setaf 0`)
+            @static if Sys.KERNEL == :FreeBSD
+                return success(`tput AF 0`)
+            else
+                return success(`tput setaf 0`)
+            end
         catch
             return false
         end


### PR DESCRIPTION
(not sure why `setaf` not works :p