### PR TITLE
Remove duplicate ctranspose definition for real vectors

### DIFF
--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -75,7 +75,6 @@ julia> transpose(v)
 """
 @inline transpose(vec::AbstractVector) = RowVector(vec)
 @inline ctranspose(vec::AbstractVector) = RowVector(_conj(vec))
-@inline ctranspose(vec::AbstractVector{<:Real}) = RowVector(vec)
 
 @inline transpose(rowvec::RowVector) = rowvec.vec
 @inline transpose(rowvec::ConjRowVector) = copy(rowvec.vec) # remove the ConjArray wrapper from any raw vector


### PR DESCRIPTION
Currently two definitions for `ctranspose(::AbstractVector{<:Real})` exist: one that calls `transpose` and one that wraps the input in `RowVector`. This PR removes the ~~former~~ latter definition to avoid method overwrite warnings during the build.