### PR TITLE
WIP_Update to Windows Profiler

### DIFF
--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -332,16 +332,12 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
         hBtThread = 0;
         return 0;
     }
-
     //Precision timer
     LARGE_INTEGER StartingTime, EndingTime, ElapsedMicroseconds;
     LARGE_INTEGER Frequency;
     QueryPerformanceFrequency(&Frequency);
-
-
     while (1) {
         if (running && bt_size_cur < bt_size_max) {
-            
             //multiply timeout(microseconds) by random factor between 0 and 2
             DWORD timeout = (int)((nsecprof*((double)rand() / (double)RAND_MAX*2.0)/1000));
             //if timeout is greater than a millisecond use Sleep
@@ -353,11 +349,9 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                 while (time_elapsed ==0)
                 {    
                     QueryPerformanceCounter(&EndingTime);
-                    
                     ElapsedMicroseconds.QuadPart = EndingTime.QuadPart - StartingTime.QuadPart;
                     ElapsedMicroseconds.QuadPart *= 1000000;
                     ElapsedMicroseconds.QuadPart /= Frequency.QuadPart;
-
                     if (ElapsedMicroseconds.QuadPart >= timeout)
                     {
                         time_elapsed = 1;
@@ -373,7 +367,6 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
             {
                 Sleep((int)(timeout/1000));
             }
-
             if ((DWORD)-1 == SuspendThread(hMainThread)) {
                 fputs("failed to suspend main thread. aborting profiling.",stderr);
                 break;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -346,7 +346,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                 //calculate start time for high precision sleep
                 QueryPerformanceCounter(&StartingTime);
                 int time_elapsed = 0;
-                while (time_elapsed ==0)
+                while (time_elapsed == 0)
                 {
                     QueryPerformanceCounter(&EndingTime);
                     ElapsedMicroseconds.QuadPart = EndingTime.QuadPart - StartingTime.QuadPart;
@@ -358,7 +358,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     }
                     else
                     {
-                        //if time has not elasped offer up processor to another thread
+                        //if time has not elapsed offer up processor to another thread
                         Sleep(0);
                     }
                 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -341,13 +341,13 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
 
     while (1) {
         if (running && bt_size_cur < bt_size_max) {
-			//calculate start time for high precision sleep
-			QueryPerformanceCounter(&StartingTime);
 			//multiply timeout(microseconds) by random factor between 0 and 2
             DWORD timeout = (int)((nsecprof*((double)rand() / (double)RAND_MAX*2.0)/1000));
 			//if timeout is greater than a millisecond use Sleep
 			if (timeout < 1000)
 			{
+				//calculate start time for high precision sleep
+				QueryPerformanceCounter(&StartingTime);
 				int time_elapsed = 0;
 				while (time_elapsed ==0)
 				{	

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -333,45 +333,46 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
         return 0;
     }
 
-	//Precision timer
-	LARGE_INTEGER StartingTime, EndingTime, ElapsedMicroseconds;
-	LARGE_INTEGER Frequency;
-	QueryPerformanceFrequency(&Frequency);
+    //Precision timer
+    LARGE_INTEGER StartingTime, EndingTime, ElapsedMicroseconds;
+    LARGE_INTEGER Frequency;
+    QueryPerformanceFrequency(&Frequency);
 
 
     while (1) {
         if (running && bt_size_cur < bt_size_max) {
-			//multiply timeout(microseconds) by random factor between 0 and 2
+            
+            //multiply timeout(microseconds) by random factor between 0 and 2
             DWORD timeout = (int)((nsecprof*((double)rand() / (double)RAND_MAX*2.0)/1000));
-			//if timeout is greater than a millisecond use Sleep
-			if (timeout < 1000)
-			{
-				//calculate start time for high precision sleep
-				QueryPerformanceCounter(&StartingTime);
-				int time_elapsed = 0;
-				while (time_elapsed ==0)
-				{	
-					QueryPerformanceCounter(&EndingTime);
-					
-					ElapsedMicroseconds.QuadPart = EndingTime.QuadPart - StartingTime.QuadPart;
-					ElapsedMicroseconds.QuadPart *= 1000000;
-					ElapsedMicroseconds.QuadPart /= Frequency.QuadPart;
+            //if timeout is greater than a millisecond use Sleep
+            if (timeout < 1000)
+            {
+                //calculate start time for high precision sleep
+                QueryPerformanceCounter(&StartingTime);
+                int time_elapsed = 0;
+                while (time_elapsed ==0)
+                {    
+                    QueryPerformanceCounter(&EndingTime);
+                    
+                    ElapsedMicroseconds.QuadPart = EndingTime.QuadPart - StartingTime.QuadPart;
+                    ElapsedMicroseconds.QuadPart *= 1000000;
+                    ElapsedMicroseconds.QuadPart /= Frequency.QuadPart;
 
-					if (ElapsedMicroseconds.QuadPart >= timeout)
-					{
-						time_elapsed = 1;
-					}
-					else
-					{
-						//if time has not elasped offer up processor to another thread
-						Sleep(0);
-					}
-				}
-			}
-			else
-			{
-				Sleep((int)(timeout/1000));
-			}
+                    if (ElapsedMicroseconds.QuadPart >= timeout)
+                    {
+                        time_elapsed = 1;
+                    }
+                    else
+                    {
+                        //if time has not elasped offer up processor to another thread
+                        Sleep(0);
+                    }
+                }
+            }
+            else
+            {
+                Sleep((int)(timeout/1000));
+            }
 
             if ((DWORD)-1 == SuspendThread(hMainThread)) {
                 fputs("failed to suspend main thread. aborting profiling.",stderr);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -338,8 +338,8 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
     QueryPerformanceFrequency(&Frequency);
     while (1) {
         if (running && bt_size_cur < bt_size_max) {
-            //multiply timeout(microseconds) by random factor between 0 and 2
-            DWORD timeout = (int)((nsecprof*((double)rand() / (double)RAND_MAX*2.0)/1000));
+            //Convert timeout to microseconds
+            DWORD timeout = nsecprof/1000;
             //if timeout is greater than a millisecond use Sleep
             if (timeout < 1000)
             {

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -347,7 +347,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                 QueryPerformanceCounter(&StartingTime);
                 int time_elapsed = 0;
                 while (time_elapsed ==0)
-                {    
+                {
                     QueryPerformanceCounter(&EndingTime);
                     ElapsedMicroseconds.QuadPart = EndingTime.QuadPart - StartingTime.QuadPart;
                     ElapsedMicroseconds.QuadPart *= 1000000;


### PR DESCRIPTION
#9224 
I've made two changes to the Profiler on Windows.
 - Randomised the time interval between samples. The interval is multiplied by a random number between 0 and 2.
- Utilised QPC to achieve microsecond sleep intervals. The use of Sleep(0) is key as it offers the rest of the time slice allocated to the Profiler thread to other threads of the same priority. 

@timholy 