### PR TITLE
WIP: Add an iterator implementation for String splitting

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -753,6 +753,7 @@ export
     digits!,
     dump,
     eachmatch,
+    eachsplit,
     endswith,
     escape_string,
     graphemes,

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -77,6 +77,24 @@ end
 #@test isequal(rsplit("a b c"), ["a","b","c"])
 #@test isequal(rsplit("a  b \t c\n"), ["a","b","c"])
 
+@test isequal(collect(eachsplit("foo,bar,baz", 'x')), ["foo,bar,baz"])
+@test isequal(collect(eachsplit("foo,bar,baz", ',')), ["foo","bar","baz"])
+@test isequal(collect(eachsplit("foo,bar,baz", ",")), ["foo","bar","baz"])
+@test isequal(collect(eachsplit("foo,bar,baz", r",")), ["foo","bar","baz"])
+@test isequal(collect(eachsplit("foo,bar,baz", ','; limit=0)), ["foo","bar","baz"])
+@test isequal(collect(eachsplit("foo,bar,baz", ','; limit=1)), ["foo,bar,baz"])
+@test isequal(collect(eachsplit("foo,bar,baz", ','; limit=2)), ["foo","bar,baz"])
+@test isequal(collect(eachsplit("foo,bar,baz", ','; limit=3)), ["foo","bar","baz"])
+@test isequal(collect(eachsplit("foo,bar", "o,b")), ["fo","ar"])
+
+@test isequal(collect(eachsplit("", ',')), [""])
+@test isequal(collect(eachsplit(",", ',')), ["",""])
+@test isequal(collect(eachsplit(",,", ',')), ["","",""])
+@test isequal(collect(eachsplit(",,", ','; limit=2)), [",",""])
+@test isequal(collect(eachsplit("", ','  ; keep=false)), [])
+@test isequal(collect(eachsplit(",", ',' ; keep=false)), [])
+@test isequal(collect(eachsplit(",,", ','; keep=false)), [])
+
 let str = "a.:.ba..:..cba.:.:.dcba.:."
 @test isequal(split(str, ".:."), ["a","ba.",".cba",":.dcba",""])
 @test isequal(split(str, ".:."; keep=false), ["a","ba.",".cba",":.dcba"])
@@ -93,6 +111,14 @@ let str = "a.:.ba..:..cba.:.:.dcba.:."
 @test isequal(rsplit(str, ".:."; limit=4), ["a.:.ba.", ".cba.:", "dcba", ""])
 @test isequal(rsplit(str, ".:."; limit=5), ["a", "ba.", ".cba.:", "dcba", ""])
 @test isequal(rsplit(str, ".:."; limit=6), ["a", "ba.", ".cba.:", "dcba", ""])
+
+@test isequal(collect(eachsplit(str, ".:.")), ["a","ba.",".cba.:","dcba",""])
+@test isequal(collect(eachsplit(str, ".:."; keep=false)), ["a","ba.",".cba.:","dcba"])
+@test isequal(collect(eachsplit(str, ".:."; limit=2)), ["a.:.ba..:..cba.:.:.dcba", ""])
+@test isequal(collect(eachsplit(str, ".:."; limit=3)), ["a.:.ba..:..cba.:", "dcba", ""])
+@test isequal(collect(eachsplit(str, ".:."; limit=4)), ["a.:.ba.", ".cba.:", "dcba", ""])
+@test isequal(collect(eachsplit(str, ".:."; limit=5)), ["a", "ba.", ".cba.:", "dcba", ""])
+@test isequal(collect(eachsplit(str, ".:."; limit=6)), ["a", "ba.", ".cba.:", "dcba", ""])
 end
 
 # zero-width splits
@@ -112,6 +138,21 @@ end
 @test isequal(split("abcd", r"d*"), ["a","b","c",""])
 @test isequal(split("abcd", r"d+"), ["abc",""])
 @test isequal(split("abcd", r"[ad]?"), ["","b","c",""])
+
+@test isequal(collect(eachsplit("", "")), [""])
+@test isequal(collect(eachsplit("", r"")), [""])
+@test isequal(collect(eachsplit("abc", "")), ["a","b","c"])
+@test isequal(collect(eachsplit("abc", r"")), ["a","b","c"])
+@test isequal(collect(eachsplit("abcd", r"b?")), ["a","c","d"])
+@test isequal(collect(eachsplit("abcd", r"b*")), ["a","c","d"])
+@test isequal(collect(eachsplit("abcd", r"b+")), ["a","cd"])
+@test isequal(collect(eachsplit("abcd", r"b?c?")), ["a","d"])
+@test isequal(collect(eachsplit("abcd", r"[bc]?")), ["a","","d"])
+@test isequal(collect(eachsplit("abcd", r"a*")), ["","b","c","d"])
+@test isequal(collect(eachsplit("abcd", r"a+")), ["","bcd"])
+@test isequal(collect(eachsplit("abcd", r"d*")), ["a","b","c",""])
+@test isequal(collect(eachsplit("abcd", r"d+")), ["abc",""])
+@test isequal(collect(eachsplit("abcd", r"[ad]?")), ["","b","c",""])
 
 # replace
 @test replace("\u2202", '*', '\0') == "\u2202"


### PR DESCRIPTION
Per-request of #20603 and also addresses #20628. Simple timing benchmarks show that using and collecting from these iterators are slower and cause more memory allocation.

Here's a sample timing after warming up the JIT:

```julia
julia> str = randstring(1_000_000);

# without iterator
julia> @time split(str, "a");
  0.005106 seconds (16.20 k allocations: 762.641 KB)

# with iterator
julia> @time collect(split(str, "a"));
  0.012568 seconds (194.29 k allocations: 3.957 MiB)
```

For a small string:

```julia
julia> small_str = "how-now-brown-cow";

# without iterator
julia> @time collect(split(small_str, "-"));
  0.000012 seconds (12 allocations: 544 bytes)

# with iterator
julia> @time collect(split(small_str, "-"));
  0.000048 seconds (20 allocations: 768 bytes)
```

This performance issue also seems to afflict the `GraphemeIterator` which is constructed by `graphemes(::AbstractString)` which can be optimized by implementing it as `split(str, "")` rather than returning an iterator.

Some tests are currently broken since downstream uses of `split` expect an array-like value where `length` and `getindex` can be called.

Looking for feedback before fixing these tests to see whether the maintainers-at-large still think that this abstraction is worth the performance cost or whether the unexpected allocations should be investigated.