### PR TITLE
Dict merge(!) with combiner function

### DIFF
--- a/base/associative.jl
+++ b/base/associative.jl
@@ -146,6 +146,44 @@ function merge!(d::Associative, others::Associative...)
     return d
 end
 
+"""
+    merge!(combine, d::Associative, others::Associative...)
+
+Update collection with pairs from the other collections.
+Values with the same key will be combined using the
+combiner function.
+
+```jldoctest
+julia> d1 = Dict(1 => 2, 3 => 4);
+
+julia> d2 = Dict(1 => 4, 4 => 5);
+
+julia> merge!(+, d1, d2);
+
+julia> d1
+Dict{Int64,Int64} with 3 entries:
+  4 => 5
+  3 => 4
+  1 => 6
+
+julia> merge!(-, d1, d1);
+
+julia> d1
+Dict{Int64,Int64} with 3 entries:
+  4 => 0
+  3 => 0
+  1 => 0
+```
+"""
+function merge!(combine::Function, d::Associative, others::Associative...)
+    for other in others
+        for (k,v) in other
+            d[k] = haskey(d, k) ? combine(d[k], v) : v
+        end
+    end
+    return d
+end
+
 # very similar to `merge!`, but accepts any iterable and extends code
 # that would otherwise only use `copy!` with arrays.
 function copy!(dest::Union{Associative,AbstractSet}, src)
@@ -215,13 +253,45 @@ Dict{String,Float64} with 3 entries:
   "foo" => 0.0
 ```
 """
-function merge(d::Associative, others::Associative...)
+merge(d::Associative, others::Associative...) =
+    merge!(emptymergedict(d, others...), d, others...)
+
+"""
+    merge(combine, d::Associative, others::Associative...)
+
+Construct a merged collection from the given collections. If necessary, the
+types of the resulting collection will be promoted to accommodate the types of
+the merged collections. Values with the same key will be combined using the
+combiner function.
+
+```jldoctest
+julia> a = Dict("foo" => 0.0, "bar" => 42.0)
+Dict{String,Float64} with 2 entries:
+  "bar" => 42.0
+  "foo" => 0.0
+
+julia> b = Dict("baz" => 17, "bar" => 4711)
+Dict{String,Int64} with 2 entries:
+  "bar" => 4711
+  "baz" => 17
+
+julia> merge(+, a, b)
+Dict{String,Float64} with 3 entries:
+  "bar" => 4753.0
+  "baz" => 17.0
+  "foo" => 0.0
+```
+"""
+merge(combine::Function, d::Associative, others::Associative...) =
+    merge!(combine, emptymergedict(d, others...), d, others...)
+
+function emptymergedict(d::Associative, others::Associative...)
     K, V = keytype(d), valtype(d)
     for other in others
         K = promote_type(K, keytype(other))
         V = promote_type(V, valtype(other))
     end
-    merge!(Dict{K,V}(), d, others...)
+    Dict{K,V}()
 end
 
 function filter!(f, d::Associative)

--- a/base/associative.jl
+++ b/base/associative.jl
@@ -285,12 +285,13 @@ Dict{String,Float64} with 3 entries:
 merge(combine::Function, d::Associative, others::Associative...) =
     merge!(combine, emptymergedict(d, others...), d, others...)
 
+promoteK(K) = K
+promoteV(V) = V
+promoteK(K, d, ds...) = promoteK(promote_type(K, keytype(d)), ds...)
+promoteV(V, d, ds...) = promoteV(promote_type(V, valtype(d)), ds...)
 function emptymergedict(d::Associative, others::Associative...)
-    K, V = keytype(d), valtype(d)
-    for other in others
-        K = promote_type(K, keytype(other))
-        V = promote_type(V, valtype(other))
-    end
+    K = promoteK(keytype(d), others...)
+    V = promoteV(valtype(d), others...)
     Dict{K,V}()
 end
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -682,3 +682,32 @@ let
         @test pair[1] == tupl[1] && pair[2] == tupl[2]
     end
 end
+
+@testset "Dict merge" begin
+    d1 = Dict("A" => 1, "B" => 2)
+    d2 = Dict("B" => 3.0, "C" => 4.0)
+    d3 = merge(d1, d2)
+    @test d3 == Dict("A" => 1, "B" => 3, "C" => 4)
+    # merge with combiner function
+    d4 = merge(+, d1, d2)
+    @test d4 == Dict("A" => 1, "B" => 5, "C" => 4)
+    d5 = merge(*, d1, d2)
+    @test d5 == Dict("A" => 1, "B" => 6, "C" => 4)
+    d6 = merge(-, d1, d2)
+    @test d6 == Dict("A" => 1, "B" => -1, "C" => 4)
+    @test typeof(d3) == typeof(d4) == typeof(d5) == typeof(d6) == Dict{String,Float64}
+end
+
+@testset "Dict merge!" begin
+    d1 = Dict("A" => 1, "B" => 2)
+    d2 = Dict("B" => 3, "C" => 4)
+    merge!(d1, d2)
+    @test d1 == Dict("A" => 1, "B" => 3, "C" => 4)
+    # merge! with combiner function
+    merge!(+, d1, d2)
+    @test d1 == Dict("A" => 1, "B" => 6, "C" => 8)
+    merge!(*, d1, d2)
+    @test d1 == Dict("A" => 1, "B" => 18, "C" => 32)
+    merge!(-, d1, d2)
+    @test d1 == Dict("A" => 1, "B" => 15, "C" => 28)
+end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -686,28 +686,23 @@ end
 @testset "Dict merge" begin
     d1 = Dict("A" => 1, "B" => 2)
     d2 = Dict("B" => 3.0, "C" => 4.0)
-    d3 = merge(d1, d2)
-    @test d3 == Dict("A" => 1, "B" => 3, "C" => 4)
+    @test @inferred merge(d1, d2) == Dict("A" => 1, "B" => 3, "C" => 4)
     # merge with combiner function
-    d4 = merge(+, d1, d2)
-    @test d4 == Dict("A" => 1, "B" => 5, "C" => 4)
-    d5 = merge(*, d1, d2)
-    @test d5 == Dict("A" => 1, "B" => 6, "C" => 4)
-    d6 = merge(-, d1, d2)
-    @test d6 == Dict("A" => 1, "B" => -1, "C" => 4)
-    @test typeof(d3) == typeof(d4) == typeof(d5) == typeof(d6) == Dict{String,Float64}
+    @test @inferred merge(+, d1, d2) == Dict("A" => 1, "B" => 5, "C" => 4)
+    @test @inferred merge(*, d1, d2) == Dict("A" => 1, "B" => 6, "C" => 4)
+    @test @inferred merge(-, d1, d2) == Dict("A" => 1, "B" => -1, "C" => 4)
 end
 
 @testset "Dict merge!" begin
     d1 = Dict("A" => 1, "B" => 2)
     d2 = Dict("B" => 3, "C" => 4)
-    merge!(d1, d2)
+    @inferred merge!(d1, d2)
     @test d1 == Dict("A" => 1, "B" => 3, "C" => 4)
     # merge! with combiner function
-    merge!(+, d1, d2)
+    @inferred merge!(+, d1, d2)
     @test d1 == Dict("A" => 1, "B" => 6, "C" => 8)
-    merge!(*, d1, d2)
+    @inferred merge!(*, d1, d2)
     @test d1 == Dict("A" => 1, "B" => 18, "C" => 32)
-    merge!(-, d1, d2)
+    @inferred merge!(-, d1, d2)
     @test d1 == Dict("A" => 1, "B" => 15, "C" => 28)
 end


### PR DESCRIPTION
Implements part A of https://github.com/JuliaLang/julia/issues/20699

Did not find any tests for `merge(!)` without combiner function so I added that.

A bit of code duplication though. Something like this:

```diff
diff --git a/base/associative.jl b/base/associative.jl
-function merge!(d::Associative, others::Associative...)
-    for other in others
-        for (k,v) in other
-            d[k] = v
-        end
-    end
-    return d
-end
+merge!(d::Associative, others::Associative...) = merge!((i, j)-> j, d, others...)
```


could be applied but would result in a slower `merge!`. Thoughts?