### PR TITLE
Add imports and module qualifiers for Distributed

### DIFF
--- a/base/distributed/Distributed.jl
+++ b/base/distributed/Distributed.jl
@@ -4,7 +4,7 @@ module Distributed
 
 # imports for extension
 import Base: getindex, wait, put!, take!, fetch, isready, push!, length,
-             hash, ==, connect, kill, serialize, deserialize, close
+             hash, ==, connect, kill, serialize, deserialize, close, showerror
 
 # imports for use
 using Base: Process, Semaphore, JLOptions, AnyDict, buffer_writes, wait_connected,

--- a/base/distributed/Distributed.jl
+++ b/base/distributed/Distributed.jl
@@ -10,7 +10,7 @@ import Base: getindex, wait, put!, take!, fetch, isready, push!, length,
 using Base: Process, Semaphore, JLOptions, AnyDict, buffer_writes, wait_connected,
             VERSION_STRING, sync_begin, sync_add, sync_end, async_run_thunk,
             binding_module, notify_error, atexit, julia_exename, julia_cmd,
-            AsyncGenerator, display_error
+            AsyncGenerator, display_error, acquire, release
 
 # NOTE: clusterserialize.jl imports additional symbols from Base.Serializer for use
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -922,7 +922,7 @@ if DoFullTest
     # Test sending fake data to workers. The worker processes will print an
     # error message but should not terminate.
     for w in Base.Distributed.PGRP.workers
-        if isa(w, Base.Worker)
+        if isa(w, Base.Distributed.Worker)
             s = connect(get(w.config.host), get(w.config.port))
             write(s, randstring(32))
         end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1269,6 +1269,7 @@ end
 if DoFullTest
     pids=addprocs(4);
     @test_throws ErrorException rmprocs(pids; waitfor=0.001);
+    rmprocs(pids)
 end
 
 # Auto serialization of globals from Main.

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -43,7 +43,7 @@ function Base.launch(manager::TopoTestManager, params::Dict, launched::Array, c:
 
     for i in 1:manager.np
         io, pobj = open(pipeline(detach(
-            setenv(`$(Base.julia_cmd(exename)) $exeflags --bind-to $(Base.LPROC.bind_addr) --worker $(Base.cluster_cookie())`, dir=dir)); stderr=STDERR), "r")
+            setenv(`$(Base.julia_cmd(exename)) $exeflags --bind-to $(Base.Distributed.LPROC.bind_addr) --worker $(Base.cluster_cookie())`, dir=dir)); stderr=STDERR), "r")
         wconfig = WorkerConfig()
         wconfig.process = pobj
         wconfig.io = io


### PR DESCRIPTION
helps more of `JULIA_TESTFULL=1 make testall` pass

same spirit as https://github.com/JuliaLang/julia/pull/20647

I'm not set up to properly run the passwordless ssh tests, so not sure whether those are working. @amitmurthy can you test that?