### PR TITLE
Fix doc build in cygwin cross-compile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -32,32 +32,32 @@ cleanall: clean
 html: deps
 	@echo "Building HTML documentation."
 ifneq ($(OS),WINNT)
-	$(JULIA_EXECUTABLE) $(SRCDIR)/make.jl -- deploy
+	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy
 else
 # work around issue #11727, windows output redirection breaking on buildbot
-	$(JULIA_EXECUTABLE) $(SRCDIR)/make.jl -- deploy > docbuild.log 2>&1
+	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy > docbuild.log 2>&1
 	@cat docbuild.log
 endif
 	@echo "Build finished. The HTML pages are in _build/html."
 
 pdf: deps
 	@echo "Building PDF documentation."
-	$(JULIA_EXECUTABLE) $(SRCDIR)/make.jl -- pdf
+	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) -- pdf
 	@echo "Build finished."
 
 linkcheck: deps
 	@echo "Checking external documentation links."
-	$(JULIA_EXECUTABLE) $(SRCDIR)/make.jl -- linkcheck
+	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) -- linkcheck
 	@echo "Checks finished."
 
 doctest: deps
 	@echo "Running all embedded 'doctests'."
-	$(JULIA_EXECUTABLE) --color=yes $(SRCDIR)/make.jl -- doctest
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- doctest
 	@echo "Checks finished."
 
 check: deps
 	@echo "Running all embedded 'doctests' and checking external links."
-	$(JULIA_EXECUTABLE) --color=yes $(SRCDIR)/make.jl -- doctest linkcheck
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- doctest linkcheck
 	@echo "Checks finished."
 
 .PHONY: deps


### PR DESCRIPTION
need `cygpath_w` to translate absolute paths from cygwin-style to windows for mingw julia executable to understand them

fixes buildbot failure seen at https://build.julialang.org/builders/package_win6.2-x64/builds/1346/steps/make%20binary-dist/logs/stdio
was broken by me in #20519, didn't notice until now because of #20643 preventing the buildbots from making new nightlies