### PR TITLE
fix #20704, `pure` annotation should not skip method errors

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -64,7 +64,9 @@ end
 # The type of a value might be constant
 struct Const
     val
-    Const(v::ANY) = new(v)
+    actual::Bool  # if true, we obtained `val` by actually calling a @pure function
+    Const(v::ANY) = new(v, false)
+    Const(v::ANY, a::Bool) = new(v, a)
 end
 
 # The type of a value might be Bool,
@@ -191,7 +193,7 @@ mutable struct InferenceState
                     vararg_type = rewrap(vararg_type, linfo.specTypes)
                 end
                 s_types[1][la] = VarState(vararg_type, false)
-                src.slottypes[la] = widenconst(vararg_type)
+                src.slottypes[la] = vararg_type
                 la -= 1
             end
         end
@@ -220,11 +222,11 @@ mutable struct InferenceState
                 end
                 i == laty && (lastatype = atyp)
                 s_types[1][i] = VarState(atyp, false)
-                src.slottypes[i] = widenconst(atyp)
+                src.slottypes[i] = atyp
             end
             for i = (atail + 1):la
                 s_types[1][i] = VarState(lastatype, false)
-                src.slottypes[i] = widenconst(lastatype)
+                src.slottypes[i] = lastatype
             end
         else
             @assert la == 0 # wrong number of arguments
@@ -1546,7 +1548,7 @@ function return_type_tfunc(argtypes::ANY, vtypes::VarTable, sv::InferenceState)
     return NF
 end
 
-function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv::InferenceState)
+function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, sv::InferenceState)
     for i = 2:length(argtypes)
         a = argtypes[i]
         if !(isa(a,Const) || isconstType(a))
@@ -1571,7 +1573,7 @@ function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, vtypes::VarTable, sv:
     try
         value = Core._apply_pure(f, args)
         # TODO: add some sort of edge(s)
-        return abstract_eval_constant(value)
+        return Const(value, true)
     catch
         return false
     end
@@ -1807,7 +1809,7 @@ function abstract_call(f::ANY, fargs::Union{Tuple{},Vector{Any}}, argtypes::Vect
     end
 
     atype = argtypes_to_type(argtypes)
-    t = pure_eval_call(f, argtypes, atype, vtypes, sv)
+    t = pure_eval_call(f, argtypes, atype, sv)
     t !== false && return t
 
     if istopfunction(tm, f, :promote_type) || istopfunction(tm, f, :typejoin)
@@ -1979,14 +1981,7 @@ function abstract_eval(e::ANY, vtypes::VarTable, sv::InferenceState)
     return t
 end
 
-const Type_Array = Const(Array)
-
-function abstract_eval_constant(x::ANY)
-    if x === Array
-        return Type_Array
-    end
-    return Const(x)
-end
+const abstract_eval_constant = Const
 
 function abstract_eval_global(M::Module, s::Symbol)
     if isdefined(M,s) && isconst(M,s)
@@ -2930,28 +2925,33 @@ function optimize(me::InferenceState)
 
     if isa(me.bestguess, Const) || isconstType(me.bestguess)
         me.const_ret = true
-        ispure = me.src.pure
-        if !ispure && length(me.src.code) < 10
-            ispure = true
+        proven_pure = false
+        # must be proven pure to use const_api; otherwise we might skip throwing errors
+        # (issue #20704)
+        # TODO: Improve this analysis; if a function is marked @pure we should really
+        # only care about certain errors (e.g. method errors and type errors).
+        if length(me.src.code) < 10
+            proven_pure = true
             for stmt in me.src.code
                 if !statement_effect_free(stmt, me.src, me.mod)
-                    ispure = false
+                    proven_pure = false
                     break
                 end
             end
-            if ispure
+            if proven_pure
                 for fl in me.src.slotflags
                     if (fl & Slot_UsedUndef) != 0
-                        ispure = false
+                        proven_pure = false
                         break
                     end
                 end
             end
         end
-        me.src.pure = ispure
+        if proven_pure
+            me.src.pure = true
+        end
 
-        do_coverage = coverage_enabled()
-        if ispure && !do_coverage
+        if proven_pure && !coverage_enabled()
             # use constant calling convention
             # Do not emit `jlcall_api == 2` if coverage is enabled
             # so that we don't need to add coverage support
@@ -3082,7 +3082,7 @@ function annotate_slot_load!(e::Expr, vtypes::VarTable, sv::InferenceState, unde
                 undefs[id] = true
             end
             #  add type annotations where needed
-            if !(sv.src.slottypes[id] <: vt)
+            if !(sv.src.slottypes[id] ⊑ vt)
                 e.args[i] = TypedSlot(id, vt)
             end
         end
@@ -3225,6 +3225,7 @@ end
 # we also need to preserve the type for any untyped load of a DataType
 # since codegen optimizations of functions like `is` will depend on knowing it
 function widen_slot_type(ty::ANY, untypedload::Bool)
+    ty = widenconst(ty)
     if isa(ty, DataType)
         if untypedload || isbits(ty) || isdefined(ty, :instance)
             return ty
@@ -3770,21 +3771,24 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
                                   atype_unlimited, method.sig)
         methsp = methsp::SimpleVector
     end
-    # check whether call can be inlined to just a quoted constant value
-    if isa(f, widenconst(ft)) && !method.isstaged && (method.source.pure || f === return_type)
-        if isconstType(e.typ)
-            return inline_as_constant(e.typ.parameters[1], argexprs, sv,
-                                      invoke_data)
-        elseif isa(e.typ,Const)
-            return inline_as_constant(e.typ.val, argexprs, sv,
-                                      invoke_data)
-        end
-    end
 
     methsig = method.sig
     if !(atype <: metharg)
         return invoke_NF(argexprs, e.typ, atypes, sv, atype_unlimited,
                          invoke_data)
+    end
+
+    # check whether call can be inlined to just a quoted constant value
+    if isa(f, widenconst(ft)) && !method.isstaged
+        if f === return_type
+            if isconstType(e.typ)
+                return inline_as_constant(e.typ.parameters[1], argexprs, sv, invoke_data)
+            elseif isa(e.typ,Const)
+                return inline_as_constant(e.typ.val, argexprs, sv, invoke_data)
+            end
+        elseif method.source.pure && isa(e.typ,Const) && e.typ.actual
+            return inline_as_constant(e.typ.val, argexprs, sv, invoke_data)
+        end
     end
 
     argexprs0 = argexprs


### PR DESCRIPTION
There were two issues here:

1. We should not inline a call to a `@pure` function as a constant unless the inferred argument type is a subtype of the method signature, to be sure there is no MethodError.
2. Even if a function is marked `@pure` and is inferred to return a constant, we should not use the constant calling convention (CCC) for it unless we can prove it `effect_free`. That's because the CCC is equivalent to deleting the entire body of the function, which is not the same thing as calling the function at a different time.

Item (1) is an uncontroversial bug fix. Item (2) is more of an interesting corner case. I think most people would agree that if you put `@pure` on a function that prints, you shouldn't be surprised to see the printed output more or fewer times than you expected (including zero times). Similarly, consider

```
@pure function f()
    if isdir("/")
        error()
    end
    return 42
end
```

Here I'd even say it's ok to skip throwing the error, since who's to say whether `isdir("/")` is true in the imaginary land of pure functions. However I think method errors are different. We can only conclude that a function returns `x` if it actually calls a method that returns `x`. If the method that returns `x` is not called at all for a certain argument, it can't be the result even of a pure function.