### PR TITLE
Add a DiffStat type, methods, and tests

### DIFF
--- a/base/libgit2/diff.jl
+++ b/base/libgit2/diff.jl
@@ -34,6 +34,26 @@ function diff_tree(repo::GitRepo, oldtree::GitTree, newtree::GitTree)
     return GitDiff(repo, diff_ptr_ptr[])
 end
 
+function GitDiffStats(diff::GitDiff)
+    diff_stat_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
+    @check ccall((:git_diff_get_stats, :libgit2), Cint,
+                  (Ptr{Ptr{Void}}, Ptr{Void}),
+                  diff_stat_ptr_ptr, diff.ptr)
+    return GitDiffStats(diff_stat_ptr_ptr[])
+end
+
+function files_changed(diff_stat::GitDiffStats)
+    return ccall((:git_diff_stats_files_changed, :libgit2), Csize_t, (Ptr{Void},), diff_stat.ptr)
+end
+
+function insertions(diff_stat::GitDiffStats)
+    return ccall((:git_diff_stats_insertions, :libgit2), Csize_t, (Ptr{Void},), diff_stat.ptr)
+end
+
+function deletions(diff_stat::GitDiffStats)
+    return ccall((:git_diff_stats_deletions, :libgit2), Csize_t, (Ptr{Void},), diff_stat.ptr)
+end
+
 function Base.count(diff::GitDiff)
     return ccall((:git_diff_num_deltas, :libgit2), Cint, (Ptr{Void},), diff.ptr)
 end
@@ -46,4 +66,17 @@ function Base.getindex(diff::GitDiff, i::Integer)
                       Ptr{DiffDelta},
                       (Ptr{Void}, Csize_t), diff.ptr, i-1)
     return unsafe_load(delta_ptr)
+end
+
+function Base.show(io::IO, diff_stat::GitDiffStats)
+    println(io, "GitDiffStats:")
+    println(io, "Files changed: $(files_changed(diff_stat))")
+    println(io, "Insertions: $(insertions(diff_stat))")
+    println(io, "Deletions: $(deletions(diff_stat))")
+end
+
+function Base.show(io::IO, diff::GitDiff)
+    println(io, "GitDiff:")
+    println(io, "Number of deltas: $(count(diff))")
+    show(io, GitDiffStats(diff))
 end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -471,23 +471,24 @@ Base.isempty(obj::AbstractGitObject) = (obj.ptr == C_NULL)
 abstract type GitObject <: AbstractGitObject end
 
 for (typ, reporef, sup, cname) in [
-    (:GitRepo,       nothing,   :AbstractGitObject, :git_repository),
-    (:GitTreeEntry,  nothing,   :AbstractGitObject, :git_tree_entry),
-    (:GitConfig,     :Nullable, :AbstractGitObject, :git_config),
-    (:GitIndex,      :Nullable, :AbstractGitObject, :git_index),
-    (:GitRemote,     :GitRepo,  :AbstractGitObject, :git_remote),
-    (:GitRevWalker,  :GitRepo,  :AbstractGitObject, :git_revwalk),
-    (:GitReference,  :GitRepo,  :AbstractGitObject, :git_reference),
-    (:GitDiff,       :GitRepo,  :AbstractGitObject, :git_diff),
-    (:GitAnnotated,  :GitRepo,  :AbstractGitObject, :git_annotated_commit),
-    (:GitRebase,     :GitRepo,  :AbstractGitObject, :git_rebase),
-    (:GitStatus,     :GitRepo,  :AbstractGitObject, :git_status_list),
-    (:GitBranchIter, :GitRepo,  :AbstractGitObject, :git_branch_iterator),
-    (:GitUnknownObject,  :GitRepo,  :GitObject,         :git_object),
-    (:GitCommit,     :GitRepo,  :GitObject,         :git_commit),
-    (:GitBlob,       :GitRepo,  :GitObject,         :git_blob),
-    (:GitTree,       :GitRepo,  :GitObject,         :git_tree),
-    (:GitTag,        :GitRepo,  :GitObject,         :git_tag)]
+    (:GitRepo,          nothing,   :AbstractGitObject, :git_repository),
+    (:GitTreeEntry,     nothing,   :AbstractGitObject, :git_tree_entry),
+    (:GitDiffStats,     nothing,   :AbstractGitObject, :git_diff_stats),
+    (:GitConfig,        :Nullable, :AbstractGitObject, :git_config),
+    (:GitIndex,         :Nullable, :AbstractGitObject, :git_index),
+    (:GitRemote,        :GitRepo,  :AbstractGitObject, :git_remote),
+    (:GitRevWalker,     :GitRepo,  :AbstractGitObject, :git_revwalk),
+    (:GitReference,     :GitRepo,  :AbstractGitObject, :git_reference),
+    (:GitDiff,          :GitRepo,  :AbstractGitObject, :git_diff),
+    (:GitAnnotated,     :GitRepo,  :AbstractGitObject, :git_annotated_commit),
+    (:GitRebase,        :GitRepo,  :AbstractGitObject, :git_rebase),
+    (:GitStatus,        :GitRepo,  :AbstractGitObject, :git_status_list),
+    (:GitBranchIter,    :GitRepo,  :AbstractGitObject, :git_branch_iterator),
+    (:GitUnknownObject, :GitRepo,  :GitObject,         :git_object),
+    (:GitCommit,        :GitRepo,  :GitObject,         :git_commit),
+    (:GitBlob,          :GitRepo,  :GitObject,         :git_blob),
+    (:GitTree,          :GitRepo,  :GitObject,         :git_tree),
+    (:GitTag,           :GitRepo,  :GitObject,         :git_tag)]
 
     if reporef === nothing
         @eval mutable struct $typ <: $sup

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -534,6 +534,13 @@ mktempdir() do dir
                 @test contains(diff_strs[8], "Size:")
                 @test isempty(diff_strs[9])
                 @test diff_strs[10] == "New file:"
+                diff_strs = split(sprint(show, diff), '\n')
+                @test diff_strs[1] == "GitDiff:"
+                @test diff_strs[2] == "Number of deltas: 1"
+                @test diff_strs[3] == "GitDiffStats:"
+                @test diff_strs[4] == "Files changed: 1"
+                @test diff_strs[5] == "Insertions: 1"
+                @test diff_strs[6] == "Deletions: 0"
                 LibGit2.commit(repo, "zzz")
                 @test !LibGit2.isdirty(repo)
                 @test !LibGit2.isdiff(repo, "HEAD")


### PR DESCRIPTION
Create a DiffStat type so that we can get more information
about GitDiffs. Add a show method for this type and GitDiff.
Also add methods to get the number of files changed/insertions/
deletions in the diff.