### PR TITLE
bug fix for x^Val{p} (fixes problem noted in #20648)

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -444,7 +444,7 @@ end
 ^(x::Bool   , y::BigInt ) = Base.power_by_squaring(x, y)
 
 # override default inlining of x^2 and x^3 etc.
-^{p}(x::BigInt, ::Type{Val{p}}) = x^Culong(p)
+^{p}(x::BigInt, ::Type{Val{p}}) = x^p
 
 function powermod(x::BigInt, p::BigInt, m::BigInt)
     r = BigInt()

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -505,7 +505,7 @@ end
 ^(x::BigFloat, y::Unsigned) = typemin(Culong) <= y <= typemax(Culong) ? x^Culong(y) : x^BigInt(y)
 
 # override default inlining of x^2 etc.
-^{p}(x::BigFloat, ::Type{Val{p}}) = x^Culong(p)
+^{p}(x::BigFloat, ::Type{Val{p}}) = x^p
 
 for f in (:exp, :exp2, :exp10, :expm1, :cosh, :sinh, :tanh, :sech, :csch, :coth, :cbrt)
     @eval function $f(x::BigFloat)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2912,6 +2912,17 @@ immutable PR20530; end
     @test x^p == 1
     @test x^2 == 2
     @test [x,x,x].^2 == [2,2,2]
+    for T in (Float16, Float32, Float64, BigFloat, Int8, Int, BigInt, Complex{Int}, Complex{Float64})
+        for p in -4:4
+            if p < 0 && real(T) <: Integer
+                @test_throws DomainError eval(:($T(2)^$p))
+            else
+                v = eval(:($T(2)^$p))
+                @test 2.0^p == T(2)^p == v
+                @test v isa T
+            end
+        end
+    end
 end
 
 @testset "iszero" begin


### PR DESCRIPTION
Fixes incorrect unsigned cast in #20648 noted by @tkelman, and adds more tests.