### PR TITLE
Fix corner case with LibGit2 SCP-like syntax parsing

### DIFF
--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -1,10 +1,19 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+# Parse "GIT URLs" syntax (URLs and a scp-like syntax). For details see:
+# https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a
 const URL_REGEX = r"""
-^(?:(?<scheme>https?|git|ssh)\:\/\/)?
-(?:(?<user>.*?)(?:\:(?<password>.*?))?@)?
+^(?:(?<scheme>ssh|git|https?)://)?
+(?:
+    (?<user>.*?)
+    (?:\:(?<password>.*?))?@
+)?
 (?<host>[A-Za-z0-9\-\.]+)
-(?:\:(?<port>\d+)?)?
+(?(<scheme>)
+    (?:\:(?<port>\d+))?  # only parse port when not using SCP-like syntax
+    |
+    :?
+)
 (?<path>.*?)$
 """x
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -57,56 +57,62 @@ end
     @test sig3.email == sig.email
 end
 
-#@testset "URL parsing" begin
-    # HTTPS URL
-    m = match(LibGit2.URL_REGEX, "https://user:pass@server.com:80/org/project.git")
-    @test m[:scheme] == "https"
-    @test m[:user] == "user"
-    @test m[:password] == "pass"
-    @test m[:host] == "server.com"
-    @test m[:port] == "80"
-    @test m[:path] == "/org/project.git"
+@testset "URL parsing" begin
+    @testset "HTTPS URL" begin
+        m = match(LibGit2.URL_REGEX, "https://user:pass@server.com:80/org/project.git")
+        @test m[:scheme] == "https"
+        @test m[:user] == "user"
+        @test m[:password] == "pass"
+        @test m[:host] == "server.com"
+        @test m[:port] == "80"
+        @test m[:path] == "/org/project.git"
+    end
 
-    # SSH URL
-    m = match(LibGit2.URL_REGEX, "ssh://user:pass@server:22/project.git")
-    @test m[:scheme] == "ssh"
-    @test m[:user] == "user"
-    @test m[:password] == "pass"
-    @test m[:host] == "server"
-    @test m[:port] == "22"
-    @test m[:path] == "/project.git"
+    @testset "SSH URL" begin
+        m = match(LibGit2.URL_REGEX, "ssh://user:pass@server:22/project.git")
+        @test m[:scheme] == "ssh"
+        @test m[:user] == "user"
+        @test m[:password] == "pass"
+        @test m[:host] == "server"
+        @test m[:port] == "22"
+        @test m[:path] == "/project.git"
+    end
 
-    # SSH URL using scp-like syntax
-    m = match(LibGit2.URL_REGEX, "user@server:project.git")
-    @test m[:scheme] === nothing
-    @test m[:user] == "user"
-    @test m[:password] === nothing
-    @test m[:host] == "server"
-    @test m[:port] === nothing
-    @test m[:path] == "project.git"
+    @testset "SSH URL, scp-like syntax" begin
+        m = match(LibGit2.URL_REGEX, "user@server:project.git")
+        @test m[:scheme] === nothing
+        @test m[:user] == "user"
+        @test m[:password] === nothing
+        @test m[:host] == "server"
+        @test m[:port] === nothing
+        @test m[:path] == "project.git"
+    end
 
-    # Realistic example from GitHub using HTTPS
-    m = match(LibGit2.URL_REGEX, "https://github.com/JuliaLang/Example.jl.git")
-    @test m[:scheme] == "https"
-    @test m[:user] === nothing
-    @test m[:password] === nothing
-    @test m[:host] == "github.com"
-    @test m[:port] === nothing
-    @test m[:path] == "/JuliaLang/Example.jl.git"
+    @testset "HTTPS URL, realistic" begin
+        m = match(LibGit2.URL_REGEX, "https://github.com/JuliaLang/Example.jl.git")
+        @test m[:scheme] == "https"
+        @test m[:user] === nothing
+        @test m[:password] === nothing
+        @test m[:host] == "github.com"
+        @test m[:port] === nothing
+        @test m[:path] == "/JuliaLang/Example.jl.git"
+    end
 
-    # Realistic example from GitHub using SSH
-    m = match(LibGit2.URL_REGEX, "git@github.com:JuliaLang/Example.jl.git")
-    @test m[:scheme] === nothing
-    @test m[:user] == "git"
-    @test m[:password] === nothing
-    @test m[:host] == "github.com"
-    @test m[:port] === nothing
-    @test m[:path] == "JuliaLang/Example.jl.git"
+    @testset "SSH URL, realistic" begin
+        m = match(LibGit2.URL_REGEX, "git@github.com:JuliaLang/Example.jl.git")
+        @test m[:scheme] === nothing
+        @test m[:user] == "git"
+        @test m[:password] === nothing
+        @test m[:host] == "github.com"
+        @test m[:port] === nothing
+        @test m[:path] == "JuliaLang/Example.jl.git"
+    end
 
-    # Make sure usernames can contain special characters
-    m = match(LibGit2.URL_REGEX, "user-name@hostname.com")
-    @test m[:user] == "user-name"
-#end
+    @testset "usernames with special characters" begin
+        m = match(LibGit2.URL_REGEX, "user-name@hostname.com")
+        @test m[:user] == "user-name"
+    end
+end
 
 mktempdir() do dir
     # test parameters


### PR DESCRIPTION
Fixes corner case with parsing [SCP-like syntax](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a) where part of the path could be interpreted as a port number.

Old:
```julia
julia> match(LibGit2.URL_REGEX, "server:1234/repo")
RegexMatch("server:1234/repo", scheme=nothing, user=nothing, password=nothing, host="server", port="1234", path="/repo")
```

New:
```julia
julia> match(LibGit2.URL_REGEX, "server:1234/repo")
RegexMatch("server:1234/repo", scheme=nothing, user=nothing, password=nothing, host="server", port=nothing, path="1234/repo")
```

Part of #20725