### PR TITLE
mmap: fix MAP_ANONYMOUS flags value for bsd family

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -27,7 +27,7 @@ const PROT_READ     = Cint(1)
 const PROT_WRITE    = Cint(2)
 const MAP_SHARED    = Cint(1)
 const MAP_PRIVATE   = Cint(2)
-const MAP_ANONYMOUS = Cint(is_apple() ? 0x1000 : 0x20)
+const MAP_ANONYMOUS = Cint(is_bsd() ? 0x1000 : 0x20)
 const F_GETFL       = Cint(3)
 
 gethandle(io::IO) = fd(io)


### PR DESCRIPTION
`MAP_ANONYMOUS` is  `0x1000` on bsd.

FreeBSD: https://svnweb.freebsd.org/base/head/sys/sys/mman.h?view=markup&pathrev=303699#l84
NetBSD: http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/mman.h?rev=1.48.4.2&content-type=text/x-cvsweb-markup
OpenBSD: http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/sys/mman.h?rev=1.29&content-type=text/x-cvsweb-markup
DragonflyBSD: https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/mman.h#L87