### PR TITLE
fix bug where non-tuple types were shown as `NTuple`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -211,11 +211,12 @@ end
 show(io::IO, x::DataType) = show_datatype(io, x)
 
 function show_datatype(io::IO, x::DataType)
-    if (!isempty(x.parameters) || x.name === Tuple.name) && x !== Tuple
+    istuple = x.name === Tuple.name
+    if (!isempty(x.parameters) || istuple) && x !== Tuple
         n = length(x.parameters)
 
         # Print homogeneous tuples with more than 3 elements compactly as NTuple{N, T}
-        if n > 3 && all(i -> (x.parameters[1] === i), x.parameters)
+        if istuple && n > 3 && all(i -> (x.parameters[1] === i), x.parameters)
             print(io, "NTuple{", n, ',', x.parameters[1], "}")
         else
             show(io, x.name)

--- a/test/show.jl
+++ b/test/show.jl
@@ -646,3 +646,7 @@ let d = TextDisplay(IOBuffer())
         @test e.f == show
     end
 end
+
+struct TypeWith4Params{a,b,c,d}
+end
+@test endswith(string(TypeWith4Params{Int8,Int8,Int8,Int8}), "TypeWith4Params{Int8,Int8,Int8,Int8}")


### PR DESCRIPTION
In one of the silliest bugs ever, any type with > 3 parameters that were all the same would be shown as an `NTuple`.