### PR TITLE
Calculate correct floating point fastmath mod for equal inputs (fixes #20778)

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -150,7 +150,7 @@ mul_fast{T<:FloatTypes}(x::T, y::T, zs::T...) =
     cmp_fast{T<:FloatTypes}(x::T, y::T) = ifelse(x==y, 0, ifelse(x<y, -1, +1))
     function mod_fast{T<:FloatTypes}(x::T, y::T)
         r = rem(x,y)
-        ifelse((r > 0) ⊻ (y > 0), r+y, r)
+        ifelse((r >= 0) ⊻ (y > 0), r+y, r)
     end
 end
 

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -59,6 +59,7 @@ for T in (Float32, Float64, BigFloat)
     @test @fastmath(one/two/three) ≈ one/two/three
     @test @fastmath(rem(two,three)) ≈ rem(two,three)
     @test @fastmath(mod(two,three)) ≈ mod(two,three)
+    @test @fastmath(mod(three,three)) ≈ mod(three,three)
     @test @fastmath(cmp(two,two)) == cmp(two,two)
     @test @fastmath(cmp(two,three)) == cmp(two,three)
     @test @fastmath(cmp(three,two)) == cmp(three,two)


### PR DESCRIPTION
Changes the comparison of the remainder in `fast_mod` for floating point inputs to correctly handle the case where the inputs are of equal value and the modulus should be zero.

Fixes #20778