### PR TITLE
change x^p for literal p from x^Val{p} to x^Val{p}()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,7 +74,7 @@ Language changes
     `Vector{T} = Array{T,1}` or a `const` assignment.
 
   * Experimental feature: `x^n` for integer literals `n` (e.g. `x^3`
-    or `x^-3`) is now lowered to `x^Val{n}`, to enable compile-time
+    or `x^-3`) is now lowered to `x^Val{n}()`, to enable compile-time
     specialization for literal integer exponents ([#20530]).
     `x^p` for `x::Number` and a literal `p=0,1,2,3` is now lowered to
     `one(x)`, `x`, `x*x`, and `x*x*x`, respectively ([#20648]).

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -444,7 +444,7 @@ end
 ^(x::Bool   , y::BigInt ) = Base.power_by_squaring(x, y)
 
 # override default inlining of x^2 and x^3 etc.
-^{p}(x::BigInt, ::Type{Val{p}}) = x^p
+^{p}(x::BigInt, ::Val{p}) = x^p
 
 function powermod(x::BigInt, p::BigInt, m::BigInt)
     r = BigInt()

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -195,20 +195,20 @@ end
 ^(x::Number, p::Integer)  = power_by_squaring(x,p)
 ^(x, p::Integer)          = power_by_squaring(x,p)
 
-# x^p for any literal integer p is lowered to x^Val{p},
+# x^p for any literal integer p is lowered to x^Val{p}(),
 # to enable compile-time optimizations specialized to p.
 # However, we still need a fallback that calls the general ^.
 # To avoid ambiguities for methods that dispatch on the
 # first argument, we dispatch the fallback via internal_pow:
 ^(x, p) = internal_pow(x, p)
-internal_pow{p}(x, ::Type{Val{p}}) = x^p
+internal_pow{p}(x, ::Val{p}) = x^p
 
 # inference.jl has complicated logic to inline x^2 and x^3 for
 # numeric types.  In terms of Val we can do it much more simply:
-internal_pow(x::Number, ::Type{Val{0}}) = one(x)
-internal_pow(x::Number, ::Type{Val{1}}) = x
-internal_pow(x::Number, ::Type{Val{2}}) = x*x
-internal_pow(x::Number, ::Type{Val{3}}) = x*x*x
+internal_pow(x::Number, ::Val{0}) = one(x)
+internal_pow(x::Number, ::Val{1}) = x
+internal_pow(x::Number, ::Val{2}) = x*x
+internal_pow(x::Number, ::Val{3}) = x*x*x
 
 # b^p mod m
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -212,7 +212,7 @@ catalan
 for T in (Irrational, Rational, Integer, Number)
     ^(::Irrational{:e}, x::T) = exp(x)
 end
-^{p}(::Irrational{:e}, ::Type{Val{p}}) = exp(p)
+^{p}(::Irrational{:e}, ::Val{p}) = exp(p)
 
 log(::Irrational{:e}) = 1 # use 1 to correctly promote expressions like log(x)/log(e)
 log(::Irrational{:e}, x::Number) = log(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -691,7 +691,7 @@ end
 ^(x::Float32, y::Integer) = x^Int32(y)
 ^(x::Float32, y::Int32) = powi_llvm(x, y)
 ^(x::Float16, y::Integer) = Float16(Float32(x)^y)
-^{p}(x::Float16, ::Type{Val{p}}) = Float16(Float32(x)^Val{p})
+^{p}(x::Float16, y::Val{p}) = Float16(Float32(x)^y)
 
 function angle_restrict_symm(theta)
     const P1 = 4 * 7.8539812564849853515625e-01

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -505,7 +505,7 @@ end
 ^(x::BigFloat, y::Unsigned) = typemin(Culong) <= y <= typemax(Culong) ? x^Culong(y) : x^BigInt(y)
 
 # override default inlining of x^2 etc.
-^{p}(x::BigFloat, ::Type{Val{p}}) = x^p
+^{p}(x::BigFloat, ::Val{p}) = x^p
 
 for f in (:exp, :exp2, :exp10, :expm1, :cosh, :sinh, :tanh, :sech, :csch, :coth, :cbrt)
     @eval function $f(x::BigFloat)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -254,9 +254,9 @@ end
 Exponentiation operator. If `x` is a matrix, computes matrix exponentiation.
 
 If `y` is an `Int` literal (e.g. `2` in `x^2` or `-3` in `x^-3`), the Julia code
-`x^y` is transformed by the compiler to `x^Val{y}`, to enable compile-time
+`x^y` is transformed by the compiler to `x^Val{y}()`, to enable compile-time
 specialization on the value of the exponent.  (As a default fallback,
-however, `x^Val{y}` simply calls the `^(x,y)` function.)
+however, `x^Val{y}()` simply calls the `^(x,y)` function.)
 
 ```jldoctest
 julia> 3^5

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -235,7 +235,7 @@ Cannot raise an integer x to a negative power -n.
 Make x a float by adding a zero decimal (e.g. 2.0^-n instead of 2^-n), or write 1/x^n, float(x)^-n, or (x//1)^-n.
 Stacktrace:
  [1] power_by_squaring(::Int64, ::Int64) at ./intfuncs.jl:170
- [2] ^(::Int64, ::Type{Val{-5}}) at ./intfuncs.jl:201
+ [2] ^(::Int64, ::Val{-5}) at ./intfuncs.jl:201
 ```
 
 This behavior is an inconvenient consequence of the requirement for type-stability.  In the case

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2057,7 +2057,7 @@
 
                  ((and (eq? f '^) (length= e 4) (integer? (cadddr e)))
                   (expand-forms
-                   `(call ^ ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)))))
+                   `(call ^ ,(caddr e) (call (call (core apply_type) (top Val) ,(cadddr e))))))
 
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2905,7 +2905,7 @@ end
 import Base.^
 immutable PR20530; end
 ^(::PR20530, p::Int) = 1
-^{p}(::PR20530, ::Type{Val{p}}) = 2
+^{p}(::PR20530, ::Val{p}) = 2
 @testset "literal powers" begin
     x = PR20530()
     p = 2


### PR DESCRIPTION
This changes #20530 to use `Val{p}()` rather than `Val{p}`, so that we dispatch on `^{p}(x, ::Val{p})` rather than `^{p}(x, ::Type{Val{p}})`.

This change was suggested by @vtjnash in #19890 because the old behavior thwarts constant folding.  With `Val{p}()`, constant-folding works again:
```jl
julia> f(x) = 2.0^3 * x
f (generic function with 1 method)

julia> @code_llvm f(4.0)

define double @julia_f_67331(double) #0 !dbg !5 {
top:
  %1 = fmul double %0, 8.000000e+00
  ret double %1
}
```