### PR TITLE
Revamp libgit2 owner interface.

### DIFF
--- a/base/libgit2/index.jl
+++ b/base/libgit2/index.jl
@@ -25,10 +25,10 @@ function write_tree!(idx::GitIndex)
 end
 
 function repository(idx::GitIndex)
-    if isnull(idx.nrepo)
+    if isnull(idx.owner)
         throw(GitError(Error.Index, Error.ENOTFOUND, "Index does not have an owning repository."))
     else
-        return Base.get(idx.nrepo)
+        return Base.get(idx.owner)
     end
 end
 

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -235,7 +235,7 @@ function peel{T<:GitObject}(::Type{T}, obj::GitObject)
     @check ccall((:git_object_peel, :libgit2), Cint,
                 (Ptr{Ptr{Void}}, Ptr{Void}, Cint), new_ptr_ptr, obj.ptr, Consts.OBJECT(T))
 
-    return T(obj.repo, new_ptr_ptr[])
+    return T(obj.owner, new_ptr_ptr[])
 end
 peel(obj::GitObject) = peel(GitObject, obj)
 

--- a/base/libgit2/tree.jl
+++ b/base/libgit2/tree.jl
@@ -59,7 +59,7 @@ function (::Type{T}){T<:GitObject}(te::GitTreeEntry)
     @check ccall((:git_tree_entry_to_object, :libgit2), Cint,
                   (Ptr{Ptr{Void}}, Ptr{Void}, Ref{Void}),
                    obj_ptr_ptr, repo.ptr, te.ptr)
-    return T(repo.ptr, obj_ptr_ptr[])
+    return T(repo, obj_ptr_ptr[])
 end
 
 function Base.show(io::IO, te::GitTreeEntry)

--- a/base/libgit2/tree.jl
+++ b/base/libgit2/tree.jl
@@ -53,7 +53,7 @@ function Base.getindex(tree::GitTree, i::Integer)
     te_ptr = ccall((:git_tree_entry_byindex, :libgit2),
                    Ptr{Void},
                    (Ptr{Void}, Csize_t), tree.ptr, i-1)
-    return GitTreeEntry(te_ptr, false)
+    return GitTreeEntry(tree, te_ptr, false)
 end
 
 function (::Type{T}){T<:GitObject}(repo::GitRepo, te::GitTreeEntry)

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -480,30 +480,31 @@ Base.isempty(obj::AbstractGitObject) = (obj.ptr == C_NULL)
 
 abstract type GitObject <: AbstractGitObject end
 
-for (typ, reporef, sup, cname) in [
-    (:GitRepo,          nothing,   :AbstractGitObject, :git_repository),
-    (:GitTreeEntry,     nothing,   :AbstractGitObject, :git_tree_entry),
-    (:GitDiffStats,     nothing,   :AbstractGitObject, :git_diff_stats),
-    (:GitConfig,        :Nullable, :AbstractGitObject, :git_config),
-    (:GitIndex,         :Nullable, :AbstractGitObject, :git_index),
-    (:GitRemote,        :GitRepo,  :AbstractGitObject, :git_remote),
-    (:GitRevWalker,     :GitRepo,  :AbstractGitObject, :git_revwalk),
-    (:GitReference,     :GitRepo,  :AbstractGitObject, :git_reference),
-    (:GitDiff,          :GitRepo,  :AbstractGitObject, :git_diff),
-    (:GitAnnotated,     :GitRepo,  :AbstractGitObject, :git_annotated_commit),
-    (:GitRebase,        :GitRepo,  :AbstractGitObject, :git_rebase),
-    (:GitStatus,        :GitRepo,  :AbstractGitObject, :git_status_list),
-    (:GitBranchIter,    :GitRepo,  :AbstractGitObject, :git_branch_iterator),
-    (:GitUnknownObject, :GitRepo,  :GitObject,         :git_object),
-    (:GitCommit,        :GitRepo,  :GitObject,         :git_commit),
-    (:GitBlob,          :GitRepo,  :GitObject,         :git_blob),
-    (:GitTree,          :GitRepo,  :GitObject,         :git_tree),
-    (:GitTag,           :GitRepo,  :GitObject,         :git_tag)]
+for (typ, owntyp, sup, cname) in [
+    (:GitRepo,          nothing,               :AbstractGitObject, :git_repository),
+    (:GitDiffStats,     nothing,               :AbstractGitObject, :git_diff_stats),
+    (:GitConfig,        :(Nullable{GitRepo}),  :AbstractGitObject, :git_config),
+    (:GitIndex,         :(Nullable{GitRepo}),  :AbstractGitObject, :git_index),
+    (:GitRemote,        :GitRepo,              :AbstractGitObject, :git_remote),
+    (:GitRevWalker,     :GitRepo,              :AbstractGitObject, :git_revwalk),
+    (:GitReference,     :GitRepo,              :AbstractGitObject, :git_reference),
+    (:GitDiff,          :GitRepo,              :AbstractGitObject, :git_diff),
+    (:GitAnnotated,     :GitRepo,              :AbstractGitObject, :git_annotated_commit),
+    (:GitRebase,        :GitRepo,              :AbstractGitObject, :git_rebase),
+    (:GitStatus,        :GitRepo,              :AbstractGitObject, :git_status_list),
+    (:GitBranchIter,    :GitRepo,              :AbstractGitObject, :git_branch_iterator),
+    (:GitUnknownObject, :GitRepo,              :GitObject,         :git_object),
+    (:GitCommit,        :GitRepo,              :GitObject,         :git_commit),
+    (:GitBlob,          :GitRepo,              :GitObject,         :git_blob),
+    (:GitTree,          :GitRepo,              :GitObject,         :git_tree),
+    (:GitTag,           :GitRepo,              :GitObject,         :git_tag),
+    (:GitTreeEntry,     :(Nullable{GitTree}),  :AbstractGitObject, :git_tree_entry),
+    ]
 
-    if reporef === nothing
+    if owntyp === nothing
         @eval mutable struct $typ <: $sup
             ptr::Ptr{Void}
-            function $typ(ptr::Ptr{Void},fin=true)
+            function $typ(ptr::Ptr{Void}, fin::Bool=true)
                 # fin=false should only be used when the pointer should not be free'd
                 # e.g. from within callback functions which are passed a pointer
                 @assert ptr != C_NULL
@@ -515,35 +516,25 @@ for (typ, reporef, sup, cname) in [
                 return obj
             end
         end
-    elseif reporef == :Nullable
+    else
         @eval mutable struct $typ <: $sup
-            nrepo::Nullable{GitRepo}
+            owner::$owntyp
             ptr::Ptr{Void}
-            function $typ(repo::GitRepo, ptr::Ptr{Void})
+            function $typ(owner::$owntyp, ptr::Ptr{Void}, fin::Bool=true)
                 @assert ptr != C_NULL
-                obj = new(Nullable(repo), ptr)
-                Threads.atomic_add!(REFCOUNT, UInt(1))
-                finalizer(obj, Base.close)
-                return obj
-            end
-            function $typ(ptr::Ptr{Void})
-                @assert ptr != C_NULL
-                obj = new(Nullable{GitRepo}(), ptr)
-                Threads.atomic_add!(REFCOUNT, UInt(1))
-                finalizer(obj, Base.close)
+                obj = new(owner, ptr)
+                if fin
+                    Threads.atomic_add!(REFCOUNT, UInt(1))
+                    finalizer(obj, Base.close)
+                end
                 return obj
             end
         end
-    elseif reporef == :GitRepo
-        @eval mutable struct $typ <: $sup
-            repo::GitRepo
-            ptr::Ptr{Void}
-            function $typ(repo::GitRepo, ptr::Ptr{Void})
-                @assert ptr != C_NULL
-                obj = new(repo, ptr)
-                Threads.atomic_add!(REFCOUNT, UInt(1))
-                finalizer(obj, Base.close)
-                return obj
+        if isa(owntyp, Expr) && owntyp.args[1] == :Nullable
+            @eval begin
+                $typ(ptr::Ptr{Void}, fin::Bool=true) = $typ($owntyp(), ptr, fin)
+                $typ(owner::$(owntyp.args[2]), ptr::Ptr{Void}, fin::Bool=true) =
+                    $typ($owntyp(owner), ptr, fin)
             end
         end
     end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -498,7 +498,7 @@ for (typ, owntyp, sup, cname) in [
     (:GitBlob,          :GitRepo,              :GitObject,         :git_blob),
     (:GitTree,          :GitRepo,              :GitObject,         :git_tree),
     (:GitTag,           :GitRepo,              :GitObject,         :git_tag),
-    (:GitTreeEntry,     :(Nullable{GitTree}),  :AbstractGitObject, :git_tree_entry),
+    (:GitTreeEntry,     :GitTree,              :AbstractGitObject, :git_tree_entry),
     ]
 
     if owntyp === nothing

--- a/base/libgit2/walker.jl
+++ b/base/libgit2/walker.jl
@@ -48,7 +48,7 @@ function Base.sort!(w::GitRevWalker; by::Cint = Consts.SORT_NONE, rev::Bool=fals
     return w
 end
 
-repository(w::GitRevWalker) = w.repo
+repository(w::GitRevWalker) = w.owner
 
 function Base.map(f::Function, walker::GitRevWalker;
                   oid::GitHash=GitHash(),


### PR DESCRIPTION
It seems that some objects can be owned by non-repo objects. This makes the code a bit more general to allow for this.