### PR TITLE
[release-0.5] use a counter for passed tests instead of storing the Result object

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -411,12 +411,15 @@ along with a summary of the test results.
 type DefaultTestSet <: AbstractTestSet
     description::AbstractString
     results::Vector
+    n_passed::Int
     anynonpass::Bool
 end
-DefaultTestSet(desc) = DefaultTestSet(desc, [], false)
+DefaultTestSet(desc) = DefaultTestSet(desc, [], 0, false)
 
-# For a passing or broken result, simply store the result
-record(ts::DefaultTestSet, t::Union{Pass,Broken}) = (push!(ts.results, t); t)
+# For a broken result, simply store the result
+record(ts::DefaultTestSet, t::Broken) = (push!(ts.results, t); t)
+# For a passed result, do not store the result since it uses a lot of memory
+record(ts::DefaultTestSet, t::Pass) = (ts.n_passed += 1; t)
 
 # For the other result types, immediately print the error message
 # but do not terminate. Print a backtrace.
@@ -520,10 +523,9 @@ get_alignment(ts, depth::Int) = 0
 # Recursive function that counts the number of test results of each
 # type directly in the testset, and totals across the child testsets
 function get_test_counts(ts::DefaultTestSet)
-    passes, fails, errors, broken = 0, 0, 0, 0
+    passes, fails, errors, broken = ts.n_passed, 0, 0, 0
     c_passes, c_fails, c_errors, c_broken = 0, 0, 0, 0
     for t in ts.results
-        isa(t, Pass)   && (passes += 1)
         isa(t, Fail)   && (fails  += 1)
         isa(t, Error)  && (errors += 1)
         isa(t, Broken) && (broken += 1)

--- a/test/test.jl
+++ b/test/test.jl
@@ -174,14 +174,14 @@ ts = @testset "@testset should return the testset" begin
     @test true
 end
 @test typeof(ts) == Base.Test.DefaultTestSet
-@test typeof(ts.results[1]) == Base.Test.Pass
+@test ts.n_passed == 1
 
 tss = @testset "@testset/for should return an array of testsets: $i" for i in 1:3
     @test true
 end
 @test length(tss) == 3
 @test typeof(tss[1]) == Base.Test.DefaultTestSet
-@test typeof(tss[1].results[1]) == Base.Test.Pass
+@test tss[1].n_passed == 1
 
 # Issue #17908 (return)
 testset_depth17908 = Test.get_testset_depth()


### PR DESCRIPTION
Ref #20150, cherry-picked from b7c850ea2d3b24673403b59c0d5b43ddd7b5a2a6

Reason for backport: after [converting CUDAdrv.jl to using testsets](https://github.com/JuliaGPU/CUDAdrv.jl/commit/99e16acf02de6a2d1170665afde0cb211458eddf), some finalizers [weren't being called anymore](https://ci.maleadt.net/buildbot/julia/builders/CUDAdrv.jl%3A%20Julia%200.5%20%28x86-64%29/builds/70/steps/test/logs/stdio), but only on 0.5.

Repro:

```julia
using Base.Test

type Foo
    whatever    # prevent singleton object
    function Foo()
        obj = new(nothing)
        finalizer(obj, finalize)
        return obj
    end
end

finalized = false
function finalize(obj::Foo)
    global finalized
    finalized = true
end

@testset "dummy" begin
    dummy = Foo()
    @test_throws MethodError sin(dummy)
end

try throw(nothing) end
gc()
@assert finalized
```

This is semi important to me, because for CUDAdrv.jl (any other GPU packages too) finalizers are responsible for freeing GPU memory, and without this backport we can't test whether that works reliably.

cc @KristofferC