### PR TITLE
Bump the stack size for ASAN builds.

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -139,7 +139,7 @@ static void jl_find_stack_bottom(void)
 
     // When using the sanitizers, increase stack size because they bloat
     // stack usage
-    const rlim_t kStackSize = 32 * 1024 * 1024;   // 32MB stack
+    const rlim_t kStackSize = 64 * 1024 * 1024;   // 64MiB stack
     int result;
 
     result = getrlimit(RLIMIT_STACK, &rl);


### PR DESCRIPTION
After #17057, building the system image seems to take significantly more stack space, resulting in a StackOverflowError. With this raise, I can build Julia using ASAN again.
Haven't run the tests yet, but I'll do so overnight (it takes _ages_).

I've also written down [some notes](https://blog.maleadt.net/2017/02/24/julia-asan/) on compiling Julia+ASAN; see [this script](https://gist.github.com/maleadt/2cff148b53a65f3dbe14ec373ce67b87) for a summary in code.

cc @andreasnoack