### PR TITLE
break some dependency backedges

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -826,6 +826,7 @@ end
 # Deprecate vectorized !
 @deprecate(!(A::AbstractArray{Bool}), .!A) # parens for #20541
 @deprecate(!(B::BitArray), .!B) # parens for #20541
+!(::typeof(()->())) = () # make sure ! has at least 4 methods so that for-loops don't end up getting a back-edge to depwarn
 
 # Deprecate vectorized ~
 @deprecate ~(A::AbstractArray) .~A

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -86,13 +86,17 @@ false
 """
 isequal(x, y) = x == y
 
-isequal(x::AbstractFloat, y::AbstractFloat) = (isnan(x) & isnan(y)) | (signbit(x) == signbit(y)) & (x == y)
-isequal(x::Real,          y::AbstractFloat) = (isnan(x) & isnan(y)) | (signbit(x) == signbit(y)) & (x == y)
-isequal(x::AbstractFloat, y::Real         ) = (isnan(x) & isnan(y)) | (signbit(x) == signbit(y)) & (x == y)
+signequal(x, y) = signbit(x)::Bool == signbit(y)::Bool
+signless(x, y) = signbit(x)::Bool & !signbit(y)::Bool
 
-isless(x::AbstractFloat, y::AbstractFloat) = (!isnan(x) & isnan(y)) | (signbit(x) & !signbit(y)) | (x < y)
-isless(x::Real,          y::AbstractFloat) = (!isnan(x) & isnan(y)) | (signbit(x) & !signbit(y)) | (x < y)
-isless(x::AbstractFloat, y::Real         ) = (!isnan(x) & isnan(y)) | (signbit(x) & !signbit(y)) | (x < y)
+isequal(x::AbstractFloat, y::AbstractFloat) = (isnan(x) & isnan(y)) | signequal(x, y) & (x == y)
+isequal(x::Real,          y::AbstractFloat) = (isnan(x) & isnan(y)) | signequal(x, y) & (x == y)
+isequal(x::AbstractFloat, y::Real         ) = (isnan(x) & isnan(y)) | signequal(x, y) & (x == y)
+
+isless(x::AbstractFloat, y::AbstractFloat) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
+isless(x::Real,          y::AbstractFloat) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
+isless(x::AbstractFloat, y::Real         ) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
+
 
 function ==(T::Type, S::Type)
     @_pure_meta
@@ -122,7 +126,7 @@ julia> "foo" ≠ "foo"
 false
 ```
 """
-!=(x, y) = !(x == y)
+!=(x, y) = !(x == y)::Bool
 const ≠ = !=
 
 """

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -352,6 +352,6 @@ min(x::Real) = x
 max(x::Real) = x
 minmax(x::Real) = (x, x)
 
-max{T<:Real}(x::T, y::T) = ifelse(y < x, x, y)
-min{T<:Real}(x::T, y::T) = ifelse(y < x, y, x)
+max{T<:Real}(x::T, y::T) = select_value(y < x, x, y)
+min{T<:Real}(x::T, y::T) = select_value(y < x, y, x)
 minmax{T<:Real}(x::T, y::T) = y < x ? (y, x) : (x, y)


### PR DESCRIPTION
This might be nicer if we had function types (so that we could declared that `function == end::Bool` for example), but this tries to at least hit a couple of the high points.

fix #20780

The main issue here was that BitArray deprecated bitwise operations, so `|` and `!` ended with a lot of  edges between anything with bitwise operations or for loops and anything required for printing warnings.