### PR TITLE
improve precompiles

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -259,9 +259,11 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t **pli, size_t world, int forc
         fargs[1] = (jl_value_t*)li;
         fargs[2] = jl_box_ulong(world);
 #ifdef TRACE_INFERENCE
-        jl_printf(JL_STDERR,"inference on ");
-        jl_static_show_func_sig(JL_STDERR, (jl_value_t*)li->specTypes);
-        jl_printf(JL_STDERR, "\n");
+        if (li->specTypes != (jl_value_t*)jl_emptytuple_type) {
+            jl_printf(JL_STDERR,"inference on ");
+            jl_static_show_func_sig(JL_STDERR, (jl_value_t*)li->specTypes);
+            jl_printf(JL_STDERR, "\n");
+        }
 #endif
         jl_get_ptls_states()->world_age = jl_typeinf_world;
         jl_svec_t *linfo_src_rettype = (jl_svec_t*)jl_apply(fargs, 3);
@@ -1041,6 +1043,13 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype
         JL_GC_POP();
         return NULL;
     }
+#ifdef TRACE_COMPILE
+    if (!jl_has_free_typevars((jl_value_t*)tt)) {
+        jl_printf(JL_STDERR, "precompile(");
+        jl_static_show(JL_STDERR, (jl_value_t*)tt);
+        jl_printf(JL_STDERR, ")\n");
+    }
+#endif
     sig = join_tsig(tt, entry->sig);
     jl_method_instance_t *nf;
     if (!cache) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1231,6 +1231,7 @@ JL_DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from,
 JL_DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
 JL_DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
+JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT jl_module_t *jl_new_main_module(void);
 JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)

--- a/src/module.c
+++ b/src/module.c
@@ -261,9 +261,8 @@ static int eq_bindings(jl_binding_t *a, jl_binding_t *b)
 // does module m explicitly import s?
 JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s)
 {
-    jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, s);
-    jl_binding_t *bto = *bp;
-    return (bto != HT_NOTFOUND && bto->imported);
+    jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, s);
+    return (b != HT_NOTFOUND && b->imported);
 }
 
 // NOTE: we use explici since explicit is a C++ keyword
@@ -411,23 +410,20 @@ JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var)
 
 JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var)
 {
-    jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
-    if (*bp == HT_NOTFOUND) return 0;
-    return (*bp)->exportp || (*bp)->owner==m;
+    jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
+    return b != HT_NOTFOUND && (b->exportp || b->owner==m);
 }
 
 JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var)
 {
-    jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
-    if (*bp == HT_NOTFOUND) return 0;
-    return (*bp)->exportp;
+    jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
+    return b != HT_NOTFOUND && b->exportp;
 }
 
 JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var)
 {
-    jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
-    if (*bp == HT_NOTFOUND) return 0;
-    return (*bp)->owner != NULL;
+    jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
+    return b != HT_NOTFOUND && b->owner != NULL;
 }
 
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)

--- a/src/options.h
+++ b/src/options.h
@@ -89,6 +89,7 @@
 
 // print all signatures type inference is invoked on
 //#define TRACE_INFERENCE
+//#define TRACE_COMPILE
 
 // print all generic method dispatches (excludes inlined and specialized call
 // sites). this generally prints too much output to be useful.

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -481,6 +481,8 @@ struct recur_list {
 
 static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth);
 
+JL_DLLEXPORT int jl_id_start_char(uint32_t wc);
+
 // `v` might be pointing to a field inlined in a structure therefore
 // `jl_typeof(v)` may not be the same with `vt` and only `vt` should be
 // used to determine the type of the value.
@@ -526,11 +528,49 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     }
     else if (vt == jl_datatype_type) {
         jl_datatype_t *dv = (jl_datatype_t*)v;
-        if (dv->name->module != jl_core_module) {
-            n += jl_static_show_x(out, (jl_value_t*)dv->name->module, depth);
-            n += jl_printf(out, ".");
+        jl_sym_t *globname = dv->name->mt != NULL ? dv->name->mt->name : NULL;
+        int globfunc = 0;
+        if (globname && !strchr(jl_symbol_name(globname), '#') &&
+            !strchr(jl_symbol_name(globname), '@') &&
+            jl_binding_resolved_p(dv->name->module, globname)) {
+            jl_binding_t *b = jl_get_binding(dv->name->module, globname);
+            if (b && jl_typeof(b->value) == v)
+                globfunc = 1;
         }
-        n += jl_printf(out, "%s", jl_symbol_name(dv->name->name));
+        jl_sym_t *sym = globfunc ? globname : dv->name->name;
+        char *sn = jl_symbol_name(sym);
+        int hidden = !globfunc && strchr(sn, '#');
+        size_t i = 0;
+        int quote = 0;
+        if (hidden) {
+            n += jl_printf(out, "getfield(");
+        }
+        else if (globfunc) {
+            n += jl_printf(out, "typeof(");
+        }
+        if (dv->name->module != jl_core_module || !jl_module_exports_p(jl_core_module, sym)) {
+            n += jl_static_show_x(out, (jl_value_t*)dv->name->module, depth);
+            if (!hidden) {
+                n += jl_printf(out, ".");
+                if (globfunc && !jl_id_start_char(u8_nextchar(sn, &i))) {
+                    n += jl_printf(out, ":(");
+                    quote = 1;
+                }
+            }
+        }
+        if (hidden) {
+            n += jl_printf(out, ", Symbol(\"");
+            n += jl_printf(out, "%s", sn);
+            n += jl_printf(out, "\"))");
+        }
+        else {
+            n += jl_printf(out, "%s", sn);
+            if (globfunc) {
+                n += jl_printf(out, ")");
+                if (quote)
+                    n += jl_printf(out, ")");
+            }
+        }
         if (dv->parameters && (jl_value_t*)dv != dv->name->wrapper &&
             (jl_has_free_typevars(v) ||
              (jl_value_t*)dv != (jl_value_t*)jl_tuple_type)) {
@@ -602,6 +642,9 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         jl_uv_puts(out, jl_string_data(v), jl_string_len(v)); n += jl_string_len(v);
         n += jl_printf(out, "\"");
     }
+    else if (v == jl_bottom_type) {
+        n += jl_printf(out, "Union{}");
+    }
     else if (vt == jl_uniontype_type) {
         n += jl_printf(out, "Union{");
         while (jl_is_uniontype(v)) {
@@ -662,7 +705,16 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, "%s", jl_symbol_name(m->name));
     }
     else if (vt == jl_sym_type) {
-        n += jl_printf(out, ":%s", jl_symbol_name((jl_sym_t*)v));
+        char *sn = jl_symbol_name((jl_sym_t*)v);
+        // TODO check for valid identifier
+        int quoted = strchr(sn, '/') && strcmp(sn, "/") && strcmp(sn, "//") && strcmp(sn, "//=");
+        if (quoted)
+            n += jl_printf(out, "Symbol(\"");
+        else
+            n += jl_printf(out, ":");
+        n += jl_printf(out, "%s", sn);
+        if (quoted)
+            n += jl_printf(out, "\")");
     }
     else if (vt == jl_ssavalue_type) {
         n += jl_printf(out, "SSAValue(%" PRIuPTR ")",


### PR DESCRIPTION
- Be able to print any type in parse-able syntax. This lets us precompile many more things, such as closures, more operators, types containing `Symbol("text/plain")`, etc.
- Put the code for printing things to precompile in a better place. We want to print the observed concrete types that led to compilation, not something else (previously precompile.jl contained some abstract types, which the `precompile` function actually ignores to avoid poisoning the cache).
- The precompile statements needed to be updated for 0.6 anyway.

The system image is a bit bigger after this, but the repl is really snappy.