### PR TITLE
RFC: allow TTYTerminal output streams to be non-TTYs

### DIFF
--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -100,9 +100,9 @@ end
 
 mutable struct TTYTerminal <: UnixTerminal
     term_type::String
-    in_stream::Base.TTY
-    out_stream::Base.TTY
-    err_stream::Base.TTY
+    in_stream::IO
+    out_stream::IO
+    err_stream::IO
 end
 
 const CSI = "\x1b["

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -632,3 +632,10 @@ let ends_with_semicolon = Base.REPL.ends_with_semicolon
     @test !ends_with_semicolon("begin\na; #=#=#\n=#b=#\nend")
     @test ends_with_semicolon("\na; #=#=#\n=#b=#\n# test\n#=\nfoobar\n=##bazbax\n")
 end
+
+# PR #20794, TTYTerminal with other kinds of streams
+let term = Base.Terminals.TTYTerminal("dumb",IOBuffer("1+2\n"),IOBuffer(),IOBuffer())
+    r = Base.REPL.BasicREPL(term)
+    REPL.run_repl(r)
+    @test String(take!(term.out_stream)) == "julia> 3\n\njulia> \n"
+end


### PR DESCRIPTION
Today I wanted to do `./julia 2> output` in order to use the REPL but send precompile statements to a file. This does not work, since `TTYTerminal` requires all streams to be TTYs. Here is a possible fix.

@vtjnash @Keno Is there an issue for this?