### PR TITLE
Successive Pkg.init calls can change the branch

### DIFF
--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -37,7 +37,24 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
     metadata_dir = joinpath(dir, "METADATA")
     if isdir(metadata_dir)
         info("Package directory $dir is already initialized.")
-        LibGit2.set_remote_url(metadata_dir, meta)
+        with(LibGit2.GitRepo, metadata_dir) do r
+            LibGit2.transact(r) do repo
+                LibGit2.set_remote_url(repo, meta)
+
+                # Ideally this logic would be contained within LibGit2
+                ref = LibGit2.lookup_branch(repo, branch, true)  # remote branch
+                isnull(ref) && (ref = LibGit2.lookup_branch(repo, branch, false))  # local branch
+                isnull(ref) && error("METADATA repo does not contain branch: $branch")
+                commit_obj = LibGit2.peel(LibGit2.GitCommit, unsafe_get(ref))
+                LibGit2.checkout_tree(repo, commit_obj)
+                LibGit2.head!(repo, unsafe_get(ref))
+
+                # Overwrite file last as the transact block won't roll this change back
+                open(joinpath(dir, "META_BRANCH"), "w") do io
+                    write(io, branch)
+                end
+            end
+        end
         return
     end
     local temp_dir = ""

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -494,6 +494,37 @@ temp_pkg_dir() do
             "redirect_stderr(STDOUT); using Example; Pkg.update(\"$package\")"`))
         @test contains(msg, "- $package\nRestart Julia to use the updated versions.")
     end
+
+    # Modify remote url and branch of METADATA
+    LibGit2.with(LibGit2.GitRepo, Pkg.dir("METADATA")) do repo
+        @test isdir(Pkg.dir("METADATA"))
+
+        # Make sure that init does not create a new branch
+        @test_throws ErrorException Pkg.init("foo", "bar")
+
+        commit = LibGit2.peel(LibGit2.GitCommit, LibGit2.head(repo))
+        LibGit2.create_branch(repo, "bar", commit)
+        @test LibGit2.branch(LibGit2.head(repo)) != "bar"
+
+        Pkg.init("foo", "bar")
+
+        @test LibGit2.url(LibGit2.get(LibGit2.GitRemote, repo, "origin")) == "foo"
+        @test LibGit2.branch(LibGit2.head(repo)) == "bar"
+        @test readstring(joinpath(Pkg.dir(), "META_BRANCH")) == "bar"
+
+        remote_branch = "origin/$(Pkg.META_BRANCH)"
+        Pkg.init("foo", remote_branch)
+
+        remote_branch_ref = LibGit2.lookup_branch(repo, remote_branch, true)
+        @test LibGit2.GitHash(LibGit2.head(repo)) == LibGit2.GitHash(get(remote_branch_ref))
+        @test readstring(joinpath(Pkg.dir(), "META_BRANCH")) == remote_branch
+
+        Pkg.init()  # reset
+
+        @test LibGit2.url(LibGit2.get(LibGit2.GitRemote, repo, "origin")) == Pkg.DEFAULT_META
+        @test LibGit2.branch(LibGit2.head(repo)) == Pkg.META_BRANCH
+        @test readstring(joinpath(Pkg.dir(), "META_BRANCH")) == Pkg.META_BRANCH
+    end
 end
 
 let io = IOBuffer()


### PR DESCRIPTION
After `Pkg.init` has been initialized you can call `Pkg.init` again to modify the remote URL. This PR additionally allows the branch to be modified.