### PR TITLE
Fix socket test cases on bsd family

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -856,11 +856,23 @@ function getsockname(sock::Union{TCPServer,TCPSocket})
     uv_error("cannot obtain socket name", r)
     if r == 0
         port = ntoh(rport[])
+        af_inet6 = @static if is_windows() # AF_INET6 in <sys/socket.h>
+            23
+        elseif is_apple()
+            30
+        elseif Sys.KERNEL ∈ (:FreeBSD, :DragonFly)
+            28
+        elseif Sys.KERNEL ∈ (:NetBSD, :OpenBSD)
+            24
+        else
+            10
+        end
+
         if rfamily[] == 2 # AF_INET
             addrv4 = raddress[1:4]
             naddr = ntoh(unsafe_load(Ptr{Cuint}(pointer(addrv4)), 1))
             addr = IPv4(naddr)
-        elseif rfamily[] == @static is_windows() ? 23 : (@static is_apple() ? 30 : 10) # AF_INET6
+        elseif rfamily[] == af_inet6
             naddr = ntoh(unsafe_load(Ptr{UInt128}(pointer(raddress)), 1))
             addr = IPv6(naddr)
         else

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -253,16 +253,27 @@ let
         bind(s, ip"0.0.0.0", 2000, reuseaddr = true, enable_broadcast = true)
         s
     end
+
+    function wait_with_timeout(recvs)
+        TIMEOUT_VAL = 3  # seconds
+        t0 = time()
+        recvs_check = copy(recvs)
+        while ((length(filter!(t->!istaskdone(t), recvs_check)) > 0)
+              && (time() - t0 < TIMEOUT_VAL))
+            sleep(0.05)
+        end
+        length(recvs_check) > 0 && error("timeout")
+        map(wait, recvs)
+    end
+
     a, b, c = [create_socket() for i = 1:3]
     try
         # bsd family do not allow broadcasting to ip"255.255.255.255"
         # or ip"127.255.255.255"
         @static if !is_bsd() || is_apple()
-            @sync begin
-                send(c, bcastdst, 2000, "hello")
-                recvs = [@async @test String(recv(s)) == "hello" for s in (a, b)]
-                map(wait, recvs)
-            end
+            send(c, bcastdst, 2000, "hello")
+            recvs = [@async @test String(recv(s)) == "hello" for s in (a, b)]
+            wait_with_timeout(recvs)
         end
     catch e
         if isa(e, Base.UVError) && Base.uverrorname(e) == "EPERM"


### PR DESCRIPTION
About the first commit: Is there a better way to extract the value of C macro (`AF_INET6` in this case) at compile-time automatically? We currently hard-codes those magic value again and again; this is error-prone.

----

About the second commit: 
I just googled and found that bsd family cannot make UDP socket broadcast to `255.255.255.255` or `127.255.255.255`.

I test it with this c code:
https://gist.github.com/iblis17/3164f2167a83580e0f5e043ccdccb97a

On FreeBSD, NetBSD and OpenBSD, I got error on this udp broadcast testing.

FYR: https://lists.freebsd.org/pipermail/freebsd-questions/2009-January/190019.html
 