### PR TITLE
Improve docstrings for unique()

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1302,11 +1302,14 @@ end
 hash(x::Prehashed) = x.hash
 
 """
-    unique(itr[, dim])
+    unique(A::AbstractArray[, dim::Int])
 
-Returns an array containing only the unique elements of the iterable `itr`, in
-the order that the first of each set of equivalent elements originally appears.
-If `dim` is specified, returns unique regions of the array `itr` along `dim`.
+Return an array containing only the unique elements of `A`, as determined by
+[`isequal`](@ref), in the order that the first of each set of equivalent elements
+originally appears.
+
+If `dim` is specified, return unique regions of `A` along dimension `dim`.
+
 
 ```jldoctest
 julia> A = map(isodd, reshape(collect(1:8), (2,2,2)))

--- a/base/set.jl
+++ b/base/set.jl
@@ -123,8 +123,9 @@ const ⊆ = issubset
 """
     unique(itr)
 
-Returns an array containing one value from `itr` for each unique value,
-as determined by [`isequal`](@ref).
+Return an array containing only the unique elements of collection `itr`,
+as determined by [`isequal`](@ref), in the order that the first of each
+set of equivalent elements originally appears.
 
 ```jldoctest
 julia> unique([1; 2; 2; 6])


### PR DESCRIPTION
Remove any mention of ordering of the result, since for some custom array
types an order can be more natural, useful or efficient than the order of
appearance. Also fix the signature of the AbstractArray method, and add
a mention of isequal() to it. Use imperative form.