### PR TITLE
Fix jl_is_memdebug.

### DIFF
--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <assert.h>
 #include "julia.h"
+#include "options.h"
 
 #ifdef __cplusplus
 #include <cfenv>


### PR DESCRIPTION
Need to include options.h for MEMDEBUG to be available.