### PR TITLE
made ==(args...) with more than two args work

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -412,7 +412,7 @@ function afoldl(op,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,qs...)
     y
 end
 
-for op in (:+, :*, :&, :|, :xor, :min, :max, :kron)
+for op in (:+, :*, :&, :|, :(==), :xor, :min, :max, :kron)
     @eval begin
         # note: these definitions must not cause a dispatch loop when +(a,b) is
         # not defined, and must only try to call 2-argument definitions, so


### PR DESCRIPTION
Is there any reason `1==1==1` works but not `==(1,1,1)`? 

This PR makes it so the latter (or with more than two arguments) works. I'm not actually sure this is viewed as desired behavior though, but the fix was easy enough so I figured I'd ask via this PR. 

Note that it does *not* make `isequal(1,1,1)` work nor `===(1,1,1)`. I wasn't sure if that'd be intended so left them as is, but I could add those as well. 

It also doesn't short-circuit like `1==1==1` does but I could add that too.