### PR TITLE
Loosen signature on println_with_color

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -406,21 +406,21 @@ function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args.
 end
 
 """
-    print_with_color(color::Union{Symbol, Int}, [io], strings...; bold::Bool = false)
+    print_with_color(color::Union{Symbol, Int}, [io], xs...; bold::Bool = false)
 
-Print strings in a color specified as a symbol.
+Print `xs` in a color specified as a symbol.
 
 `color` may take any of the values $(Base.available_text_colors_docstring)
 or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
 If the keyword `bold` is given as `true`, the result will be printed in bold.
 """
-print_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...; bold::Bool = false) =
+print_with_color(color::Union{Int, Symbol}, io::IO, msg...; bold::Bool = false) =
     with_output_color(print, color, io, msg...; bold = bold)
-print_with_color(color::Union{Int, Symbol}, msg::AbstractString...; bold::Bool = false) =
+print_with_color(color::Union{Int, Symbol}, msg...; bold::Bool = false) =
     print_with_color(color, STDOUT, msg...; bold = bold)
-println_with_color(color::Union{Int, Symbol}, io::IO, msg::AbstractString...; bold::Bool = false) =
+println_with_color(color::Union{Int, Symbol}, io::IO, msg...; bold::Bool = false) =
     with_output_color(println, color, io, msg...; bold = bold)
-println_with_color(color::Union{Int, Symbol}, msg::AbstractString...; bold::Bool = false) =
+println_with_color(color::Union{Int, Symbol}, msg...; bold::Bool = false) =
     println_with_color(color, STDOUT, msg...; bold = bold)
 
 ## warnings and messages ##

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -572,6 +572,25 @@ let
     end
 end
 
+# Test that `print_with_color` accepts non-string values, just as `print` does
+let
+    old_have_color = Base.have_color
+    try
+        @eval Base have_color = true
+        buf_color = IOBuffer()
+        args = (3.2, "foo", :testsym)
+        print_with_color(:red, buf_color, args...)
+        buf_plain = IOBuffer()
+        print(buf_plain, args...)
+        expected_str = string(Base.text_colors[:red],
+                              String(take!(buf_plain)),
+                              Base.text_colors[:default])
+        @test expected_str == String(take!(buf_color))
+    finally
+        @eval Base have_color = $(old_have_color)
+    end
+end
+
 let
     global c_18711 = 0
     buf = IOContext(IOBuffer(), :hascontext => true)


### PR DESCRIPTION
It seems harmless and enables you to do things like `print_with_color(:red, 1)`. 