### PR TITLE
Fix two doctests quote

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -224,7 +224,7 @@ function sum(A::AbstractArray)
 end
 ```
 
-!!! Warning
+!!! warning
 
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -108,7 +108,7 @@ The keyword arguments can be any combination of:
 
  - `C` -- If `true`, backtraces from C and Fortran code are shown (normally they are excluded).
 
- - `combine` -- If true` (default), instruction pointers are merged that correspond to the same line of code.
+ - `combine` -- If `true` (default), instruction pointers are merged that correspond to the same line of code.
 
  - `maxdepth` -- Limits the depth higher than `maxdepth` in the `:tree` format.
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -251,6 +251,7 @@ true
 
 julia> isleaftype(Vector{Complex{Float32}})
 true
+```
 """
 isleaftype(t::ANY) = (@_pure_meta; isa(t, DataType) && t.isleaftype)
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -992,7 +992,7 @@ count (`length(q) == A.n`). Row-permutation `p`'s length must match `A`'s row co
 (`length(p) == A.m`).
 
 `C`'s dimensions must match those of `transpose(A)` (`C.m == A.n` and `C.n == A.m`), and `C`
-must have enough storage to accommodate all allocated entries in `A` (`length(C.rowval)` >= nnz(A)`
+must have enough storage to accommodate all allocated entries in `A` (`length(C.rowval) >= nnz(A)`
 and `length(C.nzval) >= nnz(A)`).
 
 For additional (algorithmic) information, and for versions of these methods that forgo
@@ -1272,7 +1272,7 @@ julia> sprand(rng, Bool, 2, 2, 0.5)
 julia> sprand(rng, Float64, 3, 0.75)
 3-element SparseVector{Float64,Int64} with 1 stored entry:
   [3]  =  0.298614
-````
+```
 """
 function sprand{T}(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat,
                 rfn::Function, ::Type{T}=eltype(rfn(r,1)))


### PR DESCRIPTION
Noticed when trying to link http://docs.julialang.org/en/latest/stdlib/base.html#Base.isleaftype

The really dumb function I used to search for this is
```julia
julia> function get_docs(m, visited=ObjectIdDict())
           println(m)
           visited[m] = m
           for n in names(m, true)
               (!isdefined(m, n) || Base.isdeprecated(m, n)) && continue
               obj = getfield(m, n)
               haskey(visited, obj) && continue
               visited[obj] = obj
               doc = Docs.doc(obj)
               if doc !== nothing && contains(sprint(Markdown.term, doc), "jldoctest")
                   println(obj)
                   display(doc)
               end
               obj isa Module && get_docs(obj, visited)
           end
       end
```

Would be nice if the doc compilation script can do something similar automatically.
