### PR TITLE
Set OpenBLAS `CROSS_SUFFIX` to `XC_HOST`

### DIFF
--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -4,7 +4,7 @@ OPENBLAS_GIT_URL := git://github.com/xianyi/OpenBLAS.git
 OPENBLAS_TAR_URL = https://api.github.com/repos/xianyi/OpenBLAS/tarball/$1
 $(eval $(call git-external,openblas,OPENBLAS,,,$(BUILDDIR)))
 
-OPENBLAS_BUILD_OPTS := CC="$(CC)" FC="$(FC)" RANLIB="$(RANLIB)" FFLAGS="$(FFLAGS) $(JFFLAGS)" TARGET=$(OPENBLAS_TARGET_ARCH) BINARY=$(BINARY)
+OPENBLAS_BUILD_OPTS := CC="$(CC)" FC="$(FC)" RANLIB="$(RANLIB)" FFLAGS="$(FFLAGS) $(JFFLAGS)" TARGET=$(OPENBLAS_TARGET_ARCH) BINARY=$(BINARY) CROSS_SUFFIX="$(CROSS_COMPILE)"
 
 # Thread support
 ifeq ($(OPENBLAS_USE_THREAD), 1)
@@ -48,7 +48,7 @@ endif
 
 # Decide whether to build for 32-bit or 64-bit arch
 ifneq ($(BUILD_OS),$(OS))
-OPENBLAS_BUILD_OPTS += OSNAME=$(OS) CROSS=1 HOSTCC=$(HOSTCC) CROSS_SUFFIX=$(CROSS_COMPILE)
+OPENBLAS_BUILD_OPTS += OSNAME=$(OS) CROSS=1 HOSTCC=$(HOSTCC)
 endif
 ifeq ($(OS),WINNT)
 ifneq ($(ARCH),x86_64)


### PR DESCRIPTION
OpenBLAS has some [cross compiler detection code](https://github.com/xianyi/OpenBLAS/blob/b678471d6566ee20732b89a0de9940d454682247/c_check#L38-L40) that looks at `CC` and autodetects the cross compiler prefix (not suffix, like the name says) by chopping everything off after the last `-`.  Unfortunately, when we define a custom `MARCH`, we set `CC` to `$(CC) -march=$(MARCH)`, which in the case of ARM builders can be something like `gcc -march=armv7-a`.  This causes OpenBLAS to think that we're cross-compiling, and our cross-compiler prefix is `gcc -march=armv7-`.  Everything works until we try and run `ar`, [which is defined as `$(CROSS_SUFFIX)ar`](https://github.com/xianyi/OpenBLAS/blob/f09a9afa0302ce3f6623c751a1bed9764c1c5817/Makefile.system#L200), which ends up as `gcc -march=armv7-ar`.  Hilariously close to something reasonable.

The fix in this PR is to manually set `CROSS_SUFFIX` to `XC_HOST`, thereby overriding OpenBLAS's faulty autodetection.  On non-cross-compiling builds, this sets `CROSS_SUFFIX` to the empty string, which works out just fine for us.