### PR TITLE
Remove incorrect JL_GC_POP

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -192,7 +192,6 @@ value_t fl_invoke_julia_macro(fl_context_t *fl_ctx, value_t *args, uint32_t narg
         margs[0] = jl_toplevel_eval(margs[0]);
         mfunc = jl_method_lookup(jl_gf_mtable(margs[0]), margs, nargs, 1, world);
         if (mfunc == NULL) {
-            JL_GC_POP();
             jl_method_error((jl_function_t*)margs[0], margs, nargs, world);
             // unreachable
         }


### PR DESCRIPTION
[Static analysis](https://github.com/Keno/ClangSA.jl) claims:
```
/home/keno/julia/src/ast.c:196:13: warning: Passing non-rooted value as argument to function that may GC
            jl_method_error((jl_function_t*)margs[0], margs, nargs, world);
            ^               ~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/ast.c:179:9: note: Assuming 'nargs' is >= 1
    if (nargs < 1)
        ^~~~~~~~~
/home/keno/julia/src/ast.c:179:5: note: Taking false branch
    if (nargs < 1)
    ^
/home/keno/julia/src/ast.c:186:14: note: Assuming 'i' is >= 'nargs'
    for(i=1; i < nargs; i++) margs[i] = scm_to_julia(fl_ctx, args[i], 1);
             ^~~~~~~~~
/home/keno/julia/src/ast.c:186:5: note: Loop condition is false. Execution continues on line 187
    for(i=1; i < nargs; i++) margs[i] = scm_to_julia(fl_ctx, args[i], 1);
    ^
/home/keno/julia/src/ast.c:194:13: note: Assuming 'mfunc' is equal to NULL
        if (mfunc == NULL) {
            ^~~~~~~~~~~~~
/home/keno/julia/src/ast.c:194:9: note: Taking true branch
        if (mfunc == NULL) {
        ^
/home/keno/julia/src/ast.c:196:45: note: Started tracking value here
            jl_method_error((jl_function_t*)margs[0], margs, nargs, world);
                                            ^~~~~~~~
/home/keno/julia/src/ast.c:196:13: note: Passing non-rooted value as argument to function that may GC
            jl_method_error((jl_function_t*)margs[0], margs, nargs, world);
            ^               ~~~~~~~~~~~~~~~~~~~~~~~~
```
May or may not be reachable from julia code, but good to fix anyway.