### PR TITLE
Make length for Date ranges type stable

### DIFF
--- a/base/dates/ranges.jl
+++ b/base/dates/ranges.jl
@@ -25,7 +25,7 @@ function len(a, b, c)
     end
     return i - 1
 end
-Base.length(r::StepRange{<:TimeType}) = isempty(r) ? 0 : len(r.start, r.stop, r.step) + 1
+Base.length(r::StepRange{<:TimeType}) = isempty(r) ? Int64(0) : len(r.start, r.stop, r.step) + 1
 # Period ranges hook into Int64 overflow detection
 Base.length(r::StepRange{<:Period}) = length(StepRange(value(r.start), value(r.step), value(r.stop)))
 

--- a/test/dates/ranges.jl
+++ b/test/dates/ranges.jl
@@ -11,7 +11,9 @@ let
             for pos_step in (P(1), P(2), P(50), P(2048), P(10000))
                 # empty range
                 dr = f1:pos_step:l1
-                @test length(dr) == 0
+                len = length(dr)
+                @test len == 0
+                @test isa(len, Int64)
                 @test isempty(dr)
                 @test first(dr) == f1
                 @test last(dr) < f1
@@ -36,7 +38,7 @@ let
                     dr = f:pos_step:l
                     len = length(dr)
                     @test len > 0
-                    @test typeof(len) <: Int64
+                    @test isa(len, Int64)
                     @test !isempty(dr)
                     @test first(dr) == f
                     @test last(dr) <= l
@@ -63,7 +65,9 @@ let
             for neg_step in (P(-1), P(-2), P(-50), P(-2048), P(-10000))
                 # empty range
                 dr = l1:neg_step:f1
-                @test length(dr) == 0
+                len = length(dr)
+                @test len == 0
+                @test isa(len, Int64)
                 @test isempty(dr)
                 @test first(dr) == l1
                 @test last(dr) > l1
@@ -88,7 +92,7 @@ let
                     dr = l:neg_step:f
                     len = length(dr)
                     @test len > 0
-                    @test typeof(len) <: Int64
+                    @test isa(len, Int64)
                     @test !isempty(dr)
                     @test first(dr) == l
                     @test last(dr) >= f
@@ -117,7 +121,9 @@ let
                 for pos_step in (P(1), P(2), P(50), P(2048), P(10000))
                     # empty range
                     dr = f1:pos_step:l1
-                    @test length(dr) == 0
+                    len = length(dr)
+                    @test len == 0
+                    @test isa(len, Int64)
                     @test isempty(dr)
                     @test first(dr) == f1
                     @test last(dr) < f1
@@ -142,7 +148,7 @@ let
                         dr = f:pos_step:l
                         len = length(dr)
                         @test len > 0
-                        @test typeof(len) <: Int64
+                        @test isa(len, Int64)
                         @test !isempty(dr)
                         @test first(dr) == f
                         @test last(dr) <= l
@@ -169,7 +175,9 @@ let
                 for neg_step in (P(-1), P(-2), P(-50), P(-2048), P(-10000))
                     # empty range
                     dr = l1:neg_step:f1
-                    @test length(dr) == 0
+                    len = length(dr)
+                    @test len == 0
+                    @test isa(len, Int64)
                     @test isempty(dr)
                     @test first(dr) == l1
                     @test last(dr) > l1
@@ -194,7 +202,7 @@ let
                         dr = l:neg_step:f
                         len = length(dr)
                         @test len > 0
-                        @test typeof(len) <: Int64
+                        @test isa(len, Int64)
                         @test !isempty(dr)
                         @test first(dr) == l
                         @test last(dr) >= f


### PR DESCRIPTION
On 32-bit systems the `length` method for a `StepRange{<:TimeType}` was type instable:

```julia
julia> @code_warntype length(Date(2014):Dates.Day(1):Date(2015))
Variables:
  #self#::Base.#length
  r::StepRange{Date,Base.Dates.Day}

Body:
  begin 
      unless (Base.and_int)((Base.not_int)(((Core.getfield)(r::StepRange{Date,Base.Dates.Day},:start)::Date === (Core.getfield)(r::StepRange{Date,Base.Dates.Day},:stop)::Date)::Bool)::Bool,(Base.not_int)(((Base.slt_int)((Base.sext_int)(Int64,0)::Int64,(Core.getfield)((Core.getfield)(r::StepRange{Date,Base.Dates.Day},:step)::Base.Dates.Day,:value)::Int64)::Bool === (Base.slt_int)((Core.getfield)((Core.getfield)((Core.getfield)((Core.getfield)(r::StepRange{Date,Base.Dates.Day},:start)::Date,:instant)::Base.Dates.UTInstant{Base.Dates.Day},:periods)::Base.Dates.Day,:value)::Int64,(Core.getfield)((Core.getfield)((Core.getfield)((Core.getfield)(r::StepRange{Date,Base.Dates.Day},:stop)::Date,:instant)::Base.Dates.UTInstant{Base.Dates.Day},:periods)::Base.Dates.Day,:value)::Int64)::Bool)::Bool)::Bool)::Bool goto 3
      return 0
      3: 
      SSAValue(0) = $(Expr(:invoke, MethodInstance for len(::Date, ::Date, ::Base.Dates.Day), :(Base.Dates.len), :((Core.getfield)(r,:start)::Date), :((Core.getfield)(r,:stop)::Date), :((Core.getfield)(r,:step)::Base.Dates.Day)))
      return (Base.add_int)(SSAValue(0),(Base.sext_int)(Int64,1)::Int64)::Int64
  end::Union{Int32,Int64}
```