### PR TITLE
Fix bug in diff_files, add test

### DIFF
--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -136,7 +136,7 @@ Returns only the *names* of the files which have changed, *not* their contents.
 Equivalent to `git diff --name-only --diff-filter=<filter> <branch1> <branch2>`.
 """
 function diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractString;
-                    filter::Set{Cint}=Set([Consts.DELTA_ADDED, Consts.DELTA_MODIFIED, Consts.DELTA_DELETED]))
+                    filter::Set{Consts.DELTA_STATUS}=Set([Consts.DELTA_ADDED, Consts.DELTA_MODIFIED, Consts.DELTA_DELETED]))
     b1_id = revparseid(repo, branch1*"^{tree}")
     b2_id = revparseid(repo, branch2*"^{tree}")
     tree1 = GitTree(repo, b1_id)
@@ -147,7 +147,7 @@ function diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractStr
         for i in 1:count(diff)
             delta = diff[i]
             delta === nothing && break
-            if delta.status in filter
+            if Consts.DELTA_STATUS(delta.status) in filter
                 push!(files, unsafe_string(delta.new_file.path))
             end
         end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -778,6 +778,10 @@ mktempdir() do dir
 
             newhead = LibGit2.head_oid(repo)
 
+            files = LibGit2.diff_files(repo, "branch/a", "branch/b", filter=Set([LibGit2.Consts.DELTA_ADDED]))
+            @test files == ["file3"]
+            files = LibGit2.diff_files(repo, "branch/a", "branch/b", filter=Set([LibGit2.Consts.DELTA_MODIFIED]))
+            @test files == []
             # switch back and rebase
             LibGit2.branch!(repo, "branch/a")
             newnewhead = LibGit2.rebase!(repo, "branch/b")


### PR DESCRIPTION
I accidentally broke this function with the change to an enum. It's fixed now and has some tests.