### PR TITLE
Fix doc dependency of light-source-dist target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
 branches:
   only:
     - master
-    - /release-.*/
+    - /^release-.*/
 notifications:
     email: false
     irc:

--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ endif
 	rm -fr $(BUILDROOT)/julia-$(JULIA_COMMIT)
 
 # this target does not accept BUILDROOT
-light-source-dist.tmp: $(JULIAHOME)/doc/_build/html
+light-source-dist.tmp: $(BUILDROOT)/doc/_build/html/en/index.html
 	# Save git information
 	-@$(MAKE) -C $(JULIAHOME)/base version_git.jl.phony
 

--- a/Makefile
+++ b/Makefile
@@ -480,8 +480,10 @@ else
 endif
 	rm -fr $(BUILDROOT)/julia-$(JULIA_COMMIT)
 
-# this target does not accept BUILDROOT
 light-source-dist.tmp: $(BUILDROOT)/doc/_build/html/en/index.html
+ifneq ($(BUILDROOT),$(JULIAHOME))
+	$(error make light-source-dist does not work in out-of-tree builds)
+endif
 	# Save git information
 	-@$(MAKE) -C $(JULIAHOME)/base version_git.jl.phony
 
@@ -491,7 +493,6 @@ light-source-dist.tmp: $(BUILDROOT)/doc/_build/html/en/index.html
 	find doc/_build/html >> light-source-dist.tmp
 
 # Make tarball with only Julia code
-# this target does not accept BUILDROOT
 light-source-dist: light-source-dist.tmp
 	# Prefix everything with the current directory name (usually "julia"), then create tarball
 	DIRNAME=$$(basename $$(pwd)); \
@@ -502,7 +503,6 @@ source-dist:
 	@echo \'source-dist\' target is deprecated: use \'full-source-dist\' instead.
 
 # Make tarball with Julia code plus all dependencies
-# this target does not accept BUILDROOT
 full-source-dist: light-source-dist.tmp
 	# Get all the dependencies downloaded
 	@$(MAKE) -C deps getall NO_GIT=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
 branches:
   only:
     - master
-    - /release-.*/
+    - /^release-.*/
 
 skip_commits:
 # Add [av skip] to commit messages for docfixes, etc to reduce load on queue

--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -69,7 +69,30 @@ gpg -u julia --armor --detach-sig julia-$version-linux-i686.tar.gz
 gpg -u julia --armor --detach-sig julia-$version-linux-arm.tar.gz
 gpg -u julia --armor --detach-sig julia-$version-linux-ppc64le.tar.gz
 
-echo "All files prepared. Attach julia-$version.tar.gz and julia-$version-full.tar.gz"
-echo "to github releases, upload all binaries and checksums to julialang S3. Be sure"
-echo "to set all S3 uploads to publicly readable, and replace $majmin-latest binaries."
-# TODO: also automate uploads via aws cli and github api?
+aws configure
+aws s3 cp --acl public-read julia-$version.sha256 s3://julialang/bin/checksums/
+aws s3 cp --acl public-read julia-$version.md5 s3://julialang/bin/checksums/
+for plat in x86_64 i686 arm ppc64le; do
+  platshort=$(echo $plat | sed -e 's/x86_64/x64/' -e 's/i686/x86/')
+  aws s3 cp --acl public-read julia-$version-linux-$plat.tar.gz \
+    s3://julialang/bin/linux/$platshort/$majmin/
+  aws s3 cp --acl public-read julia-$version-linux-$plat.tar.gz.asc \
+    s3://julialang/bin/linux/$platshort/$majmin/
+  aws s3 cp --acl public-read julia-$majmin-latest-linux-$plat.tar.gz \
+    s3://julialang/bin/linux/$platshort/$majmin/
+done
+aws s3 cp --acl public-read "julia-$version-osx10.7 .dmg" \
+  s3://julialang/bin/osx/x64/$majmin/
+aws s3 cp --acl public-read "julia-$majmin-latest-osx10.7 .dmg" \
+  s3://julialang/bin/osx/x64/$majmin/
+aws s3 cp --acl public-read "julia-$version-win64.exe" \
+  s3://julialang/bin/winnt/x64/$majmin/
+aws s3 cp --acl public-read "julia-$majmin-latest-win64.exe" \
+  s3://julialang/bin/winnt/x64/$majmin/
+aws s3 cp --acl public-read "julia-$version-win32.exe" \
+  s3://julialang/bin/winnt/x86/$majmin/
+aws s3 cp --acl public-read "julia-$majmin-latest-win32.exe" \
+  s3://julialang/bin/winnt/x86/$majmin/
+
+echo "All files prepared. Attach julia-$version.tar.gz"
+echo "and julia-$version-full.tar.gz to github releases."

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -851,10 +851,10 @@ public:
             VMap[&*I] = &*(DestI++);        // Add mapping to VMap
         }
 
-    #if JL_LLVM_VERSION >= 30600
+#if JL_LLVM_VERSION >= 30600
         // Clone debug info - Not yet public API
         // llvm::CloneDebugInfoMetadata(NewF,F,VMap);
-    #endif
+#endif
 
         SmallVector<ReturnInst*, 8> Returns;
         llvm::CloneFunctionInto(NewF,F,VMap,true,Returns,"",NULL,NULL,this);
@@ -912,10 +912,10 @@ public:
                     if (oldF)
                         return oldF;
 
-                    #ifdef USE_ORCJIT
+#ifdef USE_ORCJIT
                     if (jl_ExecutionEngine->findSymbol(F->getName(), false))
                         return InjectFunctionProto(F);
-                    #endif
+#endif
 
                     return CloneFunctionProto(shadow);
                 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -153,14 +153,14 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
     }
     if (jl_is_primitivetype(jt)) {
         uint64_t SizeInBits = jl_datatype_nbits(jdt);
-    #if JL_LLVM_VERSION >= 40000
+#if JL_LLVM_VERSION >= 40000
         llvm::DIType *t = dbuilder->createBasicType(
                 jl_symbol_name(jdt->name->name),
                 SizeInBits,
                 llvm::dwarf::DW_ATE_unsigned);
         jdt->ditype = t;
         return t;
-    #elif JL_LLVM_VERSION >= 30700
+#elif JL_LLVM_VERSION >= 30700
         llvm::DIType *t = dbuilder->createBasicType(
                 jl_symbol_name(jdt->name->name),
                 SizeInBits,
@@ -168,7 +168,7 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
                 llvm::dwarf::DW_ATE_unsigned);
         jdt->ditype = t;
         return t;
-    #else
+#else
         DIType t = dbuilder->createBasicType(
                 jl_symbol_name(jdt->name->name),
                 SizeInBits,
@@ -177,9 +177,9 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
         MDNode *M = t;
         jdt->ditype = M;
         return t;
-    #endif
+#endif
     }
-    #if JL_LLVM_VERSION >= 30700
+#if JL_LLVM_VERSION >= 30700
     else if (!jl_is_leaf_type(jt)) {
         jdt->ditype = jl_pvalue_dillvmt;
         return jl_pvalue_dillvmt;
@@ -217,7 +217,7 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
             jl_symbol_name(jdt->name->name), NULL, 0, NULL);
         return (llvm::DIType*)jdt->ditype;
     }
-    #endif
+#endif
     // TODO: Fixme
     return jl_pvalue_dillvmt;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1213,11 +1213,11 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
             bool toplevel = li->def == NULL;
             if (!toplevel) {
                 const DataLayout &DL =
-    #if JL_LLVM_VERSION >= 30500
+#if JL_LLVM_VERSION >= 30500
                     m->getDataLayout();
-    #else
+#else
                     *jl_data_layout;
-    #endif
+#endif
                 // but don't remember toplevel thunks because
                 // they may not be rooted in the gc for the life of the program,
                 // and the runtime doesn't notify us when the code becomes unreachable :(

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -33,6 +33,7 @@
 #include <cstdio>
 #include <cassert>
 #include <iostream>
+#include <functional>
 
 // target machine computation
 #include <llvm/Target/TargetSubtargetInfo.h>


### PR DESCRIPTION
and a few other not-so-consequential things
- `#include <functional>` in codegen.cpp for msvc
- make ci branch whitelist regexes "starts with release-\*" instead of "contains release-\*"
- left-align preprocessor conditionals