### PR TITLE
improve optimization passes to produce more compact IR

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -4605,6 +4605,12 @@ function get_replacement(table, var::Union{SlotNumber, SSAValue}, init::ANY, nar
             return init
         end
     elseif isa(init, SSAValue)
+        if isa(var, SlotNumber) && slottypes[var.id] ⊑ Tuple
+            # Here we avoid replacing a Slot with an SSAValue when the type is an
+            # aggregate. That can cause LLVM to generate a bunch of extra memcpys
+            # if the data ever needs to be stack allocated later.
+            return var
+        end
         if haskey(table, init)
             return get_replacement(table, init, table[init], nargs, slottypes, ssavaluetypes)
         end


### PR DESCRIPTION
I've noticed a few functions with pretty bloated IR (redundant variables, useless statements, etc.). This improves the optimization passes to address some of these cases. An extreme example is vector+vector broadcast, which with these changes goes from 248 statements to 127.