### PR TITLE
Integrate OpenBLAS fix for cross compiler autodetection

### DIFF
--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -91,7 +91,13 @@ $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-clangasmbug.patch-applied: $(BUILDDIR)/
 	cd $(BUILDDIR)/$(OPENBLAS_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/openblas-clangasmbug.patch
 	echo 1 > $@
 
-$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-clangasmbug.patch-applied
+# Cross compiler autodetection workaround from https://github.com/xianyi/OpenBLAS/pull/968
+# Remove this when we upgrade beyond OpenBLAS v0.2.19
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-cross-compile.patch-applied: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-clangasmbug.patch-applied
+	cd $(BUILDDIR)/$(OPENBLAS_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/openblas-cross-compile.patch
+	echo 1 > $@
+
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas-cross-compile.patch-applied
 	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' $(dir $<)/Makefile.system
 	echo 1 > $@
 

--- a/deps/patches/openblas-cross-compile.patch
+++ b/deps/patches/openblas-cross-compile.patch
@@ -1,13 +1,13 @@
 diff --git a/c_check b/c_check
-index 371dbf61..2ec9fc48 100644
+index 2ec9fc48..371dbf61 100644
 --- a/c_check
 +++ b/c_check
 @@ -34,7 +34,7 @@ if (dirname($compiler_name) ne ".") {
      $cross_suffix .= dirname($compiler_name) . "/";
  }
  
--if (basename($compiler_name) =~ /([^\s]*-)(.*)/) {
-+if (basename($compiler_name) =~ /(.*-)(.*)/) {
+-if (basename($compiler_name) =~ /(.*-)(.*)/) {
++if (basename($compiler_name) =~ /([^\s]*-)(.*)/) {
      $cross_suffix .= $1;
  }
  

--- a/deps/patches/openblas-cross-compile.patch
+++ b/deps/patches/openblas-cross-compile.patch
@@ -1,0 +1,13 @@
+diff --git a/c_check b/c_check
+index 371dbf61..2ec9fc48 100644
+--- a/c_check
++++ b/c_check
+@@ -34,7 +34,7 @@ if (dirname($compiler_name) ne ".") {
+     $cross_suffix .= dirname($compiler_name) . "/";
+ }
+ 
+-if (basename($compiler_name) =~ /([^\s]*-)(.*)/) {
++if (basename($compiler_name) =~ /(.*-)(.*)/) {
+     $cross_suffix .= $1;
+ }
+ 


### PR DESCRIPTION
Supersedes https://github.com/JuliaLang/julia/pull/20831 with just backporting the patch from OpenBLAS `develop`.