### PR TITLE
Infer a missing method as returning `Union{}`

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1385,10 +1385,6 @@ function abstract_call_gf_by_type(f::ANY, atype::ANY, sv::InferenceState)
         add_mt_backedge(ftname.mt, argtype, sv)
         update_valid_age!(min_valid[1], max_valid[1], sv)
     end
-    if isempty(x)
-        # TODO: this is needed because type intersection is wrong in some cases
-        return Any
-    end
     #print("=> ", rettype, "\n")
     return rettype
 end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -684,3 +684,6 @@ Base.@pure function a20704(x)
 end
 aa20704(x) = x(nothing)
 @test code_typed(aa20704, (typeof(a20704),))[1][1].pure
+
+# missing method should be inferred as Union{}, ref https://github.com/JuliaLang/julia/issues/20033#issuecomment-282228948
+@test Base.return_types(f -> f(1), (typeof((x::String) -> x),)) == Any[Union{}]

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -193,7 +193,7 @@ gstr = GenericString("12")
 @test ind2chr(gstr,2)==2
 
 # issue #10307
-@test typeof(map(Int16,AbstractString[])) == Vector{Int16}
+@test typeof(map(x -> parse(Int16, x), AbstractString[])) == Vector{Int16}
 
 for T in [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128]
     for i in [typemax(T), typemin(T)]


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/issues/20033#issuecomment-282228948 and https://github.com/JuliaLang/julia/commit/0b8f0b7dc406aabdd1de700b716c5fe700fa5cca#commitcomment-21033206.