### PR TITLE
Deprecate parse(::AbstractString, ::DateFormat)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1278,6 +1278,14 @@ end
 @deprecate_binding LinearSlow IndexCartesian false
 @deprecate_binding linearindexing IndexStyle false
 
+# #20876
+@eval Base.Dates begin
+    function Base.Dates.parse(x::AbstractString, df::DateFormat)
+        Base.depwarn("`Dates.parse(x::AbstractString, df::DateFormat)` is deprecated, use `sort!(parse(Array{Dates.Period}, x, df), rev=true, lt=Dates.periodisless)` instead.", :parse)
+        sort!(parse(Array{Period}, x, df), rev=true, lt=periodisless)
+     end
+end
+
 # END 0.6 deprecations
 
 # BEGIN 1.0 deprecations

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -29,10 +29,18 @@
 # DateTime parsing
 # Useful reference for different locales: http://library.princeton.edu/departments/tsd/katmandu/reference/months.html
 
-let str = "1996/02/15 24:00", format = "yyyy/mm/dd HH:MM"
-    expected = (1996, 2, 15, 24, 0, 0, 0)
-    @test get(Dates.tryparse_internal(DateTime, str, Dates.DateFormat(format))) == expected
+# Using parse(::Array{Period}, ...) allows for more flexibility.
+let str = "02/15/1996 24:00", format = Dates.DateFormat("mm/dd/yyyy HH:MM"), T = Array{Dates.Period}
     @test_throws ArgumentError Dates.DateTime(str, Dates.DateFormat(format))
+
+    expected = [Dates.Month(2), Dates.Day(15), Dates.Year(1996), Dates.Hour(24), Dates.Minute(0)]
+    @test Dates.parse(T, str, Dates.DateFormat(format)) == expected
+end
+
+let T = Array{Dates.Period}
+    expected = Dates.Period[Dates.Year(2017), Dates.Month(3)]
+    @test Dates.parse(T, "2017-03", DateFormat("yyyy-mm-dd")) == expected
+    @test_throws ArgumentError Dates.parse(T, "2017-03-03", DateFormat("yyyy-mm"))
 end
 
 # DateFormat printing


### PR DESCRIPTION
Properly deprecates the `Dates.parse(::AbstractString, ::DateFormat) -> Array{Period}` function and replaces it with `parse(::Type{Array{Period}}, ::AbstractString, ::DateFormat) -> Array{Period}`. Note that the replacement slightly differs from the original function by returning the periods in the order of the `DateFormat` tokens and in period sorted order.

Fixes #20876