### PR TITLE
Enable assertion in C++ code in debug/force assertion build

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -316,9 +316,13 @@ JULIACODEGEN := LLVM
 
 # flag for disabling assertions
 ifeq ($(FORCE_ASSERTIONS), 1)
+# C++ code needs to include LLVM header with the same assertion flag as LLVM
+# Use this flag to re-enable assertion in our code after all the LLVM headers are included
+CXX_DISABLE_ASSERTION :=
 DISABLE_ASSERTIONS :=
 else
-DISABLE_ASSERTIONS := -DNDEBUG
+CXX_DISABLE_ASSERTION := -DJL_NDEBUG
+DISABLE_ASSERTIONS := -DNDEBUG -DJL_NDEBUG
 endif
 
 # Compiler specific stuff

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -6,6 +6,8 @@
 #include <llvm/ADT/APFloat.h>
 #include <llvm/Support/MathExtras.h>
 
+#include "fix_llvm_assert.h"
+
 #include "APInt-C.h"
 #include "julia.h"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -141,7 +141,7 @@ $(BUILDDIR)/%.o: $(SRCDIR)/%.c $(HEADERS) | $(BUILDDIR)
 $(BUILDDIR)/%.dbg.obj: $(SRCDIR)/%.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 $(BUILDDIR)/%.o: $(SRCDIR)/%.cpp $(SRCDIR)/llvm-version.h $(HEADERS) $(LLVM_CONFIG_ABSOLUTE) | $(BUILDDIR)
-	@$(call PRINT_CC, $(CXX) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(SHIPFLAGS) -c $< -o $@)
+	@$(call PRINT_CC, $(CXX) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(SHIPFLAGS) $(CXX_DISABLE_ASSERTION) -c $< -o $@)
 $(BUILDDIR)/%.dbg.obj: $(SRCDIR)/%.cpp $(SRCDIR)/llvm-version.h $(HEADERS) $(LLVM_CONFIG_ABSOLUTE) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CXX) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -2039,7 +2039,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                 assert(rtsz > 0);
                 Value *strct = emit_allocobj(ctx, rtsz, runtime_bt);
                 int boxalign = jl_gc_alignment(rtsz);
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
 #if JL_LLVM_VERSION >= 30600
                 const DataLayout &DL = jl_ExecutionEngine->getDataLayout();
 #else

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -6,12 +6,14 @@
 
 #ifdef USE_MCJIT
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include "fix_llvm_assert.h"
 #include "julia.h"
 #include "julia_internal.h"
 
 #if JL_LLVM_VERSION >= 30700
 #if JL_LLVM_VERSION < 30800
 #  include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
+#  include "fix_llvm_assert.h"
 #endif
 #ifdef _OS_LINUX_
 #  include <sys/syscall.h>

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -528,7 +528,7 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, jl_unionall_t *ua, bool *isbox
                     jst->struct_decl = StructType::get(jl_LLVMContext, ArrayRef<Type*>(&latypes[0], ntypes));
                 }
             }
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
             // If LLVM and Julia disagree about alignment, much trouble ensues, so check it!
             if (jst->layout) {
                 const DataLayout &DL =
@@ -2001,7 +2001,7 @@ static void emit_unionmove(Value *dest, const jl_cgval_t &src, Value *skip, bool
             else
                 copy_bytes = builder.CreateSelect(skip, ConstantInt::get(copy_bytes->getType(), 0), copy_bytes);
         }
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
         // try to catch codegen errors early, before it uses this to memcpy over the entire stack
         CreateConditionalAbort(builder, builder.CreateICmpEQ(copy_bytes, ConstantInt::get(T_int32, -1)));
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -103,6 +103,7 @@
 #include <polly/RegisterPasses.h>
 #include <polly/ScopDetection.h>
 #endif
+#include "fix_llvm_assert.h"
 
 using namespace llvm;
 namespace llvm {
@@ -827,7 +828,7 @@ static void CreateTrap(IRBuilder<> &builder)
     builder.SetInsertPoint(newBB);
 }
 
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
 static void CreateConditionalAbort(IRBuilder<> &builder, Value *test)
 {
     Function *f = builder.GetInsertBlock()->getParent();
@@ -5714,7 +5715,7 @@ static std::unique_ptr<Module> emit_function(
         cur_prop.is_poploc = false;
         jl_value_t *stmt = jl_array_ptr_ref(stmts, i);
         jl_expr_t *expr = jl_is_expr(stmt) ? (jl_expr_t*)stmt : nullptr;
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
         if (jl_is_labelnode(stmt)) {
             size_t lname = jl_labelnode_label(stmt);
             if (lname != i + 1) {

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -34,10 +34,7 @@
 #if JL_LLVM_VERSION >= 30700
 #  include <llvm/Object/ELFObjectFile.h>
 #endif
-
-#if defined(USE_MCJIT) && JL_LLVM_VERSION < 30600 && defined(_OS_DARWIN_)
-#include "../deps/llvm-3.5.0/lib/ExecutionEngine/MCJIT/MCJIT.h"
-#endif
+#include "fix_llvm_assert.h"
 
 using namespace llvm;
 
@@ -1040,6 +1037,7 @@ template<typename T>
 static inline void ignoreError(T &err)
 {
 #if JL_LLVM_VERSION >= 30900 && !defined(NDEBUG)
+    // Needed only with LLVM assertion build
     consumeError(err.takeError());
 #endif
 }

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -83,6 +83,7 @@
 #else
 #include <llvm/DebugInfo.h>
 #endif
+#include "fix_llvm_assert.h"
 
 #include "julia.h"
 #include "julia_internal.h"

--- a/src/fix_llvm_assert.h
+++ b/src/fix_llvm_assert.h
@@ -1,0 +1,16 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+// Include this file after every blocks of LLVM includes to set the assertion back.
+
+#ifdef NDEBUG
+#  ifndef JL_NDEBUG
+#    undef NDEBUG
+#    include <assert.h>
+// Set NDEBUG back so that we can include another LLVM header right after
+#    define NDEBUG
+#  endif
+#else
+#  ifdef JL_NDEBUG
+#    undef JL_NDEBUG
+#  endif
+#endif

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -70,6 +70,7 @@ namespace llvm {
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringSet.h>
 #include <llvm/ADT/SmallSet.h>
+#include "fix_llvm_assert.h"
 
 using namespace llvm;
 
@@ -512,7 +513,7 @@ void *JuliaOJIT::getPointerToGlobalIfAvailable(const GlobalValue *GV)
 
 void JuliaOJIT::addModule(std::unique_ptr<Module> M)
 {
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
     // validate the relocations for M
     for (Module::iterator I = M->begin(), E = M->end(); I != E; ) {
         Function *F = &*I;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -40,6 +40,7 @@ extern PassManager *jl_globalPM;
 #if JL_LLVM_VERSION >= 30500
 #include <llvm/Target/TargetMachine.h>
 #endif
+#include "fix_llvm_assert.h"
 
 extern "C" {
     extern int globalUnique;

--- a/src/julia.h
+++ b/src/julia.h
@@ -984,7 +984,7 @@ JL_DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
 jl_value_t *jl_unwrap_unionall(jl_value_t *v);
 jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u);
 
-#ifdef NDEBUG
+#if defined(NDEBUG) && defined(JL_NDEBUG)
 STATIC_INLINE int jl_is_leaf_type_(jl_value_t *v)
 {
     return jl_is_datatype(v) && ((jl_datatype_t*)v)->isleaftype;

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -24,6 +24,8 @@
 #endif
 #include <llvm/IR/MDBuilder.h>
 
+#include "fix_llvm_assert.h"
+
 #include <vector>
 #include <queue>
 #include <set>
@@ -44,7 +46,7 @@ extern std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *pare
 
 namespace {
 
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
 static struct {
     unsigned count;
     unsigned locals;
@@ -778,7 +780,7 @@ void JuliaGCAllocator::allocate_frame()
                 if (CallInst *callInst = dyn_cast<CallInst>(user)) {
                     assert(bb == NULL);
                     bb = callInst->getParent();
-#ifdef NDEBUG
+#ifdef JL_NDEBUG
                     break;
 #endif
                 }
@@ -1130,7 +1132,7 @@ void JuliaGCAllocator::allocate_frame()
         }
     }
 
-#ifndef NDEBUG
+#ifndef JL_NDEBUG
     jl_gc_frame_stats.count++;
     jl_gc_frame_stats.locals += argSpaceSize;
     jl_gc_frame_stats.temp += maxDepth;
@@ -1232,7 +1234,7 @@ static RegisterPass<LowerGCFrame> X("LowerGCFrame", "Lower GCFrame Pass",
                                     false /* Analysis Pass */);
 }
 
-#ifndef NDEBUG // llvm assertions build
+#ifndef JL_NDEBUG // llvm assertions build
 // gdb debugging code for inspecting the bb_uses map
 void jl_dump_bb_uses(std::map<BasicBlock*, std::map<frame_register, liveness::id> > &bb_uses)
 {

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -22,12 +22,13 @@
 #endif
 #include <llvm/IR/MDBuilder.h>
 
-#include "julia.h"
-#include "julia_internal.h"
-
 #if JL_LLVM_VERSION >= 30700 && defined(JULIA_ENABLE_THREADING)
 #  include <llvm/IR/InlineAsm.h>
 #endif
+#include "fix_llvm_assert.h"
+
+#include "julia.h"
+#include "julia_internal.h"
 
 using namespace llvm;
 

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -14,6 +14,8 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/Support/Debug.h>
+#include "fix_llvm_assert.h"
+
 #include <cstdio>
 
 namespace llvm {

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
 #include <llvm/Config/llvm-config.h>
+#include "fix_llvm_assert.h"
 
 #ifndef LLVM_VERSION_PATCH // for LLVM 3.3
 #define LLVM_VERSION_PATCH 0

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -1,12 +1,13 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
+#include "llvm-version.h"
 #include <map>
 #include <string>
 #include <cstdio>
 #include <llvm/Support/Host.h>
+#include "fix_llvm_assert.h"
 #include "julia.h"
 #include "julia_internal.h"
-#include "llvm-version.h"
 using namespace llvm;
 
 // --- library symbol lookup ---


### PR DESCRIPTION
Even if LLVM assertion is off.

In a local build, this can trigger https://github.com/JuliaLang/julia/issues/20764 in the debug build and not the release builld, both without LLVM assertion.
