### PR TITLE
ensure codegen normalizes Type{Union{}}

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -4755,3 +4755,8 @@ end
     x::Vector{S}
     y::Vector{T}
 end
+
+let a = Array{Core.BottomType, 1}(2)
+    @test a[1] == Union{}
+    @test a == [Union{}, Union{}]
+end


### PR DESCRIPTION
otherwise, it can become confused why both Type{Union{}} and BottomType are both leaftypes that are not equal but are both accepted as the type of the constant singleton type object Union{}