### PR TITLE
fix broadcast! where the destination is a structured matrix

### DIFF
--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -1009,6 +1009,7 @@ struct PromoteToSparse end
 # broadcast containertype definitions for structured matrices
 StructuredMatrix = Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}
 _containertype(::Type{<:StructuredMatrix}) = PromoteToSparse
+broadcast_indices(::Type{PromoteToSparse}, A) = indices(A)
 
 # combinations explicitly involving Tuples and PromoteToSparse collections
 # divert to the generic AbstractArray broadcast code

--- a/test/sparse/higherorderfns.jl
+++ b/test/sparse/higherorderfns.jl
@@ -405,6 +405,33 @@ end
     end
 end
 
+@testset "broadcast! where the destination is a structured matrix" begin
+    # Where broadcast!'s destination is a structured matrix, broadcast! should fall back
+    # to the generic AbstractArray broadcast! code (at least for now).
+    N, p = 5, 0.4
+    A = sprand(N, N, p)
+    sA = A + transpose(A)
+    D = Diagonal(rand(N))
+    B = Bidiagonal(rand(N), rand(N - 1), true)
+    T = Tridiagonal(rand(N - 1), rand(N), rand(N - 1))
+    S = SymTridiagonal(rand(N), rand(N - 1))
+    # why some of the tests below are broken:
+    #   Diagonal setindex! allows setting off-diagonal entries to zero. Subtypes of
+    #   AbstractTriangular allow analogs. But Bidiagonal, Tridiagonal, and SymTridiagonal
+    #   do not, which seems like a bug. setindex! behavior like that for Diagonal and
+    #   subtypes of AbstractTriangular is necessary for Bidiagonal, Tridiagonal, and
+    #   SymTridiagonal to be targets of the AbstractArray broadcast! methods, hence
+    #   the test failures below.
+    @test broadcast!(sin, copy(D), D) == Diagonal(sin.(D))
+    @test_broken broadcast!(sin, copy(B), B) == Bidiagonal(sin.(B), true)
+    @test_broken broadcast!(sin, copy(T), T) == Tridiagonal(sin.(T))
+    @test_broken broadcast!(sin, copy(S), S) == SymTridiagonal(sin.(S))
+    @test broadcast!(*, copy(D), D, A) == Diagonal(broadcast(*, D, A))
+    @test_broken broadcast!(*, copy(B), B, A) == Bidiagonal(broadcast(*, B, A), true)
+    @test_broken broadcast!(*, copy(T), T, A) == Tridiagonal(broadcast(*, T, A))
+    @test_broken broadcast!(*, copy(S), T, sA) == SymTridiagonal(broadcast(*, T, sA))
+end
+
 @testset "map[!] over combinations of sparse and structured matrices" begin
     N, p = 10, 0.4
     A = sprand(N, N, p)


### PR DESCRIPTION
Due to an oversight in #19926, `broadcast!` where the destination is a structured matrix presently fails. This pull request fixes the preceding issue and adds tests to guard against regression.

Some of the tests are `@test_broken` for the following reason: While `Diagonal` `setindex!` (#11582) supports setting off-diagonal entries to zero (and similarly subtypes of `AbstractTriangular` provide analogous behavior), the other special matrix types (`Bidiagonal`, `Tridiagonal`, and `SymTridiagonal`) do not provide analogous behavior (they always throw, which I'm guessing was an oversight in #15092). That behavior is necessary for a given structured matrix type to function as a destination for `AbstractArray` `broadcast!`, hence the broken tests; I have a fix (separate PR) in the works for `setindex!` over `Bidiagonal`, `Tridiagonal`, and `SymTridiagonal`. Best!