### PR TITLE
Accept any callable object as input of `cfunction`

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -4,7 +4,7 @@
 
 import Core.Intrinsics: cglobal, bitcast
 
-cfunction(f::Function, r, a) = ccall(:jl_function_ptr, Ptr{Void}, (Any, Any, Any), f, r, a)
+cfunction(f, r, a) = ccall(:jl_function_ptr, Ptr{Void}, (Any, Any, Any), f, r, a)
 
 if ccall(:jl_is_char_signed, Ref{Bool}, ())
     const Cchar = Int8

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1239,3 +1239,10 @@ end
 
 # issue #20835
 @test_throws ErrorException eval(:(f20835(x) = ccall(:fn, Void, (Ptr{typeof(x)},), x)))
+
+# cfunction on non-function singleton
+struct CallableSingleton
+end
+(::CallableSingleton)(x, y) = x + y
+@test ccall(cfunction(CallableSingleton(), Int, Tuple{Int,Int}),
+            Int, (Int, Int), 1, 2) === 3


### PR DESCRIPTION
Just noticed that this has been sitting in a local branch for half a year now...... Technically a feature addition, though a very minor one. Noticed this when writing `FunctionWrappers.jl`........