### PR TITLE
Fix missing GC root

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2584,12 +2584,13 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
         // add it to the results.
         if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
             jl_svec_t *env = NULL;
-            JL_GC_PUSH1(&env);
+            jl_value_t *mti = NULL;
+            JL_GC_PUSH2(&env, &mti);
             for (size_t j = 0; j < jl_array_len(meth->ambig); j++) {
                 jl_method_t *mambig = (jl_method_t*)jl_array_ptr_ref(meth->ambig, j);
                 env = jl_emptysvec;
-                jl_value_t *mti = jl_type_intersection_env((jl_value_t*)closure->match.type,
-                                                           (jl_value_t*)mambig->sig, &env);
+                mti = jl_type_intersection_env((jl_value_t*)closure->match.type,
+                                               (jl_value_t*)mambig->sig, &env);
                 if (mti != (jl_value_t*)jl_bottom_type) {
                     if (closure->include_ambiguous) {
                         assert(done);
@@ -2602,8 +2603,8 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
                             if (len == 0) {
                                 closure->t = (jl_value_t*)jl_alloc_vec_any(0);
                             }
-                            jl_array_ptr_1d_push((jl_array_t*)closure->t,
-                                                 (jl_value_t*)jl_svec(3, mti, env, mambig));
+                            mti = (jl_value_t*)jl_svec(3, mti, env, mambig);
+                            jl_array_ptr_1d_push((jl_array_t*)closure->t, mti);
                             len++;
                         }
                     }


### PR DESCRIPTION
[Static analysis](https://github.com/Keno/ClangSA.jl) holds:
```
/home/keno/julia/src/gf.c:2597:63: warning: Argument value may have been GCed
                                                 (jl_value_t*)jl_svec(3, mti, env, mambig));
                                                              ^          ~~~
/home/keno/julia/src/gf.c:2501:9: note: Assuming the condition is false
    if (closure->world != 0) { // use zero as a flag value for returning all matches
        ^~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2501:5: note: Taking false branch
    if (closure->world != 0) { // use zero as a flag value for returning all matches
    ^
/home/keno/julia/src/gf.c:2532:9: note: Assuming the condition is false
    if (closure->lim >= 0) {
        ^~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2532:5: note: Taking false branch
    if (closure->lim >= 0) {
    ^
/home/keno/julia/src/gf.c:2556:5: note: Taking true branch
    if (!skip) {
    ^
/home/keno/julia/src/gf.c:2565:13: note: Assuming the condition is true
        if (closure0->issubty) {
            ^~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2565:9: note: Taking true branch
        if (closure0->issubty) {
        ^
/home/keno/julia/src/gf.c:2568:17: note: Assuming the condition is false
            if (!matched_all_tvars((jl_value_t*)ml->sig, jl_svec_data(env), jl_svec_len(env)))
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2568:13: note: Taking false branch
            if (!matched_all_tvars((jl_value_t*)ml->sig, jl_svec_data(env), jl_svec_len(env)))
            ^
/home/keno/julia/src/gf.c:2576:13: note: Left side of '&&' is true
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
            ^
/home/keno/julia/src/gf.c:2576:34: note: Assuming the condition is true
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2576:13: note: Left side of '&&' is true
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
            ^
/home/keno/julia/src/gf.c:2576:64: note: Assuming the condition is false
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2576:64: note: Left side of '||' is false
/home/keno/julia/src/gf.c:2576:9: note: Taking true branch
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
        ^
/home/keno/julia/src/gf.c:2578:13: note: GC frame changed here
            JL_GC_PUSH1(&env);
            ^~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2579:32: note: Assuming the condition is true
            for (size_t j = 0; j < jl_array_len(meth->ambig); j++) {
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2579:13: note: Loop condition is true. Entering loop body
            for (size_t j = 0; j < jl_array_len(meth->ambig); j++) {
            ^
/home/keno/julia/src/gf.c:2582:35: note: Started tracking value here
                jl_value_t *mti = jl_type_intersection_env((jl_value_t*)closure->match.type,
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2584:21: note: Assuming 'mti' is not equal to 'jl_bottom_type'
                if (mti != (jl_value_t*)jl_bottom_type) {
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2584:17: note: Taking true branch
                if (mti != (jl_value_t*)jl_bottom_type) {
                ^
/home/keno/julia/src/gf.c:2585:21: note: Taking true branch
                    if (closure->include_ambiguous) {
                    ^
/home/keno/julia/src/gf.c:2588:34: note: Assuming 'k' is >= 'len'
                        for(k=0; k < len; k++) {
                                 ^~~~~~~
/home/keno/julia/src/gf.c:2588:25: note: Loop condition is false. Execution continues on line 2592
                        for(k=0; k < len; k++) {
                        ^
/home/keno/julia/src/gf.c:2592:25: note: Taking true branch
                        if (k >= len) {
                        ^
/home/keno/julia/src/gf.c:2593:29: note: Taking true branch
                            if (len == 0) {
                            ^
/home/keno/julia/src/gf.c:2594:59: note: Value may have been GCed here
                                closure->t = (jl_value_t*)jl_alloc_vec_any(0);
                                                          ^~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2597:63: note: Argument value may have been GCed
                                                 (jl_value_t*)jl_svec(3, mti, env, mambig));
                                                              ^          ~~~
/home/keno/julia/src/gf.c:2597:63: warning: Passing non-rooted value as argument to function that may GC
                                                 (jl_value_t*)jl_svec(3, mti, env, mambig));
                                                              ^          ~~~
/home/keno/julia/src/gf.c:2501:9: note: Assuming the condition is false
    if (closure->world != 0) { // use zero as a flag value for returning all matches
        ^~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2501:5: note: Taking false branch
    if (closure->world != 0) { // use zero as a flag value for returning all matches
    ^
/home/keno/julia/src/gf.c:2532:9: note: Assuming the condition is false
    if (closure->lim >= 0) {
        ^~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2532:5: note: Taking false branch
    if (closure->lim >= 0) {
    ^
/home/keno/julia/src/gf.c:2556:5: note: Taking true branch
    if (!skip) {
    ^
/home/keno/julia/src/gf.c:2565:13: note: Assuming the condition is true
        if (closure0->issubty) {
            ^~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2565:9: note: Taking true branch
        if (closure0->issubty) {
        ^
/home/keno/julia/src/gf.c:2568:17: note: Assuming the condition is false
            if (!matched_all_tvars((jl_value_t*)ml->sig, jl_svec_data(env), jl_svec_len(env)))
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2568:13: note: Taking false branch
            if (!matched_all_tvars((jl_value_t*)ml->sig, jl_svec_data(env), jl_svec_len(env)))
            ^
/home/keno/julia/src/gf.c:2576:13: note: Left side of '&&' is true
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
            ^
/home/keno/julia/src/gf.c:2576:34: note: Assuming the condition is true
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2576:13: note: Left side of '&&' is true
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
            ^
/home/keno/julia/src/gf.c:2576:64: note: Assuming the condition is false
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2576:64: note: Left side of '||' is false
/home/keno/julia/src/gf.c:2576:9: note: Taking true branch
        if (return_this_match && meth->ambig != jl_nothing && (!closure->include_ambiguous || done)) {
        ^
/home/keno/julia/src/gf.c:2578:13: note: GC frame changed here
            JL_GC_PUSH1(&env);
            ^~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2579:32: note: Assuming the condition is true
            for (size_t j = 0; j < jl_array_len(meth->ambig); j++) {
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2579:13: note: Loop condition is true. Entering loop body
            for (size_t j = 0; j < jl_array_len(meth->ambig); j++) {
            ^
/home/keno/julia/src/gf.c:2582:35: note: Started tracking value here
                jl_value_t *mti = jl_type_intersection_env((jl_value_t*)closure->match.type,
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2584:21: note: Assuming 'mti' is not equal to 'jl_bottom_type'
                if (mti != (jl_value_t*)jl_bottom_type) {
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2584:17: note: Taking true branch
                if (mti != (jl_value_t*)jl_bottom_type) {
                ^
/home/keno/julia/src/gf.c:2585:21: note: Taking true branch
                    if (closure->include_ambiguous) {
                    ^
/home/keno/julia/src/gf.c:2588:34: note: Assuming 'k' is < 'len'
                        for(k=0; k < len; k++) {
                                 ^~~~~~~
/home/keno/julia/src/gf.c:2588:25: note: Loop condition is true. Entering loop body
                        for(k=0; k < len; k++) {
                        ^
/home/keno/julia/src/gf.c:2589:33: note: Assuming the condition is false
                            if ((jl_value_t*)mambig == jl_svecref(jl_array_ptr_ref(closure->t, k), 2))
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/gf.c:2589:29: note: Taking false branch
                            if ((jl_value_t*)mambig == jl_svecref(jl_array_ptr_ref(closure->t, k), 2))
                            ^
/home/keno/julia/src/gf.c:2588:34: note: Assuming 'k' is >= 'len'
                        for(k=0; k < len; k++) {
                                 ^~~~~~~
/home/keno/julia/src/gf.c:2588:25: note: Loop condition is false. Execution continues on line 2592
                        for(k=0; k < len; k++) {
                        ^
/home/keno/julia/src/gf.c:2592:25: note: Taking true branch
                        if (k >= len) {
                        ^
/home/keno/julia/src/gf.c:2593:29: note: Taking false branch
                            if (len == 0) {
                            ^
/home/keno/julia/src/gf.c:2597:63: note: Passing non-rooted value as argument to function that may GC
                                                 (jl_value_t*)jl_svec(3, mti, env, mambig));
                                                              ^          ~~~
```
We concur.

(committed without compiling, because my local code base currently doesn't compile - if I typo'd I'll fix this once I have things in order).