### PR TITLE
RFC: address issue #20882

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,8 +74,8 @@ Language changes
     `Vector{T} = Array{T,1}` or a `const` assignment.
 
   * Experimental feature: `x^n` for integer literals `n` (e.g. `x^3`
-    or `x^-3`) is now lowered to `x^Val{n}`, to enable compile-time
-    specialization for literal integer exponents ([#20530]).
+    or `x^-3`) is now lowered to `Base.literal_pow(x, Val{n}, ^)`, to enable
+    compile-time specialization for literal integer exponents ([#20530], [#20889]).
 
 Breaking changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -74,7 +74,7 @@ Language changes
     `Vector{T} = Array{T,1}` or a `const` assignment.
 
   * Experimental feature: `x^n` for integer literals `n` (e.g. `x^3`
-    or `x^-3`) is now lowered to `Base.literal_pow(x, Val{n}, ^)`, to enable
+    or `x^-3`) is now lowered to `Base.literal_pow(^, x, Val{n})`, to enable
     compile-time specialization for literal integer exponents ([#20530], [#20889]).
 
 Breaking changes

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -202,7 +202,7 @@ end
 # We mark these @inline since if the target is marked @inline,
 # we want to make sure that gets propagated,
 # even if it is over the inlining threshold.
-@inline literal_pow{p}(^, x, ::Type{Val{p}}) = ^(x,p)
+@inline literal_pow{p}(f, x, ::Type{Val{p}}) = f(x,p)
 
 # Restrict inlining to hardware-supported arithmetic types, which
 # are fast enough to benefit from inlining.

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -211,7 +211,7 @@ const HWNumber = Union{HWReal, Complex{<:HWReal}, Rational{<:HWReal}}
 
 # inference.jl has complicated logic to inline x^2 and x^3 for
 # numeric types.  In terms of Val we can do it much more simply.
-# (The third argument prevents unexpected behavior if a function ^
+# (The first argument prevents unexpected behavior if a function ^
 # is defined that is not equal to Base.^)
 @inline literal_pow(::typeof(^), x::HWNumber, ::Type{Val{0}}) = one(x)
 @inline literal_pow(::typeof(^), x::HWNumber, ::Type{Val{1}}) = x

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -203,8 +203,7 @@ end
 # We mark these @inline since if the target is marked @inline,
 # we want to make sure that gets propagated,
 # even if it is over the inlining threshold.
-@inline ^(x, p) = internal_pow(x, p)
-@inline internal_pow{p}(x, ::Type{Val{p}}) = x^p
+@inline internal_pow{p}(x, ::Type{Val{p}}, z) = z(x,p)
 
 # Restrict inlining to hardware-supported arithmetic types, which
 # are fast enough to benefit from inlining.  This also makes it
@@ -214,10 +213,10 @@ const HWNumber = Union{HWReal, Complex{<:HWReal}, Rational{<:HWReal}}
 
 # inference.jl has complicated logic to inline x^2 and x^3 for
 # numeric types.  In terms of Val we can do it much more simply:
-@inline internal_pow(x::HWNumber, ::Type{Val{0}}) = one(x)
-@inline internal_pow(x::HWNumber, ::Type{Val{1}}) = x
-@inline internal_pow(x::HWNumber, ::Type{Val{2}}) = x*x
-@inline internal_pow(x::HWNumber, ::Type{Val{3}}) = x*x*x
+@inline internal_pow(x::HWNumber, ::Type{Val{0}}, z::typeof(^)) = one(x)
+@inline internal_pow(x::HWNumber, ::Type{Val{1}}, z::typeof(^)) = x
+@inline internal_pow(x::HWNumber, ::Type{Val{2}}, z::typeof(^)) = x*x
+@inline internal_pow(x::HWNumber, ::Type{Val{3}}, z::typeof(^)) = x*x*x
 
 # b^p mod m
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -195,14 +195,14 @@ end
 ^(x::Number, p::Integer)  = power_by_squaring(x,p)
 ^(x, p::Integer)          = power_by_squaring(x,p)
 
-# x^p for any literal integer p is lowered to Base.literal_pow(x, Val{p}, ^)
+# x^p for any literal integer p is lowered to Base.literal_pow(^, x, Val{p})
 # to enable compile-time optimizations specialized to p.
 # However, we still need a fallback that calls the function ^ which may either
 # mean Base.^ or something else, depending on context.
 # We mark these @inline since if the target is marked @inline,
 # we want to make sure that gets propagated,
 # even if it is over the inlining threshold.
-@inline literal_pow{p}(x, ::Type{Val{p}}, z) = z(x,p)
+@inline literal_pow{p}(^, x, ::Type{Val{p}}) = ^(x,p)
 
 # Restrict inlining to hardware-supported arithmetic types, which
 # are fast enough to benefit from inlining.
@@ -213,10 +213,10 @@ const HWNumber = Union{HWReal, Complex{<:HWReal}, Rational{<:HWReal}}
 # numeric types.  In terms of Val we can do it much more simply.
 # (The third argument prevents unexpected behavior if a function ^
 # is defined that is not equal to Base.^)
-@inline literal_pow(x::HWNumber, ::Type{Val{0}}, ::typeof(^)) = one(x)
-@inline literal_pow(x::HWNumber, ::Type{Val{1}}, ::typeof(^)) = x
-@inline literal_pow(x::HWNumber, ::Type{Val{2}}, ::typeof(^)) = x*x
-@inline literal_pow(x::HWNumber, ::Type{Val{3}}, ::typeof(^)) = x*x*x
+@inline literal_pow(::typeof(^), x::HWNumber, ::Type{Val{0}}) = one(x)
+@inline literal_pow(::typeof(^), x::HWNumber, ::Type{Val{1}}) = x
+@inline literal_pow(::typeof(^), x::HWNumber, ::Type{Val{2}}) = x*x
+@inline literal_pow(::typeof(^), x::HWNumber, ::Type{Val{3}}) = x*x*x
 
 # b^p mod m
 

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -254,9 +254,11 @@ end
 Exponentiation operator. If `x` is a matrix, computes matrix exponentiation.
 
 If `y` is an `Int` literal (e.g. `2` in `x^2` or `-3` in `x^-3`), the Julia code
-`x^y` is transformed by the compiler to `x^Val{y}`, to enable compile-time
-specialization on the value of the exponent.  (As a default fallback,
-however, `x^Val{y}` simply calls the `^(x,y)` function.)
+`x^y` is transformed by the compiler to `Base.literal_pow(x, Val{y}, ^)`, to
+enable compile-time specialization on the value of the exponent.
+(As a default fallback, however, `Base.literal_pow(x, Val{y}, z)` simply calls
+`z(x,y)`, where usually `z == Base.^` unless `^` has been defined in the calling
+namespace.)
 
 ```jldoctest
 julia> 3^5

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -254,10 +254,10 @@ end
 Exponentiation operator. If `x` is a matrix, computes matrix exponentiation.
 
 If `y` is an `Int` literal (e.g. `2` in `x^2` or `-3` in `x^-3`), the Julia code
-`x^y` is transformed by the compiler to `Base.literal_pow(x, Val{y}, ^)`, to
+`x^y` is transformed by the compiler to `Base.literal_pow(^, x, Val{y})`, to
 enable compile-time specialization on the value of the exponent.
-(As a default fallback, however, `Base.literal_pow(x, Val{y}, z)` simply calls
-`z(x,y)`, where usually `z == Base.^` unless `^` has been defined in the calling
+(As a default fallback we have `Base.literal_pow(^, x, Val{y}) = ^(x,y)`,
+where usually `^ == Base.^` unless `^` has been defined in the calling
 namespace.)
 
 ```jldoctest

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2057,7 +2057,7 @@
 
                  ((and (eq? f '^) (length= e 4) (integer? (cadddr e)))
                   (expand-forms
-                   `(call ^ ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)))))
+                   `(call (|.| Base (quote internal_pow)) ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)) ^)))
 
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2057,7 +2057,7 @@
 
                  ((and (eq? f '^) (length= e 4) (integer? (cadddr e)))
                   (expand-forms
-                   `(call (|.| Base (quote literal_pow)) ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)) ^)))
+                   `(call (top literal_pow) ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)) ^)))
 
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2057,7 +2057,7 @@
 
                  ((and (eq? f '^) (length= e 4) (integer? (cadddr e)))
                   (expand-forms
-                   `(call (|.| Base (quote internal_pow)) ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)) ^)))
+                   `(call (|.| Base (quote literal_pow)) ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)) ^)))
 
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2057,7 +2057,7 @@
 
                  ((and (eq? f '^) (length= e 4) (integer? (cadddr e)))
                   (expand-forms
-                   `(call (top literal_pow) ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)) ^)))
+                   `(call (top literal_pow) ^ ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)))))
 
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2908,7 +2908,7 @@ struct PR20889; x; end
 ^(::PR20530, p::Int) = 1
 ^(t::PR20889, b) = t.x + b
 ^(t::PR20889, b::Integer) = t.x + b
-Base.literal_pow{p}(::PR20530, ::Type{Val{p}}, ::typeof(^)) = 2
+Base.literal_pow{p}(::typeof(^), ::PR20530, ::Type{Val{p}}) = 2
 @testset "literal powers" begin
     x = PR20530()
     p = 2

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2904,8 +2904,11 @@ end
 
 import Base.^
 immutable PR20530; end
+immutable PR20889; x; end
 ^(::PR20530, p::Int) = 1
-^{p}(::PR20530, ::Type{Val{p}}) = 2
+^(t::PR20889, b) = t.x + b
+^(t::PR20889, b::Integer) = t.x + b
+Base.literal_pow{p}(::PR20530, ::Type{Val{p}}, ::typeof(^)) = 2
 @testset "literal powers" begin
     x = PR20530()
     p = 2
@@ -2923,6 +2926,12 @@ immutable PR20530; end
             end
         end
     end
+    @test PR20889(2)^3 == 5
+end
+module M20889 # do we get the expected behavior without importing Base.^?
+    immutable PR20889; x; end
+    ^(t::PR20889, b) = t.x + b
+    Base.Test.@test PR20889(2)^3 == 5
 end
 
 @testset "iszero" begin

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2903,8 +2903,8 @@ end
 end
 
 import Base.^
-immutable PR20530; end
-immutable PR20889; x; end
+struct PR20530; end
+struct PR20889; x; end
 ^(::PR20530, p::Int) = 1
 ^(t::PR20889, b) = t.x + b
 ^(t::PR20889, b::Integer) = t.x + b
@@ -2929,7 +2929,7 @@ Base.literal_pow{p}(::PR20530, ::Type{Val{p}}, ::typeof(^)) = 2
     @test PR20889(2)^3 == 5
 end
 module M20889 # do we get the expected behavior without importing Base.^?
-    immutable PR20889; x; end
+    struct PR20889; x; end
     ^(t::PR20889, b) = t.x + b
     Base.Test.@test PR20889(2)^3 == 5
 end


### PR DESCRIPTION
This is exploratory (i.e. Friday night entertainment) and meant to demonstrate a proof-of-concept for how I might fix #20882, keeping the new `Val` type optimizations, while also making it much less confusing for average users. It is quite possible I overlooked something but I think this could be a nice solution.

After this PR:

```
julia> type T
    x
    end

julia> ^(t::T, b) = t.x + b
^ (generic function with 2 methods)

julia> T(2)^3
5
```

and if you import `Base.^`:

```
julia> import Base: ^

julia> type T
              x
              end

julia> ^(t::T, b) = t.x + b
^ (generic function with 52 methods)

julia> T(2)^3
ERROR: MethodError: ^(::T, ::Int64) is ambiguous. Candidates:
  ^(x, p::Integer) in Base at intfuncs.jl:196
  ^(t::T, b) in Main at REPL[3]:1
Stacktrace:
 [1] internal_pow(::T, ::Type{Val{3}}, ::Base.#^) at ./intfuncs.jl:206

julia> ^(t::T, b::Integer) = t.x + b
^ (generic function with 53 methods)

julia> T(2)^3
5
```
which is pretty much a recovery of the behavior you'd expect. Sure, `internal_pow` appears in the stack trace, so there may still be lingering concerns about referential transparency, but now the average user only has to reason about `^` as was the case in Julia 0.5. So, I think the concern becomes much more academic.

Some comments:

- `Base.internal_pow` takes three arguments, the third being the function that was called to get there, which could either be `Base.^` or a different function named `^` defined in a module that did not import `Base.^`.

- The optimizations for raising `HWNumber` to integer literal powers 0, 1, 2, 3 are only applied if `Base.^` is the operator, not if the user defines `^` without importing it. In this way, even if `^` is defined in a module, we will get predictable behavior for `HWNumber` types using a literal integer power:

```
julia> ^(x::Int, y::Int) = 7
^ (generic function with 52 methods)
julia> 2^0
7
```

The only downside of this PR that I can think of is that if the user is a type pirate and tries to override methods in Base, then they will discover that they cannot dodge the `Val` optimizations so easily:

```
julia> import Base: ^

julia> ^(x::Int, y::Int) = 7
^ (generic function with 52 methods)

julia> 2^0
1
```

- We still maintain our `Val` type optimizations for `HWNumber`s, which I infer from the fact that it does repeated multiplications for powers 1, 2, 3:
```
julia> import Base: *

julia> *(::Float64, ::Float64) = 2.0
WARNING: Method definition *(Float64, Float64) in module Base at float.jl:375 overwritten in module Main at REPL[2]:1.
* (generic function with 177 methods)

julia> 2.0^3
2.0
```
however, I don't really understand why `@code_lowered` then reports:
```
julia> @code_lowered 2.0^3
CodeInfo(:(begin 
        nothing
        nothing
        return x ^ (Base.Math.Float64)(y)
    end))
```
which is clearly not what is happening.

- To take advantage of the lowering operation for optimizations, you need to specialize `Base.internal_pow`, not `Base.^`. I don't consider this a problem personally, because only experts will need this specialization. I have not yet updated the tests to reflect this, so [these lines](https://github.com/JuliaLang/julia/blob/bb76add105e4dbda5185815fe0509b1b70fc0486/test/numbers.jl#L2907) need changing for the PR 20530 tests to pass. (edit: but otherwise, the tests should pass)

- No clue if there is a performance penalty, but I don't think I've introduced any type instabilities.