### PR TITLE
Optimize `isassigned` and inline `jl_array_isassigned`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -87,9 +87,10 @@ elsize{T}(a::Array{T}) = isbits(T) ? sizeof(T) : sizeof(Ptr)
 sizeof(a::Array) = elsize(a) * length(a)
 
 function isassigned(a::Array, i::Int...)
-    ii = sub2ind(size(a), i...)
-    1 <= ii <= length(a) || return false
-    ccall(:jl_array_isassigned, Cint, (Any, UInt), a, ii-1) == 1
+    @_inline_meta
+    ii = (sub2ind(size(a), i...) % UInt) - 1
+    ii < length(a) % UInt || return false
+    ccall(:jl_array_isassigned, Cint, (Any, UInt), a, ii) == 1
 end
 
 ## copy ##

--- a/src/julia.h
+++ b/src/julia.h
@@ -1085,12 +1085,14 @@ JL_DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt);
 #define jl_unbox_long(x) jl_unbox_int64(x)
 #define jl_is_long(x)    jl_is_int64(x)
 #define jl_long_type     jl_int64_type
+#define jl_ulong_type    jl_uint64_type
 #else
 #define jl_box_long(x)   jl_box_int32(x)
 #define jl_box_ulong(x)  jl_box_uint32(x)
 #define jl_unbox_long(x) jl_unbox_int32(x)
 #define jl_is_long(x)    jl_is_int32(x)
 #define jl_long_type     jl_int32_type
+#define jl_ulong_type    jl_uint32_type
 #endif
 
 // Each tuple can exist in one of 4 Vararg states:

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -784,6 +784,7 @@ JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
 int jl_array_store_unboxed(jl_value_t *el_type);
 int jl_array_isdefined(jl_value_t **args, int nargs);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
+JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);
 
 // -- synchronization utilities -- //
 


### PR DESCRIPTION
Yet another local stale branch....

@nanosoldier `runbenchmarks(ALL, vs = ":master")`
