### PR TITLE
fixes and stronger tests for Bidiagonal setindex! and friends

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -158,13 +158,18 @@ function getindex{T}(A::Bidiagonal{T}, i::Integer, j::Integer)
 end
 
 function setindex!(A::Bidiagonal, x, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
     if i == j
-        A.dv[i] = x
-    elseif (istriu(A) && (i == j - 1)) || (istril(A) && (i == j + 1))
-        return A.ev[min(i,j)] = x
-    else
-        throw(ArgumentError("cannot set elements outside main and $(istriu(A) ? "super": "sub") diagonals."))
+        @inbounds A.dv[i] = x
+    elseif istriu(A) && (i == j - 1)
+        @inbounds A.ev[i] = x
+    elseif istril(A) && (i == j + 1)
+        @inbounds A.ev[j] = x
+    elseif !iszero(x)
+        throw(ArgumentError(string("cannot set entry ($i, $j) off the ",
+            "$(istriu(A) ? "upper" : "lower") bidiagonal band to a nonzero value ($x)")))
     end
+    return x
 end
 
 ## structured matrix methods ##

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -30,23 +30,46 @@ srand(1)
         @test_throws ArgumentError Bidiagonal(dv,ev)
     end
 
-    BD = Bidiagonal(dv, ev, true)
     @testset "getindex, setindex!, size, and similar" begin
-        @test_throws BoundsError BD[n+1,1]
-        @test BD[2,2] == dv[2]
-        @test BD[2,3] == ev[2]
-        @test_throws ArgumentError BD[2,1] = 1
-        @test_throws ArgumentError BD[3,1] = 1
-        cBD = copy(BD)
-        cBD[2,2] = BD[2,2]
-        @test BD == cBD
-        @test_throws ArgumentError size(BD,0)
-        @test size(BD,3) == 1
-        @test isa(similar(BD), Bidiagonal{elty})
-        @test isa(similar(BD, Int), Bidiagonal{Int})
-        @test isa(similar(BD, Int, (3,2)), Matrix{Int})
+        ubd = Bidiagonal(dv, ev, true)
+        lbd = Bidiagonal(dv, ev, false)
+        # bidiagonal getindex / upper & lower
+        @test_throws BoundsError ubd[n + 1, 1]
+        @test_throws BoundsError ubd[1, n + 1]
+        @test ubd[2, 2] == dv[2]
+        # bidiagonal getindex / upper
+        @test ubd[2, 3] == ev[2]
+        @test iszero(ubd[3, 2])
+        # bidiagonal getindex / lower
+        @test lbd[3, 2] == ev[2]
+        @test iszero(lbd[2, 3])
+        # bidiagonal setindex! / upper
+        cubd = copy(ubd)
+        @test_throws ArgumentError ubd[2, 1] = 1
+        @test_throws ArgumentError ubd[3, 1] = 1
+        @test (cubd[2, 1] = 0; cubd == ubd)
+        @test ((cubd[1, 2] = 10) == 10; cubd[1, 2] == 10)
+        # bidiagonal setindex! / lower
+        clbd = copy(lbd)
+        @test_throws ArgumentError lbd[1, 2] = 1
+        @test_throws ArgumentError lbd[1, 3] = 1
+        @test (clbd[1, 2] = 0; clbd == lbd)
+        @test ((clbd[2, 1] = 10) == 10; clbd[2, 1] == 10)
+        # bidiagonal setindex! / upper & lower
+        @test_throws BoundsError ubd[n + 1, 1] = 1
+        @test_throws BoundsError ubd[1, n + 1] = 1
+        @test ((cubd[2, 2] = 10) == 10; cubd[2, 2] == 10)
+        # bidiagonal size
+        @test_throws ArgumentError size(ubd, 0)
+        @test size(ubd, 1) == size(ubd, 2) == n
+        @test size(ubd, 3) == 1
+        # bidiagonal similar
+        @test isa(similar(ubd), Bidiagonal{elty})
+        @test isa(similar(ubd, Int), Bidiagonal{Int})
+        @test isa(similar(ubd, Int, (3, 2)), Matrix{Int})
     end
 
+    BD = Bidiagonal(dv, ev, true)
     @testset "show" begin
         dstring = sprint(Base.print_matrix,BD.dv')
         estring = sprint(Base.print_matrix,BD.ev')


### PR DESCRIPTION
Ref. discussion in #20886. This pull request makes `Bidiagonal` `setindex!` support zero-assignment off the main and sub/super diagonal as appropriate, and expands and strengthens tests for `Bidiagonal` `setindex!`, `getindex`, and `size`. Best!