### PR TITLE
fixes and stronger tests for Tridiagonal setindex!

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -559,15 +559,18 @@ function getindex{T}(A::Tridiagonal{T}, i::Integer, j::Integer)
 end
 
 function setindex!(A::Tridiagonal, x, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
     if i == j
-        A.d[i] = x
+        @inbounds A.d[i] = x
     elseif i - j == 1
-        A.dl[j] = x
+        @inbounds A.dl[j] = x
     elseif j - i == 1
-        A.du[i] = x
-    else
-        throw(ArgumentError("cannot set elements outside the sub, main, or super diagonals"))
+        @inbounds A.du[i] = x
+    elseif !iszero(x)
+        throw(ArgumentError(string("cannot set entry ($i, $j) off ",
+            "the tridiagonal band to a nonzero value ($x)")))
     end
+    return x
 end
 
 ## structured matrix methods ##

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -459,12 +459,13 @@ let n = 12 #Size of matrix problem to test
         @test_throws BoundsError A[1,n+1]
 
         debug && println("setindex!")
-        @test_throws ArgumentError A[n,1] = 1
-        @test_throws ArgumentError A[1,n] = 1
-        A[3,3] = A[3,3]
-        A[2,3] = A[2,3]
-        A[3,2] = A[3,2]
-        @test A == fA
+        @test_throws BoundsError A[n + 1, 1] = 0 # test bounds check
+        @test_throws BoundsError A[1, n + 1] = 0 # test bounds check
+        @test (A[3, 3] = A[3, 3]; A == fA) # test assignment on the main diagonal
+        @test (A[3, 2] = A[3, 2]; A == fA) # test assignment on the subdiagonal
+        @test (A[2, 3] = A[2, 3]; A == fA) # test assignment on the superdiagonal
+        @test ((A[1, 3] = 0) == 0; A == fA) # test zero assignment off the main/sub/super diagonal
+        @test_throws ArgumentError A[1, 3] = 1 # test non-zero assignment off the main/sub/super diagonal
     end
 end
 


### PR DESCRIPTION
Ref. discussion in #20886. This pull request makes `Tridiagonal` `setindex!` support zero-assignment off the main, sub, and super diagonals, and expands and strengthens tests for `Tridiagonal` `setindex!`. Best!