### PR TITLE
a fix and stronger tests for Diagonal setindex!, and other concomitant test fixes

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -86,10 +86,10 @@ function setindex!(D::Diagonal, v, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)
     if i == j
         @inbounds D.diag[i] = v
-    elseif v != 0
-        throw(ArgumentError("cannot set an off-diagonal index ($i, $j) to a nonzero value ($v)"))
+    elseif !iszero(v)
+        throw(ArgumentError("cannot set off-diagonal entry ($i, $j) to a nonzero value ($v)"))
     end
-    D
+    return v
 end
 
 


### PR DESCRIPTION
Ref. discussion in #20886. This pull request makes `Diagonal` `setindex!` return the assigned value (like other `setindex!` methods) rather than the `Diagonal` matrix, and strengthens the associated tests. (Those tests were unintentionally coupled to other tests in test/linalg/diagonal.jl; this pull request also decouples, annotates, and reduces nonlocality of those other tests.) Best!