### PR TITLE
fixes and stronger tests for SymTridiagonal setindex!

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -375,13 +375,13 @@ function getindex{T}(A::SymTridiagonal{T}, i::Integer, j::Integer)
 end
 
 function setindex!(A::SymTridiagonal, x, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
     if i == j
-        A.dv[i] = x
-    elseif abs(i - j) == 1
-        A.ev[min(i,j)] = x
+        @inbounds A.dv[i] = x
     else
-        throw(ArgumentError("cannot set elements outside the sub, main, or super diagonals"))
+        throw(ArgumentError("cannot set off-diagonal entry ($i, $j)"))
     end
+    return x
 end
 
 ## Tridiagonal matrices ##

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -266,12 +266,12 @@ let n = 12 #Size of matrix problem to test
         @test A[1,1] == a[1]
 
         debug && println("setindex!")
-        @test_throws ArgumentError A[n,1] = 1
-        @test_throws ArgumentError A[1,n] = 1
-        A[3,3] = A[3,3]
-        A[2,3] = A[2,3]
-        A[3,2] = A[3,2]
-        @test A == fA
+        @test_throws BoundsError A[n + 1, 1] = 0 # test bounds check
+        @test_throws BoundsError A[1, n + 1] = 0 # test bounds check
+        @test ((A[3, 3] = A[3, 3]) == A[3, 3]; A == fA) # test assignment on the main diagonal
+        @test_throws ArgumentError A[3, 2] = 1 # test assignment on the subdiagonal
+        @test_throws ArgumentError A[2, 3] = 1 # test assignment on the superdiagonal
+        @test_throws ArgumentError A[1, 3] = 1 # test assignment off the main/sub/super diagonal
 
         debug && println("Diagonal extraction")
         @test diag(A,1) == b

--- a/test/sparse/higherorderfns.jl
+++ b/test/sparse/higherorderfns.jl
@@ -424,18 +424,14 @@ end
     D = Diagonal(rand(N))
     B = Bidiagonal(rand(N), rand(N - 1), true)
     T = Tridiagonal(rand(N - 1), rand(N), rand(N - 1))
-    S = SymTridiagonal(rand(N), rand(N - 1))
-    # why some of the tests below are broken:
-    #   Diagonal setindex! allows setting off-diagonal entries to zero. Subtypes of
-    #   AbstractTriangular allow analogs.
     @test broadcast!(sin, copy(D), D) == Diagonal(sin.(D))
     @test broadcast!(sin, copy(B), B) == Bidiagonal(sin.(B), true)
     @test broadcast!(sin, copy(T), T) == Tridiagonal(sin.(T))
-    @test_broken broadcast!(sin, copy(S), S) == SymTridiagonal(sin.(S))
     @test broadcast!(*, copy(D), D, A) == Diagonal(broadcast(*, D, A))
     @test broadcast!(*, copy(B), B, A) == Bidiagonal(broadcast(*, B, A), true)
     @test broadcast!(*, copy(T), T, A) == Tridiagonal(broadcast(*, T, A))
-    @test_broken broadcast!(*, copy(S), T, sA) == SymTridiagonal(broadcast(*, T, sA))
+    # SymTridiagonal (and similar symmetric matrix types) do not support setindex!
+    # off the diagonal, and so cannot serve as a destination for broadcast!
 end
 
 @testset "map[!] over combinations of sparse and structured matrices" begin


### PR DESCRIPTION
Ref. discussion in #20886. This pull request makes `SymTridiagonal` `setindex!` no longer support off-diagonal assignment of any form and strengthens associated tests. Best!