### PR TITLE
Add peel convenience method

### DIFF
--- a/base/libgit2/merge.jl
+++ b/base/libgit2/merge.jl
@@ -25,8 +25,7 @@ function GitAnnotated(repo::GitRepo, fh::FetchHead)
 end
 
 function GitAnnotated(repo::GitRepo, comittish::AbstractString)
-    obj = GitObject(repo, comittish)
-    cmt = peel(GitCommit, obj)
+    cmt = peel(GitCommit, repo, comittish)
     return GitAnnotated(repo, GitHash(cmt))
 end
 

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -297,7 +297,7 @@ end
 Recursively peel the object in `repo` specified by `spec` until an object of type `T` is
 found.
 """
-function peel{T<:GitObject}(::Type{T}, repo::GitRepo, spec::Union{AbstractGitHash, AbstractString})
+function peel(::Type{T}, repo::GitRepo, spec::Union{AbstractGitHash, AbstractString}) where T<:GitObject
     with(GitUnknownObject, repo, spec) do unkobj
         peel(T,unkobj)
     end

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -291,6 +291,18 @@ function Base.show(io::IO, result::GitDescribeResult)
     println(io, fmt_desc)
 end
 
+"""
+    peel(T, repo::GitRepo, spec::Union{AbstractGitHash, AbstractString})
+
+Recursively peel the object in `repo` specified by `spec` until an object of type `T` is
+found.
+"""
+function peel{T<:GitObject}(::Type{T}, repo::GitRepo, spec::Union{AbstractGitHash, AbstractString})
+    with(GitUnknownObject, repo, spec) do unkobj
+        peel(T,unkobj)
+    end
+end
+
 function checkout_tree(repo::GitRepo, obj::GitObject;
                        options::CheckoutOptions = CheckoutOptions())
     @check ccall((:git_checkout_tree, :libgit2), Cint,


### PR DESCRIPTION
This simplifies a common idiom whereby a user wants a `GitTree` or `GitCommit`, but could be passed a hash/string that refers to a "higher" object (i.e. a `GitTag`).