### PR TITLE
fix shape corner cases in sparse broadcast!(f, C, A, B)

### DIFF
--- a/test/sparse/higherorderfns.jl
+++ b/test/sparse/higherorderfns.jl
@@ -193,10 +193,10 @@ end
             @test (@allocated broadcast!(*, Z, X, Y)) == 0
             @test broadcast!(*, Z, X, Y) == sparse(broadcast!(*, fZ, fX, fY))
             # --> test broadcast! entry point / not zero-preserving op
-            fZo = broadcast(f, fX, fY); Z = sparse(fZo)
-            broadcast!(f, Z, X, Y); Z = sparse(fZo) # warmup for @allocated
+            broadcast!(f, fZ, fX, fY); Z = sparse(fZ)
+            broadcast!(f, Z, X, Y); Z = sparse(fZ) # warmup for @allocated
             @test (@allocated broadcast!(f, Z, X, Y)) == 0
-            @test broadcast!(f, Z, X, Y) == sparse(broadcast!(f, fZo, fX, fY))
+            @test broadcast!(f, Z, X, Y) == sparse(broadcast!(f, fZ, fX, fY))
             # --> test shape checks for both broadcast and broadcast! entry points
             # TODO strengthen this test, avoiding dependence on checking whether
             # broadcast_indices throws to determine whether sparse broadcast should throw


### PR DESCRIPTION
Sparse `broadcast!(f, C, A, B)` produces incorrect results where destination `C`'s shape does not match the broadcast-shape of sources `A` and `B`. (This issue is the analog of that described and fixed in #19986 for `broadcast!(f, C, A)`.) This pull request fixes that issue and strengthens associated tests (first commit covers zero-preserving functions, and the second commit not-zeropreserving functions). Best!