### PR TITLE
remove unused import from SparseArrays module

### DIFF
--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -26,8 +26,6 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     rotl90, rotr90, round, scale!, setindex!, similar, size, transpose, tril,
     triu, vec, permute!, map, map!
 
-import Base.Broadcast: broadcast_indices
-
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm, speye, spones,


### PR DESCRIPTION
`Base.Broadcast.broadcast_indices` is no longer used in `SparseArrays` outside of `SparseArrays.HigherOrderFns` (which imports that function separately), so remove the unused import. Best!