### PR TITLE
Always include FFTW docstrings, even when USE_GPL_LIBS=0

### DIFF
--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -1,12 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module FFTW
-
-import ..DFT: fft, bfft, ifft, rfft, brfft, irfft, plan_fft, plan_bfft, plan_ifft, plan_rfft, plan_brfft, plan_irfft, fft!, bfft!, ifft!, plan_fft!, plan_bfft!, plan_ifft!, Plan, rfft_output_size, brfft_output_size, plan_inv, normalization, ScaledPlan
-
 import Base: show, *, convert, unsafe_convert, size, strides, ndims, pointer, A_mul_B!
-
-export r2r, r2r!, plan_r2r, plan_r2r!
 
 export export_wisdom, import_wisdom, import_system_wisdom, forget_wisdom,
        MEASURE, DESTROY_INPUT, UNALIGNED, CONSERVE_MEMORY, EXHAUSTIVE,
@@ -20,7 +14,8 @@ export export_wisdom, import_wisdom, import_system_wisdom, forget_wisdom,
 const libfftw = Base.libfftw_name
 const libfftwf = Base.libfftwf_name
 
-const version = convert(VersionNumber, split(unsafe_string(cglobal((:fftw_version,Base.DFT.FFTW.libfftw), UInt8)), ['-', ' '])[2])
+const version = convert(VersionNumber, split(unsafe_string(cglobal(
+    (:fftw_version,Base.DFT.FFTW.libfftw), UInt8)), ['-', ' '])[2])
 
 ## Direction of FFT
 
@@ -713,25 +708,6 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
     end
 end
 
-"""
-    plan_rfft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Pre-plan an optimized real-input FFT, similar to [`plan_fft`](@ref) except for
-[`rfft`](@ref) instead of [`fft`](@ref). The first two arguments, and the
-size of the transformed result, are the same as for [`rfft`](@ref).
-"""
-plan_rfft
-
-"""
-    plan_brfft(A, d [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Pre-plan an optimized real-input unnormalized transform, similar to
-[`plan_rfft`](@ref) except for [`brfft`](@ref) instead of
-[`rfft`](@ref). The first two arguments and the size of the transformed result, are
-the same as for [`brfft`](@ref).
-"""
-plan_brfft
-
 # FFTW r2r transforms (low-level interface)
 
 for f in (:r2r, :r2r!)
@@ -759,56 +735,6 @@ function plan_r2r!{T<:fftwNumber,N}(X::StridedArray{T,N}, kinds, region;
                                     timelimit::Real=NO_TIMELIMIT)
     r2rFFTWPlan{T,ANY,true,N}(X, X, region, kinds, flags, timelimit)
 end
-
-"""
-    r2r(A, kind [, dims])
-
-Performs a multidimensional real-input/real-output (r2r) transform
-of type `kind` of the array `A`, as defined in the FFTW manual.
-`kind` specifies either a discrete cosine transform of various types
-(`FFTW.REDFT00`, `FFTW.REDFT01`, `FFTW.REDFT10`, or
-`FFTW.REDFT11`), a discrete sine transform of various types
-(`FFTW.RODFT00`, `FFTW.RODFT01`, `FFTW.RODFT10`, or
-`FFTW.RODFT11`), a real-input DFT with halfcomplex-format output
-(`FFTW.R2HC` and its inverse `FFTW.HC2R`), or a discrete
-Hartley transform (`FFTW.DHT`).  The `kind` argument may be
-an array or tuple in order to specify different transform types
-along the different dimensions of `A`; `kind[end]` is used
-for any unspecified dimensions.  See the FFTW manual for precise
-definitions of these transform types, at http://www.fftw.org/doc.
-
-The optional `dims` argument specifies an iterable subset of
-dimensions (e.g. an integer, range, tuple, or array) to transform
-along. `kind[i]` is then the transform type for `dims[i]`,
-with `kind[end]` being used for `i > length(kind)`.
-
-See also [`plan_r2r`](@ref) to pre-plan optimized r2r transforms.
-"""
-FFTW.r2r
-
-"""
-    r2r!(A, kind [, dims])
-
-Same as [`r2r`](@ref), but operates in-place on `A`, which must be
-an array of real or complex floating-point numbers.
-"""
-FFTW.r2r!
-
-"""
-    plan_r2r!(A, kind [, dims [, flags [, timelimit]]])
-
-Similar to [`plan_fft`](@ref), but corresponds to [`r2r!`](@ref).
-"""
-FFTW.plan_r2r!
-
-"""
-    plan_r2r(A, kind [, dims [, flags [, timelimit]]])
-
-Pre-plan an optimized r2r transform, similar to [`plan_fft`](@ref)
-except that the transforms (and the first three arguments)
-correspond to [`r2r`](@ref) and [`r2r!`](@ref), respectively.
-"""
-FFTW.plan_r2r
 
 # mapping from r2r kind to the corresponding inverse transform
 const inv_kind = Dict{Int,Int}(R2HC => HC2R, HC2R => R2HC, DHT => DHT,
@@ -859,5 +785,3 @@ function *{T,K}(p::r2rFFTWPlan{T,K,true}, x::StridedArray{T})
 end
 
 include("dct.jl")
-
-end # module

--- a/base/fft/dct.jl
+++ b/base/fft/dct.jl
@@ -38,40 +38,6 @@ for (pf, pfr, K, inplace) in ((:plan_dct, :plan_r2r, REDFT10, false),
     end
 end
 
-"""
-    plan_dct!(A [, dims [, flags [, timelimit]]])
-
-Same as [`plan_dct`](@ref), but operates in-place on `A`.
-"""
-plan_dct!
-
-"""
-    plan_idct(A [, dims [, flags [, timelimit]]])
-
-Pre-plan an optimized inverse discrete cosine transform (DCT), similar to
-[`plan_fft`](@ref) except producing a function that computes
-[`idct`](@ref). The first two arguments have the same meaning as for
-[`idct`](@ref).
-"""
-plan_idct
-
-"""
-    plan_dct(A [, dims [, flags [, timelimit]]])
-
-Pre-plan an optimized discrete cosine transform (DCT), similar to
-[`plan_fft`](@ref) except producing a function that computes
-[`dct`](@ref). The first two arguments have the same meaning as for
-[`dct`](@ref).
-"""
-plan_dct
-
-"""
-    plan_idct!(A [, dims [, flags [, timelimit]]])
-
-Same as [`plan_idct`](@ref), but operates in-place on `A`.
-"""
-plan_idct!
-
 function plan_inv{T,K,inplace}(p::DCTPlan{T,K,inplace})
     X = Array{T}(p.plan.sz)
     iK = inv_kind[K]
@@ -92,45 +58,6 @@ for f in (:dct, :dct!, :idct, :idct!)
         $pf(x::AbstractArray{<:Complex}, region; kws...) = $pf(fftwcomplex(x), region; kws...)
     end
 end
-
-"""
-    dct(A [, dims])
-
-Performs a multidimensional type-II discrete cosine transform (DCT) of the array `A`, using
-the unitary normalization of the DCT. The optional `dims` argument specifies an iterable
-subset of dimensions (e.g. an integer, range, tuple, or array) to transform along.  Most
-efficient if the size of `A` along the transformed dimensions is a product of small primes;
-see [`nextprod`](@ref). See also [`plan_dct`](@ref) for even greater
-efficiency.
-"""
-dct
-
-"""
-    idct(A [, dims])
-
-Computes the multidimensional inverse discrete cosine transform (DCT) of the array `A`
-(technically, a type-III DCT with the unitary normalization). The optional `dims` argument
-specifies an iterable subset of dimensions (e.g. an integer, range, tuple, or array) to
-transform along.  Most efficient if the size of `A` along the transformed dimensions is a
-product of small primes; see [`nextprod`](@ref).  See also
-[`plan_idct`](@ref) for even greater efficiency.
-"""
-idct
-
-"""
-    dct!(A [, dims])
-
-Same as [`dct!`](@ref), except that it operates in-place on `A`, which must be an
-array of real or complex floating-point values.
-"""
-dct!
-
-"""
-    idct!(A [, dims])
-
-Same as [`idct!`](@ref), but operates in-place on `A`.
-"""
-idct!
 
 const sqrthalf = sqrt(0.5)
 const sqrt2 = sqrt(2.0)


### PR DESCRIPTION
Docs were failing to build without this.