### PR TITLE
Speed up copy!(dest, Rdest, src, Rsrc) by splitting out first dimension

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2028,13 +2028,6 @@ algorithms. See [`muladd`](@ref).
 fma
 
 """
-    copy!(dest, src)
-
-Copy all elements from collection `src` to array `dest`. Returns `dest`.
-"""
-copy!(dest,src)
-
-"""
     copy!(dest, do, src, so, N)
 
 Copy `N` elements from collection `src` starting at offset `so`, to array `dest` starting at

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -65,22 +65,23 @@ module IteratorsMD
     one{N}(::Type{CartesianIndex{N}}) = CartesianIndex(ntuple(x -> 1, Val{N}))
 
     # arithmetic, min/max
-    (-){N}(index::CartesianIndex{N}) = CartesianIndex{N}(map(-, index.I))
-    (+){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+    @inline (-){N}(index::CartesianIndex{N}) =
+        CartesianIndex{N}(map(-, index.I))
+    @inline (+){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
         CartesianIndex{N}(map(+, index1.I, index2.I))
-    (-){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+    @inline (-){N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
         CartesianIndex{N}(map(-, index1.I, index2.I))
-    min{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+    @inline min{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
         CartesianIndex{N}(map(min, index1.I, index2.I))
-    max{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
+    @inline max{N}(index1::CartesianIndex{N}, index2::CartesianIndex{N}) =
         CartesianIndex{N}(map(max, index1.I, index2.I))
 
-    (+)(i::Integer, index::CartesianIndex) = index+i
-    (+){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x+i, index.I))
-    (-){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x-i, index.I))
-    (-){N}(i::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->i-x, index.I))
-    (*){N}(a::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->a*x, index.I))
-    (*)(index::CartesianIndex,a::Integer)=*(a,index)
+    @inline (+)(i::Integer, index::CartesianIndex) = index+i
+    @inline (+){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x+i, index.I))
+    @inline (-){N}(index::CartesianIndex{N}, i::Integer) = CartesianIndex{N}(map(x->x-i, index.I))
+    @inline (-){N}(i::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->i-x, index.I))
+    @inline (*){N}(a::Integer, index::CartesianIndex{N}) = CartesianIndex{N}(map(x->a*x, index.I))
+    @inline (*)(index::CartesianIndex,a::Integer)=*(a,index)
 
     # comparison
     @inline isless{N}(I1::CartesianIndex{N}, I2::CartesianIndex{N}) = _isless(0, I1.I, I2.I)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -821,6 +821,7 @@ end
         @boundscheck checkbounds(src, Rsrc.start)
         @boundscheck checkbounds(src, Rsrc.stop)
         ΔI = Rdest.start - Rsrc.start
+        # TODO: restore when #9080 is fixed
         # for I in Rsrc
         #     @inbounds dest[I+ΔI] = src[I]
         @nloops $N i (n->Rsrc.start[n]:Rsrc.stop[n]) begin

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -209,6 +209,16 @@ module IteratorsMD
     @inline _split{N}(tN::NTuple{N,Any}, ::Tuple{}, ::Type{Val{N}}) = tN, ()  # ambig.
     @inline _split{N}(tN,                ::Tuple{}, ::Type{Val{N}}) = tN, ()
     @inline _split{N}(tN::NTuple{N,Any},  trest,    ::Type{Val{N}}) = tN, trest
+
+    @inline function split(I::CartesianIndex, V::Type{<:Val})
+        i, j = split(I.I, V)
+        CartesianIndex(i), CartesianIndex(j)
+    end
+    function split(R::CartesianRange, V::Type{<:Val})
+        istart, jstart = split(first(R), V)
+        istop,  jstop  = split(last(R), V)
+        CartesianRange(istart, istop), CartesianRange(jstart, jstop)
+    end
 end  # IteratorsMD
 
 
@@ -781,6 +791,13 @@ function fill!{T}(A::AbstractArray{T}, x)
     A
 end
 
+"""
+    copy!(dest, src) -> dest
+
+Copy all elements from collection `src` to array `dest`.
+"""
+copy!(dest, src)
+
 function copy!{T,N}(dest::AbstractArray{T,N}, src::AbstractArray{T,N})
     @boundscheck checkbounds(dest, indices(src)...)
     for I in eachindex(IndexStyle(src,dest), src)
@@ -804,6 +821,14 @@ function copy!(dest::AbstractArray, Rdest::CartesianRange, src::AbstractArray, R
     end
     dest
 end
+
+"""
+    copy!(dest, Rdest::CartesianRange, src, Rsrc::CartesianRange) -> dest
+
+Copy the block of `src` in the range of `Rsrc` to the block of `dest`
+in the range of `Rdest`. The sizes of the two regions must match.
+"""
+copy!(::AbstractArray, ::CartesianRange, ::AbstractArray, ::CartesianRange)
 
 # circshift!
 circshift!(dest::AbstractArray, src, ::Tuple{}) = copy!(dest, src)

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -61,6 +61,7 @@ Base.Broadcast.broadcast_setindex!
 ```@docs
 Base.getindex(::AbstractArray, ::Any...)
 Base.setindex!(::AbstractArray, ::Any, ::Any...)
+Base.copy!(::AbstractArray, ::CartesianRange, ::AbstractArray, ::CartesianRange)
 Base.isassigned
 Base.Colon
 Base.CartesianIndex

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -48,6 +48,20 @@ for (dest, src, bigsrc, emptysrc, res) in [
     @test_throws BoundsError copy!(dest, 1, src(), 2, 2)
 end
 
+let A = reshape(1:6, 3, 2), B = similar(A)
+    RA = CartesianRange(indices(A))
+    copy!(B, RA, A, RA)
+    @test B == A
+end
+let A = reshape(1:6, 3, 2), B = zeros(8,8)
+    RA = CartesianRange(indices(A))
+    copy!(B, CartesianRange((5:7,2:3)), A, RA)
+    @test B[5:7,2:3] == A
+    B[5:7,2:3] = 0
+    @test all(x->x==0, B)
+end
+
+
 # test behavior of shallow and deep copying
 let a = Any[[1]], q = QuoteNode([1])
     ca = copy(a); dca = @inferred(deepcopy(a))
@@ -128,4 +142,3 @@ end
         @test bar2.fooDict[bar2.foo] != nothing
     end
 end
-


### PR DESCRIPTION
I noticed something also reported by @JKrehl: our "block copier" `copy!(dest, Rdest, src, Rsrc)` (where `Rdest` and `Rsrc` are CartesianRanges) is slow. Presumably #9080 has something to do with it.

Master:
```julia
julia> A = rand(200, 200, 16);

julia> B = similar(A);

julia> R = CartesianRange(indices(A))
CartesianRange{CartesianIndex{3}}(CartesianIndex{3}((1, 1, 1)), CartesianIndex{3}((200, 200, 16)))

julia> copy!(B, R, A, R);

julia> @benchmark copy!(B, R, A, R) seconds=1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     3.379 ms (0.00% GC)
  median time:      3.499 ms (0.00% GC)
  mean time:        3.591 ms (0.00% GC)
  maximum time:     6.628 ms (0.00% GC)
  --------------
  samples:          273
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```
This PR:
```julia
julia> @benchmark copy!(B, R, A, R) seconds=1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     688.652 μs (0.00% GC)
  median time:      838.804 μs (0.00% GC)
  mean time:        857.291 μs (0.00% GC)
  maximum time:     1.689 ms (0.00% GC)
  --------------
  samples:          1074
  evals/sample:     1
  time tolerance:   15.00%
  memory tolerance: 1.00%
```
So approximately 4x faster for a 3d array.

I also decided to write a docstring for this method, and to explicitly test it. (I guess previously it had been tested only indirectly.)