### PR TITLE
Identify `ppc64le` as a 64-bit architecture

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -660,6 +660,7 @@ ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
 JCFLAGS += -fsigned-char
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=POWER8
+BINARY:=64
 # GCC doesn't do -march= on ppc64le
 MARCH=
 endif


### PR DESCRIPTION
This automatically opts ppc64le in to getting ILP64 BLAS.