### PR TITLE
Extensible and fast date parsing

### DIFF
--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -175,17 +175,17 @@ Delim(d::Char) = Delim{Char, 1}(d)
 Delim(d::String) = Delim{String, length(d)}(d)
 
 @inline function tryparsenext{N}(d::Delim{Char, N}, str, i::Int, len)
-    R = Nullable{Int64}
+    R = Nullable{Bool}
     for j=1:N
         i > len && return (R(), i)
         c, i = next(str, i)
         c != d.d && return (R(), i)
     end
-    return R(0), i
+    return R(true), i
 end
 
 @inline function tryparsenext{N}(d::Delim{String, N}, str, i::Int, len)
-    R = Nullable{Int64}
+    R = Nullable{Bool}
     i1 = i
     i2 = start(d.d)
     for j = 1:N
@@ -198,7 +198,7 @@ end
             return R(), i1
         end
     end
-    return R(0), i1
+    return R(true), i1
 end
 
 @inline function format(io, d::Delim, dt, locale)
@@ -206,7 +206,7 @@ end
 end
 
 function _show_content{N}(io::IO, d::Delim{Char, N})
-    if d.d in keys(SLOT_RULE)
+    if d.d in keys(FORMAT_SPECIFIERS)
         for i = 1:N
             write(io, '\\', d.d)
         end
@@ -219,7 +219,7 @@ end
 
 function _show_content(io::IO, d::Delim)
     for c in d.d
-        if c in keys(SLOT_RULE)
+        if c in keys(FORMAT_SPECIFIERS)
             write(io, '\\')
         end
         write(io, c)
@@ -236,8 +236,9 @@ end
 
 abstract type DayOfWeekToken end # special addition to Period types
 
-# mapping format specifiers to period types
-const SLOT_RULE = Dict{Char, Type}(
+# Map format specifiers to, typically period, types.
+# Note that Julia packages like TimeZones.jl can add additional specifiers.
+const FORMAT_SPECIFIERS = Dict{Char, Type}(
     'y' => Year,
     'Y' => Year,
     'm' => Month,
@@ -252,13 +253,21 @@ const SLOT_RULE = Dict{Char, Type}(
     's' => Millisecond,
 )
 
-slot_order(::Type{Date}) = (Year, Month, Day)
-slot_order(::Type{DateTime}) = (Year, Month, Day, Hour, Minute, Second, Millisecond)
+const FORMAT_DEFAULTS = Dict{Type, Any}(
+    Year => Int64(1),
+    Month => Int64(1),
+    DayOfWeekToken => Int64(0),
+    Day => Int64(1),
+    Hour => Int64(0),
+    Minute => Int64(0),
+    Second => Int64(0),
+    Millisecond => Int64(0),
+)
 
-slot_defaults(::Type{Date}) = map(Int64, (1, 1, 1))
-slot_defaults(::Type{DateTime}) = map(Int64, (1, 1, 1, 0, 0, 0, 0))
-
-slot_types{T<:TimeType}(::Type{T}) = typeof(slot_defaults(T))
+const FORMAT_TRANSLATIONS = Dict{Type{<:TimeType}, Tuple}(
+    Date => (Year, Month, Day),
+    DateTime => (Year, Month, Day, Hour, Minute, Second, Millisecond),
+)
 
 """
     DateFormat(format::AbstractString, locale="english") -> DateFormat
@@ -300,13 +309,13 @@ function DateFormat(f::AbstractString, locale::DateLocale=ENGLISH)
     prev = ()
     prev_offset = 1
 
-    letters = String(collect(keys(Base.Dates.SLOT_RULE)))
+    letters = String(collect(keys(FORMAT_SPECIFIERS)))
     for m in eachmatch(Regex("(?<!\\\\)([\\Q$letters\\E])\\1*"), f)
         tran = replace(f[prev_offset:m.offset - 1], r"\\(.)", s"\1")
 
         if !isempty(prev)
             letter, width = prev
-            typ = SLOT_RULE[letter]
+            typ = FORMAT_SPECIFIERS[letter]
 
             push!(tokens, DatePart{letter}(width, isempty(tran)))
         end
@@ -326,7 +335,7 @@ function DateFormat(f::AbstractString, locale::DateLocale=ENGLISH)
 
     if !isempty(prev)
         letter, width = prev
-        typ = SLOT_RULE[letter]
+        typ = FORMAT_SPECIFIERS[letter]
 
         push!(tokens, DatePart{letter}(width, false))
     end
@@ -367,6 +376,9 @@ end
 const ISODateTimeFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.s")
 const ISODateFormat = DateFormat("yyyy-mm-dd")
 const RFC1123Format = DateFormat("e, dd u yyyy HH:MM:SS")
+
+default_format(::Type{DateTime}) = ISODateTimeFormat
+default_format(::Type{Date}) = ISODateFormat
 
 ### API
 """

--- a/base/dates/parse.jl
+++ b/base/dates/parse.jl
@@ -254,9 +254,8 @@ function Base.tryparse{T<:TimeType}(
     end
 end
 
-@generated function Base.parse(::Type{Vector}, str::AbstractString, df::DateFormat)
+@generated function parse_components(str::AbstractString, df::DateFormat)
     letters = character_codes(df)
-
     tokens = Type[CONVERSION_SPECIFIERS[letter] for letter in letters]
 
     quote

--- a/base/dates/parse.jl
+++ b/base/dates/parse.jl
@@ -18,7 +18,7 @@ function directives{S,F}(::Type{DateFormat{S,F}})
     return tokens, directive_index, directive_letters
 end
 
-genvar(t::DataType) = Symbol(lowercase(string(t.name.name)))
+genvar(t::DataType) = Symbol(lowercase(string(Base.datatype_name(t))))
 
 
 @generated function tryparse_core(str::AbstractString, df::DateFormat, raise::Bool=false)

--- a/base/dates/parse.jl
+++ b/base/dates/parse.jl
@@ -20,7 +20,7 @@ genvar(t::DataType) = Symbol(lowercase(string(Base.datatype_name(t))))
     tryparsenext_core(str::AbstractString, pos::Int, len::Int, df::DateFormat, raise=false)
 
 Parses the string according to the directives within the DateFormat. Parsing will start at
-character index `pos` and will stop when all directives are used or we have parsed up to,
+character index `pos` and will stop when all directives are used or we have parsed up to
 the end of the string, `len`. If the provided string cannot be parsed an exception will be
 thrown only if `raise` is true.
 
@@ -115,7 +115,8 @@ end
 
 Parses the string according to the directives within the DateFormat. The specified TimeType
 type determines the type of and order of tokens returned. If the given DateFormat or string
-does not provide a required token a default value will be used.
+does not provide a required token a default value will be used. If the provided string
+cannot be parsed an exception will be thrown only if `raise` is true.
 
 Returns a 2-element tuple `(values, pos)`:
 * `values::Nullable{Tuple}`: A tuple which contains a value for each token as specified by

--- a/base/dates/parse.jl
+++ b/base/dates/parse.jl
@@ -97,7 +97,6 @@ Returns a 3-element tuple `(values, pos, num_parsed)`:
         return Nullable{$R}($(Expr(:tuple, value_names...))), pos, num_parsed
 
         @label error
-        # Note: Keeping exception generation in separate function helps with performance
         if raise
             if directive_index > length(directives)
                 throw(ArgumentError("Found extra characters at the end of date time string"))

--- a/base/dates/parse.jl
+++ b/base/dates/parse.jl
@@ -21,8 +21,8 @@ genvar(t::DataType) = Symbol(lowercase(string(Base.datatype_name(t))))
 
 Parses the string according to the directives within the DateFormat. Parsing will start at
 character index `pos` and will stop when all directives are used or we have parsed up to
-the end of the string, `len`. If the provided string cannot be parsed an exception will be
-thrown only if `raise` is true.
+the end of the string, `len`. When a directive cannot be parsed the returned value tuple
+will be null if `raise` is false otherwise an exception will be thrown.
 
 Returns a 3-element tuple `(values, pos, num_parsed)`:
 * `values::Nullable{Tuple}`: A tuple which contains a value for each `DatePart` within the
@@ -115,8 +115,9 @@ end
 
 Parses the string according to the directives within the DateFormat. The specified TimeType
 type determines the type of and order of tokens returned. If the given DateFormat or string
-does not provide a required token a default value will be used. If the provided string
-cannot be parsed an exception will be thrown only if `raise` is true.
+does not provide a required token a default value will be used. When the string cannot be
+parsed the returned value tuple will be null if `raise` is false otherwise an exception will
+be thrown.
 
 Returns a 2-element tuple `(values, pos)`:
 * `values::Nullable{Tuple}`: A tuple which contains a value for each token as specified by

--- a/base/dates/parse.jl
+++ b/base/dates/parse.jl
@@ -17,15 +17,16 @@ end
 genvar(t::DataType) = Symbol(lowercase(string(Base.datatype_name(t))))
 
 """
-    tryparsenext_core(str::AbstractString, pos::Int, len::Int, df::DateFormat)
+    tryparsenext_core(str::AbstractString, pos::Int, len::Int, df::DateFormat, raise=false)
 
 Parses the string according to the directives within the DateFormat. Parsing will start at
-character index `pos` and will stop when all directives are used or we have parsed up to the
-end of the string (`len`).
+character index `pos` and will stop when all directives are used or we have parsed up to,
+the end of the string, `len`. If the provided string cannot be parsed an exception will be
+thrown only if `raise` is true.
 
 Returns a 3-element tuple `(values, pos, num_parsed)`:
-* `values::Nullable{Tuple}`: A tuple which contains a values for each `DatePart` within the
-  `DateFormat` in the order in which the occur. If the string ends before we finish parsing
+* `values::Nullable{Tuple}`: A tuple which contains a value for each `DatePart` within the
+  `DateFormat` in the order in which they occur. If the string ends before we finish parsing
   all the directives the missing values will be filled in with default values.
 * `pos::Int`: The character index at which parsing stopped.
 * `num_parsed::Int`: The number of values which were parsed and stored within `values`.
@@ -110,14 +111,14 @@ Returns a 3-element tuple `(values, pos, num_parsed)`:
 end
 
 """
-    tryparsenext_internal(::Type{<:TimeType}, str::AbstractString, pos::Int, len::Int, df::DateFormat)
+    tryparsenext_internal(::Type{<:TimeType}, str, pos, len, df::DateFormat, raise=false)
 
 Parses the string according to the directives within the DateFormat. The specified TimeType
 type determines the type of and order of tokens returned. If the given DateFormat or string
 does not provide a required token a default value will be used.
 
 Returns a 2-element tuple `(values, pos)`:
-* `values::Nullable{Tuple}`: A tuple which contains a values for each token as specified by
+* `values::Nullable{Tuple}`: A tuple which contains a value for each token as specified by
   the passed in type.
 * `pos::Int`: The character index at which parsing stopped.
 """

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1283,9 +1283,9 @@ end
     function Base.Dates.parse(x::AbstractString, df::DateFormat)
         Base.depwarn(string(
             "`Dates.parse(x::AbstractString, df::DateFormat)` is deprecated, use ",
-            "`sort!(filter!(el -> isa(el, Dates.Period), parse(Vector, x, df), rev=true, lt=Dates.periodisless)` ",
+            "`sort!(filter!(el -> isa(el, Dates.Period), Dates.parse_components(x, df), rev=true, lt=Dates.periodisless)` ",
             " instead."), :parse)
-        sort!(filter!(el -> isa(el, Period), parse(Vector, x, df)), rev=true, lt=periodisless)
+        sort!(filter!(el -> isa(el, Period), parse_components(x, df)), rev=true, lt=periodisless)
      end
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1283,9 +1283,8 @@ end
     function Base.Dates.parse(x::AbstractString, df::DateFormat)
         Base.depwarn(string(
             "`Dates.parse(x::AbstractString, df::DateFormat)` is deprecated, use ",
-            "`sort!(filter!(el -> isa(el, Dates.Period), parse(Vector, x, df), rev=true, lt=Dates.periodisless)` "
-            " instead.", :parse)
-        # sort!([el for el in parse(Vector, x, df) if isa(el, Period)], rev=true, lt=periodisless)
+            "`sort!(filter!(el -> isa(el, Dates.Period), parse(Vector, x, df), rev=true, lt=Dates.periodisless)` ",
+            " instead."), :parse)
         sort!(filter!(el -> isa(el, Period), parse(Vector, x, df)), rev=true, lt=periodisless)
      end
 end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1278,6 +1278,18 @@ end
 @deprecate_binding LinearSlow IndexCartesian false
 @deprecate_binding linearindexing IndexStyle false
 
+# #20876
+@eval Base.Dates begin
+    function Base.Dates.parse(x::AbstractString, df::DateFormat)
+        Base.depwarn(string(
+            "`Dates.parse(x::AbstractString, df::DateFormat)` is deprecated, use ",
+            "`sort!(filter!(el -> isa(el, Dates.Period), parse(Vector, x, df), rev=true, lt=Dates.periodisless)` "
+            " instead.", :parse)
+        # sort!([el for el in parse(Vector, x, df) if isa(el, Period)], rev=true, lt=periodisless)
+        sort!(filter!(el -> isa(el, Period), parse(Vector, x, df)), rev=true, lt=periodisless)
+     end
+end
+
 # END 0.6 deprecations
 
 # BEGIN 1.0 deprecations

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -87,7 +87,7 @@ try
     @test false
 catch err
     @test isa(err, ArgumentError)
-    @test err.msg == "Unable to parse date time. Expected token Delim(.) at char 16"
+    @test err.msg == "Unable to parse date time. Expected directive Delim(.) at char 16"
 end
 
 f = "yy:dd:mm"
@@ -398,14 +398,14 @@ let
 
     try
         # Make 'Z' into a specifier
-        Dates.FORMAT_SPECIFIERS['Z'] = Zulu
-        Dates.FORMAT_DEFAULTS[Zulu] = ""
+        Dates.CONVERSION_SPECIFIERS['Z'] = Zulu
+        Dates.CONVERSION_DEFAULTS[Zulu] = ""
 
         @test parse(Vector, ds, Dates.DateFormat(format)) == [parsed; Zulu("Z")]
         @test parse(Vector, ds, Dates.DateFormat(escaped_format)) == parsed
     finally
-        delete!(Dates.FORMAT_SPECIFIERS, 'Z')
-        delete!(Dates.FORMAT_DEFAULTS, Zulu)
+        delete!(Dates.CONVERSION_SPECIFIERS, 'Z')
+        delete!(Dates.CONVERSION_DEFAULTS, Zulu)
     end
 
     # Ensure that the default behaviour has been restored

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -79,14 +79,14 @@ b2 = "96/Feb/1"
 b3 = "96/2/15"
 @test_throws ArgumentError Dates.DateTime(b3, f)
 try
-    Dates.tryparse_internal(DateTime, "2012/2/20T9:9:31.25i90", dateformat"yyyy/mm/ddTHH:MM:SS.s", true)
+    Dates.parse(DateTime, "2012/2/20T9:9:31.25i90", dateformat"yyyy/mm/ddTHH:MM:SS.s")
     @test false
 catch err
     @test isa(err, ArgumentError)
     @test err.msg == "Found extra characters at the end of date time string"
 end
 try
-    Dates.tryparse_internal(DateTime, "2012/2/20T9:9:3i90", dateformat"yyyy/mm/ddTHH:MM:SS.s", true)
+    Dates.parse(DateTime, "2012/2/20T9:9:3i90", dateformat"yyyy/mm/ddTHH:MM:SS.s")
     @test false
 catch err
     @test isa(err, ArgumentError)


### PR DESCRIPTION
The introduction of fast date time parsing (#19545) no longer allows external packages to extend the format specifiers used within `DateFormat`. This PR re-introduces full extensibility without impacting the previous performance gains. I've also revised the code to make extended specifiers also fast.

- [x] Document ~`parse(::Type{Vector}, ...)`~ `parse_components(...)`
- [x] Document `tryparse_core`
- [x] Document `tryparse_internal`
- [x] ~Add additional benchmarks~ Benchmarks will be added to TimeZones.jl

Fixes #20876 