### PR TITLE
[docathon] Add examples for diff_files

### DIFF
--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -154,6 +154,25 @@ The keyword argument is:
 
 Returns only the *names* of the files which have changed, *not* their contents.
 
+# Example
+
+```julia
+LibGit2.branch!(repo, "branch/a")
+LibGit2.branch!(repo, "branch/b")
+# add a file to repo
+open(joinpath(LibGit2.path(repo),"file"),"w") do f
+    write(f, "hello repo\n")
+end
+LibGit2.add!(repo, "file")
+LibGit2.commit(repo, "add file")
+# returns ["file"]
+filt = Set([LibGit2.Consts.DELTA_ADDED])
+files = LibGit2.diff_files(repo, "branch/a", "branch/b", filter=filt)
+# returns [] because existing files weren't modified
+filt = Set([LibGit2.Consts.DELTA_MODIFIED])
+files = LibGit2.diff_files(repo, "branch/a", "branch/b", filter=filt)
+```
+
 Equivalent to `git diff --name-only --diff-filter=<filter> <branch1> <branch2>`.
 """
 function diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractString;


### PR DESCRIPTION
Again pulling from `test/libgit2.jl` to show how to use the `enum`.