### PR TITLE
[1.0-dev] Store indices in CartesianRange

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,11 @@ This section lists changes that do not have deprecation warnings.
   * The format for a `ClusterManager` specifying the cookie on the command line is now
     `--worker=<cookie>`. `--worker <cookie>` will not work as it is now an optional argument.
 
+  * The representation of `CartesianRange` has changed to a
+    tuple-of-AbstractUnitRanges; the `start` and `stop` fields are no
+    longer present. Use `first(R)` and `last(R)` to obtain
+    start/stop. ([#20974])
+
 Library improvements
 --------------------
 
@@ -920,6 +925,7 @@ Command-line option changes
 [#20609]: https://github.com/JuliaLang/julia/issues/20609
 [#20889]: https://github.com/JuliaLang/julia/issues/20889
 [#20952]: https://github.com/JuliaLang/julia/issues/20952
+[#20974]: https://github.com/JuliaLang/julia/issues/20974
 [#21183]: https://github.com/JuliaLang/julia/issues/21183
 [#21359]: https://github.com/JuliaLang/julia/issues/21359
 [#21692]: https://github.com/JuliaLang/julia/issues/21692

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1549,7 +1549,14 @@ end
 @deprecate read(s::IO, t::Type, d1::Integer, dims::Integer...) read!(s, Array{t}(convert(Tuple{Vararg{Int}},tuple(d1,dims...))))
 @deprecate read(s::IO, t::Type, dims::Dims) read!(s, Array{t}(dims))
 
+function CartesianRange{N}(start::CartesianIndex{N}, stop::CartesianIndex{N})
+    inds = map((f,l)->f:l, start.I, stop.I)
+    depwarn("the internal representation of CartesianRange has changed, use CartesianRange($inds) (or other more approriate AbstractUnitRange type) instead.", :CartesianRange)
+    CartesianRange(inds)
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations
+
 # END 1.0 deprecations

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -157,7 +157,7 @@ function _copy!(P::PermutedDimsArray{T,N,perm}, src) where {T,N,perm}
     return P
 end
 
-@noinline function _permutedims!(P::PermutedDimsArray, src, R1::CartesianRange{CartesianIndex{0}}, R2, R3, ds, dp)
+@noinline function _permutedims!(P::PermutedDimsArray, src, R1::CartesianRange{0}, R2, R3, ds, dp)
     ip, is = indices(src, dp), indices(src, ds)
     for jo in first(ip):8:last(ip), io in first(is):8:last(is)
         for I3 in R3, I2 in R2

--- a/base/range.jl
+++ b/base/range.jl
@@ -778,6 +778,10 @@ promote_rule(::Type{UnitRange{T1}}, ::Type{UR}) where {T1,UR<:AbstractUnitRange}
 convert(::Type{UnitRange{T}}, r::AbstractUnitRange) where {T<:Real} = UnitRange{T}(first(r), last(r))
 convert(::Type{UnitRange}, r::AbstractUnitRange) = UnitRange(first(r), last(r))
 
+convert(::Type{AbstractUnitRange{T}}, r::AbstractUnitRange{T}) where {T} = r
+convert(::Type{AbstractUnitRange{T}}, r::UnitRange) where {T} = convert(UnitRange{T}, r)
+convert(::Type{AbstractUnitRange{T}}, r::OneTo) where {T} = convert(OneTo{T}, r)
+
 promote_rule(::Type{StepRange{T1a,T1b}},::Type{StepRange{T2a,T2b}}) where {T1a,T1b,T2a,T2b} =
     StepRange{promote_type(T1a,T2a),promote_type(T1b,T2b)}
 convert(::Type{StepRange{T1,T2}}, r::StepRange{T1,T2}) where {T1,T2} = r

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1544,9 +1544,10 @@ end
     @test a[1,2] == 7
     @test 2*CartesianIndex{3}(1,2,3) == CartesianIndex{3}(2,4,6)
 
-    R = CartesianRange(CartesianIndex{2}(2,3),CartesianIndex{2}(5,5))
+    R = CartesianRange(2:5, 3:5)
     @test eltype(R) <: CartesianIndex{2}
     @test eltype(typeof(R)) <: CartesianIndex{2}
+    @test eltype(CartesianRange{2}) <: CartesianIndex{2}
     indexes = collect(R)
     @test indexes[1] == CartesianIndex{2}(2,3)
     @test indexes[2] == CartesianIndex{2}(3,3)
@@ -1568,8 +1569,8 @@ end
     @test @inferred(convert(NTuple{2,UnitRange}, R)) === (2:5, 3:5)
     @test @inferred(convert(Tuple{Vararg{UnitRange}}, R)) === (2:5, 3:5)
 
-    @test CartesianRange((3:5,-7:7)) == CartesianRange(CartesianIndex{2}(3,-7),CartesianIndex{2}(5,7))
-    @test CartesianRange((3,-7:7)) == CartesianRange(CartesianIndex{2}(3,-7),CartesianIndex{2}(3,7))
+    @test CartesianRange((3:5,-7:7)) == CartesianRange(3:5,-7:7)
+    @test CartesianRange((3,-7:7)) == CartesianRange(3:3,-7:7)
 end
 
 # All we really care about is that we have an optimized

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -101,28 +101,23 @@ function simd_cartesian_range!(indexes, crng)
     indexes
 end
 
-crng = CartesianRange(CartesianIndex{4}(2,0,1,3),
-                      CartesianIndex{4}(4,1,1,5))
+crng = CartesianRange(2:4, 0:1, 1:1, 3:5)
 indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
 @test indexes == vec(collect(crng))
 
-crng = CartesianRange(CartesianIndex{2}(-1,1),
-                      CartesianIndex{2}(1,3))
+crng = CartesianRange(-1:1, 1:3)
 indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
 @test indexes == vec(collect(crng))
 
-crng = CartesianRange(CartesianIndex{2}(-1,1),
-                      CartesianIndex{2}(-1,3))
+crng = CartesianRange(-1:-1, 1:3)
 indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
 @test indexes == vec(collect(crng))
 
-crng = CartesianRange(CartesianIndex{1}(2),
-                      CartesianIndex{1}(4))
+crng = CartesianRange(2:4)
 indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
 @test indexes == collect(crng)
 
-crng = CartesianRange(CartesianIndex{0}(),
-                      CartesianIndex{0}())
+crng = CartesianRange()
 indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
 @test indexes == vec(collect(crng))
 


### PR DESCRIPTION
The main advantage of this change is that you no longer lose type information from `CartesianRange(indices(A))`. The types of the specific AbstractUnitRanges are important for `similar`, if you're using non-1 indices. It's also kind of nice to be able to write `CartesianRange{3}` rather than `CartesianRange{CartesianIndex{3}}`.

Because this changes the parametrization of an exported type, and also introduces a new depwarn, this is queued for after 0.6.

CC @JKrehl.
