### PR TITLE
Use proper alignment when copying data to a variable.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3850,7 +3850,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
                     builder.CreateMemCpy(vi.value.V,
                                          data_pointer(rval_info, ctx, T_pint8),
                                          copy_bytes,
-                                         /*TODO: min_align*/1,
+                                         ((jl_datatype_t*)rval_info.typ)->layout->alignment,
                                          vi.isVolatile,
                                          tbaa);
                 }


### PR DESCRIPTION
align=1 is very expensive on hardware without unaligned ld/st (eg. GPUs).
ref https://github.com/JuliaLang/julia/pull/20593#issuecomment-285402606

I'm not really familiar with these codepaths, so please review. A quick check revealed that `lhs.typ == rhs.typ`, so just picking the RHS's alignment seemed OK. And as per the LLVM docs, `llvm.memset` treats an alignment of 0 or 1 the same (unaligned), in case `layout->alignment` would ever be 0.