### PR TITLE
use explicit checks instead of try/catch to detect BLAS vendor

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -61,17 +61,15 @@ import ..LinAlg: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, c
 
 # utility routines
 function vendor()
-    try
-        cglobal((:openblas_set_num_threads, Base.libblas_name), Void)
-        return :openblas
-    end
-    try
-        cglobal((:openblas_set_num_threads64_, Base.libblas_name), Void)
-        return :openblas64
-    end
-    try
-        cglobal((:MKL_Set_Num_Threads, Base.libblas_name), Void)
-        return :mkl
+    lib = Libdl.dlopen_e(Base.libblas_name)
+    if lib != C_NULL
+        if Libdl.dlsym_e(lib, :openblas_set_num_threads) != C_NULL
+            return :openblas
+        elseif Libdl.dlsym_e(lib, :openblas_set_num_threads64_) != C_NULL
+            return :openblas64
+        elseif Libdl.dlsym_e(lib, :MKL_Set_Num_Threads) != C_NULL
+            return :mkl
+        end
     end
     return :unknown
 end


### PR DESCRIPTION
This is cleaner and has various benefits, e.g. when debugging.