### PR TITLE
Fix broadcast with RowVectors of matrices

### DIFF
--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -140,16 +140,17 @@ end
 @inline check_tail_indices(i1, i2, i3, is...) = i3 == 1 ? check_tail_indices(i1, i2, is...) : false
 
 # helper function for below
-@inline to_vec(rowvec::RowVector) = transpose(rowvec)
+@inline to_vec(rowvec::RowVector) = map(transpose, transpose(rowvec))
 @inline to_vec(x::Number) = x
 @inline to_vecs(rowvecs...) = (map(to_vec, rowvecs)...)
 
-# map: Preserve the RowVector, but note that `f` expects transposed elements
-@inline map(f, rowvecs::RowVector...) = RowVector(map(transpose∘f∘transpose, to_vecs(rowvecs...)...))
+# map: Preserve the RowVector by un-wrapping and re-wrapping, but note that `f`
+# expects to operate within the transposed domain, so to_vec transposes the elements
+@inline map(f, rowvecs::RowVector...) = RowVector(map(transpose∘f, to_vecs(rowvecs...)...))
 
 # broacast (other combinations default to higher-dimensional array)
 @inline broadcast(f, rowvecs::Union{Number,RowVector}...) =
-    RowVector(broadcast(transpose∘f∘transpose, to_vecs(rowvecs...)...))
+    RowVector(broadcast(transpose∘f, to_vecs(rowvecs...)...))
 
 # Horizontal concatenation #
 

--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -144,12 +144,12 @@ end
 @inline to_vec(x::Number) = x
 @inline to_vecs(rowvecs...) = (map(to_vec, rowvecs)...)
 
-# map
-@inline map(f, rowvecs::RowVector...) = RowVector(map(f, to_vecs(rowvecs...)...))
+# map: Preserve the RowVector, but note that `f` expects transposed elements
+@inline map(f, rowvecs::RowVector...) = RowVector(map(transpose∘f∘transpose, to_vecs(rowvecs...)...))
 
 # broacast (other combinations default to higher-dimensional array)
 @inline broadcast(f, rowvecs::Union{Number,RowVector}...) =
-    RowVector(broadcast(f, to_vecs(rowvecs...)...))
+    RowVector(broadcast(transpose∘f∘transpose, to_vecs(rowvecs...)...))
 
 # Horizontal concatenation #
 

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -249,3 +249,13 @@ end
         @test A'*x' == A'*y == B*x' == B*y == C'
     end
 end
+
+@testset "issue #20979" begin
+    f20979(z::Complex) = [z.re -z.im; z.im z.re]
+    v = [1+2im]'
+    @test (f20979.(v))[1] == f20979(v[1])
+    @test f20979.(v) == f20979.(collect(v))
+
+    w = rand(Complex128, 3)
+    @test f20979.(v') == f20979.(collect(v')) == (f20979.(v))'
+end

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -258,4 +258,9 @@ end
 
     w = rand(Complex128, 3)
     @test f20979.(v') == f20979.(collect(v')) == (f20979.(v))'
+
+    g20979(x, y) = [x[2,1] x[1,2]; y[1,2] y[2,1]]
+    v = [rand(2,2), rand(2,2), rand(2,2)]
+    @test g20979.(v', v') == g20979.(collect(v'), collect(v')) ==
+          map(g20979, v', v') == map(g20979, collect(v'), collect(v'))
 end


### PR DESCRIPTION
Fix JuliaLang/LinearAlgebra.jl#409. Amusingly, this bug is a direct result of `transpose` being recursive.