### PR TITLE
Fix handling of `allow_bottom_tparams` in `isambiguous`

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -1117,12 +1117,16 @@ function test_approx_eq_modphase{S<:Real,T<:Real}(
 end
 
 """
-    detect_ambiguities(mod1, mod2...; imported=false)
+    detect_ambiguities(mod1, mod2...; imported=false, allow_bottom=true)
 
 Returns a vector of `(Method,Method)` pairs of ambiguous methods
 defined in the specified modules. Use `imported=true` if you wish to
 also test functions that were imported into these modules from
 elsewhere.
+
+`allow_bottom` controls whether ambiguities triggered only by
+`Union{}` type parameters are included; in most cases you probably
+want to set this to `false`. See [`Base.isambiguous`](@ref).
 """
 function detect_ambiguities(mods...; imported::Bool=false, allow_bottom::Bool=true)
     function sortdefs(m1, m2)

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -134,7 +134,7 @@ ambs = detect_ambiguities(Ambig5)
 
 # Test that Core and Base are free of ambiguities
 # TODO jb/subtype: we now detect a lot more
-@test_broken detect_ambiguities(Core, Base; imported=true) == []
+@test_broken detect_ambiguities(Core, Base; imported=true, allow_bottom=false) == []
 # not using isempty so this prints more information when it fails
 
 amb_1(::Int8, ::Int) = 1


### PR DESCRIPTION
With master, we have a lot of ambiguities, but a subset of these involve method signatures that are ambiguous only because of the presence of `Union{}` as a type-parameter in the intersection:
```julia
julia> foo(x::Complex{<:Integer}) = 1
foo (generic function with 1 method)

julia> foo(x::Complex{<:Rational}) = 2
foo (generic function with 2 methods)

julia> m1, m2 = collect(methods(foo))
2-element Array{Any,1}:
 foo(x::Complex{#s1} where #s1<:Integer) in Main at REPL[3]:1 
 foo(x::Complex{#s1} where #s1<:Rational) in Main at REPL[4]:1

julia> typeintersect(m1.sig, m2.sig)
Tuple{#foo,Complex{Union{}}}

julia> Base.isambiguous(m1, m2)
true
```
This isn't the kind of intersection we should usually be worried about, so in e101000094794b8a14502c294ab75248cbba0be8 a strategy was developed to exclude these kinds of intersections. However, I found that it doesn't correctly catch all cases, including the one above:
```
julia> Base.isambiguous(m1, m2, false)
true
```
With this PR, I believe I've fixed the detection of `Union{}`. It has a pretty dramatic effect on our ambiguity list.

Master:
```julia
julia> length(Base.Test.detect_ambiguities(Base,Core,allow_bottom=true))
Skipping Base.<|
Skipping Base.Parallel
194

julia> length(Base.Test.detect_ambiguities(Base,Core,allow_bottom=false))
Skipping Base.<|
Skipping Base.Parallel
111
```

This PR:
```julia
julia> length(Base.Test.detect_ambiguities(Base,Core,allow_bottom=true))
Skipping Base.<|
Skipping Base.Parallel
194

julia> length(Base.Test.detect_ambiguities(Base,Core,allow_bottom=false))
Skipping Base.<|
Skipping Base.Parallel
11
```

11 seems rather more manageable (the "missing" digit is *not* a copy/paste error). Suddenly the steps that @Sacha0 has been taking (#20970, #20971) don't seem so small anymore: those should fix 3 of the 11.  Of the rest, it's just 4 functions: `cat` (4 ambiguous pairs), `checkbounds_indices` (2 ambiguous pairs), `colon` (1 ambiguous pair), and a constructor method for `Tuple` (1 ambiguous pair).

I do find myself wishing we could change the keyword argument to consistently have the same name, and I find `accept_bottom_tparams` clearer than `allow_bottom_tparams` (and perhaps flipping the sense, `exclude_bottom_tparams`, to be the clearest of all). But at this point, I don't think we can do that for 0.6. I did add some docstrings.

Fixes #20246