### PR TITLE
resolve ambiguity between colon methods

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -38,7 +38,11 @@ Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1, 
 is similar but uses a step size of `s`. These syntaxes call the function `colon`. The colon
 is also used in indexing to select whole dimensions.
 """
-function colon{T}(start::T, step, stop::T)
+colon{T}(start::T, step, stop::T) = _colon(start, step, stop)
+colon{T<:Real}(start::T, step, stop::T) = _colon(start, step, stop)
+# without the second method above, the first method above is ambiguous with
+# colon{A<:Real,C<:Real}(start::A, step, stop::C)
+function _colon{T}(start::T, step, stop::T)
     T′ = typeof(start+step)
     StepRange(convert(T′,start), step, convert(T′,stop))
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -894,6 +894,14 @@ let r = linspace(1.0, 3+im, 4)
     @test r[4] === 3.0+im
 end
 
+# ambiguity between colon methods (#20988)
+struct NotReal; val; end
+Base.:+(x, y::NotReal) = x + y.val
+Base.zero(y::NotReal) = zero(y.val)
+Base.rem(x, y::NotReal) = rem(x, y.val)
+Base.isless(x, y::NotReal) = isless(x, y.val)
+@test colon(1, NotReal(1), 5) isa StepRange{Int,NotReal}
+
 # dimensional correctness:
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using TestHelpers.Furlong


### PR DESCRIPTION
Someone familiar with the range code should have a look; chances are a more graceful fix exists. Best!