### PR TITLE
resolve ambiguities between checkbounds_indices methods

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -258,8 +258,8 @@ end
         I::Tuple{AbstractArray{CartesianIndex{0}},Vararg{Any}})
     checkbounds_indices(Bool, IA, tail(I))
 end
-@inline function checkbounds_indices(::Type{Bool}, IA::Tuple{Any},
-        I::Tuple{<:AbstractArray{<:CartesianIndex},Vararg{Any}})
+@inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple{Any},
+        I::Tuple{AbstractArray{CartesianIndex{N}},Vararg{Any}})
     checkindex(Bool, IA, I[1]) & checkbounds_indices(Bool, (), tail(I))
 end
 @inline function checkbounds_indices{N}(::Type{Bool}, IA::Tuple,

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -836,3 +836,7 @@ end
 @testset "dispatch loop introduced in #19305" begin
     @test [(1:2) zeros(2,2); ones(3,3)] == [[1,2] zeros(2,2); ones(3,3)] == [reshape([1,2],2,1) zeros(2,2); ones(3,3)]
 end
+
+@testset "checkbounds_indices method ambiguities #20989" begin
+    @test Base.checkbounds_indices(Bool, (1:1,), ([CartesianIndex(1)],))
+end


### PR DESCRIPTION
Essentially reverted the change in https://github.com/JuliaLang/julia/commit/73dabe0c733cb45d6340bef1899104f11bb07dfe. Best!