### PR TITLE
resolve ambiguity between tuple constructors

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -186,6 +186,9 @@ if isdefined(Main, :Base)
 
 (::Type{T}){T<:Tuple}(x::Tuple) = convert(T, x)  # still use `convert` for tuples
 
+# resolve ambiguity between preceding and following methods
+(::Type{All16{E,N}}){E,N}(x::Tuple) = convert(All16{E,N}, x)
+
 function (T::Type{All16{E,N}}){E,N}(itr)
     len = N+16
     elts = collect(E, Iterators.take(itr,len))

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -236,3 +236,9 @@ end
     @test_throws MethodError (1,)[]
     @test_throws MethodError (1,1,1)[1,1]
 end
+
+@testset "ambiguity between tuple constructors #20990" begin
+    Tuple16Int = Tuple{Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int,Int}
+    tuple16int = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+    @test Tuple16Int(tuple16int) isa Tuple16Int
+end


### PR DESCRIPTION
This ambiguity should be the last of those in `Core` and `Base` not involving `Union{}`s. Best!