### PR TITLE
RFC: user-friendly aggregation of time and allocation stats

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1274,6 +1274,7 @@ export
     @elapsed,
     @allocated,
     @profile,
+    timed_print,
 
     # reflection
     @which,

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -281,6 +281,15 @@ let
     @test isa(t, Real) && t >= 0
 end
 
+let
+    t = @timed nothing
+    t += @timed sin(1)
+    @test isa(t, Tuple{Any, Float64, Int64, Float64, Base.GC_Diff})
+    @test t[2] >= 0
+    @test t[3] >= 0
+    @test t[4] >= 0
+end
+
 # problem after #11801 - at global scope
 t11801 = @elapsed 1+1
 @test isa(t11801,Real) && t11801 >= 0


### PR DESCRIPTION
I wrote some code to add up the result from the `@timed` macro, e.g.

    t = @timed nothing
    t += @timed x = 3 + 4
    timed_print(t)

I have found this useful to determine which statements in a loop take the most
time and do the most allocations, e.g.

    t1 = @timed nothing
    t2 = @timed nothing
    for i=1:1000
        t1 += @timed x = sin(3.4)
        t2 += @timed y = exp(3.4)
    end
    timed_print(t1)
    timed_print(t2)

My current implementation is here: 8d0e8d3bed22843d5afe0ff34c21cbfdca01c2af

It is usable as is. However, it seems to somewhat fight the `@timed` macro. For
example, it adds a new `+()` operator for a tuple with specific types of
elements.

Therefore, it may be better to define a new type that stores the elapsed time
and a `GC_Diff`, and (in the name of backwards compatibility) introduce a new
macro, say `@timea`, or `@stats`, or `@perfstats` (names!), to make this a
cleaner implementation.

Questions: 1) Is the idea of being able to easily add up time and allocation
statistics desired and would you be interested in merging this? (I think so!)
2) Is it worth spending a little time implementing the cleaner version?