### PR TITLE
`abstract` -> `abstract type`

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -154,7 +154,7 @@ abstract type «name» end
 abstract type «name» <: «supertype» end
 ```
 
-The `abstract` keyword introduces a new abstract type, whose name is given by `«name»`. This
+The `abstract type` keyword introduces a new abstract type, whose name is given by `«name»`. This
 name can be optionally followed by `<:` and an already-existing type, indicating that the newly
 declared abstract type is a subtype of this "parent" type.
 


### PR DESCRIPTION
Changed the docs to use the new `abstract type` keyword instead of `abstract`