### PR TITLE
RFC: Fix `typeintersect` involving `TypeVar`s bound to non-types

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -941,3 +941,14 @@ ftwoparams(::TwoParams{<:Real,<:Real}) = 3
 
 # tolerate non-types in Tuples
 @test typeintersect(Tuple{0}, Tuple{T} where T) === Tuple{0}
+
+# TypeVars deduced as non-type constants (#20869)
+@test typeintersect(Tuple{Val{0}, Val{Val{N}}} where N, Tuple{Val{N}, Val{Val{N}}} where N) === Tuple{Val{0},Val{Val{0}}}
+@test typeintersect(Tuple{Val{N}, Val{Val{N}}} where N, Tuple{Val{0}, Val{Val{N}}} where N) === Tuple{Val{0},Val{Val{0}}}
+@test typeintersect(Tuple{Val{N}, Val{Val{0}}} where N, Tuple{Val{N}, Val{Val{N}}} where N) === Tuple{Val{0},Val{Val{0}}}
+@test typeintersect(Tuple{Val{N}, Val{Val{N}}} where N, Tuple{Val{N}, Val{Val{0}}} where N) === Tuple{Val{0},Val{Val{0}}}
+
+@test typeintersect(Tuple{Val{Val{0}}, Val{N}} where N, Tuple{Val{Val{N}}, Val{N}} where N) === Tuple{Val{Val{0}},Val{0}}
+@test typeintersect(Tuple{Val{Val{N}}, Val{N}} where N, Tuple{Val{Val{0}}, Val{N}} where N) === Tuple{Val{Val{0}},Val{0}}
+@test typeintersect(Tuple{Val{Val{N}}, Val{0}} where N, Tuple{Val{Val{N}}, Val{N}} where N) === Tuple{Val{Val{0}},Val{0}}
+@test typeintersect(Tuple{Val{Val{N}}, Val{N}} where N, Tuple{Val{Val{N}}, Val{0}} where N) === Tuple{Val{Val{0}},Val{0}}


### PR DESCRIPTION
I still feel like I'm missing important parts of the big picture in `subtype.c`, so this may be a completely wrong approach, but it passes tests locally and fixes #20869.