### PR TITLE
Improve printing of manually thrown `MethodError`s

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -924,21 +924,20 @@ function function_module(f::ANY, types::ANY)
 end
 
 """
-    method_exists(f, Tuple type) -> Bool
+    method_exists(f, Tuple type, world=typemax(UInt)) -> Bool
 
 Determine whether the given generic function has a method matching the given
-`Tuple` of argument types.
+`Tuple` of argument types with the upper bound of world age given by `world`.
 
 ```jldoctest
 julia> method_exists(length, Tuple{Array})
 true
 ```
 """
-function method_exists(f::ANY, t::ANY)
+function method_exists(f::ANY, t::ANY, world=typemax(UInt))
     t = to_tuple_type(t)
     t = Tuple{isa(f,Type) ? Type{f} : typeof(f), t.parameters...}
-    return ccall(:jl_method_exists, Cint, (Any, Any, UInt), typeof(f).name.mt, t,
-        typemax(UInt)) != 0
+    return ccall(:jl_method_exists, Cint, (Any, Any, UInt), typeof(f).name.mt, t, world) != 0
 end
 
 """

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -365,7 +365,8 @@ function showerror(io::IO, ex::MethodError)
             print(io, "You may have intended to import Base.", name)
         end
     end
-    if method_exists(ex.f, arg_types)
+    if (ex.world != typemax(UInt) && method_exists(ex.f, arg_types) &&
+        !method_exists(ex.f, arg_types, ex.world))
         curworld = ccall(:jl_get_world_counter, UInt, ())
         println(io)
         print(io, "The applicable method may be too new: running in world age $(ex.world), while current world is $(curworld).")


### PR DESCRIPTION
Make sure the world age is only mentioned for valid exception world age and when
exception world has no matching method.

The new `_method_exists` function isn't part of `method_exists` since I'm not sure if we want to export this function now. (Exposing too much functionality that directly takes world age might affect future optimizations).
