### PR TITLE
fix #20998

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1286,9 +1286,9 @@ static jl_value_t *finish_unionall(jl_value_t *res, jl_varbinding_t *vb, jl_sten
 
     if (vb->right && e->envidx < e->envsz) {
         jl_value_t *oldval = e->envout[e->envidx];
-        if (!varval)
+        if (!varval || (!is_leaf_bound(varval) && !var_occurs_invariant(res, vb->var, 0)))
             e->envout[e->envidx] = (jl_value_t*)vb->var;
-        else if (!oldval || !jl_is_typevar(oldval) || !jl_is_long(varval))
+        else if (!(oldval && jl_is_typevar(oldval) && jl_is_long(varval)))
             e->envout[e->envidx] = varval;
     }
 

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -853,6 +853,10 @@ function test_intersection()
     @testintersect(Tuple{Ref{Pair{p2,T2}}, Pair{p1,Pair}} where T2 where p2 where p1,
                    Tuple{Ref{Pair{p3,T3}}, Pair{p3}} where T3 where p3,
                    Tuple{Ref{Pair{p1,T2}}, Pair{p1,Pair}} where T2 where p1)
+
+    # issue #20998
+    _, E = intersection_env(Tuple{Int,Any,Any}, Tuple{T,T,S} where {T,S})
+    @test length(E) == 2 && E[1] == Int && isa(E[2], TypeVar)
 end
 
 function test_intersection_properties()


### PR DESCRIPTION
This was a case where an unknown typevar was incorrectly inferred to have the value `Any`.