### PR TITLE
fix #20992

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1542,8 +1542,10 @@ static jl_value_t *intersect_sub_datatype(jl_datatype_t *xd, jl_datatype_t *yd, 
             for(i=0; i<envsz; i++) {
                 // if a parameter is not constrained by the supertype, use the original
                 // parameter value from `x`. this is detected by the value in `env` being
-                // the exact typevar from the type's `wrapper`.
-                if (env[i] == (jl_value_t*)((jl_unionall_t*)wr)->var)
+                // the exact typevar from the type's `wrapper`, or a free typevar.
+                jl_value_t *ei = env[i];
+                if (ei == (jl_value_t*)((jl_unionall_t*)wr)->var ||
+                    (jl_is_typevar(ei) && lookup(e, (jl_tvar_t*)ei) == NULL))
                     env[i] = jl_tparam(xd,i);
                 wr = ((jl_unionall_t*)wr)->body;
             }

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -948,3 +948,12 @@ ftwoparams(::TwoParams{<:Real,<:Real}) = 3
 
 @testintersect(Tuple{Val{Val{0}}, Val{N}} where N, Tuple{Val{Val{N}}, Val{N}} where N, Tuple{Val{Val{0}},Val{0}})
 @testintersect(Tuple{Val{Val{N}}, Val{0}} where N, Tuple{Val{Val{N}}, Val{N}} where N, Tuple{Val{Val{0}},Val{0}})
+
+# issue #20992
+abstract type A20992{T,D,d} end
+abstract type B20992{SV,T,D,d} <: A20992{T,D,d} end
+struct C20992{S,n,T,D,d} <: B20992{NTuple{n,S},T,D,d}
+end
+@testintersect(Tuple{A20992{R, D, d} where d where D, Int} where R,
+               Tuple{C20992{S, n, T, D, d} where d where D where T where n where S, Any},
+               Tuple{C20992, Int})


### PR DESCRIPTION
This was due to type intersection returning a type containing a free variable.

`precise_container_type` was also trying to use types with free variables.