### PR TITLE
RFC: Added recursive transpose to `Diagonal`

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -104,7 +104,7 @@ ishermitian(D::Diagonal{<:Real}) = true
 ishermitian(D::Diagonal{<:Number}) = isreal(D.diag)
 ishermitian(D::Diagonal) = all(ishermitian, D.diag)
 issymmetric(D::Diagonal{<:Number}) = true
-issymmetric(D::Diagonal) = all(issymmetric, D.Diag)
+issymmetric(D::Diagonal) = all(issymmetric, D.diag)
 isposdef(D::Diagonal) = all(x -> x > 0, D.diag)
 
 factorize(D::Diagonal) = D
@@ -279,8 +279,11 @@ end
 eye{T}(::Type{Diagonal{T}}, n::Int) = Diagonal(ones(T,n))
 
 expm(D::Diagonal) = Diagonal(exp.(D.diag))
+expm(D::Diagonal{<:AbstractMatrix}) = Diagonal(expm.(D.diag))
 logm(D::Diagonal) = Diagonal(log.(D.diag))
+logm(D::Diagonal{<:AbstractMatrix}) = Diagonal(logm.(D.diag))
 sqrtm(D::Diagonal) = Diagonal(sqrt.(D.diag))
+sqrtm(D::Diagonal{<:AbstractMatrix}) = Diagonal(sqrtm.(D.diag))
 
 #Linear solver
 function A_ldiv_B!(D::Diagonal, B::StridedVecOrMat)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -101,8 +101,10 @@ end
 parent(D::Diagonal) = D.diag
 
 ishermitian(D::Diagonal{<:Real}) = true
-ishermitian(D::Diagonal) = isreal(D.diag)
-issymmetric(D::Diagonal) = true
+ishermitian(D::Diagonal{<:Number}) = isreal(D.diag)
+ishermitian(D::Diagonal) = all(ishermitian, D.diag)
+issymmetric(D::Diagonal{<:Number}) = true
+issymmetric(D::Diagonal) = all(issymmetric, D.Diag)
 isposdef(D::Diagonal) = all(x -> x > 0, D.diag)
 
 factorize(D::Diagonal) = D
@@ -260,8 +262,10 @@ end
 @inline A_mul_Bc(D::Diagonal, rowvec::RowVector) = D*ctranspose(rowvec)
 
 conj(D::Diagonal) = Diagonal(conj(D.diag))
-transpose(D::Diagonal) = D
-ctranspose(D::Diagonal) = conj(D)
+transpose(D::Diagonal{<:Number}) = D
+transpose(D::Diagonal) = Diagonal(transpose.(D.diag))
+ctranspose(D::Diagonal{<:Number}) = conj(D)
+ctranspose(D::Diagonal) = Diagonal(ctranspose.(D.diag))
 
 diag(D::Diagonal) = D.diag
 trace(D::Diagonal) = sum(D.diag)

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -304,3 +304,12 @@ end
     Q = qrfact(randn(5, 5))[:Q]
     @test D * Q' == Array(D) * Q'
 end
+
+@testset "block diagonal matrices" begin
+    D1 = Diagonal([[1 2; 3 4]])
+    D2 = Diagonal([[1 1+im; 1-im 1]])
+    @test D1.' == Diagonal([[1 3; 2 4]])
+    @test D2' == D2
+    @test issymmetric(D1) == false
+    @test ishermitian(D2) == true
+end

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -306,10 +306,25 @@ end
 end
 
 @testset "block diagonal matrices" begin
-    D1 = Diagonal([[1 2; 3 4]])
-    D2 = Diagonal([[1 1+im; 1-im 1]])
-    @test D1.' == Diagonal([[1 3; 2 4]])
-    @test D2' == D2
-    @test issymmetric(D1) == false
-    @test ishermitian(D2) == true
+    D = Diagonal([[1 2; 3 4], [1 2; 3 4]])
+    Dherm = Diagonal([[1 1+im; 1-im 1], [1 1+im; 1-im 1]])
+    Dsym = Diagonal([[1 1+im; 1+im 1], [1 1+im; 1+im 1]])
+    @test D' == Diagonal([[1 3; 2 4], [1 3; 2 4]])
+    @test D.' == Diagonal([[1 3; 2 4], [1 3; 2 4]])
+    @test Dherm' == Dherm
+    @test Dherm.' == Diagonal([[1 1-im; 1+im 1], [1 1-im; 1+im 1]])
+    @test Dsym' == Diagonal([[1 1-im; 1-im 1], [1 1-im; 1-im 1]])
+    @test Dsym.' == Dsym
+
+    @test issymmetric(D) == false
+    @test issymmetric(Dherm) == false
+    @test issymmetric(Dsym) == true
+
+    @test ishermitian(D) == false
+    @test ishermitian(Dherm) == true
+    @test ishermitian(Dsym) == false
+
+    @test expm(D) == Diagonal([expm([1 2; 3 4]), expm([1 2; 3 4])])
+    @test logm(D) == Diagonal([logm([1 2; 3 4]), logm([1 2; 3 4])])
+    @test sqrtm(D) == Diagonal([sqrtm([1 2; 3 4]), sqrtm([1 2; 3 4])])
 end


### PR DESCRIPTION
I mentioned this one at JuliaLang/LinearAlgebra.jl#408. (This has irked me for some time, but until that discussion I had been pretty sceptical of the foundations of block matrices as `Matrix{Matrix}`)

In theory, `Diagonal` might be used to represent a block-diagonal matrix structure. This takes one small step towards supporting this more fully, and arguably fixes a bug (since transpose is supposed to be recursive, but is not in this case).

@stevengj do you think it is reasonable that `Diagonal` is used for block-diagonal matrices?