### PR TITLE
use newest world callback on_done

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1577,7 +1577,14 @@ function run_interface(terminal, m::ModalInterface)
             @static if is_unix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
             buf, ok, suspend = prompt!(terminal, m, s)
         end
-        eval(Expr(:call, mode(state(s, s.current_mode)).on_done, s, buf, ok))
+        eval(Main,
+            Expr(:body,
+                Expr(:return,
+                     Expr(:call,
+                          mode(state(s, s.current_mode)).on_done,
+                          QuoteNode(s),
+                          QuoteNode(buf),
+                          QuoteNode(ok)))))
     end
 end
 

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1577,7 +1577,7 @@ function run_interface(terminal, m::ModalInterface)
             @static if is_unix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
             buf, ok, suspend = prompt!(terminal, m, s)
         end
-        mode(state(s, s.current_mode)).on_done(s, buf, ok)
+        eval(Expr(:call, mode(state(s, s.current_mode)).on_done, s, buf, ok))
     end
 end
 

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1581,7 +1581,7 @@ function run_interface(terminal, m::ModalInterface)
             Expr(:body,
                 Expr(:return,
                      Expr(:call,
-                          mode(state(s, s.current_mode)).on_done,
+                          QuoteNode(mode(state(s, s.current_mode)).on_done),
                           QuoteNode(s),
                           QuoteNode(buf),
                           QuoteNode(ok)))))


### PR DESCRIPTION
RCall REPL mode requires a custom `on_done` to work. At the current master branch, it is [broken][1].

```
The applicable method may be too new: running in world age 20392, while current world is 20418.
```

It occurs after https://github.com/JuliaLang/julia/pull/17057 and has been reported by https://github.com/JuliaLang/julia/issues/19774. @KristofferC has reported a similar bug for custom keybind in REPL mode at https://github.com/JuliaLang/julia/issues/19718 and it was patched at https://github.com/JuliaLang/julia/pull/19924. This solution suggested is to use `eval` to execute the callbacks, it serves as  a temp solution before a better solution arrives.

[1]: https://github.com/JuliaInterop/RCall.jl/issues/171