### PR TITLE
Fixes, tests, & the future of Base.Slice

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -440,13 +440,15 @@ false
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i) = throw(ArgumentError("unable to check bounds for indices of type $(typeof(i))"))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Real) = (first(inds) <= i) & (i <= last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
-checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
+checkindex(::Type{Bool}, inds::AbstractUnitRange, s::Slice) =
+    (first(s) >= first(inds)) & (last(s) <= last(inds))
 function checkindex(::Type{Bool}, inds::AbstractUnitRange, r::Range)
     @_propagate_inbounds_meta
     isempty(r) | (checkindex(Bool, inds, first(r)) & checkindex(Bool, inds, last(r)))
 end
 checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractVector{Bool}) = indx == indices1(I)
 checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractArray{Bool}) = false
+checkindex(::Type{Bool}, indx::Slice, I::AbstractVector{Bool}) = indx.indices == indices1(I)
 function checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractArray)
     @_inline_meta
     b = true

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -266,10 +266,14 @@ end
 compute_offset1(parent, stride1::Integer, I::Tuple) =
     (@_inline_meta; compute_offset1(parent, stride1, find_extended_dims(I)..., I))
 compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{Slice}, I::Tuple) =
-    (@_inline_meta; compute_linindex(parent, I) - stride1*first(indices(parent, dims[1])))  # index-preserving case
+    (@_inline_meta; compute_linindex(parent, I) - stride1*first(inds[1]))
 compute_offset1(parent, stride1::Integer, dims, inds, I::Tuple) =
     (@_inline_meta; compute_linindex(parent, I) - stride1)  # linear indexing starts with 1
 
+function compute_linindex(parent::AbstractVector, I::Tuple{Any})
+    @_inline_meta
+    first(I[1])
+end
 function compute_linindex{N}(parent, I::NTuple{N,Any})
     @_inline_meta
     IP = fill_to_length(indices(parent), OneTo(1), Val{N})

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2071,3 +2071,103 @@ end
 Base.:*(a::T11053, b::Real) = T11053(a.a*b)
 Base.:(==)(a::T11053, b::T11053) = a.a == b.a
 @test [T11053(1)] * 5 == [T11053(1)] .* 5 == [T11053(5.0)]
+
+@testset "Slice" begin
+    r = Base.Slice(0:-5)
+    @test isempty(r)
+    r = Base.Slice(0:2)
+    @test Base.Slice(r) === r
+    @test !isempty(r)
+    @test indices(r) === (0:2,)
+    @test step(r) == 1
+    @test first(r) == 0
+    @test last(r) == 2
+    @test minimum(r) == 0
+    @test maximum(r) == 2
+    @test r[0] == 0
+    @test r[1] == 1
+    @test r[2] == 2
+    @test r != 0:2
+    @test r == Base.Slice(0:2)
+    @test r === Base.Slice(0:2)
+    @test_throws BoundsError r[3]
+    @test_throws BoundsError r[-1]
+    @test r[0:2] === 0:2
+    @test r[r] === r
+    @test r[Base.Slice(1:2)] === Base.Slice(1:2)
+    @test r[1:2] === 1:2
+    @test_throws BoundsError r[Base.Slice(1:3)]
+    @test_throws BoundsError r[1:3]
+    k = -1
+    for i in r
+        @test i == (k+=1)
+    end
+    @test k == 2
+    @test intersect(r, Base.Slice(-1:1)) === intersect(Base.Slice(-1:1), r) === Base.Slice(0:1)
+    @test intersect(r, -1:5) === intersect(-1:5, r) === 0:2
+    @test intersect(r, 2:5) === intersect(2:5, r) === 2:2
+    # Not ideal, but at least this isn't wrong...
+    @test_throws ErrorException r+1
+    @test_throws ErrorException r-1
+    @test_throws ErrorException 2*r
+    @test_throws ErrorException r/2
+    @test_throws ErrorException reverse(r)
+
+    r = Base.Slice(2:4)
+    @test r != 2:4
+    @test r == Base.Slice(2:4)
+    @test r === Base.Slice(2:4)
+    @test Base.Slice(1:4) == 1:4
+    @test checkindex(Bool, r, 4)
+    @test !checkindex(Bool, r, 5)
+    @test checkindex(Bool, r, :)
+    @test checkindex(Bool, r, 2:4)
+    @test !checkindex(Bool, r, 1:5)
+    @test !checkindex(Bool, r, trues(4))
+    @test !checkindex(Bool, r, trues(3))
+    @test checkindex(Bool, r, view(trues(5), r))
+    @test !in(1, r)
+    @test in(2, r)
+    @test in(4, r)
+    @test !in(5, r)
+    @test issorted(r)
+    @test maximum(r) == 4
+    @test minimum(r) == 2
+    @test sortperm(r) == r
+
+    r = Base.Slice(Int16(0):Int16(4))
+    @test start(r) === 0
+    k = -1
+    for i in r
+        @test i == (k+=1)
+    end
+    @test k == 4
+    x, y = promote(r, Base.Slice(2:4))
+    @test x === Base.Slice(0:4)
+    @test y === Base.Slice(2:4)
+    x, y = promote(Base.Slice(4:5), 0:7)
+    @test x === 4:5
+    @test y === 0:7
+    r = Base.Slice(Int128(1):Int128(10))
+    @test length(r) === Int128(10)
+end
+
+@testset "Slice with view" begin
+    a = rand(8)
+    idr = Base.Slice(2:4)
+    v = view(a, idr)
+    @test indices(v) == (2:4,)
+    @test v[2] == a[2]
+    @test v[3] == a[3]
+    @test v[4] == a[4]
+    @test_throws BoundsError v[1]
+    @test_throws BoundsError v[5]
+
+    a = rand(5, 5)
+    idr2 = Base.Slice(3:4)
+    v = view(a, idr, idr2)
+    @test indices(v) == (2:4, 3:4)
+    @test v[2,3] == a[2,3]
+end
+
+nothing

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -84,6 +84,13 @@ for i = 1:9 @test A_3_3[i] == i end
 @test_throws BoundsError A[[true true;  false true]]
 
 # view
+x = OffsetArray(1:8, (-2,))
+S = view(x, :)
+@test indices(S) == (-1:6,)
+@test S[-1] == 1
+@test S[6] == 8
+@test_throws BoundsError S[-2]
+@test_throws BoundsError S[7]
 S = view(A, :, 3)
 @test S == OffsetArray([1,2], (A.offsets[1],))
 @test S[0] == 1


### PR DESCRIPTION
@mbauman added `Base.Slice` in #19730 as part of a major simplification of indexing rules. I confess I didn't really spend long enough thinking about it, and just mentally said to myself, "Colon got renamed." What I missed is that it's really quite simple and deserving of independent existence. If `isa(r, Base.Slice)`, then `r` is an `AbstractUnitRange` that should satisfy the following identities (which nearly imply one another):
- `r[i] == i` for any in-bounds `i`;
- `r[r] === r`
- `collect(r) == collect(indices(r, 1))`

Now, thinking of this as "Colon got renamed" isn't strictly wrong, because in 0.5 `Colon()` satisfies the first two of these (and `indices(:)` is not defined). But the name `Slice` doesn't convey this; consequently, for Julia 1.0 I think we should rename it, as well as reparametrize it more along the lines of other `AbstractUnitRange` objects. In my mind the leading contenders are `IdentityRange` (because of the first property) and `IdempotentRange` (because of the second).

More immediately, this type turns out to have useful properties that we're not currently exploiting or testing; in particular, it's a simple mechanism for creating "indices-preserving views", i.e. `v = view(a, Base.Slice(ind1), Base.Slice(ind2), ...)` satisfies `v[i, j, ...] == a[i, j, ...]` but might nevertheless represent a sub-region of `a` (and does not necessarily start indexing at 1). Wanting to exploit this, I noticed that the test suite for `Base.Slice` was not very extensive. I decided to add quite a few tests, and unsurprisingly I discovered (and then fixed) a number of bugs.

There's also a looming issue to address: without anyone really noticing, `Base.Slice` turns out to have introduced a non-1-indices AbstractArray type to Base. (I and others have put a lot of work into *supporting* non-1 arrays in Base, but Base does not actually allow you to *create* such an object without defining new types or loading packages.) The problem, then, is that unlike all other `AbstractArrays`s in Base, we can't support arithmetic operations on `Base.Slice`. For example, we can't return a conceptually-correct value for `r::Base.Slice + 1` unless `r` happens to start indexing at 1. I see two options:
- Leave it like this, with arithmetic operations throwing errors
- Support arithmetic operations by bringing OffsetArrays into Base

Given where we are, going back to `Colon` seems like a step backwards, so I don't really consider that to be a viable option.