### PR TITLE
A few typo and spacing fixes

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -4768,7 +4768,7 @@ function void_use_elim_pass!(sv::InferenceState)
             return !effect_free(ex, sv.src, sv.mod, false)
         elseif (isa(ex, GotoNode) || isa(ex, LineNumberNode) ||
                 isa(ex, NewvarNode) || isa(ex, Symbol) || isa(ex, LabelNode))
-            # This is a list of special type handled by the compiler
+            # This is a list of special types handled by the compiler
             return true
         end
         return false

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -248,9 +248,10 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
 end
 
 function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
-                        oid::Ptr{GitHash}, is_merge::Cuint, payload::Ptr{Void})
+                        oid_ptr::Ptr{GitHash}, is_merge::Cuint, payload::Ptr{Void})
     fhead_vec = unsafe_pointer_to_objref(payload)::Vector{FetchHead}
-    push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url), unsafe_load(oid), is_merge == 1))
+    push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url),
+        unsafe_load(oid_ptr), is_merge == 1))
     return Cint(0)
 end
 

--- a/base/libgit2/rebase.jl
+++ b/base/libgit2/rebase.jl
@@ -46,7 +46,7 @@ end
 function Base.show(io::IO, rb::GitRebase)
     println(io, "GitRebase:")
     println(io, "Number: ", count(rb))
-    println(io, "Currently performing operation: ",current(rb)+1)
+    println(io, "Currently performing operation: ", current(rb)+1)
 end
 
 """

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1583,7 +1583,7 @@ for (f, g) in ((:\, :A_ldiv_B!), (:Ac_ldiv_B, :Ac_ldiv_B!), (:At_ldiv_B, :At_ldi
         end
     end
 end
-### Multiplication with triangle to the rigth and hence lhs cannot be transposed.
+### Multiplication with triangle to the right and hence lhs cannot be transposed.
 for (f, g) in ((:*, :A_mul_B!), (:A_mul_Bc, :A_mul_Bc!), (:A_mul_Bt, :A_mul_Bt!))
     mat != :AbstractVector && @eval begin
         function ($f)(A::$mat, B::AbstractTriangular)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -475,7 +475,7 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
                 return inv(LAPACK.trcon!('O', $uploc, $isunitc, A.data))
             elseif p == Inf
                 return inv(LAPACK.trcon!('I', $uploc, $isunitc, A.data))
-            else #use fallback
+            else # use fallback
                 return cond(full(A), p)
             end
         end

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -26,7 +26,7 @@ function resolve(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}
         try
             sol = maxsum(graph, msgs)
         catch err
-            isa(err, UnsatError) || retrhow(err)
+            isa(err, UnsatError) || rethrow(err)
             p = interface.pkgs[err.info]
             # TODO: build tools to analyze the problem, and suggest to use them here.
             msg =
@@ -35,7 +35,7 @@ function resolve(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Available}
                   The problem was detected when trying to find a feasible version
                   for package $p.
                   However, this only means that package $p is involved in an
-                  unsatifiable or difficult dependency relation, and the root of
+                  unsatisfiable or difficult dependency relation, and the root of
                   the problem may be elsewhere.
                 """
             if msgs.num_nondecimated != graph.np

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -637,7 +637,7 @@ const ∈ = in
 Returns `true` if there is at least one element `y` in `itr` such that `fun(y,x)` is `true`.
 
 ```jldoctest
-julia> vec = [ 10, 100, 200 ]
+julia> vec = [10, 100, 200]
 3-element Array{Int64,1}:
   10
  100

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -129,7 +129,7 @@ function shell_split(s::AbstractString)
     parsed = shell_parse(s, false)[1]
     args = String[]
     for arg in parsed
-       push!(args, string(arg...))
+        push!(args, string(arg...))
     end
     args
 end

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -21,7 +21,7 @@ function startswith(a::AbstractString, b::AbstractString)
     while !done(a,i) && !done(b,i)
         c, i = next(a,i)
         d, j = next(b,j)
-        if c != d return false end
+        (c != d) && (return false)
     end
     done(b,i)
 end
@@ -48,7 +48,7 @@ function endswith(a::AbstractString, b::AbstractString)
     while a1 <= i && b1 <= j
         c = a[i]
         d = b[j]
-        if c != d return false end
+        (c != d) && (return false)
         i = prevind(a,i)
         j = prevind(b,j)
     end
@@ -90,9 +90,9 @@ julia> chomp("Hello\\n")
 """
 function chomp(s::AbstractString)
     i = endof(s)
-    if (i < 1 || s[i] != '\n') return SubString(s, 1, i) end
+    (i < 1 || s[i] != '\n') && (return SubString(s, 1, i))
     j = prevind(s,i)
-    if (j < 1 || s[j] != '\r') return SubString(s, 1, i-1) end
+    (j < 1 || s[j] != '\r') && (return SubString(s, 1, i-1))
     return SubString(s, 1, j-1)
 end
 function chomp(s::String)
@@ -197,7 +197,7 @@ strip(s::AbstractString, chars::Chars) = lstrip(rstrip(s, chars), chars)
 
 function lpad(s::AbstractString, n::Integer, p::AbstractString=" ")
     m = n - strwidth(s)
-    if m <= 0; return s; end
+    (m <= 0) && (return s)
     l = strwidth(p)
     if l==1
         return string(p^m, s)
@@ -210,7 +210,7 @@ end
 
 function rpad(s::AbstractString, n::Integer, p::AbstractString=" ")
     m = n - strwidth(s)
-    if m <= 0; return s; end
+    (m <= 0) && (return s)
     l = strwidth(p)
     if l==1
         return string(s, p^m)
@@ -286,7 +286,7 @@ function _split(str::AbstractString, splitter, limit::Integer, keep_empty::Bool,
             end
             i = k
         end
-        if k <= j; k = nextind(str,j) end
+        (k <= j) && (k = nextind(str,j))
         r = search(str,splitter,k)
         j, k = first(r), nextind(str,last(r))
     end

--- a/doc/src/devdocs/compiler.md
+++ b/doc/src/devdocs/compiler.md
@@ -18,7 +18,7 @@ ensuring they are valid both for the current runtime and after deserialization.
 
 When emitted into the object file, these globals are stored as references
 in a large `gvals` table. This allows the deserializer to reference them by index,
-and implement a custom manual GOT-like mechanism to restore them.
+and implement a custom manual mechanism similar to a Global Offset Table (GOT) to restore them.
 
 Function pointers are handled similarly.
 They are stored as values in a large `fvals` table.
@@ -28,7 +28,7 @@ Note that extern functions are handled separately,
 with names, via the usual symbol resolution mechanism in the linker.
 
 Note too that ccall functions are also handled separately,
-via a manual GOT + PLT.
+via a manual GOT and Procedure Linkage Table (PLT).
 
 
 ## Representation of Intermediate Values

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -269,7 +269,7 @@ First, a review of some relevant Julia type terminology:
 | `T{A}`                        | `Vector{Int}`                               | "Type Parameter" :: A specialization of a type (typically used for dispatch or storage optimization).                                                                                                                                                                          |
 |                               |                                             | "TypeVar" :: The `T` in the type parameter declaration is referred to as a TypeVar (short for type variable).                                                                                                                                                                  |
 | `primitive type`              | `Int`, `Float64`                            | "Primitive Type" :: A type with no fields, but a size. It is stored and defined by-value.                                                                                                                                                                                           |
-| `struct`                      | `Pair{Int, Int}`                            | "Struct" :: A type with all fields defined to be constant. It is defined by-value. And may be stored with a type-tag.                                                                                                                                                       |
+| `struct`                      | `Pair{Int, Int}`                            | "Struct" :: A type with all fields defined to be constant. It is defined by-value, and may be stored with a type-tag.                                                                                                                                                       |
 |                               | `Complex128` (`isbits`)                     | "Is-Bits"   :: A `primitive type`, or a `struct` type where all fields are other `isbits` types. It is defined by-value, and is stored without a type-tag.                                                                                                                       |
 | `struct ...; end`             | `nothing`                                   | "Singleton" :: a Leaf Type or Struct with no fields.                                                                                                                                                                                                                        |
 | `(...)` or `tuple(...)`       | `(1, 2, 3)`                                 | "Tuple" :: an immutable data-structure similar to an anonymous struct type, or a constant array. Represented as either an array or a struct.                                                                                                                                |
@@ -847,8 +847,8 @@ case, the expression must evaluate to a `Ptr`, which will be used as the address
 function to call. This behavior occurs when the first [`ccall`](@ref) argument contains references
 to non-constants, such as local variables, function arguments, or non-constant globals.
 
-For example, you might lookup the function via `dlsym`, then cache it in a global variable for
-that session. For example:
+For example, you might look up the function via `dlsym`, then cache it in a global
+variable for that session. For example:
 
 ```julia
 macro dlsym(func, lib)

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -827,7 +827,7 @@ end
 # other padding methods go here
 
 function myfilter(A, kernel, ::NoPad)
-     # Here's the "real" implementation of the core computation
+    # Here's the "real" implementation of the core computation
 end
 ```
 

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -928,7 +928,7 @@ Next, define the kernel:
 julia> @everywhere function advection_chunk!(q, u, irange, jrange, trange)
            @show (irange, jrange, trange)  # display so we can see what's happening
            for t in trange, j in jrange, i in irange
-               q[i,j,t+1] = q[i,j,t] +  u[i,j,t]
+               q[i,j,t+1] = q[i,j,t] + u[i,j,t]
            end
            q
        end

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -972,7 +972,7 @@ The slightly odd feature of these declarations as compared to typical parametric
 is that the type parameter `T` is not used in the definition of the type itself -- it is just
 an abstract tag, essentially defining an entire family of types with identical structure, differentiated
 only by their type parameter. Thus, `Ptr{Float64}` and `Ptr{Int64}` are distinct types, even though
-they have identical representations. And of course, all specific pointer types are subtype of
+they have identical representations. And of course, all specific pointer types are subtypes of
 the umbrella `Ptr` type:
 
 ```jldoctest
@@ -988,7 +988,7 @@ true
 We have said that a parametric type like `Ptr` acts as a supertype of all its instances
 (`Ptr{Int64}` etc.). How does this work? `Ptr` itself cannot be a normal data type, since without
 knowing the type of the referenced data the type clearly cannot be used for memory operations.
-The answer is that `Ptr` (or other parametric type like `Array`) is a different kind of type called a
+The answer is that `Ptr` (or other parametric types like `Array`) is a different kind of type called a
 `UnionAll` type. Such a type expresses the *iterated union* of types for all values of some parameter.
 
 `UnionAll` types are usually written using the keyword `where`. For example `Ptr` could be more
@@ -1056,8 +1056,8 @@ element type.
 
 Sometimes it is convenient to introduce a new name for an already expressible type.
 This can be done with a simple assignment statement.
-For example, UInt is aliased to either UInt32 or UInt64 as is appropriate for the size of pointers
-on the system:
+For example, `UInt` is aliased to either `UInt32` or `UInt64` as is appropriate
+for the size of pointers on the system:
 
 ```julia
 # 32-bit system:

--- a/doc/src/stdlib/simd-types.md
+++ b/doc/src/stdlib/simd-types.md
@@ -10,7 +10,7 @@ end
 ```
 
 It has a special compilation rule: a homogeneous tuple of `VecElement{T}` maps to an LLVM `vector`
-type when `T` is a bitstype and the tuple length is in the set {2-6,8-10,16}.
+type when `T` is a primitive bits type and the tuple length is in the set {2-6,8-10,16}.
 
 At `-O3`, the compiler *might* automatically vectorize operations on such tuples. For example,
 the following program, when compiled with `julia -O3` generates two SIMD addition instructions

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -778,7 +778,7 @@ static inline jl_cgval_t update_julia_type(const jl_cgval_t &v, jl_value_t *typ,
                 return jl_cgval_t(v.V, v.gcroot, true, typ, NULL);
             }
             else {
-                // type mismatch (there wasn't any boxed values in the union)
+                // type mismatch (there weren't any boxed values in the union)
                 CreateTrap(builder);
                 return jl_cgval_t();
             }
@@ -885,7 +885,7 @@ static jl_cgval_t convert_julia_type(const jl_cgval_t &v, jl_value_t *typ, jl_co
                 return jl_cgval_t(v.V, v.gcroot, true, typ, NULL);
             }
             else {
-                // type mismatch: there wasn't any boxed values in the union
+                // type mismatch: there weren't any boxed values in the union
                 CreateTrap(builder);
                 return jl_cgval_t();
             }
@@ -3515,7 +3515,7 @@ static jl_cgval_t emit_local(jl_value_t *slotload, jl_codectx_t *ctx)
         if (!vi.isVolatile || vi.value.constant || !vi.value.V) {
             v = vi.value;
             if (vi.pTIndex)
-                 v.TIndex = builder.CreateLoad(vi.pTIndex);
+                v.TIndex = builder.CreateLoad(vi.pTIndex);
         }
         else {
             // copy value to a non-volatile location
@@ -3528,7 +3528,7 @@ static jl_cgval_t emit_local(jl_value_t *slotload, jl_codectx_t *ctx)
             builder.CreateStore(unbox, slot);
             Value *tindex = NULL;
             if (vi.pTIndex)
-                 tindex = builder.CreateLoad(vi.pTIndex, /*volatile*/true);
+                tindex = builder.CreateLoad(vi.pTIndex, /*volatile*/true);
             v = mark_julia_slot(slot, vi.value.typ, tindex, tbaa_stack);
         }
         if (vi.boxroot == NULL)
@@ -3542,7 +3542,7 @@ static jl_cgval_t emit_local(jl_value_t *slotload, jl_codectx_t *ctx)
         Value *boxed = builder.CreateLoad(vi.boxroot, vi.isVolatile);
         Value *box_isnull;
         if (vi.usedUndef)
-             box_isnull = builder.CreateICmpNE(boxed, V_null);
+            box_isnull = builder.CreateICmpNE(boxed, V_null);
         if (vi.pTIndex) {
             // value is either boxed in the stack slot, or unboxed in value
             // as indicated by testing (pTIndex & 0x80)

--- a/src/dump.c
+++ b/src/dump.c
@@ -2698,7 +2698,7 @@ JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
 
 #ifndef NDEBUG
 // skip the performance optimizations of jl_types_equal and just use subtyping directly
-// ones of these types is invalid - that's why we're doing the recache type operation
+// one of these types is invalid - that's why we're doing the recache type operation
 static int jl_invalid_types_equal(jl_datatype_t *a, jl_datatype_t *b)
 {
     return jl_subtype((jl_value_t*)a, (jl_value_t*)b) && jl_subtype((jl_value_t*)b, (jl_value_t*)a);

--- a/src/gc.c
+++ b/src/gc.c
@@ -501,7 +501,7 @@ STATIC_INLINE void gc_queue_big_marked(jl_ptls_t ptls, bigval_t *hdr,
 }
 
 // `gc_setmark_tag` can be called concurrently on multiple threads.
-// In all cases, the functions atomically sets the mark bits and returns
+// In all cases, the function atomically sets the mark bits and returns
 // the GC bits set as well as if the tag was unchanged by this thread.
 // All concurrent calls on the same object are guaranteed to be setting the
 // bits to the same value.

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -1006,7 +1006,7 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
     newrec->max_world = max_world;
     // compute the complexity of this type signature
     newrec->va = jl_is_va_tuple((jl_datatype_t*)ttype);
-    newrec->issimplesig = !jl_is_unionall(type); // a TypeVar environment needs an complex matching test
+    newrec->issimplesig = !jl_is_unionall(type); // a TypeVar environment needs a complex matching test
     newrec->isleafsig = newrec->issimplesig && !newrec->va; // entirely leaf types don't need to be sorted
     JL_GC_PUSH1(&newrec);
     assert(jl_is_tuple_type(ttype));

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -204,7 +204,7 @@ function V1()
 end
 
 if bc_opt == bc_default || bc_opt == bc_off
-    @test V1() == nothing
+    @test V1() === nothing
 else
     @test_throws BoundsError V1()
 end

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-@testset "libgit2-online" begin
-
 #########
 # TESTS #
 #########
@@ -33,6 +31,4 @@ mktempdir() do dir
             end
         end
     end
-end
-
 end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -481,7 +481,7 @@ mktempdir() do dir
                 @test length(status) != 0
                 @test_throws BoundsError status[0]
                 @test_throws BoundsError status[length(status)+1]
-                #we've added a file - show that it is new
+                # we've added a file - show that it is new
                 @test status[1].status == LibGit2.Consts.STATUS_WT_NEW
                 close(repo_file)
             finally
@@ -635,7 +635,7 @@ mktempdir() do dir
 
             fetch_heads = LibGit2.fetchheads(repo)
             @test fetch_heads[1].name == "refs/heads/master"
-            @test fetch_heads[1].ismerge == true #we just merged master
+            @test fetch_heads[1].ismerge == true # we just merged master
             @test fetch_heads[2].name == "refs/heads/test_branch"
             @test fetch_heads[2].ismerge == false
             @test fetch_heads[3].name == "refs/tags/tag2"

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -93,8 +93,8 @@ end
     @testset "scp-like syntax, no port" begin
         m = match(LibGit2.URL_REGEX, "server:1234/repo")
         @test m[:scheme] === nothing
-        @test m[:user] == nothing
-        @test m[:password] == nothing
+        @test m[:user] === nothing
+        @test m[:password] === nothing
         @test m[:host] == "server"
         @test m[:port] === nothing
         @test m[:path] == "1234/repo"

--- a/test/linalg/lq.jl
+++ b/test/linalg/lq.jl
@@ -80,7 +80,7 @@ bimg  = randn(n,2)/2
                     @test_throws DimensionMismatch Ac_mul_B(q,ones(eltya,n+2,n+2))
                     @test_throws DimensionMismatch ones(eltyb,n+2,n+2)*q
                     if isa(a, DenseArray) && isa(b, DenseArray)
-                        #use this to test 2nd branch in mult code
+                        # use this to test 2nd branch in mult code
                         pad_a = vcat(eye(a), a)
                         pad_b = hcat(eye(b), b)
                         @test pad_a*q ≈ pad_a*full(q,thin=false) atol=100ε

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -503,27 +503,17 @@ let
     method_error = MethodError(EnclosingModule.AbstractTypeNoConstructors, ())
 
     # Test that it shows a special message when no constructors have been defined by the user.
-    @test sprint(
-        showerror,
-        method_error
-    ) == "MethodError: no constructors have been defined for $(EnclosingModule.AbstractTypeNoConstructors)"
+    @test sprint(showerror, method_error) ==
+        "MethodError: no constructors have been defined for $(EnclosingModule.AbstractTypeNoConstructors)"
 
     # Does it go back to previous behaviour when there *is* at least
     # one constructor defined?
     EnclosingModule.AbstractTypeNoConstructors(x, y) = x + y
-    @test startswith(sprint(
-            showerror,
-            method_error
-        ), "MethodError: no method matching $(EnclosingModule.AbstractTypeNoConstructors)()"
-    )
+    @test startswith(sprint(showerror, method_error),
+        "MethodError: no method matching $(EnclosingModule.AbstractTypeNoConstructors)()")
 
     # Test that the 'default' sysimg.jl method is not displayed.
-    @test !contains(sprint(
-            showerror,
-            method_error
-        ),
-        "where T at sysimg.jl"
-    )
+    @test !contains(sprint(showerror, method_error), "where T at sysimg.jl")
 
     # Test that tab-completion will not show the 'default' sysimg.jl method.
     for method_string in Base.REPLCompletions.complete_methods(:(EnclosingModule.AbstractTypeNoConstructors()))

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -1080,13 +1080,13 @@ s14046 = sprand(5, 1.0)
 @test 2*s14046 == s14046 + s14046
 
 # Issue 14589
-#test vectors with no zero elements
+# test vectors with no zero elements
 x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 7)
 @test collect(sort(x)) == sort(collect(x))
-#test vectors with all zero elements
+# test vectors with all zero elements
 x = sparsevec(Int64[], Float64[], 7)
 @test collect(sort(x)) == sort(collect(x))
-#test vector with sparsity approx 1/2
+# test vector with sparsity approx 1/2
 x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 15)
 @test collect(sort(x)) == sort(collect(x))
 # apply three distinct tranformations where zeros sort into start/middle/end
@@ -1094,7 +1094,7 @@ x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 15)
 @test collect(sort(x, by=sign)) == sort(collect(x), by=sign)
 @test collect(sort(x, by=inv)) == sort(collect(x), by=inv)
 
-#fill!
+# fill!
 for Tv in [Float32, Float64, Int64, Int32, Complex128]
     for Ti in [Int16, Int32, Int64, BigInt]
         sptypes = (SparseMatrixCSC{Tv, Ti}, SparseVector{Tv, Ti})

--- a/test/unicode/utf8proc.jl
+++ b/test/unicode/utf8proc.jl
@@ -109,26 +109,26 @@ end
     alphas=vcat(alower,ulower,aupper,uupper,nocase)
 
     for c in alphas
-         @test isalpha(c) == true
-         @test isnumber(c) == false
+        @test isalpha(c) == true
+        @test isnumber(c) == false
     end
 
     anumber=['0', '1', '5', '9']
     unumber=['٣', '٥', '٨', '¹', 'ⅳ' ]
 
     for c in anumber
-         @test isdigit(c) == true
-         @test isnumber(c) == true
+        @test isdigit(c) == true
+        @test isnumber(c) == true
     end
     for c in unumber
-         @test isdigit(c) == false
-         @test isnumber(c) == true
+        @test isdigit(c) == false
+        @test isnumber(c) == true
     end
 
     alnums=vcat(alphas,anumber,unumber)
     for c in alnums
-         @test isalnum(c) == true
-         @test ispunct(c) == false
+        @test isalnum(c) == true
+        @test ispunct(c) == false
     end
 
     asymbol = ['(',')', '~', '$' ]
@@ -138,8 +138,8 @@ end
     upunct =['‡', '؟', '჻' ]
 
     for c in vcat(apunct,upunct)
-         @test ispunct(c) == true
-         @test isalnum(c) == false
+        @test ispunct(c) == true
+        @test isalnum(c) == false
     end
 
     for c in vcat(alnums,asymbol,usymbol,apunct,upunct)


### PR DESCRIPTION
At least the `rethrow` typo in `base/pkg/resolve.jl` and the change in `test/distributed_exec.jl` should be fixed now, the rest of these don't matter as much.