### PR TITLE
Introduce temporary if necessary to inline `_apply`

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -4468,7 +4468,7 @@ function inlining_pass(e::Expr, sv::InferenceState, stmts, ins)
                         tmpv = aarg
                     else
                         # apply(f,t::(x,y)) => tmp=t; f(tmp[1],tmp[2])
-                        tmpv = add_slot!(sv.src, t, false)
+                        tmpv = newvar!(sv, t)
                         insert!(stmts, ins, Expr(:(=), tmpv, aarg))
                         ins += 1
                     end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -684,3 +684,18 @@ Base.@pure function a20704(x)
 end
 aa20704(x) = x(nothing)
 @test code_typed(aa20704, (typeof(a20704),))[1][1].pure
+
+#issue #21065, elision of _apply when splatted expression is not effect_free
+function f21065(x,y)
+    println("x=$x, y=$y")
+    return x, y
+end
+g21065(x,y) = +(f21065(x,y)...)
+function test_no_apply(expr::Expr)
+    return all(test_no_apply, expr.args)
+end
+function test_no_apply(ref::GlobalRef)
+    return ref.mod != Core || ref.name !== :_apply
+end
+test_no_apply(::Any) = true
+@test all(test_no_apply, code_typed(g21065, Tuple{Int,Int})[1].first.code)


### PR DESCRIPTION
With
```julia
julia> function foo(x,y)
           println("x=$x, y=$y")
           return x, y
       end
foo (generic function with 1 method)

julia> bar(x,y) = +(foo(x,y)...)
bar (generic function with 1 method)
```
master:
```julia
julia> @code_typed bar(1, 2)
CodeInfo(:(begin 
        return (Core._apply)(Main.+, $(Expr(:invoke, MethodInstance for foo(::Int64, ::Int64), :(Main.foo), :(x), :(y))))::Int64
    end))=>Int64
```
this PR:
```julia
julia> @code_typed bar(1, 2)
CodeInfo(:(begin 
        #temp# = $(Expr(:invoke, MethodInstance for foo(::Int64, ::Int64), :(Main.foo), :(x), :(y)))
        return (Base.add_int)((Core.getfield)(#temp#, 1)::Int64, (Core.getfield)(#temp#, 2)::Int64)::Int64
    end))=>Int64
```

Fixes #21065 and makes #21067 (almost?) obsolete.  (The "almost" being a matter of inlining `promote`, `promote_type`, and `convert`, where #21067 might still be advantageous.)