### PR TITLE
Avoid creating files when download fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ script:
     - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 &&
         cd /tmp/julia/share/julia/test &&
         /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
-        /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
+        /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg
     - cd `dirname $TRAVIS_BUILD_DIR` && mv julia2 julia &&
         rm -f julia/deps/scratch/libgit2-*/CMakeFiles/CMakeOutput.log
 # uncomment the following if failures are suspected to be due to the out-of-memory killer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,4 +56,4 @@ test_script:
   - usr\bin\julia -e "versioninfo()"
   - usr\bin\julia --precompiled=no -e "true"
   - cd test && ..\usr\bin\julia --check-bounds=yes runtests.jl all &&
-      ..\usr\bin\julia --check-bounds=yes runtests.jl libgit2-online pkg
+      ..\usr\bin\julia --check-bounds=yes runtests.jl libgit2-online download pkg

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -587,7 +587,12 @@ else
             end
         end
         if downloadcmd == :wget
-            run(`wget -O $filename $url`)
+            try
+                run(`wget -O $filename $url`)
+            catch
+                rm(filename)  # wget always creates a file
+                rethrow()
+            end
         elseif downloadcmd == :curl
             run(`curl -L -f -o $filename $url`)
         elseif downloadcmd == :fetch

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -589,7 +589,7 @@ else
         if downloadcmd == :wget
             run(`wget -O $filename $url`)
         elseif downloadcmd == :curl
-            run(`curl -o $filename -L $url`)
+            run(`curl -L -f -o $filename $url`)
         elseif downloadcmd == :fetch
             run(`fetch -f $filename $url`)
         else

--- a/test/download.jl
+++ b/test/download.jl
@@ -1,0 +1,26 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+mktempdir() do temp_dir
+    # Download a file
+    file = joinpath(temp_dir, "ip")
+    @test download("http://httpbin.org/ip", file) == file
+    @test isfile(file)
+    @test !isempty(read(file))
+
+    # Download an empty file
+    empty_file = joinpath(temp_dir, "empty")
+    @test download("http://httpbin.org/status/200", empty_file) == empty_file
+
+    # Windows and older versions of curl do not create the empty file (https://github.com/curl/curl/issues/183)
+    @test !isfile(empty_file) || isempty(read(empty_file))
+
+    # Make sure that failed downloads do not leave files around
+    missing_file = joinpath(temp_dir, "missing")
+    @test_throws ErrorException download("http://httpbin.org/status/404", missing_file)
+    @test !isfile(missing_file)
+
+    # Use a TEST-NET (192.0.2.0/24) address which shouldn't be bound
+    invalid_host_file = joinpath(temp_dir, "invalid_host")
+    @test_throws ErrorException download("http://192.0.2.1", invalid_host_file)
+    @test !isfile(invalid_host_file)
+end


### PR DESCRIPTION
```julia
julia> run(`curl -vLo tzdata.tar.gz https://www.iana.org/time-zones/repository/releases/tzdata2016z.tar.gz`)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 192.0.32.8...
* TCP_NODELAY set
* Connected to www.iana.org (192.0.32.8) port 443 (#0)
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* TLS 1.2 connection using TLS_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: *.iana.org
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> GET /time-zones/repository/releases/tzdata2016z.tar.gz HTTP/1.1
> Host: www.iana.org
> User-Agent: curl/7.51.0
> Accept: */*
> 
< HTTP/1.1 404 NOT FOUND
< Date: Fri, 17 Mar 2017 16:43:07 GMT
< X-Frame-Options: SAMEORIGIN
< Content-Security-Policy: upgrade-insecure-requests
< Vary: Accept-Encoding
< Content-Length: 1092
< Cache-Control: public, s-maxage=600, max-age=3600
< Expires: Fri, 17 Mar 2017 17:43:07 GMT
< content-type: application/x-gzip
< content-encoding: identity
< Server: Apache
< Strict-Transport-Security: max-age=47304003; preload
< X-Cache-Hits: 0
< Connection: keep-alive
< 
{ [995 bytes data]
* Curl_http_done: called premature == 0
100  1092  100  1092    0     0   2879      0 --:--:-- --:--:-- --:--:--  2873
* Connection #0 to host www.iana.org left intact

julia> isfile("tzdata.tar.gz")
true

julia> rm("tzdata.tar.gz")

julia> run(`curl -vLfo tzdata.tar.gz https://www.iana.org/time-zones/repository/releases/tzdata2016z.tar.gz`)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 192.0.32.8...
* TCP_NODELAY set
* Connected to www.iana.org (192.0.32.8) port 443 (#0)
* TLS 1.2 connection using TLS_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: *.iana.org
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> GET /time-zones/repository/releases/tzdata2016z.tar.gz HTTP/1.1
> Host: www.iana.org
> User-Agent: curl/7.51.0
> Accept: */*
> 
* The requested URL returned error: 404 NOT FOUND
* Curl_http_done: called premature == 1
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
curl: (22) The requested URL returned error: 404 NOT FOUND
ERROR: failed process: Process(`curl -vLfo tzdata.tar.gz https://www.iana.org/time-zones/repository/releases/tzdata2016z.tar.gz`, ProcessExited(22)) [22]
Stacktrace:
 [1] pipeline_error(::Base.Process) at ./process.jl:687
 [2] run(::Cmd) at ./process.jl:656

julia> isfile("tzdata.tar.gz")
false
```

Note that `wget` will always create a file. We could automatically clean it up if we wrap it in a `try/catch`.