### PR TITLE
fix #21054, parse/lowering problem with `<:T` syntax

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -928,11 +928,13 @@
                          ((not (memq op unary-ops))
                           (error (string "\"" op "\" is not a unary operator")))
                          (else
-                          (let ((arg (parse-unary s)))
-                            (if (and (pair? arg)
-                                     (eq? (car arg) 'tuple))
-                                (list* 'call op (cdr arg))
-                                (list  'call op arg)))))))))
+                          (let* ((arg  (parse-unary s))
+                                 (args (if (and (pair? arg) (eq? (car arg) 'tuple))
+                                           (cons op (cdr arg))
+                                           (list op arg))))
+                            (if (or (eq? op '|<:|) (eq? op '|>:|))
+                                args
+                                (cons 'call args)))))))))
           (else
            (parse-juxtapose (parse-factor s) s)))))
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1763,9 +1763,9 @@
     (if (null? params)
         (cons (reverse newparams) (reverse whereparams))
         (let ((p (car params)))
-          (if (and (list? p) (= (length p) 3) (eq? (car p) 'call) (or (eq? (cadr p) '|<:|) (eq? (cadr p) '|>:|)))
+          (if (and (length= p 2) (or (eq? (car p) '|<:|) (eq? (car p) '|>:|)))
               (let ((T (gensy)))
-                (extract (cdr params) (cons T newparams) (cons (list (cadr p) T (caddr p)) whereparams)))
+                (extract (cdr params) (cons T newparams) (cons (list (car p) T (cadr p)) whereparams)))
               (extract (cdr params) (cons p newparams) whereparams)))))
   (extract (cddr e) '() '()))
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1044,3 +1044,12 @@ end
 # issue #20000
 @test parse("@m(a; b=c)") == Expr(:macrocall, Symbol("@m"),
                                   Expr(:parameters, Expr(:kw, :b, :c)), :a)
+
+# issue #21054
+macro make_f21054(T)
+    quote
+        $(esc(:f21054))(X::Type{<:$T}) = 1
+    end
+end
+@eval @make_f21054 $Array
+@test isa(f21054, Function)


### PR DESCRIPTION
This is one way to fix the issue. It changes the parsing of `<:T`, but I think that's defensible since (1) in 0.5 we announced that `<:` calls would use `<:` as the expression head, but I missed the unary case, (2) unary `<:` was never used before 0.6 as far as I know.