### PR TITLE
fix #21074, constant fold more expressions

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -548,7 +548,7 @@ add_tfunc(nfields, 1, 1,
         isa(x,Conditional) && return Const(nfields(Bool))
         if isType(x)
             isleaftype(x.parameters[1]) && return Const(nfields(x.parameters[1]))
-        elseif isa(x,DataType) && !x.abstract && !(x.name === Tuple.name && isvatuple(x))
+        elseif isa(x,DataType) && !x.abstract && !(x.name === Tuple.name && isvatuple(x)) && x !== DataType
             return Const(length(x.types))
         end
         return Int

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -777,6 +777,9 @@ function getfield_tfunc(s00::ANY, name)
             if isa(sv, Module) && isa(nv, Symbol)
                 return abstract_eval_global(sv, nv)
             end
+            if !(isa(nv,Symbol) || isa(nv,Int))
+                return Bottom
+            end
             if (isa(sv, SimpleVector) || isimmutable(sv)) && isdefined(sv, nv)
                 return abstract_eval_constant(getfield(sv, nv))
             end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -715,3 +715,8 @@ err20033(x::Float64...) = prod(x)
 # Inference of constant svecs
 @eval fsvecinf() = $(QuoteNode(Core.svec(Tuple{Int,Int}, Int)))[1]
 @test Core.Inference.return_type(fsvecinf, Tuple{}) == Type{Tuple{Int,Int}}
+
+# nfields tfunc on `DataType`
+let f = ()->Val{nfields(DataType[Int][1])}
+    @test f() == Val{0}
+end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -720,3 +720,7 @@ err20033(x::Float64...) = prod(x)
 let f = ()->Val{nfields(DataType[Int][1])}
     @test f() == Val{0}
 end
+
+# inference on invalid getfield call
+@eval _getfield_with_string_() = getfield($(1=>2), "")
+@test Base.return_types(_getfield_with_string_, ()) == Any[Union{}]

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -79,3 +79,12 @@ f18948() = (local bar::Int64; bar=1.5)
 g18948() = (local bar::Int32; bar=0x80000000)
 @test_throws InexactError f18948()
 @test_throws InexactError g18948()
+
+# issue #21074
+struct s21074
+    x::Tuple{Int, Int}
+end
+@eval f21074() = $(s21074((1,2))).x[1]
+let (src, _) = code_typed(f21074, ())[1]
+    @test src.code[1] == Expr(:return, QuoteNode(1))
+end

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -84,7 +84,12 @@ g18948() = (local bar::Int32; bar=0x80000000)
 struct s21074
     x::Tuple{Int, Int}
 end
+@inline Base.getindex(v::s21074, i::Integer) = v.x[i]
 @eval f21074() = $(s21074((1,2))).x[1]
 let (src, _) = code_typed(f21074, ())[1]
-    @test src.code[1] == Expr(:return, QuoteNode(1))
+    @test src.code[1] == Expr(:return, 1)
+end
+@eval g21074() = $(s21074((1,2)))[1]
+let (src, _) = code_typed(g21074, ())[1]
+    @test src.code[1] == Expr(:return, 1)
 end


### PR DESCRIPTION
- Anything that's effect-free and inferred as `Const` can be replaced with a constant.
- Handle constant values in `getfield_elim_pass!`
- Improve constant folding of SimpleVector length
- Fix bugs in nfields and getfield tfuncs
