### PR TITLE
DefaultTestSet tests for test_broken and test_skip

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -257,6 +257,18 @@ end
 @test counter_17462_pre == 3
 @test counter_17462_post == 1
 
+# Issue #21008
+ts = try
+    @testset "@test_broken and @test_skip should not give an exception" begin
+        @test_broken false
+        @test_skip true
+        @test_skip false
+    end
+catch
+    nothing # Shouldn't get here
+end
+@test typeof(ts) == Base.Test.DefaultTestSet
+
 # now we're done running tests with DefaultTestSet so we can go back to STDOUT
 redirect_stdout(OLD_STDOUT)
 redirect_stderr(OLD_STDERR)

--- a/test/test.jl
+++ b/test/test.jl
@@ -267,7 +267,7 @@ ts = try
 catch
     nothing # Shouldn't get here
 end
-@test typeof(ts) == Base.Test.DefaultTestSet
+@test ts isa Base.Test.DefaultTestSet
 
 # now we're done running tests with DefaultTestSet so we can go back to STDOUT
 redirect_stdout(OLD_STDOUT)


### PR DESCRIPTION
Check that test_broken and test_skip do not result in an exception.
Already fixed by @kshyatt in 8982605 - "Rework test framework", but present in
julia-0.5 (see #21008).

I'll send another PR for a 0.5 fix.