### PR TITLE
[release-0.5] Don't throw for tests which are explicitly marked broken

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -494,7 +494,7 @@ function finish(ts::DefaultTestSet)
     # Recursively print a summary at every level
     print_counts(ts, 0, align, pass_width, fail_width, error_width, broken_width, total_width)
     # Finally throw an error as we are the outermost test set
-    if total != total_pass
+    if total != total_pass + total_broken
         throw(TestSetException(total_pass,total_fail,total_error, total_broken))
     end
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -227,6 +227,18 @@ end
 @test counter_17462_pre == 3
 @test counter_17462_post == 1
 
+# Issue #21008
+ts = try
+    @testset "@test_broken and @test_skip should not give an exception" begin
+        @test_broken false
+        @test_skip true
+        @test_skip false
+    end
+catch
+    nothing # Shouldn't get here
+end
+@test typeof(ts) == Base.Test.DefaultTestSet
+
 # now we're done running tests with DefaultTestSet so we can go back to STDOUT
 redirect_stdout(OLD_STDOUT)
 


### PR DESCRIPTION
Fixes #21008

Also grab the associated test case from #21086 (@tkelman - is that the right thing?  Do you want test cases backported along with minimal fixes?)