### PR TITLE
Make `@fastmath` aware of `Base.literal_pow`

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -118,6 +118,9 @@ function make_fastmath(expr::Expr)
                 $arrvar[$(indvars...)] = $op($arrvar[$(indvars...)], $rhs)
             end
         end
+    elseif is_literal_int_pow(expr)
+        expr = Expr(expr.head, :(Base.literal_pow),
+            expr.args[1], expr.args[2], Val(expr.args[3]))
     end
     Base.exprarray(make_fastmath(expr.head), Base.mapany(make_fastmath, expr.args))
 end
@@ -155,6 +158,10 @@ macro fastmath(expr)
     make_fastmath(esc(expr))
 end
 
+function is_literal_int_pow(ex::Expr)
+    return (ex.head === :call && length(ex.args) == 3 &&
+        ex.args[1] === :^ && isa(ex.args[3], Integer))
+end
 
 # Basic arithmetic
 

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -249,3 +249,10 @@ end
     @test (@fastmath "a" * "b") == "ab"
     @test (@fastmath "a" ^ 2) == "aa"
 end
+
+struct LitPowTest end
+Base.literal_pow(::typeof(Base.FastMath.pow_fast), ::LitPowTest, ::Val{p}) where {p} = 1
+Base.literal_pow(::typeof(^), ::LitPowTest, ::Val{p}) where {p} = 2
+LPT = LitPowTest()
+@test (@fastmath LPT^2) == 1
+@test LPT^2 == 2


### PR DESCRIPTION
as `Base.literal_pow(Base.FastMath.pow_fast, x, Val{p})`.

Thanks to PRs #20530 and #20889, exponentiation of a dimensionful quantity can be type-stable in some important circumstances. However, because macro expansion occurs before the `Val` lowering happens, `@fastmath x^2` cannot be type-stable for dimensionful quantities, whereas `x^2` could be. This is because `@fastmath x^2` is macro-expanded to `Base.FastMath.pow_fast(x,2)` and so we can never catch the `^` symbol. See the tests I added to get an idea of how this works.

Provided the premise of this PR isn't flawed somehow, it would probably good to have someone more familiar with `julia_syntax.scm` see if there’s a better way to implement this change. Because I tie into the mechanism introduced in #20889 I don't expect any "surprising behaviors" to be introduced here, though I haven't checked to see if there are any performance implications.