### PR TITLE
Restoring get_num_threads function of BLAS

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -117,17 +117,20 @@ Get the number of threads the BLAS library can use.
 """
 function get_num_threads()
     blas = BLAS.vendor()
-    if blas == :openblas
-        return ccall((:openblas_get_num_threads, Base.libblas_name), Cint, ())
-    elseif blas == :openblas64
-        return ccall((:openblas_get_num_threads64_, Base.libblas_name), Cint, ())
-    elseif blas == :mkl
-        return ccall((:MKL_Get_Max_Num_Threads, Base.libblas_name), Cint, ())
-    end
+    # Wrap in a try to catch unsupported blas versions
+    try
+        if blas == :openblas
+            return ccall((:openblas_get_num_threads, Base.libblas_name), Cint, ())
+        elseif blas == :openblas64
+            return ccall((:openblas_get_num_threads64_, Base.libblas_name), Cint, ())
+        elseif blas == :mkl
+            return ccall((:MKL_Get_Max_Num_Threads, Base.libblas_name), Cint, ())
+        end
 
-    # OSX BLAS looks at an environment variable
-    @static if is_apple()
-        return ENV["VECLIB_MAXIMUM_THREADS"]
+        # OSX BLAS looks at an environment variable
+        if is_apple()
+            return ENV["VECLIB_MAXIMUM_THREADS"]
+        end
     end
 
     return nothing

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -110,6 +110,29 @@ function set_num_threads(n::Integer)
     return nothing
 end
 
+"""
+    get_num_threads(n)
+
+Get the number of threads the BLAS library can use.
+"""
+function get_num_threads()
+    blas = BLAS.vendor()
+    if blas == :openblas
+        return ccall((:openblas_get_num_threads, Base.libblas_name), Cint, ())
+    elseif blas == :openblas64
+        return ccall((:openblas_get_num_threads64_, Base.libblas_name), Cint, ())
+    elseif blas == :mkl
+        return ccall((:MKL_Get_Max_Num_Threads, Base.libblas_name), Cint, ())
+    end
+
+    # OSX BLAS looks at an environment variable
+    @static if is_apple()
+        return ENV["VECLIB_MAXIMUM_THREADS"]
+    end
+
+    return nothing
+end
+
 function check()
     blas = vendor()
     if blas == :openblas || blas == :openblas64


### PR DESCRIPTION
BLAS.get_num_threads function have been deleted by this commit https://github.com/JuliaLang/julia/commit/1da2c9bfe6f911c39f203bc1d5b7486a2420fdd8.

But, I can not find why, I think, I and other people also need this function by #15008.
And It already implemented by @tkelman before.