### PR TITLE
RFC: Use `typejoin` of the field types for `eltype` of heterogeneous `Tuple`s

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -65,6 +65,7 @@ eltype(::Type{Tuple{}}) = Bottom
 eltype(::Type{<:Tuple{Vararg{E}}}) where {E} = E
 function eltype(t::Type{<:Tuple})
     @_pure_meta
+    t isa Union && return typejoin(eltype(t.a), eltype(t.b))
     t´ = unwrap_unionall(t)
     r = Union{}
     for ti in t´.parameters

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -63,6 +63,15 @@ first(t::Tuple) = t[1]
 
 eltype(::Type{Tuple{}}) = Bottom
 eltype(::Type{<:Tuple{Vararg{E}}}) where {E} = E
+function eltype(t::Type{<:Tuple})
+    @_pure_meta
+    t´ = unwrap_unionall(t)
+    r = Union{}
+    for ti in t´.parameters
+        r = typejoin(r, unwrapva(ti))
+    end
+    return rewrap_unionall(r, t)
+end
 
 # version of tail that doesn't throw on empty tuples (used in array indexing)
 safe_tail(t::Tuple) = tail(t)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -68,9 +68,9 @@ function eltype(t::Type{<:Tuple})
     t´ = unwrap_unionall(t)
     r = Union{}
     for ti in t´.parameters
-        r = typejoin(r, unwrapva(ti))
+        r = typejoin(r, rewrap_unionall(unwrapva(ti), t))
     end
-    return rewrap_unionall(r, t)
+    return r
 end
 
 # version of tail that doesn't throw on empty tuples (used in array indexing)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -72,6 +72,7 @@ end
     typejoin(Int, AbstractFloat, Bool)
 @test eltype(Tuple{Int, Bool, Vararg{T}} where T <: AbstractFloat) ===
     typejoin(Int, AbstractFloat, Bool)
+@test eltype(Union{Tuple{Int, Float64}, Tuple{Vararg{Bool}}}) === typejoin(Int, Float64, Bool)
 
 begin
     local foo

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -65,8 +65,13 @@ end
 @test eltype((1,2,3)) === Int
 @test eltype((1.0,2.0,3.0)) <: AbstractFloat
 @test eltype((true, false)) === Bool
-@test eltype((1,2.0, false)) === Any
+@test eltype((1, 2.0, false)) === typejoin(Int, Float64, Bool)
 @test eltype(()) === Union{}
+@test eltype(Tuple{Int, Float64, Vararg{Bool}}) === typejoin(Int, Float64, Bool)
+@test eltype(Tuple{Int, T, Vararg{Bool}} where T <: AbstractFloat) ===
+    typejoin(Int, AbstractFloat, Bool)
+@test eltype(Tuple{Int, Bool, Vararg{T}} where T <: AbstractFloat) ===
+    typejoin(Int, AbstractFloat, Bool)
 
 begin
     local foo


### PR DESCRIPTION
Came up here: https://github.com/JuliaLang/julia/issues/21077#issuecomment-287572830

```julia
# master
julia> collect((1,1.0))
2-element Array{Any,1}:
 1  
 1.0
```
```julia
# this PR
julia> collect((1,1.0))
2-element Array{Real,1}:
 1  
 1.0
```

Not sure this is actually helpful anywhere, but it probably won't hurt either...

Edit: Closes #20143.