### PR TITLE
Specify correct type for Workqueue

### DIFF
--- a/base/event.jl
+++ b/base/event.jl
@@ -76,7 +76,7 @@ end
 
 ## scheduler and work queue
 
-global const Workqueue = Any[]
+global const Workqueue = Task[]
 
 function enq_work(t::Task)
     t.state == :runnable || error("schedule: Task not runnable")


### PR DESCRIPTION
This one line change improved timing of the below code from 0.75 to 0.3 seconds.

```
function foo(c, n)
    for i in 1:10^n
        put!(c, i)
    end
end

function bar(c, n)
    for i in 1:10^n
        take!(c)
    end
end

function baz(n)
    c = Channel{Int}(0)
    @schedule foo(c, n)
    @time bar(c, n)
end

baz(1)
baz(5)
```

I couldn't find any code in Base that would insert a non-Task object into `Workqueue`. Please confirm @vtjnash / @JeffBezanson  