### PR TITLE
RFC: Lower x^(n//d) as Base.literal_pow(^, x, Val{n}, Val{d});... 

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -424,6 +424,8 @@ function ^(z::Complex{<:Rational}, n::Integer)
     n >= 0 ? power_by_squaring(z,n) : power_by_squaring(inv(z),-n)
 end
 
+@inline literal_pow{n,d}(f, x, ::Type{Val{n}}, ::Type{Val{d}}) = f(x, n//d)
+
 iszero(x::Rational) = iszero(numerator(x))
 
 function lerpi(j::Integer, d::Integer, a::Rational, b::Rational)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1697,6 +1697,9 @@
       (if (eq? arg (car args))
           (car fargs)
           (findfarg arg (cdr args) (cdr fargs))))
+    (define (literal-rational? g)
+      (and (length= g 4) (eq? (car g) 'call) (eq? (cadr g) '//)
+        (integer? (caddr g)) (integer? (cadddr g))))
     (if (fuse? e)
         (let ((f (cadr e))
               (args (caddr e)))
@@ -1717,7 +1720,7 @@
                                 new-fargs new-args (cons (cons (cadr farg) (cadr varfarg)) renames)
                                 varfarg vararg)
                             (error "multiple splatted args cannot be fused into a single broadcast"))))
-                   ((julia-scalar? arg) ; inline numeric literals etc.
+                   ((or (julia-scalar? arg) (literal-rational? arg)) ; inline numeric literals etc.
                     (cf (cdr old-fargs) (cdr old-args)
                         new-fargs new-args
                         (cons (cons farg arg) renames)
@@ -2055,9 +2058,19 @@
                     (expand-forms
                      `(call (core _apply) ,f ,@(tuple-wrap argl '())))))
 
-                 ((and (eq? f '^) (length= e 4) (integer? (cadddr e)))
-                  (expand-forms
-                   `(call (top literal_pow) ^ ,(caddr e) (call (core apply_type) (top Val) ,(cadddr e)))))
+                 ((and (eq? f '^) (length= e 4))
+                     (let ((g (cadddr e)))
+                        (cond ((integer? g)
+                               (expand-forms
+                                `(call (top literal_pow) ^ ,(caddr e)
+                                  (call (core apply_type) (top Val) ,(cadddr e)))))
+                              ((and (length= g 4) (eq? (car g) 'call) (eq? (cadr g) '//)
+                                (integer? (caddr g)) (integer? (cadddr g)))
+                               (expand-forms
+                                `(call (top literal_pow) ^ ,(caddr e)
+                                  (call (core apply_type) (top Val) ,(caddr g))
+                                  (call (core apply_type) (top Val) ,(cadddr g)))))
+                              (else (map expand-forms e)))))
 
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2906,15 +2906,21 @@ import Base.^
 struct PR20530; end
 struct PR20889; x; end
 ^(::PR20530, p::Int) = 1
+^(::PR20530, p::Rational) = 3
 ^(t::PR20889, b) = t.x + b
 ^(t::PR20889, b::Integer) = t.x + b
 Base.literal_pow{p}(::typeof(^), ::PR20530, ::Type{Val{p}}) = 2
+Base.literal_pow{n,d}(::typeof(^), ::PR20530, ::Type{Val{n}}, ::Type{Val{d}}) = 4
 @testset "literal powers" begin
     x = PR20530()
     p = 2
+    r = 2//1
     @test x^p == 1
     @test x^2 == 2
+    @test x^r == 3
+    @test x^(2//1) == 4
     @test [x,x,x].^2 == [2,2,2]
+    @test [x,x,x].^(2//1) == [4,4,4]
     for T in (Float16, Float32, Float64, BigFloat, Int8, Int, BigInt, Complex{Int}, Complex{Float64})
         for p in -4:4
             if p < 0 && real(T) <: Integer
@@ -2927,11 +2933,13 @@ Base.literal_pow{p}(::typeof(^), ::PR20530, ::Type{Val{p}}) = 2
         end
     end
     @test PR20889(2)^3 == 5
+    @test PR20889(2)^(3//1) == 5
 end
 module M20889 # do we get the expected behavior without importing Base.^?
     struct PR20889; x; end
     ^(t::PR20889, b) = t.x + b
     Base.Test.@test PR20889(2)^3 == 5
+    Base.Test.@test PR20889(2)^(3//1) == 5
 end
 
 @testset "iszero" begin


### PR DESCRIPTION
make fused broadcast inline Rationals.

This PR explores what it would be like to lower `x^(n//d)` for integer literals `n` and `d` to `Base.literal_pow(^, x, Val{n}, Val{d})`. The motivation here is to widen the circumstances when we can have type-stable exponentiation of dimensionful numbers. At least in Unitful, I only allow exponentiation by integers or rationals, so this PR completes that sort of functionality. (@StefanKarpinski , I understand if you have reservations about changing parser behavior further, but I already figured out how to do this so I figured I'd submit the PR anyway. If we ever wanted this change, it would have to be done at the parser level, just like with literal integers.)

In order for this to work when doing fused broadcast, I had to change [`compress-fuse`](https://github.com/ajkeller34/julia/blob/d7717ab0ee6b8ca376272ee5160e3cbe081b7c8f/src/julia-syntax.scm#L1723) to inline `Rational`s. Certainly an improvement on how I did this would be to have [`julia-scalar?`](https://github.com/JuliaLang/julia/blob/9701453df5625fad62cc603db8c6ac084855607c/src/ast.c#L234) return true for Rationals, since I guess it should ideally return true for anything that behaves like a scalar for broadcasting. I wasn’t sure how to go about doing that.

This PR doesn’t implement new optimizations using `literal_pow`, so no new surprising behaviors are introduced. Since we lower to `Val{n}` and `Val{d}` separately, rather than `Val{n//d}`, I would guess the number of Val types in use shouldn’t blow up too much. The question then is really whether the added machinery of this PR is worth the only modest benefit.

edits for formatting