### PR TITLE
Improve performance of skipchars for small inputs

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -327,7 +327,7 @@ function skipchars(io::IOStream, pred; linecomment=nothing)
         if c === linecomment
             readline(io)
         elseif !pred(c)
-            seek(io,position(io)-sizeof(string(c)))
+            skip(io, -codelen(c))
             break
         end
     end

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -4,15 +4,15 @@
 mktemp() do path, file
     function append_to_file(str)
         mark(file)
-        println(file, str)
+        print(file, str)
         flush(file)
         reset(file)
     end
 
     # test it doesn't error on eof
-    @test skipchars(file, isspace) == file
+    @test eof(skipchars(file, isspace))
 
-    # test if it correctly skips
+    # test it correctly skips
     append_to_file("    ")
     @test eof(skipchars(file, isspace))
 
@@ -22,12 +22,20 @@ mktemp() do path, file
 
     # test it stops at the appropriate time
     append_to_file("   not a space")
-    @test skipchars(file, isspace) == file
-    @test !eof(file) && read(file, Char) == 'n'
+    @test !eof(skipchars(file, isspace))
+    @test read(file, Char) == 'n'
 
     # test it correctly ignores the contents of comment lines
     append_to_file("  #not a space \n   not a space")
-    @test skipchars(file, isspace, linecomment='#') == file
-    @test !eof(file) && read(file, Char) == 'n'
+    @test !eof(skipchars(file, isspace, linecomment='#'))
+    @test read(file, Char) == 'n'
+
+    # test it correctly handles unicode
+    for (byte,char) in zip(1:4, ('@','߷','࿊','𐋺'))
+        append_to_file("abcdef$char")
+        @test Base.codelen(char) == byte
+        @test !eof(skipchars(file, isalpha))
+        @test read(file, Char) == char
+    end
 end
 


### PR DESCRIPTION
This mostly solves the problem, now the function is only significantly (2x) slower when there are no characters to skip, otherwise it's mostly the same for 1 or 2 characters and faster for 3 or more.

Also improves the tests a little.

---
No longer a large performance regression, only a few inches long.

Hopefully this is a fairly straight forward improvement and will be merged soon. Thank you @nalimilan and @JeffBezanson for pretty much giving me the solution on a plate.