### PR TITLE
Improve task switching performance on unbuffered channels

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -206,7 +206,7 @@ function setup_chnl_and_tasks(exec_func, ntasks, batch_size=nothing)
     chnl = Channel(0)
     worker_tasks = []
     foreach(_ -> start_worker_task!(worker_tasks, exec_func, chnl, batch_size), 1:nt)
-
+    yield()
     return (chnl, worker_tasks)
 end
 


### PR DESCRIPTION
This improves 10^5 task switches between two tasks (one doing a `put!` and the other a `take!` on an unbuffered channel) from 0.3 to 0.16 seconds.

It is getting closer to matching the performance of `produce-consume` which does the same in 0.08 seconds.

Benchmark code here - https://gist.github.com/amitmurthy/9fa364c5e2cc07381bdc83d6f854de97 