### PR TITLE
fix #21118, subtyping issue

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -112,6 +112,10 @@ function test_diagonal()
 
     @test issub_strict(Tuple{Int, Int},
                        (@UnionAll T Tuple{Union{T,String}, T}))
+
+    # don't consider a diagonal variable concrete if it already has an abstract lower bound
+    @test isequal_type(Tuple{Vararg{A}} where A>:Integer,
+                       Tuple{Vararg{A}} where A>:Integer)
 end
 
 # level 3: UnionAll
@@ -867,6 +871,14 @@ function test_intersection()
     I, E = intersection_env(Tuple{Ref{Integer},Int,Any}, Tuple{Ref{Z},Z,Z} where Z)
     @test isequal_type(I, Tuple{Ref{Integer},Int,Integer})
     @test E[1] == Integer
+
+    # issue #21118
+    A = Tuple{Ref, Vararg{Any}}
+    B = Tuple{Vararg{Union{Z,Ref,Void}}} where Z<:Union{Ref,Void}
+    @test B <: _type_intersect(A, B)
+    @testintersect(Tuple{Int,Any,Vararg{A}} where A>:Integer,
+                   Tuple{Any,Int,Vararg{A}} where A>:Integer,
+                   Tuple{Int,Int,Vararg{A}} where A>:Integer)
 end
 
 function test_intersection_properties()


### PR DESCRIPTION
In `Tuple{Vararg{T}} where T`, `T` is diagonal. In the case in this issue, type intersection was giving such a variable an abstract lower bound. That was wrong, but it also created a type that could not be subtyped properly since the given bound on the variable contradicted the requirement that it be concrete. So for now at least, given e.g. `Tuple{T,T} where T>:Real`, simply drop the diagonal-concrete rule.

The un-subtypeable-type could not be looked up in a typemap, causing inference to regenerate it repeatedly, leading to the hang in the issue.