### PR TITLE
OSX: Add both RPATH entries to `julia`, don't overwrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ ifneq ($(private_libdir_rel),$(build_private_libdir_rel))
 ifeq ($(OS), Darwin)
 	for julia in $(DESTDIR)$(bindir)/julia* ; do \
 		install_name_tool -rpath @executable_path/$(build_private_libdir_rel) @executable_path/$(private_libdir_rel) $$julia; \
-		install_name_tool -rpath @executable_path/$(build_libdir_rel) @executable_path/$(libdir_rel) $$julia; \
+		install_name_tool -add_rpath @executable_path/$(build_libdir_rel) @executable_path/$(libdir_rel) $$julia; \
 	done
 else ifeq ($(OS), Linux)
 	for julia in $(DESTDIR)$(bindir)/julia* ; do \


### PR DESCRIPTION
Essentially, we were overwriting our first `RPATH` entry with our second, instead of adding them together.  This didn't actually break anything, but was a little bit of a surprise for me when I was trying to debug something.