### PR TITLE
refactor gc to only need to allocate virtual addresses as needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Julia does not install anything outside the directory it was cloned into. Julia 
 
 Julia can be built for a non-generic architecture by configuring the `ARCH` Makefile variable. See the appropriate section of `Make.inc` for additional customization options, such as `MARCH` and `JULIA_CPU_TARGET`.
 
-For example, to build for Pentium 4, set `MARCH=pentium4` and install the necessary system libraries for linking. On Ubuntu, these may include lib32gfortran3 (also manually call `ln -s /usr/lib32/libgfortran3.so.0 /usr/lib32/libgfortran3.so`) and lib32gcc1, lib32stdc++6, among others.
+For example, to build for Pentium 4, set `MARCH=pentium4` and install the necessary system libraries for linking. On Ubuntu, these may include lib32gfortran-6-dev, lib32gcc1, and lib32stdc++6, among others.
 
 You can also set `MARCH=native` for a maximum-performance build customized for the current machine CPU.
 

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -9,190 +9,281 @@
 extern "C" {
 #endif
 
-// A region is contiguous storage for up to DEFAULT_REGION_PG_COUNT naturally aligned GC_PAGE_SZ pages
-// It uses a very naive allocator (see jl_gc_alloc_page & jl_gc_free_page)
-#if defined(_P64)
-#define DEFAULT_REGION_PG_COUNT (16 * 8 * 4096) // 8 GB
+// Try to allocate memory in chunks to permit faster allocation
+// and improve memory locality of the pools
+#ifdef _P64
+#define DEFAULT_BLOCK_PG_ALLOC (4096) // 64 MB
 #else
-#define DEFAULT_REGION_PG_COUNT (8 * 4096) // 512 MB
+#define DEFAULT_BLOCK_PG_ALLOC (1024) // 16 MB
 #endif
-#define MIN_REGION_PG_COUNT 64 // 1 MB
+#define MIN_BLOCK_PG_ALLOC (1) // 16 KB
 
-static int region_pg_cnt = DEFAULT_REGION_PG_COUNT;
+static int block_pg_cnt = DEFAULT_BLOCK_PG_ALLOC;
 static jl_mutex_t pagealloc_lock;
 static size_t current_pg_count = 0;
 
 void jl_gc_init_page(void)
 {
-#ifndef _OS_WINDOWS_
-    struct rlimit rl;
-    if (getrlimit(RLIMIT_AS, &rl) == 0) {
-        // This is not 100% precise and not the most efficient implementation
-        // but should be close enough and fast enough for the normal case.
-        while (rl.rlim_cur < region_pg_cnt * sizeof(jl_gc_page_t) * 2 &&
-               region_pg_cnt >= MIN_REGION_PG_COUNT) {
-            region_pg_cnt /= 2;
-        }
-    }
-#endif
+    if (GC_PAGE_SZ * block_pg_cnt < jl_page_size)
+        block_pg_cnt = jl_page_size / GC_PAGE_SZ; // exact division
 }
 
 #ifndef MAP_NORESERVE // not defined in POSIX, FreeBSD, etc.
 #define MAP_NORESERVE (0)
 #endif
 
-// Try to allocate a memory block for a region with `pg_cnt` pages.
+// Try to allocate a memory block for multiple pages
 // Return `NULL` if allocation failed. Result is aligned to `GC_PAGE_SZ`.
-static char *jl_gc_try_alloc_region(int pg_cnt)
+static char *jl_gc_try_alloc_pages(int pg_cnt)
 {
-    const size_t pages_sz = sizeof(jl_gc_page_t) * pg_cnt;
-    const size_t freemap_sz = sizeof(uint32_t) * pg_cnt / 32;
-    const size_t meta_sz = sizeof(jl_gc_pagemeta_t) * pg_cnt;
-    size_t alloc_size = pages_sz + freemap_sz + meta_sz;
+    size_t pages_sz = GC_PAGE_SZ * pg_cnt;
 #ifdef _OS_WINDOWS_
-    char *mem = (char*)VirtualAlloc(NULL, alloc_size + GC_PAGE_SZ,
+    char *mem = (char*)VirtualAlloc(NULL, pages_sz + GC_PAGE_SZ,
                                     MEM_RESERVE, PAGE_READWRITE);
     if (mem == NULL)
         return NULL;
 #else
     if (GC_PAGE_SZ > jl_page_size)
-        alloc_size += GC_PAGE_SZ;
-    char *mem = (char*)mmap(0, alloc_size, PROT_READ | PROT_WRITE,
+        pages_sz += GC_PAGE_SZ;
+    char *mem = (char*)mmap(0, pages_sz, PROT_READ | PROT_WRITE,
                             MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (mem == MAP_FAILED)
         return NULL;
 #endif
-    if (GC_PAGE_SZ > jl_page_size) {
+    if (GC_PAGE_SZ > jl_page_size)
         // round data pointer up to the nearest gc_page_data-aligned
         // boundary if mmap didn't already do so.
         mem = (char*)gc_page_data(mem + GC_PAGE_SZ - 1);
-    }
     return mem;
 }
 
-// Allocate the memory for a `region_t`. Starts with `region_pg_cnt` number
+// Allocate the memory for a new page. Starts with `block_pg_cnt` number
 // of pages. Decrease 4x every time so that there are enough space for a few.
-// more regions (or other allocations). The final page count is recorded
+// more chunks (or other allocations). The final page count is recorded
 // and will be used as the starting count next time. If the page count is
-// smaller `MIN_REGION_PG_COUNT` a `jl_memory_exception` is thrown.
-// Assume `pagealloc_lock` is acquired, the lock is released before the
+// smaller `MIN_BLOCK_PG_ALLOC` a `jl_memory_exception` is thrown.
+// Assumes `pagealloc_lock` is acquired, the lock is released before the
 // exception is thrown.
-static void jl_gc_alloc_region(region_t *region)
+static jl_gc_pagemeta_t *jl_gc_alloc_new_page(void)
 {
-    int pg_cnt = region_pg_cnt;
+    // try to allocate a large block of memory (or a small one)
+    unsigned pg, pg_cnt = block_pg_cnt;
     char *mem = NULL;
     while (1) {
-        if (__likely((mem = jl_gc_try_alloc_region(pg_cnt))))
+        if (__likely((mem = jl_gc_try_alloc_pages(pg_cnt))))
             break;
-        if (pg_cnt >= MIN_REGION_PG_COUNT * 4) {
+        size_t min_block_pg_alloc = MIN_BLOCK_PG_ALLOC;
+        if (GC_PAGE_SZ * min_block_pg_alloc < jl_page_size)
+            min_block_pg_alloc = jl_page_size / GC_PAGE_SZ; // exact division
+        if (pg_cnt >= 4 * min_block_pg_alloc) {
             pg_cnt /= 4;
-            region_pg_cnt = pg_cnt;
+            block_pg_cnt = pg_cnt;
         }
-        else if (pg_cnt > MIN_REGION_PG_COUNT) {
-            region_pg_cnt = pg_cnt = MIN_REGION_PG_COUNT;
+        else if (pg_cnt > min_block_pg_alloc) {
+            block_pg_cnt = pg_cnt = min_block_pg_alloc;
         }
         else {
             JL_UNLOCK_NOGC(&pagealloc_lock);
             jl_throw(jl_memory_exception);
         }
     }
-    const size_t pages_sz = sizeof(jl_gc_page_t) * pg_cnt;
-    const size_t allocmap_sz = sizeof(uint32_t) * pg_cnt / 32;
-    region->pages = (jl_gc_page_t*)mem;
-    region->allocmap = (uint32_t*)(mem + pages_sz);
-    region->meta = (jl_gc_pagemeta_t*)(mem + pages_sz +allocmap_sz);
-    region->lb = 0;
-    region->ub = 0;
-    region->pg_cnt = pg_cnt;
-#ifdef _OS_WINDOWS_
-    VirtualAlloc(region->allocmap, pg_cnt / 8, MEM_COMMIT, PAGE_READWRITE);
-    VirtualAlloc(region->meta, pg_cnt * sizeof(jl_gc_pagemeta_t),
-                 MEM_COMMIT, PAGE_READWRITE);
+
+    // now need to insert these pages into the pagetable metadata
+    // if any allocation fails, this just stops recording more pages from that point
+    // and will free (munmap) the remainder
+    jl_gc_pagemeta_t *page_meta = (jl_gc_pagemeta_t*)calloc(pg_cnt, sizeof(jl_gc_pagemeta_t));
+    pg = 0;
+    if (page_meta) {
+        for (; pg < pg_cnt; pg++) {
+            struct jl_gc_metadata_ext info;
+            uint32_t msk;
+            unsigned i;
+            pagetable1_t **ppagetable1;
+            pagetable0_t **ppagetable0;
+            jl_gc_pagemeta_t **pmeta;
+
+            char *ptr = mem + (GC_PAGE_SZ * pg);
+            page_meta[pg].data = ptr;
+
+            // create & store the level 2 / outermost info
+            i = REGION_INDEX(ptr);
+            info.pagetable_i = i % 32;
+            info.pagetable_i32 = i / 32;
+            msk = (1 << info.pagetable_i);
+            if ((memory_map.freemap1[info.pagetable_i32] & msk) == 0)
+                memory_map.freemap1[info.pagetable_i32] |= msk; // has free
+            info.pagetable1 = *(ppagetable1 = &memory_map.meta1[i]);
+            if (!info.pagetable1) {
+                info.pagetable1 = (*ppagetable1 = (pagetable1_t*)calloc(1, sizeof(pagetable1_t)));
+                if (!info.pagetable1)
+                    break;
+            }
+
+            // create & store the level 1 info
+            i = REGION1_INDEX(ptr);
+            info.pagetable1_i = i % 32;
+            info.pagetable1_i32 = i / 32;
+            msk = (1 << info.pagetable1_i);
+            if ((info.pagetable1->freemap0[info.pagetable1_i32] & msk) == 0)
+                info.pagetable1->freemap0[info.pagetable1_i32] |= msk; // has free
+            info.pagetable0 = *(ppagetable0 = &info.pagetable1->meta0[i]);
+            if (!info.pagetable0) {
+                info.pagetable0 = (*ppagetable0 = (pagetable0_t*)calloc(1, sizeof(pagetable0_t)));
+                if (!info.pagetable0)
+                    break;
+            }
+
+            // create & store the level 0 / page info
+            i = REGION0_INDEX(ptr);
+            info.pagetable0_i = i % 32;
+            info.pagetable0_i32 = i / 32;
+            msk = (1 << info.pagetable0_i);
+            info.pagetable0->freemap[info.pagetable0_i32] |= msk; // is free
+            pmeta = &info.pagetable0->meta[i];
+            info.meta = (*pmeta = &page_meta[pg]);
+        }
+    }
+
+    if (pg < pg_cnt) {
+#ifndef _OS_WINDOWS_
+        // Trim the allocation to only cover the region
+        // that we successfully created the metadata for.
+        // This is not supported by the Windows kernel,
+        // so we have to just skip it there and just lose these virtual addresses.
+        munmap(mem + LLT_ALIGN(GC_PAGE_SZ * pg, jl_page_size),
+               GC_PAGE_SZ * pg_cnt - LLT_ALIGN(GC_PAGE_SZ * pg, jl_page_size));
 #endif
+        if (pg == 0) {
+            JL_UNLOCK_NOGC(&pagealloc_lock);
+            jl_throw(jl_memory_exception);
+        }
+    }
+    return page_meta;
 }
 
-NOINLINE void *jl_gc_alloc_page(void)
+// get a new page, either from the freemap
+// or from the kernel if none are available
+NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void)
 {
-    int i;
-    region_t *region;
-    int region_i = 0;
+    struct jl_gc_metadata_ext info;
     JL_LOCK_NOGC(&pagealloc_lock);
-    while (region_i < REGION_COUNT) {
-        region = &regions[region_i];
-        if (region->pages == NULL)
-            jl_gc_alloc_region(region);
-        for (i = region->lb; i < region->pg_cnt / 32; i++) {
-            if (~region->allocmap[i])
-                break;
-        }
-        if (i == region->pg_cnt / 32) {
-            // region full
-            region_i++;
-            continue;
-        }
-        break;
-    }
-    if (__unlikely(region_i >= REGION_COUNT)) {
-        JL_UNLOCK_NOGC(&pagealloc_lock);
-        jl_throw(jl_memory_exception);
-    }
-    if (region->lb < i)
-        region->lb = i;
-    if (region->ub < i)
-        region->ub = i;
 
-#if defined(_COMPILER_MINGW_)
-    int j = __builtin_ffs(~region->allocmap[i]) - 1;
-#elif defined(_COMPILER_MICROSOFT_)
-    unsigned long j;
-    _BitScanForward(&j, ~region->allocmap[i]);
-#else
-    int j = ffs(~region->allocmap[i]) - 1;
-#endif
+    // scan over memory_map page-table for existing allocated but unused pages
+    for (info.pagetable_i32 = memory_map.lb; info.pagetable_i32 < (REGION2_PG_COUNT + 31) / 32; info.pagetable_i32++) {
+        uint32_t freemap1 = memory_map.freemap1[info.pagetable_i32];
+        for (info.pagetable_i = 0; freemap1; info.pagetable_i++, freemap1 >>= 1) {
+            unsigned next = ffs_u32(freemap1);
+            info.pagetable_i += next;
+            freemap1 >>= next;
+            info.pagetable1 = memory_map.meta1[info.pagetable_i + info.pagetable_i32 * 32];
+            // repeat over page-table level 1
+            for (info.pagetable1_i32 = info.pagetable1->lb; info.pagetable1_i32 < REGION1_PG_COUNT / 32; info.pagetable1_i32++) {
+                uint32_t freemap0 = info.pagetable1->freemap0[info.pagetable1_i32];
+                for (info.pagetable1_i = 0; freemap0; info.pagetable1_i++, freemap0 >>= 1) {
+                    unsigned next = ffs_u32(freemap0);
+                    info.pagetable1_i += next;
+                    freemap0 >>= next;
+                    info.pagetable0 = info.pagetable1->meta0[info.pagetable1_i + info.pagetable1_i32 * 32];
+                    // repeat over page-table level 0
+                    for (info.pagetable0_i32 = info.pagetable0->lb; info.pagetable0_i32 < REGION0_PG_COUNT / 32; info.pagetable0_i32++) {
+                        uint32_t freemap = info.pagetable0->freemap[info.pagetable0_i32];
+                        if (freemap) {
+                            info.pagetable0_i = ffs_u32(freemap);
+                            info.meta = info.pagetable0->meta[info.pagetable0_i + info.pagetable0_i32 * 32];
+                            assert(info.meta->data);
+                            // new pages available starting at min of lb and pagetable_i32
+                            if (memory_map.lb < info.pagetable_i32)
+                                memory_map.lb = info.pagetable_i32;
+                            if (info.pagetable1->lb < info.pagetable1_i32)
+                                info.pagetable1->lb = info.pagetable1_i32;
+                            if (info.pagetable0->lb < info.pagetable0_i32)
+                                info.pagetable0->lb = info.pagetable0_i32;
+                            goto have_free_page; // break out of all of these loops
+                        }
+                    }
+                    info.pagetable1->freemap0[info.pagetable1_i32] &= ~(uint32_t)(1 << info.pagetable1_i); // record that this was full
+                }
+            }
+            memory_map.freemap1[info.pagetable_i32] &= ~(uint32_t)(1 << info.pagetable_i); // record that this was full
+        }
+    }
 
-    region->allocmap[i] |= (uint32_t)(1 << j);
-    void *ptr = region->pages[i * 32 + j].data;
+    // no existing pages found, allocate a new one
+    {
+        jl_gc_pagemeta_t *meta = jl_gc_alloc_new_page();
+        info = page_metadata_ext(meta->data);
+        assert(meta == info.meta);
+        // new pages are now available starting at max of lb and pagetable_i32
+        if (memory_map.lb > info.pagetable_i32)
+            memory_map.lb = info.pagetable_i32;
+        if (info.pagetable1->lb > info.pagetable1_i32)
+            info.pagetable1->lb = info.pagetable1_i32;
+        if (info.pagetable0->lb > info.pagetable0_i32)
+            info.pagetable0->lb = info.pagetable0_i32;
+    }
+
+have_free_page:
+    // in-use pages are now ending at min of ub and pagetable_i32
+    if (memory_map.ub < info.pagetable_i32)
+        memory_map.ub = info.pagetable_i32;
+    if (info.pagetable1->ub < info.pagetable1_i32)
+        info.pagetable1->ub = info.pagetable1_i32;
+    if (info.pagetable0->ub < info.pagetable0_i32)
+        info.pagetable0->ub = info.pagetable0_i32;
+
+    // mark this entry as in-use and not free
+    info.pagetable0->freemap[info.pagetable0_i32] &= ~(uint32_t)(1 << info.pagetable0_i);
+    info.pagetable0->allocmap[info.pagetable0_i32] |= (uint32_t)(1 << info.pagetable0_i);
+    info.pagetable1->allocmap0[info.pagetable1_i32] |= (uint32_t)(1 << info.pagetable1_i);
+    memory_map.allocmap1[info.pagetable_i32] |= (uint32_t)(1 << info.pagetable_i);
+
 #ifdef _OS_WINDOWS_
-    VirtualAlloc(ptr, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
+    VirtualAlloc(info.meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
 #endif
     current_pg_count++;
     gc_final_count_page(current_pg_count);
     JL_UNLOCK_NOGC(&pagealloc_lock);
-    return ptr;
+    return info.meta;
 }
 
+// return a page to the freemap allocator
 void jl_gc_free_page(void *p)
 {
-    int pg_idx = -1;
-    int i;
-    region_t *region = regions;
-    for (i = 0; i < REGION_COUNT && regions[i].pages != NULL; i++) {
-        region = &regions[i];
-        pg_idx = page_index(region, p);
-        if (pg_idx >= 0 && pg_idx < region->pg_cnt) {
-            break;
-        }
-    }
-    assert(i < REGION_COUNT && region->pages != NULL);
-    uint32_t msk = (uint32_t)(1 << (pg_idx % 32));
-    assert(region->allocmap[pg_idx/32] & msk);
-    region->allocmap[pg_idx/32] ^= msk;
-    free(region->meta[pg_idx].ages);
+    // update the allocmap and freemap to indicate this contains a free entry
+    struct jl_gc_metadata_ext info = page_metadata_ext(p);
+    uint32_t msk;
+    msk = (uint32_t)(1 << info.pagetable0_i);
+    assert(!(info.pagetable0->freemap[info.pagetable0_i32] & msk));
+    assert(info.pagetable0->allocmap[info.pagetable0_i32] & msk);
+    info.pagetable0->allocmap[info.pagetable0_i32] &= ~msk;
+    info.pagetable0->freemap[info.pagetable0_i32] |= msk;
+
+    msk = (uint32_t)(1 << info.pagetable1_i);
+    assert(info.pagetable1->allocmap0[info.pagetable1_i32] & msk);
+    if ((info.pagetable1->freemap0[info.pagetable1_i32] & msk) == 0)
+        info.pagetable1->freemap0[info.pagetable1_i32] |= msk;
+
+    msk = (uint32_t)(1 << info.pagetable_i);
+    assert(memory_map.allocmap1[info.pagetable_i32] & msk);
+    if ((memory_map.freemap1[info.pagetable_i32] & msk) == 0)
+        memory_map.freemap1[info.pagetable_i32] |= msk;
+
+    free(info.meta->ages);
+    info.meta->ages = NULL;
+
     // tell the OS we don't need these pages right now
     size_t decommit_size = GC_PAGE_SZ;
     if (GC_PAGE_SZ < jl_page_size) {
         // ensure so we don't release more memory than intended
-        size_t n_pages = (GC_PAGE_SZ + jl_page_size - 1) / GC_PAGE_SZ;
+        size_t n_pages = jl_page_size / GC_PAGE_SZ; // exact division
         decommit_size = jl_page_size;
-        p = (void*)((uintptr_t)region->pages[pg_idx].data & ~(jl_page_size - 1)); // round down to the nearest page
-        pg_idx = page_index(region, p);
-        if (pg_idx + n_pages > region->pg_cnt)
-            goto no_decommit;
-        for (; n_pages--; pg_idx++) {
-            msk = (uint32_t)(1 << ((pg_idx % 32)));
-            if (region->allocmap[pg_idx / 32] & msk) {
+        p = (void*)((uintptr_t)p & ~(jl_page_size - 1)); // round down to the nearest physical page
+        while (n_pages--) {
+            struct jl_gc_metadata_ext info = page_metadata_ext(p);
+            msk = (uint32_t)(1 << info.pagetable0_i);
+            if (info.pagetable0->allocmap[info.pagetable0_i32] & msk)
                 goto no_decommit;
-            }
+            p = (void*)((char*)p + GC_PAGE_SZ);
         }
     }
 #ifdef _OS_WINDOWS_
@@ -200,9 +291,15 @@ void jl_gc_free_page(void *p)
 #else
     madvise(p, decommit_size, MADV_DONTNEED);
 #endif
+
 no_decommit:
-    if (region->lb > pg_idx / 32)
-        region->lb = pg_idx / 32;
+    // new pages are now available starting at max of lb and pagetable_i32
+    if (memory_map.lb > info.pagetable_i32)
+        memory_map.lb = info.pagetable_i32;
+    if (info.pagetable1->lb > info.pagetable1_i32)
+        info.pagetable1->lb = info.pagetable1_i32;
+    if (info.pagetable0->lb > info.pagetable0_i32)
+        info.pagetable0->lb = info.pagetable0_i32;
     current_pg_count--;
 }
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -34,10 +34,6 @@ extern "C" {
 #define GC_PAGE_SZ (1 << GC_PAGE_LG2) // 16k
 #define GC_PAGE_OFFSET (JL_SMALL_BYTE_ALIGNMENT - (sizeof(jl_taggedvalue_t) % JL_SMALL_BYTE_ALIGNMENT))
 
-// 8G * 32768 = 2^48
-// It's really unlikely that we'll actually allocate that much though...
-#define REGION_COUNT 32768
-
 #define jl_malloc_tag ((void*)0xdeadaa01)
 #define jl_singleton_tag ((void*)0xdeadaa02)
 
@@ -147,33 +143,90 @@ typedef struct {
     uint8_t *ages;
 } jl_gc_pagemeta_t;
 
-typedef struct {
-    char data[GC_PAGE_SZ];
-} jl_gc_page_t
-#if !defined(_COMPILER_MICROSOFT_) && !(defined(_COMPILER_MINGW_) && defined(_COMPILER_CLANG_))
-__attribute__((aligned(GC_PAGE_SZ)))
-#endif
-;
+// Page layout:
+//  Newpage freelist: sizeof(void*)
+//  Padding: GC_PAGE_OFFSET - sizeof(void*)
+//  Blocks: osize * n
+//    Tag: sizeof(jl_taggedvalue_t)
+//    Data: <= osize - sizeof(jl_taggedvalue_t)
 
+// Memory map:
+//  The complete address space is divided up into a multi-level page table.
+//  The three levels have similar but slightly different structures:
+//    - pagetable0_t: the bottom/leaf level (covers the contiguous addresses)
+//    - pagetable1_t: the middle level
+//    - pagetable2_t: the top/leaf level (covers the entire virtual address space)
+//  Corresponding to these similar structures is a large amount of repetitive
+//  code that is nearly the same but not identical. It could be made less
+//  repetitive with C macros, but only at the cost of debuggability. The specialized
+//  structure of this representation allows us to partially unroll and optimize
+//  various conditions at each level.
+
+//  The following constants define the branching factors at each level.
+//  The constants and GC_PAGE_LG2 must therefore sum to sizeof(void*).
+//  They should all be multiples of 32 (sizeof(uint32_t)) except that REGION2_PG_COUNT may also be 1.
+#ifdef _P64
+#define REGION0_PG_COUNT (1 << 16)
+#define REGION1_PG_COUNT (1 << 16)
+#define REGION2_PG_COUNT (1 << 18)
+#define REGION0_INDEX(p) (((uintptr_t)(p) >> 14) & 0xFFFF) // shift by GC_PAGE_LG2
+#define REGION1_INDEX(p) (((uintptr_t)(p) >> 30) & 0xFFFF)
+#define REGION_INDEX(p)  (((uintptr_t)(p) >> 46) & 0x3FFFF)
+#else
+#define REGION0_PG_COUNT (1 << 8)
+#define REGION1_PG_COUNT (1 << 10)
+#define REGION2_PG_COUNT (1 << 0)
+#define REGION0_INDEX(p) (((uintptr_t)(p) >> 14) & 0xFF) // shift by GC_PAGE_LG2
+#define REGION1_INDEX(p) (((uintptr_t)(p) >> 22) & 0x3FF)
+#define REGION_INDEX(p)  (0)
+#endif
+
+// define the representation of the levels of the page-table (0 to 2)
 typedef struct {
-    // Page layout:
-    //  Newpage freelist: sizeof(void*)
-    //  Padding: GC_PAGE_OFFSET - sizeof(void*)
-    //  Blocks: osize * n
-    //    Tag: sizeof(jl_taggedvalue_t)
-    //    Data: <= osize - sizeof(jl_taggedvalue_t)
-    jl_gc_page_t *pages; // [pg_cnt]; must be first, to preserve page alignment
-    uint32_t *allocmap; // [pg_cnt / 32]
-    jl_gc_pagemeta_t *meta; // [pg_cnt]
-    int pg_cnt;
+    jl_gc_pagemeta_t *meta[REGION0_PG_COUNT];
+    uint32_t allocmap[REGION0_PG_COUNT / 32];
+    uint32_t freemap[REGION0_PG_COUNT / 32];
     // store a lower bound of the first free page in each region
     int lb;
     // an upper bound of the last non-free page
     int ub;
-} region_t;
+} pagetable0_t;
+
+typedef struct {
+    pagetable0_t *meta0[REGION1_PG_COUNT];
+    uint32_t allocmap0[REGION1_PG_COUNT / 32];
+    uint32_t freemap0[REGION1_PG_COUNT / 32];
+    // store a lower bound of the first free page in each region
+    int lb;
+    // an upper bound of the last non-free page
+    int ub;
+} pagetable1_t;
+
+typedef struct {
+    pagetable1_t *meta1[REGION2_PG_COUNT];
+    uint32_t allocmap1[(REGION2_PG_COUNT + 31) / 32];
+    uint32_t freemap1[(REGION2_PG_COUNT + 31) / 32];
+    // store a lower bound of the first free page in each region
+    int lb;
+    // an upper bound of the last non-free page
+    int ub;
+} pagetable_t;
+
+STATIC_INLINE unsigned ffs_u32(uint32_t bitvec)
+{
+#if defined(_COMPILER_MINGW_)
+    return __builtin_ffs(bitvec) - 1;
+#elif defined(_COMPILER_MICROSOFT_)
+    unsigned long j;
+    _BitScanForward(&j, bitvec);
+    return j;
+#else
+    return ffs(bitvec) - 1;
+#endif
+}
 
 extern jl_gc_num_t gc_num;
-extern region_t regions[REGION_COUNT];
+extern pagetable_t memory_map;
 extern bigval_t *big_objects_marked;
 extern arraylist_t finalizer_list_marked;
 extern arraylist_t to_finalize;
@@ -198,11 +251,6 @@ STATIC_INLINE jl_taggedvalue_t *page_pfl_beg(jl_gc_pagemeta_t *p)
 STATIC_INLINE jl_taggedvalue_t *page_pfl_end(jl_gc_pagemeta_t *p)
 {
     return (jl_taggedvalue_t*)(p->data + p->fl_end_offset);
-}
-
-STATIC_INLINE int page_index(region_t *region, void *data)
-{
-    return (gc_page_data(data) - region->pages->data) / GC_PAGE_SZ;
 }
 
 STATIC_INLINE int gc_marked(uintptr_t bits)
@@ -232,31 +280,50 @@ STATIC_INLINE void *gc_ptr_clear_tag(void *v, uintptr_t mask)
 
 NOINLINE uintptr_t gc_get_stack_ptr(void);
 
-STATIC_INLINE region_t *find_region(void *ptr)
-{
-    for (int i = 0; i < REGION_COUNT && regions[i].pages; i++) {
-        region_t *region = &regions[i];
-        char *begin = region->pages->data;
-        char *end = begin + region->pg_cnt * sizeof(jl_gc_page_t);
-        if ((char*)ptr >= begin && (char*)ptr <= end) {
-            return region;
-        }
-    }
-    return NULL;
-}
-
 STATIC_INLINE jl_gc_pagemeta_t *page_metadata(void *_data)
 {
-    uintptr_t data = ((uintptr_t)_data) - 1;
-    for (int i = 0; i < REGION_COUNT && regions[i].pages; i++) {
-        region_t *region = &regions[i];
-        uintptr_t begin = (uintptr_t)region->pages->data;
-        uintptr_t offset = data - begin;
-        if (offset < region->pg_cnt * sizeof(jl_gc_page_t)) {
-            return &region->meta[offset >> GC_PAGE_LG2];
-        }
-    }
-    return NULL;
+    uintptr_t data = ((uintptr_t)_data);
+    unsigned i;
+    i = REGION_INDEX(data);
+    pagetable1_t *r1 = memory_map.meta1[i];
+    if (!r1)
+        return NULL;
+    i = REGION1_INDEX(data);
+    pagetable0_t *r0 = r1->meta0[i];
+    if (!r0)
+        return NULL;
+    i = REGION0_INDEX(data);
+    return r0->meta[i];
+}
+
+struct jl_gc_metadata_ext {
+    pagetable1_t *pagetable1;
+    pagetable0_t *pagetable0;
+    jl_gc_pagemeta_t *meta;
+    unsigned pagetable_i32, pagetable_i;
+    unsigned pagetable1_i32, pagetable1_i;
+    unsigned pagetable0_i32, pagetable0_i;
+};
+
+STATIC_INLINE struct jl_gc_metadata_ext page_metadata_ext(void *_data)
+{
+    uintptr_t data = (uintptr_t)_data;
+    struct jl_gc_metadata_ext info;
+    unsigned i;
+    i = REGION_INDEX(data);
+    info.pagetable_i = i % 32;
+    info.pagetable_i32 = i / 32;
+    info.pagetable1 = memory_map.meta1[i];
+    i = REGION1_INDEX(data);
+    info.pagetable1_i = i % 32;
+    info.pagetable1_i32 = i / 32;
+    info.pagetable0 = info.pagetable1->meta0[i];
+    i = REGION0_INDEX(data);
+    info.pagetable0_i = i % 32;
+    info.pagetable0_i32 = i / 32;
+    info.meta = info.pagetable0->meta[i];
+    assert(info.meta);
+    return info;
 }
 
 STATIC_INLINE void gc_big_object_unlink(const bigval_t *hdr)
@@ -285,7 +352,7 @@ void jl_mark_box_caches(jl_ptls_t ptls);
 // GC pages
 
 void jl_gc_init_page(void);
-NOINLINE void *jl_gc_alloc_page(void);
+NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void);
 void jl_gc_free_page(void *p);
 
 // GC debug


### PR DESCRIPTION
From local testing, this doesn't seem to have any performance impact. To get virtual address space to line up with physical allocation a bit more would require also adjusting openblas to avoid allocation of it's 512 MB buffer (32 MB * 16 threads) during initialization.

fix #17987
alterate fix for #10390