### PR TITLE
Initialize all targets that the LLVM build is configured for

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7159,11 +7159,18 @@ extern "C" void jl_init_codegen(void)
     initializeAnalysis(Registry);
 #endif
 
+#ifdef USE_POLLY
     InitializeAllTargets();
     InitializeAllTargetMCs();
     InitializeAllAsmPrinters();
     InitializeAllAsmParsers();
     InitializeAllDisassemblers();
+#else
+    InitializeNativeTarget();
+    InitializeNativeTargetAsmPrinter();
+    InitializeNativeTargetAsmParser();
+    InitializeNativeTargetDisassembler();
+#endif
 
     Module *m, *engine_module;
     engine_module = new Module("julia", jl_LLVMContext);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7159,10 +7159,11 @@ extern "C" void jl_init_codegen(void)
     initializeAnalysis(Registry);
 #endif
 
-    InitializeNativeTarget();
-    InitializeNativeTargetAsmPrinter();
-    InitializeNativeTargetAsmParser();
-    InitializeNativeTargetDisassembler();
+    InitializeAllTargets();
+    InitializeAllTargetMCs();
+    InitializeAllAsmPrinters();
+    InitializeAllAsmParsers();
+    InitializeAllDisassemblers();
 
     Module *m, *engine_module;
     engine_module = new Module("julia", jl_LLVMContext);


### PR DESCRIPTION
This change helps Polly to target GPUs for Julia, which uses the NVPTX back-end to embed kernel code within LLVM-IR. 

Polly uses TargetRegistry::lookupTarget to ascertain whether it can access the NVPTX back-end. This change makes sure that nvptx64-nvidia-cuda is registered with TargetRegistry.

This also helps link requisite libLLVMNVPTX* files to libjulia.so in case LLVM is built with  LLVM_BUILD_LLVM_DYLIB=OFF or BUILD_SHARED_LIBS=ON, since they aren't chucked out by the linker's --as-needed behaviour.