### PR TITLE
Use separate build dirs for mbedtls depending on USE_GPL_LIBS

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -190,8 +190,8 @@ julia> take!(c)
 julia> put!(c,1);
 ERROR: foo
 Stacktrace:
- [1] check_channel_state(::Channel{Any}) at ./channels.jl:125
- [2] put!(::Channel{Any}, ::Int64) at ./channels.jl:256
+ [1] check_channel_state(::Channel{Any}) at ./channels.jl:127
+ [2] put!(::Channel{Any}, ::Int64) at ./channels.jl:258
 ```
 """
 function bind(c::Channel, task::Task)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -169,7 +169,7 @@ foldr(op, itr) = mapfoldr(identity, op, itr)
 
 # `mapreduce_impl()` is called by `mapreduce()` (via `_mapreduce()`, when `A`
 # supports linear indexing) and does actual calculations (for `A[ifirst:ilast]` subset).
-# For efficiency, no parameter validity checks are done, it's the caller responsibility.
+# For efficiency, no parameter validity checks are done, it's the caller's responsibility.
 # `ifirst:ilast` range is assumed to be a valid non-empty subset of `A` indices.
 
 # This is a generic implementation of `mapreduce_impl()`,

--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -56,8 +56,11 @@ curl -L -o julia-$version-win32.exe \
   $julianightlies/winnt/x86/$majmin/julia-$majminpatch-$shashort-win32.exe
 cp julia-$version-win32.exe julia-$majmin-latest-win32.exe
 
-echo "Note: if windows code signing is not working on the buildbots, then the"
-echo "checksums need to be re-calculated after the binaries are manually signed!"
+if [ -e codesign.sh ]; then
+  # code signing needs to run on windows, script is not checked in since it
+  # hard-codes a few things. TODO: see if signtool.exe can run in wine
+  ./codesign.sh
+fi
 
 shasum -a 256 julia-$version* | grep -v -e sha256 -e md5 -e asc > julia-$version.sha256
 md5sum julia-$version* | grep -v -e sha256 -e md5 -e asc > julia-$version.md5

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -36,19 +36,19 @@ $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted: $(SRCDIR)/srccache/$(MBEDTLS
 $(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted
 	cd $(SRCDIR)/srccache/$(MBEDTLS_SRC)/include/mbedtls && patch -p0 -f < $(SRCDIR)/patches/mbedtls-ssl.h.patch
 	echo 1 > $@
-$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied
+$(BUILDDIR)/$(MBEDTLS_SRC)/build-configured: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/mbedtls-ssl.h.patch-applied
 
-$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted
+$(BUILDDIR)/$(MBEDTLS_SRC)/build-configured: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(CMAKE) $(dir $<) $(MBEDTLS_OPTS)
 	echo 1 > $@
 
-$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured
+$(BUILDDIR)/$(MBEDTLS_SRC)/build-compiled: $(BUILDDIR)/$(MBEDTLS_SRC)/build-configured
 	$(MAKE) -C $(dir $<)
 	echo 1 > $@
 
-$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-checked: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled
+$(BUILDDIR)/$(MBEDTLS_SRC)/build-checked: $(BUILDDIR)/$(MBEDTLS_SRC)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C $(dir $@) test
 endif
@@ -67,7 +67,7 @@ define MBEDTLS_INSTALL
 endef
 endif
 $(eval $(call staged-install, \
-	mbedtls,mbedtls-$(MBEDTLS_VER), \
+	mbedtls,$(MBEDTLS_SRC), \
 	MBEDTLS_INSTALL,,, \
 	$$(INSTALL_NAME_CMD)libmbedx509.$$(SHLIB_EXT) $$(build_shlibdir)/libmbedx509.$$(SHLIB_EXT) && \
 	$$(INSTALL_NAME_CMD)libmbedtls.$$(SHLIB_EXT) $$(build_shlibdir)/libmbedtls.$$(SHLIB_EXT) && \
@@ -78,20 +78,20 @@ $(eval $(call staged-install, \
 
 
 clean-mbedtls:
-	-rm $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured \
-		$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled
-	-$(MAKE) -C $(BUILDDIR)/mbedtls-$(MBEDTLS_VER) clean
+	-rm $(BUILDDIR)/$(MBEDTLS_SRC)/build-configured \
+		$(BUILDDIR)/$(MBEDTLS_SRC)/build-compiled
+	-$(MAKE) -C $(BUILDDIR)/$(MBEDTLS_SRC) clean
 
 distclean-mbedtls:
 	-rm -rf $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz \
 		$(SRCDIR)/srccache/$(MBEDTLS_SRC) \
-		$(BUILDDIR)/mbedtls-$(MBEDTLS_VER)
+		$(BUILDDIR)/$(MBEDTLS_SRC)
 
 
 get-mbedtls: $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz
 extract-mbedtls: $(SRCDIR)/srccache/$(MBEDTLS_SRC)/source-extracted
-configure-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-configured
-compile-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-compiled
+configure-mbedtls: $(BUILDDIR)/$(MBEDTLS_SRC)/build-configured
+compile-mbedtls: $(BUILDDIR)/$(MBEDTLS_SRC)/build-compiled
 # tests disabled since they are known to fail
 fastcheck-mbedtls: #check-mbedtls
-check-mbedtls: $(BUILDDIR)/mbedtls-$(MBEDTLS_VER)/build-checked
+check-mbedtls: $(BUILDDIR)/$(MBEDTLS_SRC)/build-checked

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -515,7 +515,7 @@ false
 julia> contains("Xylophon", 'o')
 ERROR: MethodError: no method matching contains(::String, ::Char)
 Closest candidates are:
-  contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:660
+  contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:664
   contains(::AbstractString, !Matched::AbstractString) at strings/search.jl:378
 ```
 


### PR DESCRIPTION
prevents cmake from complaining when you switch sources for the same build dir