### PR TITLE
WIP: enable GC sooner when loading precompiled modules

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1321,6 +1321,11 @@ NOINLINE static int gc_mark_module(jl_ptls_t ptls, jl_module_t *m,
     return refyoung;
 }
 
+void jl_gc_push_root(jl_ptls_t ptls, jl_value_t *v)
+{
+    gc_push_root(ptls, v, 0);
+}
+
 // Handle the case where the stack is only partially copied.
 STATIC_INLINE uintptr_t gc_get_stack_addr(void *_addr, uintptr_t offset,
                                           uintptr_t lb, uintptr_t ub)
@@ -1674,6 +1679,9 @@ static void mark_roots(jl_ptls_t ptls)
     // constants
     gc_push_root(ptls, jl_typetype_type, 0);
     gc_push_root(ptls, jl_emptytuple_type, 0);
+
+    // deserializer state during module reload
+    jl_gc_mark_deserializer_state(ptls);
 }
 
 // find unmarked objects that need to be finalized from the finalizer list "list".

--- a/src/gc.h
+++ b/src/gc.h
@@ -281,6 +281,7 @@ void gc_mark_object_list(jl_ptls_t ptls, arraylist_t *list, size_t start);
 void visit_mark_stack(jl_ptls_t ptls);
 void gc_debug_init(void);
 void jl_mark_box_caches(jl_ptls_t ptls);
+void jl_gc_mark_deserializer_state(jl_ptls_t ptls);
 
 // GC pages
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -350,6 +350,7 @@ jl_tupletype_t *jl_argtype_with_function(jl_function_t *f, jl_tupletype_t *types
 JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t nargs);
 
 void jl_gc_setmark(jl_ptls_t ptls, jl_value_t *v);
+void jl_gc_push_root(jl_ptls_t ptls, jl_value_t *v);
 void jl_gc_sync_total_bytes(void);
 void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a);
 void jl_gc_count_allocd(size_t sz);


### PR DESCRIPTION
part of #20671 

Loading the module still takes a long time, but now it actually completes instead of using a huge amount of memory (and, on my laptop at least, getting OOMkilled).
