### PR TITLE
Add docstring for undocumented gradient method

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -165,6 +165,7 @@ tril(M::Matrix, k::Integer) = tril!(copy(M), k)
 
 """
     gradient(F::AbstractVector, x::Vector)
+
 Compute finite differences along vector `F` at points `x`, using central differences for midpoints
 and forward/backward differences for the first and last points.
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -163,18 +163,36 @@ function tril!(M::AbstractMatrix, k::Integer)
 end
 tril(M::Matrix, k::Integer) = tril!(copy(M), k)
 
-function gradient(F::AbstractVector, h::Vector)
+"""
+    gradient(F::AbstractVector, x::Vector)
+Compute finite differences along vector `F` at points `x`, using central differences for midpoints
+and forward/backward differences for the first and last points.
+
+# Example
+
+```jldoctest
+julia> x = [1,4,7,18];
+julia> F = 2x;
+julia> gradient(F,x)
+4-element Array{Float64,1}:
+ 2.0
+ 2.0
+ 2.0
+ 2.0
+```
+"""
+function gradient(F::AbstractVector, x::Vector)
     n = length(F)
-    T = typeof(oneunit(eltype(F))/oneunit(eltype(h)))
+    T = typeof(oneunit(eltype(F))/oneunit(eltype(x)))
     g = similar(F, T)
     if n == 1
         g[1] = zero(T)
     elseif n > 1
-        g[1] = (F[2] - F[1]) / (h[2] - h[1])
-        g[n] = (F[n] - F[n-1]) / (h[end] - h[end-1])
+        g[1] = (F[2] - F[1]) / (x[2] - x[1])
+        g[n] = (F[n] - F[n-1]) / (x[end] - x[end-1])
         if n > 2
-            h = h[3:n] - h[1:n-2]
-            g[2:n-1] = (F[3:n] - F[1:n-2]) ./ h
+            x = x[3:n] - x[1:n-2]
+            g[2:n-1] = (F[3:n] - F[1:n-2]) ./ x
         end
     end
     g


### PR DESCRIPTION
gradient(F,x::Vector) is useful, but not included in the manual, making method discovery difficult. Also replaced `h` with `x` in function body (since `h` conventionally denotes inter-point spacing rather than location).