### PR TITLE
Use `TypeVar`s in `limit_type_depth` in `Union`s in invariant position

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2097,7 +2097,7 @@ function ⊑(a::ANY, b::ANY)
         if isa(b, Const)
             return a.val === b.val
         end
-        return isa(a.val, b)
+        return isa(a.val, widenconst(b))
     elseif isa(b, Const)
         return a === Bottom
     elseif !(isa(a, Type) || isa(a, TypeVar)) ||

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -670,7 +670,13 @@ end
 function limit_type_depth(t::ANY, d::Int, cov::Bool, vars::Vector{TypeVar}=TypeVar[])
     if isa(t,Union)
         if d > MAX_TYPE_DEPTH
-            return Any
+            if cov
+                return Any
+            else
+                var = TypeVar(:_)
+                push!(vars, var)
+                return var
+            end
         end
         return Union{limit_type_depth(t.a, d+1, cov, vars),
                      limit_type_depth(t.b, d+1, cov, vars)}

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -655,6 +655,11 @@ let A = 1:2, z = zip(A, A, A, A, A, A, A, A, A, A, A, A)
     @test z isa Core.Inference.limit_type_depth(typeof(z), 0)
     @test start(z) == (1, (1, (1, (1, (1, (1, (1, (1, (1, (1, (1, 1)))))))))))
 end
+# introduce TypeVars in Unions in invariant position
+let T = Val{Val{Val{Union{Int8,Int16,Int32,Int64,UInt8,UInt16,UInt32,UInt64}}}}
+    #TODO: this test hits an assertion (see #21191)
+    #@test T <: Core.Inference.limit_type_depth(T, 0)
+end
 
 # issue #20704
 f20704(::Int) = 1


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/20626#discussion_r108347856 and https://discourse.julialang.org/t/strange-failure-in-v0-6/2911

Unfortunately, types were this make a difference seem to be the same where #21191 is hit, so until #21191 is fixed, this just changes the error produced...