### PR TITLE
Correct notation used in the rem/mod docstring

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -372,8 +372,6 @@ julia> 129 % Int8
 -127
 ```
 """
-rem, mod
-
 rem{T<:Integer}(x::T, ::Type{T}) = x
 rem(x::Integer, ::Type{Bool}) = ((x & 1) != 0)
 mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)

--- a/base/int.jl
+++ b/base/int.jl
@@ -359,6 +359,10 @@ for to in BitInteger_types, from in (BitInteger_types..., Bool)
     end
 end
 
+rem{T<:Integer}(x::T, ::Type{T}) = x
+rem(x::Integer, ::Type{Bool}) = ((x & 1) != 0)
+mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)
+
 """
     rem(x::Integer, T::Type{<:Integer})
     mod(x::Integer, T::Type{<:Integer})
@@ -372,9 +376,7 @@ julia> 129 % Int8
 -127
 ```
 """
-rem{T<:Integer}(x::T, ::Type{T}) = x
-rem(x::Integer, ::Type{Bool}) = ((x & 1) != 0)
-mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)
+rem(::Integer, ::Type), mod(::Integer, ::Type)
 
 unsafe_trunc{T<:Integer}(::Type{T}, x::Integer) = rem(x, T)
 for (Ts, Tu) in ((Int8, UInt8), (Int16, UInt16), (Int32, UInt32), (Int64, UInt64), (Int128, UInt128))

--- a/base/int.jl
+++ b/base/int.jl
@@ -376,7 +376,7 @@ julia> 129 % Int8
 -127
 ```
 """
-rem(::Integer, ::Type), mod(::Integer, ::Type)
+rem(x::Integer, T::Type), mod(x::Integer, T::Type)
 
 unsafe_trunc{T<:Integer}(::Type{T}, x::Integer) = rem(x, T)
 for (Ts, Tu) in ((Int8, UInt8), (Int16, UInt16), (Int32, UInt32), (Int64, UInt64), (Int128, UInt128))

--- a/base/int.jl
+++ b/base/int.jl
@@ -360,9 +360,9 @@ for to in BitInteger_types, from in (BitInteger_types..., Bool)
 end
 
 """
-    rem(x::Integer, T<:Integer)
-    mod(x::Integer, T<:Integer)
-    %(x::Integer, T<:Integer)
+    rem(x::Integer, T::Integer)
+    mod(x::Integer, T::Integer)
+    %(x::Integer, T::Integer)
 
 Find `y::T` such that `x` ≡ `y` (mod n), where n is the number of integers representable
 in `T`, and `y` is an integer in `[typemin(T),typemax(T)]`.

--- a/base/int.jl
+++ b/base/int.jl
@@ -359,10 +359,6 @@ for to in BitInteger_types, from in (BitInteger_types..., Bool)
     end
 end
 
-rem{T<:Integer}(x::T, ::Type{T}) = x
-rem(x::Integer, ::Type{Bool}) = ((x & 1) != 0)
-mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)
-
 """
     rem(x::Integer, T::Type{<:Integer})
     mod(x::Integer, T::Type{<:Integer})
@@ -376,7 +372,11 @@ julia> 129 % Int8
 -127
 ```
 """
-rem(x::Integer, T::Type), mod(x::Integer, T::Type)
+function rem(x::Integer, T::Type) end, function mod(x::Integer, T::Type) end
+
+rem{T<:Integer}(x::T, ::Type{T}) = x
+rem(x::Integer, ::Type{Bool}) = ((x & 1) != 0)
+mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)
 
 unsafe_trunc{T<:Integer}(::Type{T}, x::Integer) = rem(x, T)
 for (Ts, Tu) in ((Int8, UInt8), (Int16, UInt16), (Int32, UInt32), (Int64, UInt64), (Int128, UInt128))

--- a/base/int.jl
+++ b/base/int.jl
@@ -360,9 +360,9 @@ for to in BitInteger_types, from in (BitInteger_types..., Bool)
 end
 
 """
-    rem(x::Integer, T::Integer)
-    mod(x::Integer, T::Integer)
-    %(x::Integer, T::Integer)
+    rem(x::Integer, T::Type{<:Integer})
+    mod(x::Integer, T::Type{<:Integer})
+    %(x::Integer, T::Type{<:Integer})
 
 Find `y::T` such that `x` ≡ `y` (mod n), where n is the number of integers representable
 in `T`, and `y` is an integer in `[typemin(T),typemax(T)]`.


### PR DESCRIPTION
Addresses my own comment on #20759. The notation used in the docstring was nonstandard, so this updates it to be proper Julia syntax.

Since this is such a trivial change, I've skipped CI. As usual, `[ci skip]` should be removed from the commit message on merge. (Should also squash-merge since I derped on the first commit. Multiple commits is what I get for using the GitHub web UI to do this...)