### PR TITLE
handle unicode space characters in `parse` for `Bool`

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -140,10 +140,10 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
 
     # Ignore leading and trailing whitespace
     while isspace(sbuff[startpos]) && startpos <= endpos
-        startpos += 1
+        startpos = nextind(sbuff, startpos)
     end
     while isspace(sbuff[endpos]) && endpos >= startpos
-        endpos -= 1
+        endpos = prevind(sbuff, endpos)
     end
 
     len = endpos - startpos + 1

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -276,6 +276,9 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned))
     @test parse(Float64, ".5    "    ) == 0.5
 end
 
+@test parse(Bool, "\u202f true") === true
+@test parse(Bool, "\u202f false") === false
+
 parsebin(s) = parse(Int,s,2)
 parseoct(s) = parse(Int,s,8)
 parsehex(s) = parse(Int,s,16)


### PR DESCRIPTION
Discovered this while investigating #21180.