### PR TITLE
Add iszero method with Irrational argument

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -95,6 +95,7 @@ end
 <=(x::Rational, y::Irrational) = x < y
 
 isfinite(::Irrational) = true
+iszero(::Irrational) = false
 
 hash(x::Irrational, h::UInt) = 3*object_id(x) - h
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2949,6 +2949,9 @@ end
         end
     end
     @test !iszero(nextfloat(BigFloat(0)))
+    for x in (π, e, γ, catalan, φ)
+        @test !iszero(x)
+    end
 
     # Array reduction
     @test !iszero([0, 1, 2, 3])


### PR DESCRIPTION
Assuming that an irrational is not zero should be safe enough, and if someone wants to define a "zero" irrational (even if it doesn't make much sense) can easily overload `iszero` for the specific number.