### PR TITLE
Make cor work again for complex input

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -307,7 +307,7 @@ _vmean(x::AbstractMatrix, vardim::Int) = mean(x, vardim)
 unscaled_covzm(x::AbstractVector) = sum(abs2, x)
 unscaled_covzm(x::AbstractMatrix, vardim::Int) = (vardim == 1 ? _conj(x'x) : x * x')
 
-unscaled_covzm(x::AbstractVector, y::AbstractVector) = dot(x, y)
+unscaled_covzm(x::AbstractVector, y::AbstractVector) = dot(y, x)
 unscaled_covzm(x::AbstractVector, y::AbstractMatrix, vardim::Int) =
     (vardim == 1 ? At_mul_B(x, _conj(y)) : At_mul_Bt(x, _conj(y)))
 unscaled_covzm(x::AbstractMatrix, y::AbstractVector, vardim::Int) =
@@ -362,9 +362,10 @@ cov(X::AbstractMatrix) = cov(X, 1, true)
 """
     cov(x, y[, corrected=true])
 
-Compute the covariance between the vectors `x` and `y`. If `corrected` is `true` (the default)
-then the sum is scaled with `n-1`, whereas the sum is scaled with `n` if `corrected` is `false`
-where `n = length(x) = length(y)`.
+Compute the covariance between the vectors `x` and `y`. If `corrected` is `true` (the
+default), computes ``\\frac{1}{n-1}\\sum_{i=1}^n (x_i-\\bar x) (y_i-\\bar y)^*`` where
+``*`` denotes the complex conjugate and `n = length(x) = length(y)`. If `corrected` is
+`false`, computes ``\frac{1}{n}\sum_{i=1}^n (x_i-\\bar x) (y_i-\\bar y)^*``.
 """
 cov(x::AbstractVector, y::AbstractVector, corrected::Bool) =
     covm(x, Base.mean(x), y, Base.mean(y), corrected)
@@ -388,6 +389,14 @@ cov(X::AbstractMatrix, Y::AbstractMatrix) = cov(X, Y, 1, true)
 
 ##### correlation #####
 
+"""
+    clampcor(x)
+
+Clamp a real correlation to between -1 and 1, leaving complex correlations unchanged
+"""
+clampcor(x::Real) = clamp(x, -1, 1)
+clampcor(x) = x
+
 # cov2cor!
 
 function cov2cor!{T}(C::AbstractMatrix{T}, xsd::AbstractArray)
@@ -395,11 +404,11 @@ function cov2cor!{T}(C::AbstractMatrix{T}, xsd::AbstractArray)
     size(C) == (nx, nx) || throw(DimensionMismatch("inconsistent dimensions"))
     for j = 1:nx
         for i = 1:j-1
-            C[i,j] = C[j,i]
+            C[i,j] = C[j,i]'
         end
         C[j,j] = oneunit(T)
         for i = j+1:nx
-            C[i,j] = clamp(C[i,j] / (xsd[i] * xsd[j]), -1, 1)
+            C[i,j] = clampcor(C[i,j] / (xsd[i] * xsd[j]))
         end
     end
     return C
@@ -409,7 +418,7 @@ function cov2cor!(C::AbstractMatrix, xsd::Number, ysd::AbstractArray)
     length(ysd) == ny || throw(DimensionMismatch("inconsistent dimensions"))
     for (j, y) in enumerate(ysd)   # fixme (iter): here and in all `cov2cor!` we assume that `C` is efficiently indexed by integers
         for i in 1:nx
-            C[i,j] = clamp(C[i, j] / (xsd * y), -1, 1)
+            C[i,j] = clampcor(C[i, j] / (xsd * y))
         end
     end
     return C
@@ -419,7 +428,7 @@ function cov2cor!(C::AbstractMatrix, xsd::AbstractArray, ysd::Number)
     length(xsd) == nx || throw(DimensionMismatch("inconsistent dimensions"))
     for j in 1:ny
         for (i, x) in enumerate(xsd)
-            C[i,j] = clamp(C[i,j] / (x * ysd), -1, 1)
+            C[i,j] = clampcor(C[i,j] / (x * ysd))
         end
     end
     return C
@@ -430,7 +439,7 @@ function cov2cor!(C::AbstractMatrix, xsd::AbstractArray, ysd::AbstractArray)
         throw(DimensionMismatch("inconsistent dimensions"))
     for (i, x) in enumerate(xsd)
         for (j, y) in enumerate(ysd)
-            C[i,j] = clamp(C[i,j] / (x * y), -1, 1)
+            C[i,j] = clampcor(C[i,j] / (x * y))
         end
     end
     return C
@@ -461,11 +470,11 @@ function corm(x::AbstractVector, mx::Number, y::AbstractVector, my::Number)
 
     @inbounds begin
         # Initialize the accumulators
-        xx = zero(sqrt(x[1] * x[1]))
-        yy = zero(sqrt(y[1] * y[1]))
-        xy = zero(xx * yy)
+        xx = zero(sqrt(abs2(x[1])))
+        yy = zero(sqrt(abs2(y[1])))
+        xy = zero(x[1] * y[1]')
 
-        @simd for i = 1:n
+        @simd for i in eachindex(x, y)
             xi = x[i] - mx
             yi = y[i] - my
             xx += abs2(xi)
@@ -473,8 +482,9 @@ function corm(x::AbstractVector, mx::Number, y::AbstractVector, my::Number)
             xy += xi * yi'
         end
     end
-    return clamp(xy / max(xx, yy) / sqrt(min(xx, yy) / max(xx, yy)), -1, 1)
+    return clampcor(xy / max(xx, yy) / sqrt(min(xx, yy) / max(xx, yy)))
 end
+
 corm(x::AbstractVecOrMat, xmean, y::AbstractVecOrMat, ymean, vardim::Int=1) =
     corzm(x .- xmean, y .- ymean, vardim)
 

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -348,6 +348,24 @@ let v = varm([1.0+2.0im], 0; corrected = false)
     @test isa(v, Float64)
 end
 
+# cov and cor of complex arrays (issue #21093)
+x = [2.7 - 3.3im, 0.9 + 5.4im, 0.1 + 0.2im, -1.7 - 5.8im, 1.1 + 1.9im]
+y = [-1.7 - 1.6im, -0.2 + 6.5im, 0.8 - 10.0im, 9.1 - 3.4im, 2.7 - 5.5im]
+@test cov(x, y) ≈ 4.8365 - 12.119im
+@test cov(y, x) ≈ 4.8365 + 12.119im
+@test cov(x, reshape(y, :, 1)) ≈ reshape([4.8365 - 12.119im], 1, 1)
+@test cov(reshape(x, :, 1), y) ≈ reshape([4.8365 - 12.119im], 1, 1)
+@test cov(reshape(x, :, 1), reshape(y, :, 1)) ≈ reshape([4.8365 - 12.119im], 1, 1)
+@test cov([x y]) ≈ [21.779 4.8365-12.119im;
+                    4.8365+12.119im 54.548]
+@test cor(x, y) ≈ 0.14032104449218274 - 0.35160772008699703im
+@test cor(y, x) ≈ 0.14032104449218274 + 0.35160772008699703im
+@test cor(x, reshape(y, :, 1)) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
+@test cor(reshape(x, :, 1), y) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
+@test cor(reshape(x, :, 1), reshape(y, :, 1)) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
+@test cor([x y]) ≈ [1.0                                          0.14032104449218274-0.35160772008699703im
+                    0.14032104449218274+0.35160772008699703im  1.0]
+
 # Issue #17153 and PR #17154
 let a = rand(10,10)
     b = deepcopy(a)


### PR DESCRIPTION
Also fix an inconsistency in complex `cov`. Fixes #21093.

It appears there is some ambiguity regarding whether the first or second argument should be conjugated when computing these quantities. MATLAB conjugates the first argument, while NumPy conjugates the second. [Wikipedia](https://en.wikipedia.org/wiki/Covariance_matrix#Complex_random_vectors) defines the complex covariance matrix as E((Z - μ)(Z - μ)ᴴ), which seems to imply that the second argument should be conjugated, so that is the convention I followed here. Previously, we were not consistent about this: We conjugated the first argument when computing the covariance between vectors, but the second when computing the covariance between matrices.