### PR TITLE
Fix character index to byte index in datafmt.jl

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -263,7 +263,7 @@ function store_cell{T}(dlmstore::DLMStore{T}, row::Int, col::Int,
         # fill data
         if quoted && _chrinstr(sbuff, UInt8('"'), startpos, endpos)
             unescaped = replace(SubString(sbuff, startpos, endpos), r"\"\"", "\"")
-            fail = colval(unescaped, 1, length(unescaped), cells, drow, col)
+            fail = colval(unescaped, 1, endof(unescaped), cells, drow, col)
         else
             fail = colval(sbuff, startpos, endpos, cells, drow, col)
         end
@@ -282,7 +282,7 @@ function store_cell{T}(dlmstore::DLMStore{T}, row::Int, col::Int,
         # fill header
         if quoted && _chrinstr(sbuff, UInt8('"'), startpos, endpos)
             unescaped = replace(SubString(sbuff, startpos, endpos), r"\"\"", "\"")
-            colval(unescaped, 1, length(unescaped), dlmstore.hdr, 1, col)
+            colval(unescaped, 1, endof(unescaped), dlmstore.hdr, 1, col)
         else
             colval(sbuff, startpos, endpos, dlmstore.hdr, 1, col)
         end

--- a/test/datafmt.jl
+++ b/test/datafmt.jl
@@ -272,3 +272,8 @@ let fn = tempname()
     readdlm(fn)[] == "Julia"
     rm(fn)
 end
+
+# issue #21207
+let data = "\"1\",\"灣\"\"灣灣灣灣\",\"3\""
+    @test readcsv(IOBuffer(data)) == Any[1 "灣\"灣灣灣灣" 3]
+end


### PR DESCRIPTION
Use `endof` instead of `length` in call to `colval` as it expects byte index.