### PR TITLE
Fix exports of undefined/missing/conditionally defined symbols

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -23,7 +23,7 @@ export
     Markdown,
     Threads,
     Iterators,
-    Parallel,
+    Distributed,
 
 # Types
     AbstractChannel,
@@ -1344,7 +1344,7 @@ export
     nzrange,
     nnz,
 
-# Parallel module re-exports
+# Distributed module re-exports
     @spawn,
     @spawnat,
     @fetch,

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -4,8 +4,7 @@ module MPFR
 
 export
     BigFloat,
-    setprecision,
-    big_str
+    setprecision
 
 import
     Base: (*), +, -, /, <, <=, ==, >, >=, ^, ceil, cmp, convert, copysign, div,

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -27,7 +27,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     triu, vec, permute!, map, map!
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
-    SparseMatrixCSC, SparseVector, blkdiag, dense, droptol!, dropzeros!, dropzeros,
+    SparseMatrixCSC, SparseVector, blkdiag, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm, speye, spones,
     sprand, sprandn, spzeros, nnz, permute
 


### PR DESCRIPTION
It appears in #20486, `Base.Parallel` has been renamed to `Base.Distributed`, but is
still exported.  Thus, the export in base/exports.jl is not valid anymore.  In
particular, when doing e.g. a `[ s for s in names(Base) if
typeof(getfield(Base,s))<:Function]` an UndefVarError is thrown on 'Parallel'.

```jl
julia> [ s for s in names(Base) if typeof(getfield(Base,s))<:Function]
ERROR: UndefVarError: Parallel not defined
Stacktrace:
 [1] advance_filter(::##6#8, ::Array{Symbol,1}, ::Tuple{Bool,Symbol,Int64}) at ./iterators.jl:270
 [2] next at ./generator.jl:44 [inlined]
 [3] grow_to!(::Array{Symbol,1}, ::Base.Generator{Base.Iterators.Filter{##6#8,Array{Symbol,1}},##5#7}, ::Tuple{Bool,Symbol,Int64}) at ./array.jl:475
 [4] grow_to!(::Array{Union{},1}, ::Base.Generator{Base.Iterators.Filter{##6#8,Array{Symbol,1}},##5#7}, ::Tuple{Bool,Symbol,Int64}) at ./array.jl:483
 [5] grow_to!(::Array{Symbol,1}, ::Base.Generator{Base.Iterators.Filter{##6#8,Array{Symbol,1}},##5#7}) at ./array.jl:468
 [6] collect(::Base.Generator{Base.Iterators.Filter{##6#8,Array{Symbol,1}},##5#7}) at ./array.jl:412
```