### PR TITLE
Define methods for big(T)

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -880,8 +880,8 @@ end
 float(z::Complex{<:AbstractFloat}) = z
 float(z::Complex) = Complex(float(real(z)), float(imag(z)))
 
-big(z::Complex{<:AbstractFloat}) = Complex{BigFloat}(z)
-big(z::Complex{<:Integer}) = Complex{BigInt}(z)
+big(::Type{Complex{T}}) where {T<:Real} = Complex{big(T)}
+big(z::Complex{T}) where {T<:Real} = Complex{big(T)}(z)
 
 ## Array operations on complex numbers ##
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -9,7 +9,7 @@ import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
              ndigits, promote_rule, rem, show, isqrt, string, powermod,
              sum, trailing_zeros, trailing_ones, count_ones, base, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, prevpow2, nextpow2, ndigits0z, widen, signed, unsafe_trunc, trunc,
-             iszero
+             iszero, big
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -247,6 +247,9 @@ convert(::Type{Float32}, n::BigInt) = Float32(n,RoundNearest)
 convert(::Type{Float16}, n::BigInt) = Float16(n,RoundNearest)
 
 promote_rule(::Type{BigInt}, ::Type{<:Integer}) = BigInt
+
+big(::Type{<:Integer})  = BigInt
+big(::Type{<:Rational}) = Rational{BigInt}
 
 # Binary ops
 for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -131,6 +131,7 @@ macro irrational(sym, val, def)
 end
 
 big(x::Irrational) = convert(BigFloat,x)
+big(::Type{<:Irrational}) = BigFloat
 
 ## specific irrational mathematical constants
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -16,7 +16,7 @@ import
         eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
         cbrt, typemax, typemin, unsafe_trunc, realmin, realmax, rounding,
-        setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero
+        setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero, big
 
 import Base.Rounding: rounding_raw, setrounding_raw
 
@@ -251,6 +251,8 @@ Float16(x::BigFloat, r::RoundingMode) =
 promote_rule(::Type{BigFloat}, ::Type{<:Real}) = BigFloat
 promote_rule(::Type{BigInt}, ::Type{<:AbstractFloat}) = BigFloat
 promote_rule(::Type{BigFloat}, ::Type{<:AbstractFloat}) = BigFloat
+
+big(::Type{<:AbstractFloat}) = BigFloat
 
 function convert(::Type{Rational{BigInt}}, x::AbstractFloat)
     if isnan(x); return zero(BigInt)//zero(BigInt); end

--- a/base/number.jl
+++ b/base/number.jl
@@ -211,3 +211,22 @@ julia> factorial(big(21))
 ```
 """
 factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
+
+"""
+    big(T::Type)
+
+Returns an appropriate type to represent a value of type `T` as an arbitrary precision number.
+Falls back to `typeof(big(zero(T)))`.
+
+```jldoctest
+julia> big(Rational)
+Rational{BigInt}
+
+julia> big(Float64)
+BigFloat
+
+julia> big(Complex{Int})
+Complex{BigInt}
+```
+"""
+big(::Type{T}) where {T<:Number} = typeof(big(zero(T)))

--- a/base/number.jl
+++ b/base/number.jl
@@ -215,8 +215,8 @@ factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
 """
     big(T::Type)
 
-Returns an appropriate type to represent a value of type `T` as an arbitrary precision number.
-Falls back to `typeof(big(zero(T)))`.
+Compute the type that represents the numeric type `T` with arbitrary precision.
+Equivalent to `typeof(big(zero(T)))`.
 
 ```jldoctest
 julia> big(Rational)

--- a/test/bigfloat.jl
+++ b/test/bigfloat.jl
@@ -7,5 +7,10 @@ for T in [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt
     @test big(2.0)^T(3) == 8
 end
 
+for x in (2f0, pi, 7.8, big(e))
+    @test big(typeof(x)) == typeof(big(x))
+    @test big(typeof(complex(x, x))) == typeof(big(complex(x, x)))
+end
+
 # issue 15659
 @test (setprecision(53) do; big(1/3); end) < 1//3

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -57,6 +57,10 @@ end
 
 @test typeof(BigInt(BigInt(1))) == BigInt
 
+for x in (Int16(0), 1, 3//4, big(5//6), big(9))
+    @test big(typeof(x)) == typeof(big(x))
+    @test big(typeof(complex(x, x))) == typeof(big(complex(x, x)))
+end
 
 # Signed addition
 @test a+Int8(1) == b


### PR DESCRIPTION
This PR defines methods for `big(T)`, which return an appropriate type to represent a value of type `T` as an arbitrary precision number.  I believe this is useful *per se* and also to define a single simple method to promote a complex number to arbitrary precision, as suggested [here](https://github.com/JuliaLang/julia/issues/21204#issuecomment-289910964).  If this PR will be merged, I'll follow up with a patch implementing `big{T<:Real}(z::Complex{T})`.