### PR TITLE
More efficient float(T) for rationals and big*, works with Irrational

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -33,6 +33,9 @@ promote_rule(::Type{Complex{T}}, ::Type{Complex{S}}) where {T<:Real,S<:Real} =
 
 widen(::Type{Complex{T}}) where {T} = Complex{widen(T)}
 
+float(::Type{Complex{T}}) where {T<:AbstractFloat} = Complex{T}
+float(::Type{Complex{T}}) where {T} = Complex{float(T)}
+
 """
     real(z)
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -272,6 +272,7 @@ Float64
 ```
 """
 float(::Type{T}) where {T<:Number} = typeof(float(zero(T)))
+float(::Type{T}) where {T<:AbstractFloat} = T
 
 for Ti in (Int8, Int16, Int32, Int64)
     @eval begin

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -37,6 +37,8 @@ convert(::Type{Rational{BigInt}}, x::Irrational) = throw(ArgumentError("Cannot c
     end
 end
 
+float(::Type{<:Irrational}) = Float64
+
 ==(::Irrational{s}, ::Irrational{s}) where {s} = true
 ==(::Irrational, ::Irrational) = false
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -10,7 +10,7 @@ import
     Base: (*), +, -, /, <, <=, ==, >, >=, ^, ceil, cmp, convert, copysign, div,
         exp, exp2, exponent, factorial, floor, fma, hypot, isinteger,
         isfinite, isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf,
-        nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show,
+        nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show, float,
         sum, sqrt, string, print, trunc, precision, exp10, expm1,
         gamma, lgamma, log1p,
         eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
@@ -117,6 +117,8 @@ end
 
 convert(::Type{Rational}, x::BigFloat) = convert(Rational{BigInt}, x)
 convert(::Type{AbstractFloat}, x::BigInt) = BigFloat(x)
+
+float(::Type{BigInt}) = BigFloat
 
 # generic constructor with arbitrary precision:
 """

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -429,3 +429,5 @@ iszero(x::Rational) = iszero(numerator(x))
 function lerpi(j::Integer, d::Integer, a::Rational, b::Rational)
     ((d-j)*a)/d + (j*b)/d
 end
+
+float{T<:Integer}(::Type{Rational{T}}) = float(T)

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -68,3 +68,10 @@ for elty in (Float32,Float64)
         @test round.(elty2,A) == fill(round(elty2,x),(10,10,10))
     end
 end
+
+@testset "Types" begin
+    for x in (Int16(0), 1, 2f0, pi, 3//4, big(5//6), 7.8, big(9), big(e))
+        @test float(typeof(x)) == typeof(float(x))
+        @test float(typeof(complex(x, x))) == typeof(float(complex(x, x)))
+    end
+end


### PR DESCRIPTION
Before:
```julia
julia> T = BigInt; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  160 bytes
  allocs estimate:  4
  --------------
  minimum time:     171.846 ns (0.00% GC)
  median time:      178.750 ns (0.00% GC)
  mean time:        250.258 ns (27.08% GC)
  maximum time:     12.712 μs (97.33% GC)
  --------------
  samples:          10000
  evals/sample:     800

julia> T = BigFloat; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  104 bytes
  allocs estimate:  2
  --------------
  minimum time:     109.191 ns (0.00% GC)
  median time:      117.609 ns (0.00% GC)
  mean time:        156.539 ns (22.95% GC)
  maximum time:     8.991 μs (97.65% GC)
  --------------
  samples:          10000
  evals/sample:     934

julia> T = Rational{Int64}; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     70.327 ns (0.00% GC)
  median time:      71.700 ns (0.00% GC)
  mean time:        72.825 ns (0.00% GC)
  maximum time:     125.440 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     975

julia> T = Rational{BigInt}; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  624 bytes
  allocs estimate:  17
  --------------
  minimum time:     511.825 ns (0.00% GC)
  median time:      548.327 ns (0.00% GC)
  mean time:        843.876 ns (33.19% GC)
  maximum time:     55.189 μs (98.20% GC)
  --------------
  samples:          10000
  evals/sample:     194
```
after:
```julia
julia> T = BigInt; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.013 ns (0.00% GC)
  median time:      0.020 ns (0.00% GC)
  mean time:        0.021 ns (0.00% GC)
  maximum time:     0.047 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> T = BigFloat; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.013 ns (0.00% GC)
  median time:      0.021 ns (0.00% GC)
  mean time:        0.021 ns (0.00% GC)
  maximum time:     0.042 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> T = Rational{Int64}; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.013 ns (0.00% GC)
  median time:      0.020 ns (0.00% GC)
  mean time:        0.021 ns (0.00% GC)
  maximum time:     0.174 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> T = Rational{BigInt}; @benchmark float($T)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.013 ns (0.00% GC)
  median time:      0.020 ns (0.00% GC)
  mean time:        0.020 ns (0.00% GC)
  maximum time:     0.040 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```