### PR TITLE
Add methods to add refspecs and tests to view fetchspecs

### DIFF
--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -103,6 +103,18 @@ function push_refspecs(rmt::GitRemote)
     res
 end
 
+function add_fetch!(repo::GitRepo, rmt::GitRemote, fetch_spec::String)
+    @check ccall((:git_remote_add_fetch, :libgit2), Cint,
+                 (Ptr{Void}, Cstring, Cstring), repo.ptr,
+                 name(rmt), fetch_spec)
+end
+
+function add_push!(repo::GitRepo, rmt::GitRemote, push_spec::String)
+    @check ccall((:git_remote_add_push, :libgit2), Cint,
+                 (Ptr{Void}, Cstring, Cstring), repo.ptr,
+                 name(rmt), push_spec)
+end
+
 """
     fetch(rmt::GitRemote, refspecs; options::FetchOptions=FetchOptions(), msg="")
 

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -181,8 +181,8 @@ The keyword arguments are:
 !!! note
     You can add information about the push refspecs in two other ways: by setting
     an option in the repository's `GitConfig` (with `push.default` as the key) or
-    by calling [`add_push!`](@ref). Otherwise you will need to explicity specify
-    a push refspec in the call to `push` for any effect, like so:
+    by calling [`add_push!`](@ref). Otherwise you will need to explicitly specify
+    a push refspec in the call to `push` for it to have any effect, like so:
     `LibGit2.push(repo, refspecs=["refs/heads/master"])`.
 """
 function push(rmt::GitRemote, refspecs::Vector{<:AbstractString};

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -103,12 +103,48 @@ function push_refspecs(rmt::GitRemote)
     res
 end
 
+"""
+    add_fetch!(repo::GitRepo, rmt::GitRemote, fetch_spec::String)
+
+Add a *fetch* refspec for the specified `rmt`. This refspec will contain
+information about which branch(es) to fetch from.
+
+# Example
+```julia
+julia> LibGit2.add_fetch!(repo, remote, "upstream");
+
+julia> LibGit2.fetch_refspecs(remote)
+String["+refs/heads/*:refs/remotes/upstream/*"]
+```
+"""
 function add_fetch!(repo::GitRepo, rmt::GitRemote, fetch_spec::String)
     @check ccall((:git_remote_add_fetch, :libgit2), Cint,
                  (Ptr{Void}, Cstring, Cstring), repo.ptr,
                  name(rmt), fetch_spec)
 end
 
+"""
+    add_push!(repo::GitRepo, rmt::GitRemote, push_spec::String)
+
+Add a *push* refspec for the specified `rmt`. This refspec will contain
+information about which branch(es) to push to.
+
+# Example
+```julia
+julia> LibGit2.add_push!(repo, remote, "refs/heads/master");
+
+julia> remote = LibGit2.get(LibGit2.GitRemote, repo, branch);
+
+julia> LibGit2.push_refspecs(remote)
+String["refs/heads/master"]
+```
+
+!!! note
+    You may need to [`close`](@ref) and reopen the `GitRemote`
+    in question after updating its push refspecs in order for
+    the change to take effect and for calls to [`push`](@ref)
+    to work.
+"""
 function add_push!(repo::GitRepo, rmt::GitRemote, push_spec::String)
     @check ccall((:git_remote_add_push, :libgit2), Cint,
                  (Ptr{Void}, Cstring, Cstring), repo.ptr,
@@ -141,6 +177,13 @@ determine which remote branch(es) to push to.
 The keyword arguments are:
   * `force`: if `true`, a force-push will occur, disregarding conflicts.
   * `options`: determines the options for the push, e.g. which proxy headers to use.
+
+!!! note
+    You can add information about the push refspecs in two other ways: by setting
+    an option in the repository's `GitConfig` (with `push.default` as the key) or
+    by calling [`add_push!`](@ref). Otherwise you will need to explicity specify
+    a push refspec in the call to `push` for any effect, like so:
+    `LibGit2.push(repo, refspecs=["refs/heads/master"])`.
 """
 function push(rmt::GitRemote, refspecs::Vector{<:AbstractString};
               force::Bool = false, options::PushOptions = PushOptions())

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -206,6 +206,12 @@ mktempdir() do dir
                 LibGit2.set_remote_url(cache_repo, repo_url, remote="upstream")
                 remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
                 @test sprint(show, remote) == "GitRemote:\nRemote name: upstream url: $repo_url"
+                LibGit2.add_fetch!(repo, remote, "upstream")
+                @test LibGit2.fetch_refspecs(remote) == String["+refs/heads/*:refs/remotes/upstream/*"]
+                LibGit2.add_push!(repo, remote, "refs/heads/master")
+                close(remote)
+                remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
+                @test LibGit2.push_refspecs(remote) == String["refs/heads/master"]
                 close(remote)
 
                 remote = LibGit2.GitRemoteAnon(repo, repo_url)


### PR DESCRIPTION
This should let you set a push refspec and have `LibGit2.push` do things.