### PR TITLE
Add tests for internal fastforward merge methods

### DIFF
--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -619,6 +619,40 @@ mktempdir() do dir
         end
     end
 
+    # TO DO: add more tests for various merge
+    # preference options
+    @testset "Fastforward merges" begin
+        path = joinpath(dir, "Example.FF")
+        repo = LibGit2.clone(cache_repo, path)
+        try
+            oldhead = LibGit2.head_oid(repo)
+            LibGit2.branch!(repo, "branch/ff_a")
+            open(joinpath(LibGit2.path(repo),"ff_file1"),"w") do f
+                write(f, "111\n")
+            end
+            LibGit2.add!(repo, "ff_file1")
+            LibGit2.commit(repo, "add ff_file1")
+
+            open(joinpath(LibGit2.path(repo),"ff_file2"),"w") do f
+                write(f, "222\n")
+            end
+            LibGit2.add!(repo, "ff_file2")
+            LibGit2.commit(repo, "add ff_file2")
+            LibGit2.branch!(repo, "master")
+            # switch back, now try to ff-merge the changes
+            # from branch/a
+
+            upst_ann = LibGit2.GitAnnotated(repo, "branch/ff_a")
+            head_ann = LibGit2.GitAnnotated(repo, "master")
+
+            # ff merge them
+            @test LibGit2.merge!(repo, [upst_ann], true)
+            @test LibGit2.is_ancestor_of(string(oldhead), string(LibGit2.head_oid(repo)), repo)
+        finally
+            close(repo)
+        end
+    end
+
     @testset "Fetch from cache repository" begin
         repo = LibGit2.GitRepo(test_repo)
         try

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -624,6 +624,10 @@ mktempdir() do dir
     @testset "Fastforward merges" begin
         path = joinpath(dir, "Example.FF")
         repo = LibGit2.clone(cache_repo, path)
+        # need to set this for merges to succeed
+        cfg = LibGit2.GitConfig(repo)
+        LibGit2.set!(cfg, "user.name", "AAAA")
+        LibGit2.set!(cfg, "user.email", "BBBB@BBBB.COM")
         try
             oldhead = LibGit2.head_oid(repo)
             LibGit2.branch!(repo, "branch/ff_a")
@@ -647,6 +651,45 @@ mktempdir() do dir
 
             # ff merge them
             @test LibGit2.merge!(repo, [upst_ann], true)
+            @test LibGit2.is_ancestor_of(string(oldhead), string(LibGit2.head_oid(repo)), repo)
+        finally
+            close(repo)
+        end
+    end
+
+    @testset "Merges" begin
+        path = joinpath(dir, "Example.Merge")
+        repo = LibGit2.clone(cache_repo, path)
+        # need to set this for merges to succeed
+        cfg = LibGit2.GitConfig(repo)
+        LibGit2.set!(cfg, "user.name", "AAAA")
+        LibGit2.set!(cfg, "user.email", "BBBB@BBBB.COM")
+        try
+            oldhead = LibGit2.head_oid(repo)
+            LibGit2.branch!(repo, "branch/merge_a")
+            open(joinpath(LibGit2.path(repo),"file1"),"w") do f
+                write(f, "111\n")
+            end
+            LibGit2.add!(repo, "file1")
+            LibGit2.commit(repo, "add file1")
+
+            # switch back, add a commit, try to merge
+            # from branch/merge_a
+            LibGit2.branch!(repo, "master")
+
+            open(joinpath(LibGit2.path(repo), "file2"), "w") do f
+                write(f, "222\n")
+            end
+            LibGit2.add!(repo, "file2")
+            LibGit2.commit(repo, "add file2")
+
+            upst_ann = LibGit2.GitAnnotated(repo, "branch/merge_a")
+            head_ann = LibGit2.GitAnnotated(repo, "master")
+
+            # (fail to) merge them because we can't fastforward
+            @test !LibGit2.merge!(repo, [upst_ann], true)
+            # merge them now that we allow non-ff
+            @test LibGit2.merge!(repo, [upst_ann], false)
             @test LibGit2.is_ancestor_of(string(oldhead), string(LibGit2.head_oid(repo)), repo)
         finally
             close(repo)


### PR DESCRIPTION
Attempting to get at [this](https://codecov.io/gh/JuliaLang/julia/src/6659b59fee30232c77cefbba1848b958041f5c61/base/libgit2/merge.jl#L83) code.