### PR TITLE
RFC: Allow newline or semicolon in abstract and primitive defs

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1141,6 +1141,14 @@
     (begin0 (list 'type (if mut? 'true 'false) sig (parse-block s))
             (expect-end s word))))
 
+;; consume any number of line endings from a token stream
+(define (take-lineendings s)
+  (let ((nt (peek-token s)))
+    (if (or (newline? nt) (eqv? nt #\;))
+        (begin (take-token s)
+               (take-lineendings s))
+        s)))
+
 ;; parse expressions or blocks introduced by syntactic reserved words
 (define (parse-resword s word)
   (with-bindings
@@ -1271,7 +1279,7 @@
                 (syntax-deprecation s (string "abstract " (deparse spec))
                                     (string "abstract type " (deparse spec) " end")))
             (begin0 (list 'abstract spec)
-                    (if ty (expect-end s "abstract type"))))))
+                    (if ty (expect-end (take-lineendings s) "abstract type"))))))
        ((struct)
         (begin (take-token s)
                (parse-struct-def s #f word)))
@@ -1287,7 +1295,7 @@
                    (let* ((spec (with-space-sensitive (parse-subtype-spec s)))
                           (nb   (with-space-sensitive (parse-cond s))))
                      (begin0 (list 'bitstype nb spec)
-                             (expect-end s "primitive type"))))))
+                             (expect-end (take-lineendings s) "primitive type"))))))
        ;; deprecated type keywords
        ((type)
         ;; TODO fully deprecate post-0.6

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1065,3 +1065,17 @@ g21054(>:) = >:2
 # issue #21168
 @test expand(:(a.[1])) == Expr(:error, "invalid syntax a.[1]")
 @test expand(:(a.{1})) == Expr(:error, "invalid syntax a.{1}")
+
+# Issue #21225
+let abstr = parse("abstract type X end")
+    @test parse("abstract type X; end") == abstr
+    @test parse(string("abstract type X", ";"^5, " end")) == abstr
+    @test parse("abstract type X\nend") == abstr
+    @test parse(string("abstract type X", "\n"^5, "end")) == abstr
+end
+let prim = parse("primitive type X 8 end")
+    @test parse("primitive type X 8; end") == prim
+    @test parse(string("primitive type X 8", ";"^5, " end")) == prim
+    @test parse("primitive type X 8\nend") == prim
+    @test parse(string("primitive type X 8", "\n"^5, "end")) == prim
+end


### PR DESCRIPTION
Fixes #21225 

This puts an end to the silliness noted in the linked issue by allowing a newline or semicolon in `abstract type` and `primitive type` definitions. That is,
```julia
abstract type X end
abstract type X; end
abstract type X
end
```
are now all valid and equivalent.