### PR TITLE
document that srand() returns the passed RNG

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -220,7 +220,7 @@ end
 ## srand()
 
 """
-    srand([rng=GLOBAL_RNG], [seed])
+    srand([rng=GLOBAL_RNG], [seed]) -> rng
 
 Reseed the random number generator. If a `seed` is provided, the RNG will give a
 reproducible sequence of numbers, otherwise Julia will get entropy from the system. For

--- a/base/random.jl
+++ b/base/random.jl
@@ -221,12 +221,13 @@ end
 
 """
     srand([rng=GLOBAL_RNG], [seed]) -> rng
+    srand([rng=GLOBAL_RNG], filename, n=4) -> rng
 
 Reseed the random number generator. If a `seed` is provided, the RNG will give a
 reproducible sequence of numbers, otherwise Julia will get entropy from the system. For
 `MersenneTwister`, the `seed` may be a non-negative integer, a vector of `UInt32` integers
-or a filename, in which case the seed is read from a file. `RandomDevice` does not support
-seeding.
+or a filename, in which case the seed is read from a file (`4n` bytes are read from the file,
+where `n` is an optional argument). `RandomDevice` does not support seeding.
 """
 srand(r::MersenneTwister) = srand(r, make_seed())
 srand(r::MersenneTwister, n::Integer) = srand(r, make_seed(n))

--- a/test/random.jl
+++ b/test/random.jl
@@ -479,3 +479,18 @@ let seed = rand(UInt32, 10)
     resize!(seed, 4)
     @test r.seed != seed
 end
+
+# srand(rng, ...) returns rng (#21248)
+let g = Base.Random.GLOBAL_RNG,
+    m = MersenneTwister(0)
+    @test srand() === g
+    @test srand(rand(UInt)) === g
+    @test srand(rand(UInt32, rand(1:10))) === g
+    @test srand(@__FILE__) === g
+    @test srand(@__FILE__, rand(1:10)) === g
+    @test srand(m) === m
+    @test srand(m, rand(UInt)) === m
+    @test srand(m, rand(UInt32, rand(1:10))) === m
+    @test srand(m, rand(1:10)) === m
+    @test srand(m, @__FILE__, rand(1:10)) === m
+end


### PR DESCRIPTION
Till now this behavior was very useful as the shortest way to get a randomly seeded RNG was `r = srand(MersenneTwister())`. This could change in the future (cf. #16984), but I still think this will be a desirable feature (which was introduced in 68049d4b4478f738d68efd08275a57731a82becf, but not systematically).
Also, this PR documents the optional argument of `srand` when seeding from a file.