### PR TITLE
More fixes for non-1 arrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -124,7 +124,7 @@ julia> length(A)
 length(t::AbstractArray) = (@_inline_meta; prod(size(t)))
 _length(A::AbstractArray) = (@_inline_meta; prod(map(unsafe_length, indices(A)))) # circumvent missing size
 _length(A) = (@_inline_meta; length(A))
-endof(a::AbstractArray) = (@_inline_meta; length(a))
+endof(a::AbstractArray) = (@_inline_meta; last(linearindices(a)))
 first(a::AbstractArray) = a[first(eachindex(a))]
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -1040,26 +1040,30 @@ function =={T<:BitInteger}(a::Array{T,1}, b::Array{T,1})
         :memcmp, Int32, (Ptr{T}, Ptr{T}, UInt), a, b, sizeof(T) * len)
 end
 
-function reverse(A::AbstractVector, s=1, n=length(A))
+function reverse(A::AbstractVector, s=first(linearindices(A)), n=last(linearindices(A)))
     B = similar(A)
-    for i = 1:s-1
+    for i = first(linearindices(A)):s-1
         B[i] = A[i]
     end
     for i = s:n
         B[i] = A[n+s-i]
     end
-    for i = n+1:length(A)
+    for i = n+1:last(linearindices(A))
         B[i] = A[i]
     end
     return B
 end
-reverseind(a::AbstractVector, i::Integer) = length(a) + 1 - i
+function reverseind(a::AbstractVector, i::Integer)
+    li = linearindices(a)
+    first(li) + last(li) - i
+end
 
-function reverse!(v::AbstractVector, s=1, n=length(v))
+function reverse!(v::AbstractVector, s=first(linearindices(v)), n=last(linearindices(v)))
+    liv = linearindices(v)
     if n <= s  # empty case; ok
-    elseif !(1 ≤ s ≤ endof(v))
+    elseif !(first(liv) ≤ s ≤ last(liv))
         throw(BoundsError(v, s))
-    elseif !(1 ≤ n ≤ endof(v))
+    elseif !(first(liv) ≤ n ≤ last(liv))
         throw(BoundsError(v, n))
     end
     r = n

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -278,8 +278,18 @@ am = map(identity, a)
 
 # other functions
 v = OffsetArray(v0, (-3,))
+@test endof(v) == 1
 @test v ≈ v
 @test indices(v') === (Base.OneTo(1),-2:1)
+rv = reverse(v)
+@test indices(rv) == indices(v)
+@test rv[1] == v[-2]
+@test rv[0] == v[-1]
+@test rv[-1] == v[0]
+@test rv[-2] == v[1]
+cv = copy(v)
+@test reverse!(cv) == rv
+
 A = OffsetArray(rand(4,4), (-3,5))
 @test A ≈ A
 @test indices(A') === (6:9, -2:1)


### PR DESCRIPTION
The `endof` change is worthy of @nanosoldier `runbenchmarks(ALL, vs = :master)`.