### PR TITLE
improve error message for unescape_string

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -299,7 +299,8 @@ function unescape_string(io, s::AbstractString)
                     i = j
                 end
                 if k == 1
-                    throw(ArgumentError("\\x used with no following hex digits in $(repr(s))"))
+                    throw(ArgumentError("invalid $(m == 2 ? "hex (\\x)" :
+                                            "unicode (\\u)") escape sequence used in $(repr(s))"))
                 end
                 if m == 2 # \x escape sequence
                     write(io, UInt8(n))


### PR DESCRIPTION
Because
```julia
julia> unescape_string("\\U")
ERROR: ArgumentError: \x used with no following hex digits in "\\U"
```
just looks confusing.