### PR TITLE
Make codegen emit dereferenceability attributes

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5627,11 +5627,16 @@ static std::unique_ptr<Module> emit_function(
                     theArg = ghostValue(argType);
                 }
                 else if (llvmArgType->isAggregateType()) {
-                    theArg = mark_julia_slot(&*AI++, argType, NULL, tbaa_const); // this argument is by-pointer
+                    Argument *Arg = &*AI++;
+                    maybe_mark_argument_dereferenceable(Arg, argType);
+                    theArg = mark_julia_slot(Arg, argType, NULL, tbaa_const); // this argument is by-pointer
                     theArg.isimmutable = true;
                 }
                 else {
-                    theArg = mark_julia_type(&*AI++, isboxed, argType, &ctx, /*needsgcroot*/false);
+                    Argument *Arg = &*AI++;
+                    if (isboxed)
+                        maybe_mark_argument_dereferenceable(Arg, argType);
+                    theArg = mark_julia_type(Arg, isboxed, argType, &ctx, /*needsgcroot*/false);
                 }
             }
             else {


### PR DESCRIPTION
Consider for example the function

```julia
type foo
    a::Vector{Float64}
end
function bar(x::foo, n)
    for i = 1:1000
        for j = 1:n
            x.a[i] = i
        end
    end
end
```

Now, there's three loads in the inner loop:
 - x.a (the field reference)
 - a (the load of the array ptr)
 - a[i] (the load of the array value)

However, two of those loads have loop invariant addresses, so they
can be hoisted all the way out of the loop nest. However, without
this commit LLVM isn't actually allowed to do so. Since n could be
<= 0, there are valid executions in which the loads don't happen.
Naively, this means that hoisting the loads could introduce segfaults
that weren't there before (because the pointers could be invalid when
n <= 0). Now, in this partiuclar case, LLVM is smart enough to do at
least some form of loop versioning (one for n > 0 with hoisted loads,
and one regular case), but it doesn't always know how to do that. In
cache sensitive codes, the extra loads can easily kill performance.
With this commit, we tell LLVM that julia objects aren't generally invalid
pointers, so it's safe to speculatively dereference them. This allows
LLVM to perform the LICM without having to fear introducing extra segfaults.