### PR TITLE
Improve code generation for homogenous tuples of unknown length

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3014,8 +3014,8 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             jl_value_t *utt = jl_unwrap_unionall((jl_value_t*)stt);
             if (jl_is_tuple_type(utt) && is_tupletype_homogeneous(((jl_datatype_t*)utt)->types, true)) {
                 // For tuples, we can emit code even if we don't know the exact
-                // type (e.g. because we don't know the length). So long as all
-                // elements are the same and a leaf type.
+                // type (e.g. because we don't know the length). This is possible
+                // as long as we know that all elements are of the same (leaf) type.
                 jl_cgval_t strct = emit_expr(args[1], ctx);
                 if (strct.ispointer()) {
                     // Determine which was the type that was homogenous

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3010,6 +3010,33 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     }
                 }
             }
+        } else {
+            jl_value_t *utt = jl_unwrap_unionall((jl_value_t*)stt);
+            if (jl_is_tuple_type(utt) && is_tupletype_homogeneous(((jl_datatype_t*)utt)->types, true)) {
+                // For tuples, we can emit code even if we don't know the exact
+                // type (e.g. because we don't know the length). So long as all
+                // elements are the same and a leaf type.
+                jl_cgval_t strct = emit_expr(args[1], ctx);
+                if (strct.ispointer()) {
+                    // Determine which was the type that was homogenous
+                    jl_value_t *jt = jl_tparam0(utt);
+                    if (jl_is_vararg_type(jt))
+                        jt = jl_unwrap_vararg(jt);
+                    Value *vidx = emit_unbox(T_size, emit_expr(args[2], ctx), (jl_value_t*)jl_long_type);
+                    // This is not necessary for correctness, but allows to omit
+                    // the extra code for getting the length of the tuple
+                    if (!bounds_check_enabled(ctx)) {
+                        vidx = builder.CreateSub(vidx, ConstantInt::get(T_size, 1));
+                    } else {
+                        vidx = emit_bounds_check(strct, (jl_value_t*)stt, vidx,
+                            emit_datatype_nfields(emit_typeof_boxed(strct, ctx)), ctx);
+                    }
+                    Value *ptr = data_pointer(strct, ctx);
+                    *ret = typed_load(ptr, vidx, jt, ctx, strct.tbaa, false);
+                    JL_GC_POP();
+                    return true;
+                }
+            }
         }
     }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -627,7 +627,7 @@ static jl_cgval_t emit_pointerref(jl_cgval_t *argv, jl_codectx_t *ctx)
     Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
     assert(!isboxed);
     Value *thePtr = emit_unbox(ptrty, e, e.typ);
-    return typed_load(thePtr, im1, ety, ctx, tbaa_data, align_nb);
+    return typed_load(thePtr, im1, ety, ctx, tbaa_data, true, align_nb);
 }
 
 static jl_cgval_t emit_runtime_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)


### PR DESCRIPTION
E.g.:
```
mutable struct foo
    x::Int
end
mutable struct bar
    tup::NTuple{N, foo} where N
end
function f(b::bar)
    sum = 0
    for i = 1:2
        @inbounds sum += b.tup[i].x
    end
    sum
end
global x = bar((foo(1),foo(2)))
@benchmark f(x::bar)
```

Before:
```
julia> @benchmark f(x::bar)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     27.124 ns (0.00% GC)
  median time:      28.771 ns (0.00% GC)
  mean time:        29.864 ns (0.00% GC)
  maximum time:     116.762 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995
```

After:
```
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     10.531 ns (0.00% GC)
  median time:      10.559 ns (0.00% GC)
  mean time:        10.610 ns (0.00% GC)
  maximum time:     122.751 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
  time tolerance:   5.00%
  memory tolerance: 1.00%
```