### PR TITLE
fix #21271, codegen of typeassert involving `Tuple{Type{T}}`

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1023,7 +1023,7 @@ static void emit_typecheck(const jl_cgval_t &x, jl_value_t *type, const std::str
     //     return;
     // }
     Value *istype = emit_isa(x, type, &msg, ctx);
-    if (!isa<Constant>(istype)) {
+    if (!isa<ConstantInt>(istype)) {
         BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx->f);
         BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext, "pass");
         builder.CreateCondBr(istype, passBB, failBB);

--- a/test/core.jl
+++ b/test/core.jl
@@ -4792,3 +4792,7 @@ b21178(::F1,::F2) where {B1,B2,F1<:F21178{B1,<:Any},F2<:F21178{B2}} = F1,F2,B1,B
 a21172 = f21172(x) = 2x
 @test f21172(8) == 16
 @test a21172 === f21172
+
+# issue #21271
+f21271()::Tuple{Type{Int}, Type{Float64}} = (Int, Float64)
+@test_throws TypeError f21271()


### PR DESCRIPTION
`isa<Constant>` was catching icmp instructions with constant operands, which can happen with two leaf types with a non-empty intersection, i.e. `Tuple{DataType}` and `Tuple{Type{Int}}`.