### PR TITLE
fix jl_isa optimization

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -661,9 +661,7 @@ static jl_cgval_t emit_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
         return emit_runtime_pointerset(argv, ctx);
     if (!jl_is_datatype(ety))
         ety = (jl_value_t*)jl_any_type;
-    jl_value_t *xty = x.typ;
-    if (!jl_subtype(xty, ety))
-        emit_typecheck(x, ety, "pointerset: type mismatch in assign", ctx);
+    emit_typecheck(x, ety, "pointerset: type mismatch in assign", ctx);
 
     Value *idx = emit_unbox(T_size, i, (jl_value_t*)jl_long_type);
     Value *im1 = builder.CreateSub(idx, ConstantInt::get(T_size, 1));

--- a/test/core.jl
+++ b/test/core.jl
@@ -4792,3 +4792,9 @@ b21178(::F1,::F2) where {B1,B2,F1<:F21178{B1,<:Any},F2<:F21178{B2}} = F1,F2,B1,B
 a21172 = f21172(x) = 2x
 @test f21172(8) == 16
 @test a21172 === f21172
+
+# issue #21271
+f21271() = convert(Tuple{Type{Int}, Type{Float64}}, (Int, Float64))::Tuple{Type{Int}, Type{Float64}}
+f21271(x) = x::Tuple{Type{Int}, Type{Float64}}
+@test_throws TypeError f21271()
+@test_throws TypeError f21271((Int, Float64))


### PR DESCRIPTION
isa<Constant> was catching icmp instructions with constant operands, which can happen with two leaf types with a non-empty intersection, i.e. Tuple{DataType} and Tuple{Type{Int}}.
