### PR TITLE
Refactor null_safe_op to workaround codegen changes

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,7 @@ module Broadcast
 using Base.Cartesian
 using Base: linearindices, tail, OneTo, to_shape,
             _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache,
-            nullable_returntype, null_safe_eltype_op, hasvalue, isoperator
+            nullable_returntype, hasvalue, isoperator, null_safe_op
 import Base: broadcast, broadcast!
 export broadcast_getindex, broadcast_setindex!, dotview, @__dot__
 
@@ -283,6 +283,14 @@ eltypestuple(a) = (Base.@_pure_meta; Tuple{eltype(a)})
 eltypestuple(T::Type) = (Base.@_pure_meta; Tuple{Type{T}})
 eltypestuple(a, b...) = (Base.@_pure_meta; Tuple{eltypestuple(a).types..., eltypestuple(b...).types...})
 _broadcast_eltype(f, A, Bs...) = Base._return_type(f, eltypestuple(A, Bs...))
+
+typeeltypestuple(a) = (Base.@_pure_meta; Tuple{Type{eltype(a)}})
+typeeltypestuple(T::Type) = (Base.@_pure_meta; Tuple{Type{Type{T}}})
+typeeltypestuple(a, b...) = (Base.@_pure_meta; Tuple{typeeltypestuple(a).types..., typeeltypestuple(b...).types...})
+function null_safe_eltype_op(op, xs...)
+    Base.@_pure_meta
+    null_safe_op(op, typeeltypestuple(xs...))
+end
 
 # broadcast methods that dispatch on the type of the final container
 @inline function broadcast_c(f, ::Type{Array}, A, Bs...)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -279,16 +279,15 @@ end
     return C
 end
 
-eltypestuple(a) = (Base.@_pure_meta; Tuple{eltype(a)})
-eltypestuple(T::Type) = (Base.@_pure_meta; Tuple{Type{T}})
-eltypestuple(a, b...) = (Base.@_pure_meta; Tuple{eltypestuple(a).types..., eltypestuple(b...).types...})
+eltypestuple(a) = Tuple{eltype(a)}
+eltypestuple(T::Type) = Tuple{Type{T}}
+eltypestuple(a, b...) = Tuple{eltypestuple(a).types..., eltypestuple(b...).types...}
 _broadcast_eltype(f, A, Bs...) = Base._return_type(f, eltypestuple(A, Bs...))
 
-typeeltypestuple(a) = (Base.@_pure_meta; Tuple{Type{eltype(a)}})
-typeeltypestuple(T::Type) = (Base.@_pure_meta; Tuple{Type{Type{T}}})
-typeeltypestuple(a, b...) = (Base.@_pure_meta; Tuple{typeeltypestuple(a).types..., typeeltypestuple(b...).types...})
+typeeltypestuple(a) = Tuple{Type{eltype(a)}}
+typeeltypestuple(T::Type) = Tuple{Type{Type{T}}}
+typeeltypestuple(a, b...) = Tuple{typeeltypestuple(a).types..., typeeltypestuple(b...).types...}
 function null_safe_eltype_op(op, xs...)
-    Base.@_pure_meta
     null_safe_op(op, typeeltypestuple(xs...))
 end
 


### PR DESCRIPTION
There have been codegen / inference changes since #16961 was merged that result in substantial (~40x) regressions in trivial `Nullable` broadcasts.

See https://discourse.julialang.org/t/performance-of-dot-operator-on-nullables/3071 for a report of the regressions.

This PR works around those changes by combining all parameters for `null_safe_op` into a single `Type{<:Tuple}` argument, which avoids the splat of `(::Type{<:Tuple}).parameters` which had previously confounded codegen (and would not be eliminated even when the function is declared `@pure`.)

Since this is a performance only change it should go into 0.6.