### PR TITLE
Improve IPO-safety of TBAA information 

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2,9 +2,21 @@
 
 // utility procedures used in code generation
 
+static Instruction *aa_decorate(MDNode *tbaa, MDNode *invariant_group, Instruction *load_or_store)
+{
+    if (tbaa)
+        load_or_store->setMetadata( llvm::LLVMContext::MD_tbaa, tbaa );
+    if (invariant_group)
+        load_or_store->setMetadata( llvm::LLVMContext::MD_invariant_group, tbaa );
+    return load_or_store;
+}
+static Instruction *aa_decorate(aa_data aa, Instruction *load_or_store) {
+    return aa_decorate(aa.tbaa, aa.invariant_group, load_or_store);
+}
+
 static Instruction *tbaa_decorate(MDNode *md, Instruction *load_or_store)
 {
-    load_or_store->setMetadata( llvm::LLVMContext::MD_tbaa, md );
+    aa_decorate(md, nullptr, load_or_store);
     return load_or_store;
 }
 
@@ -1126,7 +1138,7 @@ static unsigned julia_alignment(Value* /*ptr*/, jl_value_t *jltype, unsigned ali
 static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value* dest = NULL, bool volatile_store = false);
 
 static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
-                             jl_codectx_t *ctx, MDNode *tbaa, unsigned alignment = 0)
+                             jl_codectx_t *ctx, aa_data aa, unsigned alignment = 0)
 {
     bool isboxed;
     Type *elty = julia_type_to_llvm(jltype, &isboxed);
@@ -1148,12 +1160,7 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
     //else {
         Instruction *load = builder.CreateAlignedLoad(data, isboxed ?
             alignment : julia_alignment(data, jltype, alignment), false);
-        if (tbaa) {
-            elt = tbaa_decorate(tbaa, load);
-        }
-        else {
-            elt = load;
-        }
+        elt = aa_decorate(aa, load);
         if (isboxed) {
             null_pointer_check(elt, ctx);
         }
@@ -1162,7 +1169,7 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
 }
 
 static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
-                        jl_value_t *jltype, jl_codectx_t *ctx, MDNode *tbaa,
+                        jl_value_t *jltype, jl_codectx_t *ctx, aa_data aa,
                         Value *parent,  // for the write barrier, NULL if no barrier needed
                         unsigned alignment = 0, bool root_box = true) // if the value to store needs a box, should we root it ?
 {
@@ -1185,8 +1192,7 @@ static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
         data = ptr;
     Instruction *store = builder.CreateAlignedStore(r, builder.CreateGEP(data,
         idx_0based), isboxed ? alignment : julia_alignment(r, jltype, alignment));
-    if (tbaa)
-        tbaa_decorate(tbaa, store);
+    aa_decorate(aa, store);
 }
 
 // --- convert boolean value to julia ---
@@ -1286,7 +1292,7 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct,
     if (strct.ispointer()) { // boxed or stack
         if (is_datatype_all_pointers(stt)) {
             idx = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
-            Value *fld = tbaa_decorate(strct.tbaa, builder.CreateLoad(
+            Value *fld = aa_decorate(strct.aa, builder.CreateLoad(
                         builder.CreateGEP(data_pointer(strct, ctx), idx)));
             if ((unsigned)stt->ninitialized != nfields)
                 null_pointer_check(fld, ctx);
@@ -1302,12 +1308,12 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct,
                 // just compute the pointer and let user load it when necessary
                 Type *fty = julia_type_to_llvm(jt);
                 Value *addr = builder.CreateGEP(builder.CreatePointerCast(ptr, PointerType::get(fty,0)), idx);
-                *ret = mark_julia_slot(addr, jt, NULL, strct.tbaa);
+                *ret = mark_julia_slot(addr, jt, NULL, strct.aa);
                 ret->gcroot = strct.gcroot;
                 ret->isimmutable = strct.isimmutable;
                 return true;
             }
-            *ret = typed_load(ptr, idx, jt, ctx, strct.tbaa);
+            *ret = typed_load(ptr, idx, jt, ctx, strct.aa);
             return true;
         }
         else if (strct.isboxed) {
@@ -1363,14 +1369,14 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         Value *llvm_idx = ConstantInt::get(T_size, jl_field_offset(jt, idx));
         addr = builder.CreateGEP(ptr, llvm_idx);
         if (jl_field_isptr(jt, idx)) {
-            Value *fldv = tbaa_decorate(strct.tbaa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
+            Value *fldv = aa_decorate(strct.aa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
             if (idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
             return mark_julia_type(fldv, true, jfty, ctx, strct.gcroot || !strct.isimmutable);
         }
         else if (!jt->mutabl) {
             // just compute the pointer and let user load it when necessary
-            jl_cgval_t fieldval = mark_julia_slot(addr, jfty, NULL, strct.tbaa);
+            jl_cgval_t fieldval = mark_julia_slot(addr, jfty, NULL, strct.aa);
             fieldval.isimmutable = strct.isimmutable;
             fieldval.gcroot = strct.gcroot;
             return fieldval;
@@ -1378,7 +1384,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         int align = jl_field_offset(jt, idx);
         align |= 16;
         align &= -align;
-        return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, strct.tbaa, align);
+        return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, strct.aa, align);
     }
     else if (isa<UndefValue>(strct.V)) {
         return jl_cgval_t();
@@ -2125,7 +2131,7 @@ static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t id
         jl_value_t *jfty = jl_svecref(sty->types, idx0);
         if (jl_field_isptr(sty, idx0)) {
             Value *r = boxed(rhs, ctx, false); // don't need a temporary gcroot since it'll be rooted by strct (but should ensure strct is rooted via mark_gc_use)
-            tbaa_decorate(strct.tbaa, builder.CreateStore(r, emit_bitcast(addr, T_ppjlvalue)));
+            aa_decorate(strct.aa, builder.CreateStore(r, emit_bitcast(addr, T_ppjlvalue)));
             if (wb && strct.isboxed) emit_checked_write_barrier(ctx, boxed(strct, ctx), r);
             mark_gc_use(strct);
         }
@@ -2134,7 +2140,7 @@ static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t id
             align |= 16;
             align &= -align;
             typed_store(addr, ConstantInt::get(T_size, 0), rhs, jfty, ctx,
-                strct.tbaa, data_pointer(strct, ctx, T_pjlvalue), align);
+                strct.aa, data_pointer(strct, ctx, T_pjlvalue), align);
         }
     }
     else {
@@ -2231,7 +2237,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
         }
         for(size_t i=j; i < nf; i++) {
             if (jl_field_isptr(sty, i)) {
-                tbaa_decorate(strctinfo.tbaa, builder.CreateStore(
+                aa_decorate(strctinfo.aa, builder.CreateStore(
                         V_null,
                         builder.CreatePointerCast(
                             builder.CreateGEP(emit_bitcast(strct, T_pint8),

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -269,6 +269,7 @@ static MDNode *tbaa_arrayptr;       // The pointer inside a jl_array_t
 static MDNode *tbaa_arraysize;      // A size in a jl_array_t
 static MDNode *tbaa_arraylen;       // The len in a jl_array_t
 static MDNode *tbaa_arrayflags;     // The flags in a jl_array_t
+static MDNode *tbaa_array_owner_ptr;// The owner pointer in an nd array (1-d array owner ptrs are tbaa_const)
 static MDNode *tbaa_const;      // Memory that is immutable by the time LLVM can see it
 
 // Basic DITypes
@@ -2883,7 +2884,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                             // load owner pointer
                             Value *own_ptr;
                             if (jl_is_long(ndp)) {
-                                own_ptr = tbaa_decorate(tbaa_const, builder.CreateLoad(
+                                own_ptr = tbaa_decorate(nd == 1 ? tbaa_array_owner_ptr : tbaa_const, builder.CreateLoad(
                                     emit_bitcast(
                                         builder.CreateConstGEP1_32(
                                             emit_bitcast(aryv, T_pint8),
@@ -6318,6 +6319,7 @@ static void init_julia_llvm_meta(void)
     tbaa_arraysize = tbaa_make_child("jtbaa_arraysize", tbaa_array_scalar).first;
     tbaa_arraylen = tbaa_make_child("jtbaa_arraylen", tbaa_array_scalar).first;
     tbaa_arrayflags = tbaa_make_child("jtbaa_arrayflags", tbaa_array_scalar).first;
+    tbaa_array_owner_ptr = tbaa_make_child("jtbaa_array_owner_ptr", tbaa_array_scalar).first;
     tbaa_const = tbaa_make_child("jtbaa_const", nullptr, true).first;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -437,7 +437,7 @@ static bool isbits_spec(jl_value_t *jt, bool allow_singleton = true)
 // metadata tracking for a llvm Value* during codegen
 struct aa_data {
     MDNode *tbaa; // The related tbaa node. Non-NULL iff this holds an address.
-    MDNode *invariant_group; // The LLVM invariant group for this pointer if applicable  
+    MDNode *invariant_group; // The LLVM invariant group for this pointer if applicable
     aa_data() : tbaa(nullptr), invariant_group(nullptr) {}
     aa_data(MDNode *tbaa, MDNode *invariant_group) : tbaa(tbaa), invariant_group(invariant_group) {}
 };

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -714,7 +714,6 @@ static inline jl_cgval_t mark_julia_const(jl_value_t *jv)
 static inline jl_cgval_t mark_julia_slot(Value *v, jl_value_t *typ, Value *tindex, MDNode *tbaa)
 {
     // this enables lazy-copying of immutable values and stack or argument slots
-    assert(tbaa);
     jl_cgval_t tagval(v, NULL, false, typ, tindex);
     tagval.tbaa = tbaa;
     tagval.isimmutable = true;
@@ -4672,7 +4671,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
                     arg_box = arg_v;
                 }
                 else if (et->isAggregateType()) {
-                    arg_box = boxed(mark_julia_slot(arg_v, jt, NULL, tbaa_const), &ctx2, false);
+                    arg_box = boxed(mark_julia_slot(arg_v, jt, NULL, NULL), &ctx2, false);
                 }
                 else {
                     assert(at == et);
@@ -5596,7 +5595,7 @@ static std::unique_ptr<Module> emit_function(
                     theArg = ghostValue(argType);
                 }
                 else if (llvmArgType->isAggregateType()) {
-                    theArg = mark_julia_slot(&*AI++, argType, NULL, tbaa_const); // this argument is by-pointer
+                    theArg = mark_julia_slot(&*AI++, argType, NULL, NULL); // this argument is by-pointer
                     theArg.isimmutable = true;
                 }
                 else {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -435,6 +435,13 @@ static bool isbits_spec(jl_value_t *jt, bool allow_singleton = true)
 }
 
 // metadata tracking for a llvm Value* during codegen
+struct aa_data {
+    MDNode *tbaa; // The related tbaa node. Non-NULL iff this holds an address.
+    MDNode *invariant_group; // The LLVM invariant group for this pointer if applicable  
+    aa_data() : tbaa(nullptr), invariant_group(nullptr) {}
+    aa_data(MDNode *tbaa, MDNode *invariant_group) : tbaa(tbaa), invariant_group(invariant_group) {}
+};
+
 struct jl_cgval_t {
     Value *V; // may be of type T* or T, or set to NULL if ghost (or if the value has not been initialized yet, for a variable definition)
     Value *TIndex; // if `V` is an unboxed (tagged) Union described by `typ`, this gives the DataType index (1-based, small int) as an i8
@@ -444,11 +451,11 @@ struct jl_cgval_t {
     bool isboxed; // whether this value is a jl_value_t* allocated on the heap with the right type tag
     bool isghost; // whether this value is "ghost"
     bool isimmutable; // V points to something that is definitely immutable (e.g. single-assignment, but including memory)
-    MDNode *tbaa; // The related tbaa node. Non-NULL iff this holds an address.
+    aa_data aa;
     bool ispointer() const
     {
         // whether this value is compatible with `data_pointer`
-        return tbaa != nullptr;
+        return aa.tbaa != nullptr || aa.invariant_group != nullptr;
     }
     //bool isvalue() const
     //{
@@ -464,9 +471,10 @@ struct jl_cgval_t {
         isboxed(isboxed),
         isghost(false),
         isimmutable(isboxed && jl_is_immutable_datatype(typ)),
-        tbaa(isboxed ? (jl_is_leaf_type(typ) ?
+        aa{isboxed ? (jl_is_leaf_type(typ) ?
                         (jl_is_mutable(typ) ? tbaa_mutab : tbaa_immut) :
-                        tbaa_value) : nullptr)
+                        tbaa_value) : nullptr,
+           nullptr}
     {
         assert(!(isboxed && TIndex != NULL));
         assert(TIndex == NULL || TIndex->getType() == T_int8);
@@ -480,7 +488,7 @@ struct jl_cgval_t {
         isboxed(false),
         isghost(true),
         isimmutable(true),
-        tbaa(nullptr)
+        aa{nullptr, nullptr}
     {
         assert(jl_is_datatype(typ));
         assert(constant);
@@ -494,7 +502,7 @@ struct jl_cgval_t {
         isboxed(v.isboxed),
         isghost(v.isghost),
         isimmutable(v.isimmutable),
-        tbaa(v.tbaa)
+        aa(v.aa)
     {
         // this constructor expects we had a badly or equivalently typed version
         // make sure we aren't discarding the actual type information
@@ -514,7 +522,7 @@ struct jl_cgval_t {
         isboxed(false),
         isghost(true),
         isimmutable(true),
-        tbaa(nullptr)
+        aa{nullptr, nullptr}
     {
     }
 };
@@ -710,14 +718,19 @@ static inline jl_cgval_t mark_julia_const(jl_value_t *jv)
     return constant;
 }
 
-
-static inline jl_cgval_t mark_julia_slot(Value *v, jl_value_t *typ, Value *tindex, MDNode *tbaa)
+static inline jl_cgval_t mark_julia_slot(Value *v, jl_value_t *typ, Value *tindex, aa_data aa)
 {
     // this enables lazy-copying of immutable values and stack or argument slots
+    assert(aa.tbaa || aa.invariant_group);
     jl_cgval_t tagval(v, NULL, false, typ, tindex);
-    tagval.tbaa = tbaa;
+    tagval.aa = aa;
     tagval.isimmutable = true;
     return tagval;
+}
+
+static inline jl_cgval_t mark_julia_slot(Value *v, jl_value_t *typ, Value *tindex, MDNode *tbaa, MDNode *invariant_group = NULL)
+{
+    return mark_julia_slot(v, typ, tindex, aa_data{tbaa, invariant_group});
 }
 
 static inline jl_cgval_t mark_julia_type(Value *v, bool isboxed, jl_value_t *typ, jl_codectx_t *ctx, bool needsroot = true)
@@ -1018,22 +1031,22 @@ static jl_cgval_t convert_julia_type(const jl_cgval_t &v, jl_value_t *typ, jl_co
                     else {
                         Value *isboxv = builder.CreateIsNotNull(boxv);
                         Value *slotv;
-                        MDNode *tbaa;
+                        aa_data aa;
                         bool isimmutable;
                         if (v.ispointer()) {
                             slotv = v.V;
-                            tbaa = v.tbaa;
+                            aa = v.aa;
                             isimmutable = v.isimmutable;
                         }
                         else {
                             slotv = emit_static_alloca(v.V->getType());
                             builder.CreateStore(v.V, slotv);
-                            tbaa = tbaa_stack;
+                            aa = aa_data{tbaa_stack, nullptr};
                             isimmutable = true;
                         }
                         slotv = builder.CreateSelect(isboxv, boxv, emit_bitcast(slotv, boxv->getType()));
                         jl_cgval_t newv = jl_cgval_t(slotv, froot, false, typ, new_tindex);
-                        newv.tbaa = tbaa;
+                        newv.aa = aa;
                         newv.isimmutable = isimmutable;
                         return newv;
                     }
@@ -1055,7 +1068,7 @@ static jl_cgval_t convert_julia_type(const jl_cgval_t &v, jl_value_t *typ, jl_co
                     Value *slotv = emit_static_alloca(v.V->getType());
                     builder.CreateStore(v.V, slotv);
                     jl_cgval_t newv = jl_cgval_t(slotv, NULL, false, typ, new_tindex);
-                    newv.tbaa = tbaa_stack;
+                    newv.aa = aa_data{tbaa_stack, nullptr};
                     newv.isimmutable = true;
                     return newv;
                 }
@@ -2502,8 +2515,8 @@ static Value *emit_bits_compare(const jl_cgval_t &arg1, const jl_cgval_t &arg2, 
                 if (type_is_ghost(fld1->getType()->getPointerElementType()))
                     continue;
                 subAns = emit_bits_compare(
-                        mark_julia_slot(fld1, fldty, NULL, arg1.tbaa),
-                        mark_julia_slot(fld2, fldty, NULL, arg2.tbaa),
+                        mark_julia_slot(fld1, fldty, NULL, arg1.aa),
+                        mark_julia_slot(fld2, fldty, NULL, arg2.aa),
                         ctx);
                 answer = builder.CreateAnd(answer, subAns);
             }
@@ -2829,7 +2842,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                     }
                     else {
                         *ret = typed_load(emit_arrayptr(ary, args[1], ctx), idx, ety, ctx,
-                            jl_array_store_unboxed(ety) ? tbaa_arraybuf : tbaa_ptrarraybuf);
+                            aa_data{jl_array_store_unboxed(ety) ? tbaa_arraybuf : tbaa_ptrarraybuf, nullptr});
                     }
                     JL_GC_POP();
                     return true;
@@ -2908,7 +2921,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
                             data_owner->addIncoming(own_ptr, ownedBB);
                         }
                         typed_store(emit_arrayptr(ary,args[1],ctx), idx, v,
-                                    ety, ctx, !isboxed ? tbaa_arraybuf : tbaa_ptrarraybuf, data_owner, 0,
+                                    ety, ctx, aa_data{!isboxed ? tbaa_arraybuf : tbaa_ptrarraybuf, nullptr}, data_owner, 0,
                                     false); // don't need to root the box if we had to make one since it's being stored in the array immediatly
                     }
                     *ret = ary;
@@ -3142,7 +3155,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
             Value *ptr = data_pointer(strct, ctx, T_pint8);
             Value *llvm_idx = ConstantInt::get(T_size, offs);
             Value *addr = builder.CreateGEP(ptr, llvm_idx);
-            Value *fldv = tbaa_decorate(strct.tbaa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
+            Value *fldv = aa_decorate(strct.aa, builder.CreateLoad(emit_bitcast(addr, T_ppjlvalue)));
             Value *isdef = builder.CreateICmpNE(fldv, V_null);
             *ret = mark_julia_type(isdef, false, jl_bool_type, ctx);
         }
@@ -3870,7 +3883,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
                 }
             }
             else {
-                MDNode *tbaa = rval_info.tbaa;
+                MDNode *tbaa = rval_info.aa.tbaa;
                 // the memcpy intrinsic does not allow to specify different alias tags
                 // for the load part (x.tbaa) and the store part (tbaa_stack).
                 // since the tbaa lattice has to be a tree we have unfortunately
@@ -4653,6 +4666,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
             /*InsertBefore*/ctx2.ptlsStates);
         if (cc == jl_returninfo_t::SRet || cc == jl_returninfo_t::Union)
             ++AI;
+        MDNode *invariant_group = llvm::MDNode::getDistinct(jl_LLVMContext, {});
         for (size_t i = 0; i < nargs + 1; i++) {
             jl_value_t *jt = jl_nth_slot_type(lam->specTypes, i);
             bool isboxed;
@@ -4671,7 +4685,8 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
                     arg_box = arg_v;
                 }
                 else if (et->isAggregateType()) {
-                    arg_box = boxed(mark_julia_slot(arg_v, jt, NULL, NULL), &ctx2, false);
+                    arg_v = builder.CreateInvariantGroupBarrier(arg_v);
+                    arg_box = boxed(mark_julia_slot(arg_v, jt, NULL, NULL, invariant_group), &ctx2, false);
                 }
                 else {
                     assert(at == et);
@@ -5508,7 +5523,7 @@ static std::unique_ptr<Module> emit_function(
                 AllocaInst *lv = emit_static_alloca(T_int8, &ctx);
                 lv->setName(jl_symbol_name(s));
                 varinfo.pTIndex = lv;
-                varinfo.value.tbaa = NULL;
+                varinfo.value.aa = aa_data{nullptr, nullptr};
                 varinfo.value.isboxed = false;
                 varinfo.value.isimmutable = true;
             }
@@ -5569,6 +5584,7 @@ static std::unique_ptr<Module> emit_function(
     }
 
     // step 9. move args into local variables
+    MDNode *invariant_group = llvm::MDNode::getDistinct(jl_LLVMContext, {});
     Function::arg_iterator AI = f->arg_begin();
     if (ctx.has_sret)
         AI++; // skip sret slot
@@ -5595,7 +5611,9 @@ static std::unique_ptr<Module> emit_function(
                     theArg = ghostValue(argType);
                 }
                 else if (llvmArgType->isAggregateType()) {
-                    theArg = mark_julia_slot(&*AI++, argType, NULL, NULL); // this argument is by-pointer
+	            Argument *Arg = &*AI++;
+                    Value *Arg2 = builder.CreateInvariantGroupBarrier(Arg);
+                    theArg = mark_julia_slot(Arg2, argType, NULL, NULL, invariant_group); // this argument is by-pointer
                     theArg.isimmutable = true;
                 }
                 else {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -321,9 +321,9 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
 
     Value *unboxed = NULL;
     if (to == T_int1)
-        unboxed = builder.CreateTrunc(tbaa_decorate(x.tbaa, builder.CreateLoad(p)), T_int1);
+        unboxed = builder.CreateTrunc(aa_decorate(x.aa, builder.CreateLoad(p)), T_int1);
     else if (jt == (jl_value_t*)jl_bool_type)
-        unboxed = builder.CreateZExt(builder.CreateTrunc(tbaa_decorate(x.tbaa, builder.CreateLoad(p)), T_int1), to);
+        unboxed = builder.CreateZExt(builder.CreateTrunc(aa_decorate(x.aa, builder.CreateLoad(p)), T_int1), to);
     if (unboxed) {
         if (!dest)
             return unboxed;
@@ -346,7 +346,7 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
     if (dest) {
         // callers using the dest argument only use it for a stack slot for now
         alignment = 0;
-        MDNode *tbaa = x.tbaa;
+        MDNode *tbaa = x.aa.tbaa;
         // the memcpy intrinsic does not allow to specify different alias tags
         // for the load part (x.tbaa) and the store part (tbaa_stack).
         // since the tbaa lattice has to be a tree we have unfortunately
@@ -362,7 +362,7 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
             load = builder.CreateAlignedLoad(p, alignment);
         else
             load = builder.CreateLoad(p);
-        return tbaa_decorate(x.tbaa, load);
+        return aa_decorate(x.aa, load);
     }
 }
 
@@ -444,7 +444,7 @@ static jl_cgval_t generic_bitcast(const jl_cgval_t *argv, jl_codectx_t *ctx)
         // but if the v.typ is not well known, use llvmt
         if (isboxed)
             vxt = llvmt;
-        vx = tbaa_decorate(v.tbaa, builder.CreateLoad(data_pointer(v, ctx,
+        vx = aa_decorate(v.aa, builder.CreateLoad(data_pointer(v, ctx,
                                                                    vxt == T_int1 ? T_pint8 : vxt->getPointerTo())));
     }
 
@@ -629,7 +629,7 @@ static jl_cgval_t emit_pointerref(jl_cgval_t *argv, jl_codectx_t *ctx)
     Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
     assert(!isboxed);
     Value *thePtr = emit_unbox(ptrty, e, e.typ);
-    return typed_load(thePtr, im1, ety, ctx, tbaa_data, align_nb);
+    return typed_load(thePtr, im1, ety, ctx, aa_data{tbaa_data, nullptr}, align_nb);
 }
 
 static jl_cgval_t emit_runtime_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
@@ -686,7 +686,7 @@ static jl_cgval_t emit_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
         Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
         assert(!isboxed);
         thePtr = emit_unbox(ptrty, e, e.typ);
-        typed_store(thePtr, im1, x, ety, ctx, tbaa_data, NULL, align_nb);
+        typed_store(thePtr, im1, x, ety, ctx, aa_data{tbaa_data, nullptr}, NULL, align_nb);
     }
     return mark_julia_type(thePtr, false, aty, ctx);
 }


### PR DESCRIPTION
I've been experimenting with enabling some IPO passes on our generated code.
Unfortunately at the moment, we're seeing some pretty major miscompiles from
code like the following:

```
define @foo() {
%local = alloca
store %local, !tbaa tbaa_stack
call @bar(%local)
}
define @bar(%arg) {
load %arg, !tbaa tbaa_const
}
```

Now, in the absence of IPO, this IR is mostly fine. We don't modify %arg during
the course of bar and don't otherwise reference it. However, once IPO comes into
play, the above IR is actually illegal, because the %local in foo and the
%arg in %bar alias, but have different TBAA information. Because of this,
LLVM can assume that they don't alias (even if it's other alias analyses tell
it that they must alias) and will happily replace the load value with undef
to punish us for our subversive behavior.

LLVM is not entirely incorrect here. The constant flag in TBAA is meant to apply
only to data that is globally constant (e.g. because it was initialized by the dynamic
library loader).

To please LLVM here, we need to stop annotating tbaa_const on function arguments.
However, doing so without coming up with some replacement would be quite bad for performance,
because LLVM would no longer be able to optimize these values as aggressively. So here's the
replacement:
```
define @bar(%arg) {
%arg2 = @llvm.invariant.group.barrier(%arg)
load %arg2, !invariant.group !0
}
```
The invariant group allows LLVM to assume that any load from that pointer with the annotated
inariant group loads the same value, so in particular, it's allowed to fold:
```
define @bar(%arg) {
%arg2 = @llvm.invariant.group.barrier(%arg)
load %arg2, !invariant.group !0
call @external()
load %arg2, !invariant.group !0
}
```
by removing the second load.