### PR TITLE
RFC: Performance improvement for Diagonal' * Vector|Matrix

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -225,6 +225,16 @@ A_mul_B!(A::AbstractMatrix,B::Diagonal)  = scale!(A,B.diag)
 A_mul_Bt!(A::AbstractMatrix,B::Diagonal) = scale!(A,B.diag)
 A_mul_Bc!(A::AbstractMatrix,B::Diagonal) = scale!(A,conj(B.diag))
 
+# Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
+A_mul_B!(out::AbstractVector, A::Diagonal, in::AbstractVector) = out .= A.diag .* in
+Ac_mul_B!(out::AbstractVector, A::Diagonal, in::AbstractVector) = out .= ctranspose.(A.diag) .* in
+At_mul_B!(out::AbstractVector, A::Diagonal, in::AbstractVector) = out .= transpose.(A.diag) .* in
+
+A_mul_B!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= A.diag .* in
+Ac_mul_B!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= ctranspose.(A.diag) .* in
+At_mul_B!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= transpose.(A.diag) .* in
+
+
 /(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag)
 function A_ldiv_B!{T}(D::Diagonal{T}, v::AbstractVector{T})
     if length(v) != length(D.diag)

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -137,6 +137,17 @@ srand(1)
         #division of two Diagonals
         @test D/D2 ≈ Diagonal(D.diag./D2.diag)
         @test D\D2 ≈ Diagonal(D2.diag./D.diag)
+
+        # Performance specialisations for A*_mul_B!
+        vv = similar(v)
+        @test (r = full(D) * v   ; A_mul_B!(vv, D, v)  ≈ r ≈ vv)
+        @test (r = full(D)' * v  ; Ac_mul_B!(vv, D, v) ≈ r ≈ vv)
+        @test (r = full(D).' * v ; At_mul_B!(vv, D, v) ≈ r ≈ vv)
+
+        UU = similar(U)
+        @test (r = full(D) * U   ; A_mul_B!(UU, D, U) ≈ r ≈ UU)
+        @test (r = full(D)' * U  ; Ac_mul_B!(UU, D, U) ≈ r ≈ UU)
+        @test (r = full(D).' * U ; At_mul_B!(UU, D, U) ≈ r ≈ UU)
     end
     @testset "triu/tril" begin
         @test istriu(D)
@@ -177,6 +188,9 @@ srand(1)
             @test Array(conj(D)) ≈ conj(DM)
             @test ctranspose(D) == conj(D)
         end
+        # Translates to Ac/t_mul_B, which is specialized after issue 21286
+        @test(D' * v == conj(D) * v)
+        @test(D.' * v == D * v)
     end
 
     #logdet
@@ -315,6 +329,10 @@ end
     @test Dherm.' == Diagonal([[1 1-im; 1+im 1], [1 1-im; 1+im 1]])
     @test Dsym' == Diagonal([[1 1-im; 1-im 1], [1 1-im; 1-im 1]])
     @test Dsym.' == Dsym
+
+    v = [[1, 2], [3, 4]]
+    @test Dherm' * v == Dherm * v
+    @test D.' * v == [[7, 10], [15, 22]]
 
     @test issymmetric(D) == false
     @test issymmetric(Dherm) == false


### PR DESCRIPTION
Added tests
Only addresses diagonal part of JuliaLang/LinearAlgebra.jl#418, not sparse matrices

```julia
julia> include("test.jl")
  0.000014 seconds (6 allocations: 78.359 KiB)
  0.000012 seconds (6 allocations: 78.359 KiB)
  0.000012 seconds (6 allocations: 78.359 KiB)
```
from
```julia
begin
	D = Diagonal(randn(10000))
	v = randn(10000)
	@time D * v
	@time D' * v
	@time D.' * v
end
```
