### PR TITLE
Removing frames from a `StackTrace` by source `Module`.

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -190,6 +190,16 @@ function remove_frames!(stack::StackTrace, names::Vector{Symbol})
     return stack
 end
 
+"""
+    remove_frames!(stack::StackTrace, m::Module)
+
+Returns the `StackTrace` with all `StackFrame`s from the provided `Module` removed.
+"""
+function remove_frames!(stack::StackTrace, m::Module)
+    filter!(f -> !from(f, m), stack)
+    return stack
+end
+
 function show_spec_linfo(io::IO, frame::StackFrame)
     if isnull(frame.linfo)
         if frame.func === empty_sym
@@ -224,6 +234,23 @@ function show(io::IO, frame::StackFrame; full_path::Bool=false)
     if frame.inlined
         print(io, " [inlined]")
     end
+end
+
+"""
+    from(frame::StackFrame, filter_mod::Module) -> Bool
+
+Returns whether the `frame` is from the provided `Module`
+"""
+function from(frame::StackFrame, m::Module)
+    finfo = frame.linfo
+    result = false
+
+    if !isnull(finfo)
+        frame_m = get(finfo).def.module
+        result = module_name(frame_m) === module_name(m)
+    end
+
+    return result
 end
 
 end

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -130,3 +130,15 @@ let st = stacktrace(empty!(backtrace()))
     @test isempty(st)
     @test isa(st, StackTrace)
 end
+
+module StackTracesTestMod
+    unfiltered_stacktrace() = stacktrace()
+    filtered_stacktrace() = StackTraces.remove_frames!(stacktrace(), StackTracesTestMod)
+end
+
+# Test that `removes_frames!` can correctly remove frames from withing the module
+trace = StackTracesTestMod.unfiltered_stacktrace()
+@test contains(string(trace), "unfiltered_stacktrace")
+
+trace = StackTracesTestMod.filtered_stacktrace()
+@test !contains(string(trace), "filtered_stacktrace")


### PR DESCRIPTION
Finding and removing `StackFrame`s from `StackTrace`s based on source `Module`.

* `StackTraces.remove_frames!(::StackTrace, ::Module)` for removing `StackFrame`s from a given `Module`.
* `StackTraces.from(::StackFrame, ::Module) -> Bool` tests if the `StackFrame` is from the `Module`.