### PR TITLE
fix #21314, `close` on a SubArray-based IOBuffer

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -4,7 +4,7 @@
 
 # Stateful string
 mutable struct AbstractIOBuffer{T<:AbstractVector{UInt8}} <: IO
-    data::T # T should support: getindex, setindex!, length, copy!, resize!, and T()
+    data::T # T should support: getindex, setindex!, length, copy!, and resize!
     readable::Bool
     writable::Bool
     seekable::Bool # if not seekable, implementation is free to destroy (compact) past read data
@@ -251,8 +251,6 @@ eof(io::AbstractIOBuffer) = (io.ptr-1 == io.size)
     io.mark = -1
     if io.writable
         resize!(io.data, 0)
-    else
-        io.data = T()
     end
     nothing
 end

--- a/test/base64.jl
+++ b/test/base64.jl
@@ -41,3 +41,6 @@ ipipe = Base64DecodePipe(IOBuffer(string(encodedMaxLine76[1:end-2],"==")))
 # Test incorrect format
 ipipe = Base64DecodePipe(IOBuffer(encodedMaxLine76[1:end-3]))
 @test_throws ArgumentError readstring(ipipe)
+
+# issue #21314
+@test base64decode(chomp("test")) == base64decode("test")


### PR DESCRIPTION
`SubArray` doesn't have a 0-arg constructor. I guess the old version of the code wanted to unreference the data vector, which is nice, but it also meant allocating a new object just to close something, which doesn't seem ideal either.