### PR TITLE
Fix #21325, use special version of eltype

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -280,8 +280,8 @@ end
     return C
 end
 
-maptuple(f) = Tuple{}
-maptuple(f, a, b...) = Tuple{f(a), maptuple(f, b...).types...}
+maptoTuple(f) = Tuple{}
+maptoTuple(f, a, b...) = Tuple{f(a), maptoTuple(f, b...).types...}
 
 # An element type satisfying for all A:
 # broadcast_getindex(
@@ -301,9 +301,9 @@ _unsafe_get_eltype(x) = typeof(x)
 
 # Inferred eltype of result of broadcast(f, xs...)
 _broadcast_eltype(f, A, As...) =
-    Base._return_type(f, maptuple(_broadcast_getindex_eltype, A, As...))
+    Base._return_type(f, maptoTuple(_broadcast_getindex_eltype, A, As...))
 _nullable_eltype(f, A, As...) =
-    Base._return_type(f, maptuple(_unsafe_get_eltype, A, As...))
+    Base._return_type(f, maptoTuple(_unsafe_get_eltype, A, As...))
 
 # broadcast methods that dispatch on the type of the final container
 @inline function broadcast_c(f, ::Type{Array}, A, Bs...)
@@ -321,8 +321,8 @@ end
 @inline function broadcast_c(f, ::Type{Nullable}, a...)
     nonnull = all(hasvalue, a)
     S = _nullable_eltype(f, a...)
-    if isleaftype(S) && null_safe_op(f, maptuple(_unsafe_get_eltype,
-                                                 a...).types...)
+    if isleaftype(S) && null_safe_op(f, maptoTuple(_unsafe_get_eltype,
+                                                   a...).types...)
         Nullable{S}(f(map(unsafe_get, a)...), nonnull)
     else
         if nonnull

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,7 @@ module Broadcast
 using Base.Cartesian
 using Base: linearindices, tail, OneTo, to_shape,
             _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache,
-            nullable_returntype, null_safe_eltype_op, hasvalue, isoperator
+            nullable_returntype, null_safe_op, hasvalue, isoperator
 import Base: broadcast, broadcast!
 export broadcast_getindex, broadcast_setindex!, dotview, @__dot__
 
@@ -51,6 +51,7 @@ broadcast_indices(::Type{Tuple}, A) = (OneTo(length(A)),)
 broadcast_indices(::Type{Array}, A::Ref) = ()
 broadcast_indices(::Type{Array}, A) = indices(A)
 @inline broadcast_indices(A, B...) = broadcast_shape((), broadcast_indices(A), map(broadcast_indices, B)...)
+
 # shape (i.e., tuple-of-indices) inputs
 broadcast_shape(shape::Tuple) = shape
 @inline broadcast_shape(shape::Tuple, shape1::Tuple, shapes::Tuple...) = broadcast_shape(_bcs((), shape, shape1), shapes...)
@@ -279,10 +280,30 @@ end
     return C
 end
 
-eltypestuple(a) = (Base.@_pure_meta; Tuple{eltype(a)})
-eltypestuple(T::Type) = (Base.@_pure_meta; Tuple{Type{T}})
-eltypestuple(a, b...) = (Base.@_pure_meta; Tuple{eltypestuple(a).types..., eltypestuple(b...).types...})
-_broadcast_eltype(f, A, Bs...) = Base._return_type(f, eltypestuple(A, Bs...))
+maptuple(f) = Tuple{}
+maptuple(f, a, b...) = Tuple{f(a), maptuple(f, b...).types...}
+
+# An element type satisfying for all A:
+# broadcast_getindex(
+#     containertype(A),
+#     A, broadcast_indices(A)
+# )::_broadcast_getindex_eltype(A)
+_broadcast_getindex_eltype(A) = _broadcast_getindex_eltype(containertype(A), A)
+_broadcast_getindex_eltype(::ScalarType, T::Type) = Type{T}
+_broadcast_getindex_eltype(::ScalarType, A) = typeof(A)
+_broadcast_getindex_eltype(::Any, A) = eltype(A)  # Tuple, Array, etc.
+
+# An element type satisfying for all A:
+# unsafe_get(A)::unsafe_get_eltype(A)
+_unsafe_get_eltype(x::Nullable) = eltype(x)
+_unsafe_get_eltype(T::Type) = Type{T}
+_unsafe_get_eltype(x) = typeof(x)
+
+# Inferred eltype of result of broadcast(f, xs...)
+_broadcast_eltype(f, A, As...) =
+    Base._return_type(f, maptuple(_broadcast_getindex_eltype, A, As...))
+_nullable_eltype(f, A, As...) =
+    Base._return_type(f, maptuple(_unsafe_get_eltype, A, As...))
 
 # broadcast methods that dispatch on the type of the final container
 @inline function broadcast_c(f, ::Type{Array}, A, Bs...)
@@ -299,8 +320,9 @@ _broadcast_eltype(f, A, Bs...) = Base._return_type(f, eltypestuple(A, Bs...))
 end
 @inline function broadcast_c(f, ::Type{Nullable}, a...)
     nonnull = all(hasvalue, a)
-    S = _broadcast_eltype(f, a...)
-    if isleaftype(S) && null_safe_eltype_op(f, a...)
+    S = _nullable_eltype(f, a...)
+    if isleaftype(S) && null_safe_op(f, maptuple(_unsafe_get_eltype,
+                                                 a...).types...)
         Nullable{S}(f(map(unsafe_get, a)...), nonnull)
     else
         if nonnull

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -188,12 +188,6 @@ const EqualOrLess = Union{typeof(isequal), typeof(isless)}
 
 null_safe_op{T}(::typeof(identity), ::Type{T}) = isbits(T)
 
-eltypes() = Tuple{}
-eltypes(x, xs...) = Tuple{eltype(x), eltypes(xs...).parameters...}
-
-@pure null_safe_eltype_op(op, xs...) =
-    null_safe_op(op, eltypes(xs...).parameters...)
-
 null_safe_op(f::EqualOrLess, ::NullSafeTypes, ::NullSafeTypes) = true
 null_safe_op{S,T}(f::EqualOrLess, ::Type{Rational{S}}, ::Type{T}) =
     null_safe_op(f, T, S)

--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -85,7 +85,7 @@ function _noshapecheck_map{Tf,N}(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseVecO
     fofzeros = f(_zeros_eltypes(A, Bs...)...)
     fpreszeros = _iszero(fofzeros)
     maxnnzC = fpreszeros ? min(length(A), _sumnnzs(A, Bs...)) : length(A)
-    entrytypeC = Base.Broadcast._broadcast_eltype(A, Bs...)
+    entrytypeC = Base.Broadcast._broadcast_eltype(f, A, Bs...)
     indextypeC = _promote_indtype(A, Bs...)
     C = _allocres(size(A), indextypeC, entrytypeC, maxnnzC)
     return fpreszeros ? _map_zeropres!(f, C, A, Bs...) :

--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -85,7 +85,7 @@ function _noshapecheck_map{Tf,N}(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseVecO
     fofzeros = f(_zeros_eltypes(A, Bs...)...)
     fpreszeros = _iszero(fofzeros)
     maxnnzC = fpreszeros ? min(length(A), _sumnnzs(A, Bs...)) : length(A)
-    entrytypeC = Base.Broadcast._broadcast_eltype(f, A, Bs...)
+    entrytypeC = Base.Broadcast._broadcast_eltype(A, Bs...)
     indextypeC = _promote_indtype(A, Bs...)
     C = _allocres(size(A), indextypeC, entrytypeC, maxnnzC)
     return fpreszeros ? _map_zeropres!(f, C, A, Bs...) :

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -494,3 +494,18 @@ end
     A[1:3,1:3] .= [ones(2,2)]
     @test all(A[1:3,1:3] .== [ones(2,2)])
 end
+
+# Test that broadcast does not confuse eltypes. See also
+# https://github.com/JuliaLang/julia/issues/21325
+@testset "eltype confusion (#21325)" begin
+    foo(x::Char, y::Int) = 0
+    foo(x::String, y::Int) = "hello"
+    @test broadcast(foo, "x", [1, 2, 3]) == ["hello", "hello", "hello"]
+
+    @test isequal(
+        [Set([1]), Set([2])] .∪ Set([3]),
+        [Set([1, 3]), Set([2, 3])])
+
+    @test isequal(@inferred(broadcast(foo, "world", Nullable(1))),
+                  Nullable("hello"))
+end


### PR DESCRIPTION
Currently `_broadcast_eltype` calls inference but can often do it on the wrong types, which is not good. Calling `eltype` to get those types was incorrect because `broadcast` treats more things as scalars than what `eltype` does.

This PR replaces `eltypestuple` with a more general `maptuple` and adds two `_*_eltype` functions. We also combine `Base.eltypes` and `Base.eltypestuple` into the `maptuple` function.

A further nice consequence is that in many cases where this bug was nearly invisible before (because inference failed on one of the arguments), the return of `broadcast` can now be inferred, and performance is improved. (I don't know if any such benchmarks are in BaseBenchmarks, but I plan to add some.)