### PR TITLE
Docs: Added more details to Operator Precedence section

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -469,6 +469,24 @@ end
 isidentifier(s::Symbol) = isidentifier(string(s))
 
 isoperator(s::Symbol) = ccall(:jl_is_operator, Cint, (Cstring,), s) != 0
+
+"""
+    operator_precedence(s::Symbol)
+
+Return an integer representing the precedence of operator `s`, relative to
+other operators. Higher-numbered operators take precedence over lower-numbered
+operators. Return `0` if `s` is not a valid operator.
+
+# Examples
+
+```jldoctest
+julia> Base.operator_precedence(:+), Base.operator_precedence(:*), Base.operator_precedence(:.)
+(9,11,15)
+
+julia> Base.operator_precedence(:+=), Base.operator_precedence(:(=))  # (Note the necessary parens on `:(=)`)
+(1,1)
+```
+"""
 operator_precedence(s::Symbol) = Int(ccall(:jl_operator_precedence, Cint, (Cstring,), s))
 operator_precedence(x::Any) = 0 # fallback for generic expression nodes
 const prec_power = operator_precedence(:(^))

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -331,7 +331,18 @@ comparison is undefined. It is strongly recommended not to use expressions with 
 as printing) in chained comparisons. If side effects are required, the short-circuit `&&` operator
 should be used explicitly (see [Short-Circuit Evaluation](@ref)).
 
-### Operator Precedence
+### Elementary Functions
+
+Julia provides a comprehensive collection of mathematical functions and operators. These mathematical
+operations are defined over as broad a class of numerical values as permit sensible definitions,
+including integers, floating-point numbers, rationals, and complexes, wherever such definitions
+make sense.
+
+Moreover, these functions (like any Julia function) can be applied in "vectorized" fashion to
+arrays and other collections with the [dot syntax](@ref man-vectorized) `f.(A)`,
+e.g. `sin.(A)` will compute the elementwise sine of each element of an array `A`.
+
+## Operator Precedence
 
 Julia applies the following order of operations, from highest precedence to lowest:
 
@@ -348,16 +359,18 @@ Julia applies the following order of operations, from highest precedence to lowe
 | Control flow   | `&&` followed by `\|\|` followed by `?`                                                           |
 | Assignments    | `= += -= *= /= //= \= ^= ÷= %= \|= &= ⊻= <<= >>= >>>=`                                            |
 
-### Elementary Functions
+For a complete list of *every* Julia operator's precedence, see the top of this file:
+[julia/src/julia-parser.scm](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm)
 
-Julia provides a comprehensive collection of mathematical functions and operators. These mathematical
-operations are defined over as broad a class of numerical values as permit sensible definitions,
-including integers, floating-point numbers, rationals, and complexes, wherever such definitions
-make sense.
+You can also find the numerical precedence for any given operator via the built-in function `Base.operator_precedence`, where higher numbers take precedence:
 
-Moreover, these functions (like any Julia function) can be applied in "vectorized" fashion to
-arrays and other collections with the [dot syntax](@ref man-vectorized) `f.(A)`,
-e.g. `sin.(A)` will compute the elementwise sine of each element of an array `A`.
+```jldoctest
+julia> Base.operator_precedence(:+), Base.operator_precedence(:*), Base.operator_precedence(:.)
+(9,11,15)
+
+julia> Base.operator_precedence(:+=), Base.operator_precedence(:(=))  # (Note the necessary parens on `:(=)`)
+(1,1)
+```
 
 ## Numerical Conversions
 


### PR DESCRIPTION
From Issue #14933.

- Made Operator Precedence a higher heading, since it's not really a subsection of `##Numeric Comparisons`, and it references all the operators described in earlier sections on the page.
- Added a link to the source file that lists *all* operator precedences.
- Added code examples for `Base.operator_precedence` to show how to programmatically find an operator's precedence.