### PR TITLE
Refer to `mkpath` from `mkdir` docs

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -85,7 +85,10 @@ cd(f::Function) = cd(f, homedir())
     mkdir(path::AbstractString, mode::Unsigned=0o777)
 
 Make a new directory with name `path` and permissions `mode`. `mode` defaults to `0o777`,
-modified by the current file creation mask.
+modified by the current file creation mask. This function never creates more than one
+directory. If the directory already exists, or some intermediate directories do not exist,
+this function throws an error. See [`mkpath`](@ref) for a function which creates all
+required intermediate directories.
 """
 function mkdir(path::AbstractString, mode::Unsigned=0o777)
     @static if is_windows()


### PR DESCRIPTION
I had wondered why there was no recursive `mkdir`, but then stumbled upon `mkpath`. Since these functions are very related, I think it would be good to reference one from the other.