### PR TITLE
Make libgit2 print repo path on error

### DIFF
--- a/base/libgit2/error.jl
+++ b/base/libgit2/error.jl
@@ -83,9 +83,12 @@ function last_error()
     return (err_class, err_msg)
 end
 
-function GitError(code::Integer)
+function GitError(code::Integer; path = "")
     err_code = Code[code][]
     err_class, err_msg = last_error()
+
+    length(path) > 0 && (err_msg = err_msg * "\n               in path: $path")
+
     return GitError(err_class, err_code, err_msg)
 end
 
@@ -96,7 +99,7 @@ macro check(git_func)
         local err::Cint
         err = $(esc(git_func::Expr))
         if err < 0
-            throw(Error.GitError(err))
+            throw(Error.GitError(err; path = gitdir($(esc(:repo)))))
         end
         err
     end


### PR DESCRIPTION
The error messages in #17994 occur because a package folder is not actually a git repository, is a bare repo (no commits), or apparently some other reasons. I had about 10 of those for various reasons, and the error messages were not helpful.

Pending more useful errors, this PR prints the libgit2 repo directory when something goes wrong, so that the problem can at least be tracked down manually.