### PR TITLE
Protect DWARF lookup with codegen lock

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -761,6 +761,7 @@ static int lookup_pointer(DIContext *context, jl_frame_t **frames,
         }
         return 1;
     }
+    jl_mutex_lock_maybe_nogc(&codegen_lock);
 #if JL_LLVM_VERSION >= 30500
     DILineInfoSpecifier infoSpec(DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath,
                                  DILineInfoSpecifier::FunctionNameKind::ShortName);
@@ -774,9 +775,11 @@ static int lookup_pointer(DIContext *context, jl_frame_t **frames,
 
     int fromC = (*frames)[0].fromC;
     int n_frames = inlineInfo.getNumberOfFrames();
-    if (n_frames == 0)
+    if (n_frames == 0) {
+        jl_mutex_unlock_maybe_nogc(&codegen_lock);
         // no line number info available in the context, return without the context
         return lookup_pointer(NULL, frames, pointer, demangle, noInline);
+    }
     if (noInline)
         n_frames = 1;
     if (n_frames > 1) {
@@ -834,6 +837,7 @@ static int lookup_pointer(DIContext *context, jl_frame_t **frames,
         else
             jl_copy_str(&frame->file_name, file_name.c_str());
     }
+    jl_mutex_unlock_maybe_nogc(&codegen_lock);
     return n_frames;
 }
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -557,6 +557,18 @@ static inline void jl_mutex_lock(jl_mutex_t *lock)
     jl_gc_enable_finalizers(ptls, 0);
 }
 
+/* Call this function for code that could be called from either a managed
+   or an unmanaged thread */
+static inline void jl_mutex_lock_maybe_nogc(jl_mutex_t *lock)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    if (ptls->safepoint) {
+        jl_mutex_lock(lock);
+    } else {
+        jl_mutex_lock_nogc(lock);
+    }
+}
+
 static inline void jl_mutex_unlock_nogc(jl_mutex_t *lock)
 {
     assert(lock->owner == jl_thread_self() &&
@@ -574,6 +586,15 @@ static inline void jl_mutex_unlock(jl_mutex_t *lock)
     jl_gc_enable_finalizers(ptls, 1);
     jl_lock_frame_pop();
     JL_SIGATOMIC_END();
+}
+
+static inline void jl_mutex_unlock_maybe_nogc(jl_mutex_t *lock) {
+    jl_ptls_t ptls = jl_get_ptls_states();
+    if (ptls->safepoint) {
+        jl_mutex_unlock(lock);
+    } else {
+        jl_mutex_unlock_nogc(lock);
+    }
 }
 
 static inline void jl_mutex_init(jl_mutex_t *lock)


### PR DESCRIPTION
LLVM is not thread safe (at least we build it don't way), so we need
to make sure we can't possibly be accessing LLVM simulateneously on
different threads. The easiest way to ensure that is to lock this
with the codegen lock.