### PR TITLE
deprecate srand(rng, filename::AbstractString, n=4)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,34 @@
+Julia v0.7.0 Release Notes
+==========================
+
+New language features
+---------------------
+
+
+Language changes
+----------------
+
+
+Breaking changes
+----------------
+
+This section lists changes that do not have deprecation warnings.
+
+
+Library improvements
+--------------------
+
+
+Compiler/Runtime improvements
+-----------------------------
+
+
+Deprecated or removed
+---------------------
+
+  * The method `srand(rng, filename, n=4)` has been deprecated ([#21359]).
+
+
 Julia v0.6.0 Release Notes
 ==========================
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1336,6 +1336,12 @@ next(p::Union{Process, ProcessChain}, i::Int) = (getindex(p, i), i + 1)
 end
 
 @deprecate cond(F::LinAlg.LU, p::Integer) cond(full(F), p)
+
+# PR #21359
+@deprecate srand(r::MersenneTwister, filename::AbstractString, n::Integer=4) srand(r, read!(filename, Array{UInt32}(Int(n))))
+@deprecate srand(filename::AbstractString, n::Integer=4) srand(read!(filename, Array{UInt32}(Int(n))))
+@deprecate MersenneTwister(filename::AbstractString)  srand(MersenneTwister(0), read!(filename, Array{UInt32}(Int(4))))
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/random.jl
+++ b/base/random.jl
@@ -213,25 +213,19 @@ function make_seed(n::Integer)
     end
 end
 
-function make_seed(filename::AbstractString, n::Integer)
-    read!(filename, Vector{UInt32}(Int(n)))
-end
-
 ## srand()
 
 """
-    srand([rng=GLOBAL_RNG], [seed]) -> rng
-    srand([rng=GLOBAL_RNG], filename, n=4) -> rng
+    srand([rng=GLOBAL_RNG], seed) -> rng
+    srand([rng=GLOBAL_RNG]) -> rng
 
 Reseed the random number generator. If a `seed` is provided, the RNG will give a
 reproducible sequence of numbers, otherwise Julia will get entropy from the system. For
-`MersenneTwister`, the `seed` may be a non-negative integer, a vector of `UInt32` integers
-or a filename, in which case the seed is read from a file (`4n` bytes are read from the file,
-where `n` is an optional argument). `RandomDevice` does not support seeding.
+`MersenneTwister`, the `seed` may be a non-negative integer or a vector of `UInt32` integers.
+`RandomDevice` does not support seeding.
 """
 srand(r::MersenneTwister) = srand(r, make_seed())
 srand(r::MersenneTwister, n::Integer) = srand(r, make_seed(n))
-srand(r::MersenneTwister, filename::AbstractString, n::Integer=4) = srand(r, make_seed(filename, n))
 
 
 function dsfmt_gv_srand()
@@ -247,11 +241,6 @@ end
 
 function srand(seed::Union{Integer, Vector{UInt32}})
     srand(GLOBAL_RNG, seed)
-    dsfmt_gv_srand()
-end
-
-function srand(filename::AbstractString, n::Integer=4)
-    srand(GLOBAL_RNG, filename, n)
     dsfmt_gv_srand()
 end
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -485,11 +485,8 @@ let g = Base.Random.GLOBAL_RNG,
     @test srand() === g
     @test srand(rand(UInt)) === g
     @test srand(rand(UInt32, rand(1:10))) === g
-    @test srand(@__FILE__) === g
-    @test srand(@__FILE__, rand(1:10)) === g
     @test srand(m) === m
     @test srand(m, rand(UInt)) === m
     @test srand(m, rand(UInt32, rand(1:10))) === m
     @test srand(m, rand(1:10)) === m
-    @test srand(m, @__FILE__, rand(1:10)) === m
 end


### PR DESCRIPTION
This method

- is never used in practice, I _guess_, which probably makes its maintenance cost not worth it.

- was introduced in b13d0379365676547df9c185b6f2153e018b07dd (cc @ViralBShah), mainly (apparently) to be able to seed from "/dev/urandom"; we now have a direct abstraction with `RandomDevice` (e.g. `srand(rng, rand(RandomDevice(), UInt32, 4))`, when `srand(rng)` is not enough).
 
- prevents the introduction of a more natural `srand(rng, seed::String)`. `srand` should only accept a direct seed as second argument (for less confusion); here `filename` is an indirect seed, and hence requires an extra explanation in the docstring. Moreover, it would be easy to use `srand` using a file if the above method existed (e.g. `srand(rng, read("/dev/urandom", UInt32, 4))` but not the other way around).

- is not fully satisfying to use: e.g. if `n` is too big for the file (a finite file, i.e. not "/dev/urandom"), an error is issued, and there is no way to tell `srand` to read exactly the whole file (I agree that this argument is not strong, we could simply improve this method instead of deprecating it).

If this method is nonetheless deemed to be useful enough that we want to keep its functionality, I propose to make the filename a keyword argument, allowing the introduction later of `srand(rng, seed::String)`.
