### PR TITLE
add exit/quit hint

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1145,14 +1145,6 @@ See [`BigFloat`](@ref) for information about some pitfalls with floating-point n
 big
 
 """
-    quit()
-
-Quit the program indicating that the processes completed successfully. This function calls
-`exit(0)` (see [`exit`](@ref)).
-"""
-quit
-
-"""
     typejoin(T, S)
 
 Compute a type that contains both `T` and `S`.
@@ -2217,14 +2209,6 @@ Like [`parse`](@ref), but returns a [`Nullable`](@ref) of the requested type. Th
 string does not contain a valid number.
 """
 tryparse
-
-"""
-    exit([code])
-
-Quit (or control-D at the prompt). The default exit code is zero, indicating that the
-processes completed successfully.
-"""
-exit
 
 """
     skipchars(stream, predicate; linecomment::Char)

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -18,9 +18,26 @@ An array of the command line arguments passed to Julia, as strings.
 """
 const ARGS = String[]
 
+"""
+    exit([code])
+
+Quit (or control-D at the prompt). The default exit code is zero, indicating that the
+processes completed successfully.
+"""
 exit(n) = ccall(:jl_exit, Void, (Int32,), n)
 exit() = exit(0)
+
+"""
+    quit()
+
+Quit the program indicating that the processes completed successfully. This function calls
+`exit(0)` (see [`exit`](@ref)).
+"""
 quit() = exit()
+
+# hint for people who forget parentheses
+show(io::IO, ::MIME"text/plain", ::typeof(quit)) = print(io, "Use exit(), quit() or Ctrl-D to exit")
+show(io::IO, ::MIME"text/plain", ::typeof(exit)) = print(io, "Use exit(), quit() or Ctrl-D to exit")
 
 const roottask = current_task()
 


### PR DESCRIPTION
By changing the `show` method, we can provide more useful hints (this idea is gratuitously stolen from Python):
```
julia> exit
Use exit(), quit() or Ctrl-D to exit
```