### PR TITLE
make jl_init more friendly to embedded targets

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -40,15 +40,15 @@ end
 JLOptions() = unsafe_load(cglobal(:jl_options, JLOptions))
 
 function show(io::IO, opt::JLOptions)
-    println(io, "JLOptions(")
+    print(io, "JLOptions(")
     fields = fieldnames(opt)
     nfields = length(fields)
-    for (i,f) in enumerate(fieldnames(opt))
-        v = getfield(opt,f)
+    for (i, f) in enumerate(fields)
+        v = getfield(opt, i)
         if isa(v, Ptr{UInt8})
-            v = v != C_NULL ? unsafe_string(v) : ""
+            v = (v != C_NULL) ? unsafe_string(v) : ""
         end
-        println(io, "  ", f, " = ", repr(v), i < nfields ? "," : "")
+        print(io, f, " = ", repr(v), i < nfields ? ", " : "")
     end
-    print(io,")")
+    print(io, ")")
 end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -151,6 +151,21 @@ function show(io::IO, ::MIME"text/plain", s::String)
     end
 end
 
+function show(io::IO, ::MIME"text/plain", opt::JLOptions)
+    println(io, "JLOptions(")
+    fields = fieldnames(opt)
+    nfields = length(fields)
+    for (i, f) in enumerate(fields)
+        v = getfield(opt, i)
+        if isa(v, Ptr{UInt8})
+            v = (v != C_NULL) ? unsafe_string(v) : ""
+        end
+        println(io, "  ", f, " = ", repr(v), i < nfields ? "," : "")
+    end
+    print(io, ")")
+end
+
+
 # showing exception objects as descriptive error messages
 
 showerror(io::IO, ex) = show(io, ex)

--- a/base/util.jl
+++ b/base/util.jl
@@ -619,7 +619,13 @@ function julia_cmd(julia=joinpath(JULIA_HOME, julia_exename()))
     `$julia -C$cpu_target -J$image_file --compile=$compile --depwarn=$depwarn`
 end
 
-julia_exename() = ccall(:jl_is_debugbuild,Cint,())==0 ? "julia" : "julia-debug"
+function julia_exename()
+    if ccall(:jl_is_debugbuild, Cint, ()) == 0
+        return @static is_windows() ? "julia.exe" : "julia"
+    else
+        return @static is_windows() ? "julia-debug.exe" : "julia-debug"
+    end
+end
 
 """
     securezero!(o)

--- a/src/init.c
+++ b/src/init.c
@@ -190,10 +190,52 @@ void jl_init_timing(void);
 void jl_destroy_timing(void);
 void jl_uv_call_close_callback(jl_value_t *val);
 
+static void jl_close_item_atexit(uv_handle_t *handle)
+{
+    if (handle->type != UV_FILE && uv_is_closing(handle))
+        return;
+    switch(handle->type) {
+    case UV_PROCESS:
+        // cause Julia to forget about the Process object
+        if (handle->data)
+            jl_uv_call_close_callback((jl_value_t*)handle->data);
+        // and make libuv think it is already dead
+        ((uv_process_t*)handle)->pid = 0;
+        // fall-through
+    case UV_TTY:
+    case UV_UDP:
+    case UV_TCP:
+    case UV_NAMED_PIPE:
+    case UV_POLL:
+    case UV_TIMER:
+    case UV_ASYNC:
+    case UV_FS_EVENT:
+    case UV_FS_POLL:
+    case UV_IDLE:
+    case UV_PREPARE:
+    case UV_CHECK:
+    case UV_SIGNAL:
+    case UV_FILE:
+        // These will be shutdown as appropriate by jl_close_uv
+        jl_close_uv(handle);
+        break;
+    case UV_HANDLE:
+    case UV_STREAM:
+    case UV_UNKNOWN_HANDLE:
+    case UV_HANDLE_TYPE_MAX:
+    case UV_RAW_FD:
+    case UV_RAW_HANDLE:
+    default:
+        assert(0);
+    }
+}
+
 JL_DLLEXPORT void jl_atexit_hook(int exitcode)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    if (exitcode == 0) jl_write_compiler_output();
+
+    if (exitcode == 0)
+        jl_write_compiler_output();
     jl_print_gc_stats(JL_STDERR);
     if (jl_options.code_coverage)
         jl_write_coverage_data();
@@ -203,10 +245,10 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
         jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_atexit"));
         if (f != NULL) {
             JL_TRY {
-                size_t last_age = jl_get_ptls_states()->world_age;
-                jl_get_ptls_states()->world_age = jl_get_world_counter();
+                size_t last_age = ptls->world_age;
+                ptls->world_age = jl_get_world_counter();
                 jl_apply(&f, 1);
-                jl_get_ptls_states()->world_age = last_age;
+                ptls->world_age = last_age;
             }
             JL_CATCH {
                 jl_printf(JL_STDERR, "\natexit hook threw an error: ");
@@ -231,62 +273,33 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
     struct uv_shutdown_queue queue = {NULL, NULL};
     uv_walk(loop, jl_uv_exitcleanup_walk, &queue);
     struct uv_shutdown_queue_item *item = queue.first;
-    while (item) {
-        JL_TRY {
-            while (item) {
-                uv_handle_t *handle = item->h;
-                if (handle->type != UV_FILE && uv_is_closing(handle)) {
+    if (ptls->current_task != NULL) {
+        while (item) {
+            JL_TRY {
+                while (item) {
+                    jl_close_item_atexit(item->h);
                     item = next_shutdown_queue_item(item);
-                    continue;
                 }
-                switch(handle->type) {
-                case UV_PROCESS:
-                    // cause Julia to forget about the Process object
-                    if (handle->data)
-                        jl_uv_call_close_callback((jl_value_t*)handle->data);
-                    // and make libuv think it is already dead
-                    ((uv_process_t*)handle)->pid = 0;
-                    // fall-through
-                case UV_TTY:
-                case UV_UDP:
-                case UV_TCP:
-                case UV_NAMED_PIPE:
-                case UV_POLL:
-                case UV_TIMER:
-                case UV_ASYNC:
-                case UV_FS_EVENT:
-                case UV_FS_POLL:
-                case UV_IDLE:
-                case UV_PREPARE:
-                case UV_CHECK:
-                case UV_SIGNAL:
-                case UV_FILE:
-                    // These will be shutdown as appropriate by jl_close_uv
-                    jl_close_uv(handle);
-                    break;
-                case UV_HANDLE:
-                case UV_STREAM:
-                case UV_UNKNOWN_HANDLE:
-                case UV_HANDLE_TYPE_MAX:
-                case UV_RAW_FD:
-                case UV_RAW_HANDLE:
-                default:
-                    assert(0);
-                }
+            }
+            JL_CATCH {
+                //error handling -- continue cleanup, as much as possible
+                uv_unref(item->h);
+                jl_printf(JL_STDERR, "error during exit cleanup: close: ");
+                jl_static_show(JL_STDERR, ptls->exception_in_transit);
                 item = next_shutdown_queue_item(item);
             }
         }
-        JL_CATCH {
-            //error handling -- continue cleanup, as much as possible
-            uv_unref(item->h);
-            jl_printf(JL_STDERR, "error during exit cleanup: close: ");
-            jl_static_show(JL_STDERR, ptls->exception_in_transit);
+    }
+    else {
+        while (item) {
+            jl_close_item_atexit(item->h);
             item = next_shutdown_queue_item(item);
         }
     }
+
     // force libuv to spin until everything has finished closing
     loop->stop_flag = 0;
-    while (uv_run(loop,UV_RUN_DEFAULT)) {}
+    while (uv_run(loop, UV_RUN_DEFAULT)) { }
 
     jl_destroy_timing();
 #ifdef ENABLE_TIMINGS
@@ -527,9 +540,11 @@ void _julia_init(JL_IMAGE_SEARCH rel)
                                     // best to call this first, since it also initializes libuv
     jl_init_signal_async();
     restore_signals();
+
     jl_resolve_sysimg_location(rel);
     // loads sysimg if available, and conditionally sets jl_options.cpu_target
-    jl_preload_sysimg_so(jl_options.image_file);
+    if (jl_options.image_file)
+        jl_preload_sysimg_so(jl_options.image_file);
     if (jl_options.cpu_target == NULL)
         jl_options.cpu_target = "native";
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1121,6 +1121,16 @@ static void jl_gen_llvm_globaldata(llvm::Module *mod, ValueToValueMapTy &VMap,
                                  feature_string,
                                  "jl_sysimg_cpu_target"));
 
+    // reflect the address of the jl_RTLD_DEFAULT_handle variable
+    // back to the caller, so that we can check for consistency issues
+    GlobalValue *jlRTLD_DEFAULT_var = mod->getNamedValue("jl_RTLD_DEFAULT_handle");
+    addComdat(new GlobalVariable(*mod,
+                                 jlRTLD_DEFAULT_var->getType(),
+                                 true,
+                                 GlobalVariable::ExternalLinkage,
+                                 jlRTLD_DEFAULT_var,
+                                 "jl_RTLD_DEFAULT_handle_pointer"));
+
 #ifdef HAVE_CPUID
     // For native also store the cpuid
     if (strcmp(jl_options.cpu_target,"native") == 0) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1324,6 +1324,7 @@ JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
 JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname);
+JL_DLLEXPORT void jl_set_sysimg_so(void *handle);
 JL_DLLEXPORT ios_t *jl_create_system_image(void);
 JL_DLLEXPORT void jl_save_system_image(const char *fname);
 JL_DLLEXPORT void jl_restore_system_image(const char *fname);

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -62,8 +62,8 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     @test !success(`$exename --load`)
 
     # --cpu-target
-    # NOTE: this test only holds true when there is a sys.{dll,dylib,so} shared library present.
-    if Libdl.dlopen_e(splitext(unsafe_string(Base.JLOptions().image_file))[1]) != C_NULL
+    # NOTE: this test only holds true if image_file is a shared library.
+    if Libdl.dlopen_e(unsafe_string(Base.JLOptions().image_file)) != C_NULL
         @test !success(`$exename -C invalidtarget --precompiled=yes`)
         @test !success(`$exename --cpu-target=invalidtarget --precompiled=yes`)
     else
@@ -328,6 +328,43 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
             rm(testdir)
             @test success(`$exename -e "exit(0)"`)
         end
+    end
+end
+
+
+# Find the path of libjulia (or libjulia-debug, as the case may be)
+# to use as a dummy shlib to open
+libjulia = abspath(Libdl.dlpath((ccall(:jl_is_debugbuild, Cint, ()) != 0) ? "libjulia-debug" : "libjulia"))
+
+# test error handling code paths of running --sysimage
+let exename = joinpath(JULIA_HOME, Base.julia_exename()),
+    sysname = unsafe_string(Base.JLOptions().image_file)
+    for nonexist_image in (
+            joinpath(@__DIR__, "nonexistent"),
+            "$sysname.nonexistent",
+            )
+        let stderr = Pipe(),
+            p = spawn(pipeline(`$exename --sysimage=$nonexist_image`, stderr=stderr))
+            close(stderr.in)
+            let s = readstring(stderr)
+                @test contains(s, "ERROR: could not load library \"$nonexist_image\"\n")
+                @test !contains(s, "Segmentation fault")
+                @test !contains(s, "EXCEPTION_ACCESS_VIOLATION")
+            end
+            @test !success(p)
+            @test !Base.process_signaled(p)
+            @test p.exitcode == 1
+        end
+    end
+    let stderr = Pipe(),
+        p = spawn(pipeline(`$exename --sysimage=$libjulia`, stderr=stderr))
+        close(stderr.in)
+        let s = readstring(stderr)
+            @test s == "ERROR: System image file failed consistency check: maybe opened the wrong version?\n"
+        end
+        @test !success(p)
+        @test !Base.process_signaled(p)
+        @test p.exitcode == 1
     end
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -514,9 +514,19 @@ if is_windows()
     end
 end
 
-optstring = sprint(show, Base.JLOptions())
-@test startswith(optstring, "JLOptions(")
-@test endswith(optstring, ")")
+let optstring = stringmime(MIME("text/plain"), Base.JLOptions())
+    @test startswith(optstring, "JLOptions(\n")
+    @test !contains(optstring, "Ptr")
+    @test endswith(optstring, "\n)")
+    @test contains(optstring, " = \"")
+end
+let optstring = repr(Base.JLOptions())
+    @test startswith(optstring, "JLOptions(")
+    @test endswith(optstring, ")")
+    @test !contains(optstring, "\n")
+    @test !contains(optstring, "Ptr")
+    @test contains(optstring, " = \"")
+end
 
 # Base.securezero! functions (#17579)
 import Base: securezero!, unsafe_securezero!


### PR DESCRIPTION
this throws the error messages directly when the problem occurs,
rather than waiting until late to throw a generic "System image file not found" message