### PR TITLE
Update src to work with latest LLVM 5.

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -19,6 +19,11 @@ inline uint64_t RoundUpToAlignment(uint64_t Value, uint64_t Align, uint64_t Skew
 }
 #endif
 
+#if JL_LLVM_VERSION >= 50000
+const unsigned int integerPartWidth = llvm::APInt::APINT_BITS_PER_WORD;
+const unsigned int host_char_bit = 8;
+#endif
+
 /* create "APInt s" from "integerPart *ps" */
 #define CREATE(s) \
     APInt s; \

--- a/src/APInt-C.h
+++ b/src/APInt-C.h
@@ -9,7 +9,11 @@ extern "C" {
 #include "dtypes.h"
 
 #ifdef LLVM_VERSION_MAJOR
+#  if JL_LLVM_VERSION >= 50000
+using integerPart = llvm::APInt::WordType;
+#  else
 using llvm::integerPart;
+#  endif
 #else
 typedef void integerPart;
 #endif

--- a/src/llvm-gcroot.cpp
+++ b/src/llvm-gcroot.cpp
@@ -137,7 +137,11 @@ public:
         T_int64(Type::getInt64Ty(F.getContext())),
         V_null(T_pjlvalue ? Constant::getNullValue(T_pjlvalue) : nullptr),
         ptlsStates(ptlsStates),
+#if JL_LLVM_VERSION >= 50000
+        gcframe(ptlsStates ? new AllocaInst(T_pjlvalue, 0, ConstantInt::get(T_int32, 0)) : nullptr),
+#else
         gcframe(ptlsStates ? new AllocaInst(T_pjlvalue, ConstantInt::get(T_int32, 0)) : nullptr),
+#endif
         gcroot_func(M.getFunction("julia.gc_root_decl")),
         gckill_func(M.getFunction("julia.gc_root_kill")),
         jlcall_frame_func(M.getFunction("julia.jlcall_frame_decl")),
@@ -344,7 +348,11 @@ void JuliaGCAllocator::lowerHandlers()
     Instruction *firstInst = &F.getEntryBlock().front();
     while (!handlers.empty()) {
         processing.clear();
+#if JL_LLVM_VERSION >= 50000
+        auto buff = new AllocaInst(T_int8, 0, handler_sz, "", firstInst);
+#else
         auto buff = new AllocaInst(T_int8, handler_sz, "", firstInst);
+#endif
         buff->setAlignment(16);
         // Collect the list of frames to process.
         for (auto &hdlr: handlers) {


### PR DESCRIPTION
Define using integerPart = llvm::APInt::WordType. Define integerPartWidth for now.
Should eventually become lvm::APInt::APINT_BITS_PER_WORD. See

https://github.com/llvm-mirror/llvm/commit/6b60db9e917fdc394d19a990d49563fce37d4c25

AllocaInst now requires an addrsspce argument. See

https://github.com/llvm-mirror/llvm/commit/e1b3c335a27ae50c4f339ffb81c18662bc983e52