### PR TITLE
RFC: Various Nullable comparison methods

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -210,6 +210,22 @@ and `false` if one is null but not the other: nulls are considered equal.
     end
 end
 
+@inline function isequal{S,T}(x::Nullable{S}, y::T)
+    if null_safe_op(isequal, S, T)
+        !isnull(x) & isequal(x.value, y)
+    else
+        !isnull(x) && isequal(x.value, y)
+    end
+end
+
+@inline function isequal{S,T}(x::S, y::Nullable{T})
+    if null_safe_op(isequal, S, T)
+        !isnull(y) & isequal(x, y.value)
+    else
+        !isnull(y) && isequal(x, y.value)
+    end
+end
+
 isequal(x::Nullable{Union{}}, y::Nullable{Union{}}) = true
 isequal(x::Nullable{Union{}}, y::Nullable) = isnull(y)
 isequal(x::Nullable, y::Nullable{Union{}}) = isnull(x)

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -231,6 +231,42 @@ isequal(x::Nullable{Union{}}, y::Nullable) = isnull(y)
 isequal(x::Nullable, y::Nullable{Union{}}) = isnull(x)
 
 """
+    ==(x::Nullable, y::Nullable)
+
+If neither `x` nor `y` is null, compare them according to their values
+(i.e. `==(get(x), get(y))`). Else, return `true` if both arguments are null,
+and `false` if one is null but not the other: nulls are considered equal.
+"""
+@inline function =={S,T}(x::Nullable{S}, y::Nullable{T})
+    if null_safe_op(isequal, S, T)
+        (isnull(x) & isnull(y)) | (!isnull(x) & !isnull(y) & (x.value==y.value))
+    else
+        (isnull(x) & isnull(y)) || (!isnull(x) & !isnull(y) && x.value==y.value)
+    end
+end
+
+@inline function =={S,T}(x::Nullable{S}, y::T)
+    if null_safe_op(isequal, S, T)
+        !isnull(x) & (x.value == y)
+    else
+        !isnull(x) && x.value == y
+    end
+end
+
+@inline function =={S,T}(x::S, y::Nullable{T})
+    if null_safe_op(isequal, S, T)
+        !isnull(y) & (x == y.value)
+    else
+        !isnull(y) && x == y.value
+    end
+end
+
+==(x::Nullable{Union{}}, y::Nullable{Union{}}) = true
+==(x::Nullable{Union{}}, y::Nullable) = isnull(y)
+==(x::Nullable, y::Nullable{Union{}}) = isnull(x)
+
+
+"""
     isless(x::Nullable, y::Nullable)
 
 If neither `x` nor `y` is null, compare them according to their values
@@ -269,7 +305,6 @@ isless(x::Nullable{Union{}}, y::Nullable{Union{}}) = false
 isless(x::Nullable{Union{}}, y::Nullable) = false
 isless(x::Nullable, y::Nullable{Union{}}) = !isnull(x)
 
-==(x::Nullable, y::Nullable) = throw(NullException())
 
 const nullablehash_seed = UInt === UInt64 ? 0x932e0143e51d0171 : 0xe51d0171
 

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -265,6 +265,9 @@ end
 ==(x::Nullable{Union{}}, y::Nullable) = isnull(y)
 ==(x::Nullable, y::Nullable{Union{}}) = isnull(x)
 
+=={T}(x::Nullable{T}, y::WeakRef) = !isnull(x) && x.value == y
+=={T}(x::WeakRef, y::Nullable{T}) = !isnull(y) && y.value == x
+
 
 """
     isless(x::Nullable, y::Nullable)

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -247,6 +247,24 @@ another null.
     end
 end
 
+@inline function isless{S,T}(x::Nullable{S}, y::T)
+    # NULL values are sorted last
+    if null_safe_op(isless, S, T)
+        !isnull(x) & isless(x.value, y)
+    else
+        !isnull(x) && isless(x.value, y)
+    end
+end
+
+@inline function isless{S,T}(x::S, y::Nullable{T})
+    # NULL values are sorted last
+    if null_safe_op(isless, S, T)
+        !isnull(y) & isless(x, y.value)
+    else
+        !isnull(y) && isless(x, y.value)
+    end
+end
+
 isless(x::Nullable{Union{}}, y::Nullable{Union{}}) = false
 isless(x::Nullable{Union{}}, y::Nullable) = false
 isless(x::Nullable, y::Nullable{Union{}}) = !isnull(x)

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -232,30 +232,30 @@ for T in types
     x3 = Nullable(zero(T))
     x4 = Nullable(one(T))
 
-    @test_throws NullException (x0 == x1)
-    @test_throws NullException (x0 == x2)
-    @test_throws NullException (x0 == x3)
-    @test_throws NullException (x0 == x4)
+    @test x0 == x1
+    @test x0 == x2
+    @test x0 != x3
+    @test x0 != x4
 
-    @test_throws NullException (x1 == x1)
-    @test_throws NullException (x1 == x2)
-    @test_throws NullException (x1 == x3)
-    @test_throws NullException (x1 == x4)
+    @test x1 == x1
+    @test x1 == x2
+    @test x1 != x3
+    @test x1 != x4
 
-    @test_throws NullException (x2 == x1)
-    @test_throws NullException (x2 == x2)
-    @test_throws NullException (x2 == x3)
-    @test_throws NullException (x2 == x4)
+    @test x2 == x1
+    @test x2 == x2
+    @test x2 != x3
+    @test x2 != x4
 
-    @test_throws NullException (x3 == x1)
-    @test_throws NullException (x3 == x2)
-    @test_throws NullException (x3 == x3)
-    @test_throws NullException (x3 == x4)
+    @test x3 != x1
+    @test x3 != x2
+    @test x3 == x3
+    @test x3 != x4
 
-    @test_throws NullException (x4 == x1)
-    @test_throws NullException (x4 == x2)
-    @test_throws NullException (x4 == x3)
-    @test_throws NullException (x4 == x4)
+    @test x4 != x1
+    @test x4 != x2
+    @test x4 != x3
+    @test x4 == x4
 end
 
 # function hash(x::Nullable, h::UInt)


### PR DESCRIPTION
This PR makes two changes:

1. It adds mixed ``Nullable`` and non-``Nullable`` ``isequal`` and ``isless`` methods.
2. It adds methods to ``==`` that handle ``Nullable``s. The semantics of ``==`` are identical to the semantics of ``isequal`` for the ``Nullable`` case (which is also the C# semantics).

This is essentially an implementation of my suggestion from #20504.

I still need to write tests and probably more documentation, but before I put more work into this I'd like to get feedback whether the core group would consider merging this.

In terms of timing, I assume this would go in after 0.6 has branched.

Here are some arguments why I think it would be good to merge this:

1. I could move [Query.jl](https://github.com/davidanthoff/Query.jl) back to using ``Nullable``. Now, maybe I'm the only one who cares, but I do think that would be valuable.
2. I think adding support for ``==(x::Nullable, y::Nullable)`` makes things a lot more consistent. All the other comparison operators, like ``<`` etc. already work for ``Nullable``s, and it seems odd that ``==`` is the only comparison operator that throws an error.
3. I don't really see a big drawback in adding the mixed ``Nullable`` and non-``Nullable`` operators, but the payoff in terms of usability seems large to me.

CC @nalimilan