### PR TITLE
fix #21370, regression in dynamic dispatch of complex constructors

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -476,7 +476,7 @@ function reshape{N}(B::BitArray, dims::NTuple{N,Int})
     prod(dims) == length(B) ||
         throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(length(B))"))
     dims == size(B) && return B
-    Br = BitArray{N}(ntuple(i->0,N)...)
+    Br = BitArray{N}(ntuple(i->0,Val{N})...)
     Br.chunks = B.chunks
     Br.len = prod(dims)
     N != 1 && (Br.dims = dims)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1198,7 +1198,7 @@ end
 @generated function findn{N}(B::BitArray{N})
     quote
         nnzB = countnz(B)
-        I = ntuple(x->Array{Int}(nnzB), $N)
+        I = ntuple(x->Array{Int}(nnzB), Val{$N})
         if nnzB > 0
             count = 1
             @nloops $N i B begin

--- a/src/dump.c
+++ b/src/dump.c
@@ -2379,7 +2379,8 @@ static void jl_reinit_item(jl_value_t *v, int how, arraylist_t *tracee_list)
             case 3: { // rehash MethodTable
                 jl_methtable_t *mt = (jl_methtable_t*)v;
                 jl_typemap_rehash(mt->defs, 0);
-                jl_typemap_rehash(mt->cache, (mt == jl_type_typename->mt) ? 0 : 1);
+                // TODO: consider reverting this when we can split on Type{...} better
+                jl_typemap_rehash(mt->cache, 1); //(mt == jl_type_typename->mt) ? 0 : 1);
                 if (tracee_list)
                     arraylist_push(tracee_list, mt);
                 break;

--- a/src/gf.c
+++ b/src/gf.c
@@ -134,7 +134,8 @@ const struct jl_typemap_info tfunc_cache = {
 
 static int8_t jl_cachearg_offset(jl_methtable_t *mt)
 {
-    return (mt == jl_type_type_mt) ? 0 : 1;
+    // TODO: consider reverting this when we can split on Type{...} better
+    return 1; //(mt == jl_type_type_mt) ? 0 : 1;
 }
 
 /// ----- Insertion logic for special entries ----- ///


### PR DESCRIPTION
Here is a possible approach to #21370. With this change, the times get pretty close to 0.4 levels.

First, I added a fast-reject path to `sig_match_simple` to help avoid more calls to `jl_types_equal`.

More significantly, the problem is that we can't use hash lookup for `Type{T}`, so dispatching constructors was doing a really long linear lookup. We can get around that by using the type of the first argument as the primary key. That seems to work well in practice, but eventually we should come up with a scheme for splitting typemap levels on Type{T}. I believe we are most often looking for egal types, so one thing that might work would be to hash assuming we are looking for something egal, and fall back to linear lookup if that fails.