### PR TITLE
Reduce number of QR functions

### DIFF
--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -100,7 +100,7 @@ representable by the element type of `A`, e.g. for integer types.
 """
 qrfact!(A::StridedMatrix,              ::Type{Val{false}}) = qrfact!(QR, A)
 qrfact!(A::StridedMatrix{<:BlasFloat}, ::Type{Val{false}}) = qrfact!(QRCompactWY, A)
-qrfact!(A::StridedMatrix,              ::Type{Val{true}})  = qrfact!(QRPivtoted, A)
+qrfact!(A::StridedMatrix,              ::Type{Val{true}})  = qrfact!(QRPivoted, A)
 
 qrfact!(A::StridedMatrix) = qrfact!(A, Val{false})
 

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -601,7 +601,7 @@ end
             end
 
             ## QR
-            FJulia  = LinAlg.qrfactUnblocked!(copy(A))
+            FJulia  = LinAlg.qrfact!(LinAlg.QR, copy(A))
             FLAPACK = Base.LinAlg.LAPACK.geqrf!(copy(A))
             @test FJulia.factors ≈ FLAPACK[1]
             @test FJulia.τ ≈ FLAPACK[2]


### PR DESCRIPTION
This gets rid of a couple of `qrfactXXX!` functions by instead dispatching on types. Seems to make it a bit clearer.