### PR TITLE
Use dirname in the location of the sys image path

### DIFF
--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -8,7 +8,7 @@ function default_sysimg_path(debug=false)
     if is_unix()
         splitext(Libdl.dlpath(debug ? "sys-debug" : "sys"))[1]
     else
-        joinpath(JULIA_HOME, "..", "lib", "julia", debug ? "sys-debug" : "sys")
+        joinpath(dirname(JULIA_HOME), "lib", "julia", debug ? "sys-debug" : "sys")
     end
 end
 


### PR DESCRIPTION
Nicer since it now prints
`System image successfully built at C:\Julia\Julia-0.6-latest\lib\julia\sys.dll`
instead of
`System image successfully built at C:\Julia\Julia-0.6-latest\bin\..\lib\julia\sys.dll`
