### PR TITLE
Add @inbounds annotations to any(), all() and count()

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -572,7 +572,8 @@ true
 ```
 """
 function any(f, itr)
-    for x in itr
+    # @inbounds allows the compiler to optimize out the loop in case f is constant
+    @inbounds for x in itr
         f(x) && return true
     end
     return false
@@ -597,13 +598,14 @@ false
 ```
 """
 function all(f, itr)
-    for x in itr
+    # @inbounds allows the compiler to optimize out the loop in case f is constant
+    @inbounds for x in itr
         f(x) || return false
     end
     return true
 end
 
-## in & contains
+## in
 
 """
     in(item, collection) -> Bool
@@ -658,15 +660,9 @@ julia> count([true, false, true, true])
 """
 function count(pred, itr)
     n = 0
-    for x in itr
+    # @inbounds allows the compiler to optimize out the loop in case f is constant
+    @inbounds for x in itr
         n += pred(x)::Bool
-    end
-    return n
-end
-function count(pred, a::AbstractArray)
-    n = 0
-    for i in eachindex(a)
-        @inbounds n += pred(a[i])::Bool
     end
     return n
 end


### PR DESCRIPTION
Beside removing unnecessary bounds checks, `@inbounds` allows the compiler
to optimize away the loop when method is constant for input type, e.g.
`all(x -> true, X)` or `all(isnull, 1:3)`.  An optimized method already existed
for `count(::Any, ::AbstractArray)`, remove it since it is redundant with
method for the general iterables after adding `@inbounds`.

Fixes https://github.com/JuliaLang/julia/issues/21256.

I'm still not completely sure what our policy is regarding `@inbounds`: if it's OK to use for `AbstractArray` when working with an index obtained via `eachindex`, or equivalently using the iteration protocol, why wouldn't it be OK for any iterable? It seems a bit silly to duplicate all methods. Ideally, `for x in X` would automatically imply `@inbounds` (at least if the type implementation decides to do so). Cf. https://github.com/JuliaLang/julia/issues/20469.

Also I don't know how to test this, except with benchmarks?