### PR TITLE
Consistently use joinpath in various base files

### DIFF
--- a/base/dft.jl
+++ b/base/dft.jl
@@ -580,7 +580,7 @@ module FFTW
     """
     function plan_r2r end
 
-    Base.USE_GPL_LIBS && include("fft/FFTW.jl")
+    Base.USE_GPL_LIBS && include(joinpath("fft", "FFTW.jl"))
 end
 
 importall .FFTW

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1,3 +1,3 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-include("helpdb/Base.jl")
+include(joinpath("helpdb", "Base.jl"))

--- a/base/grisu/grisu.jl
+++ b/base/grisu/grisu.jl
@@ -13,12 +13,12 @@ const PRECISION = 3
 
 const DIGITS = Array{UInt8}(309+17)
 
-include("grisu/float.jl")
-include("grisu/fastshortest.jl")
-include("grisu/fastprecision.jl")
-include("grisu/fastfixed.jl")
-include("grisu/bignums.jl")
-include("grisu/bignum.jl")
+include(joinpath("grisu", "float.jl"))
+include(joinpath("grisu", "fastshortest.jl"))
+include(joinpath("grisu", "fastprecision.jl"))
+include(joinpath("grisu", "fastfixed.jl"))
+include(joinpath("grisu", "bignums.jl"))
+include(joinpath("grisu", "bignum.jl"))
 
 const BIGNUMS = [Bignums.Bignum(),Bignums.Bignum(),Bignums.Bignum(),Bignums.Bignum()]
 

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -5,21 +5,21 @@ module Markdown
 import Base: show, ==
 import Core: @doc_str
 
-include("parse/config.jl")
-include("parse/util.jl")
-include("parse/parse.jl")
+include(joinpath("parse", "config.jl"))
+include(joinpath("parse", "util.jl"))
+include(joinpath("parse", "parse.jl"))
 
-include("Common/Common.jl")
-include("GitHub/GitHub.jl")
-include("IPython/IPython.jl")
-include("Julia/Julia.jl")
+include(joinpath("Common", "Common.jl"))
+include(joinpath("GitHub", "GitHub.jl"))
+include(joinpath("IPython", "IPython.jl"))
+include(joinpath("Julia", "Julia.jl"))
 
-include("render/plain.jl")
-include("render/html.jl")
-include("render/latex.jl")
-include("render/rst.jl")
+include(joinpath("render", "plain.jl"))
+include(joinpath("render", "html.jl"))
+include(joinpath("render", "latex.jl"))
+include(joinpath("render", "rst.jl"))
 
-include("render/terminal/render.jl")
+include(joinpath("render", "terminal", "render.jl"))
 
 export readme, license, @md_str, @doc_str
 

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -2,9 +2,9 @@
 
 module Resolve
 
-include("resolve/versionweight.jl")
-include("resolve/interface.jl")
-include("resolve/maxsum.jl")
+include(joinpath("resolve", "versionweight.jl"))
+include(joinpath("resolve", "interface.jl"))
+include(joinpath("resolve", "maxsum.jl"))
 
 using ..Types, ..Query, .PkgToMaxSumInterface, .MaxSum
 import ...Pkg.PkgError


### PR DESCRIPTION
The only locations that don't use `joinpath` (other than test files which I didn't bother with) are listed below:

base\coreimg.jl:
   63: include("docs/core.jl")

base\sysimg.jl:
  123: include("strings/string.jl")
  165:     include("docs/core.jl")
  176: include("strings/strings.jl")
  225: include("grisu/grisu.jl")
  326: include("linalg/linalg.jl")
  351: include("pkg/pkg.jl")
  358: include("dates/Dates.jl")
  362: include("sparse/sparse.jl")
  367: include("distributed/Distributed.jl")
  381: include("docs/helpdb.jl")
  382: include("docs/basedocs.jl")
  385: include("markdown/Markdown.jl")
  386: include("docs/Docs.jl")

base\strings\strings.jl:
    3: include("strings/errors.jl")
    4: include("strings/types.jl")
    5: include("strings/basic.jl")
    6: include("strings/search.jl")
    7: include("strings/util.jl")
    8: include("strings/io.jl")

for the reason that they need the `Filesystem` module, but that doesn't get loaded till later in `sysimg.jl`