### PR TITLE
Updated `filter!` to take an `AbstractVector` vs a `Vector`.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1806,7 +1806,7 @@ julia> filter(isodd, a)
 """
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
-function filter!(f, a::Vector)
+function filter!(f, a::AbstractVector)
     insrt = 1
     for acurr in a
         if f(acurr)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1807,20 +1807,20 @@ julia> filter(isodd, a)
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
 function filter!(f, a::AbstractVector)
-    if !isempty(a)
-        idx = eachindex(a)
-        state = start(idx)
-        i, state = next(idx, state)
+    isempty(a) && return a
 
-        for acurr in a
-            if f(acurr)
-                a[i] = acurr
-                i, state = next(idx, state)
-            end
+    idx = eachindex(a)
+    state = start(idx)
+    i, state = next(idx, state)
+
+    for acurr in a
+        if f(acurr)
+            a[i] = acurr
+            i, state = next(idx, state)
         end
-
-        deleteat!(a, i:last(idx))
     end
+
+    deleteat!(a, i:last(idx))
 
     return a
 end

--- a/base/array.jl
+++ b/base/array.jl
@@ -1807,18 +1807,21 @@ julia> filter(isodd, a)
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
 function filter!(f, a::AbstractVector)
-    idx = eachindex(a)
-    state = start(idx)
-    (i, state) = next(idx, state)
+    if !isempty(a)
+        idx = eachindex(a)
+        state = start(idx)
+        i, state = next(idx, state)
 
-    for acurr in a
-        if f(acurr)
-            a[i] = acurr
-            (i, state) = next(idx, state)
+        for acurr in a
+            if f(acurr)
+                a[i] = acurr
+                i, state = next(idx, state)
+            end
         end
+
+        deleteat!(a, i:last(idx))
     end
 
-    deleteat!(a, i:last(idx))
     return a
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1807,14 +1807,18 @@ julia> filter(isodd, a)
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
 function filter!(f, a::AbstractVector)
-    insrt = 1
+    idx = eachindex(a)
+    state = start(idx)
+    (i, state) = next(idx, state)
+
     for acurr in a
         if f(acurr)
-            a[insrt] = acurr
-            insrt += 1
+            a[i] = acurr
+            (i, state) = next(idx, state)
         end
     end
-    deleteat!(a, insrt:length(a))
+
+    deleteat!(a, i:last(idx))
     return a
 end
 

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -198,6 +198,24 @@ end
     val
 end
 
+@inline function Base.deleteat!(A::OffsetArray, i::Int)
+    checkbounds(A, i)
+    @inbounds deleteat!(parent(A), offset(A.offsets, (i,))[1])
+end
+
+@inline function Base.deleteat!{T,N}(A::OffsetArray{T,N}, I::Vararg{Int, N})
+    checkbounds(A, I...)
+    @inbounds deleteat!(parent(A), offset(A.offsets, I)...)
+end
+
+@inline function Base.deleteat!(A::OffsetArray, i::UnitRange{Int})
+    checkbounds(A, first(i))
+    checkbounds(A, last(i))
+    first_idx = offset(A.offsets, (first(i),))[1]
+    last_idx = offset(A.offsets, (last(i),))[1]
+    @inbounds deleteat!(parent(A), first_idx:last_idx)
+end
+
 # Computing a shifted index (subtracting the offset)
 offset{N}(offsets::NTuple{N,Int}, inds::NTuple{N,Int}) = _offset((), offsets, inds)
 _offset(out, ::Tuple{}, ::Tuple{}) = out

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1081,6 +1081,24 @@ end
     end
 end
 
+@testset "filter!" begin
+    # base case w/ Vector
+    a = collect(1:10)
+    filter!(x -> x > 5, a)
+
+    # different subtype of AbstractVector
+    @test a == collect(6:10)
+    ba = rand(10) .> 0.5
+    filter!(x -> x, ba)
+    @test all(ba)
+
+    # empty array
+    ea = []
+    filter!(x -> x > 5, ea)
+    @test isempty(ea)
+end
+
+
 @testset "deleteat!" begin
     for idx in Any[1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:10,
                    8:9, 9:10, 6:9, 7:10]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # Array test
+isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
+using TestHelpers.OAs
 
 @testset "basics" begin
     @test length([1, 2, 3]) == 3
@@ -1097,6 +1099,16 @@ end
     ea = []
     filter!(x -> x > 5, ea)
     @test isempty(ea)
+
+    # non-1-indexed array
+    oa = OffsetArray(collect(1:10), -5)
+    filter!(x -> x > 5, oa)
+    @test oa == OffsetArray(collect(6:10), -5)
+
+    # empty non-1-indexed array
+    eoa = OffsetArray([], -5)
+    filter!(x -> x > 5, eoa)
+    @test isempty(eoa)
 end
 
 
@@ -1210,9 +1222,6 @@ end
 A = [[i i; i i] for i=1:2]
 @test cumsum(A) == Any[[1 1; 1 1], [3 3; 3 3]]
 @test cumprod(A) == Any[[1 1; 1 1], [4 4; 4 4]]
-
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using TestHelpers.OAs
 
 @testset "prepend/append" begin
     # PR #4627

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1085,10 +1085,11 @@ end
     # base case w/ Vector
     a = collect(1:10)
     filter!(x -> x > 5, a)
+    @test a == collect(6:10)
 
     # different subtype of AbstractVector
-    @test a == collect(6:10)
     ba = rand(10) .> 0.5
+    @test isa(ba, BitArray)
     filter!(x -> x, ba)
     @test all(ba)
 


### PR DESCRIPTION
Allow `filter!` to operate on `AbstractVector`s. This pushes the requirement to whether or not `deleteat!` is implemented for the array. My use case is that I want `filter!` to work on `NullableArray`s and `DataArray`s, which already have `deleteat!` implemented.