### PR TITLE
fix #21410, need to handle static param values with free typevars

### DIFF
--- a/test/inference.jl
+++ b/test/inference.jl
@@ -745,3 +745,7 @@ type T10207{A, B}
     b::B
 end
 @test code_typed(T10207, (Int,Any))[1].second == T10207{Int,T} where T
+
+# issue #21410
+f21410(::V, ::Pair{V,E}) where {V, E} = E
+@test code_typed(f21410, Tuple{Ref, Pair{Ref{T},Ref{T}} where T<:Number})[1].second == Type{Ref{T}} where T<:Number


### PR DESCRIPTION
Inference already handled the case where an inferred static parameter value is a free type variable; this needed to be generalized to any type containing free variables.