### PR TITLE
Use comprehension instead of map for AbstractArray filter

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1803,7 +1803,7 @@ julia> filter(isodd, a)
  9
 ```
 """
-filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
+filter(f, As::AbstractArray) = As[Bool[f(x) for x in As]]
 
 function filter!(f, a::Vector)
     insrt = 1


### PR DESCRIPTION
It now works with `NullableArray` and appears to be faster on regular `Array` and especially on `SparseMatrixCSC`. 