### PR TITLE
add docstring to base/Dates, base/Pkg

### DIFF
--- a/base/dates/Dates.jl
+++ b/base/dates/Dates.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 """
+    Dates
+
 The `Dates` module provides `Date`, `DateTime`, `Time` types, and related functions.
 
 The types are not aware of time zones, based on UT seconds

--- a/base/dates/Dates.jl
+++ b/base/dates/Dates.jl
@@ -1,20 +1,32 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 """
-The Dates module provides `Date`, `DateTime`, `Time` types, and related funtions.
+The `Dates` module provides `Date`, `DateTime`, `Time` types, and related functions.
 
-The types are *timezone-unaware*, based on UT seconds (1/86400 of a day),
-and the proleptic Gregorian calendar, as specified in ISO 8601.
+The types are not aware of time zones, based on UT seconds
+(86400 seconds a day, avoiding leap seconds), and
+use the proleptic Gregorian calendar, as specified in ISO 8601.
 For time zone functionality, see the TimeZones.jl package.
 
-Try
-`dt = DateTime(2017,12,31,23,59,59,999)`,
-`d1 = Date(Dates.Month(12), Dates.Year(2017))`,
-`d2 = Date("2017-12-31", Dates.DateFormat("y-m-d"))`,
-`Dates.yearmonthday(d2)`,
-`d2-d1`.
+```jldoctest
+julia> dt = DateTime(2017,12,31,23,59,59,999)
+2017-12-31T23:59:59.999
 
-Please see the docs for Date and DateTime for more information.
+julia> d1 = Date(Dates.Month(12), Dates.Year(2017))
+2017-12-01
+
+julia> d2 = Date("2017-12-31", Dates.DateFormat("y-m-d"))
+2017-12-31
+
+julia> Dates.yearmonthday(d2)
+(2017,12,31)
+
+julia> d2-d1
+30 days
+```
+
+Please see the manual section on [`Date`](@ref) and [`DateTime`](@ref)
+for more information.
 """
 module Dates
 

--- a/base/dates/Dates.jl
+++ b/base/dates/Dates.jl
@@ -21,7 +21,7 @@ julia> d2 = Date("2017-12-31", Dates.DateFormat("y-m-d"))
 2017-12-31
 
 julia> Dates.yearmonthday(d2)
-(2017,12,31)
+(2017, 12, 31)
 
 julia> d2-d1
 30 days

--- a/base/dates/Dates.jl
+++ b/base/dates/Dates.jl
@@ -1,5 +1,21 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+"""
+The Dates module provides `Date`, `DateTime`, `Time` types, and related funtions.
+
+The types are *timezone-unaware*, based on UT seconds (1/86400 of a day),
+and the proleptic Gregorian calendar, as specified in ISO 8601.
+For time zone functionality, see the TimeZones.jl package.
+
+Try
+`dt = DateTime(2017,12,31,23,59,59,999)`,
+`d1 = Date(Dates.Month(12), Dates.Year(2017))`,
+`d2 = Date("2017-12-31", Dates.DateFormat("y-m-d"))`,
+`Dates.yearmonthday(d2)`,
+`d2-d1`.
+
+Please see the docs for Date and DateTime for more information.
+"""
 module Dates
 
 importall ..Base.Operators

--- a/base/dates/Dates.jl
+++ b/base/dates/Dates.jl
@@ -7,7 +7,7 @@ The `Dates` module provides `Date`, `DateTime`, `Time` types, and related functi
 
 The types are not aware of time zones, based on UT seconds
 (86400 seconds a day, avoiding leap seconds), and
-use the proleptic Gregorian calendar, as specified in ISO 8601.
+use the proleptic Gregorian calendar, as specified in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
 For time zone functionality, see the TimeZones.jl package.
 
 ```jldoctest

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -409,7 +409,7 @@ function summarize(io::IO, m::Module, binding)
         println(io, "---\n")
         println(io, readstring(readme))
     else
-        println(io, "No `README.md` found for module `", m, "`.\n")
+        println(io, "No docstring or `README.md` found for module `", m, "`.\n")
     end
 end
 

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -1,8 +1,10 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 """
-The Docs module provides the `@doc` macro which can be used to set and retrieve
-documentation metadata for Julia objects. Please see docs for the `@doc` macro for more
+The `Docs` module provides the `@doc` macro which can be used to set and retrieve
+documentation metadata for Julia objects.
+
+Please see the manual section on documentation for more
 information.
 """
 module Docs

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 """
+    Docs
+
 The `Docs` module provides the `@doc` macro which can be used to set and retrieve
 documentation metadata for Julia objects.
 

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 """
+    Pkg
+
 The `Pkg` module provides package management for Julia.
 Use
 `Pkg.status()` for a list of installed packages,

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -1,5 +1,14 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+"""
+The Pkg module provides package management for Julia.
+Try
+`Pkg.status()` for a list of installed pkgs,
+`Pkg.add("<pkg name>")` to add a package,
+`Pkg.update()` to update your packages.
+
+Please see the docs for package management for more information.
+"""
 module Pkg
 
 export Dir, Types, Reqs, Cache, Read, Query, Resolve, Write, Entry

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 """
-The Pkg module provides package management for Julia.
-Try
-`Pkg.status()` for a list of installed pkgs,
+The `Pkg` module provides package management for Julia.
+Use
+`Pkg.status()` for a list of installed packages,
 `Pkg.add("<pkg name>")` to add a package,
-`Pkg.update()` to update your packages.
+`Pkg.update()` to update the installed packages.
 
-Please see the docs for package management for more information.
+Please see the manual section on packages for more information.
 """
 module Pkg
 

--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -14,11 +14,12 @@ time, and leap seconds are unnecessary and avoided.
 
 Both [`Date`](@ref) and [`DateTime`](@ref) are basically immutable `Int64` wrappers. The single
 `instant` field of either type is actually a `UTInstant{P}` type, which represents a continuously
-increasing machine timeline based on the UT second [^1]. The [`DateTime`](@ref) type is *timezone-unaware*
-(in Python parlance) or is analogous to a *LocalDateTime* in Java 8. Additional time zone functionality
+increasing machine timeline based on the UT second [^1]. The [`DateTime`](@ref)
+type is not aware of time zones (*naive*, in Python parlance),
+analogous to a *LocalDateTime* in Java 8. Additional time zone functionality
 can be added through the [TimeZones.jl package](https://github.com/JuliaTime/TimeZones.jl/), which
 compiles the [IANA time zone database](http://www.iana.org/time-zones). Both [`Date`](@ref) and
-[`DateTime`](@ref) are based on the ISO 8601 standard, which follows the proleptic Gregorian calendar.
+[`DateTime`](@ref) are based on the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard, which follows the proleptic Gregorian calendar.
 One note is that the ISO 8601 standard is particular about BC/BCE dates. In general, the last
 day of the BC/BCE era, 1-12-31 BC/BCE, was followed by 1-1-1 AD/CE, thus no year zero exists.
 The ISO standard, however, states that 1 BC/BCE is year zero, so `0000-12-31` is the day before


### PR DESCRIPTION
Added very short doc string with a few basic usage examples. Extend the error msg if no documentation found for module.
Hoping that `Pkg.add("<pkg name>")` (the less-than, greater than) is unproblematic?