### PR TITLE
Do not use light version of colors by default

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -268,7 +268,7 @@ terminal(r::LineEditREPL) = r.t
 
 LineEditREPL(t::TextTerminal, envcolors = false) =  LineEditREPL(t,
                                               true,
-                                              Base.text_colors[:light_green],
+                                              Base.text_colors[:green],
                                               Base.input_color(),
                                               Base.answer_color(),
                                               Base.text_colors[:red],
@@ -960,7 +960,7 @@ mutable struct StreamREPL <: AbstractREPL
     waserror::Bool
     StreamREPL(stream,pc,ic,ac) = new(stream,pc,ic,ac,false)
 end
-StreamREPL(stream::IO) = StreamREPL(stream, Base.text_colors[:light_green], Base.input_color(), Base.answer_color())
+StreamREPL(stream::IO) = StreamREPL(stream, Base.text_colors[:green], Base.input_color(), Base.answer_color())
 run_repl(stream::IO) = run_repl(StreamREPL(stream))
 
 outstream(s::StreamREPL) = s.stream

--- a/base/version.jl
+++ b/base/version.jl
@@ -248,10 +248,10 @@ function banner(io::IO = STDOUT)
         c = text_colors
         tx = c[:normal] # text
         jl = c[:normal] # julia
-        d1 = c[:bold] * c[:light_blue]    # first dot
-        d2 = c[:bold] * c[:light_red]     # second dot
-        d3 = c[:bold] * c[:light_green]   # third dot
-        d4 = c[:bold] * c[:light_magenta] # fourth dot
+        d1 = c[:bold] * c[:blue]    # first dot
+        d2 = c[:bold] * c[:red]     # second dot
+        d3 = c[:bold] * c[:green]   # third dot
+        d4 = c[:bold] * c[:magenta] # fourth dot
 
         print(io,"""               $(d3)_$(tx)
            $(d1)_$(tx)       $(jl)_$(tx) $(d2)_$(d3)(_)$(d4)_$(tx)     |  A fresh approach to technical computing


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/11250#issuecomment-294922716 

It looks like all the underscore light_ colors ended up breaking the julia repl color setup for me on 0.6 on, e.g.,  the bash subsystem for windows.

