### PR TITLE
Add a callback to Base.require

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -105,6 +105,7 @@ const PAGES = [
             "devdocs/locks.md",
             "devdocs/offset-arrays.md",
             "devdocs/libgit2.md",
+            "devdocs/require.md",
         ],
         "Developing/debugging Julia's C code" => [
             "devdocs/backtraces.md",

--- a/doc/src/devdocs/require.md
+++ b/doc/src/devdocs/require.md
@@ -1,0 +1,40 @@
+# Module loading
+
+`Base.require`[@ref] is responsible for loading modules and it also manages the
+precompilation cache. It is the implementation of the `import` statement.
+
+## Experimental features
+The features below are experimental and not part of the stable Julia API.
+Before building upon them inform yourself about the current thinking and whether they might change soon.
+
+### Module loading callbacks
+
+It is possible to listen to the modules loaded by `Base.require`, by registering a callback.
+
+```julia
+loaded_packages = Channel{Symbol}()
+callback = (mod::Symbol) -> put!(loaded_packages, mod)
+push!(Base.package_callbacks, callback)
+```
+
+Please note that the symbol given to the callback is a non-unique identifier and
+it is the responsibility of the callback provider to walk the module chain to
+determine the fully qualified name of the loaded binding.
+
+The callback below is an example of how to do that:
+
+```julia
+# Get the fully-qualified name of a module.
+function module_fqn(name::Symbol)
+    fqn = Symbol[name]
+    mod = getfield(Main, name)
+    parent = Base.module_parent(mod)
+    while parent !== Main
+        push!(fqn, Base.module_name(parent))
+        parent = Base.module_parent(parent)
+    end
+    fqn = reverse!(fqn)
+    return join(fqn, '.')
+end
+```
+

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -89,6 +89,7 @@
       * [Proper maintenance and care of multi-threading locks](@ref)
       * [Arrays with custom indices](@ref)
       * [Base.LibGit2](@ref)
+      * [Module loading](@ref)
   * Developing/debugging Julia's C code
       * [Reporting and analyzing crashes (segfaults)](@ref)
       * [gdb debugging tips](@ref)


### PR DESCRIPTION
Packages such as `Requires.jl` need to be notified when a package is
successfully loaded. Currently we have to resolve to a horrible hack
that overrides `Base.require`. In a post 265 world this is no longer
feasible.