### PR TITLE
Create show_supertypes function

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -400,6 +400,13 @@ function summarize(io::IO, T::DataType, binding)
         end
         println(io, "```")
     end
+    if supertype(T) != Any
+        println(io, "**Supertype Hierarchy:**")
+        println(io, "```")
+        Base.show_supertypes(io, T)
+        println(io)
+        println(io, "```")
+    end
 end
 
 function summarize(io::IO, m::Module, binding)

--- a/base/show.jl
+++ b/base/show.jl
@@ -236,6 +236,16 @@ function show_datatype(io::IO, x::DataType)
     end
 end
 
+function show_supertypes(io::IO, typ::DataType)
+    print(io, typ)
+    while typ != Any
+        typ = supertype(typ)
+        print(io, " <: ", typ)
+    end
+end
+
+show_supertypes(typ::DataType) = show_supertypes(STDOUT, typ)
+
 macro show(exs...)
     blk = Expr(:block)
     for ex in exs

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -750,6 +750,11 @@ abstract type $(curmod_prefix)Undocumented.B <: $(curmod_prefix)Undocumented.A
 ```
 $(curmod_prefix)Undocumented.D
 ```
+
+**Supertype Hierarchy:**
+```
+$(curmod_prefix)Undocumented.B <: $(curmod_prefix)Undocumented.A <: Any
+```
 """)
 @test docstrings_equal(@doc(Undocumented.B), doc"$doc_str")
 
@@ -759,6 +764,11 @@ No documentation found.
 **Summary:**
 ```
 mutable struct $(curmod_prefix)Undocumented.C <: $(curmod_prefix)Undocumented.A
+```
+
+**Supertype Hierarchy:**
+```
+$(curmod_prefix)Undocumented.C <: $(curmod_prefix)Undocumented.A <: Any
 ```
 """)
 @test docstrings_equal(@doc(Undocumented.C), doc"$doc_str")
@@ -776,6 +786,11 @@ struct $(curmod_prefix)Undocumented.D <: $(curmod_prefix)Undocumented.B
 one   :: Any
 two   :: String
 three :: Float64
+```
+
+**Supertype Hierarchy:**
+```
+$(curmod_prefix)Undocumented.D <: $(curmod_prefix)Undocumented.B <: $(curmod_prefix)Undocumented.A <: Any
 ```
 """)
 @test docstrings_equal(@doc(Undocumented.D), doc"$doc_str")

--- a/test/show.jl
+++ b/test/show.jl
@@ -670,3 +670,6 @@ let m = which(T20332{Int}(), (Int,)),
 end
 
 @test sprint(show, Main) == "Main"
+
+@test sprint(Base.show_supertypes, Int64) == "Int64 <: Signed <: Integer <: Real <: Number <: Any"
+@test sprint(Base.show_supertypes, Vector{String}) == "Array{String,1} <: DenseArray{String,1} <: AbstractArray{String,1} <: Any"


### PR DESCRIPTION
A colleague of mine wanted to visualize the type hierarchy so I came up with this. I would like to potentially work it into `show` itself but I was unsure how I should integrate this.