### PR TITLE
avoid an extra copy in some cases of `readstring`

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -75,7 +75,7 @@ optionally specifying a size beyond which the underlying `Array` may not be grow
 """
 PipeBuffer(data::Vector{UInt8}=UInt8[], maxsize::Int=typemax(Int)) =
     AbstractIOBuffer(data,true,true,false,true,maxsize)
-PipeBuffer(maxsize::Int) = (x = PipeBuffer(Vector{UInt8}(maxsize),maxsize); x.size=0; x)
+PipeBuffer(maxsize::Int) = (x = PipeBuffer(StringVector(maxsize),maxsize); x.size=0; x)
 
 function copy(b::AbstractIOBuffer)
     ret = typeof(b)(b.writable ? copy(b.data) : b.data,

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -287,7 +287,7 @@ function read(s::IOStream)
             sz -= pos
         end
     end
-    b = Array{UInt8,1}(sz<=0 ? 1024 : sz)
+    b = StringVector(sz<=0 ? 1024 : sz)
     nr = readbytes_all!(s, b, typemax(Int))
     resize!(b, nr)
 end


### PR DESCRIPTION
The default definition of `readstring` is `String(read(io))`, which causes the data to be copied if the vector is not allocated with `StringVector`. This commit is a band-aid that fixes most cases, such as `readstring(filename)`.

A better definition of `readstring` would be something like `readbytes!(io, StringVector(0), typemax(Int))`, but this performs much worse in cases where the size of the data is known in advance (as with most files). We could improve that by adding a size estimate function that defaults to returning 0.