### PR TITLE
WIP: Stylistic and syntactic updates to the manual

### DIFF
--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -60,11 +60,11 @@ value of a boolean expression. Here is the anatomy of the `if`-`elseif`-`else` c
 
 ```julia
 if x < y
-  println("x is less than y")
+    println("x is less than y")
 elseif x > y
-  println("x is greater than y")
+    println("x is greater than y")
 else
-  println("x is equal to y")
+    println("x is equal to y")
 end
 ```
 
@@ -777,7 +777,7 @@ try bad() catch; x end
 
 try bad()
 catch
-  x
+    x
 end
 ```
 

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -194,27 +194,27 @@ most powerful and central feature of the Julia language. Core operations typical
 of methods:
 
 ```julia
- julia> methods(+)
- # 166 methods for generic function "+":
- +(a::Float16, b::Float16) at float16.jl:136
- +(x::Float32, y::Float32) at float.jl:206
- +(x::Float64, y::Float64) at float.jl:207
- +(x::Bool, z::Complex{Bool}) at complex.jl:126
- +(x::Bool, y::Bool) at bool.jl:48
- +(x::Bool) at bool.jl:45
- +{T<:AbstractFloat}(x::Bool, y::T) at bool.jl:55
- +(x::Bool, z::Complex) at complex.jl:133
- +(x::Bool, A::AbstractArray{Bool,N<:Any}) at arraymath.jl:105
- +(x::Char, y::Integer) at char.jl:40
- +{T<:Union{Int128,Int16,Int32,Int64,Int8,UInt128,UInt16,UInt32,UInt64,UInt8}}(x::T, y::T) at int.jl:32
- +(z::Complex, w::Complex) at complex.jl:115
- +(z::Complex, x::Bool) at complex.jl:134
- +(x::Real, z::Complex{Bool}) at complex.jl:140
- +(x::Real, z::Complex) at complex.jl:152
- +(z::Complex, x::Real) at complex.jl:153
- +(x::Rational, y::Rational) at rational.jl:179
- ...
- +(a, b, c, xs...) at operators.jl:119
+julia> methods(+)
+# 180 methods for generic function "+":
++(x::Bool, z::Complex{Bool}) in Base at complex.jl:224
++(x::Bool, y::Bool) in Base at bool.jl:89
++(x::Bool) in Base at bool.jl:86
++(x::Bool, y::T) where T<:AbstractFloat in Base at bool.jl:96
++(x::Bool, z::Complex) in Base at complex.jl:231
++(a::Float16, b::Float16) in Base at float.jl:372
++(x::Float32, y::Float32) in Base at float.jl:374
++(x::Float64, y::Float64) in Base at float.jl:375
++(z::Complex{Bool}, x::Bool) in Base at complex.jl:225
++(z::Complex{Bool}, x::Real) in Base at complex.jl:239
++(x::Char, y::Integer) in Base at char.jl:40
++(c::BigInt, x::BigFloat) in Base.MPFR at mpfr.jl:303
++(a::BigInt, b::BigInt, c::BigInt, d::BigInt, e::BigInt) in Base.GMP at gmp.jl:303
++(a::BigInt, b::BigInt, c::BigInt, d::BigInt) in Base.GMP at gmp.jl:296
++(a::BigInt, b::BigInt, c::BigInt) in Base.GMP at gmp.jl:290
++(x::BigInt, y::BigInt) in Base.GMP at gmp.jl:258
++(x::BigInt, c::Union{UInt16, UInt32, UInt64, UInt8}) in Base.GMP at gmp.jl:315
+...
++(a, b, c, xs...) at operators.jl:119
 ```
 
 Multiple dispatch together with the flexible parametric type system give Julia its ability to
@@ -545,7 +545,7 @@ Closest candidates are:
 More usefully, it is possible to constrain varargs methods by a parameter. For example:
 
 ```julia
-function getindex{T,N}(A::AbstractArray{T,N}, indexes::Vararg{Number,N})
+function getindex(A::AbstractArray{T,N}, indexes::Vararg{Number,N}) where {T,N}
 ```
 
 would be called only when the number of `indexes` matches the dimensionality of the array.
@@ -666,8 +666,8 @@ Below we discuss particular challenges and some alternative ways to resolve such
 `Tuple` (and `NTuple`) arguments present special challenges. For example,
 
 ```julia
-f{N}(x::NTuple{N,Int}) = 1
-f{N}(x::NTuple{N,Float64}) = 2
+f(x::NTuple{N,Int}) where {N} = 1
+f(x::NTuple{N,Float64}) where {N} = 2
 ```
 
 are ambiguous because of the possibility that `N == 0`: there are no
@@ -683,7 +683,7 @@ Alternatively, for all methods but one you can insist that there is at
 least one element in the tuple:
 
 ```julia
-f{N}(x::NTuple{N,Int}) = 1                  # this is the fallback
+f(x::NTuple{N,Int}) where {N} = 1           # this is the fallback
 f(x::Tuple{Float64, Vararg{Float64}}) = 2   # this requires at least one Float64
 ```
 
@@ -721,7 +721,7 @@ A related strategy exploits `promote` to bring `x` and `y` to a common
 type:
 
 ```julia
-f{T}(x::T, y::T) = ...
+f(x::T, y::T) where {T} = ...
 f(x, y) = f(promote(x, y)...)
 ```
 
@@ -761,13 +761,13 @@ Where possible, try to avoid defining methods that dispatch on
 specific element types of abstract containers. For example,
 
 ```julia
--{T<:Date}(A::AbstractArray{T}, b::Date)
+-(A::AbstractArray{T}, b::Date) where {T<:Date}
 ```
 
 generates ambiguities for anyone who defines a method
 
 ```julia
--{T}(A::MyArrayType{T}, b::T)
+-(A::MyArrayType{T}, b::T) where {T}
 ```
 
 The best approach is to avoid defining *either* of these methods:
@@ -784,7 +784,7 @@ can't be modified or eliminated.  As a last resort, one developer can
 define the "band-aid" method
 
 ```julia
--{T<:Date}(A::MyArrayType{T}, b::Date) = ...
+-(A::MyArrayType{T}, b::Date) where {T<:Date} = ...
 ```
 
 that resolves the ambiguity by brute force.

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -90,7 +90,7 @@ is that declaring more specific types leaves more "space" for future method defi
 Instead of:
 
 ```julia
-function double{T<:Number}(a::AbstractArray{T})
+function double(a::AbstractArray{<:Number})
     for i = 1:endof(a)
         a[i] *= 2
     end
@@ -101,7 +101,7 @@ end
 use:
 
 ```julia
-function double!{T<:Number}(a::AbstractArray{T})
+function double!(a::AbstractArray{<:Number})
     for i = 1:endof(a)
         a[i] *= 2
     end
@@ -123,7 +123,7 @@ Types such as `Union{Function,AbstractString}` are often a sign that some design
 When creating a type such as:
 
 ```julia
-type MyType
+struct MyType
     ...
     x::Union{Void,T}
 end
@@ -194,7 +194,7 @@ is already iterable it is often even better to leave it alone, and not convert i
 A function signature:
 
 ```julia
-foo{T<:Real}(x::T) = ...
+foo(x::T) where {T<:Real} = ...
 ```
 
 should be written as:
@@ -243,7 +243,7 @@ it will naturally have access to the run-time values it needs.
 If you have a type that uses a native pointer:
 
 ```julia
-type NativeType
+mutable struct NativeType
     p::Ptr{UInt8}
     ...
 end

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -129,3 +129,5 @@ conventions:
   * Functions that write to their arguments have names that end in `!`. These are sometimes called
     "mutating" or "in-place" functions because they are intended to produce changes in their arguments
     after the function is called, not just return a value.
+
+For more information about stylistic conventions, see the [Style Guide](@ref).


### PR DESCRIPTION
Not ready to be merged yet, still a WIP.

My goal here is to make the stylistic conventions in the manual consistent, including (but not limited to) migrating to `where` and `struct` syntax as well as using the standard 4 spaces for indentation everywhere.