### PR TITLE
improve yieldto error handling

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -104,10 +104,9 @@ true
 """
 function Channel(func::Function; ctype=Any, csize=0, taskref=nothing)
     chnl = Channel{ctype}(csize)
-    task = Task(()->func(chnl))
-    bind(chnl,task)
-    schedule(task)
-    yield()
+    task = Task(() -> func(chnl))
+    bind(chnl, task)
+    yield(task) # immediately start it
 
     isa(taskref, Ref{Task}) && (taskref[] = task)
     return chnl
@@ -215,14 +214,13 @@ function channeled_tasks(n::Int, funcs...; ctypes=fill(Any,n), csizes=fill(0,n))
     @assert length(csizes) == n
     @assert length(ctypes) == n
 
-    chnls = map(i->Channel{ctypes[i]}(csizes[i]), 1:n)
-    tasks=Task[Task(()->f(chnls...)) for f in funcs]
+    chnls = map(i -> Channel{ctypes[i]}(csizes[i]), 1:n)
+    tasks = Task[ Task(() -> f(chnls...)) for f in funcs ]
 
     # bind all tasks to all channels and schedule them
-    foreach(t -> foreach(c -> bind(c,t), chnls), tasks)
+    foreach(t -> foreach(c -> bind(c, t), chnls), tasks)
     foreach(schedule, tasks)
-
-    yield()  # Allow scheduled tasks to run
+    yield() # Allow scheduled tasks to run
 
     return (chnls, tasks)
 end
@@ -283,9 +281,8 @@ function put_unbuffered(c::Channel, v)
         end
     end
     taker = shift!(c.takers)
-    schedule(current_task())
-    yieldto(taker, v)
-    v
+    yield(taker, v) # immediately give taker a chance to run, but don't block the current task
+    return v
 end
 
 push!(c::Channel, v) = put!(c, v)
@@ -328,8 +325,12 @@ function take_unbuffered(c::Channel{T}) where T
     push!(c.takers, current_task())
     try
         if length(c.putters) > 0
-            putter = shift!(c.putters)
-            return yieldto(putter)::T
+            let putter = shift!(c.putters)
+                return Base.try_yieldto(putter) do
+                    # if we fail to start putter, put it back in the queue
+                    unshift!(c.putters, putter)
+                end::T
+            end
         else
             return wait()::T
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -238,7 +238,7 @@ function task_done_hook(t::Task)
         if isa(result,InterruptException) && isdefined(Base,:active_repl_backend) &&
             active_repl_backend.backend_task.state == :runnable && isempty(Workqueue) &&
             active_repl_backend.in_eval
-            throwto(active_repl_backend.backend_task, result)
+            throwto(active_repl_backend.backend_task, result) # this terminates the task
         end
         if !suppress_excp_printing(t)
             let bt = t.backtrace
@@ -253,7 +253,7 @@ function task_done_hook(t::Task)
     end
     # Clear sigatomic before waiting
     sigatomic_end()
-    wait()
+    wait() # this will not return
 end
 
 

--- a/doc/src/stdlib/parallel.md
+++ b/doc/src/stdlib/parallel.md
@@ -4,11 +4,11 @@
 
 ```@docs
 Core.Task
-Base.yieldto
 Base.current_task
 Base.istaskdone
 Base.istaskstarted
 Base.yield
+Base.yieldto
 Base.task_local_storage(::Any)
 Base.task_local_storage(::Any, ::Any)
 Base.task_local_storage(::Function, ::Any, ::Any)

--- a/src/dump.c
+++ b/src/dump.c
@@ -81,7 +81,7 @@ static const jl_fptr_t id_to_fptrs[] = {
   jl_f_tuple, jl_f_svec, jl_f_intrinsic_call, jl_f_invoke_kwsorter,
   jl_f_getfield, jl_f_setfield, jl_f_fieldtype, jl_f_nfields,
   jl_f_arrayref, jl_f_arrayset, jl_f_arraysize, jl_f_apply_type,
-  jl_f_applicable, jl_f_invoke, jl_unprotect_stack, jl_f_sizeof, jl_f__expr,
+  jl_f_applicable, jl_f_invoke, jl_f_sizeof, jl_f__expr,
   NULL };
 
 static const intptr_t LongSymbol_tag   = 23;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1710,7 +1710,6 @@ static void jl_gc_mark_thread_local(jl_ptls_t ptls, jl_ptls_t ptls2)
     gc_push_root(ptls, ptls2->current_task, 0);
     gc_push_root(ptls, ptls2->root_task, 0);
     gc_push_root(ptls, ptls2->exception_in_transit, 0);
-    gc_push_root(ptls, ptls2->task_arg_in_transit, 0);
 }
 
 // mark the initial root set

--- a/src/gc.c
+++ b/src/gc.c
@@ -1734,7 +1734,9 @@ static void mark_roots(jl_ptls_t ptls)
     if (jl_all_methods != NULL)
         gc_push_root(ptls, jl_all_methods, 0);
 
-    // gc_push_root(ptls, jl_unprotect_stack_func, 0);
+#ifndef COPY_STACKS
+    gc_push_root(ptls, jl_unprotect_stack_func, 0);
+#endif
 
     // constants
     gc_push_root(ptls, jl_typetype_type, 0);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1495,7 +1495,7 @@ typedef struct _jl_task_t {
 } jl_task_t;
 
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
-JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);
+JL_DLLEXPORT void jl_switchto(jl_task_t *t);
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e);
@@ -1797,7 +1797,6 @@ typedef struct {
 #define jl_current_task (jl_get_ptls_states()->current_task)
 #define jl_root_task (jl_get_ptls_states()->root_task)
 #define jl_exception_in_transit (jl_get_ptls_states()->exception_in_transit)
-#define jl_task_arg_in_transit (jl_get_ptls_states()->task_arg_in_transit)
 
 
 // codegen interface ----------------------------------------------------------

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -401,7 +401,6 @@ JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t);
 #define JL_CALLABLE(name)                                               \
     JL_DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)
 
-JL_CALLABLE(jl_unprotect_stack);
 JL_CALLABLE(jl_f_tuple);
 JL_CALLABLE(jl_f_intrinsic_call);
 extern jl_function_t *jl_unprotect_stack_func;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -105,7 +105,6 @@ typedef struct _jl_tls_states_t {
     struct _jl_module_t *current_module;
     struct _jl_task_t *volatile current_task;
     struct _jl_task_t *root_task;
-    struct _jl_value_t *volatile task_arg_in_transit;
     void *stackbase;
     char *stack_lo;
     char *stack_hi;

--- a/src/task.c
+++ b/src/task.c
@@ -210,10 +210,15 @@ static void JL_NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
 #ifdef COPY_STACKS
     t->stkbuf = (void*)(intptr_t)-1;
 #endif
+    // ensure that state is cleared
+    ptls->in_finalizer = 0;
+    ptls->in_pure_callback = 0;
+    jl_get_ptls_states()->world_age = jl_world_counter;
     if (ptls->tid != 0) {
         // For now, only thread 0 runs the task scheduler.
         // The others return to the thread loop
-        jl_switchto(ptls->root_task, jl_nothing);
+        ptls->root_task->result = jl_nothing;
+        jl_switchto(ptls->root_task);
         gc_debug_critical_error();
         abort();
     }
@@ -234,15 +239,6 @@ static void JL_NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
     abort();
 }
 
-static void throw_if_exception_set(jl_task_t *t)
-{
-    if (t->exception != NULL && t->exception != jl_nothing) {
-        jl_value_t *exc = t->exception;
-        t->exception = jl_nothing;
-        jl_throw(exc);
-    }
-}
-
 static void record_backtrace(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
@@ -256,7 +252,7 @@ static void NOINLINE JL_NORETURN start_task(void)
     jl_task_t *t = ptls->current_task;
     jl_value_t *res;
     t->started = 1;
-    if (t->exception != NULL && t->exception != jl_nothing) {
+    if (t->exception != jl_nothing) {
         record_backtrace();
         res = t->exception;
     }
@@ -276,7 +272,6 @@ static void NOINLINE JL_NORETURN start_task(void)
             jl_gc_wb(t, res);
         }
     }
-    jl_get_ptls_states()->world_age = jl_world_counter; // TODO
     finish_task(t, res);
     gc_debug_critical_error();
     abort();
@@ -400,18 +395,17 @@ static void ctx_switch(jl_ptls_t ptls, jl_task_t *t, jl_jmp_buf *where)
 #endif
 }
 
-JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg)
+JL_DLLEXPORT void jl_switchto(jl_task_t *t)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (t == ptls->current_task) {
-        throw_if_exception_set(t);
-        return arg;
+        return;
     }
     if (t->state == done_sym || t->state == failed_sym ||
         (t->stkbuf == (void*)(intptr_t)-1)) {
-        if (t->exception != jl_nothing)
-            jl_throw(t->exception);
-        return t->result;
+        ptls->current_task->exception = t->exception;
+        ptls->current_task->result = t->result;
+        return;
     }
     if (ptls->in_finalizer)
         jl_error("task switch not allowed from inside gc finalizer");
@@ -419,17 +413,12 @@ JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg)
         jl_error("task switch not allowed from inside staged nor pure functions");
     sig_atomic_t defer_signal = ptls->defer_signal;
     int8_t gc_state = jl_gc_unsafe_enter(ptls);
-    ptls->task_arg_in_transit = arg;
     ctx_switch(ptls, t, &t->ctx);
-    jl_value_t *val = ptls->task_arg_in_transit;
-    ptls->task_arg_in_transit = jl_nothing;
-    throw_if_exception_set(ptls->current_task);
     jl_gc_unsafe_leave(ptls, gc_state);
     sig_atomic_t other_defer_signal = ptls->defer_signal;
     ptls->defer_signal = defer_signal;
     if (other_defer_signal && !defer_signal)
         jl_sigint_safepoint(ptls);
-    return val;
 }
 
 #ifndef COPY_STACKS
@@ -738,7 +727,6 @@ void jl_init_root_task(void *stack, size_t ssize)
     ptls->root_task = ptls->current_task;
 
     ptls->exception_in_transit = (jl_value_t*)jl_nothing;
-    ptls->task_arg_in_transit = (jl_value_t*)jl_nothing;
 }
 
 JL_DLLEXPORT int jl_is_task_started(jl_task_t *t)


### PR DESCRIPTION
previously we couldn't reliably tell the difference between a failure to context switch
and an explicitly scheduled error

in the former case, we often need to undo some prior action
by moving the code for the later into Julia,
we can reliably run the necessary undo action when required

fix #21442