### PR TITLE
use MKL when available for sparse * dense

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -43,19 +43,23 @@ end
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 
+function _check_A_mul_B(A, B, C, transpose)
+    if transpose
+        A.n == size(C, 1) || throw(DimensionMismatch())
+        A.m == size(B, 1) || throw(DimensionMismatch())
+    else
+        A.n == size(B, 1) || throw(DimensionMismatch())
+        A.m == size(C, 1) || throw(DimensionMismatch())
+    end
+    size(B, 2) == size(C, 2) || throw(DimensionMismatch())
+end
+
 for (f, op, transp) in ((:A_mul_B, :identity, false),
                         (:Ac_mul_B, :ctranspose, true),
                         (:At_mul_B, :transpose, true))
     @eval begin
         function $(Symbol(f,:!))(α::Number, A::SparseMatrixCSC, B::StridedVecOrMat, β::Number, C::StridedVecOrMat)
-            if $transp
-                A.n == size(C, 1) || throw(DimensionMismatch())
-                A.m == size(B, 1) || throw(DimensionMismatch())
-            else
-                A.n == size(B, 1) || throw(DimensionMismatch())
-                A.m == size(C, 1) || throw(DimensionMismatch())
-            end
-            size(B, 2) == size(C, 2) || throw(DimensionMismatch())
+            _check_A_mul_B(A, B, C, $transp)
             nzv = A.nzval
             rv = A.rowval
             if β != 1

--- a/base/sparse/mkl_sparse.jl
+++ b/base/sparse/mkl_sparse.jl
@@ -1,0 +1,56 @@
+import Base.LinAlg: BlasInt, BlasFloat, BlasReal
+
+for (mv, mm, T) in ((:mkl_scscmv_, :mkl_scscmm_, :Float32),
+                    (:mkl_dcscmv_, :mkl_dcscmm_, :Float64),
+                    (:mkl_ccscmv_, :mkl_ccscmm_, :Complex64),
+                    (:mkl_zcscmv_, :mkl_zcscmm_, :Complex128))
+  @eval begin
+      function cscmv!(transa::Char, α::$T, matdescra::String, A::SparseMatrixCSC{$T, BlasInt}, x::StridedVector{$T}, β::$T, y::StridedVector{$T})
+          trns = uppercase(transa)
+          in(trns, ['N','T','C']) || error("uppercase(transa) is '$trns', must be 'N' or 'T'")
+          length(x) == (trns == 'T' ? A.m : A.n) ||
+              throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with vector of length $(length(x))"))
+          length(y) == (trns == 'T' ? A.n : A.m) ||
+              throw(DimensionMismatch("Vector of length $(A.m) added to vector of length $(length(y))"))
+          ccall(($(string(mv)), Base.BLAS.libblas), Void,
+              (Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T},
+               Ptr{UInt8}, Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt},
+               Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{$T}),
+              &transa, &A.m, &A.n, &α,
+              matdescra, A.nzval, A.rowval, pointer(A.colptr, 1),
+              pointer(A.colptr, 2), x, &β, y)
+          return y
+      end
+
+      function cscmm!(transa::Char, α::$T, matdescra::String, A::SparseMatrixCSC{$T, BlasInt}, B::StridedMatrix{$T}, β::$T, C::StridedMatrix{$T})
+          mB, nB = size(B)
+          mC, nC = size(C)
+          A.n == mB || throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with matrix with $(mB) rows"))
+          A.m == mC || throw(DimensionMismatch("Matrix with $(A.m) rows added to matrix with $(mC) rows"))
+          nB == nC || throw(DimensionMismatch("Matrix with $(nB) columns added to matrix with $(nC) columns"))
+          ccall(($(string(mm)), Base.BLAS.libblas), Void,
+              (Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+               Ptr{$T}, Ptr{UInt8}, Ptr{$T}, Ptr{BlasInt},
+               Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt},
+               Ptr{$T}, Ptr{$T}, Ptr{BlasInt}),
+              &transa, &A.m, &nC, &A.n,
+              &α, matdescra, A.nzval, A.rowval,
+              pointer(A.colptr, 1), pointer(A.colptr, 2), B, &mB,
+              &β, C, &mC)
+          return C
+        end
+    end
+end
+
+for (f, C, transp) in ((:A_mul_B, 'N', false),
+                       (:Ac_mul_B, 'C', true),
+                       (:At_mul_B, 'T', true))
+    @eval begin
+        function $(Symbol(f,:!))(α::T, A::SparseMatrixCSC{T,BlasInt}, B::StridedVecOrMat{T}, β::T, C::StridedVecOrMat{T}) where T <: BlasFloat
+            _check_A_mul_B(A, B, C, $transp)
+            isa(B,AbstractVector) ?
+                cscmv!($C, α, "GUUF", A ,B, β, C) :
+                cscmm!($C, α, "GUUF", A ,B, β, C)
+        end
+    end
+end

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -35,6 +35,9 @@ include("abstractsparse.jl")
 include("sparsematrix.jl")
 include("sparsevector.jl")
 include("higherorderfns.jl")
+if Base.BLAS.vendor() == :mkl
+    include("mkl_sparse.jl")
+end
 
 include("linalg.jl")
 if Base.USE_GPL_LIBS


### PR DESCRIPTION
This moves some code over from https://github.com/JuliaSparse/MKLSparse.jl to Base, so that everyone who compiles with MKL get's (potentially) faster sparse matrix * dense (vector / matrix), which is important in iterative solvers. On my laptop, it was about 25% faster for one "div grad"-matrix I tested.

cc @dmbates from whom the code originally comes from.

Would be nice if the people who regularly use MKL could test this. Tests passes locally using MKL as blas library.