### PR TITLE
Evaluate thread range only once

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -23,9 +23,10 @@ function _threadsfor(iter,lbody)
     lidx = iter.args[1]         # index
     range = iter.args[2]
     quote
+        range = $(esc(range))
         function $fun()
             tid = threadid()
-            r = $(esc(range))
+            r = range # Load into local variable
             # divide loop iterations among threads
             len, rem = divrem(length(r), nthreads())
             # not enough iterations for all the threads?

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -390,6 +390,20 @@ else
     @test_throws ErrorException cglobal(:jl_tls_states)
 end
 
+function test_thread_range()
+    a = zeros(Int, nthreads())
+    @threads for i in 1:threadid()
+        a[i] = 1
+    end
+    for i in 1:threadid()
+        @test a[i] == 1
+    end
+    for i in (threadid() + 1):nthreads()
+        @test a[i] == 0
+    end
+end
+test_thread_range()
+
 # Thread safety of `jl_load_and_lookup`.
 function test_load_and_lookup_18020(n)
     @threads for i in 1:n


### PR DESCRIPTION
Noticed when a typo in the thread range didn't throw an error since it was running on the thread with the error swallowed. Is there a reason why we weren't doing this? Unless I'm missing something, doing this only once on the master thread seems to be better both performance wise and semantic wise.
