### PR TITLE
More stylistic updates to the manual for consistency

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -513,7 +513,7 @@ iterate over any array type.
 If you write a custom `AbstractArray` type, you can specify that it has fast linear indexing using
 
 ```julia
-Base.IndexStyle{T<:MyArray}(::Type{T}) = IndexLinear()
+Base.IndexStyle(::Type{<:MyArray}) = IndexLinear()
 ```
 
 This setting will cause `eachindex` iteration over a `MyArray` to use integers. If you don't
@@ -716,7 +716,7 @@ Julia sparse matrices have the type `SparseMatrixCSC{Tv,Ti}`, where `Tv` is the 
 values, and `Ti` is the integer type for storing column pointers and row indices.:
 
 ```julia
-type SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
+struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows
     n::Int                  # Number of columns
     colptr::Vector{Ti}      # Column i is in colptr[i]:(colptr[i+1]-1)

--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -119,8 +119,8 @@ julia> dt2 = Date("2015-01-02",df)
 You can also use the `dateformat""` string macro. This macro creates the `DateFormat` object once when the macro is expanded and uses the same `DateFormat` object even if a code snippet is run multiple times.
 
 ```jldoctest
-julia> for i=1:10^5
-           Date("2015-01-01",dateformat"y-m-d")
+julia> for i = 1:10^5
+           Date("2015-01-01", dateformat"y-m-d")
        end
 ```
 

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -267,7 +267,7 @@ instance, rather than just on the type itself. In these cases, you can add a met
 for your custom type that returns the documentation on a per-instance basis. For instance,
 
 ```julia
-type MyType
+struct MyType
     value::String
 end
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -29,7 +29,7 @@ you can redefine types and constants.  You can't import the type names into `Mai
 to be able to redefine them there, but you can use the module name to resolve the scope.  In other
 words, while developing you might use a workflow something like this:
 
-```
+```julia
 include("mynewcode.jl")              # this defines a module MyModule
 obj1 = MyModule.ObjConstructor(a, b)
 obj2 = MyModule.somefunction(obj1)
@@ -108,10 +108,10 @@ have two options:
 
 1. Use `import`:
 
-   ```
+   ```julia
    import Foo
    function bar(...)
-       ... refer to Foo symbols via Foo.baz ...
+       # ... refer to Foo symbols via Foo.baz ...
    end
    ```
 
@@ -120,12 +120,12 @@ have two options:
    `Foo` symbols by their qualified names `Foo.bar` etc.
 2. Wrap your function in a module:
 
-   ```
+   ```julia
    module Bar
    export bar
    using Foo
    function bar(...)
-       ... refer to Foo.baz as simply baz ....
+       # ... refer to Foo.baz as simply baz ....
    end
    end
    using Bar

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -189,14 +189,14 @@ history without prefix search, one could put the following code in `.juliarc.jl`
 import Base: LineEdit, REPL
 
 const mykeys = Dict{Any,Any}(
-  # Up Arrow
-  "\e[A" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_prev(s, LineEdit.mode(s).hist)),
-  # Down Arrow
-  "\e[B" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_next(s, LineEdit.mode(s).hist))
+    # Up Arrow
+    "\e[A" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_prev(s, LineEdit.mode(s).hist)),
+    # Down Arrow
+    "\e[B" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_next(s, LineEdit.mode(s).hist))
 )
 
 function customize_keys(repl)
-  repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys)
+    repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys)
 end
 
 atreplinit(customize_keys)

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -294,11 +294,11 @@ julia> SparseArray{T,N}(::Type{T}, dims::NTuple{N,Int}) = SparseArray{T,N}(Dict{
 
 julia> Base.size(A::SparseArray) = A.dims
 
-julia> Base.similar{T}(A::SparseArray, ::Type{T}, dims::Dims) = SparseArray(T, dims)
+julia> Base.similar(A::SparseArray, ::Type{T}, dims::Dims) where {T} = SparseArray(T, dims)
 
-julia> Base.getindex{T,N}(A::SparseArray{T,N}, I::Vararg{Int,N}) = get(A.data, I, zero(T))
+julia> Base.getindex(A::SparseArray{T,N}, I::Vararg{Int,N}) where {T,N} = get(A.data, I, zero(T))
 
-julia> Base.setindex!{T,N}(A::SparseArray{T,N}, v, I::Vararg{Int,N}) = (A.data[I] = v)
+julia> Base.setindex!(A::SparseArray{T,N}, v, I::Vararg{Int,N}) where {T,N} = (A.data[I] = v)
 ```
 
 Notice that this is an `IndexCartesian` array, so we must manually define [`getindex()`](@ref) and [`setindex!()`](@ref)

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -474,7 +474,7 @@ I execute at runtime. The argument is: (1, 2, 3)
 
 Macros are invoked with the following general syntax:
 
-```
+```julia
 @name expr1 expr2 ...
 @name(expr1, expr2, ...)
 ```
@@ -484,7 +484,7 @@ expressions in the first form, and the lack of whitespace after `@name` in the s
 two styles should not be mixed. For example, the following syntax is different from the examples
 above; it passes the tuple `(expr1, expr2, ...)` as one argument to the macro:
 
-```
+```julia
 @name (expr1, expr2, ...)
 ```
 
@@ -661,7 +661,7 @@ with any user variables, and `time` and `println` will refer to the standard lib
 
 One problem remains however. Consider the following use of this macro:
 
-```
+```julia
 module MyModule
 import Base.@time
 
@@ -675,7 +675,7 @@ Here the user expression `ex` is a call to `time`, but not the same `time` funct
 uses. It clearly refers to `MyModule.time`. Therefore we must arrange for the code in `ex` to
 be resolved in the macro call environment. This is done by "escaping" the expression with [`esc()`](@ref):
 
-```
+```julia
 macro time(ex)
     ...
     local val = $(esc(ex))
@@ -1075,7 +1075,7 @@ can be used to index into an array `A` using `A[i]`, instead of `A[x,y,z,...]`. 
 is the following:
 
 ```jldoctest sub2ind
-julia> function sub2ind_loop{N}(dims::NTuple{N}, I::Integer...)
+julia> function sub2ind_loop(dims::NTuple{N}, I::Integer...) where N
            ind = I[N] - 1
            for i = N-1:-1:1
                ind = I[i]-1 + dims[i]*ind
@@ -1114,7 +1114,7 @@ we use generated functions to manually unroll the loop. The body becomes almost 
 instead of calculating the linear index, we build up an *expression* that calculates the index:
 
 ```jldoctest sub2ind_gen
-julia> @generated function sub2ind_gen{N}(dims::NTuple{N}, I::Integer...)
+julia> @generated function sub2ind_gen(dims::NTuple{N}, I::Integer...) where N
            ex = :(I[$N] - 1)
            for i = (N - 1):-1:1
                ex = :(I[$i] - 1 + dims[$i] * $ex)
@@ -1132,7 +1132,7 @@ julia> sub2ind_gen((3, 5), 1, 2)
 An easy way to find out is to extract the body into another (regular) function:
 
 ```jldoctest sub2ind_gen2
-julia> @generated function sub2ind_gen{N}(dims::NTuple{N}, I::Integer...)
+julia> @generated function sub2ind_gen(dims::NTuple{N}, I::Integer...) where N
            return sub2ind_gen_impl(dims, I...)
        end
 sub2ind_gen (generic function with 1 method)

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -321,7 +321,7 @@ Other known potential failure scenarios include:
    code snippet:
 
    ```julia
-   type UniquedById
+   mutable struct UniquedById
        myid::Int
        let counter = 0
            UniquedById() = new(counter += 1)

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -175,7 +175,7 @@ anonymous function on the fly:
 
 ```julia
 julia> open("hello.txt") do f
-          uppercase(readstring(f))
+           uppercase(readstring(f))
        end
 "HELLO AGAIN."
 ```
@@ -186,11 +186,11 @@ Let's jump right in with a simple example involving TCP sockets. Let's first cre
 
 ```julia
 julia> @async begin
-         server = listen(2000)
-         while true
-           sock = accept(server)
-           println("Hello World\n")
-         end
+           server = listen(2000)
+           while true
+               sock = accept(server)
+               println("Hello World\n")
+           end
        end
 Task (runnable) @0x00007fd31dc11ae0
 ```
@@ -252,13 +252,13 @@ To see this, consider the following simple echo server:
 
 ```julia
 julia> @async begin
-         server = listen(2001)
-         while true
-           sock = accept(server)
-           @async while isopen(sock)
-             write(sock,readline(sock))
+           server = listen(2001)
+           while true
+               sock = accept(server)
+               @async while isopen(sock)
+                   write(sock,readline(sock))
+               end
            end
-         end
        end
 Task (runnable) @0x00007fd31dc12e60
 
@@ -266,7 +266,7 @@ julia> clientside = connect(2001)
 TCPSocket(RawFD(28) open, 0 bytes waiting)
 
 julia> @async while true
-          write(STDOUT,readline(clientside))
+           write(STDOUT,readline(clientside))
        end
 Task (runnable) @0x00007fd31dc11870
 

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -520,7 +520,7 @@ A channel can be visualized as a pipe, i.e., it has a write end and read end.
   * Multiple readers in different tasks can read data concurrently via [`take!()`](@ref) calls.
   * As an example:
 
-    ```
+    ```julia
     # Given Channels c1 and c2,
     c1 = Channel(32)
     c2 = Channel(32)

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -359,10 +359,10 @@ However, there are cases where you may need to declare different versions of the
 for different element types of `a`. You could do it like this:
 
 ```
-function myfun{T<:AbstractFloat}(c::MySimpleContainer{Vector{T}})
+function myfun(c::MySimpleContainer{Vector{T}}) where T<:AbstractFloat
     ...
 end
-function myfun{T<:Integer}(c::MySimpleContainer{Vector{T}})
+function myfun(c::MySimpleContainer{Vector{T}}) where T<:Integer
     ...
 end
 ```
@@ -389,17 +389,17 @@ Note the somewhat surprising fact that `T` doesn't appear in the declaration of 
 that we'll return to in a moment. With this approach, one can write functions such as:
 
 ```jldoctest containers2
-julia> function myfunc{T<:Integer, A<:AbstractArray}(c::MyContainer{T,A})
+julia> function myfunc(c::MyContainer{<:Integer, <:AbstractArray})
            return c.a[1]+1
        end
 myfunc (generic function with 1 method)
 
-julia> function myfunc{T<:AbstractFloat}(c::MyContainer{T})
+julia> function myfunc(c::MyContainer{<:AbstractFloat})
            return c.a[1]+2
        end
 myfunc (generic function with 2 methods)
 
-julia> function myfunc{T<:Integer}(c::MyContainer{T,Vector{T}})
+julia> function myfunc(c::MyContainer{T,Vector{T}}) where T<:Integer
            return c.a[1]+3
        end
 myfunc (generic function with 3 methods)
@@ -509,7 +509,7 @@ function norm(A)
     if isa(A, Vector)
         return sqrt(real(dot(A,A)))
     elseif isa(A, Matrix)
-        return max(svd(A)[2])
+        return maximum(svd(A)[2])
     else
         error("norm: invalid argument")
     end
@@ -520,7 +520,7 @@ This can be written more concisely and efficiently as:
 
 ```julia
 norm(x::Vector) = sqrt(real(dot(x,x)))
-norm(A::Matrix) = max(svd(A)[2])
+norm(A::Matrix) = maximum(svd(A)[2])
 ```
 
 ## Write "type-stable" functions
@@ -681,7 +681,7 @@ one approach is to pass the dimensionality as a parameter, for example through `
 ["Value types"](@ref)):
 
 ```jldoctest
-julia> function array3{N}(fillval, ::Type{Val{N}})
+julia> function array3(fillval, ::Type{Val{N}}) where N
            fill(fillval, ntuple(d->3, Val{N}))
        end
 array3 (generic function with 1 method)
@@ -715,7 +715,7 @@ code like the above be used.)
 An example of correct usage of `Val` would be:
 
 ```julia
-function filter3{T,N}(A::AbstractArray{T,N})
+function filter3(A::AbstractArray{T,N}) where {T,N}
     kernel = array3(1, Val{N})
     filter(A, kernel)
 end
@@ -804,7 +804,7 @@ copies (perhaps the rest of the code can be easily adapted accordingly). We coul
 do this in at least four ways (in addition to the recommended call to the built-in [`repmat()`](@ref)):
 
 ```julia
-function copy_cols{T}(x::Vector{T})
+function copy_cols(x::Vector{T}) where T
     n = size(x, 1)
     out = Array{T}(n, n)
     for i = 1:n
@@ -813,7 +813,7 @@ function copy_cols{T}(x::Vector{T})
     out
 end
 
-function copy_rows{T}(x::Vector{T})
+function copy_rows(x::Vector{T}) where T
     n = size(x, 1)
     out = Array{T}(n, n)
     for i = 1:n
@@ -822,7 +822,7 @@ function copy_rows{T}(x::Vector{T})
     out
 end
 
-function copy_col_row{T}(x::Vector{T})
+function copy_col_row(x::Vector{T}) where T
     n = size(x, 1)
     out = Array{T}(n, n)
     for col = 1:n, row = 1:n
@@ -831,7 +831,7 @@ function copy_col_row{T}(x::Vector{T})
     out
 end
 
-function copy_row_col{T}(x::Vector{T})
+function copy_row_col(x::Vector{T}) where T
     n = size(x, 1)
     out = Array{T}(n, n)
     for row = 1:n, col = 1:n
@@ -886,7 +886,7 @@ end
 with
 
 ```julia
-function xinc!{T}(ret::AbstractVector{T}, x::T)
+function xinc!(ret::AbstractVector{T}, x::T) where T
     ret[1] = x
     ret[2] = x+1
     ret[3] = x+2
@@ -1261,7 +1261,7 @@ strict IEEE behavior for subnormal numbers.
 Below is an example where subnormals noticeably impact performance on some hardware:
 
 ```julia
-function timestep{T}( b::Vector{T}, a::Vector{T}, Δt::T )
+function timestep(b::Vector{T}, a::Vector{T}, Δt::T) where T
     @assert length(a)==length(b)
     n = length(b)
     b[1] = 1                            # Boundary condition
@@ -1271,7 +1271,7 @@ function timestep{T}( b::Vector{T}, a::Vector{T}, Δt::T )
     b[n] = 0                            # Boundary condition
 end
 
-function heatflow{T}( a::Vector{T}, nstep::Integer )
+function heatflow(a::Vector{T}, nstep::Integer) where T
     b = similar(a)
     for t=1:div(nstep,2)                # Assume nstep is even
         timestep(b,a,T(0.1))

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -123,7 +123,7 @@ Types such as `Union{Function,AbstractString}` are often a sign that some design
 When creating a type such as:
 
 ```julia
-struct MyType
+mutable struct MyType
     ...
     x::Union{Void,T}
 end


### PR DESCRIPTION
In the same vein as #21456, my goal is to make the stylistic conventions in the manual consistent, e.g. by migrating to `where` and `struct` syntax, using the standard 4 spaces for indentation, etc.

CI skipped, remove from commit message when merging.