### PR TITLE
Stylistic updates to the devdocs for consistency

### DIFF
--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -507,7 +507,7 @@ parses as:
 Type definition:
 
 ```julia
-type Foo{T<:S}
+mutable struct Foo{T<:S}
     x::T
 end
 ```

--- a/doc/src/devdocs/cartesian.md
+++ b/doc/src/devdocs/cartesian.md
@@ -69,7 +69,7 @@ Starting in Julia 0.4-pre, the recommended approach is to use a `@generated func
 an example:
 
 ```julia
-@generated function mysum{T,N}(A::Array{T,N})
+@generated function mysum(A::Array{T,N}) where {T,N}
     quote
         s = zero(T)
         @nloops $N i A begin

--- a/doc/src/devdocs/compiler.md
+++ b/doc/src/devdocs/compiler.md
@@ -1,9 +1,5 @@
 # High-level Overview of the Native-Code Generation Process
 
-
-    <placeholder>
-
-
 ## Representation of Pointers
 
 When emitting code to an object file, pointers will be emitted as relocations.
@@ -24,10 +20,10 @@ Function pointers are handled similarly.
 They are stored as values in a large `fvals` table.
 Like globals, this allows the deserializer to reference them by index.
 
-Note that extern functions are handled separately,
+Note that `extern` functions are handled separately,
 with names, via the usual symbol resolution mechanism in the linker.
 
-Note too that ccall functions are also handled separately,
+Note too that `ccall` functions are also handled separately,
 via a manual GOT and Procedure Linkage Table (PLT).
 
 

--- a/doc/src/devdocs/debuggingtips.md
+++ b/doc/src/devdocs/debuggingtips.md
@@ -234,9 +234,9 @@ process)
 
 ## Mozilla's Record and Replay Framework (rr)
 
-Julia now works out of the box with [rr,](http://rr-project.org/) the lightweight recording and
+Julia now works out of the box with [rr](http://rr-project.org/), the lightweight recording and
 deterministic debugging framework from Mozilla. This allows you to replay the trace of an execution
 deterministically.  The replayed execution's address spaces, register contents, syscall data etc
 are exactly the same in every run.
 
-A recent version of `rr` (3.1.0 or higher) is required.
+A recent version of rr (3.1.0 or higher) is required.

--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -3,10 +3,10 @@
 One of the hardest parts about learning how the Julia Language runs code is learning how all of
 the pieces work together to execute a block of code.
 
-Each chunk of code typically makes a trip through many esoteric acronyms such as (in no particular
-order), `flisp`, `AST`, `C++`, `LLVM`, `eval`, `typeinf`, `macroexpand`, `sysimg` (or `system image`),
-`bootstrapping`, `compile`, `parse`, `execute`, `JIT`, `interpret`, `box`, `unbox`, `intrinsic function`,
-`primitive function` before turning into the desired result (hopefully).
+Each chunk of code typically makes a trip through many steps with potentially unfamiliar names,
+such as (in no particular order): flisp, AST, C++, LLVM, `eval`, `typeinf`, `macroexpand`, sysimg
+(or system image), bootstrapping, compile, parse, execute, JIT, interpret, box, unbox, intrinsic
+function, and primitive function, before turning into the desired result (hopefully).
 
 !!! sidebar "Definitions"
       * REPL
@@ -25,19 +25,19 @@ The 10,000 foot view of the whole process is as follows:
 1. The user starts `julia`.
 2. The C function `main()` from `ui/repl.c` gets called. This function processes the command line
    arguments, filling in the `jl_options` struct and setting the variable `ARGS`. It then initializes
-   Julia (by calling [julia_init in task.c](https://github.com/JuliaLang/julia/blob/master/src/task.c),
+   Julia (by calling [`julia_init` in task.c](https://github.com/JuliaLang/julia/blob/master/src/task.c),
    which may load a previously compiled [sysimg](@ref dev-sysimg)). Finally, it passes off control to Julia
-   by calling [Base._start()](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
+   by calling [`Base._start()`](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
 3. When `_start()` takes over control, the subsequent sequence of commands depends on the command
    line arguments given. For example, if a filename was supplied, it will proceed to execute that
    file. Otherwise, it will start an interactive REPL.
 4. Skipping the details about how the REPL interacts with the user, let's just say the program ends
    up with a block of code that it wants to run.
-5. If the block of code to run is in a file, [jl_load(char *filename)](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
+5. If the block of code to run is in a file, [`jl_load(char *filename)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
    gets invoked to load the file and [parse](@ref dev-parsing) it. Each fragment of code is then passed to `eval`
    to execute.
 6. Each fragment of code (or AST), is handed off to [`eval()`](@ref) to turn into results.
-7. [`eval()`](@ref) takes each code fragment and tries to run it in [jl_toplevel_eval_flex()](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c).
+7. [`eval()`](@ref) takes each code fragment and tries to run it in [`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c).
 8. `jl_toplevel_eval_flex()` decides whether the code is a "toplevel" action (such as `using` or
    `module`), which would be invalid inside a function. If so, it passes off the code to the toplevel
    interpreter.
@@ -45,16 +45,16 @@ The 10,000 foot view of the whole process is as follows:
    the AST to make it simpler to execute.
 10. `jl_toplevel_eval_flex()` then uses some simple heuristics to decide whether to JIT compiler the
     AST or to interpret it directly.
-11. The bulk of the work to interpret code is handled by [eval in interpreter.c](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
+11. The bulk of the work to interpret code is handled by [`eval` in interpreter.c](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
 12. If instead, the code is compiled, the bulk of the work is handled by `codegen.cpp`. Whenever a
     Julia function is called for the first time with a given set of argument types, [type inference](@ref dev-type-inference)
     will be run on that function. This information is used by the [codegen](@ref dev-codegen) step to generate
     faster code.
 13. Eventually, the user quits the REPL, or the end of the program is reached, and the `_start()`
     method returns.
-14. Just before exiting, `main()` calls [jl_atexit_hook(exit_code)](https://github.com/JuliaLang/julia/blob/master/src/init.c).
+14. Just before exiting, `main()` calls [`jl_atexit_hook(exit_code)`](https://github.com/JuliaLang/julia/blob/master/src/init.c).
     This calls `Base._atexit()` (which calls any functions registered to [`atexit()`](@ref) inside
-    Julia). Then it calls [jl_gc_run_all_finalizers()](https://github.com/JuliaLang/julia/blob/master/src/gc.c).
+    Julia). Then it calls [`jl_gc_run_all_finalizers()`](https://github.com/JuliaLang/julia/blob/master/src/gc.c).
     Finally, it gracefully cleans up all `libuv` handles and waits for them to flush and close.
 
 ## [Parsing](@id dev-parsing)
@@ -103,7 +103,7 @@ Type inference may also include other steps such as constant propagation and inl
       * C++
 
         The programming language that LLVM is implemented in, which means that codegen is also implemented
-        in this language. The rest of Julia's library is implemented in C, in part because it's smaller
+        in this language. The rest of Julia's library is implemented in C, in part because its smaller
         feature set makes it more usable as a cross-language interface layer.
       * box
 
@@ -135,7 +135,7 @@ Type inference may also include other steps such as constant propagation and inl
 
 Codegen is the process of turning a Julia AST into native machine code.
 
-The JIT environment is initialized by an early call to [jl_init_codegen in codegen.cpp](https://github.com/JuliaLang/julia/blob/master/src/codegen.cpp).
+The JIT environment is initialized by an early call to [`jl_init_codegen` in codegen.cpp](https://github.com/JuliaLang/julia/blob/master/src/codegen.cpp).
 
 On demand, a Julia method is converted into a native function by the function `emit_function(jl_method_instance_t*)`.
 (note, when using the MCJIT (in LLVM v3.4+), each function must be JIT into a new module.) This
@@ -161,7 +161,7 @@ Other parts of codegen are handled by various helper files:
 !!! sidebar "Bootstrapping"
     The process of creating a new system image is called "bootstrapping".
 
-    The etymology of this word comes from the phrase "pulling one's self up by the bootstraps", and
+    The etymology of this word comes from the phrase "pulling oneself up by the bootstraps", and
     refers to the idea of starting from a very limited set of available functions and definitions
     and ending with the creation of a full-featured environment.
 
@@ -172,7 +172,7 @@ with Julia is one such system image, generated by executing the file [sysimg.jl]
 and serializing the resulting environment (including Types, Functions, Modules, and all other
 defined values) into a file. Therefore, it contains a frozen version of the `Main`, `Core`, and
 `Base` modules (and whatever else was in the environment at the end of bootstrapping). This serializer/deserializer
-is implemented by [jl_save_system_image/jl_restore_system_image in dump.c](https://github.com/JuliaLang/julia/blob/master/src/dump.c).
+is implemented by [`jl_save_system_image`/`jl_restore_system_image` in dump.c](https://github.com/JuliaLang/julia/blob/master/src/dump.c).
 
 If there is no sysimg file (`jl_options.image_file == NULL`), this also implies that `--build`
 was given on the command line, so the final result should be a new sysimg file. During Julia initialization,

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -33,14 +33,14 @@ of the argument structure.
 For example, the following function for performing a call accepts just an `args` pointer, so the
 first element of the args array will be the function to call:
 
-```
+```c
 jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)
 ```
 
 This entry point for the same functionality accepts the function separately, so the `args` array
 does not contain the function:
 
-```
+```c
 jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs);
 ```
 
@@ -110,7 +110,7 @@ a method table via special arrangement.
 The "builtin" functions, defined in the `Core` module, are:
 
 ```
-is typeof sizeof issubtype isa typeassert throw tuple getfield setfield! fieldtype
+=== typeof sizeof issubtype isa typeassert throw tuple getfield setfield! fieldtype
 nfields isdefined arrayref arrayset arraysize applicable invoke apply_type _apply
 _expr svec
 ```
@@ -119,7 +119,7 @@ These are all singleton objects whose types are subtypes of `Builtin`, which is 
 `Function`. Their purpose is to expose entry points in the run time that use the "jlcall" calling
 convention:
 
-```
+```c
 jl_value_t *(jl_value_t*, jl_value_t**, uint32_t)
 ```
 
@@ -152,7 +152,7 @@ actually produces *three* method definitions. The first is a function that accep
 (including keywords) as positional arguments, and includes the code for the method body. It has
 an auto-generated name:
 
-```
+```julia
 function #circle#1(color, fill::Bool, options, circle, center, radius)
     # draw
 end
@@ -268,11 +268,11 @@ filtering definitions from "replaced modules" out of method tables and caches be
 system image. A "replaced module" is one that satisfies the condition `m != jl_get_global(m->parent, m->name)`
 -- in other words, some newer module has taken its name and place.
 
-Another type inference worst case was triggered by the following code from the QuadGK.jl package,
+Another type inference worst case was triggered by the following code from the [QuadGK.jl package](https://github.com/JuliaMath/QuadGK.jl),
 formerly part of Base:
 
 ```julia
-function do_quadgk{Tw}(f, s, n, ::Type{Tw}, abstol, reltol, maxevals, nrm)
+function do_quadgk(f, s, n, ::Type{Tw}, abstol, reltol, maxevals, nrm) where Tw
     if eltype(s) <: Real # check for infinite or semi-infinite intervals
         s1 = s[1]; s2 = s[end]; inf1 = isinf(s1); inf2 = isinf(s2)
         if inf1 || inf2
@@ -300,5 +300,5 @@ function do_quadgk{Tw}(f, s, n, ::Type{Tw}, abstol, reltol, maxevals, nrm)
 
 This code has a 3-way tail recursion, where each call wraps the current function argument `f`
 in a different new closure. Inference must consider 3^n (where n is the call depth) possible signatures.
-This blows up way too quickly, so logic was added to typeinf_uncached to immediately widen any
+This blows up way too quickly, so logic was added to `typeinf_uncached` to immediately widen any
 argument that is a subtype of `Function` and that grows in depth down the stack.

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -4,42 +4,42 @@ How does the Julia runtime execute `julia -e 'println("Hello World!")'` ?
 
 ## main()
 
-Execution starts at [main() in julia/ui/repl.c](https://github.com/JuliaLang/julia/blob/master/ui/repl.c).
+Execution starts at [`main()` in ui/repl.c](https://github.com/JuliaLang/julia/blob/master/ui/repl.c).
 
-main() calls [libsupport_init()](https://github.com/JuliaLang/julia/blob/master/src/support/libsupportinit.c)
-to set the C library locale and to initialise the "ios" library (see [ios_init_stdstreams()](https://github.com/JuliaLang/julia/blob/master/src/support/ios.c)
+`main()` calls [`libsupport_init()`](https://github.com/JuliaLang/julia/blob/master/src/support/libsupportinit.c)
+to set the C library locale and to initialize the "ios" library (see [`ios_init_stdstreams()`](https://github.com/JuliaLang/julia/blob/master/src/support/ios.c)
 and [Legacy ios.c library](@ref)).
 
-Next [parse_opts()](https://github.com/JuliaLang/julia/blob/master/ui/repl.c) is called to process
+Next [`parse_opts()`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c) is called to process
 command line options. Note that `parse_opts()` only deals with options that affect code generation
-or early initialisation. Other options are handled later by [process_options() in base/client.jl](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
+or early initialization. Other options are handled later by [`process_options()` in base/client.jl](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
 
-`parse_opts()` stores command line options in the [global jl_options struct](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
+`parse_opts()` stores command line options in the [global `jl_options` struct](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
 
 ## julia_init()
 
-[julia_init() in task.c](https://github.com/JuliaLang/julia/blob/master/src/task.c) is called
-by main() and calls [_julia_init() in init.c](https://github.com/JuliaLang/julia/blob/master/src/init.c).
+[`julia_init()` in task.c](https://github.com/JuliaLang/julia/blob/master/src/task.c) is called
+by `main()` and calls [`_julia_init()` in init.c](https://github.com/JuliaLang/julia/blob/master/src/init.c).
 
 `_julia_init()` begins by calling `libsupport_init()` again (it does nothing the second time).
 
-[restore_signals()](https://github.com/JuliaLang/julia/blob/master/src/signals-unix.c) is called
+[`restore_signals()`](https://github.com/JuliaLang/julia/blob/master/src/signals-unix.c) is called
 to zero the signal handler mask.
 
-[jl_resolve_sysimg_location()](https://github.com/JuliaLang/julia/blob/master/src/init.c) searches
+[`jl_resolve_sysimg_location()`](https://github.com/JuliaLang/julia/blob/master/src/init.c) searches
 configured paths for the base system image. See [Building the Julia system image](@ref).
 
-[jl_gc_init()](https://github.com/JuliaLang/julia/blob/master/src/gc.c) sets up allocation pools
-and lists for: weak refs, preserved values and finalization.
+[`jl_gc_init()`](https://github.com/JuliaLang/julia/blob/master/src/gc.c) sets up allocation pools
+and lists for weak refs, preserved values and finalization.
 
-[jl_init_frontend()](https://github.com/JuliaLang/julia/blob/master/src/ast.c) loads and initialises
-a pre-compiled femtolisp image containing the scanner/parser;
+[`jl_init_frontend()`](https://github.com/JuliaLang/julia/blob/master/src/ast.c) loads and initializes
+a pre-compiled femtolisp image containing the scanner/parser.
 
-[jl_init_types()](https://github.com/JuliaLang/julia/blob/master/src/jltypes.c) creates `jl_datatype_t`
+[`jl_init_types()`](https://github.com/JuliaLang/julia/blob/master/src/jltypes.c) creates `jl_datatype_t`
 type description objects for the [built-in types defined in julia.h](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
 e.g.
 
-```julia
+```c
 jl_any_type = jl_new_abstracttype(jl_symbol("Any"), NULL, jl_null);
 jl_any_type->super = jl_any_type;
 
@@ -49,14 +49,14 @@ jl_int32_type = jl_new_bitstype(jl_symbol("Int32"),
                                 jl_any_type, jl_null, 32);
 ```
 
-[jl_init_tasks()](https://github.com/JuliaLang/julia/blob/master/src/task.c) creates the `jl_datatype_t* jl_task_type`
-object; initialises the global `jl_root_task` struct; and sets `jl_current_task` to the root task.
+[`jl_init_tasks()`](https://github.com/JuliaLang/julia/blob/master/src/task.c) creates the `jl_datatype_t* jl_task_type`
+object; initializes the global `jl_root_task` struct; and sets `jl_current_task` to the root task.
 
-[jl_init_codegen()](https://github.com/JuliaLang/julia/blob/master/src/codegen.cpp) initialises
+[`jl_init_codegen()`](https://github.com/JuliaLang/julia/blob/master/src/codegen.cpp) initializes
 the [LLVM library](http://llvm.org).
 
-[jl_init_serializer()](https://github.com/JuliaLang/julia/blob/master/src/dump.c) initialises
-8-bit serialisation tags for 256 frequently used `jl_value_t` values. The serialisation mechanism
+[`jl_init_serializer()`](https://github.com/JuliaLang/julia/blob/master/src/dump.c) initializes
+8-bit serialization tags for 256 frequently used `jl_value_t` values. The serialization mechanism
 uses these tags as shorthand (in lieu of storing whole objects) to save storage space.
 
 If there is no sysimg file (`!jl_options.image_file`) then the `Core` and `Main` modules are
@@ -64,168 +64,168 @@ created and `boot.jl` is evaluated:
 
 `jl_core_module = jl_new_module(jl_symbol("Core"))` creates the Julia `Core` module.
 
-[jl_init_intrinsic_functions()](https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp)
-creates a new Julia module "Intrinsics" containing constant jl_intrinsic_type symbols. These define
+[`jl_init_intrinsic_functions()`](https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp)
+creates a new Julia module `Intrinsics` containing constant `jl_intrinsic_type` symbols. These define
 an integer code for each [intrinsic function](https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp).
-[emit_intrinsic()](https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp) translates
+[`emit_intrinsic()`](https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp) translates
 these symbols into LLVM instructions during code generation.
 
-[jl_init_primitives()](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) hooks C
+[`jl_init_primitives()`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) hooks C
 functions up to Julia function symbols. e.g. the symbol `Base.is()` is bound to C function pointer
 `jl_f_is()` by calling `add_builtin_func("eval", jl_f_top_eval)`.
 
-[jl_new_main_module()](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) creates
+[`jl_new_main_module()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) creates
 the global "Main" module and sets `jl_current_task->current_module = jl_main_module`.
 
-Note: _julia_init() [then sets](https://github.com/JuliaLang/julia/blob/master/src/init.c)`jl_root_task->current_module = jl_core_module`.
-`jl_root_task` is an alias of `jl_current_task` at this point, so the current_module set by `jl_new_main_module()`
+Note: `_julia_init()` [then sets](https://github.com/JuliaLang/julia/blob/master/src/init.c) `jl_root_task->current_module = jl_core_module`.
+`jl_root_task` is an alias of `jl_current_task` at this point, so the `current_module` set by `jl_new_main_module()`
 above is overwritten.
 
-[jl_load("boot.jl", sizeof("boot.jl"))](https://github.com/JuliaLang/julia/blob/master/src/init.c)
-calls [jl_parse_eval_all](https://github.com/JuliaLang/julia/blob/master/src/ast.c) which repeatedly
-calls [jl_toplevel_eval_flex()](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
-to execute [boot.jl](https://github.com/JuliaLang/julia/blob/master/base/boot.jl). TODO – drill
-down into eval?
+[`jl_load("boot.jl", sizeof("boot.jl"))`](https://github.com/JuliaLang/julia/blob/master/src/init.c)
+calls [`jl_parse_eval_all`](https://github.com/JuliaLang/julia/blob/master/src/ast.c) which repeatedly
+calls [`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
+to execute [boot.jl](https://github.com/JuliaLang/julia/blob/master/base/boot.jl). <!-- TODO – drill
+down into eval? -->
 
-[jl_get_builtin_hooks()](https://github.com/JuliaLang/julia/blob/master/src/init.c) initialises
-global C pointers to Julia globals defined in `boot.jl`.
+[`jl_get_builtin_hooks()`](https://github.com/JuliaLang/julia/blob/master/src/init.c) initializes
+global C pointers to Julia globals defined in boot.jl.
 
-[jl_init_box_caches()](https://github.com/JuliaLang/julia/blob/master/src/alloc.c) pre-allocates
+[`jl_init_box_caches()`](https://github.com/JuliaLang/julia/blob/master/src/datatype.c) pre-allocates
 global boxed integer value objects for values up to 1024. This speeds up allocation of boxed ints
 later on. e.g.:
 
-```
+```c
 jl_value_t *jl_box_uint8(uint32_t x)
 {
     return boxed_uint8_cache[(uint8_t)x];
 }
 ```
 
-[_julia_init() iterates](https://github.com/JuliaLang/julia/blob/master/src/init.c) over the
+[`_julia_init()` iterates](https://github.com/JuliaLang/julia/blob/master/src/init.c) over the
 `jl_core_module->bindings.table` looking for `jl_datatype_t` values and sets the type name's module
 prefix to `jl_core_module`.
 
-[jl_add_standard_imports(jl_main_module)](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
+[`jl_add_standard_imports(jl_main_module)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
 does "using Base" in the "Main" module.
 
 Note: `_julia_init()` now reverts to `jl_root_task->current_module = jl_main_module` as it was
 before being set to `jl_core_module` above.
 
-Platform specific signal handlers are initialised for `SIGSEGV` (OSX, Linux), and `SIGFPE` (Windows).
+Platform specific signal handlers are initialized for `SIGSEGV` (OSX, Linux), and `SIGFPE` (Windows).
 
 Other signals (`SIGINFO, SIGBUS, SIGILL, SIGTERM, SIGABRT, SIGQUIT, SIGSYS` and `SIGPIPE`) are
-hooked up to [sigdie_handler()](https://github.com/JuliaLang/julia/blob/master/src/signals-unix.c)
+hooked up to [`sigdie_handler()`](https://github.com/JuliaLang/julia/blob/master/src/signals-unix.c)
 which prints a backtrace.
 
-[jl_init_restored_modules()](https://github.com/JuliaLang/julia/blob/master/src/dump.c) calls
-[jl_module_run_initializer()](https://github.com/JuliaLang/julia/blob/master/src/module.c) for
-each deserialised module to run the `__init__()` function.
+[`jl_init_restored_modules()`](https://github.com/JuliaLang/julia/blob/master/src/dump.c) calls
+[`jl_module_run_initializer()`](https://github.com/JuliaLang/julia/blob/master/src/module.c) for
+each deserialized module to run the `__init__()` function.
 
-Finally [sigint_handler()](https://github.com/JuliaLang/julia/blob/master/src/signals-unix.c)
+Finally [`sigint_handler()`](https://github.com/JuliaLang/julia/blob/master/src/signals-unix.c)
 is hooked up to `SIGINT` and calls `jl_throw(jl_interrupt_exception)`.
 
-`_julia_init()` then returns [back to main() in julia/ui/repl.c](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
-and main() calls `true_main(argc, (char**)argv)`.
+`_julia_init()` then returns [back to `main()` in julia/ui/repl.c](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
+and `main()` calls `true_main(argc, (char**)argv)`.
 
 !!! sidebar "sysimg"
     If there is a sysimg file, it contains a pre-cooked image of the `Core` and `Main` modules (and
-    whatever else is created by `boot.jl`). See [Building the Julia system image](@ref).
+    whatever else is created by boot.jl). See [Building the Julia system image](@ref).
 
-    [jl_restore_system_image()](https://github.com/JuliaLang/julia/blob/master/src/dump.c) de-serialises
-    the saved sysimg into the current Julia runtime environment and initialisation continues after
+    [`jl_restore_system_image()`](https://github.com/JuliaLang/julia/blob/master/src/dump.c) deserializes
+    the saved sysimg into the current Julia runtime environment and initialization continues after
     `jl_init_box_caches()` below...
 
-    Note: [jl_restore_system_image() (and dump.c in general)](https://github.com/JuliaLang/julia/blob/master/src/dump.c)
+    Note: [`jl_restore_system_image()` (and dump.c in general)](https://github.com/JuliaLang/julia/blob/master/src/dump.c)
     uses the [Legacy ios.c library](@ref).
 
 ## true_main()
 
-[true_main()](https://github.com/JuliaLang/julia/blob/master/ui/repl.c) loads the contents of
+[`true_main()`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c) loads the contents of
 `argv[]` into [`Base.ARGS`](@ref).
 
-If a .jl "program" file was supplied on the command line, then [exec_program()](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
-calls [jl_load(program,len)](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) which
-calls [jl_parse_eval_all](https://github.com/JuliaLang/julia/blob/master/src/ast.c) which repeatedly
-calls [jl_toplevel_eval_flex()](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
+If a .jl "program" file was supplied on the command line, then [`exec_program()`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
+calls [`jl_load(program,len)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) which
+calls [`jl_parse_eval_all`](https://github.com/JuliaLang/julia/blob/master/src/ast.c) which repeatedly
+calls [`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
 to execute the program.
 
-However, in our example (`julia -e 'println("Hello World!")'`), [jl_get_global(jl_base_module, jl_symbol("_start"))](https://github.com/JuliaLang/julia/blob/master/src/module.c)
-looks up [Base._start](https://github.com/JuliaLang/julia/blob/master/base/client.jl) and [jl_apply()](https://github.com/JuliaLang/julia/blob/master/src/julia.h)
+However, in our example (`julia -e 'println("Hello World!")'`), [`jl_get_global(jl_base_module, jl_symbol("_start"))`](https://github.com/JuliaLang/julia/blob/master/src/module.c)
+looks up [`Base._start`](https://github.com/JuliaLang/julia/blob/master/base/client.jl) and [`jl_apply()`](https://github.com/JuliaLang/julia/blob/master/src/julia.h)
 executes it.
 
 ## Base._start
 
-[Base._start](https://github.com/JuliaLang/julia/blob/master/base/client.jl) calls [Base.process_options](https://github.com/JuliaLang/julia/blob/master/base/client.jl)
-which calls [jl_parse_input_line("println("Hello World!")")](https://github.com/JuliaLang/julia/blob/master/src/ast.c)
+[`Base._start`](https://github.com/JuliaLang/julia/blob/master/base/client.jl) calls [`Base.process_options`](https://github.com/JuliaLang/julia/blob/master/base/client.jl)
+which calls [`jl_parse_input_line("println("Hello World!")")`](https://github.com/JuliaLang/julia/blob/master/src/ast.c)
 to create an expression object and [`Base.eval()`](@ref eval) to execute it.
 
 ## Base.eval
 
-[`Base.eval()`](@ref eval) was [mapped to jl_f_top_eval](https://github.com/JuliaLang/julia/blob/master/src/builtins.c)
+[`Base.eval()`](@ref eval) was [mapped to `jl_f_top_eval`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c)
 by `jl_init_primitives()`.
 
-[jl_f_top_eval()](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) calls [jl_toplevel_eval_in(jl_main_module, ex)](https://github.com/JuliaLang/julia/blob/master/src/builtins.c),
-where "ex" is the parsed expression `println("Hello World!")`.
+[`jl_f_top_eval()`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) calls [`jl_toplevel_eval_in(jl_main_module, ex)`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c),
+where `ex` is the parsed expression `println("Hello World!")`.
 
-[jl_toplevel_eval_in()](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) calls
-[jl_toplevel_eval_flex()](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) which
-calls [eval() in interpreter.c](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
+[`jl_toplevel_eval_in()`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) calls
+[`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) which
+calls [`eval()` in interpreter.c](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
 
 The stack dump below shows how the interpreter works its way through various methods of [`Base.println()`](@ref)
-and [`Base.print()`](@ref) before arriving at [write{T}(s::IO, a::Array{T})](https://github.com/JuliaLang/julia/blob/master/base/stream.jl)
+and [`Base.print()`](@ref) before arriving at [`write(s::IO, a::Array{T}) where T`](https://github.com/JuliaLang/julia/blob/master/base/stream.jl)
  which does `ccall(jl_uv_write())`.
 
-[jl_uv_write()](https://github.com/JuliaLang/julia/blob/master/src/jl_uv.c) calls `uv_write()`
+[`jl_uv_write()`](https://github.com/JuliaLang/julia/blob/master/src/jl_uv.c) calls `uv_write()`
 to write "Hello World!" to `JL_STDOUT`. See [Libuv wrappers for stdio](@ref).:
 
 ```
 Hello World!
 ```
 
-| Stack frame                  | Source code   | Notes                                             |
-|:---------------------------- |:------------- |:------------------------------------------------- |
-| jl_uv_write()                | jl_uv.c       | called though [`ccall`](@ref)                     |
-| julia_write_282942           | stream.jl     | function write!{T}(s::IO, a::Array{T})            |
-| julia_print_284639           | ascii.jl      | print(io::IO, s::String) = (write(io, s);nothing) |
-| jlcall_print_284639          |               |                                                   |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_trampoline()              | builtins.c    |                                                   |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_apply_generic()           | gf.c          | Base.print(Base.TTY, String)                      |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_trampoline()              | builtins.c    |                                                   |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_apply_generic()           | gf.c          | Base.print(Base.TTY, String, Char, Char...)       |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_f_apply()                 | builtins.c    |                                                   |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_trampoline()              | builtins.c    |                                                   |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_apply_generic()           | gf.c          | Base.println(Base.TTY, String, String...)         |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_trampoline()              | builtins.c    |                                                   |
-| jl_apply()                   | julia.h       |                                                   |
-| jl_apply_generic()           | gf.c          | Base.println(String,)                             |
-| jl_apply()                   | julia.h       |                                                   |
-| do_call()                    | interpreter.c |                                                   |
-| eval()                       | interpreter.c |                                                   |
-| jl_interpret_toplevel_expr() | interpreter.c |                                                   |
-| jl_toplevel_eval_flex()      | toplevel.c    |                                                   |
-| jl_toplevel_eval()           | toplevel.c    |                                                   |
-| jl_toplevel_eval_in()        | builtins.c    |                                                   |
-| jl_f_top_eval()              | builtins.c    |                                                   |
+| Stack frame                    | Source code   | Notes                                                |
+|:------------------------------ |:------------- |:---------------------------------------------------- |
+| `jl_uv_write()`                | jl_uv.c       | called though [`ccall`](@ref)                        |
+| `julia_write_282942`           | stream.jl     | function `write!(s::IO, a::Array{T}) where T`        |
+| `julia_print_284639`           | ascii.jl      | `print(io::IO, s::String) = (write(io, s); nothing)` |
+| `jlcall_print_284639`          |               |                                                      |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_trampoline()`              | builtins.c    |                                                      |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_apply_generic()`           | gf.c          | `Base.print(Base.TTY, String)`                       |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_trampoline()`              | builtins.c    |                                                      |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_apply_generic()`           | gf.c          | `Base.print(Base.TTY, String, Char, Char...)`        |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_f_apply()`                 | builtins.c    |                                                      |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_trampoline()`              | builtins.c    |                                                      |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_apply_generic()`           | gf.c          | `Base.println(Base.TTY, String, String...)`          |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_trampoline()`              | builtins.c    |                                                      |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `jl_apply_generic()`           | gf.c          | `Base.println(String,)`                              |
+| `jl_apply()`                   | julia.h       |                                                      |
+| `do_call()`                    | interpreter.c |                                                      |
+| `eval()`                       | interpreter.c |                                                      |
+| `jl_interpret_toplevel_expr()` | interpreter.c |                                                      |
+| `jl_toplevel_eval_flex()`      | toplevel.c    |                                                      |
+| `jl_toplevel_eval()`           | toplevel.c    |                                                      |
+| `jl_toplevel_eval_in()`        | builtins.c    |                                                      |
+| `jl_f_top_eval()`              | builtins.c    |                                                      |
 
 Since our example has just one function call, which has done its job of printing "Hello World!",
 the stack now rapidly unwinds back to `main()`.
 
 ## jl_atexit_hook()
 
-`main()` calls [jl_atexit_hook()](https://github.com/JuliaLang/julia/blob/master/src/init.c).
-This calls _atexit for each module, then calls [jl_gc_run_all_finalizers()](https://github.com/JuliaLang/julia/blob/master/src/gc.c)
+`main()` calls [`jl_atexit_hook()`](https://github.com/JuliaLang/julia/blob/master/src/init.c).
+This calls `_atexit` for each module, then calls [`jl_gc_run_all_finalizers()`](https://github.com/JuliaLang/julia/blob/master/src/gc.c)
 and cleans up libuv handles.
 
 ## julia_save()
 
-Finally, `main()` calls [julia_save()](https://github.com/JuliaLang/julia/blob/master/src/init.c),
-which if requested on the command line, saves the runtime state to a new system image. See [jl_compile_all()](https://github.com/JuliaLang/julia/blob/master/src/gf.c)
-and [jl_save_system_image()](https://github.com/JuliaLang/julia/blob/master/src/dump.c).
+Finally, `main()` calls [`julia_save()`](https://github.com/JuliaLang/julia/blob/master/src/init.c),
+which if requested on the command line, saves the runtime state to a new system image. See [`jl_compile_all()`](https://github.com/JuliaLang/julia/blob/master/src/gf.c)
+and [`jl_save_system_image()`](https://github.com/JuliaLang/julia/blob/master/src/dump.c).

--- a/doc/src/devdocs/offset-arrays.md
+++ b/doc/src/devdocs/offset-arrays.md
@@ -186,7 +186,7 @@ implement this).
 In some cases, the fallback definition for `indices(A, d)`:
 
 ```julia
-indices{T,N}(A::AbstractArray{T,N}, d) = d <= N ? indices(A)[d] : OneTo(1)
+indices(A::AbstractArray{T,N}, d) where {T,N} = d <= N ? indices(A)[d] : OneTo(1)
 ```
 
 may not be what you want: you may need to specialize it to return something other than `OneTo(1)`
@@ -195,8 +195,8 @@ to `indices(A, 1)` but which avoids checking (at runtime) whether `ndims(A) > 0`
 a performance optimization.)  It is defined as:
 
 ```julia
-indices1{T}(A::AbstractArray{T,0}) = OneTo(1)
-indices1{T}(A::AbstractArray{T})   = indices(A)[1]
+indices1(A::AbstractArray{T,0}) where {T} = OneTo(1)
+indices1(A::AbstractArray) = indices(A)[1]
 ```
 
 If the first of these (the zero-dimensional case) is problematic for your custom array type, be

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -15,7 +15,7 @@ given the following type, `fieldnames(Point)` returns an arrays of [`Symbol`](@r
 the field names:
 
 ```julia
-julia> type Point
+julia> struct Point
            x::Int
            y
        end

--- a/doc/src/devdocs/stdio.md
+++ b/doc/src/devdocs/stdio.md
@@ -4,7 +4,7 @@
 
 `julia.h` defines [libuv](http://docs.libuv.org) wrappers for the `stdio.h` streams:
 
-```julia
+```c
 uv_stream_t *JL_STDIN;
 uv_stream_t *JL_STDOUT;
 uv_stream_t *JL_STDERR;
@@ -12,24 +12,24 @@ uv_stream_t *JL_STDERR;
 
 ... and corresponding output functions:
 
-```
+```c
 int jl_printf(uv_stream_t *s, const char *format, ...);
 int jl_vprintf(uv_stream_t *s, const char *format, va_list args);
 ```
 
-These `printf` functions are used by `julia/{src,ui}/*.c` wherever stdio is needed to ensure that
-output buffering is handled in a unified way.
+These `printf` functions are used by the `.c` files in the `src/` and `ui/` directories wherever stdio is
+needed to ensure that output buffering is handled in a unified way.
 
-In special cases, like signal handlers, where the full `libuv` infrastructure is too heavy, `jl_safe_printf()`
+In special cases, like signal handlers, where the full libuv infrastructure is too heavy, `jl_safe_printf()`
 can be used to [`write(2)`](@ref) directly to `STDERR_FILENO`:
 
-```
+```c
 void jl_safe_printf(const char *str, ...);
 ```
 
 ## Interface between JL_STD* and Julia code
 
-[`Base.STDIN`](@ref), [`Base.STDOUT`](@ref) and [`Base.STDERR`](@ref) are bound to the `JL_STD*`[libuv](http://docs.libuv.org)
+[`Base.STDIN`](@ref), [`Base.STDOUT`](@ref) and [`Base.STDERR`](@ref) are bound to the `JL_STD*` libuv
 streams defined in the runtime.
 
 Julia's `__init__()` function (in `base/sysimg.jl`) calls `reinit_stdio()` (in `base/stream.jl`)
@@ -51,7 +51,7 @@ Tuple{Base.PipeEndpoint,Base.PipeEndpoint,Base.TTY}
 ```
 
 The [`Base.read()`](@ref) and [`Base.write()`](@ref) methods for these streams use [`ccall`](@ref)
-to call `libuv` wrappers in `src/jl_uv.c`, e.g.:
+to call libuv wrappers in `src/jl_uv.c`, e.g.:
 
 ```
 stream.jl: function write(s::IO, p::Ptr, nb::Integer)
@@ -60,43 +60,43 @@ stream.jl: function write(s::IO, p::Ptr, nb::Integer)
                         -> uv_write(uvw, stream, buf, ...)
 ```
 
-## printf() during initialisation
+## printf() during initialization
 
-The `libuv` streams relied upon by `jl_printf()` etc., are not available until midway through
-initialisation of the runtime (see `init.c`, `init_stdio()`).  Error messages or warnings that
+The libuv streams relied upon by `jl_printf()` etc., are not available until midway through
+initialization of the runtime (see `init.c`, `init_stdio()`).  Error messages or warnings that
 need to be printed before this are routed to the standard C library `fwrite()` function by the
 following mechanism:
 
-In `sys.c`, the `JL_STD*` stream pointers are statically initialised to integer constants: `STD*_FILENO (0, 1 and 2)`.
+In `sys.c`, the `JL_STD*` stream pointers are statically initialized to integer constants: `STD*_FILENO (0, 1 and 2)`.
 In `jl_uv.c` the `jl_uv_puts()` function checks its `uv_stream_t* stream` argument and calls
 `fwrite()` if stream is set to `STDOUT_FILENO` or `STDERR_FILENO`.
 
 This allows for uniform use of `jl_printf()` throughout the runtime regardless of whether or not
-any particular piece of code is reachable before initialisation is complete.
+any particular piece of code is reachable before initialization is complete.
 
 ## Legacy ios.c library
 
-The `julia/src/support/ios.c` library is inherited from [femtolisp](https://github.com/JeffBezanson/femtolisp).
+The `src/support/ios.c` library is inherited from [femtolisp](https://github.com/JeffBezanson/femtolisp).
 It provides cross-platform buffered file IO and in-memory temporary buffers.
 
-`ios.c` is still used by:
+ios.c is still used by:
 
-  * `julia/src/flisp/*.c`
-  * `julia/src/dump.c` – for serialisation file IO and for memory buffers.
-  * `base/iostream.jl` – for file IO (see `base/fs.jl` for `libuv` equivalent).
+  * `src/flisp/*.c`
+  * `src/dump.c` – for serialization file IO and for memory buffers.
+  * `base/iostream.jl` – for file IO (see `base/fs.jl` for libuv equivalent).
 
-Use of `ios.c` in these modules is mostly self-contained and separated from the `libuv` I/O system.
+Use of ios.c in these modules is mostly self-contained and separated from the libuv I/O system.
 However, there is [one place](https://github.com/JuliaLang/julia/blob/master/src/flisp/print.c#L654)
 where femtolisp calls through to `jl_printf()` with a legacy `ios_t` stream.
 
 There is a hack in `ios.h` that makes the `ios_t.bm` field line up with the `uv_stream_t.type`
-and ensures that the values used for `ios_t.bm` to not overlap with valid UV_HANDLE_TYPE values.
+and ensures that the values used for `ios_t.bm` to not overlap with valid `UV_HANDLE_TYPE` values.
  This allows `uv_stream_t` pointers to point to `ios_t` streams.
 
 This is needed because `jl_printf()` caller `jl_static_show()` is passed an `ios_t` stream by
 femtolisp's `fl_print()` function. Julia's `jl_uv_puts()` function has special handling for this:
 
-```
+```c
 if (stream->type > UV_HANDLE_TYPE_MAX) {
     return ios_write((ios_t*)stream, str, n);
 }

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -229,7 +229,7 @@ field, it's helpful to pick a type that is less heavily used than Array. Let's f
 own type:
 
 ```jldoctest
-julia> type MyType{T,N} end
+julia> struct MyType{T,N} end
 
 julia> MyType{Int,2}
 MyType{Int64,2}


### PR DESCRIPTION
As an accompaniment to #21463 and its predecessor #21456, this PR seeks to update the stylistic conventions used in the dev docs. In particular this converts code to use `where` and `struct` as applicable, and it applies more consistent Markdown formatting across the board.

CI skipped, remove from commit message when merging.