### PR TITLE
Give symbolic name to special libname on windows.

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -243,9 +243,9 @@ JL_DLLEXPORT void *jl_dlsym(void *handle, const char *symbol)
 const char *jl_dlfind_win32(const char *f_name)
 {
     if (jl_dlsym_e(jl_exe_handle, f_name))
-        return (const char*)1;
+        return JL_EXE_LIBNAME;
     if (jl_dlsym_e(jl_dl_handle, f_name))
-        return (const char*)2;
+        return JL_DL_LIBNAME;
     if (jl_dlsym_e(jl_kernel32_handle, f_name))
         return "kernel32";
     if (jl_dlsym_e(jl_ntdll_handle, f_name))

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -684,6 +684,9 @@ extern void *jl_winsock_handle;
 void *jl_get_library(const char *f_lib);
 JL_DLLEXPORT void *jl_load_and_lookup(const char *f_lib, const char *f_name,
                                       void **hnd);
+// Windows only
+#define JL_EXE_LIBNAME ((const char*)1)
+#define JL_DL_LIBNAME ((const char*)2)
 const char *jl_dlfind_win32(const char *name);
 void *jl_dlopen_soname(const char *pfx, size_t n, unsigned flags);
 

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -140,9 +140,9 @@ void *jl_get_library(const char *f_lib)
 {
     void *hnd;
 #ifdef _OS_WINDOWS_
-    if ((intptr_t)f_lib == 1)
+    if (f_lib == JL_EXE_LIBNAME)
         return jl_exe_handle;
-    if ((intptr_t)f_lib == 2)
+    if (f_lib == JL_DL_LIBNAME)
         return jl_dl_handle;
 #endif
     if (f_lib == NULL)


### PR DESCRIPTION
And clean up ccall special case generation conditions.

Ref https://github.com/JuliaLang/julia/pull/21448#discussion_r112480819
