### PR TITLE
Optimize pause and wake functions in julia code

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -96,8 +96,10 @@
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>
 
-#if defined(_CPU_ARM_) || defined(_CPU_AARCH64_)
+#if JL_LLVM_VERSION >= 30700
 #  include <llvm/IR/InlineAsm.h>
+#endif
+#if defined(_CPU_ARM_) || defined(_CPU_AARCH64_)
 #  include <sys/utsname.h>
 #endif
 #if defined(USE_POLLY)

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -140,6 +140,7 @@ typedef struct _jl_tls_states_t {
 } jl_tls_states_t;
 typedef jl_tls_states_t *jl_ptls_t;
 
+// Update codegen version in `ccall.cpp` after changing either `pause` or `wake`
 #ifdef __MIC__
 #  define jl_cpu_pause() _mm_delay_64(100)
 #  define jl_cpu_wake() ((void)0)


### PR DESCRIPTION
At this point we can probably write these in llvmcall with inline assembly but these two functions are still useful for writing platform independent code. The optimization on x86 for pause doesn't really matter that much (afterall it's the backoff and wait code path) though it does make the compiler making less pessimistic decision on register allocations. and reduces the code size.