### PR TITLE
Put worker threads to sleep immediately on startup

### DIFF
--- a/src/threadgroup.c
+++ b/src/threadgroup.c
@@ -116,7 +116,7 @@ int ti_threadgroup_size(ti_threadgroup_t *tg, int16_t *tgsize)
     return 0;
 }
 
-int ti_threadgroup_fork(ti_threadgroup_t *tg, int16_t ext_tid, void **bcast_val)
+int ti_threadgroup_fork(ti_threadgroup_t *tg, int16_t ext_tid, void **bcast_val, int init)
 {
     uint8_t *group_sense = &tg->group_sense;
     int16_t tid = tg->tid_map[ext_tid];
@@ -147,13 +147,14 @@ int ti_threadgroup_fork(ti_threadgroup_t *tg, int16_t ext_tid, void **bcast_val)
                 }
                 spin_ns = uv_hrtime() - spin_start;
                 // In case uv_hrtime is not monotonic, we'll sleep earlier
-                if (spin_ns >= tg->sleep_threshold) {
+                if (init || spin_ns >= tg->sleep_threshold) {
                     uv_mutex_lock(&tg->alarm_lock);
                     if (jl_atomic_load_acquire(group_sense) != thread_sense) {
                         uv_cond_wait(&tg->alarm, &tg->alarm_lock);
                     }
                     uv_mutex_unlock(&tg->alarm_lock);
                     spin_start = 0;
+                    init = 0;
                     continue;
                 }
             }

--- a/src/threadgroup.h
+++ b/src/threadgroup.h
@@ -37,7 +37,7 @@ int ti_threadgroup_member(ti_threadgroup_t *tg, int16_t ext_tid,
                           int16_t *tgtid);
 int ti_threadgroup_size(ti_threadgroup_t *tg, int16_t *tgsize);
 int ti_threadgroup_fork(ti_threadgroup_t *tg, int16_t ext_tid,
-                        void **bcast_val);
+                        void **bcast_val, int init);
 int ti_threadgroup_join(ti_threadgroup_t *tg, int16_t ext_tid);
 int ti_threadgroup_destroy(ti_threadgroup_t *tg);
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -378,13 +378,16 @@ void ti_threadfun(void *arg)
     // free the thread argument here
     free(ta);
 
+    int init = 1;
+
     // work loop
     for (; ;) {
 #if PROFILE_JL_THREADING
         uint64_t tstart = uv_hrtime();
 #endif
 
-        ti_threadgroup_fork(tg, ptls->tid, (void **)&work);
+        ti_threadgroup_fork(tg, ptls->tid, (void **)&work, init);
+        init = 0;
 
 #if PROFILE_JL_THREADING
         uint64_t tfork = uv_hrtime();
@@ -632,7 +635,7 @@ void jl_shutdown_threading(void)
     ti_threadwork_t *work = &threadwork;
 
     work->command = TI_THREADWORK_DONE;
-    ti_threadgroup_fork(tgworld, ptls->tid, (void **)&work);
+    ti_threadgroup_fork(tgworld, ptls->tid, (void **)&work, 0);
 
     sleep(1);
 
@@ -691,7 +694,7 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_value_t *_args)
 
     // fork the world thread group
     ti_threadwork_t *tw = &threadwork;
-    ti_threadgroup_fork(tgworld, ptls->tid, (void **)&tw);
+    ti_threadgroup_fork(tgworld, ptls->tid, (void **)&tw, 0);
 
 #if PROFILE_JL_THREADING
     uint64_t tfork = uv_hrtime();


### PR DESCRIPTION
This help startup for normal code since the CPUs no longer has to run at 100% for a long time at startup by default. This is especially useful when precompilation is triggerred since we currently do the precompilation on one thread while `2(N-1)` other threads are eating 100% CPU time causing a huge oversubscription. With this patch the time it takes to precompile a package with threads enabled is almost halfed, taking the same amount of time when the threads disabled.

The one case this can cause a small slow down is if the loading is instantaneous and the threaded code starts immediately after that. I kind of doubt the difference matters since this is a tiny one time cost but it is still possible to get the old behavior back when the sleep threshold is set to infinity.
