### PR TITLE
remove manual memory-management from Timer and AsyncConditional

### DIFF
--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -49,7 +49,6 @@ disassociate_julia_struct(handle::Ptr{Void}) =
 # and should thus not be garbage collected
 const uvhandles = ObjectIdDict()
 preserve_handle(x) = uvhandles[x] = get(uvhandles,x,0)::Int+1
-preserve_handle_new(x) = uvhandles[x] = 1
 unpreserve_handle(x) = (v = uvhandles[x]::Int; v == 1 ? pop!(uvhandles,x) : (uvhandles[x] = v-1); nothing)
 
 ## Libuv error handling ##

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -123,7 +123,25 @@ end
 # issue #12473
 # make sure 1-shot timers work
 let a = []
-    Timer(t->push!(a, 1), 0.01, 0)
+    Timer(t -> push!(a, 1), 0.01, 0)
     sleep(0.2)
     @test a == [1]
+end
+
+# make sure repeating timers work
+@noinline function make_unrooted_timer(a)
+    t = Timer(0.0, 0.1)
+    finalizer(t, t -> a[] += 1)
+    wait(t)
+    e = @elapsed for i = 1:5
+        wait(t)
+    end
+    @test 1.5 > e > 0.5
+    @test a[] == 0
+    nothing
+end
+let a = Ref(0)
+    make_unrooted_timer(a)
+    gc()
+    @test a[] == 1
 end


### PR DESCRIPTION
fixes a potential resource leak with a repeating timer
and is just generally less finicky