### PR TITLE
A few fixes for the GC pages changes

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -135,7 +135,7 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t nfields,
     jl_datatype_layout_t *flddesc =
         (jl_datatype_layout_t*)jl_gc_perm_alloc(sizeof(jl_datatype_layout_t) +
                                                 nfields * fielddesc_size +
-                                                (has_padding ? sizeof(uint32_t) : 0));
+                                                (has_padding ? sizeof(uint32_t) : 0), 0);
     if (has_padding) {
         if (first_ptr > UINT16_MAX)
             first_ptr = UINT16_MAX;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1502,7 +1502,7 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
             size_t fielddesc_size = nf > 0 ? jl_fielddesc_size(fielddesc_type) : 0;
             jl_datatype_layout_t *layout = (jl_datatype_layout_t*)jl_gc_perm_alloc(
                     sizeof(jl_datatype_layout_t) + nf * fielddesc_size +
-                    (has_padding ? sizeof(uint32_t) : 0));
+                    (has_padding ? sizeof(uint32_t) : 0), 0);
             if (has_padding) {
                 layout = (jl_datatype_layout_t*)(((char*)layout) + sizeof(uint32_t));
                 jl_datatype_layout_n_nonptr(layout) = read_int32(s->s);

--- a/src/gc.c
+++ b/src/gc.c
@@ -2366,13 +2366,13 @@ static char *gc_perm_pool = NULL;
 static size_t gc_perm_size = 0;
 
 // **NOT** a safepoint
-void *jl_gc_perm_alloc_nolock(size_t sz)
+void *jl_gc_perm_alloc_nolock(size_t sz, int zero)
 {
     // The caller should have acquired `gc_perm_lock`
 #ifndef MEMDEBUG
     if (__unlikely(sz > GC_PERM_POOL_LIMIT))
 #endif
-        return malloc(sz);
+        return zero ? calloc(1, sz) : malloc(sz);
     sz = LLT_ALIGN(sz, JL_SMALL_BYTE_ALIGNMENT);
     if (__unlikely(sz > gc_perm_size)) {
 #ifdef _OS_WINDOWS_
@@ -2399,14 +2399,14 @@ void *jl_gc_perm_alloc_nolock(size_t sz)
 }
 
 // **NOT** a safepoint
-void *jl_gc_perm_alloc(size_t sz)
+void *jl_gc_perm_alloc(size_t sz, int zero)
 {
 #ifndef MEMDEBUG
     if (__unlikely(sz > GC_PERM_POOL_LIMIT))
 #endif
-        return malloc(sz);
+        return zero ? calloc(1, sz) : malloc(sz);
     JL_LOCK_NOGC(&gc_perm_lock);
-    void *p = jl_gc_perm_alloc_nolock(sz);
+    void *p = jl_gc_perm_alloc_nolock(sz, zero);
     JL_UNLOCK_NOGC(&gc_perm_lock);
     return p;
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -602,7 +602,7 @@ STATIC_INLINE void gc_setmark_pool_(jl_ptls_t ptls, jl_taggedvalue_t *o,
 STATIC_INLINE void gc_setmark_pool(jl_ptls_t ptls, jl_taggedvalue_t *o,
                                    uint8_t mark_mode)
 {
-    gc_setmark_pool_(ptls, o, mark_mode, page_metadata_ext(o).meta);
+    gc_setmark_pool_(ptls, o, mark_mode, jl_assume(page_metadata(o)));
 }
 
 STATIC_INLINE void gc_setmark(jl_ptls_t ptls, jl_taggedvalue_t *o,
@@ -930,7 +930,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
         if (__unlikely(gc_page_data(v) != gc_page_data(next))) {
             // we only update pg's fields when the freelist changes page
             // since pg's metadata is likely not in cache
-            jl_gc_pagemeta_t *pg = page_metadata_ext(v).meta;
+            jl_gc_pagemeta_t *pg = jl_assume(page_metadata(v));
             assert(pg->osize == p->osize);
             pg->nfree = 0;
             pg->has_young = 1;
@@ -947,7 +947,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
         if (v) {
             // like the freelist case,
             // but only update the page metadata when it is full
-            jl_gc_pagemeta_t *pg = page_metadata_ext((char*)v - 1).meta;
+            jl_gc_pagemeta_t *pg = jl_assume(page_metadata((char*)v - 1));
             assert(pg->osize == p->osize);
             pg->nfree = 0;
             pg->has_young = 1;
@@ -1220,7 +1220,7 @@ static void gc_sweep_pool(int sweep_full)
             jl_gc_pool_t *p = &ptls2->heap.norm_pools[i];
             jl_taggedvalue_t *last = p->freelist;
             if (last) {
-                jl_gc_pagemeta_t *pg = page_metadata_ext(last).meta;
+                jl_gc_pagemeta_t *pg = jl_assume(page_metadata(last));
                 gc_pool_sync_nfree(pg, last);
                 pg->has_young = 1;
             }
@@ -1230,7 +1230,7 @@ static void gc_sweep_pool(int sweep_full)
             last = p->newpages;
             if (last) {
                 char *last_p = (char*)last;
-                jl_gc_pagemeta_t *pg = page_metadata_ext(last_p - 1).meta;
+                jl_gc_pagemeta_t *pg = jl_assume(page_metadata(last_p - 1));
                 assert(last_p - gc_page_data(last_p - 1) >= GC_PAGE_OFFSET);
                 pg->nfree = (GC_PAGE_SZ - (last_p - gc_page_data(last_p - 1))) / p->osize;
                 pg->has_young = 1;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -127,8 +127,8 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
 JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t allocsz);
 int jl_gc_classify_pools(size_t sz, int *osize);
 extern jl_mutex_t gc_perm_lock;
-void *jl_gc_perm_alloc_nolock(size_t sz);
-void *jl_gc_perm_alloc(size_t sz);
+void *jl_gc_perm_alloc_nolock(size_t sz, int zero);
+void *jl_gc_perm_alloc(size_t sz, int zero);
 
 // pools are 16376 bytes large (GC_POOL_SZ - GC_PAGE_OFFSET)
 static const int jl_gc_sizeclasses[JL_GC_N_POOLS] = {

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -32,7 +32,7 @@ static jl_sym_t *mk_symbol(const char *str, size_t len)
     jl_sym_t *sym;
     size_t nb = symbol_nbytes(len);
 
-    jl_taggedvalue_t *tag = (jl_taggedvalue_t*)jl_gc_perm_alloc_nolock(nb);
+    jl_taggedvalue_t *tag = (jl_taggedvalue_t*)jl_gc_perm_alloc_nolock(nb, 0);
     sym = (jl_sym_t*)jl_valueof(tag);
     // set to old marked since we don't need write barrier on it.
     tag->header = ((uintptr_t)jl_sym_type) | GC_OLD_MARKED;


### PR DESCRIPTION
1. Use `jl_assume` as fast path. I think this is more obvious for the reader than `page_metadata_ext`.

    Some of them might not be necessary since a NULL return would be a UB but keeping them there shouldn't hurt.

2. Fix `GC_VERIFY` (and therefore `GC_DEBUG_ENV`). This should fix the GC debug buildbot

3. Use the permgen allocator to allocate the page metadata

    Merge the permgen and the page alloc lock. Add an option to permgen allocator to request for zeroed memory even if the size passes bump pointer threshold.
