### PR TITLE
Consistently apply code formatting to paths and file names

### DIFF
--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -8,7 +8,7 @@ to figure out why your script is running slower than expected.
 If you've been directed to this page, find the symptom that best matches what you're experiencing
 and follow the instructions to generate the debugging information requested.  Table of symptoms:
 
-  * [Segfaults during bootstrap (sysimg.jl)](@ref)
+  * [Segfaults during bootstrap (`sysimg.jl`)](@ref)
   * [Segfaults when running a script](@ref)
   * [Errors during Julia startup](@ref)
 
@@ -32,7 +32,7 @@ Platform Info:
   LLVM: libLLVM-3.3
 ```
 
-## Segfaults during bootstrap (sysimg.jl)
+## Segfaults during bootstrap (`sysimg.jl`)
 
 Segfaults toward the end of the `make` process of building Julia are a common symptom of something
 going wrong while Julia is preparsing the corpus of code in the `base/` folder.  Many factors
@@ -64,7 +64,7 @@ on Github with a link to the gist.
 
 ## Segfaults when running a script
 
-The procedure is very similar to [Segfaults during bootstrap (sysimg.jl)](@ref).  Create a debug
+The procedure is very similar to [Segfaults during bootstrap (`sysimg.jl`)](@ref).  Create a debug
 build of Julia, and run your script inside of a debugged Julia process:
 
 ```

--- a/doc/src/devdocs/debuggingtips.md
+++ b/doc/src/devdocs/debuggingtips.md
@@ -26,7 +26,7 @@ Julia's flisp interpreter uses `value_t` objects; these can be displayed with `c
 ## Useful Julia variables for Inspecting
 
 While the addresses of many variables, like singletons, can be be useful to print for many failures,
-there are a number of additional variables (see julia.h for a complete list) that are even more
+there are a number of additional variables (see `julia.h` for a complete list) that are even more
 useful.
 
   * (when in `jl_apply_generic`) `mfunc` and `jl_uncompress_ast(mfunc->def, mfunc->code)` :: for

--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -62,12 +62,12 @@ The 10,000 foot view of the whole process is as follows:
 The Julia parser is a small lisp program written in femtolisp, the source-code for which is distributed
 inside Julia in [src/flisp](https://github.com/JuliaLang/julia/tree/master/src/flisp).
 
-The interface functions for this are primarily defined in [jlfrontend.scm](https://github.com/JuliaLang/julia/blob/master/src/jlfrontend.scm).
+The interface functions for this are primarily defined in [`jlfrontend.scm`](https://github.com/JuliaLang/julia/blob/master/src/jlfrontend.scm).
 The code in [`ast.c`](https://github.com/JuliaLang/julia/blob/master/src/ast.c) handles this handoff
 on the Julia side.
 
-The other relevant files at this stage are [julia-parser.scm](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm),
-which handles tokenizing Julia code and turning it into an AST, and [julia-syntax.scm](https://github.com/JuliaLang/julia/blob/master/src/julia-syntax.scm),
+The other relevant files at this stage are [`julia-parser.scm`](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm),
+which handles tokenizing Julia code and turning it into an AST, and [`julia-syntax.scm`](https://github.com/JuliaLang/julia/blob/master/src/julia-syntax.scm),
 which handles transforming complex AST representations into simpler, "lowered" AST representations
 which are more suitable for analysis and execution.
 

--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -25,7 +25,7 @@ The 10,000 foot view of the whole process is as follows:
 1. The user starts `julia`.
 2. The C function `main()` from `ui/repl.c` gets called. This function processes the command line
    arguments, filling in the `jl_options` struct and setting the variable `ARGS`. It then initializes
-   Julia (by calling [`julia_init` in task.c](https://github.com/JuliaLang/julia/blob/master/src/task.c),
+   Julia (by calling [`julia_init` in `task.c`](https://github.com/JuliaLang/julia/blob/master/src/task.c),
    which may load a previously compiled [sysimg](@ref dev-sysimg)). Finally, it passes off control to Julia
    by calling [`Base._start()`](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
 3. When `_start()` takes over control, the subsequent sequence of commands depends on the command
@@ -45,7 +45,7 @@ The 10,000 foot view of the whole process is as follows:
    the AST to make it simpler to execute.
 10. `jl_toplevel_eval_flex()` then uses some simple heuristics to decide whether to JIT compiler the
     AST or to interpret it directly.
-11. The bulk of the work to interpret code is handled by [`eval` in interpreter.c](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
+11. The bulk of the work to interpret code is handled by [`eval` in `interpreter.c`](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
 12. If instead, the code is compiled, the bulk of the work is handled by `codegen.cpp`. Whenever a
     Julia function is called for the first time with a given set of argument types, [type inference](@ref dev-type-inference)
     will be run on that function. This information is used by the [codegen](@ref dev-codegen) step to generate
@@ -63,7 +63,7 @@ The Julia parser is a small lisp program written in femtolisp, the source-code f
 inside Julia in [src/flisp](https://github.com/JuliaLang/julia/tree/master/src/flisp).
 
 The interface functions for this are primarily defined in [jlfrontend.scm](https://github.com/JuliaLang/julia/blob/master/src/jlfrontend.scm).
-The code in [ast.c](https://github.com/JuliaLang/julia/blob/master/src/ast.c) handles this handoff
+The code in [`ast.c`](https://github.com/JuliaLang/julia/blob/master/src/ast.c) handles this handoff
 on the Julia side.
 
 The other relevant files at this stage are [julia-parser.scm](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm),
@@ -83,7 +83,7 @@ although it can also be invoked directly by a call to [`macroexpand()`](@ref)/`j
 
 ## [Type Inference](@id dev-type-inference)
 
-Type inference is implemented in Julia by [typeinf() in inference.jl](https://github.com/JuliaLang/julia/blob/master/base/inference.jl).
+Type inference is implemented in Julia by [`typeinf()` in `inference.jl`](https://github.com/JuliaLang/julia/blob/master/base/inference.jl).
 Type inference is the process of examining a Julia function and determining bounds for the types
 of each of its variables, as well as bounds on the type of the return value from the function.
 This enables many future optimizations, such as unboxing of known immutable values, and compile-time
@@ -135,7 +135,7 @@ Type inference may also include other steps such as constant propagation and inl
 
 Codegen is the process of turning a Julia AST into native machine code.
 
-The JIT environment is initialized by an early call to [`jl_init_codegen` in codegen.cpp](https://github.com/JuliaLang/julia/blob/master/src/codegen.cpp).
+The JIT environment is initialized by an early call to [`jl_init_codegen` in `codegen.cpp`](https://github.com/JuliaLang/julia/blob/master/src/codegen.cpp).
 
 On demand, a Julia method is converted into a native function by the function `emit_function(jl_method_instance_t*)`.
 (note, when using the MCJIT (in LLVM v3.4+), each function must be JIT into a new module.) This
@@ -143,18 +143,18 @@ function recursively calls `emit_expr()` until the entire function has been emit
 
 Much of the remaining bulk of this file is devoted to various manual optimizations of specific
 code patterns. For example, `emit_known_call()` knows how to inline many of the primitive functions
-(defined in [builtins.c](https://github.com/JuliaLang/julia/blob/master/src/builtins.c)) for various
+(defined in [`builtins.c`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c)) for various
 combinations of argument types.
 
 Other parts of codegen are handled by various helper files:
 
-  * [debuginfo.cpp](https://github.com/JuliaLang/julia/blob/master/src/debuginfo.cpp)
+  * [`debuginfo.cpp`](https://github.com/JuliaLang/julia/blob/master/src/debuginfo.cpp)
 
     Handles backtraces for JIT functions
-  * [ccall.cpp](https://github.com/JuliaLang/julia/blob/master/src/ccall.cpp)
+  * [`ccall.cpp`](https://github.com/JuliaLang/julia/blob/master/src/ccall.cpp)
 
     Handles the ccall and llvmcall FFI, along with various `abi_*.cpp` files
-  * [intrinsics.cpp](https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp)
+  * [`intrinsics.cpp`](https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp)
 
     Handles the emission of various low-level intrinsic functions
 
@@ -168,11 +168,11 @@ Other parts of codegen are handled by various helper files:
 ## [System Image](@id dev-sysimg)
 
 The system image is a precompiled archive of a set of Julia files. The `sys.ji` file distributed
-with Julia is one such system image, generated by executing the file [sysimg.jl](https://github.com/JuliaLang/julia/blob/master/base/sysimg.jl),
+with Julia is one such system image, generated by executing the file [`sysimg.jl`](https://github.com/JuliaLang/julia/blob/master/base/sysimg.jl),
 and serializing the resulting environment (including Types, Functions, Modules, and all other
 defined values) into a file. Therefore, it contains a frozen version of the `Main`, `Core`, and
 `Base` modules (and whatever else was in the environment at the end of bootstrapping). This serializer/deserializer
-is implemented by [`jl_save_system_image`/`jl_restore_system_image` in dump.c](https://github.com/JuliaLang/julia/blob/master/src/dump.c).
+is implemented by [`jl_save_system_image`/`jl_restore_system_image` in `dump.c`](https://github.com/JuliaLang/julia/blob/master/src/dump.c).
 
 If there is no sysimg file (`jl_options.image_file == NULL`), this also implies that `--build`
 was given on the command line, so the final result should be a new sysimg file. During Julia initialization,

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -263,7 +263,7 @@ more than 25 exception handlers. If one ever does, I'm willing to raise the limi
 A minor issue occurs during the bootstrap process due to storing all constructors in a single
 method table. In the second bootstrap step, where inference.ji is compiled using inference0.ji,
 constructors for inference0's types remain in the table, so there are still references to the
-old inference module and inference.ji is 2x the size it should be. This was fixed in dump.c by
+old inference module and inference.ji is 2x the size it should be. This was fixed in `dump.c` by
 filtering definitions from "replaced modules" out of method tables and caches before saving a
 system image. A "replaced module" is one that satisfies the condition `m != jl_get_global(m->parent, m->name)`
 -- in other words, some newer module has taken its name and place.

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -261,9 +261,9 @@ some number of handlers (currently 25). Presumably no performance-critical funct
 more than 25 exception handlers. If one ever does, I'm willing to raise the limit to 26.
 
 A minor issue occurs during the bootstrap process due to storing all constructors in a single
-method table. In the second bootstrap step, where inference.ji is compiled using inference0.ji,
-constructors for inference0's types remain in the table, so there are still references to the
-old inference module and inference.ji is 2x the size it should be. This was fixed in `dump.c` by
+method table. In the second bootstrap step, where `inference.ji` is compiled using `inference0.ji`,
+constructors for `inference0`'s types remain in the table, so there are still references to the
+old inference module and `inference.ji` is 2x the size it should be. This was fixed in `dump.c` by
 filtering definitions from "replaced modules" out of method tables and caches before saving a
 system image. A "replaced module" is one that satisfies the condition `m != jl_get_global(m->parent, m->name)`
 -- in other words, some newer module has taken its name and place.

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -4,22 +4,22 @@ How does the Julia runtime execute `julia -e 'println("Hello World!")'` ?
 
 ## main()
 
-Execution starts at [`main()` in ui/repl.c](https://github.com/JuliaLang/julia/blob/master/ui/repl.c).
+Execution starts at [`main()` in `ui/repl.c`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c).
 
 `main()` calls [`libsupport_init()`](https://github.com/JuliaLang/julia/blob/master/src/support/libsupportinit.c)
 to set the C library locale and to initialize the "ios" library (see [`ios_init_stdstreams()`](https://github.com/JuliaLang/julia/blob/master/src/support/ios.c)
-and [Legacy ios.c library](@ref)).
+and [Legacy `ios.c` library](@ref)).
 
 Next [`parse_opts()`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c) is called to process
 command line options. Note that `parse_opts()` only deals with options that affect code generation
-or early initialization. Other options are handled later by [`process_options()` in base/client.jl](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
+or early initialization. Other options are handled later by [`process_options()` in `base/client.jl`](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
 
 `parse_opts()` stores command line options in the [global `jl_options` struct](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
 
 ## julia_init()
 
-[`julia_init()` in task.c](https://github.com/JuliaLang/julia/blob/master/src/task.c) is called
-by `main()` and calls [`_julia_init()` in init.c](https://github.com/JuliaLang/julia/blob/master/src/init.c).
+[`julia_init()` in `task.c`](https://github.com/JuliaLang/julia/blob/master/src/task.c) is called
+by `main()` and calls [`_julia_init()` in `init.c`](https://github.com/JuliaLang/julia/blob/master/src/init.c).
 
 `_julia_init()` begins by calling `libsupport_init()` again (it does nothing the second time).
 
@@ -36,7 +36,7 @@ and lists for weak refs, preserved values and finalization.
 a pre-compiled femtolisp image containing the scanner/parser.
 
 [`jl_init_types()`](https://github.com/JuliaLang/julia/blob/master/src/jltypes.c) creates `jl_datatype_t`
-type description objects for the [built-in types defined in julia.h](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
+type description objects for the [built-in types defined in `julia.h`](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
 e.g.
 
 ```c
@@ -84,11 +84,11 @@ above is overwritten.
 [`jl_load("boot.jl", sizeof("boot.jl"))`](https://github.com/JuliaLang/julia/blob/master/src/init.c)
 calls [`jl_parse_eval_all`](https://github.com/JuliaLang/julia/blob/master/src/ast.c) which repeatedly
 calls [`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
-to execute [boot.jl](https://github.com/JuliaLang/julia/blob/master/base/boot.jl). <!-- TODO – drill
+to execute [`boot.jl`](https://github.com/JuliaLang/julia/blob/master/base/boot.jl). <!-- TODO – drill
 down into eval? -->
 
 [`jl_get_builtin_hooks()`](https://github.com/JuliaLang/julia/blob/master/src/init.c) initializes
-global C pointers to Julia globals defined in boot.jl.
+global C pointers to Julia globals defined in `boot.jl`.
 
 [`jl_init_box_caches()`](https://github.com/JuliaLang/julia/blob/master/src/datatype.c) pre-allocates
 global boxed integer value objects for values up to 1024. This speeds up allocation of boxed ints
@@ -124,26 +124,26 @@ each deserialized module to run the `__init__()` function.
 Finally [`sigint_handler()`](https://github.com/JuliaLang/julia/blob/master/src/signals-unix.c)
 is hooked up to `SIGINT` and calls `jl_throw(jl_interrupt_exception)`.
 
-`_julia_init()` then returns [back to `main()` in julia/ui/repl.c](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
+`_julia_init()` then returns [back to `main()` in `ui/repl.c`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
 and `main()` calls `true_main(argc, (char**)argv)`.
 
 !!! sidebar "sysimg"
     If there is a sysimg file, it contains a pre-cooked image of the `Core` and `Main` modules (and
-    whatever else is created by boot.jl). See [Building the Julia system image](@ref).
+    whatever else is created by `boot.jl`). See [Building the Julia system image](@ref).
 
     [`jl_restore_system_image()`](https://github.com/JuliaLang/julia/blob/master/src/dump.c) deserializes
     the saved sysimg into the current Julia runtime environment and initialization continues after
     `jl_init_box_caches()` below...
 
-    Note: [`jl_restore_system_image()` (and dump.c in general)](https://github.com/JuliaLang/julia/blob/master/src/dump.c)
-    uses the [Legacy ios.c library](@ref).
+    Note: [`jl_restore_system_image()` (and `dump.c` in general)](https://github.com/JuliaLang/julia/blob/master/src/dump.c)
+    uses the [Legacy `ios.c` library](@ref).
 
 ## true_main()
 
 [`true_main()`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c) loads the contents of
 `argv[]` into [`Base.ARGS`](@ref).
 
-If a .jl "program" file was supplied on the command line, then [`exec_program()`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
+If a `.jl` "program" file was supplied on the command line, then [`exec_program()`](https://github.com/JuliaLang/julia/blob/master/ui/repl.c)
 calls [`jl_load(program,len)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) which
 calls [`jl_parse_eval_all`](https://github.com/JuliaLang/julia/blob/master/src/ast.c) which repeatedly
 calls [`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c)
@@ -169,7 +169,7 @@ where `ex` is the parsed expression `println("Hello World!")`.
 
 [`jl_toplevel_eval_in()`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) calls
 [`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) which
-calls [`eval()` in interpreter.c](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
+calls [`eval()` in `interpreter.c`](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
 
 The stack dump below shows how the interpreter works its way through various methods of [`Base.println()`](@ref)
 and [`Base.print()`](@ref) before arriving at [`write(s::IO, a::Array{T}) where T`](https://github.com/JuliaLang/julia/blob/master/base/stream.jl)
@@ -182,38 +182,38 @@ to write "Hello World!" to `JL_STDOUT`. See [Libuv wrappers for stdio](@ref).:
 Hello World!
 ```
 
-| Stack frame                    | Source code   | Notes                                                |
-|:------------------------------ |:------------- |:---------------------------------------------------- |
-| `jl_uv_write()`                | jl_uv.c       | called though [`ccall`](@ref)                        |
-| `julia_write_282942`           | stream.jl     | function `write!(s::IO, a::Array{T}) where T`        |
-| `julia_print_284639`           | ascii.jl      | `print(io::IO, s::String) = (write(io, s); nothing)` |
-| `jlcall_print_284639`          |               |                                                      |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_trampoline()`              | builtins.c    |                                                      |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_apply_generic()`           | gf.c          | `Base.print(Base.TTY, String)`                       |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_trampoline()`              | builtins.c    |                                                      |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_apply_generic()`           | gf.c          | `Base.print(Base.TTY, String, Char, Char...)`        |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_f_apply()`                 | builtins.c    |                                                      |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_trampoline()`              | builtins.c    |                                                      |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_apply_generic()`           | gf.c          | `Base.println(Base.TTY, String, String...)`          |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_trampoline()`              | builtins.c    |                                                      |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `jl_apply_generic()`           | gf.c          | `Base.println(String,)`                              |
-| `jl_apply()`                   | julia.h       |                                                      |
-| `do_call()`                    | interpreter.c |                                                      |
-| `eval()`                       | interpreter.c |                                                      |
-| `jl_interpret_toplevel_expr()` | interpreter.c |                                                      |
-| `jl_toplevel_eval_flex()`      | toplevel.c    |                                                      |
-| `jl_toplevel_eval()`           | toplevel.c    |                                                      |
-| `jl_toplevel_eval_in()`        | builtins.c    |                                                      |
-| `jl_f_top_eval()`              | builtins.c    |                                                      |
+| Stack frame                    | Source code     | Notes                                                |
+|:------------------------------ |:--------------- |:---------------------------------------------------- |
+| `jl_uv_write()`                | `jl_uv.c`       | called though [`ccall`](@ref)                        |
+| `julia_write_282942`           | `stream.jl`     | function `write!(s::IO, a::Array{T}) where T`        |
+| `julia_print_284639`           | `ascii.jl`      | `print(io::IO, s::String) = (write(io, s); nothing)` |
+| `jlcall_print_284639`          |                 |                                                      |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_trampoline()`              | `builtins.c`    |                                                      |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_apply_generic()`           | `gf.c`          | `Base.print(Base.TTY, String)`                       |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_trampoline()`              | `builtins.c`    |                                                      |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_apply_generic()`           | `gf.c`          | `Base.print(Base.TTY, String, Char, Char...)`        |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_f_apply()`                 | `builtins.c`    |                                                      |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_trampoline()`              | `builtins.c`    |                                                      |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_apply_generic()`           | `gf.c`          | `Base.println(Base.TTY, String, String...)`          |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_trampoline()`              | `builtins.c`    |                                                      |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `jl_apply_generic()`           | `gf.c`          | `Base.println(String,)`                              |
+| `jl_apply()`                   | `julia.h`       |                                                      |
+| `do_call()`                    | `interpreter.c` |                                                      |
+| `eval()`                       | `interpreter.c` |                                                      |
+| `jl_interpret_toplevel_expr()` | `interpreter.c` |                                                      |
+| `jl_toplevel_eval_flex()`      | `toplevel.c`    |                                                      |
+| `jl_toplevel_eval()`           | `toplevel.c`    |                                                      |
+| `jl_toplevel_eval_in()`        | `builtins.c`    |                                                      |
+| `jl_f_top_eval()`              | `builtins.c`    |                                                      |
 
 Since our example has just one function call, which has done its job of printing "Hello World!",
 the stack now rapidly unwinds back to `main()`.

--- a/doc/src/devdocs/object.md
+++ b/doc/src/devdocs/object.md
@@ -85,14 +85,14 @@ void jl_gc_wb(jl_value_t *parent, jl_value_t *ptr);
 However, the [Embedding Julia](@ref) section of the manual is also required reading at this point,
 for covering other details of boxing and unboxing various types, and understanding the gc interactions.
 
-Mirror structs for some of the built-in types are [defined in julia.h](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
-The corresponding global `jl_datatype_t` objects are created by [`jl_init_types` in jltypes.c](https://github.com/JuliaLang/julia/blob/master/src/jltypes.c).
+Mirror structs for some of the built-in types are [defined in `julia.h`](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
+The corresponding global `jl_datatype_t` objects are created by [`jl_init_types` in `jltypes.c`](https://github.com/JuliaLang/julia/blob/master/src/jltypes.c).
 
 ## Garbage collector mark bits
 
 The garbage collector uses several bits from the metadata portion of the `jl_typetag_t` to track
 each object in the system. Further details about this algorithm can be found in the comments of
-the [garbage collector implementation in gc.c](https://github.com/JuliaLang/julia/blob/master/src/gc.c).
+the [garbage collector implementation in `gc.c`](https://github.com/JuliaLang/julia/blob/master/src/gc.c).
 
 ## Object allocation
 
@@ -120,7 +120,7 @@ jl_uniontype_t *jl_new_uniontype(jl_tuple_t *types);
 ```
 
 While these are the most commonly used options, there are more low-level constructors too, which
-you can find declared in [julia.h](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
+you can find declared in [`julia.h`](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
 These are used in `jl_init_types()` to create the initial types needed to bootstrap the creation
 of the Julia system image.
 
@@ -173,7 +173,7 @@ jl_array_t *jl_alloc_vec_any(size_t n);
 
 Note that many of these have alternative allocation functions for various special-purposes. The
 list here reflects the more common usages, but a more complete list can be found by reading the
-[julia.h header file](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
+[`julia.h` header file](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
 
 Internal to Julia, storage is typically allocated by `newstruct()` (or `newobj()` for the special
 types):

--- a/doc/src/devdocs/offset-arrays.md
+++ b/doc/src/devdocs/offset-arrays.md
@@ -169,8 +169,8 @@ is (perhaps counterintuitively) an advantage: `ModuleA.ZeroRange` indicates that
 create a `ModuleA.ZeroArray`, whereas `ModuleB.ZeroRange` indicates a `ModuleB.ZeroArray` type.
  This design allows peaceful coexistence among many different custom array types.
 
-Note that the Julia package `CustomUnitRanges.jl` can sometimes be used to avoid the need to write
-your own `ZeroRange` type.
+Note that the Julia package [CustomUnitRanges.jl](https://github.com/JuliaArrays/CustomUnitRanges.jl)
+can sometimes be used to avoid the need to write your own `ZeroRange` type.
 
 ### Specializing `indices`
 

--- a/doc/src/devdocs/stdio.md
+++ b/doc/src/devdocs/stdio.md
@@ -74,18 +74,18 @@ In `jl_uv.c` the `jl_uv_puts()` function checks its `uv_stream_t* stream` argume
 This allows for uniform use of `jl_printf()` throughout the runtime regardless of whether or not
 any particular piece of code is reachable before initialization is complete.
 
-## Legacy ios.c library
+## Legacy `ios.c` library
 
 The `src/support/ios.c` library is inherited from [femtolisp](https://github.com/JeffBezanson/femtolisp).
 It provides cross-platform buffered file IO and in-memory temporary buffers.
 
-ios.c is still used by:
+`ios.c` is still used by:
 
   * `src/flisp/*.c`
   * `src/dump.c` – for serialization file IO and for memory buffers.
   * `base/iostream.jl` – for file IO (see `base/fs.jl` for libuv equivalent).
 
-Use of ios.c in these modules is mostly self-contained and separated from the libuv I/O system.
+Use of `ios.c` in these modules is mostly self-contained and separated from the libuv I/O system.
 However, there is [one place](https://github.com/JuliaLang/julia/blob/master/src/flisp/print.c#L654)
 where femtolisp calls through to `jl_printf()` with a legacy `ios_t` stream.
 

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -454,12 +454,12 @@ in Julia:
 struct B
     A::NTuple{3, CInt}
 end
-b_a_2 = B.A[2]
+b_a_2 = B.A[3]  # note the difference in indexing (1-based in Julia, 0-based in C)
 ```
 
 Arrays of unknown size (C99-compliant variable length structs specified by `[]` or `[0]`) are not directly supported.
 Often the best way to deal with these is to deal with the byte offsets directly.
-For example, if a c-library declared a proper string type and returned a pointer to it:
+For example, if a C library declared a proper string type and returned a pointer to it:
 
 ```c
 struct String {

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -95,7 +95,7 @@ uses in Julia functions that set up arguments and then check for errors in whate
 C or Fortran function indicates them, propagating to the Julia caller as exceptions. This is especially
 important since C and Fortran APIs are notoriously inconsistent about how they indicate error
 conditions. For example, the `getenv` C library function is wrapped in the following Julia function,
-which is a simplified version of the actual definition from [env.jl](https://github.com/JuliaLang/julia/blob/master/base/env.jl):
+which is a simplified version of the actual definition from [`env.jl`](https://github.com/JuliaLang/julia/blob/master/base/env.jl):
 
 ```julia
 function getenv(var::AbstractString)
@@ -149,7 +149,7 @@ throw a conversion error.
 It is possible to pass Julia functions to native C functions that accept function pointer arguments.
 For example, to match C prototypes of the form:
 
-```
+```c
 typedef returntype (*functiontype)(argumenttype,...)
 ```
 
@@ -162,7 +162,7 @@ Julia library function. Arguments to [`cfunction()`](@ref) are as follows:
 
 A classic example is the standard C library `qsort` function, declared as:
 
-```
+```c
 void qsort(void *base, size_t nmemb, size_t size,
            int(*compare)(const void *a, const void *b));
 ```
@@ -176,7 +176,7 @@ calling `qsort` and passing arguments, we need to write a comparison function th
 arbitrary type T:
 
 ```jldoctest mycompare
-julia> function mycompare{T}(a::T, b::T)
+julia> function mycompare(a::T, b::T) where T
            return convert(Cint, a < b ? -1 : a > b ? +1 : 0)::Cint
        end
 mycompare (generic function with 1 method)
@@ -409,7 +409,7 @@ checks and is only meant to improve readability of the call.
     C functions that take an argument of the type `char**` can be called by using a `Ptr{Ptr{UInt8}}`
     type within Julia. For example, C functions of the form:
 
-    ```
+    ```c
     int main(int argc, char **argv);
     ```
 
@@ -451,7 +451,7 @@ struct B {
 b_a_2 = B.A[2];
 
 in Julia:
-type B
+struct B
     A::NTuple{3, CInt}
 end
 b_a_2 = B.A[2]
@@ -461,7 +461,7 @@ Arrays of unknown size (C99-compliant variable length structs specified by `[]` 
 Often the best way to deal with these is to deal with the byte offsets directly.
 For example, if a c-library declared a proper string type and returned a pointer to it:
 
-```
+```c
 struct String {
     int strlen;
     char data[];
@@ -470,7 +470,7 @@ struct String {
 
 In Julia, we can access the parts independently to make a copy of that string:
 
-```
+```julia
 str = from_c::Ptr{Void}
 len = unsafe_load(Ptr{Cint}(str))
 unsafe_string(str + Core.sizeof(Cint), len)
@@ -489,9 +489,9 @@ However, while the type layout must be known statically to compute the `ccall` A
 the static parameters of the function are considered to be part of this static environment.
 The static parameters of the function may be used as type parameters in the `ccall` signature,
 as long as they don't affect the layout of the type.
-For example, `f{T}(x::T) = ccall(:valid, Ptr{T}, (Ptr{T},), x)`
+For example, `f(x::T) where {T} = ccall(:valid, Ptr{T}, (Ptr{T},), x)`
 is valid, since `Ptr` is always a word-size primitive type.
-But, `g{T}(x::T) = ccall(:notvalid, T, (T,), x)`
+But, `g(x::T) where {T} = ccall(:notvalid, T, (T,), x)`
 is not valid, since the type layout of `T` is not known statically.
 
 ### SIMD Values
@@ -508,7 +508,7 @@ Julia type is a homogeneous tuple of `VecElement` that naturally maps to the SIM
 
 For instance, consider this C routine that uses AVX intrinsics:
 
-```
+```c
 #include <immintrin.h>
 
 __m256 dist( __m256 a, __m256 b ) {
@@ -677,14 +677,14 @@ arguments, as noted above). The following example computes a dot product using a
 
 ```julia
 function compute_dot(DX::Vector{Float64}, DY::Vector{Float64})
-  assert(length(DX) == length(DY))
-  n = length(DX)
-  incx = incy = 1
-  product = ccall((:ddot_, "libLAPACK"),
-                  Float64,
-                  (Ptr{Int32}, Ptr{Float64}, Ptr{Int32}, Ptr{Float64}, Ptr{Int32}),
-                  &n, DX, &incx, DY, &incy)
-  return product
+    @assert length(DX) == length(DY)
+    n = length(DX)
+    incx = incy = 1
+    product = ccall((:ddot_, "libLAPACK"),
+                    Float64,
+                    (Ptr{Int32}, Ptr{Float64}, Ptr{Int32}, Ptr{Float64}, Ptr{Int32}),
+                    &n, DX, &incx, DY, &incy)
+    return product
 end
 ```
 
@@ -702,7 +702,7 @@ converted to type `T`.
 Here is a simple example of a C wrapper that returns a `Ptr` type:
 
 ```julia
-type gsl_permutation
+mutable struct gsl_permutation
 end
 
 # The corresponding C signature is
@@ -977,4 +977,5 @@ For more details on how to pass callbacks to C libraries, see this [blog post](h
 
 ## C++
 
-For direct C++ interfacing, see the [Cxx](https://github.com/Keno/Cxx.jl) package. For tools to create C++ bindings, see the [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl) package.
+For direct C++ interfacing, see the [Cxx](https://github.com/Keno/Cxx.jl) package. For tools to create C++
+bindings, see the [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl) package.

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -407,7 +407,7 @@ defining sophisticated behavior is typically quite simple.
 ## Case Study: Rational
 
 Perhaps the best way to tie all these pieces together is to present a real world example of a
-parametric composite type and its constructor methods. To that end, here is the (slightly modified) beginning of [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
+parametric composite type and its constructor methods. To that end, here is the (slightly modified) beginning of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
 which implements Julia's [Rational Numbers](@ref):
 
 ```jldoctest rational
@@ -502,7 +502,7 @@ false
 
 Thus, although the [`//`](@ref) operator usually returns an instance of `OurRational`, if either
 of its arguments are complex integers, it will return an instance of `Complex{OurRational}` instead.
-The interested reader should consider perusing the rest of [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl):
+The interested reader should consider perusing the rest of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl):
 it is short, self-contained, and implements an entire basic Julia type.
 
 ## [Constructors and Conversion](@id constructors-and-conversion)

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -143,7 +143,7 @@ ERROR: InexactError()
 
 ### [Case Study: Rational Conversions](@id man-rational-conversion)
 
-To continue our case study of Julia's `Rational` type, here are the conversions declared in [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
+To continue our case study of Julia's `Rational` type, here are the conversions declared in [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
 right after the declaration of the type and its constructors:
 
 ```julia
@@ -231,7 +231,7 @@ promoted to the appropriate kind of complex value.
 That is really all there is to using promotions. The rest is just a matter of clever application,
 the most typical "clever" application being the definition of catch-all methods for numeric operations
 like the arithmetic operators `+`, `-`, `*` and `/`. Here are some of the catch-all method definitions
-given in [promotion.jl](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl):
+given in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl):
 
 ```julia
 +(x::Number, y::Number) = +(promote(x,y)...)
@@ -245,11 +245,11 @@ multiplying and dividing pairs of numeric values, promote the values to a common
 try again. That's all there is to it: nowhere else does one ever need to worry about promotion
 to a common numeric type for arithmetic operations -- it just happens automatically. There are
 definitions of catch-all promotion methods for a number of other arithmetic and mathematical functions
-in [promotion.jl](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl), but beyond
+in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl), but beyond
 that, there are hardly any calls to `promote` required in the Julia standard library. The most
 common usages of `promote` occur in outer constructors methods, provided for convenience, to allow
 constructor calls with mixed types to delegate to an inner type with fields promoted to an appropriate
-common type. For example, recall that [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)
+common type. For example, recall that [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)
 provides the following outer constructor method:
 
 ```julia
@@ -309,7 +309,7 @@ Int64
 
 Internally, `promote_type` is used inside of `promote` to determine what type argument values
 should be converted to for promotion. It can, however, be useful in its own right. The curious
-reader can read the code in [promotion.jl](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl),
+reader can read the code in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl),
 which defines the complete promotion mechanism in about 35 lines.
 
 ### Case Study: Rational Promotions

--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -124,7 +124,7 @@ julia> for i = 1:10^5
        end
 ```
 
-A full suite of parsing and formatting tests and examples is available in [tests/dates/io.jl](https://github.com/JuliaLang/julia/blob/master/test/dates/io.jl).
+A full suite of parsing and formatting tests and examples is available in [`tests/dates/io.jl`](https://github.com/JuliaLang/julia/blob/master/test/dates/io.jl).
 
 ## Durations/Comparisons
 
@@ -503,7 +503,7 @@ julia> filter(dr) do x
  2014-11-11
 ```
 
-Additional examples and tests are available in [test/dates/adjusters.jl](https://github.com/JuliaLang/julia/blob/master/test/dates/adjusters.jl).
+Additional examples and tests are available in [`test/dates/adjusters.jl`](https://github.com/JuliaLang/julia/blob/master/test/dates/adjusters.jl).
 
 ## Period Types
 

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -75,7 +75,7 @@ example program calls this before returning from `main`.
 
 ### Using julia-config to automatically determine build parameters
 
-The script *julia-config.jl* was created to aid in determining what build parameters are required
+The script `julia-config.jl` was created to aid in determining what build parameters are required
 by a program that uses embedded Julia.  This script uses the build parameters and system configuration
 of the particular Julia distribution it is invoked by to export the necessary compiler flags for
 an embedding program to interact with that distribution.  This script is located in the Julia
@@ -97,8 +97,8 @@ int main(int argc, char *argv[])
 
 #### On the command line
 
-A simple use of this script is from the command line.  Assuming that *julia-config.jl* is located
-in */usr/local/julia/share/julia*, it can be invoked on the command line directly and takes any
+A simple use of this script is from the command line.  Assuming that `julia-config.jl` is located
+in `/usr/local/julia/share/julia`, it can be invoked on the command line directly and takes any
 combination of 3 flags:
 
 ```
@@ -106,7 +106,7 @@ combination of 3 flags:
 Usage: julia-config [--cflags|--ldflags|--ldlibs]
 ```
 
-If the above example source is saved in the file *embed_example.c*, then the following command
+If the above example source is saved in the file `embed_example.c`, then the following command
 will compile it into a running program on Linux and Windows (MSYS2 environment), or if on OS/X,
 then substitute `clang` for `gcc`.:
 
@@ -118,8 +118,8 @@ then substitute `clang` for `gcc`.:
 
 But in general, embedding projects will be more complicated than the above, and so the following
 allows general makefile support as well – assuming GNU make because of the use of the **shell**
-macro expansions.  Additionally, though many times *julia-config.jl* may be found in the directory
-*/usr/local*, this is not necessarily the case, but Julia can be used to locate *julia-config.jl*
+macro expansions.  Additionally, though many times `julia-config.jl` may be found in the directory
+`/usr/local`, this is not necessarily the case, but Julia can be used to locate `julia-config.jl`
 too, and the makefile can be used to take advantage of that.  The above example is extended to
 use a Makefile:
 
@@ -133,7 +133,7 @@ LDLIBS   += $(shell $(JL_SHARE)/julia-config.jl --ldlibs)
 all: embed_example
 ```
 
-Now the build command is simply **make**.
+Now the build command is simply `make`.
 
 ## Converting Types
 

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -360,7 +360,7 @@ Julia applies the following order of operations, from highest precedence to lowe
 | Assignments    | `= += -= *= /= //= \= ^= ÷= %= \|= &= ⊻= <<= >>= >>>=`                                            |
 
 For a complete list of *every* Julia operator's precedence, see the top of this file:
-[julia/src/julia-parser.scm](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm)
+[`src/julia-parser.scm`](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm)
 
 You can also find the numerical precedence for any given operator via the built-in function `Base.operator_precedence`, where higher numbers take precedence:
 

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -609,7 +609,7 @@ Expr
 
 So now instead of getting a plain string in `msg_body`, the macro is receiving a full expression
 that will need to be evaluated in order to display as expected. This can be spliced directly into
-the returned expression as an argument to the [`string()`](@ref) call; see [error.jl](https://github.com/JuliaLang/julia/blob/master/base/error.jl)
+the returned expression as an argument to the [`string()`](@ref) call; see [`error.jl`](https://github.com/JuliaLang/julia/blob/master/base/error.jl)
 for the complete implementation.
 
 The `@assert` macro makes great use of splicing into quoted expressions to simplify the manipulation

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -131,7 +131,7 @@ ERROR: RemoteException(2, CapturedException(UndefVarError(Symbol("#rand2"))
 Process 1 knew about the function `rand2`, but process 2 did not.
 
 Most commonly you'll be loading code from files or packages, and you have a considerable amount
-of flexibility in controlling which processes load code. Consider a file, `"DummyModule.jl"`,
+of flexibility in controlling which processes load code. Consider a file, `DummyModule.jl`,
 containing the following code:
 
 ```julia
@@ -814,8 +814,8 @@ Once finalized, a reference becomes invalid and cannot be used in any further ca
 ## [Shared Arrays](@id man-shared-arrays)
 
 Shared Arrays use system shared memory to map the same array across many processes. While there
-are some similarities to a [DArray](https://github.com/JuliaParallel/DistributedArrays.jl), the
-behavior of a [`SharedArray`](@ref) is quite different. In a [DArray](https://github.com/JuliaParallel/DistributedArrays.jl),
+are some similarities to a [`DArray`](https://github.com/JuliaParallel/DistributedArrays.jl), the
+behavior of a [`SharedArray`](@ref) is quite different. In a [`DArray`](https://github.com/JuliaParallel/DistributedArrays.jl),
 each process has local access to just a chunk of the data, and no two processes share the same
 chunk; in contrast, in a [`SharedArray`](@ref) each "participating" process has access to the
 entire array.  A [`SharedArray`](@ref) is a good choice when you want to have a large amount of

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -81,7 +81,7 @@ problem with type-stability. Consequently, in addition to the allocation itself,
 that the code generated for your function is far from optimal. Take such indications seriously
 and follow the advice below.
 
-For more serious benchmarking, consider the [`BenchmarkTools.jl`](https://github.com/JuliaCI/BenchmarkTools.jl)
+For more serious benchmarking, consider the [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl)
 package which evaluates the function multiple times in order to reduce noise.
 
 As a teaser, an improved version of this function allocates no memory
@@ -629,7 +629,7 @@ of `fill_twos!` for different types of `a`.
 The second form is also often better style and can lead to more code reuse.
 
 This pattern is used in several places in the standard library. For example, see `hvcat_fill`
-in [abstractarray.jl](https://github.com/JuliaLang/julia/blob/master/base/abstractarray.jl), or
+in [`abstractarray.jl`](https://github.com/JuliaLang/julia/blob/master/base/abstractarray.jl), or
 the [`fill!`](@ref) function, which we could have used instead of writing our own `fill_twos!`.
 
 Functions like `strange_twos` occur when dealing with data of uncertain type, for example data

--- a/doc/src/stdlib/sort.md
+++ b/doc/src/stdlib/sort.md
@@ -174,7 +174,7 @@ your preferred algorithm, e.g. `sort!(v, alg=QuickSort)`.
 
 The mechanism by which Julia picks default sorting algorithms is implemented via the `Base.Sort.defalg`
 function. It allows a particular algorithm to be registered as the default in all sorting functions
-for specific arrays. For example, here are the two default methods from [sort.jl](https://github.com/JuliaLang/julia/blob/master/base/sort.jl):
+for specific arrays. For example, here are the two default methods from [`sort.jl`](https://github.com/JuliaLang/julia/blob/master/base/sort.jl):
 
 ```julia
 defalg(v::AbstractArray) = MergeSort


### PR DESCRIPTION
This updates the manual, stdlib, and devdocs to consistently use code formatting on file names and paths. Currently it is used inconsistently. I've also fixed a few formatting and 0.6 syntax things I missed in my previous two doc PRs.

CI has been skipped, remove from commit message when merging.