### PR TITLE
Ignore nulls from terminal CTRL-space in LineEdit

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -725,6 +725,9 @@ function match_input(k::Dict, s, term=terminal(s), cs=Char[], keymap = k)
     # return an empty keymap function
     eof(term) && return keymap_fcn(nothing, "")
     c = read(term, Char)
+    # Ignore any '\0' (eg, CTRL-space in xterm), as this is used as a
+    # placeholder for the wildcard (see normalize_key("*"))
+    c != '\0' || return keymap_fcn(nothing, "")
     push!(cs, c)
     key = haskey(k, c) ? c : '\0'
     # if we don't match on the key, look for a default action then fallback on 'nothing' to ignore

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -125,6 +125,14 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
               startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n [1] ")
     end
 
+    # Issue #7001
+    # Test ignoring '\0'
+    let
+        write(stdin_write, "\0\n")
+        s = readuntil(stdout_read, "\n\n")
+        @test !contains(s, "invalid character")
+    end
+
     # Test that accepting a REPL result immediately shows up, not
     # just on the next keystroke
     write(stdin_write, "1+1\n") # populate history with a trivial input
@@ -137,6 +145,7 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     # yield make sure this got processed
     readuntil(stdout_read, "1+1")
     close(t)
+    readuntil(stdout_read, "\n\n")
 
     # Issue #10222
     # Test ignoring insert key in standard and prefix search modes


### PR DESCRIPTION
By default some terminals (eg, xterm) generate '\0' when CTRL-space is
pressed.  This is an invisible character, so hard to notice and delete,
but it breaks the input causing a parser error which persists into the
history.

AFAICT we must deal with this as early as possible by discarding any '\0'
characters immediately, as '\0' is used as a special value in the
rest of the keymap system.

Fixes #7001