### PR TITLE
Fix the printing of flags in build_sysimg.jl

### DIFF
--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -157,7 +157,7 @@ function link_sysimg(sysimg_path=nothing, cc=find_system_compiler(), debug=false
 
     sysimg_file = "$sysimg_path.$(Libdl.dlext)"
     info("Linking sys.$(Libdl.dlext)")
-    info("$cc $FLAGS -o $sysimg_file $sysimg_path.o")
+    info("$cc $(join(FLAGS, ' ')) -o $sysimg_file $sysimg_path.o")
     # Windows has difficulties overwriting a file in use so we first link to a temp file
     if is_windows() && isfile(sysimg_file)
         if success(pipeline(`$cc $FLAGS -o $sysimg_path.tmp $sysimg_path.o`; stdout=STDOUT, stderr=STDERR))


### PR DESCRIPTION
Right now it prints
`
INFO: C:\Users\Mus\.julia\v0.6\WinRPM\deps\usr\x86_64-w64-mingw32\sys-root\mingw\bin\gcc.exe -LC:\Julia\Julia-0.6-latest\bin String[\"-shared\", \"-ljulia\", \"-lssp\"] -o C:\Julia\Julia-0.6-latest\lib\julia\sys.dll C:\Julia\Julia-0.6-latest\lib\julia\sys.o
`
instead of
`INFO: C:\Users\Mus\.julia\v0.6\WinRPM\deps\usr\x86_64-w64-mingw32\sys-root\mingw\bin\gcc.exe -LC:\Julia\Julia-0.6-latest\bin -shared -ljulia -lssp -o C:\Julia\Julia-0.6-latest\lib\julia\sys.dll C:\Julia\Julia-0.6-latest\lib\julia\sys.o`