### PR TITLE
Fixing 2 broken links in Dates documentation

### DIFF
--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -559,7 +559,7 @@ julia> round(DateTime(2016, 8, 6, 20, 15), Dates.Day)
 Unlike the numeric [`round()`](@ref) method, which breaks ties toward the even number by default,
 the [`TimeType`](@ref)[`round()`](@ref) method uses the `RoundNearestTiesUp` rounding mode. (It's
 difficult to guess what breaking ties to nearest "even" [`TimeType`](@ref) would entail.) Further
-details on the available `RoundingMode` s can be found in the [API reference](https://docs.julialang.org/en/latest/stdlib/dates.html).
+details on the available `RoundingMode` s can be found in the [API reference](https://docs.julialang.org/en/stable/stdlib/dates/).
 
 Rounding should generally behave as expected, but there are a few cases in which the expected
 behaviour is not obvious.
@@ -624,5 +624,5 @@ will result in the months field having an odd value. Because both months and yea
 an irregular number of days, whether rounding to an even number of days will result in an even
 value in the days field is uncertain.
 
-See the [API reference](https://docs.julialang.org/en/latest/stdlib/dates.html) for additional information
+See the [API reference](https://docs.julialang.org/en/stable/stdlib/dates/) for additional information
 on methods exported from the `Dates` module.


### PR DESCRIPTION
Searching for information about Dates and DateTime in

https://docs.julialang.org/en/release-0.5/manual/dates/

I found broken links at the end of the page, pointing to

https://docs.julialang.org/en/latest/stdlib/dates/

As it is in the doc of the stable 0.5 version, pointing to the stable version of stdlib/dates makes it work:

https://docs.julialang.org/en/stable/stdlib/dates/