### PR TITLE
Only evaluate `fexpr` in `fexpr(kw=...)` once

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1434,7 +1434,7 @@
       (if (null? kw)
         (let ((f (if (sym-ref? fexpr) fexpr (make-ssavalue))))
           `(block
-            ,(if (eq? f fexpr) () `(= ,f, fexpr))
+            ,@(if (eq? f fexpr) '() `((= ,f, fexpr)))
             ,(if (null? stmts)
               `(call (call (core kwfunc) ,f) (call (top vector_any) ,@(reverse initial-kw)) ,f ,@pa)
               `(block

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1425,14 +1425,17 @@
             (reverse a))))))
 
 ;; lower function call containing keyword arguments
-(define (lower-kw-call f kw pa)
+(define (lower-kw-call fexpr kw pa)
   (let ((container (make-ssavalue)))
     (let loop ((kw kw)
                (initial-kw '()) ;; keyword args before any splats
                (stmts '())
                (has-kw #f))     ;; whether there are definitely >0 kwargs
       (if (null? kw)
-          (if (null? stmts)
+        (let ((f (if (sym-ref? fexpr) fexpr (make-ssavalue))))
+          `(block
+            ,(if (eq? f fexpr) () `(= ,f, fexpr))
+            ,(if (null? stmts)
               `(call (call (core kwfunc) ,f) (call (top vector_any) ,@(reverse initial-kw)) ,f ,@pa)
               `(block
                 (= ,container (call (top vector_any) ,@(reverse initial-kw)))
@@ -1446,8 +1449,8 @@
                          ,@stmts
                          (if (call (top isempty) ,container)
                              (call ,f ,@pa)
-                             (call (call (core kwfunc) ,f) ,container ,f ,@pa)))))))
-          (let ((arg (car kw)))
+                             (call (call (core kwfunc) ,f) ,container ,f ,@pa)))))))))
+        (let ((arg (car kw)))
             (cond ((and (pair? arg) (eq? (car arg) 'parameters))
                    (error "more than one semicolon in argument list"))
                   ((kwarg? arg)

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -277,10 +277,11 @@ f21510(; a::ANY = 2) = a
 @test f21510() == 2
 
 # issue #21518
-a = 0
-f21518(;kw=nothing) = kw
-g21518() = (global a; a+=1; f21518)
-g21518()(kw=1)
-@test a == 1
-g21518()(; :kw=>1)
-@test a == 2
+let a = 0
+    f21518(;kw=nothing) = kw
+    g21518() = (a+=1; f21518)
+    g21518()(kw=1)
+    @test a == 1
+    g21518()(; :kw=>1)
+    @test a == 2
+end

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -275,3 +275,12 @@ end
 f21510(; a::ANY = 2) = a
 @test f21510(a=:b) == :b
 @test f21510() == 2
+
+# issue #21518
+a = 0
+f21518(;kw=nothing) = kw
+g21518() = (global a; a+=1; f21518)
+g21518()(kw=1)
+@test a == 1
+g21518()(; :kw=>1)
+@test a == 2


### PR DESCRIPTION
Lower e.g. `get_inner()(kw=1)` to
```
SSAValue(n) = get_inner()
((Core.kwfunc)(SSAValue(n)))((Base.vector_any)(:kw, 1), SSAValue(n))
```
instead of
```
((Core.kwfunc)(get_inner()))((Base.vector_any)(:kw, 1), get_inner())
```
as the latter would call `get_inner` twice.

Fixes #21518.