### PR TITLE
Includes FFTW if USE_INTEL_MKL is enabled

### DIFF
--- a/base/dft.jl
+++ b/base/dft.jl
@@ -579,8 +579,7 @@ module FFTW
     correspond to [`r2r`](@ref) and [`r2r!`](@ref), respectively.
     """
     function plan_r2r end
-
-    Base.USE_GPL_LIBS && include(joinpath("fft", "FFTW.jl"))
+    (Base.USE_GPL_LIBS || Base.fftw_vendor() == :mkl) && include(joinpath("fft", "FFTW.jl"))
 end
 
 importall .FFTW

--- a/base/util.jl
+++ b/base/util.jl
@@ -383,7 +383,7 @@ macro timed(ex)
 end
 
 function fftw_vendor()
-    if Base.libfftw_name == "libmkl_rt"
+    if Base.libfftw_name == "libmkl_rt" || (is_windows() && Base.libfftw_name == "mkl_rt")
         return :mkl
     else
         return :fftw

--- a/base/util.jl
+++ b/base/util.jl
@@ -383,7 +383,7 @@ macro timed(ex)
 end
 
 function fftw_vendor()
-    if Base.libfftw_name == "libmkl_rt" || (is_windows() && Base.libfftw_name == "mkl_rt")
+    if Base.libfftw_name in ("libmkl_rt", "mkl_rt")
         return :mkl
     else
         return :fftw


### PR DESCRIPTION
Setting USE_INTEL_MKL to 1 will make sure FFTW is included in the final build (Even if Base.USE_GPL_LIBS is disabled)
