### PR TITLE
A few fixes for the unicode table generation code

### DIFF
--- a/doc/src/manual/unicode-input.md
+++ b/doc/src/manual/unicode-input.md
@@ -41,6 +41,13 @@ function unicode_data()
     return names
 end
 
+# Prepend a dotted circle ('◌' i.e. '\u25CC') to combining characters
+function fix_combining_chars(char)
+    cat = Base.UTF8proc.category_code(char)
+    return string(cat == 6 || cat == 8 ? "◌" : "", char)
+end
+
+
 function table_entries(completions, unicode_dict)
     entries = [[
         "Code point(s)", "Character(s)",
@@ -51,10 +58,10 @@ function table_entries(completions, unicode_dict)
         for char in chars
             push!(code_points, "U+$(uppercase(hex(char, 5)))")
             push!(unicode_names, get(unicode_dict, UInt32(char), "(No Unicode name)"))
-            push!(characters, Base.UTF8proc.category_code(char) == 6 ? "◌$char" : "$char")
+            push!(characters, isempty(characters) ? fix_combining_chars(char) : "$char")
         end
         push!(entries, [
-            join(code_points, " + "), join(chars),
+            join(code_points, " + "), join(characters),
             join(inputs, ", "), join(unicode_names, " + ")
         ])
     end


### PR DESCRIPTION
This fixes the combining characters in the [Unicode input table](https://docs.julialang.org/en/latest/manual/unicode-input.html#Unicode-Input-1) in the docs.

1. Due to a typo, the combining characters were not actually fixed (where the "fix" is to prepend a dotted circle, `◌`)
2. Only fix combining characters that appear as the first char (e.g. \neqsim is U+02242 + U+00338, we don't want to fix the second one)
3. Characters in category ME ([code 8](https://github.com/JuliaLang/julia/blob/e14cf14e31b3b3f84422a43db53e47c541545ee2/base/strings/utf8proc.jl#L31)) are also combining (see e.g. [here](http://www.fileformat.info/info/unicode/category/Me/list.htm))