### PR TITLE
small performance enhancements for isabspath and regexes in general

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -19,7 +19,6 @@ export
 if is_unix()
     const path_separator    = "/"
     const path_separator_re = r"/+"
-    const path_absolute_re  = r"^/"
     const path_directory_re = r"(?:^|/)\.{0,2}$"
     const path_dir_splitter = r"^(.*?)(/+)([^/]*)$"
     const path_ext_splitter = r"^((?:.*/)?(?:\.|[^/\.])[^/]*?)(\.[^/\.]*|)$"
@@ -73,6 +72,12 @@ function homedir()
 end
 
 
+if is_windows()
+    isabspath(path::String) = ismatch(path_absolute_re, path)
+else
+    isabspath(path::String) = startswith(path, '/')
+end
+
 """
     isabspath(path::AbstractString) -> Bool
 
@@ -86,7 +91,7 @@ julia> isabspath("home")
 false
 ```
 """
-isabspath(path::String) = ismatch(path_absolute_re, path)
+isabspath(path::AbstractString)
 
 """
     isdirpath(path::AbstractString) -> Bool

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -8,20 +8,20 @@ include(string(length(Core.ARGS)>=2?Core.ARGS[2]:"","pcre_h.jl"))  # include($BU
 
 const PCRE_LIB = "libpcre2-8"
 
-global JIT_STACK = C_NULL
-global MATCH_CONTEXT = C_NULL
+const JIT_STACK = Ref{Ptr{Void}}(C_NULL)
+const MATCH_CONTEXT = Ref{Ptr{Void}}(C_NULL)
 
 function __init__()
     try
         JIT_STACK_START_SIZE = 32768
         JIT_STACK_MAX_SIZE = 1048576
-        global JIT_STACK = ccall((:pcre2_jit_stack_create_8, PCRE_LIB), Ptr{Void},
+        JIT_STACK[] = ccall((:pcre2_jit_stack_create_8, PCRE_LIB), Ptr{Void},
                                  (Cint, Cint, Ptr{Void}),
                                  JIT_STACK_START_SIZE, JIT_STACK_MAX_SIZE, C_NULL)
-        global MATCH_CONTEXT = ccall((:pcre2_match_context_create_8, PCRE_LIB),
+        MATCH_CONTEXT[] = ccall((:pcre2_match_context_create_8, PCRE_LIB),
                                      Ptr{Void}, (Ptr{Void},), C_NULL)
         ccall((:pcre2_jit_stack_assign_8, PCRE_LIB), Void,
-              (Ptr{Void}, Ptr{Void}, Ptr{Void}), MATCH_CONTEXT, C_NULL, JIT_STACK)
+              (Ptr{Void}, Ptr{Void}, Ptr{Void}), MATCH_CONTEXT[], C_NULL, JIT_STACK[])
     catch ex
         Base.showerror_nostdio(ex,
             "WARNING: Error during initialization of module PCRE")
@@ -129,7 +129,7 @@ end
 function exec(re,subject,offset,options,match_data)
     rc = ccall((:pcre2_match_8, PCRE_LIB), Cint,
                (Ptr{Void}, Ptr{UInt8}, Csize_t, Csize_t, Cuint, Ptr{Void}, Ptr{Void}),
-               re, subject, sizeof(subject), offset, options, match_data, MATCH_CONTEXT)
+               re, subject, sizeof(subject), offset, options, match_data, MATCH_CONTEXT[])
     # rc == -1 means no match, -2 means partial match.
     rc < -2 && error("PCRE.exec error: $(err_message(rc))")
     rc >= 0


### PR DESCRIPTION
Performance difference between having dynamic dispatch here and not having it is basically negligible, (relative to hitting the filesystem) but it's still free performance gains for little effort to change it.

```
# on master
julia> @time for i = 1:10^6; ismatch(r"^/", "/"); end # equivalent to isabspath on master
  0.201463 seconds (1000.00 k allocations: 15.259 MiB)

# on this PR
julia> @time for i = 1:10^6; ismatch(r"^/", "/"); end
  0.050551 seconds # no allocations

julia> @time for i = 1:10^6; isabspath("/"); end
  0.011138 seconds
```

AFAIK, nanosoldier doesn't have any filesystem perf tests to run this against?