### PR TITLE
Do not use as default `light_red` color for error msgs

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -59,7 +59,7 @@ text_colors
 
 have_color = false
 default_color_warn = :yellow
-default_color_error = :light_red
+default_color_error = :red
 default_color_info = :cyan
 default_color_input = :normal
 default_color_answer = :normal


### PR DESCRIPTION
discussion here https://github.com/JuliaLang/julia/pull/21433

What constitutes `light_red` (especially under non-standard terminal colors) seems to wildly inconsistent across terminals, so I think we should avoid using the color by default.

default terminal colorscheme
![](https://cloud.githubusercontent.com/assets/4319522/25153290/0ce8dc30-245a-11e7-83b4-ea288295b8ef.png)
here are other schemes (note how inconsistent `light_red` is)

![](https://cloud.githubusercontent.com/assets/4319522/25153216/d7af2970-2459-11e7-8107-ba71fce7f70d.png)

![](https://cloud.githubusercontent.com/assets/4319522/25153346/3d8f7a88-245a-11e7-901a-f1dc10ee226d.png)

![](https://cloud.githubusercontent.com/assets/4319522/25153392/5f8891e2-245a-11e7-99f6-64af632fe791.png)

I propose we stick to default colors for the main colors used by Julia, and if the user finds the color not to their liking they can easily change it.





