### PR TITLE
force a require if binding with different uuid is present.

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -750,7 +750,7 @@ function stale_cachefile(modpath::String, cachefile::String)
             if mod == :Main || mod == :Core || mod == :Base
                 continue
             # Module is already loaded
-            elseif isdefined(Main, mod)
+            elseif isbindingresolved(Main, mod)
                 continue
             end
             name = string(mod)

--- a/src/dump.c
+++ b/src/dump.c
@@ -2282,8 +2282,12 @@ static jl_value_t *read_verify_mod_list(ios_t *s, arraylist_t *dependent_worlds)
         uint64_t uuid = read_uint64(s);
         jl_sym_t *sym = jl_symbol(name);
         jl_module_t *m = NULL;
-        if (jl_binding_resolved_p(jl_main_module, sym))
+        if (jl_binding_resolved_p(jl_main_module, sym)) {
             m = (jl_module_t*)jl_get_global(jl_main_module, sym);
+            // Potentially two modules with the same name.
+            if (m && jl_is_module(m) && m->uuid != uuid)
+                m = NULL;
+        }
         if (!m) {
             static jl_value_t *require_func = NULL;
             if (!require_func)


### PR DESCRIPTION
This works around `Base.Iterators` shadowing `Iterators`, as noted in #21492.

I don't quite understand why that didn't happen before #21492, but that fixes it for me locally.
@fredrikekre  and @bjarthur could you try this locally?