### PR TITLE
Disable FFT plan check with FFTW < 3.3.4

### DIFF
--- a/test/fft.jl
+++ b/test/fft.jl
@@ -8,8 +8,10 @@ let a = randn(10^5,1), p1 = plan_rfft(a, flags=FFTW.ESTIMATE)
     @test p1*a ≈ p2*a
     # make sure threads are actually being used for p2
     # (tests #21163).
-    @test !contains(string(p1), "dft-thr")
-    @test contains(string(p2), "dft-thr")
+    if FFTW.version >= v"3.3.4"
+        @test !contains(string(p1), "dft-thr")
+        @test contains(string(p2), "dft-thr")
+    end
 end
 
 # fft


### PR DESCRIPTION
`fftw_sprint_plan` wasn't available in FFTW 3.3.3. Hence show of a plan in
FFTW 3.3.3 doesn't actually show the plan contents and the test will fail.

This fixes a test failure introduced by https://github.com/JuliaLang/julia/pull/21169 on RHEL/Centos 7 when using system FFTW.