### PR TITLE
fix `let` with type declaration

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1850,6 +1850,7 @@
    'const  expand-const-decl
    'local  expand-local-or-global-decl
    'global expand-local-or-global-decl
+   'local-def expand-local-or-global-decl
 
    '=
    (lambda (e)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4865,3 +4865,9 @@ struct T21516
     T21516(x::Vector{T}, y::Vector{T}) where {T<:Real} = new(float.(x), float.(y))
 end
 @test isa(T21516([1],[2]).x, Vector{Float64})
+
+# let with type declaration
+let letvar::Int = 2
+    letvar = 3.0
+    @test letvar === 3
+end


### PR DESCRIPTION
Randomly found this. Somewhat recently an optimization for `let` variables and closures was introduced, and a case was left out that caused type declarations to be dropped.
