### PR TITLE
fix #21568, crash on certain out-of-scope method adds

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3084,10 +3084,10 @@ f(x) = yt(x)
                                (newlam    (renumber-slots-and-labels (linearize (car exprs)))))
                           `(toplevel-butlast
                             ,@top-stmts
-                            ,@sp-inits
-                            (method ,name ,(cl-convert sig fname lam namemap toplevel interp)
-                                    ,(julia-expand-macros `(quote ,newlam))
-                                    ,(last e))))))
+                            (block ,@sp-inits
+                                   (method ,name ,(cl-convert sig fname lam namemap toplevel interp)
+                                           ,(julia-expand-macros `(quote ,newlam))
+                                           ,(last e)))))))
                  ;; local case - lift to a new type at top level
                  (let* ((exists (get namemap name #f))
                         (type-name  (or exists

--- a/test/core.jl
+++ b/test/core.jl
@@ -4871,3 +4871,13 @@ let letvar::Int = 2
     letvar = 3.0
     @test letvar === 3
 end
+
+# issue #21568
+f21568() = 0
+function foo21568()
+    y = 1
+    global f21568
+    f21568{T<:Real}(x::AbstractArray{T,1}) = y
+end
+foo21568()
+@test f21568([0]) == 1


### PR DESCRIPTION
This was just moving too much stuff to top level, specifically the initialization of the typevar for the inner method definition, causing an access to an undefined ssavalue.