### PR TITLE
Unescape A in A=B keyword argument

### DIFF
--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -270,12 +270,12 @@
                       ,(if inarg
                            (resolve-expansion-vars- (cadr (cadr e)) env m inarg)
                            ;; in keyword arg A=B, don't transform "A"
-                           (cadr (cadr e)))
+                           (unescape (cadr (cadr e))))
                       ,(resolve-expansion-vars- (caddr (cadr e)) env m inarg))
                      ,(resolve-expansion-vars- (caddr e) env m inarg))
                 `(kw ,(if inarg
                           (resolve-expansion-vars- (cadr e) env m inarg)
-                          (cadr e))
+                          (unescape (cadr e)))
                      ,(resolve-expansion-vars- (caddr e) env m inarg))))
 
            ((let)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1127,3 +1127,11 @@ f21545(::Type{<: AbstractArray{T,N} where N}) where T = T
 @test parse("<:{T} where T") == Expr(:where, Expr(:curly, :(<:), :T), :T)
 @test parse("<:(T) where T") == Expr(:where, Expr(:(<:), :T), :T)
 @test parse("<:{T}(T) where T") == Expr(:where, Expr(:call, Expr(:curly, :(<:), :T), :T), :T)
+
+# issue #21586
+macro m21586(x)
+    Expr(:kw, esc(x), 42)
+end
+
+f21586(; @m21586(a), @m21586(b)) = a + b
+@test f21586(a=10) == 52


### PR DESCRIPTION
Fix #21586.