### PR TITLE
Make building against MKL on Windows a bit easier

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1002,9 +1002,16 @@ MKLLIB := $(MKLROOT)/lib/ia32
 endif
 USE_SYSTEM_BLAS:=1
 USE_SYSTEM_LAPACK:=1
+ifeq ($(OS), WINNT)
+LIBBLASNAME := mkl_rt
+LIBLAPACKNAME := mkl_rt
+# work around libtool issue with arpack
+MKL_LDFLAGS := -L$(MKLLIB) -Wl,-lmkl_rt
+else
 LIBBLASNAME := libmkl_rt
 LIBLAPACKNAME := libmkl_rt
 MKL_LDFLAGS := -L$(MKLLIB) -lmkl_rt
+endif
 ifneq ($(strip $(MKLLIB)),)
   ifeq ($(OS), Linux)
     RPATH_MKL := -Wl,-rpath,$(MKLLIB)

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -579,6 +579,7 @@ module FFTW
     correspond to [`r2r`](@ref) and [`r2r!`](@ref), respectively.
     """
     function plan_r2r end
+
     (Base.USE_GPL_LIBS || Base.fftw_vendor() == :mkl) && include(joinpath("fft", "FFTW.jl"))
 end
 


### PR DESCRIPTION
account for mkl_rt.dll naming, and tweak blas linking flags to
work around an issue with libtool in arpack where it says

```
*** Warning: linker path does not have real file for library -lmkl_rt.
*** I have the capability to make that library automatically link in when
*** you link to this library.  But I can only do this if you have a
*** shared version of the library, which you do not appear to have
*** because I did check the linker path looking for a file starting
*** with libmkl_rt but no candidates were found. (...for file magic test)
*** The inter-library dependencies that have been dropped here will be
*** automatically added whenever a program is linked with this library
*** or is declared to -dlopen it.

*** Since this library must not contain undefined symbols,
*** because either the platform does not support them or
*** it was explicitly requested with -no-undefined,
*** libtool will only create a static version of it.
```
then refuses to build the shared library we want

cc @ranjanan @bmharsha