### PR TITLE
Use `sincos` from libm in `cis`

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -424,7 +424,10 @@ sqrt(z::Complex) = sqrt(float(z))
 # end
 
 # compute exp(im*theta)
-cis(theta::Real) = Complex(cos(theta),sin(theta))
+function cis(theta::Real)
+    s, c = sincos(theta)
+    Complex(c, s)
+end
 
 """
     cis(z)
@@ -433,7 +436,8 @@ Return ``\\exp(iz)``.
 """
 function cis(z::Complex)
     v = exp(-imag(z))
-    Complex(v*cos(real(z)), v*sin(real(z)))
+    s, c = sincos(real(z))
+    Complex(v * c, v * s)
 end
 
 """
@@ -510,7 +514,8 @@ function exp(z::Complex)
         if iszero(zi)
             Complex(er, zi)
         else
-            Complex(er*cos(zi), er*sin(zi))
+            s, c = sincos(zi)
+            Complex(er * c, er * s)
         end
     end
 end
@@ -538,7 +543,8 @@ function expm1(z::Complex{T}) where T<:Real
                 wr = erm1 - 2 * er * (sin(convert(Tf, 0.5) * zi))^2
                 return Complex(wr, er * sin(zi))
             else
-                return Complex(er * cos(zi), er * sin(zi))
+                s, c = sincos(zi)
+                return Complex(er * c, er * s)
             end
         end
     end
@@ -600,13 +606,15 @@ end
 function exp2(z::Complex{T}) where T
     er = exp2(real(z))
     theta = imag(z) * log(convert(T, 2))
-    Complex(er*cos(theta), er*sin(theta))
+    s, c = sincos(theta)
+    Complex(er * c, er * s)
 end
 
 function exp10(z::Complex{T}) where T
     er = exp10(real(z))
     theta = imag(z) * log(convert(T, 10))
-    Complex(er*cos(theta), er*sin(theta))
+    s, c = sincos(theta)
+    Complex(er * c, er * s)
 end
 
 function ^(z::T, p::T) where T<:Complex
@@ -628,8 +636,7 @@ function ^(z::T, p::T) where T<:Complex
         rp = rp*exp(-pim*theta)
         ntheta = ntheta + pim*log(r)
     end
-    cosntheta = cos(ntheta)
-    sinntheta = sin(ntheta)
+    sinntheta, cosntheta = sincos(ntheta)
     re, im = rp*cosntheta, rp*sinntheta
     if isinf(rp)
         if isnan(re)
@@ -689,7 +696,8 @@ function sin(z::Complex{T}) where T
             Complex(F(NaN), F(NaN))
         end
     else
-        Complex(sin(zr)*cosh(zi), cos(zr)*sinh(zi))
+        s, c = sincos(zr)
+        Complex(s * cosh(zi), c * sinh(zi))
     end
 end
 
@@ -708,7 +716,8 @@ function cos(z::Complex{T}) where T
             Complex(F(NaN), F(NaN))
         end
     else
-        Complex(cos(zr)*cosh(zi), -sin(zr)*sinh(zi))
+        s, c = sincos(zr)
+        Complex(c * cosh(zi), -s * sinh(zi))
     end
 end
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -405,6 +405,7 @@ export
     significand,
     sin,
     sinc,
+    sincos,
     sind,
     sinh,
     sinpi,

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -327,7 +327,10 @@ sincos_fast(v) = (sin_fast(v), cos_fast(v))
 
     # complex numbers
 
-    cis_fast(x::T) where {T<:FloatTypes} = Complex{T}(cos(x), sin(x))
+    function cis_fast(x::T) where {T<:FloatTypes}
+        s, c = sincos_fast(x)
+        Complex{T}(c, s)
+    end
 
     # See <http://en.cppreference.com/w/cpp/numeric/complex>
     pow_fast(x::T, y::T) where {T<:ComplexTypes} = exp(y*log(x))

--- a/base/math.jl
+++ b/base/math.jl
@@ -2,7 +2,7 @@
 
 module Math
 
-export sin, cos, tan, sinh, cosh, tanh, asin, acos, atan,
+export sin, cos, sincos, tan, sinh, cosh, tanh, asin, acos, atan,
        asinh, acosh, atanh, sec, csc, cot, asec, acsc, acot,
        sech, csch, coth, asech, acsch, acoth,
        sinpi, cospi, sinc, cosc,
@@ -417,6 +417,19 @@ for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
         @inline ($f)(x::Float32) = nan_dom_err(ccall(($(string(f, "f")), libm), Float32, (Float32,), x), x)
         @inline ($f)(x::Real) = ($f)(float(x))
     end
+end
+
+"""
+    sincos(x)
+
+Compute sine and cosine of `x`, where `x` is in radians.
+"""
+@inline function sincos(x)
+    res = Base.FastMath.sincos_fast(x)
+    if (isnan(res[1]) | isnan(res[2])) & !isnan(x)
+        throw(DomainError())
+    end
+    return res
 end
 
 sqrt(x::Float64) = sqrt_llvm(x)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -13,7 +13,7 @@ import
         nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show, float,
         sum, sqrt, string, print, trunc, precision, exp10, expm1,
         gamma, lgamma, log1p,
-        eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
+        eps, signbit, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
         cbrt, typemax, typemin, unsafe_trunc, realmin, realmax, rounding,
         setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero, big
@@ -23,6 +23,8 @@ import Base.Rounding: rounding_raw, setrounding_raw
 import Base.GMP: ClongMax, CulongMax, CdoubleMax, Limb
 
 import Base.Math.lgamma_r
+
+import Base.FastMath.sincos_fast
 
 function __init__()
     try
@@ -514,6 +516,15 @@ for f in (:exp, :exp2, :exp10, :expm1, :cosh, :sinh, :tanh, :sech, :csch, :coth,
         return z
     end
 end
+
+function sincos_fast(v::BigFloat)
+    s = BigFloat()
+    c = BigFloat()
+    ccall((:mpfr_sin_cos, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Int32),
+          &s, &c, &v, ROUNDING_MODE[])
+    return (s, c)
+end
+sincos(v::BigFloat) = sincos_fast(v)
 
 # return log(2)
 function big_ln2()

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -258,6 +258,10 @@ importall .Order
 include("sort.jl")
 importall .Sort
 
+# Fast math
+include("fastmath.jl")
+importall .FastMath
+
 function deepcopy_internal end
 
 # BigInts and BigFloats
@@ -342,10 +346,6 @@ include("dft.jl")
 importall .DFT
 include("dsp.jl")
 importall .DSP
-
-# Fast math
-include("fastmath.jl")
-importall .FastMath
 
 # libgit2 support
 include("libgit2/libgit2.jl")

--- a/doc/src/stdlib/math.md
+++ b/doc/src/stdlib/math.md
@@ -58,6 +58,7 @@ Base.:(!)
 Base.isapprox
 Base.sin
 Base.cos
+Base.sincos
 Base.tan
 Base.Math.sind
 Base.Math.cosd

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -9,6 +9,7 @@
 @test macroexpand(:(@fastmath min(1))) == :(Base.FastMath.min_fast(1))
 @test macroexpand(:(@fastmath min)) == :(Base.FastMath.min_fast)
 @test macroexpand(:(@fastmath x.min)) == :(x.min)
+@test macroexpand(:(@fastmath sincos(x))) == :(Base.FastMath.sincos_fast(x))
 
 # basic arithmetic
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -627,3 +627,12 @@ end
 @testset "promote Float16 irrational #15359" begin
     @test typeof(Float16(.5) * pi) == Float16
 end
+
+@testset "sincos" begin
+    @test sincos(1.0) === (sin(1.0), cos(1.0))
+    @test sincos(1f0) === (sin(1f0), cos(1f0))
+    @test sincos(Float16(1)) === (sin(Float16(1)), cos(Float16(1)))
+    @test sincos(1) === (sin(1), cos(1))
+    @test sincos(big(1)) == (sin(big(1)), cos(big(1)))
+    @test sincos(big(1.0)) == (sin(big(1.0)), cos(big(1.0)))
+end


### PR DESCRIPTION
I came up with this implementation for my research code last week that doesn't need heap allocation and is almost as good as the ccall version apart from the PLT entry part (so one more branch than an actual ccall in sysimg) so I guess people might be interested.

I don't think https://github.com/JuliaLang/julia/issues/10442 can be closed by this since it's too late to add another function in 0.6.

Do we have benchmarks for `cis` on nanosoldier?

Anyway, local benchmarks (the code_warntype and code_llvm are just to check that the invoke is correctly optimized)

```julia
julia> using BenchmarkTools

julia> f1(v) = cis(v)
f1 (generic function with 1 method)

julia> f2(v) = invoke(cis, Tuple{AbstractFloat}, v)
f2 (generic function with 1 method)

julia> @code_warntype f1(1.0)
Variables:
  #self#::#f1
  v::Float64

Body:
  begin 
      return $(Expr(:invoke, MethodInstance for cis(::Float64), :(Main.cis), :(v)))
  end::Complex{Float64}

julia> @code_warntype f2(1.0)
Variables:
  #self#::#f2
  v::Float64

Body:
  begin 
      SSAValue(0) = Main.cis
      return $(Expr(:invoke, MethodInstance for cis(::Float64), SSAValue(0), :(v)))
  end::Complex{Float64}

julia> @code_llvm f2(1.0)

define void @julia_f2_61158(%Complex.61* noalias nocapture sret, double) #0 !dbg !5 {
top:
  %2 = alloca %Complex.61, align 8
  call void @julia_cis_61159(%Complex.61* noalias nocapture nonnull sret %2, double %1)
  %3 = bitcast %Complex.61* %2 to i8*
  %4 = bitcast %Complex.61* %0 to i8*
  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %4, i8* %3, i32 16, i32 8, i1 false)
  ret void
}

julia> @code_llvm f1(1.0)

define void @julia_f1_61160(%Complex.61* noalias nocapture sret, double) #0 !dbg !5 {
top:
  %2 = alloca %Complex.61, align 8
  call void @julia_cis_61161(%Complex.61* noalias nocapture nonnull sret %2, double %1)
  %3 = bitcast %Complex.61* %2 to i8*
  %4 = bitcast %Complex.61* %0 to i8*
  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %4, i8* %3, i32 16, i32 8, i1 false)
  ret void
}

julia> @benchmark f1(1.0)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     12.538 ns (0.00% GC)
  median time:      12.569 ns (0.00% GC)
  mean time:        13.719 ns (0.00% GC)
  maximum time:     54.756 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> @benchmark f2(1.0)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     15.018 ns (0.00% GC)
  median time:      15.113 ns (0.00% GC)
  mean time:        15.705 ns (0.00% GC)
  maximum time:     70.411 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998

julia> @benchmark f1(1f0)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     6.552 ns (0.00% GC)
  median time:      6.987 ns (0.00% GC)
  mean time:        7.532 ns (0.00% GC)
  maximum time:     36.562 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> @benchmark f2(1f0)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.849 ns (0.00% GC)
  median time:      9.951 ns (0.00% GC)
  mean time:        10.802 ns (0.00% GC)
  maximum time:     52.768 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
```
