### PR TITLE
Fix type instability when using custom indices

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -37,7 +37,7 @@ Base.OneTo(6)
 """
 function indices(A::AbstractArray{T,N}, d) where {T,N}
     @_inline_meta
-    d <= N ? indices(A)[d] : OneTo(1)
+    d <= N ? indices(A)[d] : one(indicestype(typeof(A),d))
 end
 
 """
@@ -55,6 +55,23 @@ julia> indices(A)
 function indices(A)
     @_inline_meta
     map(OneTo, size(A))
+end
+
+"""
+    indicestype(T, d)
+
+Returns the type of the indices for array type `T` along dimension `d`
+
+```jldoctest
+julia> A = ones(5,6,7);
+
+julia> indicestype(typeof(A), 1)
+Base.OneTo{Int}
+```
+"""
+function indicestype{T <: AbstractArray}(::Type{T}, d)
+    @_inline_meta
+    OneTo{Int}
 end
 
 # Performance optimization: get rid of a branch on `d` in `indices(A,

--- a/base/range.jl
+++ b/base/range.jl
@@ -897,3 +897,5 @@ function +(r1::StepRangeLen{T,S}, r2::StepRangeLen{T,S}) where {T,S}
 end
 
 -(r1::StepRangeLen, r2::StepRangeLen) = +(r1, -r2)
+
+one{T, RangeT <: Range{T}}(::Type{RangeT}) = RangeT(one(T))


### PR DESCRIPTION
This adds a new method `indicestype` to overcome a type instability when using non-conventional indices. Example:

```julia
using Compat
using Base.Test

using CustomUnitRanges: filename_for_zerorange
include(filename_for_zerorange)

immutable ZeroView{ScalarT,N} <: AbstractArray{ScalarT,N}
  a::Array{ScalarT,N}
end

@compat Base.IndexStyle{ScalarT,N}(::Type{ZeroView{ScalarT,N}}) = IndexLinear()
Base.indices{ScalarT,N}(v::ZeroView{ScalarT,N}) = map(ZeroRange, size(v.a))
Base.getindex{ScalarT}(v::ZeroView{ScalarT,1}, i::Integer) = v.a[i+1]
Base.setindex!{ScalarT}(v::ZeroView{ScalarT,1}, value, i::Integer) = (v.a[i+1] = value)
Base.getindex{ScalarT,N}(v::ZeroView{ScalarT,N}, i::Integer) = v.a[i] # linearindices are always 1-based for ND arrays
Base.setindex!{ScalarT,N}(v::ZeroView{ScalarT,N}, value, i::Integer) = (v.a[i] = value)

function benchmark_fill_vec(A)
  for i in linearindices(A)
    A[i] = i
  end
end

function benchmark_fill_mat(A)
  for i in indices(A,1)
    for j in indices(A,2)
      A[i,j] = i*(j+1)
    end
  end
end

const bench_size = 1000000
const ncols = 3
v_bench = ZeroView(zeros(bench_size))
A_bench = ZeroView(zeros(bench_size,ncols))

println("vector timings:")
@time benchmark_fill_vec(v_bench)
@time benchmark_fill_vec(v_bench)
@time benchmark_fill_vec(v_bench)

@test v_bench[0] == 0
@test v_bench[bench_size-1] == bench_size-1

println("matrix timings, linear indexing:")
@time benchmark_fill_vec(A_bench)
@time benchmark_fill_vec(A_bench)
@time benchmark_fill_vec(A_bench)

@test A_bench[0,0] == 1
@test A_bench[bench_size-1,2] == bench_size*ncols

println("matrix timings, [i,j] indexing:")
@time benchmark_fill_mat(A_bench)
@time benchmark_fill_mat(A_bench)
@time benchmark_fill_mat(A_bench)

@test A_bench[0,0] == 0
@test A_bench[bench_size-1,2] == (bench_size-1)*ncols

```
This gives a time of 0.18 s with 16 M allocations on the `benchmark_fill_mat` function. After the fix and specializing `indicestype` as follows:

```julia
Base.indicestype{ScalarT,N}(::Type{ZeroView{ScalarT,N}},d) = ZeroRange{Int}
```
Then the new timing is 0.02 s with 4 allocations.

Context:
https://discourse.julialang.org/t/multidimensional-arrays-with-0-based-indices/3325/7

cc @timholy 