### PR TITLE
Fix #21604, check Any fields at runtime

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -207,7 +207,7 @@
   (if (decl? v) (cadr v) v))
 
 (define (decl-type v)
-  (if (decl? v) (caddr v) 'Any))
+  (if (decl? v) (caddr v) '(core Any)))
 
 (define (sym-dot? e)
   (and (length= e 3) (eq? (car e) '|.|)

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -154,7 +154,7 @@
            (else (bad-formal-argument v))))))
 
 (define (arg-type v)
-  (cond ((symbol? v)  'Any)
+  (cond ((symbol? v)  '(core Any))
         ((not (pair? v))
          (bad-formal-argument v))
         (else
@@ -273,7 +273,7 @@
 (define (eq-sym? a b)
   (or (eq? a b) (and (ssavalue? a) (ssavalue? b) (eqv? (cdr a) (cdr b)))))
 
-(define (make-var-info name) (list name 'Any 0))
+(define (make-var-info name) (list name '(core Any) 0))
 (define vinfo:name car)
 (define vinfo:type cadr)
 (define (vinfo:set-type! v t) (set-car! (cdr v) t))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -164,7 +164,7 @@
                   `(block ,body))))
     `(lambda ,argl ()
              (scope-block
-              ,(if (eq? rett 'Any)
+              ,(if (equal? rett '(core Any))
                    body
                    (let ((meta (take-while (lambda (x) (and (pair? x)
                                                             (memq (car x) '(line meta))))
@@ -300,7 +300,7 @@
 
 ;; construct the (method ...) expression for one primitive method definition,
 ;; assuming optional and keyword args are already handled
-(define (method-def-expr- name sparams argl body isstaged (rett 'Any))
+(define (method-def-expr- name sparams argl body isstaged (rett '(core Any)))
   (if
    (any kwarg? argl)
    ;; has optional positional args
@@ -940,9 +940,9 @@
 ;; take apart a type signature, e.g. T{X} <: S{Y}
 (define (analyze-type-sig ex)
   (or ((pattern-lambda (-- name (-s))
-                       (values name '() 'Any)) ex)
+                       (values name '() '(core Any))) ex)
       ((pattern-lambda (curly (-- name (-s)) . params)
-                       (values name params 'Any)) ex)
+                       (values name params '(core Any))) ex)
       ((pattern-lambda (|<:| (-- name (-s)) super)
                        (values name '() super)) ex)
       ((pattern-lambda (|<:| (curly (-- name (-s)) . params) super)
@@ -1004,7 +1004,7 @@
                               (set! name (cadr w))))
                     #f))
          (dcl   (and (pair? name) (eq? (car name) '|::|)))
-         (rett  (if dcl (caddr name) 'Any))
+         (rett  (if dcl (caddr name) '(core Any)))
          (name  (if dcl (cadr name) name)))
     (cond ((and (length= e 2) (symbol? name))
            (if (or (eq? name 'true) (eq? name 'false))
@@ -2686,7 +2686,7 @@
          ;; record. for non-symbols or globals, emit a type assertion.
          (let ((vi (var-info-for (cadr e) env)))
            (if vi
-               (begin (if (not (eq? (vinfo:type vi) 'Any))
+               (begin (if (not (equal? (vinfo:type vi) '(core Any)))
                           (error (string "multiple type declarations for \""
                                          (cadr e) "\"")))
                       (if (assq (cadr e) captvars)
@@ -2753,7 +2753,7 @@ f(x) = yt(x)
                   (composite_type ,name (call (core svec))
                                   (call (core svec) ,@(map (lambda (v) `',v) fields))
                                   ,super
-                                  (call (core svec) ,@(map (lambda (v) 'Any) fields))
+                                  (call (core svec) ,@(map (lambda (v) '(core Any)) fields))
                                   false ,(length fields))
                   (return (null)))))))
 
@@ -2800,7 +2800,7 @@ f(x) = yt(x)
        (cl-convert (cadddr lam) fname lam (table) #f interp))))
 
 (define (convert-for-type-decl rhs t)
-  (if (eq? t 'Any)
+  (if (equal? t '(core Any))
       rhs
       `(call (core typeassert)
              (call (top convert) ,t ,rhs)
@@ -2816,16 +2816,16 @@ f(x) = yt(x)
          (cv (assq var (cadr (lam:vinfo lam))))
          (vt  (or (and vi (vinfo:type vi))
                   (and cv (vinfo:type cv))
-                  'Any))
+                  '(core Any)))
          (closed (and cv (vinfo:asgn cv) (vinfo:capt cv)))
          (capt   (and vi (vinfo:asgn vi) (vinfo:capt vi))))
-    (if (and (not closed) (not capt) (eq? vt 'Any))
+    (if (and (not closed) (not capt) (equal? vt '(core Any)))
         `(= ,var ,rhs0)
         (let* ((rhs1 (if (or (ssavalue? rhs0) (simple-atom? rhs0)
                              (equal? rhs0 '(the_exception)))
                          rhs0
                          (make-ssavalue)))
-               (rhs  (if (eq? vt 'Any)
+               (rhs  (if (equal? vt '(core Any))
                          rhs1
                          (convert-for-type-decl rhs1 (cl-convert vt fname lam #f #f interp))))
                (ex (cond (closed `(call (core setfield!)
@@ -3004,7 +3004,7 @@ f(x) = yt(x)
                                    `(call (core getfield) ,fname (inert ,e)))))
                    (if (and (vinfo:asgn cv) (vinfo:capt cv))
                        (let ((val `(call (core getfield) ,access (inert contents))))
-                         (if (eq? (vinfo:type cv) 'Any)
+                         (if (equal? (vinfo:type cv) '(core Any))
                              val
                              `(call (core typeassert) ,val
                                     ,(cl-convert (vinfo:type cv) fname lam namemap toplevel interp))))
@@ -3012,7 +3012,7 @@ f(x) = yt(x)
                 (vi
                  (if (and (vinfo:asgn vi) (vinfo:capt vi))
                      (let ((val `(call (core getfield) ,e (inert contents))))
-                       (if (eq? (vinfo:type vi) 'Any)
+                       (if (equal? (vinfo:type vi) '(core Any))
                            val
                            `(call (core typeassert) ,val
                                   ,(cl-convert (vinfo:type vi) fname lam namemap toplevel interp))))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -677,7 +677,8 @@
                      (block
                       ,@locs
                       (call new ,@field-names)))))
-    (if (and (null? params) (pair? field-types))
+    (if (and (null? params) (any (lambda (t) (not (equal? t '(core Any))))
+                                 field-types))
         (list
          ;; definition with field types for all arguments
          ;; only if any field type is not Any, checked at runtime

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1144,3 +1144,42 @@ f21586(; @m21586(a), @m21586(b)) = a + b
     end
 end
 @test Test21604.X(1.0) === Test21604.X(1.0)
+
+# comment 298107224 on pull #21607
+module Test21607
+    using Base.Test
+
+    @test_warn(
+    "WARNING: imported binding for Any overwritten in module Test21607",
+    @eval const Any = Integer)
+
+    # check that X <: Core.Any, not Integer
+    mutable struct X; end
+    @test supertype(X) === Core.Any
+
+    # check that return type is Integer
+    f()::Any = 1.0
+    @test f() === 1
+
+    # check that constructor accepts Any
+    struct Y
+        x
+    end
+    @test Y(1.0) !== Y(1)
+
+    # check that function default argument type is Any
+    g(x) = x
+    @test g(1.0) === 1.0
+
+    # check that asserted variable type is Integer
+    @test let
+        x::Any = 1.0
+        x
+    end === 1
+
+    # check that unasserted variable type is not Integer
+    @test let
+        x = 1.0
+        x
+    end === 1.0
+end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1135,3 +1135,12 @@ end
 
 f21586(; @m21586(a), @m21586(b)) = a + b
 @test f21586(a=10) == 52
+
+# issue #21604
+@test_nowarn @eval module Test21604
+    const Foo = Any
+    struct X
+        x::Foo
+    end
+end
+@test Test21604.X(1.0) === Test21604.X(1.0)


### PR DESCRIPTION
This moves the check for whether field types are `Any` or not to runtime instead of at lowering time.

I made the assumption that `X == Any` iff `X === Any` here; please tell me if that is invalid. (Maybe we need `Core.issubtype(Any, X)`?)