### PR TITLE
perf.m: missing semi-colon in pisumvec causes matrix of 10000 els to …

### DIFF
--- a/test/perf/micro/perf.m
+++ b/test/perf/micro/perf.m
@@ -177,7 +177,7 @@ end
 %% slow pi series, vectorized %%
 
 function s = pisumvec(ignore)
-    a = [1:10000]
+    a = [1:10000];
     for j=1:500
         s = sum( 1./(a.^2));
     end


### PR DESCRIPTION
…be printed to command line, taking non negligible time.