### PR TITLE
Improve docstrings for norm, vecnorm, normalize and normalize!

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -508,10 +508,7 @@ end
 
 Compute the `p`-norm of a vector or the operator norm of a matrix `A`,
 defaulting to the 2-norm.
-"""
-function norm end
 
-"""
     norm(A::AbstractVector, p::Real=2)
 
 For vectors, this is equivalent to [`vecnorm`](@ref) and equal to:

--- a/doc/src/stdlib/linalg.md
+++ b/doc/src/stdlib/linalg.md
@@ -73,10 +73,6 @@ Base.LinAlg.diagm
 Base.LinAlg.scale!
 Base.LinAlg.rank
 Base.LinAlg.norm
-Base.LinAlg.norm(::AbstractVector, ::Real)
-Base.LinAlg.norm(::AbstractMatrix, ::Real)
-Base.LinAlg.norm(::Number, ::Real)
-Base.LinAlg.norm(::RowVector, ::Real)
 Base.LinAlg.vecnorm
 Base.LinAlg.normalize!
 Base.LinAlg.normalize

--- a/doc/src/stdlib/linalg.md
+++ b/doc/src/stdlib/linalg.md
@@ -73,6 +73,10 @@ Base.LinAlg.diagm
 Base.LinAlg.scale!
 Base.LinAlg.rank
 Base.LinAlg.norm
+Base.LinAlg.norm(::AbstractVector, ::Real)
+Base.LinAlg.norm(::AbstractMatrix, ::Real)
+Base.LinAlg.norm(::Number, ::Real)
+Base.LinAlg.norm(::RowVector, ::Real)
 Base.LinAlg.vecnorm
 Base.LinAlg.normalize!
 Base.LinAlg.normalize


### PR DESCRIPTION
Add equations defining the norms, reorganize the docstrings by argument type,
and mention what "normalizing" means.

Somebody should really review the equations, as I'm not familiar with matrix norms.