### PR TITLE
Catch more substituition failures in finish_unionall (closes #21613)

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1402,8 +1402,14 @@ static jl_value_t *finish_unionall(jl_value_t *res, jl_varbinding_t *vb, jl_sten
                 JL_GC_POP();
                 return jl_bottom_type;
             }
-            if (varval)
-                btemp->lb = jl_substitute_var(btemp->lb, vb->var, varval);
+            if (varval) {
+                JL_TRY {
+                    btemp->lb = jl_substitute_var(btemp->lb, vb->var, varval);
+                }
+                JL_CATCH {
+                    res = jl_bottom_type;
+                }
+            }
             else if (btemp->lb == (jl_value_t*)vb->var)
                 btemp->lb = vb->lb;
             else if (btemp->depth0 == vb->depth0 && !jl_has_typevar(vb->lb, btemp->var) &&
@@ -1430,8 +1436,14 @@ static jl_value_t *finish_unionall(jl_value_t *res, jl_varbinding_t *vb, jl_sten
                 JL_GC_POP();
                 return jl_bottom_type;
             }
-            if (varval)
-                btemp->ub = jl_substitute_var(btemp->ub, vb->var, varval);
+            if (varval) {
+                JL_TRY {
+                    btemp->ub = jl_substitute_var(btemp->ub, vb->var, varval);
+                }
+                JL_CATCH {
+                    res = jl_bottom_type;
+                }
+            }
             else if (btemp->ub == (jl_value_t*)vb->var)
                 btemp->ub = vb->ub;
             else

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1099,3 +1099,12 @@ let T1 = Val{Val{Val{Union{Int8,Int16,Int32,Int64,UInt8,UInt16}}}},
     T2 = Val{Val{Val{Union{Int8,Int16,Int32,Int64,UInt8, S}}}} where S
     @test T1 <: T2
 end
+
+# issue #21613
+abstract type A21613{S <: Tuple} end
+immutable B21613{S <: Tuple, L} <: A21613{S}
+    data::NTuple{L,Float64}
+end
+@testintersect(Tuple{Type{B21613{Tuple{L},L}} where L, Any},
+               Tuple{Type{SA}, Tuple} where SA<:(A21613{S} where S<:Tuple),
+               Tuple{Type{B21613{Tuple{L},L}} where L, Tuple})


### PR DESCRIPTION
As #21613 is exposed by StaticArrays, quite a few packages suffer from it, so if this is not the right approach, we should either come up with something better soon or I suggest we merge this as an interim solution.