### PR TITLE
remove redundant convert definitions

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -2,7 +2,6 @@
 
 ## boolean conversions ##
 
-convert(::Type{Bool}, x::Bool) = x
 convert(::Type{Bool}, x::Float16) = x==0 ? false : x==1 ? true : throw(InexactError())
 convert(::Type{Bool}, x::Real) = x==0 ? false : x==1 ? true : throw(InexactError())
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -23,7 +23,6 @@ convert(::Type{Complex{T}}, z::Complex) where {T<:Real} = Complex{T}(real(z),ima
 convert(::Type{T}, z::Complex) where {T<:Real} =
     isreal(z) ? convert(T,real(z)) : throw(InexactError())
 
-convert(::Type{Complex}, z::Complex) = z
 convert(::Type{Complex}, x::Real) = Complex(x)
 
 promote_rule(::Type{Complex{T}}, ::Type{S}) where {T<:Real,S<:Real} =

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -75,8 +75,6 @@ widen(::Type{BigInt})  = BigInt
 
 signed(x::BigInt) = x
 
-convert(::Type{BigInt}, x::BigInt) = x
-
 function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
     _n = Nullable{BigInt}()
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -43,7 +43,6 @@ end
 _string_n(n::Integer) = ccall(:jl_alloc_string, Ref{String}, (Csize_t,), n)
 
 convert(::Type{Vector{UInt8}}, s::String) = ccall(:jl_string_to_array, Ref{Vector{UInt8}}, (Any,), s)
-convert(::Type{String}, s::String) = s
 convert(::Type{String}, v::Vector{UInt8}) = String(v)
 
 ## low-level functions ##


### PR DESCRIPTION
I believe these are handled by `convert(::Type{T}, x::T) where T = x` in essentials.jl.