### PR TITLE
Make structure of Cmd more obvious in printing

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -22,6 +22,7 @@ const text_colors = AnyDict(
     :normal        => "\033[0m",
     :default       => "\033[39m",
     :bold          => "\033[1m",
+    :underline     => "\033[4m",
     :nothing       => "",
 )
 
@@ -31,6 +32,7 @@ end
 
 const disable_text_style = AnyDict(
     :bold => "\033[22m",
+    :underline => "\033[24m",
     :normal => "",
     :default => "",
 )

--- a/base/process.jl
+++ b/base/process.jl
@@ -104,14 +104,14 @@ function show(io::IO, cmd::Cmd)
     print_env = cmd.env !== nothing
     print_dir = !isempty(cmd.dir)
     (print_env || print_dir) && print(io, "setenv(")
-    esc = shell_escape(cmd, special=shell_special)
     print(io, '`')
-    for c in esc
-        if c == '`'
-            print(io, '\\')
-        end
-        print(io, c)
-    end
+    print(io, join(map(cmd.exec) do arg
+        replace(sprint() do io
+            with_output_color(:underline, io) do io
+                print_shell_word(io, arg, shell_special)
+            end
+        end, '`', "\\`")
+    end, ' '))
     print(io, '`')
     print_env && (print(io, ","); show(io, cmd.env))
     print_dir && (print(io, "; dir="); show(io, cmd.dir))


### PR DESCRIPTION
Cmds behave as an array of strings, but for most new users the mental
model they start with is that Cmds are essentially strings. As a result,
people can get easily confused by the interpolation rules around Cmds.
They are quite intuitive when one thinks of them as arrays of strings
(e.g. arrays get expanded, strings get inserted as is), but less so
when thinking of a Cmd as a single string. It seems possible to make
it clearer in printing that there is an underlying structure to the
Cmd by adjusting the way it prints. This one attempt at doing so by
underlining each separate part of the array. Some advantages:
- The underlining makes it clear that there is something going on
  beyong being a regular string
- The underlining gets dropped when copying out from a terminal, so
  there's no trouble with pasting it back into a REPL.
- The underlying structure of clearly visible (each contiguous underline
  is one of the elements of the array of strings).

Examples:
![screen shot 2017-04-28 at 2 53 32 pm](https://cloud.githubusercontent.com/assets/1291671/25544920/ab07ea64-2c2a-11e7-91e8-2cc5f1020ee1.png)
![screen shot 2017-04-28 at 2 55 37 pm](https://cloud.githubusercontent.com/assets/1291671/25544921/ab0a2ce8-2c2a-11e7-8c1c-d9ef8b617e8e.png)
![screen shot 2017-04-28 at 3 21 16 pm](https://cloud.githubusercontent.com/assets/1291671/25544922/ab0a49d0-2c2a-11e7-97f1-ccae1a66f617.png)
