### PR TITLE
more performance improvements to `Distributed`

### DIFF
--- a/base/distributed/remotecall.jl
+++ b/base/distributed/remotecall.jl
@@ -235,7 +235,7 @@ end
 function send_del_client(rr)
     if rr.where == myid()
         del_client(rr)
-    elseif rr.where in procs() # process only if a valid worker
+    elseif id_in_procs(rr.where) # process only if a valid worker
         w = worker_from_id(rr.where)
         push!(w.del_msgs, (remoteref_id(rr), myid()))
         w.gcflag = true
@@ -260,7 +260,7 @@ end
 function send_add_client(rr::AbstractRemoteRef, i)
     if rr.where == myid()
         add_client(remoteref_id(rr), i)
-    elseif (i != rr.where) && (rr.where in procs())
+    elseif (i != rr.where) && id_in_procs(rr.where)
         # don't need to send add_client if the message is already going
         # to the processor that owns the remote ref. it will add_client
         # itself inside deserialize().

--- a/base/distributed/workerpool.jl
+++ b/base/distributed/workerpool.jl
@@ -97,7 +97,7 @@ function wp_local_take!(pool::AbstractWorkerPool)
         end
 
         worker = take!(pool.channel)
-        if worker in procs()
+        if id_in_procs(worker)
             break
         else
             delete!(pool.workers, worker) # Remove invalid worker from pool


### PR DESCRIPTION
Before:

```
x = [bitrand(4,2) for i = 1:10000];

julia> @time pmap(identity, x);
  1.050650 seconds (1.14 M allocations: 41.453 MiB, 1.20% gc time)
```

after:

```
julia> @time pmap(identity, x);
  0.961973 seconds (964.03 k allocations: 35.041 MiB, 0.69% gc time)
```

Changes:
- Only allocate Task vectors for unbuffered channels that need them
- Avoid allocating array from `procs()`