### PR TITLE
Fix Windows LLVM build for addition of LLVM_LINK_LLVM_DYLIB flag

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -553,8 +553,14 @@ endif
 $(build_prefix)/manifest/llvm: | $(llvm_python_workaround)
 
 ifeq ($(LLVM_USE_CMAKE),1)
+ifeq ($(OS), WINNT)
+LLVM_INSTALL = \
+	cd $1 && $$(CMAKE) -DCMAKE_INSTALL_PREFIX="$2$$(build_prefix)" -P cmake_install.cmake && \
+	cp $2$$(build_shlibdir)/LLVM.dll $2$$(build_depsbindir)
+else
 LLVM_INSTALL = \
 	cd $1 && $$(CMAKE) -DCMAKE_INSTALL_PREFIX="$2$$(build_prefix)" -P cmake_install.cmake
+endif
 else
 LLVM_INSTALL = \
 	$(call MAKE_INSTALL,$1,$2,$3 $$(LLVM_MFLAGS) PATH="$$(llvm_python_workaround):$$$$PATH" DestSharedLibDir="$2$$(build_shlibdir)")

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -553,13 +553,10 @@ endif
 $(build_prefix)/manifest/llvm: | $(llvm_python_workaround)
 
 ifeq ($(LLVM_USE_CMAKE),1)
-ifeq ($(OS), WINNT)
-LLVM_INSTALL = \
-	cd $1 && $$(CMAKE) -DCMAKE_INSTALL_PREFIX="$2$$(build_prefix)" -P cmake_install.cmake && \
-	cp $2$$(build_shlibdir)/LLVM.dll $2$$(build_depsbindir)
-else
 LLVM_INSTALL = \
 	cd $1 && $$(CMAKE) -DCMAKE_INSTALL_PREFIX="$2$$(build_prefix)" -P cmake_install.cmake
+ifeq ($(OS), WINNT)
+LLVM_INSTALL += && cp $2$$(build_shlibdir)/LLVM.dll $2$$(build_depsbindir)
 endif
 else
 LLVM_INSTALL = \


### PR DESCRIPTION
fixes #21621, since this flag was enabled in #21498 the llvm tools have
been linking against the LLVM shared library, which means on windows the
dll has to be copied to build_depsbindir in order for llvm-config to run