### PR TITLE
add documentation for abspath(p1, p2...)

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -258,6 +258,13 @@ normpath(a::AbstractString, b::AbstractString...) = normpath(joinpath(a,b...))
 Convert a path to an absolute path by adding the current directory if necessary.
 """
 abspath(a::String) = normpath(isabspath(a) ? a : joinpath(pwd(),a))
+
+"""
+	abspath(path::AbstractString, paths::AbstractString...) -> AbstractString
+
+Convert a set of paths to an absolute path by joining them together and adding the
+current directory if neccessary. Equivalent to `abspath(joinpath(path, paths...))`.
+"""
 abspath(a::AbstractString, b::AbstractString...) = abspath(joinpath(a,b...))
 
 if is_windows()

--- a/base/path.jl
+++ b/base/path.jl
@@ -260,10 +260,10 @@ Convert a path to an absolute path by adding the current directory if necessary.
 abspath(a::String) = normpath(isabspath(a) ? a : joinpath(pwd(),a))
 
 """
-	abspath(path::AbstractString, paths::AbstractString...) -> AbstractString
+    abspath(path::AbstractString, paths::AbstractString...) -> AbstractString
 
 Convert a set of paths to an absolute path by joining them together and adding the
-current directory if neccessary. Equivalent to `abspath(joinpath(path, paths...))`.
+current directory if necessary. Equivalent to `abspath(joinpath(path, paths...))`.
 """
 abspath(a::AbstractString, b::AbstractString...) = abspath(joinpath(a,b...))
 


### PR DESCRIPTION
Addresses issue #18406. Made separate docs for `abspath(p)` and `abspath(p, p1...)` as suggested in a previous pull request (#18483).