### PR TITLE
Make python benchmark more idiomatic

### DIFF
--- a/test/perf/micro/perf.py
+++ b/test/perf/micro/perf.py
@@ -1,9 +1,9 @@
 from numpy import *
-from numpy.linalg import *
+from numpy.random import rand, randn
+from numpy.linalg import matrix_power
 import sys
 import time
 import random
-import numpy
 
 if sys.version_info < (3,):
     range = xrange
@@ -44,22 +44,22 @@ def randmatstat(t):
     v = zeros(t)
     w = zeros(t)
     for i in range(1,t):
-        a = numpy.random.randn(n, n)
-        b = numpy.random.randn(n, n)
-        c = numpy.random.randn(n, n)
-        d = numpy.random.randn(n, n)
-        P = matrix(hstack((a, b, c, d)))
-        Q = matrix(vstack((hstack((a, b)), hstack((c, d)))))
-        v[i] = trace(matrix_power(transpose(P)*P, 4))
-        w[i] = trace(matrix_power(transpose(Q)*Q, 4))
+        a = randn(n, n)
+        b = randn(n, n)
+        c = randn(n, n)
+        d = randn(n, n)
+        P = concatenate((a, b, c, d))
+        Q = concatenate((concatenate((a, b)), concatenate((c, d))),axis=1)
+        v[i] = trace(matrix_power(dot(P.T,P), 4))
+        w[i] = trace(matrix_power(dot(Q.T,Q), 4))
     return (std(v)/mean(v), std(w)/mean(w))
 
 ## randmatmul ##
 
 def randmatmul(n):
-    A = numpy.random.rand(n,n)
-    B = numpy.random.rand(n,n)
-    return numpy.dot(A,B)
+    A = rand(n,n)
+    B = rand(n,n)
+    return dot(A,B)
 
 ## mandelbrot ##
 
@@ -73,8 +73,8 @@ def mandel(z):
     return maxiter
 
 def mandelperf():
-    r1 = numpy.linspace(-2.0, 0.5, 26)
-    r2 = numpy.linspace(-1.0, 1.0, 21)
+    r1 = [-2. + 0.1*i for i in range(26)]
+    r2 = [-1. + 0.1*i for i in range(21)]
     return [mandel(complex(r, i)) for r in r1 for i in r2]
 
 def pisum():
@@ -89,15 +89,28 @@ def pisum():
 # def pisumvec():
 #     return numpy.sum(1./(numpy.arange(1,10000)**2))
 
+def parse_int(t):
+    for i in range(1,t):
+        n = random.randint(0,2**32-1)
+        s = hex(n)
+        if s[-1]=='L':
+            s = s[0:-1]
+        m = int(s,16)
+        assert m == n
+    return n
+
 def print_perf(name, time):
     print("python," + name + "," + str(time*1000))
 
 ## run tests ##
 
 if __name__=="__main__":
+
+    mintrials = 5
+
     assert fib(20) == 6765
     tmin = float('inf')
-    for i in range(5):
+    for i in range(mintrials):
         t = time.time()
         f = fib(20)
         t = time.time()-t
@@ -105,22 +118,16 @@ if __name__=="__main__":
     print_perf("fib", tmin)
 
     tmin = float('inf')
-    for i in range(5):
+    for i in range(mintrials):
         t = time.time()
-        for i in range(1,1000):
-            n = random.randint(0,2**32-1)
-            s = hex(n)
-            if s[-1]=='L':
-                s = s[0:-1]
-            m = int(s,16)
-            assert m == n
+        n = parse_int(1000)
         t = time.time()-t
         if t < tmin: tmin = t
     print_perf ("parse_int", tmin)
 
     assert sum(mandelperf()) == 14791
     tmin = float('inf')
-    for i in range(5):
+    for i in range(mintrials):
         t = time.time()
         mandelperf()
         t = time.time()-t
@@ -128,7 +135,7 @@ if __name__=="__main__":
     print_perf ("mandel", tmin)
 
     tmin = float('inf')
-    for i in range(5):
+    for i in range(mintrials):
         lst = [ random.random() for i in range(1,5000) ]
         t = time.time()
         qsort_kernel(lst, 0, len(lst)-1)
@@ -138,7 +145,7 @@ if __name__=="__main__":
 
     assert abs(pisum()-1.644834071848065) < 1e-6
     tmin = float('inf')
-    for i in range(5):
+    for i in range(mintrials):
         t = time.time()
         pisum()
         t = time.time()-t
@@ -147,7 +154,7 @@ if __name__=="__main__":
 
     # assert abs(pisumvec()-1.644834071848065) < 1e-6
     # tmin = float('inf')
-    # for i in range(5):
+    # for i in range(mintrials):
     #     t = time.time()
     #     pisumvec()
     #     t = time.time()-t
@@ -157,7 +164,7 @@ if __name__=="__main__":
     (s1, s2) = randmatstat(1000)
     assert s1 > 0.5 and s1 < 1.0
     tmin = float('inf')
-    for i in range(5):
+    for i in range(mintrials):
         t = time.time()
         randmatstat(1000)
         t = time.time()-t
@@ -165,7 +172,7 @@ if __name__=="__main__":
     print_perf ("rand_mat_stat", tmin)
 
     tmin = float('inf')
-    for i in range(5):
+    for i in range(mintrials):
         t = time.time()
         C = randmatmul(1000)
         assert C[0,0] >= 0


### PR DESCRIPTION
A few pythonic enhancements to the python benchmark:

1. The main webpage says "the Python implementations of `rand_mat_stat` and `rand_mat_mul` use NumPy functions; the rest are pure Python implementations". Yet the `mandelperf` algorithm uses numpy arrays.
2. Move the `parse_int` to a function as right now it is implemented in the global scope. This is consistent with the benchmark in all the other languages.
3. The `rand_mat_stat` function uses numpy matrices (which are seldom used in python codes) instead of numpy arrays. The benchmark also uses list comprehension based appending i.e. `vstack/hstack`. Concatenation should be used instead. 
4. Use a counter for number of trials for the benchmarks to run, similar to julia's own benchmarks.