### PR TITLE
Fix libgit2 config write with symlink

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -94,6 +94,11 @@ $(LIBGIT2_SRC_PATH)/libgit2-gitconfig-symlink.patch-applied: $(LIBGIT2_SRC_PATH)
 		patch -p1 -f < $(SRCDIR)/patches/libgit2-gitconfig-symlink.patch
 	echo 1 > $@
 
+$(LIBGIT2_SRC_PATH)/libgit2-free-config.patch-applied: $(LIBGIT2_SRC_PATH)/source-extracted | $(LIBGIT2_SRC_PATH)/libgit2-gitconfig-symlink.patch-applied
+	cd $(LIBGIT2_SRC_PATH) && \
+		patch -p1 -f < $(SRCDIR)/patches/libgit2-free-config.patch
+	echo 1 > $@
+
 $(build_datarootdir)/julia/cert.pem: $(CERTFILE)
 	mkdir -p $(build_datarootdir)/julia
 	-cp $(CERTFILE) $@
@@ -104,7 +109,8 @@ $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: \
 	$(LIBGIT2_SRC_PATH)/libgit2-agent-nonfatal.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied \
-	$(LIBGIT2_SRC_PATH)/libgit2-gitconfig-symlink.patch-applied
+	$(LIBGIT2_SRC_PATH)/libgit2-gitconfig-symlink.patch-applied \
+	$(LIBGIT2_SRC_PATH)/libgit2-free-config.patch-applied
 
 ifneq ($(CERTFILE),)
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: $(build_datarootdir)/julia/cert.pem

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -89,6 +89,11 @@ $(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied: $(LIBGIT2_SRC_PATH)/so
 		patch -p1 -f < $(SRCDIR)/patches/libgit2-mbedtls-verify.patch
 	echo 1 > $@
 
+$(LIBGIT2_SRC_PATH)/libgit2-gitconfig-symlink.patch-applied: $(LIBGIT2_SRC_PATH)/source-extracted | $(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied
+	cd $(LIBGIT2_SRC_PATH) && \
+		patch -p1 -f < $(SRCDIR)/patches/libgit2-gitconfig-symlink.patch
+	echo 1 > $@
+
 $(build_datarootdir)/julia/cert.pem: $(CERTFILE)
 	mkdir -p $(build_datarootdir)/julia
 	-cp $(CERTFILE) $@
@@ -98,7 +103,8 @@ $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: \
 	$(LIBGIT2_SRC_PATH)/libgit2-ssh.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-agent-nonfatal.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied \
-	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied
+	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied \
+	$(LIBGIT2_SRC_PATH)/libgit2-gitconfig-symlink.patch-applied
 
 ifneq ($(CERTFILE),)
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: $(build_datarootdir)/julia/cert.pem

--- a/deps/patches/libgit2-free-config.patch
+++ b/deps/patches/libgit2-free-config.patch
@@ -1,0 +1,25 @@
+From 5552237686dae90fb9c22f0088de488b48654828 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sat, 29 Apr 2017 12:28:35 -0400
+Subject: [PATCH] Do not free config when creating remote
+
+The regression was introduced in 22261344de18b3cc60ee6937468d66a6a6a28875
+---
+ src/remote.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/remote.c b/src/remote.c
+index d3132f75c..15752ab27 100644
+--- a/src/remote.c
++++ b/src/remote.c
+@@ -260,7 +260,6 @@ on_error:
+ 	if (error)
+ 		git_remote_free(remote);
+ 
+-	git_config_free(config);
+ 	git_buf_free(&canonical_url);
+ 	git_buf_free(&var);
+ 	return error;
+-- 
+2.12.2
+

--- a/deps/patches/libgit2-gitconfig-symlink.patch
+++ b/deps/patches/libgit2-gitconfig-symlink.patch
@@ -1,0 +1,27 @@
+From 86a8cd9f6a039889801b5bec865a4bc3deb30f47 Mon Sep 17 00:00:00 2001
+From: Sven Strickroth2 <email@cs-ware.de>
+Date: Mon, 20 Mar 2017 11:21:00 +0100
+Subject: [PATCH] filebuf: fix resolving absolute symlinks
+
+The symlink destination is always concatenated to the original path. Fix
+this by using `git_buf_sets` instead of `git_buf_puts`.
+---
+ src/filebuf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/filebuf.c b/src/filebuf.c
+index ef68b16f4..825b9c04c 100644
+--- a/src/filebuf.c
++++ b/src/filebuf.c
+@@ -246,7 +246,7 @@ static int resolve_symlink(git_buf *out, const char *path)
+ 
+ 		root = git_path_root(target.ptr);
+ 		if (root >= 0) {
+-			if ((error = git_buf_puts(&curpath, target.ptr)) < 0)
++			if ((error = git_buf_sets(&curpath, target.ptr)) < 0)
+ 				goto cleanup;
+ 		} else {
+ 			git_buf dir = GIT_BUF_INIT;
+-- 
+2.12.2
+


### PR DESCRIPTION
Ref https://github.com/libgit2/libgit2/pull/4169

* Test this on unix
* Do not write to user's global gitconfig