### PR TITLE
replace various instances of Array with Vector

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -63,7 +63,7 @@ macro enum(T,syms...)
     elseif !isa(T,Symbol)
         throw(ArgumentError("invalid type expression for enum $T"))
     end
-    vals = Array{Tuple{Symbol,Integer}}(0)
+    vals = Vector{Tuple{Symbol,Integer}}(0)
     lo = hi = 0
     i = zero(basetype)
     hasexpr = false

--- a/base/io.jl
+++ b/base/io.jl
@@ -521,7 +521,7 @@ Read at most `nb` bytes from `s`, returning a `Vector{UInt8}` of the bytes read.
 function read(s::IO, nb=typemax(Int))
     # Let readbytes! grow the array progressively by default
     # instead of taking of risk of over-allocating
-    b = Array{UInt8}(nb == typemax(Int) ? 1024 : nb)
+    b = Vector{UInt8}(nb == typemax(Int) ? 1024 : nb)
     nr = readbytes!(s, b, nb)
     return resize!(b, nr)
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -47,7 +47,7 @@ elseif is_apple()
         path_basename = String(basename(path))
         local casepreserved_basename
         const header_size = 12
-        buf = Array{UInt8}(length(path_basename) + header_size + 1)
+        buf = Vector{UInt8}(length(path_basename) + header_size + 1)
         while true
             ret = ccall(:getattrlist, Cint,
                         (Cstring, Ptr{Void}, Ptr{Void}, Csize_t, Culong),

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -74,7 +74,7 @@ function sanity_check(deps::Dict{String,Dict{VersionNumber,Available}},
         end
     end
 
-    vers = Array{Tuple{String,VersionNumber,VersionNumber}}(0)
+    vers = Vector{Tuple{String,VersionNumber,VersionNumber}}(0)
     for (p,d) in deps, vn in keys(d)
         lvns = VersionNumber[Iterators.filter(vn2->(vn2>vn), keys(d))...]
         nvn = isempty(lvns) ? typemax(VersionNumber) : minimum(lvns)
@@ -88,7 +88,7 @@ function sanity_check(deps::Dict{String,Dict{VersionNumber,Available}},
 
     checked = falses(nv)
 
-    problematic = Array{Tuple{String,VersionNumber,String}}(0)
+    problematic = Vector{Tuple{String,VersionNumber,String}}(0)
     i = 1
     psl = 0
     for (p,vn,nvn) in vers

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -240,7 +240,7 @@ function enforce_optimality!(sol::Vector{Int}, interface::Interface)
 
     # prepare some useful structures
     # pdeps[p0][v0] has all dependencies of package p0 version v0
-    pdeps = [Array{Requires}(spp[p0]-1) for p0 = 1:np]
+    pdeps = [Vector{Requires}(spp[p0]-1) for p0 = 1:np]
     # prevdeps[p1][p0][v0] is the VersionSet of package p1 which package p0 version v0
     # depends upon
     prevdeps = [Dict{Int,Dict{Int,VersionSet}}() for p0 = 1:np]

--- a/base/random.jl
+++ b/base/random.jl
@@ -576,7 +576,7 @@ else
         limbs::Vector{Limb}   # buffer to be copied into generated BigInt's
         mask::Limb            # applied to the highest limb
 
-        RangeGeneratorBigInt(a, m, nlimbs, mask) = new(a, m, Array{Limb}(nlimbs), mask)
+        RangeGeneratorBigInt(a, m, nlimbs, mask) = new(a, m, Vector{Limb}(nlimbs), mask)
     end
 end
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -327,7 +327,7 @@ end
 # convert'ing from SparseMatrixCSC to other matrix types
 function convert(::Type{Matrix}, S::SparseMatrixCSC{Tv}) where Tv
     # Handle cases where zero(Tv) is not defined but the array is dense.
-    A = length(S) == nnz(S) ? Array{Tv}(S.m, S.n) : zeros(Tv, S.m, S.n)
+    A = length(S) == nnz(S) ? Matrix{Tv}(S.m, S.n) : zeros(Tv, S.m, S.n)
     for Sj in 1:S.n
         for Sk in nzrange(S, Sj)
             Si = S.rowval[Sk]


### PR DESCRIPTION
Ref. #20114. This pull request replaces the remaining instances of `Array{...}(...)` that should be `Vector{...}(...)` that I could identify via various broad `grep` incantations. Best!