### PR TITLE
add documentation for Function type

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -693,4 +693,22 @@ run(pipeline(`cat test.txt`, DevNull))
 """
 DevNull
 
+"""
+    Function
+
+Abstract type of all functions.
+
+```jldoctest
+julia> isa(+, Function)
+true
+
+julia> typeof(sin)
+Base.#sin
+
+julia> ans <: Function
+true
+```
+"""
+Function
+
 end

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -118,6 +118,7 @@ Base.instances
 ## Generic Functions
 
 ```@docs
+Core.Function
 Base.method_exists
 Core.applicable
 Core.invoke


### PR DESCRIPTION
Addresses the unwieldy auto-generated documentation noted in #20904.

Fixes #20904