### PR TITLE
Fix bug in nprocs()/nworkers()/procs() in non :all_to_all topology case.

### DIFF
--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -652,13 +652,17 @@ myid() = LPROC.id
 Get the number of available processes.
 """
 function nprocs()
-    n = length(PGRP.workers)
-    for jw in PGRP.workers
-        if !isa(jw, LocalProcess) && (jw.state != W_CONNECTED)
-            n = n - 1
+    if myid() == 1 || PGRP.topology == :all_to_all
+        n = length(PGRP.workers)
+        for jw in PGRP.workers
+            if !isa(jw, LocalProcess) && (jw.state != W_CONNECTED)
+                n = n - 1
+            end
         end
+        return n
+    else
+        return remotecall_fetch(nprocs, 1)
     end
-    n
 end
 
 """
@@ -677,7 +681,13 @@ end
 
 Returns a list of all process identifiers.
 """
-procs() = Int[x.id for x in PGRP.workers if isa(x, LocalProcess) || (x.state == W_CONNECTED)]
+function procs()
+    if myid() == 1 || PGRP.topology == :all_to_all
+        return Int[x.id for x in PGRP.workers if isa(x, LocalProcess) || (x.state == W_CONNECTED)]
+    else
+        return remotecall_fetch(procs, 1)
+    end
+end
 
 """
     procs(pid::Integer)

--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -654,6 +654,7 @@ Get the number of available processes.
 function nprocs()
     if myid() == 1 || PGRP.topology == :all_to_all
         n = length(PGRP.workers)
+        # filter out workers in the process of being setup/shutdown.
         for jw in PGRP.workers
             if !isa(jw, LocalProcess) && (jw.state != W_CONNECTED)
                 n = n - 1
@@ -661,7 +662,7 @@ function nprocs()
         end
         return n
     else
-        return remotecall_fetch(nprocs, 1)
+        return length(PGRP.workers)
     end
 end
 
@@ -683,9 +684,10 @@ Returns a list of all process identifiers.
 """
 function procs()
     if myid() == 1 || PGRP.topology == :all_to_all
+        # filter out workers in the process of being setup/shutdown.
         return Int[x.id for x in PGRP.workers if isa(x, LocalProcess) || (x.state == W_CONNECTED)]
     else
-        return remotecall_fetch(procs, 1)
+        return Int[x.id for x in PGRP.workers]
     end
 end
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -897,19 +897,6 @@ clear!(wp)
 DoFullTest = Bool(parse(Int,(get(ENV, "JULIA_TESTFULL", "0"))))
 
 if DoFullTest
-    # Topology tests need to run externally since a given cluster at any
-    # time can only support a single topology and the current session
-    # is already running in parallel under the default topology.
-    script = joinpath(dirname(@__FILE__), "topology.jl")
-    cmd = `$(Base.julia_cmd()) $script`
-
-    (strm, proc) = open(pipeline(cmd, stderr=STDERR))
-    wait(proc)
-    if !success(proc) && ccall(:jl_running_on_valgrind,Cint,()) == 0
-        println(readstring(strm))
-        error("Topology tests failed : $cmd")
-    end
-
     println("Testing exception printing on remote worker from a `remote_do` call")
     println("Please ensure the remote error and backtrace is displayed on screen")
 
@@ -1552,4 +1539,17 @@ catch ex
     @test isa(ex.captured.ex.exceptions[1].ex, ErrorException)
     @test contains(ex.captured.ex.exceptions[1].ex.msg, "BoundsError")
     @test ex.captured.ex.exceptions[2].ex == UndefVarError(:DontExistOn1)
+end
+
+# Topology tests need to run externally since a given cluster at any
+# time can only support a single topology and the current session
+# is already running in parallel under the default topology.
+script = joinpath(dirname(@__FILE__), "topology.jl")
+cmd = `$(Base.julia_cmd()) $cov_in_exeflags $script`
+
+(strm, proc) = open(pipeline(cmd, stderr=STDERR))
+wait(proc)
+if !success(proc) && ccall(:jl_running_on_valgrind,Cint,()) == 0
+    println(readstring(strm))
+    error("Topology tests failed : $cmd")
 end


### PR DESCRIPTION
Closes #21632

- In non all-to-all connected topologies we now query back to node 1 for correct values for `nprocs` and `procs` 

- The topology test case has been moved from full test to regular CI. It was under fulltest when CI resources were much more limited. Should be OK to run under regular CI now.