### PR TITLE
Testsystem: Define and use exename and exeflags used in addprocs in a consistent manner

### DIFF
--- a/test/distributed.jl
+++ b/test/distributed.jl
@@ -3,15 +3,7 @@
 # Run the distributed test outside of the main driver since it needs its own
 # set of dedicated workers.
 
-inline_flag = Base.JLOptions().can_inline == 1 ? `` : `--inline=no`
-cov_flag = ``
-if Base.JLOptions().code_coverage == 1
-    cov_flag = `--code-coverage=user`
-elseif Base.JLOptions().code_coverage == 2
-    cov_flag = `--code-coverage=all`
-end
-
-cmd = `$(Base.julia_cmd()) $inline_flag $cov_flag --check-bounds=yes --startup-file=no --depwarn=error distributed_exec.jl`
+cmd = `$test_exename $test_exeflags distributed_exec.jl`
 
 if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR)) && ccall(:jl_running_on_valgrind,Cint,()) == 0
     error("Distributed test failed, cmd : $cmd")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@
 
 using Base.Test
 include("choosetests.jl")
+include("testdefs.jl")
+
 tests, net_on = choosetests(ARGS)
 tests = unique(tests)
 
@@ -9,18 +11,6 @@ const max_worker_rss = if haskey(ENV, "JULIA_TEST_MAXRSS_MB")
     parse(Int, ENV["JULIA_TEST_MAXRSS_MB"]) * 2^20
 else
     typemax(Csize_t)
-end
-
-if haskey(ENV, "JULIA_TEST_EXEFLAGS")
-    const test_exeflags = `$(Base.shell_split(ENV["JULIA_TEST_EXEFLAGS"]))`
-else
-    const test_exeflags = `--check-bounds=yes --startup-file=no --depwarn=error`
-end
-
-if haskey(ENV, "JULIA_TEST_EXENAME")
-    const test_exename = `$(Base.shell_split(ENV["JULIA_TEST_EXENAME"]))`
-else
-    const test_exename = `$(joinpath(JULIA_HOME, Base.julia_exename()))`
 end
 
 const node1_tests = String[]
@@ -40,11 +30,14 @@ cd(dirname(@__FILE__)) do
     n = 1
     if net_on
         n = min(Sys.CPU_CORES, length(tests))
-        n > 1 && addprocs(n; exename=test_exename, exeflags=test_exeflags)
+        if n > 1
+            addprocs_with_testenv(n)
+            @sync for p in workers()
+                @async remotecall_fetch(include, p, "testdefs.jl")
+            end
+        end
         BLAS.set_num_threads(1)
     end
-
-    @everywhere include("testdefs.jl")
 
     #pretty print the information about gc and mem usage
     name_align    = maximum([length("Test (Worker)"); map(x -> length(x) + 3 + ndigits(nworkers()), tests)])
@@ -72,8 +65,8 @@ cd(dirname(@__FILE__)) do
                     if (isa(resp[end], Integer) && (resp[end] > max_worker_rss)) || isa(resp, Exception)
                         if n > 1
                             rmprocs(wrkr, waitfor=30)
-                            p = addprocs(1; exename=test_exename, exeflags=test_exeflags)[1]
-                            remotecall_fetch(()->include("testdefs.jl"), p)
+                            p = addprocs_with_testenv(1)[1]
+                            remotecall_fetch(include, p, "testdefs.jl")
                         else
                             # single process testing, bail if mem limit reached, or, on an exception.
                             isa(resp, Exception) ? rethrow(resp) : error("Halting tests. Memory limit reached : $resp > $max_worker_rss")

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -1,18 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-include("testdefs.jl")
-inline_flag = Base.JLOptions().can_inline == 1 ? `` : `--inline=no`
-cov_flag = ``
-if Base.JLOptions().code_coverage == 1
-    cov_flag = `--code-coverage=user`
-elseif Base.JLOptions().code_coverage == 2
-    cov_flag = `--code-coverage=all`
-end
-cov_in_exeflags = `$cov_flag $inline_flag --check-bounds=yes --startup-file=no --depwarn=error`
-addprocs(4; exeflags=cov_in_exeflags, topology="master_slave")
-using Base.Test
+pids = addprocs_with_testenv(4; topology="master_slave")
+p1 = pids[1]
+p2 = pids[2]
 
-@test_throws RemoteException remotecall_fetch(()->remotecall_fetch(myid, 3), 2)
+@test_throws RemoteException remotecall_fetch(()->remotecall_fetch(myid, p2), p1)
 
 function test_worker_counts()
     # check if the nprocs/nworkers/workers are the same on the remaining workers
@@ -51,7 +43,7 @@ function Base.launch(manager::TopoTestManager, params::Dict, launched::Array, c:
 
     for i in 1:manager.np
         io, pobj = open(pipeline(detach(
-            setenv(`$(Base.julia_cmd(exename)) $exeflags --bind-to $(Base.Distributed.LPROC.bind_addr) --worker $(Base.cluster_cookie())`, dir=dir)); stderr=STDERR), "r")
+            setenv(`$exename $exeflags --bind-to $(Base.Distributed.LPROC.bind_addr) --worker $(Base.cluster_cookie())`, dir=dir)); stderr=STDERR), "r")
         wconfig = WorkerConfig()
         wconfig.process = pobj
         wconfig.io = io
@@ -72,7 +64,7 @@ function Base.manage(manager::TopoTestManager, id::Integer, config::WorkerConfig
     end
 end
 
-addprocs(TopoTestManager(8); exeflags=cov_in_exeflags, topology="custom")
+addprocs_with_testenv(TopoTestManager(8); topology="custom")
 
 while true
     if any(x->get(map_pid_ident, x, 0)==0, workers())


### PR DESCRIPTION
Refactoring of code setting `exename` and `exeflags` to do it in one place only.