### PR TITLE
group ccall'ed MPZ library functions in a module

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -44,15 +44,11 @@ mutable struct BigInt <: Integer
     d::Ptr{Limb}
     function BigInt()
         b = new(zero(Cint), zero(Cint), C_NULL)
-        ccall((:__gmpz_init,:libgmp), Void, (Ptr{BigInt},), &b)
+        MPZ.init!(b)
         finalizer(b, cglobal((:__gmpz_clear, :libgmp)))
         return b
     end
 end
-
-const ZERO = BigInt()
-const ONE  = BigInt()
-const _ONE = Limb[1]
 
 function __init__()
     try
@@ -75,6 +71,122 @@ function __init__()
             "WARNING: Error during initialization of module GMP")
     end
 end
+
+
+module MPZ
+# wrapping of libgmp functions
+# - "output parameters" are labeled x, y, z, and are returned when appropriate
+# - constant input parameters are labeled a, b, c
+# - a method modifying its input has a "!" appendend to its name, according to Julia's conventions
+# - some convenient methods are added (in addition to the pure MPZ ones), e.g. `add(a, b) = add!(BigInt(), a, b)`
+#   and `add!(x, a) = add!(x, x, a)`.
+using Base.GMP: BigInt, Limb
+
+const mpz_t = Ptr{BigInt}
+const bitcnt_t = Culong
+
+gmpz(op::Symbol) = (Symbol(:__gmpz_, op), :libgmp)
+
+init!(x::BigInt) = (ccall((:__gmpz_init, :libgmp), Void, (mpz_t,), &x); x)
+init2!(x::BigInt, a) = (ccall((:__gmpz_init2, :libgmp), Void, (mpz_t, bitcnt_t), &x, a); x)
+
+sizeinbase(a::BigInt, b) = Int(ccall((:__gmpz_sizeinbase, :libgmp), Csize_t, (mpz_t, Cint), &a, b))
+
+for op in (:add, :sub, :mul, :fdiv_q, :tdiv_q, :fdiv_r, :tdiv_r, :gcd, :lcm, :and, :ior, :xor)
+    op! = Symbol(op, :!)
+    @eval begin
+        $op!(x::BigInt, a::BigInt, b::BigInt) = (ccall($(gmpz(op)), Void, (mpz_t, mpz_t, mpz_t), &x, &a, &b); x)
+        $op(a::BigInt, b::BigInt) = $op!(BigInt(), a, b)
+        $op!(x::BigInt, b::BigInt) = $op!(x, x, b)
+    end
+end
+
+invert!(x::BigInt, a::BigInt, b::BigInt) =
+    ccall((:__gmpz_invert, :libgmp), Cint, (mpz_t, mpz_t, mpz_t), &x, &a, &b)
+invert(a::BigInt, b::BigInt) = invert!(BigInt(), a, b)
+invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
+
+for op in (:add_ui, :sub_ui, :mul_ui, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
+    op! = Symbol(op, :!)
+    @eval begin
+        $op!(x::BigInt, a::BigInt, b) = (ccall($(gmpz(op)), Void, (mpz_t, mpz_t, Culong), &x, &a, b); x)
+        $op(a::BigInt, b) = $op!(BigInt(), a, b)
+        $op!(x::BigInt, b) = $op!(x, x, b)
+    end
+end
+
+ui_sub!(x::BigInt, a, b::BigInt) = (ccall((:__gmpz_ui_sub, :libgmp), Void, (mpz_t, Culong, mpz_t), &x, a, &b); x)
+ui_sub(a, b::BigInt) = ui_sub!(BigInt(), a, b)
+
+for op in (:scan1, :scan0)
+    @eval $op(a::BigInt, b) = Int(ccall($(gmpz(op)), Culong, (mpz_t, Culong), &a, b))
+end
+
+mul_si!(x::BigInt, a::BigInt, b) = (ccall((:__gmpz_mul_si, :libgmp), Void, (mpz_t, mpz_t, Clong), &x, &a, b); x)
+mul_si(a::BigInt, b) = mul_si!(BigInt(), a, b)
+mul_si!(x::BigInt, b) = mul_si!(x, x, b)
+
+for op in (:neg, :com, :sqrt, :set)
+    op! = Symbol(op, :!)
+    @eval begin
+        $op!(x::BigInt, a::BigInt) = (ccall($(gmpz(op)), Void, (mpz_t, mpz_t), &x, &a); x)
+        $op(a::BigInt) = $op!(BigInt(), a)
+    end
+    op == :set && continue # MPZ.set!(x) would make no sense
+    @eval $op!(x::BigInt) = $op!(x, x)
+end
+
+for (op, T) in ((:fac_ui, Culong), (:set_ui, Culong), (:set_si, Clong), (:set_d, Cdouble))
+    op! = Symbol(op, :!)
+    @eval begin
+        $op!(x::BigInt, a) = (ccall($(gmpz(op)), Void, (mpz_t, $T), &x, a); x)
+        $op(a) = $op!(BigInt(), a)
+    end
+end
+
+popcount(a::BigInt) = ccall((:__gmpz_popcount, :libgmp), Culong, (mpz_t,), &a) % Int
+
+mpn_popcount(d::Ptr{Limb}, s::Integer) = ccall((:__gmpn_popcount, :libgmp), Culong, (Ptr{Limb}, Csize_t), d, s) % Int
+mpn_popcount(a::BigInt) = mpn_popcount(a.d, abs(a.size))
+
+function tdiv_qr!(x::BigInt, y::BigInt, a::BigInt, b::BigInt)
+    ccall((:__gmpz_tdiv_qr, :libgmp), Void, (mpz_t, mpz_t, mpz_t, mpz_t), &x, &y, &a, &b)
+    x, y
+end
+tdiv_qr(a::BigInt, b::BigInt) = tdiv_qr!(BigInt(), BigInt(), a, b)
+
+powm!(x::BigInt, a::BigInt, b::BigInt, c::BigInt) =
+    (ccall((:__gmpz_powm, :libgmp), Void, (mpz_t, mpz_t, mpz_t, mpz_t), &x, &a, &b, &c); x)
+powm(a::BigInt, b::BigInt, c::BigInt) = powm!(BigInt(), a, b, c)
+powm!(x::BigInt, b::BigInt, c::BigInt) = powm!(x, x, b, c)
+
+function gcdext!(x::BigInt, y::BigInt, z::BigInt, a::BigInt, b::BigInt)
+    ccall((:__gmpz_gcdext, :libgmp), Void, (mpz_t, mpz_t, mpz_t, mpz_t, mpz_t),
+          &x, &y, &z, &a, &b)
+    x, y, z
+end
+gcdext(a::BigInt, b::BigInt) = gcdext!(BigInt(), BigInt(), BigInt(), a, b)
+
+cmp(a::BigInt, b::BigInt) = ccall((:__gmpz_cmp, :libgmp), Cint, (mpz_t, mpz_t), &a, &b) % Int
+cmp_si(a::BigInt, b) = ccall((:__gmpz_cmp_si, :libgmp), Cint, (mpz_t, Clong), &a, b) % Int
+cmp_ui(a::BigInt, b) = ccall((:__gmpz_cmp_ui, :libgmp), Cint, (mpz_t, Culong), &a, b) % Int
+cmp_d(a::BigInt, b) = ccall((:__gmpz_cmp_d, :libgmp), Cint, (mpz_t, Cdouble), &a, b) % Int
+
+get_str!(x, a, b::BigInt) = (ccall((:__gmpz_get_str,:libgmp), Ptr{Cchar}, (Ptr{Cchar}, Cint, mpz_t), x, a, &b); x)
+set_str!(x::BigInt, a, b) = ccall((:__gmpz_set_str, :libgmp), Cint, (mpz_t, Ptr{UInt8}, Cint), &x, a, b) % Int
+get_d(a::BigInt) = ccall((:__gmpz_get_d, :libgmp), Cdouble, (mpz_t,), &a)
+
+limbs_write!(x::BigInt, a) = ccall((:__gmpz_limbs_write, :libgmp), Ptr{Limb}, (mpz_t, Clong), &x, a)
+limbs_finish!(x::BigInt, a) = ccall((:__gmpz_limbs_finish, :libgmp), Void, (mpz_t, Clong), &x, a)
+import!(x::BigInt, a, b, c, d, e, f) =
+    ccall((:__gmpz_import, :libgmp), Void, (mpz_t, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Void}),
+          &x, a, b, c, d, e, f)
+
+end # module MPZ
+
+const ZERO = BigInt()
+const ONE  = BigInt()
+const _ONE = Limb[1]
 
 widen(::Type{Int128})  = BigInt
 widen(::Type{UInt128}) = BigInt
@@ -103,9 +215,7 @@ function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, end
     if Base.containsnul(bstr)
         err = -1 # embedded NUL char (not handled correctly by GMP)
     else
-        err = ccall((:__gmpz_set_str, :libgmp),
-                    Int32, (Ptr{BigInt}, Ptr{UInt8}, Int32),
-                    &z, pointer(bstr)+(i-start(bstr)), base)
+        err = MPZ.set_str!(z, pointer(bstr)+(i-start(bstr)), base)
     end
     if err != 0
         raise && throw(ArgumentError("invalid BigInt: $(repr(bstr))"))
@@ -114,25 +224,11 @@ function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, end
     Nullable(flipsign!(z, sgn))
 end
 
-function convert(::Type{BigInt}, x::Union{Clong,Int32})
-    z = BigInt()
-    ccall((:__gmpz_set_si, :libgmp), Void, (Ptr{BigInt}, Clong), &z, x)
-    return z
-end
-function convert(::Type{BigInt}, x::Union{Culong,UInt32})
-    z = BigInt()
-    ccall((:__gmpz_set_ui, :libgmp), Void, (Ptr{BigInt}, Culong), &z, x)
-    return z
-end
-
+convert(::Type{BigInt}, x::Union{Clong,Int32}) = MPZ.set_si(x)
+convert(::Type{BigInt}, x::Union{Culong,UInt32}) = MPZ.set_ui(x)
 convert(::Type{BigInt}, x::Bool) = BigInt(UInt(x))
 
-
-function unsafe_trunc(::Type{BigInt}, x::Union{Float32,Float64})
-    z = BigInt()
-    ccall((:__gmpz_set_d, :libgmp), Void, (Ptr{BigInt}, Cdouble), &z, x)
-    return z
-end
+unsafe_trunc(::Type{BigInt}, x::Union{Float32,Float64}) = MPZ.set_d(x)
 
 function convert(::Type{BigInt}, x::Union{Float32,Float64})
     isinteger(x) || throw(InexactError())
@@ -210,9 +306,7 @@ function convert(::Type{T}, x::BigInt) where T<:Signed
 end
 
 
-function (::Type{Float64})(n::BigInt, ::RoundingMode{:ToZero})
-    ccall((:__gmpz_get_d, :libgmp), Float64, (Ptr{BigInt},), &n)
-end
+(::Type{Float64})(n::BigInt, ::RoundingMode{:ToZero}) = MPZ.get_d(n)
 
 function (::Type{T})(n::BigInt, ::RoundingMode{:ToZero}) where T<:Union{Float16,Float32}
     T(Float64(n,RoundToZero),RoundToZero)
@@ -264,11 +358,7 @@ for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
                  (:gcd, :gcd), (:lcm, :lcm),
                  (:&, :and), (:|, :ior), (:xor, :xor))
     @eval begin
-        function ($fJ)(x::BigInt, y::BigInt)
-            z = BigInt()
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &x, &y)
-            return z
-        end
+        ($fJ)(x::BigInt, y::BigInt) = MPZ.$fC(x, y)
     end
 end
 
@@ -280,14 +370,14 @@ function invmod(x::BigInt, y::BigInt)
     if ya == 1
         return z
     end
-    if (y==0 || ccall((:__gmpz_invert, :libgmp), Cint, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &x, &ya) == 0)
+    if (y==0 || MPZ.invert!(z, x, ya) == 0)
         throw(DomainError())
     end
     # GMP always returns a positive inverse; we instead want to
     # normalize such that div(z, y) == 0, i.e. we want a negative z
     # when y is negative.
     if y < 0
-        z = z + y
+        MPZ.add!(z, y)
     end
     # The postcondition is: mod(z * x, y) == mod(big(1), m) && div(z, y) == 0
     return z
@@ -295,146 +385,69 @@ end
 
 # More efficient commutative operations
 for (fJ, fC) in ((:+, :add), (:*, :mul), (:&, :and), (:|, :ior), (:xor, :xor))
+    fC! = Symbol(fC, :!)
     @eval begin
-        function ($fJ)(a::BigInt, b::BigInt, c::BigInt)
-            z = BigInt()
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &a, &b)
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &z, &c)
-            return z
-        end
-        function ($fJ)(a::BigInt, b::BigInt, c::BigInt, d::BigInt)
-            z = BigInt()
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &a, &b)
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &z, &c)
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &z, &d)
-            return z
-        end
-        function ($fJ)(a::BigInt, b::BigInt, c::BigInt, d::BigInt, e::BigInt)
-            z = BigInt()
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &a, &b)
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &z, &c)
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &z, &d)
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z, &z, &e)
-            return z
-        end
+        ($fJ)(a::BigInt, b::BigInt, c::BigInt) = MPZ.$fC!(MPZ.$fC(a, b), c)
+        ($fJ)(a::BigInt, b::BigInt, c::BigInt, d::BigInt) = MPZ.$fC!(MPZ.$fC!(MPZ.$fC(a, b), c), d)
+        ($fJ)(a::BigInt, b::BigInt, c::BigInt, d::BigInt, e::BigInt) =
+            MPZ.$fC!(MPZ.$fC!(MPZ.$fC!(MPZ.$fC(a, b), c), d), e)
     end
 end
 
 # Basic arithmetic without promotion
-function +(x::BigInt, c::CulongMax)
-    z = BigInt()
-    ccall((:__gmpz_add_ui, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, c)
-    return z
-end
++(x::BigInt, c::CulongMax) = MPZ.add_ui(x, c)
 +(c::CulongMax, x::BigInt) = x + c
 
-function -(x::BigInt, c::CulongMax)
-    z = BigInt()
-    ccall((:__gmpz_sub_ui, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, c)
-    return z
-end
-function -(c::CulongMax, x::BigInt)
-    z = BigInt()
-    ccall((:__gmpz_ui_sub, :libgmp), Void, (Ptr{BigInt}, Culong, Ptr{BigInt}), &z, c, &x)
-    return z
-end
+-(x::BigInt, c::CulongMax) = MPZ.sub_ui(x, c)
+-(c::CulongMax, x::BigInt) = MPZ.ui_sub(c, x)
+
 +(x::BigInt, c::ClongMax) = c < 0 ? -(x, -(c % Culong)) : x + convert(Culong, c)
 +(c::ClongMax, x::BigInt) = c < 0 ? -(x, -(c % Culong)) : x + convert(Culong, c)
 -(x::BigInt, c::ClongMax) = c < 0 ? +(x, -(c % Culong)) : -(x, convert(Culong, c))
 -(c::ClongMax, x::BigInt) = c < 0 ? -(x + -(c % Culong)) : -(convert(Culong, c), x)
 
-function *(x::BigInt, c::CulongMax)
-    z = BigInt()
-    ccall((:__gmpz_mul_ui, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, c)
-    return z
-end
+*(x::BigInt, c::CulongMax) = MPZ.mul_ui(x, c)
 *(c::CulongMax, x::BigInt) = x * c
-function *(x::BigInt, c::ClongMax)
-    z = BigInt()
-    ccall((:__gmpz_mul_si, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Clong), &z, &x, c)
-    return z
-end
+*(x::BigInt, c::ClongMax) = MPZ.mul_si(x, c)
 *(c::ClongMax, x::BigInt) = x * c
 
 /(x::BigInt, y::Union{ClongMax,CulongMax}) = float(x)/y
 /(x::Union{ClongMax,CulongMax}, y::BigInt) = x/float(y)
 
 # unary ops
-for (fJ, fC) in ((:-, :neg), (:~, :com))
-    @eval begin
-        function ($fJ)(x::BigInt)
-            z = BigInt()
-            ccall(($(string(:__gmpz_,fC)), :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}), &z, &x)
-            return z
-        end
-    end
-end
+(-)(x::BigInt) = MPZ.neg(x)
+(~)(x::BigInt) = MPZ.com(x)
 
-function <<(x::BigInt, c::UInt)
-    c == 0 && return x
-    z = BigInt()
-    ccall((:__gmpz_mul_2exp, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, c)
-    return z
-end
-
-function >>(x::BigInt, c::UInt)
-    c == 0 && return x
-    z = BigInt()
-    ccall((:__gmpz_fdiv_q_2exp, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, c)
-    return z
-end
-
+<<(x::BigInt, c::UInt) = c == 0 ? x : MPZ.mul_2exp(x, c)
+>>(x::BigInt, c::UInt) = c == 0 ? x : MPZ.fdiv_q_2exp(x, c)
 >>>(x::BigInt, c::UInt) = x >> c
 
+trailing_zeros(x::BigInt) = MPZ.scan1(x, 0)
+trailing_ones(x::BigInt) = MPZ.scan0(x, 0)
 
-trailing_zeros(x::BigInt) = Int(ccall((:__gmpz_scan1, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))
-trailing_ones(x::BigInt) = Int(ccall((:__gmpz_scan0, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))
-
-count_ones(x::BigInt) = Int(ccall((:__gmpz_popcount, :libgmp), Culong, (Ptr{BigInt},), &x))
+count_ones(x::BigInt) = MPZ.popcount(x)
 
 """
     count_ones_abs(x::BigInt)
 
 Number of ones in the binary representation of abs(x).
 """
-count_ones_abs(x::BigInt) = iszero(x) ? 0 : ccall((:__gmpn_popcount, :libgmp), Culong, (Ptr{Limb}, Csize_t), x.d, abs(x.size)) % Int
+count_ones_abs(x::BigInt) = iszero(x) ? 0 : MPZ.mpn_popcount(x)
 
-function divrem(x::BigInt, y::BigInt)
-    z1 = BigInt()
-    z2 = BigInt()
-    ccall((:__gmpz_tdiv_qr, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &z1, &z2, &x, &y)
-    z1, z2
-end
+divrem(x::BigInt, y::BigInt) = MPZ.tdiv_qr(x, y)
 
-function cmp(x::BigInt, y::BigInt)
-    ccall((:__gmpz_cmp, :libgmp), Int32, (Ptr{BigInt}, Ptr{BigInt}), &x, &y)
-end
-function cmp(x::BigInt, y::ClongMax)
-    ccall((:__gmpz_cmp_si, :libgmp), Int32, (Ptr{BigInt}, Clong), &x, y)
-end
-function cmp(x::BigInt, y::CulongMax)
-    ccall((:__gmpz_cmp_ui, :libgmp), Int32, (Ptr{BigInt}, Culong), &x, y)
-end
-cmp(x::BigInt, y::Integer) = cmp(x,big(y))
-cmp(x::Integer, y::BigInt) = -cmp(y,x)
+cmp(x::BigInt, y::BigInt) = MPZ.cmp(x, y)
+cmp(x::BigInt, y::ClongMax) = MPZ.cmp_si(x, y)
+cmp(x::BigInt, y::CulongMax) = MPZ.cmp_ui(x, y)
+cmp(x::BigInt, y::Integer) = cmp(x, big(y))
+cmp(x::Integer, y::BigInt) = -cmp(y, x)
 
-function cmp(x::BigInt, y::CdoubleMax)
-    isnan(y) && throw(DomainError())
-    ccall((:__gmpz_cmp_d, :libgmp), Int32, (Ptr{BigInt}, Cdouble), &x, y)
-end
-cmp(x::CdoubleMax, y::BigInt) = -cmp(y,x)
+cmp(x::BigInt, y::CdoubleMax) = isnan(y) ? throw(DomainError()) : MPZ.cmp_d(x, y)
+cmp(x::CdoubleMax, y::BigInt) = -cmp(y, x)
 
-function isqrt(x::BigInt)
-    z = BigInt()
-    ccall((:__gmpz_sqrt, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}), &z, &x)
-    return z
-end
+isqrt(x::BigInt) = MPZ.sqrt(x)
 
-function ^(x::BigInt, y::Culong)
-    z = BigInt()
-    ccall((:__gmpz_pow_ui, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &x, y)
-    return z
-end
+^(x::BigInt, y::Culong) = MPZ.pow_ui(x, y)
 
 function bigint_pow(x::BigInt, y::Integer)
     if y<0; throw(DomainError()); end
@@ -463,11 +476,8 @@ end
 ^(x::Bool   , y::BigInt ) = Base.power_by_squaring(x, y)
 
 function powermod(x::BigInt, p::BigInt, m::BigInt)
-    r = BigInt()
-    ccall((:__gmpz_powm, :libgmp), Void,
-          (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}),
-          &r, &x, &p, &m)
-    return m < 0 && r > 0 ? r + m : r # choose sign conistent with mod(x^p, m)
+    r = MPZ.powm(x, p, m)
+    return m < 0 && r > 0 ? MPZ.add!(r, m) : r # choose sign conistent with mod(x^p, m)
 end
 
 powermod(x::Integer, p::Integer, m::BigInt) = powermod(big(x), big(p), m)
@@ -478,12 +488,7 @@ function gcdx(a::BigInt, b::BigInt)
         # we don't return the globals ONE and ZERO in case the user wants to
         # mutate the result
     end
-    g = BigInt()
-    s = BigInt()
-    t = BigInt()
-    ccall((:__gmpz_gcdext, :libgmp), Void,
-        (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}),
-        &g, &s, &t, &a, &b)
+    g, s, t = MPZ.gcdext(a, b)
     if t == 0
         # work around a difference in some versions of GMP
         if a == b
@@ -495,28 +500,11 @@ function gcdx(a::BigInt, b::BigInt)
     g, s, t
 end
 
-function sum(arr::AbstractArray{BigInt})
-    n = BigInt(0)
-    for i in arr
-        ccall((:__gmpz_add, :libgmp), Void,
-            (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}),
-            &n, &n, &i)
-    end
-    return n
-end
+sum(arr::AbstractArray{BigInt}) = foldl(MPZ.add!, BigInt(0), arr)
 
-function factorial(x::BigInt)
-    isneg(x) && return BigInt(0)
-    z = BigInt()
-    ccall((:__gmpz_fac_ui, :libgmp), Void, (Ptr{BigInt}, Culong), &z, x)
-    return z
-end
+factorial(x::BigInt) = isneg(x) ? BigInt(0) : MPZ.fac_ui(x)
 
-function binomial(n::BigInt, k::UInt)
-    z = BigInt()
-    ccall((:__gmpz_bin_ui, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Culong), &z, &n, k)
-    return z
-end
+binomial(n::BigInt, k::UInt) = MPZ.bin_ui(n, k)
 binomial(n::BigInt, k::Integer) = k < 0 ? BigInt(0) : binomial(n, UInt(k))
 
 ==(x::BigInt, y::BigInt) = cmp(x,y) == 0
@@ -562,8 +550,7 @@ function base(b::Integer, n::BigInt)
     2 <= b <= 62 || throw(ArgumentError("base must be 2 ≤ base ≤ 62, got $b"))
     nd = ndigits(n, b)
     str = Base._string_n(n < 0 ? nd+1 : nd)
-    ccall((:__gmpz_get_str,:libgmp), Ptr{UInt8}, (Ptr{UInt8}, Cint, Ptr{BigInt}), str, b, &n)
-    return str
+    MPZ.get_str!(str, b, n)
 end
 
 function base(b::Integer, n::BigInt, pad::Integer)
@@ -585,11 +572,11 @@ function ndigits0zpb(x::BigInt, b::Integer)
     b < 2 && throw(DomainError())
     x.size == 0 && return 0 # for consistency with other ndigits0z methods
     if ispow2(b) && 2 <= b <= 62 # GMP assumes b is in this range
-        Int(ccall((:__gmpz_sizeinbase,:libgmp), Csize_t, (Ptr{BigInt}, Cint), &x, b))
+        MPZ.sizeinbase(x, b)
     else
         # non-base 2 mpz_sizeinbase might return an answer 1 too big
         # use property that log(b, x) < ndigits(x, b) <= log(b, x) + 1
-        n = Int(ccall((:__gmpz_sizeinbase,:libgmp), Csize_t, (Ptr{BigInt}, Cint), &x, 2))
+        n = MPZ.sizeinbase(x, 2)
         lb = log2(b) # assumed accurate to <1ulp (true for openlibm)
         q,r = divrem(n,lb)
         iq = Int(q)
@@ -627,8 +614,7 @@ function Base.deepcopy_internal(x::BigInt, stackdict::ObjectIdDict)
     if haskey(stackdict, x)
         return stackdict[x]
     end
-    y = BigInt()
-    ccall((:__gmpz_set,:libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}), &y, &x)
+    y = MPZ.set(x)
     stackdict[x] = y
     return y
 end

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -881,8 +881,7 @@ function decode(b::Int, x::BigInt)
     pt = Base.ndigits(x, abs(b))
     length(DIGITS) < pt+1 && resize!(DIGITS, pt+1)
     neg && (x.size = -x.size)
-    ccall((:__gmpz_get_str, :libgmp), Cstring,
-          (Ptr{UInt8}, Cint, Ptr{BigInt}), DIGITS, b, &x)
+    GMP.MPZ.get_str!(DIGITS, b, x)
     neg && (x.size = -x.size)
     return Int32(pt), Int32(pt), neg
 end
@@ -901,8 +900,7 @@ function decode_0ct(x::BigInt)
     length(DIGITS) < pt+1 && resize!(DIGITS, pt+1)
     neg && (x.size = -x.size)
     p = convert(Ptr{UInt8}, DIGITS) + 1
-    ccall((:__gmpz_get_str, :libgmp), Cstring,
-          (Ptr{UInt8}, Cint, Ptr{BigInt}), p, 8, &x)
+    GMP.MPZ.get_str!(p, 8, x)
     neg && (x.size = -x.size)
     return neg, Int32(pt), Int32(pt)
 end


### PR DESCRIPTION
The goals where 1) making the code cleaner in the implementation of julia function (so that it's not full of difficult-to-read `ccall`s), and 2) avoid duplication for for some of the `ccall`, within base itself, but also for users/packages.

With the help of some functions which create automatically new `BigInt` objects for output arguments, the simplification in 1) has gone beyond my expectation :) The same could probably be done in mpfr.jl.
