### PR TITLE
Some fixes in Distributed 

### DIFF
--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -10,7 +10,7 @@ mutable struct WorkerConfig
 
     # Used when launching additional workers at a host
     count::Nullable{Union{Int, Symbol}}
-    exename::Nullable{AbstractString}
+    exename::Nullable{Union{AbstractString, Cmd}}
     exeflags::Nullable{Cmd}
 
     # External cluster managers can use this to store information at a per-worker level

--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -167,7 +167,7 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     portopt = ``
     if length(machine_def) == 2
         portstr = machine_def[2]
-        if !isinteger(portstr) || (p = parse(Int,portstr); p < 1 || p > 65535)
+        if !all(isdigit, portstr) || (p = parse(Int,portstr); p < 1 || p > 65535)
             msg = "invalid machine definition format string: invalid port format \"$machine_def\""
             throw(ArgumentError(msg))
         end

--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -259,8 +259,7 @@ Returns a port number `localport` such that `localhost:localport` connects to `h
 """
 function ssh_tunnel(user, host, bind_addr, port, sshflags)
     port = Int(port)
-    cnt  = 100
-    localport = next_tunnel_port()
+    cnt = ntries = 100
     # if we cannot do port forwarding, bail immediately
     # the connection is forwarded to `port` on the remote server over the local port `localport`
     # the -f option backgrounds the ssh session
@@ -269,15 +268,16 @@ function ssh_tunnel(user, host, bind_addr, port, sshflags)
     # If no connections are made within 60 seconds, ssh will exit and an error will be printed on the
     # process that launched the remote process.
     ssh = `ssh -T -a -x -o ExitOnForwardFailure=yes`
-    while !success(detach(`$ssh -f $sshflags $user@$host -L $localport:$bind_addr:$port sleep 60`)) && cnt > 0
+    while cnt > 0
         localport = next_tunnel_port()
+        if success(detach(`$ssh -f $sshflags $user@$host -L $localport:$bind_addr:$port sleep 60`))
+            return localport
+        end
         cnt -= 1
     end
-    if cnt == 0
-        throw(ErrorException(
-            "unable to create SSH tunnel after $cnt tries. No free port?"))
-    end
-    return localport
+
+    throw(ErrorException(
+        string("unable to create SSH tunnel after ", ntries, " tries. No free port?")))
 end
 
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -996,6 +996,18 @@ if is_unix() # aka have ssh
     @test length(new_pids) == 5
     test_n_remove_pids(new_pids)
 
+    print("\nkeyword arg exename\n")
+
+    for exename in [`$(joinpath(JULIA_HOME, Base.julia_exename()))`, "$(joinpath(JULIA_HOME, Base.julia_exename()))"]
+        for addp_func in [()->addprocs(["localhost"]; exename=exename, exeflags=cov_in_exeflags, sshflags=sshflags),
+                          ()->addprocs(1; exename=exename, exeflags=cov_in_exeflags)]
+
+            new_pids = addp_func()
+            @test length(new_pids) == 1
+            test_n_remove_pids(new_pids)
+        end
+    end
+
 end # unix-only
 end # full-test
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -887,7 +887,6 @@ wp = CachingPool(workers())
 clear!(wp)
 @test length(wp.map_obj2ref) == 0
 
-
 # The below block of tests are usually run only on local development systems, since:
 # - tests which print errors
 # - addprocs tests are memory intensive
@@ -950,7 +949,10 @@ if is_unix() # aka have ssh
     end
 
     print("\n\nTesting SSHManager. A minimum of 4GB of RAM is recommended.\n")
-    print("Please ensure sshd is running locally with passwordless login enabled.\n")
+    print("Please ensure: \n")
+    print("1) sshd is running locally with passwordless login enabled.\n")
+    print("2) Env variable USER is defined and is the ssh user.\n")
+    print("3) Port 9300 is not in use.\n")
 
     sshflags = `-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR `
     #Issue #9951
@@ -963,32 +965,37 @@ if is_unix() # aka have ssh
     end
 
     print("\nTesting SSH addprocs with $(length(hosts)) workers...\n")
-    new_pids = remotecall_fetch(1, hosts, sshflags) do h, sf
-        addprocs(h; exeflags=cov_in_exeflags, sshflags=sf)
-    end
+    new_pids = addprocs(hosts; exeflags=cov_in_exeflags, sshflags=sshflags)
     @test length(new_pids) == length(hosts)
     test_n_remove_pids(new_pids)
 
     print("\nMixed ssh addprocs with :auto\n")
-    new_pids = sort(remotecall_fetch(1, ["localhost", ("127.0.0.1", :auto), "localhost"], sshflags) do h, sf
-        addprocs(h; exeflags=cov_in_exeflags, sshflags=sf)
-    end)
+    new_pids = addprocs(["localhost", ("127.0.0.1", :auto), "localhost"]; sshflags=sshflags)
     @test length(new_pids) == (2 + Sys.CPU_CORES)
     test_n_remove_pids(new_pids)
 
     print("\nMixed ssh addprocs with numeric counts\n")
-    new_pids = sort(remotecall_fetch(1, [("localhost", 2), ("127.0.0.1", 2), "localhost"], sshflags) do h, sf
-        addprocs(h; exeflags=cov_in_exeflags, sshflags=sf)
-    end)
+    new_pids = addprocs([("localhost", 2), ("127.0.0.1", 2), "localhost"]; exeflags=cov_in_exeflags, sshflags=sshflags)
     @test length(new_pids) == 5
     test_n_remove_pids(new_pids)
 
     print("\nssh addprocs with tunnel\n")
-    new_pids = sort(remotecall_fetch(1, [("localhost", num_workers)], sshflags) do h, sf
-        addprocs(h; tunnel=true, sshflags=sf, exeflags=cov_in_exeflags)
-    end)
+    new_pids = addprocs([("localhost", num_workers)]; tunnel=true, exeflags=cov_in_exeflags, sshflags=sshflags)
     @test length(new_pids) == num_workers
     test_n_remove_pids(new_pids)
+
+    print("\nAll supported formats for hostname\n")
+    h1 = "localhost"
+    user = ENV["USER"]
+    h2 = "$user@$h1"
+    h3 = "$h2:22"
+    h4 = "$h3 $(string(getipaddr()))"
+    h5 = "$h4:9300"
+
+    new_pids = addprocs([h1, h2, h3, h4, h5]; exeflags=cov_in_exeflags, sshflags=sshflags)
+    @test length(new_pids) == 5
+    test_n_remove_pids(new_pids)
+
 end # unix-only
 end # full-test
 


### PR DESCRIPTION
- Fix bug in parsing port number from host spec. Closes #21630
- Fix wrong error message with ssh addprocs tunnel option (Discovered on Discourse - https://discourse.julialang.org/t/addprocs-remote-does-not-work-but-ssh-remote-julia-version-does-why/3400/10)
- SSHManager now supports keyword arg exename as a Cmd type. Discovered issue while working on https://github.com/JuliaLang/julia/pull/21652#discussion_r114075816