### PR TITLE
Macroexpand1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -100,7 +100,7 @@ Library improvements
     `ntuple`, `Base.literal_pow`, `sqrtm`, `lufact`, `lufact!`, `qrfact`, `qrfact!`,
     `cholfact`, `cholfact!`, `_broadcast!`, `reshape`, `cat` and `cat_t`.
 
-  * A new `macroexpand1` function and `@macroexpand1` macro for non recursive macro expansion ([#21662]).
+  * A new `@macroexpand1` macro for non recursive macro expansion ([#21662]).
 
 Compiler/Runtime improvements
 -----------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,8 @@ Library improvements
     `ntuple`, `Base.literal_pow`, `sqrtm`, `lufact`, `lufact!`, `qrfact`, `qrfact!`,
     `cholfact`, `cholfact!`, `_broadcast!`, `reshape`, `cat` and `cat_t`.
 
+  * A new `macroexpand1` function and `@macroexpand1` macro for non recursive macro expansion ([#21662]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -964,7 +964,6 @@ export
     expand,
     gensym,
     macroexpand,
-    macroexpand1,
     @macroexpand1,
     @macroexpand,
     parse,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -964,6 +964,8 @@ export
     expand,
     gensym,
     macroexpand,
+    macroexpand1,
+    @macroexpand1,
     @macroexpand,
     parse,
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -61,7 +61,7 @@ Takes the expression `x` and returns an equivalent expression with all macros re
 for executing in module `m`.
 The `recursive` keyword controls whether deeper levels of nested macros are also expanded.
 This is demonstrated in the example below:
-```julia
+```julia-repl
 julia> module M
            macro m1()
                42

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -59,8 +59,18 @@ expand(m::Module, x::ANY) = ccall(:jl_expand, Any, (Any, Any), x, m)
 
 Takes the expression `x` and returns an equivalent expression with all macros removed (expanded)
 for executing in module `m`.
+For non recursive expansion, see [`macroexpand1`](@ref).
+For more convenient interfaces, see [`@macroexpand`](@ref) and [`@macroexpand1`](@ref).
 """
 macroexpand(m::Module, x::ANY) = ccall(:jl_macroexpand, Any, (Any, Any), x, m)
+
+"""
+    macroexpand1(m, x)
+
+Like `macroexpand(m, x)`, but only macros that are directly
+called in `x` are expanded. Deeper levels of nested macrocalls are not expanded.
+"""
+macroexpand1(m::Module, x::ANY) = ccall(:jl_macroexpand1, Any, (Any, Any), x, m)
 
 """
     @macroexpand
@@ -98,6 +108,16 @@ With `@macroexpand` the expression expands where `@macroexpand` appears in the c
 """
 macro macroexpand(code)
     return :(macroexpand($__module__, $(QuoteNode(code))))
+end
+
+
+"""
+    @macroexpand1
+
+Macro version of [`macroexpand1`](@ref). See also [`@macroexpand`](@ref).
+"""
+macro macroexpand1(code)
+    return :(macroexpand1($__module__, $(QuoteNode(code))))
 end
 
 ## misc syntax ##

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -94,9 +94,12 @@ Return equivalent expression with all macros removed (expanded).
 
 There are differences between `@macroexpand` and [`macroexpand`](@ref).
 
-* While [`macroexpand`](@ref) takes a keyword argument `recursive`, `@macroexpand` is always recursive. For a non recursive macro version, see [`@macroexpand1`](@ref).
+* While [`macroexpand`](@ref) takes a keyword argument `recursive`, `@macroexpand`
+is always recursive. For a non recursive macro version, see [`@macroexpand1`](@ref).
 
-* While [`macroexpand`](@ref) has an explicit `module` argument, `@macroexpand` always expands with respect to the module in which it is called. This is best seen in the following example:
+* While [`macroexpand`](@ref) has an explicit `module` argument, `@macroexpand` always
+expands with respect to the module in which it is called.
+This is best seen in the following example:
 ```jldoctest
 julia> module M
            macro m()
@@ -119,7 +122,8 @@ julia> macro m()
 julia> M.f()
 (1, 1, 2)
 ```
-With `@macroexpand` the expression expands where `@macroexpand` appears in the code (module `M` in the example). With `macroexpand` the expression expands in the module given as the first argument.
+With `@macroexpand` the expression expands where `@macroexpand` appears in the code (module `M` in the example).
+With `macroexpand` the expression expands in the module given as the first argument.
 """
 macro macroexpand(code)
     return :(macroexpand($__module__, $(QuoteNode(code)), recursive=true))

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -276,7 +276,6 @@ Base.gc
 Base.gc_enable
 Base.macroexpand
 Base.@macroexpand
-Base.macroexpand1
 Base.@macroexpand1
 Base.expand
 Base.code_lowered

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -276,6 +276,8 @@ Base.gc
 Base.gc_enable
 Base.macroexpand
 Base.@macroexpand
+Base.macroexpand1
+Base.@macroexpand1
 Base.expand
 Base.code_lowered
 Base.@code_lowered

--- a/src/ast.c
+++ b/src/ast.c
@@ -987,6 +987,12 @@ JL_DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr, jl_module_t *inmodule)
     return jl_call_scm_on_ast("jl-macroexpand", expr, inmodule);
 }
 
+JL_DLLEXPORT jl_value_t *jl_macroexpand1(jl_value_t *expr, jl_module_t *inmodule)
+{
+    JL_TIMING(LOWERING);
+    return jl_call_scm_on_ast("jl-macroexpand-1", expr, inmodule);
+}
+
 // wrap expr in a thunk AST
 jl_code_info_t *jl_wrap_expr(jl_value_t *expr)
 {

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -225,6 +225,11 @@
   (parser-wrap (lambda ()
                  (julia-expand-macros expr))))
 
+(define (jl-macroexpand-1 expr)
+  (reset-gensyms)
+  (parser-wrap (lambda ()
+                 (julia-expand-macros-limited expr 1))))
+
 ; run whole frontend on a string. useful for testing.
 (define (fe str)
   (expand-toplevel-expr (julia-parse str)))

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -228,7 +228,7 @@
 (define (jl-macroexpand-1 expr)
   (reset-gensyms)
   (parser-wrap (lambda ()
-                 (julia-expand-macros-limited expr 1))))
+                 (julia-expand-macros expr 1))))
 
 ; run whole frontend on a string. useful for testing.
 (define (fe str)

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -466,12 +466,12 @@
 
 ;; macro expander entry point
 
-(define (julia-expand-macros-limited e max-depth)
+(define (julia-expand-macros e (max-depth -1))
   (cond ((= max-depth 0)   e)
         ((not (pair? e))     e)
         ((eq? (car e) 'quote)
          ;; backquote is essentially a built-in macro at the moment
-         (julia-expand-macros-limited (julia-bq-expand (cadr e) 0) max-depth))
+         (julia-expand-macros (julia-bq-expand (cadr e) 0) max-depth))
         ((eq? (car e) 'inert) e)
         ((eq? (car e) 'macrocall)
          ;; expand macro
@@ -484,9 +484,7 @@
                  (m    (cdr form)))
              ;; m is the macro's def module
              (rename-symbolic-labels
-              (julia-expand-macros-limited (resolve-expansion-vars form m) (- max-depth 1))))))
+              (julia-expand-macros (resolve-expansion-vars form m) (- max-depth 1))))))
         ((eq? (car e) 'module) e)
         (else
-         (map (lambda (ex) (julia-expand-macros-limited ex max-depth)) e))))
-
-(define (julia-expand-macros e) (julia-expand-macros-limited e -1))
+         (map (lambda (ex) (julia-expand-macros ex max-depth)) e))))

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -466,11 +466,12 @@
 
 ;; macro expander entry point
 
-(define (julia-expand-macros e)
-  (cond ((not (pair? e))     e)
+(define (julia-expand-macros-limited e max-depth)
+  (cond ((= max-depth 0)   e)
+        ((not (pair? e))     e)
         ((eq? (car e) 'quote)
          ;; backquote is essentially a built-in macro at the moment
-         (julia-expand-macros (julia-bq-expand (cadr e) 0)))
+         (julia-expand-macros-limited (julia-bq-expand (cadr e) 0) max-depth))
         ((eq? (car e) 'inert) e)
         ((eq? (car e) 'macrocall)
          ;; expand macro
@@ -483,8 +484,10 @@
                  (m    (cdr form)))
              ;; m is the macro's def module
              (rename-symbolic-labels
-              (julia-expand-macros
-               (resolve-expansion-vars form m))))))
+              (julia-expand-macros-limited (resolve-expansion-vars form m) (- max-depth 1))
+               ))))
         ((eq? (car e) 'module) e)
         (else
-         (map julia-expand-macros e))))
+         (map (lambda (ex) (julia-expand-macros-limited ex max-depth) ) e))))
+
+(define (julia-expand-macros e) (julia-expand-macros-limited e -1))

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -484,10 +484,9 @@
                  (m    (cdr form)))
              ;; m is the macro's def module
              (rename-symbolic-labels
-              (julia-expand-macros-limited (resolve-expansion-vars form m) (- max-depth 1))
-               ))))
+              (julia-expand-macros-limited (resolve-expansion-vars form m) (- max-depth 1))))))
         ((eq? (car e) 'module) e)
         (else
-         (map (lambda (ex) (julia-expand-macros-limited ex max-depth) ) e))))
+         (map (lambda (ex) (julia-expand-macros-limited ex max-depth)) e))))
 
 (define (julia-expand-macros e) (julia-expand-macros-limited e -1))

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -505,17 +505,18 @@ macro nest2b(code)
     :(@nest1($code); @nest1($code))
 end
 
-@testset "macroexpand1, @macroexpand1" begin
+@testset "@macroexpand1" begin
     M = @__MODULE__
+    _macroexpand1(ex) = macroexpand(M, ex, recursive=false)
     ex = :(@nest1 42)
-    @test macroexpand1(M,ex) == macroexpand(M,ex)
+    @test _macroexpand1(ex) == macroexpand(M,ex)
     ex = :(@nest2 42)
-    @test macroexpand1(M,ex) != macroexpand(M,ex)
-    @test macroexpand1(M,macroexpand1(M,ex)) == macroexpand(M,ex)
+    @test _macroexpand1(ex) != macroexpand(M,ex)
+    @test _macroexpand1(_macroexpand1(ex)) == macroexpand(M,ex)
     ex = :(@nest2b 42)
-    @test macroexpand1(M,ex) != macroexpand(M,ex)
-    @test macroexpand1(M,macroexpand1(M,ex)) == macroexpand(M,ex)
-    @test (@macroexpand1 @nest2b 42) == macroexpand1(M,ex)
+    @test _macroexpand1(ex) != macroexpand(M,ex)
+    @test _macroexpand1(_macroexpand1(ex)) == macroexpand(M, ex)
+    @test (@macroexpand1 @nest2b 42) == _macroexpand1(ex)
 end
 
 foo_9965(x::Float64; w=false) = x

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -493,6 +493,31 @@ let
     @test (@macroexpand @seven_dollar 1+$x) == :(1 + $(Expr(:$, :x)))
 end
 
+macro nest1(code)
+    code
+end
+
+macro nest2(code)
+    :(@nest1 $code)
+end
+
+macro nest2b(code)
+    :(@nest1($code); @nest1($code))
+end
+
+@testset "macroexpand1, @macroexpand1" begin
+    M = @__MODULE__
+    ex = :(@nest1 42)
+    @test macroexpand1(M,ex) == macroexpand(M,ex)
+    ex = :(@nest2 42)
+    @test macroexpand1(M,ex) != macroexpand(M,ex)
+    @test macroexpand1(M,macroexpand1(M,ex)) == macroexpand(M,ex)
+    ex = :(@nest2b 42)
+    @test macroexpand1(M,ex) != macroexpand(M,ex)
+    @test macroexpand1(M,macroexpand1(M,ex)) == macroexpand(M,ex)
+    @test (@macroexpand1 @nest2b 42) == macroexpand1(M,ex)
+end
+
 foo_9965(x::Float64; w=false) = x
 foo_9965(x::Int) = 2x
 


### PR DESCRIPTION
This PR adds a non recursive variant of `macroexpand`, see #19365. What is the preferred API?

* `macroexpand1(ex)`, `@macroexpand1(ex)` ?
* `macroexpand(ex, recursive::Bool)`, `@macroexpand(ex, recursive)` ?

Both? Something else? For REPL usage I think `@macroexpand1` is the most convenient, albeit a bit cryptic.