### PR TITLE
Add libgit2 patch to allow NULL refspec in git_remote_push

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -99,6 +99,11 @@ $(LIBGIT2_SRC_PATH)/libgit2-free-config.patch-applied: $(LIBGIT2_SRC_PATH)/sourc
 		patch -p1 -f < $(SRCDIR)/patches/libgit2-free-config.patch
 	echo 1 > $@
 
+$(LIBGIT2_SRC_PATH)/libgit2-remote-push-NULL.patch-applied: $(LIBGIT2_SRC_PATH)/source-extracted | $(LIBGIT2_SRC_PATH)/libgit2-free-config.patch-applied
+	cd $(LIBGIT2_SRC_PATH) && \
+		patch -p1 -f < $(SRCDIR)/patches/libgit2-remote-push-NULL.patch
+	echo 1 > $@
+
 $(build_datarootdir)/julia/cert.pem: $(CERTFILE)
 	mkdir -p $(build_datarootdir)/julia
 	-cp $(CERTFILE) $@
@@ -110,7 +115,8 @@ $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: \
 	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-writer-fix.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-verify.patch-applied \
 	$(LIBGIT2_SRC_PATH)/libgit2-gitconfig-symlink.patch-applied \
-	$(LIBGIT2_SRC_PATH)/libgit2-free-config.patch-applied
+	$(LIBGIT2_SRC_PATH)/libgit2-free-config.patch-applied \
+	$(LIBGIT2_SRC_PATH)/libgit2-remote-push-NULL.patch-applied
 
 ifneq ($(CERTFILE),)
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: $(build_datarootdir)/julia/cert.pem

--- a/deps/patches/libgit2-remote-push-NULL.patch
+++ b/deps/patches/libgit2-remote-push-NULL.patch
@@ -1,0 +1,26 @@
+From 90cdf44ffb7c78cb9d36709f8a07a216e06bd919 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sat, 29 Apr 2017 13:00:07 -0400
+Subject: [PATCH] Allow NULL refspec in git_remote_push
+
+Since this is allowed in `git_remote_upload`
+---
+ src/remote.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/remote.c b/src/remote.c
+index d3132f75c..4cbc45eda 100644
+--- a/src/remote.c
++++ b/src/remote.c
+@@ -2412,7 +2412,7 @@ int git_remote_push(git_remote *remote, const git_strarray *refspecs, const git_
+ 		proxy = &opts->proxy_opts;
+ 	}
+ 
+-	assert(remote && refspecs);
++	assert(remote);
+ 
+ 	if ((error = git_remote_connect(remote, GIT_DIRECTION_PUSH, cbs, proxy, custom_headers)) < 0)
+ 		return error;
+-- 
+2.12.2
+


### PR DESCRIPTION
libgit2/libgit2#4225 is accepted upstream.

Fix #21639