### PR TITLE
WIP: don't use single quotes in displaying Cmd objects on Windows

### DIFF
--- a/base/shell.jl
+++ b/base/shell.jl
@@ -147,7 +147,7 @@ function print_shell_word(io::IO, word::AbstractString, special::AbstractString 
     end
     if !has_special
         print(io, word)
-    elseif !has_single
+    elseif !has_single && is_unix()
         print(io, '\'', word, '\'')
     else
         print(io, '"')


### PR DESCRIPTION
ref https://github.com/JuliaLang/julia/pull/21619#issuecomment-298097186, Windows cmd doesn't understand single quotes so Julia Cmd objects do not get displayed in a way that can be copy-pasted on the default command line.

WIP because changing the behavior of `print_shell_word` changes the output of `shell_escape`, and we might want to make this strictly a display change rather than a behavior one. And could use tests.