### PR TITLE
[release-0.5] backport mapreduce fixes

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -93,15 +93,25 @@ foldr(op, itr) = mapfoldr(identity, op, itr)
 
 ## reduce & mapreduce
 
+# `mapreduce_impl()` is called by `mapreduce()` (via `_mapreduce()`, when `A`
+# supports linear indexing) and does actual calculations (for `A[ifirst:ilast]` subset).
+# For efficiency, no parameter validity checks are done, it's the caller responsibility.
+# `ifirst:ilast` range is assumed to be a valid non-empty subset of `A` indices.
+
+# This is a generic implementation of `mapreduce_impl()`,
+# certain `op` (e.g. `min` and `max`) may have their own specialized versions.
 function mapreduce_impl(f, op, A::AbstractArray, ifirst::Integer, ilast::Integer, blksize::Int=pairwise_blocksize(f, op))
-    if ifirst + blksize > ilast
+    if ifirst == ilast
+        @inbounds a1 = A[ifirst]
+        return r_promote(op, f(a1))
+    elseif ifirst + blksize > ilast
         # sequential portion
-        fx1 = r_promote(op, f(A[ifirst]))
-        fx2 = r_promote(op, f(A[ifirst + 1]))
-        v = op(fx1, fx2)
+        @inbounds a1 = A[ifirst]
+        @inbounds a2 = A[ifirst+1]
+        v = op(r_promote(op, f(a1)), r_promote(op, f(a2)))
         @simd for i = ifirst + 2 : ilast
-            @inbounds Ai = A[i]
-            v = op(v, f(Ai))
+            @inbounds ai = A[i]
+            v = op(v, f(ai))
         end
         return v
     else
@@ -148,26 +158,8 @@ _mapreduce(f, op, A::AbstractArray) = _mapreduce(f, op, linearindexing(A), A)
 
 function _mapreduce{T}(f, op, ::LinearFast, A::AbstractArray{T})
     inds = linearindices(A)
-    n = length(inds)
-    @inbounds begin
-        if n == 0
-            return mr_empty(f, op, T)
-        elseif n == 1
-            return r_promote(op, f(A[inds[1]]))
-        elseif n < 16
-            fx1 = r_promote(op, f(A[inds[1]]))
-            fx2 = r_promote(op, f(A[inds[2]]))
-            s = op(fx1, fx2)
-            i = inds[2]
-            while i < last(inds)
-                Ai = A[i+=1]
-                s = op(s, f(Ai))
-            end
-            return s
-        else
-            return mapreduce_impl(f, op, A, first(inds), last(inds))
-        end
-    end
+    length(inds) > 0 ? mapreduce_impl(f, op, A, first(inds), last(inds)) :
+                       mr_empty(f, op, T)
 end
 
 _mapreduce{T}(f, op, ::LinearSlow, A::AbstractArray{T}) = mapfoldl(f, op, A)
@@ -273,17 +265,17 @@ function mapreduce_impl(f, op::Union{typeof(scalarmax),
                                      typeof(min)},
                         A::AbstractArray, first::Int, last::Int)
     # locate the first non NaN number
-    v = f(A[first])
+    @inbounds a1 = A[first]
+    v = f(a1)
     i = first + 1
     while v != v && i <= last
-        @inbounds Ai = A[i]
-        v = f(Ai)
+        @inbounds ai = A[i]
+        v = f(ai)
         i += 1
     end
     while i <= last
-        @inbounds Ai = A[i]
-        x = f(Ai)
-        v = op(v, x)
+        @inbounds ai = A[i]
+        v = op(v, f(ai))
         i += 1
     end
     v

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -158,8 +158,25 @@ _mapreduce(f, op, A::AbstractArray) = _mapreduce(f, op, linearindexing(A), A)
 
 function _mapreduce{T}(f, op, ::LinearFast, A::AbstractArray{T})
     inds = linearindices(A)
-    length(inds) > 0 ? mapreduce_impl(f, op, A, first(inds), last(inds)) :
-                       mr_empty(f, op, T)
+    n = length(inds)
+    if n == 0
+        return mr_empty(f, op, T)
+    elseif n == 1
+        @inbounds a1 = A[inds[1]]
+        return r_promote(op, f(a1))
+    elseif n < 16 # process short array here
+        @inbounds i = inds[1]
+        @inbounds a1 = A[i]
+        @inbounds a2 = A[i+=1]
+        s = op(r_promote(op, f(a1)), r_promote(op, f(a2)))
+        while i < last(inds)
+            @inbounds Ai = A[i+=1]
+            s = op(s, f(Ai))
+        end
+        return s
+    else
+        return mapreduce_impl(f, op, A, first(inds), last(inds))
+    end
 end
 
 _mapreduce{T}(f, op, ::LinearSlow, A::AbstractArray{T}) = mapfoldl(f, op, A)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -22,14 +22,37 @@
 @test Base.mapfoldr(abs2, -, 2:5) == -14
 @test Base.mapfoldr(abs2, -, 10, 2:5) == -4
 
-# reduce & mapreduce
+# reduce
 @test reduce((x,y)->"($x+$y)", 9:11) == "((9+10)+11)"
 @test reduce(max, [8 6 7 5 3 0 9]) == 9
 @test reduce(+, 1000, 1:5) == (1000 + 1 + 2 + 3 + 4 + 5)
 @test reduce(+,1) == 1
 
+# mapreduce
 @test mapreduce(-, +, [-10 -9 -3]) == ((10 + 9) + 3)
 @test mapreduce((x)->x[1:3], (x,y)->"($x+$y)", ["abcd", "efgh", "01234"]) == "((abc+efg)+012)"
+
+# mapreduce() for 1- 2- and n-sized blocks (PR #19325)
+@test mapreduce(-, +, [-10]) == 10
+@test mapreduce(abs2, +, [-9, -3]) == 81 + 9
+@test mapreduce(-, +, [-9, -3, -4, 8, -2]) == (9 + 3 + 4 - 8 + 2)
+@test mapreduce(-, +, collect(linspace(1.0, 10000.0, 10000))) == -50005000.0
+# mapreduce() type stability
+@test typeof(mapreduce(*, +, Int8[10])) ===
+      typeof(mapreduce(*, +, Int8[10, 11])) ===
+      typeof(mapreduce(*, +, Int8[10, 11, 12, 13]))
+@test typeof(mapreduce(*, +, Float32[10.0])) ===
+      typeof(mapreduce(*, +, Float32[10, 11])) ===
+      typeof(mapreduce(*, +, Float32[10, 11, 12, 13]))
+# mapreduce() type stability when f supports empty collections
+@test typeof(mapreduce(abs, +, Int8[])) ===
+      typeof(mapreduce(abs, +, Int8[10])) ===
+      typeof(mapreduce(abs, +, Int8[10, 11])) ===
+      typeof(mapreduce(abs, +, Int8[10, 11, 12, 13]))
+@test typeof(mapreduce(abs, +, Float32[])) ===
+      typeof(mapreduce(abs, +, Float32[10])) ===
+      typeof(mapreduce(abs, +, Float32[10, 11])) ===
+      typeof(mapreduce(abs, +, Float32[10, 11, 12, 13]))
 
 # sum
 


### PR DESCRIPTION
Backport #19325 and #21167 to 0.5 branch (I hope it's not too late for #21684):
- fix `mapreduce_impl()` for 1-element ranges
- avoid `@inbounds` propagating into user-specified `f`
- the backport doesn't include the changes of `mapreduce(f, min/max)` behaviour introduced in 0.6