### PR TITLE
Recover some lost build flags for openblas

### DIFF
--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -4,7 +4,7 @@ OPENBLAS_GIT_URL := git://github.com/xianyi/OpenBLAS.git
 OPENBLAS_TAR_URL = https://api.github.com/repos/xianyi/OpenBLAS/tarball/$1
 $(eval $(call git-external,openblas,OPENBLAS,,,$(BUILDDIR)))
 
-OPENBLAS_BUILD_OPTS := CC="$(CC)" FC="$(FC)" RANLIB="$(RANLIB)" FFLAGS="$(FFLAGS) $(JFFLAGS)" TARGET=$(OPENBLAS_TARGET_ARCH) BINARY=$(BINARY)
+OPENBLAS_BUILD_OPTS := CC="$(CC)" FC="$(FC)" RANLIB="$(RANLIB)" TARGET=$(OPENBLAS_TARGET_ARCH) BINARY=$(BINARY)
 
 # Thread support
 ifeq ($(OPENBLAS_USE_THREAD), 1)
@@ -46,8 +46,8 @@ $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled: | $(BUILDDIR)/objconv/build-comp
 endif
 endif
 
-OPENBLAS_FFLAGS :=
-OPENBLAS_CFLAGS :=
+OPENBLAS_FFLAGS := $(JFFLAGS)
+OPENBLAS_CFLAGS := -O2
 
 # Decide whether to build for 32-bit or 64-bit arch
 ifneq ($(BUILD_OS),$(OS))
@@ -56,14 +56,14 @@ endif
 ifeq ($(OS),WINNT)
 ifneq ($(ARCH),x86_64)
 ifneq ($(USECLANG),1)
-OPENBLAS_CFLAGS += $(CFLAGS) -mincoming-stack-boundary=2
+OPENBLAS_CFLAGS += -mincoming-stack-boundary=2
 endif
-OPENBLAS_FFLAGS += $(FFLAGS) -mincoming-stack-boundary=2
+OPENBLAS_FFLAGS += -mincoming-stack-boundary=2
 endif
 endif
 
-OPENBLAS_BUILD_OPTS += CFLAGS="$(OPENBLAS_CFLAGS)"
-OPENBLAS_BUILD_OPTS += FFLAGS="$(OPENBLAS_FFLAGS)"
+OPENBLAS_BUILD_OPTS += CFLAGS="$(CFLAGS) $(OPENBLAS_CFLAGS)"
+OPENBLAS_BUILD_OPTS += FFLAGS="$(FFLAGS) $(OPENBLAS_FFLAGS)"
 
 # Debug OpenBLAS
 ifeq ($(OPENBLAS_DEBUG), 1)


### PR DESCRIPTION
... that went lost in #20806.

Fix #21624 

This should fix the following regressions from 0.5 (found in #20993):

| `["linalg","factorization",("eig","Matrix",1024)]` | 1.94 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("eig","Matrix",256)]` | 2.29 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("eig","SymTridiagonal",1024)]` | 1.59 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("eig","SymTridiagonal",256)]` | 1.61 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("eigfact","Matrix",1024)]` | 1.95 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("eigfact","Matrix",256)]` | 2.28 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("eigfact","SymTridiagonal",1024)]` | 1.59 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("eigfact","SymTridiagonal",256)]` | 1.61 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("lu","Tridiagonal",1024)]` | 1.70 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("schur","Matrix",1024)]` | 2.10 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("schur","Matrix",256)]` | 2.36 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("schurfact","Matrix",1024)]` | 2.09 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("schurfact","Matrix",256)]` | 2.36 (45%) :x: | 1.00 (1%)  |
| `["linalg","factorization",("svd","Bidiagonal",1024)]` | 1.46 (45%) :x: | 1.00 (1%)  |

First trip to makefile-land, but at least it works out locally.

Found this from the following. On 0.5.1:
`make -C build/openblas-12ab1804b6ebcd38b26960d65d254314d8bc33d6/   CC=gcc -m64 FC=gfortran -m64 RANLIB=ranlib FFLAGS= -O2 -fPIC TARGET= BINARY=64 USE_THREAD=1 GEMM_MULTITHREADING_THRESHOLD=50 NUM_THREADS=16 NO_AFFINITY=1 DYNAMIC_ARCH=1 INTERFACE64=1 SYMBOLSUFFIX=64_ LIBPREFIX=libopenblas64_ MAKE_NB_JOBS=0`

and master:
`make -C scratch/openblas-85636ff1a015d04d3a8f960bc644b85ee5157135/ CC=gcc -m64 FC=gfortran -m64 RANLIB=ranlib FFLAGS= -O2 -fPIC TARGET= BINARY=64 USE_THREAD=1 GEMM_MULTITHREADING_THRESHOLD=50 NUM_THREADS=16 NO_AFFINITY=1 DYNAMIC_ARCH=1 INTERFACE64=1 SYMBOLSUFFIX=64_ LIBPREFIX=libopenblas64_ CFLAGS= FFLAGS= MAKE_NB_JOBS=0`

Note the `FFLAGS=` in the end of the master build command overriding `FFLAGS= -O2 -fPIC` in the beginning of it.