### PR TITLE
Set RPATH for private libdirs on FreeBSD

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1,4 +1,5 @@
 # -*- mode: makefile-gmake -*-
+# vi:syntax=make
 
 ## Note:
 ##   It is generally preferable to change these options, for

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ ifeq ($(OS), Darwin)
 		install_name_tool -rpath @executable_path/$(build_private_libdir_rel) @executable_path/$(private_libdir_rel) $$julia; \
 		install_name_tool -add_rpath @executable_path/$(build_libdir_rel) @executable_path/$(libdir_rel) $$julia; \
 	done
-else ifeq ($(OS), Linux)
+else ifneq (,$(findstring $(OS),Linux FreeBSD))
 	for julia in $(DESTDIR)$(bindir)/julia* ; do \
 		patchelf --set-rpath '$$ORIGIN/$(private_libdir_rel):$$ORIGIN/$(libdir_rel)' $$julia; \
 	done

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -58,7 +58,7 @@ DEP_LIBS += osxunwind
 endif
 endif
 
-ifeq ($(OS), Linux)
+ifneq (,$(findstring $(OS),Linux FreeBSD))
 ifeq ($(USE_SYSTEM_PATCHELF), 0)
 DEP_LIBS += patchelf
 PATCHELF:=$(build_depsbindir)/patchelf


### PR DESCRIPTION
Currently this is only done on Linux, but it's also applicable for FreeBSD.