### PR TITLE
fix finalizer's doc

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1637,10 +1637,11 @@ true
 issubtype(type1, type2)
 
 """
-    finalizer(x, function)
+    finalizer(x, f)
 
 Register a function `f(x)` to be called when there are no program-accessible references to
-`x`. The behavior of this function is unpredictable if `x` is of a bits type.
+`x`. The type of `x` must be a `mutable struct`, otherwise the behavior of this function is
+unpredictable.
 """
 finalizer
 


### PR DESCRIPTION
While I'm at it:  "x is of a bits type." is equivalent to `isbits(typeof(x)) == true` right? If so I would like to add this clarification.