### PR TITLE
Switch to dash for list default in docstrings

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -733,7 +733,7 @@ for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7 of Hyndman
     handling of missing data, the `DataArrays.jl` package is recommended. `quantile` will
     throw an `ArgumentError` in the presence of `NaN` values in the data array.
 
-* Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
+- Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
   *The American Statistician*, Vol. 50, No. 4, pp. 361-365
 """
 quantile(v::AbstractVector, p; sorted::Bool=false) =

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -15,9 +15,9 @@ end
 Compute the amount of memory used by all unique objects reachable from the argument.
 
 # Keyword Arguments
-* `exclude`: specifies the types of objects to exclude from the traversal.
-* `chargeall`: specifies the types of objects to always charge the size of all of their fields,
-               even if those fields would normally be excluded.
+- `exclude`: specifies the types of objects to exclude from the traversal.
+- `chargeall`: specifies the types of objects to always charge the size of all of their
+  fields, even if those fields would normally be excluded.
 """
 function summarysize(obj::ANY;
                      exclude::ANY = Union{DataType, TypeName, Method},

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -69,15 +69,15 @@ As in the example above, we recommend following some simple conventions when wri
    description of the function's purpose. An argument list would only repeat information already
    provided elsewhere. However, providing an argument list can be a good idea for complex functions
    with many arguments (in particular keyword arguments). In that case, insert it after the general
-   description of the function, under an `# Arguments` header, with one `*` bullet for each argument.
+   description of the function, under an `# Arguments` header, with one `-` bullet for each argument.
    The list should mention the types and default values (if any) of the arguments:
 
    ```julia
    """
    ...
    # Arguments
-   * `n::Integer`: the number of elements to compute.
-   * `dim::Integer=1`: the dimensions along which to perform the computation.
+   - `n::Integer`: the number of elements to compute.
+   - `dim::Integer=1`: the dimensions along which to perform the computation.
    ...
    """
    ```


### PR DESCRIPTION
When reading raw markdown I find it easier to distinguish dashes from asterisks after a heading. The following unrealistic example illustrates the point when visually looking for headings:

```
# Arguments
* `n::Integer`: the number of elements to compute.
* `dim::Integer=1`: the dimensions along which to perform the computation.
# Returns
* `Integer`: the result of the computation.
```

```
# Arguments
- `n::Integer`: the number of elements to compute.
- `dim::Integer=1`: the dimensions along which to perform the computation.
# Returns
- `Integer`: the result of the computation.
```

Note that `-` and `*` are both rendered as `•` in the help prompt and in the manual.