### PR TITLE
fix serialization of multiple global bindings to the same object in a closure

### DIFF
--- a/base/distributed/clusterserialize.jl
+++ b/base/distributed/clusterserialize.jl
@@ -143,7 +143,7 @@ function serialize_global_from_main(s::ClusterSerializer, sym)
             end
         end
     end
-    record_v && (s.glbs_sent[oid] = hash(v))
+    record_v && (s.glbs_sent[oid] = hash(sym, hash(v)))
 
     serialize(s, isconst(Main, sym))
     serialize(s, v)

--- a/base/distributed/clusterserialize.jl
+++ b/base/distributed/clusterserialize.jl
@@ -114,7 +114,7 @@ function syms_2b_sent(s::ClusterSerializer, identifier)
             oid = object_id(v)
             if haskey(s.glbs_sent, oid)
                 # We have sent this object before, see if it has changed.
-                s.glbs_sent[oid] != hash(v) && push!(lst, sym)
+                s.glbs_sent[oid] != hash(sym, hash(v)) && push!(lst, sym)
             else
                 push!(lst, sym)
             end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1361,9 +1361,9 @@ end
 # Different global bindings to the same object
 global v3 = ones(10)
 global v4 = v3
-@test remotecall_fetch(isdefined, id_other, :v3) == true
-@test remotecall_fetch(isdefined, id_other, :v4) == true
 @test remotecall_fetch(()->v3, id_other) == remotecall_fetch(()->v4, id_other)
+@test remotecall_fetch(()->isdefined(Main, :v3), id_other)
+@test remotecall_fetch(()->isdefined(Main, :v4), id_other)
 
 # Test that a global is not being repeatedly serialized when
 # a) referenced multiple times in the closure

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1358,6 +1358,13 @@ for i in 1:5
     @test remotecall_fetch(()->v2, id_other) == v2
 end
 
+# Different global bindings to the same object
+global v3 = ones(10)
+global v4 = v3
+@test remotecall_fetch(isdefined, id_other, :v3) == true
+@test remotecall_fetch(isdefined, id_other, :v4) == true
+@test remotecall_fetch(()->v3, id_other) == remotecall_fetch(()->v4, id_other)
+
 # Test that a global is not being repeatedly serialized when
 # a) referenced multiple times in the closure
 # b) hash value has not changed.


### PR DESCRIPTION
This allows for the following 
```
A = B = ones(10)
remotecall_fetch(()->A, 2)
remotecall_fetch(()->B, 2)
```

On master this results in an error since `B` would not have been serialized as `hash(A) == hash(B)`.

However now, on the calling node both A and B point to the same object, while on the remote node they will be pointing to different objects.