### PR TITLE
Use A'A instead of [0 A;A' 0] in svds.

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -177,8 +177,8 @@ function _eigs(A, B;
     T = eltype(A)
     iscmplx = T <: Complex
     isgeneral = B !== I
-    sym = issymmetric(A) && issymmetric(B) && !iscmplx
-    nevmax=sym ? n-1 : n-2
+    sym = !iscmplx && issymmetric(A) && issymmetric(B)
+    nevmax = sym ? n-1 : n-2
     if nevmax <= 0
         throw(ArgumentError("input matrix A is too small. Use eigfact instead."))
     end
@@ -299,29 +299,49 @@ end
 
 
 ## svds
-### Restrict operator to BlasFloat because ARPACK only supports that. Loosen restriction
-### when we switch to our own implementation
-mutable struct SVDOperator{T<:BlasFloat,S} <: AbstractArray{T, 2}
+struct SVDAugmented{T,S} <: AbstractArray{T, 2}
     X::S
-    m::Int
-    n::Int
-    SVDOperator{T,S}(X::AbstractMatrix) where {T<:BlasFloat,S} = new(X, size(X, 1), size(X, 2))
+    SVDAugmented{T,S}(X::AbstractMatrix) where {T,S} = new(X)
 end
 
-function SVDOperator(A::AbstractMatrix{T}) where T
+function SVDAugmented(A::AbstractMatrix{T}) where T
     Tnew = typeof(zero(T)/sqrt(one(T)))
     Anew = convert(AbstractMatrix{Tnew}, A)
-    SVDOperator{Tnew,typeof(Anew)}(Anew)
+    SVDAugmented{Tnew,typeof(Anew)}(Anew)
 end
 
-function A_mul_B!(u::StridedVector{T}, s::SVDOperator{T}, v::StridedVector{T}) where T
-    a, b = s.m, length(v)
-    A_mul_B!(view(u,1:a), s.X, view(v,a+1:b)) # left singular vector
-    Ac_mul_B!(view(u,a+1:b), s.X, view(v,1:a)) # right singular vector
-    u
+function A_mul_B!(y::StridedVector{T}, A::SVDAugmented{T}, x::StridedVector{T}) where T
+    m, mn = size(A.X, 1), length(x)
+    A_mul_B!( view(y, 1:m), A.X, view(x, m + 1:mn)) # left singular vector
+    Ac_mul_B!(view(y, m + 1:mn), A.X, view(x, 1:m)) # right singular vector
+    return y
 end
-size(s::SVDOperator)  = s.m + s.n, s.m + s.n
-issymmetric(s::SVDOperator) = true
+size(A::SVDAugmented)  = ((+)(size(A.X)...), (+)(size(A.X)...))
+ishermitian(A::SVDAugmented) = true
+
+struct AtA_or_AAt{T,S} <: AbstractArray{T, 2}
+    A::S
+    buffer::Vector{T}
+end
+
+function AtA_or_AAt(A::AbstractMatrix{T}) where T
+    Tnew = typeof(zero(T)/sqrt(one(T)))
+    Anew = convert(AbstractMatrix{Tnew}, A)
+    AtA_or_AAt{Tnew,typeof(Anew)}(Anew, Vector{Tnew}(max(size(A)...)))
+end
+
+function A_mul_B!(y::StridedVector{T}, A::AtA_or_AAt{T}, x::StridedVector{T}) where T
+    if size(A.A, 1) >= size(A.A, 2)
+        A_mul_B!(A.buffer, A.A, x)
+        return Ac_mul_B!(y, A.A, A.buffer)
+    else
+        Ac_mul_B!(A.buffer, A.A, x)
+        return A_mul_B!(y, A.A, A.buffer)
+    end
+end
+size(A::AtA_or_AAt) = ntuple(i -> min(size(A.A)...), Val{2})
+ishermitian(s::AtA_or_AAt) = true
+
 
 svds(A::AbstractMatrix{<:BlasFloat}; kwargs...) = _svds(A; kwargs...)
 svds(A::AbstractMatrix{BigFloat}; kwargs...) = throw(MethodError(svds, Any[A, kwargs...]))
@@ -331,7 +351,7 @@ function svds(A::AbstractMatrix{T}; kwargs...) where T
 end
 
 """
-    svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000, ncv=2*nsv, u0=zeros((0,)), v0=zeros((0,))) -> (SVD([left_sv,] s, [right_sv,]), nconv, niter, nmult, resid)
+    svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000, ncv=2*nsv, v0=zeros((0,))) -> (SVD([left_sv,] s, [right_sv,]), nconv, niter, nmult, resid)
 
 Computes the largest singular values `s` of `A` using implicitly restarted Lanczos
 iterations derived from [`eigs`](@ref).
@@ -348,8 +368,7 @@ iterations derived from [`eigs`](@ref).
 * `tol`: tolerance, see [`eigs`](@ref).
 * `maxiter`: Maximum number of iterations, see [`eigs`](@ref). Default: 1000.
 * `ncv`: Maximum size of the Krylov subspace, see [`eigs`](@ref) (there called `nev`). Default: `2*nsv`.
-* `u0`: Initial guess for the first left Krylov vector. It may have length `m` (the first dimension of `A`), or 0.
-* `v0`: Initial guess for the first right Krylov vector. It may have length `n` (the second dimension of `A`), or 0.
+* `v0`: Initial guess for the first Krylov vector. It may have length `min(size(A)...)`, or 0.
 
 **Outputs**
 
@@ -374,48 +393,45 @@ julia> s[:S]
 
 !!! note "Implementation"
     `svds(A)` is formally equivalent to calling [`eigs`](@ref) to perform implicitly restarted
-    Lanczos tridiagonalization on the Hermitian matrix
-    ``\\begin{pmatrix} 0 & A^\\prime \\\\ A & 0 \\end{pmatrix}``, whose eigenvalues are
-    plus and minus the singular values of ``A``.
+    Lanczos tridiagonalization on the Hermitian matrix ``A^\\prime A`` or ``AA^\\prime`` such
+    that the size is smallest.
 """
 svds(A; kwargs...) = _svds(A; kwargs...)
-function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000, ncv::Int = 2*nsv, u0::Vector=zeros(eltype(X),(0,)), v0::Vector=zeros(eltype(X),(0,)))
+function _svds(X; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000, ncv::Int = 2*nsv, v0::Vector=zeros(eltype(X),(0,)))
     if nsv < 1
         throw(ArgumentError("number of singular values (nsv) must be ≥ 1, got $nsv"))
     end
     if nsv > minimum(size(X))
         throw(ArgumentError("number of singular values (nsv) must be ≤ $(minimum(size(X))), got $nsv"))
     end
-    m,n = size(X)
+    m, n = size(X)
     otype = eltype(X)
-    padv0 = zeros(eltype(X),(0,))
     if length(v0) ∉ [0,n]
         throw(DimensionMismatch("length of v0, the guess for the starting right Krylov vector, must be 0, or $n, got $(length(v0))"))
     end
-    if length(u0) ∉ [0,m]
-        throw(DimensionMismatch("length of u0, the guess for the starting left Krylov vector, must be 0, or $m, got $(length(u0))"))
-    end
-    if length(v0) == n && length(u0) == m
-        padv0 = [u0; v0]
-    elseif length(v0) == n && length(u0) == 0
-        padv0 = [zeros(otype,m); v0]
-    elseif length(v0) == 0 && length(u0) == m
-        padv0 = [u0; zeros(otype,n) ]
-    end
-    ex    = eigs(SVDOperator(X), I; ritzvec = ritzvec, nev = ncv, tol = tol, maxiter = maxiter, v0=padv0)
-    ind   = [1:2:ncv;]
-    sval  = abs.(ex[1][ind])
+    ex    = eigs(AtA_or_AAt(X), I; which = :LM, ritzvec = ritzvec, nev = nsv, tol = tol, maxiter = maxiter, v0=v0)
+    # ind   = [1:2:ncv;]
+    # sval  = abs.(ex[1][ind])
 
+    svals = sqrt.(real.(ex[1]))
     if ritzvec
         # calculating singular vectors
-        left_sv  = sqrt(2) * ex[2][ 1:size(X,1),     ind ] .* sign.(ex[1][ind]')
-        right_sv = sqrt(2) * ex[2][ size(X,1)+1:end, ind ]
-        return (SVD(left_sv, sval, right_sv'), ex[3], ex[4], ex[5], ex[6])
+        # left_sv  = sqrt(2) * ex[2][ 1:size(X,1),     ind ] .* sign.(ex[1][ind]')
+        if size(X, 1) >= size(X, 2)
+            V = ex[2]
+            U = qr(scale!(X*V, inv.(svals)))[1]
+        else
+            U = ex[2]
+            V = qr(scale!(X'U, inv.(svals)))[1]
+        end
+
+        # right_sv = sqrt(2) * ex[2][ size(X,1)+1:end, ind ]
+        return (SVD(U, svals, V'), ex[3], ex[4], ex[5], ex[6])
     else
         #The sort is necessary to work around #10329
-        return (SVD(zeros(eltype(sval), n, 0),
-                    sort!(sval, by=real, rev=true),
-                    zeros(eltype(sval), 0, m)),
+        return (SVD(zeros(eltype(svals), n, 0),
+                    svals,
+                    zeros(eltype(svals), 0, m)),
                     ex[2], ex[3], ex[4], ex[5])
     end
 end

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -149,7 +149,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::String,
         end
 
         p = sortperm(dmap(d), rev=true)
-        return ritzvec ? (d[p], v[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d,iparam[5],iparam[3],iparam[9],resid)
+        return ritzvec ? (d[p], v[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d[p],iparam[5],iparam[3],iparam[9],resid)
     else
         dr     = Vector{T}(nev+1)
         di     = Vector{T}(nev+1)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -800,6 +800,8 @@ condition number, or componentwise relative condition number.
 """
 condskeel(A::AbstractMatrix, x::AbstractVector, p::Real=Inf) = norm(abs.(inv(A))*(abs.(A)*abs.(x)), p)
 
+issymmetric(A::AbstractMatrix{<:Real}) = ishermitian(A)
+
 """
     issymmetric(A) -> Bool
 

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -3,77 +3,82 @@
 using Base.Test
 
 @testset "eigs" begin
-    let
-        srand(1234)
-        local n,a,asym,b,bsym,d,v
-        n = 10
-        areal  = sprandn(n,n,0.4)
-        breal  = sprandn(n,n,0.4)
-        acmplx = complex.(sprandn(n,n,0.4), sprandn(n,n,0.4))
-        bcmplx = complex.(sprandn(n,n,0.4), sprandn(n,n,0.4))
+    srand(1234)
+    n = 10
+    areal  = sprandn(n,n,0.4)
+    breal  = sprandn(n,n,0.4)
+    acmplx = complex.(sprandn(n,n,0.4), sprandn(n,n,0.4))
+    bcmplx = complex.(sprandn(n,n,0.4), sprandn(n,n,0.4))
 
-        testtol = 1e-6
+    testtol = 1e-6
 
-        @testset for elty in (Float64, Complex128)
-            if elty == Complex64 || elty == Complex128
-                a = acmplx
-                b = bcmplx
-            else
-                a = areal
-                b = breal
-            end
-            a     = convert(SparseMatrixCSC{elty}, a)
-            asym  = a' + a                  # symmetric indefinite
-            apd   = a'*a                    # symmetric positive-definite
+    @testset for elty in (Float64, Complex128)
+        if elty == Complex64 || elty == Complex128
+            a = acmplx
+            b = bcmplx
+        else
+            a = areal
+            b = breal
+        end
+        a     = convert(SparseMatrixCSC{elty}, a)
+        asym  = a' + a                  # symmetric indefinite
+        apd   = a'*a                    # symmetric positive-definite
 
-            b     = convert(SparseMatrixCSC{elty}, b)
-            bsym  = b' + b
-            bpd   = b'*b
+        b     = convert(SparseMatrixCSC{elty}, b)
+        bsym  = b' + b
+        bpd   = b'*b
 
-            (d,v) = eigs(a, nev=3)
-            @test a*v[:,2] ≈ d[2]*v[:,2]
-            @test norm(v) > testtol # eigenvectors cannot be null vectors
-            # (d,v) = eigs(a, b, nev=3, tol=1e-8) # not handled yet
-            # @test a*v[:,2] ≈ d[2]*b*v[:,2] atol=testtol
-            # @test norm(v) > testtol # eigenvectors cannot be null vectors
+        (d,v) = eigs(a, nev=3)
+        @test a*v[:,2] ≈ d[2]*v[:,2]
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
+        # (d,v) = eigs(a, b, nev=3, tol=1e-8) # not handled yet
+        # @test a*v[:,2] ≈ d[2]*b*v[:,2] atol=testtol
+        # @test norm(v) > testtol # eigenvectors cannot be null vectors
 
-            (d,v) = eigs(asym, nev=3)
-            @test asym*v[:,1] ≈ d[1]*v[:,1]
-            @test eigs(asym; nev=1, sigma=d[3])[1][1] ≈ d[3]
-            @test norm(v) > testtol # eigenvectors cannot be null vectors
+        (d,v) = eigs(asym, nev=3)
+        @test asym*v[:,1] ≈ d[1]*v[:,1]
+        @test eigs(asym; nev=1, sigma=d[3])[1][1] ≈ d[3]
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
 
-            (d,v) = eigs(apd, nev=3)
+        (d,v) = eigs(apd, nev=3)
+        @test apd*v[:,3] ≈ d[3]*v[:,3]
+        @test eigs(apd; nev=1, sigma=d[3])[1][1] ≈ d[3]
+
+        (d,v) = eigs(apd, bpd, nev=3, tol=1e-8)
+        @test apd*v[:,2] ≈ d[2]*bpd*v[:,2] atol=testtol
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
+
+        @testset "(shift-and-)invert mode" begin
+            (d,v) = eigs(apd, nev=3, sigma=0)
             @test apd*v[:,3] ≈ d[3]*v[:,3]
-            @test eigs(apd; nev=1, sigma=d[3])[1][1] ≈ d[3]
-
-            (d,v) = eigs(apd, bpd, nev=3, tol=1e-8)
-            @test apd*v[:,2] ≈ d[2]*bpd*v[:,2] atol=testtol
             @test norm(v) > testtol # eigenvectors cannot be null vectors
 
-            @testset "(shift-and-)invert mode" begin
-                (d,v) = eigs(apd, nev=3, sigma=0)
-                @test apd*v[:,3] ≈ d[3]*v[:,3]
-                @test norm(v) > testtol # eigenvectors cannot be null vectors
+            (d,v) = eigs(apd, bpd, nev=3, sigma=0, tol=1e-8)
+            @test apd*v[:,1] ≈ d[1]*bpd*v[:,1] atol=testtol
+            @test norm(v) > testtol # eigenvectors cannot be null vectors
+        end
 
-                (d,v) = eigs(apd, bpd, nev=3, sigma=0, tol=1e-8)
-                @test apd*v[:,1] ≈ d[1]*bpd*v[:,1] atol=testtol
-                @test norm(v) > testtol # eigenvectors cannot be null vectors
-            end
-
-            @testset "ArgumentErrors" begin
-                @test_throws ArgumentError eigs(rand(elty,2,2))
-                @test_throws ArgumentError eigs(a, nev=-1)
-                @test_throws ArgumentError eigs(a, which=:Z)
-                @test_throws ArgumentError eigs(a, which=:BE)
-                @test_throws DimensionMismatch eigs(a, v0=zeros(elty,n+2))
-                @test_throws ArgumentError eigs(a, v0=zeros(Int,n))
-                if elty == Float64
-                    @test_throws ArgumentError eigs(a+a.',which=:SI)
-                    @test_throws ArgumentError eigs(a+a.',which=:LI)
-                    @test_throws ArgumentError eigs(a,sigma=rand(Complex64))
-                end
+        @testset "ArgumentErrors" begin
+            @test_throws ArgumentError eigs(rand(elty,2,2))
+            @test_throws ArgumentError eigs(a, nev=-1)
+            @test_throws ArgumentError eigs(a, which=:Z)
+            @test_throws ArgumentError eigs(a, which=:BE)
+            @test_throws DimensionMismatch eigs(a, v0=zeros(elty,n+2))
+            @test_throws ArgumentError eigs(a, v0=zeros(Int,n))
+            if elty == Float64
+                @test_throws ArgumentError eigs(a+a.',which=:SI)
+                @test_throws ArgumentError eigs(a+a.',which=:LI)
+                @test_throws ArgumentError eigs(a,sigma=rand(Complex64))
             end
         end
+    end
+
+    @testset "Symmetric generalized with singular B" begin
+        n = 10
+        k = 3
+        A = randn(n,n); A = A'A
+        B = randn(n,k); B = B*B'
+        @test sort(eigs(A, B, nev = k, sigma = 1.0)[1]) ≈ sort(eigvals(A, B)[1:k])
     end
 end
 
@@ -152,81 +157,93 @@ let
 end
 
 @testset "real svds" begin
-    let A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
-        S1 = svds(A, nsv = 2)
-        S2 = svd(Array(A))
+    A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
+    S1 = svds(A, nsv = 2)
+    S2 = svd(Array(A))
 
-        ## singular values match:
+    ## singular values match:
+    @test S1[1][:S] ≈ S2[2][1:2]
+    @testset "singular vectors" begin
+        ## 1st left singular vector
+        s1_left = sign(S1[1][:U][3,1]) * S1[1][:U][:,1]
+        s2_left = sign(S2[1][3,1]) * S2[1][:,1]
+        @test s1_left ≈ s2_left
+
+        ## 1st right singular vector
+        s1_right = sign(S1[1][:V][3,1]) * S1[1][:V][:,1]
+        s2_right = sign(S2[3][3,1]) * S2[3][:,1]
+        @test s1_right ≈ s2_right
+    end
+    # Issue number 10329
+    # Ensure singular values from svds are in
+    # the correct order
+    @testset "singular values ordered correctly" begin
+        B = sparse(diagm([1.0, 2.0, 34.0, 5.0, 6.0]))
+        S3 = svds(B, ritzvec=false, nsv=2)
+        @test S3[1][:S] ≈ [34.0, 6.0]
+        S4 = svds(B, nsv=2)
+        @test S4[1][:S] ≈ [34.0, 6.0]
+    end
+    @testset "passing guess for Krylov vectors" begin
+        S1 = svds(A, nsv = 2, v0=rand(eltype(A),size(A,2)))
         @test S1[1][:S] ≈ S2[2][1:2]
-        @testset "singular vectors" begin
-            ## 1st left singular vector
-            s1_left = sign(S1[1][:U][3,1]) * S1[1][:U][:,1]
-            s2_left = sign(S2[1][3,1]) * S2[1][:,1]
-            @test s1_left ≈ s2_left
+    end
 
-            ## 1st right singular vector
-            s1_right = sign(S1[1][:V][3,1]) * S1[1][:V][:,1]
-            s2_right = sign(S2[3][3,1]) * S2[3][:,1]
-            @test s1_right ≈ s2_right
-        end
-        # Issue number 10329
-        # Ensure singular values from svds are in
-        # the correct order
-        @testset "singular values ordered correctly" begin
-            B = sparse(diagm([1.0, 2.0, 34.0, 5.0, 6.0]))
-            S3 = svds(B, ritzvec=false, nsv=2)
-            @test S3[1][:S] ≈ [34.0, 6.0]
-            S4 = svds(B, nsv=2)
-            @test S4[1][:S] ≈ [34.0, 6.0]
-        end
-        @testset "passing guess for Krylov vectors" begin
-            S1 = svds(A, nsv = 2, u0=rand(eltype(A),size(A,1)))
-            @test S1[1][:S] ≈ S2[2][1:2]
-            S1 = svds(A, nsv = 2, v0=rand(eltype(A),size(A,2)))
-            @test S1[1][:S] ≈ S2[2][1:2]
-            S1 = svds(A, nsv = 2, u0=rand(eltype(A),size(A,1)), v0=rand(eltype(A),size(A,2)))
-            @test S1[1][:S] ≈ S2[2][1:2]
-        end
+    @test_throws ArgumentError svds(A,nsv=0)
+    @test_throws ArgumentError svds(A,nsv=20)
+    @test_throws DimensionMismatch svds(A,nsv=2,v0=rand(size(A,2)+1))
 
-        @test_throws ArgumentError svds(A,nsv=0)
-        @test_throws ArgumentError svds(A,nsv=20)
-        @test_throws DimensionMismatch svds(A,nsv=2,u0=rand(size(A,1)+1))
-        @test_throws DimensionMismatch svds(A,nsv=2,v0=rand(size(A,2)+1))
+    @testset "Orthogonal vectors with repeated singular values $i times. Issue 16608" for i in 2:3
+        rng = MersenneTwister(126) # Fragile to compute repeated values without blocking so we set the seed
+        v0  = randn(rng, 20)
+        d   = sort(rand(rng, 20), rev = true)
+        for j in 2:i
+            d[j] = d[1]
+        end
+        A = qr(randn(rng, 20, 20))[1]*Diagonal(d)*qr(randn(rng, 20, 20))[1]
+        @testset "Number of singular values: $j" for j in 2:6
+            # Default size of subspace
+            F = svds(A, nsv = j, v0 = v0)
+            @test F[1][:U]'F[1][:U] ≈ eye(j)
+            @test F[1][:V]'F[1][:V] ≈ eye(j)
+            @test F[1][:S]          ≈ d[1:j]
+            for k in 3j:2:5j
+                # Custom size of subspace
+                F = svds(A, nsv = j, ncv = k, v0 = v0)
+                @test F[1][:U]'F[1][:U] ≈ eye(j)
+                @test F[1][:V]'F[1][:V] ≈ eye(j)
+                @test F[1][:S]          ≈ d[1:j]
+            end
+        end
     end
 end
 
 @testset "complex svds" begin
-    let A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp.(im*[2.0:2:10;]))
-        S1 = svds(A, nsv = 2)
-        S2 = svd(Array(A))
+    A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp.(im*[2.0:2:10;]), 5, 4)
+    S1 = svds(A, nsv = 2)
+    S2 = svd(Array(A))
 
-        ## singular values match:
-        @test S1[1][:S] ≈ S2[2][1:2]
-        @testset "singular vectors" begin
-            ## left singular vectors
-            s1_left = abs.(S1[1][:U][:,1:2])
-            s2_left = abs.(S2[1][:,1:2])
-            @test s1_left ≈ s2_left
+    ## singular values match:
+    @test S1[1][:S] ≈ S2[2][1:2]
+    @testset "singular vectors" begin
+        ## left singular vectors
+        s1_left = abs.(S1[1][:U][:,1:2])
+        s2_left = abs.(S2[1][:,1:2])
+        @test s1_left ≈ s2_left
 
-            ## right singular vectors
-            s1_right = abs.(S1[1][:V][:,1:2])
-            s2_right = abs.(S2[3][:,1:2])
-            @test s1_right ≈ s2_right
-        end
-        @testset "passing guess for Krylov vectors" begin
-            S1 = svds(A, nsv = 2, u0=rand(eltype(A),size(A,1)))
-            @test S1[1][:S] ≈ S2[2][1:2]
-            S1 = svds(A, nsv = 2, v0=rand(eltype(A),size(A,2)))
-            @test S1[1][:S] ≈ S2[2][1:2]
-            S1 = svds(A, nsv = 2, u0=rand(eltype(A),size(A,1)), v0=rand(eltype(A),size(A,2)))
-            @test S1[1][:S] ≈ S2[2][1:2]
-        end
-
-        @test_throws ArgumentError svds(A,nsv=0)
-        @test_throws ArgumentError svds(A,nsv=20)
-        @test_throws DimensionMismatch svds(A,nsv=2,u0=complex(rand(size(A,1)+1)))
-        @test_throws DimensionMismatch svds(A,nsv=2,v0=complex(rand(size(A,2)+1)))
+        ## right singular vectors
+        s1_right = abs.(S1[1][:V][:,1:2])
+        s2_right = abs.(S2[3][:,1:2])
+        @test s1_right ≈ s2_right
     end
+    @testset "passing guess for Krylov vectors" begin
+        S1 = svds(A, nsv = 2, v0=rand(eltype(A),size(A,2)))
+        @test S1[1][:S] ≈ S2[2][1:2]
+    end
+
+    @test_throws ArgumentError svds(A,nsv=0)
+    @test_throws ArgumentError svds(A,nsv=20)
+    @test_throws DimensionMismatch svds(A,nsv=2,v0=complex(rand(size(A,2)+1)))
 end
 
 @testset "promotion" begin
@@ -236,12 +253,4 @@ end
     @test_throws MethodError eigs(big.(rand(1:10, 10, 10)))
     @test_throws MethodError eigs(big.(rand(1:10, 10, 10)), rand(1:10, 10, 10))
     @test_throws MethodError svds(big.(rand(1:10, 10, 8)))
-end
-
-# Symmetric generalized with singular B
-let n = 10
-    k = 3
-    A = randn(n,n); A = A'A
-    B = randn(n,k);  B = B*B'
-    @test sort(eigs(A, B, nev = k, sigma = 1.0)[1]) ≈ sort(eigvals(A, B)[1:k])
 end


### PR DESCRIPTION
The former can be much faster. The latter is only relevant when computing the small values and we don't support that. I've kept the `SVDOperator` but renamed it `SVDAugmetned` since that name was used in PRIMME.

This also fixes JuliaLang/LinearAlgebra.jl#335 and this PR supersedes JuliaLang/julia#20694.

Update: To quantify this, the time to process IMDB on my laptop with this is
```julia
julia> @time svds(A, nsv = 10);
  7.760984 seconds (833 allocations: 394.811 MiB, 2.73% gc time)
```
where it used to be
```julia
julia> @time svds(A, nsv = 10);
 45.004135 seconds (2.31 k allocations: 891.884 MB, 1.31% gc time)
```