### PR TITLE
Word wrap docstrings at 92-characters

### DIFF
--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -58,48 +58,47 @@ location on each node, or to be available via a shared file system.
 
 A machine specification is either a string `machine_spec` or a tuple - `(machine_spec, count)`.
 
-`machine_spec` is a string of the form `[user@]host[:port] [bind_addr[:port]]`. `user` defaults
-to current user, `port` to the standard ssh port. If `[bind_addr[:port]]` is specified, other
-workers will connect to this worker at the specified `bind_addr` and `port`.
+`machine_spec` is a string of the form `[user@]host[:port] [bind_addr[:port]]`. `user`
+defaults to current user, `port` to the standard ssh port. If `[bind_addr[:port]]` is
+specified, other workers will connect to this worker at the specified `bind_addr` and
+`port`.
 
-`count` is the number of workers to be launched on the specified host. If specified as `:auto`
-it will launch as many workers as the number of cores on the specific host.
+`count` is the number of workers to be launched on the specified host. If specified as
+`:auto` it will launch as many workers as the number of cores on the specific host.
 
 Keyword arguments:
 
 * `tunnel`: if `true` then SSH tunneling will be used to connect to the worker from the
-            master process. Default is `false`.
+  master process. Default is `false`.
 
-* `sshflags`: specifies additional ssh options, e.g.
-  ```sshflags=\`-i /home/foo/bar.pem\` ```
+* `sshflags`: specifies additional ssh options, e.g. ```sshflags=\`-i /home/foo/bar.pem\````
 
-* `max_parallel`: specifies the maximum number of workers connected to in parallel at a host.
-                  Defaults to 10.
+* `max_parallel`: specifies the maximum number of workers connected to in parallel at a
+  host. Defaults to 10.
 
 * `dir`: specifies the working directory on the workers. Defaults to the host's current
-         directory (as found by `pwd()`)
+  directory (as found by `pwd()`)
 
- * `enable_threaded_blas`: if `true` then  BLAS will run on multiple threads in added
-                           processes. Default is `false`.
+* `enable_threaded_blas`: if `true` then  BLAS will run on multiple threads in added
+  processes. Default is `false`.
 
 * `exename`: name of the `julia` executable. Defaults to `"\$JULIA_HOME/julia"` or
-             `"\$JULIA_HOME/julia-debug"` as the case may be.
+  `"\$JULIA_HOME/julia-debug"` as the case may be.
 
 * `exeflags`: additional flags passed to the worker processes.
 
-* `topology`: Specifies how the workers connect to each other. Sending a message
-            between unconnected workers results in an error.
+* `topology`: Specifies how the workers connect to each other. Sending a message between
+  unconnected workers results in an error.
 
-  + `topology=:all_to_all`  :  All processes are connected to each other.
-                      This is the default.
+    + `topology=:all_to_all`: All processes are connected to each other. The default.
 
-  + `topology=:master_slave`  :  Only the driver process, i.e. `pid` 1 connects to the
-                        workers. The workers do not connect to each other.
+    + `topology=:master_slave`: Only the driver process, i.e. `pid` 1 connects to the
+      workers. The workers do not connect to each other.
 
-  + `topology=:custom`  :  The `launch` method of the cluster manager specifies the
-                  connection topology via fields `ident` and `connect_idents` in
-                  `WorkerConfig`. A worker with a cluster manager identity `ident`
-                  will connect to all workers specified in `connect_idents`.
+    + `topology=:custom`: The `launch` method of the cluster manager specifies the
+      connection topology via fields `ident` and `connect_idents` in `WorkerConfig`.
+      A worker with a cluster manager identity `ident` will connect to all workers specified
+      in `connect_idents`.
 
 
 Environment variables :

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1300,20 +1300,23 @@ cotd
 
 Block the current task until some event occurs, depending on the type of the argument:
 
-* [`RemoteChannel`](@ref) : Wait for a value to become available on the specified remote channel.
+* [`RemoteChannel`](@ref) : Wait for a value to become available on the specified remote
+  channel.
 * [`Future`](@ref) : Wait for a value to become available for the specified future.
 * [`Channel`](@ref): Wait for a value to be appended to the channel.
 * [`Condition`](@ref): Wait for [`notify`](@ref) on a condition.
 * `Process`: Wait for a process or process chain to exit. The `exitcode` field of a process
   can be used to determine success or failure.
-* [`Task`](@ref): Wait for a `Task` to finish, returning its result value. If the task fails with an
-  exception, the exception is propagated (re-thrown in the task that called `wait`).
-* `RawFD`: Wait for changes on a file descriptor (see [`poll_fd`](@ref) for keyword arguments and return code)
+* [`Task`](@ref): Wait for a `Task` to finish, returning its result value. If the task fails
+  with an exception, the exception is propagated (re-thrown in the task that called `wait`).
+* `RawFD`: Wait for changes on a file descriptor (see [`poll_fd`](@ref) for keyword
+  arguments and return code)
 
 If no argument is passed, the task blocks for an undefined period. A task can only be
 restarted by an explicit call to [`schedule`](@ref) or [`yieldto`](@ref).
 
-Often `wait` is called within a `while` loop to ensure a waited-for condition is met before proceeding.
+Often `wait` is called within a `while` loop to ensure a waited-for condition is met before
+proceeding.
 """
 wait
 

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -338,10 +338,9 @@ iterations derived from [`eigs`](@ref).
 
 **Inputs**
 
-* `A`: Linear operator whose singular values are desired. `A` may be represented
-  as a subtype of `AbstractArray`, e.g., a sparse matrix, or any other type
-  supporting the four methods `size(A)`, `eltype(A)`, `A * vector`, and
-  `A' * vector`.
+* `A`: Linear operator whose singular values are desired. `A` may be represented as a
+  subtype of `AbstractArray`, e.g., a sparse matrix, or any other type supporting the four
+  methods `size(A)`, `eltype(A)`, `A * vector`, and `A' * vector`.
 * `nsv`: Number of singular values. Default: 6.
 * `ritzvec`: If `true`, return the left and right singular vectors `left_sv` and `right_sv`.
    If `false`, omit the singular vectors. Default: `true`.
@@ -353,7 +352,9 @@ iterations derived from [`eigs`](@ref).
 
 **Outputs**
 
-* `svd`: An `SVD` object containing the left singular vectors, the requested values, and the right singular vectors. If `ritzvec = false`, the left and right singular vectors will be empty.
+* `svd`: An `SVD` object containing the left singular vectors, the requested values, and the
+  right singular vectors. If `ritzvec = false`, the left and right singular vectors will be
+  empty.
 * `nconv`: Number of converged singular values.
 * `niter`: Number of iterations.
 * `nmult`: Number of matrix--vector products used.

--- a/base/process.jl
+++ b/base/process.jl
@@ -31,42 +31,37 @@ struct Cmd <: AbstractCmd
 end
 
 """
-    Cmd(cmd::Cmd; ignorestatus, detach, windows_verbatim, windows_hide,
-                  env, dir)
+    Cmd(cmd::Cmd; ignorestatus, detach, windows_verbatim, windows_hide, env, dir)
 
-Construct a new `Cmd` object, representing an external program and
-arguments, from `cmd`, while changing the settings of the optional
-keyword arguments:
+Construct a new `Cmd` object, representing an external program and arguments, from `cmd`,
+while changing the settings of the optional keyword arguments:
 
-* `ignorestatus::Bool`: If `true` (defaults to `false`), then the `Cmd`
-  will not throw an error if the return code is nonzero.
-* `detach::Bool`: If `true` (defaults to `false`), then the `Cmd` will be
-  run in a new process group, allowing it to outlive the `julia` process
-  and not have Ctrl-C passed to it.
-* `windows_verbatim::Bool`: If `true` (defaults to `false`), then on Windows
-  the `Cmd` will send a command-line string to the process with no quoting
-  or escaping of arguments, even arguments containing spaces.  (On Windows,
-  arguments are sent to a program as a single "command-line" string, and
-  programs are responsible for parsing it into arguments.  By default,
-  empty arguments and arguments with spaces or tabs are quoted with double
-  quotes `"` in the command line, and `\\` or `"` are preceded by backslashes.
-  `windows_verbatim=true` is useful for launching programs that parse their
-  command line in nonstandard ways.)  Has no effect on non-Windows systems.
-* `windows_hide::Bool`: If `true` (defaults to `false`), then on Windows no
-  new console window is displayed when the `Cmd` is executed.  This has
-  no effect if a console is already open or on non-Windows systems.
-* `env`: Set environment variables to use when running the `Cmd`.  `env`
-  is either a dictionary mapping strings to strings, an array
-  of strings of the form `"var=val"`, an array or tuple of `"var"=>val`
-  pairs, or `nothing`.  In order to modify (rather than replace)
-  the existing environment, create `env` by `copy(ENV)` and then
-  set `env["var"]=val` as desired.
+* `ignorestatus::Bool`: If `true` (defaults to `false`), then the `Cmd` will not throw an
+  error if the return code is nonzero.
+* `detach::Bool`: If `true` (defaults to `false`), then the `Cmd` will be run in a new
+  process group, allowing it to outlive the `julia` process and not have Ctrl-C passed to
+  it.
+* `windows_verbatim::Bool`: If `true` (defaults to `false`), then on Windows the `Cmd` will
+  send a command-line string to the process with no quoting or escaping of arguments, even
+  arguments containing spaces. (On Windows, arguments are sent to a program as a single
+  "command-line" string, and programs are responsible for parsing it into arguments. By
+  default, empty arguments and arguments with spaces or tabs are quoted with double quotes
+  `"` in the command line, and `\\` or `"` are preceded by backslashes.
+  `windows_verbatim=true` is useful for launching programs that parse their command line in
+  nonstandard ways.) Has no effect on non-Windows systems.
+* `windows_hide::Bool`: If `true` (defaults to `false`), then on Windows no new console
+  window is displayed when the `Cmd` is executed. This has no effect if a console is
+  already open or on non-Windows systems.
+* `env`: Set environment variables to use when running the `Cmd`. `env` is either a
+  dictionary mapping strings to strings, an array of strings of the form `"var=val"`, an
+  array or tuple of `"var"=>val` pairs, or `nothing`. In order to modify (rather than
+  replace) the existing environment, create `env` by `copy(ENV)` and then set
+  `env["var"]=val` as desired.
 * `dir::AbstractString`: Specify a working directory for the command (instead
   of the current directory).
 
-For any keywords that are not specified, the current settings from `cmd` are
-used.   Normally, to create a `Cmd` object in the first place, one uses
-backticks, e.g.
+For any keywords that are not specified, the current settings from `cmd` are used. Normally,
+to create a `Cmd` object in the first place, one uses backticks, e.g.
 
     Cmd(`echo "Hello world"`, ignorestatus=true, detach=false)
 """

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -451,8 +451,8 @@ Set UDP socket options.
 
 * `multicast_loop`: loopback for multicast packets (default: `true`).
 * `multicast_ttl`: TTL for multicast packets (default: `nothing`).
-* `enable_broadcast`: flag must be set to `true` if socket will be used for broadcast messages,
-  or else the UDP system will return an access error (default: `false`).
+* `enable_broadcast`: flag must be set to `true` if socket will be used for broadcast
+  messages, or else the UDP system will return an access error (default: `false`).
 * `ttl`: Time-to-live of packets sent on the socket (default: `nothing`).
 """
 function setopt(sock::UDPSocket; multicast_loop = nothing, multicast_ttl=nothing, enable_broadcast=nothing, ttl=nothing)

--- a/base/strings/utf8proc.jl
+++ b/base/strings/utf8proc.jl
@@ -160,18 +160,19 @@ Alternatively, finer control and additional transformations may be be obtained b
 options (which all default to `false` except for `compose`) are specified:
 
 * `compose=false`: do not perform canonical composition
-* `decompose=true`: do canonical decomposition instead of canonical composition (`compose=true`
-  is ignored if present)
+* `decompose=true`: do canonical decomposition instead of canonical composition
+  (`compose=true` is ignored if present)
 * `compat=true`: compatibility equivalents are canonicalized
 * `casefold=true`: perform Unicode case folding, e.g. for case-insensitive string comparison
-* `newline2lf=true`, `newline2ls=true`, or `newline2ps=true`: convert various newline sequences
-  (LF, CRLF, CR, NEL) into a linefeed (LF), line-separation (LS), or paragraph-separation (PS)
-  character, respectively
+* `newline2lf=true`, `newline2ls=true`, or `newline2ps=true`: convert various newline
+  sequences (LF, CRLF, CR, NEL) into a linefeed (LF), line-separation (LS), or
+  paragraph-separation (PS) character, respectively
 * `stripmark=true`: strip diacritical marks (e.g. accents)
 * `stripignore=true`: strip Unicode's "default ignorable" characters (e.g. the soft hyphen
   or the left-to-right marker)
 * `stripcc=true`: strip control characters; horizontal tabs and form feeds are converted to
-  spaces; newlines are also converted to spaces unless a newline-conversion flag was specified
+  spaces; newlines are also converted to spaces unless a newline-conversion flag was
+  specified
 * `rejectna=true`: throw an error if unassigned code points are found
 * `stable=true`: enforce Unicode Versioning Stability
 


### PR DESCRIPTION
As I was looking through base as part of #21699 I found some docstrings that were not word wrapped to 92-characters.