### PR TITLE
Install `libLTO*.so` alongside `libLLVM*.so` when running `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ endif
 endif
 ifeq ($(USE_SYSTEM_LLVM),0)
 ifeq ($(USE_LLVM_SHLIB),1)
-JL_PRIVATE_LIBS += LLVM
+JL_PRIVATE_LIBS += LLVM LTO
 endif
 endif
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
This is an important library that we need on LLVM >= 3.9.0