### PR TITLE
workspace command: fix for missing incremental support

### DIFF
--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -54,8 +54,10 @@ JL_DLLEXPORT jl_module_t *jl_new_main_module(void)
 
     jl_main_module = jl_new_module(jl_symbol("Main"));
     jl_main_module->parent = jl_main_module;
-    if (old_main) // don't block continued loading of incremental caches
+    if (old_main) { // don't block continued loading of incremental caches
+        jl_main_module->primary_world = old_main->primary_world;
         jl_main_module->uuid = old_main->uuid;
+    }
     ptls->current_module = jl_main_module;
 
     jl_core_module->parent = jl_main_module;

--- a/test/workspace.jl
+++ b/test/workspace.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+using Base.Test
+
 script = """
 # Issue #11948
 f(x) = x+1
@@ -24,3 +26,35 @@ mutable struct Foo end
 @assert Tuple{Type{LastMain.Foo}} !== Tuple{Type{Main.Foo}}
 """
 run(`$exename --startup-file=no -e $script2`)
+
+# Issue #22101
+mktempdir() do dir
+    withenv("JULIA_DEBUG_LOADING" => nothing) do
+        # We need to ensure that the module does a nontrivial amount of work during precompilation
+        write(joinpath(dir, "Test22101.jl"), """
+            __precompile__()
+            module Test22101
+                export f22101
+                f22101() = collect(1:10)
+                f22101()
+            end
+        """)
+        write(joinpath(dir, "testdriver.jl"), """
+            insert!(LOAD_PATH, 1, $(repr(dir)))
+            insert!(Base.LOAD_CACHE_PATH, 1, $(repr(dir)))
+            try
+                using Test22101
+                f22101()
+                workspace()
+                using Test22101
+            finally
+                splice!(LOAD_PATH, 1)
+                splice!(Base.LOAD_CACHE_PATH, 1)
+            end
+            exit(isdefined(Main, :f22101) ? 0 : 1)
+        """)
+        # Ensure that STDIO doesn't get swallowed (helps with debugging)
+        cmd = `$(Base.julia_cmd()) --startup-file=no --precompiled=yes --compilecache=yes $(joinpath(dir, "testdriver.jl"))`
+        @test success(pipeline(cmd, stdout=STDOUT, stderr=STDERR))
+    end
+end


### PR DESCRIPTION
I can't really spend the time to analyze the consequences of calling `workspace()`, but this at least makes it not fail too quickly.