### PR TITLE
make at-everywhere import modules before remote calls

### DIFF
--- a/base/distributed/macros.jl
+++ b/base/distributed/macros.jl
@@ -49,22 +49,20 @@ macro fetchfrom(p, expr)
 end
 
 # extract a list of modules to import from an expression
-extract_imports(x) = Symbol[]
-function extract_imports(ex::Expr)
-    if Meta.isexpr(ex, [:import, :using])
-        return Symbol[ex.args[1]]
+extract_imports!(imports, x) = imports
+function extract_imports!(imports, ex::Expr)
+    if Meta.isexpr(ex, (:import, :using))
+        return push!(imports, ex.args[1])
     elseif Meta.isexpr(ex, :let)
-        return extract_imports(ex.args[1])
-    elseif Meta.isexpr(ex, [:toplevel, :block])
-        imports = Symbol[]
+        return extract_imports!(imports, ex.args[1])
+    elseif Meta.isexpr(ex, (:toplevel, :block))
         for i in eachindex(ex.args)
-            append!(imports, extract_imports(ex.args[i]))
+            extract_imports!(imports, ex.args[i])
         end
-        return imports
-    else
-        return Symbol[]
     end
+    return imports
 end
+extract_imports(x) = extract_imports!(Symbol[], x)
 
 """
     @everywhere expr

--- a/base/distributed/macros.jl
+++ b/base/distributed/macros.jl
@@ -96,8 +96,9 @@ For example :
 will result in `Main.bar` being defined on all processes and not `FooBar.bar`.
 """
 macro everywhere(ex)
+    imps = [Expr(:import, m) for m in extract_imports(ex)]
     quote
-        $(Expr(:toplevel, [Expr(:import, m) for m in extract_imports(ex)]...))
+        $(isempty(imps) ? nothing : Expr(:toplevel, imps...))
         sync_begin()
         for pid in workers()
             async_run_thunk(()->remotecall_fetch(eval_ew_expr, pid, $(Expr(:quote,ex))))

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -83,7 +83,7 @@ function initmeta(m::Module = current_module())
 end
 
 function signature!(tv, expr::Expr)
-    if isexpr(expr, [:call, :macrocall])
+    if isexpr(expr, (:call, :macrocall))
         sig = :(Union{Tuple{}})
         for arg in expr.args[2:end]
             isexpr(arg, :parameters) && continue
@@ -454,7 +454,7 @@ function nameof(x::Expr, ismacro)
     if isexpr(x, :.)
         ismacro ? macroname(x) : x
     else
-        n = isexpr(x, [:module, :type, :bitstype]) ? 2 : 1
+        n = isexpr(x, (:module, :type, :bitstype)) ? 2 : 1
         nameof(x.args[n], ismacro)
     end
 end
@@ -531,7 +531,7 @@ function calldoc(str, def)
         docerror(def)
     end
 end
-validcall(x) = isa(x, Symbol) || isexpr(x, [:(::), :..., :kw, :parameters])
+validcall(x) = isa(x, Symbol) || isexpr(x, (:(::), :..., :kw, :parameters))
 
 function moduledoc(meta, def, def′)
     name  = namify(def′)

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -12,8 +12,7 @@ export quot,
 quot(ex) = Expr(:quote, ex)
 
 isexpr(ex::Expr, head)          = ex.head === head
-isexpr(ex::Expr, heads::Set)    = in(ex.head, heads)
-isexpr(ex::Expr, heads::Vector) = in(ex.head, heads)
+isexpr(ex::Expr, heads::Union{Set,Vector,Tuple}) = in(ex.head, heads)
 isexpr(ex,       head)          = false
 
 isexpr(ex,       head, n::Int)  = isexpr(ex, head) && length(ex.args) == n

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -122,12 +122,16 @@ using Base.Meta
 
 @test isexpr(:(1+1),Set([:call]))
 @test isexpr(:(1+1),Vector([:call]))
+@test isexpr(:(1+1),(:call))
 @test isexpr(1,:call)==false
 @test isexpr(:(1+1),:call,3)
 ioB = IOBuffer()
 show_sexpr(ioB,:(1+1))
 
 show_sexpr(ioB,QuoteNode(1),1)
+
+@test Base.Meta.extract_imports(:(begin; import Foo, Bar; let; using Baz; end; end)) ==
+      [:Foo, :Bar, :Baz]
 
 # test base/expr.jl
 baremodule B

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -122,7 +122,7 @@ using Base.Meta
 
 @test isexpr(:(1+1),Set([:call]))
 @test isexpr(:(1+1),Vector([:call]))
-@test isexpr(:(1+1),(:call))
+@test isexpr(:(1+1),(:call,))
 @test isexpr(1,:call)==false
 @test isexpr(:(1+1),:call,3)
 ioB = IOBuffer()
@@ -130,7 +130,7 @@ show_sexpr(ioB,:(1+1))
 
 show_sexpr(ioB,QuoteNode(1),1)
 
-@test Base.Meta.extract_imports(:(begin; import Foo, Bar; let; using Baz; end; end)) ==
+@test Base.Distributed.extract_imports(:(begin; import Foo, Bar; let; using Baz; end; end)) ==
       [:Foo, :Bar, :Baz]
 
 # test base/expr.jl


### PR DESCRIPTION
This PR is intended to make `@everywhere using Foo` a bit more reliable and performant, by turning it into essentially `import Foo; @everywhere using Foo`.  Similarly for `@everwhere begin ... end` and other blocks that might contain `import` or `using` statements.

e.g. right now `@everywhere using Foo` gives `WARNING: replacing module Foo.` because it ends up importing Foo twice, and that in turn can cause problems with certain modules (e.g. PyCall: JuliaPy/PyCall.jl#388) that don't like to be initialized twice.  Also there are potential race conditions with cache recompilation.

Not completely sure how to implement a test for this.