### PR TITLE
Provide build instructions for nVidia Jetson TX2 (AArch64)

### DIFF
--- a/README.arm.md
+++ b/README.arm.md
@@ -129,3 +129,43 @@ finding appropriate `crouton` help.
 
 On the current [Scaleway](http://scaleway.com) ARM servers, the Julia
 build works out of the box.
+
+## nVidia Jetson TX2
+
+Julia builds and runs on the [nVidia Jetson TX2](http://www.nvidia.com/object/embedded-systems-dev-kits-modules.html) platform with minimal configuration changes. A full multi-threaded build, including LLVM, will complete in around two hours. All tests pass and CUDA functionality is available through, e.g., [CUDAdrv](https://github.com/JuliaGPU/CUDAdrv.jl). 
+
+Starting from the default configuration flashed by [Jetpack 3.0](https://developer.nvidia.com/embedded/jetpack):
+
+```
+sudo apt-get install libssl-dev
+```
+
+### Julia 0.5.1
+
+The easiest method to build Julia 0.5.1 is to use system provided versions of BLAS and LAPACK:
+
+```
+sudo apt-get install libopenblas-dev liblapack-dev
+```
+
+Configure Make.user as follows:
+
+```
+MARCH=armv8-a
+JULIA_CPU_TARGET=cortex-a57
+override USE_SYSTEM_BLAS=1
+override USE_SYSTEM_LAPACK=1
+```
+
+Note that package manager functions fail with an error regarding SSL certificates. This can be overcome by following the instructions in [this comment](https://github.com/JuliaLang/julia/issues/13399#issuecomment-182018321).
+
+### Julia 0.6 beta
+
+Configure Make.user as follows:
+
+```
+MARCH=armv8-a
+JULIA_CPU_TARGET=cortex-a57
+```
+
+No further changes are required.


### PR DESCRIPTION
cc @ViralBShah 

The 0.5.1 build instructions are slightly more involved than those for 0.6 beta since the former's build system does not include configuration for ARMv8 (7191bde57a5ce87343c74496a597b4a8185f0ce2). No doubt it is possible to avoid the use of system libraries in 0.5.1 by manually overriding the particular build options, but since the release of 0.6 is pending it seems unnecessary to flesh this out further.

Indeed, it may be preferable to remove the 0.5.1 build instructions all together (since this document will relate to master). Please let me know your preference.

Thanks to all the work that has been put into ARM support, Julia runs well on this platform. It is particularly encouraging that various CUDA related packages run out of the box on the embedded Pascal GPU, supporting its intended use as an embedded platform for vision & machine learning.
