### PR TITLE
Fix in(x, r::Range{<:Integer}) when x is not numeric

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -200,6 +200,8 @@ bswap(z::Complex) = Complex(bswap(real(z)), bswap(imag(z)))
 
 isequal(z::Complex, w::Complex) = isequal(real(z),real(w)) & isequal(imag(z),imag(w))
 
+in(x::Complex, r::Range{<:Real}) = isreal(x) && real(x) in r
+
 if UInt === UInt64
     const h_imag = 0x32a7a07f3e7cd1f9
 else

--- a/base/range.jl
+++ b/base/range.jl
@@ -876,8 +876,12 @@ end
 median(r::Range{<:Real}) = mean(r)
 
 function _in_range(x, r::Range)
-    n = step(r) == 0 ? 1 : round(Integer,(x-first(r))/step(r))+1
-    n >= 1 && n <= length(r) && r[n] == x
+    if step(r) == 0
+        return !isempty(r) && first(r) == x
+    else
+        n = round(Integer, (x - first(r)) / step(r)) + 1
+        return n >= 1 && n <= length(r) && r[n] == x
+    end
 end
 in(x::Real, r::Range{<:Real}) = _in_range(x, r)
 # This method needs to be defined separately since -(::T, ::T) can be implemented

--- a/base/range.jl
+++ b/base/range.jl
@@ -875,13 +875,18 @@ end
 
 median(r::Range{<:Real}) = mean(r)
 
-function in(x, r::Range)
+function _in_range(x, r::Range)
     n = step(r) == 0 ? 1 : round(Integer,(x-first(r))/step(r))+1
     n >= 1 && n <= length(r) && r[n] == x
 end
+in(x::Real, r::Range{<:Real}) = _in_range(x, r)
+# This method needs to be defined separately since -(::T, ::T) can be implemented
+# even if -(::T, ::Real) is not
+in(x::T, r::Range{T}) where {T} = _in_range(x, r)
 
 in(x::Integer, r::AbstractUnitRange{<:Integer}) = (first(r) <= x) & (x <= last(r))
-in(x, r::Range{T}) where {T<:Integer} =
+
+in(x::Real, r::Range{T}) where {T<:Integer} =
     isinteger(x) && !isempty(r) && x >= minimum(r) && x <= maximum(r) &&
         (mod(convert(T,x),step(r))-mod(first(r),step(r)) == 0)
 in(x::Char, r::Range{Char}) =

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -159,6 +159,28 @@ r = (-4*Int64(maxintfloat(Int === Int32 ? Float32 : Float64))):5
 @test !(1 in 1:0)
 @test !(1.0 in 1.0:0.0)
 
+# test that in() works across types, including non-numeric types (#21728)
+@test 1//1 in 1:3
+@test 1//1 in 1.0:3.0
+@test !(5//1 in 1:3)
+@test !(5//1 in 1.0:3.0)
+@test Complex(1, 0) in 1:3
+@test Complex(1, 0) in 1.0:3.0
+@test Complex(1.0, 0.0) in 1:3
+@test Complex(1.0, 0.0) in 1.0:3.0
+@test !(Complex(1, 1) in 1:3)
+@test !(Complex(1, 1) in 1.0:3.0)
+@test !(Complex(1.0, 1.0) in 1:3)
+@test !(Complex(1.0, 1.0) in 1.0:3.0)
+@test !(π in 1:3)
+@test !(π in 1.0:3.0)
+@test !("a" in 1:3)
+@test !("a" in 1.0:3.0)
+@test !(1 in Date(2017, 01, 01):Date(2017, 01, 05))
+@test !(Complex(1, 0) in Date(2017, 01, 01):Date(2017, 01, 05))
+@test !(π in Date(2017, 01, 01):Date(2017, 01, 05))
+@test !("a" in Date(2017, 01, 01):Date(2017, 01, 05))
+
 # indexing range with empty range (#4309)
 @test (3:6)[5:4] == 7:6
 @test_throws BoundsError (3:6)[5:5]


### PR DESCRIPTION
Previously, checking that a string was in() a container would work for Array
but not for Range.

Another (possibly cleaner) approach would be to restrict the current definitions to `x::Number`, and introduce fallbacks returning `false`.