### PR TITLE
fix #21719, incorrect MethodError

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2157,11 +2157,13 @@ jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t *
             // we assume that if the intersection is a leaf type, we have
             // full information in `env`. however the intersection algorithm
             // does not yet provide that in all cases so use subtype.
-            if (szb > 0 && jl_is_leaf_type(*ans) && !jl_types_equal(b, (jl_value_t*)jl_type_type)) {
+            if (szb > 0 && !jl_types_equal(b, (jl_value_t*)jl_type_type)) {
                 if (jl_subtype_env(*ans, b, env, szb)) {
-                    for(i=0; i < sz; i++) {
-                        if (jl_is_typevar(env[i])) {
-                            *ans = jl_bottom_type; goto bot;
+                    if (jl_is_leaf_type(*ans)) {
+                        for(i=0; i < sz; i++) {
+                            if (jl_is_typevar(env[i])) {
+                                *ans = jl_bottom_type; goto bot;
+                            }
                         }
                     }
                 }

--- a/test/core.jl
+++ b/test/core.jl
@@ -4881,3 +4881,12 @@ function foo21568()
 end
 foo21568()
 @test f21568([0]) == 1
+
+# issue #21719
+type T21719{V}
+    f
+    tol::Float64
+    goal::V
+end
+g21719(f, goal; tol = 1e-6) = T21719(f, tol, goal)
+@test isa(g21719(identity, 1.0; tol=0.1), T21719)


### PR DESCRIPTION
This was caused by incorrectly using a TypeVar as the value of a static parameter in the case of a compiled specialization whose signature is not a leaf type. In this case, one slot was specialized on `Function`, but the slot with the static parameter had a leaf type.