### PR TITLE
Clean up testenv and old test isolation code

### DIFF
--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -9,9 +9,8 @@ ambig(x::Int, y::Int) = 4
 ambig(x::Number, y) = 5
 # END OF LINE NUMBER SENSITIVITY
 
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
+# For curmod_*
+include("testenv.jl")
 
 ambigs = Any[[], [3], [2,5], [], [3]]
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1,8 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module BitArrayTests
-
-using Base.Test
 using Base: findprevnot, findnextnot
 
 tc{N}(r1::NTuple{N,Any}, r2::NTuple{N,Any}) = all(x->tc(x...), [zip(r1,r2)...])
@@ -1467,5 +1464,3 @@ end
 end
 
 timesofar("I/O")
-
-end # module

--- a/test/core.jl
+++ b/test/core.jl
@@ -2,9 +2,9 @@
 
 # test core language features
 const Bottom = Union{}
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+
+# For curmod_*
+include("testenv.jl")
 
 f47{T}(x::Vector{Vector{T}}) = 0
 @test_throws MethodError f47(Array{Vector}(0))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -2,9 +2,8 @@
 
 import Base.Docs: meta, @var, DocStr, parsedoc
 
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+# For curmod_*
+include("testenv.jl")
 
 # Test helpers.
 function docstrings_equal(d1, d2)
@@ -875,7 +874,7 @@ let x = Binding(Base, :bindingdoesnotexist)
     @test @var(Base.bindingdoesnotexist) == x
 end
 
-let x = Binding(current_module(), :bindingdoesnotexist)
+let x = Binding(curmod, :bindingdoesnotexist)
     @test defined(x) == false
     @test @var(bindingdoesnotexist) == x
 end

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -1,8 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+# For curmod_*
+include("testenv.jl")
 
 using Base.Test
 

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # intrinsic functions
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+
+# For curmod_*
+include("testenv.jl")
 
 # bits types
 @test isa((() -> Core.Intrinsics.bitcast(Ptr{Int8}, 0))(), Ptr{Int8})

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module TridiagTest
-using Base.Test
 debug = false
 
 # basic tridiagonal operations
@@ -483,4 +481,3 @@ SymTridiagonal([1, 2], [0])^3 == [1 0; 0 8]
 # Test constructors with range and other abstract vectors
 @test SymTridiagonal(1:3, 1:2) == [1 1 0; 1 2 2; 0 2 3]
 @test Tridiagonal(4:5, 1:3, 1:2) == [1 1 0; 4 2 2; 0 5 3]
-end

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -2,10 +2,6 @@
 
 # test meta-expressions that annotate blocks of code
 
-module MetaTest
-
-using Base.Test
-
 const inlining_on = Base.JLOptions().can_inline != 0
 
 function f(x)
@@ -121,13 +117,7 @@ body.args = ast.code
 @test popmeta!(body, :test) == (true, [42])
 @test popmeta!(body, :nonexistent) == (false, [])
 
-end
-
-
 # tests to fully cover functions in base/meta.jl
-module MetaJLtest
-
-using Base.Test
 using Base.Meta
 
 @test isexpr(:(1+1),Set([:call]))
@@ -138,8 +128,6 @@ ioB = IOBuffer()
 show_sexpr(ioB,:(1+1))
 
 show_sexpr(ioB,QuoteNode(1),1)
-
-end
 
 # test base/expr.jl
 baremodule B

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -115,9 +115,8 @@ for (i, T) in enumerate(types)
 end
 
 module NullableTestEnum
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+# For curmod_*
+include("testenv.jl")
 io = IOBuffer()
 @enum TestEnum a b
 show(io, Nullable(a))

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -163,8 +163,8 @@ not_const = 1
 ## find bindings tests
 @test ccall(:jl_get_module_of_binding, Any, (Any, Any), Base, :sin)==Base
 
-const curmod = current_module()
-const curmod_name = fullname(curmod)
+# For curmod_*
+include("testenv.jl")
 
 module TestMod7648
 using Base.Test

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -1,8 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+# For curmod_*
+include("testenv.jl")
 
 # REPL tests
 isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -1,9 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+# For curmod_*
+include("testenv.jl")
 
 function test_have_color(buf, color, no_color)
     if Base.have_color

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,8 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-const curmod = current_module()
-const curmod_name = fullname(curmod)
-const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+# For curmod_*
+include("testenv.jl")
 
 replstr(x) = sprint((io,x) -> show(IOContext(io, :limit => true), MIME("text/plain"), x), x)
 

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -1,22 +1,35 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-if haskey(ENV, "JULIA_TEST_EXEFLAGS")
-    const test_exeflags = `$(Base.shell_split(ENV["JULIA_TEST_EXEFLAGS"]))`
-else
-    inline_flag = Base.JLOptions().can_inline == 1 ? `` : `--inline=no`
-    cov_flag = ``
-    if Base.JLOptions().code_coverage == 1
-        cov_flag = `--code-coverage=user`
-    elseif Base.JLOptions().code_coverage == 2
-        cov_flag = `--code-coverage=all`
+# This includes a few helper variables and functions that provide information about the
+# test environment (command line flags, current module, etc).
+# This file can be included multiple times in the same module if necessary,
+# which can happen with unisolated test runs.
+
+if !isdefined(:testenv_defined)
+    const testenv_defined = true
+    if haskey(ENV, "JULIA_TEST_EXEFLAGS")
+        const test_exeflags = `$(Base.shell_split(ENV["JULIA_TEST_EXEFLAGS"]))`
+    else
+        inline_flag = Base.JLOptions().can_inline == 1 ? `` : `--inline=no`
+        cov_flag = ``
+        if Base.JLOptions().code_coverage == 1
+            cov_flag = `--code-coverage=user`
+        elseif Base.JLOptions().code_coverage == 2
+            cov_flag = `--code-coverage=all`
+        end
+        const test_exeflags = `$cov_flag $inline_flag --check-bounds=yes --startup-file=no --depwarn=error`
     end
-    const test_exeflags = `$cov_flag $inline_flag --check-bounds=yes --startup-file=no --depwarn=error`
-end
 
-if haskey(ENV, "JULIA_TEST_EXENAME")
-    const test_exename = `$(Base.shell_split(ENV["JULIA_TEST_EXENAME"]))`
-else
-    const test_exename = `$(joinpath(JULIA_HOME, Base.julia_exename()))`
-end
+    if haskey(ENV, "JULIA_TEST_EXENAME")
+        const test_exename = `$(Base.shell_split(ENV["JULIA_TEST_EXENAME"]))`
+    else
+        const test_exename = `$(joinpath(JULIA_HOME, Base.julia_exename()))`
+    end
 
-addprocs_with_testenv(X; kwargs...) = addprocs(X; exename=test_exename, exeflags=test_exeflags, kwargs...)
+    addprocs_with_testenv(X; kwargs...) = addprocs(X; exename=test_exename, exeflags=test_exeflags, kwargs...)
+
+    const curmod = current_module()
+    const curmod_name = fullname(curmod)
+    const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
+    const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+end


### PR DESCRIPTION
* We now have `testenv.jl` which is a better central place to put the `curmod_*` variables without making running each testfile harder.
* Remove some toplevel module in test files since they are not necessary to isolate the namespace of the tests anymore.