### PR TITLE
Clean up of jl_assume

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -309,7 +309,7 @@ static jl_value_t *ti_run_fun(const jl_generic_fptr_t *fptr, jl_method_instance_
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     JL_TRY {
-        jl_assume(fptr->jlcall_api != 2);
+        (void)jl_assume(fptr->jlcall_api != 2);
         jl_call_fptr_internal(fptr, mfunc, args, nargs);
     }
     JL_CATCH {


### PR DESCRIPTION
* Make sure the unused result of `jl_assume` is explicitly discarded to suppress compiler warnings
* Enable it on other GCC compatible compilers (like mingw) too

Either should get rid of the warning on AppVeyor (assuming it compiles....)
