### PR TITLE
improve error reporting for invalid type arguments to `ccall`

### DIFF
--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1239,6 +1239,8 @@ end
 
 # issue #20835
 @test_throws ErrorException eval(:(f20835(x) = ccall(:fn, Void, (Ptr{typeof(x)},), x)))
+@test_throws UndefVarError  eval(:(f20835(x) = ccall(:fn, Something_not_defined_20835, (Ptr{typeof(x)},), x)))
+
 @noinline f21104at(::Type{T}) where {T} = ccall(:fn, Void, (Nullable{T},), 0)
 @noinline f21104rt(::Type{T}) where {T} = ccall(:fn, Nullable{T}, ())
 @test code_llvm(DevNull, f21104at, (Type{Float64},)) === nothing


### PR DESCRIPTION
If `ccall` return or argument types could not be evaluated, previously we swallowed the error and replaced it with a generic `invalid return type or argument type in ccall`. This improves the message to (1) specify whether the argument or return type is the problem, (2) let more specific exception types through, (3) otherwise, make the error message the more helpful `could not evaluate ccall return type (it might depend on a local variable)`.