### PR TITLE
Completely remove partial linear indexing

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -211,6 +211,7 @@ given tuple of indices and the dimensional indices of `A` in tandem. As such,
 not all index types are guaranteed to propagate to `Base.to_index`.
 """
 to_indices(A, I::Tuple) = (@_inline_meta; to_indices(A, indices(A), I))
+to_indices(A, I::Tuple{Any}) = (@_inline_meta; to_indices(A, (linearindices(A),), I))
 to_indices(A, inds, ::Tuple{}) = ()
 to_indices(A, inds, I::Tuple{Any, Vararg{Any}}) =
     (@_inline_meta; (to_index(A, I[1]), to_indices(A, _maybetail(inds), tail(I))...))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -442,15 +442,6 @@ done(L::LogicalIndex, s) = s[3] > length(L)
 end
 @inline done(L::LogicalIndex{Int,<:BitArray}, s) = s[2] > length(L)
 
-# Checking bounds with LogicalIndex{Int} is tricky since we allow linear indexing over trailing dimensions
-@inline checkbounds_indices(::Type{Bool},IA::Tuple{},I::Tuple{LogicalIndex{Int,AbstractArray{Bool,N}}}) where {N} =
-    checkindex(Bool, IA, I[1])
-@inline checkbounds_indices(::Type{Bool},IA::Tuple{Any},I::Tuple{LogicalIndex{Int,AbstractArray{Bool,N}}}) where {N} =
-    checkindex(Bool, IA[1], I[1])
-@inline function checkbounds_indices(::Type{Bool}, IA::Tuple, I::Tuple{LogicalIndex{Int,AbstractArray{Bool,N}}}) where N
-    IA1, IArest = IteratorsMD.split(IA, Val(N))
-    checkindex(Bool, IA1, I[1])
-end
 @inline checkbounds(::Type{Bool}, A::AbstractArray, I::LogicalIndex{<:Any,<:AbstractArray{Bool,1}}) =
     linearindices(A) == linearindices(I.mask)
 @inline checkbounds(::Type{Bool}, A::AbstractArray, I::LogicalIndex) = indices(A) == indices(I.mask)
@@ -490,15 +481,8 @@ _maybe_linear_logical_index(::IndexLinear, A, i) = LogicalIndex{Int}(i)
     (uncolon(inds, I), to_indices(A, _maybetail(inds), tail(I))...)
 
 const CI0 = Union{CartesianIndex{0}, AbstractArray{CartesianIndex{0}}}
-uncolon(inds::Tuple{},    I::Tuple{Colon})              = Slice(OneTo(1))
 uncolon(inds::Tuple{},    I::Tuple{Colon, Vararg{Any}}) = Slice(OneTo(1))
-uncolon(inds::Tuple{},    I::Tuple{Colon, Vararg{CI0}}) = Slice(OneTo(1))
-uncolon(inds::Tuple{Any}, I::Tuple{Colon})              = Slice(inds[1])
-uncolon(inds::Tuple{Any}, I::Tuple{Colon, Vararg{Any}}) = Slice(inds[1])
-uncolon(inds::Tuple{Any}, I::Tuple{Colon, Vararg{CI0}}) = Slice(inds[1])
 uncolon(inds::Tuple,      I::Tuple{Colon, Vararg{Any}}) = Slice(inds[1])
-uncolon(inds::Tuple,      I::Tuple{Colon})              = Slice(OneTo(trailingsize(inds)))
-uncolon(inds::Tuple,      I::Tuple{Colon, Vararg{CI0}}) = Slice(OneTo(trailingsize(inds)))
 
 ### From abstractarray.jl: Internal multidimensional indexing definitions ###
 getindex(x::Number, i::CartesianIndex{0}) = x

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -370,7 +370,7 @@ end
     replace_ref_end!(ex)
 
 Recursively replace occurrences of the symbol :end in a "ref" expression (i.e. A[...]) `ex`
-with the appropriate function calls (`endof`, `size` or `trailingsize`). Replacement uses
+with the appropriate function calls (`endof` or `size`). Replacement uses
 the closest enclosing ref, so
 
     A[B[end]]
@@ -402,7 +402,7 @@ function replace_ref_end_!(ex, withex)
             else
                 n = 1
                 J = endof(ex.args)
-                for j = 2:J-1
+                for j = 2:J
                     exj, used = replace_ref_end_!(ex.args[j],:($size($S,$n)))
                     used_S |= used
                     ex.args[j] = exj
@@ -418,8 +418,6 @@ function replace_ref_end_!(ex, withex)
                         n += 1
                     end
                 end
-                ex.args[J], used = replace_ref_end_!(ex.args[J],:($trailingsize($S,$n)))
-                used_S |= used
             end
             if used_S && S !== ex.args[1]
                 S0 = ex.args[1]

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1674,8 +1674,8 @@ static Value *emit_array_nd_index(jl_codectx_t &ctx,
         bool linear_indexing = nd == -1 || nidxs < (size_t)nd;
         if (linear_indexing && nidxs == 1) {
             // Check against the entire linear span of the array
-            Value *alen = emit_arraylen(ainfo, ex, ctx);
-            builder.CreateCondBr(builder.CreateICmpULT(i, alen), endBB, failBB);
+            Value *alen = emit_arraylen(ctx, ainfo, ex);
+            ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(i, alen), endBB, failBB);
         } else {
             // Compare the last index of the access against the last dimension of
             // the accessed array, i.e. `if !(last_index < last_dimension) goto error`.

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1672,33 +1672,10 @@ static Value *emit_array_nd_index(jl_codectx_t &ctx,
         // We have already emitted a bounds check for each index except for
         // the last one which we therefore have to do here.
         bool linear_indexing = nd == -1 || nidxs < (size_t)nd;
-        if (linear_indexing) {
-            // Compare the linearized index `i` against the linearized size of
-            // the accessed array, i.e. `if !(i < alen) goto error`.
-            if (nidxs > 1) {
-                // TODO: REMOVE DEPWARN AND RETURN FALSE AFTER 0.6.
-                // We need to check if this is inside the non-linearized size
-                BasicBlock *partidx = BasicBlock::Create(jl_LLVMContext, "partlinidx");
-                BasicBlock *partidxwarn = BasicBlock::Create(jl_LLVMContext, "partlinidxwarn");
-                Value *d = emit_arraysize_for_unsafe_dim(ctx, ainfo, ex, nidxs, nd);
-                ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(ii, d), endBB, partidx);
-
-                // We failed the normal bounds check; check to see if we're
-                // inside the linearized size (partial linear indexing):
-                ctx.f->getBasicBlockList().push_back(partidx);
-                ctx.builder.SetInsertPoint(partidx);
-                Value *alen = emit_arraylen(ctx, ainfo, ex);
-                ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(i, alen), partidxwarn, failBB);
-
-                // We passed the linearized bounds check; now throw the depwarn:
-                ctx.f->getBasicBlockList().push_back(partidxwarn);
-                ctx.builder.SetInsertPoint(partidxwarn);
-                ctx.builder.CreateCall(prepare_call(jldepwarnpi_func), ConstantInt::get(T_size, nidxs));
-                ctx.builder.CreateBr(endBB);
-            } else {
-                Value *alen = emit_arraylen(ctx, ainfo, ex);
-                ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(i, alen), endBB, failBB);
-            }
+        if (linear_indexing && nidxs == 1) {
+            // Check against the entire linear span of the array
+            Value *alen = emit_arraylen(ainfo, ex, ctx);
+            builder.CreateCondBr(builder.CreateICmpULT(i, alen), endBB, failBB);
         } else {
             // Compare the last index of the access against the last dimension of
             // the accessed array, i.e. `if !(last_index < last_dimension) goto error`.

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -343,7 +343,6 @@ static Function *expect_func;
 static Function *jldlsym_func;
 static Function *jlnewbits_func;
 static Function *jltypeassert_func;
-static Function *jldepwarnpi_func;
 //static Function *jlgetnthfield_func;
 static Function *jlgetnthfieldchecked_func;
 //static Function *jlsetnthfield_func;
@@ -6283,13 +6282,6 @@ static void init_julia_llvm_env(Module *m)
     jlgetfield_func = builtin_func_map[jl_f_getfield];
 
     jlapply2va_func = jlcall_func_to_llvm("jl_apply_2va", &jl_apply_2va, m);
-
-    std::vector<Type*> argsdepwarnpi(0);
-    argsdepwarnpi.push_back(T_size);
-    jldepwarnpi_func = Function::Create(FunctionType::get(T_void, argsdepwarnpi, false),
-                                        Function::ExternalLinkage,
-                                        "jl_depwarn_partial_indexing", m);
-    add_named_global(jldepwarnpi_func, &jl_depwarn_partial_indexing);
 
     std::vector<Type *> args_1ptr(0);
     args_1ptr.push_back(T_prjlvalue);

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -90,20 +90,16 @@
 ;; the array `a` in the `n`th index.
 ;; `tuples` are a list of the splatted arguments that precede index `n`
 ;; `last` = is this last index?
-;; returns a call to endof(a), trailingsize(a,n), or size(a,n)
+;; returns a call to endof(a) or size(a,n)
 (define (end-val a n tuples last)
   (if (null? tuples)
-      (if last
-          (if (= n 1)
-              `(call (top endof) ,a)
-              `(call (top trailingsize) ,a ,n))
+      (if (and last (= n 1))
+          `(call (top endof) ,a)
           `(call (top size) ,a ,n))
       (let ((dimno `(call (top +) ,(- n (length tuples))
                           ,.(map (lambda (t) `(call (top length) ,t))
                                  tuples))))
-        (if last
-            `(call (top trailingsize) ,a ,dimno)
-            `(call (top size) ,a ,dimno)))))
+            `(call (top size) ,a ,dimno))))
 
 ;; replace `end` for the closest ref expression, so doesn't go inside nested refs
 (define (replace-end ex a n tuples last)

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1016,26 +1016,6 @@ void jl_depwarn(const char *msg, jl_value_t *sym)
     JL_GC_POP();
 }
 
-JL_DLLEXPORT void jl_depwarn_partial_indexing(size_t n)
-{
-    static jl_value_t *depwarn_func = NULL;
-    if (!depwarn_func && jl_base_module) {
-        depwarn_func = jl_get_global(jl_base_module, jl_symbol("partial_linear_indexing_warning"));
-    }
-    if (!depwarn_func) {
-        jl_safe_printf("WARNING: Partial linear indexing is deprecated. Use "
-            "`reshape(A, Val(%zd))` to make the dimensionality of the array match "
-            "the number of indices\n", n);
-        return;
-    }
-    jl_value_t **depwarn_args;
-    JL_GC_PUSHARGS(depwarn_args, 2);
-    depwarn_args[0] = depwarn_func;
-    depwarn_args[1] = jl_box_long(n);
-    jl_apply(depwarn_args, 2);
-    JL_GC_POP();
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -16,10 +16,10 @@ A = rand(5,4,3)
     @test checkbounds(Bool, A, 2, 2, 2, 1) == true  # extra indices
     @test checkbounds(Bool, A, 2, 2, 2, 2) == false
     @test checkbounds(Bool, A, 1, 1)  == true       # partial linear indexing (PLI)
-    # @test checkbounds(Bool, A, 1, 12) == false     # PLI TODO: Re-enable after partial linear indexing deprecation
-    # @test checkbounds(Bool, A, 5, 12) == false     # PLI TODO: Re-enable after partial linear indexing deprecation
-    @test checkbounds(Bool, A, 1, 13) == false      # PLI
-    # @test checkbounds(Bool, A, 6, 12) == false    # PLI TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, 1, 12) == false
+    @test checkbounds(Bool, A, 5, 12) == false
+    @test checkbounds(Bool, A, 1, 13) == false
+    @test checkbounds(Bool, A, 6, 12) == false
 end
 
 @testset "single CartesianIndex" begin
@@ -32,15 +32,15 @@ end
     @test checkbounds(Bool, A, CartesianIndex((5, 5, 3))) == false
     @test checkbounds(Bool, A, CartesianIndex((5, 4, 4))) == false
     @test checkbounds(Bool, A, CartesianIndex((1,))) == true
-    # @test checkbounds(Bool, A, CartesianIndex((60,))) == false     # TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, CartesianIndex((60,))) == false
     @test checkbounds(Bool, A, CartesianIndex((61,))) == false
     @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 1,))) == true
     @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 2,))) == false
     @test checkbounds(Bool, A, CartesianIndex((1, 1,)))  == true
-    # @test checkbounds(Bool, A, CartesianIndex((1, 12,))) == false  # TODO: Re-enable after partial linear indexing deprecation
-    # @test checkbounds(Bool, A, CartesianIndex((5, 12,))) == false  # TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, CartesianIndex((1, 12,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((5, 12,))) == false
     @test checkbounds(Bool, A, CartesianIndex((1, 13,))) == false
-    # @test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false # TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false
 end
 
 @testset "mix of CartesianIndex and Int" begin
@@ -67,9 +67,9 @@ end
     @test checkbounds(Bool, A, 2, 2, 2, 1:1) == true  # extra indices
     @test checkbounds(Bool, A, 2, 2, 2, 1:2) == false
     @test checkbounds(Bool, A, 1:5, 1:4) == true
-    # @test checkbounds(Bool, A, 1:5, 1:12) == false # TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, 1:5, 1:12) == false
     @test checkbounds(Bool, A, 1:5, 1:13) == false
-    # @test checkbounds(Bool, A, 1:6, 1:12) == false # TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, 1:6, 1:12) == false
 end
 
 @testset "logical" begin
@@ -81,9 +81,9 @@ end
     @test checkbounds(Bool, A, trues(61)) == false
     @test checkbounds(Bool, A, 2, 2, 2, trues(1)) == true  # extra indices
     @test checkbounds(Bool, A, 2, 2, 2, trues(2)) == false
-    # @test checkbounds(Bool, A, trues(5), trues(12)) == false  # TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, trues(5), trues(12)) == false
     @test checkbounds(Bool, A, trues(5), trues(13)) == false
-    # @test checkbounds(Bool, A, trues(6), trues(12)) == false # TODO: Re-enable after partial linear indexing deprecation
+    @test checkbounds(Bool, A, trues(6), trues(12)) == false
     @test checkbounds(Bool, A, trues(5, 4, 3)) == true
     @test checkbounds(Bool, A, trues(5, 4, 2)) == false
     @test checkbounds(Bool, A, trues(5, 12)) == false
@@ -144,11 +144,6 @@ end
             @test ind2sub((1:4,1:3), k) == (i,j)
             @test sub2ind((0:3,3:5), i-1, j+2) == k
             @test ind2sub((0:3,3:5), k) == (i-1, j+2)
-        end
-        @testset "Delete when partial linear indexing is deprecated (#14770)" begin
-            @test sub2ind((4,3), 7) == 7
-            @test sub2ind((1:4,1:3), 7) == 7
-            @test sub2ind((0:3,3:5), 7) == 8
         end
     end
 
@@ -377,8 +372,8 @@ function test_vector_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where
         @test B[vec(idxs)] == A[vec(idxs)] == vec(idxs)
         @test B[:] == A[:] == collect(1:N)
         @test B[1:end] == A[1:end] == collect(1:N)
-        # @test B[:,:] == A[:,:] == reshape(1:N, shape[1], prod(shape[2:end])) # TODO: Re-enable after partial linear indexing deprecation
-        # @test B[1:end,1:end] == A[1:end,1:end] == reshape(1:N, shape[1], prod(shape[2:end])) # TODO: Re-enable after partial linear indexing deprecation
+        @test B[:,:] == A[:,:] == B[:,:,1] == A[:,:,1]
+            B[1:end,1:end] == A[1:end,1:end] == B[1:end,1:end,1] == A[1:end,1:end,1]
 
         @testset "Test with containers that aren't Int[]" begin
             @test B[[]] == A[[]] == []
@@ -395,7 +390,7 @@ function test_vector_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where
         @testset "test removing dimensions with 0-d arrays" begin
             idx0 = reshape([rand(1:size(A, 1))])
             @test B[idx0, idx2] == A[idx0, idx2] == reshape(A[idx0[], vec(idx2)], 4, 5) == reshape(B[idx0[], vec(idx2)], 4, 5)
-            # @test B[reshape([end]), reshape([end])] == A[reshape([end]), reshape([end])] == reshape([A[end,end]]) == reshape([B[end,end]]) # TODO: Re-enable after partial linear indexing deprecation
+            @test B[reshape([end]), reshape([end])] == A[reshape([end]), reshape([end])] == reshape([A[end,end]]) == reshape([B[end,end]])
         end
 
         mask = bitrand(shape)

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -34,11 +34,10 @@ _Agen(A, i1, i2, i3, i4) = [A[j1,j2,j3,j4] for j1 in i1, j2 in i2, j3 in i3, j4 
 
 function replace_colon(A::AbstractArray, I)
     Iout = Array{Any}(length(I))
-    for d = 1:length(I)-1
+    I == (:,) && return (1:length(A),)
+    for d = 1:length(I)
         Iout[d] = isa(I[d], Colon) ? (1:size(A,d)) : I[d]
     end
-    d = length(I)
-    Iout[d] = isa(I[d], Colon) ? (1:prod(size(A)[d:end])) : I[d]
     (Iout...,)
 end
 
@@ -226,11 +225,9 @@ end
 function runviews(SB::AbstractArray, indexN, indexNN, indexNNN)
     @assert ndims(SB) > 2
     for i3 in indexN, i2 in indexN, i1 in indexN
-        ndims(SB) > 3 && i3 isa Colon && continue # TODO: Re-enable once Colon no longer spans partial trailing dimensions
         runsubarraytests(SB, i1, i2, i3)
     end
     for i2 in indexN, i1 in indexN
-        i2 isa Colon && continue # TODO: Re-enable once Colon no longer spans partial trailing dimensions
         runsubarraytests(SB, i1, i2)
     end
     for i1 in indexNNN
@@ -282,9 +279,6 @@ _ndims(x) = 1
 if testfull
     let B = copy(reshape(1:13^3, 13, 13, 13))
         for o3 in oindex, o2 in oindex, o1 in oindex
-            if (o3 isa Colon && (_ndims(o1) + _ndims(o2) != 2))
-                continue # TODO: remove once Colon no longer spans partial trailing dimensions
-            end
             viewB = view(B, o1, o2, o3)
             runviews(viewB, index5, index25, index125)
         end
@@ -482,7 +476,7 @@ Y = 4:-1:1
 @test X[1:end] == @.(@view X[1:end]) # test compatibility of @. and @view
 @test X[1:end-3] == @view X[1:end-3]
 @test X[1:end,2,2] == @view X[1:end,2,2]
-# @test X[1,1:end-2] == @view X[1,1:end-2] # TODO: Re-enable after partial linear indexing deprecation
+@test X[1,1:end-2] == @view X[1,1:end-2]
 @test X[1,2,1:end-2] == @view X[1,2,1:end-2]
 @test X[1,2,Y[2:end]] == @view X[1,2,Y[2:end]]
 @test X[1:end,2,Y[2:end]] == @view X[1:end,2,Y[2:end]]
@@ -533,7 +527,7 @@ end
 @test X[1:end] == @views X[1:end]
 @test X[1:end-3] == @views X[1:end-3]
 @test X[1:end,2,2] == @views X[1:end,2,2]
-# @test X[1,1:end-2] == @views X[1,1:end-2] # TODO: Re-enable after partial linear indexing deprecation
+@test X[1,1:end-2] == @views X[1,1:end-2]
 @test X[1,2,1:end-2] == @views X[1,2,1:end-2]
 @test X[1,2,Y[2:end]] == @views X[1,2,Y[2:end]]
 @test X[1:end,2,Y[2:end]] == @views X[1:end,2,Y[2:end]]


### PR DESCRIPTION
This removes the partial linear indexing deprecation and implents the new behavior: Linear indexing now only takes effect when there is exactly one non-cartesian index.

I know we've typically held off on removing deprecation until the mid-end of the release cycle, but this is a more complicated removal than typical, and several features that I'd like to see in this release depend on or are much simpler with this deprecation gone. 