### PR TITLE
Fix a promotion failure with linspace

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -238,6 +238,7 @@ julia> linspace(1.3,2.9,9)
 ```
 """
 linspace(start, stop, len::Real=50) = linspace(promote_noncircular(start, stop)..., Int(len))
+linspace(start::T, stop::T, len::Real=50) where {T} = linspace(start, stop, Int(len))
 
 linspace(start::Real, stop::Real, len::Integer) = linspace(promote(start, stop)..., len)
 linspace(start::T, stop::T, len::Integer) where {T<:Integer} = linspace(Float64, start, stop, len, 1)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -25,6 +25,7 @@ L64 = @inferred(linspace(Int64(1), Int64(4), 4))
 @test L32[2] == 2 && L64[2] == 2
 @test L32[3] == 3 && L64[3] == 3
 @test L32[4] == 4 && L64[4] == 4
+@test @inferred(linspace(1.0, 2.0, 2.0f0)) === linspace(1.0, 2.0, 2)
 
 r = 5:-1:1
 @test r[1]==5


### PR DESCRIPTION
On 0.6, we have the following error:
```julia
julia> linspace(1.0, 2.0, 2.0f0)
ERROR: circular method definition: promotion of types Float64 and Float64 failed to change any input types
Stacktrace:
 [1] error(::String, ::String, ::Vararg{String,N} where N) at ./error.jl:30
 [2] sametype_error(::Float64, ::Vararg{Float64,N} where N) at ./promotion.jl:241
 [3] promote_noncircular at ./promotion.jl:216 [inlined]
 [4] linspace(::Float64, ::Float64, ::Float32) at ./range.jl:240
```
It tries to promote the first two arguments to a common type, but since they're already of a common type `promote_noncircular` complains. This just separates out the conversion to `Int`, distinguishing it from the need for promotion.
