### PR TITLE
Implement tryparse(Float16, str) via Float32 conversion

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -195,6 +195,8 @@ tryparse(::Type{Float32}, s::SubString{String}) = ccall(:jl_try_substrtof, Nulla
 
 tryparse(::Type{T}, s::AbstractString) where {T<:Union{Float32,Float64}} = tryparse(T, String(s))
 
+tryparse(::Type{Float16}, s::AbstractString) = convert(Nullable{Float16}, tryparse(Float32, s))
+
 function parse(::Type{T}, s::AbstractString) where T<:AbstractFloat
     result = tryparse(T, s)
     if isnull(result)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -674,6 +674,10 @@ end
 # error throwing branch from #10560
 @test_throws ArgumentError Base.tryparse_internal(Bool, "foo", 1, 2, 10, true)
 
+@test tryparse(Float64, "1.23") === Nullable(1.23)
+@test tryparse(Float32, "1.23") === Nullable(1.23f0)
+@test tryparse(Float16, "1.23") === Nullable(Float16(1.23))
+
 # PR #17393
 for op in (:.==, :.&, :.|, :.≤)
     @test parse("a $op b") == Expr(:call, op, :a, :b)


### PR DESCRIPTION
The `Float32` and `Float64` versions are implemented via a `ccall`, but for `Float16` I thought it wouldn't be cheating to just convert the `Float32` result.