### PR TITLE
fix error in `showerror` with backtraces from CapturedExceptions

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -136,6 +136,10 @@ end
 
 lookup(pointer::UInt) = lookup(convert(Ptr{Void}, pointer))
 
+# allow lookup on already-looked-up data for easier handling of pre-processed frames
+lookup(s::StackFrame) = StackFrame[s]
+lookup(s::Tuple{StackFrame,Int}) = StackFrame[s[1]]
+
 """
     stacktrace([trace::Vector{Ptr{Void}},] [c_funcs::Bool=false]) -> StackTrace
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1498,6 +1498,18 @@ if true
 end
 @test x == map(_->sin(2), 1:2)
 
+let thrown = false
+    try
+        remotecall_fetch(sqrt, 2, -1)
+    catch e
+        thrown = true
+        b = IOBuffer()
+        showerror(b, e)
+        @test contains(String(take!(b)), "sqrt will only return")
+    end
+    @test thrown
+end
+
 # Testing clear!
 function setup_syms(n, pids)
     syms = []


### PR DESCRIPTION
Example: `remotecall_fetch(sqrt, 2, -1)`

Before:

```
ERROR: On worker 2:
DomainError:
Stacktrace:
 [1] #remotecall_fetch#141(::Array{Any,1}, ::Function, ::Function, ::Base.Distributed.Worker, ::Base.Distributed.RRID, ::Vararg{Any,N} where N) at ./distributed/remotecall.jl:354
 [2] remotecall_fetch(::Function, ::Base.Distributed.Worker, ::Base.Distributed.RRID, ::Vararg{Any,N} where N) at ./distributed/remotecall.jl:346
 [3] #remotecall_fetch#144(::Array{Any,1}, ::Function, ::Function, ::Int64, ::Base.Distributed.RRID, ::Vararg{Any,N} where N) at ./distributed/remotecall.jl:367
 [4] remotecall_fetch(::Function, ::Int64, ::Base.Distributed.RRID, ::Vararg{Any,N} where N) at ./distributed/remotecall.jl:367
 [5] call_on_owner(::Function, ::Future, ::Int64, ::Vararg{Int64,N} where N) at ./distributed/remotecall.jl:440
 [6] wait(::Future) at ./distributed/remotecall.jl:455SYSTEM: show(lasterr) caused an error
MethodError(Base.StackTraces.lookup, ((f at REPL[1]:1, 1),), 0x0000000000005512)
```

after:

```
ERROR: On worker 2:
DomainError:
sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
sqrt at ./math.jl:431
#106 at ./distributed/process_messages.jl:268 [inlined]
run_work_thunk at ./distributed/process_messages.jl:56
macro expansion at ./distributed/process_messages.jl:268 [inlined]
#105 at ./event.jl:73
Stacktrace:
 [1] #remotecall_fetch#141(::Array{Any,1}, ::Function, ::Function, ::Base.Distributed.Worker, ::Int64, ::Vararg{Int64,N} where N) at ./distributed/remotecall.jl:354
 [2] remotecall_fetch(::Function, ::Base.Distributed.Worker, ::Int64, ::Vararg{Int64,N} where N) at ./distributed/remotecall.jl:346
 [3] #remotecall_fetch#144(::Array{Any,1}, ::Function, ::Function, ::Int64, ::Int64, ::Vararg{Int64,N} where N) at ./distributed/remotecall.jl:367
 [4] remotecall_fetch(::Function, ::Int64, ::Int64, ::Vararg{Int64,N} where N) at ./distributed/remotecall.jl:367
```

This affects `showerror` methods that look at the stack trace to generate more helpful messages. `DomainError` might be the only example of this, but I'm not sure.