### PR TITLE
give a syntax error for repeated keyword args. fixes #16937

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@ This section lists changes that do not have deprecation warnings.
   * `@__DIR__` returns the current working directory rather than `nothing` when not run
     from a file ([#21759]).
 
+  * Passing the same keyword argument multiple times is now a syntax error ([#16937]).
+
 
 Library improvements
 --------------------

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1439,6 +1439,11 @@
 ;; lower function call containing keyword arguments
 (define (lower-kw-call fexpr kw0 pa)
 
+  ;; check for keyword arguments syntactically passed more than once
+  (let ((dups (has-dups (map cadr (filter kwarg? kw0)))))
+    (if dups
+        (error (string "keyword argument \"" (car dups) "\" repeated in call to \"" (deparse fexpr) "\""))))
+
   (define (kwcall-unless-empty f pa kw-container-test kw-container)
     (let* ((expr_stmts (remove-argument-side-effects `(call ,f ,@pa)))
            (pa         (cddr (car expr_stmts)))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1187,3 +1187,7 @@ module Test21607
         x
     end === 1.0
 end
+
+# issue #16937
+@test expand(:(f(2, a=1, w=3, c=3, w=4, b=2))) == Expr(:error,
+                                                       "keyword argument \"w\" repeated in call to \"f\"")


### PR DESCRIPTION
I'm ok with just adding this error without a deprecation. This should be very uncommon and never did anything useful.