### PR TITLE
Fix sinpi and cospi with Irrational arguments

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -221,6 +221,15 @@ end
 log(::Irrational{:e}) = 1 # use 1 to correctly promote expressions like log(x)/log(e)
 log(::Irrational{:e}, x::Number) = log(x)
 
+# These methods should go to special/trig.jl, but Irrational is not yet defined when the
+# file is loaded.
+sinpi(x::Irrational) = sinpi(float(x))
+cospi(x::Irrational) = cospi(float(x))
+sinc(x::Irrational) = sinc(float(x))
+cosc(x::Irrational) = cosc(float(x))
+sinc(z::Complex{<:Irrational}) = sinc(float(z))
+cosc(z::Complex{<:Irrational}) = cosc(float(z))
+
 # align along = for nice Array printing
 function alignment(io::IO, x::Irrational)
     m = match(r"^(.*?)(=.*)$", sprint(0, showcompact, x, env=io))

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -221,15 +221,6 @@ end
 log(::Irrational{:e}) = 1 # use 1 to correctly promote expressions like log(x)/log(e)
 log(::Irrational{:e}, x::Number) = log(x)
 
-# These methods should go to special/trig.jl, but Irrational is not yet defined when the
-# file is loaded.
-sinpi(x::Irrational) = sinpi(float(x))
-cospi(x::Irrational) = cospi(float(x))
-sinc(x::Irrational) = sinc(float(x))
-cosc(x::Irrational) = cosc(float(x))
-sinc(z::Complex{<:Irrational}) = sinc(float(z))
-cosc(z::Complex{<:Irrational}) = cosc(float(z))
-
 # align along = for nice Array printing
 function alignment(io::IO, x::Irrational)
     m = match(r"^(.*?)(=.*)$", sprint(0, showcompact, x, env=io))

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -132,8 +132,8 @@ function sinpi(x::T) where T<:AbstractFloat
     end
 end
 
-# Rationals and other Real types
-function sinpi(x::T) where T<:Real
+# Integers and Rationals
+function sinpi(x::T) where T<:Union{Integer,Rational}
     Tf = float(T)
     if !isfinite(x)
         throw(DomainError())
@@ -191,8 +191,8 @@ function cospi(x::T) where T<:AbstractFloat
     end
 end
 
-# Rationals and other Real types
-function cospi(x::T) where T<:Real
+# Integers and Rationals
+function cospi(x::T) where T<:Union{Integer,Rational}
     if !isfinite(x)
         throw(DomainError())
     end
@@ -217,6 +217,8 @@ end
 
 sinpi(x::Integer) = x >= 0 ? zero(float(x)) : -zero(float(x))
 cospi(x::Integer) = isodd(x) ? -one(float(x)) : one(float(x))
+sinpi(x::Real) = sinpi(float(x))
+cospi(x::Real) = cospi(float(x))
 
 function sinpi(z::Complex{T}) where T
     F = float(T)
@@ -292,7 +294,8 @@ Compute ``\\sin(\\pi x) / (\\pi x)`` if ``x \\neq 0``, and ``1`` if ``x = 0``.
 """
 sinc(x::Number) = x==0 ? one(x)  : oftype(x,sinpi(x)/(pi*x))
 sinc(x::Integer) = x==0 ? one(x) : zero(x)
-sinc(x::Complex{<:Integer}) = sinc(float(x))
+sinc(x::Complex{<:AbstractFloat}) = x==0 ? one(x) : oftype(x, sinpi(x)/(pi*x))
+sinc(x::Complex) = sinc(float(x))
 sinc(x::Real) = x==0 ? one(x) : isinf(x) ? zero(x) : sinpi(x)/(pi*x)
 
 """
@@ -303,7 +306,8 @@ Compute ``\\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2)`` if ``x \\neq 0``, and
 """
 cosc(x::Number) = x==0 ? zero(x) : oftype(x,(cospi(x)-sinpi(x)/(pi*x))/x)
 cosc(x::Integer) = cosc(float(x))
-cosc(x::Complex{<:Integer}) = cosc(float(x))
+cosc(x::Complex{<:AbstractFloat}) = x==0 ? zero(x) : oftype(x,(cospi(x)-sinpi(x)/(pi*x))/x)
+cosc(x::Complex) = cosc(float(x))
 cosc(x::Real) = x==0 || isinf(x) ? zero(x) : (cospi(x)-sinpi(x)/(pi*x))/x
 
 for (finv, f) in ((:sec, :cos), (:csc, :sin), (:cot, :tan),

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -134,7 +134,7 @@ end
 
 # Rationals and other Real types
 function sinpi(x::T) where T<:Real
-    Tf = typeof(float(x))
+    Tf = float(T)
     if !isfinite(x)
         throw(DomainError())
     end

--- a/test/math.jl
+++ b/test/math.jl
@@ -379,6 +379,19 @@ end
     @test cosc(Inf) == 0
 end
 
+@testset "Irrational args to sinpi/cospi/sinc/cosc" begin
+    for x in (pi, e, golden)
+        @test sinpi(x) ≈ Float64(sinpi(big(x)))
+        @test cospi(x) ≈ Float64(cospi(big(x)))
+        @test sinc(x)  ≈ Float64(sinc(big(x)))
+        @test cosc(x)  ≈ Float64(cosc(big(x)))
+        @test sinpi(complex(x, x)) ≈ Complex{Float64}(sinpi(complex(big(x), big(x))))
+        @test cospi(complex(x, x)) ≈ Complex{Float64}(cospi(complex(big(x), big(x))))
+        @test sinc(complex(x, x))  ≈ Complex{Float64}(sinc(complex(big(x),  big(x))))
+        @test cosc(complex(x, x))  ≈ Complex{Float64}(cosc(complex(big(x),  big(x))))
+    end
+end
+
 @testset "trig function type stability" begin
     @testset "$T $f" for T = (Float32,Float64,BigFloat), f = (sind,cosd,sinpi,cospi)
         @test Base.return_types(f,Tuple{T}) == [T]


### PR DESCRIPTION
I replaced `typeof(float(x))` with `float(T)`, because after PR #21219 the latter doesn't allocate for `BigInt` and `Rational`.