### PR TITLE
Fix log1p with complex Irrational argument

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -546,7 +546,7 @@ function log1p(z::Complex{T}) where T
         # This is based on a well-known trick for log1p of real z,
         # allegedly due to Kahan, only modified to handle real(u) <= 0
         # differently to avoid inaccuracy near z==-2 and for correct branch cut
-        u = float(one(T)) + z
+        u = one(float(T)) + z
         u == 1 ? convert(typeof(u), z) : real(u) <= 0 ? log(u) : log(u)*z/(u-1)
     elseif isnan(zr)
         Complex(zr, zr)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -948,5 +948,6 @@ end
     for x in (pi, e, catalan) # No need to test all of them
         @test typeof(Complex(x, x)) == Complex{typeof(x)}
         @test exp(complex(x, x)) ≈ exp(x) * cis(x)
+        @test log1p(complex(x, x)) ≈ log(1 + complex(x, x))
     end
 end


### PR DESCRIPTION
Even if you don't like `Complex{Irrational}`, this change is a slight performance improvement, because after PR #21219 `float(T)` doesn't allocate with bignumbers and Rationals