### PR TITLE
Workaround for FreeBSD linking to outdated system libs

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -520,6 +520,36 @@ ifeq (exists, $(shell [ -e $(BUILDROOT)/Make.user ] && echo exists ))
 include $(BUILDROOT)/Make.user
 endif
 
+# A bit of a kludge to work around libraries linking to FreeBSD's outdated system libgcc_s
+# Instead, let's link to the libgcc_s corresponding to the installation of gfortran
+ifeq ($(OS),FreeBSD)
+ifneq (,$(findstring gfortran,$(FC)))
+
+# First let's figure out what version of GCC we're dealing with
+_GCCMAJOR := $(shell $(FC) -dumpversion | cut -d'.' -f1)
+_GCCMINOR := $(shell $(FC) -dumpversion | cut -d'.' -f2)
+
+# The ports system uses major and minor for GCC < 5 (e.g. gcc49 for GCC 4.9), otherwise major only
+ifeq ($(_GCCMAJOR),4)
+  _GCCVER := $(_GCCMAJOR)$(_GCCMINOR)
+else
+  _GCCVER := $(_GCCMAJOR)
+endif
+
+# Allow the user to specify this in Make.user
+GCCPATH ?= $(LOCALBASE)/lib/gcc$(_GCCVER)
+
+LDFLAGS += -L$(build_libdir) -L$(GCCPATH) -Wl,-rpath,$(build_libdir) -Wl,-rpath,$(GCCPATH)
+
+# This ensures we get the right RPATH even if we're missing FFLAGS somewhere
+FC += -Wl,-rpath=$(GCCPATH)
+
+# Build our own libc++ and libc++abi because otherwise /usr/lib/libc++.so and /lib/libcxxrt.so will
+# be linked in when building LLVM, and those link to /lib/libgcc_s.so
+BUILD_CUSTOM_LIBCXX ?= 1
+endif # gfortran
+endif # FreeBSD
+
 ifneq ($(CC_BASE)$(CXX_BASE),$(shell echo $(CC) | cut -d' ' -f1)$(shell echo $(CXX) | cut -d' ' -f1))
     $(error Forgot override directive on CC or CXX in Make.user? Cowardly refusing to build)
 endif

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -37,14 +37,7 @@ LIBGIT2_OPTS += -DCURL_INCLUDE_DIRS=$(build_includedir) -DCURL_LIBRARIES="-L$(bu
 endif
 
 ifeq ($(OS),Linux)
-LIBGIT2_OPTS += -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
-endif
-
-ifeq ($(OS),FreeBSD)
-# We're getting this from CMAKE_COMMON when GCCPATH is nonempty
-ifeq ($(GCCPATH),)
-LIBGIT2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
-endif
+LIBGIT2_OPTS += -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
 endif
 
 # We need to bundle ca certs on linux now that we're using libgit2 with ssl

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -41,7 +41,10 @@ LIBGIT2_OPTS += -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DCMAKE_INSTALL_RPATH="\$$ORI
 endif
 
 ifeq ($(OS),FreeBSD)
+# We're getting this from CMAKE_COMMON when GCCPATH is nonempty
+ifeq ($(GCCPATH),)
 LIBGIT2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
 endif
 
 # We need to bundle ca certs on linux now that we're using libgit2 with ssl

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -20,14 +20,6 @@ else
 LIBSSH2_OPTS += -DCRYPTO_BACKEND=mbedTLS -DENABLE_ZLIB_COMPRESSION=OFF
 endif
 
-ifeq ($(OS),Linux)
-LIBSSH2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
-endif
-
-ifeq ($(OS),FreeBSD)
-LIBSSH2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
-endif
-
 $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-encryptedpem.patch
 	echo 1 > $@

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -138,7 +138,6 @@ endif # BUILD_LLDB
 # Part of the FreeBSD libgcc_s kludge
 ifeq ($(OS),FreeBSD)
 ifneq ($(GCCPATH),)
-LLVM_CMAKE += -DCMAKE_INSTALL_RPATH="\$$ORIGIN:$(GCCPATH)"
 LLVM_LDFLAGS += -Wl,-rpath,'\$$ORIGIN',-rpath,$(GCCPATH)
 endif
 endif

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -135,6 +135,14 @@ LLVM_CMAKE += -DLLDB_DISABLE_PYTHON=ON
 endif # LLDB_DISABLE_PYTHON
 endif # BUILD_LLDB
 
+# Part of the FreeBSD libgcc_s kludge
+ifeq ($(OS),FreeBSD)
+ifneq ($(GCCPATH),)
+LLVM_CMAKE += -DCMAKE_INSTALL_RPATH="\$$ORIGIN:$(GCCPATH)"
+LLVM_LDFLAGS += -Wl,-rpath,'\$$ORIGIN',-rpath,$(GCCPATH)
+endif
+endif
+
 ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
 LLVM_CXXFLAGS += -mminimal-toc
 endif

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -20,7 +20,10 @@ MBEDTLS_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
 ifeq ($(OS),FreeBSD)
+# We're getting this from CMAKE_COMMON when GCCPATH is nonempty
+ifeq ($(GCCPATH),)
 MBEDTLS_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
 endif
 
 $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz: | $(SRCDIR)/srccache

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -15,17 +15,6 @@ ifeq ($(BUILD_OS),WINNT)
 MBEDTLS_OPTS += -G"MSYS Makefiles"
 endif
 
-ifeq ($(OS),Linux)
-MBEDTLS_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
-endif
-
-ifeq ($(OS),FreeBSD)
-# We're getting this from CMAKE_COMMON when GCCPATH is nonempty
-ifeq ($(GCCPATH),)
-MBEDTLS_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
-endif
-endif
-
 $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ $(MBEDTLS_URL)
 

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -37,12 +37,16 @@ CMAKE_COMMON += -DCMAKE_RC_COMPILER="$$(which $(CROSS_COMPILE)windres)"
 endif
 endif
 
+ifneq (,$(findstring $(OS),Linux FreeBSD))
+INSTALL_RPATH := "\$$ORIGIN"
 # Part of the FreeBSD libgcc_s kludge
 ifeq ($(OS),FreeBSD)
 ifneq ($(GCCPATH),)
-CMAKE_COMMON += -DCMAKE_INSTALL_RPATH="\$$ORIGIN:$(GCCPATH)"
+INSTALL_RPATH := "\$$ORIGIN:$(GCCPATH)"
 endif
 endif
+CMAKE_COMMON += -DCMAKE_INSTALL_RPATH=$(INSTALL_RPATH)
+endif # Linux or FreeBSD
 
 # For now this is LLVM specific, but I expect it won't be in the future
 ifeq ($(LLVM_USE_CMAKE),1)

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -37,6 +37,13 @@ CMAKE_COMMON += -DCMAKE_RC_COMPILER="$$(which $(CROSS_COMPILE)windres)"
 endif
 endif
 
+# Part of the FreeBSD libgcc_s kludge
+ifeq ($(OS),FreeBSD)
+ifneq ($(GCCPATH),)
+CMAKE_COMMON += -DCMAKE_INSTALL_RPATH="\$$ORIGIN:$(GCCPATH)"
+endif
+endif
+
 # For now this is LLVM specific, but I expect it won't be in the future
 ifeq ($(LLVM_USE_CMAKE),1)
 ifeq ($(CMAKE_GENERATOR),Ninja)


### PR DESCRIPTION
FreeBSD's system libgcc_s declares its GCC version as 4.6, which is too old to build Julia. Since gfortran doesn't come installed by default, when it's installed it's done so through a GCC port, which includes its own libgcc_s. Linking to libgfortran from the port and to the system's libgcc_s causes versioning issues which wreck the build.

This PR works around this issue by determining the version of GCC used for gfortran, then linking in the libgcc_s corresponding to that version everywhere. It's a bit of a kludge, but it gets the job done.
With this change, all libraries which need to link to libgcc_s link to the proper version.