### PR TITLE
Clarify precedence of numeric literal coefs over parenthesis

### DIFF
--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -611,12 +611,12 @@ Numeric literals also work as coefficients to parenthesized expressions:
 julia> 2(x-1)^2 - 3(x-1) + 1
 3
 ```
-
-!!! warning
-    Notice that, in this case, the precedence of numeric literal coefficient is
-    still the same as that of the unary operators. Hence, the expression
-    `6/2(2+1)` leads to `1` instead of the conventional result `9`, which is
-    obtained by `6/2*(2+1)`.
+!!! note
+    The precedence of numeric literal coefficients used for implicit
+    multiplication is higher than other binary operators such as multiplication
+    (`*`), division (`/`, `\`, and `//`), and exponentiation (`^`).  This means,
+    for example, that `1 / 2im` equals `-0.5im` and `6 // 2(2 + 1)` equals
+    `1 // 1`.
 
 Additionally, parenthesized expressions can be used as coefficients to variables, implying multiplication
 of the expression by the variable:

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -614,9 +614,8 @@ julia> 2(x-1)^2 - 3(x-1) + 1
 !!! note
     The precedence of numeric literal coefficients used for implicit
     multiplication is higher than other binary operators such as multiplication
-    (`*`), division (`/`, `\`, and `//`), and exponentiation (`^`).  This means,
-    for example, that `1 / 2im` equals `-0.5im` and `6 // 2(2 + 1)` equals
-    `1 // 1`.
+    (`*`), and division (`/`, `\`, and `//`).  This means, for example, that
+    `1 / 2im` equals `-0.5im` and `6 // 2(2 + 1)` equals `1 // 1`.
 
 Additionally, parenthesized expressions can be used as coefficients to variables, implying multiplication
 of the expression by the variable:

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -612,6 +612,12 @@ julia> 2(x-1)^2 - 3(x-1) + 1
 3
 ```
 
+!!! warning
+    Notice that, in this case, the precedence of numeric literal coefficient is
+    still the same as that of the unary operators. Hence, the expression
+    `6/2(2+1)` leads to `1` instead of the conventional result `9`, which is
+    obtained by `6/2*(2+1)`.
+
 Additionally, parenthesized expressions can be used as coefficients to variables, implying multiplication
 of the expression by the variable:
 


### PR DESCRIPTION
As stated in issue #21798, it was not clear to me that the precedence of numeric literal coefficients with parenthesized expressions is also the same as that of unary operators. This caused confusion with expressions like `6/2(2+1)`, which results in `1` in julia, but conventionally it should be `9`. Hence, the documentation was slightly modified to make this fact much clear.