### PR TITLE
add link to libuv's uv_os_homedir documentation to homedir's docstring

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -53,6 +53,11 @@ splitdrive(path::AbstractString)
     homedir() -> AbstractString
 
 Return the current user's home directory.
+
+!!! note
+    `homedir` determines the home directory via `libuv`'s `uv_os_homedir`. For details
+    (for example on how to specify the home directory via environment variables), see the
+    [`uv_os_homedir` documentation](http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_homedir).
 """
 function homedir()
     path_max = 1024


### PR DESCRIPTION
#19636 reimplemented `homedir` via `libuv`'s `uv_os_homedir`, prompting a question towards the end of #19636: How does one now influence `homedir` via environment variables? Anticipating that question might become common, this pull request adds a note to `homedir`'s docstring pointing to `uv_os_homedir`'s documentation (following the resolution in #19636). Best!