### PR TITLE
improve cache locality in sparse * dense

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -61,8 +61,8 @@ for (f, op, transp) in ((:A_mul_B, :identity, false),
             if β != 1
                 β != 0 ? scale!(C, β) : fill!(C, zero(eltype(C)))
             end
-            for col = 1:A.n
-                for k = 1:size(C, 2)
+            for k = 1:size(C, 2)
+                for col = 1:A.n
                     if $transp
                         tmp = zero(eltype(C))
                         @inbounds for j = A.colptr[col]:(A.colptr[col + 1] - 1)


### PR DESCRIPTION
Should fix JuliaLang/LinearAlgebra.jl#427 cc @lruthotto 

Benchmark:

```jl
t = []
for n in [1, 5, 10, 20, 40, 100]
    B = randn(100000, n)
    A = sprandn(100000,100000, 0.001)
    push!(t, (@elapsed A * B) / n);
end
```

Master: `[0.146273, 0.113295, 0.11342, 0.225131, 0.302216, 0.176864]`
PR: `[0.126037, 0.086543, 0.0889958, 0.0847611, 0.088924, 0.0874686]`