### PR TITLE
Fix and enforce reinterpret/unsafe_wrap alignment

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -283,11 +283,12 @@ function copy_to_bitarray_chunks!(Bc::Vector{UInt64}, pos_d::Int, C::Array{Bool}
     nc8 = (nc >>> 3) << 3
     if nc8 > 0
         ind8 = 1
-        C8 = reinterpret(UInt64, unsafe_wrap(Array, pointer(C, ind), nc8 << 6))
+        P8 = Ptr{UInt64}(pointer(C, ind)) # unaligned i64 pointer
         @inbounds for i = 1:nc8
             c = UInt64(0)
             for j = 0:7
-                c |= (pack8bools(C8[ind8]) << (j<<3))
+                # unaligned load
+                c |= (pack8bools(unsafe_load(P8, ind8)) << (j<<3))
                 ind8 += 1
             end
             Bc[bind] = c

--- a/base/dSFMT.jl
+++ b/base/dSFMT.jl
@@ -89,9 +89,13 @@ end
 
 # dSFMT jump
 function dsfmt_jump(s::DSFMT_state, jp::AbstractString)
-    index = s.val[end-1]
-    work = zeros(UInt64, JN32>>1)
-    dsfmt = reinterpret(UInt64, copy(s.val))
+    val = s.val
+    nval = length(val)
+    index = val[nval - 1]
+    work = zeros(UInt64, JN32 >> 1)
+    dsfmt = Vector{UInt64}(nval >> 1)
+    ccall(:memcpy, Ptr{Void}, (Ptr{UInt64}, Ptr{Int32}, Csize_t),
+          dsfmt, val, (nval - 1) * sizeof(Int32))
     dsfmt[end] = UInt64(N*2)
 
     for c in jp

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1063,6 +1063,14 @@ For example,
 `reinterpret(Float32, UInt32(7))` interprets the 4 bytes corresponding to `UInt32(7)` as a
 `Float32`.
 
+!!! warning
+
+    It is not allowed to `reinterpret` an array to an element type with a larger alignment then
+    the alignment of the array. For a normal `Array`, this is the alignment of its element type.
+    For a reinterpreted array, this is the alignment of the `Array` it was reinterpreted from.
+    For example, `reinterpret(UInt32, UInt8[0, 0, 0, 0])` is not allowed but
+    `reinterpret(UInt32, reinterpret(UInt8, Float32[1.0]))` is allowed.
+
 ```jldoctest
 julia> reinterpret(Float32, UInt32(7))
 1.0f-44

--- a/base/io.jl
+++ b/base/io.jl
@@ -215,6 +215,25 @@ readlines(s=STDIN; chomp::Bool=true) = collect(eachline(s, chomp=chomp))
 
 ## byte-order mark, ntoh & hton ##
 
+let endian_boms = reinterpret(UInt8, UInt32[0x01020304])
+    global ntoh, hton, ltoh, htol
+    if endian_boms == UInt8[1:4;]
+        ntoh(x) = x
+        hton(x) = x
+        ltoh(x) = bswap(x)
+        htol(x) = bswap(x)
+        const global ENDIAN_BOM = 0x01020304
+    elseif endian_boms == UInt8[4:-1:1;]
+        ntoh(x) = bswap(x)
+        hton(x) = bswap(x)
+        ltoh(x) = x
+        htol(x) = x
+        const global ENDIAN_BOM = 0x04030201
+    else
+        error("seriously? what is this machine?")
+    end
+end
+
 """
     ENDIAN_BOM
 
@@ -222,22 +241,7 @@ The 32-bit byte-order-mark indicates the native byte order of the host machine.
 Little-endian machines will contain the value `0x04030201`. Big-endian machines will contain
 the value `0x01020304`.
 """
-const ENDIAN_BOM = reinterpret(UInt32,UInt8[1:4;])[1]
-
-if ENDIAN_BOM == 0x01020304
-    ntoh(x) = x
-    hton(x) = x
-    ltoh(x) = bswap(x)
-    htol(x) = bswap(x)
-elseif ENDIAN_BOM == 0x04030201
-    ntoh(x) = bswap(x)
-    hton(x) = bswap(x)
-    ltoh(x) = x
-    htol(x) = x
-else
-    error("seriously? what is this machine?")
-end
-
+ENDIAN_BOM
 
 """
     ntoh(x)

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -69,10 +69,10 @@ const OPTIONS_MASK = COMPILE_MASK | EXECUTE_MASK
 
 const UNSET = ~Csize_t(0)  # Indicates that an output vector element is unset
 
-function info(regex::Ptr{Void}, what::Integer, T)
-    buf = zeros(UInt8,sizeof(T))
+function info(regex::Ptr{Void}, what::Integer, ::Type{T}) where T
+    buf = Ref{T}()
     ret = ccall((:pcre2_pattern_info_8, PCRE_LIB), Int32,
-                (Ptr{Void}, Int32, Ptr{UInt8}),
+                (Ptr{Void}, Int32, Ptr{Void}),
                 regex, what, buf)
     if ret != 0
         error(ret == ERROR_NULL      ? "NULL regex object" :
@@ -80,7 +80,7 @@ function info(regex::Ptr{Void}, what::Integer, T)
               ret == ERROR_BADOPTION ? "invalid option flags" :
                                        "unknown error $ret")
     end
-    reinterpret(T,buf)[1]
+    buf[]
 end
 
 function get_ovec(match_data)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4848,12 +4848,15 @@ end
 let ni128 = sizeof(FP128test) ÷ sizeof(Int),
     ns128 = sizeof(FP128align) ÷ sizeof(Int),
     nbit = sizeof(Int) * 8,
-    arr = reinterpret(FP128align, collect(Int, 1:(2 * ns128))),
+    arr = Vector{FP128align}(2),
     offset = Base.datatype_alignment(FP128test) ÷ sizeof(Int),
     little,
-    expected
+    expected,
+    arrint = reinterpret(Int, arr)
+
+    @test length(arrint) == 2 * ns128
+    arrint .= 1:(2 * ns128)
     @test sizeof(FP128test) == 16
-    @test length(arr) == 2
     @test arr[1].i == 1
     @test arr[2].i == 1 + ns128
     expected = UInt128(0)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -678,3 +678,26 @@ let foo() = begin
     end
     @test foo() == 2
 end
+
+# Endian tests
+# For now, we only support little endian.
+# Add an `Sys.ARCH` test for big endian when/if we add support for that.
+# Do **NOT** use `ENDIAN_BOM` to figure out the endianess
+# since that's exactly what we want to test.
+@test ENDIAN_BOM == 0x04030201
+@test ntoh(0x1) == 0x1
+@test hton(0x1) == 0x1
+@test ltoh(0x1) == 0x1
+@test htol(0x1) == 0x1
+@test ntoh(0x102) == 0x201
+@test hton(0x102) == 0x201
+@test ltoh(0x102) == 0x102
+@test htol(0x102) == 0x102
+@test ntoh(0x1020304) == 0x4030201
+@test hton(0x1020304) == 0x4030201
+@test ltoh(0x1020304) == 0x1020304
+@test htol(0x1020304) == 0x1020304
+@test ntoh(0x102030405060708) == 0x807060504030201
+@test hton(0x102030405060708) == 0x807060504030201
+@test ltoh(0x102030405060708) == 0x102030405060708
+@test htol(0x102030405060708) == 0x102030405060708


### PR DESCRIPTION
The first commit is a bug fix that fixes a LLVM undefined behavior which actually cause segfault on ARM and is the one that should be backported. The second commit is to reflect this semantic requirement in the julia API so that we won't have this kind of bug in the future especially since we've actually had [this kind of bug in the test before](https://github.com/JuliaLang/julia/pull/14551)...

It is in principle possible to loosen the alignment check in `reinterpret` on the pointer though that make this kind of bug much harder to catch/reason about. We should ideally also run PkgEval on it to identify buggy packages.
