### PR TITLE
RFC: Fixed relative path include on remote machines

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -263,6 +263,9 @@ const _require_dependencies = Any[] # a list of (path, mtime) tuples that are th
 const _track_dependencies = Ref(false) # set this to true to track the list of file dependencies
 function _include_dependency(_path::AbstractString)
     prev = source_path(nothing)
+    if myid() != 1 && prev === nothing
+        prev = remotecall_fetch(abspath, 1, ".")
+    end
     path = (prev === nothing) ? abspath(_path) : joinpath(dirname(prev), _path)
     if myid() == 1 && _track_dependencies[]
         apath = abspath(path)
@@ -817,3 +820,4 @@ function stale_cachefile(modpath::String, cachefile::String)
         close(io)
     end
 end
+

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -820,4 +820,3 @@ function stale_cachefile(modpath::String, cachefile::String)
         close(io)
     end
 end
-

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -273,8 +273,7 @@ function _include_dependency(_path::AbstractString)
         path = joinpath(dirname(prev), _path)
     end
     if myid() == 1 && _track_dependencies[]
-        apath = abspath(path)
-        push!(_require_dependencies, (apath, mtime(apath)))
+        push!(_require_dependencies, (path, mtime(path)))
     end
     return path, prev
 end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1570,44 +1570,38 @@ catch ex
 end
 
 @test let
-    # creates a new worker in the same folder and tries to include file on both procs
-    working_directory = pwd()
-    cd(tempdir())
+    # creates a new worker in the same folder and tries to include file
+    tmp_file = relpath(mktemp()[1])
     try
-        tmp_file = relpath(mktemp()[1])
         proc = addprocs_with_testenv(1)
         include(tmp_file)
         remotecall_fetch(include, proc[1], tmp_file)
         rmprocs(proc)
         rm(tmp_file)
-        cd(working_directory)
         return true
     catch e
-        try rm(tmp_file) end
-        cd(working_directory)
+        println(e)
+        rm(tmp_file, force=true)
         return false
     end
 end == true
 
 @test let
-    # creates a new worker in the different folder and tries to include file on both procs
-    working_directory = pwd()
-    cd(tempdir())
+    # creates a new worker in the different folder and tries to include file
+    tmp_file = relpath(mktemp()[1])
+    tmp_dir = relpath(mktempdir())
     try
-        tmp_file = relpath(mktemp()[1])
-        tmp_dir = relpath(mktempdir())
         proc = addprocs_with_testenv(1, dir=tmp_dir)
         include(tmp_file)
         remotecall_fetch(include, proc[1], tmp_file)
         rmprocs(proc)
         rm(tmp_dir)
         rm(tmp_file)
-        cd(working_directory)
         return true
     catch e
-        try rm(tmp_dir) end
-        try rm(tmp_file) end
-        cd(working_directory)
+        println(e)
+        rm(tmp_dir, force=true)
+        rm(tmp_file, force=true)
         return false
     end
 end == true

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1571,7 +1571,9 @@ end
 
 @test let
     # creates a new worker in the same folder and tries to include file
-    tmp_file = relpath(mktemp()[1])
+    tmp_file, temp_file_stream = mktemp()
+    close(temp_file_stream)
+    tmp_file = relpath(tmp_file)
     try
         proc = addprocs_with_testenv(1)
         include(tmp_file)
@@ -1588,7 +1590,9 @@ end == true
 
 @test let
     # creates a new worker in the different folder and tries to include file
-    tmp_file = relpath(mktemp()[1])
+    tmp_file, temp_file_stream = mktemp()
+    close(temp_file_stream)
+    tmp_file = relpath(tmp_file)
     tmp_dir = relpath(mktempdir())
     try
         proc = addprocs_with_testenv(1, dir=tmp_dir)

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1571,35 +1571,43 @@ end
 
 @test let
     # creates a new worker in the same folder and tries to include file on both procs
+    working_directory = pwd()
+    cd(tempdir())
     try
-        touch("temp.jl")
+        tmp_file = relpath(mktemp()[1])
         proc = addprocs_with_testenv(1)
-        include("temp.jl")
-        remotecall_fetch(include, proc[1], "temp.jl")
+        include(tmp_file)
+        remotecall_fetch(include, proc[1], tmp_file)
         rmprocs(proc)
-        rm("temp.jl")
+        rm(tmp_file)
+        cd(working_directory)
         return true
     catch e
-        try rm("temp.jl") end
+        try rm(tmp_file) end
+        cd(working_directory)
         return false
     end
 end == true
 
 @test let
     # creates a new worker in the different folder and tries to include file on both procs
+    working_directory = pwd()
+    cd(tempdir())
     try
-        mkdir("temp_folder")
-        touch("temp.jl")
-        proc = addprocs_with_testenv(1, dir="temp_folder")
-        include("temp.jl")
-        remotecall_fetch(include, proc[1], "temp.jl")
+        tmp_file = relpath(mktemp()[1])
+        tmp_dir = relpath(mktempdir())
+        proc = addprocs_with_testenv(1, dir=tmp_dir)
+        include(tmp_file)
+        remotecall_fetch(include, proc[1], tmp_file)
         rmprocs(proc)
-        rm("temp_folder")
-        rm("temp.jl")
+        rm(tmp_dir)
+        rm(tmp_file)
+        cd(working_directory)
         return true
     catch e
-        try rm("temp_folder") end
-        try rm("temp.jl") end
+        try rm(tmp_dir) end
+        try rm(tmp_file) end
+        cd(working_directory)
         return false
     end
 end == true


### PR DESCRIPTION
The fix of https://github.com/JuliaLang/julia/issues/21679
This code works when the remote machine tries to include the file using the current working directory. Previously the machine was resolving the path locally, what could lead to errors with relative paths. In the case of `include("file.jl")` machine remote@remotehost could try to download `/home/remote/file.jl` from the main machine local@localhost when the true file location is `/home/local/file.jl`.
Now if the remote machine has to use working directory to include files it will use the main machine working directory instead.