### PR TITLE
VersionNumber and return build in windows_version

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -159,7 +159,6 @@ include(string((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "version_git.jl")) # 
 
 include("osutils.jl")
 include("c.jl")
-include("sysinfo.jl")
 
 if !isdefined(Core, :Inference)
     include("docs/core.jl")
@@ -200,6 +199,7 @@ importall .Base64
 include("version.jl")
 
 # system & environment
+include("sysinfo.jl")
 include("libc.jl")
 using .Libc: getpid, gethostname, time
 include("libdl.jl")

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -183,19 +183,19 @@ maxrss() = ccall(:jl_maxrss, Csize_t, ())
 if is_windows()
     function windows_version()
         verinfo = ccall(:GetVersion, UInt32, ())
-        (Int(verinfo & 0xFF), Int((verinfo >> 8) & 0xFF))
+        VersionNumber(verinfo & 0xFF, (verinfo >> 8) & 0xFF, verinfo >> 16)
     end
 else
-    windows_version() = (0, 0)
+    windows_version() = v"0.0"
 end
 """
     windows_version()
 
-Returns the version number for the Windows NT Kernel as a (major, minor) pair,
-or `(0, 0)` if this is not running on Windows.
+Returns the version number for the Windows NT Kernel as a VersionNumber,
+i.e. v"major.minor.build", or `v"0.0.0` if this is not running on Windows.
 """
 windows_version
 
-const WINDOWS_VISTA_VER = (6, 0)
+const WINDOWS_VISTA_VER = v"6.0"
 
 end # module Sys

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -191,8 +191,8 @@ end
 """
     windows_version()
 
-Returns the version number for the Windows NT Kernel as a VersionNumber,
-i.e. v"major.minor.build", or `v"0.0.0` if this is not running on Windows.
+Returns the version number for the Windows NT Kernel as a `VersionNumber`,
+i.e. `v"major.minor.build"`, or `v"0.0.0"` if this is not running on Windows.
 """
 windows_version
 

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -13,9 +13,9 @@
 @test Base.is_unix(:FreeBSD)
 @test_throws ArgumentError Base.is_unix(:BeOS)
 if !is_windows()
-    @test Sys.windows_version() === (0, 0)
+    @test Sys.windows_version() == v"0.0.0"
 else
-    @test (Sys.windows_version()::Tuple{Int,Int})[1] > 0
+    @test Sys.windows_version() > v"0.0.0"
 end
 
 @test (@static true ? 1 : 2) === 1

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -15,7 +15,7 @@
 if !is_windows()
     @test Sys.windows_version() == v"0.0.0"
 else
-    @test Sys.windows_version() > v"0.0.0"
+    @test Sys.windows_version() >= v"1.0.0-"
 end
 
 @test (@static true ? 1 : 2) === 1


### PR DESCRIPTION
Use VersionNumber for windows_version function and also return the build number in the patch field.

Ref https://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx

