### PR TITLE
Build release tags on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ branches:
   only:
     - master
     - /^release-.*/
+    - /^v\d+\.\d+\.\d+$/
 notifications:
     email: false
     irc:

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -194,8 +194,8 @@ julia> take!(c)
 julia> put!(c,1);
 ERROR: foo
 Stacktrace:
- [1] check_channel_state(::Channel{Any}) at ./channels.jl:126
- [2] put!(::Channel{Any}, ::Int64) at ./channels.jl:256
+ [1] check_channel_state(::Channel{Any}) at ./channels.jl:131
+ [2] put!(::Channel{Any}, ::Int64) at ./channels.jl:261
 ```
 """
 function bind(c::Channel, task::Task)

--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
-Compat 0.24.0 0.24.0+
+Compat 0.25.0 0.25.0+
 DocStringExtensions 0.3.3 0.3.3+
-Documenter 0.10.0 0.10.0+
+Documenter 0.10.2 0.10.2+


### PR DESCRIPTION
this should hopefully result in automatic docs deployment to release-0.6

cc @mortenpi @MichaelHatherly is this right, will travis builds from a tag just do the right thing to gh-pages here? It looks like 0.5.1/0.5.2 might need to be built and committed manually to gh-pages for release-0.5?