### PR TITLE
Fix deprecated indexing of open call in windows displaysize

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -638,3 +638,6 @@ Command-line option changes
 [#20609]: https://github.com/JuliaLang/julia/issues/20609
 [#20889]: https://github.com/JuliaLang/julia/issues/20889
 [#21183]: https://github.com/JuliaLang/julia/issues/21183
+[#21359]: https://github.com/JuliaLang/julia/issues/21359
+[#21697]: https://github.com/JuliaLang/julia/issues/21697
+[#21759]: https://github.com/JuliaLang/julia/issues/21759

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -362,7 +362,7 @@ function displaysize(io::TTY)
         if ispty(io)
             # io is actually a libuv pipe but a cygwin/msys2 pty
             try
-                h, w = map(x -> parse(Int, x), split(readstring(open(Base.Cmd(String["stty", "size"]), "r", io)[1])))
+                h, w = parse.(Int, split(readstring(open(Base.Cmd(String["stty", "size"]), "r", io).out)))
                 h > 0 || (h = default_size[1])
                 w > 0 || (w = default_size[2])
                 return h, w


### PR DESCRIPTION
missed from #12807, only happens when running in mintty

also run NEWS-update, just so the 0.7 diff doesn't show up for other news PR's that should be backported (this one should not since #12807 is 0.7-only)