### PR TITLE
Use julia-repl in manual & other edits

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -480,7 +480,7 @@ default is an `Array{element_type}(dims...)`.
 For example, `similar(1:10, 1, 4)` returns an uninitialized `Array{Int,2}` since ranges are
 neither mutable nor support 2 dimensions:
 
-```julia
+```julia-repl
 julia> similar(1:10, 1, 4)
 1×4 Array{Int64,2}:
  4419743872  4374413872  4419743888  0
@@ -489,7 +489,7 @@ julia> similar(1:10, 1, 4)
 Conversely, `similar(trues(10,10), 2)` returns an uninitialized `BitVector` with two
 elements since `BitArray`s are both mutable and can support 1-dimensional arrays:
 
-```julia
+```julia-repl
 julia> similar(trues(10,10), 2)
 2-element BitArray{1}:
  false
@@ -499,7 +499,7 @@ julia> similar(trues(10,10), 2)
 Since `BitArray`s can only store elements of type `Bool`, however, if you request a
 different element type it will create a regular `Array` instead:
 
-```julia
+```julia-repl
 julia> similar(falses(10), Float64, 2, 4)
 2×4 Array{Float64,2}:
  2.18425e-314  2.18425e-314  2.18425e-314  2.18425e-314

--- a/base/array.jl
+++ b/base/array.jl
@@ -701,7 +701,7 @@ julia> resize!([6, 5, 4, 3, 2, 1], 3)
  4
 ```
 
-```julia
+```julia-repl
 julia> resize!([6, 5, 4, 3, 2, 1], 8)
 8-element Array{Int64,1}:
  6

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -35,7 +35,7 @@ end
 Construct an uninitialized `BitArray` with the given dimensions.
 Behaves identically to the [`Array`](@ref) constructor.
 
-```julia
+```julia-repl
 julia> BitArray(2, 2)
 2×2 BitArray{2}:
  false  false

--- a/base/distributed/pmap.jl
+++ b/base/distributed/pmap.jl
@@ -60,7 +60,7 @@ which is then returned inline with the results to the caller.
 
 Consider the following two examples. The first one returns the exception object inline,
 the second a 0 in place of any exception:
-```julia
+```julia-repl
 julia> pmap(x->iseven(x) ? error("foo") : x, 1:4; on_error=identity)
 4-element Array{Any,1}:
  1

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1957,7 +1957,7 @@ julia> convert(Int, 3.0)
 julia> convert(Int, 3.5)
 ERROR: InexactError()
 Stacktrace:
- [1] convert(::Type{Int64}, ::Float64) at ./float.jl:679
+ [1] convert(::Type{Int64}, ::Float64) at ./float.jl:680
 ```
 
 If `T` is a `AbstractFloat` or `Rational` type,

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -75,7 +75,7 @@ is in the repository.
 
 # Example
 
-```julia
+```julia-repl
 julia> repo = LibGit2.GitRepo(repo_path);
 
 julia> LibGit2.add!(repo, test_file);
@@ -220,7 +220,7 @@ Returns `true` if `a`, a [`GitHash`](@ref) in string form, is an ancestor of
 
 # Example
 
-```julia
+```julia-repl
 julia> repo = LibGit2.GitRepo(repo_path);
 
 julia> LibGit2.add!(repo, test_file1);
@@ -954,4 +954,3 @@ end
 
 
 end # module
-

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -48,7 +48,7 @@ end
 Returns a shortened version of the name of `ref` that's
 "human-readable".
 
-```julia
+```julia-repl
 julia> repo = LibGit2.GitRepo(path_to_repo);
 
 julia> branch_ref = LibGit2.head(repo);

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -78,7 +78,7 @@ Get the URL of a remote git repository.
 
 # Example
 
-```julia
+```julia-repl
 julia> repo_url = "https://github.com/JuliaLang/Example.jl";
 
 julia> repo = LibGit2.clone(cache_repo, "test_directory");
@@ -104,7 +104,7 @@ the name will be an empty string `""`.
 
 # Example
 
-```julia
+```julia-repl
 julia> repo_url = "https://github.com/JuliaLang/Example.jl";
 
 julia> repo = LibGit2.clone(cache_repo, "test_directory");
@@ -158,7 +158,7 @@ Add a *fetch* refspec for the specified `rmt`. This refspec will contain
 information about which branch(es) to fetch from.
 
 # Example
-```julia
+```julia-repl
 julia> LibGit2.add_fetch!(repo, remote, "upstream");
 
 julia> LibGit2.fetch_refspecs(remote)
@@ -178,7 +178,7 @@ Add a *push* refspec for the specified `rmt`. This refspec will contain
 information about which branch(es) to push to.
 
 # Example
-```julia
+```julia-repl
 julia> LibGit2.add_push!(repo, remote, "refs/heads/master");
 
 julia> remote = LibGit2.get(LibGit2.GitRemote, repo, branch);

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -909,7 +909,7 @@ their indices; any offset results in a (circular) wraparound. If the
 arrays have overlapping indices, then on the domain of the overlap
 `dest` agrees with `src`.
 
-```julia
+```julia-repl
 julia> src = reshape(collect(1:16), (4,4))
 4×4 Array{Int64,2}:
  1  5   9  13

--- a/base/path.jl
+++ b/base/path.jl
@@ -139,9 +139,9 @@ Get the directory part of a path.
 ```jldoctest
 julia> dirname("/home/myuser")
 "/home"
+```
 
 See also: [`basename`](@ref)
-```
 """
  dirname(path::AbstractString) = splitdir(path)[1]
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -75,7 +75,7 @@ after the ending quote, to change its behaviour:
 
 For example, this regex has all three flags enabled:
 
-```julia
+```julia-repl
 julia> match(r"a+.*b+.*?d\$"ism, "Goodbye,\\nOh, angry,\\nBad world\\n")
 RegexMatch("angry,\\nBad world")
 ```

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -75,7 +75,7 @@ after the ending quote, to change its behaviour:
 
 For example, this regex has all three flags enabled:
 
-```julia-repl
+```jldoctest
 julia> match(r"a+.*b+.*?d\$"ism, "Goodbye,\\nOh, angry,\\nBad world\\n")
 RegexMatch("angry,\\nBad world")
 ```

--- a/base/util.jl
+++ b/base/util.jl
@@ -82,7 +82,7 @@ gc_bytes() = ccall(:jl_gc_total_bytes, Int64, ())
 Set a timer to be read by the next call to [`toc`](@ref) or [`toq`](@ref). The
 macro call `@time expr` can also be used to time evaluation.
 
-```julia
+```julia-repl
 julia> tic()
 0x0000c45bc7abac95
 
@@ -105,7 +105,7 @@ end
 Return, but do not print, the time elapsed since the last [`tic`](@ref). The
 macro calls `@timed expr` and `@elapsed expr` also return evaluation time.
 
-```julia
+```julia-repl
 julia> tic()
 0x0000c46477a9675d
 
@@ -132,7 +132,7 @@ end
 Print and return the time elapsed since the last [`tic`](@ref). The macro call
 `@time expr` can also be used to time evaluation.
 
-```julia
+```julia-repl
 julia> tic()
 0x0000c45bc7abac95
 
@@ -219,7 +219,7 @@ returning the value of the expression.
 See also [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref), and
 [`@allocated`](@ref).
 
-```julia
+```julia-repl
 julia> @time rand(10^6);
   0.001525 seconds (7 allocations: 7.630 MiB)
 
@@ -253,7 +253,7 @@ expression.
 See also [`@time`](@ref), [`@timed`](@ref), [`@elapsed`](@ref), and
 [`@allocated`](@ref).
 
-```julia
+```julia-repl
 julia> @timev rand(10^6);
   0.001006 seconds (7 allocations: 7.630 MiB)
 elapsed time (ns): 1005567
@@ -282,7 +282,7 @@ number of seconds it took to execute as a floating-point number.
 See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
 and [`@allocated`](@ref).
 
-```julia
+```julia-repl
 julia> @elapsed sleep(0.3)
 0.301391426
 ```
@@ -314,7 +314,7 @@ for the effects of compilation.
 See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
 and [`@elapsed`](@ref).
 
-```julia
+```julia-repl
 julia> @allocated rand(10^6)
 8000080
 ```
@@ -343,7 +343,7 @@ counters.
 See also [`@time`](@ref), [`@timev`](@ref), [`@elapsed`](@ref), and
 [`@allocated`](@ref).
 
-```julia
+```julia-repl
 julia> val, t, bytes, gctime, memallocs = @timed rand(10^6);
 
 julia> t

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -18,18 +18,8 @@ No matter the error, we will always need to know what version of Julia you are r
 first starts up, a header is printed out with a version number and date.  If your version is
 `0.2.0` or higher, please include the output of `versioninfo()` in any report you create:
 
-```julia-repl
-julia> versioninfo()
-Julia Version 0.3.3-pre+25
-Commit 417b50a* (2014-11-03 11:32 UTC)
-Platform Info:
-  OS: Linux (x86_64-linux-gnu)
-  CPU: Intel(R) Core(TM) i7 CPU       L 640  @ 2.13GHz
-  WORD_SIZE: 64
-  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Nehalem)
-  LAPACK: libopenblas
-  LIBM: libopenlibm
-  LLVM: libLLVM-3.3
+```@repl
+versioninfo()
 ```
 
 ## Segfaults during bootstrap (`sysimg.jl`)

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -18,7 +18,7 @@ No matter the error, we will always need to know what version of Julia you are r
 first starts up, a header is printed out with a version number and date.  If your version is
 `0.2.0` or higher, please include the output of `versioninfo()` in any report you create:
 
-```julia
+```julia-repl
 julia> versioninfo()
 Julia Version 0.3.3-pre+25
 Commit 417b50a* (2014-11-03 11:32 UTC)

--- a/doc/src/devdocs/cartesian.md
+++ b/doc/src/devdocs/cartesian.md
@@ -53,9 +53,19 @@ is `@nref 3 A i` (as in `A[i_1,i_2,i_3]`, where the array comes first).
 If you're developing code with Cartesian, you may find that debugging is easier when you examine
 the generated code, using `macroexpand`:
 
-```julia-repl
+```@meta
+DocTestSetup = quote
+    import Base.Cartesian: @nref
+end
+```
+
+```jldoctest
 julia> macroexpand(:(@nref 2 A i))
-:(A[i_1,i_2])
+:(A[i_1, i_2])
+```
+
+```@meta
+DocTestSetup = nothing
 ```
 
 ### Supplying the number of expressions

--- a/doc/src/devdocs/cartesian.md
+++ b/doc/src/devdocs/cartesian.md
@@ -53,7 +53,7 @@ is `@nref 3 A i` (as in `A[i_1,i_2,i_3]`, where the array comes first).
 If you're developing code with Cartesian, you may find that debugging is easier when you examine
 the generated code, using `macroexpand`:
 
-```julia
+```julia-repl
 julia> macroexpand(:(@nref 2 A i))
 :(A[i_1,i_2])
 ```

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -14,7 +14,7 @@ The names of `DataType` fields may be interrogated using [`fieldnames()`](@ref).
 given the following type, `fieldnames(Point)` returns an arrays of [`Symbol`](@ref) elements representing
 the field names:
 
-```julia-repl
+```jldoctest struct_point
 julia> struct Point
            x::Int
            y
@@ -29,9 +29,9 @@ julia> fieldnames(Point)
 The type of each field in a `Point` object is stored in the `types` field of the `Point` variable
 itself:
 
-```julia-repl
+```jldoctest struct_point
 julia> Point.types
-svec(Int64,Any)
+svec(Int64, Any)
 ```
 
 While `x` is annotated as an `Int`, `y` was unannotated in the type definition, therefore `y`
@@ -39,7 +39,7 @@ defaults to the `Any` type.
 
 Types are themselves represented as a structure called `DataType`:
 
-```julia-repl
+```jldoctest struct_point
 julia> typeof(Point)
 DataType
 ```
@@ -52,9 +52,9 @@ of these fields is the `types` field observed in the example above.
 The *direct* subtypes of any `DataType` may be listed using [`subtypes()`](@ref). For example,
 the abstract `DataType``AbstractFloat` has four (concrete) subtypes:
 
-```julia-repl
+```jldoctest
 julia> subtypes(AbstractFloat)
-4-element Array{DataType,1}:
+4-element Array{Union{DataType, UnionAll},1}:
  BigFloat
  Float16
  Float32
@@ -83,9 +83,9 @@ the unquoted and interpolated expression (`Expr`) form for a given macro. To use
 `quote` the expression block itself (otherwise, the macro will be evaluated and the result will
 be passed instead!). For example:
 
-```julia-repl
+```jldoctest
 julia> macroexpand( :(@edit println("")) )
-:((Base.edit)(println,(Base.typesof)("")))
+:((Base.edit)(println, (Base.typesof)("")))
 ```
 
 The functions `Base.Meta.show_sexpr()` and [`dump()`](@ref) are used to display S-expr style views
@@ -95,11 +95,11 @@ Finally, the [`expand()`](@ref) function gives the `lowered` form of any express
 particular interest for understanding both macros and top-level statements such as function declarations
 and variable assignments:
 
-```julia-repl
+```jldoctest
 julia> expand( :(f() = 1) )
 :(begin
         $(Expr(:method, :f))
-        $(Expr(:method, :f, :((Core.svec)((Core.svec)((Core.Typeof)(f)),(Core.svec)())), CodeInfo(:(begin  # none, line 1:
+        $(Expr(:method, :f, :((Core.svec)((Core.svec)((Core.Typeof)(f)), (Core.svec)())), CodeInfo(:(begin  # none, line 1:
         return 1
     end)), false))
         return f

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -14,7 +14,7 @@ The names of `DataType` fields may be interrogated using [`fieldnames()`](@ref).
 given the following type, `fieldnames(Point)` returns an arrays of [`Symbol`](@ref) elements representing
 the field names:
 
-```julia
+```julia-repl
 julia> struct Point
            x::Int
            y
@@ -29,7 +29,7 @@ julia> fieldnames(Point)
 The type of each field in a `Point` object is stored in the `types` field of the `Point` variable
 itself:
 
-```julia
+```julia-repl
 julia> Point.types
 svec(Int64,Any)
 ```
@@ -39,7 +39,7 @@ defaults to the `Any` type.
 
 Types are themselves represented as a structure called `DataType`:
 
-```julia
+```julia-repl
 julia> typeof(Point)
 DataType
 ```
@@ -52,7 +52,7 @@ of these fields is the `types` field observed in the example above.
 The *direct* subtypes of any `DataType` may be listed using [`subtypes()`](@ref). For example,
 the abstract `DataType``AbstractFloat` has four (concrete) subtypes:
 
-```julia
+```julia-repl
 julia> subtypes(AbstractFloat)
 4-element Array{DataType,1}:
  BigFloat
@@ -83,7 +83,7 @@ the unquoted and interpolated expression (`Expr`) form for a given macro. To use
 `quote` the expression block itself (otherwise, the macro will be evaluated and the result will
 be passed instead!). For example:
 
-```julia
+```julia-repl
 julia> macroexpand( :(@edit println("")) )
 :((Base.edit)(println,(Base.typesof)("")))
 ```
@@ -95,7 +95,7 @@ Finally, the [`expand()`](@ref) function gives the `lowered` form of any express
 particular interest for understanding both macros and top-level statements such as function declarations
 and variable assignments:
 
-```julia
+```julia-repl
 julia> expand( :(f() = 1) )
 :(begin
         $(Expr(:method, :f))
@@ -123,7 +123,7 @@ generation for any function which has not previously been called).
 For convenience, there are macro versions of the above functions which take standard function
 calls and expand argument types automatically:
 
-```julia
+```julia-repl
 julia> @code_llvm +(1,1)
 
 ; Function Attrs: sspreq

--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -54,7 +54,7 @@ any runtime overhead.
 
 The strategy adopted is first and foremost expressed in the definition of the type:
 
-```
+```julia
 struct SubArray{T,N,P,I,L} <: AbstractArray{T,N}
     parent::P
     indexes::I
@@ -89,7 +89,7 @@ types.  For example, for `S1`, one needs to apply the `i,j` indices to the first
 of the parent array, whereas for `S2` one needs to apply them to the second and third.  The simplest
 approach to indexing would be to do the type-analysis at runtime:
 
-```
+```julia
 parentindexes = Array{Any}(0)
 for thisindex in S.indexes
     ...

--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -74,7 +74,7 @@ If in our example above `A` is a `Array{Float64, 3}`, our `S1` case above would 
 Note in particular the tuple parameter, which stores the types of the indices used to create
 `S1`.  Likewise,
 
-```julia
+```julia-repl
 julia> S1.indexes
 (Colon(),5,2:6)
 ```
@@ -137,7 +137,7 @@ For `SubArray` types, the availability of efficient linear indexing is based pur
 of the indices, and does not depend on values like the size of the parent array. You can ask whether
 a given set of indices supports fast linear indexing with the internal `Base.viewindexing` function:
 
-```julia
+```julia-repl
 julia> Base.viewindexing(S1.indexes)
 IndexCartesian()
 
@@ -152,7 +152,7 @@ we can define dispatch directly on `SubArray{T,N,A,I,true}` without any intermed
 Since this computation doesn't depend on runtime values, it can miss some cases in which the stride
 happens to be uniform:
 
-```julia
+```julia-repl
 julia> A = reshape(1:4*2, 4, 2)
 4×2 Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}:
  1  5
@@ -171,7 +171,7 @@ A view constructed as `view(A, 2:2:4, :)` happens to have uniform stride, and th
 indexing indeed could be performed efficiently.  However, success in this case depends on the
 size of the array: if the first dimension instead were odd,
 
-```julia
+```julia-repl
 julia> A = reshape(1:5*2, 5, 2)
 5×2 Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}:
  1   6

--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -152,7 +152,7 @@ we can define dispatch directly on `SubArray{T,N,A,I,true}` without any intermed
 Since this computation doesn't depend on runtime values, it can miss some cases in which the stride
 happens to be uniform:
 
-```julia-repl
+```jldoctest
 julia> A = reshape(1:4*2, 4, 2)
 4×2 Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}:
  1  5
@@ -171,7 +171,7 @@ A view constructed as `view(A, 2:2:4, :)` happens to have uniform stride, and th
 indexing indeed could be performed efficiently.  However, success in this case depends on the
 size of the array: if the first dimension instead were odd,
 
-```julia-repl
+```jldoctest
 julia> A = reshape(1:5*2, 5, 2)
 5×2 Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}:
  1   6

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -169,7 +169,7 @@ Array{T,N}
 These can be distinguished by examining the `name` field of the type, which is an object of type
 `TypeName`:
 
-```julia
+```julia-repl
 julia> dump(Array{Int,1}.name)
 TypeName
   name: Symbol Array
@@ -207,7 +207,7 @@ TypeName
 In this case, the relevant field is `wrapper`, which holds a reference to the top-level type used
 to make new `Array` types.
 
-```julia
+```julia-repl
 julia> pointer_from_objref(Array)
 Ptr{Void} @0x00007fcc7de64850
 
@@ -299,7 +299,7 @@ Union{}
 
 What is the "primary" tuple-type?
 
-```julia
+```julia-repl
 julia> pointer_from_objref(Tuple)
 Ptr{Void} @0x00007f5998a04370
 
@@ -461,7 +461,7 @@ Build Julia with `make debug` and fire up Julia within a debugger.
 Because the subtyping code is used heavily in the REPL itself--and hence breakpoints in this
 code get triggered often--it will be easiest if you make the following definition:
 
-```julia
+```julia-repl
 julia> function mysubtype(a,b)
            ccall(:jl_breakpoint, Void, (Any,), nothing)
            issubtype(a, b)

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -768,7 +768,7 @@ The [`sparse()`](@ref) function is often a handy way to construct sparse matrice
 its input a vector `I` of row indices, a vector `J` of column indices, and a vector `V` of nonzero
 values. `sparse(I,J,V)` constructs a sparse matrix such that `S[I[k], J[k]] = V[k]`.
 
-```julia-repl
+```jldoctest sparse_function
 julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
 julia> S = sparse(I,J,V)
@@ -782,12 +782,12 @@ julia> S = sparse(I,J,V)
 The inverse of the [`sparse()`](@ref) function is [`findn()`](@ref), which retrieves the inputs
 used to create the sparse matrix.
 
-```julia-repl
+```jldoctest sparse_function
 julia> findn(S)
-([1,4,5,3],[4,7,9,18])
+([1, 4, 5, 3], [4, 7, 9, 18])
 
 julia> findnz(S)
-([1,4,5,3],[4,7,9,18],[1,2,3,-5])
+([1, 4, 5, 3], [4, 7, 9, 18], [1, 2, 3, -5])
 ```
 
 Another way to create sparse matrices is to convert a dense matrix into a sparse matrix using

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -137,7 +137,7 @@ of the variable ranges `rx`, `ry`, etc. and each `F(x,y,...)` evaluation returns
 The following example computes a weighted average of the current element and its left and right
 neighbor along a 1-d grid. :
 
-```julia
+```julia-repl
 julia> x = rand(8)
 8-element Array{Float64,1}:
  0.843025
@@ -182,7 +182,7 @@ julia> sum(1/n^2 for n=1:1000)
 When writing a generator expression with multiple dimensions inside an argument list, parentheses
 are needed to separate the generator from subsequent arguments:
 
-```julia
+```julia-repl
 julia> map(tuple, 1/(i+j) for i=1:2, j=1:2, [1:4;])
 ERROR: syntax: invalid iteration specification
 ```
@@ -556,7 +556,7 @@ It is sometimes useful to perform element-by-element binary operations on arrays
 sizes, such as adding a vector to each column of a matrix. An inefficient way to do this would
 be to replicate the vector to the size of the matrix:
 
-```julia
+```julia-repl
 julia> a = rand(2,1); A = rand(2,3);
 
 julia> repmat(a,1,3)+A
@@ -569,7 +569,7 @@ This is wasteful when dimensions get large, so Julia offers [`broadcast()`](@ref
 singleton dimensions in array arguments to match the corresponding dimension in the other array
 without using extra memory, and applies the given function elementwise:
 
-```julia
+```julia-repl
 julia> broadcast(+, a, A)
 2×3 Array{Float64,2}:
  1.20813  1.82068  1.25387
@@ -666,7 +666,7 @@ The following example computes the QR decomposition of a small section of a larg
 creating any temporaries, and by calling the appropriate LAPACK function with the right leading
 dimension size and stride parameters.
 
-```julia
+```julia-repl
 julia> a = rand(10,10)
 10×10 Array{Float64,2}:
  0.561255   0.226678   0.203391  0.308912   …  0.750307  0.235023   0.217964
@@ -768,7 +768,7 @@ The [`sparse()`](@ref) function is often a handy way to construct sparse matrice
 its input a vector `I` of row indices, a vector `J` of column indices, and a vector `V` of nonzero
 values. `sparse(I,J,V)` constructs a sparse matrix such that `S[I[k], J[k]] = V[k]`.
 
-```jldoctest
+```julia-repl
 julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
 julia> S = sparse(I,J,V)
@@ -782,7 +782,7 @@ julia> S = sparse(I,J,V)
 The inverse of the [`sparse()`](@ref) function is [`findn()`](@ref), which retrieves the inputs
 used to create the sparse matrix.
 
-```julia
+```julia-repl
 julia> findn(S)
 ([1,4,5,3],[4,7,9,18])
 

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -55,7 +55,7 @@ to [`ccall`](@ref) are as follows:
 As a complete but simple example, the following calls the `clock` function from the standard C
 library:
 
-```julia
+```julia-repl
 julia> t = ccall((:clock, "libc"), Int32, ())
 2292761
 
@@ -70,7 +70,7 @@ Int32
 written with a trailing comma. For example, to call the `getenv` function to get a pointer to
 the value of an environment variable, one makes a call like this:
 
-```julia
+```julia-repl
 julia> path = ccall((:getenv, "libc"), Cstring, (Cstring,), "SHELL")
 Cstring(@0x00007fff5fbffc45)
 
@@ -113,7 +113,7 @@ indicate errors in various different ways, including by returning -1, 0, 1 and o
 This wrapper throws an exception clearly indicating the problem if the caller tries to get a non-existent
 environment variable:
 
-```julia
+```julia-repl
 julia> getenv("SHELL")
 "/bin/bash"
 
@@ -905,7 +905,7 @@ Global variables exported by native libraries can be accessed by name using the 
 function. The arguments to [`cglobal()`](@ref) are a symbol specification identical to that used
 by [`ccall`](@ref), and a type describing the value stored in the variable:
 
-```julia
+```julia-repl
 julia> cglobal((:errno, :libc), Int32)
 Ptr{Int32} @0x00007f418d0816b8
 ```

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -181,7 +181,7 @@ julia> mutable struct SelfReferential
 This type may appear innocuous enough, until one considers how to construct an instance of it.
 If `a` is an instance of `SelfReferential`, then a second instance can be created by the call:
 
-```julia
+```julia-repl
 julia> b = SelfReferential(a)
 ```
 
@@ -246,7 +246,7 @@ and does not reference other objects. The plain data types consist of primitive 
 and immutable structs of other plain data types. The initial contents of a plain data type is
 undefined:
 
-```julia
+```julia-repl
 julia> struct HasPlain
            n::Int
            HasPlain() = new()

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -301,7 +301,7 @@ Point{Int64}(1, 2)
 julia> Point{Int64}(1.0,2.5) ## explicit T ##
 ERROR: InexactError()
 Stacktrace:
- [1] convert(::Type{Int64}, ::Float64) at ./float.jl:679
+ [1] convert(::Type{Int64}, ::Float64) at ./float.jl:680
  [2] Point{Int64}(::Float64, ::Float64) at ./none:2
 
 julia> Point{Float64}(1.0, 2.5) ## explicit T ##

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -134,11 +134,6 @@ actual Julia behaviour. This is the actual implementation in Julia:
 ```julia
 convert(::Type{T}, z::Complex) where {T<:Real} =
     (imag(z) == 0 ? convert(T, real(z)) : throw(InexactError()))
-
-julia> convert(Bool, 1im)
-ERROR: InexactError()
- in convert(::Type{Bool}, ::Complex{Int64}) at ./complex.jl:18
- ...
 ```
 
 ### [Case Study: Rational Conversions](@id man-rational-conversion)

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -46,7 +46,7 @@ generally takes two arguments: the first is a type object while the second is a 
 to that type; the returned value is the value converted to an instance of given type. The simplest
 way to understand this function is to see it in action:
 
-```julia
+```julia-repl
 julia> x = 12
 12
 
@@ -79,7 +79,7 @@ julia> convert(Array{Float64}, a)
 Conversion isn't always possible, in which case a no method error is thrown indicating that `convert`
 doesn't know how to perform the requested conversion:
 
-```julia
+```julia-repl
 julia> convert(AbstractFloat, "foo")
 ERROR: MethodError: Cannot `convert` an object of type String to an object of type AbstractFloat
 This may have arisen from a call to the constructor AbstractFloat(...),
@@ -111,7 +111,7 @@ example, since the type is a singleton, there would never be any reason to use i
 the body. When invoked, the method determines whether a numeric value is true or false as a boolean,
 by comparing it to one and zero:
 
-```julia
+```julia-repl
 julia> convert(Bool, 1)
 true
 
@@ -201,7 +201,7 @@ any number of arguments, and returns a tuple of the same number of values, conve
 type, or throws an exception if promotion is not possible. The most common use case for promotion
 is to convert numeric arguments to a common type:
 
-```julia
+```julia-repl
 julia> promote(1, 2.5)
 (1.0,2.5)
 
@@ -258,7 +258,7 @@ Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 
 This allows calls like the following to work:
 
-```julia
+```julia-repl
 julia> Rational(Int8(15),Int32(-5))
 -3//1
 
@@ -302,7 +302,7 @@ which, given any number of type objects, returns the common type to which those 
 to `promote` should be promoted. Thus, if one wants to know, in absence of actual values, what
 type a collection of values of certain types would promote to, one can use `promote_type`:
 
-```julia
+```julia-repl
 julia> promote_type(Int8, UInt16)
 Int64
 ```

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -120,8 +120,8 @@ false
 
 julia> convert(Bool, 1im)
 ERROR: InexactError()
- in convert(::Type{Bool}, ::Complex{Int64}) at ./complex.jl:23
- ...
+Stacktrace:
+ [1] convert(::Type{Bool}, ::Complex{Int64}) at ./complex.jl:23
 
 julia> convert(Bool, 0im)
 false

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -46,7 +46,7 @@ generally takes two arguments: the first is a type object while the second is a 
 to that type; the returned value is the value converted to an instance of given type. The simplest
 way to understand this function is to see it in action:
 
-```julia-repl
+```jldoctest
 julia> x = 12
 12
 
@@ -66,12 +66,12 @@ julia> typeof(ans)
 Float64
 
 julia> a = Any[1 2 3; 4 5 6]
-2x3 Array{Any,2}:
+2×3 Array{Any,2}:
  1  2  3
  4  5  6
 
 julia> convert(Array{Float64}, a)
-2x3 Array{Float64,2}:
+2×3 Array{Float64,2}:
  1.0  2.0  3.0
  4.0  5.0  6.0
 ```
@@ -79,12 +79,11 @@ julia> convert(Array{Float64}, a)
 Conversion isn't always possible, in which case a no method error is thrown indicating that `convert`
 doesn't know how to perform the requested conversion:
 
-```julia-repl
+```jldoctest
 julia> convert(AbstractFloat, "foo")
 ERROR: MethodError: Cannot `convert` an object of type String to an object of type AbstractFloat
 This may have arisen from a call to the constructor AbstractFloat(...),
 since type constructors fall back to convert methods.
- ...
 ```
 
 Some languages consider parsing strings as numbers or formatting numbers as strings to be conversions
@@ -111,7 +110,7 @@ example, since the type is a singleton, there would never be any reason to use i
 the body. When invoked, the method determines whether a numeric value is true or false as a boolean,
 by comparing it to one and zero:
 
-```julia-repl
+```jldoctest
 julia> convert(Bool, 1)
 true
 
@@ -196,24 +195,24 @@ any number of arguments, and returns a tuple of the same number of values, conve
 type, or throws an exception if promotion is not possible. The most common use case for promotion
 is to convert numeric arguments to a common type:
 
-```julia-repl
+```jldoctest
 julia> promote(1, 2.5)
-(1.0,2.5)
+(1.0, 2.5)
 
 julia> promote(1, 2.5, 3)
-(1.0,2.5,3.0)
+(1.0, 2.5, 3.0)
 
 julia> promote(2, 3//4)
-(2//1,3//4)
+(2//1, 3//4)
 
 julia> promote(1, 2.5, 3, 3//4)
-(1.0,2.5,3.0,0.75)
+(1.0, 2.5, 3.0, 0.75)
 
 julia> promote(1.5, im)
-(1.5 + 0.0im,0.0 + 1.0im)
+(1.5 + 0.0im, 0.0 + 1.0im)
 
 julia> promote(1 + 2im, 3//4)
-(1//1 + 2//1*im,3//4 + 0//1*im)
+(1//1 + 2//1*im, 3//4 + 0//1*im)
 ```
 
 Floating-point values are promoted to the largest of the floating-point argument types. Integer
@@ -253,7 +252,7 @@ Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 
 This allows calls like the following to work:
 
-```julia-repl
+```jldoctest
 julia> Rational(Int8(15),Int32(-5))
 -3//1
 
@@ -297,7 +296,7 @@ which, given any number of type objects, returns the common type to which those 
 to `promote` should be promoted. Thus, if one wants to know, in absence of actual values, what
 type a collection of values of certain types would promote to, one can use `promote_type`:
 
-```julia-repl
+```jldoctest
 julia> promote_type(Int8, UInt16)
 Int64
 ```

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -27,7 +27,7 @@ Compute the Bar index between `x` and `y`. If `y` is missing, compute
 the Bar index between all pairs of columns of `x`.
 
 # Examples
-```julia
+```julia-repl
 julia> bar([1, 2], [1, 2])
 1
 ```

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -391,7 +391,7 @@ arithmetic. For example, since Julia integers use normal machine integer arithme
 to aggressively optimize simple little functions like `f(k) = 5k-1`. The machine code for this
 function is just this:
 
-```julia
+```julia-repl
 julia> code_native(f, Tuple{Int})
   .text
 Filename: none
@@ -407,7 +407,7 @@ Source line: 1
 The actual body of the function is a single `leaq` instruction, which computes the integer multiply
 and add at once. This is even more beneficial when `f` gets inlined into another function:
 
-```julia
+```julia-repl
 julia> function g(k, n)
            for i = 1:n
                k = f(k)
@@ -442,7 +442,7 @@ L26:
 Since the call to `f` gets inlined, the loop body ends up being just a single `leaq` instruction.
 Next, consider what happens if we make the number of loop iterations fixed:
 
-```julia
+```julia-repl
 julia> function g(k)
            for i = 1:10
                k = f(k)
@@ -485,7 +485,7 @@ to checked integer arithmetic in Julia, but for now, we have to live with the po
 As the error states, an immediate cause of an `UndefVarError` on a remote node is that a binding
 by that name does not exist. Let us explore some of the possible causes.
 
-```julia
+```julia-repl
 julia> module Foo
            foo() = remotecall_fetch(x->x, 2, "Hello")
        end
@@ -502,7 +502,7 @@ an `UndefVarError` is thrown.
 Globals under modules other than `Main` are not serialized by value to the remote node. Only a reference is sent.
 Functions which create global bindings (except under `Main`) may cause an `UndefVarError` to be thrown later.
 
-```julia
+```julia-repl
 julia> @everywhere module Foo
            function foo()
                global gvar = "Hello"
@@ -522,7 +522,7 @@ a new global binding `gvar` on the local node, but this was not found on node 2 
 Note that this does not apply to globals created under module `Main`. Globals under module `Main` are serialized
 and new bindings created under `Main` on the remote node.
 
-```julia
+```julia-repl
 julia> gvar_self = "Node1"
 "Node1"
 
@@ -540,7 +540,7 @@ julia> remotecall_fetch(whos, 2)
 This does not apply to `function` or `type` declarations. However, anonymous functions bound to global
 variables are serialized as can be seen below.
 
-```julia
+```julia-repl
 julia> bar() = 1
 bar (generic function with 1 method)
 

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -584,7 +584,7 @@ To make common numeric formulas and expressions clearer, Julia allows variables 
 preceded by a numeric literal, implying multiplication. This makes writing polynomial expressions
 much cleaner:
 
-```jldoctest
+```jldoctest numeric-coefficients
 julia> x = 3
 3
 
@@ -597,7 +597,7 @@ julia> 1.5x^2 - .5x + 1
 
 It also makes writing exponential functions more elegant:
 
-```julia-repl
+```jldoctest numeric-coefficients
 julia> 2^2x
 64
 ```
@@ -607,7 +607,7 @@ negation. So `2^3x` is parsed as `2^(3x)`, and `2x^3` is parsed as `2*(x^3)`.
 
 Numeric literals also work as coefficients to parenthesized expressions:
 
-```julia-repl
+```jldoctest numeric-coefficients
 julia> 2(x-1)^2 - 3(x-1) + 1
 3
 ```
@@ -615,7 +615,7 @@ julia> 2(x-1)^2 - 3(x-1) + 1
 Additionally, parenthesized expressions can be used as coefficients to variables, implying multiplication
 of the expression by the variable:
 
-```julia-repl
+```jldoctest numeric-coefficients
 julia> (x-1)x
 6
 ```
@@ -623,7 +623,7 @@ julia> (x-1)x
 Neither juxtaposition of two parenthesized expressions, nor placing a variable before a parenthesized
 expression, however, can be used to imply multiplication:
 
-```julia-repl
+```jldoctest numeric-coefficients
 julia> (x-1)(x+1)
 ERROR: MethodError: objects of type Int64 are not callable
 

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -59,7 +59,7 @@ julia> 1234
 The default type for an integer literal depends on whether the target system has a 32-bit architecture
 or a 64-bit architecture:
 
-```julia
+```julia-repl
 # 32-bit system:
 julia> typeof(1)
 Int32
@@ -72,7 +72,7 @@ Int64
 The Julia internal variable [`Sys.WORD_SIZE`](@ref) indicates whether the target system is 32-bit
 or 64-bit:
 
-```julia
+```julia-repl
 # 32-bit system:
 julia> Sys.WORD_SIZE
 32
@@ -85,7 +85,7 @@ julia> Sys.WORD_SIZE
 Julia also defines the types `Int` and `UInt`, which are aliases for the system's signed and unsigned
 native integer types respectively:
 
-```julia
+```julia-repl
 # 32-bit system:
 julia> Int
 Int32
@@ -597,7 +597,7 @@ julia> 1.5x^2 - .5x + 1
 
 It also makes writing exponential functions more elegant:
 
-```julia
+```julia-repl
 julia> 2^2x
 64
 ```
@@ -607,7 +607,7 @@ negation. So `2^3x` is parsed as `2^(3x)`, and `2x^3` is parsed as `2*(x^3)`.
 
 Numeric literals also work as coefficients to parenthesized expressions:
 
-```julia
+```julia-repl
 julia> 2(x-1)^2 - 3(x-1) + 1
 3
 ```
@@ -615,7 +615,7 @@ julia> 2(x-1)^2 - 3(x-1) + 1
 Additionally, parenthesized expressions can be used as coefficients to variables, implying multiplication
 of the expression by the variable:
 
-```julia
+```julia-repl
 julia> (x-1)x
 6
 ```
@@ -623,7 +623,7 @@ julia> (x-1)x
 Neither juxtaposition of two parenthesized expressions, nor placing a variable before a parenthesized
 expression, however, can be used to imply multiplication:
 
-```julia
+```julia-repl
 julia> (x-1)(x+1)
 ERROR: MethodError: objects of type Int64 are not callable
 

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -63,7 +63,7 @@ at detecting when a paste occurs.
 When the cursor is at the beginning of the line, the prompt can be changed to a help mode by typing
 `?`. Julia will attempt to print help or documentation for anything entered in help mode:
 
-```julia
+```julia-repl
 julia> ? # upon typing ?, the prompt changes (in place) to: help?>
 
 help?> string
@@ -111,7 +111,7 @@ system shell to execute system commands. Just as `?` entered help mode when at t
 of the line, a semicolon (`;`) will enter the shell mode. And it can be exited by pressing backspace
 at the beginning of the line.
 
-```julia
+```julia-repl
 julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 
 shell> echo hello
@@ -209,7 +209,7 @@ Users should refer to `base/LineEdit.jl` to discover the available actions on ke
 In both the Julian and help modes of the REPL, one can enter the first few characters of a function
 or type and then press the tab key to get a list all matches:
 
-```julia
+```julia-repl
 julia> stri[TAB]
 stride     strides     string      stringmime  strip
 
@@ -220,7 +220,7 @@ StridedArray    StridedMatrix    StridedVecOrMat  StridedVector    String
 The tab key can also be used to substitute LaTeX math symbols with their Unicode equivalents,
 and get a list of LaTeX matches as well:
 
-```julia
+```julia-repl
 julia> \pi[TAB]
 julia> π
 π = 3.1415926535897...
@@ -258,7 +258,7 @@ A full list of tab-completions can be found in the [Unicode Input](@ref) section
 
 Completion of paths works for strings and julia's shell mode:
 
-```julia
+```julia-repl
 julia> path="/[TAB]"
 .dockerenv  .juliabox/   boot/        etc/         lib/         media/       opt/         root/        sbin/        sys/         usr/
 .dockerinit bin/         dev/         home/        lib64/       mnt/         proc/        run/         srv/         tmp/         var/
@@ -269,7 +269,7 @@ shell> /[TAB]
 
 Tab completion can help with investigation of the available methods matching the input arguments:
 
-```julia
+```julia-repl
 julia> max([TAB] # All methods are displayed, not shown here due to size of the list
 
 julia> max([1, 2], [TAB] # All methods where `Vector{Int}` matches as first argument
@@ -284,7 +284,7 @@ max(a, b, c, xs...) in Base at operators.jl:281
 Keywords are also displayed in the suggested methods, see second line after `;` where `limit`
 and `keep` are keyword arguments:
 
-```julia
+```julia-repl
 julia> split("1 1 1", [TAB]
 split(str::AbstractString) in Base at strings/util.jl:278
 split{T<:AbstractString}(str::T, splitter; limit, keep) in Base at strings/util.jl:254
@@ -296,14 +296,14 @@ completion to be able to remove non-matching methods.
 
 Tab completion can also help completing fields:
 
-```julia
+```julia-repl
 julia> Pkg.a[TAB]
 add       available
 ```
 
 Fields for output from functions can also be completed:
 
-```julia
+```julia-repl
 julia> split("","")[1].[TAB]
 endof  offset  string
 ```

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -397,7 +397,7 @@ julia> Int8(127)
 julia> Int8(128)
 ERROR: InexactError()
 Stacktrace:
- [1] Int8(::Int64) at ./sysimg.jl:24
+ [1] Int8(::Int64) at ./sysimg.jl:77
 
 julia> Int8(127.0)
 127
@@ -405,14 +405,14 @@ julia> Int8(127.0)
 julia> Int8(3.14)
 ERROR: InexactError()
 Stacktrace:
- [1] convert(::Type{Int8}, ::Float64) at ./float.jl:658
- [2] Int8(::Float64) at ./sysimg.jl:24
+ [1] convert(::Type{Int8}, ::Float64) at ./float.jl:659
+ [2] Int8(::Float64) at ./sysimg.jl:77
 
 julia> Int8(128.0)
 ERROR: InexactError()
 Stacktrace:
- [1] convert(::Type{Int8}, ::Float64) at ./float.jl:658
- [2] Int8(::Float64) at ./sysimg.jl:24
+ [1] convert(::Type{Int8}, ::Float64) at ./float.jl:659
+ [2] Int8(::Float64) at ./sysimg.jl:77
 
 julia> 127 % Int8
 127
@@ -426,8 +426,8 @@ julia> round(Int8,127.4)
 julia> round(Int8,127.6)
 ERROR: InexactError()
 Stacktrace:
- [1] trunc(::Type{Int8}, ::Float64) at ./float.jl:651
- [2] round(::Type{Int8}, ::Float64) at ./float.jl:337
+ [1] trunc(::Type{Int8}, ::Float64) at ./float.jl:652
+ [2] round(::Type{Int8}, ::Float64) at ./float.jl:338
 ```
 
 See [Conversion and Promotion](@ref conversion-and-promotion) for how to define your own conversions and promotions.

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -238,7 +238,7 @@ julia> ex = :(a in $:((1,2,3)) )
 Interpolating symbols into a nested expression requires enclosing each symbol in an enclosing
 quote block:
 
-```julia
+```julia-repl
 julia> :( :a in $( :(:a + :b) ) )
                    ^^^^^^^^^^
                    quoted inner expression
@@ -298,7 +298,7 @@ Since expressions are just `Expr` objects which can be constructed programmatica
 it is possible to dynamically generate arbitrary code which can then be run using [`eval()`](@ref).
 Here is a simple example:
 
-```julia
+```julia-repl
 julia> a = 1;
 
 julia> ex = Expr(:call, :+, a, :b)
@@ -920,7 +920,7 @@ we returned from the definition, now with the *value* of `x`.
 
 What happens if we evaluate `foo` again with a type that we have already used?
 
-```julia generated
+```julia-repl generated
 julia> foo(4)
 16
 ```

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -920,7 +920,7 @@ we returned from the definition, now with the *value* of `x`.
 
 What happens if we evaluate `foo` again with a type that we have already used?
 
-```julia-repl generated
+```jldoctest generated
 julia> foo(4)
 16
 ```

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -163,7 +163,7 @@ f (generic function with 2 methods)
 This output tells us that `f` is a function object with two methods. To find out what the signatures
 of those methods are, use the [`methods()`](@ref) function:
 
-```julia
+```julia-repl
 julia> methods(f)
 # 2 methods for generic function "f":
 f(x::Float64, y::Float64) in Main at none:1
@@ -193,7 +193,7 @@ Although it seems a simple concept, multiple dispatch on the types of values is 
 most powerful and central feature of the Julia language. Core operations typically have dozens
 of methods:
 
-```julia
+```julia-repl
 julia> methods(+)
 # 180 methods for generic function "+":
 +(x::Bool, z::Complex{Bool}) in Base at complex.jl:224
@@ -412,7 +412,7 @@ Indeed, any new method definition won't be visible to the current runtime enviro
 including Tasks and Threads (and any previously defined `@generated` functions).
 Let's start with an example to see what this means:
 
-```julia
+```julia-repl
 julia> function tryeval()
            @eval newfun() = 1
            newfun()

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -11,7 +11,7 @@ functionality.
 All Julia streams expose at least a [`read()`](@ref) and a [`write()`](@ref) method, taking the
 stream as their first argument, e.g.:
 
-```julia
+```julia-repl
 julia> write(STDOUT,"Hello World");  # suppress return value 11 with ;
 Hello World
 julia> read(STDIN,Char)
@@ -28,7 +28,7 @@ takes the type of the data to be read as the second argument.
 
 For example, to read a simple byte array, we could do:
 
-```julia
+```julia-repl
 julia> x = zeros(UInt8, 4)
 4-element Array{UInt8,1}:
  0x00
@@ -48,7 +48,7 @@ abcd
 However, since this is slightly cumbersome, there are several convenience methods provided. For
 example, we could have written the above as:
 
-```julia
+```julia-repl
 julia> read(STDIN,4)
 abcd
 4-element Array{UInt8,1}:
@@ -60,7 +60,7 @@ abcd
 
 or if we had wanted to read the entire line instead:
 
-```julia
+```julia-repl
 julia> readline(STDIN)
 abcd
 "abcd"
@@ -120,7 +120,7 @@ Like many other environments, Julia has an [`open()`](@ref) function, which take
 returns an `IOStream` object that you can use to read and write things from the file. For example
 if we have a file, `hello.txt`, whose contents are `Hello, World!`:
 
-```julia
+```julia-repl
 julia> f = open("hello.txt")
 IOStream(<file hello.txt>)
 
@@ -131,7 +131,7 @@ julia> readlines(f)
 
 If you want to write to a file, you can open it with the write (`"w"`) flag:
 
-```julia
+```julia-repl
 julia> f = open("hello.txt","w")
 IOStream(<file hello.txt>)
 
@@ -143,7 +143,7 @@ If you examine the contents of `hello.txt` at this point, you will notice that i
 has actually been written to disk yet. This is because the `IOStream` must be closed before the
 write is actually flushed to disk:
 
-```julia
+```julia-repl
 julia> close(f)
 ```
 
@@ -162,7 +162,7 @@ end
 
 You can call:
 
-```julia
+```julia-repl
 julia> open(read_and_capitalize, "hello.txt")
 "HELLO AGAIN."
 ```
@@ -173,7 +173,7 @@ contents.
 To avoid even having to define a named function, you can use the `do` syntax, which creates an
 anonymous function on the fly:
 
-```julia
+```julia-repl
 julia> open("hello.txt") do f
            uppercase(readstring(f))
        end
@@ -184,7 +184,7 @@ julia> open("hello.txt") do f
 
 Let's jump right in with a simple example involving TCP sockets. Let's first create a simple server:
 
-```julia
+```julia-repl
 julia> @async begin
            server = listen(2000)
            while true
@@ -200,7 +200,7 @@ usage is somewhat simpler than the raw Unix socket API. The first call to [`list
 create a server waiting for incoming connections on the specified port (2000) in this case. The
 same function may also be used to create various other kinds of servers:
 
-```julia
+```julia-repl
 julia> listen(2000) # Listens on localhost:2000 (IPv4)
 TCPServer(active)
 
@@ -230,7 +230,7 @@ cwd, etc.) is the same you should be able to pass the same arguments to [`connec
 you did to listen to establish the connection. So let's try that out (after having created the
 server above):
 
-```julia
+```julia-repl
 julia> connect(2000)
 TCPSocket(open, 0 bytes waiting)
 
@@ -250,7 +250,7 @@ task resumed execution (because a connection request was now available), accepte
 printed the message and waited for the next client. Reading and writing works in the same way.
 To see this, consider the following simple echo server:
 
-```julia
+```julia-repl
 julia> @async begin
            server = listen(2001)
            while true
@@ -276,7 +276,7 @@ Hello World from the Echo Server
 
 As with other streams, use [`close()`](@ref) to disconnect the socket:
 
-```julia
+```julia-repl
 julia> close(clientside)
 ```
 
@@ -286,7 +286,7 @@ One of the [`connect()`](@ref) methods that does not follow the [`listen()`](@re
 `connect(host::String,port)`, which will attempt to connect to the host given by the `host` parameter
 on the port given by the port parameter. It allows you to do things like:
 
-```julia
+```julia-repl
 julia> connect("google.com",80)
 TCPSocket(RawFD(30) open, 0 bytes waiting)
 ```
@@ -294,7 +294,7 @@ TCPSocket(RawFD(30) open, 0 bytes waiting)
 At the base of this functionality is [`getaddrinfo()`](@ref), which will do the appropriate address
 resolution:
 
-```julia
+```julia-repl
 julia> getaddrinfo("google.com")
 ip"74.125.226.225"
 ```

--- a/doc/src/manual/packages.md
+++ b/doc/src/manual/packages.md
@@ -1080,7 +1080,7 @@ If a requirement line has leading words that begin with `@`, it is a system-depe
 If your system matches these system conditionals, the requirement is included, if not, the requirement
 is ignored. For example:
 
-```julia
+```
 @osx Homebrew
 ```
 
@@ -1098,7 +1098,7 @@ conditions that are currently supported are (hierarchically):
 The `@unix` condition is satisfied on all UNIX systems, including Linux and BSD. Negated system
 conditionals are also supported by adding a `!` after the leading `@`. Examples:
 
-```julia
+```
 @!windows
 @unix @!osx
 ```

--- a/doc/src/manual/packages.md
+++ b/doc/src/manual/packages.md
@@ -16,7 +16,7 @@ add your code to the curated METADATA repository.
 The [`Pkg.status()`](@ref) function prints out a summary of the state of packages you have installed.
 Initially, you'll have no packages installed:
 
-```julia
+```julia-repl
 julia> Pkg.status()
 INFO: Initializing package repository /Users/stefan/.julia/v0.6
 INFO: Cloning METADATA from git://github.com/JuliaLang/METADATA.jl
@@ -27,7 +27,7 @@ Your package directory is automatically initialized the first time you run a `Pk
 that expects it to exist – which includes [`Pkg.status()`](@ref). Here's an example non-trivial
 set of required and additional packages:
 
-```julia
+```julia-repl
 julia> Pkg.status()
 Required packages:
  - Distributions                 0.2.8
@@ -43,7 +43,7 @@ will explain these states and annotations as we encounter them. For programmatic
 returns a dictionary, mapping installed package names to the version of that package which is
 installed:
 
-```julia
+```julia-repl
 julia> Pkg.installed()
 Dict{String,VersionNumber} with 4 entries:
 "Distributions"     => v"0.2.8"
@@ -73,7 +73,7 @@ commands, which add or remove a single requirement to `REQUIRE` and then call [`
 You can add a package to the list of requirements with the [`Pkg.add()`](@ref) function, and the
 package and all the packages that it depends on will be installed:
 
-```julia
+```julia-repl
 julia> Pkg.status()
 No packages installed.
 
@@ -106,7 +106,7 @@ that the `Distributions` package should be installed since it is required but no
 stated before, you can accomplish the same thing by editing your `~/.julia/v0.6/REQUIRE` file
 by hand and then running [`Pkg.resolve()`](@ref) yourself:
 
-```julia
+```julia-repl
 $ echo UTF16 >> ~/.julia/v0.6/REQUIRE
 
 julia> Pkg.resolve()
@@ -131,7 +131,7 @@ specific ranges of versions of packages.
 When you decide that you don't want to have a package around any more, you can use [`Pkg.rm()`](@ref)
 to remove the requirement for it from the `REQUIRE` file:
 
-```julia
+```julia-repl
 julia> Pkg.rm("Distributions")
 INFO: Removing Distributions v0.2.7
 INFO: Removing Stats v0.2.6
@@ -207,7 +207,7 @@ in the previous section interact with registered packages, but the package manag
 and work with unregistered packages too. To install an unregistered package, use [`Pkg.clone(url)`](@ref),
 where `url` is a git URL from which the package can be cloned:
 
-```julia
+```julia-repl
 julia> Pkg.clone("git://example.com/path/to/Package.jl.git")
 INFO: Cloning Package from git://example.com/path/to/Package.jl.git
 Cloning into 'Package'...
@@ -242,7 +242,7 @@ When package developers publish new registered versions of packages that you're 
 of course, want the new shiny versions. To get the latest and greatest versions of all your packages,
 just do [`Pkg.update()`](@ref):
 
-```julia
+```julia-repl
 julia> Pkg.update()
 INFO: Updating METADATA...
 INFO: Computing changes...
@@ -276,7 +276,7 @@ You can also update only a subset of the installed packages, by providing argume
 function. In that case, only the packages provided as arguments and their dependencies will be
 updated:
 
-```julia
+```julia-repl
 julia> Pkg.update("Example")
 INFO: Updating METADATA...
 INFO: Computing changes...
@@ -295,7 +295,7 @@ registered versions, or you may be a developer of the package and need to make c
 or some other development branch. In such cases, you can do [`Pkg.checkout(pkg)`](@ref) to checkout
 the `master` branch of `pkg` or [`Pkg.checkout(pkg,branch)`](@ref) to checkout some other branch:
 
-```julia
+```julia-repl
 julia> Pkg.add("Distributions")
 INFO: Installing Distributions v0.2.9
 INFO: Installing NumericExtensions v0.2.17
@@ -337,7 +337,7 @@ for this (described below).
 When you decide that you no longer want to have a package checked out on a branch, you can "free"
 it back to the control of the package manager with [`Pkg.free(pkg)`](@ref):
 
-```julia
+```julia-repl
 julia> Pkg.free("Distributions")
 INFO: Freeing Distributions...
 INFO: No packages to install, update or remove.
@@ -356,7 +356,7 @@ be updated as new registered versions of the package are published.
 If you want to pin a package at a specific version so that calling [`Pkg.update()`](@ref) won't
 change the version the package is on, you can use the [`Pkg.pin()`](@ref) function:
 
-```julia
+```julia-repl
 julia> Pkg.pin("Stats")
 INFO: Creating Stats branch pinned.47c198b1.tmp
 
@@ -374,7 +374,7 @@ the same thing. [`Pkg.pin()`](@ref) works by creating a throw-away branch for th
 to pin the package at and then checking that branch out. By default, it pins a package at the
 current commit, but you can choose a different version by passing a second argument:
 
-```julia
+```julia-repl
 julia> Pkg.pin("Stats",v"0.2.5")
 INFO: Creating Stats branch pinned.1fd0983b.tmp
 INFO: No packages to install, update or remove.
@@ -391,7 +391,7 @@ Now the `Stats` package is pinned at commit `1fd0983b`, which corresponds to ver
 When you decide to "unpin" a package and let the package manager update it again, you can use
 [`Pkg.free()`](@ref) like you would to move off of any branch:
 
-```julia
+```julia-repl
 julia> Pkg.free("Stats")
 INFO: Freeing Stats...
 INFO: No packages to install, update or remove.
@@ -424,7 +424,7 @@ local metadata repository using that custom location and branch and then periodi
 custom branch with the official `metadata-v2` branch. In order to use a custom repository and
 branch, issue the following command:
 
-```julia
+```julia-repl
 julia> Pkg.init("https://me.example.com/METADATA.jl.git", "branch")
 ```
 
@@ -525,7 +525,7 @@ starting with `Pkg.` or `PkgDev.` is meant to be typed at the Julia prompt; anyt
 with `git` is meant to be typed in [julia's shell mode](@ref man-shell-mode) (or using the shell that comes with
 your operating system). Within Julia, you can combine these two modes:
 
-```julia
+```julia-repl
 julia> cd(Pkg.dir("Foo"))          # go to Foo's folder
 
 shell> git command arguments...    # command will apply to Foo
@@ -743,7 +743,7 @@ Suppose you want to create a new Julia package called `FooBar`. To get started, 
 where `pkg` is the new package name and `license` is the name of a license that the package generator
 knows about:
 
-```julia
+```julia-repl
 julia> PkgDev.generate("FooBar","MIT")
 INFO: Initializing FooBar repo: /Users/stefan/.julia/v0.6/FooBar
 INFO: Origin: git://github.com/StefanKarpinski/FooBar.jl.git
@@ -830,7 +830,7 @@ For your package, it will be your GitHub user name and the name of your package,
 idea. People you send this URL to can use [`Pkg.clone()`](@ref) to install the package and try
 it out:
 
-```julia
+```julia-repl
 julia> Pkg.clone("git://github.com/StefanKarpinski/FooBar.jl.git")
 INFO: Cloning FooBar from git@github.com:StefanKarpinski/FooBar.jl.git
 ```
@@ -849,7 +849,7 @@ INFO: Cloning FooBar from git@github.com:StefanKarpinski/FooBar.jl.git
 Once you've decided that `FooBar` is ready to be registered as an official package, you can add
 it to your local copy of `METADATA` using `PkgDev.register()`:
 
-```julia
+```julia-repl
 julia> PkgDev.register("FooBar")
 INFO: Registering FooBar at git://github.com/StefanKarpinski/FooBar.jl.git
 INFO: Committing METADATA for FooBar
@@ -880,7 +880,7 @@ need to merge your local `METADATA` upstream into the official repo. The `PkgDev
 will fork the `METADATA` repository on GitHub, push your changes to your fork, and open a pull
 request:
 
-```julia
+```julia-repl
 julia> PkgDev.publish()
 INFO: Validating METADATA
 INFO: No new package versions to publish
@@ -910,7 +910,7 @@ Once the package URL for `FooBar` is registered in the official `METADATA` repo,
 to clone the package from, but there still aren't any registered versions available. You can tag
 and register it with the `PkgDev.tag()` command:
 
-```julia
+```julia-repl
 julia> PkgDev.tag("FooBar")
 INFO: Tagging FooBar v0.0.1
 INFO: Committing METADATA for FooBar
@@ -958,7 +958,7 @@ they've been included upstream. Again, use the `PkgDev.publish()` command, which
 that individual package repos have been tagged, pushes them if they haven't already been, and
 then opens a pull request to `METADATA`:
 
-```julia
+```julia-repl
 julia> PkgDev.publish()
 INFO: Validating METADATA
 INFO: Pushing FooBar permanent tags: v0.0.1

--- a/doc/src/manual/packages.md
+++ b/doc/src/manual/packages.md
@@ -31,7 +31,7 @@ set of required and additional packages:
 julia> Pkg.status()
 Required packages:
  - Distributions                 0.2.8
- - UTF16                         0.2.0
+ - SHA                           0.3.2
 Additional packages:
  - NumericExtensions             0.2.17
  - Stats                         0.2.6
@@ -48,7 +48,7 @@ julia> Pkg.installed()
 Dict{String,VersionNumber} with 4 entries:
 "Distributions"     => v"0.2.8"
 "Stats"             => v"0.2.6"
-"UTF16"             => v"0.2.0"
+"SHA"               => v"0.3.2"
 "NumericExtensions" => v"0.2.17"
 ```
 
@@ -107,22 +107,22 @@ stated before, you can accomplish the same thing by editing your `~/.julia/v0.6/
 by hand and then running [`Pkg.resolve()`](@ref) yourself:
 
 ```julia-repl
-$ echo UTF16 >> ~/.julia/v0.6/REQUIRE
+$ echo SHA >> ~/.julia/v0.6/REQUIRE
 
 julia> Pkg.resolve()
-INFO: Cloning cache of UTF16 from git://github.com/nolta/UTF16.jl.git
-INFO: Installing UTF16 v0.2.0
+INFO: Cloning cache of SHA from git://github.com/staticfloat/SHA.jl.git
+INFO: Installing SHA v0.3.2
 
 julia> Pkg.status()
 Required packages:
  - Distributions                 0.2.7
- - UTF16                         0.2.0
+ - SHA                           0.3.2
 Additional packages:
  - NumericExtensions             0.2.17
  - Stats                         0.2.6
 ```
 
-This is functionally equivalent to calling [`Pkg.add("UTF16")`](@ref), except that [`Pkg.add()`](@ref)
+This is functionally equivalent to calling [`Pkg.add("SHA")`](@ref), except that [`Pkg.add()`](@ref)
 doesn't change `REQUIRE` until *after* installation has completed, so if there are problems,
 `REQUIRE` will be left as it was before calling [`Pkg.add()`](@ref). The format of the `REQUIRE`
 file is described in [Requirements Specification](@ref); it allows, among other things, requiring
@@ -140,10 +140,10 @@ INFO: REQUIRE updated.
 
 julia> Pkg.status()
 Required packages:
- - UTF16                         0.2.0
+ - SHA                           0.3.2
 
-julia> Pkg.rm("UTF16")
-INFO: Removing UTF16 v0.2.0
+julia> Pkg.rm("SHA")
+INFO: Removing SHA v0.3.2
 INFO: REQUIRE updated.
 
 julia> Pkg.status()

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -71,7 +71,7 @@ you read from a remote object to obtain data needed by the next local operation.
 [`remotecall_fetch()`](@ref) exists for this purpose. It is equivalent to `fetch(remotecall(...))`
 but is more efficient.
 
-```julia
+```julia-repl
 julia> remotecall_fetch(getindex, 2, r, 1, 1)
 0.18526337335308085
 ```
@@ -83,7 +83,7 @@ The syntax of [`remotecall()`](@ref) is not especially convenient. The macro [`@
 makes things easier. It operates on an expression rather than a function, and picks where to do
 the operation for you:
 
-```julia
+```julia-repl
 julia> r = @spawn rand(2,2)
 Future(2, 1, 4, Nullable{Any}())
 
@@ -113,7 +113,7 @@ have fetched, the remote stored value is deleted.
 Your code must be available on any process that runs it. For example, type the following into
 the Julia prompt:
 
-```julia
+```julia-repl
 julia> function rand2(dims...)
            return 2*rand(dims...)
        end
@@ -169,7 +169,7 @@ Starting Julia with `julia -p 2`, you can use this to verify the following:
 You can force a command to run on all processes using the [`@everywhere`](@ref) macro. For example, `@everywhere`
 can also be used to directly define a function on all processes:
 
-```julia
+```julia-repl
 julia> @everywhere id = myid()
 
 julia> remotecall_fetch(()->id, 2)
@@ -216,7 +216,7 @@ operation. Consider these two approaches to constructing and squaring a random m
 
 Method 1:
 
-```julia
+```julia-repl
 julia> A = rand(1000,1000);
 
 julia> Bref = @spawn A^2;
@@ -228,7 +228,7 @@ julia> fetch(Bref);
 
 Method 2:
 
-```julia
+```julia-repl
 julia> Bref = @spawn rand(1000,1000)^2;
 
 [...]
@@ -256,7 +256,7 @@ Expressions executed remotely via `@spawn`, or closures specified for remote exe
 a little differently compared to global bindings in other modules. Consider the following code
 snippet:
 
-```julia
+```julia-repl
 A = rand(10,10)
 remotecall_fetch(()->foo(A), 2)
 ```
@@ -296,7 +296,7 @@ altogether if possible. If you must reference globals, consider using `let` bloc
 
 For example:
 
-```julia
+```julia-repl
 julia> A = rand(10,10);
 
 julia> remotecall_fetch(()->A, 2);
@@ -339,7 +339,7 @@ end
 The function `count_heads` simply adds together `n` random bits. Here is how we can perform some
 trials on two machines, and add together the results:
 
-```julia
+```julia-repl
 julia> @everywhere include("count_heads.jl")
 
 julia> a = @spawn count_heads(100000000)
@@ -424,7 +424,7 @@ in some range (or, more generally, to all elements in some collection). This is 
 operation called *parallel map*, implemented in Julia as the [`pmap()`](@ref) function. For example,
 we could compute the singular values of several large random matrices in parallel as follows:
 
-```julia
+```julia-repl
 julia> M = Matrix{Float64}[rand(1000,1000) for i = 1:10];
 
 julia> pmap(svd, M);
@@ -453,7 +453,7 @@ work to processes only when they finish their current tasks.
 
 As an example, consider computing the singular values of matrices of different sizes:
 
-```julia
+```julia-repl
 julia> M = Matrix{Float64}[rand(800,800), rand(600,600), rand(800,800), rand(600,600)];
 
 julia> pmap(svd, M);
@@ -553,7 +553,7 @@ A channel can be visualized as a pipe, i.e., it has a write end and read end.
     freely via [`take!()`](@ref) and [`put!()`](@ref) calls. [`close()`](@ref) closes a [`Channel`](@ref).
     On a closed [`Channel`](@ref), [`put!()`](@ref) will fail. For example:
 
-```julia
+```julia-repl
 julia> c = Channel(2);
 
 julia> put!(c, 1) # `put!` on an open channel succeeds
@@ -569,7 +569,7 @@ ERROR: InvalidStateException("Channel is closed.",:closed)
   * [`take!()`](@ref) and [`fetch()`](@ref) (which retrieves but does not remove the value) on a closed
     channel successfully return any existing values until it is emptied. Continuing the above example:
 
-```julia
+```julia-repl
 julia> fetch(c) # Any number of `fetch` calls succeed.
 1
 
@@ -590,7 +590,7 @@ long as the `Channel` has data or is open. The loop variable takes on all values
 
 For example, the following would cause the `for` loop to wait for more data:
 
-```julia
+```julia-repl
 julia> c = Channel{Int}(10);
 
 julia> foreach(i->put!(c, i), 1:3) # add a few entries
@@ -600,7 +600,7 @@ julia> data = [i for i in c]
 
 while this will return after reading all data:
 
-```julia
+```julia-repl
 julia> c = Channel{Int}(10);
 
 julia> foreach(i->put!(c, i), 1:3); # add a few entries
@@ -620,7 +620,7 @@ Each task in this simulation reads a `job_id`, waits for a random amout of time 
 a tuple of `job_id` and the simulated time to the results channel. Finally all the `results` are
 printed out.
 
-```julia
+```julia-repl
 julia> const jobs = Channel{Int}(32);
 
 julia> const results = Channel{Tuple}(32);
@@ -725,7 +725,7 @@ are written to the channel. Each remotely executing task in this simulation read
 waits for a random amount of time and writes back a tuple of `job_id`, time taken and its own
 `pid` to the results channel. Finally all the `results` are printed out on the master process.
 
-```julia
+```julia-repl
 julia> addprocs(4); # add worker processes
 
 julia> const jobs = RemoteChannel(()->Channel{Int}(32));
@@ -845,7 +845,7 @@ portion of the array, thereby parallelizing initialization.
 
 Here's a brief example:
 
-```julia
+```julia-repl
 julia> addprocs(3)
 3-element Array{Int64,1}:
  2
@@ -872,7 +872,7 @@ julia> S
 convenient for splitting up tasks among processes. You can, of course, divide the work any way
 you wish:
 
-```julia
+```julia-repl
 julia> S = SharedArray{Int,2}((3,4), init = S -> S[indexpids(S):length(procs(S)):length(S)] = myid())
 3×4 SharedArray{Int64,2}:
  2  2  2  2
@@ -910,7 +910,7 @@ not be ready at the time it's needed for computing `q[i,j,t+1]`. In such cases, 
 off chunking the array manually. Let's split along the second dimension.
 Define a function that returns the `(irange, jrange)` indexes assigned to this worker:
 
-```julia
+```julia-repl
 julia> @everywhere function myrange(q::SharedArray)
            idx = indexpids(q)
            if idx == 0 # This worker is not assigned a piece
@@ -924,7 +924,7 @@ julia> @everywhere function myrange(q::SharedArray)
 
 Next, define the kernel:
 
-```julia
+```julia-repl
 julia> @everywhere function advection_chunk!(q, u, irange, jrange, trange)
            @show (irange, jrange, trange)  # display so we can see what's happening
            for t in trange, j in jrange, i in irange
@@ -936,20 +936,20 @@ julia> @everywhere function advection_chunk!(q, u, irange, jrange, trange)
 
 We also define a convenience wrapper for a `SharedArray` implementation
 
-```julia
+```julia-repl
 julia> @everywhere advection_shared_chunk!(q, u) =
            advection_chunk!(q, u, myrange(q)..., 1:size(q,3)-1)
 ```
 
 Now let's compare three different versions, one that runs in a single process:
 
-```julia
+```julia-repl
 julia> advection_serial!(q, u) = advection_chunk!(q, u, 1:size(q,1), 1:size(q,2), 1:size(q,3)-1);
 ```
 
 one that uses [`@parallel`](@ref):
 
-```julia
+```julia-repl
 julia> function advection_parallel!(q, u)
            for t = 1:size(q,3)-1
                @sync @parallel for j = 1:size(q,2)
@@ -964,7 +964,7 @@ julia> function advection_parallel!(q, u)
 
 and one that delegates in chunks:
 
-```julia
+```julia-repl
 julia> function advection_shared!(q, u)
            @sync begin
                for p in procs(q)
@@ -977,7 +977,7 @@ julia> function advection_shared!(q, u)
 
 If we create `SharedArray`s and time these functions, we get the following results (with `julia -p 4`):
 
-```julia
+```julia-repl
 julia> q = SharedArray{Float64,3}((500,500,500));
 
 julia> u = SharedArray{Float64,3}((500,500,500));
@@ -985,7 +985,7 @@ julia> u = SharedArray{Float64,3}((500,500,500));
 
 Run the functions once to JIT-compile and [`@time`](@ref) them on the second run:
 
-```julia
+```julia-repl
 julia> @time advection_serial!(q, u);
 (irange,jrange,trange) = (1:500,1:500,1:499)
  830.220 milliseconds (216 allocations: 13820 bytes)
@@ -1300,7 +1300,7 @@ in the future.
 By default, Julia starts up with a single thread of execution. This can be verified by using the
 command [`Threads.nthreads()`](@ref):
 
-```julia
+```julia-repl
 julia> Threads.nthreads()
 1
 ```
@@ -1318,14 +1318,14 @@ start up the command line in the location of `julia.exe` and use `set` instead o
 
 Let's verify there are 4 threads at our disposal.
 
-```julia
+```julia-repl
 julia> Threads.nthreads()
 4
 ```
 
 But we are currently on the master thread. To check, we use the command [`Threads.threadid()`](@ref)
 
-```julia
+```julia-repl
 julia> Threads.threadid()
 1
 ```
@@ -1355,7 +1355,7 @@ thread ID into each location.
 Julia supports parallel loops using the [`Threads.@threads`](@ref) macro. This macro is affixed
 in front of a `for` loop to indicate to Julia that the loop is a multi-threaded region:
 
-```julia
+```julia-repl
 julia> Threads.@threads for i = 1:10
            a[i] = Threads.threadid()
        end
@@ -1364,7 +1364,7 @@ julia> Threads.@threads for i = 1:10
 The iteration space is split amongst the threads, after which each thread writes its thread ID
 to its assigned locations:
 
-```julia
+```julia-repl
 julia> a
 10-element Array{Float64,1}:
  1.0

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1308,7 +1308,7 @@ julia> Threads.nthreads()
 The number of threads Julia starts up with is controlled by an environment variable called `JULIA_NUM_THREADS`.
 Now, let's start up Julia with 4 threads:
 
-```
+```bash
 export JULIA_NUM_THREADS=4
 ```
 
@@ -1415,4 +1415,3 @@ It is very important that the called function does not call back into Julia.
     introduced a new set of communication mechanisms, collectively referred to as Remote Memory Access
     (RMA). The motivation for adding RMA to the MPI standard was to facilitate one-sided communication
     patterns. For additional information on the latest MPI standard, see [http://mpi-forum.org/docs](http://mpi-forum.org/docs/).
-

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -257,7 +257,7 @@ like `m` but not for objects like `t`.
 Of course, all of this is true only if we construct `m` with a concrete type.  We can break this
 by explicitly constructing it with an abstract type:
 
-```julia-repl myambig2
+```jldoctest myambig2
 julia> m = MyType{AbstractFloat}(3.2)
 MyType{AbstractFloat}(3.2)
 
@@ -429,7 +429,7 @@ the array type `A`.
 However, there's one remaining hole: we haven't enforced that `A` has element type `T`, so it's
 perfectly possible to construct an object like this:
 
-```julia-repl
+```jldoctest containers2
 julia> b = MyContainer{Int64, UnitRange{Float64}}(UnitRange(1.3, 5.0));
 
 julia> typeof(b)

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -34,13 +34,13 @@ being done, and what their inputs and outputs are.
 
 In the following REPL session:
 
-```julia
+```julia-repl
 julia> x = 1.0
 ```
 
 is equivalent to:
 
-```julia
+```julia-repl
 julia> global x = 1.0
 ```
 
@@ -51,7 +51,7 @@ so all the performance issues discussed previously apply.
 A useful tool for measuring performance is the [`@time`](@ref) macro. The following example
 illustrates good working style:
 
-```julia
+```julia-repl
 julia> function f(n)
            s = 0
            for i = 1:n
@@ -88,7 +88,7 @@ As a teaser, an improved version of this function allocates no memory
 (the allocation reported below is due to running the `@time` macro in global scope)
 and has an order of magnitude faster execution after the first call:
 
-```julia
+```julia-repl
 julia> @time f_improved(1)
   0.007008 seconds (1.32 k allocations: 63.640 KiB)
 0.5
@@ -257,7 +257,7 @@ like `m` but not for objects like `t`.
 Of course, all of this is true only if we construct `m` with a concrete type.  We can break this
 by explicitly constructing it with an abstract type:
 
-```julia myambig2
+```julia-repl myambig2
 julia> m = MyType{AbstractFloat}(3.2)
 MyType{AbstractFloat}(3.2)
 
@@ -429,7 +429,7 @@ the array type `A`.
 However, there's one remaining hole: we haven't enforced that `A` has element type `T`, so it's
 perfectly possible to construct an object like this:
 
-```julia
+```julia-repl
 julia> b = MyContainer{Int64, UnitRange{Float64}}(UnitRange(1.3, 5.0));
 
 julia> typeof(b)
@@ -843,7 +843,7 @@ end
 
 Now we will time each of these functions using the same random `10000` by `1` input vector:
 
-```julia
+```julia-repl
 julia> x = randn(10000);
 
 julia> fmt(f) = println(rpad(string(f)*": ", 14, ' '), @elapsed f(x))
@@ -906,7 +906,7 @@ end
 
 Timing results:
 
-```julia
+```julia-repl
 julia> @time loopinc()
   0.529894 seconds (40.00 M allocations: 1.490 GiB, 12.14% gc time)
 50000015000000
@@ -951,7 +951,7 @@ Both `f` and `fdot` compute the same thing.  However, `fdot`
 (defined with the help of the [`@.`](@ref @__dot__) macro) is
 significantly faster when applied to an array:
 
-```julia
+```julia-repl
 julia> x = rand(10^6);
 
 julia> @time f(x);
@@ -992,7 +992,7 @@ This can be done for individual slices by calling [`view()`](@ref),
 or more simply for a whole expression or block of code by putting
 [`@views`](@ref) in front of that expression.  For example:
 
-```julia
+```julia-repl
 julia> fcopy(x) = sum(x[2:end-1])
 
 julia> @views fview(x) = sum(x[2:end-1])

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -465,7 +465,7 @@ It is often convenient to work with data structures that may contain values of a
 of type `Array{Any}`). But, if you're using one of these structures and happen to know the type
 of an element, it helps to share this knowledge with the compiler:
 
-```
+```julia
 function foo(a::Array{Any,1})
     x = a[1]::Int32
     b = x+1
@@ -481,7 +481,7 @@ expected type, potentially catching certain bugs earlier.
 
 Keyword arguments can have declared types:
 
-```
+```julia
 function with_keyword(x; name::Int = 1)
     ...
 end

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -36,7 +36,7 @@ any alternatives.
 
 Let's work with a simple test case:
 
-```julia
+```julia-repl
 julia> function myfunc()
            A = rand(200, 200, 400)
            maximum(A)
@@ -46,20 +46,20 @@ julia> function myfunc()
 It's a good idea to first run the code you intend to profile at least once (unless you want to
 profile Julia's JIT-compiler):
 
-```julia
+```julia-repl
 julia> myfunc() # run once to force compilation
 ```
 
 Now we're ready to profile this function:
 
-```julia
+```julia-repl
 julia> @profile myfunc()
 ```
 
 To see the profiling results, there is a [graphical browser](https://github.com/timholy/ProfileView.jl)
 available, but here we'll use the text-based display that comes with the standard library:
 
-```julia
+```julia-repl
 julia> Profile.print()
 80 ./event.jl:73; (::Base.REPL.##1#2{Base.REPL.REPLBackend})()
  80 ./REPL.jl:97; macro expansion
@@ -126,7 +126,7 @@ Overall, we can tentatively conclude that generating the random numbers is appro
 as finding the maximum element. We could increase our confidence in this result by
 collecting more samples:
 
-```julia
+```julia-repl
 julia> @profile (for i = 1:100; myfunc(); end)
 
 julia> Profile.print()
@@ -150,7 +150,7 @@ using the `C=true` output mode described below, or by using [ProfileView.jl](htt
 This illustrates the default "tree" dump; an alternative is the "flat" dump, which accumulates
 counts independent of their nesting:
 
-```julia
+```julia-repl
 julia> Profile.print(format=:flat)
  Count File          Line Function
   6714 ./<missing>     -1 anonymous

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -49,7 +49,7 @@ true
 
 More generally, you can use [`open()`](@ref) to read from or write to an external command.
 
-```julia
+```julia-repl
 julia> open(`less`, "w", STDOUT) do io
            for i = 1:3
                println(io, i)
@@ -256,7 +256,7 @@ This pipes the output of the `echo` command to the `sort` command. Of course, th
 interesting since there's only one line to sort, but we can certainly do much more interesting
 things:
 
-```julia
+```julia-repl
 julia> run(pipeline(`cut -d: -f3 /etc/passwd`, `sort -n`, `tail -n5`))
 210
 211
@@ -273,7 +273,7 @@ that shells cannot.
 
 Julia can run multiple commands in parallel:
 
-```julia
+```julia-repl
 julia> run(`echo hello` & `echo world`)
 world
 hello
@@ -326,7 +326,7 @@ setup of pipes between processes is a powerful one. To give some sense of the co
 that can be created easily, here are some more sophisticated examples, with apologies for the
 excessive use of Perl one-liners:
 
-```julia
+```julia-repl
 julia> prefixer(prefix, sleep) = `perl -nle '$|=1; print "'$prefix' ", $_; sleep '$sleep';'`;
 
 julia> run(pipeline(`perl -le '$|=1; for(0..9){ print; sleep 1 }'`, prefixer("A",2) & prefixer("B",2)))
@@ -352,7 +352,7 @@ the output is buffered and printed to the pipe at once, to be read by just one c
 
 Here is an even more complex multi-stage producer-consumer example:
 
-```julia
+```julia-repl
 julia> run(pipeline(`perl -le '$|=1; for(0..9){ print; sleep 1 }'`,
            prefixer("X",3) & prefixer("Y",3) & prefixer("Z",3),
            prefixer("A",2) & prefixer("B",2)))

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -49,7 +49,7 @@ true
 
 More generally, you can use [`open()`](@ref) to read from or write to an external command.
 
-```julia-repl
+```jldoctest
 julia> open(`less`, "w", STDOUT) do io
            for i = 1:3
                println(io, i)

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -7,7 +7,7 @@ easy to use programmatically.
 
 The primary function used to obtain a stack trace is [`stacktrace()`](@ref):
 
-```julia
+```julia-repl
 julia> stacktrace()
 4-element Array{StackFrame,1}:
  eval(::Module, ::Any) at boot.jl:236
@@ -20,7 +20,7 @@ Calling [`stacktrace()`](@ref) returns a vector of [`StackFrame`](@ref) s. For e
 alias [`StackTrace`](@ref) can be used in place of `Vector{StackFrame}`. (Examples with `[...]`
 indicate that output may vary depending on how the code is run.)
 
-```julia
+```julia-repl
 julia> example() = stacktrace()
 example (generic function with 1 method)
 
@@ -51,7 +51,7 @@ Note that when calling [`stacktrace()`](@ref) you'll typically see a frame with 
 When calling [`stacktrace()`](@ref) from the REPL you'll also have a few extra frames in the stack
 from `REPL.jl`, usually looking something like this:
 
-```julia
+```julia-repl
 julia> example() = stacktrace()
 example (generic function with 1 method)
 
@@ -71,7 +71,7 @@ indicating whether the frame has been inlined, a flag indicating whether it is a
 default C functions do not appear in the stack trace), and an integer representation of the pointer
 returned by [`backtrace()`](@ref):
 
-```julia
+```julia-repl
 julia> top_frame = stacktrace()[1]
 eval(::Module, ::Any) at boot.jl:236
 
@@ -94,7 +94,7 @@ julia> top_frame.from_c
 false
 ```
 
-```julia
+```julia-repl
 julia> top_frame.pointer
 0x00007f390d152a59
 ```
@@ -107,7 +107,7 @@ more.
 While having easy access to information about the current state of the callstack can be helpful
 in many places, the most obvious application is in error handling and debugging.
 
-```julia
+```julia-repl
 julia> @noinline bad_function() = undeclared_variable
 bad_function (generic function with 1 method)
 
@@ -135,7 +135,7 @@ This can be remedied by calling [`catch_stacktrace()`](@ref) instead of [`stackt
 Instead of returning callstack information for the current context, [`catch_stacktrace()`](@ref)
 returns stack information for the context of the most recent exception:
 
-```julia
+```julia-repl
 julia> @noinline bad_function() = undeclared_variable
 bad_function (generic function with 1 method)
 
@@ -155,7 +155,7 @@ julia> example()
 
 Notice that the stack trace now indicates the appropriate line number and the missing frame.
 
-```julia
+```julia-repl
 julia> @noinline child() = error("Whoops!")
 child (generic function with 1 method)
 
@@ -186,7 +186,7 @@ ERROR: Whoops!
 A call to [`backtrace()`](@ref) returns a vector of `Ptr{Void}`, which may then be passed into
 [`stacktrace()`](@ref) for translation:
 
-```julia
+```julia-repl
 julia> trace = backtrace()
 21-element Array{Ptr{Void},1}:
  Ptr{Void} @0x00007f10049d5b2f
@@ -225,7 +225,7 @@ by [`stacktrace()`](@ref) only has 5. This is because, by default, [`stacktrace(
 any lower-level C functions from the stack. If you want to include stack frames from C calls,
 you can do it like this:
 
-```julia
+```julia-repl
 julia> stacktrace(trace, true)
 27-element Array{StackFrame,1}:
  jl_backtrace_from_here at stackwalk.c:103
@@ -260,7 +260,7 @@ julia> stacktrace(trace, true)
 Individual pointers returned by [`backtrace()`](@ref) can be translated into [`StackFrame`](@ref)
 s by passing them into [`StackTraces.lookup()`](@ref):
 
-```julia
+```julia-repl
 julia> pointer = backtrace()[1];
 
 julia> frame = StackTraces.lookup(pointer)

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -692,7 +692,7 @@ julia> m.offsets
 It is convenient to have captures returned as an array so that one can use destructuring syntax
 to bind them to local variables:
 
-```julia
+```julia-repl
 julia> first, second, third = m.captures; first
 "a"
 ```
@@ -808,7 +808,7 @@ The Unicode escape `\u2200` is encoded in UTF-8 as the three bytes 226, 136, 128
 resulting byte array does not correspond to a valid UTF-8 string -- if you try to use this as
 a regular string literal, you will get a syntax error:
 
-```julia
+```julia-repl
 julia> "DATA\xff\u2200"
 ERROR: syntax: invalid UTF-8 sequence
 ```

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -645,7 +645,7 @@ For when a capture doesn't match, instead of a substring, `m.captures` contains 
 position, and `m.offsets` has a zero offset (recall that indices in Julia are 1-based, so a zero
 offset into a string is invalid). Here is a pair of somewhat contrived examples:
 
-```jldoctest
+```jldoctest acdmatch
 julia> m = match(r"(a|b)(c)?(d)", "acd")
 RegexMatch("acd", 1="a", 2="c", 3="d")
 
@@ -692,7 +692,7 @@ julia> m.offsets
 It is convenient to have captures returned as an array so that one can use destructuring syntax
 to bind them to local variables:
 
-```julia-repl
+```jldoctest acdmatch
 julia> first, second, third = m.captures; first
 "a"
 ```

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1059,7 +1059,7 @@ This can be done with a simple assignment statement.
 For example, `UInt` is aliased to either `UInt32` or `UInt64` as is appropriate
 for the size of pointers on the system:
 
-```julia
+```julia-repl
 # 32-bit system:
 julia> UInt
 UInt32

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -341,7 +341,7 @@ must be convertible to `Int`:
 julia> Foo((), 23.5, 1)
 ERROR: InexactError()
 Stacktrace:
- [1] convert(::Type{Int64}, ::Float64) at ./float.jl:679
+ [1] convert(::Type{Int64}, ::Float64) at ./float.jl:680
  [2] Foo(::Tuple{}, ::Float64, ::Int64) at ./none:2
 ```
 
@@ -645,7 +645,7 @@ ERROR: MethodError: Cannot `convert` an object of type Float64 to an object of t
 This may have arisen from a call to the constructor Point{Float64}(...),
 since type constructors fall back to convert methods.
 Stacktrace:
- [1] Point{Float64}(::Float64) at ./sysimg.jl:24
+ [1] Point{Float64}(::Float64) at ./sysimg.jl:77
 
 julia> Point{Float64}(1.0,2.0,3.0)
 ERROR: MethodError: no method matching Point{Float64}(::Float64, ::Float64, ::Float64)

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -174,7 +174,7 @@ julia> x
 Within soft scopes, the *global* keyword is never necessary, although allowed. The only case
 when it would change the semantics is (currently) a syntax error:
 
-```julia
+```julia-repl
 julia> let
            local j = 2
            let
@@ -332,7 +332,7 @@ The reason to allow *modifying local* variables of parent scopes in nested funct
 constructing [closures](https://en.wikipedia.org/wiki/Closure_%28computer_programming%29) which
 have a private state, for instance the `state` variable in the following example:
 
-```julia
+```julia-repl
 julia> let
            state = 0
            global counter
@@ -411,7 +411,7 @@ julia> Fs[2]()
 Since the `begin` construct does not introduce a new scope, it can be useful to use a zero-argument
 `let` to just introduce a new scope block without creating any new bindings:
 
-```julia
+```julia-repl
 julia> let
            local x = 1
            let

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -174,7 +174,7 @@ julia> x
 Within soft scopes, the *global* keyword is never necessary, although allowed. The only case
 when it would change the semantics is (currently) a syntax error:
 
-```julia-repl
+```jldoctest
 julia> let
            local j = 2
            let
@@ -332,7 +332,7 @@ The reason to allow *modifying local* variables of parent scopes in nested funct
 constructing [closures](https://en.wikipedia.org/wiki/Closure_%28computer_programming%29) which
 have a private state, for instance the `state` variable in the following example:
 
-```julia-repl
+```jldoctest
 julia> let
            state = 0
            global counter
@@ -411,7 +411,7 @@ julia> Fs[2]()
 Since the `begin` construct does not introduce a new scope, it can be useful to use a zero-argument
 `let` to just introduce a new scope block without creating any new bindings:
 
-```julia-repl
+```jldoctest
 julia> let
            local x = 1
            let

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -3,7 +3,7 @@
 A variable, in Julia, is a name associated (or bound) to a value. It's useful when you want to
 store a value (that you obtained after some math, for example) for later use. For example:
 
-```julia
+```julia-repl
 # Assign the value 10 to the variable x
 julia> x = 10
 10
@@ -100,7 +100,7 @@ to define `⊗` as an infix Kronecker product).
 
 The only explicitly disallowed names for variables are the names of built-in statements:
 
-```julia
+```julia-repl
 julia> else = false
 ERROR: syntax: unexpected "else"
 

--- a/doc/src/stdlib/sort.md
+++ b/doc/src/stdlib/sort.md
@@ -3,7 +3,7 @@
 Julia has an extensive, flexible API for sorting and interacting with already-sorted arrays of
 values. By default, Julia picks reasonable algorithms and sorts in standard ascending order:
 
-```julia-repl
+```jldoctest
 julia> sort([2,3,1])
 3-element Array{Int64,1}:
  1
@@ -13,7 +13,7 @@ julia> sort([2,3,1])
 
 You can easily sort in reverse order as well:
 
-```julia-repl
+```jldoctest
 julia> sort([2,3,1], rev=true)
 3-element Array{Int64,1}:
  3
@@ -23,7 +23,7 @@ julia> sort([2,3,1], rev=true)
 
 To sort an array in-place, use the "bang" version of the sort function:
 
-```julia-repl
+```jldoctest
 julia> a = [2,3,1];
 
 julia> sort!(a);

--- a/doc/src/stdlib/sort.md
+++ b/doc/src/stdlib/sort.md
@@ -3,7 +3,7 @@
 Julia has an extensive, flexible API for sorting and interacting with already-sorted arrays of
 values. By default, Julia picks reasonable algorithms and sorts in standard ascending order:
 
-```julia
+```julia-repl
 julia> sort([2,3,1])
 3-element Array{Int64,1}:
  1
@@ -13,7 +13,7 @@ julia> sort([2,3,1])
 
 You can easily sort in reverse order as well:
 
-```julia
+```julia-repl
 julia> sort([2,3,1], rev=true)
 3-element Array{Int64,1}:
  3
@@ -23,7 +23,7 @@ julia> sort([2,3,1], rev=true)
 
 To sort an array in-place, use the "bang" version of the sort function:
 
-```julia
+```julia-repl
 julia> a = [2,3,1];
 
 julia> sort!(a);
@@ -38,7 +38,7 @@ julia> a
 Instead of directly sorting an array, you can compute a permutation of the array's indices that
 puts the array into sorted order:
 
-```julia
+```julia-repl
 julia> v = randn(5)
 5-element Array{Float64,1}:
   0.297288
@@ -66,7 +66,7 @@ julia> v[p]
 
 Arrays can easily be sorted according to an arbitrary transformation of their values:
 
-```julia
+```julia-repl
 julia> sort(v, by=abs)
 5-element Array{Float64,1}:
  -0.0104452
@@ -78,7 +78,7 @@ julia> sort(v, by=abs)
 
 Or in reverse order by a transformation:
 
-```julia
+```julia-repl
 julia> sort(v, by=abs, rev=true)
 5-element Array{Float64,1}:
  -0.839027
@@ -90,7 +90,7 @@ julia> sort(v, by=abs, rev=true)
 
 If needed, the sorting algorithm can be chosen:
 
-```julia
+```julia-repl
 julia> sort(v, alg=InsertionSort)
 5-element Array{Float64,1}:
  -0.839027

--- a/doc/src/stdlib/test.md
+++ b/doc/src/stdlib/test.md
@@ -26,7 +26,7 @@ Base.Test.@test_throws
 
 For example, suppose we want to check our new function `foo(x)` works as expected:
 
-```julia
+```julia-repl
 julia> using Base.Test
 
 julia> foo(x) = length(x)^2
@@ -35,7 +35,7 @@ foo (generic function with 1 method)
 
 If the condition is true, a `Pass` is returned:
 
-```julia
+```julia-repl
 julia> @test foo("bar") == 9
 Test Passed
   Expression: foo("bar") == 9
@@ -49,7 +49,7 @@ Test Passed
 
 If the condition is false, then a `Fail` is returned and an exception is thrown:
 
-```julia
+```julia-repl
 julia> @test foo("f") == 20
 Test Failed
   Expression: foo("f") == 20
@@ -63,7 +63,7 @@ If the condition could not be evaluated because an exception was thrown, which o
 case because `length()` is not defined for symbols, an `Error` object is returned and an exception
 is thrown:
 
-```julia
+```julia-repl
 julia> @test foo(:cat) == 1
 Error During Test
   Test threw an exception of type MethodError
@@ -80,7 +80,7 @@ ERROR: There was an error during testing
 If we expect that evaluating an expression *should* throw an exception, then we can use `@test_throws()`
 to check that this occurs:
 
-```julia
+```julia-repl
 julia> @test_throws MethodError foo(:cat)
 Test Passed
   Expression: foo(:cat)
@@ -104,7 +104,7 @@ Base.Test.@testset
 
 We can put our tests for the `foo(x)` function in a test set:
 
-```julia
+```julia-repl
 julia> @testset "Foo Tests" begin
            @test foo("a")   == 1
            @test foo("ab")  == 4
@@ -116,7 +116,7 @@ Foo Tests     |    3      3
 
 Test sets can also be nested:
 
-```julia
+```julia-repl
 julia> @testset "Foo Tests" begin
            @testset "Animals" begin
                @test foo("cat") == 9
@@ -134,7 +134,7 @@ Foo Tests     |    8      8
 In the event that a nested test set has no failures, as happened here, it will be hidden in the
 summary. If we do have a test failure, only the details for the failed test sets will be shown:
 
-```julia
+```julia-repl
 julia> @testset "Foo Tests" begin
            @testset "Animals" begin
                @testset "Felines" begin
@@ -169,7 +169,7 @@ As calculations on floating-point values can be imprecise, you can perform appro
 checks using either `@test a ≈ b` (where `≈`, typed via tab completion of `\approx`, is the
 [`isapprox()`](@ref) function) or use [`isapprox()`](@ref) directly.
 
-```julia
+```julia-repl
 julia> @test 1 ≈ 0.999999999
 
 julia> @test 1 ≈ 0.999999


### PR DESCRIPTION
Use `julia-repl` to highlight REPL blocks in the manual, which makes them consistent with doctest blocks. Requires Documenter v0.10.1, which is why it's currently based on #21846.

I also came across a number of REPL blocks that seemed like they could be turned into doctests as well, and a few other small things. However, I guess there might have been a good reason why some of them were not enabled, so I'd be happy to drop some or all of those commits if need be.

I think it would be good to get this backported to 0.6 as well, at least the first commit. It seems that there's only one tiny conflict, so it shouldn't be a big problem.

Example build: http://mortenpi.eu/julia/julia-repl/index.html