### PR TITLE
allocate distinct seed arrays for RNGs in randjump

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -166,7 +166,7 @@ function randjump(mt::MersenneTwister, jumps::Integer, jumppoly::AbstractString)
     push!(mts, mt)
     for i in 1:jumps-1
         cmt = mts[end]
-        push!(mts, MersenneTwister(cmt.seed, dSFMT.dsfmt_jump(cmt.state, jumppoly)))
+        push!(mts, MersenneTwister(copy(cmt.seed), dSFMT.dsfmt_jump(cmt.state, jumppoly)))
     end
     return mts
 end

--- a/test/random.jl
+++ b/test/random.jl
@@ -475,6 +475,12 @@ end
 let seed = rand(UInt32, 10)
     r = MersenneTwister(seed)
     @test r.seed == seed && r.seed !== seed
+    # RNGs do not share their seed in randjump
+    let rs = randjump(r, 2)
+        @test  rs[1].seed !== rs[2].seed
+        srand(rs[2])
+        @test seed == rs[1].seed != rs[2].seed
+    end
     resize!(seed, 4)
     @test r.seed != seed
 end


### PR DESCRIPTION
Cf. also #16919, where I started avoiding aliasing the seed field of `MersenneTwister`'s with other arrays.