### PR TITLE
Disable two libgit2 tests with libgit2 < 0.26.0

### DIFF
--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -99,7 +99,8 @@ end
     end
 end
 
-is_unix() && @testset "Default config with symlink" begin
+# See #21872 and #21636
+LibGit2.version() >= v"0.26.0" && is_unix() && @testset "Default config with symlink" begin
     with_libgit2_temp_home() do tmphome
         write(joinpath(tmphome, "real_gitconfig"), "[fake]\n\tproperty = BBB")
         symlink(joinpath(tmphome, "real_gitconfig"),
@@ -854,8 +855,10 @@ mktempdir() do dir
             end
             LibGit2.add!(our_repo, "file1")
             LibGit2.commit(our_repo, "add file1")
-            # we cannot yet locally push to non-bare repos
-            @test_throws LibGit2.GitError LibGit2.push(our_repo, remoteurl=up_path)
+            if LibGit2.version() >= v"0.26.0" # See #21872, #21639 and #21597
+                # we cannot yet locally push to non-bare repos
+                @test_throws LibGit2.GitError LibGit2.push(our_repo, remoteurl=up_path)
+            end
         finally
             close(our_repo)
             close(up_repo)


### PR DESCRIPTION
Without our patches libgit2-remote-push-NULL and libgit2-gitconfig-symlink,
which are not yet included in an upstream release, these tests fail.
Disable them so that builds using the system libgit2 can pass the tests.

See https://github.com/JuliaLang/julia/pull/21597#issuecomment-300909309, https://github.com/JuliaLang/julia/issues/21639 and #21636.