### PR TITLE
Fix compilation on LLVM-svn

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -732,8 +732,11 @@ public:
     }
     void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
                           size_t Size) override;
+#if 0
+    // Disable for now since we are not actually using this.
     void deregisterEHFrames(uint8_t *Addr, uint64_t LoadAddr,
                             size_t Size) override;
+#endif
     uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
                                  unsigned SectionID,
                                  StringRef SectionName) override;
@@ -860,12 +863,14 @@ void RTDyldMemoryManagerJL::registerEHFrames(uint8_t *Addr,
     }
 }
 
+#if 0
 void RTDyldMemoryManagerJL::deregisterEHFrames(uint8_t *Addr,
                                                uint64_t LoadAddr,
                                                size_t Size)
 {
     deregister_eh_frames((uint8_t*)LoadAddr, Size);
 }
+#endif
 
 }
 


### PR DESCRIPTION
Disable eh frame deregistration overload since we don't actually use it.

There's still an assertion about DICompileUnit but at least this gets it further.

Close #21744
