### PR TITLE
inference: remove hacks around type-system incorrectness

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2082,12 +2082,12 @@ struct F21666{T <: Base.TypeArithmetic}
     x::Float32
 end
 
+Base.TypeArithmetic(::Type{F21666{T}}) where {T} = T()
+Base.:+(x::F, y::F) where {F <: F21666} = F(x.x + y.x)
+Base.convert(::Type{Float64}, x::F21666) = Float64(x.x)
 @testset "Exactness of cumsum # 21666" begin
     # test that cumsum uses more stable algorithm
     # for types with unknown/rounding arithmetic
-    Base.TypeArithmetic(::Type{F21666{T}}) where {T} = T
-    Base.:+(x::F, y::F) where {F <: F21666} = F(x.x + y.x)
-    Base.convert(::Type{Float64}, x::F21666) = Float64(x.x)
     # we make v pretty large, because stable algorithm may have a large base case
     v = zeros(300); v[1] = 2; v[200:end] = eps(Float32)
 

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -835,3 +835,6 @@ f21771(::Val{U}) where {U} = Tuple{g21771(U)}
 @test @inferred(f21771(Val{Int}())) === Tuple{Int}
 @test @inferred(f21771(Val{Union{}}())) === Tuple{Union{}}
 @test @inferred(f21771(Val{Integer}())) === Tuple{Integer}
+
+# missing method should be inferred as Union{}, ref https://github.com/JuliaLang/julia/issues/20033#issuecomment-282228948
+@test Base.return_types(f -> f(1), (typeof((x::String) -> x),)) == Any[Union{}]

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -194,7 +194,7 @@ gstr = GenericString("12")
 @test ind2chr(gstr,2)==2
 
 # issue #10307
-@test typeof(map(Int16,AbstractString[])) == Vector{Int16}
+@test typeof(map(x -> parse(Int16, x), AbstractString[])) == Vector{Int16}
 
 for T in [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128]
     for i in [typemax(T), typemin(T)]


### PR DESCRIPTION
infers a missing method (MethodError) as returning `Union{}`
and fix tests that were wrong, but not detected previously!