### PR TITLE
improved type-inference of union types

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2497,12 +2497,14 @@ function typeinf_edge(method::Method, atypes::ANY, sparams::SimpleVector, caller
     frame = resolve_call_cycle!(code, caller)
     if frame === nothing
         code.inInference = true
-        frame = InferenceState(code, true, true, caller.params) # always optimize and cache edge targets
+        frame = InferenceState(code, #=optimize=#true, #=cached=#true, caller.params) # always optimize and cache edge targets
         if frame === nothing
             code.inInference = false
             return Any, nothing
         end
-        frame.parent = caller
+        if caller.cached # don't involved uncached functions in cycle resolution
+            frame.parent = caller
+        end
         typeinf(frame)
         return frame.bestguess, frame.inferred ? frame.linfo : nothing
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -507,44 +507,7 @@ function _methods_by_ftype(t::ANY, lim::Int, world::UInt)
     return _methods_by_ftype(t, lim, world, UInt[typemin(UInt)], UInt[typemax(UInt)])
 end
 function _methods_by_ftype(t::ANY, lim::Int, world::UInt, min::Array{UInt,1}, max::Array{UInt,1})
-    tp = unwrap_unionall(t).parameters::SimpleVector
-    nu = 1
-    for ti in tp
-        if isa(ti, Union)
-            nu *= unionlen(ti::Union)
-        end
-    end
-    if 1 < nu <= 64
-        return _methods_by_ftype(Any[tp...], t, length(tp), lim, [], world, min, max)
-    end
-    # XXX: the following can return incorrect answers that the above branch would have corrected
     return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), t, lim, 0, world, min, max)
-end
-
-function _methods_by_ftype(t::Array, origt::ANY, i, lim::Integer, matching::Array{Any,1},
-                           world::UInt, min::Array{UInt,1}, max::Array{UInt,1})
-    if i == 0
-        world = typemax(UInt)
-        new = ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}),
-                    rewrap_unionall(Tuple{t...}, origt), lim, 0, world, min, max)
-        new === false && return false
-        append!(matching, new::Array{Any,1})
-    else
-        ti = t[i]
-        if isa(ti, Union)
-            for ty in uniontypes(ti::Union)
-                t[i] = ty
-                if _methods_by_ftype(t, origt, i - 1, lim, matching, world, min, max) === false
-                    t[i] = ti
-                    return false
-                end
-            end
-            t[i] = ti
-        else
-            return _methods_by_ftype(t, origt, i - 1, lim, matching, world, min, max)
-        end
-    end
-    return matching
 end
 
 # high-level, more convenient method lookup functions


### PR DESCRIPTION
This makes better use of Union types in call-sites by trying harder to form leaftype, and removing the hack from reflection. This should make it easier to add new inference heuristics. Needed to reduce `tupletype_len` back to a reasonable value so that many of the (sub)array-based tests don't require hours to finish inferring, now that inference can see into some of their calls better and it starts trying to infer a couple of complex recursive functions (used for indexing?).