### PR TITLE
Make `expm1(::Complex64)` type stable.

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -515,7 +515,8 @@ function exp(z::Complex)
     end
 end
 
-function expm1(z::Complex)
+function expm1(z::Complex{T}) where T<:Real
+    Tf = float(T)
     zr,zi = reim(z)
     if isnan(zr)
         Complex(zr, zi==0 ? zi : zr)
@@ -533,8 +534,12 @@ function expm1(z::Complex)
             Complex(erm1, zi)
         else
             er = erm1+one(erm1)
-            wr = isfinite(er) ? erm1 - 2.0*er*(sin(0.5*zi))^2 : er*cos(zi)
-            Complex(wr, er*sin(zi))
+            if isfinite(er)
+                wr = erm1 - 2 * er * (sin(convert(Tf, 0.5) * zi))^2
+                return Complex(wr, er * sin(zi))
+            else
+                return Complex(er * cos(zi), er * sin(zi))
+            end
         end
     end
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -951,3 +951,10 @@ end
         @test log1p(complex(x, x)) ≈ log(1 + complex(x, x))
     end
 end
+
+@testset "expm1 type stability" begin
+    x = @inferred expm1(0.1im)
+    @test x isa Complex128
+    x = @inferred expm1(0.1f0im)
+    @test x isa Complex64
+end


### PR DESCRIPTION
Noticed by accident when debugging https://github.com/JuliaLang/julia/pull/21831#issuecomment-301661393 .... The issue is apparently there ever since `expm1(::Complex)` is defined in 0.3....