### PR TITLE
Use VersionNumber for libllvm_version

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -55,7 +55,7 @@ else
 endif
 	@echo "const libfftw_name = \"$(LIBFFTWNAME)\"" >> $@
 	@echo "const libfftwf_name = \"$(LIBFFTWFNAME)\"" >> $@
-	@echo "const libllvm_version = \"$$($(LLVM_CONFIG_HOST) --version)\"" >> $@
+	@echo "const libllvm_version_string = \"$$($(LLVM_CONFIG_HOST) --version)\"" >> $@
 	@echo "const VERSION_STRING = \"$(JULIA_VERSION)\"" >> $@
 	@echo "const TAGGED_RELEASE_BANNER = \"$(TAGGED_RELEASE_BANNER)\"" >> $@
 	@echo "const SYSCONFDIR = \"$(sysconfdir_rel)\"" >> $@

--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -17,7 +17,7 @@ export
 # Disable 128-bit types on 32-bit Intel sytems due to LLVM problems;
 # see <https://github.com/JuliaLang/julia/issues/14818> (fixed on LLVM 3.9)
 # 128-bit atomics do not exist on AArch32.
-if (VersionNumber(Base.libllvm_version) < v"3.9-" && ARCH === :i686) ||
+if (Base.libllvm_version < v"3.9-" && ARCH === :i686) ||
         startswith(string(ARCH), "arm")
     const inttypes = (Int8, Int16, Int32, Int64,
                       UInt8, UInt16, UInt32, UInt64)
@@ -330,8 +330,8 @@ alignment(::Type{T}) where {T} = ccall(:jl_alignment, Cint, (Csize_t,), sizeof(T
 for typ in atomictypes
     lt = llvmtypes[typ]
     ilt = llvmtypes[inttype(typ)]
-    rt = VersionNumber(Base.libllvm_version) >= v"3.6" ? "$lt, $lt*" : "$lt*"
-    irt = VersionNumber(Base.libllvm_version) >= v"3.6" ? "$ilt, $ilt*" : "$ilt*"
+    rt = Base.libllvm_version >= v"3.6" ? "$lt, $lt*" : "$lt*"
+    irt = Base.libllvm_version >= v"3.6" ? "$ilt, $ilt*" : "$ilt*"
     if VersionNumber(Base.libllvm_version) >= v"3.8"
         @eval getindex(x::Atomic{$typ}) =
             llvmcall($"""

--- a/base/version.jl
+++ b/base/version.jl
@@ -223,6 +223,8 @@ catch e
     VersionNumber(0)
 end
 
+libllvm_version = convert(VersionNumber, libllvm_version_string)
+
 function banner(io::IO = STDOUT)
     if GIT_VERSION_INFO.tagged_commit
         commit_string = TAGGED_RELEASE_BANNER

--- a/base/version.jl
+++ b/base/version.jl
@@ -223,7 +223,7 @@ catch e
     VersionNumber(0)
 end
 
-libllvm_version = convert(VersionNumber, libllvm_version_string)
+const libllvm_version = convert(VersionNumber, libllvm_version_string)
 
 function banner(io::IO = STDOUT)
     if GIT_VERSION_INFO.tagged_commit

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -322,7 +322,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     # issue #12671, starting from a non-directory
     # rm(dir) fails on windows with Permission denied
     # and was an upstream bug in llvm <= v3.3
-    if !is_windows() && VersionNumber(Base.libllvm_version) > v"3.3"
+    if !is_windows() && Base.libllvm_version > v"3.3"
         testdir = mktempdir()
         cd(testdir) do
             rm(testdir)

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -177,7 +177,7 @@ module ObjLoadTest
 end
 
 # Test for proper parenting
-if VersionNumber(Base.libllvm_version) >= v"3.6" # llvm 3.6 changed the syntax for a gep, so just ignore this test on older versions
+if Base.libllvm_version >= v"3.6" # llvm 3.6 changed the syntax for a gep, so just ignore this test on older versions
     local foo
     function foo()
         # this IR snippet triggers an optimization relying


### PR DESCRIPTION
To me it looks like every usage of `libllvm_version` is better of if it was an actual `VersionNumber`

Same with packages that use this which also just end up wrapping the string in a `VersionNumber`. 

This makes things more convenient. 