### PR TITLE
fix #21848, bug in widening done by limit_type_depth

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -707,8 +707,19 @@ function limit_type_depth(t::ANY, d::Int, cov::Bool, vars::Vector{TypeVar}=TypeV
     P = t.parameters
     isempty(P) && return t
     if d > MAX_TYPE_DEPTH
-        cov && return t.name.wrapper
-        var = TypeVar(:_, t.name.wrapper)
+        if isvarargtype(t)
+            # never replace Vararg with non-Vararg
+            return Vararg{limit_type_depth(P[1], d, cov, vars), P[2]}
+        end
+        widert = t.name.wrapper
+        if !(t <: widert)
+            # This can happen when a typevar has bounds too wide for its context, e.g.
+            # `Complex{T} where T` is not a subtype of `Complex`. In that case widen even
+            # faster to something safe to ensure the result is a supertype of the input.
+            widert = Any
+        end
+        cov && return widert
+        var = TypeVar(:_, widert)
         push!(vars, var)
         return var
     end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -777,3 +777,14 @@ function break_21369()
     end
 end
 @test_throws ErrorException break_21369()  # not TypeError
+
+# issue #21848
+@test Core.Inference.limit_type_depth(Ref{Complex{T} where T}, Core.Inference.MAX_TYPE_DEPTH) == Ref
+let T = Tuple{Tuple{Int64, Void},
+              Tuple{Tuple{Int64, Void},
+                    Tuple{Int64, Tuple{Tuple{Int64, Void},
+                                       Tuple{Tuple{Int64, Void}, Tuple{Int64, Tuple{Tuple{Int64, Void}, Tuple{Tuple, Tuple}}}}}}}}
+    @test Core.Inference.limit_type_depth(T, 0) >: T
+    @test Core.Inference.limit_type_depth(T, 1) >: T
+    @test Core.Inference.limit_type_depth(T, 2) >: T
+end


### PR DESCRIPTION
This would widen e.g. `Complex{T} where T` to `_ <: Complex`, which is valid in some sense but yields a type that's not a supertype of the input, which is bad.