### PR TITLE
re-enable the 0-arg MersenneTwister() constructor

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1267,9 +1267,6 @@ end
      end
 end
 
-# PR #16984
-@deprecate MersenneTwister() MersenneTwister(0)
-
 # #19635
 for fname in (:ones, :zeros)
     @eval @deprecate ($fname)(T::Type, arr) ($fname)(T, size(arr))

--- a/base/random/RNGs.jl
+++ b/base/random/RNGs.jl
@@ -40,8 +40,12 @@ end # os-test
 
 Create a `RandomDevice` RNG object.
 Two such objects will always generate different streams of random numbers.
+The entropy is obtained from the operating system.
 """
 RandomDevice
+
+RandomDevice(::Void) = RandomDevice()
+srand(rng::RandomDevice) = rng
 
 ### generation of floats
 
@@ -71,10 +75,17 @@ MersenneTwister(seed::Vector{UInt32}, state::DSFMT_state) =
 
 """
     MersenneTwister(seed)
+    MersenneTwister()
 
 Create a `MersenneTwister` RNG object. Different RNG objects can have
 their own seeds, which may be useful for generating different streams
 of random numbers.
+The `seed` may be a non-negative integer or a vector of
+`UInt32` integers. If no seed is provided, a randomly generated one
+is created (using entropy from the system).
+See the [`srand`](@ref) function for reseeding an already existing
+`MersenneTwister` object.
+
 
 # Examples
 ```jldoctest
@@ -96,7 +107,8 @@ julia> x1 == x2
 true
 ```
 """
-MersenneTwister(seed) = srand(MersenneTwister(Vector{UInt32}(), DSFMT_state()), seed)
+MersenneTwister(seed=nothing) =
+    srand(MersenneTwister(Vector{UInt32}(), DSFMT_state()), seed)
 
 function copy!(dst::MersenneTwister, src::MersenneTwister)
     copy!(resize!(dst.seed, length(src.seed)), src.seed)

--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -117,13 +117,14 @@ rand!
     srand([rng=GLOBAL_RNG], seed) -> rng
     srand([rng=GLOBAL_RNG]) -> rng
 
-Reseed the random number generator. If a `seed` is provided, the RNG will give a
-reproducible sequence of numbers, otherwise Julia will get entropy from the system. For
-`MersenneTwister`, the `seed` may be a non-negative integer or a vector of [`UInt32`](@ref)
-integers. `RandomDevice` does not support seeding.
+Reseed the random number generator: `rng` will give a reproducible
+sequence of numbers if and only if a `seed` is provided. Some RNGs
+don't accept a seed, like `RandomDevice`.
+After the call to `srand`, `rng` is equivalent to a newly created
+object initialized with the same seed.
 
 # Examples
-```jldoctest
+```julia-repl
 julia> srand(1234);
 
 julia> x1 = rand(2)
@@ -140,8 +141,23 @@ julia> x2 = rand(2)
 
 julia> x1 == x2
 true
+
+julia> rng = MersenneTwister(1234); rand(rng, 2) == x1
+true
+
+julia> MersenneTwister(1) == srand(rng, 1)
+true
+
+julia> rand(srand(rng), Bool) # not reproducible
+true
+
+julia> rand(srand(rng), Bool)
+false
+
+julia> rand(MersenneTwister(), Bool) # not reproducible either
+true
 ```
 """
-srand
+srand(rng::AbstractRNG, ::Void) = srand(rng)
 
 end # module


### PR DESCRIPTION
Cf. #16984 for context, which deprecated `MersenneTwister() = MersenneTwister(0)`. 
The next step here is to re-enable this constructor to be equivalent to `srand(MersenneTwister(0))`. 
I think that it's good for predictability that for an RNG type `T`, `T([seed])` produces an RNG object equivalent to `srand(T(), [seed]))`.
Accordingly, `srand(RandomDevice())` is also enabled (as a no-op).
I put WIP as I'm not satisfied with my wording in the docstrings.