### PR TITLE
fix #21906, `ccall` causes unnecessary variable `Box`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2960,7 +2960,7 @@ f(x) = yt(x)
                                (memq (car e) '(quote top core line inert local local-def unnecessary
                                                meta inbounds boundscheck simdloop decl
                                                implicit-global global globalref outerref
-                                               const = null method call ssavalue))))
+                                               const = null method call foreigncall ssavalue))))
                          (lam:body lam))))
                (unused (map cadr (filter (lambda (x) (memq (car x) '(method =)))
                                          leading))))


### PR DESCRIPTION
This was probably an oversight from when the `foreigncall` expr head was introduced.