### PR TITLE
WIP: Make mutating immutables easier

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -138,7 +138,8 @@ export
     Expr, GotoNode, LabelNode, LineNumberNode, QuoteNode,
     GlobalRef, NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot,
     # object model functions
-    fieldtype, getfield, setfield!, nfields, throw, tuple, ===, isdefined, eval,
+    fieldtype, getfield, setfield, setfield!, nfields, throw, tuple, ===,
+    isdefined, eval,
     # sizeof    # not exported, to avoid conflicting with Base.sizeof
     # type reflection
     issubtype, typeof, isa, typeassert,

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -138,7 +138,7 @@ export
     Expr, GotoNode, LabelNode, LineNumberNode, QuoteNode,
     GlobalRef, NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot,
     # object model functions
-    fieldtype, getfield, setfield, setfield!, nfields, throw, tuple, ===,
+    fieldtype, getfield, setfield!, nfields, throw, tuple, ===,
     isdefined, eval,
     # sizeof    # not exported, to avoid conflicting with Base.sizeof
     # type reflection

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -978,6 +978,11 @@ export
     catch_stacktrace,
 
 # types
+    gepfield,
+    gepindex,
+    setfield,
+    setindex,
+    @setfield,
     convert,
     fieldoffset,
     fieldname,

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -875,6 +875,7 @@ function getfield_tfunc(s00::ANY, name)
     return rewrap_unionall(limit_type_depth(R, 0), s00)
 end
 add_tfunc(getfield, 2, 2, (s::ANY, name::ANY) -> getfield_tfunc(s, name))
+add_tfunc(setfield, 3, 3, (o::ANY, f::ANY, v::ANY) -> o)
 add_tfunc(setfield!, 3, 3, (o::ANY, f::ANY, v::ANY) -> v)
 function fieldtype_tfunc(s0::ANY, name::ANY)
     if s0 === Any || s0 === Type || DataType ⊑ s0 || UnionAll ⊑ s0

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -875,7 +875,6 @@ function getfield_tfunc(s00::ANY, name)
     return rewrap_unionall(limit_type_depth(R, 0), s00)
 end
 add_tfunc(getfield, 2, 2, (s::ANY, name::ANY) -> getfield_tfunc(s, name))
-add_tfunc(setfield, 3, 3, (o::ANY, f::ANY, v::ANY) -> o)
 add_tfunc(setfield!, 3, 3, (o::ANY, f::ANY, v::ANY) -> v)
 function fieldtype_tfunc(s0::ANY, name::ANY)
     if s0 === Any || s0 === Type || DataType ⊑ s0 || UnionAll ⊑ s0

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -379,6 +379,8 @@ function fieldindex(T::DataType, name::Symbol, err::Bool=true)
     return Int(ccall(:jl_field_index, Cint, (Any, Any, Cint), T, name, err)+1)
 end
 
+fieldisptr(T::DataType, idx::Integer) = 1 == ccall(:jl_get_field_isptr, Cint, (Any, Cint), T, idx)
+
 type_alignment(x::DataType) = (@_pure_meta; ccall(:jl_get_alignment, Csize_t, (Any,), x))
 
 # return all instances, for types that can be enumerated

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -376,10 +376,17 @@ julia> Base.fieldindex(Foo, :z, false)
 ```
 """
 function fieldindex(T::DataType, name::Symbol, err::Bool=true)
-    return Int(ccall(:jl_field_index, Cint, (Any, Any, Cint), T, name, err)+1)
+    @_pure_meta
+    i = 1
+    for fld in T.name.names
+        name == fld && return i
+        i += 1
+    end
+    err && error("type $T has no field $name")
+    return -1
 end
 
-fieldisptr(T::DataType, idx::Integer) = 1 == ccall(:jl_get_field_isptr, Cint, (Any, Cint), T, idx)
+fieldisptr(T::DataType, idx::Integer) = 1 == (@_pure_meta; ccall(:jl_get_field_isptr, Cint, (Any, Cint), T, idx))
 
 type_alignment(x::DataType) = (@_pure_meta; ccall(:jl_get_alignment, Csize_t, (Any,), x))
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -102,7 +102,7 @@ julia> ntuple(i -> 2*i, 4)
 """
 function ntuple(f::F, n::Integer) where F
     RT = Core.Inference.return_type(f, Tuple{Int})
-    TT = NTuple{RT, n}
+    TT = NTuple{n, RT}
     if isbits(RT)
         r = Ref{TT}()
         for i = 1:n
@@ -316,6 +316,18 @@ function isless(t1::Tuple, t2::Tuple)
         end
     end
     return n1 < n2
+end
+
+function convert(::Type{NTuple{N, S}}, x::NTuple{N, T} where T) where {N, S}
+    if isbits(S)
+        r = Ref{NTuple{N, S}}()
+        for i = 1:N
+            r@[i] = convert(S, x[i])
+        end
+        return r[]
+    else
+        return tuple([convert(S, x[i]) for i = 1:N]...)
+    end
 end
 
 ## functions ##

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -23,13 +23,8 @@ getindex(t::Tuple, i::Real) = getfield(t, convert(Int, i))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = ([t[ri] for ri in r]...)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t,find(b)) : throw(BoundsError(t, b))
 
-# returns new tuple; N.B.: becomes no-op if i is out-of-bounds
-setindex(x::Tuple, v, i::Integer) = _setindex((), x, v, i::Integer)
-function _setindex(y::Tuple, r::Tuple, v, i::Integer)
-    @_inline_meta
-    _setindex((y..., ifelse(length(y) + 1 == i, v, first(r))), tail(r), v, i)
-end
-_setindex(y::Tuple, r::Tuple{}, v, i::Integer) = y
+# returns new tuple
+setindex(x::Tuple, v, i::Integer) = setfield(x, i, v)
 
 ## iterating ##
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -22,6 +22,7 @@ getindex(t::Tuple, i::Int) = getfield(t, i)
 getindex(t::Tuple, i::Real) = getfield(t, convert(Int, i))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = ([t[ri] for ri in r]...)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t,find(b)) : throw(BoundsError(t, b))
+gepindex(x::Tuple, i) = gepfield(x, i)
 
 # returns new tuple
 setindex(x::Tuple, v, i::Integer) = setfield(x, i, v)

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -27,6 +27,7 @@ DECLARE_BUILTIN(_apply_latest);
 DECLARE_BUILTIN(isdefined);  DECLARE_BUILTIN(nfields);
 DECLARE_BUILTIN(tuple);      DECLARE_BUILTIN(svec);
 DECLARE_BUILTIN(getfield);   DECLARE_BUILTIN(setfield);
+DECLARE_BUILTIN(setfield_bang);
 DECLARE_BUILTIN(fieldtype);  DECLARE_BUILTIN(arrayref);
 DECLARE_BUILTIN(arrayset);   DECLARE_BUILTIN(arraysize);
 DECLARE_BUILTIN(apply_type); DECLARE_BUILTIN(applicable);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3044,7 +3044,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
         }
     }
 
-    else if (f==jl_builtin_setfield && nargs==3) {
+    else if (f==jl_builtin_setfield_bang && nargs==3) {
         jl_datatype_t *sty = (jl_datatype_t*)expr_type(args[1], ctx);
         rt1 = (jl_value_t*)sty;
         jl_datatype_t *uty = (jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)sty);
@@ -6776,6 +6776,7 @@ static void init_julia_llvm_env(Module *m)
     builtin_func_map[jl_f_isdefined] = jlcall_func_to_llvm("jl_f_isdefined", &jl_f_isdefined, m);
     builtin_func_map[jl_f_getfield] = jlcall_func_to_llvm("jl_f_getfield", &jl_f_getfield, m);
     builtin_func_map[jl_f_setfield] = jlcall_func_to_llvm("jl_f_setfield", &jl_f_setfield, m);
+    builtin_func_map[jl_f_setfield_bang] = jlcall_func_to_llvm("jl_f_setfield_bang", &jl_f_setfield_bang, m);
     builtin_func_map[jl_f_fieldtype] = jlcall_func_to_llvm("jl_f_fieldtype", &jl_f_fieldtype, m);
     builtin_func_map[jl_f_nfields] = jlcall_func_to_llvm("jl_f_nfields", &jl_f_nfields, m);
     builtin_func_map[jl_f__expr] = jlcall_func_to_llvm("jl_f__expr", &jl_f__expr, m);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -755,6 +755,13 @@ JL_DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
     return jl_field_offset(ty, field - 1);
 }
 
+JL_DLLEXPORT int jl_get_field_isptr(jl_datatype_t *ty, int field)
+{
+    if (ty->layout == NULL || field > jl_datatype_nfields(ty) || field < 1)
+        jl_bounds_error_int((jl_value_t*)ty, field);
+    return jl_field_isptr(ty, field - 1);
+}
+
 JL_DLLEXPORT size_t jl_get_alignment(jl_datatype_t *ty)
 {
     if (ty->layout == NULL)

--- a/src/dump.c
+++ b/src/dump.c
@@ -79,7 +79,7 @@ static const jl_fptr_t id_to_fptrs[] = {
   jl_f_throw, jl_f_is, jl_f_typeof, jl_f_issubtype, jl_f_isa,
   jl_f_typeassert, jl_f__apply, jl_f__apply_pure, jl_f__apply_latest, jl_f_isdefined,
   jl_f_tuple, jl_f_svec, jl_f_intrinsic_call, jl_f_invoke_kwsorter,
-  jl_f_getfield, jl_f_setfield, jl_f_fieldtype, jl_f_nfields,
+  jl_f_getfield, jl_f_setfield, jl_f_setfield_bang, jl_f_fieldtype, jl_f_nfields,
   jl_f_arrayref, jl_f_arrayset, jl_f_arraysize, jl_f_apply_type,
   jl_f_applicable, jl_f_invoke, jl_f_sizeof, jl_f__expr,
   NULL };

--- a/src/init.c
+++ b/src/init.c
@@ -817,7 +817,7 @@ void jl_get_builtins(void)
     jl_builtin_isdefined = core("isdefined");   jl_builtin_nfields = core("nfields");
     jl_builtin_tuple = core("tuple");           jl_builtin_svec = core("svec");
     jl_builtin_getfield = core("getfield");     jl_builtin_setfield_bang = core("setfield!");
-    jl_builtin_setfield = core("setfield");
+    jl_builtin_setfield = NULL; //core("setfield");
     jl_builtin_fieldtype = core("fieldtype");   jl_builtin_arrayref = core("arrayref");
     jl_builtin_arrayset = core("arrayset");     jl_builtin_arraysize = core("arraysize");
     jl_builtin_apply_type = core("apply_type"); jl_builtin_applicable = core("applicable");

--- a/src/init.c
+++ b/src/init.c
@@ -816,7 +816,8 @@ void jl_get_builtins(void)
     jl_builtin_typeassert = core("typeassert"); jl_builtin__apply = core("_apply");
     jl_builtin_isdefined = core("isdefined");   jl_builtin_nfields = core("nfields");
     jl_builtin_tuple = core("tuple");           jl_builtin_svec = core("svec");
-    jl_builtin_getfield = core("getfield");     jl_builtin_setfield = core("setfield!");
+    jl_builtin_getfield = core("getfield");     jl_builtin_setfield_bang = core("setfield!");
+    jl_builtin_setfield = core("setfield");
     jl_builtin_fieldtype = core("fieldtype");   jl_builtin_arrayref = core("arrayref");
     jl_builtin_arrayset = core("arrayset");     jl_builtin_arraysize = core("arraysize");
     jl_builtin_apply_type = core("apply_type"); jl_builtin_applicable = core("applicable");

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -158,6 +158,7 @@ void addOptimizationPasses(PassManager *PM)
     // list of passes from vmkit
     PM->add(createCFGSimplificationPass()); // Clean up disgusting code
     PM->add(createPromoteMemoryToRegisterPass()); // Kill useless allocas
+    PM->add(createMemCpyOptPass());
 
     // hopefully these functions (from llvmcall) don't try to interact with the Julia runtime
     // or have anything that might corrupt the createLowerPTLSPass pass

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -30,6 +30,7 @@
 (define prec-power       (add-dots '(^ ↑ ↓ ⇵ ⟰ ⟱ ⤈ ⤉ ⤊ ⤋ ⤒ ⤓ ⥉ ⥌ ⥍ ⥏ ⥑ ⥔ ⥕ ⥘ ⥙ ⥜ ⥝ ⥠ ⥡ ⥣ ⥥ ⥮ ⥯ ￪ ￬)))
 (define prec-decl        '(|::|))
 ;; `where` occurring after `::`
+;; '@' after here if used in `a.b@c = ` syntax
 (define prec-dot         '(|.|))
 
 (define prec-names '(prec-assignment
@@ -972,10 +973,19 @@
            (list 'call
                  (take-token s) ex (parse-factor-h s parse-unary ops))))))
 
-;; -2^3 is parsed as -(2^3), so call parse-decl for the first argument,
+;; -2^3 is parsed as -(2^3), so call parse-at for the first argument,
 ;; and parse-unary from then on (to handle 2^-3)
 (define (parse-factor s)
-  (parse-factor-h s parse-decl is-prec-power?))
+  (parse-factor-h s parse-at is-prec-power?))
+
+(define (parse-at s)
+  (let loop ((ex (parse-decl s)))
+    (let ((t (peek-token s)))
+      (case t
+        ((#\@) (take-token s)
+          (loop (list '@ ex (parse-decl s))))
+        (else
+          ex)))))
 
 (define (parse-decl s)
   (let loop ((ex (parse-call s)))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1978,8 +1978,12 @@
                 (unnecessary ,rr)))))
          ((@)
           ;; x@c =
-          (let ((expanded-ref (expand-at-ref lhs)))
-            `(call setindex! ,expanded-ref ,(caddr e))))
+          (let ((rhs (caddr e)))
+            (let ((expanded-ref (expand-at-ref lhs))
+                  (rr (if (or (symbol-like? rhs) (atom? rhs)) rhs (make-ssavalue))))
+              `(block
+                ,.(if (eq? rr rhs) '() `((= ,rr ,(expand-forms rhs))))
+                (call setindex! ,expanded-ref ,rr)))))
          ((tuple)
           ;; multiple assignment
           (let ((lhss (cdr lhs))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1580,6 +1580,12 @@
                (T (caddr lhs)))
            `(block ,@(cdr e)
                    ,(expand-update-operator op op= (car e) rhs T))))
+        ((and (pair? lhs) (eq? (car lhs) '@))
+          (let* ((ref (make-ssavalue))
+                 (nlhs `(ref ,ref)))
+            `(block
+                (= ,ref ,(expand-forms lhs))
+                ,(expand-update-operator- op op= nlhs rhs declT))))
         (else
          (if (and (pair? lhs)
                   (not (memq (car lhs) '(|.| tuple vcat typed_hcat typed_vcat))))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1836,6 +1836,56 @@
               (extract (cdr params) (cons p newparams) whereparams)))))
   (extract (cddr e) '() '()))
 
+(define (expand-at-assign expr base rr)
+  (let ((ssas `(,base))
+        (code '())
+        (idxs '()))
+  (define (emit c)
+      (set! code (cons c code)))
+  (define (add-level ssa sym)
+      (set! ssas (cons ssa ssas))
+      (set! idxs (cons sym idxs)))
+  (define (visit expr)
+    (let* ((ssa (make-ssavalue))
+           (primitive (or (symbol-like? expr) (eq? (car expr) 'vect)))
+           (prevval (if primitive base (visit (cadr expr))))
+           (refidx (and (not (symbol-like? expr)) (eq? (car expr) 'ref)))
+           (indexing (and (not (symbol-like? expr))
+                          (or (eq? (car expr) 'vect) refidx)))
+           (sym (if (symbol-like? expr) `',expr
+                  (if indexing (if refidx (cddr expr) (cdr expr)) (caddr expr)))))
+        (if indexing
+            (receive
+              (new-idxs stuff) (process-indexes prevval sym)
+              (add-level ssa new-idxs)
+              (emit `(block ,@stuff (= ,ssa (call getindex ,prevval ,@new-idxs)))))
+            (let ((ssym (if (or (symbol-like? sym) (quoted? sym)) sym
+                      (let ((nssa (make-ssavalue)))
+                          (emit `(= ,nssa ,sym))
+                          nssa))))
+              (add-level ssa ssym)
+              (emit `(= ,ssa (call (core getfield) ,prevval ,ssym)))))
+        ssa))
+    (define (build-assign expr ssas idxs v)
+        (let ((prevssa (if (symbol-like? ssas) ssas (car ssas)))
+              (sym (if (symbol-like? idxs) idxs (car idxs))))
+            (let ((new-expr
+               (if (symbol-like? expr)
+                  `(call (top setfield) ,prevssa ,sym ,v)
+                  (case (car expr)
+                    ((|.|)
+                        `(call (top setfield) ,prevssa ,sym ,v))
+                    ((vect)
+                        `(call (top setindex) ,prevssa ,v ,@sym))
+                    ((ref)
+                        `(call (top setindex) ,prevssa ,v ,@sym))))))
+                (if (null? (cdr idxs)) new-expr
+                    (build-assign (cadr expr) (cdr ssas) (cdr idxs) new-expr)))))
+    (visit expr)
+    (let ((res (build-assign expr (cdr ssas) idxs rr)))
+      (cons (reverse code) res))))
+
+
 ;; table mapping expression head to a function expanding that form
 (define expand-table
   (table
@@ -1956,6 +2006,41 @@
                             (call (core fieldtype) (call (core typeof) ,aa) ,bb)
                             ,rr))
                 (unnecessary ,rr)))))
+         ((@)
+          ;; x@c =
+          (let ((x (cadr lhs))
+                 (c  (caddr lhs))
+                 (rhs (caddr e)))
+           (let* ((xx (if (or (symbol-like? x) (atom? x)) x (make-ssavalue)))
+                  (rr (if (or (symbol-like? rhs) (atom? rhs)) rhs (make-ssavalue)))
+                  (lowered (expand-at-assign c xx rr))
+                  (pre-assign (if (eq? rr rhs) '() `((= ,rr ,(expand-forms rhs))))))
+            `(block ,.pre-assign
+              ,.(if (symbol-like? x) `(,@(car lowered) (= ,x ,(cdr lowered)))
+                 (case (car x)
+                  ;; a.b@c =
+                  ((|.|)
+                    (let*  ((a   (cadr x))
+                            (b  (caddr x))
+                            (aa (if (symbol-like? a) a (make-ssavalue))))
+                      `(
+                         ,.(if (eq? aa a)   '() `((= ,aa ,(expand-forms a))))
+                         (= ,xx (call (core getfield) ,aa ,b))
+                         ,@(car lowered)
+                         (call (core setfield!) ,aa ,b ,(cdr lowered))
+                       )))
+                  ;; a[b]@c =
+                  ((ref)
+                    (let*  ((a   (cadr x))
+                            (b  (caddr x))
+                            (aa (if (symbol-like? a) a (make-ssavalue))))
+                      `(
+                         ,.(if (eq? aa a)   '() `((= ,aa ,(expand-forms a))))
+                         (= ,xx (call getindex ,aa ,b))
+                         ,@(car lowered)
+                         (call (core setindex!) ,aa ,(cdr lowered) ,b)
+                       )))
+                  ))))))
          ((tuple)
           ;; multiple assignment
           (let ((lhss (cdr lhs))

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,7 +35,7 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "distributed", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
-        "channels", "iostream"
+        "channels", "iostream", "reffield"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1196,13 +1196,25 @@ end
 @test expand(:(f(2, a=1, w=3, c=3, w=4, b=2))) == Expr(:error,
                                                        "keyword argument \"w\" repeated in call to \"f\"")
 
-# Basic parsing for in place assign
-@test parse("a@b = 1") == :(a@b = 1)
-@test parse("a.b@c = 1") == :(a.b@c = 1)
-@test parse("a.b@c.d = 1") == :(a.b@c.d = 1)
-@test parse("a.b@c.d[e] = 1") == :(a.b@c.d[e] = 1)
-@test parse("a.b@c[d] = 1") == :(a.b@c[d] = 1)
-@test parse("a.b@c[d,e] = 1") == :(a.b@c[d,e] = 1)
-@test parse("a.b@[c] = 1") == :(a.b@[c] = 1)
-@test parse("a.b@[c,d] = 1") == :(a.b@[c,d] = 1)
-@test parse("a.b[c]@[d] = 1") == :(a.b[c]@[d] = 1)
+# Basic parsing of reference syntax
+@test expand(parse("a@b")) == :(gepfield(a, :b))
+@test expand(parse("a@c")) == :(gepfield(a, :c))
+@test expand(parse("a@c.d")) == :(gepfield(gepfield(a, :c), :d))
+@test expand(parse("a@c.d[e]")) == :(gepindex(gepfield(gepfield(a, :c), :d), e))
+@test expand(parse("a@c[d]")) == :(gepindex(gepfield(a, :c), d))
+@test expand(parse("a@c[d,e]")) == :(gepindex(gepfield(a, :c), d, e))
+@test expand(parse("a@[c]")) == :(gepindex(a, c))
+@test expand(parse("a@[c,d]")) == :(gepindex(a, c, d))
+@test expand(parse("a@[c].d")) == :(gepfield(gepindex(a, c),:d))
+
+@test expand(parse("a@b = 1")) == :(setindex!(gepfield(a, :b), 1))
+@test expand(parse("a@c = 1")) == :(setindex!(gepfield(a, :c), 1))
+@test expand(parse("a@c.d = 1")) == :(setindex!(gepfield(gepfield(a, :c), :d), 1))
+@test expand(parse("a@c.d[e] = 1")) == :(setindex!(gepindex(gepfield(gepfield(a, :c), :d), e), 1))
+@test expand(parse("a@c[d] = 1")) == :(setindex!(gepindex(gepfield(a, :c), d), 1))
+@test expand(parse("a@c[d,e] = 1")) == :(setindex!(gepindex(gepfield(a, :c), d, e), 1))
+@test expand(parse("a@[c] = 1")) == :(setindex!(gepindex(a, c), 1))
+@test expand(parse("a@[c,d] = 1")) == :(setindex!(gepindex(a, c, d), 1))
+@test expand(parse("a@[c].d = 1")) == :(setindex!(gepfield(gepindex(a, c),:d), 1))
+
+expand(:(foo(1)@a))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1217,4 +1217,11 @@ end
 @test expand(parse("a@[c,d] = 1")) == :(setindex!(gepindex(a, c, d), 1))
 @test expand(parse("a@[c].d = 1")) == :(setindex!(gepfield(gepindex(a, c),:d), 1))
 
-expand(:(foo(1)@a))
+struct reftuplefoo
+    t::NTuple{2, Int}
+end
+let x = Ref{reftuplefoo}()
+    # Check that the RHS gets expanded
+    x@t = ntuple(identity, 2)
+    @test x[] == (1,2)
+end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1195,3 +1195,14 @@ end
 # issue #16937
 @test expand(:(f(2, a=1, w=3, c=3, w=4, b=2))) == Expr(:error,
                                                        "keyword argument \"w\" repeated in call to \"f\"")
+
+# Basic parsing for in place assign
+@test parse("a@b = 1") == :(a@b = 1)
+@test parse("a.b@c = 1") == :(a.b@c = 1)
+@test parse("a.b@c.d = 1") == :(a.b@c.d = 1)
+@test parse("a.b@c.d[e] = 1") == :(a.b@c.d[e] = 1)
+@test parse("a.b@c[d] = 1") == :(a.b@c[d] = 1)
+@test parse("a.b@c[d,e] = 1") == :(a.b@c[d,e] = 1)
+@test parse("a.b@[c] = 1") == :(a.b@[c] = 1)
+@test parse("a.b@[c,d] = 1") == :(a.b@[c,d] = 1)
+@test parse("a.b[c]@[d] = 1") == :(a.b[c]@[d] = 1)

--- a/test/reffield.jl
+++ b/test/reffield.jl
@@ -1,0 +1,43 @@
+struct reffoo3
+    c::Int
+end
+
+struct reffoo2
+    b::reffoo3
+end
+
+mutable struct reffoo
+    a::reffoo2
+end
+
+let x = reffoo(reffoo2(reffoo3(1)))
+    x@a.b.c = 2
+    @test x.a.b.c == 2
+    (x@a.b.c)[] = 3
+    @test x.a.b.c == 3
+    let x = x@a.b
+        x@c = 4
+    end
+    @test x.a.b.c == 4
+    ya = @setfield(x.a, b.c = 5)
+    @test ya.b.c == 5
+    @test x.a.b.c == 4
+    @test_throws ErrorException x.a@b.c = 2
+    @test @setfield(x.a, b.c = 5).b.c == 5
+end
+
+let t = ntuple(identity, 4)
+    r = Ref{typeof(t)}(t)
+    r@[][2] = 1
+    @test r[] == (1,1,3,4)
+    @test @setfield(r, [][3] = 1)[] == (1,1,1,4)
+    @test r[] == (1,1,3,4)
+    @test_throws ErrorException t@[1]
+    @test @setfield(t, [3] = 1) == (1,2,1,4)
+end
+
+let t = ntuple(i->reffoo2(reffoo3(i)), 3)
+    r = Ref{typeof(t)}(t)
+    r@[][2].b.c = 6
+    @test r[][2].b.c == 6
+end


### PR DESCRIPTION
I like immutables, I really do, they're simple to work with, fast, don't cause allocations. Really the only thing that bothers me about them is that they're well, immutable, making them a bit of pain to work with, esp. when wanting to construct one incrementally. So here's an attempt to remedy that.
Example usage:

```
julia> struct Foo
       a::Int
       end

julia> x = Foo(1)
Foo(1)

julia> x@a = 2
Foo(2)

julia> x
Foo(2)
```

The ways this works is that under the hood, it creates a new immutable object with the specified field modified and then assigns it back to the appropriate place. Syntax wise, everything to the left of the `@` is what's being assigned to, everything to the right of the `@` is what is to be modified. E.g.

```
struct Foo4; d::Int; end
struct Foo3; c::Foo4; end
mutable struct Foo2; b::Foo3; end
struct Foo1; a::Foo2; end
x = Foo1(Foo2(Foo3(Foo4(1))))
x.a.b@c.d = 2
julia> x
Foo1(Foo2(Foo3(Foo4(2))))
```

Internally, everything to the right of the `@` gets lowered to `setindex` (no bang) and `setfield` (also no bang), which are overridable by the user. The intent is to disallow `setfield` for immutables that have a non-default inner constructor, allowing the user to provide their own which checks any required invariants. That part isn't implemented here yet, however.

Lastly, LLVM isn't currently too happy about the IR this generates, so I'm working on making that happen to make sure this actually performs ok. I think from the julia side, this is pretty much the extent of it though. Pretty much untested at the moment. I want to get the LLVM side of things done first. With that in mind, feel free to check out this branch and see if you like it.

One motivating example here is of course efficient, generic fixed size arrays, so here's an example of that:
```
mutable struct MArray{Size, T, D, L} <: AbstractArray{T, D}
    data::NTuple{L, T}
end

Base.size(::MArray{Size}) where {Size} = tuple(Size.parameters...)
@inline to_linear_index(::Type{Tuple{}}, idxs, stride) = 1
@inline to_linear_index(::Type, idxs::Tuple{}, stride) = 1
@inline to_linear_index(::Type{Tuple{A}}, idxs, stride) where {A} = idxs[1]
@inline to_linear_index(::Type{Tuple{A,B}}, idxs, stride) where {A, B} = A*(idxs[1]-1) + idxs[2]
@inline to_linear_index(T::Type{<:Tuple{A, Vararg{Any}}}, idxs, stride) where A =
    (stride * (idxs[1]-1)) + to_linear_index(Base.tuple_type_tail(T), idxs[2:end], stride * A)
function Base.setindex!(a::MArray{Size}, v, idxs...) where Size
    @inbounds a.data@[to_linear_index(Size, idxs, 1)] = v
    v
end
Base.getindex(a::MArray{Size}, idxs...) where {Size} = a.data[to_linear_index(Size, idxs, 1)]

a = MArray{Tuple{2, 2}, Int, 2, 4}((1,2,3,4))
b = [1 2; 3 4]
c = [4 5; 6 7]


# Look ma, no allocations
julia> @benchmark A_mul_B!(a, b, c)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     86.193 ns (0.00% GC)
  median time:      86.993 ns (0.00% GC)
  mean time:        87.978 ns (0.00% GC)
  maximum time:     3.282 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     961
```

Fixes #11902
Supersedes #12113