### PR TITLE
Add a missing return in doInitialization

### DIFF
--- a/src/llvm-lower-handlers.cpp
+++ b/src/llvm-lower-handlers.cpp
@@ -116,6 +116,7 @@ bool LowerExcHandlers::doInitialization(Module &M) {
     setjmp_func = M.getFunction(jl_setjmp_name);
     lifetime_start = Intrinsic::getDeclaration(&M, Intrinsic::lifetime_start);
     lifetime_end = Intrinsic::getDeclaration(&M, Intrinsic::lifetime_end);
+    return true;
 }
 
 bool LowerExcHandlers::runOnFunction(Function &F) {


### PR DESCRIPTION
This fixes the warning emitted by Clang when building, and it fixes the segfault that occurs when building this on FreeBSD.