### PR TITLE
Mark the backtrace test as broken on FreeBSD

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -404,8 +404,8 @@ for precomp in ("yes", "no")
     bt = readstring(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --precompiled=$precomp
         -E 'include("____nonexistent_file")'`), stderr=catcmd))
     @test contains(bt, "include_from_node1")
-    if is_windows() && Sys.WORD_SIZE == 32 && precomp == "yes"
-        # fixme, issue #17251
+    if ((is_windows() && Sys.WORD_SIZE == 32) || (is_bsd() && !is_apple())) && precomp == "yes"
+        # FIXME: Issue #17251 (Windows), #20798 (FreeBSD)
         @test_broken contains(bt, "include_from_node1(::String) at $(joinpath(".","loading.jl"))")
     else
         @test contains(bt, "include_from_node1(::String) at $(joinpath(".","loading.jl"))")


### PR DESCRIPTION
FreeBSD has the same problem as 32-bit Windows in that some information is lost in the backtrace when precompilation is enabled (see #17251). This affects the test that looks for specific contents in the backtrace. This PR simply changes the `@test` to `@test_broken` for BSD systems, pending some fix for the lookup.