### PR TITLE
Use cached urls for appveyor and contrib/prepare_release.sh

### DIFF
--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -33,7 +33,7 @@ cd ..
 rm -rf julia-$version
 
 # download and rename binaries, with -latest copies
-julianightlies="https://s3.amazonaws.com/julianightlies/bin"
+julianightlies="https://julialangnightlies-s3.julialang.org/bin"
 curl -L -o julia-$version-linux-x86_64.tar.gz \
   $julianightlies/linux/x64/$majmin/julia-$majminpatch-$shashort-linux64.tar.gz
 cp julia-$version-linux-x86_64.tar.gz julia-$majmin-latest-linux-x86_64.tar.gz

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -89,7 +89,7 @@ esac
 if ! [ -e julia-installer.exe ]; then
   f=julia-latest-win$bits.exe
   echo "Downloading $f"
-  $curlflags -O https://s3.amazonaws.com/julianightlies/bin/winnt/x$archsuffix/$f
+  $curlflags -O https://julialangnightlies-s3.julialang.org/bin/winnt/x$archsuffix/$f
   echo "Extracting $f"
   $SEVENZIP x -y $f >> get-deps.log
 fi


### PR DESCRIPTION
downloads of nightlies

presumably if packages should be using these on appveyor, so should base?