### PR TITLE
Add specialized findin version for sorted collections

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -263,6 +263,15 @@ end
     b = [4, 6, 2, -7, 1]
     ind = findin(a, b)
     @test ind == [3,4]
+    @test findin(a, Int[]) == Int[]
+    @test findin(Int[], a) == Int[]
+
+    a = [1,2,3,4,5]
+    b = [2,3,4,6]
+    @test findin(a, b) == [2,3,4]
+    @test findin(b, a) == [1,2,3]
+    @test findin(a, Int[]) == Int[]
+    @test findin(Int[], a) == Int[]
 
     rt = Base.return_types(setindex!, Tuple{Array{Int32, 3}, UInt8, Vector{Int}, Int16, UnitRange{Int}})
     @test length(rt) == 1 && rt[1] == Array{Int32, 3}


### PR DESCRIPTION
I'm using this in a project so thought I'd put it here as well. E.g.
#### before
```julia
julia> x, y = collect(1:10^6), collect(1:10^6);

julia> @btime findin(x, y);
  137.288 ms (33 allocations: 36.00 MiB)

julia> x, y = collect(1:10^6), collect(1:10^6) + 10^6;

julia> @btime findin(x, y);
  117.592 ms (14 allocations: 27.00 MiB)
```
#### after
```julia
julia> x, y = collect(1:10^6), collect(1:10^6);

julia> @btime findin(x, y);
  8.540 ms (20 allocations: 9.00 MiB)

julia> x, y = collect(1:10^6), collect(1:10^6) + 10^6;

julia> @btime findin(x, y);
  2.006 ms (1 allocation: 80 bytes)
```
This should also be possible for `intersect` with a tiny change to the implementation.