### PR TITLE
Update parallel-computing.md

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -951,7 +951,8 @@ one that uses [`@parallel`](@ref):
 
 ```julia
 julia> function advection_parallel!(q, u)
-           for t = 1:size(q,3)-1
+           #Type assertion, see #15276 
+           for t::Int = 1:size(q,3)-1
                @sync @parallel for j = 1:size(q,2)
                    for i = 1:size(q,1)
                        q[i,j,t+1]= q[i,j,t] + u[i,j,t]


### PR DESCRIPTION
Without the assertion, type `t is Core.box` because of #15276, and the code (if copied and pasted) takes FOREVER to run (on versions 0.5 and 0.6, linux 64 bit binaries)  .

Hope this helps.