### PR TITLE
add breadcrumb to relevant PR to mysterious depwarn

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -459,7 +459,7 @@ end
 @deprecate den denominator
 @deprecate num numerator
 
-Filesystem.stop_watching(stream::Filesystem._FDWatcher) = depwarn("stop_watching(::_FDWatcher) should not be used", :stop_watching)
+Filesystem.stop_watching(stream::Filesystem._FDWatcher) = depwarn("stop_watching(::_FDWatcher) should not be used (see PR #19152 for more)", :stop_watching)
 
 # #19088
 @deprecate takebuf_array take!


### PR DESCRIPTION
Ref. #21475. #19152's deprecation does not seem to warrant a NEWS.md entry. But from the discussion in #19152, the depwarn should either be revised or removed. This pull request at least adds a reference to the relevant PR / discussion. And given that the method that depwarns only issues the depwarn (that is, does not perform replacement functionality), perhaps the method should throw an error stating the same rather than a depwarn so that failure to perform the requested behavior fails hard? Best!