### PR TITLE
add pop!(::Dict) to return a key=>value pair

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -544,6 +544,15 @@ function pop!(h::Dict, key, default)
     return index > 0 ? _pop!(h, index) : default
 end
 
+function pop!(h::Dict)
+    isempty(h) && throw(ArgumentError("dict must be non-empty"))
+    idx = start(h)
+    key = h.keys[idx]
+    val = h.vals[idx]
+    _delete!(h, idx)
+    key => val
+end
+
 function _delete!(h::Dict, index)
     h.slots[index] = 0x2
     ccall(:jl_arrayunset, Void, (Any, UInt), h.keys, index-1)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2360,28 +2360,35 @@ pop!(collection,key,?)
 """
     pop!(collection) -> item
 
-Remove the last item in `collection` and return it.
+Remove an item in `collection` and return it. If `collection` is an
+ordered container, the last item is returned.
 
 ```jldoctest
-julia> A=[1, 2, 3, 4, 5, 6]
+julia> A=[1, 2, 3]
 6-element Array{Int64,1}:
  1
  2
  3
- 4
- 5
- 6
 
 julia> pop!(A)
-6
+3
 
 julia> A
 5-element Array{Int64,1}:
  1
  2
- 3
- 4
- 5
+
+julia> S = Set([1, 2])
+Set([2, 1])
+
+julia> pop!(S)
+2
+
+julia> S
+Set([1])
+
+julia> pop!(Dict(1=>2))
+1=>2
 ```
 """
 pop!(collection)

--- a/base/set.jl
+++ b/base/set.jl
@@ -35,7 +35,15 @@ in(x, s::Set) = haskey(s.dict, x)
 push!(s::Set, x) = (s.dict[x] = nothing; s)
 pop!(s::Set, x) = (pop!(s.dict, x); x)
 pop!(s::Set, x, deflt) = x in s ? pop!(s, x) : deflt
-pop!(s::Set) = (idx = start(s.dict); val = s.dict.keys[idx]; _delete!(s.dict, idx); val)
+
+function pop!(s::Set)
+    isempty(s) && throw(ArgumentError("set must be non-empty"))
+    idx = start(s.dict)
+    val = s.dict.keys[idx]
+    _delete!(s.dict, idx)
+    val
+end
+
 delete!(s::Set, x) = (delete!(s.dict, x); s)
 
 copy(s::Set) = union!(similar(s), s)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -718,3 +718,12 @@ end
     @test 'b' ∈ key_str
     @test 'c' ∈ key_str
 end
+
+@testset "Dict pop!" begin
+    d = Dict(1=>2, 3=>4)
+    @test pop!(d, 1) == 2
+    @test_throws KeyError pop!(d, 1)
+    @test pop!(d, 1, 0) == 0
+    @test pop!(d) == (3=>4)
+    @test_throws ArgumentError pop!(d)
+end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -78,6 +78,7 @@ push!(s,1); push!(s,2); push!(s,3)
 @test pop!(s) == 3
 @test length(s) == 0
 @test isempty(s)
+@test_throws ArgumentError pop!(s)
 
 # copy
 data_in = (1,2,9,8,4)


### PR DESCRIPTION
I didn't find a discussion on this method, so I guess it's simply an omission. I propose it because I needed it.