### PR TITLE
Use the pure Julia exp function for fastmath

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -250,7 +250,7 @@ sqrt_fast(x::FloatTypes) = sqrt_llvm_fast(x)
 const libm = Base.libm_name
 
 for f in (:acos, :acosh, :asin, :asinh, :atan, :atanh, :cbrt, :cos,
-          :cosh, :exp2, :exp, :expm1, :lgamma, :log10, :log1p, :log2,
+          :cosh, :exp2, :expm1, :lgamma, :log10, :log1p, :log2,
           :log, :sin, :sinh, :tan, :tanh)
     f_fast = fast_op[f]
     @eval begin


### PR DESCRIPTION
I noticed this when I was doing some benchmarking and found the fastmath version to be a bit slower, only realizing it was still calling the openlibm version and not the pure julia implementation. 