### PR TITLE
Allocate objects in pools with correct alignment

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -475,6 +475,7 @@ Array{T}(A::AbstractArray{S,N}) where {T,N,S} = Array{T,N}(A)
 AbstractArray{T}(A::AbstractArray{S,N}) where {T,S,N} = AbstractArray{T,N}(A)
 
 # primitive Symbol constructors
+# XXX: these use unrooted, invalid GC pointers
 eval(Core, :(function Symbol(s::String)
     $(Expr(:meta, :pure))
     return ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int),

--- a/src/array.c
+++ b/src/array.c
@@ -75,14 +75,15 @@ size_t jl_arr_xtralloc_limit = 0;
 #define MAXINTVAL (((size_t)-1)>>1)
 
 static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
-                               int isunboxed, int hasptr, int isunion, int elsz)
+                               int isunboxed, int hasptr, int isunion, int elsz, int elalign)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    size_t i, tot, nel=1;
+    size_t i, tot, nel = 1;
     void *data;
     jl_array_t *a;
+    assert(elalign);
 
-    for(i=0; i < ndims; i++) {
+    for (i = 0; i < ndims; i++) {
         size_t di = dims[i];
         wideint_t prod = (wideint_t)nel * (wideint_t)di;
         if (prod > (wideint_t) MAXINTVAL || di > MAXINTVAL)
@@ -115,11 +116,11 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
     int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), JL_CACHE_BYTE_ALIGNMENT);
     if (tot <= ARRAY_INLINE_NBYTES) {
         if (isunboxed && elsz >= 4)
-            tsz = JL_ARRAY_ALIGN(tsz, JL_SMALL_BYTE_ALIGNMENT); // align data area
+            tsz = JL_ARRAY_ALIGN(tsz, elalign); // align data area
         size_t doffs = tsz;
         tsz += tot;
-        tsz = JL_ARRAY_ALIGN(tsz, JL_SMALL_BYTE_ALIGNMENT); // align whole object
-        a = (jl_array_t*)jl_gc_alloc(ptls, tsz, atype);
+        a = (jl_array_t*)jl_gc_alloc(ptls, tsz, elalign, atype);
+        tsz = JL_ARRAY_ALIGN(tsz + sizeof(void*), JL_SMALL_BYTE_ALIGNMENT) - sizeof(void*); // XXX: predict possible gc behavior
         // No allocation or safepoint allowed after this
         a->flags.how = 0;
         data = (char*)a + doffs;
@@ -127,11 +128,11 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
             memset(data, 0, tot);
     }
     else {
-        tsz = JL_ARRAY_ALIGN(tsz, JL_CACHE_BYTE_ALIGNMENT); // align whole object
         data = jl_gc_managed_malloc(tot);
         // Allocate the Array **after** allocating the data
         // to make sure the array is still young
-        a = (jl_array_t*)jl_gc_alloc(ptls, tsz, atype);
+        a = (jl_array_t*)jl_gc_alloc(ptls, tsz, JL_SMALL_BYTE_ALIGNMENT, atype);
+        tsz = JL_ARRAY_ALIGN(tsz + sizeof(void*), JL_SMALL_BYTE_ALIGNMENT) - sizeof(void*); // XXX: predict possible gc behavior
         // No allocation or safepoint allowed after this
         a->flags.how = 2;
         jl_gc_track_malloced_array(ptls, a);
@@ -187,13 +188,13 @@ static inline jl_array_t *_new_array(jl_value_t *atype, uint32_t ndims, size_t *
         elsz = LLT_ALIGN(elsz, al);
     }
 
-    return _new_array_(atype, ndims, dims, isunboxed, hasptr, isunion, elsz);
+    return _new_array_(atype, ndims, dims, isunboxed, hasptr, isunion, elsz, al);
 }
 
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
-                                             int isunboxed, int hasptr, int isunion, int elsz)
+                                             int isunboxed, int hasptr, int isunion, int elsz, int elalign)
 {
-    return _new_array_(atype, ndims, dims, isunboxed, hasptr, isunion, elsz);
+    return _new_array_(atype, ndims, dims, isunboxed, hasptr, isunion, elsz, elalign);
 }
 
 #ifndef JL_NDEBUG
@@ -224,7 +225,7 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
 
     int ndimwords = jl_array_ndimwords(ndims);
     int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords * sizeof(size_t) + sizeof(void*), JL_SMALL_BYTE_ALIGNMENT);
-    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, atype);
+    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, JL_SMALL_BYTE_ALIGNMENT, atype);
     // No allocation or safepoint allowed after this
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
     a->flags.ndims = ndims;
@@ -305,7 +306,7 @@ JL_DLLEXPORT jl_array_t *jl_string_to_array(jl_value_t *str)
 
     int ndimwords = jl_array_ndimwords(1);
     int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t) + sizeof(void*), JL_SMALL_BYTE_ALIGNMENT);
-    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, jl_array_uint8_type);
+    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, JL_SMALL_BYTE_ALIGNMENT, jl_array_uint8_type);
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
     a->flags.ndims = 1;
     a->offset = 0;
@@ -352,7 +353,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
 
     int ndimwords = jl_array_ndimwords(1);
     int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), JL_CACHE_BYTE_ALIGNMENT);
-    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, atype);
+    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, align, atype);
     // No allocation or safepoint allowed after this
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
     a->data = data;
@@ -419,7 +420,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
 
     int ndimwords = jl_array_ndimwords(ndims);
     int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), JL_CACHE_BYTE_ALIGNMENT);
-    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, atype);
+    a = (jl_array_t*)jl_gc_alloc(ptls, tsz, align, atype);
     // No allocation or safepoint allowed after this
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
     a->data = data;
@@ -515,7 +516,7 @@ JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
         jl_throw(jl_memory_exception);
     if (len == 0)
         return jl_an_empty_string;
-    jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, jl_string_type); // force inlining
+    jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, /*align*/ 0, jl_string_type); // force inlining
     *(size_t*)s = len;
     memcpy((char*)s + sizeof(size_t), str, len);
     ((char*)s + sizeof(size_t))[len] = 0;
@@ -529,7 +530,7 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
         jl_throw(jl_memory_exception);
     if (len == 0)
         return jl_an_empty_string;
-    jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, jl_string_type); // force inlining
+    jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, /*align*/ 0, jl_string_type); // force inlining
     *(size_t*)s = len;
     ((char*)s + sizeof(size_t))[len] = 0;
     return s;
@@ -1197,11 +1198,12 @@ JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
 JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary)
 {
     size_t elsz = ary->elsize;
+    size_t elalign = ary->flags.ptrarray ? sizeof(void*) : jl_datatype_align(jl_tparam0(jl_typeof(ary)));
     size_t len = jl_array_len(ary);
     int isunion = jl_is_uniontype(jl_tparam0(jl_typeof(ary)));
     jl_array_t *new_ary = _new_array_(jl_typeof(ary), jl_array_ndims(ary),
                                       &ary->nrows, !ary->flags.ptrarray,
-                                      ary->flags.hasptr, isunion, elsz);
+                                      ary->flags.hasptr, isunion, elsz, elalign);
     memcpy(new_ary->data, ary->data, len * elsz);
     // ensure isbits union arrays copy their selector bytes correctly
     if (jl_array_isbitsunion(ary))

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -754,7 +754,7 @@ JL_CALLABLE(jl_f_tuple)
     if (tt->instance != NULL)
         return tt->instance;
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(tt), tt);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(tt), jl_datatype_align(tt), tt);
     for (i = 0; i < nargs; i++)
         set_nth_field(tt, (void*)jv, i, args[i]);
     return jv;
@@ -1091,8 +1091,7 @@ jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_array_t *ar = jl_alloc_vec_any(n);
     JL_GC_PUSH1(&ar);
-    jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc(ptls, sizeof(jl_expr_t),
-                                            jl_expr_type);
+    jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc(ptls, sizeof(jl_expr_t), /*align*/ 0, jl_expr_type);
     ex->head = head;
     ex->args = ar;
     JL_GC_POP();
@@ -1108,8 +1107,7 @@ JL_CALLABLE(jl_f__expr)
     JL_GC_PUSH1(&ar);
     for(size_t i=0; i < nargs-1; i++)
         jl_array_ptr_set(ar, i, args[i+1]);
-    jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc(ptls, sizeof(jl_expr_t),
-                                            jl_expr_type);
+    jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc(ptls, sizeof(jl_expr_t), /*align*/ 0, jl_expr_type);
     ex->head = (jl_sym_t*)args[0];
     ex->args = ar;
     JL_GC_POP();
@@ -1124,7 +1122,7 @@ JL_DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name, jl_value_t *lb, jl_value_
     if ((ub != (jl_value_t *)jl_any_type && !jl_is_type(ub) && !jl_is_typevar(ub)) || jl_is_vararg_type(ub))
         jl_type_error_rt("TypeVar", "upper bound", (jl_value_t *)jl_type_type, ub);
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_tvar_t *tv = (jl_tvar_t *)jl_gc_alloc(ptls, sizeof(jl_tvar_t), jl_tvar_type);
+    jl_tvar_t *tv = (jl_tvar_t *)jl_gc_alloc(ptls, sizeof(jl_tvar_t), 0, jl_tvar_type);
     tv->name = name;
     tv->lb = lb;
     tv->ub = ub;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -611,7 +611,7 @@ static const auto jlegal_func = new JuliaFunction{
 static const auto jl_alloc_obj_func = new JuliaFunction{
     "julia.gc_alloc_obj",
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
-                {T_pint8, T_size, T_prjlvalue}, false); },
+                {T_pint8, T_size, T_size, T_prjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet::get(C, makeArrayRef({Attribute::getWithAllocSizeArgs(C, 1, None)})), // returns %1 bytes
             Attributes(C, {Attribute::NoAlias, Attribute::NonNull}),
@@ -5368,7 +5368,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
         outboxed = (output_type != (jl_value_t*)jl_voidpointer_type);
         if (outboxed) {
             assert(jl_datatype_size(output_type) == sizeof(void*) * 4);
-            Value *strct = emit_allocobj(ctx, jl_datatype_size(output_type),
+            Value *strct = emit_allocobj(ctx, jl_datatype_size(output_type), jl_datatype_align(output_type),
                                          literal_pointer_val(ctx, (jl_value_t*)output_type));
             Value *derived_strct = emit_bitcast(ctx, decay_derived(ctx, strct), T_psize);
             MDNode *tbaa = best_tbaa(output_type);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -43,9 +43,8 @@ static jl_sym_t *jl_demangle_typename(jl_sym_t *s) JL_NOTSAFEPOINT
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_methtable_t *mt =
-        (jl_methtable_t*)jl_gc_alloc(ptls, sizeof(jl_methtable_t),
-                                     jl_methtable_type);
+    jl_methtable_t *mt = (jl_methtable_t*)jl_gc_alloc(ptls,
+            sizeof(jl_methtable_t), /*align*/ 0, jl_methtable_type);
     mt->name = jl_demangle_typename(name);
     mt->module = module;
     mt->defs = jl_nothing;
@@ -63,9 +62,8 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
 JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *module)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_typename_t *tn =
-        (jl_typename_t*)jl_gc_alloc(ptls, sizeof(jl_typename_t),
-                                    jl_typename_type);
+    jl_typename_t *tn = (jl_typename_t*)jl_gc_alloc(ptls,
+            sizeof(jl_typename_t), /*align*/ 0, jl_typename_type);
     tn->name = name;
     tn->module = module;
     tn->wrapper = NULL;
@@ -88,7 +86,8 @@ jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_module_t *module, jl_dat
 jl_datatype_t *jl_new_uninitialized_datatype(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_datatype_t *t = (jl_datatype_t*)jl_gc_alloc(ptls, sizeof(jl_datatype_t), jl_datatype_type);
+    jl_datatype_t *t = (jl_datatype_t*)jl_gc_alloc(ptls,
+            sizeof(jl_datatype_t), /*align*/ 0, jl_datatype_type);
     t->hash = 0;
     t->hasfreetypevars = 0;
     t->isdispatchtuple = 0;
@@ -229,7 +228,7 @@ STATIC_INLINE void jl_maybe_allocate_singleton_instance(jl_datatype_t *st)
     if (jl_is_datatype_make_singleton(st)) {
         // It's possible for st to already have an ->instance if it was redefined
         if (!st->instance) {
-            st->instance = jl_gc_alloc(jl_get_ptls_states(), 0, st);
+            st->instance = jl_gc_alloc(jl_get_ptls_states(), 0, 0, st);
             jl_gc_wb(st, st->instance);
         }
     }
@@ -707,7 +706,7 @@ JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, void *data)
     if (bt == jl_uint16_type)  return jl_box_uint16(*(uint16_t*)data);
     if (bt == jl_char_type)    return jl_box_char(*(uint32_t*)data);
 
-    jl_value_t *v = jl_gc_alloc(ptls, nb, bt);
+    jl_value_t *v = jl_gc_alloc(ptls, nb, jl_datatype_align(bt), bt);
     switch (nb) {
     case  1: *(uint8_t*) v = *(uint8_t*)data;    break;
     case  2: *(uint16_t*)v = jl_load_unaligned_i16(data);   break;
@@ -725,7 +724,7 @@ JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, void *data)
 JL_DLLEXPORT jl_value_t *jl_typemax_uint(jl_value_t *bt)
 {
     uint64_t data = 0xffffffffffffffffULL;
-    jl_value_t *v = jl_gc_alloc(jl_get_ptls_states(), sizeof(size_t), bt);
+    jl_value_t *v = jl_gc_alloc(jl_get_ptls_states(), sizeof(size_t), 0, bt);
     memcpy(v, &data, sizeof(size_t));
     return v;
 }
@@ -789,7 +788,7 @@ UNBOX_FUNC(uint8pointer, uint8_t*)
     JL_DLLEXPORT jl_value_t *pfx##_##typ(c_type x)              \
     {                                                           \
         jl_ptls_t ptls = jl_get_ptls_states();                  \
-        jl_value_t *v = jl_gc_alloc(ptls, nw * sizeof(void*),   \
+        jl_value_t *v = jl_gc_alloc(ptls, nw * sizeof(void*), 0,\
                                     jl_##typ##_type);           \
         *(c_type*)jl_data_ptr(v) = x;                           \
         return v;                                               \
@@ -813,7 +812,7 @@ BOX_FUNC(float64, double, jl_box, 2)
         c_type idx = x+NBOX_C/2;                                \
         if ((u##c_type)idx < (u##c_type)NBOX_C)                 \
             return boxed_##typ##_cache[idx];                    \
-        jl_value_t *v = jl_gc_alloc(ptls, nw * sizeof(void*),   \
+        jl_value_t *v = jl_gc_alloc(ptls, nw * sizeof(void*), 0,\
                                     jl_##typ##_type);           \
         *(c_type*)jl_data_ptr(v) = x;                           \
         return v;                                               \
@@ -825,7 +824,7 @@ BOX_FUNC(float64, double, jl_box, 2)
         jl_ptls_t ptls = jl_get_ptls_states();                  \
         if (x < NBOX_C)                                         \
             return boxed_##typ##_cache[x];                      \
-        jl_value_t *v = jl_gc_alloc(ptls, nw * sizeof(void*),   \
+        jl_value_t *v = jl_gc_alloc(ptls, nw * sizeof(void*), 0,\
                                     jl_##typ##_type);           \
         *(c_type*)jl_data_ptr(v) = x;                           \
         return v;                                               \
@@ -851,7 +850,7 @@ JL_DLLEXPORT jl_value_t *jl_box_char(uint32_t x)
     uint32_t u = bswap_32(x);
     if (u < 128)
         return boxed_char_cache[(uint8_t)u];
-    jl_value_t *v = jl_gc_alloc(ptls, sizeof(void*), jl_char_type);
+    jl_value_t *v = jl_gc_alloc(ptls, sizeof(void*), /*align*/ 0, jl_char_type);
     *(uint32_t*)jl_data_ptr(v) = x;
     return v;
 }
@@ -919,7 +918,7 @@ JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
     va_list args;
     size_t nf = jl_datatype_nfields(type);
     va_start(args, type);
-    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), jl_datatype_align(type), type);
     for (size_t i = 0; i < nf; i++) {
         set_nth_field(type, (void*)jv, i, va_arg(args, jl_value_t*));
     }
@@ -950,7 +949,7 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, 
     }
     if (type->instance != NULL)
         return type->instance;
-    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), jl_datatype_align(type), type);
     JL_GC_PUSH1(&jv);
     for (size_t i = 0; i < na; i++) {
         set_nth_field(type, (void*)jv, i, args[i]);
@@ -981,7 +980,7 @@ JL_DLLEXPORT jl_value_t *jl_new_structt(jl_datatype_t *type, jl_value_t *tup)
         }
         return type->instance;
     }
-    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
+    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), jl_datatype_align(type), type);
     jl_value_t *fi = NULL;
     JL_GC_PUSH2(&jv, &fi);
     if (type->layout->npointers > 0) {
@@ -1005,8 +1004,9 @@ JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (type->instance != NULL) return type->instance;
-    size_t size = jl_datatype_size(type);
-    jl_value_t *jv = jl_gc_alloc(ptls, size, type);
+    size_t size  = jl_datatype_size(type);
+    size_t align = jl_datatype_align(type);
+    jl_value_t *jv = jl_gc_alloc(ptls, size, align, type);
     if (size > 0)
         memset(jl_data_ptr(jv), 0, size);
     return jv;

--- a/src/gc.c
+++ b/src/gc.c
@@ -837,8 +837,7 @@ static inline void maybe_collect(jl_ptls_t ptls)
 JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref_th(jl_ptls_t ptls,
                                                 jl_value_t *value)
 {
-    jl_weakref_t *wr = (jl_weakref_t*)jl_gc_alloc(ptls, sizeof(void*),
-                                                  jl_weakref_type);
+    jl_weakref_t *wr = (jl_weakref_t*)jl_gc_alloc(ptls, sizeof(void*), 0, jl_weakref_type);
     wr->value = value;  // NOTE: wb not needed here
     arraylist_push(&ptls->heap.weak_refs, wr);
     return wr;
@@ -1183,12 +1182,14 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
     return jl_valueof(v);
 }
 
-int jl_gc_classify_pools(size_t sz, int *osize)
+int jl_gc_classify_pools(size_t sz, size_t alignment, int *osize)
 {
     if (sz > GC_MAX_SZCLASS)
         return -1;
     size_t allocsz = sz + sizeof(jl_taggedvalue_t);
-    int klass = jl_gc_szclass(allocsz);
+    size_t alignsz = jl_gc_alignsz(allocsz, alignment);
+    int klass = jl_gc_szclass(alignsz, alignment);
+    assert(klass != -1);
     *osize = jl_gc_sizeclasses[klass];
     return (int)(intptr_t)(&((jl_ptls_t)0)->heap.norm_pools[klass]);
 }
@@ -3216,9 +3217,9 @@ void gc_mark_queue_all_roots(jl_ptls_t ptls, jl_gc_mark_sp_t *sp)
 
 // allocator entry points
 
-JL_DLLEXPORT jl_value_t *(jl_gc_alloc)(jl_ptls_t ptls, size_t sz, void *ty)
+JL_DLLEXPORT jl_value_t *(jl_gc_alloc)(jl_ptls_t ptls, size_t sz, size_t alignment, void *ty)
 {
-    return jl_gc_alloc_(ptls, sz, ty);
+    return jl_gc_alloc_(ptls, sz, alignment, ty);
 }
 
 // Per-thread initialization
@@ -3610,31 +3611,31 @@ JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value)
 JL_DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    return jl_gc_alloc(ptls, sz, NULL);
+    return jl_gc_alloc(ptls, sz, /*align*/ 0, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_gc_alloc_0w(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    return jl_gc_alloc(ptls, 0, NULL);
+    return jl_gc_alloc(ptls, 0, 0, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_gc_alloc_1w(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    return jl_gc_alloc(ptls, sizeof(void*), NULL);
+    return jl_gc_alloc(ptls, sizeof(void*), 0, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_gc_alloc_2w(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    return jl_gc_alloc(ptls, sizeof(void*) * 2, NULL);
+    return jl_gc_alloc(ptls, sizeof(void*) * 2, 0, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_gc_alloc_3w(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    return jl_gc_alloc(ptls, sizeof(void*) * 3, NULL);
+    return jl_gc_alloc(ptls, sizeof(void*) * 3, 0, NULL);
 }
 
 JL_DLLEXPORT int jl_gc_enable_conservative_gc_support(void)
@@ -3769,7 +3770,7 @@ JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void)
 
 JL_DLLEXPORT void * jl_gc_alloc_typed(jl_ptls_t ptls, size_t sz, void *ty)
 {
-    return jl_gc_alloc(ptls, sz, ty);
+    return jl_gc_alloc(ptls, sz, jl_datatype_align(ty), ty);
 }
 
 JL_DLLEXPORT void jl_gc_schedule_foreign_sweepfunc(jl_ptls_t ptls, jl_value_t *obj)

--- a/src/gf.c
+++ b/src/gf.c
@@ -375,8 +375,8 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     assert(min_world <= max_world && "attempting to set invalid world constraints");
-    jl_code_instance_t *codeinst = (jl_code_instance_t*)jl_gc_alloc(ptls, sizeof(jl_code_instance_t),
-            jl_code_instance_type);
+    jl_code_instance_t *codeinst = (jl_code_instance_t*)jl_gc_alloc(ptls,
+            sizeof(jl_code_instance_t), 0, jl_code_instance_type);
     codeinst->def = mi;
     codeinst->min_world = min_world;
     codeinst->max_world = max_world;
@@ -2558,7 +2558,7 @@ enum SIGNATURE_FULLY_COVERS {
 static jl_method_match_t *make_method_match(jl_tupletype_t *spec_types, jl_svec_t *sparams, jl_method_t *method, enum SIGNATURE_FULLY_COVERS fully_covers)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_method_match_t *match = (jl_method_match_t*)jl_gc_alloc(ptls, sizeof(jl_method_match_t), jl_method_match_type);
+    jl_method_match_t *match = (jl_method_match_t*)jl_gc_alloc(ptls, sizeof(jl_method_match_t), 0, jl_method_match_type);
     match->spec_types = spec_types;
     match->sparams = sparams;
     match->method = method;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -497,7 +497,7 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
         return mark_julia_type(ctx, vx, false, bt);
     }
     else {
-        Value *box = emit_allocobj(ctx, nb, boxed(ctx, bt_value));
+        Value *box = emit_allocobj(ctx, nb, jl_datatype_align(bt), boxed(ctx, bt_value));
         init_bits_value(ctx, box, vx, tbaa_immut);
         return mark_julia_type(ctx, box, true, bt);
     }
@@ -589,7 +589,8 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
         }
         assert(jl_is_datatype(ety));
         uint64_t size = jl_datatype_size(ety);
-        Value *strct = emit_allocobj(ctx, size,
+        size_t alignment = jl_datatype_align(ety);
+        Value *strct = emit_allocobj(ctx, size, alignment,
                                      literal_pointer_val(ctx, ety));
         im1 = ctx.builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, jl_datatype_align(ety))));

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -183,11 +183,12 @@ Instruction *FinalLowerGC::getPgcstack(Instruction *ptlsStates)
 
 Value *FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
 {
-    assert(target->getNumArgOperands() == 2);
+    assert(target->getNumArgOperands() == 3);
     auto sz = (size_t)cast<ConstantInt>(target->getArgOperand(1))->getZExtValue();
+    auto al = (size_t)cast<ConstantInt>(target->getArgOperand(2))->getZExtValue();
     // This is strongly architecture and OS dependent
     int osize;
-    int offset = jl_gc_classify_pools(sz, &osize);
+    int offset = jl_gc_classify_pools(sz, al, &osize);
     IRBuilder<> builder(target);
     builder.SetCurrentDebugLocation(target->getDebugLoc());
     auto ptls = target->getArgOperand(0);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2250,7 +2250,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                 CI->replaceAllUsesWith(ASCI);
                 UpdatePtrNumbering(CI, ASCI, S);
             } else if (alloc_obj_func && callee == alloc_obj_func) {
-                assert(CI->getNumArgOperands() == 3);
+                assert(CI->getNumArgOperands() == 4);
 
                 // Initialize an IR builder.
                 IRBuilder<> builder(CI);
@@ -2266,6 +2266,10 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                         builder.CreateIntCast(
                             CI->getArgOperand(1),
                             allocBytesIntrinsic->getFunctionType()->getParamType(1),
+                            false),
+                        builder.CreateIntCast(
+                            CI->getArgOperand(2),
+                            allocBytesIntrinsic->getFunctionType()->getParamType(2),
                             false)
                     });
                 newI->takeName(CI);
@@ -2275,9 +2279,9 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                 // We pretty much only load using `T_size` so try our best to strip
                 // as many cast as possible.
 #if JL_LLVM_VERSION >= 100000
-                auto tag = CI->getArgOperand(2)->stripPointerCastsAndAliases();
+                auto tag = CI->getArgOperand(3)->stripPointerCastsAndAliases();
 #else
-                auto tag = CI->getArgOperand(2)->stripPointerCasts();
+                auto tag = CI->getArgOperand(3)->stripPointerCasts();
 #endif
                 if (auto C = dyn_cast<ConstantExpr>(tag)) {
                     if (C->getOpcode() == Instruction::IntToPtr) {

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -147,7 +147,7 @@ namespace jl_intrinsics {
             auto intrinsic = Function::Create(
                 FunctionType::get(
                     context.T_prjlvalue,
-                    { context.T_pint8, context.T_size },
+                    { context.T_pint8, context.T_size, context.T_size },
                     false),
                 Function::ExternalLinkage,
                 GC_ALLOC_BYTES_NAME);

--- a/src/method.c
+++ b/src/method.c
@@ -307,7 +307,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_new_method_instance_uninit(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_method_instance_t *li =
-        (jl_method_instance_t*)jl_gc_alloc(ptls, sizeof(jl_method_instance_t),
+        (jl_method_instance_t*)jl_gc_alloc(ptls, sizeof(jl_method_instance_t), 0,
                                            jl_method_instance_type);
     li->def.value = NULL;
     li->specTypes = NULL;
@@ -323,7 +323,7 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_code_info_t *src =
-        (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t),
+        (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t), 0,
                                        jl_code_info_type);
     src->code = NULL;
     src->codelocs = NULL;
@@ -474,7 +474,7 @@ JL_DLLEXPORT jl_code_info_t *jl_copy_code_info(jl_code_info_t *src)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_code_info_t *newsrc =
-        (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t),
+        (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t), 0,
                                        jl_code_info_type);
     *newsrc = *src;
     return newsrc;
@@ -601,8 +601,7 @@ static void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
 JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_method_t *m =
-        (jl_method_t*)jl_gc_alloc(ptls, sizeof(jl_method_t), jl_method_type);
+    jl_method_t *m = (jl_method_t*)jl_gc_alloc(ptls, sizeof(jl_method_t), 0, jl_method_type);
     m->specializations = jl_emptysvec;
     m->speckeyset = (jl_array_t*)jl_an_empty_vec_any;
     m->sig = NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -20,8 +20,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     const jl_uuid_t uuid_zero = {0, 0};
-    jl_module_t *m = (jl_module_t*)jl_gc_alloc(ptls, sizeof(jl_module_t),
-                                               jl_module_type);
+    jl_module_t *m = (jl_module_t*)jl_gc_alloc(ptls, sizeof(jl_module_t), 0, jl_module_type);
     JL_GC_PUSH1(&m);
     assert(jl_is_symbol(name));
     m->name = name;

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -422,7 +422,7 @@ static inline jl_value_t *jl_intrinsiclambda_u1(jl_value_t *ty, void *pa, unsign
     if (osize <= sizeof(cnt)) {
         return jl_new_bits(ty, &cnt);
     }
-    jl_value_t *newv = jl_gc_alloc(ptls, osize, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, osize, 0, ty);
     // perform zext, if needed
     memset((char*)jl_data_ptr(newv) + sizeof(cnt), 0, osize - sizeof(cnt));
     memcpy(jl_data_ptr(newv), &cnt, sizeof(cnt));
@@ -484,7 +484,7 @@ static inline jl_value_t *jl_fintrinsic_1(jl_value_t *ty, jl_value_t *a, const c
     if (!jl_is_primitivetype(ty))
         jl_errorf("%s: type is not a primitive type", name);
     unsigned sz2 = jl_datatype_size(ty);
-    jl_value_t *newv = jl_gc_alloc(ptls, sz2, ty);
+    jl_value_t *newv = jl_gc_alloc(ptls, sz2, 0, ty);
     void *pa = jl_data_ptr(a), *pr = jl_data_ptr(newv);
     unsigned sz = jl_datatype_size(jl_typeof(a));
     switch (sz) {
@@ -646,7 +646,7 @@ static inline jl_value_t *jl_intrinsiclambda_checked(jl_value_t *ty, void *pa, v
     jl_datatype_t *tuptyp = jl_apply_tuple_type_v(params, 2);
     JL_GC_PROMISE_ROOTED(tuptyp); // (JL_ALAWYS_LEAFTYPE)
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *newv = jl_gc_alloc(ptls, ((jl_datatype_t*)tuptyp)->size, tuptyp);
+    jl_value_t *newv = jl_gc_alloc(ptls, jl_datatype_size(tuptyp), 0, tuptyp);
 
     intrinsic_checked_t op = select_intrinsic_checked(sz2, (const intrinsic_checked_t*)voidlist);
     int ovflw = op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
@@ -679,8 +679,8 @@ JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
         jl_error(#name ": types of a and b must match"); \
     if (!jl_is_primitivetype(ty)) \
         jl_error(#name ": values are not primitive types"); \
-    int sz = jl_datatype_size(ty); \
-    jl_value_t *newv = jl_gc_alloc(ptls, sz, ty);          \
+    size_t sz = jl_datatype_size(ty); \
+    jl_value_t *newv = jl_gc_alloc(ptls, sz, 0, ty); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pr = jl_data_ptr(newv); \
     switch (sz) { \
     /* choose the right size c-type operation */ \
@@ -742,8 +742,8 @@ JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b, jl_value_t *c) 
         jl_error(#name ": types of a, b, and c must match"); \
     if (!jl_is_primitivetype(ty)) \
         jl_error(#name ": values are not primitive types"); \
-    int sz = jl_datatype_size(ty);                                      \
-    jl_value_t *newv = jl_gc_alloc(ptls, sz, ty);                       \
+    size_t sz = jl_datatype_size(ty); \
+    jl_value_t *newv = jl_gc_alloc(ptls, sz, 0, ty); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pc = jl_data_ptr(c), *pr = jl_data_ptr(newv); \
     switch (sz) { \
     /* choose the right size c-type operation */ \

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -35,7 +35,7 @@ jl_svec_t *(jl_perm_symsvec)(size_t n, ...)
 JL_DLLEXPORT jl_svec_t *jl_svec1(void *a)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc(ptls, sizeof(void*) * 2,
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc(ptls, sizeof(void*) * 2, 0,
                                            jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 1);
     jl_svecset(v, 0, a);
@@ -45,7 +45,7 @@ JL_DLLEXPORT jl_svec_t *jl_svec1(void *a)
 JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc(ptls, sizeof(void*) * 3,
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc(ptls, sizeof(void*) * 3, 0,
                                            jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 2);
     jl_svecset(v, 0, a);
@@ -57,7 +57,7 @@ JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (n == 0) return jl_emptysvec;
-    jl_svec_t *jv = (jl_svec_t*)jl_gc_alloc(ptls, (n + 1) * sizeof(void*),
+    jl_svec_t *jv = (jl_svec_t*)jl_gc_alloc(ptls, (n + 1) * sizeof(void*), 0,
                                             jl_simplevector_type);
     jl_svec_set_len_unsafe(jv, n);
     return jv;

--- a/src/task.c
+++ b/src/task.c
@@ -651,7 +651,7 @@ JL_DLLEXPORT void jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED)
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion_future, size_t ssize)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_task_t *t = (jl_task_t*)jl_gc_alloc(ptls, sizeof(jl_task_t), jl_task_type);
+    jl_task_t *t = (jl_task_t*)jl_gc_alloc(ptls, sizeof(jl_task_t), 0, jl_task_type);
     t->copy_stack = 0;
     if (ssize == 0) {
         // stack size unspecified; use default
@@ -1220,7 +1220,7 @@ void jl_init_root_task(void *stack_lo, void *stack_hi)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (ptls->root_task == NULL) {
-        ptls->root_task = (jl_task_t*)jl_gc_alloc(ptls, sizeof(jl_task_t), jl_task_type);
+        ptls->root_task = (jl_task_t*)jl_gc_alloc(ptls, sizeof(jl_task_t), 0, jl_task_type);
         memset(ptls->root_task, 0, sizeof(jl_task_t));
         ptls->root_task->tls = jl_nothing;
     }

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -1090,9 +1090,8 @@ static void jl_typemap_list_insert_sorted(
 static jl_typemap_level_t *jl_new_typemap_level(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    jl_typemap_level_t *cache =
-        (jl_typemap_level_t*)jl_gc_alloc(ptls, sizeof(jl_typemap_level_t),
-                                         jl_typemap_level_type);
+    jl_typemap_level_t *cache = (jl_typemap_level_t*)jl_gc_alloc(ptls,
+            sizeof(jl_typemap_level_t), 0, jl_typemap_level_type);
     cache->arg1 = (jl_array_t*)jl_an_empty_vec_any;
     cache->targ = (jl_array_t*)jl_an_empty_vec_any;
     cache->name1 = (jl_array_t*)jl_an_empty_vec_any;
@@ -1267,9 +1266,8 @@ jl_typemap_entry_t *jl_typemap_alloc(
             isleafsig = issimplesig = 0;
     }
 
-    jl_typemap_entry_t *newrec =
-        (jl_typemap_entry_t*)jl_gc_alloc(ptls, sizeof(jl_typemap_entry_t),
-                                         jl_typemap_entry_type);
+    jl_typemap_entry_t *newrec = (jl_typemap_entry_t*)jl_gc_alloc(ptls,
+            sizeof(jl_typemap_entry_t), 0, jl_typemap_entry_type);
     newrec->sig = type;
     newrec->simplesig = simpletype;
     newrec->func.value = newvalue;


### PR DESCRIPTION
Fixes #21918. 

The issue was that out gc pools only guaranteed 16 bytes alignment and the pool pages are only aligned by 16 bytes as well.
This PR changes the alignment of the pool pages to 64 bytes (enough for avx512) and takes the alignment information into account when selecting the szclass/pool.
It correctly handles unaligned allocations and allocations that are near the maximum pool size.

This should be squashed a bit before we merge.