### PR TITLE
add rand(::IntSet)

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -339,7 +339,7 @@ function rand(r::AbstractRNG, ::Type{Char})
     (c < 0xd800) ? Char(c) : Char(c+0x800)
 end
 
-# random values from Dict or Set (for efficiency)
+# random values from Dict, Set, IntSet (for efficiency)
 function rand(r::AbstractRNG, t::Dict)
     isempty(t) && throw(ArgumentError("dict must be non-empty"))
     n = length(t.slots)
@@ -351,6 +351,20 @@ end
 rand(t::Dict) = rand(GLOBAL_RNG, t)
 rand(r::AbstractRNG, s::Set) = rand(r, s.dict).first
 rand(s::Set) = rand(GLOBAL_RNG, s)
+
+function rand(r::AbstractRNG, s::IntSet)
+    isempty(s) && throw(ArgumentError("collection must be non-empty"))
+    # s can be empty while s.bits is not, so we cannot rely on the
+    # length check in RangeGenerator below
+    rg = RangeGenerator(1:length(s.bits))
+    while true
+        n = rand(r, rg)
+        @inbounds b = s.bits[n]
+        b && return n
+    end
+end
+
+rand(s::IntSet) = rand(GLOBAL_RNG, s)
 
 ## Arrays of random numbers
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -341,11 +341,11 @@ end
 
 # random values from Dict, Set, IntSet (for efficiency)
 function rand(r::AbstractRNG, t::Dict)
-    isempty(t) && throw(ArgumentError("dict must be non-empty"))
-    n = length(t.slots)
+    isempty(t) && throw(ArgumentError("collection must be non-empty"))
+    rg = RangeGenerator(1:length(t.slots))
     while true
-        i = rand(r, 1:n)
-        Base.isslotfilled(t, i) && return (t.keys[i] => t.vals[i])
+        i = rand(r, rg)
+        Base.isslotfilled(t, i) && @inbounds return (t.keys[i] => t.vals[i])
     end
 end
 rand(t::Dict) = rand(GLOBAL_RNG, t)

--- a/test/random.jl
+++ b/test/random.jl
@@ -53,11 +53,16 @@ let mt = MersenneTwister(0)
     rand(coll, 2, 3)
 end
 
-# rand using Dict, Set
+# rand using Dict, Set, IntSet
 adict = Dict(1=>2, 3=>4, 5=>6)
 @test rand(adict) in adict
+@test_throws ArgumentError rand(Dict())
 aset = Set(1:10)
 @test rand(aset) in aset
+@test_throws ArgumentError rand(Set())
+anintset = IntSet(1:10)
+@test rand(anintset) in anintset
+@test_throws ArgumentError rand(IntSet())
 
 # randn
 @test randn(MersenneTwister(42)) == -0.5560268761463861


### PR DESCRIPTION
The second commit optimizes `rand(::Dict)` by using a `RangeGenerator` object, the speed-up seems to be roughly +50%.