### PR TITLE
optimize Dict{Void}/Set{Void} (fix #20903)

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -271,7 +271,8 @@ function rehash!(h::Dict{K,V}, newsz = length(h.keys)) where V where K
 end
 
 max_values(::Type) = typemax(Int)
-max_values(T::Type{<:Union{Void, Bool, Int8, UInt8, Int16, UInt16}}) = 1 << sizeof(T)
+max_values(T::Type{<:Union{Void, Int8, UInt8, Int16, UInt16}}) = 1 << sizeof(T)
+max_values(::Type{Bool}) = 2
 
 function sizehint!(d::Dict{T}, newsz) where T
     oldsz = length(d.slots)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -270,7 +270,10 @@ function rehash!(h::Dict{K,V}, newsz = length(h.keys)) where V where K
     return h
 end
 
-function sizehint!(d::Dict, newsz)
+max_values(::Type) = typemax(Int)
+max_values(T::Type{<:Union{Void, Bool, Int8, UInt8, Int16, UInt16}}) = 1 << sizeof(T)
+
+function sizehint!(d::Dict{T}, newsz) where T
     oldsz = length(d.slots)
     if newsz <= oldsz
         # todo: shrink
@@ -279,7 +282,8 @@ function sizehint!(d::Dict, newsz)
         return d
     end
     # grow at least 25%
-    newsz = max(newsz, (oldsz*5)>>2)
+    newsz = min(max(newsz, (oldsz*5)>>2),
+                max_values(T))
     rehash!(d, newsz)
 end
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -271,7 +271,8 @@ function rehash!(h::Dict{K,V}, newsz = length(h.keys)) where V where K
 end
 
 max_values(::Type) = typemax(Int)
-max_values(T::Type{<:Union{Void, Int8, UInt8, Int16, UInt16}}) = 1 << sizeof(T)
+max_values(T::Type{<:Union{Void,BitIntegerSmall}}) = 1 << 8*sizeof(T)
+max_values(T::Union) = max(max_values(T.a), max_values(T.b))
 max_values(::Type{Bool}) = 2
 
 function sizehint!(d::Dict{T}, newsz) where T

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -116,3 +116,5 @@ indices(g::Generator) = indices(g.iter)
 ndims(g::Generator) = ndims(g.iter)
 
 iteratoreltype(::Type{Generator{I,T}}) where {I,T} = EltypeUnknown()
+
+haslength(iter) = iteratorsize(iter) isa Union{HasShape, HasLength}

--- a/base/int.jl
+++ b/base/int.jl
@@ -7,21 +7,27 @@
 # they are also used elsewhere where Int128/UInt128 support is separated out,
 # such as in hashing2.jl
 
-const BitSigned64_types   = (Int8, Int16, Int32, Int64)
-const BitUnsigned64_types = (UInt8, UInt16, UInt32, UInt64)
-const BitInteger64_types  = (BitSigned64_types..., BitUnsigned64_types...)
-const BitSigned_types     = (BitSigned64_types..., Int128)
-const BitUnsigned_types   = (BitUnsigned64_types..., UInt128)
-const BitInteger_types    = (BitSigned_types..., BitUnsigned_types...)
+const BitSigned64_types      = (Int8, Int16, Int32, Int64)
+const BitUnsigned64_types    = (UInt8, UInt16, UInt32, UInt64)
+const BitInteger64_types     = (BitSigned64_types..., BitUnsigned64_types...)
+const BitSigned_types        = (BitSigned64_types..., Int128)
+const BitUnsigned_types      = (BitUnsigned64_types..., UInt128)
+const BitInteger_types       = (BitSigned_types..., BitUnsigned_types...)
+const BitSignedSmall_types   = Int === Int64 ? ( Int8,  Int16,  Int32) : ( Int8,  Int16)
+const BitUnsignedSmall_types = Int === Int64 ? (UInt8, UInt16, UInt32) : (UInt8, UInt16)
+const BitIntegerSmall_types  = (BitSignedSmall_types..., BitUnsignedSmall_types...)
 
-const BitSigned64    = Union{BitSigned64_types...}
-const BitUnsigned64  = Union{BitUnsigned64_types...}
-const BitInteger64   = Union{BitInteger64_types...}
-const BitSigned      = Union{BitSigned_types...}
-const BitUnsigned    = Union{BitUnsigned_types...}
-const BitInteger     = Union{BitInteger_types...}
-const BitSigned64T   = Union{Type{Int8}, Type{Int16}, Type{Int32}, Type{Int64}}
-const BitUnsigned64T = Union{Type{UInt8}, Type{UInt16}, Type{UInt32}, Type{UInt64}}
+const BitSigned64      = Union{BitSigned64_types...}
+const BitUnsigned64    = Union{BitUnsigned64_types...}
+const BitInteger64     = Union{BitInteger64_types...}
+const BitSigned        = Union{BitSigned_types...}
+const BitUnsigned      = Union{BitUnsigned_types...}
+const BitInteger       = Union{BitInteger_types...}
+const BitSignedSmall   = Union{BitSignedSmall_types...}
+const BitUnsignedSmall = Union{BitUnsignedSmall_types...}
+const BitIntegerSmall  = Union{BitIntegerSmall_types...}
+const BitSigned64T     = Union{Type{Int8}, Type{Int16}, Type{Int32}, Type{Int64}}
+const BitUnsigned64T   = Union{Type{UInt8}, Type{UInt16}, Type{UInt32}, Type{UInt64}}
 
 ## integer comparisons ##
 

--- a/base/set.jl
+++ b/base/set.jl
@@ -92,10 +92,8 @@ julia> a
 Set([7, 4, 3, 5, 1])
 ```
 """
-union!(s::Set, xs) = _union!(s, xs)
-union!(s::Set, xs::AbstractArray) = (sizehint!(s, length(xs)); _union!(s, xs))
-
-function _union!(s::Set{T}, xs) where T
+function union!(s::Set{T}, xs) where T
+    isa(iteratorsize(xs), Union{HasShape, HasLength}) && sizehint!(s, length(xs))
     for x=xs
         push!(s,x)
         length(s) == max_values(T) && break

--- a/base/set.jl
+++ b/base/set.jl
@@ -27,14 +27,14 @@ similar(s::Set{T}) where {T} = Set{T}()
 similar(s::Set, T::Type) = Set{T}()
 
 function show(io::IO, s::Set)
-    print(io,"Set")
+    print(io, "Set")
     if isempty(s)
-        print(io,"{",eltype(s),"}()")
+        print(io, "{", eltype(s), "}()")
         return
     end
-    print(io,"(")
-    show_vector(io,s,"[","]")
-    print(io,")")
+    print(io, "(")
+    show_vector(io, s, "[", "]")
+    print(io, ")")
 end
 
 isempty(s::Set) = isempty(s.dict)
@@ -63,15 +63,15 @@ rehash!(s::Set) = (rehash!(s.dict); s)
 start(s::Set)       = start(s.dict)
 done(s::Set, state) = done(s.dict, state)
 # NOTE: manually optimized to take advantage of Dict representation
-next(s::Set, i)     = (s.dict.keys[i], skip_deleted(s.dict,i+1))
+next(s::Set, i)     = (s.dict.keys[i], skip_deleted(s.dict, i+1))
 
 union() = Set()
 union(s::Set) = copy(s)
 function union(s::Set, sets::Set...)
     u = Set{join_eltype(s, sets...)}()
-    union!(u,s)
+    union!(u, s)
     for t in sets
-        union!(u,t)
+        union!(u, t)
     end
     return u
 end
@@ -95,7 +95,7 @@ Set([7, 4, 3, 5, 1])
 function union!(s::Set{T}, xs) where T
     haslength(xs) && sizehint!(s, length(xs))
     for x=xs
-        push!(s,x)
+        push!(s, x)
         length(s) == max_values(T) && break
     end
     s
@@ -110,7 +110,7 @@ function intersect(s::Set, sets::Set...)
     for x in s
         inall = true
         for t in sets
-            if !in(x,t)
+            if !in(x, t)
                 inall = false
                 break
             end
@@ -146,7 +146,7 @@ julia> a
 Set([4])
 ```
 """
-setdiff!(s::Set, xs) = (for x=xs; delete!(s,x); end; s)
+setdiff!(s::Set, xs) = (for x=xs; delete!(s, x); end; s)
 
 ==(l::Set, r::Set) = (length(l) == length(r)) && (l <= r)
 <( l::Set, r::Set) = (length(l) < length(r)) && (l <= r)

--- a/base/set.jl
+++ b/base/set.jl
@@ -93,7 +93,7 @@ Set([7, 4, 3, 5, 1])
 ```
 """
 function union!(s::Set{T}, xs) where T
-    isa(iteratorsize(xs), Union{HasShape, HasLength}) && sizehint!(s, length(xs))
+    haslength(xs) && sizehint!(s, length(xs))
     for x=xs
         push!(s,x)
         length(s) == max_values(T) && break

--- a/base/set.jl
+++ b/base/set.jl
@@ -92,8 +92,17 @@ julia> a
 Set([7, 4, 3, 5, 1])
 ```
 """
-union!(s::Set, xs) = (for x=xs; push!(s,x); end; s)
-union!(s::Set, xs::AbstractArray) = (sizehint!(s,length(xs));for x=xs; push!(s,x); end; s)
+union!(s::Set, xs) = _union!(s, xs)
+union!(s::Set, xs::AbstractArray) = (sizehint!(s, length(xs)); _union!(s, xs))
+
+function _union!(s::Set{T}, xs) where T
+    for x=xs
+        push!(s,x)
+        length(s) == max_values(T) && break
+    end
+    s
+end
+
 join_eltype() = Bottom
 join_eltype(v1, vs...) = typejoin(eltype(v1), join_eltype(vs...))
 


### PR DESCRIPTION
A simple (simplistic?) fix for @sbromberger's problem (expressed in particular [here](https://github.com/JuliaLang/julia/issues/20903#issuecomment-284427298)) with the inefficiency of `Set(Vector{Void}(bignumber))`, using mainly ideas from https://github.com/JuliaLang/julia/issues/20903#issuecomment-284404696. This is maybe not a very general solution, but at least it can serve as a start.