### PR TITLE
Method overwriting by an ambiguity should also invalidate the method cache

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1162,10 +1162,10 @@ static int check_ambiguous_visitor(jl_typemap_entry_t *oldentry, struct typemap_
             jl_static_show_func_sig(s, isect);
             jl_printf(s, "\nbefore the new definition.\n");
         }
-        return 1;  // there may be multiple ambiguities, keep going
     }
-    else if (closure->after) {
+    if (!msp || closure->after) {
         // record that this method definition is being partially replaced
+        // (either with a real definition, or an ambiguity error)
         if (closure->shadowed == NULL) {
             closure->shadowed = oldentry->func.value;
         }

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -85,6 +85,16 @@ cfunction(ambig, Int, (UInt8, Int))  # test for a crash (doesn't throw an error)
 ambig(x, y::Integer) = 3
 @test_throws MethodError ambig(2, 0x03)
 
+# Method overwriting by an ambiguity should also invalidate the method cache (#21963)
+ambig(x::Union{Char, Int8}) = 'r'
+@test ambig('c') == 'r'
+@test ambig(Int8(1)) == 'r'
+@test_throws MethodError ambig(Int16(1))
+ambig(x::Union{Char, Int16}) = 's'
+@test_throws MethodError ambig('c')
+@test ambig(Int8(1)) == 'r'
+@test ambig(Int16(1)) == 's'
+
 # Automatic detection of ambiguities
 module Ambig1
 ambig(x, y) = 1


### PR DESCRIPTION
fix #21963

~DO NOT MERGE (until https://github.com/JuliaArchive/LegacyStrings.jl/issues/8 is fixed)~