### PR TITLE
use titlecase, not uppercase, for ucfirst

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -394,6 +394,8 @@ lowercase(s::AbstractString) = map(lowercase, s)
     titlecase(s::AbstractString)
 
 Capitalizes the first character of each word in `s`.
+See also [`ucfirst`](@ref) to capitalize only the first
+character in `s`.
 
 ```jldoctest
 julia> titlecase("the julia programming language")
@@ -418,7 +420,10 @@ end
 """
     ucfirst(s::AbstractString)
 
-Returns `string` with the first character converted to uppercase.
+Returns `string` with the first character converted to uppercase
+(technically "title case" for Unicode).
+See also [`titlecase`](@ref) to capitalize the first character of
+every word in `s`.
 
 ```jldoctest
 julia> ucfirst("python")
@@ -426,7 +431,10 @@ julia> ucfirst("python")
 ```
 """
 function ucfirst(s::AbstractString)
-    isempty(s) || isupper(s[1]) ? s : string(uppercase(s[1]),s[nextind(s,1):end])
+    isempty(s) && return s
+    c = s[1]
+    tc = titlecase(c)
+    return c==tc ? s : string(tc,s[nextind(s,1):end])
 end
 
 """

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -151,6 +151,7 @@ end
 @test ucfirst("hola")=="Hola"
 @test ucfirst("")==""
 @test ucfirst("*")=="*"
+@test ucfirst("Ǆxx") == ucfirst("ǆxx") == "ǅxx"
 
 @test lcfirst("Hola")=="hola"
 @test lcfirst("hola")=="hola"


### PR DESCRIPTION
Separate from questions of what `ucfirst` should be called or whether it should even exist (#21910), the current behavior was clearly wrong (using uppercase rather than titlecase) for Unicode.   This PR fixes that.

Most users won't notice any difference, since titlecase and uppercase are almost always the same.  (Of the 2621 Unicode characters that have case at all, only 12 have a distinct titlecase.)

The Julia `ucfirst` function seems to have been modeled on the Perl [ucfirst](http://perldoc.perl.org/functions/ucfirst.html) function, which uses titlecase.  However, when the Julia `ucfirst` function was written, we didn't have access to the Unicode tables needed to implement titlecase.