### PR TITLE
Make the output of versioninfo() customizable with kwargs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ A useful bug report filed as a GitHub issue provides information about how to re
 3. When filing a bug report, provide where possible:
   - The full error message, including the backtrace.
   - A minimal working example, i.e. the smallest chunk of code that triggers the error. Ideally, this should be code that can be pasted into a REPL or run from a source file. If the code is larger than (say) 50 lines, consider putting it in a [gist](https://gist.github.com).
-  - The version of Julia as provided by the `versioninfo()` command. Occasionally, the longer output produced by `versioninfo(true)` may be useful also, especially if the issue is related to a specific package.
+  - The version of Julia as provided by the `versioninfo()` command. Occasionally, the longer output produced by `versioninfo(verbose = true)` may be useful also, especially if the issue is related to a specific package.
 
 4. When pasting code blocks or output, put triple backquotes (\`\`\`) around the text so GitHub will format it nicely. Code statements should be surrounded by single backquotes (\`). Be aware that the `@` sign tags users on GitHub, so references to macros should always be in single backquotes. See [GitHub's guide on Markdown](https://guides.github.com/features/mastering-markdown) for more formatting tricks.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@ Library improvements
   * `resize!` and `sizehint!` methods no longer over-reserve memory when the
     requested array size is more than double of its current size ([#22038]).
 
+  * The output of `versioninfo()` is now controlled with keyword arguments ([#21974]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1350,6 +1350,10 @@ end
 @deprecate srand(filename::AbstractString, n::Integer=4) srand(read!(filename, Array{UInt32}(Int(n))))
 @deprecate MersenneTwister(filename::AbstractString)  srand(MersenneTwister(0), read!(filename, Array{UInt32}(Int(4))))
 
+# PR #21974
+@deprecate versioninfo(verbose::Bool) versioninfo(verbose=verbose)
+@deprecate versioninfo(io::IO, verbose::Bool) versioninfo(io, verbose=verbose)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -15,8 +15,8 @@ and follow the instructions to generate the debugging information requested.  Ta
 ## [Version/Environment info](@id dev-version-info)
 
 No matter the error, we will always need to know what version of Julia you are running. When Julia
-first starts up, a header is printed out with a version number and date.  If your version is
-`0.2.0` or higher, please include the output of `versioninfo()` in any report you create:
+first starts up, a header is printed out with a version number and date. Please also include the
+output of `versioninfo()` in any report you create:
 
 ```@repl
 versioninfo()

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -59,10 +59,10 @@ temp_pkg_dir() do
     @test_throws PkgError Pkg.installed("MyFakePackage")
     @test Pkg.installed("Example") === nothing
 
-    # check that versioninfo(io, true) doesn't error and produces some output
+    # check that versioninfo(io; verbose=true) doesn't error and produces some output
     # (done here since it calls Pkg.status which might error or clone metadata)
     buf = PipeBuffer()
-    versioninfo(buf, true)
+    versioninfo(buf, verbose=true)
     ver = readstring(buf)
     @test startswith(ver, "Julia Version $VERSION")
     @test contains(ver, "Environment:")


### PR DESCRIPTION
also reordered some things in a more logical order. Fix #21971 

What kwargs should we have?