### PR TITLE
Add `convert()` methods for `Matrix` from `Vector` and `RowVector`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -320,6 +320,11 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 
 convert(::Type{Vector}, x::AbstractVector{T}) where {T} = convert(Vector{T}, x)
 convert(::Type{Matrix}, x::AbstractMatrix{T}) where {T} = convert(Matrix{T}, x)
+function convert(::Type{Matrix}, x::Vector{T}) where {T}
+    xm = Matrix{T}(length(x), 1)
+    xm[:,1] = x[:]
+    return xm
+end
 
 convert(::Type{Array{T}}, x::Array{T,n}) where {T,n} = x
 convert(::Type{Array{T,n}}, x::Array{T,n}) where {T,n} = x

--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -44,6 +44,13 @@ const ConjRowVector{T,CV<:ConjVector} = RowVector{T,CV}
     RowVector{T}(Vector{transpose_type(T)}(n[2])) :
     error("RowVector expects 1×N size, got $n")
 
+# Convenience constructor to Matrix
+function convert(::Type{Matrix}, x::RowVector{T}) where {T}
+    xm = Matrix{T}(1, length(x))
+    xm[1,:] = x[:]
+    return xm
+end
+
 # Conversion of underlying storage
 convert(::Type{RowVector{T,V}}, rowvec::RowVector) where {T,V<:AbstractVector} =
     RowVector{T,V}(convert(V,rowvec.vec))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -452,7 +452,6 @@ function test_primitives{T}(::Type{T}, shape, ::Type{TestAbstractArray})
     # convert{T}(::Type{Matrix}, A::AbstractMatrix{T})
     @test convert(Matrix, Y) == Y
     @test convert(Matrix, view(Y, 1:2, 1:2)) == Y
-    @test_throws MethodError convert(Matrix, X)
 end
 
 mutable struct TestThrowNoGetindex{T} <: AbstractVector{T} end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -191,6 +191,21 @@ end
     @test convert(Vector{Float64}, b) == b
 end
 
+@testset "(Row)Vector to Matrix conversion and equality (#21977)" begin
+    a = Vector(1:10)
+    am = Matrix(length(a), 1)
+    am[:,1] = a[:]
+
+    # Ensure we have equality between Vectors/RowVectors and their
+    # corresponding Matrices
+    @test convert(Matrix, a) == am
+    @test convert(Matrix, a) != am'
+    @test convert(Matrix, a') != am
+    @test convert(Matrix, a') == am'
+    @test Matrix(a) == am
+    @test Matrix(a') == am'
+end
+
 @testset "operations with IndexLinear ReshapedArray" begin
     b = collect(1:12)
     a = Base.ReshapedArray(b, (4,3), ())


### PR DESCRIPTION
Now that we take vector transposes seriously, it makes sense to provide these simple conversion routines from `Vector`/`RowVector` to `Matrix`.

I'm definitely open to suggestions on the most efficient way to do this; I don't know the array subsystem very well.