### PR TITLE
faster rem(::BigInt, ::Type{Union{Bool, Int, UInt...}})

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -313,14 +313,14 @@ end
 rem(x::BigInt, ::Type{Bool}) = !iszero(x) & unsafe_load(x.d) % Bool # never unsafe here
 
 rem(x::BigInt, ::Type{T}) where T<:Union{SLimbMax,ULimbMax} =
-    iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x)
+    iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x.size)
 
 function rem(x::BigInt, ::Type{T}) where T<:Union{Unsigned,Signed}
     u = zero(T)
     for l = 1:min(abs(x.size), cld(sizeof(T), sizeof(Limb)))
         u += (unsafe_load(x.d, l) % T) << ((sizeof(Limb)<<3)*(l-1))
     end
-    flipsign(u, x)
+    flipsign(u, x.size)
 end
 
 rem(x::Integer, ::Type{BigInt}) = convert(BigInt, x)
@@ -579,7 +579,6 @@ ispos(x::BigInt) = x.size > 0
 signbit(x::BigInt) = isneg(x)
 flipsign!(x::BigInt,  y::Integer) = (signbit(y) && (x.size = -x.size); x)
 flipsign( x::BigInt,  y::Integer) = signbit(y) ? -x : x
-flipsign( x::Integer, y::BigInt)  = flipsign(x, y.size)
 
 string(x::BigInt) = dec(x)
 show(io::IO, x::BigInt) = print(io, string(x))

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -31,8 +31,12 @@ const GMP_BITS_PER_LIMB = gmp_bits_per_limb()
 # be used whenever mp_limb_t is in the signature of ccall'ed GMP functions.
 if GMP_BITS_PER_LIMB == 32
     const Limb = UInt32
+    const SLimbMax = Union{Int8, Int16, Int32}
+    const ULimbMax = Union{UInt8, UInt16, UInt32}
 elseif GMP_BITS_PER_LIMB == 64
     const Limb = UInt64
+    const SLimbMax = Union{Int8, Int16, Int32, Int64}
+    const ULimbMax = Union{UInt8, UInt16, UInt32, UInt64}
 else
     error("GMP: cannot determine the type mp_limb_t (__gmp_bits_per_limb == $GMP_BITS_PER_LIMB)")
 end
@@ -306,11 +310,15 @@ function convert(::Type{BigInt}, x::Integer)
 end
 
 
-rem(x::BigInt, ::Type{Bool}) = ((x&1)!=0)
+rem(x::BigInt, ::Type{Bool}) = !iszero(x) & unsafe_load(x.d) % Bool # never unsafe here
+
+rem(x::BigInt, ::Type{T}) where T <:Union{SLimbMax,ULimbMax} =
+    iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x)
+
 function rem(x::BigInt, ::Type{T}) where T<:Union{Unsigned,Signed}
     u = zero(T)
-    for l = 1:min(abs(x.size), cld(sizeof(T),sizeof(Limb)))
-        u += (unsafe_load(x.d,l)%T) << ((sizeof(Limb)<<3)*(l-1))
+    for l = 1:min(abs(x.size), cld(sizeof(T), sizeof(Limb)))
+        u += (unsafe_load(x.d, l) % T) << ((sizeof(Limb)<<3)*(l-1))
     end
     flipsign(u, x)
 end
@@ -569,8 +577,9 @@ isneg(x::BigInt) = x.size < 0
 ispos(x::BigInt) = x.size > 0
 
 signbit(x::BigInt) = isneg(x)
-flipsign!(x::BigInt, y::Integer) = (signbit(y) && (x.size = -x.size); x)
-flipsign( x::BigInt, y::Integer) = signbit(y) ? -x : x
+flipsign!(x::BigInt,  y::Integer) = (signbit(y) && (x.size = -x.size); x)
+flipsign( x::BigInt,  y::Integer) = signbit(y) ? -x : x
+flipsign( x::Integer, y::BigInt)  = flipsign(x, y.size)
 
 string(x::BigInt) = dec(x)
 show(io::IO, x::BigInt) = print(io, string(x))

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -312,7 +312,7 @@ end
 
 rem(x::BigInt, ::Type{Bool}) = !iszero(x) & unsafe_load(x.d) % Bool # never unsafe here
 
-rem(x::BigInt, ::Type{T}) where T <:Union{SLimbMax,ULimbMax} =
+rem(x::BigInt, ::Type{T}) where T<:Union{SLimbMax,ULimbMax} =
     iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x)
 
 function rem(x::BigInt, ::Type{T}) where T<:Union{Unsigned,Signed}

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -577,8 +577,8 @@ isneg(x::BigInt) = x.size < 0
 ispos(x::BigInt) = x.size > 0
 
 signbit(x::BigInt) = isneg(x)
-flipsign!(x::BigInt,  y::Integer) = (signbit(y) && (x.size = -x.size); x)
-flipsign( x::BigInt,  y::Integer) = signbit(y) ? -x : x
+flipsign!(x::BigInt, y::Integer) = (signbit(y) && (x.size = -x.size); x)
+flipsign( x::BigInt, y::Integer) = signbit(y) ? -x : x
 
 string(x::BigInt) = dec(x)
 show(io::IO, x::BigInt) = print(io, string(x))


### PR DESCRIPTION
This is about 60 times faster for `Bool` and twice as fast for `Int`.