### PR TITLE
[skip ci] Make comment describing add22condh meaningful

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -716,7 +716,10 @@ end
 ## rem2pi-related calculations ##
 
 function add22condh(xh::Float64, xl::Float64, yh::Float64, yl::Float64)
-    # as above, but only compute and return high double
+    # This algorithm, due to Dekker, computes the sum of
+    # two double-double numbers and return high double.  References:
+    # [1] http://www.digizeitschriften.de/en/dms/img/?PID=GDZPPN001170007
+    # [2] https://dx.doi.org/10.1007/BF01397083
     r = xh+yh
     s = (abs(xh) > abs(yh)) ? (xh-r+yh+yl+xl) : (yh-r+xh+xl+yl)
     zh = r+s


### PR DESCRIPTION
PR #4862 removed a bunch of functions together with their comments.  `add22condh` survived, but the comment describing this function refers to the comment of a deleted function.  This PR basically resurrects and adapts the deleted comment, but please check for correctness of the comment ;-)

For reference, the deleted comment was here: https://github.com/JuliaLang/julia/blob/4d83f892e11008a165d55ca05833e971c4937f38/base/math.jl#L1343-L1346  I replaced the second URL, now dead, with a DOI.