### PR TITLE
add replacement suggestion to frexp(::Array{<:AbstractFloat}) deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -841,7 +841,9 @@ end
 @deprecate ~(B::BitArray) .~B
 
 function frexp(A::Array{<:AbstractFloat})
-    depwarn("`frexp(x::Array)` is discontinued.", :frexp)
+    depwarn(string("`frexp(x::Array)` is discontinued. Though not a direct replacement, ",
+                   "consider using dot-syntax to `broadcast` scalar `frexp` over `Array`s ",
+                   "instead, for example `frexp.(rand(4))`."), :frexp)
     F = similar(A)
     E = Array{Int}(size(A))
     for (iF, iE, iA) in zip(eachindex(F), eachindex(E), eachindex(A))


### PR DESCRIPTION
Ref. #21475. The news aspect of this deprecation should be covered by the broad news entry for deprecation of vectorized methods. This pull request makes the deprecation warning slightly more helpful. Best!