### PR TITLE
[WIP] Loosen totality requirement for isless

### DIFF
--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -443,8 +443,8 @@ Base.promote_rule(::Type{Year}, ::Type{Month}) = Month
 (==)(x::FixedPeriod, y::OtherPeriod) = throw(MethodError(==, (x, y)))
 (==)(x::OtherPeriod, y::FixedPeriod) = throw(MethodError(==, (x, y)))
 
-Base.isless(x::FixedPeriod, y::OtherPeriod) = throw(MethodError(isless, (x, y)))
-Base.isless(x::OtherPeriod, y::FixedPeriod) = throw(MethodError(isless, (x, y)))
+Base.isless(x::FixedPeriod, y::OtherPeriod) = false
+Base.isless(x::OtherPeriod, y::FixedPeriod) = false
 
 # truncating conversions to milliseconds and days:
 toms(c::Nanosecond)  = div(value(c), 1000000)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -96,7 +96,9 @@ isequal(x::AbstractFloat, y::Real         ) = (isnan(x) & isnan(y)) | signequal(
 isless(x::AbstractFloat, y::AbstractFloat) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
 isless(x::Real,          y::AbstractFloat) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
 isless(x::AbstractFloat, y::Real         ) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
+isless(x, y) = false
 
+isnan(x)     = false
 
 function ==(T::Type, S::Type)
     @_pure_meta
@@ -235,7 +237,7 @@ julia> 5 <= 3
 false
 ```
 """
-<=(x, y) = !(y < x)
+<=(x, y) = (x < y) | (x == y)
 const ≤ = <=
 
 """
@@ -345,7 +347,7 @@ julia> max(2, 5, 1)
 5
 ```
 """
-max(x, y) = ifelse(y < x, x, y)
+max(x, y) = y < x ? x : (x <= y ? y : error("elements not comparable"))
 
 """
     min(x, y, ...)
@@ -358,7 +360,7 @@ julia> min(2, 5, 1)
 1
 ```
 """
-min(x,y) = ifelse(y < x, y, x)
+min(x,y) = y < x ? y : (x <= y ? x : error("elements not comparable"))
 
 """
     minmax(x, y)
@@ -370,7 +372,7 @@ julia> minmax('c','b')
 ('b', 'c')
 ```
 """
-minmax(x,y) = y < x ? (y, x) : (x, y)
+minmax(x,y) = y < x ? (y, x) : (x <= y ? (x, y) : error("elements not comparable"))
 
 scalarmax(x,y) = max(x,y)
 scalarmax(x::AbstractArray, y::AbstractArray) = throw(ArgumentError("ordering is not well-defined for arrays"))

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -51,7 +51,7 @@ function issorted(itr, order::Ordering)
     prev, state = next(itr, state)
     while !done(itr, state)
         this, state = next(itr, state)
-        lt(order, this, prev) && return false
+        lt(order, prev, this) || prev == this || isnan(this) || return false
         prev = this
     end
     return true

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -164,8 +164,8 @@ y2 = Dates.Year(2)
 @test_throws MethodError div(2, y) == Dates.Year(2)
 @test div(y, y) == 1
 @test y*10 % Dates.Year(5) == Dates.Year(0)
-@test_throws MethodError (y > 3) == false
-@test_throws MethodError (4 < y) == false
+@test !(y > 3)
+@test !(4 < y)
 @test 1 != y
 t = [y, y, y, y, y]
 @test t .+ Dates.Year(2) == [Dates.Year(3), Dates.Year(3), Dates.Year(3), Dates.Year(3), Dates.Year(3)]
@@ -233,8 +233,8 @@ test = ((((((((dt + y) - m) + w) - d) + h) - mi) + s) - ms)
 @test Dates.Millisecond(-1) < Dates.Millisecond(1)
 @test !(Dates.Millisecond(-1) > Dates.Millisecond(1))
 @test Dates.Millisecond(1) == Dates.Millisecond(1)
-@test_throws MethodError Dates.Year(1) < Dates.Millisecond(1)
-@test_throws MethodError Dates.Millisecond(1) < Dates.Year(1)
+@test !(Dates.Year(1) < Dates.Millisecond(1))
+@test !(Dates.Millisecond(1) < Dates.Year(1))
 @test_throws MethodError Dates.Year(1) == Dates.Millisecond(1)
 @test_throws MethodError Dates.Millisecond(1) == Dates.Year(1)
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1181,9 +1181,9 @@ for A = real_types, B = real_types
     @test typeof(Complex(convert(A,2),convert(B,3))) <: Complex{T}
 end
 
-# comparison should fail on complex
-@test_throws MethodError complex(1,2) > 0
-@test_throws MethodError complex(1,2) > complex(0,0)
+# comparison should not fail on complex
+@test !(complex(1,2) > 0)
+@test !(complex(1,2) > complex(0,0))
 
 # div, fld, cld, rem, mod
 for yr = Any[

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -342,6 +342,7 @@ mutable struct Twain
     b :: Int
 end
 Base.isless(x :: Twain, y :: Twain) = x.a < y.a
+Base.:(==)(x :: Twain, y :: Twain) = !isless(x, y) && !isless(y, x)
 let x = Twain(2,3), y = Twain(2,4)
     @test (min(x,y), max(x,y)) == (x,y) == minmax(x,y)
 end


### PR DESCRIPTION
I've tried to come up with solutions to the problem with https://github.com/JuliaLang/julia/pull/21934. There are simple solutions where the fast version for sorted arrays is only attempted for a small number of types where we know that sorting works. We could also introduce a `CanBeSorted` trait but in this PR, I try something different: make comparisons non-throwing. This would allow us to use `issorted`, and comparisons in general, on any input without fearing an exception. For now, this PR is meant as an investigation into the consequences of such a change.

Basically, we'll have to give up totality (aka Trichotomy) which, among a few other things, means that we don't have `(<=)(x, y) = !(y < x)` but instead must define `(<=)(x, y) = (x < y) | (x == y)` both directly but also where the "weak" inequality is used implicitly as in `issorted`. The fallback definitions for `min` and `max` must also take into account that some pair might not be comparable. Notice that there are more specific definitions for machine types so it shouldn't really matter for performance.

So far, this requires surprisingly few changes to the source and the tests. I think there is only one major unresolved issue. It is that `issorted` "translates" the order relation by from strong to weak and vice versa by negation, i.e. it uses totality. (This was only triggered by the sparse tests btw). The obvious fix is to use the passed order relation directly instead of "translating" it. However, in contrast to the other changes, this would be heavily breaking but I think that such a change would be to the better.

The negative part is mainly that most people have a total ordering as their internal model for an ordering relation and that `sort` on collections without an order defined is a noop as e.g. complex number.