### PR TITLE
Add `squeeze(A)` method to squeeze all singleton dimensions

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -81,6 +81,29 @@ end
 
 squeeze(A::AbstractArray, dim::Integer) = squeeze(A, (Int(dim),))
 
+"""
+    squeeze(A)
+
+Remove all singleton dimensions from array `A`.
+
+```jldoctest
+julia> a = reshape(collect(1:4),(2,2,1,1))
+2×2×1×1 Array{Int64,4}:
+[:, :, 1, 1] =
+ 1  3
+ 2  4
+
+julia> squeeze(a)
+2×2 Array{Int64,2}:
+ 1  3
+ 2  4
+```
+"""
+function squeeze(A::AbstractArray)
+    singleton_dims = tuple((d for d in 1:ndims(A) if size(A, d) == 1)...)
+    return squeeze(A, singleton_dims)
+end
+
 
 ## Unary operators ##
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -555,3 +555,11 @@ let
     @test Base.IndexStyle(view(a, :, :)) == Base.IndexLinear()
     @test isbits(view(a, :, :))
 end
+
+# issue
+# Ensure that we can auto-squeeze out all singleton dimensions of an array
+let
+    @test ndims(squeeze(ones(10, 1, 1))) == 1
+    @test ndims(squeeze(ones(1, 10))) == 1
+    @test ndims(squeeze(ones(10, 10))) == 2
+end


### PR DESCRIPTION
This addresses https://github.com/JuliaLang/julia/issues/11838, which gave me hope that this might be accepted.  I'm not sure I agree with the "the user may accidentally shoot themselves in the foot" argument; it seems to me that this function does something useful (that at least a few people want) and the behavior is very straightforward, and so isn't something to cause much surprise.

The only surprising thing about this implementation is that passing in an array with nothing but singleton dimensions returns a zero-dimensional array:

```julia
julia> z = randn(1,1)
1×1 Array{Float64,2}:
 -0.454977

julia> squeeze(z)
0-dimensional Array{Float64,0}:
-0.454977
```

Of course, this is what happens with the old squeeze as well:
```julia
julia> squeeze(z, (1,2))
0-dimensional Array{Float64,0}:
-0.454977
```