### PR TITLE
Fix Period objects hashing to match ==

### DIFF
--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -394,3 +394,24 @@ cpa = [1y + 1s 1m + 1s 1w + 1s 1d + 1s; 1h + 1s 1mi + 1s 2m + 1s 1s + 1ms]
 
 @test [1y + 1s 1m + 1s; 1w + 1s 1d + 1s] + [1y + 1h 1y + 1mi; 1y + 1s 1y + 1ms] == [2y + 1h + 1s 1y + 1m + 1mi + 1s; 1y + 1w + 2s 1y + 1d + 1s + 1ms]
 @test [1y + 1s 1m + 1s; 1w + 1s 1d + 1s] - [1y + 1h 1y + 1mi; 1y + 1s 1y + 1ms] == [1s-1h 1m + 1s-1y-1mi; 1w-1y 1d + 1s-1y-1ms]
+
+# Equality and hashing between FixedPeriod types
+let types = (Dates.Week, Dates.Day, Dates.Hour, Dates.Minute,
+             Dates.Second, Dates.Millisecond, Dates.Microsecond, Dates.Nanosecond)
+    for i in 1:length(types), j in i:length(types), x in (0, 1, 235, -4677, 15250)
+        T = types[i]
+        U = types[j]
+        y = T(x)
+        z = convert(U, y)
+        @test y == z
+        @test hash(y) == hash(z)
+    end
+end
+
+# Equality and hashing between OtherPeriod types
+for x in (0, 1, 235, -4677, 15250)
+    y = Dates.Year(x)
+    z = convert(Dates.Month, y)
+    @test y == z
+    @test hash(y) == hash(z)
+end


### PR DESCRIPTION
`==` is supported between `FixedPeriod` and `OtherPeriod` objects, but equal periods
were hashed to different values when their types were different.
Since converting periods to a common, more precise period can overflow, the
computation must use `Int128`.

-----------
I bumped into this when making arrays and ranges hash equal in https://github.com/JuliaLang/julia/pull/16401: the step of a `Date` range can be expressed in a different `Period` type than the difference between two subsequent elements, even when they compare equal.

I hope `Int128` is not too slow, as it's quite hard to compare arbitrary periods without it. (That said, hashing periods is not a priori a really common thing to do...)