### PR TITLE
jump to numbered method in the REPL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,10 @@ Library improvements
   * the functions `base` and `digits` digits now accept a negative
     base (like `ndigits` did) ([#21692]).
 
+  * Method lists are now printed as a numbered list. In addition, the source code of a
+    method can be opened in an editor by entering the corresponding number in the REPL
+    and pressing `^Q` ([#22007]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -891,11 +891,11 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
             end
         end,
 
-        # Open the editor at the location of a stackframe
+        # Open the editor at the location of a stackframe or method
         # This is accessing a global variable that gets set in
-        # the show_backtrace function.
+        # the show_backtrace and show_method_table functions.
         "^Q" => (s, o...) -> begin
-            linfos = Base.LAST_BACKTRACE_LINE_INFOS
+            linfos = Base.LAST_SHOWN_LINE_INFOS
             str = String(take!(LineEdit.buffer(s)))
             n = tryparse(Int, str)
             isnull(n) && @goto writeback

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -150,11 +150,15 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
     kwtype = isdefined(mt, :kwsorter) ? Nullable{DataType}(typeof(mt.kwsorter)) : Nullable{DataType}()
     n = rest = 0
     local last
+
+    resize!(LAST_SHOWN_LINE_INFOS, 0)
     for meth in ms
        if max==-1 || n<max
-            println(io)
-            show(io, meth; kwtype=kwtype)
             n += 1
+            println(io)
+            print(io, "[$(n)] ")
+            show(io, meth; kwtype=kwtype)
+            push!(LAST_SHOWN_LINE_INFOS, (string(meth.file), meth.line))
         else
             rest += 1
             last = meth

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -629,20 +629,20 @@ function show_trace_entry(io, frame, n; prefix = "")
 end
 
 # Contains file name and file number. Gets set when a backtrace
-# is shown. Used by the REPL to make it possible to open
-# the location of a stackframe in the edítor.
-global LAST_BACKTRACE_LINE_INFOS = Tuple{String, Int}[]
+# or methodlist is shown. Used by the REPL to make it possible to open
+# the location of a stackframe/method in the editor.
+global LAST_SHOWN_LINE_INFOS = Tuple{String, Int}[]
 
 function show_backtrace(io::IO, t::Vector)
     n_frames = 0
     frame_counter = 0
-    resize!(LAST_BACKTRACE_LINE_INFOS, 0)
+    resize!(LAST_SHOWN_LINE_INFOS, 0)
     process_backtrace((a,b) -> n_frames += 1, t)
     n_frames != 0 && print(io, "\nStacktrace:")
     process_entry = (last_frame, n) -> begin
         frame_counter += 1
         show_trace_entry(IOContext(io, :backtrace => true), last_frame, n, prefix = string(" [", frame_counter, "] "))
-        push!(LAST_BACKTRACE_LINE_INFOS, (string(last_frame.file), last_frame.line))
+        push!(LAST_SHOWN_LINE_INFOS, (string(last_frame.file), last_frame.line))
     end
     process_backtrace(process_entry, t)
 end

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -171,7 +171,7 @@ to do so).
 | `^K`                | "Kill" to end of line, placing the text in a buffer                              |
 | `^Y`                | "Yank" insert the text from the kill buffer                                      |
 | `^T`                | Transpose the characters about the cursor                                        |
-| `^Q`                | Write a number in REPL and press `^Q` to open editor at corresponding stackframe |
+| `^Q`                | Write a number in REPL and press `^Q` to open editor at corresponding stackframe or method |
 
 
 ### Customizing keybindings

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -166,8 +166,8 @@ of those methods are, use the [`methods()`](@ref) function:
 ```julia
 julia> methods(f)
 # 2 methods for generic function "f":
-f(x::Float64, y::Float64) in Main at none:1
-f(x::Number, y::Number) in Main at none:1
+[1] f(x::Float64, y::Float64) in Main at none:1
+[2] f(x::Number, y::Number) in Main at none:1
 ```
 
 which shows that `f` has two methods, one taking two `Float64` arguments and one taking arguments
@@ -196,25 +196,25 @@ of methods:
 ```julia
 julia> methods(+)
 # 180 methods for generic function "+":
-+(x::Bool, z::Complex{Bool}) in Base at complex.jl:224
-+(x::Bool, y::Bool) in Base at bool.jl:89
-+(x::Bool) in Base at bool.jl:86
-+(x::Bool, y::T) where T<:AbstractFloat in Base at bool.jl:96
-+(x::Bool, z::Complex) in Base at complex.jl:231
-+(a::Float16, b::Float16) in Base at float.jl:372
-+(x::Float32, y::Float32) in Base at float.jl:374
-+(x::Float64, y::Float64) in Base at float.jl:375
-+(z::Complex{Bool}, x::Bool) in Base at complex.jl:225
-+(z::Complex{Bool}, x::Real) in Base at complex.jl:239
-+(x::Char, y::Integer) in Base at char.jl:40
-+(c::BigInt, x::BigFloat) in Base.MPFR at mpfr.jl:303
-+(a::BigInt, b::BigInt, c::BigInt, d::BigInt, e::BigInt) in Base.GMP at gmp.jl:303
-+(a::BigInt, b::BigInt, c::BigInt, d::BigInt) in Base.GMP at gmp.jl:296
-+(a::BigInt, b::BigInt, c::BigInt) in Base.GMP at gmp.jl:290
-+(x::BigInt, y::BigInt) in Base.GMP at gmp.jl:258
-+(x::BigInt, c::Union{UInt16, UInt32, UInt64, UInt8}) in Base.GMP at gmp.jl:315
+[1] +(x::Bool, z::Complex{Bool}) in Base at complex.jl:227
+[2] +(x::Bool, y::Bool) in Base at bool.jl:89
+[3] +(x::Bool) in Base at bool.jl:86
+[4] +(x::Bool, y::T) where T<:AbstractFloat in Base at bool.jl:96
+[5] +(x::Bool, z::Complex) in Base at complex.jl:234
+[6] +(a::Float16, b::Float16) in Base at float.jl:373
+[7] +(x::Float32, y::Float32) in Base at float.jl:375
+[8] +(x::Float64, y::Float64) in Base at float.jl:376
+[9] +(z::Complex{Bool}, x::Bool) in Base at complex.jl:228
+[10] +(z::Complex{Bool}, x::Real) in Base at complex.jl:242
+[11] +(x::Char, y::Integer) in Base at char.jl:40
+[12] +(c::BigInt, x::BigFloat) in Base.MPFR at mpfr.jl:307
+[13] +(a::BigInt, b::BigInt, c::BigInt, d::BigInt, e::BigInt) in Base.GMP at gmp.jl:392
+[14] +(a::BigInt, b::BigInt, c::BigInt, d::BigInt) in Base.GMP at gmp.jl:391
+[15] +(a::BigInt, b::BigInt, c::BigInt) in Base.GMP at gmp.jl:390
+[16] +(x::BigInt, y::BigInt) in Base.GMP at gmp.jl:361
+[17] +(x::BigInt, c::Union{UInt16, UInt32, UInt64, UInt8}) in Base.GMP at gmp.jl:398
 ...
-+(a, b, c, xs...) at operators.jl:119
+[180] +(a, b, c, xs...) in Base at operators.jl:424
 ```
 
 Multiple dispatch together with the flexible parametric type system give Julia its ability to


### PR DESCRIPTION
This PR makes it possible to jump to a numbered method from `methods(foo)`, as can now be done for numbered stackframes (#19680).
I think this is really convenient sometimes, instead of figuring out the correct input and then use `@edit` to get there.

Example here:
https://asciinema.org/a/1r34os4hyyugzw0e2n3il2a5a?t=12