### PR TITLE
Only try to call specialized findin method for sorted input when elements are Real.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -753,7 +753,7 @@ next(A::AbstractArray, i) = (@_propagate_inbounds_meta; (idx, s) = next(i[1], i[
 done(A::AbstractArray, i) = (@_propagate_inbounds_meta; done(i[1], i[2]))
 
 # eachindex iterates over all indices. IndexCartesian definitions are later.
-eachindex(A::AbstractVector) = (@_inline_meta(); indices1(A))
+eachindex(A::Union{Number,AbstractVector}) = (@_inline_meta(); indices1(A))
 
 """
     eachindex(A...)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1791,13 +1791,16 @@ julia> findin(a,b) # 10 is the only common element
  4
 ```
 """
-function findin(a, b)
+function findin(a::Array{<:Real}, b::Union{Array{<:Real},Real})
     if issorted(a, Sort.Forward) && issorted(b, Sort.Forward)
         return _sortedfindin(a, b)
     else
         return _findin(a, b)
     end
 end
+# issorted fails for some element types so the method above has to be restricted
+# to element with isless/< defined.
+findin(a, b) = _findin(a, b)
 
 # Copying subregions
 # TODO: DEPRECATE FOR #14770

--- a/base/array.jl
+++ b/base/array.jl
@@ -1745,22 +1745,27 @@ function _sortedfindin(v, w)
     witerj, j = next(witer, j)
     @inbounds begin
         vi, wj = v[viteri], w[witerj]
-        while !(done(viter, i) || done(witer, j))
-            if vi < wj
+        while true
+            if isless(vi, wj)
+                if done(viter, i)
+                    break
+                end
                 viteri, i = next(viter, i)
                 vi        = v[viteri]
-            elseif vi > wj
+            elseif isless(wj, vi)
+                if done(witer, j)
+                    break
+                end
                 witerj, j = next(witer, j)
                 wj        = w[witerj]
             else
                 push!(out, viteri)
+                if done(viter, i)
+                    break
+                end
                 viteri, i = next(viter, i)
-                witerj, j = next(witer, j)
-                vi, wj    = v[viteri], w[witerj]
+                vi        = v[viteri]
             end
-        end
-        if vi == wj
-            push!(out, viteri)
         end
     end
     return out

--- a/base/array.jl
+++ b/base/array.jl
@@ -1734,6 +1734,9 @@ function _findin(a, b)
     ind
 end
 
+# If two collections are already sorted, findin can be computed with
+# a single traversal of the two collections. This is much faster than
+# using a hash table (although it has the same complexity).
 function _sortedfindin(v, w)
     viter, witer = eachindex(v), eachindex(w)
     out  = eltype(viter)[]
@@ -1763,6 +1766,8 @@ function _sortedfindin(v, w)
                 if done(viter, i)
                     break
                 end
+                # We only increment the v iterator because v can have
+                # repeated matches to a single value in w
                 viteri, i = next(viter, i)
                 vi        = v[viteri]
             end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -273,6 +273,12 @@ end
     @test findin(a, Int[]) == Int[]
     @test findin(Int[], a) == Int[]
 
+    @testset "findin for uncomparable element types" begin
+        a = [1 + 1im, 1 - 1im]
+        @test findin(a, 1 + 1im) == [1]
+        @test findin(a, a)       == [1,2]
+    end
+
     rt = Base.return_types(setindex!, Tuple{Array{Int32, 3}, UInt8, Vector{Int}, Int16, UnitRange{Int}})
     @test length(rt) == 1 && rt[1] == Array{Int32, 3}
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -273,6 +273,14 @@ end
     @test findin(a, Int[]) == Int[]
     @test findin(Int[], a) == Int[]
 
+    a = collect(1:3:15)
+    b = collect(2:4:10)
+    @test findin(a, b) == [4]
+    @test findin([a[1:4]; a[4:end]], b) == [4,5]
+
+    @test findin([1.0, NaN, 2.0], NaN) == [2]
+    @test findin([1.0, 2.0, NaN], NaN) == [3]
+
     @testset "findin for uncomparable element types" begin
         a = [1 + 1im, 1 - 1im]
         @test findin(a, 1 + 1im) == [1]


### PR DESCRIPTION
This should handle the issue mentioned in https://github.com/JuliaLang/julia/pull/21934#issuecomment-302873055. Eventually, we might want to handle this in a smarter way. See https://github.com/JuliaLang/julia/pull/21999.