### PR TITLE
make flipsign(typemin(T), -1) == typemin(T) consistently

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -71,6 +71,7 @@ signbit(x::Integer) = x < 0
 signbit(x::Unsigned) = false
 
 flipsign(x::T, y::T) where {T<:BitSigned} = flipsign_int(x, y)
+flipsign(x::BitSigned, y::BitSigned) = flipsign_int(promote(x, y)...) % typeof(x)
 
 flipsign(x::Signed, y::Signed)  = convert(typeof(x), flipsign(promote_noncircular(x, y)...))
 flipsign(x::Signed, y::Float16) = flipsign(x, bitcast(Int16, y))

--- a/base/number.jl
+++ b/base/number.jl
@@ -93,8 +93,8 @@ abs2(x::Real) = x*x
 
 Return `x` with its sign flipped if `y` is negative. For example `abs(x) = flipsign(x,x)`.
 """
-flipsign(x::Real, y::Real) = ifelse(signbit(y), -x, x)
-copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, x)
+flipsign(x::Real, y::Real) = ifelse(signbit(y), -x, +x) # the + is for type-stability on Bool
+copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, +x)
 
 conj(x::Real) = x
 transpose(x::Number) = x

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -286,6 +286,12 @@ function deepcopy_internal end
 # BigInts and BigFloats
 include("gmp.jl")
 importall .GMP
+
+for T in [Signed, Integer, BigInt, Float32, Float64, Real, Complex, Rational]
+    @eval flipsign(x::$T, ::Unsigned) = +x
+    @eval copysign(x::$T, ::Unsigned) = +x
+end
+
 include("mpfr.jl")
 importall .MPFR
 big(n::Integer) = convert(BigInt,n)

--- a/test/int.jl
+++ b/test/int.jl
@@ -17,15 +17,30 @@ for y in (4, Float32(4), 4.0, big(4.0))
     @test copysign(-3, y) == 3
 end
 
-# Result type must be type of first argument
-for T in (Base.BitInteger_types..., BigInt,
+# Result type must be type of first argument, except for Bool
+for U in (Base.BitInteger_types..., BigInt,
           Rational{Int}, Rational{BigInt},
           Float16, Float32, Float64)
-    for U in (Base.BitInteger_types..., BigInt,
+    for T in (Base.BitInteger_types..., BigInt,
               Rational{Int}, Rational{BigInt},
               Float16, Float32, Float64)
         @test typeof(copysign(T(3), U(4))) === T
         @test typeof(flipsign(T(3), U(4))) === T
+    end
+    # Bool promotes to Int
+    U <: Unsigned && continue
+    for x in [true, false]
+        @test flipsign(x, U(4)) === Int(x)
+        @test flipsign(x, U(-1)) === -Int(x)
+        @test copysign(x, U(4)) === Int(x)
+        @test copysign(x, U(-1)) === -Int(x)
+    end
+end
+
+@testset "flipsign/copysign(typemin($T), -1)" for T in Base.BitInteger_types
+    for U in (Base.BitSigned_types..., BigInt, Float16, Float32, Float64)
+        @test flipsign(typemin(T), U(-1)) == typemin(T)
+        @test copysign(typemin(T), U(-1)) == typemin(T)
     end
 end
 


### PR DESCRIPTION
Cf. https://github.com/JuliaLang/julia/pull/21984#issuecomment-302886513 where the discussion started.
This makes `flipsign(x, y)` always (hopefully) equal to `y < 0 ? +x : -x`.
Before: `flipsign(typemin(Int8), -1)` was an `InexactError()` but `copysign(typemin(Int8), -1) == -128`, and `-typemin(Int8) == -128`.

This PR also
* makes those methods typestable on `Bool` by adding a `+` which is a no-op in most cases. 
* add a special case when the second argument is `Unsigned`, but I'm not sure this is really faster.