### PR TITLE
Return socket correctly in socket_reuse_port

### DIFF
--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -471,6 +471,7 @@ function socket_reuse_port()
             return TCPSocket()
         end
         is_apple() && bind_client_port(s)
+        return s
     else
         return TCPSocket()
     end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -11,6 +11,7 @@ include("testenv.jl")
     end
 
 addprocs_with_testenv(4)
+@test nprocs() == 5
 
 function reuseport_tests()
     # Run the test on all processes.

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -12,9 +12,7 @@ include("testenv.jl")
 
 addprocs_with_testenv(4)
 
-# Test that the client port is reused. SO_REUSEPORT may not be supported on
-# all UNIX platforms, Linux kernels prior to 3.9 and older versions of OSX
-if is_unix()
+function reuseport_tests()
     # Run the test on all processes.
     results = asyncmap(procs()) do p
         remotecall_fetch(p) do
@@ -45,6 +43,19 @@ if is_unix()
 
     # Ensure that the code has indeed been successfully executed everywhere
     @test all(p -> p in results, procs())
+end
+
+# Test that the client port is reused. SO_REUSEPORT may not be supported on
+# all UNIX platforms, Linux kernels prior to 3.9 and older versions of OSX
+if is_unix()
+    # Run reuse client port tests only if SO_REUSEPORT is supported.
+    s = TCPSocket(delay = false)
+    is_linux() && Base.Distributed.bind_client_port(s)
+    if ccall(:jl_tcp_reuseport, Int32, (Ptr{Void},), s.handle) == 0
+        reuseport_tests()
+    else
+        info("SO_REUSEPORT is unsupported, skipping reuseport tests.")
+    end
 end
 
 id_me = myid()


### PR DESCRIPTION
Should fix buildbot failure  https://github.com/JuliaLang/julia/pull/21818#issuecomment-303074536

A bit of a mystery as to how Linux CI passed correctly.....