### PR TITLE
improve inferability of base

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1668,15 +1668,15 @@ end
 function _sub2ind!(Iout, inds, Iinds, I)
     @_noinline_meta
     for i in Iinds
-        # Iout[i] = sub2ind(inds, map(Ij->Ij[i], I)...)
+        # Iout[i] = sub2ind(inds, map(Ij -> Ij[i], I)...)
         Iout[i] = sub2ind_vec(inds, i, I)
     end
     Iout
 end
 
-sub2ind_vec(inds, i, I) = (@_inline_meta; _sub2ind_vec(inds, (), i, I...))
-_sub2ind_vec(inds, out, i, I1, I...) = (@_inline_meta; _sub2ind_vec(inds, (out..., I1[i]), i, I...))
-_sub2ind_vec(inds, out, i) = (@_inline_meta; sub2ind(inds, out...))
+sub2ind_vec(inds, i, I) = (@_inline_meta; sub2ind(inds, _sub2ind_vec(i, I...)...))
+_sub2ind_vec(i, I1, I...) = (@_inline_meta; (I1[i], _sub2ind_vec(i, I...)...))
+_sub2ind_vec(i) = ()
 
 function ind2sub(inds::Union{DimsInteger{N},Indices{N}}, ind::AbstractVector{<:Integer}) where N
     M = length(ind)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -202,13 +202,11 @@ julia> strides(A)
 (1, 3, 12)
 ```
 """
-strides(A::AbstractArray) = _strides((1,), A)
-_strides(out::Tuple{Int}, A::AbstractArray{<:Any,0}) = ()
-_strides(out::NTuple{N,Int}, A::AbstractArray{<:Any,N}) where {N} = out
-function _strides(out::NTuple{M,Int}, A::AbstractArray) where M
-    @_inline_meta
-    _strides((out..., out[M]*size(A, M)), A)
-end
+strides(A::AbstractArray) = size_to_strides(1, size(A)...)
+@inline size_to_strides(s, d, sz...) = (s, size_to_strides(s * d, sz...)...)
+size_to_strides(s, d) = (s,)
+size_to_strides(s) = ()
+
 
 function isassigned(a::AbstractArray, i::Int...)
     try

--- a/base/array.jl
+++ b/base/array.jl
@@ -73,12 +73,7 @@ end
 size(a::Array, d) = arraysize(a, d)
 size(a::Vector) = (arraysize(a,1),)
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))
-size(a::Array) = (@_inline_meta; _size((), a))
-_size(out::NTuple{N}, A::Array{_,N}) where {_,N} = out
-function _size(out::NTuple{M}, A::Array{_,N}) where _ where M where N
-    @_inline_meta
-    _size((out..., size(A,M+1)), A)
-end
+size(a::Array{<:Any,N}) where {N} = (@_inline_meta; ntuple(M -> size(a, M), Val{N}))
 
 asize_from(a::Array, n) = n > ndims(a) ? () : (arraysize(a,n), asize_from(a, n+1)...)
 

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -15,6 +15,7 @@ struct InferenceParams
     inlining::Bool
 
     # parameters limiting potentially-infinite types (configurable)
+    MAX_METHODS::Int
     MAX_TUPLETYPE_LEN::Int
     MAX_TUPLE_DEPTH::Int
     MAX_TUPLE_SPLAT::Int
@@ -24,12 +25,13 @@ struct InferenceParams
     # reasonable defaults
     function InferenceParams(world::UInt;
                     inlining::Bool = inlining_enabled(),
+                    max_methods::Int = 4,
                     tupletype_len::Int = 15,
                     tuple_depth::Int = 4,
                     tuple_splat::Int = 16,
                     union_splitting::Int = 4,
                     apply_union_enum::Int = 8)
-        return new(world, inlining, tupletype_len,
+        return new(world, inlining, max_methods, tupletype_len,
             tuple_depth, tuple_splat, union_splitting, apply_union_enum)
     end
 end
@@ -1280,7 +1282,7 @@ function abstract_call_gf_by_type(f::ANY, atype::ANY, sv::InferenceState)
     end
     min_valid = UInt[typemin(UInt)]
     max_valid = UInt[typemax(UInt)]
-    applicable = _methods_by_ftype(argtype, 4, sv.params.world, min_valid, max_valid)
+    applicable = _methods_by_ftype(argtype, sv.params.MAX_METHODS, sv.params.world, min_valid, max_valid)
     rettype = Bottom
     if applicable === false
         # this means too many methods matched

--- a/base/int.jl
+++ b/base/int.jl
@@ -362,22 +362,24 @@ end
 # @doc isn't available when running in Core at this point.
 # Tuple syntax for documention two function signatures at the same time
 # doesn't work either at this point.
-isdefined(Main, :Base) && for fname in (:mod, :rem)
-    @eval @doc """
-        rem(x::Integer, T::Type{<:Integer}) -> T
-        mod(x::Integer, T::Type{<:Integer}) -> T
-        %(x::Integer, T::Type{<:Integer}) -> T
+if module_name(current_module()) === :Base
+    for fname in (:mod, :rem)
+        @eval @doc ("""
+            rem(x::Integer, T::Type{<:Integer}) -> T
+            mod(x::Integer, T::Type{<:Integer}) -> T
+            %(x::Integer, T::Type{<:Integer}) -> T
 
-    Find `y::T` such that `x` ≡ `y` (mod n), where n is the number of integers representable
-    in `T`, and `y` is an integer in `[typemin(T),typemax(T)]`.
-    If `T` can represent any integer (e.g. `T == BigInt`), then this operation corresponds to
-    a conversion to `T`.
+        Find `y::T` such that `x` ≡ `y` (mod n), where n is the number of integers representable
+        in `T`, and `y` is an integer in `[typemin(T),typemax(T)]`.
+        If `T` can represent any integer (e.g. `T == BigInt`), then this operation corresponds to
+        a conversion to `T`.
 
-    ```jldoctest
-    julia> 129 % Int8
-    -127
-    ```
-    """ -> $fname(x::Integer, T::Type{<:Integer})
+        ```jldoctest
+        julia> 129 % Int8
+        -127
+        ```
+        """ -> $fname(x::Integer, T::Type{<:Integer}))
+    end
 end
 
 rem(x::T, ::Type{T}) where {T<:Integer} = x

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -138,9 +138,10 @@ module IteratorsMD
     eachindex(::IndexCartesian, A::AbstractArray) = CartesianRange(indices(A))
 
     @inline eachindex(::IndexCartesian, A::AbstractArray, B::AbstractArray...) =
-        CartesianRange(maxsize((), A, B...))
-    maxsize(sz) = sz
-    @inline maxsize(sz, A, B...) = maxsize(maxt(sz, size(A)), B...)
+        CartesianRange(maxsize(A, B...))
+    maxsize() = ()
+    @inline maxsize(A) = size(A)
+    @inline maxsize(A, B...) = maxt(size(A), maxsize(B...))
     @inline maxt(a::Tuple{}, b::Tuple{}) = ()
     @inline maxt(a::Tuple{}, b::Tuple)   = b
     @inline maxt(a::Tuple,   b::Tuple{}) = a

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -74,10 +74,7 @@ end
     val
 end
 
-# For some reason this is faster than ntuple(d->I[perm[d]], Val{N}) (#15276?)
-@inline genperm(I::NTuple{N,Any}, perm::Dims{N}) where {N} = _genperm((), I, perm...)
-_genperm(out, I) = out
-@inline _genperm(out, I, p, perm...) = _genperm((out..., I[p]), I, perm...)
+@inline genperm(I::NTuple{N,Any}, perm::Dims{N}) where {N} = ntuple(d -> I[perm[d]], Val{N})
 @inline genperm(I, perm::AbstractVector{Int}) = genperm(I, (perm...,))
 
 """

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -167,11 +167,11 @@ parentindexes(A::ReshapedArray) = map(s->1:s, size(parent(A)))
 reinterpret(::Type{T}, A::ReshapedArray, dims::Dims) where {T} = reinterpret(T, parent(A), dims)
 
 @inline ind2sub_rs(::Tuple{}, i::Int) = i
-@inline ind2sub_rs(strds, i) = ind2sub_rs((), strds, i-1)
-@inline ind2sub_rs(out, ::Tuple{}, ind) = (ind+1, out...)
-@inline function ind2sub_rs(out, strds, ind)
+@inline ind2sub_rs(strds, i) = _ind2sub_rs(strds, i - 1)
+@inline _ind2sub_rs(::Tuple{}, ind) = (ind + 1,)
+@inline function _ind2sub_rs(strds, ind)
     d, r = divrem(ind, strds[1])
-    ind2sub_rs((d+1, out...), tail(strds), r)
+    (_ind2sub_rs(tail(strds), r)..., d + 1)
 end
 
 @inline function getindex(A::ReshapedArrayLF, index::Int)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -148,7 +148,7 @@ _reshape(R::ReshapedArray, dims::Dims) = _reshape(R.parent, dims)
 
 function __reshape(p::Tuple{AbstractArray,IndexCartesian}, dims::Dims)
     parent = p[1]
-    strds = front(size_strides(parent))
+    strds = front(size_to_strides(size(parent)..., 1))
     strds1 = map(s->max(1,s), strds)  # for resizing empty arrays
     mi = map(SignedMultiplicativeInverse, strds1)
     ReshapedArray(parent, dims, reverse(mi))
@@ -158,10 +158,6 @@ function __reshape(p::Tuple{AbstractArray,IndexLinear}, dims::Dims)
     parent = p[1]
     ReshapedArray(parent, dims, ())
 end
-
-@inline size_strides(A::AbstractArray) = tail(size_strides((1,), size(A)...))
-size_strides(out::Tuple) = out
-@inline size_strides(out, s, sz...) = size_strides((out..., out[end]*s), sz...)
 
 size(A::ReshapedArray) = A.dims
 similar(A::ReshapedArray, eltype::Type, dims::Dims) = similar(parent(A), eltype, dims)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1036,7 +1036,9 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show_type = false
     # print anything else as "Expr(head, args...)"
     else
-        show_type = false
+        if head !== :invoke
+            show_type = false
+        end
         if emphstate && ex.head !== :lambda && ex.head !== :method
             io = IOContext(io, :TYPEEMPHASIZE => false)
             emphstate = false

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -195,6 +195,25 @@ include("nullable.jl")
 include("broadcast.jl")
 importall .Broadcast
 
+# define the real ntuple functions
+@generated function ntuple(f::F, ::Type{Val{N}}) where {F,N}
+    Core.typeassert(N, Int)
+    (N >= 0) || return :(throw($(ArgumentError(string("tuple length should be ≥0, got ", N)))))
+    return quote
+        $(Expr(:meta, :inline))
+        @nexprs $N i -> t_i = f(i)
+        @ncall $N tuple t
+    end
+end
+@generated function fill_to_length(t::Tuple, val, ::Type{Val{N}}) where {N}
+    M = length(t.parameters)
+    M > N  && return :(throw($(ArgumentError("input tuple of length $M, requested $N"))))
+    return quote
+        $(Expr(:meta, :inline))
+        (t..., $(Any[ :val for i = (M + 1):N ]...))
+    end
+end
+
 # base64 conversions (need broadcast)
 include("base64.jl")
 importall .Base64

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -83,13 +83,13 @@ safe_tail(t::Tuple{}) = ()
 
 function front(t::Tuple)
     @_inline_meta
-    _front((), t...)
+    _front(t...)
 end
-front(::Tuple{}) = throw(ArgumentError("Cannot call front on an empty tuple"))
-_front(out, v) = out
-function _front(out, v, t...)
+_front() = throw(ArgumentError("Cannot call front on an empty tuple"))
+_front(v) = ()
+function _front(v, t...)
     @_inline_meta
-    _front((out..., v), t...)
+    (v, _front(t...)...)
 end
 
 ## mapping ##

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -24,12 +24,13 @@ getindex(t::Tuple, r::AbstractArray{<:Any,1}) = ([t[ri] for ri in r]...)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t,find(b)) : throw(BoundsError(t, b))
 
 # returns new tuple; N.B.: becomes no-op if i is out-of-bounds
-setindex(x::Tuple, v, i::Integer) = _setindex((), x, v, i::Integer)
-function _setindex(y::Tuple, r::Tuple, v, i::Integer)
+setindex(x::Tuple, v, i::Integer) = (@_inline_meta; _setindex(v, i, x...))
+function _setindex(v, i::Integer, first, tail...)
     @_inline_meta
-    _setindex((y..., ifelse(length(y) + 1 == i, v, first(r))), tail(r), v, i)
+    return (ifelse(i == 1, v, first), _setindex(v, i - 1, tail...)...)
 end
-_setindex(y::Tuple, r::Tuple{}, v, i::Integer) = y
+_setindex(v, i::Integer) = ()
+
 
 ## iterating ##
 
@@ -126,36 +127,11 @@ function _ntuple(f, n)
     ([f(i) for i = 1:n]...)
 end
 
-# inferrable ntuple
-ntuple(f, ::Type{Val{0}}) = (@_inline_meta; ())
+# inferrable ntuple (enough for bootstrapping)
+ntuple(f, ::Type{Val{0}}) = ()
 ntuple(f, ::Type{Val{1}}) = (@_inline_meta; (f(1),))
 ntuple(f, ::Type{Val{2}}) = (@_inline_meta; (f(1), f(2)))
 ntuple(f, ::Type{Val{3}}) = (@_inline_meta; (f(1), f(2), f(3)))
-ntuple(f, ::Type{Val{4}}) = (@_inline_meta; (f(1), f(2), f(3), f(4)))
-ntuple(f, ::Type{Val{5}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5)))
-ntuple(f, ::Type{Val{6}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6)))
-ntuple(f, ::Type{Val{7}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7)))
-ntuple(f, ::Type{Val{8}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8)))
-ntuple(f, ::Type{Val{9}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8), f(9)))
-ntuple(f, ::Type{Val{10}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8), f(9), f(10)))
-ntuple(f, ::Type{Val{11}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8), f(9), f(10), f(11)))
-ntuple(f, ::Type{Val{12}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8), f(9), f(10), f(11), f(12)))
-ntuple(f, ::Type{Val{13}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8), f(9), f(10), f(11), f(12), f(13)))
-ntuple(f, ::Type{Val{14}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8), f(9), f(10), f(11), f(12), f(13), f(14)))
-ntuple(f, ::Type{Val{15}}) = (@_inline_meta; (f(1), f(2), f(3), f(4), f(5), f(6), f(7), f(8), f(9), f(10), f(11), f(12), f(13), f(14), f(15)))
-
-function ntuple(f::F, ::Type{Val{N}}) where {F,N}
-    Core.typeassert(N, Int)
-    (N >= 0) || throw(ArgumentError(string("tuple length should be ≥0, got ", N)))
-    _ntuple((), f, Val{N})
-end
-
-# Build up the output until it has length N
-_ntuple(out::NTuple{N,Any}, f::F, ::Type{Val{N}}) where {F,N} = out
-function _ntuple(out::NTuple{M,Any}, f::F, ::Type{Val{N}}) where {F,N,M}
-    @_inline_meta
-    _ntuple((out..., f(M+1)), f, Val{N})
-end
 
 # 1 argument function
 map(f, t::Tuple{})              = ()
@@ -211,20 +187,14 @@ end
 
 
 # type-stable padding
-fill_to_length(t::Tuple, val, ::Type{Val{N}}) where {N} = _ftl((), val, Val{N}, t...)
-_ftl(out::NTuple{N,Any}, val, ::Type{Val{N}}) where {N} = out
-function _ftl(out::NTuple{N,Any}, val, ::Type{Val{N}}, t...) where N
-    @_inline_meta
-    throw(ArgumentError("input tuple of length $(N+length(t)), requested $N"))
-end
-function _ftl(out, val, ::Type{Val{N}}, t1, t...) where N
-    @_inline_meta
-    _ftl((out..., t1), val, Val{N}, t...)
-end
-function _ftl(out, val, ::Type{Val{N}}) where N
-    @_inline_meta
-    _ftl((out..., val), val, Val{N})
-end
+fill_to_length(t::NTuple{N,Any}, val, ::Type{Val{N}}) where {N} = t
+fill_to_length(t::Tuple{}, val, ::Type{Val{1}}) = (val,)
+fill_to_length(t::Tuple{Any}, val, ::Type{Val{2}}) = (t..., val)
+fill_to_length(t::Tuple{}, val, ::Type{Val{2}}) = (val, val)
+#function fill_to_length(t::Tuple, val, ::Type{Val{N}}) where {N}
+#    @_inline_meta
+#    return (t..., ntuple(i -> val, N - length(t))...)
+#end
 
 # constructing from an iterator
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3048,7 +3048,7 @@ static bool emit_builtin_call(jl_cgval_t *ret, jl_value_t *f, jl_value_t **args,
         jl_datatype_t *sty = (jl_datatype_t*)expr_type(args[1], ctx);
         rt1 = (jl_value_t*)sty;
         jl_datatype_t *uty = (jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)sty);
-        if (jl_is_structtype(uty) && uty != jl_module_type) {
+        if (jl_is_structtype(uty) && uty != jl_module_type && ((jl_datatype_t*)uty)->layout) {
             size_t idx = (size_t)-1;
             if (jl_is_quotenode(args[2]) && jl_is_symbol(jl_fieldref(args[2],0))) {
                 idx = jl_field_index(uty, (jl_sym_t*)jl_fieldref(args[2],0), 0);

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -3,21 +3,21 @@
 module TestBroadcastInternals
 
 using Base.Broadcast: broadcast_indices, check_broadcast_indices,
-                      check_broadcast_shape, newindex, _bcs, _bcsm
+                      check_broadcast_shape, newindex, _bcs
 using Base: Test, OneTo
 
-@test @inferred(_bcs((), (3,5), (3,5))) == (3,5)
-@test @inferred(_bcs((), (3,1), (3,5))) == (3,5)
-@test @inferred(_bcs((), (3,),  (3,5))) == (3,5)
-@test @inferred(_bcs((), (3,5), (3,)))  == (3,5)
-@test_throws DimensionMismatch _bcs((), (3,5), (4,5))
-@test_throws DimensionMismatch _bcs((), (3,5), (3,4))
-@test @inferred(_bcs((), (-1:1, 2:5), (-1:1, 2:5))) == (-1:1, 2:5)
-@test @inferred(_bcs((), (-1:1, 2:5), (1, 2:5)))    == (-1:1, 2:5)
-@test @inferred(_bcs((), (-1:1, 1),   (1, 2:5)))    == (-1:1, 2:5)
-@test @inferred(_bcs((), (-1:1,),     (-1:1, 2:5))) == (-1:1, 2:5)
-@test_throws DimensionMismatch _bcs((), (-1:1, 2:6), (-1:1, 2:5))
-@test_throws DimensionMismatch _bcs((), (-1:1, 2:5), (2, 2:5))
+@test @inferred(_bcs((3,5), (3,5))) == (3,5)
+@test @inferred(_bcs((3,1), (3,5))) == (3,5)
+@test @inferred(_bcs((3,),  (3,5))) == (3,5)
+@test @inferred(_bcs((3,5), (3,)))  == (3,5)
+@test_throws DimensionMismatch _bcs((3,5), (4,5))
+@test_throws DimensionMismatch _bcs((3,5), (3,4))
+@test @inferred(_bcs((-1:1, 2:5), (-1:1, 2:5))) == (-1:1, 2:5)
+@test @inferred(_bcs((-1:1, 2:5), (1, 2:5)))    == (-1:1, 2:5)
+@test @inferred(_bcs((-1:1, 1),   (1, 2:5)))    == (-1:1, 2:5)
+@test @inferred(_bcs((-1:1,),     (-1:1, 2:5))) == (-1:1, 2:5)
+@test_throws DimensionMismatch _bcs((-1:1, 2:6), (-1:1, 2:5))
+@test_throws DimensionMismatch _bcs((-1:1, 2:5), (2, 2:5))
 
 @test @inferred(broadcast_indices(zeros(3,4), zeros(3,4))) == (OneTo(3),OneTo(4))
 @test @inferred(broadcast_indices(zeros(3,4), zeros(3)))   == (OneTo(3),OneTo(4))


### PR DESCRIPTION
Avoid growing an input parameter during recursion. In general, permitting that would require that inference be potentially non-terminating (as proving that it will converge requires solving the halting problem). However, the methods in base using this pattern only actually requires the simpler pattern of tail-recursing on some element and concatenating the output.

(This is the learnings of #21933 without the policy change.)