### PR TITLE
More flexible perm-gen allocation alignment control

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -135,7 +135,7 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t nfields,
     jl_datatype_layout_t *flddesc =
         (jl_datatype_layout_t*)jl_gc_perm_alloc(sizeof(jl_datatype_layout_t) +
                                                 nfields * fielddesc_size +
-                                                (has_padding ? sizeof(uint32_t) : 0), 0);
+                                                (has_padding ? sizeof(uint32_t) : 0), 0, 4, 0);
     if (has_padding) {
         if (first_ptr > UINT16_MAX)
             first_ptr = UINT16_MAX;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1506,7 +1506,7 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
             size_t fielddesc_size = nf > 0 ? jl_fielddesc_size(fielddesc_type) : 0;
             jl_datatype_layout_t *layout = (jl_datatype_layout_t*)jl_gc_perm_alloc(
                     sizeof(jl_datatype_layout_t) + nf * fielddesc_size +
-                    (has_padding ? sizeof(uint32_t) : 0), 0);
+                    (has_padding ? sizeof(uint32_t) : 0), 0, 4, 0);
             if (has_padding) {
                 layout = (jl_datatype_layout_t*)(((char*)layout) + sizeof(uint32_t));
                 jl_datatype_layout_n_nonptr(layout) = read_int32(s->s);

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -91,7 +91,8 @@ static jl_gc_pagemeta_t *jl_gc_alloc_new_page(void)
     // if any allocation fails, this just stops recording more pages from that point
     // and will free (munmap) the remainder
     jl_gc_pagemeta_t *page_meta =
-        (jl_gc_pagemeta_t*)jl_gc_perm_alloc_nolock(pg_cnt * sizeof(jl_gc_pagemeta_t), 1);
+        (jl_gc_pagemeta_t*)jl_gc_perm_alloc_nolock(pg_cnt * sizeof(jl_gc_pagemeta_t), 1,
+                                                   sizeof(void*), 0);
     pg = 0;
     if (page_meta) {
         for (; pg < pg_cnt; pg++) {
@@ -114,7 +115,8 @@ static jl_gc_pagemeta_t *jl_gc_alloc_new_page(void)
                 memory_map.freemap1[info.pagetable_i32] |= msk; // has free
             info.pagetable1 = *(ppagetable1 = &memory_map.meta1[i]);
             if (!info.pagetable1) {
-                info.pagetable1 = (pagetable1_t*)jl_gc_perm_alloc_nolock(sizeof(pagetable1_t), 1);
+                info.pagetable1 = (pagetable1_t*)jl_gc_perm_alloc_nolock(sizeof(pagetable1_t), 1,
+                                                                         sizeof(void*), 0);
                 *ppagetable1 = info.pagetable1;
                 if (!info.pagetable1)
                     break;
@@ -129,7 +131,8 @@ static jl_gc_pagemeta_t *jl_gc_alloc_new_page(void)
                 info.pagetable1->freemap0[info.pagetable1_i32] |= msk; // has free
             info.pagetable0 = *(ppagetable0 = &info.pagetable1->meta0[i]);
             if (!info.pagetable0) {
-                info.pagetable0 = (pagetable0_t*)jl_gc_perm_alloc_nolock(sizeof(pagetable0_t), 1);
+                info.pagetable0 = (pagetable0_t*)jl_gc_perm_alloc_nolock(sizeof(pagetable0_t), 1,
+                                                                         sizeof(void*), 0);
                 *ppagetable0 = info.pagetable0;
                 if (!info.pagetable0)
                     break;

--- a/src/gc.c
+++ b/src/gc.c
@@ -2821,51 +2821,68 @@ jl_value_t *jl_gc_realloc_string(jl_value_t *s, size_t sz)
 // 20k limit for pool allocation. At most 1% fragmentation
 #define GC_PERM_POOL_LIMIT (20 * 1024)
 jl_mutex_t gc_perm_lock = {0, 0};
-static char *gc_perm_pool = NULL;
-static size_t gc_perm_size = 0;
+static uintptr_t gc_perm_pool = 0;
+static uintptr_t gc_perm_end = 0;
 
-// **NOT** a safepoint
-void *jl_gc_perm_alloc_nolock(size_t sz, int zero)
+static void *gc_perm_alloc_large(size_t sz, int zero, unsigned align, unsigned offset)
 {
-    // The caller should have acquired `gc_perm_lock`
-#ifndef MEMDEBUG
-    if (__unlikely(sz > GC_PERM_POOL_LIMIT))
-#endif
-        return zero ? calloc(1, sz) : malloc(sz);
-    sz = LLT_ALIGN(sz, JL_SMALL_BYTE_ALIGNMENT);
-    if (__unlikely(sz > gc_perm_size)) {
-#ifdef _OS_WINDOWS_
-        void *pool = VirtualAlloc(NULL,
-                                  GC_PERM_POOL_SIZE + JL_SMALL_BYTE_ALIGNMENT,
-                                  MEM_COMMIT, PAGE_READWRITE);
-        if (__unlikely(pool == NULL))
-            return NULL;
-        pool = (void*)LLT_ALIGN((uintptr_t)pool, JL_SMALL_BYTE_ALIGNMENT);
-#else
-        void *pool = mmap(0, GC_PERM_POOL_SIZE, PROT_READ | PROT_WRITE,
-                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (__unlikely(pool == MAP_FAILED))
-            return NULL;
-#endif
-        gc_perm_pool = (char*)pool;
-        gc_perm_size = GC_PERM_POOL_SIZE;
-    }
-    assert(((uintptr_t)gc_perm_pool) % JL_SMALL_BYTE_ALIGNMENT == 0);
-    void *p = gc_perm_pool;
-    gc_perm_size -= sz;
-    gc_perm_pool += sz;
-    return p;
+    // `align` must be power of two
+    assert(offset == 0 || offset < align);
+    const size_t malloc_align = sizeof(void*) == 8 ? 16 : 4;
+    if (align > 1 && (offset != 0 || align > malloc_align))
+        sz += align - 1;
+    uintptr_t base = (uintptr_t)(zero ? calloc(1, sz) : malloc(sz));
+    unsigned diff = (offset - base) % align;
+    return (void*)(base + diff);
+}
+
+STATIC_INLINE void *gc_try_perm_alloc_pool(size_t sz, unsigned align, unsigned offset)
+{
+    uintptr_t pool = LLT_ALIGN(gc_perm_pool + offset, (uintptr_t)align) - offset;
+    uintptr_t end = pool + sz;
+    if (end > gc_perm_end)
+        return NULL;
+    gc_perm_pool = end;
+    return (void*)jl_assume(pool);
 }
 
 // **NOT** a safepoint
-void *jl_gc_perm_alloc(size_t sz, int zero)
+void *jl_gc_perm_alloc_nolock(size_t sz, int zero, unsigned align, unsigned offset)
 {
+    // The caller should have acquired `gc_perm_lock`
+    assert(align < GC_PERM_POOL_LIMIT);
 #ifndef MEMDEBUG
     if (__unlikely(sz > GC_PERM_POOL_LIMIT))
 #endif
-        return zero ? calloc(1, sz) : malloc(sz);
+        return gc_perm_alloc_large(sz, zero, align, offset);
+    void *ptr = gc_try_perm_alloc_pool(sz, align, offset);
+    if (__likely(ptr))
+        return ptr;
+#ifdef _OS_WINDOWS_
+    void *pool = VirtualAlloc(NULL, GC_PERM_POOL_SIZE, MEM_COMMIT, PAGE_READWRITE);
+    if (__unlikely(pool == NULL))
+        return NULL;
+#else
+    void *pool = mmap(0, GC_PERM_POOL_SIZE, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (__unlikely(pool == MAP_FAILED))
+        return NULL;
+#endif
+    gc_perm_pool = (uintptr_t)pool;
+    gc_perm_end = gc_perm_pool + GC_PERM_POOL_SIZE;
+    return gc_try_perm_alloc_pool(sz, align, offset);
+}
+
+// **NOT** a safepoint
+void *jl_gc_perm_alloc(size_t sz, int zero, unsigned align, unsigned offset)
+{
+    assert(align < GC_PERM_POOL_LIMIT);
+#ifndef MEMDEBUG
+    if (__unlikely(sz > GC_PERM_POOL_LIMIT))
+#endif
+        return gc_perm_alloc_large(sz, zero, align, offset);
     JL_LOCK_NOGC(&gc_perm_lock);
-    void *p = jl_gc_perm_alloc_nolock(sz, zero);
+    void *p = jl_gc_perm_alloc_nolock(sz, zero, align, offset);
     JL_UNLOCK_NOGC(&gc_perm_lock);
     return p;
 }

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -32,7 +32,7 @@ static jl_sym_t *mk_symbol(const char *str, size_t len)
     jl_sym_t *sym;
     size_t nb = symbol_nbytes(len);
 
-    jl_taggedvalue_t *tag = (jl_taggedvalue_t*)jl_gc_perm_alloc_nolock(nb, 0);
+    jl_taggedvalue_t *tag = (jl_taggedvalue_t*)jl_gc_perm_alloc_nolock(nb, 0, sizeof(void*), 0);
     sym = (jl_sym_t*)jl_valueof(tag);
     // set to old marked so that we won't look at it in the GC or write barrier.
     tag->header = ((uintptr_t)jl_sym_type) | GC_OLD_MARKED;

--- a/test/core.jl
+++ b/test/core.jl
@@ -4941,3 +4941,12 @@ let arr8 = zeros(UInt8, 16),
     arr64_i[2] = 1234
     @test arr64[2] == 1234
 end
+
+# Alignment of perm boxes
+for i in 1:10
+    # Int64 box should be 16bytes aligned even on 32bits
+    ptr1 = ccall(:jl_box_int64, UInt, (Int64,), i)
+    ptr2 = ccall(:jl_box_int64, UInt, (Int64,), i)
+    @test ptr1 === ptr2
+    @test ptr1 % 16 == 0
+end


### PR DESCRIPTION
I just realized that https://github.com/JuliaLang/julia/pull/21767 accidentally broke a GC allocation alignment guarantee (though it's unlikely any hardware would care very....)

This makes sure the cached box allocation are 16bytes aligned again and test that. It also use less alignment for allocations that doesn't need more (mainly `Symbol`s and `DataLayout`s) which reduces the initial permgen size from ~1.6M to 1.3M...
