### PR TITLE
Do exact array resize!() in more cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,9 @@ Library improvements
   * `getpeername` on a `TCPSocket` returns the address and port of the remote
     endpoint of the TCP connection ([#21825]).
 
+  * `resize!` and `sizehint!` methods no longer over-reserve memory when the
+    requested array size is more than double of its current size ([#22038]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -597,11 +597,19 @@ setindex!(A::Array{T, N}, x::Number, ::Vararg{Colon, N}) where {T, N} = fill!(A,
 
 # efficiently grow an array
 
+_growbeg!(a::Vector, delta::Integer) =
+    ccall(:jl_array_grow_beg, Void, (Any, UInt), a, delta)
+_growend!(a::Vector, delta::Integer) =
+    ccall(:jl_array_grow_end, Void, (Any, UInt), a, delta)
 _growat!(a::Vector, i::Integer, delta::Integer) =
     ccall(:jl_array_grow_at, Void, (Any, Int, UInt), a, i - 1, delta)
 
 # efficiently delete part of an array
 
+_deletebeg!(a::Vector, delta::Integer) =
+    ccall(:jl_array_del_beg, Void, (Any, UInt), a, delta)
+_deleteend!(a::Vector, delta::Integer) =
+    ccall(:jl_array_del_end, Void, (Any, UInt), a, delta)
 _deleteat!(a::Vector, i::Integer, delta::Integer) =
     ccall(:jl_array_del_at, Void, (Any, Int, UInt), a, i - 1, delta)
 
@@ -610,13 +618,13 @@ _deleteat!(a::Vector, i::Integer, delta::Integer) =
 function push!(a::Array{T,1}, item) where T
     # convert first so we don't grow the array if the assignment won't work
     itemT = convert(T, item)
-    ccall(:jl_array_grow_end, Void, (Any, UInt), a, 1)
+    _growend!(a, 1)
     a[end] = itemT
     return a
 end
 
 function push!(a::Array{Any,1}, item::ANY)
-    ccall(:jl_array_grow_end, Void, (Any, UInt), a, 1)
+    _growend!(a, 1)
     arrayset(a, item, length(a))
     return a
 end
@@ -624,7 +632,7 @@ end
 function append!(a::Array{<:Any,1}, items::AbstractVector)
     itemindices = eachindex(items)
     n = length(itemindices)
-    ccall(:jl_array_grow_end, Void, (Any, UInt), a, n)
+    _growend!(a, n)
     copy!(a, length(a)-n+1, items, first(itemindices), n)
     return a
 end
@@ -666,7 +674,7 @@ function prepend! end
 function prepend!(a::Array{<:Any,1}, items::AbstractVector)
     itemindices = eachindex(items)
     n = length(itemindices)
-    ccall(:jl_array_grow_beg, Void, (Any, UInt), a, n)
+    _growbeg!(a, n)
     if a === items
         copy!(a, 1, items, n+1, n)
     else
@@ -680,7 +688,7 @@ unshift!(a::Vector, iter...) = prepend!(a, iter)
 
 function _prepend!(a, ::Union{HasLength,HasShape}, iter)
     n = length(iter)
-    ccall(:jl_array_grow_beg, Void, (Any, UInt), a, n)
+    _growbeg!(a, n)
     i = 0
     for item in iter
         @inbounds a[i += 1] = item
@@ -734,7 +742,7 @@ function resize!(a::Vector, nl::Integer)
         if nl < 0
             throw(ArgumentError("new length must be ≥ 0"))
         end
-        ccall(:jl_array_del_end, Void, (Any, UInt), a, l-nl)
+        _deleteend!(a, l-nl)
     end
     return a
 end
@@ -749,7 +757,7 @@ function pop!(a::Vector)
         throw(ArgumentError("array must be non-empty"))
     end
     item = a[end]
-    ccall(:jl_array_del_end, Void, (Any, UInt), a, 1)
+    _deleteend!(a, 1)
     return item
 end
 
@@ -771,7 +779,7 @@ julia> unshift!([1, 2, 3, 4], 5, 6)
 """
 function unshift!(a::Array{T,1}, item) where T
     item = convert(T, item)
-    ccall(:jl_array_grow_beg, Void, (Any, UInt), a, 1)
+    _growbeg!(a, 1)
     a[1] = item
     return a
 end
@@ -781,7 +789,7 @@ function shift!(a::Vector)
         throw(ArgumentError("array must be non-empty"))
     end
     item = a[1]
-    ccall(:jl_array_del_beg, Void, (Any, UInt), a, 1)
+    _deletebeg!(a, 1)
     return item
 end
 
@@ -892,7 +900,7 @@ function _deleteat!(a::Vector, inds)
         @inbounds a[p] = a[q]
         p += 1; q += 1
     end
-    ccall(:jl_array_del_end, Void, (Any, UInt), a, n-p+1)
+    _deleteend!(a, n-p+1)
     return a
 end
 
@@ -905,7 +913,7 @@ function deleteat!(a::Vector, inds::AbstractVector{Bool})
         @inbounds a[p] = a[q]
         p += !i
     end
-    ccall(:jl_array_del_end, Void, (Any, UInt), a, n-p+1)
+    _deleteend!(a, n-p+1)
     return a
 end
 
@@ -1034,7 +1042,7 @@ function splice!(a::Vector, r::UnitRange{<:Integer}, ins=_default_splice)
 end
 
 function empty!(a::Vector)
-    ccall(:jl_array_del_end, Void, (Any, UInt), a, length(a))
+    _deleteend!(a, length(a))
     return a
 end
 


### PR DESCRIPTION
Sometimes it's useful to have precise control over memory size allocated for a given array (see e.g. #21938).
One would assume it could be done by `resize!()`, but under the hood it calls `jl_array_grow_at_end()`.
The latter method is actually tuned for the gradually growing arrays, it would allocate the exactly requested size only if the array is empty,
otherwise it would allocate the next power of 2 that is greater or equal to the requested size.

There are several options:
* do nothing
* change the heuristic to allocate exactly requested amounts in more cases (**final decision** implemented by this PR) 
* add keyword/positional `exact` argument to `resize!()`/`sizehint!()`
* change the behaviour of `resize!()`/`sizehint!()` to always grow to the exactly specified size
* add new `resize_exact!()` method (either exported or not)
* ...