### PR TITLE
check overflow in hex2num (fix #22031)

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -77,21 +77,6 @@ Subtraction operator.
 -(x, y)
 
 """
-    bits(n)
-
-A string giving the literal bit representation of a number.
-
-```jldoctest
-julia> bits(4)
-"0000000000000000000000000000000000000000000000000000000000000100"
-
-julia> bits(2.2)
-"0100000000000001100110011001100110011001100110011001100110011010"
-```
-"""
-bits
-
-"""
     getindex(type[, elements...])
 
 Construct a 1-d array of the specified type. This is usually called with the syntax
@@ -564,18 +549,6 @@ matches. If overlap is `true`, the matching sequences are allowed to overlap ind
 original string, otherwise they must be from distinct character ranges.
 """
 eachmatch
-
-"""
-    num2hex(f)
-
-Get a hexadecimal string of the binary representation of a floating point number.
-
-```jldoctest
-julia> num2hex(2.2)
-"400199999999999a"
-```
-"""
-num2hex
 
 """
     truncate(file,n)
@@ -1122,13 +1095,6 @@ julia> bin(bswap(1))
 bswap
 
 """
-    maxintfloat(T)
-
-The largest integer losslessly representable by the given floating-point DataType `T`.
-"""
-maxintfloat
-
-"""
     delete!(collection, key)
 
 Delete the mapping for the given key in a collection, and return the collection.
@@ -1359,13 +1325,6 @@ false
 ```
 """
 isempty
-
-"""
-    hex2num(str)
-
-Convert a hexadecimal string to the floating point number it represents.
-"""
-hex2num
 
 """
     InexactError()
@@ -2164,14 +2123,6 @@ be either `Char` or `String`. Values for `Char` can be of type `Char` or [`UInt3
 Values for `String` can be of that type, or `Vector{UInt8}`.
 """
 isvalid(T,value)
-
-"""
-    unsigned(x) -> Unsigned
-
-Convert a number to an unsigned integer. If the argument is signed, it is reinterpreted as
-unsigned without checking for negative values.
-"""
-unsigned
 
 """
     reverseind(v, i)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2249,14 +2249,6 @@ for sets of arbitrary objects.
 Set
 
 """
-    signed(x)
-
-Convert a number to a signed integer. If the argument is unsigned, it is reinterpreted as
-signed without checking for overflow.
-"""
-signed
-
-"""
     Val{c}
 
 Create a "value type" out of `c`, which must be an `isbits` value. The intent of this

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -138,6 +138,24 @@ convert(::Type{T}, x::T) where {T<:Tuple{Any,Vararg{Any}}} = x
 
 oftype(x,c) = convert(typeof(x),c)
 
+"""
+    unsigned(x) -> Unsigned
+
+Convert a number to an unsigned integer. If the argument is signed, it is reinterpreted as
+unsigned without checking for negative values.
+
+    unsigned(T::Type) -> UnsignedType
+
+Return the return-type of unsigned(x::T).
+
+```jldoctest
+julia> unsigned(12)
+0x000000000000000c
+
+julia> unsigned(Int)
+UInt64
+```
+"""
 unsigned(x::Int) = reinterpret(UInt, x)
 signed(x::UInt) = reinterpret(Int, x)
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -145,16 +145,9 @@ Convert a number to an unsigned integer. If the argument is signed, it is reinte
 unsigned without checking for negative values.
 See also [`signed`](@ref).
 
-    unsigned(T::Type) -> UnsignedType
-
-Return the return-type of `unsigned(x::T)`, so that `unsigned(x)::unsigned(typeof(x))`.
-
 ```jldoctest
 julia> unsigned(12)
 0x000000000000000c
-
-julia> unsigned(Int64)
-UInt64
 
 julia> unsigned(2.0)
 0x0000000000000002
@@ -173,16 +166,9 @@ Convert a number to a signed integer. If the argument is unsigned, it is reinter
 signed without checking for overflow.
 See also [`unsigned`](@ref).
 
-    signed(T::Type) -> SignedType
-
-Return the return-type of `signed(x::T)`, so that `signed(x)::signed(typeof(x))`.
-
 ```jldoctest
 julia> signed(0xc)
 12
-
-julia> signed(UInt64)
-Int64
 
 julia> signed(2.0)
 2
@@ -190,6 +176,7 @@ julia> signed(2.0)
 julia> signed(2.2)
 ERROR: InexactError()
 [...]
+```
 """
 signed(x::UInt) = reinterpret(Int, x)
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -143,20 +143,54 @@ oftype(x,c) = convert(typeof(x),c)
 
 Convert a number to an unsigned integer. If the argument is signed, it is reinterpreted as
 unsigned without checking for negative values.
+See also [`signed`](@ref).
 
     unsigned(T::Type) -> UnsignedType
 
-Return the return-type of unsigned(x::T).
+Return the return-type of `unsigned(x::T)`, so that `unsigned(x)::unsigned(typeof(x))`.
 
 ```jldoctest
 julia> unsigned(12)
 0x000000000000000c
 
-julia> unsigned(Int)
+julia> unsigned(Int64)
 UInt64
+
+julia> unsigned(2.0)
+0x0000000000000002
+
+julia> unsigned(2.2)
+ERROR: InexactError()
+[...]
 ```
 """
 unsigned(x::Int) = reinterpret(UInt, x)
+
+"""
+    signed(x)
+
+Convert a number to a signed integer. If the argument is unsigned, it is reinterpreted as
+signed without checking for overflow.
+See also [`unsigned`](@ref).
+
+    signed(T::Type) -> SignedType
+
+Return the return-type of `signed(x::T)`, so that `signed(x)::signed(typeof(x))`.
+
+```jldoctest
+julia> signed(0xc)
+12
+
+julia> signed(UInt64)
+Int64
+
+julia> signed(2.0)
+2
+
+julia> signed(2.2)
+ERROR: InexactError()
+[...]
+"""
 signed(x::UInt) = reinterpret(Int, x)
 
 # conversions used by ccall

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -16,6 +16,11 @@ signbit(x::Float64) = signbit(bitcast(Int64, x))
 signbit(x::Float32) = signbit(bitcast(Int32, x))
 signbit(x::Float16) = signbit(bitcast(Int16, x))
 
+"""
+    maxintfloat(T)
+
+The largest integer losslessly representable by the given floating-point DataType `T`.
+"""
 maxintfloat(::Type{Float64}) = 9007199254740992.
 maxintfloat(::Type{Float32}) = Float32(16777216.)
 maxintfloat(::Type{Float16}) = Float16(2048f0)
@@ -24,18 +29,10 @@ maxintfloat() = maxintfloat(Float64)
 
 isinteger(x::AbstractFloat) = (x - trunc(x) == 0)
 
-num2hex(x::Float16) = hex(bitcast(UInt16, x), 4)
-num2hex(x::Float32) = hex(bitcast(UInt32, x), 8)
-num2hex(x::Float64) = hex(bitcast(UInt64, x), 16)
-
 function hex2num(s::AbstractString)
-    if length(s) <= 4
-        return bitcast(Float16, parse(UInt16, s, 16))
-    end
-    if length(s) <= 8
-        return bitcast(Float32, parse(UInt32, s, 16))
-    end
-    return bitcast(Float64, parse(UInt64, s, 16))
+    l = length(s)
+    l > 16 && throw(ArgumentError("the passed string must be of length <= 16, got $l"))
+    hex2num(l <= 4 ? Float16 : l <= 8 ? Float32 : Float64, s)
 end
 
 """

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -29,9 +29,17 @@ maxintfloat() = maxintfloat(Float64)
 
 isinteger(x::AbstractFloat) = (x - trunc(x) == 0)
 
+"""
+    hex2num(str)
+
+Convert a hexadecimal string to the floating point number it represents.
+This function, which is inherently type-unstable, returns a `Float16`,
+a `Float32`, or a `Float64` depending on the length of the string `str`
+(note that this length must hence be no greater than 16).
+"""
 function hex2num(s::AbstractString)
     l = length(s)
-    l > 16 && throw(ArgumentError("the passed string must be of length <= 16, got $l"))
+    l > 16 && throw(ArgumentError("the length of the passed string must be <= 16, got $l"))
     hex2num(l <= 4 ? Float16 : l <= 8 ? Float32 : Float64, s)
 end
 

--- a/base/int.jl
+++ b/base/int.jl
@@ -23,6 +23,14 @@ const BitInteger     = Union{BitInteger_types...}
 const BitSigned64T   = Union{Type{Int8}, Type{Int16}, Type{Int32}, Type{Int64}}
 const BitUnsigned64T = Union{Type{UInt8}, Type{UInt16}, Type{UInt32}, Type{UInt64}}
 
+const BitFloat_types = (Float16, Float32, Float64)
+const BitFloat       = Union{BitFloat_types...}
+const BitReal_types  = (BitInteger_types..., BitFloat_types...)
+const BitReal        = Union{BitReal_types...}
+
+reinterpret(::Type{Unsigned}, x::BitInteger) = unsigned(x)
+
+
 ## integer comparisons ##
 
 (<)(x::T, y::T) where {T<:BitSigned}  = slt_int(x, y)

--- a/base/int.jl
+++ b/base/int.jl
@@ -28,11 +28,34 @@ const BitFloat       = Union{BitFloat_types...}
 const BitReal_types  = (BitInteger_types..., BitFloat_types...)
 const BitReal        = Union{BitReal_types...}
 
+## integer signed-ness conversions
+
 reinterpret(::Type{Unsigned}, x::BitInteger) = unsigned(x)
 reinterpret(::Type{  Signed}, x::BitInteger) = signed(x)
 
+"""
+    unsigned(T::Type) -> UnsignedType
+
+Return the return-type of `unsigned(x::T)`, so that `unsigned(x)::unsigned(typeof(x))`.
+
+```jldoctest
+julia> unsigned(Int64)
+UInt64
+```
+"""
 unsigned(::Type{T}) where {T<:Unsigned} = T
-signed(  ::Type{T}) where {T<:Signed}   = T
+
+"""
+    signed(T::Type) -> SignedType
+
+Return the return-type of `signed(x::T)`, so that `signed(x)::signed(typeof(x))`.
+
+```jldoctest
+julia> signed(UInt64)
+Int64
+```
+"""
+signed(::Type{T}) where {T<:Signed} = T
 
 unsigned(::Type{<:Union{Bool,BitFloat}}) = UInt
 signed(  ::Type{<:Union{Bool,BitFloat}}) = Int

--- a/base/int.jl
+++ b/base/int.jl
@@ -32,6 +32,10 @@ const BitReal        = Union{BitReal_types...}
 
 reinterpret(::Type{Unsigned}, x::BitInteger) = unsigned(x)
 reinterpret(::Type{  Signed}, x::BitInteger) = signed(x)
+reinterpret(::Type{Unsigned}, ::Type{Bool})  = UInt8
+reinterpret(::Type{  Signed}, ::Type{Bool})  =  Int8
+reinterpret(::Type{Unsigned}, x::Bool)       = x % UInt8
+reinterpret(::Type{  Signed}, x::Bool)       = x %  Int8
 
 """
     unsigned(T::Type) -> UnsignedType

--- a/base/int.jl
+++ b/base/int.jl
@@ -29,7 +29,13 @@ const BitReal_types  = (BitInteger_types..., BitFloat_types...)
 const BitReal        = Union{BitReal_types...}
 
 reinterpret(::Type{Unsigned}, x::BitInteger) = unsigned(x)
+reinterpret(::Type{  Signed}, x::BitInteger) = signed(x)
 
+unsigned(::Type{T}) where {T<:Unsigned} = T
+signed(  ::Type{T}) where {T<:Signed}   = T
+
+unsigned(::Type{<:Union{Bool,BitFloat}}) = UInt
+signed(  ::Type{<:Union{Bool,BitFloat}}) = Int
 
 ## integer comparisons ##
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -518,8 +518,7 @@ julia> num2hex(2.2)
 "400199999999999a"
 ```
 """
-num2hex(n::BitReal) = hex(reinterpret(Unsigned, n), sizeof(n)*2)
-num2hex(n::Bool) = hex(n)
+num2hex(n::Union{Bool,BitReal}) = hex(reinterpret(Unsigned, n), sizeof(n)*2)
 
 """
     hex2num(T::Type, str)
@@ -535,7 +534,7 @@ julia> hex2num(Int32, "fffffffe")
 -2
 ```
 """
-hex2num(::Type{T}, s::AbstractString) where {T<:BitReal} =
+hex2num(::Type{T}, s::AbstractString) where {T<:Union{Bool,BitReal}} =
     reinterpret(T, parse(reinterpret(Unsigned, T), s, 16))
 
 const base36digits = ['0':'9';'a':'z']

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -2,23 +2,23 @@
 
 # this construction is not available when put in int.jl and running in Core
 for (S,U,F) in zip(BitSigned_types, BitUnsigned_types,
-                       (nothing, Float16, Float32, Float64, nothing))
-        @eval begin
-            unsigned(::Type{$S}) = $U
-            unsigned(::Type{$U}) = $U
-            signed(  ::Type{$S}) = $S
-            signed(  ::Type{$U}) = $S
-            reinterpret(::Type{Unsigned}, ::Type{$S}) = $U
-            reinterpret(::Type{Unsigned}, ::Type{$U}) = $U
-            reinterpret(::Type{Signed}, ::Type{$S}) = $S
-            reinterpret(::Type{Signed}, ::Type{$U}) = $S
-        end
-        F === nothing && continue
-        @eval begin
-            reinterpret(::Type{Unsigned}, ::Type{$F}) = $U
-            reinterpret(::Type{Signed}, ::Type{$F}) = $S
-        end
+                   (nothing, Float16, Float32, Float64, nothing))
+    @eval begin
+        unsigned(::Type{$S}) = $U
+        unsigned(::Type{$U}) = $U
+        signed(  ::Type{$S}) = $S
+        signed(  ::Type{$U}) = $S
+        reinterpret(::Type{Unsigned}, ::Type{$S}) = $U
+        reinterpret(::Type{Unsigned}, ::Type{$U}) = $U
+        reinterpret(::Type{Signed}, ::Type{$S}) = $S
+        reinterpret(::Type{Signed}, ::Type{$U}) = $S
     end
+    F === nothing && continue
+    @eval begin
+        reinterpret(::Type{Unsigned}, ::Type{$F}) = $U
+        reinterpret(::Type{Signed}, ::Type{$F}) = $S
+    end
+end
 
 ## number-theoretic functions ##
 
@@ -506,9 +506,9 @@ end
 """
     num2hex(f)
 
-An hexadecimal string of the binary representation of a number.
+A hexadecimal string of the binary representation of a number.
 See also the [`bits`](@ref) function, which is similar but gives
-a binary string, and [`hex2num`] which does the opposite conversion.
+a binary string, and [`hex2num`](@ref) which does the opposite conversion.
 
 ```jldoctest
 julia> num2hex(Int64(4))
@@ -516,7 +516,6 @@ julia> num2hex(Int64(4))
 
 julia> num2hex(2.2)
 "400199999999999a"
-
 ```
 """
 num2hex(n::BitReal) = hex(reinterpret(Unsigned, n), sizeof(n)*2)
@@ -632,7 +631,7 @@ dec
 
 A string giving the literal bit representation of a number.
 See also the [`num2hex`](@ref) function, which is similar but
-gives an hexadecimal string.
+gives a hexadecimal string.
 
 ```jldoctest
 julia> bits(4)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -483,7 +483,48 @@ function hex(x::Unsigned, pad::Int, neg::Bool)
     String(a)
 end
 
-num2hex(n::Integer) = hex(n, sizeof(n)*2)
+"""
+    num2hex(f)
+
+An hexadecimal string of the binary representation of a number.
+See also the [`bits`](@ref) function, which is similar but gives
+a binary string.
+
+```jldoctest
+julia> num2hex(Int64(4))
+"0000000000000004"
+
+julia> num2hex(2.2)
+"400199999999999a"
+
+```
+"""
+num2hex(n::BitReal) = hex(reinterpret(Unsigned, n), sizeof(n)*2)
+num2hex(n::Bool) = hex(n)
+
+"""
+    hex2num(T::Type, str)
+
+Interprets a hexadecimal string as the bit representation of a
+number of type `T`. See also [`num2hex`](@ref).
+
+```jldoctest
+julia> hex2num(Float64, "400199999999999a")
+2.2
+
+julia> hex2num(Int32, "fffffffe")
+-2
+```
+
+    hex2num(str)
+
+Convert a hexadecimal string to the floating point number it represents.
+This function, which is inherently type-unstable, returns a `Float16`,
+a `Float32`, or a `Float64` depending on the length of the string `str`
+(note that this length must hence be no greater than 16).
+"""
+hex2num(::Type{T}, s::AbstractString) where {T<:BitReal} =
+    reinterpret(T, parse(unsigned(T), s, 16))
 
 const base36digits = ['0':'9';'a':'z']
 const base62digits = ['0':'9';'A':'Z';'a':'z']
@@ -573,6 +614,21 @@ Convert an integer to a decimal string, optionally specifying a number of digits
 """
 dec
 
+"""
+    bits(n)
+
+A string giving the literal bit representation of a number.
+See also the [`num2hex`](@ref) function, which is similar but
+gives an hexadecimal string.
+
+```jldoctest
+julia> bits(4)
+"0000000000000000000000000000000000000000000000000000000000000100"
+
+julia> bits(2.2)
+"0100000000000001100110011001100110011001100110011001100110011010"
+```
+"""
 bits(x::Union{Bool,Int8,UInt8})           = bin(reinterpret(UInt8,x),8)
 bits(x::Union{Int16,UInt16,Float16})      = bin(reinterpret(UInt16,x),16)
 bits(x::Union{Char,Int32,UInt32,Float32}) = bin(reinterpret(UInt32,x),32)

--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -2,19 +2,9 @@
 
 module MultiplicativeInverses
 
-import Base: div, divrem, rem, unsigned
+import Base: div, divrem, rem
 using  Base: IndexLinear, IndexCartesian, tail
 export multiplicativeinverse
-
-unsigned(::Type{Int8}) = UInt8
-unsigned(::Type{Int16}) = UInt16
-unsigned(::Type{Int32}) = UInt32
-unsigned(::Type{Int64}) = UInt64
-unsigned(::Type{Int128}) = UInt128
-unsigned(::Type{T}) where {T<:Unsigned} = T
-unsigned(::Type{Float16}) = UInt16
-unsigned(::Type{Float32}) = UInt32
-unsigned(::Type{Float64}) = UInt64
 
 abstract type  MultiplicativeInverse{T} end
 

--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -11,7 +11,10 @@ unsigned(::Type{Int16}) = UInt16
 unsigned(::Type{Int32}) = UInt32
 unsigned(::Type{Int64}) = UInt64
 unsigned(::Type{Int128}) = UInt128
-unsigned{T<:Unsigned}(::Type{T}) = T
+unsigned(::Type{T}) where {T<:Unsigned} = T
+unsigned(::Type{Float16}) = UInt16
+unsigned(::Type{Float32}) = UInt32
+unsigned(::Type{Float64}) = UInt64
 
 abstract type  MultiplicativeInverse{T} end
 

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -39,7 +39,9 @@ end
 for elty in (Float16,Float32,Float64), _ = 1:10
     x = rand(elty)
     @test hex2num(num2hex(x)) ≈ x
+    @test hex2num(elty, num2hex(x)) ≈ x
 end
+@test_throws ArgumentError hex2num(String(rand('a':'f', rand(17:100))))
 
 # round
 for elty in (Float32,Float64)

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -41,7 +41,7 @@ for elty in (Float16,Float32,Float64), _ = 1:10
     @test hex2num(num2hex(x)) ≈ x
     @test hex2num(elty, num2hex(x)) ≈ x
 end
-@test_throws ArgumentError hex2num(String(rand('a':'f', rand(17:100))))
+@test_throws ArgumentError hex2num(String(rand(['a':'f';'0':'1'], rand(17:100))))
 
 # round
 for elty in (Float32,Float64)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -124,6 +124,14 @@ end
 @test hex(12) == "c"
 @test hex(-12, 3) == "-00c"
 @test num2hex(1243) == (Int == Int32 ? "000004db" : "00000000000004db")
+@test num2hex(-1243) == (Int == Int32 ? "fffffb25" : "fffffffffffffb25")
+@test num2hex(true) == "1"
+@test num2hex(false) == "0"
+
+for elty in Base.BitInteger_types, _ = 1:10
+    x = rand(elty)
+    @test hex2num(elty, num2hex(x)) == x
+end
 
 @test base(2, 5, 7) == "0000101"
 

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -125,8 +125,8 @@ end
 @test hex(-12, 3) == "-00c"
 @test num2hex(1243) == (Int == Int32 ? "000004db" : "00000000000004db")
 @test num2hex(-1243) == (Int == Int32 ? "fffffb25" : "fffffffffffffb25")
-@test num2hex(true) == "1"
-@test num2hex(false) == "0"
+@test num2hex(true) == "01"
+@test num2hex(false) == "00"
 
 for elty in Base.BitInteger_types, _ = 1:10
     x = rand(elty)


### PR DESCRIPTION
This also creates `hex2num(::Type, str)` to get a type-stable function, and fix (what I think to be) a bug, where `num2hex(-1) == "-0000000000000001"` instead of "ffffffffffffffff", i.e. `num2hex` is supposed to give the bit-pattern in hex form (similar to `bits`).

Edit: this is independant of the question on whether `hex2num` should be moved to `parse`...