### PR TITLE
Deploy docs with clean URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,3 +147,5 @@ script:
         rm -f julia/deps/scratch/libgit2-*/CMakeFiles/CMakeOutput.log
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg
+after_success:
+    - cd julia && make -C doc deploy

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,7 +8,7 @@ JULIAHOME        := $(abspath $(SRCDIR)/..)
 include $(JULIAHOME)/Make.inc
 JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
 
-.PHONY: help clean cleanall html pdf linkcheck doctest check deps
+.PHONY: help clean cleanall html pdf linkcheck doctest check deps deploy
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"
@@ -32,10 +32,10 @@ cleanall: clean
 html: deps
 	@echo "Building HTML documentation."
 ifneq ($(OS),WINNT)
-	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy
+	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl)
 else
 # work around issue #11727, windows output redirection breaking on buildbot
-	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy > docbuild.log 2>&1
+	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) > docbuild.log 2>&1
 	@cat docbuild.log
 endif
 	@echo "Build finished. The HTML pages are in _build/html."
@@ -59,3 +59,9 @@ check: deps
 	@echo "Running all embedded 'doctests' and checking external links."
 	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- doctest linkcheck
 	@echo "Checks finished."
+
+# The deploy target should only be called in Travis builds
+deploy: deps
+	@echo "Deploying HTML documentation."
+	$(JULIA_EXECUTABLE) $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy
+	@echo "Build & deploy of docs finished."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,7 +8,7 @@ JULIAHOME        := $(abspath $(SRCDIR)/..)
 include $(JULIAHOME)/Make.inc
 JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
 
-.PHONY: help clean cleanall html pdf linkcheck doctest check
+.PHONY: help clean cleanall html pdf linkcheck doctest check deps
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"
@@ -59,5 +59,3 @@ check: deps
 	@echo "Running all embedded 'doctests' and checking external links."
 	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- doctest linkcheck
 	@echo "Checks finished."
-
-.PHONY: deps

--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
-Compat 0.25.0 0.25.0+
+Compat 0.25.2 0.25.2+
 DocStringExtensions 0.3.3 0.3.3+
-Documenter 0.10.3 0.10.3+
+Documenter 0.11.1 0.11.1+

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -47,7 +47,6 @@ const PAGES = [
         "manual/calling-c-and-fortran-code.md",
         "manual/handling-operating-system-variation.md",
         "manual/environment-variables.md",
-        "manual/interacting-with-julia.md",
         "manual/embedding.md",
         "manual/packages.md",
         "manual/profile.md",

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -129,6 +129,7 @@ makedocs(
     authors   = "The Julia Project",
     analytics = "UA-28835595-6",
     pages     = PAGES,
+    html_prettyurls = ("deploy" in ARGS),
 )
 
 if "deploy" in ARGS

--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -561,7 +561,7 @@ julia> round(DateTime(2016, 8, 6, 20, 15), Dates.Day)
 Unlike the numeric [`round()`](@ref) method, which breaks ties toward the even number by default,
 the [`TimeType`](@ref)[`round()`](@ref) method uses the `RoundNearestTiesUp` rounding mode. (It's
 difficult to guess what breaking ties to nearest "even" [`TimeType`](@ref) would entail.) Further
-details on the available `RoundingMode` s can be found in the [API reference](https://docs.julialang.org/en/latest/stdlib/dates.html).
+details on the available `RoundingMode` s can be found in the [API reference](../stdlib/dates.md).
 
 Rounding should generally behave as expected, but there are a few cases in which the expected
 behaviour is not obvious.
@@ -626,5 +626,5 @@ will result in the months field having an odd value. Because both months and yea
 an irregular number of days, whether rounding to an even number of days will result in an even
 value in the days field is uncertain.
 
-See the [API reference](https://docs.julialang.org/en/latest/stdlib/dates.html) for additional information
+See the [API reference](../stdlib/dates.md) for additional information
 on methods exported from the `Dates` module.

--- a/doc/src/stdlib/linalg.md
+++ b/doc/src/stdlib/linalg.md
@@ -224,7 +224,6 @@ Base.LinAlg.BLAS.gemv(::Any, ::Any, ::Any)
 Base.LinAlg.BLAS.symm!
 Base.LinAlg.BLAS.symm(::Any, ::Any, ::Any, ::Any, ::Any)
 Base.LinAlg.BLAS.symm(::Any, ::Any, ::Any, ::Any)
-Base.LinAlg.BLAS.symm(::Char, ::Char, ::Any, ::Any, ::Any)
 Base.LinAlg.BLAS.symv!
 Base.LinAlg.BLAS.symv(::Any, ::Any, ::Any, ::Any)
 Base.LinAlg.BLAS.symv(::Any, ::Any, ::Any)


### PR DESCRIPTION
Switch the deployed docs to cleaner URLs like `manual/linalg/` instead of `manual/linalg.html`. Requires Documenter `v0.11.0`.

The new Documenter version brings a couple of other [updates](https://github.com/JuliaDocs/Documenter.jl/releases/tag/v0.11.0) as well, most importantly a decent mobile experience (many thanks to @wookay for that). I hope I'm not too late to the party, but it would be great to have this for the 0.6 release docs as well.

There are a couple of loose ends:

- [x] Local builds should still go with the `page.md` -> `page.html` convention, i.e. `html_prettyurls` should be `false` for them. I made the option depend on the `deploy` argument, and I propose two different targets for the docs Makefile -- `html` for local builds and a separate `deploy` just for deploying from Travis. But it also requires support from the main Makefile, and I could use some advice there.
- [x] One of the links in the manual is broken due to a bug in Documenter (ref to "Unicode Input" in `manual/interacting-with-julia.md`).
- [x] Updated Documenter also complains about links that start with a `#`, but that doesn't actually break any URLs in the output.
- [x] Broken search links.

An example build of the manual: http://mortenpi.eu/julia/pretty-urls/