### PR TITLE
Add extra early memcpyopt pass

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -161,6 +161,7 @@ void addOptimizationPasses(PassManager *PM)
     // list of passes from vmkit
     PM->add(createCFGSimplificationPass()); // Clean up disgusting code
     PM->add(createPromoteMemoryToRegisterPass()); // Kill useless allocas
+    PM->add(createMemCpyOptPass());
 
     // hopefully these functions (from llvmcall) don't try to interact with the Julia runtime
     // or have anything that might corrupt the createLowerPTLSPass pass


### PR DESCRIPTION
Under certain circumstances, we emit loads/stores of large LLVM
structs. A lot of these can be trivially folded to memcpy and memcpyopt
is capable of doing so, but we weren't running it until after SROA.
SROA unfortunately, likes to take these apart, causing exponential
compile-time blow up and reduced runtime performance. In one particular
case (2000 element tuple), this change results in a 100x improvement
in compile time.