### PR TITLE
add AbstractArray to stdlib

### DIFF
--- a/doc/src/devdocs/offset-arrays.md
+++ b/doc/src/devdocs/offset-arrays.md
@@ -59,7 +59,7 @@ the ranges may not start at 1.  If you just want the range for a particular dime
 is `indices(A, d)`.
 
 Base implements a custom range type, `OneTo`, where `OneTo(n)` means the same thing as `1:n` but
-in a form that guarantees (via the type system) that the lower index is 1.  For any new `AbstractArray`
+in a form that guarantees (via the type system) that the lower index is 1. For any new [`AbstractArray`](@ref)
 type, this is the default returned by `indices`, and it indicates that this array type uses "conventional"
 1-based indexing.  Note that if you don't want to be bothered supporting arrays with non-1 indexing,
 you can add the following line:

--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -1,6 +1,6 @@
 # SubArrays
 
-Julia's `SubArray` type is a container encoding a "view" of a parent `AbstractArray`.  This page
+Julia's `SubArray` type is a container encoding a "view" of a parent [`AbstractArray`](@ref).  This page
 documents some of the design principles and implementation of `SubArray`s.
 
 ## Indexing: cartesian vs. linear indexing

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -433,7 +433,7 @@ When we are done evaluating the body of a `UnionAll` type whose variable is diag
 we look at the final values of the bounds.
 Since the variable must be concrete, a contradiction occurs if its lower bound
 could not be a subtype of a concrete type.
-For example, an abstract type like `AbstractArray` cannot be a subtype of a concrete
+For example, an abstract type like [`AbstractArray`](@ref) cannot be a subtype of a concrete
 type, but a concrete type like `Int` can be, and the empty type `Bottom` can be as well.
 If a lower bound fails this test the algorithm stops with the answer `false`.
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -510,7 +510,7 @@ iterate over any array type.
 
 ### Array traits
 
-If you write a custom `AbstractArray` type, you can specify that it has fast linear indexing using
+If you write a custom [`AbstractArray`](@ref) type, you can specify that it has fast linear indexing using
 
 ```julia
 Base.IndexStyle(::Type{<:MyArray}) = IndexLinear()

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -187,7 +187,7 @@ julia> Squares(10)[[3,4.,5]]
 While this is starting to support more of the [indexing operations supported by some of the builtin types](@ref man-array-indexing),
 there's still quite a number of behaviors missing. This `Squares` sequence is starting to look
 more and more like a vector as we've added behaviors to it. Instead of defining all these behaviors
-ourselves, we can officially define it as a subtype of an `AbstractArray`.
+ourselves, we can officially define it as a subtype of an [`AbstractArray`](@ref).
 
 ## [Abstract Arrays](@id man-interface-array)
 

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -1,5 +1,27 @@
 # [Arrays](@id lib-arrays)
 
+## Constructors and Types
+
+```@docs
+Core.AbstractArray
+Core.Array
+Base.getindex(::Type, ::Any...)
+Base.zeros
+Base.ones
+Base.BitArray
+Base.trues
+Base.falses
+Base.fill
+Base.fill!
+Base.similar(::AbstractArray)
+Base.similar(::Any, ::Tuple)
+Base.eye
+Base.linspace
+Base.logspace
+Base.Random.randsubseq
+Base.Random.randsubseq!
+```
+
 ## Basic functions
 
 ```@docs
@@ -18,27 +40,6 @@ Base.strides
 Base.ind2sub
 Base.sub2ind
 Base.LinAlg.checksquare
-```
-
-## Constructors
-
-```@docs
-Core.Array
-Base.getindex(::Type, ::Any...)
-Base.zeros
-Base.ones
-Base.BitArray
-Base.trues
-Base.falses
-Base.fill
-Base.fill!
-Base.similar(::AbstractArray)
-Base.similar(::Any, ::Tuple)
-Base.eye
-Base.linspace
-Base.logspace
-Base.Random.randsubseq
-Base.Random.randsubseq!
 ```
 
 ## Broadcast and vectorization

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -39,7 +39,7 @@ Fully implemented by:
   * `UnitRange`
   * `Tuple`
   * `Number`
-  * `AbstractArray`
+  * [`AbstractArray`](@ref)
   * [`IntSet`](@ref)
   * [`ObjectIdDict`](@ref)
   * [`Dict`](@ref)
@@ -63,7 +63,7 @@ Fully implemented by:
   * `UnitRange`
   * `Tuple`
   * `Number`
-  * `AbstractArray`
+  * [`AbstractArray`](@ref)
   * [`IntSet`](@ref)
   * [`ObjectIdDict`](@ref)
   * [`Dict`](@ref)
@@ -145,7 +145,7 @@ Fully implemented by:
 
   * [`Array`](@ref)
   * [`BitArray`](@ref)
-  * `AbstractArray`
+  * [`AbstractArray`](@ref)
   * `SubArray`
   * [`ObjectIdDict`](@ref)
   * [`Dict`](@ref)


### PR DESCRIPTION
Follow up on #22052

I also moved `Constructors` to the top, I think it makes sense to have that before functions on arrays.