### PR TITLE
Refactor `LibGit2.set_remote_url`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,10 @@ Library improvements
 
   * The output of `versioninfo()` is now controlled with keyword arguments ([#21974]).
 
+  * The function `LibGit2.set_remote_url` now always sets both the fetch and push URLs for a
+    git repo. Additionally, the argument order was changed to be consistent with the git
+    command line tool ([#22062]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1403,6 +1403,20 @@ DEPRECATED: use @__MODULE__ instead
 end
 export current_module
 
+# PR #22062
+function LibGit2.set_remote_url(repo::LibGit2.GitRepo, url::AbstractString; remote::AbstractString="origin")
+    Base.depwarn(string(
+        "`LibGit2.set_remote_url(repo, url; remote=remote)` is deprecated, use ",
+        "`LibGit2.set_remote_url(repo, remote, url)` instead."), :set_remote_url)
+    LibGit2.set_remote_url(repo, remote, url)
+end
+function LibGit2.set_remote_url(path::AbstractString, url::AbstractString; remote::AbstractString="origin")
+    Base.depwarn(string(
+        "`LibGit2.set_remote_url(path, url; remote=remote)` is deprecated, use ",
+        "`LibGit2.set_remote_url(path, remote, url)` instead."), :set_remote_url)
+    LibGit2.set_remote_url(path, remote, url)
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -240,42 +240,6 @@ function is_ancestor_of(a::AbstractString, b::AbstractString, repo::GitRepo)
     merge_base(repo, a, b) == A
 end
 
-"""
-    set_remote_url(repo::GitRepo, url::AbstractString; remote::AbstractString="origin")
-
-Set the `url` for `remote` for the git repository `repo`.
-The default name of the remote is `"origin"`.
-
-# Examples
-
-```julia
-repo_path = joinpath("test_directory", "Example")
-repo = LibGit2.init(repo_path)
-url1 = "https://github.com/JuliaLang/Example.jl"
-LibGit2.set_remote_url(repo, url1, remote="upstream")
-url2 = "https://github.com/JuliaLang/Example2.jl"
-LibGit2.set_remote_url(repo_path, url2, remote="upstream2")
-```
-"""
-function set_remote_url(repo::GitRepo, url::AbstractString; remote::AbstractString="origin")
-    with(GitConfig, repo) do cfg
-        set!(cfg, "remote.$remote.url", url)
-        set!(cfg, "remote.$remote.pushurl", url)
-    end
-end
-
-"""
-    set_remote_url(path::AbstractString, url::AbstractString; remote::AbstractString="origin")
-
-Set the `url` for `remote` for the git repository located at `path`.
-The default name of the remote is `"origin"`.
-"""
-function set_remote_url(path::AbstractString, url::AbstractString; remote::AbstractString="origin")
-    with(GitRepo, path) do repo
-        set_remote_url(repo, url, remote=remote)
-    end
-end
-
 function make_payload(payload::Nullable{<:AbstractCredentials})
     Ref{Nullable{AbstractCredentials}}(payload)
 end

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -260,14 +260,7 @@ LibGit2.set_remote_url(repo_path, url2, remote="upstream2")
 function set_remote_url(repo::GitRepo, url::AbstractString; remote::AbstractString="origin")
     with(GitConfig, repo) do cfg
         set!(cfg, "remote.$remote.url", url)
-
-        m = match(GITHUB_REGEX,url)
-        if m !== nothing
-            push = "git@github.com:$(m.captures[1]).git"
-            if push != url
-                set!(cfg, "remote.$remote.pushurl", push)
-            end
-        end
+        set!(cfg, "remote.$remote.pushurl", url)
     end
 end
 

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -74,23 +74,34 @@ end
 """
     url(rmt::GitRemote)
 
-Get the URL of a remote git repository.
+Get the fetch URL of a remote git repository.
 
 # Example
 
 ```julia-repl
 julia> repo_url = "https://github.com/JuliaLang/Example.jl";
 
-julia> repo = LibGit2.clone(cache_repo, "test_directory");
+julia> repo = LibGit2.init(mktempdir());
 
 julia> remote = LibGit2.GitRemote(repo, "origin", repo_url);
 
-julia> url(remote)
+julia> LibGit2.url(remote)
 "https://github.com/JuliaLang/Example.jl"
 ```
 """
 function url(rmt::GitRemote)
     url_ptr = ccall((:git_remote_url, :libgit2), Cstring, (Ptr{Void},), rmt.ptr)
+    url_ptr == C_NULL && return ""
+    return unsafe_string(url_ptr)
+end
+
+"""
+    push_url(rmt::GitRemote)
+
+Get the push URL of a remote git repository.
+"""
+function push_url(rmt::GitRemote)
+    url_ptr = ccall((:git_remote_pushurl, :libgit2), Cstring, (Ptr{Void},), rmt.ptr)
     url_ptr == C_NULL && return ""
     return unsafe_string(url_ptr)
 end

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -57,7 +57,7 @@ function prefetch(pkg::AbstractString, url::AbstractString, sha1s::Vector)
         end
     end
     try
-        LibGit2.set_remote_url(repo, normalized_url)
+        LibGit2.set_remote_url(repo, "origin", normalized_url)
         in_cache = BitArray(map(sha1->LibGit2.iscommit(sha1, repo), sha1s))
         if !all(in_cache)
             info("Updating cache of $pkg...")

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -43,7 +43,7 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
     metadata_dir = joinpath(dir, "METADATA")
     if isdir(metadata_dir)
         info("Package directory $dir is already initialized.")
-        LibGit2.set_remote_url(metadata_dir, meta)
+        LibGit2.set_remote_url(metadata_dir, "origin", meta)
         return
     end
     local temp_dir = ""
@@ -53,7 +53,7 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
         Base.cd(temp_dir) do
             info("Cloning METADATA from $meta")
             with(LibGit2.clone(meta, "METADATA", branch = branch)) do metadata_repo
-                LibGit2.set_remote_url(metadata_repo, meta)
+                LibGit2.set_remote_url(metadata_repo, "origin", meta)
             end
             touch("REQUIRE")
             touch("META_BRANCH")

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -193,7 +193,7 @@ function clone(url::AbstractString, pkg::AbstractString)
     ispath(pkg) && throw(PkgError("$pkg already exists"))
     try
         LibGit2.with(LibGit2.clone(url, pkg)) do repo
-            LibGit2.set_remote_url(repo, url)
+            LibGit2.set_remote_url(repo, "origin", url)
         end
     catch err
         isdir(pkg) && Base.rm(pkg, recursive=true)

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -27,7 +27,7 @@ function fetch(repo::GitRepo, pkg::AbstractString, sha1::AbstractString)
 end
 
 function checkout(repo::GitRepo, pkg::AbstractString, sha1::AbstractString)
-    LibGit2.set_remote_url(repo, Cache.normalize_url(Read.url(pkg)))
+    LibGit2.set_remote_url(repo, "origin", Cache.normalize_url(Read.url(pkg)))
     LibGit2.checkout!(repo, sha1)
 end
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -252,16 +252,21 @@ mktempdir() do dir
 
                 remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
                 @test LibGit2.url(remote) == repo_url
+                @test LibGit2.push_url(remote) == ""
                 @test LibGit2.name(remote) == "upstream"
                 @test isa(remote, LibGit2.GitRemote)
                 @test sprint(show, remote) == "GitRemote:\nRemote name: upstream url: $repo_url"
                 @test LibGit2.isattached(repo)
                 LibGit2.set_remote_url(repo, "", remote="upstream")
                 remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
+                @test LibGit2.url(remote) == ""
+                @test LibGit2.push_url(remote) == ""
                 @test sprint(show, remote) == "GitRemote:\nRemote name: upstream url: "
                 close(remote)
                 LibGit2.set_remote_url(cache_repo, repo_url, remote="upstream")
                 remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
+                @test LibGit2.url(remote) == repo_url
+                @test LibGit2.push_url(remote) == repo_url
                 @test sprint(show, remote) == "GitRemote:\nRemote name: upstream url: $repo_url"
                 LibGit2.add_fetch!(repo, remote, "upstream")
                 @test LibGit2.fetch_refspecs(remote) == String["+refs/heads/*:refs/remotes/upstream/*"]
@@ -278,6 +283,7 @@ mktempdir() do dir
 
                 remote = LibGit2.GitRemoteAnon(repo, repo_url)
                 @test LibGit2.url(remote) == repo_url
+                @test LibGit2.push_url(remote) == ""
                 @test LibGit2.name(remote) == ""
                 @test isa(remote, LibGit2.GitRemote)
                 close(remote)


### PR DESCRIPTION
Added new functions `set_remote_fetch_url` and `set_remote_push_url` which allow you to specify the fetch/push remote URLs independently. Additionally, I switched `set_remote_url` from using a the keyword remote to using an optional argument.

Fixes https://github.com/JuliaLang/julia/issues/21773

