### PR TITLE
WIP: add Base.isfusing function to allow containers to disable fusion

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -6,10 +6,13 @@ using Base.Cartesian
 using Base: linearindices, tail, OneTo, to_shape,
             _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache,
             nullable_returntype, null_safe_op, hasvalue, isoperator
-import Base: broadcast, broadcast!
-export broadcast_getindex, broadcast_setindex!, dotview, @__dot__
+import Base: broadcast, broadcast!, @_pure_meta
+export broadcast_getindex, broadcast_setindex!, dotview, @__dot__, isfusing
 
 const ScalarType = Union{Type{Any}, Type{Nullable}}
+
+# containers can override isfusing to disable broadcast fusion for specific container types
+isfusing(args...) = (@_pure_meta; true)
 
 ## Broadcasting utilities ##
 # fallbacks for some special cases

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -312,7 +312,7 @@ end
 
 # make sure scalars are inlined, which causes f.(x,scalar) to lower to a "thunk"
 import Base.Meta: isexpr
-@test isexpr(expand(:(f.(x,y))), :call)
+@test isexpr(expand(:(f.(x,y))), :body)
 @test isexpr(expand(:(f.(x,1))), :thunk)
 @test isexpr(expand(:(f.(x,1.0))), :thunk)
 @test isexpr(expand(:(f.(x,$π))), :thunk)


### PR DESCRIPTION
This adds a `Base.isfusing(x...) = true` function that container types can override to disable broadcast fusion, as discussed in #22060.

To do:

- [ ] memo-ize `broadcast` arguments so that they are only evaluated once (currently, they are evaluated twice: once to call `isfusing`, and once for `broadcast` itself).
- [ ] make `isfusing` like `promote_type`: callers should only have to define `isfusing(::MyType, x) = false`
- [ ] Tests
- [ ] Documentation