### PR TITLE
Document number types

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    Complex{T<:Real}
+    Complex{T<:Real} <: Number
 
 Complex number type with real and imaginary part of type `T`.
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1,5 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    Complex{T<:Real}
+
+Complex number type with real and imaginary part of type `T`.
+
+`Complex32`, `Complex64` and `Complex128` are aliases for
+`Complex{Float16}`, `Complex{Float32}` and `Complex{Float64}` respectively.
+"""
 struct Complex{T<:Real} <: Number
     re::T
     im::T

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -229,7 +229,7 @@ julia> Float32(1/3, RoundUp)
 
 See [`RoundingMode`](@ref) for available rounding modes.
 """
-Float32
+Float32(x)
 
 """
     Mmap.mmap(io::Union{IOStream,AbstractString,Mmap.AnonymousMmap}[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
@@ -814,7 +814,7 @@ julia> Float64(pi, RoundUp)
 
 See [`RoundingMode`](@ref) for available rounding modes.
 """
-Float64
+Float64(x)
 
 """
     union(s1,s2...)
@@ -1430,18 +1430,6 @@ The function call grew beyond the size of the call stack. This usually happens w
 recurses infinitely.
 """
 StackOverflowError
-
-"""
-    BigInt(x)
-
-Create an arbitrary precision integer. `x` may be an `Int` (or anything that can be
-converted to an `Int`).  The usual mathematical operators are defined for this type, and
-results are promoted to a `BigInt`.
-
-Instances can be constructed from strings via [`parse`](@ref), or using the `big`
-string literal.
-"""
-BigInt
 
 """
     ==(x, y)
@@ -2414,3 +2402,81 @@ seekend
 Integer division was attempted with a denominator value of 0.
 """
 DivideError
+
+"""
+    Number
+
+Abstract supertype for all number types.
+"""
+Number
+
+"""
+    Real
+
+Abstract supertype for all real numbers.
+"""
+Real
+
+"""
+    AbstractFloat
+
+Abstract supertype for all floating point numbers.
+"""
+AbstractFloat
+
+"""
+    Integer
+
+Abstract supertype for all integers.
+"""
+Integer
+
+"""
+    Signed
+
+Abstract supertype for all signed integers.
+"""
+Signed
+
+"""
+    Unsigned
+
+Abstract supertype for all unsigned integers.
+"""
+Unsigned
+
+"""
+    Bool
+
+Boolean type.
+"""
+Bool
+
+for bit in (16, 32, 64)
+    @eval begin
+        """
+            Float$($bit)
+
+        $($bit)-bit floating point number type.
+        """
+        $(Symbol("Float", bit))
+    end
+end
+
+for bit in (8, 16, 32, 64, 128)
+    @eval begin
+        """
+            Int$($bit)
+
+        $($bit)-bit signed integer type.
+        """
+        $(Symbol("Int", bit))
+
+        """
+            UInt$($bit)
+
+        $($bit)-bit unsigned integer type.
+        """
+        $(Symbol("UInt", bit))
+    end
+end

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2411,42 +2411,42 @@ Abstract supertype for all number types.
 Number
 
 """
-    Real
+    Real <: Number
 
 Abstract supertype for all real numbers.
 """
 Real
 
 """
-    AbstractFloat
+    AbstractFloat <: Real
 
 Abstract supertype for all floating point numbers.
 """
 AbstractFloat
 
 """
-    Integer
+    Integer <: Real
 
 Abstract supertype for all integers.
 """
 Integer
 
 """
-    Signed
+    Signed <: Integer
 
 Abstract supertype for all signed integers.
 """
 Signed
 
 """
-    Unsigned
+    Unsigned <: Integer
 
 Abstract supertype for all unsigned integers.
 """
 Unsigned
 
 """
-    Bool
+    Bool <: Integer
 
 Boolean type.
 """
@@ -2455,7 +2455,7 @@ Bool
 for bit in (16, 32, 64)
     @eval begin
         """
-            Float$($bit)
+            Float$($bit) <: AbstractFloat
 
         $($bit)-bit floating point number type.
         """
@@ -2466,14 +2466,14 @@ end
 for bit in (8, 16, 32, 64, 128)
     @eval begin
         """
-            Int$($bit)
+            Int$($bit) <: Signed
 
         $($bit)-bit signed integer type.
         """
         $(Symbol("Int", bit))
 
         """
-            UInt$($bit)
+            UInt$($bit) <: Unsigned
 
         $($bit)-bit unsigned integer type.
         """

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -38,7 +38,7 @@ else
 end
 
 """
-    BigInt
+    BigInt <: Integer
 
 Arbitrary precision integer type.
 """

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -37,7 +37,11 @@ else
     error("GMP: cannot determine the type mp_limb_t (__gmp_bits_per_limb == $GMP_BITS_PER_LIMB)")
 end
 
+"""
+    BigInt
 
+Arbitrary precision integer type.
+"""
 mutable struct BigInt <: Integer
     alloc::Cint
     size::Cint
@@ -49,6 +53,26 @@ mutable struct BigInt <: Integer
         return b
     end
 end
+
+"""
+    BigInt(x)
+
+Create an arbitrary precision integer. `x` may be an `Int` (or anything that can be
+converted to an `Int`).  The usual mathematical operators are defined for this type, and
+results are promoted to a `BigInt`.
+
+Instances can be constructed from strings via [`parse`](@ref), or using the `big`
+string literal.
+
+```jldoctest
+julia> parse(BigInt, "42")
+42
+
+julia> big"313"
+313
+```
+"""
+BigInt(x)
 
 function __init__()
     try

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -5,7 +5,7 @@
 """
     Irrational <: Real
 
-Abstract supertype for irrational numbers.
+Irrational number type.
 """
 struct Irrational{sym} <: Real end
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -2,6 +2,11 @@
 
 ## general machinery for irrational mathematical constants
 
+"""
+    Irrational
+
+Abstract supertype for irrational numbers.
+"""
 struct Irrational{sym} <: Real end
 
 show(io::IO, x::Irrational{sym}) where {sym} = print(io, "$sym = $(string(float(x))[1:15])...")

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -156,7 +156,7 @@ julia> pi
 π = 3.1415926535897...
 ```
 """
-const pi = π
+π, const pi = π
 
 """
     e
@@ -169,7 +169,7 @@ julia> e
 e = 2.7182818284590...
 ```
 """
-const eu = e
+e, const eu = e
 
 """
     γ
@@ -182,7 +182,7 @@ julia> eulergamma
 γ = 0.5772156649015...
 ```
 """
-const eulergamma = γ
+γ, const eulergamma = γ
 
 """
     φ
@@ -195,7 +195,7 @@ julia> golden
 φ = 1.6180339887498...
 ```
 """
-const golden = φ
+φ, const golden = φ
 
 """
     catalan

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -3,7 +3,7 @@
 ## general machinery for irrational mathematical constants
 
 """
-    Irrational
+    Irrational <: Real
 
 Abstract supertype for irrational numbers.
 """

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -43,7 +43,7 @@ const DEFAULT_PRECISION = [256]
 # Basic type and initialization definitions
 
 """
-    BigFloat
+    BigFloat <: AbstractFloat
 
 Arbitrary precision floating point number type.
 """

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -43,23 +43,9 @@ const DEFAULT_PRECISION = [256]
 # Basic type and initialization definitions
 
 """
-    BigFloat(x)
+    BigFloat
 
-Create an arbitrary precision floating point number. `x` may be an `Integer`, a `Float64` or
-a `BigInt`. The usual mathematical operators are defined for this type, and results are
-promoted to a `BigFloat`.
-
-Note that because decimal literals are converted to floating point numbers when parsed,
-`BigFloat(2.1)` may not yield what you expect. You may instead prefer to initialize
-constants from strings via [`parse`](@ref), or using the `big` string literal.
-
-```jldoctest
-julia> BigFloat(2.1)
-2.100000000000000088817841970012523233890533447265625000000000000000000000000000
-
-julia> big"2.1"
-2.099999999999999999999999999999999999999999999999999999999999999999999999999986
-```
+Arbitrary precision floating point number type.
 """
 mutable struct BigFloat <: AbstractFloat
     prec::Clong
@@ -80,6 +66,27 @@ mutable struct BigFloat <: AbstractFloat
         new(prec, sign, exp, d)
     end
 end
+
+"""
+    BigFloat(x)
+
+Create an arbitrary precision floating point number. `x` may be an `Integer`, a `Float64` or
+a `BigInt`. The usual mathematical operators are defined for this type, and results are
+promoted to a `BigFloat`.
+
+Note that because decimal literals are converted to floating point numbers when parsed,
+`BigFloat(2.1)` may not yield what you expect. You may instead prefer to initialize
+constants from strings via [`parse`](@ref), or using the `big` string literal.
+
+```jldoctest
+julia> BigFloat(2.1)
+2.100000000000000088817841970012523233890533447265625000000000000000000000000000
+
+julia> big"2.1"
+2.099999999999999999999999999999999999999999999999999999999999999999999999999986
+```
+"""
+BigFloat(x)
 
 widen(::Type{Float64}) = BigFloat
 widen(::Type{BigFloat}) = BigFloat

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -1,5 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    Rational{T<:Integer}
+
+Rational number type, with numerator and denominator of type `T`.
+"""
 struct Rational{T<:Integer} <: Real
     num::T
     den::T

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    Rational{T<:Integer}
+    Rational{T<:Integer} <: Real
 
 Rational number type, with numerator and denominator of type `T`.
 """

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -11,7 +11,6 @@ Core.AbstractFloat
 Core.Integer
 Core.Signed
 Core.Unsigned
-Base.Irrational
 ```
 
 ### Concrete number types
@@ -35,6 +34,7 @@ Core.UInt128
 Base.BigInt
 Base.Complex
 Base.Rational
+Base.Irrational
 ```
 
 ## Data Formats

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -2,22 +2,40 @@
 
 ## Standard Numeric Types
 
-  * `Bool`
-  * `Int8`
-  * `UInt8`
-  * `Int16`
-  * `UInt16`
-  * `Int32`
-  * `UInt32`
-  * `Int64`
-  * `UInt64`
-  * `Int128`
-  * `UInt128`
-  * `Float16`
-  * `Float32`
-  * `Float64`
-  * `Complex64`
-  * `Complex128`
+### Abstract number types
+
+```@docs
+Core.Number
+Core.Real
+Core.AbstractFloat
+Core.Integer
+Core.Signed
+Core.Unsigned
+Base.Irrational
+```
+
+### Concrete number types
+
+```@docs
+Core.Float16
+Core.Float32
+Core.Float64
+Base.BigFloat
+Core.Bool
+Core.Int8
+Core.UInt8
+Core.Int16
+Core.UInt16
+Core.Int32
+Core.UInt32
+Core.Int64
+Core.UInt64
+Core.Int128
+Core.UInt128
+Base.BigInt
+Base.Complex
+Base.Rational
+```
 
 ## Data Formats
 
@@ -73,10 +91,10 @@ Base.nextfloat
 Base.prevfloat
 Base.isinteger
 Base.isreal
-Core.Float32
-Core.Float64
-Base.GMP.BigInt
-Base.MPFR.BigFloat
+Core.Float32(::Any)
+Core.Float64(::Any)
+Base.GMP.BigInt(::Any)
+Base.MPFR.BigFloat(::Any)
 Base.Rounding.rounding
 Base.Rounding.setrounding(::Type, ::Any)
 Base.Rounding.setrounding(::Function, ::Type, ::RoundingMode)


### PR DESCRIPTION
Original reason for this was to fix #21489 but decided to document all the types, and replace [this very underwhelming list](https://docs.julialang.org/en/latest/stdlib/numbers.html#Standard-Numeric-Types-1) with actual docstrings.

Attached the docstrings to `π`, `e`, `γ` and `φ` also (previously only `pi`, `eu`, `eulergamma` and `golden` had the docstring)