### PR TITLE
special show for AbstractVector{Method} for ::MIMEtext/plain

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -289,7 +289,16 @@ end
 
 show(io::IO, mime::MIME"text/html", mt::MethodTable) = show(io, mime, MethodList(mt))
 
-# pretty-printing of Vector{Method} for output of methodswith:
+# pretty-printing of AbstractVector{Method} for output of methodswith:
+function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
+    resize!(LAST_SHOWN_LINE_INFOS, 0)
+    for (i, m) in enumerate(mt)
+        print(io, "[$(i)] ")
+        show(io, m)
+        println(io)
+        push!(LAST_SHOWN_LINE_INFOS, (string(m.file), m.line))
+    end
+end
 
 function show(io::IO, mime::MIME"text/html", mt::AbstractVector{Method})
     print(io, summary(mt))


### PR DESCRIPTION
This is currently done for "text/html" do generate links to the methods. The REPL equivalent to links is #22007, so this enables that to be used with `methodswith(Foo)` along with `methods(foo)`.

This also prevents large spacing in the printing, since the general vector output prints with equal spacing for all elements (?), and some methods have very long signatures (try for instance `methodswith(SparseMatrixCSC)`)