### PR TITLE
no paragraph tags when list is tight

### DIFF
--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -61,7 +61,7 @@ function github_table(stream::IO, md::MD)
     end
 end
 
-function html(io::IO, md::Table)
+function html(io::IO, md::Table, parent = nothing)
     withtag(io, :table) do
         for (i, row) in enumerate(md.rows)
             withtag(io, :tr) do
@@ -102,7 +102,7 @@ _dash(width, align) =
     align == :c ? ":" * "-"^width * ":" :
     throw(ArgumentError("Invalid alignment $align"))
 
-function plain(io::IO, md::Table)
+function plain(io::IO, md::Table, parent = nothing)
     cells = mapmap(md.rows) do each
         replace(plaininline(each), "|", "\\|")
     end
@@ -119,7 +119,7 @@ function plain(io::IO, md::Table)
     end
 end
 
-function rst(io::IO, md::Table)
+function rst(io::IO, md::Table, parent = nothing)
     cells = mapmap(rstinline, md.rows)
     padcells!(cells, md.align, len = length, min = 3)
     single = ["-"^length(c) for c in cells[1]]
@@ -137,7 +137,7 @@ function rst(io::IO, md::Table)
     end
 end
 
-function term(io::IO, md::Table, columns)
+function term(io::IO, md::Table, columns, parent = nothing)
     cells = mapmap(terminline, md.rows)
     padcells!(cells, md.align, len = ansi_length)
     for i = 1:length(cells)
@@ -150,7 +150,7 @@ function term(io::IO, md::Table, columns)
     end
 end
 
-function latex(io::IO, md::Table)
+function latex(io::IO, md::Table, parent = nothing)
     wrapblock(io, "tabular") do
         align = md.align
         println(io, "{$(join(align, " | "))}")

--- a/base/markdown/IPython/IPython.jl
+++ b/base/markdown/IPython/IPython.jl
@@ -25,11 +25,11 @@ end
 show(io::IO, tex::LaTeX) =
     print(io, '$', tex.formula, '$')
 
-latex(io::IO, tex::LaTeX) =
+latex(io::IO, tex::LaTeX, parent = nothing) =
     println(io, "\$\$", tex.formula, "\$\$")
 
 latexinline(io::IO, tex::LaTeX) =
     print(io, '$', tex.formula, '$')
 
-term(io::IO, tex::LaTeX, cols) = println_with_format(:magenta, io, tex.formula)
+term(io::IO, tex::LaTeX, cols, parent = nothing) = println_with_format(:magenta, io, tex.formula)
 terminline(io::IO, tex::LaTeX) = print_with_format(:magenta, io, tex.formula)

--- a/base/markdown/render/html.jl
+++ b/base/markdown/render/html.jl
@@ -76,8 +76,12 @@ function html(io::IO, code::Code)
 end
 
 function html(io::IO, md::Paragraph)
-    withtag(io, :p) do
+    if md.intightlist
         htmlinline(io, md.content)
+    else
+        withtag(io, :p) do
+            htmlinline(io, md.content)
+        end
     end
 end
 

--- a/base/markdown/render/latex.jl
+++ b/base/markdown/render/latex.jl
@@ -46,8 +46,8 @@ function latexinline(io::IO, code::Code)
 end
 
 function latex(io::IO, md::Paragraph)
-    for md in md.content
-        latexinline(io, md)
+    for content in md.content
+        latexinline(io, content)
     end
     println(io)
     println(io)

--- a/base/markdown/render/terminal/formatting.jl
+++ b/base/markdown/render/terminal/formatting.jl
@@ -81,11 +81,11 @@ end
 wrapped_lines(f::Function, args...; width = 80, i = 0) =
     wrapped_lines(sprint(f, args...), width = width, i = 0)
 
-function print_wrapped(io::IO, s...; width = 80, pre = "", i = 0)
+function print_wrapped(io::IO, s...; width = 80, pre = "", i = 0, newline = true)
     lines = wrapped_lines(s..., width = width, i = i)
-    println(io, lines[1])
+    print(io, lines[1], newline ? "\n" : "")
     for line in lines[2:end]
-        println(io, pre, line)
+        print(io, pre, line, newline ? "\n" : "")
     end
     length(lines), length(pre) + ansi_length(lines[end])
 end

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -2,7 +2,7 @@
 
 include("formatting.jl")
 
-const margin = 2
+const MARGIN = 2
 cols(io) = displaysize(io)[2]
 
 function term(io::IO, content::Vector, cols)
@@ -17,8 +17,8 @@ end
 term(io::IO, md::MD, columns = cols(io)) = term(io, md.content, columns)
 
 function term(io::IO, md::Paragraph, columns)
-    print(io, " "^margin)
-    print_wrapped(io, width = columns-2margin, pre = " "^margin) do io
+    print(io, " "^MARGIN)
+    print_wrapped(io, width = columns-2MARGIN, pre = " "^MARGIN, newline = !md.intightlist) do io
         terminline(io, md.content)
     end
 end
@@ -26,35 +26,35 @@ end
 function term(io::IO, md::BlockQuote, columns)
     s = sprint(term, md.content, columns - 10)
     for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "|", line)
+        println(io, " "^MARGIN, "|", line)
     end
 end
 
 function term(io::IO, md::Admonition, columns)
-    print(io, " "^margin, "| ")
+    print(io, " "^MARGIN, "| ")
     with_output_format(:bold, print, io, isempty(md.title) ? md.category : md.title)
-    println(io, "\n", " "^margin, "|")
+    println(io, "\n", " "^MARGIN, "|")
     s = sprint(term, md.content, columns - 10)
     for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "|", line)
+        println(io, " "^MARGIN, "|", line)
     end
 end
 
 function term(io::IO, f::Footnote, columns)
-    print(io, " "^margin, "| ")
+    print(io, " "^MARGIN, "| ")
     with_output_format(:bold, print, io, "[^$(f.id)]")
-    println(io, "\n", " "^margin, "|")
+    println(io, "\n", " "^MARGIN, "|")
     s = sprint(term, f.text, columns - 10)
     for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "|", line)
+        println(io, " "^MARGIN, "|", line)
     end
 end
 
 function term(io::IO, md::List, columns)
     for (i, point) in enumerate(md.items)
-        print(io, " "^2margin, isordered(md) ? "$(i + md.ordered - 1). " : "•  ")
-        print_wrapped(io, width = columns-(4margin+2), pre = " "^(2margin+2),
-                          i = 2margin+2) do io
+        print(io, " "^2MARGIN, isordered(md) ? "$(i + md.ordered - 1). " : "•  ")
+        print_wrapped(io, width = columns-(4MARGIN+2), pre = " "^(2MARGIN+2),
+                          i = 2MARGIN+2) do io
             term(io, point, columns - 10)
         end
     end
@@ -63,14 +63,14 @@ end
 function _term_header(io::IO, md, char, columns)
     text = terminline(md.text)
     with_output_format(:bold, io) do io
-        print(io, " "^(2margin), " ")
+        print(io, " "^(2MARGIN), " ")
         line_no, lastline_width = print_wrapped(io, text,
-                                                width=columns - 4margin; pre=" ")
+                                                width=columns - 4MARGIN; pre=" ")
         line_width = min(1 + lastline_width, columns)
         if line_no > 1
             line_width = max(line_width, div(columns, 3))
         end
-        char != ' ' && println(io, " "^(2margin), string(char) ^ line_width)
+        char != ' ' && println(io, " "^(2MARGIN), string(char) ^ line_width)
     end
 end
 
@@ -85,7 +85,7 @@ end
 function term(io::IO, md::Code, columns)
     with_output_format(:cyan, io) do io
         for line in lines(md.code)
-            print(io, " "^margin)
+            print(io, " "^MARGIN)
             println(io, line)
         end
     end
@@ -96,7 +96,7 @@ function term(io::IO, br::LineBreak, columns)
 end
 
 function term(io::IO, br::HorizontalRule, columns)
-   println(io, " " ^ margin, "-" ^ (columns - 2margin))
+   println(io, " " ^ MARGIN, "-" ^ (columns - 2MARGIN))
 end
 
 term(io::IO, x, _) = show(io, MIME"text/plain"(), x)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -247,8 +247,8 @@ end
 @test md"###### h6" |> html == "<h6>h6</h6>\n"
 @test md"####### h7" |> html == "<p>####### h7</p>\n"
 @test md"   >" |> html == "<blockquote>\n</blockquote>\n"
-@test md"1. Hello" |> html == "<ol>\n<li><p>Hello</p>\n</li>\n</ol>\n"
-@test md"* World" |> html == "<ul>\n<li><p>World</p>\n</li>\n</ul>\n"
+@test md"1. Hello" |> html == "<ol>\n<li>Hello\n</li>\n</ol>\n"
+@test md"* World" |> html == "<ul>\n<li>World\n</li>\n</ul>\n"
 @test md"# title *blah*" |> html == "<h1>title <em>blah</em></h1>\n"
 @test md"## title *blah*" |> html == "<h2>title <em>blah</em></h2>\n"
 @test md"<https://julialang.org>" |> html == """<p><a href="https://julialang.org">https://julialang.org</a></p>\n"""
@@ -326,9 +326,9 @@ let out =
     <h2>Section <em>important</em></h2>
     <p>Some <strong>bolded</strong></p>
     <ul>
-    <li><p>list1</p>
+    <li>list1
     </li>
-    <li><p>list2</p>
+    <li>list2
     </li>
     </ul>
     </div>"""
@@ -922,7 +922,7 @@ let text =
             </li>
             </ol>
             <ul>
-            <li><p>one</p>
+            <li>one
             </li>
             </ul>
             <p>two</p>
@@ -938,11 +938,11 @@ let text =
             </li>
             </ul>
             <ol>
-            <li><p>foo</p>
+            <li>foo
             </li>
-            <li><p>bar</p>
+            <li>bar
             </li>
-            <li><p>baz</p>
+            <li>baz
             </li>
             </ol>
             """
@@ -1003,21 +1003,21 @@ let text =
     let expected =
             """
             <ol start="42">
-            <li><p>foo</p>
+            <li>foo
             </li>
-            <li><p>bar</p>
+            <li>bar
             </li>
             </ol>
             <ol>
-            <li><p>foo</p>
+            <li>foo
             </li>
-            <li><p>bar</p>
+            <li>bar
             </li>
             </ol>
             <ul>
-            <li><p>foo</p>
+            <li>foo
             </li>
-            <li><p>bar</p>
+            <li>bar
             </li>
             </ul>
             """


### PR DESCRIPTION
This and https://github.com/JuliaDocs/Documenter.jl/pull/493 should fix #21922 

I interpret CommonMarks:

> (The difference in HTML output is that paragraphs in a loose list are wrapped in <p> tags, while paragraphs in a tight list are not.)

as that it is the rendering of the paragraphs that should be changed based on the context (in a tight list or not). Easiest way to get that context to the Paragraph-writer was through an extra field.