### PR TITLE
Fix bash on windows build and add instructions

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -516,14 +516,14 @@ ifeq ($(LLVM_USE_CMAKE),1)
 $(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_SRC_DIR)/source-extracted | $(llvm_python_workaround) $(LIBCXX_DEPENDENCY)
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-		export PATH=$(llvm_python_workaround):$$PATH && \
+		export PATH=$(llvm_python_workaround):"$$PATH" && \
 		$(CMAKE) $(LLVM_SRC_DIR) $(CMAKE_GENERATOR_COMMAND) $(CMAKE_COMMON) $(LLVM_CMAKE) \
 		|| { echo '*** To install a newer version of cmake, run contrib/download_cmake.sh ***' && false; }
 	echo 1 > $@
 
 $(LLVM_BUILDDIR_withtype)/build-compiled: $(LLVM_BUILDDIR_withtype)/build-configured | $(llvm_python_workaround)
 	cd $(LLVM_BUILDDIR_withtype) && \
-		export PATH=$(llvm_python_workaround):$$PATH && \
+		export PATH=$(llvm_python_workaround):"$$PATH" && \
 		$(if $(filter $(CMAKE_GENERATOR),make), \
 		  $(MAKE), \
 		  $(CMAKE) --build .)
@@ -534,13 +534,13 @@ else
 $(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_SRC_DIR)/source-extracted | $(llvm_python_workaround) $(LIBCXX_DEPENDENCY)
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-		export PATH=$(llvm_python_workaround):$$PATH && \
+		export PATH=$(llvm_python_workaround):"$$PATH" && \
 		$(LLVM_SRC_DIR)/configure $(CONFIGURE_COMMON) $(LLVM_FLAGS)
 	echo 1 > $@
 
 $(LLVM_BUILDDIR_withtype)/build-compiled: $(LLVM_BUILDDIR_withtype)/build-configured | $(llvm_python_workaround)
 	cd $(LLVM_BUILDDIR_withtype) && \
-		export PATH=$(llvm_python_workaround):$$PATH && \
+		export PATH=$(llvm_python_workaround):"$$PATH" && \
 		$(MAKE) $(LLVM_MFLAGS) $(MAKE_COMMON)
 	echo 1 > $@
 
@@ -549,7 +549,7 @@ endif # LLVM_USE_CMAKE
 $(LLVM_BUILDDIR_withtype)/build-checked: $(LLVM_BUILDDIR_withtype)/build-compiled | $(llvm_python_workaround)
 ifeq ($(OS),$(BUILD_OS))
 	cd $(LLVM_BUILDDIR_withtype) && \
-		export PATH=$(llvm_python_workaround):$$PATH && \
+		export PATH=$(llvm_python_workaround):"$$PATH" && \
 		$(if $(filter $(LLVM_USE_CMAKE),1), \
 		  $(CMAKE) --build . --target check, \
 		  $(MAKE) $(LLVM_MFLAGS) check)


### PR DESCRIPTION
For a smooth build of Julia in bash on windows `$$PATH` needs to be in quotes as windows paths with spaces are in the path.
Simple instructions were also added to help users wanting to build Julia in bash on windows. Some dependencies like python 2.7 are not by default installed.
