### PR TITLE
Assign PROGRAM_FILE earlier

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,10 @@ This section lists changes that do not have deprecation warnings.
     of the socket. Previously the address of the remote endpoint was being
     returned ([#21825]).
 
+  * Using `ARGS` within the ~/.juliarc.jl or within a .jl file loaded with `--load` will no
+    longer contain the script name as the first argument. Instead the script name will be
+    assigned to `PROGRAM_FILE`. ([#22092])
+
 Library improvements
 --------------------
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -257,6 +257,11 @@ function process_options(opts::JLOptions)
     color_set             = (opts.color != 0)
     global have_color     = (opts.color == 1)
     global is_interactive = (opts.isinteractive != 0)
+
+    # remove filename from ARGS
+    arg_is_program = opts.eval == C_NULL && opts.print == C_NULL && !isempty(ARGS)
+    global const PROGRAM_FILE = arg_is_program ? shift!(ARGS) : ""
+
     while true
         # startup worker.
         # opts.startupfile, opts.load, etc should should not be processed for workers.
@@ -296,11 +301,9 @@ function process_options(opts::JLOptions)
             break
         end
         # load file
-        if !isempty(ARGS) && !isempty(ARGS[1])
+        if !isempty(PROGRAM_FILE)
             # program
             repl = false
-            # remove filename from ARGS
-            global PROGRAM_FILE = shift!(ARGS)
             if !is_interactive
                 ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
             end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -9,7 +9,7 @@ A string containing the script name passed to Julia from the command line. Note 
 script name remains unchanged from within included files. Alternatively see
 [`@__FILE__`](@ref).
 """
-PROGRAM_FILE = ""
+:PROGRAM_FILE
 
 """
     ARGS

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -293,23 +293,24 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
             """)
         cp(b, c)
 
-        @test split(readchomp(`$exename $a`), '\n') ==
-            [a, a,
-             b, a]
-        @test split(readchomp(`$exename -L $b -e 'exit(0)'`), '\n') ==
-            [realpath(b), ""]
-        @test split(readchomp(`$exename -L $b $a`), '\n') ==
-            [realpath(b), a,
-             a, a,
-             b, a]
+        readsplit(cmd) = split(readchomp(cmd), '\n')
 
         withenv((is_windows() ? "USERPROFILE" : "HOME") => dir) do
-            @test split(readchomp(`$exename --startup-file=yes -e 'exit(0)'`), '\n') ==
+            @test readsplit(`$exename $a`) ==
+                [a, a,
+                 b, a]
+            @test readsplit(`$exename -L $b -e 'exit(0)'`) ==
+                [realpath(b), ""]
+            @test readsplit(`$exename -L $b $a`) ==
+                [realpath(b), a,
+                 a, a,
+                 b, a]
+            @test readsplit(`$exename --startup-file=yes -e 'exit(0)'`) ==
                 [c, ""]
-            @test split(readchomp(`$exename --startup-file=yes -L $b -e 'exit(0)'`), '\n') ==
+            @test readsplit(`$exename --startup-file=yes -L $b -e 'exit(0)'`) ==
                 [c, "",
                  realpath(b), ""]
-            @test split(readchomp(`$exename --startup-file=yes -L $b $a`), '\n') ==
+            @test readsplit(`$exename --startup-file=yes -L $b $a`) ==
                 [c, a,
                  realpath(b), a,
                  a, a,

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -264,7 +264,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
             @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar --baz`) ==
                 "String[\"foo\", \"-bar\", \"--baz\"]"
             @test split(readchomp(`$exename -L $testfile $testfile`), '\n') ==
-                ["String[\"$(escape(testfile))\"]", "String[]"]
+                ["String[]", "String[]"]
             @test !success(`$exename --foo $testfile`)
             @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar -- baz`) == "String[\"foo\", \"-bar\", \"--\", \"baz\"]"
         finally
@@ -273,6 +273,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     end
 
     # test the script name
+    # TODO: Add tests to make sure PROGRAM_FILE is available within the `.juliarc.jl`
     let a = tempname(), b = tempname()
         try
             write(a, """
@@ -291,7 +292,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
             @test split(readchomp(`$exename -L $b -e 'exit(0)'`), '\n') ==
                 ["$(realpath(b))", "", "0"]
             @test split(readchomp(`$exename -L $b $a`), '\n') ==
-                ["$(realpath(b))", "", "1", "$a", "$a", "0", "$b", "$a", "0"]
+                ["$(realpath(b))", "$a", "0", "$a", "$a", "0", "$b", "$a", "0"]
         finally
             rm(a)
             rm(b)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -248,16 +248,13 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     # tested in test/parallel.jl, test/examples.jl)
     @test !success(`$exename --worker=true`)
 
-    escape(str) = replace(str, "\\", "\\\\")
-
     # test passing arguments
     let testfile = tempname()
         try
             # write a julia source file that just prints ARGS to STDOUT
             write(testfile, """
                 println(ARGS)
-                """
-            )
+                """)
             @test readchomp(`$exename $testfile foo -bar --baz`) ==
                 "String[\"foo\", \"-bar\", \"--baz\"]"
             @test readchomp(`$exename $testfile -- foo -bar --baz`) ==
@@ -282,14 +279,12 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
         write(a, """
             println(@__FILE__)
             println(PROGRAM_FILE)
-            include(\"$(escape(b))\")
-            """
-        )
+            include(\"$(escape_string(b))\")
+            """)
         write(b, """
             println(@__FILE__)
             println(PROGRAM_FILE)
-            """
-        )
+            """)
         cp(b, c)
 
         @test split(readchomp(`$exename $a`), '\n') ==

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -302,7 +302,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
              a, a,
              b, a]
 
-        withenv("HOME" => dir) do
+        withenv((is_windows() ? "USERPROFILE" : "HOME") => dir) do
             @test split(readchomp(`$exename --startup-file=yes -e 'exit(0)'`), '\n') ==
                 [c, ""]
             @test split(readchomp(`$exename --startup-file=yes -L $b -e 'exit(0)'`), '\n') ==


### PR DESCRIPTION
I discovered a use case where it would be nice to be able to access `PROGRAM_FILE` while within the .juliarc.jl. The global variable is now assigned and available within `--load` file or the .juliarc.jl.

Additionally, `PROGRAM_FILE` is now a constant.

Follow up to https://github.com/JuliaLang/julia/pull/14114