### PR TITLE
printf.jl: add missing import of GMP

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Printf
-using Base.Grisu
+using Base: Grisu, GMP
 export @printf, @sprintf
 
 ### printf formatter generation ###

--- a/test/printf.jl
+++ b/test/printf.jl
@@ -25,8 +25,9 @@ for (fmt, val) in (("%i", "42"),
                    ("%f", "42.000000"),
                    ("%g", "42")),
      num in (UInt16(42), UInt32(42), UInt64(42), UInt128(42),
-              Int16(42), Int32(42), Int64(42), Int128(42))
+              Int16(42), Int32(42), Int64(42), Int128(42), big"42")
             #big"42" causes stack overflow on %a ; gh #14409
+    num isa BigInt && fmt in ["%a", "%#o", "%g"] && continue
     @test @eval(@sprintf($fmt, $num) == $val)
 end
 


### PR DESCRIPTION
As [reported](https://discourse.julialang.org/t/printf-is-broken-with-bigint-on-master/3952) by @ScottPJones  (thanks!), I broke `@printf("%d", big(1))` in #21654. 
