### PR TITLE
Send cookie via stdin to the workers.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,9 @@ This section lists changes that do not have deprecation warnings.
     longer contain the script name as the first argument. Instead the script name will be
     assigned to `PROGRAM_FILE`. ([#22092])
 
+  * The format for a `ClusterManager` specifying the cookie on the command line is now
+    `--worker=<cookie>`. `--worker <cookie>` will not work as it is now an optional argument.
+
 Library improvements
 --------------------
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -265,8 +265,13 @@ function process_options(opts::JLOptions)
     while true
         # startup worker.
         # opts.startupfile, opts.load, etc should should not be processed for workers.
-        if opts.worker != C_NULL
-            start_worker(unsafe_string(opts.worker)) # does not return
+        if opts.worker == 1
+            # does not return
+            if opts.cookie != C_NULL
+                start_worker(unsafe_string(opts.cookie))
+            else
+                start_worker()
+            end
         end
 
         # add processors

--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -155,7 +155,7 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     if length(machine_bind) > 1
         exeflags = `--bind-to $(machine_bind[2]) $exeflags`
     end
-    exeflags = `$exeflags --worker $(cluster_cookie())`
+    exeflags = `$exeflags --worker`
 
     machine_def = split(machine_bind[1], ':')
     # if this machine def has a port number, add the port information to the ssh flags
@@ -192,16 +192,15 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     # -x → disable X11 forwarding
     # -o ClearAllForwardings → option if forwarding connections and
     #                          forwarded connections are causing collisions
-    # -n → Redirects stdin from /dev/null (actually, prevents reading from stdin).
-    #      Used when running ssh in the background.
-    cmd = `ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host $(Base.shell_escape(cmd))`
+    cmd = `ssh -T -a -x -o ClearAllForwardings=yes $sshflags $host $(Base.shell_escape(cmd))`
 
     # launch the remote Julia process
 
     # detach launches the command in a new process group, allowing it to outlive
     # the initial julia process (Ctrl-C and teardown methods are handled through messages)
     # for the launched processes.
-    io = open(detach(cmd))
+    io = open(detach(cmd), "r+")
+    write_cookie(io)
 
     wconfig = WorkerConfig()
     wconfig.io = io.out
@@ -320,8 +319,10 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
     bind_to = manager.restrict ? `127.0.0.1` : `$(LPROC.bind_addr)`
 
     for i in 1:manager.np
-        cmd = `$(julia_cmd(exename)) $exeflags --bind-to $bind_to --worker $(cluster_cookie())`
-        io = open(detach(setenv(cmd, dir=dir)))
+        cmd = `$(julia_cmd(exename)) $exeflags --bind-to $bind_to --worker`
+        io = open(detach(setenv(cmd, dir=dir)), "r+")
+        write_cookie(io)
+
         wconfig = WorkerConfig()
         wconfig.process = io
         wconfig.io = io.out

--- a/base/options.jl
+++ b/base/options.jl
@@ -26,7 +26,8 @@ struct JLOptions
     can_inline::Int8
     polly::Int8
     fast_math::Int8
-    worker::Ptr{UInt8}
+    worker::Int8
+    cookie::Ptr{UInt8}
     handle_signals::Int8
     use_precompiled::Int8
     use_compilecache::Int8

--- a/doc/src/stdlib/parallel.md
+++ b/doc/src/stdlib/parallel.md
@@ -150,7 +150,8 @@ and transport messages between processes. It is possible for Cluster Managers to
 Base.launch
 Base.manage
 Base.kill(::ClusterManager, ::Int, ::WorkerConfig)
-Base.init_worker
 Base.connect(::ClusterManager, ::Int, ::WorkerConfig)
+Base.init_worker
+Base.start_worker
 Base.process_messages
 ```

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -62,6 +62,7 @@ jl_options_t jl_options = { 0,    // quiet
                             JL_OPTIONS_POLLY_ON, // polly
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
+                            NULL, // cookie
                             JL_OPTIONS_HANDLE_SIGNALS_ON,
                             JL_OPTIONS_USE_PRECOMPILED_YES,
                             JL_OPTIONS_USE_COMPILECACHE_YES,
@@ -199,7 +200,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "math-mode",       required_argument, 0, opt_math_mode },
         { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
-        { "worker",          required_argument, 0, opt_worker },
+        { "worker",          optional_argument, 0, opt_worker },
         { "bind-to",         required_argument, 0, opt_bind_to },
         { "lisp",            no_argument,       0, 1 },
         { 0, 0, 0, 0 }
@@ -497,7 +498,8 @@ restart_switch:
                 jl_errorf("julia: invalid argument to --math-mode (%s)", optarg);
             break;
         case opt_worker:
-            jl_options.worker = strdup(optarg);
+            jl_options.worker = 1;
+            if (optarg != NULL) jl_options.cookie = strdup(optarg);
             break;
         case opt_bind_to:
             jl_options.bindto = strdup(optarg);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1730,7 +1730,8 @@ typedef struct {
     int8_t can_inline;
     int8_t polly;
     int8_t fast_math;
-    const char *worker;
+    int8_t worker;
+    const char *cookie;
     int8_t handle_signals;
     int8_t use_precompiled;
     int8_t use_compilecache;

--- a/test/show.jl
+++ b/test/show.jl
@@ -417,12 +417,19 @@ let filename = tempname()
         end
     end
     @test ret == [2]
+
+    # STDIN is unavailable on the workers. Run test on master.
     @test contains(readstring(filename), "WARNING: hello")
-    ret = open(filename) do f
-        redirect_stdin(f) do
-            readline()
+    ret = eval(Main, quote
+        remotecall_fetch(1, $filename) do fname
+            open(fname) do f
+                redirect_stdin(f) do
+                    readline()
+                end
+            end
         end
-    end
+    end)
+
     @test contains(ret, "WARNING: hello")
     rm(filename)
 end

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -41,10 +41,12 @@ function Base.launch(manager::TopoTestManager, params::Dict, launched::Array, c:
     exename = params[:exename]
     exeflags = params[:exeflags]
 
-    cmd = `$exename $exeflags --bind-to 127.0.0.1 --worker $(Base.cluster_cookie())`
+    cmd = `$exename $exeflags --bind-to $(Base.Distributed.LPROC.bind_addr) --worker`
     cmd = pipeline(detach(setenv(cmd, dir=dir)))
     for i in 1:manager.np
-        io = open(cmd)
+        io = open(cmd, "r+")
+        Base.Distributed.write_cookie(io)
+
         wconfig = WorkerConfig()
         wconfig.process = io
         wconfig.io = io.out


### PR DESCRIPTION
Addresses #21949 

Cluster managers in Base, i.e., `LocalManager` and `SSHManager` pass the cookie via the worker's STDIN. `--worker` on the command line results in the worker trying to read the cookie from stdin. The current method of `--worker=<cookie>` continues to be supported. However since it is now an optional argument,  the `=` is required, i.e. `--worker <cookie>` will not work.