### PR TITLE
Fix broadcast_indices

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -45,12 +45,12 @@ promote_containertype(::Type{T}, ::Type{T}) where {T} = T
 ## Calculate the broadcast indices of the arguments, or error if incompatible
 # array inputs
 broadcast_indices() = ()
-broadcast_indices(A) = _broadcast_indices(containertype(A), A)
+broadcast_indices(A) = broadcast_indices(containertype(A), A)
 @inline broadcast_indices(A, B...) = broadcast_shape(broadcast_indices(A), broadcast_indices(B...))
-_broadcast_indices(::Type, A) = ()
-_broadcast_indices(::Type{Tuple}, A) = (OneTo(length(A)),)
-_broadcast_indices(::Type{Array}, A::Ref) = ()
-_broadcast_indices(::Type{Array}, A) = indices(A)
+broadcast_indices(::ScalarType, A) = ()
+broadcast_indices(::Type{Tuple}, A) = (OneTo(length(A)),)
+broadcast_indices(::Type{Array}, A::Ref) = ()
+broadcast_indices(::Type{Array}, A) = indices(A)
 
 # shape (i.e., tuple-of-indices) inputs
 broadcast_shape(shape::Tuple) = shape

--- a/base/sparse/higherorderfns.jl
+++ b/base/sparse/higherorderfns.jl
@@ -6,8 +6,7 @@ module HigherOrderFns
 # particularly map[!]/broadcast[!] for SparseVectors and SparseMatrixCSCs at present.
 import Base: map, map!, broadcast, broadcast!
 import Base.Broadcast: _containertype, promote_containertype,
-                       broadcast_indices, _broadcast_indices,
-                       broadcast_c, broadcast_c!
+                       broadcast_indices, broadcast_c, broadcast_c!
 
 using Base: front, tail, to_shape
 using ..SparseArrays: SparseVector, SparseMatrixCSC, AbstractSparseVector,
@@ -901,7 +900,7 @@ end
 # (10) broadcast[!] over combinations of broadcast scalars and sparse vectors/matrices
 
 # broadcast shape promotion for combinations of sparse arrays and other types
-_broadcast_indices(::Type{AbstractSparseArray}, A) = indices(A)
+broadcast_indices(::Type{AbstractSparseArray}, A) = indices(A)
 # broadcast container type promotion for combinations of sparse arrays and other types
 _containertype(::Type{<:SparseVecOrMat}) = AbstractSparseArray
 # combinations of sparse arrays with broadcast scalars should yield sparse arrays
@@ -985,7 +984,7 @@ struct PromoteToSparse end
 # broadcast containertype definitions for structured matrices
 StructuredMatrix = Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}
 _containertype(::Type{<:StructuredMatrix}) = PromoteToSparse
-_broadcast_indices(::Type{PromoteToSparse}, A) = indices(A)
+broadcast_indices(::Type{PromoteToSparse}, A) = indices(A)
 
 # combinations explicitly involving Tuples and PromoteToSparse collections
 # divert to the generic AbstractArray broadcast code


### PR DESCRIPTION
This fixes a regression introduced in 4f1b479d. `broadcast_indices()` needs to
be overloaded by packages for custom types, so it cannot be hidden under
`_broadcast_indices()`. Also, `::Type` is incorrect since the method only applies
to scalars.

Make the tests more complex to be closer to actual implementations in packages
so that regressions like this will be noticed in the future.

Fixes a bug in DataArrays: https://github.com/JuliaStats/DataArrays.jl/pull/259#issuecomment-304627359