### PR TITLE
fix base(b, big(0), 0) == "0"

### DIFF
--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -339,6 +339,12 @@ let padding = 4, low = big(4), high = big(2^20)
     @test hex(-high, padding) == "-100000"
 end
 
+# respect 0-padding on big(0)
+for f in (bin, oct, dec, hex)
+    @test f(big(0), 0) == ""
+end
+@test base(rand(2:62), big(0), 0) == ""
+
 @test isqrt(big(4)) == 2
 @test isqrt(big(5)) == 2
 


### PR DESCRIPTION
When `pad==0`, `base` should give `""` on input `big(0)`.
I merged the two versions `base(b, ::BigInt)` and `base(b, ::BigInt, pad)`. Without `pad`, it gets about 10% slower (so I could re-add the old version if requested), but the version with a pad is vastly faster (it gets faster when `pad` gets bigger).
Also I'm not sure: the buffer sent to libgmp must contain space for a final `'\0'`, do I need to handle that manually or `Sting` allocates automatically 1 byte for it?