### PR TITLE
inference: fix some cases of invalid age range updates

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -282,7 +282,7 @@ function get_type_call(expr::Expr)
         found ? push!(args, typ) : push!(args, Any)
     end
     # use _methods_by_ftype as the function is supplied as a type
-    world = typemax(UInt)
+    world = ccall(:jl_get_world_counter, UInt, ())
     mt = Base._methods_by_ftype(Tuple{ft, args...}, -1, world)
     length(mt) == 1 || return (Any, false)
     m = first(mt)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -5415,7 +5415,8 @@ end
 # especially try to make sure any recursive and leaf functions have concrete signatures,
 # since we won't be able to specialize & infer them at runtime
 
-let fs = Any[typeinf_ext, typeinf, typeinf_edge, occurs_outside_getfield, pure_eval_call]
+let fs = Any[typeinf_ext, typeinf, typeinf_edge, occurs_outside_getfield, pure_eval_call],
+    world = ccall(:jl_get_world_counter, UInt, ())
     for x in t_ffunc_val
         push!(fs, x[3])
     end
@@ -5434,7 +5435,7 @@ let fs = Any[typeinf_ext, typeinf, typeinf_edge, occurs_outside_getfield, pure_e
                     typ[i] = typ[i].ub
                 end
             end
-            typeinf_type(m[3], Tuple{typ...}, m[2], true, InferenceParams(typemax(UInt)))
+            typeinf_type(m[3], Tuple{typ...}, m[2], true, InferenceParams(world))
         end
     end
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -763,7 +763,6 @@ function func_for_method_checked(m::Method, types::ANY)
     return m
 end
 
-
 """
     code_typed(f, types; optimize=true)
 
@@ -778,7 +777,7 @@ function code_typed(f::ANY, types::ANY=Tuple; optimize=true)
     end
     types = to_tuple_type(types)
     asts = []
-    world = typemax(UInt)
+    world = ccall(:jl_get_world_counter, UInt, ())
     params = Core.Inference.InferenceParams(world)
     for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)
@@ -796,7 +795,7 @@ function return_types(f::ANY, types::ANY=Tuple)
     end
     types = to_tuple_type(types)
     rt = []
-    world = typemax(UInt)
+    world = ccall(:jl_get_world_counter, UInt, ())
     params = Core.Inference.InferenceParams(world)
     for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -838,3 +838,8 @@ f21771(::Val{U}) where {U} = Tuple{g21771(U)}
 
 # missing method should be inferred as Union{}, ref https://github.com/JuliaLang/julia/issues/20033#issuecomment-282228948
 @test Base.return_types(f -> f(1), (typeof((x::String) -> x),)) == Any[Union{}]
+
+# issue #21653
+# ensure that we don't try to resolve cycles using uncached edges
+f21653() = f21653()
+@test code_typed(f21653, Tuple{}, optimize=false)[1] isa Pair{CodeInfo, typeof(Union{})}


### PR DESCRIPTION
ref #21653

(backport is a bit different, so I've made a separate branch with a similar fix for the old inference aab78090ada753154e7b9901b140e6b12c9374b7)