### PR TITLE
make it easier to mark a new module as top

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,9 @@ Library improvements
     method can be opened in an editor by entering the corresponding number in the REPL
     and pressing `^Q` ([#22007]).
 
+  * A macro `Base.@topmodule` was added to make it easier to override key functions in packages ([#22147]).
+
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -349,6 +349,7 @@ include("stacktraces.jl")
 importall .StackTraces
 
 # misc useful functions & macros
+include("topmodule.jl")
 include("util.jl")
 
 # dense linear algebra

--- a/base/topmodule.jl
+++ b/base/topmodule.jl
@@ -1,0 +1,56 @@
+"""
+    @topmodule
+
+Place a call to `@Base.topmodule` as the _first_ statement in a module
+to permit overriding a "top" function later in that module.
+See `names(Base.TopModule)` for the set of names this will define.
+"""
+macro topmodule()
+    @noinline topmodule() = ccall(:jl_set_istopmod, Void, (Bool,), false)
+    return quote
+        $topmodule()
+        using Main.Base.TopModule
+    end
+end
+
+# this is a record of all functions that may get used by lowering in Expr(:top)
+# it must be kept in sync with julia-syntax.scm
+baremodule TopModule
+    import ..Base # keep name pollution down to an absolute minimum
+    macro from(mod, exports)
+        # reexport everything in `exports` from `mod`
+        getindex = Base.getindex
+        colon = Base.colon
+        Base.Meta.isexpr(exports, :export) || error("expected export expression")
+        # flatten a A.B.C expression into a list
+        modpath = Base.Vector{Symbol}()
+        while isa(mod, Expr)
+            p = mod.args[2]
+            (Base.Meta.isexpr(p, :quote) && isa(p.args[1], Symbol)) || error("expected quoted symbol")
+            Base.unshift!(modpath, p.args[1])
+            mod = mod.args[1]
+        end
+        isa(mod, Symbol) || error("expected symbol")
+        Base.unshift!(modpath, mod)
+        # make an import for each export
+        imports = Any[ Expr(:import, modpath..., exports.args[i]) for i = 1:Base.length(exports.args) ]
+        Base.push!(imports, exports)
+        # return the result
+        expr = Expr(:toplevel)
+        expr.args = imports
+        return expr
+    end
+
+    @from Base export
+        endof, trailingsize, size, length, isempty,
+        start, next, done, indexed_next,
+        error, kwerr, as_kwargs,
+        vector_any, append_any,
+        vect, hcat, typed_hcat, typed_vcat, string,
+        collect, product, Iterators#=.Filter=#, Generator, Flatten,
+        setindex!, # note: setindex! / getindex are usually not special
+        convert, ptr_arg_cconvert, cconvert, ptr_arg_unsafe_convert, unsafe_convert,
+        dotview, broadcast, broadcast!, identity,
+        literal_pow, Val,
+        !, +, -, *, >>, !=
+end

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2257,7 +2257,7 @@
    (lambda (e) (expand-forms `(call (top vect) ,@(cdr e))))
 
    'hcat
-   (lambda (e) (expand-forms `(call hcat ,.(map expand-forms (cdr e)))))
+   (lambda (e) (expand-forms `(call (top hcat) ,.(map expand-forms (cdr e)))))
 
    'vcat
    (lambda (e)

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,7 +35,7 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "distributed", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
-        "channels", "iostream"
+        "channels", "iostream", "topmodule"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")

--- a/test/topmodule.jl
+++ b/test/topmodule.jl
@@ -1,0 +1,23 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# this tests that Expr(:top) is resolved correctly
+
+module TestTop
+    string(x...) = Base.string("TestTop: ", x...)
+    module NewTop
+        Base.@topmodule
+        import ..string
+        hello(x) = "hello world \"$x\""
+        module Sub
+            hello(x) = "goodnight world \"$x\""
+        end
+    end
+    hello(x) = "bonjour world \"$x\""
+end
+
+hello(x) = "ciao world \"$x\""
+@test hello("user") == "ciao world \"user\""
+@test TestTop.hello("user") == "bonjour world \"user\""
+@test TestTop.NewTop.hello("user") == "TestTop: hello world \"user\""
+@test TestTop.NewTop.Sub.hello("user") == "TestTop: goodnight world \"user\""
+@test 25 < length(names(Base.TopModule)) < 75 # currently about 40


### PR DESCRIPTION
It's a bit hard to explain exactly what this does, but see the demonstration in the added tests for how this affects the `string` function.