### PR TITLE
prevent Docs.apropos from breaking on random interpolated stuff

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -414,6 +414,7 @@ Strip all Markdown markup from x, leaving the result in plain text. Used
 internally by apropos to make docstrings containing more than one markdown
 element searchable.
 """
+stripmd(x::ANY) = string(x) # for random objects interpolated into the docstring
 stripmd(x::AbstractString) = x  # base case
 stripmd(x::Void) = " "
 stripmd(x::Vector) = string(map(stripmd, x)...)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -34,6 +34,20 @@ macro macro_doctest() end
 
 @test (@doc @macro_doctest) !== nothing
 
+# test that random stuff interpolated into docstrings doesn't break search or other methods here
+doc"""
+break me:
+
+    code
+
+$:asymbol # a symbol
+$1 # a number
+$string # a function
+$$latex literal$$
+### header!
+"""
+function break_me_docs end
+
 # issue #11548
 
 module ModuleMacroDoc


### PR DESCRIPTION
problem noticed on the coverage build bots (e.g. https://build.julialang.org/builders/coverage_ubuntu14.04-x64/builds/296/steps/Run%20inlined%20tests/logs/stdio)