### PR TITLE
improve static_show of unparseable Symbols

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -493,6 +493,20 @@ struct recur_list {
 static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth);
 
 JL_DLLEXPORT int jl_id_start_char(uint32_t wc);
+JL_DLLEXPORT int jl_id_char(uint32_t wc);
+
+JL_DLLEXPORT int jl_is_identifier(char *str)
+{
+    size_t i = 0;
+    uint32_t wc = u8_nextchar(str, &i);
+    if (!jl_id_start_char(wc))
+        return 0;
+    while ((wc = u8_nextchar(str, &i)) != 0) {
+        if (!jl_id_char(wc))
+            return 0;
+    }
+    return 1;
+}
 
 // `v` might be pointing to a field inlined in a structure therefore
 // `jl_typeof(v)` may not be the same with `vt` and only `vt` should be
@@ -717,8 +731,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     }
     else if (vt == jl_sym_type) {
         char *sn = jl_symbol_name((jl_sym_t*)v);
-        // TODO check for valid identifier
-        int quoted = strchr(sn, '/') && strcmp(sn, "/") && strcmp(sn, "//") && strcmp(sn, "//=");
+        int quoted = !jl_is_identifier(sn) && jl_operator_precedence(sn) == 0;
         if (quoted)
             n += jl_printf(out, "Symbol(\"");
         else

--- a/test/show.jl
+++ b/test/show.jl
@@ -742,3 +742,25 @@ end
 
 @test sprint(Base.show_supertypes, Int64) == "Int64 <: Signed <: Integer <: Real <: Number <: Any"
 @test sprint(Base.show_supertypes, Vector{String}) == "Array{String,1} <: DenseArray{String,1} <: AbstractArray{String,1} <: Any"
+
+# static_show
+
+function static_shown(x)
+    p = Pipe()
+    Base.link_pipe(p; julia_only_read=true, julia_only_write=true)
+    ccall(:jl_static_show, Void, (Ptr{Void}, Any), p.in, x)
+    @async close(p.in)
+    return readstring(p.out)
+end
+
+# Test for PR 17803
+@test static_shown(Int128(-1)) == "Int128(0xffffffffffffffffffffffffffffffff)"
+
+# PR #22160
+@test static_shown(:aa) == ":aa"
+@test static_shown(:+) == ":+"
+@test static_shown(://) == "://"
+@test static_shown(://=) == "://="
+@test static_shown(Symbol("")) == "Symbol(\"\")"
+@test static_shown(Symbol("a/b")) == "Symbol(\"a/b\")"
+@test static_shown(Symbol("a-b")) == "Symbol(\"a-b\")"

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -448,14 +448,6 @@ if is_unix()
     end
 end
 
-# Test for PR 17803
-let p=Pipe()
-    Base.link_pipe(p; julia_only_read=true, julia_only_write=true)
-    ccall(:jl_static_show, Void, (Ptr{Void}, Any), p.in, Int128(-1))
-    @async close(p.in)
-    @test readstring(p.out) == "Int128(0xffffffffffffffffffffffffffffffff)"
-end
-
 # readlines(::Cmd), accidentally broken in #20203
 @test sort(readlines(`$lscmd -A`)) == sort(readdir())
 


### PR DESCRIPTION
Fixes symbol quoting logic in `static_show`.