### PR TITLE
Fix TLS variant def on AArch64

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -29,12 +29,10 @@ TODO:
 #  if defined(_CPU_X86_64_) || defined(_CPU_X86_)
 #    define JL_ELF_TLS_VARIANT 2
 #    define JL_ELF_TLS_INIT_SIZE 0
-#  endif
-#  if defined(_CPU_AARCH64_)
+#  elif defined(_CPU_AARCH64_)
 #    define JL_ELF_TLS_VARIANT 1
 #    define JL_ELF_TLS_INIT_SIZE 16
-#  endif
-#  if defined(__ARM_ARCH) && __ARM_ARCH >= 7
+#  elif defined(__ARM_ARCH) && __ARM_ARCH >= 7
 #    define JL_ELF_TLS_VARIANT 1
 #    define JL_ELF_TLS_INIT_SIZE 8
 #  endif


### PR DESCRIPTION
This doesn't do much harm other than raising a compiler warning due to macro redefinition. The wrong value shouldn't cause any issue in practice since it only make the check more permissive and the additional range it allows is theoretically impossible to happen since it'll mean the memory of our tls variable overlaps with internal libc data structure....

@jlbuild !filter=arm,aarch64
