### PR TITLE
fix at-[no]inline with short func. def with return type annotation

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -34,17 +34,8 @@ convert(::Type{Tuple{Vararg{T}}}, x::Tuple) where {T} = cnvt_all(T, x...)
 cnvt_all(T) = ()
 cnvt_all(T, x, rest...) = tuple(convert(T,x), cnvt_all(T, rest...)...)
 
-# test whether an assignment LHS is a function definition
-function eventually_call(ex)
-    isa(ex, Expr) && (ex.head === :call ||
-                      ((ex.head === :where || ex.head === :(::)) &&
-                       eventually_call(ex.args[1])))
-end
-
 macro generated(f)
-    isa(f, Expr) || error("invalid syntax; @generated must be used with a function definition")
-    if f.head === :function || (isdefined(:length) && f.head === :(=) && length(f.args) == 2 &&
-                                eventually_call(f.args[1]))
+    if isa(f, Expr) && (f.head === :function || is_short_function_def(f))
         f.head = :stagedfunction
         return Expr(:escape, f)
     else

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -240,7 +240,7 @@ function is_short_function_def(ex)
     ex.head == :(=) || return false
     while length(ex.args) >= 1 && isa(ex.args[1], Expr)
         (ex.args[1].head == :call) && return true
-        (ex.args[1].head == :where) || return false
+        (ex.args[1].head == :where || ex.args[1].head == :(::)) || return false
         ex = ex.args[1]
     end
     return false

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -111,3 +111,15 @@ end
 let a = read21311()
     @test a[] == 1
 end
+
+@testset "issue #19122: [no]inline of short func. def. with return type annotation" begin
+    exf19122 = macroexpand(:(@inline f19122()::Bool = true))
+    exg19122 = macroexpand(:(@noinline g19122()::Bool = true))
+    @test exf19122.args[2].args[1].args[1] == :inline
+    @test exg19122.args[2].args[1].args[1] == :noinline
+
+    @inline f19122()::Bool = true
+    @noinline g19122()::Bool = true
+    @test f19122()
+    @test g19122()
+end


### PR DESCRIPTION
fix #19122

will rebase after #22166 