### PR TITLE
RFC: Deprecate is_<os> functions in favor of is<os>

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -160,6 +160,11 @@ Deprecated or removed
   * `InexactError` now takes arguments: `InexactError(func::Symbol,
     type, -3)` now prints as `ERROR: InexactError: func(type, -3)`. ([#20005])
 
+  * The operating system identification functions: `is_linux`, `is_bsd`, `is_apple`, `is_unix`,
+    and `is_windows`, have been deprecated in favor of `Sys.islinux`, `Sys.isbsd`, `Sys.isapple`,
+    `Sys.isunix`, and `Sys.iswindows`, respectively ([#22182]).
+
+
 Julia v0.6.0 Release Notes
 ==========================
 
@@ -954,6 +959,7 @@ Command-line option changes
 [#22038]: https://github.com/JuliaLang/julia/issues/22038
 [#22062]: https://github.com/JuliaLang/julia/issues/22062
 [#22064]: https://github.com/JuliaLang/julia/issues/22064
+[#22182]: https://github.com/JuliaLang/julia/issues/22182
 [#22187]: https://github.com/JuliaLang/julia/issues/22187
 [#22188]: https://github.com/JuliaLang/julia/issues/22188
 [#22224]: https://github.com/JuliaLang/julia/issues/22224

--- a/base/c.jl
+++ b/base/c.jl
@@ -18,7 +18,8 @@ Equivalent to the native `char` c-type.
 """
 Cchar
 
-if is_windows()
+# The ccall here is equivalent to Sys.iswindows(), but that's not defined yet
+@static if ccall(:jl_get_UNAME, Any, ()) === :NT
     const Clong = Int32
     const Culong = UInt32
     const Cwchar_t = UInt16
@@ -49,7 +50,7 @@ Equivalent to the native `wchar_t` c-type ([`Int32`](@ref)).
 """
 Cwchar_t
 
-if !is_windows()
+@static if ccall(:jl_get_UNAME, Any, ()) !== :NT
     const sizeof_mode_t = ccall(:jl_sizeof_mode_t, Cint, ())
     if sizeof_mode_t == 2
         const Cmode_t = Int16
@@ -118,7 +119,7 @@ end
 # symbols are guaranteed not to contain embedded NUL
 convert(::Type{Cstring}, s::Symbol) = Cstring(unsafe_convert(Ptr{Cchar}, s))
 
-if is_windows()
+@static if ccall(:jl_get_UNAME, Any, ()) === :NT
 """
     Base.cwstring(s)
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -102,7 +102,7 @@ function repl_cmd(cmd, out)
                 end
                 cd(ENV["OLDPWD"])
             else
-                cd(@static is_windows() ? dir : readchomp(`$shell -c "echo $(shell_escape(dir))"`))
+                cd(@static Sys.iswindows() ? dir : readchomp(`$shell -c "echo $(shell_escape(dir))"`))
             end
         else
             cd()
@@ -110,7 +110,7 @@ function repl_cmd(cmd, out)
         ENV["OLDPWD"] = new_oldpwd
         println(out, pwd())
     else
-        run(ignorestatus(@static is_windows() ? cmd : (isa(STDIN, TTY) ? `$shell -i -c "$(shell_wrap_true(shell_name, cmd))"` : `$shell -c "$(shell_wrap_true(shell_name, cmd))"`)))
+        run(ignorestatus(@static Sys.iswindows() ? cmd : (isa(STDIN, TTY) ? `$shell -i -c "$(shell_wrap_true(shell_name, cmd))"` : `$shell -c "$(shell_wrap_true(shell_name, cmd))"`)))
     end
     nothing
 end
@@ -390,7 +390,7 @@ function _start()
                 global is_interactive |= !isa(STDIN, Union{File, IOStream})
                 color_set || (global have_color = false)
             else
-                term = Terminals.TTYTerminal(get(ENV, "TERM", @static is_windows() ? "" : "dumb"), STDIN, STDOUT, STDERR)
+                term = Terminals.TTYTerminal(get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb"), STDIN, STDOUT, STDERR)
                 global is_interactive = true
                 color_set || (global have_color = Terminals.hascolor(term))
                 quiet || REPL.banner(term,term)

--- a/base/dSFMT.jl
+++ b/base/dSFMT.jl
@@ -163,7 +163,7 @@ end
 
 ## Windows entropy
 
-if is_windows()
+if Sys.iswindows()
     function win32_SystemFunction036!(a::Array)
         ccall((:SystemFunction036, :Advapi32), stdcall, UInt8, (Ptr{Void}, UInt32), a, sizeof(a))
     end

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -120,7 +120,7 @@ readdlm_auto(input::IO, dlm::Char, T::Type, eol::Char, auto::Bool; opts...) =
     readdlm_string(readstring(input), dlm, T, eol, auto, val_opts(opts))
 function readdlm_auto(input::AbstractString, dlm::Char, T::Type, eol::Char, auto::Bool; opts...)
     optsd = val_opts(opts)
-    use_mmap = get(optsd, :use_mmap, is_windows() ? false : true)
+    use_mmap = get(optsd, :use_mmap, Sys.iswindows() ? false : true)
     fsz = filesize(input)
     if use_mmap && fsz > 0 && fsz < typemax(Int)
         a = open(input, "r") do f

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1570,6 +1570,13 @@ end
 # nfields(::Type) deprecation in builtins.c: update nfields tfunc in inference.jl when it is removed.
 # also replace `_nfields` with `nfields` in summarysize.c when this is removed.
 
+# PR #22182
+@deprecate is_apple   Sys.isapple
+@deprecate is_bsd     Sys.isbsd
+@deprecate is_linux   Sys.islinux
+@deprecate is_unix    Sys.isunix
+@deprecate is_windows Sys.iswindows
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -975,7 +975,7 @@ end
 function disable_nagle(sock)
     # disable nagle on all OSes
     ccall(:uv_tcp_nodelay, Cint, (Ptr{Void}, Cint), sock.handle, 1)
-    @static if is_linux()
+    @static if Sys.islinux()
         # tcp_quickack is a linux only option
         if ccall(:jl_tcp_quickack, Cint, (Ptr{Void}, Cint), sock.handle, 1) < 0
             warn_once("Networking unoptimized ( Error enabling TCP_QUICKACK : ", Libc.strerror(Libc.errno()), " )")

--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -460,7 +460,7 @@ function socket_reuse_port()
         s = TCPSocket(delay = false)
 
         # Some systems (e.g. Linux) require the port to be bound before setting REUSEPORT
-        bind_early = is_linux()
+        bind_early = Sys.islinux()
 
         bind_early && bind_client_port(s)
         rc = ccall(:jl_tcp_reuseport, Int32, (Ptr{Void},), s.handle)

--- a/base/env.jl
+++ b/base/env.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-if is_windows()
+if Sys.iswindows()
     const ERROR_ENVVAR_NOT_FOUND = UInt32(203)
 
     _getenvlen(var::Vector{UInt16}) = ccall(:GetEnvironmentVariableW,stdcall,UInt32,(Ptr{UInt16},Ptr{UInt16},UInt32),var,C_NULL,0)
@@ -84,7 +84,7 @@ delete!(::EnvHash, k::AbstractString) = (_unsetenv(k); ENV)
 setindex!(::EnvHash, v, k::AbstractString) = _setenv(k,string(v))
 push!(::EnvHash, k::AbstractString, v) = setindex!(ENV, v, k)
 
-if is_windows()
+if Sys.iswindows()
     start(hash::EnvHash) = (pos = ccall(:GetEnvironmentStringsW,stdcall,Ptr{UInt16},()); (pos,pos))
     function done(hash::EnvHash, block::Tuple{Ptr{UInt16},Ptr{UInt16}})
         if unsafe_load(block[1]) == 0

--- a/base/event.jl
+++ b/base/event.jl
@@ -247,7 +247,7 @@ function wait()
     # unreachable
 end
 
-if is_windows()
+if Sys.iswindows()
     pause() = ccall(:Sleep, stdcall, Void, (UInt32,), 0xffffffff)
 else
     pause() = ccall(:pause, Void, ())

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1258,14 +1258,6 @@ export
     @code_llvm,
     @code_native,
 
-    # platform-conditional code
-    @static,
-    is_windows,
-    is_linux,
-    is_apple,
-    is_bsd,
-    is_unix,
-
     # tasks
     @schedule,
     @sync,
@@ -1295,6 +1287,7 @@ export
     @goto,
     @view,
     @views,
+    @static,
 
 # SparseArrays module re-exports
     SparseArrays,

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -44,7 +44,7 @@ import Base:
     skip, stat, unsafe_read, unsafe_write, transcode, uv_error, uvhandle,
     uvtype, write
 
-if is_windows()
+if Sys.iswindows()
     import Base: cwstring
 end
 

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -50,7 +50,7 @@ const LOAD_CACHE_PATH = String[]
 function init_load_path()
     vers = "v$(VERSION.major).$(VERSION.minor)"
     if haskey(ENV, "JULIA_LOAD_PATH")
-        prepend!(LOAD_PATH, split(ENV["JULIA_LOAD_PATH"], @static is_windows() ? ';' : ':'))
+        prepend!(LOAD_PATH, split(ENV["JULIA_LOAD_PATH"], @static Sys.iswindows() ? ';' : ':'))
     end
     push!(LOAD_PATH, abspath(JULIA_HOME, "..", "local", "share", "julia", "site", vers))
     push!(LOAD_PATH, abspath(JULIA_HOME, "..", "share", "julia", "site", vers))

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -6,7 +6,7 @@ import Base: transcode
 
 export FILE, TmStruct, strftime, strptime, getpid, gethostname, free, malloc, calloc, realloc,
     errno, strerror, flush_cstdio, systemsleep, time, transcode
-if is_windows()
+if Sys.iswindows()
     export GetLastError, FormatMessage
 end
 
@@ -23,13 +23,13 @@ end
 
 Base.cconvert(::Type{Int32}, fd::RawFD) = fd.fd
 
-dup(x::RawFD) = RawFD(ccall((@static is_windows() ? :_dup : :dup), Int32, (Int32,), x.fd))
+dup(x::RawFD) = RawFD(ccall((@static Sys.iswindows() ? :_dup : :dup), Int32, (Int32,), x.fd))
 dup(src::RawFD, target::RawFD) = systemerror("dup", -1 ==
-    ccall((@static is_windows() ? :_dup2 : :dup2), Int32,
+    ccall((@static Sys.iswindows() ? :_dup2 : :dup2), Int32,
                 (Int32, Int32), src.fd, target.fd))
 
 # Wrapper for an OS file descriptor (for Windows)
-if is_windows()
+if Sys.iswindows()
     struct WindowsRawSocket
         handle::Ptr{Void}   # On Windows file descriptors are HANDLE's and 64-bit on 64-bit Windows
     end
@@ -67,7 +67,7 @@ modestr(s::IO) = modestr(isreadable(s), iswritable(s))
 modestr(r::Bool, w::Bool) = r ? (w ? "r+" : "r") : (w ? "w" : throw(ArgumentError("neither readable nor writable")))
 
 function FILE(fd::RawFD, mode)
-    FILEp = ccall((@static is_windows() ? :_fdopen : :fdopen), Ptr{Void}, (Cint, Cstring), fd, mode)
+    FILEp = ccall((@static Sys.iswindows() ? :_fdopen : :fdopen), Ptr{Void}, (Cint, Cstring), fd, mode)
     systemerror("fdopen", FILEp == C_NULL)
     FILE(FILEp)
 end
@@ -102,9 +102,9 @@ flush_cstdio() = ccall(:jl_flush_cstdio, Void, ())
 ## time-related functions ##
 
 # TODO: check for usleep errors?
-if is_unix()
+if Sys.isunix()
     systemsleep(s::Real) = ccall(:usleep, Int32, (UInt32,), round(UInt32, s*1e6))
-elseif is_windows()
+elseif Sys.iswindows()
     function systemsleep(s::Real)
         ccall(:Sleep, stdcall, Void, (UInt32,), round(UInt32, s * 1e3))
         return Int32(0)
@@ -202,7 +202,7 @@ function strptime(fmt::AbstractString, timestr::AbstractString)
         # TODO: better error message
         throw(ArgumentError("invalid arguments"))
     end
-    @static if is_apple()
+    @static if Sys.isapple()
         # if we didn't explicitly parse the weekday or year day, use mktime
         # to fill them in automatically.
         if !ismatch(r"([^%]|^)%(a|A|j|w|Ow)", fmt)
@@ -240,7 +240,7 @@ Get the local machine's host name.
 """
 function gethostname()
     hn = Vector{UInt8}(256)
-    err = @static if is_windows()
+    err = @static if Sys.iswindows()
         ccall(:gethostname, stdcall, Int32, (Ptr{UInt8}, UInt32), hn, length(hn))
     else
         ccall(:gethostname, Int32, (Ptr{UInt8}, UInt), hn, length(hn))
@@ -286,7 +286,7 @@ Convert a Win32 system call error code to a descriptive string [only available o
 """
 function FormatMessage end
 
-if is_windows()
+if Sys.iswindows()
     GetLastError() = ccall(:GetLastError, stdcall, UInt32, ())
 
     function FormatMessage(e=GetLastError())

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -109,7 +109,7 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
         else
             passdef = creds.pass # check if credentials were already used
             if passphrase_required && (isempty(passdef) || isusedcreds)
-                if is_windows()
+                if Sys.iswindows()
                     passdef = Base.winprompt(
                         "Your SSH Key requires a password, please enter it now:",
                         "Passphrase required", privatekey; prompt_username = false)
@@ -144,7 +144,7 @@ function authenticate_userpass(creds::UserPasswordCredentials, libgit2credptr::P
     if creds.prompt_if_incorrect
         username = creds.user
         userpass = creds.pass
-        if is_windows()
+        if Sys.iswindows()
             if isempty(username) || isempty(userpass) || isusedcreds
                 res = Base.winprompt("Please enter your credentials for '$schema$host'", "Credentials required",
                         isempty(username) ? urlusername : username; prompt_username = true)

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -891,7 +891,7 @@ function __init__()
 
     # Look for OpenSSL env variable for CA bundle (linux only)
     # windows and macOS use the OS native security backends
-    @static if is_linux()
+    @static if Sys.islinux()
         cert_loc = if "SSL_CERT_DIR" in keys(ENV)
             ENV["SSL_CERT_DIR"]
         elseif "SSL_CERT_FILE" in keys(ENV)

--- a/base/libgit2/repository.jl
+++ b/base/libgit2/repository.jl
@@ -19,7 +19,7 @@ Open a git repository at `path` with extended controls (for instance, if the cur
 user must be a member of a special access group to read `path`).
 """
 function GitRepoExt(path::AbstractString, flags::Cuint = Cuint(Consts.REPOSITORY_OPEN_DEFAULT))
-    separator = @static is_windows() ? ";" : ":"
+    separator = @static Sys.iswindows() ? ";" : ":"
     repo_ptr_ptr = Ref{Ptr{Void}}(C_NULL)
     @check ccall((:git_repository_open_ext, :libgit2), Cint,
                  (Ptr{Ptr{Void}}, Cstring, Cuint, Cstring),

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -32,7 +32,7 @@ reset(val::Integer, flag::Integer) = (val &= ~flag)
 toggle(val::Integer, flag::Integer) = (val |= flag)
 
 function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)
-    if is_windows() && password
+    if Sys.iswindows() && password
         error("Command line prompt not supported for password entry on windows. Use winprompt instead")
     end
     msg = !isempty(default) ? msg*" [$default]:" : msg*":"
@@ -60,8 +60,8 @@ end
 Standardise the path string `path` to use POSIX separators.
 """
 function posixpath end
-if is_windows()
+if Sys.iswindows()
     posixpath(path) = replace(path,'\\','/')
-else is_unix()
+else Sys.isunix()
     posixpath(path) = path
 end

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -105,7 +105,7 @@ function set_num_threads(n::Integer)
     end
 
     # OSX BLAS looks at an environment variable
-    @static if is_apple()
+    @static if Sys.isapple()
         ENV["VECLIB_MAXIMUM_THREADS"] = n
     end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -4,16 +4,16 @@
 
 # Cross-platform case-sensitive path canonicalization
 
-if is_unix() && !is_apple()
+if Sys.isunix() && !Sys.isapple()
     # assume case-sensitive filesystems, don't have to do anything
     isfile_casesensitive(path) = isfile(path)
-elseif is_windows()
+elseif Sys.iswindows()
     # GetLongPathName Win32 function returns the case-preserved filename on NTFS.
     function isfile_casesensitive(path)
         isfile(path) || return false  # Fail fast
         basename(Filesystem.longpath(path)) == basename(path)
     end
-elseif is_apple()
+elseif Sys.isapple()
     # HFS+ filesystem is case-preserving. The getattrlist API returns
     # a case-preserved filename. In the rare event that HFS+ is operating
     # in case-sensitive mode, this will still work but will be redundant.

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -194,7 +194,7 @@ function url(m::Method)
     file = string(m.file)
     line = m.line
     line <= 0 || ismatch(r"In\[[0-9]+\]", file) && return ""
-    is_windows() && (file = replace(file, '\\', '/'))
+    Sys.iswindows() && (file = replace(file, '\\', '/'))
     if inbase(M)
         if isempty(Base.GIT_VERSION_INFO.commit)
             # this url will only work if we're on a tagged release

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -2,7 +2,7 @@
 
 module Mmap
 
-const PAGESIZE = Int(is_unix() ? ccall(:jl_getpagesize, Clong, ()) : ccall(:jl_getallocationgranularity, Clong, ()))
+const PAGESIZE = Int(Sys.isunix() ? ccall(:jl_getpagesize, Clong, ()) : ccall(:jl_getallocationgranularity, Clong, ()))
 
 # for mmaps not backed by files
 mutable struct Anonymous <: IO
@@ -21,13 +21,13 @@ const INVALID_HANDLE_VALUE = -1
 gethandle(io::Anonymous) = INVALID_HANDLE_VALUE
 
 # platform-specific mmap utilities
-if is_unix()
+if Sys.isunix()
 
 const PROT_READ     = Cint(1)
 const PROT_WRITE    = Cint(2)
 const MAP_SHARED    = Cint(1)
 const MAP_PRIVATE   = Cint(2)
-const MAP_ANONYMOUS = Cint(is_bsd() ? 0x1000 : 0x20)
+const MAP_ANONYMOUS = Cint(Sys.isbsd() ? 0x1000 : 0x20)
 const F_GETFL       = Cint(3)
 
 gethandle(io::IO) = fd(io)
@@ -65,7 +65,7 @@ function grow!(io::IO, offset::Integer, len::Integer)
     return
 end
 
-elseif is_windows()
+elseif Sys.iswindows()
 
 const DWORD = Culong
 
@@ -116,7 +116,7 @@ function mmap(io::IO,
 
     file_desc = gethandle(io)
     # platform-specific mmapping
-    @static if is_unix()
+    @static if Sys.isunix()
         prot, flags, iswrite = settings(file_desc, shared)
         iswrite && grow && grow!(io, offset, len)
         # mmap the file
@@ -138,7 +138,7 @@ function mmap(io::IO,
     # convert mmapped region to Julia Array at `ptr + (offset - offset_page)` since file was mapped at offset_page
     A = unsafe_wrap(Array, convert(Ptr{T}, UInt(ptr) + UInt(offset - offset_page)), dims)
     finalizer(A, function(x)
-        @static if is_unix()
+        @static if Sys.isunix()
             systemerror("munmap",  ccall(:munmap, Cint, (Ptr{Void}, Int), ptr, mmaplen) != 0)
         else
             status = ccall(:UnmapViewOfFile, stdcall, Cint, (Ptr{Void},), ptr)!=0
@@ -207,7 +207,7 @@ const MS_SYNC = 4
 function sync!(m::Array{T}, flags::Integer=MS_SYNC) where T
     offset = rem(UInt(pointer(m)), PAGESIZE)
     ptr = pointer(m) - offset
-    @static if is_unix()
+    @static if Sys.isunix()
         systemerror("msync",
                     ccall(:msync, Cint, (Ptr{Void}, Csize_t, Cint), ptr, length(m) * sizeof(T), flags) != 0)
     else

--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -1,62 +1,15 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    is_unix([os])
-
-Predicate for testing if the OS provides a Unix-like interface.
-See documentation in [Handling Operating System Variation](@ref).
-"""
-function is_unix(os::Symbol)
-    if is_windows(os)
-        return false
-    elseif is_linux(os) || is_bsd(os)
-        return true
-    else
-        throw(ArgumentError("unknown operating system \"$os\""))
-    end
-end
-
-"""
-    is_linux([os])
-
-Predicate for testing if the OS is a derivative of Linux.
-See documentation in [Handling Operating System Variation](@ref).
-"""
-is_linux(os::Symbol) = (os == :Linux)
-
-"""
-    is_bsd([os])
-
-Predicate for testing if the OS is a derivative of BSD.
-See documentation in [Handling Operating System Variation](@ref).
-"""
-is_bsd(os::Symbol) = (os == :FreeBSD || os == :OpenBSD || os == :NetBSD || os == :DragonFly || os == :Darwin || os == :Apple)
-
-"""
-    is_windows([os])
-
-Predicate for testing if the OS is a derivative of Microsoft Windows NT.
-See documentation in [Handling Operating System Variation](@ref).
-"""
-is_windows(os::Symbol) = (os == :Windows || os == :NT)
-
-"""
-    is_apple([os])
-
-Predicate for testing if the OS is a derivative of Apple Macintosh OS X or Darwin.
-See documentation in [Handling Operating System Variation](@ref).
-"""
-is_apple(os::Symbol) = (os == :Apple || os == :Darwin)
-
-"""
     @static
 
-Partially evaluates an expression at parse time.
+Partially evaluate an expression at parse time.
 
-For example, `@static is_windows() ? foo : bar` will evaluate `is_windows()` and insert either `foo` or `bar` into the expression.
+For example, `@static Sys.iswindows() ? foo : bar` will evaluate `Sys.iswindows()` and insert
+either `foo` or `bar` into the expression.
 This is useful in cases where a construct would be invalid on other platforms,
 such as a `ccall` to a non-existent function.
-`@static if is_apple() foo end` and `@static foo <&&,||> bar` are also valid syntax.
+`@static if Sys.isapple() foo end` and `@static foo <&&,||> bar` are also valid syntax.
 """
 macro static(ex)
     if isa(ex, Expr)
@@ -74,14 +27,4 @@ macro static(ex)
         end
     end
     throw(ArgumentError("invalid @static macro"))
-end
-
-let KERNEL = ccall(:jl_get_UNAME, Any, ()),
-    __module__ = @__MODULE__
-    # evaluate the zero-argument form of each of these functions
-    # as a function returning a static constant based on the build-time
-    # operating-system kernel
-    for f in (:is_unix, :is_linux, :is_bsd, :is_apple, :is_windows)
-        @eval $f() = $(getfield(__module__, f)(KERNEL))
-    end
 end

--- a/base/path.jl
+++ b/base/path.jl
@@ -16,7 +16,7 @@ export
     splitdrive,
     splitext
 
-if is_unix()
+if Sys.isunix()
     const path_separator    = "/"
     const path_separator_re = r"/+"
     const path_directory_re = r"(?:^|/)\.{0,2}$"
@@ -24,7 +24,7 @@ if is_unix()
     const path_ext_splitter = r"^((?:.*/)?(?:\.|[^/\.])[^/]*?)(\.[^/\.]*|)$"
 
     splitdrive(path::String) = ("",path)
-elseif is_windows()
+elseif Sys.iswindows()
     const path_separator    = "\\"
     const path_separator_re = r"[/\\]+"
     const path_absolute_re  = r"^(?:\w+:)?[/\\]"
@@ -77,7 +77,7 @@ function homedir()
 end
 
 
-if is_windows()
+if Sys.iswindows()
     isabspath(path::String) = ismatch(path_absolute_re, path)
 else
     isabspath(path::String) = startswith(path, '/')
@@ -276,7 +276,7 @@ current directory if necessary. Equivalent to `abspath(joinpath(path, paths...))
 """
 abspath(a::AbstractString, b::AbstractString...) = abspath(joinpath(a,b...))
 
-if is_windows()
+if Sys.iswindows()
 function realpath(path::AbstractString)
     p = cwstring(path)
     buf = zeros(UInt16, length(p))
@@ -324,7 +324,7 @@ Canonicalize a path by expanding symbolic links and removing "." and ".." entrie
 realpath(path::AbstractString)
 
 
-if is_windows()
+if Sys.iswindows()
 expanduser(path::AbstractString) = path # on windows, ~ means "temporary file"
 else
 function expanduser(path::AbstractString)

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -18,7 +18,7 @@ function mkcachedir()
         return
     end
 
-    @static if is_unix()
+    @static if Sys.isunix()
         if Dir.isversioned(pwd())
             rootcache = joinpath(realpath(".."), ".cache")
             if !isdir(rootcache)

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -90,16 +90,16 @@ function parse(lines::Vector{Line})
         if isa(line,Requirement)
             if !isempty(line.system)
                 applies = false
-                if is_windows(); applies |=  ("windows"  in line.system); end
-                if is_unix();    applies |=  ("unix"     in line.system); end
-                if is_apple();   applies |=  ("osx"      in line.system); end
-                if is_linux();   applies |=  ("linux"    in line.system); end
-                if is_bsd();     applies |=  ("bsd"      in line.system); end
-                if is_windows(); applies &= !("!windows" in line.system); end
-                if is_unix();    applies &= !("!unix"    in line.system); end
-                if is_apple();   applies &= !("!osx"     in line.system); end
-                if is_linux();   applies &= !("!linux"   in line.system); end
-                if is_bsd();     applies &= !("!bsd"     in line.system); end
+                if Sys.iswindows(); applies |=  ("windows"  in line.system); end
+                if Sys.isunix();    applies |=  ("unix"     in line.system); end
+                if Sys.isapple();   applies |=  ("osx"      in line.system); end
+                if Sys.islinux();   applies |=  ("linux"    in line.system); end
+                if Sys.isbsd();     applies |=  ("bsd"      in line.system); end
+                if Sys.iswindows(); applies &= !("!windows" in line.system); end
+                if Sys.isunix();    applies &= !("!unix"    in line.system); end
+                if Sys.isapple();   applies &= !("!osx"     in line.system); end
+                if Sys.islinux();   applies &= !("!linux"   in line.system); end
+                if Sys.isbsd();     applies &= !("!bsd"     in line.system); end
                 applies || continue
             end
             reqs[line.package] = haskey(reqs, line.package) ?

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -82,8 +82,8 @@ VersionSet(versions::VersionNumber...) = VersionSet(VersionNumber[versions...])
 const empty_versionset = VersionSet(VersionInterval[])
 
 # Windows console doesn't like Unicode
-const _empty_symbol = @static is_windows() ? "empty" : "∅"
-const _union_symbol = @static is_windows() ? " or " : " ∪ "
+const _empty_symbol = @static Sys.iswindows() ? "empty" : "∅"
+const _union_symbol = @static Sys.iswindows() ? " or " : " ∪ "
 show(io::IO, s::VersionSet) = isempty(s) ? print(io, _empty_symbol) :
                                            join(io, s.intervals, _union_symbol)
 isempty(s::VersionSet) = all(isempty, s.intervals)

--- a/base/process.jl
+++ b/base/process.jl
@@ -136,7 +136,7 @@ struct FileRedirect
     filename::AbstractString
     append::Bool
     function FileRedirect(filename, append)
-        if lowercase(filename) == (@static is_windows() ? "nul" : "/dev/null")
+        if lowercase(filename) == (@static Sys.iswindows() ? "nul" : "/dev/null")
             warn_once("for portability use DevNull instead of a file redirect")
         end
         new(filename, append)

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -60,7 +60,7 @@ end
 
 # init with default values
 # Use a max size of 1M profile samples, and fire timer every 1ms
-if is_windows()
+if Sys.iswindows()
     __init__() = init(1_000_000, 0.01)
 else
     __init__() = init(1_000_000, 0.001)

--- a/base/random.jl
+++ b/base/random.jl
@@ -32,7 +32,7 @@ const BitIntegerType = Union{map(T->Type{T}, Base.BitInteger_types)...}
 const BoolBitIntegerType = Union{Type{Bool},BitIntegerType}
 const BoolBitIntegerArray = Union{Array{Bool},Base.BitIntegerArray}
 
-if is_windows()
+if Sys.iswindows()
     struct RandomDevice <: AbstractRNG
         buffer::Vector{UInt128}
 

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -201,7 +201,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
     write_prompt(termbuf, prompt)
     prompt = prompt_string(prompt)
     # Count the '\n' at the end of the line if the terminal emulator does (specific to DOS cmd prompt)
-    miscountnl = @static is_windows() ? (isa(Terminals.pipe_reader(terminal), Base.TTY) && !Base.ispty(Terminals.pipe_reader(terminal))) : false
+    miscountnl = @static Sys.iswindows() ? (isa(Terminals.pipe_reader(terminal), Base.TTY) && !Base.ispty(Terminals.pipe_reader(terminal))) : false
     lindent = strwidth(prompt)
 
     # Now go through the buffer line by line
@@ -1574,7 +1574,7 @@ function run_interface(terminal, m::ModalInterface)
     while !s.aborted
         buf, ok, suspend = prompt!(terminal, m, s)
         while suspend
-            @static if is_unix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
+            @static if Sys.isunix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
             buf, ok, suspend = prompt!(terminal, m, s)
         end
         eval(Main,
@@ -1626,7 +1626,7 @@ function prompt!(term, prompt, s = init_state(term, prompt))
             elseif state === :done
                 return buffer(s), true, false
             elseif state === :suspend
-                if is_unix()
+                if Sys.isunix()
                     return buffer(s), true, true
                 end
             else

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -101,7 +101,7 @@ function complete_keyword(s::String)
 end
 
 function complete_path(path::AbstractString, pos; use_envpath=false)
-    if Base.is_unix() && ismatch(r"^~(?:/|$)", path)
+    if Base.Sys.isunix() && ismatch(r"^~(?:/|$)", path)
         # if the path is just "~", don't consider the expanded username as a prefix
         if path == "~"
             dir, prefix = homedir(), ""
@@ -129,13 +129,13 @@ function complete_path(path::AbstractString, pos; use_envpath=false)
         if startswith(file, prefix)
             id = try isdir(joinpath(dir, file)) catch; false end
             # joinpath is not used because windows needs to complete with double-backslash
-            push!(matches, id ? file * (@static is_windows() ? "\\\\" : "/") : file)
+            push!(matches, id ? file * (@static Sys.iswindows() ? "\\\\" : "/") : file)
         end
     end
 
     if use_envpath && length(dir) == 0
         # Look for files in PATH as well
-        local pathdirs = split(ENV["PATH"], @static is_windows() ? ";" : ":")
+        local pathdirs = split(ENV["PATH"], @static Sys.iswindows() ? ";" : ":")
 
         for pathdir in pathdirs
             local actualpath

--- a/base/repl/Terminals.jl
+++ b/base/repl/Terminals.jl
@@ -120,7 +120,7 @@ cmove_line_up(t::UnixTerminal, n) = (cmove_up(t, n); cmove_col(t, 1))
 cmove_line_down(t::UnixTerminal, n) = (cmove_down(t, n); cmove_col(t, 1))
 cmove_col(t::UnixTerminal, n) = (write(t.out_stream, '\r'); n > 1 && cmove_right(t, n-1))
 
-if is_windows()
+if Sys.iswindows()
     function raw!(t::TTYTerminal,raw::Bool)
         check_open(t.in_stream)
         if Base.ispty(t.in_stream)
@@ -150,7 +150,7 @@ end
 
 Base.displaysize(t::UnixTerminal) = displaysize(t.out_stream)
 
-if is_windows()
+if Sys.iswindows()
     hascolor(t::TTYTerminal) = true
 else
     function hascolor(t::TTYTerminal)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -1110,7 +1110,7 @@ function deserialize(s::AbstractSerializer, t::Type{Regex})
     Regex(pattern, compile_options, match_options)
 end
 
-if !is_windows()
+if !Sys.iswindows()
     function serialize(s::AbstractSerializer, rd::RandomDevice)
         serialize_type(s, typeof(rd))
         serialize(s, rd.unlimited)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -579,9 +579,9 @@ end
 
 function print_shmem_limits(slen)
     try
-        if is_linux()
+        if Sys.islinux()
             pfx = "kernel"
-        elseif is_apple()
+        elseif Sys.isapple()
             pfx = "kern.sysv"
         elseif Sys.KERNEL == :FreeBSD || Sys.KERNEL == :DragonFly
             pfx = "kern.ipc"
@@ -633,7 +633,7 @@ end
 
 # platform-specific code
 
-if is_windows()
+if Sys.iswindows()
 function _shm_mmap_array(T, dims, shm_seg_name, mode)
     readonly = !((mode & JL_O_RDWR) == JL_O_RDWR)
     create = (mode & JL_O_CREAT) == JL_O_CREAT

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -875,9 +875,9 @@ function _sockname(sock, self=true)
     uv_error("cannot obtain socket name", r)
     if r == 0
         port = ntoh(rport[])
-        af_inet6 = @static if is_windows() # AF_INET6 in <sys/socket.h>
+        af_inet6 = @static if Sys.iswindows() # AF_INET6 in <sys/socket.h>
             23
-        elseif is_apple()
+        elseif Sys.isapple()
             30
         elseif Sys.KERNEL ∈ (:FreeBSD, :DragonFly)
             28

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 import .Libc: RawFD, dup
-if is_windows()
+if Sys.iswindows()
     import .Libc: WindowsRawSocket
 end
 
@@ -159,7 +159,7 @@ mutable struct TTY <: LibuvStream
     sendbuf::Nullable{IOBuffer}
     lock::ReentrantLock
     throttle::Int
-    @static if is_windows(); ispty::Bool; end
+    @static if Sys.iswindows(); ispty::Bool; end
     TTY() = TTY(Libc.malloc(_sizeof_uv_tty), StatusUninit)
     function TTY(handle::Ptr{Void}, status)
         tty = new(
@@ -172,7 +172,7 @@ mutable struct TTY <: LibuvStream
             DEFAULT_READ_BUFFER_SZ)
         associate_julia_struct(handle, tty)
         finalizer(tty, uvfinalize)
-        @static if is_windows()
+        @static if Sys.iswindows()
             tty.ispty = ccall(:jl_ispty, Cint, (Ptr{Void},), handle) != 0
         end
         return tty
@@ -343,7 +343,7 @@ function uvfinalize(uv::Union{LibuvStream, LibuvServer})
     nothing
 end
 
-if is_windows()
+if Sys.iswindows()
     ispty(s::TTY) = s.ispty
     ispty(s::IO) = false
 end
@@ -358,7 +358,7 @@ function displaysize(io::TTY)
     local h::Int, w::Int
     default_size = displaysize()
 
-    @static if is_windows()
+    @static if Sys.iswindows()
         if ispty(io)
             # io is actually a libuv pipe but a cygwin/msys2 pty
             try
@@ -676,7 +676,7 @@ function start_reading(stream::LibuvStream)
     end
 end
 
-if is_windows()
+if Sys.iswindows()
     # the low performance version of stop_reading is required
     # on Windows due to a NT kernel bug that we can't use a blocking
     # stream for non-blocking (overlapped) calls,
@@ -994,8 +994,8 @@ Connect to the named pipe / UNIX domain socket at `path`.
 """
 connect(path::AbstractString) = connect(init_pipe!(PipeEndpoint(); readable=false, writable=false, julia_only=true),path)
 
-const OS_HANDLE = is_windows() ? WindowsRawSocket : RawFD
-const INVALID_OS_HANDLE = is_windows() ? WindowsRawSocket(Ptr{Void}(-1)) : RawFD(-1)
+const OS_HANDLE = Sys.iswindows() ? WindowsRawSocket : RawFD
+const INVALID_OS_HANDLE = Sys.iswindows() ? WindowsRawSocket(Ptr{Void}(-1)) : RawFD(-1)
 _fd(x::IOStream) = RawFD(fd(x))
 function _fd(x::Union{LibuvStream, LibuvServer})
     fd = Ref{OS_HANDLE}(INVALID_OS_HANDLE)
@@ -1016,7 +1016,7 @@ for (x, writable, unix_fd, c_symbol) in
         function ($_f)(stream)
             global $x
             posix_fd = _fd(stream)
-            @static if is_windows()
+            @static if Sys.iswindows()
                 ccall(:SetStdHandle, stdcall, Int32, (Int32, Ptr{Void}),
                     $(-10 - unix_fd), Libc._get_osfhandle(posix_fd).handle)
             end

--- a/base/util.jl
+++ b/base/util.jl
@@ -619,9 +619,9 @@ end
 
 function julia_exename()
     if ccall(:jl_is_debugbuild, Cint, ()) == 0
-        return @static is_windows() ? "julia.exe" : "julia"
+        return @static Sys.iswindows() ? "julia.exe" : "julia"
     else
-        return @static is_windows() ? "julia-debug.exe" : "julia-debug"
+        return @static Sys.iswindows() ? "julia-debug.exe" : "julia-debug"
     end
 end
 
@@ -640,7 +640,7 @@ securezero!(s::String) = unsafe_securezero!(pointer(s), sizeof(s))
     ccall(:memset, Ptr{T}, (Ptr{T}, Cint, Csize_t), p, 0, len*sizeof(T))
 unsafe_securezero!(p::Ptr{Void}, len::Integer=1) = Ptr{Void}(unsafe_securezero!(Ptr{UInt8}(p), len))
 
-if is_windows()
+if Sys.iswindows()
 function getpass(prompt::AbstractString)
     print(prompt)
     flush(STDOUT)
@@ -673,7 +673,7 @@ getpass(prompt::AbstractString) = unsafe_string(ccall(:getpass, Cstring, (Cstrin
 end
 
 # Windows authentication prompt
-if is_windows()
+if Sys.iswindows()
     struct CREDUI_INFO
         cbSize::UInt32
         parent::Ptr{Void}

--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -5,7 +5,7 @@
 # userimg_path.  If sysimg_path.dlext is currently loaded into memory, don't continue
 # unless force is set to true.  Allow targeting of a CPU architecture via cpu_target.
 function default_sysimg_path(debug=false)
-    if is_unix()
+    if Sys.isunix()
         splitext(Libdl.dlpath(debug ? "sys-debug" : "sys"))[1]
     else
         joinpath(dirname(JULIA_HOME), "lib", "julia", debug ? "sys-debug" : "sys")
@@ -114,7 +114,7 @@ function find_system_compiler()
     end
 
     # On Windows, check to see if WinRPM is installed, and if so, see if gcc is installed
-    if is_windows()
+    if Sys.iswindows()
         try
             eval(Main, :(using WinRPM))
             winrpmgcc = joinpath(WinRPM.installdir, "usr", "$(Sys.ARCH)-w64-mingw32",
@@ -151,7 +151,7 @@ function link_sysimg(sysimg_path=nothing, cc=find_system_compiler(), debug=false
 
     push!(FLAGS, "-shared")
     push!(FLAGS, debug ? "-ljulia-debug" : "-ljulia")
-    if is_windows()
+    if Sys.iswindows()
         push!(FLAGS, "-lssp")
     end
 
@@ -159,7 +159,7 @@ function link_sysimg(sysimg_path=nothing, cc=find_system_compiler(), debug=false
     info("Linking sys.$(Libdl.dlext)")
     info("$cc $(join(FLAGS, ' ')) -o $sysimg_file $sysimg_path.o")
     # Windows has difficulties overwriting a file in use so we first link to a temp file
-    if is_windows() && isfile(sysimg_file)
+    if Sys.iswindows() && isfile(sysimg_file)
         if success(pipeline(`$cc $FLAGS -o $sysimg_path.tmp $sysimg_path.o`; stdout=STDOUT, stderr=STDERR))
             mv(sysimg_file, "$sysimg_file.old"; remove_destination=true)
             mv("$sysimg_path.tmp", sysimg_file; remove_destination=true)

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -35,9 +35,9 @@ end
 
 function ldflags()
     fl = "-L$(shell_escape(libDir()))"
-    if is_windows()
+    if Sys.iswindows()
         fl = fl * " -Wl,--stack,8388608"
-    elseif is_linux()
+    elseif Sys.islinux()
         fl = fl * " -Wl,--export-dynamic"
     end
     return fl
@@ -49,7 +49,7 @@ function ldlibs()
     else
         "julia"
     end
-    if is_unix()
+    if Sys.isunix()
         return "-Wl,-rpath,$(shell_escape(libDir())) -Wl,-rpath,$(shell_escape(private_libDir())) -l$libname"
     else
         return "-l$libname -lopenlibm"
@@ -64,7 +64,7 @@ function cflags()
     if threadingOn()
         print(flags, " -DJULIA_ENABLE_THREADING=1")
     end
-    if is_unix()
+    if Sys.isunix()
         print(flags, " -fPIC")
     end
     return String(take!(flags))

--- a/doc/src/manual/handling-operating-system-variation.md
+++ b/doc/src/manual/handling-operating-system-variation.md
@@ -2,38 +2,38 @@
 
 When dealing with platform libraries, it is often necessary to provide special cases for various
 platforms. The variable `Sys.KERNEL` can be used to write these special cases. There are several
-functions intended to make this easier: `is_unix`, `is_linux`, `is_apple`, `is_bsd`, and `is_windows`.
-These may be used as follows:
+functions in the `Sys` module intended to make this easier: `isunix`, `islinux`, `isapple`,
+`isbsd`, and `iswindows`. These may be used as follows:
 
 ```julia
-if is_windows()
+if Sys.iswindows()
     some_complicated_thing(a)
 end
 ```
 
-Note that `is_linux` and `is_apple` are mutually exclusive subsets of `is_unix`. Additionally,
+Note that `islinux` and `isapple` are mutually exclusive subsets of `isunix`. Additionally,
 there is a macro `@static` which makes it possible to use these functions to conditionally hide
 invalid code, as demonstrated in the following examples.
 
 Simple blocks:
 
 ```
-ccall( (@static is_windows() ? :_fopen : :fopen), ...)
+ccall((@static Sys.iswindows() ? :_fopen : :fopen), ...)
 ```
 
 Complex blocks:
 
 ```julia
-@static if is_linux()
+@static if Sys.islinux()
     some_complicated_thing(a)
 else
     some_different_thing(a)
 end
 ```
 
-When chaining conditionals (including if/elseif/end), the `@static` must be repeated for each
-level (parentheses optional, but recommended for readability):
+When chaining conditionals (including `if`/`elseif`/`end`), the `@static` must be repeated for
+each level (parentheses optional, but recommended for readability):
 
 ```julia
-@static is_windows() ? :a : (@static is_apple() ? :b : :c)
+@static Sys.iswindows() ? :a : (@static Sys.isapple() ? :b : :c)
 ```

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -189,11 +189,11 @@ Base.@elapsed
 Base.@allocated
 Base.EnvHash
 Base.ENV
-Base.is_unix
-Base.is_apple
-Base.is_linux
-Base.is_bsd
-Base.is_windows
+Base.Sys.isunix
+Base.Sys.isapple
+Base.Sys.islinux
+Base.Sys.isbsd
+Base.Sys.iswindows
 Base.Sys.windows_version
 Base.@static
 ```

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -20,7 +20,7 @@ Base.Terminals.raw!(t::FakeTerminal, raw::Bool) = t.raw = raw
 Base.Terminals.size(t::FakeTerminal) = (24, 80)
 
 function open_fake_pty()
-    @static if is_windows()
+    @static if Sys.iswindows()
         error("Unable to create a fake PTY in Windows")
     end
 

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -49,7 +49,7 @@ catch err
 end
 
 # different-file inline
-const absfilepath = is_windows() ? "C:\\foo\\bar\\baz.jl" : "/foo/bar/baz.jl"
+const absfilepath = Sys.iswindows() ? "C:\\foo\\bar\\baz.jl" : "/foo/bar/baz.jl"
 eval(Expr(:function, Expr(:call, :test_inline_2),
           Expr(:block, Expr(:line, 81, Symbol("backtrace.jl")),
                        Expr(:block, Expr(:meta, :push_loc, Symbol(absfilepath)),

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -315,7 +315,7 @@ let tc = Ref(0),
     ccall(:uv_async_send, Void, (Ptr{Void},), async)
     Base.process_events(false) # schedule event
     ccall(:uv_async_send, Void, (Ptr{Void},), async)
-    is_windows() && Base.process_events(false) # schedule event (windows?)
+    Sys.iswindows() && Base.process_events(false) # schedule event (windows?)
     @test tc[] == 0
     yield() # consume event
     @test tc[] == 1
@@ -327,7 +327,7 @@ let tc = Ref(0),
     @test !isopen(async)
     @test tc[] == 1
     Base.process_events(false) # schedule event & then close
-    is_windows() && Base.process_events(false) # schedule event (windows?)
+    Sys.iswindows() && Base.process_events(false) # schedule event (windows?)
     yield() # consume event & then close
     @test tc[] == 2
     sleep(0.1) # no further events
@@ -342,7 +342,7 @@ let tc = Ref(0),
     close(async)
     @test !isopen(async)
     Base.process_events(false) # schedule event & then close
-    is_windows() && Base.process_events(false) # schedule event (windows)
+    Sys.iswindows() && Base.process_events(false) # schedule event (windows)
     @test tc[] == 0
     yield() # consume event & then close
     @test tc[] == 1

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 catcmd = `cat`
-if is_windows()
+if Sys.iswindows()
     try # use busybox-w32 on windows
         success(`busybox`)
         catcmd = `busybox cat`
@@ -257,7 +257,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
             """)
         cp(testfile, joinpath(dir, ".juliarc.jl"))
 
-        withenv((is_windows() ? "USERPROFILE" : "HOME") => dir) do
+        withenv((Sys.iswindows() ? "USERPROFILE" : "HOME") => dir) do
             output = "String[\"foo\", \"-bar\", \"--baz\"]"
             @test readchomp(`$exename $testfile foo -bar --baz`) == output
             @test readchomp(`$exename $testfile -- foo -bar --baz`) == output
@@ -295,7 +295,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
 
         readsplit(cmd) = split(readchomp(cmd), '\n')
 
-        withenv((is_windows() ? "USERPROFILE" : "HOME") => dir) do
+        withenv((Sys.iswindows() ? "USERPROFILE" : "HOME") => dir) do
             @test readsplit(`$exename $a`) ==
                 [a, a,
                  b, a]
@@ -342,7 +342,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     # issue #12671, starting from a non-directory
     # rm(dir) fails on windows with Permission denied
     # and was an upstream bug in llvm <= v3.3
-    if !is_windows() && Base.libllvm_version > v"3.3"
+    if !Sys.iswindows() && Base.libllvm_version > v"3.3"
         testdir = mktempdir()
         cd(testdir) do
             rm(testdir)

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -286,7 +286,7 @@ try
     @test !isdefined(Main, :FooBar1)
 
     relFooBar_file = joinpath(dir, "subfolder", "..", "FooBar.jl")
-    @test Base.stale_cachefile(relFooBar_file, joinpath(dir, "FooBar.ji")) == !is_windows() # `..` is not a symlink on Windows
+    @test Base.stale_cachefile(relFooBar_file, joinpath(dir, "FooBar.ji")) == !Sys.iswindows() # `..` is not a symlink on Windows
     mkdir(joinpath(dir, "subfolder"))
     @test !Base.stale_cachefile(relFooBar_file, joinpath(dir, "FooBar.ji"))
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -2149,7 +2149,7 @@ let x = [1,2,3]
 end
 
 # sig 2 is SIGINT per the POSIX.1-1990 standard
-if !is_windows()
+if !Sys.iswindows()
     ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
     @test_throws InterruptException begin
         ccall(:kill, Void, (Cint, Cint,), getpid(), 2)

--- a/test/dates/conversions.jl
+++ b/test/dates/conversions.jl
@@ -48,7 +48,7 @@
 @test typeof(Dates.today()) <: Dates.Date
 @test typeof(Dates.now(Dates.UTC)) <: Dates.DateTime
 
-if is_apple()
+if Sys.isapple()
     withenv("TZ" => "UTC") do
         @test abs(Dates.now() - now(Dates.UTC)) < Dates.Second(1)
     end

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -270,7 +270,7 @@ test_indexing(RemoteChannel(id_other))
 
 dims = (20,20,20)
 
-if is_linux()
+if Sys.islinux()
     S = SharedArray{Int64,3}(dims)
     @test startswith(S.segname, "/jl")
     @test !ispath("/dev/shm" * S.segname)
@@ -962,7 +962,7 @@ if DoFullTest
     @test workers() == all_w
     @test all([p == remotecall_fetch(myid, p) for p in all_w])
 
-if is_unix() # aka have ssh
+if Sys.isunix() # aka have ssh
     function test_n_remove_pids(new_pids)
         for p in new_pids
             w_in_remote = sort(remotecall_fetch(workers, p))
@@ -1233,7 +1233,7 @@ const get_num_threads = function() # anonymous so it will be serialized when cal
         end
 
         # OSX BLAS looks at an environment variable
-        if is_apple()
+        if Sys.isapple()
             return ENV["VECLIB_MAXIMUM_THREADS"]
         end
     end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -37,7 +37,7 @@ include(joinpath(dir, "queens.jl"))
 # Different cluster managers do not play well together. Since
 # the test infrastructure already uses LocalManager, we will test the simple
 # cluster manager example through a new Julia session.
-if is_unix()
+if Sys.isunix()
     script = joinpath(dir, "clustermanager/simple/test_simple.jl")
     cmd = `$(Base.julia_cmd()) --startup-file=no $script`
     if !success(pipeline(cmd; stdout=STDOUT, stderr=STDERR)) && ccall(:jl_running_on_valgrind,Cint,()) == 0

--- a/test/file.jl
+++ b/test/file.jl
@@ -26,7 +26,7 @@ let err = nothing
     end
 end
 
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     dirlink = joinpath(dir, "dirlink")
     symlink(subdir, dirlink)
     # relative link
@@ -37,7 +37,7 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     cd(pwd_)
 end
 
-if !is_windows()
+if !Sys.iswindows()
     link = joinpath(dir, "afilelink.txt")
     symlink(file, link)
     # relative link
@@ -67,7 +67,7 @@ chmod(file, filemode(file) | 0o222)
 @test filemode(file) & 0o111 == 0
 @test filesize(file) == 0
 
-if is_windows()
+if Sys.iswindows()
     permissions = 0o444
     @test filemode(dir) & 0o777 != permissions
     @test filemode(subdir) & 0o777 != permissions
@@ -103,7 +103,7 @@ end
 
 # On windows the filesize of a folder is the accumulation of all the contained
 # files and is thus zero in this case.
-if is_windows()
+if Sys.iswindows()
     @test filesize(dir) == 0
 else
     @test filesize(dir) > 0
@@ -118,15 +118,15 @@ end
 #@test Int(time()) >= Int(mtime(file)) >= Int(mtime(dir)) >= 0 # 1 second accuracy should be sufficient
 
 # test links
-if is_unix()
+if Sys.isunix()
     @test islink(link) == true
     @test readlink(link) == file
 end
 
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     @test islink(dirlink) == true
     @test isdir(dirlink) == true
-    @test readlink(dirlink) == subdir * (is_windows() ? "\\" : "")
+    @test readlink(dirlink) == subdir * (Sys.iswindows() ? "\\" : "")
 end
 
 # rm recursive TODO add links
@@ -162,7 +162,7 @@ rm(c_tmpdir, recursive=true)
 @test_throws Base.UVError rm(c_tmpdir, recursive=true)
 @test rm(c_tmpdir, force=true, recursive=true) === nothing
 
-if !is_windows()
+if !Sys.iswindows()
     # chown will give an error if the user does not have permissions to change files
     if get(ENV, "USER", "") == "root" || get(ENV, "HOME", "") == "/root"
         chown(file, -2, -1)  # Change the file owner to nobody
@@ -236,7 +236,7 @@ function test_monitor_wait(tval)
     end
     fname, events = wait(fm)
     close(fm)
-    if is_linux() || is_windows() || is_apple()
+    if Sys.islinux() || Sys.iswindows() || Sys.isapple()
         @test fname == basename(file)
     else
         @test fname == ""  # platforms where F_GETPATH is not available
@@ -307,7 +307,7 @@ my_tempdir = tempdir()
 
 path = tempname()
 # Issue #9053.
-@test ispath(path) == is_windows()
+@test ispath(path) == Sys.iswindows()
 ispath(path) && rm(path)
 
 (p, f) = mktemp()
@@ -476,7 +476,7 @@ end
 
 # issue #10506 #10434
 ## Tests for directories and links to directories
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     function setup_dirs(tmpdir)
         srcdir = joinpath(tmpdir, "src")
         hidden_srcdir = joinpath(tmpdir, ".hidden_srcdir")
@@ -686,7 +686,7 @@ end
 
 # issue #10506 #10434
 ## Tests for files and links to files as well as directories and links to directories
-if !is_windows()
+if !Sys.iswindows()
     function setup_files(tmpdir)
         srcfile = joinpath(tmpdir, "srcfile.txt")
         hidden_srcfile = joinpath(tmpdir, ".hidden_srcfile.txt")
@@ -918,7 +918,7 @@ let f = open(file, "w")
     f = open(file, "r")
     test_LibcFILE(convert(Libc.FILE, f))
     close(f)
-    if is_windows()
+    if Sys.iswindows()
         f = RawFD(ccall(:_open, Cint, (Cstring, Cint), file, Base.Filesystem.JL_O_RDONLY))
     else
         f = RawFD(ccall(:open, Cint, (Cstring, Cint), file, Base.Filesystem.JL_O_RDONLY))
@@ -937,7 +937,7 @@ end
 @test_throws ArgumentError open("ba\0d", "w")
 @test_throws ArgumentError cp(file, "ba\0d")
 @test_throws ArgumentError mv(file, "ba\0d")
-if !is_windows() || (Sys.windows_version() >= Sys.WINDOWS_VISTA_VER)
+if !Sys.iswindows() || (Sys.windows_version() >= Sys.WINDOWS_VISTA_VER)
     @test_throws ArgumentError symlink(file, "ba\0d")
 else
     @test_throws ErrorException symlink(file, "ba\0d")
@@ -959,7 +959,7 @@ cd(dirwalk) do
         touch(joinpath("sub_dir1", "file$i"))
     end
     touch(joinpath("sub_dir2", "file_dir2"))
-    has_symlinks = !is_windows() || (Sys.windows_version() >= Sys.WINDOWS_VISTA_VER)
+    has_symlinks = !Sys.iswindows() || (Sys.windows_version() >= Sys.WINDOWS_VISTA_VER)
     follow_symlink_vec = has_symlinks ? [true, false] : [false]
     has_symlinks && symlink(abspath("sub_dir2"), joinpath("sub_dir1", "link"))
     for follow_symlinks in follow_symlink_vec
@@ -1048,11 +1048,11 @@ rm(dirwalk, recursive=true)
 ############
 # Clean up #
 ############
-if !is_windows()
+if !Sys.iswindows()
     rm(link)
     rm(rellink)
 end
-if !is_windows() || (Sys.windows_version() >= Sys.WINDOWS_VISTA_VER)
+if !Sys.iswindows() || (Sys.windows_version() >= Sys.WINDOWS_VISTA_VER)
     rm(dirlink)
     rm(relsubdirlink)
 end
@@ -1113,7 +1113,7 @@ test2_12992()
 test2_12992()
 
 # issue 13559
-if !is_windows()
+if !Sys.iswindows()
 function test_13559()
     fn = tempname()
     run(`mkfifo $fn`)

--- a/test/libdl.jl
+++ b/test/libdl.jl
@@ -5,7 +5,7 @@
 dlls = Libdl.dllist()
 @test !isempty(dlls)
 @test length(dlls) > 3 # at a bare minimum, probably have some version of libstdc, libgcc, libjulia, ...
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     for dl in dlls
         if isfile(dl) && (Libdl.dlopen_e(dl) != C_NULL)
             @test Base.samefile(Libdl.dlpath(dl), dl)

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -40,7 +40,7 @@ mktempdir() do dir
                 error("unexpected")
             catch ex
                 @test isa(ex, LibGit2.Error.GitError)
-                if is_windows() && LibGit2.version() >= v"0.26.0"
+                if Sys.iswindows() && LibGit2.version() >= v"0.26.0"
                     # see #22681 and https://github.com/libgit2/libgit2/pull/4055
                     @test_broken ex.code == LibGit2.Error.EAUTH
                     @test ex.code == LibGit2.Error.ERROR

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -100,7 +100,7 @@ end
 end
 
 # See #21872 and #21636
-LibGit2.version() >= v"0.26.0" && is_unix() && @testset "Default config with symlink" begin
+LibGit2.version() >= v"0.26.0" && Sys.isunix() && @testset "Default config with symlink" begin
     with_libgit2_temp_home() do tmphome
         write(joinpath(tmphome, "real_gitconfig"), "[fake]\n\tproperty = BBB")
         symlink(joinpath(tmphome, "real_gitconfig"),
@@ -1432,7 +1432,7 @@ mktempdir() do dir
     end
 
 
-    if is_unix()
+    if Sys.isunix()
         @testset "checkout/proptest" begin
             repo = LibGit2.GitRepo(test_repo)
             try
@@ -1485,7 +1485,7 @@ mktempdir() do dir
     # The following tests require that we can fake a TTY so that we can provide passwords
     # which use the `getpass` function. At the moment we can only fake this on UNIX based
     # systems.
-    if is_unix()
+    if Sys.isunix()
         @testset "SSH credential prompt" begin
             url = "git@github.com/test/package.jl"
 
@@ -1647,7 +1647,7 @@ mktempdir() do dir
     @testset "SSH" begin
         sshd_command = ""
         ssh_repo = joinpath(dir, "Example.SSH")
-        if !is_windows()
+        if !Sys.iswindows()
             try
                 # SSHD needs to be executed by its full absolute path
                 sshd_command = strip(readstring(`which sshd`))
@@ -1697,7 +1697,7 @@ mktempdir() do dir
                     sshp = spawn_sshd()
 
                     TIOCSCTTY_str = "ccall(:ioctl, Void, (Cint, Cint, Int64), 0,
-                        (is_bsd() || is_apple()) ? 0x20007461 : is_linux() ? 0x540E :
+                        (Sys.isbsd() || Sys.isapple()) ? 0x20007461 : Sys.islinux() ? 0x540E :
                         error(\"Fill in TIOCSCTTY for this OS here\"), 0)"
 
                     # To fail rather than hang
@@ -1823,7 +1823,7 @@ mktempdir() do dir
     @testset "Hostname verification" begin
         openssl_installed = false
         common_name = ""
-        if is_linux()
+        if Sys.islinux()
             try
                 # OpenSSL needs to be on the path
                 openssl_installed = !isempty(readstring(`openssl version`))

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -507,7 +507,7 @@ let s = "abcα🐨\0x\0"
 end
 
 # clipboard functionality
-if is_windows()
+if Sys.iswindows()
     for str in ("Hello, world.", "∀ x ∃ y", "")
         clipboard(str)
         @test clipboard() == str
@@ -546,7 +546,7 @@ let creds = Base.LibGit2.CachedCredentials()
 end
 
 # Test that we can VirtualProtect jitted code to writable
-if is_windows()
+if Sys.iswindows()
     @noinline function WeVirtualProtectThisToRWX(x, y)
         x+y
     end

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -1,18 +1,18 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-@test !Base.is_unix(:Windows)
-@test !Base.is_linux(:Windows)
-@test Base.is_linux(:Linux)
-@test Base.is_windows(:Windows)
-@test Base.is_windows(:NT)
-@test !Base.is_windows(:Darwin)
-@test Base.is_apple(:Darwin)
-@test Base.is_apple(:Apple)
-@test !Base.is_apple(:Windows)
-@test Base.is_unix(:Darwin)
-@test Base.is_unix(:FreeBSD)
-@test_throws ArgumentError Base.is_unix(:BeOS)
-if !is_windows()
+@test !Sys.isunix(:Windows)
+@test !Sys.islinux(:Windows)
+@test Sys.islinux(:Linux)
+@test Sys.iswindows(:Windows)
+@test Sys.iswindows(:NT)
+@test !Sys.iswindows(:Darwin)
+@test Sys.isapple(:Darwin)
+@test Sys.isapple(:Apple)
+@test !Sys.isapple(:Windows)
+@test Sys.isunix(:Darwin)
+@test Sys.isunix(:FreeBSD)
+@test_throws ArgumentError Sys.isunix(:BeOS)
+if !Sys.iswindows()
     @test Sys.windows_version() == v"0.0.0"
 else
     @test Sys.windows_version() >= v"1.0.0-"

--- a/test/path.jl
+++ b/test/path.jl
@@ -11,7 +11,7 @@ for S in (String, GenericString)
     @test dirname(S("foo$(sep)bar")) == "foo"
 
     @test expanduser(S("x")) == "x"
-    @test expanduser(S("~")) == (is_windows() ? "~" : homedir())
+    @test expanduser(S("~")) == (Sys.iswindows() ? "~" : homedir())
 
     @test isabspath(S(homedir()))
     @test !isabspath(S("foo"))
@@ -68,7 +68,7 @@ for S in (String, GenericString)
     @test joinpath(splitdir(S(homedir()))...) == homedir()
     @test string(splitdrive(S(homedir()))...) == homedir()
 
-    if is_windows()
+    if Sys.iswindows()
         @test splitdrive(S("\\\\servername\\hello.world\\filename.ext")) ==
             ("\\\\servername\\hello.world","\\filename.ext")
         @test splitdrive(S("\\\\servername.com\\hello.world\\filename.ext")) ==
@@ -95,8 +95,8 @@ end
 
 @test isabspath("~") == false
 @test isabspath("/") == true # on windows, this is relatively absolute
-@test isabspath("A:/") == is_windows()
-@test isabspath("B:\\") == is_windows()
+@test isabspath("A:/") == Sys.iswindows()
+@test isabspath("B:\\") == Sys.iswindows()
 @test isabspath("./") == false
 @test isabspath("C:") == false
 @test isabspath("C:.") == false
@@ -104,8 +104,8 @@ end
 @test isabspath(".:/") == false
 #@test isabspath("_:/") == false # FIXME?
 #@test isabspath("AB:/") == false # FIXME?
-@test isabspath("\\\\") == is_windows()
-if is_unix()
+@test isabspath("\\\\") == Sys.iswindows()
+if Sys.isunix()
     @test isabspath(expanduser("~")) == true
     @test startswith(expanduser("~"), homedir())
 else
@@ -199,8 +199,8 @@ test_relpath()
 @test isa(joinpath(abspath("a"), "b"), String)
 
 # homedir
-let var = is_windows() ? "USERPROFILE" : "HOME",
-    MAX_PATH = is_windows() ? 240 : 1020
+let var = Sys.iswindows() ? "USERPROFILE" : "HOME",
+    MAX_PATH = Sys.iswindows() ? 240 : 1020
     for i = 0:9
         local home = " "^MAX_PATH * "123456789"[1:i]
         @test withenv(var => home) do

--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -138,7 +138,7 @@ end
 
 ## printfd ##
 
-if is_unix()
+if Sys.isunix()
     function printfd(n)
         open("/dev/null", "w") do io
             for i = 1:n

--- a/test/perf/perfutil.jl
+++ b/test/perf/perfutil.jl
@@ -102,7 +102,7 @@ end
 
 function maxrss(name)
     # FIXME: call uv_getrusage instead here
-    @static if is_linux()
+    @static if Sys.islinux()
         rus = Array{Int64}(div(144,8))
         fill!(rus, 0x0)
         res = ccall(:getrusage, Int32, (Int32, Ptr{Void}), 0, rus)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -322,7 +322,7 @@ temp_pkg_dir() do
         include(Pkg.dir("Example","src","Example.jl"))
         meth = first(methods(Example.domath))
         fname = string(meth.file)
-        @test ('\\' in fname) == is_windows()
+        @test ('\\' in fname) == Sys.iswindows()
         @test startswith(Base.url(meth), "https://github.com/JuliaLang/Example.jl/tree")
     end
 
@@ -556,7 +556,7 @@ temp_pkg_dir() do
         mkdir(home)
         write(joinpath(home, ".juliarc.jl"), "const JULIA_RC_LOADED = true")
 
-        withenv((is_windows() ? "USERPROFILE" : "HOME") => home) do
+        withenv((Sys.iswindows() ? "USERPROFILE" : "HOME") => home) do
             code = "redirect_stderr(STDOUT); Pkg.build(\"$package\")"
 
             msg = readstring(`$(Base.julia_cmd()) --startup-file=no -e $code`)

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -13,7 +13,7 @@ intvls = [2, .2, .1, .005]
 
 pipe_fds = Vector{Any}(n)
 for i in 1:n
-    @static if is_windows()
+    @static if Sys.iswindows()
         pipe_fds[i] = Array{Libc.WindowsRawSocket}(2)
         0 == ccall(:wsasocketpair, Cint, (Cint, Cuint, Cint, Ptr{Libc.WindowsRawSocket}), 1, 1, 6, pipe_fds[i]) || error(Libc.FormatMessage())
     else
@@ -41,7 +41,7 @@ function pfd_tst_reads(idx, intvl)
     # @test t_elapsed <= (intvl + 1)
 
     dout = Array{UInt8}(1)
-    @static if is_windows()
+    @static if Sys.iswindows()
         1 == ccall(:recv, stdcall, Cint, (Ptr{Void}, Ptr{UInt8}, Cint, Cint), pipe_fds[idx][1], dout, 1, 0) || error(Libc.FormatMessage())
     else
         @test 1 == ccall(:read, Csize_t, (Cint, Ptr{UInt8}, Csize_t), pipe_fds[idx][1], dout, 1)
@@ -96,7 +96,7 @@ for (i, intvl) in enumerate(intvls)
             @test event.writable
 
             if isodd(idx)
-                @static if is_windows()
+                @static if Sys.iswindows()
                     1 == ccall(:send, stdcall, Cint, (Ptr{Void}, Ptr{UInt8}, Cint, Cint), pipe_fds[idx][2], "A", 1, 0) || error(Libc.FormatMessage())
                 else
                     @test 1 == ccall(:write, Csize_t, (Cint, Ptr{UInt8}, Csize_t), pipe_fds[idx][2], "A", 1)
@@ -112,7 +112,7 @@ end
 
 for i in 1:n
     for j = 1:2
-        @static if is_windows()
+        @static if Sys.iswindows()
             0 == ccall(:closesocket, stdcall, Cint, (Ptr{Void},), pipe_fds[i][j]) || error(Libc.FormatMessage())
         else
             @test 0 == ccall(:close, Cint, (Cint,), pipe_fds[i][j])

--- a/test/read.jl
+++ b/test/read.jl
@@ -83,7 +83,7 @@ push!(l, ("TCPSocket", io))
 io = (text) -> begin
     a = "\\\\.\\pipe\\uv-test-$(randstring(6))"
     b = joinpath(dir, "socket-$(randstring(6))")
-    socketname = is_windows() ? a : b
+    socketname = Sys.iswindows() ? a : b
     srv = listen(socketname)
     run_test_server(srv, text)
     connect(socketname)
@@ -98,7 +98,7 @@ push!(l, ("PipeEndpoint", io))
 #FIXME See https://github.com/JuliaLang/julia/issues/14747
 #      Reading from open(::Command) seems to deadlock on Linux/Travis
 #=
-if !is_windows()
+if !Sys.iswindows()
 
 # Windows type command not working?
 # See "could not spawn `type 'C:\Users\appveyor\AppData\Local\Temp\1\jul3516.tmp\file.txt'`"
@@ -107,7 +107,7 @@ if !is_windows()
 # Pipe
 io = (text) -> begin
     write(filename, text)
-    open(`$(is_windows() ? "type" : "cat") $filename`)[1]
+    open(`$(Sys.iswindows() ? "type" : "cat") $filename`)[1]
 #    Was open(`echo -n $text`)[1]
 #    See https://github.com/JuliaLang/julia/issues/14747
 end
@@ -415,13 +415,13 @@ rm(f)
 io = Base.Filesystem.open(f, Base.Filesystem.JL_O_WRONLY | Base.Filesystem.JL_O_CREAT | Base.Filesystem.JL_O_EXCL, 0o000)
 @test write(io, "abc") == 3
 close(io)
-if !is_windows() && get(ENV, "USER", "") != "root" && get(ENV, "HOME", "") != "/root"
+if !Sys.iswindows() && get(ENV, "USER", "") != "root" && get(ENV, "HOME", "") != "/root"
     # msvcrt _wchmod documentation states that all files are readable,
     # so we don't test that it correctly set the umask on windows
     @test_throws SystemError open(f)
     @test_throws Base.UVError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDONLY)
 else
-    is_windows() || warn("file permissions tests skipped due to running tests as root (not recommended)")
+    Sys.iswindows() || warn("file permissions tests skipped due to running tests as root (not recommended)")
     close(open(f))
 end
 chmod(f, 0o400)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -546,7 +546,7 @@ function has_backslashes(meth::Method)
 end
 has_backslashes(x) = Nullable{Method}()
 h16850 = has_backslashes(Base)
-if is_windows()
+if Sys.iswindows()
     if isnull(h16850)
         warn("No methods found in Base with backslashes in file name, ",
              "skipping test for Base.url")

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -31,7 +31,7 @@ ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
 # in the mix. If verification needs to be done, keep it to the bare minimum. Basically
 # this should make sure nothing crashes without depending on how exactly the control
 # characters are being used.
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     stdin_write, stdout_read, stderr_read, repl = fake_repl()
 
     repl.specialdisplay = Base.REPL.REPLDisplay(repl)
@@ -100,7 +100,7 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     cd(origpwd)
 
     # issue #20482
-    if !is_windows()
+    if !Sys.iswindows()
         write(stdin_write, ";")
         readuntil(stdout_read, "shell> ")
         write(stdin_write, "echo hello >/dev/null\n")
@@ -126,7 +126,7 @@ if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
 
     # issues #22176 & #20482
     # TODO: figure out how to test this on Windows
-    is_windows() || let tmp = tempname()
+    Sys.iswindows() || let tmp = tempname()
         try
             write(stdin_write, ";")
             readuntil(stdout_read, "shell> ")
@@ -534,7 +534,7 @@ begin
 end
 
 # Simple non-standard REPL tests
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     stdin_write, stdout_read, stdout_read, repl = fake_repl()
     panel = LineEdit.Prompt("testπ";
         prompt_prefix="\e[38;5;166m",
@@ -579,7 +579,7 @@ ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
 let exename = Base.julia_cmd()
 
 # Test REPL in dumb mode
-if !is_windows()
+if !Sys.iswindows()
     TestHelpers.with_fake_pty() do slave, master
         nENV = copy(ENV)
         nENV["TERM"] = "dumb"
@@ -600,7 +600,7 @@ if !is_windows()
 end
 
 # Test stream mode
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     outs, ins, p = readandwrite(`$exename --startup-file=no --quiet`)
     write(ins,"1\nquit()\n")
     @test readstring(outs) == "1\n"
@@ -712,7 +712,7 @@ const altkeys = [Dict{Any,Any}("\e[A" => (s,o...)->(LineEdit.edit_move_up(s) || 
                 ]
 
 
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     for keys = [altkeys, merge(altkeys...)]
         histfile = tempname()
         try

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -471,7 +471,7 @@ c, r, res = test_scomplete(s)
 # which would raise an error in the repl code.
 @test (String[], 0:-1, false) == test_scomplete("\$a")
 
-if is_unix()
+if Sys.isunix()
     #Assume that we can rely on the existence and accessibility of /tmp
 
     # Tests path in Julia code and closing " if it's a file
@@ -622,12 +622,12 @@ let #test that it can auto complete with spaces in file/path
     mkdir(dir)
     cd(path) do
         open(joinpath(space_folder, "space .file"),"w") do f
-            s = is_windows() ? "rm $dir_space\\\\space" : "cd $dir_space/space"
+            s = Sys.iswindows() ? "rm $dir_space\\\\space" : "cd $dir_space/space"
             c,r = test_scomplete(s)
             @test r == endof(s)-4:endof(s)
             @test "space\\ .file" in c
 
-            s = is_windows() ? "cd(\"β $dir_space\\\\space" : "cd(\"β $dir_space/space"
+            s = Sys.iswindows() ? "cd(\"β $dir_space\\\\space" : "cd(\"β $dir_space/space"
             c,r = test_complete(s)
             @test r == endof(s)-4:endof(s)
             @test "space\\ .file\"" in c
@@ -645,7 +645,7 @@ end
 c,r = test_complete("cd(\"folder_do_not_exist_77/file")
 @test length(c) == 0
 
-if is_windows()
+if Sys.iswindows()
     tmp = tempname()
     path = dirname(tmp)
     file = basename(tmp)

--- a/test/show.jl
+++ b/test/show.jl
@@ -372,7 +372,7 @@ let oldout = STDOUT, olderr = STDERR
         @test wrerr === STDERR
         err = @async readstring(rderr)
         @test dump(Int64) === nothing
-        if !is_windows()
+        if !Sys.iswindows()
             close(wrout)
             close(wrerr)
         end

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -94,7 +94,7 @@ for testport in [0, defaultport]
 end
 
 mktempdir() do tmpdir
-    socketname = is_windows() ? ("\\\\.\\pipe\\uv-test-" * randstring(6)) : joinpath(tmpdir, "socket")
+    socketname = Sys.iswindows() ? ("\\\\.\\pipe\\uv-test-" * randstring(6)) : joinpath(tmpdir, "socket")
     c = Base.Condition()
     tsk = @async begin
         s = listen(socketname)
@@ -176,7 +176,7 @@ begin
     close(a)
     close(b)
 end
-if !is_windows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     a = UDPSocket()
     b = UDPSocket()
     bind(a, ip"::1", UInt16(port))
@@ -227,7 +227,7 @@ end
 # Local-machine broadcast
 let
     # (Mac OS X's loopback interface doesn't support broadcasts)
-    bcastdst = is_apple() ? ip"255.255.255.255" : ip"127.255.255.255"
+    bcastdst = Sys.isapple() ? ip"255.255.255.255" : ip"127.255.255.255"
 
     function create_socket()
         s = UDPSocket()
@@ -251,7 +251,7 @@ let
     try
         # bsd family do not allow broadcasting to ip"255.255.255.255"
         # or ip"127.255.255.255"
-        @static if !is_bsd() || is_apple()
+        @static if !Sys.isbsd() || Sys.isapple()
             send(c, bcastdst, 2000, "hello")
             recvs = [@async @test String(recv(s)) == "hello" for s in (a, b)]
             wait_with_timeout(recvs)
@@ -288,12 +288,12 @@ let P = Pipe()
     # on windows, the kernel fails to do even that
     # causing the `write` call to freeze
     # so we end up forced to do a slightly weaker test here
-    is_windows() || wait(t)
+    Sys.iswindows() || wait(t)
     @test isopen(P) # without an active uv_reader, P shouldn't be closed yet
     @test !eof(P) # should already know this,
     @test isopen(P) #  so it still shouldn't have an active uv_reader
     @test readuntil(P, 'w') == "llow"
-    is_windows() && wait(t)
+    Sys.iswindows() && wait(t)
     @test eof(P)
     @test !isopen(P) # eof test should have closed this by now
     close(P) # should be a no-op, just make sure

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -16,7 +16,7 @@ catcmd = `cat`
 shcmd = `sh`
 sleepcmd = `sleep`
 lscmd = `ls`
-if is_windows()
+if Sys.iswindows()
     try # use busybox-w32 on windows
         success(`busybox`)
         yescmd = `busybox yes`
@@ -46,7 +46,7 @@ out = readstring(`$echocmd hello` & `$echocmd world`)
 @test (run(`$printfcmd "       \033[34m[stdio passthrough ok]\033[0m\n"`); true)
 
 # Test for SIGPIPE being treated as normal termination (throws an error if broken)
-is_unix() && run(pipeline(yescmd, `head`, DevNull))
+Sys.isunix() && run(pipeline(yescmd, `head`, DevNull))
 
 begin
     a = Base.Condition()
@@ -65,7 +65,7 @@ if valgrind_off
     @test_throws Base.UVError run(`foo_is_not_a_valid_command`)
 end
 
-if is_unix()
+if Sys.isunix()
     prefixer(prefix, sleep) = `sh -c "while IFS= read REPLY; do echo '$prefix ' \$REPLY; sleep $sleep; done"`
     @test success(pipeline(`sh -c "for i in 1 2 3 4 5 6 7 8 9 10; do echo \$i; sleep 0.1; done"`,
                        prefixer("A", 0.2) & prefixer("B", 0.2)))
@@ -93,7 +93,7 @@ let file = tempname()
 end
 
 # Stream Redirection
-if !is_windows() # WINNT reports operation not supported on socket (ENOTSUP) for this test
+if !Sys.iswindows() # WINNT reports operation not supported on socket (ENOTSUP) for this test
     local r = Channel(1)
     local port, server, sock, client, t1, t2
     t1 = @async begin
@@ -121,7 +121,7 @@ end
        readstring(`$shcmd -c "echo \$TEST"`); end) == "Hello World\n"
 let pathA = readchomp(setenv(`$shcmd -c "pwd -P"`;dir="..")),
     pathB = readchomp(setenv(`$shcmd -c "cd .. && pwd -P"`))
-    if is_windows()
+    if Sys.iswindows()
         # on windows, sh returns posix-style paths that are not valid according to ispath
         @test pathA == pathB
     else
@@ -298,11 +298,11 @@ let out = Pipe(), echo = `$exename --startup-file=no -e 'print(STDOUT, " 1\t", r
         @test iswritable(out)
         close(out.in)
         @test !isopen(out.in)
-        is_windows() || @test !isopen(out.out) # it takes longer to propagate EOF through the Windows event system
+        Sys.iswindows() || @test !isopen(out.out) # it takes longer to propagate EOF through the Windows event system
         @test_throws ArgumentError write(out, "now closed error")
         @test isreadable(out)
         @test !iswritable(out)
-        if is_windows()
+        if Sys.iswindows()
             # WINNT kernel does not provide a fast mechanism for async propagation
             # of EOF for a blocking stream, so just wait for it to catch up.
             # This shouldn't take much more than 32ms.
@@ -341,7 +341,7 @@ let fname = tempname()
     write(fname, "test\n")
     code = """
     cmd = pipeline(`echo asdf`,`cat`)
-    if is_windows()
+    if Sys.iswindows()
         try
             success(`busybox`)
             cmd = pipeline(`busybox echo asdf`,`busybox cat`)
@@ -383,7 +383,7 @@ end
 @test_throws ErrorException collect(eachline(pipeline(`$catcmd _doesnt_exist__111_`, stderr=DevNull)))
 
 # make sure windows_verbatim strips quotes
-if is_windows()
+if Sys.iswindows()
     readstring(`cmd.exe /c dir /b spawn.jl`) == readstring(Cmd(`cmd.exe /c dir /b "\"spawn.jl\""`, windows_verbatim=true))
 end
 
@@ -422,7 +422,7 @@ end
 @test reduce(&, [`$echocmd abc`, `$echocmd def`, `$echocmd hij`]) == `$echocmd abc` & `$echocmd def` & `$echocmd hij`
 
 # test for proper handling of FD exhaustion
-if is_unix()
+if Sys.isunix()
     let ps = Pipe[]
         ulimit_n = tryparse(Int, readchomp(`sh -c 'ulimit -n'`))
         try

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -258,7 +258,7 @@ let s = normalize_string("tést",:NFKC)
 end
 @test_throws ArgumentError Base.unsafe_convert(Cstring, Base.cconvert(Cstring, "ba\0d"))
 
-cstrdup(s) = @static is_windows() ? ccall(:_strdup, Cstring, (Cstring,), s) : ccall(:strdup, Cstring, (Cstring,), s)
+cstrdup(s) = @static Sys.iswindows() ? ccall(:_strdup, Cstring, (Cstring,), s) : ccall(:strdup, Cstring, (Cstring,), s)
 let p = cstrdup("hello")
     @test unsafe_string(p) == "hello"
     Libc.free(p)


### PR DESCRIPTION
This PR deprecates the OS predicate functions which contain underscores in favor of ones without underscores, thereby making them consistent with the vast majority of Base predicates, which simply prefix with `is` rather than `is_`. That is, `is_unix` for example is now `isunix`.

This is part of the underscore audit as mentioned in #20402.