### PR TITLE
Install and use libatomic on windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,7 @@ $(eval $(call std_dll,gcc_s_seh-1))
 endif
 $(eval $(call std_dll,ssp-0))
 $(eval $(call std_dll,winpthread-1))
+$(eval $(call std_dll,atomic-1))
 endif
 define stringreplace
 	$(build_depsbindir)/stringreplace $$(strings -t x - $1 | grep '$2' | awk '{print $$1;}') '$3' 255 "$(call cygpath_w,$1)"

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -341,12 +341,17 @@ void NotifyDebugger(jit_code_entry *JITCodeEntry)
 }
 // ------------------------ END OF TEMPORARY COPY FROM LLVM -----------------
 
-#if defined(_OS_LINUX_)
+#if defined(_OS_LINUX_) || defined(_OS_WINDOWS_)
 // Resolve non-lock free atomic functions in the libatomic library.
 // This is the library that provides support for c11/c++11 atomic operations.
 static uint64_t resolve_atomic(const char *name)
 {
-    static void *atomic_hdl = jl_load_dynamic_library_e("libatomic",
+#if defined(_OS_LINUX_)
+    static const char *const libatomic = "libatomic";
+#elif defined(_OS_WINDOWS_)
+    static const char *const libatomic = "libatomic-1";
+#endif
+    static void *atomic_hdl = jl_load_dynamic_library_e(libatomic,
                                                         JL_RTLD_LOCAL);
     static const char *const atomic_prefix = "__atomic_";
     if (!atomic_hdl)
@@ -578,7 +583,7 @@ void JuliaOJIT::addModule(std::unique_ptr<Module> M)
                         // Step 2: Search the program symbols
                         if (uint64_t addr = SectionMemoryManager::getSymbolAddressInProcess(Name))
                             return JL_SymbolInfo(addr, JITSymbolFlags::Exported);
-#if defined(_OS_LINUX_)
+#if defined(_OS_LINUX_) || defined(_OS_WINDOWS_)
                         if (uint64_t addr = resolve_atomic(Name.c_str()))
                             return JL_SymbolInfo(addr, JITSymbolFlags::Exported);
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -136,12 +136,9 @@ void *jl_gc_perm_alloc(size_t sz, int zero, unsigned align, unsigned offset);
 static const int jl_gc_sizeclasses[JL_GC_N_POOLS] = {
 #ifdef _P64
     8,
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
     // ARM and PowerPC have max alignment of 8,
     // make sure allocation of size 8 has that alignment.
-    // for x86 alignment is important for atomic ops and
-    // the corresponding platform ABI. Once we can use
-    // libatomic on Windows this is no longer necessary.
     4, 8,
 #else
     4, 8, 12,
@@ -177,7 +174,7 @@ STATIC_INLINE int jl_gc_alignment(size_t sz)
 #ifdef _P64
     (void)sz;
     return 16;
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
     return sz <= 4 ? 8 : 16;
 #else
     // szclass 8
@@ -198,7 +195,7 @@ STATIC_INLINE int JL_CONST_FUNC jl_gc_szclass(size_t sz)
     if (sz <=    8)
         return 0;
     const int N = 0;
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
     if (sz <=    8)
         return (sz + 3) / 4 - 1;
     const int N = 1;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -62,7 +62,7 @@ typedef struct {
     // variables for allocating objects from pools
 #ifdef _P64
 #  define JL_GC_N_POOLS 41
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_X86_)
+#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
 #  define JL_GC_N_POOLS 42
 #else
 #  define JL_GC_N_POOLS 43


### PR DESCRIPTION
As mentioned in https://github.com/JuliaLang/julia/pull/20152#issuecomment-274222415 we should use `libatomic` on windows as well.
So far we have gotten around it but in #21959 the windows CI fails due to the lack of `libatomic`.

