### PR TITLE
Export jl_get_function

### DIFF
--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -421,6 +421,11 @@ JL_DLLEXPORT void jl_get_fenv_consts(int *ret)
     ret[8] = FE_TOWARDZERO;
 }
 
+JL_DLLEXPORT jl_function_t *jl_get_function(jl_module_t *m, const char *name)
+{
+    return (jl_function_t*)jl_get_global(m, jl_symbol(name));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -1240,10 +1240,8 @@ JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
 JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT jl_module_t *jl_new_main_module(void);
 JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
-STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
-{
-    return (jl_function_t*)jl_get_global(m, jl_symbol(name));
-}
+JL_DLLEXPORT jl_function_t *jl_get_function(jl_module_t *m, const char *name);
+
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
 // eq hash tables


### PR DESCRIPTION
We use this as an example in the docs, so it should actually be usable.
I don't know why it was initially declared STATIC_INLINE, but it does
enough work that inlining seems pointless.

ref:

https://stackoverflow.com/questions/44314254/embedding-julia-script-into-c-jl-get-function-doesnt-exist