### PR TITLE
Work around linkcheck errors in docs

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -57,7 +57,7 @@
   * [Punctuation](@ref)
   * [Sorting and Related Functions](@ref)
   * [Package Manager Functions](@ref)
-  * [Dates and Time](@ref)
+  * [Dates and Time](@ref stdlib-dates)
   * [Iteration utilities](@ref)
   * [Unit Testing](@ref)
   * [C Interface](@ref)

--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -561,7 +561,7 @@ julia> round(DateTime(2016, 8, 6, 20, 15), Dates.Day)
 Unlike the numeric [`round()`](@ref) method, which breaks ties toward the even number by default,
 the [`TimeType`](@ref)[`round()`](@ref) method uses the `RoundNearestTiesUp` rounding mode. (It's
 difficult to guess what breaking ties to nearest "even" [`TimeType`](@ref) would entail.) Further
-details on the available `RoundingMode` s can be found in the [API reference](../stdlib/dates.md).
+details on the available `RoundingMode` s can be found in the [API reference](@ref stdlib-dates).
 
 Rounding should generally behave as expected, but there are a few cases in which the expected
 behaviour is not obvious.
@@ -626,5 +626,5 @@ will result in the months field having an odd value. Because both months and yea
 an irregular number of days, whether rounding to an even number of days will result in an even
 value in the days field is uncertain.
 
-See the [API reference](../stdlib/dates.md) for additional information
+See the [API reference](@ref stdlib-dates) for additional information
 on methods exported from the `Dates` module.

--- a/doc/src/stdlib/dates.md
+++ b/doc/src/stdlib/dates.md
@@ -1,4 +1,4 @@
-# Dates and Time
+# [Dates and Time](@id stdlib-dates)
 
 ## Dates and Time Types
 

--- a/doc/src/stdlib/index.md
+++ b/doc/src/stdlib/index.md
@@ -14,7 +14,7 @@
   * [Punctuation](@ref)
   * [Sorting and Related Functions](@ref)
   * [Package Manager Functions](@ref)
-  * [Dates and Time](@ref)
+  * [Dates and Time](@ref stdlib-dates)
   * [Iteration utilities](@ref)
   * [Unit Testing](@ref)
   * [C Interface](@ref)


### PR DESCRIPTION
Switch the cross-references introduced in #22048 to `@ref` links so that linkcheck would pass.

This is just a workaround to get this fixed quickly. In the long-term, Documenter should handle relative links properly (JuliaDocs/Documenter.jl#509).