### PR TITLE
Use map instead of broadcast for Array*/Number and Matrix+-Matrix.

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -24,7 +24,7 @@ julia> A
  2-2im  3-1im
 ```
 """
-conj!(A::AbstractArray{<:Number}) = (@inbounds broadcast!(conj, A, A); A)
+conj!(A::AbstractArray{<:Number}) = (@inbounds map!(conj, A, A); A)
 
 for f in (:-, :conj, :real, :imag)
     @eval ($f)(A::AbstractArray) = broadcast_preserving_zero_d($f, A)
@@ -36,7 +36,7 @@ end
 for f in (:+, :-)
     @eval function ($f)(A::AbstractArray, B::AbstractArray)
         promote_shape(A, B) # check size compatibility
-        broadcast_preserving_zero_d($f, A, B)
+        return map($f, A, B)
     end
 end
 
@@ -44,15 +44,15 @@ function +(A::Array, Bs::Array...)
     for B in Bs
         promote_shape(A, B) # check size compatibility
     end
-    broadcast_preserving_zero_d(+, A, Bs...)
+    return map(+, A, Bs...)
 end
 
 for f in (:/, :\, :*)
     if f !== :/
-        @eval ($f)(A::Number, B::AbstractArray) = broadcast_preserving_zero_d($f, A, B)
+        @eval ($f)(x::Number, A::AbstractArray) = map(t -> ($f)(x, t), A)
     end
     if f !== :\
-        @eval ($f)(A::AbstractArray, B::Number) = broadcast_preserving_zero_d($f, A, B)
+        @eval ($f)(A::AbstractArray, x::Number) = map(t -> ($f)(t, x), A)
     end
 end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2815,3 +2815,23 @@ end
     @test String(take!(b)) ==
         "BoundsError: attempt to access 2×2 Array{Float64,2} at index [10, \"bad index\"]"
 end
+
+struct T22208 <: DenseMatrix{Float64}
+    A::Matrix{Float64}
+end
+Base.size(A::T22208) = size(A.A)
+Base.map(f, A::T22208)            = T22208(map(f, A.A))
+Base.map(f, A::T22208, B::T22208) = T22208(map(f, A.A, B.A))
+@testset "test that binary ops for custom arrays call map" begin
+    A = T22208(randn(3,3))
+    x = randn()
+
+    @test (x * A).A == x * A.A
+    @test (x \ A).A == x \ A.A
+
+    @test (A * x).A == A.A * x
+    @test (A / x).A == A.A / x
+
+    @test (A + A).A == A.A + A.A
+    @test (A - A).A == A.A - A.A
+end


### PR DESCRIPTION
This makes it easier to implement these methods for custom array
types since map is much simpler than broadcast.