### PR TITLE
RFC: Make `struct` optional in `mutable struct`

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -116,7 +116,7 @@
 
 (define initial-reserved-words '(begin while if for try return break continue
                          function macro quote let local global const do
-                         struct
+                         struct mutable
                          abstract typealias bitstype type immutable  ;; to be deprecated
                          module baremodule using import export importall))
 
@@ -1005,7 +1005,7 @@
 ;; also handles looking for syntactic reserved words
 (define (parse-call s)
   (let ((ex (parse-unary-prefix s)))
-    (if (or (initial-reserved-word? ex) (memq ex '(mutable primitive)))
+    (if (or (initial-reserved-word? ex) (eq? ex 'primitive))
         (parse-resword s ex)
         (parse-call-chain s ex #f))))
 
@@ -1320,10 +1320,9 @@
         (begin (take-token s)
                (parse-struct-def s #f word)))
        ((mutable)
-        (if (not (eq? (peek-token s) 'struct))
-            (parse-call-chain s word #f)
-            (begin (take-token s)
-                   (parse-struct-def s #t word))))
+        (if (eq? (peek-token s) 'struct)
+            (take-token s))
+        (parse-struct-def s #t word))
        ((primitive)
         (if (not (eq? (peek-token s) 'type))
             (parse-call-chain s word #f)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1215,3 +1215,20 @@ end
 # issue #19351
 # adding return type decl should not affect parse of function body
 @test :(t(abc) = 3).args[2] == :(t(abc)::Int = 3).args[2]
+
+# Optional `struct` in `mutable struct`
+let
+    mutsct = """
+        mutable struct Enterprise <: Starship
+            captain::String
+        end
+    """
+    mut = """
+        mutable Enterprise <: Starship
+            captain::String
+        end
+    """
+    @test parse(mutsct) == parse(mut)
+    # Ensure we haven't broken the `T.mutable` field for types
+    @test !Int.mutable
+end


### PR DESCRIPTION
After using this for a while, I've decided that I find `mutable struct` to be quite long, and I find it odd that it doesn't match `struct` in being a single word. Thus this PR makes `struct` optional. Mutable types may now simply be defined as `mutable X end` rather than `mutable struct X end`, though the latter still works. Once upon a time, `type` was optional in `immutable`; we had `immutable` and `immutable type`. This is analogous to that.

I imagine this may be controversial, but hopefully it can at least be considered.