### PR TITLE
Add a Makefile option to disable libunwind

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -26,6 +26,7 @@ OPENBLAS_USE_THREAD:=1
 # Use libraries available on the system instead of building them
 USE_SYSTEM_LLVM:=0
 USE_SYSTEM_LIBUNWIND:=0
+DISABLE_LIBUNWIND:=0
 USE_SYSTEM_PCRE:=0
 USE_SYSTEM_LIBM:=0
 USE_SYSTEM_OPENLIBM:=0
@@ -737,6 +738,8 @@ endif
 
 ifeq ($(OS),WINNT)
 LIBUNWIND:=
+else ifneq ($(DISABLE_LIBUNWIND), 0)
+LIBUNWIND:=
 else
 ifeq ($(USE_SYSTEM_LIBUNWIND), 1)
 ifneq ($(OS),Darwin)
@@ -983,6 +986,10 @@ endif
 # OProfile
 ifeq ($(USE_OPROFILE_JITEVENTS), 1)
 JCPPFLAGS += -DJL_USE_OPROFILE_JITEVENTS
+endif
+
+ifeq ($(DISABLE_LIBUNWIND), 1)
+JCPPFLAGS += -DJL_DISABLE_LIBUNWIND
 endif
 
 # Intel libraries

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -48,6 +48,7 @@ ifeq ($(USE_SYSTEM_LIBUV), 0)
 DEP_LIBS += libuv
 endif
 
+ifeq ($(DISABLE_LIBUNWIND), 0)
 ifeq ($(USE_SYSTEM_LIBUNWIND), 0)
 ifeq ($(OS), Linux)
 DEP_LIBS += unwind
@@ -55,6 +56,7 @@ else ifeq ($(OS), FreeBSD)
 DEP_LIBS += unwind
 else ifeq ($(OS), Darwin)
 DEP_LIBS += osxunwind
+endif
 endif
 endif
 

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -41,9 +41,7 @@ using namespace llvm;
 #include "julia.h"
 #include "julia_internal.h"
 #include "codegen_internal.h"
-#ifdef _OS_LINUX_
-#  define UNW_LOCAL_ONLY
-#  include <libunwind.h>
+#if defined(_OS_LINUX_)
 #  include <link.h>
 #endif
 
@@ -1400,7 +1398,7 @@ static int jl_getDylibFunctionInfo(jl_frame_t **frames, size_t pointer, int skip
     }
     frame0->fromC = !isSysImg;
     if (isSysImg && sysimg_fvars) {
-#ifdef _OS_LINUX_
+#if defined(_OS_LINUX_) && !defined(JL_DISABLE_LIBUNWIND)
         unw_proc_info_t pip;
         if (!saddr && unw_get_proc_info_by_ip(unw_local_addr_space,
                                               pointer, &pip, NULL) == 0)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -648,7 +648,7 @@ typedef struct {
 } bt_cursor_t;
 #endif
 extern volatile int jl_in_stackwalk;
-#else
+#elif !defined(JL_DISABLE_LIBUNWIND)
 // This gives unwind only local unwinding options ==> faster code
 #  define UNW_LOCAL_ONLY
 #  include <libunwind.h>
@@ -660,6 +660,10 @@ typedef unw_cursor_t bt_cursor_t;
 // on a newer release
 #    define JL_UNW_HAS_FORMAT_IP 1
 #  endif
+#else
+// Unwinding is disabled
+typedef int bt_context_t;
+typedef int bt_cursor_t;
 #endif
 size_t rec_backtrace(uintptr_t *data, size_t maxsize);
 size_t rec_backtrace_ctx(uintptr_t *data, size_t maxsize, bt_context_t *ctx);


### PR DESCRIPTION
There's been a request for a version of julia that does not depend on
libunwind, for easier bring up on new architectures. This adds a makefile
flag that can be put in Make.user (`DISABLE_LIBUNWIND`) and if set, will
disable any dependency on libunwind. Backtraces and profiling won't work
of course.