### PR TITLE
RFC: Speedup generic LowerTriangular chol

### DIFF
--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -101,10 +101,12 @@ function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
             end
             A[k,k] = Akk
             AkkInv = inv(Akk)
-            for i = k + 1:n
-                for j = 1:k - 1
+            for j = 1:k - 1
+                for i = k + 1:n
                     A[i,k] -= A[i,j]*A[k,j]'
                 end
+            end
+            for i = k + 1:n
                 A[i,k] *= AkkInv'
             end
         end

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -102,10 +102,10 @@ function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
             A[k,k] = Akk
             AkkInv = inv(Akk)
             for i = k + 1:n
-                for j = 1:k-1
+                for j = 1:k - 1
                     A[i,k] -= A[i,j]*A[k,j]'
                 end
-                A[i,k] = A[i,k]*AkkInv'
+                A[i,k] *= AkkInv'
             end
         end
      end

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -102,7 +102,7 @@ function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
             A[k,k] = Akk
             AkkInv = inv(Akk)
             for j = 1:k - 1
-                for i = k + 1:n
+                @simd for i = k + 1:n
                     A[i,k] -= A[i,j]*A[k,j]'
                 end
             end

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -101,15 +101,11 @@ function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
             end
             A[k,k] = Akk
             AkkInv = inv(Akk)
-            for j = 1:k
-                for i = k + 1:n
-                    if j == 1
-                        A[i,k] = A[i,k]*AkkInv'
-                    end
-                    if j < k
-                        A[i,k] -= A[i,j]*A[k,j]'*AkkInv'
-                    end
+            for i = k + 1:n
+                for j = 1:k-1
+                    A[i,k] -= A[i,j]*A[k,j]'
                 end
+                A[i,k] = A[i,k]*AkkInv'
             end
         end
      end


### PR DESCRIPTION
The generic `LowerTriangular` `_chol!` function is a bit slower than its `UpperTriangular` counterpart. After removing some unnecessary multiplications and branches they are about the same speed. Bellow are a couple of benchmarks to demonstrate. On master
```julia
srand(1234)
A = randn(100,100) |> t -> t't
@benchmark invoke(Base.LinAlg._chol!, Tuple{AbstractMatrix, Type{LowerTriangular}}, copy($A), LowerTriangular)
@benchmark invoke(Base.LinAlg._chol!, Tuple{AbstractMatrix, Type{UpperTriangular}}, copy($A), UpperTriangular)
```
Gives mean timings of 177.964 μs for the `LowerTriangular` version and 142.604 μs for the `UpperTriangular`. With this PR the same benchmark gives mean timings of 143.273 μs and 142.406 μs respectively.