### PR TITLE
randstring: allow specifying chars to pick from

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -767,24 +767,6 @@ julia> a
 select!
 
 """
-    randstring([rng,] len=8)
-
-Create a random ASCII string of length `len`, consisting of upper- and
-lower-case letters and the digits 0-9. The optional `rng` argument
-specifies a random number generator, see [Random Numbers](@ref).
-
-# Example
-
-```jldoctest
-julia> rng = MersenneTwister(1234);
-
-julia> randstring(rng, 4)
-"mbDd"
-```
-"""
-randstring
-
-"""
     Float64(x [, mode::RoundingMode])
 
 Create a Float64 from `x`. If `x` is not exactly representable then `mode` determines how

--- a/base/random.jl
+++ b/base/random.jl
@@ -1626,33 +1626,17 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
     randstring(r::AbstractRNG, n::Int) = randstring(r, b, n)
     randstring(chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) = randstring(GLOBAL_RNG, chars, n)
     randstring(n::Int) = randstring(GLOBAL_RNG, b, n)
-
-    rand(rng::AbstractRNG, ::Type{String}, chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) =
-        randstring(rng, chars, n)
-    rand(rng::AbstractRNG, ::Type{String}, n::Int) = randstring(rng, b, n)
-    rand(::Type{String}, chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) =
-        randstring(GLOBAL_RNG, chars, n)
-    rand(::Type{String}, n::Int) = randstring(GLOBAL_RNG, b, n)
 end
 
 """
     randstring([rng=GLOBAL_RNG], [chars::AbstractArray{<:Union{UInt8,Char}}], [len=8])
 
-Create a random string of length `len`, consisting of characters
+Create a random ASCII string of length `len`, consisting of characters
 from `chars` if specified, and of upper- and lower-case letters and
 the digits 0-9 otherwise. The optional `rng` argument specifies a
 random number generator, see [Random Numbers](@ref).
 """
 randstring
-
-"""
-    rand([rng=GLOBAL_RNG], ::Type{String}, [chars::AbstractArray{<:Union{UInt8,Char}}], [len=8])
-
-Create a random string of length `len`, consisting of characters
-from `chars` if specified, and of upper- and lower-case letters and
-the digits 0-9 otherwise. Equivalent to [`randstring`](@ref)`(rng, chars, len)`.
-"""
-rand
 
 # Fill S (resized as needed) with a random subsequence of A, where
 # each element of A is included in S with independent probability p.

--- a/base/random.jl
+++ b/base/random.jl
@@ -1620,10 +1620,8 @@ Base.show(io::IO, u::UUID) = write(io, Base.repr(u))
 # return a random string (often useful for temporary filenames/dirnames)
 let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
-    randstring(r::AbstractRNG, n::Int) = String(b[rand(r, 1:length(b), n)])
-    randstring(r::AbstractRNG) = randstring(r,8)
-    randstring(n::Int) = randstring(GLOBAL_RNG, n)
-    randstring() = randstring(GLOBAL_RNG)
+    randstring(r::AbstractRNG, n::Int=8) = String(rand(r, b, n))
+    randstring(n::Int=8) = randstring(GLOBAL_RNG, n)
 end
 
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -1619,14 +1619,6 @@ Base.show(io::IO, u::UUID) = write(io, Base.repr(u))
 
 # return a random string (often useful for temporary filenames/dirnames)
 
-let b = UInt8['0':'9';'A':'Z';'a':'z']
-    global randstring
-    randstring(r::AbstractRNG, chars=b, n::Integer=8) = String(rand(r, chars, n))
-    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, n)
-    randstring(chars=b, n::Integer=8) = randstring(GLOBAL_RNG, chars, n)
-    randstring(n::Integer) = randstring(GLOBAL_RNG, b, n)
-end
-
 """
     randstring([rng=GLOBAL_RNG], [chars], [len=8])
 
@@ -1652,8 +1644,15 @@ julia> randstring("ACGT")
     `UInt8` (more efficient), provided [`rand`](@ref) can randomly
     pick characters from it.
 """
+function randstring end
 
-randstring
+let b = UInt8['0':'9';'A':'Z';'a':'z']
+    global randstring
+    randstring(r::AbstractRNG, chars=b, n::Integer=8) = String(rand(r, chars, n))
+    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, n)
+    randstring(chars=b, n::Integer=8) = randstring(GLOBAL_RNG, chars, n)
+    randstring(n::Integer) = randstring(GLOBAL_RNG, b, n)
+end
 
 # Fill S (resized as needed) with a random subsequence of A, where
 # each element of A is included in S with independent probability p.

--- a/base/random.jl
+++ b/base/random.jl
@@ -1635,6 +1635,18 @@ from `chars` if specified, and of upper- and lower-case letters and
 the digits 0-9 otherwise. The optional `rng` argument specifies a
 random number generator, see [Random Numbers](@ref).
 
+# Examples
+```julia-repl
+julia> randstring()
+"c03rgKi1"
+
+julia> randstring(MersenneTwister(0), 'a':'z', 6)
+"wijzek"
+
+julia> randstring("gcat")
+"tgtcaatc"
+```
+
 !!! note
     The collection `chars` can be any collection of characters
     (of type `Char` or `UInt8`)

--- a/base/random.jl
+++ b/base/random.jl
@@ -1628,8 +1628,8 @@ and the digits 0-9. The optional `rng` argument specifies a random
 number generator, see [Random Numbers](@ref).
 
 # Examples
-```julia-repl
-julia> randstring()
+```jldoctest
+julia> srand(0); randstring()
 "c03rgKi1"
 
 julia> randstring(MersenneTwister(0), 'a':'z', 6)

--- a/base/random.jl
+++ b/base/random.jl
@@ -1626,17 +1626,33 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
     randstring(r::AbstractRNG, n::Int) = randstring(r, b, n)
     randstring(chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) = randstring(GLOBAL_RNG, chars, n)
     randstring(n::Int) = randstring(GLOBAL_RNG, b, n)
+
+    rand(rng::AbstractRNG, ::Type{String}, chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) =
+        randstring(rng, chars, n)
+    rand(rng::AbstractRNG, ::Type{String}, n::Int) = randstring(rng, b, n)
+    rand(::Type{String}, chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) =
+        randstring(GLOBAL_RNG, chars, n)
+    rand(::Type{String}, n::Int) = randstring(GLOBAL_RNG, b, n)
 end
 
 """
     randstring([rng=GLOBAL_RNG], [chars::AbstractArray{<:Union{UInt8,Char}}], [len=8])
 
-Create a random ASCII string of length `len`, consisting of characters
+Create a random string of length `len`, consisting of characters
 from `chars` if specified, and of upper- and lower-case letters and
 the digits 0-9 otherwise. The optional `rng` argument specifies a
 random number generator, see [Random Numbers](@ref).
 """
 randstring
+
+"""
+    rand([rng=GLOBAL_RNG], ::Type{String}, [chars::AbstractArray{<:Union{UInt8,Char}}], [len=8])
+
+Create a random string of length `len`, consisting of characters
+from `chars` if specified, and of upper- and lower-case letters and
+the digits 0-9 otherwise. Equivalent to [`randstring`](@ref)`(rng, chars, len)`.
+"""
+rand
 
 # Fill S (resized as needed) with a random subsequence of A, where
 # each element of A is included in S with independent probability p.

--- a/base/random.jl
+++ b/base/random.jl
@@ -1631,7 +1631,7 @@ end
 """
     randstring([rng=GLOBAL_RNG], [chars::AbstractArray{<:Union{UInt8,Char}}], [len=8])
 
-Create a random ASCII string of length `len`, consisting of characters
+Create a random string of length `len`, consisting of characters
 from `chars` if specified, and of upper- and lower-case letters and
 the digits 0-9 otherwise. The optional `rng` argument specifies a
 random number generator, see [Random Numbers](@ref).

--- a/base/random.jl
+++ b/base/random.jl
@@ -1621,10 +1621,10 @@ Base.show(io::IO, u::UUID) = write(io, Base.repr(u))
 
 let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
-    randstring(r::AbstractRNG, chars=b, n::Int=8) = String(rand(r, chars, n))
-    randstring(r::AbstractRNG, n::Int) = randstring(r, b, n)
-    randstring(chars=b, n::Int=8) = randstring(GLOBAL_RNG, chars, n)
-    randstring(n::Int) = randstring(GLOBAL_RNG, b, n)
+    randstring(r::AbstractRNG, chars=b, n::Integer=8) = String(rand(r, chars, n))
+    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, n)
+    randstring(chars=b, n::Integer=8) = randstring(GLOBAL_RNG, chars, n)
+    randstring(n::Integer) = randstring(GLOBAL_RNG, b, n)
 end
 
 """

--- a/base/random.jl
+++ b/base/random.jl
@@ -1621,20 +1621,24 @@ Base.show(io::IO, u::UUID) = write(io, Base.repr(u))
 
 let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
-    randstring(r::AbstractRNG, chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) =
-        String(rand(r, chars, n))
+    randstring(r::AbstractRNG, chars=b, n::Int=8) = String(rand(r, chars, n))
     randstring(r::AbstractRNG, n::Int) = randstring(r, b, n)
-    randstring(chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) = randstring(GLOBAL_RNG, chars, n)
+    randstring(chars=b, n::Int=8) = randstring(GLOBAL_RNG, chars, n)
     randstring(n::Int) = randstring(GLOBAL_RNG, b, n)
 end
 
 """
-    randstring([rng=GLOBAL_RNG], [chars::AbstractArray{<:Union{UInt8,Char}}], [len=8])
+    randstring([rng=GLOBAL_RNG], [chars], [len=8])
 
 Create a random string of length `len`, consisting of characters
 from `chars` if specified, and of upper- and lower-case letters and
 the digits 0-9 otherwise. The optional `rng` argument specifies a
 random number generator, see [Random Numbers](@ref).
+
+!!! note
+    The collection `chars` can be any collection of characters
+    (of type `Char` or `UInt8`)
+    from which [`rand`](@ref) can randomly pick characters.
 """
 randstring
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -1630,10 +1630,10 @@ end
 """
     randstring([rng=GLOBAL_RNG], [chars], [len=8])
 
-Create a random string of length `len`, consisting of characters
-from `chars` if specified, and of upper- and lower-case letters and
-the digits 0-9 otherwise. The optional `rng` argument specifies a
-random number generator, see [Random Numbers](@ref).
+Create a random string of length `len`, consisting of characters from
+`chars`, which defaults to the set of upper- and lower-case letters
+and the digits 0-9. The optional `rng` argument specifies a random
+number generator, see [Random Numbers](@ref).
 
 # Examples
 ```julia-repl
@@ -1643,15 +1643,16 @@ julia> randstring()
 julia> randstring(MersenneTwister(0), 'a':'z', 6)
 "wijzek"
 
-julia> randstring("gcat")
-"tgtcaatc"
+julia> randstring("ACGT")
+"TATCGGTC"
 ```
 
 !!! note
-    The collection `chars` can be any collection of characters
-    (of type `Char` or `UInt8`)
-    from which [`rand`](@ref) can randomly pick characters.
+    `chars` can be any collection of characters, of type `Char` or
+    `UInt8` (more efficient), provided [`rand`](@ref) can randomly
+    pick characters from it.
 """
+
 randstring
 
 # Fill S (resized as needed) with a random subsequence of A, where

--- a/base/random.jl
+++ b/base/random.jl
@@ -1618,12 +1618,25 @@ end
 Base.show(io::IO, u::UUID) = write(io, Base.repr(u))
 
 # return a random string (often useful for temporary filenames/dirnames)
+
 let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
-    randstring(r::AbstractRNG, n::Int=8) = String(rand(r, b, n))
-    randstring(n::Int=8) = randstring(GLOBAL_RNG, n)
+    randstring(r::AbstractRNG, chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) =
+        String(rand(r, chars, n))
+    randstring(r::AbstractRNG, n::Int) = randstring(r, b, n)
+    randstring(chars::AbstractArray{<:Union{UInt8,Char}}=b, n::Int=8) = randstring(GLOBAL_RNG, chars, n)
+    randstring(n::Int) = randstring(GLOBAL_RNG, b, n)
 end
 
+"""
+    randstring([rng=GLOBAL_RNG], [chars::AbstractArray{<:Union{UInt8,Char}}], [len=8])
+
+Create a random ASCII string of length `len`, consisting of characters
+from `chars` if specified, and of upper- and lower-case letters and
+the digits 0-9 otherwise. The optional `rng` argument specifies a
+random number generator, see [Random Numbers](@ref).
+"""
+randstring
 
 # Fill S (resized as needed) with a random subsequence of A, where
 # each element of A is included in S with independent probability p.

--- a/test/random.jl
+++ b/test/random.jl
@@ -543,3 +543,17 @@ let r = MersenneTwister(0)
     @inferred Base.Random.reserve_1(r)
     @inferred Base.Random.reserve(r, 1)
 end
+
+# test randstring API
+let b = ['0':'9';'A':'Z';'a':'z'],
+    c = 'a':'z'
+    for rng = [[], [MersenneTwister(0)]]
+        @test length(randstring(rng...)) == 8
+        @test length(randstring(rng..., 20)) == 20
+        @test issubset(randstring(rng...), b)
+        @test issubset(randstring(rng..., c), c)
+        s = randstring(rng..., c, 20)
+        @test length(s) == 20
+        @test issubset(s, c)
+    end
+end

--- a/test/random.jl
+++ b/test/random.jl
@@ -552,13 +552,13 @@ let b = ['0':'9';'A':'Z';'a':'z']
         @test issubset(randstring(rng...), b)
         for c = ['a':'z', "qwèrtï", Set(Vector{UInt8}("gcat"))],
             len = [8, 20]
-            s = len == 8 ? randstring(rng..., c) : randstring(rng..., c, len)
-            @test length(s) == len
-            if eltype(c) == Char
-                @test issubset(s, c)
-            else # UInt8
-                @test issubset(s, map(Char, c))
-            end
+                s = len == 8 ? randstring(rng..., c) : randstring(rng..., c, len)
+                @test length(s) == len
+                if eltype(c) == Char
+                    @test issubset(s, c)
+                else # UInt8
+                    @test issubset(s, map(Char, c))
+                end
         end
     end
     @test randstring(MersenneTwister(0)) == randstring(MersenneTwister(0), b)

--- a/test/random.jl
+++ b/test/random.jl
@@ -545,15 +545,21 @@ let r = MersenneTwister(0)
 end
 
 # test randstring API
-let b = ['0':'9';'A':'Z';'a':'z'],
-    c = 'a':'z'
+let b = ['0':'9';'A':'Z';'a':'z']
     for rng = [[], [MersenneTwister(0)]]
         @test length(randstring(rng...)) == 8
         @test length(randstring(rng..., 20)) == 20
         @test issubset(randstring(rng...), b)
-        @test issubset(randstring(rng..., c), c)
-        s = randstring(rng..., c, 20)
-        @test length(s) == 20
-        @test issubset(s, c)
+        for c = ['a':'z', "qwèrtï", Set(Vector{UInt8}("gcat"))],
+            len = [8, 20]
+            s = len == 8 ? randstring(rng..., c) : randstring(rng..., c, len)
+            @test length(s) == len
+            if eltype(c) == Char
+                @test issubset(s, c)
+            else # UInt8
+                @test issubset(s, map(Char, c))
+            end
+        end
     end
+    @test randstring(MersenneTwister(0)) == randstring(MersenneTwister(0), b)
 end

--- a/test/random.jl
+++ b/test/random.jl
@@ -551,14 +551,14 @@ let b = ['0':'9';'A':'Z';'a':'z']
         @test length(randstring(rng..., 20)) == 20
         @test issubset(randstring(rng...), b)
         for c = ['a':'z', "qwèrtï", Set(Vector{UInt8}("gcat"))],
-            len = [8, 20]
-                s = len == 8 ? randstring(rng..., c) : randstring(rng..., c, len)
-                @test length(s) == len
-                if eltype(c) == Char
-                    @test issubset(s, c)
-                else # UInt8
-                    @test issubset(s, map(Char, c))
-                end
+                len = [8, 20]
+            s = len == 8 ? randstring(rng..., c) : randstring(rng..., c, len)
+            @test length(s) == len
+            if eltype(c) == Char
+                @test issubset(s, c)
+            else # UInt8
+                @test issubset(s, map(Char, c))
+            end
         end
     end
     @test randstring(MersenneTwister(0)) == randstring(MersenneTwister(0), b)


### PR DESCRIPTION
This allows the API `randstring([rng], [chars], len=8)`, e.g. `randstring('a':'z')` will produce a random string of length 8 of lower case letters.

~~I also added an alias as a method of `rand`: `rand([rng], ::Type{String}, [chars], len=8)`. I'm not sure both ways should exist, hence requesting for comments.~~ EDIT: this will be for another time (possibly with a different API).