### PR TITLE
fix alignment in complex numbers with exponents

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1343,7 +1343,7 @@ function alignment(io::IO, x::Real)
 end
 "`alignment(1 + 10im)` yields (3,5) for `1 +` and `_10im` (plus sign on left, space on right)"
 function alignment(io::IO, x::Complex)
-    m = match(r"^(.*[\+\-])(.*)$", sprint(0, show, x, env=io))
+    m = match(r"^(.*[^e][\+\-])(.*)$", sprint(0, show, x, env=io))
     m === nothing ? (length(sprint(0, show, x, env=io)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -967,10 +967,10 @@ end
 @testset "array printing with exponent format" begin
     a = [1.0 + 1e-10im, 2.0e-15 - 2.0e-5im, 1.0e-15 + 2im, 1.0 + 2e-15im]
     @test sprint((io, x) -> show(io, MIME("text/plain"), x), a) ==
-    join([
-        "4-element Array{Complex{Float64},1}:",
-        "     1.0+1.0e-10im",
-        " 2.0e-15-2.0e-5im ",
-        " 1.0e-15+2.0im    ",
-        "     1.0+2.0e-15im"], "\n")
+        join([
+            "4-element Array{Complex{Float64},1}:",
+            "     1.0+1.0e-10im",
+            " 2.0e-15-2.0e-5im ",
+            " 1.0e-15+2.0im    ",
+            "     1.0+2.0e-15im"], "\n")
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -963,3 +963,14 @@ end
     x = @inferred expm1(0.1f0im)
     @test x isa Complex64
 end
+
+@testset "array printing with exponent format" begin
+    a = [1.0 + 1e-10im, 2.0e-15 - 2.0e-5im, 1.0e-15 + 2im, 1.0 + 2e-15im]
+    @test sprint((io, x) -> show(io, MIME("text/plain"), x), a) ==
+    join([
+    "4-element Array{Complex{Float64},1}:",
+    "     1.0+1.0e-10im",
+    " 2.0e-15-2.0e-5im ",
+    " 1.0e-15+2.0im    ",
+    "     1.0+2.0e-15im"], "\n")
+end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -968,9 +968,9 @@ end
     a = [1.0 + 1e-10im, 2.0e-15 - 2.0e-5im, 1.0e-15 + 2im, 1.0 + 2e-15im]
     @test sprint((io, x) -> show(io, MIME("text/plain"), x), a) ==
     join([
-    "4-element Array{Complex{Float64},1}:",
-    "     1.0+1.0e-10im",
-    " 2.0e-15-2.0e-5im ",
-    " 1.0e-15+2.0im    ",
-    "     1.0+2.0e-15im"], "\n")
+        "4-element Array{Complex{Float64},1}:",
+        "     1.0+1.0e-10im",
+        " 2.0e-15-2.0e-5im ",
+        " 1.0e-15+2.0im    ",
+        "     1.0+2.0e-15im"], "\n")
 end


### PR DESCRIPTION
Ref: https://github.com/JuliaLang/julia/issues/29#issuecomment-306157662 cc @i-apellaniz

Before:

```
5-element Array{Complex{Float64},1}:
             0.441248-0.279063im  
          0.000860292+0.00161108im
             -16.1468-14.4275im   
 9.75539e-10+8.84465e-10im        
  -1.90441e-5-9.5242e-5im  
```

After

```
5-element Array{Complex{Float64},1}:
    0.441248-0.279063im   
 0.000860292+0.00161108im 
    -16.1468-14.4275im    
 9.75539e-10+8.84465e-10im
 -1.90441e-5-9.5242e-5im  

```