### PR TITLE
display macro

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1271,6 +1271,7 @@ export
 
     # output
     @show,
+    @display,
     @printf,
     @sprintf,
 

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -229,7 +229,7 @@ end
 macro display(exs...)
     blk = Expr(:block)
     for ex in exs
-        push!(blk.args, :(print($(sprint(show_unquoted,ex)*" = "))))
+        push!(blk.args, :(print($(sprint(print, ex)), " = ")))
         push!(blk.args, :(display(begin value=$(esc(ex)) end)))
         push!(blk.args, :(println()))
     end

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -225,6 +225,18 @@ function displayable(m::MIME)
     return false
 end
 
+
+macro display(exs...)
+    blk = Expr(:block)
+    for ex in exs
+        push!(blk.args, :(print($(sprint(show_unquoted,ex)*" = "))))
+        push!(blk.args, :(display(begin value=$(esc(ex)) end)))
+        push!(blk.args, :(println()))
+    end
+    if !isempty(exs); push!(blk.args, :value); end
+    return blk
+end
+
 ###########################################################################
 # The redisplay method can be overridden by a Display in order to
 # update an existing display (instead of, for example, opening a new


### PR DESCRIPTION
Add `@display`. This macro is to `display` what `@show` is for `show`. Fix #15820 and this [Discourse issue](https://discourse.julialang.org/t/how-to-print-arrays-inside-functions/4091)

Compare with `@show`
```julia
function f(x)
   @show x
   @display x
   return nothing
end
f(zeros(5, 5))
#> x = [0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 #> 0.0 0.0]
#> x = 5×5 Array{Float64,2}:
#> 0.0  0.0  0.0  0.0  0.0
#> 0.0  0.0  0.0  0.0  0.0
#> 0.0  0.0  0.0  0.0  0.0
#> 0.0  0.0  0.0  0.0  0.0
#> 0.0  0.0  0.0  0.0  0.0
```