### PR TITLE
fix #22239, stack overflow in type intersection

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1287,7 +1287,7 @@ static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int
         return ub;
     }
     else if (bb->constraintkind == 0) {
-        if (!jl_is_typevar(a)) {
+        if (!jl_is_typevar(bb->ub) && !jl_is_typevar(a)) {
             if (try_subtype_in_env(bb->ub, a, e))
                 return (jl_value_t*)b;
         }

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1108,3 +1108,8 @@ end
 @testintersect(Tuple{Type{B21613{Tuple{L},L}} where L, Any},
                Tuple{Type{SA}, Tuple} where SA<:(A21613{S} where S<:Tuple),
                Tuple{Type{B21613{Tuple{L},L}} where L, Tuple})
+
+# issue #22239
+@testintersect(Val{Pair{T,T}} where T,
+               Val{Pair{Int,T}} where T,
+               Val{Pair{Int,Int}})


### PR DESCRIPTION
The problem seems to be part of a heuristic fast path, so hopefully it is ok to kind of hack around it, which this does.