### PR TITLE
Use multi-line format in `@show`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -249,10 +249,11 @@ show_supertypes(typ::DataType) = show_supertypes(STDOUT, typ)
 macro show(exs...)
     blk = Expr(:block)
     for ex in exs
-        push!(blk.args, :(println($(sprint(show_unquoted,ex)*" = "),
-                                  repr(begin value=$(esc(ex)) end))))
+        push!(blk.args, :(print($(sprint(show_unquoted,ex)*" = "))))
+        push!(blk.args, :(show(STDOUT, "text/plain", begin value=$(esc(ex)) end)))
+        push!(blk.args, :(println()))
     end
-    if !isempty(exs); push!(blk.args, :value); end
+    isempty(exs) || push!(blk.args, :value)
     return blk
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -767,18 +767,15 @@ end
 
 
 # Test @show
-fname = tempname()
-f = open(fname, "w")
-redirect_stdout(f)
-@show x = 1 y = 2
-close(f)
-@test readstring(fname) == "x = 1 = 1\ny = 2 = 2\n"
-rm(fname)
-
-fname = tempname()
-f = open(fname, "w")
-redirect_stdout(f)
-@show zeros(2, 2)
-close(f)
-@test readstring(fname) == "zeros(2, 2) = 2×2 Array{Float64,2}:\n 0.0  0.0\n 0.0  0.0\n"
-rm(fname)
+let fname = tempname()
+    try
+        open(fname, "w") do fout
+            redirect_stdout(fout) do
+                @show zeros(2, 2)
+            end
+        end
+        @test readstring(fname) == "zeros(2, 2) = 2×2 Array{Float64,2}:\n 0.0  0.0\n 0.0  0.0\n"
+    finally
+        rm(fname, force=true)
+    end
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -764,3 +764,21 @@ end
 @test static_shown(Symbol("")) == "Symbol(\"\")"
 @test static_shown(Symbol("a/b")) == "Symbol(\"a/b\")"
 @test static_shown(Symbol("a-b")) == "Symbol(\"a-b\")"
+
+
+# Test @show
+fname = tempname()
+f = open(fname, "w")
+redirect_stdout(f)
+@show x = 1 y = 2
+close(f)
+@test readstring(fname) == "x = 1 = 1\ny = 2 = 2\n"
+rm(fname)
+
+fname = tempname()
+f = open(fname, "w")
+redirect_stdout(f)
+@show zeros(2, 2)
+close(f)
+@test readstring(fname) == "zeros(2, 2) = 2×2 Array{Float64,2}:\n 0.0  0.0\n 0.0  0.0\n"
+rm(fname)


### PR DESCRIPTION
`@show` now display objects using the multi-line format.

This pull request fixes #15820 and this [Discourse issue](https://discourse.julialang.org/t/how-to-print-arrays-inside-functions/4091).  Replaces pull request #22244