### PR TITLE
Add a custom LLVM pass to replace fastmath multiple and add with muladd

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -941,8 +941,11 @@ mod2pi(x) = rem2pi(x,RoundDown)
 """
     muladd(x, y, z)
 
-Combined multiply-add, computes `x*y+z` in an efficient manner. This may on some systems be
-equivalent to `x*y+z`, or to `fma(x,y,z)`. `muladd` is used to improve performance.
+Combined multiply-add, computes `x*y+z` allowing the add and multiply to be contracted with
+each other or ones from other `muladd` and `@fastmath` to form `fma`
+if the transformation can improve performance.
+The result can be different on different machines and can also be different on the same machine
+due to constant propagation or other optimizations.
 See [`fma`](@ref).
 
 # Example

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ endif
 LLVMLINK :=
 
 ifeq ($(JULIACODEGEN),LLVM)
-SRCS += codegen jitlayers disasm debuginfo llvm-simdloop llvm-ptls llvm-late-gc-lowering llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces cgmemmgr
+SRCS += codegen jitlayers disasm debuginfo llvm-simdloop llvm-ptls llvm-muladd llvm-late-gc-lowering llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces cgmemmgr
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -242,6 +242,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level)
     PM->add(createDeadCodeEliminationPass());
     PM->add(createLowerPTLSPass(imaging_mode));
 #endif
+    PM->add(createCombineMulAddPass());
 }
 
 extern "C" JL_DLLEXPORT

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -202,6 +202,7 @@ extern JuliaOJIT *jl_ExecutionEngine;
 JL_DLLEXPORT extern LLVMContext jl_LLVMContext;
 
 Pass *createLowerPTLSPass(bool imaging_mode);
+Pass *createCombineMulAddPass();
 Pass *createLateLowerGCFramePass();
 Pass *createLowerExcHandlersPass();
 Pass *createGCInvariantVerifierPass(bool Strong);

--- a/src/llvm-muladd.cpp
+++ b/src/llvm-muladd.cpp
@@ -1,0 +1,123 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#define DEBUG_TYPE "combine_muladd"
+#undef DEBUG
+#include "llvm-version.h"
+
+#include <llvm/IR/Value.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Operator.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/Debug.h>
+#include "fix_llvm_assert.h"
+
+#include "julia.h"
+
+using namespace llvm;
+
+/**
+ * Combine
+ * ```
+ * %v0 = fmul ... %a, %b
+ * %v = fadd fast ... %v0, %c
+ * ```
+ * to
+ * `%v = call fast @llvm.fmuladd.<...>(... %a, ... %b, ... %c)`
+ * when `%v0` has no other use
+ */
+
+struct CombineMulAdd : public FunctionPass {
+    static char ID;
+    CombineMulAdd() : FunctionPass(ID)
+    {}
+
+private:
+    bool runOnFunction(Function &F) override;
+};
+
+// Return true if this function shouldn't be called again on the other operand
+// This will always return false on LLVM 5.0+
+static bool checkCombine(Module *m, Instruction *addOp, Value *maybeMul, Value *addend,
+                         bool negadd, bool negres)
+{
+    auto mulOp = dyn_cast<Instruction>(maybeMul);
+    if (!mulOp || mulOp->getOpcode() != Instruction::FMul)
+        return false;
+    if (!mulOp->hasOneUse())
+        return false;
+#if JL_LLVM_VERSION >= 50000
+    // On 5.0+ we only need to mark the mulOp as contract and the backend will do the work for us.
+    auto fmf = mulOp->getFastMathFlags();
+    fmf.setAllowContract(true);
+    mulOp->copyFastMathFlags(fmf);
+    return false;
+#else
+    IRBuilder<> builder(m->getContext());
+    builder.SetInsertPoint(addOp);
+    auto mul1 = mulOp->getOperand(0);
+    auto mul2 = mulOp->getOperand(1);
+    Value *muladdf = Intrinsic::getDeclaration(m, Intrinsic::fmuladd, addOp->getType());
+    if (negadd) {
+        auto newaddend = builder.CreateFNeg(addend);
+        // Might be a const
+        if (auto neginst = dyn_cast<Instruction>(newaddend))
+            neginst->setHasUnsafeAlgebra(true);
+        addend = newaddend;
+    }
+    Instruction *newv = builder.CreateCall(muladdf, {mul1, mul2, addend});
+    newv->setHasUnsafeAlgebra(true);
+    if (negres) {
+        // Shouldn't be a constant
+        newv = cast<Instruction>(builder.CreateFNeg(newv));
+        newv->setHasUnsafeAlgebra(true);
+    }
+    addOp->replaceAllUsesWith(newv);
+    addOp->eraseFromParent();
+    mulOp->eraseFromParent();
+    return true;
+#endif
+}
+
+bool CombineMulAdd::runOnFunction(Function &F)
+{
+    Module *m = F.getParent();
+    for (auto &BB: F) {
+        for (auto it = BB.begin(); it != BB.end();) {
+            auto &I = *it;
+            it++;
+            switch (I.getOpcode()) {
+            case Instruction::FAdd: {
+                if (!I.hasUnsafeAlgebra())
+                    continue;
+                checkCombine(m, &I, I.getOperand(0), I.getOperand(1), false, false) ||
+                    checkCombine(m, &I, I.getOperand(1), I.getOperand(0), false, false);
+                break;
+            }
+            case Instruction::FSub: {
+                if (!I.hasUnsafeAlgebra())
+                    continue;
+                checkCombine(m, &I, I.getOperand(0), I.getOperand(1), true, false) ||
+                    checkCombine(m, &I, I.getOperand(1), I.getOperand(0), true, true);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return true;
+}
+
+char CombineMulAdd::ID = 0;
+static RegisterPass<CombineMulAdd> X("CombineMulAdd", "Combine mul and add to muladd",
+                                     false /* Only looks at CFG */,
+                                     false /* Analysis Pass */);
+
+Pass *createCombineMulAddPass()
+{
+    return new CombineMulAdd();
+}

--- a/test/llvmpasses/muladd.ll
+++ b/test/llvmpasses/muladd.ll
@@ -1,0 +1,28 @@
+; RUN: opt -load libjulia.so -CombineMulAdd -S %s | FileCheck %s
+
+define double @fast_muladd1(double %a, double %b, double %c) {
+top:
+; CHECK: {{contract|fmuladd}}
+  %v1 = fmul double %a, %b
+  %v2 = fadd fast double %v1, %c
+; CHECK: ret double
+  ret double %v2
+}
+
+define double @fast_mulsub1(double %a, double %b, double %c) {
+top:
+; CHECK: {{contract|fmuladd}}
+  %v1 = fmul double %a, %b
+  %v2 = fsub fast double %v1, %c
+; CHECK: ret double
+  ret double %v2
+}
+
+define <2 x double> @fast_mulsub_vec1(<2 x double> %a, <2 x double> %b, <2 x double> %c) {
+top:
+; CHECK: {{contract|fmuladd}}
+  %v1 = fmul <2 x double> %a, %b
+  %v2 = fsub fast <2 x double> %c, %v1
+; CHECK: ret <2 x double>
+  ret <2 x double> %v2
+}


### PR DESCRIPTION
Now that it's our norm to use custom LLVM passes....

This currently does the replacement as long as one of the instruction allows unsafe arithmetic
mainly because LLVM vectorization pass does not always preserve the fastmath flags. This is arguable though I don't think there'll be any problem since this optimization is only done when the intermediate result is not being used or in another word when the `fmul` and `fadd` are producing only one result while allowing some contraction in this process....

I guess this kind of makes `muladd` obsolete, oh, well ;-p...

Fix #18654, Fix #22217

For simple cases:

```julia
julia> f1(a, b, c) = @fastmath a * b + c
f1 (generic function with 1 method)

julia> f2(a, b, c) = @fastmath a * b - c
f2 (generic function with 1 method)

julia> f3(a, b, c) = @fastmath c - a * b
f3 (generic function with 1 method)

julia> @code_native f1(1.0, 2.0, 3.0)
        .text
Filename: REPL[1]
        pushq   %rbp
        movq    %rsp, %rbp
        vfmadd213sd     %xmm2, %xmm1, %xmm0
Source line: 1
        popq    %rbp
        retq
        nopl    (%rax,%rax)

julia> @code_native f2(1.0, 2.0, 3.0)
        .text
Filename: REPL[2]
        pushq   %rbp
        movq    %rsp, %rbp
        vfmsub213sd     %xmm2, %xmm1, %xmm0
Source line: 1
        popq    %rbp
        retq
        nopl    (%rax,%rax)

julia> @code_native f3(1.0, 2.0, 3.0)
        .text
Filename: REPL[3]
        pushq   %rbp
        movq    %rsp, %rbp
        vfnmadd213sd    %xmm2, %xmm1, %xmm0
Source line: 1
        popq    %rbp
        retq
        nopl    (%rax,%rax)
```

For the complex case enabled by running this after the loop vectorizer
```julia
julia> function f(a, b)
           s = zero(eltype(a))
           @inbounds @simd for i in 1:length(a)
               s += a[i] * b[i]
           end
           return s
       end
f (generic function with 1 method)

julia> @code_llvm f(Float64[], Float64[])
...
  %34 = getelementptr double, double* %28, i64 12
  %35 = bitcast double* %34 to <4 x double>*
  %wide.load106 = load <4 x double>, <4 x double>* %35, align 8
  %36 = call <4 x double> @llvm.fmuladd.v4f64(<4 x double> %wide.load, <4 x double> %wide.load103, <4 x double> %vec.phi)
  %37 = call <4 x double> @llvm.fmuladd.v4f64(<4 x double> %wide.load100, <4 x double> %wide.load104, <4 x double> %vec.phi94)
  %38 = call <4 x double> @llvm.fmuladd.v4f64(<4 x double> %wide.load101, <4 x double> %wide.load105, <4 x double> %vec.phi95)
  %39 = call <4 x double> @llvm.fmuladd.v4f64(<4 x double> %wide.load102, <4 x double> %wide.load106, <4 x double> %vec.phi96)
  %index.next = add i64 %index, 16
  %40 = icmp eq i64 %index.next, %n.vec
  br i1 %40, label %middle.block, label %vector.body
...
```
