### PR TITLE
allow passing a type in rand!

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -285,11 +285,13 @@ rand!(A::AbstractArray) = rand!(GLOBAL_RNG, A)
 rand(r::AbstractArray) = rand(GLOBAL_RNG, r)
 
 """
-    rand!([rng=GLOBAL_RNG], A, [coll])
+    rand!([rng=GLOBAL_RNG], A, [S=eltype(A)])
 
-Populate the array `A` with random values. If the collection `coll` is specified,
-the values are picked randomly from `coll`. This is equivalent to `copy!(A, rand(rng, coll, size(A)))`
-or `copy!(A, rand(rng, eltype(A), size(A)))` but without allocating a new array.
+Populate the array `A` with random values. If `S` is specified
+(`S` can be a type or a collection, cf. [`rand`](@ref) for details),
+the values are picked randomly from `S`.
+This is equivalent to `copy!(A, rand(rng, S, size(A)))`
+but without allocating a new array.
 """
 rand!(A::AbstractArray, r::AbstractArray) = rand!(GLOBAL_RNG, A, r)
 
@@ -389,12 +391,14 @@ rand(r::AbstractRNG, T::Type, d1::Integer, dims::Integer...) = rand(r, T, tuple(
 # rand(r, ()) would match both this method and rand(r, dims::Dims)
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
 
-function rand!(r::AbstractRNG, A::AbstractArray{T}) where T
+function rand!(r::AbstractRNG, A::AbstractArray{T}, ::Type{X}=T) where {T,X}
     for i in eachindex(A)
-        @inbounds A[i] = rand(r, T)
+        @inbounds A[i] = rand(r, X)
     end
     A
 end
+
+rand!(A::AbstractArray, ::Type{X}) where {X} = rand!(GLOBAL_RNG, A, X)
 
 function rand!(r::AbstractRNG, A::AbstractArray, s::Union{Dict,Set,IntSet})
     for i in eachindex(A)

--- a/test/random.jl
+++ b/test/random.jl
@@ -309,11 +309,13 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
     ftypes = [Float16, Float32, Float64]
     cftypes = [Complex32, Complex64, Complex128, ftypes...]
     types = [Bool, Char, Base.BitInteger_types..., ftypes...]
-    collections = [(IntSet(rand(1:100, 20)), Int),
-                   (Set(rand(Int, 20)), Int),
-                   (Dict(zip(rand(Int,10), rand(Int, 10))), Pair{Int,Int}),
-                   (1:100, Int),
-                   (rand(Int, 100), Int)]
+    collections = [IntSet(rand(1:100, 20))                => Int,
+                   Set(rand(Int, 20))                     => Int,
+                   Dict(zip(rand(Int,10), rand(Int, 10))) => Pair{Int,Int},
+                   1:100                                  => Int,
+                   rand(Int, 100)                         => Int,
+                   Int                                    => Int,
+                   Float64                                => Float64]
     b2 = big(2)
     u3 = UInt(3)
     for f in [rand, randn, randexp]
@@ -342,7 +344,11 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
         a3 = rand!(rng..., Array{T}(5), C)    ::Vector{T}
         a4 = rand!(rng..., Array{T}(2, 3), C) ::Array{T, 2}
         for a in [a0, a1..., a2..., a3..., a4...]
-            @test a in C
+            if C isa Type
+                @test a isa C
+            else
+                @test a in C
+            end
         end
     end
     for C in [1:0, Dict(), Set(), IntSet(), Int[]]


### PR DESCRIPTION
This is for completeness (to have `rand!(A, S)` equivalent to `copy!(A, rand(S, size(A)`). This allows to call e.g. 
```
julia> rand!(Number[1, 2.2], Int)
2-element Array{Number,1}:
 -8360691903160122118
  9128535470341546347
```
