### PR TITLE
Treat sub and div as induction in simd loop lowering

### DIFF
--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -67,13 +67,15 @@ struct LowerSIMDLoop: public LoopPass {
     LowerSIMDLoop() : LoopPass(ID) {}
 
 private:
-    /*override*/ bool runOnLoop(Loop *, LPPassManager &LPM);
+    bool runOnLoop(Loop *, LPPassManager &LPM) override;
 
     /// Check if loop has "simd_loop" annotation.
     /// If present, the annotation is an MDNode attached to an instruction in the loop's latch.
     bool hasSIMDLoopMetadata( Loop *L) const;
 
-    /// If Phi is part of a reduction cycle of FAdd or FMul, mark the ops as permitting reassociation/commuting.
+    /// If Phi is part of a reduction cycle of FAdd, FSub, FMul or FDiv,
+    /// mark the ops as permitting reassociation/commuting.
+    /// As of LLVM 4.0, FDiv is not handled by the loop vectorizer
     void enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const;
 };
 
@@ -85,6 +87,26 @@ bool LowerSIMDLoop::hasSIMDLoopMetadata(Loop *L) const
             if (II->getMetadata(simd_loop_mdkind))
                 return true;
     return false;
+}
+
+static unsigned getReduceOpcode(Instruction *J, Instruction *operand)
+{
+    switch (J->getOpcode()) {
+    case Instruction::FSub:
+        if (J->getOperand(0) != operand)
+            return 0;
+        JL_FALLTHROUGH;
+    case Instruction::FAdd:
+        return Instruction::FAdd;
+    case Instruction::FDiv:
+        if (J->getOperand(0) != operand)
+            return 0;
+        JL_FALLTHROUGH;
+    case Instruction::FMul:
+        return Instruction::FMul;
+    default:
+        return 0;
+    }
 }
 
 void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const
@@ -115,21 +137,21 @@ void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const
             DEBUG(dbgs() << "LSL: chain prematurely terminated at " << *I << "\n");
             return;
         }
-        if (J==Phi) {
+        if (J == Phi) {
             // Found the entire chain.
             break;
         }
         if (opcode) {
             // Check that arithmetic op matches prior arithmetic ops in the chain.
-            if (J->getOpcode()!=opcode) {
+            if (getReduceOpcode(J, I) != opcode) {
                 DEBUG(dbgs() << "LSL: chain broke at " << *J << " because of wrong opcode\n");
                 return;
             }
         }
         else {
             // First arithmetic op in the chain.
-            opcode = J->getOpcode();
-            if (opcode!=Instruction::FAdd && opcode!=Instruction::FMul) {
+            opcode = getReduceOpcode(J, I);
+            if (!opcode) {
                 DEBUG(dbgs() << "LSL: first arithmetic op in chain is uninteresting" << *J << "\n");
                 return;
             }

--- a/test/llvmpasses/simdloop.ll
+++ b/test/llvmpasses/simdloop.ll
@@ -8,8 +8,8 @@ loop:
   %aptr = getelementptr double, double *%a, i64 %i
   %bptr = getelementptr double, double *%b, i64 %i
 ; CHECK: llvm.mem.parallel_loop_access
-  %aval = load double, double *%aptr 
-  %bval = load double, double *%aptr 
+  %aval = load double, double *%aptr
+  %bval = load double, double *%aptr
   %cval = fadd double %aval, %bval
   store double %cval, double *%bptr
   %nexti = add i64 %i, 1, !simd_loop !1
@@ -17,6 +17,24 @@ loop:
   br i1 %done, label %loopdone, label %loop
 loopdone:
   ret void
+}
+
+define double @simd_test_sub(double *%a) {
+top:
+  br label %loop
+loop:
+  %i = phi i64 [0, %top], [%nexti, %loop]
+  %v = phi double [0.000000e+00, %top], [%nextv, %loop]
+  %aptr = getelementptr double, double *%a, i64 %i
+; CHECK: llvm.mem.parallel_loop_access
+  %aval = load double, double *%aptr
+  %nextv = fsub double %v, %aval
+; CHECK: fsub fast double %v, %aval
+  %nexti = add i64 %i, 1, !simd_loop !1
+  %done = icmp sgt i64 %nexti, 500
+  br i1 %done, label %loopdone, label %loop
+loopdone:
+  ret double %nextv
 }
 
 !1 = !{}


### PR DESCRIPTION
This makes sure induction like

```julia
s -= a[i]
```

in an at-simd loop can be vectorized without fastmath annotation.

LLVM currently support at least sub in the vectorizer.
I don't see why it can't handle div so let's first make sure we are ready for that.

@nanosoldier `runbenchmarks(ALL, vs = ":master")`
