### PR TITLE
incremental serialize: restore recache order back to original

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -3280,10 +3280,10 @@ static jl_value_t *_jl_restore_incremental(ios_t *f)
     // at this point, the AST is fully reconstructed, but still completely disconnected
     // now all of the interconnects will be created
     jl_recache_types(); // make all of the types identities correct
+    jl_recache_other(&dependent_worlds); // make all of the other objects identities correct (needs to be after recache types)
     init_order = jl_finalize_deserializer(&s, tracee_list); // done with f and s (needs to be after recache types)
-    jl_insert_methods(&external_methods); // hook up methods of external generic functions (needs to be after recache types)
-    jl_recache_other(&dependent_worlds); // make all of the other objects identities correct (needs to be after insert methods)
-    jl_insert_backedges(&external_backedges); // restore external backedges (needs to be after recache other)
+    jl_insert_methods(&external_methods); // hook up methods of external generic functions (needs to be after recache other)
+    jl_insert_backedges(&external_backedges); // restore external backedges (needs to be after insert methods)
     free_linkedlist(external_methods.next);
     free_linkedlist(external_backedges.next);
     serializer_worklist = NULL;


### PR DESCRIPTION
the commit fix for #265 reshuffled this order, but that was wrong
the correctness of jl_recache_other has since been fixed,
permitting this to go back to the correct original order

fix #22171