### PR TITLE
Add fastly purging to contrib/prepare_release.sh

### DIFF
--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -90,6 +90,7 @@ aws s3 cp --acl public-read "julia-$version-osx10.7 .dmg" \
 aws s3 cp --acl public-read "julia-$majmin-latest-osx10.7 .dmg" \
   s3://julialang/bin/osx/x64/$majmin/
 curl -X PURGE -L "https://julialang-s3.julialang.org/bin/osx/x64/$majmin/julia-$majmin-latest-osx10.7 .dmg"
+curl -X PURGE -L "https://julialang-s3.julialang.org/bin/osx/x64/$majmin/julia-$majmin-latest-osx10.7+.dmg"
 aws s3 cp --acl public-read "julia-$version-win64.exe" \
   s3://julialang/bin/winnt/x64/$majmin/
 aws s3 cp --acl public-read "julia-$majmin-latest-win64.exe" \

--- a/contrib/prepare_release.sh
+++ b/contrib/prepare_release.sh
@@ -83,19 +83,24 @@ for plat in x86_64 i686 arm ppc64le; do
     s3://julialang/bin/linux/$platshort/$majmin/
   aws s3 cp --acl public-read julia-$majmin-latest-linux-$plat.tar.gz \
     s3://julialang/bin/linux/$platshort/$majmin/
+  curl -X PURGE -L "https://julialang-s3.julialang.org/bin/linux/$platshort/$majmin/julia-$majmin-latest-linux-$plat.tar.gz"
 done
 aws s3 cp --acl public-read "julia-$version-osx10.7 .dmg" \
   s3://julialang/bin/osx/x64/$majmin/
 aws s3 cp --acl public-read "julia-$majmin-latest-osx10.7 .dmg" \
   s3://julialang/bin/osx/x64/$majmin/
+curl -X PURGE -L "https://julialang-s3.julialang.org/bin/osx/x64/$majmin/julia-$majmin-latest-osx10.7 .dmg"
 aws s3 cp --acl public-read "julia-$version-win64.exe" \
   s3://julialang/bin/winnt/x64/$majmin/
 aws s3 cp --acl public-read "julia-$majmin-latest-win64.exe" \
   s3://julialang/bin/winnt/x64/$majmin/
+curl -X PURGE -L "https://julialang-s3.julialang.org/bin/winnt/x64/$majmin/julia-$majmin-latest-win64.exe"
 aws s3 cp --acl public-read "julia-$version-win32.exe" \
   s3://julialang/bin/winnt/x86/$majmin/
 aws s3 cp --acl public-read "julia-$majmin-latest-win32.exe" \
   s3://julialang/bin/winnt/x86/$majmin/
+curl -X PURGE -L "https://julialang-s3.julialang.org/bin/winnt/x86/$majmin/julia-$majmin-latest-win32.exe"
+
 
 echo "All files prepared. Attach julia-$version.tar.gz"
 echo "and julia-$version-full.tar.gz to github releases."


### PR DESCRIPTION
Fastly caches our files for a long time; we need to explicitly ask it to purge the -latest files.