### PR TITLE
Show evaluated expr when `@test isequal(...)` fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,8 @@ Library improvements
 
   * Added `unique!` which is an inplace version of `unique` ([#20549]).
 
+  * `@test isequal(x, y)` now prints an evaluated expression when the test fails ([#22296]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -79,7 +79,8 @@ Library improvements
 
   * Added `unique!` which is an inplace version of `unique` ([#20549]).
 
-  * `@test isequal(x, y)` now prints an evaluated expression when the test fails ([#22296]).
+  * `@test isequal(x, y)` and `@test isapprox(x, y)` now prints an evaluated expression when
+    the test fails ([#22296]).
 
 Compiler/Runtime improvements
 -----------------------------

--- a/base/test.jl
+++ b/base/test.jl
@@ -322,7 +322,7 @@ function get_test_result(ex)
             Expr(:comparison, $(escaped_terms...)),
             Expr(:comparison, $(quoted_terms...)),
         ))
-    elseif isa(ex, Expr) && ex.head == :call && ex.args[1] == :isequal
+    elseif isa(ex, Expr) && ex.head == :call && ex.args[1] in (:isequal, :isapprox)
         escaped_terms = [esc(arg) for arg in ex.args]
         quoted_terms = [QuoteNode(arg) for arg in ex.args]
         testret = :(eval_test(

--- a/test/test.jl
+++ b/test/test.jl
@@ -11,6 +11,10 @@
 let g = Int[], f = (x) -> (push!(g, x); x)
     @test f(1) == 1
     @test g == [1]
+
+    empty!(g)
+    @test isequal(f(2), 2)
+    @test g == [2]
 end
 
 # Test @test_broken with fail
@@ -74,6 +78,8 @@ fails = @testset NoThrowTestSet begin
     @test 1+0 == 2+0 == 3+0
     # Fail - comparison call
     @test ==(1 - 2, 2 - 1)
+    # Fail - isequal
+    @test isequal(0 / 0, 1 / 0)
     # Error - unexpected pass
     @test_broken true
 end
@@ -106,6 +112,10 @@ str = sprint(show, fails[6])
 @test contains(str, "Evaluated: -1 == 1")
 
 str = sprint(show, fails[7])
+@test contains(str, "Expression: isequal(0 / 0, 1 / 0)")
+@test contains(str, "Evaluated: isequal(NaN, Inf)")
+
+str = sprint(show, fails[8])
 @test contains(str, "Unexpected Pass")
 @test contains(str, "Expression: true")
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -80,6 +80,8 @@ fails = @testset NoThrowTestSet begin
     @test ==(1 - 2, 2 - 1)
     # Fail - isequal
     @test isequal(0 / 0, 1 / 0)
+    # Fail - isapprox
+    @test isapprox(0 / 1, -1 / 0)
     # Error - unexpected pass
     @test_broken true
 end
@@ -116,6 +118,10 @@ str = sprint(show, fails[7])
 @test contains(str, "Evaluated: isequal(NaN, Inf)")
 
 str = sprint(show, fails[8])
+@test contains(str, "Expression: isapprox(0 / 1, -1 / 0)")
+@test contains(str, "Evaluated: isapprox(0.0, -Inf)")
+
+str = sprint(show, fails[9])
 @test contains(str, "Unexpected Pass")
 @test contains(str, "Expression: true")
 


### PR DESCRIPTION
Support showing the evaluated version of the expression when using `@test` with `isequal`:

```julia
julia> using Base.Test

julia> x, y = 1, 2
(1, 2)

julia> @test isequal(x, y)
Test Failed
  Expression: isequal(x, y)
   Evaluated: isequal(1, 2)
ERROR: There was an error during testing
```