### PR TITLE
make vcat of SparseVectors with different el- and/or ind-type yield SparseVector (#22225)

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -876,6 +876,11 @@ end
 # of _absspvec_vcat below. The <:Integer qualifications are necessary for correct dispatch.
 vcat(X::SparseVector{Tv,Ti}...) where {Tv,Ti<:Integer} = _absspvec_vcat(X...)
 vcat(X::AbstractSparseVector{Tv,Ti}...) where {Tv,Ti<:Integer} = _absspvec_vcat(X...)
+function vcat(X::SparseVector...)
+    commeltype = promote_type(map(eltype, X)...)
+    commindtype = promote_type(map(indtype, X)...)
+    vcat(map(x -> SparseVector{commeltype,commindtype}(x), X)...)
+end
 function _absspvec_vcat(X::AbstractSparseVector{Tv,Ti}...) where {Tv,Ti}
     # check sizes
     n = length(X)

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -474,7 +474,12 @@ let N = 4
     @test issparse(cat((1,2), densemat, diagmat, spmat, densevec, spvec))
     @test issparse(cat((1,2), spvec, diagmat, densevec, spmat, densemat))
 end
-
+@testset "vertical concatenation of SparseVectors with different el- and ind-type (#22225)" begin
+    spv6464 = SparseVector(0, Int64[], Int64[])
+    @test isa(vcat(spv6464, SparseVector(0, Int64[], Int32[])), SparseVector{Int64,Int64})
+    @test isa(vcat(spv6464, SparseVector(0, Int32[], Int64[])), SparseVector{Int64,Int64})
+    @test isa(vcat(spv6464, SparseVector(0, Int32[], Int32[])), SparseVector{Int64,Int64})
+end
 
 ## sparsemat: combinations with sparse matrix
 


### PR DESCRIPTION
Fixes the first part of #22225. Best!

(Probably should be backported alongside #22299: #22299 fixes the second part of #22225, but makes the bug in the first part of #22225 worse (wrong result type -> stack overflow). This pull request fixes the stack overflow.)