### PR TITLE
Fix reuse of client port on FreeBSD

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -823,6 +823,15 @@ JL_DLLEXPORT int jl_tcp_quickack(uv_tcp_t *handle, int on)
 
 #endif
 
+JL_DLLEXPORT int jl_has_so_reuseport(void)
+{
+#if defined(SO_REUSEPORT)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 JL_DLLEXPORT int jl_tcp_reuseport(uv_tcp_t *handle)
 {
 #if defined(SO_REUSEPORT)
@@ -833,7 +842,7 @@ JL_DLLEXPORT int jl_tcp_reuseport(uv_tcp_t *handle)
     }
     return 0;
 #else
-    return 1;
+    return -1;
 #endif
 }
 

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -48,15 +48,10 @@ end
 
 # Test that the client port is reused. SO_REUSEPORT may not be supported on
 # all UNIX platforms, Linux kernels prior to 3.9 and older versions of OSX
-if is_unix()
-    # Run reuse client port tests only if SO_REUSEPORT is supported.
-    s = TCPSocket(delay = false)
-    is_linux() && Base.Distributed.bind_client_port(s)
-    if ccall(:jl_tcp_reuseport, Int32, (Ptr{Void},), s.handle) == 0
-        reuseport_tests()
-    else
-        info("SO_REUSEPORT is unsupported, skipping reuseport tests.")
-    end
+if ccall(:jl_has_so_reuseport, Int32, ()) == 1
+    reuseport_tests()
+else
+    info("SO_REUSEPORT is unsupported, skipping reuseport tests.")
 end
 
 id_me = myid()


### PR DESCRIPTION
Fixes #22302 

I think DragonFly BSD might do the same thing as Linux here but I can't confirm because I've yet to get Julia to build on DragonFly. This at least gets the distributed tests passing on FreeBSD.