### PR TITLE
include Hermitian{<:Real} in signature for symmetric blas matmul

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -281,12 +281,18 @@ end
 ## Matvec
 A_mul_B!(y::StridedVector{T}, A::Symmetric{T,<:StridedMatrix}, x::StridedVector{T}) where {T<:BlasFloat} =
     BLAS.symv!(A.uplo, one(T), A.data, x, zero(T), y)
+A_mul_B!(y::StridedVector{T}, A::Hermitian{T,<:StridedMatrix}, x::StridedVector{T}) where {T<:BlasReal} =
+    BLAS.symv!(A.uplo, one(T), A.data, x, zero(T), y)
 A_mul_B!(y::StridedVector{T}, A::Hermitian{T,<:StridedMatrix}, x::StridedVector{T}) where {T<:BlasComplex} =
     BLAS.hemv!(A.uplo, one(T), A.data, x, zero(T), y)
 ## Matmat
 A_mul_B!(C::StridedMatrix{T}, A::Symmetric{T,<:StridedMatrix}, B::StridedMatrix{T}) where {T<:BlasFloat} =
     BLAS.symm!('L', A.uplo, one(T), A.data, B, zero(T), C)
 A_mul_B!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Symmetric{T,<:StridedMatrix}) where {T<:BlasFloat} =
+    BLAS.symm!('R', B.uplo, one(T), B.data, A, zero(T), C)
+A_mul_B!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{T}) where {T<:BlasReal} =
+    BLAS.symm!('L', A.uplo, one(T), A.data, B, zero(T), C)
+A_mul_B!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix}) where {T<:BlasReal} =
     BLAS.symm!('R', B.uplo, one(T), B.data, A, zero(T), C)
 A_mul_B!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{T}) where {T<:BlasComplex} =
     BLAS.hemm!('L', A.uplo, one(T), A.data, B, zero(T), C)


### PR DESCRIPTION
This dispatches matvec/matmat with `A::Hermitian{<:BlasReal}` to `BLAS.symv!`/`BLAS.symm!` rather than `generic_matvecmul!`/`generic_matmatmul!`:

```julia
using BenchmarkTools
for n in (10, 100, 1000)
    A = rand(n, n)
    b = rand(n)
    B = rand(n, n)
    H = Hermitian(A)
    @btime $H * $b
    @btime $H * $B
end
```

master:
```julia
1.545 μs (1 allocation: 160 bytes)
1.455 μs (5 allocations: 1.09 KiB)
148.136 μs (1 allocation: 896 bytes)
1.564 ms (8 allocations: 78.53 KiB)
19.717 ms (1 allocation: 7.94 KiB)
1.773 s (8 allocations: 7.63 MiB)
```

PR:
```julia
561.506 ns (1 allocation: 160 bytes)
392.736 ns (1 allocation: 896 bytes)
3.199 μs (1 allocation: 896 bytes)
47.599 μs (2 allocations: 78.20 KiB)
99.609 μs (1 allocation: 7.94 KiB)
31.843 ms (2 allocations: 7.63 MiB)
```

Edit: updated with mat-mat benchmarks too.