### PR TITLE
add a base keyword to logspace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,9 @@ Library improvements
     git repo. Additionally, the argument order was changed to be consistent with the git
     command line tool ([#22062]).
 
+  * `logspace` now accepts a `base` keyword argument to specify the base of the logarithmic
+    range. The base defaults to 10 ([#22310]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -316,9 +316,9 @@ function print_range(io::IO, r::Range,
 end
 
 """
-    logspace(start::Real, stop::Real, n::Integer=50)
+    logspace(start::Real, stop::Real, n::Integer=50; base=10)
 
-Construct a vector of `n` logarithmically spaced numbers from `10^start` to `10^stop`.
+Construct a vector of `n` logarithmically spaced numbers from `base^start` to `base^stop`.
 
 ```jldoctest
 julia> logspace(1.,10.,5)
@@ -328,9 +328,17 @@ julia> logspace(1.,10.,5)
     3.16228e5
     5.62341e7
     1.0e10
+
+julia> logspace(1.,10.,5,base=2)
+5-element Array{Float64,1}:
+    2.0
+    9.51366
+   45.2548
+  215.269
+ 1024.0
 ```
 """
-logspace(start::Real, stop::Real, n::Integer=50) = 10.^linspace(start, stop, n)
+logspace(start::Real, stop::Real, n::Integer=50; base=10) = base.^linspace(start, stop, n)
 
 ## interface implementations
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -918,3 +918,14 @@ let linsp = linspace(1.0, 2.0, 10)
     @test Float32(linsp.ref) === convert(Float32, linsp.ref)
     @test Float32(linsp.ref) ≈ linsp.ref.hi + linsp.ref.lo
 end
+
+@testset "logspace" begin
+    n = 10; a = 2; b = 4
+    # test default values; n = 50, base = 10
+    @test logspace(a, b) == logspace(a, b, 50) == 10.^linspace(a, b, 50)
+    @test logspace(a, b, n) == 10.^linspace(a, b, n)
+    for base in (10, 2, e)
+        @test logspace(a, b, base=base) == logspace(a, b, 50, base=base) == base.^linspace(a, b, 50)
+        @test logspace(a, b, n, base=base) == base.^linspace(a, b, n)
+    end
+end


### PR DESCRIPTION
Example:
```julia
julia> logspace(1, 4, 4, base=2)
4-element Array{Float64,1}:
  2.0
  4.0
  8.0
 16.0

julia> logspace(1, 3, 3, base=10)
3-element Array{Float64,1}:
   10.0
  100.0
 1000.0
```

(ref https://docs.scipy.org/doc/numpy/reference/generated/numpy.logspace.html)