### PR TITLE
Fix inInference state corruption.

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -262,7 +262,7 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t **pli, size_t world, int forc
     li->inInference = 1;
     jl_svec_t *linfo_src_rettype = (jl_svec_t*)jl_apply_with_saved_exception_state(fargs, 3, 0);
     ptls->world_age = last_age;
-    assert((jl_is_method(li->def.method) || li->inInference == 0) && "inference failed on a toplevel expr");
+    li->inInference = 0;
 
     jl_code_info_t *src = NULL;
     if (linfo_src_rettype &&

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -856,3 +856,10 @@ let f, m
     ]
     @test @inferred(f()) == 6
 end
+
+# issue #22290
+f22290() = return nothing
+for i in 1:3
+    ir = sprint(io->code_llvm(io, f22290, Tuple{}))
+    @test contains(ir, "julia_f22290")
+end

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -174,7 +174,7 @@ let gf_err, tsk = @async nothing # create a Task for yield to try to run
     end
     @test_throws ErrorException gf_err()
     @test_throws ErrorException gf_err()
-    @test gf_err_ref[] == 3
+    @test gf_err_ref[] == 4
 end
 
 gf_err_ref[] = 0


### PR DESCRIPTION
This led to non-idempotent irgen.
Fixes #22290, caused by #21677.