### PR TITLE
Fix issues with showing failed `@test` results

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -300,10 +300,7 @@ function get_test_result(ex)
                                          $(esc(ex.args[2])), $(esc(ex.args[1])), $(esc(ex.args[3])))))
     elseif isa(ex, Expr) && ex.head == :comparison
         # pass all terms of the comparison to `eval_comparison`, as an Expr
-        terms = ex.args
-        for i = 1:length(terms)
-            terms[i] = esc(terms[i])
-        end
+        terms = [esc(arg) for arg in ex.args]
         testret = :(eval_comparison(Expr(:comparison, $(terms...))))
     else
         testret = :(Returned($(esc(ex)), nothing))

--- a/test/test.jl
+++ b/test/test.jl
@@ -76,12 +76,30 @@ end
 for i in 1:length(fails) - 1
     @test isa(fails[i], Base.Test.Fail)
 end
-@test contains(sprint(show, fails[1]), "Thrown: ErrorException")
-@test contains(sprint(show, fails[2]), "No exception thrown")
-@test contains(sprint(show, fails[3]), "Evaluated: 2 == 4")
-@test contains(sprint(show, fails[4]), "Evaluated: 1.0 ≈ 2.0")
-@test contains(sprint(show, fails[5]), "Evaluated: 1 == 2 == 3")
-@test contains(sprint(show, fails[6]), "Unexpected Pass")
+
+str = sprint(show, fails[1])
+@test contains(str, "Expression: error()")
+@test contains(str, "Thrown: ErrorException")
+
+str = sprint(show, fails[2])
+@test contains(str, "Expression: 1 + 1")
+@test contains(str, "No exception thrown")
+
+str = sprint(show, fails[3])
+@test contains(str, "Expression: 1 + 1 == 2 + 2")
+@test contains(str, "Evaluated: 2 == 4")
+
+str = sprint(show, fails[4])
+@test contains(str, "Expression: 1 / 1 ≈ 2 / 1")
+@test contains(str, "Evaluated: 1.0 ≈ 2.0")
+
+str = sprint(show, fails[5])
+@test contains(str, "Expression: 1 + 0 == 2 + 0 == 3 + 0")
+@test contains(str, "Evaluated: 1 == 2 == 3")
+
+str = sprint(show, fails[6])
+@test contains(str, "Unexpected Pass")
+@test contains(str, "Expression: true")
 
 # Test printing of a TestSetException
 tse_str = sprint(show, Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}()))

--- a/test/test.jl
+++ b/test/test.jl
@@ -70,6 +70,8 @@ fails = @testset NoThrowTestSet begin
     @test 1/1 ≈ 2/1
     # Fail - chained comparison
     @test 1+0 == 2+0 == 3+0
+    # Fail - comparison call
+    @test ==(1 - 2, 2 - 1)
     # Error - unexpected pass
     @test_broken true
 end
@@ -98,6 +100,10 @@ str = sprint(show, fails[5])
 @test contains(str, "Evaluated: 1 == 2 == 3")
 
 str = sprint(show, fails[6])
+@test contains(str, "Expression: 1 - 2 == 2 - 1")
+@test contains(str, "Evaluated: -1 == 1")
+
+str = sprint(show, fails[7])
 @test contains(str, "Unexpected Pass")
 @test contains(str, "Expression: true")
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -7,6 +7,12 @@
 @test strip("\t  hi   \n") == "hi"
 @test strip("\t  this should fail   \n") != "hi"
 
+# @test should only evaluate the arguments once
+let g = Int[], f = (x) -> (push!(g, x); x)
+    @test f(1) == 1
+    @test g == [1]
+end
+
 # Test @test_broken with fail
 @test_broken false
 @test_broken 1 == 2
@@ -60,6 +66,8 @@ fails = @testset NoThrowTestSet begin
     @test_throws OverflowError 1 + 1
     # Fail - comparison
     @test 1+1 == 2+2
+    # Fail - approximate comparison
+    @test 1/1 ≈ 2/1
     # Fail - chained comparison
     @test 1+0 == 2+0 == 3+0
     # Error - unexpected pass
@@ -71,8 +79,9 @@ end
 @test contains(sprint(show, fails[1]), "Thrown: ErrorException")
 @test contains(sprint(show, fails[2]), "No exception thrown")
 @test contains(sprint(show, fails[3]), "Evaluated: 2 == 4")
-@test contains(sprint(show, fails[4]), "Evaluated: 1 == 2 == 3")
-@test contains(sprint(show, fails[5]), "Unexpected Pass")
+@test contains(sprint(show, fails[4]), "Evaluated: 1.0 ≈ 2.0")
+@test contains(sprint(show, fails[5]), "Evaluated: 1 == 2 == 3")
+@test contains(sprint(show, fails[6]), "Unexpected Pass")
 
 # Test printing of a TestSetException
 tse_str = sprint(show, Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}()))

--- a/test/test.jl
+++ b/test/test.jl
@@ -60,16 +60,19 @@ fails = @testset NoThrowTestSet begin
     @test_throws OverflowError 1 + 1
     # Fail - comparison
     @test 1+1 == 2+2
+    # Fail - chained comparison
+    @test 1+0 == 2+0 == 3+0
     # Error - unexpected pass
     @test_broken true
 end
-for i in 1:3
+for i in 1:length(fails) - 1
     @test isa(fails[i], Base.Test.Fail)
 end
 @test contains(sprint(show, fails[1]), "Thrown: ErrorException")
 @test contains(sprint(show, fails[2]), "No exception thrown")
 @test contains(sprint(show, fails[3]), "Evaluated: 2 == 4")
-@test contains(sprint(show, fails[4]), "Unexpected Pass")
+@test contains(sprint(show, fails[4]), "Evaluated: 1 == 2 == 3")
+@test contains(sprint(show, fails[5]), "Unexpected Pass")
 
 # Test printing of a TestSetException
 tse_str = sprint(show, Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}()))


### PR DESCRIPTION
Fixes a variety of issues found while working on #22296
```julia
julia> using Base.Test

julia> x, y, z = 1:3;

julia> @test x ≈ y
Test Failed
  Expression: x ≈ y
   Evaluated: 1 isapprox 2
ERROR: There was an error during testing

julia> @test x == y == z
Test Failed
  Expression: $(Expr(:escape, :x)) $(Expr(:escape, :(==))) $(Expr(:escape, :y)) $(Expr(:escape, :(==))) $(Expr(:escape, :z))
   Evaluated: 1 == 2 == 3
ERROR: There was an error during testing
```