### PR TITLE
make `@ccallable` work with return type declarations

### DIFF
--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -191,3 +191,19 @@ if Base.libllvm_version >= v"3.6" # llvm 3.6 changed the syntax for a gep, so ju
 else
     println("INFO: skipping gep parentage test on llvm < 3.6")
 end
+
+module CcallableRetTypeTest
+    using Base: Test, llvmcall, @ccallable
+    @ccallable function jl_test_returns_float()::Float64
+        return 42
+    end
+    function do_the_call()
+        llvmcall(
+        (""" declare double @jl_test_returns_float()""",
+        """
+        %1 = call double @jl_test_returns_float()
+        ret double %1
+        """),Float64,Tuple{})
+    end
+    @test do_the_call() === 42.0
+end


### PR DESCRIPTION
Allow return type declarations, and use them as the C return type if a C return type is not explicitly passed.

This probably should have been done in the 0.5 timeframe, but better late than never.