### PR TITLE
Make usage of `foo` clearer

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -258,14 +258,15 @@ snippet:
 
 ```julia-repl
 A = rand(10,10)
-remotecall_fetch(()->foo(A), 2)
+remotecall_fetch(()->norm(A), 2)
 ```
 
-In this case `foo` is expected to be a function that takes 2D array as a parameter, and is defined
-in the remote process. So you could, for example, think of the term `foo` being replaced with the function [`norm`](@ref).
+In this case [`norm`](@ref) is a function that takes 2D array as a parameter, and MUST be defined in
+the remote process.  You could, any function other than `norm` as long as it is defined in the remote
+process and accepts the appropriate parameter.
 
 Note that `A` is a global variable defined in the local workspace. Worker 2 does not have a variable called
-`A` under `Main`. The act of shipping the closure `()->foo(A)` to worker 2 results in `Main.A` being defined
+`A` under `Main`. The act of shipping the closure `()->norm(A)` to worker 2 results in `Main.A` being defined
 on 2. `Main.A` continues to exist on worker 2 even after the call `remotecall_fetch` returns. Remote calls
 with embedded global references (under `Main` module only) manage globals as follows:
 
@@ -279,9 +280,9 @@ with embedded global references (under `Main` module only) manage globals as fol
 
   ```julia
   A = rand(10,10)
-  remotecall_fetch(()->foo(A), 2) # worker 2
+  remotecall_fetch(()->norm(A), 2) # worker 2
   A = rand(10,10)
-  remotecall_fetch(()->foo(A), 3) # worker 3
+  remotecall_fetch(()->norm(A), 3) # worker 3
   A = nothing
   ```
 

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -261,6 +261,9 @@ A = rand(10,10)
 remotecall_fetch(()->foo(A), 2)
 ```
 
+In this case `foo` is expected to be a function that takes 2D array as a parameter, and is defined
+in the remote process. So you could, for example, think of the term `foo` being replaced with the function [`norm`](@ref).
+
 Note that `A` is a global variable defined in the local workspace. Worker 2 does not have a variable called
 `A` under `Main`. The act of shipping the closure `()->foo(A)` to worker 2 results in `Main.A` being defined
 on 2. `Main.A` continues to exist on worker 2 even after the call `remotecall_fetch` returns. Remote calls

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -262,7 +262,7 @@ remotecall_fetch(()->norm(A), 2)
 ```
 
 In this case [`norm`](@ref) is a function that takes 2D array as a parameter, and MUST be defined in
-the remote process.  You could, any function other than `norm` as long as it is defined in the remote
+the remote process.  You could use any function other than `norm` as long as it is defined in the remote
 process and accepts the appropriate parameter.
 
 Note that `A` is a global variable defined in the local workspace. Worker 2 does not have a variable called


### PR DESCRIPTION
This change replaces the term `foo` in the code example with `norm` so that the example works when entered into a julia runtime.  It also explains the requirements for the function.

Thanks to Avik Sengupta for the text and for all the commenters on https://discourse.julialang.org/t/what-does-foo-in-the-parallel-computing-docs-refer-to/4182 for making this happen.