### PR TITLE
Expand FreeBSD build section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,20 +225,25 @@ When building Julia, or its dependencies, libraries installed by third party pac
 
 ### FreeBSD
 
-On *FreeBSD Release 11.0*, install the gfortran, git, cmake, and gmake packages/ports (`pkg install gcc6 gmake git cmake`), and compile Julia with the command:
+Clang is the default compiler on FreeBSD 11.0-RELEASE and above.
+The remaining build tools are available from the Ports Collection, and can be installed using `pkg install git gcc gmake cmake`.
+To build Julia, simply run `gmake`.
+(Note that `gmake` must be used rather than `make`, since `make` on FreeBSD corresponds to the incompatible BSD Make rather than GNU Make.)
 
-    $ echo 'FC=gfortran6' >> Make.user
-    $ gmake
+It's important to note that the `USE_SYSTEM_*` flags should be used with caution on FreeBSD.
+This is because many system libraries, and even libraries from the Ports Collection, link to the system's `libgcc_s.so.1`,
+or to another library which links to the system `libgcc_s`.
+This library declares its GCC version to be 4.6, which is too old to build Julia, and conflicts with other libraries when linking.
+Thus it is highly recommended to simply allow Julia to build all of its dependencies.
+If you do choose to use the `USE_SYSTEM_*` flags, note that `/usr/local` is not on the compiler path by default, so you may need
+to add `LDFLAGS=-L/usr/local/lib` and `CPPFLAGS=-I/usr/local/include` to your `Make.user`, though doing so may interfere with
+other dependencies.
 
-You must use the `gmake` command on FreeBSD instead of `make`.
+Some known issues on FreeBSD are:
 
-Note that Julia is community-supported and we have little control over our upstream dependencies, you may still run into issues with dependencies and YMMV. Current known issues include:
-
- - The x86 arch doesn't support threading due to lack of compiler runtime library support (set `JULIA_THREADS=0`).
- - OpenBLAS patches in pkg haven't been upstreamed.
- - gfortran can't link binaries. Set `FFLAGS=-Wl,-rpath,/usr/local/lib/gcc6` to work around this (upstream bug submitted to FreeBSD pkg maintainers).
- - System libraries installed by pkg are not on the compiler path by default. You may need to add `LDFLAGS=-L/usr/local/lib` and `CPPFLAGS=-I/usr/local/include` to your environment or `Make.user` file to build successfully.
-
+* The x86 architecture does not support threading due to lack of compiler runtime library support, so you may need to
+  set `JULIA_THREADS=0` in your `Make.user` if you're on a 32-bit system.
+* Some stack trace information is not available due to differences with libunwind.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ The following distributions include julia, but the versions may be out of date d
   * [Nightly builds PPA](https://launchpad.net/~staticfloat/+archive/julianightlies) (depends on the [julia-deps PPA](https://launchpad.net/~staticfloat/+archive/julia-deps/))
 * [MacPorts](https://trac.macports.org/browser/trunk/dports/lang/julia/Portfile)
 * [OS X Homebrew Tap](https://github.com/staticfloat/homebrew-julia/)
+* [FreeBSD Ports](https://www.freshports.org/lang/julia/)
 
 ## Editor and Terminal Setup
 


### PR DESCRIPTION
This PR updates and clarifies the README to explain the new state of Julia on FreeBSD, which is basically "it builds out of the box, don't touch _anything_ or it could all go down in flames."

Note: I've skipped CI but `make check-whitespace` was run locally and passed.