### PR TITLE
Disambiguate convert(::Type{Vector{Bottom}}, ::Vector{Bottom})

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -551,6 +551,9 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 
 ## Conversions ##
 
+# arises in similar(dest, Pair{Union{},Union{}}) where dest::Dict:
+convert(::Type{Vector{Union{}}}, a::Vector{Union{}}) = a
+
 convert(::Type{Vector}, x::AbstractVector{T}) where {T} = convert(Vector{T}, x)
 convert(::Type{Matrix}, x::AbstractMatrix{T}) where {T} = convert(Matrix{T}, x)
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1860,7 +1860,13 @@ function showarg(io::IO, x, toplevel)
     toplevel || print(io, "::")
     print(io, typeof(x))
 end
+# This method resolves an ambiguity for packages that specialize on eltype
+function showarg(io::IO, a::Array{Union{}}, toplevel)
+    toplevel || print(io, "::")
+    print(io, typeof(a))
+end
 
+# Container specializations
 function showarg(io::IO, v::SubArray, toplevel)
     print(io, "view(")
     showarg(io, parent(v), false)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -856,3 +856,10 @@ end
 # nextind
 @test nextind(zeros(4), 2) == 3
 @test nextind(zeros(2,3), CartesianIndex(2,1)) == CartesianIndex(1, 2)
+
+@testset "ImageCore #40" begin
+    Base.convert(::Type{Array{T,n}}, a::Array{T,n}) where {T<:Number,n} = a
+    Base.convert(::Type{Array{T,n}}, a::Array) where {T<:Number,n} =
+        copy!(Array{T,n}(size(a)), a)
+    @test isa(similar(Dict(:a=>1, :b=>2.0), Pair{Union{},Union{}}), Dict{Union{}, Union{}})
+end


### PR DESCRIPTION
This is the type of method that we deliberately exclude from our ambiguity detection, but it can be triggered by [this call](https://github.com/JuliaLang/julia/blob/ee9d28b199be88bafb69feacc887d4a8464d4376/base/dict.jl#L173). See https://github.com/JuliaImages/ImageCore.jl/issues/40.
