### PR TITLE
Add replace & replace! for collections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -475,6 +475,10 @@ Library improvements
     defined, linear-algebra function `transpose`. Similarly,
     `permutedims(v::AbstractVector)` will create a row matrix ([#24839]).
 
+  * A new `replace(A, old=>new)` function is introduced to replace `old` by `new` in
+    collection `A`. There are also two other methods with a different API, and
+    a mutating variant, `replace!` ([#22324]).
+
   * `CartesianRange` changes ([#24715]):
     - Inherits from `AbstractArray`, and linear indexing can be used to provide
       linear-to-cartesian conversion ([#24715])

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -748,6 +748,7 @@ export
     randstring,
     repeat,
     replace,
+    replace!,
     repr,
     reverseind,
     rpad,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -203,6 +203,9 @@ if !isdefined(Core, :Inference)
     Core.atdoc!(CoreDocs.docm)
 end
 
+# Some type
+include("some.jl")
+
 include("dict.jl")
 include("set.jl")
 include("iterators.jl")
@@ -254,9 +257,6 @@ using .Cartesian
 include("multidimensional.jl")
 include("permuteddimsarray.jl")
 using .PermutedDimsArrays
-
-# Some type
-include("some.jl")
 
 include("broadcast.jl")
 using .Broadcast

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -133,6 +133,10 @@ Base.collect(::Type, ::Any)
 Base.issubset(::Any, ::Any)
 Base.filter
 Base.filter!
+Base.replace(::Any, ::Pair...)
+Base.replace(::Base.Callable, ::Any, ::Any)
+Base.replace(::Base.Callable, ::Any)
+Base.replace!
 ```
 
 ## Indexable Collections

--- a/doc/src/stdlib/strings.md
+++ b/doc/src/stdlib/strings.md
@@ -38,7 +38,7 @@ Base.searchindex
 Base.rsearchindex
 Base.contains(::AbstractString, ::AbstractString)
 Base.reverse(::Union{String,SubString{String}})
-Base.replace
+Base.replace(s::AbstractString, pat, f)
 Base.split
 Base.rsplit
 Base.strip


### PR DESCRIPTION
This adds methods to `replace` for `AbstractArray`, `AbstractSet` and `Associative` and a corresponding inplace `replace!` function.
Did I miss already existing similar functionality in Base?

The order in which to put the 2 function arguments `pred` and `f` can be discussed.

Also, `replace!(f::Function, A, old)` is not included as it would be ambiguous with `replace!(pred, A, new)` (and a new function name would be necessary, e.g. `replaceif!`); But it is assumed that in most of the cases, the replacement value `f(x)` can be computed by `f(old)` and then use `replace!(A, old, f(old))`. Otherwise, `replace!(pred, f, A)` can be used.
