### PR TITLE
make `replace` with count=0 a no-op

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -127,6 +127,9 @@ Deprecated or removed
     Ternaries must now include some amount of whitespace, e.g. `x ? a : b` rather than
     `x? a : b` ([#22523]).
 
+  * The method `replace(s::AbstractString, pat, r, count)` with `count <= 0` is deprecated
+    in favor of `replace(s::AbstractString, pat, r, typemax(Int))` ([#22325]).
+
 
 Julia v0.6.0 Release Notes
 ==========================

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1508,7 +1508,7 @@ end
 function replace(s::AbstractString, pat, f, n::Integer)
     if n <= 0
         depwarn(string("`replace(s, pat, r, count)` with `count <= 0` is deprecated, use ",
-                       "`replace(s, pat, r, typemax(Int))` or replace(s, pat, r)` instead"),
+                       "`replace(s, pat, r, typemax(Int))` or `replace(s, pat, r)` instead"),
                 :replace)
         replace(s, pat, f)
     else

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1503,6 +1503,8 @@ function bkfact!(A::StridedMatrix, uplo::Symbol, symmetric::Bool = issymmetric(A
     return bkfact!(symmetric ? Symmetric(A, uplo) : Hermitian(A, uplo), rook)
 end
 
+# NOTE: rename the function replace_new from strings/util.jl to replace
+# when this replace is removed from deprecated.jl
 function replace(s::AbstractString, pat, f, n::Integer)
     if n <= 0
         depwarn(string("`replace(s, pat, r, count)` with `count <= 0` is deprecated, use ",
@@ -1510,7 +1512,7 @@ function replace(s::AbstractString, pat, f, n::Integer)
                 :replace)
         Base.replace(s, pat, f)
     else
-        Base.replace_new(String(s), pat, f, Int(n))
+        Base.replace_new(String(s), pat, f, clamp(n, 0, typemax(Int)) % Int)
     end
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1512,7 +1512,7 @@ function replace(s::AbstractString, pat, f, n::Integer)
                 :replace)
         replace(s, pat, f)
     else
-        Base.replace_new(String(s), pat, f, clamp(n, 0, typemax(Int)) % Int)
+        replace_new(String(s), pat, f, n)
     end
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1510,7 +1510,7 @@ function replace(s::AbstractString, pat, f, n::Integer)
         depwarn(string("`replace(s, pat, r, count)` with `count <= 0` is deprecated, use ",
                        "`replace(s, pat, r, typemax(Int))` or replace(s, pat, r)` instead"),
                 :replace)
-        Base.replace(s, pat, f)
+        replace(s, pat, f)
     else
         Base.replace_new(String(s), pat, f, clamp(n, 0, typemax(Int)) % Int)
     end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1503,8 +1503,11 @@ function bkfact!(A::StridedMatrix, uplo::Symbol, symmetric::Bool = issymmetric(A
     return bkfact!(symmetric ? Symmetric(A, uplo) : Hermitian(A, uplo), rook)
 end
 
-# NOTE: rename the function replace_new from strings/util.jl to replace
-# when this replace is removed from deprecated.jl
+# PR #22325
+# TODO: when this replace is removed from deprecated.jl:
+# 1) rename the function replace_new from strings/util.jl to replace
+# 2) update the replace(s::AbstractString, pat, f) method, below replace_new
+#    (see instructions there)
 function replace(s::AbstractString, pat, f, n::Integer)
     if n <= 0
         depwarn(string("`replace(s, pat, r, count)` with `count <= 0` is deprecated, use ",

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1503,6 +1503,17 @@ function bkfact!(A::StridedMatrix, uplo::Symbol, symmetric::Bool = issymmetric(A
     return bkfact!(symmetric ? Symmetric(A, uplo) : Hermitian(A, uplo), rook)
 end
 
+function replace(s::AbstractString, pat, f, n::Integer)
+    if n <= 0
+        depwarn(string("`replace(s, pat, r, count)` with `count <= 0` is deprecated, use ",
+                       "`replace(s, pat, r, typemax(Int))` or replace(s, pat, r)` instead"),
+                :replace)
+        Base.replace(s, pat, f)
+    else
+        Base.replace_new(String(s), pat, f, Int(n))
+    end
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -359,9 +359,10 @@ _replace(io, repl, str, r, pattern) = print(io, repl)
 _replace(io, repl::Function, str, r, pattern) =
     print(io, repl(SubString(str, first(r), last(r))))
 
-function replace(str::String, pattern, repl, limit::Int)
-    limit == 0 && return str
-    limit < 0 && throw(DomainError())
+function replace_new(str::String, pattern, repl, count::Int)
+    # rename to `replace` when `replace` is removed from deprecated.jl
+    count == 0 && return str
+    count < 0 && throw(DomainError())
     n = 1
     e = endof(str)
     i = a = start(str)
@@ -386,7 +387,7 @@ function replace(str::String, pattern, repl, limit::Int)
         end
         r = search(str,pattern,k)
         j, k = first(r), last(r)
-        n == limit && break
+        n == count && break
         n += 1
     end
     write(out, SubString(str,i))
@@ -394,9 +395,9 @@ function replace(str::String, pattern, repl, limit::Int)
 end
 
 """
-    replace(string::AbstractString, pat, r, [count::Integer])
+    replace(s::AbstractString, pat, r, [count::Integer])
 
-Search for the given pattern `pat`, and replace each occurrence with `r`.
+Search for the given pattern `pat` in `s`, and replace each occurrence with `r`.
 If `count` is provided, replace at most `count` occurrences.
 As with search, the second argument may be a
 single character, a vector or a set of characters, a string, or a regular expression. If `r`
@@ -404,8 +405,7 @@ is a function, each occurrence is replaced with `r(s)` where `s` is the matched 
 If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture group
 references in `r` are replaced with the corresponding matched text.
 """
-replace(s::AbstractString, pat, f, n::Integer=typemax(Int)) =
-    replace(String(s), pat, f, Int(n))
+replace(s::AbstractString, pat, f) = replace_new(String(s), pat, f, typemax(Int))
 
 # hex <-> bytes conversion
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -406,6 +406,10 @@ If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture
 references in `r` are replaced with the corresponding matched text.
 """
 replace(s::AbstractString, pat, f) = replace_new(String(s), pat, f, typemax(Int))
+# change this to the following when `replace` is removed from deprecated:
+# replace(s::AbstractString, pat, f, count::Integer=typemax(Int)) =
+#     replace(String(s), pat, f, clamp(count, typemin(Int), typemax(Int)) % Int)
+
 
 # hex <-> bytes conversion
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -360,6 +360,7 @@ _replace(io, repl::Function, str, r, pattern) =
     print(io, repl(SubString(str, first(r), last(r))))
 
 function replace(str::String, pattern, repl, limit::Integer)
+    limit == 0 && return str
     n = 1
     e = endof(str)
     i = a = start(str)
@@ -402,7 +403,7 @@ If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture
 references in `r` are replaced with the corresponding matched text.
 """
 replace(s::AbstractString, pat, f, n::Integer) = replace(String(s), pat, f, n)
-replace(s::AbstractString, pat, r) = replace(s, pat, r, 0)
+replace(s::AbstractString, pat, r) = replace(s, pat, r, -1)
 
 # hex <-> bytes conversion
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -399,7 +399,7 @@ end
 
 Search for the given pattern `pat` in `s`, and replace each occurrence with `r`.
 If `count` is provided, replace at most `count` occurrences.
-As with search, the second argument may be a
+As with [`search`](@ref), the second argument may be a
 single character, a vector or a set of characters, a string, or a regular expression. If `r`
 is a function, each occurrence is replaced with `r(s)` where `s` is the matched substring.
 If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture group

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -359,7 +359,7 @@ _replace(io, repl, str, r, pattern) = print(io, repl)
 _replace(io, repl::Function, str, r, pattern) =
     print(io, repl(SubString(str, first(r), last(r))))
 
-function replace_new(str::String, pattern, repl, count::Int)
+function replace_new(str::String, pattern, repl, count::Integer)
     # rename to `replace` when `replace` is removed from deprecated.jl
     count == 0 && return str
     count < 0 && throw(DomainError())
@@ -408,7 +408,7 @@ references in `r` are replaced with the corresponding matched text.
 replace(s::AbstractString, pat, f) = replace_new(String(s), pat, f, typemax(Int))
 # change this to the following when `replace` is removed from deprecated:
 # replace(s::AbstractString, pat, f, count::Integer=typemax(Int)) =
-#     replace(String(s), pat, f, clamp(count, typemin(Int), typemax(Int)) % Int)
+#     replace(String(s), pat, f, count)
 
 
 # hex <-> bytes conversion

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -359,8 +359,9 @@ _replace(io, repl, str, r, pattern) = print(io, repl)
 _replace(io, repl::Function, str, r, pattern) =
     print(io, repl(SubString(str, first(r), last(r))))
 
-function replace(str::String, pattern, repl, limit::Integer)
+function replace(str::String, pattern, repl, limit::Int)
     limit == 0 && return str
+    limit < 0 && throw(DomainError())
     n = 1
     e = endof(str)
     i = a = start(str)
@@ -393,18 +394,18 @@ function replace(str::String, pattern, repl, limit::Integer)
 end
 
 """
-    replace(string::AbstractString, pat, r, [n::Integer])
+    replace(string::AbstractString, pat, r, [count::Integer])
 
 Search for the given pattern `pat`, and replace each occurrence with `r`.
-If `n` is provided, replace at most `n` occurrences (if `n < 0`, replace
-all occurrences). As with search, the second argument may be a
+If `count` is provided, replace at most `count` occurrences.
+As with search, the second argument may be a
 single character, a vector or a set of characters, a string, or a regular expression. If `r`
 is a function, each occurrence is replaced with `r(s)` where `s` is the matched substring.
 If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture group
 references in `r` are replaced with the corresponding matched text.
 """
-replace(s::AbstractString, pat, f, n::Integer) = replace(String(s), pat, f, n)
-replace(s::AbstractString, pat, r) = replace(s, pat, r, -1)
+replace(s::AbstractString, pat, f, n::Integer=typemax(Int)) =
+    replace(String(s), pat, f, Int(n))
 
 # hex <-> bytes conversion
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -359,8 +359,8 @@ _replace(io, repl, str, r, pattern) = print(io, repl)
 _replace(io, repl::Function, str, r, pattern) =
     print(io, repl(SubString(str, first(r), last(r))))
 
+# TODO: rename to `replace` when `replace` is removed from deprecated.jl
 function replace_new(str::String, pattern, repl, count::Integer)
-    # rename to `replace` when `replace` is removed from deprecated.jl
     count == 0 && return str
     count < 0 && throw(DomainError())
     n = 1
@@ -406,7 +406,7 @@ If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture
 references in `r` are replaced with the corresponding matched text.
 """
 replace(s::AbstractString, pat, f) = replace_new(String(s), pat, f, typemax(Int))
-# change this to the following when `replace` is removed from deprecated:
+# TODO: change this to the following when `replace` is removed from deprecated.jl:
 # replace(s::AbstractString, pat, f, count::Integer=typemax(Int)) =
 #     replace(String(s), pat, f, count)
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -395,8 +395,9 @@ end
 """
     replace(string::AbstractString, pat, r[, n::Integer=0])
 
-Search for the given pattern `pat`, and replace each occurrence with `r`. If `n` is
-provided, replace at most `n` occurrences. As with search, the second argument may be a
+Search for the given pattern `pat`, and replace each occurrence with `r`.
+If `n` is provided, replace at most `n` occurrences (if `n < 0`, replace
+all occurrences). As with search, the second argument may be a
 single character, a vector or a set of characters, a string, or a regular expression. If `r`
 is a function, each occurrence is replaced with `r(s)` where `s` is the matched substring.
 If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture group

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -393,7 +393,7 @@ function replace(str::String, pattern, repl, limit::Integer)
 end
 
 """
-    replace(string::AbstractString, pat, r[, n::Integer=0])
+    replace(string::AbstractString, pat, r, [n::Integer])
 
 Search for the given pattern `pat`, and replace each occurrence with `r`.
 If `n` is provided, replace at most `n` occurrences (if `n < 0`, replace

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -209,11 +209,12 @@ end
 @test replace("abc", 'b', 2.1) == "a2.1c"
 
 # test replace with a count, check that replace is a no-op if count==0
-@test replace("aaa", 'a', 'z', 0) == "aaa"
+# @test replace("aaa", 'a', 'z', 0) == "aaa" # re-enable when undeprecated
 @test replace("aaa", 'a', 'z', 1) == "zaa"
 @test replace("aaa", 'a', 'z', 2) == "zza"
 @test replace("aaa", 'a', 'z', 3) == "zzz"
 @test replace("aaa", 'a', 'z', 4) == "zzz"
+@test replace("aaa", 'a', 'z', typemax(Int)) == "zzz"
 
 # chomp/chop
 @test chomp("foo\n") == "foo"

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -208,6 +208,13 @@ end
 # Issue 13332
 @test replace("abc", 'b', 2.1) == "a2.1c"
 
+# test replace with a count, check that replace is a no-op if count==0
+@test replace("aaa", 'a', 'z', 0) == "aaa"
+@test replace("aaa", 'a', 'z', 1) == "zaa"
+@test replace("aaa", 'a', 'z', 2) == "zza"
+@test replace("aaa", 'a', 'z', 3) == "zzz"
+@test replace("aaa", 'a', 'z', 4) == "zzz"
+
 # chomp/chop
 @test chomp("foo\n") == "foo"
 @test chop("fooε") == "foo"

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -208,13 +208,17 @@ end
 # Issue 13332
 @test replace("abc", 'b', 2.1) == "a2.1c"
 
-# test replace with a count, check that replace is a no-op if count==0
-# @test replace("aaa", 'a', 'z', 0) == "aaa" # re-enable when undeprecated
-@test replace("aaa", 'a', 'z', 1) == "zaa"
-@test replace("aaa", 'a', 'z', 2) == "zza"
-@test replace("aaa", 'a', 'z', 3) == "zzz"
-@test replace("aaa", 'a', 'z', 4) == "zzz"
-@test replace("aaa", 'a', 'z', typemax(Int)) == "zzz"
+# test replace with a count for String and GenericString
+# check that replace is a no-op if count==0
+for s in ["aaa", Base.Test.GenericString("aaa")]
+    # @test replace("aaa", 'a', 'z', 0) == "aaa" # enable when undeprecated
+    @test replace(s, 'a', 'z', 1) == "zaa"
+    @test replace(s, 'a', 'z', 2) == "zza"
+    @test replace(s, 'a', 'z', 3) == "zzz"
+    @test replace(s, 'a', 'z', 4) == "zzz"
+    @test replace(s, 'a', 'z', typemax(Int)) == "zzz"
+    @test replace(s, 'a', 'z')    == "zzz"
+end
 
 # chomp/chop
 @test chomp("foo\n") == "foo"


### PR DESCRIPTION
Before we had `replace("aaa", 'a', 'z',  0) == "zzz"` which can seem unintuitive. This PR changes this to a no-op, while still allowing a negative count to mean unlimited replacements. 