### PR TITLE
Make Pkg.test runs tests within an anonymous module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,10 @@ This section lists changes that do not have deprecation warnings.
     of the socket. Previously the address of the remote endpoint was being
     returned ([#21825]).
 
+  * `Pkg.test` now runs package tests inside of an anonymous module instead of `Main`. The
+    change ensures that package developers do not accidentally reference variables defined
+    in their ~/.juliarc.jl file.
+
 Library improvements
 --------------------
 

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -710,6 +710,7 @@ function test!(pkg::AbstractString,
         push!(notests, pkg)
     else
         info("Testing $pkg")
+        code = "evalfile(\"$(escape_string(test_path))\")"
         cd(dirname(test_path)) do
             try
                 cmd = ```
@@ -719,7 +720,7 @@ function test!(pkg::AbstractString,
                     --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
                     --check-bounds=yes
                     --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
-                    $test_path
+                    --eval $code
                     ```
                 run(cmd)
                 info("$pkg tests passed")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -573,10 +573,8 @@ temp_pkg_dir() do
             @test contains(msg, "INFO: JULIA_RC_LOADED defined false")
             @test contains(msg, "INFO: Main.JULIA_RC_LOADED defined false")
 
-            # Note: Since both the startup-file and "runtests.jl" are run in the Main
-            # module any global variables created in the .juliarc.jl can be referenced.
             msg = readstring(`$(Base.julia_cmd()) --startup-file=yes -e $code`)
-            @test contains(msg, "INFO: JULIA_RC_LOADED defined true")
+            @test contains(msg, "INFO: JULIA_RC_LOADED defined false")
             @test contains(msg, "INFO: Main.JULIA_RC_LOADED defined true")
         end
     end


### PR DESCRIPTION
The controversial component of #22094. Modifies `Pkg.test` to run the "runtests.jl" file using `evalfile` which runs the tests within an anonymous module. This change ensure that developers do not accidentally reference variables defined from their ".juliarc.jl" file or assume that the tests are running within the `Main` module.

I expect that the disruption for package maintainers will be minimal as all published packages should already not rely on variables defined in the ".juliarc.jl". Some disruption will occur with tests assuming they are running in `Main` (for example https://github.com/JuliaLang/Compat.jl/pull/364) and a NEWS entry has been added to explain the change.

Overall, I believe this change is worth the disruption as it makes `Pkg.build` and `Pkg.test` both execute user code in the same way and will avoid accidentally referencing ".juliarc.jl" defined globals.