### PR TITLE
Add remaining 0.6 news items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -798,6 +798,7 @@ Command-line option changes
 [#19721]: https://github.com/JuliaLang/julia/issues/19721
 [#19722]: https://github.com/JuliaLang/julia/issues/19722
 [#19724]: https://github.com/JuliaLang/julia/issues/19724
+[#19730]: https://github.com/JuliaLang/julia/issues/19730
 [#19737]: https://github.com/JuliaLang/julia/issues/19737
 [#19741]: https://github.com/JuliaLang/julia/issues/19741
 [#19766]: https://github.com/JuliaLang/julia/issues/19766
@@ -864,4 +865,15 @@ Command-line option changes
 [#21359]: https://github.com/JuliaLang/julia/issues/21359
 [#21692]: https://github.com/JuliaLang/julia/issues/21692
 [#21697]: https://github.com/JuliaLang/julia/issues/21697
+[#21746]: https://github.com/JuliaLang/julia/issues/21746
 [#21759]: https://github.com/JuliaLang/julia/issues/21759
+[#21818]: https://github.com/JuliaLang/julia/issues/21818
+[#21825]: https://github.com/JuliaLang/julia/issues/21825
+[#21973]: https://github.com/JuliaLang/julia/issues/21973
+[#21974]: https://github.com/JuliaLang/julia/issues/21974
+[#22007]: https://github.com/JuliaLang/julia/issues/22007
+[#22038]: https://github.com/JuliaLang/julia/issues/22038
+[#22062]: https://github.com/JuliaLang/julia/issues/22062
+[#22064]: https://github.com/JuliaLang/julia/issues/22064
+[#22187]: https://github.com/JuliaLang/julia/issues/22187
+[#22188]: https://github.com/JuliaLang/julia/issues/22188

--- a/NEWS.md
+++ b/NEWS.md
@@ -679,6 +679,23 @@ Deprecated or removed
     [StatsBase.jl package](https://github.com/JuliaStats/StatsBase.jl)'s
     `midpoints` function ([#20058]).
 
+  * Passing a type argument to `LibGit2.cat` has been deprecated in favor of a simpler,
+    two-argument method for `LibGit2.cat` ([#20435]).
+
+  * The `LibGit2.owner` function for finding the repository which owns a given Git object
+    has been deprecated in favor of `LibGit2.repository` ([#20135]).
+
+  * The `LibGit2.GitAnyObject` type has been renamed to `LibGit2.GitUnknownObject` to
+    clarify its intent ([#19935]).
+
+  * The `LibGit2.GitOid` type has been renamed to `LibGit2.GitHash` for clarity ([#19878]).
+
+  * Finalizing `LibGit2` objects with `finalize` has been deprecated in favor of using `close`
+    ([#19660]).
+
+  * Parsing string dates from a `Dates.DateFormat` object has been deprecated as part of a
+    larger effort toward faster, more extensible date parsing ([#20952]).
+
 Command-line option changes
 ---------------------------
 
@@ -768,6 +785,7 @@ Command-line option changes
 [#19598]: https://github.com/JuliaLang/julia/issues/19598
 [#19635]: https://github.com/JuliaLang/julia/issues/19635
 [#19636]: https://github.com/JuliaLang/julia/issues/19636
+[#19660]: https://github.com/JuliaLang/julia/issues/19660
 [#19669]: https://github.com/JuliaLang/julia/issues/19669
 [#19670]: https://github.com/JuliaLang/julia/issues/19670
 [#19677]: https://github.com/JuliaLang/julia/issues/19677
@@ -794,6 +812,7 @@ Command-line option changes
 [#19811]: https://github.com/JuliaLang/julia/issues/19811
 [#19814]: https://github.com/JuliaLang/julia/issues/19814
 [#19841]: https://github.com/JuliaLang/julia/issues/19841
+[#19878]: https://github.com/JuliaLang/julia/issues/19878
 [#19900]: https://github.com/JuliaLang/julia/issues/19900
 [#19901]: https://github.com/JuliaLang/julia/issues/19901
 [#19903]: https://github.com/JuliaLang/julia/issues/19903
@@ -803,6 +822,7 @@ Command-line option changes
 [#19926]: https://github.com/JuliaLang/julia/issues/19926
 [#19931]: https://github.com/JuliaLang/julia/issues/19931
 [#19934]: https://github.com/JuliaLang/julia/issues/19934
+[#19935]: https://github.com/JuliaLang/julia/issues/19935
 [#19937]: https://github.com/JuliaLang/julia/issues/19937
 [#19944]: https://github.com/JuliaLang/julia/issues/19944
 [#19949]: https://github.com/JuliaLang/julia/issues/19949
@@ -812,6 +832,7 @@ Command-line option changes
 [#20047]: https://github.com/JuliaLang/julia/issues/20047
 [#20058]: https://github.com/JuliaLang/julia/issues/20058
 [#20079]: https://github.com/JuliaLang/julia/issues/20079
+[#20135]: https://github.com/JuliaLang/julia/issues/20135
 [#20164]: https://github.com/JuliaLang/julia/issues/20164
 [#20213]: https://github.com/JuliaLang/julia/issues/20213
 [#20228]: https://github.com/JuliaLang/julia/issues/20228
@@ -831,12 +852,14 @@ Command-line option changes
 [#20414]: https://github.com/JuliaLang/julia/issues/20414
 [#20418]: https://github.com/JuliaLang/julia/issues/20418
 [#20427]: https://github.com/JuliaLang/julia/issues/20427
+[#20435]: https://github.com/JuliaLang/julia/issues/20435
 [#20500]: https://github.com/JuliaLang/julia/issues/20500
 [#20530]: https://github.com/JuliaLang/julia/issues/20530
 [#20543]: https://github.com/JuliaLang/julia/issues/20543
 [#20575]: https://github.com/JuliaLang/julia/issues/20575
 [#20609]: https://github.com/JuliaLang/julia/issues/20609
 [#20889]: https://github.com/JuliaLang/julia/issues/20889
+[#20952]: https://github.com/JuliaLang/julia/issues/20952
 [#21183]: https://github.com/JuliaLang/julia/issues/21183
 [#21359]: https://github.com/JuliaLang/julia/issues/21359
 [#21692]: https://github.com/JuliaLang/julia/issues/21692


### PR DESCRIPTION
This PR adds NEWS items for the remaining points in https://github.com/JuliaLang/julia/issues/21475#issuecomment-302899987, so I believe this fixes #21475.

Edit: Forgot to skip CI. Sorry about that.