### PR TITLE
Ensure Bool to Integer conversions always return 0 or 1

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -334,7 +334,11 @@ for to in BitInteger_types, from in (BitInteger_types..., Bool)
                     checked_trunc_uint($to, x)
             end
             @eval rem(x::($from), ::Type{$to}) = trunc_int($to, x)
-        elseif from.size < to.size || from === Bool
+        elseif from === Bool
+            # Bools use i8 storage and may have garbage in their 7 high bits
+            @eval convert(::Type{$to}, x::($from)) = zext_int($to, x) & $to(1)
+            @eval rem(x::($from), ::Type{$to}) = convert($to, x)
+        elseif from.size < to.size
             if issubtype(from, Signed)
                 if issubtype(to, Unsigned)
                     @eval convert(::Type{$to}, x::($from)) =

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2965,3 +2965,14 @@ end
     @test !iszero([0, 1, 2, 3])
     @test iszero(zeros(Int, 5))
 end
+
+f20065(B, i) = UInt8(B[i])
+@testset "issue 20065" begin
+    # f20065 must be called from global scope to exhibit the buggy behavior
+    for B in (Array{Bool}(10), Array{Bool}(10,10), reinterpret(Bool, rand(UInt8, 10)))
+        @test all(x-> x <= 1, (f20065(B, i) for i in eachindex(B)))
+        for i in 1:length(B)
+            @test (@eval f20065($B, $i) <= 1)
+        end
+    end
+end


### PR DESCRIPTION
Fix #20065. Supersedes #22293.