### PR TITLE
Add utilities for debugging LLVM during sysimg build

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -32,6 +32,7 @@ struct JLOptions
     use_compilecache::Int8
     bindto::Ptr{UInt8}
     outputbc::Ptr{UInt8}
+    outputunoptbc::Ptr{UInt8}
     outputo::Ptr{UInt8}
     outputji::Ptr{UInt8}
     incremental::Int8

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -67,6 +67,7 @@ jl_options_t jl_options = { 0,    // quiet
                             JL_OPTIONS_USE_COMPILECACHE_YES,
                             NULL, // bind-to
                             NULL, // output-bc
+                            NULL, // output-unopt-bc
                             NULL, // output-o
                             NULL, // output-ji
                             0, // incremental
@@ -125,6 +126,7 @@ static const char opts[]  =
     // compiler output options
     " --output-o name           Generate an object file (including system image data)\n"
     " --output-ji name          Generate a system image data file (.ji)\n"
+    " --output-unopt-bc name    Generate unoptimized LLVM bitcode (.bc)\n"
     " --output-bc name          Generate LLVM bitcode (.bc)\n"
     " --output-incremental=no   Generate an incremental output file (rather than complete)\n\n"
 
@@ -145,6 +147,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_code_coverage,
            opt_track_allocation,
            opt_check_bounds,
+           opt_output_unopt_bc,
            opt_output_bc,
            opt_depwarn,
            opt_inline,
@@ -186,6 +189,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "optimize",        optional_argument, 0, 'O' },
         { "check-bounds",    required_argument, 0, opt_check_bounds },
         { "output-bc",       required_argument, 0, opt_output_bc },
+        { "output-unopt-bc", required_argument, 0, opt_output_unopt_bc },
         { "output-o",        required_argument, 0, opt_output_o },
         { "output-ji",       required_argument, 0, opt_output_ji },
         { "output-incremental",required_argument, 0, opt_incremental },
@@ -432,6 +436,10 @@ restart_switch:
             break;
         case opt_output_bc:
             jl_options.outputbc = optarg;
+            if (!jl_options.image_file_specified) jl_options.image_file = NULL;
+            break;
+        case opt_output_unopt_bc:
+            jl_options.outputunoptbc = optarg;
             if (!jl_options.image_file_specified) jl_options.image_file = NULL;
             break;
         case opt_output_o:

--- a/src/julia.h
+++ b/src/julia.h
@@ -1726,6 +1726,7 @@ typedef struct {
     int8_t use_compilecache;
     const char *bindto;
     const char *outputbc;
+    const char *outputunoptbc;
     const char *outputo;
     const char *outputji;
     int8_t incremental;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -511,6 +511,7 @@ void jl_init_types(void);
 void jl_init_box_caches(void);
 void jl_init_frontend(void);
 void jl_init_primitives(void);
+void *jl_init_llvm(void);
 void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
 void jl_init_intrinsic_properties(void);
@@ -592,7 +593,7 @@ static inline void jl_set_gc_and_wait(void)
 }
 #endif
 
-void jl_dump_native(const char *bc_fname, const char *obj_fname, const char *sysimg_data, size_t sysimg_len);
+void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *sysimg_data, size_t sysimg_len);
 int32_t jl_get_llvm_gv(jl_value_t *p);
 int32_t jl_assign_functionID(/*llvm::Function*/void *function);
 int32_t jl_jlcall_api(/*llvm::Function*/const void *function);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -17,7 +17,7 @@ extern "C" {
 
 JL_DLLEXPORT int jl_generating_output(void)
 {
-    return jl_options.outputo || jl_options.outputbc || jl_options.outputji;
+    return jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc || jl_options.outputji;
 }
 
 void jl_precompile(int all);
@@ -50,14 +50,14 @@ void jl_write_compiler_output(void)
         if (jl_options.outputji)
             if (jl_save_incremental(jl_options.outputji, worklist))
                 jl_exit(1);
-        if (jl_options.outputbc)
+        if (jl_options.outputbc || jl_options.outputunoptbc)
             jl_printf(JL_STDERR, "WARNING: incremental output to a .bc file is not implemented\n");
         if (jl_options.outputo)
             jl_printf(JL_STDERR, "WARNING: incremental output to a .o file is not implemented\n");
     }
     else {
         ios_t *s = NULL;
-        if (jl_options.outputo || jl_options.outputbc)
+        if (jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc)
             s = jl_create_system_image();
 
         if (jl_options.outputji) {
@@ -73,8 +73,9 @@ void jl_write_compiler_output(void)
             }
         }
 
-        if (jl_options.outputo || jl_options.outputbc)
+        if (jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc)
             jl_dump_native(jl_options.outputbc,
+                           jl_options.outputunoptbc,
                            jl_options.outputo,
                            (const char*)s->buf, (size_t)s->size);
     }


### PR DESCRIPTION
This adds an extra command line option to dump the unoptimized
rather than the optimized representation of the LLVM IR. This
is very useful when debugging new LLVM passes (which we're now
increasingly making use of) or when profiling LLVM, to split
out JIT and sysimg optimization.