### PR TITLE
windows readme: winbind is needed for TLS

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -275,7 +275,7 @@ export BITS=64
 zypper addrepo http://download.opensuse.org/repositories/windows:mingw:win$BITS/openSUSE_13.2/windows:mingw:win$BITS.repo
 zypper --gpg-auto-import-keys refresh
 zypper -n install --no-recommends git make cmake tar wine which curl \
-    python python-xml patch gcc-c++ m4 p7zip.i586 libxml2-tools
+    python python-xml patch gcc-c++ m4 p7zip.i586 libxml2-tools winbind
 zypper -n install mingw$BITS-cross-gcc-c++ mingw$BITS-cross-gcc-fortran \
     mingw$BITS-libstdc++6 mingw$BITS-libgfortran3 mingw$BITS-libssp0
 # opensuse packages the mingw runtime dlls under sys-root/mingw/bin, not /usr/lib64/gcc
@@ -310,9 +310,7 @@ need wine (>=1.7.5), a system compiler, and some downloaders.
 
 **On Ubuntu** (on other linux systems, the dependency names are likely to be similar):
 ```sh
-apt-add-repository ppa:ubuntu-wine/ppa
-apt-get update
-apt-get install wine1.7 subversion cvs gcc wget p7zip-full
+apt-get install wine subversion cvs gcc wget p7zip-full winbind
 ```
 
 **On Mac**: Install XCode, XCode command line tools, X11 (now [XQuartz](


### PR DESCRIPTION
this fixes an error (warning?) message I get when trying to using Pkg over https:
```
err:winediag:SECUR32_initNTLMSP ntlm_auth was not found or is outdated. Make sure that ntlm_auth >= 3.0.25 is in your path. Usually, you can find it in the winbind package of your distribution.
```

(if the following also occurs, you need to recompile wine with SSL support, or use your distro version)
```
err:secur32:SECUR32_initSchannelSP TLS library not found, SSL connections will fail
```