### PR TITLE
RFC: Avoid setting the RPATH for LLVM

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -37,7 +37,10 @@ LIBGIT2_OPTS += -DCURL_INCLUDE_DIRS=$(build_includedir) -DCURL_LIBRARIES="-L$(bu
 endif
 
 ifeq ($(OS),Linux)
-LIBGIT2_OPTS += -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+LIBGIT2_OPTS += -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
+ifeq ($(OS),FreeBSD)
+LIBGIT2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
 # We need to bundle ca certs on linux now that we're using libgit2 with ssl

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -20,6 +20,10 @@ else
 LIBSSH2_OPTS += -DCRYPTO_BACKEND=mbedTLS -DENABLE_ZLIB_COMPRESSION=OFF
 endif
 
+ifneq (,$(findstring $(OS),Linux FreeBSD))
+LIBSSH2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
+
 $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR)/source-extracted
 	cd $(SRCDIR)/srccache/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-encryptedpem.patch
 	echo 1 > $@

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -60,6 +60,12 @@ else
 LLVM_TARGETS := host;NVPTX
 endif
 
+LLVM_CFLAGS :=
+LLVM_CXXFLAGS :=
+LLVM_CPPFLAGS :=
+LLVM_LDFLAGS :=
+LLVM_CMAKE :=
+
 # Allow adding LLVM specific flags
 LLVM_CFLAGS += $(CFLAGS)
 LLVM_CXXFLAGS += $(CXXFLAGS)

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -15,6 +15,10 @@ ifeq ($(BUILD_OS),WINNT)
 MBEDTLS_OPTS += -G"MSYS Makefiles"
 endif
 
+ifneq (,$(findstring $(OS),Linux FreeBSD))
+MBEDTLS_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
+
 $(SRCDIR)/srccache/$(MBEDTLS_SRC).tgz: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ $(MBEDTLS_URL)
 

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -40,16 +40,14 @@ CMAKE_COMMON += -DCMAKE_RC_COMPILER="$$(which $(CROSS_COMPILE)windres)"
 endif
 endif
 
-ifneq (,$(findstring $(OS),Linux FreeBSD))
-INSTALL_RPATH := "\$$ORIGIN"
-# Part of the FreeBSD libgcc_s kludge
+# NOTE: Do not make RPATH changes in CMAKE_COMMON on platforms other than FreeBSD, since
+# it will make its way into the LLVM build flags, and LLVM is picky about RPATH (though
+# apparently not on FreeBSD). Ref PR #22352
 ifeq ($(OS),FreeBSD)
 ifneq ($(GCCPATH),)
-INSTALL_RPATH := "\$$ORIGIN:$(GCCPATH)"
+CMAKE_COMMON += -DCMAKE_INSTALL_RPATH="\$$ORIGIN:$(GCCPATH)"
 endif
 endif
-CMAKE_COMMON += -DCMAKE_INSTALL_RPATH=$(INSTALL_RPATH)
-endif # Linux or FreeBSD
 
 # For now this is LLVM specific, but I expect it won't be in the future
 ifeq ($(LLVM_USE_CMAKE),1)


### PR DESCRIPTION
Some of the changes in #21788 adversely affected Linux. This partially reverts/restructures some of the changes.