### PR TITLE
Added docstring to @fastmath macro.

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -124,6 +124,32 @@ function make_fastmath(symb::Symbol)
 end
 make_fastmath(expr) = expr
 
+"""
+@fastmath expr
+
+Executes a transformed version of the expression, which calls
+functions that may violate strict IEEE semantics. This allows
+the fastest possible operation, but results are undefined.
+
+This makes the following transformations:
+- nnan: No NaNs - Allow optimizations to assume the arguments and
+        result are not NaN.
+- ninf: No Infs - Allow optimizations to assume the arguments and
+        result are not +/-Inf.
+- nsz:  No Signed Zeros - Allow optimizations to treat the sign of a
+        zero argument or result as insignificant.
+- arcp: Allow Reciprocal - Allow optimizations to use the reciprocal
+        of an argument rather than perform division.
+
+# Examples
+```jldoctest
+julia> @fastmath 1+2
+3
+
+julia> @fastmath(sin(3))
+0.1411200080598672
+```
+"""
 macro fastmath(expr)
     make_fastmath(esc(expr))
 end

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -5,7 +5,8 @@
 # This module provides versions of math functions that may violate
 # strict IEEE semantics.
 
-# This allows the following transformations:
+# This allows the following transformations. For more information see
+# http://llvm.org/docs/LangRef.html#fast-math-flags:
 # nnan: No NaNs - Allow optimizations to assume the arguments and
 #       result are not NaN. Such optimizations are required to retain
 #       defined behavior over NaNs, but the value of the result is
@@ -131,7 +132,9 @@ Executes a transformed version of the expression, which calls
 functions that may violate strict IEEE semantics. This allows
 the fastest possible operation, but results are undefined.
 
-This makes the following transformations:
+This sets the [LLVM Fast-Math
+flags](http://llvm.org/docs/LangRef.html#fast-math-flags), including
+the following transformations:
 - nnan: No NaNs - Allow optimizations to assume the arguments and
         result are not NaN.
 - ninf: No Infs - Allow optimizations to assume the arguments and
@@ -140,6 +143,10 @@ This makes the following transformations:
         zero argument or result as insignificant.
 - arcp: Allow Reciprocal - Allow optimizations to use the reciprocal
         of an argument rather than perform division.
+- contract: Allow floating-point contraction (e.g. fusing a multiply
+        followed by an addition into a fused multiply-and-add).
+- fast: Allow algebraically equivalent transformations that may
+        dramatically change results in floating point (e.g. reassociate).
 
 # Examples
 ```jldoctest

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -130,7 +130,8 @@ make_fastmath(expr) = expr
 
 Executes a transformed version of the expression, which calls functions that
 may violate strict IEEE semantics. This allows the fastest possible operation,
-but results are undefined.
+but results are undefined -- be careful when doing this, as it may change numerical
+results.
 
 This sets the [LLVM Fast-Math flags](http://llvm.org/docs/LangRef.html#fast-math-flags),
 and corresponds to the `-ffast-math` option in clang. See [the notes on performance

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -126,7 +126,7 @@ end
 make_fastmath(expr) = expr
 
 """
-@fastmath expr
+    @fastmath expr
 
 Executes a transformed version of the expression, which calls
 functions that may violate strict IEEE semantics. This allows

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -128,7 +128,7 @@ make_fastmath(expr) = expr
 """
     @fastmath expr
 
-Executes a transformed version of the expression, which calls functions that
+Execute a transformed version of the expression, which calls functions that
 may violate strict IEEE semantics. This allows the fastest possible operation,
 but results are undefined -- be careful when doing this, as it may change numerical
 results.

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -133,20 +133,7 @@ functions that may violate strict IEEE semantics. This allows
 the fastest possible operation, but results are undefined.
 
 This sets the [LLVM Fast-Math
-flags](http://llvm.org/docs/LangRef.html#fast-math-flags), including
-the following transformations:
-- nnan: No NaNs - Allow optimizations to assume the arguments and
-        result are not NaN.
-- ninf: No Infs - Allow optimizations to assume the arguments and
-        result are not +/-Inf.
-- nsz:  No Signed Zeros - Allow optimizations to treat the sign of a
-        zero argument or result as insignificant.
-- arcp: Allow Reciprocal - Allow optimizations to use the reciprocal
-        of an argument rather than perform division.
-- contract: Allow floating-point contraction (e.g. fusing a multiply
-        followed by an addition into a fused multiply-and-add).
-- fast: Allow algebraically equivalent transformations that may
-        dramatically change results in floating point (e.g. reassociate).
+flags](http://llvm.org/docs/LangRef.html#fast-math-flags), and corresponds to the `-ffast-math` option in clang. See [the notes on performance annotations](https://docs.julialang.org/en/stable/manual/performance-tips#performance-annotations) for more details.
 
 # Examples
 ```jldoctest

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -128,12 +128,13 @@ make_fastmath(expr) = expr
 """
     @fastmath expr
 
-Executes a transformed version of the expression, which calls
-functions that may violate strict IEEE semantics. This allows
-the fastest possible operation, but results are undefined.
+Executes a transformed version of the expression, which calls functions that
+may violate strict IEEE semantics. This allows the fastest possible operation,
+but results are undefined.
 
-This sets the [LLVM Fast-Math
-flags](http://llvm.org/docs/LangRef.html#fast-math-flags), and corresponds to the `-ffast-math` option in clang. See [the notes on performance annotations](https://docs.julialang.org/en/stable/manual/performance-tips#performance-annotations) for more details.
+This sets the [LLVM Fast-Math flags](http://llvm.org/docs/LangRef.html#fast-math-flags),
+and corresponds to the `-ffast-math` option in clang. See [the notes on performance
+annotations](@ref man-performance-annotations) for more details.
 
 # Examples
 ```jldoctest

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1082,7 +1082,7 @@ These are some minor points that might help in tight inner loops.
   * Use [`div(x,y)`](@ref) for truncating division of integers instead of [`trunc(x/y)`](@ref), [`fld(x,y)`](@ref)
     instead of [`floor(x/y)`](@ref), and [`cld(x,y)`](@ref) instead of [`ceil(x/y)`](@ref).
 
-## Performance Annotations
+## [Performance Annotations](@id man-performance-annotations)
 
 Sometimes you can enable better optimization by promising certain program properties.
 

--- a/doc/src/stdlib/math.md
+++ b/doc/src/stdlib/math.md
@@ -181,6 +181,7 @@ Base.Math.lbeta
 Base.ndigits
 Base.widemul
 Base.Math.@evalpoly
+Base.FastMath.@fastmath
 ```
 
 ## Statistics


### PR DESCRIPTION
Adds docstring to @fastmath macro that explains a bit about what it does, and includes examples how to use it.

Pulled the detailed list of effects from the top of the file.

#doc