### PR TITLE
uniquify the docstring of unique(itr)

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1294,14 +1294,11 @@ end
 hash(x::Prehashed) = x.hash
 
 """
-    unique(A::AbstractArray[, dim::Int])
+    unique(A::AbstractArray, dim::Int)
 
-Return an array containing only the unique elements of `A`, as determined by
-[`isequal`](@ref), in the order that the first of each set of equivalent elements
-originally appears.
+Return unique regions of `A` along dimension `dim`.
 
-If `dim` is specified, return unique regions of `A` along dimension `dim`.
-
+# Examples
 
 ```jldoctest
 julia> A = map(isodd, reshape(collect(1:8), (2,2,2)))

--- a/base/set.jl
+++ b/base/set.jl
@@ -127,8 +127,10 @@ Return an array containing only the unique elements of collection `itr`,
 as determined by [`isequal`](@ref), in the order that the first of each
 set of equivalent elements originally appears.
 
+# Example
+
 ```jldoctest
-julia> unique([1; 2; 2; 6])
+julia> unique([1, 2, 6, 2])
 3-element Array{Int64,1}:
  1
  2
@@ -182,8 +184,10 @@ end
 Returns an array containing one value from `itr` for each unique value produced by `f`
 applied to elements of `itr`.
 
+# Example
+
 ```jldoctest
-julia> unique(isodd, [1; 2; 2; 6])
+julia> unique(isodd, [1, 2, 6, 2])
 2-element Array{Int64,1}:
  1
  2


### PR DESCRIPTION
The docs for `unique(itr)` seems to have been redundant, cf. https://github.com/JuliaLang/julia/pull/15741#issuecomment-308471930.