### PR TITLE
remove *(A::Matrix, B::HermOrSym) = A*full(B)

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -299,8 +299,7 @@ A_mul_B!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{
 A_mul_B!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix}) where {T<:BlasComplex} =
     BLAS.hemm!('R', B.uplo, one(T), B.data, A, zero(T), C)
 
-*(A::HermOrSym, B::HermOrSym) = full(A)*full(B)
-*(A::StridedMatrix, B::HermOrSym) = A*full(B)
+*(A::HermOrSym, B::HermOrSym) = A*full(B)
 
 for T in (:Symmetric, :Hermitian), op in (:+, :-, :*, :/)
     # Deal with an ambiguous case


### PR DESCRIPTION
ref brief discussion here: https://github.com/JuliaLang/julia/pull/3315#discussion_r121254442

- this dispatches to BLAS instead
- seems a tiny bit faster
- allocates half of the memory
- main reason is to be consistent with the opposite method
  e.g. `*(A::HermOrSym, B::Matrix)` which does no longer have this
  fallback method with a `full` call, but dispatches to
  `BLAS.symv!`/`BLAS.hemv!` directly

Some timings with the following snippet
```julia
using BenchmarkTools
import Base.LinAlg.HermOrSym
f(A, B) = A*B
g(A::HermOrSym, B::Matrix) = full(A)*B
g(A::Matrix, B::HermOrSym) = A*full(B)

for N in (10, 100, 250, 500, 1000, 2000, 3000, 4000, 5000, 6000)
    A = rand(N, N)
    S = Symmetric(rand(N, N))
    println(N)
    println("real")
    @btime f($A, $S)
    @btime g($A, $S)
    @btime f($S, $A)
    @btime g($S, $A)
    C = complex.(rand(N, N), rand(N, N))
    H = Hermitian(C'C)
    println("complex")
    @btime f($C, $H)
    @btime g($C, $H)
    @btime f($H, $C)
    @btime g($H, $C)
end
```

`Float64`:

| size  | `A*S` | `A*full(S)` | `S*A` | `full(S)*A` |
| ----- | -----:| -----------:| -----:| -----------:|
| 10    | 297.855 ns | 420.910 ns | 308.080 ns | 424.060 ns |
| 100   | 23.385 μs | 34.549 μs | 24.954 μs | 34.945 μs |
| 250   | 255.773 μs | 331.616 μs | 256.503 μs | 329.004 μs |
| 500   | 1.918 ms | 2.368 ms | 1.910 ms | 2.350 ms |
| 1000  | 13.266 ms | 15.429 ms | 13.394 ms | 15.672 ms |
| 2000  | 127.112 ms | 136.122 ms | 127.281 ms | 140.681 ms |
| 3000  | 358.161 ms | 376.963 ms | 344.898 ms | 378.834 ms |
| 4000  | 882.631 ms | 927.317 ms | 887.798 ms | 931.449 ms |
| 5000  | 1.568 s | 1.664 s | 1.580 s | 1.665 s |
| 6000  | 3.034 s | 3.048 s | 2.975 s | 3.207 s |

`Complex128`:

| size  | `C*H` | `C*full(H)` | `H*C` | `full(H)*C` |
| ----- | ----:| ---------:| ----:| ---------:|
| 10 | 619.873 ns | 744.557 ns | 579.403 ns | 761.532 ns |
| 100 | 64.229 μs | 77.251 μs | 62.550 μs | 78.272 μs |
| 250 | 761.147 μs | 963.050 μs | 757.831 μs | 920.223 μs |
| 500 | 5.837 ms | 6.750 ms | 5.841 ms |6.771 ms |
| 1000 | 43.129 ms | 49.266 ms | 43.558 ms | 48.567 ms |
| 2000 | 341.213 ms | 360.443 ms | 334.390 ms | 355.828 ms |
| 3000 | 1.146 s | 1.154 s | 1.241 s | 1.255 s |
| 4000 | 2.534 s | 2.668 s | 2.541 s | 2.641 s |
| 5000 | 6.160 s | 5.274 s | 5.277 s | 5.335 s |
| 6000 | 8.611 s | 9.049 s | 9.042 s | 8.815 s |

```
julia> versioninfo()
Julia Version 0.7.0-DEV.590
Commit 9fdc6d1* (2017-06-14 19:50 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: Intel(R) Core(TM) i5-7600K CPU @ 3.80GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT NO_AFFINITY HASWELL)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, broadwell)
```