### PR TITLE
Revert "Fix a few naming conflicts in LinAlg/BLAS. Fixes #14268."

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -2,13 +2,15 @@
 
 module BLAS
 
+import ..axpy!
 import Base: copy!
-import Base.LinAlg: axpy!, dot
 
 export
 # Level 1
     asum,
+    axpy!,
     blascopy!,
+    dot,
     dotc,
     dotu,
     scal!,

--- a/base/linalg/linalg.jl
+++ b/base/linalg/linalg.jl
@@ -248,7 +248,6 @@ include("exceptions.jl")
 include("generic.jl")
 
 include("blas.jl")
-import .BLAS: gemv! # consider renaming gemv! in matmul
 include("matmul.jl")
 include("lapack.jl")
 

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -249,14 +249,15 @@ end
 # issue #6450
 @test dot(Any[1.0,2.0], Any[3.5,4.5]) === 12.5
 
-for elty in (Float32,Float64,Complex64,Complex128)
-    x = convert(Vector{elty},[1.0,2.0,3.0])
-    y = convert(Vector{elty},[3.5,4.5,5.5])
+@testset "dot" for elty in (Float32, Float64, Complex64, Complex128)
+    x = convert(Vector{elty},[1.0, 2.0, 3.0])
+    y = convert(Vector{elty},[3.5, 4.5, 5.5])
     @test_throws DimensionMismatch dot(x, 1:2, y, 1:3)
     @test_throws BoundsError dot(x, 1:4, y, 1:4)
     @test_throws BoundsError dot(x, 1:3, y, 2:4)
-    @test dot(x,1:2,y,1:2) == convert(elty,12.5)
-    @test x.'*y == convert(elty,29.0)
+    @test dot(x, 1:2,y, 1:2) == convert(elty, 12.5)
+    @test x.'*y == convert(elty, 29.0)
+    @test_throws MethodError dot(rand(elty, 2, 2), randn(elty, 2, 2))
 end
 
 vecdot_(x,y) = invoke(vecdot, Tuple{Any,Any}, x,y) # generic vecdot


### PR DESCRIPTION
The "fix" of JuliaLang/LinearAlgebra.jl#289 was not the right one since `LinAlg.dot` and `LinAlg.BLAS.dot` have different signatures. Hence, this accidentally changed the behavior of `dot` and made it behave like `vecdot`. I've added a test to avoid that we accidentally reintroduce the behavior again.

At some point, we might adjust the signatures in the `BLAS` module to match those in the `LinAlg` module. Basically, the signatures in `BLAS` are more permissive right now and allow for higher dimensional arrays instead of requiring a `reshape` to `Vector`. However, I think we should respect our abstractions and enforce that the input has `N=1`, but that can be done in a separate PR.

This supersedes https://github.com/JuliaLang/julia/pull/22240.