### PR TITLE
Require the runtime language feature for such foreigncalls.

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1565,6 +1565,12 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         rt = (jl_value_t*)jl_any_type; // convert return type to jl_value_t*
     }
 
+    // check if we require the runtime
+    // TODO: could be more fine-grained,
+    //       respecting special functions below that don't require the runtime
+    if (!llvmcall && (!f_lib || f_lib == JL_DL_LIBNAME))
+        JL_FEAT_REQUIRE(ctx, runtime);
+
     // some sanity checking and check whether there's a vararg
     bool isVa;
     size_t nargt;


### PR DESCRIPTION
Only affects external codegen.
I've kept the diff minimal (hence the TODO) hoping that this could still be part of 0.6.

Repro:
```julia
foo() = Int[]
```

`code_typed`:
```
CodeInfo(:(begin 
        return $(Expr(:foreigncall, :(:jl_alloc_array_1d), Array{Int64,1}, svec(Any, Int64), Array{Int64,1}, 0, 0, 0))
    end))=>Array{Int64,1}
```

Generating code using:
```julia
params = Base.CodegenParams(runtime=false)
println(Base._dump_function(foo, Tuple{},
                            #=native=#false, #=wrapper=#false, #=strip=#false,
                            #=dump_module=#false, #=syntax=#:att, #=optimize=#false,
                            params))
```

This currently works, erroneously:
```llvm
define i8** @julia_foo_60700() #0 !dbg !5 {
top:
  %0 = call i8*** @julia.gc_root_decl()
  %1 = call i8**** @jl_get_ptls_states()
  %2 = bitcast i8**** %1 to i8***
  %3 = getelementptr i8**, i8*** %2, i64 3
  %4 = bitcast i8*** %3 to i64**
  %5 = load i64*, i64** %4, !tbaa !7
  %6 = call i8** inttoptr (i64 140434590856416 to i8** (i8**, i64)*)(i8** inttoptr (i64 140434413023536 to i8**), i64 0), !dbg !10
  store i8** %6, i8*** %0, !dbg !10
  ret i8** %6, !dbg !10
}
```

with the `inttoptr` coming from `emit_ccall(:jl_alloc_array_1d)`.

With this patch:

```
ERROR: LoadError: error compiling foo: emit_ccall for repro.jl:1 requires the runtime language feature, which is disabled
```