### PR TITLE
Remove order::Ordering keyword argument to sort* methods where possible

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1543,6 +1543,12 @@ end
 @deprecate cat_t{N,T}(::Type{Val{N}}, ::Type{T}, A, B) cat_t(Val(N), T, A, B) false
 @deprecate reshape{N}(A::AbstractArray, ::Type{Val{N}}) reshape(A, Val(N))
 
+# PR #22388: also remove corresonding code in ordering.jl and sort.jl
+function Base.Order.ord_deprecated(lt, by, rev::Bool, order::Ordering)
+    depwarn("`order` keyword argument is deprecated, use `lt`, `by` and `rev` instead", :ord_deprecated)
+    ord(lt, by, rev, order)
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -9,7 +9,7 @@ export # not exported by Base
     By, Lt, Perm,
     ReverseOrdering, ForwardOrdering, LexicographicOrdering,
     DirectOrdering,
-    lt, ord, ordtype
+    lt, ord, ord_deprecated, ordtype
 
 abstract type Ordering end
 
@@ -71,5 +71,8 @@ function ord(lt, by, rev::Bool, order::Ordering=Forward)
                                           Lt((x,y)->lt(by(x),by(y)))
     rev ? ReverseOrdering(o) : o
 end
+
+# See also method in deprecated.jl
+ord_deprecated(lt, by, rev::Bool, order::Void) = ord(lt, by, rev, Forward)
 
 end


### PR DESCRIPTION
This argument is only used internally and was not supposed to be documented
(which was the case in Julia 0.6). Remove it everywhere it is not needed, that
is in all functions except  `sortperm()`, for which that argument is used by
`sortrows()` and `sortcols()` internally. Remove it for docstrings anyway.

Also remove the initialized keyword argument to sort(), which had no effect
and was not documented in Julia 0.6 either.

-------------
Fixes https://github.com/JuliaLang/julia/issues/22382 in the most radical way.

I must say I don't really understand the role of `Ordering` but since @StefanKarpinski said it was supposed to be internal I removed it from all places where it wasn't used. If that's not OK, I can change the PR to remove only the mentions in the docstrings.

Cc @kshyatt who added mentions of these arguments to the docstrings in https://github.com/JuliaLang/julia/pull/18041, probably to match the actual signature.