### PR TITLE
Fix improper FFTW function deprecation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,6 +106,10 @@ Deprecated or removed
   * The `Operators` module is deprecated. Instead, import required operators explicitly
     from `Base`, e.g. `import Base: +, -, *, /` ([#22251]).
 
+  * Bindings to the FFTW library have been removed from Base. The DFT framework for building FFT
+    implementations is now in AbstractFFTs.jl, the bindings to the FFTW library are in FFTW.jl,
+    and the Base signal processing functions which used FFTs are now in DSP.jl ([#21956]).
+
 
 Julia v0.6.0 Release Notes
 ==========================
@@ -891,6 +895,7 @@ Command-line option changes
 [#21759]: https://github.com/JuliaLang/julia/issues/21759
 [#21818]: https://github.com/JuliaLang/julia/issues/21818
 [#21825]: https://github.com/JuliaLang/julia/issues/21825
+[#21956]: https://github.com/JuliaLang/julia/issues/21956
 [#21960]: https://github.com/JuliaLang/julia/issues/21960
 [#21973]: https://github.com/JuliaLang/julia/issues/21973
 [#21974]: https://github.com/JuliaLang/julia/issues/21974

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1445,8 +1445,8 @@ module DFT
         pkg = endswith(String(f), "shift") ? "AbstractFFTs" : "FFTW"
         @eval begin
             function $f(args...; kwargs...)
-                error($f, " has been moved to the package $pkg.jl.\n",
-                      "Run `Pkg.add(\"$pkg\")` to install $pkg then run `using $pkg` ",
+                error($f, " has been moved to the package $($pkg).jl.\n",
+                      "Run `Pkg.add(\"$($pkg)\")` to install $($pkg) then run `using $($pkg)` ",
                       "to load it.")
             end
             export $f


### PR DESCRIPTION
I changed something incorrectly during a rebase in #21956. This now works as expected:
```julia
julia> fft(1)
ERROR: fft has been moved to the package FFTW.jl.
Run `Pkg.add("FFTW")` to install FFTW then run `using FFTW` to load it.
Stacktrace:
 [1] #fft#8(::Array{Any,1}, ::Function, ::Int64, ::Vararg{Int64,N} where N) at ./deprecated.jl:1457
 [2] fft(::Int64, ::Vararg{Int64,N} where N) at ./deprecated.jl:1457
```