### PR TITLE
Define new dot method for abstract vectors

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -674,6 +674,9 @@ vecdot(x::Number, y::Number) = conj(x) * y
 
 dot(x::Number, y::Number) = vecdot(x, y)
 
+dot(x::Number, y::AbstractArray) = conj(x) * y
+dot(x::AbstractArray, y::Number) = ctranspose(x) * y
+
 """
     dot(x, y)
     ⋅(x,y)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -674,15 +674,11 @@ vecdot(x::Number, y::Number) = conj(x) * y
 
 dot(x::Number, y::Number) = vecdot(x, y)
 
-dot(x::Number, y::AbstractArray) = conj(x) * y
-dot(x::AbstractArray, y::Number) = ctranspose(x) * y
-dot(x::AbstractArray, y::AbstractArray) = ctranspose(x) * y
-
 """
     dot(x, y)
     ⋅(x,y)
 
-Compute the dot product. For complex vectors, the first vector is conjugated. If the first argument is a matrix, it is conjugate transposed instead.  Note: if both arguments are vectors, `dot` is called recursively between its inner elements (see `vecdot`).
+Compute the dot product. For complex vectors, the first vector is conjugated.
 
 # Example
 
@@ -692,11 +688,6 @@ julia> dot([1; 1], [2; 3])
 
 julia> dot([im; im], [1; 1])
 0 - 2im
-
-julia> dot([im 0; 0 im], [1; 1])
-2-element Array{Complex{Int64},1}:
- 0-1im
- 0-1im
 ```
 """
 dot(x::AbstractVector, y::AbstractVector) = vecdot(x, y)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -676,6 +676,7 @@ dot(x::Number, y::Number) = vecdot(x, y)
 
 dot(x::Number, y::AbstractArray) = conj(x) * y
 dot(x::AbstractArray, y::Number) = ctranspose(x) * y
+dot(x::AbstractArray, y::AbstractArray) = ctranspose(x) * y
 
 """
     dot(x, y)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -682,7 +682,7 @@ dot(x::AbstractArray, y::AbstractArray) = ctranspose(x) * y
     dot(x, y)
     ⋅(x,y)
 
-Compute the dot product. For complex vectors, the first vector is conjugated.
+Compute the dot product. For complex vectors, the first vector is conjugated. If the first argument is a matrix, it is conjugate transposed instead.  Note: if both arguments are vectors, `dot` is called recursively between its inner elements (see `vecdot`).
 
 # Example
 
@@ -692,6 +692,11 @@ julia> dot([1; 1], [2; 3])
 
 julia> dot([im; im], [1; 1])
 0 - 2im
+
+julia> dot([im 0; 0 im], [1; 1])
+2-element Array{Complex{Int64},1}:
+ 0-1im
+ 0-1im
 ```
 """
 dot(x::AbstractVector, y::AbstractVector) = vecdot(x, y)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -678,7 +678,8 @@ dot(x::Number, y::Number) = vecdot(x, y)
     dot(x, y)
     ⋅(x,y)
 
-Compute the dot product. For complex vectors, the first vector is conjugated.
+Compute the dot product between two vectors. For complex vectors, the first vector is conjugated.
+When the vectors have equal lengths, calling `dot` is semantically equivalent to `sum(vx'vy for (vx,vy) in zip(x, y))`.
 
 # Example
 
@@ -690,7 +691,29 @@ julia> dot([im; im], [1; 1])
 0 - 2im
 ```
 """
-dot(x::AbstractVector, y::AbstractVector) = vecdot(x, y)
+function dot(x::AbstractVector, y::AbstractVector)
+    if length(x) != length(y)
+        throw(DimensionMismatch("dot product arguments have lengths $(length(x)) and $(length(y))"))
+    end
+    ix = start(x)
+    if done(x, ix)
+        # we only need to check the first vector, since equal lengths have been asserted
+        return zero(eltype(x))'zero(eltype(y))
+    end
+    @inbounds (vx, ix) = next(x, ix)
+    @inbounds (vy, iy) = next(y, start(y))
+    s = vx'vy
+    while !done(x, ix)
+        @inbounds (vx, ix) = next(x, ix)
+        @inbounds (vy, iy) = next(y, iy)
+        s += vx'vy
+    end
+    return s
+end
+
+# Call optimized BLAS methods for vectors of numbers
+dot(x::AbstractVector{<:Number}, y::AbstractVector{<:Number}) = vecdot(x, y)
+
 
 ###########################################################################################
 

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -258,6 +258,9 @@ end
     @test dot(x, 1:2,y, 1:2) == convert(elty, 12.5)
     @test x.'*y == convert(elty, 29.0)
     @test_throws MethodError dot(rand(elty, 2, 2), randn(elty, 2, 2))
+    X = convert(Vector{Matrix{elty}},[reshape(1:4, 2, 2), ones(2, 2)])
+    res = convert(Matrix{elty}, [7.0 13.0; 13.0 27.0])
+    @test dot(X, X) == res
 end
 
 vecdot_(x,y) = invoke(vecdot, Tuple{Any,Any}, x,y) # generic vecdot


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/22374 undefines `dot` between matrices. The concerns raised in https://github.com/JuliaLang/julia/pull/22220 was that `dot(::Matrix, ::Matrix)` is presently the Euclidean product. This behaviour will be fixed/broken by https://github.com/JuliaLang/julia/pull/22374 and the Euclidean product between matrices will have to be computed by calling `vecdot`.

There are two main arguments for adding methods between matrices and numbers to `dot` as in this PR:  

- numpy defines dot in a similar way (except for the conjugation) between arrays and numbers and arrays and arrays
- this allows exploitation of the nested calls to dot between the entries in vectors, where the entries are arrays or numbers to write sums of products as dot products of vectors

(I don't know how to make https://github.com/JuliaLang/julia/pull/22220 point to this new branch, so I'm making a new PR. Sorry for the noise.)