### PR TITLE
Silence Clang warnings for GC root placement pass

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1450,7 +1450,7 @@ public:
         addOptimizationPasses(&Adapter, 3);
     }
     JuliaPipeline() : Pass(PT_PassManager, ID) {}
-    Pass *createPrinterPass(raw_ostream &O, const std::string &Banner) const {
+    Pass *createPrinterPass(raw_ostream &O, const std::string &Banner) const override {
         return createPrintModulePass(O, Banner);
     }
 };

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1045,7 +1045,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F) {
                 IRBuilder<> Builder (CI);
                 for (; it != CI->arg_end(); ++it) {
                     Builder.CreateStore(*it, Builder.CreateGEP(T_prjlvalue, Frame,
-                      {ConstantInt::get(T_int32, slot++)}));
+                        ConstantInt::get(T_int32, slot++)));
                 }
                 ReplacementArgs.push_back(nframeargs == 0 ?
                     (llvm::Value*)ConstantPointerNull::get(T_pprjlvalue) :


### PR DESCRIPTION
This fixes a couple of warnings emitted by Clang when building after #21888.