### PR TITLE
carry out (c)transpose in Ax_mul_Bx methods for Hermitian and Symmetric

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -234,6 +234,12 @@ A_mul_B!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= A.diag .
 Ac_mul_B!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= ctranspose.(A.diag) .* in
 At_mul_B!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= transpose.(A.diag) .* in
 
+# ambiguities with Symmetric/Hermitian
+# RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose
+A_mul_Bt(A::Diagonal, B::RealHermSymComplexSym) = A*B
+At_mul_B(A::RealHermSymComplexSym, B::Diagonal) = A*B
+A_mul_Bc(A::Diagonal, B::RealHermSymComplexHerm) = A*B
+Ac_mul_B(A::RealHermSymComplexHerm, B::Diagonal) = A*B
 
 (/)(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag)
 function A_ldiv_B!(D::Diagonal{T}, v::AbstractVector{T}) where {T}


### PR DESCRIPTION
Benchmarks: https://gist.github.com/fredrikekre/03f31913dd322f4c245740f3f6894436

~~`transpose(A::Hermitian{<:Complex})` and `ctranspose(A::Symmetric{<:Complex})` will allocate more here. (But that amount is comparable to element type promotion so I think it is okay?). It is still faster to be able to use BLAS instead of the generic methods.~~

(This change only makes sense after #22373 so will rebase after that is merged)