### PR TITLE
fix keyword example to be runable in x86 also

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -443,7 +443,7 @@ prior keyword arguments.
 The types of keyword arguments can be made explicit as follows:
 
 ```julia
-function f(;x::Int64=1)
+function f(;x::Int=1)
     ###
 end
 ```


### PR DESCRIPTION
replace `Int64` by the Architecture independent `Int`