### PR TITLE
Drop support for LLVM <= 3.9.1

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1104,7 +1104,7 @@ static std::pair<Value*, bool> emit_isa(const jl_cgval_t &x, jl_value_t *type, c
                 builder.CreateCondBr(isboxed, isaBB, postBB);
                 builder.SetInsertPoint(isaBB);
                 Value *istype_boxed = builder.CreateICmpEQ(emit_typeof(x.V),
-                  maybe_decay_untracked(literal_pointer_val(type)));
+                    maybe_decay_untracked(literal_pointer_val(type)));
                 builder.CreateBr(postBB);
                 builder.SetInsertPoint(postBB);
                 PHINode *istype = builder.CreatePHI(T_int1, 2);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1156,7 +1156,7 @@ static void emit_leafcheck(Value *typ, const std::string &msg, jl_codectx_t *ctx
     assert(typ->getType() == T_pjlvalue);
     emit_typecheck(mark_julia_type(typ, true, jl_any_type, ctx, false), (jl_value_t*)jl_datatype_type, msg, ctx);
     Value *isleaf;
-    isleaf = builder.CreateConstInBoundsGEP1_32(LLVM37_param(T_int8) emit_bitcast(decay_derived(typ), T_pint8), offsetof(jl_datatype_t, isleaftype));
+    isleaf = builder.CreateConstInBoundsGEP1_32(T_int8, emit_bitcast(decay_derived(typ), T_pint8), offsetof(jl_datatype_t, isleaftype));
     isleaf = builder.CreateLoad(isleaf, tbaa_const);
     isleaf = builder.CreateTrunc(isleaf, T_int1);
     error_unless(isleaf, msg, ctx);
@@ -1526,14 +1526,14 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
                 lt = vlt->getElementType();
                 Value *ptr = data_pointer(strct, ctx, lt->getPointerTo());
                 Value *llvm_idx = ConstantInt::get(T_size, idx);
-                addr = builder.CreateGEP(LLVM37_param(lt) ptr, llvm_idx);
+                addr = builder.CreateGEP(lt, ptr, llvm_idx);
             }
             else if (lt->isSingleValueType()) {
                 addr = data_pointer(strct, ctx, lt->getPointerTo());
             }
             else {
                 Value *ptr = data_pointer(strct, ctx, lt->getPointerTo());
-                addr = builder.CreateStructGEP(LLVM37_param(lt) ptr, idx);
+                addr = builder.CreateStructGEP(lt, ptr, idx);
             }
         }
         if (jl_field_isptr(jt, idx)) {
@@ -2394,7 +2394,7 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                     if (!init_as_value) {
                         // avoid unboxing the argument explicitely
                         // and use memcpy instead
-                        dest = builder.CreateConstInBoundsGEP2_32(LLVM37_param(lt) strct, 0, i);
+                        dest = builder.CreateConstInBoundsGEP2_32(lt, strct, 0, i);
                     }
                     fval = emit_unbox(fty, fval_info, jtype, dest);
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4322,7 +4322,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx)
         }
         jl_cgval_t ast = emit_expr(arg, ctx);
         return mark_julia_type(builder.CreateCall(prepare_call(jlcopyast_func),
-          maybe_decay_untracked(boxed(ast, ctx))), true, ast.typ, ctx);
+            maybe_decay_untracked(boxed(ast, ctx))), true, ast.typ, ctx);
     }
     else if (head == simdloop_sym) {
         llvm::annotateSimdLoop(builder.GetInsertBlock());

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -2,36 +2,19 @@
 
 #include "codegen_shared.h"
 
-#if defined(USE_ORCJIT) && JL_LLVM_VERSION <= 30800
-#  include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
-void notifyObjectLoaded(RTDyldMemoryManager *memmgr,
-                        llvm::orc::ObjectLinkingLayerBase::ObjSetHandleT H);
-#endif
-
 // Declarations for disasm.cpp
 extern "C"
 void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
-#ifndef USE_MCJIT
-                          std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
-#endif
                           const object::ObjectFile *object,
                           llvm::DIContext *context,
-#if JL_LLVM_VERSION >= 30700
                           raw_ostream &rstream,
-#else
-                          formatted_raw_ostream &stream,
-#endif
                           const char* asm_variant="att"
                           );
 
 // Declarations for debuginfo.cpp
 extern int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide, int64_t *section_slide,
                       const object::ObjectFile **object,
-#ifdef USE_MCJIT
                       llvm::DIContext **context
-#else
-                      std::vector<JITEvent_EmittedFunctionDetails::LineStart> *lines
-#endif
                       );
 
 extern bool jl_dylib_DI_for_fptr(size_t pointer, const object::ObjectFile **object, llvm::DIContext **context, int64_t *slide, int64_t *section_slide,
@@ -43,6 +26,4 @@ void *lookupWriteAddressFor(RTDyldMemoryManager *memmgr, void *rt_addr);
 #endif
 #endif
 
-#ifdef USE_MCJIT
 RTDyldMemoryManager* createRTDyldMemoryManager(void);
-#endif

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -49,45 +49,22 @@
 #include <llvm/MC/MCExpr.h>
 #include <llvm/MC/MCInstrAnalysis.h>
 #include <llvm/MC/MCSymbol.h>
-#if JL_LLVM_VERSION >= 30500
-#  include <llvm/AsmParser/Parser.h>
-#  if JL_LLVM_VERSION >= 30900
-#    include <llvm/MC/MCDisassembler/MCDisassembler.h>
-#    include <llvm/MC/MCDisassembler/MCExternalSymbolizer.h>
-#  else
-#    include <llvm/MC/MCExternalSymbolizer.h>
-#    include <llvm/MC/MCDisassembler.h>
-#  endif
-#else
-#  include <llvm/Assembly/Parser.h>
-#  include <llvm/ADT/OwningPtr.h>
-#  include <llvm/MC/MCDisassembler.h>
-#endif
+#include <llvm/AsmParser/Parser.h>
+#include <llvm/MC/MCDisassembler/MCDisassembler.h>
+#include <llvm/MC/MCDisassembler/MCExternalSymbolizer.h>
 #include <llvm/ADT/Triple.h>
 #include <llvm/Support/MemoryBuffer.h>
-#if JL_LLVM_VERSION < 30600
-#include <llvm/Support/MemoryObject.h>
-#endif
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/Host.h>
 #include "llvm/Support/TargetSelect.h"
 #include <llvm/Support/raw_ostream.h>
 #include "llvm/Support/FormattedStream.h"
-#if JL_LLVM_VERSION < 30500
-#include <llvm/Support/system_error.h>
-#endif
 #include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/DebugInfo/DIContext.h>
-#if JL_LLVM_VERSION >= 30700
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
-#endif
-#if JL_LLVM_VERSION >= 30500
 #include <llvm/IR/DebugInfo.h>
-#else
-#include <llvm/DebugInfo.h>
-#endif
 #include "fix_llvm_assert.h"
 
 #include "julia.h"
@@ -98,31 +75,7 @@ using namespace llvm;
 extern JL_DLLEXPORT LLVMContext &jl_LLVMContext;
 
 namespace {
-#if JL_LLVM_VERSION >= 30600
 #define FuncMCView ArrayRef<uint8_t>
-#else
-class FuncMCView : public MemoryObject {
-private:
-    const char *Fptr;
-    const size_t Fsize;
-public:
-    FuncMCView(const void *fptr, size_t size) : Fptr((const char*)fptr), Fsize(size) {}
-    uint64_t getBase() const { return 0; }
-    uint64_t getExtent() const { return Fsize; }
-    int readByte(uint64_t Addr, uint8_t *Byte) const {
-        if (Addr >= getExtent())
-            return -1;
-        *Byte = Fptr[Addr];
-        return 0;
-    }
-
-    // ArrayRef-like accessors:
-    const char operator[] (const size_t idx) const { return Fptr[idx]; }
-    uint64_t size() const { return Fsize; }
-    const uint8_t *data() const { return (const uint8_t*)Fptr; }
-    FuncMCView slice(unsigned N) const { return FuncMCView(Fptr+N, Fsize-N); }
-};
-#endif
 
 // Look up a symbol, and return a const char* to its name when the
 // address matches. We currently just use "L<address>" as name for the
@@ -180,33 +133,16 @@ const char *SymbolTable::lookupLocalPC(size_t addr) {
 StringRef SymbolTable::getSymbolNameAt(uint64_t offset) const
 {
     if (object == NULL) return StringRef();
-#if JL_LLVM_VERSION >= 30700
     object::section_iterator ESection = object->section_end();
     for (const object::SymbolRef &Sym : object->symbols()) {
-#else
-    llvm::error_code err;
-    object::section_iterator ESection = object->end_sections();
-    for (object::symbol_iterator I = object->begin_symbols(), E = object->end_symbols();
-            !err && I != E; I.increment(err)) {
-        object::SymbolRef Sym = *I;
-#endif
         uint64_t Addr, SAddr;
         object::section_iterator Sect = ESection;
-#if JL_LLVM_VERSION >= 30800
         auto SectOrError = Sym.getSection();
         assert(SectOrError);
         Sect = SectOrError.get();
-#else
-        if (Sym.getSection(Sect)) continue;
-#endif
         if (Sect == ESection) continue;
-#if JL_LLVM_VERSION >= 30500
         SAddr = Sect->getAddress();
         if (SAddr == 0) continue;
-#else
-        if (Sym.getAddress(SAddr) || SAddr == 0) continue;
-#endif
-#if JL_LLVM_VERSION >= 30700
         auto AddrOrError = Sym.getAddress();
         assert(AddrOrError);
         Addr = AddrOrError.get();
@@ -215,14 +151,6 @@ StringRef SymbolTable::getSymbolNameAt(uint64_t offset) const
             if (sNameOrError)
                 return sNameOrError.get();
         }
-#else
-        if (Sym.getAddress(Addr)) continue;
-        if (Addr == offset) {
-            StringRef Name;
-            if (!Sym.getName(Name))
-                return Name;
-        }
-#endif
     }
     return StringRef();
 }
@@ -258,13 +186,8 @@ void SymbolTable::createSymbols()
             name << global;
         }
 
-#if JL_LLVM_VERSION >= 30700
         MCSymbol *symb = Ctx.getOrCreateSymbol(StringRef(name.str()));
         assert(symb->isUndefined());
-#else
-        MCSymbol *symb = Ctx.GetOrCreateSymbol(StringRef(name.str()));
-        symb->setVariableValue(MCConstantExpr::Create(rel, Ctx));
-#endif
         isymb->second = symb;
     }
 }
@@ -304,11 +227,7 @@ static const char *SymbolLookup(void *DisInfo, uint64_t ReferenceValue, uint64_t
         else if (*ReferenceType == LLVMDisassembler_ReferenceType_In_PCrel_Load) {
             const char *symbolName = SymTab->lookupSymbolName(addr, false);
             if (symbolName) {
-#if JL_LLVM_VERSION >= 30700
                 *ReferenceType = LLVMDisassembler_ReferenceType_Out_LitPool_SymAddr;
-#else
-                *ReferenceType = LLVMDisassembler_ReferenceType_Out_LitPool_CstrAddr;
-#endif
                 *ReferenceName = symbolName;
                 return NULL;
             }
@@ -364,16 +283,9 @@ JL_DLLEXPORT size_t jl_LLVMDisasmInstruction(LLVMDisasmContextRef DC, uint8_t *B
 }
 
 void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
-#ifndef USE_MCJIT
-                          std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
-#endif
                           const object::ObjectFile *object,
                           DIContext *di_ctx,
-#if JL_LLVM_VERSION >= 30700
                           raw_ostream &rstream,
-#else
-                          formatted_raw_ostream &stream,
-#endif
                           const char* asm_variant="att"
                           )
 {
@@ -396,58 +308,24 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
     const Target *TheTarget = TargetRegistry::lookupTarget(TripleName, err);
 
     // Set up required helpers and streamer
-#if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCStreamer> Streamer;
-#else
-    OwningPtr<MCStreamer> Streamer;
-#endif
     SourceMgr SrcMgr;
 
-#if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCAsmInfo> MAI(TheTarget->createMCAsmInfo(*TheTarget->createMCRegInfo(TripleName),TripleName));
-#elif JL_LLVM_VERSION >= 30400
-    llvm::OwningPtr<MCAsmInfo> MAI(TheTarget->createMCAsmInfo(*TheTarget->createMCRegInfo(TripleName),TripleName));
-#else
-    llvm::OwningPtr<MCAsmInfo> MAI(TheTarget->createMCAsmInfo(TripleName));
-#endif
     assert(MAI && "Unable to create target asm info!");
 
-#if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
-#else
-    llvm::OwningPtr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
-#endif
     assert(MRI && "Unable to create target register info!");
 
-#if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCObjectFileInfo> MOFI(new MCObjectFileInfo());
-#else
-    OwningPtr<MCObjectFileInfo> MOFI(new MCObjectFileInfo());
-#endif
-#if JL_LLVM_VERSION >= 30400
     MCContext Ctx(MAI.get(), MRI.get(), MOFI.get(), &SrcMgr);
-#else
-    MCContext Ctx(*MAI, *MRI, MOFI.get(), &SrcMgr);
-#endif
-#if JL_LLVM_VERSION >= 30900
     MOFI->InitMCObjectFileInfo(TheTriple, /* PIC */ false,
                                CodeModel::Default, Ctx);
-#elif JL_LLVM_VERSION >= 30700
-    MOFI->InitMCObjectFileInfo(TheTriple, Reloc::Default, CodeModel::Default, Ctx);
-#else
-    MOFI->InitMCObjectFileInfo(TripleName, Reloc::Default, CodeModel::Default, Ctx);
-#endif
 
     // Set up Subtarget and Disassembler
-#if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCSubtargetInfo>
         STI(TheTarget->createMCSubtargetInfo(TripleName, MCPU, Features.getString()));
     std::unique_ptr<MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI, Ctx));
-#else
-    OwningPtr<MCSubtargetInfo>
-        STI(TheTarget->createMCSubtargetInfo(TripleName, MCPU, Features.getString()));
-    OwningPtr<MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI));
-#endif
     if (!DisAsm) {
         jl_printf(JL_STDERR, "ERROR: no disassembler for target %s\n",
                   TripleName.c_str());
@@ -460,74 +338,37 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
     }
     bool ShowEncoding = false;
 
-#if JL_LLVM_VERSION >= 30500
     std::unique_ptr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());
     std::unique_ptr<MCInstrAnalysis>
         MCIA(TheTarget->createMCInstrAnalysis(MCII.get()));
-#else
-    OwningPtr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());
-    OwningPtr<MCInstrAnalysis>
-        MCIA(TheTarget->createMCInstrAnalysis(MCII.get()));
-#endif
-#if JL_LLVM_VERSION >= 30700
     MCInstPrinter *IP =
         TheTarget->createMCInstPrinter(TheTriple, OutputAsmVariant, *MAI, *MCII, *MRI);
-#else
-    MCInstPrinter *IP =
-        TheTarget->createMCInstPrinter(OutputAsmVariant, *MAI, *MCII, *MRI, *STI);
-#endif
     //IP->setPrintImmHex(true); // prefer hex or decimal immediates
     MCCodeEmitter *CE = 0;
     MCAsmBackend *MAB = 0;
     if (ShowEncoding) {
-#if JL_LLVM_VERSION >= 30700
         CE = TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx);
-#else
-        CE = TheTarget->createMCCodeEmitter(*MCII, *MRI, *STI, Ctx);
-#endif
 #if JL_LLVM_VERSION >= 40000
         MCTargetOptions Options;
         MAB = TheTarget->createMCAsmBackend(*MRI, TripleName, MCPU, Options);
-#elif JL_LLVM_VERSION >= 30400
-        MAB = TheTarget->createMCAsmBackend(*MRI, TripleName, MCPU);
 #else
-        MAB = TheTarget->createMCAsmBackend(TripleName, MCPU);
+        MAB = TheTarget->createMCAsmBackend(*MRI, TripleName, MCPU);
 #endif
     }
 
-#if JL_LLVM_VERSION >= 30700
     // createAsmStreamer expects a unique_ptr to a formatted stream, which means
     // it will destruct the stream when it is done. We cannot have this, so we
     // start out with a raw stream, and create formatted stream from it here.
     // LLVM will desctruct the formatted stream, and we keep the raw stream.
     auto ustream = llvm::make_unique<formatted_raw_ostream>(rstream);
     Streamer.reset(TheTarget->createAsmStreamer(Ctx, std::move(ustream), /*asmverbose*/true,
-#else
-    Streamer.reset(TheTarget->createAsmStreamer(Ctx, stream, /*asmverbose*/true,
-#endif
-#if JL_LLVM_VERSION < 30500
-                                                /*useLoc*/ true,
-                                                /*useCFI*/ true,
-#endif
                                                 /*useDwarfDirectory*/ true,
                                                 IP, CE, MAB, /*ShowInst*/ false));
-#if JL_LLVM_VERSION >= 30600
     Streamer->InitSections(true);
-#else
-    Streamer->InitSections();
-#endif
 
     // Make the MemoryObject wrapper
-#if JL_LLVM_VERSION >= 30600
     ArrayRef<uint8_t> memoryObject(const_cast<uint8_t*>((const uint8_t*)Fptr),Fsize);
-#else
-    FuncMCView memoryObject((const uint8_t*)Fptr, Fsize);
-#endif
     SymbolTable DisInfo(Ctx, object, slide, memoryObject);
-
-#ifndef USE_MCJIT
-    typedef std::vector<JITEvent_EmittedFunctionDetails::LineStart> LInfoVec;
-#endif
 
     DILineInfoTable di_lineinfo;
     if (di_ctx)
@@ -545,72 +386,29 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
             // MCIA->evaluateBranch. (It should be possible to rewrite
             // this routine to handle this case correctly as well.)
             // Could add OpInfoLookup here
-#if JL_LLVM_VERSION >= 30500
             DisAsm->setSymbolizer(std::unique_ptr<MCSymbolizer>(new MCExternalSymbolizer(
                         Ctx,
                         std::unique_ptr<MCRelocationInfo>(new MCRelocationInfo(Ctx)),
                         OpInfoLookup,
                         SymbolLookup,
                         &DisInfo)));
-#elif JL_LLVM_VERSION >= 30400
-            OwningPtr<MCRelocationInfo> relinfo(new MCRelocationInfo(Ctx));
-            DisAsm->setupForSymbolicDisassembly(OpInfoLookup, SymbolLookup, &DisInfo, &Ctx,
-                                                relinfo);
-#else
-            DisAsm->setupForSymbolicDisassembly(OpInfoLookup, SymbolLookup, &DisInfo, &Ctx);
-#endif
         }
 
         uint64_t nextLineAddr = -1;
         DILineInfoTable::iterator di_lineIter = di_lineinfo.begin();
         DILineInfoTable::iterator di_lineEnd = di_lineinfo.end();
-#ifndef USE_MCJIT
-        LInfoVec::iterator lineIter = lineinfo.begin();
-        LInfoVec::iterator lineEnd  = lineinfo.end();
-#endif
         if (pass != 0) {
             if (di_ctx) {
                 // Set up the line info
                 if (di_lineIter != di_lineEnd) {
-#if JL_LLVM_VERSION >= 30700
                     std::ostringstream buf;
                     buf << "Filename: " << di_lineIter->second.FileName << "\n";
                     Streamer->EmitRawText(buf.str());
-#elif JL_LLVM_VERSION >= 30500
-                    stream << "Filename: " << di_lineIter->second.FileName << "\n";
-#else
-                    stream << "Filename: " << di_lineIter->second.getFileName() << "\n";
-#endif
-#if JL_LLVM_VERSION >= 30500
                     if (di_lineIter->second.Line <= 0)
-#else
-                    if (di_lineIter->second.getLine() <= 0)
-#endif
                         ++di_lineIter;
                     nextLineAddr = di_lineIter->first;
                 }
             }
-#ifndef USE_MCJIT
-            else {
-            // Set up the line info
-                if (lineIter != lineEnd) {
-                    DebugLoc Loc = (*lineIter).Loc;
-                    MDNode *outer = Loc.getInlinedAt(jl_LLVMContext);
-                    while (outer) {
-                        Loc = DebugLoc::getFromDILocation(outer);
-                        outer = Loc.getInlinedAt(jl_LLVMContext);
-                    }
-                    StringRef FileName;
-                    DISubprogram debugscope = DISubprogram(Loc.getScope(jl_LLVMContext));
-                    stream << "Filename: " << debugscope.getFilename() << "\n";
-                    if (Loc.getLine() > 0)
-                        stream << "Source line: " << Loc.getLine() << "\n";
-#if JL_LLVM_VERSION >= 30500
-                    nextLineAddr = (*lineIter).Address;
-#endif
-                }
-            }
-#endif
         }
 
         uint64_t Index = 0;
@@ -621,45 +419,21 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
 
             if (nextLineAddr != (uint64_t)-1 && Index + Fptr + slide == nextLineAddr) {
                 if (di_ctx) {
-#if JL_LLVM_VERSION >= 30700
                     std::ostringstream buf;
                     buf << "Source line: " << di_lineIter->second.Line << "\n";
                     Streamer->EmitRawText(buf.str());
-#elif JL_LLVM_VERSION >= 30500
-                    stream << "Source line: " << di_lineIter->second.Line << "\n";
-#else
-                    stream << "Source line: " << di_lineIter->second.getLine() << "\n";
-#endif
                     nextLineAddr = (++di_lineIter)->first;
                 }
-#ifndef USE_MCJIT
-                else {
-                    DebugLoc Loc = (*lineIter).Loc;
-                    MDNode *outer = Loc.getInlinedAt(jl_LLVMContext);
-                    while (outer) {
-                        Loc = DebugLoc::getFromDILocation(outer);
-                        outer = Loc.getInlinedAt(jl_LLVMContext);
-                    }
-                    stream << "Source line: " << Loc.getLine() << "\n";
-                    nextLineAddr = (*++lineIter).Address;
-                }
-#endif
             }
 
             DisInfo.setIP(Fptr+Index);
             if (pass != 0) {
                 // Uncomment this to output addresses for all instructions
                 // stream << Index << ": ";
-#if JL_LLVM_VERSION >= 30700
                 MCSymbol *symbol = DisInfo.lookupSymbol(Fptr+Index);
                 if (symbol)
                     Streamer->EmitLabel(symbol);
                     // emitInstructionAnnot
-#else
-                const char *symbolName = DisInfo.lookupSymbolName(Fptr + Index, true);
-                if (symbolName)
-                    stream << symbolName << ":";
-#endif
             }
 
             MCInst Inst;
@@ -703,21 +477,13 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, int64_t slide,
                     // Pass 0: Record all branch targets
                     if (MCIA && (MCIA->isBranch(Inst) || MCIA->isCall(Inst))) {
                         uint64_t addr;
-#if JL_LLVM_VERSION >= 30400
                         if (MCIA->evaluateBranch(Inst, Fptr+Index, insSize, addr))
-#else
-                        if ((addr = MCIA->evaluateBranch(Inst, Fptr+Index, insSize)) != (uint64_t)-1)
-#endif
                             DisInfo.insertAddress(addr);
                     }
                 }
                 else {
                     // Pass 1: Output instruction
-#if JL_LLVM_VERSION >= 30500
                     Streamer->EmitInstruction(Inst, *STI);
-#else
-                    Streamer->EmitInstruction(Inst);
-#endif
                 }
                 break;
             }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -17,29 +17,16 @@
 #  include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #endif
 #include "llvm/ExecutionEngine/ObjectMemoryBuffer.h"
-#elif defined(USE_MCJIT)
+#else
 #include <llvm/ExecutionEngine/MCJIT.h>
 #include <llvm/ADT/DenseMapInfo.h>
 #include <llvm/Object/ObjectFile.h>
-#else
-#include <llvm/ExecutionEngine/JIT.h>
-#include <llvm/ExecutionEngine/JITMemoryManager.h>
-#include <llvm/ExecutionEngine/Interpreter.h>
-#include <llvm/ExecutionEngine/ExecutionEngine.h>
-#include <llvm/ExecutionEngine/JITEventListener.h>
 #endif
 
-#if JL_LLVM_VERSION >= 30700
 #include "llvm/IR/LegacyPassManager.h"
 extern legacy::PassManager *jl_globalPM;
-#else
-#include <llvm/PassManager.h>
-extern PassManager *jl_globalPM;
-#endif
 
-#if JL_LLVM_VERSION >= 30500
 #include <llvm/Target/TargetMachine.h>
-#endif
 #include "fix_llvm_assert.h"
 
 extern "C" {
@@ -60,11 +47,7 @@ extern size_t jltls_offset_idx;
 
 typedef struct {Value *gv; int32_t index;} jl_value_llvm; // uses 1-based indexing
 
-#if JL_LLVM_VERSION >= 30700
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level);
-#else
-void addOptimizationPasses(PassManager *PM, int opt_level);
-#endif
 void* jl_emit_and_add_to_shadow(GlobalVariable *gv, void *gvarinit = NULL);
 GlobalVariable *jl_emit_sysimg_slot(Module *m, Type *typ, const char *name,
                                     uintptr_t init, size_t &idx);
@@ -84,11 +67,9 @@ static inline GlobalVariable *global_proto(GlobalVariable *G, Module *M = NULL)
             G->isConstant(), GlobalVariable::ExternalLinkage,
             NULL, G->getName(),  G->getThreadLocalMode());
     proto->copyAttributesFrom(G);
-#if JL_LLVM_VERSION >= 30500
     // DLLImport only needs to be set for the shadow module
     // it just gets annoying in the JIT
     proto->setDLLStorageClass(GlobalValue::DefaultStorageClass);
-#endif
     if (M)
         M->getGlobalList().push_back(proto);
     return proto;
@@ -106,28 +87,22 @@ static inline Function *function_proto(Function *F, Module *M = NULL)
     // routine from `F`, since copying it and then resetting is more expensive
     // as well as introducing an extra use from this unowned function, which
     // can cause crashes in the LLVMContext's global destructor.
-#if JL_LLVM_VERSION >= 30700
     llvm::Constant *OldPersonalityFn = nullptr;
     if (F->hasPersonalityFn()) {
         OldPersonalityFn = F->getPersonalityFn();
         F->setPersonalityFn(nullptr);
     }
-#endif
 
      // FunctionType does not include any attributes. Copy them over manually
      // as codegen may make decisions based on the presence of certain attributes
      NewF->copyAttributesFrom(F);
 
-#if JL_LLVM_VERSION >= 30700
     if (OldPersonalityFn)
         F->setPersonalityFn(OldPersonalityFn);
-#endif
 
-#if JL_LLVM_VERSION >= 30500
     // DLLImport only needs to be set for the shadow module
     // it just gets annoying in the JIT
     NewF->setDLLStorageClass(GlobalValue::DefaultStorageClass);
-#endif
 
     return NewF;
 }
@@ -143,15 +118,9 @@ static inline GlobalVariable *prepare_global(GlobalVariable *G, Module *M)
     return cast<GlobalVariable>(local);
 }
 
-#if JL_LLVM_VERSION >= 30500
 void add_named_global(GlobalObject *gv, void *addr, bool dllimport);
 template<typename T>
 static inline void add_named_global(GlobalObject *gv, T *addr, bool dllimport = true)
-#else
-void add_named_global(GlobalValue *gv, void *addr, bool dllimport);
-template<typename T>
-static inline void add_named_global(GlobalValue *gv, T *addr, bool dllimport = true)
-#endif
 {
     // cast through integer to avoid c++ pedantic warning about casting between
     // data and code pointers
@@ -240,11 +209,7 @@ extern JuliaOJIT *jl_ExecutionEngine;
 #else
 extern ExecutionEngine *jl_ExecutionEngine;
 #endif
-#if JL_LLVM_VERSION >= 30900
 JL_DLLEXPORT extern LLVMContext jl_LLVMContext;
-#else
-JL_DLLEXPORT extern LLVMContext &jl_LLVMContext;
-#endif
 
 Pass *createLowerPTLSPass(bool imaging_mode);
 Pass *createLateLowerGCFramePass();

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -15,14 +15,10 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/LLVMContext.h>
-#if JL_LLVM_VERSION >= 30700
 #include <llvm/IR/LegacyPassManager.h>
-#else
-#include <llvm/PassManager.h>
-#endif
 #include <llvm/IR/MDBuilder.h>
 
-#if JL_LLVM_VERSION >= 30700 && defined(JULIA_ENABLE_THREADING)
+#if defined(JULIA_ENABLE_THREADING)
 #  include <llvm/IR/InlineAsm.h>
 #  include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #endif
@@ -63,12 +59,8 @@ static void ensure_global(const char *name, Type *t, Module &M,
     // setting JL_DLLEXPORT correctly only matters when building a binary
     // (global_proto will strip this from the JIT)
     if (dllimport) {
-#if JL_LLVM_VERSION >= 30500
         // add the __declspec(dllimport) attribute
         proto->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
-#else
-        proto->setLinkage(GlobalValue::DLLImportLinkage);
-#endif
     }
 #else // _OS_WINDOWS_
     (void)proto;
@@ -87,7 +79,6 @@ static void setCallPtlsAttrs(CallInst *ptlsStates)
 #endif
 }
 
-#if JL_LLVM_VERSION >= 30700
 static Instruction *emit_ptls_tp(LLVMContext &ctx, Value *offset, Type *T_ppjlvalue,
                                  Instruction *insertBefore)
 {
@@ -153,7 +144,6 @@ static Instruction *emit_ptls_tp(LLVMContext &ctx, Value *offset, Type *T_ppjlva
     return nullptr;
 #  endif
 }
-#endif
 
 #endif
 
@@ -182,7 +172,6 @@ void LowerPTLS::runOnFunction(LLVMContext &ctx, Module &M, Function *F,
     if (imaging_mode) {
         GlobalVariable *GV = cast<GlobalVariable>(
             M.getNamedValue("jl_get_ptls_states.ptr"));
-#if JL_LLVM_VERSION >= 30700
         if (jl_tls_elf_support) {
             GlobalVariable *OffsetGV = cast<GlobalVariable>(
                 M.getNamedValue("jl_tls_offset.val"));
@@ -215,18 +204,15 @@ void LowerPTLS::runOnFunction(LLVMContext &ctx, Module &M, Function *F,
 
             return;
         }
-#endif
         auto getter = new LoadInst(GV, "", ptlsStates);
         getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
         ptlsStates->setCalledFunction(getter);
         setCallPtlsAttrs(ptlsStates);
     }
-#if JL_LLVM_VERSION >= 30700
     else if (jl_tls_offset != -1) {
         ptlsStates->replaceAllUsesWith(emit_ptls_tp(ctx, nullptr, T_ppjlvalue, ptlsStates));
         ptlsStates->eraseFromParent();
     }
-#endif
     else {
         setCallPtlsAttrs(ptlsStates);
     }

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -3,36 +3,14 @@
 #include <llvm/Config/llvm-config.h>
 #include "fix_llvm_assert.h"
 
-#ifndef LLVM_VERSION_PATCH // for LLVM 3.3
-#define LLVM_VERSION_PATCH 0
-#endif
-
 // The LLVM version used, JL_LLVM_VERSION, is represented as a 5-digit integer
 // of the form ABBCC, where A is the major version, B is minor, and C is patch.
 // So for example, LLVM 3.7.0 is 30700.
 #define JL_LLVM_VERSION (LLVM_VERSION_MAJOR * 10000 + LLVM_VERSION_MINOR * 100 \
                         + LLVM_VERSION_PATCH)
 
-#if JL_LLVM_VERSION != 30300 && JL_LLVM_VERSION < 30701
-    #error Only LLVM versions 3.3 and >= 3.7.1 are supported by Julia
+#if JL_LLVM_VERSION < 30901
+    #error Only LLVM versions >= 3.9.1 are supported by Julia
 #endif
 
-#if JL_LLVM_VERSION >= 30800
-    #define USE_ORCJIT
-// We enable ORCJIT only if we have our custom patches
-#elif JL_LLVM_VERSION >= 30700 && !defined(SYSTEM_LLVM)
-    #define USE_ORCJIT
-#endif
-
-#if JL_LLVM_VERSION >= 30400
-    #define USE_MCJIT
-#endif
-
-
-//temporary, since in some places USE_MCJIT may be used instead of the correct LLVM version test
-#ifdef USE_ORCJIT
-    #define USE_MCJIT
-#endif
-#ifdef USE_ORCMCJIT
-    #define USE_MCJIT
-#endif
+#define USE_ORCJIT


### PR DESCRIPTION
As of the merge of #21888, we no longer support building on LLVM <= 3.9.1.
This is essentialyl the mechanical cleanup to rip out all code that
we had to support building on older LLVM versions. There may still be
some residual support left in places and of course some things can now
be cleaned up further, but this should get us started.