### PR TITLE
replace types of Union with Union of types in some places

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1142,21 +1142,15 @@ function lexcmp(a::Array{UInt8,1}, b::Array{UInt8,1})
     return c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
 end
 
+const BitIntegerArray{N} = Union{map(T->Array{T,N}, BitInteger_types)...} where N
 # use memcmp for == on bit integer types
-
-function ==(a::A, b::A) where A <: Union{Array{Int8,N},Array{UInt8,N},Array{Int16,N},
-                                         Array{UInt16,N},Array{Int32,N},Array{UInt32,N},
-                                         Array{Int64,N},Array{UInt64,N},Array{Int128,N},
-                                         Array{UInt128,N}} where N
+function ==(a::A, b::A) where A <: BitIntegerArray
     size(a) == size(b) && 0 == ccall(
         :memcmp, Int32, (Ptr{Void}, Ptr{Void}, UInt), a, b, sizeof(eltype(A)) * length(a))
 end
 
 # this is ~20% faster than the generic implementation above for very small arrays
-function ==(a::A, b::A) where A <: Union{Array{Int8,1},Array{UInt8,1},Array{Int16,1},
-                                         Array{UInt16,1},Array{Int32,1},Array{UInt32,1},
-                                         Array{Int64,1},Array{UInt64,1},Array{Int128,1},
-                                         Array{UInt128,1}}
+function ==(a::A, b::A) where A <: BitIntegerArray{1}
     len = length(a)
     len == length(b) && 0 == ccall(
         :memcmp, Int32, (Ptr{Void}, Ptr{Void}, UInt), a, b, sizeof(eltype(A)) * len)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1144,16 +1144,16 @@ end
 
 const BitIntegerArray{N} = Union{map(T->Array{T,N}, BitInteger_types)...} where N
 # use memcmp for == on bit integer types
-function ==(a::A, b::A) where A <: BitIntegerArray
+function ==(a::Arr, b::Arr) where Arr <: BitIntegerArray
     size(a) == size(b) && 0 == ccall(
-        :memcmp, Int32, (Ptr{Void}, Ptr{Void}, UInt), a, b, sizeof(eltype(A)) * length(a))
+        :memcmp, Int32, (Ptr{Void}, Ptr{Void}, UInt), a, b, sizeof(eltype(Arr)) * length(a))
 end
 
 # this is ~20% faster than the generic implementation above for very small arrays
-function ==(a::A, b::A) where A <: BitIntegerArray{1}
+function ==(a::Arr, b::Arr) where Arr <: BitIntegerArray{1}
     len = length(a)
     len == length(b) && 0 == ccall(
-        :memcmp, Int32, (Ptr{Void}, Ptr{Void}, UInt), a, b, sizeof(eltype(A)) * len)
+        :memcmp, Int32, (Ptr{Void}, Ptr{Void}, UInt), a, b, sizeof(eltype(Arr)) * len)
 end
 
 function reverse(A::AbstractVector, s=first(linearindices(A)), n=last(linearindices(A)))

--- a/base/array.jl
+++ b/base/array.jl
@@ -1143,16 +1143,20 @@ function lexcmp(a::Array{UInt8,1}, b::Array{UInt8,1})
 end
 
 # use memcmp for == on bit integer types
-function ==(a::Array{T,N}, b::Array{T,N}) where T<:BitInteger where N
-    size(a) == size(b) && 0 == ccall(
-        :memcmp, Int32, (Ptr{T}, Ptr{T}, UInt), a, b, sizeof(T) * length(a))
-end
+for T in BitInteger_types
+    @eval begin
+        function ==(a::Array{$T,N}, b::Array{$T,N}) where N
+            size(a) == size(b) && 0 == ccall(
+                :memcmp, Int32, (Ptr{$T}, Ptr{$T}, UInt), a, b, sizeof($T) * length(a))
+        end
 
-# this is ~20% faster than the generic implementation above for very small arrays
-function ==(a::Array{T,1}, b::Array{T,1}) where T<:BitInteger
-    len = length(a)
-    len == length(b) && 0 == ccall(
-        :memcmp, Int32, (Ptr{T}, Ptr{T}, UInt), a, b, sizeof(T) * len)
+        # this is ~20% faster than the generic implementation above for very small arrays
+        function ==(a::Array{$T,1}, b::Array{$T,1})
+            len = length(a)
+            len == length(b) && 0 == ccall(
+                :memcmp, Int32, (Ptr{$T}, Ptr{$T}, UInt), a, b, sizeof($T) * len)
+        end
+    end
 end
 
 function reverse(A::AbstractVector, s=first(linearindices(A)), n=last(linearindices(A)))

--- a/base/random.jl
+++ b/base/random.jl
@@ -621,7 +621,7 @@ end
 
 # A::Array{UInt128} will match the specialized method above
 function rand!(r::MersenneTwister, A::Base.BitIntegerArray)
-    n=length(A)
+    n = length(A)
     T = eltype(A)
     n128 = n * sizeof(T) ÷ 16
     rand!(r, unsafe_wrap(Array, convert(Ptr{UInt128}, pointer(A)), n128))

--- a/base/random.jl
+++ b/base/random.jl
@@ -55,7 +55,7 @@ else # !windows
 
     rand(rd::RandomDevice, T::BoolBitIntegerType)   = read( rd.file, T)
     rand!(rd::RandomDevice, A::BoolBitIntegerArray) = read!(rd.file, A)
-end
+end # os-test
 
 """
     RandomDevice()

--- a/base/random.jl
+++ b/base/random.jl
@@ -623,8 +623,9 @@ function rand!(r::MersenneTwister, A::Array{UInt128}, n::Int=length(A))
 end
 
 # A::Array{UInt128} will matche the specialized method above
-function rand!(r::MersenneTwister, A::Base.BitIntegerArray{T}) where T
+function rand!(r::MersenneTwister, A::Base.BitIntegerArray)
     n=length(A)
+    T = eltype(A)
     n128 = n * sizeof(T) ÷ 16
     rand!(r, unsafe_wrap(Array, convert(Ptr{UInt128}, pointer(A)), n128))
     for i = 16*n128÷sizeof(T)+1:n

--- a/base/random.jl
+++ b/base/random.jl
@@ -33,7 +33,6 @@ const BoolBitIntegerType = Union{Type{Bool},BitIntegerType}
 const BoolBitIntegerArray = Union{Array{Bool},Base.BitIntegerArray}
 
 if is_windows()
-
     struct RandomDevice <: AbstractRNG
         buffer::Vector{UInt128}
 
@@ -46,9 +45,7 @@ if is_windows()
     end
 
     rand!(rd::RandomDevice, A::BoolBitIntegerArray) = (win32_SystemFunction036!(A); A)
-
 else # !windows
-
     struct RandomDevice <: AbstractRNG
         file::IOStream
         unlimited::Bool
@@ -622,7 +619,7 @@ function rand!(r::MersenneTwister, A::Array{UInt128}, n::Int=length(A))
     A
 end
 
-# A::Array{UInt128} will matche the specialized method above
+# A::Array{UInt128} will match the specialized method above
 function rand!(r::MersenneTwister, A::Base.BitIntegerArray)
     n=length(A)
     T = eltype(A)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2155,3 +2155,19 @@ Base.:(==)(a::T11053, b::T11053) = a.a == b.a
 
 #15907
 @test typeof(Array{Int,0}()) == Array{Int,0}
+
+# check a == b for arrays of Union type (#22403)
+let TT = Union{UInt8, Int8}
+    a = TT[0x0, 0x1]
+    b = TT[0x0, 0x0]
+    pa = pointer(a)
+    pb = pointer(b)
+    resize!(a, 1) # sets a[2] = 0
+    resize!(b, 1)
+    @assert pointer(a) == pa
+    @assert pointer(b) == pb
+    unsafe_store!(pa, 0x1, 2) # reset a[2] to 1
+    @test length(a) == length(b) == 1
+    @test a[1] == b[1] == 0x0
+    @test a == b
+end

--- a/test/random.jl
+++ b/test/random.jl
@@ -563,3 +563,6 @@ let b = ['0':'9';'A':'Z';'a':'z']
     end
     @test randstring(MersenneTwister(0)) == randstring(MersenneTwister(0), b)
 end
+
+# this shouldn't crash (#22403)
+@test_throws MethodError rand!(Union{UInt,Int}[1, 2, 3]) isa Vector{Union{UInt,Int}}

--- a/test/random.jl
+++ b/test/random.jl
@@ -565,4 +565,4 @@ let b = ['0':'9';'A':'Z';'a':'z']
 end
 
 # this shouldn't crash (#22403)
-@test_throws MethodError rand!(Union{UInt,Int}[1, 2, 3]) isa Vector{Union{UInt,Int}}
+@test_throws MethodError rand!(Union{UInt,Int}[1, 2, 3])


### PR DESCRIPTION
`T <: Union{A, B}` is sometimes meant to mean either `A` or `B`, which are concrete types. This can result in crashes or wrong results if T takes actually the value `Union{A, B}`.

There may be other places in base with similar bugs...