### PR TITLE
fix shell mode interpolation & allow special chars in commands

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -750,7 +750,9 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
         # and pass into Base.repl_cmd for processing (handles `ls` and `cd`
         # special)
         on_done = respond(repl, julia_prompt) do line
-            Expr(:call, :(Base.repl_cmd), Cmd(Base.shell_split(line)), outstream(repl))
+            Expr(:call, :(Base.repl_cmd),
+                :(Base.cmd_gen($(Base.shell_parse(line)[1]))),
+                outstream(repl))
         end)
 
 

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -588,7 +588,7 @@ function shell_completions(string, pos)
         use_envpath = !ignore_last_word && length(args.args) < 2
 
         return complete_path(prefix, pos, use_envpath=use_envpath)
-    elseif isexpr(arg, :escape) && (isexpr(arg.args[1], :incomplete) || isexpr(arg.args[1], :error))
+    elseif isexpr(arg, :incomplete) || isexpr(arg, :error)
         r = first(last_parse):prevind(last_parse, last(last_parse))
         partial = scs[r]
         ret, range = completions(partial, endof(partial))

--- a/base/process.jl
+++ b/base/process.jl
@@ -817,7 +817,7 @@ function cmd_gen(parsed)
 end
 
 macro cmd(str)
-    return :(cmd_gen($(shell_parse(str, special=shell_special)[1])))
+    return :(cmd_gen($(esc(shell_parse(str, special=shell_special)[1]))))
 end
 
 wait(x::Process)      = if !process_exited(x); stream_wait(x, x.exitnotify); end

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -75,7 +75,7 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
             stpos = j
             ex, j = parse(s,j,greedy=false)
             last_parse = stpos:j
-            update_arg(esc(ex)); i = j
+            update_arg(ex); i = j
         else
             if !in_double_quotes && c == '\''
                 in_single_quotes = !in_single_quotes


### PR DESCRIPTION
fixes #22176, see also #20494 and #20482