### PR TITLE
[GC Lowering] Implement load refinements

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6962,6 +6962,7 @@ extern "C" void *jl_init_llvm(void)
     cl::ParseEnvironmentOptions("Julia", "JULIA_LLVM_ARGS");
 #endif
 
+    jl_page_size = jl_getpagesize();
     imaging_mode = jl_generating_output();
     jl_init_debuginfo();
     jl_init_runtime_ccall();

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -253,6 +253,10 @@ struct State {
     // The result of the local analysis
     std::map<BasicBlock *, BBState> BBStates;
 
+    // Load refinement map. All uses of the keys can be combined with uses
+    // of the value (but not the other way around).
+    std::map<int, int> LoadRefinements;
+
     // The assignment of numbers to safepoints. The indices in the map
     // are indices into the next three maps which store safepoint properties
     std::map<Instruction *, int> SafepointNumbering;
@@ -303,7 +307,7 @@ private:
     Function *pointer_from_objref_func;
     CallInst *ptlsStates;
 
-    void MaybeNoteDef(State &S, BBState &BBS, Value *Def, const std::vector<int> &SafepointsSoFar);
+    void MaybeNoteDef(State &S, BBState &BBS, Value *Def, const std::vector<int> &SafepointsSoFar, int RefinedPtr = -2);
     void NoteUse(State &S, BBState &BBS, Value *V, BitVector &Uses);
     void NoteUse(State &S, BBState &BBS, Value *V) {
         NoteUse(S, BBS, V, BBS.UpExposedUses);
@@ -542,7 +546,7 @@ static void NoteDef(State &S, BBState &BBS, int Num, const std::vector<int> &Saf
     }
 }
 
-void LateLowerGCFrame::MaybeNoteDef(State &S, BBState &BBS, Value *Def, const std::vector<int> &SafepointsSoFar) {
+void LateLowerGCFrame::MaybeNoteDef(State &S, BBState &BBS, Value *Def, const std::vector<int> &SafepointsSoFar, int RefinedPtr) {
     int Num = -1;
     Type *RT = Def->getType();
     if (isSpecialPtr(RT)) {
@@ -558,6 +562,8 @@ void LateLowerGCFrame::MaybeNoteDef(State &S, BBState &BBS, Value *Def, const st
         std::vector<int> Nums = NumberVector(S, Def);
         for (int Num : Nums) {
             NoteDef(S, BBS, Num, SafepointsSoFar);
+            if (RefinedPtr != -2)
+                S.LoadRefinements[Num] = RefinedPtr;
         }
         return;
     }
@@ -565,6 +571,8 @@ void LateLowerGCFrame::MaybeNoteDef(State &S, BBState &BBS, Value *Def, const st
         return;
     }
     NoteDef(S, BBS, Num, SafepointsSoFar);
+    if (RefinedPtr != -2)
+        S.LoadRefinements[Num] = RefinedPtr;
 }
 
 static int NoteSafepoint(State &S, BBState &BBS, CallInst *CI) {
@@ -667,6 +675,31 @@ JL_USED_FUNC static void dumpLivenessState(Function &F, State &S) {
     }
 }
 
+// Check if this is a load from an immutable value. The easiest
+// way to do so is to look at the tbaa and see if it derives from
+// jtbaa_immut.
+static bool isLoadFromImmut(LoadInst *LI)
+{
+    MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
+    if (!TBAA)
+        return false;
+    while (TBAA->getNumOperands() > 1) {
+        TBAA = cast<MDNode>(TBAA->getOperand(1).get());
+        if (cast<MDString>(TBAA->getOperand(0))->getString() == "jtbaa_immut") {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool LooksLikeFrameRef(Value *V) {
+    if (isSpecialPtr(V->getType()))
+        return false;
+    if (isa<GetElementPtrInst>(V))
+        return LooksLikeFrameRef(cast<GetElementPtrInst>(V)->getOperand(0));
+    return isa<Argument>(V);
+}
+
 State LateLowerGCFrame::LocalScan(Function &F) {
     State S;
     for (BasicBlock &BB : F) {
@@ -692,8 +725,21 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                 BBS.TopmostSafepoint = SafepointNumber;
                 BBS.Safepoints.push_back(SafepointNumber);
             } else if (LoadInst *LI = dyn_cast<LoadInst>(&I)) {
-                // Allocas get sunk into the gc frame, so don't generate defs
-                MaybeNoteDef(S, BBS, LI, BBS.Safepoints);
+                // If this is a load from an immutable, we know that
+                // this object will always be rooted as long as the
+                // object we're loading from is, so we can refine uses
+                // of this object to uses of the object we're loading
+                // from.
+                int RefinedPtr = -2;
+                if (isLoadFromImmut(LI) && isSpecialPtr(LI->getPointerOperand()->getType())) {
+                    RefinedPtr = Number(S, LI->getPointerOperand());
+                } else if (LI->getType()->isPointerTy() &&
+                    isSpecialPtr(LI->getType()) &&
+                    LooksLikeFrameRef(LI->getPointerOperand())) {
+                    // Loads from a jlcall argument array
+                    RefinedPtr = -1;
+                }
+                MaybeNoteDef(S, BBS, LI, BBS.Safepoints, RefinedPtr);
                 NoteOperandUses(S, BBS, I, BBS.UpExposedUsesUnrooted);
             } else if (SelectInst *SI = dyn_cast<SelectInst>(&I)) {
                 // We need to insert an extra select for the GC root
@@ -815,10 +861,19 @@ void LateLowerGCFrame::ComputeLiveSets(Function &F, State &S) {
         BBState &BBS = S.BBStates[BB];
         BitVector LiveAcross = BBS.LiveIn;
         LiveAcross &= BBS.LiveOut;
-        S.LiveSets[idx] |= LiveAcross;
+        BitVector &LS = S.LiveSets[idx];
+        LS |= LiveAcross;
         for (int Live : S.LiveIfLiveOut[idx]) {
             if (HasBitSet(BBS.LiveOut, Live))
-                S.LiveSets[idx][Live] = 1;
+                LS[Live] = 1;
+        }
+        // Apply refinements
+        for (int Idx = LS.find_first(); Idx >= 0; Idx = LS.find_next(Idx)) {
+            if (!S.LoadRefinements.count(Idx))
+                continue;
+            int RefinedPtr = S.LoadRefinements[Idx];
+            if (RefinedPtr == -1 || HasBitSet(LS, RefinedPtr))
+                LS[Idx] = 0;
         }
     }
     // Compute the interference graph

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -60,3 +60,5 @@ if opt_level > 0
     # Check that we load the elsize
     test_loads_no_call(get_llvm(core_sizeof, Tuple{Vector}), [Iptr, "i16"])
 end
+
+@test !contains(get_llvm(isequal, Tuple{Nullable{BigFloat}, Nullable{BigFloat}}), "%gcframe")

--- a/test/llvmpasses/gcroots.ll
+++ b/test/llvmpasses/gcroots.ll
@@ -28,7 +28,7 @@ top:
     ret void
 }
 
-define void @leftover_alloca(%jl_value_t addrspace(10)*%a) {
+define void @leftover_alloca(%jl_value_t addrspace(10)* %a) {
 ; If this pass encounters an alloca, it'll just sink it into the gcframe,
 ; relying on mem2reg to catch simple cases such as this earlier
 ; CHECK-LABEL: @leftover_alloca
@@ -173,4 +173,14 @@ top:
   %11 = zext i1 %10 to i8
   %12 = xor i8 %11, 1
   ret i8 %12
+}
+
+define void @global_ref() {
+; CHECK-LABEL: @global_ref
+; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %loaded = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** getelementptr (%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** inttoptr (i64 140540744325952 to %jl_value_t addrspace(10)**), i64 1)
+; CHECK: store %jl_value_t addrspace(10)* %loaded, %jl_value_t addrspace(10)**
+    call void @one_arg_boxed(%jl_value_t addrspace(10)* %loaded)
+    ret void
 }

--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -1,0 +1,55 @@
+; RUN: opt -load libjulia.so -LateLowerGCFrame -S %s | FileCheck %s
+
+%jl_value_t = type opaque
+
+declare %jl_value_t*** @jl_get_ptls_states()
+declare void @jl_safepoint()
+declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
+declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+
+define void @argument_refinement(%jl_value_t addrspace(10)* %a) {
+; CHECK-LABEL: @argument_refinement
+; CHECK-NOT: %gcframe
+    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %casted1 = bitcast %jl_value_t addrspace(10)* %a to %jl_value_t addrspace(10)* addrspace(10)*
+    %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
+    call void @jl_safepoint()
+    %casted2 = bitcast %jl_value_t addrspace(10)* %loaded1 to i64 addrspace(10)*
+    %loaded2 = load i64, i64 addrspace(10)* %casted2
+    ret void
+}
+
+; Check that we reuse the gc slot from the box
+define void @heap_refinement1(i64 %a) {
+; CHECK-LABEL: @heap_refinement1
+; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
+    %casted1 = bitcast %jl_value_t addrspace(10)* %aboxed to %jl_value_t addrspace(10)* addrspace(10)*
+    %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
+; CHECK: store %jl_value_t addrspace(10)* %aboxed
+    call void @jl_safepoint()
+    %casted2 = bitcast %jl_value_t addrspace(10)* %loaded1 to i64 addrspace(10)*
+    %loaded2 = load i64, i64 addrspace(10)* %casted2
+    call void @one_arg_boxed(%jl_value_t addrspace(10)* %aboxed)
+    ret void
+}
+
+; Check that we don't root the allocated value here, just the derived value
+define void @heap_refinement2(i64 %a) {
+; CHECK-LABEL: @heap_refinement2
+; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
+    %casted1 = bitcast %jl_value_t addrspace(10)* %aboxed to %jl_value_t addrspace(10)* addrspace(10)*
+    %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
+; CHECK: store %jl_value_t addrspace(10)* %loaded1
+    call void @jl_safepoint()
+    %casted2 = bitcast %jl_value_t addrspace(10)* %loaded1 to i64 addrspace(10)*
+    %loaded2 = load i64, i64 addrspace(10)* %casted2
+    ret void
+}
+
+!0 = !{!"jtbaa"}
+!1 = !{!2, !2, i64 0}
+!2 = !{!"jtbaa_immut", !0, i64 0}


### PR DESCRIPTION
When loading from an immutable, the loaded value will be rooted whenever
the original value is rooted. We can use this to avoid rooting the derived
value if we know the original value is rooted.