### PR TITLE
A few inference/codegen optimizations

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -91,7 +91,7 @@ asize_from(a::Array, n) = n > ndims(a) ? () : (arraysize(a,n), asize_from(a, n+1
 
 length(a::Array) = arraylen(a)
 elsize(a::Array{T}) where {T} = isbits(T) ? sizeof(T) : sizeof(Ptr)
-sizeof(a::Array) = elsize(a) * length(a)
+sizeof(a::Array) = Core.sizeof(a)
 
 function isassigned(a::Array, i::Int...)
     @_inline_meta

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -51,7 +51,7 @@ convert(::Type{String}, v::Vector{UInt8}) = String(v)
 pointer(s::String) = unsafe_convert(Ptr{UInt8}, s)
 pointer(s::String, i::Integer) = pointer(s)+(i-1)
 
-sizeof(s::String) = s.len
+sizeof(s::String) = Core.sizeof(s)
 
 """
     codeunit(s::AbstractString, i::Integer)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1818,6 +1818,15 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             }
         }
     }
+    else if (is_libjulia_func(jl_string_ptr)) {
+        assert(lrt == T_pint8);
+        assert(!isVa && !llvmcall);
+        assert(nargt == 1);
+        auto obj = emit_pointer_from_objref(boxed(emit_expr(args[4], ctx), ctx));
+        auto strp = builder.CreateConstGEP1_32(emit_bitcast(obj, T_pint8), sizeof(void*));
+        JL_GC_POP();
+        return mark_or_box_ccall_result(strp, retboxed, rt, unionall, static_rt, ctx);
+    }
 
     // emit arguments
     jl_cgval_t *argv = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * (nargs - 3) / 2);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1645,6 +1645,20 @@ static Value *emit_arrayflags(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
     return tbaa_decorate(tbaa_arrayflags, builder.CreateLoad(addr));
 }
 
+static Value *emit_arrayelsize(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
+{
+    Value *t = boxed(tinfo, ctx);
+#ifdef STORE_ARRAY_LEN
+    int elsize_field = 3;
+#else
+    int elsize_field = 2;
+#endif
+    Value *addr = builder.CreateStructGEP(nullptr,
+                                          emit_bitcast(decay_derived(t), jl_parray_llvmt),
+                                          elsize_field);
+    return tbaa_decorate(tbaa_const, builder.CreateLoad(addr));
+}
+
 static void assign_arrayvar(jl_arrayvar_t &av, const jl_cgval_t &ainfo, jl_codectx_t *ctx)
 {
     tbaa_decorate(tbaa_arrayptr,builder.CreateStore(emit_bitcast(emit_arrayptr(ainfo, ctx),

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -3,6 +3,7 @@
 # tests for codegen and optimizations
 
 const opt_level = Base.JLOptions().opt_level
+const Iptr = sizeof(Int) == 8 ? "i64" : "i32"
 
 # `_dump_function` might be more efficient but it doesn't really matter here...
 get_llvm(f::ANY, t::ANY, strip_ir_metadata=true, dump_module=false) =
@@ -11,4 +12,48 @@ get_llvm(f::ANY, t::ANY, strip_ir_metadata=true, dump_module=false) =
 if opt_level > 0
     # Make sure getptls call is removed at IR level with optimization on
     @test !contains(get_llvm(identity, Tuple{String}), " call ")
+end
+
+jl_string_ptr(s::String) = ccall(:jl_string_ptr, Ptr{UInt8}, (Any,), s)
+core_sizeof(o) = Core.sizeof(o)
+function test_loads_no_call(ir, load_types)
+    in_function = false
+    load_idx = 1
+    for line in eachline(IOBuffer(ir))
+        if !in_function
+            if startswith(line, "define ")
+                in_function = true
+            end
+            continue
+        end
+        @test !contains(line, " call ")
+        load_split = split(line, " load ", limit=2)
+        if length(load_split) >= 2
+            @test load_idx <= length(load_types)
+            if load_idx <= length(load_types)
+                @test startswith(load_split[2], "$(load_types[load_idx]),")
+            end
+            load_idx += 1
+        end
+        if startswith(line, "}")
+            break
+        end
+    end
+    @test load_idx == length(load_types) + 1
+end
+if opt_level > 0
+    # Make sure `jl_string_ptr` is inlined
+    @test !contains(get_llvm(jl_string_ptr, Tuple{String}), " call ")
+    s = "aaa"
+    @test jl_string_ptr(s) == pointer_from_objref(s) + sizeof(Int)
+    # String
+    test_loads_no_call(get_llvm(core_sizeof, Tuple{String}), [Iptr])
+    # String
+    test_loads_no_call(get_llvm(core_sizeof, Tuple{SimpleVector}), [Iptr])
+    # Array
+    test_loads_no_call(get_llvm(core_sizeof, Tuple{Vector{Int}}), [Iptr])
+    # As long as the eltype is known we don't need to load the elsize
+    test_loads_no_call(get_llvm(core_sizeof, Tuple{Array{Any}}), [Iptr])
+    # Check that we load the elsize
+    test_loads_no_call(get_llvm(core_sizeof, Tuple{Vector}), [Iptr, "i16"])
 end


### PR DESCRIPTION
* Infer `Core.sizeof` constant results
* Inline `Core.sizeof` in codegen
* Optimize `jl_string_str`

Fix #22422