### PR TITLE
Improve searchindex performance for Char type

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -76,6 +76,8 @@ function _searchindex(s, t, i)
     end
 end
 
+_searchindex(s, t::Char, i) = search(s, t, i)
+
 function _search_bloom_mask(c)
     UInt64(1) << (c & 63)
 end


### PR DESCRIPTION
Update `_searchindex`  to call faster `search` method instead of the general `_searchindex` method when the search needle is a `Char` since they are equivalent  in this case

FYI ref: https://github.com/JuliaLang/julia/pull/22435
so that `contains` with a `Char` needle is just as fast as the `in` function 