### PR TITLE
Fix performance problem in root coloring

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -64,6 +64,7 @@
 #include <llvm/Support/SourceMgr.h> // for llvmcall
 #include <llvm/Transforms/Utils/Cloning.h> // for llvmcall inlining
 #include <llvm/IR/Verifier.h> // for llvmcall validation
+#include <llvm/Bitcode/ReaderWriter.h>
 
 // C API
 #include <llvm-c/Types.h>
@@ -7144,4 +7145,16 @@ extern "C" void jl_dump_llvm_type(void *v)
     ((Type*)v)->dump();
 #endif
     putchar('\n');
+}
+
+extern void jl_write_bitcode_func(void *F, char *fname) {
+    std::error_code EC;
+    raw_fd_ostream OS(fname, EC, sys::fs::F_None);
+    llvm::WriteBitcodeToFile(((llvm::Function*)F)->getParent(), OS);
+}
+
+extern void jl_write_bitcode_module(void *M, char *fname) {
+    std::error_code EC;
+    raw_fd_ostream OS(fname, EC, sys::fs::F_None);
+    llvm::WriteBitcodeToFile((llvm::Module*)M, OS);
 }

--- a/test/llvmpasses/lit.cfg
+++ b/test/llvmpasses/lit.cfg
@@ -7,9 +7,10 @@ import lit.util
 import lit.formats
 
 config.name = 'Julia'
-config.suffixes = ['.ll']
+config.suffixes = ['.ll','.jl']
 config.test_source_root = os.path.dirname(__file__)
-config.test_format = lit.formats.ShTest(False)
+config.test_format = lit.formats.ShTest(True)
 
-path = os.path.pathsep.join((os.path.join(os.path.dirname(__file__),"../../usr/tools"), config.environment['PATH']))
+path = os.path.pathsep.join((os.path.join(os.path.dirname(__file__),"../../usr/tools"), os.path.join(os.path.dirname(__file__),"../../usr/bin"), config.environment['PATH']))
 config.environment['PATH'] = path
+config.environment['HOME'] = "/tmp"

--- a/test/llvmpasses/safepoint_stress.jl
+++ b/test/llvmpasses/safepoint_stress.jl
@@ -1,0 +1,25 @@
+# RUN: julia --startup-file=no %s | opt -load libjulia.so -LateLowerGCFrame -S - | FileCheck %s
+
+println("""
+%jl_value_t = type opaque
+declare %jl_value_t addrspace(10)* @alloc()
+declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
+declare %jl_value_t*** @jl_get_ptls_states()
+
+define void @stress(i64 %a, i64 %b) {
+    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+""")
+
+# CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 10002
+for i = 1:10000
+    println("\t%arg$i = call %jl_value_t addrspace(10)* @alloc()")
+end
+
+for i = 1:10000
+    println("\tcall void @one_arg_boxed(%jl_value_t addrspace(10)* %arg$i)")
+end
+
+println("""
+    ret void
+}
+""")


### PR DESCRIPTION
By originally using a vector, rather than a set, neighbors would
end up getting duplicated in the list. This blew up the size of
the list, causing excessive performance problems in the ColorRoots
function.

Might fix #22431