### PR TITLE
allow CodeInfo to be returned directly from generated function generator

### DIFF
--- a/test/staged.jl
+++ b/test/staged.jl
@@ -228,3 +228,20 @@ g10178(x) = f10178(x)
 # issue #22135
 @generated f22135(x::T) where T = x
 @test f22135(1) === Int
+
+# PR #22440
+
+@generated function f22440(y)
+    sig, spvals, method = Base._methods_by_ftype(Tuple{typeof(one),y}, -1, typemax(UInt))[1]
+    code_info = Base.uncompressed_ast(method)
+    body = Expr(:block, code_info.code...)
+    Base.Core.Inference.substitute!(body, 1, Any[:y], sig, Any[spvals...], 0)
+    return code_info
+end
+
+@test f22440(Int) === one(Int)
+@test f22440(Float64) === one(Float64)
+@test f22440(Float32) === one(Float32)
+@test f22440(0.0) === one(0.0)
+@test f22440(0.0f0) === one(0.0f0)
+@test f22440(0) === one(0)

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -231,17 +231,22 @@ g10178(x) = f10178(x)
 
 # PR #22440
 
+f22440kernel(x...) = x[1] + x[1]
+f22440kernel(x::AbstractFloat) = x * x
+f22440kernel(::Type{T}) where {T} = one(T)
+f22440kernel(::Type{T}) where {T<:AbstractFloat} = zero(T)
+
 @generated function f22440(y)
-    sig, spvals, method = Base._methods_by_ftype(Tuple{typeof(one),y}, -1, typemax(UInt))[1]
+    sig, spvals, method = Base._methods_by_ftype(Tuple{typeof(f22440kernel),y}, -1, typemax(UInt))[1]
     code_info = Base.uncompressed_ast(method)
     body = Expr(:block, code_info.code...)
-    Base.Core.Inference.substitute!(body, 1, Any[:y], sig, Any[spvals...], 0)
+    Base.Core.Inference.substitute!(body, 0, Any[], sig, Any[spvals...], 0)
     return code_info
 end
 
-@test f22440(Int) === one(Int)
-@test f22440(Float64) === one(Float64)
-@test f22440(Float32) === one(Float32)
-@test f22440(0.0) === one(0.0)
-@test f22440(0.0f0) === one(0.0f0)
-@test f22440(0) === one(0)
+@test f22440(Int) === f22440kernel(Int)
+@test f22440(Float64) === f22440kernel(Float64)
+@test f22440(Float32) === f22440kernel(Float32)
+@test f22440(0.0) === f22440kernel(0.0)
+@test f22440(0.0f0) === f22440kernel(0.0f0)
+@test f22440(0) === f22440kernel(0)


### PR DESCRIPTION
My pitiable attempt at resolving #21146. I'm not a C programmer by any means, so I've probably done something stupid/silly. 

I would appreciate any direction here, since if I can get it working, this would be quite useful for tracing generic Julia calls via dispatch-interceptable function wrappers. 