### PR TITLE
Support isbits Union array elements and struct fields

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -22,16 +22,10 @@ extern "C" {
 
 // array constructors ---------------------------------------------------------
 
-static inline int store_unboxed(jl_value_t *el_type) // jl_isbits
+JL_DLLEXPORT int jl_array_store_unboxed(jl_value_t *eltype)
 {
-    return jl_is_leaf_type(el_type) && jl_is_immutable(el_type) &&
-        ((jl_datatype_t*)el_type)->layout &&
-        ((jl_datatype_t*)el_type)->layout->npointers == 0;
-}
-
-int jl_array_store_unboxed(jl_value_t *el_type)
-{
-    return store_unboxed(el_type);
+    size_t fsz = 0, al = 0;
+    return jl_islayout_inline(eltype, &fsz, &al);
 }
 
 STATIC_INLINE jl_value_t *jl_array_owner(jl_array_t *a)
@@ -67,15 +61,19 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
             jl_error("invalid Array dimensions");
         nel = prod;
     }
-
+    int isunion = atype != NULL && jl_is_uniontype(jl_tparam0(atype));
     if (isunboxed) {
         wideint_t prod = (wideint_t)elsz * (wideint_t)nel;
         if (prod > (wideint_t) MAXINTVAL)
             jl_error("invalid Array size");
         tot = prod;
-        if (elsz == 1) {
+        if (elsz == 1 && !isunion) {
             // extra byte for all julia allocated byte arrays
             tot++;
+        }
+        if (isunion) {
+            // an extra byte for each isbits union array element, stored directly after the last array element
+            tot += nel;
         }
     }
     else {
@@ -97,7 +95,7 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
         // No allocation or safepoint allowed after this
         a->flags.how = 0;
         data = (char*)a + doffs;
-        if (tot > 0 && !isunboxed)
+        if ((tot > 0 && !isunboxed) || isunion)
             memset(data, 0, tot);
     }
     else {
@@ -109,7 +107,8 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
         // No allocation or safepoint allowed after this
         a->flags.how = 2;
         jl_gc_track_malloced_array(ptls, a);
-        if (!isunboxed)
+        if (!isunboxed || isunion)
+            // need to zero out isbits union array selector bytes to ensure a valid type index
             memset(data, 0, tot);
     }
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
@@ -141,11 +140,14 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
 
 static inline jl_array_t *_new_array(jl_value_t *atype, uint32_t ndims, size_t *dims)
 {
-    int isunboxed=0, elsz=sizeof(void*);
-    jl_value_t *el_type = jl_tparam0(atype);
-    isunboxed = store_unboxed(el_type);
-    if (isunboxed)
-        elsz = jl_datatype_size(el_type);
+    jl_value_t *eltype = jl_tparam0(atype);
+    size_t elsz = 0, al = 0;
+    int isunboxed = jl_islayout_inline(eltype, &elsz, &al);
+    if (!isunboxed) {
+        elsz = sizeof(void*);
+        al = elsz;
+    }
+
     return _new_array_(atype, ndims, dims, isunboxed, elsz);
 }
 
@@ -180,7 +182,7 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
     size_t *dims = (size_t*)_dims;
 
     int ndimwords = jl_array_ndimwords(ndims);
-    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t) + sizeof(void*), JL_SMALL_BYTE_ALIGNMENT);
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords * sizeof(size_t) + sizeof(void*), JL_SMALL_BYTE_ALIGNMENT);
     a = (jl_array_t*)jl_gc_alloc(ptls, tsz, atype);
     // No allocation or safepoint allowed after this
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
@@ -189,18 +191,24 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
     a->data = NULL;
     a->flags.isaligned = data->flags.isaligned;
     jl_array_t *owner = (jl_array_t*)jl_array_owner(data);
-    jl_value_t *el_type = jl_tparam0(atype);
-    assert(store_unboxed(el_type) == !data->flags.ptrarray);
-    if (!data->flags.ptrarray) {
-        a->elsize = jl_datatype_size(el_type);
-        unsigned align = jl_datatype_align(el_type);
+    jl_value_t *eltype = jl_tparam0(atype);
+    size_t elsz = 0, align = 0;
+    int isboxed = !jl_islayout_inline(eltype, &elsz, &align);
+    assert(isboxed == data->flags.ptrarray);
+    if (!isboxed) {
+        a->elsize = elsz;
         jl_value_t *ownerty = jl_typeof(owner);
-        unsigned oldalign = (ownerty == (jl_value_t*)jl_string_type ? 1 :
-                             jl_datatype_align(jl_tparam0(ownerty)));
+        size_t oldelsz = 0, oldalign = 0;
+        if (ownerty == (jl_value_t*)jl_string_type) {
+            oldalign = 1;
+        }
+        else {
+            jl_islayout_inline(jl_tparam0(ownerty), &oldelsz, &oldalign);
+        }
         if (oldalign < align)
             jl_exceptionf(jl_argumenterror_type,
-                          "reinterpret from alignment %u bytes to alignment %u bytes not allowed",
-                          oldalign, align);
+                          "reinterpret from alignment %d bytes to alignment %d bytes not allowed",
+                          (int) oldalign, (int) align);
         a->flags.ptrarray = 0;
     }
     else {
@@ -276,14 +284,17 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_array_t *a;
-    jl_value_t *el_type = jl_tparam0(atype);
+    jl_value_t *eltype = jl_tparam0(atype);
 
-    int isunboxed = store_unboxed(el_type);
+    int isunboxed = jl_array_store_unboxed(eltype);
     size_t elsz;
     unsigned align;
+    if (isunboxed && jl_is_uniontype(eltype))
+        jl_exceptionf(jl_argumenterror_type,
+                      "unsafe_wrap: unspecified layout for union element type");
     if (isunboxed) {
-        elsz = jl_datatype_size(el_type);
-        align = jl_datatype_align(el_type);
+        elsz = jl_datatype_size(eltype);
+        align = jl_datatype_align(eltype);
     }
     else {
         align = elsz = sizeof(void*);
@@ -339,14 +350,17 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
     }
     if (__unlikely(ndims == 1))
         return jl_ptr_to_array_1d(atype, data, nel, own_buffer);
-    jl_value_t *el_type = jl_tparam0(atype);
+    jl_value_t *eltype = jl_tparam0(atype);
 
-    int isunboxed = store_unboxed(el_type);
+    int isunboxed = jl_array_store_unboxed(eltype);
     size_t elsz;
     unsigned align;
+    if (isunboxed && jl_is_uniontype(eltype))
+        jl_exceptionf(jl_argumenterror_type,
+                      "unsafe_wrap: unspecified layout for union element type");
     if (isunboxed) {
-        elsz = jl_datatype_size(el_type);
-        align = jl_datatype_align(el_type);
+        elsz = jl_datatype_size(eltype);
+        align = jl_datatype_align(eltype);
     }
     else {
         align = elsz = sizeof(void*);
@@ -485,8 +499,15 @@ JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
     assert(i < jl_array_len(a));
     jl_value_t *elt;
     if (!a->flags.ptrarray) {
-        jl_value_t *el_type = (jl_value_t*)jl_tparam0(jl_typeof(a));
-        elt = jl_new_bits(el_type, &((char*)a->data)[i*a->elsize]);
+        jl_value_t *eltype = (jl_value_t*)jl_tparam0(jl_typeof(a));
+        if (jl_is_uniontype(eltype)) {
+            // isbits union selector bytes are always stored directly after the last array element
+            uint8_t sel = ((uint8_t*)a->data)[jl_array_len(a) * a->elsize + i];
+            eltype = jl_nth_union_component(eltype, sel);
+            if (jl_is_datatype_singleton((jl_datatype_t*)eltype))
+                return ((jl_datatype_t*)eltype)->instance;
+        }
+        elt = jl_new_bits(eltype, &((char*)a->data)[i * a->elsize]);
     }
     else {
         elt = ((jl_value_t**)a->data)[i];
@@ -539,13 +560,22 @@ int jl_array_isdefined(jl_value_t **args0, int nargs)
 JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *rhs, size_t i)
 {
     assert(i < jl_array_len(a));
-    jl_value_t *el_type = jl_tparam0(jl_typeof(a));
-    if (el_type != (jl_value_t*)jl_any_type) {
-        if (!jl_isa(rhs, el_type))
-            jl_type_error("arrayset", el_type, rhs);
+    jl_value_t *eltype = jl_tparam0(jl_typeof(a));
+    if (eltype != (jl_value_t*)jl_any_type) {
+        if (!jl_isa(rhs, eltype))
+            jl_type_error("arrayset", eltype, rhs);
     }
     if (!a->flags.ptrarray) {
-        jl_assign_bits(&((char*)a->data)[i*a->elsize], rhs);
+        if (jl_is_uniontype(eltype)) {
+            uint8_t *psel = &((uint8_t*)a->data)[jl_array_len(a) * a->elsize + i];
+            unsigned nth = 0;
+            if (!jl_find_union_component(eltype, jl_typeof(rhs), &nth))
+                assert(0 && "invalid arrayset to isbits union");
+            *psel = nth;
+            if (jl_is_datatype_singleton((jl_datatype_t*)jl_typeof(rhs)))
+                return;
+        }
+        jl_assign_bits(&((char*)a->data)[i * a->elsize], rhs);
     }
     else {
         ((jl_value_t**)a->data)[i] = rhs;
@@ -585,6 +615,10 @@ static int NOINLINE array_resize_buffer(jl_array_t *a, size_t newlen)
     if (elsz == 1) {
         nbytes++;
         oldnbytes++;
+    }
+    if (!a->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(a)))) {
+        nbytes += newlen;
+        oldnbytes += oldlen;
     }
     int newbuf = 0;
     if (a->flags.how == 2) {
@@ -649,6 +683,9 @@ static void NOINLINE array_try_unshare(jl_array_t *a)
         size_t len = jl_array_nrows(a);
         size_t es = a->elsize;
         size_t nbytes = len * es;
+        if (!a->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(a)))) {
+            nbytes += len;
+        }
         char *olddata = (char*)a->data;
         int newbuf = array_resize_buffer(a, len);
         assert(newbuf);
@@ -688,11 +725,16 @@ STATIC_INLINE void jl_array_grow_at_beg(jl_array_t *a, size_t idx, size_t inc,
     size_t nbinc = inc * elsz;
     char *data = (char*)a->data;
     char *newdata;
+    int isbitsunion = !a->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(a)));
     if (a->offset >= inc) {
         newdata = data - nbinc;
         a->offset -= inc;
-        if (idx > 0) {
+        if (idx > 0)
             memmove(newdata, data, idx * elsz);
+        if (isbitsunion) {
+            // move isbits union select bytes back by `inc` & zero out new selector bytes
+            memmove(data + n * elsz + idx + inc, data + n * elsz + idx, n - idx);
+            memset(data + n * elsz + idx, 0, inc);
         }
     }
     else {
@@ -707,6 +749,11 @@ STATIC_INLINE void jl_array_grow_at_beg(jl_array_t *a, size_t idx, size_t inc,
             if (!array_resize_buffer(a, newlen))
                 data = (char*)a->data + oldoffsnb;
             newdata = (char*)a->data + newoffset * elsz;
+            if (isbitsunion) {
+                memmove(newdata + newnrows * elsz, data + n * elsz, idx);
+                memmove(newdata + newnrows * elsz + idx + inc, data + n * elsz + idx, n - idx);
+                memset(newdata + newnrows * elsz + idx, 0, inc);
+            }
             // We could use memcpy if resizing allocates a new buffer,
             // hopefully it's not a particularly important optimization.
             if (idx > 0 && newdata < data)
@@ -719,6 +766,10 @@ STATIC_INLINE void jl_array_grow_at_beg(jl_array_t *a, size_t idx, size_t inc,
         else {
             a->offset = (a->maxsize - newnrows) / 2;
             newdata = data - oldoffsnb + a->offset * elsz;
+            if (isbitsunion) {
+                memmove(newdata + newnrows * elsz + idx + inc, data + n * elsz + idx, n - idx);
+                memset(newdata + newnrows * elsz + idx, 0, inc);
+            }
             // We could use memcpy if resizing allocates a new buffer,
             // hopefully it's not a particularly important optimization.
             if (idx > 0 && newdata < data)
@@ -754,6 +805,8 @@ STATIC_INLINE void jl_array_grow_at_end(jl_array_t *a, size_t idx,
     }
     size_t elsz = a->elsize;
     char *data = (char*)a->data;
+    int isbitsunion = !a->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(a)));
+    size_t oldmaxsize = jl_array_len(a);
     int has_gap = n > idx;
     size_t reqmaxsize = a->offset + n + inc;
     if (__unlikely(reqmaxsize > a->maxsize)) {
@@ -769,18 +822,42 @@ STATIC_INLINE void jl_array_grow_at_end(jl_array_t *a, size_t idx,
         char *newdata = (char*)a->data + a->offset * elsz;
         if (newbuf) {
             memcpy(newdata, data, nb1);
+            if (isbitsunion) {
+                memmove(newdata + (oldmaxsize + inc) * elsz, data + oldmaxsize * elsz, idx);
+            }
             if (has_gap) {
                 memcpy(newdata + nb1 + nbinc, data + nb1, n * elsz - nb1);
+                if (isbitsunion) {
+                    memmove(newdata + (oldmaxsize + inc) * elsz + idx + inc, data + oldmaxsize * elsz + idx, n - idx);
+                    memset(newdata + (oldmaxsize + inc) * elsz + idx, 0, inc);
+                }
             }
         }
         else if (has_gap) {
+            if (isbitsunion) {
+                memmove(newdata + (oldmaxsize + inc) * elsz, newdata + oldmaxsize * elsz, idx);
+                memmove(newdata + (oldmaxsize + inc) * elsz + idx + inc, newdata + oldmaxsize * elsz + idx, n - idx);
+                memset(newdata + (oldmaxsize + inc) * elsz + idx, 0, inc);
+            }
             memmove(newdata + nb1 + nbinc, newdata + nb1, n * elsz - nb1);
         }
         a->data = data = newdata;
     }
     else if (has_gap) {
         size_t nb1 = idx * elsz;
+        if (isbitsunion) {
+            memmove(data + (n + inc) * elsz + idx + inc, data + n * elsz + idx, n - idx);
+            memmove(data + (n + inc) * elsz, data + n * elsz, idx);
+            memset(data +  (n + inc) * elsz + idx, 0, inc);
+        }
         memmove(data + nb1 + inc * elsz, data + nb1, n * elsz - nb1);
+    }
+    else {
+        if (isbitsunion) {
+            // need to move isbits union selector bytes back & zero out new bytes
+            memmove(data + (n + inc) * elsz, data + n * elsz, oldmaxsize);
+            memset(data + (n + inc) * elsz + idx, 0, inc);
+        }
     }
     size_t newnrows = n + inc;
 #ifdef STORE_ARRAY_LEN
@@ -840,6 +917,7 @@ STATIC_INLINE void jl_array_del_at_beg(jl_array_t *a, size_t idx, size_t dec,
     // assume inbounds, assume unshared
     size_t elsz = a->elsize;
     size_t offset = a->offset;
+    int isbitsunion = !a->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(a)));
     offset += dec;
 #ifdef STORE_ARRAY_LEN
     a->length = n - dec;
@@ -854,15 +932,28 @@ STATIC_INLINE void jl_array_del_at_beg(jl_array_t *a, size_t idx, size_t dec,
         size_t nb1 = idx * elsz; // size in bytes of the first block
         size_t nbtotal = a->nrows * elsz; // size in bytes of the new array
         // Implicit '\0' for byte arrays
-        if (elsz == 1)
+        if (elsz == 1 && !isbitsunion)
             nbtotal++;
-        if (idx > 0)
+        if (idx > 0) {
             memmove(newdata, olddata, nb1);
+            if (isbitsunion) {
+                memmove(newdata + nbtotal, olddata + n * elsz, idx);
+                memset(newdata + nbtotal + idx, 0, dec);
+            }
+        }
         memmove(newdata + nb1, olddata + nb1 + nbdec, nbtotal - nb1);
+        if (isbitsunion) {
+            memmove(newdata + nbtotal + idx, olddata + n * elsz + idx + dec, n - idx);
+        }
         a->data = newdata;
     }
     else {
-        a->data = (char*)a->data + nbdec;
+        char *data = (char*)a->data;
+        a->data = data + nbdec;
+        if (isbitsunion) {
+            // move isbits union selector bytes forward, overwriting the deleted bytes
+            memmove(data + elsz * n, data + elsz * n + dec, n - dec);
+        }
     }
     a->offset = newoffs;
 }
@@ -874,16 +965,25 @@ STATIC_INLINE void jl_array_del_at_end(jl_array_t *a, size_t idx, size_t dec,
     // assume inbounds, assume unshared
     char *data = (char*)a->data;
     size_t elsz = a->elsize;
+    int isbitsunion = !a->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(a)));
     size_t last = idx + dec;
-    if (n > last)
+    if (n > last) {
         memmove(data + idx * elsz, data + last * elsz, (n - last) * elsz);
+        if (isbitsunion) {
+            memmove(data + n * elsz + idx, data + n * elsz + last, n - last);
+        }
+    }
     n -= dec;
-    if (elsz == 1)
+    if (elsz == 1 && !isbitsunion)
         data[n] = 0;
     a->nrows = n;
 #ifdef STORE_ARRAY_LEN
     a->length = n;
 #endif
+    if (isbitsunion) {
+        // move last isbits union selector bytes forward to close the gap of deleted elements
+        memmove(data + n * elsz, data + (n + dec) * elsz, n);
+    }
 }
 
 JL_DLLEXPORT void jl_array_del_at(jl_array_t *a, ssize_t idx, size_t dec)
@@ -941,9 +1041,15 @@ JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
 JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary)
 {
     size_t elsz = ary->elsize;
+    size_t len = jl_array_len(ary);
     jl_array_t *new_ary = _new_array_(jl_typeof(ary), jl_array_ndims(ary),
                                       &ary->nrows, !ary->flags.ptrarray, elsz);
-    memcpy(new_ary->data, ary->data, jl_array_len(ary) * elsz);
+    memcpy(new_ary->data, ary->data, len * elsz);
+    // ensure isbits union arrays copy their selector bytes correctly
+    if (!ary->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(ary)))) {
+        memcpy((char*)new_ary->data + len * elsz,
+               (char*)ary->data + len * elsz, len);
+    }
     return new_ary;
 }
 
@@ -985,6 +1091,14 @@ static NOINLINE ssize_t jl_array_ptr_copy_backward(jl_value_t *owner,
 JL_DLLEXPORT void jl_array_ptr_copy(jl_array_t *dest, void **dest_p,
                                     jl_array_t *src, void **src_p, ssize_t n)
 {
+    // need to intercept union isbits arrays here since they're unboxed
+    if (!src->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(src))) &&
+        !dest->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(dest)))) {
+        memcpy(dest_p, src_p, n * src->elsize);
+        memcpy((char*)dest->data + jl_array_len(dest) * dest->elsize,
+               (char*)src->data + jl_array_len(src) * src->elsize, n);
+        return;
+    }
     assert(dest->flags.ptrarray && src->flags.ptrarray);
     jl_value_t *owner = jl_array_owner(dest);
     // Destination is old and doesn't refer to any young object

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1139,35 +1139,6 @@ static Value *emit_bounds_check(jl_codectx_t &ctx, const jl_cgval_t &ainfo, jl_v
     return im1;
 }
 
-// --- loading and storing ---
-
-static Value *compute_box_tindex(Value *datatype, jl_value_t *supertype, jl_value_t *ut, jl_codectx_t *ctx)
-{
-    Value *tindex = ConstantInt::get(T_int8, 0);
-    unsigned counter = 0;
-    for_each_uniontype_small(
-            [&](unsigned idx, jl_datatype_t *jt) {
-                if (jl_subtype((jl_value_t*)jt, supertype)) {
-                    Value *cmp = builder.CreateICmpEQ(literal_pointer_val((jl_value_t*)jt), datatype);
-                    tindex = builder.CreateSelect(cmp, ConstantInt::get(T_int8, idx), tindex);
-                }
-            },
-            ut,
-            counter);
-    return tindex;
-}
-
-// get the runtime tindex value
-static Value *compute_tindex_unboxed(const jl_cgval_t &val, jl_value_t *typ, jl_codectx_t *ctx)
-{
-    if (val.constant)
-        return ConstantInt::get(T_int8, get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
-    if (val.isboxed)
-        return compute_box_tindex(emit_typeof_boxed(val, ctx), val.typ, typ, ctx);
-    assert(val.TIndex);
-    return builder.CreateAnd(val.TIndex, ConstantInt::get(T_int8, 0x7f));
-}
-
 // If given alignment is 0 and LLVM's assumed alignment for a load/store via ptr
 // might be stricter than the Julia alignment for jltype, return the alignment of jltype.
 // Otherwise return the given alignment.
@@ -1925,7 +1896,32 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
     return box;
 }
 
+static Value *compute_box_tindex(jl_codectx_t &ctx, Value *datatype, jl_value_t *supertype, jl_value_t *ut)
+{
+    Value *tindex = ConstantInt::get(T_int8, 0);
+    unsigned counter = 0;
+    for_each_uniontype_small(
+            [&](unsigned idx, jl_datatype_t *jt) {
+                if (jl_subtype((jl_value_t*)jt, supertype)) {
+                    Value *cmp = ctx.builder.CreateICmpEQ(maybe_decay_untracked(literal_pointer_val(ctx, (jl_value_t*)jt)), datatype);
+                    tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, idx), tindex);
+                }
+            },
+            ut,
+            counter);
+    return tindex;
+}
 
+// get the runtime tindex value
+static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, jl_value_t *typ)
+{
+    if (val.constant)
+        return ConstantInt::get(T_int8, get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
+    if (val.isboxed)
+        return compute_box_tindex(ctx, emit_typeof_boxed(ctx, val), val.typ, typ);
+    assert(val.TIndex);
+    return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(T_int8, 0x7f));
+}
 
 static Value *box_union(jl_codectx_t &ctx, const jl_cgval_t &vinfo, const SmallBitVector &skip)
 {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -236,6 +236,7 @@ static MDNode *tbaa_arraysize;      // A size in a jl_array_t
 static MDNode *tbaa_arraylen;       // The len in a jl_array_t
 static MDNode *tbaa_arrayflags;     // The flags in a jl_array_t
 static MDNode *tbaa_const;      // Memory that is immutable by the time LLVM can see it
+static MDNode *tbaa_arrayselbyte;   // a selector byte in a isbits Union jl_array_t
 
 // Basic DITypes
 static DICompositeType *jl_value_dillvmt;
@@ -2400,18 +2401,35 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             jl_value_t *ndp = jl_tparam1(aty_dt);
             if (!jl_has_free_typevars(ety) && (jl_is_long(ndp) || nargs == 2)) {
                 jl_value_t *ary_ex = jl_exprarg(ex, 1);
-                if (!jl_array_store_unboxed(ety))
+                size_t elsz = 0, al = 0;
+                bool isboxed = !jl_islayout_inline(ety, &elsz, &al);
+                if (isboxed)
                     ety = (jl_value_t*)jl_any_type;
                 ssize_t nd = jl_is_long(ndp) ? jl_unbox_long(ndp) : -1;
                 Value *idx = emit_array_nd_index(ctx, ary, ary_ex, nd, &argv[2], nargs - 1);
-                if (jl_array_store_unboxed(ety) && jl_datatype_size(ety) == 0) {
-                    assert(jl_is_datatype(ety));
+                if (!isboxed && jl_is_datatype(ety) && jl_datatype_size(ety) == 0) {
                     assert(((jl_datatype_t*)ety)->instance != NULL);
                     *ret = ghostValue(ety);
                 }
+                else if (!isboxed && jl_is_uniontype(ety)) {
+                    Value *nbytes = ConstantInt::get(T_size, elsz);
+                    Value *data = emit_bitcast(ctx, emit_arrayptr(ctx, ary, ary_ex), T_pint8);
+                    // isbits union selector bytes are stored directly after the last array element
+                    Value *selidx = ctx.builder.CreateMul(emit_arraylen_prim(ctx, ary), nbytes);
+                    selidx = ctx.builder.CreateAdd(selidx, idx);
+                    Value *ptindex = ctx.builder.CreateGEP(T_int8, data, selidx);
+                    Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(T_int8, 1), tbaa_decorate(tbaa_arrayselbyte, ctx.builder.CreateLoad(T_int8, ptindex)));
+                    Type *AT = ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al), (elsz + al - 1) / al);
+                    AllocaInst *lv = emit_static_alloca(ctx, AT);
+                    if (al > 1)
+                        lv->setAlignment(al);
+                    Value *elidx = ctx.builder.CreateMul(idx, nbytes);
+                    ctx.builder.CreateMemCpy(lv, ctx.builder.CreateGEP(T_int8, data, elidx), nbytes, al);
+                    *ret = mark_julia_slot(lv, ety, tindex, tbaa_stack);
+                }
                 else {
                     *ret = typed_load(ctx, emit_arrayptr(ctx, ary, ary_ex), idx, ety,
-                        jl_array_store_unboxed(ety) ? tbaa_arraybuf : tbaa_ptrarraybuf);
+                        !isboxed ? tbaa_arraybuf : tbaa_ptrarraybuf);
                 }
                 return true;
             }
@@ -2434,14 +2452,15 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             jl_value_t *ndp = jl_tparam1(aty_dt);
             if (!jl_has_free_typevars(ety) && (jl_is_long(ndp) || nargs == 3)) {
                 if (jl_subtype(val.typ, ety)) { // TODO: probably should just convert this to a type-assert
-                    bool isboxed = !jl_array_store_unboxed(ety);
+                    size_t elsz = 0, al = 0;
+                    bool isboxed = !jl_islayout_inline(ety, &elsz, &al);
                     if (isboxed)
                         ety = (jl_value_t*)jl_any_type;
                     jl_value_t *ary_ex = jl_exprarg(ex, 1);
                     ssize_t nd = jl_is_long(ndp) ? jl_unbox_long(ndp) : -1;
                     Value *idx = emit_array_nd_index(ctx, ary, ary_ex, nd, &argv[3], nargs - 2);
-                    if (!isboxed && jl_datatype_size(ety) == 0) {
-                        assert(jl_is_datatype(ety));
+                    if (!isboxed && jl_is_datatype(ety) && jl_datatype_size(ety) == 0) {
+                        // no-op
                     }
                     else {
                         PHINode *data_owner = NULL; // owner object against which the write barrier must check
@@ -2478,15 +2497,40 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                             data_owner->addIncoming(aryv, curBB);
                             data_owner->addIncoming(own_ptr, ownedBB);
                         }
-                        typed_store(ctx,
-                                    emit_arrayptr(ctx, ary, ary_ex, isboxed),
-                                    idx, val, ety,
-                                    !isboxed ? tbaa_arraybuf : tbaa_ptrarraybuf,
-                                    data_owner, 0,
-                                    false); // don't need to root the box if we had to make one since it's being stored in the array immediatly
+                        if (jl_is_uniontype(ety)) {
+                            Value *nbytes = ConstantInt::get(T_size, elsz);
+                            Value *data = emit_bitcast(ctx, emit_arrayptr(ctx, ary, ary_ex), T_pint8);
+                            if (!(val.typ == jl_bottom_type)) {
+                                // compute tindex from val
+                                jl_cgval_t rhs_union = convert_julia_type(ctx, val, ety);
+                                Value *tindex = compute_tindex_unboxed(ctx, rhs_union, ety);
+                                tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(T_int8, 1));
+                                Value *selidx = ctx.builder.CreateMul(emit_arraylen_prim(ctx, ary), nbytes);
+                                selidx = ctx.builder.CreateAdd(selidx, idx);
+                                Value *ptindex = ctx.builder.CreateGEP(T_int8, data, selidx);
+                                ctx.builder.CreateStore(tindex, ptindex);
+                                if (jl_is_datatype(val.typ) && jl_datatype_size(val.typ) == 0) {
+                                    // no-op
+                                }
+                                else {
+                                    // copy data
+                                    Value *elidx = ctx.builder.CreateMul(idx, nbytes);
+                                    Value *addr = ctx.builder.CreateGEP(T_int8, data, elidx);
+                                    emit_unionmove(ctx, addr, val, NULL, false, NULL);
+                                }
+                            }
+                        }
+                        else {
+                            typed_store(ctx,
+                                        emit_arrayptr(ctx, ary, ary_ex, isboxed),
+                                        idx, val, ety,
+                                        !isboxed ? tbaa_arraybuf : tbaa_ptrarraybuf,
+                                        data_owner, 0,
+                                        false); // don't need to root the box if we had to make one since it's being stored in the array immediatly
+                        }
+                        *ret = ary;
+                        return true;
                     }
-                    *ret = ary;
-                    return true;
                 }
             }
         }
@@ -5881,6 +5925,7 @@ static void init_julia_llvm_meta(void)
     tbaa_arraylen = tbaa_make_child("jtbaa_arraylen", tbaa_array_scalar).first;
     tbaa_arrayflags = tbaa_make_child("jtbaa_arrayflags", tbaa_array_scalar).first;
     tbaa_const = tbaa_make_child("jtbaa_const", nullptr, true).first;
+    tbaa_arrayselbyte = tbaa_make_child("jtbaa_arrayselbyte", tbaa_array_scalar).first;
 }
 
 static void init_julia_llvm_env(Module *m)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -738,7 +738,7 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
     return jl_cgval_t(v, typ, NULL);
 }
 
-static jl_cgval_t convert_julia_type(const jl_cgval_t &v, jl_value_t *typ, jl_codectx_t *ctx, bool needsroot = true);
+static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ, bool needsroot = true);
 
 // --- allocating local variables ---
 
@@ -5998,7 +5998,7 @@ static void init_julia_llvm_env(Module *m)
         StructType::create(jl_LLVMContext,
                            ArrayRef<Type*>(vaelts,sizeof(vaelts)/sizeof(vaelts[0])),
                            "jl_array_t");
-    jl_parray_llvmt = PointerType::get(jl_array_llvmt,0);
+    jl_parray_llvmt = PointerType::get(jl_array_llvmt, 0);
 
     global_to_llvm("__stack_chk_guard", (void*)&__stack_chk_guard, m);
     Function *jl__stack_chk_fail =

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -738,6 +738,8 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
     return jl_cgval_t(v, typ, NULL);
 }
 
+static jl_cgval_t convert_julia_type(const jl_cgval_t &v, jl_value_t *typ, jl_codectx_t *ctx, bool needsroot = true);
+
 // --- allocating local variables ---
 
 static jl_sym_t *slot_symbol(jl_codectx_t &ctx, int s)
@@ -818,7 +820,7 @@ static void jl_rethrow_with_add(const char *fmt, ...)
 }
 
 // given a value marked with type `v.typ`, compute the mapping and/or boxing to return a value of type `typ`
-static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ, bool needsroot = true)
+static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ, bool needsroot)
 {
     if (typ == (jl_value_t*)jl_typeofbottom_type)
         return ghostValue(typ); // normalize TypeofBottom to Type{Union{}}
@@ -3307,33 +3309,6 @@ static Value *try_emit_union_alloca(jl_codectx_t &ctx, jl_uniontype_t *ut, bool 
         return lv;
     }
     return NULL;
-}
-
-static Value *compute_box_tindex(jl_codectx_t &ctx, Value *datatype, jl_value_t *supertype, jl_value_t *ut)
-{
-    Value *tindex = ConstantInt::get(T_int8, 0);
-    unsigned counter = 0;
-    for_each_uniontype_small(
-            [&](unsigned idx, jl_datatype_t *jt) {
-                if (jl_subtype((jl_value_t*)jt, supertype)) {
-                    Value *cmp = ctx.builder.CreateICmpEQ(maybe_decay_untracked(literal_pointer_val(ctx, (jl_value_t*)jt)), datatype);
-                    tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, idx), tindex);
-                }
-            },
-            ut,
-            counter);
-    return tindex;
-}
-
-// get the runtime tindex value
-static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, jl_value_t *typ)
-{
-    if (val.constant)
-        return ConstantInt::get(T_int8, get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
-    if (val.isboxed)
-        return compute_box_tindex(ctx, emit_typeof_boxed(ctx, val), val.typ, typ);
-    assert(val.TIndex);
-    return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(T_int8, 0x7f));
 }
 
 static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -820,7 +820,7 @@ JL_DLLEXPORT void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
             if (!jl_find_union_component(ty, jl_typeof(rhs), &nth))
                 assert(0 && "invalid field assignment to isbits union");
             *psel = nth;
-            if (jl_is_datatype_singleton((jl_datatype_t*)ty))
+            if (jl_is_datatype_singleton((jl_datatype_t*)jl_typeof(rhs)))
                 return;
         }
         jl_assign_bits((char*)v + offs, rhs);

--- a/src/dump.c
+++ b/src/dump.c
@@ -570,7 +570,8 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
             jl_serialize_value(s, jl_box_long(jl_array_dim(ar,i)));
         jl_serialize_value(s, jl_typeof(ar));
         if (!ar->flags.ptrarray) {
-            size_t tot = jl_array_len(ar) * ar->elsize;
+            size_t extra = jl_is_uniontype(jl_tparam0(jl_typeof(ar))) ? jl_array_len(ar) : 0;
+            size_t tot = jl_array_len(ar) * ar->elsize + extra;
             ios_write(s->s, (char*)jl_array_data(ar), tot);
         }
         else {
@@ -1346,7 +1347,8 @@ static jl_value_t *jl_deserialize_value_array(jl_serializer_state *s, jl_value_t
     jl_value_t *aty = jl_deserialize_value(s, &jl_astaggedvalue(a)->type);
     jl_set_typeof(a, aty);
     if (!a->flags.ptrarray) {
-        size_t tot = jl_array_len(a) * a->elsize;
+        size_t extra = jl_is_uniontype(jl_tparam0(aty)) ? jl_array_len(a) : 0;
+        size_t tot = jl_array_len(a) * a->elsize + extra;
         ios_read(s->s, (char*)jl_array_data(a), tot);
     }
     else {

--- a/src/gc.c
+++ b/src/gc.c
@@ -857,6 +857,9 @@ static size_t array_nbytes(jl_array_t *a)
         sz = a->elsize * a->maxsize + (a->elsize == 1 ? 1 : 0);
     else
         sz = a->elsize * jl_array_len(a);
+    if (!a->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(a))))
+        // account for isbits Union array selector bytes
+        sz += jl_array_len(a);
     return sz;
 }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -302,6 +302,9 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
         }
         if (!dest)
             return unboxed;
+        Type *dest_ty = unboxed->getType()->getPointerTo();
+        if (dest->getType() != dest_ty)
+            dest = emit_bitcast(dest, dest_ty);
         ctx.builder.CreateStore(unboxed, dest, volatile_store);
         return NULL;
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -304,7 +304,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
             return unboxed;
         Type *dest_ty = unboxed->getType()->getPointerTo();
         if (dest->getType() != dest_ty)
-            dest = emit_bitcast(dest, dest_ty);
+            dest = emit_bitcast(ctx, dest, dest_ty);
         ctx.builder.CreateStore(unboxed, dest, volatile_store);
         return NULL;
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -368,6 +368,22 @@ jl_value_t *jl_nth_union_component(jl_value_t *v, int i)
     return nth_union_component(v, &i);
 }
 
+// inverse of jl_nth_union_component
+int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth)
+{
+    if (jl_is_uniontype(haystack)) {
+        if (jl_find_union_component(((jl_uniontype_t*)haystack)->a, needle, nth))
+            return 1;
+        if (jl_find_union_component(((jl_uniontype_t*)haystack)->b, needle, nth))
+            return 1;
+        return 0;
+    }
+    if (needle == haystack)
+        return 1;
+    (*nth)++;
+    return 0;
+}
+
 static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, size_t *idx)
 {
     size_t i;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1180,6 +1180,7 @@ JL_DLLEXPORT void        jl_set_nth_field(jl_value_t *v, size_t i,
 JL_DLLEXPORT int         jl_field_isdefined(jl_value_t *v, size_t i);
 JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld);
 JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a);
+JL_DLLEXPORT int jl_islayout_inline(jl_value_t *eltype, size_t *fsz, size_t *al);
 
 // arrays
 JL_DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -475,6 +475,7 @@ jl_value_t *jl_substitute_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val);
 jl_svec_t *jl_outer_unionall_vars(jl_value_t *u);
 int jl_count_union_components(jl_value_t *v);
 jl_value_t *jl_nth_union_component(jl_value_t *v, int i);
+int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth);
 jl_datatype_t *jl_new_uninitialized_datatype(void);
 void jl_precompute_memoized_dt(jl_datatype_t *dt);
 jl_datatype_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -589,7 +589,8 @@ static void jl_write_values(jl_serializer_state *s)
             // make some header modifications in-place
             jl_array_t *newa = (jl_array_t*)&s->s->buf[reloc_offset];
             size_t alen = jl_array_len(ar);
-            size_t tot = alen * ar->elsize;
+            size_t extra = (!ar->flags.ptrarray && jl_is_uniontype(jl_tparam0(jl_typeof(ar)))) ? alen : 0;
+            size_t tot = alen * ar->elsize + extra;
             if (newa->flags.ndims == 1)
                 newa->maxsize = alen;
             newa->offset = 0;

--- a/test/core.jl
+++ b/test/core.jl
@@ -5181,3 +5181,234 @@ let idx = (7,5,9)
     (v,) = (idx...,)
     @test v == 7
 end
+
+module UnionOptimizations
+
+using Base.Test
+
+const boxedunions = [Union{}, Union{String, Void}]
+const unboxedunions = [Union{Int8, Void}, Union{Int8, Float16, Void},
+                       Union{Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128},
+                       Union{Char, Date, Int}]
+
+@test !Base.isbitsunion(boxedunions[1])
+@test !Base.isbitsunion(boxedunions[2])
+@test Base.isbitsunion(unboxedunions[1])
+@test Base.isbitsunion(unboxedunions[2])
+@test Base.isbitsunion(unboxedunions[3])
+
+@test Base.bitsunionsize(unboxedunions[1]) == 1
+@test Base.bitsunionsize(unboxedunions[2]) == 2
+@test Base.bitsunionsize(unboxedunions[3]) == 16
+@test Base.bitsunionsize(unboxedunions[4]) == 8
+
+initvalue(::Type{Void}) = nothing
+initvalue(::Type{Char}) = '\0'
+initvalue(::Type{Date}) = Date(0, 12, 31)
+initvalue(::Type{T}) where {T <: Number} = T(0)
+
+initvalue2(::Type{Void}) = nothing
+initvalue2(::Type{Char}) = Char(0x01)
+initvalue2(::Type{Date}) = Date(1)
+initvalue2(::Type{T}) where {T <: Number} = T(1)
+
+U = unboxedunions[1]
+
+mutable struct UnionField
+    u::U
+end
+
+x = UnionField(initvalue(Base.uniontypes(U)[1]))
+@test x.u === initvalue(Base.uniontypes(U)[1])
+x.u = initvalue2(Base.uniontypes(U)[1])
+@test x.u === initvalue2(Base.uniontypes(U)[1])
+x.u = initvalue(Base.uniontypes(U)[2])
+@test x.u === initvalue(Base.uniontypes(U)[2])
+
+for U in boxedunions
+    for N in (1, 2, 3, 4)
+        A = Array{U}(ntuple(x->0, N)...)
+        @test isempty(A)
+        @test Core.sizeof(A) == 0
+
+        A = Array{U}(ntuple(x->10, N)...)
+        @test length(A) == 10^N
+        @test Core.sizeof(A) == sizeof(Int) * (10^N)
+        @test !isassigned(A, 1)
+    end
+end
+
+# unsafe_wrap
+A4 = [1, 2, 3]
+@test_throws ArgumentError unsafe_wrap(Array, convert(Ptr{Union{Int, Void}}, pointer(A4)), 3)
+A5 = [1 2 3; 4 5 6]
+@test_throws ArgumentError unsafe_wrap(Array, convert(Ptr{Union{Int, Void}}, pointer(A5)), 6)
+
+for U in unboxedunions
+    for N in (1, 2, 3, 4)
+        A = Array{U}(ntuple(x->0, N)...)
+        @test isempty(A)
+        @test Core.sizeof(A) == 0
+
+        len = ntuple(x->10, N)
+        mxsz = maximum(sizeof, Base.uniontypes(U))
+        A = Array{U}(len)
+        @test length(A) == prod(len)
+        @test Core.sizeof(A) == prod(len) * mxsz
+        @test isassigned(A, 1)
+        @test isassigned(A, length(A))
+
+        # arrayref / arrayset
+        F = Base.uniontypes(U)[1]
+        @test A[1] === initvalue(F)
+        A[1] = initvalue2(F)
+        @test A[1] === initvalue2(F)
+
+        F2 = Base.uniontypes(U)[2]
+        A[2] = initvalue(F2)
+        @test A[2] === initvalue(F2)
+
+        for (i, U2) in enumerate(Base.uniontypes(U))
+            A[i] = initvalue2(U2)
+            @test A[i] === initvalue2(U2)
+        end
+
+        # serialize / deserialize
+        io = IOBuffer()
+        serialize(io, A)
+        seekstart(io)
+        A2 = deserialize(io)
+        @test A == A2
+
+        # reshape
+        A3 = reshape(A, (div(prod(len), 2), 2))
+        @test Core.sizeof(A) == prod(len) * mxsz
+        @test isassigned(A, 1)
+        @test A[1] === initvalue2(F)
+
+        # copy
+        A4 = copy(A)
+        @test A == A4
+
+        if N == 1
+            ## Dequeue functions
+            # pop!
+            F2 = Base.uniontypes(U)[2]
+            len = len[1]
+            A = U[initvalue2(F2) for i = 1:len]
+            for i = 1:len
+                @test A[end] === initvalue2(F2)
+                v = pop!(A)
+                @test v === initvalue2(F2)
+            end
+            @test isempty(A)
+
+            # shift!
+            A = U[initvalue2(F2) for i = 1:len]
+            for i = 1:len
+                @test A[1] === initvalue2(F2)
+                shift!(A)
+            end
+            @test isempty(A)
+
+            # empty!
+            A = U[initvalue2(F2) for i = 1:len]
+            empty!(A)
+            @test isempty(A)
+
+            # resize!
+            A = U[initvalue2(F2) for i = 1:len]
+            resize!(A, 1)
+            @test length(A) === 1
+            @test A[1] === initvalue2(F2)
+            resize!(A, len)
+            @test length(A) === len
+            @test A[1] === initvalue2(F2)
+            @test typeof(A[end]) === F
+
+            # deleteat!
+            F = Base.uniontypes(U)[2]
+            A = U[rand(F(1):F(len)) for i = 1:len]
+            deleteat!(A, map(Int, sort!(unique(A[1:4]))))
+            A = U[initvalue2(F2) for i = 1:len]
+            deleteat!(A, 1:2)
+            @test length(A) == len - 2
+            @test all(A .== initvalue2(F2))
+            deleteat!(A, 1:2)
+            @test length(A) == len - 4
+            @test all(A .== initvalue2(F2))
+            A = U[initvalue2(F2) for i = 1:len]
+            deleteat!(A, length(A)-1:length(A))
+            @test length(A) == len - 2
+            @test all(A .== initvalue2(F2))
+            deleteat!(A, length(A)-1:length(A))
+            @test length(A) == len - 4
+            @test all(A .== initvalue2(F2))
+            A = U[initvalue2(F2) for i = 1:len]
+            deleteat!(A, 2:3)
+            @test length(A) == len - 2
+            @test all(A .== initvalue2(F2))
+            A = U[initvalue2(F2) for i = 1:len]
+            deleteat!(A, length(A)-2:length(A)-1)
+            @test length(A) == len - 2
+            @test all(A .== initvalue2(F2))
+
+            # unshift!
+            A = U[initvalue2(F2) for i = 1:len]
+            for i = 1:5
+                unshift!(A, initvalue2(F))
+                unshift!(A, initvalue(F2))
+                @test A[1] === initvalue(F2)
+                @test A[2] === initvalue2(F)
+            end
+
+            # push! / append! / prepend!
+            A = U[initvalue2(F2) for i = 1:len]
+            push!(A, initvalue2(F))
+            @test A[end] === initvalue2(F)
+            push!(A, initvalue2(F2))
+            @test A[end] === initvalue2(F2)
+            append!(A, [initvalue(F), initvalue2(F)])
+            @test A[end] === initvalue2(F)
+            @test A[end-1] === initvalue(F)
+            prepend!(A, [initvalue(F), initvalue2(F)])
+            @test A[2] === initvalue2(F)
+            @test A[1] === initvalue(F)
+
+            # insert!
+            A = U[initvalue2(F2) for i = 1:len]
+            insert!(A, 2, initvalue2(F))
+            @test A[2] === initvalue2(F)
+            @test A[1] === initvalue2(F2)
+            @test A[3] === initvalue2(F2)
+            @test A[end] === initvalue2(F2)
+            A = U[initvalue2(F2) for i = 1:len]
+            insert!(A, 8, initvalue2(F))
+            @test A[8] === initvalue2(F)
+            @test A[7] === initvalue2(F2)
+            @test A[9] === initvalue2(F2)
+            @test A[end] === initvalue2(F2)
+
+            # splice!
+            A = U[initvalue2(F2) for i = 1:len]
+            V = splice!(A, 1:2)
+            @test length(A) == len - 2
+            @test length(V) == 2
+            @test V[1] == initvalue2(F2)
+            @test V[2] == initvalue2(F2)
+            @test A[1] == initvalue2(F2)
+            @test A[end] == initvalue2(F2)
+
+            A = U[initvalue2(F2) for i = 1:len]
+            V = splice!(A, 4:5)
+            @test length(A) == len - 2
+            @test length(V) == 2
+            @test V[1] == initvalue2(F2)
+            @test V[2] == initvalue2(F2)
+            @test A[1] == initvalue2(F2)
+            @test A[end] == initvalue2(F2)
+        end
+    end
+end
+
+end # module UnionOptimizations


### PR DESCRIPTION
Note this is based on the `jn/union-bits-layout` branch.

This is an initial attempt to fix some of the issues reported [here](https://github.com/JuliaLang/julia/issues/22097).

This successfully compiles, but I'm still feeling my way around `/src` code and figuring out if my code paths are even getting hit. The idea here is that when we allocate a `Union{T, S}` array where `T` and `S` are both isbits, we compute the "element size" for the array using `jl_union_isbits`, allocate the buffer for that, then add on an extra "selector" byte for each element after the data buffer. The "selector" bytes indicate which Union element is actually stored in a data buffer element.

If anyone can provide more pointers to what else needs to be updated, or simple ways to ensure I'm actually hitting codepaths, I'd appreciate it. I feel like a bit of a bull in a china shop here 😄 .

Closes https://github.com/JuliaLang/julia/issues/17073