### PR TITLE
Issue #20062: make Random.reserve type-stable

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -124,10 +124,10 @@ function gen_rand(r::MersenneTwister)
     mt_setfull!(r)
 end
 
-@inline reserve_1(r::MersenneTwister) = mt_empty(r) && gen_rand(r)
+@inline reserve_1(r::MersenneTwister) = (mt_empty(r) && gen_rand(r); nothing)
 # `reserve` allows one to call `rand_inbounds` n times
 # precondition: n <= MTCacheLength
-@inline reserve(r::MersenneTwister, n::Int) = mt_avail(r) < n && gen_rand(r)
+@inline reserve(r::MersenneTwister, n::Int) = (mt_avail(r) < n && gen_rand(r); nothing)
 
 # precondition: !mt_empty(r)
 @inline rand_inbounds(r::MersenneTwister, ::Type{Close1Open2}) = mt_pop!(r)

--- a/test/random.jl
+++ b/test/random.jl
@@ -540,10 +540,6 @@ end
 
 # Issue 20062 - ensure internal functions reserve_1, reserve are type-stable
 let r = MersenneTwister(0)
-    @test  Base.Random.mt_empty(r); @inferred Base.Random.reserve_1(r)
-    @test !Base.Random.mt_empty(r); @inferred Base.Random.reserve_1(r)
-
-    rand(r)
-    @test 0 < Base.Random.mt_avail(r) < Base.Random.MTCacheLength; @inferred Base.Random.reserve(r, Base.Random.mt_avail(r))
-    @test 0 < Base.Random.mt_avail(r) < Base.Random.MTCacheLength; @inferred Base.Random.reserve(r, Base.Random.mt_avail(r)+1)
+    @inferred Base.Random.reserve_1(r)
+    @inferred Base.Random.reserve(r, 1)
 end

--- a/test/random.jl
+++ b/test/random.jl
@@ -537,3 +537,13 @@ let g = Base.Random.GLOBAL_RNG,
     @test srand(m, rand(UInt32, rand(1:10))) === m
     @test srand(m, rand(1:10)) === m
 end
+
+# Issue 20062 - ensure internal functions reserve_1, reserve are type-stable
+let r = MersenneTwister(0)
+    @test  Base.Random.mt_empty(r); @inferred Base.Random.reserve_1(r)
+    @test !Base.Random.mt_empty(r); @inferred Base.Random.reserve_1(r)
+
+    rand(r)
+    @test 0 < Base.Random.mt_avail(r) < Base.Random.MTCacheLength; @inferred Base.Random.reserve(r, Base.Random.mt_avail(r))
+    @test 0 < Base.Random.mt_avail(r) < Base.Random.MTCacheLength; @inferred Base.Random.reserve(r, Base.Random.mt_avail(r)+1)
+end


### PR DESCRIPTION
Issue #20062

Not a performance issue, but does pollute `@code_warntype` for functions that include `rand()`.

Also thought that returning `nothing` better documents that return value is not used.
 