### PR TITLE
Turn off PIC for the JIT

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6997,9 +6997,8 @@ extern "C" void *jl_init_llvm(void)
     eb  .setEngineKind(EngineKind::JIT)
         .setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager>{createRTDyldMemoryManager()})
         .setTargetOptions(options)
-#if (defined(_OS_LINUX_) && defined(_CPU_X86_64_))
-        .setRelocationModel(Reloc::PIC_)
-#endif
+        // Generate simpler code for JIT
+        .setRelocationModel(Reloc::Static)
 #ifdef _P64
         .setCodeModel(CodeModel::Large)
 #else


### PR DESCRIPTION
It was added in 7723bd20b599af78ac975dbc7173f2e5effd0af9 to make TLS access work.
We have since changed how we do that and shouldn't need anything special from LLVM anymore.

This was useful to expose (and be affected by) LLVM bugs though
(i.e. https://reviews.llvm.org/D34409)

Running tests locally (well, actually remotely) to see if this exposes new llvm bugs.

Ideally we should backport either this or https://reviews.llvm.org/D34409 to 0.6 but seems that people don't really run julia in an environment that allocate data and code section far away so maybe we can wait until someone report an issue....
