### PR TITLE
Update libgit2 makefile to not fail on stale file

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -105,7 +105,7 @@ $(LIBGIT2_SRC_PATH)/libgit2-remote-push-NULL.patch-applied: $(LIBGIT2_SRC_PATH)/
 
 $(build_datarootdir)/julia/cert.pem: $(CERTFILE)
 	mkdir -p $(build_datarootdir)/julia
-	-cp $(CERTFILE) $@
+	cp -f $(CERTFILE) $@
 
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: \
 	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls.patch-applied \


### PR DESCRIPTION
When the timestamp of the original file changes compiliation will fail
on some systems due to permissions. Observed on Arch Linux.

Co-authored-by: Tim Besard <tim.besard@gmail.com>
Co-authored-by: Simon Byrne <simonbyrne@gmail.com>