### PR TITLE
Add a dead code elimination pass before lowering ptls

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -148,6 +148,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level)
 #if JL_LLVM_VERSION < 50000
     PM->add(createLowerExcHandlersPass());
     PM->add(createLateLowerGCFramePass());
+    PM->add(createDeadCodeEliminationPass());
     PM->add(createLowerPTLSPass(imaging_mode));
 #endif
 
@@ -240,6 +241,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level)
     PM->add(createLowerExcHandlersPass());
     PM->add(createGCInvariantVerifierPass(false));
     PM->add(createLateLowerGCFramePass());
+    PM->add(createDeadCodeEliminationPass());
     PM->add(createLowerPTLSPass(imaging_mode));
 #endif
 }

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,7 +35,7 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "distributed", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
-        "channels", "iostream", "specificity"
+        "channels", "iostream", "specificity", "codegen"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -1,0 +1,14 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# tests for codegen and optimizations
+
+const opt_level = Base.JLOptions().opt_level
+
+# `_dump_function` might be more efficient but it doesn't really matter here...
+get_llvm(f::ANY, t::ANY, strip_ir_metadata=true, dump_module=false) =
+    sprint(code_llvm, f, t, strip_ir_metadata, dump_module)
+
+if opt_level > 0
+    # Make sure getptls call is removed at IR level with optimization on
+    @test !contains(get_llvm(identity, Tuple{String}), " call ")
+end


### PR DESCRIPTION
Make sure dead ptls references are removed at LLVM IR level and add test for it.
This is mostly for test purpose. LLVM is usually smart enough to remove it later but
it's much harder to test and the present of a dead call in the IR makes many other tests harder.

And thanks to @Keno for showing me the difference between the three passes (`die`, `dce`, `adce`) that does similar stuff.
