### PR TITLE
allow default arguments at any place in a function

### DIFF
--- a/base/defaults.jl
+++ b/base/defaults.jl
@@ -1,0 +1,116 @@
+module Defaults
+
+function findtypevars(e::Expr, vars, found = falses(length(vars)))
+    for a in e.args
+        all(found) && break # handles empty case
+        findtypevars(a, vars, found)
+    end
+    found
+end
+
+function findtypevars(e, vars, found)
+    i = findfirst(vars, e)
+    i > 0 && (found[i] = true)
+    found
+end
+
+function getargname(arg::Expr)
+    if arg.head == :(::)
+        if length(arg.args) == 2
+            arg.args[1]
+        else # length == 1
+            arg1 = arg.args[1]
+            arg1 isa Expr && arg1.head == :curly && arg1.args[1] == :Type ||
+                throw(ArgumentError("unsupported argument"))
+            arg1.args[2]
+        end
+    elseif arg.head == :kw
+        getargname(arg.args[1])
+    elseif arg.head == :...
+        Expr(:..., getargname(arg.args[1]))
+    else
+        throw(ArgumentError("malformed definition"))
+    end
+end
+
+getargname(arg::Symbol) = arg
+getargname(arg) = throw(ArgumentError("malformed definition"))
+
+function replacedefault!(args, sym, defval)
+    for i in eachindex(args)
+        if args[i] isa Expr
+            replacedefault!(args[i].args, sym, defval)
+        elseif args[i] === sym
+            args[i] = defval
+        end
+    end
+end
+
+function gendefinitions(master, defaults, fname, argnames, linefile, wherevars)
+    definitions = []
+    for n = 1:(2^length(defaults)-1)
+        sgn = copy(master)
+        an = similar(argnames, Any) # Any to handle x...
+        copy!(an, argnames)
+        for b = 31:-1:1
+            if n & (1<<(b-1)) != 0
+                idx, defval = defaults[b]
+                deleteat!(sgn, idx)
+                # handle cases with references to previous args,
+                # like f([x=1], y=typeof(x))
+                replacedefault!(view(sgn, idx:length(sgn)), # not idx+1, as idx was just deleted
+                                an[idx], defval)
+                an[idx] = defval
+            end
+        end
+        newdef = :($fname($(sgn...)) = $fname($(an...)))
+        newvars = wherevars[findtypevars(newdef, wherevars)]
+        # @assert newdef.args[2].args[1] isa LineNumberNode
+        newdef.args[2].args[1] = linefile
+        push!(definitions, newdef=>newvars)
+    end
+    definitions
+end
+
+
+macro defaults(e)
+    e.head in [:(=), :function] ||
+        throw(ArgumentError("expected function definition"))
+    if e.args[1].head == :where
+        wherevars = e.args[1].args[2:end]
+        e.args[1] = e.args[1].args[1] # delete where
+    else
+        wherevars = []
+    end
+    e.args[1].head == :call ||
+        throw(ArgumentError("expected function definition 2"))
+    args = e.args[1].args
+    defs = []
+    fname = args[1]
+    argnames = []
+    for i = 2:length(args) # omit function name
+        if args[i] isa Expr && args[i].head == :vect
+            length(args[i].args) == 1 && args[i].args[1].head == :(=) ||
+                throw(ArgumentError("malformed default expression"))
+            push!(defs, i-1 => args[i].args[1].args[2])
+            args[i] = args[i].args[1].args[1]
+        end
+        push!(argnames, getargname(args[i]))
+    end
+    length(defs) > 31 &&
+        throw(ArgumentError(
+            "number of defaults ($(length(defs))) exceeded maximum (31)"))
+    linefile = e.args[2].args[1]
+    # @assert linefile isa LineNumberNode # not within macro
+    definitions = (e => wherevars, gendefinitions(args[2:end], defs, fname, argnames, linefile, wherevars)...)
+    for (d, w) in definitions
+        if !isempty(w)
+            d.args[1] = Expr(:where, d.args[1], w...)
+        end
+    end
+    esc(Expr(:block, [d.first for d in definitions]...))
+end
+
+export @defaults
+
+end # module

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1218,7 +1218,8 @@ function findnz(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
 end
 
 
-import Base.Random.GLOBAL_RNG
+using Base.Random: @defaultRNG
+
 function sprand_IJ(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat)
     ((m < 0) || (n < 0)) && throw(ArgumentError("invalid Array dimensions"))
     0 <= density <= 1 || throw(ArgumentError("$density not in [0,1]"))
@@ -1279,7 +1280,9 @@ julia> sprand(rng, Float64, 3, 0.75)
   [3]  =  0.298614
 ```
 """
-function sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat,
+:sprand
+
+@defaultRNG function sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat,
                 rfn::Function, ::Type{T}=eltype(rfn(r,1))) where T
     N = m*n
     N == 0 && return spzeros(T,m,n)
@@ -1289,24 +1292,12 @@ function sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat,
     sparse_IJ_sorted!(I, J, rfn(r,length(I)), m, n, +)  # it will never need to combine
 end
 
-function sprand(m::Integer, n::Integer, density::AbstractFloat,
-                rfn::Function, ::Type{T}=eltype(rfn(1))) where T
-    N = m*n
-    N == 0 && return spzeros(T,m,n)
-    N == 1 && return rand() <= density ? sparse([1], [1], rfn(1)) : spzeros(T,1,1)
-
-    I,J = sprand_IJ(GLOBAL_RNG, m, n, density)
-    sparse_IJ_sorted!(I, J, rfn(length(I)), m, n, +)  # it will never need to combine
-end
-
 truebools(r::AbstractRNG, n::Integer) = ones(Bool, n)
 
-sprand(m::Integer, n::Integer, density::AbstractFloat) = sprand(GLOBAL_RNG,m,n,density)
-
-sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,rand,Float64)
-sprand(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(r,m,n,density,(r, i) -> rand(r, T, i), T)
+@defaultRNG sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,rand,Float64)
+@defaultRNG sprand(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} =
+    sprand(r,m,n,density,(r, i) -> rand(r, T, i), T)
 sprand(r::AbstractRNG, ::Type{Bool}, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density, truebools, Bool)
-sprand(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(GLOBAL_RNG, T, m, n, density)
 
 
 """
@@ -1327,8 +1318,9 @@ julia> sprandn(rng, 2, 2, 0.75)
   [2, 2]  =  0.502334
 ```
 """
-sprandn(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,randn,Float64)
-sprandn(m::Integer, n::Integer, density::AbstractFloat) = sprandn(GLOBAL_RNG,m,n,density)
+:sprandn
+
+@defaultRNG sprandn(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,randn,Float64)
 
 
 """

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -421,29 +421,22 @@ copy!(A::SparseMatrixCSC, B::SparseVector{TvB,TiB}) where {TvB,TiB} =
 
 
 ### Rand Construction
-sprand(n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where {T} = sprand(GLOBAL_RNG, n, p, rfn, T)
-function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where T
+@defaultRNG function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where T
     I = randsubseq(r, 1:convert(Int, n), p)
     V = rfn(r, T, length(I))
     SparseVector(n, I, V)
 end
 
-sprand(n::Integer, p::AbstractFloat, rfn::Function) = sprand(GLOBAL_RNG, n, p, rfn)
-function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function)
+@defaultRNG function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function=rand)
     I = randsubseq(r, 1:convert(Int, n), p)
     V = rfn(r, length(I))
     SparseVector(n, I, V)
 end
 
-sprand(n::Integer, p::AbstractFloat) = sprand(GLOBAL_RNG, n, p, rand)
-
-sprand(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, rand)
-sprand(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(r, n, p, (r, i) -> rand(r, T, i))
+@defaultRNG sprand(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(r, n, p, (r, i) -> rand(r, T, i))
 sprand(r::AbstractRNG, ::Type{Bool}, n::Integer, p::AbstractFloat) = sprand(r, n, p, truebools)
-sprand(::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(GLOBAL_RNG, T, n, p)
 
-sprandn(n::Integer, p::AbstractFloat) = sprand(GLOBAL_RNG, n, p, randn)
-sprandn(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, randn)
+@defaultRNG sprandn(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, randn)
 
 ## Indexing into Matrices can return SparseVectors
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -322,6 +322,11 @@ include("hashing2.jl")
 # irrational mathematical constants
 include("irrationals.jl")
 
+
+# @defaults macro
+include("defaults.jl")
+using .Defaults: @defaults
+
 # random number generation
 include("dSFMT.jl")
 include("random.jl")

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -814,7 +814,7 @@ end
     @test countnz(A) == 11
     @test A[I] == A[X] == c
 
-    S = sprand(50, 30, 0.5, x -> round.(Int, rand(x) * 100))
+    S = sprand(50, 30, 0.5, (r, x) -> round.(Int, rand(x) * 100))
     I = sprand(Bool, 50, 30, 0.2)
     FS = Array(S)
     FI = Array(I)
@@ -843,7 +843,7 @@ end
     S[FI] = [1:sum(FI);]
     @test sum(S) == sumS2 + sum(1:sum(FI))
 
-    S = sprand(50, 30, 0.5, x -> round.(Int, rand(x) * 100))
+    S = sprand(50, 30, 0.5, (r, x) -> round.(Int, rand(x) * 100))
     N = length(S) >> 2
     I = randperm(N) .* 4
     J = randperm(N)
@@ -933,7 +933,7 @@ end
 end
 
 @testset "issue #7677" begin
-    A = sprand(5,5,0.5,(n)->rand(Float64,n))
+    A = sprand(5,5,0.5,(r, n)->rand(Float64,n))
     ACPY = copy(A)
     B = reshape(A,25,1)
     @test A == ACPY
@@ -1620,7 +1620,7 @@ end
 @testset "issue #16073" begin
     @inferred sprand(1, 1, 1.0)
     @inferred sprand(1, 1, 1.0, rand, Float64)
-    @inferred sprand(1, 1, 1.0, x -> round.(Int, rand(x) * 100))
+    @inferred sprand(1, 1, 1.0, (r, x) -> round.(Int, rand(x) * 100))
 end
 
 # Test that concatenations of combinations of sparse matrices with sparse matrices or dense


### PR DESCRIPTION
This is more a feature idea, with a proof of concept via a macro `@defaults`, rather than a PR.  

In Julia, it's not possible to get a default argument before a non-default, so to simulate that functionality, one usually has duplicate the methods signatures by hand. But in the docstrings, we specify a default arg at any position with the use of brackets, e.g.: 
```
rand([rng::AbstractRNG=GLOBAL_RNG], T::Type) = ...
```
I propose to allow that syntax in real code: Julia will automatically duplicate the signature (and forward the default argument when it's not supplied, similarly to what happens with regular default args) for each argument with a bracket (this means `2^n` methods if `n` args have a bracket). It's up to the user to handle ambiguities (e.g. with `f([a=0], [b=0])=...`, the call `f(0)` is ambiguous). 

This would not cover all our docstring uses (where sometimes the default is not shown), but could be a good step forward.

For the cons, I see that 1) it makes the language a bit more complicated (but anyway the user has to face this syntax in docstrings), and 2) it prevents using this syntax in the future for destructuring arguments (a la Haskell, e.g. defining `f([a, b], c=>d) = a+c` and being  able to call `f([1, 2], 3=>4)`, where `a` will take value `1`, etc.), but I didn't notice such a proposition yet.

This PR shows how the `rand` methods could be updated with this syntax: basically the number of methods is halved (or even decreased from 8 to 2 for `randn/randexp`). 

If in base, I believe it would be nicer without a macro, but a package with this macro is likely to be sufficient (the impact on Base itself doesn't seem so big).

(For reference, this [issue](https://github.com/JuliaLang/julia/issues/1817) has some related comments).