### PR TITLE
optimize repeat(string, n) for repeating single ASCII chars

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -427,8 +427,12 @@ function repeat(s::String, r::Integer)
     r < 0 && throw(ArgumentError("can't repeat a string $r times"))
     n = s.len
     out = _string_n(n*r)
-    for i=1:r
-        unsafe_copy!(pointer(out, 1+(i-1)*n), pointer(s), n)
+    if n == 1 # common case: repeating a single ASCII char
+        ccall(:memset, Ptr{Void}, (Ptr{UInt8}, Cint, Csize_t), out, unsafe_load(pointer(s)), r)
+    else
+        for i=1:r
+            unsafe_copy!(pointer(out, 1+(i-1)*n), pointer(s), n)
+        end
     end
     return out
 end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -462,6 +462,10 @@ Base.endof(x::CharStr) = endof(x.chars)
 @test cmp("\U1f596\U1f596", CharStr("\U1f596")) == 1   # Gives BoundsError with bug
 @test cmp(CharStr("\U1f596"), "\U1f596\U1f596") == -1
 
+# repeat function
+@test repeat("xx",3) == repeat("x",6) == "xxxxxx"
+@test repeat("αα",3) == repeat("α",6) == "αααααα"
+
 # issue #12495: check that logical indexing attempt raises ArgumentError
 @test_throws ArgumentError "abc"[[true, false, true]]
 @test_throws ArgumentError "abc"[BitArray([true, false, true])]


### PR DESCRIPTION
While working on #22461, I noticed that nearly all uses of `repeat(string,n)` or `string^n` were for repeating strings consisting of a single ASCII character, most commonly `" "`.  This PR speeds up that case by calling `memset`.

The speedups vary with length `n`.  For `n=5` I get a 50% speedup, for `n=20` a 3.5x speedup, and for `n=1000` I get a 41x speedup.