### PR TITLE
More clean up for dropping LLVM 3.9.0 support

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -899,12 +899,8 @@ public:
                     Function *oldF = destModule->getFunction(F->getName());
                     if (oldF)
                         return oldF;
-
-#ifdef USE_ORCJIT
                     if (jl_ExecutionEngine->findSymbol(F->getName(), false))
                         return InjectFunctionProto(F);
-#endif
-
                     return CloneFunctionProto(shadow);
                 }
                 else if (!F->isDeclaration()) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1305,10 +1305,8 @@ extern "C" JL_DLLEXPORT
 uint64_t jl_get_llvm_fptr(llvm::Function *llvmf)
 {
     uint64_t addr = getAddressForFunction(llvmf);
-#ifdef USE_ORCJIT
     if (!addr)
         addr = jl_ExecutionEngine->findUnmangledSymbol(llvmf->getName()).getAddress();
-#endif
     return addr;
 }
 
@@ -7010,9 +7008,6 @@ extern "C" void *jl_init_llvm(void)
 #else
         .setOptLevel(jl_options.opt_level == 0 ? CodeGenOpt::None : CodeGenOpt::Aggressive)
 #endif
-#ifdef USE_ORCMCJIT
-        .setUseOrcMCJITReplacement(true)
-#endif
     ;
     Triple TheTriple(sys::getProcessTriple());
 #if defined(FORCE_ELF)
@@ -7034,21 +7029,7 @@ extern "C" void *jl_init_llvm(void)
     #endif
 
     init_julia_llvm_meta();
-#ifdef USE_ORCJIT
     jl_ExecutionEngine = new JuliaOJIT(*jl_TargetMachine);
-#else
-    jl_ExecutionEngine = eb.create(jl_TargetMachine);
-    //jl_printf(JL_STDERR,"%s\n",jl_ExecutionEngine->getDataLayout()->getStringRepresentation().c_str());
-    if (!jl_ExecutionEngine) {
-        jl_printf(JL_STDERR, "Critical error initializing llvm: %s\n",
-                  ErrorStr.c_str());
-        exit(1);
-    }
-#if !defined(USE_ORCMCJIT)
-    jl_ExecutionEngine->setProcessAllSections(true);
-#endif
-    jl_ExecutionEngine->DisableLazyCompilation();
-#endif
 
 // Mark our address spaces as non-integral
 #if JL_LLVM_VERSION >= 40000
@@ -7067,21 +7048,6 @@ extern "C" void jl_init_codegen(void)
 {
     Module *m = (Module *)jl_init_llvm();
     init_julia_llvm_env(m);
-
-#ifndef USE_ORCJIT
-    jl_ExecutionEngine->RegisterJITEventListener(CreateJuliaJITEventListener());
-#ifdef JL_USE_INTEL_JITEVENTS
-    if (jl_using_intel_jitevents)
-        jl_ExecutionEngine->RegisterJITEventListener(
-            JITEventListener::createIntelJITEventListener());
-#endif // JL_USE_INTEL_JITEVENTS
-
-#ifdef JL_USE_OPROFILE_JITEVENTS
-    if (jl_using_oprofile_jitevents)
-        jl_ExecutionEngine->RegisterJITEventListener(
-            JITEventListener::createOProfileJITEventListener());
-#endif // JL_USE_OPROFILE_JITEVENTS
-#endif
 
     BOX_F(int8,int8);  UBOX_F(uint8,uint8);
     BOX_F(int16,int16); UBOX_F(uint16,uint16);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -20,10 +20,8 @@ extern int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide, int6
 extern bool jl_dylib_DI_for_fptr(size_t pointer, const object::ObjectFile **object, llvm::DIContext **context, int64_t *slide, int64_t *section_slide,
         bool onlySysImg, bool *isSysImg, void **saddr, char **name, char **filename);
 
-#ifdef USE_ORCJIT
 #ifdef _OS_WINDOWS_
 void *lookupWriteAddressFor(RTDyldMemoryManager *memmgr, void *rt_addr);
-#endif
 #endif
 
 RTDyldMemoryManager* createRTDyldMemoryManager(void);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -413,7 +413,6 @@ public:
     }
 };
 
-#ifdef USE_ORCJIT
 JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
                                          const object::ObjectFile &obj,
                                          const object::ObjectFile &debugObj,
@@ -422,7 +421,6 @@ JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
 {
     ((JuliaJITEventListener*)Listener)->_NotifyObjectEmitted(obj,debugObj,L,memmgr);
 }
-#endif
 
 static std::pair<char *, bool> jl_demangle(const char *name)
 {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -911,10 +911,7 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t narg
     case srem_int: return builder.CreateSRem(x, y);
     case urem_int: return builder.CreateURem(x, y);
 
-// Implements IEEE negate. Unfortunately there is no compliant way
-// to implement this in LLVM 3.4, though there are two different idioms
-// that do the correct thing on LLVM <= 3.3 and >= 3.5 respectively.
-// See issue #7868
+// Implements IEEE negate. See issue #7868
     case neg_float: return math_builder(ctx)().CreateFSub(ConstantFP::get(t, -0.0), x);
     case neg_float_fast: return math_builder(ctx, true)().CreateFNeg(x);
     case add_float: return math_builder(ctx)().CreateFAdd(x, y);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -6,7 +6,6 @@
 #include <llvm/IR/Value.h>
 
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
-#if defined(USE_ORCJIT)
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/LambdaResolver.h"
@@ -17,11 +16,6 @@
 #  include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #endif
 #include "llvm/ExecutionEngine/ObjectMemoryBuffer.h"
-#else
-#include <llvm/ExecutionEngine/MCJIT.h>
-#include <llvm/ADT/DenseMapInfo.h>
-#include <llvm/Object/ObjectFile.h>
-#endif
 
 #include "llvm/IR/LegacyPassManager.h"
 extern legacy::PassManager *jl_globalPM;
@@ -128,7 +122,6 @@ static inline void add_named_global(GlobalObject *gv, T *addr, bool dllimport = 
 }
 
 void jl_init_jit(Type *T_pjlvalue_);
-#ifdef USE_ORCJIT
 #if JL_LLVM_VERSION >= 40000
 typedef JITSymbol JL_JITSymbol;
 // The type that is similar to SymbolInfo on LLVM 4.0 is actually
@@ -206,9 +199,6 @@ private:
     SymbolTableT LocalSymbolTable;
 };
 extern JuliaOJIT *jl_ExecutionEngine;
-#else
-extern ExecutionEngine *jl_ExecutionEngine;
-#endif
 JL_DLLEXPORT extern LLVMContext jl_LLVMContext;
 
 Pass *createLowerPTLSPass(bool imaging_mode);

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -12,5 +12,3 @@
 #if JL_LLVM_VERSION < 30901
     #error Only LLVM versions >= 3.9.1 are supported by Julia
 #endif
-
-#define USE_ORCJIT

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -182,12 +182,6 @@ jl_value_t *jl_get_cpu_name(void)
 extern "C" JL_DLLEXPORT
 jl_value_t *jl_get_JIT(void)
 {
-#if defined(USE_ORCJIT)
     const std::string& HostJITName = "ORCJIT";
-#elif defined(USE_MCJIT)
-    const std::string& HostJITName = "MCJIT";
-#else
-    const std::string& HostJITName = "Unknown";
-#endif
     return jl_pchar_to_string(HostJITName.data(), HostJITName.size());
 }


### PR DESCRIPTION
* Remove USE_ORCJIT
* Update out-of-date comments of lower-ptls