### PR TITLE
Store global variables and function addresses as 32bit offsets

### DIFF
--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -36,9 +36,10 @@ int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int no
     return 0;
 }
 
-void jl_register_fptrs(uint64_t sysimage_base, void **fptrs, jl_method_instance_t **linfos, size_t n)
+void jl_register_fptrs(uint64_t sysimage_base, const char *base, const int32_t *offsets,
+                       jl_method_instance_t **linfos, size_t n)
 {
-    (void)sysimage_base; (void)fptrs; (void)linfos; (void)n;
+    (void)sysimage_base; (void)base; (void)offsets; (void)linfos; (void)n;
 }
 
 void jl_compile_linfo(jl_method_instance_t *li) { }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1000,6 +1000,9 @@ extern jl_sym_t *polly_sym; extern jl_sym_t *inline_sym;
 extern jl_sym_t *propagate_inbounds_sym;
 extern jl_sym_t *isdefined_sym;
 
+void jl_register_fptrs(uint64_t sysimage_base, const char *base, const int32_t *offsets,
+                       jl_method_instance_t **linfos, size_t n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -423,13 +423,7 @@ end
 for precomp in ("yes", "no")
     bt = readstring(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --precompiled=$precomp
         -E 'include("____nonexistent_file")'`), stderr=catcmd))
-    @test contains(bt, "include_from_node1")
-    if ((is_windows() && Sys.WORD_SIZE == 32) || (is_bsd() && !is_apple())) && precomp == "yes"
-        # FIXME: Issue #17251 (Windows), #20798 (FreeBSD)
-        @test_broken contains(bt, "include_from_node1(::Module, ::String) at $(joinpath(".", "loading.jl"))")
-    else
-        @test contains(bt, "include_from_node1(::Module, ::String) at $(joinpath(".", "loading.jl"))")
-    end
+    @test contains(bt, "include_from_node1(::Module, ::String) at $(joinpath(".", "loading.jl"))")
     lno = match(r"at \.[\/\\]loading\.jl:(\d+)", bt)
     @test length(lno.captures) == 1
     @test parse(Int, lno.captures[1]) > 0


### PR DESCRIPTION
Yet another PR split out of https://github.com/JuliaLang/julia/pull/21849 ....

This makes the two tables static data and reduces the number of dynamic relocations by ~100x
(~40k to ~400). Before @JeffBezanson asks, this reduces the size of the `.rela.dyn` section from `1144776` to `9432` while other sections remains roughly the same. Total size reduction is ~1.25MB. Apparently each pointer takes ~32bytes.
