### PR TITLE
implement lufact(A::HermOrSym)

### DIFF
--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -19,6 +19,10 @@ function lufact!(A::StridedMatrix{T}, pivot::Union{Type{Val{false}}, Type{Val{tr
     lpt = LAPACK.getrf!(A)
     return LU{T,typeof(A)}(lpt[1], lpt[2], lpt[3])
 end
+function lufact!(A::HermOrSym, pivot::Union{Type{Val{false}}, Type{Val{true}}} = Val{true})
+    copytri!(A.data, A.uplo, isa(A, Hermitian))
+    lufact!(A.data, pivot)
+end
 
 """
     lufact!(A, pivot=Val{true}) -> LU

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -150,6 +150,12 @@ debug && println("Fat LU")
         lua   = lufact(a[1:n1,:])
         @test lua[:L]*lua[:U] ≈ lua[:P]*a[1:n1,:]
     end
+
+debug && println("LU of Symmetric/Hermitian")
+    for HS in (Hermitian(a'a), Symmetric(a'a))
+        luhs = lufact(HS)
+        @test luhs[:L]*luhs[:U] ≈ luhs[:P]*Matrix(HS)
+    end
 end
 
 # test conversion routine


### PR DESCRIPTION
This also fixed the following:

```julia
julia> A = rand(3, 3); S = Symmetric(A'A); D = Diagonal(rand(3));

julia> S\D
3×3 Array{Float64,2}:
  4.47548    0.58589  -2.70101
  0.799888   2.49059  -1.74015
 -4.00037   -1.88777   3.61472

julia> S\S
3×3 Array{Float64,2}:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0
```

but I am not sure this is the correct fix for that so I have not yet included tests for that. The other fix would be to relax the method definition [here](https://github.com/JuliaLang/julia/blob/8915d9b3384d5ffbafeb83974c267d983f4cb07d/base/linalg/symmetric.jl#L318). Regardless, I think it could be useful to have `lufact` work for `Symmetric`/`Hermitian`. Thoughts?