### PR TITLE
Remove atomic stuff we don't need

### DIFF
--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -332,90 +332,40 @@ for typ in atomictypes
     ilt = llvmtypes[inttype(typ)]
     rt = Base.libllvm_version >= v"3.6" ? "$lt, $lt*" : "$lt*"
     irt = Base.libllvm_version >= v"3.6" ? "$ilt, $ilt*" : "$ilt*"
-    if VersionNumber(Base.libllvm_version) >= v"3.8"
-        @eval getindex(x::Atomic{$typ}) =
-            llvmcall($"""
-                     %rv = load atomic $rt %0 acquire, align $(alignment(typ))
-                     ret $lt %rv
-                     """, $typ, Tuple{Ptr{$typ}}, unsafe_convert(Ptr{$typ}, x))
-        @eval setindex!(x::Atomic{$typ}, v::$typ) =
-            llvmcall($"""
-                     store atomic $lt %1, $lt* %0 release, align $(alignment(typ))
-                     ret void
-                     """, Void, Tuple{Ptr{$typ},$typ}, unsafe_convert(Ptr{$typ}, x), v)
-    else
-        if typ <: Integer
-            @eval getindex(x::Atomic{$typ}) =
-                llvmcall($"""
-                         %rv = load atomic $rt %0 acquire, align $(alignment(typ))
-                         ret $lt %rv
-                         """, $typ, Tuple{Ptr{$typ}}, unsafe_convert(Ptr{$typ}, x))
-            @eval setindex!(x::Atomic{$typ}, v::$typ) =
-                llvmcall($"""
-                         store atomic $lt %1, $lt* %0 release, align $(alignment(typ))
-                         ret void
-                         """, Void, Tuple{Ptr{$typ},$typ}, unsafe_convert(Ptr{$typ}, x), v)
-        else
-            @eval getindex(x::Atomic{$typ}) =
-                llvmcall($"""
-                         %iptr = bitcast $lt* %0 to $ilt*
-                         %irv = load atomic $irt %iptr acquire, align $(alignment(typ))
-                         %rv = bitcast $ilt %irv to $lt
-                         ret $lt %rv
-                         """, $typ, Tuple{Ptr{$typ}}, unsafe_convert(Ptr{$typ}, x))
-            @eval setindex!(x::Atomic{$typ}, v::$typ) =
-                llvmcall($"""
-                         %iptr = bitcast $lt* %0 to $ilt*
-                         %ival = bitcast $lt %1 to $ilt
-                         store atomic $ilt %ival, $ilt* %iptr release, align $(alignment(typ))
-                         ret void
-                         """, Void, Tuple{Ptr{$typ},$typ}, unsafe_convert(Ptr{$typ}, x), v)
-        end
-    end
+    @eval getindex(x::Atomic{$typ}) =
+        llvmcall($"""
+                 %rv = load atomic $rt %0 acquire, align $(alignment(typ))
+                 ret $lt %rv
+                 """, $typ, Tuple{Ptr{$typ}}, unsafe_convert(Ptr{$typ}, x))
+    @eval setindex!(x::Atomic{$typ}, v::$typ) =
+        llvmcall($"""
+                 store atomic $lt %1, $lt* %0 release, align $(alignment(typ))
+                 ret void
+                 """, Void, Tuple{Ptr{$typ},$typ}, unsafe_convert(Ptr{$typ}, x), v)
+
     # Note: atomic_cas! succeeded (i.e. it stored "new") if and only if the result is "cmp"
-    if VersionNumber(Base.libllvm_version) >= v"3.5"
-        if typ <: Integer
-            @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
-                llvmcall($"""
-                         %rs = cmpxchg $lt* %0, $lt %1, $lt %2 acq_rel acquire
-                         %rv = extractvalue { $lt, i1 } %rs, 0
-                         ret $lt %rv
-                         """, $typ, Tuple{Ptr{$typ},$typ,$typ},
-                         unsafe_convert(Ptr{$typ}, x), cmp, new)
-        else
-            @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
-                llvmcall($"""
-                         %iptr = bitcast $lt* %0 to $ilt*
-                         %icmp = bitcast $lt %1 to $ilt
-                         %inew = bitcast $lt %2 to $ilt
-                         %irs = cmpxchg $ilt* %iptr, $ilt %icmp, $ilt %inew acq_rel acquire
-                         %irv = extractvalue { $ilt, i1 } %irs, 0
-                         %rv = bitcast $ilt %irv to $lt
-                         ret $lt %rv
-                         """, $typ, Tuple{Ptr{$typ},$typ,$typ},
-                         unsafe_convert(Ptr{$typ}, x), cmp, new)
-        end
+    if typ <: Integer
+        @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
+            llvmcall($"""
+                     %rs = cmpxchg $lt* %0, $lt %1, $lt %2 acq_rel acquire
+                     %rv = extractvalue { $lt, i1 } %rs, 0
+                     ret $lt %rv
+                     """, $typ, Tuple{Ptr{$typ},$typ,$typ},
+                     unsafe_convert(Ptr{$typ}, x), cmp, new)
     else
-        if typ <: Integer
-            @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
-                llvmcall($"""
-                         %rv = cmpxchg $lt* %0, $lt %1, $lt %2 acq_rel
-                         ret $lt %rv
-                         """, $typ, Tuple{Ptr{$typ},$typ,$typ},
-                         unsafe_convert(Ptr{$typ}, x), cmp, new)
-        else
-            @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
-                llvmcall($"""
-                         %iptr = bitcast $lt* %0 to $ilt*
-                         %icmp = bitcast $lt %1 to $ilt
-                         %inew = bitcast $lt %2 to $ilt
-                         %irv = cmpxchg $ilt* %iptr, $ilt %icmp, $ilt %inew acq_rel
-                         %rv = bitcast $ilt %irv to $lt
-                         ret $lt %rv
-                         """, $typ, Tuple{Ptr{$typ},$typ,$typ},
-                         unsafe_convert(Ptr{$typ}, x), cmp, new)
-        end
+        @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
+            llvmcall($"""
+                     %iptr = bitcast $lt* %0 to $ilt*
+                     %icmp = bitcast $lt %1 to $ilt
+                     %inew = bitcast $lt %2 to $ilt
+                     %irs = cmpxchg $ilt* %iptr, $ilt %icmp, $ilt %inew acq_rel acquire
+                     %irv = extractvalue { $ilt, i1 } %irs, 0
+                     %rv = bitcast $ilt %irv to $lt
+                     ret $lt %rv
+                     """, $typ, Tuple{Ptr{$typ},$typ,$typ},
+                     unsafe_convert(Ptr{$typ}, x), cmp, new)
     end
+
     for rmwop in [:xchg, :add, :sub, :and, :nand, :or, :xor, :max, :min]
         rmw = string(rmwop)
         fn = Symbol("atomic_", rmw, "!")


### PR DESCRIPTION
Now that we require LLVM >=3.9 a bunch of this code is extraneous.