### PR TITLE
Don't dump toplevel thunk if jl_dump_compiles is enabled.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1236,7 +1236,11 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
 
     JL_UNLOCK(&codegen_lock); // Might GC
 
-    if (dump_compiles_stream != NULL) {
+    // If logging of the compilation stream is enabled then dump the function to the stream
+    // ... unless li->def isn't defined here meaning the function is a toplevel thunk and
+    // would have its CodeInfo printed in the stream, which might contain double-quotes that
+    // would not be properly escaped given the double-quotes added to the stream below.
+    if (dump_compiles_stream != NULL && li->def) {
         uint64_t this_time = jl_hrtime();
         jl_printf(dump_compiles_stream, "%" PRIu64 "\t\"", this_time - last_time);
         jl_static_show(dump_compiles_stream, (jl_value_t*)li);


### PR DESCRIPTION
If jl_dump_compiles is enabled, it will print a double quote and then the result of jl_static_show.  If jl_static_show is called on a method instance whose def is NULL it prints "toplevel thunk -> CodeInfo(...)" and the CodeInfo can itself contain double quotes which then aren't properly escaped for the outer double-quotes added in jl_compile_linfo.  Maybe eventually more control would be nice here to say if thunks are really desired and if so to fix the double quote escaping issue but that seems more difficult given the streaming nature of jl_static_show.  So, for now, just disable the printing of info for thunks.