### PR TITLE
Improve implementation of rstrip and lstrip

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,7 +48,7 @@ Library improvements
 --------------------
 
   * The functions `strip`, `lstrip` and `rstrip` now return `SubString` ([#22496]).
-  
+
   * The functions `base` and `digits` digits now accept a negative
     base (like `ndigits` did) ([#21692]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,8 @@ This section lists changes that do not have deprecation warnings.
 Library improvements
 --------------------
 
+  * The functions `strip`, `lstrip` and `rstrip` now return `SubString` ([#22496]).
+  
   * The functions `base` and `digits` digits now accept a negative
     base (like `ndigits` did) ([#21692]).
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -487,9 +487,9 @@ end
     readchomp(x)
 
 Read the entirety of `x` as a string and remove a single trailing newline.
-Equivalent to `chomp!(readstring(x))`.
+Equivalent to `chomp(readstring(x))`.
 """
-readchomp(x) = chomp!(readstring(x))
+readchomp(x) = chomp(readstring(x))
 
 # read up to nb bytes into nb, returning # bytes read
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -487,9 +487,9 @@ end
     readchomp(x)
 
 Read the entirety of `x` as a string and remove a single trailing newline.
-Equivalent to `chomp(readstring(x))`.
+Equivalent to `chomp!(readstring(x))`.
 """
-readchomp(x) = chomp(readstring(x))
+readchomp(x) = chomp!(readstring(x))
 
 # read up to nb bytes into nb, returning # bytes read
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -115,7 +115,7 @@ end
 #    end
 #    return s
 #end
-#chomp!(s::AbstractString) = chomp(s) # copying fallback for other string types
+chomp!(s::AbstractString) = chomp(s) # copying fallback for other string types
 
 const _default_delims = [' ','\t','\n','\v','\f','\r']
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -137,15 +137,16 @@ julia> lstrip(a)
 ```
 """
 function lstrip(s::AbstractString, chars::Chars=_default_delims)
+    e = endof(s)
     i = start(s)
     while !done(s,i)
         c, j = next(s,i)
         if !(c in chars)
-            return s[i:end]
+            return SubString(s, i, e)
         end
         i = j
     end
-    s[end+1:end]
+    SubString(s, e+1, e)
 end
 
 """
@@ -171,11 +172,11 @@ function rstrip(s::AbstractString, chars::Chars=_default_delims)
     while !done(r,i)
         c, j = next(r,i)
         if !(c in chars)
-            return s[1:end-i+1]
+            return SubString(s, 1, endof(s)-i+1)
         end
         i = j
     end
-    s[1:0]
+    SubString(s, 1, 0)
 end
 
 """

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -115,7 +115,7 @@ end
 #    end
 #    return s
 #end
-chomp!(s::AbstractString) = chomp(s) # copying fallback for other string types
+#chomp!(s::AbstractString) = chomp(s) # copying fallback for other string types
 
 const _default_delims = [' ','\t','\n','\v','\f','\r']
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -26,7 +26,7 @@ for s in ("", " ", " abc", "abc ", "  abc  "), f in (lstrip, rstrip, strip)
         ft = f(t)
         @test s == t
         @test fs == ft
-        @test typeof(ft) == typeof(t[1:end])
+        @test typeof(ft) == SubString{T}
 
         b = convert(SubString{T}, t)
         fb = f(b)


### PR DESCRIPTION
I propose to consider the following:
- change `lstrip` and `rstrip` to use `SubString` instead of allocating a new string;
- removing `chomp!` without deprecation period; it is not exported and falls back to `chomp` anyway;
- change `readchomp` to use `chomp` instead of `chomp!`.