### PR TITLE
Add `get(string, index, default)`

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -39,6 +39,7 @@ getindex(s::AbstractString, v::AbstractVector{<:Integer}) =
 getindex(s::AbstractString, v::AbstractVector{Bool}) =
     throw(ArgumentError("logical indexing not supported for strings"))
 
+get(s::AbstractString, i::Integer, default) = isvalid(s,i) ? s[i] : default
 Symbol(s::AbstractString) = Symbol(String(s))
 
 """

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -107,6 +107,21 @@ end
 @test SubString("", 1, 6)[10:9] == ""
 @test SubString("", 1, 0)[10:9] == ""
 
+# issue #22500 (using `get()` to index strings with default returns)
+let
+    utf8_str = "我很喜欢Julia"
+
+    # Test that we can index in at valid locations
+    @test get(utf8_str, 1, 'X') == '我'
+    @test get(utf8_str, 13, 'X') == 'J'
+
+    # Test that obviously incorrect locations return the default
+    @test get(utf8_str, -1, 'X') == 'X'
+    @test get(utf8_str, 1000, 'X') == 'X'
+
+    # Test that indexing into the middle of a character returns the default
+    @test get(utf8_str, 2, 'X') == 'X'
+end
 
 #=
 # issue #7764


### PR DESCRIPTION
I think it would be nice to provide this functionality with a wider set of collections.  With this change we now get:

```julia
julia> get("Julia", 1, ' ')
'J': ASCII/Unicode U+004a (category Lu: Letter, uppercase)

julia> get("Julia", 20, ' ')
' ': ASCII/Unicode U+0020 (category Zs: Separator, space)

julia> get("Julia", -5, ' ')
' ': ASCII/Unicode U+0020 (category Zs: Separator, space)
```