### PR TITLE
clean up of merge! documentation

### DIFF
--- a/base/libgit2/merge.jl
+++ b/base/libgit2/merge.jl
@@ -45,7 +45,11 @@ function merge_analysis(repo::GitRepo, anns::Vector{GitAnnotated})
     return analysis[], preference[]
 end
 
-"""Fastforward merge changes into current head """
+"""
+    ffmerge!(repo::GitRepo, ann::GitAnnotated)
+
+Fastforward merge changes into current head
+"""
 function ffmerge!(repo::GitRepo, ann::GitAnnotated)
     cmt = GitCommit(repo, GitHash(ann))
 
@@ -63,7 +67,7 @@ function ffmerge!(repo::GitRepo, ann::GitAnnotated)
     return true
 end
 
-""" Merge changes into current head """
+# Merge changes into current head
 function merge!(repo::GitRepo, anns::Vector{GitAnnotated};
                 merge_opts::MergeOptions = MergeOptions(),
                 checkout_opts::CheckoutOptions = CheckoutOptions())
@@ -77,9 +81,8 @@ function merge!(repo::GitRepo, anns::Vector{GitAnnotated};
     return true
 end
 
-"""Internal implementation of merge.
-Returns `true` if merge was successful, otherwise `false`
-"""
+# Internal implementation of merge.
+# Returns `true` if merge was successful, otherwise `false`
 function merge!(repo::GitRepo, anns::Vector{GitAnnotated}, fastforward::Bool;
                 merge_opts::MergeOptions = MergeOptions(),
                 checkout_opts::CheckoutOptions = CheckoutOptions())

--- a/doc/src/devdocs/libgit2.md
+++ b/doc/src/devdocs/libgit2.md
@@ -69,6 +69,7 @@ Base.LibGit2.diff_files
 Base.LibGit2.fetch
 Base.LibGit2.fetch_refspecs
 Base.LibGit2.fetchhead_foreach_cb
+Base.LibGit2.merge!(::Base.LibGit2.GitRepo; ::Any...)
 Base.LibGit2.ffmerge!
 Base.LibGit2.fullname
 Base.LibGit2.get_creds!

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -197,7 +197,8 @@ Base.pop!(::Any, ::Any, ::Any)
 Base.keys
 Base.values
 Base.merge
-Base.merge!
+Base.merge!(::Associative, ::Associative...)
+Base.merge!(::Function, ::Associative, ::Associative...)
 Base.sizehint!
 Base.keytype
 Base.valtype


### PR DESCRIPTION
Fixes the following three problems:
- `LibGit2.merge!` documentation showed up in `stdlib/collections.md`
- random `LibGit2.merge!` docstrings showed up in `?merge!` in the REPL which looked like part of other docstrings since there was no function signature.
- `LibGit2.merge!` missing from `devdocs/libgit2.md`

Rendered documentation looks good locally.