### PR TITLE
DLLEXPORT the function to add all optimization passes.

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -244,6 +244,11 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level)
 #endif
 }
 
+extern "C" JL_DLLEXPORT
+void jl_add_optimization_passes(LLVMPassManagerRef PM, int opt_level) {
+    addOptimizationPasses(unwrap(PM), opt_level);
+}
+
 // ------------------------ TEMPORARILY COPIED FROM LLVM -----------------
 // This must be kept in sync with gdb/gdb/jit.h .
 extern "C" {

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -33,8 +33,6 @@
     julia_type_to_llvm;
     _IO_stdin_used;
     __ZN4llvm23createLowerSimdLoopPassEv;
-    LLVMAddLowerGCFramePass;
-    LLVMAddLowerPTLSPass;
 
     /* freebsd */
     environ;

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -15,7 +15,6 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/LLVMContext.h>
-#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/MDBuilder.h>
 
 #if defined(JULIA_ENABLE_THREADING)
@@ -264,9 +263,4 @@ static RegisterPass<LowerPTLS> X("LowerPTLS", "LowerPTLS Pass",
 Pass *createLowerPTLSPass(bool imaging_mode)
 {
     return new LowerPTLS(imaging_mode);
-}
-
-extern "C" JL_DLLEXPORT
-void LLVMAddLowerPTLSPass(LLVMPassManagerRef PM, int imaging_mode) {
-    unwrap(PM)->add(createLowerPTLSPass(imaging_mode != 0));
 }


### PR DESCRIPTION
... instead of exporting Julia-specific passes individually and requiring users (eg. CUDAnative.jl) to rebuild the pass chain by themselves.