### PR TITLE
Support for limited compile-time arithmetic on Val types

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -373,6 +373,9 @@ importall .StackTraces
 # misc useful functions & macros
 include("util.jl")
 
+# limited compile-time arithmetic on Val types
+include("valmath.jl")
+
 # dense linear algebra
 include("linalg/linalg.jl")
 importall .LinAlg

--- a/base/valmath.jl
+++ b/base/valmath.jl
@@ -1,0 +1,3 @@
+@generated (+)(::Type{Val{X}}, ::Type{Val{Y}}) where {X, Y} = :(Val{$(X + Y)})
+@generated (-)(::Type{Val{X}}, ::Type{Val{Y}}) where {X, Y} = :(Val{$(X - Y)})
+@generated (*)(::Type{Val{X}}, ::Type{Val{Y}}) where {X, Y} = :(Val{$(X * Y)})

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -35,7 +35,7 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
         "checked", "intset", "floatfuncs", "compile", "distributed", "inline",
         "boundscheck", "error", "ambiguous", "cartesian", "asmvariant", "osutils",
-        "channels", "iostream", "specificity", "codegen"
+        "channels", "iostream", "specificity", "codegen", "valmath"
     ]
     profile_skipped = false
     if startswith(string(Sys.ARCH), "arm")

--- a/test/valmath.jl
+++ b/test/valmath.jl
@@ -1,0 +1,19 @@
+@testset "Val math" begin
+    @testset "Val +" begin
+        @testset for x in -10:1:10, y in -10:1:10
+            @test Val{x} + Val{y} == Val{x + y}
+        end
+    end
+
+    @testset "Val -" begin
+        @testset for x in -10:1:10, y in -10:1:10
+            @test Val{x} - Val{y} == Val{x - y}
+        end
+    end
+
+    @testset "Val *" begin
+        @testset for x in -10:1:10, y in -10:1:10
+            @test Val{x} * Val{y} == Val{x * y}
+        end
+    end
+end


### PR DESCRIPTION
After this PR:

```julia
@inferred Val{2} + Val{1} == Val{3}
```

I was doing inlineable type-stable recursion in AxisArrays but wanted to be able to specify an early terminator. I started with just `decrement` but decided to do `+`, `-`, and `*` in case other use cases came up. 