### PR TITLE
use where syntax in deprecated.jl

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -216,7 +216,7 @@ macro dep_vectorize_1arg(S, f)
     T = esc(:T)
     x = esc(:x)
     AbsArr = esc(:AbstractArray)
-    :( @deprecate $f{$T<:$S}($x::$AbsArr{$T}) $f.($x) )
+    :( @deprecate $f($x::$AbsArr{$T}) where {$T<:$S} $f.($x) )
 end
 macro dep_vectorize_2arg(S, f)
     S = esc(S)
@@ -227,9 +227,9 @@ macro dep_vectorize_2arg(S, f)
     y = esc(:y)
     AbsArr = esc(:AbstractArray)
     quote
-        @deprecate $f{$T1<:$S}($x::$S, $y::$AbsArr{$T1}) $f.($x,$y)
-        @deprecate $f{$T1<:$S}($x::$AbsArr{$T1}, $y::$S) $f.($x,$y)
-        @deprecate $f{$T1<:$S,$T2<:$S}($x::$AbsArr{$T1}, $y::$AbsArr{$T2}) $f.($x,$y)
+        @deprecate $f($x::$S, $y::$AbsArr{$T1}) where {$T1<:$S} $f.($x,$y)
+        @deprecate $f($x::$AbsArr{$T1}, $y::$S) where {$T1<:$S} $f.($x,$y)
+        @deprecate $f($x::$AbsArr{$T1}, $y::$AbsArr{$T2}) where {$T1<:$S,$T2<:$S} $f.($x,$y)
     end
 end
 
@@ -480,7 +480,7 @@ Filesystem.stop_watching(stream::Filesystem._FDWatcher) = depwarn("stop_watching
             filter(fun, dr)
         end
      end
-     recur{T<:TimeType}(fun::Function, start::T, stop::T; step::Period=Day(1), negate::Bool=false, limit::Int=10000) = recur(fun, start:step:stop; negate=negate)
+     recur(fun::Function, start::T, stop::T; step::Period=Day(1), negate::Bool=false, limit::Int=10000) where {T<:TimeType} = recur(fun, start:step:stop; negate=negate)
 end
 
 # Index conversions revamp; #19730
@@ -707,19 +707,19 @@ export Collections
 @deprecate bitbroadcast broadcast
 
 # Deprecate two-argument map! (map!(f, A)) for a cycle in anticipation of semantic change
-@deprecate map!{F}(f::F, A::AbstractArray) map!(f, A, A)
+@deprecate map!(f::F, A::AbstractArray) where {F} map!(f, A, A)
 @deprecate asyncmap!(f, c; ntasks=0, batch_size=nothing) asyncmap!(f, c, c; ntasks=ntasks, batch_size=batch_size)
 
 # Not exported, but used outside Base
 _promote_array_type(F, ::Type, ::Type, T::Type) = T
-_promote_array_type{A<:AbstractFloat}(F, ::Type{<:Real}, ::Type{A}, ::Type) = A
-_promote_array_type{A<:Integer}(F, ::Type{<:Integer}, ::Type{A}, ::Type) = A
+_promote_array_type(F, ::Type{<:Real}, ::Type{A}, ::Type) where {A<:AbstractFloat} = A
+_promote_array_type(F, ::Type{<:Integer}, ::Type{A}, ::Type) where {A<:Integer} = A
 _promote_array_type(::typeof(/), ::Type{<:Integer}, ::Type{<:Integer}, T::Type) = T
 _promote_array_type(::typeof(\), ::Type{<:Integer}, ::Type{<:Integer}, T::Type) = T
 _promote_array_type(::typeof(/), ::Type{<:Integer}, ::Type{Bool}, T::Type) = T
 _promote_array_type(::typeof(\), ::Type{<:Integer}, ::Type{Bool}, T::Type) = T
 _promote_array_type(F, ::Type{<:Integer}, ::Type{Bool}, T::Type) = T
-_promote_array_type{T<:AbstractFloat}(F, ::Type{<:Union{Complex, Real}}, ::Type{Complex{T}}, ::Type) = Complex{T}
+_promote_array_type(F, ::Type{<:Union{Complex, Real}}, ::Type{Complex{T}}, ::Type) where {T<:AbstractFloat} = Complex{T}
 function promote_array_type(F, R, S, T)
     Base.depwarn("`promote_array_type` is deprecated as it is no longer needed " *
                  "in Base. See https://github.com/JuliaLang/julia/issues/19669 " *
@@ -752,8 +752,8 @@ end
 @deprecate round(M::Bidiagonal) round.(M)
 @deprecate round(M::Tridiagonal) round.(M)
 @deprecate round(M::SymTridiagonal) round.(M)
-@deprecate round{T}(::Type{T}, x::AbstractArray) round.(T, x)
-@deprecate round{T}(::Type{T}, x::AbstractArray, r::RoundingMode) round.(T, x, r)
+@deprecate round(::Type{T}, x::AbstractArray) where {T} round.(T, x)
+@deprecate round(::Type{T}, x::AbstractArray, r::RoundingMode) where {T} round.(T, x, r)
 @deprecate round(x::AbstractArray, r::RoundingMode) round.(x, r)
 @deprecate round(x::AbstractArray, digits::Integer, base::Integer = 10) round.(x, digits, base)
 
@@ -761,21 +761,21 @@ end
 @deprecate trunc(M::Bidiagonal) trunc.(M)
 @deprecate trunc(M::Tridiagonal) trunc.(M)
 @deprecate trunc(M::SymTridiagonal) trunc.(M)
-@deprecate trunc{T}(::Type{T}, x::AbstractArray) trunc.(T, x)
+@deprecate trunc(::Type{T}, x::AbstractArray) where {T} trunc.(T, x)
 @deprecate trunc(x::AbstractArray, digits::Integer, base::Integer = 10) trunc.(x, digits, base)
 
 # Deprecate manually vectorized floor methods in favor of compact broadcast syntax
 @deprecate floor(M::Bidiagonal) floor.(M)
 @deprecate floor(M::Tridiagonal) floor.(M)
 @deprecate floor(M::SymTridiagonal) floor.(M)
-@deprecate floor{T}(::Type{T}, A::AbstractArray) floor.(T, A)
+@deprecate floor(::Type{T}, A::AbstractArray) where {T} floor.(T, A)
 @deprecate floor(A::AbstractArray, digits::Integer, base::Integer = 10) floor.(A, digits, base)
 
 # Deprecate manually vectorized ceil methods in favor of compact broadcast syntax
 @deprecate ceil(M::Bidiagonal) ceil.(M)
 @deprecate ceil(M::Tridiagonal) ceil.(M)
 @deprecate ceil(M::SymTridiagonal) ceil.(M)
-@deprecate ceil{T}(::Type{T}, x::AbstractArray) ceil.(T, x)
+@deprecate ceil(::Type{T}, x::AbstractArray) where {T} ceil.(T, x)
 @deprecate ceil(x::AbstractArray, digits::Integer, base::Integer = 10) ceil.(x, digits, base)
 
 # Deprecate manually vectorized `big` methods in favor of compact broadcast syntax
@@ -804,10 +804,10 @@ end
 @deprecate rem(A::AbstractArray, B::Number) rem.(A, B)
 
 # Deprecate manually vectorized div, mod, and % methods for dates
-@deprecate div{P<:Dates.Period}(X::StridedArray{P}, y::P)         div.(X, y)
+@deprecate div(X::StridedArray{P}, y::P) where {P<:Dates.Period}  div.(X, y)
 @deprecate div(X::StridedArray{<:Dates.Period}, y::Integer)       div.(X, y)
-@deprecate (%){P<:Dates.Period}(X::StridedArray{P}, y::P)         X .% y
-@deprecate mod{P<:Dates.Period}(X::StridedArray{P}, y::P)         mod.(X, y)
+@deprecate (%)(X::StridedArray{P}, y::P) where {P<:Dates.Period}  X .% y
+@deprecate mod(X::StridedArray{P}, y::P) where {P<:Dates.Period}  mod.(X, y)
 
 # Deprecate manually vectorized mod methods in favor of compact broadcast syntax
 @deprecate mod(B::BitArray, x::Bool) mod.(B, x)
@@ -1022,7 +1022,7 @@ isempty(::Task) = error("isempty not defined for Tasks")
         end
     end
 
-    array_eps{T}(a::AbstractArray{Complex{T}}) = eps(float(maximum(x->(isfinite(x) ? abs(x) : T(NaN)), a)))
+    array_eps(a::AbstractArray{Complex{T}}) where {T} = eps(float(maximum(x->(isfinite(x) ? abs(x) : T(NaN)), a)))
     array_eps(a) = eps(float(maximum(x->(isfinite(x) ? abs(x) : oftype(x,NaN)), a)))
 
     test_approx_eq(va, vb, astr, bstr) =
@@ -1096,22 +1096,22 @@ function partial_linear_indexing_warning(n)
 end
 
 # Deprecate Array(T, dims...) in favor of proper type constructors
-@deprecate Array{T,N}(::Type{T}, d::NTuple{N,Int})               Array{T}(d)
-@deprecate Array{T}(::Type{T}, d::Int...)                        Array{T}(d...)
-@deprecate Array{T}(::Type{T}, m::Int)                           Array{T}(m)
-@deprecate Array{T}(::Type{T}, m::Int,n::Int)                    Array{T}(m,n)
-@deprecate Array{T}(::Type{T}, m::Int,n::Int,o::Int)             Array{T}(m,n,o)
-@deprecate Array{T}(::Type{T}, d::Integer...)                    Array{T}(convert(Tuple{Vararg{Int}}, d))
-@deprecate Array{T}(::Type{T}, m::Integer)                       Array{T}(Int(m))
-@deprecate Array{T}(::Type{T}, m::Integer,n::Integer)            Array{T}(Int(m),Int(n))
-@deprecate Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) Array{T}(Int(m),Int(n),Int(o))
+@deprecate Array(::Type{T}, d::NTuple{N,Int}) where {T,N}               Array{T}(d)
+@deprecate Array(::Type{T}, d::Int...) where {T}                        Array{T}(d...)
+@deprecate Array(::Type{T}, m::Int) where {T}                           Array{T}(m)
+@deprecate Array(::Type{T}, m::Int,n::Int) where {T}                    Array{T}(m,n)
+@deprecate Array(::Type{T}, m::Int,n::Int,o::Int) where {T}             Array{T}(m,n,o)
+@deprecate Array(::Type{T}, d::Integer...) where {T}                    Array{T}(convert(Tuple{Vararg{Int}}, d))
+@deprecate Array(::Type{T}, m::Integer) where {T}                       Array{T}(Int(m))
+@deprecate Array(::Type{T}, m::Integer,n::Integer) where {T}            Array{T}(Int(m),Int(n))
+@deprecate Array(::Type{T}, m::Integer,n::Integer,o::Integer) where {T} Array{T}(Int(m),Int(n),Int(o))
 
 # Likewise for SharedArrays
-@deprecate SharedArray{T,N}(::Type{T}, dims::Dims{N}; kwargs...) SharedArray{T}(dims; kwargs...)
-@deprecate SharedArray{T}(::Type{T}, dims::Int...; kwargs...)    SharedArray{T}(dims...; kwargs...)
-@deprecate(SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,Int}, offset; kwargs...),
+@deprecate SharedArray(::Type{T}, dims::Dims{N}; kwargs...) where {T,N} SharedArray{T}(dims; kwargs...)
+@deprecate SharedArray(::Type{T}, dims::Int...; kwargs...) where {T}    SharedArray{T}(dims...; kwargs...)
+@deprecate(SharedArray(filename::AbstractString, ::Type{T}, dims::NTuple{N,Int}, offset; kwargs...) where {T,N},
            SharedArray{T}(filename, dims, offset; kwargs...))
-@deprecate(SharedArray{T}(filename::AbstractString, ::Type{T}, dims::NTuple, offset; kwargs...),
+@deprecate(SharedArray(filename::AbstractString, ::Type{T}, dims::NTuple, offset; kwargs...) where {T},
            SharedArray{T}(filename, dims, offset; kwargs...))
 
 @noinline function is_intrinsic_expr(x::ANY)
@@ -1122,14 +1122,14 @@ end
 @deprecate EachLine(stream, ondone) EachLine(stream, ondone=ondone)
 
 # These conversions should not be defined, see #19896
-@deprecate convert{T<:Number}(::Type{T}, x::Dates.Period) convert(T, Dates.value(x))
-@deprecate convert{T<:Dates.Period}(::Type{T}, x::Real)   T(x)
-@deprecate convert{R<:Real}(::Type{R}, x::Dates.DateTime) R(Dates.value(x))
-@deprecate convert{R<:Real}(::Type{R}, x::Dates.Date)     R(Dates.value(x))
-@deprecate convert(::Type{Dates.DateTime}, x::Real)       Dates.DateTime(Dates.Millisecond(x))
-@deprecate convert(::Type{Dates.Date}, x::Real)           Dates.Date(Dates.Day(x))
+@deprecate convert(::Type{T}, x::Dates.Period) where {T<:Number} convert(T, Dates.value(x))
+@deprecate convert(::Type{T}, x::Real) where {T<:Dates.Period}   T(x)
+@deprecate convert(::Type{R}, x::Dates.DateTime) where {R<:Real} R(Dates.value(x))
+@deprecate convert(::Type{R}, x::Dates.Date) where {R<:Real}     R(Dates.value(x))
+@deprecate convert(::Type{Dates.DateTime}, x::Real)              Dates.DateTime(Dates.Millisecond(x))
+@deprecate convert(::Type{Dates.Date}, x::Real)                  Dates.Date(Dates.Day(x))
 
-function colon{T<:Dates.Period}(start::T, stop::T)
+function colon(start::T, stop::T) where T<:Dates.Period
     depwarn("$start:$stop is deprecated, use $start:$T(1):$stop instead.", :colon)
     colon(start, T(1), stop)
 end
@@ -1140,13 +1140,13 @@ end
      Base.@deprecate_binding GitAnyObject GitUnknownObject
 
      @deprecate owner(x) repository(x) false
-     @deprecate get{T<:GitObject}(::Type{T}, repo::GitRepo, x) T(repo, x) false
-     @deprecate get{T<:GitObject}(::Type{T}, repo::GitRepo, oid::GitHash, oid_size::Int) T(repo, GitShortHash(oid, oid_size)) false
+     @deprecate get(::Type{T}, repo::GitRepo, x) where {T<:GitObject} T(repo, x) false
+     @deprecate get(::Type{T}, repo::GitRepo, oid::GitHash, oid_size::Int) where {T<:GitObject} T(repo, GitShortHash(oid, oid_size)) false
      @deprecate revparse(repo::GitRepo, objname::AbstractString) GitObject(repo, objname) false
      @deprecate object(repo::GitRepo, te::GitTreeEntry) GitObject(repo, te) false
      @deprecate commit(ann::GitAnnotated) GitHash(ann) false
      @deprecate lookup(repo::GitRepo, oid::GitHash) GitBlob(repo, oid) false
-    function Base.cat{T<:GitObject}(repo::GitRepo, ::Type{T}, spec::Union{AbstractString,AbstractGitHash})
+    function Base.cat(repo::GitRepo, ::Type{T}, spec::Union{AbstractString,AbstractGitHash}) where T<:GitObject
         Base.depwarn("cat(repo::GitRepo, T, spec) is deprecated, use content(T(repo, spec))", :cat)
         try
             return content(GitBlob(repo, spec))
@@ -1197,9 +1197,9 @@ step(r::Use_StepRangeLen_Instead) = r.step/r.divisor
 
 length(r::Use_StepRangeLen_Instead) = Integer(r.len)
 
-first{T}(r::Use_StepRangeLen_Instead{T}) = convert(T, r.start/r.divisor)
+first(r::Use_StepRangeLen_Instead{T}) where {T} = convert(T, r.start/r.divisor)
 
-last{T}(r::Use_StepRangeLen_Instead{T}) = convert(T, (r.start + (r.len-1)*r.step)/r.divisor)
+last(r::Use_StepRangeLen_Instead{T}) where {T} = convert(T, (r.start + (r.len-1)*r.step)/r.divisor)
 
 start(r::Use_StepRangeLen_Instead) = 0
 done(r::Use_StepRangeLen_Instead, i::Int) = length(r) <= i
@@ -1321,7 +1321,7 @@ end
 for fname in (:ones, :zeros)
     @eval @deprecate ($fname)(T::Type, arr) ($fname)(T, size(arr))
     @eval ($fname)(T::Type, i::Integer) = ($fname)(T, (i,))
-    @eval function ($fname){T}(::Type{T}, arr::Array{T})
+    @eval function ($fname)(::Type{T}, arr::Array{T}) where T
         msg = string("`", $fname, "{T}(::Type{T}, arr::Array{T})` is deprecated, use ",
                             "`", $fname , "(T, size(arr))` instead. ",
                            )


### PR DESCRIPTION
I think it would be nice to show the new syntax in the deprecation warnings. This is mainly for backporting purposes (since the 0.6 deprecations will be removed soon enough), only 0.6 deprecations are touched so this applies cleanly to the `release-0.6` branch. Feel free to change target branch.

Master:
```julia
julia> v = rand(3); map!(sin, v);
WARNING: map!{F}(f::F, A::AbstractArray) is deprecated, use map!(f, A, A) instead.
Stacktrace:
[...]
```

PR:
```julia
julia> v = rand(3); map!(sin, v);
WARNING: map!(f::F, A::AbstractArray) where F is deprecated, use map!(f, A, A) instead.
Stacktrace:
[...]
```