### PR TITLE
Fix #18479, path completion of paths with ampersand characters.

### DIFF
--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -456,7 +456,7 @@ function completions(string, pos)
 
     # otherwise...
     if inc_tag in [:cmd, :string]
-        m = match(r"[\t\n\r\"'`@\$><=;|&\{]| (?!\\)", reverse(partial))
+        m = match(r"[\t\n\r\"><=*?|]| (?!\\)", reverse(partial))
         startpos = nextind(partial, reverseind(partial, m.offset))
         r = startpos:pos
         paths, r, success = complete_path(replace(string[r], r"\\ ", " "), pos)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -647,11 +647,11 @@ let #test that it can auto complete with spaces in file/path
                     # in shell commands the shell path completion cannot complete
                     # paths with these characters
                     c,r,res = test_scomplete(test_dir)
-                    @test c[1] == test_dir*(Sys.is_windows() ? "\\\\" : "/")
+                    @test c[1] == test_dir*(Sys.iswindows() ? "\\\\" : "/")
                     @test res
                 end
                 c,r,res  = test_complete("\""*test_dir)
-                @test c[1] == test_dir*(Sys.is_windows() ? "\\\\" : "/")
+                @test c[1] == test_dir*(Sys.iswindows() ? "\\\\" : "/")
                 @test res
             finally
                 rm(joinpath(path, test_dir), recursive=true)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -637,6 +637,26 @@ let #test that it can auto complete with spaces in file/path
         c,r = test_complete(s)
         @test r == 5:15
         @test s[r] ==  dir_space
+
+        #Test for #18479
+        for c in "'`@\$;&"
+            test_dir = "test$(c)test"
+            mkdir(joinpath(path, test_dir))
+            try
+                if !(c in ['\'','$']) # As these characters hold special meaning
+                    # in shell commands the shell path completion cannot complete
+                    # paths with these characters
+                    c,r,res = test_scomplete(test_dir)
+                    @test c[1] == test_dir*(is_windows() ? "\\\\" : "/")
+                    @test res
+                end
+                c,r,res  = test_complete("\""*test_dir)
+                @test c[1] == test_dir*(is_windows() ? "\\\\" : "/")
+                @test res
+            finally
+                rm(joinpath(path, test_dir), recursive=true)
+            end
+        end
     end
     rm(dir, recursive=true)
 end

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -647,11 +647,11 @@ let #test that it can auto complete with spaces in file/path
                     # in shell commands the shell path completion cannot complete
                     # paths with these characters
                     c,r,res = test_scomplete(test_dir)
-                    @test c[1] == test_dir*(is_windows() ? "\\\\" : "/")
+                    @test c[1] == test_dir*(Sys.is_windows() ? "\\\\" : "/")
                     @test res
                 end
                 c,r,res  = test_complete("\""*test_dir)
-                @test c[1] == test_dir*(is_windows() ? "\\\\" : "/")
+                @test c[1] == test_dir*(Sys.is_windows() ? "\\\\" : "/")
                 @test res
             finally
                 rm(joinpath(path, test_dir), recursive=true)


### PR DESCRIPTION
This supersedes #18567 without the controversial part.