### PR TITLE
Don't dump toplevel thunks for dump_compiles_stream.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1240,7 +1240,7 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
     // ... unless li->def isn't defined here meaning the function is a toplevel thunk and
     // would have its CodeInfo printed in the stream, which might contain double-quotes that
     // would not be properly escaped given the double-quotes added to the stream below.
-    if (dump_compiles_stream != NULL && li->def) {
+    if (dump_compiles_stream != NULL && jl_is_method(li->def.method)) {
         uint64_t this_time = jl_hrtime();
         jl_printf(dump_compiles_stream, "%" PRIu64 "\t\"", this_time - last_time);
         jl_static_show(dump_compiles_stream, (jl_value_t*)li);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1236,7 +1236,11 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
 
     JL_UNLOCK(&codegen_lock); // Might GC
 
-    if (dump_compiles_stream != NULL) {
+    // If logging of the compilation stream is enabled then dump the function to the stream
+    // ... unless li->def isn't defined here meaning the function is a toplevel thunk and
+    // would have its CodeInfo printed in the stream, which might contain double-quotes that
+    // would not be properly escaped given the double-quotes added to the stream below.
+    if (dump_compiles_stream != NULL && li->def) {
         uint64_t this_time = jl_hrtime();
         jl_printf(dump_compiles_stream, "%" PRIu64 "\t\"", this_time - last_time);
         jl_static_show(dump_compiles_stream, (jl_value_t*)li);

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -44,6 +44,43 @@ function test_loads_no_call(ir, load_types)
         @test load_idx == length(load_types) + 1
     end
 end
+
+# This function tests if functions are output when compiled if jl_dump_compiles is enabled.
+# Have to go through pains with recursive function (eval probably not required) to make sure
+# that inlining won't happen.
+function test_jl_dump_compiles()
+    tfile = tempname()
+    io = open(tfile, "w")
+    ccall(:jl_dump_compiles, Void, (Ptr{Void},), io.handle)
+    eval(@noinline function test_jl_dump_compiles_internal(x)
+        if x > 0
+            test_jl_dump_compiles_internal(x-1)
+        end
+        end)
+    test_jl_dump_compiles_internal(1)
+    ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
+    close(io)
+    tstats = stat(tfile)
+    tempty = tstats.size == 0
+    rm(tfile)
+    @test tempty == false
+end
+
+# This function tests if a toplevel thunk is output if jl_dump_compiles is enabled.
+# The eval statement creates the toplevel thunk.
+function test_jl_dump_compiles_toplevel_thunks()
+    tfile = tempname()
+    io = open(tfile, "w")
+    ccall(:jl_dump_compiles, Void, (Ptr{Void},), io.handle)
+    eval(expand(Main, :(for i in 1:10 end)))
+    ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
+    close(io)
+    tstats = stat(tfile)
+    tempty = tstats.size == 0
+    rm(tfile)
+    @test tempty == true
+end
+
 if opt_level > 0
     # Make sure `jl_string_ptr` is inlined
     @test !contains(get_llvm(jl_string_ptr, Tuple{String}), " call ")
@@ -59,4 +96,7 @@ if opt_level > 0
     test_loads_no_call(get_llvm(core_sizeof, Tuple{Array{Any}}), [Iptr])
     # Check that we load the elsize
     test_loads_no_call(get_llvm(core_sizeof, Tuple{Vector}), [Iptr, "i16"])
+
+    test_jl_dump_compiles()
+    test_jl_dump_compiles_toplevel_thunks()
 end


### PR DESCRIPTION
As requested, this has been moved from release-0.6 to master.

If jl_dump_compiles is enabled, it will print a double quote and then do a jl_static_show. If jl_static_show is called on a method instance whose def is NULL it prints "toplevel thunk -> CodeInfo(...)" and the CodeInfo can itself contain double quotes which then aren't properly escaped for the outer double-quotes added in jl_compile_linfo. Maybe eventually more control would be nice here to say if thunks are really desired and if so to fix the double quote escaping issue but that seems more difficult given the streaming nature of jl_static_show. So, for now, just disable the printing of info for thunks.

This behavior breaks the SnoopCompile package and the toplevel thunk isn't really a precompile target right so maybe best just to skip thunks from printing just for jl_dump_compiles.