### PR TITLE
debuginfo: tweak the order of get_function_name_and_base and dladdr on FreeBSD

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -423,12 +423,7 @@ end
 for precomp in ("yes", "no")
     bt = readstring(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --precompiled=$precomp
         -E 'include("____nonexistent_file")'`), stderr=catcmd))
-    if (is_bsd() && !is_apple()) && precomp == "yes"
-        # FIXME: #20798 (FreeBSD)
-        @test_broken contains(bt, "include_from_node1(::Module, ::String) at $(joinpath(".", "loading.jl"))")
-    else
-        @test contains(bt, "include_from_node1(::Module, ::String) at $(joinpath(".", "loading.jl"))")
-    end
+    @test contains(bt, "include_from_node1(::Module, ::String) at $(joinpath(".", "loading.jl"))")
     lno = match(r"at \.[\/\\]loading\.jl:(\d+)", bt)
     @test length(lno.captures) == 1
     @test parse(Int, lno.captures[1]) > 0


### PR DESCRIPTION
There is a known bug in FreeBSD's dladdr(3):
(Quote from manual dladdr(3))
```
    In dynamically linked programs,
    the address of a global function is considered to point to its
    program linkage table entry, rather than to the entry point of the
    function itself.  This causes most global functions to appear to be
    defined within the main executable, rather than in the shared
    libraries where the actual code resides.
```

Function `get_function_name_and_base` implemented in PR #22472 provides
a (slow but cross-platform) way to lookup function name and base address
via LLVM.

@yuyichao proposes that getting info from `get_function_name_and_base`
first and making original `dladdr` as fallback.

Fix: #20798
See also: https://github.com/JuliaLang/julia/pull/22472#issuecomment-310903446

----
Once this issue get fixed, [`test-file`](https://github.com/JuliaLang/julia/issues/20585#issuecomment-309259520) will become the last blocker of FreeBSD CI. :)