### PR TITLE
Fix `@test isapprox(...)` when using keywords

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -320,8 +320,9 @@ end
 function get_test_result(ex)
     orig_ex = Expr(:inert, ex)
     # Normalize non-dot comparison operator calls to :comparison expressions
+    is_splat = x -> isa(x, Expr) && x.head == :...
     if isa(ex, Expr) && ex.head == :call && length(ex.args) == 3 &&
-        first(string(ex.args[1])) != '.' &&
+        first(string(ex.args[1])) != '.' && !is_splat(ex.args[2]) && !is_splat(ex.args[3]) &&
         (ex.args[1] === :(==) || Base.operator_precedence(ex.args[1]) == comparison_prec)
         ex = Expr(:comparison, ex.args[2], ex.args[1], ex.args[3])
     end

--- a/test/test.jl
+++ b/test/test.jl
@@ -82,6 +82,9 @@ fails = @testset NoThrowTestSet begin
     @test isequal(0 / 0, 1 / 0)
     # Fail - isapprox
     @test isapprox(0 / 1, -1 / 0)
+    # Fail - isapprox with keyword
+    @test isapprox(1 / 2, 2 / 1, atol=1 / 1)
+    @test isapprox(1 - 2, 2 - 1; atol=1 - 1)
     # Error - unexpected pass
     @test_broken true
 end
@@ -122,6 +125,14 @@ str = sprint(show, fails[8])
 @test contains(str, "Evaluated: isapprox(0.0, -Inf)")
 
 str = sprint(show, fails[9])
+@test contains(str, "Expression: isapprox(1 / 2, 2 / 1, atol=1 / 1)")
+@test contains(str, "Evaluated: isapprox(0.5, 2.0; atol=1.0)")
+
+str = sprint(show, fails[10])
+@test contains(str, "Expression: isapprox(1 - 2, 2 - 1; atol=1 - 1)")
+@test contains(str, "Evaluated: isapprox(-1, 1; atol=0)")
+
+str = sprint(show, fails[11])
 @test contains(str, "Unexpected Pass")
 @test contains(str, "Expression: true")
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -78,13 +78,21 @@ fails = @testset NoThrowTestSet begin
     @test 1+0 == 2+0 == 3+0
     # Fail - comparison call
     @test ==(1 - 2, 2 - 1)
+    # Fail - splatting
+    @test ==(1:2...)
+    # @test ==(1, (1, 2)...)  # MethodError
     # Fail - isequal
     @test isequal(0 / 0, 1 / 0)
+    # Fail - function splatting
+    @test isequal(1:2...)
     # Fail - isapprox
     @test isapprox(0 / 1, -1 / 0)
-    # Fail - isapprox with keyword
+    # Fail - function with keyword
     @test isapprox(1 / 2, 2 / 1, atol=1 / 1)
     @test isapprox(1 - 2, 2 - 1; atol=1 - 1)
+    # Fail - function keyword splatting
+    k = [(:atol, 0), (:nans, true)]
+    @test isapprox(1, 2; k...)
     # Error - unexpected pass
     @test_broken true
 end
@@ -116,23 +124,35 @@ str = sprint(show, fails[6])
 @test contains(str, "Expression: 1 - 2 == 2 - 1")
 @test contains(str, "Evaluated: -1 == 1")
 
-str = sprint(show, fails[7])
+# str = sprint(show, fails[7])
+# @test contains(str, "Expression: ==(1:2...)")
+# @test contains(str, "Evaluated: ==(1, 2)")
+
+str = sprint(show, fails[8])
 @test contains(str, "Expression: isequal(0 / 0, 1 / 0)")
 @test contains(str, "Evaluated: isequal(NaN, Inf)")
 
-str = sprint(show, fails[8])
+str = sprint(show, fails[9])
+@test contains(str, "Expression: isequal(1:2...)")
+@test contains(str, "Evaluated: isequal(1, 2)")
+
+str = sprint(show, fails[10])
 @test contains(str, "Expression: isapprox(0 / 1, -1 / 0)")
 @test contains(str, "Evaluated: isapprox(0.0, -Inf)")
 
-str = sprint(show, fails[9])
+str = sprint(show, fails[11])
 @test contains(str, "Expression: isapprox(1 / 2, 2 / 1, atol=1 / 1)")
 @test contains(str, "Evaluated: isapprox(0.5, 2.0; atol=1.0)")
 
-str = sprint(show, fails[10])
+str = sprint(show, fails[12])
 @test contains(str, "Expression: isapprox(1 - 2, 2 - 1; atol=1 - 1)")
 @test contains(str, "Evaluated: isapprox(-1, 1; atol=0)")
 
-str = sprint(show, fails[11])
+str = sprint(show, fails[13])
+@test contains(str, "Expression: isapprox(1, 2; k...)")
+@test contains(str, "Evaluated: isapprox(1, 2; atol=0, nans=true)")
+
+str = sprint(show, fails[14])
 @test contains(str, "Unexpected Pass")
 @test contains(str, "Expression: true")
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -80,7 +80,6 @@ fails = @testset NoThrowTestSet begin
     @test ==(1 - 2, 2 - 1)
     # Fail - splatting
     @test ==(1:2...)
-    # @test ==(1, (1, 2)...)  # MethodError
     # Fail - isequal
     @test isequal(0 / 0, 1 / 0)
     # Fail - function splatting
@@ -95,8 +94,10 @@ fails = @testset NoThrowTestSet begin
     @test isapprox(1, 2; k...)
     # Error - unexpected pass
     @test_broken true
+    # Error - converting a call into a comparison
+    @test ==(1, 1:2...)
 end
-for i in 1:length(fails) - 1
+for i in 1:length(fails) - 2
     @test isa(fails[i], Base.Test.Fail)
 end
 
@@ -124,9 +125,9 @@ str = sprint(show, fails[6])
 @test contains(str, "Expression: 1 - 2 == 2 - 1")
 @test contains(str, "Evaluated: -1 == 1")
 
-# str = sprint(show, fails[7])
-# @test contains(str, "Expression: ==(1:2...)")
-# @test contains(str, "Evaluated: ==(1, 2)")
+str = sprint(show, fails[7])
+@test contains(str, "Expression: (==)(1:2...)")
+@test !contains(str, "Evaluated")
 
 str = sprint(show, fails[8])
 @test contains(str, "Expression: isequal(0 / 0, 1 / 0)")
@@ -155,6 +156,11 @@ str = sprint(show, fails[13])
 str = sprint(show, fails[14])
 @test contains(str, "Unexpected Pass")
 @test contains(str, "Expression: true")
+
+str = sprint(show, fails[15])
+@test contains(str, "Expression: ==(1, 1:2...)")
+@test contains(str, "MethodError: no method matching ==(::$Int, ::$Int, ::$Int)")
+
 
 # Test printing of a TestSetException
 tse_str = sprint(show, Test.TestSetException(1,2,3,4,Vector{Union{Base.Test.Error, Base.Test.Fail}}()))


### PR DESCRIPTION
The introduction of showing evaluated expressions for calls in #22296 only dealt with parsing function arguments without considering keyword arguments. Mostly this oversight was due to the functionality being added just for `isequal` call and `isapprox` was afterthought.

Addresses https://github.com/JuliaLang/julia/pull/22296#issuecomment-310920407