### PR TITLE
Symmetric/Hermitian solver with misc RHS

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -337,7 +337,13 @@ det(A::RealHermSymComplexHerm) = real(det(bkfact(A)))
 det(A::Symmetric{<:Real}) = det(bkfact(A))
 det(A::Symmetric) = det(bkfact(A))
 
-\(A::HermOrSym{<:Any,<:StridedMatrix}, B::StridedVecOrMat) = \(bkfact(A), B)
+\(A::HermOrSym{<:Any,<:StridedMatrix}, B::AbstractVector) = \(bkfact(A), B)
+# Bunch-Kaufman solves can not utilize BLAS-3 for multiple right hand sides
+# so using LU is faster for AbstractMatrix right hand side
+\(A::HermOrSym{<:Any,<:StridedMatrix}, B::AbstractMatrix) = \(lufact(A), B)
+# ambiguity with RowVector
+\(A::HermOrSym{<:Any,<:StridedMatrix}, B::RowVector) = invoke(\, Tuple{AbstractMatrix, RowVector}, A, B)
+
 
 inv(A::Hermitian{T,S}) where {T<:BlasFloat,S<:StridedMatrix} = Hermitian{T,S}(inv(bkfact(A)), A.uplo)
 inv(A::Symmetric{T,S}) where {T<:BlasFloat,S<:StridedMatrix} = Symmetric{T,S}(inv(bkfact(A)), A.uplo)

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -236,6 +236,14 @@ end
     @test_throws DimensionMismatch ut\rv
 end
 
+@testset "Symmetric/Hermitian ambiguity methods" begin
+    S = Symmetric(rand(3, 3))
+    H = Hermitian(rand(3, 3))
+    v = (rand(3)')::RowVector
+    @test_throws DimensionMismatch S\v
+    @test_throws DimensionMismatch H\v
+end
+
 # issue #20389
 @testset "1 row/col vec*mat" begin
     let x=[1,2,3], A=ones(1,4), y=x', B=A', C=x.*A

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -336,3 +336,12 @@ end
     @test ishermitian(Symmetric(B, :L))
     @test issymmetric(Hermitian(B, :L))
 end
+
+@testset "$HS solver with $RHS RHS - $T" for HS  in (Hermitian, Symmetric),
+        RHS in (Hermitian, Symmetric, Diagonal, UpperTriangular, LowerTriangular),
+        T   in (Float64, Complex128)
+    D = rand(T, 10, 10); D = D'D
+    A = HS(D)
+    B = RHS(D)
+    @test A\B ≈ Matrix(A)\Matrix(B)
+end


### PR DESCRIPTION
Solving with these types of right hand sides where enabled by #22478 via the generic codepath [here](https://github.com/JuliaLang/julia/blob/da68c52008440477fe7acfdf099b6643177e1b06/base/linalg/generic.jl#L817). I will try to justify the second commit with some benchmarks in a sec.

Ref https://github.com/JuliaLang/julia/pull/22478#issue-237827493