### PR TITLE
Make getindex for String check if indices are valid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,9 @@ Breaking changes
 
 This section lists changes that do not have deprecation warnings.
 
+  * `getindex(s::String, r::UnitRange{Int})` now throws `UnicodeError` if `last(r)`
+    is not a valid index into `s` ([#22572]).
+
   * `ntuple(f, n::Integer)` throws `ArgumentError` if `n` is negative.
     Previously an empty tuple was returned ([#21697]).
 

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -330,7 +330,7 @@ function DateFormat(f::AbstractString, locale::DateLocale=ENGLISH)
 
     letters = String(collect(keys(CONVERSION_SPECIFIERS)))
     for m in eachmatch(Regex("(?<!\\\\)([\\Q$letters\\E])\\1*"), f)
-        tran = replace(f[prev_offset:m.offset - 1], r"\\(.)", s"\1")
+        tran = replace(f[prev_offset:prevind(f, m.offset)], r"\\(.)", s"\1")
 
         if !isempty(prev)
             letter, width = prev

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -317,7 +317,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
             # in this case, we haven't yet written the cursor position
             line_pos -= slength # '\n' gets an extra pos
             if line_pos < 0 || !moreinput
-                num_chars = (line_pos >= 0 ? llength : strwidth(l[1:(line_pos + slength)]))
+                num_chars = (line_pos >= 0 ? llength : strwidth(l[1:prevind(l, line_pos + slength + 1)]))
                 curs_row, curs_pos = divrem(lindent + num_chars - 1, cols)
                 curs_row += cur_row
                 curs_pos += 1

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -882,7 +882,7 @@ function setup_interface(
                     end
                     # Check if input line starts with "julia> ", remove it if we are in prompt paste mode
                     jl_prompt_len = 7
-                    if (firstline || isprompt_paste) && (oldpos + jl_prompt_len <= sizeof(input) && input[oldpos:oldpos+jl_prompt_len-1] == JULIA_PROMPT)
+                    if (firstline || isprompt_paste) && startswith(SubString(input, oldpos), JULIA_PROMPT)
                         isprompt_paste = true
                         oldpos += jl_prompt_len
                     # If we are prompt pasting and current statement does not begin with julia> , skip to next line

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -482,9 +482,11 @@ function completions(string, pos)
         paths, r, success = complete_path(replace(string[r], r"\\ ", " "), pos)
 
         if inc_tag == :string &&
-           length(paths) == 1 &&                              # Only close if there's a single choice,
-           !isdir(expanduser(replace(string[startpos:start(r)-1] * paths[1], r"\\ ", " "))) &&  # except if it's a directory
-           (length(string) <= pos || string[pos+1] != '"')    # or there's already a " at the cursor.
+           length(paths) == 1 &&  # Only close if there's a single choice,
+           !isdir(expanduser(replace(string[startpos:prevind(string, start(r))] * paths[1],
+                                     r"\\ ", " "))) &&  # except if it's a directory
+           (length(string) <= pos ||
+            string[nextind(string,pos)] != '"')  # or there's already a " at the cursor.
             paths[1] *= "\""
         end
 
@@ -534,10 +536,11 @@ function completions(string, pos)
                         #   <Mod>/src/<Mod>.jl
                         #   <Mod>.jl/src/<Mod>.jl
                         if isfile(joinpath(dir, pname))
-                            endswith(pname, ".jl") && push!(suggestions, pname[1:end-3])
+                            endswith(pname, ".jl") && push!(suggestions,
+                                                            pname[1:prevind(pname, end-2)])
                         else
                             mod_name = if endswith(pname, ".jl")
-                                pname[1:end - 3]
+                                pname[1:prevind(pname, end-2)]
                             else
                                 pname
                             end

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -11,7 +11,11 @@ function completes_global(x, name)
 end
 
 function appendmacro!(syms, macros, needle, endchar)
-    append!(syms, s[2:end-sizeof(needle)]*endchar for s in filter(x -> endswith(x, needle), macros))
+    r = Regex("^.(.*)$needle\$")
+    for s in macros
+        m = match(r, s)
+        m === nothing || push!(syms, m[1]*endchar)
+    end
 end
 
 function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString, all::Bool=false, imported::Bool=false)

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -11,10 +11,12 @@ function completes_global(x, name)
 end
 
 function appendmacro!(syms, macros, needle, endchar)
-    r = Regex("^.(.*)$needle\$")
     for s in macros
-        m = match(r, s)
-        m === nothing || push!(syms, m[1]*endchar)
+        if endswith(s, needle)
+            from = nextind(s, start(s))
+            to = prevind(s, sizeof(s)-sizeof(needle)+1)
+            push!(syms, s[from:to]*endchar)
+        end
     end
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -159,9 +159,10 @@ end
 @test first('\x00':'\x7f') === '\x00'
 @test last('\x00':'\x7f') === '\x7f'
 
-# make sure substrings handle last code unit even if not start of codepoint
+# make sure substrings do not accept code unit if it is not start of codepoint
 let s = "x\u0302"
-    @test s[1:3] == s
+    @test_throws UnicodeError s[1:3]
+    @test s[1:2]==s
 end
 
 # issue #9781


### PR DESCRIPTION
Make `getindex` for `String` check if indices are valid. See #22548 for discussion.

Benchmark code (`new_getindex` is the proposed implementation):
```
using BenchmarkTools

x = "a∀"
x[1:2]
new_getindex(x, 1:2)
for i in 1:2, j in i:2
    println("\nnew_getindex(x,$i:$j)")
    display(@benchmark new_getindex($x, $i:$j))
    println("\nx[$i:$j]")
    display(@benchmark $x[$i:$j])
end
```

produces:
```
new_getindex(x,1:1)
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     24.726 ns (0.00% GC)
  median time:      26.126 ns (0.00% GC)
  mean time:        30.946 ns (8.76% GC)
  maximum time:     2.997 μs (96.86% GC)
  --------------
  samples:          10000
  evals/sample:     1000

x[1:1]
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     24.726 ns (0.00% GC)
  median time:      26.592 ns (0.00% GC)
  mean time:        30.430 ns (8.19% GC)
  maximum time:     1.952 μs (95.27% GC)
  --------------
  samples:          10000
  evals/sample:     1000

new_getindex(x,1:2)
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     27.058 ns (0.00% GC)
  median time:      28.459 ns (0.00% GC)
  mean time:        33.833 ns (7.45% GC)
  maximum time:     2.164 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

x[1:2]
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     27.058 ns (0.00% GC)
  median time:      28.925 ns (0.00% GC)
  mean time:        33.668 ns (7.92% GC)
  maximum time:     2.864 μs (96.87% GC)
  --------------
  samples:          10000
  evals/sample:     1000

new_getindex(x,2:2)
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     26.592 ns (0.00% GC)
  median time:      28.925 ns (0.00% GC)
  mean time:        33.125 ns (7.68% GC)
  maximum time:     2.035 μs (94.68% GC)
  --------------
  samples:          10000
  evals/sample:     1000

x[2:2]
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     25.660 ns (0.00% GC)
  median time:      27.992 ns (0.00% GC)
  mean time:        32.443 ns (7.73% GC)
  maximum time:     1.980 μs (95.83% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```