### PR TITLE
Split filter! docs, add # Examples, add doctests, move from helpdb

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1934,7 +1934,7 @@ Return a copy of `a`, removing elements for which `f` is `false`.
 The function `f` is passed one argument.
 
 # Examples
-```jldocttest
+```jldoctest
 julia> a = 1:10
 1:10
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1952,10 +1952,10 @@ filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 """
     filter!(f, a::AbstractVector)
 
-Update `a`, removing elements for which `function` is `false`.
+Update `a`, removing elements for which `f` is `false`.
 The function `f` is passed one argument.
 
-# Example
+# Examples
 ```jldoctest
 julia> filter!(isodd, collect(1:10))
 5-element Array{Int64,1}:

--- a/base/array.jl
+++ b/base/array.jl
@@ -1928,10 +1928,10 @@ end
 ## Filter ##
 
 """
-    filter(function, collection)
+    filter(f, a::AbstractArray)
 
-Return a copy of `collection`, removing elements for which `function` is `false`. For
-associative collections, the function is passed two arguments (key and value).
+Return a copy of `a`, removing elements for which `f` is `false`.
+The function `f` is passed one argument.
 
 # Examples
 ```jldocttest
@@ -1945,24 +1945,15 @@ julia> filter(isodd, a)
  5
  7
  9
-
-julia> d = Dict(1=>"a", 2=>"b")
-Dict{Int64,String} with 2 entries:
-  2 => "b"
-  1 => "a"
-
-julia> filter((x,y)->isodd(x), d)
-Dict{Int64,String} with 1 entry:
-  1 => "a"
 ```
 """
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
 """
-    filter!(function, a::AbstractVector)
+    filter!(f, a::AbstractVector)
 
-Update `collection`, removing elements for which `function` is `false`.
-The function is passed one argument.
+Update `a`, removing elements for which `function` is `false`.
+The function `f` is passed one argument.
 
 # Example
 ```jldoctest

--- a/base/array.jl
+++ b/base/array.jl
@@ -1958,6 +1958,23 @@ Dict{Int64,String} with 1 entry:
 """
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
+"""
+    filter!(function, a::AbstractVector)
+
+Update `collection`, removing elements for which `function` is `false`.
+The function is passed one argument.
+
+# Example
+```jldoctest
+julia> filter!(isodd, collect(1:10))
+5-element Array{Int64,1}:
+ 1
+ 3
+ 5
+ 7
+ 9
+```
+"""
 function filter!(f, a::AbstractVector)
     isempty(a) && return a
 

--- a/base/associative.jl
+++ b/base/associative.jl
@@ -295,6 +295,26 @@ function emptymergedict(d::Associative, others::Associative...)
     Dict{K,V}()
 end
 
+"""
+    filter!(function, d::Associative)
+
+Update `d`, removing elements for which `function` is `false`.
+Fhe function is passed two arguments (key and value).
+
+# Example
+```jldoctest
+julia> d = Dict(1=>"a", 2=>"b", 3=>"c")
+Dict{Int64,String} with 3 entries:
+  2 => "b"
+  3 => "c"
+  1 => "a"
+
+julia> filter!((x,y)->isodd(x), d)
+Dict{Int64,String} with 2 entries:
+  3 => "c"
+  1 => "a"
+```
+"""
 function filter!(f, d::Associative)
     badkeys = Vector{keytype(d)}(0)
     for (k,v) in d

--- a/base/associative.jl
+++ b/base/associative.jl
@@ -331,7 +331,8 @@ end
 """
     filter(f, d::Associative)
 
-Return a copy of `d`, removing elements for which `f` is `false`.The function `f` is passed two arguments (key and value).
+Return a copy of `d`, removing elements for which `f` is `false`.
+The function `f` is passed two arguments (key and value).
 
 # Examples
 ```jldocttest

--- a/base/associative.jl
+++ b/base/associative.jl
@@ -296,10 +296,10 @@ function emptymergedict(d::Associative, others::Associative...)
 end
 
 """
-    filter!(function, d::Associative)
+    filter!(f, d::Associative)
 
-Update `d`, removing elements for which `function` is `false`.
-Fhe function is passed two arguments (key and value).
+Update `d`, removing elements for which `f` is `false`.
+The function `f` is passed two arguments (key and value).
 
 # Example
 ```jldoctest
@@ -327,6 +327,24 @@ function filter!(f, d::Associative)
     end
     return d
 end
+
+"""
+    filter(f, d::Associative)
+
+Return a copy of `d`, removing elements for which `f` is `false`.The function `f` is passed two arguments (key and value).
+
+# Examples
+```jldocttest
+julia> d = Dict(1=>"a", 2=>"b")
+Dict{Int64,String} with 2 entries:
+  2 => "b"
+  1 => "a"
+
+julia> filter((x,y)->isodd(x), d)
+Dict{Int64,String} with 1 entry:
+  1 => "a"
+```
+"""
 function filter(f, d::Associative)
     # don't just do filter!(f, copy(d)): avoid making a whole copy of d
     df = similar(d)

--- a/base/associative.jl
+++ b/base/associative.jl
@@ -335,7 +335,7 @@ Return a copy of `d`, removing elements for which `f` is `false`.
 The function `f` is passed two arguments (key and value).
 
 # Examples
-```jldocttest
+```jldoctest
 julia> d = Dict(1=>"a", 2=>"b")
 Dict{Int64,String} with 2 entries:
   2 => "b"

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -311,25 +311,6 @@ This would create a 25-by-30000 `BitArray`, linked to the file associated with s
 Mmap.mmap(io, ::BitArray, dims = ?, offset = ?)
 
 """
-    filter!(function, collection)
-
-Update `collection`, removing elements for which `function` is `false`.
-For associative collections, the function is passed two arguments (key and value).
-
-# Example
-```jldoctest
-julia> filter!(isodd, collect(1:10))
-5-element Array{Int64,1}:
- 1
- 3
- 5
- 7
- 9
-```
-"""
-filter!
-
-"""
     sizeof(T)
 
 Size, in bytes, of the canonical binary representation of the given DataType `T`, if any.
@@ -424,7 +405,6 @@ Returns the file descriptor backing the stream or file. Note that this function 
 to synchronous `File`'s and `IOStream`'s not to any of the asynchronous streams.
 """
 fd
-
 
 """
     ones([A::AbstractArray,] [T=eltype(A)::Type,] [dims=size(A)::Tuple])
@@ -788,13 +768,6 @@ append!
 Seek a stream relative to the current position.
 """
 skip
-
-"""
-    setdiff!(s, iterable)
-
-Remove each element of `iterable` from set `s` in-place.
-"""
-setdiff!
 
 """
     copysign(x, y) -> z
@@ -2517,13 +2490,6 @@ skipchars
 The smallest in absolute value non-subnormal value representable by the given floating-point DataType `T`.
 """
 realmin
-
-"""
-    union!(s, iterable)
-
-Union each element of `iterable` into set `s` in-place.
-"""
-union!
 
 """
     deepcopy(x)

--- a/base/set.jl
+++ b/base/set.jl
@@ -68,6 +68,22 @@ function union(s::Set, sets::Set...)
     return u
 end
 const ∪ = union
+
+"""
+    union!(s, iterable)
+
+Union each element of `iterable` into set `s` in-place.
+
+# Examples
+```jldoctest
+julia> a = Set([1, 3, 4, 5]);
+
+julia> union!(a, 1:2:8);
+
+julia> a
+Set([7, 4, 3, 5, 1])
+```
+"""
 union!(s::Set, xs) = (for x=xs; push!(s,x); end; s)
 union!(s::Set, xs::AbstractArray) = (sizehint!(s,length(xs));for x=xs; push!(s,x); end; s)
 join_eltype() = Bottom
@@ -99,6 +115,22 @@ function setdiff(a::Set, b::Set)
     end
     d
 end
+
+"""
+    setdiff!(s, iterable)
+
+Remove each element of `iterable` from set `s` in-place.
+
+# Examples
+```jldoctest
+julia> a = Set([1, 3, 4, 5]);
+
+julia> setdiff!(a, 1:2:6);
+
+julia> a
+Set([4])
+```
+"""
 setdiff!(s::Set, xs) = (for x=xs; delete!(s,x); end; s)
 
 ==(l::Set, r::Set) = (length(l) == length(r)) && (l <= r)
@@ -249,6 +281,7 @@ Remove duplicate items as determined by [`isequal`](@ref), then return the modif
 about the order of the returned data, then calling `(sort!(A); unique!(A))` will be much
 more efficient as long as the elements of `A` can be sorted.
 
+# Examples
 ```jldoctest
 julia> unique!([1, 1, 1])
 1-element Array{Int64,1}:
@@ -299,6 +332,7 @@ end
 
 Return `true` if all values from `itr` are distinct when compared with [`isequal`](@ref).
 
+# Examples
 ```jldoctest
 julia> a = [1; 2; 3]
 3-element Array{Int64,1}:


### PR DESCRIPTION
Seems like it's better to have two docs for `filter!` if the `Associative` one needs a function that takes two arguments.