### PR TITLE
Add TargetMachine arg to addOptimizationPasses.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -41,7 +41,6 @@
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/TargetSelect.h>
-#include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Object/SymbolSize.h>
 
 // IR building
@@ -6551,7 +6550,7 @@ static void init_julia_llvm_env(Module *m)
     add_named_global(jlgetworld_global, &jl_world_counter);
 
     jl_globalPM = new legacy::PassManager();
-    jl_globalPM->add(new TargetLibraryInfoWrapperPass(Triple(jl_TargetMachine->getTargetTriple())));
+    addTargetPasses(jl_globalPM, jl_TargetMachine);
     addOptimizationPasses(jl_globalPM, jl_options.opt_level);
 }
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -92,7 +92,14 @@ void jl_init_jit(Type *T_pjlvalue_)
 
 // Except for parts of this file which were copied from LLVM, under the UIUC license (marked below).
 
-// this defines the set of optimization passes defined for Julia at various optimization levels
+void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM)
+{
+    PM->add(new TargetLibraryInfoWrapperPass(Triple(TM->getTargetTriple())));
+    PM->add(createTargetTransformInfoWrapperPass(TM->getTargetIRAnalysis()));
+}
+
+// this defines the set of optimization passes defined for Julia at various optimization levels.
+// it assumes that the TLI and TTI wrapper passes have already been added.
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level)
 {
 #ifdef JL_DEBUG_BUILD
@@ -132,7 +139,6 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level)
         return;
     }
     PM->add(createPropagateJuliaAddrspaces());
-    PM->add(createTargetTransformInfoWrapperPass(jl_TargetMachine->getTargetIRAnalysis()));
     PM->add(createTypeBasedAAWrapperPass());
     if (jl_options.opt_level >= 3) {
         PM->add(createBasicAAWrapperPass());
@@ -485,6 +491,7 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM)
             CompilerT(this)
         )
 {
+    addTargetPasses(&PM, &TM);
     addOptimizationPasses(&PM, jl_generating_output() ? 0 : jl_options.opt_level);
     if (TM.addPassesToEmitMC(PM, Ctx, ObjStream))
         llvm_unreachable("Target does not support MC emission.");
@@ -1137,7 +1144,7 @@ void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char
         ));
 
     legacy::PassManager PM;
-    PM.add(new TargetLibraryInfoWrapperPass(Triple(TM->getTargetTriple())));
+    addTargetPasses(&PM, TM.get());
 
     // set up optimization passes
     std::unique_ptr<raw_fd_ostream> unopt_bc_OS;
@@ -1269,6 +1276,7 @@ public:
         (void)jl_init_llvm();
         PMTopLevelManager *TPM = Stack.top()->getTopLevelManager();
         TPMAdapter Adapter(TPM);
+        addTargetPasses(&Adapter, jl_TargetMachine);
         addOptimizationPasses(&Adapter, OptLevel);
     }
     JuliaPipeline() : Pass(PT_PassManager, ID) {}

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -42,6 +42,7 @@ extern size_t jltls_offset_idx;
 
 typedef struct {Value *gv; int32_t index;} jl_value_llvm; // uses 1-based indexing
 
+void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM);
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level);
 void* jl_emit_and_add_to_shadow(GlobalVariable *gv, void *gvarinit = NULL);
 GlobalVariable *jl_emit_sysimg_slot(Module *m, Type *typ, const char *name,


### PR DESCRIPTION
Extension of #22517

Alternatively, we could drop the call to `createTargetTransformInfoWrapperPass` and require the caller to do so beforehand, but I'm not sure how that would interact with other passes / whether that's equivalent. Looks like we already do so for the global PM though...
```
    jl_globalPM = new legacy::PassManager();
    jl_globalPM->add(new TargetLibraryInfoWrapperPass(Triple(jl_TargetMachine->getTargetTriple())));
    addOptimizationPasses(jl_globalPM, jl_options.opt_level);
```