### PR TITLE
Allocate less in limited sparse printing

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -728,8 +728,8 @@ end
 ## rem2pi-related calculations ##
 
 function add22condh(xh::Float64, xl::Float64, yh::Float64, yl::Float64)
-    # This algorithm, due to Dekker, computes the sum of
-    # two double-double numbers and return high double.  References:
+    # This algorithm, due to Dekker, computes the sum of two
+    # double-double numbers and returns the high double. References:
     # [1] http://www.digizeitschriften.de/en/dms/img/?PID=GDZPPN001170007
     # [2] https://dx.doi.org/10.1007/BF01397083
     r = xh+yh

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -308,8 +308,8 @@ function A_rdiv_B!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T
     A
 end
 
-A_rdiv_Bc!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T = A_rdiv_B!(A, conj(D))
-A_rdiv_Bt!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T = A_rdiv_B!(A, D)
+A_rdiv_Bc!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where {T} = A_rdiv_B!(A, conj(D))
+A_rdiv_Bt!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where {T} = A_rdiv_B!(A, D)
 
 ## triu, tril
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -149,7 +149,7 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
 
     function _format_line(r, col)
         pad = ndigits(max(S.m, S.n))
-        print(ioc, "  ", '[', rpad(S.rowval[r], pad), ", ", lpad(col, pad), "]  =  ")
+        print(ioc, "  [", rpad(S.rowval[r], pad), ", ", lpad(col, pad), "]  =  ")
         if isassigned(S.nzval, Int(r))
             show(ioc, S.nzval[r])
         else
@@ -171,19 +171,17 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
         count == print_count && break
     end
 
-    lines_bottom = String[]
     if !will_fit
-        count = 0
-        for col = reverse(1:S.n), r = reverse(nzrange(S, col))
-            count += 1
-            push!(lines_bottom, _format_line(r, col))
-            count == print_count && break
+        print(io, "\n  \u22ee")
+        # find the column to start printing in for the last print_count elements
+        nextcol = searchsortedfirst(S.colptr, nnz(S) - print_count + 1)
+        for r = nnz(S) - print_count + 1 : S.colptr[nextcol] - 1
+            print(io, "\n", _format_line(r, nextcol - 1))
         end
-    end
-
-    if !will_fit
-        print(io, "\n  ", '\u22ee', "\n")
-        print(io, join(reverse(lines_bottom), '\n'))
+        # print all of the remaining columns
+        for col = nextcol:S.n, r = nzrange(S, col)
+            print(io, "\n", _format_line(r, col))
+        end
     end
 end
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -175,7 +175,7 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
         print(io, "\n  \u22ee")
         # find the column to start printing in for the last print_count elements
         nextcol = searchsortedfirst(S.colptr, nnz(S) - print_count + 1)
-        for r = nnz(S) - print_count + 1 : S.colptr[nextcol] - 1
+        for r = (nnz(S) - print_count + 1) : (S.colptr[nextcol] - 1)
             print(io, "\n", _format_line(r, nextcol - 1))
         end
         # print all of the remaining columns

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1664,7 +1664,7 @@ end
 end == true
 
 @test let
-    # creates a new worker in the different folder and tries to include file
+    # creates a new worker in a different folder and tries to include file
     tmp_file, temp_file_stream = mktemp()
     close(temp_file_stream)
     tmp_file = relpath(tmp_file)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1779,6 +1779,21 @@ end
     show(ioc, MIME"text/plain"(), sparse(Int64[1, 1], Int64[1, 2], [1.0, 2.0]))
     @test String(take!(io)) == "1×2 SparseMatrixCSC{Float64,Int64} with 2 stored entries:\n  ⋮"
 
+    # even number of rows
+    ioc = IOContext(IOContext(io, :displaysize => (8, 80)), :limit => true)
+    show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4], Int64[1,1,2,2], [1.0,2.0,3.0,4.0]))
+    @test String(take!(io)) == string("4×2 SparseMatrixCSC{Float64,Int64} with 4 stored entries:\n  [1, 1]",
+                                      "  =  1.0\n  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0")
+
+    show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5], Int64[1,1,2,2,3], [1.0,2.0,3.0,4.0,5.0]))
+    @test String(take!(io)) ==  string("5×3 SparseMatrixCSC{Float64,Int64} with 5 stored entries:\n  [1, 1]",
+                                       "  =  1.0\n  ⋮\n  [5, 3]  =  5.0")
+
+    show(ioc, MIME"text/plain"(), sparse(ones(5,3)))
+    @test String(take!(io)) ==  string("5×3 SparseMatrixCSC{Float64,Int64} with 15 stored entries:\n  [1, 1]",
+                                       "  =  1.0\n  ⋮\n  [5, 3]  =  1.0")
+
+    # odd number of rows
     ioc = IOContext(IOContext(io, :displaysize => (9, 80)), :limit => true)
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5], Int64[1,1,2,2,3], [1.0,2.0,3.0,4.0,5.0]))
     @test String(take!(io)) == string("5×3 SparseMatrixCSC{Float64,Int64} with 5 stored entries:\n  [1, 1]",
@@ -1787,6 +1802,10 @@ end
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5,6], Int64[1,1,2,2,3,3], [1.0,2.0,3.0,4.0,5.0,6.0]))
     @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,Int64} with 6 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  [2, 1]  =  2.0\n  ⋮\n  [5, 3]  =  5.0\n  [6, 3]  =  6.0")
+
+    show(ioc, MIME"text/plain"(), sparse(ones(6,3)))
+    @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,Int64} with 18 stored entries:\n  [1, 1]",
+                                       "  =  1.0\n  [2, 1]  =  1.0\n  ⋮\n  [5, 3]  =  1.0\n  [6, 3]  =  1.0")
 
     ioc = IOContext(io, :displaysize => (9, 80))
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5,6], Int64[1,1,2,2,3,3], [1.0,2.0,3.0,4.0,5.0,6.0]))

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1773,14 +1773,14 @@ end
     show(io, MIME"text/plain"(), spzeros(Float32, Int64, 2, 2))
     @test String(take!(io)) == "2×2 SparseMatrixCSC{Float32,Int64} with 0 stored entries"
 
-    ioc = IOContext(IOContext(io, :displaysize => (5, 80)), :limit => true)
+    ioc = IOContext(io, displaysize = (5, 80), limit = true)
     show(ioc, MIME"text/plain"(), sparse(Int64[1], Int64[1], [1.0]))
     @test String(take!(io)) == "1×1 SparseMatrixCSC{Float64,Int64} with 1 stored entry:\n  [1, 1]  =  1.0"
     show(ioc, MIME"text/plain"(), sparse(Int64[1, 1], Int64[1, 2], [1.0, 2.0]))
     @test String(take!(io)) == "1×2 SparseMatrixCSC{Float64,Int64} with 2 stored entries:\n  ⋮"
 
     # even number of rows
-    ioc = IOContext(IOContext(io, :displaysize => (8, 80)), :limit => true)
+    ioc = IOContext(io, displaysize = (8, 80), limit = true)
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4], Int64[1,1,2,2], [1.0,2.0,3.0,4.0]))
     @test String(take!(io)) == string("4×2 SparseMatrixCSC{Float64,Int64} with 4 stored entries:\n  [1, 1]",
                                       "  =  1.0\n  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0")
@@ -1794,7 +1794,7 @@ end
                                        "  =  1.0\n  ⋮\n  [5, 3]  =  1.0")
 
     # odd number of rows
-    ioc = IOContext(IOContext(io, :displaysize => (9, 80)), :limit => true)
+    ioc = IOContext(io, displaysize = (9, 80), limit = true)
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5], Int64[1,1,2,2,3], [1.0,2.0,3.0,4.0,5.0]))
     @test String(take!(io)) == string("5×3 SparseMatrixCSC{Float64,Int64} with 5 stored entries:\n  [1, 1]",
                                       "  =  1.0\n  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0\n  [5, 3]  =  5.0")
@@ -1807,7 +1807,7 @@ end
     @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,$Int} with 18 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  [2, 1]  =  1.0\n  ⋮\n  [5, 3]  =  1.0\n  [6, 3]  =  1.0")
 
-    ioc = IOContext(io, :displaysize => (9, 80))
+    ioc = IOContext(io, displaysize = (9, 80))
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5,6], Int64[1,1,2,2,3,3], [1.0,2.0,3.0,4.0,5.0,6.0]))
     @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,Int64} with 6 stored entries:\n  [1, 1]  =  1.0\n",
         "  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0\n  [5, 3]  =  5.0\n  [6, 3]  =  6.0")

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1790,7 +1790,7 @@ end
                                        "  =  1.0\n  ⋮\n  [5, 3]  =  5.0")
 
     show(ioc, MIME"text/plain"(), sparse(ones(5,3)))
-    @test String(take!(io)) ==  string("5×3 SparseMatrixCSC{Float64,Int64} with 15 stored entries:\n  [1, 1]",
+    @test String(take!(io)) ==  string("5×3 SparseMatrixCSC{Float64,$Int} with 15 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  ⋮\n  [5, 3]  =  1.0")
 
     # odd number of rows
@@ -1804,7 +1804,7 @@ end
                                        "  =  1.0\n  [2, 1]  =  2.0\n  ⋮\n  [5, 3]  =  5.0\n  [6, 3]  =  6.0")
 
     show(ioc, MIME"text/plain"(), sparse(ones(6,3)))
-    @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,Int64} with 18 stored entries:\n  [1, 1]",
+    @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,$Int} with 18 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  [2, 1]  =  1.0\n  ⋮\n  [5, 3]  =  1.0\n  [6, 3]  =  1.0")
 
     ioc = IOContext(io, :displaysize => (9, 80))


### PR DESCRIPTION
Avoids unnecessary allocation and reversal of an array of outputs from the method in https://github.com/JuliaLang/julia/pull/22536. Add a few more test cases with dense columns to be sure this is consistent with the output from master. The new tests should pass with or without the rest of the change.

edit: mac travis hung while downloading something, log backed up to https://gist.github.com/6433751028a10ec3d17391cd57bf0c26 and restarted