### PR TITLE
Explained pattern deletion in replace() docs

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -400,7 +400,7 @@ single character, a vector or a set of characters, a string, or a regular expres
 is a function, each occurrence is replaced with `r(s)` where `s` is the matched substring.
 If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture group
 references in `r` are replaced with the corresponding matched text.
-To delete patterns in `pat` set `r` to an empty String (`""` or `string()`).
+To delete patterns in `pat` set `r` to an empty String (`""`).
 """
 replace(s::AbstractString, pat, f, n::Integer) = replace(String(s), pat, f, n)
 replace(s::AbstractString, pat, r) = replace(s, pat, r, 0)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -400,6 +400,7 @@ single character, a vector or a set of characters, a string, or a regular expres
 is a function, each occurrence is replaced with `r(s)` where `s` is the matched substring.
 If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture group
 references in `r` are replaced with the corresponding matched text.
+To delete patterns in `pat` set `r` to an empty String (`""` or `string()`).
 """
 replace(s::AbstractString, pat, f, n::Integer) = replace(String(s), pat, f, n)
 replace(s::AbstractString, pat, r) = replace(s, pat, r, 0)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -400,7 +400,7 @@ single character, a vector or a set of characters, a string, or a regular expres
 is a function, each occurrence is replaced with `r(s)` where `s` is the matched substring.
 If `pat` is a regular expression and `r` is a `SubstitutionString`, then capture group
 references in `r` are replaced with the corresponding matched text.
-To delete patterns in `pat` set `r` to an empty String (`""`).
+To remove instances of `pat` from `string`, set `r` to the empty `String` (`""`).
 """
 replace(s::AbstractString, pat, f, n::Integer) = replace(String(s), pat, f, n)
 replace(s::AbstractString, pat, r) = replace(s, pat, r, 0)


### PR DESCRIPTION
Recently i couldn't find a way to remove a pattern from a string. 
I would have found replace() faster, if deletion was mentioned in the docs.
I also first tried to use an empty char `''` as replacement, which doesn't work. 