### PR TITLE
Add more `@test` tests

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -318,7 +318,6 @@ end
 # evaluate each term in the comparison individually so the results
 # can be displayed nicely.
 function get_test_result(ex)
-    orig_ex = Expr(:inert, ex)
     # Normalize non-dot comparison operator calls to :comparison expressions
     is_splat = x -> isa(x, Expr) && x.head == :...
     if isa(ex, Expr) && ex.head == :call && length(ex.args) == 3 &&

--- a/test/test.jl
+++ b/test/test.jl
@@ -4,8 +4,14 @@
 @test true
 @test 1 == 1
 @test 1 != 2
+@test ==(1, 1)
+@test ==((1, 1)...)
 @test strip("\t  hi   \n") == "hi"
 @test strip("\t  this should fail   \n") != "hi"
+@test isequal(1, 1)
+@test isapprox(1, 1, atol=0.1)
+@test isapprox(1, 1; atol=0.1)
+@test isapprox(1, 1; [(:atol, 0)]...)
 
 # @test should only evaluate the arguments once
 let g = Int[], f = (x) -> (push!(g, x); x)

--- a/test/test.jl
+++ b/test/test.jl
@@ -6,12 +6,17 @@
 @test 1 != 2
 @test ==(1, 1)
 @test ==((1, 1)...)
+@test 1 ≈ 2 atol=1
 @test strip("\t  hi   \n") == "hi"
 @test strip("\t  this should fail   \n") != "hi"
 @test isequal(1, 1)
 @test isapprox(1, 1, atol=0.1)
 @test isapprox(1, 1; atol=0.1)
 @test isapprox(1, 1; [(:atol, 0)]...)
+
+# @test keyword precedence: post-semicolon keyword, suffix keyword, pre-semicolon keyword
+@test isapprox(1, 2, atol=0) atol=1
+@test isapprox(1, 3, atol=0; atol=2) atol=1
 
 # @test should only evaluate the arguments once
 let g = Int[], f = (x) -> (push!(g, x); x)


### PR DESCRIPTION
Minor follow up to #22558.

I also discovered a small issue when invalid syntax is used when calling `isapprox` or `isequal` where a `MethodError` will be thrown instead of a syntax error:
```julia
julia> isequal(; a=1:2...)
ERROR: syntax: splicing with "..." cannot be used for a keyword argument value

julia> @test isequal(; a=1:2...)
Error During Test
  Test threw an exception of type MethodError
  Expression: isequal(; a=1:2...)
  MethodError: no method matching Pair(::Symbol, ::Int64, ::Int64)
```
Due to the way `@test` revises the expression so that each argument is evaluated I'm not sure much can be done here without evaluating the original expression and the arguments separately (effectively evaluating the arguments twice). I can open an issue if need be. 