### PR TITLE
RFC: rewrite_sourceloc! function

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -16,8 +16,9 @@ export quot,
 """
     Meta.quot(ex)::Expr
 
-Quote expression `ex` to produce an expression with head `quote`. This can for instance be used to represent objects of type `Expr` in the AST.
-See also the manual section about [QuoteNode](@ref man-quote-node).
+Quote expression `ex` to produce an expression with head `quote`. This can for
+instance be used to represent objects of type `Expr` in the AST. See also the
+manual section about [QuoteNode](@ref man-quote-node).
 
 # Examples
 ```jldoctest
@@ -39,7 +40,10 @@ quot(ex) = Expr(:quote, ex)
 """
     Meta.isexpr(ex, head[, n])::Bool
 
-Check if `ex` is an expression with head `head` and `n` arguments.
+Return true if `ex` is an `Expr` with the given type `head` and optionally that
+the argument list is of length `n`. `head` may be a `Symbol` or collection of
+`Symbol`s. For example, to check that a macro was passed a function call
+expression, you might use `isexpr(ex, :call)`.
 
 # Examples
 ```jldoctest

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -388,6 +388,9 @@ Base.parentmodule
 Base.pathof(::Module)
 Base.moduleroot
 Base.@__MODULE__
+Base.@__FILE__
+Base.@__DIR__
+Base.@__LINE__
 Base.fullname
 Base.names
 Core.nfields

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -48,9 +48,6 @@ Base.Filesystem.issticky
 Base.Filesystem.homedir
 Base.Filesystem.dirname
 Base.Filesystem.basename
-Base.@__FILE__
-Base.@__DIR__
-Base.@__LINE__
 Base.Filesystem.isabspath
 Base.Filesystem.isdirpath
 Base.Filesystem.joinpath

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -123,6 +123,16 @@ using Base.Meta
 @test isexpr(:(1+1),(:call,))
 @test isexpr(1,:call)==false
 @test isexpr(:(1+1),:call,3)
+
+let
+    fakeline = LineNumberNode(100000,"A")
+    # Interop with __LINE__
+    @test macroexpand(@__MODULE__, replace_sourceloc!(fakeline, :(@__LINE__))) == fakeline.line
+    # replace_sourceloc! should recurse:
+    @test replace_sourceloc!(fakeline, :((@a) + 1)).args[2].args[2] == fakeline
+    @test replace_sourceloc!(fakeline, :(@a @b)).args[3].args[2] == fakeline
+end
+
 ioB = IOBuffer()
 show_sexpr(ioB,:(1+1))
 


### PR DESCRIPTION
A tool to propagate the implicit `__source__` variable from a macro to any
macro calls in the generated AST.

This automates @vtjnash's trick from https://github.com/JuliaLang/julia/pull/21746#discussion_r121573359 and makes it accessible to people who want to do the common task of making uses of `@__LINE__` inside a macro expand to the location of the macro caller, rather than a location inside the macro.  (The trick is simple to use directly in some cases, but this tool makes it a *lot* easier to use if `@__LINE__` is deeply embeeded in the AST.)

An obvious question is whether this should propagate into nested macro calls when processing the AST.  For now, I've not done this but perhaps I need to think a bit more about that.