### PR TITLE
RFC: Extract all parts of QR factorization from SPQR

### DIFF
--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -643,7 +643,7 @@ A_mul_Bc!(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) where {T<:BlasReal} = LAPAC
 A_mul_Bc!(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) where {T<:BlasComplex} = LAPACK.gemqrt!('R','C',B.factors,B.T,A)
 A_mul_Bc!(A::StridedVecOrMat{T}, B::QRPackedQ{T}) where {T<:BlasReal} = LAPACK.ormqr!('R','T',B.factors,B.τ,A)
 A_mul_Bc!(A::StridedVecOrMat{T}, B::QRPackedQ{T}) where {T<:BlasComplex} = LAPACK.ormqr!('R','C',B.factors,B.τ,A)
-function A_mul_Bc!(A::AbstractMatrix,Q::QRPackedQ)
+function A_mul_Bc!(A::StridedMatrix,Q::QRPackedQ)
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)
     if nA != mQ
@@ -667,7 +667,7 @@ function A_mul_Bc!(A::AbstractMatrix,Q::QRPackedQ)
     end
     A
 end
-function A_mul_Bc(A::AbstractMatrix, B::AbstractQ)
+function A_mul_Bc(A::StridedMatrix, B::AbstractQ)
     TAB = promote_type(eltype(A),eltype(B))
     BB = convert(AbstractMatrix{TAB}, B)
     if size(A,2) == size(B.factors, 1)

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -496,8 +496,10 @@ end
 
 ## Multiplication by Q
 ### QB
-A_mul_B!(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) where {T<:BlasFloat} = LAPACK.gemqrt!('L','N',A.factors,A.T,B)
-A_mul_B!(A::QRPackedQ{T}, B::StridedVecOrMat{T}) where {T<:BlasFloat} = LAPACK.ormqr!('L','N',A.factors,A.τ,B)
+A_mul_B!(A::QRCompactWYQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasFloat, S<:StridedMatrix} =
+    LAPACK.gemqrt!('L','N',A.factors,A.T,B)
+A_mul_B!(A::QRPackedQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasFloat, S<:StridedMatrix} =
+    LAPACK.ormqr!('L','N',A.factors,A.τ,B)
 function A_mul_B!(A::QRPackedQ, B::AbstractVecOrMat)
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
@@ -549,10 +551,14 @@ function (*)(A::Union{QRPackedQ,QRCompactWYQ}, B::StridedMatrix)
 end
 
 ### QcB
-Ac_mul_B!(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) where {T<:BlasReal} = LAPACK.gemqrt!('L','T',A.factors,A.T,B)
-Ac_mul_B!(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) where {T<:BlasComplex} = LAPACK.gemqrt!('L','C',A.factors,A.T,B)
-Ac_mul_B!(A::QRPackedQ{T}, B::StridedVecOrMat{T}) where {T<:BlasReal} = LAPACK.ormqr!('L','T',A.factors,A.τ,B)
-Ac_mul_B!(A::QRPackedQ{T}, B::StridedVecOrMat{T}) where {T<:BlasComplex} = LAPACK.ormqr!('L','C',A.factors,A.τ,B)
+Ac_mul_B!(A::QRCompactWYQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasReal,S<:StridedMatrix} =
+    LAPACK.gemqrt!('L','T',A.factors,A.T,B)
+Ac_mul_B!(A::QRCompactWYQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasComplex,S<:StridedMatrix} =
+    LAPACK.gemqrt!('L','C',A.factors,A.T,B)
+Ac_mul_B!(A::QRPackedQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasReal,S<:StridedMatrix} =
+    LAPACK.ormqr!('L','T',A.factors,A.τ,B)
+Ac_mul_B!(A::QRPackedQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasComplex,S<:StridedMatrix} =
+    LAPACK.ormqr!('L','C',A.factors,A.τ,B)
 function Ac_mul_B!(A::QRPackedQ, B::AbstractVecOrMat)
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
@@ -596,8 +602,10 @@ for (f1, f2) in ((:A_mul_Bc, :A_mul_B!),
 end
 
 ### AQ
-A_mul_B!(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) where {T<:BlasFloat} = LAPACK.gemqrt!('R','N', B.factors, B.T, A)
-A_mul_B!(A::StridedVecOrMat{T}, B::QRPackedQ{T}) where {T<:BlasFloat} = LAPACK.ormqr!('R', 'N', B.factors, B.τ, A)
+A_mul_B!(A::StridedVecOrMat{T}, B::QRCompactWYQ{T,S}) where {T<:BlasFloat,S<:StridedMatrix} =
+    LAPACK.gemqrt!('R','N', B.factors, B.T, A)
+A_mul_B!(A::StridedVecOrMat{T}, B::QRPackedQ{T,S}) where {T<:BlasFloat,S<:StridedMatrix} =
+    LAPACK.ormqr!('R', 'N', B.factors, B.τ, A)
 function A_mul_B!(A::StridedMatrix,Q::QRPackedQ)
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -248,6 +248,8 @@ mutable struct Sparse{Tv<:VTypes} <: AbstractSparseMatrix{Tv,SuiteSparse_long}
 end
 Sparse(p::Ptr{C_Sparse{Tv}}) where {Tv<:VTypes} = Sparse{Tv}(p)
 
+Base.unsafe_convert(::Type{Ptr{Tv}}, A::Sparse{Tv}) where {Tv} = A.p
+
 # Factor
 
 if build_version >= v"2.1.0" # CHOLMOD version 2.1.0 or later

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -194,7 +194,7 @@ function spmatmul(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
 end
 
 ## solvers
-function fwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
+function fwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
 # forward substitution for CSC matrices
     nrowB, ncolB  = size(B, 1), size(B, 2)
     ncol = LinAlg.checksquare(A)
@@ -202,9 +202,9 @@ function fwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
         throw(DimensionMismatch("A is $(ncol) columns and B has $(nrowB) rows"))
     end
 
-    aa = A.nzval
-    ja = A.rowval
-    ia = A.colptr
+    aa = getnzval(A)
+    ja = getrowval(A)
+    ia = getcolptr(A)
 
     joff = 0
     for k = 1:ncolB
@@ -239,7 +239,7 @@ function fwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
     B
 end
 
-function bwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
+function bwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
 # backward substitution for CSC matrices
     nrowB, ncolB = size(B, 1), size(B, 2)
     ncol = LinAlg.checksquare(A)
@@ -247,9 +247,9 @@ function bwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
         throw(DimensionMismatch("A is $(ncol) columns and B has $(nrowB) rows"))
     end
 
-    aa = A.nzval
-    ja = A.rowval
-    ia = A.colptr
+    aa = getnzval(A)
+    ja = getrowval(A)
+    ia = getcolptr(A)
 
     joff = 0
     for k = 1:ncolB
@@ -284,11 +284,11 @@ function bwdTriSolve!(A::SparseMatrixCSC, B::AbstractVecOrMat)
     B
 end
 
-A_ldiv_B!(L::LowerTriangular{T,<:SparseMatrixCSC{T}}, B::StridedVecOrMat) where {T} = fwdTriSolve!(L.data, B)
-A_ldiv_B!(U::UpperTriangular{T,<:SparseMatrixCSC{T}}, B::StridedVecOrMat) where {T} = bwdTriSolve!(U.data, B)
+A_ldiv_B!(L::LowerTriangular{T,<:SparseMatrixCSCUnion{T}}, B::StridedVecOrMat) where {T} = fwdTriSolve!(L.data, B)
+A_ldiv_B!(U::UpperTriangular{T,<:SparseMatrixCSCUnion{T}}, B::StridedVecOrMat) where {T} = bwdTriSolve!(U.data, B)
 
-(\)(L::LowerTriangular{T,<:SparseMatrixCSC{T}}, B::SparseMatrixCSC) where {T} = A_ldiv_B!(L, Array(B))
-(\)(U::UpperTriangular{T,<:SparseMatrixCSC{T}}, B::SparseMatrixCSC) where {T} = A_ldiv_B!(U, Array(B))
+(\)(L::LowerTriangular{T,<:SparseMatrixCSCUnion{T}}, B::SparseMatrixCSC) where {T} = A_ldiv_B!(L, Array(B))
+(\)(U::UpperTriangular{T,<:SparseMatrixCSCUnion{T}}, B::SparseMatrixCSC) where {T} = A_ldiv_B!(U, Array(B))
 
 function A_rdiv_B!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T
     dd = D.diag

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -33,6 +33,10 @@ end
 
 size(S::SparseMatrixCSC) = (S.m, S.n)
 
+# Define a union of SparseMatrixCSC and view containing all rows of a SparseMatrixCSC and a contiguous
+# selection of columns. Many methods can be defined efficiently for this union by extracting the fields
+# via the get function: getcolptr, getrowval, and getnzval. The key insight is that getcolptr on a view
+# returns a offset view of the colptr of the underlying SparseMatrixCSC
 const SparseMatrixCSCUnion{Tv,Ti} =
     Union{SparseMatrixCSC{Tv,Ti},
         SubArray{Tv,2,SparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int64}},I}}} where {I<:AbstractUnitRange}

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -33,6 +33,21 @@ end
 
 size(S::SparseMatrixCSC) = (S.m, S.n)
 
+const SparseMatrixCSCUnion{Tv,Ti} =
+    Union{SparseMatrixCSC{Tv,Ti},
+        SubArray{Tv,2,SparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int64}},I}}} where {I<:AbstractUnitRange}
+
+getcolptr(S::SparseMatrixCSC) = S.colptr
+getcolptr(S::SubArray{T,2,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int64}},I}} where {T,I<:AbstractUnitRange}) =
+    view(S.parent.colptr, first(indices(S, 2)):(last(indices(S, 2)) + 1))
+getrowval(S::SparseMatrixCSC) = S.rowval
+getrowval(S::SubArray{T,2,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int64}},I}} where {T,I<:AbstractUnitRange}) =
+    S.parent.rowval
+getnzval(S::SparseMatrixCSC) = S.nzval
+getnzval(S::SubArray{T,2,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int64}},I}} where {T,I<:AbstractUnitRange}) =
+    S.parent.nzval
+
+
 """
     nnz(A)
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -40,7 +40,7 @@ size(S::SparseMatrixCSC) = (S.m, S.n)
 # underlying SparseMatrixCSC
 const SparseMatrixCSCView{Tv,Ti} =
     SubArray{Tv,2,SparseMatrixCSC{Tv,Ti},
-        Tuple{Base.Slice{Base.OneTo{Int64}},I}} where {I<:AbstractUnitRange}
+        Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractUnitRange}
 const SparseMatrixCSCUnion{Tv,Ti} = Union{SparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
 
 getcolptr(S::SparseMatrixCSC)     = S.colptr

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -30,9 +30,10 @@ end
 SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
     SparseVector{Tv,Ti}(n, nzind, nzval)
 
-const AbstractSparseVectorUnion{T<:Number} =
-    Union{AbstractSparseVector{T},
-          SubArray{T,1,<:AbstractSparseArray,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false}}
+# Define an alias for a view of a whole column of a SparseMatrixCSC. Many methods can be written for the
+# union of such a view and a SparseVector so we define an alias for such a union as well
+const SparseVectorView{T}  = SubArray{T,1,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false}
+const SparseVectorUnion{T} = Union{SparseVector{T}, SparseVectorView{T}}
 
 ### Basic properties
 
@@ -43,18 +44,18 @@ countnz(x::SparseVector) = countnz(x.nzval)
 count(x::SparseVector) = count(x.nzval)
 
 nonzeros(x::SparseVector) = x.nzval
-function nonzeros(x::SubArray{T,1,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false} where T)
+function nonzeros(x::SparseVectorView)
     rowidx, colidx = parentindexes(x)
     A = parent(x)
-    @inbounds y = view(A.nzval, A.colptr[colidx]:A.colptr[colidx + 1] - 1)
+    @inbounds y = view(A.nzval, nzrange(A, colidx))
     return y
 end
 
 nonzeroinds(x::SparseVector) = x.nzind
-function nonzeroinds(x::SubArray{T,1,<:AbstractSparseArray,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false} where T)
+function nonzeroinds(x::SparseVectorView)
     rowidx, colidx = parentindexes(x)
     A = parent(x)
-    @inbounds y = view(A.rowval, A.colptr[colidx]:A.colptr[colidx + 1] - 1)
+    @inbounds y = view(A.rowval, nzrange(A, colidx))
     return y
 end
 
@@ -1414,7 +1415,7 @@ for f in [:sum, :maximum, :minimum], op in [:abs, :abs2]
     end
 end
 
-vecnorm(x::AbstractSparseVector, p::Real=2) = vecnorm(nonzeros(x), p)
+vecnorm(x::SparseVectorUnion, p::Real=2) = vecnorm(nonzeros(x), p)
 
 ### linalg.jl
 
@@ -1427,7 +1428,7 @@ vecnorm(x::AbstractSparseVector, p::Real=2) = vecnorm(nonzeros(x), p)
 
 # axpy
 
-function LinAlg.axpy!(a::Number, x::AbstractSparseVectorUnion, y::StridedVector)
+function LinAlg.axpy!(a::Number, x::SparseVectorUnion, y::StridedVector)
     length(x) == length(y) || throw(DimensionMismatch())
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
@@ -1472,7 +1473,7 @@ broadcast(::typeof(*), a::Number, x::AbstractSparseVector) = a * x
 broadcast(::typeof(/), x::AbstractSparseVector, a::Number) = x / a
 
 # dot
-function dot(x::StridedVector{Tx}, y::AbstractSparseVector{Ty}) where {Tx<:Number,Ty<:Number}
+function dot(x::StridedVector{Tx}, y::SparseVectorUnion{Ty}) where {Tx<:Number,Ty<:Number}
     n = length(x)
     length(y) == n || throw(DimensionMismatch())
     nzind = nonzeroinds(y)
@@ -1484,7 +1485,7 @@ function dot(x::StridedVector{Tx}, y::AbstractSparseVector{Ty}) where {Tx<:Numbe
     return s
 end
 
-function dot(x::AbstractSparseVector{Tx}, y::AbstractVector{Ty}) where {Tx<:Number,Ty<:Number}
+function dot(x::SparseVectorUnion{Tx}, y::AbstractVector{Ty}) where {Tx<:Number,Ty<:Number}
     n = length(y)
     length(x) == n || throw(DimensionMismatch())
     nzind = nonzeroinds(x)
@@ -1517,7 +1518,7 @@ function _spdot(f::Function,
     s
 end
 
-function dot(x::AbstractSparseVectorUnion{<:Number}, y::AbstractSparseVectorUnion{<:Number})
+function dot(x::SparseVectorUnion{<:Number}, y::SparseVectorUnion{<:Number})
     x === y && return sum(abs2, x)
     n = length(x)
     length(y) == n || throw(DimensionMismatch())
@@ -1536,7 +1537,7 @@ end
 ### BLAS-2 / dense A * sparse x -> dense y
 
 # lowrankupdate (BLAS.ger! like)
-function LinAlg.lowrankupdate!(A::StridedMatrix, x::StridedVector, y::AbstractSparseVectorUnion, α::Number = 1)
+function LinAlg.lowrankupdate!(A::StridedMatrix, x::StridedVector, y::SparseVectorUnion, α::Number = 1)
     nzi = nonzeroinds(y)
     nzv = nonzeros(y)
     @inbounds for (j,v) in zip(nzi,nzv)

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -43,7 +43,7 @@ countnz(x::SparseVector) = countnz(x.nzval)
 count(x::SparseVector) = count(x.nzval)
 
 nonzeros(x::SparseVector) = x.nzval
-function nonzeros(x::SubArray{T,1,<:AbstractSparseArray,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false} where T)
+function nonzeros(x::SubArray{T,1,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false} where T)
     rowidx, colidx = parentindexes(x)
     A = parent(x)
     @inbounds y = view(A.nzval, A.colptr[colidx]:A.colptr[colidx + 1] - 1)

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -30,6 +30,10 @@ end
 SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
     SparseVector{Tv,Ti}(n, nzind, nzval)
 
+const AbstractSparseVectorUnion{T<:Number} =
+    Union{AbstractSparseVector{T},
+          SubArray{T,1,<:AbstractSparseArray,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false}}
+
 ### Basic properties
 
 length(x::SparseVector) = x.n
@@ -37,8 +41,22 @@ size(x::SparseVector) = (x.n,)
 nnz(x::SparseVector) = length(x.nzval)
 countnz(x::SparseVector) = countnz(x.nzval)
 count(x::SparseVector) = count(x.nzval)
+
 nonzeros(x::SparseVector) = x.nzval
+function nonzeros(x::SubArray{T,1,<:AbstractSparseArray,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false} where T)
+    rowidx, colidx = parentindexes(x)
+    A = parent(x)
+    @inbounds y = view(A.nzval, A.colptr[colidx]:A.colptr[colidx + 1] - 1)
+    return y
+end
+
 nonzeroinds(x::SparseVector) = x.nzind
+function nonzeroinds(x::SubArray{T,1,<:AbstractSparseArray,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false} where T)
+    rowidx, colidx = parentindexes(x)
+    A = parent(x)
+    @inbounds y = view(A.rowval, A.colptr[colidx]:A.colptr[colidx + 1] - 1)
+    return y
+end
 
 similar(x::SparseVector, Tv::Type=eltype(x)) = SparseVector(x.n, copy(x.nzind), Vector{Tv}(length(x.nzval)))
 function similar(x::SparseVector, ::Type{Tv}, ::Type{Ti}) where {Tv,Ti}
@@ -1409,7 +1427,7 @@ vecnorm(x::AbstractSparseVector, p::Real=2) = vecnorm(nonzeros(x), p)
 
 # axpy
 
-function LinAlg.axpy!(a::Number, x::AbstractSparseVector, y::StridedVector)
+function LinAlg.axpy!(a::Number, x::AbstractSparseVectorUnion, y::StridedVector)
     length(x) == length(y) || throw(DimensionMismatch())
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
@@ -1454,7 +1472,6 @@ broadcast(::typeof(*), a::Number, x::AbstractSparseVector) = a * x
 broadcast(::typeof(/), x::AbstractSparseVector, a::Number) = x / a
 
 # dot
-
 function dot(x::StridedVector{Tx}, y::AbstractSparseVector{Ty}) where {Tx<:Number,Ty<:Number}
     n = length(x)
     length(y) == n || throw(DimensionMismatch())
@@ -1473,7 +1490,7 @@ function dot(x::AbstractSparseVector{Tx}, y::AbstractVector{Ty}) where {Tx<:Numb
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
     s = zero(Tx) * zero(Ty)
-    for i = 1:length(nzind)
+    @inbounds for i = 1:length(nzind)
         s += conj(nzval[i]) * y[nzind[i]]
     end
     return s
@@ -1500,7 +1517,7 @@ function _spdot(f::Function,
     s
 end
 
-function dot(x::AbstractSparseVector{<:Number}, y::AbstractSparseVector{<:Number})
+function dot(x::AbstractSparseVectorUnion{<:Number}, y::AbstractSparseVectorUnion{<:Number})
     x === y && return sum(abs2, x)
     n = length(x)
     length(y) == n || throw(DimensionMismatch())
@@ -1517,6 +1534,19 @@ end
 
 
 ### BLAS-2 / dense A * sparse x -> dense y
+
+# lowrankupdate (BLAS.ger! like)
+function LinAlg.lowrankupdate!(A::StridedMatrix, x::StridedVector, y::AbstractSparseVectorUnion, α::Number = 1)
+    nzi = nonzeroinds(y)
+    nzv = nonzeros(y)
+    @inbounds for (j,v) in zip(nzi,nzv)
+        αv = α*v'
+        for i in indices(x, 1)
+            A[i,j] += x[i]*αv
+        end
+    end
+    return A
+end
 
 # A_mul_B
 

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -32,8 +32,8 @@ SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
 
 # Define an alias for a view of a whole column of a SparseMatrixCSC. Many methods can be written for the
 # union of such a view and a SparseVector so we define an alias for such a union as well
-const SparseVectorView{T}  = SubArray{T,1,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int64}},Int64},false}
-const SparseVectorUnion{T} = Union{SparseVector{T}, SparseVectorView{T}}
+const SparseColumnView{T}  = SubArray{T,1,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
+const SparseVectorUnion{T} = Union{SparseVector{T}, SparseColumnView{T}}
 
 ### Basic properties
 
@@ -44,7 +44,7 @@ countnz(x::SparseVector) = countnz(x.nzval)
 count(x::SparseVector) = count(x.nzval)
 
 nonzeros(x::SparseVector) = x.nzval
-function nonzeros(x::SparseVectorView)
+function nonzeros(x::SparseColumnView)
     rowidx, colidx = parentindexes(x)
     A = parent(x)
     @inbounds y = view(A.nzval, nzrange(A, colidx))
@@ -52,7 +52,7 @@ function nonzeros(x::SparseVectorView)
 end
 
 nonzeroinds(x::SparseVector) = x.nzind
-function nonzeroinds(x::SparseVectorView)
+function nonzeroinds(x::SparseColumnView)
     rowidx, colidx = parentindexes(x)
     A = parent(x)
     @inbounds y = view(A.rowval, nzrange(A, colidx))

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -39,29 +39,29 @@ const RTX_EQUALS_ETB = Int32(3) # solve R'*X=E'*B  or X = R'\(E'*B)
 
 
 using ..SparseArrays: SparseMatrixCSC
-using ..SparseArrays.CHOLMOD: C_Dense, C_Sparse, Dense, ITypes, Sparse, SuiteSparseStruct, VTypes, common
+using ..SparseArrays.CHOLMOD
 
 import Base: size
-import Base.LinAlg: qrfact
-import ..SparseArrays.CHOLMOD: convert, free!
+import Base.LinAlg: qr, qrfact
+import ..CHOLMOD: convert, free!
 
-struct C_Factorization{Tv<:VTypes} <: SuiteSparseStruct
+struct C_Factorization{Tv<:CHOLMOD.VTypes} <: CHOLMOD.SuiteSparseStruct
     xtype::Cint
     factors::Ptr{Tv}
 end
 
-mutable struct Factorization{Tv<:VTypes} <: Base.LinAlg.Factorization{Tv}
+mutable struct Factorization{Tv<:CHOLMOD.VTypes} <: Base.LinAlg.Factorization{Tv}
     m::Int
     n::Int
     p::Ptr{C_Factorization{Tv}}
-    function Factorization{Tv}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where Tv<:VTypes
+    function Factorization{Tv}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where Tv<:CHOLMOD.VTypes
         if p == C_NULL
             throw(ArgumentError("factorization failed for unknown reasons. Please submit a bug report."))
         end
         new(m, n, p)
     end
 end
-Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where Tv<:VTypes = Factorization{Tv}(m, n, p)
+Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where Tv<:CHOLMOD.VTypes = Factorization{Tv}(m, n, p)
 
 size(F::Factorization) = (F.m, F.n)
 function size(F::Factorization, i::Integer)
@@ -76,37 +76,37 @@ function size(F::Factorization, i::Integer)
     return 1
 end
 
-function free!(F::Factorization{Tv}) where Tv<:VTypes
+function free!(F::Factorization{Tv}) where {Tv<:VTypes}
     ccall((:SuiteSparseQR_C_free, :libspqr), Cint,
         (Ptr{Ptr{C_Factorization{Tv}}}, Ptr{Void}),
-            &F.p, common()) == 1
+            &F.p, CHOLMOD.common()) == 1
 end
 
-function backslash(ordering::Integer, tol::Real, A::Sparse{Tv}, B::Dense{Tv}) where Tv<:VTypes
+function backslash(ordering::Integer, tol::Real, A::Sparse{Tv}, B::Dense{Tv}) where {Tv<:VTypes}
     m, n  = size(A)
     if m != size(B, 1)
         throw(DimensionMismatch("left hand side and right hand side must have same number of rows"))
     end
-    d = Dense(ccall((:SuiteSparseQR_C_backslash, :libspqr), Ptr{C_Dense{Tv}},
-        (Cint, Cdouble, Ptr{C_Sparse{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-            ordering, tol, get(A.p), get(B.p), common()))
+    d = Dense(ccall((:SuiteSparseQR_C_backslash, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
+        (Cint, Cdouble, Ptr{CHOLMOD.C_Sparse{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
+            ordering, tol, get(A.p), get(B.p), CHOLMOD.common()))
     finalizer(d, free!)
     d
 end
 
-function factorize(ordering::Integer, tol::Real, A::Sparse{Tv}) where Tv<:VTypes
+function factorize(ordering::Integer, tol::Real, A::Sparse{Tv}) where {Tv<:VTypes}
     s = unsafe_load(A.p)
     if s.stype != 0
         throw(ArgumentError("stype must be zero"))
     end
     f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv}},
         (Cint, Cdouble, Ptr{Sparse{Tv}}, Ptr{Void}),
-            ordering, tol, get(A.p), common()))
+            ordering, tol, get(A.p), CHOLMOD.common()))
     finalizer(f, free!)
     f
 end
 
-function solve(system::Integer, QR::Factorization{Tv}, B::Dense{Tv}) where Tv<:VTypes
+function solve(system::Integer, QR::Factorization{Tv}, B::Dense{Tv}) where {Tv<:VTypes}
     m, n = size(QR)
     mB = size(B, 1)
     if (system == RX_EQUALS_B || system == RETX_EQUALS_B) && m != mB
@@ -114,14 +114,14 @@ function solve(system::Integer, QR::Factorization{Tv}, B::Dense{Tv}) where Tv<:V
     elseif (system == RTX_EQUALS_ETB || system == RTX_EQUALS_B) && n != mB
         throw(DimensionMismatch("number of columns in factorized matrix must equal number of rows in right hand side"))
     end
-    d = Dense(ccall((:SuiteSparseQR_C_solve, :libspqr), Ptr{C_Dense{Tv}},
-        (Cint, Ptr{C_Factorization{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-            system, get(QR.p), get(B.p), common()))
+    d = Dense(ccall((:SuiteSparseQR_C_solve, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
+        (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
+            system, get(QR.p), get(B.p), CHOLMOD.common()))
     finalizer(d, free!)
     d
 end
 
-function qmult(method::Integer, QR::Factorization{Tv}, X::Dense{Tv}) where Tv<:VTypes
+function qmult(method::Integer, QR::Factorization{Tv}, X::Dense{Tv}) where {Tv<:VTypes}
     mQR, nQR = size(QR)
     mX, nX = size(X)
     if (method == QTX || method == QX) && mQR != mX
@@ -129,15 +129,138 @@ function qmult(method::Integer, QR::Factorization{Tv}, X::Dense{Tv}) where Tv<:V
     elseif (method == XQT || method == XQ) && mQR != nX
         throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $nX columns"))
     end
-    d = Dense(ccall((:SuiteSparseQR_C_qmult, :libspqr), Ptr{C_Dense{Tv}},
-            (Cint, Ptr{C_Factorization{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-                method, get(QR.p), get(X.p), common()))
+    d = Dense(ccall((:SuiteSparseQR_C_qmult, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
+            (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
+                method, get(QR.p), get(X.p), CHOLMOD.common()))
     finalizer(d, free!)
     d
 end
+    # int ordering,           // all, except 3:given treated as 0:fixed
+    # double tol,             // columns with 2-norm <= tol are treated as 0
+    # Long econ,              // e = max(min(m,econ),rank(A))
+    # int getCTX,             // 0: Z=C (e-by-k), 1: Z=C', 2: Z=X (e-by-k)
+    # cholmod_sparse *A,      // m-by-n sparse matrix to factorize
+    # cholmod_sparse *Bsparse,// sparse m-by-k B
+    # cholmod_dense  *Bdense, // dense  m-by-k B
+    # // outputs:
+    # cholmod_sparse **Zsparse,   // sparse Z
+    # cholmod_dense  **Zdense,    // dense Z
+    # cholmod_sparse **R,     // R factor, e-by-n
+    # Long **E,               // size n column permutation, NULL if identity
+    # cholmod_sparse **H,     // m-by-nh Householder vectors
+    # Long **HPinv,           // size m row permutation
+    # cholmod_dense **HTau,   // 1-by-nh Householder coefficients
+    # cholmod_common *cc
 
+function _qr!(ordering, tol, econ, getCTX, A::Ptr{CHOLMOD.C_Sparse{Tv}},
+    Bsparse::Ptr{CHOLMOD.C_Sparse{Tv}}        = Ptr{CHOLMOD.C_Sparse{Tv}}(C_NULL),
+    Bdense::Ptr{CHOLMOD.C_Dense{Tv}}          = Ptr{CHOLMOD.C_Dense{Tv}}(C_NULL),
+    Zsparse::Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}   = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
+    Zdense::Ref{Ptr{CHOLMOD.C_Dense{Tv}}}     = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL),
+    R::Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}         = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
+    E::Ref{Ptr{CHOLMOD.SuiteSparse_long}}     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}(C_NULL),
+    H::Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}         = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
+    HPinv::Ref{Ptr{CHOLMOD.SuiteSparse_long}} = Ref{Ptr{CHOLMOD.SuiteSparse_long}}(C_NULL),
+    HTau::Ref{Ptr{CHOLMOD.C_Dense{Tv}}}       = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)) where Tv<:CHOLMOD.VTypes
 
-qrfact(A::SparseMatrixCSC, ::Val{true}) = factorize(ORDERING_DEFAULT, DEFAULT_TOL, Sparse(A, 0))
+    AA   = unsafe_load(A)
+    m, n = AA.nrow, AA.ncol
+    rnk  = ccall((:SuiteSparseQR_C, :libspqr), CHOLMOD.SuiteSparse_long,
+        (Cint, Cdouble, CHOLMOD.SuiteSparse_long, Cint,
+         Ptr{CHOLMOD.C_Sparse{Tv}}, Ptr{CHOLMOD.C_Sparse{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}},
+         Ptr{Ptr{CHOLMOD.C_Sparse{Tv}}}, Ptr{Ptr{CHOLMOD.C_Dense{Tv}}}, Ptr{Ptr{CHOLMOD.C_Sparse{Tv}}},
+         Ptr{Ptr{CHOLMOD.SuiteSparse_long}}, Ptr{Ptr{CHOLMOD.C_Sparse{Tv}}}, Ptr{Ptr{CHOLMOD.SuiteSparse_long}},
+         Ptr{Ptr{CHOLMOD.C_Dense{Tv}}}, Ptr{Void}),
+        ordering,       # all, except 3:given treated as 0:fixed
+        tol,            # columns with 2-norm <= tol treated as 0
+        econ,           # e = max(min(m,econ),rank(A))
+        getCTX,         # 0: Z=C (e-by-k), 1: Z=C', 2: Z=X (e-by-k)
+        A,              # m-by-n sparse matrix to factorize
+        Bsparse,        # sparse m-by-k B
+        Bdense,         # dense  m-by-k B
+        # /* outputs: */
+        Zsparse,        # sparse Z
+        Zdense,         # dense Z
+        R,              # e-by-n sparse matrix */
+        E,              # size n column perm, NULL if identity */
+        H,              # m-by-nh Householder vectors
+        HPinv,          # size m row permutation
+        HTau,           # 1-by-nh Householder coefficients
+        CHOLMOD.common()) # /* workspace and parameters */
+
+    if rnk < 0
+        error("Sparse QR factorization failed")
+    end
+
+    e = E[]
+    if e == C_NULL
+        _E = Vector{CHOLMOD.SuiteSparse_long}()
+    else
+        _E = Vector{CHOLMOD.SuiteSparse_long}(n)
+        for i in 1:n
+            @inbounds _E[i] = unsafe_load(e, i) + 1
+        end
+        # Free memory allocated by SPQR. This call will make sure that the
+        # correct deallocator function is called and that the memory count in
+        # the common struct is updated
+        ccall((:cholmod_l_free, :libcholmod), Void,
+            (Csize_t, Cint, Ptr{CHOLMOD.SuiteSparse_long}, Ptr{Void}),
+            n, sizeof(CHOLMOD.SuiteSparse_long), e, CHOLMOD.common())
+    end
+    hpinv = HPinv[]
+    if hpinv == C_NULL
+        _HPinv = Vector{CHOLMOD.SuiteSparse_long}()
+    else
+        _HPinv = Vector{CHOLMOD.SuiteSparse_long}(m)
+        for i in 1:m
+            @inbounds _HPinv[i] = unsafe_load(hpinv, i) + 1
+        end
+        # Free memory allocated by SPQR. This call will make sure that the
+        # correct deallocator function is called and that the memory count in
+        # the common struct is updated
+        ccall((:cholmod_l_free, :libcholmod), Void,
+            (Csize_t, Cint, Ptr{CHOLMOD.SuiteSparse_long}, Ptr{Void}),
+            m, sizeof(CHOLMOD.SuiteSparse_long), hpinv, CHOLMOD.common())
+    end
+
+    return rnk, _E, _HPinv
+end
+# _qr{Tv<:CHOLMOD.VTypes}(Q, R, E, A::Sparse{Tv}, ordering, tol, econ) =
+#     _qr!(Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(),
+#         Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(),
+#         Ref{Ptr{CHOLMOD.SuiteSparse_long}}(),
+#         A, ordering, tol, econ)
+function Base.LinAlg.qr(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = size(A, 1)*eps()) where Tv <: CHOLMOD.VTypes
+
+    R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
+    E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
+    H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
+    HPinv = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
+    HTau  = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)
+
+    r, p, hpinv = _qr!(ORDERING_DEFAULT, tol, 0, 0, CHOLMOD.Sparse(A).p,
+        Ptr{CHOLMOD.C_Sparse{Tv}}(C_NULL),
+        Ptr{CHOLMOD.C_Dense{Tv}}(C_NULL),
+        Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
+        Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL),
+        R, E, H, HPinv, HTau)
+    return SparseMatrixCSC(Sparse(H[])), Array(CHOLMOD.Dense(HTau[])), SparseMatrixCSC(Sparse(R[])), p, hpinv
+end
+# function Base.LinAlg.qr(A::SparseMatrixCSC, ::Type{Val{false}})
+#     Q, R, p, r = _qr(CHOLMOD.Sparse(A), ORDERING_FIXED, 0.0, size(A, 2))
+#     return SparseMatrixCSC(Q), SparseMatrixCSC(R)
+# end
+Base.LinAlg.qr(A::SparseMatrixCSC) = qr(A, Val{true})
+# qrR(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = size(A, 1)*eps()) where Tv =
+#     _qr!(Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(0), Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(), Ref{Ptr{CHOLMOD.SuiteSparse_long}}(),
+#         CHOLMOD.Sparse(A), ORDERING_DEFAULT, tol, 0)
+# function Base.rank(A::SparseMatrixCSC; tol = size(A, 1)*eps())
+#     Q, R, p, r = _qr(CHOLMOD.Sparse(A), ORDERING_DEFAULT, tol, 0)
+#     return r
+# end
+
+### High level API
+qrfact(A::SparseMatrixCSC, ::Type{Val{true}}) = factorize(ORDERING_DEFAULT, DEFAULT_TOL, Sparse(A, 0))
 
 """
     qrfact(A) -> SPQR.Factorization
@@ -174,7 +297,7 @@ function (\)(F::Factorization{Float64}, B::VecOrMat{Complex{Float64}})
     return reinterpret(Complex{Float64}, transpose(reshape(x, (length(x) >> 1), 2)), _ret_size(F, B))
 end
 
-function (\)(F::Factorization{T}, B::StridedVecOrMat{T}) where T<:VTypes
+function (\)(F::Factorization{T}, B::StridedVecOrMat{T}) where {T<:VTypes}
     QtB = qmult(QTX, F, Dense(B))
     convert(typeof(B), solve(RETX_EQUALS_B, F, QtB))
 end

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -43,114 +43,98 @@ using ..SparseArrays.CHOLMOD
 
 import Base: size
 import Base.LinAlg: qr, qrfact
-import ..CHOLMOD: convert, free!
+# import ..CHOLMOD: convert, free!
 
-struct C_Factorization{Tv<:CHOLMOD.VTypes} <: CHOLMOD.SuiteSparseStruct
-    xtype::Cint
-    factors::Ptr{Tv}
-end
+# struct C_Factorization{Tv<:CHOLMOD.VTypes} <: CHOLMOD.SuiteSparseStruct
+#     xtype::Cint
+#     factors::Ptr{Tv}
+# end
 
-mutable struct Factorization{Tv<:CHOLMOD.VTypes} <: Base.LinAlg.Factorization{Tv}
-    m::Int
-    n::Int
-    p::Ptr{C_Factorization{Tv}}
-    function Factorization{Tv}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where Tv<:CHOLMOD.VTypes
-        if p == C_NULL
-            throw(ArgumentError("factorization failed for unknown reasons. Please submit a bug report."))
-        end
-        new(m, n, p)
-    end
-end
-Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where Tv<:CHOLMOD.VTypes = Factorization{Tv}(m, n, p)
+# mutable struct Factorization{Tv<:CHOLMOD.VTypes} <: Base.LinAlg.Factorization{Tv}
+#     m::Int
+#     n::Int
+#     p::Ptr{C_Factorization{Tv}}
+#     function Factorization{Tv}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where {Tv<:CHOLMOD.VTypes}
+#         if p == C_NULL
+#             throw(ArgumentError("factorization failed for unknown reasons. Please submit a bug report."))
+#         end
+#         new(m, n, p)
+#     end
+# end
+# Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where {Tv<:CHOLMOD.VTypes} = Factorization{Tv}(m, n, p)
 
-size(F::Factorization) = (F.m, F.n)
-function size(F::Factorization, i::Integer)
-    if i < 1
-        throw(ArgumentError("dimension must be positive"))
-    end
-    if i == 1
-        return F.m
-    elseif i == 2
-        return F.n
-    end
-    return 1
-end
+# size(F::Factorization) = (F.m, F.n)
+# function size(F::Factorization, i::Integer)
+#     if i < 1
+#         throw(ArgumentError("dimension must be positive"))
+#     end
+#     if i == 1
+#         return F.m
+#     elseif i == 2
+#         return F.n
+#     end
+#     return 1
+# end
 
-function free!(F::Factorization{Tv}) where {Tv<:VTypes}
-    ccall((:SuiteSparseQR_C_free, :libspqr), Cint,
-        (Ptr{Ptr{C_Factorization{Tv}}}, Ptr{Void}),
-            &F.p, CHOLMOD.common()) == 1
-end
+# function free!(F::Factorization{Tv}) where {Tv<:CHOLMOD.VTypes}
+#     ccall((:SuiteSparseQR_C_free, :libspqr), Cint,
+#         (Ptr{Ptr{C_Factorization{Tv}}}, Ptr{Void}),
+#             &F.p, CHOLMOD.common()) == 1
+# end
 
-function backslash(ordering::Integer, tol::Real, A::Sparse{Tv}, B::Dense{Tv}) where {Tv<:VTypes}
-    m, n  = size(A)
-    if m != size(B, 1)
-        throw(DimensionMismatch("left hand side and right hand side must have same number of rows"))
-    end
-    d = Dense(ccall((:SuiteSparseQR_C_backslash, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
-        (Cint, Cdouble, Ptr{CHOLMOD.C_Sparse{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
-            ordering, tol, get(A.p), get(B.p), CHOLMOD.common()))
-    finalizer(d, free!)
-    d
-end
+# function backslash(ordering::Integer, tol::Real, A::Sparse{Tv}, B::Dense{Tv}) where {Tv<:CHOLMOD.VTypes}
+#     m, n  = size(A)
+#     if m != size(B, 1)
+#         throw(DimensionMismatch("left hand side and right hand side must have same number of rows"))
+#     end
+#     d = Dense(ccall((:SuiteSparseQR_C_backslash, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
+#         (Cint, Cdouble, Ptr{CHOLMOD.C_Sparse{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
+#             ordering, tol, get(A.p), get(B.p), CHOLMOD.common()))
+#     finalizer(d, free!)
+#     d
+# end
 
-function factorize(ordering::Integer, tol::Real, A::Sparse{Tv}) where {Tv<:VTypes}
-    s = unsafe_load(A.p)
-    if s.stype != 0
-        throw(ArgumentError("stype must be zero"))
-    end
-    f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv}},
-        (Cint, Cdouble, Ptr{Sparse{Tv}}, Ptr{Void}),
-            ordering, tol, get(A.p), CHOLMOD.common()))
-    finalizer(f, free!)
-    f
-end
+# function factorize(ordering::Integer, tol::Real, A::Sparse{Tv}) where {Tv<:CHOLMOD.VTypes}
+#     s = unsafe_load(A.p)
+#     if s.stype != 0
+#         throw(ArgumentError("stype must be zero"))
+#     end
+#     f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv}},
+#         (Cint, Cdouble, Ptr{Sparse{Tv}}, Ptr{Void}),
+#             ordering, tol, get(A.p), CHOLMOD.common()))
+#     finalizer(f, free!)
+#     f
+# end
 
-function solve(system::Integer, QR::Factorization{Tv}, B::Dense{Tv}) where {Tv<:VTypes}
-    m, n = size(QR)
-    mB = size(B, 1)
-    if (system == RX_EQUALS_B || system == RETX_EQUALS_B) && m != mB
-        throw(DimensionMismatch("number of rows in factorized matrix must equal number of rows in right hand side"))
-    elseif (system == RTX_EQUALS_ETB || system == RTX_EQUALS_B) && n != mB
-        throw(DimensionMismatch("number of columns in factorized matrix must equal number of rows in right hand side"))
-    end
-    d = Dense(ccall((:SuiteSparseQR_C_solve, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
-        (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
-            system, get(QR.p), get(B.p), CHOLMOD.common()))
-    finalizer(d, free!)
-    d
-end
+# function solve(system::Integer, QR::Factorization{Tv}, B::Dense{Tv}) where {Tv<:CHOLMOD.VTypes}
+#     m, n = size(QR)
+#     mB = size(B, 1)
+#     if (system == RX_EQUALS_B || system == RETX_EQUALS_B) && m != mB
+#         throw(DimensionMismatch("number of rows in factorized matrix must equal number of rows in right hand side"))
+#     elseif (system == RTX_EQUALS_ETB || system == RTX_EQUALS_B) && n != mB
+#         throw(DimensionMismatch("number of columns in factorized matrix must equal number of rows in right hand side"))
+#     end
+#     d = Dense(ccall((:SuiteSparseQR_C_solve, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
+#         (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
+#             system, get(QR.p), get(B.p), CHOLMOD.common()))
+#     finalizer(d, free!)
+#     d
+# end
 
-function qmult(method::Integer, QR::Factorization{Tv}, X::Dense{Tv}) where {Tv<:VTypes}
-    mQR, nQR = size(QR)
-    mX, nX = size(X)
-    if (method == QTX || method == QX) && mQR != mX
-        throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $mX rows"))
-    elseif (method == XQT || method == XQ) && mQR != nX
-        throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $nX columns"))
-    end
-    d = Dense(ccall((:SuiteSparseQR_C_qmult, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
-            (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
-                method, get(QR.p), get(X.p), CHOLMOD.common()))
-    finalizer(d, free!)
-    d
-end
-    # int ordering,           // all, except 3:given treated as 0:fixed
-    # double tol,             // columns with 2-norm <= tol are treated as 0
-    # Long econ,              // e = max(min(m,econ),rank(A))
-    # int getCTX,             // 0: Z=C (e-by-k), 1: Z=C', 2: Z=X (e-by-k)
-    # cholmod_sparse *A,      // m-by-n sparse matrix to factorize
-    # cholmod_sparse *Bsparse,// sparse m-by-k B
-    # cholmod_dense  *Bdense, // dense  m-by-k B
-    # // outputs:
-    # cholmod_sparse **Zsparse,   // sparse Z
-    # cholmod_dense  **Zdense,    // dense Z
-    # cholmod_sparse **R,     // R factor, e-by-n
-    # Long **E,               // size n column permutation, NULL if identity
-    # cholmod_sparse **H,     // m-by-nh Householder vectors
-    # Long **HPinv,           // size m row permutation
-    # cholmod_dense **HTau,   // 1-by-nh Householder coefficients
-    # cholmod_common *cc
+# function qmult(method::Integer, QR::Factorization{Tv}, X::Dense{Tv}) where {Tv<:CHOLMOD.VTypes}
+#     mQR, nQR = size(QR)
+#     mX, nX = size(X)
+#     if (method == QTX || method == QX) && mQR != mX
+#         throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $mX rows"))
+#     elseif (method == XQT || method == XQ) && mQR != nX
+#         throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $nX columns"))
+#     end
+#     d = Dense(ccall((:SuiteSparseQR_C_qmult, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
+#             (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
+#                 method, get(QR.p), get(X.p), CHOLMOD.common()))
+#     finalizer(d, free!)
+#     d
+# end
 
 function _qr!(ordering, tol, econ, getCTX, A::Ptr{CHOLMOD.C_Sparse{Tv}},
     Bsparse::Ptr{CHOLMOD.C_Sparse{Tv}}        = Ptr{CHOLMOD.C_Sparse{Tv}}(C_NULL),
@@ -161,7 +145,7 @@ function _qr!(ordering, tol, econ, getCTX, A::Ptr{CHOLMOD.C_Sparse{Tv}},
     E::Ref{Ptr{CHOLMOD.SuiteSparse_long}}     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}(C_NULL),
     H::Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}         = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
     HPinv::Ref{Ptr{CHOLMOD.SuiteSparse_long}} = Ref{Ptr{CHOLMOD.SuiteSparse_long}}(C_NULL),
-    HTau::Ref{Ptr{CHOLMOD.C_Dense{Tv}}}       = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)) where Tv<:CHOLMOD.VTypes
+    HTau::Ref{Ptr{CHOLMOD.C_Dense{Tv}}}       = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)) where {Tv<:CHOLMOD.VTypes}
 
     AA   = unsafe_load(A)
     m, n = AA.nrow, AA.ncol
@@ -230,7 +214,38 @@ end
 #         Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(),
 #         Ref{Ptr{CHOLMOD.SuiteSparse_long}}(),
 #         A, ordering, tol, econ)
-function Base.LinAlg.qr(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = size(A, 1)*eps()) where Tv <: CHOLMOD.VTypes
+
+# Such that A[invperm(p), q] = (I - H[:,1]*τ[1]*H[:,1]')*...*(I - H[:,k]*τ[k]*H[:,k]')*R
+# with k=size(H,2).
+struct QRSparse{Tv,Ti} <: LinAlg.Factorization{Tv}
+    factors::SparseMatrixCSC{Tv,Ti}
+    τ::Vector{Tv}
+    R::SparseMatrixCSC{Tv,Ti}
+    p::Vector{Ti}
+    q::Vector{Ti}
+end
+
+Base.size(F::QRSparse) = (size(F.factors, 1), size(F.R, 2))
+function Base.size(F::QRSparse, i::Integer)
+    if i == 1
+        return size(F.factors, 1)
+    elseif i == 2
+        return size(F.R, 2)
+    elseif i > 2
+        return 1
+    else
+        throw(ArgumentError("second argument must be 1 or 2"))
+    end
+end
+
+struct QRSparseQ{Tv<:CHOLMOD.VTypes,Ti<:Integer} <: LinAlg.AbstractQ{Tv}
+    factors::SparseMatrixCSC{Tv,Ti}
+    τ::Vector{Tv}
+end
+
+Base.size(Q::QRSparseQ) = (size(Q.factors, 1), size(Q.factors, 1))
+
+function Base.LinAlg.qrfact(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = size(A, 1)*eps()) where {Tv <: CHOLMOD.VTypes}
 
     R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
     E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
@@ -238,13 +253,14 @@ function Base.LinAlg.qr(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = size(A,
     HPinv = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
     HTau  = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)
 
-    r, p, hpinv = _qr!(ORDERING_DEFAULT, tol, 0, 0, CHOLMOD.Sparse(A).p,
+    # SPQR doesn't accept symmetric matrices so we explicitly call the Sparse constructor with 0
+    r, p, hpinv = _qr!(ORDERING_DEFAULT, tol, 0, 0, CHOLMOD.Sparse(A, 0).p,
         Ptr{CHOLMOD.C_Sparse{Tv}}(C_NULL),
         Ptr{CHOLMOD.C_Dense{Tv}}(C_NULL),
         Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
         Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL),
         R, E, H, HPinv, HTau)
-    return SparseMatrixCSC(Sparse(H[])), Array(CHOLMOD.Dense(HTau[])), SparseMatrixCSC(Sparse(R[])), p, hpinv
+    return QRSparse(SparseMatrixCSC(Sparse(H[])), vec(Array(CHOLMOD.Dense(HTau[]))), SparseMatrixCSC(Sparse(R[])), p, hpinv)
 end
 # function Base.LinAlg.qr(A::SparseMatrixCSC, ::Type{Val{false}})
 #     Q, R, p, r = _qr(CHOLMOD.Sparse(A), ORDERING_FIXED, 0.0, size(A, 2))
@@ -259,18 +275,103 @@ Base.LinAlg.qr(A::SparseMatrixCSC) = qr(A, Val{true})
 #     return r
 # end
 
+function Base.A_mul_B!(Q::QRSparseQ, A::StridedVecOrMat)
+    if size(A, 1) != size(Q, 1)
+        throw(DimensionMismatch("size(Q) = $(size(Q)) but size(A) = $(size(A))"))
+    end
+    for l in size(Q.factors, 2):-1:1
+        τl = -Q.τ[l]'
+        h = view(Q.factors, :, l)
+        for j in 1:size(A, 2)
+            a = view(A, :, j)
+            LinAlg.axpy!(τl*dot(h, a), h, a)
+        end
+    end
+    return A
+end
+
+function Base.A_mul_B!(A::StridedMatrix, Q::QRSparseQ)
+    if size(A, 2) != size(Q, 1)
+        throw(DimensionMismatch("size(Q) = $(size(Q)) but size(A) = $(size(A))"))
+    end
+    tmp = similar(A, size(A, 1))
+    for l in 1:size(Q.factors, 2)
+        τl = -Q.τ[l]'
+        h = view(Q.factors, :, l)
+        A_mul_B!(tmp, A, h)
+        LinAlg.lowrankupdate!(A, tmp, h, τl)
+    end
+    return A
+end
+
+function Base.Ac_mul_B!(Q::QRSparseQ, A::StridedVecOrMat)
+    if size(A, 1) != size(Q, 1)
+        throw(DimensionMismatch("size(Q) = $(size(Q)) but size(A) = $(size(A))"))
+    end
+    for l in 1:size(Q.factors, 2)
+        τl = -Q.τ[l]
+        h = view(Q.factors, :, l)
+        for j in 1:size(A, 2)
+            a = view(A, :, j)
+            LinAlg.axpy!(τl'*dot(h, a), h, a)
+        end
+    end
+    return A
+end
+
+function Base.A_mul_Bc!(A::StridedMatrix, Q::QRSparseQ)
+    if size(A, 2) != size(Q, 1)
+        throw(DimensionMismatch("size(Q) = $(size(Q)) but size(A) = $(size(A))"))
+    end
+    tmp = similar(A, size(A, 1))
+    for l in size(Q.factors, 2):-1:1
+        τl = -Q.τ[l]
+        h = view(Q.factors, :, l)
+        A_mul_B!(tmp, A, h)
+        LinAlg.lowrankupdate!(A, tmp, h, τl)
+    end
+    return A
+end
+
+# function qrfact2(A::SparseMatrixCSC{Tv}; tol = size(A, 1)*eps()) where {Tv <: CHOLMOD.VTypes}
+#     R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
+#     E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
+#     H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
+#     HPinv = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
+#     HTau  = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)
+
+#     r, q, p = _qr!(ORDERING_DEFAULT, tol, 0, 0, CHOLMOD.Sparse(A).p,
+#         Ptr{CHOLMOD.C_Sparse{Tv}}(C_NULL),
+#         Ptr{CHOLMOD.C_Dense{Tv}}(C_NULL),
+#         Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
+#         Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL),
+#         R, E, H, HPinv, HTau)
+#     QRSparse(SparseMatrixCSC(Sparse(H[])), vec(Array(CHOLMOD.Dense(HTau[]))),
+#              SparseMatrixCSC(Sparse(R[])), p, q)
+# end
+
+Base.LinAlg.getq(F::QRSparse) = QRSparseQ(F.factors, F.τ)
+
+function Base.getindex(F::QRSparse, k::Symbol)
+    if k == :Q
+        return LinAlg.getq(F)
+    else
+        throw(ArgumentError("k must be :Q"))
+    end
+end
+
 ### High level API
-qrfact(A::SparseMatrixCSC, ::Type{Val{true}}) = factorize(ORDERING_DEFAULT, DEFAULT_TOL, Sparse(A, 0))
+# qrfact(A::SparseMatrixCSC, ::Type{Val{true}}) = factorize(ORDERING_DEFAULT, DEFAULT_TOL, Sparse(A, 0))
 
-"""
-    qrfact(A) -> SPQR.Factorization
+# """
+#     qrfact(A) -> SPQR.Factorization
 
-Compute the `QR` factorization of a sparse matrix `A`. A fill-reducing permutation is used.
-The main application of this type is to solve least squares problems with [`\\`](@ref). The function
-calls the C library SPQR and a few additional functions from the library are wrapped but not
-exported.
-"""
-qrfact(A::SparseMatrixCSC) = qrfact(A, Val(true))
+# Compute the `QR` factorization of a sparse matrix `A`. A fill-reducing permutation is used.
+# The main application of this type is to solve least squares problems with [`\\`](@ref). The function
+# calls the C library SPQR and a few additional functions from the library are wrapped but not
+# exported.
+# """
+qrfact(A::SparseMatrixCSC) = qrfact(A, Val{true})
 
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
@@ -279,10 +380,10 @@ qrfact(A::SparseMatrixCSC) = qrfact(A, Val(true))
 # here we have to use \ instead of A_ldiv_B! because of limitations in SPQR
 
 ## Two helper methods
-_ret_size(F::Factorization, b::AbstractVector) = (size(F, 2),)
-_ret_size(F::Factorization, B::AbstractMatrix) = (size(F, 2), size(B, 2))
+_ret_size(F::QRSparse, b::AbstractVector) = (size(F, 2),)
+_ret_size(F::QRSparse, B::AbstractMatrix) = (size(F, 2), size(B, 2))
 
-function (\)(F::Factorization{Float64}, B::VecOrMat{Complex{Float64}})
+function (\)(F::QRSparse{Float64}, B::VecOrMat{Complex{Float64}})
 # |z1|z3|  reinterpret  |x1|x2|x3|x4|  transpose  |x1|y1|  reshape  |x1|y1|x3|y3|
 # |z2|z4|      ->       |y1|y2|y3|y4|     ->      |x2|y2|     ->    |x2|y2|x4|y4|
 #                                                 |x3|y3|
@@ -297,11 +398,84 @@ function (\)(F::Factorization{Float64}, B::VecOrMat{Complex{Float64}})
     return reinterpret(Complex{Float64}, transpose(reshape(x, (length(x) >> 1), 2)), _ret_size(F, B))
 end
 
-function (\)(F::Factorization{T}, B::StridedVecOrMat{T}) where {T<:VTypes}
-    QtB = qmult(QTX, F, Dense(B))
-    convert(typeof(B), solve(RETX_EQUALS_B, F, QtB))
-end
+# function (\)(F::Factorization{T}, B::StridedVecOrMat{T}) where {T<:CHOLMOD.VTypes}
+#     QtB = qmult(QTX, F, Dense(B))
+#     convert(typeof(B), solve(RETX_EQUALS_B, F, QtB))
+# end
 
-(\)(F::Factorization, B::StridedVecOrMat) = F\convert(AbstractArray{eltype(F)}, B)
+# (\)(F::Factorization, B::StridedVecOrMat) = F\convert(AbstractArray{eltype(F)}, B)
+
+# function (\)(F::QRSparse{T}, B::StridedVecOrMat{T}) where {T<:CHOLMOD.VTypes}
+#     rnk = maximum(F.R.rowval)
+#     x0  = LinAlg.getq(F)'*B[invperm(F.q)]
+#     A_ldiv_B!(UpperTriangular(F.R[Base.OneTo(rnk),Base.OneTo(rnk)]), view(x0, Base.OneTo(rnk)))
+#     x0[rnk + 1:size(F.R,2),:] = 0
+#     convert(typeof(B), x0[invperm(F.p)])
+# end
+
+function _ldiv_basic(F::QRSparse, B::StridedVecOrMat)
+    if size(F, 1) != size(B, 1)
+        throw(DimensionMismatch("size(F) = $(size(F)) but size(B) = $(size(B))"))
+    end
+    # The rank of F equal to the number of rows in R
+    rnk = size(F.R,1)
+    # allocate an array for the return value large enough to hold B and X
+    # For overdetermined problem, B is larger than X and vice versa
+    X   = similar(B, ntuple(i -> i == 1 ? max(size(F, 2), size(B, 1)) : size(B, 2), Val{ndims(B)}))
+    # Fill will zeros. These will eventually become the zeros in the basic solution
+    # fill!(X, 0)
+    # Apply left permutation to the solution and store in X
+    for j in 1:size(B, 2)
+        for i in 1:length(F.q)
+            @inbounds X[F.q[i], j] = B[i, j]
+        end
+    end
+    # Make a view into x correstonding to the size of b
+    X0 = view(X, 1:size(B, 1), :)
+    # Apply Q' to B
+    Ac_mul_B!(LinAlg.getq(F), X0)
+    # Zero out to get basic solution
+    X[rnk + 1:end, :] = 0
+    # Solve R*X = B
+    A_ldiv_B!(UpperTriangular(view(F.R, :, Base.OneTo(rnk))), view(X0, Base.OneTo(rnk), :))
+    # Apply right permutation and extract solution from x
+    return getindex(X, ntuple(i -> i == 1 ? invperm(F.p) : :, Val{ndims(B)})...)
+end
+# function _ldiv_basic(F::QRSparse, B::StridedMatrix)
+#     rnk = size(F.R,1)
+#     x0  = Ac_mul_B!(LinAlg.getq(F), B[invperm(F.q),:])
+#     A_ldiv_B!(UpperTriangular(view(F.R, :, Base.OneTo(rnk))), view(x0, Base.OneTo(rnk), :))
+#     x0[rnk + 1:end, :] = 0
+#     return x0[invperm(F.p),:]
+# end
+(\)(F::QRSparse{T}, B::StridedVecOrMat{T}) where {T} = _ldiv_basic(F, B)
+(\)(F::QRSparse, B::StridedVecOrMat) = F\convert(AbstractArray{eltype(F)}, B)
+
+
+# inv(A'A)*A'b
+# Pl*A*Pr = Q*R
+# A = Pl'*Q*R*Pr'
+# inv(Pr*R'R*Pr')*Pr*R'*Q'*Pl*b
+# Pr*inv(R)*Q'*Pl*b
+
+# A*x = b
+# Pl'*Q*R*Pr'*x = b
+# R*pr'*x = Q'*Pl*b
+# pr'*x = inv(R)*Q'*Pl*b
+
+# [R0 R1]*[x0;x1] = b
+# R0*x0 + R1*x1 = b
+# x0 + inv(R0)*R1*x1 = inv(R0)*b
+# R0*inv(R0)*(b - R1*x1) + R1*x1 = b
+
+# x0'x0 + x1'x1
+# (inv(R0)*(b - R1*x1))'(inv(R0)*(b - R1*x1)) + x1'x1
+# (b - R1*x1)'*inv(R0)'inv(R0)*(b - R1*x1) + x1'x1
+# b'inv(R0)'inv(R0)*b + x1'R1'*inv(R0)'inv(R0)*R1*x1 -2*x1'R1*inv(R0)'inv(R0)*b + x1'x1
+
+# (R1'inv(R0)'*inv(R0)*R1 + I)*x1 = R1*inv(R0)'inv(R0)*b
+# (R2'R2 + I)*x1 = R2'b2
+# x1 = inv(R2'R2 + I)*R2'b2
+# x0 = b2 - R2*x1
 
 end # module

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -25,116 +25,11 @@ const ORDERING_BESTAMD = Int32(9) # try COLAMD and AMD; pick best#
 const DEFAULT_TOL = Int32(-2) # if tol <= -2, the default tol is used
 const NO_TOL      = Int32(-1) # if -2 < tol < 0, then no tol is used
 
-# for qmult, method can be 0,1,2,3:
-const QTX = Int32(0)
-const QX  = Int32(1)
-const XQT = Int32(2)
-const XQ  = Int32(3)
-
-# system can be 0,1,2,3:  Given Q*R=A*E from SuiteSparseQR_factorize:
-const RX_EQUALS_B    = Int32(0) # solve R*X=B      or X = R\B
-const RETX_EQUALS_B  = Int32(1) # solve R*E'*X=B   or X = E*(R\B)
-const RTX_EQUALS_B   = Int32(2) # solve R'*X=B     or X = R'\B
-const RTX_EQUALS_ETB = Int32(3) # solve R'*X=E'*B  or X = R'\(E'*B)
-
-
 using ..SparseArrays: SparseMatrixCSC
 using ..SparseArrays.CHOLMOD
 
 import Base: size
 import Base.LinAlg: qr, qrfact
-# import ..CHOLMOD: convert, free!
-
-# struct C_Factorization{Tv<:CHOLMOD.VTypes} <: CHOLMOD.SuiteSparseStruct
-#     xtype::Cint
-#     factors::Ptr{Tv}
-# end
-
-# mutable struct Factorization{Tv<:CHOLMOD.VTypes} <: Base.LinAlg.Factorization{Tv}
-#     m::Int
-#     n::Int
-#     p::Ptr{C_Factorization{Tv}}
-#     function Factorization{Tv}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where {Tv<:CHOLMOD.VTypes}
-#         if p == C_NULL
-#             throw(ArgumentError("factorization failed for unknown reasons. Please submit a bug report."))
-#         end
-#         new(m, n, p)
-#     end
-# end
-# Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) where {Tv<:CHOLMOD.VTypes} = Factorization{Tv}(m, n, p)
-
-# size(F::Factorization) = (F.m, F.n)
-# function size(F::Factorization, i::Integer)
-#     if i < 1
-#         throw(ArgumentError("dimension must be positive"))
-#     end
-#     if i == 1
-#         return F.m
-#     elseif i == 2
-#         return F.n
-#     end
-#     return 1
-# end
-
-# function free!(F::Factorization{Tv}) where {Tv<:CHOLMOD.VTypes}
-#     ccall((:SuiteSparseQR_C_free, :libspqr), Cint,
-#         (Ptr{Ptr{C_Factorization{Tv}}}, Ptr{Void}),
-#             &F.p, CHOLMOD.common()) == 1
-# end
-
-# function backslash(ordering::Integer, tol::Real, A::Sparse{Tv}, B::Dense{Tv}) where {Tv<:CHOLMOD.VTypes}
-#     m, n  = size(A)
-#     if m != size(B, 1)
-#         throw(DimensionMismatch("left hand side and right hand side must have same number of rows"))
-#     end
-#     d = Dense(ccall((:SuiteSparseQR_C_backslash, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
-#         (Cint, Cdouble, Ptr{CHOLMOD.C_Sparse{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
-#             ordering, tol, get(A.p), get(B.p), CHOLMOD.common()))
-#     finalizer(d, free!)
-#     d
-# end
-
-# function factorize(ordering::Integer, tol::Real, A::Sparse{Tv}) where {Tv<:CHOLMOD.VTypes}
-#     s = unsafe_load(A.p)
-#     if s.stype != 0
-#         throw(ArgumentError("stype must be zero"))
-#     end
-#     f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv}},
-#         (Cint, Cdouble, Ptr{Sparse{Tv}}, Ptr{Void}),
-#             ordering, tol, get(A.p), CHOLMOD.common()))
-#     finalizer(f, free!)
-#     f
-# end
-
-# function solve(system::Integer, QR::Factorization{Tv}, B::Dense{Tv}) where {Tv<:CHOLMOD.VTypes}
-#     m, n = size(QR)
-#     mB = size(B, 1)
-#     if (system == RX_EQUALS_B || system == RETX_EQUALS_B) && m != mB
-#         throw(DimensionMismatch("number of rows in factorized matrix must equal number of rows in right hand side"))
-#     elseif (system == RTX_EQUALS_ETB || system == RTX_EQUALS_B) && n != mB
-#         throw(DimensionMismatch("number of columns in factorized matrix must equal number of rows in right hand side"))
-#     end
-#     d = Dense(ccall((:SuiteSparseQR_C_solve, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
-#         (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
-#             system, get(QR.p), get(B.p), CHOLMOD.common()))
-#     finalizer(d, free!)
-#     d
-# end
-
-# function qmult(method::Integer, QR::Factorization{Tv}, X::Dense{Tv}) where {Tv<:CHOLMOD.VTypes}
-#     mQR, nQR = size(QR)
-#     mX, nX = size(X)
-#     if (method == QTX || method == QX) && mQR != mX
-#         throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $mX rows"))
-#     elseif (method == XQT || method == XQ) && mQR != nX
-#         throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $nX columns"))
-#     end
-#     d = Dense(ccall((:SuiteSparseQR_C_qmult, :libspqr), Ptr{CHOLMOD.C_Dense{Tv}},
-#             (Cint, Ptr{C_Factorization{Tv}}, Ptr{CHOLMOD.C_Dense{Tv}}, Ptr{Void}),
-#                 method, get(QR.p), get(X.p), CHOLMOD.common()))
-#     finalizer(d, free!)
-#     d
-# end
 
 function _qr!(ordering, tol, econ, getCTX, A::Ptr{CHOLMOD.C_Sparse{Tv}},
     Bsparse::Ptr{CHOLMOD.C_Sparse{Tv}}        = Ptr{CHOLMOD.C_Sparse{Tv}}(C_NULL),
@@ -209,11 +104,6 @@ function _qr!(ordering, tol, econ, getCTX, A::Ptr{CHOLMOD.C_Sparse{Tv}},
 
     return rnk, _E, _HPinv
 end
-# _qr{Tv<:CHOLMOD.VTypes}(Q, R, E, A::Sparse{Tv}, ordering, tol, econ) =
-#     _qr!(Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(),
-#         Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(),
-#         Ref{Ptr{CHOLMOD.SuiteSparse_long}}(),
-#         A, ordering, tol, econ)
 
 # Such that A[invperm(p), q] = (I - H[:,1]*τ[1]*H[:,1]')*...*(I - H[:,k]*τ[k]*H[:,k]')*R
 # with k=size(H,2).
@@ -221,8 +111,8 @@ struct QRSparse{Tv,Ti} <: LinAlg.Factorization{Tv}
     factors::SparseMatrixCSC{Tv,Ti}
     τ::Vector{Tv}
     R::SparseMatrixCSC{Tv,Ti}
-    p::Vector{Ti}
-    q::Vector{Ti}
+    cpiv::Vector{Ti}
+    rpivinv::Vector{Ti}
 end
 
 Base.size(F::QRSparse) = (size(F.factors, 1), size(F.R, 2))
@@ -246,7 +136,6 @@ end
 Base.size(Q::QRSparseQ) = (size(Q.factors, 1), size(Q.factors, 1))
 
 function Base.LinAlg.qrfact(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = size(A, 1)*eps()) where {Tv <: CHOLMOD.VTypes}
-
     R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
     E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
     H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
@@ -262,25 +151,15 @@ function Base.LinAlg.qrfact(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = siz
         R, E, H, HPinv, HTau)
     return QRSparse(SparseMatrixCSC(Sparse(H[])), vec(Array(CHOLMOD.Dense(HTau[]))), SparseMatrixCSC(Sparse(R[])), p, hpinv)
 end
-# function Base.LinAlg.qr(A::SparseMatrixCSC, ::Type{Val{false}})
-#     Q, R, p, r = _qr(CHOLMOD.Sparse(A), ORDERING_FIXED, 0.0, size(A, 2))
-#     return SparseMatrixCSC(Q), SparseMatrixCSC(R)
-# end
+
 Base.LinAlg.qr(A::SparseMatrixCSC) = qr(A, Val{true})
-# qrR(A::SparseMatrixCSC{Tv}, ::Type{Val{true}}; tol = size(A, 1)*eps()) where Tv =
-#     _qr!(Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(0), Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(), Ref{Ptr{CHOLMOD.SuiteSparse_long}}(),
-#         CHOLMOD.Sparse(A), ORDERING_DEFAULT, tol, 0)
-# function Base.rank(A::SparseMatrixCSC; tol = size(A, 1)*eps())
-#     Q, R, p, r = _qr(CHOLMOD.Sparse(A), ORDERING_DEFAULT, tol, 0)
-#     return r
-# end
 
 function Base.A_mul_B!(Q::QRSparseQ, A::StridedVecOrMat)
     if size(A, 1) != size(Q, 1)
         throw(DimensionMismatch("size(Q) = $(size(Q)) but size(A) = $(size(A))"))
     end
     for l in size(Q.factors, 2):-1:1
-        τl = -Q.τ[l]'
+        τl = -Q.τ[l]
         h = view(Q.factors, :, l)
         for j in 1:size(A, 2)
             a = view(A, :, j)
@@ -296,7 +175,7 @@ function Base.A_mul_B!(A::StridedMatrix, Q::QRSparseQ)
     end
     tmp = similar(A, size(A, 1))
     for l in 1:size(Q.factors, 2)
-        τl = -Q.τ[l]'
+        τl = -Q.τ[l]
         h = view(Q.factors, :, l)
         A_mul_B!(tmp, A, h)
         LinAlg.lowrankupdate!(A, tmp, h, τl)
@@ -328,49 +207,37 @@ function Base.A_mul_Bc!(A::StridedMatrix, Q::QRSparseQ)
         τl = -Q.τ[l]
         h = view(Q.factors, :, l)
         A_mul_B!(tmp, A, h)
-        LinAlg.lowrankupdate!(A, tmp, h, τl)
+        LinAlg.lowrankupdate!(A, tmp, h, τl')
     end
     return A
 end
 
-# function qrfact2(A::SparseMatrixCSC{Tv}; tol = size(A, 1)*eps()) where {Tv <: CHOLMOD.VTypes}
-#     R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
-#     E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
-#     H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
-#     HPinv = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
-#     HTau  = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)
-
-#     r, q, p = _qr!(ORDERING_DEFAULT, tol, 0, 0, CHOLMOD.Sparse(A).p,
-#         Ptr{CHOLMOD.C_Sparse{Tv}}(C_NULL),
-#         Ptr{CHOLMOD.C_Dense{Tv}}(C_NULL),
-#         Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}(C_NULL),
-#         Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL),
-#         R, E, H, HPinv, HTau)
-#     QRSparse(SparseMatrixCSC(Sparse(H[])), vec(Array(CHOLMOD.Dense(HTau[]))),
-#              SparseMatrixCSC(Sparse(R[])), p, q)
-# end
-
 Base.LinAlg.getq(F::QRSparse) = QRSparseQ(F.factors, F.τ)
 
-function Base.getindex(F::QRSparse, k::Symbol)
-    if k == :Q
+function Base.getindex(F::QRSparse, d::Symbol)
+    if d == :Q
         return LinAlg.getq(F)
+    elseif d == :R
+        return F.R
+    elseif d == :prow
+        return invperm(F.rpivinv)
+    elseif d == :pcol
+        return F.cpiv
     else
-        throw(ArgumentError("k must be :Q"))
+        throw(KeyError(d))
     end
 end
 
 ### High level API
-# qrfact(A::SparseMatrixCSC, ::Type{Val{true}}) = factorize(ORDERING_DEFAULT, DEFAULT_TOL, Sparse(A, 0))
 
-# """
-#     qrfact(A) -> SPQR.Factorization
+"""
+    qrfact(A) -> QRSparse
 
-# Compute the `QR` factorization of a sparse matrix `A`. A fill-reducing permutation is used.
-# The main application of this type is to solve least squares problems with [`\\`](@ref). The function
-# calls the C library SPQR and a few additional functions from the library are wrapped but not
-# exported.
-# """
+Compute the `QR` factorization of a sparse matrix `A`. A fill-reducing permutation is used.
+The main application of this type is to solve least squares problems with [`\\`](@ref). The function
+calls the C library SPQR and a few additional functions from the library are wrapped but not
+exported.
+"""
 qrfact(A::SparseMatrixCSC) = qrfact(A, Val{true})
 
 # With a real lhs and complex rhs with the same precision, we can reinterpret
@@ -398,84 +265,44 @@ function (\)(F::QRSparse{Float64}, B::VecOrMat{Complex{Float64}})
     return reinterpret(Complex{Float64}, transpose(reshape(x, (length(x) >> 1), 2)), _ret_size(F, B))
 end
 
-# function (\)(F::Factorization{T}, B::StridedVecOrMat{T}) where {T<:CHOLMOD.VTypes}
-#     QtB = qmult(QTX, F, Dense(B))
-#     convert(typeof(B), solve(RETX_EQUALS_B, F, QtB))
-# end
-
-# (\)(F::Factorization, B::StridedVecOrMat) = F\convert(AbstractArray{eltype(F)}, B)
-
-# function (\)(F::QRSparse{T}, B::StridedVecOrMat{T}) where {T<:CHOLMOD.VTypes}
-#     rnk = maximum(F.R.rowval)
-#     x0  = LinAlg.getq(F)'*B[invperm(F.q)]
-#     A_ldiv_B!(UpperTriangular(F.R[Base.OneTo(rnk),Base.OneTo(rnk)]), view(x0, Base.OneTo(rnk)))
-#     x0[rnk + 1:size(F.R,2),:] = 0
-#     convert(typeof(B), x0[invperm(F.p)])
-# end
-
 function _ldiv_basic(F::QRSparse, B::StridedVecOrMat)
     if size(F, 1) != size(B, 1)
         throw(DimensionMismatch("size(F) = $(size(F)) but size(B) = $(size(B))"))
     end
+
     # The rank of F equal to the number of rows in R
     rnk = size(F.R,1)
+
     # allocate an array for the return value large enough to hold B and X
     # For overdetermined problem, B is larger than X and vice versa
     X   = similar(B, ntuple(i -> i == 1 ? max(size(F, 2), size(B, 1)) : size(B, 2), Val{ndims(B)}))
+
     # Fill will zeros. These will eventually become the zeros in the basic solution
     # fill!(X, 0)
     # Apply left permutation to the solution and store in X
     for j in 1:size(B, 2)
-        for i in 1:length(F.q)
-            @inbounds X[F.q[i], j] = B[i, j]
+        for i in 1:length(F.rpivinv)
+            @inbounds X[F.rpivinv[i], j] = B[i, j]
         end
     end
+
     # Make a view into x correstonding to the size of b
     X0 = view(X, 1:size(B, 1), :)
+
     # Apply Q' to B
     Ac_mul_B!(LinAlg.getq(F), X0)
+
     # Zero out to get basic solution
     X[rnk + 1:end, :] = 0
+
     # Solve R*X = B
     A_ldiv_B!(UpperTriangular(view(F.R, :, Base.OneTo(rnk))), view(X0, Base.OneTo(rnk), :))
+
     # Apply right permutation and extract solution from x
-    return getindex(X, ntuple(i -> i == 1 ? invperm(F.p) : :, Val{ndims(B)})...)
+    return getindex(X, ntuple(i -> i == 1 ? invperm(F.cpiv) : :, Val{ndims(B)})...)
 end
-# function _ldiv_basic(F::QRSparse, B::StridedMatrix)
-#     rnk = size(F.R,1)
-#     x0  = Ac_mul_B!(LinAlg.getq(F), B[invperm(F.q),:])
-#     A_ldiv_B!(UpperTriangular(view(F.R, :, Base.OneTo(rnk))), view(x0, Base.OneTo(rnk), :))
-#     x0[rnk + 1:end, :] = 0
-#     return x0[invperm(F.p),:]
-# end
+
 (\)(F::QRSparse{T}, B::StridedVecOrMat{T}) where {T} = _ldiv_basic(F, B)
 (\)(F::QRSparse, B::StridedVecOrMat) = F\convert(AbstractArray{eltype(F)}, B)
-
-
-# inv(A'A)*A'b
-# Pl*A*Pr = Q*R
-# A = Pl'*Q*R*Pr'
-# inv(Pr*R'R*Pr')*Pr*R'*Q'*Pl*b
-# Pr*inv(R)*Q'*Pl*b
-
-# A*x = b
-# Pl'*Q*R*Pr'*x = b
-# R*pr'*x = Q'*Pl*b
-# pr'*x = inv(R)*Q'*Pl*b
-
-# [R0 R1]*[x0;x1] = b
-# R0*x0 + R1*x1 = b
-# x0 + inv(R0)*R1*x1 = inv(R0)*b
-# R0*inv(R0)*(b - R1*x1) + R1*x1 = b
-
-# x0'x0 + x1'x1
-# (inv(R0)*(b - R1*x1))'(inv(R0)*(b - R1*x1)) + x1'x1
-# (b - R1*x1)'*inv(R0)'inv(R0)*(b - R1*x1) + x1'x1
-# b'inv(R0)'inv(R0)*b + x1'R1'*inv(R0)'inv(R0)*R1*x1 -2*x1'R1*inv(R0)'inv(R0)*b + x1'x1
-
-# (R1'inv(R0)'*inv(R0)*R1 + I)*x1 = R1*inv(R0)'inv(R0)*b
-# (R2'R2 + I)*x1 = R2'b2
-# x1 = inv(R2'R2 + I)*R2'b2
-# x0 = b2 - R2*x1
 
 end # module

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -344,7 +344,7 @@ function _ldiv_basic(F::QRSparse, B::StridedVecOrMat)
 
     # allocate an array for the return value large enough to hold B and X
     # For overdetermined problem, B is larger than X and vice versa
-    X   = similar(B, ntuple(i -> i == 1 ? max(size(F, 2), size(B, 1)) : size(B, 2), Val{ndims(B)}))
+    X   = similar(B, ntuple(i -> i == 1 ? max(size(F, 2), size(B, 1)) : size(B, 2), Val(ndims(B))))
 
     # Fill will zeros. These will eventually become the zeros in the basic solution
     # fill!(X, 0)
@@ -368,7 +368,7 @@ function _ldiv_basic(F::QRSparse, B::StridedVecOrMat)
     A_ldiv_B!(UpperTriangular(view(F.R, :, Base.OneTo(rnk))), view(X0, Base.OneTo(rnk), :))
 
     # Apply right permutation and extract solution from x
-    return getindex(X, ntuple(i -> i == 1 ? invperm(F.cpiv) : :, Val{ndims(B)})...)
+    return getindex(X, ntuple(i -> i == 1 ? invperm(F.cpiv) : :, Val(ndims(B)))...)
 end
 
 (\)(F::QRSparse{T}, B::StridedVecOrMat{T}) where {T} = _ldiv_basic(F, B)

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -240,7 +240,47 @@ end
 Base.LinAlg.getq(F::QRSparse) = QRSparseQ(F.factors, F.τ)
 
 """
-    getindex
+    getindex(F::QRSparse, d::Symbol)
+
+Extract factors of a QRSparse factorization. Possible values of `d` are
+- :Q : `QRSparseQ` matrix of the ``Q`` factor in Householder form
+- :R : `UpperTriangular` ``R`` factor
+- :prow : Vector of the row permutations applied to the factorized matrix
+- :pcol : Vector of the column permutations applied to the factorized matrix
+
+# Examples
+```jldoctest
+julia> F = qrfact(sparse([1,3,2,3,4], [1,1,2,3,4], [1.0,2.0,3.0,4.0,5.0]));
+
+julia> F[:Q]
+4×4 Base.SparseArrays.SPQR.QRSparseQ{Float64,Int64}:
+ 1.0  0.0  0.0  0.0
+ 0.0  1.0  0.0  0.0
+ 0.0  0.0  1.0  0.0
+ 0.0  0.0  0.0  1.0
+
+julia> F[:R]
+4×4 SparseMatrixCSC{Float64,Int64} with 5 stored entries:
+  [1, 1]  =  3.0
+  [2, 2]  =  4.0
+  [3, 3]  =  5.0
+  [2, 4]  =  2.0
+  [4, 4]  =  1.0
+
+julia> F[:prow]
+4-element Array{Int64,1}:
+ 2
+ 3
+ 4
+ 1
+
+julia> F[:pcol]
+4-element Array{Int64,1}:
+ 2
+ 3
+ 4
+ 1
+```
 """
 function Base.getindex(F::QRSparse, d::Symbol)
     if d == :Q

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -61,6 +61,9 @@ nn = 100
         @test_throws DimensionMismatch A\B[1:m-1,:]
         @test A[1:9,:]*(A[1:9,:]\ones(eltyB, 9)) ≈ ones(9) # Underdetermined system
     end
+
+    # Make sure that conversion to Sparse doesn't use SuiteSparse's symmetric flag
+    @test qrfact(sparse(eye(eltyA, 5)))\ones(eltyA, 5) == ones(5)
 end
 
 @testset "basic solution of rank deficient ls" begin

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -25,13 +25,13 @@ for eltyA in (Float64, Complex{Float64})
         @inferred A\B
         @test A\B[:,1] ≈ Array(A)\B[:,1]
         @test A\B ≈ Array(A)\B
-        @test_throws DimensionMismatch A\B[1:m-1,:]
+        # @test_throws DimensionMismatch A\B[1:m-1,:]
         @test A[1:9,:]*(A[1:9,:]\ones(eltyB, 9)) ≈ ones(9) # Underdetermined system
 
         if eltyA == eltyB # promotions not defined for unexported methods
             @test qrfact(sparse(eye(eltyA, 5)))\ones(eltyA, 5) == ones(5)
-            @test_throws ArgumentError SPQR.factorize(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(sparse(eye(eltyA, 5))))
-            @test_throws ArgumentError SPQR.Factorization(1, 1, convert(Ptr{SPQR.C_Factorization{eltyA}}, C_NULL))
+            # @test_throws ArgumentError SPQR.factorize(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(sparse(eye(eltyA, 5))))
+            # @test_throws ArgumentError SPQR.Factorization(1, 1, convert(Ptr{SPQR.C_Factorization{eltyA}}, C_NULL))
             F = qrfact(A)
             @test size(F) == (m,n)
             @test size(F, 1) == m
@@ -40,12 +40,12 @@ for eltyA in (Float64, Complex{Float64})
             @test_throws ArgumentError size(F, 0)
 
             # low level wrappers
-            @test_throws DimensionMismatch SPQR.solve(SPQR.RX_EQUALS_B, F, CHOLMOD.Dense(B'))
-            @test_throws DimensionMismatch SPQR.solve(SPQR.RTX_EQUALS_B, F, CHOLMOD.Dense(B))
-            @test_throws DimensionMismatch SPQR.qmult(SPQR.QX, F, CHOLMOD.Dense(B'))
-            @test_throws DimensionMismatch SPQR.qmult(SPQR.XQ, F, CHOLMOD.Dense(B))
-            @test A\B ≈ SPQR.backslash(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(A), CHOLMOD.Dense(B))
-            @test_throws DimensionMismatch SPQR.backslash(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(A), CHOLMOD.Dense(B[1:m-1,:]))
+            # @test_throws DimensionMismatch SPQR.solve(SPQR.RX_EQUALS_B, F, CHOLMOD.Dense(B'))
+            # @test_throws DimensionMismatch SPQR.solve(SPQR.RTX_EQUALS_B, F, CHOLMOD.Dense(B))
+            # @test_throws DimensionMismatch SPQR.qmult(SPQR.QX, F, CHOLMOD.Dense(B'))
+            # @test_throws DimensionMismatch SPQR.qmult(SPQR.XQ, F, CHOLMOD.Dense(B))
+            # @test A\B ≈ SPQR.backslash(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(A), CHOLMOD.Dense(B))
+            # @test_throws DimensionMismatch SPQR.backslash(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(A), CHOLMOD.Dense(B[1:m-1,:]))
         end
     end
 end

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -3,17 +3,50 @@
 using Base.SparseArrays.SPQR
 using Base.SparseArrays.CHOLMOD
 
-let
+@testset "Sparse QR" begin
 m, n = 100, 10
 nn = 100
 
-for eltyA in (Float64, Complex{Float64})
-    for eltyB in (Int, Float64, Complex{Float64})
-        if eltyA <: Real
-            A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], randn(nn), m, n)
-        else
-            A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], complex.(randn(nn), randn(nn)), m, n)
-        end
+@test size(qrfact(sprandn(m, n, 0.1))[:Q]) == (m, m)
+
+@testset "element type of A: $eltyA" for eltyA in (Float64, Complex{Float64})
+    if eltyA <: Real
+        A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], randn(nn), m, n)
+    else
+        A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], complex.(randn(nn), randn(nn)), m, n)
+    end
+
+    F = qrfact(A)
+    @test size(F) == (m,n)
+    @test size(F, 1) == m
+    @test size(F, 2) == n
+    @test size(F, 3) == 1
+    @test_throws ArgumentError size(F, 0)
+
+    @testset "getindex" begin
+        @test istriu(F[:R])
+        @test isperm(F[:pcol])
+        @test isperm(F[:prow])
+        @test_throws KeyError F[:T]
+    end
+
+    @testset "apply Q" begin
+        Q = F[:Q]
+        @test Q'*(Q*eye(m)) ≈ eye(m)
+        @test (eye(m)*Q)*Q' ≈ eye(m)
+
+        # test that Q'Pl*A*Pr = R
+        R0 = Q'*full(A[F[:prow], F[:pcol]])
+        @test R0[1:n, :] ≈ F[:R]
+        @test norm(R0[n + 1:end, :], 1) < 1e-12
+
+        @test_throws DimensionMismatch A_mul_B!(Q, eye(m + 1))
+        @test_throws DimensionMismatch Ac_mul_B!(Q, eye(m + 1))
+        @test_throws DimensionMismatch A_mul_B!(eye(m + 1), Q)
+        @test_throws DimensionMismatch A_mul_Bc!(eye(m + 1), Q)
+    end
+
+    @testset "element type of B: $eltyB" for eltyB in (Int, Float64, Complex{Float64})
         if eltyB == Int
             B = rand(1:10, m, 2)
         elseif eltyB <: Real
@@ -25,36 +58,20 @@ for eltyA in (Float64, Complex{Float64})
         @inferred A\B
         @test A\B[:,1] ≈ Array(A)\B[:,1]
         @test A\B ≈ Array(A)\B
-        # @test_throws DimensionMismatch A\B[1:m-1,:]
+        @test_throws DimensionMismatch A\B[1:m-1,:]
         @test A[1:9,:]*(A[1:9,:]\ones(eltyB, 9)) ≈ ones(9) # Underdetermined system
-
-        if eltyA == eltyB # promotions not defined for unexported methods
-            @test qrfact(sparse(eye(eltyA, 5)))\ones(eltyA, 5) == ones(5)
-            # @test_throws ArgumentError SPQR.factorize(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(sparse(eye(eltyA, 5))))
-            # @test_throws ArgumentError SPQR.Factorization(1, 1, convert(Ptr{SPQR.C_Factorization{eltyA}}, C_NULL))
-            F = qrfact(A)
-            @test size(F) == (m,n)
-            @test size(F, 1) == m
-            @test size(F, 2) == n
-            @test size(F, 3) == 1
-            @test_throws ArgumentError size(F, 0)
-
-            # low level wrappers
-            # @test_throws DimensionMismatch SPQR.solve(SPQR.RX_EQUALS_B, F, CHOLMOD.Dense(B'))
-            # @test_throws DimensionMismatch SPQR.solve(SPQR.RTX_EQUALS_B, F, CHOLMOD.Dense(B))
-            # @test_throws DimensionMismatch SPQR.qmult(SPQR.QX, F, CHOLMOD.Dense(B'))
-            # @test_throws DimensionMismatch SPQR.qmult(SPQR.XQ, F, CHOLMOD.Dense(B))
-            # @test A\B ≈ SPQR.backslash(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(A), CHOLMOD.Dense(B))
-            # @test_throws DimensionMismatch SPQR.backslash(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(A), CHOLMOD.Dense(B[1:m-1,:]))
-        end
     end
 end
 
-# Issue 14134
-F = qrfact(sprandn(10,5,0.5))
-b = IOBuffer()
-serialize(b, F)
-seekstart(b)
-@test_throws ArgumentError deserialize(b)\ones(10)
+@testset "basic solution of rank deficient ls" begin
+    A = sprandn(m, 5, 0.9)*sprandn(5, n, 0.9)
+    b = randn(m)
+    xs = A\b
+    xd = full(A)\b
+
+    # check that basic solution has more zeros
+    @test countnz(xs) < countnz(xd)
+    @test A*xs ≈ A*xd
+end
 
 end


### PR DESCRIPTION
I think this is mostly done. The documentation needs to be adjusted a bit.

Instead of storing a void pointer to a SPQR object, this PR extracts the Householder reflectors and loadings, the R factor and the permutations produced by SPQR and store them in the Julia type `SparseQR`. This makes the sparse QR more similar to the other QRs. The SPQR C API doesn't allow you to return these components to the library (as far as I can tell) so a consequence of this change is that Q multiplication and least squares solve must be implemented in Julia. For now, I've implemented the basic solution in the case of rank deficiency. We can add the minimum norm solution later.

cc: @dpo

Update:
The PR includes some general improvements to some functions acting on column views of a sparse matrix. Some the existing methods for sparse matrices require very limited adjustments to become efficient for column views. These changes are pretty selfcontained so I might factor them out of this PR.