### PR TITLE
Add Window Visual Styles to julia.exe

### DIFF
--- a/contrib/windows/julia-manifest.xml
+++ b/contrib/windows/julia-manifest.xml
@@ -7,6 +7,11 @@
       </requestedPrivileges>
     </security>
   </trustInfo>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type='win32'  name='Microsoft.Windows.Common-Controls' version='6.0.0.0'     processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*' />
+    </dependentAssembly>
+  </dependency>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!--The ID below indicates application support for Windows Vista -->


### PR DESCRIPTION
This issue was brought in the Red Language and in discourse topic https://discourse.julialang.org/t/windows-visual-styles-in-julia-exe/4563. Basically it gives a much nicer look to the windows created via `Red`` (and possible other toolkits) by Julia ccall()