### PR TITLE
Define chol for UniformScaling's

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -313,3 +313,27 @@ function hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractVecOrMat,UniformScalin
     end
     return hvcat(rows, promote_to_arrays(n,1, promote_to_array_type(A), A...)...)
 end
+
+
+## Cholesky
+function _chol!(J::UniformScaling, uplo)
+    c, info = _chol!(J.λ, uplo)
+    UniformScaling(c), info
+end
+
+chol!(J::UniformScaling, uplo) = ((J, info) = _chol!(J, uplo); @assertposdef J info)
+
+"""
+    chol(J::UniformScaling) -> C
+
+Compute the square root of a non-negative UniformScaling `J`.
+
+# Examples
+```jldoctest
+julia> chol(16I)
+UniformScaling{Float64}
+4.0*I
+```
+"""
+chol(J::UniformScaling, args...) = ((C, info) = _chol!(J, nothing); @assertposdef C info)
+

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -59,6 +59,9 @@ using Base.LinAlg: BlasComplex, BlasFloat, BlasReal, QRPivoted, PosDefException
         @test all(x -> x ≈ √apos, cholfact(apos).factors)
         @test_throws PosDefException chol(-one(eltya))
 
+        @test  √apos*I ≈ chol(apos*I)
+        @test_throws PosDefException chol(-one(eltya)*I)
+
         # Test cholfact with Symmetric/Hermitian upper/lower
         apds  = Symmetric(apd)
         apdsL = Symmetric(apd, :L)

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -59,9 +59,6 @@ using Base.LinAlg: BlasComplex, BlasFloat, BlasReal, QRPivoted, PosDefException
         @test all(x -> x ≈ √apos, cholfact(apos).factors)
         @test_throws PosDefException chol(-one(eltya))
 
-        @test  √apos*I ≈ chol(apos*I)
-        @test_throws PosDefException chol(-one(eltya)*I)
-
         # Test cholfact with Symmetric/Hermitian upper/lower
         apds  = Symmetric(apd)
         apdsL = Symmetric(apd, :L)

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -173,3 +173,11 @@ end
             hvcat((2,1,2),B,2eye(3,3),eye(6,6),3eye(3,3),4eye(3,3))
     end
 end
+
+@testset "chol" begin
+    for T in (Float64, Complex64, BigFloat, Int)
+        λ = T(4)
+        @test chol(λ*I) ≈ √λ*I
+        @test_throws LinAlg.PosDefException chol(-λ*I)
+    end
+end


### PR DESCRIPTION
This came also up during the review by @tkelman of https://github.com/mschauer/Bridge.jl and is quite natural to define. There cannot be a CholFact because UniformScaling s are not AbstractArray s