### PR TITLE
RFC: Add vararg comparison functions

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -334,6 +334,19 @@ lexless(x, y) = lexcmp(x,y) < 0
 # cmp returns -1, 0, +1 indicating ordering
 cmp(x::Integer, y::Integer) = ifelse(isless(x, y), -1, ifelse(isless(y, x), 1, 0))
 
+## chained comparisons ##
+for op in (:(==), :isequal, :<, :>, :<=, :>=, :isless, :lexless)
+    @eval begin
+        """
+            $($op)(x, y, z, ...)
+
+        Call `$($op)` successively on each pair of arguments
+        (e.g. `$($op)(x, y) && $($op)(y, z) && ...`).
+        """
+        ($op)(a, b, c, args...) = ($op)(a, b) && ($op)(b, c, args...)
+    end
+end
+
 """
     max(x, y, ...)
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -343,7 +343,16 @@ for op in (:(==), :isequal, :<, :>, :<=, :>=, :isless, :lexless)
         Call `$($op)` successively on each pair of arguments
         (e.g. `$($op)(x, y) && $($op)(y, z) && ...`).
         """
-        ($op)(a, b, c, args...) = ($op)(a, b) && ($op)(b, c, args...)
+        function ($op)(a, b, c, args...)
+            result = ($op)(a, b) && ($op)(b, c)
+            @inbounds if result && length(args) > 0
+                ($op)(c, args[1]) || return false
+                for i in 1:length(args)-1
+                    ($op)(args[i], args[i + 1]) || return false
+                end
+            end
+            return result
+        end
     end
 end
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -117,6 +117,11 @@ function test_chained_comparison(op, args)
     op(args...) === all((tup) -> op(tup...), zip(args[1:end-1], args[2:end]))
 end
 
+mutable struct T22638A end
+mutable struct T22638B end
+
+Base.:(==)(::T22638A, ::T22638B) = throw(MethodError("no equality"))
+
 let
     test_cases = [
         [1, 1, 1],
@@ -147,6 +152,16 @@ let
     @testset "chained comparisons" begin
         @testset "chained equality" for op in ops, test_case in test_cases
             @test test_chained_comparison(op, test_case)
+        end
+
+        # ensures no methods are accidentally defined with varargs but not 2-args
+        @testset "invalid comparisons" begin
+            a = T22638A()
+            b = T22638B()
+
+            @testset for op in ops
+                @test_throws MethodError op(a, b)
+            end
         end
     end
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -106,7 +106,7 @@ fails = @testset NoThrowTestSet begin
     # Error - unexpected pass
     @test_broken true
     # Error - converting a call into a comparison
-    @test ==(1, 1:2...)
+    @test ==(()...)
 end
 for i in 1:length(fails) - 2
     @test isa(fails[i], Base.Test.Fail)
@@ -169,8 +169,8 @@ str = sprint(show, fails[14])
 @test contains(str, "Expression: true")
 
 str = sprint(show, fails[15])
-@test contains(str, "Expression: ==(1, 1:2...)")
-@test contains(str, "MethodError: no method matching ==(::$Int, ::$Int, ::$Int)")
+@test contains(str, "Expression: (==)(()...)")
+@test contains(str, "MethodError: no method matching ==()")
 
 
 # Test printing of a TestSetException


### PR DESCRIPTION
~I couldn't get docstrings working so I'll wait to see if this might be accepted and then ask for help on that.~

This allows calls like:
```julia
all(map(==, parallel_arrays...))
```

Currently short-circuits and has no special optimized versions for small or large argument lengths.