### PR TITLE
NFC: codegen: eliminate builder global

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -128,10 +128,12 @@ static bool runtime_sym_gvs(const char *f_lib, const char *f_name, MT &&M,
     return runtime_lib;
 }
 
-static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib,
-                                 const char *f_name, Function *f,
-                                 GlobalVariable *libptrgv,
-                                 GlobalVariable *llvmgv, bool runtime_lib)
+static Value *runtime_sym_lookup(
+        IRBuilder<> &irbuilder,
+        PointerType *funcptype, const char *f_lib,
+        const char *f_name, Function *f,
+        GlobalVariable *libptrgv,
+        GlobalVariable *llvmgv, bool runtime_lib)
 {
     // in pseudo-code, this function emits the following:
     //   global HMODULE *libptrgv
@@ -140,11 +142,11 @@ static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib,
     //       *llvmgv = jl_load_and_lookup(f_lib, f_name, libptrgv);
     //   }
     //   return (*llvmgv)
-    BasicBlock *enter_bb = builder.GetInsertBlock();
+    BasicBlock *enter_bb = irbuilder.GetInsertBlock();
     BasicBlock *dlsym_lookup = BasicBlock::Create(jl_LLVMContext, "dlsym");
     BasicBlock *ccall_bb = BasicBlock::Create(jl_LLVMContext, "ccall");
     Constant *initnul = ConstantPointerNull::get((PointerType*)T_pvoidfunc);
-    LoadInst *llvmf_orig = builder.CreateAlignedLoad(llvmgv, sizeof(void*));
+    LoadInst *llvmf_orig = irbuilder.CreateAlignedLoad(llvmgv, sizeof(void*));
     // This in principle needs a consume ordering so that load from
     // this pointer sees a valid value. However, this is not supported by
     // LLVM (or agreed on in the C/C++ standard FWIW) and should be
@@ -153,34 +155,40 @@ static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib,
     // invalid load from the `cglobal` but doesn't depend on the `cglobal`
     // value for this to happen.
     // llvmf_orig->setAtomic(AtomicOrdering::Consume);
-    builder.CreateCondBr(builder.CreateICmpNE(llvmf_orig, initnul),
-                         ccall_bb, dlsym_lookup);
+    irbuilder.CreateCondBr(
+            irbuilder.CreateICmpNE(llvmf_orig, initnul),
+            ccall_bb,
+            dlsym_lookup);
 
     assert(f->getParent() != NULL);
     f->getBasicBlockList().push_back(dlsym_lookup);
-    builder.SetInsertPoint(dlsym_lookup);
+    irbuilder.SetInsertPoint(dlsym_lookup);
     Value *libname;
     if (runtime_lib) {
-        libname = stringConstPtr(builder, f_lib);
+        libname = stringConstPtr(irbuilder, f_lib);
     }
     else {
-        libname = literal_static_pointer_val(f_lib, T_pint8);
+        // f_lib is actually one of the special sentinel values
+        libname = ConstantExpr::getIntToPtr(ConstantInt::get(T_size, (uintptr_t)f_lib), T_pint8);
     }
-    Value *llvmf = builder.CreateCall(prepare_call(builder, jldlsym_func), { libname, stringConstPtr(builder, f_name), libptrgv });
-    auto store = builder.CreateAlignedStore(llvmf, llvmgv, sizeof(void*));
+    Value *llvmf = irbuilder.CreateCall(prepare_call_in(jl_builderModule(irbuilder), jldlsym_func),
+            { libname, stringConstPtr(irbuilder, f_name), libptrgv });
+    auto store = irbuilder.CreateAlignedStore(llvmf, llvmgv, sizeof(void*));
     store->setAtomic(AtomicOrdering::Release);
-    builder.CreateBr(ccall_bb);
+    irbuilder.CreateBr(ccall_bb);
 
     f->getBasicBlockList().push_back(ccall_bb);
-    builder.SetInsertPoint(ccall_bb);
-    PHINode *p = builder.CreatePHI(T_pvoidfunc, 2);
+    irbuilder.SetInsertPoint(ccall_bb);
+    PHINode *p = irbuilder.CreatePHI(T_pvoidfunc, 2);
     p->addIncoming(llvmf_orig, enter_bb);
     p->addIncoming(llvmf, dlsym_lookup);
-    return builder.CreatePointerCast(p, funcptype);
+    return irbuilder.CreatePointerCast(p, funcptype);
 }
 
-static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib,
-                                 const char *f_name, Function *f)
+static Value *runtime_sym_lookup(
+        jl_codectx_t &ctx,
+        PointerType *funcptype, const char *f_lib,
+        const char *f_name, Function *f)
 {
     GlobalVariable *libptrgv;
     GlobalVariable *llvmgv;
@@ -188,7 +196,7 @@ static Value *runtime_sym_lookup(PointerType *funcptype, const char *f_lib,
                                        libptrgv, llvmgv);
     libptrgv = prepare_global(libptrgv);
     llvmgv = prepare_global(llvmgv);
-    return runtime_sym_lookup(funcptype, f_lib, f_name, f, libptrgv, llvmgv,
+    return runtime_sym_lookup(ctx.builder, funcptype, f_lib, f_name, f, libptrgv, llvmgv,
                               runtime_lib);
 }
 
@@ -208,23 +216,20 @@ static DenseMap<AttributeSet,
 
 // Emit a "PLT" entry that will be lazily initialized
 // when being called the first time.
-static GlobalVariable *emit_plt_thunk(Module *M, FunctionType *functype,
+static GlobalVariable *emit_plt_thunk(
+        Module *M, FunctionType *functype,
 #if JL_LLVM_VERSION >= 50000
-                                      const AttributeList &attrs,
+        const AttributeList &attrs,
 #else
-                                      const AttributeSet &attrs,
+        const AttributeSet &attrs,
 #endif
-                                      CallingConv::ID cc, const char *f_lib, const char *f_name,
-                                      GlobalVariable *libptrgv, GlobalVariable *llvmgv,
-                                      void *symaddr, bool runtime_lib)
+        CallingConv::ID cc, const char *f_lib, const char *f_name,
+        GlobalVariable *libptrgv, GlobalVariable *llvmgv,
+        void *symaddr, bool runtime_lib)
 {
     PointerType *funcptype = PointerType::get(functype, 0);
-    libptrgv = prepare_global(libptrgv, M);
-    llvmgv = prepare_global(llvmgv, M);
-    BasicBlock *old = builder.GetInsertBlock();
-    DebugLoc olddl = builder.getCurrentDebugLocation();
-    DebugLoc noDbg;
-    builder.SetCurrentDebugLocation(noDbg);
+    libptrgv = prepare_global_in(M, libptrgv);
+    llvmgv = prepare_global_in(M, llvmgv);
     std::stringstream funcName;
     funcName << "jlplt_" << f_name << "_" << globalUnique++;
     auto fname = funcName.str();
@@ -242,15 +247,15 @@ static GlobalVariable *emit_plt_thunk(Module *M, FunctionType *functype,
                                              nullptr, gname);
     *(void**)jl_emit_and_add_to_shadow(got) = symaddr;
     BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", plt);
-    builder.SetInsertPoint(b0);
-    Value *ptr = runtime_sym_lookup(funcptype, f_lib, f_name, plt, libptrgv,
+    IRBuilder<> irbuilder(b0);
+    Value *ptr = runtime_sym_lookup(irbuilder, funcptype, f_lib, f_name, plt, libptrgv,
                                     llvmgv, runtime_lib);
-    auto store = builder.CreateAlignedStore(builder.CreateBitCast(ptr, T_pvoidfunc), got, sizeof(void*));
+    auto store = irbuilder.CreateAlignedStore(irbuilder.CreateBitCast(ptr, T_pvoidfunc), got, sizeof(void*));
     store->setAtomic(AtomicOrdering::Release);
     SmallVector<Value*, 16> args;
     for (Function::arg_iterator arg = plt->arg_begin(), arg_e = plt->arg_end(); arg != arg_e; ++arg)
         args.push_back(&*arg);
-    CallInst *ret = builder.CreateCall(ptr, ArrayRef<Value*>(args));
+    CallInst *ret = irbuilder.CreateCall(ptr, ArrayRef<Value*>(args));
     ret->setAttributes(attrs);
     if (cc != CallingConv::C)
         ret->setCallingConv(cc);
@@ -263,7 +268,7 @@ static GlobalVariable *emit_plt_thunk(Module *M, FunctionType *functype,
     if (attrs.hasAttribute(AttributeSet::FunctionIndex,
 #endif
                            Attribute::NoReturn)) {
-        builder.CreateUnreachable();
+        irbuilder.CreateUnreachable();
     }
     else {
         // musttail support is very bad on ARM, PPC, PPC64 (as of LLVM 3.9)
@@ -273,14 +278,13 @@ static GlobalVariable *emit_plt_thunk(Module *M, FunctionType *functype,
         ret->setTailCallKind(CallInst::TCK_MustTail);
 #endif
         if (functype->getReturnType() == T_void) {
-            builder.CreateRetVoid();
+            irbuilder.CreateRetVoid();
         }
         else {
-            builder.CreateRet(ret);
+            irbuilder.CreateRet(ret);
         }
     }
-    builder.SetInsertPoint(old);
-    builder.SetCurrentDebugLocation(olddl);
+    irbuilder.ClearInsertionPoint();
     got = global_proto(got); // exchange got for the permanent global before jl_finalize_module destroys it
     jl_finalize_module(M, true);
 
@@ -292,13 +296,15 @@ static GlobalVariable *emit_plt_thunk(Module *M, FunctionType *functype,
     return got;
 }
 
-static Value *emit_plt(FunctionType *functype,
+static Value *emit_plt(
+        jl_codectx_t &ctx,
+        FunctionType *functype,
 #if JL_LLVM_VERSION >= 50000
-                       const AttributeList &attrs,
+       const AttributeList &attrs,
 #else
-                       const AttributeSet &attrs,
+       const AttributeSet &attrs,
 #endif
-                       CallingConv::ID cc, const char *f_lib, const char *f_name)
+       CallingConv::ID cc, const char *f_lib, const char *f_name)
 {
     assert(imaging_mode);
     // Don't do this for vararg functions so that the `musttail` is only
@@ -328,13 +334,13 @@ static Value *emit_plt(FunctionType *functype,
         assert(!LM.m);
     }
     GlobalVariable *got = prepare_global(shadowgot);
-    LoadInst *got_val = builder.CreateAlignedLoad(got, sizeof(void*));
+    LoadInst *got_val = ctx.builder.CreateAlignedLoad(got, sizeof(void*));
     // See comment in `runtime_sym_lookup` above. This in principle needs a
     // consume ordering too. This is even less likely to cause issues though
     // since the only thing we do to this loaded pointer is to call it
     // immediately.
     // got_val->setAtomic(AtomicOrdering::Consume);
-    return builder.CreateBitCast(got_val, funcptype);
+    return ctx.builder.CreateBitCast(got_val, funcptype);
 }
 
 // --- ABI Implementations ---
@@ -404,9 +410,9 @@ static bool is_native_simd_type(jl_datatype_t *dt) {
 
 // basic type widening and cast conversions
 static Value *llvm_type_rewrite(
+        jl_codectx_t &ctx,
         Value *v, Type *target_type,
-        bool issigned, /* determines whether an integer value should be zero or sign extended */
-        jl_codectx_t *ctx)
+        bool issigned) /* determines whether an integer value should be zero or sign extended */
 {
     Type *from_type = v->getType();
     if (target_type == from_type)
@@ -417,27 +423,27 @@ static Value *llvm_type_rewrite(
 
     assert(from_type->isPointerTy() == target_type->isPointerTy()); // expect that all ABIs consider all pointers to be equivalent
     if (target_type->isPointerTy())
-        return emit_bitcast(v, target_type);
+        return emit_bitcast(ctx, v, target_type);
 
     // simple integer and float widening & conversion cases
     if (from_type->getPrimitiveSizeInBits() > 0 &&
             target_type->getPrimitiveSizeInBits() == from_type->getPrimitiveSizeInBits())
-        return emit_bitcast(v, target_type);
+        return emit_bitcast(ctx, v, target_type);
 
     if (target_type->isFloatingPointTy() && from_type->isFloatingPointTy()) {
         if (target_type->getPrimitiveSizeInBits() > from_type->getPrimitiveSizeInBits())
-            return builder.CreateFPExt(v, target_type);
+            return ctx.builder.CreateFPExt(v, target_type);
         else if (target_type->getPrimitiveSizeInBits() < from_type->getPrimitiveSizeInBits())
-            return builder.CreateFPTrunc(v, target_type);
+            return ctx.builder.CreateFPTrunc(v, target_type);
         else
             return v;
     }
 
     if (target_type->isIntegerTy() && from_type->isIntegerTy()) {
         if (issigned)
-            return builder.CreateSExtOrTrunc(v, target_type);
+            return ctx.builder.CreateSExtOrTrunc(v, target_type);
         else
-            return builder.CreateZExtOrTrunc(v, target_type);
+            return ctx.builder.CreateZExtOrTrunc(v, target_type);
     }
 
     // one or both of from_type and target_type is a VectorType or AggregateType
@@ -453,33 +459,33 @@ static Value *llvm_type_rewrite(
     const DataLayout &DL = jl_ExecutionEngine->getDataLayout();
 #endif
     if (DL.getTypeAllocSize(target_type) >= DL.getTypeAllocSize(from_type)) {
-        to = emit_static_alloca(target_type, ctx);
-        from = emit_bitcast(to, from_type->getPointerTo());
+        to = emit_static_alloca(ctx, target_type);
+        from = emit_bitcast(ctx, to, from_type->getPointerTo());
     }
     else {
-        from = emit_static_alloca(from_type, ctx);
-        to = emit_bitcast(from, target_type->getPointerTo());
+        from = emit_static_alloca(ctx, from_type);
+        to = emit_bitcast(ctx, from, target_type->getPointerTo());
     }
-    builder.CreateStore(v, from);
-    return builder.CreateLoad(to);
+    ctx.builder.CreateStore(v, from);
+    return ctx.builder.CreateLoad(to);
 }
 
 // --- argument passing and scratch space utilities ---
 
-static Value *runtime_apply_type(jl_value_t *ty, jl_unionall_t *unionall, jl_codectx_t *ctx)
+static Value *runtime_apply_type(jl_codectx_t &ctx, jl_value_t *ty, jl_unionall_t *unionall)
 {
     // box if concrete type was not statically known
     Value *args[3];
-    args[0] = literal_pointer_val(ty);
-    args[1] = literal_pointer_val((jl_value_t*)ctx->linfo->def.method->sig);
-    args[2] = builder.CreateInBoundsGEP(
+    args[0] = literal_pointer_val(ctx, ty);
+    args[1] = literal_pointer_val(ctx, (jl_value_t*)ctx.linfo->def.method->sig);
+    args[2] = ctx.builder.CreateInBoundsGEP(
             T_prjlvalue,
-            emit_bitcast(decay_derived(ctx->spvals_ptr), T_pprjlvalue),
+            emit_bitcast(ctx, decay_derived(ctx.spvals_ptr), T_pprjlvalue),
             ConstantInt::get(T_size, sizeof(jl_svec_t) / sizeof(jl_value_t*)));
-    return builder.CreateCall(prepare_call(jlapplytype_func), makeArrayRef(args));
+    return ctx.builder.CreateCall(prepare_call(jlapplytype_func), makeArrayRef(args));
 }
 
-static void typeassert_input(const jl_cgval_t &jvinfo, jl_value_t *jlto, jl_unionall_t *jlto_env, int argn, bool addressOf, jl_codectx_t *ctx)
+static void typeassert_input(jl_codectx_t &ctx, const jl_cgval_t &jvinfo, jl_value_t *jlto, jl_unionall_t *jlto_env, int argn, bool addressOf)
 {
     if (jlto != (jl_value_t*)jl_any_type && !jl_subtype(jvinfo.typ, jlto)) {
         if (!addressOf && jlto == (jl_value_t*)jl_voidpointer_type) {
@@ -489,7 +495,7 @@ static void typeassert_input(const jl_cgval_t &jvinfo, jl_value_t *jlto, jl_unio
                 std::stringstream msg;
                 msg << "ccall argument ";
                 msg << argn;
-                emit_cpointercheck(jvinfo, msg.str(), ctx);
+                emit_cpointercheck(ctx, jvinfo, msg.str());
             }
         }
         else {
@@ -498,36 +504,38 @@ static void typeassert_input(const jl_cgval_t &jvinfo, jl_value_t *jlto, jl_unio
             msg << "ccall argument ";
             msg << argn;
             if (!jlto_env || !jl_has_typevar_from_unionall(jlto, jlto_env)) {
-                emit_typecheck(jvinfo, jlto, msg.str(), ctx);
+                emit_typecheck(ctx, jvinfo, jlto, msg.str());
             }
             else {
-                jl_cgval_t jlto_runtime = mark_julia_type(runtime_apply_type(jlto, jlto_env, ctx), true, jl_any_type, ctx);
-                Value *vx = boxed(jvinfo, ctx);
-                Value *istype = builder.
-                    CreateICmpNE(
-                                 builder.CreateCall(prepare_call(jlisa_func), { vx, boxed(jlto_runtime, ctx) }),
-                                 ConstantInt::get(T_int32, 0));
-                BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx->f);
-                BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext, "pass", ctx->f);
-                builder.CreateCondBr(istype, passBB, failBB);
+                jl_cgval_t jlto_runtime = mark_julia_type(ctx, runtime_apply_type(ctx, jlto, jlto_env), true, jl_any_type);
+                Value *vx = boxed(ctx, jvinfo);
+                Value *istype = ctx.builder.CreateICmpNE(
+                        ctx.builder.CreateCall(prepare_call(jlisa_func), { vx, boxed(ctx, jlto_runtime) }),
+                        ConstantInt::get(T_int32, 0));
+                BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx.f);
+                BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext, "pass", ctx.f);
+                ctx.builder.CreateCondBr(istype, passBB, failBB);
 
-                builder.SetInsertPoint(failBB);
-                emit_type_error(mark_julia_type(vx, true, jl_any_type, ctx), boxed(jlto_runtime, ctx), msg.str(), ctx);
-                builder.CreateUnreachable();
+                ctx.builder.SetInsertPoint(failBB);
+                emit_type_error(ctx, mark_julia_type(ctx, vx, true, jl_any_type), boxed(ctx, jlto_runtime), msg.str());
+                ctx.builder.CreateUnreachable();
 
-                builder.SetInsertPoint(passBB);
+                ctx.builder.SetInsertPoint(passBB);
             }
         }
     }
 }
 
-static Value *julia_to_address(Type *to, jl_value_t *jlto, jl_unionall_t *jlto_env, const jl_cgval_t &jvinfo,
-                               int argn, jl_codectx_t *ctx, bool *needStackRestore)
+static Value *julia_to_address(
+        jl_codectx_t &ctx,
+        Type *to, jl_value_t *jlto, jl_unionall_t *jlto_env,
+        const jl_cgval_t &jvinfo,
+        int argn, bool *needStackRestore)
 {
     assert(jl_is_datatype(jlto) && julia_struct_has_layout((jl_datatype_t*)jlto, jlto_env));
 
     if (!jl_is_cpointer_type(jlto) || !to->isPointerTy()) {
-        emit_error("ccall: & on argument was not matched by Ptr{T} argument type", ctx);
+        emit_error(ctx, "ccall: & on argument was not matched by Ptr{T} argument type");
         return UndefValue::get(to);
     }
 
@@ -537,7 +545,7 @@ static Value *julia_to_address(Type *to, jl_value_t *jlto, jl_unionall_t *jlto_e
     }
     else {
         ety = jl_tparam0(jlto);
-        typeassert_input(jvinfo, ety, jlto_env, argn, true, ctx);
+        typeassert_input(ctx, jvinfo, ety, jlto_env, argn, true);
     }
     assert(to->isPointerTy());
 
@@ -545,7 +553,7 @@ static Value *julia_to_address(Type *to, jl_value_t *jlto, jl_unionall_t *jlto_e
         if (!jl_is_abstracttype(ety)) {
             if (jl_is_mutable_datatype(ety)) {
                 // no copy, just reference the data field
-                return data_pointer(jvinfo, ctx, to);
+                return data_pointer(ctx, jvinfo, to);
             }
             else if (jl_is_immutable_datatype(ety) && jlto != (jl_value_t*)jl_voidpointer_type) {
                 // yes copy
@@ -554,38 +562,38 @@ static Value *julia_to_address(Type *to, jl_value_t *jlto, jl_unionall_t *jlto_e
                 if (jl_is_leaf_type(ety) || jl_is_primitivetype(ety)) {
                     int nb = jl_datatype_size(ety);
                     nbytes = ConstantInt::get(T_int32, nb);
-                    ai = emit_static_alloca(T_int8, nb, ctx);
+                    ai = emit_static_alloca(ctx, T_int8, nb);
                 }
                 else {
-                    nbytes = emit_datatype_size(emit_typeof_boxed(jvinfo,ctx));
-                    ai = builder.CreateAlloca(T_int8, nbytes);
+                    nbytes = emit_datatype_size(ctx, emit_typeof_boxed(ctx, jvinfo));
+                    ai = ctx.builder.CreateAlloca(T_int8, nbytes);
                     *needStackRestore = true;
                 }
                 ai->setAlignment(16);
-                builder.CreateMemCpy(ai, data_pointer(jvinfo, ctx, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
-                return emit_bitcast(ai, to);
+                ctx.builder.CreateMemCpy(ai, data_pointer(ctx, jvinfo, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
+                return emit_bitcast(ctx, ai, to);
             }
         }
         // emit maybe copy
         *needStackRestore = true;
-        Value *jvt = emit_typeof_boxed(jvinfo, ctx);
-        BasicBlock *mutableBB = BasicBlock::Create(jl_LLVMContext, "is-mutable", ctx->f);
-        BasicBlock *immutableBB = BasicBlock::Create(jl_LLVMContext, "is-immutable", ctx->f);
-        BasicBlock *afterBB = BasicBlock::Create(jl_LLVMContext, "after", ctx->f);
-        Value *ismutable = emit_datatype_mutabl(jvt);
-        builder.CreateCondBr(ismutable, mutableBB, immutableBB);
-        builder.SetInsertPoint(mutableBB);
-        Value *p1 = data_pointer(jvinfo, ctx, to);
-        builder.CreateBr(afterBB);
-        builder.SetInsertPoint(immutableBB);
-        Value *nbytes = emit_datatype_size(jvt);
-        AllocaInst *ai = builder.CreateAlloca(T_int8, nbytes);
+        Value *jvt = emit_typeof_boxed(ctx, jvinfo);
+        BasicBlock *mutableBB = BasicBlock::Create(jl_LLVMContext, "is-mutable", ctx.f);
+        BasicBlock *immutableBB = BasicBlock::Create(jl_LLVMContext, "is-immutable", ctx.f);
+        BasicBlock *afterBB = BasicBlock::Create(jl_LLVMContext, "after", ctx.f);
+        Value *ismutable = emit_datatype_mutabl(ctx, jvt);
+        ctx.builder.CreateCondBr(ismutable, mutableBB, immutableBB);
+        ctx.builder.SetInsertPoint(mutableBB);
+        Value *p1 = data_pointer(ctx, jvinfo, to);
+        ctx.builder.CreateBr(afterBB);
+        ctx.builder.SetInsertPoint(immutableBB);
+        Value *nbytes = emit_datatype_size(ctx, jvt);
+        AllocaInst *ai = ctx.builder.CreateAlloca(T_int8, nbytes);
         ai->setAlignment(16);
-        builder.CreateMemCpy(ai, data_pointer(jvinfo, ctx, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
-        Value *p2 = emit_bitcast(ai, to);
-        builder.CreateBr(afterBB);
-        builder.SetInsertPoint(afterBB);
-        PHINode *p = builder.CreatePHI(to, 2);
+        ctx.builder.CreateMemCpy(ai, data_pointer(ctx, jvinfo, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
+        Value *p2 = emit_bitcast(ctx, ai, to);
+        ctx.builder.CreateBr(afterBB);
+        ctx.builder.SetInsertPoint(afterBB);
+        PHINode *p = ctx.builder.CreatePHI(to, 2);
         p->addIncoming(p1, mutableBB);
         p->addIncoming(p2, immutableBB);
         return p;
@@ -594,18 +602,18 @@ static Value *julia_to_address(Type *to, jl_value_t *jlto, jl_unionall_t *jlto_e
     Type *slottype = julia_struct_to_llvm(jvinfo.typ, NULL, NULL);
     // pass the address of an alloca'd thing, not a box
     // since those are immutable.
-    Value *slot = emit_static_alloca(slottype, ctx);
+    Value *slot = emit_static_alloca(ctx, slottype);
     if (!jvinfo.ispointer()) {
-        builder.CreateStore(emit_unbox(slottype, jvinfo, ety), slot);
+        ctx.builder.CreateStore(emit_unbox(ctx, slottype, jvinfo, ety), slot);
     }
     else {
-        builder.CreateMemCpy(slot,
-                             data_pointer(jvinfo, ctx, slot->getType()),
+        ctx.builder.CreateMemCpy(slot,
+                             data_pointer(ctx, jvinfo, slot->getType()),
                              (uint64_t)jl_datatype_size(ety),
                              (uint64_t)jl_datatype_align(ety));
     }
     if (slot->getType() != to)
-        slot = emit_bitcast(slot, to);
+        slot = emit_bitcast(ctx, slot, to);
     return slot;
 }
 
@@ -614,31 +622,33 @@ static Value *julia_to_address(Type *to, jl_value_t *jlto, jl_unionall_t *jlto_e
 // to = desired LLVM type
 // jlto = Julia type of formal argument
 // jvinfo = value of actual argument
-static Value *julia_to_native(Type *to, bool toboxed, jl_value_t *jlto, jl_unionall_t *jlto_env,
-                              const jl_cgval_t &jvinfo,
-                              bool byRef, int argn, jl_codectx_t *ctx,
-                              bool *needStackRestore)
+static Value *julia_to_native(
+        jl_codectx_t &ctx,
+        Type *to, bool toboxed, jl_value_t *jlto, jl_unionall_t *jlto_env,
+        const jl_cgval_t &jvinfo,
+        bool byRef, int argn,
+        bool *needStackRestore)
 {
     // We're passing Any
     if (toboxed) {
         assert(!byRef); // don't expect any ABI to pass pointers by pointer
-        return maybe_decay_untracked(boxed(jvinfo, ctx));
+        return maybe_decay_untracked(boxed(ctx, jvinfo));
     }
     assert(jl_is_datatype(jlto) && julia_struct_has_layout((jl_datatype_t*)jlto, jlto_env));
 
-    typeassert_input(jvinfo, jlto, jlto_env, argn, false, ctx);
+    typeassert_input(ctx, jvinfo, jlto, jlto_env, argn, false);
     if (!byRef)
-        return emit_unbox(to, jvinfo, jlto);
+        return emit_unbox(ctx, to, jvinfo, jlto);
 
     // pass the address of an alloca'd thing, not a box
     // since those are immutable.
-    Value *slot = emit_static_alloca(to, ctx);
+    Value *slot = emit_static_alloca(ctx, to);
     if (!jvinfo.ispointer()) {
-        builder.CreateStore(emit_unbox(to, jvinfo, jlto), slot);
+        ctx.builder.CreateStore(emit_unbox(ctx, to, jvinfo, jlto), slot);
     }
     else {
-        builder.CreateMemCpy(slot,
-                             data_pointer(jvinfo, ctx, slot->getType()),
+        ctx.builder.CreateMemCpy(slot,
+                             data_pointer(ctx, jvinfo, slot->getType()),
                              (uint64_t)jl_datatype_size(jlto),
                              (uint64_t)jl_datatype_align(jlto));
     }
@@ -654,26 +664,25 @@ typedef struct {
 } native_sym_arg_t;
 
 // --- parse :sym or (:sym, :lib) argument into address info ---
-static void interpret_symbol_arg(native_sym_arg_t &out, jl_value_t *arg, jl_codectx_t *ctx, const char *fname, bool llvmcall)
+static void interpret_symbol_arg(jl_codectx_t &ctx, native_sym_arg_t &out, jl_value_t *arg, const char *fname, bool llvmcall)
 {
     Value *&jl_ptr = out.jl_ptr;
     void (*&fptr)(void) = out.fptr;
     const char *&f_name = out.f_name;
     const char *&f_lib = out.f_lib;
 
-    jl_value_t *ptr = static_eval(arg, ctx, true);
+    jl_value_t *ptr = static_eval(ctx, arg, true);
     if (ptr == NULL) {
-        jl_value_t *ptr_ty = expr_type(arg, ctx);
-        jl_cgval_t arg1 = emit_expr(arg, ctx);
+        jl_value_t *ptr_ty = expr_type(ctx, arg);
+        jl_cgval_t arg1 = emit_expr(ctx, arg);
         if (!jl_is_cpointer_type(ptr_ty)) {
-            emit_cpointercheck(arg1,
-                               !strcmp(fname,"ccall") ?
-                               "ccall: first argument not a pointer or valid constant expression" :
-                               "cglobal: first argument not a pointer or valid constant expression",
-                               ctx);
+           const char *errmsg = !strcmp(fname, "ccall") ?
+               "ccall: first argument not a pointer or valid constant expression" :
+               "cglobal: first argument not a pointer or valid constant expression";
+            emit_cpointercheck(ctx, arg1, errmsg);
         }
-        arg1 = update_julia_type(arg1, (jl_value_t*)jl_voidpointer_type, ctx);
-        jl_ptr = emit_unbox(T_size, arg1, (jl_value_t*)jl_voidpointer_type);
+        arg1 = update_julia_type(ctx, arg1, (jl_value_t*)jl_voidpointer_type);
+        jl_ptr = emit_unbox(ctx, T_size, arg1, (jl_value_t*)jl_voidpointer_type);
     }
     else {
         out.gcroot = ptr;
@@ -721,23 +730,23 @@ static void interpret_symbol_arg(native_sym_arg_t &out, jl_value_t *arg, jl_code
 }
 
 
-static jl_value_t* try_eval(jl_value_t *ex, jl_codectx_t *ctx, const char *failure, bool compiletime=false)
+static jl_value_t* try_eval(jl_codectx_t &ctx, jl_value_t *ex, const char *failure, bool compiletime=false)
 {
     jl_value_t *constant = NULL;
-    constant = static_eval(ex, ctx, true, true);
+    constant = static_eval(ctx, ex, true, true);
     if (constant || jl_is_ssavalue(ex))
         return constant;
     JL_TRY {
         size_t last_age = jl_get_ptls_states()->world_age;
-        jl_get_ptls_states()->world_age = ctx->world;
-        constant = jl_interpret_toplevel_expr_in(ctx->module, ex, ctx->source, ctx->linfo->sparam_vals);
+        jl_get_ptls_states()->world_age = ctx.world;
+        constant = jl_interpret_toplevel_expr_in(ctx.module, ex, ctx.source, ctx.linfo->sparam_vals);
         jl_get_ptls_states()->world_age = last_age;
     }
     JL_CATCH {
         if (compiletime)
             jl_rethrow_with_add(failure);
         if (failure)
-            emit_error(failure, ctx);
+            emit_error(ctx, failure);
         constant = NULL;
     }
     return constant;
@@ -745,9 +754,9 @@ static jl_value_t* try_eval(jl_value_t *ex, jl_codectx_t *ctx, const char *failu
 
 // --- code generator for cglobal ---
 
-static jl_cgval_t emit_runtime_call(JL_I::intrinsic f, const jl_cgval_t *argv, size_t nargs, jl_codectx_t *ctx);
+static jl_cgval_t emit_runtime_call(jl_codectx_t &ctx, JL_I::intrinsic f, const jl_cgval_t *argv, size_t nargs);
 
-static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
+static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
 {
     JL_NARGS(cglobal, 1, 2);
     jl_value_t *rt = NULL;
@@ -756,13 +765,13 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
     JL_GC_PUSH2(&rt, &sym.gcroot);
 
     if (nargs == 2) {
-        rt = static_eval(args[2], ctx, true, true);
+        rt = static_eval(ctx, args[2], true, true);
         if (rt == NULL) {
             JL_GC_POP();
             jl_cgval_t argv[2];
-            argv[0] = emit_expr(args[0], ctx);
-            argv[1] = emit_expr(args[1], ctx);
-            return emit_runtime_call(JL_I::cglobal, argv, nargs, ctx);
+            argv[0] = emit_expr(ctx, args[0]);
+            argv[1] = emit_expr(ctx, args[1]);
+            return emit_runtime_call(ctx, JL_I::cglobal, argv, nargs);
         }
 
         JL_TYPECHK(cglobal, type, rt);
@@ -775,19 +784,19 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
     if (lrt == NULL)
         lrt = T_pint8;
 
-    interpret_symbol_arg(sym, args[1], ctx, "cglobal", false);
+    interpret_symbol_arg(ctx, sym, args[1], "cglobal", false);
 
     if (sym.jl_ptr != NULL) {
-        res = builder.CreateIntToPtr(sym.jl_ptr, lrt);
+        res = ctx.builder.CreateIntToPtr(sym.jl_ptr, lrt);
     }
     else if (sym.fptr != NULL) {
-        res = literal_static_pointer_val((void*)(uintptr_t)sym.fptr, lrt);
+        res = literal_static_pointer_val(ctx, (void*)(uintptr_t)sym.fptr, lrt);
         if (imaging_mode)
             jl_printf(JL_STDERR,"WARNING: literal address used in cglobal for %s; code cannot be statically compiled\n", sym.f_name);
     }
     else {
         if (imaging_mode) {
-            res = runtime_sym_lookup((PointerType*)lrt, sym.f_lib, sym.f_name, ctx->f);
+            res = runtime_sym_lookup(ctx, (PointerType*)lrt, sym.f_lib, sym.f_name, ctx.f);
         }
         else {
             void *symaddr = jl_dlsym_e(jl_get_library(sym.f_lib), sym.f_name);
@@ -802,16 +811,16 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
                     msg << " in library ";
                     msg << sym.f_lib;
                 }
-                emit_error(msg.str(), ctx);
+                emit_error(ctx, msg.str());
             }
             // since we aren't saving this code, there's no sense in
             // putting anything complicated here: just JIT the address of the cglobal
-            res = literal_static_pointer_val(symaddr, lrt);
+            res = literal_static_pointer_val(ctx, symaddr, lrt);
         }
     }
 
     JL_GC_POP();
-    return mark_julia_type(res, false, rt, ctx);
+    return mark_julia_type(ctx, res, false, rt);
 }
 
 class FunctionMover final : public ValueMaterializer
@@ -950,15 +959,15 @@ public:
 };
 
 // llvmcall(ir, (rettypes...), (argtypes...), args...)
-static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
+static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
 {
     JL_NARGSV(llvmcall, 3);
     jl_value_t *rt = NULL, *at = NULL, *ir = NULL, *decl = NULL;
     jl_svec_t *stt = NULL;
     JL_GC_PUSH5(&ir, &rt, &at, &stt, &decl);
-    at = try_eval(args[3], ctx, "error statically evaluating llvmcall argument tuple", true);
-    rt = try_eval(args[2], ctx, "error statically evaluating llvmcall return type", true);
-    ir = try_eval(args[1], ctx, "error statically evaluating llvm IR argument", true);
+    at = try_eval(ctx, args[3], "error statically evaluating llvmcall argument tuple", true);
+    rt = try_eval(ctx, args[2], "error statically evaluating llvmcall return type", true);
+    ir = try_eval(ctx, args[1], "error statically evaluating llvm IR argument", true);
     int i = 1;
     if (jl_is_tuple(ir)) {
         // if the IR is a tuple, we expect (declarations, ir)
@@ -983,7 +992,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
     stt = jl_alloc_svec(nargs - 3);
 
     for (size_t i = 0; i < nargs - 3; ++i) {
-        jl_svecset(stt, i, expr_type(args[4 + i], ctx));
+        jl_svecset(stt, i, expr_type(ctx, args[4 + i]));
     }
 
     // Generate arguments
@@ -1011,11 +1020,11 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         }
         jl_value_t *argi = args[4 + i];
         jl_cgval_t &arg = argv[i];
-        arg = emit_expr(argi, ctx);
+        arg = emit_expr(ctx, argi);
 
-        Value *v = julia_to_native(t, toboxed, tti, NULL, arg, false, i, ctx, NULL);
+        Value *v = julia_to_native(ctx, t, toboxed, tti, NULL, arg, false, i, NULL);
         bool issigned = jl_signed_type && jl_subtype(tti, (jl_value_t*)jl_signed_type);
-        argvals[i] = llvm_type_rewrite(v, t, issigned, ctx);
+        argvals[i] = llvm_type_rewrite(ctx, v, t, issigned);
     }
 
     Function *f;
@@ -1026,7 +1035,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         std::string ir_name;
         while(true) {
             std::stringstream name;
-            name << (ctx->f->getName().str()) << "u" << i++;
+            name << (ctx.f->getName().str()) << "u" << i++;
             ir_name = name.str();
             if (jl_Module->getFunction(ir_name) == NULL)
                 break;
@@ -1127,7 +1136,7 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         f->setLinkage(GlobalValue::LinkOnceODRLinkage);
     }
 
-    CallInst *inst = builder.CreateCall(f, ArrayRef<Value*>(&argvals[0], nargt));
+    CallInst *inst = ctx.builder.CreateCall(f, ArrayRef<Value*>(&argvals[0], nargt));
     if (isString)
         f->addFnAttr(Attribute::AlwaysInline);
 
@@ -1137,18 +1146,18 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         jl_error("Return type of llvmcall'ed function does not match declared return type");
     }
 
-    return mark_julia_type(inst, retboxed, rtt, ctx);
+    return mark_julia_type(ctx, inst, retboxed, rtt);
 }
 
 // --- code generator for ccall itself ---
 
-static jl_cgval_t mark_or_box_ccall_result(Value *result, bool isboxed, jl_value_t *rt, jl_unionall_t *unionall, bool static_rt, jl_codectx_t *ctx)
+static jl_cgval_t mark_or_box_ccall_result(jl_codectx_t &ctx, Value *result, bool isboxed, jl_value_t *rt, jl_unionall_t *unionall, bool static_rt)
 {
     if (!static_rt) {
-        assert(!isboxed && ctx->spvals_ptr && unionall && jl_is_datatype(rt));
-        Value *runtime_dt = runtime_apply_type(rt, unionall, ctx);
+        assert(!isboxed && ctx.spvals_ptr && unionall && jl_is_datatype(rt));
+        Value *runtime_dt = runtime_apply_type(ctx, rt, unionall);
         // TODO: is this leaf check actually necessary, or is it structurally guaranteed?
-        emit_leafcheck(runtime_dt, "ccall: return type must be a leaf DataType", ctx);
+        emit_leafcheck(ctx, runtime_dt, "ccall: return type must be a leaf DataType");
 #if JL_LLVM_VERSION >= 40000
         const DataLayout &DL = jl_data_layout;
 #else
@@ -1157,10 +1166,10 @@ static jl_cgval_t mark_or_box_ccall_result(Value *result, bool isboxed, jl_value
         unsigned nb = DL.getTypeStoreSize(result->getType());
         MDNode *tbaa = jl_is_mutable(rt) ? tbaa_mutab : tbaa_immut;
         Value *strct = emit_allocobj(ctx, nb, runtime_dt);
-        init_bits_value(strct, result, tbaa);
-        return mark_julia_type(strct, true, rt, ctx);
+        init_bits_value(ctx, strct, result, tbaa);
+        return mark_julia_type(ctx, strct, true, rt);
     }
-    return mark_julia_type(result, isboxed, rt, ctx);
+    return mark_julia_type(ctx, result, isboxed, rt);
 }
 
 class function_sig_t {
@@ -1201,13 +1210,13 @@ public:
     }
 
     jl_cgval_t emit_a_ccall(
+            jl_codectx_t &ctx,
             const native_sym_arg_t &symarg,
             size_t nargt,
             std::vector<bool> &addressOf,
             jl_cgval_t *argv,
             SmallVector<Value*, 16> &gc_uses,
-            bool static_rt,
-            jl_codectx_t *ctx);
+            bool static_rt);
 
 private:
 std::string generate_func_sig()
@@ -1437,7 +1446,7 @@ static const std::string verify_ccall_sig(size_t nargs, jl_value_t *&rt, jl_valu
 }
 
 // Expr(:foreigncall, pointer, rettype, (argtypes...), args...)
-static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
+static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
 {
     JL_NARGSV(ccall, 3);
     args -= 1;
@@ -1455,20 +1464,20 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         nargs -= 1;
     }
 
-    interpret_symbol_arg(symarg, args[1], ctx, "ccall", llvmcall);
+    interpret_symbol_arg(ctx, symarg, args[1], "ccall", llvmcall);
     Value *&jl_ptr = symarg.jl_ptr;
     void (*&fptr)(void) = symarg.fptr;
     const char *&f_name = symarg.f_name;
     const char *&f_lib = symarg.f_lib;
 
     if (f_name == NULL && fptr == NULL && jl_ptr == NULL) {
-        emit_error("ccall: null function pointer", ctx);
+        emit_error(ctx, "ccall: null function pointer");
         JL_GC_POP();
         return jl_cgval_t();
     }
 
-    jl_unionall_t *unionall = (jl_is_method(ctx->linfo->def.method) && jl_is_unionall(ctx->linfo->def.method->sig))
-        ? (jl_unionall_t*)ctx->linfo->def.method->sig
+    jl_unionall_t *unionall = (jl_is_method(ctx.linfo->def.method) && jl_is_unionall(ctx.linfo->def.method->sig))
+        ? (jl_unionall_t*)ctx.linfo->def.method->sig
         : NULL;
 
     if (jl_is_abstract_ref_type(rt)) {
@@ -1485,16 +1494,16 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                 jl_unionall_t *ua = unionall;
                 for (i = 0; jl_is_unionall(ua); i++) {
                     if (ua->var == (jl_tvar_t*)ref) {
-                        jl_cgval_t runtime_sp = emit_sparam(i, ctx);
+                        jl_cgval_t runtime_sp = emit_sparam(ctx, i);
                         if (runtime_sp.constant) {
                             if (runtime_sp.constant != (jl_value_t*)jl_any_type)
                                 always_error = false;
                         }
                         else {
-                            Value *notany = builder.CreateICmpNE(
-                                    boxed(runtime_sp, ctx, false),
-                                    literal_pointer_val((jl_value_t*)jl_any_type));
-                            error_unless(notany, "ccall: return type Ref{Any} is invalid. use Ptr{Any} instead.", ctx);
+                            Value *notany = ctx.builder.CreateICmpNE(
+                                    boxed(ctx, runtime_sp, false),
+                                    literal_pointer_val(ctx, (jl_value_t*)jl_any_type));
+                            error_unless(ctx, notany, "ccall: return type Ref{Any} is invalid. use Ptr{Any} instead.");
                             always_error = false;
                         }
                         break;
@@ -1503,7 +1512,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             }
         }
         if (always_error) {
-            emit_error("ccall: return type Ref{Any} is invalid. use Ptr{Any} instead.", ctx);
+            emit_error(ctx, "ccall: return type Ref{Any} is invalid. use Ptr{Any} instead.");
             JL_GC_POP();
             return jl_cgval_t();
         }
@@ -1525,12 +1534,12 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     std::string err = verify_ccall_sig(
             /* inputs:  */
             nargs, rt, at, unionall,
-            ctx->spvals_ptr == NULL ? ctx->linfo->sparam_vals : NULL,
-            ctx->funcName.c_str(),
+            ctx.spvals_ptr == NULL ? ctx.linfo->sparam_vals : NULL,
+            ctx.funcName.c_str(),
             /* outputs: */
             nargt, isVa, lrt, retboxed, static_rt);
     if (!err.empty()) {
-        emit_error(err, ctx);
+        emit_error(ctx, err);
         JL_GC_POP();
         return jl_cgval_t();
     }
@@ -1560,10 +1569,10 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(nargt==1);
         jl_value_t *argi = args[4];
         assert(!(jl_is_expr(argi) && ((jl_expr_t*)argi)->head == amp_sym));
-        jl_cgval_t ary = emit_expr(argi, ctx);
+        jl_cgval_t ary = emit_expr(ctx, argi);
         JL_GC_POP();
-        return mark_or_box_ccall_result(emit_bitcast(emit_arrayptr(ary, ctx), lrt),
-                                        retboxed, rt, unionall, static_rt, ctx);
+        return mark_or_box_ccall_result(ctx, emit_bitcast(ctx, emit_arrayptr(ctx, ary), lrt),
+                                        retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_value_ptr)) {
         assert(lrt->isPointerTy());
@@ -1590,22 +1599,24 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             largty = julia_struct_to_llvm(tti, unionall, &isboxed);
         }
         if (isboxed) {
-            ary = boxed(emit_expr(argi, ctx), ctx);
+            ary = boxed(ctx, emit_expr(ctx, argi));
         }
         else {
             assert(!addressOf);
-            ary = emit_unbox(largty, emit_expr(argi, ctx), tti);
+            ary = emit_unbox(ctx, largty, emit_expr(ctx, argi), tti);
         }
         JL_GC_POP();
         if (!retboxed) {
             return mark_or_box_ccall_result(
-                      emit_bitcast(emit_pointer_from_objref(
-                                          emit_bitcast(ary, T_prjlvalue)), lrt),
-                   retboxed, rt, unionall, static_rt, ctx);
+                    ctx,
+                    emit_bitcast(ctx, emit_pointer_from_objref(ctx,
+                            emit_bitcast(ctx, ary, T_prjlvalue)), lrt),
+                    retboxed, rt, unionall, static_rt);
         } else {
-            return mark_or_box_ccall_result(maybe_decay_untracked(
-                                            emit_bitcast(ary, lrt)),
-                                            retboxed, rt, unionall, static_rt, ctx);
+            return mark_or_box_ccall_result(
+                    ctx,
+                    maybe_decay_untracked(emit_bitcast(ctx, ary, lrt)),
+                    retboxed, rt, unionall, static_rt);
         }
     }
     else if (is_libjulia_func(jl_cpu_pause)) {
@@ -1618,13 +1629,13 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 #elif defined(_CPU_X86_64_) || defined(_CPU_X86_)  /* !__MIC__ */
         static auto pauseinst = InlineAsm::get(FunctionType::get(T_void, false), "pause",
                                                "~{memory}", true);
-        builder.CreateCall(pauseinst);
+        ctx.builder.CreateCall(pauseinst);
         JL_GC_POP();
         return ghostValue(jl_void_type);
 #elif defined(_CPU_AARCH64_) || (defined(_CPU_ARM_) && __ARM_ARCH >= 7)
         static auto wfeinst = InlineAsm::get(FunctionType::get(T_void, false), "wfe",
                                              "~{memory}", true);
-        builder.CreateCall(wfeinst);
+        ctx.builder.CreateCall(wfeinst);
         JL_GC_POP();
         return ghostValue(jl_void_type);
 #else
@@ -1643,7 +1654,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 #elif defined(_CPU_AARCH64_) || (defined(_CPU_ARM_) && __ARM_ARCH >= 7)
         static auto sevinst = InlineAsm::get(FunctionType::get(T_void, false), "sev",
                                              "~{memory}", true);
-        builder.CreateCall(sevinst);
+        ctx.builder.CreateCall(sevinst);
         JL_GC_POP();
         return ghostValue(jl_void_type);
 #endif
@@ -1653,10 +1664,10 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!isVa && !llvmcall);
         assert(nargt == 0);
         JL_GC_POP();
-        builder.CreateCall(prepare_call(gcroot_flush_func));
-        emit_signal_fence();
-        builder.CreateLoad(ctx->signalPage, true);
-        emit_signal_fence();
+        ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
+        emit_signal_fence(ctx);
+        ctx.builder.CreateLoad(ctx.signalPage, true);
+        emit_signal_fence(ctx);
         return ghostValue(jl_void_type);
     }
     else if (_is_libjulia_func((uintptr_t)ptls_getter, "jl_get_ptls_states")) {
@@ -1664,34 +1675,34 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!isVa && !llvmcall);
         assert(nargt == 0);
         JL_GC_POP();
-        return mark_or_box_ccall_result(
-            emit_bitcast(ctx->ptlsStates, lrt),
-            retboxed, rt, unionall, static_rt, ctx);
+        return mark_or_box_ccall_result(ctx,
+            emit_bitcast(ctx, ctx.ptlsStates, lrt),
+            retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_threadid)) {
         assert(lrt == T_int16);
         assert(!isVa && !llvmcall);
         assert(nargt == 0);
         JL_GC_POP();
-        Value *ptls_i16 = emit_bitcast(ctx->ptlsStates, T_pint16);
+        Value *ptls_i16 = emit_bitcast(ctx, ctx.ptlsStates, T_pint16);
         const int tid_offset = offsetof(jl_tls_states_t, tid);
-        Value *ptid = builder.CreateGEP(ptls_i16, ConstantInt::get(T_size, tid_offset / 2));
-        return mark_or_box_ccall_result(
-            tbaa_decorate(tbaa_const, builder.CreateLoad(ptid)),
-            retboxed, rt, unionall, static_rt, ctx);
+        Value *ptid = ctx.builder.CreateGEP(ptls_i16, ConstantInt::get(T_size, tid_offset / 2));
+        return mark_or_box_ccall_result(ctx,
+            tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(ptid)),
+            retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_sigatomic_begin)) {
         assert(lrt == T_void);
         assert(!isVa && !llvmcall);
         assert(nargt == 0);
         JL_GC_POP();
-        builder.CreateCall(prepare_call(gcroot_flush_func));
+        ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
         Value *pdefer_sig = emit_defer_signal(ctx);
-        Value *defer_sig = builder.CreateLoad(pdefer_sig);
-        defer_sig = builder.CreateAdd(defer_sig,
+        Value *defer_sig = ctx.builder.CreateLoad(pdefer_sig);
+        defer_sig = ctx.builder.CreateAdd(defer_sig,
                                       ConstantInt::get(T_sigatomic, 1));
-        builder.CreateStore(defer_sig, pdefer_sig);
-        emit_signal_fence();
+        ctx.builder.CreateStore(defer_sig, pdefer_sig);
+        emit_signal_fence(ctx);
         return ghostValue(jl_void_type);
     }
     else if (is_libjulia_func(jl_sigatomic_end)) {
@@ -1699,53 +1710,56 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(!isVa && !llvmcall);
         assert(nargt == 0);
         JL_GC_POP();
-        builder.CreateCall(prepare_call(gcroot_flush_func));
+        ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
         Value *pdefer_sig = emit_defer_signal(ctx);
-        Value *defer_sig = builder.CreateLoad(pdefer_sig);
-        emit_signal_fence();
-        error_unless(builder.CreateICmpNE(defer_sig,
-                                          ConstantInt::get(T_sigatomic, 0)),
-                     "sigatomic_end called in non-sigatomic region", ctx);
-        defer_sig = builder.CreateSub(defer_sig,
-                                      ConstantInt::get(T_sigatomic, 1));
-        builder.CreateStore(defer_sig, pdefer_sig);
+        Value *defer_sig = ctx.builder.CreateLoad(pdefer_sig);
+        emit_signal_fence(ctx);
+        error_unless(ctx,
+                ctx.builder.CreateICmpNE(defer_sig, ConstantInt::get(T_sigatomic, 0)),
+                "sigatomic_end called in non-sigatomic region");
+        defer_sig = ctx.builder.CreateSub(
+                defer_sig,
+                ConstantInt::get(T_sigatomic, 1));
+        ctx.builder.CreateStore(defer_sig, pdefer_sig);
         BasicBlock *checkBB = BasicBlock::Create(jl_LLVMContext, "check",
-                                                 ctx->f);
+                                                 ctx.f);
         BasicBlock *contBB = BasicBlock::Create(jl_LLVMContext, "cont");
-        builder.CreateCondBr(
-            builder.CreateICmpEQ(defer_sig, ConstantInt::get(T_sigatomic, 0)),
-            checkBB, contBB);
-        builder.SetInsertPoint(checkBB);
-        builder.CreateLoad(builder.CreateConstGEP1_32(ctx->signalPage, -1),
-                           true);
-        builder.CreateBr(contBB);
-        ctx->f->getBasicBlockList().push_back(contBB);
-        builder.SetInsertPoint(contBB);
+        ctx.builder.CreateCondBr(
+                ctx.builder.CreateICmpEQ(defer_sig, ConstantInt::get(T_sigatomic, 0)),
+                checkBB, contBB);
+        ctx.builder.SetInsertPoint(checkBB);
+        ctx.builder.CreateLoad(
+                ctx.builder.CreateConstGEP1_32(ctx.signalPage, -1),
+                true);
+        ctx.builder.CreateBr(contBB);
+        ctx.f->getBasicBlockList().push_back(contBB);
+        ctx.builder.SetInsertPoint(contBB);
         return ghostValue(jl_void_type);
     }
     else if (is_libjulia_func(jl_is_leaf_type)) {
         assert(nargt == 1);
         assert(!isVa && !llvmcall);
         jl_value_t *arg = args[4];
-        jl_value_t *ty = expr_type(arg, ctx);
+        jl_value_t *ty = expr_type(ctx, arg);
         if (jl_is_type_type(ty) && !jl_is_typevar(jl_tparam0(ty))) {
             int isleaf = jl_is_leaf_type(jl_tparam0(ty));
             JL_GC_POP();
-            return mark_or_box_ccall_result(ConstantInt::get(T_int32, isleaf),
-                    false, rt, unionall, static_rt, ctx);
+            return mark_or_box_ccall_result(ctx,
+                    ConstantInt::get(T_int32, isleaf),
+                    false, rt, unionall, static_rt);
         }
     }
     else if (is_libjulia_func(jl_function_ptr)) {
         assert(nargt == 3);
         assert(!isVa && !llvmcall);
-        jl_value_t *f = static_eval(args[4], ctx, false, false);
+        jl_value_t *f = static_eval(ctx, args[4], false, false);
         jl_value_t *fargt = nullptr;
         JL_GC_PUSH2(&f, &fargt);
-        jl_value_t *frt = expr_type(args[6], ctx);
+        jl_value_t *frt = expr_type(ctx, args[6]);
         if (f && (jl_is_type_type((jl_value_t*)frt) && !jl_has_free_typevars(jl_tparam0(frt)))) {
-            fargt = static_eval(args[8], ctx, true, true);
+            fargt = static_eval(ctx, args[8], true, true);
             if (!fargt) {
-                fargt = expr_type(args[8], ctx);
+                fargt = expr_type(ctx, args[8]);
                 if (jl_is_type_type((jl_value_t*)fargt)) {
                     fargt = jl_tparam0(fargt);
                     if (jl_has_free_typevars(fargt) || !jl_is_tuple_type(fargt)) {
@@ -1775,42 +1789,42 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                 if (llvmf) {
                     llvmf = prepare_call(llvmf);
                     // make sure to emit any side-effects that may have been part of the original expression
-                    emit_expr(args[4], ctx);
-                    emit_expr(args[6], ctx);
-                    emit_expr(args[8], ctx);
+                    emit_expr(ctx, args[4]);
+                    emit_expr(ctx, args[6]);
+                    emit_expr(ctx, args[8]);
                     JL_GC_POP();
                     JL_GC_POP();
-                    return mark_or_box_ccall_result(emit_bitcast(llvmf, lrt),
-                                                    retboxed, rt, unionall, static_rt, ctx);
+                    return mark_or_box_ccall_result(ctx, emit_bitcast(ctx, llvmf, lrt),
+                                                    retboxed, rt, unionall, static_rt);
                 }
             }
         }
         JL_GC_POP();
     }
     else if (is_libjulia_func(jl_array_isassigned) &&
-             expr_type(args[6], ctx) == (jl_value_t*)jl_ulong_type) {
+             expr_type(ctx, args[6]) == (jl_value_t*)jl_ulong_type) {
         assert(nargt == 2);
         jl_value_t *aryex = args[4];
         jl_value_t *idxex = args[6];
-        jl_value_t *aryty = expr_type(aryex, ctx);
+        jl_value_t *aryty = expr_type(ctx, aryex);
         if (jl_is_array_type(aryty)) {
             jl_value_t *ety = jl_tparam0(aryty);
             if (jl_isbits(ety)) {
-                emit_expr(aryex, ctx);
-                emit_expr(idxex, ctx);
+                emit_expr(ctx, aryex);
+                emit_expr(ctx, idxex);
                 JL_GC_POP();
-                return mark_or_box_ccall_result(ConstantInt::get(T_int32, 1),
-                                                false, rt, unionall, static_rt, ctx);
+                return mark_or_box_ccall_result(ctx, ConstantInt::get(T_int32, 1),
+                                                false, rt, unionall, static_rt);
             }
             else if (!jl_has_free_typevars(ety)) { // TODO: jn/foreigncall branch has a better predicate
-                jl_cgval_t aryv = emit_expr(aryex, ctx);
-                Value *idx = emit_unbox(T_size, emit_expr(idxex, ctx), (jl_value_t*)jl_ulong_type);
-                Value *arrayptr = emit_bitcast(emit_arrayptr(aryv, aryex, ctx), T_ppjlvalue);
-                Value *slot_addr = builder.CreateGEP(arrayptr, idx);
-                Value *load = tbaa_decorate(tbaa_arraybuf, builder.CreateLoad(slot_addr));
-                Value *res = builder.CreateZExt(builder.CreateICmpNE(load, V_null), T_int32);
+                jl_cgval_t aryv = emit_expr(ctx, aryex);
+                Value *idx = emit_unbox(ctx, T_size, emit_expr(ctx, idxex), (jl_value_t*)jl_ulong_type);
+                Value *arrayptr = emit_bitcast(ctx, emit_arrayptr(ctx, aryv, aryex), T_ppjlvalue);
+                Value *slot_addr = ctx.builder.CreateGEP(arrayptr, idx);
+                Value *load = tbaa_decorate(tbaa_arraybuf, ctx.builder.CreateLoad(slot_addr));
+                Value *res = ctx.builder.CreateZExt(ctx.builder.CreateICmpNE(load, V_null), T_int32);
                 JL_GC_POP();
-                return mark_or_box_ccall_result(res, retboxed, rt, unionall, static_rt, ctx);
+                return mark_or_box_ccall_result(ctx, res, retboxed, rt, unionall, static_rt);
             }
         }
     }
@@ -1818,10 +1832,10 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(lrt == T_pint8);
         assert(!isVa && !llvmcall);
         assert(nargt == 1);
-        auto obj = emit_pointer_from_objref(boxed(emit_expr(args[4], ctx), ctx));
-        auto strp = builder.CreateConstGEP1_32(emit_bitcast(obj, T_pint8), sizeof(void*));
+        auto obj = emit_pointer_from_objref(ctx, boxed(ctx, emit_expr(ctx, args[4])));
+        auto strp = ctx.builder.CreateConstGEP1_32(emit_bitcast(ctx, obj, T_pint8), sizeof(void*));
         JL_GC_POP();
-        return mark_or_box_ccall_result(strp, retboxed, rt, unionall, static_rt, ctx);
+        return mark_or_box_ccall_result(ctx, strp, retboxed, rt, unionall, static_rt);
     }
 
     // emit arguments
@@ -1847,47 +1861,47 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         }
 
         jl_cgval_t &arg = argv[ai];
-        arg = emit_expr((jl_value_t*)argi, ctx);
+        arg = emit_expr(ctx, (jl_value_t*)argi);
 
         // Julia (expression) value of current parameter gcroot
         jl_value_t *argi_root = args[i + 1];
         if (jl_is_long(argi_root))
             continue;
-        jl_cgval_t arg_root = emit_expr(argi_root, ctx);
-        Value *gcuse = arg_root.gcroot ? builder.CreateLoad(arg_root.gcroot) : arg_root.V;
+        jl_cgval_t arg_root = emit_expr(ctx, argi_root);
+        Value *gcuse = arg_root.gcroot ? ctx.builder.CreateLoad(arg_root.gcroot) : arg_root.V;
         if (gcuse)
             gc_uses.push_back(gcuse);
     }
 
     function_sig_t sig(lrt, rt, retboxed, (jl_svec_t*)at, unionall, (nargs - 3) / 2, isVa, cc, llvmcall);
     jl_cgval_t retval = sig.emit_a_ccall(
+            ctx,
             symarg,
             nargt,
             addressOf,
             argv,
             gc_uses,
-            static_rt,
-            ctx);
+            static_rt);
     JL_GC_POP();
     return retval;
 }
 
 jl_cgval_t function_sig_t::emit_a_ccall(
+        jl_codectx_t &ctx,
         const native_sym_arg_t &symarg,
         size_t nargt,
         std::vector<bool> &addressOf,
         jl_cgval_t *argv,
         SmallVector<Value*, 16> &gc_uses,
-        bool static_rt,
-        jl_codectx_t *ctx)
+        bool static_rt)
 {
     if (!err_msg.empty()) {
-        emit_error(err_msg, ctx);
+        emit_error(ctx, err_msg);
         return jl_cgval_t();
     }
 
     // save place before arguments, for possible insertion of temp arg area saving code.
-    BasicBlock::InstListType &instList = builder.GetInsertBlock()->getInstList();
+    BasicBlock::InstListType &instList = ctx.builder.GetInsertBlock()->getInstList();
     Instruction *savespot = instList.empty() ? NULL : &instList.back();
 
     bool needStackRestore = false;
@@ -1916,9 +1930,9 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         // if we know the function sparams, try to fill those in now
         // so that the julia_to_native type checks are more likely to be doable (e.g. leaf types) at compile-time
         jl_value_t *jargty_in_env = jargty;
-        if (ctx->spvals_ptr == NULL && !toboxed && unionall_env && jl_has_typevar_from_unionall(jargty, unionall_env) &&
-            jl_svec_len(ctx->linfo->sparam_vals) > 0) {
-            jargty_in_env = jl_instantiate_type_in_env(jargty_in_env, unionall_env, jl_svec_data(ctx->linfo->sparam_vals));
+        if (ctx.spvals_ptr == NULL && !toboxed && unionall_env && jl_has_typevar_from_unionall(jargty, unionall_env) &&
+            jl_svec_len(ctx.linfo->sparam_vals) > 0) {
+            jargty_in_env = jl_instantiate_type_in_env(jargty_in_env, unionall_env, jl_svec_data(ctx.linfo->sparam_vals));
             if (jargty_in_env != jargty)
                 jl_add_method_root(ctx, jargty_in_env);
         }
@@ -1927,15 +1941,15 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         if (!addressOf.at(ai)) {
             if (jl_is_abstract_ref_type(jargty)) {
                 if (!jl_is_cpointer_type(arg.typ)) {
-                    emit_cpointercheck(arg, "ccall: argument to Ref{T} is not a pointer", ctx);
+                    emit_cpointercheck(ctx, arg, "ccall: argument to Ref{T} is not a pointer");
                     arg.typ = (jl_value_t*)jl_voidpointer_type;
                     arg.isboxed = false;
                 }
                 jargty_in_env = (jl_value_t*)jl_voidpointer_type;
             }
 
-            v = julia_to_native(largty, toboxed, jargty_in_env, unionall_env, arg, byRef,
-                                ai + 1, ctx, &needStackRestore);
+            v = julia_to_native(ctx, largty, toboxed, jargty_in_env, unionall_env, arg, byRef,
+                                ai + 1, &needStackRestore);
             bool issigned = jl_signed_type && jl_subtype(jargty, (jl_value_t*)jl_signed_type);
             if (byRef) {
                 v = decay_derived(v);
@@ -1943,24 +1957,24 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                 assert(v->getType() == pargty);
             }
             else {
-                v = llvm_type_rewrite(v, pargty, issigned, ctx);
+                v = llvm_type_rewrite(ctx, v, pargty, issigned);
             }
         }
         else {
             if (jl_is_abstract_ref_type(jargty)) {
-                emit_error("ccall: & on a Ref{T} argument is invalid", ctx);
+                emit_error(ctx, "ccall: & on a Ref{T} argument is invalid");
                 JL_GC_POP();
                 return jl_cgval_t();
             }
-            v = julia_to_address(largty, jargty_in_env, unionall_env, arg,
-                                 ai + 1, ctx, &needStackRestore);
+            v = julia_to_address(ctx, largty, jargty_in_env, unionall_env, arg,
+                                 ai + 1, &needStackRestore);
             if (isa<UndefValue>(v)) {
                 JL_GC_POP();
                 return jl_cgval_t();
             }
             // A bit of a hack, but we're trying to get rid of this feature
             // anyway.
-            v = emit_bitcast(emit_pointer_from_objref(v), pargty);
+            v = emit_bitcast(ctx, emit_pointer_from_objref(ctx, v), pargty);
             assert((!toboxed && !byRef) || isa<UndefValue>(v));
         }
 
@@ -1979,16 +1993,16 @@ jl_cgval_t function_sig_t::emit_a_ccall(
     if (sret) {
         assert(!retboxed && jl_is_datatype(rt) && "sret return type invalid");
         if (jl_isbits(rt)) {
-            result = emit_static_alloca(lrt, ctx);
+            result = emit_static_alloca(ctx, lrt);
         }
         else {
             // XXX: result needs to be zero'd and given a GC root here
             assert(jl_datatype_size(rt) > 0 && "sret shouldn't be a singleton instance");
             result = emit_allocobj(ctx, jl_datatype_size(rt),
-                                   literal_pointer_val((jl_value_t*)rt));
+                                   literal_pointer_val(ctx, (jl_value_t*)rt));
             sretboxed = true;
         }
-        argvals[0] = emit_bitcast(decay_derived(result), fargt_sig.at(0));
+        argvals[0] = emit_bitcast(ctx, decay_derived(result), fargt_sig.at(0));
     }
 
     Instruction *stacksave = NULL;
@@ -2025,13 +2039,13 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         }
     }
     else if (symarg.jl_ptr != NULL) {
-        null_pointer_check(symarg.jl_ptr, ctx);
+        null_pointer_check(ctx, symarg.jl_ptr);
         Type *funcptype = PointerType::get(functype, 0);
-        llvmf = builder.CreateIntToPtr(symarg.jl_ptr, funcptype);
+        llvmf = ctx.builder.CreateIntToPtr(symarg.jl_ptr, funcptype);
     }
     else if (symarg.fptr != NULL) {
         Type *funcptype = PointerType::get(functype, 0);
-        llvmf = literal_static_pointer_val((void*)(uintptr_t)symarg.fptr, funcptype);
+        llvmf = literal_static_pointer_val(ctx, (void*)(uintptr_t)symarg.fptr, funcptype);
         if (imaging_mode)
             jl_printf(JL_STDERR,"WARNING: literal address used in ccall for %s; code cannot be statically compiled\n", symarg.f_name);
     }
@@ -2043,9 +2057,9 @@ jl_cgval_t function_sig_t::emit_a_ccall(
             // vararg requires musttail,
             // but musttail is incompatible with noreturn.
             if (functype->isVarArg())
-                llvmf = runtime_sym_lookup(funcptype, symarg.f_lib, symarg.f_name, ctx->f);
+                llvmf = runtime_sym_lookup(ctx, funcptype, symarg.f_lib, symarg.f_name, ctx.f);
             else
-                llvmf = emit_plt(functype, attributes, cc, symarg.f_lib, symarg.f_name);
+                llvmf = emit_plt(ctx, functype, attributes, cc, symarg.f_lib, symarg.f_name);
         }
         else {
             void *symaddr = jl_dlsym_e(jl_get_library(symarg.f_lib), symarg.f_name);
@@ -2060,18 +2074,18 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                     msg << " in library ";
                     msg << symarg.f_lib;
                 }
-                emit_error(msg.str(), ctx);
+                emit_error(ctx, msg.str());
                 return jl_cgval_t();
             }
             // since we aren't saving this code, there's no sense in
             // putting anything complicated here: just JIT the function address
-            llvmf = literal_static_pointer_val(symaddr, funcptype);
+            llvmf = literal_static_pointer_val(ctx, symaddr, funcptype);
         }
     }
 
     OperandBundleDef OpBundle("jl_roots", gc_uses);
     // the actual call
-    Value *ret = builder.CreateCall(prepare_call(llvmf),
+    Value *ret = ctx.builder.CreateCall(prepare_call(llvmf),
                                     ArrayRef<Value*>(&argvals[0], nargs + sret),
                                     ArrayRef<OperandBundleDef>(&OpBundle, gc_uses.empty() ? 0 : 1));
     ((CallInst*)ret)->setAttributes(attributes);
@@ -2082,14 +2096,14 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         result = ret;
     if (needStackRestore) {
         assert(stacksave != NULL);
-        builder.CreateCall(Intrinsic::getDeclaration(jl_Module, Intrinsic::stackrestore), stacksave);
+        ctx.builder.CreateCall(Intrinsic::getDeclaration(jl_Module, Intrinsic::stackrestore), stacksave);
     }
     if (0) { // Enable this to turn on SSPREQ (-fstack-protector) on the function containing this ccall
-        ctx->f->addFnAttr(Attribute::StackProtectReq);
+        ctx.f->addFnAttr(Attribute::StackProtectReq);
     }
 
     if (rt == jl_bottom_type) {
-        CreateTrap(builder);
+        CreateTrap(ctx.builder);
         return jl_cgval_t();
     }
 
@@ -2108,7 +2122,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
             // something alloca'd above is SSA
             if (static_rt)
                 return mark_julia_slot(result, rt, NULL, tbaa_stack);
-            result = builder.CreateLoad(result);
+            result = ctx.builder.CreateLoad(result);
         }
     }
     else {
@@ -2125,7 +2139,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         else if (jlretboxed && !retboxed) {
             assert(jl_is_datatype(rt));
             if (static_rt) {
-                Value *runtime_bt = literal_pointer_val(rt);
+                Value *runtime_bt = literal_pointer_val(ctx, rt);
                 size_t rtsz = jl_datatype_size(rt);
                 assert(rtsz > 0);
                 Value *strct = emit_allocobj(ctx, rtsz, runtime_bt);
@@ -2143,16 +2157,16 @@ jl_cgval_t function_sig_t::emit_a_ccall(
 #endif
                 // copy the data from the return value to the new struct
                 MDNode *tbaa = jl_is_mutable(rt) ? tbaa_mutab : tbaa_immut;
-                init_bits_value(strct, result, tbaa, boxalign);
-                return mark_julia_type(strct, true, rt, ctx);
+                init_bits_value(ctx, strct, result, tbaa, boxalign);
+                return mark_julia_type(ctx, strct, true, rt);
             }
             jlretboxed = false; // trigger mark_or_box_ccall_result to build the runtime box
         }
         else if (lrt != prt) {
             assert(jlrt == lrt || !lrt->isStructTy()); // julia_type_to_llvm and julia_struct_to_llvm should be returning the same StructType
-            result = llvm_type_rewrite(result, lrt, false, ctx);
+            result = llvm_type_rewrite(ctx, result, lrt, false);
         }
     }
 
-    return mark_or_box_ccall_result(result, jlretboxed, rt, unionall_env, static_rt, ctx);
+    return mark_or_box_ccall_result(ctx, result, jlretboxed, rt, unionall_env, static_rt);
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -8,10 +8,10 @@ static Instruction *tbaa_decorate(MDNode *md, Instruction *load_or_store)
     return load_or_store;
 }
 
-static Value *prepare_call(IRBuilder<> &builder, Value *Callee)
+#define prepare_call(Callee) prepare_call_in(jl_Module, (Callee))
+static Value *prepare_call_in(Module *M, Value *Callee)
 {
     if (Function *F = dyn_cast<Function>(Callee)) {
-        Module *M = jl_builderModule;
         GlobalValue *local = M->getNamedValue(Callee->getName());
         if (!local) {
             local = function_proto(F, M);
@@ -20,21 +20,17 @@ static Value *prepare_call(IRBuilder<> &builder, Value *Callee)
     }
     return Callee;
 }
-static Value *prepare_call(Value *Callee)
-{
-    return prepare_call(builder, Callee);
-}
 
-static Value *maybe_decay_untracked(Value *V)
+static Value *maybe_decay_untracked(IRBuilder<> &irbuilder, Value *V)
 {
     if (V->getType() == T_pjlvalue)
-        return builder.CreateAddrSpaceCast(V, T_prjlvalue);
+        return irbuilder.CreateAddrSpaceCast(V, T_prjlvalue);
     else if (V->getType() == T_ppjlvalue)
-        return builder.CreateBitCast(V, T_pprjlvalue);
+        return irbuilder.CreateBitCast(V, T_pprjlvalue);
     return V;
 }
 
-static Constant *maybe_decay_untracked(Constant *C)
+static Constant *maybe_decay_untracked(IRBuilder<> &irbuilder, Constant *C)
 {
     if (C->getType() == T_pjlvalue)
         return ConstantExpr::getAddrSpaceCast(C, T_prjlvalue);
@@ -43,33 +39,39 @@ static Constant *maybe_decay_untracked(Constant *C)
     return C;
 }
 
-static Value *decay_derived(Value *V)
+static Value *decay_derived(IRBuilder<> &irbuilder, Value *V)
 {
     Type *T = V->getType();
     if (cast<PointerType>(T)->getAddressSpace() == AddressSpace::Derived)
         return V;
     // Once llvm deletes pointer element types, we won't need it here any more either.
     Type *NewT = PointerType::get(cast<PointerType>(T)->getElementType(), AddressSpace::Derived);
-    return builder.CreateAddrSpaceCast(V, NewT);
+    return irbuilder.CreateAddrSpaceCast(V, NewT);
 }
 
-static Value *mark_callee_rooted(Value *V)
+static Value *mark_callee_rooted(IRBuilder<> &irbuilder, Value *V)
 {
     assert(V->getType() == T_pjlvalue || V->getType() == T_prjlvalue);
-    return builder.CreateAddrSpaceCast(V,
+    return irbuilder.CreateAddrSpaceCast(V,
         PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
 }
+
+#define maybe_decay_untracked(V)  maybe_decay_untracked(ctx.builder, (V))
+#define maybe_decay_untracked(V)  maybe_decay_untracked(ctx.builder, (V))
+#define decay_derived(V)          decay_derived(ctx.builder, (V))
+#define mark_callee_rooted(V)     mark_callee_rooted(ctx.builder, (V))
+
 
 // --- language feature checks ---
 
 // branch on whether a language feature is enabled or not
-#define JL_FEAT_TEST(ctx, feature) ((ctx)->params->feature)
+#define JL_FEAT_TEST(ctx, feature) ((ctx).params->feature)
 
 // require a language feature to be enabled
 #define JL_FEAT_REQUIRE(ctx, feature) \
     if (!JL_FEAT_TEST(ctx, feature)) \
         jl_errorf("%s for %s:%d requires the " #feature " language feature, which is disabled", \
-                  __FUNCTION__, (ctx)->file.str().c_str(), *(ctx)->line);
+                  __FUNCTION__, (ctx).file.str().c_str(), *(ctx).line);
 
 
 // --- hook checks ---
@@ -92,7 +94,7 @@ static inline void _hook_call(jl_value_t *hook, std::array<jl_value_t*,N> args) 
 
 // --- string constants ---
 static StringMap<GlobalVariable*> stringConstants;
-static Value *stringConstPtr(IRBuilder<> &builder, const std::string &txt)
+static Value *stringConstPtr(IRBuilder<> &irbuilder, const std::string &txt)
 {
     StringRef ctxt(txt.c_str(), strlen(txt.c_str()) + 1);
     StringMap<GlobalVariable*>::iterator pooledval =
@@ -114,10 +116,10 @@ static Value *stringConstPtr(IRBuilder<> &builder, const std::string &txt)
             jl_ExecutionEngine->addGlobalMapping(gv, (void*)(uintptr_t)pooledtxt.data());
         }
 
-        GlobalVariable *v = prepare_global(pooledval->second, jl_builderModule);
+        GlobalVariable *v = prepare_global_in(jl_builderModule(irbuilder), pooledval->second);
         Value *zero = ConstantInt::get(Type::getInt32Ty(jl_LLVMContext), 0);
         Value *Args[] = { zero, zero };
-        return builder.CreateInBoundsGEP(v->getValueType(), v, Args);
+        return irbuilder.CreateInBoundsGEP(v->getValueType(), v, Args);
     }
     else {
         Value *v = ConstantExpr::getIntToPtr(
@@ -125,10 +127,6 @@ static Value *stringConstPtr(IRBuilder<> &builder, const std::string &txt)
                 T_pint8);
         return v;
     }
-}
-static Value *stringConstPtr(const std::string &txt)
-{
-    return stringConstPtr(builder, txt);
 }
 
 // --- Debug info ---
@@ -211,14 +209,14 @@ static DIType *julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxe
     return jl_pvalue_dillvmt;
 }
 
-static Value *emit_pointer_from_objref(Value *V)
+static Value *emit_pointer_from_objref(jl_codectx_t &ctx, Value *V)
 {
     unsigned AS = cast<PointerType>(V->getType())->getAddressSpace();
     if (AS != AddressSpace::Tracked && AS != AddressSpace::Derived)
-        return builder.CreateBitCast(V, T_pjlvalue);
-    V = builder.CreateBitCast(decay_derived(V),
+        return ctx.builder.CreateBitCast(V, T_pjlvalue);
+    V = ctx.builder.CreateBitCast(decay_derived(V),
             PointerType::get(T_jlvalue, AddressSpace::Derived));
-    CallInst *Call = builder.CreateCall(prepare_call(pointer_from_objref_func), V);
+    CallInst *Call = ctx.builder.CreateCall(prepare_call(pointer_from_objref_func), V);
 #if JL_LLVM_VERSION >= 50000
     Call->addAttribute(AttributeList::FunctionIndex, Attribute::ReadNone);
 #else
@@ -229,7 +227,7 @@ static Value *emit_pointer_from_objref(Value *V)
 
 // --- emitting pointers directly into code ---
 
-static Constant *literal_static_pointer_val(const void *p, Type *t)
+static Constant *literal_static_pointer_val(jl_codectx_t &ctx, const void *p, Type *t)
 {
     // this function will emit a static pointer into the generated code
     // the generated code will only be valid during the current session,
@@ -242,13 +240,13 @@ static Constant *literal_static_pointer_val(const void *p, Type *t)
 }
 
 
-static Value *julia_pgv(const char *cname, void *addr)
+static Value *julia_pgv(jl_codectx_t &ctx, const char *cname, void *addr)
 {
     // emit a GlobalVariable for a jl_value_t named "cname"
-    return jl_get_global_for(cname, addr, jl_builderModule);
+    return jl_get_global_for(cname, addr, jl_Module);
 }
 
-static Value *julia_pgv(const char *prefix, jl_sym_t *name, jl_module_t *mod, void *addr)
+static Value *julia_pgv(jl_codectx_t &ctx, const char *prefix, jl_sym_t *name, jl_module_t *mod, void *addr)
 {
     // emit a GlobalVariable for a jl_value_t, using the prefix, name, and module to
     // to create a readable name of the form prefixModA.ModB.name
@@ -274,75 +272,75 @@ static Value *julia_pgv(const char *prefix, jl_sym_t *name, jl_module_t *mod, vo
         prev = parent;
         parent = parent->parent;
     }
-    return julia_pgv(fullname, addr);
+    return julia_pgv(ctx, fullname, addr);
 }
 
 static GlobalVariable *julia_const_gv(jl_value_t *val);
-static Value *literal_pointer_val_slot(jl_value_t *p)
+static Value *literal_pointer_val_slot(jl_codectx_t &ctx, jl_value_t *p)
 {
     // emit a pointer to a jl_value_t* which will allow it to be valid across reloading code
     // also, try to give it a nice name for gdb, for easy identification
     if (!imaging_mode) {
-        Module *M = jl_builderModule;
+        Module *M = jl_Module;
         GlobalVariable *gv = new GlobalVariable(
                 *M, T_pjlvalue, true, GlobalVariable::PrivateLinkage,
-                literal_static_pointer_val(p, T_pjlvalue));
+                literal_static_pointer_val(ctx, p, T_pjlvalue));
         gv->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
         return gv;
     }
     if (GlobalVariable *gv = julia_const_gv(p)) {
         // if this is a known object, use the existing GlobalValue
-        return maybe_decay_untracked(prepare_global(gv, jl_builderModule));
+        return maybe_decay_untracked(prepare_global(gv));
     }
     if (jl_is_datatype(p)) {
         jl_datatype_t *addr = (jl_datatype_t*)p;
         // DataTypes are prefixed with a +
-        return maybe_decay_untracked(julia_pgv("+", addr->name->name, addr->name->module, p));
+        return maybe_decay_untracked(julia_pgv(ctx, "+", addr->name->name, addr->name->module, p));
     }
     if (jl_is_method(p)) {
         jl_method_t *m = (jl_method_t*)p;
         // functions are prefixed with a -
-        return maybe_decay_untracked(julia_pgv("-", m->name, m->module, p));
+        return maybe_decay_untracked(julia_pgv(ctx, "-", m->name, m->module, p));
     }
     if (jl_is_method_instance(p)) {
         jl_method_instance_t *linfo = (jl_method_instance_t*)p;
         // Type-inferred functions are also prefixed with a -
         if (jl_is_method(linfo->def.method))
-            return maybe_decay_untracked(julia_pgv("-", linfo->def.method->name, linfo->def.method->module, p));
+            return maybe_decay_untracked(julia_pgv(ctx, "-", linfo->def.method->name, linfo->def.method->module, p));
     }
     if (jl_is_symbol(p)) {
         jl_sym_t *addr = (jl_sym_t*)p;
         // Symbols are prefixed with jl_sym#
-        return maybe_decay_untracked(julia_pgv("jl_sym#", addr, NULL, p));
+        return maybe_decay_untracked(julia_pgv(ctx, "jl_sym#", addr, NULL, p));
     }
     // something else gets just a generic name
-    return maybe_decay_untracked(julia_pgv("jl_global#", p));
+    return maybe_decay_untracked(julia_pgv(ctx, "jl_global#", p));
 }
 
-static Value *literal_pointer_val(jl_value_t *p)
+static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p)
 {
     if (p == NULL)
         return V_null;
     if (!imaging_mode)
-        return literal_static_pointer_val(p, T_prjlvalue);
-    Value *pgv = literal_pointer_val_slot(p);
-    return tbaa_decorate(tbaa_const, builder.CreateLoad(pgv));
+        return literal_static_pointer_val(ctx, p, T_prjlvalue);
+    Value *pgv = literal_pointer_val_slot(ctx, p);
+    return tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(pgv));
 }
 
-static Value *literal_pointer_val(jl_binding_t *p)
+static Value *literal_pointer_val(jl_codectx_t &ctx, jl_binding_t *p)
 {
     // emit a pointer to any jl_value_t which will be valid across reloading code
     if (p == NULL)
         return V_null;
     if (!imaging_mode)
-        return literal_static_pointer_val(p, T_pjlvalue);
+        return literal_static_pointer_val(ctx, p, T_pjlvalue);
     // bindings are prefixed with jl_bnd#
-    Value *pgv = julia_pgv("jl_bnd#", p->name, p->owner, p);
-    return tbaa_decorate(tbaa_const, builder.CreateLoad(pgv));
+    Value *pgv = julia_pgv(ctx, "jl_bnd#", p->name, p->owner, p);
+    return tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(pgv));
 }
 
 // bitcast a value, but preserve its address space when dealing with pointer types
-static Value *emit_bitcast(Value *v, Type *jl_value)
+static Value *emit_bitcast(jl_codectx_t &ctx, Value *v, Type *jl_value)
 {
     if (isa<PointerType>(jl_value) &&
         v->getType()->getPointerAddressSpace() != jl_value->getPointerAddressSpace()) {
@@ -350,32 +348,32 @@ static Value *emit_bitcast(Value *v, Type *jl_value)
         Type *jl_value_addr =
                 PointerType::get(cast<PointerType>(jl_value)->getElementType(),
                                  v->getType()->getPointerAddressSpace());
-        return builder.CreateBitCast(v, jl_value_addr);
+        return ctx.builder.CreateBitCast(v, jl_value_addr);
     }
     else {
-        return builder.CreateBitCast(v, jl_value);
+        return ctx.builder.CreateBitCast(v, jl_value);
     }
 }
 
-static Value *julia_binding_gv(Value *bv)
+static Value *julia_binding_gv(jl_codectx_t &ctx, Value *bv)
 {
     Value *offset = ConstantInt::get(T_size, offsetof(jl_binding_t, value) / sizeof(size_t));
-    return builder.CreateGEP(bv, offset);
+    return ctx.builder.CreateGEP(bv, offset);
 }
 
-static Value *julia_binding_gv(jl_binding_t *b)
+static Value *julia_binding_gv(jl_codectx_t &ctx, jl_binding_t *b)
 {
     // emit a literal_pointer_val to the value field of a jl_binding_t
     // binding->value are prefixed with *
     Value *bv;
     if (imaging_mode)
-        bv = emit_bitcast(
+        bv = emit_bitcast(ctx,
                 tbaa_decorate(tbaa_const,
-                              builder.CreateLoad(julia_pgv("*", b->name, b->owner, b))),
+                              ctx.builder.CreateLoad(julia_pgv(ctx, "*", b->name, b->owner, b))),
                 T_pprjlvalue);
     else
-        bv = literal_static_pointer_val(b, T_pprjlvalue);
-    return julia_binding_gv(bv);
+        bv = literal_static_pointer_val(ctx, b, T_pprjlvalue);
+    return julia_binding_gv(ctx, bv);
 }
 
 // --- mapping between julia and llvm types ---
@@ -606,7 +604,7 @@ static bool for_each_uniontype_small(
     return false;
 }
 
-static Value *emit_typeof_boxed(const jl_cgval_t &p, jl_codectx_t *ctx);
+static Value *emit_typeof_boxed(jl_codectx_t &ctx, const jl_cgval_t &p);
 
 static unsigned get_box_tindex(jl_datatype_t *jt, jl_value_t *ut)
 {
@@ -626,57 +624,57 @@ static unsigned get_box_tindex(jl_datatype_t *jt, jl_value_t *ut)
 
 // --- generating various field accessors ---
 
-static Value *emit_nthptr_addr(Value *v, ssize_t n, bool gctracked = true)
+static Value *emit_nthptr_addr(jl_codectx_t &ctx, Value *v, ssize_t n, bool gctracked = true)
 {
-    return builder.CreateGEP(emit_bitcast(gctracked ? decay_derived(v) : v, T_pprjlvalue),
+    return ctx.builder.CreateGEP(emit_bitcast(ctx, gctracked ? decay_derived(v) : v, T_pprjlvalue),
                              ConstantInt::get(T_size, n));
 }
 
-static Value *emit_nthptr_addr(Value *v, Value *idx, bool gctracked = true)
+static Value *emit_nthptr_addr(jl_codectx_t &ctx, Value *v, Value *idx, bool gctracked = true)
 {
-    return builder.CreateGEP(emit_bitcast(gctracked ? decay_derived(v) : v, T_pprjlvalue), idx);
+    return ctx.builder.CreateGEP(emit_bitcast(ctx, gctracked ? decay_derived(v) : v, T_pprjlvalue), idx);
 }
 
-static Value *emit_nthptr(Value *v, ssize_t n, MDNode *tbaa)
+static Value *emit_nthptr(jl_codectx_t &ctx, Value *v, ssize_t n, MDNode *tbaa)
 {
     // p = (jl_value_t**)v; p[n]
-    Value *vptr = emit_nthptr_addr(v, n);
-    return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
+    Value *vptr = emit_nthptr_addr(ctx, v, n);
+    return tbaa_decorate(tbaa, ctx.builder.CreateLoad(vptr, false));
 }
 
-static Value *emit_nthptr_recast(Value *v, Value *idx, MDNode *tbaa, Type *ptype, bool gctracked = true)
+static Value *emit_nthptr_recast(jl_codectx_t &ctx, Value *v, Value *idx, MDNode *tbaa, Type *ptype, bool gctracked = true)
 {
     // p = (jl_value_t**)v; *(ptype)&p[n]
-    Value *vptr = emit_nthptr_addr(v, idx, gctracked);
-    return tbaa_decorate(tbaa,builder.CreateLoad(emit_bitcast(vptr,ptype), false));
+    Value *vptr = emit_nthptr_addr(ctx, v, idx, gctracked);
+    return tbaa_decorate(tbaa, ctx.builder.CreateLoad(emit_bitcast(ctx, vptr, ptype), false));
 }
 
-static Value *emit_nthptr_recast(Value *v, ssize_t n, MDNode *tbaa, Type *ptype, bool gctracked = true)
+static Value *emit_nthptr_recast(jl_codectx_t &ctx, Value *v, ssize_t n, MDNode *tbaa, Type *ptype, bool gctracked = true)
 {
     // p = (jl_value_t**)v; *(ptype)&p[n]
-    Value *vptr = emit_nthptr_addr(v, n, gctracked);
-    return tbaa_decorate(tbaa,builder.CreateLoad(emit_bitcast(vptr,ptype), false));
+    Value *vptr = emit_nthptr_addr(ctx, v, n, gctracked);
+    return tbaa_decorate(tbaa, ctx.builder.CreateLoad(emit_bitcast(ctx, vptr, ptype), false));
 }
 
-static Value *emit_typeptr_addr(Value *p)
+static Value *emit_typeptr_addr(jl_codectx_t &ctx, Value *p)
 {
     ssize_t offset = (sizeof(jl_taggedvalue_t) -
                       offsetof(jl_taggedvalue_t, type)) / sizeof(jl_value_t*);
-    return emit_nthptr_addr(p, -offset);
+    return emit_nthptr_addr(ctx, p, -offset);
 }
 
-static Value *boxed(const jl_cgval_t &v, jl_codectx_t *ctx, bool gcooted=true);
-static Value *boxed(const jl_cgval_t &v, jl_codectx_t *ctx, jl_value_t* type) = delete; // C++11 (temporary to prevent rebase error)
+static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &v, bool gcooted=true);
+static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t* type) = delete; // C++11 (temporary to prevent rebase error)
 
-static Value* mask_gc_bits(Value *tag)
+static Value* mask_gc_bits(jl_codectx_t &ctx, Value *tag)
 {
-    return builder.CreateIntToPtr(builder.CreateAnd(
-                builder.CreatePtrToInt(tag, T_size),
+    return ctx.builder.CreateIntToPtr(ctx.builder.CreateAnd(
+                ctx.builder.CreatePtrToInt(tag, T_size),
                 ConstantInt::get(T_size, ~(uintptr_t)15)),
             tag->getType());
 }
 
-static Value *emit_typeof(Value *tt)
+static Value *emit_typeof(jl_codectx_t &ctx, Value *tt)
 {
     assert(tt != NULL && !isa<AllocaInst>(tt) && "expected a conditionally boxed value");
     // given p, a jl_value_t*, compute its type tag
@@ -684,21 +682,21 @@ static Value *emit_typeof(Value *tt)
     // Note that this gives the optimizer license to not root this value. That
     // is fine however, since leaf types are not GCed at the moment. Should
     // that ever change, this may have to go through a special intrinsic.
-    Value *addr = emit_bitcast(emit_typeptr_addr(tt), T_ppjlvalue);
-    tt = tbaa_decorate(tbaa_tag, builder.CreateLoad(addr));
-    return maybe_decay_untracked(mask_gc_bits(tt));
+    Value *addr = emit_bitcast(ctx, emit_typeptr_addr(ctx, tt), T_ppjlvalue);
+    tt = tbaa_decorate(tbaa_tag, ctx.builder.CreateLoad(addr));
+    return maybe_decay_untracked(mask_gc_bits(ctx, tt));
 }
 
-static jl_cgval_t emit_typeof(const jl_cgval_t &p, jl_codectx_t *ctx)
+static jl_cgval_t emit_typeof(jl_codectx_t &ctx, const jl_cgval_t &p)
 {
     // given p, compute its type
     if (p.constant)
         return mark_julia_const(jl_typeof(p.constant));
     if (p.isboxed && !jl_is_leaf_type(p.typ)) {
-        return mark_julia_type(emit_typeof(p.V), true, jl_datatype_type, ctx, /*needsroot*/false);
+        return mark_julia_type(ctx, emit_typeof(ctx, p.V), true, jl_datatype_type, /*needsroot*/false);
     }
     if (p.TIndex) {
-        Value *tindex = builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x7f));
+        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x7f));
         Value *pdatatype;
         unsigned counter;
         counter = 0;
@@ -711,26 +709,26 @@ static jl_cgval_t emit_typeof(const jl_cgval_t &p, jl_codectx_t *ctx)
         else {
             // See note above in emit_typeof(Value*), we can't tell the system
             // about this until we've cleared the GC bits.
-            pdatatype = emit_bitcast(emit_typeptr_addr(builder.CreateLoad(p.gcroot)), T_ppjlvalue);
+            pdatatype = emit_bitcast(ctx, emit_typeptr_addr(ctx, ctx.builder.CreateLoad(p.gcroot)), T_ppjlvalue);
         }
         counter = 0;
         for_each_uniontype_small(
                 [&](unsigned idx, jl_datatype_t *jt) {
-                    Value *cmp = builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
-                    pdatatype = builder.CreateSelect(cmp,
-                        decay_derived(emit_bitcast(literal_pointer_val_slot((jl_value_t*)jt), T_ppjlvalue)),
+                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
+                    pdatatype = ctx.builder.CreateSelect(cmp,
+                        decay_derived(emit_bitcast(ctx, literal_pointer_val_slot(ctx, (jl_value_t*)jt), T_ppjlvalue)),
                         decay_derived(pdatatype));
                 },
                 p.typ,
                 counter);
         Value *datatype;
         if (allunboxed) {
-            datatype = tbaa_decorate(tbaa_const, builder.CreateLoad(maybe_decay_untracked(pdatatype)));
+            datatype = tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(maybe_decay_untracked(pdatatype)));
         }
         else {
-            datatype = maybe_decay_untracked(mask_gc_bits(tbaa_decorate(tbaa_tag, builder.CreateLoad(pdatatype))));
+            datatype = maybe_decay_untracked(mask_gc_bits(ctx, tbaa_decorate(tbaa_tag, ctx.builder.CreateLoad(pdatatype))));
         }
-        return mark_julia_type(datatype, true, jl_datatype_type, ctx, /*needsroot*/false);
+        return mark_julia_type(ctx, datatype, true, jl_datatype_type, /*needsroot*/false);
     }
     jl_value_t *aty = p.typ;
     if (jl_is_type_type(aty)) {
@@ -741,80 +739,66 @@ static jl_cgval_t emit_typeof(const jl_cgval_t &p, jl_codectx_t *ctx)
     return mark_julia_const(aty);
 }
 
-static Value *emit_typeof_boxed(const jl_cgval_t &p, jl_codectx_t *ctx)
+static Value *emit_typeof_boxed(jl_codectx_t &ctx, const jl_cgval_t &p)
 {
-    return boxed(emit_typeof(p, ctx), ctx);
+    return boxed(ctx, emit_typeof(ctx, p));
 }
 
-static Value *emit_datatype_types(Value *dt)
+static Value *emit_datatype_types(jl_codectx_t &ctx, Value *dt)
 {
-    return tbaa_decorate(tbaa_const, builder.
-        CreateLoad(emit_bitcast(builder.
-                                CreateGEP(emit_bitcast(decay_derived(dt), T_pint8),
-                                          ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
-                                T_ppjlvalue)));
+    Value *Ptr = emit_bitcast(ctx, decay_derived(dt), T_ppjlvalue);
+    Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, types) / sizeof(void*));
+    return tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(T_pjlvalue, ctx.builder.CreateGEP(T_pjlvalue, Ptr, Idx)));
 }
 
-static Value *emit_datatype_nfields(Value *dt)
+static Value *emit_datatype_nfields(jl_codectx_t &ctx, Value *dt)
 {
-    Value *nf = tbaa_decorate(tbaa_const, builder.CreateLoad(
-        tbaa_decorate(tbaa_const, builder.CreateLoad(
-            emit_bitcast(
-                builder.CreateGEP(
-                    emit_bitcast(decay_derived(dt), T_pint8),
-                    ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
-                T_pint32->getPointerTo())))));
-#ifdef _P64
-    nf = builder.CreateSExt(nf, T_int64);
-#endif
-    return nf;
+    Value *type_svec = emit_bitcast(ctx, emit_datatype_types(ctx, dt), T_psize);
+    return tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(T_size, type_svec));
 }
 
-static Value *emit_datatype_size(Value *dt)
+static Value *emit_datatype_size(jl_codectx_t &ctx, Value *dt)
 {
-    Value *size = tbaa_decorate(tbaa_const, builder.
-        CreateLoad(emit_bitcast(builder.
-                                CreateGEP(emit_bitcast(decay_derived(dt), T_pint8),
-                                          ConstantInt::get(T_size, offsetof(jl_datatype_t, size))),
-                                T_pint32)));
-    return size;
+    Value *Ptr = emit_bitcast(ctx, decay_derived(dt), T_pint32);
+    Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, size) / sizeof(int));
+    return tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(T_int32, ctx.builder.CreateGEP(T_int32, Ptr, Idx)));
 }
 
 /* this is valid code, it's simply unused
-static Value *emit_sizeof(const jl_cgval_t &p, jl_codectx_t *ctx)
+static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
 {
     if (p.TIndex) {
-        Value *tindex = builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x7f));
+        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x7f));
         Value *size = ConstantInt::get(T_int32, -1);
         unsigned counter = 0;
         bool allunboxed = for_each_uniontype_small(
                 [&](unsigned idx, jl_datatype_t *jt) {
-                    Value *cmp = builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
-                    size = builder.CreateSelect(cmp, ConstantInt::get(T_int32, jl_datatype_size(jt)), size);
+                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
+                    size = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int32, jl_datatype_size(jt)), size);
                 },
                 p.typ,
                 counter);
         if (!allunboxed && p.ispointer() && p.V && !isa<AllocaInst>(p.V)) {
-            BasicBlock *currBB = builder.GetInsertBlock();
-            BasicBlock *dynloadBB = BasicBlock::Create(jl_LLVMContext, "dyn_sizeof", ctx->f);
-            BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_sizeof", ctx->f);
-            Value *isboxed = builder.CreateICmpNE(
-                    builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x80)),
+            BasicBlock *currBB = ctx.builder.GetInsertBlock();
+            BasicBlock *dynloadBB = BasicBlock::Create(jl_LLVMContext, "dyn_sizeof", ctx.f);
+            BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_sizeof", ctx.f);
+            Value *isboxed = ctx.builder.CreateICmpNE(
+                    ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x80)),
                     ConstantInt::get(T_int8, 0));
-            builder.CreateCondBr(isboxed, dynloadBB, postBB);
-            builder.SetInsertPoint(dynloadBB);
+            ctx.builder.CreateCondBr(isboxed, dynloadBB, postBB);
+            ctx.builder.SetInsertPoint(dynloadBB);
             Value *datatype = emit_typeof(p.V);
-            Value *dyn_size = emit_datatype_size(datatype);
-            builder.CreateBr(postBB);
-            builder.SetInsertPoint(postBB);
-            PHINode *sizeof_merge = builder.CreatePHI(T_int32, 2);
+            Value *dyn_size = emit_datatype_size(ctx, datatype);
+            ctx.builder.CreateBr(postBB);
+            ctx.builder.SetInsertPoint(postBB);
+            PHINode *sizeof_merge = ctx.builder.CreatePHI(T_int32, 2);
             sizeof_merge->addIncoming(dyn_size, dynloadBB);
             sizeof_merge->addIncoming(size, currBB);
             size = sizeof_merge;
         }
 #ifndef NDEBUG
         // try to catch codegen errors early, before it uses this to memcpy over the entire stack
-        CreateConditionalAbort(builder, builder.CreateICmpEQ(size, ConstantInt::get(T_int32, -1)));
+        CreateConditionalAbort(ctx.builder, ctx.builder.CreateICmpEQ(size, ConstantInt::get(T_int32, -1)));
 #endif
         return size;
     }
@@ -822,44 +806,49 @@ static Value *emit_sizeof(const jl_cgval_t &p, jl_codectx_t *ctx)
         return ConstantInt::get(T_int32, jl_datatype_size(p.typ));
     }
     else {
-        Value *datatype = emit_typeof_boxed(p, ctx);
-        Value *dyn_size = emit_datatype_size(datatype);
+        Value *datatype = emit_typeof_boxed(ctx, p);
+        Value *dyn_size = emit_datatype_size(ctx, datatype);
         return dyn_size;
     }
 }
 */
 
-static Value *emit_datatype_mutabl(Value *dt)
+static Value *emit_datatype_mutabl(jl_codectx_t &ctx, Value *dt)
 {
-    Value *mutabl = tbaa_decorate(tbaa_const, builder.
-        CreateLoad(builder.CreateGEP(emit_bitcast(decay_derived(dt), T_pint8),
-                                     ConstantInt::get(T_size, offsetof(jl_datatype_t, mutabl)))));
-    return builder.CreateTrunc(mutabl, T_int1);
+    Value *Ptr = emit_bitcast(ctx, decay_derived(dt), T_pint8);
+    Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, mutabl));
+    Value *mutabl = tbaa_decorate(tbaa_const,
+            ctx.builder.CreateLoad(T_int8, ctx.builder.CreateGEP(T_int8, Ptr, Idx)));
+    return ctx.builder.CreateTrunc(mutabl, T_int1);
 }
 
-static Value *emit_datatype_abstract(Value *dt)
+static Value *emit_datatype_abstract(jl_codectx_t &ctx, Value *dt)
 {
-    Value *abstract = tbaa_decorate(tbaa_const, builder.
-        CreateLoad(builder.CreateGEP(emit_bitcast(decay_derived(dt), T_pint8),
-                                     ConstantInt::get(T_size, offsetof(jl_datatype_t, abstract)))));
-    return builder.CreateTrunc(abstract, T_int1);
+    Value *Ptr = emit_bitcast(ctx, decay_derived(dt), T_pint8);
+    Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, abstract));
+
+    Value *abstract = tbaa_decorate(tbaa_const,
+            ctx.builder.CreateLoad(T_int8, ctx.builder.CreateGEP(T_int8, Ptr, Idx)));
+    return ctx.builder.CreateTrunc(abstract, T_int1);
 }
 
-static Value *emit_datatype_isbitstype(Value *dt)
+static Value *emit_datatype_isbitstype(jl_codectx_t &ctx, Value *dt)
 {
-    Value *immut = builder.CreateXor(emit_datatype_mutabl(dt), ConstantInt::get(T_int1, -1));
-    Value *nofields = builder.CreateICmpEQ(emit_datatype_nfields(dt), ConstantInt::get(T_size, 0));
-    Value *isbitstype = builder.CreateAnd(immut, builder.CreateAnd(nofields,
-            builder.CreateXor(builder.CreateAnd(emit_datatype_abstract(dt),
-                    builder.CreateICmpSGT(emit_datatype_size(dt), ConstantInt::get(T_int32, 0))),
+    Value *immut = ctx.builder.CreateXor(emit_datatype_mutabl(ctx, dt), ConstantInt::get(T_int1, -1));
+    Value *nofields = ctx.builder.CreateICmpEQ(emit_datatype_nfields(ctx, dt), ConstantInt::get(T_size, 0));
+    Value *isbitstype = ctx.builder.CreateAnd(immut, ctx.builder.CreateAnd(nofields,
+            ctx.builder.CreateXor(ctx.builder.CreateAnd(emit_datatype_abstract(ctx, dt),
+                    ctx.builder.CreateICmpSGT(emit_datatype_size(ctx, dt), ConstantInt::get(T_int32, 0))),
                 ConstantInt::get(T_int1, -1))));
     return isbitstype;
 }
 
-static Value *emit_datatype_name(Value *dt)
+static Value *emit_datatype_name(jl_codectx_t &ctx, Value *dt)
 {
-    return emit_nthptr(dt, (ssize_t)(offsetof(jl_datatype_t,name)/sizeof(char*)),
-                       tbaa_const);
+    return emit_nthptr(
+            ctx, dt,
+            (ssize_t)(offsetof(jl_datatype_t, name) / sizeof(char*)),
+            tbaa_const);
 }
 
 // --- generating various error checks ---
@@ -867,68 +856,68 @@ static Value *emit_datatype_name(Value *dt)
 // the error is always thrown. This may cause non dominated use
 // of SSA value error in the verifier.
 
-static void just_emit_error(const std::string &txt, jl_codectx_t *ctx)
+static void just_emit_error(jl_codectx_t &ctx, const std::string &txt)
 {
-    builder.CreateCall(prepare_call(jlerror_func), stringConstPtr(txt));
+    ctx.builder.CreateCall(prepare_call(jlerror_func), stringConstPtr(ctx.builder, txt));
 }
 
-static void emit_error(const std::string &txt, jl_codectx_t *ctx)
+static void emit_error(jl_codectx_t &ctx, const std::string &txt)
 {
-    just_emit_error(txt, ctx);
-    builder.CreateUnreachable();
-    BasicBlock *cont = BasicBlock::Create(jl_LLVMContext,"after_error",ctx->f);
-    builder.SetInsertPoint(cont);
+    just_emit_error(ctx, txt);
+    ctx.builder.CreateUnreachable();
+    BasicBlock *cont = BasicBlock::Create(jl_LLVMContext,"after_error",ctx.f);
+    ctx.builder.SetInsertPoint(cont);
 }
 
 // DO NOT PASS IN A CONST CONDITION!
-static void error_unless(Value *cond, const std::string &msg, jl_codectx_t *ctx)
+static void error_unless(jl_codectx_t &ctx, Value *cond, const std::string &msg)
 {
-    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx.f);
     BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
-    builder.CreateCondBr(cond, passBB, failBB);
-    builder.SetInsertPoint(failBB);
-    just_emit_error(msg, ctx);
-    builder.CreateUnreachable();
-    ctx->f->getBasicBlockList().push_back(passBB);
-    builder.SetInsertPoint(passBB);
+    ctx.builder.CreateCondBr(cond, passBB, failBB);
+    ctx.builder.SetInsertPoint(failBB);
+    just_emit_error(ctx, msg);
+    ctx.builder.CreateUnreachable();
+    ctx.f->getBasicBlockList().push_back(passBB);
+    ctx.builder.SetInsertPoint(passBB);
 }
 
-static void raise_exception(Value *exc, jl_codectx_t *ctx,
+static void raise_exception(jl_codectx_t &ctx, Value *exc,
                             BasicBlock *contBB=nullptr)
 {
-    if (JL_HOOK_TEST(ctx->params, raise_exception)) {
-        JL_HOOK_CALL(ctx->params, raise_exception, 2,
-                     jl_box_voidpointer(wrap(builder.GetInsertBlock())),
+    if (JL_HOOK_TEST(ctx.params, raise_exception)) {
+        JL_HOOK_CALL(ctx.params, raise_exception, 2,
+                     jl_box_voidpointer(wrap(ctx.builder.GetInsertBlock())),
                      jl_box_voidpointer(wrap(exc)));
     } else {
         JL_FEAT_REQUIRE(ctx, runtime);
-        builder.CreateCall(prepare_call(jlthrow_func), { mark_callee_rooted(exc) });
+        ctx.builder.CreateCall(prepare_call(jlthrow_func), { mark_callee_rooted(exc) });
     }
-    builder.CreateUnreachable();
+    ctx.builder.CreateUnreachable();
     if (!contBB) {
-        contBB = BasicBlock::Create(jl_LLVMContext, "after_throw", ctx->f);
+        contBB = BasicBlock::Create(jl_LLVMContext, "after_throw", ctx.f);
     }
     else {
-        ctx->f->getBasicBlockList().push_back(contBB);
+        ctx.f->getBasicBlockList().push_back(contBB);
     }
-    builder.SetInsertPoint(contBB);
+    ctx.builder.SetInsertPoint(contBB);
 }
 
 // DO NOT PASS IN A CONST CONDITION!
-static void raise_exception_unless(Value *cond, Value *exc, jl_codectx_t *ctx)
+static void raise_exception_unless(jl_codectx_t &ctx, Value *cond, Value *exc)
 {
-    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx.f);
     BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
-    builder.CreateCondBr(cond, passBB, failBB);
-    builder.SetInsertPoint(failBB);
-    raise_exception(exc, ctx, passBB);
+    ctx.builder.CreateCondBr(cond, passBB, failBB);
+    ctx.builder.SetInsertPoint(failBB);
+    raise_exception(ctx, exc, passBB);
 }
 
 // DO NOT PASS IN A CONST CONDITION!
-static void raise_exception_if(Value *cond, Value *exc, jl_codectx_t *ctx)
+static void raise_exception_if(jl_codectx_t &ctx, Value *cond, Value *exc)
 {
-    raise_exception_unless(builder.CreateXor(cond, ConstantInt::get(T_int1,-1)),
-                           exc, ctx);
+    raise_exception_unless(ctx, ctx.builder.CreateXor(cond, ConstantInt::get(T_int1,-1)),
+                           exc);
 }
 
 static size_t dereferenceable_size(jl_value_t *jt) {
@@ -973,23 +962,23 @@ static inline Instruction *maybe_mark_load_dereferenceable(Instruction *LI, bool
     return maybe_mark_load_dereferenceable(LI, can_be_null, size);
 }
 
-static void null_pointer_check(Value *v, jl_codectx_t *ctx)
+static void null_pointer_check(jl_codectx_t &ctx, Value *v)
 {
-    raise_exception_unless(builder.CreateICmpNE(v,Constant::getNullValue(v->getType())),
-                           literal_pointer_val(jl_undefref_exception), ctx);
+    raise_exception_unless(ctx,
+            ctx.builder.CreateICmpNE(v, Constant::getNullValue(v->getType())),
+            literal_pointer_val(ctx, jl_undefref_exception));
 }
 
-static void emit_type_error(const jl_cgval_t &x, Value *type, const std::string &msg,
-                            jl_codectx_t *ctx)
+static void emit_type_error(jl_codectx_t &ctx, const jl_cgval_t &x, Value *type, const std::string &msg)
 {
-    Value *fname_val = stringConstPtr(ctx->funcName);
-    Value *msg_val = stringConstPtr(msg);
-    builder.CreateCall(prepare_call(jltypeerror_func),
+    Value *fname_val = stringConstPtr(ctx.builder, ctx.funcName);
+    Value *msg_val = stringConstPtr(ctx.builder, msg);
+    ctx.builder.CreateCall(prepare_call(jltypeerror_func),
                        { fname_val, msg_val,
-                         type, mark_callee_rooted(boxed(x, ctx, false))});
+                         type, mark_callee_rooted(boxed(ctx, x, false))});
 }
 
-static std::pair<Value*, bool> emit_isa(const jl_cgval_t &x, jl_value_t *type, const std::string *msg, jl_codectx_t *ctx)
+static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *type, const std::string *msg)
 {
     Optional<bool> known_isa;
     if (x.constant)
@@ -1000,24 +989,24 @@ static std::pair<Value*, bool> emit_isa(const jl_cgval_t &x, jl_value_t *type, c
         known_isa = false;
     if (known_isa) {
         if (!*known_isa && msg) {
-            emit_type_error(x, literal_pointer_val(type), *msg, ctx);
-            builder.CreateUnreachable();
-            BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx->f);
-            builder.SetInsertPoint(failBB);
+            emit_type_error(ctx, x, literal_pointer_val(ctx, type), *msg);
+            ctx.builder.CreateUnreachable();
+            BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx.f);
+            ctx.builder.SetInsertPoint(failBB);
         }
         return std::make_pair(ConstantInt::get(T_int1, *known_isa), true);
     }
 
     // intersection with Type needs to be handled specially
     if (jl_has_intersect_type_not_kind(type)) {
-        Value *vx = maybe_decay_untracked(boxed(x, ctx));
-        Value *vtyp = literal_pointer_val(type);
+        Value *vx = maybe_decay_untracked(boxed(ctx, x));
+        Value *vtyp = literal_pointer_val(ctx, type);
         if (msg && *msg == "typeassert") {
-            builder.CreateCall(prepare_call(jltypeassert_func), { vx, vtyp });
+            ctx.builder.CreateCall(prepare_call(jltypeassert_func), { vx, vtyp });
             return std::make_pair(ConstantInt::get(T_int1, 1), true);
         }
-        return std::make_pair(builder.CreateICmpNE(
-                builder.CreateCall(prepare_call(jlisa_func), { vx, vtyp }),
+        return std::make_pair(ctx.builder.CreateICmpNE(
+                ctx.builder.CreateCall(prepare_call(jlisa_func), { vx, vtyp }),
                 ConstantInt::get(T_int32, 0)), false);
     }
     // tests for isa leaftype can be handled with pointer comparisons
@@ -1026,74 +1015,73 @@ static std::pair<Value*, bool> emit_isa(const jl_cgval_t &x, jl_value_t *type, c
             unsigned tindex = get_box_tindex((jl_datatype_t*)type, x.typ);
             if (tindex > 0) {
                 // optimize more when we know that this is a split union-type where tindex = 0 is invalid
-                Value *xtindex = builder.CreateAnd(x.TIndex, ConstantInt::get(T_int8, 0x7f));
-                return std::make_pair(builder.CreateICmpEQ(xtindex, ConstantInt::get(T_int8, tindex)), false);
+                Value *xtindex = ctx.builder.CreateAnd(x.TIndex, ConstantInt::get(T_int8, 0x7f));
+                return std::make_pair(ctx.builder.CreateICmpEQ(xtindex, ConstantInt::get(T_int8, tindex)), false);
             }
             else {
                 // test for (x.TIndex == 0x80 && typeof(x.V) == type)
-                Value *isboxed = builder.CreateICmpEQ(x.TIndex, ConstantInt::get(T_int8, 0x80));
-                BasicBlock *currBB = builder.GetInsertBlock();
-                BasicBlock *isaBB = BasicBlock::Create(jl_LLVMContext, "isa", ctx->f);
-                BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_isa", ctx->f);
-                builder.CreateCondBr(isboxed, isaBB, postBB);
-                builder.SetInsertPoint(isaBB);
-                Value *istype_boxed = builder.CreateICmpEQ(emit_typeof(x.V),
-                    maybe_decay_untracked(literal_pointer_val(type)));
-                builder.CreateBr(postBB);
-                builder.SetInsertPoint(postBB);
-                PHINode *istype = builder.CreatePHI(T_int1, 2);
+                Value *isboxed = ctx.builder.CreateICmpEQ(x.TIndex, ConstantInt::get(T_int8, 0x80));
+                BasicBlock *currBB = ctx.builder.GetInsertBlock();
+                BasicBlock *isaBB = BasicBlock::Create(jl_LLVMContext, "isa", ctx.f);
+                BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_isa", ctx.f);
+                ctx.builder.CreateCondBr(isboxed, isaBB, postBB);
+                ctx.builder.SetInsertPoint(isaBB);
+                Value *istype_boxed = ctx.builder.CreateICmpEQ(emit_typeof(ctx, x.V),
+                    maybe_decay_untracked(literal_pointer_val(ctx, type)));
+                ctx.builder.CreateBr(postBB);
+                ctx.builder.SetInsertPoint(postBB);
+                PHINode *istype = ctx.builder.CreatePHI(T_int1, 2);
                 istype->addIncoming(ConstantInt::get(T_int1, 0), currBB);
                 istype->addIncoming(istype_boxed, isaBB);
                 return std::make_pair(istype, false);
             }
         }
-        return std::make_pair(builder.CreateICmpEQ(emit_typeof_boxed(x, ctx),
-            maybe_decay_untracked(literal_pointer_val(type))), false);
+        return std::make_pair(ctx.builder.CreateICmpEQ(emit_typeof_boxed(ctx, x),
+            maybe_decay_untracked(literal_pointer_val(ctx, type))), false);
     }
     // everything else can be handled via subtype tests
-    Value *vxt = maybe_decay_untracked(emit_typeof_boxed(x, ctx));
-    return std::make_pair(builder.CreateICmpNE(
-            builder.CreateCall(prepare_call(jlsubtype_func),
+    Value *vxt = maybe_decay_untracked(emit_typeof_boxed(ctx, x));
+    return std::make_pair(ctx.builder.CreateICmpNE(
+            ctx.builder.CreateCall(prepare_call(jlsubtype_func),
               { vxt,
-                literal_pointer_val(type) }),
+                literal_pointer_val(ctx, type) }),
             ConstantInt::get(T_int32, 0)), false);
 }
 
-static void emit_typecheck(const jl_cgval_t &x, jl_value_t *type, const std::string &msg,
-                           jl_codectx_t *ctx)
+static void emit_typecheck(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *type, const std::string &msg)
 {
     Value *istype;
     bool handled_msg;
-    std::tie(istype, handled_msg) = emit_isa(x, type, &msg, ctx);
+    std::tie(istype, handled_msg) = emit_isa(ctx, x, type, &msg);
     if (!handled_msg) {
-        BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx->f);
+        BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx.f);
         BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext, "pass");
-        builder.CreateCondBr(istype, passBB, failBB);
-        builder.SetInsertPoint(failBB);
+        ctx.builder.CreateCondBr(istype, passBB, failBB);
+        ctx.builder.SetInsertPoint(failBB);
 
-        emit_type_error(x, literal_pointer_val(type), msg, ctx);
-        builder.CreateUnreachable();
+        emit_type_error(ctx, x, literal_pointer_val(ctx, type), msg);
+        ctx.builder.CreateUnreachable();
 
-        ctx->f->getBasicBlockList().push_back(passBB);
-        builder.SetInsertPoint(passBB);
+        ctx.f->getBasicBlockList().push_back(passBB);
+        ctx.builder.SetInsertPoint(passBB);
     }
 }
 
-static void emit_leafcheck(Value *typ, const std::string &msg, jl_codectx_t *ctx)
+static void emit_leafcheck(jl_codectx_t &ctx, Value *typ, const std::string &msg)
 {
     assert(typ->getType() == T_pjlvalue);
-    emit_typecheck(mark_julia_type(typ, true, jl_any_type, ctx, false), (jl_value_t*)jl_datatype_type, msg, ctx);
+    emit_typecheck(ctx, mark_julia_type(ctx, typ, true, jl_any_type, false), (jl_value_t*)jl_datatype_type, msg);
     Value *isleaf;
-    isleaf = builder.CreateConstInBoundsGEP1_32(T_int8, emit_bitcast(decay_derived(typ), T_pint8), offsetof(jl_datatype_t, isleaftype));
-    isleaf = builder.CreateLoad(isleaf, tbaa_const);
-    isleaf = builder.CreateTrunc(isleaf, T_int1);
-    error_unless(isleaf, msg, ctx);
+    isleaf = ctx.builder.CreateConstInBoundsGEP1_32(T_int8, emit_bitcast(ctx, decay_derived(typ), T_pint8), offsetof(jl_datatype_t, isleaftype));
+    isleaf = ctx.builder.CreateLoad(isleaf, tbaa_const);
+    isleaf = ctx.builder.CreateTrunc(isleaf, T_int1);
+    error_unless(ctx, isleaf, msg);
 }
 
 #define CHECK_BOUNDS 1
-static bool bounds_check_enabled(jl_codectx_t *ctx) {
+static bool bounds_check_enabled(jl_codectx_t &ctx) {
 #if CHECK_BOUNDS==1
-    return (!ctx->is_inbounds &&
+    return (!ctx.is_inbounds &&
          jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_OFF) ||
          jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_ON;
 #else
@@ -1101,21 +1089,21 @@ static bool bounds_check_enabled(jl_codectx_t *ctx) {
 #endif
 }
 
-static Value *emit_bounds_check(const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len, jl_codectx_t *ctx)
+static Value *emit_bounds_check(jl_codectx_t &ctx, const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len)
 {
-    Value *im1 = builder.CreateSub(i, ConstantInt::get(T_size, 1));
+    Value *im1 = ctx.builder.CreateSub(i, ConstantInt::get(T_size, 1));
 #if CHECK_BOUNDS==1
     if (bounds_check_enabled(ctx)) {
-        Value *ok = builder.CreateICmpULT(im1, len);
-        BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+        Value *ok = ctx.builder.CreateICmpULT(im1, len);
+        BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx.f);
         BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
-        builder.CreateCondBr(ok, passBB, failBB);
-        builder.SetInsertPoint(failBB);
+        ctx.builder.CreateCondBr(ok, passBB, failBB);
+        ctx.builder.SetInsertPoint(failBB);
         if (!ty) { // jl_value_t** tuple (e.g. the vararg)
-            builder.CreateCall(prepare_call(jlvboundserror_func), { ainfo.V, len, i });
+            ctx.builder.CreateCall(prepare_call(jlvboundserror_func), { ainfo.V, len, i });
         }
         else if (ainfo.isboxed) { // jl_datatype_t or boxed jl_value_t
-            builder.CreateCall(prepare_call(jlboundserror_func), { mark_callee_rooted(boxed(ainfo, ctx)), i });
+            ctx.builder.CreateCall(prepare_call(jlboundserror_func), { mark_callee_rooted(boxed(ctx, ainfo)), i });
         }
         else { // unboxed jl_value_t*
             Value *a = ainfo.V;
@@ -1124,18 +1112,18 @@ static Value *emit_bounds_check(const jl_cgval_t &ainfo, jl_value_t *ty, Value *
             }
             else if (!ainfo.ispointer()) {
                 // CreateAlloca is OK here since we are on an error branch
-                Value *tempSpace = builder.CreateAlloca(a->getType());
-                builder.CreateStore(a, tempSpace);
+                Value *tempSpace = ctx.builder.CreateAlloca(a->getType());
+                ctx.builder.CreateStore(a, tempSpace);
                 a = tempSpace;
             }
-            builder.CreateCall(prepare_call(jluboundserror_func), {
-                                emit_bitcast(decay_derived(a), T_pint8),
-                                literal_pointer_val(ty),
+            ctx.builder.CreateCall(prepare_call(jluboundserror_func), {
+                                emit_bitcast(ctx, decay_derived(a), T_pint8),
+                                literal_pointer_val(ctx, ty),
                                 i });
         }
-        builder.CreateUnreachable();
-        ctx->f->getBasicBlockList().push_back(passBB);
-        builder.SetInsertPoint(passBB);
+        ctx.builder.CreateUnreachable();
+        ctx.f->getBasicBlockList().push_back(passBB);
+        ctx.builder.SetInsertPoint(passBB);
     }
 #endif
     return im1;
@@ -1159,10 +1147,10 @@ static unsigned julia_alignment(Value* /*ptr*/, jl_value_t *jltype, unsigned ali
     return alignment;
 }
 
-static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value* dest = NULL, bool volatile_store = false);
+static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_value_t *jt, Value* dest = NULL, bool volatile_store = false);
 
-static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
-                             jl_codectx_t *ctx, MDNode *tbaa, bool maybe_null_if_boxed = true, unsigned alignment = 0)
+static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, jl_value_t *jltype,
+                             MDNode *tbaa, bool maybe_null_if_boxed = true, unsigned alignment = 0)
 {
     bool isboxed;
     Type *elty = julia_type_to_llvm(jltype, &isboxed);
@@ -1173,18 +1161,18 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
         elty = T_prjlvalue;
     // TODO: preserving_pointercast?
     if (ptr->getType()->getContainedType(0) != elty)
-        data = emit_bitcast(ptr, PointerType::get(elty, 0));
+        data = emit_bitcast(ctx, ptr, PointerType::get(elty, 0));
     else
         data = ptr;
     if (idx_0based)
-        data = builder.CreateGEP(data, idx_0based);
+        data = ctx.builder.CreateGEP(data, idx_0based);
     Value *elt;
     // TODO: can only lazy load if we can create a gc root for ptr for the lifetime of elt
     //if (elty->isAggregateType() && tbaa == tbaa_immut && !alignment) { // can lazy load on demand, no copy needed
     //    elt = data;
     //}
     //else {
-        Instruction *load = builder.CreateAlignedLoad(data, isboxed ?
+        Instruction *load = ctx.builder.CreateAlignedLoad(data, isboxed ?
             alignment : julia_alignment(data, jltype, alignment), false);
         if (isboxed)
             load = maybe_mark_load_dereferenceable(load, true, jltype);
@@ -1195,16 +1183,17 @@ static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
             elt = load;
         }
         if (maybe_null_if_boxed && isboxed) {
-            null_pointer_check(elt, ctx);
+            null_pointer_check(ctx, elt);
         }
     //}
-    return mark_julia_type(elt, isboxed, jltype, ctx);
+    return mark_julia_type(ctx, elt, isboxed, jltype);
 }
 
-static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
-                        jl_value_t *jltype, jl_codectx_t *ctx, MDNode *tbaa,
-                        Value *parent,  // for the write barrier, NULL if no barrier needed
-                        unsigned alignment = 0, bool root_box = true) // if the value to store needs a box, should we root it ?
+static void typed_store(jl_codectx_t &ctx,
+        Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
+        jl_value_t *jltype, MDNode *tbaa,
+        Value *parent,  // for the write barrier, NULL if no barrier needed
+        unsigned alignment = 0, bool root_box = true) // if the value to store needs a box, should we root it ?
 {
     bool isboxed;
     Type *elty = julia_type_to_llvm(jltype, &isboxed);
@@ -1212,22 +1201,23 @@ static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
         return;
     Value *r;
     if (!isboxed) {
-        r = emit_unbox(elty, rhs, jltype);
+        r = emit_unbox(ctx, elty, rhs, jltype);
     }
     else {
-        r = maybe_decay_untracked(boxed(rhs, ctx, root_box));
-        if (parent != NULL) emit_write_barrier(ctx, parent, r);
+        r = maybe_decay_untracked(boxed(ctx, rhs, root_box));
+        if (parent != NULL)
+            emit_write_barrier(ctx, parent, r);
     }
     Value *data;
     if (ptr->getType()->getContainedType(0) != elty) {
         if (isboxed) {
-            data = emit_bitcast(ptr, T_pprjlvalue);
+            data = emit_bitcast(ctx, ptr, T_pprjlvalue);
         } else {
-            data = emit_bitcast(ptr, PointerType::get(elty, cast<PointerType>(ptr->getType())->getAddressSpace()));
+            data = emit_bitcast(ctx, ptr, PointerType::get(elty, cast<PointerType>(ptr->getType())->getAddressSpace()));
         }
     } else
         data = ptr;
-    Instruction *store = builder.CreateAlignedStore(r, builder.CreateGEP(data,
+    Instruction *store = ctx.builder.CreateAlignedStore(r, ctx.builder.CreateGEP(data,
         idx_0based), isboxed ? alignment : julia_alignment(r, jltype, alignment));
     if (tbaa)
         tbaa_decorate(tbaa, store);
@@ -1235,31 +1225,31 @@ static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
 
 // --- convert boolean value to julia ---
 
-static Value *julia_bool(Value *cond)
+static Value *julia_bool(jl_codectx_t &ctx, Value *cond)
 {
-    return builder.CreateSelect(cond, literal_pointer_val(jl_true),
-                                      literal_pointer_val(jl_false));
+    return ctx.builder.CreateSelect(cond, literal_pointer_val(ctx, jl_true),
+                                      literal_pointer_val(ctx, jl_false));
 }
 
 // --- get the inferred type of an AST node ---
 
-static inline jl_module_t *topmod(jl_codectx_t *ctx)
+static inline jl_module_t *topmod(jl_codectx_t &ctx)
 {
-    return jl_base_relative_to(ctx->module);
+    return jl_base_relative_to(ctx.module);
 }
 
-static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
+static jl_value_t *expr_type(jl_codectx_t &ctx, jl_value_t *e)
 {
     if (jl_is_ssavalue(e)) {
-        if (jl_is_long(ctx->source->ssavaluetypes))
+        if (jl_is_long(ctx.source->ssavaluetypes))
             return (jl_value_t*)jl_any_type;
         int idx = ((jl_ssavalue_t*)e)->id;
-        assert(jl_is_array(ctx->source->ssavaluetypes));
-        jl_array_t *ssavalue_types = (jl_array_t*)ctx->source->ssavaluetypes;
+        assert(jl_is_array(ctx.source->ssavaluetypes));
+        jl_array_t *ssavalue_types = (jl_array_t*)ctx.source->ssavaluetypes;
         return jl_array_ptr_ref(ssavalue_types, idx);
     }
     if (jl_typeis(e, jl_slotnumber_type)) {
-        jl_array_t *slot_types = (jl_array_t*)ctx->source->slottypes;
+        jl_array_t *slot_types = (jl_array_t*)ctx.source->slottypes;
         if (!jl_is_array(slot_types))
             return (jl_value_t*)jl_any_type;
         return jl_array_ptr_ref(slot_types, jl_slot_number(e)-1);
@@ -1273,9 +1263,9 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
     if (jl_is_expr(e)) {
         if (((jl_expr_t*)e)->head == static_parameter_sym) {
             size_t idx = jl_unbox_long(jl_exprarg(e,0))-1;
-            if (idx >= jl_svec_len(ctx->linfo->sparam_vals))
+            if (idx >= jl_svec_len(ctx.linfo->sparam_vals))
                 return (jl_value_t*)jl_any_type;
-            e = jl_svecref(ctx->linfo->sparam_vals, idx);
+            e = jl_svecref(ctx.linfo->sparam_vals, idx);
             if (jl_is_typevar(e))
                 return (jl_value_t*)jl_any_type;
             goto type_of_constant;
@@ -1299,7 +1289,7 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
         return (jl_value_t*)jl_any_type;
     }
     if (jl_is_symbol(e)) {
-        jl_binding_t *b = jl_get_binding(ctx->module, (jl_sym_t*)e);
+        jl_binding_t *b = jl_get_binding(ctx.module, (jl_sym_t*)e);
         if (!b || !b->value)
             return (jl_value_t*)jl_any_type;
         if (b->constp)
@@ -1316,7 +1306,7 @@ type_of_constant:
 // --- accessing the representations of built-in data types ---
 
 static Constant *julia_const_to_llvm(jl_value_t *e);
-static Value *data_pointer(const jl_cgval_t &x, jl_codectx_t *ctx, Type *astype = T_ppjlvalue)
+static Value *data_pointer(jl_codectx_t &ctx, const jl_cgval_t &x, Type *astype = T_ppjlvalue)
 {
     Value *data = x.V;
     if (x.constant) {
@@ -1325,21 +1315,22 @@ static Value *data_pointer(const jl_cgval_t &x, jl_codectx_t *ctx, Type *astype 
             data = get_pointer_to_constant(val, "", *jl_Module);
         }
         else {
-            data = boxed(x, ctx);
+            data = boxed(ctx, x);
         }
     }
     if (data->getType() != astype)
-        data = emit_bitcast(data, astype);
+        data = emit_bitcast(ctx, data, astype);
     return decay_derived(data);
 }
 
-static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct,
-        Value *idx, jl_datatype_t *stt, jl_codectx_t *ctx)
+static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
+        jl_cgval_t *ret, const jl_cgval_t &strct,
+        Value *idx, jl_datatype_t *stt)
 {
     size_t nfields = jl_datatype_nfields(stt);
     if (strct.ispointer()) { // boxed or stack
         if (is_datatype_all_pointers(stt)) {
-            idx = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
+            idx = emit_bounds_check(ctx, strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields));
             bool maybe_null = (unsigned)stt->ninitialized != nfields;
             size_t minimum_field_size = (size_t)-1;
             for (size_t i = 0; i < nfields; ++i) {
@@ -1350,70 +1341,70 @@ static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct,
             }
             Value *fld = tbaa_decorate(strct.tbaa,
                 maybe_mark_load_dereferenceable(
-                    builder.CreateLoad(
-                        builder.CreateBitCast(builder.CreateGEP(decay_derived(data_pointer(strct, ctx)), idx),
+                    ctx.builder.CreateLoad(
+                        ctx.builder.CreateBitCast(ctx.builder.CreateGEP(decay_derived(data_pointer(ctx, strct)), idx),
                             PointerType::get(T_prjlvalue, AddressSpace::Derived))),
                     maybe_null,  minimum_field_size));
             if (maybe_null)
-                null_pointer_check(fld, ctx);
-            *ret = mark_julia_type(fld, true, jl_any_type, ctx, strct.gcroot || !strct.isimmutable);
+                null_pointer_check(ctx, fld);
+            *ret = mark_julia_type(ctx, fld, true, jl_any_type, strct.gcroot || !strct.isimmutable);
             return true;
         }
         else if (is_tupletype_homogeneous(stt->types)) {
             assert(nfields > 0); // nf == 0 trapped by all_pointers case
             jl_value_t *jt = jl_field_type(stt, 0);
-            idx = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
-            Value *ptr = data_pointer(strct, ctx);
+            idx = emit_bounds_check(ctx, strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields));
+            Value *ptr = data_pointer(ctx, strct);
             if (!stt->mutabl) {
                 // just compute the pointer and let user load it when necessary
                 Type *fty = julia_type_to_llvm(jt);
-                Value *addr = builder.CreateGEP(emit_bitcast(decay_derived(ptr), PointerType::get(fty,0)), idx);
+                Value *addr = ctx.builder.CreateGEP(emit_bitcast(ctx, decay_derived(ptr), PointerType::get(fty,0)), idx);
                 *ret = mark_julia_slot(addr, jt, NULL, strct.tbaa);
                 ret->gcroot = strct.gcroot;
                 ret->isimmutable = strct.isimmutable;
                 return true;
             }
-            *ret = typed_load(ptr, idx, jt, ctx, strct.tbaa, false);
+            *ret = typed_load(ctx, ptr, idx, jt, strct.tbaa, false);
             return true;
         }
         else if (strct.isboxed) {
-            idx = builder.CreateSub(idx, ConstantInt::get(T_size, 1));
-            Value *fld = builder.CreateCall(prepare_call(jlgetnthfieldchecked_func), { boxed(strct, ctx), idx });
-            *ret = mark_julia_type(fld, true, jl_any_type, ctx);
+            idx = ctx.builder.CreateSub(idx, ConstantInt::get(T_size, 1));
+            Value *fld = ctx.builder.CreateCall(prepare_call(jlgetnthfieldchecked_func), { boxed(ctx, strct), idx });
+            *ret = mark_julia_type(ctx, fld, true, jl_any_type);
             return true;
         }
     }
     else if (is_tupletype_homogeneous(stt->types)) {
         assert(jl_isbits(stt));
         if (nfields == 0) {
-            idx = emit_bounds_check(ghostValue(stt),
-                                    (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
+            idx = emit_bounds_check(ctx, ghostValue(stt),
+                                    (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields));
             *ret = jl_cgval_t();
             return true;
         }
         assert(!jl_field_isptr(stt, 0));
         jl_value_t *jt = jl_field_type(stt, 0);
-        Value *idx0 = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
+        Value *idx0 = emit_bounds_check(ctx, strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields));
         if (strct.isghost) {
             *ret = ghostValue(jt);
             return true;
         }
         // llvm::VectorType
         if (sizeof(void*) != sizeof(int))
-            idx0 = builder.CreateTrunc(idx0, T_int32); // llvm3.3 requires this, harmless elsewhere
-        Value *fld = builder.CreateExtractElement(strct.V, idx0);
-        *ret = mark_julia_type(fld, false, jt, ctx);
+            idx0 = ctx.builder.CreateTrunc(idx0, T_int32); // llvm3.3 requires this, harmless elsewhere
+        Value *fld = ctx.builder.CreateExtractElement(strct.V, idx0);
+        *ret = mark_julia_type(ctx, fld, false, jt);
         return true;
     }
     return false;
 }
 
-static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, jl_datatype_t *jt, jl_codectx_t *ctx)
+static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &strct, unsigned idx, jl_datatype_t *jt)
 {
     jl_value_t *jfty = jl_field_type(jt, idx);
     Type *elty = julia_type_to_llvm(jfty);
     if (jfty == jl_bottom_type) {
-        raise_exception(literal_pointer_val(jl_undefref_exception), ctx);
+        raise_exception(ctx, literal_pointer_val(ctx, jl_undefref_exception));
         return jl_cgval_t(); // unreachable
     }
     if (type_is_ghost(elty))
@@ -1424,37 +1415,37 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         bool isboxed;
         Type *lt = julia_type_to_llvm((jl_value_t*)jt, &isboxed);
         if (isboxed) {
-            Value *ptr = decay_derived(data_pointer(strct, ctx, T_pint8));
+            Value *ptr = decay_derived(data_pointer(ctx, strct, T_pint8));
             Value *llvm_idx = ConstantInt::get(T_size, jl_field_offset(jt, idx));
-            addr = builder.CreateGEP(ptr, llvm_idx);
+            addr = ctx.builder.CreateGEP(ptr, llvm_idx);
         }
         else {
             if (VectorType *vlt = dyn_cast<VectorType>(lt)) {
                 // doesn't have the struct wrapper, so this must have been a VecElement
                 // cast to the element type so that it can be addressed with GEP
                 lt = vlt->getElementType();
-                Value *ptr = data_pointer(strct, ctx, lt->getPointerTo());
+                Value *ptr = data_pointer(ctx, strct, lt->getPointerTo());
                 Value *llvm_idx = ConstantInt::get(T_size, idx);
-                addr = builder.CreateGEP(lt, ptr, llvm_idx);
+                addr = ctx.builder.CreateGEP(lt, ptr, llvm_idx);
             }
             else if (lt->isSingleValueType()) {
-                addr = data_pointer(strct, ctx, lt->getPointerTo());
+                addr = data_pointer(ctx, strct, lt->getPointerTo());
             }
             else {
-                Value *ptr = data_pointer(strct, ctx, lt->getPointerTo());
-                addr = builder.CreateStructGEP(lt, ptr, idx);
+                Value *ptr = data_pointer(ctx, strct, lt->getPointerTo());
+                addr = ctx.builder.CreateStructGEP(lt, ptr, idx);
             }
         }
         if (jl_field_isptr(jt, idx)) {
             bool maybe_null = idx >= (unsigned)jt->ninitialized;
             Instruction *Load = maybe_mark_load_dereferenceable(
-                builder.CreateLoad(emit_bitcast(addr, T_pprjlvalue)),
+                ctx.builder.CreateLoad(emit_bitcast(ctx, addr, T_pprjlvalue)),
                 maybe_null, jl_field_type(jt, idx)
             );
             Value *fldv = tbaa_decorate(strct.tbaa, Load);
             if (maybe_null)
-                null_pointer_check(fldv, ctx);
-            return mark_julia_type(fldv, true, jfty, ctx, strct.gcroot || !strct.isimmutable);
+                null_pointer_check(ctx, fldv);
+            return mark_julia_type(ctx, fldv, true, jfty, strct.gcroot || !strct.isimmutable);
         }
         else if (!jt->mutabl) {
             // just compute the pointer and let user load it when necessary
@@ -1466,14 +1457,14 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
         int align = jl_field_offset(jt, idx);
         align |= 16;
         align &= -align;
-        return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, strct.tbaa, true, align);
+        return typed_load(ctx, addr, ConstantInt::get(T_size, 0), jfty, strct.tbaa, true, align);
     }
     else if (isa<UndefValue>(strct.V)) {
         return jl_cgval_t();
     }
     else {
         if (strct.V->getType()->isVectorTy()) {
-            fldv = builder.CreateExtractElement(strct.V, ConstantInt::get(T_int32, idx));
+            fldv = ctx.builder.CreateExtractElement(strct.V, ConstantInt::get(T_int32, idx));
         }
         else {
             // VecElement types are unwrapped in LLVM.
@@ -1481,18 +1472,18 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
             fldv = strct.V;
         }
         assert(!jl_field_isptr(jt, idx));
-        return mark_julia_type(fldv, false, jfty, ctx);
+        return mark_julia_type(ctx, fldv, false, jfty);
     }
 }
 
 // emit length of vararg tuple
-static Value *emit_n_varargs(jl_codectx_t *ctx)
+static Value *emit_n_varargs(jl_codectx_t &ctx)
 {
-    int nreq = ctx->nReqArgs;
-    Value *valen = builder.CreateSub((Value*)ctx->argCount,
+    int nreq = ctx.nReqArgs;
+    Value *valen = ctx.builder.CreateSub((Value*)ctx.argCount,
                                      ConstantInt::get(T_int32, nreq));
 #ifdef _P64
-    return builder.CreateSExt(valen, T_int64);
+    return ctx.builder.CreateSExt(valen, T_int64);
 #else
     return valen;
 #endif
@@ -1504,15 +1495,14 @@ static bool arraytype_constshape(jl_value_t *ty)
             jl_is_long(jl_tparam1(ty)) && jl_unbox_long(jl_tparam1(ty)) != 1);
 }
 
-static void maybe_alloc_arrayvar(int s, jl_codectx_t *ctx)
+static void maybe_alloc_arrayvar(jl_codectx_t &ctx, int s)
 {
-    jl_value_t *jt = ctx->slots[s].value.typ;
+    jl_value_t *jt = ctx.slots[s].value.typ;
     if (arraytype_constshape(jt)) {
         // TODO: this optimization does not yet work with 1-d arrays, since the
         // length and data pointer can change at any time via push!
         // we could make it work by reloading the metadata when the array is
         // passed to an external function (ideally only impure functions)
-        jl_arrayvar_t av;
         int ndims = jl_unbox_long(jl_tparam1(jt));
         jl_value_t *jelt = jl_tparam0(jt);
         bool isboxed = !jl_array_store_unboxed(jelt);
@@ -1522,61 +1512,63 @@ static void maybe_alloc_arrayvar(int s, jl_codectx_t *ctx)
         if (isboxed)
             elt = T_prjlvalue;
         // CreateAlloca is OK here because maybe_alloc_arrayvar is only called in the prologue setup
-        av.dataptr = builder.CreateAlloca(PointerType::get(elt, 0));
-        av.len = builder.CreateAlloca(T_size);
+        jl_arrayvar_t &av = (*ctx.arrayvars)[s];
+        av.dataptr = ctx.builder.CreateAlloca(PointerType::get(elt, 0));
+        av.len = ctx.builder.CreateAlloca(T_size);
         for (int i = 0; i < ndims - 1; i++)
-            av.sizes.push_back(builder.CreateAlloca(T_size));
+            av.sizes.push_back(ctx.builder.CreateAlloca(T_size));
         av.ty = jt;
-        (*ctx->arrayvars)[s] = av;
     }
 }
 
-static Value *emit_arraysize(const jl_cgval_t &tinfo, Value *dim, jl_codectx_t *ctx)
+static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, Value *dim)
 {
-    Value *t = boxed(tinfo, ctx);
-    int o = offsetof(jl_array_t, nrows)/sizeof(void*) - 1;
+    Value *t = boxed(ctx, tinfo);
+    int o = offsetof(jl_array_t, nrows) / sizeof(void*) - 1;
     MDNode *tbaa = arraytype_constshape(tinfo.typ) ? tbaa_const : tbaa_arraysize;
-    return emit_nthptr_recast(t, builder.CreateAdd(dim,
-                                                   ConstantInt::get(dim->getType(), o)),
-                              tbaa, T_psize);
+    return emit_nthptr_recast(ctx,
+            t,
+            ctx.builder.CreateAdd(dim, ConstantInt::get(dim->getType(), o)),
+            tbaa, T_psize);
 }
 
-static jl_arrayvar_t *arrayvar_for(jl_value_t *ex, jl_codectx_t *ctx)
+static jl_arrayvar_t *arrayvar_for(jl_codectx_t &ctx, jl_value_t *ex)
 {
-    if (ex == NULL) return NULL;
+    if (ex == NULL)
+        return NULL;
     if (!jl_is_slot(ex))
         return NULL;
-    int sl = jl_slot_number(ex)-1;
-    if (ctx->arrayvars->find(sl) != ctx->arrayvars->end())
-        return &(*ctx->arrayvars)[sl];
+    int sl = jl_slot_number(ex) - 1;
+    auto av = ctx.arrayvars->find(sl);
+    if (av != ctx.arrayvars->end())
+        return &av->second;
     //TODO: ssavalue case
     return NULL;
 }
 
-static Value *emit_arraysize(const jl_cgval_t &tinfo, int dim, jl_codectx_t *ctx)
+static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int dim)
 {
-    return emit_arraysize(tinfo, ConstantInt::get(T_int32, dim), ctx);
+    return emit_arraysize(ctx, tinfo, ConstantInt::get(T_int32, dim));
 }
 
-static Value *emit_arraylen_prim(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
+static Value *emit_arraylen_prim(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
 {
-    Value *t = boxed(tinfo, ctx);
+    Value *t = boxed(ctx, tinfo);
     jl_value_t *ty = tinfo.typ;
 #ifdef STORE_ARRAY_LEN
-    Value *addr = builder.CreateStructGEP(
-                                          nullptr,
-                                          emit_bitcast(decay_derived(t), jl_parray_llvmt),
+    Value *addr = ctx.builder.CreateStructGEP(jl_array_llvmt,
+                                          emit_bitcast(ctx, decay_derived(t), jl_parray_llvmt),
                                           1); //index (not offset) of length field in jl_parray_llvmt
 
     MDNode *tbaa = arraytype_constshape(ty) ? tbaa_const : tbaa_arraylen;
-    return tbaa_decorate(tbaa, builder.CreateLoad(addr, false));
+    return tbaa_decorate(tbaa, ctx.builder.CreateLoad(addr, false));
 #else
     jl_value_t *p1 = jl_tparam1(ty); // FIXME: check that ty is an array type
     if (jl_is_long(p1)) {
         size_t nd = jl_unbox_long(p1);
         Value *l = ConstantInt::get(T_size, 1);
         for(size_t i=0; i < nd; i++) {
-            l = builder.CreateMul(l, emit_arraysize(t, (int)(i+1), ctx));
+            l = ctx.builder.CreateMul(l, emit_arraysize(ctx, t, (int)(i + 1)));
         }
         return l;
     }
@@ -1585,107 +1577,107 @@ static Value *emit_arraylen_prim(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
         fargt.push_back(T_pjlvalue);
         FunctionType *ft = FunctionType::get(T_size, fargt, false);
         Value *alen = jl_Module->getOrInsertFunction("jl_array_len_", ft); // TODO: move to codegen init block
-        return builder.CreateCall(prepare_call(alen), t);
+        return ctx.builder.CreateCall(prepare_call(alen), t);
     }
 #endif
 }
 
-static Value *emit_arraylen(const jl_cgval_t &tinfo, jl_value_t *ex, jl_codectx_t *ctx)
+static Value *emit_arraylen(jl_codectx_t &ctx, const jl_cgval_t &tinfo, jl_value_t *ex)
 {
-    jl_arrayvar_t *av = arrayvar_for(ex, ctx);
-    if (av!=NULL)
-        return builder.CreateLoad(av->len);
-    return emit_arraylen_prim(tinfo, ctx);
+    jl_arrayvar_t *av = arrayvar_for(ctx, ex);
+    if (av != NULL)
+        return ctx.builder.CreateLoad(av->len);
+    return emit_arraylen_prim(ctx, tinfo);
 }
 
-static Value *emit_arrayptr(const jl_cgval_t &tinfo, jl_codectx_t *ctx, bool isboxed = false)
+static Value *emit_arrayptr(jl_codectx_t &ctx, const jl_cgval_t &tinfo, bool isboxed = false)
 {
-    Value *t = boxed(tinfo, ctx);
-    Value *addr = builder.CreateStructGEP(
-                                          nullptr,
-                                          emit_bitcast(decay_derived(t), jl_parray_llvmt),
+    Value *t = boxed(ctx, tinfo);
+    Value *addr = ctx.builder.CreateStructGEP(jl_array_llvmt,
+                                          emit_bitcast(ctx, decay_derived(t), jl_parray_llvmt),
                                           0); //index (not offset) of data field in jl_parray_llvmt
 
     MDNode *tbaa = arraytype_constshape(tinfo.typ) ? tbaa_const : tbaa_arrayptr;
     if (isboxed) {
-        addr = builder.CreateBitCast(addr,
+        addr = ctx.builder.CreateBitCast(addr,
             PointerType::get(T_pprjlvalue, cast<PointerType>(addr->getType())->getAddressSpace()));
     }
-    return tbaa_decorate(tbaa, builder.CreateLoad(addr, false));
+    return tbaa_decorate(tbaa, ctx.builder.CreateLoad(addr, false));
 }
 
-static Value *emit_arrayptr(const jl_cgval_t &tinfo, jl_value_t *ex, jl_codectx_t *ctx, bool isboxed = false)
+static Value *emit_arrayptr(jl_codectx_t &ctx, const jl_cgval_t &tinfo, jl_value_t *ex, bool isboxed = false)
 {
-    jl_arrayvar_t *av = arrayvar_for(ex, ctx);
+    jl_arrayvar_t *av = arrayvar_for(ctx, ex);
     if (av!=NULL)
-        return builder.CreateLoad(av->dataptr);
-    return emit_arrayptr(tinfo, ctx, isboxed);
+        return ctx.builder.CreateLoad(av->dataptr);
+    return emit_arrayptr(ctx, tinfo, isboxed);
 }
 
-static Value *emit_arraysize(const jl_cgval_t &tinfo, jl_value_t *ex, int dim, jl_codectx_t *ctx)
+static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, jl_value_t *ex, int dim)
 {
-    jl_arrayvar_t *av = arrayvar_for(ex, ctx);
+    jl_arrayvar_t *av = arrayvar_for(ctx, ex);
     if (av != NULL && dim <= (int)av->sizes.size())
-        return builder.CreateLoad(av->sizes[dim-1]);
-    return emit_arraysize(tinfo, dim, ctx);
+        return ctx.builder.CreateLoad(av->sizes[dim - 1]);
+    return emit_arraysize(ctx, tinfo, dim);
 }
 
-static Value *emit_arrayflags(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
+static Value *emit_arrayflags(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
 {
-    Value *t = boxed(tinfo, ctx);
+    Value *t = boxed(ctx, tinfo);
 #ifdef STORE_ARRAY_LEN
     int arrayflag_field = 2;
 #else
     int arrayflag_field = 1;
 #endif
-    Value *addr = builder.CreateStructGEP(
-                            nullptr,
-                            emit_bitcast(decay_derived(t), jl_parray_llvmt),
-                            arrayflag_field);
-    return tbaa_decorate(tbaa_arrayflags, builder.CreateLoad(addr));
+    Value *addr = ctx.builder.CreateStructGEP(
+            jl_array_llvmt,
+            emit_bitcast(ctx, decay_derived(t), jl_parray_llvmt),
+            arrayflag_field);
+    return tbaa_decorate(tbaa_arrayflags, ctx.builder.CreateLoad(addr));
 }
 
-static Value *emit_arrayelsize(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
+static Value *emit_arrayelsize(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
 {
-    Value *t = boxed(tinfo, ctx);
+    Value *t = boxed(ctx, tinfo);
 #ifdef STORE_ARRAY_LEN
     int elsize_field = 3;
 #else
     int elsize_field = 2;
 #endif
-    Value *addr = builder.CreateStructGEP(nullptr,
-                                          emit_bitcast(decay_derived(t), jl_parray_llvmt),
+    Value *addr = ctx.builder.CreateStructGEP(jl_array_llvmt,
+                                          emit_bitcast(ctx, decay_derived(t), jl_parray_llvmt),
                                           elsize_field);
-    return tbaa_decorate(tbaa_const, builder.CreateLoad(addr));
+    return tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(addr));
 }
 
-static void assign_arrayvar(jl_arrayvar_t &av, const jl_cgval_t &ainfo, jl_codectx_t *ctx)
+static void assign_arrayvar(jl_codectx_t &ctx, jl_arrayvar_t &av, const jl_cgval_t &ainfo)
 {
-    tbaa_decorate(tbaa_arrayptr,builder.CreateStore(emit_bitcast(emit_arrayptr(ainfo, ctx),
-                                                    av.dataptr->getType()->getContainedType(0)),
-                                                    av.dataptr));
-    builder.CreateStore(emit_arraylen_prim(ainfo, ctx), av.len);
-    for(size_t i=0; i < av.sizes.size(); i++)
-        builder.CreateStore(emit_arraysize(ainfo, i+1, ctx), av.sizes[i]);
+    Value *aptr = emit_bitcast(ctx,
+        emit_arrayptr(ctx, ainfo),
+        av.dataptr->getType()->getContainedType(0));
+    tbaa_decorate(tbaa_arrayptr, ctx.builder.CreateStore(aptr, av.dataptr));
+    ctx.builder.CreateStore(emit_arraylen_prim(ctx, ainfo), av.len);
+    for (size_t i = 0; i < av.sizes.size(); i++)
+        ctx.builder.CreateStore(emit_arraysize(ctx, ainfo, i + 1), av.sizes[i]);
 }
 
 // Returns the size of the array represented by `tinfo` for the given dimension `dim` if
 // `dim` is a valid dimension, otherwise returns constant one.
-static Value *emit_arraysize_for_unsafe_dim(const jl_cgval_t &tinfo, jl_value_t *ex, size_t dim,
-                                            size_t nd, jl_codectx_t *ctx)
+static Value *emit_arraysize_for_unsafe_dim(jl_codectx_t &ctx,
+        const jl_cgval_t &tinfo, jl_value_t *ex, size_t dim, size_t nd)
 {
-    return dim > nd ? ConstantInt::get(T_size, 1) : emit_arraysize(tinfo, ex, dim, ctx);
+    return dim > nd ? ConstantInt::get(T_size, 1) : emit_arraysize(ctx, tinfo, ex, dim);
 }
 
 // `nd == -1` means the dimension is unknown.
-static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, ssize_t nd, jl_value_t **args,
-                                  size_t nidxs, jl_codectx_t *ctx)
+static Value *emit_array_nd_index(jl_codectx_t &ctx,
+        const jl_cgval_t &ainfo, jl_value_t *ex, ssize_t nd, jl_value_t **args, size_t nidxs)
 {
-    Value *a = boxed(ainfo, ctx);
+    Value *a = boxed(ctx, ainfo);
     Value *i = ConstantInt::get(T_size, 0);
     Value *stride = ConstantInt::get(T_size, 1);
 #if CHECK_BOUNDS==1
-    bool bc = (!ctx->is_inbounds &&
+    bool bc = (!ctx.is_inbounds &&
                jl_options.check_bounds != JL_OPTIONS_CHECK_BOUNDS_OFF) ||
         jl_options.check_bounds == JL_OPTIONS_CHECK_BOUNDS_ON;
     BasicBlock *failBB=NULL, *endBB=NULL;
@@ -1695,26 +1687,26 @@ static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, ssize
     }
 #endif
     Value **idxs = (Value**)alloca(sizeof(Value*)*nidxs);
-    for(size_t k=0; k < nidxs; k++) {
-        idxs[k] = emit_unbox(T_size, emit_expr(args[k], ctx), NULL);
+    for (size_t k = 0; k < nidxs; k++) {
+        idxs[k] = emit_unbox(ctx, T_size, emit_expr(ctx, args[k]), NULL);
     }
     Value *ii;
-    for(size_t k=0; k < nidxs; k++) {
-        ii = builder.CreateSub(idxs[k], ConstantInt::get(T_size, 1));
-        i = builder.CreateAdd(i, builder.CreateMul(ii, stride));
-        if (k < nidxs-1) {
+    for (size_t k = 0; k < nidxs; k++) {
+        ii = ctx.builder.CreateSub(idxs[k], ConstantInt::get(T_size, 1));
+        i = ctx.builder.CreateAdd(i, ctx.builder.CreateMul(ii, stride));
+        if (k < nidxs - 1) {
             assert(nd >= 0);
-            Value *d = emit_arraysize_for_unsafe_dim(ainfo, ex, k+1, nd, ctx);
+            Value *d = emit_arraysize_for_unsafe_dim(ctx, ainfo, ex, k + 1, nd);
 #if CHECK_BOUNDS==1
             if (bc) {
                 BasicBlock *okBB = BasicBlock::Create(jl_LLVMContext, "ib");
                 // if !(i < d) goto error
-                builder.CreateCondBr(builder.CreateICmpULT(ii, d), okBB, failBB);
-                ctx->f->getBasicBlockList().push_back(okBB);
-                builder.SetInsertPoint(okBB);
+                ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(ii, d), okBB, failBB);
+                ctx.f->getBasicBlockList().push_back(okBB);
+                ctx.builder.SetInsertPoint(okBB);
             }
 #endif
-            stride = builder.CreateMul(stride, d);
+            stride = ctx.builder.CreateMul(stride, d);
         }
     }
 #if CHECK_BOUNDS==1
@@ -1730,47 +1722,47 @@ static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, ssize
                 // We need to check if this is inside the non-linearized size
                 BasicBlock *partidx = BasicBlock::Create(jl_LLVMContext, "partlinidx");
                 BasicBlock *partidxwarn = BasicBlock::Create(jl_LLVMContext, "partlinidxwarn");
-                Value *d = emit_arraysize_for_unsafe_dim(ainfo, ex, nidxs, nd, ctx);
-                builder.CreateCondBr(builder.CreateICmpULT(ii, d), endBB, partidx);
+                Value *d = emit_arraysize_for_unsafe_dim(ctx, ainfo, ex, nidxs, nd);
+                ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(ii, d), endBB, partidx);
 
                 // We failed the normal bounds check; check to see if we're
                 // inside the linearized size (partial linear indexing):
-                ctx->f->getBasicBlockList().push_back(partidx);
-                builder.SetInsertPoint(partidx);
-                Value *alen = emit_arraylen(ainfo, ex, ctx);
-                builder.CreateCondBr(builder.CreateICmpULT(i, alen), partidxwarn, failBB);
+                ctx.f->getBasicBlockList().push_back(partidx);
+                ctx.builder.SetInsertPoint(partidx);
+                Value *alen = emit_arraylen(ctx, ainfo, ex);
+                ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(i, alen), partidxwarn, failBB);
 
                 // We passed the linearized bounds check; now throw the depwarn:
-                ctx->f->getBasicBlockList().push_back(partidxwarn);
-                builder.SetInsertPoint(partidxwarn);
-                builder.CreateCall(prepare_call(jldepwarnpi_func), ConstantInt::get(T_size, nidxs));
-                builder.CreateBr(endBB);
+                ctx.f->getBasicBlockList().push_back(partidxwarn);
+                ctx.builder.SetInsertPoint(partidxwarn);
+                ctx.builder.CreateCall(prepare_call(jldepwarnpi_func), ConstantInt::get(T_size, nidxs));
+                ctx.builder.CreateBr(endBB);
             } else {
-                Value *alen = emit_arraylen(ainfo, ex, ctx);
-                builder.CreateCondBr(builder.CreateICmpULT(i, alen), endBB, failBB);
+                Value *alen = emit_arraylen(ctx, ainfo, ex);
+                ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(i, alen), endBB, failBB);
             }
         } else {
             // Compare the last index of the access against the last dimension of
             // the accessed array, i.e. `if !(last_index < last_dimension) goto error`.
             assert(nd >= 0);
             Value *last_index = ii;
-            Value *last_dimension = emit_arraysize_for_unsafe_dim(ainfo, ex, nidxs, nd, ctx);
-            builder.CreateCondBr(builder.CreateICmpULT(last_index, last_dimension), endBB, failBB);
+            Value *last_dimension = emit_arraysize_for_unsafe_dim(ctx, ainfo, ex, nidxs, nd);
+            ctx.builder.CreateCondBr(ctx.builder.CreateICmpULT(last_index, last_dimension), endBB, failBB);
         }
 
-        ctx->f->getBasicBlockList().push_back(failBB);
-        builder.SetInsertPoint(failBB);
+        ctx.f->getBasicBlockList().push_back(failBB);
+        ctx.builder.SetInsertPoint(failBB);
         // CreateAlloca is OK here since we are on an error branch
-        Value *tmp = builder.CreateAlloca(T_size, ConstantInt::get(T_size, nidxs));
+        Value *tmp = ctx.builder.CreateAlloca(T_size, ConstantInt::get(T_size, nidxs));
         for(size_t k=0; k < nidxs; k++) {
-            builder.CreateStore(idxs[k], builder.CreateGEP(tmp, ConstantInt::get(T_size, k)));
+            ctx.builder.CreateStore(idxs[k], ctx.builder.CreateGEP(tmp, ConstantInt::get(T_size, k)));
         }
-        builder.CreateCall(prepare_call(jlboundserrorv_func),
+        ctx.builder.CreateCall(prepare_call(jlboundserrorv_func),
             { mark_callee_rooted(a), tmp, ConstantInt::get(T_size, nidxs) });
-        builder.CreateUnreachable();
+        ctx.builder.CreateUnreachable();
 
-        ctx->f->getBasicBlockList().push_back(endBB);
-        builder.SetInsertPoint(endBB);
+        ctx.f->getBasicBlockList().push_back(endBB);
+        ctx.builder.SetInsertPoint(endBB);
     }
 #endif
 
@@ -1779,23 +1771,24 @@ static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, ssize
 
 // --- boxing ---
 
-static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size, Value *jt);
+static Value *emit_allocobj(jl_codectx_t &ctx, size_t static_size, Value *jt);
 
-static void init_bits_value(Value *newv, Value *v, MDNode *tbaa, unsigned alignment = sizeof(void*)) // min alignment in julia's gc is pointer-aligned
+static void init_bits_value(jl_codectx_t &ctx, Value *newv, Value *v, MDNode *tbaa,
+                            unsigned alignment = sizeof(void*)) // min alignment in julia's gc is pointer-aligned
 {
     // newv should already be tagged
-    tbaa_decorate(tbaa, builder.CreateAlignedStore(v, emit_bitcast(newv,
+    tbaa_decorate(tbaa, ctx.builder.CreateAlignedStore(v, emit_bitcast(ctx, newv,
         PointerType::get(v->getType(), 0)), alignment));
 }
 
-static void init_bits_cgval(Value *newv, const jl_cgval_t& v, MDNode *tbaa, jl_codectx_t *ctx)
+static void init_bits_cgval(jl_codectx_t &ctx, Value *newv, const jl_cgval_t& v, MDNode *tbaa)
 {
     // newv should already be tagged
     if (v.ispointer()) {
-        builder.CreateMemCpy(newv, data_pointer(v, ctx, T_pint8), jl_datatype_size(v.typ), sizeof(void*));
+        ctx.builder.CreateMemCpy(newv, data_pointer(ctx, v, T_pint8), jl_datatype_size(v.typ), sizeof(void*));
     }
     else {
-        init_bits_value(newv, v.V, tbaa);
+        init_bits_value(ctx, newv, v.V, tbaa);
     }
 }
 
@@ -1863,43 +1856,43 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
     return tpl;
 }
 
-static Value *call_with_signed(Function *sfunc, Value *v)
+static Value *call_with_signed(jl_codectx_t &ctx, Function *sfunc, Value *v)
 {
-    CallInst *Call = builder.CreateCall(prepare_call(sfunc), v);
+    CallInst *Call = ctx.builder.CreateCall(prepare_call(sfunc), v);
     Call->addAttribute(1, Attribute::SExt);
     return Call;
 }
 
-static Value *call_with_unsigned(Function *ufunc, Value *v)
+static Value *call_with_unsigned(jl_codectx_t &ctx, Function *ufunc, Value *v)
 {
-    CallInst *Call = builder.CreateCall(prepare_call(ufunc), v);
+    CallInst *Call = ctx.builder.CreateCall(prepare_call(ufunc), v);
     Call->addAttribute(1, Attribute::ZExt);
     return Call;
 }
 
-static void jl_add_method_root(jl_codectx_t *ctx, jl_value_t *val);
+static void jl_add_method_root(jl_codectx_t &ctx, jl_value_t *val);
 
-static Value *as_value(Type *to, const jl_cgval_t &v)
+static Value *as_value(jl_codectx_t &ctx, Type *to, const jl_cgval_t &v)
 {
     assert(!v.isboxed);
-    return emit_unbox(to, v, v.typ);
+    return emit_unbox(ctx, to, v, v.typ);
 }
 
 // some types have special boxing functions with small-value caches
-static Value *_boxed_special(const jl_cgval_t &vinfo, Type *t, jl_codectx_t *ctx)
+static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t)
 {
     jl_value_t *jt = vinfo.typ;
     if (jt == (jl_value_t*)jl_bool_type)
-        return julia_bool(builder.CreateTrunc(as_value(t, vinfo), T_int1));
+        return julia_bool(ctx, ctx.builder.CreateTrunc(as_value(ctx, t, vinfo), T_int1));
     if (t == T_int1)
-        return julia_bool(as_value(t, vinfo));
+        return julia_bool(ctx, as_value(ctx, t, vinfo));
 
-    if (ctx->linfo && jl_is_method(ctx->linfo->def.method) && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
+    if (ctx.linfo && jl_is_method(ctx.linfo->def.method) && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
         if (Constant *c = dyn_cast<Constant>(vinfo.V)) {
             jl_value_t *s = static_constant_instance(c, jt);
             if (s) {
                 jl_add_method_root(ctx, s);
-                return literal_pointer_val(s);
+                return literal_pointer_val(ctx, s);
             }
         }
     }
@@ -1908,46 +1901,46 @@ static Value *_boxed_special(const jl_cgval_t &vinfo, Type *t, jl_codectx_t *ctx
     assert(jl_is_datatype(jb));
     Value *box = NULL;
     if (jb == jl_int8_type)
-        box = call_with_signed(box_int8_func, as_value(t, vinfo));
+        box = call_with_signed(ctx, box_int8_func, as_value(ctx, t, vinfo));
     else if (jb == jl_int16_type)
-        box = call_with_signed(box_int16_func, as_value(t, vinfo));
+        box = call_with_signed(ctx, box_int16_func, as_value(ctx, t, vinfo));
     else if (jb == jl_int32_type)
-        box = call_with_signed(box_int32_func, as_value(t, vinfo));
+        box = call_with_signed(ctx, box_int32_func, as_value(ctx, t, vinfo));
     else if (jb == jl_int64_type)
-        box = call_with_signed(box_int64_func, as_value(t, vinfo));
+        box = call_with_signed(ctx, box_int64_func, as_value(ctx, t, vinfo));
     else if (jb == jl_float32_type)
-        box = builder.CreateCall(prepare_call(box_float32_func), as_value(t, vinfo));
+        box = ctx.builder.CreateCall(prepare_call(box_float32_func), as_value(ctx, t, vinfo));
     //if (jb == jl_float64_type)
-    //  box = builder.CreateCall(box_float64_func, as_value(t, vinfo);
+    //  box = ctx.builder.CreateCall(box_float64_func, as_value(ctx, t, vinfo);
     // for Float64, fall through to generic case below, to inline alloc & init of Float64 box. cheap, I know.
     else if (jb == jl_uint8_type)
-        box = call_with_unsigned(box_uint8_func, as_value(t, vinfo));
+        box = call_with_unsigned(ctx, box_uint8_func, as_value(ctx, t, vinfo));
     else if (jb == jl_uint16_type)
-        box = call_with_unsigned(box_uint16_func, as_value(t, vinfo));
+        box = call_with_unsigned(ctx, box_uint16_func, as_value(ctx, t, vinfo));
     else if (jb == jl_uint32_type)
-        box = call_with_unsigned(box_uint32_func, as_value(t, vinfo));
+        box = call_with_unsigned(ctx, box_uint32_func, as_value(ctx, t, vinfo));
     else if (jb == jl_uint64_type)
-        box = call_with_unsigned(box_uint64_func, as_value(t, vinfo));
+        box = call_with_unsigned(ctx, box_uint64_func, as_value(ctx, t, vinfo));
     else if (jb == jl_char_type)
-        box = call_with_unsigned(box_char_func, as_value(t, vinfo));
+        box = call_with_unsigned(ctx, box_char_func, as_value(ctx, t, vinfo));
     else if (jb == jl_ssavalue_type) {
         unsigned zero = 0;
-        Value *v = as_value(t, vinfo);
+        Value *v = as_value(ctx, t, vinfo);
         assert(v->getType() == jl_ssavalue_type->struct_decl);
-        v = builder.CreateExtractValue(v, makeArrayRef(&zero, 1));
-        box = call_with_unsigned(box_ssavalue_func, v);
+        v = ctx.builder.CreateExtractValue(v, makeArrayRef(&zero, 1));
+        box = call_with_unsigned(ctx, box_ssavalue_func, v);
     }
     else if (!jb->abstract && jl_datatype_nbits(jb) == 0) {
         // singleton
         assert(jb->instance != NULL);
-        return literal_pointer_val(jb->instance);
+        return literal_pointer_val(ctx, jb->instance);
     }
     return box;
 }
 
 
 
-static Value *box_union(const jl_cgval_t &vinfo, jl_codectx_t *ctx, const SmallBitVector &skip)
+static Value *box_union(jl_codectx_t &ctx, const jl_cgval_t &vinfo, const SmallBitVector &skip)
 {
     // given vinfo::Union{T, S}, emit IR of the form:
     //   ...
@@ -1965,292 +1958,294 @@ static Value *box_union(const jl_cgval_t &vinfo, jl_codectx_t *ctx, const SmallB
     //   box = phi [ box1, box_union_1 ], [ box2, box_union_2 ], [ vinfo, box_union_isboxed ]
     //   ...
     Value *tindex = vinfo.TIndex;
-    BasicBlock *defaultBB = BasicBlock::Create(jl_LLVMContext, "box_union_isboxed", ctx->f);
-    SwitchInst *switchInst = builder.CreateSwitch(tindex, defaultBB);
-    BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_box_union", ctx->f);
-    builder.SetInsertPoint(postBB);
-    PHINode *box_merge = builder.CreatePHI(T_prjlvalue, 2);
+    BasicBlock *defaultBB = BasicBlock::Create(jl_LLVMContext, "box_union_isboxed", ctx.f);
+    SwitchInst *switchInst = ctx.builder.CreateSwitch(tindex, defaultBB);
+    BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_box_union", ctx.f);
+    ctx.builder.SetInsertPoint(postBB);
+    PHINode *box_merge = ctx.builder.CreatePHI(T_prjlvalue, 2);
     unsigned counter = 0;
     for_each_uniontype_small(
             [&](unsigned idx, jl_datatype_t *jt) {
                 if (idx < skip.size() && skip[idx])
                     return;
                 Type *t = julia_type_to_llvm((jl_value_t*)jt);
-                BasicBlock *tempBB = BasicBlock::Create(jl_LLVMContext, "box_union", ctx->f);
-                builder.SetInsertPoint(tempBB);
+                BasicBlock *tempBB = BasicBlock::Create(jl_LLVMContext, "box_union", ctx.f);
+                ctx.builder.SetInsertPoint(tempBB);
                 switchInst->addCase(ConstantInt::get(T_int8, idx), tempBB);
                 Value *box;
                 if (type_is_ghost(t)) {
-                    box = literal_pointer_val(jt->instance);
+                    box = literal_pointer_val(ctx, jt->instance);
                 }
                 else {
                     jl_cgval_t vinfo_r = jl_cgval_t(vinfo, (jl_value_t*)jt, NULL);
-                    box = _boxed_special(vinfo_r, t, ctx);
+                    box = _boxed_special(ctx, vinfo_r, t);
                     if (!box) {
-                        box = emit_allocobj(ctx, jl_datatype_size(jt), literal_pointer_val((jl_value_t*)jt));
-                        init_bits_cgval(box, vinfo_r, jl_is_mutable(jt) ? tbaa_mutab : tbaa_immut, ctx);
+                        box = emit_allocobj(ctx, jl_datatype_size(jt), literal_pointer_val(ctx, (jl_value_t*)jt));
+                        init_bits_cgval(ctx, box, vinfo_r, jl_is_mutable(jt) ? tbaa_mutab : tbaa_immut);
                     }
                 }
                 box_merge->addIncoming(maybe_decay_untracked(box), tempBB);
-                builder.CreateBr(postBB);
+                ctx.builder.CreateBr(postBB);
             },
             vinfo.typ,
             counter);
-    builder.SetInsertPoint(defaultBB);
+    ctx.builder.SetInsertPoint(defaultBB);
     if (skip.size() > 0 && skip[0]) {
         // skip[0] specifies where to return NULL or the original pointer
         // if the value was not handled above
         box_merge->addIncoming(maybe_decay_untracked(V_null), defaultBB);
-        builder.CreateBr(postBB);
+        ctx.builder.CreateBr(postBB);
     }
     else if ((vinfo.V == NULL || isa<AllocaInst>(vinfo.V)) && !vinfo.gcroot) {
         Function *trap_func = Intrinsic::getDeclaration(
-                ctx->f->getParent(),
+                ctx.f->getParent(),
                 Intrinsic::trap);
-        builder.CreateCall(trap_func);
-        builder.CreateUnreachable();
+        ctx.builder.CreateCall(trap_func);
+        ctx.builder.CreateUnreachable();
     }
     else {
         // We're guaranteed here that Load(.gcroot) == .V, because we have determined
         // that this union is a boxed value, rather than an interior pointer of some sort
-        box_merge->addIncoming(builder.CreateLoad(vinfo.gcroot), defaultBB);
-        builder.CreateBr(postBB);
+        box_merge->addIncoming(ctx.builder.CreateLoad(vinfo.gcroot), defaultBB);
+        ctx.builder.CreateBr(postBB);
     }
-    builder.SetInsertPoint(postBB);
+    ctx.builder.SetInsertPoint(postBB);
     return box_merge;
 }
 
 // this is used to wrap values for generic contexts, where a
 // dynamically-typed value is required (e.g. argument to unknown function).
 // if it's already a pointer it's left alone.
-static Value *boxed(const jl_cgval_t &vinfo, jl_codectx_t *ctx, bool gcrooted)
+static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool gcrooted)
 {
     jl_value_t *jt = vinfo.typ;
     if (jt == jl_bottom_type || jt == NULL)
         // We have an undef value on a (hopefully) dead branch
         return UndefValue::get(T_prjlvalue);
     if (vinfo.constant)
-        return literal_pointer_val(vinfo.constant);
+        return literal_pointer_val(ctx, vinfo.constant);
     if (vinfo.isboxed) {
         assert(vinfo.V && "Missing value for box.");
         // We're guaranteed here that Load(.gcroot) == .V, because we have determined
         // that this value is a box, so if it has a gcroot, that's where the value is.
-        return vinfo.gcroot ? builder.CreateLoad(vinfo.gcroot) : vinfo.V;
+        return vinfo.gcroot ? ctx.builder.CreateLoad(vinfo.gcroot) : vinfo.V;
     }
 
     Value *box;
     if (vinfo.TIndex) {
         SmallBitVector skip_none;
-        box = box_union(vinfo, ctx, skip_none);
+        box = box_union(ctx, vinfo, skip_none);
     }
     else {
         assert(vinfo.V && "Missing data for unboxed value.");
         assert(jl_isbits(jt) && jl_is_leaf_type(jt) && "This type shouldn't have been unboxed.");
         Type *t = julia_type_to_llvm(jt);
         assert(!type_is_ghost(t)); // ghost values should have been handled by vinfo.constant above!
-        box = _boxed_special(vinfo, t, ctx);
+        box = _boxed_special(ctx, vinfo, t);
         if (!box) {
-            box = emit_allocobj(ctx, jl_datatype_size(jt), literal_pointer_val((jl_value_t*)jt));
-            init_bits_cgval(box, vinfo, jl_is_mutable(jt) ? tbaa_mutab : tbaa_immut, ctx);
+            box = emit_allocobj(ctx, jl_datatype_size(jt), literal_pointer_val(ctx, (jl_value_t*)jt));
+            init_bits_cgval(ctx, box, vinfo, jl_is_mutable(jt) ? tbaa_mutab : tbaa_immut);
         }
     }
     if (gcrooted) {
         // make a gcroot for the new box
         // (unless the caller explicitly said this was unnecessary)
         Value *froot = emit_local_root(ctx);
-        builder.CreateStore(box, froot);
+        ctx.builder.CreateStore(box, froot);
     }
     return box;
 }
 
 // copy src to dest, if src is isbits. if skip is true, the value of dest is undefined
-static void emit_unionmove(Value *dest, const jl_cgval_t &src, Value *skip, bool isVolatile, MDNode *tbaa, jl_codectx_t *ctx)
+static void emit_unionmove(jl_codectx_t &ctx, Value *dest, const jl_cgval_t &src, Value *skip, bool isVolatile, MDNode *tbaa)
 {
     if (AllocaInst *ai = dyn_cast<AllocaInst>(dest))
-        builder.CreateStore(UndefValue::get(ai->getAllocatedType()), ai);
+        ctx.builder.CreateStore(UndefValue::get(ai->getAllocatedType()), ai);
     if (jl_is_leaf_type(src.typ) || src.constant) {
         jl_value_t *typ = src.constant ? jl_typeof(src.constant) : src.typ;
         Type *store_ty = julia_type_to_llvm(typ);
         assert(skip || jl_isbits(typ));
         if (jl_isbits(typ)) {
             if (!src.ispointer() || src.constant) {
-                emit_unbox(store_ty, src, typ, dest, isVolatile);
+                emit_unbox(ctx, store_ty, src, typ, dest, isVolatile);
             }
             else {
-                Value *src_ptr = data_pointer(src, ctx, T_pint8);
+                Value *src_ptr = data_pointer(ctx, src, T_pint8);
                 if (dest->getType() != T_pint8)
-                    dest = emit_bitcast(dest, T_pint8);
+                    dest = emit_bitcast(ctx, dest, T_pint8);
                 if (skip) // copy dest -> dest to simulate an undef value / conditional copy
-                    src_ptr = builder.CreateSelect(skip, dest, src_ptr);
+                    src_ptr = ctx.builder.CreateSelect(skip, dest, src_ptr);
                 unsigned nb = jl_datatype_size(typ);
                 unsigned alignment = 0;
-                builder.CreateMemCpy(dest, src_ptr, nb, alignment, isVolatile, tbaa);
+                ctx.builder.CreateMemCpy(dest, src_ptr, nb, alignment, isVolatile, tbaa);
             }
         }
     }
     else if (src.TIndex) {
-        Value *tindex = builder.CreateAnd(src.TIndex, ConstantInt::get(T_int8, 0x7f));
+        Value *tindex = ctx.builder.CreateAnd(src.TIndex, ConstantInt::get(T_int8, 0x7f));
         if (skip)
-            tindex = builder.CreateSelect(skip, ConstantInt::get(T_int8, 0), tindex);
-        Value *src_ptr = data_pointer(src, ctx, T_pint8);
+            tindex = ctx.builder.CreateSelect(skip, ConstantInt::get(T_int8, 0), tindex);
+        Value *src_ptr = data_pointer(ctx, src, T_pint8);
         if (dest->getType() != T_pint8)
-            dest = emit_bitcast(dest, T_pint8);
-        BasicBlock *defaultBB = BasicBlock::Create(jl_LLVMContext, "union_move_skip", ctx->f);
-        SwitchInst *switchInst = builder.CreateSwitch(tindex, defaultBB);
-        BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_union_move", ctx->f);
+            dest = emit_bitcast(ctx, dest, T_pint8);
+        BasicBlock *defaultBB = BasicBlock::Create(jl_LLVMContext, "union_move_skip", ctx.f);
+        SwitchInst *switchInst = ctx.builder.CreateSwitch(tindex, defaultBB);
+        BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_union_move", ctx.f);
         unsigned counter = 0;
         bool allunboxed = for_each_uniontype_small(
                 [&](unsigned idx, jl_datatype_t *jt) {
                     unsigned nb = jl_datatype_size(jt);
                     unsigned alignment = 0;
-                    BasicBlock *tempBB = BasicBlock::Create(jl_LLVMContext, "union_move", ctx->f);
-                    builder.SetInsertPoint(tempBB);
+                    BasicBlock *tempBB = BasicBlock::Create(jl_LLVMContext, "union_move", ctx.f);
+                    ctx.builder.SetInsertPoint(tempBB);
                     switchInst->addCase(ConstantInt::get(T_int8, idx), tempBB);
                     if (nb > 0)
-                        builder.CreateMemCpy(dest, src_ptr, nb, alignment, isVolatile, tbaa);
-                    builder.CreateBr(postBB);
+                        ctx.builder.CreateMemCpy(dest, src_ptr, nb, alignment, isVolatile, tbaa);
+                    ctx.builder.CreateBr(postBB);
                 },
                 src.typ,
                 counter);
-        builder.SetInsertPoint(defaultBB);
+        ctx.builder.SetInsertPoint(defaultBB);
         if (!skip && allunboxed && (src.V == NULL || isa<AllocaInst>(src.V))) {
             Function *trap_func = Intrinsic::getDeclaration(
-                    ctx->f->getParent(),
+                    ctx.f->getParent(),
                     Intrinsic::trap);
-            builder.CreateCall(trap_func);
-            builder.CreateUnreachable();
+            ctx.builder.CreateCall(trap_func);
+            ctx.builder.CreateUnreachable();
         }
         else {
-            builder.CreateBr(postBB);
+            ctx.builder.CreateBr(postBB);
         }
-        builder.SetInsertPoint(postBB);
+        ctx.builder.SetInsertPoint(postBB);
     }
     else {
-        Value *datatype = emit_typeof_boxed(src, ctx);
-        Value *copy_bytes = emit_datatype_size(datatype);
+        Value *datatype = emit_typeof_boxed(ctx, src);
+        Value *copy_bytes = emit_datatype_size(ctx, datatype);
         if (skip)
-            copy_bytes = builder.CreateSelect(skip, ConstantInt::get(copy_bytes->getType(), 0), copy_bytes);
-        builder.CreateMemCpy(dest,
-                             data_pointer(src, ctx, T_pint8),
+            copy_bytes = ctx.builder.CreateSelect(skip, ConstantInt::get(copy_bytes->getType(), 0), copy_bytes);
+        ctx.builder.CreateMemCpy(dest,
+                             data_pointer(ctx, src, T_pint8),
                              copy_bytes,
                              /*TODO: min-align*/1);
     }
 }
 
 
-static void emit_cpointercheck(const jl_cgval_t &x, const std::string &msg, jl_codectx_t *ctx)
+static void emit_cpointercheck(jl_codectx_t &ctx, const jl_cgval_t &x, const std::string &msg)
 {
-    Value *t = emit_typeof_boxed(x,ctx);
-    emit_typecheck(mark_julia_type(t, true, jl_any_type, ctx, false), (jl_value_t*)jl_datatype_type, msg, ctx);
+    Value *t = emit_typeof_boxed(ctx, x);
+    emit_typecheck(ctx, mark_julia_type(ctx, t, true, jl_any_type, false), (jl_value_t*)jl_datatype_type, msg);
 
     Value *istype =
-        builder.CreateICmpEQ(mark_callee_rooted(emit_datatype_name(t)),
-                             mark_callee_rooted(literal_pointer_val((jl_value_t*)jl_pointer_typename)));
-    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx->f);
+        ctx.builder.CreateICmpEQ(mark_callee_rooted(emit_datatype_name(ctx, t)),
+                             mark_callee_rooted(literal_pointer_val(ctx, (jl_value_t*)jl_pointer_typename)));
+    BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext,"fail",ctx.f);
     BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext,"pass");
-    builder.CreateCondBr(istype, passBB, failBB);
-    builder.SetInsertPoint(failBB);
+    ctx.builder.CreateCondBr(istype, passBB, failBB);
+    ctx.builder.SetInsertPoint(failBB);
 
-    emit_type_error(x, literal_pointer_val((jl_value_t*)jl_pointer_type), msg, ctx);
-    builder.CreateUnreachable();
+    emit_type_error(ctx, x, literal_pointer_val(ctx, (jl_value_t*)jl_pointer_type), msg);
+    ctx.builder.CreateUnreachable();
 
-    ctx->f->getBasicBlockList().push_back(passBB);
-    builder.SetInsertPoint(passBB);
+    ctx.f->getBasicBlockList().push_back(passBB);
+    ctx.builder.SetInsertPoint(passBB);
 }
 
 // allocation for known size object
-static Value *emit_allocobj(jl_codectx_t *ctx, size_t static_size, Value *jt)
+static Value *emit_allocobj(jl_codectx_t &ctx, size_t static_size, Value *jt)
 {
     JL_FEAT_REQUIRE(ctx, dynamic_alloc);
     JL_FEAT_REQUIRE(ctx, runtime);
 
     int osize;
     int offset = jl_gc_classify_pools(static_size, &osize);
-    Value *ptls_ptr = emit_bitcast(ctx->ptlsStates, T_pint8);
+    Value *ptls_ptr = emit_bitcast(ctx, ctx.ptlsStates, T_pint8);
     Value *v;
     if (offset < 0) {
         Value *args[] = {ptls_ptr,
                          ConstantInt::get(T_size, static_size + sizeof(void*))};
-        v = builder.CreateCall(prepare_call(jlalloc_big_func),
+        v = ctx.builder.CreateCall(prepare_call(jlalloc_big_func),
                                ArrayRef<Value*>(args, 2));
     }
     else {
         Value *pool_offs = ConstantInt::get(T_int32, offset);
         Value *args[] = {ptls_ptr, pool_offs, ConstantInt::get(T_int32, osize)};
-        v = builder.CreateCall(prepare_call(jlalloc_pool_func),
+        v = ctx.builder.CreateCall(prepare_call(jlalloc_pool_func),
                                ArrayRef<Value*>(args, 3));
     }
-    tbaa_decorate(tbaa_tag, builder.CreateStore(maybe_decay_untracked(jt), emit_typeptr_addr(v)));
+    tbaa_decorate(tbaa_tag, ctx.builder.CreateStore(maybe_decay_untracked(jt), emit_typeptr_addr(ctx, v)));
     return v;
 }
 
 // if ptr is NULL this emits a write barrier _back_
-static void emit_write_barrier(jl_codectx_t *ctx, Value *parent, Value *ptr)
+static void emit_write_barrier(jl_codectx_t &ctx, Value *parent, Value *ptr)
 {
-    Value *parenttag = emit_bitcast(emit_typeptr_addr(parent), T_psize);
-    Value *parent_type = tbaa_decorate(tbaa_tag, builder.CreateLoad(parenttag));
-    Value *parent_bits = builder.CreateAnd(parent_type, 3);
+    Value *parenttag = emit_bitcast(ctx, emit_typeptr_addr(ctx, parent), T_psize);
+    Value *parent_type = tbaa_decorate(tbaa_tag, ctx.builder.CreateLoad(parenttag));
+    Value *parent_bits = ctx.builder.CreateAnd(parent_type, 3);
 
     // the branch hint does not seem to make it to the generated code
-    Value *parent_old_marked = builder.CreateICmpEQ(parent_bits,
+    Value *parent_old_marked = ctx.builder.CreateICmpEQ(parent_bits,
                                                     ConstantInt::get(T_size, 3));
 
     BasicBlock *cont = BasicBlock::Create(jl_LLVMContext, "cont");
-    BasicBlock *barrier_may_trigger = BasicBlock::Create(jl_LLVMContext, "wb_may_trigger", ctx->f);
-    BasicBlock *barrier_trigger = BasicBlock::Create(jl_LLVMContext, "wb_trigger", ctx->f);
-    builder.CreateCondBr(parent_old_marked, barrier_may_trigger, cont);
+    BasicBlock *barrier_may_trigger = BasicBlock::Create(jl_LLVMContext, "wb_may_trigger", ctx.f);
+    BasicBlock *barrier_trigger = BasicBlock::Create(jl_LLVMContext, "wb_trigger", ctx.f);
+    ctx.builder.CreateCondBr(parent_old_marked, barrier_may_trigger, cont);
 
-    builder.SetInsertPoint(barrier_may_trigger);
-    Value *ptr_mark_bit = builder.CreateAnd(tbaa_decorate(tbaa_tag,
-        builder.CreateLoad(emit_bitcast(emit_typeptr_addr(ptr), T_psize))), 1);
-    Value *ptr_not_marked = builder.CreateICmpEQ(ptr_mark_bit, ConstantInt::get(T_size, 0));
-    builder.CreateCondBr(ptr_not_marked, barrier_trigger, cont);
-    builder.SetInsertPoint(barrier_trigger);
-    builder.CreateCall(prepare_call(queuerootfun), maybe_decay_untracked(emit_bitcast(parent, T_prjlvalue)));
-    builder.CreateBr(cont);
-    ctx->f->getBasicBlockList().push_back(cont);
-    builder.SetInsertPoint(cont);
+    ctx.builder.SetInsertPoint(barrier_may_trigger);
+    Value *ptr_mark_bit = ctx.builder.CreateAnd(tbaa_decorate(tbaa_tag,
+        ctx.builder.CreateLoad(emit_bitcast(ctx, emit_typeptr_addr(ctx, ptr), T_psize))), 1);
+    Value *ptr_not_marked = ctx.builder.CreateICmpEQ(ptr_mark_bit, ConstantInt::get(T_size, 0));
+    ctx.builder.CreateCondBr(ptr_not_marked, barrier_trigger, cont);
+    ctx.builder.SetInsertPoint(barrier_trigger);
+    ctx.builder.CreateCall(prepare_call(queuerootfun), maybe_decay_untracked(emit_bitcast(ctx, parent, T_prjlvalue)));
+    ctx.builder.CreateBr(cont);
+    ctx.f->getBasicBlockList().push_back(cont);
+    ctx.builder.SetInsertPoint(cont);
 }
 
-static void emit_checked_write_barrier(jl_codectx_t *ctx, Value *parent, Value *ptr)
+static void emit_checked_write_barrier(jl_codectx_t &ctx, Value *parent, Value *ptr)
 {
     BasicBlock *cont;
-    Value *not_null = builder.CreateICmpNE(mark_callee_rooted(ptr), mark_callee_rooted(V_null));
-    BasicBlock *if_not_null = BasicBlock::Create(jl_LLVMContext, "wb_not_null", ctx->f);
+    Value *not_null = ctx.builder.CreateICmpNE(mark_callee_rooted(ptr), mark_callee_rooted(V_null));
+    BasicBlock *if_not_null = BasicBlock::Create(jl_LLVMContext, "wb_not_null", ctx.f);
     cont = BasicBlock::Create(jl_LLVMContext, "cont");
-    builder.CreateCondBr(not_null, if_not_null, cont);
-    builder.SetInsertPoint(if_not_null);
+    ctx.builder.CreateCondBr(not_null, if_not_null, cont);
+    ctx.builder.SetInsertPoint(if_not_null);
     emit_write_barrier(ctx, parent, ptr);
-    builder.CreateBr(cont);
-    ctx->f->getBasicBlockList().push_back(cont);
-    builder.SetInsertPoint(cont);
+    ctx.builder.CreateBr(cont);
+    ctx.f->getBasicBlockList().push_back(cont);
+    ctx.builder.SetInsertPoint(cont);
 }
 
-static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t idx0,
-                          const jl_cgval_t &rhs, jl_codectx_t *ctx, bool checked, bool wb)
+static void emit_setfield(jl_codectx_t &ctx,
+        jl_datatype_t *sty, const jl_cgval_t &strct, size_t idx0,
+        const jl_cgval_t &rhs, bool checked, bool wb)
 {
     if (sty->mutabl || !checked) {
         assert(strct.ispointer());
-        Value *addr = builder.CreateGEP(data_pointer(strct, ctx, T_pint8),
+        Value *addr = ctx.builder.CreateGEP(data_pointer(ctx, strct, T_pint8),
                 ConstantInt::get(T_size, jl_field_offset(sty, idx0)));
         jl_value_t *jfty = jl_svecref(sty->types, idx0);
         if (jl_field_isptr(sty, idx0)) {
-            Value *r = maybe_decay_untracked(boxed(rhs, ctx, false)); // don't need a temporary gcroot since it'll be rooted by strct
-            tbaa_decorate(strct.tbaa, builder.CreateStore(r,
-                emit_bitcast(addr, T_pprjlvalue)));
-            if (wb && strct.isboxed) emit_checked_write_barrier(ctx, boxed(strct, ctx), r);
+            Value *r = maybe_decay_untracked(boxed(ctx, rhs, false)); // don't need a temporary gcroot since it'll be rooted by strct
+            tbaa_decorate(strct.tbaa, ctx.builder.CreateStore(r,
+                emit_bitcast(ctx, addr, T_pprjlvalue)));
+            if (wb && strct.isboxed)
+                emit_checked_write_barrier(ctx, boxed(ctx, strct), r);
         }
         else {
             int align = jl_field_offset(sty, idx0);
             align |= 16;
             align &= -align;
-            typed_store(addr, ConstantInt::get(T_size, 0), rhs, jfty, ctx,
-                strct.tbaa, data_pointer(strct, ctx, T_pjlvalue), align);
+            typed_store(ctx, addr, ConstantInt::get(T_size, 0), rhs, jfty,
+                strct.tbaa, data_pointer(ctx, strct, T_pjlvalue), align);
         }
     }
     else {
         // TODO: better error
-        emit_error("type is immutable", ctx);
+        emit_error(ctx, "type is immutable");
     }
 }
 
@@ -2261,7 +2256,7 @@ static bool might_need_root(jl_value_t *ex)
             !jl_is_globalref(ex));
 }
 
-static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, jl_codectx_t *ctx)
+static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t nargs, jl_value_t **args)
 {
     assert(jl_is_datatype(ty));
     assert(jl_is_leaf_type(ty));
@@ -2284,30 +2279,30 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
             if (init_as_value)
                 strct = UndefValue::get(lt == T_void ? NoopType : lt);
             else
-                strct = emit_static_alloca(lt);
+                strct = emit_static_alloca(ctx, lt);
 
             unsigned idx = 0;
             for (size_t i = 0; i < na; i++) {
                 jl_value_t *jtype = jl_svecref(sty->types, i);
                 Type *fty = julia_type_to_llvm(jtype);
-                jl_cgval_t fval_info = emit_expr(args[i + 1], ctx);
-                emit_typecheck(fval_info, jtype, "new", ctx);
+                jl_cgval_t fval_info = emit_expr(ctx, args[i + 1]);
+                emit_typecheck(ctx, fval_info, jtype, "new");
                 if (!type_is_ghost(fty)) {
                     Value *fval = NULL, *dest = NULL;
                     if (!init_as_value) {
                         // avoid unboxing the argument explicitely
                         // and use memcpy instead
-                        dest = builder.CreateConstInBoundsGEP2_32(lt, strct, 0, i);
+                        dest = ctx.builder.CreateConstInBoundsGEP2_32(lt, strct, 0, i);
                     }
-                    fval = emit_unbox(fty, fval_info, jtype, dest);
+                    fval = emit_unbox(ctx, fty, fval_info, jtype, dest);
 
                     if (init_as_value) {
                         if (lt->isVectorTy())
-                            strct = builder.CreateInsertElement(strct, fval, ConstantInt::get(T_int32,idx));
+                            strct = ctx.builder.CreateInsertElement(strct, fval, ConstantInt::get(T_int32,idx));
                         else if (jl_is_vecelement_type(ty))
                             strct = fval;  // VecElement type comes unwrapped in LLVM.
                         else if (lt->isAggregateType())
-                            strct = builder.CreateInsertValue(strct, fval, ArrayRef<unsigned>(&idx,1));
+                            strct = ctx.builder.CreateInsertValue(strct, fval, ArrayRef<unsigned>(&idx,1));
                         else
                             assert(false);
                     }
@@ -2315,19 +2310,19 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
                 idx++;
             }
             if (init_as_value)
-                return mark_julia_type(strct, false, ty, ctx);
+                return mark_julia_type(ctx, strct, false, ty);
             else
                 return mark_julia_slot(strct, ty, NULL, tbaa_stack);
         }
         Value *strct = emit_allocobj(ctx, jl_datatype_size(sty),
-                                     literal_pointer_val((jl_value_t*)ty));
-        jl_cgval_t strctinfo = mark_julia_type(strct, true, ty, ctx);
+                                     literal_pointer_val(ctx, (jl_value_t*)ty));
+        jl_cgval_t strctinfo = mark_julia_type(ctx, strct, true, ty);
         for (size_t i = 0; i < nf; i++) {
             if (jl_field_isptr(sty, i)) {
-                tbaa_decorate(strctinfo.tbaa, builder.CreateStore(
+                tbaa_decorate(strctinfo.tbaa, ctx.builder.CreateStore(
                         ConstantPointerNull::get(cast<PointerType>(T_prjlvalue)),
-                        emit_bitcast(
-                            builder.CreateGEP(emit_bitcast(decay_derived(strct), T_pint8),
+                        emit_bitcast(ctx,
+                            ctx.builder.CreateGEP(emit_bitcast(ctx, decay_derived(strct), T_pint8),
                                 ConstantInt::get(T_size, jl_field_offset(sty, i))),
                             T_pprjlvalue)));
             }
@@ -2335,16 +2330,16 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
         bool need_wb = false;
         // TODO: verify that nargs <= nf (currently handled by front-end)
         for (size_t i = 1; i < nargs; i++) {
-            jl_cgval_t rhs = emit_expr(args[i], ctx);
+            jl_cgval_t rhs = emit_expr(ctx, args[i]);
             if (jl_field_isptr(sty, i - 1) && !rhs.isboxed) {
                 need_wb = true;
             }
             if (rhs.isboxed) {
-                emit_typecheck(rhs, jl_svecref(sty->types, i - 1), "new", ctx);
+                emit_typecheck(ctx, rhs, jl_svecref(sty->types, i - 1), "new");
             }
             if (might_need_root(args[i])) // TODO: how to remove this?
                 need_wb = true;
-            emit_setfield(sty, strctinfo, i - 1, rhs, ctx, false, need_wb);
+            emit_setfield(ctx, sty, strctinfo, i - 1, rhs, false, need_wb);
         }
         return strctinfo;
     }
@@ -2353,11 +2348,11 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
         if (jl_datatype_nbits(sty) == 0)
             return ghostValue(sty);
         if (nargs >= 2)
-            return emit_expr(args[1], ctx);  // do side effects
+            return emit_expr(ctx, args[1]);  // do side effects
         bool isboxed;
         Type *lt = julia_type_to_llvm(ty, &isboxed);
         assert(!isboxed);
-        return mark_julia_type(UndefValue::get(lt), false, ty, ctx);
+        return mark_julia_type(ctx, UndefValue::get(lt), false, ty);
     }
     else {
         // 0 fields, singleton
@@ -2366,35 +2361,35 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
     }
 }
 
-static Value *emit_exc_in_transit(jl_codectx_t *ctx)
+static Value *emit_exc_in_transit(jl_codectx_t &ctx)
 {
-    Value *pexc_in_transit = emit_bitcast(ctx->ptlsStates, T_pprjlvalue);
+    Value *pexc_in_transit = emit_bitcast(ctx, ctx.ptlsStates, T_pprjlvalue);
     Constant *offset = ConstantInt::getSigned(T_int32,
         offsetof(jl_tls_states_t, exception_in_transit) / sizeof(void*));
-    return builder.CreateGEP(pexc_in_transit, ArrayRef<Value*>(offset), "jl_exception_in_transit");
+    return ctx.builder.CreateGEP(pexc_in_transit, ArrayRef<Value*>(offset), "jl_exception_in_transit");
 }
 
-static void emit_signal_fence(void)
+static void emit_signal_fence(jl_codectx_t &ctx)
 {
 #if defined(_CPU_ARM_) || defined(_CPU_AARCH64_)
     // LLVM generates very inefficient code (and might include function call)
     // for signal fence. Fallback to the poor man signal fence with
     // inline asm instead.
     // https://llvm.org/bugs/show_bug.cgi?id=27545
-    builder.CreateCall(InlineAsm::get(FunctionType::get(T_void, false), "",
+    ctx.builder.CreateCall(InlineAsm::get(FunctionType::get(T_void, false), "",
                                       "~{memory}", true));
 #else
-    builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
+    ctx.builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
 #endif
 }
 
-static Value *emit_defer_signal(jl_codectx_t *ctx)
+static Value *emit_defer_signal(jl_codectx_t &ctx)
 {
-    Value *ptls = emit_bitcast(ctx->ptlsStates,
+    Value *ptls = emit_bitcast(ctx, ctx.ptlsStates,
                                         PointerType::get(T_sigatomic, 0));
     Constant *offset = ConstantInt::getSigned(T_int32,
         offsetof(jl_tls_states_t, defer_signal) / sizeof(sig_atomic_t));
-    return builder.CreateGEP(ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
+    return ctx.builder.CreateGEP(ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
 }
 
 static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -137,14 +137,14 @@ static Type *INTT(Type *t)
     return IntegerType::get(jl_LLVMContext, nb);
 }
 
-static Value *uint_cnvt(Type *to, Value *x)
+static Value *uint_cnvt(jl_codectx_t &ctx, Type *to, Value *x)
 {
     Type *t = x->getType();
     if (t == to)
         return x;
     if (to->getPrimitiveSizeInBits() < x->getType()->getPrimitiveSizeInBits())
-        return builder.CreateTrunc(x, to);
-    return builder.CreateZExt(x, to);
+        return ctx.builder.CreateTrunc(x, to);
+    return ctx.builder.CreateZExt(x, to);
 }
 
 #if JL_LLVM_VERSION >= 40000
@@ -257,7 +257,7 @@ static Constant *julia_const_to_llvm(jl_value_t *e)
 static jl_cgval_t ghostValue(jl_value_t *ty);
 
 // emit code to unpack a raw value from a box into registers or a stack slot
-static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *dest, bool volatile_store)
+static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *dest, bool volatile_store)
 {
     assert(to != T_void);
     // TODO: fully validate that x.typ == jt?
@@ -268,7 +268,7 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
         if (type_is_ghost(to)) {
             return NULL;
         }
-        //emit_error("emit_unbox: a type mismatch error in occurred during codegen", ctx);
+        //emit_error(ctx, "emit_unbox: a type mismatch error in occurred during codegen");
         return UndefValue::get(to); // type mismatch error
     }
 
@@ -280,48 +280,48 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
         bool frompointer = ty->isPointerTy();
         bool topointer = to->isPointerTy();
         if (frompointer && topointer) {
-            unboxed = emit_bitcast(unboxed, to);
+            unboxed = emit_bitcast(ctx, unboxed, to);
         }
         else if (frompointer) {
             Type *INTT_to = INTT(to);
-            unboxed = builder.CreatePtrToInt(unboxed, INTT_to);
+            unboxed = ctx.builder.CreatePtrToInt(unboxed, INTT_to);
             if (INTT_to != to)
-                unboxed = builder.CreateBitCast(unboxed, to);
+                unboxed = ctx.builder.CreateBitCast(unboxed, to);
         }
         else if (topointer) {
             Type *INTT_to = INTT(to);
             if (to != INTT_to)
-                unboxed = builder.CreateBitCast(unboxed, INTT_to);
-            unboxed = builder.CreateIntToPtr(unboxed, to);
+                unboxed = ctx.builder.CreateBitCast(unboxed, INTT_to);
+            unboxed = ctx.builder.CreateIntToPtr(unboxed, to);
         }
         else if (ty == T_int1 && to == T_int8) {
             // bools may be stored internally as int8
-            unboxed = builder.CreateZExt(unboxed, T_int8);
+            unboxed = ctx.builder.CreateZExt(unboxed, T_int8);
         }
         else if (ty != to) {
-            unboxed = builder.CreateBitCast(unboxed, to);
+            unboxed = ctx.builder.CreateBitCast(unboxed, to);
         }
         if (!dest)
             return unboxed;
-        builder.CreateStore(unboxed, dest, volatile_store);
+        ctx.builder.CreateStore(unboxed, dest, volatile_store);
         return NULL;
     }
 
     // bools stored as int8, so an extra Trunc is needed to get an int1
-    Value *p = x.constant ? literal_pointer_val(x.constant) : x.V;
+    Value *p = x.constant ? literal_pointer_val(ctx, x.constant) : x.V;
     Type *ptype = (to == T_int1 ? T_pint8 : to->getPointerTo());
     if (p->getType() != ptype)
-        p = emit_bitcast(p, ptype);
+        p = emit_bitcast(ctx, p, ptype);
 
     Value *unboxed = NULL;
     if (to == T_int1)
-        unboxed = builder.CreateTrunc(tbaa_decorate(x.tbaa, builder.CreateLoad(p)), T_int1);
+        unboxed = ctx.builder.CreateTrunc(tbaa_decorate(x.tbaa, ctx.builder.CreateLoad(p)), T_int1);
     else if (jt == (jl_value_t*)jl_bool_type)
-        unboxed = builder.CreateZExt(builder.CreateTrunc(tbaa_decorate(x.tbaa, builder.CreateLoad(p)), T_int1), to);
+        unboxed = ctx.builder.CreateZExt(ctx.builder.CreateTrunc(tbaa_decorate(x.tbaa, ctx.builder.CreateLoad(p)), T_int1), to);
     if (unboxed) {
         if (!dest)
             return unboxed;
-        builder.CreateStore(unboxed, dest);
+        ctx.builder.CreateStore(unboxed, dest);
         return NULL;
     }
 
@@ -347,15 +347,15 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt, Value *d
         // x.tbaa ∪ tbaa_stack = tbaa_root if x.tbaa != tbaa_stack
         if (tbaa != tbaa_stack)
             tbaa = NULL;
-        builder.CreateMemCpy(dest, p, jl_datatype_size(jt), alignment, volatile_store, tbaa);
+        ctx.builder.CreateMemCpy(dest, p, jl_datatype_size(jt), alignment, volatile_store, tbaa);
         return NULL;
     }
     else {
         Instruction *load;
         if (alignment)
-            load = builder.CreateAlignedLoad(p, alignment);
+            load = ctx.builder.CreateAlignedLoad(p, alignment);
         else
-            load = builder.CreateLoad(p);
+            load = ctx.builder.CreateLoad(p);
         return tbaa_decorate(x.tbaa, load);
     }
 }
@@ -371,19 +371,19 @@ static jl_value_t *staticeval_bitstype(const jl_cgval_t &targ)
     return NULL;
 }
 
-static jl_cgval_t emit_runtime_call(JL_I::intrinsic f, const jl_cgval_t *argv, size_t nargs, jl_codectx_t *ctx)
+static jl_cgval_t emit_runtime_call(jl_codectx_t &ctx, JL_I::intrinsic f, const jl_cgval_t *argv, size_t nargs)
 {
     Value *func = prepare_call(runtime_func[f]);
     Value **argvalues = (Value**)alloca(sizeof(Value*) * nargs);
     for (size_t i = 0; i < nargs; ++i) {
-        argvalues[i] = boxed(argv[i], ctx);
+        argvalues[i] = boxed(ctx, argv[i]);
     }
-    Value *r = builder.CreateCall(func, makeArrayRef(argvalues, nargs));
-    return mark_julia_type(r, true, (jl_value_t*)jl_any_type, ctx);
+    Value *r = ctx.builder.CreateCall(func, makeArrayRef(argvalues, nargs));
+    return mark_julia_type(ctx, r, true, (jl_value_t*)jl_any_type);
 }
 
 // put a bits type tag on some value (despite the name, this doesn't necessarily actually change anything about the value however)
-static jl_cgval_t generic_bitcast(const jl_cgval_t *argv, jl_codectx_t *ctx)
+static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
 {
     // Give the arguments names //
     const jl_cgval_t &bt_value = argv[0];
@@ -392,7 +392,7 @@ static jl_cgval_t generic_bitcast(const jl_cgval_t *argv, jl_codectx_t *ctx)
 
     // it's easier to throw a good error from C than llvm
     if (!bt)
-        return emit_runtime_call(bitcast, argv, 2, ctx);
+        return emit_runtime_call(ctx, bitcast, argv, 2);
 
     Type *llvmt = bitstype_to_llvm(bt);
     int nb = jl_datatype_size(bt);
@@ -402,25 +402,26 @@ static jl_cgval_t generic_bitcast(const jl_cgval_t *argv, jl_codectx_t *ctx)
     Type *vxt = julia_type_to_llvm(v.typ, &isboxed);
 
     if (!jl_is_primitivetype(v.typ) || jl_datatype_size(v.typ) != nb) {
-        Value *typ = emit_typeof_boxed(v, ctx);
+        Value *typ = emit_typeof_boxed(ctx, v);
         if (!jl_is_primitivetype(v.typ)) {
             if (isboxed) {
-                Value *isbits = emit_datatype_isbitstype(typ);
-                error_unless(isbits, "bitcast: expected primitive type value for second argument", ctx);
+                Value *isbits = emit_datatype_isbitstype(ctx, typ);
+                error_unless(ctx, isbits, "bitcast: expected primitive type value for second argument");
             }
             else {
-                emit_error("bitcast: expected primitive type value for second argument", ctx);
+                emit_error(ctx, "bitcast: expected primitive type value for second argument");
                 return jl_cgval_t();
             }
         }
         if (jl_datatype_size(v.typ) != nb) {
             if (isboxed) {
-                Value *size = emit_datatype_size(typ);
-                error_unless(builder.CreateICmpEQ(size, ConstantInt::get(T_int32, nb)),
-                            "bitcast: argument size does not match size of target type", ctx);
+                Value *size = emit_datatype_size(ctx, typ);
+                error_unless(ctx,
+                        ctx.builder.CreateICmpEQ(size, ConstantInt::get(T_int32, nb)),
+                        "bitcast: argument size does not match size of target type");
             }
             else {
-                emit_error("bitcast: argument size does not match size of target type", ctx);
+                emit_error(ctx, "bitcast: argument size does not match size of target type");
                 return jl_cgval_t();
             }
         }
@@ -438,43 +439,44 @@ static jl_cgval_t generic_bitcast(const jl_cgval_t *argv, jl_codectx_t *ctx)
         // but if the v.typ is not well known, use llvmt
         if (isboxed)
             vxt = llvmt;
-        vx = tbaa_decorate(v.tbaa, builder.CreateLoad(data_pointer(v, ctx,
-                                                                   vxt == T_int1 ? T_pint8 : vxt->getPointerTo())));
+        vx = tbaa_decorate(v.tbaa, ctx.builder.CreateLoad(
+                    data_pointer(ctx, v, vxt == T_int1 ? T_pint8 : vxt->getPointerTo())));
     }
 
     vxt = vx->getType();
     if (vxt != llvmt) {
         if (llvmt == T_int1)
-            vx = builder.CreateTrunc(vx, llvmt);
+            vx = ctx.builder.CreateTrunc(vx, llvmt);
         else if (vxt == T_int1 && llvmt == T_int8)
-            vx = builder.CreateZExt(vx, llvmt);
+            vx = ctx.builder.CreateZExt(vx, llvmt);
         else if (vxt->isPointerTy() && !llvmt->isPointerTy())
-            vx = builder.CreatePtrToInt(vx, llvmt);
+            vx = ctx.builder.CreatePtrToInt(vx, llvmt);
         else if (!vxt->isPointerTy() && llvmt->isPointerTy())
-            vx = builder.CreateIntToPtr(vx, llvmt);
+            vx = ctx.builder.CreateIntToPtr(vx, llvmt);
         else
-            vx = emit_bitcast(vx, llvmt);
+            vx = emit_bitcast(ctx, vx, llvmt);
     }
 
     if (jl_is_leaf_type(bt)) {
-        return mark_julia_type(vx, false, bt, ctx);
+        return mark_julia_type(ctx, vx, false, bt);
     }
     else {
-        Value *box = emit_allocobj(ctx, nb, boxed(bt_value, ctx));
-        init_bits_value(box, vx, tbaa_immut);
-        return mark_julia_type(box, true, bt, ctx);
+        Value *box = emit_allocobj(ctx, nb, boxed(ctx, bt_value));
+        init_bits_value(ctx, box, vx, tbaa_immut);
+        return mark_julia_type(ctx, box, true, bt);
     }
 }
 
 static jl_cgval_t generic_cast(
-        intrinsic f, Value *(*generic)(Type*, Value*, jl_codectx_t*),
-        const jl_cgval_t *argv, jl_codectx_t *ctx, bool toint, bool fromint)
+        jl_codectx_t &ctx,
+        intrinsic f, Value *(*generic)(jl_codectx_t&, Type*, Value*),
+        const jl_cgval_t *argv, bool toint, bool fromint)
 {
     const jl_cgval_t &targ = argv[0];
     const jl_cgval_t &v = argv[1];
     jl_value_t *jlto = staticeval_bitstype(targ);
     if (!jlto || !jl_is_primitivetype(v.typ))
-        return emit_runtime_call(f, argv, 2, ctx);
+        return emit_runtime_call(ctx, f, argv, 2);
     Type *to = bitstype_to_llvm(jlto);
     Type *vt = bitstype_to_llvm(v.typ);
     if (toint)
@@ -486,71 +488,71 @@ static jl_cgval_t generic_cast(
     else
         vt = FLOATT(vt);
     if (!to || !vt)
-        return emit_runtime_call(f, argv, 2, ctx);
-    Value *from = emit_unbox(vt, v, v.typ);
-    Value *ans = generic(to, from, ctx);
-    return mark_julia_type(ans, false, jlto, ctx);
+        return emit_runtime_call(ctx, f, argv, 2);
+    Value *from = emit_unbox(ctx, vt, v, v.typ);
+    Value *ans = generic(ctx, to, from);
+    return mark_julia_type(ctx, ans, false, jlto);
 }
 
-static Value *generic_trunc(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_trunc(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateTrunc(x, to);
+    return ctx.builder.CreateTrunc(x, to);
 }
 
-static Value *generic_trunc_uchecked(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_trunc_uchecked(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    Value *ans = builder.CreateTrunc(x, to);
-    Value *back = builder.CreateZExt(ans, x->getType());
-    raise_exception_unless(builder.CreateICmpEQ(back, x),
-                           literal_pointer_val(jl_inexact_exception), ctx);
+    Value *ans = ctx.builder.CreateTrunc(x, to);
+    Value *back = ctx.builder.CreateZExt(ans, x->getType());
+    raise_exception_unless(ctx, ctx.builder.CreateICmpEQ(back, x),
+                           literal_pointer_val(ctx, jl_inexact_exception));
     return ans;
 }
 
-static Value *generic_trunc_schecked(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_trunc_schecked(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    Value *ans = builder.CreateTrunc(x, to);
-    Value *back = builder.CreateSExt(ans, x->getType());
-    raise_exception_unless(builder.CreateICmpEQ(back, x),
-                           literal_pointer_val(jl_inexact_exception), ctx);
+    Value *ans = ctx.builder.CreateTrunc(x, to);
+    Value *back = ctx.builder.CreateSExt(ans, x->getType());
+    raise_exception_unless(ctx, ctx.builder.CreateICmpEQ(back, x),
+                           literal_pointer_val(ctx, jl_inexact_exception));
     return ans;
 }
 
-static Value *generic_sext(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_sext(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateSExt(x, to);
+    return ctx.builder.CreateSExt(x, to);
 }
 
-static Value *generic_zext(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_zext(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateZExt(x, to);
+    return ctx.builder.CreateZExt(x, to);
 }
 
-static Value *generic_uitofp(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_uitofp(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateUIToFP(x, to);
+    return ctx.builder.CreateUIToFP(x, to);
 }
 
-static Value *generic_sitofp(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_sitofp(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateSIToFP(x, to);
+    return ctx.builder.CreateSIToFP(x, to);
 }
 
-static Value *generic_fptoui(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_fptoui(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateFPToUI(x, to);
+    return ctx.builder.CreateFPToUI(x, to);
 }
 
-static Value *generic_fptosi(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_fptosi(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateFPToSI(x, to);
+    return ctx.builder.CreateFPToSI(x, to);
 }
 
-static Value *generic_fptrunc(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_fptrunc(jl_codectx_t &ctx, Type *to, Value *x)
 {
-    return builder.CreateFPTrunc(x, to);
+    return ctx.builder.CreateFPTrunc(x, to);
 }
 
-static Value *generic_fpext(Type *to, Value *x, jl_codectx_t *ctx)
+static Value *generic_fpext(jl_codectx_t &ctx, Type *to, Value *x)
 {
 #ifdef JL_NEED_FLOATTEMP_VAR
     // Target platform might carry extra precision.
@@ -559,80 +561,81 @@ static Value *generic_fpext(Type *to, Value *x, jl_codectx_t *ctx)
     // understood that everything is implicitly rounded to 23 bits,
     // but if we start looking at more bits we need to actually do the
     // rounding first instead of carrying around incorrect low bits.
-    Value *jlfloattemp_var = emit_static_alloca(x->getType());
-    builder.CreateStore(x, jlfloattemp_var);
-    x  = builder.CreateLoad(jlfloattemp_var, true);
+    Value *jlfloattemp_var = emit_static_alloca(ctx, x->getType());
+    ctx.builder.CreateStore(x, jlfloattemp_var);
+    x  = ctx.builder.CreateLoad(jlfloattemp_var, true);
 #endif
-    return builder.CreateFPExt(x, to);
+    return ctx.builder.CreateFPExt(x, to);
 }
 
-static jl_cgval_t emit_runtime_pointerref(jl_cgval_t *argv, jl_codectx_t *ctx)
+static jl_cgval_t emit_runtime_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
 {
-    return emit_runtime_call(pointerref, argv, 3, ctx);
+    return emit_runtime_call(ctx, pointerref, argv, 3);
 }
 
-static jl_cgval_t emit_pointerref(jl_cgval_t *argv, jl_codectx_t *ctx)
+static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
 {
     const jl_cgval_t &e = argv[0];
     const jl_cgval_t &i = argv[1];
     const jl_cgval_t &align = argv[2];
 
     if (align.constant == NULL || !jl_is_long(align.constant))
-        return emit_runtime_pointerref(argv, ctx);
+        return emit_runtime_pointerref(ctx, argv);
     unsigned align_nb = jl_unbox_long(align.constant);
 
     if (i.typ != (jl_value_t*)jl_long_type)
-        return emit_runtime_pointerref(argv, ctx);
+        return emit_runtime_pointerref(ctx, argv);
     jl_value_t *aty = e.typ;
     if (!jl_is_cpointer_type(aty))
-        return emit_runtime_pointerref(argv, ctx);
+        return emit_runtime_pointerref(ctx, argv);
     jl_value_t *ety = jl_tparam0(aty);
     if (jl_is_typevar(ety))
-        return emit_runtime_pointerref(argv, ctx);
+        return emit_runtime_pointerref(ctx, argv);
     if (!jl_is_datatype(ety))
         ety = (jl_value_t*)jl_any_type;
 
-    Value *idx = emit_unbox(T_size, i, (jl_value_t*)jl_long_type);
-    Value *im1 = builder.CreateSub(idx, ConstantInt::get(T_size, 1));
+    Value *idx = emit_unbox(ctx, T_size, i, (jl_value_t*)jl_long_type);
+    Value *im1 = ctx.builder.CreateSub(idx, ConstantInt::get(T_size, 1));
 
     if (!jl_isbits(ety)) {
         if (ety == (jl_value_t*)jl_any_type) {
-            Value *thePtr = emit_unbox(T_pprjlvalue, e, e.typ);
+            Value *thePtr = emit_unbox(ctx, T_pprjlvalue, e, e.typ);
             return mark_julia_type(
-                    builder.CreateAlignedLoad(builder.CreateGEP(thePtr, im1), align_nb),
+                    ctx,
+                    ctx.builder.CreateAlignedLoad(ctx.builder.CreateGEP(thePtr, im1), align_nb),
                     true,
-                    ety, ctx);
+                    ety);
         }
         if (!jl_is_structtype(ety) || jl_is_array_type(ety) || !jl_is_leaf_type(ety)) {
-            emit_error("pointerref: invalid pointer type", ctx);
+            emit_error(ctx, "pointerref: invalid pointer type");
             return jl_cgval_t();
         }
         assert(jl_is_datatype(ety));
         uint64_t size = jl_datatype_size(ety);
         Value *strct = emit_allocobj(ctx, size,
-                                     literal_pointer_val((jl_value_t*)ety));
-        im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
+                                     literal_pointer_val(ctx, (jl_value_t*)ety));
+        im1 = ctx.builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, jl_datatype_align(ety))));
-        Value *thePtr = emit_unbox(T_pint8, e, e.typ);
-        thePtr = builder.CreateGEP(emit_bitcast(thePtr, T_pint8), im1);
-        builder.CreateMemCpy(emit_bitcast(strct, T_pint8), thePtr, size, 1);
-        return mark_julia_type(strct, true, ety, ctx);
+        Value *thePtr = emit_unbox(ctx, T_pint8, e, e.typ);
+        thePtr = ctx.builder.CreateGEP(emit_bitcast(ctx, thePtr, T_pint8), im1);
+        ctx.builder.CreateMemCpy(emit_bitcast(ctx, strct, T_pint8), thePtr, size, 1);
+        return mark_julia_type(ctx, strct, true, ety);
     }
 
     bool isboxed;
     Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
     assert(!isboxed);
-    Value *thePtr = emit_unbox(ptrty, e, e.typ);
-    return typed_load(thePtr, im1, ety, ctx, tbaa_data, true, align_nb);
+    Value *thePtr = emit_unbox(ctx, ptrty, e, e.typ);
+    return typed_load(ctx, thePtr, im1, ety, tbaa_data, true, align_nb);
 }
 
-static jl_cgval_t emit_runtime_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
+static jl_cgval_t emit_runtime_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
 {
-    return emit_runtime_call(pointerset, argv, 4, ctx);
+    return emit_runtime_call(ctx, pointerset, argv, 4);
 }
 
 // e[i] = x
-static jl_cgval_t emit_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
+static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
 {
     const jl_cgval_t &e = argv[0];
     const jl_cgval_t &x = argv[1];
@@ -640,106 +643,108 @@ static jl_cgval_t emit_pointerset(jl_cgval_t *argv, jl_codectx_t *ctx)
     const jl_cgval_t &align = argv[3];
 
     if (align.constant == NULL || !jl_is_long(align.constant))
-        return emit_runtime_pointerset(argv, ctx);
+        return emit_runtime_pointerset(ctx, argv);
     unsigned align_nb = jl_unbox_long(align.constant);
 
     if (i.typ != (jl_value_t*)jl_long_type)
-        return emit_runtime_pointerset(argv, ctx);
+        return emit_runtime_pointerset(ctx, argv);
     jl_value_t *aty = e.typ;
     if (!jl_is_cpointer_type(aty))
-        return emit_runtime_pointerset(argv, ctx);
+        return emit_runtime_pointerset(ctx, argv);
     jl_value_t *ety = jl_tparam0(aty);
     if (jl_is_typevar(ety))
-        return emit_runtime_pointerset(argv, ctx);
+        return emit_runtime_pointerset(ctx, argv);
     if (align.constant == NULL || !jl_is_long(align.constant))
-        return emit_runtime_pointerset(argv, ctx);
+        return emit_runtime_pointerset(ctx, argv);
     if (!jl_is_datatype(ety))
         ety = (jl_value_t*)jl_any_type;
-    emit_typecheck(x, ety, "pointerset: type mismatch in assign", ctx);
+    emit_typecheck(ctx, x, ety, "pointerset: type mismatch in assign");
 
-    Value *idx = emit_unbox(T_size, i, (jl_value_t*)jl_long_type);
-    Value *im1 = builder.CreateSub(idx, ConstantInt::get(T_size, 1));
+    Value *idx = emit_unbox(ctx, T_size, i, (jl_value_t*)jl_long_type);
+    Value *im1 = ctx.builder.CreateSub(idx, ConstantInt::get(T_size, 1));
 
     Value *thePtr;
     if (!jl_isbits(ety) && ety != (jl_value_t*)jl_any_type) {
         if (!jl_is_structtype(ety) || jl_is_array_type(ety) || !jl_is_leaf_type(ety)) {
-            emit_error("pointerset: invalid pointer type", ctx);
+            emit_error(ctx, "pointerset: invalid pointer type");
             return jl_cgval_t();
         }
-        thePtr = emit_unbox(T_pint8, e, e.typ);
+        thePtr = emit_unbox(ctx, T_pint8, e, e.typ);
         uint64_t size = jl_datatype_size(ety);
-        im1 = builder.CreateMul(im1, ConstantInt::get(T_size,
+        im1 = ctx.builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, jl_datatype_align(ety))));
-        builder.CreateMemCpy(builder.CreateGEP(thePtr, im1),
-                             data_pointer(x, ctx, T_pint8), size, align_nb);
+        ctx.builder.CreateMemCpy(ctx.builder.CreateGEP(thePtr, im1),
+                             data_pointer(ctx, x, T_pint8), size, align_nb);
     }
     else {
         bool isboxed;
         Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
         assert(!isboxed);
-        thePtr = emit_unbox(ptrty, e, e.typ);
+        thePtr = emit_unbox(ctx, ptrty, e, e.typ);
         if (ety == (jl_value_t*)jl_any_type) {
             // unsafe_store to Ptr{Any} is allowed to implicitly drop GC roots.
-            Instruction *store = builder.CreateAlignedStore(
-              emit_pointer_from_objref(boxed(x, ctx, false)),
-                builder.CreateGEP(thePtr, im1), align_nb);
+            Instruction *store = ctx.builder.CreateAlignedStore(
+              emit_pointer_from_objref(ctx, boxed(ctx, x, false)),
+                ctx.builder.CreateGEP(thePtr, im1), align_nb);
             tbaa_decorate(tbaa_data, store);
         } else {
-            typed_store(thePtr, im1, x, ety, ctx, tbaa_data, NULL, align_nb);
+            typed_store(ctx, thePtr, im1, x, ety, tbaa_data, NULL, align_nb);
         }
     }
-    return mark_julia_type(thePtr, false, aty, ctx);
+    return mark_julia_type(ctx, thePtr, false, aty);
 }
 
-static Value *emit_checked_srem_int(Value *x, Value *den, jl_codectx_t *ctx)
+static Value *emit_checked_srem_int(jl_codectx_t &ctx, Value *x, Value *den)
 {
     Type *t = den->getType();
-    raise_exception_unless(builder.CreateICmpNE(den, ConstantInt::get(t,0)),
-                           literal_pointer_val(jl_diverror_exception), ctx);
-    BasicBlock *m1BB = BasicBlock::Create(jl_LLVMContext,"minus1",ctx->f);
-    BasicBlock *okBB = BasicBlock::Create(jl_LLVMContext,"oksrem",ctx->f);
-    BasicBlock *cont = BasicBlock::Create(jl_LLVMContext,"after_srem",ctx->f);
+    raise_exception_unless(ctx,
+            ctx.builder.CreateICmpNE(den, ConstantInt::get(t, 0)),
+            literal_pointer_val(ctx, jl_diverror_exception));
+    BasicBlock *m1BB = BasicBlock::Create(jl_LLVMContext, "minus1", ctx.f);
+    BasicBlock *okBB = BasicBlock::Create(jl_LLVMContext, "oksrem", ctx.f);
+    BasicBlock *cont = BasicBlock::Create(jl_LLVMContext, "after_srem", ctx.f);
     PHINode *ret = PHINode::Create(t, 2);
-    builder.CreateCondBr(builder.CreateICmpEQ(den,ConstantInt::get(t,-1,true)),
+    ctx.builder.CreateCondBr(ctx.builder.CreateICmpEQ(den ,ConstantInt::get(t, -1, true)),
                          m1BB, okBB);
-    builder.SetInsertPoint(m1BB);
-    builder.CreateBr(cont);
-    builder.SetInsertPoint(okBB);
-    Value *sremval = builder.CreateSRem(x, den);
-    builder.CreateBr(cont);
-    builder.SetInsertPoint(cont);
+    ctx.builder.SetInsertPoint(m1BB);
+    ctx.builder.CreateBr(cont);
+    ctx.builder.SetInsertPoint(okBB);
+    Value *sremval = ctx.builder.CreateSRem(x, den);
+    ctx.builder.CreateBr(cont);
+    ctx.builder.SetInsertPoint(cont);
     ret->addIncoming(// rem(typemin, -1) is undefined
-                     ConstantInt::get(t,0), m1BB);
+                     ConstantInt::get(t, 0), m1BB);
     ret->addIncoming(sremval, okBB);
-    builder.Insert(ret);
+    ctx.builder.Insert(ret);
     return ret;
 }
 
-// Temporarily switch the builder to fast-math mode if requested
+// Temporarily switch the ctx.builder to fast-math mode if requested
 struct math_builder {
+    IRBuilder<> &ctxbuilder;
     FastMathFlags old_fmf;
-    math_builder(jl_codectx_t *ctx, bool always_fast = false):
-        old_fmf(builder.getFastMathFlags())
+    math_builder(jl_codectx_t &ctx, bool always_fast = false)
+      : ctxbuilder(ctx.builder),
+        old_fmf(ctxbuilder.getFastMathFlags())
     {
         if (jl_options.fast_math != JL_OPTIONS_FAST_MATH_OFF &&
             (always_fast ||
              jl_options.fast_math == JL_OPTIONS_FAST_MATH_ON)) {
             FastMathFlags fmf;
             fmf.setUnsafeAlgebra();
-            builder.setFastMathFlags(fmf);
+            ctxbuilder.setFastMathFlags(fmf);
         }
     }
-    IRBuilder<>& operator()() const { return builder; }
+    IRBuilder<>& operator()() const { return ctxbuilder; }
     ~math_builder() {
-        builder.setFastMathFlags(old_fmf);
+        ctxbuilder.setFastMathFlags(old_fmf);
     }
 };
 
-static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t nargs,
-                                     jl_codectx_t *ctx, jl_datatype_t **newtyp, jl_value_t *xtyp);
+static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **argvalues, size_t nargs,
+                                     jl_datatype_t **newtyp, jl_value_t *xtyp);
 
-static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
-                                 jl_codectx_t *ctx)
+static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **args, size_t nargs)
 {
     assert(f < num_intrinsics);
     if (f == cglobal && nargs == 1)
@@ -750,52 +755,52 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     }
 
     if (f == llvmcall)
-        return emit_llvmcall(args, nargs, ctx);
+        return emit_llvmcall(ctx, args, nargs);
     if (f == cglobal_auto || f == cglobal)
-        return emit_cglobal(args, nargs, ctx);
+        return emit_cglobal(ctx, args, nargs);
 
     jl_cgval_t *argv = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nargs);
     for (size_t i = 0; i < nargs; ++i) {
-        argv[i] = emit_expr(args[i + 1], ctx);
+        argv[i] = emit_expr(ctx, args[i + 1]);
     }
 
     // this forces everything to use runtime-intrinsics (e.g. for testing)
-    // return emit_runtime_call(f, argv, nargs, ctx);
+    // return emit_runtime_call(ctx, f, argv, nargs);
 
     switch (f) {
     case arraylen:
-        return mark_julia_type(emit_arraylen(argv[0], args[1], ctx), false, jl_long_type, ctx);
+        return mark_julia_type(ctx, emit_arraylen(ctx, argv[0], args[1]), false, jl_long_type);
     case pointerref:
-        return emit_pointerref(argv, ctx);
+        return emit_pointerref(ctx, argv);
     case pointerset:
-        return emit_pointerset(argv, ctx);
+        return emit_pointerset(ctx, argv);
     case bitcast:
-        return generic_bitcast(argv, ctx);
+        return generic_bitcast(ctx, argv);
     case trunc_int:
-        return generic_cast(f, generic_trunc, argv, ctx, true, true);
+        return generic_cast(ctx, f, generic_trunc, argv, true, true);
     case checked_trunc_uint:
-        return generic_cast(f, generic_trunc_uchecked, argv, ctx, true, true);
+        return generic_cast(ctx, f, generic_trunc_uchecked, argv, true, true);
     case checked_trunc_sint:
-        return generic_cast(f, generic_trunc_schecked, argv, ctx, true, true);
+        return generic_cast(ctx, f, generic_trunc_schecked, argv, true, true);
     case sext_int:
-        return generic_cast(f, generic_sext, argv, ctx, true, true);
+        return generic_cast(ctx, f, generic_sext, argv, true, true);
     case zext_int:
-        return generic_cast(f, generic_zext, argv, ctx, true, true);
+        return generic_cast(ctx, f, generic_zext, argv, true, true);
     case uitofp:
-        return generic_cast(f, generic_uitofp, argv, ctx, false, true);
+        return generic_cast(ctx, f, generic_uitofp, argv, false, true);
     case sitofp:
-        return generic_cast(f, generic_sitofp, argv, ctx, false, true);
+        return generic_cast(ctx, f, generic_sitofp, argv, false, true);
     case fptoui:
-        return generic_cast(f, generic_fptoui, argv, ctx, true, false);
+        return generic_cast(ctx, f, generic_fptoui, argv, true, false);
     case fptosi:
-        return generic_cast(f, generic_fptosi, argv, ctx, true, false);
+        return generic_cast(ctx, f, generic_fptosi, argv, true, false);
     case fptrunc:
-        return generic_cast(f, generic_fptrunc, argv, ctx, false, false);
+        return generic_cast(ctx, f, generic_fptrunc, argv, false, false);
     case fpext:
-        return generic_cast(f, generic_fpext, argv, ctx, false, false);
+        return generic_cast(ctx, f, generic_fpext, argv, false, false);
 
     case select_value: {
-        Value *isfalse = emit_condition(argv[0], "select_value", ctx); // emit the first argument
+        Value *isfalse = emit_condition(ctx, argv[0], "select_value"); // emit the first argument
         // emit X and Y arguments
         const jl_cgval_t &x = argv[1];
         const jl_cgval_t &y = argv[2];
@@ -817,31 +822,31 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         if (!isboxed) {
             if (type_is_ghost(llt1))
                 return x;
-            ifelse_result = builder.CreateSelect(isfalse,
-                    emit_unbox(llt1, y, t1),
-                    emit_unbox(llt1, x, t1));
+            ifelse_result = ctx.builder.CreateSelect(isfalse,
+                    emit_unbox(ctx, llt1, y, t1),
+                    emit_unbox(ctx, llt1, x, t1));
         }
         else {
-            ifelse_result = builder.CreateSelect(isfalse,
-                    boxed(y, ctx),
-                    boxed(x, ctx));
+            ifelse_result = ctx.builder.CreateSelect(isfalse,
+                    boxed(ctx, y),
+                    boxed(ctx, x));
         }
         jl_value_t *jt = (t1 == t2 ? t1 : (jl_value_t*)jl_any_type);
-        return mark_julia_type(ifelse_result, isboxed, jt, ctx);
+        return mark_julia_type(ctx, ifelse_result, isboxed, jt);
     }
 
     case not_int: {
         const jl_cgval_t &x = argv[0];
         if (!jl_is_primitivetype(x.typ))
-            return emit_runtime_call(f, argv, nargs, ctx);
+            return emit_runtime_call(ctx, f, argv, nargs);
         Type *xt = INTT(bitstype_to_llvm(x.typ));
-        Value *from = emit_unbox(xt, x, x.typ);
+        Value *from = emit_unbox(ctx, xt, x, x.typ);
         Value *ans;
         if (x.typ == (jl_value_t*)jl_bool_type)
-            ans = builder.CreateXor(from, ConstantInt::get(T_int8, 1, true));
+            ans = ctx.builder.CreateXor(from, ConstantInt::get(T_int8, 1, true));
         else
-            ans = builder.CreateXor(from, ConstantInt::get(xt, -1, true));
-        return mark_julia_type(ans, false, x.typ, ctx);
+            ans = ctx.builder.CreateXor(from, ConstantInt::get(xt, -1, true));
+        return mark_julia_type(ctx, ans, false, x.typ);
     }
 
     default: {
@@ -850,27 +855,27 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 
         // verify argument types
         if (!jl_is_primitivetype(xinfo.typ))
-            return emit_runtime_call(f, argv, nargs, ctx);
+            return emit_runtime_call(ctx, f, argv, nargs);
         Type *xtyp = bitstype_to_llvm(xinfo.typ);
         if (float_func[f])
             xtyp = FLOATT(xtyp);
         else
             xtyp = INTT(xtyp);
         if (!xtyp)
-            return emit_runtime_call(f, argv, nargs, ctx);
+            return emit_runtime_call(ctx, f, argv, nargs);
 
         Type **argt = (Type**)alloca(sizeof(Type*) * nargs);
         argt[0] = xtyp;
 
         if (f == shl_int || f == lshr_int || f == ashr_int) {
             if (!jl_is_primitivetype(argv[1].typ))
-                return emit_runtime_call(f, argv, nargs, ctx);
+                return emit_runtime_call(ctx, f, argv, nargs);
             argt[1] = INTT(bitstype_to_llvm(argv[1].typ));
         }
         else {
             for (size_t i = 1; i < nargs; ++i) {
                 if (xinfo.typ != argv[i].typ)
-                    return emit_runtime_call(f, argv, nargs, ctx);
+                    return emit_runtime_call(ctx, f, argv, nargs);
                 argt[i] = xtyp;
             }
         }
@@ -878,22 +883,22 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         // unbox the arguments
         Value **argvalues = (Value**)alloca(sizeof(Value*) * nargs);
         for (size_t i = 0; i < nargs; ++i) {
-            argvalues[i] = emit_unbox(argt[i], argv[i], argv[i].typ);
+            argvalues[i] = emit_unbox(ctx, argt[i], argv[i], argv[i].typ);
         }
 
         // call the intrinsic
         jl_value_t *newtyp = NULL;
-        Value *r = emit_untyped_intrinsic(f, argvalues, nargs, ctx, (jl_datatype_t**)&newtyp, xinfo.typ);
+        Value *r = emit_untyped_intrinsic(ctx, f, argvalues, nargs, (jl_datatype_t**)&newtyp, xinfo.typ);
         if (r->getType() == T_int1)
-            r = builder.CreateZExt(r, T_int8);
-        return mark_julia_type(r, false, newtyp ? newtyp : xinfo.typ, ctx);
+            r = ctx.builder.CreateZExt(r, T_int8);
+        return mark_julia_type(ctx, r, false, newtyp ? newtyp : xinfo.typ);
     }
     }
     assert(0 && "unreachable");
 }
 
-static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t nargs,
-                                     jl_codectx_t *ctx, jl_datatype_t **newtyp, jl_value_t *xtyp)
+static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **argvalues, size_t nargs,
+                                     jl_datatype_t **newtyp, jl_value_t *xtyp)
 {
     Value *x = nargs > 0 ? argvalues[0] : NULL;
     Value *y = nargs > 1 ? argvalues[1] : NULL;
@@ -902,14 +907,14 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t narg
 
     switch (f) {
     case neg_int:
-        return builder.CreateNeg(x);
-    case add_int: return builder.CreateAdd(x, y);
-    case sub_int: return builder.CreateSub(x, y);
-    case mul_int: return builder.CreateMul(x, y);
-    case sdiv_int: return builder.CreateSDiv(x, y);
-    case udiv_int: return builder.CreateUDiv(x, y);
-    case srem_int: return builder.CreateSRem(x, y);
-    case urem_int: return builder.CreateURem(x, y);
+        return ctx.builder.CreateNeg(x);
+    case add_int: return ctx.builder.CreateAdd(x, y);
+    case sub_int: return ctx.builder.CreateSub(x, y);
+    case mul_int: return ctx.builder.CreateMul(x, y);
+    case sdiv_int: return ctx.builder.CreateSDiv(x, y);
+    case udiv_int: return ctx.builder.CreateUDiv(x, y);
+    case srem_int: return ctx.builder.CreateSRem(x, y);
+    case urem_int: return ctx.builder.CreateURem(x, y);
 
 // Implements IEEE negate. See issue #7868
     case neg_float: return math_builder(ctx)().CreateFSub(ConstantFP::get(t, -0.0), x);
@@ -928,13 +933,13 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t narg
         assert(y->getType() == x->getType());
         assert(z->getType() == y->getType());
         Value *fmaintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::fma, makeArrayRef(t));
-        return builder.CreateCall(fmaintr, {x, y, z});
+        return ctx.builder.CreateCall(fmaintr, {x, y, z});
     }
     case muladd_float: {
         assert(y->getType() == x->getType());
         assert(z->getType() == y->getType());
         Value *muladdintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::fmuladd, makeArrayRef(t));
-        return builder.CreateCall(muladdintr, {x, y, z});
+        return ctx.builder.CreateCall(muladdintr, {x, y, z});
     }
 
     case checked_sadd_int:
@@ -957,10 +962,10 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t narg
                  Intrinsic::smul_with_overflow :
                  Intrinsic::umul_with_overflow)))));
         Value *intr = Intrinsic::getDeclaration(jl_Module, intr_id, makeArrayRef(t));
-        Value *res = builder.CreateCall(intr, {x, y});
-        Value *val = builder.CreateExtractValue(res, ArrayRef<unsigned>(0));
-        Value *obit = builder.CreateExtractValue(res, ArrayRef<unsigned>(1));
-        Value *obyte = builder.CreateZExt(obit, T_int8);
+        Value *res = ctx.builder.CreateCall(intr, {x, y});
+        Value *val = ctx.builder.CreateExtractValue(res, ArrayRef<unsigned>(0));
+        Value *obit = ctx.builder.CreateExtractValue(res, ArrayRef<unsigned>(1));
+        Value *obyte = ctx.builder.CreateZExt(obit, T_int8);
 
         jl_value_t *params[2];
         params[0] = xtyp;
@@ -970,51 +975,53 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t narg
 
         Value *tupval;
         tupval = UndefValue::get(julia_type_to_llvm((jl_value_t*)tuptyp));
-        tupval = builder.CreateInsertValue(tupval, val, ArrayRef<unsigned>(0));
-        tupval = builder.CreateInsertValue(tupval, obyte, ArrayRef<unsigned>(1));
+        tupval = ctx.builder.CreateInsertValue(tupval, val, ArrayRef<unsigned>(0));
+        tupval = ctx.builder.CreateInsertValue(tupval, obyte, ArrayRef<unsigned>(1));
         return tupval;
     }
 
     case checked_sdiv_int: {
-        Value *typemin = builder.CreateShl(ConstantInt::get(t, 1), t->getPrimitiveSizeInBits() - 1);
-        raise_exception_unless(
-                builder.CreateAnd(
-                    builder.CreateICmpNE(y, ConstantInt::get(t, 0)),
-                    builder.CreateOr(
-                        builder.CreateICmpNE(y, ConstantInt::get(t, -1, true)),
-                        builder.CreateICmpNE(x, typemin))),
-                literal_pointer_val(jl_diverror_exception), ctx);
+        Value *typemin = ctx.builder.CreateShl(ConstantInt::get(t, 1), t->getPrimitiveSizeInBits() - 1);
+        raise_exception_unless(ctx,
+                ctx.builder.CreateAnd(
+                    ctx.builder.CreateICmpNE(y, ConstantInt::get(t, 0)),
+                    ctx.builder.CreateOr(
+                        ctx.builder.CreateICmpNE(y, ConstantInt::get(t, -1, true)),
+                        ctx.builder.CreateICmpNE(x, typemin))),
+                literal_pointer_val(ctx, jl_diverror_exception));
 
-        return builder.CreateSDiv(x, y);
+        return ctx.builder.CreateSDiv(x, y);
     }
     case checked_udiv_int:
-        raise_exception_unless(builder.CreateICmpNE(y, ConstantInt::get(t, 0)),
-                               literal_pointer_val(jl_diverror_exception), ctx);
-        return builder.CreateUDiv(x, y);
+        raise_exception_unless(ctx,
+                ctx.builder.CreateICmpNE(y, ConstantInt::get(t, 0)),
+                literal_pointer_val(ctx, jl_diverror_exception));
+        return ctx.builder.CreateUDiv(x, y);
 
     case checked_srem_int:
-        return emit_checked_srem_int(x, y, ctx);
+        return emit_checked_srem_int(ctx, x, y);
 
     case checked_urem_int:
-        raise_exception_unless(builder.CreateICmpNE(y, ConstantInt::get(t, 0)),
-                               literal_pointer_val(jl_diverror_exception), ctx);
-        return builder.CreateURem(x, y);
+        raise_exception_unless(ctx,
+                ctx.builder.CreateICmpNE(y, ConstantInt::get(t, 0)),
+                literal_pointer_val(ctx, jl_diverror_exception));
+        return ctx.builder.CreateURem(x, y);
 
     case check_top_bit:
         // raise InexactError if argument's top bit is set
-        raise_exception_if(
-                builder.CreateTrunc(
-                    builder.CreateLShr(x, ConstantInt::get(t, t->getPrimitiveSizeInBits() - 1)),
+        raise_exception_if(ctx,
+                ctx.builder.CreateTrunc(
+                    ctx.builder.CreateLShr(x, ConstantInt::get(t, t->getPrimitiveSizeInBits() - 1)),
                     T_int1),
-                literal_pointer_val(jl_inexact_exception), ctx);
+                literal_pointer_val(ctx, jl_inexact_exception));
         return x;
 
-    case eq_int:  *newtyp = jl_bool_type; return builder.CreateICmpEQ(x, y);
-    case ne_int:  *newtyp = jl_bool_type; return builder.CreateICmpNE(x, y);
-    case slt_int: *newtyp = jl_bool_type; return builder.CreateICmpSLT(x, y);
-    case ult_int: *newtyp = jl_bool_type; return builder.CreateICmpULT(x, y);
-    case sle_int: *newtyp = jl_bool_type; return builder.CreateICmpSLE(x, y);
-    case ule_int: *newtyp = jl_bool_type; return builder.CreateICmpULE(x, y);
+    case eq_int:  *newtyp = jl_bool_type; return ctx.builder.CreateICmpEQ(x, y);
+    case ne_int:  *newtyp = jl_bool_type; return ctx.builder.CreateICmpNE(x, y);
+    case slt_int: *newtyp = jl_bool_type; return ctx.builder.CreateICmpSLT(x, y);
+    case ult_int: *newtyp = jl_bool_type; return ctx.builder.CreateICmpULT(x, y);
+    case sle_int: *newtyp = jl_bool_type; return ctx.builder.CreateICmpSLE(x, y);
+    case ule_int: *newtyp = jl_bool_type; return ctx.builder.CreateICmpULE(x, y);
 
     case eq_float: *newtyp = jl_bool_type; return math_builder(ctx)().CreateFCmpOEQ(x, y);
     case ne_float: *newtyp = jl_bool_type; return math_builder(ctx)().CreateFCmpUNE(x, y);
@@ -1029,88 +1036,88 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t narg
     case fpiseq: {
         *newtyp = jl_bool_type;
         Type *it = INTT(t);
-        Value *xi = builder.CreateBitCast(x, it);
-        Value *yi = builder.CreateBitCast(y, it);
-        return builder.CreateOr(builder.CreateAnd(builder.CreateFCmpUNO(x, x),
-                                                  builder.CreateFCmpUNO(y, y)),
-                                builder.CreateICmpEQ(xi, yi));
+        Value *xi = ctx.builder.CreateBitCast(x, it);
+        Value *yi = ctx.builder.CreateBitCast(y, it);
+        return ctx.builder.CreateOr(ctx.builder.CreateAnd(ctx.builder.CreateFCmpUNO(x, x),
+                                                  ctx.builder.CreateFCmpUNO(y, y)),
+                                ctx.builder.CreateICmpEQ(xi, yi));
     }
 
     case fpislt: {
         *newtyp = jl_bool_type;
         Type *it = INTT(t);
-        Value *xi = builder.CreateBitCast(x, it);
-        Value *yi = builder.CreateBitCast(y, it);
-        return builder.CreateOr(
-            builder.CreateAnd(
-                builder.CreateFCmpORD(x, x),
-                builder.CreateFCmpUNO(y, y)),
-            builder.CreateAnd(
-                builder.CreateFCmpORD(x, y),
-                builder.CreateOr(
-                    builder.CreateAnd(
-                        builder.CreateICmpSGE(xi, ConstantInt::get(it, 0)),
-                        builder.CreateICmpSLT(xi, yi)),
-                    builder.CreateAnd(
-                        builder.CreateICmpSLT(xi, ConstantInt::get(it, 0)),
-                        builder.CreateICmpUGT(xi, yi)))));
+        Value *xi = ctx.builder.CreateBitCast(x, it);
+        Value *yi = ctx.builder.CreateBitCast(y, it);
+        return ctx.builder.CreateOr(
+            ctx.builder.CreateAnd(
+                ctx.builder.CreateFCmpORD(x, x),
+                ctx.builder.CreateFCmpUNO(y, y)),
+            ctx.builder.CreateAnd(
+                ctx.builder.CreateFCmpORD(x, y),
+                ctx.builder.CreateOr(
+                    ctx.builder.CreateAnd(
+                        ctx.builder.CreateICmpSGE(xi, ConstantInt::get(it, 0)),
+                        ctx.builder.CreateICmpSLT(xi, yi)),
+                    ctx.builder.CreateAnd(
+                        ctx.builder.CreateICmpSLT(xi, ConstantInt::get(it, 0)),
+                        ctx.builder.CreateICmpUGT(xi, yi)))));
     }
 
-    case and_int: return builder.CreateAnd(x, y);
-    case or_int:  return builder.CreateOr(x, y);
-    case xor_int: return builder.CreateXor(x, y);
+    case and_int: return ctx.builder.CreateAnd(x, y);
+    case or_int:  return ctx.builder.CreateOr(x, y);
+    case xor_int: return ctx.builder.CreateXor(x, y);
 
     case shl_int:
-        return builder.CreateSelect(
-                builder.CreateICmpUGE(y, ConstantInt::get(y->getType(),
+        return ctx.builder.CreateSelect(
+                ctx.builder.CreateICmpUGE(y, ConstantInt::get(y->getType(),
                                                           t->getPrimitiveSizeInBits())),
                 ConstantInt::get(t, 0),
-                builder.CreateShl(x, uint_cnvt(t, y)));
+                ctx.builder.CreateShl(x, uint_cnvt(ctx, t, y)));
     case lshr_int:
-        return builder.CreateSelect(
-                builder.CreateICmpUGE(y, ConstantInt::get(y->getType(),
+        return ctx.builder.CreateSelect(
+                ctx.builder.CreateICmpUGE(y, ConstantInt::get(y->getType(),
                                                           t->getPrimitiveSizeInBits())),
                 ConstantInt::get(t, 0),
-                builder.CreateLShr(x, uint_cnvt(t, y)));
+                ctx.builder.CreateLShr(x, uint_cnvt(ctx, t, y)));
     case ashr_int:
-        return builder.CreateSelect(
-                builder.CreateICmpUGE(y, ConstantInt::get(y->getType(),
+        return ctx.builder.CreateSelect(
+                ctx.builder.CreateICmpUGE(y, ConstantInt::get(y->getType(),
                                                           t->getPrimitiveSizeInBits())),
-                builder.CreateAShr(x, ConstantInt::get(t, t->getPrimitiveSizeInBits() - 1)),
-                builder.CreateAShr(x, uint_cnvt(t, y)));
+                ctx.builder.CreateAShr(x, ConstantInt::get(t, t->getPrimitiveSizeInBits() - 1)),
+                ctx.builder.CreateAShr(x, uint_cnvt(ctx, t, y)));
 
     case bswap_int: {
         Value *bswapintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::bswap, makeArrayRef(t));
-        return builder.CreateCall(bswapintr, x);
+        return ctx.builder.CreateCall(bswapintr, x);
     }
     case ctpop_int: {
         Value *ctpopintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::ctpop, makeArrayRef(t));
-        return builder.CreateCall(ctpopintr, x);
+        return ctx.builder.CreateCall(ctpopintr, x);
     }
     case ctlz_int: {
         Value *ctlz = Intrinsic::getDeclaration(jl_Module, Intrinsic::ctlz, makeArrayRef(t));
         y = ConstantInt::get(T_int1, 0);
-        return builder.CreateCall(ctlz, {x, y});
+        return ctx.builder.CreateCall(ctlz, {x, y});
     }
     case cttz_int: {
         Value *cttz = Intrinsic::getDeclaration(jl_Module, Intrinsic::cttz, makeArrayRef(t));
         y = ConstantInt::get(T_int1, 0);
-        return builder.CreateCall(cttz, {x, y});
+        return ctx.builder.CreateCall(cttz, {x, y});
     }
 
     case abs_float: {
         Value *absintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::fabs, makeArrayRef(t));
-        return builder.CreateCall(absintr, x);
+        return ctx.builder.CreateCall(absintr, x);
     }
     case copysign_float: {
-        Value *bits = builder.CreateBitCast(x, t);
-        Value *sbits = builder.CreateBitCast(y, t);
+        Value *bits = ctx.builder.CreateBitCast(x, t);
+        Value *sbits = ctx.builder.CreateBitCast(y, t);
         unsigned nb = cast<IntegerType>(t)->getBitWidth();
         APInt notsignbit = APInt::getSignedMaxValue(nb);
         APInt signbit0(nb, 0); signbit0.setBit(nb - 1);
-        return builder.CreateOr(
-                    builder.CreateAnd(bits, ConstantInt::get(t, notsignbit)),
-                    builder.CreateAnd(sbits, ConstantInt::get(t, signbit0)));
+        return ctx.builder.CreateOr(
+                    ctx.builder.CreateAnd(bits, ConstantInt::get(t, notsignbit)),
+                    ctx.builder.CreateAnd(sbits, ConstantInt::get(t, signbit0)));
     }
     case flipsign_int: {
         ConstantInt *cx = dyn_cast<ConstantInt>(x);
@@ -1122,34 +1129,35 @@ static Value *emit_untyped_intrinsic(intrinsic f, Value **argvalues, size_t narg
         }
         if (cy) {
             APInt iy = cy->getValue();
-            return iy.isNonNegative() ? x : builder.CreateSub(ConstantInt::get(t, 0), x);
+            return iy.isNonNegative() ? x : ctx.builder.CreateSub(ConstantInt::get(t, 0), x);
         }
-        Value *tmp = builder.CreateAShr(y, ConstantInt::get(t, cast<IntegerType>(t)->getBitWidth() - 1));
-        return builder.CreateXor(builder.CreateAdd(x, tmp), tmp);
+        Value *tmp = ctx.builder.CreateAShr(y, ConstantInt::get(t, cast<IntegerType>(t)->getBitWidth() - 1));
+        return ctx.builder.CreateXor(ctx.builder.CreateAdd(x, tmp), tmp);
     }
     case ceil_llvm: {
         Value *ceilintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::ceil, makeArrayRef(t));
-        return builder.CreateCall(ceilintr, x);
+        return ctx.builder.CreateCall(ceilintr, x);
     }
     case floor_llvm: {
         Value *floorintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::floor, makeArrayRef(t));
-        return builder.CreateCall(floorintr, x);
+        return ctx.builder.CreateCall(floorintr, x);
     }
     case trunc_llvm: {
         Value *truncintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::trunc, makeArrayRef(t));
-        return builder.CreateCall(truncintr, x);
+        return ctx.builder.CreateCall(truncintr, x);
     }
     case rint_llvm: {
         Value *rintintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::rint, makeArrayRef(t));
-        return builder.CreateCall(rintintr, x);
+        return ctx.builder.CreateCall(rintintr, x);
     }
     case sqrt_llvm:
-        raise_exception_unless(builder.CreateFCmpUGE(x, ConstantFP::get(t, 0.0)),
-                               literal_pointer_val(jl_domain_exception), ctx);
+        raise_exception_unless(ctx,
+                ctx.builder.CreateFCmpUGE(x, ConstantFP::get(t, 0.0)),
+                literal_pointer_val(ctx, jl_domain_exception));
         // fall-through
     case sqrt_llvm_fast: {
         Value *sqrtintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::sqrt, makeArrayRef(t));
-        return builder.CreateCall(sqrtintr, x);
+        return ctx.builder.CreateCall(sqrtintr, x);
     }
 
     default:

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1189,7 +1189,7 @@ GlobalVariable *jl_get_global_for(const char *cname, void *addr, Module *M)
     // first see if there already is a GlobalVariable for this address
     it = jl_value_to_llvm.find(addr);
     if (it != jl_value_to_llvm.end())
-        return prepare_global((llvm::GlobalVariable*)it->second.gv, M);
+        return prepare_global_in(M, (llvm::GlobalVariable*)it->second.gv);
 
     std::stringstream gvname;
     gvname << cname << globalUnique++;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -101,7 +101,7 @@ static inline Function *function_proto(Function *F, Module *M = NULL)
     return NewF;
 }
 
-static inline GlobalVariable *prepare_global(GlobalVariable *G, Module *M)
+static inline GlobalVariable *prepare_global_in(Module *M, GlobalVariable *G)
 {
     if (G->getParent() == M)
         return G;


### PR DESCRIPTION
No functional change intended here (other than making the ctx argument usage and naming consistent). This just does the tedious work of passing jl_codectx_t to (almost) every function where it is needed. But since this ends up touching almost everything in codegen, I would like to merge it fairly quickly (before starting on removing the next bits of global state).