### PR TITLE
Handle 32 bit architecture when creating float ranges (#22613)

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1318,7 +1318,14 @@ bswap
 
 The largest integer losslessly representable by the given floating-point DataType `T`.
 """
-maxintfloat
+maxintfloat(T)
+
+"""
+    maxintfloat(T, S)
+
+The largest integer losslessly representable by the given floating-point DataType `T` that also does not exceed the maximum integer representable by the integer data type T.
+"""
+maxintfloat(S, T)
 
 """
     delete!(collection, key)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1323,9 +1323,10 @@ maxintfloat(T)
 """
     maxintfloat(T, S)
 
-The largest integer losslessly representable by the given floating-point DataType `T` that also does not exceed the maximum integer representable by the integer data type T.
+The largest integer losslessly representable by the given floating-point DataType `T` that
+also does not exceed the maximum integer representable by the integer DataType `S`.
 """
-maxintfloat(S, T)
+maxintfloat(T, S)
 
 """
     delete!(collection, key)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -20,7 +20,7 @@ maxintfloat(::Type{Float64}) = 9007199254740992.
 maxintfloat(::Type{Float32}) = Float32(16777216.)
 maxintfloat(::Type{Float16}) = Float16(2048f0)
 maxintfloat(x::T) where {T<:AbstractFloat} = maxintfloat(T)
-maxintfloat(::Type{S}, ::Type{T}) where {S<:AbstractFloat, T<:Integer} = (m = maxintfloat(S); Int === Int32 ? min(m, S(typemax(T))) : m)
+maxintfloat(::Type{S}, ::Type{T}) where {S<:AbstractFloat, T<:Integer} = min(maxintfloat(S), S(typemax(T)))
 maxintfloat() = maxintfloat(Float64)
 
 isinteger(x::AbstractFloat) = (x - trunc(x) == 0)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -20,7 +20,7 @@ maxintfloat(::Type{Float64}) = 9007199254740992.
 maxintfloat(::Type{Float32}) = Float32(16777216.)
 maxintfloat(::Type{Float16}) = Float16(2048f0)
 maxintfloat(x::T) where {T<:AbstractFloat} = maxintfloat(T)
-maxintfloat(::Type{S}, ::Type{T}) where S <: AbstractFloat where T <: Integer = (m = maxintfloat(S); Int === Int32 ? min(m, S(typemax(T))) : m)
+maxintfloat(::Type{S}, ::Type{T}) where {S<:AbstractFloat, T<:Integer} = (m = maxintfloat(S); Int === Int32 ? min(m, S(typemax(T))) : m)
 maxintfloat() = maxintfloat(Float64)
 
 isinteger(x::AbstractFloat) = (x - trunc(x) == 0)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -20,6 +20,7 @@ maxintfloat(::Type{Float64}) = 9007199254740992.
 maxintfloat(::Type{Float32}) = Float32(16777216.)
 maxintfloat(::Type{Float16}) = Float16(2048f0)
 maxintfloat(x::T) where {T<:AbstractFloat} = maxintfloat(T)
+maxintfloat(::Type{S}, ::Type{T}) where S <: AbstractFloat where T <: Integer = (m = maxintfloat(S); Int === Int32 ? min(m, S(typemax(T))) : m)
 maxintfloat() = maxintfloat(Float64)
 
 isinteger(x::AbstractFloat) = (x - trunc(x) == 0)

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -167,7 +167,7 @@ function range(a::T, st::T, len::Integer) where T<:Union{Float16,Float32,Float64
     if start_d != 0 && step_d != 0 &&
             T(start_n/start_d) == a && T(step_n/step_d) == st
         den = lcm(start_d, step_d)
-        m = maxintfloat(T ,Int)
+        m = maxintfloat(T, Int)
         if abs(den*a) <= m && abs(den*st) <= m &&
                 rem(den, start_d) == 0 && rem(den, step_d) == 0
             start_n = round(Int, den*a)

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -106,10 +106,7 @@ end
 
 function floatrange(a::AbstractFloat, st::AbstractFloat, len::Real, divisor::AbstractFloat)
     T = promote_type(typeof(a), typeof(st), typeof(divisor))
-    m = maxintfloat(T)
-    if Int == Int32
-        m = min(m, 2147483647.)
-    end
+    m = maxintfloat(T, Int)
     if abs(a) <= m && abs(st) <= m && abs(divisor) <= m
         ia, ist, idivisor = round(Int, a), round(Int, st), round(Int, divisor)
         if ia == a && ist == st && idivisor == divisor
@@ -134,10 +131,7 @@ function colon(start::T, step::T, stop::T) where T<:Union{Float16,Float32,Float6
         if start_d != 0 && stop_d != 0 &&
                 T(start_n/start_d) == start && T(stop_n/stop_d) == stop
             den = lcm(start_d, step_d) # use same denominator for start and step
-            m = maxintfloat(T)
-            if Int == Int32
-                m = min(m, 2147483647.)
-            end
+            m = maxintfloat(T, Int)
             if den != 0 && abs(start*den) <= m && abs(step*den) <= m &&  # will round succeed?
                     rem(den, start_d) == 0 && rem(den, step_d) == 0      # check lcm overflow
                 start_n = round(Int, start*den)
@@ -173,10 +167,7 @@ function range(a::T, st::T, len::Integer) where T<:Union{Float16,Float32,Float64
     if start_d != 0 && step_d != 0 &&
             T(start_n/start_d) == a && T(step_n/step_d) == st
         den = lcm(start_d, step_d)
-        m = maxintfloat(T)
-        if Int == Int32
-            m = min(m, 2147483647.)
-        end
+        m = maxintfloat(T ,Int)
         if abs(den*a) <= m && abs(den*st) <= m &&
                 rem(den, start_d) == 0 && rem(den, step_d) == 0
             start_n = round(Int, den*a)
@@ -266,10 +257,7 @@ function _convertSRL(::Type{StepRangeLen{T,R,S}}, r::Range{U}) where {T,R,S,U}
     if start_d != 0 && step_d != 0 &&
             U(start_n/start_d) == f && U(step_n/step_d) == s
         den = lcm(start_d, step_d)
-        m = maxintfloat(T)
-        if Int == Int32
-            m = min(m, 2147483647.)
-        end
+        m = maxintfloat(T, Int)
         if den != 0 && abs(f*den) <= m && abs(s*den) <= m &&
                 rem(den, start_d) == 0 && rem(den, step_d) == 0
             start_n = round(Int, f*den)
@@ -338,10 +326,7 @@ function linspace(start::T, stop::T, len::Integer) where T<:Union{Float16,Float3
     stop_n, stop_d = rat(stop)
     if start_d != 0 && stop_d != 0
         den = lcm(start_d, stop_d)
-        m = maxintfloat(T)
-        if Int == Int32
-            m = min(m, 2147483647.)
-        end
+        m = maxintfloat(T, Int)
         if den != 0 && abs(den*start) <= m && abs(den*stop) <= m
             start_n = round(Int, den*start)
             stop_n = round(Int, den*stop)

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -107,6 +107,9 @@ end
 function floatrange(a::AbstractFloat, st::AbstractFloat, len::Real, divisor::AbstractFloat)
     T = promote_type(typeof(a), typeof(st), typeof(divisor))
     m = maxintfloat(T)
+    if Int == Int32
+        m = min(m, 2147483647.)
+    end
     if abs(a) <= m && abs(st) <= m && abs(divisor) <= m
         ia, ist, idivisor = round(Int, a), round(Int, st), round(Int, divisor)
         if ia == a && ist == st && idivisor == divisor
@@ -132,6 +135,9 @@ function colon(start::T, step::T, stop::T) where T<:Union{Float16,Float32,Float6
                 T(start_n/start_d) == start && T(stop_n/stop_d) == stop
             den = lcm(start_d, step_d) # use same denominator for start and step
             m = maxintfloat(T)
+            if Int == Int32
+                m = min(m, 2147483647.)
+            end
             if den != 0 && abs(start*den) <= m && abs(step*den) <= m &&  # will round succeed?
                     rem(den, start_d) == 0 && rem(den, step_d) == 0      # check lcm overflow
                 start_n = round(Int, start*den)
@@ -168,6 +174,9 @@ function range(a::T, st::T, len::Integer) where T<:Union{Float16,Float32,Float64
             T(start_n/start_d) == a && T(step_n/step_d) == st
         den = lcm(start_d, step_d)
         m = maxintfloat(T)
+        if Int == Int32
+            m = min(m, 2147483647.)
+        end
         if abs(den*a) <= m && abs(den*st) <= m &&
                 rem(den, start_d) == 0 && rem(den, step_d) == 0
             start_n = round(Int, den*a)
@@ -258,6 +267,9 @@ function _convertSRL(::Type{StepRangeLen{T,R,S}}, r::Range{U}) where {T,R,S,U}
             U(start_n/start_d) == f && U(step_n/step_d) == s
         den = lcm(start_d, step_d)
         m = maxintfloat(T)
+        if Int == Int32
+            m = min(m, 2147483647.)
+        end
         if den != 0 && abs(f*den) <= m && abs(s*den) <= m &&
                 rem(den, start_d) == 0 && rem(den, step_d) == 0
             start_n = round(Int, f*den)
@@ -327,6 +339,9 @@ function linspace(start::T, stop::T, len::Integer) where T<:Union{Float16,Float3
     if start_d != 0 && stop_d != 0
         den = lcm(start_d, stop_d)
         m = maxintfloat(T)
+        if Int == Int32
+            m = min(m, 2147483647.)
+        end
         if den != 0 && abs(den*start) <= m && abs(den*stop) <= m
             start_n = round(Int, den*start)
             stop_n = round(Int, den*stop)

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -14,15 +14,15 @@ end
 
 # maxintfloat
 
-@test maxintfloat(Float16) == Float16(2048f0)
+@test maxintfloat(Float16) === Float16(2048f0)
 for elty in (Float16,Float32,Float64)
-    @test maxintfloat(rand(elty)) == maxintfloat(elty)
+    @test maxintfloat(rand(elty)) === maxintfloat(elty)
 end
-@test maxintfloat() == maxintfloat(Float64)
-@test maxintfloat(Float64, Int32) == 2147483647.0
-@test maxintfloat(Float32, Int32) == maxintfloat(Float32)
-@test maxintfloat(Float64, Int16) == 32767.0
-@test maxintfloat(Float64, Int64) == maxintfloat(Float64)
+@test maxintfloat() === maxintfloat(Float64)
+@test maxintfloat(Float64, Int32) === 2147483647.0
+@test maxintfloat(Float32, Int32) === maxintfloat(Float32)
+@test maxintfloat(Float64, Int16) === 32767.0
+@test maxintfloat(Float64, Int64) === maxintfloat(Float64)
 
 # isinteger
 for elty in (Float16,Float32,Float64)

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -19,6 +19,10 @@ for elty in (Float16,Float32,Float64)
     @test maxintfloat(rand(elty)) == maxintfloat(elty)
 end
 @test maxintfloat() == maxintfloat(Float64)
+@test maxintfloat(Float64, Int32) == 2147483647.0
+@test maxintfloat(Float32, Int32) == maxintfloat(Float32)
+@test maxintfloat(Float64, Int16) == 32767.0
+@test maxintfloat(Float64, Int64) == maxintfloat(Float64)
 
 # isinteger
 for elty in (Float16,Float32,Float64)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -366,6 +366,7 @@ end
 # Inexact errors on 32 bit architectures. #22613
 @test first(linspace(log(0.2), log(10.0), 10)) == log(0.2)
 @test last(linspace(log(0.2), log(10.0), 10)) == log(10.0)
+@test length(Base.floatrange(-3e9, 1.0, 1, 1.0)) == 1
 
 # linspace & ranges with very small endpoints
 for T = (Float32, Float64)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -356,8 +356,6 @@ for T = (Float32, Float64,), i = 1:2^15, n = 1:5
     # FIXME: these fail some small portion of the time
     @test_skip start == first(r)
     @test_skip stop  == last(r)
-    # FIXME: linspace construction fails on 32-bit
-    Sys.WORD_SIZE == 64 || continue
     l = linspace(start,stop,n)
     @test n == length(l)
     # FIXME: these fail some small portion of the time

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -365,6 +365,10 @@ for T = (Float32, Float64,), i = 1:2^15, n = 1:5
     @test_skip stop  == last(l)
 end
 
+# Inexact errors on 32 bit architectures. #22613
+@test first(linspace(log(0.2), log(10.0), 10)) == log(0.2)
+@test last(linspace(log(0.2), log(10.0), 10)) == log(10.0)
+
 # linspace & ranges with very small endpoints
 for T = (Float32, Float64)
     z = zero(T)


### PR DESCRIPTION
Adds a specialisation of `maxintfloat` that optionally checks (only on 32 bit systems) whether the max float is larger than maximum 32 bit integer. If so, it downsizes the returned float to the max Int32.

For background: The maximum 32 bit integer is smaller than the maximum representable integer in a Float64. This caused `InexactError`s when linspace, floatrange, etc (see #22613) attempted to round the maximum float returned by` maxintfloat` to an `Int32`

I've added a test that reproduces the bug in #22613. This test passes under this branch.

I have also removed a line that skipped some range tests on 32 bit architecture. I assume it was this bug was causing the tests to fail on 32-bit, but it just got commented out and added to the todo pile. With the fix in this PR, these tests passed when I ran them on my 32-bit machine.