### PR TITLE
remove deprecation for #7314 (`local x=1, y=2` syntax)

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -149,6 +149,9 @@ julia> z
 10
 ```
 
+The `local` and `global` keywords can also be applied to destructuring assignments, e.g.
+`local x, y = 1, 2`. In this case the keyword affects all listed variables.
+
 ### Soft Local Scope
 
 > In a soft local scope, all variables are inherited from its parent scope unless a variable is

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1275,23 +1275,12 @@
                 `(let ,ex ,@binds)))))
 
        ((global local)
-        (let* ((lno (input-port-line (ts:port s)))
-               (const (and (eq? (peek-token s) 'const)
+        (let* ((const (and (eq? (peek-token s) 'const)
                            (take-token s)))
-               (expr  (cons word
-			    (parse-comma-separated-assignments s))))
-          ;; issue #7314
-          (if (and (length> expr 2) (any assignment? (cdr expr)))
-              (if (every assignment? (cdr expr))
-                  (syntax-deprecation s (deparse expr)
-                                      (string word " "
-                                              (string.join (map deparse (map cadr (cdr expr))) ", ")
-                                              " = "
-                                              (string.join (map deparse (map caddr (cdr expr))) ", ")))
-                  (syntax-deprecation s (deparse expr)
-                                      (string.join (map (lambda (x) (string word " " (deparse x)))
-                                                        (cdr expr))
-                                                   "; "))))
+               (assgn (parse-eq s))
+               (expr  (if (and (pair? assgn) (eq? (car assgn) 'tuple))
+                          (cons word (cdr assgn))
+                          (list word assgn))))
           (if const
               `(const ,expr)
               expr)))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1223,3 +1223,8 @@ end
 # issue #19351
 # adding return type decl should not affect parse of function body
 @test :(t(abc) = 3).args[2] == :(t(abc)::Int = 3).args[2]
+
+# issue #7314
+@test parse("local x, y = 1, 2") == Expr(:local, Expr(:(=),
+                                                      Expr(:tuple, :x, :y),
+                                                      Expr(:tuple, 1, 2)))


### PR DESCRIPTION
This completes #7314.