### PR TITLE
 FreeBSD: propose a simpler way to deal with libgcc_s

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -544,9 +544,6 @@ LDFLAGS += -L$(build_libdir) -L$(GCCPATH) -Wl,-rpath,$(build_libdir) -Wl,-rpath,
 # This ensures we get the right RPATH even if we're missing FFLAGS somewhere
 FC += -Wl,-rpath=$(GCCPATH)
 
-# Build our own libc++ and libc++abi because otherwise /usr/lib/libc++.so and /lib/libcxxrt.so will
-# be linked in when building LLVM, and those link to /lib/libgcc_s.so
-BUILD_CUSTOM_LIBCXX ?= 1
 endif # gfortran
 endif # FreeBSD
 
@@ -959,7 +956,16 @@ endif
 
 ifeq ($(OS), FreeBSD)
 JLDFLAGS := -Wl,-Bdynamic
-OSLIBS += -lelf -lkvm -lrt -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap $(NO_WHOLE_ARCHIVE) $(LIBUNWIND)
+OSLIBS += -lelf -lkvm -lrt
+
+# Tweak order of libgcc_s in DT_NEEDED,
+# make it loaded first to
+# prevent from linking to outdated system libs.
+# See #21788
+OSLIBS += -lgcc_s
+
+OSLIBS += -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap \
+	$(NO_WHOLE_ARCHIVE) $(LIBUNWIND)
 endif
 
 ifeq ($(OS), Darwin)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -133,13 +133,6 @@ LLVM_CMAKE += -DLLDB_DISABLE_PYTHON=ON
 endif # LLDB_DISABLE_PYTHON
 endif # BUILD_LLDB
 
-# Part of the FreeBSD libgcc_s kludge
-ifeq ($(OS),FreeBSD)
-ifneq ($(GCCPATH),)
-LLVM_LDFLAGS += -Wl,-rpath,'\$$ORIGIN',-rpath,$(GCCPATH)
-endif
-endif
-
 ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
 LLVM_CXXFLAGS += -mminimal-toc
 endif

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -43,11 +43,6 @@ endif
 # NOTE: Do not make RPATH changes in CMAKE_COMMON on platforms other than FreeBSD, since
 # it will make its way into the LLVM build flags, and LLVM is picky about RPATH (though
 # apparently not on FreeBSD). Ref PR #22352
-ifeq ($(OS),FreeBSD)
-ifneq ($(GCCPATH),)
-CMAKE_COMMON += -DCMAKE_INSTALL_RPATH="\$$ORIGIN:$(GCCPATH)"
-endif
-endif
 
 # For now this is LLVM specific, but I expect it won't be in the future
 ifeq ($(CMAKE_GENERATOR),Ninja)

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -1,5 +1,9 @@
 ## Some shared configuration options ##
 
+# NOTE: Do not make RPATH changes in CMAKE_COMMON on platforms other than FreeBSD, since
+# it will make its way into the LLVM build flags, and LLVM is picky about RPATH (though
+# apparently not on FreeBSD). Ref PR #22352
+
 CONFIGURE_COMMON := --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir)) --bindir=$(abspath $(build_depsbindir)) $(CUSTOM_LD_LIBRARY_PATH)
 ifneq ($(XC_HOST),)
 CONFIGURE_COMMON += --host=$(XC_HOST)
@@ -39,10 +43,6 @@ ifneq ($(BUILD_OS),WINNT)
 CMAKE_COMMON += -DCMAKE_RC_COMPILER="$$(which $(CROSS_COMPILE)windres)"
 endif
 endif
-
-# NOTE: Do not make RPATH changes in CMAKE_COMMON on platforms other than FreeBSD, since
-# it will make its way into the LLVM build flags, and LLVM is picky about RPATH (though
-# apparently not on FreeBSD). Ref PR #22352
 
 # For now this is LLVM specific, but I expect it won't be in the future
 ifeq ($(CMAKE_GENERATOR),Ninja)


### PR DESCRIPTION
Tweak the order of libgcc_s in DT_NEEDED.
Making FreeBSD do not require `BUILD_CUSTOM_LIBCXX`.