### PR TITLE
Add Window Visual Styles to julia.exe, II

### DIFF
--- a/contrib/windows/julia-manifest.xml
+++ b/contrib/windows/julia-manifest.xml
@@ -7,6 +7,11 @@
       </requestedPrivileges>
     </security>
   </trustInfo>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type='win32'  name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' language='*' />
+    </dependentAssembly>
+  </dependency>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!--The ID below indicates application support for Windows Vista -->

--- a/contrib/windows/julia-manifest.xml
+++ b/contrib/windows/julia-manifest.xml
@@ -9,7 +9,7 @@
   </trustInfo>
   <dependency>
     <dependentAssembly>
-      <assemblyIdentity type='win32'  name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' language='*' />
+      <assemblyIdentity type='win32'  name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*' />
     </dependentAssembly>
   </dependency>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
This is a modification of #22632 to remove the ``publicKeyToken`` attribute. The original PR does not let me modify it probably because I have cleared many old forks from my Github account and among the Julia fork