### PR TITLE
small improvements to (de)serialize perf. helps #22593

### DIFF
--- a/base/associative.jl
+++ b/base/associative.jl
@@ -451,6 +451,16 @@ function rehash!(t::ObjectIdDict, newsz = length(t.ht))
     t
 end
 
+function sizehint!(t::ObjectIdDict, newsz)
+    newsz = _tablesz(newsz*2)  # *2 for keys and values in same array
+    oldsz = length(t.ht)
+    # grow at least 25%
+    if newsz < (oldsz*5)>>2
+        return t
+    end
+    rehash!(t, newsz)
+end
+
 function setindex!(t::ObjectIdDict, v::ANY, k::ANY)
     if t.ndel >= ((3*length(t.ht))>>2)
         rehash!(t, max(length(t.ht)>>1, 32))

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -130,7 +130,7 @@ end
 
 # cycle handling
 function serialize_cycle(s::AbstractSerializer, x)
-    offs = get(s.table, x, -1)
+    offs = get(s.table, x, -1)::Int
     if offs != -1
         if offs <= typemax(UInt16)
             writetag(s.io, SHORTBACKREF_TAG)
@@ -212,8 +212,8 @@ function serialize(s::AbstractSerializer, x::Symbol)
 end
 
 function serialize_array_data(s::IO, a)
-    elty = eltype(a)
-    if elty === Bool && !isempty(a)
+    isempty(a) && return 0
+    if eltype(a) === Bool
         last = a[1]
         count = 1
         for i = 2:length(a)
@@ -246,7 +246,8 @@ function serialize(s::AbstractSerializer, a::Array)
     if isbits(elty)
         serialize_array_data(s.io, a)
     else
-        for i in eachindex(a)
+        sizehint!(s.table, div(length(a),4))  # prepare for lots of pointers
+        @inbounds for i in eachindex(a)
             if isassigned(a, i)
                 serialize(s, a[i])
             else
@@ -869,10 +870,11 @@ function deserialize_array(s::AbstractSerializer)
     end
     A = Array{elty, length(dims)}(dims)
     s.table[slot] = A
+    sizehint!(s.table, s.counter + div(length(A),4))
     for i = eachindex(A)
         tag = Int32(read(s.io, UInt8)::UInt8)
         if tag != UNDEFREF_TAG
-            A[i] = handle_deserialize(s, tag)
+            @inbounds A[i] = handle_deserialize(s, tag)
         end
     end
     return A


### PR DESCRIPTION
```
julia> x=IOBuffer();
julia> a = [Int[] for i = 1:100000];
```

0.6:
```
julia> @time (seek(x,0);serialize(x, a));
  0.041324 seconds (99.52 k allocations: 6.856 MiB)

julia> @time (seek(x,0);deserialize(x));
  0.378439 seconds (1.20 M allocations: 61.010 MiB, 9.42% gc time)
```

Master:
```
julia> @time (seek(x,0);serialize(x, a));
  0.040443 seconds (99.52 k allocations: 6.856 MiB)

julia> @time (seek(x,0);deserialize(x));
  0.190012 seconds (498.51 k allocations: 21.337 MiB, 4.74% gc time)
```

That improvement is due to #22635.

This PR:
```
julia> @time (seek(x,0);serialize(x, a));
  0.029831 seconds (99.51 k allocations: 4.020 MiB)

julia> @time (seek(x,0);deserialize(x));
  0.176677 seconds (498.50 k allocations: 18.500 MiB)
```

These are some very modest improvements that can be done in a totally non-breaking way. The next thing to do is to use a `Vector` instead of an `ObjectIdDict` for backreferences when deserializing, however that could potentially break packages if they're accessing Serializer internals directly. Hopefully nobody is doing that.