### PR TITLE
Relax keyword argument type in REPL.setup_interface()

### DIFF
--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -693,7 +693,7 @@ enable_promptpaste(v::Bool) = JL_PROMPT_PASTE[] = v
 function setup_interface(
     repl::LineEditREPL;
     hascolor::Bool = repl.hascolor,
-    extra_repl_keymap::Vector{<:Dict} = Dict{Any,Any}[]
+    extra_repl_keymap::Union{Dict,Vector{<:Dict}} = Dict{Any,Any}[]
 )
     ###
     #


### PR DESCRIPTION
[This type annotation](https://github.com/JuliaLang/julia/blob/ee4c5bcf5864de5aad4e44222cb2990dd8d48dd7/base/repl/REPL.jl#L696), introduced in b3e658922d1f8dfbd518673bea3b1d1733d15820, does not allow to pass a `Dict` as the keyword argument `extra_repl_keymap` in the function `REPL.setup_interface()` any more.

However, [there is still code](https://github.com/JuliaLang/julia/blob/ee4c5bcf5864de5aad4e44222cb2990dd8d48dd7/base/repl/REPL.jl#L795-L798) intended for allowing to pass a `Dict`, and [the manual](https://github.com/JuliaLang/julia/blob/ee4c5bcf5864de5aad4e44222cb2990dd8d48dd7/doc/src/manual/interacting-with-julia.md#customizing-keybindings) uses it too (which is nicer from the UI perspective IMO).

I suppose this was accidental, and this PR relaxes again the type of that argument. The other option would be to remove some dead code and change the manual.