### PR TITLE
fix bug in serialization of nested anonymous functions across processes

### DIFF
--- a/base/distributed/clusterserialize.jl
+++ b/base/distributed/clusterserialize.jl
@@ -88,8 +88,9 @@ function serialize(s::ClusterSerializer, g::GlobalRef)
     # Record if required and then invoke the default GlobalRef serializer.
     sym = g.name
     if g.mod === Main && isdefined(g.mod, sym)
-        v = getfield(Main, sym)
-         if (binding_module(Main, sym) === Main) && (s.anonfunc_id != 0)
+        if (binding_module(Main, sym) === Main) && (s.anonfunc_id != 0) &&
+            !startswith(string(sym), "#") # Anonymous functions are handled via FULL_GLOBALREF_TAG
+
             push!(get!(s.glbs_in_tnobj, s.anonfunc_id, []), sym)
         end
     end

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -437,7 +437,9 @@ function serialize(s::AbstractSerializer, t::Task)
 end
 
 function serialize(s::AbstractSerializer, g::GlobalRef)
-    if g.mod === Main && isdefined(g.mod, g.name) && isconst(g.mod, g.name)
+    if (g.mod === __deserialized_types__ ) ||
+        (g.mod === Main && isdefined(g.mod, g.name) && isconst(g.mod, g.name))
+
         v = getfield(g.mod, g.name)
         unw = unwrap_unionall(v)
         if isa(unw,DataType) && v === unw.name.wrapper && should_send_whole_type(s, unw)

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1585,6 +1585,20 @@ let thrown = false
     @test thrown
 end
 
+#19463
+function foo19463()
+    w1 = workers()[1]
+    w2 = workers()[2]
+    w3 = workers()[3]
+
+    b1 = () -> 1
+    b2 = () -> fetch(@spawnat w1 b1()) + 1
+    b3 = () -> fetch(@spawnat w2 b2()) + 1
+    b4 = () -> fetch(@spawnat w3 b3()) + 1
+    b4()
+end
+@test foo19463() == 4
+
 # Testing clear!
 function setup_syms(n, pids)
     syms = []


### PR DESCRIPTION
This fixes https://github.com/JuliaLang/julia/issues/19463

AFAICT the issue was with nested anonymous functions not being serialized across multiple worker boundaries. An anonymous function with nested functions sent from 1 to 2, would deserialize them into `__deserialized_types__`. But when 2 is sending to 3, these would not be sent.

Tests are pending.  