### PR TITLE
libgit2 test: use a valid user/pass parameter to test EAUTH instead of OS:ERROR

### DIFF
--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -22,7 +22,7 @@ mktempdir() do dir
             try
                 repo_path = joinpath(dir, "Example2")
                 # credentials are required because github tries to authenticate on unknown repo
-                cred = LibGit2.UserPasswordCredentials("","") # empty credentials cause authentication error
+                cred = LibGit2.UserPasswordCredentials("JeffBezanson", "hunter2") # make sure Jeff is using a good password :)
                 LibGit2.clone(repo_url*randstring(10), repo_path, payload=Nullable(cred))
                 error("unexpected")
             catch ex

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -30,5 +30,24 @@ mktempdir() do dir
                 @test ex.code == LibGit2.Error.EAUTH
             end
         end
+
+        @testset "with empty credentials" begin
+            try
+                repo_path = joinpath(dir, "Example3")
+                # credentials are required because github tries to authenticate on unknown repo
+                cred = LibGit2.UserPasswordCredentials("","") # empty credentials cause authentication error
+                LibGit2.clone(repo_url*randstring(10), repo_path, payload=Nullable(cred))
+                error("unexpected")
+            catch ex
+                @test isa(ex, LibGit2.Error.GitError)
+                if is_windows() && LibGit2.version() >= v"0.26.0"
+                    # see #22681 and https://github.com/libgit2/libgit2/pull/4055
+                    @test_broken ex.code == LibGit2.Error.EAUTH
+                    @test ex.code == LibGit2.Error.ERROR
+                else
+                    @test ex.code == LibGit2.Error.EAUTH
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
this should fix the appveyor failures resulting from upgrading libgit2