### PR TITLE
tuple type introspection via indexing/iteration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,7 +50,7 @@ Library improvements
 --------------------
 
   * The components of a tuple type `T` may now be iterated over and indexed
-    as if `T` were a tuple of types.
+    as if `T` were a tuple of types ([#22687]).
 
   * The functions `strip`, `lstrip` and `rstrip` now return `SubString` ([#22496]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,9 @@ This section lists changes that do not have deprecation warnings.
 Library improvements
 --------------------
 
+  * The components of a tuple type `T` may now be iterated over and indexed
+    as if `T` were a tuple of types.
+
   * The functions `strip`, `lstrip` and `rstrip` now return `SubString` ([#22496]).
 
   * The functions `base` and `digits` digits now accept a negative

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -877,6 +877,25 @@ false
 Intuitively, this corresponds to the type of a function's arguments being a subtype of the function's
 signature (when the signature matches).
 
+You can inspect the component types of a tuple type `T` almost
+as if `T` were an array or tuple of types:
+```jldoctest
+julia> T = Tuple{Int8,String,Float32}
+Tuple{Int8,String,Float32}
+
+julia> length(T)
+3
+
+julia> T[2]
+String
+
+julia> collect(Type, T)
+3-element Array{Type,1}:
+ Int8
+ String
+ Float32
+```
+
 ### Vararg Tuple Types
 
 The last parameter of a tuple type can be the special type `Vararg`, which denotes any number
@@ -904,6 +923,9 @@ used to represent the arguments accepted by varargs methods (see [Varargs Functi
 
 The type `Vararg{T,N}` corresponds to exactly `N` elements of type `T`.  `NTuple{N,T}` is a convenient
 alias for `Tuple{Vararg{T,N}}`, i.e. a tuple type containing exactly `N` elements of type `T`.
+
+For introspection/indexing purposes, a `Vararg` tuple type behaves like an "array" of
+an unbounded number of types (its [`length`](@ref) is `typemax(Int)`).
 
 #### [Singleton Types](@id man-singleton-types)
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -291,3 +291,25 @@ let
 
     test_15703()
 end
+
+@testset "tuple type introspection" begin
+    for (T,a) in ((Tuple{}, Type[]),
+                  (Tuple{Int,String,Int8}, [Int,String,Int8]),
+                  (NTuple{4,Int}, [Int,Int,Int,Int]),
+                  (Tuple{Int,String,Vararg{Int8}}, [Int,String,Int8,Int8,Int8]))
+        @test isempty(T) == isempty(a)
+        if Base._iteratorsize(T) isa Base.HasLength
+            @test length(T) == endof(T) == length(a)
+            @test collect(Type, T) == a == [T[i] for i = 1:length(T)]
+            @test_throws BoundsError T[length(T)+1]
+        else
+            @test length(T) == endof(T) == typemax(Int)
+        end
+        if !isempty(T)
+            @test first(T) == first(a)
+            @test last(T) == last(a) == T[end]
+        end
+        @test collect(Type, Base.Iterators.take(T, length(a))) == a == [T[i] for i = 1:length(a)]
+        @test_throws BoundsError T[0]
+    end
+end


### PR DESCRIPTION
This PR simplifies introspection of tuple types by allowing you to iterate/index tuple types almost as if they were simply a tuple of types.  For example, it allows you to do:

```jl
julia> T = Tuple{Int8,String,Float32}
Tuple{Int8,String,Float32}

julia> length(T)
3

julia> T[2]
String

julia> collect(Type, T)
3-element Array{Type,1}:
 Int8
 String
 Float32
```

Without this PR, you have to do a lot of digging through Julia internals to do introspection of tuple types (via the undocumented `T.types` field), and it is especially difficult to introspect vararg tuple types (via undocumented functions like `Base.unwrapva`).

I encountered this when generalizing tuple conversion for PyCall (JuliaPy/PyCall.jl#404), and the difficulty of tuple introspection has also caused some fragility in JLD (#10999).