### PR TITLE
fix graphemes eltype for substrings

### DIFF
--- a/base/strings/utf8proc.jl
+++ b/base/strings/utf8proc.jl
@@ -354,6 +354,7 @@ letter combined with an accent mark is a single grapheme.)
 graphemes(s::AbstractString) = GraphemeIterator{typeof(s)}(s)
 
 eltype(::Type{GraphemeIterator{S}}) where {S} = SubString{S}
+eltype(::Type{GraphemeIterator{SubString{S}}}) where {S} = SubString{S}
 
 function length(g::GraphemeIterator)
     c0 = Char(0x00ad) # soft hyphen (grapheme break always allowed after this)

--- a/test/unicode/utf8proc.jl
+++ b/test/unicode/utf8proc.jl
@@ -311,9 +311,6 @@ end
         h = hash(str)
         @test hash(g) == h
         @test convert(GenericString, g) == str
-        io = IOBuffer()
-        show(io, g)
-        check = "length-14 GraphemeIterator{String} for \"$str\""
-        @test String(take!(io)) == check
+        @test repr(g) == "length-14 GraphemeIterator{String} for \"$str\""
     end
 end

--- a/test/unicode/utf8proc.jl
+++ b/test/unicode/utf8proc.jl
@@ -314,3 +314,9 @@ end
         @test repr(g) == "length-14 GraphemeIterator{String} for \"$str\""
     end
 end
+
+@testset "#22693: substring graphemes" begin
+    g = graphemes(SubString("123α56789", 1, 6))
+    @test eltype(g) == SubString{String}
+    @test collect(g) == ["1","2","3","α","5"]
+end


### PR DESCRIPTION
Fixes #22693.  Also noticed a small simplification in another utf8proc test.