### PR TITLE
Register finalizers in constructors

### DIFF
--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -147,20 +147,10 @@ function Base.LinAlg.qrfact(A::SparseMatrixCSC{Tv}; tol = _default_tol(A)) where
         C_NULL, C_NULL, C_NULL, C_NULL,
         R, E, H, HPinv, HTau)
 
-    # convert to Julia managed memory and free memory from SuiteSparse
-    tmpH = Sparse(H[])
-    HCSC = SparseMatrixCSC(tmpH)
-    free!(tmpH)
-
-    tmpHTau    = CHOLMOD.Dense(HTau[])
-    HTauVector = vec(Array(tmpHTau))
-    free!(tmpHTau)
-
-    tmpR = Sparse(R[])
-    RCSC = SparseMatrixCSC(tmpR)
-    free!(tmpR)
-
-    return QRSparse(HCSC, HTauVector, RCSC, p, hpinv)
+    return QRSparse(SparseMatrixCSC(Sparse(H[])),
+                    vec(Array(CHOLMOD.Dense(HTau[]))),
+                    SparseMatrixCSC(Sparse(R[])),
+                    p, hpinv)
 end
 
 """


### PR DESCRIPTION
Leave an escape hatch for Factor to avoid registering a finalizer
since we sometimes want to change the element type of an existing
Factor