### PR TITLE
test/file: repeated running `test_13559` triggers SystemError randomly

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -1134,3 +1134,25 @@ end
 test_13559()
 end
 @test_throws ArgumentError mkpath("fakepath",-1)
+
+# issue #22566
+if !Sys.iswindows()
+    function test_22566()
+        fn = tempname()
+        run(`mkfifo $fn`)
+
+        script = "x = open(\"$fn\", \"w\"); close(x)"
+        cmd = `$(Base.julia_cmd()) --startup-file=no -e $script`
+        open(pipeline(cmd, stderr=STDERR))
+
+        r = open(fn, "r")
+        close(r)
+
+        rm(fn)
+    end
+
+    # repeat opening/closing fifo file, ensure no EINTR popped out
+    for i ∈ 1:50
+        test_22566()
+    end
+end  # !Sys.iswindows


### PR DESCRIPTION
The function `test_13559` in `test/file.jl` will randomly raise SystemError.
but (not sure why) this exception cannot trigger via `(g)make test-file` even I added a loop in `test/file.jl`.

I just extract the function in a standalone script, found it can be reproduced easily within 10 iters on my Linux and FreeBSD machines.
please checkout this script: https://gist.github.com/iblis17/b39e37071f3d816076e2770b338a8d07

Here is the result on Linux
```julia
└─[iblis@kaladbolg Oops]% ../julia test.jl 
=================== iter 0 ======================
pipe: /tmp/juliaCo8IW7
=================== iter 0 done =================
=================== iter 1 ======================
pipe: /tmp/juliaDhJxvz
=================== iter 1 done =================
=================== iter 2 ======================
pipe: /tmp/juliaw9NMlN
ERROR: LoadError: SystemError: opening file /tmp/juliaw9NMlN: Interrupted system call
Stacktrace:
 [1] #systemerror#43 at ./error.jl:64 [inlined]
 [2] systemerror(::String, ::Bool) at ./error.jl:64
 [3] open(::String, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at ./iostream.jl:104
 [4] open(::String, ::String) at ./iostream.jl:132
 [5] test_13559() at /home/iblis/git/julia/tmp/test.jl:11
 [6] macro expansion at /home/iblis/git/julia/tmp/test.jl:25 [inlined]
 [7] anonymous at ./<missing>:?
 [8] include_from_node1(::Module, ::String) at ./loading.jl:549
 [9] include(::Module, ::String) at ./sysimg.jl:14
 [10] process_options(::Base.JLOptions) at ./client.jl:310
 [11] _start() at ./client.jl:378
while loading /home/iblis/git/julia/tmp/test.jl, in expression starting on line 23
┌─[~/git/julia/tmp]
| [Venv(py36)] [ master] [-- INSERT --]
└─[iblis@kaladbolg Oops]% uname -a
Linux kaladbolg 4.11.3-1-ARCH #1 SMP PREEMPT Sun May 28 10:40:17 CEST 2017 x86_64 GNU/Linux
```

See also: https://github.com/JuliaLang/julia/issues/20585#issuecomment-308611688