### PR TITLE
fix corner cases of binary arithmetic ops between sparse vectors and scalars (#21515)

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -1443,13 +1443,9 @@ scale!(x::AbstractSparseVector, a::Complex) = (scale!(nonzeros(x), a); x)
 scale!(a::Real, x::AbstractSparseVector) = (scale!(nonzeros(x), a); x)
 scale!(a::Complex, x::AbstractSparseVector) = (scale!(nonzeros(x), a); x)
 
-
 (*)(x::AbstractSparseVector, a::Number) = SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) * a)
 (*)(a::Number, x::AbstractSparseVector) = SparseVector(length(x), copy(nonzeroinds(x)), a * nonzeros(x))
 (/)(x::AbstractSparseVector, a::Number) = SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) / a)
-broadcast(::typeof(*), x::AbstractSparseVector, a::Number) = x * a
-broadcast(::typeof(*), a::Number, x::AbstractSparseVector) = a * x
-broadcast(::typeof(/), x::AbstractSparseVector, a::Number) = x / a
 
 # dot
 function dot(x::StridedVector{Tx}, y::SparseVectorUnion{Ty}) where {Tx<:Number,Ty<:Number}

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -1164,3 +1164,13 @@ end
 @testset "spzeros with index type" begin
     @test typeof(spzeros(Float32, Int16, 3)) == SparseVector{Float32,Int16}
 end
+
+@testset "corner cases of broadcast arithmetic operations with scalars (#21515)" begin
+    # test both scalar literals and variables
+    areequal(a, b, c) = isequal(a, b) && isequal(b, c)
+    inf, zeroh, zv, spzv = Inf, 0.0, zeros(1), spzeros(1)
+    @test areequal(spzv .* Inf,  spzv .* inf,    sparsevec(zv .* Inf))
+    @test areequal(Inf .* spzv,  inf .* spzv,    sparsevec(Inf .* zv))
+    @test areequal(spzv ./ 0.0,  spzv ./ zeroh,  sparsevec(zv ./ 0.0))
+    @test areequal(0.0 .\ spzv,  zeroh .\ spzv,  sparsevec(0.0 .\ zv))
+end


### PR DESCRIPTION
This pull request fixes a few corner cases of binary arithmetic operations between sparse vectors and scalars. Ref. https://github.com/JuliaLang/julia/issues/21515#issuecomment-313868609 and downstream discussion. (Backport candidate? Tentatively added to the 0.6.x milestone.) Best!