### PR TITLE
Fix exp10 fallback and exp2 and exp10 for Float16

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -263,7 +263,7 @@ cbrt(x::AbstractFloat) = x < 0 ? -(-x)^(1//3) : x^(1//3)
 """
     exp2(x)
 
-Compute the base `2` exponential of `x`, in other words ``2^x``.
+Compute the base 2 exponential of `x`, in other words ``2^x``.
 
 # Examples
 ```jldoctest
@@ -276,7 +276,7 @@ exp2(x::AbstractFloat) = 2^x
 """
     exp10(x)
 
-Compute the base `10` exponential of `x`, in other words ``10^x``.
+Compute the base 10 exponential of `x`, in other words ``10^x``.
 
 # Examples
 ```jldoctest

--- a/base/math.jl
+++ b/base/math.jl
@@ -265,6 +265,7 @@ cbrt(x::AbstractFloat) = x < 0 ? -(-x)^(1//3) : x^(1//3)
 
 Compute the base `2` exponential of `x`, in other words ``2^x``.
 
+# Examples
 ```jldoctest
 julia> exp2(5)
 32.0
@@ -277,6 +278,7 @@ exp2(x::AbstractFloat) = 2^x
 
 Compute the base `10` exponential of `x`, in other words ``10^x``.
 
+# Examples
 ```jldoctest
 julia> exp10(2)
 100.0

--- a/base/math.jl
+++ b/base/math.jl
@@ -263,7 +263,7 @@ cbrt(x::AbstractFloat) = x < 0 ? -(-x)^(1//3) : x^(1//3)
 """
     exp2(x)
 
-Compute ``2^x``.
+Compute the base `2` exponential of `x`, in other words ``2^x``.
 
 ```jldoctest
 julia> exp2(5)
@@ -271,6 +271,19 @@ julia> exp2(5)
 ```
 """
 exp2(x::AbstractFloat) = 2^x
+
+"""
+    exp10(x)
+
+Compute the base `10` exponential of `x`, in other words ``10^x``.
+
+```jldoctest
+julia> exp10(2)
+100.0
+```
+"""
+exp10(x::AbstractFloat) = 10^x
+
 for f in (:sinh, :cosh, :tanh, :atan, :asinh, :exp, :expm1)
     @eval ($f)(x::AbstractFloat) = error("not implemented for ", typeof(x))
 end
@@ -959,7 +972,7 @@ muladd(x,y,z) = x*y+z
 # Float16 definitions
 
 for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
-             :atanh,:exp,:log,:log2,:log10,:sqrt,:lgamma,:log1p)
+             :atanh,:exp,:exp2,:exp10,:log,:log2,:log10,:sqrt,:lgamma,:log1p)
     @eval begin
         $func(a::Float16) = Float16($func(Float32(a)))
         $func(a::Complex32) = Complex32($func(Complex64(a)))

--- a/base/special/exp10.jl
+++ b/base/special/exp10.jl
@@ -67,16 +67,6 @@ MIN_EXP10(::Type{Float32}) = -45.15449934959718f0         # log10 2^-150
 @eval exp10_small_thres(::Type{Float64}) = $(2.0^-29)
 @eval exp10_small_thres(::Type{Float32}) = $(2.0f0^-14)
 
-"""
-    exp10(x)
-
-Compute the base `10` exponential of `x`, in other words ``10^x``.
-
-```jldoctest
-julia> exp10(1.0)
-10.0
-```
-"""
 function exp10(x::T) where T<:Union{Float32,Float64}
     xa = reinterpret(Unsigned, x) & ~sign_mask(T)
     xsb = signbit(x)

--- a/test/math.jl
+++ b/test/math.jl
@@ -246,11 +246,6 @@ end
         end
     end
 end
-@test exp10(5) ≈ exp10(5.0)
-@test exp10(50//10) ≈ exp10(5.0)
-@test log10(exp10(e)) ≈ e
-@test exp2(Float16(2.)) ≈ exp2(2.)
-@test log(e) == 1
 
 @testset "exp function" for T in (Float64, Float32)
     @testset "$T accuracy" begin
@@ -662,7 +657,12 @@ end
     @test sincos(big(1.0)) == (sin(big(1.0)), cos(big(1.0)))
 end
 
-@testset "Float16 fallbacks" begin
+@testset "test fallback definitions" begin
+    @test exp10(5) ≈ exp10(5.0)
+    @test exp10(50//10) ≈ exp10(5.0)
+    @test log10(exp10(e)) ≈ e
+    @test log(e) === 1
+    @test exp2(Float16(2.0)) ≈ exp2(2.0)
     @test exp2(Float16(1.0)) === Float16(exp2(1.0))
     @test exp10(Float16(1.0)) === Float16(exp10(1.0))
 end
@@ -673,5 +673,6 @@ struct Float32432{T<:AbstractFloat} <: AbstractFloat
 end
 Base.:^(x::Number, y::Float32432) = x^(y.x)
 let x = 2.0
-    @test exp2(TestFloat324(x)) == 2^x
+    @test exp2(Float32432(x)) === 2^x
+    @test exp10(Float32432(x)) === 10^x
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -667,12 +667,12 @@ end
     @test exp10(Float16(1.0)) === Float16(exp10(1.0))
 end
 
-# test AbstractFloat fallback
-struct Float32432{T<:AbstractFloat} <: AbstractFloat
+# test AbstractFloat fallback pr22716
+struct Float22716{T<:AbstractFloat} <: AbstractFloat
     x::T
 end
-Base.:^(x::Number, y::Float32432) = x^(y.x)
+Base.:^(x::Number, y::Float22716) = x^(y.x)
 let x = 2.0
-    @test exp2(Float32432(x)) === 2^x
-    @test exp10(Float32432(x)) === 10^x
+    @test exp2(Float22716(x)) === 2^x
+    @test exp10(Float22716(x)) === 10^x
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -661,3 +661,17 @@ end
     @test sincos(big(1)) == (sin(big(1)), cos(big(1)))
     @test sincos(big(1.0)) == (sin(big(1.0)), cos(big(1.0)))
 end
+
+@testset "Float16 fallbacks" begin
+    @test exp2(Float16(1.0)) === Float16(exp2(1.0))
+    @test exp10(Float16(1.0)) === Float16(exp10(1.0))
+end
+
+# test AbstractFloat fallback
+struct Float32432{T<:AbstractFloat} <: AbstractFloat
+    x::T
+end
+Base.:^(x::Number, y::Float32432) = x^(y.x)
+let x = 2.0
+    @test exp2(TestFloat324(x)) == 2^x
+end


### PR DESCRIPTION
`exp2` was  not added to the  Float16 definitions and hence calls the very slow fallback to `2^x`. 

`exp10` does not have any fallback definitions and thus things like 
```julia
julia> exp10(Float16(2.0))
ERROR: StackOverflowError:
```
lead to a StackOverFlow  or with other `AbstractFloat`


