### PR TITLE
implement rand(::BigFloat) (close #13948)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -203,6 +203,8 @@ Library improvements
   * Mutating versions of `randperm` and `randcycle` have been added:
     `randperm!` and `randcycle!` ([#22723]).
 
+  * `BigFloat` random numbers can now be generated ([#22720]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/random/RNGs.jl
+++ b/base/random/RNGs.jl
@@ -45,12 +45,7 @@ RandomDevice
 
 ### generation of floats
 
-rand(rng::RandomDevice, ::Close1Open2_64) =
-    reinterpret(Float64, 0x3ff0000000000000 | rand(rng, UInt64) & 0x000fffffffffffff)
-
-rand(rng::RandomDevice, ::CloseOpen_64) = rand(rng, Close1Open2()) - 1.0
-
-@inline rand(r::RandomDevice, T::BitFloatType) = rand_generic(r, T)
+@inline rand(r::RandomDevice, I::FloatInterval) = rand_generic(r, I)
 
 
 ## MersenneTwister
@@ -224,7 +219,7 @@ rand_ui23_raw(r::MersenneTwister) = rand_ui52_raw(r)
 
 @inline rand(r::MersenneTwister, I::FloatInterval_64) = (reserve_1(r); rand_inbounds(r, I))
 
-@inline rand(r::MersenneTwister, T::BitFloatType) = rand_generic(r, T)
+@inline rand(r::MersenneTwister, I::FloatInterval) = rand_generic(r, I)
 
 #### integers
 

--- a/base/random/generation.jl
+++ b/base/random/generation.jl
@@ -10,11 +10,11 @@
 
 ### random floats
 
-@inline rand(r::AbstractRNG=GLOBAL_RNG) = rand(r, CloseOpen)
+@inline rand(r::AbstractRNG=GLOBAL_RNG) = rand(r, CloseOpen())
 
 # generic random generation function which can be used by RNG implementors
 # it is not defined as a fallback rand method as this could create ambiguities
-@inline rand_generic(r::AbstractRNG, ::Type{Float64}) = rand(r, CloseOpen)
+@inline rand_generic(r::AbstractRNG, ::Type{Float64}) = rand(r, CloseOpen())
 
 rand_generic(r::AbstractRNG, ::Type{Float16}) =
     Float16(reinterpret(Float32,
@@ -28,7 +28,7 @@ rand_generic(r::AbstractRNG, ::Type{Float32}) =
 rand_ui10_raw(r::AbstractRNG) = rand(r, UInt16)
 rand_ui23_raw(r::AbstractRNG) = rand(r, UInt32)
 
-@inline rand_ui52_raw(r::AbstractRNG) = reinterpret(UInt64, rand(r, Close1Open2))
+@inline rand_ui52_raw(r::AbstractRNG) = reinterpret(UInt64, rand(r, Close1Open2()))
 @inline rand_ui52(r::AbstractRNG) = rand_ui52_raw(r) & 0x000fffffffffffff
 
 ### random complex numbers

--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -22,9 +22,17 @@ export srand,
 
 abstract type AbstractRNG end
 
-abstract type FloatInterval end
-mutable struct CloseOpen <: FloatInterval end
-mutable struct Close1Open2 <: FloatInterval end
+abstract type FloatInterval{T<:AbstractFloat} end
+
+struct CloseOpen{  T<:AbstractFloat} <: FloatInterval{T} end # interval [0,1)
+struct Close1Open2{T<:AbstractFloat} <: FloatInterval{T} end # interval [1,2)
+
+const FloatInterval_64 = FloatInterval{Float64}
+const CloseOpen_64     = CloseOpen{Float64}
+const Close1Open2_64   = Close1Open2{Float64}
+
+CloseOpen()   = CloseOpen{Float64}()
+Close1Open2() = Close1Open2{Float64}()
 
 const BitFloatType = Union{Type{Float16},Type{Float32},Type{Float64}}
 

--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -31,8 +31,8 @@ const FloatInterval_64 = FloatInterval{Float64}
 const CloseOpen_64     = CloseOpen{Float64}
 const Close1Open2_64   = Close1Open2{Float64}
 
-CloseOpen()   = CloseOpen{Float64}()
-Close1Open2() = Close1Open2{Float64}()
+CloseOpen(  ::Type{T}=Float64) where {T<:AbstractFloat} = CloseOpen{T}()
+Close1Open2(::Type{T}=Float64) where {T<:AbstractFloat} = Close1Open2{T}()
 
 const BitFloatType = Union{Type{Float16},Type{Float32},Type{Float64}}
 

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -143,12 +143,12 @@ dimension specifications `dims...` (which can be given as a tuple) to generate a
 values.
 
 A `MersenneTwister` or `RandomDevice` RNG can generate random numbers of the following types:
-[`Float16`](@ref), [`Float32`](@ref), [`Float64`](@ref), [`Bool`](@ref), [`Int8`](@ref),
-[`UInt8`](@ref), [`Int16`](@ref), [`UInt16`](@ref), [`Int32`](@ref), [`UInt32`](@ref),
-[`Int64`](@ref), [`UInt64`](@ref), [`Int128`](@ref), [`UInt128`](@ref), [`BigInt`](@ref)
-(or complex numbers of those types). Random floating point numbers are generated uniformly
-in ``[0, 1)``. As `BigInt` represents unbounded integers, the interval must be specified
-(e.g. `rand(big(1:6))`).
+[`Float16`](@ref), [`Float32`](@ref), [`Float64`](@ref), [`BigFloat`](@ref), [`Bool`](@ref),
+[`Int8`](@ref), [`UInt8`](@ref), [`Int16`](@ref), [`UInt16`](@ref), [`Int32`](@ref),
+[`UInt32`](@ref), [`Int64`](@ref), [`UInt64`](@ref), [`Int128`](@ref), [`UInt128`](@ref),
+[`BigInt`](@ref) (or complex numbers of those types).
+Random floating point numbers are generated uniformly in ``[0, 1)``. As `BigInt` represents
+unbounded integers, the interval must be specified (e.g. `rand(big(1:6))`).
 
 ```@docs
 Base.Random.srand

--- a/test/random.jl
+++ b/test/random.jl
@@ -308,7 +308,7 @@ end
 for rng in ([], [MersenneTwister(0)], [RandomDevice()])
     ftypes = [Float16, Float32, Float64]
     cftypes = [Complex32, Complex64, Complex128, ftypes...]
-    types = [Bool, Char, Base.BitInteger_types..., ftypes...]
+    types = [Bool, Char, BigFloat, Base.BitInteger_types..., ftypes...]
     randset = Set(rand(Int, 20))
     randdict = Dict(zip(rand(Int,10), rand(Int, 10)))
     collections = [IntSet(rand(1:100, 20)) => Int,
@@ -322,6 +322,9 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
                    Float64                 => Float64,
                    "qwèrtï"                => Char,
                    GenericString("qwèrtï") => Char]
+    functypes = Dict(rand  => types, randn  => cftypes, randexp  => ftypes,
+                     rand! => types, randn! => cftypes, randexp! => ftypes)
+
     b2 = big(2)
     u3 = UInt(3)
     for f in [rand, randn, randexp]
@@ -330,7 +333,7 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
         f(rng..., 2, 3)               ::Array{Float64, 2}
         f(rng..., b2, u3)             ::Array{Float64, 2}
         f(rng..., (2, 3))             ::Array{Float64, 2}
-        for T in (f === rand ? types : f === randn ? cftypes : ftypes)
+        for T in functypes[f]
             a0 = f(rng..., T)         ::T
             a1 = f(rng..., T, 5)      ::Vector{T}
             a2 = f(rng..., T, 2, 3)   ::Array{T, 2}
@@ -370,7 +373,7 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
         @test_throws ArgumentError rand(rng..., C, 5)
     end
     for f! in [rand!, randn!, randexp!]
-        for T in (f! === rand! ? types : f! === randn! ? cftypes : ftypes)
+        for T in functypes[f!]
             X = T == Bool ? T[0,1] : T[0,1,2]
             for A in (Array{T}(5), Array{T}(2, 3), GenericArray{T}(5), GenericArray{T}(2, 3))
                 f!(rng..., A)                    ::typeof(A)
@@ -409,17 +412,19 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
     end
 end
 
-function hist(X,n)
-    v = zeros(Int,n)
+function hist(X, n)
+    v = zeros(Int, n)
     for x in X
-        v[floor(Int,x*n)+1] += 1
+        v[floor(Int, x*n) + 1] += 1
     end
     v
 end
 
 # test uniform distribution of floats
-for rng in [srand(MersenneTwister(0)), RandomDevice()]
-    for T in [Float16,Float32,Float64]
+for rng in [srand(MersenneTwister(0)), RandomDevice()],
+    T in [Float16, Float32, Float64, BigFloat],
+        prec in (T == BigFloat ? [3, 53, 64, 100, 256, 1000] : [256])
+    setprecision(BigFloat, prec) do
         # array version
         counts = hist(rand(rng, T, 2000), 4)
         @test minimum(counts) > 300 # should fail with proba < 1e-26


### PR DESCRIPTION
This uses a similar method as for `Float64`: generate uniformly sufficiently many random bits to get a number `x` in `[1, 2)`.
Then there are two simple possibilities (cf. this nice [write-up](https://github.com/JuliaLang/julia/issues/16344#issuecomment-219001816)):
1) return `x-1.0` : then one bit of precision is lost
2) return `rand(Bool) ? x/2 : x/2-0.5`

For `Float64`, we do option 1) as dSFMT generates only 52 random bits per iteration, when `Float64` has 53 bits of precision, and this is way faster (the cost of the branch of option 2 is non-negligible).
For `BigFloat`, the two options have similar performances (within few percents, and option 2) even is slightly faster than 1) for higher precisions), so I would favor this one. On the other hand, option 1) has the advantage that it would behave similarly to other floats when their precision is set to match (e.g. `rand(BigFloat)` would behave like `rand(Float64)` when `precision(BigFloat) == 53`). "RFC" until this is decided (option 1 is commented out here, if someone wants to play with it).

One possibility would be to have something along the lines of having `rand(CloseOpen{T})` generate 1 random a float of type `T` with 1 bit less than the precision, `rand(CloseOpenFull{T})` generate at full precision number, and `rand(T)` generate the best of the 2 options (1 for `Float64` and 2 for `BigFloat`). This would incidentaly solve #16344, by allowing to get random `Float64` at full precision (opt-in), which is not terribly slow after all: on my machine, this takes 14ns for full precision vs 5ns for 52 bits precision. 
 