### PR TITLE
Support type renaming

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -115,6 +115,13 @@ function resolve(g::GlobalRef; force::Bool=false)
     return g
 end
 
+function rename_binding(m::Module, oldname::Symbol, newname::Symbol)
+    T = unwrap_unionall(getfield(m, oldname))
+    ccall(:jl_rename_binding, Cvoid, (Any, Any, Any), m, oldname, newname)
+    T.name.name = newname
+    T
+end
+
 const NamedTuple_typename = NamedTuple.body.body.name
 
 function _fieldnames(@nospecialize t)

--- a/src/module.c
+++ b/src/module.c
@@ -682,6 +682,16 @@ void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b)
     }
 }
 
+JL_DLLEXPORT void jl_rename_binding(jl_module_t *m, jl_sym_t *oldvar, jl_sym_t *newvar)
+{
+    jl_binding_t *b = jl_get_binding(m, oldvar);
+    if (b) {
+        b->name = newvar;
+        ptrhash_remove(&m->bindings, oldvar);
+        ptrhash_put(&m->bindings, newvar, b);
+    }
+}
+
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
 {
     if (b->constp && b->value != NULL) {

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -34,7 +34,7 @@ in the `choices` argument:
 function choosetests(choices = [])
     testnames = [
         "subarray", "core", "compiler", "worlds",
-        "keywordargs", "numbers", "subtype",
+        "keywordargs", "numbers", "subtype", "type_redefinition",
         "char", "strings", "triplequote", "unicode", "intrinsics",
         "dict", "hashing", "iobuffer", "staged", "offsetarray",
         "arrayops", "tuple", "reduce", "reducedim", "abstractarray",

--- a/test/testhelpers/RedefStruct.jl
+++ b/test/testhelpers/RedefStruct.jl
@@ -1,0 +1,31 @@
+module RedefStruct
+
+struct A
+    x::Int
+end
+
+struct B{T<:AbstractFloat}
+    y::T
+end
+
+struct C{T,N,A<:AbstractArray{T}}
+    data::A
+
+    function C{T,N,A}(data::AbstractArray{T}) where {T,N,A}
+        ndims(data) == N-1 || error("wrong dimensionality")
+        return new{T,N,A}(data)
+    end
+end
+C(data::AbstractArray{T,N}) where {T,N} = C{T,N+1,typeof(data)}(data)
+
+# Methods that take the type as an argument
+fA(a::A) = true
+fB(b::B{T}) where T = true
+fC(c::C{T,N}) where {T,N} = N
+
+# Methods that call the constructor
+gA(x) = A(x)
+gB(::Type{T}) where T = B{float(T)}(-2)
+gC(sz) = C(zeros(sz))
+
+end

--- a/test/type_redefinition.jl
+++ b/test/type_redefinition.jl
@@ -1,0 +1,142 @@
+using Test
+
+function invalidate_struct(m::Module, name::Symbol)
+    # Delete the constructors for the old type, in an attempt to ensure that
+    # old objects can't be created anymore.
+    T = getfield(m, name)
+    for constructor in methods(T)
+        Base.delete_method(constructor)
+    end
+    # Rename the old type (move it "out of the way")
+    new_name = gensym(name)
+    return Base.rename_binding(m, name, new_name)
+end
+
+## In the first set of tests, we redefine the types before using them
+include("testhelpers/RedefStruct.jl")
+
+oldtype = invalidate_struct(RedefStruct, :A)
+ex = quote
+    struct A
+        x::Int8   # change the field type
+    end
+end
+Core.eval(RedefStruct, ex)
+@test fieldtype(RedefStruct.A, :x) === Int8
+a = RedefStruct.A(-1)
+@test a.x === Int8(-1)
+@test_throws MethodError RedefStruct.fA(a)  # this method was defined for the old A
+aa = RedefStruct.gA(5)
+@test !isa(aa, oldtype)
+@test aa.x === Int8(5)
+
+oldtype = invalidate_struct(RedefStruct, :B)
+ex = quote
+    struct B{T<:Integer}
+        z::T
+    end
+end
+Core.eval(RedefStruct, ex)
+@test fieldtype(RedefStruct.B{Int16}, :z) === Int16
+b = RedefStruct.B{Int16}(-1)
+@test b.z === Int16(-1)
+@test_throws MethodError RedefStruct.fB(b)
+# It's not possible to directly construct the TypeError that gets returned, so let's cheat
+typerr = try RedefStruct.gB(Int) catch err err end
+@test isa(typerr, TypeError) && typerr.func == :B && typerr.context == "T" &&
+      typerr.expected.name == :T && typerr.expected.ub === Integer && typerr.got === Float64
+Core.eval(RedefStruct, :(gB(::Type{T}) where T = B{unsigned(T)}(2)))
+bb = RedefStruct.gB(Int)
+@test !isa(bb, oldtype)
+@test bb.z === UInt(2)
+
+oldtype = invalidate_struct(RedefStruct, :C)
+ex = quote
+    struct C{T,N,A<:AbstractArray{T,N}}
+        data::A
+
+        function C{T,N,A}(data::AbstractArray) where {T,N,A}
+            return new{T,N,A}(data)
+        end
+    end
+end
+Core.eval(RedefStruct, ex)
+c32 = RedefStruct.C{Float32,2,Array{Float32,2}}([0.1 0.2; 0.3 0.4])
+@test c32.data isa Array{Float32,2}
+@test_throws MethodError RedefStruct.C([0.1 0.2; 0.3 0.4])  # outer constructor is not yet defined
+Core.eval(RedefStruct, :(C(data::AbstractArray{T,N}) where {T,N} = C{T,N,typeof(data)}(data)))
+c64 = RedefStruct.C([0.1 0.2; 0.3 0.4])
+@test c64.data isa Array{Float64,2}
+@test_throws MethodError RedefStruct.fC(c32)
+cc = RedefStruct.gC((3,2))
+@test cc.data == zeros(3, 2) && isa(cc.data, Matrix{Float64})
+
+
+## Do it again, this time having already used the old methods
+include("testhelpers/RedefStruct.jl")
+
+a = RedefStruct.gA(3)
+@test RedefStruct.fA(a)
+oldtype = invalidate_struct(RedefStruct, :A)
+ex = quote
+    struct A
+        x::Int8   # change the field type
+    end
+end
+Core.eval(RedefStruct, ex)
+@test fieldtype(RedefStruct.A, :x) === Int8
+a = RedefStruct.A(-1)
+@test a.x === Int8(-1)
+@test_throws MethodError RedefStruct.fA(a)  # this method was defined for the old A
+aa = RedefStruct.gA(5)
+@test !isa(aa, oldtype)
+@test aa.x === Int8(5)
+
+b = RedefStruct.gB(Int)
+@test b isa RedefStruct.B{Float64}
+@test RedefStruct.fB(b)
+oldtype = invalidate_struct(RedefStruct, :B)
+ex = quote
+    struct B{T<:Integer}
+        z::T
+    end
+end
+Core.eval(RedefStruct, ex)
+@test fieldtype(RedefStruct.B{Int16}, :z) === Int16
+b = RedefStruct.B{Int16}(-1)
+@test b.z === Int16(-1)
+@test_throws MethodError RedefStruct.fB(b)
+typerr = try RedefStruct.gB(Int) catch err err end
+@test_broken isa(typerr, TypeError) && typerr.func == :B && typerr.context == "T" &&
+      typerr.expected.name == :T && typerr.expected.ub === Integer && typerr.got === Float64
+typerr = try RedefStruct.gB(Float32) catch err err end
+@test isa(typerr, TypeError) && typerr.func == :B && typerr.context == "T" &&
+      typerr.expected.name == :T && typerr.expected.ub === Integer && typerr.got === Float32
+Core.eval(RedefStruct, :(gB(::Type{T}) where T = B{unsigned(T)}(2)))
+bb = RedefStruct.gB(Int)
+@test !isa(bb, oldtype)
+@test bb.z === UInt(2)
+
+c = RedefStruct.gC((3,2))
+@test RedefStruct.fC(c) == 3
+@test c.data == zeros(3, 2)
+oldtype = invalidate_struct(RedefStruct, :C)
+ex = quote
+    struct C{T,N,A<:AbstractArray{T,N}}
+        data::A
+
+        function C{T,N,A}(data::AbstractArray) where {T,N,A}
+            return new{T,N,A}(data)
+        end
+    end
+end
+Core.eval(RedefStruct, ex)
+c32 = RedefStruct.C{Float32,2,Array{Float32,2}}([0.1 0.2; 0.3 0.4])
+@test c32.data isa Array{Float32,2}
+@test_throws MethodError RedefStruct.C([0.1 0.2; 0.3 0.4])  # outer constructor is not yet defined
+Core.eval(RedefStruct, :(C(data::AbstractArray{T,N}) where {T,N} = C{T,N,typeof(data)}(data)))
+c64 = RedefStruct.C([0.1 0.2; 0.3 0.4])
+@test c64.data isa Array{Float64,2}
+@test_throws MethodError RedefStruct.fC(c32)
+cc = RedefStruct.gC((3,2))
+@test cc.data == zeros(3, 2) && isa(cc.data, Matrix{Float64})


### PR DESCRIPTION
Several of us have found [Revise.jl](https://github.com/timholy/Revise.jl) to be a significant productivity booster. In principle, it's now possible to keep a Julia session open for a week or more, at which point one of the main negatives of Julia---the cost of JITting your, e.g., plotting package---becomes a non-issue.

However, there are two events which prevent this from being commonplace. One is method-deletion (#20048) and the other is type redefinition (https://github.com/timholy/Revise.jl/issues/18). It occurred to me that type redefinition may not be quite as nasty a problem as I've thought. A demo with this PR:
```julia
julia> struct Mine
           arg
       end

julia> a = Mine(1)
Mine(1)

julia> foo(val::Mine) = val.arg
foo (generic function with 1 method)

julia> Base.shunt_binding(Main, :Mine)
Mine#1

julia> a
Mine#1(1)

julia> foo(a)
1

julia> struct Mine{T}
           arg::T
       end

julia> x = Mine(3)
Mine{Int64}(3)
```

The only catch I'm aware of is:
```julia
julia> foo(x)
ERROR: MethodError: no method matching foo(::Mine{Int64})
Closest candidates are:
  foo(::Mine#1) at REPL[3]:1
```

However, I wonder if this might be solvable via `methodswith` *plus* maintaining a cache of the source-code expressions so that they can be re-evaluated. (Revise would like that anyway, since it re-parses and caches every source file so that it can detect diffs. This adds considerably to the package load time, but caching the Exprs to the `.ji` file seems both cheap and effective.)
