### PR TITLE
Fix libgit2 test failure with system libgit2 and OpenSSL

### DIFF
--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1905,7 +1905,8 @@ mktempdir() do dir
                         deserialize(f)
                     end
                     @test err.code == LibGit2.Error.ECERTIFICATE
-                    @test startswith(err.msg, "The SSL certificate is invalid")
+                    @test startswith(lowercase(err.msg),
+                                     lowercase("The SSL certificate is invalid"))
 
                     rm(errfile)
 


### PR DESCRIPTION
The first letter of the error message is in lowercase in some systems,
notably Fedora Rawhide with libgit2 0.26 and OpenSSL 1.1.0f.

Introduced in #22614.