### PR TITLE
Add `:()` when printing quoted symbols

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -762,9 +762,15 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         if (!jl_is_symbol(qv)) {
             n += jl_printf(out, "quote ");
         }
+        else {
+            n += jl_printf(out, ":(");
+        }
         n += jl_static_show_x(out, qv, depth);
         if (!jl_is_symbol(qv)) {
             n += jl_printf(out, " end");
+        }
+        else {
+            n += jl_printf(out, ")");
         }
     }
     else if (vt == jl_newvarnode_type) {

--- a/test/show.jl
+++ b/test/show.jl
@@ -772,6 +772,7 @@ end
 @test static_shown(Symbol("a/b")) == "Symbol(\"a/b\")"
 @test static_shown(Symbol("a-b")) == "Symbol(\"a-b\")"
 
+@test static_shown(QuoteNode(:x)) == ":(:x)"
 
 # Test @show
 let fname = tempname()


### PR DESCRIPTION
The old code prints `:(:x)` and `:x` the same, which is very confusing.

This partially revert fe50621cd2bc6383e41a8d759258ac71d6dff82b