### PR TITLE
Eliminating allocation of ccall root in simple cases

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -115,11 +115,14 @@ getindex(collection, key...)
 """
     cconvert(T,x)
 
-Convert `x` to a value of type `T`, typically by calling `convert(T,x)`
+Convert `x` to a value to be passed to C code as type `T`, typically by calling `convert(T, x)`.
 
 In cases where `x` cannot be safely converted to `T`, unlike [`convert`](@ref), `cconvert` may
 return an object of a type different from `T`, which however is suitable for
-[`unsafe_convert`](@ref) to handle.
+[`unsafe_convert`](@ref) to handle. The result of this function should be kept valid (for the GC)
+until the result of [`unsafe_convert`](@ref) is not needed anymore.
+This can be used to allocate memory that will be accessed by the `ccall`.
+If multiple objects need to be allocated, a tuple of the objects can be used as return value.
 
 Neither `convert` nor `cconvert` should take a Julia object and turn it into a `Ptr`.
 """
@@ -881,7 +884,8 @@ trunc
 """
     unsafe_convert(T,x)
 
-Convert `x` to a value of type `T`
+Convert `x` to a C argument of type `T`
+where the input `x` must be the return value of `cconvert(T, ...)`.
 
 In cases where [`convert`](@ref) would need to take a Julia object
 and turn it into a `Ptr`, this function should be used to define and perform
@@ -895,6 +899,8 @@ but `x=[a,b,c]` is not.
 The `unsafe` prefix on this function indicates that using the result of this function after
 the `x` argument to this function is no longer accessible to the program may cause undefined
 behavior, including program corruption or segfaults, at any later time.
+
+See also [`cconvert`](@ref)
 """
 unsafe_convert
 

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3687,6 +3687,10 @@ function substitute!(@nospecialize(e), na::Int, argexprs::Vector{Any}, @nospecia
                         for argt
                         in e.args[3] ]
                     e.args[3] = svec(argtuple...)
+                elseif i == 4
+                    @assert isa((e.args[4]::QuoteNode).value, Symbol)
+                elseif i == 5
+                    @assert isa(e.args[5], Int)
                 else
                     e.args[i] = substitute!(e.args[i], na, argexprs, spsig, spvals, offset)
                 end
@@ -4766,8 +4770,8 @@ function inlining_pass(e::Expr, sv::InferenceState, stmts, ins)
     # by the interpreter and inlining might put in something it can't handle,
     # like another ccall (or try to move the variables out into the function)
     if e.head === :foreigncall
-        # 3 is rewritten to 1 below to handle the callee.
-        i0 = 3
+        # 5 is rewritten to 1 below to handle the callee.
+        i0 = 5
         isccall = true
     elseif is_known_call(e, Core.Intrinsics.llvmcall, sv.src, sv.mod)
         i0 = 5
@@ -4775,7 +4779,7 @@ function inlining_pass(e::Expr, sv::InferenceState, stmts, ins)
     has_stmts = false # needed to preserve order-of-execution
     prev_stmts_length = length(stmts)
     for _i = length(eargs):-1:i0
-        if isccall && _i == 3
+        if isccall && _i == 5
             i = 1
             isccallee = true
         else
@@ -4830,10 +4834,21 @@ function inlining_pass(e::Expr, sv::InferenceState, stmts, ins)
     end
     if isccall
         le = length(eargs)
-        for i = 4:2:(le - 1)
-            if eargs[i] === eargs[i + 1]
-                eargs[i + 1] = 0
+        nccallargs = eargs[5]::Int
+        ccallargs = ObjectIdDict()
+        for i in 6:(5 + nccallargs)
+            ccallargs[eargs[i]] = nothing
+        end
+        i = 6 + nccallargs
+        while i <= le
+            rootarg = eargs[i]
+            if haskey(ccallargs, rootarg)
+                deleteat!(eargs, i)
+                le -= 1
+            elseif i < le
+                ccallargs[rootarg] = nothing
             end
+            i += 1
         end
     end
     if e.head !== :call

--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -260,7 +260,7 @@ pointer which drops the reference to the array value. However, we of course
 need to make sure that the array does stay alive while we're doing the `ccall`.
 To understand how this is done, first recall the lowering of the above code:
 ```julia
-return $(Expr(:foreigncall, :(:foo), Void, svec(Ptr{Float64}), :($(Expr(:foreigncall, :(:jl_array_ptr), Ptr{Float64}, svec(Any), :(A), 0))), :(A)))
+return $(Expr(:foreigncall, :(:foo), Void, svec(Ptr{Float64}), :(:ccall), 1, :($(Expr(:foreigncall, :(:jl_array_ptr), Ptr{Float64}, svec(Any), :(:ccall), 1, :(A)))), :(A)))
 ```
 The last `:(A)`, is an extra argument list inserted during lowering that informs
 the code generator which Julia level values need to be kept alive for the

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -255,8 +255,9 @@ ccall((:foo, "libfoo"), Void, (Int32, Float64),
 ```
 
 [`Base.cconvert()`](@ref) normally just calls [`convert()`](@ref), but can be defined to return an
-arbitrary new object more appropriate for passing to C. For example, this is used to convert an
-`Array` of objects (e.g. strings) to an array of pointers.
+arbitrary new object more appropriate for passing to C.
+This should be used to perform all allocations of memory that will be accessed by the C code.
+For example, this is used to convert an `Array` of objects (e.g. strings) to an array of pointers.
 
 [`Base.unsafe_convert()`](@ref) handles conversion to `Ptr` types. It is considered unsafe because
 converting an object to a native pointer can hide the object from the garbage collector, causing

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2129,10 +2129,10 @@ static void simple_escape_analysis(jl_codectx_t &ctx, jl_value_t *expr, bool esc
         }
         else if (e->head == foreigncall_sym) {
             simple_escape_analysis(ctx, jl_exprarg(e, 0), esc);
-            // 2nd and 3d arguments are static
-            size_t alen = jl_array_dim0(e->args);
-            for (i = 3; i < alen; i += 2) {
-                simple_escape_analysis(ctx, jl_exprarg(e, i), esc);
+            // 2nd to 5th arguments are static
+            size_t nccallargs = jl_unbox_long(jl_exprarg(e, 4));
+            for (i = 0; i < nccallargs; i++) {
+                simple_escape_analysis(ctx, jl_exprarg(e, i + 5), esc);
             }
         }
         else if (e->head == method_sym) {

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -543,9 +543,10 @@
                                            (list `(... ,(arg-name (car vararg))))))
                               ;; otherwise add to rest keywords
                               `(foreigncall 'jl_array_ptr_1d_push (core Void) (call (core svec) Any Any)
-                                            ,rkw 0 (tuple ,elt
-                                                          (call (core arrayref) ,kw
-                                                                (call (top +) ,ii 1))) 0))
+                                            'ccall 2
+                                            ,rkw (tuple ,elt
+                                                        (call (core arrayref) ,kw
+                                                              (call (top +) ,ii 1)))))
                           (map list vars vals flags))))
             ;; set keywords that weren't present to their default values
             ,@(apply append
@@ -963,29 +964,31 @@
   (let loop ((F atypes)  ;; formals
              (A args)    ;; actuals
              (stmts '()) ;; initializers
-             (C '()))    ;; converted
+             (C '())     ;; converted
+             (GC '()))   ;; GC roots
     (if (and (null? F) (not (null? A))) (error "more arguments than types for ccall"))
     (if (and (null? A) (not (or (null? F) (and (pair? F) (vararg? (car F)) (null? (cdr F)))))) (error "more types than arguments for ccall"))
     (if (null? A)
         `(block
           ,.(reverse! stmts)
           (foreigncall ,name ,RT (call (core svec) ,@(dots->vararg atypes))
-                ,.(reverse! C)
-                ,@A
-                ,@cconv))
+                       ',cconv
+                       ,(length C)
+                       ,.(reverse! C)
+                       ,@GC)) ; GC root ordering is arbitrary
         (let* ((a     (car A))
                (isseq (and (vararg? (car F))))
                (ty    (if isseq (cadar F) (car F))))
           (if (and isseq (not (null? (cdr F)))) (error "only the trailing ccall argument type should have '...'"))
           (if (eq? ty 'Any)
-              (loop (if isseq F (cdr F)) (cdr A) stmts (list* 0 a C))
+              (loop (if isseq F (cdr F)) (cdr A) stmts (list* a C) GC)
               (let* ((g (make-ssavalue))
                      (isamp (and (pair? a) (eq? (car a) '&)))
                      (a (if isamp (cadr a) a))
                      (stmts (cons `(= ,g (call (top ,(if isamp 'ptr_arg_cconvert 'cconvert)) ,ty ,a)) stmts))
                      (ca `(call (top ,(if isamp 'ptr_arg_unsafe_convert 'unsafe_convert)) ,ty ,g)))
                 (loop (if isseq F (cdr F)) (cdr A) stmts
-                      (list* g (if isamp `(& ,ca) ca) C))))))))
+                      (list* (if isamp `(& ,ca) ca) C) (list* g GC))))))))
 
 (define (expand-function-def e)   ;; handle function or stagedfunction
   (define (just-arglist? ex)
@@ -1289,7 +1292,8 @@
                         (= ,err true)))
                   (= ,finally-exception (the_exception))
                   ,finalb
-                  (if ,err (foreigncall 'jl_rethrow_other (core Void) (call (core svec) Any) ,finally-exception 0))
+                  (if ,err (foreigncall 'jl_rethrow_other (core Void) (call (core svec) Any)
+                                        'ccall 1 ,finally-exception))
                   ,(if hasret
                        (if ret
                            `(if ,ret (return ,retval) ,val)
@@ -1519,9 +1523,10 @@
                              (loop (cdr kw) (list* (caddr arg) `(quote ,(cadr arg)) initial-kw) stmts #t)
                              (loop (cdr kw) initial-kw
                                    (cons `(foreigncall 'jl_array_ptr_1d_push2 (core Void) (call (core svec) Any Any Any)
-                                                       ,container 0
-                                                       (|::| (quote ,(cadr arg)) (core Symbol)) 0
-                                                       ,(caddr arg) 0)
+                                                       'ccall 3
+                                                       ,container
+                                                       (|::| (quote ,(cadr arg)) (core Symbol))
+                                                       ,(caddr arg))
                                          stmts)
                                    #t)))
                         (else
@@ -1529,9 +1534,10 @@
                                (cons (let* ((k (make-ssavalue))
                                             (v (make-ssavalue))
                                             (push-expr `(foreigncall 'jl_array_ptr_1d_push2 (core Void) (call (core svec) Any Any Any)
-                                                                     ,container 0
-                                                                     (|::| ,k (core Symbol)) 0
-                                                                     ,v 0)))
+                                                                     'ccall 3
+                                                                     ,container
+                                                                     (|::| ,k (core Symbol))
+                                                                     ,v)))
                                        (if (vararg? arg)
                                            `(for (= (tuple ,k ,v) ,(cadr arg))
                                                  ,push-expr)
@@ -2111,7 +2117,7 @@
                                   (error "ccall argument types must be a tuple; try \"(T,)\"")))
                           (expand-forms
                            (lower-ccall name RT (cdr argtypes) args
-                            (if have-cconv (list (list cconv)) '()))))))
+                                        (if have-cconv cconv 'ccall))))))
                  ((and (pair? (caddr e))
                        (eq? (car (caddr e)) 'parameters))
                   ;; (call f (parameters . kwargs) ...)
@@ -3408,13 +3414,13 @@ f(x) = yt(x)
           (case (car e)
             ((call new foreigncall)
              (let* ((args (if (eq? (car e) 'foreigncall)
-                              ;; NOTE: 2nd and 3rd arguments of ccall must be left in place
+                              ;; NOTE: 2nd to 5th arguments of ccall must be left in place
                               ;;       the 1st should be compiled if an atom.
                               (append (list)
                                       (cond (atom? (cadr e) (compile-args (list (cadr e)) break-labels linearize-args))
                                             (else (cadr e)))
-                                      (list-head (cddr e) 2)
-                                      (compile-args (list-tail e 4) break-labels linearize-args))
+                                      (list-head (cddr e) 4)
+                                      (compile-args (list-tail e 6) break-labels linearize-args))
                               (compile-args (cdr e) break-labels linearize-args)))
                     (callex (cons (car e) args)))
                (cond (tail (emit-return callex))

--- a/src/method.c
+++ b/src/method.c
@@ -69,7 +69,7 @@ jl_value_t *jl_resolve_globals(jl_value_t *expr, jl_module_t *module, jl_svec_t 
             }
             size_t i = 0, nargs = jl_array_len(e->args);
             if (e->head == foreigncall_sym) {
-                JL_NARGSV(ccall method definition, 3); // (fptr, rt, at)
+                JL_NARGSV(ccall method definition, 5); // (fptr, rt, at, cc, narg)
                 jl_value_t *rt = jl_exprarg(e, 1);
                 jl_value_t *at = jl_exprarg(e, 2);
                 if (!jl_is_type(rt)) {
@@ -100,6 +100,9 @@ jl_value_t *jl_resolve_globals(jl_value_t *expr, jl_module_t *module, jl_svec_t 
                     jl_error("ccall: missing return type");
                 JL_TYPECHK(ccall method definition, type, rt);
                 JL_TYPECHK(ccall method definition, simplevector, at);
+                JL_TYPECHK(ccall method definition, quotenode, jl_exprarg(e, 3));
+                JL_TYPECHK(ccall method definition, symbol, *(jl_value_t**)jl_exprarg(e, 3));
+                JL_TYPECHK(ccall method definition, long, jl_exprarg(e, 4));
             }
             if (e->head == method_sym || e->head == abstracttype_sym || e->head == compositetype_sym ||
                 e->head == bitstype_sym || e->head == module_sym) {

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1285,3 +1285,21 @@ evalf_callback_c_19805{FUNC_FT}(ci::callinfos_19805{FUNC_FT}) = cfunction(
 
 @test_throws(ErrorException("ccall: the type of argument 1 doesn't correspond to a C type"),
              evalf_callback_c_19805( callinfos_19805(sin) ))
+
+# test Ref{abstract_type} calling parameter passes a heap box
+abstract type Abstract22734 end
+struct Bits22734 <: Abstract22734
+    x::Int
+    y::Float64
+end
+function cb22734(ptr::Ptr{Void})
+    gc()
+    obj = unsafe_pointer_to_objref(ptr)::Bits22734
+    obj.x + obj.y
+end
+ptr22734 = cfunction(cb22734, Float64, Tuple{Ptr{Void}})
+function caller22734(ptr)
+    obj = Bits22734(12, 20)
+    ccall(ptr, Float64, (Ref{Abstract22734},), obj)
+end
+@test caller22734(ptr22734) === 32.0

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -128,10 +128,37 @@ function compare_large_struct(a)
     end
 end
 
+mutable struct MutableStruct
+    a::Int
+    MutableStruct() = new()
+end
+
+breakpoint_mutable(a::MutableStruct) = ccall(:jl_breakpoint, Void, (Ref{MutableStruct},), a)
+
+# Allocation with uninitialized field as gcroot
+mutable struct BadRef
+    x::MutableStruct
+    y::MutableStruct
+    BadRef(x) = new(x)
+end
+Base.cconvert(::Type{Ptr{BadRef}}, a::MutableStruct) = BadRef(a)
+Base.unsafe_convert(::Type{Ptr{BadRef}}, ar::BadRef) = Ptr{BadRef}(pointer_from_objref(ar.x))
+
+breakpoint_badref(a::MutableStruct) = ccall(:jl_breakpoint, Void, (Ptr{BadRef},), a)
+
 if opt_level > 0
     @test !contains(get_llvm(isequal, Tuple{Nullable{BigFloat}, Nullable{BigFloat}}), "%gcframe")
     @test !contains(get_llvm(pointer_not_safepoint, Tuple{}), "%gcframe")
     compare_large_struct_ir = get_llvm(compare_large_struct, Tuple{typeof(create_ref_struct())})
     @test contains(compare_large_struct_ir, "call i32 @memcmp")
     @test !contains(compare_large_struct_ir, "%gcframe")
+
+    @test contains(get_llvm(MutableStruct, Tuple{}), "jl_gc_pool_alloc")
+    breakpoint_mutable_ir = get_llvm(breakpoint_mutable, Tuple{MutableStruct})
+    @test !contains(breakpoint_mutable_ir, "%gcframe")
+    @test !contains(breakpoint_mutable_ir, "jl_gc_pool_alloc")
+
+    breakpoint_badref_ir = get_llvm(breakpoint_badref, Tuple{MutableStruct})
+    @test !contains(breakpoint_badref_ir, "%gcframe")
+    @test !contains(breakpoint_badref_ir, "jl_gc_pool_alloc")
 end


### PR DESCRIPTION
Applied on top of https://github.com/JuliaLang/julia/pull/22684, this should eliminate most if not all of the allocation in `ccall` that was previously only non-allocationg when using the to be deprecated `&` syntax.
