### PR TITLE
Faster Sparse Covariance Matrix

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -941,3 +941,26 @@ end
 chol(A::SparseMatrixCSC) = error("Use cholfact() instead of chol() for sparse matrices.")
 lu(A::SparseMatrixCSC) = error("Use lufact() instead of lu() for sparse matrices.")
 eig(A::SparseMatrixCSC) = error("Use eigs() instead of eig() for sparse matrices.")
+
+function spcov(X::SparseMatrixCSC{Tv1,Ti1} where {Tv1,Ti1})
+    n,p = size(X)
+    means = mean(X, 1)
+
+    #Part 1 compute X'X
+    part1 = X'X
+
+    #Part 2 compute X'μ
+    sums = sum(X, 1)
+    part2 = sums'means
+
+    #Part 3 compute μ'μ
+    part3 = zeros(p,p)
+    for i in 1:p
+        for j in i:p
+            part3[i,j] = means[i] * means[j] * n
+            part3[j,i] = part3[i,j]
+        end
+    end
+
+    return (part1 - part2 - part2' + part3) ./ (n-1)
+end

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -951,7 +951,7 @@ function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
 
     # Part1
     # Compute X'X using sparse matrix operations
-    out = Matrix(Base.unscaled_covzm(X,vardim))
+    out = Matrix(Base.unscaled_covzm(X, vardim))
 
     # Part 2
     # Compute X'μ
@@ -970,7 +970,7 @@ function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
     sums = sum(X, vardim)
     means = sums ./ n
     @inbounds for j in 1:p, i in 1:p
-        part2 = sums[i]*means[j]
+        part2 = sums[i] * means[j]
         out[i,j] -= part2
     end
     return scale!(out, inv(n-Int(corrected)))

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -947,7 +947,8 @@ function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
     n, p = vardim == 1 ? (a, b) : (b, a)
 
     # Cov(X) = E[(X-μ)'(X-μ)]
-    # = X'X - X'u - μ'X + μ'μ
+    # = X'X - X'μ - μ'X + μ'μ
+    # = X'X - X'μ
 
     # Part1
     # Compute X'X using sparse matrix operations
@@ -968,9 +969,8 @@ function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
     #         [k1*k2*n k2*k2*n]
     # but k1*n = a+b, and k2*n = c+d
     sums = sum(X, vardim)
-    means = sums ./ n
     @inbounds for j in 1:p, i in 1:p
-        part2 = sums[i] * means[j]
+        part2 = sums[i] * sums[j] / n
         out[i,j] -= part2
     end
     return scale!(out, inv(n-Int(corrected)))

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -947,27 +947,12 @@ function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
     n, p = vardim == 1 ? (a, b) : (b, a)
 
     # Cov(X) = E[(X-μ)'(X-μ)]
-    # = X'X - X'μ - μ'X + μ'μ
     # = X'X - X'μ
 
-    # Part1
     # Compute X'X using sparse matrix operations
     out = Matrix(Base.unscaled_covzm(X, vardim))
 
-    # Part 2
     # Compute X'μ
-
-    # Part 3
-    # Compute μ'μ
-
-    # Note that part3 = part2 !
-    # X = [a c]    \mu = [k1 k2]
-    #     [b d]          [k1 k2]
-    # part2 = [(a+b)k1 (a+b)k2]
-    #         [(c+d)k1 (c+d)k2]
-    # part3 = [k1*k1*n k1*k2*n]
-    #         [k1*k2*n k2*k2*n]
-    # but k1*n = a+b, and k2*n = c+d
     sums = sum(X, vardim)
     @inbounds for j in 1:p, i in 1:p
         part2 = sums[i] * (sums[j] / n)

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -970,7 +970,7 @@ function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
     # but k1*n = a+b, and k2*n = c+d
     sums = sum(X, vardim)
     @inbounds for j in 1:p, i in 1:p
-        part2 = sums[i] * sums[j] / n
+        part2 = sums[i] * (sums[j] / n)
         out[i,j] -= part2
     end
     return scale!(out, inv(n-Int(corrected)))

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -948,7 +948,7 @@ function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
     out = Matrix(Base.unscaled_covzm(X,vardim)) # part1
     sums = sum(X, vardim)
     means = mean(X, vardim)
-    for j in 1:p, i in 1:p
+    @inbounds for j in 1:p, i in 1:p
         part2 = sums[i]*means[j]
         part3 = means[i] * means[j] * n
         out[i,j] += - part2 - conj(part2) + part3

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1846,7 +1846,7 @@ end
 
 @testset "optimizing sparse covariance" begin
     n = 10
-    p = 50
+    p = 5
     srand(1)
     x_sparse = sprand(n, p, .50)
     x_dense = convert(Matrix{Float64}, x_sparse)
@@ -1923,9 +1923,9 @@ end
 
     cov_sparse = cov(x_sparse, 2, corrected=true)
     cov_dense = cov(x_dense, 2, true)
-    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
-    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
-    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+    @test cov_sparse[3:end, 3:end] ≈ cov_dense[3:end, 3:end]
+    @test isequal(cov_sparse[1:end, 1:2], cov_dense[1:end, 1:2])
+    @test isequal(cov_sparse[1:2, 1:end], cov_dense[1:2, 1:end])
 
     cov_sparse = cov(x_sparse, 1, corrected=false)
     cov_dense = cov(x_dense, 1, false)
@@ -1935,7 +1935,7 @@ end
 
     cov_sparse = cov(x_sparse, 2, corrected=false)
     cov_dense = cov(x_dense, 2, false)
-    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
-    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
-    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+    @test cov_sparse[3:end, 3:end] ≈ cov_dense[3:end, 3:end]
+    @test isequal(cov_sparse[1:end, 1:2], cov_dense[1:end, 1:2])
+    @test isequal(cov_sparse[1:2, 1:end], cov_dense[1:2, 1:end])
 end

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1843,3 +1843,13 @@ end
     B = A[5:-1:1, 5:-1:1]
     @test issymmetric(B)
 end
+
+@testset "optimizing sparse covariance" begin
+    n = 10000
+    p = 50
+    x_sparse = sprand(n, p, .05)
+    x_dense = convert(Matrix{Float64}, x_sparse)
+    cov1 = cov(x_dense)
+    cov2 = spcov(x_sparse)
+    @test cov1 \approx cov2
+end

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1845,12 +1845,37 @@ end
 end
 
 @testset "optimizing sparse covariance" begin
-    n = 1000
+    n = 10
     p = 5
     srand(1)
-    x_sparse = sprand(n, p, .25)
+    x_sparse = sprand(n, p, .50)
     x_dense = convert(Matrix{Float64}, x_sparse)
-    cov1 = cov(x_dense)
-    cov2 = cov(x_sparse)
-    @test cov1 ≈ cov2
+    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
+    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
+    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
+    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
+
+    # Test with NaN
+    x_sparse[1,1] = NaN
+    x_dense[1,1]  = NaN
+    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
+    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
+    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
+    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
+
+    # Test with Inf
+    x_sparse[1,1] = Inf
+    x_dense[1,1]  = Inf
+    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
+    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
+    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
+    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
+
+    # Test with NaN and Inf
+    x_sparse[2,1] = NaN
+    x_dense[2,1]  = NaN
+    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
+    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
+    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
+    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
 end

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1845,11 +1845,12 @@ end
 end
 
 @testset "optimizing sparse covariance" begin
-    n = 10000
-    p = 50
-    x_sparse = sprand(n, p, .05)
+    n = 1000
+    p = 5
+    srand(1)
+    x_sparse = sprand(n, p, .25)
     x_dense = convert(Matrix{Float64}, x_sparse)
     cov1 = cov(x_dense)
-    cov2 = spcov(x_sparse)
-    @test cov1 \approx cov2
+    cov2 = cov(x_sparse)
+    @test cov1 ≈ cov2
 end

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1844,6 +1844,15 @@ end
     @test issymmetric(B)
 end
 
+# Faster covariance function for sparse matrices
+# Prevents densifying the input matrix when subtracting the mean
+# Test against dense implementation
+# PR https://github.com/JuliaLang/julia/pull/22735
+# Part of this test needed to be hacked due to the treatment
+# of Inf in sparse matrix algebra
+# https://github.com/JuliaLang/julia/issues/22921
+# The issue will be resolved in
+# https://github.com/JuliaLang/julia/issues/22733
 @testset "optimizing sparse covariance" begin
     n = 10
     p = 5
@@ -1888,24 +1897,44 @@ end
     x_dense[1,1]  = Inf
 
     cov_sparse = cov(x_sparse, 1, corrected=true)
+
+    # Sparse matrix algebra generates Inf, but
+    # dense matrix algebra generates NaN
+    # NaN  NaN           -Inf           -Inf          NaN
+    # NaN    0.124035       0.00830252    -0.0430049    0.021373
+    # -Inf    0.00830252     0.111628      -0.0149783    0.00773125
+    # -Inf   -0.0430049     -0.0149783      0.099782    -0.0496011
+    # NaN    0.021373       0.00773125    -0.0496011    0.126186
+
+    cov_sparse[isinf.(cov_sparse)] = NaN
     cov_dense = cov(x_dense, 1, corrected=true)
+
+    # NaN  NaN           NaN           NaN          NaN
+    # NaN    0.124035      0.00830252   -0.0430049    0.021373
+    # NaN    0.00830252    0.111628     -0.0149783    0.00773125
+    # NaN   -0.0430049    -0.0149783     0.099782    -0.0496011
+    # NaN    0.021373      0.00773125   -0.0496011    0.126186
+
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=true)
+    cov_sparse[isinf.(cov_sparse)] = NaN
     cov_dense = cov(x_dense, 2, corrected=true)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 1, corrected=false)
+    cov_sparse[isinf.(cov_sparse)] = NaN
     cov_dense = cov(x_dense, 1, corrected=false)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=false)
+    cov_sparse[isinf.(cov_sparse)] = NaN
     cov_dense = cov(x_dense, 2, corrected=false)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
@@ -1922,6 +1951,7 @@ end
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=true)
+    cov_sparse[isinf.(cov_sparse)] = NaN
     cov_dense = cov(x_dense, 2, corrected=true)
     @test cov_sparse[3:end, 3:end] ≈ cov_dense[3:end, 3:end]
     @test isequal(cov_sparse[1:end, 1:2], cov_dense[1:end, 1:2])
@@ -1934,6 +1964,7 @@ end
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=false)
+    cov_sparse[isinf.(cov_sparse)] = NaN
     cov_dense = cov(x_dense, 2, corrected=false)
     @test cov_sparse[3:end, 3:end] ≈ cov_dense[3:end, 3:end]
     @test isequal(cov_sparse[1:end, 1:2], cov_dense[1:end, 1:2])

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1850,7 +1850,7 @@ end
     srand(1)
     x_sparse = sprand(n, p, .50)
     x_dense = convert(Matrix{Float64}, x_sparse)
-    @test cov(x_sparse, 1, corrected=true)  ≈ cov(x_dense, 1, true)
+    @test cov(x_sparse, 1, corrected=true)  ≈ cov(x_dense, 1, corrected=true)
     @test cov(x_sparse, 1, corrected=false) ≈ cov(x_dense, 1, corrected=false)
     @test cov(x_sparse, 2, corrected=true)  ≈ cov(x_dense, 2, corrected=true)
     @test cov(x_sparse, 2, corrected=false) ≈ cov(x_dense, 2, corrected=false)
@@ -1860,25 +1860,25 @@ end
     x_dense[1,1]  = NaN
 
     cov_sparse = cov(x_sparse, 1, corrected=true)
-    cov_dense = cov(x_dense, 1, true)
+    cov_dense = cov(x_dense, 1, corrected=true)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=true)
-    cov_dense = cov(x_dense, 2, true)
+    cov_dense = cov(x_dense, 2, corrected=true)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 1, corrected=false)
-    cov_dense = cov(x_dense, 1, false)
+    cov_dense = cov(x_dense, 1, corrected=false)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=false)
-    cov_dense = cov(x_dense, 2, false)
+    cov_dense = cov(x_dense, 2, corrected=false)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
@@ -1888,25 +1888,25 @@ end
     x_dense[1,1]  = Inf
 
     cov_sparse = cov(x_sparse, 1, corrected=true)
-    cov_dense = cov(x_dense, 1, true)
+    cov_dense = cov(x_dense, 1, corrected=true)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=true)
-    cov_dense = cov(x_dense, 2, true)
+    cov_dense = cov(x_dense, 2, corrected=true)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 1, corrected=false)
-    cov_dense = cov(x_dense, 1, false)
+    cov_dense = cov(x_dense, 1, corrected=false)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=false)
-    cov_dense = cov(x_dense, 2, false)
+    cov_dense = cov(x_dense, 2, corrected=false)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
@@ -1916,25 +1916,25 @@ end
     x_dense[2,1]  = NaN
 
     cov_sparse = cov(x_sparse, 1, corrected=true)
-    cov_dense = cov(x_dense, 1, true)
+    cov_dense = cov(x_dense, 1, corrected=true)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=true)
-    cov_dense = cov(x_dense, 2, true)
+    cov_dense = cov(x_dense, 2, corrected=true)
     @test cov_sparse[3:end, 3:end] ≈ cov_dense[3:end, 3:end]
     @test isequal(cov_sparse[1:end, 1:2], cov_dense[1:end, 1:2])
     @test isequal(cov_sparse[1:2, 1:end], cov_dense[1:2, 1:end])
 
     cov_sparse = cov(x_sparse, 1, corrected=false)
-    cov_dense = cov(x_dense, 1, false)
+    cov_dense = cov(x_dense, 1, corrected=false)
     @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
     @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
     @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     cov_sparse = cov(x_sparse, 2, corrected=false)
-    cov_dense = cov(x_dense, 2, false)
+    cov_dense = cov(x_dense, 2, corrected=false)
     @test cov_sparse[3:end, 3:end] ≈ cov_dense[3:end, 3:end]
     @test isequal(cov_sparse[1:end, 1:2], cov_dense[1:end, 1:2])
     @test isequal(cov_sparse[1:2, 1:end], cov_dense[1:2, 1:end])

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1846,36 +1846,96 @@ end
 
 @testset "optimizing sparse covariance" begin
     n = 10
-    p = 5
+    p = 50
     srand(1)
     x_sparse = sprand(n, p, .50)
     x_dense = convert(Matrix{Float64}, x_sparse)
-    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
-    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
-    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
-    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
+    @test cov(x_sparse, 1, corrected=true)  ≈ cov(x_dense, 1, true)
+    @test cov(x_sparse, 1, corrected=false) ≈ cov(x_dense, 1, corrected=false)
+    @test cov(x_sparse, 2, corrected=true)  ≈ cov(x_dense, 2, corrected=true)
+    @test cov(x_sparse, 2, corrected=false) ≈ cov(x_dense, 2, corrected=false)
 
     # Test with NaN
     x_sparse[1,1] = NaN
     x_dense[1,1]  = NaN
-    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
-    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
-    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
-    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
+
+    cov_sparse = cov(x_sparse, 1, corrected=true)
+    cov_dense = cov(x_dense, 1, true)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 2, corrected=true)
+    cov_dense = cov(x_dense, 2, true)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 1, corrected=false)
+    cov_dense = cov(x_dense, 1, false)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 2, corrected=false)
+    cov_dense = cov(x_dense, 2, false)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     # Test with Inf
     x_sparse[1,1] = Inf
     x_dense[1,1]  = Inf
-    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
-    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
-    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
-    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
+
+    cov_sparse = cov(x_sparse, 1, corrected=true)
+    cov_dense = cov(x_dense, 1, true)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 2, corrected=true)
+    cov_dense = cov(x_dense, 2, true)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 1, corrected=false)
+    cov_dense = cov(x_dense, 1, false)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 2, corrected=false)
+    cov_dense = cov(x_dense, 2, false)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 
     # Test with NaN and Inf
     x_sparse[2,1] = NaN
     x_dense[2,1]  = NaN
-    @test cov(x_sparse, 1, true)  ≈ cov(x_dense, 1, true)
-    @test cov(x_sparse, 1, false) ≈ cov(x_dense, 1, false)
-    @test cov(x_sparse, 2, true)  ≈ cov(x_dense, 2, true)
-    @test cov(x_sparse, 2, false) ≈ cov(x_dense, 2, false)
+
+    cov_sparse = cov(x_sparse, 1, corrected=true)
+    cov_dense = cov(x_dense, 1, true)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 2, corrected=true)
+    cov_dense = cov(x_dense, 2, true)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 1, corrected=false)
+    cov_dense = cov(x_dense, 1, false)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
+
+    cov_sparse = cov(x_sparse, 2, corrected=false)
+    cov_dense = cov(x_dense, 2, false)
+    @test cov_sparse[2:end, 2:end] ≈ cov_dense[2:end, 2:end]
+    @test isequal(cov_sparse[1:end, 1], cov_dense[1:end, 1])
+    @test isequal(cov_sparse[1, 1:end], cov_dense[1, 1:end])
 end


### PR DESCRIPTION
This PR is for https://github.com/JuliaLang/LinearAlgebra.jl/issues/447, making cov faster for sparse matrices.

I am new to Julia so will need some help to make sure I have done my first PR correctly. From my machine I see a ~50x speedup in calling `cov` on a sparse matrix.

```
n = 50000
p = 500
x_sparse = sprand(n, p, .05)
@time cov1 = cov(x_sparse)
@time cov2 = spcov(x_sparse)
```

The two techniques produce answers that only differ by 1e-16.

Fixes https://github.com/JuliaLang/julia/issues/7788.