### PR TITLE
show of Val's

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -338,8 +338,6 @@ end
 
 Val(x) = (@_pure_meta; Val{x}())
 
-show(io::IO, ::Val{x}) where {x} = print(io, "Val($x)")
-
 # used by interpolating quote and some other things in the front end
 function vector_any(xs::ANY...)
     n = length(xs)

--- a/test/show.jl
+++ b/test/show.jl
@@ -796,3 +796,9 @@ let io = IOBuffer()
     show(io, MIME"text/html"(), f_with_params.body.name.mt)
     @test contains(String(take!(io)), "f_with_params")
 end
+
+@testset "printing of Val's" begin
+    @test sprint(show, Val(Float64))  == "Val{Float64}()"  # Val of a type
+    @test sprint(show, Val(:Float64)) == "Val{:Float64}()" # Val of a symbol
+    @test sprint(show, Val(true))     == "Val{true}()"     # Val of a value
+end


### PR DESCRIPTION
Currently we have this:

```julia
julia> Val(:A)
Val(A)

julia> Val(A)
ERROR: UndefVarError: A not defined
```
Because of [string interpolation](https://github.com/JuliaLang/julia/blob/00e74c37bc1431a779e8de3c20f3a22b008cfe8d/base/essentials.jl#L341), so ["print it like you write it"](https://github.com/JuliaLang/julia/pull/22475/files#r123911746) did not work out quite right, @andyferris :smile: . Also, this is very confusing:

```julia
julia> Val(:Float64)
Val(Float64)

julia> Val(Float64)
Val(Float64)

julia> typeof(Val(:Float64)) == typeof(Val(Float64)) # they print the same but are different
false
```

Ref discussion here: https://github.com/JuliaLang/julia/pull/22475/files#r123873584

This is the simple fix; remove the special `show` method. If people really want to instead display `Val(:L)` I will update with a fix for that instead. As in the linked discussion, personally I think its nicer to print `Val{:L}()` because then you see the `typeof` much clearer. (The type of almost all printed objects can be easily visually parsed like that)